### PR TITLE
Fix link in doc/cic.rst, there is no Credits chapter anymore

### DIFF
--- a/doc/sphinx/language/cic.rst
+++ b/doc/sphinx/language/cic.rst
@@ -5,7 +5,7 @@ The underlying formal language of Coq is a
 :gdef:`Calculus of Inductive Constructions` (|Cic|) whose inference rules
 are presented in this
 chapter. The history of this formalism as well as pointers to related
-work are provided in a separate chapter; see *Credits*.
+work are provided in a separate chapter; see :ref:`history`.
 
 
 .. _The-terms:


### PR DESCRIPTION
**Kind:** documentation.

The `cic` file in the documentation referred to the `Credits` chapter, which has been moved to be the `Early history of Coq` chapter. Now the `cic` file reflects this change.