### PR TITLE
Gramlib: new tree-based look-ahead of tokens

### DIFF
--- a/doc/changelog/03-notations/14070-master+gramlib-tree-based-token-look-ahead.rst
+++ b/doc/changelog/03-notations/14070-master+gramlib-tree-based-token-look-ahead.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  Look-ahead of tokens is changed from sequential to tree-based,
+  allowing more automatic rule factorizations in notations
+  (`#14070 <https://github.com/coq/coq/pull/14070>`_,
+  by Hugo Herbelin).

--- a/test-suite/success/Notations2.v
+++ b/test-suite/success/Notations2.v
@@ -205,3 +205,11 @@ Notation "#" := (@id nat).
 Check # = (fun a:nat => a). (* # should inherit its maximal implicit argument *)
 
 End InheritanceMaximalImplicitPureNotation.
+
+Module TreeLikeLookAhead.
+
+Notation "6 ^" := true (at level 0, format "6 ^").
+Notation "6 ?" := false (at level 0, format "6 ?").
+Check 6.
+
+End TreeLikeLookAhead.


### PR DESCRIPTION
**Kind:**  feature

Formerly, look-ahead of tokens was able to consider a linear sequence of tokens as one token, recovering from a failure in the middle of a sequence of tokens. That is, in
```
[ [ "foo"; "bar"; ... -> action
  | other-rules ] ]
```
a failure after `"foo"` was seen as a failure of parsing the whole sequence `"foo"; "bar"` and was going back to `other-rules`.
    
This had limits. For instance, parsing `foo bar3` in the following non-linear situation:
 ```
 [ [ "foo"; "bar1"; ... -> action1
   | "foo"; "bar2"; ... -> action2
   | other-rules ] ]
```
was not going back to other-rules (because internally seen as `"foo"; ["bar1"|"bar2"]` which is not a linear look-ahead), even though `other-rules` is a priori liable to parse `foo bar3`.
    
This PR is about using a tree of tokens rather than a sequence of tokens, so as to support the above example. As a consequence, we are for instance able to support the following example (extracted from the fourcolor development):
```
Notation "6 +" := true (at level 0, format "6 +").
Notation "6 -" := false (at level 0, format "6 -").
Check 6.
```

Technically:
- we renounce to computing in advance a linear sequence of consecutive tokens (as was done in `get_token_list`)
- instead, we browse the tree of tokens directly in `parse_of_token_list`, following the sons to make progresses in the rule everytime the next token matches, backtracking on the brothers of the current position when the token does not match
- like before, once a maximal sequence of tokens is parsed, no backtracking is done anymore: the non-token rest of the rule should apply, and if not, a message of the form `[symbol] expected after 'token' (in [entry])` is displayed.

Incidentally, it will be useful for #13664 which itself will help #13353 and provide a better general support for notations using numerals.

- [X] Added / updated test-suite
- [ ] Corresponding documentation was added / updated
- [x] Entry added in the changelog
