### PR TITLE
Gramlib: improved support for multi-token LIST0/LIST1 separators and related minor changes

### DIFF
--- a/coqpp/coqpp_main.ml
+++ b/coqpp/coqpp_main.ml
@@ -238,11 +238,11 @@ and print_symbol fmt tkn = match tkn with
 | SymbList0 (s, None) ->
   fprintf fmt "(Pcoq.Symbol.list0 %a)" print_symbol s
 | SymbList0 (s, Some sep) ->
-  fprintf fmt "(Pcoq.Symbol.list0sep (%a) (%a) false)" print_symbol s print_symbol sep
+  fprintf fmt "(Pcoq.Symbol.list0sep (%a) (%a) false)" print_symbol s print_anonymized_symbol sep
 | SymbList1 (s, None) ->
   fprintf fmt "(Pcoq.Symbol.list1 (%a))" print_symbol s
 | SymbList1 (s, Some sep) ->
-  fprintf fmt "(Pcoq.Symbol.list1sep (%a) (%a) false)" print_symbol s print_symbol sep
+  fprintf fmt "(Pcoq.Symbol.list1sep (%a) (%a) false)" print_symbol s print_anonymized_symbol sep
 | SymbOpt s ->
   fprintf fmt "(Pcoq.Symbol.opt %a)" print_symbol s
 | SymbRules rules ->
@@ -255,6 +255,11 @@ and print_symbol fmt tkn = match tkn with
   fprintf fmt "(Pcoq.Symbol.rules %a)" pr (List.rev rules)
 | SymbQuote c ->
   fprintf fmt "(%s)" c
+
+and print_anonymized_symbol fmt tkn = match tkn with
+| SymbToken (t, s) ->
+  fprintf fmt "(Pcoq.Symbol.tokens [Pcoq.TPattern (%a)])" print_tok (t, s)
+| _ -> print_symbol fmt (SymbRules [[None, tkn], mk_code "()"])
 
 let print_rule fmt r =
   let pr_lvl fmt lvl = print_opt fmt print_string lvl in

--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -90,8 +90,6 @@ module type S = sig
 
   val generalize_symbol : ('a, 'tr, 'c) Symbol.t -> ('a, norec, 'c) Symbol.t option
 
-  val mk_rule : 'a pattern list -> string Rules.t
-
   (* Used in custom entries, should tweak? *)
   val level_of_nonterm : ('a, norec, 'c) Symbol.t -> string option
 
@@ -1843,15 +1841,5 @@ and generalize_tree : type a tr s .
 let generalize_symbol s =
   try Some (generalize_symbol s)
   with SelfSymbol -> None
-
-let rec mk_rule tok =
-  match tok with
-  | [] ->
-    let stop_e = Rule.stop in
-    TRules (stop_e, fun _ -> (* dropped anyway: *) "")
-  | tkn :: rem ->
-    let TRules (r, f) = mk_rule rem in
-    let r = Rule.next_norec r (Symbol.token tkn) in
-    TRules (r, fun _ -> f)
 
 end

--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -44,11 +44,11 @@ module type S = sig
     val nterml : 'a Entry.t -> string -> ('self, norec, 'a) t
     val list0 : ('self, 'trec, 'a) t -> ('self, 'trec, 'a list) t
     val list0sep :
-      ('self, 'trec, 'a) t -> ('self, norec, 'b) t -> bool ->
+      ('self, 'trec, 'a) t -> ('self, norec, unit) t -> bool ->
       ('self, 'trec, 'a list) t
     val list1 : ('self, 'trec, 'a) t -> ('self, 'trec, 'a list) t
     val list1sep :
-      ('self, 'trec, 'a) t -> ('self, norec, 'b) t -> bool ->
+      ('self, 'trec, 'a) t -> ('self, norec, unit) t -> bool ->
       ('self, 'trec, 'a list) t
     val opt : ('self, 'trec, 'a) t -> ('self, 'trec, 'a option) t
     val self : ('self, mayrec, 'self) t
@@ -167,9 +167,9 @@ and ('self, 'trec, 'a) ty_symbol =
 | Stoken : 'c pattern -> ('self, norec, 'c) ty_symbol
 | Stokens : ty_pattern list -> ('self, norec, unit) ty_symbol
 | Slist1 : ('self, 'trec, 'a) ty_symbol -> ('self, 'trec, 'a list) ty_symbol
-| Slist1sep : ('self, 'trec, 'a) ty_symbol * ('self, norec, _) ty_symbol * bool -> ('self, 'trec, 'a list) ty_symbol
+| Slist1sep : ('self, 'trec, 'a) ty_symbol * ('self, norec, unit) ty_symbol * bool -> ('self, 'trec, 'a list) ty_symbol
 | Slist0 : ('self, 'trec, 'a) ty_symbol -> ('self, 'trec, 'a list) ty_symbol
-| Slist0sep : ('self, 'trec, 'a) ty_symbol * ('self, norec, _) ty_symbol * bool -> ('self, 'trec, 'a list) ty_symbol
+| Slist0sep : ('self, 'trec, 'a) ty_symbol * ('self, norec, unit) ty_symbol * bool -> ('self, 'trec, 'a list) ty_symbol
 | Sopt : ('self, 'trec, 'a) ty_symbol -> ('self, 'trec, 'a option) ty_symbol
 | Sself : ('self, mayrec, 'self) ty_symbol
 | Snext : ('self, mayrec, 'self) ty_symbol
@@ -1698,11 +1698,11 @@ module rec Symbol : sig
   val nterml : 'a Entry.t -> string -> ('self, norec, 'a) t
   val list0 : ('self, 'trec, 'a) t -> ('self, 'trec, 'a list) t
   val list0sep :
-    ('self, 'trec, 'a) t -> ('self, norec, 'b) t -> bool ->
+    ('self, 'trec, 'a) t -> ('self, norec, unit) t -> bool ->
     ('self, 'trec, 'a list) t
   val list1 : ('self, 'trec, 'a) t -> ('self, 'trec, 'a list) t
   val list1sep :
-    ('self, 'trec, 'a) t -> ('self, norec, 'b) t -> bool ->
+    ('self, 'trec, 'a) t -> ('self, norec, unit) t -> bool ->
     ('self, 'trec, 'a list) t
   val opt : ('self, 'trec, 'a) t -> ('self, 'trec, 'a option) t
   val self : ('self, mayrec, 'self) t

--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -14,6 +14,7 @@ type mayrec
 module type S = sig
   type te
   type 'c pattern
+  type ty_pattern = TPattern : 'a pattern -> ty_pattern
 
   module Parsable : sig
     type t
@@ -53,6 +54,7 @@ module type S = sig
     val self : ('self, mayrec, 'self) t
     val next : ('self, mayrec, 'self) t
     val token : 'c pattern -> ('self, norec, 'c) t
+    val tokens : ty_pattern list -> ('self, norec, unit) t
     val rules : 'a Rules.t list -> ('self, norec, 'a) t
 
   end and Rule : sig
@@ -114,6 +116,7 @@ module GMake (L : Plexing.S) = struct
 
 type te = L.te
 type 'c pattern = 'c L.pattern
+type ty_pattern = TPattern : 'a pattern -> ty_pattern
 
 type 'a parser_t = L.te LStream.t -> 'a
 
@@ -162,6 +165,7 @@ and ('trecs, 'trecp, 'a) ty_rec_level = {
 
 and ('self, 'trec, 'a) ty_symbol =
 | Stoken : 'c pattern -> ('self, norec, 'c) ty_symbol
+| Stokens : ty_pattern list -> ('self, norec, unit) ty_symbol
 | Slist1 : ('self, 'trec, 'a) ty_symbol -> ('self, 'trec, 'a list) ty_symbol
 | Slist1sep : ('self, 'trec, 'a) ty_symbol * ('self, norec, _) ty_symbol * bool -> ('self, 'trec, 'a list) ty_symbol
 | Slist0 : ('self, 'trec, 'a) ty_symbol -> ('self, 'trec, 'a list) ty_symbol
@@ -207,6 +211,7 @@ let rec derive_eps : type s r a. (s, r, a) ty_symbol -> bool =
   | Snext -> false
   | Sself -> false
   | Stoken _ -> false
+  | Stokens _ -> false
 and tree_derive_eps : type s tr a. (s, tr, a) ty_tree -> bool =
   function
     LocAct (_, _) -> true
@@ -218,6 +223,10 @@ and tree_derive_eps : type s tr a. (s, tr, a) ty_tree -> bool =
 let eq_entry : type a1 a2. a1 ty_entry -> a2 ty_entry -> (a1, a2) eq option = fun e1 e2 ->
   if (Obj.magic e1) == (Obj.magic e2) then Some (Obj.magic Refl)
   else None
+
+let tok_pattern_eq_list pl1 pl2 =
+  let f (TPattern p1) (TPattern p2) = Option.has_some (L.tok_pattern_eq p1 p2) in
+  if List.for_all2eq f pl1 pl2 then Some Refl else None
 
 let rec eq_symbol : type s r1 r2 a1 a2. (s, r1, a1) ty_symbol -> (s, r2, a2) ty_symbol -> (a1, a2) eq option = fun s1 s2 ->
   match s1, s2 with
@@ -250,6 +259,7 @@ let rec eq_symbol : type s r1 r2 a1 a2. (s, r1, a1) ty_symbol -> (s, r2, a2) ty_
   | Sself, Sself -> Some Refl
   | Snext, Snext -> Some Refl
   | Stoken p1, Stoken p2 -> L.tok_pattern_eq p1 p2
+  | Stokens pl1, Stokens pl2 -> tok_pattern_eq_list pl1 pl2
   | _ -> None
 
 let is_before : type s1 s2 r1 r2 a1 a2. (s1, r1, a1) ty_symbol -> (s2, r2, a2) ty_symbol -> bool = fun s1 s2 ->
@@ -460,6 +470,7 @@ let srules (type self a) (rl : a ty_rules list) : (self, norec, a) ty_symbol =
   and retype_symbol : type s a. (s, norec, a) ty_symbol -> (self, norec, a) ty_symbol =
     function
     | Stoken p -> Stoken p
+    | Stokens l -> Stokens l
     | Slist1 s -> Slist1 (retype_symbol s)
     | Slist1sep (s, sep, b) -> Slist1sep (retype_symbol s, retype_symbol sep, b)
     | Slist0 s -> Slist0 (retype_symbol s)
@@ -579,6 +590,15 @@ let rec change_to_self : type s trec a r. s ty_entry -> (s, trec, a, r) ty_rule 
   let MayRecSymbol t = change_to_self0 e t in
   MayRecRule (TNext (MayRec2, r, t))
 
+let insert_token gram tok =
+  L.tok_using tok;
+  let r =
+    let tok = L.tok_pattern_strings tok in
+    try Hashtbl.find gram.gtokens tok with
+      Not_found -> let r = ref 0 in Hashtbl.add gram.gtokens tok r; r
+  in
+  incr r
+
 let insert_tokens gram symbols =
   let rec insert : type s trec a. (s, trec, a) ty_symbol -> unit =
     function
@@ -588,14 +608,9 @@ let insert_tokens gram symbols =
     | Slist1sep (s, t, _) -> insert s; insert t
     | Sopt s -> insert s
     | Stree t -> tinsert t
-    | Stoken tok ->
-        L.tok_using tok;
-        let r =
-          let tok = L.tok_pattern_strings tok in
-          try Hashtbl.find gram.gtokens tok with
-            Not_found -> let r = ref 0 in Hashtbl.add gram.gtokens tok r; r
-        in
-        incr r
+    | Stoken tok -> insert_token gram tok
+    | Stokens (TPattern tok::_) -> insert_token gram tok (* Only the first token is liable to trigger a keyword effect *)
+    | Stokens [] -> assert false
     | Snterm _ -> () | Snterml (_, _) -> ()
     | Snext -> ()
     | Sself -> ()
@@ -663,6 +678,7 @@ let logically_eq_symbols entry =
     | Sopt s1, Sopt s2 -> eq_symbols s1 s2
     | Stree t1, Stree t2 -> eq_trees t1 t2
     | Stoken p1, Stoken p2 -> L.tok_pattern_eq p1 p2 <> None
+    | Stokens pl1, Stokens pl2 -> tok_pattern_eq_list pl1 pl2 <> None
     | Sself, Sself -> true
     | Snext, Snext -> true
     | _ -> false
@@ -728,17 +744,21 @@ let delete_rule_in_tree entry =
   in
   delete_in_tree
 
+let decr_keyw_use_in_token gram tok =
+  let tok' = L.tok_pattern_strings tok in
+  let r = Hashtbl.find gram.gtokens tok' in
+  decr r;
+  if !r == 0 then
+    begin
+      Hashtbl.remove gram.gtokens tok';
+      L.tok_removing tok
+    end
+
 let rec decr_keyw_use : type s tr a. _ -> (s, tr, a) ty_symbol -> unit = fun gram ->
   function
-    Stoken tok ->
-      let tok' = L.tok_pattern_strings tok in
-      let r = Hashtbl.find gram.gtokens tok' in
-      decr r;
-      if !r == 0 then
-        begin
-          Hashtbl.remove gram.gtokens tok';
-          L.tok_removing tok
-        end
+    Stoken tok -> decr_keyw_use_in_token gram tok
+  | Stokens (TPattern tok :: _) -> decr_keyw_use_in_token gram tok
+  | Stokens [] -> assert false
   | Slist0 s -> decr_keyw_use gram s
   | Slist1 s -> decr_keyw_use gram s
   | Slist0sep (s1, s2, _) -> decr_keyw_use gram s1; decr_keyw_use gram s2
@@ -853,6 +873,20 @@ let string_escaped s =
 
 let print_str ppf s = fprintf ppf "\"%s\"" (string_escaped s)
 
+let print_token b ppf p =
+  match L.tok_pattern_strings p with
+  | "", Some s -> print_str ppf s
+  | con, Some prm -> if b then fprintf ppf "%s@ %a" con print_str prm else fprintf ppf "(%s@ %a)" con print_str prm
+  | con, None -> fprintf ppf "%s" con
+
+let print_tokens ppf = function
+  | [] -> assert false
+  | TPattern p :: pl ->
+    fprintf ppf "[%a%a]"
+    (print_token true) p
+    (fun ppf -> List.iter (function TPattern p -> fprintf ppf ";@ "; print_token true ppf p))
+    pl
+
 let rec print_symbol : type s tr r. formatter -> (s, tr, r) ty_symbol -> unit =
   fun ppf ->
   function
@@ -865,11 +899,9 @@ let rec print_symbol : type s tr r. formatter -> (s, tr, r) ty_symbol -> unit =
       fprintf ppf "LIST1 %a SEP %a%s" print_symbol1 s print_symbol1 t
         (if osep then " OPT_SEP" else "")
   | Sopt s -> fprintf ppf "OPT %a" print_symbol1 s
-  | Stoken p ->
-     begin match L.tok_pattern_strings p with
-     | "", Some s -> print_str ppf s
-     | con, Some prm -> fprintf ppf "%s@ %a" con print_str prm
-     | con, None -> fprintf ppf "%s" con end
+  | Stoken p -> print_token true ppf p
+  | Stokens [TPattern p] -> print_token true ppf p
+  | Stokens pl -> print_tokens ppf pl
   | Snterml (e, l) ->
       fprintf ppf "%s%s@ LEVEL@ %a" e.ename ""
         print_str l
@@ -880,11 +912,9 @@ and print_symbol1 : type s tr r. formatter -> (s, tr, r) ty_symbol -> unit =
   | Snterm e -> fprintf ppf "%s%s" e.ename ""
   | Sself -> pp_print_string ppf "SELF"
   | Snext -> pp_print_string ppf "NEXT"
-  | Stoken p ->
-     begin match L.tok_pattern_strings p with
-     | "", Some s -> print_str ppf s
-     | con, None -> pp_print_string ppf con
-     | con, Some prm -> fprintf ppf "(%s@ %a)" con print_str prm end
+  | Stoken p -> print_token false ppf p
+  | Stokens [TPattern p] -> print_token false ppf p
+  | Stokens pl -> print_tokens ppf pl
   | Stree t -> print_level ppf pp_print_space (flatten_tree t)
   | s ->
       fprintf ppf "(%a)" print_symbol s
@@ -948,6 +978,7 @@ let name_of_symbol : type s tr a. s ty_entry -> (s, tr, a) ty_symbol -> string =
   | Sself -> "[" ^ entry.ename ^ "]"
   | Snext -> "[" ^ entry.ename ^ "]"
   | Stoken tok -> L.tok_text tok
+  | Stokens tokl -> String.concat " " (List.map (function TPattern tok -> L.tok_text tok) tokl)
   | Slist0 _ -> assert false
   | Slist1sep _ -> assert false
   | Slist1 _ -> assert false
@@ -1390,6 +1421,7 @@ and parser_of_symbol : type s tr a.
   | Sself -> (fun (strm__ : _ LStream.t) -> entry.estart 0 strm__)
   | Snext -> (fun (strm__ : _ LStream.t) -> entry.estart nlevn strm__)
   | Stoken tok -> parser_of_token entry tok
+  | Stokens tokl -> parser_of_tokens entry tokl
 and parser_of_token : type s a.
   s ty_entry -> a pattern -> a parser_t =
   fun entry tok ->
@@ -1398,6 +1430,17 @@ and parser_of_token : type s a.
     match LStream.peek strm with
       Some tok -> let r = f tok in LStream.junk strm; r
     | None -> raise Stream.Failure
+and parser_of_tokens : type s.
+  s ty_entry -> ty_pattern list -> unit parser_t =
+  fun entry tokl ->
+  let rec loop n = function
+  | [] -> fun strm -> for _i = 1 to n do LStream.junk strm done; ()
+  | TPattern tok :: tokl ->
+     let tematch = token_ematch tok in
+     fun strm ->
+     ignore (tematch (LStream.peek_nth n strm)); loop (n+1) tokl strm
+  in
+  loop 0 tokl
 and parse_top_symb : type s tr a. s ty_entry -> (s, tr, a) ty_symbol -> a parser_t =
   fun entry symb ->
   parser_of_symbol entry 0 (top_symb entry symb)
@@ -1665,6 +1708,7 @@ module rec Symbol : sig
   val self : ('self, mayrec, 'self) t
   val next : ('self, mayrec, 'self) t
   val token : 'c pattern -> ('self, norec, 'c) t
+  val tokens : ty_pattern list -> ('self, norec, unit) t
   val rules : 'a Rules.t list -> ('self, norec, 'a) t
 
 end = struct
@@ -1680,6 +1724,7 @@ end = struct
   let self = Sself
   let next = Snext
   let token tok = Stoken tok
+  let tokens tokl = Stokens tokl
   let rules (t : 'a Rules.t list) = srules t
 
 end and Rule : sig
@@ -1750,6 +1795,8 @@ let rec generalize_symbol :
   function
   | Stoken tok ->
     Stoken tok
+  | Stokens tokl ->
+    Stokens tokl
   | Slist1 e ->
     Slist1 (generalize_symbol e)
   | Slist1sep (e, sep, b) ->

--- a/gramlib/grammar.mli
+++ b/gramlib/grammar.mli
@@ -102,8 +102,6 @@ module type S = sig
 
   val generalize_symbol : ('a, 'tr, 'c) Symbol.t -> ('a, norec, 'c) Symbol.t option
 
-  val mk_rule : 'a pattern list -> string Rules.t
-
   (* Used in custom entries, should tweak? *)
   val level_of_nonterm : ('a, norec, 'c) Symbol.t -> string option
 

--- a/gramlib/grammar.mli
+++ b/gramlib/grammar.mli
@@ -24,6 +24,7 @@ type mayrec
 module type S = sig
   type te
   type 'c pattern
+  type ty_pattern = TPattern : 'a pattern -> ty_pattern
 
   module Parsable : sig
     type t
@@ -63,6 +64,7 @@ module type S = sig
     val self : ('self, mayrec, 'self) t
     val next : ('self, mayrec, 'self) t
     val token : 'c pattern -> ('self, norec, 'c) t
+    val tokens : ty_pattern list -> ('self, norec, unit) t
     val rules : 'a Rules.t list -> ('self, norec, 'a) t
 
   end and Rule : sig

--- a/gramlib/grammar.mli
+++ b/gramlib/grammar.mli
@@ -54,11 +54,11 @@ module type S = sig
     val nterml : 'a Entry.t -> string -> ('self, norec, 'a) t
     val list0 : ('self, 'trec, 'a) t -> ('self, 'trec, 'a list) t
     val list0sep :
-      ('self, 'trec, 'a) t -> ('self, norec, 'b) t -> bool ->
+      ('self, 'trec, 'a) t -> ('self, norec, unit) t -> bool ->
       ('self, 'trec, 'a list) t
     val list1 : ('self, 'trec, 'a) t -> ('self, 'trec, 'a list) t
     val list1sep :
-      ('self, 'trec, 'a) t -> ('self, norec, 'b) t -> bool ->
+      ('self, 'trec, 'a) t -> ('self, norec, unit) t -> bool ->
       ('self, 'trec, 'a list) t
     val opt : ('self, 'trec, 'a) t -> ('self, 'trec, 'a option) t
     val self : ('self, mayrec, 'self) t

--- a/parsing/extend.ml
+++ b/parsing/extend.ml
@@ -51,7 +51,7 @@ type simple_constr_prod_entry_key =
 
 (** Entries used in productions (in right-hand-side of grammar rules), to parse non-terminals *)
 
-type binder_entry_kind = ETBinderOpen | ETBinderClosed of string Tok.p list
+type binder_entry_kind = ETBinderOpen | ETBinderClosed of (bool * string) list
 
 type binder_target = ForBinder | ForTerm
 
@@ -63,7 +63,7 @@ type constr_prod_entry_key =
   | ETProdOneBinder of bool (* Parsed as name, or name:type or 'pattern, possibly in closed form *)
   | ETProdConstr of Constrexpr.notation_entry * (production_level * production_position) (* Parsed as constr or pattern, or a subentry of those *)
   | ETProdPattern of int  (* Parsed as pattern as a binder (as subpart of a constr) *)
-  | ETProdConstrList of Constrexpr.notation_entry * (production_level * production_position) * string Tok.p list (* Parsed as non-empty list of constr, or subentries of those *)
+  | ETProdConstrList of Constrexpr.notation_entry * (production_level * production_position) * (bool * string) list (* Parsed as non-empty list of constr, or subentries of those *)
   | ETProdBinderList of binder_entry_kind  (* Parsed as non-empty list of local binders *)
 
 (** {5 AST for user-provided entries} *)

--- a/parsing/extend.mli
+++ b/parsing/extend.mli
@@ -46,7 +46,7 @@ type simple_constr_prod_entry_key =
 
 (** Entries used in productions (in right-hand-side of grammar rules), to parse non-terminals *)
 
-type binder_entry_kind = ETBinderOpen | ETBinderClosed of string Tok.p list
+type binder_entry_kind = ETBinderOpen | ETBinderClosed of (bool * string) list
 
 type binder_target = ForBinder | ForTerm
 
@@ -58,7 +58,7 @@ type constr_prod_entry_key =
   | ETProdOneBinder of bool (* Parsed as name, or name:type or 'pattern, possibly in closed form *)
   | ETProdConstr of Constrexpr.notation_entry * (production_level * production_position) (* Parsed as constr or pattern, or a subentry of those *)
   | ETProdPattern of int  (* Parsed as pattern as a binder (as subpart of a constr) *)
-  | ETProdConstrList of Constrexpr.notation_entry * (production_level * production_position) * string Tok.p list (* Parsed as non-empty list of constr, or subentries of those *)
+  | ETProdConstrList of Constrexpr.notation_entry * (production_level * production_position) * (bool * string) list (* Parsed as non-empty list of constr, or subentries of those *)
   | ETProdBinderList of binder_entry_kind  (* Parsed as non-empty list of local binders *)
 
 (** {5 AST for user-provided entries} *)

--- a/parsing/notation_gram.ml
+++ b/parsing/notation_gram.ml
@@ -11,7 +11,7 @@
 open Names
 
 type grammar_constr_prod_item =
-  | GramConstrTerminal of string Tok.p
+  | GramConstrTerminal of bool (* true = in keyword position *) * string
   | GramConstrNonTerminal of Extend.constr_prod_entry_key * Id.t option
   | GramConstrListMark of int * bool * int
     (* tells action rule to make a list of the n previous parsed items;

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -143,10 +143,10 @@ let rec prod_item_of_symbol lev = function
   EntryName (Rawwit (ListArg typ), Pcoq.Symbol.list0 e)
 | Extend.Ulist1sep (s, sep) ->
   let EntryName (Rawwit typ, e) = prod_item_of_symbol lev s in
-  EntryName (Rawwit (ListArg typ), Pcoq.Symbol.list1sep e (Pcoq.Symbol.token (CLexer.terminal sep)) false)
+  EntryName (Rawwit (ListArg typ), Pcoq.Symbol.list1sep e (Pcoq.Symbol.tokens [Pcoq.TPattern (CLexer.terminal sep)]) false)
 | Extend.Ulist0sep (s, sep) ->
   let EntryName (Rawwit typ, e) = prod_item_of_symbol lev s in
-  EntryName (Rawwit (ListArg typ), Pcoq.Symbol.list0sep e (Pcoq.Symbol.token (CLexer.terminal sep)) false)
+  EntryName (Rawwit (ListArg typ), Pcoq.Symbol.list0sep e (Pcoq.Symbol.tokens [Pcoq.TPattern (CLexer.terminal sep)]) false)
 | Extend.Uopt s ->
   let EntryName (Rawwit typ, e) = prod_item_of_symbol lev s in
   EntryName (Rawwit (OptArg typ), Pcoq.Symbol.opt e)

--- a/test-suite/success/Notations2.v
+++ b/test-suite/success/Notations2.v
@@ -213,3 +213,12 @@ Notation "6 ?" := false (at level 0, format "6 ?").
 Check 6.
 
 End TreeLikeLookAhead.
+
+Module FactorizationListSeparators.
+
+Notation "[ a + + .. + + c | d ]" := (cons a .. (cons c d) ..) (a at level 10).
+Notation "[ a + + .. + + c ]" := (cons a .. (cons c nil) ..) (a at level 10).
+Check [0 + + 1 | nil].
+Check [0 + + 1].
+
+End FactorizationListSeparators.

--- a/user-contrib/Ltac2/tac2core.ml
+++ b/user-contrib/Ltac2/tac2core.ml
@@ -1672,7 +1672,7 @@ let () = add_scope "list0" begin function
   Tac2entries.ScopeRule (scope, act)
 | [tok; SexprStr {v=str}] ->
   let Tac2entries.ScopeRule (scope, act) = Tac2entries.parse_scope tok in
-  let sep = Pcoq.Symbol.token (CLexer.terminal str) in
+  let sep = Pcoq.Symbol.tokens [Pcoq.TPattern (CLexer.terminal str)] in
   let scope = Pcoq.Symbol.list0sep scope sep false in
   let act l = Tac2quote.of_list act l in
   Tac2entries.ScopeRule (scope, act)
@@ -1687,7 +1687,7 @@ let () = add_scope "list1" begin function
   Tac2entries.ScopeRule (scope, act)
 | [tok; SexprStr {v=str}] ->
   let Tac2entries.ScopeRule (scope, act) = Tac2entries.parse_scope tok in
-  let sep = Pcoq.Symbol.token (CLexer.terminal str) in
+  let sep = Pcoq.Symbol.tokens [Pcoq.TPattern (CLexer.terminal str)] in
   let scope = Pcoq.Symbol.list1sep scope sep false in
   let act l = Tac2quote.of_list act l in
   Tac2entries.ScopeRule (scope, act)

--- a/vernac/egramcoq.ml
+++ b/vernac/egramcoq.ml
@@ -328,12 +328,8 @@ let is_binder_level custom (custom',from) e = match e with
   custom = InConstrEntry && custom' = InConstrEntry && from = 200
 | _ -> false
 
-let make_sep_rules = function
-  | [tk] ->
-    Pcoq.Symbol.token tk
-  | tkl ->
-    let r = Pcoq.mk_rule (List.rev tkl) in
-    Pcoq.Symbol.rules [r]
+let make_sep_rules tkl =
+  Pcoq.Symbol.tokens (List.map (fun tk -> TPattern tk) tkl)
 
 type ('s, 'a) mayrec_symbol =
 | MayRecNo : ('s, Gramlib.Grammar.norec, 'a) Symbol.t -> ('s, 'a) mayrec_symbol

--- a/vernac/egramcoq.ml
+++ b/vernac/egramcoq.ml
@@ -254,10 +254,10 @@ type (_, _) entry =
 | TTBigint : ('self, string) entry
 | TTBinder : bool -> ('self, kinded_cases_pattern_expr) entry
 | TTConstr : notation_entry * prod_info * 'r target -> ('r, 'r) entry
-| TTConstrList : notation_entry * prod_info * string Tok.p list * 'r target -> ('r, 'r list) entry
+| TTConstrList : notation_entry * prod_info * (bool * string) list * 'r target -> ('r, 'r list) entry
 | TTPattern : int -> ('self, cases_pattern_expr) entry
 | TTOpenBinderList : ('self, local_binder_expr list) entry
-| TTClosedBinderList : string Tok.p list -> ('self, local_binder_expr list list) entry
+| TTClosedBinderList : (bool * string) list -> ('self, local_binder_expr list list) entry
 
 type _ any_entry = TTAny : ('s, 'r) entry -> 's any_entry
 
@@ -328,8 +328,11 @@ let is_binder_level custom (custom',from) e = match e with
   custom = InConstrEntry && custom' = InConstrEntry && from = 200
 | _ -> false
 
+let make_pattern (keyword,s) =
+   TPattern (if keyword then Tok.PKEYWORD s else Tok.PIDENT (Some s))
+
 let make_sep_rules tkl =
-  Pcoq.Symbol.tokens (List.map (fun tk -> TPattern tk) tkl)
+  Pcoq.Symbol.tokens (List.map make_pattern tkl)
 
 type ('s, 'a) mayrec_symbol =
 | MayRecNo : ('s, Gramlib.Grammar.norec, 'a) Symbol.t -> ('s, 'a) mayrec_symbol
@@ -433,7 +436,7 @@ match e with
 | TTConstrList _ -> { subst with constrlists = v :: subst.constrlists }
 
 type (_, _) ty_symbol =
-| TyTerm : string Tok.p -> ('s, string) ty_symbol
+| TyTerm : 'a Tok.p -> ('s, 'a) ty_symbol
 | TyNonTerm : 's target * ('s, 'a) entry * ('s, 'a) mayrec_symbol * bool -> ('s, 'a) ty_symbol
 
 type ('self, _, 'r) ty_rule =
@@ -495,9 +498,10 @@ type ('self, 'r) any_ty_rule =
 let make_ty_rule assoc from forpat prods =
   let rec make_ty_rule = function
   | [] -> AnyTyRule TyStop
-  | GramConstrTerminal tok :: rem ->
+  | GramConstrTerminal (kw,s) :: rem ->
     let AnyTyRule r = make_ty_rule rem in
-    AnyTyRule (TyNext (r, TyTerm tok))
+    let TPattern tk = make_pattern (kw,s) in
+    AnyTyRule (TyNext (r, TyTerm tk))
   | GramConstrNonTerminal (e, var) :: rem ->
     let AnyTyRule r = make_ty_rule rem in
     let TTAny e = interp_entry forpat e in

--- a/vernac/vernacextend.ml
+++ b/vernac/vernacextend.ml
@@ -172,9 +172,9 @@ let rec untype_command : type r s. (r, s) ty_sig -> r -> plugin_args -> vernac_c
 let rec untype_user_symbol : type s a b c. (a, b, c) Extend.ty_user_symbol -> (s, Gramlib.Grammar.norec, a) Pcoq.Symbol.t =
   let open Extend in function
   | TUlist1 l -> Pcoq.Symbol.list1 (untype_user_symbol l)
-  | TUlist1sep (l, s) -> Pcoq.Symbol.list1sep (untype_user_symbol l) (Pcoq.Symbol.token (CLexer.terminal s)) false
+  | TUlist1sep (l, s) -> Pcoq.Symbol.list1sep (untype_user_symbol l) (Pcoq.Symbol.tokens [Pcoq.TPattern (CLexer.terminal s)]) false
   | TUlist0 l -> Pcoq.Symbol.list0 (untype_user_symbol l)
-  | TUlist0sep (l, s) -> Pcoq.Symbol.list0sep (untype_user_symbol l) (Pcoq.Symbol.token (CLexer.terminal s)) false
+  | TUlist0sep (l, s) -> Pcoq.Symbol.list0sep (untype_user_symbol l) (Pcoq.Symbol.tokens [Pcoq.TPattern (CLexer.terminal s)]) false
   | TUopt o -> Pcoq.Symbol.opt (untype_user_symbol o)
   | TUentry a -> Pcoq.Symbol.nterm (Pcoq.genarg_grammar (Genarg.ExtraArg a))
   | TUentryl (a, i) -> Pcoq.Symbol.nterml (Pcoq.genarg_grammar (Genarg.ExtraArg a)) (string_of_int i)


### PR DESCRIPTION
**Kind:** enhancement

This PR does the following:
- introduce a new gramlib/camlp5 primitive symbol `tokens` for list of tokens; this has the following consequences:
  - list separators made of several tokens can be treated as first-order citizens: there is no more need to encode them as a rule of the form `["foo" "bar" -> ()]`
  - comparison of such separators is now possible (rules are arbitrary code and are always considered distinct by default); in particular, in the following example:
    ```coq
     Notation "[ a + + .. + + c | d ]" := (cons a .. (cons c d) ..) (a at level 10).
     Notation "[ a + + .. + + c ]" := (cons a .. (cons c nil) ..) (a at level 10).
     Check [0 + + 1 | nil].  (* now works *)
     Check [0 + + 1].
     ```
    the parser is now able to recognize that the separators are the same and to factorize the rules
  - the API for `LIST0 SEP` and `LIST1 SEP` can be cleaned: it is possible to give to the action associated to the separators the type `unit` even when the separator is a single token; this is a clean-up in that the action, even if not formally of type `unit`, was silently discarded
- incidentally, we support the `mlg` shortcut `[ symbs ]` for `[ symbs -> { () } ]` in `coqpp`: this notation was used by the gramlib printer but not accepted by `coqpp` (@ppedrot, is it ok for you?) (removed: redundant with #11910)
- add supports for terminals of different types (useful to treat both numbers and strings as terminals even if their associated tokens have different types)
- a few minor changes (moved to #14429)
  - moving `token_text` from `cLexer.ml` to `tok.ml` which looks more natural
  - introducing symmetry between `token_using` and `token_removing` (even if the effect of `token_removing` is overriden by state unfreezing) [incidentally, there is a problem with the state of keywords in plugins which need to be fixed]
  - add symmetry in the interchangeability of `IDENT` and `KEYWORD` when the corresponding identifier is a keyword


- [X] Added / updated test-suite
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
