### PR TITLE
UState.process_universe_constraints: rather than checking in the graph whether a constraint is implied by already existing ones, just add it as is when possible.

### DIFF
--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -259,7 +259,15 @@ let process_universe_constraints uctx cstrs =
                 | Some l ->
                   Univ.Constraint.add (l, Le, r') local
                 | None ->
-                  if UGraph.check_leq univs l r then local else enforce_leq l r local
+                  (* We insert the constraint in the graph even if the graph
+                     already contains it.  Indeed, checking the existance of the
+                     constraint is costly when the constraint does not already
+                     exist directly as a single edge in the graph, but adding an
+                     edge in the graph which is implied by others is cheap.
+                     Hence, by doing this, we avoid a costly check here, and
+                     make further checks of this constraint easier since it will
+                     exist directly in the graph. *)
+                  enforce_leq l r local
               end
           | ULub (l, r) ->
               equalize_variables true (Universe.make l) l (Universe.make r) r local


### PR DESCRIPTION
This improves performances dramatically on Metacoq.

**Kind:** performance

In theory, this should not cause incompatibilities. However, tests on metacoq already showed that this is not true since the behavior is different when using type-in-type, but this might be a bug in the implementation of type-in-type (not clear to me).

I am eager to see:
- What is the performance impact on other developments
- Whether there is some incompatibilities on other developments

@mattam82 suggested to activate this only when defining monomorphic values, but not for polymorphic values. I am a bit skeptical about such a choice because the performance issue mainly shows up for polymorphic definitions, but why not if we find this useful.