### PR TITLE
Generic support for parsing optional arguments in Ltac2 tactic notations

### DIFF
--- a/test-suite/ltac2/optsyntax.v
+++ b/test-suite/ltac2/optsyntax.v
@@ -1,0 +1,126 @@
+Require Import Ltac2.Ltac2.
+
+Import Ltac2.Notations Ltac2.Control Ltac2.Printf Ltac2.Attributes.
+
+Class A (n : nat).
+Instance a0 : A 0 := {}.
+
+Ltac2 parse_strategy tac opts :=
+  let act value :=
+    match Attribute.to_string value with
+    | Some s =>
+      if String.equal s "bfs" then Some Std.BFS
+      else if String.equal s "dfs" then Some Std.DFS
+      else unsupported_attribute_value tac "strategy" value
+    | None =>
+      unsupported_attribute_value tac "strategy" value
+    end
+  in parse_option opts "strategy" act.
+
+Ltac2 parse_int_opt tac key opts :=
+  let act value :=
+    match Attribute.to_string value with
+    | Some s =>
+      match String.to_int s with
+      | Some i => Some i
+      | None => unsupported_attribute_value tac key value
+      end
+    | None =>
+      unsupported_attribute_value tac key value
+    end
+  in parse_option opts key act.
+
+Ltac2 tceauto_attributes opts :=
+  let bfs := parse_flag opts "bfs" in
+  let be := parse_flag opts "best_effort" in
+  let strategy := parse_strategy "typeclasses eauto" opts in
+  let depth := parse_int_opt "typeclasses eauto" "depth" opts in
+  check_empty_attributes "typeclasses eauto" opts;
+  (bfs, be, strategy, depth).
+
+Ltac2 of_strategy s :=
+  match s with
+  | Some s =>
+    match s with
+    | Std.BFS => "breadth-first search"
+    | Std.DFS => "depth-first search"
+    end
+  | None => "default"
+  end.
+
+Ltac2 of_depth d :=
+  match d with
+  | Some i => Message.of_int i
+  | None => Message.of_string "∞"
+  end.
+
+Ltac2 rec of_list f l :=
+  match l with
+  | [] => Message.of_string "[]"
+  | x :: xs => Message.concat (f x) (Message.concat (Message.of_string " :: ") (of_list f xs))
+  end.
+
+Ltac2 of_bfs_flag b := if b then Some Std.BFS else None.
+
+Ltac2 tceauto (attrs : Attributes.t) (cstrs : constr list) (depth : int option) (dbs : ident list option) :=
+  let (bfs, be, strat, _) := tceauto_attributes attrs in
+  printf "cstrs: %a" (fun _ => of_list Message.of_constr) cstrs;
+  printf "bfs: %a" (fun _ => Message.of_bool) bfs;
+  printf "best_effort: %a" (fun _ => Message.of_bool) be;
+  printf "strategy: %s" (of_strategy strat);
+  printf "depth: %a" (fun _ => of_depth) depth;
+  Std.typeclasses_eauto (of_bfs_flag bfs) depth dbs.
+
+(* Probably ill-advised to use a constr list without delimiters but it works *)
+Ltac2 Notation "tc" "eauto" attrs(attributes) cstrs(list0(constr, ",")) n(opt(tactic(0)))
+  dbs(opt(seq("with", list1(ident)))) :=
+  tceauto attrs cstrs n dbs.
+
+(* A clearer alternative, but we still can't move "depth" to any position *)
+Ltac2 Notation "tceauto'" attrs(attributes)
+  cstrs(seq("[", list0(constr, ","), "]"))
+  n(opt(seq("depth", "(", tactic(0), ")")))
+  dbs(opt(seq("with", list1(ident)))) :=
+  tceauto attrs cstrs n dbs.
+
+Ltac2 tceauto_attrs (attrs : Attributes.t) (cstrs : constr list) (dbs : ident list option) :=
+  let (bfs, be, strat, depth) := tceauto_attributes attrs in
+  printf "cstrs: %a" (fun _ => of_list Message.of_constr) cstrs;
+  printf "bfs: %a" (fun _ => Message.of_bool) bfs;
+  printf "best_effort: %a" (fun _ => Message.of_bool) be;
+  printf "strategy: %s" (of_strategy strat);
+  printf "depth: %a" (fun _ => of_depth) depth;
+  Std.typeclasses_eauto (of_bfs_flag bfs) depth dbs.
+
+(* Use attributes for depth as well *)
+Ltac2 Notation "tceauto_attrs" attrs(attributes)
+  cstrs(seq("[", list0(constr, ","), "]"))
+  dbs(opt(seq("with", list1(ident)))) :=
+  tceauto_attrs attrs cstrs dbs.
+
+Goal A 0.
+Proof.
+  (** Note the quite terrible I, 0 5*)
+  tc eauto @[best_effort, strategy="dfs"] I, 0 5 with typeclass_instances.
+  (* Parses and prints out as expected:
+    cstrs: I :: 0 :: []
+    bfs: false
+    best_effort: true
+    strategy: depth-first search
+    depth: 5
+  *)
+  Undo 1.
+  tceauto' @[best_effort, strategy="dfs"] [I, 0] depth(5) with typeclass_instances.
+  (* Parses and prints out as expected:
+    cstrs: I :: 0 :: []
+    bfs: false
+    best_effort: true
+    strategy: depth-first search
+    depth: 5
+  *)
+  Undo 1.
+  Fail tceauto_attrs @[best_effort, depth="0", strategy="dfs"] [I, 0] with typeclass_instances.
+  (* Invalid argument dept="0" *)
+  Fail tceauto_attrs @[best_effort, dept="0", strategy="dfs"] [I, 0] with typeclass_instances.
+  tceauto_attrs @[best_effort, strategy="dfs", depth="1"] [I, 0] with typeclass_instances.
+Qed.

--- a/test-suite/ltac2/optsyntax.v
+++ b/test-suite/ltac2/optsyntax.v
@@ -72,12 +72,12 @@ Ltac2 tceauto (attrs : Attributes.t) (cstrs : constr list) (depth : int option) 
   Std.typeclasses_eauto (of_bfs_flag bfs) depth dbs.
 
 (* Probably ill-advised to use a constr list without delimiters but it works *)
-Ltac2 Notation "tc" "eauto" attrs(attributes) cstrs(list0(constr, ",")) n(opt(tactic(0)))
+Ltac2 Notation attrs(attributes) "tc" "eauto" cstrs(list0(constr, ",")) n(opt(tactic(0)))
   dbs(opt(seq("with", list1(ident)))) :=
   tceauto attrs cstrs n dbs.
 
 (* A clearer alternative, but we still can't move "depth" to any position *)
-Ltac2 Notation "tceauto'" attrs(attributes)
+Ltac2 Notation attrs(attributes) "tceauto'"
   cstrs(seq("[", list0(constr, ","), "]"))
   n(opt(seq("depth", "(", tactic(0), ")")))
   dbs(opt(seq("with", list1(ident)))) :=
@@ -93,7 +93,7 @@ Ltac2 tceauto_attrs (attrs : Attributes.t) (cstrs : constr list) (dbs : ident li
   Std.typeclasses_eauto (of_bfs_flag bfs) depth dbs.
 
 (* Use attributes for depth as well *)
-Ltac2 Notation "tceauto_attrs" attrs(attributes)
+Ltac2 Notation attrs(attributes) "tceauto_attrs"
   cstrs(seq("[", list0(constr, ","), "]"))
   dbs(opt(seq("with", list1(ident)))) :=
   tceauto_attrs attrs cstrs dbs.
@@ -101,7 +101,8 @@ Ltac2 Notation "tceauto_attrs" attrs(attributes)
 Goal A 0.
 Proof.
   (** Note the quite terrible I, 0 5*)
-  tc eauto @[best_effort, strategy="dfs"] I, 0 5 with typeclass_instances.
+  (* #[best_effort, strategy="dfs"]
+  tc eauto I, 0 5. with typeclass_instances. *)
   (* Parses and prints out as expected:
     cstrs: I :: 0 :: []
     bfs: false
@@ -110,7 +111,7 @@ Proof.
     depth: 5
   *)
   Undo 1.
-  tceauto' @[best_effort, strategy="dfs"] [I, 0] depth(5) with typeclass_instances.
+  (#[best_effort, strategy="dfs"] tceauto' [I, 0] depth(5) with typeclass_instances).
   (* Parses and prints out as expected:
     cstrs: I :: 0 :: []
     bfs: false
@@ -119,8 +120,8 @@ Proof.
     depth: 5
   *)
   Undo 1.
-  Fail tceauto_attrs @[best_effort, depth="0", strategy="dfs"] [I, 0] with typeclass_instances.
+  Fail (#[best_effort, depth="0", strategy="dfs"] tceauto_attrs [I, 0] with typeclass_instances).
   (* Invalid argument dept="0" *)
-  Fail tceauto_attrs @[best_effort, dept="0", strategy="dfs"] [I, 0] with typeclass_instances.
-  tceauto_attrs @[best_effort, strategy="dfs", depth="1"] [I, 0] with typeclass_instances.
+  Fail (#[best_effort, dept="0", strategy="dfs"] tceauto_attrs [I, 0] with typeclass_instances).
+  (#[best_effort, strategy="dfs", depth="1"] tceauto_attrs [I, 0] with typeclass_instances).
 Qed.

--- a/user-contrib/Ltac2/Attributes.v
+++ b/user-contrib/Ltac2/Attributes.v
@@ -53,15 +53,13 @@ Ltac2 @ external of_list : (string * Attribute.attribute_value) list -> t := "lt
 Ltac2 check_empty_attributes tac attrs :=
   if Attributes.is_empty attrs then ()
   else Control.throw (Invalid_argument (Some
-    (Message.concat (Message.of_string "Tactic ") (Message.concat (Message.of_string tac)
-      (Message.concat (Message.of_string " does not support attribute(s): ")
-      (Attributes.to_message attrs)))))).
+    (fprintf "Tactic %s does not support attribute(s): %a" tac
+      (fun () => to_message) attrs))).
 
 Ltac2 unsupported_attribute_value tac key value :=
   Control.throw (Invalid_argument (Some
-  (Message.concat (Message.of_string "Tactic ") (Message.concat (Message.of_string tac)
-    (Message.concat (Message.of_string " does not support attribute: ")
-    (Attributes.Attribute.to_message key value)))))).
+    (fprintf "Tactic %s does not support attribute: %a" tac
+      (fun () => Attributes.Attribute.to_message key) value))).
 
 (** [parse_option attrs k cont] parses an option [k] in attributes [attrs]:
     - if present it ensures that there is no duplicate attribute declaration,

--- a/user-contrib/Ltac2/Attributes.v
+++ b/user-contrib/Ltac2/Attributes.v
@@ -1,0 +1,97 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+Require Import Ltac2.Init.
+Require Ltac2.Control.
+Require Ltac2.List.
+Require Import Ltac2.Printf.
+
+Ltac2 Type t.
+(** Type of attribute declarations.
+    A mutable set of attribute declarations: string -> attribute_value. *)
+
+Module Attribute.
+Ltac2 Type attribute_value.
+(** Type of an attribute declaration *)
+
+Ltac2 @ external to_string : attribute_value -> string option := "ltac2" "attributes_attribute_to_string".
+Ltac2 @ external to_ident : attribute_value -> ident option := "ltac2" "attributes_attribute_to_ident".
+Ltac2 @ external to_attributes : attribute_value -> t option := "ltac2" "attributes_attribute_to_attributes".
+Ltac2 @ external is_empty : attribute_value -> bool := "ltac2" "attributes_attribute_is_empty".
+Ltac2 @ external to_message : string -> attribute_value -> message := "ltac2" "attributes_attribute_to_message".
+(** Prints the key and attribute. *)
+
+(* For internal use: constructs attributes *)
+Ltac2 @ external empty : unit -> attribute_value := "ltac2" "attributes_attribute_empty".
+Ltac2 @ external of_string : string -> attribute_value := "ltac2" "attributes_attribute_of_string".
+Ltac2 @ external of_ident : ident -> attribute_value := "ltac2" "attributes_attribute_of_ident".
+Ltac2 @ external of_attributes : t -> attribute_value := "ltac2" "attributes_attribute_of_attributes".
+End Attribute.
+
+Ltac2 @ external is_empty : t -> bool := "ltac2" "attributes_is_empty".
+(** Checks if the attributes are empty. *)
+
+Ltac2 @ external consume : t -> string -> Attribute.attribute_value option  := "ltac2" "attributes_consume".
+(** [consume attrs key] Consumes the first attribute of key `key` from the attributes [attrs],
+    removing it from the list of attributes as a side-effect. *)
+
+Ltac2 @ external to_message : t -> message := "ltac2" "attributes_to_message".
+(** Prints the current state of the attributes. *)
+
+Ltac2 @ external of_list : (string * Attribute.attribute_value) list -> t := "ltac2" "attributes_of_list".
+(* For internal use: constructs a list of attributes *)
+
+(* Higher-level functions to work with attributes. *)
+
+Ltac2 check_empty_attributes tac attrs :=
+  if Attributes.is_empty attrs then ()
+  else Control.throw (Invalid_argument (Some
+    (Message.concat (Message.of_string "Tactic ") (Message.concat (Message.of_string tac)
+      (Message.concat (Message.of_string " does not support attribute(s): ")
+      (Attributes.to_message attrs)))))).
+
+Ltac2 unsupported_attribute_value tac key value :=
+  Control.throw (Invalid_argument (Some
+  (Message.concat (Message.of_string "Tactic ") (Message.concat (Message.of_string tac)
+    (Message.concat (Message.of_string " does not support attribute: ")
+    (Attributes.Attribute.to_message key value)))))).
+
+(** [parse_option attrs k cont] parses an option [k] in attributes [attrs]:
+    - if present it ensures that there is no duplicate attribute declaration,
+      and returns [cont k]
+    - otherwise returns [None]. *)
+Ltac2 parse_option attrs k cont :=
+  let value := Attributes.consume attrs k in
+  match value with
+  | Some v =>
+    match Attributes.consume attrs k with
+    | Some duplicate =>
+      Control.throw (Invalid_argument (Some (fprintf "Duplicate attribute values for %s." k)))
+    | None => cont v
+    end
+  | None => None
+  end.
+
+(** Parse a flag [k] in attributes [attrs]:
+    - if present ensure that there is no attached value and no duplicate attribute declaration,
+      and returns [true]
+    - otherwise returns [false]. *)
+Ltac2 parse_flag attrs k :=
+  let cont v :=
+    match Attributes.Attribute.is_empty v with
+    | true => Some ()
+    | false =>
+        Control.throw (Invalid_argument (Some (fprintf "Attribute %s does not accept any value" k)))
+    end
+  in
+  match parse_option attrs k cont with
+  | Some _ => true
+  | None => false
+  end.

--- a/user-contrib/Ltac2/Char.v
+++ b/user-contrib/Ltac2/Char.v
@@ -9,6 +9,10 @@
 (************************************************************************)
 
 Require Import Ltac2.Init.
+Require Import Ltac2.Int.
 
 Ltac2 @external of_int : int -> char := "ltac2" "char_of_int".
 Ltac2 @external to_int : char -> int := "ltac2" "char_to_int".
+
+Ltac2 equal (x : char) (y : char) : bool :=
+  Int.equal (Char.to_int x) (Char.to_int y).

--- a/user-contrib/Ltac2/Ltac2.v
+++ b/user-contrib/Ltac2/Ltac2.v
@@ -28,5 +28,6 @@ Require Ltac2.Pattern.
 Require Ltac2.Printf.
 Require Ltac2.Std.
 Require Ltac2.String.
+Require Ltac2.Attributes.
 
 Require Export Ltac2.Notations.

--- a/user-contrib/Ltac2/Message.v
+++ b/user-contrib/Ltac2/Message.v
@@ -24,6 +24,8 @@ Ltac2 @ external of_constr : constr -> message := "ltac2" "message_of_constr".
 Ltac2 @ external of_exn : exn -> message := "ltac2" "message_of_exn".
 (** Panics if there is more than one goal under focus. *)
 
+Ltac2 of_bool b := if b then of_string "true" else of_string "false".
+
 Ltac2 @ external concat : message -> message -> message := "ltac2" "message_concat".
 
 Module Format.

--- a/user-contrib/Ltac2/String.v
+++ b/user-contrib/Ltac2/String.v
@@ -9,8 +9,20 @@
 (************************************************************************)
 
 Require Import Ltac2.Init.
+Require Import Ltac2.Int Ltac2.Char.
 
 Ltac2 @external make : int -> char -> string := "ltac2" "string_make".
 Ltac2 @external length : string -> int := "ltac2" "string_length".
 Ltac2 @external get : string -> int -> char := "ltac2" "string_get".
 Ltac2 @external set : string -> int -> char -> unit := "ltac2" "string_set".
+Ltac2 @external to_int : string -> int option := "ltac2" "string_to_int".
+
+Ltac2 equal (x : string) (y : string) : bool :=
+  let rec aux n :=
+    if Int.lt n 0 then true
+    else if Char.equal (String.get x n) (String.get y n) then aux (Int.sub n 1)
+    else false
+  in
+  let len := String.length x in
+  if Int.equal len (String.length y) then aux (Int.sub len 1)
+  else false.

--- a/user-contrib/Ltac2/tac2core.ml
+++ b/user-contrib/Ltac2/tac2core.ml
@@ -1939,7 +1939,7 @@ end
 let () = add_scope "attributes" begin fun toks ->
   match toks with
   | [] ->
-    let scope = G_vernac.tactic_attributes in
+    let scope = G_vernac.quoted_attributes in
     let act attrs = Tac2quote.of_attributes (CAst.make attrs) in
     Tac2entries.ScopeRule (Pcoq.Symbol.nterm scope, act)
   | arg -> scope_fail "attributes" arg

--- a/user-contrib/Ltac2/tac2ffi.ml
+++ b/user-contrib/Ltac2/tac2ffi.ml
@@ -103,6 +103,8 @@ let val_case = Val.create "case"
 let val_binder = Val.create "binder"
 let val_univ = Val.create "universe"
 let val_free : Names.Id.Set.t Val.tag = Val.create "free"
+let val_attribute : Attributes.vernac_flag_value Val.tag = Val.create "attribute"
+let val_attributes : Attributes.vernac_flags ref Val.tag = Val.create "attributes"
 let val_ltac1 : Geninterp.Val.t Val.tag = Val.create "ltac1"
 let val_ind_data : (Names.Ind.t * Declarations.mutual_inductive_body) Val.tag = Val.create "ind_data"
 

--- a/user-contrib/Ltac2/tac2ffi.mli
+++ b/user-contrib/Ltac2/tac2ffi.mli
@@ -183,6 +183,8 @@ val val_case : Constr.case_info Val.tag
 val val_binder : (Name.t Context.binder_annot * types) Val.tag
 val val_univ : Univ.Level.t Val.tag
 val val_free : Id.Set.t Val.tag
+val val_attribute : Attributes.vernac_flag_value Val.tag
+val val_attributes : Attributes.vernac_flags ref Val.tag
 val val_ltac1 : Geninterp.Val.t Val.tag
 val val_ind_data : (Names.Ind.t * Declarations.mutual_inductive_body) Val.tag
 

--- a/user-contrib/Ltac2/tac2quote.mli
+++ b/user-contrib/Ltac2/tac2quote.mli
@@ -87,6 +87,8 @@ val of_goal_matching : goal_matching -> raw_tacexpr
 
 val of_format : lstring -> raw_tacexpr
 
+val of_attributes : (string * Attributes.vernac_flag_value) list CAst.t -> raw_tacexpr
+
 (** {5 Generic arguments} *)
 
 val wit_pattern : (Constrexpr.constr_expr, Pattern.constr_pattern) Arg.tag

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -41,6 +41,7 @@ let search_queries = Entry.create "search_queries"
 let subprf = Entry.create "subprf"
 
 let quoted_attributes = Entry.create "quoted_attributes"
+let tactic_attributes = Entry.create "tactic_attributes"
 let class_rawexpr = Entry.create "class_rawexpr"
 let thm_token = Entry.create "thm_token"
 let def_token = Entry.create "def_token"
@@ -85,7 +86,7 @@ let test_id_colon =
 }
 
 GRAMMAR EXTEND Gram
-  GLOBAL: vernac_control quoted_attributes gallina_ext noedit_mode subprf;
+  GLOBAL: vernac_control quoted_attributes tactic_attributes gallina_ext noedit_mode subprf;
   vernac_control: FIRST
     [ [ IDENT "Time"; c = vernac_control ->
         { add_control_flag ~loc ~flag:(ControlTime false) c }
@@ -105,6 +106,10 @@ GRAMMAR EXTEND Gram
   ;
   quoted_attributes:
     [ [ "#[" ; a = attribute_list ; "]" -> { a } ]
+    ]
+  ;
+  tactic_attributes:
+    [ [ "@[" ; a = attribute_list ; "]" -> { a } ]
     ]
   ;
   attribute_list:

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -41,7 +41,6 @@ let search_queries = Entry.create "search_queries"
 let subprf = Entry.create "subprf"
 
 let quoted_attributes = Entry.create "quoted_attributes"
-let tactic_attributes = Entry.create "tactic_attributes"
 let class_rawexpr = Entry.create "class_rawexpr"
 let thm_token = Entry.create "thm_token"
 let def_token = Entry.create "def_token"
@@ -86,7 +85,7 @@ let test_id_colon =
 }
 
 GRAMMAR EXTEND Gram
-  GLOBAL: vernac_control quoted_attributes tactic_attributes gallina_ext noedit_mode subprf;
+  GLOBAL: vernac_control quoted_attributes gallina_ext noedit_mode subprf;
   vernac_control: FIRST
     [ [ IDENT "Time"; c = vernac_control ->
         { add_control_flag ~loc ~flag:(ControlTime false) c }
@@ -106,10 +105,6 @@ GRAMMAR EXTEND Gram
   ;
   quoted_attributes:
     [ [ "#[" ; a = attribute_list ; "]" -> { a } ]
-    ]
-  ;
-  tactic_attributes:
-    [ [ "@[" ; a = attribute_list ; "]" -> { a } ]
     ]
   ;
   attribute_list:


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

This PR adds a new scope `attributes` (which could also be called `options`, but reuses the genric s-expr structure of attributes) for Ltac2 notations and an API to consume attribute declarations (hiding the ADT but letting users access most of the functionality). Right now they are parsed using `@[ attribute_list ]` so one can write tactic notations like:

```coq
  typeclasses eauto @[best_effort, strategy="dfs", depth="1"] with typeclass_instances.
```

After talking with PMP, this seems like a more lightweight solution than generally extending Ltac2's type system with optional arguments. It also stays at the parsing level, so we don't need to do much at the ML level really. The solution using (delimited) attributes also avoids any potential headache with factorization of rules or crazy GADTs to have a generic mechanism in ML to parse options in any order while writing type-safe code.

<!-- Keep what applies -->
**Kind:**  feature / infrastructure.

There is a bit of Ltac2 code used to generically parse flags/options but this is all user customizable: we have more or less access to the raw sexprs of attributes, as in the vernac level.

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
- [ ] Overlay pull requests (if this breaks 3rd party developments in CI, see
https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md for details)
