### PR TITLE
Fixes #11690: wrongly toggled coqide printing matching flag

### DIFF
--- a/ide/coqide/coq.ml
+++ b/ide/coqide/coq.ml
@@ -538,7 +538,7 @@ struct
 
   let implicit = BoolOpt ["Printing"; "Implicit"]
   let coercions = BoolOpt ["Printing"; "Coercions"]
-  let raw_matching = BoolOpt ["Printing"; "Matching"]
+  let nested_matching = BoolOpt ["Printing"; "Matching"]
   let notations = BoolOpt ["Printing"; "Notations"]
   let parentheses = BoolOpt ["Printing"; "Parentheses"]
   let all_basic = BoolOpt ["Printing"; "All"]
@@ -553,8 +553,8 @@ struct
   let bool_items = [
     { opts = [implicit]; init = false; label = "Display _implicit arguments" };
     { opts = [coercions]; init = false; label = "Display _coercions" };
-    { opts = [raw_matching]; init = true;
-      label = "Display raw _matching expressions" };
+    { opts = [nested_matching]; init = true;
+      label = "Display nested _matching expressions" };
     { opts = [notations]; init = true; label = "Display _notations" };
     { opts = [parentheses]; init = false; label = "Display _parentheses" };
     { opts = [all_basic]; init = false;

--- a/ide/coqide/coqide_ui.ml
+++ b/ide/coqide/coqide_ui.ml
@@ -77,7 +77,7 @@ let init () =
 \n    <separator/>\
 \n    <menuitem action='Display implicit arguments' />\
 \n    <menuitem action='Display coercions' />\
-\n    <menuitem action='Display raw matching expressions' />\
+\n    <menuitem action='Display nested matching expressions' />\
 \n    <menuitem action='Display notations' />\
 \n    <menuitem action='Display parentheses' />\
 \n    <menuitem action='Display all basic low-level contents' />\


### PR DESCRIPTION
**Kind:** bug fix

We change the flag from `Display raw matching expressions` to `Display nested matching expressions`. (It is a bit an approximation because the option is a noop on non-nested matching...)

Fixes #11690

- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
