### PR TITLE
[ci] Disable native compilation for paramcoq

### DIFF
--- a/dev/ci/ci-paramcoq.sh
+++ b/dev/ci/ci-paramcoq.sh
@@ -5,4 +5,7 @@ ci_dir="$(dirname "$0")"
 
 git_download paramcoq
 
+# Typically flaky on our worker configuration
+# https://gitlab.com/coq/coq/-/jobs/1144081161
+export COQEXTRAFLAGS='-native-compiler no'
 ( cd "${CI_BUILD_DIR}/paramcoq" && make && make install && cd test-suite && make examples)


### PR DESCRIPTION
Paramcoq is typically flaky on our worker configuration, c.f. https://gitlab.com/coq/coq/-/jobs/1144081161

