### PR TITLE
[stdlib] [List] removed deprecated/unnecessary dependencies: Le, Gt, Minus, Lt, Setoid

### DIFF
--- a/doc/changelog/10-standard-library/13986-clean-List-imports.rst
+++ b/doc/changelog/10-standard-library/13986-clean-List-imports.rst
@@ -1,0 +1,4 @@
+- **Removed:**
+  from ``List.v`` deprecated/unexpected dependencies ``Setoid``, ``Le``, ``Gt``, ``Minus``, ``Lt``
+  (`#13986 <https://github.com/coq/coq/pull/13986>`_,
+  by Andrej Dudenhefner).

--- a/theories/MSets/MSetGenTree.v
+++ b/theories/MSets/MSetGenTree.v
@@ -30,6 +30,7 @@
 *)
 
 Require Import FunInd Orders OrdersFacts MSetInterface PeanoNat.
+Require Arith. (* contains deprecated dependencies *)
 Local Open Scope list_scope.
 Local Open Scope lazy_bool_scope.
 


### PR DESCRIPTION
<!-- Keep what applies -->
**Kind:** feature / infrastructure.

As stated in the stdlib, modules `Le`, `Gt`, `Minus`, `Lt` are deprecated/obsolete.
This PR removes those dependencies from `List.v` replacing deprecated lemmas by those from `PeanoNat.Nat`.
Also, for `List.v` the dependency `Setoid` is not necessary and is removed.

Several ci projects (wrongly) rely on `List` to provide `Arith` functionality, this is fixed via 
- GeoCoq/GeoCoq#33 (merged)
- damien-pous/relation-algebra#19 (merged)
- coq-community/coq-ext-lib#109 (merged)

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
