### PR TITLE
Properly pass the Ltac2 notation level to the gramlib API.

### DIFF
--- a/doc/changelog/05-tactic-language/14094-ltac2-notation-level-fix.rst
+++ b/doc/changelog/05-tactic-language/14094-ltac2-notation-level-fix.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Ltac2 notations now correctly take into account their assigned level
+  (`#14094 <https://github.com/coq/coq/pull/14094>`_,
+  fixes `#11866 <https://github.com/coq/coq/issues/11866>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -1251,6 +1251,10 @@ Notations
 
    This command supports the :attr:`deprecated` attribute.
 
+   .. exn:: Notation levels must range between 0 and 6.
+
+      The level of a notation must be an integer between 0 and 6 inclusive.
+
 Abbreviations
 ~~~~~~~~~~~~~
 

--- a/test-suite/bugs/closed/bug_11866.v
+++ b/test-suite/bugs/closed/bug_11866.v
@@ -1,0 +1,43 @@
+Require Import Ltac2.Ltac2.
+
+Ltac2 Notation "ex0" x(tactic(0)) := ().
+Ltac2 Notation "ex1" x(tactic(1)) := ().
+Ltac2 Notation "ex2" x(tactic(2)) := ().
+Ltac2 Notation "ex3" x(tactic(3)) := ().
+Ltac2 Notation "ex4" x(tactic(4)) := ().
+Ltac2 Notation "ex5" x(tactic(5)) := ().
+Ltac2 Notation "ex6" x(tactic(6)) := ().
+
+Ltac2 Notation ":::0" x(tactic) "+0" y(tactic) : 0 := ().
+Ltac2 Notation ":::1" x(tactic) "+1" y(tactic) : 1 := ().
+Ltac2 Notation ":::2" x(tactic) "+2" y(tactic) : 2 := ().
+Ltac2 Notation ":::3" x(tactic) "+3" y(tactic) : 3 := ().
+Ltac2 Notation ":::4" x(tactic) "+4" y(tactic) : 4 := ().
+Ltac2 Notation ":::5" x(tactic) "+5" y(tactic) : 5 := ().
+Ltac2 Notation ":::6" x(tactic) "+6" y(tactic) : 6 := ().
+Fail Ltac2 Notation ":::7" x(tactic) "+7" y(tactic) : 7 := ().
+Goal True.
+  ex0 :::0 0 +0 0.
+  ex1 :::0 0 +0 0.
+  (*ex2 :::0 0 +0 0.*) (* fails with an anomaly, cf COQBUG(https://github.com/coq/coq/issues/12807) *)
+  (*ex3 :::0 0 +0 0.*)
+  ex4 :::0 0 +0 0.
+  ex5 :::0 0 +0 0.
+  ex6 :::0 0 +0 0.
+
+  ex0 :::1 0 +1 0.
+  ex1 :::1 0 +1 0.
+  (*ex2 :::1 0 +1 0.*)
+  (*ex3 :::1 0 +1 0.*)
+  ex4 :::1 0 +1 0.
+  ex5 :::1 0 +1 0.
+  ex6 :::1 0 +1 0.
+
+  ex0 :::6 0 +6 0.
+  ex1 :::6 0 +6 0.
+  (*ex2 :::6 0 +6 0.*)
+  (*ex3 :::6 0 +6 0.*)
+  ex4 :::6 0 +6 0.
+  ex5 :::6 0 +6 0.
+  ex6 :::6 0 +6 0.
+Abort.


### PR DESCRIPTION
For some reason I was confusing the position and the level in the previous version of the code.

I am leaving this as a draft for now since we may seize the opportunity to have a richer level language for Ltac2 notations.

Fixes #11866: Ltac2 Notations do not respect precedence.

- [x] Added / updated test-suite
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
