### PR TITLE
Do not rely on accumulators having tag 0 in native compilation.

### DIFF
--- a/kernel/byterun/coq_values.c
+++ b/kernel/byterun/coq_values.c
@@ -96,3 +96,26 @@ value coq_tcode_array(value tcodes) {
   }
   CAMLreturn(res);
 }
+
+/* Low-level representation of accumulators for native compilation */
+
+static code_t coq_accumulator_code;
+static int coq_accumulator_init = 0;
+
+value coq_native_register_accu(value v) {
+  if (coq_accumulator_init == 0) {
+    coq_accumulator_init = 1;
+    coq_accumulator_code = Code_val(v);
+  }
+  return Val_unit;
+}
+
+value coq_native_is_clos(value v) {
+  if (Is_block(v) && Tag_val(v) == Closure_tag) return Val_true;
+  return Val_false;
+}
+
+value coq_native_is_accu(value v) {
+  if (Is_block(v) && Tag_val(v) == Closure_tag && Code_val(v) == coq_accumulator_code) return Val_true;
+  return Val_false;
+}

--- a/kernel/nativevalues.mli
+++ b/kernel/nativevalues.mli
@@ -116,6 +116,8 @@ val accu_nargs : accumulator -> int
 val cast_accu : t -> accumulator
 [@@ocaml.inline always]
 
+val is_closure : 'a -> bool
+
 (* Functions over block: i.e constructors *)
 
 type block


### PR DESCRIPTION
Instead, we add a test for accumulator branches. We cannot use Obj.tag because the latter is inefficient, so we roll up our own test to check that a value has a closure tag and the right code.

- [ ] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
- [ ] Overlay pull requests (if this breaks 3rd party developments in CI, see
https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md for details)
