### PR TITLE
[zify] better error reporting

### DIFF
--- a/plugins/micromega/g_zify.mlg
+++ b/plugins/micromega/g_zify.mlg
@@ -24,17 +24,17 @@ let warn_deprecated_Spec =
 DECLARE PLUGIN "zify_plugin"
 
 VERNAC COMMAND EXTEND DECLAREINJECTION CLASSIFIED AS SIDEFF
-| ["Add" "Zify" "InjTyp"    constr(t) ] -> { Zify.InjTable.register t }
-| ["Add" "Zify" "BinOp"     constr(t) ] -> { Zify.BinOp.register t }
-| ["Add" "Zify" "UnOp"      constr(t) ] -> { Zify.UnOp.register t }
-| ["Add" "Zify" "CstOp"     constr(t) ] -> { Zify.CstOp.register t }
-| ["Add" "Zify" "BinRel"    constr(t) ] -> { Zify.BinRel.register t }
-| ["Add" "Zify" "PropOp"    constr(t) ] -> { Zify.PropBinOp.register t }
-| ["Add" "Zify" "PropBinOp"    constr(t) ] -> { Zify.PropBinOp.register t }
-| ["Add" "Zify" "PropUOp"   constr(t) ] -> { Zify.PropUnOp.register t }
-| ["Add" "Zify" "BinOpSpec" constr(t) ] -> { Zify.BinOpSpec.register t }
-| ["Add" "Zify" "UnOpSpec"  constr(t) ] -> { Zify.UnOpSpec.register t }
-| ["Add" "Zify" "Saturate"  constr(t) ] -> { Zify.Saturate.register t }
+| ["Add" "Zify" "InjTyp"   reference(t) ] -> { Zify.InjTable.register t }
+| ["Add" "Zify" "BinOp"     reference(t) ] -> { Zify.BinOp.register t }
+| ["Add" "Zify" "UnOp"      reference(t) ] -> { Zify.UnOp.register t }
+| ["Add" "Zify" "CstOp"     reference(t) ] -> { Zify.CstOp.register t }
+| ["Add" "Zify" "BinRel"    reference(t) ] -> { Zify.BinRel.register t }
+| ["Add" "Zify" "PropOp"    reference(t) ] -> { Zify.PropBinOp.register t }
+| ["Add" "Zify" "PropBinOp"    reference(t) ] -> { Zify.PropBinOp.register t }
+| ["Add" "Zify" "PropUOp"   reference(t) ] -> { Zify.PropUnOp.register t }
+| ["Add" "Zify" "BinOpSpec" reference(t) ] -> { Zify.BinOpSpec.register t }
+| ["Add" "Zify" "UnOpSpec"  reference(t) ] -> { Zify.UnOpSpec.register t }
+| ["Add" "Zify" "Saturate"  reference(t) ] -> { Zify.Saturate.register t }
 END
 
 TACTIC EXTEND ITER

--- a/plugins/micromega/zify.mli
+++ b/plugins/micromega/zify.mli
@@ -7,10 +7,9 @@
 (*         *     GNU Lesser General Public License Version 2.1          *)
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
-open Constrexpr
 
 module type S = sig
-  val register : constr_expr -> unit
+  val register : Libnames.qualid -> unit
   val print : unit -> unit
 end
 

--- a/test-suite/micromega/bug_14054.v
+++ b/test-suite/micromega/bug_14054.v
@@ -1,0 +1,46 @@
+(* bug 13242 *)
+
+Require Import Lia.
+Fail Add Zify InjTyp id.
+
+(* bug 14054 *)
+
+Require Import Coq.ZArith.ZArith. Open Scope Z_scope.
+Require Coq.Init.Byte .
+Require Import Coq.micromega.ZifyClasses Coq.micromega.Lia.
+
+Notation byte := Coq.Init.Byte.byte.
+
+Module byte.
+  Definition unsigned(b: byte): Z := Z.of_N (Byte.to_N b).
+End byte.
+
+Section WithA.
+  Context (A: Type).
+  Fixpoint tuple(n: nat): Type :=
+    match n with
+    | O => unit
+    | S m => A * tuple m
+    end.
+End WithA.
+
+Module LittleEndian.
+  Fixpoint combine (n : nat) : forall (bs : tuple byte n), Z :=
+    match n with
+    | O => fun _ => 0
+    | S n => fun bs => Z.lor (byte.unsigned (fst bs))
+                             (Z.shiftl (combine n (snd bs)) 8)
+    end.
+  Lemma combine_bound: forall {n: nat} (t: tuple byte n),
+      0 <= LittleEndian.combine n t < 2 ^ (8 * Z.of_nat n).
+  Admitted.
+End LittleEndian.
+
+Instance InjByteTuple{n: nat}: InjTyp (tuple byte n) Z := {|
+  inj := LittleEndian.combine n;
+  pred x := 0 <= x < 2 ^ (8 * Z.of_nat n);
+  cstr := @LittleEndian.combine_bound n;
+|}.
+Fail Add Zify InjTyp InjByteTuple.
+Fail Add Zify UnOp InjByteTuple.
+Fail Add Zify UnOp X.

--- a/theories/micromega/ZifyClasses.v
+++ b/theories/micromega/ZifyClasses.v
@@ -250,8 +250,18 @@ Register rew_iff     as ZifyClasses.rew_iff.
 Register source_prop as ZifyClasses.source_prop.
 Register injprop_ok  as ZifyClasses.injprop_ok.
 Register iff         as ZifyClasses.iff.
+
+Register InjTyp      as ZifyClasses.InjTyp.
+Register BinOp       as ZifyClasses.BinOp.
+Register UnOp        as ZifyClasses.UnOp.
+Register CstOp       as ZifyClasses.CstOp.
+Register BinRel      as ZifyClasses.BinRel.
+Register PropOp   as ZifyClasses.PropOp.
+Register PropUOp     as ZifyClasses.PropUOp.
 Register BinOpSpec   as ZifyClasses.BinOpSpec.
 Register UnOpSpec    as ZifyClasses.UnOpSpec.
+Register Saturate    as ZifyClasses.Saturate.
+
 
 (** Propositional logic *)
 Register and as ZifyClasses.and.


### PR DESCRIPTION
The Add Zify X command may fail with an anomaly if the term is not well-formed.

This PR checks the X argument.
- X is now a reference (previously a constr)
- the head symbol of the type of X is checked

Closes #14054, closes #13242

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** bug fix 

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [ x] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
