### PR TITLE
The usual order of strings, take 2

### DIFF
--- a/doc/changelog/10-standard-library/14096-string-ot.rst
+++ b/doc/changelog/10-standard-library/14096-string-ot.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  Added ``Coq.Structures.OrdersEx.String_as_OT`` and
+  ``Coq.Structures.OrdersEx.Ascii_as_OT`` to make strings and ascii ordered
+  types (using lexical order).  (`#14096
+  <https://github.com/coq/coq/pull/14096>`_, by Jason Gross).

--- a/theories/Structures/OrdersEx.v
+++ b/theories/Structures/OrdersEx.v
@@ -15,11 +15,12 @@
 
 Require Import Orders BoolOrder PeanoNat POrderedType BinNat BinInt
  RelationPairs EqualitiesFacts.
+Require Import Ascii String.
 
 (** * Examples of Ordered Type structures. *)
 
 
-(** Ordered Type for [bool], [nat], [Positive], [N], [Z] with the usual order. *)
+(** Ordered Type for [bool], [nat], [Positive], [N], [Z], [ascii], [string] with the usual or lexicographic order. *)
 
 Module Bool_as_OT := BoolOrder.BoolOrd.
 Module Nat_as_OT := PeanoNat.Nat.
@@ -155,3 +156,88 @@ Module PositiveOrderedTypeBits <: UsualOrderedType.
   Qed.
 
 End PositiveOrderedTypeBits.
+
+Module Ascii_as_OT <: UsualOrderedType.
+  Definition t := ascii.
+  Include HasUsualEq <+ UsualIsEq.
+  Definition eqb := Ascii.eqb.
+  Definition eqb_eq := Ascii.eqb_eq.
+  Include HasEqBool2Dec.
+
+  Definition compare (a b : ascii) := N_as_OT.compare (N_of_ascii a) (N_of_ascii b).
+  Definition lt (a b : ascii) := N_as_OT.lt (N_of_ascii a) (N_of_ascii b).
+
+  Instance lt_compat : Proper (eq==>eq==>iff) lt.
+  Proof.
+    intros x x' Hx y y' Hy. rewrite Hx, Hy; intuition.
+  Qed.
+
+  Instance lt_strorder : StrictOrder lt.
+  Proof.
+    split; unfold lt; [ intro | intros ??? ]; eapply N_as_OT.lt_strorder.
+  Qed.
+
+  Lemma compare_spec : forall x y, CompSpec eq lt x y (compare x y).
+  Proof.
+    intros x y; unfold eq, lt, compare.
+    destruct (N_as_OT.compare_spec (N_of_ascii x) (N_of_ascii y)) as [H|H|H]; constructor; try assumption.
+    now rewrite <- (ascii_N_embedding x), <- (ascii_N_embedding y), H.
+  Qed.
+End Ascii_as_OT.
+
+(** [String] is an ordered type with respect to the usual lexical order. *)
+
+Module String_as_OT <: UsualOrderedType.
+  Definition t := string.
+  Include HasUsualEq <+ UsualIsEq.
+  Definition eqb := String.eqb.
+  Definition eqb_eq := String.eqb_eq.
+  Include HasEqBool2Dec.
+
+  Fixpoint compare (a b : string)
+    := match a, b with
+       | EmptyString, EmptyString => Eq
+       | EmptyString, _ => Lt
+       | String _ _, EmptyString => Gt
+       | String a_head a_tail, String b_head b_tail =>
+         match Ascii_as_OT.compare a_head b_head with
+         | Lt => Lt
+         | Gt => Gt
+         | Eq => compare a_tail b_tail
+         end
+       end.
+
+  Definition lt (a b : string) := compare a b = Lt.
+
+  Instance lt_compat : Proper (eq==>eq==>iff) lt.
+  Proof.
+    intros x x' Hx y y' Hy. rewrite Hx, Hy; intuition.
+  Qed.
+
+  Lemma compare_spec : forall x y, CompSpec eq lt x y (compare x y).
+  Proof.
+    unfold eq, lt.
+    induction x as [|x xs IHxs], y as [|y ys]; cbn [compare]; try constructor; cbn [compare]; try reflexivity.
+    specialize (IHxs ys).
+    destruct (Ascii_as_OT.compare x y) eqn:H; [ destruct IHxs; constructor | constructor | constructor ]; cbn [compare].
+    all: destruct (Ascii_as_OT.compare_spec y x), (Ascii_as_OT.compare_spec x y); cbv [Ascii_as_OT.eq] in *; try congruence; subst.
+    all: exfalso; eapply irreflexivity; (idtac + etransitivity); eassumption.
+  Qed.
+
+  Instance lt_strorder : StrictOrder lt.
+  Proof.
+    split; unfold lt; [ intro x | intros x y z ]; unfold complement.
+    { induction x as [|x xs IHxs]; cbn [compare]; [ congruence | ].
+      destruct (Ascii_as_OT.compare x x) eqn:H; try congruence.
+      exfalso; eapply irreflexivity; eassumption. }
+    { revert x y z.
+      induction x as [|x xs IHxs], y as [|y ys], z as [|z zs]; cbn [compare]; try congruence.
+      specialize (IHxs ys zs).
+      destruct (Ascii_as_OT.compare x y) eqn:Hxy, (Ascii_as_OT.compare y z) eqn:Hyz, (Ascii_as_OT.compare x z) eqn:Hxz;
+        try intuition (congruence || eauto).
+      all: destruct (Ascii_as_OT.compare_spec x y), (Ascii_as_OT.compare_spec y z), (Ascii_as_OT.compare_spec x z);
+        try discriminate.
+      all: unfold Ascii_as_OT.eq in *; subst.
+      all: exfalso; eapply irreflexivity; (idtac + etransitivity); (idtac + etransitivity); eassumption. }
+  Qed.
+End String_as_OT.


### PR DESCRIPTION
There are versions in `theories/Structures/OrderedTypeEx.v` since
https://github.com/coq/coq/pull/7221, but this module is deprecated, and
there does not seem to be any standard way to convert to the
non-deprecated `OrderedType`.  This fixes that problem, and allows users
to sort strings and ascii.

Pluasibly, we should move these modules to `Ascii.v` and `String.v` (and
fill out `Byte.v`, but this seems to require a deeper restructuring of
the files.  For `N`, `Z`, et. al., there seems to be a clear distinction
between which modules get imported (to get notations, `N`, etc), and
which modules do not get imported (so that lemmas are qualified for what
they are about, so that we have `N.t` and `Z.t` not `t`, etc).  I'm not
sure how to restructure the `Ascii`, `Byte`, and `String` files in this
way, and this reorganization seems beyond the scope of this minor
enhancement.

- [ ] Added / updated test-suite
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
- [ ] Overlay pull requests (if this breaks 3rd party developments in CI, see
https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md for details)
