### PR TITLE
Fix a bug in UnivProblem

### DIFF
--- a/engine/univProblem.ml
+++ b/engine/univProblem.ml
@@ -30,7 +30,7 @@ let subst_univs fn = function
   | UEq (u, v) ->
     let u' = subst_univs_universe fn u and v' = subst_univs_universe fn v in
     if Universe.equal u' v' then None
-    else Some (ULe (u',v'))
+    else Some (UEq (u',v'))
   | ULub (u, v) ->
     let u' = level_subst_of fn u and v' = level_subst_of fn v in
     if Level.equal u' v' then None


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** bug fix 

This is a minor bugfix: we transformed Eq constraints into Leq constraints for no good reason in a universe constraint substitution function. Probably caused by copy-pasting.

I don't know how to trigger the bug but that's certainly possible.

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [ ] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
- [ ] Overlay pull requests (if this breaks 3rd party developments in CI, see
https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md for details)
