### PR TITLE
[coqdep] error on non-existent and unreadable files

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -893,7 +893,7 @@ PLUGININCLUDES=$(addprefix -I plugins/, $(PLUGINDIRS))
 
 $(VDFILE).d: $(D_DEPEND_BEFORE_SRC) $(VFILES) $(D_DEPEND_AFTER_SRC) $(COQDEPBOOT)
 	$(SHOW)'COQDEP    VFILES'
-	$(HIDE)$(COQDEPBOOT) -vos -boot $(DYNDEP) -R theories Coq -R plugins Coq -Q user-contrib "" $(PLUGININCLUDES) $(USERCONTRIBINCLUDES) $(VFILES) $(TOTARGET)
+	$(HIDE)$(COQDEPBOOT) -boot $(DYNDEP) -R theories Coq -R plugins Coq -Q user-contrib "" $(PLUGININCLUDES) $(USERCONTRIBINCLUDES) $(VFILES) $(TOTARGET)
 
 ###########################################################################
 

--- a/doc/changelog/08-cli-tools/14024-coqdep-errors.rst
+++ b/doc/changelog/08-cli-tools/14024-coqdep-errors.rst
@@ -1,0 +1,8 @@
+- **Changed:**
+  ``coqdep`` now reports an error if files specified on the
+  command line don't exist or if it encounters unreadable files.
+  Unknown options now generate a warning. Previously these
+  conditions were ignored.
+  (`#14024 <https://github.com/coq/coq/pull/14024>`_,
+  fixes `#14023 <https://github.com/coq/coq/issues/14023>`_,
+  by Hendrik Tews).

--- a/man/coqdep.1
+++ b/man/coqdep.1
@@ -70,6 +70,21 @@ Output dependencies for .vos files (this is not the default as it breaks dune's 
 .B \-boot
 For coq developers, prints dependencies over coq library files
 (omitted by default).
+.TP
+.B \-noinit
+Currently no effect.
+
+
+.SH EXIT STATUS
+.IP "1"
+A file given on the command line cannot be found or some file
+cannot be opened.
+.IP "0"
+In all other cases. In particular, when a dependency cannot be
+found or an invalid option is encountered,
+.B coqdep
+prints a warning and exits with status
+.B 0\fR.
 
 
 .SH SEE ALSO

--- a/tools/coqdep.ml
+++ b/tools/coqdep.ml
@@ -34,7 +34,8 @@ let usage () =
   eprintf "  -boot : For coq developers, prints dependencies over coq library files (omitted by default).\n";
   eprintf "  -sort : output the given file name ordered by dependencies\n";
   eprintf "  -noglob | -no-glob : \n";
-  eprintf "  -f file : read -I, -Q, -R and filenames from _CoqProject-formatted FILE.";
+  eprintf "  -noinit : currently no effect\n";
+  eprintf "  -f file : read -I, -Q, -R and filenames from _CoqProject-formatted FILE.\n";
   eprintf "  -I dir : add (non recursively) dir to ocaml path\n";
   eprintf "  -R dir logname : add and import dir recursively to coq load path under logical name logname\n";
   eprintf "  -Q dir logname : add (recursively) and open (non recursively) dir to coq load path under logical name logname\n";
@@ -64,6 +65,7 @@ let rec parse = function
   | "-sort" :: ll -> option_sort := true; parse ll
   | "-vos" :: ll -> write_vos := true; parse ll
   | ("-noglob" | "-no-glob") :: ll -> option_noglob := true; parse ll
+  | "-noinit" :: ll -> (* do nothing *) parse ll
   | "-f" :: f :: ll -> treat_coqproject f; parse ll
   | "-I" :: r :: ll -> add_caml_dir r; parse ll
   | "-I" :: [] -> usage ()
@@ -80,6 +82,8 @@ let rec parse = function
   | "-dyndep" :: "both" :: ll -> option_dynlink := Both; parse ll
   | "-dyndep" :: "var" :: ll -> option_dynlink := Variable; parse ll
   | ("-h"|"--help"|"-help") :: _ -> usage ()
+  | opt :: ll when String.length opt > 0 && opt.[0] = '-' ->
+     coqdep_warning "unknown option %s" opt; parse ll
   | f :: ll -> treat_file None f; parse ll
   | [] -> ()
 


### PR DESCRIPTION
Print an error message and return non-zero status in these cases.

**Kind:** bug fix
Fixes #14023
