### PR TITLE
noglob/dumpglob should be in coqc specific usage

### DIFF
--- a/sysinit/usage.ml
+++ b/sysinit/usage.ml
@@ -73,8 +73,6 @@ let print_usage_common co command =
 \n  -debug                 debug mode (implies -bt)\
 \n  -xml-debug             debug mode and print XML messages to/from coqide\
 \n  -diffs (on|off|removed) highlight differences between proof steps\
-\n  -noglob                do not dump globalizations\
-\n  -dump-glob f           dump globalizations in file f (to be used by coqdoc)\
 \n  -impredicative-set     set sort Set impredicative\
 \n  -allow-sprop           allow using the proof irrelevant SProp sort\
 \n  -disallow-sprop        forbid using the proof irrelevant SProp sort\

--- a/toplevel/coqc.ml
+++ b/toplevel/coqc.ml
@@ -26,6 +26,8 @@ let coqc_specific_usage = Usage.{
 coqc specific options:\
 \n  -o f.vo                use f.vo as the output file name\
 \n  -verbose               compile and output the input file\
+\n  -noglob                do not dump globalizations\
+\n  -dump-glob f           dump globalizations in file f (to be used by coqdoc)\
 \n  -schedule-vio2vo j f1..fn   run up to j instances of Coq to turn each fi.vio\
 \n                         into fi.vo\
 \n  -schedule-vio-checking j f1..fn   run up to j instances of Coq to check all\


### PR DESCRIPTION
Fix #13930

We should really have usage combined with parsing.