### PR TITLE
Normalize evars during bytecode compilation.

### DIFF
--- a/kernel/vconv.ml
+++ b/kernel/vconv.ml
@@ -196,8 +196,9 @@ let vm_conv_gen cv_pb env univs t1 t2 =
       TransparentState.full env univs t1 t2
   else
   try
-    let v1 = val_of_constr env t1 in
-    let v2 = val_of_constr env t2 in
+    let sigma _ = assert false in
+    let v1 = val_of_constr env sigma t1 in
+    let v2 = val_of_constr env sigma t2 in
     fst (conv_val env cv_pb (nb_rel env) v1 v2 univs)
   with Not_found | Invalid_argument _ ->
     warn_bytecode_compiler_failed ();

--- a/kernel/vmbytegen.ml
+++ b/kernel/vmbytegen.ml
@@ -840,21 +840,21 @@ let dump_bytecodes init code fvs =
      prlist_with_sep (fun () -> str "; ") pp_fv_elem fvs ++
      fnl ())
 
-let compile ~fail_on_error ?universes:(universes=0) env c =
+let compile ~fail_on_error ?universes:(universes=0) env sigma c =
   init_fun_code ();
   Label.reset_label_counter ();
   let cont = [Kstop] in
   try
     let cenv, init_code =
       if Int.equal universes 0 then
-        let lam = lambda_of_constr ~optimize:true env c in
+        let lam = lambda_of_constr ~optimize:true env sigma c in
         let cenv = empty_comp_env () in
         cenv, ensure_stack_capacity (compile_lam env cenv lam 0) cont
       else
         (* We are going to generate a lambda, but merge the universe closure
          * with the function closure if it exists.
          *)
-        let lam = lambda_of_constr ~optimize:true env c in
+        let lam = lambda_of_constr ~optimize:true env sigma c in
         let params, body = decompose_Llam lam in
         let arity = Array.length params in
         let cenv = empty_comp_env () in
@@ -896,7 +896,8 @@ let compile_constant_body ~fail_on_error env univs = function
             let con= Constant.make1 (Constant.canonical kn') in
               Some (BCalias (get_alias env con))
         | _ ->
-            let res = compile ~fail_on_error ~universes:instance_size env body in
+            let sigma _ = assert false in
+            let res = compile ~fail_on_error ~universes:instance_size env sigma body in
               Option.map (fun x -> BCdefined (to_memory x)) res
 
 (* Shortcut of the previous function used during module strengthening *)

--- a/kernel/vmbytegen.mli
+++ b/kernel/vmbytegen.mli
@@ -15,8 +15,10 @@ open Declarations
 open Environ
 
 (** Should only be used for monomorphic terms *)
-val compile : fail_on_error:bool ->
-              ?universes:int -> env -> constr -> (bytecodes * bytecodes * fv) option
+val compile :
+  fail_on_error:bool -> ?universes:int ->
+  env -> (existential -> constr option) -> constr ->
+  (bytecodes * bytecodes * fv) option
 (** init, fun, fv *)
 
 val compile_constant_body : fail_on_error:bool ->

--- a/kernel/vmlambda.mli
+++ b/kernel/vmlambda.mli
@@ -33,7 +33,7 @@ and fix_decl =  Name.t Context.binder_annot array * lambda array * lambda array
 
 exception TooLargeInductive of Pp.t
 
-val lambda_of_constr : optimize:bool -> env -> Constr.t -> lambda
+val lambda_of_constr : optimize:bool -> env -> (existential -> constr option) -> Constr.t -> lambda
 
 val decompose_Llam : lambda -> Name.t Context.binder_annot array * lambda
 

--- a/kernel/vmsymtable.mli
+++ b/kernel/vmsymtable.mli
@@ -14,7 +14,7 @@ open Names
 open Constr
 open Environ
 
-val val_of_constr : env -> constr -> Vmvalues.values
+val val_of_constr : env -> (existential -> constr option) -> constr -> Vmvalues.values
 
 val set_opaque_const      : Constant.t -> unit
 val set_transparent_const : Constant.t -> unit

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -135,8 +135,9 @@ let construct_of_constr_notnative const env tag (mind, _ as ind) u allargs =
 
 
 let construct_of_constr const env sigma tag typ =
-  let t, l = app_type env typ in
-  match EConstr.kind_upto sigma t with
+  let typ = Reductionops.clos_whd_flags CClosure.all env sigma (EConstr.of_constr typ) in
+  let t, l = decompose_appvect (EConstr.Unsafe.to_constr typ) in
+  match Constr.kind t with
   | Ind (ind,u) ->
       construct_of_constr_notnative const env tag ind u l
   | _ ->

--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -414,9 +414,9 @@ let cbv_vm env sigma c t  =
   if Termops.occur_meta sigma c then
     CErrors.user_err Pp.(str "vm_compute does not support metas.");
   (* This evar-normalizes terms beforehand *)
-  let c = EConstr.to_constr ~abort_on_undefined_evars:false sigma c in
-  let t = EConstr.to_constr ~abort_on_undefined_evars:false sigma t in
-  let v = Vmsymtable.val_of_constr env c in
+  let c = EConstr.Unsafe.to_constr c in
+  let t = EConstr.Unsafe.to_constr t in
+  let v = Vmsymtable.val_of_constr env (Evd.existential_opt_value0 sigma) c in
   EConstr.of_constr (nf_val env sigma v t)
 
 let vm_infer_conv ?(pb=Reduction.CUMUL) env sigma t1 t2 =

--- a/test-suite/bugs/closed/bug_13841.v
+++ b/test-suite/bugs/closed/bug_13841.v
@@ -1,0 +1,11 @@
+Goal True.
+evar (p : bool).
+unify ?p true.
+let v := eval vm_compute in (orb p false) in
+match v with true => idtac end.
+assert (orb p false = true).
+vm_compute.
+match goal with |- true = _ => idtac end.
+easy.
+easy.
+Qed.

--- a/test-suite/bugs/closed/bug_7631.v
+++ b/test-suite/bugs/closed/bug_7631.v
@@ -21,3 +21,9 @@ Definition bar (x := foo) := Eval native_compute in x.
 Definition barvm (x := foo) := Eval vm_compute in x.
 
 End RelContext.
+
+Definition bar (t:=_) (x := true : t) := Eval native_compute in x.
+Definition barvm (t:=_) (x := true : t) := Eval vm_compute in x.
+
+Definition baz (z:nat) (t:=_ z) (x := true : t) := Eval native_compute in x.
+Definition bazvm (z:nat) (t:=_ z) (x := true : t) := Eval vm_compute in x.


### PR DESCRIPTION
Otherwise, the interpreter sees already unified evars as accumulators rather than actual constants, thus preventing the computations from progressing.

This was caused by 6b61b63bb8626827708024cbea1312a703a54124, which removed evar normalization. The effect went unnoticed because the computed term is still convertible to the reduced term, except that it is the lazy machinery that ends up reducing it, rather than the bytecode one. So, performances became abysmal, seemingly at random.

**Kind:** bug fix / performance.

Fixes / closes #13841