### PR TITLE
Typeclasses default mode

### DIFF
--- a/doc/changelog/07-vernac-commands-and-options/14103-class-mode-declarations.rst
+++ b/doc/changelog/07-vernac-commands-and-options/14103-class-mode-declarations.rst
@@ -1,0 +1,10 @@
+- **Added:**
+  New attribute :attr:`modes` for :cmd:`Class` declarations,
+  option :opt:`Typeclasses Default Mode` and warning
+  :ref:`class-declaration-default-mode <TypeclassesDefaultModeWarning>`.
+  The new attribute allows to set the :ref:`modes of resolution <ClassModes>`
+  of a class at declaration time.
+  The new option declares a default mode which will be used for *all* indices of
+  declared classes. The new warning can be activated or even turned into an error
+  if a library author prefers to require mode declarations on every class.
+  (`#14103 <https://github.com/coq/coq/pull/14103>`_, by Matthieu Sozeau).

--- a/doc/sphinx/addendum/type-classes.rst
+++ b/doc/sphinx/addendum/type-classes.rst
@@ -44,7 +44,7 @@ Leibniz equality on some type.
 .. note::
    The mode declaration "!" states that ``EqDec A`` class constraints can
    only be resolved when the index ``A`` is not an existential variable,
-   preventing typeclass resolution to arbitrarily choose an instance in
+   preventing typeclass resolution from arbitrarily choosing an instance in
    those cases. An even stricter choice is the mode "+" which prevents
    resolution if an existential variable appears at any position in ``A``,
    not just at the head.
@@ -244,7 +244,7 @@ superclasses will be done automatically.
 
 The mode declaration states that resolution of `Ord A E` constraints
 is restricted to cases where `A`'s head is determined, or equivalently
-when `A` is not an existential variable, but `E` can be any term.
+when `A` is not an existential variable and `E` is any term.
 
 .. coqtop:: all
 
@@ -344,20 +344,20 @@ Summary of the commands
 
    .. attr:: mode
 
-      This attribute can be used to set the mode of resolution of the class
+      Sets the resolution mode of the class
       at declaration time, using the same syntax as :cmd:`Hint Mode`,
-      and is mostly equivalent to a `Hint Mode` declaration after the
+      and is equivalent to a `Hint Mode` declaration after the
       `Class` declaration, except that the `mode` declaration can survive
       section closing. The setting affects when typeclass resolution can be triggered
-      on a constraint for the class, see :ref:`below <ClassMode>` for details.
-      It is recommended to always set a mode when introducing a class or use
+      for a class constraint, see :ref:`below <ClassMode>` for details.
+      We recommend always setting a mode when introducing a class or using
       a default mode.
 
    .. error: Discharging the class @ident would drop its mode declaration. Declare the class outside a section.
 
       If a :attr:`mode` attribute is given to a class inside a section, but no
-      `default mode <TypeclassesDefaultMode>` is set, then this results in an error at section
-      closing as we don't know how which mode the discharged variables for the class should have.
+      `default mode <TypeclassesDefaultMode>` is set, this results in an error at section
+      closing since Coq don't know which mode the discharged variables for the class should have.
 
    .. cmd:: Existing Class @qualid
 
@@ -570,7 +570,7 @@ Settings
 
    .. warn:: Using inferred default mode declaration “mode” for “@ident”
 
-      This (by default disabled) warning informs the user when a mode has been assigned
+      Indicates that the mode has been assigned
       automatically. It can be used to lint a library and ensure all typeclasses
       have been assigned explicit mode declarations.
 

--- a/doc/sphinx/addendum/type-classes.rst
+++ b/doc/sphinx/addendum/type-classes.rst
@@ -26,14 +26,14 @@ the ``fi : ti`` are called the *methods*. Each class definition gives
 rise to a corresponding record declaration and each instance is a
 regular definition whose name is given by `instancename` and type is an
 instantiation of the record type. The :cmd:`Class` command supports the
-additional :attr:`mode` attribute to set a :ref:`mode of resolution <ClassMode>`
+additional :attr:`modes` attribute to set a :ref:`mode of resolution <ClassModes>`
 for queries of the class instances.
 
 We’ll use the following example class in the rest of the chapter:
 
 .. coqtop:: in
 
-   #[mode="!"]
+   #[modes="!"]
    Class EqDec (A : Type) :=
      { eqb : A -> A -> bool ;
        eqb_leibniz : forall x y, eqb x y = true -> x = y }.
@@ -221,7 +221,7 @@ superclasses as a binding context:
 
 .. coqtop:: all
 
-   #[mode="! -"]
+   #[modes="! -"]
    Class Ord `(E : EqDec A) := { le : A -> A -> bool }.
 
 Contrary to Haskell, we have no special syntax for superclasses, but
@@ -340,22 +340,23 @@ Summary of the commands
    Like any command declaring a record, this command supports the
    :attr:`universes(polymorphic)`, :attr:`universes(template)`,
    :attr:`universes(cumulative)`, and :attr:`private(matching)`
-   attributes. In addition, it supports the :attr:`mode` attribute.
+   attributes. In addition, it supports the :attr:`modes` attribute.
 
-   .. attr:: mode
+   .. attr:: modes
 
-      Sets the resolution mode of the class
-      at declaration time, using the same syntax as :cmd:`Hint Mode`,
-      and is equivalent to a :cmd:`Hint Mode` declaration after the
-      :cmd:`Class` declaration, except that the `mode` declaration can survive
+      Sets the resolution modes of the class at declaration time,
+      using the same syntax as :cmd:`Hint Mode`: :n:`{+ {| + | ! | - } }`.
+      It is equivalent to :cmd:`Hint Mode` declarations for the class name
+      in the ``typeclass_instances`` database after the
+      :cmd:`Class` declaration, except that the `modes` declaration can survive
       section closing. The setting affects when typeclass resolution can be triggered
-      for a class constraint, see :ref:`below <ClassMode>` for details.
+      for a class constraint, see :ref:`below <ClassModes>` for details.
       We recommend always setting a mode when introducing a class or using
       a default mode.
 
    .. error:: Discharging the class @ident would drop its mode declaration. Declare the class outside a section.
 
-      If a :attr:`mode` attribute is given to a class inside a section, but no
+      If a :attr:`modes` attribute is given to a class inside a section, but no
       :ref:`default mode <TypeclassesDefaultMode>` is set, this results in an error at section
       closing since Coq doesn't know which mode the discharged variables for the class should have.
 
@@ -363,7 +364,7 @@ Summary of the commands
 
       This variant declares a class from a previously declared :term:`constant` or
       inductive definition. No methods or instances are defined. It also supports
-      the :attr:`mode` attribute.
+      the :attr:`modes` attribute.
 
       .. warn:: @ident is already declared as a typeclass
 
@@ -458,7 +459,7 @@ Summary of the commands
      resolution with the local hypotheses use full conversion during
      unification.
 
-.. _ClassMode:
+.. _ClassModes:
 
    + The mode hints (see :cmd:`Hint Mode`) associated with a class are
      taken into account by typeclass resolution and :tacn:`typeclasses eauto`.
@@ -565,7 +566,7 @@ Settings
 
    Sets the default mode declaration
    associated with a :cmd:`Class`. It is unset by default. If set, then each class declaration uses
-   this default mode for *all* its indices, unless a :attr:`mode` attribute
+   this default mode for *all* its indices, unless a :attr:`modes` attribute
    is used to set the mode explicitly.
 
    .. warn:: Using inferred default mode declaration “mode” for “@ident”

--- a/doc/sphinx/addendum/type-classes.rst
+++ b/doc/sphinx/addendum/type-classes.rst
@@ -346,18 +346,18 @@ Summary of the commands
 
       Sets the resolution mode of the class
       at declaration time, using the same syntax as :cmd:`Hint Mode`,
-      and is equivalent to a `Hint Mode` declaration after the
-      `Class` declaration, except that the `mode` declaration can survive
+      and is equivalent to a :cmd:`Hint Mode` declaration after the
+      :cmd:`Class` declaration, except that the `mode` declaration can survive
       section closing. The setting affects when typeclass resolution can be triggered
       for a class constraint, see :ref:`below <ClassMode>` for details.
       We recommend always setting a mode when introducing a class or using
       a default mode.
 
-   .. error: Discharging the class @ident would drop its mode declaration. Declare the class outside a section.
+   .. error:: Discharging the class @ident would drop its mode declaration. Declare the class outside a section.
 
       If a :attr:`mode` attribute is given to a class inside a section, but no
-      `default mode <TypeclassesDefaultMode>` is set, this results in an error at section
-      closing since Coq don't know which mode the discharged variables for the class should have.
+      :ref:`default mode <TypeclassesDefaultMode>` is set, this results in an error at section
+      closing since Coq doesn't know which mode the discharged variables for the class should have.
 
    .. cmd:: Existing Class @qualid
 
@@ -561,11 +561,11 @@ Settings
 
    .. _TypeclassesDefaultMode:
 
-.. opt:: Typeclasses Default Mode {? ( {| "+" | "-" | "!" } ) }.
+.. opt:: Typeclasses Default Mode {| "+" | "-" | "!" }.
 
-   This option (unset by default) controls the default mode declaration
-   associated to a :cmd:`Class`. If set, the each class declaration uses
-   this default mode for *all* its indices, unless an :attr:`mode` attribute
+   Sets the default mode declaration
+   associated with a :cmd:`Class`. It is unset by default. If set, then each class declaration uses
+   this default mode for *all* its indices, unless a :attr:`mode` attribute
    is used to set the mode explicitly.
 
    .. warn:: Using inferred default mode declaration “mode” for “@ident”

--- a/doc/sphinx/addendum/type-classes.rst
+++ b/doc/sphinx/addendum/type-classes.rst
@@ -26,7 +26,7 @@ the ``fi : ti`` are called the *methods*. Each class definition gives
 rise to a corresponding record declaration and each instance is a
 regular definition whose name is given by `instancename` and type is an
 instantiation of the record type. The :cmd:`Class` command supports the
-additional attr:`mode` attribute to set a `mode of resolution <ClassMode>`
+additional :attr:`mode` attribute to set a :ref:`mode of resolution <ClassMode>`
 for queries of the class instances.
 
 We’ll use the following example class in the rest of the chapter:
@@ -461,8 +461,8 @@ Summary of the commands
 .. _ClassMode:
 
    + The mode hints (see :cmd:`Hint Mode`) associated with a class are
-     taken into account by :tacn:`typeclasses eauto`. When a goal
-     does not match any of the declared modes for its head (if any),
+     taken into account by typeclass resolution and :tacn:`typeclasses eauto`.
+     When a goal does not match any of the declared modes for its head (if any),
      instead of failing like :tacn:`eauto`, the goal is suspended and
      resolution proceeds on the remaining goals.
      If after one run of resolution, there remains suspended goals,
@@ -561,18 +561,18 @@ Settings
 
    .. _TypeclassesDefaultMode:
 
-.. option:: Typeclasses Default Mode {? ( {| "+" | "-" | "!" } ) }.
+.. opt:: Typeclasses Default Mode {? ( {| "+" | "-" | "!" } ) }.
 
    This option (unset by default) controls the default mode declaration
    associated to a :cmd:`Class`. If set, the each class declaration uses
-   this default mode for *all* its indices, unless an attr:`mode` attribute
+   this default mode for *all* its indices, unless an :attr:`mode` attribute
    is used to set the mode explicitly.
 
    .. warn:: Using inferred default mode declaration “mode” for “@ident”
 
       This (by default disabled) warning informs the user when a mode has been assigned
       automatically. It can be used to lint a library and ensure all typeclasses
-      has been assigned explicit mode declarations.
+      have been assigned explicit mode declarations.
 
 .. flag:: Typeclasses Filtered Unification
 

--- a/doc/sphinx/addendum/type-classes.rst
+++ b/doc/sphinx/addendum/type-classes.rst
@@ -345,7 +345,8 @@ Summary of the commands
    .. attr:: modes
 
       Sets the resolution modes of the class at declaration time,
-      using the same syntax as :cmd:`Hint Mode`: :n:`{+ {| + | ! | - } }`.
+      using the same syntax as :cmd:`Hint Mode`: :n:`{+, {+ {| + | ! | - } }}`, where
+      multiple modes can be declared, separated by a comma.
       It is equivalent to :cmd:`Hint Mode` declarations for the class name
       in the ``typeclass_instances`` database after the
       :cmd:`Class` declaration, except that the `modes` declaration can survive
@@ -354,11 +355,11 @@ Summary of the commands
       We recommend always setting a mode when introducing a class or using
       a default mode.
 
-   .. error:: Discharging the class @ident would drop its mode declaration. Declare the class outside a section.
+   .. exn:: Discharging the class @ident would drop its modes declaration. Declare the class outside a section.
 
       If a :attr:`modes` attribute is given to a class inside a section, but no
       :ref:`default mode <TypeclassesDefaultMode>` is set, this results in an error at section
-      closing since Coq doesn't know which mode the discharged variables for the class should have.
+      closing since Coq doesn't know which mode should be set for the discharged variables.
 
    .. cmd:: Existing Class @qualid
 
@@ -564,16 +565,19 @@ Settings
 
 .. opt:: Typeclasses Default Mode {| "+" | "-" | "!" }.
 
-   Sets the default mode declaration
-   associated with a :cmd:`Class`. It is unset by default. If set, then each class declaration uses
+   Sets the default mode declaration associated with a :cmd:`Class`.
+   It is unset by default. If set, then each class declaration uses
    this default mode for *all* its indices, unless a :attr:`modes` attribute
-   is used to set the mode explicitly.
+   is used to set the modes explicitly.
 
-   .. warn:: Using inferred default mode declaration “mode” for “@ident”
+   .. warn:: Using inferred default mode(s): “modes” for “@ident”
 
-      Indicates that the mode has been assigned
-      automatically. It can be used to lint a library and ensure all typeclasses
-      have been assigned explicit mode declarations.
+      Indicates that the :attr:`modes` for a :cmd:`Class` declaration have been
+      assigned automatically using the default mode.
+      This warning is named ``class-declaration-default-mode``.
+      It is disabled by default, see :opt:`Warnings` to enable it or turn it into an error.
+      It can be used to lint a library and ensure all typeclasses have been assigned
+      explicit mode declarations.
 
 .. flag:: Typeclasses Filtered Unification
 

--- a/doc/sphinx/addendum/type-classes.rst
+++ b/doc/sphinx/addendum/type-classes.rst
@@ -342,15 +342,20 @@ Summary of the commands
    :attr:`universes(cumulative)`, and :attr:`private(matching)`
    attributes. In addition, it supports the :attr:`modes` attribute.
 
-   .. attr:: modes
+   .. attr:: modes "{+, {+ {| + | ! | - } }}"
+      :name: modes
 
       Sets the resolution modes of the class at declaration time,
-      using the same syntax as :cmd:`Hint Mode`: :n:`{+, {+ {| + | ! | - } }}`, where
-      multiple modes can be declared, separated by a comma.
+      using the same syntax as :cmd:`Hint Mode`, where
+      multiple mode declarations can be declared simultaneously,
+      separated by a comma. The comma models a disjunction, so ordering
+      and duplicate mode declarations are irrelevant.
+      In a single mode declaration, the number of mode annotations should
+      match exactly the number of (non-let) parameters of the :cmd:`Class`.
       It is equivalent to :cmd:`Hint Mode` declarations for the class name
       in the ``typeclass_instances`` database after the
       :cmd:`Class` declaration, except that the `modes` declaration can survive
-      section closing. The setting affects when typeclass resolution can be triggered
+      section closing. Mode declarations affect when typeclass resolution can be triggered
       for a class constraint, see :ref:`below <ClassModes>` for details.
       We recommend always setting a mode when introducing a class or using
       a default mode.
@@ -569,6 +574,8 @@ Settings
    It is unset by default. If set, then each class declaration uses
    this default mode for *all* its indices, unless a :attr:`modes` attribute
    is used to set the modes explicitly.
+
+   .. _TypeclassesDefaultModeWarning:
 
    .. warn:: Using inferred default mode(s): “modes” for “@ident”
 

--- a/doc/sphinx/proofs/automatic-tactics/auto.rst
+++ b/doc/sphinx/proofs/automatic-tactics/auto.rst
@@ -491,6 +491,8 @@ Creating Hints
       instances and avoid ambiguity in general. Setting a parameter of a class as an
       input forces proof search to be driven by that index of the class, with ``!``
       allowing existentials to appear in the index but not at its head.
+      One can also use the :attr:`modes` attribute on :cmd:`Class` declarations to set
+      their modes at declaration time.
 
    .. note::
 
@@ -501,6 +503,43 @@ Creating Hints
         :cmd:`Hint Cut`, or :cmd:`Hint Mode`, for typeclass
         resolution, do not forget to put them in the
         ``typeclass_instances`` hint database.
+
+
+   .. example::
+
+      An example use of hint modes is to write logic programs that can be run
+      during typechecking. Here we define a `Plus` relation that is functional
+      in any two of its three arguments, allowing to infer the result of addition
+      of two numbers, or a missing operand giving a specific result after addition
+      with the other operand:
+
+      .. coqtop:: in
+
+         #[modes="+ + -, - + +, + - +"]
+         Class Plus (x y z : nat).
+
+      The :attr:`modes` attribute specifies that if any two of the indexes are
+      determined, then the last can be determined as well using proof-search.
+      The following instances implement the logic program:
+
+      .. coqtop:: in
+
+         Instance plus0 x : Plus 0 x x := {}.
+         Instance plus0' x : Plus x 0 x := {}.
+         Instance plusS x y z : Plus x y z -> Plus (S x) y (S z) := {}.
+         Instance plusS' x y z : Plus x y z -> Plus x (S y) (S z) := {}.
+
+      .. coqtop:: all
+
+         Type (_ : Plus 2 3 _).
+         Type (_ : Plus _ 2 3).
+         Type (_ : Plus 2 _ 3).
+         Type (_ : Plus _ 2 4).
+         Fail Type (_ : Plus _ _ 3).
+         Fail Type (_ : Plus _ 2 _).
+
+      The last two examples show that if the query is ambiguous as the query
+      does not match any declared mode, then proof-search fails.
 
 .. cmd:: Hint Rewrite {? {| -> | <- } } {+ @one_term } {? using @ltac_expr } {? : {* @ident } }
 

--- a/library/goptions.ml
+++ b/library/goptions.ml
@@ -408,6 +408,16 @@ let declare_interpreted_string_option_and_ref ~depr ~key ~(value:'a) from_string
     } in
   fun () -> !r_opt
 
+let declare_interpreted_stringopt_option_and_ref ~depr ~key from_string to_string =
+  let r_opt = ref None in
+  let optwrite v = r_opt := Option.map from_string v in
+  let optread () = Option.map to_string !r_opt in
+  let _ = declare_stringopt_option {
+      optdepr = depr;
+      optkey = key;
+      optread; optwrite
+    } in
+  fun () -> !r_opt
 (* 3- User accessible commands *)
 
 (* Setting values of options *)

--- a/library/goptions.mli
+++ b/library/goptions.mli
@@ -151,6 +151,8 @@ val declare_string_option_and_ref : (value:string -> (unit -> string)) opt_decl
 val declare_stringopt_option_and_ref : (unit -> string option) opt_decl
 val declare_interpreted_string_option_and_ref :
   (value:'a -> (string -> 'a) -> ('a -> string) -> (unit -> 'a)) opt_decl
+val declare_interpreted_stringopt_option_and_ref :
+  ((string -> 'a) -> ('a -> string) -> (unit -> 'a option)) opt_decl
 
 (** {6 Special functions supposed to be used only in vernacentries.ml } *)
 

--- a/pretyping/typeclasses.ml
+++ b/pretyping/typeclasses.ml
@@ -24,6 +24,8 @@ type hint_mode =
   | ModeNoHeadEvar (* No evar at the head *)
   | ModeOutput (* Anything *)
 
+type hint_modes = hint_mode list list
+
 (* Core typeclasses hints *)
 type 'a hint_info_gen =
     { hint_priority : int option;
@@ -81,7 +83,7 @@ type typeclass = {
   cl_context : Constr.rel_context;
 
   (* The initial mode declaration of the typeclass: should match the cl_context *)
-  cl_mode : hint_mode list option;
+  cl_modes : hint_modes option;
 
   (* Context of definitions and properties on defs, will not be shared *)
   cl_props : Constr.rel_context;

--- a/pretyping/typeclasses.ml
+++ b/pretyping/typeclasses.ml
@@ -47,9 +47,9 @@ let resolve_one_typeclass ?(unique=get_typeclasses_unique_solutions ()) env evm 
 
 let get_typeclasses_default_mode =
   let interp = function
-    | "+" -> ModeInput
-    | "-" -> ModeOutput
-    | "!" -> ModeNoHeadEvar
+    | "+" ->  ModeInput
+    | "-" ->  ModeOutput
+    | "!" ->  ModeNoHeadEvar
     | s ->
       CErrors.user_err Pp.(str "Unrecognizable mode declaration: \"" ++ str s ++ str"\", allowed values are +, - or !")
   in
@@ -58,10 +58,9 @@ let get_typeclasses_default_mode =
     | ModeOutput -> "-"
     | ModeNoHeadEvar -> "!"
   in
-  Goptions.declare_interpreted_string_option_and_ref
+  Goptions.declare_interpreted_stringopt_option_and_ref
     ~depr:false
     ~key:["Typeclasses";"Default";"Mode"]
-    ~value:ModeOutput
     interp print
 
 type class_method = {
@@ -82,7 +81,7 @@ type typeclass = {
   cl_context : Constr.rel_context;
 
   (* The initial mode declaration of the typeclass: should match the cl_context *)
-  cl_mode : hint_mode list;
+  cl_mode : hint_mode list option;
 
   (* Context of definitions and properties on defs, will not be shared *)
   cl_props : Constr.rel_context;

--- a/pretyping/typeclasses.mli
+++ b/pretyping/typeclasses.mli
@@ -21,6 +21,8 @@ type hint_mode =
   | ModeNoHeadEvar (* No evar at the head *)
   | ModeOutput (* Anything *)
 
+type hint_modes = hint_mode list list
+
 val get_typeclasses_default_mode : unit -> hint_mode option
 
 (* Core typeclasses hints *)
@@ -50,7 +52,7 @@ type typeclass = {
   (** Context in which the definitions are typed.
       Includes both typeclass parameters and superclasses. *)
 
-  cl_mode : hint_mode list option;
+  cl_modes : hint_modes option;
   (** The initial mode declaration of the typeclass *)
 
   cl_props : Constr.rel_context;

--- a/pretyping/typeclasses.mli
+++ b/pretyping/typeclasses.mli
@@ -21,7 +21,7 @@ type hint_mode =
   | ModeNoHeadEvar (* No evar at the head *)
   | ModeOutput (* Anything *)
 
-val get_typeclasses_default_mode : unit -> hint_mode
+val get_typeclasses_default_mode : unit -> hint_mode option
 
 (* Core typeclasses hints *)
 type 'a hint_info_gen =
@@ -50,7 +50,7 @@ type typeclass = {
   (** Context in which the definitions are typed.
       Includes both typeclass parameters and superclasses. *)
 
-  cl_mode : hint_mode list;
+  cl_mode : hint_mode list option;
   (** The initial mode declaration of the typeclass *)
 
   cl_props : Constr.rel_context;

--- a/pretyping/typeclasses.mli
+++ b/pretyping/typeclasses.mli
@@ -13,6 +13,16 @@ open Constr
 open Evd
 open Environ
 
+(* As typeclasses come before hints, we must define it here so that class declarations
+  can embed a mode declaration. *)
+
+type hint_mode =
+  | ModeInput (* No evars *)
+  | ModeNoHeadEvar (* No evar at the head *)
+  | ModeOutput (* Anything *)
+
+val get_typeclasses_default_mode : unit -> hint_mode
+
 (* Core typeclasses hints *)
 type 'a hint_info_gen =
     { hint_priority : int option;
@@ -39,6 +49,9 @@ type typeclass = {
   cl_context : Constr.rel_context;
   (** Context in which the definitions are typed.
       Includes both typeclass parameters and superclasses. *)
+
+  cl_mode : hint_mode list;
+  (** The initial mode declaration of the typeclass *)
 
   cl_props : Constr.rel_context;
   (** Context of definitions and properties on defs, will not be shared *)

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -503,7 +503,7 @@ let make_hints g (modes,st) only_classes sign =
         else hints)
       ([]) sign
   in
-  let db = Hint_db.set_modes modes @@ Hint_db.empty st true in
+  let db = Hint_db.add_modes modes @@ Hint_db.empty st true in
   Hint_db.add_list (pf_env g) (project g) hintlist db
 
 module Search = struct
@@ -990,7 +990,9 @@ let typeclasses_eauto ?(only_classes=false) ?(st=TransparentState.full)
                       with e when CErrors.noncritical e -> None)
               dbs
   in
-  let st, modes = match dbs with x :: _ -> Hint_db.transparent_state x, Hint_db.modes x | _ -> st, GlobRef.Map.empty in
+  let st = match dbs with x :: _ -> Hint_db.transparent_state x | _ -> st in
+  let modes = List.map Hint_db.modes dbs in
+  let modes = List.fold_left (GlobRef.Map.union (fun _ m1 m2 -> Some (m1@m2))) GlobRef.Map.empty modes in
   let depth = match depth with None -> get_typeclasses_depth () | Some l -> Some l in
   Proofview.tclIGNORE
     (Search.eauto_tac (modes,st) ~only_classes ?strategy ~depth ~dep:true dbs)

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -503,7 +503,7 @@ let make_hints g (modes,st) only_classes sign =
         else hints)
       ([]) sign
   in
-  let db = Hint_db.add_modes modes @@ Hint_db.empty st true in
+  let db = Hint_db.set_modes modes @@ Hint_db.empty st true in
   Hint_db.add_list (pf_env g) (project g) hintlist db
 
 module Search = struct
@@ -990,9 +990,7 @@ let typeclasses_eauto ?(only_classes=false) ?(st=TransparentState.full)
                       with e when CErrors.noncritical e -> None)
               dbs
   in
-  let st = match dbs with x :: _ -> Hint_db.transparent_state x | _ -> st in
-  let modes = List.map Hint_db.modes dbs in
-  let modes = List.fold_left (GlobRef.Map.union (fun _ m1 m2 -> Some (m1@m2))) GlobRef.Map.empty modes in
+  let st, modes = match dbs with x :: _ -> Hint_db.transparent_state x, Hint_db.modes x | _ -> st, GlobRef.Map.empty in
   let depth = match depth with None -> get_typeclasses_depth () | Some l -> Some l in
   Proofview.tclIGNORE
     (Search.eauto_tac (modes,st) ~only_classes ?strategy ~depth ~dep:true dbs)

--- a/tactics/class_tactics.mli
+++ b/tactics/class_tactics.mli
@@ -46,7 +46,7 @@ val autoapply : constr -> Hints.hint_db_name -> unit Proofview.tactic
 
 module Search : sig
   val eauto_tac :
-    Typeclasses.hint_mode array option GlobRef.Map.t * TransparentState.t
+    Typeclasses.hint_mode array list GlobRef.Map.t * TransparentState.t
     (** The transparent_state and modes used when working with local hypotheses  *)
     -> ?unique:bool
     (** Should we force a unique solution *)

--- a/tactics/class_tactics.mli
+++ b/tactics/class_tactics.mli
@@ -46,7 +46,7 @@ val autoapply : constr -> Hints.hint_db_name -> unit Proofview.tactic
 
 module Search : sig
   val eauto_tac :
-    Hints.hint_mode array list GlobRef.Map.t * TransparentState.t
+    Typeclasses.hint_mode array list GlobRef.Map.t * TransparentState.t
     (** The transparent_state and modes used when working with local hypotheses  *)
     -> ?unique:bool
     (** Should we force a unique solution *)

--- a/tactics/class_tactics.mli
+++ b/tactics/class_tactics.mli
@@ -46,7 +46,7 @@ val autoapply : constr -> Hints.hint_db_name -> unit Proofview.tactic
 
 module Search : sig
   val eauto_tac :
-    Typeclasses.hint_mode array list GlobRef.Map.t * TransparentState.t
+    Typeclasses.hint_mode array option GlobRef.Map.t * TransparentState.t
     (** The transparent_state and modes used when working with local hypotheses  *)
     -> ?unique:bool
     (** Should we force a unique solution *)

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -165,11 +165,6 @@ type full_hint = hint hint_ast with_uid with_metadata
 type hint_entry = GlobRef.t option *
   raw_hint hint_ast with_uid with_metadata
 
-type hint_mode =
-  | ModeInput (* No evars *)
-  | ModeNoHeadEvar (* No evar at the head *)
-  | ModeOutput (* Anything *)
-
 type 'a hints_transparency_target =
   | HintsVariables
   | HintsConstants

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -748,11 +748,7 @@ struct
 
   let set_mode gr m db =
     let se = find gr db in
-    let m =
-      if Array.for_all (fun x -> x = ModeInput) m then None
-      else Some m
-    in
-    let se = { se with sentry_mode = m } in
+    let se = { se with sentry_mode = Some m } in
     { db with hintdb_map = GlobRef.Map.add gr se db.hintdb_map }
 
   let cut db = db.hintdb_cut
@@ -945,8 +941,8 @@ let make_extern pri pat tacast =
 let make_mode ref m =
   let open Term in
   let ty, _ = Typeops.type_of_global_in_context (Global.env ()) ref in
-  let ctx, t = decompose_prod ty in
-  let n = List.length ctx in
+  let ctx, t = decompose_prod_assum ty in
+  let n = Context.Rel.nhyps ctx in
   let m' = Array.of_list m in
     if not (n == Array.length m') then
       user_err ~hdr:"Hint"

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -268,14 +268,14 @@ type search_entry = {
   sentry_nopat : stored_data list;
   sentry_pat : stored_data list;
   sentry_bnet : Bounded_net.t;
-  sentry_mode : hint_mode array list;
+  sentry_mode : hint_mode array option;
 }
 
 let empty_se = {
   sentry_nopat = [];
   sentry_pat = [];
   sentry_bnet = Bounded_net.empty;
-  sentry_mode = [];
+  sentry_mode = None;
 }
 
 let eq_pri_auto_tactic (_, x) (_, y) = KerName.equal x.code.uid y.code.uid
@@ -532,17 +532,17 @@ val add_one : env -> evar_map -> hint_entry -> t -> t
 val add_list : env -> evar_map -> hint_entry list -> t -> t
 val remove_one : Environ.env -> GlobRef.t -> t -> t
 val remove_list : Environ.env -> GlobRef.t list -> t -> t
-val iter : (GlobRef.t option -> hint_mode array list -> full_hint list -> unit) -> t -> unit
+val iter : (GlobRef.t option -> hint_mode array option -> full_hint list -> unit) -> t -> unit
 val use_dn : t -> bool
 val transparent_state : t -> TransparentState.t
 val set_transparent_state : t -> TransparentState.t -> t
 val add_cut : hints_path -> t -> t
-val add_mode : GlobRef.t -> hint_mode array -> t -> t
+val set_mode : GlobRef.t -> hint_mode array -> t -> t
 val cut : t -> hints_path
 val unfolds : t -> Id.Set.t * Cset.t
-val add_modes : hint_mode array list GlobRef.Map.t -> t -> t
-val modes : t -> hint_mode array list GlobRef.Map.t
-val fold : (GlobRef.t option -> hint_mode array list -> full_hint list -> 'a -> 'a) ->
+val set_modes : hint_mode array option GlobRef.Map.t -> t -> t
+val modes : t -> hint_mode array option GlobRef.Map.t
+val fold : (GlobRef.t option -> hint_mode array option -> full_hint list -> 'a -> 'a) ->
   t -> 'a -> 'a
 end =
 struct
@@ -606,9 +606,9 @@ struct
     Array.length mode == Array.length args &&
       Array.for_all2 (match_mode sigma) mode args
 
-  let matches_modes sigma args modes =
-    if List.is_empty modes then true
-    else List.exists (matches_mode sigma args) modes
+  let matches_mode sigma args = function
+    | None -> true
+    | Some mode -> matches_mode sigma args mode
 
   let merge_entry secvars db nopat pat =
     let h = List.sort pri_order_int (List.map snd db.hintdb_nopat) in
@@ -632,14 +632,14 @@ struct
 
   let map_existential sigma ~secvars (k,args) concl db =
     let se = find k db in
-      if matches_modes sigma args se.sentry_mode then
+      if matches_mode sigma args se.sentry_mode then
         ModeMatch (merge_entry secvars db se.sentry_nopat se.sentry_pat)
       else ModeMismatch
 
   (* [c] contains an existential *)
   let map_eauto env sigma ~secvars (k,args) concl db =
     let se = find k db in
-      if matches_modes sigma args se.sentry_mode then
+      if matches_mode sigma args se.sentry_mode then
         let st = if db.use_dn then Some db.hintdb_state else None in
         let pat = lookup_tacs env sigma concl st se in
         ModeMatch (merge_entry secvars db [] pat)
@@ -730,11 +730,11 @@ struct
 
   let iter f db =
     let iter_se k se = f (Some k) se.sentry_mode (get_entry se) in
-    f None [] (List.map (fun x -> snd (snd x)) db.hintdb_nopat);
+    f None None (List.map (fun x -> snd (snd x)) db.hintdb_nopat);
     GlobRef.Map.iter iter_se db.hintdb_map
 
   let fold f db accu =
-    let accu = f None [] (List.map (fun x -> snd (snd x)) db.hintdb_nopat) accu in
+    let accu = f None None (List.map (fun x -> snd (snd x)) db.hintdb_nopat) accu in
     GlobRef.Map.fold (fun k se -> f (Some k) se.sentry_mode (get_entry se)) db.hintdb_map accu
 
   let transparent_state db = db.hintdb_state
@@ -746,18 +746,22 @@ struct
   let add_cut path db =
     { db with hintdb_cut = normalize_path (PathOr (db.hintdb_cut, path)) }
 
-  let add_mode gr m db =
+  let set_mode gr m db =
     let se = find gr db in
-    let se = { se with sentry_mode = m :: se.sentry_mode } in
+    let m =
+      if Array.for_all (fun x -> x = ModeInput) m then None
+      else Some m
+    in
+    let se = { se with sentry_mode = m } in
     { db with hintdb_map = GlobRef.Map.add gr se db.hintdb_map }
 
   let cut db = db.hintdb_cut
 
   let unfolds db = db.hintdb_unfolds
 
-  let add_modes modes db =
+  let set_modes modes db =
     let f gr e me =
-      Some { e with sentry_mode = me.sentry_mode @ e.sentry_mode }
+      Some { e with sentry_mode = me.sentry_mode }
     in
     let mode_entries = GlobRef.Map.map (fun m -> { empty_se with sentry_mode = m }) modes in
     { db with hintdb_map = GlobRef.Map.union f db.hintdb_map mode_entries }
@@ -1019,9 +1023,9 @@ let add_cut dbname path =
   let db' = Hint_db.add_cut path db in
     searchtable_add (dbname, db')
 
-let add_mode dbname l m =
+let set_mode dbname l m =
   let db = get_db dbname in
-  let db' = Hint_db.add_mode l m db in
+  let db' = Hint_db.set_mode l m db in
     searchtable_add (dbname, db')
 
 type db_obj = {
@@ -1057,7 +1061,7 @@ type hint_action =
   | AddHints of hint_entry list
   | RemoveHints of GlobRef.t list
   | AddCut of hints_path
-  | AddMode of { gref : GlobRef.t; mode : hint_mode array }
+  | SetMode of { gref : GlobRef.t; mode : hint_mode array }
 
 type hint_locality = Local | Export | SuperGlobal
 
@@ -1083,8 +1087,8 @@ let load_autohint _ (kn, h) =
     if superglobal then remove_hint name hints
   | AddCut paths ->
     if superglobal then add_cut name paths
-  | AddMode { gref; mode } ->
-    if superglobal then add_mode name gref mode
+  | SetMode { gref; mode } ->
+    if superglobal then set_mode name gref mode
 
 let open_autohint i (kn, h) =
   let superglobal = superglobal h in
@@ -1104,8 +1108,8 @@ let open_autohint i (kn, h) =
     if not superglobal then add_transparency h.hint_name grefs state
   | RemoveHints hints ->
     if not superglobal then remove_hint h.hint_name hints
-  | AddMode { gref; mode } ->
-    if not superglobal then add_mode h.hint_name gref mode
+  | SetMode { gref; mode } ->
+    if not superglobal then set_mode h.hint_name gref mode
 
 let cache_autohint (kn, obj) =
   load_autohint 1 (kn, obj); open_autohint 1 (kn, obj)
@@ -1181,9 +1185,9 @@ let subst_autohint (subst, obj) =
     | AddCut path ->
       let path' = subst_hints_path subst path in
       if path' == path then obj.hint_action else AddCut path'
-    | AddMode { gref = l; mode = m } ->
+    | SetMode { gref = l; mode = m } ->
       let l' = subst_global_reference subst l in
-      if l' == l then obj.hint_action else AddMode { gref = l'; mode = m }
+      if l' == l then obj.hint_action else SetMode { gref = l'; mode = m }
   in
   if action == obj.hint_action then obj else { obj with hint_action = action }
 
@@ -1297,7 +1301,7 @@ let add_mode l m ~local dbnames =
   List.iter
     (fun dbname ->
       let m' = make_mode l m in
-      let hint = make_hint ~local dbname (AddMode { gref = l; mode = m' }) in
+      let hint = make_hint ~local dbname (SetMode { gref = l; mode = m' }) in
       Lib.add_anonymous_leaf (inAutoHint hint))
     dbnames
 
@@ -1539,15 +1543,15 @@ let pp_hint_mode = function
 (* displays the whole hint database db *)
 let pr_hint_db_env env sigma db =
   let pr_mode = prvect_with_sep spc pp_hint_mode in
-  let pr_modes l =
-    if List.is_empty l then mt ()
-    else str" (modes " ++ prlist_with_sep pr_comma pr_mode l ++ str")"
+  let pr_mode = function
+    | None -> mt ()
+    | Some m -> str" (mode " ++ pr_mode m ++ str")"
   in
   let content =
-    let fold head modes hintlist accu =
+    let fold head mode hintlist accu =
       let goal_descr = match head with
       | None -> str "For any goal"
-      | Some head -> str "For " ++ pr_global head ++ pr_modes modes
+      | Some head -> str "For " ++ pr_global head ++ pr_mode mode
       in
       let hints = pr_hint_list env sigma (List.map (fun x -> (0, x)) hintlist) in
       let hint_descr = hov 0 (goal_descr ++ str " -> " ++ hints) in

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -141,9 +141,9 @@ module Hint_db :
     val remove_one : Environ.env -> GlobRef.t -> t -> t
     val remove_list : Environ.env -> GlobRef.t list -> t -> t
     val iter : (GlobRef.t option ->
-                hint_mode array list -> FullHint.t list -> unit) -> t -> unit
+                hint_mode array option -> FullHint.t list -> unit) -> t -> unit
 
-    val fold : (GlobRef.t option -> hint_mode array list -> FullHint.t list -> 'a -> 'a) -> t -> 'a -> 'a
+    val fold : (GlobRef.t option -> hint_mode array option -> FullHint.t list -> 'a -> 'a) -> t -> 'a -> 'a
 
     val use_dn : t -> bool
     val transparent_state : t -> TransparentState.t
@@ -155,10 +155,10 @@ module Hint_db :
     val unfolds : t -> Id.Set.t * Cset.t
 
     (** [add_mode gr m] Add a mode declaration for head [gr] *)
-    val add_mode : GlobRef.t -> hint_mode array -> t -> t
+    val set_mode : GlobRef.t -> hint_mode array -> t -> t
 
-    val add_modes : hint_mode array list GlobRef.Map.t -> t -> t
-    val modes : t -> hint_mode array list GlobRef.Map.t
+    val set_modes : hint_mode array option GlobRef.Map.t -> t -> t
+    val modes : t -> hint_mode array option GlobRef.Map.t
   end
 
 type hint_db = Hint_db.t

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -73,11 +73,6 @@ end
 
 type hint_entry
 
-type hint_mode =
-  | ModeInput (* No evars *)
-  | ModeNoHeadEvar (* No evar at the head *)
-  | ModeOutput (* Anything *)
-
 type 'a hints_transparency_target =
   | HintsVariables
   | HintsConstants
@@ -158,6 +153,9 @@ module Hint_db :
     val cut : t -> hints_path
 
     val unfolds : t -> Id.Set.t * Cset.t
+
+    (** [add_mode gr m] Add a mode declaration for head [gr] *)
+    val add_mode : GlobRef.t -> hint_mode array -> t -> t
 
     val add_modes : hint_mode array list GlobRef.Map.t -> t -> t
     val modes : t -> hint_mode array list GlobRef.Map.t

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -141,9 +141,9 @@ module Hint_db :
     val remove_one : Environ.env -> GlobRef.t -> t -> t
     val remove_list : Environ.env -> GlobRef.t list -> t -> t
     val iter : (GlobRef.t option ->
-                hint_mode array option -> FullHint.t list -> unit) -> t -> unit
+                hint_mode array list -> FullHint.t list -> unit) -> t -> unit
 
-    val fold : (GlobRef.t option -> hint_mode array option -> FullHint.t list -> 'a -> 'a) -> t -> 'a -> 'a
+    val fold : (GlobRef.t option -> hint_mode array list -> FullHint.t list -> 'a -> 'a) -> t -> 'a -> 'a
 
     val use_dn : t -> bool
     val transparent_state : t -> TransparentState.t
@@ -155,10 +155,10 @@ module Hint_db :
     val unfolds : t -> Id.Set.t * Cset.t
 
     (** [add_mode gr m] Add a mode declaration for head [gr] *)
-    val set_mode : GlobRef.t -> hint_mode array -> t -> t
+    val add_mode : GlobRef.t -> hint_mode array -> t -> t
 
-    val set_modes : hint_mode array option GlobRef.Map.t -> t -> t
-    val modes : t -> hint_mode array option GlobRef.Map.t
+    val add_modes : hint_mode array list GlobRef.Map.t -> t -> t
+    val modes : t -> hint_mode array list GlobRef.Map.t
   end
 
 type hint_db = Hint_db.t

--- a/test-suite/success/HintMode.v
+++ b/test-suite/success/HintMode.v
@@ -39,14 +39,16 @@ Module HintModeDecl.
   Fail Type foodefault.
 
   Instance default_list : FooDefault (list nat) := { foodefault := nil }.
-  Type (foodefault : list _).
+  Type (foodefault : list _). (* list _ respects !*)
   Set Warnings "class-declaration-default-mode".
 
   Section Bla.
     Context (A : Type).
     #[mode="+"]
     Class FooSec (B : Type) := { bar : A -> B -> nat }.
-  End Bla. (* In VSCoq the warning is not displayed as it is attached to an unknown stateid, but
+  End Bla.
+
+  (* In VSCoq the warning is not displayed as it is attached to an unknown stateid, but
     coqc displays it. If the warning is made an error it is properly reported *)
   Print HintDb typeclass_instances. (* Default mode = !, FooSec -> ! + *)
 

--- a/test-suite/success/HintMode.v
+++ b/test-suite/success/HintMode.v
@@ -18,3 +18,12 @@ Goal forall A T `{In A T} `{Empty T} `{EmptyIn A T}, forall x : A, IsIn x empty 
 Qed.
 
 End Postponing.
+
+
+Module HintModeDecl.
+
+  #[mode="+ +"]
+  Class Foo (A : Type) (B : Type).
+
+  Print TypeClasses.
+  Print HintDb typeclass_instances.

--- a/test-suite/success/HintMode.v
+++ b/test-suite/success/HintMode.v
@@ -19,7 +19,6 @@ Qed.
 
 End Postponing.
 
-
 Module HintModeDecl.
 
   Class Foo (A : Type) := foo : A.

--- a/test-suite/success/HintMode.v
+++ b/test-suite/success/HintMode.v
@@ -26,7 +26,7 @@ Module HintModeDecl.
   Instance: Foo nat := 0.
   Type foo.
 
-  #[mode="+"]
+  #[modes="+"]
   Class FooPlus (A : Type) := fooplus : A.
   Instance: FooPlus nat := 0.
   Fail Type fooplus.
@@ -44,7 +44,7 @@ Module HintModeDecl.
 
   Section Bla.
     Context (A : Type).
-    #[mode="+"]
+    #[modes="+"]
     Class FooSec (B : Type) := { bar : A -> B -> nat }.
   End Bla.
 
@@ -53,5 +53,20 @@ Module HintModeDecl.
   Print HintDb typeclass_instances. (* Default mode = !, FooSec -> ! + *)
 
   Class Baz (A : Type).
+
+  #[modes="+ + -, - + +, + - +"]
+  Class Plus (x y z : nat).
+
+  Instance plus0 x : Plus 0 x x := {}.
+  Instance plus0' x : Plus x 0 x := {}.
+  Instance plusS x y z : Plus x y z -> Plus (S x) y (S z) := {}.
+  Instance plusS' x y z : Plus x y z -> Plus x (S y) (S z) := {}.
+
+  Check (_ : Plus 2 3 _).
+  Check (_ : Plus _ 2 3).
+  Check (_ : Plus 2 _ 3).
+  Fail Type (_ : Plus _ _ 3).
+  Fail Type (_ : Plus _ 2 _).
+  Type (_ : Plus _ 2 4).
 
 End HintModeDecl.

--- a/test-suite/success/HintMode.v
+++ b/test-suite/success/HintMode.v
@@ -5,9 +5,9 @@ Class Empty T := { empty : T }.
 Class EmptyIn (A T : Type) `{In A T} `{Empty T} :=
  { isempty : forall x, IsIn x empty -> False }.
 
-Hint Mode EmptyIn ! ! - - : typeclass_instances.
-Hint Mode Empty ! : typeclass_instances.
-Hint Mode In ! - : typeclass_instances.
+#[local] Hint Mode EmptyIn ! ! - - : typeclass_instances.
+#[local] Hint Mode Empty ! : typeclass_instances.
+#[local] Hint Mode In ! - : typeclass_instances.
 Existing Class IsIn.
 Goal forall A T `{In A T} `{Empty T} `{EmptyIn A T}, forall x : A, IsIn x empty -> False.
  Proof.
@@ -41,5 +41,17 @@ Module HintModeDecl.
 
   Instance default_list : FooDefault (list nat) := { foodefault := nil }.
   Type (foodefault : list _).
+  Set Warnings "class-declaration-default-mode".
+
+  Section Bla.
+    Context (A : Type).
+    #[mode="+"]
+    Class FooSec (B : Type) := { bar : A -> B -> nat }.
+  End Bla.
+  Print HintDb typeclass_instances. (* Default mode = !, FooSec -> ! + *)
+
+  Class Baz (A : Type).
+
+
 
 End HintModeDecl.

--- a/test-suite/success/HintMode.v
+++ b/test-suite/success/HintMode.v
@@ -22,8 +22,24 @@ End Postponing.
 
 Module HintModeDecl.
 
-  #[mode="+ +"]
-  Class Foo (A : Type) (B : Type).
+  Class Foo (A : Type) := foo : A.
 
-  Print TypeClasses.
-  Print HintDb typeclass_instances.
+  Instance: Foo nat := 0.
+  Type foo.
+
+  #[mode="+"]
+  Class FooPlus (A : Type) := fooplus : A.
+  Instance: FooPlus nat := 0.
+  Fail Type fooplus.
+
+  Set Typeclasses Default Mode "!".
+  Class FooDefault (A : Type) := foodefault : A.
+  Print HintDb typeclass_instances. (* mode ! *)
+
+  Instance: FooDefault nat := 0.
+  Fail Type foodefault.
+
+  Instance default_list : FooDefault (list nat) := { foodefault := nil }.
+  Type (foodefault : list _).
+
+End HintModeDecl.

--- a/test-suite/success/HintMode.v
+++ b/test-suite/success/HintMode.v
@@ -47,11 +47,10 @@ Module HintModeDecl.
     Context (A : Type).
     #[mode="+"]
     Class FooSec (B : Type) := { bar : A -> B -> nat }.
-  End Bla.
+  End Bla. (* In VSCoq the warning is not displayed as it is attached to an unknown stateid, but
+    coqc displays it. If the warning is made an error it is properly reported *)
   Print HintDb typeclass_instances. (* Default mode = !, FooSec -> ! + *)
 
   Class Baz (A : Type).
-
-
 
 End HintModeDecl.

--- a/vernac/attributes.ml
+++ b/vernac/attributes.ml
@@ -382,3 +382,20 @@ let typing_flags_parser : Declarations.typing_flags key_parser = fun orig args -
 
 let typing_flags =
   attribute_of_list ["bypass_check", typing_flags_parser]
+
+let mode_declaration_parser : Typeclasses.hint_mode list key_parser = fun orig att ->
+  match att with
+  | VernacFlagLeaf (FlagString args) ->
+    let args = String.split_on_char ' ' args in
+    let parse_mode = function
+      | "-" -> Typeclasses.ModeOutput
+      | "+" -> Typeclasses.ModeInput
+      | "!" -> Typeclasses.ModeNoHeadEvar
+      | _ ->
+        CErrors.user_err Pp.(str "Ill-formed “mode” attribute: " ++ pr_vernac_flag_value att)
+    in  List.map parse_mode args
+  | att ->
+    CErrors.user_err Pp.(str "Ill-formed “mode” attribute: " ++ pr_vernac_flag_value att)
+
+let mode_declaration =
+  attribute_of_list ["mode", mode_declaration_parser]

--- a/vernac/attributes.ml
+++ b/vernac/attributes.ml
@@ -386,14 +386,14 @@ let typing_flags =
 let mode_declaration_parser : Typeclasses.hint_mode list key_parser = fun orig att ->
   match att with
   | VernacFlagLeaf (FlagString args) ->
-    let args = String.split_on_char ' ' args in
+    let args = CString.explode args in
     let parse_mode = function
-      | "-" -> Typeclasses.ModeOutput
-      | "+" -> Typeclasses.ModeInput
-      | "!" -> Typeclasses.ModeNoHeadEvar
-      | _ ->
-        CErrors.user_err Pp.(str "Ill-formed “mode” attribute: " ++ pr_vernac_flag_value att)
-    in  List.map parse_mode args
+      | "-" -> Some Typeclasses.ModeOutput
+      | "+" -> Some Typeclasses.ModeInput
+      | "!" -> Some Typeclasses.ModeNoHeadEvar
+      | " " -> None
+      | s -> CErrors.user_err Pp.(str "Ill-formed “mode” specification: " ++ str s)
+    in CList.map_filter parse_mode args
   | att ->
     CErrors.user_err Pp.(str "Ill-formed “mode” attribute: " ++ pr_vernac_flag_value att)
 

--- a/vernac/attributes.mli
+++ b/vernac/attributes.mli
@@ -58,6 +58,7 @@ val deprecation : Deprecation.t option attribute
 val canonical_field : bool attribute
 val canonical_instance : bool attribute
 val using : string option attribute
+val mode_declaration : Typeclasses.hint_mode list option attribute
 
 (** Enable/Disable universe checking *)
 val typing_flags : Declarations.typing_flags option attribute

--- a/vernac/attributes.mli
+++ b/vernac/attributes.mli
@@ -58,7 +58,7 @@ val deprecation : Deprecation.t option attribute
 val canonical_field : bool attribute
 val canonical_instance : bool attribute
 val using : string option attribute
-val mode_declaration : Typeclasses.hint_mode list option attribute
+val modes_declaration : Typeclasses.hint_modes option attribute
 
 (** Enable/Disable universe checking *)
 val typing_flags : Declarations.typing_flags option attribute

--- a/vernac/classes.mli
+++ b/vernac/classes.mli
@@ -14,6 +14,9 @@ open Constrexpr
 open Typeclasses
 open Libnames
 
+(** A configurable warning to output if a default mode is used for a class declaration. *)
+val warn_default_mode : ?loc:Loc.t -> (GlobRef.t * hint_mode list) -> unit
+
 (** Instance declaration *)
 
 val declare_instance : ?warn:bool -> env -> Evd.evar_map ->

--- a/vernac/classes.mli
+++ b/vernac/classes.mli
@@ -15,7 +15,7 @@ open Typeclasses
 open Libnames
 
 (** A configurable warning to output if a default mode is used for a class declaration. *)
-val warn_default_mode : ?loc:Loc.t -> (GlobRef.t * hint_mode list) -> unit
+val warn_default_modes : ?loc:Loc.t -> (GlobRef.t * hint_modes) -> unit
 
 (** Instance declaration *)
 

--- a/vernac/g_proofs.mlg
+++ b/vernac/g_proofs.mlg
@@ -133,8 +133,8 @@ GRAMMAR EXTEND Gram
       | ":"; t = lconstr; ":="; c = lconstr -> { CAst.make ~loc @@ CCast(c,CastConv t) } ] ]
   ;
   mode:
-    [ [ l = LIST1 [ "+" -> { ModeInput }
-                  | "!" -> { ModeNoHeadEvar }
-                  | "-" -> { ModeOutput } ] -> { l } ] ]
+    [ [ l = LIST1 [ "+" -> { Typeclasses.ModeInput }
+                  | "!" -> { Typeclasses.ModeNoHeadEvar }
+                  | "-" -> { Typeclasses.ModeOutput } ] -> { l } ] ]
   ;
 END

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -269,7 +269,7 @@ let pr_reference_or_constr pr_c = function
   | HintsReference r -> pr_qualid r
   | HintsConstr c -> pr_c c
 
-let pr_hint_mode = let open Hints in function
+let pr_hint_mode = let open Typeclasses in function
   | ModeInput -> str"+"
   | ModeNoHeadEvar -> str"!"
   | ModeOutput -> str"-"

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -769,7 +769,7 @@ let add_constant_class env sigma cst =
     }
   in
   Classes.add_class env sigma tc;
-    Classes.set_typeclass_transparency (Tacred.EvalConstRef cst) false false
+  Classes.set_typeclass_transparency (Tacred.EvalConstRef cst) false false
 
 let add_inductive_class env sigma ind =
   let mind, oneind = Inductive.lookup_mind_specif env ind in

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -617,11 +617,13 @@ let implicits_of_context ctx =
 let interp_mode (gr, mode) ctx =
   match mode with
   | None ->
-    let default = Typeclasses.get_typeclasses_default_mode () in
-    let n = Context.Rel.nhyps ctx in
-    let m = List.make n default in
-    Classes.warn_default_mode (gr, m); m
-  | Some m -> m
+    (match Typeclasses.get_typeclasses_default_mode () with
+    | Some default ->
+      let n = Context.Rel.nhyps ctx in
+      let m = List.make n default in
+      Classes.warn_default_mode (gr, m); Some m
+    | None -> None)
+  | Some m -> Some m
 
 let build_class_constant ~univs ~rdata field implfs params paramimpls coers binder id proj_name =
   let class_body = it_mkLambda_or_LetIn field params in

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -771,7 +771,7 @@ let add_constant_class env sigma ?mode_declaration cst =
     }
   in
   Classes.add_class env sigma tc;
-  Classes.set_typeclass_transparency (Tacred.EvalConstRef cst) false false
+    Classes.set_typeclass_transparency (Tacred.EvalConstRef cst) false false
 
 let add_inductive_class env sigma ?mode_declaration ind =
   let mind, oneind = Inductive.lookup_mind_specif env ind in

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -614,6 +614,14 @@ let implicits_of_context ctx =
   List.map (fun name -> CAst.make (Some (name,true)))
     (List.rev (Anonymous :: (List.map RelDecl.get_name ctx)))
 
+let interp_mode mode ctx =
+  match mode with
+  | None ->
+    let default = Typeclasses.get_typeclasses_default_mode () in
+    let n = Context.Rel.nhyps ctx in
+    List.make n default
+  | Some m -> m
+
 let build_class_constant ~univs ~rdata field implfs params paramimpls coers binder id proj_name =
   let class_body = it_mkLambda_or_LetIn field params in
   let class_type = it_mkProd_or_LetIn rdata.DataR.arity params in
@@ -733,6 +741,7 @@ let declare_class def ~cumulative ~ubind ~univs ~variances id idbuild paramimpls
         cl_strict = typeclasses_strict ();
         cl_unique = typeclasses_unique ();
         cl_context = params;
+        cl_mode = interp_mode None params;
         cl_props = fields;
         cl_projs = projs }
     in
@@ -752,6 +761,7 @@ let add_constant_class env sigma cst =
     { cl_univs = univs;
       cl_impl = GlobRef.ConstRef cst;
       cl_context = ctx;
+      cl_mode = interp_mode None ctx;
       cl_props = [LocalAssum (make_annot Anonymous r, t)];
       cl_projs = [];
       cl_strict = typeclasses_strict ();
@@ -774,6 +784,7 @@ let add_inductive_class env sigma ind =
       { cl_univs = univs;
         cl_impl = GlobRef.IndRef ind;
         cl_context = ctx;
+        cl_mode = interp_mode None ctx;
         cl_props = [LocalAssum (make_annot Anonymous r, ty)];
         cl_projs = [];
         cl_strict = typeclasses_strict ();

--- a/vernac/record.mli
+++ b/vernac/record.mli
@@ -30,13 +30,13 @@ val definition_structure
   -> template:bool option
   -> cumulative:bool
   -> poly:bool
-  -> ?mode_declaration:Typeclasses.hint_mode list
+  -> ?modes_declaration:Typeclasses.hint_mode list list
   -> Declarations.recursivity_kind
   -> Ast.t list
   -> GlobRef.t list
 
 val declare_existing_class :
-  ?mode_declaration:Typeclasses.hint_mode list
+  ?modes_declaration:Typeclasses.hint_mode list list
   -> GlobRef.t
   -> unit
 

--- a/vernac/record.mli
+++ b/vernac/record.mli
@@ -35,7 +35,10 @@ val definition_structure
   -> Ast.t list
   -> GlobRef.t list
 
-val declare_existing_class : GlobRef.t -> unit
+val declare_existing_class :
+  ?mode_declaration:Typeclasses.hint_mode list
+  -> GlobRef.t
+  -> unit
 
 (* Implementation internals, consult Coq developers before using;
    current user Elpi, see https://github.com/LPCIC/coq-elpi/pull/151 *)

--- a/vernac/record.mli
+++ b/vernac/record.mli
@@ -30,6 +30,7 @@ val definition_structure
   -> template:bool option
   -> cumulative:bool
   -> poly:bool
+  -> ?mode_declaration:Typeclasses.hint_mode list
   -> Declarations.recursivity_kind
   -> Ast.t list
   -> GlobRef.t list

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1328,8 +1328,11 @@ let vernac_existing_instance ~section_local insts =
   let glob = not section_local in
   List.iter (fun (id, info) -> Classes.existing_instance glob id (Some info)) insts
 
-let vernac_existing_class id =
-  Record.declare_existing_class (Nametab.global id)
+let vernac_existing_class ~atts id =
+  let mode_declaration =
+    Attributes.(parse mode_declaration) atts
+  in
+  Record.declare_existing_class ?mode_declaration (Nametab.global id)
 
 (***********)
 (* Solving *)
@@ -2248,9 +2251,7 @@ let translate_vernac ?loc ~atts v = let open Vernacextend in match v with
   | VernacExistingInstance insts ->
     VtDefault(fun () -> with_section_locality ~atts vernac_existing_instance insts)
   | VernacExistingClass id ->
-    VtDefault(fun () ->
-        unsupported_attributes atts;
-        vernac_existing_class id)
+    VtDefault(fun () -> vernac_existing_class ~atts id)
 
   (* Solving *)
   | VernacSolveExistential (n,c) ->

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -793,7 +793,7 @@ let should_treat_as_uniform () =
   then ComInductive.UniformParameters
   else ComInductive.NonUniformParameters
 
-let vernac_record ~template udecl ~cumulative k ~poly ?typing_flags ?mode_declaration finite records =
+let vernac_record ~template udecl ~cumulative k ~poly ?typing_flags ?modes_declaration finite records =
   let map ((is_coercion, name), binders, sort, nameopt, cfs) =
     let idbuild = match nameopt with
     | None -> Nameops.add_prefix "Build_" name.v
@@ -819,7 +819,7 @@ let vernac_record ~template udecl ~cumulative k ~poly ?typing_flags ?mode_declar
     CErrors.user_err (Pp.str "typing flags are not yet supported for records")
   | None ->
     let _ : _ list =
-      Record.definition_structure ~template udecl k ~cumulative ~poly ?mode_declaration finite records in
+      Record.definition_structure ~template udecl k ~cumulative ~poly ?modes_declaration finite records in
     ()
 
 let extract_inductive_udecl (indl:(inductive_expr * decl_notation list) list) =
@@ -852,8 +852,8 @@ let private_ind =
   | None -> return false
 
 let vernac_inductive ~atts kind indl =
-  let ((((template, (poly, cumulative)), private_ind), typing_flags), mode_declaration) = Attributes.(
-      parse Notations.(template ++ polymorphic_cumulative ++ private_ind ++ typing_flags ++ mode_declaration) atts) in
+  let ((((template, (poly, cumulative)), private_ind), typing_flags), modes_declaration) = Attributes.(
+      parse Notations.(template ++ polymorphic_cumulative ++ private_ind ++ typing_flags ++ modes_declaration) atts) in
   let open Pp in
   let udecl, indl = extract_inductive_udecl indl in
   if Dumpglob.dump () then
@@ -890,7 +890,7 @@ let vernac_inductive ~atts kind indl =
     let coe' = if coe then BackInstance else NoInstance in
     let f = AssumExpr ((make ?loc:lid.loc @@ Name lid.v), [], ce),
             { rf_subclass = coe' ; rf_priority = None ; rf_notation = [] ; rf_canonical = true } in
-    vernac_record ~template udecl ~cumulative (Class true) ~poly ?typing_flags ?mode_declaration finite [id, bl, c, None, [f]]
+    vernac_record ~template udecl ~cumulative (Class true) ~poly ?typing_flags ?modes_declaration finite [id, bl, c, None, [f]]
   else if List.for_all is_record indl then
     (* Mutual record case *)
     let () = match kind with
@@ -913,13 +913,13 @@ let vernac_inductive ~atts kind indl =
       (id, bl, c, oc, fs)
     | Constructors _ -> assert false (* ruled out above *)
     in
-    let kind = match kind, mode_declaration with
+    let kind = match kind, modes_declaration with
       | Class _, _ -> Class false
       | _, Some _ -> CErrors.user_err Pp.(str "Only Classes support the \"mode\" attribute.")
       | _, None ->kind
     in
     let recordl = List.map unpack indl in
-    vernac_record ~template udecl ~cumulative kind ~poly ?typing_flags ?mode_declaration finite recordl
+    vernac_record ~template udecl ~cumulative kind ~poly ?typing_flags ?modes_declaration finite recordl
   else if List.for_all is_constructor indl then
     (* Mutual inductive case *)
     let () = match kind with
@@ -929,8 +929,8 @@ let vernac_inductive ~atts kind indl =
       user_err (str "Inductive classes not supported")
     | Variant | Inductive_kw | CoInductive -> ()
     in
-    let () = match mode_declaration with
-      | Some _ -> CErrors.user_err Pp.(str "Only Classes support the \"mode\" attribute.")
+    let () = match modes_declaration with
+      | Some _ -> CErrors.user_err Pp.(str "Only Classes support the \"modes\" attribute.")
       | None -> ()
     in
     let check_name ((na, _, _, _), _) = match na with
@@ -1329,10 +1329,10 @@ let vernac_existing_instance ~section_local insts =
   List.iter (fun (id, info) -> Classes.existing_instance glob id (Some info)) insts
 
 let vernac_existing_class ~atts id =
-  let mode_declaration =
-    Attributes.(parse mode_declaration) atts
+  let modes_declaration =
+    Attributes.(parse modes_declaration) atts
   in
-  Record.declare_existing_class ?mode_declaration (Nametab.global id)
+  Record.declare_existing_class ?modes_declaration (Nametab.global id)
 
 (***********)
 (* Solving *)

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -304,7 +304,7 @@ type hints_expr =
   | HintsImmediate of reference_or_constr list
   | HintsUnfold of Libnames.qualid list
   | HintsTransparency of Libnames.qualid Hints.hints_transparency_target * bool
-  | HintsMode of Libnames.qualid * Hints.hint_mode list
+  | HintsMode of Libnames.qualid * Typeclasses.hint_mode list
   | HintsConstructors of Libnames.qualid list
   | HintsExtern of int * Constrexpr.constr_expr option * Genarg.raw_generic_argument
 


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** feature / bug fix

This PR adds 3 things at once to the treatment of hint modes for typeclasses:

- A new option `Set Typeclasses Default Mode "!"/"+"/"-"` that tells which mode should be used for indices of a typeclass at its introduction (the option is unset by default). Previously, the code was morally using '-' when introducing a class without subsequent mode declaration, but it actually did not set a mode. So, the first mode declaration afterwards was setting it. As there can be multiple modes per head/class, this is not the same: "- - or ! -" is different from just "! -", hence the "unset" option by default to maintain 100% backward compatibility. After this PR we can globally set "!" in the prelude to check where the stdlib depends on defaulting. It would make a much more user-friendly default too.
- A new attribute `#[modes="+ - !, - + !"]` for Class and Existing Class that can be used as a shortcut to subsequent `Hint Mode ... : typeclass_instances` declarations (fixes #13083)
- A new warning "class-declaration-default-mode", disabled by default, that informs the user that a default mode has been inferred. It can be turned into a warning or an error to check that declarations have all an accompanying #[mode] attribute.
- It is an *error* to put a mode declaration for a class in a section if it depends on section variables, if no default mode is set. If a default is set, it is used to set the mode of the discharged variables, but the behavior is also controlled by the above warning, so it can also be turned into an error.

The PR also fixes one bug in the interpretation of modes which was wrong if let-ins appeared in the parameters: we only need modes for the non-let bindings.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #13083

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
