### PR TITLE
[build] Make the dune-based build system the default for developers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,8 @@ jobs:
         run: |
           eval $(opam env)
           ./configure -prefix "$(pwd)/_install_ci" -warn-error yes -native-compiler no -coqide opt
-          make -j "$NJOBS" byte
-          make -j "$NJOBS"
+          make -f Makefile.make -j "$NJOBS" byte
+          make -f Makefile.make -j "$NJOBS"
         env:
           MACOSX_DEPLOYMENT_TARGET: "10.11"
           NJOBS: "2"
@@ -93,12 +93,12 @@ jobs:
       - name: Install Coq
         run: |
           eval $(opam env)
-          make install install-byte
+          make -f Makefile.make install install-byte
 
       - name: Run Coq Test Suite
         run: |
           eval $(opam env)
           export OCAMLPATH="$(pwd)/_install_ci/lib":"$OCAMLPATH"
-          make -j "$NJOBS" test-suite PRINT_LOGS=1
+          make -f Makefile.make -j "$NJOBS" test-suite PRINT_LOGS=1
         env:
           NJOBS: "2"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,7 +84,7 @@ before_script:
     - set -e
 
     - echo 'start:coq.clean'
-    - make clean # ensure that `make clean` works on a fresh clone
+    - make -f Makefile.make clean # ensure that `make clean` works on a fresh clone
     - echo 'end:coq.clean'
 
     - echo 'start:coq.config'
@@ -92,11 +92,11 @@ before_script:
     - echo 'end:coq.config'
 
     - echo 'start:coq.build'
-    - make -j "$NJOBS" world $EXTRA_TARGET
+    - make -f Makefile.make -j "$NJOBS" world $EXTRA_TARGET
     - echo 'end:coq:build'
 
     - echo 'start:coq.install'
-    - make install $EXTRA_INSTALL
+    - make -f Makefile.make install $EXTRA_INSTALL
     - echo 'end:coq.install'
 
     - set +e
@@ -114,7 +114,7 @@ before_script:
     # and https://github.com/coq/coq/pull/11916#issuecomment-609977375
     - ulimit -s 16384
     - set -e
-    - make -f Makefile.dune world
+    - make world
     - set +e
     - tar cfj _build.tar.bz2 _build
   variables:
@@ -140,7 +140,7 @@ before_script:
     - tar xfj _build.tar.bz2
     - set -e
     - echo 'start:coq.test'
-    - make -f Makefile.dune "$DUNE_TARGET"
+    - make "$DUNE_TARGET"
     - echo 'end:coq.test'
     - set +e
   variables:
@@ -166,8 +166,8 @@ before_script:
     - not-a-real-job
   script:
     - SPHINXENV='COQBIN="'"$PWD"'/_install_ci/bin/"'
-    - make -j "$NJOBS" SPHINXENV="$SPHINXENV" SPHINX_DEPS= refman
-    - make install-doc-sphinx
+    - make -f Makefile.make -j "$NJOBS" SPHINXENV="$SPHINXENV" SPHINX_DEPS= refman
+    - make -f Makefile.make install-doc-sphinx
   artifacts:
     name: "$CI_JOB_NAME"
     paths:
@@ -523,7 +523,7 @@ test-suite:edge:dune:dev:
     - build:edge+flambda:dune:dev
   script:
     - tar xfj _build.tar.bz2
-    - make -f Makefile.dune test-suite
+    - make test-suite
   variables:
     OPAM_SWITCH: edge
     OPAM_VARIANT: "+flambda"
@@ -550,7 +550,7 @@ test-suite:edge:dune:dev:
     - opam install dune zarith
     - eval $(opam env)
     - export COQ_UNIT_TEST=noop
-    - make -f Makefile.dune test-suite
+    - make test-suite
   variables:
     OPAM_SWITCH: base
   artifacts:
@@ -840,7 +840,7 @@ plugin:plugin-tutorial:
   interruptible: true
   script:
     - ./configure -profile devel -warn-error yes
-    - make -j "$NJOBS" plugin-tutorial
+    - make -f Makefile.make -j "$NJOBS" plugin-tutorial
 
 plugin:ci-quickchick:
   extends: .ci-template-flambda

--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,5 @@
 ##         #     (see LICENSE file for the text of the license)         ##
 ##########################################################################
 
-# The default build system is make-based one.
-ifndef COQ_USE_DUNE
-include Makefile.make
-else
-ifdef OPAM_PACKAGE_NAME # installing through opam: ignore COQ_USE_DUNE
-include Makefile.make
-else
+# The default build system is the dune-based one.
 include Makefile.dune
-endif
-endif

--- a/default.nix
+++ b/default.nix
@@ -90,6 +90,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  makefile = "Makefile.make";
+
   buildFlags = [ "world" "byte" ] ++ optional buildDoc "doc-html";
 
   installTargets =

--- a/dev/README.md
+++ b/dev/README.md
@@ -32,7 +32,7 @@
 
 
 ## Documentation of ML interfaces using `odoc` ( `_build/default/_doc`)
-`make -f Makefile.dune apidoc` in coq root directory.
+`make apidoc` in coq root directory.
 
 ## Other development tools (`dev/tools`)
 

--- a/dev/doc/INSTALL.make.md
+++ b/dev/doc/INSTALL.make.md
@@ -2,8 +2,8 @@ Quick Installation Procedure using Make.
 ----------------------------------------
 
     $ ./configure
-    $ make world
-    $ make install (you may need superuser rights)
+    $ make -f Makefile.make world
+    $ make -f Makefile.make install (you may need superuser rights)
 
 Detailed Installation Procedure.
 --------------------------------

--- a/dev/doc/build-system.dune.md
+++ b/dev/doc/build-system.dune.md
@@ -20,14 +20,14 @@ need an explicit `-f Makefile.make` if you want to use one of the
 legacy targets.
 
 It is strongly recommended that you use the helper targets available
-in `Makefile.dune`, `make -f Makefile.dune` will display help. Note
-that dune will call configure for you if needed, so no need to call
-`./configure` in the regular development workflow.
+in `Makefile.dune`, `make` will display help. Note that dune will call
+configure for you if needed, so no need to call `./configure` in the
+regular development workflow.
 
 4 common operations targets are:
 
-- `make -f Makefile.dune check` : build all ml targets as fast as possible
-- `make -f Makefile.dune world` : build a complete Coq distribution
+- `make check` : build all ml targets as fast as possible
+- `make world` : build a complete Coq distribution
 - `dune exec -- dev/shim/coqtop-prelude` : build and launch coqtop + prelude [equivalent to `make states`].
 - `dune build $target`: where `$target` can refer to the build
   directory or the source directory [but will be placed under


### PR DESCRIPTION
Recent experiences plus #13617 have shown that it could be a good idea
to actually default to the dune-based build system for developers.

Workflow is a bit different, but I find it _much_ superior and faster,
at least for all my use cases. YMMV.

Main reasons developers do still need to use the make-based system are:

- documentation? Not sure about this one, but should be easy to fix
- different vo compilation modes, dune doesn't indeed understand
  native, vok, and vio targets. I am not sure if these targets are
  used in development [outside of the test suite, where they are
  properly tested].

  Native will be fixed as soon as we get coqnative, there is also
  support for it in more recent versions of dune, see PR.

  vok support is also planned, see corresponding upstream PR

Reasons developers may want to use dune are many, ranging from speed to soundness.

Closes #7208
