### PR TITLE
Do not match on record types with mutable fields in function arguments.

### DIFF
--- a/lib/cProfile.ml
+++ b/lib/cProfile.ml
@@ -285,7 +285,7 @@ let format_profile (table, outside, total) =
   Printf.printf
     "%-23s  %9s %9s %10s %10s %10s\n"
     "Function name" "Own time" "Tot. time" "Own alloc" "Tot. alloc" "Calls ";
-  let l = List.sort (fun (_,{tottime=p}) (_,{tottime=p'}) -> p' - p) table in
+  let l = List.sort (fun p p' -> (snd p').tottime - (snd p).tottime) table in
   List.iter (fun (name,e) ->
     Printf.printf
       "%-23s %9.2f %9.2f %10.0f %10.0f %6d %6d\n"

--- a/plugins/extraction/mlutil.ml
+++ b/plugins/extraction/mlutil.ml
@@ -217,13 +217,13 @@ module Mlenv = struct
 
   (* Adding a type with no [Tvar], hence no generalization needed. *)
 
-  let push_type {env=e;free=f} t =
-    { env = (0,t) :: e; free = find_free f t}
+  let push_type mle t =
+    { env = (0,t) :: mle.env; free = find_free mle.free t}
 
   (* Adding a type with no [Tvar] nor [Tmeta]. *)
 
-  let push_std_type {env=e;free=f} t =
-    { env = (0,t) :: e; free = f}
+  let push_std_type mle t =
+    { env = (0,t) :: mle.env; free = mle.free}
 
 end
 

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -2565,8 +2565,8 @@ let get_allow_nested_proofs =
     ~value:false
 
 (** [process_transaction] adds a node in the document *)
-let process_transaction ~doc ?(newtip=Stateid.fresh ())
-  ({ verbose; expr } as x) c =
+let process_transaction ~doc ?(newtip=Stateid.fresh ()) x c =
+  let { verbose; expr } = x in
   stm_pperr_endline (fun () -> str "{{{ processing: " ++ pr_ast x);
   let vcs = VCS.backup () in
   try


### PR DESCRIPTION
This tends to confuse the OCaml compiler, for good reasons. Indeed, if there are mutable fields, the generated code cannot wait for the function to be fully applied. It needs to recover the value of the mutable fields as early as possible, and thus to create a closure.

Example:
```ocaml
let foo {bar} x = ...
```
is compiled as
```ocaml
let foo y = match y with {bar} -> fun x -> ...
```
