### PR TITLE
Let destruct consistently use a whnf-normalized type of the destructed term

### DIFF
--- a/dev/ci/user-overlays/14099-LasseBlaauwbroek-fix-destruct-type.sh
+++ b/dev/ci/user-overlays/14099-LasseBlaauwbroek-fix-destruct-type.sh
@@ -1,0 +1,1 @@
+overlay coq_dpdgraph https://github.com/LasseBlaauwbroek/coq-dpdgraph fix-destruct-type 14099

--- a/doc/changelog/04-tactics/15099-fix-destruct-type.rst
+++ b/doc/changelog/04-tactics/15099-fix-destruct-type.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Anomaly of :tacn:`destruct` on terms with dependent variables unused in goal
+  (`#15099 <https://github.com/coq/coq/pull/15099>`_,
+  fixes `#11504 <https://github.com/coq/coq/issues/11504>`_
+  and `#14090 <https://github.com/coq/coq/issues/14090>`_,
+  by Lasse Blaauwbroek and Hugo Herbelin).

--- a/test-suite/bugs/closed/bug_11504.v
+++ b/test-suite/bugs/closed/bug_11504.v
@@ -1,0 +1,25 @@
+(* These examples should generate side conditions for the non-instantiated non-dependent parameters *)
+(* but they used to raise an anomaly from 8.5 to 8.13 *)
+
+Definition hl_inv(a b c: nat): Prop := a > 0 /\ b > 0.
+
+Goal forall a b,
+    (forall m, hl_inv a b m) ->
+    True.
+Proof.
+  intros.
+  destruct H.
+Abort.
+
+Definition R (arg: bool) : Type := bool.
+
+Definition r (arg: bool) : R arg := false.
+
+Goal True.
+  destruct r.
+Abort.
+
+(* #14090 *)
+Lemma t (H : forall x, (fun _ : unit => unit) x) : True.
+destruct H.
+Abort.


### PR DESCRIPTION
This will prevent goals that were marked as non-dependent from becoming
dependent later, if its type is not properly normalized then.

Fixes #11504
Fixes #14090

See #14097 for previous PR.

<!-- Keep what applies -->
**Kind:** bug fix


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).