### PR TITLE
[ci] [gitlab] Remove ad-hoc mathcomp install macros

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -706,7 +706,11 @@ library:ci-engine_bench:
   extends: .ci-template
 
 library:ci-fcsl_pcm:
-  extends: .ci-template
+  extends: .ci-template-flambda
+  stage: stage-3
+  needs:
+  - build:edge+flambda
+  - library:ci-mathcomp
 
 library:ci-fiat_crypto:
   extends: .ci-template-flambda
@@ -781,6 +785,10 @@ plugin:ci-gappa:
 
 library:ci-geocoq:
   extends: .ci-template-flambda
+  stage: stage-3
+  needs:
+  - build:edge+flambda
+  - library:ci-mathcomp
 
 library:ci-hott:
   extends: .ci-template
@@ -878,6 +886,10 @@ plugin:plugin-tutorial:
 
 plugin:ci-quickchick:
   extends: .ci-template-flambda
+  stage: stage-3
+  needs:
+  - build:edge+flambda
+  - library:ci-mathcomp
 
 plugin:ci-reduction_effects:
   extends: .ci-template

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -88,9 +88,12 @@ ci-fiat_crypto_ocaml: ci-fiat_crypto
 ci-interval: ci-mathcomp ci-flocq ci-coquelicot ci-bignums
 ci-fourcolor: ci-mathcomp
 ci-oddorder: ci-mathcomp
+ci-fcsl_pcm: ci-mathcomp
+
+ci-geocoq: ci-mathcomp
 
 ci-simple_io: ci-ext_lib
-ci-quickchick: ci-ext_lib ci-simple_io
+ci-quickchick: ci-ext_lib ci-simple_io ci-mathcomp
 
 ci-metacoq: ci-equations
 

--- a/dev/ci/ci-common.sh
+++ b/dev/ci/ci-common.sh
@@ -143,33 +143,3 @@ make()
         command make --output-sync "$@"
     fi
 }
-
-# this installs just the ssreflect library of math-comp
-install_ssreflect()
-{
-  echo 'Installing ssreflect'
-
-  git_download mathcomp
-
-  ( cd "${CI_BUILD_DIR}/mathcomp/mathcomp/ssreflect" && \
-    make && \
-    make install )
-
-}
-
-# this installs just the ssreflect + algebra library of math-comp
-install_ssralg()
-{
-  echo 'Installing ssralg'
-
-  git_download mathcomp
-
-  ( cd "${CI_BUILD_DIR}/mathcomp/mathcomp" && \
-    make -C ssreflect && \
-    make -C ssreflect install && \
-    make -C fingroup && \
-    make -C fingroup install && \
-    make -C algebra && \
-    make -C algebra install )
-
-}

--- a/dev/ci/ci-deriving.sh
+++ b/dev/ci/ci-deriving.sh
@@ -3,8 +3,6 @@
 ci_dir="$(dirname "$0")"
 . "${ci_dir}/ci-common.sh"
 
-install_ssreflect
-
 git_download deriving
 
 ( cd "${CI_BUILD_DIR}/deriving" && make && make tests && make install )

--- a/dev/ci/ci-fcsl_pcm.sh
+++ b/dev/ci/ci-fcsl_pcm.sh
@@ -3,8 +3,6 @@
 ci_dir="$(dirname "$0")"
 . "${ci_dir}/ci-common.sh"
 
-install_ssreflect
-
 git_download fcsl_pcm
 
 ( cd "${CI_BUILD_DIR}/fcsl_pcm" && make )

--- a/dev/ci/ci-geocoq.sh
+++ b/dev/ci/ci-geocoq.sh
@@ -3,8 +3,6 @@
 ci_dir="$(dirname "$0")"
 . "${ci_dir}/ci-common.sh"
 
-install_ssralg
-
 git_download geocoq
 
 ( cd "${CI_BUILD_DIR}/geocoq" && ./configure.sh && make )

--- a/dev/ci/ci-quickchick.sh
+++ b/dev/ci/ci-quickchick.sh
@@ -3,8 +3,6 @@
 ci_dir="$(dirname "$0")"
 . "${ci_dir}/ci-common.sh"
 
-install_ssreflect
-
 git_download quickchick
 
 ( cd "${CI_BUILD_DIR}/quickchick" && make && make install)


### PR DESCRIPTION
They should not be necessary today as they date from the shareable
pre-artifact epoch, an incur in an slowdown.
