### PR TITLE
[configure] Allow to avoid embedding the date on Coq's binaries

### DIFF
--- a/checker/checker.ml
+++ b/checker/checker.ml
@@ -48,17 +48,19 @@ let path_of_string s =
 
 let ( / ) = Filename.concat
 
+(* Duplicated with coqtop.ml *)
 let get_version_date () =
   try
     let ch = open_in (Envars.coqlib () / "revision") in
     let ver = input_line ch in
     let rev = input_line ch in
     let () = close_in ch in
-    (ver,rev)
+    (ver,Some rev)
   with _ -> (Coq_config.version,Coq_config.date)
 
 let print_header () =
   let (ver,rev) = (get_version_date ()) in
+  let rev = Option.default "n/a" rev in
   Printf.printf "Welcome to Chicken %s (%s)\n" ver rev;
   flush stdout
 
@@ -169,10 +171,13 @@ let compile_files senv =
     ~admit:(List.rev !admit_list)
     ~check:(List.rev !compile_list)
 
+(* duplicated with usage.ml *)
+let avail_version = Option.default "n/a"
+
 let version () =
   Printf.printf "The Coq Proof Checker, version %s (%s)\n"
-    Coq_config.version Coq_config.date;
-  Printf.printf "compiled on %s\n" Coq_config.compile_date;
+    Coq_config.version (avail_version Coq_config.date);
+  Printf.printf "compiled on %s\n" (avail_version Coq_config.compile_date);
   exit 0
 
 (* print the usage of coqtop (or coqc) on channel co *)

--- a/config/coq_config.mli
+++ b/config/coq_config.mli
@@ -33,8 +33,8 @@ val arch_is_win32 : bool
 val version : string    (* version number of Coq *)
 val caml_version : string    (* OCaml version used to compile Coq *)
 val caml_version_nums : int list    (* OCaml version used to compile Coq by components *)
-val date : string       (* release date *)
-val compile_date : string (* compile date *)
+val date : string option         (* release date / None when in dev mode as to improve binary caching *)
+val compile_date : string option (* compile date / None when in dev mode as to improve binary caching *)
 val vo_version : int32
 val state_magic_number : int
 

--- a/config/dune
+++ b/config/dune
@@ -22,4 +22,4 @@
    ; Needed to generate include lists for coq_makefile
    plugin_list
   (env_var COQ_CONFIGURE_PREFIX))
- (action (chdir %{project_root} (run %{ocaml} configure.ml -no-ask -native-compiler no -bin-annot))))
+ (action (chdir %{project_root} (run %{ocaml} configure.ml -no-ask -native-compiler no -bin-annot -embed-date no))))

--- a/ide/coqide/coq.ml
+++ b/ide/coqide/coq.ml
@@ -16,9 +16,10 @@ let ideslave_coqtop_flags = ref None
 (** * Version and date *)
 
 let get_version_date () =
+  let coq_date = Option.default "n/a" Coq_config.date in
   let date =
-    if Glib.Utf8.validate Coq_config.date
-    then Coq_config.date
+    if Glib.Utf8.validate coq_date
+    then coq_date
     else "<date not printable>" in
   try
     (* the following makes sense only when running with local layout *)

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -394,11 +394,13 @@ let set_options options =
   in
   List.iter iter options
 
+let avail_version = Option.default "n/a"
+
 let about () = {
   Interface.coqtop_version = Coq_config.version;
   Interface.protocol_version = Xmlprotocol.protocol_version;
-  Interface.release_date = Coq_config.date;
-  Interface.compile_date = Coq_config.compile_date;
+  Interface.release_date = avail_version Coq_config.date;
+  Interface.compile_date = avail_version Coq_config.compile_date;
 }
 
 let handle_exn (e, info) =

--- a/sysinit/usage.ml
+++ b/sysinit/usage.ml
@@ -8,10 +8,13 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+let avail_version = Option.default "n/a"
+
 let version () =
   Printf.printf "The Coq Proof Assistant, version %s (%s)\n"
-    Coq_config.version Coq_config.date;
-  Printf.printf "compiled on %s with OCaml %s\n" Coq_config.compile_date Coq_config.caml_version
+    Coq_config.version (avail_version Coq_config.date);
+  Printf.printf "compiled on %s with OCaml %s\n"
+    (avail_version Coq_config.compile_date) Coq_config.caml_version
 
 let machine_readable_version () =
   Printf.printf "%s %s\n"

--- a/tools/coqdoc/main.ml
+++ b/tools/coqdoc/main.ml
@@ -86,9 +86,11 @@ let obsolete s =
     is not (unless both standard and error outputs are redirected, of
     course). *)
 
+let avail_version = Option.default "n/a"
+
 let banner () =
   eprintf "This is coqdoc version %s, compiled on %s\n"
-    Coq_config.version Coq_config.compile_date;
+    Coq_config.version (avail_version Coq_config.compile_date);
   flush stderr
 
 let target_full_name f =

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -24,12 +24,13 @@ let get_version_date () =
     let ver = input_line ch in
     let rev = input_line ch in
     let () = close_in ch in
-    (ver,rev)
+    (ver,Some rev)
   with e when CErrors.noncritical e ->
     (Coq_config.version,Coq_config.date)
 
 let print_header () =
   let (ver,rev) = get_version_date () in
+  let rev = Option.default "n/a" rev in
   Feedback.msg_info (str "Welcome to Coq " ++ str ver ++ str " (" ++ str rev ++ str ")");
   flush_all ()
 


### PR DESCRIPTION
This is quite important in some contexts, for example when using a
global compilation cache (as we do in Dune).
