### PR TITLE
[coqrst] Show "Error:"/"Warning:" with white type (on red/orange background)

### DIFF
--- a/doc/sphinx/_static/ansi.css
+++ b/doc/sphinx/_static/ansi.css
@@ -69,7 +69,7 @@
 }
 
 .ansi-fg-white {
-    color: #2e3436;
+    color: #ffffff;
 }
 
 .ansi-fg-light-black {

--- a/doc/tools/coqrst/repl/ansicolors.py
+++ b/doc/tools/coqrst/repl/ansicolors.py
@@ -91,7 +91,10 @@ def parse_ansi(code):
                  leading ‘^[[’ or the final ‘m’
     """
     classes = []
-    parse_style([int(c) for c in code.split(';')], 0, classes)
+    if code == "37":
+        pass # ignore white fg
+    else:
+        parse_style([int(c) for c in code.split(';')], 0, classes)
     return ["ansi-" + cls for cls in classes]
 
 if __name__ == '__main__':


### PR DESCRIPTION
More legible and more similar to coqtop's appearance.

Left is the old appearance, right is the new appearance:

![image](https://user-images.githubusercontent.com/1253341/107911242-faa1ce00-6f10-11eb-8a77-4de7550c6bb5.png)

Coqtop appearance:

![image](https://user-images.githubusercontent.com/1253341/107911669-da264380-6f11-11eb-9e83-487e026054b9.png)

(Supporting diff highlights would require redesigning Coqdomain.colorize_str, might take a day or two.  So not now.)