### PR TITLE
Add option --version to Coqide (fix #13752).

### DIFF
--- a/ide/coqide/coqide.ml
+++ b/ide/coqide/coqide.ml
@@ -1405,6 +1405,9 @@ let read_coqide_args argv =
     |"-coqtop-flags" :: flags :: args->
       Coq.ideslave_coqtop_flags := Some flags;
       filter_coqtop coqtop project_files bindings_files out args
+    | ("-v" | "--version") :: _ ->
+      Printf.printf "CoqIDE, version %s\n" Coq_config.version;
+      exit 0
     |arg::args when out = [] && CString.is_prefix "-psn_" arg ->
       (* argument added by MacOS during .app launch *)
       filter_coqtop coqtop project_files bindings_files out args


### PR DESCRIPTION
Fixes / closes #13752

By the way, I recently rediscovered the following 2-year old bug reported against Why3: https://gitlab.inria.fr/why3/why3/-/issues/301

>  the provers are detected by launching commands like `cvc4 --version` and checking the result in `share/provers-detection-data.conf`. I would like editors to be detected as well if possible: `coqide --version`