### PR TITLE
fix documentation of Ltac2.Env.expand

### DIFF
--- a/user-contrib/Ltac2/Env.v
+++ b/user-contrib/Ltac2/Env.v
@@ -16,7 +16,7 @@ Ltac2 @ external get : ident list -> Std.reference option := "ltac2" "env_get".
 
 Ltac2 @ external expand : ident list -> Std.reference list := "ltac2" "env_expand".
 (** Returns the list of all global references whose absolute name contains
-    the argument list as a prefix. *)
+    the argument list as a suffix. *)
 
 Ltac2 @ external path : Std.reference -> ident list := "ltac2" "env_path".
 (** Returns the absolute name of the given reference. Panics if the reference


### PR DESCRIPTION
Maybe I'm just confused about the direction of lists, but according to this experiment:

```coq
Require Import Ltac2.Ltac2.
Ltac2 Eval List.map Env.path (Env.expand [@Datatypes; @nat]).
```

```
- : ident list list = [[@Coq; @Init; @Datatypes; @nat]]
```

the documentation of `Ltac2.Env.expand` should say "suffix" instead of "prefix", it seems?

