### PR TITLE
Remove IF_then_else

### DIFF
--- a/doc/changelog/10-standard-library/13871-IF.rst
+++ b/doc/changelog/10-standard-library/13871-IF.rst
@@ -1,0 +1,4 @@
+- **Removed:**
+  ``IF_then_else`` definition and corresponding ``IF P then Q else R`` notation
+  (`#13871 <https://github.com/coq/coq/pull/13871>`_,
+  by Yishuai Li).

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -68,7 +68,7 @@ least 3 characters and starting with a simple quote must be quoted
 
 .. coqtop:: in
 
-   Notation "'IF' c1 'then' c2 'else' c3" := (IF_then_else c1 c2 c3).
+   Notation "'IF' c1 'then' c2 'else' c3" := (c1 /\ c2 \/ ~ c1 /\ c3) (at level 200, right associativity).
 
 A notation binds a syntactic expression to a term. Unless the parser
 and pretty-printer of Coq already know how to deal with the syntactic

--- a/theories/Init/Logic.v
+++ b/theories/Init/Logic.v
@@ -252,14 +252,6 @@ Proof.
   intros; split; intros [Hl Hr]; (split; intros; [ apply Hl | apply Hr]); assumption.
 Qed.
 
-(** [(IF_then_else P Q R)], written [IF P then Q else R] denotes
-    either [P] and [Q], or [~P] and [R] *)
-
-Definition IF_then_else (P Q R:Prop) := P /\ Q \/ ~ P /\ R.
-
-Notation "'IF' c1 'then' c2 'else' c3" := (IF_then_else c1 c2 c3)
-  (at level 200, right associativity) : type_scope.
-
 (** * First-order quantifiers *)
 
 (** [ex P], or simply [exists x, P x], or also [exists x:A, P x],


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->
The notation disallows `IF` as identifier. Is the definition used anywhere?

<!-- Keep what applies -->
**Kind:** cleanup.

<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
