### PR TITLE
CI-paramcoq: Re-enable native

### DIFF
--- a/dev/ci/ci-paramcoq.sh
+++ b/dev/ci/ci-paramcoq.sh
@@ -5,7 +5,4 @@ ci_dir="$(dirname "$0")"
 
 git_download paramcoq
 
-# Typically flaky on our worker configuration
-# https://gitlab.com/coq/coq/-/jobs/1144081161
-export COQEXTRAFLAGS='-native-compiler no'
 ( cd "${CI_BUILD_DIR}/paramcoq" && make && make install && cd test-suite && make examples)


### PR DESCRIPTION
It's an issue in paramcoq's test suite, which doesn't respect
COQEXTRAFLAGS and so will be handled upstream
(https://github.com/coq-community/paramcoq/pull/66)