### PR TITLE
Remove decimal-only number notations (deprecated in 8.12)

### DIFF
--- a/dev/ci/user-overlays/13842-proux01-remove-decimal.sh
+++ b/dev/ci/user-overlays/13842-proux01-remove-decimal.sh
@@ -1,0 +1,1 @@
+overlay hott https://github.com/proux01/HoTT coq-13842 13842

--- a/doc/changelog/03-notations/13842-remove-decimal.rst
+++ b/doc/changelog/03-notations/13842-remove-decimal.rst
@@ -1,0 +1,3 @@
+- **Removed:**
+  Remove decimal-only number notations which were deprecated in 8.12.
+  (`#13842 <https://github.com/coq/coq/pull/13842>`_, by Pierre Roux).

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -1726,12 +1726,6 @@ Number notations
             * :n:`@qualid__type -> Number.number`
             * :n:`@qualid__type -> option Number.number`
 
-         .. deprecated:: 8.12
-            Number notations on :g:`Decimal.uint`, :g:`Decimal.int` and
-            :g:`Decimal.decimal` are replaced respectively by number
-            notations on :g:`Number.uint`, :g:`Number.int` and
-            :g:`Number.number`.
-
          When parsing, the application of the parsing function
          :n:`@qualid__parse` to the number will be fully reduced, and universes
          of the resulting term will be refreshed.

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -146,9 +146,6 @@ type target_kind =
   | Z of z_pos_ty (* Coq.Numbers.BinNums.Z and positive *)
   | Int63 of pos_neg_int63_ty (* Coq.Numbers.Cyclic.Int63.PrimInt63.pos_neg_int63 *)
   | Number of number_ty (* Coq.Init.Number.number + uint + int *)
-  | DecimalInt of int_ty (* Coq.Init.Decimal.int + uint (deprecated) *)
-  | DecimalUInt of int_ty (* Coq.Init.Decimal.uint (deprecated) *)
-  | Decimal of number_ty (* Coq.Init.Decimal.Decimal + uint + int (deprecated) *)
 
 type string_target_kind =
   | ListByte

--- a/plugins/syntax/number.ml
+++ b/plugins/syntax/number.ml
@@ -131,13 +131,6 @@ let type_error_of g ty =
      str " to Number.int or (option Number.int)." ++ fnl () ++
      str "Instead of Number.int, the types Number.uint or Z or PrimInt63.pos_neg_int63 or Number.number could be used (you may need to require BinNums or Number or PrimInt63 first).")
 
-let warn_deprecated_decimal =
-  CWarnings.create ~name:"decimal-numeral-notation" ~category:"deprecated"
-    (fun () ->
-      strbrk "Deprecated Number Notation for Decimal.uint, \
-              Decimal.int or Decimal.decimal. Use Number.uint, \
-              Number.int or Number.number respectively.")
-
 let error_params ind =
   CErrors.user_err
     (str "Wrong number of parameters for inductive" ++ spc ()
@@ -456,12 +449,6 @@ let vernac_number_notation local ty f g opts scope =
     | Some (int_ty, _, cuint, _, _, _, _, _) when has_type env sigma f (arrow cuint (opt cty)) -> UInt int_ty, Option
     | Some (_, _, _, _, _, num_ty, cnum, _) when has_type env sigma f (arrow cnum cty) -> Number num_ty, Direct
     | Some (_, _, _, _, _, num_ty, cnum, _) when has_type env sigma f (arrow cnum (opt cty)) -> Number num_ty, Option
-    | Some (int_ty, _, _, cint, _, _, _, _) when has_type env sigma f (arrow cint cty) -> DecimalInt int_ty, Direct
-    | Some (int_ty, _, _, cint, _, _, _, _) when has_type env sigma f (arrow cint (opt cty)) -> DecimalInt int_ty, Option
-    | Some (int_ty, _, _, _, cuint, _, _, _) when has_type env sigma f (arrow cuint cty) -> DecimalUInt int_ty, Direct
-    | Some (int_ty, _, _, _, cuint, _, _, _) when has_type env sigma f (arrow cuint (opt cty)) -> DecimalUInt int_ty, Option
-    | Some (_, _, _, _, _, num_ty, _, cdec) when has_type env sigma f (arrow cdec cty) -> Decimal num_ty, Direct
-    | Some (_, _, _, _, _, num_ty, _, cdec) when has_type env sigma f (arrow cdec (opt cty)) -> Decimal num_ty, Option
     | _ ->
     match z_pos_ty with
     | Some (z_pos_ty, cZ) when has_type env sigma f (arrow cZ cty) -> Z z_pos_ty, Direct
@@ -484,12 +471,6 @@ let vernac_number_notation local ty f g opts scope =
     | Some (int_ty, _, cuint, _, _, _, _, _) when has_type env sigma g (arrow cty (opt cuint)) -> UInt int_ty, Option
     | Some (_, _, _, _, _, num_ty, cnum, _) when has_type env sigma g (arrow cty cnum) -> Number num_ty, Direct
     | Some (_, _, _, _, _, num_ty, cnum, _) when has_type env sigma g (arrow cty (opt cnum)) -> Number num_ty, Option
-    | Some (int_ty, _, _, cint, _, _, _, _) when has_type env sigma g (arrow cty cint) -> DecimalInt int_ty, Direct
-    | Some (int_ty, _, _, cint, _, _, _, _) when has_type env sigma g (arrow cty (opt cint)) -> DecimalInt int_ty, Option
-    | Some (int_ty, _, _, _, cuint, _, _, _) when has_type env sigma g (arrow cty cuint) -> DecimalUInt int_ty, Direct
-    | Some (int_ty, _, _, _, cuint, _, _, _) when has_type env sigma g (arrow cty (opt cuint)) -> DecimalUInt int_ty, Option
-    | Some (_, _, _, _, _, num_ty, _, cdec) when has_type env sigma g (arrow cty cdec) -> Decimal num_ty, Direct
-    | Some (_, _, _, _, _, num_ty, _, cdec) when has_type env sigma g (arrow cty (opt cdec)) -> Decimal num_ty, Option
     | _ ->
     match z_pos_ty with
     | Some (z_pos_ty, cZ) when has_type env sigma g (arrow cty cZ) -> Z z_pos_ty, Direct
@@ -500,11 +481,6 @@ let vernac_number_notation local ty f g opts scope =
     | Some (pos_neg_int63_ty, cint63) when has_type env sigma g (arrow cty (opt cint63)) -> Int63 pos_neg_int63_ty, Option
     | _ -> type_error_of g ty
   in
-  (match to_kind, of_kind with
-   | ((DecimalInt _ | DecimalUInt _ | Decimal _), _), _
-   | _, ((DecimalInt _ | DecimalUInt _ | Decimal _), _) ->
-      warn_deprecated_decimal ()
-   | _ -> ());
   let to_post, pt_required, pt_refs = match tyc_params with
     | TargetPrim path -> [||], path, [Coqlib.lib_ref "num.int63.wrap_int"]
     | TargetInd (tyc, params) ->


### PR DESCRIPTION
- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).

Overlays:
- HoTT: https://github.com/HoTT/HoTT/pull/1418
