### PR TITLE
[ocaml] Bump Ocaml edge to 4.12.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           opam install -j "$NJOBS" ocamlfind${FINDLIB_VER} ounit lablgtk3-sourceview3 zarith.1.10 dune.2.8.5
           opam list
         env:
-          COMPILER: "4.11.1"
+          COMPILER: "4.12.0"
           FINDLIB_VER: ".1.8.1"
           OPAMYES: "true"
           MACOSX_DEPLOYMENT_TARGET: "10.11"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ variables:
   # Format: $IMAGE-V$DATE-$hash
   # The $hash is the first 10 characters of the md5 of the Dockerfile. e.g.
   # echo $(md5sum dev/ci/docker/bionic_coq/Dockerfile | head -c 10)
-  CACHEKEY: "bionic_coq-V2021-04-14-802aebab96"
+  CACHEKEY: "bionic_coq-V2021-04-30-2b30c6dc00"
   IMAGE: "$CI_REGISTRY_IMAGE:$CACHEKEY"
   # By default, jobs run in the base switch; override to select another switch
   OPAM_SWITCH: "base"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,7 +13,7 @@ Build Requirements
 To compile Coq yourself, you need:
 
 - [OCaml](https://ocaml.org/) (version >= 4.05.0)
-  (This version of Coq has been tested up to OCaml 4.11.1)
+  (This version of Coq has been tested up to OCaml 4.12.0)
 
 - The [Dune OCaml build system](https://github.com/ocaml/dune/) >= 2.5.1
 
@@ -52,7 +52,7 @@ CoqIDE with:
 Opam (https://opam.ocaml.org/) is recommended to install OCaml and
 the corresponding packages.
 
-    $ opam switch create coq 4.11.1+flambda
+    $ opam switch create coq --packages="ocaml-variants.4.12.0+options,ocaml-option-flambda"
     $ eval $(opam env)
     $ opam install dune ocamlfind zarith lablgtk3-sourceview3
 

--- a/coqpp/coqpp_main.ml
+++ b/coqpp/coqpp_main.ml
@@ -360,7 +360,7 @@ let print_body_fun state fmt r =
     print_binders r.vernac_toks print_atts_left r.vernac_atts (print_body_state state) r
 
 let print_body state fmt r =
-  fprintf fmt "@[(%afun %a?loc ~atts@ -> coqpp_body %a%a)@]"
+  fprintf fmt "@[(%afun %a?loc ~atts ()@ -> coqpp_body %a%a)@]"
     (print_body_fun state) r print_binders r.vernac_toks
     print_binders r.vernac_toks print_atts_right r.vernac_atts
 

--- a/dev/ci/azure-opam.sh
+++ b/dev/ci/azure-opam.sh
@@ -2,7 +2,7 @@
 
 set -e -x
 
-OPAM_VARIANT=ocaml-variants.4.11.1+mingw64c
+OPAM_VARIANT=ocaml-variants.4.12.0+mingw64c
 
 wget https://github.com/fdopen/opam-repository-mingw/releases/download/0.0.0.2/opam64.tar.xz -O opam64.tar.xz
 tar -xf opam64.tar.xz

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -123,7 +123,7 @@ project coquelicot "https://gitlab.inria.fr/coquelicot/coquelicot" "master"
 ########################################################################
 # To revert when upstream maintainer comes back online
 # project interval "https://gitlab.inria.fr/coqinterval/interval" "master"
-project interval "https://gitlab.inria.fr/egallego/interval" "make+use_dune_for_ocaml"
+project interval "https://gitlab.inria.fr/egallego/interval" "ocaml+4.12"
 
 ########################################################################
 # Gappa stand alone tool

--- a/dev/ci/docker/bionic_coq/Dockerfile
+++ b/dev/ci/docker/bionic_coq/Dockerfile
@@ -42,9 +42,9 @@ ENV NJOBS="2" \
 ENV COMPILER="4.05.0"
 
 # Common OPAM packages
-ENV BASE_OPAM="zarith.1.10 ocamlfind.1.8.1 ounit2.2.2.3 odoc.1.5.1" \
+ENV BASE_OPAM="zarith.1.10 ocamlfind.1.8.1 ounit2.2.2.3 odoc.1.5.2" \
     CI_OPAM="ocamlgraph.1.8.8" \
-    BASE_ONLY_OPAM="elpi.1.13.1"
+    BASE_ONLY_OPAM="dune.2.7.1 elpi.1.13.1"
 
 # BASE switch; CI_OPAM contains Coq's CI dependencies.
 ENV COQIDE_OPAM="cairo2.0.6.1 lablgtk3-sourceview3.3.1.0"
@@ -61,13 +61,13 @@ RUN opam switch create "${COMPILER}+32bit" && eval $(opam env) && \
         i386 env CC='gcc -m32' opam install zarith.1.10 && \
         opam install $BASE_OPAM
 
-# EDGE switch
-ENV COMPILER_EDGE="4.11.1" \
-    BASE_OPAM_EDGE="dune.2.5.1 dune-release.1.3.3"
+# EDGE switch, dune 2.8 is required for OCaml 4.12
+ENV COMPILER_EDGE="4.12.0" \
+    BASE_OPAM_EDGE="dune.2.8.5 dune-release.1.4.0"
 
 # EDGE+flambda switch, we install CI_OPAM as to be able to use
 # `ci-template-flambda` with everything.
-RUN opam switch create "${COMPILER_EDGE}+flambda" && eval $(opam env) && \
+RUN opam switch create 4.12.0+flambda --packages="ocaml-variants.${COMPILER_EDGE}+options,ocaml-option-flambda" && eval $(opam env) && \
     opam install $BASE_OPAM $BASE_OPAM_EDGE $COQIDE_OPAM $CI_OPAM
 
 RUN opam clean -a -c

--- a/dev/ci/user-overlays/13885-ejgallego-ocaml+4.12.sh
+++ b/dev/ci/user-overlays/13885-ejgallego-ocaml+4.12.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/ejgallego/coq-elpi ocaml+4.12 13885

--- a/dev/dune-workspace.all
+++ b/dev/dune-workspace.all
@@ -3,5 +3,5 @@
 ; Add custom flags here. Default developer profile is `dev`
 (context (opam (switch 4.05.0)))
 (context (opam (switch 4.05.0+32bit)))
-(context (opam (switch 4.11.1)))
-(context (opam (switch 4.11.1+flambda)))
+(context (opam (switch 4.12.0)))
+(context (opam (switch 4.12.0+flambda)))

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -575,7 +575,7 @@ let _ =
   let open Vernacextend in
   let ty_constr = Extend.TUentry (get_arg_tag Stdarg.wit_constr) in
   let cmd_sig = TyTerminal("PrintConstr", TyNonTerminal(ty_constr, TyNil)) in
-  let cmd_fn c ?loc:_ ~atts = VtDefault (fun () -> in_current_context econstr_display c) in
+  let cmd_fn c ?loc:_ ~atts () = VtDefault (fun () -> in_current_context econstr_display c) in
   let cmd_class _ = VtQuery in
   let cmd : ty_ml = TyML (false, cmd_sig, cmd_fn, Some cmd_class) in
   vernac_extend ~command:"PrintConstr" [cmd]
@@ -584,7 +584,7 @@ let _ =
   let open Vernacextend in
   let ty_constr = Extend.TUentry (get_arg_tag Stdarg.wit_constr) in
   let cmd_sig = TyTerminal("PrintPureConstr", TyNonTerminal(ty_constr, TyNil)) in
-  let cmd_fn c ?loc:_ ~atts = VtDefault (fun () -> in_current_context print_pure_econstr c) in
+  let cmd_fn c ?loc:_ ~atts () = VtDefault (fun () -> in_current_context print_pure_econstr c) in
   let cmd_class _ = VtQuery in
   let cmd : ty_ml = TyML (false, cmd_sig, cmd_fn, Some cmd_class) in
   vernac_extend ~command:"PrintPureConstr" [cmd]

--- a/doc/changelog/11-infrastructure-and-dependencies/13885-ocaml+4.12.rst
+++ b/doc/changelog/11-infrastructure-and-dependencies/13885-ocaml+4.12.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Support OCaml 4.12
+  (`#13885 <https://github.com/coq/coq/pull/13885>`_,
+  by Emilio Jesus Gallego Arias, review by Gaëtan Gilbert and Théo Zimmerman).

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -199,7 +199,7 @@ let toggle_scope_printing ~scope ~activate =
   else
     deactivate_scope scope
 
-let toggle_notation_printing ?scope ~notation ~activate =
+let toggle_notation_printing ?scope ~notation ~activate () =
   let inscope = match scope with
   | None -> LastLonelyNotation
   | Some sc -> NotationInScope sc in

--- a/interp/constrextern.mli
+++ b/interp/constrextern.mli
@@ -98,8 +98,12 @@ val with_meta_as_hole : ('a -> 'b) -> 'a -> 'b
 val toggle_scope_printing :
   scope:Notation_term.scope_name -> activate:bool -> unit
 
-val toggle_notation_printing :
-  ?scope:Notation_term.scope_name -> notation:Constrexpr.notation -> activate:bool -> unit
+val toggle_notation_printing
+  : ?scope:Notation_term.scope_name
+  -> notation:Constrexpr.notation
+  -> activate:bool
+  -> unit
+  -> unit
 
 (** Probably shouldn't be used *)
 val empty_extern_env : extern_env

--- a/plugins/ssr/ssripats.ml
+++ b/plugins/ssr/ssripats.ml
@@ -454,7 +454,7 @@ let rec ipat_tac1 ipat : bool tactic =
             let inter = CList.intersect Id.equal clr extra_clear in
             List.iter duplicate_clear inter;
             let cl = CList.union Id.equal clr extra_clear in
-            intro_clear cl)
+            intro_clear cl) ()
 
   | IOpDispatchBranches ipatss ->
       tclDISPATCH (List.map ipat_tac ipatss) <*> notTAC

--- a/plugins/ssr/ssrview.ml
+++ b/plugins/ssr/ssrview.ml
@@ -401,7 +401,7 @@ end
 
 (* Entry points *********************************************************)
 
-let tclIPAT_VIEWS ~views:vs ?(clear_if_id=false) ~conclusion =
+let tclIPAT_VIEWS ~views:vs ?(clear_if_id=false) ~conclusion () =
   tclINDEPENDENTL begin
     State.vsASSERT_EMPTY <*>
     apply_all_views vs ~conclusion ~clear_if_id >>= fun was_tac ->

--- a/plugins/ssr/ssrview.mli
+++ b/plugins/ssr/ssrview.mli
@@ -25,9 +25,12 @@ end
  * as to be cleared (see the to_clear argument to the continuation)
  *
  * returns true if the last view was a tactic *)
-val tclIPAT_VIEWS : views:ast_closure_term list -> ?clear_if_id:bool ->
-    conclusion:(to_clear:Names.Id.t list -> unit Proofview.tactic) ->
-  bool Proofview.tactic
+val tclIPAT_VIEWS
+  :  views:ast_closure_term list
+  -> ?clear_if_id:bool
+  -> conclusion:(to_clear:Names.Id.t list -> unit Proofview.tactic)
+  -> unit
+  -> bool Proofview.tactic
 
 (* Apply views to a given subject (as if was the top of the stack), then
    call conclusion on the obtained term (something like [v2 (v1 subject)]).

--- a/tools/configure/configure.ml
+++ b/tools/configure/configure.ml
@@ -614,8 +614,9 @@ let camltag = match caml_version_list with
     48: implicit elimination of optional arguments: too common
     58: "no cmx file was found in path": See https://github.com/ocaml/num/issues/9
     67: "unused functor parameter" seems totally bogus
+    68: "This pattern depends on mutable state" no idea what it means, dune builds don't display it
 *)
-let coq_warnings = "-w +a-4-9-27-41-42-44-45-48-58-67"
+let coq_warnings = "-w +a-4-9-27-41-42-44-45-48-58-67-68"
 let coq_warn_error =
     if !prefs.warn_error
     then "-warn-error +a"

--- a/vernac/comCoercion.ml
+++ b/vernac/comCoercion.ml
@@ -262,7 +262,7 @@ let inCoercion : coe_info_typ -> obj =
     classify_function = classify_coercion;
     discharge_function = discharge_coercion }
 
-let declare_coercion coef ?(local = false) ~isid ~src:cls ~target:clt ~params:ps =
+let declare_coercion coef ?(local = false) ~isid ~src:cls ~target:clt ~params:ps () =
   let isproj =
     match coef with
     | GlobRef.ConstRef c -> Structures.PrimitiveProjections.find_opt c
@@ -296,7 +296,7 @@ let warn_uniform_inheritance =
           Printer.pr_global g ++
             strbrk" does not respect the uniform inheritance condition")
 
-let add_new_coercion_core coef stre poly source target isid =
+let add_new_coercion_core coef stre poly source target isid : unit =
   check_source source;
   let env = Global.env () in
   let t, _ = Typeops.type_of_global_in_context env coef in
@@ -327,7 +327,7 @@ let add_new_coercion_core coef stre poly source target isid =
   | `LOCAL -> true
   | `GLOBAL -> false
   in
-  declare_coercion coef ~local ~isid ~src:cls ~target:clt ~params:(List.length lvs)
+  declare_coercion coef ~local ~isid ~src:cls ~target:clt ~params:(List.length lvs) ()
 
 
 let try_add_new_coercion_core ref ~local c d e f =

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2401,4 +2401,4 @@ let translate_vernac ?loc ~atts v = let open Vernacextend in match v with
 
   (* Extensions *)
   | VernacExtend (opn,args) ->
-    Vernacextend.type_vernac ?loc ~atts opn args
+    Vernacextend.type_vernac ?loc ~atts opn args ()

--- a/vernac/vernacextend.ml
+++ b/vernac/vernacextend.ml
@@ -64,7 +64,7 @@ type typed_vernac =
   | VtDeclareProgram of (pm:Declare.OblState.t -> Declare.Proof.t)
   | VtOpenProofProgram of (pm:Declare.OblState.t -> Declare.OblState.t * Declare.Proof.t)
 
-type vernac_command = ?loc:Loc.t -> atts:Attributes.vernac_flags -> typed_vernac
+type vernac_command = ?loc:Loc.t -> atts:Attributes.vernac_flags -> unit -> typed_vernac
 
 type plugin_args = Genarg.raw_generic_argument list
 
@@ -94,7 +94,7 @@ let warn_deprecated_command =
 
 (* Interpretation of a vernac command *)
 
-let type_vernac opn converted_args ?loc ~atts =
+let type_vernac opn converted_args ?loc ~atts () =
   let depr, callback = vinterp_map opn in
   let () = if depr then
       let rules = Egramml.get_extend_vernac_rule opn in
@@ -106,7 +106,7 @@ let type_vernac opn converted_args ?loc ~atts =
       warn_deprecated_command pr;
   in
   let hunk = callback converted_args in
-  hunk ?loc ~atts
+  hunk ?loc ~atts ()
 
 (** VERNAC EXTEND registering *)
 

--- a/vernac/vernacextend.mli
+++ b/vernac/vernacextend.mli
@@ -82,7 +82,7 @@ type typed_vernac =
   | VtDeclareProgram of (pm:Declare.OblState.t -> Declare.Proof.t)
   | VtOpenProofProgram of (pm:Declare.OblState.t -> Declare.OblState.t * Declare.Proof.t)
 
-type vernac_command = ?loc:Loc.t -> atts:Attributes.vernac_flags -> typed_vernac
+type vernac_command = ?loc:Loc.t -> atts:Attributes.vernac_flags -> unit -> typed_vernac
 
 type plugin_args = Genarg.raw_generic_argument list
 


### PR DESCRIPTION
Main changes are due to OCaml 4.12.0 detecting more instance of warning 16. This doesn't affect 8.13 as users do build without warnings as errors.

Stub handling has changed upstream, this was tested to work with Dune 2.8.2, however older dune versions or the make system could require adjustments, however I believe compatibility in this sense was improved before the final release.

Another significant change is the new handling of OCaml options in Opam, see https://discuss.ocaml.org/t/experimental-new-layout-for-the-ocaml-variants-packages-in-opam-repository/6779

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/238