### PR TITLE
Set the lsb of return addresses on the bytecode interpreter stack.

### DIFF
--- a/kernel/byterun/coq_memory.c
+++ b/kernel/byterun/coq_memory.c
@@ -66,10 +66,6 @@ static void coq_scan_roots(scanning_action action)
   /* Scan the stack */
   for (i = coq_sp; i < coq_stack_high; i++) {
     if (!Is_block(*i)) continue;
-#ifdef NO_NAKED_POINTERS
-    /* The VM stack may contain C-allocated bytecode */
-    if (!Is_in_heap_or_young(*i)) continue;
-#endif
     (*action) (*i, i);
   };
   /* Hook */


### PR DESCRIPTION
This makes it possible to skip the check when scanning the stack for the garbage collector. See also #13940.