### PR TITLE
[ide] Extend the API so we can specify max both depth

### DIFF
--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -113,10 +113,10 @@ let annotate phrase =
   let doc = get_doc () in
   let pa = Pcoq.Parsable.make (Stream.of_string phrase) in
   match Stm.parse_sentence ~doc (Stm.get_current_state ~doc) ~entry:Pvernac.main_entry pa with
-  | None -> Richpp.richpp_of_pp 78 (Pp.mt ())
+  | None -> Richpp.richpp_of_pp ~width:78 (Pp.mt ())
   | Some ast ->
     (* XXX: Width should be a parameter of annotate... *)
-    Richpp.richpp_of_pp 78 (Ppvernac.pr_vernac ast)
+    Richpp.richpp_of_pp ~width:78 (Ppvernac.pr_vernac ast)
 
 (** Goal display *)
 
@@ -495,8 +495,8 @@ let slave_feeder fmt xml_oc msg =
     trying to answer malformed requests. *)
 
 let msg_format = ref (fun () ->
-    let margin = Option.default 72 (Topfmt.get_margin ()) in
-    Xmlprotocol.Richpp margin
+    let width = Option.default 72 (Topfmt.get_margin ()) in
+    Xmlprotocol.Richpp { width; depth = max_int }
   )
 
 (* The loop ignores the command line arguments as the current model delegates

--- a/ide/coqide/protocol/richpp.ml
+++ b/ide/coqide/protocol/richpp.ml
@@ -36,7 +36,7 @@ type 'a context = {
     marking functions. As those functions are called when actually writing to
     the device, the resulting tree is correct.
 *)
-let rich_pp width ppcmds =
+let rich_pp ~width ?depth ppcmds =
 
   let context = {
     stack = Leaf;
@@ -99,6 +99,7 @@ let rich_pp width ppcmds =
 
   (* Setting the formatter *)
   pp_set_margin ft width;
+  Option.iter (pp_set_max_boxes ft) depth;
   let m = max (64 * width / 100) (width-30) in
   pp_set_max_indent ft m;
   pp_set_max_boxes ft 50 ;
@@ -158,7 +159,7 @@ let xml_of_rich_pp tag_of_annotation attributes_of_annotation xml =
 
 type richpp = xml
 
-let richpp_of_pp width pp =
+let richpp_of_pp ~width ?depth pp =
   let rec drop = function
   | PCData s -> [PCData s]
   | Element (_, annotation, cs) ->
@@ -167,5 +168,5 @@ let richpp_of_pp width pp =
     | None -> cs
     | Some s -> [Element (s, [], cs)]
   in
-  let xml = rich_pp width pp in
+  let xml = rich_pp ~width ?depth pp in
   Element ("_", [], drop xml)

--- a/ide/coqide/protocol/richpp.mli
+++ b/ide/coqide/protocol/richpp.mli
@@ -26,7 +26,7 @@ type 'annotation located = {
     that represents (located) annotations of this string.
     The [get_annotations] function is used to convert tags into the desired
     annotation. [width] sets the printing width of the formatter. *)
-val rich_pp : int -> Pp.t -> Pp.pp_tag located Xml_datatype.gxml
+val rich_pp : width:int -> ?depth:int -> Pp.t -> Pp.pp_tag located Xml_datatype.gxml
 
 (** [annotations_positions ssdoc] returns a list associating each
     annotations with its position in the string from which [ssdoc] is
@@ -49,5 +49,5 @@ type richpp = Xml_datatype.xml
 
 (** Type of text with style annotations *)
 
-val richpp_of_pp : int -> Pp.t -> richpp
+val richpp_of_pp : width:int -> ?depth:int -> Pp.t -> richpp
 (** Extract style information from formatted text *)

--- a/ide/coqide/protocol/xmlprotocol.ml
+++ b/ide/coqide/protocol/xmlprotocol.ml
@@ -15,8 +15,8 @@ let protocol_version = "20210506"
 
 (** See xml-protocol.md for a description of the protocol. *)
 
-type msg_format = Richpp of int | Ppcmds
-let msg_format = ref (Richpp 72)
+type msg_format = Richpp of { width : int; depth : int } | Ppcmds
+let msg_format = ref (Richpp { width = 72; depth = max_int })
 
 (** * Interface of calls to Coq by CoqIDE *)
 
@@ -152,7 +152,8 @@ let of_richpp x = Element ("richpp", [], [x])
 (* Run-time Selectable *)
 let of_pp (pp : Pp.t) =
   match !msg_format with
-  | Richpp margin -> of_richpp (Richpp.richpp_of_pp margin pp)
+  | Richpp { width; depth } ->
+    of_richpp (Richpp.richpp_of_pp ~width ~depth pp)
   | Ppcmds        -> of_pp pp
 
 let of_value f = function

--- a/ide/coqide/protocol/xmlprotocol.mli
+++ b/ide/coqide/protocol/xmlprotocol.mli
@@ -49,7 +49,7 @@ val protocol_version : string
 (** By default, we still output messages in Richpp so we are
     compatible with 8.6, however, 8.7 aware clients will want to
     set this to Ppcmds *)
-type msg_format = Richpp of int | Ppcmds
+type msg_format = Richpp of { width : int; depth : int } | Ppcmds
 
 (** * XML data marshalling *)
 

--- a/ide/coqide/wg_MessageView.ml
+++ b/ide/coqide/wg_MessageView.ml
@@ -89,7 +89,7 @@ let message_view () : message_view =
     in
     let mark = `MARK mark in
     let width = Ideutils.textview_width view in
-    Ideutils.insert_xml ~mark buffer ~tags (Richpp.richpp_of_pp width msg);
+    Ideutils.insert_xml ~mark buffer ~tags (Richpp.richpp_of_pp ~width msg);
     buffer#insert ~iter:(buffer#get_iter_at_mark mark) "\n";
     buffer#move_mark (`NAME "end_of_output") ~where:buffer#end_iter;
   in
@@ -99,7 +99,7 @@ let message_view () : message_view =
     let tags = [] in
     let mark = `MARK mark in
     let width = Ideutils.textview_width view in
-    Ideutils.insert_xml ~mark buffer ~tags (Richpp.richpp_of_pp width msg);
+    Ideutils.insert_xml ~mark buffer ~tags (Richpp.richpp_of_pp ~width msg);
     buffer#move_mark (`NAME "end_of_output") ~where:buffer#end_iter;
     view#set_editable true;
     view#set_cursor_visible true;

--- a/ide/coqide/wg_ProofView.ml
+++ b/ide/coqide/wg_ProofView.ml
@@ -91,7 +91,7 @@ let mode_tactic sel_cb (proof : #GText.view_skel) goals ~unfoc_goals hints = mat
           let () = hook_tag_cb tag hint sel_cb on_hover in
           [tag], hints
         in
-        let () = insert_xml ~tags proof#buffer (Richpp.richpp_of_pp width hyp) in
+        let () = insert_xml ~tags proof#buffer (Richpp.richpp_of_pp ~width hyp) in
         proof#buffer#insert "\n";
         insert_hyp rem_hints hs
       in
@@ -105,13 +105,13 @@ let mode_tactic sel_cb (proof : #GText.view_skel) goals ~unfoc_goals hints = mat
           else []
         in
         proof#buffer#insert (goal_str ~shownum:true 1 goals_cnt cur_name);
-        insert_xml ~tags:[Tags.Proof.goal] proof#buffer (Richpp.richpp_of_pp width cur_goal);
+        insert_xml ~tags:[Tags.Proof.goal] proof#buffer (Richpp.richpp_of_pp ~width cur_goal);
         proof#buffer#insert "\n"
       in
       (* Insert remaining goals (no hypotheses) *)
       let fold_goal ?(shownum=false) i _ { Interface.goal_ccl = g; Interface.goal_name = name } =
         proof#buffer#insert (goal_str ~shownum i goals_cnt name);
-        insert_xml proof#buffer (Richpp.richpp_of_pp width g);
+        insert_xml proof#buffer (Richpp.richpp_of_pp ~width g);
         proof#buffer#insert "\n"
       in
       let () = Util.List.fold_left_i (fold_goal ~shownum:true) 2 () rem_goals in
@@ -163,7 +163,7 @@ let display mode (view : #GText.view_skel) goals hints evars =
       (* The proof is finished, with the exception of given up goals. *)
       view#buffer#insert "No more goals, but there are some goals you gave up:\n\n";
       let iter goal =
-        insert_xml view#buffer (Richpp.richpp_of_pp width goal.Interface.goal_ccl);
+        insert_xml view#buffer (Richpp.richpp_of_pp ~width goal.Interface.goal_ccl);
         view#buffer#insert "\n"
       in
       List.iter iter given_up_goals;
@@ -172,7 +172,7 @@ let display mode (view : #GText.view_skel) goals hints evars =
       (* All the goals have been resolved but those on the shelf. *)
       view#buffer#insert "All the remaining goals are on the shelf:\n\n";
       let iter goal =
-        insert_xml view#buffer (Richpp.richpp_of_pp width goal.Interface.goal_ccl);
+        insert_xml view#buffer (Richpp.richpp_of_pp ~width goal.Interface.goal_ccl);
         view#buffer#insert "\n"
       in
       List.iter iter shelved_goals
@@ -189,7 +189,7 @@ let display mode (view : #GText.view_skel) goals hints evars =
       view#buffer#insert "This subproof is complete, but there are some unfocused goals:\n\n";
       let iter i goal =
         let () = view#buffer#insert (goal_str (succ i) goal.Interface.goal_id) in
-        insert_xml view#buffer (Richpp.richpp_of_pp width goal.Interface.goal_ccl);
+        insert_xml view#buffer (Richpp.richpp_of_pp ~width goal.Interface.goal_ccl);
         view#buffer#insert "\n"
       in
       List.iteri iter bg


### PR DESCRIPTION
This is a step towards fixing #13971 , we allow the `Pp.t` render API
to take a `depth` from the clients.

The main remaining bit is how to set the `depth` in coqide, as of
today, Coqide doesn't link to Coq itself so we cannot access the
state set by `Set Printing Depth`, there are several choices possible
here:

- add a printing depth option to Coqide
- pass display options set server-side along with the `Pp.t` object
- switch back to Coq-side rendering: this is cumbersome as it means
  that we cannot reflow for example on panel resize without a
  round-trip, code was kept in the Coq tree tho so in case we'd like
  to switch back to it.

I think option 1 makes the most sense, for example in term of boxes,
the api is designed as for example to allow users to click on an
ellipsis and have it expanded, this is possible with the current
client-side rendering API.
