### PR TITLE
Improve description of "coqc -Q"

### DIFF
--- a/doc/sphinx/addendum/ring.rst
+++ b/doc/sphinx/addendum/ring.rst
@@ -46,9 +46,12 @@ of associativity and commutativity.
 
 .. example::
 
-   In the ring of integers, the normal form of 
-     :math:`x (3 + yx + 25(1 − z)) + zx` 
-   is 
+   In the ring of integers, the normal form of
+
+     :math:`x (3 + yx + 25(1 − z)) + zx`
+
+   is
+
      :math:`28x + (−24)xz + xxy`.
 
 

--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -966,34 +966,37 @@ A logical prefix Lib can be associated with a physical path using
 the command line option ``-Q`` `path` ``Lib``. All subfolders of path are
 recursively associated with the logical path ``Lib`` extended with the
 corresponding suffix coming from the physical path. For instance, the
-folder ``path/fOO/Bar`` maps to ``Lib.fOO.Bar``. Subdirectories corresponding
+folder ``path/foo/Bar`` maps to ``Lib.foo.Bar``. Subdirectories corresponding
 to invalid Coq identifiers are skipped, and, by convention,
 subdirectories named ``CVS`` or ``_darcs`` are skipped too.
 
 Thanks to this mechanism, ``.vo`` files are made available through the
 logical name of the folder they are in, extended with their own
 basename. For example, the name associated with the file
-``path/fOO/Bar/File.vo`` is ``Lib.fOO.Bar.File``. The same caveat applies for
+``path/foo/Bar/File.vo`` is ``Lib.foo.Bar.File``. The same caveat applies for
 invalid identifiers. When compiling a source file, the ``.vo`` file stores
 its logical name, so that an error is issued if it is loaded with the
 wrong loadpath afterwards.
 
 Some folders have a special status and are automatically put in the
-path. Coq commands associate automatically a logical path to files in
-the repository trees rooted at the directory from where the command is
+path. Coq commands automatically associate a logical path to files in
+the repository tree rooted at the directory from where the command is
 launched, ``coqlib/user-contrib/``, the directories listed in the
 ``$COQPATH``, ``${XDG_DATA_HOME}/coq/`` and ``${XDG_DATA_DIRS}/coq/``
 environment variables (see `XDG base directory specification
 <http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html>`_)
 with the same physical-to-logical translation and with an empty logical prefix.
 
+.. todo: Needs a more better explanation of COQPATH and XDG* with example(s)
+   and suggest best practices for their use
+
 The command line option ``-R`` is a variant of ``-Q`` which has the strictly
 same behavior regarding loadpaths, but which also makes the
 corresponding ``.vo`` files available through their short names in a way
 similar to the :cmd:`Import` command. For instance, ``-R path Lib``
-associates to the file ``/path/fOO/Bar/File.vo`` the logical name
-``Lib.fOO.Bar.File``, but allows this file to be accessed through the
-short names ``fOO.Bar.File,Bar.File`` and ``File``. If several files with
+associates the file ``/path/foo/Bar/File.vo`` with the logical name
+``Lib.foo.Bar.File`` but allows this file to be accessed through the
+short names ``foo.Bar.File``, ``Bar.File`` and ``File``. If several files with
 identical base name are present in different subdirectories of a
 recursive loadpath, which of these files is found first may be system-
 dependent and explicit qualification is recommended. The ``From`` argument

--- a/doc/sphinx/practical-tools/coq-commands.rst
+++ b/doc/sphinx/practical-tools/coq-commands.rst
@@ -42,16 +42,54 @@ toplevel with the command ``Coqloop.loop();;``.
 Batch compilation (coqc)
 ------------------------
 
-The ``coqc`` command takes a name *file* as argument. Then it looks for a
-file named *file*.v, and tries to compile it into a
-*file*.vo file (See :ref:`compiled-files`).
+The ``coqc`` command compiles a Coq proof script file with a ".v" suffix
+to create a compiled file with a ".vo" suffix.  (See :ref:`compiled-files`.)
+The last component of the filename must be a valid Coq identifier as described in
+:ref:`lexical-conventions`; it should contain only letters, digits or
+underscores (_) with a ".v" suffix on the final component.
+For example ``/bar/foo/toto.v`` is valid, but ``/bar/foo/to-to.v`` is not.
 
-.. caution::
+We recommend specifying a logical directory name (which is also the module name)
+with the `-R` or the `-Q` options.
+Generally we recommend using utilities such as `make` (using `coq_makefile`
+to generate the `Makefile`) or `dune` to build Coq projects.
+See :ref:`building_coq_project`.
 
-   The name *file* should be a regular Coq identifier as defined in Section :ref:`lexical-conventions`.
-   It should contain only letters, digits or underscores (_). For example ``/bar/foo/toto.v`` is valid,
-   but ``/bar/foo/to-to.v`` is not.
+.. example:: Compiling and loading a single file
 
+   If `foo.v` is in Coq's current directory, you can use `coqc foo.v`
+   to compile it and then `Require foo.` in your script.  But this
+   doesn't scale well for larger projects.
+
+   Generally it's' better to define a new module:
+   To compile `foo.v` as part of a module `Mod1` that is rooted
+   at `.` (i.e. the directory containing `foo.v`), run `coqc -Q . Mod1 foo.v`.
+
+   To make the module available in `CoqIDE`, include the following line in the
+   `_CoqProject` file (see :ref:`coq_makefile`) in the directory from which you
+   start `CoqIDE`.  *<PATH>* is the pathname of the directory containing the module,
+   which can be an absolute path or relative to Coq's current directory.  For now,
+   you must close and reload a named script file for `CoqIDE` to pick up the change,
+   or restart `CoqIDE`.
+   The project file name is configurable in `Edit / Preferences / Project`.
+
+      .. coqdoc::
+         -R <PATH> Mod1
+
+   It's also possible to load a module within `coqtop` or `coqide` with
+   commands like these.  The drawback of this is that it adds
+   environment-specific information (the PATH) to your script, making
+   it non-portable, so we discourage using this approach.
+
+      .. coqdoc::
+         Add LoadPath "PATH" as Mod1.
+         Require Mod1.foo.
+
+   in which `PATH` is the pathname of the directory containing `foo.v`, which
+   can be absolute or relative to Coq's current directory.  The
+   :cmd:`Add LoadPath` is not needed if you provide the mapping from the
+   logical directory (module name) to the physical directory by including the
+   `-Q . Mod1` as command-line arguments to `coqtop` or `coqide`.
 
 Customization at launch time
 ---------------------------------

--- a/doc/sphinx/practical-tools/utilities.rst
+++ b/doc/sphinx/practical-tools/utilities.rst
@@ -34,8 +34,10 @@ For example, to statically link |Ltac|, you can just do:
 
 and similarly for other plugins.
 
+.. _building_coq_project:
+
 Building a Coq project
-------------------------
+----------------------
 
 As of today it is possible to build Coq projects using two tools:
 
@@ -50,7 +52,7 @@ Building a Coq project with coq_makefile
 The majority of Coq projects are very similar: a collection of ``.v``
 files and eventually some ``.ml`` ones (a Coq plugin). The main piece of
 metadata needed in order to build the project are the command line
-options to ``coqc`` (e.g. ``-R``, ``Q``, ``-I``, see :ref:`command
+options to ``coqc`` (e.g. ``-R``, ``-Q``, ``-I``, see :ref:`command
 line options <command-line-options>`). Collecting the list of files
 and options is the job of the ``_CoqProject`` file.
 


### PR DESCRIPTION
There was no description of how to compile a single file with `coqc` and load it into a Coq session--an elementary use case that beginners will run into frequently, as I did.

BTW, I notice that `.. coqdoc::` directives generate an extra space above the output.  This seems to be from the CSS but I haven't figured it out:

![image](https://user-images.githubusercontent.com/1253341/115971004-eb379600-a4fa-11eb-83c2-c49307b0b464.png)
