### PR TITLE
Fix a GTK warning in CoqIDE introduced by #14063.

### DIFF
--- a/ide/coqide/coq_commands.ml
+++ b/ide/coqide/coq_commands.ml
@@ -93,7 +93,6 @@ let commands = [
    ];
   ["Read Module";
    "Record";
-   "Variant";
    "Remark";
    "Remove LoadPath";
    "Remove Printing Constructor";


### PR DESCRIPTION
The Variant entry was appearing twice, leading to a duplicate warning.

cc @herbelin 