### PR TITLE
Treat set predicativity and sprop-allowed more like normal typing flags

### DIFF
--- a/checker/check_stat.ml
+++ b/checker/check_stat.ml
@@ -24,13 +24,9 @@ let print_memory_stat () =
 
 let output_context = ref false
 
-let pr_engagement env =
-  begin
-    match engagement env with
-    | ImpredicativeSet -> str "Theory: Set is impredicative"
-    | PredicativeSet -> str "Theory: Set is predicative"
-  end
-
+let pr_impredicative_set env =
+  if is_impredicative_set env then str "Theory: Set is impredicative"
+  else str "Theory: Set is predicative"
 
 let pr_assumptions ass axs =
   if axs = [] then
@@ -68,7 +64,7 @@ let print_context env opac =
       (hov 0
       (fnl() ++ str"CONTEXT SUMMARY" ++ fnl() ++
       str"===============" ++ fnl() ++ fnl() ++
-      str "* " ++ hov 0 (pr_engagement env ++ fnl()) ++ fnl() ++
+      str "* " ++ hov 0 (pr_impredicative_set env ++ fnl()) ++ fnl() ++
       str "* " ++ hov 0 (pr_axioms env opac ++ fnl()) ++ fnl() ++
       str "* " ++ hov 0 (pr_type_in_type env ++ fnl()) ++ fnl() ++
       str "* " ++ hov 0 (pr_unguarded env ++ fnl()) ++ fnl() ++

--- a/checker/checker.ml
+++ b/checker/checker.ml
@@ -138,14 +138,14 @@ let init_load_path () =
   includes := []
 
 
-let impredicative_set = ref Declarations.PredicativeSet
-let set_impredicative_set () = impredicative_set := Declarations.ImpredicativeSet
+let impredicative_set = ref false
+let set_impredicative_set () = impredicative_set := true
 
 let indices_matter = ref false
 
 let make_senv () =
   let senv = Safe_typing.empty_environment in
-  let senv = Safe_typing.set_engagement !impredicative_set senv in
+  let senv = Safe_typing.set_impredicative_set !impredicative_set senv in
   let senv = Safe_typing.set_indices_matter !indices_matter senv in
   let senv = Safe_typing.set_VM false senv in
   let senv = Safe_typing.set_allow_sprop true senv in (* be smarter later *)
@@ -291,7 +291,7 @@ let explain_exn = function
                              Constr.debug_print a ++ fnl ());
         Feedback.msg_notice (str"====== universes ====" ++ fnl () ++
                              (UGraph.pr_universes Univ.Level.pr
-                                (UGraph.repr (ctx.Environ.env_stratification.Environ.env_universes))));
+                                (UGraph.repr (ctx.Environ.env_universes))));
         str "CantApplyBadType at argument " ++ int n
       | CantApplyNonFunctional _ -> str"CantApplyNonFunctional"
       | IllFormedRecBody _ -> str"IllFormedRecBody"

--- a/checker/include
+++ b/checker/include
@@ -169,8 +169,7 @@ let read_mod s f =
   ((Obj.magic lib.library_compiled):
     dir_path *
     module_body *
-    (dir_path * Digest.t) list *
-    engagement option);;
+    (dir_path * Digest.t) list);;
 
 
 let expln f x =

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -214,9 +214,6 @@ let v_opaque =
 
 (** kernel/declarations *)
 
-let v_impredicative_set = v_enum "impr-set" 2
-let v_engagement = v_impredicative_set
-
 let v_conv_level =
   v_sum "conv_level" 2 [|[|Int|]|]
 
@@ -245,7 +242,7 @@ let v_typing_flags =
   v_tuple "typing_flags"
     [|v_bool; v_bool; v_bool;
       v_oracle; v_bool; v_bool;
-      v_bool; v_bool; v_bool; v_bool|]
+      v_bool; v_bool; v_bool; v_bool; v_bool; v_bool|]
 
 let v_univs = v_sum "universes" 0 [|[|v_context_set|]; [|v_abs_context|]|]
 
@@ -373,7 +370,7 @@ and v_modtype =
 let v_vodigest = Sum ("module_impl",0, [| [|String|]; [|String;String|] |])
 let v_deps = Array (v_tuple "dep" [|v_dp;v_vodigest|])
 let v_compiled_lib =
-  v_tuple "compiled" [|v_dp;v_module;v_context_set;v_deps;v_engagement|]
+  v_tuple "compiled" [|v_dp;v_module;v_context_set;v_deps|]
 
 (** Library objects *)
 

--- a/kernel/declarations.ml
+++ b/kernel/declarations.ml
@@ -15,10 +15,6 @@ open Constr
    declarations. This includes global constants/axioms, mutual
    inductive definitions, modules and module types *)
 
-type set_predicativity = ImpredicativeSet | PredicativeSet
-
-type engagement = set_predicativity
-
 (** {6 Representation of constants (Definition/Axiom) } *)
 
 (** Non-universe polymorphic mode polymorphism (Coq 8.2+): inductives
@@ -91,6 +87,12 @@ type typing_flags = {
 
   indices_matter: bool;
   (** The universe of an inductive type must be above that of its indices. *)
+
+  impredicative_set: bool;
+  (** Predicativity of the [Set] universe. *)
+
+  sprop_allowed: bool;
+  (** If [false], error when encountering [SProp]. *)
 
   cumulative_sprop : bool;
   (** SProp <= Type *)

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -26,6 +26,8 @@ let safe_flags oracle = {
   enable_VM = true;
   enable_native_compiler = true;
   indices_matter = true;
+  impredicative_set = false;
+  sprop_allowed = true;
   cumulative_sprop = false;
   allow_uip = false;
 }

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -58,13 +58,6 @@ module Globals : sig
   val view : t -> view
 end
 
-type stratification = {
-  env_universes : UGraph.t;
-  env_sprop_allowed : bool;
-  env_universes_lbound : UGraph.Bound.t;
-  env_engagement : engagement
-}
-
 type named_context_val = private {
   env_named_ctx : Constr.named_context;
   env_named_map : (Constr.named_declaration * lazy_val) Id.Map.t;
@@ -85,7 +78,8 @@ type env = private {
   env_named_context : named_context_val; (* section variables *)
   env_rel_context   : rel_context_val;
   env_nb_rel        : int;
-  env_stratification : stratification;
+  env_universes : UGraph.t;
+  env_universes_lbound : UGraph.Bound.t;
   env_typing_flags  : typing_flags;
   retroknowledge : Retroknowledge.retroknowledge;
   indirect_pterms : Opaqueproof.opaquetab;
@@ -111,7 +105,6 @@ val opaque_tables : env -> Opaqueproof.opaquetab
 val set_opaque_tables : env -> Opaqueproof.opaquetab -> env
 
 
-val engagement    : env -> engagement
 val typing_flags    : env -> typing_flags
 val is_impredicative_set : env -> bool
 val type_in_type : env -> bool
@@ -349,8 +342,8 @@ val push_subgraph : Univ.ContextSet.t -> env -> env
    also checks that they do not imply new transitive constraints
    between pre-existing universes in [env]. *)
 
-val set_engagement : engagement -> env -> env
 val set_typing_flags : typing_flags -> env -> env
+val set_impredicative_set : bool -> env -> env
 val set_cumulative_sprop : bool -> env -> env
 val set_type_in_type : bool -> env -> env
 val set_allow_sprop : bool -> env -> env

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -128,7 +128,7 @@ val add_constraints :
 (* val next_universe : int safe_transformer *)
 
 (** Setting the type theory flavor *)
-val set_engagement : Declarations.engagement -> safe_transformer0
+val set_impredicative_set : bool -> safe_transformer0
 val set_indices_matter : bool -> safe_transformer0
 val set_typing_flags : Declarations.typing_flags -> safe_transformer0
 val set_share_reduction : bool -> safe_transformer0
@@ -138,8 +138,6 @@ val set_check_universes : bool -> safe_transformer0
 val set_VM : bool -> safe_transformer0
 val set_native_compiler : bool -> safe_transformer0
 val set_allow_sprop : bool -> safe_transformer0
-
-val check_engagement : Environ.env -> Declarations.set_predicativity -> unit
 
 (** {6 Interactive section functions } *)
 

--- a/library/global.ml
+++ b/library/global.ml
@@ -92,7 +92,7 @@ let push_section_context c = globalize0 (Safe_typing.push_section_context c)
 let add_constraints c = globalize0 (Safe_typing.add_constraints c)
 let push_context_set ~strict c = globalize0 (Safe_typing.push_context_set ~strict c)
 
-let set_engagement c = globalize0 (Safe_typing.set_engagement c)
+let set_impredicative_set c = globalize0 (Safe_typing.set_impredicative_set c)
 let set_indices_matter b = globalize0 (Safe_typing.set_indices_matter b)
 let set_typing_flags c = globalize0 (Safe_typing.set_typing_flags c)
 let set_check_guarded c = globalize0 (Safe_typing.set_check_guarded c)

--- a/library/global.mli
+++ b/library/global.mli
@@ -30,7 +30,8 @@ val named_context : unit -> Constr.named_context
 (** {6 Enriching the global environment } *)
 
 (** Changing the (im)predicativity of the system *)
-val set_engagement : engagement -> unit
+val set_impredicative_set : bool -> unit
+
 val set_indices_matter : bool -> unit
 val set_typing_flags : typing_flags -> unit
 val set_check_guarded : bool -> unit

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -925,7 +925,7 @@ module ContextObjectMap = Map.Make (OrderedContextObject)
 
 let pr_assumptionset env sigma s =
   if ContextObjectMap.is_empty s &&
-       engagement env = PredicativeSet then
+       not (is_impredicative_set env) then
     str "Closed under the global context"
   else
     let safe_pr_constant env kn =

--- a/sysinit/coqargs.ml
+++ b/sysinit/coqargs.ml
@@ -40,7 +40,7 @@ type injection_command =
   | WarnNativeDeprecated
 
 type coqargs_logic_config = {
-  impredicative_set : Declarations.set_predicativity;
+  impredicative_set : bool;
   indices_matter    : bool;
   type_in_type      : bool;
   toplevel_name     : top;
@@ -96,7 +96,7 @@ let default_toplevel = Names.(DirPath.make [Id.of_string "Top"])
 let default_native = Coq_config.native_compiler
 
 let default_logic_config = {
-  impredicative_set = Declarations.PredicativeSet;
+  impredicative_set = false;
   indices_matter = false;
   type_in_type = false;
   toplevel_name = TopLogical default_toplevel;
@@ -391,7 +391,7 @@ let parse_args ~usage ~init arglist : t * string list =
       add_set_option oval Proof_diffs.opt_name @@ OptionSet (Some (next ()))
     |"-emacs" -> set_emacs oval
     |"-impredicative-set" ->
-      set_logic (fun o -> { o with impredicative_set = Declarations.ImpredicativeSet }) oval
+      set_logic (fun o -> { o with impredicative_set = true }) oval
     |"-allow-sprop" ->
       add_set_option oval Vernacentries.allow_sprop_opt_name (OptionSet None)
     |"-disallow-sprop" ->

--- a/sysinit/coqargs.mli
+++ b/sysinit/coqargs.mli
@@ -39,7 +39,7 @@ type injection_command =
       does not cause a warning, similarly to above. *)
 
 type coqargs_logic_config = {
-  impredicative_set : Declarations.set_predicativity;
+  impredicative_set : bool;
   indices_matter    : bool;
   type_in_type      : bool;
   toplevel_name     : top;

--- a/sysinit/coqinit.ml
+++ b/sysinit/coqinit.ml
@@ -103,7 +103,7 @@ let init_runtime opts =
   Mltop.init_known_plugins ();
 
   (* Configuration *)
-  Global.set_engagement opts.config.logic.impredicative_set;
+  Global.set_impredicative_set opts.config.logic.impredicative_set;
   Global.set_indices_matter opts.config.logic.indices_matter;
   Global.set_check_universes (not opts.config.logic.type_in_type);
   Global.set_VM opts.config.enable_VM;

--- a/topbin/coqnative_bin.ml
+++ b/topbin/coqnative_bin.ml
@@ -263,7 +263,6 @@ let fb_handler = function
 
 let init_coq () =
   let senv = Safe_typing.empty_environment in
-  let senv = Safe_typing.set_engagement Declarations.PredicativeSet senv in
   let () = Flags.set_native_compiler true in
   let senv = Safe_typing.set_native_compiler true senv in
   let () = Safe_typing.allow_delayed_constants := false in


### PR DESCRIPTION
I believe the only user visible change is the removal of the
require-time check that we don't depend on -impredicative-set files
without having it on.

For instance this means:
- the checker obeys only the command line -impredicative-set, it
  ignores the one stored for each definition.
- the checker always allows sprop (as previously).
- there is no new control for set predicativity with coqc/coqtop
  either, eg no "Set Impredicative Set".
