### PR TITLE
Implement the export locality for typeclass instances

### DIFF
--- a/dev/ci/user-overlays/14148-ppedrot-export-instance-take-two.sh
+++ b/dev/ci/user-overlays/14148-ppedrot-export-instance-take-two.sh
@@ -1,0 +1,9 @@
+overlay elpi https://github.com/ppedrot/coq-elpi export-instance-take-two 14148
+
+overlay equations https://github.com/ppedrot/Coq-Equations export-instance-take-two 14148
+
+overlay metacoq https://github.com/ppedrot/metacoq export-instance-take-two 14148
+
+overlay mtac2 https://github.com/ppedrot/Mtac2 export-instance-take-two 14148
+
+overlay quickchick https://github.com/ppedrot/QuickChick export-instance-take-two 14148

--- a/doc/changelog/07-vernac-commands-and-options/14148-export-instance-take-two.rst
+++ b/doc/changelog/07-vernac-commands-and-options/14148-export-instance-take-two.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  :cmd:`Instance` now accepts the :attr:`export` locality
+  attribute
+  (`#14148 <https://github.com/coq/coq/pull/14148>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/addendum/type-classes.rst
+++ b/doc/sphinx/addendum/type-classes.rst
@@ -347,10 +347,8 @@ Summary of the commands
    matching that pattern will trigger use of the instance.  Otherwise,
    use is triggered based on the conclusion of the type.
 
-   This command supports the :attr:`global` attribute that can be
-   used on instances declared in a section so that their
-   generalization is automatically redeclared when the section is
-   closed.
+   This command supports the :attr:`local`, :attr:`global` and :attr:`export`
+   locality attributes.
 
    Like :cmd:`Definition`, it also supports the :attr:`program`
    attribute to switch the type checking to `Program` (chapter

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -1944,8 +1944,7 @@ let add_morphism_as_parameter atts m n : unit =
   let cst = Declare.declare_constant ~name:instance_id ~kind (Declare.ParameterEntry pe) in
   let cst = GlobRef.ConstRef cst in
   Classes.add_instance
-    (Classes.mk_instance
-       (PropGlobal.proper_class env evd) Hints.empty_hint_info atts.global cst);
+    (PropGlobal.proper_class env evd) Hints.empty_hint_info atts.global cst;
   declare_projection n instance_id cst
 
 let add_morphism_interactive atts m n : Declare.Proof.t =
@@ -1959,9 +1958,8 @@ let add_morphism_interactive atts m n : Declare.Proof.t =
   let tac = make_tactic "Coq.Classes.SetoidTactics.add_morphism_tactic" in
   let hook { Declare.Hook.S.dref; _ } = dref |> function
     | GlobRef.ConstRef cst ->
-      Classes.add_instance (Classes.mk_instance
-                      (PropGlobal.proper_class env evd) Hints.empty_hint_info
-                      atts.global (GlobRef.ConstRef cst));
+      Classes.add_instance (PropGlobal.proper_class env evd) Hints.empty_hint_info
+        atts.global (GlobRef.ConstRef cst);
       declare_projection n instance_id (GlobRef.ConstRef cst)
     | _ -> assert false
   in

--- a/pretyping/typeclasses.ml
+++ b/pretyping/typeclasses.ml
@@ -75,9 +75,6 @@ type typeclasses = typeclass GlobRef.Map.t
 type instance = {
   is_class: GlobRef.t;
   is_info: hint_info;
-  (* Sections where the instance should be redeclared,
-     None for discard, Some 0 for none. *)
-  is_global: int option;
   is_impl: GlobRef.t;
 }
 

--- a/pretyping/typeclasses.mli
+++ b/pretyping/typeclasses.mli
@@ -60,9 +60,6 @@ type typeclass = {
 type instance = {
   is_class: GlobRef.t;
   is_info: hint_info;
-  (* Sections where the instance should be redeclared,
-     None for discard, Some 0 for none. *)
-  is_global: int option;
   is_impl: GlobRef.t;
 }
 

--- a/test-suite/success/export_inst.v
+++ b/test-suite/success/export_inst.v
@@ -1,0 +1,39 @@
+Class Foo.
+
+Module Foo.
+
+#[export]
+Instance F : Foo := {}.
+
+End Foo.
+
+Fail Definition foo_test := let _ : Foo := _ in tt.
+
+Import Foo.
+
+Definition foo_test := let _ : Foo := _ in tt.
+
+Class Bar.
+
+Module Bar.
+
+Section Bar.
+
+Variable b : Bar.
+
+#[export] Instance B : Bar := {}.
+
+(* Cannot declare variables as export instances *)
+Fail #[export] Existing Instance b.
+
+End Bar.
+
+Definition bar_test := let _ : Bar := _ in tt.
+
+End Bar.
+
+Fail Definition bar_test := let _ : Bar := _ in tt.
+
+Import Bar.
+
+Definition bar_test := let _ : Bar := _ in tt.

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -52,8 +52,6 @@ type instance_locality =
 | InstExport
 | InstLocal
 
-let _ = InstExport (* FIXME *)
-
 type instance_obj = {
   inst_class : GlobRef.t;
   inst_info: hint_info;
@@ -73,8 +71,8 @@ let add_instance_base inst =
     if Global.sections_are_opened () then Goptions.OptLocal
     else Goptions.OptGlobal
   | InstExport ->
-    (* For uniformity with hints, export instances are forbidden inside sections *)
-    if Global.sections_are_opened () then assert false
+    (* Same as above for export *)
+    if Global.sections_are_opened () then Goptions.OptLocal
     else Goptions.OptExport
   in
   add_instance_hint (Hints.hint_globref inst.inst_impl) [inst.inst_impl] ~locality
@@ -131,12 +129,19 @@ let instance_input : instance_obj -> obj =
       subst_function = subst_instance }
 
 let add_instance cl info glob impl =
-  let global =
-    if glob then InstGlobal
-    else InstLocal
+  let global = match glob with
+  | Goptions.OptDefault ->
+    if Global.sections_are_opened () then InstLocal else InstGlobal
+  | Goptions.OptGlobal ->
+    if Global.sections_are_opened () && isVarRef impl then
+      CErrors.user_err (Pp.str "Cannot set Global an instance referring to a section variable.")
+    else InstGlobal
+  | Goptions.OptLocal -> InstLocal
+  | Goptions.OptExport ->
+    if Global.sections_are_opened () && isVarRef impl then
+      CErrors.user_err (Pp.str "The export attribute cannot be applied to an instance referring to a section variable.")
+    else InstExport
   in
-  if glob && Global.sections_are_opened () && isVarRef impl then
-    CErrors.user_err (Pp.str "Cannot set Global an instance referring to a section variable.");
   let i = {
     inst_class = cl.cl_impl;
     inst_info = info ;
@@ -164,8 +169,7 @@ let declare_instance ?(warn = false) env sigma info local glob =
   let info = Option.default {hint_priority = None; hint_pattern = None} info in
   match class_of_constr env sigma (EConstr.of_constr ty) with
   | Some (rels, ((tc,_), args) as _cl) ->
-    assert (not (isVarRef glob) || local);
-    add_instance tc info (not local) glob
+    add_instance tc info local glob
   | None -> if warn then warning_not_a_class (glob, ty)
 
 (*
@@ -270,7 +274,7 @@ let add_class env sigma cl =
       | Some info ->
         (match m.meth_const with
          | None -> CErrors.user_err Pp.(str "Non-definable projection can not be declared as a subinstance")
-         | Some b -> declare_instance ~warn:true env sigma (Some info) false (GlobRef.ConstRef b))
+         | Some b -> declare_instance ~warn:true env sigma (Some info) Goptions.OptGlobal (GlobRef.ConstRef b))
       | _ -> ())
     cl.cl_projs
 
@@ -325,7 +329,7 @@ let instance_hook info global ?hook cst =
   let info = intern_info info in
   let env = Global.env () in
   let sigma = Evd.from_env env in
-  declare_instance env sigma (Some info) (not global) cst;
+  declare_instance env sigma (Some info) global cst;
   (match hook with Some h -> h cst | None -> ())
 
 let declare_instance_constant iinfo global impargs ?hook name udecl poly sigma term termtype =
@@ -336,7 +340,7 @@ let declare_instance_constant iinfo global impargs ?hook name udecl poly sigma t
   let kn = Declare.declare_definition ~cinfo ~info ~opaque:false ~body:term sigma in
   instance_hook iinfo global ?hook kn
 
-let do_declare_instance sigma ~global ~poly k u ctx ctx' pri udecl impargs subst name =
+let do_declare_instance sigma ~locality ~poly k u ctx ctx' pri udecl impargs subst name =
   let subst = List.fold_left2
       (fun subst' s decl -> if is_local_assum decl then s :: subst' else subst')
       [] subst k.cl_context
@@ -349,15 +353,15 @@ let do_declare_instance sigma ~global ~poly k u ctx ctx' pri udecl impargs subst
   DeclareUniv.declare_univ_binders (GlobRef.ConstRef cst) (Evd.universe_binders sigma);
   let cst = (GlobRef.ConstRef cst) in
   Impargs.maybe_declare_manual_implicits false cst impargs;
-  instance_hook pri global cst
+  instance_hook pri locality cst
 
-let declare_instance_program pm env sigma ~global ~poly name pri impargs udecl term termtype =
+let declare_instance_program pm env sigma ~locality ~poly name pri impargs udecl term termtype =
   let hook { Declare.Hook.S.scope; dref; _ } =
     let cst = match dref with GlobRef.ConstRef kn -> kn | _ -> assert false in
     let pri = intern_info pri in
     let env = Global.env () in
     let sigma = Evd.from_env env in
-    declare_instance env sigma (Some pri) (not global) (GlobRef.ConstRef cst)
+    declare_instance env sigma (Some pri) locality (GlobRef.ConstRef cst)
   in
   let obls, _, term, typ = RetrieveObl.retrieve_obligations env name sigma 0 term termtype in
   let hook = Declare.Hook.make hook in
@@ -370,7 +374,7 @@ let declare_instance_program pm env sigma ~global ~poly name pri impargs udecl t
     Declare.Obls.add_definition ~pm ~cinfo ~info ~term ~uctx obls
   in pm
 
-let declare_instance_open sigma ?hook ~tac ~global ~poly id pri impargs udecl ids term termtype =
+let declare_instance_open sigma ?hook ~tac ~locality ~poly id pri impargs udecl ids term termtype =
   (* spiwack: it is hard to reorder the actions to do
      the pretyping after the proof has opened. As a
      consequence, we use the low-level primitives to code
@@ -379,7 +383,7 @@ let declare_instance_open sigma ?hook ~tac ~global ~poly id pri impargs udecl id
   let gls = List.rev future_goals.Evd.FutureGoals.comb in
   let sigma = Evd.push_future_goals sigma in
   let kind = Decls.(IsDefinition Instance) in
-  let hook = Declare.Hook.(make (fun { S.dref ; _ } -> instance_hook pri global ?hook dref)) in
+  let hook = Declare.Hook.(make (fun { S.dref ; _ } -> instance_hook pri locality ?hook dref)) in
   let info = Declare.Info.make ~hook ~kind ~udecl ~poly () in
   (* XXX: We need to normalize the type, otherwise Admitted / Qed will fails!
      This is due to a bug in proof_global :( *)
@@ -481,7 +485,7 @@ let interp_props ~program_mode env' cty k u ctx ctx' subst sigma = function
     let term = it_mkLambda_or_LetIn def ctx in
     term, termtype, sigma
 
-let do_instance_interactive env env' sigma ?hook ~tac ~global ~poly cty k u ctx ctx' pri decl imps subst id opt_props =
+let do_instance_interactive env env' sigma ?hook ~tac ~locality ~poly cty k u ctx ctx' pri decl imps subst id opt_props =
   let term, termtype, sigma = match opt_props with
     | Some props ->
       on_pi1 (fun x -> Some x)
@@ -499,19 +503,19 @@ let do_instance_interactive env env' sigma ?hook ~tac ~global ~poly cty k u ctx 
       term, termtype, sigma
   in
   Flags.silently (fun () ->
-      declare_instance_open sigma ?hook ~tac ~global ~poly
+      declare_instance_open sigma ?hook ~tac ~locality ~poly
         id pri imps decl (List.map RelDecl.get_name ctx) term termtype)
     ()
 
-let do_instance env env' sigma ?hook ~global ~poly cty k u ctx ctx' pri decl imps subst id props =
+let do_instance env env' sigma ?hook ~locality ~poly cty k u ctx ctx' pri decl imps subst id props =
   let term, termtype, sigma =
     interp_props ~program_mode:false env' cty k u ctx ctx' subst sigma props
   in
   let termtype, sigma = do_instance_resolve_TC termtype sigma env in
   Pretyping.check_evars_are_solved ~program_mode:false env sigma;
-  declare_instance_constant pri global imps ?hook id decl poly sigma term termtype
+  declare_instance_constant pri locality imps ?hook id decl poly sigma term termtype
 
-let do_instance_program ~pm env env' sigma ?hook ~global ~poly cty k u ctx ctx' pri decl imps subst id opt_props =
+let do_instance_program ~pm env env' sigma ?hook ~locality ~poly cty k u ctx ctx' pri decl imps subst id opt_props =
   let term, termtype, sigma =
     match opt_props with
     | Some props ->
@@ -524,10 +528,10 @@ let do_instance_program ~pm env env' sigma ?hook ~global ~poly cty k u ctx ctx' 
       term, termtype, sigma in
   let termtype, sigma = do_instance_resolve_TC termtype sigma env in
   if not (Evd.has_undefined sigma) && not (Option.is_empty opt_props) then
-    let () = declare_instance_constant pri global imps ?hook id decl poly sigma term termtype in
+    let () = declare_instance_constant pri locality imps ?hook id decl poly sigma term termtype in
     pm
   else
-    declare_instance_program pm env sigma ~global ~poly id pri imps decl term termtype
+    declare_instance_program pm env sigma ~locality ~poly id pri imps decl term termtype
 
 let auto_generalize =
   Goptions.declare_bool_option_and_ref
@@ -580,44 +584,44 @@ let new_instance_common ~program_mode ?generalize env instid ctx cl =
   let env' = push_rel_context ctx env in
   id, env', sigma, k, u, cty, ctx', ctx, imps, subst, decl
 
-let new_instance_interactive ?(global=false)
+let new_instance_interactive ?(locality=Goptions.OptLocal)
     ~poly instid ctx cl
     ?generalize ?(tac:unit Proofview.tactic option) ?hook
     pri opt_props =
   let env = Global.env() in
   let id, env', sigma, k, u, cty, ctx', ctx, imps, subst, decl =
     new_instance_common ~program_mode:false ?generalize env instid ctx cl in
-  id, do_instance_interactive env env' sigma ?hook ~tac ~global ~poly
+  id, do_instance_interactive env env' sigma ?hook ~tac ~locality ~poly
     cty k u ctx ctx' pri decl imps subst id opt_props
 
-let new_instance_program ?(global=false) ~pm
+let new_instance_program ?(locality=Goptions.OptLocal) ~pm
     ~poly instid ctx cl opt_props
     ?generalize ?hook pri =
   let env = Global.env() in
   let id, env', sigma, k, u, cty, ctx', ctx, imps, subst, decl =
     new_instance_common ~program_mode:true ?generalize env instid ctx cl in
   let pm =
-    do_instance_program ~pm env env' sigma ?hook ~global ~poly
+    do_instance_program ~pm env env' sigma ?hook ~locality ~poly
       cty k u ctx ctx' pri decl imps subst id opt_props in
   pm, id
 
-let new_instance ?(global=false)
+let new_instance ?(locality=Goptions.OptLocal)
     ~poly instid ctx cl props
     ?generalize ?hook pri =
   let env = Global.env() in
   let id, env', sigma, k, u, cty, ctx', ctx, imps, subst, decl =
     new_instance_common ~program_mode:false ?generalize env instid ctx cl in
-  do_instance env env' sigma ?hook ~global ~poly
+  do_instance env env' sigma ?hook ~locality ~poly
     cty k u ctx ctx' pri decl imps subst id props;
   id
 
-let declare_new_instance ?(global=false) ~program_mode ~poly instid ctx cl pri =
+let declare_new_instance ?(locality=Goptions.OptLocal) ~program_mode ~poly instid ctx cl pri =
   let env = Global.env() in
   let ({CAst.loc;v=instid}, pl) = instid in
   let sigma, k, u, cty, ctx', ctx, imps, subst, decl =
     interp_instance_context ~program_mode ~generalize:false env ctx pl cl
   in
-  do_declare_instance sigma ~global ~poly k u ctx ctx' pri decl imps subst instid
+  do_declare_instance sigma ~locality ~poly k u ctx ctx' pri decl imps subst instid
 
 let refine_att =
   let open Attributes in
@@ -625,3 +629,10 @@ let refine_att =
   attribute_of_list ["refine",single_key_parser ~name:"refine" ~key:"refine" ()] >>= function
   | None -> return false
   | Some () -> return true
+
+module Internal =
+struct
+let add_instance cl info glob r =
+  let glob = if glob then Goptions.OptGlobal else Goptions.OptLocal in
+  add_instance cl info glob r
+end

--- a/vernac/classes.mli
+++ b/vernac/classes.mli
@@ -17,16 +17,16 @@ open Libnames
 (** Instance declaration *)
 
 val declare_instance : ?warn:bool -> env -> Evd.evar_map ->
-                       hint_info option -> bool -> GlobRef.t -> unit
+                       hint_info option -> Goptions.option_locality -> GlobRef.t -> unit
 (** Declares the given global reference as an instance of its type.
     Does nothing — or emit a “not-a-class” warning if the [warn] argument is set —
     when said type is not a registered type class. *)
 
-val existing_instance : bool -> qualid -> Vernacexpr.hint_info_expr option -> unit
+val existing_instance : Goptions.option_locality -> qualid -> Vernacexpr.hint_info_expr option -> unit
 (** globality, reference, optional priority and pattern information *)
 
 val new_instance_interactive
-  :  ?global:bool (** Not global by default. *)
+  :  ?locality:Goptions.option_locality (** Not global by default. *)
   -> poly:bool
   -> name_decl
   -> local_binder_expr list
@@ -39,7 +39,7 @@ val new_instance_interactive
   -> Id.t * Declare.Proof.t
 
 val new_instance
-  :  ?global:bool (** Not global by default. *)
+  :  ?locality:Goptions.option_locality (** Not global by default. *)
   -> poly:bool
   -> name_decl
   -> local_binder_expr list
@@ -51,7 +51,7 @@ val new_instance
   -> Id.t
 
 val new_instance_program
-  : ?global:bool (** Not global by default. *)
+  : ?locality:Goptions.option_locality (** Not global by default. *)
   -> pm:Declare.OblState.t
   -> poly:bool
   -> name_decl
@@ -64,7 +64,7 @@ val new_instance_program
   -> Declare.OblState.t * Id.t
 
 val declare_new_instance
-  : ?global:bool (** Not global by default. *)
+  : ?locality:Goptions.option_locality (** Not global by default. *)
   -> program_mode:bool
   -> poly:bool
   -> ident_decl
@@ -72,9 +72,6 @@ val declare_new_instance
   -> constr_expr
   -> Vernacexpr.hint_info_expr
   -> unit
-
-(** {6 Low level interface used by Add Morphism, do not use } *)
-val add_instance : typeclass -> hint_info -> bool -> GlobRef.t -> unit
 
 val add_class : env -> Evd.evar_map -> typeclass -> unit
 
@@ -87,3 +84,9 @@ val set_typeclass_transparency : Tacred.evaluable_global_reference -> bool -> bo
 val id_of_class : typeclass -> Id.t
 
 val refine_att : bool Attributes.attribute
+
+(** {6 Low level interface used by Add Morphism, do not use } *)
+module Internal :
+sig
+val add_instance : typeclass -> hint_info -> bool -> GlobRef.t -> unit
+end

--- a/vernac/classes.mli
+++ b/vernac/classes.mli
@@ -74,8 +74,7 @@ val declare_new_instance
   -> unit
 
 (** {6 Low level interface used by Add Morphism, do not use } *)
-val mk_instance : typeclass -> hint_info -> bool -> GlobRef.t -> instance
-val add_instance : instance -> unit
+val add_instance : typeclass -> hint_info -> bool -> GlobRef.t -> unit
 
 val add_class : env -> Evd.evar_map -> typeclass -> unit
 

--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -29,7 +29,7 @@ let declare_variable is_coe ~kind typ imps impl {CAst.v=name} =
   let () = maybe_declare_manual_implicits true r imps in
   let env = Global.env () in
   let sigma = Evd.from_env env in
-  let () = Classes.declare_instance env sigma None true r in
+  let () = Classes.declare_instance env sigma None Goptions.OptLocal r in
   let () = if is_coe then ComCoercion.try_add_new_coercion r ~local:true ~poly:false in
   ()
 
@@ -58,7 +58,7 @@ let declare_axiom is_coe ~poly ~local ~kind typ (univs, pl) imps nl {CAst.v=name
   let () = Declare.assumption_message name in
   let env = Global.env () in
   let sigma = Evd.from_env env in
-  let () = if do_instance then Classes.declare_instance env sigma None false gr in
+  let () = if do_instance then Classes.declare_instance env sigma None Goptions.OptGlobal gr in
   let local = match local with
     | Locality.ImportNeedQualified -> true
     | Locality.ImportDefaultBehavior -> false
@@ -244,8 +244,9 @@ let context_nosection sigma ~poly ctx =
     let () = Declare.assumption_message name in
     let env = Global.env () in
     (* why local when is_modtype? *)
+    let locality = if Lib.is_modtype () then Goptions.OptLocal else Goptions.OptGlobal in
     let () = if Lib.is_modtype() || Option.is_empty b then
-        Classes.declare_instance env sigma None (Lib.is_modtype()) (GlobRef.ConstRef cst)
+        Classes.declare_instance env sigma None locality (GlobRef.ConstRef cst)
     in
     Constr.mkConstU (cst,instance_of_univ_entry univs) :: subst
   in


### PR DESCRIPTION
This PR at last implements the export locality for typeclass instances, thus bridging the gap with mere hints.

~~We explictly forbid export to appear inside sections for uniformity with hints. Otherwise the semantics is open to interpretation, since export only specifies import-scoped behaviour. This can always be changed easily at a later time if desired.~~ I implemented it in this PR finally.

See #3056, #13833.

Overlays:
+ https://github.com/mattam82/Coq-Equations/pull/370
+ https://github.com/LPCIC/coq-elpi/pull/234
+ https://github.com/MetaCoq/metacoq/pull/554
+ https://github.com/Mtac2/Mtac2/pull/330
+ https://github.com/QuickChick/QuickChick/pull/221

- [X] Added / updated test-suite
- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
