### PR TITLE
[stdlib] [List] cleaner List.v

### DIFF
--- a/doc/changelog/10-standard-library/14153-cleaner-list.rst
+++ b/doc/changelog/10-standard-library/14153-cleaner-list.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  lemmas :g:`app_eq_app`, :g:`Forall_nil_iff`, :g:`Forall_cons_iff` to ``List.v``
+  (`#14153 <https://github.com/coq/coq/pull/14153>`_,
+  closes `#1803 <https://github.com/coq/coq/issues/1803>`_,
+  by Andrej Dudenhefner, with help from Olivier Laurent).


### PR DESCRIPTION
This PR cleans up some `List.v` proofs
- replace `plus_n_Sm`, `plus_n_O` by `Nat` alternatives
- replace partially applied `intuition` tactic by `tauto`
- remove non-monotone `try solve [...]`
- place `flat_map` into own section (no collision with `f` from `map`)
- remove `Proof with`
- add `app_eq_app` lemma suggested in https://github.com/coq/coq/issues/1803 (there called `app_inj_exists`) for simpler proofs
- add `Forall_nil_iff`, `Forall_cons_iff` lemmas similar to `Exist`
- compatibility with `Set Mangle Names.`
- the `List.v` code (with the new lemma) is ~50LOC shorter, it compiles 2% faster, and the resulting `.vo` file is 1% smaller
- this is a gradual, conservative improvement (of course, as is always, more can be done)

<!-- Keep what applies -->
**Kind:** cleanup / feature


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Closes #1803

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->

<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).