### PR TITLE
Make `pose_all_metas_as_evars` also pose free metas inside defined metas

### DIFF
--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -191,7 +191,10 @@ let pose_all_metas_as_evars env evd t =
   let rec aux t = match EConstr.kind !evdref t with
   | Meta mv ->
       (match Evd.meta_opt_fvalue !evdref mv with
-       | Some ({rebus=c},_) -> c
+       | Some ({rebus=c;freemetas=mvs},_) ->
+         let c = if Evd.Metaset.is_empty mvs then c else aux c in
+         evdref := meta_reassign mv (c,(Conv,TypeNotProcessed)) !evdref;
+         c
        | None ->
         let {rebus=ty;freemetas=mvs} = Evd.meta_ftype evd mv in
         let ty = if Evd.Metaset.is_empty mvs then ty else aux ty in

--- a/test-suite/bugs/closed/bug_14150.v
+++ b/test-suite/bugs/closed/bug_14150.v
@@ -1,0 +1,9 @@
+Axiom a : forall A B : Prop, B -> A.
+Axiom t : unit -> Set.
+Axiom H: forall (m : unit) (p : t m), p = p.
+
+Goal True.
+eapply a.
+rewrite H.
+elim tt.
+Abort.


### PR DESCRIPTION
Testcase:
```
Axiom a : forall A B : Prop, B -> A.
Axiom t : unit -> Set.
Axiom H: forall (m : unit) (p : t m), p = p.

Goal True.
eapply a.
rewrite H.
elim tt.
Abort.
```

<!-- Keep what applies -->
**Kind:** bug fix

- [x] Added / updated test-suite
