### PR TITLE
Minimize the set of multiple inheritance (coercion) paths to check for conversion

### DIFF
--- a/doc/changelog/07-vernac-commands-and-options/13909-reduce-ambiguous-paths.rst
+++ b/doc/changelog/07-vernac-commands-and-options/13909-reduce-ambiguous-paths.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  Improve the :cmd:`Coercion` command to reduce the number of ambiguous paths to
+  report. A pair of multiple inheritance paths that can be reduced to smaller
+  adjoining pairs will not be reported as ambiguous paths anymore.
+  (`#13909 <https://github.com/coq/coq/pull/13909>`_,
+  by Kazuhiko Sakaguchi).

--- a/pretyping/coercionops.ml
+++ b/pretyping/coercionops.ml
@@ -57,9 +57,13 @@ module ClTypMap = Map.Make(ClTyp)
 module ClPairMap = Map.Make(ClPairOrd)
 
 type cl_info_typ = {
+  (* The number of parameters of the coercion class. *)
   cl_param : int;
+  (* The sets of coercion classes respectively reachable from and to the
+     coercion class. *)
   cl_reachable_from : ClTypSet.t;
   cl_reachable_to : ClTypSet.t;
+  (* The representative class of the strongly connected component. *)
   cl_repr : cl_typ;
 }
 
@@ -113,6 +117,8 @@ let add_new_path x y =
 (* class_info : cl_typ -> int * cl_info_typ *)
 
 let class_info cl = ClTypMap.find cl !class_tab
+
+let class_nparams cl = (class_info cl).cl_param
 
 let class_exists cl = ClTypMap.mem cl !class_tab
 

--- a/pretyping/coercionops.mli
+++ b/pretyping/coercionops.mli
@@ -31,20 +31,6 @@ val subst_cl_typ : env -> substitution -> cl_typ -> cl_typ
 (** Comparison of [cl_typ] *)
 val cl_typ_ord : cl_typ -> cl_typ -> int
 
-module ClTypSet : Set.S with type elt = cl_typ
-
-(** This is the type of infos for declared classes *)
-type cl_info_typ = {
-  (* The number of parameters of the coercion class. *)
-  cl_param : int;
-  (* The sets of coercion classes respectively reachable from and to the
-     coercion class. *)
-  cl_reachable_from : ClTypSet.t;
-  cl_reachable_to : ClTypSet.t;
-  (* The representative class of the strongly connected component. *)
-  cl_repr : cl_typ;
-}
-
 (** This is the type of coercion kinds *)
 type coe_typ = GlobRef.t
 
@@ -67,7 +53,7 @@ type inheritance_path = coe_info_typ list
 val class_exists : cl_typ -> bool
 
 (** @raise Not_found if this type is not a class *)
-val class_info : cl_typ -> cl_info_typ
+val class_nparams : cl_typ -> int
 
 (** [find_class_type env sigma c] returns the head reference of [c],
     its universe instance and its arguments *)

--- a/pretyping/coercionops.mli
+++ b/pretyping/coercionops.mli
@@ -31,9 +31,19 @@ val subst_cl_typ : env -> substitution -> cl_typ -> cl_typ
 (** Comparison of [cl_typ] *)
 val cl_typ_ord : cl_typ -> cl_typ -> int
 
+module ClTypSet : Set.S with type elt = cl_typ
+
 (** This is the type of infos for declared classes *)
 type cl_info_typ = {
-  cl_param : int }
+  (* The number of parameters of the coercion class. *)
+  cl_param : int;
+  (* The sets of coercion classes respectively reachable from and to the
+     coercion class. *)
+  cl_reachable_from : ClTypSet.t;
+  cl_reachable_to : ClTypSet.t;
+  (* The representative class of the strongly connected component. *)
+  cl_repr : cl_typ;
+}
 
 (** This is the type of coercion kinds *)
 type coe_typ = GlobRef.t

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -1423,7 +1423,7 @@ let path_convertible env sigma cl p q =
           p'
     | [] ->
       (* identity function for the class [i]. *)
-      let params = (class_info cl).cl_param in
+      let params = class_nparams cl in
       let clty =
         match cl with
         | CL_SORT -> mkGSort (Glob_term.UAnonymous {rigid=false})

--- a/test-suite/output/relaxed_ambiguous_paths.out
+++ b/test-suite/output/relaxed_ambiguous_paths.out
@@ -1,13 +1,24 @@
-File "stdin", line 10, characters 0-28:
+File "stdin", line 13, characters 0-29:
 Warning:
-New coercion path [ac; cd] : A >-> D is ambiguous with existing 
-[ab; bd] : A >-> D. [ambiguous-paths,typechecker]
-[ab] : A >-> B
-[ac] : A >-> C
-[ab; bd] : A >-> D
-[bd] : B >-> D
-[cd] : C >-> D
-File "stdin", line 26, characters 0-28:
+New coercion path [g1; f2] : A >-> B' is ambiguous with existing 
+[f1; g2] : A >-> B'. [ambiguous-paths,typechecker]
+File "stdin", line 14, characters 0-29:
+Warning:
+New coercion path [h1; f3] : B >-> C' is ambiguous with existing 
+[f2; h2] : B >-> C'. [ambiguous-paths,typechecker]
+[f1] : A >-> A'
+[g1] : A >-> B
+[f1; g2] : A >-> B'
+[g1; h1] : A >-> C
+[f1; g2; h2] : A >-> C'
+[g2] : A' >-> B'
+[g2; h2] : A' >-> C'
+[f2] : B >-> B'
+[h1] : B >-> C
+[f2; h2] : B >-> C'
+[h2] : B' >-> C'
+[f3] : C >-> C'
+File "stdin", line 33, characters 0-28:
 Warning:
 New coercion path [ab; bc] : A >-> C is ambiguous with existing 
 [ac] : A >-> C. [ambiguous-paths,typechecker]
@@ -17,6 +28,19 @@ New coercion path [ab; bc] : A >-> C is ambiguous with existing
 [bc] : B >-> C
 [bc; cd] : B >-> D
 [cd] : C >-> D
+File "stdin", line 50, characters 0-28:
+Warning:
+New coercion path [ab; bc] : A >-> C is ambiguous with existing 
+[ac] : A >-> C. [ambiguous-paths,typechecker]
+File "stdin", line 51, characters 0-28:
+Warning:
+New coercion path [ba; ab] : B >-> B is not definitionally an identity function.
+New coercion path [ab; ba] : A >-> A is not definitionally an identity function.
+[ambiguous-paths,typechecker]
+[ab] : A >-> B
+[ac] : A >-> C
+[ba] : B >-> A
+[bc] : B >-> C
 [B_A] : B >-> A
 [C_A] : C >-> A
 [D_A] : D >-> A
@@ -31,7 +55,7 @@ New coercion path [ab; bc] : A >-> C is ambiguous with existing
 [D_B; B_A'] : D >-> A'
 [D_B] : D >-> B
 [D_C] : D >-> C
-File "stdin", line 121, characters 0-86:
+File "stdin", line 147, characters 0-86:
 Warning:
 New coercion path [D_C; C_A'] : D >-> A' is ambiguous with existing 
 [D_B; B_A'] : D >-> A'. [ambiguous-paths,typechecker]
@@ -44,15 +68,15 @@ New coercion path [D_C; C_A'] : D >-> A' is ambiguous with existing
 [D_B; B_A'] : D >-> A'
 [D_B] : D >-> B
 [D_C] : D >-> C
-File "stdin", line 130, characters 0-47:
+File "stdin", line 156, characters 0-47:
 Warning:
 New coercion path [unwrap_nat; wrap_nat] : NAT >-> NAT is not definitionally an identity function.
 [ambiguous-paths,typechecker]
-File "stdin", line 131, characters 0-64:
+File "stdin", line 157, characters 0-64:
 Warning:
 New coercion path [unwrap_list; wrap_list] : LIST >-> LIST is not definitionally an identity function.
 [ambiguous-paths,typechecker]
-File "stdin", line 132, characters 0-51:
+File "stdin", line 158, characters 0-51:
 Warning:
 New coercion path [unwrap_Type; wrap_Type] : TYPE >-> TYPE is not definitionally an identity function.
 [ambiguous-paths,typechecker]

--- a/test-suite/output/relaxed_ambiguous_paths.v
+++ b/test-suite/output/relaxed_ambiguous_paths.v
@@ -1,13 +1,20 @@
 Module test1.
 Section test1.
 
-Variable (A B C D : Type).
-Variable (ab : A -> B) (bd : B -> D) (ac : A -> C) (cd : C -> D).
+Variable (A B C A' B' C' : Type).
+Variable (f1 : A -> A') (f2 : B -> B') (f3 : C -> C').
+Variable (g1 : A -> B) (g2 : A' -> B') (h1 : B -> C) (h2 : B' -> C').
 
-Local Coercion ab : A >-> B.
-Local Coercion bd : B >-> D.
-Local Coercion ac : A >-> C.
-Local Coercion cd : C >-> D.
+Local Coercion g1 : A >-> B.
+Local Coercion g2 : A' >-> B'.
+Local Coercion h1 : B >-> C.
+Local Coercion h2 : B' >-> C'.
+Local Coercion f1 : A >-> A'.
+Local Coercion f2 : B >-> B'.
+Local Coercion f3 : C >-> C'.
+(* [g1; h1; f3], [f1; g2; h2] : A >-> C' should not be reported as ambiguous  *)
+(* paths because they are redundant with `[g1; f2], [f1; g2] : A >-> B'` and  *)
+(* `[h1; f3], [f2; h2] : B >-> C'`.                                           *)
 
 Print Graph.
 
@@ -24,8 +31,8 @@ Local Coercion ac : A >-> C.
 Local Coercion cd : C >-> D.
 Local Coercion ab : A >-> B.
 Local Coercion bc : B >-> C.
-(* `[ab; bc; cd], [ac; cd] : A >-> D` should not be shown as ambiguous paths  *)
-(* here because they are redundant with `[ab; bc], [ac] : A >-> C`.           *)
+(* `[ab; bc; cd], [ac; cd] : A >-> D` should not be reported as ambiguous     *)
+(* paths because they are redundant with `[ab; bc], [ac] : A >-> C`.          *)
 
 Print Graph.
 
@@ -34,6 +41,25 @@ End test2.
 
 Module test3.
 Section test3.
+
+Variable (A B C : Type).
+Variable (ab : A -> B) (ba : B -> A) (ac : A -> C) (bc : B -> C).
+
+Local Coercion ac : A >-> C.
+Local Coercion bc : B >-> C.
+Local Coercion ab : A >-> B.
+Local Coercion ba : B >-> A.
+(* `[ba; ac], [bc] : B >-> C` should not be reported as ambiguous paths       *)
+(* because they are redundant with `[ab; bc], [ac] : A >-> C` and             *)
+(* `[ba; ab] : B >-> B`.                                                      *)
+
+Print Graph.
+
+End test3.
+End test3.
+
+Module test4.
+Section test4.
 Variable (A : Type) (P Q : A -> Prop).
 
 Record B := {
@@ -57,11 +83,11 @@ Local Coercion D_C (d : D) : C := Build_C (D_A d) (D_Q d).
 
 Print Graph.
 
-End test3.
-End test3.
+End test4.
+End test4.
 
-Module test4.
-Section test4.
+Module test5.
+Section test5.
 
 Variable (A : Type) (P Q : A -> Prop).
 
@@ -89,11 +115,11 @@ Local Coercion D_C (d : D) : C true := Build_C true (D_A d) (D_Q d).
 
 Print Graph.
 
-End test4.
-End test4.
+End test5.
+End test5.
 
-Module test5.
-Section test5.
+Module test6.
+Section test6.
 
 Variable (A : Type) (P Q : A -> Prop).
 
@@ -123,18 +149,18 @@ Local Coercion D_C (d : D) : C true :=
 
 Print Graph.
 
-End test5.
-End test5.
-
-Module test6.
-Record > NAT := wrap_nat { unwrap_nat :> nat }.
-Record > LIST (T : Type) := wrap_list { unwrap_list :> list T }.
-Record > TYPE := wrap_Type { unwrap_Type :> Type }.
+End test6.
 End test6.
 
 Module test7.
+Record > NAT := wrap_nat { unwrap_nat :> nat }.
+Record > LIST (T : Type) := wrap_list { unwrap_list :> list T }.
+Record > TYPE := wrap_Type { unwrap_Type :> Type }.
+End test7.
+
+Module test8.
 Set Primitive Projections.
 Record > NAT_prim := wrap_nat { unwrap_nat :> nat }.
 Record > LIST_prim (T : Type) := wrap_list { unwrap_list :> list T }.
 Record > TYPE_prim := wrap_Type { unwrap_Type :> Type }.
-End test7.
+End test8.


### PR DESCRIPTION
The coercion mechanism reports a pair of inheritance paths sharing the same source and target classes (hereinafter a diamond) as ambiguous paths if they are inconvertible, to let the user ensure the coherence of the inheritance graph. In general, we do not necessarily have to check all the diamonds in an inheritance graph to verify its coherence. For example, it is sufficient to check two (small) diamonds `([f1; g2], [g1, f2])` and `([f2; h2], [h1; f3])` in the following diagram, since commutations of other (large) diamonds can be deduced from those of small ones using basic equational reasoning. In practice, not checking such large diamonds may reduce the number of ambiguous path warnings.
```
     /\
    /  \
f1 /    \ g1
  /      \
 /        \
 \        /\
  \   f2 /  \
g2 \    /    \ h1
    \  /      \
     \/        \
      \        /
       \      /
     h2 \    / f3
         \  /
          \/
```
This PR implements the most general way to do such reduction I could find, which is [proved correct](https://gist.github.com/pi8027/aa63dd0f4f575788a9d0e3f927539e52#file-meta-v-L407) in the sense that the inheritance graph is coherent if Coq does not report any ambiguous path. (I also have a draft paper briefly explain this, which I think I can partially share if needed.) To check if a diamond is reducible or not, the table of coercion classes (`class_tab`) has been extended with:
1. the two sets of coercion classes reachable from (`cl_reachable_from`) and to (`cl_reachable_to`) the class, respectively, and
2. the representative element of the strongly connected component including the class (`cl_repr`).

(I will add more explanations later depending on what reviewers request. Let me run CI first.)

<!-- Keep what applies -->
**Kind:** enhancement.

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- ~Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).~
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
