### PR TITLE
[plugins] Support for a findlib-based loader

### DIFF
--- a/theories/Init/Ltac.v
+++ b/theories/Init/Ltac.v
@@ -8,6 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-Declare ML Module "ltac_plugin".
+Declare Findlib Module "coq.plugins.ltac".
 
 Export Set Default Proof Mode "Classic".

--- a/tools/coqdep_common.ml
+++ b/tools/coqdep_common.ml
@@ -344,7 +344,7 @@ let rec find_dependencies basename =
                   if verbose && not (is_in_coqlib ?from str) then
                   warning_module_notfound from f str
               end) strl
-        | Declare sl ->
+        | Declare { findlib = false; libraries = sl } ->
             let declare suff dir s =
               let base = escape (file_name s dir) in
               match !option_dynlink with
@@ -369,6 +369,11 @@ let rec find_dependencies basename =
                 end
                 in
               List.iter decl sl
+        | Declare { findlib = true; libraries = sl } ->
+          (* XXX TODO: Call to finlib to locate the file, think a bit
+             about the interaction with current dune build mode tho,
+             it is not clear that dune will setup findlib properly ! *)
+          ()
         | Load str ->
             let str = Filename.basename str in
             if should_visit_v_and_mark None [str] then begin

--- a/tools/coqdep_lexer.mli
+++ b/tools/coqdep_lexer.mli
@@ -12,7 +12,7 @@ type qualid = string list
 
 type coq_token =
   | Require of qualid option * qualid list
-  | Declare of string list
+  | Declare of { findlib : bool; libraries: string list }
   | Load of string
   | AddLoadPath of string
   | AddRecLoadPath of string * qualid

--- a/vernac/dune
+++ b/vernac/dune
@@ -4,6 +4,6 @@
  (public_name coq-core.vernac)
  (wrapped false)
  (private_modules comProgramFixpoint egramcoq)
- (libraries tactics parsing))
+ (libraries findlib.dynload tactics parsing))
 
 (coq.pp (modules g_proofs g_vernac))

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -900,7 +900,7 @@ GRAMMAR EXTEND Gram
       | IDENT "Declare"; IDENT "ML"; IDENT "Module"; l = LIST1 ne_string ->
           { VernacDeclareMLModule { loader = CoqLoader ; modules = l } }
 
-      | IDENT "Require"; IDENT "ML"; IDENT "Module"; l = LIST1 ne_string ->
+      | IDENT "Declare"; IDENT "Findlib"; IDENT "Module"; l = LIST1 ne_string ->
           { VernacDeclareMLModule { loader = Findlib ; modules = l } }
 
       | IDENT "Locate"; l = locatable -> { VernacLocate l }

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -898,7 +898,10 @@ GRAMMAR EXTEND Gram
         s = [ s = ne_string -> { s } | s = IDENT -> { s } ] ->
           { VernacLoad (verbosely, s) }
       | IDENT "Declare"; IDENT "ML"; IDENT "Module"; l = LIST1 ne_string ->
-          { VernacDeclareMLModule l }
+          { VernacDeclareMLModule { loader = CoqLoader ; modules = l } }
+
+      | IDENT "Require"; IDENT "ML"; IDENT "Module"; l = LIST1 ne_string ->
+          { VernacDeclareMLModule { loader = Findlib ; modules = l } }
 
       | IDENT "Locate"; l = locatable -> { VernacLocate l }
 

--- a/vernac/mltop.mli
+++ b/vernac/mltop.mli
@@ -62,10 +62,21 @@ val declare_cache_obj : (unit -> unit) -> string -> unit
 
 (** {5 Declaring modules} *)
 
+(** [declare_ml_modules mods] Load dynamically modules [mods] calling
+   low-level [Dynlink] API, cmxs/cma files are searched in the path
+   specified with add_ml_dir . [mods] are a string such that
+   [mod.cmxs] is the expected object file. Note this is a simple
+   wrapper over [Dynlink] thus no dependency or double-loading are, in
+   principle handled. *)
 val declare_ml_modules : Vernacexpr.locality_flag -> string list -> unit
+
+(** [load_plugins fl_name] load dynamically a plugin with findlib name
+   [fl_name] using [Fl_dynload]. Findlib will handle locating, and
+   loading the dependencies for the plugin, so the plugin should
+   install a META file and be in scope. *)
+val load_plugins : local:Vernacexpr.locality_flag -> string list -> unit
 
 (** {5 Utilities} *)
 
-val print_ml_path : unit -> Pp.t
-val print_ml_modules : unit -> Pp.t
-val print_gc : unit -> Pp.t
+val print_ml_path : unit -> Pp.t val print_ml_modules : unit -> Pp.t
+   val print_gc : unit -> Pp.t

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -1065,9 +1065,13 @@ let pr_vernac_expr v =
       ++ keyword "ML Path"
       ++ qs s
     )
-  | VernacDeclareMLModule (l) ->
+  | VernacDeclareMLModule { loader; modules } ->
     return (
-      hov 2 (keyword "Declare ML Module" ++ spc() ++ prlist_with_sep sep qs l)
+      let require_type = function
+        | CoqLoader -> keyword "Declare ML Module"
+        | Findlib -> keyword "Require ML Module"
+      in
+      hov 2 (require_type loader ++ spc() ++ prlist_with_sep sep qs modules)
     )
   | VernacChdir s ->
     return (keyword "Cd" ++ pr_opt qs s)

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -301,6 +301,8 @@ type reference_or_constr =
   | HintsReference of Libnames.qualid
   | HintsConstr of Constrexpr.constr_expr
 
+type ml_loader = CoqLoader | Findlib
+
 type hints_expr =
   | HintsResolve of (hint_info_expr * bool * reference_or_constr) list
   | HintsResolveIFF of bool * Libnames.qualid list * int option
@@ -391,7 +393,7 @@ type nonrec vernac_expr =
 
   | VernacRemoveLoadPath of string
   | VernacAddMLPath of string
-  | VernacDeclareMLModule of string list
+  | VernacDeclareMLModule of { loader : ml_loader; modules : string list }
   | VernacChdir of string option
 
   (* State management *)


### PR DESCRIPTION
We introduce new syntax
```
Require ML Module pkg1 ... pkgn.
```
that uses findlib to locate and load a Coq plugin and its dependencies.

This makes feasible to actually develop Coq plugins that depend on
OCaml libraries not linked into the Coq main binaries without hitting
problems.

Fixes #5028, fixes #7698 .

This provides a workaround for #12607 , and helps with #9547 .
