### PR TITLE
iris_string_ident is no longer needed

### DIFF
--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -79,8 +79,6 @@ project iris "https://gitlab.mpi-sws.org/iris/iris" ""
 
 project autosubst "https://github.com/coq-community/autosubst" "master"
 
-project iris_string_ident "https://gitlab.mpi-sws.org/iris/string-ident" "master"
-
 project iris_examples "https://gitlab.mpi-sws.org/iris/examples" "master"
 
 ########################################################################

--- a/dev/ci/ci-iris.sh
+++ b/dev/ci/ci-iris.sh
@@ -5,7 +5,6 @@ ci_dir="$(dirname "$0")"
 
 # Setup iris_examples and separate dependencies first
 git_download autosubst
-git_download iris_string_ident
 git_download iris_examples
 
 # Extract required version of Iris (avoiding "+" which does not work on MacOS :( *)
@@ -30,9 +29,6 @@ git_download stdpp
 
 # Build autosubst
 ( cd "${CI_BUILD_DIR}/autosubst" && make && make install )
-
-# Build iris-string-ident
-( cd "${CI_BUILD_DIR}/iris_string_ident" && make && make install )
 
 # Build Iris examples
 ( cd "${CI_BUILD_DIR}/iris_examples" && make && make install )


### PR DESCRIPTION
CI will probably be broken until this is merged.