### PR TITLE
Register Ltac2 grammar entry as "ltac2" for the Print Grammar vernacular

### DIFF
--- a/doc/changelog/07-vernac-commands-and-options/14093-fix-14092.rst
+++ b/doc/changelog/07-vernac-commands-and-options/14093-fix-14092.rst
@@ -1,0 +1,6 @@
+- **Added:**
+  The Ltac2 grammar can now be printed using the
+  Print Grammar ltac2 command
+  (`#14093 <https://github.com/coq/coq/pull/14093>`_,
+  fixes `#14092 <https://github.com/coq/coq/issues/14092>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -467,6 +467,7 @@ Displaying information about notations
    - `tactic` - for currently-defined tactic notations, :token:`tactic`\s and tacticals
      (corresponding to :token:`ltac_expr` in the documentation).
    - `vernac` - for :token:`command`\s
+   - `ltac2` - for Ltac2 notations (corresponding to :token:`ltac2_expr`)
 
    This command doesn't display all nonterminals of the grammar.  For example,
    productions shown by `Print Grammar tactic` refer to nonterminals `tactic_then_locality`

--- a/user-contrib/Ltac2/tac2entries.ml
+++ b/user-contrib/Ltac2/tac2entries.ml
@@ -50,6 +50,12 @@ let q_pose = Pcoq.Entry.create "q_pose"
 let q_assert = Pcoq.Entry.create "q_assert"
 end
 
+let () =
+  let entries = [
+    Pcoq.AnyEntry Pltac.ltac2_expr;
+  ] in
+  Pcoq.register_grammars_by_name "ltac2" entries
+
 (** Tactic definition *)
 
 type tacdef = {


### PR DESCRIPTION
Fixes #14092: Print Grammar ltac2 should exist.

- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
