### PR TITLE
[stdlib] Simplify definition of Pos.add and Pos.add_carry

### DIFF
--- a/doc/changelog/10-standard-library/13936-simpler-pos-add.rst
+++ b/doc/changelog/10-standard-library/13936-simpler-pos-add.rst
@@ -1,0 +1,4 @@
+- **Changed:**
+  Simplified definition of `Pos.add` and `Pos.add_carry` to not use mutual recursion
+  (`#13936 <https://github.com/coq/coq/pull/13936>`_,
+  by Li-yao Xia).

--- a/theories/PArith/BinPos.v
+++ b/theories/PArith/BinPos.v
@@ -177,7 +177,7 @@ Qed.
 
 Theorem add_carry_spec p q : add_carry p q = succ (p + q).
 Proof.
-  revert q. induction p; intro q; destruct q; simpl; now f_equal.
+  reflexivity.
 Qed.
 
 (** ** Commutativity *)
@@ -185,7 +185,7 @@ Qed.
 Theorem add_comm p q : p + q = q + p.
 Proof.
   revert q. induction p; intro q; destruct q; simpl; f_equal; trivial.
-  rewrite 2 add_carry_spec; now f_equal.
+  now f_equal.
 Qed.
 
 (** ** Permutation of [add] and [succ] *)
@@ -223,7 +223,7 @@ Proof.
   revert p q. induction r.
   intros [p|p| ] [q|q| ] H; simpl; destr_eq H; f_equal;
    auto using add_carry_add; contradict H;
-   rewrite add_carry_spec, <- add_succ_r; auto using add_no_neutral.
+   rewrite <- add_succ_r; auto using add_no_neutral.
   intros [p|p| ] [q|q| ] H; simpl; destr_eq H; f_equal; auto;
     contradict H; auto using add_no_neutral.
   intros p q H. apply succ_inj. now rewrite <- 2 add_1_r.
@@ -689,8 +689,8 @@ Proof.
  destruct (IHp q) as [|r|r]; subst; try constructor.
   now apply SubIsNeg with 1.
   destruct r; simpl; try constructor; simpl.
-   now rewrite add_carry_spec, <- add_succ_r.
-   now rewrite add_carry_spec, <- add_succ_r, succ_pred_double.
+   now rewrite <- add_succ_r.
+   now rewrite <- add_succ_r, succ_pred_double.
    now rewrite add_1_r.
   now apply SubIsNeg with r~1.
  (* p~0 q~0 *)
@@ -1666,7 +1666,7 @@ destruct (sub_mask_pos' _ _ LT) as (y & -> & H). constructor.
 rewrite Hfg, <- H. now rewrite square_xI, add_assoc. clear Hfg.
 rewrite <- lt_succ_r in Hr. change (r < s~1) in Hr.
 rewrite <- lt_succ_r, (add_lt_mono_l (s~0~1)), H. simpl.
-rewrite add_carry_spec, add_diag. simpl.
+rewrite add_diag. simpl.
 destruct Hf,Hg; subst; red; simpl_compare; now rewrite Hr.
 (* - GT *)
 constructor. now rewrite Hfg, square_xO. apply lt_succ_r, GT.

--- a/theories/PArith/BinPosDef.v
+++ b/theories/PArith/BinPosDef.v
@@ -54,7 +54,7 @@ Fixpoint succ x :=
 
 Fixpoint add x y :=
   match x, y with
-    | p~1, q~1 => (add_carry p q)~0
+    | p~1, q~1 => (succ (add p q))~0
     | p~1, q~0 => (add p q)~1
     | p~1, 1 => (succ p)~0
     | p~0, q~1 => (add p q)~1
@@ -63,20 +63,9 @@ Fixpoint add x y :=
     | 1, q~1 => (succ q)~0
     | 1, q~0 => q~1
     | 1, 1 => 1~0
-  end
-
-with add_carry x y :=
-  match x, y with
-    | p~1, q~1 => (add_carry p q)~1
-    | p~1, q~0 => (add_carry p q)~0
-    | p~1, 1 => (succ p)~1
-    | p~0, q~1 => (add_carry p q)~0
-    | p~0, q~0 => (add p q)~1
-    | p~0, 1 => (succ p)~0
-    | 1, q~1 => (succ q)~1
-    | 1, q~0 => (succ q)~0
-    | 1, 1 => 1~1
   end.
+
+Definition add_carry x y := succ (add x y).
 
 Infix "+" := add : positive_scope.
 

--- a/theories/setoid_ring/InitialRing.v
+++ b/theories/setoid_ring/InitialRing.v
@@ -138,7 +138,6 @@ Section ZMORPHISM.
  Proof.
   intros x;induction x as [x IHx|x IHx|];
    intros y;destruct y as [y|y|];simpl;norm.
-  rewrite Pos.add_carry_spec.
   rewrite ARgen_phiPOS_Psucc.
   rewrite IHx;norm.
   add_push (gen_phiPOS1 y);add_push 1;rrefl.

--- a/theories/setoid_ring/Ncring_initial.v
+++ b/theories/setoid_ring/Ncring_initial.v
@@ -113,7 +113,6 @@ Ltac rsimpl := simpl.
    gen_phiPOS1 (x + y) == (gen_phiPOS1 x) + (gen_phiPOS1 y).
  Proof.
   induction x;destruct y;simpl;norm.
-  rewrite Pos.add_carry_spec.
   rewrite ARgen_phiPOS_Psucc.
   rewrite IHx;norm.
   add_push (gen_phiPOS1 y);add_push 1;reflexivity.


### PR DESCRIPTION
**Kind:** feature

The current definition using mutual recursion is a little tricky to think about, you have to remember to use `Pos.add_carry_spec`.

- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
- [ ] Overlay pull requests (if this breaks 3rd party developments in CI, see
https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md for details)
