### PR TITLE
[coqc] Don't allow to pass more than one file to coqc

### DIFF
--- a/doc/changelog/08-cli-tools/13876-coqc+no_multiple_files.rst
+++ b/doc/changelog/08-cli-tools/13876-coqc+no_multiple_files.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  `coqc` now enforces that at most a single `.v` file can be passed in
+  the command line. Support for multiple `.v` files in the form of
+  `coqc f1.v f2.v` didn't properly work in 8.13, tho it was accepted.
+  (`#13876 <https://github.com/coq/coq/pull/13876>`_,
+  by Emilio Jesus Gallego Arias).

--- a/test-suite/bugs/closed/bug_4836.v
+++ b/test-suite/bugs/closed/bug_4836.v
@@ -1,1 +1,1 @@
-(* -*- coq-prog-args: ("bugs/closed/PLACEHOLDER.v") -*- *)
+(* Placeholder file for directory / file test *)

--- a/toplevel/ccompile.ml
+++ b/toplevel/ccompile.ml
@@ -216,9 +216,8 @@ let compile_file opts stm_opts copts injections (f_in, echo) =
   else
     compile opts stm_opts copts injections ~echo ~f_in ~f_out
 
-let compile_files (opts, stm_opts) copts injections =
-  let compile_list = copts.compile_list in
-  List.iter (compile_file opts stm_opts copts injections) compile_list
+let compile_file opts stm_opts copts injections =
+  Option.iter (compile_file opts stm_opts copts injections) copts.compile_file
 
 (******************************************************************************)
 (* VIO Dispatching                                                            *)

--- a/toplevel/ccompile.mli
+++ b/toplevel/ccompile.mli
@@ -12,8 +12,8 @@
    the init (rc) file *)
 val load_init_vernaculars : Coqargs.t -> state:Vernac.State.t-> Vernac.State.t
 
-(** [compile_files opts] compile files specified in [opts] *)
-val compile_files : Coqargs.t * Stm.AsyncOpts.stm_opt -> Coqcargs.t -> Coqargs.injection_command list -> unit
+(** [compile_file opts] compile file specified in [opts] *)
+val compile_file : Coqargs.t -> Stm.AsyncOpts.stm_opt -> Coqcargs.t -> Coqargs.injection_command list -> unit
 
 (** [do_vio opts] process [.vio] files in [opts] *)
 val do_vio : Coqargs.t -> Coqcargs.t -> Coqargs.injection_command list -> unit

--- a/toplevel/coqc.ml
+++ b/toplevel/coqc.ml
@@ -44,7 +44,7 @@ coqc specific options:\
 
 let coqc_main ((copts,_),stm_opts) injections ~opts =
   Topfmt.(in_phase ~phase:CompilationPhase)
-    Ccompile.compile_files (opts,stm_opts) copts injections;
+    Ccompile.compile_file opts stm_opts copts injections;
 
   (* Careful this will modify the load-path and state so after this
      point some stuff may not be safe anymore. *)

--- a/toplevel/coqcargs.mli
+++ b/toplevel/coqcargs.mli
@@ -27,7 +27,7 @@ type compilation_mode = BuildVo | BuildVio | Vio2Vo | BuildVos | BuildVok
 type t =
   { compilation_mode : compilation_mode
 
-  ; compile_list: (string * bool) list  (* bool is verbosity  *)
+  ; compile_file: (string * bool) option  (* bool is verbosity  *)
   ; compilation_output_name : string option
 
   ; vio_checking : bool


### PR DESCRIPTION
This has been in the TODO queue for a long time, and indeed
I have recently seen some trouble with users passing two .v files to
Coq, which it isn't a) tested, b) supported.

Moreover, it doesn't even work correctly in 8.13 due to some other
changes.

(*) https://stackoverflow.com/questions/66261987/compiling-multiple-coq-files-does-not-work
