### PR TITLE
[kernel] API to get the number of module parameters

### DIFF
--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1102,6 +1102,18 @@ let add_module_parameter mbid mte inl senv =
     modvariant = new_variant;
     paramresolver = new_paramresolver }
 
+let rec module_num_parameters senv =
+  match senv.modvariant with
+  | STRUCT (params,senv) -> List.length params :: module_num_parameters senv
+  | SIG (params,senv) -> List.length params :: module_num_parameters senv
+  | _ -> []
+
+let rec module_is_modtype senv =
+  match senv.modvariant with
+  | STRUCT (_,senv) -> false :: module_is_modtype senv
+  | SIG (_,senv) -> true :: module_is_modtype senv
+  | _ -> []
+
 let functorize params init =
   List.fold_left (fun e (mbid,mt) -> MoreFunctor(mbid,mt,e)) init params
 

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -194,6 +194,15 @@ val add_module_parameter :
   MBId.t -> Entries.module_struct_entry -> Declarations.inline ->
     Mod_subst.delta_resolver safe_transformer
 
+(** returns the number of module (type) parameters following the nested module
+    structure. The inner module (type) comes first in the list. *)
+val module_num_parameters : safe_environment -> int list
+
+(** returns true if the module is a module type following the nested module
+    structure. The inner module (type) comes first in the list. true means
+    a module type, false a regular mofule *)
+val module_is_modtype : safe_environment -> bool list
+
 (** Traditional mode: check at end of module that no future was
     created. *)
 val allow_delayed_constants : bool ref

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -200,7 +200,7 @@ val module_num_parameters : safe_environment -> int list
 
 (** returns true if the module is a module type following the nested module
     structure. The inner module (type) comes first in the list. true means
-    a module type, false a regular mofule *)
+    a module type, false a regular module *)
 val module_is_modtype : safe_environment -> bool list
 
 (** Traditional mode: check at end of module that no future was

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -365,22 +365,23 @@ let end_compilation oname =
   !lib_state.path_prefix,after
 
 (* Returns true if we are inside an opened module or module type *)
+let is_module_or_modtype () =
+  match Safe_typing.module_is_modtype (Global.safe_env ()) with
+  | [] -> false
+  | _ -> true
 
-let is_module_gen which check =
-  let test = function
-    | _, OpenedModule (ty,_,_,_) -> which ty
-    | _ -> false
-  in
-  try
-    match find_entry_p test with
-    | _, OpenedModule (ty,_,_,_) -> check ty
-    | _ -> assert false
-  with Not_found -> false
+let is_modtype () =
+  let modules = Safe_typing.module_is_modtype (Global.safe_env ()) in
+  List.exists (fun x -> x) modules
 
-let is_module_or_modtype () = is_module_gen (fun _ -> true) (fun _ -> true)
-let is_modtype () = is_module_gen (fun b -> b) (fun _ -> true)
-let is_modtype_strict () = is_module_gen (fun _ -> true) (fun b -> b)
-let is_module () = is_module_gen (fun b -> not b) (fun _ -> true)
+let is_modtype_strict () =
+  match Safe_typing.module_is_modtype (Global.safe_env ()) with
+  | b :: _ -> b
+  | [] -> false
+
+let is_module () =
+  let modules = Safe_typing.module_is_modtype (Global.safe_env ()) in
+  List.exists (fun x -> not x) modules
 
 (* Returns the opening node of a given name *)
 let find_opening_node id =


### PR DESCRIPTION
We provide a few APIs to access the module structure being declared interactively.
This in turn can be used by clients of the libobject API to support modules but not functors, for example.