### PR TITLE
[printing] Remove ability to set per-sentence "verbosity"

### DIFF
--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -76,13 +76,14 @@ let ide_doc = ref None
 let get_doc () = Option.get !ide_doc
 let set_doc doc = ide_doc := Some doc
 
-let add ((s,eid),(sid,verbose)) =
+(* _ is for compat with older versions of the protocol *)
+let add ((s,eid), (sid,_)) =
   let doc = get_doc () in
   let pa = Pcoq.Parsable.make (Stream.of_string s) in
   match Stm.parse_sentence ~doc sid ~entry:Pvernac.main_entry pa with
   | None -> assert false (* s may not be empty *)
   | Some ast ->
-    let doc, newid, rc = Stm.add ~doc ~ontop:sid verbose ast in
+    let doc, newid, rc = Stm.add ~doc ~ontop:sid ast in
     set_doc doc;
     let rc = match rc with `NewTip -> CSig.Inl () | `Unfocus id -> CSig.Inr id in
     ide_cmd_warns ~id:newid ast;

--- a/ide/coqide/protocol/interface.ml
+++ b/ide/coqide/protocol/interface.ml
@@ -133,16 +133,20 @@ type ('a, 'b) union = ('a, 'b) Util.union
 
 (* Request/Reply message protocol between Coq and CoqIDE *)
 
-(**  [add ((s,eid),(sid,v))] adds the phrase [s] with edit id [eid]
-     on top of the current edit position (that is asserted to be [sid])
-     verbosely if [v] is true.  The response [(id,(rc,s)] is the new state
+(**  [add ((s,eid), (sid,_))] adds the phrase [s] with edit id [eid]
+     on top of the current edit position (that is asserted to be [sid]).
+     The response [(id,(rc,s)] is the new state
      [id] assigned to the phrase. [rc] is [Inl] if the new
      state id is the tip of the edit point, or [Inr tip] if the new phrase
      closes a focus and [tip] is the new edit tip
 
      [s] used to contain Coq's console output and has been deprecated
      in favor of sending feedback, it will be removed in a future
-     version of the protocol.  *)
+     version of the protocol.
+
+     The missing boolean is not used now, but kept in place for
+     compatibility (it used to indicate verbosity control)
+   *)
 type add_sty = (string * edit_id) * (state_id * verbose)
 type add_rty = state_id * ((unit, state_id) union * string)
 

--- a/ide/coqide/protocol/xmlprotocol.ml
+++ b/ide/coqide/protocol/xmlprotocol.ml
@@ -8,12 +8,19 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(** Protocol version of this file. This is the date of the last modification. *)
-let protocol_version = "20210506"
-
 (** WARNING: TO BE UPDATED WHEN MODIFIED! *)
 
-(** See xml-protocol.md for a description of the protocol. *)
+(** See xml-protocol.md for a description of the protocol *)
+
+(** Protocol changelog:
+
+  - 20210413: the "verbose" parameter in add call is now ignored; no
+    changes to the in-wire representation.
+
+*)
+
+(** Protocol version of this file. This is the date of the last modification. *)
+let protocol_version = "20210413"
 
 type msg_format = Richpp of { width : int; depth : int } | Ppcmds
 let msg_format = ref (Richpp { width = 72; depth = max_int })

--- a/stm/stm.mli
+++ b/stm/stm.mli
@@ -88,15 +88,20 @@ val parse_sentence :
 (* Reminder: A parsable [pa] is constructed using
    [Pcoq.Parsable.t stream], where [stream : char Stream.t]. *)
 
-(* [add ~ontop ?newtip verbose cmd] adds a new command [cmd] ontop of
-   the state [ontop].
-   The [ontop] parameter just asserts that the GUI is on
-   sync, but it will eventually call edit_at on the fly if needed.
-   If [newtip] is provided, then the returned state id is guaranteed
-   to be [newtip] *)
-val add : doc:doc -> ontop:Stateid.t -> ?newtip:Stateid.t ->
-  bool -> Vernacexpr.vernac_control ->
-  doc * Stateid.t * [ `NewTip | `Unfocus of Stateid.t ]
+(** [add ~ontop ?newtip cmd] adds a new command [cmd] ontop of
+    the state [ontop].
+
+    The [ontop] parameter just asserts that the GUI is on
+    sync, but it will eventually call edit_at on the fly if needed.
+
+    If [newtip] is provided, then the returned state id is guaranteed
+    to be [newtip] *)
+val add
+  : doc:doc
+  -> ontop:Stateid.t
+  -> ?newtip:Stateid.t
+  -> Vernacexpr.vernac_control
+  -> doc * Stateid.t * [ `NewTip | `Unfocus of Stateid.t ]
 
 (* Returns the proof state before the last tactic that was applied at or before
 the specified state AND that has differences in the underlying proof (i.e.,

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -894,9 +894,8 @@ GRAMMAR EXTEND Gram
       | IDENT "Cd" -> { VernacChdir None }
       | IDENT "Cd"; dir = ne_string -> { VernacChdir (Some dir) }
 
-      | IDENT "Load"; verbosely = [ IDENT "Verbose" -> { true } | -> { false } ];
-        s = [ s = ne_string -> { s } | s = IDENT -> { s } ] ->
-          { VernacLoad (verbosely, s) }
+      | IDENT "Load"; s = [ s = ne_string -> { s } | s = IDENT -> { s } ] ->
+          { VernacLoad s }
       | IDENT "Declare"; IDENT "ML"; IDENT "Module"; l = LIST1 ne_string ->
           { VernacDeclareMLModule l }
 

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -670,14 +670,8 @@ let pr_extend s cl =
 let pr_vernac_expr v =
   let return = tag_vernac v in
   match v with
-  | VernacLoad (f,s) ->
-    return (
-      keyword "Load"
-      ++ if f then
-        (spc() ++ keyword "Verbose" ++ spc())
-      else
-        spc() ++ qs s
-    )
+  | VernacLoad s ->
+    return (keyword "Load" ++ spc() ++ qs s)
 
   (* Proof management *)
   | VernacAbortAll ->

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -103,7 +103,6 @@ type search_restriction =
   | SearchInside of qualid list
   | SearchOutside of qualid list
 
-type verbose_flag   = bool (* true = Verbose;       false = Silent         *)
 type coercion_flag  = bool (* true = AddCoercion    false = NoCoercion     *)
 type instance_flag  = BackInstance | NoInstance
 
@@ -313,7 +312,7 @@ type hints_expr =
 
 type nonrec vernac_expr =
 
-  | VernacLoad of verbose_flag * string
+  | VernacLoad of string
   (* Syntax *)
   | VernacReservedNotation of infix_flag * (lstring * syntax_modifier CAst.t list)
   | VernacOpenCloseScope of bool * scope_name

--- a/vernac/vernacinterp.mli
+++ b/vernac/vernacinterp.mli
@@ -9,7 +9,7 @@
 (************************************************************************)
 
 (** The main interpretation function of vernacular expressions *)
-val interp : ?verbosely:bool -> st:Vernacstate.t -> Vernacexpr.vernac_control -> Vernacstate.t
+val interp : st:Vernacstate.t -> Vernacexpr.vernac_control -> Vernacstate.t
 
 (** Execute a Qed but with a proof_object which may contain a delayed
    proof and won't be forced *)


### PR DESCRIPTION
As part of the ongoing effort on
https://github.com/coq/coq/issues/12923 , we simplify the verbose API,
and in particular we remove the ability for `Stm.add` to attach a
verbosity argument per-sentence in favor of the global settings.

Having per-sentence verbosity information to override user-provided
settings seems strange, tho I think this change makes sense, but I
could be missing something.

Note in particular that vernac processing sets verbosity as:
```ocaml
Stm.add ~doc:state.doc ~ontop:state.sid (not !Flags.quiet) com in
```
so it is actually always the value of the global parameter in Coq.

The XML protocol allows to specify it as an argument, as far as I know
CoqIDE sets it but I am not sure the use did make sense in general.
