### PR TITLE
Fixes #14151: coqdoc error on ill-bracketed begin details/show

### DIFF
--- a/tools/coqdoc/cpretty.mll
+++ b/tools/coqdoc/cpretty.mll
@@ -1184,6 +1184,11 @@ and skip_to_dot_or_brace = parse
   | _ { skip_to_dot lexbuf }
 
 and body_bol = parse
+  | (space_nl+ as s) ('-'+ | '+'+ | '*'+) space*
+      { let nl_count = count_newlines s in
+        new_lines nl_count lexbuf;
+        String.iter Output.char (lexeme lexbuf);
+        if is_none !formatted then true else body_bol lexbuf }
   | space+
       { Output.indentation (fst (count_spaces (lexeme lexbuf))); body lexbuf }
   | "" { Output.indentation 0; body lexbuf }


### PR DESCRIPTION
**Kind:** bug fix

We report a regular located error rather than a "fatal error". We also recognize explicitly bullets as "sentences".

Fixes / closes #14151

- [ ] Entry added in the changelog
