### PR TITLE
Delay the dynamic linking of native-code libraries until native_compute is called.

### DIFF
--- a/doc/changelog/01-kernel/13853-delay-native.rst
+++ b/doc/changelog/01-kernel/13853-delay-native.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  Native-code libraries used by :tacn:`native_compute` are now delayed
+  until an actual call to the :tacn:`native_compute` machinery is
+  performed. This should make Coq more responsive on some systems
+  (`#13853 <https://github.com/coq/coq/pull/13853>`_, fixes `#13849
+  <https://github.com/coq/coq/issues/13849>`_, by Guillaume Melquiond).

--- a/kernel/nativecode.mli
+++ b/kernel/nativecode.mli
@@ -63,6 +63,8 @@ val empty_updates : code_location_updates
 
 val register_native_file : string -> unit
 
+val is_loaded_native_file : string -> bool
+
 val compile_constant_field : env -> string -> Constant.t ->
   global list -> 'a constant_body -> global list
 

--- a/kernel/nativeconv.ml
+++ b/kernel/nativeconv.ml
@@ -9,7 +9,6 @@
 (************************************************************************)
 
 open Names
-open Nativelib
 open Reduction
 open Util
 open Nativevalues
@@ -151,22 +150,25 @@ let warn_no_native_compiler =
                       strbrk " falling back to VM conversion test.")
 
 let native_conv_gen pb sigma env univs t1 t2 =
-  if not (typing_flags env).Declarations.enable_native_compiler then begin
-    warn_no_native_compiler ();
-    Vconv.vm_conv_gen pb env univs t1 t2
-  end
-  else
-  let ml_filename, prefix = get_ml_filename () in
+  Nativelib.link_libraries ();
+  let ml_filename, prefix = Nativelib.get_ml_filename () in
   let code, upds = mk_conv_code env sigma prefix t1 t2 in
-  let fn = compile ml_filename code ~profile:false in
+  let fn = Nativelib.compile ml_filename code ~profile:false in
   debug_native_compiler (fun () -> Pp.str "Running test...");
   let t0 = Sys.time () in
-  call_linker ~fatal:true ~prefix fn (Some upds);
+  let (rt1, rt2) = Nativelib.execute_library ~prefix fn upds in
   let t1 = Sys.time () in
   let time_info = Format.sprintf "Evaluation done in %.5f@." (t1 -. t0) in
   debug_native_compiler (fun () -> Pp.str time_info);
   (* TODO change 0 when we can have de Bruijn *)
-  fst (conv_val env pb 0 !rt1 !rt2 univs)
+  fst (conv_val env pb 0 rt1 rt2 univs)
+
+let native_conv_gen pb sigma env univs t1 t2 =
+  if not (typing_flags env).Declarations.enable_native_compiler then begin
+    warn_no_native_compiler ();
+    Vconv.vm_conv_gen pb env univs t1 t2
+  end
+  else native_conv_gen pb sigma env univs t1 t2
 
 (* Wrapper for [native_conv] above *)
 let native_conv cv_pb sigma env t1 t2 =

--- a/kernel/nativelib.mli
+++ b/kernel/nativelib.mli
@@ -7,7 +7,6 @@
 (*         *     GNU Lesser General Public License Version 2.1          *)
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
-open Nativecode
 
 (** This file provides facilities to access OCaml compiler and dynamic linker,
 used by the native compiler. *)
@@ -25,7 +24,7 @@ val get_ml_filename : unit -> string * string
 (** [compile file code ~profile] will compile native [code] to [file],
    and return the name of the object file; this name depends on
    whether are in byte mode or not; file is expected to be .ml file *)
-val compile : string -> global list -> profile:bool -> string
+val compile : string -> Nativecode.global list -> profile:bool -> string
 
 type native_library = Nativecode.global list * Nativevalues.symbols
 
@@ -33,18 +32,19 @@ type native_library = Nativecode.global list * Nativevalues.symbols
    but will perform some extra tweaks to handle [code] as a Coq lib. *)
 val compile_library : native_library -> string -> unit
 
-val call_linker
-  : ?fatal:bool
-  -> prefix:string
-  -> string
-  -> code_location_updates option
-  -> unit
+(** [execute_library file upds] dynamically loads library [file],
+    updates the library locations [upds], and returns the values stored
+    in [rt1] and [rt2] *)
+val execute_library :
+  prefix:string -> string -> Nativecode.code_location_updates ->
+  Nativevalues.t * Nativevalues.t
 
-val link_library
-  : prefix:string
-  -> dirname:string
-  -> basename:string
-  -> unit
+(** [enable_library] marks the given library for dynamic loading
+    the next time [link_libraries] is called. *)
+val enable_library : string -> Names.DirPath.t -> unit
 
+val link_libraries : unit -> unit
+
+(* used for communication with the loaded libraries *)
 val rt1 : Nativevalues.t ref
 val rt2 : Nativevalues.t ref

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -155,17 +155,13 @@ let library_is_loaded dir =
 
 let register_loaded_library m =
   let libname = m.libsum_name in
-  let link () =
-    let dirname = Filename.dirname (library_full_filename libname) in
-    let prefix = Nativecode.mod_uid_of_dirpath libname ^ "." in
-    let f = prefix ^ "cmo" in
-    let f = Dynlink.adapt_filename f in
-    Nativelib.link_library ~prefix ~dirname ~basename:f
-  in
   let rec aux = function
     | [] ->
-      let () = if Flags.get_native_compiler () then link () in
-      [libname]
+        if Flags.get_native_compiler () then begin
+            let dirname = Filename.dirname (library_full_filename libname) in
+            Nativelib.enable_library dirname libname
+          end;
+        [libname]
     | m'::_ as l when DirPath.equal m' libname -> l
     | m'::l' -> m' :: aux l' in
   libraries_loaded_list := aux !libraries_loaded_list;


### PR DESCRIPTION
Actual calls to `native_compute` are characterized by an unadorned call to `call_linker`. So, this commit adds a wrapper around `call_linker` to deal with all the delayed libraries.

**Kind:** performance.

Fixes / closes #13849