### PR TITLE
[vernac] pass the loc of the whole command to the interp function

### DIFF
--- a/coqpp/coqpp_main.ml
+++ b/coqpp/coqpp_main.ml
@@ -360,7 +360,7 @@ let print_body_fun state fmt r =
     print_binders r.vernac_toks print_atts_left r.vernac_atts (print_body_state state) r
 
 let print_body state fmt r =
-  fprintf fmt "@[(%afun %a~atts@ -> coqpp_body %a%a)@]"
+  fprintf fmt "@[(%afun %a?loc ~atts@ -> coqpp_body %a%a)@]"
     (print_body_fun state) r print_binders r.vernac_toks
     print_binders r.vernac_toks print_atts_right r.vernac_atts
 

--- a/dev/ci/user-overlays/13844-gares-command-loc.sh
+++ b/dev/ci/user-overlays/13844-gares-command-loc.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/LPCIC/coq-elpi command-loc 13844

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -576,7 +576,7 @@ let _ =
   let open Vernacextend in
   let ty_constr = Extend.TUentry (get_arg_tag Stdarg.wit_constr) in
   let cmd_sig = TyTerminal("PrintConstr", TyNonTerminal(ty_constr, TyNil)) in
-  let cmd_fn c ~atts = VtDefault (fun () -> in_current_context econstr_display c) in
+  let cmd_fn c ?loc:_ ~atts = VtDefault (fun () -> in_current_context econstr_display c) in
   let cmd_class _ = VtQuery in
   let cmd : ty_ml = TyML (false, cmd_sig, cmd_fn, Some cmd_class) in
   vernac_extend ~command:"PrintConstr" [cmd]
@@ -585,7 +585,7 @@ let _ =
   let open Vernacextend in
   let ty_constr = Extend.TUentry (get_arg_tag Stdarg.wit_constr) in
   let cmd_sig = TyTerminal("PrintPureConstr", TyNonTerminal(ty_constr, TyNil)) in
-  let cmd_fn c ~atts = VtDefault (fun () -> in_current_context print_pure_econstr c) in
+  let cmd_fn c ?loc:_ ~atts = VtDefault (fun () -> in_current_context print_pure_econstr c) in
   let cmd_class _ = VtQuery in
   let cmd : ty_ml = TyML (false, cmd_sig, cmd_fn, Some cmd_class) in
   vernac_extend ~command:"PrintPureConstr" [cmd]

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2064,7 +2064,7 @@ let vernac_check_guard ~pstate =
 
 (* We interpret vernacular commands to a DSL that specifies their
    allowed actions on proof states *)
-let translate_vernac ~atts v = let open Vernacextend in match v with
+let translate_vernac ?loc ~atts v = let open Vernacextend in match v with
   | VernacAbortAll
   | VernacRestart
   | VernacUndo _
@@ -2389,4 +2389,4 @@ let translate_vernac ~atts v = let open Vernacextend in match v with
 
   (* Extensions *)
   | VernacExtend (opn,args) ->
-    Vernacextend.type_vernac ~atts opn args
+    Vernacextend.type_vernac ?loc ~atts opn args

--- a/vernac/vernacentries.mli
+++ b/vernac/vernacentries.mli
@@ -10,7 +10,8 @@
 
 (** Vernac Translation into the Vernac DSL *)
 val translate_vernac
-  : atts:Attributes.vernac_flags
+  : ?loc:Loc.t
+  -> atts:Attributes.vernac_flags
   -> Vernacexpr.vernac_expr
   -> Vernacextend.typed_vernac
 

--- a/vernac/vernacextend.ml
+++ b/vernac/vernacextend.ml
@@ -64,7 +64,7 @@ type typed_vernac =
   | VtDeclareProgram of (pm:Declare.OblState.t -> Declare.Proof.t)
   | VtOpenProofProgram of (pm:Declare.OblState.t -> Declare.OblState.t * Declare.Proof.t)
 
-type vernac_command = atts:Attributes.vernac_flags -> typed_vernac
+type vernac_command = ?loc:Loc.t -> atts:Attributes.vernac_flags -> typed_vernac
 
 type plugin_args = Genarg.raw_generic_argument list
 
@@ -94,7 +94,7 @@ let warn_deprecated_command =
 
 (* Interpretation of a vernac command *)
 
-let type_vernac opn converted_args ~atts =
+let type_vernac opn converted_args ?loc ~atts =
   let depr, callback = vinterp_map opn in
   let () = if depr then
       let rules = Egramml.get_extend_vernac_rule opn in
@@ -106,7 +106,7 @@ let type_vernac opn converted_args ~atts =
       warn_deprecated_command pr;
   in
   let hunk = callback converted_args in
-  hunk ~atts
+  hunk ?loc ~atts
 
 (** VERNAC EXTEND registering *)
 

--- a/vernac/vernacextend.mli
+++ b/vernac/vernacextend.mli
@@ -82,7 +82,7 @@ type typed_vernac =
   | VtDeclareProgram of (pm:Declare.OblState.t -> Declare.Proof.t)
   | VtOpenProofProgram of (pm:Declare.OblState.t -> Declare.OblState.t * Declare.Proof.t)
 
-type vernac_command = atts:Attributes.vernac_flags -> typed_vernac
+type vernac_command = ?loc:Loc.t -> atts:Attributes.vernac_flags -> typed_vernac
 
 type plugin_args = Genarg.raw_generic_argument list
 


### PR DESCRIPTION
Without this patch it is impossible for a command to know exactly the location of its text in the source file. In particular the text parsed as vernac control (eg `Fail`) or attributes is not part of the loc of the AST one can look at.

In HB I need to be able to produce "patches" for the source file and the location of the commands has to be accurate.

I tested this patch and the locs I get are now good.

overlay PR: https://github.com/LPCIC/coq-elpi/pull/209