### PR TITLE
Fixing #11504, #14090: anomaly of destruct in the presence of dependent variables unused in goal

### DIFF
--- a/doc/changelog/04-tactics/14097-master+fix11504-anomaly-destruct-unused-dep-var.rst
+++ b/doc/changelog/04-tactics/14097-master+fix11504-anomaly-destruct-unused-dep-var.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Anomaly of :tacn:`destruct` on terms with dependent variables unused in goal
+  (`#14097 <https://github.com/coq/coq/pull/14097>`_,
+  fixes `#11504 <https://github.com/coq/coq/issues/11504>`_
+  and `#14090 <https://github.com/coq/coq/issues/14090>`_,
+  by Hugo Herbelin).

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -108,8 +108,7 @@ let clenv_environments evd bound t =
       | (n, Prod (na,t1,t2)) ->
           let mv = new_meta () in
           let dep = not (noccurn evd 1 t2) in
-          let na' = if dep then na.binder_name else Anonymous in
-          let e' = meta_declare mv t1 ~name:na' e in
+          let e' = meta_declare mv t1 ~name:na.binder_name e in
           clrec (e', (mkMeta mv)::metas) (Option.map ((+) (-1)) n)
             (if dep then (subst1 (mkMeta mv) t2) else t2)
       | (n, LetIn (na,b,_,t)) -> clrec (e,metas) n (subst1 b t)

--- a/test-suite/bugs/closed/bug_11504.v
+++ b/test-suite/bugs/closed/bug_11504.v
@@ -1,0 +1,25 @@
+(* These examples should fail with "Unable to find an instance for the variable ..." *)
+(* but they used to raise an anomaly from 8.5 to 8.13 *)
+
+Definition hl_inv(a b c: nat): Prop := a > 0 /\ b > 0.
+
+Goal forall a b,
+    (forall m, hl_inv a b m) ->
+    True.
+Proof.
+  intros.
+  Fail destruct H.
+Abort.
+
+Definition R (arg: bool) : Type := bool.
+
+Definition r (arg: bool) : R arg := false.
+
+Goal True.
+  Fail destruct r.
+Abort.
+
+(* #14090 *)
+Lemma t (H : forall x, (fun _ : unit => unit) x) : True.
+Fail destruct H.
+Abort.


### PR DESCRIPTION
**Kind:** bug fix

Hoping that the fix (always naming a variable in the clausenv, if it has a name, even if non dependent) will not have side effects.

Fixes / closes #11504
Fixes / closes #14090

- [X] Added / updated test-suite
- [x] Entry added in the changelog
