### PR TITLE
Add `inversion_sigma H`

### DIFF
--- a/doc/changelog/04-tactics/14174-inversion-sigma-on.rst
+++ b/doc/changelog/04-tactics/14174-inversion-sigma-on.rst
@@ -1,0 +1,8 @@
+- **Added:**
+  :tacn:`inversion_sigma` can now be applied to a specified hypothesis
+  and additionally supports intropatterns, so it can be used much like
+  :tacn:`induction` and :tacn:`inversion`.  Additionally,
+  :tacn:`inversion_sigma` now supports the types :n:`ex` (:n:`exists x
+  : A, P x`) and :n:`ex2` (:n:`exists2 x : A, P x & Q x`) in cases
+  where the first argument :n:`A` is a :n:`Prop` (`#14174
+  <https://github.com/coq/coq/pull/14174>`_, by Jason Gross).

--- a/doc/changelog/10-standard-library/14174-inversion-sigma-on.rst
+++ b/doc/changelog/10-standard-library/14174-inversion-sigma-on.rst
@@ -1,0 +1,12 @@
+- **Changed:**
+  The standard library now contains a more complete theory of equality
+  on types of the form :g:`exists x : A, P x` and :g:`exists2 x : A, P
+  x & Q x` when we have :g:`A : Prop`.  To bring this theory more in
+  line with the existing theory about sigma types,
+  :g:`eq_ex_uncurried`, :g:`eq_ex2_uncurried`, :g:`eq_ex`,
+  :g:`eq_ex2`, :g:`eq_ex_hprop`, :g:`eq_ex2_hprop` have been renamed
+  into :g:`eq_ex_intro_uncurried`, :g:`eq_ex_intro2_uncurried`,
+  :g:`eq_ex_intro`, :g:`eq_ex_intro2`, :g:`eq_ex_intro_hprop`,
+  :g:`eq_ex_intro2_hprop` respectively and the implicit status of
+  these lemmas has changed slightly (`#14174
+  <https://github.com/coq/coq/pull/14174>`_, by Jason Gross).

--- a/doc/sphinx/proofs/writing-proofs/inductive.rst
+++ b/doc/sphinx/proofs/writing-proofs/inductive.rst
@@ -856,7 +856,7 @@ and an explanation of the underlying technique.
    This tactic behaves as generalizing :n:`{+ @ident}`, then doing
    :n:`inversion @ident using @ident`.
 
-.. tacv:: inversion_sigma
+.. tacv:: inversion_sigma {? @ident {? as @simple_intropattern } }
    :name: inversion_sigma
 
    This tactic turns equalities of dependent pairs (e.g.,
@@ -865,11 +865,22 @@ and an explanation of the underlying technique.
    :g:`H : x = y` and a hypothesis of type :g:`rew H in p = q`); these
    hypotheses can subsequently be simplified using :tacn:`subst`, without ever
    invoking any kind of axiom asserting uniqueness of identity proofs. If you
-   want to explicitly specify the hypothesis to be inverted, or name the
-   generated hypotheses, you can invoke
-   :n:`induction H as [H1 H2] using eq_sigT_rect.` This tactic also works for
-   :g:`sig`, :g:`sigT2`, and :g:`sig2`, and there are similar :g:`eq_sig`
+   want to explicitly specify the hypothesis to be inverted, you can pass it as
+   an argument to :tacn:`inversion_sigma`. This tactic also works for
+   :g:`sig`, :g:`sigT2`, :g:`sig2`, :g:`ex`, and :g:`ex2` and there are similar :g:`eq_sig`
    :g:`***_rect` induction lemmas.
+
+
+   .. exn:: Type of @ident is not an equality of recognized Σ types: expected one of sig sig2 sigT sigT2 sigT2 ex or ex2 but got @term
+
+      When applied to a hypothesis, :tacn:`inversion_sigma` can only handle equalities of the
+      listed sigma types.
+
+   .. exn:: @ident is not an equality of Σ types
+
+      When applied to a hypothesis, :tacn:`inversion_sigma` can only be called on hypotheses that
+      are equalities using :g:`Coq.Logic.Init.eq`.
+
 
 .. example::
 

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1831,7 +1831,7 @@ ltac_defined_tactics: [
 | "discrR"
 | "easy"
 | "exfalso"
-| "inversion_sigma"
+| "inversion_sigma" OPT ( ident OPT ( "as" simple_intropattern ) )
 | "lia"
 | "lra"
 | "nia"

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1901,7 +1901,7 @@ simple_tactic: [
 | "dtauto"
 | "easy"
 | "exfalso"
-| "inversion_sigma"
+| "inversion_sigma" OPT ( ident OPT ( "as" simple_intropattern ) )
 | "lia"
 | "lra"
 | "nia"

--- a/test-suite/success/InversionSigma.v
+++ b/test-suite/success/InversionSigma.v
@@ -1,32 +1,173 @@
 Section inversion_sigma.
   Local Unset Implicit Arguments.
-  Context A (B : A -> Prop) (C C' : forall a, B a -> Prop)
+  Context A (B B' : A -> Prop) (C C' : forall a, B a -> Prop)
           (D : forall a b, C a b -> Prop) (E : forall a b c, D a b c -> Prop).
+  Context (AP : Prop) (BP BP' : AP -> Prop) (CP CP' : forall a, BP a -> Prop)
+          (DP : forall a b, CP a b -> Prop) (EP : forall a b c, DP a b c -> Prop).
 
   (* Require that, after destructing sigma types and inverting
      equalities, we can subst equalities of variables only, and reduce
      down to [eq_refl = eq_refl]. *)
-  Local Ltac test_inversion_sigma :=
-    intros;
+  Local Ltac destr_sigma :=
     repeat match goal with
+           | [ H : ex _ |- _ ] => destruct H
            | [ H : sig _ |- _ ] => destruct H
            | [ H : sigT _ |- _ ] => destruct H
+           | [ H : ex2 _ _ |- _ ] => destruct H
            | [ H : sig2 _ _ |- _ ] => destruct H
            | [ H : sigT2 _ _ |- _ ] => destruct H
-           end; simpl in *;
+           end; simpl in *.
+  Local Ltac fin_test_inversion_sigma :=
+    match goal with
+    | [ |- eq_refl = eq_refl ] => reflexivity
+    end.
+  Local Ltac test_inversion_sigma :=
+    intros;
+    destr_sigma;
     inversion_sigma;
     repeat match goal with
            | [ H : ?x = ?y |- _ ] => is_var x; is_var y; subst x; simpl in *
            end;
-    match goal with
-    | [ |- eq_refl = eq_refl ] => reflexivity
+    fin_test_inversion_sigma.
+
+  Local Ltac test_inversion_sigma_in_H :=
+    intros;
+    destr_sigma;
+    repeat match goal with H : _ = _ |- _ => inversion_sigma H end;
+    repeat match goal with
+           | [ H : ?x = ?y |- _ ] => is_var x; is_var y; subst x; simpl in *
+           end;
+    fin_test_inversion_sigma.
+
+  Goal forall (x y : { a : A & { b : { b : B a & C a b } & { d : D a (projT1 b) (projT2 b) & E _ _ _ d } } })
+              (p : x = y), p = p.
+  Proof.
+    intros x y p; destr_sigma.
+    inversion_sigma p as [-> p]; cbn [eq_rect] in *.
+    lazymatch type of p with
+    | existT _ (existT _ ?a ?b) (existT _ ?c ?d) = existT _ (existT _ ?e ?f) (existT _ ?g ?h)
+      => is_var a; is_var b; is_var c; is_var d; is_var e; is_var f; is_var g; is_var h
     end.
+    inversion_sigma p as [p1 p2].
+    lazymatch type of p1 with existT _ ?a ?b = existT _ ?c ?d => is_var a; is_var b; is_var c; is_var d end.
+    inversion_sigma p1 as [-> <-]; cbn [eq_rect eq_existT_uncurried eq_sigT eq_existT_curried eq_sigT_uncurried] in * |- .
+    lazymatch type of p2 with existT _ ?a ?b = existT _ ?c ?d => is_var a; is_var b; is_var c; is_var d end.
+    inversion_sigma p2 as [-> <-].
+    cbn.
+    fin_test_inversion_sigma.
+  Qed.
+
+  Goal forall (x y : { a : A | { b : { b : B a | C a b } | { d : D a (proj1_sig b) (proj2_sig b) | E _ _ _ d } } })
+              (p : x = y), p = p.
+  Proof.
+    intros x y p; destr_sigma.
+    inversion_sigma p as [-> p]; cbn [eq_rect] in *.
+    lazymatch type of p with
+    | exist _ (exist _ ?a ?b) (exist _ ?c ?d) = exist _ (exist _ ?e ?f) (exist _ ?g ?h)
+      => is_var a; is_var b; is_var c; is_var d; is_var e; is_var f; is_var g; is_var h
+    end.
+    inversion_sigma p as [p1 p2].
+    lazymatch type of p1 with exist _ ?a ?b = exist _ ?c ?d => is_var a; is_var b; is_var c; is_var d end.
+    inversion_sigma p1 as [-> <-]; cbn [eq_rect eq_exist_uncurried eq_sig eq_exist_curried eq_sig_uncurried] in * |- .
+    lazymatch type of p2 with exist _ ?a ?b = exist _ ?c ?d => is_var a; is_var b; is_var c; is_var d end.
+    inversion_sigma p2 as [-> <-].
+    cbn.
+    fin_test_inversion_sigma.
+  Qed.
+
+  Goal forall (x y : exists a : AP, exists b : exists b : BP a, CP a b, exists d : DP a (ex_proj1 b) (ex_proj2 b), EP _ _ _ d)
+              (p : x = y), p = p.
+  Proof.
+    intros x y p; destr_sigma.
+    inversion_sigma p as [-> p]; cbn [eq_rect] in *.
+    lazymatch type of p with
+    | ex_intro _ (ex_intro _ ?a ?b) (ex_intro _ ?c ?d) = ex_intro _ (ex_intro _ ?e ?f) (ex_intro _ ?g ?h)
+      => is_var a; is_var b; is_var c; is_var d; is_var e; is_var f; is_var g; is_var h
+    end.
+    inversion_sigma p as [p1 p2].
+    lazymatch type of p1 with ex_intro _ ?a ?b = ex_intro _ ?c ?d => is_var a; is_var b; is_var c; is_var d end.
+    inversion_sigma p1 as [-> <-]; cbn [eq_rect eq_ex_intro_uncurried eq_ex_intro eq_ex eq_ex_uncurried] in * |- .
+    lazymatch type of p2 with ex_intro _ ?a ?b = ex_intro _ ?c ?d => is_var a; is_var b; is_var c; is_var d end.
+    inversion_sigma p2 as [-> <-].
+    cbn.
+    fin_test_inversion_sigma.
+  Qed.
+
+  Goal forall (x y : { a : { a : A & B a } & C _ (projT2 a) & C' _ (projT2 a) })
+              (p : x = y), p = p.
+  Proof.
+    intros x y p; destr_sigma.
+    inversion_sigma p as [p <- <-]; cbn [eq_rect] in *.
+    lazymatch type of p with existT _ ?a ?b = existT _ ?c ?d => is_var a; is_var b; is_var c; is_var d end.
+    inversion_sigma p as [-> <-].
+    cbn.
+    fin_test_inversion_sigma.
+  Qed.
+
+  Goal forall (x y : { a : { a : A & B a } | C _ (projT2 a) & C' _ (projT2 a) })
+              (p : x = y), p = p.
+  Proof.
+    intros x y p; destr_sigma.
+    inversion_sigma p as [p <- <-]; cbn [eq_rect] in *.
+    lazymatch type of p with existT _ ?a ?b = existT _ ?c ?d => is_var a; is_var b; is_var c; is_var d end.
+    inversion_sigma p as [-> <-].
+    cbn.
+    fin_test_inversion_sigma.
+  Qed.
+
+  Goal forall (x y : exists2 a : exists a : AP, BP a, CP _ (ex_proj2 a) & CP' _ (ex_proj2 a))
+              (p : x = y), p = p.
+  Proof.
+    intros x y p; destr_sigma.
+    inversion_sigma p as [p <- <-]; cbn [eq_rect] in *.
+    lazymatch type of p with ex_intro _ ?a ?b = ex_intro _ ?c ?d => is_var a; is_var b; is_var c; is_var d end.
+    inversion_sigma p as [-> <-].
+    cbn.
+    fin_test_inversion_sigma.
+  Qed.
+
+  Goal forall (x y : { a : { a : A & B a & B' a } & C _ (projT2 (sigT_of_sigT2 a)) & C' _ (projT2 (sigT_of_sigT2 a)) })
+              (p : x = y), p = p.
+  Proof.
+    intros x y p; destr_sigma.
+    inversion_sigma p as [p <- <-]; cbn [eq_rect] in *.
+    lazymatch type of p with existT2 _ _ ?a ?b ?c = existT2 _ _ ?d ?e ?f => is_var a; is_var b; is_var c; is_var d; is_var e; is_var f end.
+    inversion_sigma p as [-> <- <-].
+    cbn.
+    fin_test_inversion_sigma.
+  Qed.
+
+  Goal forall (x y : { a : { a : A & B a & B' a } | C _ (projT2 (sigT_of_sigT2 a)) & C' _ (projT2 (sigT_of_sigT2 a)) })
+              (p : x = y), p = p.
+  Proof.
+    intros x y p; destr_sigma.
+    inversion_sigma p as [p <- <-]; cbn [eq_rect] in *.
+    lazymatch type of p with existT2 _ _ ?a ?b ?c = existT2 _ _ ?d ?e ?f => is_var a; is_var b; is_var c; is_var d; is_var e; is_var f end.
+    inversion_sigma p as [-> <- <-].
+    cbn.
+    fin_test_inversion_sigma.
+  Qed.
+
+  Goal forall (x y : exists2 a : exists2 a : AP, BP a & BP' a, CP _ (ex_proj2 (ex_of_ex2 a)) & CP' _ (ex_proj2 (ex_of_ex2 a)))
+              (p : x = y), p = p.
+  Proof.
+    intros x y p; destr_sigma.
+    inversion_sigma p as [p <- <-]; cbn [eq_rect] in *.
+    lazymatch type of p with ex_intro2 _ _ ?a ?b ?c = ex_intro2 _ _ ?d ?e ?f => is_var a; is_var b; is_var c; is_var d; is_var e; is_var f end.
+    inversion_sigma p as [-> <- <-].
+    cbn.
+    fin_test_inversion_sigma.
+  Qed.
 
   Goal forall (x y : { a : A & { b : { b : B a & C a b } & { d : D a (projT1 b) (projT2 b) & E _ _ _ d } } })
               (p : x = y), p = p.
   Proof. test_inversion_sigma. Qed.
 
   Goal forall (x y : { a : A | { b : { b : B a | C a b } | { d : D a (proj1_sig b) (proj2_sig b) | E _ _ _ d } } })
+              (p : x = y), p = p.
+  Proof. test_inversion_sigma. Qed.
+
+  Goal forall (x y : exists a : AP, exists b : exists b : BP a, CP a b, exists d : DP a (ex_proj1 b) (ex_proj2 b), EP _ _ _ d)
               (p : x = y), p = p.
   Proof. test_inversion_sigma. Qed.
 
@@ -37,4 +178,49 @@ Section inversion_sigma.
   Goal forall (x y : { a : { a : A & B a } | C _ (projT2 a) & C' _ (projT2 a) })
               (p : x = y), p = p.
   Proof. test_inversion_sigma. Qed.
+
+  Goal forall (x y : { a : { a : A & B a & B' a } | C _ (projT2 (sigT_of_sigT2 a)) & C' _ (projT2 (sigT_of_sigT2 a)) })
+              (p : x = y), p = p.
+  Proof. test_inversion_sigma. Qed.
+
+  Goal forall (x y : { a : { a : A & B a & B' a } | C _ (projT2 (sigT_of_sigT2 a)) & C' _ (projT2 (sigT_of_sigT2 a)) })
+              (p : x = y), p = p.
+  Proof. test_inversion_sigma. Qed.
+
+  Goal forall (x y : exists2 a : exists2 a : AP, BP a & BP' a, CP _ (ex_proj2 (ex_of_ex2 a)) & CP' _ (ex_proj2 (ex_of_ex2 a)))
+              (p : x = y), p = p.
+  Proof. test_inversion_sigma. Qed.
+
+
+  Goal forall (x y : { a : A & { b : { b : B a & C a b } & { d : D a (projT1 b) (projT2 b) & E _ _ _ d } } })
+              (p : x = y), p = p.
+  Proof. test_inversion_sigma_in_H. Qed.
+
+  Goal forall (x y : { a : A | { b : { b : B a | C a b } | { d : D a (proj1_sig b) (proj2_sig b) | E _ _ _ d } } })
+              (p : x = y), p = p.
+  Proof. test_inversion_sigma_in_H. Qed.
+
+  Goal forall (x y : exists a : AP, exists b : exists b : BP a, CP a b, exists d : DP a (ex_proj1 b) (ex_proj2 b), EP _ _ _ d)
+              (p : x = y), p = p.
+  Proof. test_inversion_sigma_in_H. Qed.
+
+  Goal forall (x y : { a : { a : A & B a } & C _ (projT2 a) & C' _ (projT2 a) })
+              (p : x = y), p = p.
+  Proof. test_inversion_sigma_in_H. Qed.
+
+  Goal forall (x y : { a : { a : A & B a } | C _ (projT2 a) & C' _ (projT2 a) })
+              (p : x = y), p = p.
+  Proof. test_inversion_sigma_in_H. Qed.
+
+  Goal forall (x y : { a : { a : A & B a & B' a } | C _ (projT2 (sigT_of_sigT2 a)) & C' _ (projT2 (sigT_of_sigT2 a)) })
+              (p : x = y), p = p.
+  Proof. test_inversion_sigma_in_H. Qed.
+
+  Goal forall (x y : { a : { a : A & B a & B' a } | C _ (projT2 (sigT_of_sigT2 a)) & C' _ (projT2 (sigT_of_sigT2 a)) })
+              (p : x = y), p = p.
+  Proof. test_inversion_sigma_in_H. Qed.
+
+  Goal forall (x y : exists2 a : exists2 a : AP, BP a & BP' a, CP _ (ex_proj2 (ex_of_ex2 a)) & CP' _ (ex_proj2 (ex_of_ex2 a)))
+              (p : x = y), p = p.
+  Proof. test_inversion_sigma_in_H. Qed.
 End inversion_sigma.

--- a/test-suite/success/bug_14174.v
+++ b/test-suite/success/bug_14174.v
@@ -1,0 +1,16 @@
+(** Check that we avoid an extraction error that came up in PR #14174 in metacoq *)
+Require Import Coq.extraction.ExtrOcamlBasic.
+Module A.
+  Include Coq.Init.Specif.
+End A.
+Recursive Extraction A.
+(* Avoding
+Error:
+The informative inductive type sig2 has a Prop instance
+in A.eq_sig2_rec_uncurried (or in its mutual block).
+This happens when a sort-polymorphic singleton inductive type
+has logical parameters, such as (I,I) : (True * True) : Prop.
+The Ocaml extraction cannot handle this situation yet.
+Instead, use a sort-monomorphic type such as (True /\ True)
+or extract to Haskell.
+*)

--- a/theories/Init/Logic.v
+++ b/theories/Init/Logic.v
@@ -299,6 +299,32 @@ End Projections.
 Inductive ex2 (A:Type) (P Q:A -> Prop) : Prop :=
   ex_intro2 : forall x:A, P x -> Q x -> ex2 (A:=A) P Q.
 
+(** [ex2] of a predicate can be projected to an [ex].
+
+    This allows [ex_proj1] and [ex_proj2] to be usable with [ex2].
+
+    We have two choices here: either we can set up the definition so
+    that [ex_proj1] of a coerced [X : ex2 P Q] will unify with [let
+    (a, _, _) := X in a] by restricting the first argument of [ex2] to
+    be a [Prop], or we can define a more general [ex_of_ex2] which
+    does not satisfy this conversion rule.  We choose the former,
+    under the assumption that there is no reason to turn an [ex2] into
+    an [ex] unless it is to project out the components. *)
+
+Definition ex_of_ex2 (A : Prop) (P Q : A -> Prop) (X : ex2 P Q) : ex P
+  := ex_intro P
+              (let (a, _, _) := X in a)
+              (let (x, p, _) as s return (P (let (a, _, _) := s in a)) := X in p).
+
+Section ex2_Projections.
+
+  Variables (A:Prop) (P Q:A->Prop).
+
+  Definition ex_proj3 (x:ex2 P Q) : Q (ex_proj1 (ex_of_ex2 x)) :=
+    match x with ex_intro2 _ _ _ _ b => b end.
+
+End ex2_Projections.
+
 Definition all (A:Type) (P:A -> Prop) := forall x:A, P x.
 
 (* Rule order is important to give printing priority to fully typed exists *)
@@ -841,89 +867,336 @@ Qed.
 Declare Left Step iff_stepl.
 Declare Right Step iff_trans.
 
+(** More properties of [ex] and [ex2] that rely on equality being present *)
+
+(** We define restricted versions of [ex_rect] and [ex_rec] which
+    allow elimination into non-Prop sorts when the inductive is not
+    informative *)
+
+(** η Principles *)
+Definition ex_eta {A : Prop} {P} (p : exists a : A, P a)
+  : p = ex_intro _ (ex_proj1 p) (ex_proj2 p).
+Proof. destruct p; reflexivity. Defined.
+
+Definition ex2_eta {A : Prop} {P Q} (p : exists2 a : A, P a & Q a)
+  : p = ex_intro2 _ _ (ex_proj1 (ex_of_ex2 p)) (ex_proj2 (ex_of_ex2 p)) (ex_proj3 p).
+Proof. destruct p; reflexivity. Defined.
+
+Section ex_Prop.
+  Variables (A:Prop) (P:A->Prop).
+
+  Definition ex_rect (P0 : ex P -> Type) (f : forall x p, P0 (ex_intro P x p))
+    : forall e, P0 e
+    := fun e => rew <- ex_eta e in f _ _.
+  Definition ex_rec : forall (P0 : ex P -> Set) (f : forall x p, P0 (ex_intro P x p)),
+      forall e, P0 e
+    := ex_rect.
+
+End ex_Prop.
+
 (** Equality for [ex] *)
 Section ex.
   Local Unset Implicit Arguments.
-  Definition eq_ex_uncurried {A : Type} (P : A -> Prop) {u1 v1 : A} {u2 : P u1} {v2 : P v1}
+  (** Projecting an equality of a pair to equality of the first components *)
+  Definition ex_proj1_eq {A : Prop} {P : A -> Prop} {u v : exists a : A, P a} (p : u = v)
+    : ex_proj1 u = ex_proj1 v
+    := f_equal (@ex_proj1 _ _) p.
+
+  (** Projecting an equality of a pair to equality of the second components *)
+  Definition ex_proj2_eq {A : Prop} {P : A -> Prop} {u v : exists a : A, P a} (p : u = v)
+    : rew ex_proj1_eq p in ex_proj2 u = ex_proj2 v
+    := rew dependent p in eq_refl.
+
+  (** Equality of [ex] is itself a [ex] (forwards-reasoning version) *)
+  Definition eq_ex_intro_uncurried {A : Type} {P : A -> Prop} {u1 v1 : A} {u2 : P u1} {v2 : P v1}
              (pq : exists p : u1 = v1, rew p in u2 = v2)
-  : ex_intro P u1 u2 = ex_intro P v1 v2.
+    : ex_intro _ u1 u2 = ex_intro _ v1 v2.
   Proof.
     destruct pq as [p q].
     destruct q; simpl in *.
     destruct p; reflexivity.
-  Qed.
+  Defined.
 
-  Definition eq_ex {A : Type} {P : A -> Prop} (u1 v1 : A) (u2 : P u1) (v2 : P v1)
+  (** Equality of [ex] is itself a [ex] (backwards-reasoning version) *)
+  Definition eq_ex_uncurried {A : Prop} {P : A -> Prop} (u v : exists a : A, P a)
+             (pq : exists p : ex_proj1 u = ex_proj1 v, rew p in ex_proj2 u = ex_proj2 v)
+    : u = v.
+  Proof.
+    destruct u as [u1 u2], v as [v1 v2]; simpl in *.
+    apply eq_ex_intro_uncurried; exact pq.
+  Defined.
+
+  (** Curried version of proving equality of [ex] types *)
+  Definition eq_ex_intro {A : Type} {P : A -> Prop} {u1 v1 : A} {u2 : P u1} {v2 : P v1}
              (p : u1 = v1) (q : rew p in u2 = v2)
-  : ex_intro P u1 u2 = ex_intro P v1 v2
-    := eq_ex_uncurried P (ex_intro _ p q).
+    : ex_intro _ u1 u2 = ex_intro _ v1 v2
+    := eq_ex_intro_uncurried (ex_intro _ p q).
 
-  Definition eq_ex_hprop {A} {P : A -> Prop} (P_hprop : forall (x : A) (p q : P x), p = q)
-             (u1 v1 : A) (u2 : P u1) (v2 : P v1)
+  (** Curried version of proving equality of [ex] types *)
+  Definition eq_ex {A : Prop} {P : A -> Prop} (u v : exists a : A, P a)
+             (p : ex_proj1 u = ex_proj1 v) (q : rew p in ex_proj2 u = ex_proj2 v)
+    : u = v
+    := eq_ex_uncurried u v (ex_intro _ p q).
+
+  (** In order to have a performant [inversion_sigma], we define
+      specialized versions for when we have constructors on one or
+      both sides of the equality *)
+  Definition eq_ex_intro_l {A : Prop} {P : A -> Prop} u1 u2 (v : exists a : A, P a)
+             (p : u1 = ex_proj1 v) (q : rew p in u2 = ex_proj2 v)
+    : ex_intro P u1 u2 = v
+    := eq_ex (ex_intro P u1 u2) v p q.
+  Definition eq_ex_intro_r {A : Prop} {P : A -> Prop} (u : exists a : A, P a) v1 v2
+             (p : ex_proj1 u = v1) (q : rew p in ex_proj2 u = v2)
+    : u = ex_intro P v1 v2
+    := eq_ex u (ex_intro P v1 v2) p q.
+
+  (** Induction principle for [@eq (ex _)] *)
+  Definition eq_ex_eta {A : Prop} {P : A -> Prop} {u v : exists a : A, P a} (p : u = v) : p = eq_ex u v (ex_proj1_eq p) (ex_proj2_eq p).
+  Proof. destruct p, u; reflexivity. Defined.
+  Definition eq_ex_rect {A : Prop} {P : A -> Prop} {u v : exists a : A, P a} (Q : u = v -> Type)
+             (f : forall p q, Q (eq_ex u v p q))
+    : forall p, Q p
+    := fun p => rew <- eq_ex_eta p in f _ _.
+  Definition eq_ex_rec {A : Prop} {P : A -> Prop} {u v} (Q : u = v :> (exists a : A, P a) -> Set) := eq_ex_rect Q.
+  Definition eq_ex_ind {A : Prop} {P : A -> Prop} {u v} (Q : u = v :> (exists a : A, P a) -> Prop) := eq_ex_rec Q.
+
+  (** In order to have a performant [inversion_sigma], we define
+      specialized versions for when we have constructors on one or
+      both sides of the equality *)
+  Definition eq_ex_rect_ex_intro_l {A : Prop} {P : A -> Prop} {u1 u2 v} (Q : _ -> Type)
+             (f : forall p q, Q (eq_ex_intro_l (P:=P) u1 u2 v p q))
+    : forall p, Q p
+    := eq_ex_rect Q f.
+  Definition eq_ex_rect_ex_intro_r {A : Prop} {P : A -> Prop} {u v1 v2} (Q : _ -> Type)
+             (f : forall p q, Q (eq_ex_intro_r (P:=P) u v1 v2 p q))
+    : forall p, Q p
+    := eq_ex_rect Q f.
+  Definition eq_ex_rect_ex_intro {A : Prop} {P : A -> Prop} {u1 u2 v1 v2} (Q : _ -> Type)
+             (f : forall p q, Q (@eq_ex_intro A P u1 v1 u2 v2 p q))
+    : forall p, Q p
+    := eq_ex_rect Q f.
+
+  Definition eq_ex_rect_uncurried {A : Prop} {P : A -> Prop} {u v : exists a : A, P a} (Q : u = v -> Type)
+             (f : forall pq, Q (eq_ex u v (ex_proj1 pq) (ex_proj2 pq)))
+    : forall p, Q p
+    := eq_ex_rect Q (fun p q => f (ex_intro _ p q)).
+  Definition eq_ex_rec_uncurried {A : Prop} {P : A -> Prop} {u v} (Q : u = v :> (exists a : A, P a) -> Set) := eq_ex_rect_uncurried Q.
+  Definition eq_ex_ind_uncurried {A : Prop} {P : A -> Prop} {u v} (Q : u = v :> (exists a : A, P a) -> Prop) := eq_ex_rec_uncurried Q.
+
+  (** Equality of [ex] when the property is an hProp *)
+  Definition eq_ex_hprop {A : Prop} {P : A -> Prop} (P_hprop : forall (x : A) (p q : P x), p = q)
+             (u v : exists a : A, P a)
+             (p : ex_proj1 u = ex_proj1 v)
+    : u = v
+    := eq_ex u v p (P_hprop _ _ _).
+
+  Definition eq_ex_intro_hprop {A : Type} {P : A -> Prop} (P_hprop : forall (x : A) (p q : P x), p = q)
+             {u1 v1 : A} {u2 : P u1} {v2 : P v1}
              (p : u1 = v1)
     : ex_intro P u1 u2 = ex_intro P v1 v2
-    := eq_ex u1 v1 u2 v2 p (P_hprop _ _ _).
+    := eq_ex_intro p (P_hprop _ _ _).
 
-  Lemma rew_ex {A x} {P : A -> Type} (Q : forall a, P a -> Prop) (u : exists p, Q x p) {y} (H : x = y)
-  : rew [fun a => exists p, Q a p] H in u
-    = match u with
-        | ex_intro _ u1 u2
-          => ex_intro
-               (Q y)
-               (rew H in u1)
-               (rew dependent H in u2)
-      end.
+  (** Equivalence of equality of [ex] with a [ex] of equality *)
+  (** We could actually prove an isomorphism here, and not just [<->],
+      but for simplicity, we don't. *)
+  Definition eq_ex_uncurried_iff {A : Prop} {P : A -> Prop} (u v : exists a : A, P a)
+    : u = v <-> exists p : ex_proj1 u = ex_proj1 v, rew p in ex_proj2 u = ex_proj2 v.
+  Proof.
+    split; [ intro; subst; exists eq_refl; reflexivity | apply eq_ex_uncurried ].
+  Defined.
+
+  (** Equivalence of equality of [ex] involving hProps with equality of the first components *)
+  Definition eq_ex_hprop_iff {A : Prop} {P : A -> Prop} (P_hprop : forall (x : A) (p q : P x), p = q)
+             (u v : exists a : A, P a)
+    : u = v <-> (ex_proj1 u = ex_proj1 v)
+    := conj (fun p => f_equal (@ex_proj1 _ _) p) (eq_ex_hprop P_hprop u v).
+
+  Lemma rew_ex {A' : Type} {x} {P : A' -> Prop} (Q : forall a, P a -> Prop) (u : exists p : P x, Q x p) {y} (H : x = y)
+    : rew [fun a => exists p : P a, Q a p] H in u
+      = ex_intro
+          (Q y)
+          (rew H in ex_proj1 u)
+          (rew dependent H in ex_proj2 u).
   Proof.
     destruct H, u; reflexivity.
-  Qed.
+  Defined.
 End ex.
+Global Arguments eq_ex_intro A P _ _ _ _ !p !q / .
+
+Section ex2_Prop.
+  Variables (A:Prop) (P Q:A->Prop).
+
+  Definition ex2_rect (P0 : ex2 P Q -> Type) (f : forall x p q, P0 (ex_intro2 P Q x p q))
+    : forall e, P0 e
+    := fun e => rew <- ex2_eta e in f _ _ _.
+  Definition ex2_rec : forall (P0 : ex2 P Q -> Set) (f : forall x p q, P0 (ex_intro2 P Q x p q)),
+      forall e, P0 e
+    := ex2_rect.
+
+End ex2_Prop.
 
 (** Equality for [ex2] *)
 Section ex2.
+  (* We make [ex_of_ex2] a coercion so we can use [proj1], [proj2] on [ex2] *)
+  Local Coercion ex_of_ex2 : ex2 >-> ex.
   Local Unset Implicit Arguments.
+  (** Projecting an equality of a pair to equality of the first components *)
+  Definition ex_of_ex2_eq {A : Prop} {P Q : A -> Prop} {u v : exists2 a : A, P a & Q a} (p : u = v)
+    : u = v :> exists a : A, P a
+    := f_equal _ p.
+  Definition ex_proj1_of_ex2_eq {A : Prop} {P Q : A -> Prop} {u v : exists2 a : A, P a & Q a} (p : u = v)
+    : ex_proj1 u = ex_proj1 v
+    := ex_proj1_eq (ex_of_ex2_eq p).
 
-  Definition eq_ex2_uncurried {A : Type} (P Q : A -> Prop) {u1 v1 : A}
-             {u2 : P u1} {v2 : P v1}
-             {u3 : Q u1} {v3 : Q v1}
-             (pq : exists2 p : u1 = v1, rew p in u2 = v2 & rew p in u3 = v3)
-  : ex_intro2 P Q u1 u2 u3 = ex_intro2 P Q v1 v2 v3.
+  (** Projecting an equality of a pair to equality of the second components *)
+  Definition ex_proj2_of_ex2_eq {A : Prop} {P Q : A -> Prop} {u v : exists2 a : A, P a & Q a} (p : u = v)
+    : rew ex_proj1_of_ex2_eq p in ex_proj2 u = ex_proj2 v
+    := rew dependent p in eq_refl.
+
+  (** Projecting an equality of a pair to equality of the third components *)
+  Definition ex_proj3_eq {A : Prop} {P Q : A -> Prop} {u v : exists2 a : A, P a & Q a} (p : u = v)
+    : rew ex_proj1_of_ex2_eq p in ex_proj3 u = ex_proj3 v
+    := rew dependent p in eq_refl.
+
+  (** Equality of [ex2] is itself a [ex2] (fowards-reasoning version) *)
+  Definition eq_ex_intro2_uncurried {A : Type} {P Q : A -> Prop} {u1 v1 : A} {u2 : P u1} {v2 : P v1} {u3 : Q u1} {v3 : Q v1}
+             (pqr : exists2 p : u1 = v1, rew p in u2 = v2 & rew p in u3 = v3)
+    : ex_intro2 _ _ u1 u2 u3 = ex_intro2 _ _ v1 v2 v3.
   Proof.
-    destruct pq as [p q r].
-    destruct r, q, p; simpl in *.
+    destruct pqr as [p q r].
+    destruct r, q, p; simpl.
     reflexivity.
-  Qed.
+  Defined.
 
-  Definition eq_ex2 {A : Type} {P Q : A -> Prop}
-             (u1 v1 : A)
-             (u2 : P u1) (v2 : P v1)
-             (u3 : Q u1) (v3 : Q v1)
-             (p : u1 = v1) (q : rew p in u2 = v2) (r : rew p in u3 = v3)
-  : ex_intro2 P Q u1 u2 u3 = ex_intro2 P Q v1 v2 v3
-    := eq_ex2_uncurried P Q (ex_intro2 _ _ p q r).
+  (** Equality of [ex2] is itself a [ex2] (backwards-reasoning version) *)
+  Definition eq_ex2_uncurried {A : Prop} {P Q : A -> Prop} (u v : exists2 a : A, P a & Q a)
+             (pqr : exists2 p : ex_proj1 u = ex_proj1 v,
+                                rew p in ex_proj2 u = ex_proj2 v & rew p in ex_proj3 u = ex_proj3 v)
+    : u = v.
+  Proof.
+    destruct u as [u1 u2 u3], v as [v1 v2 v3]; simpl in *.
+    apply eq_ex_intro2_uncurried; exact pqr.
+  Defined.
 
-  Definition eq_ex2_hprop {A} {P Q : A -> Prop}
-             (P_hprop : forall (x : A) (p q : P x), p = q)
-             (Q_hprop : forall (x : A) (p q : Q x), p = q)
-             (u1 v1 : A) (u2 : P u1) (v2 : P v1) (u3 : Q u1) (v3 : Q v1)
+  (** Curried version of proving equality of [ex] types *)
+  Definition eq_ex2 {A : Prop} {P Q : A -> Prop} (u v : exists2 a : A, P a & Q a)
+             (p : ex_proj1 u = ex_proj1 v)
+             (q : rew p in ex_proj2 u = ex_proj2 v)
+             (r : rew p in ex_proj3 u = ex_proj3 v)
+    : u = v
+    := eq_ex2_uncurried u v (ex_intro2 _ _ p q r).
+
+  Definition eq_ex_intro2 {A : Type} {P Q : A -> Prop} {u1 v1 : A} {u2 : P u1} {v2 : P v1} {u3 : Q u1} {v3 : Q v1}
+             (p : u1 = v1)
+             (q : rew p in u2 = v2)
+             (r : rew p in u3 = v3)
+    : ex_intro2 P Q u1 u2 u3 = ex_intro2 P Q v1 v2 v3
+    := eq_ex_intro2_uncurried (ex_intro2 _ _ p q r).
+
+  (** In order to have a performant [inversion_sigma], we define
+      specialized versions for when we have constructors on one or
+      both sides of the equality *)
+  Definition eq_ex_intro2_l {A : Prop} {P Q : A -> Prop} u1 u2 u3 (v : exists2 a : A, P a & Q a)
+             (p : u1 = ex_proj1 v) (q : rew p in u2 = ex_proj2 v) (r : rew p in u3 = ex_proj3 v)
+    : ex_intro2 P Q u1 u2 u3 = v
+    := eq_ex2 (ex_intro2 P Q u1 u2 u3) v p q r.
+  Definition eq_ex_intro2_r {A : Prop} {P Q : A -> Prop} (u : exists2 a : A, P a & Q a) v1 v2 v3
+             (p : ex_proj1 u = v1) (q : rew p in ex_proj2 u = v2) (r : rew p in ex_proj3 u = v3)
+    : u = ex_intro2 P Q v1 v2 v3
+    := eq_ex2 u (ex_intro2 P Q v1 v2 v3) p q r.
+
+  (** Equality of [ex2] when the second property is an hProp *)
+  Definition eq_ex2_hprop {A : Prop} {P Q : A -> Prop} (Q_hprop : forall (x : A) (p q : Q x), p = q)
+             (u v : exists2 a : A, P a & Q a)
+             (p : u = v :> exists a : A, P a)
+    : u = v
+    := eq_ex2 u v (ex_proj1_eq p) (ex_proj2_eq p) (Q_hprop _ _ _).
+
+  Definition eq_ex_intro2_hprop_nondep {A : Type} {P : A -> Prop} {Q : Prop} (Q_hprop : forall (p q : Q), p = q)
+             {u1 v1 : A} {u2 : P u1} {v2 : P v1} {u3 v3 : Q}
+             (p : ex_intro _ u1 u2 = ex_intro _ v1 v2)
+    : ex_intro2 _ _ u1 u2 u3 = ex_intro2 _ _ v1 v2 v3
+    := rew [fun v3 => _ = ex_intro2 _ _ _ _ v3] (Q_hprop u3 v3) in
+        f_equal (fun u => match u with ex_intro _ u1 u2 => ex_intro2 _ _ u1 u2 u3 end) p.
+
+  Definition eq_ex_intro2_hprop {A : Type} {P Q : A -> Prop}
+             (P_hprop : forall x (p q : P x), p = q)
+             (Q_hprop : forall x (p q : Q x), p = q)
+             {u1 v1 : A} {u2 : P u1} {v2 : P v1} {u3 : Q u1} {v3 : Q v1}
              (p : u1 = v1)
     : ex_intro2 P Q u1 u2 u3 = ex_intro2 P Q v1 v2 v3
-    := eq_ex2 u1 v1 u2 v2 u3 v3 p (P_hprop _ _ _) (Q_hprop _ _ _).
+    := eq_ex_intro2 p (P_hprop _ _ _) (Q_hprop _ _ _).
 
-  Lemma rew_ex2 {A x} {P : A -> Type}
-        (Q : forall a, P a -> Prop)
-        (R : forall a, P a -> Prop)
-        (u : exists2 p, Q x p & R x p) {y} (H : x = y)
-  : rew [fun a => exists2 p, Q a p & R a p] H in u
-    = match u with
-        | ex_intro2 _ _ u1 u2 u3
-          => ex_intro2
-               (Q y)
-               (R y)
-               (rew H in u1)
-               (rew dependent H in u2)
-               (rew dependent H in u3)
-      end.
+  (** Equivalence of equality of [ex2] with a [ex2] of equality *)
+  (** We could actually prove an isomorphism here, and not just [<->],
+      but for simplicity, we don't. *)
+  Definition eq_ex2_uncurried_iff {A : Prop} {P Q : A -> Prop} (u v : exists2 a : A, P a & Q a)
+    : u = v
+      <-> exists2 p : ex_proj1 u = ex_proj1 v,
+                      rew p in ex_proj2 u = ex_proj2 v & rew p in ex_proj3 u = ex_proj3 v.
+  Proof.
+    split; [ intro; subst; exists eq_refl; reflexivity | apply eq_ex2_uncurried ].
+  Defined.
+
+  (** Induction principle for [@eq (ex2 _ _)] *)
+  Definition eq_ex2_eta {A : Prop} {P Q : A -> Prop} {u v : exists2 a : A, P a & Q a} (p : u = v)
+    : p = eq_ex2 u v (ex_proj1_of_ex2_eq p) (ex_proj2_of_ex2_eq p) (ex_proj3_eq p).
+  Proof. destruct p, u; reflexivity. Defined.
+  Definition eq_ex2_rect {A : Prop} {P Q : A -> Prop} {u v : exists2 a : A, P a & Q a} (R : u = v -> Type)
+             (f : forall p q r, R (eq_ex2 u v p q r))
+    : forall p, R p
+    := fun p => rew <- eq_ex2_eta p in f _ _ _.
+  Definition eq_ex2_rec {A : Prop} {P Q : A -> Prop} {u v} (R : u = v :> (exists2 a : A, P a & Q a) -> Set) := eq_ex2_rect R.
+  Definition eq_ex2_ind {A : Prop} {P Q : A -> Prop} {u v} (R : u = v :> (exists2 a : A, P a & Q a) -> Prop) := eq_ex2_rec R.
+
+  (** In order to have a performant [inversion_sigma], we define
+      specialized versions for when we have constructors on one or
+      both sides of the equality *)
+  Definition eq_ex2_rect_ex_intro2_l {A : Prop} {P Q : A -> Prop} {u1 u2 u3 v} (R : _ -> Type)
+             (f : forall p q r, R (eq_ex_intro2_l (P:=P) (Q:=Q) u1 u2 u3 v p q r))
+    : forall p, R p
+    := eq_ex2_rect R f.
+  Definition eq_ex2_rect_ex_intro2_r {A : Prop} {P Q : A -> Prop} {u v1 v2 v3} (R : _ -> Type)
+             (f : forall p q r, R (eq_ex_intro2_r (P:=P) (Q:=Q) u v1 v2 v3 p q r))
+    : forall p, R p
+    := eq_ex2_rect R f.
+  Definition eq_ex2_rect_ex_intro2 {A : Prop} {P Q : A -> Prop} {u1 u2 u3 v1 v2 v3} (R : _ -> Type)
+             (f : forall p q r, R (@eq_ex_intro2 A P Q u1 v1 u2 v2 u3 v3 p q r))
+    : forall p, R p
+    := eq_ex2_rect R f.
+
+  Definition eq_ex2_rect_uncurried {A : Prop} {P Q : A -> Prop} {u v : exists2 a : A, P a & Q a} (R : u = v -> Type)
+             (f : forall pqr : exists2 p : _ = _, _ & _, R (eq_ex2 u v (ex_proj1 pqr) (ex_proj2 pqr) (ex_proj3 pqr)))
+    : forall p, R p
+    := eq_ex2_rect R (fun p q r => f (ex_intro2 _ _ p q r)).
+  Definition eq_ex2_rec_uncurried {A : Prop} {P Q : A -> Prop} {u v} (R : u = v :> (exists2 a : A, P a & Q a) -> Set) := eq_ex2_rect_uncurried R.
+  Definition eq_ex2_ind_uncurried {A : Prop} {P Q : A -> Prop} {u v} (R : u = v :> (exists2 a : A, P a & Q a) -> Prop) := eq_ex2_rec_uncurried R.
+
+  (** Equivalence of equality of [ex2] involving hProps with equality of the first components *)
+  Definition eq_ex2_hprop_iff {A : Prop} {P Q : A -> Prop} (Q_hprop : forall (x : A) (p q : Q x), p = q)
+             (u v : exists2 a : A, P a & Q a)
+    : u = v <-> (u = v :> exists a : A, P a)
+    := conj (fun p => f_equal (@ex_of_ex2 _ _ _) p) (eq_ex2_hprop Q_hprop u v).
+
+  (** Non-dependent classification of equality of [ex] *)
+  Definition eq_ex2_nondep {A : Prop} {B C : Prop} (u v : @ex2 A (fun _ => B) (fun _ => C))
+             (p : ex_proj1 u = ex_proj1 v) (q : ex_proj2 u = ex_proj2 v) (r : ex_proj3 u = ex_proj3 v)
+    : u = v
+    := @eq_ex2 _ _ _ u v p (eq_trans (rew_const _ _) q) (eq_trans (rew_const _ _) r).
+
+  (** Classification of transporting across an equality of [ex2]s *)
+  Lemma rew_ex2 {A' : Type} {x} {P : A' -> Prop} (Q R : forall a, P a -> Prop)
+        (u : exists2 p : P x, Q x p & R x p)
+        {y} (H : x = y)
+    : rew [fun a => exists2 p : P a, Q a p & R a p] H in u
+      = ex_intro2
+          (Q y)
+          (R y)
+          (rew H in ex_proj1 u)
+          (rew dependent H in ex_proj2 u)
+          (rew dependent H in ex_proj3 u).
   Proof.
     destruct H, u; reflexivity.
-  Qed.
+  Defined.
 End ex2.
+Global Arguments eq_ex_intro2 A P Q _ _ _ _ _ _ !p !q !r / .


### PR DESCRIPTION
Now `inversion_sigma` can be invoked on specific hypotheses, just like
`inversion` and `induction`.

**Kind:** feature

- [x] Added / updated test-suite
- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
- [ ] Overlay pull requests (if this breaks 3rd party developments in CI, see
https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md for details)
