### PR TITLE
Factorize the functor parameters to enhance sharing.

### DIFF
--- a/checker/check.ml
+++ b/checker/check.ml
@@ -340,7 +340,7 @@ let intern_from_file ~intern_mode (dir, f) =
       let (sd:summary_disk) = marshal_in_segment ~validate ~value:Values.v_libsum ~segment:seg_sd f ch in
       let (md:library_disk) = marshal_in_segment ~validate ~value:Values.v_lib ~segment:seg_md f ch in
       let (opaque_csts:seg_univ option) = marshal_in_segment ~validate ~value:Values.v_univopaques ~segment:seg_univs f ch in
-      let (tasks:'a option) = marshal_in_segment ~validate ~value:Values.(Opt Any) ~segment:seg_tasks f ch in
+      let (tasks:'a option) = marshal_in_segment ~validate ~value:Values.(make (Opt (make Any))) ~segment:seg_tasks f ch in
       let (table:seg_proofs option) =
         marshal_or_skip ~validate ~value:Values.v_opaquetable ~segment:seg_opaque f ch in
       (* Verification of the final checksum *)

--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -94,7 +94,7 @@ let lookup_module mp env =
 
 let mk_mtb mp sign delta =
   { mod_mp = mp;
-    mod_expr = ();
+    mod_expr = ModType;
     mod_type = sign;
     mod_type_alg = None;
     mod_delta = delta;

--- a/checker/validate.ml
+++ b/checker/validate.ml
@@ -130,11 +130,11 @@ let val_dyn mem ctx o =
 
 open Values
 
-let rec val_gen v mem ctx o = match v with
+let rec val_gen v mem ctx o = match kind v with
   | Tuple (name,vs) -> val_tuple ~name vs mem ctx o
   | Sum (name,cc,vv) -> val_sum name cc vv mem ctx o
   | Array v -> val_array v mem ctx o
-  | List v0 -> val_sum "list" 1 [|[|Annot ("elem",v0);v|]|] mem ctx o
+  | List v0 -> val_sum "list" 1 [|[|v0;v|]|] mem ctx o
   | Opt v -> val_sum "option" 1 [|[|v|]|] mem ctx o
   | Int -> if not (is_int mem o) then fail mem ctx o "expected an int"
   | String ->

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -37,6 +37,30 @@ type value =
   | Int64
   | Float64
 
+type kind = value =
+  | Any
+  | Fail of string
+  | Tuple of string * value array
+  | Sum of string * int * value array array
+  | Array of value
+  | List of value
+  | Opt of value
+  | Int
+  | String
+  | Annot of string * value
+  | Dyn
+
+  | Proxy of value ref
+  | Int64
+  | Float64
+
+
+let rec kind (v : value) = match v with
+| Proxy r -> kind !r
+| _ -> v
+
+let make v = v
+
 let fix (f : value -> value) : value =
   let self = ref Any in
   let ans = f (Proxy self) in

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -365,7 +365,7 @@ and v_impl =
   Sum ("module_impl",2, (* Abstract, FullStruct *)
   [|[|v_mexpr|];  (* Algebraic *)
     [|v_sign|]|])  (* Struct *)
-and v_noimpl = v_unit
+and v_noimpl = Sum ("module_type", 3, [||]) (* ModType, allows in practice Abstract / FullStruct but should not matter *)
 and v_module =
   Tuple ("module_body",
          [|v_mp;v_impl;v_sign;Opt v_mexpr;v_resolver;v_retroknowledge|])

--- a/checker/values.mli
+++ b/checker/values.mli
@@ -8,7 +8,9 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-type value =
+type value
+
+type kind =
   | Any
   (** A value that we won't check, *)
 
@@ -40,6 +42,9 @@ type value =
 
   | Int64
   | Float64
+
+val kind : value -> kind
+val make : kind -> value
 
 (** NB: List and Opt have their own constructors to make it easy to
    define eg [let rec foo = List foo]. *)

--- a/interp/modintern.ml
+++ b/interp/modintern.ml
@@ -66,8 +66,8 @@ let lookup_module lqid = fst (lookup_module_or_modtype Module lqid)
 
 let lookup_polymorphism env base kind fqid =
   let m = match kind with
-    | Module -> (Environ.lookup_module base env).mod_type
-    | ModType -> (Environ.lookup_modtype base env).mod_type
+    | Module -> Declareops.expand_mod_type (Environ.lookup_module base env).mod_data
+    | ModType -> Declareops.expand_mod_type (Environ.lookup_modtype base env).mod_data
     | ModAny -> assert false
   in
   let rec defunctor = function
@@ -94,9 +94,9 @@ let lookup_polymorphism env base kind fqid =
       let test (lab,obj) =
         match Id.equal (Label.to_id lab) id, obj with
         | false, _ | _, (SFBconst _ | SFBmind _) -> None
-        | true, SFBmodule body -> Some (next body.mod_type)
+        | true, SFBmodule body -> Some (next (Declareops.expand_mod_type body.mod_data))
         | true, SFBmodtype body ->  (* XXX is this valid? If not error later *)
-          Some (next body.mod_type)
+          Some (next (Declareops.expand_mod_type body.mod_data))
       in
       (try CList.find_map test m with Not_found -> false (* error later *))
   in

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -401,7 +401,7 @@ and hcons_module_signature ms =
 and hcons_module_expression me =
   hcons_functorize hcons_module_type hcons_module_alg_expr hcons_module_expression me
 
-and hcons_module_implementation mip = match mip with
+and hcons_module_implementation (type a) (mip : a module_implementation) : a module_implementation = match mip with
 | Abstract -> Abstract
 | Algebraic me ->
   let me' = hcons_module_expression me in
@@ -410,12 +410,13 @@ and hcons_module_implementation mip = match mip with
   let ms' = hcons_module_signature ms in
   if ms == ms' then mip else Struct ms
 | FullStruct -> FullStruct
+| ModType -> ModType
 
 and hcons_generic_module_body :
-  'a. ('a -> 'a) -> 'a generic_module_body -> 'a generic_module_body =
-  fun hcons_impl mb ->
+  'a. 'a generic_module_body -> 'a generic_module_body =
+  fun mb ->
   let mp' = mb.mod_mp in
-  let expr' = hcons_impl mb.mod_expr in
+  let expr' = hcons_module_implementation mb.mod_expr in
   let type' = hcons_module_signature mb.mod_type in
   let type_alg' = mb.mod_type_alg in
   let delta' = mb.mod_delta in
@@ -439,7 +440,7 @@ and hcons_generic_module_body :
   }
 
 and hcons_module_body mb =
-  hcons_generic_module_body hcons_module_implementation mb
+  hcons_generic_module_body mb
 
 and hcons_module_type mb =
-  hcons_generic_module_body (fun () -> ()) mb
+  hcons_generic_module_body mb

--- a/kernel/declareops.mli
+++ b/kernel/declareops.mli
@@ -75,6 +75,13 @@ val inductive_make_projections : Names.inductive -> mutual_inductive_body ->
 
 val relevance_of_projection_repr : mutual_inductive_body -> Names.Projection.Repr.t -> Sorts.relevance
 
+(** {6 Module accessors} *)
+
+val map_functorize : ('a -> 'b) -> ('r, 'a) functorize -> ('r, 'b) functorize
+
+val expand_mod_type : 'a module_data -> module_signature
+val expand_mod_impl : 'a module_data -> (module_signature, module_expression, 'a) module_implementation
+
 (** {6 Kernel flags} *)
 
 (** A default, safe set of flags for kernel type-checking *)

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -143,7 +143,7 @@ let rec check_with_def env struc (idl,(c,ctx)) mp equiv =
                       mod_type_alg = None }
           in
           before@(lab,SFBmodule mb')::after, c', cst
-        | _ -> error_generative_module_expected lab
+        | (Algebraic _ | Struct _ | FullStruct) -> error_generative_module_expected lab
       end
   with
   | Not_found -> error_no_such_label lab
@@ -280,7 +280,7 @@ let mk_mod mp e ty reso =
 
 let mk_modtype mp ty reso =
   let mb = mk_mod mp Abstract ty reso in
-  { mb with mod_expr = (); mod_retroknowledge = ModTypeRK }
+  { mb with mod_expr = ModType; mod_retroknowledge = ModTypeRK }
 
 let rec translate_mse_funct env mpo inl mse = function
   |[] ->

--- a/kernel/mod_typing.mli
+++ b/kernel/mod_typing.mli
@@ -49,7 +49,7 @@ val translate_mse :
     an (optional) signature entry, produces a final [module_body] *)
 
 val finalize_module :
-  env -> ModPath.t -> (module_expression option) translation ->
+  env -> ModPath.t -> module_signature -> delta_resolver ->
   (module_type_entry * inline) option ->
   module_body * Univ.Constraint.t
 

--- a/kernel/modops.mli
+++ b/kernel/modops.mli
@@ -32,11 +32,6 @@ val module_body_of_type : ModPath.t -> module_type_body -> module_body
 
 val check_modpath_equiv : env -> ModPath.t -> ModPath.t -> unit
 
-val implem_smartmap :
-  (module_signature -> module_signature) ->
-  (module_expression -> module_expression) ->
-  ([`modimpl] module_implementation -> [`modimpl] module_implementation)
-
 (** {6 Substitutions } *)
 
 val subst_signature : substitution -> module_signature -> module_signature

--- a/kernel/modops.mli
+++ b/kernel/modops.mli
@@ -35,7 +35,7 @@ val check_modpath_equiv : env -> ModPath.t -> ModPath.t -> unit
 val implem_smartmap :
   (module_signature -> module_signature) ->
   (module_expression -> module_expression) ->
-  (module_implementation -> module_implementation)
+  ([`modimpl] module_implementation -> [`modimpl] module_implementation)
 
 (** {6 Substitutions } *)
 
@@ -57,7 +57,7 @@ val add_linked_module : module_body -> link_info -> env -> env
 (** same, for a module type *)
 val add_module_type : ModPath.t -> module_type_body -> env -> env
 
-val add_retroknowledge : module_implementation module_retroknowledge -> env -> env
+val add_retroknowledge : [`modimpl] module_retroknowledge -> env -> env
 
 (** {6 Strengthening } *)
 

--- a/kernel/nativelibrary.ml
+++ b/kernel/nativelibrary.ml
@@ -45,7 +45,7 @@ and translate_field mp env acc (l,x) =
           Printf.sprintf "Compiling module %s..." (ModPath.to_string mp)
         in
         Pp.str msg));
-     translate_mod mp env md.mod_type acc
+     translate_mod mp env (Declareops.expand_mod_type md.mod_data) acc
   | SFBmodtype mdtyp ->
      let mp = mdtyp.mod_mp in
      (debug_native_compiler (fun () ->
@@ -53,7 +53,7 @@ and translate_field mp env acc (l,x) =
           Printf.sprintf "Compiling module type %s..." (ModPath.to_string mp)
         in
         Pp.str msg));
-     translate_mod mp env mdtyp.mod_type acc
+     translate_mod mp env (Declareops.expand_mod_type mdtyp.mod_data) acc
 
 let dump_library mp env mod_expr =
   debug_native_compiler (fun () -> Pp.str "Compiling library...");

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1166,7 +1166,7 @@ let end_module l restype senv =
 
 let build_mtb mp sign delta =
   { mod_mp = mp;
-    mod_expr = ();
+    mod_expr = ModType;
     mod_type = sign;
     mod_type_alg = None;
     mod_delta = delta;

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -95,10 +95,10 @@ and fields_of_mp mp =
   in
   Modops.subst_structure subs fields
 
-and fields_of_mb subs mb args = match mb.mod_expr with
+and fields_of_mb subs mb args = match Declareops.expand_mod_impl mb.mod_data with
   |Algebraic expr -> fields_of_expression subs mb.mod_mp args expr
   |Struct sign -> fields_of_signature subs mb.mod_mp args sign
-  |Abstract|FullStruct -> fields_of_signature subs mb.mod_mp args mb.mod_type
+  |Abstract|FullStruct -> fields_of_signature subs mb.mod_mp args (Declareops.expand_mod_type mb.mod_data)
 
 (** The Abstract case above corresponds to [Declare Module] *)
 

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -494,7 +494,7 @@ let rec compute_subst env mbids sign mp_l inl =
         let mb = Environ.lookup_module mp env in
         let mbid_left,subst = compute_subst env mbids fbody_b mp_l inl in
         let resolver =
-          if Modops.is_functor mb.mod_type then empty_delta_resolver
+          if Modops.is_functor (Declareops.expand_mod_type mb.mod_data) then empty_delta_resolver
           else
             Modops.inline_delta_resolver env inl mp farg_id farg_b mb.mod_delta
         in
@@ -521,8 +521,8 @@ let rec replace_module_object idl mp0 objs0 mp1 objs1 =
   | idl,lobj::tail -> lobj::replace_module_object idl mp0 tail mp1 objs1
 
 let type_of_mod mp env = function
-  |true -> (Environ.lookup_module mp env).mod_type
-  |false -> (Environ.lookup_modtype mp env).mod_type
+  |true -> Declareops.expand_mod_type (Environ.lookup_module mp env).mod_data
+  |false -> Declareops.expand_mod_type (Environ.lookup_modtype mp env).mod_data
 
 let rec get_module_path = function
   |MEident mp -> mp
@@ -672,9 +672,9 @@ let build_subtypes env mp args mtys =
        let env = Environ.push_context_set ~strict:true ctx' env in
        let ctx = Univ.ContextSet.union ctx ctx' in
        let mtb, cst = Mod_typing.translate_modtype env mp inl ([],mte) in
-       let mod_type, cst = mk_funct_type env args (mtb.mod_type,cst) in
+       let mod_data, cst = mk_funct_type env args (mtb.mod_data,cst) in
        let ctx = Univ.ContextSet.add_constraints cst ctx in
-       ctx, { mtb with mod_type })
+       ctx, { mtb with mod_data })
     Univ.ContextSet.empty mtys
   in
   (ans, ctx)

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1019,8 +1019,8 @@ let explain_incompatible_module_types mexpr1 mexpr2 =
   | NoFunctor _ -> 0
   | MoreFunctor (_, _, ty) -> succ (get_arg ty)
   in
-  let len1 = get_arg mexpr1.mod_type in
-  let len2 = get_arg mexpr2.mod_type in
+  let len1 = get_arg (Declareops.expand_mod_type mexpr1.mod_data) in
+  let len2 = get_arg (Declareops.expand_mod_type mexpr2.mod_data) in
   if len1 <> len2 then
     str "Incompatible module types: module expects " ++ int len2 ++
       str " arguments, found " ++ int len1 ++ str "."

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1075,7 +1075,7 @@ let vernac_import export refl =
     let loc = qid.loc in
     let m = try
         let m = Nametab.locate_module qid in
-        let () = if Modops.is_functor (Global.lookup_module m).Declarations.mod_type
+        let () = if Modops.is_functor (Declareops.expand_mod_type (Global.lookup_module m).Declarations.mod_data)
           then CErrors.user_err ?loc Pp.(str "Cannot import functor " ++ pr_qualid qid ++ str".")
         in
         m


### PR DESCRIPTION
This statically enforces in particular that the parameters of the module expression are a prefix of the fully expanded signature.
