### PR TITLE
Dead code elimination: not reducible error message is never raised.

### DIFF
--- a/doc/sphinx/proofs/writing-proofs/rewriting.rst
+++ b/doc/sphinx/proofs/writing-proofs/rewriting.rst
@@ -577,9 +577,6 @@ the conversion in hypotheses :n:`{+ @ident}`.
    definition (say :g:`t`) and then reduces
    :g:`(t t`:sub:`1` :g:`... t`:sub:`n` :g:`)` according to :math:`\beta`:math:`\iota`:math:`\zeta`-reduction rules.
 
-.. exn:: Not reducible.
-   :undocumented:
-
 .. exn:: No head constant to reduce.
    :undocumented:
 

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -1203,9 +1203,7 @@ let unfoldn loccname env sigma c =
 
 (* Re-folding constants tactics: refold com in term c *)
 let fold_one_com com env sigma c =
-  let rcom =
-    try red_product env sigma com
-    with Redelimination -> user_err Pp.(str "Not reducible.") in
+  let rcom = red_product env sigma com in
   (* Reason first on the beta-iota-zeta normal form of the constant as
      unfold produces it, so that the "unfold f; fold f" configuration works
      to refold fix expressions *)


### PR DESCRIPTION
**Kind:** clean-up + documentation fix.

- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).

Found by @JasonGross (see https://github.com/coq/coq/pull/13707#discussion_r572226190).

cc @jfehrle (will conflict with #13707)

`red_product` already does the `try ... with Redelimination -> user_err` dance.

As noticed by @JasonGross:

>This dead code was already present when the functions were first defined in ae47a49. However, at this point in time, the error messages were the same. They got out of sync in d223f85, when the error message in the live codepath was changed without changing the error message in the dead codepath.