### PR TITLE
[dune] Rename byterun to coqrun

### DIFF
--- a/kernel/byterun/dune
+++ b/kernel/byterun/dune
@@ -1,5 +1,5 @@
 (library
- (name byterun)
+ (name coqrun)
  (synopsis "Coq's Kernel Abstract Reduction Machine [C implementation]")
  (public_name coq-core.vm)
  (foreign_stubs

--- a/kernel/dune
+++ b/kernel/dune
@@ -4,7 +4,7 @@
  (public_name coq-core.kernel)
  (wrapped false)
  (modules (:standard \ genOpcodeFiles uint63_31 uint63_63 float64_31 float64_63))
- (libraries lib byterun dynlink))
+ (libraries lib coqrun dynlink))
 
 (executable
   (name genOpcodeFiles)


### PR DESCRIPTION
This seems the official name, the byterun name is just an artifact
from the very preliminary dune build.

Not sure if we want to keep that name, or maybe tweak the dir name.