### PR TITLE
Implement ! goal selector for Ltac2.

### DIFF
--- a/test-suite/bugs/closed/bug_13960.v
+++ b/test-suite/bugs/closed/bug_13960.v
@@ -1,0 +1,10 @@
+Require Ltac2.Ltac2.
+
+Set Default Goal Selector "!".
+
+Ltac2 t () := let _ := Message.print (Message.of_string "hi") in 42.
+
+Goal False.
+Proof.
+Ltac2 Eval t ().
+Abort.

--- a/user-contrib/Ltac2/tac2entries.ml
+++ b/user-contrib/Ltac2/tac2entries.ml
@@ -816,7 +816,18 @@ let perform_eval ~pstate e =
   | Goal_select.SelectList l -> Proofview.tclFOCUSLIST l v
   | Goal_select.SelectId id -> Proofview.tclFOCUSID id v
   | Goal_select.SelectAll -> v
-  | Goal_select.SelectAlreadyFocused -> assert false (* TODO **)
+  | Goal_select.SelectAlreadyFocused ->
+    let open Proofview.Notations in
+    Proofview.numgoals >>= fun n ->
+    if Int.equal n 1 then v
+    else
+      let e = CErrors.UserError
+          (None,
+            Pp.(str "Expected a single focused goal but " ++
+                int n ++ str " goals are focused."))
+      in
+      let info = Exninfo.reify () in
+      Proofview.tclZERO ~info e
   in
   let (proof, _, ans) = Proof.run_tactic (Global.env ()) v proof in
   let { Proof.sigma } = Proof.data proof in


### PR DESCRIPTION
Fixes #13960: Ltac2 Eval does not work with Set Default Goal Selector "!".