### PR TITLE
Only run windows job when WINDOWS=enabled

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -351,6 +351,9 @@ windows64:
     - call dev/ci/platform-windows.bat
   tags:
     - windows-inria
+  only:
+    variables:
+      - $WINDOWS =~ /enabled/
 
 lint:
   stage: stage-1


### PR DESCRIPTION
This seems to have been missed in
https://github.com/coq/coq/pull/13598
(16cd0d5cfc0c4702b8220dad8e91f31a89d904ba)
