### PR TITLE
[zify] add support for Nat.div, Nat.mod, Nat.pow

### DIFF
--- a/doc/changelog/04-tactics/14037-N-Z-div-mod.rst
+++ b/doc/changelog/04-tactics/14037-N-Z-div-mod.rst
@@ -1,0 +1,7 @@
+- **Added:**
+  ``zify`` (``lia``/``nia``) support for :g:`div`, :g:`mod`, :g:`pow`
+  for :g:`Nat` (via ``ZifyNat`` module) and :g:`N` (via ``ZifyN`` module).
+  The signature of :g:`Z_div_mod_eq_full` has no assumptions.
+  (`#14037 <https://github.com/coq/coq/pull/14037>`_,
+  fixes `#11447 <https://github.com/coq/coq/issues/11447>`_,
+  by Andrej Dudenhefner, Jason Gross, and Frédéric Besson).

--- a/doc/sphinx/addendum/micromega.rst
+++ b/doc/sphinx/addendum/micromega.rst
@@ -284,6 +284,8 @@ obtain :math:`-1`. By Theorem :ref:`Psatz <psatz_thm>`, the goal is valid.
    + For boolean operators (e.g., :g:`Nat.leb`), require the module :g:`ZifyBool`.
    + For comparison operators (e.g., :g:`Z.compare`), require the module :g:`ZifyComparison`.
    + For native 63 bit integers, require the module :g:`ZifyInt63`.
+   + For operators :g:`Nat.div`, :g:`Nat.mod`, and :g:`Nat.pow`, require the module :g:`ZifyNat`.
+   + For operators :g:`N.div`, :g:`N.mod`, and :g:`N.pow`, require the module :g:`ZifyN`.
 
    :tacn:`zify` can also be extended by rebinding the tactics `Zify.zify_pre_hook` and `Zify.zify_post_hook` that are
    respectively run in the first and the last steps of :tacn:`zify`.

--- a/doc/stdlib/hidden-files
+++ b/doc/stdlib/hidden-files
@@ -52,6 +52,8 @@ theories/micromega/ZMicromega.v
 theories/micromega/ZifyInst.v
 theories/micromega/ZifyBool.v
 theories/micromega/ZifyInt63.v
+theories/micromega/ZifyNat.v
+theories/micromega/ZifyN.v
 theories/micromega/ZifyComparison.v
 theories/micromega/ZifyClasses.v
 theories/micromega/ZifyPow.v

--- a/test-suite/micromega/div_mod.v
+++ b/test-suite/micromega/div_mod.v
@@ -1,0 +1,35 @@
+Require Import ZArith Lia ZifyNat.
+
+(* regression observed in PR 14037 *)
+Goal forall (n:nat), n mod 2 < 2 -> n mod 2 = 0 \/ n mod 2 = 1.
+Proof. lia. Qed.
+
+(* regression observed in PR 14037 *)
+Goal forall (n:nat), n / 2 < 2 -> n / 2 = 0 \/ n / 2 = 1.
+Proof. lia. Qed.
+
+Goal forall (n:nat), n mod 2 = 0 \/ n mod 2 = 1.
+Proof. lia. Qed.
+
+Goal forall (n:nat), n / 2 < 2 -> n / 2 = 0 \/ n / 2 = 1.
+Proof. lia. Qed.
+
+Goal forall (n:nat), (n * 3) mod 3 = 0.
+Proof. lia. Qed.
+
+Goal forall (n:nat), (n * 3) / 3 = n.
+Proof. lia. Qed.
+
+Goal forall (m n:nat), m > 0 -> (n * m) / m = n.
+Proof. nia. Qed.
+
+(* just nia is not strong enough in 8.14 *)
+Goal forall (m n:nat), m > 0 -> (n * m) mod m = 0.
+Proof.
+  Fail nia. (* if this suceeds, please update test *)
+  intros.
+  cut ((n * m) / m = n); nia.
+Qed.
+
+Goal forall (n m:nat), 1 <= (1+n)^m.
+Proof. lia. Qed.

--- a/test-suite/stm/Nijmegen_QArithSternBrocot_Zaux.v
+++ b/test-suite/stm/Nijmegen_QArithSternBrocot_Zaux.v
@@ -2983,8 +2983,7 @@ Proof.
  intros.
  apply Zplus_minus_eq.
  rewrite Zplus_comm.
- apply Z_div_mod_eq.
- Flip.
+ apply Z_div_mod_eq_full.
 Qed.
 
 Lemma Z_div_le :
@@ -3006,7 +3005,7 @@ Qed.
 Lemma Z_div_neg : forall a b : Z, (0 < b)%Z -> (a < 0)%Z -> (a / b < 0)%Z.
 Proof.
  intros.
- rewrite (Z_div_mod_eq a b) in H0.
+ rewrite (Z_div_mod_eq_full a b) in H0.
  elim (Z_mod_lt a b).
  intros H1 _.
  apply Znot_ge_lt.
@@ -3017,7 +3016,6 @@ Proof.
  apply Zlt_le_weak; assumption.
  Flip.
  assumption.
- Flip.
  Flip.
 Qed.
 

--- a/theories/Arith/PeanoNat.v
+++ b/theories/Arith/PeanoNat.v
@@ -380,6 +380,11 @@ Proof.
  now rewrite mul_0_r, sub_diag, !add_0_r in U.
 Qed.
 
+Lemma div_mod_eq x y : x = y*(x/y) + x mod y.
+Proof.
+  destruct y as [|y]; [reflexivity|now apply div_mod].
+Qed.
+
 Lemma mod_bound_pos x y : 0<=x -> 0<y -> 0 <= x mod y < y.
 Proof.
  intros Hx Hy. split. apply le_0_l.

--- a/theories/NArith/Nnat.v
+++ b/theories/NArith/Nnat.v
@@ -39,6 +39,9 @@ Qed.
 
 (** Interaction of this translation and usual operations. *)
 
+Lemma inj_0 : N.to_nat 0 = 0.
+Proof. reflexivity. Qed.
+
 Lemma inj_double a : N.to_nat (N.double a) = 2*(N.to_nat a).
 Proof.
  destruct a; simpl N.to_nat; trivial. apply Pos2Nat.inj_xO.
@@ -99,6 +102,33 @@ Proof.
  - apply Pos2Nat.inj_compare.
 Qed.
 
+Lemma inj_div n m :
+  N.to_nat (n / m) = N.to_nat n / N.to_nat m.
+Proof.
+  destruct m as [|m]; [now destruct n|].
+  apply Nat.div_unique with (N.to_nat (n mod (N.pos m))).
+  - apply Nat.compare_lt_iff. rewrite <- inj_compare.
+    now apply N.mod_lt.
+  - now rewrite <- inj_mul, <- inj_add, <- N.div_mod.
+Qed.
+
+Lemma inj_mod a a' :
+  N.to_nat (a mod a') = N.to_nat a mod N.to_nat a'.
+Proof.
+  destruct a' as [|a']; [now destruct a|].
+  apply Nat.mod_unique with (N.to_nat (a / (N.pos a'))).
+  - apply Nat.compare_lt_iff. rewrite <- inj_compare.
+    now apply N.mod_lt.
+  - now rewrite <- inj_mul, <- inj_add, <- N.div_mod.
+Qed.
+
+Lemma inj_pow a a' :
+  N.to_nat (a ^ a') = N.to_nat a ^ N.to_nat a'.
+Proof.
+  destruct a, a'; [easy| |easy|apply Pos2Nat.inj_pow].
+  now rewrite N.pow_0_l, Nat.pow_0_l; [|rewrite <- inj_0; intros ? %inj|].
+Qed.
+
 Lemma inj_max a a' :
   N.to_nat (N.max a a') = Nat.max (N.to_nat a) (N.to_nat a').
 Proof.
@@ -127,7 +157,8 @@ Qed.
 
 End N2Nat.
 
-Global Hint Rewrite N2Nat.inj_double N2Nat.inj_succ_double
+Global Hint Rewrite N2Nat.inj_div N2Nat.inj_mod N2Nat.inj_pow
+ N2Nat.inj_double N2Nat.inj_succ_double
  N2Nat.inj_succ N2Nat.inj_add N2Nat.inj_mul N2Nat.inj_sub
  N2Nat.inj_pred N2Nat.inj_div2 N2Nat.inj_max N2Nat.inj_min
  N2Nat.id
@@ -192,6 +223,18 @@ Lemma inj_compare n n' :
   (n ?= n') = (N.of_nat n ?= N.of_nat n')%N.
 Proof. now rewrite N2Nat.inj_compare, !id. Qed.
 
+Lemma inj_div n n' :
+  N.of_nat (n / n') = (N.of_nat n / N.of_nat n')%N.
+Proof. nat2N. Qed.
+
+Lemma inj_mod n n' :
+  N.of_nat (n mod n') = (N.of_nat n mod N.of_nat n')%N.
+Proof. nat2N. Qed.
+
+Lemma inj_pow n n' :
+  N.of_nat (n ^ n') = (N.of_nat n ^ N.of_nat n')%N.
+Proof. nat2N. Qed.
+
 Lemma inj_min n n' :
   N.of_nat (Nat.min n n') = N.min (N.of_nat n) (N.of_nat n').
 Proof. nat2N. Qed.
@@ -221,6 +264,9 @@ Notation nat_of_Nminus := N2Nat.inj_sub (only parsing).
 Notation nat_of_Npred := N2Nat.inj_pred (only parsing).
 Notation nat_of_Ndiv2 := N2Nat.inj_div2 (only parsing).
 Notation nat_of_Ncompare := N2Nat.inj_compare (only parsing).
+Notation nat_of_Ndiv := N2Nat.inj_div (only parsing).
+Notation nat_of_Nmod := N2Nat.inj_mod (only parsing).
+Notation nat_of_Npow := N2Nat.inj_pow (only parsing).
 Notation nat_of_Nmax := N2Nat.inj_max (only parsing).
 Notation nat_of_Nmin := N2Nat.inj_min (only parsing).
 
@@ -235,5 +281,8 @@ Notation N_of_minus := Nat2N.inj_sub (only parsing).
 Notation N_of_mult := Nat2N.inj_mul (only parsing).
 Notation N_of_div2 := Nat2N.inj_div2 (only parsing).
 Notation N_of_nat_compare := Nat2N.inj_compare (only parsing).
+Notation N_of_nat_div := Nat2N.inj_div (only parsing).
+Notation N_of_nat_mod := Nat2N.inj_mod (only parsing).
+Notation N_of_nat_pow := Nat2N.inj_pow (only parsing).
 Notation N_of_min := Nat2N.inj_min (only parsing).
 Notation N_of_max := Nat2N.inj_max (only parsing).

--- a/theories/Numbers/Cyclic/Int31/Cyclic31.v
+++ b/theories/Numbers/Cyclic/Int31/Cyclic31.v
@@ -1378,14 +1378,14 @@ Section Int31_Specs.
  assert (forall z, (z / wB) mod wB * wB + z mod wB = z mod wB ^ 2).
   intros.
   assert ((z/wB) mod wB = z/wB - (z/wB/wB)*wB).
-   rewrite (Z_div_mod_eq (z/wB) wB wB_pos) at 2; ring.
+   rewrite (Z_div_mod_eq_full (z/wB) wB) at 2; ring.
   assert (z mod wB = z - (z/wB)*wB).
-   rewrite (Z_div_mod_eq z wB wB_pos) at 2; ring.
+   rewrite (Z_div_mod_eq_full z wB) at 2; ring.
   rewrite H.
   rewrite H0 at 1.
   ring_simplify.
   rewrite Zdiv_Zdiv; auto with zarith.
-  rewrite (Z_div_mod_eq z (wB*wB)) at 2; auto with zarith.
+  rewrite (Z_div_mod_eq_full z (wB*wB)) at 2.
   change (wB*wB) with (wB^2); ring.
 
  unfold phi_inv2.
@@ -1948,7 +1948,7 @@ Section Int31_Specs.
  intros Hi Hj.
  assert (Hij: 0 <= i/j) by (apply Z_div_pos; auto with zarith).
  apply Z.lt_le_trans with (2 := sqrt_main_trick _ _ (Z.lt_le_incl _ _ Hj) Hij).
- pattern i at 1; rewrite (Z_div_mod_eq i j); case (Z_mod_lt i j); auto with zarith.
+ pattern i at 1; rewrite (Z_div_mod_eq_full i j); case (Z_mod_lt i j); auto with zarith.
  Qed.
 
  Lemma sqrt_init i: 1 < i -> i < (i/2 + 1) ^ 2.

--- a/theories/Numbers/Cyclic/Int63/Int63.v
+++ b/theories/Numbers/Cyclic/Int63/Int63.v
@@ -214,39 +214,16 @@ Proof. apply Z.div_lt_upper_bound; reflexivity. Qed.
 
 Theorem Zmod_le_first a b : 0 <= a -> 0 < b -> 0 <= a mod b <= a.
 Proof.
-  intros ha hb; case (Z_mod_lt a b); [ auto with zarith | ]; intros p q; apply (conj p).
-  case (Z.le_gt_cases b a). lia.
-  intros hlt; rewrite Zmod_small; lia.
+  intros. now split; [apply Z.mod_bound_pos|apply Z.mod_le].
 Qed.
 
 Theorem Zmod_distr: forall a b r t, 0 <= a <= b -> 0 <= r -> 0 <= t < 2 ^a ->
   (2 ^a * r + t) mod (2 ^ b) = (2 ^a * r) mod (2 ^ b) + t.
 Proof.
-  intros a b r t (H1, H2) H3 (H4, H5).
-  assert (t < 2 ^ b).
-  apply Z.lt_le_trans with (1:= H5); auto with zarith.
-  apply Zpower_le_monotone; auto with zarith.
-  rewrite Zplus_mod; auto with zarith.
-  rewrite -> (Zmod_small t); auto with zarith.
-  apply Zmod_small; auto with zarith.
-  split; auto with zarith.
-  assert (0 <= 2 ^a * r); auto with zarith.
-  apply Z.add_nonneg_nonneg; auto with zarith.
-  match goal with |- context [?X mod ?Y] => case (Z_mod_lt X Y) end;
-   auto with zarith.
-  pattern (2 ^ b) at 2; replace (2 ^ b) with ((2 ^ b - 2 ^a) + 2 ^ a);
-    try ring.
-  apply Z.add_le_lt_mono; auto with zarith.
-  replace b with ((b - a) + a); try ring.
-  rewrite Zpower_exp; auto with zarith.
-  pattern (2 ^a) at 4; rewrite <- (Z.mul_1_l (2 ^a));
-   try rewrite <- Z.mul_sub_distr_r.
-  rewrite (Z.mul_comm (2 ^(b - a))); rewrite  Zmult_mod_distr_l;
-   auto with zarith.
-  rewrite (Z.mul_comm (2 ^a)); apply Z.mul_le_mono_nonneg_r; auto with zarith.
-  match goal with |- context [?X mod ?Y] => case (Z_mod_lt X Y) end.
-    apply Z.lt_gt; auto with zarith.
-    auto with zarith.
+  intros a b r t ? ? ?.
+  replace (2^b) with (2^a * 2^(b-a)) by (rewrite <-Zpower_exp; [f_equal| |]; lia).
+  assert (0 < 2 ^ (b - a)) by (apply Z.pow_pos_nonneg; lia).
+  rewrite Z.add_mul_mod_distr_l, <- Z.mul_mod_distr_l; lia.
 Qed.
 
 (* Results about pow2 *)
@@ -835,7 +812,7 @@ Proof.
    case (to_Z_bounded (digits -1)); auto with zarith.
  assert (H: φ (i << (digits -1)) = (φ i mod 2 * 2^ φ (digits -1))%Z).
  rewrite lsl_spec.
- rewrite -> (Z_div_mod_eq φ i 2) at 1; auto with zarith.
+ rewrite -> (Z_div_mod_eq_full φ i 2) at 1.
  rewrite -> Zmult_plus_distr_l, <-Zplus_mod_idemp_l.
  rewrite -> (Zmult_comm 2), <-Zmult_assoc.
  replace (2 * 2 ^ φ (digits - 1))%Z with wB; auto.
@@ -860,7 +837,7 @@ Proof.
  apply to_Z_inj.
  rewrite -> add_spec, lsl_spec, lsr_spec, bit_0_spec, Zplus_mod_idemp_l.
  replace (2 ^ φ 1) with 2%Z; auto with zarith.
- rewrite -> Zmult_comm, <-Z_div_mod_eq; auto with zarith.
+ rewrite -> Zmult_comm, <-Z_div_mod_eq_full.
  rewrite Zmod_small; auto; case (to_Z_bounded i); auto.
 Qed.
 
@@ -999,7 +976,7 @@ Proof.
  rewrite -> Zpower_exp; auto with zarith.
  rewrite -> Zdiv_mult_cancel_r.
    2: generalize (Zpower2_lt_lin φ  i  H1i); auto with zarith.
- rewrite -> (Z_div_mod_eq φ x (2^d1)) at 2; auto with zarith.
+ rewrite -> (Z_div_mod_eq_full φ x (2^d1)) at 2.
  pattern d1 at 2;
    replace d1 with (d2 + (1+ (d - φ j - 1)))%Z
    by (unfold d1, d2; ring).
@@ -1241,7 +1218,7 @@ Proof.
  intros Hi Hj.
  assert (Hij: 0 <= i/j) by (apply Z_div_pos; auto with zarith).
  refine (Z.lt_le_trans _ _ _ _ (sqrt_main_trick _ _ (Zlt_le_weak _ _ Hj) Hij)).
- pattern i at 1; rewrite -> (Z_div_mod_eq i j); case (Z_mod_lt i j); auto with zarith.
+ pattern i at 1; rewrite -> (Z_div_mod_eq_full i j); case (Z_mod_lt i j); auto with zarith.
 Qed.
 
 Lemma sqrt_test_false i j: 0 <= i -> 0 < j -> i/j < j ->  (j + (i/j))/2 < j.
@@ -1312,7 +1289,7 @@ Proof.
  assert (H1: 0 <= i - 2) by auto with zarith.
  assert (H2: 1 <= (i / 2) ^ 2); auto with zarith.
    replace i with (1* 2 + (i - 2)); auto with zarith.
-   rewrite Z.pow_2_r, Z_div_plus_full_l; auto with zarith.
+   rewrite Z.pow_2_r, Z_div_plus_full_l; [|auto with zarith].
    generalize (sqr_pos ((i - 2)/ 2)) (Z_div_pos (i - 2) 2).
    rewrite Zmult_plus_distr_l; repeat rewrite Zmult_plus_distr_r.
    auto with zarith.

--- a/theories/Numbers/Cyclic/ZModulo/ZModulo.v
+++ b/theories/Numbers/Cyclic/ZModulo/ZModulo.v
@@ -208,7 +208,7 @@ Section ZModulo.
   forall x y z, z>0 -> (x-y) mod z = 0 -> x mod z = y mod z.
  Proof.
  intros.
- generalize (Z_div_mod_eq (x-y) z H); rewrite H0, Z.add_0_r.
+ generalize (Z_div_mod_eq_full (x-y) z); rewrite H0, Z.add_0_r.
  remember ((x-y)/z) as k.
  rewrite Z.sub_move_r, Z.add_comm, Z.mul_comm. intros ->.
  now apply Z_mod_plus.

--- a/theories/Numbers/Integer/Abstract/ZDivFloor.v
+++ b/theories/Numbers/Integer/Abstract/ZDivFloor.v
@@ -660,6 +660,14 @@ Proof.
  auto using mod_bound_or.
 Qed.
 
+Lemma add_mul_mod_distr_l : forall a b c d, 0<=a -> 0<b -> 0<=d<c ->
+ (c*a+d) mod (c*b) == c*(a mod b)+d.
+Proof. intros. apply add_mul_mod_distr_l; assumption. Qed.
+
+Lemma add_mul_mod_distr_r: forall a b c d, 0<=a -> 0<b -> 0<=d<c ->
+ (a*c+d) mod (b*c) == (a mod b)*c+d.
+Proof. intros. apply add_mul_mod_distr_r; assumption. Qed.
+
 (** A last inequality: *)
 
 Theorem div_mul_le:

--- a/theories/Numbers/NatInt/NZDiv.v
+++ b/theories/Numbers/NatInt/NZDiv.v
@@ -414,24 +414,6 @@ Proof.
  intros a b c ? ? ?. rewrite !(mul_comm c); apply div_mul_cancel_r; auto.
 Qed.
 
-Lemma mul_mod_distr_l: forall a b c, 0<=a -> 0<b -> 0<c ->
-  (c*a) mod (c*b) == c * (a mod b).
-Proof.
- intros a b c ? ? ?.
- rewrite <- (add_cancel_l _ _ ((c*b)* ((c*a)/(c*b)))).
- rewrite <- div_mod.
- - rewrite div_mul_cancel_l; auto.
-   rewrite <- mul_assoc, <- mul_add_distr_l, mul_cancel_l by order.
-   apply div_mod; order.
- - rewrite <- neq_mul_0; intuition; order.
-Qed.
-
-Lemma mul_mod_distr_r: forall a b c, 0<=a -> 0<b -> 0<c ->
-  (a*c) mod (b*c) == (a mod b) * c.
-Proof.
- intros a b c ? ? ?. rewrite !(mul_comm _ c); now rewrite mul_mod_distr_l.
-Qed.
-
 (** Operations modulo. *)
 
 Theorem mod_mod: forall a n, 0<=a -> 0<n ->
@@ -522,6 +504,35 @@ Proof.
  rewrite add_assoc, add_shuffle0, <- mul_assoc, <- mul_add_distr_l.
  rewrite <- div_mod by order.
  apply div_mod; order.
+Qed.
+
+Lemma add_mul_mod_distr_l: forall a b c d, 0<=a -> 0<b -> 0<=d<c ->
+ (c*a+d) mod (c*b) == c*(a mod b)+d.
+Proof.
+ intros a b c d ? ? [? ?].
+ assert (0 <= a*c) by (apply mul_nonneg_nonneg; order).
+ assert (0 <= a*c+d) by (apply add_nonneg_nonneg; order).
+ rewrite (mul_comm c a), mod_mul_r, add_mod, mod_mul, div_add_l; [|order ..].
+ now rewrite ? add_0_l, div_small, add_0_r, ? (mod_small d c), (add_comm d).
+Qed.
+
+Lemma add_mul_mod_distr_r: forall a b c d, 0<=a -> 0<b -> 0<=d<c ->
+ (a*c+d) mod (b*c) == (a mod b)*c+d.
+Proof.
+ intros a b c d ? ? ?. now rewrite !(mul_comm _ c), add_mul_mod_distr_l.
+Qed.
+
+Lemma mul_mod_distr_l: forall a b c, 0<=a -> 0<b -> 0<c ->
+  (c*a) mod (c*b) == c * (a mod b).
+Proof.
+ intros a b c ? ? ?. pose proof (E := add_mul_mod_distr_l a b c 0).
+ rewrite ? add_0_r in E. now apply E.
+Qed.
+
+Lemma mul_mod_distr_r: forall a b c, 0<=a -> 0<b -> 0<c ->
+  (a*c) mod (b*c) == (a mod b) * c.
+Proof.
+ intros a b c ? ? ?. now rewrite !(mul_comm _ c), mul_mod_distr_l.
 Qed.
 
 (** A last inequality: *)

--- a/theories/PArith/Pnat.v
+++ b/theories/PArith/Pnat.v
@@ -201,6 +201,14 @@ Proof.
   simpl. f_equal. apply IHp.
 Qed.
 
+Theorem inj_pow p q : to_nat (p ^ q) = to_nat p ^ to_nat q.
+Proof.
+ induction q as [|q IHq] using peano_ind.
+ - now rewrite Pos.pow_1_r, inj_1, Nat.pow_1_r.
+ - unfold Pos.pow. rewrite inj_succ, iter_succ, inj_mul. fold (Pos.pow p q).
+   now rewrite IHq.
+Qed.
+
 End Pos2Nat.
 
 Module Nat2Pos.
@@ -236,6 +244,9 @@ Qed.
 
 (** Usual operations are morphisms with respect to [Pos.of_nat]
     for non-zero numbers. *)
+
+Lemma inj_0 : Pos.of_nat 0 = 1%positive.
+Proof. reflexivity. Qed.
 
 Lemma inj_succ (n:nat) : n<>0 -> Pos.of_nat (S n) = Pos.succ (Pos.of_nat n).
 Proof.
@@ -299,6 +310,15 @@ Proof.
  case Nat.compare_spec; intros H; f_equal;
   apply Nat.max_l || apply Nat.max_r.
  rewrite H; auto. now apply Nat.lt_le_incl. now apply Nat.lt_le_incl.
+Qed.
+
+Theorem inj_pow (n m : nat) : m <> 0 ->
+ Pos.of_nat (n^m) = (Pos.of_nat n ^ Pos.of_nat m)%positive.
+Proof.
+ intros Hm. apply Pos2Nat.inj. rewrite Pos2Nat.inj_pow.
+ destruct n.
+ - now rewrite Nat.pow_0_l, inj_0, Pos2Nat.inj_1, Nat.pow_1_l.
+ - now rewrite !id; [..|apply Nat.pow_nonzero].
 Qed.
 
 End Nat2Pos.

--- a/theories/QArith/Qround.v
+++ b/theories/QArith/Qround.v
@@ -86,7 +86,7 @@ replace (n*1)%Z with n by ring.
 ring_simplify.
 replace (n / Zpos d * Zpos d + Zpos d)%Z with
   ((Zpos d * (n / Zpos d) + n mod Zpos  d) + Zpos  d - n mod Zpos d)%Z by ring.
-rewrite <- Z_div_mod_eq; auto with*.
+rewrite <- Z_div_mod_eq_full.
 rewrite <- Z.lt_add_lt_sub_r.
 destruct (Z_mod_lt n (Zpos d)); auto with *.
 Qed.

--- a/theories/ZArith/Zdiv.v
+++ b/theories/ZArith/Zdiv.v
@@ -23,7 +23,6 @@ Local Open Scope Z_scope.
 Notation Zdiv_eucl_POS := Z.pos_div_eucl (only parsing).
 Notation Zmod := Z.modulo (only parsing).
 
-Notation Z_div_mod_eq_full := Z.div_mod (only parsing).
 Notation Zmod_POS_bound := Z.pos_div_eucl_bound (only parsing).
 Notation Zmod_pos_bound := Z.mod_pos_bound (only parsing).
 Notation Zmod_neg_bound := Z.mod_neg_bound (only parsing).
@@ -108,9 +107,15 @@ Proof (fun Hb => Z.mod_pos_bound a b (Z.gt_lt _ _ Hb)).
 Lemma Z_mod_neg a b : b < 0 -> b < a mod b <= 0.
 Proof (Z.mod_neg_bound a b).
 
+Lemma Z_div_mod_eq_full a b : a = b*(a/b) + (a mod b).
+Proof.
+  now destruct (Z.eq_dec b 0) as [->|?]; [destruct a|apply Z.div_mod].
+Qed.
+
+#[deprecated(since="8.14",note="Z_div_mod_eq_full instead")]
 Lemma Z_div_mod_eq a b : b > 0 -> a = b*(a/b) + (a mod b).
 Proof.
-  intros Hb; apply Z.div_mod; now intros ->.
+  intros. apply Z_div_mod_eq_full.
 Qed.
 
 Lemma Zmod_eq_full a b : b<>0 -> a mod b = a - (a/b)*b.
@@ -236,6 +241,20 @@ Proof. intros. apply Z.div_pos; auto using Z.gt_lt. Qed.
 Lemma Z_div_ge0: forall a b, b > 0 -> a >= 0 -> a/b >=0.
 Proof.
   intros; apply Z.le_ge, Z_div_pos; auto using Z.ge_le.
+Qed.
+
+(* Division of non-negative numbers is non-negative. *)
+
+Lemma Z_div_nonneg_nonneg : forall a b, 0 <= a -> 0 <= b -> 0 <= a / b.
+Proof.
+  intros a b. destruct b; intros; now (rewrite Zdiv_0_r + apply Z_div_pos).
+Qed.
+
+(* Modulo for a non-negative divisor is non-negative. *)
+
+Lemma Z_mod_nonneg_nonneg : forall a b, 0 <= a -> 0 <= b -> 0 <= a mod b.
+Proof.
+  destruct b; intros; now (rewrite Zmod_0_r + apply Z_mod_lt).
 Qed.
 
 (** As soon as the divisor is greater or equal than 2,
@@ -717,26 +736,12 @@ Arguments Zdiv_eucl_extended : default implicits.
 
 (** * Division and modulo in Z agree with same in nat: *)
 
-Require Import PeanoNat.
-
+#[deprecated(since="8.14",note="Use Nat2Z.inj_div instead.")]
 Lemma div_Zdiv (n m: nat): m <> O ->
   Z.of_nat (n / m) = Z.of_nat n / Z.of_nat m.
-Proof.
- intros.
- apply (Zdiv_unique _ _ _ (Z.of_nat (n mod m))).
-  split. auto with zarith.
-  now apply inj_lt, Nat.mod_upper_bound.
- rewrite <- Nat2Z.inj_mul, <- Nat2Z.inj_add.
- now apply inj_eq, Nat.div_mod.
-Qed.
+Proof. intros. apply Nat2Z.inj_div. Qed.
 
+#[deprecated(since="8.14",note="Use Nat2Z.inj_mod instead.")]
 Lemma mod_Zmod (n m: nat): m <> O ->
   Z.of_nat (n mod m) = (Z.of_nat n) mod (Z.of_nat m).
-Proof.
- intros.
- apply (Zmod_unique _ _ (Z.of_nat n / Z.of_nat m)).
-  split. auto with zarith.
-  now apply inj_lt, Nat.mod_upper_bound.
- rewrite <- div_Zdiv, <- Nat2Z.inj_mul, <- Nat2Z.inj_add by trivial.
- now apply inj_eq, Nat.div_mod.
-Qed.
+Proof. intros. apply Nat2Z.inj_mod. Qed.

--- a/theories/ZArith/Znat.v
+++ b/theories/ZArith/Znat.v
@@ -420,10 +420,7 @@ Qed.
 
 Lemma inj_pow n m : 0<=n -> 0<=m -> Z.to_N (n^m) = ((Z.to_N n)^(Z.to_N m))%N.
 Proof.
- destruct m.
- - trivial.
- - intros. now rewrite <- (N2Z.id (_ ^ _)), N2Z.inj_pow, id.
- - now destruct 2.
+ intros Hn Hm. now rewrite <- (N2Z.id (_ ^ _)), N2Z.inj_pow, !id.
 Qed.
 
 Lemma inj_testbit a n : 0<=n ->
@@ -721,6 +718,23 @@ Proof.
  now rewrite <- !nat_N_Z, Nat2N.inj_max, N2Z.inj_max.
 Qed.
 
+Lemma inj_div n m : Z.of_nat (n / m) = Z.of_nat n / Z.of_nat m.
+Proof.
+ destruct m as [|m]; [now destruct n|].
+ now rewrite <- !nat_N_Z, Nat2N.inj_div, N2Z.inj_div.
+Qed.
+
+Lemma inj_mod n m : Z.of_nat (n mod m) = (Z.of_nat n mod Z.of_nat m)%Z.
+Proof.
+ destruct m as [|m]; [now destruct n|].
+ now rewrite <- !nat_N_Z, Nat2N.inj_mod, N2Z.inj_mod.
+Qed.
+
+Lemma inj_pow n m : Z.of_nat (n^m) = (Z.of_nat n)^(Z.of_nat m).
+Proof.
+ now rewrite <- !nat_N_Z, Nat2N.inj_pow, N2Z.inj_pow.
+Qed.
+
 End Nat2Z.
 
 Module Z2Nat.
@@ -816,6 +830,21 @@ Qed.
 Lemma inj_max n m : Z.to_nat (Z.max n m) = Nat.max (Z.to_nat n) (Z.to_nat m).
 Proof.
  now rewrite <- !Z_N_nat, Z2N.inj_max, N2Nat.inj_max.
+Qed.
+
+Lemma inj_div n m : 0<=n -> 0<=m -> Z.to_nat (n / m) = (Z.to_nat n / Z.to_nat m)%nat.
+Proof.
+ intros. now rewrite <- !Z_N_nat, Z2N.inj_div, N2Nat.inj_div.
+Qed.
+
+Lemma inj_mod n m : 0<=n -> 0<=m -> Z.to_nat (n mod m) = (Z.to_nat n mod Z.to_nat m)%nat.
+Proof.
+ intros. now rewrite <- !Z_N_nat, Z2N.inj_mod, N2Nat.inj_mod.
+Qed.
+
+Lemma inj_pow n m : 0 <= n -> 0 <= m -> Z.to_nat (n ^ m) = (Z.to_nat n ^ Z.to_nat m)%nat.
+Proof.
+ intros Hn Hm. now rewrite <- !Z_N_nat, Z2N.inj_pow, N2Nat.inj_pow.
 Qed.
 
 End Z2Nat.
@@ -981,6 +1010,9 @@ Notation inj_minus1 := Nat2Z.inj_sub (only parsing).
 Notation inj_minus := Nat2Z.inj_sub_max (only parsing).
 Notation inj_min := Nat2Z.inj_min (only parsing).
 Notation inj_max := Nat2Z.inj_max (only parsing).
+Notation inj_div := Nat2Z.inj_div (only parsing).
+Notation inj_mod := Nat2Z.inj_mod (only parsing).
+Notation inj_pow := Nat2Z.inj_pow (only parsing).
 
 Notation Z_of_nat_of_P := positive_nat_Z (only parsing).
 Notation Zpos_eq_Z_of_nat_o_nat_of_P :=

--- a/theories/ZArith/Znumtheory.v
+++ b/theories/ZArith/Znumtheory.v
@@ -315,8 +315,7 @@ Section extended_euclid_algorithm.
     replace (u3 - q * x) with (u3 mod x).
     apply Z_mod_lt.
     apply Z.lt_gt, Z.le_neq; auto.
-    assert (xpos : x > 0) by (apply Z.lt_gt, Z.le_neq; auto).
-    generalize (Z_div_mod_eq u3 x xpos).
+    generalize (Z_div_mod_eq_full u3 x).
     unfold q.
     intro eq; pattern u3 at 2; rewrite eq; ring.
     apply (H (u3 - q * x) Hq (proj1 Hq) v1 v2 x (u1 - q * v1) (u2 - q * v2)).
@@ -547,15 +546,14 @@ Proof.
   apply bezout_rel_prime.
   apply Bezout_intro with q1  (r1 + q1 * (p / q)).
   rewrite <- H2.
-  pattern p at 3; rewrite (Z_div_mod_eq p q); try ring.
-  now apply Z.lt_gt.
+  pattern p at 3; rewrite (Z_div_mod_eq_full p q); ring.
 Qed.
 
 Theorem rel_prime_mod_rev: forall p q, 0 < q ->
  rel_prime (p mod q) q -> rel_prime p q.
 Proof.
   intros p q H H0.
-  rewrite (Z_div_mod_eq p q) by now apply Z.lt_gt. red.
+  rewrite (Z_div_mod_eq_full p q). red.
   apply Zis_gcd_sym; apply Zis_gcd_for_euclid2; auto.
 Qed.
 

--- a/theories/ZArith/Zquot.v
+++ b/theories/ZArith/Zquot.v
@@ -417,7 +417,7 @@ Proof.
   apply Zdiv_mod_unique with b.
   apply Zrem_lt_pos; lia.
   rewrite Z.abs_eq by lia. apply Z_mod_lt; lia.
-  rewrite <- Z_div_mod_eq by lia.
+  rewrite <- Z_div_mod_eq_full.
   symmetry; apply Z.quot_rem; lia.
 Qed.
 

--- a/theories/micromega/ZifyInst.v
+++ b/theories/micromega/ZifyInst.v
@@ -202,9 +202,6 @@ Instance Op_pos_succ : UnOp Pos.succ :=
   { TUOp := fun x => x + 1; TUOpInj := Pos2Z.inj_succ  }.
 Add Zify UnOp Op_pos_succ.
 
-
-
-
 #[global]
 Instance Op_pos_pred_double : UnOp Pos.pred_double :=
 { TUOp := fun x => 2 * x - 1; TUOpInj := ltac:(refl) }.

--- a/theories/micromega/ZifyN.v
+++ b/theories/micromega/ZifyN.v
@@ -1,0 +1,58 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(* Instances of [ZifyClasses] for dealing with advanced [N] operators. *)
+
+Require Import BinNat BinInt Znat Zdiv.
+Require Import ZifyClasses ZifyInst Zify.
+
+Ltac zify_convert_to_euclidean_division_equations_flag ::= constr:(true).
+
+(** Support for [N] *)
+
+#[local]
+Existing Instance Inj_N_Z.
+
+#[global]
+Instance Op_N_div : BinOp N.div :=
+  {| TBOp := Z.div ; TBOpInj := N2Z.inj_div |}.
+Add Zify BinOp Op_N_div.
+
+#[global]
+Instance Op_N_mod : BinOp N.modulo :=
+  {| TBOp := Z.rem ; TBOpInj := N2Z.inj_rem |}.
+Add Zify BinOp Op_N_mod.
+
+#[global]
+Instance Op_N_pow : BinOp N.pow :=
+  {| TBOp := Z.pow ; TBOpInj := N2Z.inj_pow|}.
+Add Zify BinOp Op_N_pow.
+
+#[local] Open Scope Z_scope.
+
+#[global]
+Instance SatDiv : Saturate Z.div :=
+  {|
+    PArg1 := fun x => 0 <= x;
+    PArg2 := fun y => 0 <= y;
+    PRes  := fun r => 0 <= r;
+    SatOk := Z_div_nonneg_nonneg
+  |}.
+Add Zify Saturate SatDiv.
+
+#[global]
+Instance SatMod : Saturate Z.modulo :=
+  {|
+    PArg1 := fun x => 0 <= x;
+    PArg2 := fun y => 0 <= y;
+    PRes  := fun r => 0 <= r;
+    SatOk := Z_mod_nonneg_nonneg
+  |}.
+Add Zify Saturate SatMod.

--- a/theories/micromega/ZifyNat.v
+++ b/theories/micromega/ZifyNat.v
@@ -1,0 +1,58 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(* Instances of [ZifyClasses] for dealing with advanced [nat] operators. *)
+
+Require Import BinInt Znat Zdiv.
+Require Import ZifyClasses ZifyInst Zify.
+
+Ltac zify_convert_to_euclidean_division_equations_flag ::= constr:(true).
+
+(** Support for [nat] *)
+
+#[local]
+Existing Instance Inj_nat_Z.
+
+#[global]
+Instance Op_mod : BinOp Nat.modulo :=
+  {| TBOp := Z.modulo ; TBOpInj := Nat2Z.inj_mod |}.
+Add Zify BinOp Op_mod.
+
+#[global]
+Instance Op_div : BinOp Nat.div :=
+  {| TBOp := Z.div ; TBOpInj := Nat2Z.inj_div |}.
+Add Zify BinOp Op_div.
+
+#[global]
+Instance Op_pow : BinOp Nat.pow :=
+  {| TBOp := Z.pow ; TBOpInj := Nat2Z.inj_pow |}.
+Add Zify BinOp Op_pow.
+
+#[local] Open Scope Z_scope.
+
+#[global]
+Instance SatDiv : Saturate Z.div :=
+  {|
+    PArg1 := fun x => 0 <= x;
+    PArg2 := fun y => 0 <= y;
+    PRes  := fun r => 0 <= r;
+    SatOk := Z_div_nonneg_nonneg
+  |}.
+Add Zify Saturate SatDiv.
+
+#[global]
+Instance SatMod : Saturate Z.modulo :=
+  {|
+    PArg1 := fun x => 0 <= x;
+    PArg2 := fun y => 0 <= y;
+    PRes  := fun r => 0 <= r;
+    SatOk := Z_mod_nonneg_nonneg
+  |}.
+Add Zify Saturate SatMod.


### PR DESCRIPTION
The required declarations `BinOp Nat.modulo`, `BinOp Nat.div`, `BinOp Nat.pow` are added to `ZifyInst`.
Also `Saturate Z.div`, `Saturate Z.modulo` are added.

I did not follow the suggestion https://github.com/coq/coq/issues/11447#issuecomment-745144254 of using ad-hoc lemmas from `Zdiv.v` (because of circular dependencies).
Instead, I added missing `inj_*` lemmas to `Nnat.v`, which were sufficient.

Additionally, this PR cleans up `Zdiv.v` a little (no more `PeanoNat`) and renders `div_Zdiv` and `mod_Zmod` as derived from `inj_*`.
Actually, I would prefer to remove `div_Zdiv` and `mod_Zmod` completely.

Here is a demo snippet which uses the added functionality:
```
Require Import ZArith Lia.

Ltac Zify.zify_post_hook ::= Z.to_euclidean_division_equations.
 
Goal forall (n:nat), (n * 3) mod 3 = 0.
Proof. lia. Qed.
 
Goal forall (n:nat), (n * 3) / 3 = n.
Proof. lia. Qed.
 
(* not sure how to fix *)
Goal forall (m n:nat), m > 0 -> (n * m) mod m = 0.
Proof. Fail nia. Abort.
 
Goal forall (m n:nat), m > 0 -> (n * m) / m = n.
Proof. nia. Qed.
```
Does anyone know how to fix the failing third Goal?

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** feature.


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Closes #11447

Requires https://github.com/coq/coq/pull/14045, https://github.com/coq/coq/pull/14086

Associted PRs:
- [x] math-classes (merged): https://github.com/coq-community/math-classes/pull/98
- [x] flocq: (merged) https://github.com/mrhaandi/flocq/tree/N-Z-div-mod
@silene diff: [flocq.diff.txt](https://github.com/coq/coq/files/6521863/flocq.diff.txt)


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
- [x] Overlay pull requests (if this breaks 3rd party developments in CI, see
https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md for details)
