### PR TITLE
[stdlib] [Arith] uniform modulo

### DIFF
--- a/doc/changelog/10-standard-library/14086-mod-uniform.rst
+++ b/doc/changelog/10-standard-library/14086-mod-uniform.rst
@@ -1,0 +1,10 @@
+- **Changed:**
+  set :g:`n mod 0 = n` uniformly for :g:`nat`, :g:`N`, :g:`Z`, :g:`int63`, :g:`sint63`, :g:`int31`
+  such that :g:`m = (m / n) * n + (m mod n)` holds (also for :g:`n = 0`)
+
+  .. warning:: code that relies on :g:`n mod 0 = 0` will break;
+     for compatibility with both :g:`n mod 0 = n` and :g:`n mod 0 = 0` you can use
+     :g:`n mod 0 = ltac:(match eval hnf in (1 mod 0) with |0 => exact 0 |_ => exact n end)`
+
+  (`#14086 <https://github.com/coq/coq/pull/14086>`_,
+  by Andrej Dudenhefner with help of Guillaume Melquiond, Jason Gross, and Kazuhiko Sakaguchi).

--- a/kernel/byterun/coq_interp.c
+++ b/kernel/byterun/coq_interp.c
@@ -1396,7 +1396,7 @@ value coq_interprete
         int b;
         Uint63_eq0(b, *sp);
         if (b) {
-          accu = *sp++;
+          sp++;
         }
         else {
           Uint63_mod(accu,*sp++);
@@ -1413,9 +1413,11 @@ value coq_interprete
         int b;
         Uint63_eq0(b, *sp);
         if (b) {
-          AllocPair();
-          Field(accu, 0) = *sp;
-          Field(accu, 1) = *sp++;
+          value block;
+          Alloc_small(block, 2, coq_tag_pair);
+          Field(block, 0) = *sp++;
+          Field(block, 1) = accu;
+          accu = block;
         }
         else {
           *--sp = accu;
@@ -1459,7 +1461,7 @@ value coq_interprete
         int b;
         Uint63_eq0(b, *sp);
         if (b) {
-          accu = *sp++;
+          sp++;
         }
         else {
           Uint63_mods(accu,*sp++);

--- a/kernel/uint63_31.ml
+++ b/kernel/uint63_31.ml
@@ -97,7 +97,7 @@ let div x y =
 
     (* modulo *)
 let rem x y =
-  if y = 0L then 0L else Int64.rem x y
+  if y = 0L then x else Int64.rem x y
 
 let diveucl x y = (div x y, rem x y)
 
@@ -107,7 +107,7 @@ let divs x y =
 
     (* signed modulo *)
 let rems x y =
-  if y = 0L then 0L else
+  if y = 0L then x else
     Int64.shift_right_logical (Int64.(rem (shift_left x 1) (shift_left y 1))) 1
 
 let addmuldiv p x y =

--- a/kernel/uint63_63.ml
+++ b/kernel/uint63_63.ml
@@ -84,7 +84,7 @@ let div (x : int) (y : int) =
 
     (* modulo *)
 let rem (x : int) (y : int) =
-  if y = 0 then 0 else Int64.to_int (Int64.rem (to_uint64 x) (to_uint64 y))
+  if y = 0 then x else Int64.to_int (Int64.rem (to_uint64 x) (to_uint64 y))
 
 let diveucl x y = (div x y, rem x y)
 
@@ -94,7 +94,7 @@ let divs (x : int) (y : int) =
 
     (* modulo *)
 let rems (x : int) (y : int) =
-  if y = 0 then 0 else x mod y
+  if y = 0 then x else x mod y
 
 let addmuldiv p x y =
   l_or (l_sl x p) (l_sr y (uint_size - p))

--- a/plugins/micromega/micromega.ml
+++ b/plugins/micromega/micromega.ml
@@ -538,7 +538,7 @@ module Z =
     | Z0 -> Z0,Z0
     | Zpos a' ->
       (match b with
-       | Z0 -> Z0,Z0
+       | Z0 -> Z0,a
        | Zpos _ -> pos_div_eucl a' b
        | Zneg b' ->
          let q0,r = pos_div_eucl a' (Zpos b') in
@@ -547,7 +547,7 @@ module Z =
           | _ -> (opp (add q0 (Zpos XH))),(add b r)))
     | Zneg a' ->
       (match b with
-       | Z0 -> Z0,Z0
+       | Z0 -> Z0,a
        | Zpos _ ->
          let q0,r = pos_div_eucl a' b in
          (match r with

--- a/test-suite/success/Nia.v
+++ b/test-suite/success/Nia.v
@@ -38,10 +38,10 @@ Ltac destr_step :=
   end.
 
 Example mod_0_l: forall x : Z, 0 mod x = 0. Proof. t. Qed.
-Example mod_0_r: forall x : Z, x mod 0 = 0. Proof. intros; nia. Qed.
+Example mod_0_r: forall x : Z, x mod 0 = x. Proof. intros; nia. Qed.
 Example Z_mod_same_full: forall a : Z, a mod a = 0. Proof. t. Qed.
 Example Zmod_0_l: forall a : Z, 0 mod a = 0. Proof. t. Qed.
-Example Zmod_0_r: forall a : Z, a mod 0 = 0. Proof. intros; nia. Qed.
+Example Zmod_0_r: forall a : Z, a mod 0 = a. Proof. intros; nia. Qed.
 Example mod_mod_same: forall x y : Z, (x mod y) mod y = x mod y. Proof. t. Qed.
 Example Zmod_mod: forall a n : Z, (a mod n) mod n = a mod n. Proof. t. Qed.
 Example Zmod_1_r: forall a : Z, a mod 1 = 0. Proof. intros; nia. Qed.
@@ -237,7 +237,7 @@ Qed.
 Example Z_mod_nz_opp_r: forall a b : Z, a mod b <> 0 -> a mod - b = a mod b - b.
 Proof.
   intros a b.
-  assert (a mod b <> 0 -> a / -b = -(a/b)-1) by t.
+  assert (b <> 0 -> a mod b <> 0 -> a / -b = -(a/b)-1) by t.
   nia.
 Qed.
 Example Z_mul_mod_idemp_l: forall a b n : Z, n <> 0 -> (a mod n * b) mod n = (a * b) mod n.
@@ -252,7 +252,7 @@ Qed.
 Example Z_mod_nz_opp_full: forall a b : Z, a mod b <> 0 -> - a mod b = b - a mod b.
 Proof.
   intros a b.
-  assert (a mod b <> 0 -> -a/b = -1-a/b) by nia.
+  assert (b <> 0 -> a mod b <> 0 -> -a/b = -1-a/b) by nia.
   nia.
 Qed.
 Example Z_add_mod_idemp_r: forall a b n : Z, n <> 0 -> (a + b mod n) mod n = (a + b) mod n.
@@ -303,7 +303,7 @@ Example Z_div_opp_r_z: forall a b : Z, b <> 0 -> a mod b = 0 -> a / - b = - (a /
 Example Z_mod_opp_r_nz: forall a b : Z, b <> 0 -> a mod b <> 0 -> a mod - b = a mod b - b.
 Proof.
   intros a b.
-  assert (a mod b <> 0 -> a/(-b) = -1-a/b) by nia.
+  assert (b <> 0 -> a mod b <> 0 -> a/(-b) = -1-a/b) by nia.
   nia.
 Qed.
 Example Z_mul_mod_distr_r: forall a b c : Z, b <> 0 -> c <> 0 -> (a * c) mod (b * c) = a mod b * c.
@@ -321,12 +321,12 @@ Qed.
 Example Z_mod_opp_l_nz: forall a b : Z, b <> 0 -> a mod b <> 0 -> - a mod b = b - a mod b.
 Proof.
   intros a b.
-  assert (a mod b <> 0 -> -a/b = -1-a/b) by nia.
+  assert (b <> 0 -> a mod b <> 0 -> -a/b = -1-a/b) by nia.
   nia.
 Qed.
 Example mod_eq: forall x x' y : Z, x / y = x' / y -> x mod y = x' mod y -> y <> 0 -> x = x'. Proof. intros; nia. Qed.
-Example Z_div_nz_opp_r: forall a b : Z, a mod b <> 0 -> a / - b = - (a / b) - 1. Proof. intros; nia. Qed.
-Example Z_div_nz_opp_full: forall a b : Z, a mod b <> 0 -> - a / b = - (a / b) - 1. Proof. intros; nia. Qed.
+Example Z_div_nz_opp_r: forall a b : Z, b <> 0 -> a mod b <> 0 -> a / - b = - (a / b) - 1. Proof. intros; nia. Qed.
+Example Z_div_nz_opp_full: forall a b : Z, b <> 0 -> a mod b <> 0 -> - a / b = - (a / b) - 1. Proof. intros; nia. Qed.
 Example Zmod_unique: forall a b q r : Z, 0 <= r < b -> a = b * q + r -> r = a mod b.
 Proof.
   intros a b q r ??.

--- a/theories/Init/Nat.v
+++ b/theories/Init/Nat.v
@@ -288,7 +288,7 @@ Definition div x y :=
 
 Definition modulo x y :=
   match y with
-    | 0 => y
+    | 0 => x
     | S y' => y' - snd (divmod x y' 0 y')
   end.
 

--- a/theories/ZArith/BinIntDef.v
+++ b/theories/ZArith/BinIntDef.v
@@ -388,11 +388,13 @@ Definition iter (n:Z) {A} (f:A -> A) (x:A) :=
       fraction [a/b].
     - there is no easy sign rule.
 
-  In addition, note that we arbitrary take [a/0 = 0] and [a mod 0 = 0].
+  In addition, note that we take [a/0 = 0] and [a mod 0 = a].
+  This choice is motivated by the div-mod equation
+    [a = (a / b) * b + (a mod b)] for [b = 0].
 *)
 
 (** First, a division for positive numbers. Even if the second
-   argument is a Z, the answer is arbitrary is it isn't a Zpos. *)
+   argument is a Z, the answer is arbitrary if it isn't a Zpos. *)
 
 Fixpoint pos_div_eucl (a:positive) (b:Z) : Z * Z :=
   match a with
@@ -412,7 +414,7 @@ Fixpoint pos_div_eucl (a:positive) (b:Z) : Z * Z :=
 Definition div_eucl (a b:Z) : Z * Z :=
   match a, b with
     | 0, _ => (0, 0)
-    | _, 0 => (0, 0)
+    | _, 0 => (0, a)
     | pos a', pos _ => pos_div_eucl a' b
     | neg a', pos _ =>
       let (q, r) := pos_div_eucl a' b in
@@ -450,7 +452,9 @@ Infix "mod" := modulo (at level 40, no associativity) : Z_scope.
    - sign rule for division: [quot (-a) b = quot a (-b) = -(quot a b)]
    - and for modulo: [a rem (-b) = a rem b] and [(-a) rem b = -(a rem b)]
 
- Note that we arbitrary take here [quot a 0 = 0] and [a rem 0 = a].
+  Note that we take here [quot a 0 = 0] and [a rem 0 = a].
+  This choice is motivated by the quot-rem equation
+    [a = (quot a b) * b + (a rem b)] for [b = 0].
 *)
 
 Definition quotrem (a b:Z) : Z * Z :=

--- a/theories/ZArith/Zdiv.v
+++ b/theories/ZArith/Zdiv.v
@@ -178,7 +178,7 @@ Proof.
   intros a; destruct a; simpl; auto.
 Qed.
 
-Lemma Zmod_0_r: forall a, a mod 0 = 0.
+Lemma Zmod_0_r: forall a, a mod 0 = a.
 Proof.
   intros a; destruct a; simpl; auto.
 Qed.
@@ -221,7 +221,7 @@ Lemma Z_mod_same_full : forall a, a mod a = 0.
 Proof. intros a. zero_or_not a. apply Z.mod_same; auto. Qed.
 
 Lemma Z_mod_mult : forall a b, (a*b) mod b = 0.
-Proof. intros a b. zero_or_not b. apply Z.mod_mul. auto. Qed.
+Proof. intros a b. now zero_or_not b; [apply Z.mul_0_r|apply Z.mod_mul]. Qed.
 
 Lemma Z_div_mult_full : forall a b:Z, b <> 0 -> (a*b)/b = a.
 Proof Z.div_mul.
@@ -327,7 +327,10 @@ Qed.
 (** * Relations between usual operations and Z.modulo and Z.div *)
 
 Lemma Z_mod_plus_full : forall a b c:Z, (a + b * c) mod c = a mod c.
-Proof. intros a b c. zero_or_not c. apply Z.mod_add; auto. Qed.
+Proof. intros a b c. zero_or_not c.
+ - now rewrite Z.mul_0_r, Z.add_0_r.
+ - now apply Z.mod_add.
+Qed.
 
 Lemma Z_div_plus_full : forall a b c:Z, c <> 0 -> (a + b * c) / c = a / c + b.
 Proof Z.div_add.
@@ -346,7 +349,7 @@ Lemma Zmod_opp_opp : forall a b:Z, (-a) mod (-b) = - (a mod b).
 Proof. intros a b. zero_or_not b. apply Z.mod_opp_opp; auto. Qed.
 
 Lemma Z_mod_zero_opp_full : forall a b:Z, a mod b = 0 -> (-a) mod b = 0.
-Proof. intros a b. zero_or_not b. apply Z.mod_opp_l_z; auto. Qed.
+Proof. intros a b. now zero_or_not b; [intros; subst|apply Z.mod_opp_l_z]. Qed.
 
 Lemma Z_mod_nz_opp_full : forall a b:Z, a mod b <> 0 ->
  (-a) mod b = b - (a mod b).
@@ -357,21 +360,21 @@ Proof. intros a b. zero_or_not b. apply Z.mod_opp_r_z; auto. Qed.
 
 Lemma Z_mod_nz_opp_r : forall a b:Z, a mod b <> 0 ->
  a mod (-b) = (a mod b) - b.
-Proof. intros a b ?. zero_or_not b. apply Z.mod_opp_r_nz; auto. Qed.
+Proof. intros a b ?. now zero_or_not b; [destruct a|apply Z.mod_opp_r_nz]. Qed.
 
 Lemma Z_div_zero_opp_full : forall a b:Z, a mod b = 0 -> (-a)/b = -(a/b).
 Proof. intros a b ?. zero_or_not b. apply Z.div_opp_l_z; auto. Qed.
 
-Lemma Z_div_nz_opp_full : forall a b:Z, a mod b <> 0 ->
+Lemma Z_div_nz_opp_full : forall a b:Z, b <> 0 -> a mod b <> 0 ->
  (-a)/b = -(a/b)-1.
-Proof. intros a b. zero_or_not b. easy. intros; rewrite Z.div_opp_l_nz; auto. Qed.
+Proof. intros a b. zero_or_not b; [easy|]. intros; rewrite Z.div_opp_l_nz; auto. Qed.
 
 Lemma Z_div_zero_opp_r : forall a b:Z, a mod b = 0 -> a/(-b) = -(a/b).
 Proof. intros a b ?. zero_or_not b. apply Z.div_opp_r_z; auto. Qed.
 
-Lemma Z_div_nz_opp_r : forall a b:Z, a mod b <> 0 ->
+Lemma Z_div_nz_opp_r : forall a b:Z, b <> 0 -> a mod b <> 0 ->
  a/(-b) = -(a/b)-1.
-Proof. intros a b. zero_or_not b. easy. intros; rewrite Z.div_opp_r_nz; auto. Qed.
+Proof. intros a b. zero_or_not b; [easy|]. intros; rewrite Z.div_opp_r_nz; auto. Qed.
 
 (** Cancellations. *)
 
@@ -390,15 +393,14 @@ Lemma Zmult_mod_distr_l: forall a b c,
   (c*a) mod (c*b) = c * (a mod b).
 Proof.
  intros a b c. zero_or_not c. rewrite (Z.mul_comm c b); zero_or_not b.
- + now rewrite Z.mul_0_r.
- + rewrite (Z.mul_comm b c). apply Z.mul_mod_distr_l; auto.
+ rewrite (Z.mul_comm b c). apply Z.mul_mod_distr_l; auto.
 Qed.
 
 Lemma Zmult_mod_distr_r: forall a b c,
   (a*c) mod (b*c) = (a mod b) * c.
 Proof.
  intros a b c. zero_or_not b. rewrite (Z.mul_comm b c); zero_or_not c.
- + now rewrite Z.mul_0_r.
+ + now rewrite !Z.mul_0_r.
  + rewrite (Z.mul_comm c b). apply Z.mul_mod_distr_r; auto.
 Qed.
 
@@ -646,7 +648,7 @@ Definition Zmod' a b :=
    | Z0 => 0
    | Zpos a' =>
       match b with
-       | Z0 => 0
+       | Z0 => a
        | Zpos _ => Zmod_POS a' b
        | Zneg b' =>
           let r := Zmod_POS a' (Zpos b') in
@@ -654,7 +656,7 @@ Definition Zmod' a b :=
       end
    | Zneg a' =>
       match b with
-       | Z0 => 0
+       | Z0 => a
        | Zpos _ =>
           let r := Zmod_POS a' b in
           match r with Z0 =>  0 | _  =>  b - r end

--- a/theories/ZArith/Znat.v
+++ b/theories/ZArith/Znat.v
@@ -234,10 +234,10 @@ Proof.
  rewrite <- inj_mul, <- inj_add. f_equal. now apply N.div_mod.
 Qed.
 
-Lemma inj_mod n m : (m<>0)%N -> Z.of_N (n mod m) = (Z.of_N n) mod (Z.of_N m).
+Lemma inj_mod n m : Z.of_N (n mod m) = (Z.of_N n) mod (Z.of_N m).
 Proof.
- intros Hm.
- apply Z.mod_unique_pos with (Z.of_N (n / m)).
+ destruct m as [|m]. now destruct n.
+ apply Z.mod_unique_pos with (Z.of_N (n / N.pos m)).
  split. apply is_nonneg. apply inj_lt. now apply N.mod_lt.
  rewrite <- inj_mul, <- inj_add. f_equal. now apply N.div_mod.
 Qed.
@@ -253,7 +253,7 @@ Lemma inj_rem n m : Z.of_N (n mod m) = Z.rem (Z.of_N n) (Z.of_N m).
 Proof.
  destruct m.
  - now destruct n.
- - rewrite Z.rem_mod_nonneg, inj_mod; trivial. easy. apply is_nonneg. easy.
+ - rewrite Z.rem_mod_nonneg, inj_mod; trivial. apply is_nonneg. easy.
 Qed.
 
 Lemma inj_div2 n : Z.of_N (N.div2 n) = Z.div2 (Z.of_N n).
@@ -383,7 +383,7 @@ Proof.
  simpl. rewrite <- (N2Z.id (_ / _)). f_equal. now rewrite N2Z.inj_div.
 Qed.
 
-Lemma inj_mod n m : 0<=n -> 0<m ->
+Lemma inj_mod n m : 0<=n -> 0<=m ->
  Z.to_N (n mod m) = ((Z.to_N n) mod (Z.to_N m))%N.
 Proof.
  destruct n, m; trivial; intros Hn Hm;

--- a/theories/extraction/ExtrHaskellNatNum.v
+++ b/theories/extraction/ExtrHaskellNatNum.v
@@ -32,6 +32,6 @@ Extract Constant Init.Nat.pred => "(\n -> Prelude.max 0 (Prelude.pred n))".
 Extract Constant Init.Nat.sub => "(\n m -> Prelude.max 0 (n Prelude.- m))".
 
 Extract Constant Nat.div => "(\n m -> if m Prelude.== 0 then 0 else Prelude.div n m)".
-Extract Constant Nat.modulo => "(\n m -> if m Prelude.== 0 then 0 else Prelude.mod n m)".
+Extract Constant Nat.modulo => "(\n m -> if m Prelude.== 0 then n else Prelude.mod n m)".
 Extract Constant Init.Nat.div => "(\n m -> if m Prelude.== 0 then 0 else Prelude.div n m)".
-Extract Constant Init.Nat.modulo => "(\n m -> if m Prelude.== 0 then 0 else Prelude.mod n m)".
+Extract Constant Init.Nat.modulo => "(\n m -> if m Prelude.== 0 then n else Prelude.mod n m)".

--- a/theories/extraction/ExtrHaskellZNum.v
+++ b/theories/extraction/ExtrHaskellZNum.v
@@ -20,4 +20,4 @@ Extract Inlined Constant Z_ge_lt_dec => "(Prelude.>=)".
 Extract Inlined Constant Z_gt_le_dec => "(Prelude.>)".
 
 Extract Constant Z.div => "(\n m -> if m Prelude.== 0 then 0 else Prelude.div n m)".
-Extract Constant Z.modulo => "(\n m -> if m Prelude.== 0 then 0 else Prelude.mod n m)".
+Extract Constant Z.modulo => "(\n m -> if m Prelude.== 0 then n else Prelude.mod n m)".

--- a/theories/extraction/ExtrOcamlZBigInt.v
+++ b/theories/extraction/ExtrOcamlZBigInt.v
@@ -60,7 +60,7 @@ Extract Constant N.max => "Big.max".
 Extract Constant N.div =>
  "fun a b -> if Big.eq b Big.zero then Big.zero else Big.div a b".
 Extract Constant N.modulo =>
- "fun a b -> if Big.eq b Big.zero then Big.zero else Big.modulo a b".
+ "fun a b -> if Big.eq b Big.zero then a else Big.modulo a b".
 Extract Constant N.compare => "Big.compare_case Eq Lt Gt".
 
 Extract Constant Z.add => "Big.add".

--- a/theories/omega/PreOmega.v
+++ b/theories/omega/PreOmega.v
@@ -24,7 +24,7 @@ Local Open Scope Z_scope.
     of division/quotient and modulo/remainder. *)
 
 Module Z.
-  Lemma mod_0_r_ext x y : y = 0 -> x mod y = 0.
+  Lemma mod_0_r_ext x y : y = 0 -> x mod y = x.
   Proof. intro; subst; destruct x; reflexivity. Qed.
   Lemma div_0_r_ext x y : y = 0 -> x / y = 0.
   Proof. intro; subst; destruct x; reflexivity. Qed.


### PR DESCRIPTION
<!-- Keep what applies -->
**Kind:** cleanup / feature

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

Currently stdlib contains the following incoherence:
```
Compute (1 mod 0)%nat.  (* = 0%nat : nat *)
Compute (1 mod 0)%Z.    (* = 0%Z : Z *)
Compute (1 mod 0)%N.    (* = 1%N : N *)
```
This leads to glue code/additional assumptions upon switching representations (e.g. for `zify`).

This PR sets `n mod 0 = n` uniformly for `nat`, `N`, `Z`, `int63`, `sint63`, `int31`. As a result we get:
- conversions between `nat`, `N`, `Z` (for `zify`) behave well wrt. `mod`
- stronger `inj_mod` lemmas for `zify` (better `lia`, `nia`)
- uniformly we have `n = (n / m) * m + (n mod m)` in `nat`, `N`, (nonnegative) `Z`
- conformity with `math-comp`'s `Lemma modn0 m : m %% 0 = m.` (see also [zulip](https://coq.zulipchat.com/#narrow/stream/237664-math-comp-users/topic/m.20.25.25.200.20.3D.20m))
- in future the `div_mod` axiom in `NZDiv` can be strengthened
- since for the cyclic group *Z/0Z = Z* it is sensible to consider `_ mod 0` as identity
- fyi, `lean` has `theorem mod_zero (a : Nat) : a % 0 = a`

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
- [x] Overlay pull requests (if this breaks 3rd party developments in CI, see
https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md for details)

Compatibility PRs for CI:
- [x] iris (merged): https://gitlab.mpi-sws.org/iris/stdpp/-/merge_requests/240
- [x] flocq (merged): @silene manual https://github.com/mrhaandi/flocq/tree/mod-uniform
- [x] paramcoq (merged): https://github.com/coq-community/paramcoq/pull/67
- [x] rewriter (merged): https://github.com/mit-plv/rewriter/pull/25
- [x] bbv (merged): https://github.com/mit-plv/bbv/pull/34
- [x] coqutil (merged): https://github.com/mit-plv/coqutil/pull/35
- [x] perennial (merged): https://github.com/mit-pdos/perennial/pull/31
- [x] kami (merged): https://github.com/mit-plv/kami/pull/23
- [x] bedrock2 (merged): https://github.com/mit-plv/bedrock2/pull/178
- [x] bignums (merged): https://github.com/coq/bignums/pull/58
- [x] coqprime (merged): https://github.com/thery/coqprime/pull/26
- [x] fiat_crypto_legacy (merged): https://github.com/mit-plv/fiat-crypto/pull/933
- [x] math_classes (merged): https://github.com/coq-community/math-classes/pull/95
- [x] corn (merged): https://github.com/coq-community/corn/pull/159
- [x] fiat_crypto (merged): https://github.com/mit-plv/fiat-crypto/pull/935