### PR TITLE
Setoid_rewrite: Substitue constraint evars in all new goals

### DIFF
--- a/test-suite/bugs/closed/bug_14129.v
+++ b/test-suite/bugs/closed/bug_14129.v
@@ -1,0 +1,19 @@
+Require Import Setoid Morphisms.
+
+Parameter reli : forall (dummy:unit)(R:relation unit), relation unit.
+
+Parameter f g : unit -> unit.
+
+Declare Instance c
+  (dummy : unit) (R : relation unit) :
+  Proper (reli dummy R ==> R) f.
+
+Parameter H : forall (eq : relation unit) (a : unit), eq a a -> eq (g a) a.
+
+Goal f (g tt) = tt.
+try rewrite H.
+Abort.
+
+Goal f (g tt) = tt.
+try setoid_rewrite H.
+Abort.


### PR DESCRIPTION
setoid_rewrite generates evar constraints that are solved by the typeclasses
mechanism. After the constraints are solved, they are substituted away. This
substitution is incomplete though, because it is not done for all newly
generated goals.

Testcase:
```
Require Import Setoid Morphisms.

Module Type T.

Parameter reli : forall (dummy:unit) (R:relation (unit -> Prop)), relation unit.

Parameter k : relation unit.

Declare Instance c
  (dummy : unit)
  (R : relation (unit -> Prop)) :
  Proper (reli dummy R ==> R) k.

Parameter r : unit -> unit.

Parameter H : forall (eq : relation unit) y, eq y y -> eq (r y) tt.


Lemma t (y : unit) : k (r y) tt.
setoid_rewrite H.
Abort.
```
Fix https://github.com/coq/coq/issues/14239

<!-- Keep what applies -->
**Kind:** bug fix

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite