### PR TITLE
[stdlib] [Arith] add add_mul_mod_distr

### DIFF
--- a/doc/changelog/10-standard-library/14082-Int63-cleanup.rst
+++ b/doc/changelog/10-standard-library/14082-Int63-cleanup.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  lemmas ``add_mul_mod_distr_l``, ``add_mul_mod_distr_r`` to ``NZDiv.v`` (for ``nat``, ``N``, ``Z``)
+  (`#14082 <https://github.com/coq/coq/pull/14082>`_,
+  by Andrej Dudenhefner).

--- a/theories/Numbers/Cyclic/Int63/Int63.v
+++ b/theories/Numbers/Cyclic/Int63/Int63.v
@@ -214,39 +214,16 @@ Proof. apply Z.div_lt_upper_bound; reflexivity. Qed.
 
 Theorem Zmod_le_first a b : 0 <= a -> 0 < b -> 0 <= a mod b <= a.
 Proof.
-  intros ha hb; case (Z_mod_lt a b); [ auto with zarith | ]; intros p q; apply (conj p).
-  case (Z.le_gt_cases b a). lia.
-  intros hlt; rewrite Zmod_small; lia.
+  intros. now split; [apply Z.mod_bound_pos|apply Z.mod_le].
 Qed.
 
 Theorem Zmod_distr: forall a b r t, 0 <= a <= b -> 0 <= r -> 0 <= t < 2 ^a ->
   (2 ^a * r + t) mod (2 ^ b) = (2 ^a * r) mod (2 ^ b) + t.
 Proof.
-  intros a b r t (H1, H2) H3 (H4, H5).
-  assert (t < 2 ^ b).
-  apply Z.lt_le_trans with (1:= H5); auto with zarith.
-  apply Zpower_le_monotone; auto with zarith.
-  rewrite Zplus_mod; auto with zarith.
-  rewrite -> (Zmod_small t); auto with zarith.
-  apply Zmod_small; auto with zarith.
-  split; auto with zarith.
-  assert (0 <= 2 ^a * r); auto with zarith.
-  apply Z.add_nonneg_nonneg; auto with zarith.
-  match goal with |- context [?X mod ?Y] => case (Z_mod_lt X Y) end;
-   auto with zarith.
-  pattern (2 ^ b) at 2; replace (2 ^ b) with ((2 ^ b - 2 ^a) + 2 ^ a);
-    try ring.
-  apply Z.add_le_lt_mono; auto with zarith.
-  replace b with ((b - a) + a); try ring.
-  rewrite Zpower_exp; auto with zarith.
-  pattern (2 ^a) at 4; rewrite <- (Z.mul_1_l (2 ^a));
-   try rewrite <- Z.mul_sub_distr_r.
-  rewrite (Z.mul_comm (2 ^(b - a))); rewrite  Zmult_mod_distr_l;
-   auto with zarith.
-  rewrite (Z.mul_comm (2 ^a)); apply Z.mul_le_mono_nonneg_r; auto with zarith.
-  match goal with |- context [?X mod ?Y] => case (Z_mod_lt X Y) end.
-    apply Z.lt_gt; auto with zarith.
-    auto with zarith.
+  intros a b r t ? ? ?.
+  replace (2^b) with (2^a * 2^(b-a)) by (rewrite <-Zpower_exp; [f_equal| |]; lia).
+  assert (0 < 2 ^ (b - a)) by (apply Z.pow_pos_nonneg; lia).
+  rewrite Z.add_mul_mod_distr_l, <- Z.mul_mod_distr_l; lia.
 Qed.
 
 (* Results about pow2 *)

--- a/theories/Numbers/Integer/Abstract/ZDivEucl.v
+++ b/theories/Numbers/Integer/Abstract/ZDivEucl.v
@@ -613,6 +613,14 @@ Proof.
  auto using mod_always_pos.
 Qed.
 
+Lemma add_mul_mod_distr_l : forall a b c d, 0<=a -> 0<b -> 0<=d<c ->
+ (c*a+d) mod (c*b) == c*(a mod b)+d.
+Proof. intros. apply add_mul_mod_distr_l; assumption. Qed.
+
+Lemma add_mul_mod_distr_r: forall a b c d, 0<=a -> 0<b -> 0<=d<c ->
+ (a*c+d) mod (b*c) == (a mod b)*c+d.
+Proof. intros. apply add_mul_mod_distr_r; assumption. Qed.
+
 (** A last inequality: *)
 
 Theorem div_mul_le:

--- a/theories/Numbers/Integer/Abstract/ZDivFloor.v
+++ b/theories/Numbers/Integer/Abstract/ZDivFloor.v
@@ -660,6 +660,14 @@ Proof.
  auto using mod_bound_or.
 Qed.
 
+Lemma add_mul_mod_distr_l : forall a b c d, 0<=a -> 0<b -> 0<=d<c ->
+ (c*a+d) mod (c*b) == c*(a mod b)+d.
+Proof. intros. apply add_mul_mod_distr_l; assumption. Qed.
+
+Lemma add_mul_mod_distr_r: forall a b c d, 0<=a -> 0<b -> 0<=d<c ->
+ (a*c+d) mod (b*c) == (a mod b)*c+d.
+Proof. intros. apply add_mul_mod_distr_r; assumption. Qed.
+
 (** A last inequality: *)
 
 Theorem div_mul_le:

--- a/theories/Numbers/NatInt/NZDiv.v
+++ b/theories/Numbers/NatInt/NZDiv.v
@@ -412,24 +412,6 @@ Proof.
  intros a b c ? ? ?. rewrite !(mul_comm c); apply div_mul_cancel_r; auto.
 Qed.
 
-Lemma mul_mod_distr_l: forall a b c, 0<=a -> 0<b -> 0<c ->
-  (c*a) mod (c*b) == c * (a mod b).
-Proof.
- intros a b c ? ? ?.
- rewrite <- (add_cancel_l _ _ ((c*b)* ((c*a)/(c*b)))).
- rewrite <- div_mod.
- - rewrite div_mul_cancel_l; auto.
-   rewrite <- mul_assoc, <- mul_add_distr_l, mul_cancel_l by order.
-   apply div_mod; order.
- - rewrite <- neq_mul_0; intuition; order.
-Qed.
-
-Lemma mul_mod_distr_r: forall a b c, 0<=a -> 0<b -> 0<c ->
-  (a*c) mod (b*c) == (a mod b) * c.
-Proof.
- intros a b c ? ? ?. rewrite !(mul_comm _ c); now rewrite mul_mod_distr_l.
-Qed.
-
 (** Operations modulo. *)
 
 Theorem mod_mod: forall a n, 0<=a -> 0<n ->
@@ -520,6 +502,35 @@ Proof.
  rewrite add_assoc, add_shuffle0, <- mul_assoc, <- mul_add_distr_l.
  rewrite <- div_mod by order.
  apply div_mod; order.
+Qed.
+
+Lemma add_mul_mod_distr_l: forall a b c d, 0<=a -> 0<b -> 0<=d<c ->
+ (c*a+d) mod (c*b) == c*(a mod b)+d.
+Proof.
+ intros a b c d ? ? [? ?].
+ assert (0 <= a*c) by (apply mul_nonneg_nonneg; order).
+ assert (0 <= a*c+d) by (apply add_nonneg_nonneg; order).
+ rewrite (mul_comm c a), mod_mul_r, add_mod, mod_mul, div_add_l; [|order ..].
+ now rewrite ? add_0_l, div_small, add_0_r, ? (mod_small d c), (add_comm d).
+Qed.
+
+Lemma add_mul_mod_distr_r: forall a b c d, 0<=a -> 0<b -> 0<=d<c ->
+ (a*c+d) mod (b*c) == (a mod b)*c+d.
+Proof.
+ intros a b c d ? ? ?. now rewrite !(mul_comm _ c), add_mul_mod_distr_l.
+Qed.
+
+Lemma mul_mod_distr_l: forall a b c, 0<=a -> 0<b -> 0<c ->
+  (c*a) mod (c*b) == c * (a mod b).
+Proof.
+ intros a b c ? ? ?. pose proof (E := add_mul_mod_distr_l a b c 0).
+ rewrite ? add_0_r in E. now apply E.
+Qed.
+
+Lemma mul_mod_distr_r: forall a b c, 0<=a -> 0<b -> 0<c ->
+  (a*c) mod (b*c) == (a mod b) * c.
+Proof.
+ intros a b c ? ? ?. now rewrite !(mul_comm _ c), mul_mod_distr_l.
 Qed.
 
 (** A last inequality: *)

--- a/theories/Numbers/Natural/Abstract/NDiv.v
+++ b/theories/Numbers/Natural/Abstract/NDiv.v
@@ -228,6 +228,14 @@ Lemma mod_mul_r : forall a b c, b~=0 -> c~=0 ->
  a mod (b*c) == a mod b + b*((a/b) mod c).
 Proof. intros. apply mod_mul_r; auto'. Qed.
 
+Lemma add_mul_mod_distr_l : forall a b c d, 0<=a -> 0<b -> 0<=d<c ->
+ (c*a+d) mod (c*b) == c*(a mod b)+d.
+Proof. intros. apply add_mul_mod_distr_l; assumption. Qed.
+
+Lemma add_mul_mod_distr_r: forall a b c d, 0<=a -> 0<b -> 0<=d<c ->
+ (a*c+d) mod (b*c) == (a mod b)*c+d.
+Proof. intros. apply add_mul_mod_distr_r; assumption. Qed.
+
 (** A last inequality: *)
 
 Theorem div_mul_le:


### PR DESCRIPTION
This PR adds lemmas `add_mul_mod_distr_l`, `add_mul_mod_distr_r` to `NZDiv.v`, which are strictly more general than the previous `mul_mod_distr_l`, `mul_mod_distr_r`.
This greatly cleans up the previously ugly proof of `Zmod_distr` in `Int63.v` that broke each time `zarith`/`zify` were touched.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** feature / cleanup.

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
