### PR TITLE
Fixed grammar productions for PDF documentations

### DIFF
--- a/doc/tools/coqrst/coqdomain.py
+++ b/doc/tools/coqrst/coqdomain.py
@@ -529,12 +529,12 @@ class ProductionObject(CoqObject):
         self.signatures = []
         indexnode = super().run()[0]  # makes calls to handle_signature
 
-        table = nodes.container(classes=['prodn-table'])
-        tgroup = nodes.container(classes=['prodn-column-group'])
+        table = nodes.inline(classes=['prodn-table'])
+        tgroup = nodes.inline(classes=['prodn-column-group'])
         for _ in range(4):
-            tgroup += nodes.container(classes=['prodn-column'])
+            tgroup += nodes.inline(classes=['prodn-column'])
         table += tgroup
-        tbody = nodes.container(classes=['prodn-row-group'])
+        tbody = nodes.inline(classes=['prodn-row-group'])
         table += tbody
 
         # create rows
@@ -542,8 +542,8 @@ class ProductionObject(CoqObject):
             lhs, op, rhs, tag = signature
             position = self.state_machine.get_source_and_line(self.lineno)
 
-            row = nodes.container(classes=['prodn-row'])
-            entry = nodes.container(classes=['prodn-cell-nonterminal'])
+            row = nodes.inline(classes=['prodn-row'])
+            entry = nodes.inline(classes=['prodn-cell-nonterminal'])
             if lhs != "":
                 target_name = make_id('grammar-token-' + lhs)
                 target = nodes.target('', '', ids=[target_name], names=[target_name])
@@ -553,19 +553,19 @@ class ProductionObject(CoqObject):
                 entry += inline
                 entry += notation_to_sphinx('@'+lhs, *position)
             else:
-                entry += nodes.Text('')
+                entry += nodes.literal('', '')
             row += entry
 
-            entry = nodes.container(classes=['prodn-cell-op'])
-            entry += nodes.Text(op)
+            entry = nodes.inline(classes=['prodn-cell-op'])
+            entry += nodes.literal(op, op)
             row += entry
 
-            entry = nodes.container(classes=['prodn-cell-production'])
+            entry = nodes.inline(classes=['prodn-cell-production'])
             entry += notation_to_sphinx(rhs, *position)
             row += entry
 
-            entry = nodes.container(classes=['prodn-cell-tag'])
-            entry += nodes.Text(tag)
+            entry = nodes.inline(classes=['prodn-cell-tag'])
+            entry += nodes.literal(tag, tag)
             row += entry
 
             tbody += row


### PR DESCRIPTION
This is a very simple pull request that undoes changes made by 48bb58156acec84991a9e570e93a4e31c0349e79 that broke the grammar productions in the PDF reference manual. 

Specifically, grammar productions where printed inline, not only did this look ugly, but made multiple productions following eachother unreadable. 

Compare section "2.1.3 Functions and assumptions" of the [v8.12.0 referance manual](https://github.com/coq/coq/releases/download/V8.12.0/coq-8.12.0-reference-manual.pdf) which was before the afformentioned commit, and [v8.12.1](https://github.com/coq/coq/releases/download/V8.12.1/coq-8.12.1-reference-manual.pdf) which was after; this commit restores the v8.12.0 formatting.


<!-- Keep what applies -->
**Kind:** documentation.

