### PR TITLE
CI Windows: adjust branch name to Coq Platform branch renaming

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -260,7 +260,7 @@ before_script:
   stage: stage-1
   interruptible: true
   variables:
-    PLATFORM: "https://github.com/coq/platform/archive/master.zip"
+    PLATFORM: "https://github.com/coq/platform/archive/dev-ci.zip"
   artifacts:
     name: "$CI_JOB_NAME"
     paths:


### PR DESCRIPTION
**Kind:** infrastructure.

This adjusts the Coq Platform branch name used for Windows CI to branch renaming in Coq platform (master has been renamed to dev-ci)

Without this Windows CI will fail.