### PR TITLE
Fixes #14100: extraction failure of a logical type with parameters sealed behind a non-logical type assumption

### DIFF
--- a/doc/changelog/07-vernac-commands-and-options/14102-master+fix14100-extraction-aliased-logical-type-with-params.rst
+++ b/doc/changelog/07-vernac-commands-and-options/14102-master+fix14100-extraction-aliased-logical-type-with-params.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  extraction failure of a parameterized type in :g:`Prop` exported in
+  an module interface as an assumption in :g:`Type`
+  (`#14102 <https://github.com/coq/coq/pull/14102>`_,
+  fixes `#14100 <https://github.com/coq/coq/issues/14100>`_,
+  by Hugo Herbelin).

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -1123,7 +1123,9 @@ let extract_constant env kn cb =
   in
   try
     match flag_of_type env sg typ with
-    | (Logic,TypeScheme) -> warn_log (); Dtype (r, [], Tdummy Ktype)
+    | (Logic,TypeScheme) -> warn_log ();
+        let s,vl = type_sign_vl env sg typ in
+        Dtype (r, vl, Tdummy Ktype)
     | (Logic,Default) -> warn_log (); Dterm (r, MLdummy Kprop, Tdummy Kprop)
     | (Info,TypeScheme) ->
         (match cb.const_body with
@@ -1160,7 +1162,9 @@ let extract_constant_spec env kn cb =
   let typ = EConstr.of_constr cb.const_type in
   try
     match flag_of_type env sg typ with
-    | (Logic, TypeScheme) -> Stype (r, [], Some (Tdummy Ktype))
+    | (Logic, TypeScheme) ->
+        let s,vl = type_sign_vl env sg typ in
+        Stype (r, vl, Some (Tdummy Ktype))
     | (Logic, Default) -> Sval (r, Tdummy Kprop)
     | (Info, TypeScheme) ->
         let s,vl = type_sign_vl env sg typ in
@@ -1225,7 +1229,7 @@ let extract_inductive env kn =
 
 let logical_decl = function
   | Dterm (_,MLdummy _,Tdummy _) -> true
-  | Dtype (_,[],Tdummy _) -> true
+  | Dtype (_,_,Tdummy _) -> true
   | Dfix (_,av,tv) ->
       (Array.for_all isMLdummy av) &&
       (Array.for_all isTdummy tv)
@@ -1235,7 +1239,7 @@ let logical_decl = function
 (*s Is a [ml_spec] logical ? *)
 
 let logical_spec = function
-  | Stype (_, [], Some (Tdummy _)) -> true
+  | Stype (_, _, Some (Tdummy _)) -> true
   | Sval (_,Tdummy _) -> true
   | Sind (_,i) -> Array.for_all (fun ip -> ip.ip_logical) i.ind_packets
   | _ -> false

--- a/test-suite/bugs/closed/bug_14100.v
+++ b/test-suite/bugs/closed/bug_14100.v
@@ -1,0 +1,57 @@
+From Coq Require Import Extraction.
+
+Set Warnings "-extraction-inside-module".
+
+Module OriginalExample.
+
+Variant nondetE : Type -> Type :=
+  Or : nondetE bool.
+
+Module Type MinSIG.
+Parameter otherE : Type -> Type.
+End MinSIG.
+
+Module Min : MinSIG.
+Definition otherE := nondetE.
+End Min.
+
+Extraction TestCompile Min.
+
+End OriginalExample.
+
+(**)
+
+Module ExampleWithSmallParameter.
+
+Variant nondetE : nat -> Type -> Type :=
+  Or : nondetE 0 bool.
+
+Module Type MinSIG.
+Parameter otherE : nat -> Type -> Type.
+End MinSIG.
+
+Module Min : MinSIG.
+Definition otherE := nondetE.
+End Min.
+
+Extraction TestCompile Min.
+
+End ExampleWithSmallParameter.
+
+(* This was already working *)
+
+Module ExampleWithLogicalDefinition.
+
+Definition nondetE (n:nat) (X:Type) := Prop.
+
+Module Type MinSIG.
+Parameter otherE : nat -> Type -> Type.
+End MinSIG.
+
+Module Min : MinSIG.
+Definition otherE := nondetE.
+End Min.
+
+Extraction TestCompile Min.
+
+End ExampleWithLogicalDefinition.


### PR DESCRIPTION
**Kind:** bug fix 

The fix strictly needs to add the correct parameters to `Dtype` (for the implementation of the module). I added them also to `Stype` (for the interface of the module) even if it is probably not needed because logical type in signatures would not be exported anyway.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #14100



- [X] Added / updated test-suite
- [x] Entry added in the changelog
