### PR TITLE
Include (* ... *) comments in .. coqtop:: directives in Sphinx output

### DIFF
--- a/doc/sphinx/_static/notations.css
+++ b/doc/sphinx/_static/notations.css
@@ -267,6 +267,11 @@ code span.error {
     color: inherit !important;
 }
 
+
+.coqdoc-comment {
+    color: #808080 !important
+}
+
 /* make the error message index readable */
 .indextable code {
     white-space: inherit;  /* break long lines */


### PR DESCRIPTION
~~I think this code is pretty close to correct.  The comments show up in the html, but the output for lines that have a tactic or command and end with a comment is delayed in the output.  Look at beginning of the Basic proof writing/Reasoning with equalities section.  I couldn't figure out the right regex to use in `Coqdomain.split_lines` to also split on lines that end with "*)\n".  @cpitclaudel if you know of a way to do that, let me know.  The alternative is to change the `split` in that routine to a loop.~~

Comments are marked with the CSS class `coqdoc-comment`, which I didn't yet define.  Let me know if you'd like to give comments their own color, etc.

![image](https://user-images.githubusercontent.com/1253341/107609893-0f225580-6bf5-11eb-8fd2-ff66c012af76.png)

I'll back out the change to `rewriting.rst` before any merge.