### PR TITLE
Fix bug #13942: allow deterministic interpretation of modes

### DIFF
--- a/dev/ci/user-overlays/13952-mattam82-hints-modes.sh
+++ b/dev/ci/user-overlays/13952-mattam82-hints-modes.sh
@@ -1,0 +1,1 @@
+overlay coqhammer https://github.com/skyskimmer/coqhammer pr-13952 13952 fix-13942

--- a/doc/changelog/04-tactics/13952-typeclasses-eauto-best_effort.rst
+++ b/doc/changelog/04-tactics/13952-typeclasses-eauto-best_effort.rst
@@ -1,0 +1,9 @@
+- **Added:**
+  :ref:`best_effort <TypeclassesEautoBestEffort>` option to :tacn:`typeclasses eauto`,
+  to return a *partial* solution to its initial proof-search problem. The goals that
+  can remain unsolved are determined according to the modes declared for their head
+  (see :cmd:`Hint Mode`). This is used by typeclass resolution during type
+  inference to provide more informative error messages.
+  (`#13952 <https://github.com/coq/coq/pull/13952>`_,
+  fixes `#13942 <https://github.com/coq/coq/pull/13952>`_ and
+  `#14125 <https://github.com/coq/coq/pull/14125>`_, by Matthieu Sozeau).

--- a/doc/sphinx/addendum/type-classes.rst
+++ b/doc/sphinx/addendum/type-classes.rst
@@ -400,7 +400,7 @@ Summary of the commands
    Shows the list of instances associated with the typeclass :token:`reference`.
 
 
-.. tacn:: typeclasses eauto {? {| bfs | dfs } } {? @nat_or_var } {? with {+ @ident } }
+.. tacn:: typeclasses eauto {? {| bfs | dfs | best_effort } } {? @nat_or_var } {? with {+ @ident } }
 
    This proof search tactic uses the resolution engine that is run
    implicitly during type checking. This tactic uses a different resolution
@@ -444,11 +444,30 @@ Summary of the commands
    + Use the :cmd:`Typeclasses eauto` command to customize the behavior of
      this tactic.
 
-   :n:`{| bfs | dfs }`
+   :n:`{| bfs | dfs}`
      Specifies whether to use breadth-first search or depth-first search.
      The default is depth-first search, which can be changed with the
      :flag:`Typeclasses Iterative Deepening` flag.
 
+   .. _TypeclassesEautoBestEffort:
+
+   :n:`best_effort`
+     If the `best_effort` option is given and resolution fails, `typeclasses eauto`
+     returns the first partial solution in which all remaining subgoals fall into one
+     of these categories:
+
+     - Stuck goals: the head of the goal has at least one associated declared mode
+       and the constraint does not match any mode declared for its head. These goals
+       are shelved.
+
+     - Mode failures: the head of the constraint has at least one matching declared mode,
+       but the constraint couldn't be solved. These goals are left as subgoals of
+       :n:`typeclasses eauto best_effort`.
+
+     During type inference, typeclass resolution always uses the `best_effort` option:
+     in case of failure, it constructs a partial solution for the goals and gives
+     a more informative error message. It can be used the same way in interactive proofs
+     to check which instances/hints are missing for a typeclass resolution to succeed.
 
    :n:`@nat_or_var`
      Specifies the maximum depth of the search.

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1134,7 +1134,7 @@ simple_tactic: [
 | DELETE "transparent_abstract" tactic3
 | REPLACE "transparent_abstract" tactic3 "using" ident
 | WITH "transparent_abstract" ltac_expr3 OPT ( "using" ident )
-| "typeclasses" "eauto" OPT [ "bfs" | "dfs" ] OPT nat_or_var OPT ( "with" LIST1 preident )
+| "typeclasses" "eauto" OPT [ "bfs" | "dfs" | "best_effort" ] OPT nat_or_var OPT ( "with" LIST1 preident )
 | DELETE "typeclasses" "eauto" "dfs" OPT nat_or_var "with" LIST1 preident
 | DELETE "typeclasses" "eauto" "dfs" OPT nat_or_var
 | DELETE "typeclasses" "eauto" "bfs" OPT nat_or_var "with" LIST1 preident

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1650,9 +1650,11 @@ simple_tactic: [
 | "unify" constr constr "with" preident
 | "typeclasses" "eauto" "dfs" OPT nat_or_var "with" LIST1 preident
 | "typeclasses" "eauto" "bfs" OPT nat_or_var "with" LIST1 preident
+| "typeclasses" "eauto" "best_effort" OPT nat_or_var "with" LIST1 preident
 | "typeclasses" "eauto" OPT nat_or_var "with" LIST1 preident
 | "typeclasses" "eauto" "bfs" OPT nat_or_var
 | "typeclasses" "eauto" "dfs" OPT nat_or_var
+| "typeclasses" "eauto" "best_effort" OPT nat_or_var
 | "typeclasses" "eauto" OPT nat_or_var
 | "head_of_constr" ident constr
 | "not_evar" constr

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1624,7 +1624,7 @@ simple_tactic: [
 | "einjection" OPT induction_arg OPT ( "as" LIST0 simple_intropattern )
 | "simple" "injection" OPT induction_arg
 | "replace" OPT [ "->" | "<-" ] one_term OPT occurrences
-| "typeclasses" "eauto" OPT [ "bfs" | "dfs" ] OPT nat_or_var OPT ( "with" LIST1 ident )
+| "typeclasses" "eauto" OPT [ "bfs" | "dfs" | "best_effort" ] OPT nat_or_var OPT ( "with" LIST1 ident )
 | "setoid_replace" one_term "with" one_term OPT ( "using" "relation" one_term ) OPT ( "in" ident ) OPT ( "at" LIST1 int_or_var ) OPT ( "by" ltac_expr3 )
 | OPT ( [ natural | "[" ident "]" ] ":" ) "{"
 | bullet
@@ -1741,6 +1741,8 @@ simple_tactic: [
 | "autounfold" OPT hintbases OPT simple_occurrences
 | "autounfold_one" OPT hintbases OPT ( "in" ident )
 | "unify" one_term one_term OPT ( "with" ident )
+| "typeclasses" "eauto" "best_effort" OPT nat_or_var "with" LIST1 ident
+| "typeclasses" "eauto" "best_effort" OPT nat_or_var
 | "head_of_constr" ident one_term
 | "not_evar" one_term
 | "is_ground" one_term

--- a/plugins/ltac/g_class.mlg
+++ b/plugins/ltac/g_class.mlg
@@ -84,12 +84,16 @@ TACTIC EXTEND typeclasses_eauto
     { typeclasses_eauto ~depth:d ~strategy:Dfs l }
  | [ "typeclasses" "eauto" "bfs" nat_or_var_opt(d) "with" ne_preident_list(l) ] ->
     { typeclasses_eauto ~depth:d ~strategy:Bfs l }
+ | [ "typeclasses" "eauto" "best_effort" nat_or_var_opt(d) "with" ne_preident_list(l) ] ->
+    { typeclasses_eauto ~depth:d ~best_effort:true l }
  | [ "typeclasses" "eauto" nat_or_var_opt(d) "with" ne_preident_list(l) ] ->
     { typeclasses_eauto ~depth:d l }
  | [ "typeclasses" "eauto" "bfs" nat_or_var_opt(d) ] -> {
      typeclasses_eauto ~depth:d ~strategy:Bfs ~only_classes:true [Class_tactics.typeclasses_db] }
  | [ "typeclasses" "eauto" "dfs" nat_or_var_opt(d) ] -> {
      typeclasses_eauto ~depth:d ~strategy:Dfs ~only_classes:true [Class_tactics.typeclasses_db] }
+ | [ "typeclasses" "eauto" "best_effort" nat_or_var_opt(d) ] -> {
+      typeclasses_eauto ~depth:d ~only_classes:true ~best_effort:true [Class_tactics.typeclasses_db] }
  | [ "typeclasses" "eauto" nat_or_var_opt(d) ] -> {
      typeclasses_eauto ~depth:d ~only_classes:true [Class_tactics.typeclasses_db] }
 END

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -264,7 +264,7 @@ let hintmap_of env sigma secvars hdc concl =
   | Some hdc ->
      if occur_existential sigma concl then
        (fun db -> match Hint_db.map_eauto env sigma ~secvars hdc concl db with
-                  | ModeMatch l -> l
+                  | ModeMatch (_, l) -> l
                   | ModeMismatch -> [])
      else Hint_db.map_auto env sigma ~secvars hdc concl
 

--- a/tactics/class_tactics.mli
+++ b/tactics/class_tactics.mli
@@ -25,11 +25,22 @@ val set_typeclasses_strategy : search_strategy -> unit
 
 val typeclasses_eauto :
   ?only_classes:bool
-  (** Should non-class goals be shelved and resolved at the end *)
+  (** Should non-class goals be shelved and resolved at the end. Default: false *)
+  -> ?best_effort:bool
+  (** Default: false. Allow some unresolved goals to remain in the result. We explore the
+    whole search space to find a complete solution but if that fails,
+    we return the first solution (if any) with only two kind of constraints:
+    - Stuck constraints which do not validate the modes declared
+      for their heads in the database are shelved.
+    - Constraints which validate a mode declaration for their class but have no solution
+      are left as subgoals.
+      This is useful to debug eauto calls and in typeclass resolution to give more informative
+      error messages. *)
   -> ?st:TransparentState.t
-  (** The transparent_state used when working with local hypotheses  *)
+  (** Default: full. The transparent_state used when working with local hypotheses  *)
   -> ?strategy:search_strategy
-  (** Is a traversing-strategy specified? *)
+  (** Default: governed by a global flag, which itself defaults to depth-first search.
+    Is a traversing-strategy specified? *)
   -> depth:(Int.t option)
   (** Bounded or unbounded search *)
   -> Hints.hint_db_name list
@@ -52,6 +63,18 @@ module Search : sig
     (** Should we force a unique solution *)
     -> only_classes:bool
     (** Should non-class goals be shelved and resolved at the end *)
+    -> best_effort:bool
+    (** If true, when considering a proof search problem where some
+        constraints obey mode declarations, we allow in some situations
+        to perform proof search on the rest of the goals and report these
+        remaining goals (if they remaing unsolved) at the end.
+        The remaining goals are constraints that either do not match the mode declared
+        for their head (i.e. a class), so we cannot even try to solve them,
+        or that match it but have no solution (for a single run of the resolution).
+        This is an approximation: there might in general be other runs
+        of resolution that fail too and generate different instantiations of these goals.
+        However it is still sound: providing instances for the reported constraints
+        would provide a solution to the whole proof search problem. *)
     -> ?strategy:search_strategy
     (** Is a traversing-strategy specified? *)
     -> depth:Int.t option

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -78,7 +78,7 @@ let hintmap_of env sigma secvars concl =
      if occur_existential sigma concl then
        (fun db ->
           match Hint_db.map_eauto env sigma ~secvars hdc concl db with
-          | ModeMatch l -> l
+          | ModeMatch (_, l) -> l
           | ModeMismatch -> [])
      else (fun db -> Hint_db.map_auto env sigma ~secvars hdc concl db)
    (* FIXME: should be (Hint_db.map_eauto hdc concl db) *)

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -514,8 +514,12 @@ let rec subst_hints_path subst hp =
 
 type hint_db_name = string
 
+type mode_match =
+  | NoMode
+  | WithMode of hint_mode array
+
 type 'a with_mode =
-  | ModeMatch of 'a
+  | ModeMatch of mode_match * 'a
   | ModeMismatch
 
 module Hint_db :
@@ -602,12 +606,15 @@ struct
     | ModeOutput -> true
 
   let matches_mode sigma args mode =
-    Array.length mode == Array.length args &&
-      Array.for_all2 (match_mode sigma) mode args
+    if Array.length mode == Array.length args &&
+        Array.for_all2 (match_mode sigma) mode args then Some mode
+    else None
 
   let matches_modes sigma args modes =
-    if List.is_empty modes then true
-    else List.exists (matches_mode sigma args) modes
+    if List.is_empty modes then Some NoMode
+    else
+      try Some (WithMode (List.find_map (matches_mode sigma args) modes))
+      with Not_found -> None
 
   let merge_entry secvars db nopat pat =
     let h = List.sort pri_order_int (List.map snd db.hintdb_nopat) in
@@ -631,10 +638,11 @@ struct
   (* [c] contains an existential *)
   let map_eauto env sigma ~secvars (k,args) concl db =
     let se = find k db in
-      if matches_modes sigma args se.sentry_mode then
+      match matches_modes sigma args se.sentry_mode with
+      | Some m ->
         let pat = lookup_tacs env sigma concl se in
-        ModeMatch (merge_entry secvars db [] pat)
-      else ModeMismatch
+        ModeMatch (m, merge_entry secvars db [] pat)
+      | None -> ModeMismatch
 
   let is_exact = function
     | Give_exact _ -> true
@@ -1570,7 +1578,7 @@ let pr_hint_term env sigma cl =
           let hdc = decompose_app_bound sigma cl in
             if occur_existential sigma cl then
               (fun db -> match Hint_db.map_eauto env sigma ~secvars:Id.Pred.full hdc cl db with
-              | ModeMatch l -> l
+              | ModeMatch (_, l) -> l
               | ModeMismatch -> [])
             else Hint_db.map_auto env sigma ~secvars:Id.Pred.full hdc cl
         with Bound -> Hint_db.map_none ~secvars:Id.Pred.full

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -102,8 +102,12 @@ val glob_hints_path_atom :
 val glob_hints_path :
   Libnames.qualid hints_path_gen -> GlobRef.t hints_path_gen
 
+type mode_match =
+  | NoMode
+  | WithMode of hint_mode array
+
 type 'a with_mode =
-  | ModeMatch of 'a
+  | ModeMatch of mode_match * 'a
   | ModeMismatch
 
 module Hint_db :

--- a/test-suite/bugs/closed/bug_14125.v
+++ b/test-suite/bugs/closed/bug_14125.v
@@ -1,0 +1,13 @@
+Class A (x : True) := a : True.
+Class B x (y : A x) := b : True.
+Axiom pf : forall x y, B x y -> False.
+Instance: B I I := I.
+Goal False.
+  Hint Mode A + : typeclass_instances.
+  Set Typeclasses Debug.
+  pose (pf _ _ _).
+  Set Typeclasses Debug Verbosity 2.
+
+  Hint Mode A - : typeclass_instances.
+  pose (pf _ _ _).
+Abort.

--- a/test-suite/bugs/closed/bug_14441.v
+++ b/test-suite/bugs/closed/bug_14441.v
@@ -1,0 +1,29 @@
+Require Import Utf8 Relation_Definitions.
+
+Class Equiv A := equiv: relation A.
+Hint Mode Equiv ! : typeclass_instances.
+
+Class Lookup (K A M : Type) := lookup: K → M → option A.
+Hint Mode Lookup ! - - : typeclass_instances.
+Hint Mode Lookup - - ! : typeclass_instances.
+
+Parameter list_equiv : ∀ A, Equiv A → Equiv (list A).
+Parameter option_equiv : ∀ A, Equiv A → Equiv (option A).
+Parameter list_lookup : ∀ A, Lookup nat A (list A).
+
+Existing Instance list_equiv.
+Existing Instance option_equiv.
+Existing Instance list_lookup.
+
+Set Typeclasses Debug.
+(* fails *)
+Lemma list_equiv_lookup {A} `{Equiv A} (l k : list A) :
+  equiv l k ↔ ∀ i, equiv (lookup i l) (lookup i k).
+Admitted.
+(*
+?Equiv : "Equiv (option ?A)"
+
+?Lookup : "Lookup ?K ?A (list A)"
+
+?Lookup0 : "Lookup ?K ?A (list A)"
+*)

--- a/test-suite/output/bug_13942.out
+++ b/test-suite/output/bug_13942.out
@@ -1,0 +1,162 @@
+The command has indeed failed with message:
+The following term contains unresolved implicit arguments:
+  (fi fu)
+More precisely: 
+- ?A: Cannot infer the implicit parameter A of fi whose type is 
+  "Type" in
+  environment:
+  K : Type
+  M : Type -> Type
+  H : FMap K M
+  A : Type
+  B : Type
+  i : Union (M A)
+  i' : Union (M B)
+  fi' : Insert K B (M B)
+- ?hi: Cannot infer the implicit parameter hi of fi whose type is
+  "Insert K ?A (M ?A)" (no type class instance found) in
+  environment:
+  K : Type
+  M : Type -> Type
+  H : FMap K M
+  A : Type
+  B : Type
+  i : Union (M A)
+  i' : Union (M B)
+  fi' : Insert K B (M B)
+- ?hu: Cannot infer the implicit parameter hu of fu whose type is
+  "Union (M ?A)" (no type class instance found) in
+  environment:
+  K : Type
+  M : Type -> Type
+  H : FMap K M
+  A : Type
+  B : Type
+  i : Union (M A)
+  i' : Union (M B)
+  fi' : Insert K B (M B)
+The command has indeed failed with message:
+The following term contains unresolved implicit arguments:
+  (fi fu)
+More precisely: 
+- ?hi: Cannot infer the implicit parameter hi of fi whose type is
+  "Insert K A (M A)" (no type class instance found) in
+  environment:
+  K : Type
+  M : Type -> Type
+  H : FMap K M
+  A : Type
+  B : Type
+  i : Union (M A)
+  i' : Union (M B)
+  fi' : Insert K B (M B)
+The command has indeed failed with message:
+The following term contains unresolved implicit arguments:
+  (fi fu)
+More precisely: 
+- ?A: Cannot infer the implicit parameter A of fi whose type is 
+  "Type" in
+  environment:
+  K : Type
+  M : Type -> Type
+  H : FMap K M
+  A : Type
+  B : Type
+  i' : Union (M B)
+  fi' : Insert K B (M B)
+  i : Union (M A)
+- ?hi: Cannot infer the implicit parameter hi of fi whose type is
+  "Insert K ?A (M ?A)" (no type class instance found) in
+  environment:
+  K : Type
+  M : Type -> Type
+  H : FMap K M
+  A : Type
+  B : Type
+  i' : Union (M B)
+  fi' : Insert K B (M B)
+  i : Union (M A)
+- ?hu: Cannot infer the implicit parameter hu of fu whose type is
+  "Union (M ?A)" (no type class instance found) in
+  environment:
+  K : Type
+  M : Type -> Type
+  H : FMap K M
+  A : Type
+  B : Type
+  i' : Union (M B)
+  fi' : Insert K B (M B)
+  i : Union (M A)
+The command has indeed failed with message:
+The following term contains unresolved implicit arguments:
+  (fi fu)
+More precisely: 
+- ?hi: Cannot infer the implicit parameter hi of fi whose type is
+  "Insert K A (M A)" (no type class instance found) in
+  environment:
+  K : Type
+  M : Type -> Type
+  H : FMap K M
+  A : Type
+  B : Type
+  i' : Union (M B)
+  fi' : Insert K B (M B)
+  i : Union (M A)
+The command has indeed failed with message:
+Unable to satisfy the following constraints:
+In environment:
+K : Type
+M : Type -> Type
+H : FMap K M
+A : Type
+B : Type
+ifalse : Choose false -> Union (M B)
+itrue : Choose true -> Union (M B)
+ib : Insert K B (M B)
+i : Choose false -> Union (M A)
+
+?hi : "Insert K ?A (M ?A)"
+
+?hu : "Union (M ?A)"
+
+The command has indeed failed with message:
+Unable to satisfy the following constraints:
+In environment:
+K : Type
+M : Type -> Type
+H : FMap K M
+A : Type
+B : Type
+ifalse : Choose false -> Union (M B)
+itrue : Choose true -> Union (M B)
+ib : Insert K B (M B)
+i : Choose false -> Union (M A)
+
+?hu : "Union (M B)"
+
+fi fu : B
+     : B
+The command has indeed failed with message:
+Unable to satisfy the following constraints:
+In environment:
+K : Type
+M : Type → Type
+H : FMap M
+H0 : ∀ A : Type, Lookup K A (M A)
+Empty : Type → Type
+H1 : ∀ A : Type, Empty (M A)
+H2 : ∀ A : Type, PartialAlter K A (M A)
+OMap : (Type → Type) → Type
+OMap0 : OMap M
+H3 : Merge M
+H4 : ∀ A : Type, FinMapToList K A (M A)
+EqDecision : Type → Type
+EqDecision0 : EqDecision K
+H5 : FinMap K M
+A : Type
+m1, m2 : M A
+i : K
+x : A
+
+?Insert : "Insert K K (M A)"
+

--- a/test-suite/output/bug_13942.v
+++ b/test-suite/output/bug_13942.v
@@ -1,0 +1,314 @@
+
+Set Warnings "-deprecated".
+
+Module Backtrack.
+  Class A (T : Type).
+  (* Global Hint Mode A + : typeclass_instances. *)
+  Class B (T T' : Type) := b : T'.
+  (* Global Hint Mode B - + : typeclass_instances. *)
+
+  Instance anat : A nat := {}.
+  Instance abool : A bool := {}.
+  Instance bnatnat : B nat nat := { b := 0 }.
+
+  Definition foo {T'} {T} {a : A T'} {b : B T' T} : T := b.
+
+  (* This relies on backtracking: we first solve
+      A ? with abool (most recent decl), the find out that B bool _
+      is not solvable and backtrack, find anat and finally solve B.
+  *)
+  Definition test := (foo : nat).
+
+  (* This forces a different resolution path, where A ? is stuck at first,
+    then we solve B's constraint, and we come back to A nat which is solvable.
+  *)
+  Global Hint Mode A + : typeclass_instances.
+
+  Definition test' := (foo : nat).
+
+End Backtrack.
+
+
+Module Minimized.
+  Class Insert (K V M : Type) : Prop.
+  Global Hint Mode Insert - - + : typeclass_instances.
+  Class Lookup (K A M : Type) : Prop.
+  Global Hint Mode Lookup - - ! : typeclass_instances.
+
+  Class Union (A : Type) : Prop.
+  Global Hint Mode Union ! : typeclass_instances.
+  Class FMap (K : Type) (M : Type -> Type) : Prop.
+
+  Section Foo.
+  Context K M `{FMap K M}.
+  Context {A B : Type}.
+  Axiom fi : forall {A} {hi : Insert K A (M A)}, A -> A.
+  Axiom fu : forall {A} {hu : Union (M A)}, A.
+
+  Section OrderOne.
+  Context {i : Union (M A)}.
+  Context {i' : Union (M B)}.
+  Context {fi' : Insert K B (M B)}.
+
+  (** Succees because Union has mode !, so (M _) is enough to trigger
+      i', and then fi'. Union should probably be using + to avoid ambiguities.
+    *)
+  Definition test := (fi fu).
+  End OrderOne.
+
+  (* We check here that typeclass resolution backtracks correctly when reporting
+     errors and does not follow modes too eagerly. *)
+  Section OrderTwo.
+  Context {i' : Union (M B)}.
+  Context {fi' : Insert K B (M B)}.
+  Context {i : Union (M A)}.
+
+  (** Here we get two constraints, first is [Insert K ?A (M ?A)], second is [Union (M ?A)].
+      The first is stuck so we proceed on the second one, which has two solutions.
+      The i / M A is chosen first, but it has no insert instance,
+      so we backtrack on this first solution to find i', even if i respected the mode
+      of Union (just !). *)
+  Definition test' := (fi fu).
+  End OrderTwo.
+  End Foo.
+End Minimized.
+
+Module Minimized'.
+  Class Insert (K V M : Type) : Prop.
+  Global Hint Mode Insert - - + : typeclass_instances.
+  Class Lookup (K A M : Type) : Prop.
+  Global Hint Mode Lookup - - + : typeclass_instances.
+
+  Class Union (A : Type) : Prop.
+  Global Hint Mode Union + : typeclass_instances.
+  Class FMap (K : Type) (M : Type -> Type) : Prop.
+
+  Section Foo.
+  Context K M `{FMap K M}.
+  Context {A B : Type}.
+  Axiom fi : forall {A} {hi : Insert K A (M A)}, A -> A.
+  Axiom fu : forall {A} {hu : Union (M A)}, A.
+  Axiom fu' : forall {A} {hu : Union (M A)}, A -> A.
+  Axiom fi' : forall {A} {hi : Insert K A (M A)}, A.
+
+  Section OrderOne.
+  Context {i : Union (M A)}.
+  Context {i' : Union (M B)}.
+  Context {fi' : Insert K B (M B)}.
+
+  (** Fail because Union has now mode +, so (M _) is not enough to trigger
+      i' and fi'. So we get a general type error
+    *)
+  Fail Definition test := (fi fu).
+
+  (** Here we get the precise missing Insert instance when A is chosen: *)
+
+  Fail Definition test' : A := (fi fu).
+
+  (** Of course the unambiguous querry works *)
+  Definition test : B := (fi fu).
+
+  End OrderOne.
+
+  Section OrderTwo.
+  Context {i' : Union (M B)}.
+  Context {fi' : Insert K B (M B)}.
+  Context {i : Union (M A)}.
+
+  (** Here this fails because this is entirely ambiguous: it cannot decide
+      even on the A type. *)
+  Fail Definition test := (fi fu).
+  Definition test' : B := (fi fu).
+
+  (** Here we get the precise missing instance when A is chosen: *)
+  Fail Definition test'' : A := (fi fu).
+
+  End OrderTwo.
+
+  (** There can still be internal backtracking: here
+      we check that if the union instance depends on another
+      class we get the right behavior.*)
+  Section OrderThree.
+  Class Choose (b : bool).
+  Context {ifalse : Choose false -> Union (M B)}.
+  Context {itrue : Choose true -> Union (M B)}.
+  Context {ib : Insert K B (M B)}.
+  Context {i : Choose false -> Union (M A)}.
+
+  (** Here this fails because this is entirely ambiguous: it cannot decide
+      even on the A type. *)
+  Fail Type (fi fu).
+
+  (** Here we commit to B, but neither ifalse nor itrue applies, so
+      Union (M B) is reported as unsolvable.
+    *)
+  Fail Type (fi fu : B).
+
+  Context {ct : Choose false}.
+  (** Here we can find ifalse to get Union (M B), after backtracking
+      on the failing application of itrue (which last declared instance)
+  *)
+  Type (fi fu : B).
+
+  End OrderThree.
+  End Foo.
+
+
+End Minimized'.
+
+From Coq Require Export Morphisms RelationClasses List Bool Setoid Peano Utf8.
+From Coq Require Import Permutation.
+Export ListNotations.
+From Coq.Program Require Export Basics Syntax.
+
+Module Import base.
+Global Generalizable All Variables.
+Obligation Tactic := idtac.
+
+(** Throughout this development we use [stdpp_scope] for all general purpose
+notations that do not belong to a more specific scope. *)
+Declare Scope stdpp_scope.
+Delimit Scope stdpp_scope with stdpp.
+Global Open Scope stdpp_scope.
+
+Class Union A := union: A → A → A.
+Global Hint Mode Union ! : typeclass_instances.
+Instance: Params (@union) 2 := {}.
+Infix "∪" := union (at level 50, left associativity) : stdpp_scope.
+
+Class ElemOf A B := elem_of: A → B → Prop.
+Global Hint Mode ElemOf - ! : typeclass_instances.
+Instance: Params (@elem_of) 3 := {}.
+Infix "∈" := elem_of (at level 70) : stdpp_scope.
+
+Class FMap (M : Type → Type) := fmap : ∀ {A B}, (A → B) → M A → M B.
+Global Arguments fmap {_ _ _ _} _ !_ / : assert.
+Instance: Params (@fmap) 4 := {}.
+Infix "<$>" := fmap (at level 61, left associativity) : stdpp_scope.
+
+(** * Operations on maps *)
+(** In this section we define operational type classes for the operations
+on maps. In the file [fin_maps] we will axiomatize finite maps.
+The function look up [m !! k] should yield the element at key [k] in [m]. *)
+Class Lookup (K A M : Type) := lookup: K → M → option A.
+Global Hint Mode Lookup - - ! : typeclass_instances.
+Instance: Params (@lookup) 4 := {}.
+Notation "m !! i" := (lookup i m) (at level 20) : stdpp_scope.
+Global Arguments lookup _ _ _ _ !_ !_ / : simpl nomatch, assert.
+
+(** The function insert [<[k:=a]>m] should update the element at key [k] with
+value [a] in [m]. *)
+Class Insert (K A M : Type) := insert: K → A → M → M.
+Global Hint Mode Insert - - ! : typeclass_instances.
+Instance: Params (@insert) 5 := {}.
+Notation "<[ k := a ]>" := (insert k a)
+  (at level 5, right associativity, format "<[ k := a ]>") : stdpp_scope.
+Global Arguments insert _ _ _ _ !_ _ !_ / : simpl nomatch, assert.
+
+(** The function delete [delete k m] should delete the value at key [k] in
+[m]. If the key [k] is not a member of [m], the original map should be
+returned. *)
+Class Delete (K M : Type) := delete: K → M → M.
+Global Hint Mode Delete - ! : typeclass_instances.
+Instance: Params (@delete) 4 := {}.
+Global Arguments delete _ _ _ !_ !_ / : simpl nomatch, assert.
+
+(** The function [partial_alter f k m] should update the value at key [k] using the
+function [f], which is called with the original value at key [k] or [None]
+if [k] is not a member of [m]. The value at [k] should be deleted if [f]
+yields [None]. *)
+Class PartialAlter (K A M : Type) :=
+  partial_alter: (option A → option A) → K → M → M.
+Global Hint Mode PartialAlter - - ! : typeclass_instances.
+Instance: Params (@partial_alter) 4 := {}.
+Global Arguments partial_alter _ _ _ _ _ !_ !_ / : simpl nomatch, assert.
+
+(** The function [merge f m1 m2] should merge the maps [m1] and [m2] by
+constructing a new map whose value at key [k] is [f (m1 !! k) (m2 !! k)].*)
+Class Merge (M : Type → Type) :=
+  merge: ∀ {A B C}, (option A → option B → option C) → M A → M B → M C.
+Global Hint Mode Merge ! : typeclass_instances.
+Instance: Params (@merge) 4 := {}.
+Global Arguments merge _ _ _ _ _ _ !_ !_ / : simpl nomatch, assert.
+
+(** The function [union_with f m1 m2] is supposed to yield the union of [m1]
+and [m2] using the function [f] to combine values of members that are in
+both [m1] and [m2]. *)
+Class UnionWith (A M : Type) :=
+  union_with: (A → A → option A) → M → M → M.
+Global Hint Mode UnionWith - ! : typeclass_instances.
+Instance: Params (@union_with) 3 := {}.
+Global Arguments union_with {_ _ _} _ !_ !_ / : simpl nomatch, assert.
+
+(** We redefine the standard library's [In] and [NoDup] using type classes. *)
+Inductive elem_of_list {A} : ElemOf A (list A) :=
+  | elem_of_list_here (x : A) l : x ∈ x :: l
+  | elem_of_list_further (x y : A) l : x ∈ l → x ∈ y :: l.
+Existing Instance elem_of_list.
+
+End base.
+
+(** * Monadic operations *)
+Global Instance option_fmap: FMap option := @option_map.
+
+Global Instance option_union_with {A} : UnionWith A (option A) := λ f mx my,
+  match mx, my with
+  | Some x, Some y => f x y
+  | Some x, None => Some x
+  | None, Some y => Some y
+  | None, None => None
+  end.
+Global Instance option_union {A} : Union (option A) := union_with (λ x _, Some x).
+
+Unset Default Proof Using.
+
+Class FinMapToList K A M := map_to_list: M → list (K * A).
+Global Hint Mode FinMapToList ! - - : typeclass_instances.
+Global Hint Mode FinMapToList - - ! : typeclass_instances.
+
+Class FinMap K M `{FMap M, ∀ A, Lookup K A (M A), ∀ A, Empty (M A), ∀ A,
+    PartialAlter K A (M A), OMap M, Merge M, ∀ A, FinMapToList K A (M A),
+    EqDecision K} := {
+  map_eq {A} (m1 m2 : M A) : (∀ i, m1 !! i = m2 !! i) → m1 = m2;
+  lookup_partial_alter {A} f (m : M A) i :
+    partial_alter f i m !! i = f (m !! i);
+  lookup_partial_alter_ne {A} f (m : M A) i j :
+    i ≠ j → partial_alter f i m !! j = m !! j;
+  lookup_fmap {A B} (f : A → B) (m : M A) i : (f <$> m) !! i = f <$> m !! i;
+  NoDup_map_to_list {A} (m : M A) : NoDup (map_to_list m);
+  elem_of_map_to_list {A} (m : M A) i x :
+    (i,x) ∈ map_to_list m ↔ m !! i = Some x;
+  lookup_merge {A B C} (f : option A → option B → option C)
+      `{!DiagNone f} (m1 : M A) (m2 : M B) i :
+    merge f m1 m2 !! i = f (m1 !! i) (m2 !! i)
+}.
+
+(** * Derived operations *)
+(** All of the following functions are defined in a generic way for arbitrary
+finite map implementations. These generic implementations do not cause a
+significant performance loss, which justifies including them in the finite map
+interface as primitive operations. *)
+Global Instance map_insert `{PartialAlter K A M} : Insert K A M :=
+  λ i x, partial_alter (λ _, Some x) i.
+Global Instance map_delete `{PartialAlter K A M} : Delete K M :=
+  partial_alter (λ _, None).
+
+Global Instance map_union_with `{Merge M} {A} : UnionWith A (M A) :=
+  λ f, merge (union_with f).
+Global Instance map_union `{Merge M} {A} : Union (M A) := union_with (λ x _, Some x).
+
+(** * Theorems *)
+Section theorems.
+  Context `{FinMap K M}.
+
+  (** Just the Insert instance is missing, as we've commited on (M A) *)
+  Fail Lemma union_delete_insert {A} (m1 m2 : M A) i x :
+    m1 !! i = Some x →
+    delete i m1 ∪ <[i:=i]> m2 = m1 ∪ m2.
+
+  Lemma union_delete_insert {A} (m1 m2 : M A) i x :
+    m1 !! i = Some x →
+    delete i m1 ∪ <[i:=x]> m2 = m1 ∪ m2.
+  Proof. Abort.
+
+End theorems.

--- a/test-suite/success/HintMode.v
+++ b/test-suite/success/HintMode.v
@@ -35,3 +35,27 @@ Module Heads.
     exact onef.
   Defined.
 End Heads.
+
+Module BestEffort.
+
+  Class A (T : Type).
+  Global Hint Mode A + : typeclass_instances.
+  Class B (T : Type).
+  Global Hint Mode B + : typeclass_instances.
+
+  Instance a_imp_b T : A T -> B T := {}.
+  Instance anat : B nat := {}.
+  Lemma b : B nat * A nat.
+  Proof.
+    Fail split; typeclasses eauto.
+    Set Typeclasses Debug Verbosity 2.
+    Fail split; solve [typeclasses eauto best_effort].
+    (* Here typeclasses eauto best_effort, when run on the 2 goals at once,
+       can solve the B goal which has a nat instance nd whose mode is +
+       (this morally assumes that there is only one instance matching B nat)
+    *)
+    split; typeclasses eauto best_effort.
+    admit.
+  Admitted.
+
+End BestEffort.

--- a/test-suite/success/Typeclasses.v
+++ b/test-suite/success/Typeclasses.v
@@ -136,6 +136,19 @@ Module Leivantex2PR339.
   Qed.
 End Leivantex2PR339.
 
+Module HintMode_NonStuck_Failure_Refine_DoNotShelve.
+
+Class test (x : nat) := testv : True.
+Local Hint Mode test ! : typeclass_instances.
+Record foo := { n : nat ; t : test n ; h : t = t }.
+Goal True.
+  (* This tests that non-stuck classes whose resolution fails
+     are left as proper subgoals and not shelved if failure is allowed.
+  *)
+  simple refine (let name := (_ : test 5) in _); [|].
+Abort.
+End HintMode_NonStuck_Failure_Refine_DoNotShelve.
+
 Module bt.
 Require Import Equivalence.
 
@@ -289,7 +302,6 @@ Module IterativeDeepening.
   
   Goal C -> A.
     intros.
-    Set Typeclasses Debug.
     Fail Timeout 1 typeclasses eauto.
     Set Typeclasses Iterative Deepening.
     Fail typeclasses eauto 1.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** bug fix / feature

This is a tentative to fix the error messages given by type class resolution in presence of mode declarations.
It basically allows interpreting modes as giving a functional/deterministic spec to a class, so if a class constraint
respects the modes of its class, but no instance can solve it, we treat it as a stuck constraint, and move
to the next constraints. 
We let resolution run until there are only stuck constraints left and no progress can be made, 
as before, but we now report the state at then end of the resolution to the user rather than the initial constraints.
This gives much nicer error messages. It is guaranteed that if the user provides the reported missing instances, then
the proof search will succeed. In general however there might be other paths of proof search that could succeed using different instances.

The change only applies to classes with at least one mode declaration, so it is relatively backwards compatible. 
Resolution is still launched only once but we report the first solution which resulted in only stuck subgoals and subgoals which match a mode declaration but whose resolution fail, if any.  It can in principle raise performance issues because a search that previously failed early (because we were not backtracking correctly on stuck failures), now continues with subsequent goals before finally failing.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #13942
Closes #14125
Closes #14441

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
- [x] Overlay pull requests (if this breaks 3rd party developments in CI, see
https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md for details)

Overlay:
- https://github.com/lukaszcz/coqhammer/pull/112
