### PR TITLE
Add mczify to CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -806,6 +806,13 @@ library:ci-math_classes:
 library:ci-mathcomp:
   extends: .ci-template-flambda
 
+library:ci-mczify:
+  extends: .ci-template-flambda
+  stage: stage-3
+  needs:
+  - build:edge+flambda
+  - library:ci-mathcomp
+
 library:ci-sf:
   extends: .ci-template
 

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -44,6 +44,7 @@ CI_TARGETS= \
     ci-iris \
     ci-math_classes \
     ci-mathcomp \
+	ci-mczify \
     ci-menhir \
     ci-metacoq \
     ci-mtac2 \
@@ -89,6 +90,7 @@ ci-interval: ci-mathcomp ci-flocq ci-coquelicot ci-bignums
 ci-fourcolor: ci-mathcomp
 ci-oddorder: ci-mathcomp
 ci-fcsl_pcm: ci-mathcomp
+ci-mczify: ci-mathcomp
 
 ci-geocoq: ci-mathcomp
 

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -48,6 +48,8 @@ project fourcolor "https://github.com/math-comp/fourcolor" "master"
 
 project oddorder "https://github.com/math-comp/odd-order" "master"
 
+project mczify "https://github.com/math-comp/mczify" "master"
+
 ########################################################################
 # UniMath
 ########################################################################

--- a/dev/ci/ci-mczify.sh
+++ b/dev/ci/ci-mczify.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+git_download mczify
+
+( cd "${CI_BUILD_DIR}/mczify" && make )


### PR DESCRIPTION
[Mczify](https://github.com/math-comp/mczify) is a library to enable the use of the Micromega tactics for goals stated with the definitions of the Mathematical Components library. It heavily depends on the extensibility of the `zify` tactic and is worth testing in CI. In fact, a recent change of the zify tactic (#11907) broke the mczify library (see #14043). CC: @fajb

**Kind:** infrastructure.
