### PR TITLE
Uniformize the name of the Ltac2 boolean equality function.

### DIFF
--- a/doc/changelog/05-tactic-language/14128-ltac2-bool-equal-rename.rst
+++ b/doc/changelog/05-tactic-language/14128-ltac2-bool-equal-rename.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  Renamed Ltac2 Bool.eq into Bool.equal for uniformity.
+  The old function is now a deprecated alias
+  (`#14128 <https://github.com/coq/coq/pull/14128>`_,
+  by Pierre-Marie Pédrot).

--- a/user-contrib/Ltac2/Bool.v
+++ b/user-contrib/Ltac2/Bool.v
@@ -48,7 +48,7 @@ Ltac2 xor x y :=
        end
   end.
 
-Ltac2 eq x y :=
+Ltac2 equal x y :=
   match x with
   | true
     => match y with
@@ -61,3 +61,6 @@ Ltac2 eq x y :=
        | false => true
        end
   end.
+
+#[deprecated(note="Use Bool.equal", since="8.14")]
+Ltac2 eq := equal.


### PR DESCRIPTION
All other equality functions are called "equal" but this one was called "eq". We add a deprecated alias for backward compatibility.

- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
