### PR TITLE
[build] Remove `-local` build layout, use always install-like layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,5 +139,8 @@ ide/coqide/index_urls.txt
 ide/coqide/coqide.keys
 .dune.lock
 
+# bin compat directory, should be eventually be phased out
+bin
+
 # To remove when Dune 2.8 is the minimum version
 .merlin

--- a/Makefile.common
+++ b/Makefile.common
@@ -27,14 +27,21 @@ HIDE := $(if $(VERBOSE),,@)
 #
 # Note, we can use this as _build/default , but unfortunately dune
 # will remove the .vos files as they are not recognized as targets
-VO_OUT_DIR=_build_vo/default/
+BUILD_OUT_DIR=_build_vo/default/
+VO_OUT_DIR=$(BUILD_OUT_DIR)/lib/coq/
 
-$(VO_OUT_DIR):
-	$(SHOW)'MKDIR     BUILD_VO'
-	$(HIDE)mkdir -p $@
-	$(HIDE)ln -s $(shell pwd)/_build/default/plugins/ $@
-	$(HIDE)ln -s $(shell pwd)/_build/default/tools/ $@
-	$(HIDE)ln -s $(shell pwd)/_build/default/kernel/ $@
+LEGACY_BIN_DIR=bin
+
+$(BUILD_OUT_DIR) $(VO_OUT_DIR):
+	$(SHOW)'MKDIR     BUILD_OUT'
+	$(HIDE)mkdir -p $(BUILD_OUT_DIR)
+	$(HIDE)mkdir -p $(BUILD_OUT_DIR)/lib/coq
+	$(HIDE)mkdir -p $(BUILD_OUT_DIR)/lib/coq-core
+	$(HIDE)ln -s $(shell pwd)/_build/install/default/bin/ $(LEGACY_BIN_DIR)
+	$(HIDE)ln -s $(shell pwd)/_build/install/default/bin/ $(BUILD_OUT_DIR)/bin
+	$(HIDE)ln -s $(shell pwd)/_build/default/plugins/ $(BUILD_OUT_DIR)/lib/coq-core
+	$(HIDE)ln -s $(shell pwd)/_build/default/tools/ $(BUILD_OUT_DIR)/lib/coq-core
+	$(HIDE)ln -s $(shell pwd)/_build/default/kernel/ $(BUILD_OUT_DIR)/lib/coq-core
 
 ###########################################################################
 # Executables

--- a/Makefile.install
+++ b/Makefile.install
@@ -16,9 +16,9 @@
 # by dependencies between rules, so do *not* try overly clever things like
 # 'make world install' in one unique command
 
-ifeq ($(LOCAL),true)
+ifeq ($(COQPREFIX),local)
 install:
-	@echo "Nothing to install in a local build!"
+	@echo "Prefix not set in configure, nothing to install."
 else
 install: install-coq install-coqide install-doc-$(WITHDOC)
 endif

--- a/config/coq_config.mli
+++ b/config/coq_config.mli
@@ -8,8 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-val local : bool        (* local use (no installation) *)
-
 (* The fields below are absolute paths *)
 val coqlib : string     (* where the std library is installed *)
 val configdir : string  (* where configuration files are installed *)

--- a/dev/doc/changes.md
+++ b/dev/doc/changes.md
@@ -7,8 +7,17 @@
 - Dune is now used to build the OCaml parts of Coq, thus:
 
   + ML object files live now in `_build`, as standard in Dune world
-  + .vo files live now in `_build_vo`
-  + you can build object files using `make _build/install/default/bin/coqc`.
+  + you can build object files using `make
+    _build/install/default/bin/coqc`, thanks to our implementation of
+    a make-Dune bridge
+  + .vo files live now in `_build_vo/`
+  + `_build_vo` follows a standard "Coq install layout", that is to say:
+    * `_build_vo/default/bin`: coq-core binaries
+    * `_build_vo/default/lib/coq-core`: coq-core libraries
+    * `_build_vo/default/lib/coq`: coq libraries, such as stdlib
+    This greatly simplifies layout as tooling can assume that
+    `_build_vo/default` has the structure of an installed Coq, thus
+    making the `-local` flag obsolete.
   + Some developer targets have changed or have been removed in favor
     of Dune's counterparts, for example `byte` and `install-byte` are
     no longer needed.

--- a/lib/envars.ml
+++ b/lib/envars.ml
@@ -129,7 +129,7 @@ let guess_coqlib fail =
   let prelude = "theories/Init/Prelude.vo" in
   check_file_else ~dir:Coq_config.coqlibsuffix ~file:prelude
     (fun () ->
-      if not Coq_config.local && Sys.file_exists (Coq_config.coqlib / prelude)
+      if Sys.file_exists (Coq_config.coqlib / prelude)
       then Coq_config.coqlib
       else
         fail "cannot guess a path for Coq libraries; please use -coqlib option \
@@ -207,9 +207,8 @@ let xdg_dirs ~warn =
 
 let print_config ?(prefix_var_name="") f coq_src_subdirs =
   let open Printf in
-  fprintf f "%sLOCAL=%s\n" prefix_var_name (if Coq_config.local then "1" else "0");
   fprintf f "%sCOQLIB=%s/\n" prefix_var_name (coqlib ());
-  fprintf f "%sCOQCORELIB=%s/\n" prefix_var_name (if Coq_config.local then coqlib () else coqlib () / "../coq-core/");
+  fprintf f "%sCOQCORELIB=%s/\n" prefix_var_name (coqlib () / "../coq-core/");
   fprintf f "%sDOCDIR=%s/\n" prefix_var_name (docdir ());
   fprintf f "%sOCAMLFIND=%s\n" prefix_var_name (ocamlfind ());
   fprintf f "%sCAMLFLAGS=%s\n" prefix_var_name Coq_config.caml_flags;

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -46,7 +46,7 @@ else
   export FINDLIB_SEP=:
 endif
 
-# Be careful to use COQPREFIX when in local mode
+# Be careful to use COQPREFIX when prefix is not set
 ifeq ($(COQPREFIX),local)
 	COQPREFIX:=$(shell cd ../..;pwd)/install/default/
 endif
@@ -61,11 +61,7 @@ endif
 # COQLIB is an env variable so no quotes
 COQLIB?=
 ifeq ($(COQLIB),)
-  ifeq ($(LOCAL),true)
-	COQLIB := $(shell ocaml ocaml_pwd.ml $(ROOT)/_build_vo/default)
-  else
 	COQLIB := $(shell ocaml ocaml_pwd.ml $(COQLIBINSTALL))
-  endif
 endif
 export COQLIB
 

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -35,7 +35,6 @@ SRC_SUBDIRS       := $(COQMF_SRC_SUBDIRS)
 COQLIBS           := $(COQMF_COQLIBS)
 COQLIBS_NOML      := $(COQMF_COQLIBS_NOML)
 CMDLINE_COQLIBS   := $(COQMF_CMDLINE_COQLIBS)
-LOCAL             := $(COQMF_LOCAL)
 COQLIB            := $(COQMF_COQLIB)
 COQCORELIB        := $(COQMF_COQCORELIB)
 DOCDIR            := $(COQMF_DOCDIR)
@@ -826,7 +825,6 @@ opt:
 printenv::
 	$(warning printenv is deprecated)
 	$(warning write extensions in @LOCAL_FILE@ or include @CONF_FILE@)
-	@echo 'LOCAL = $(LOCAL)'
 	@echo 'COQLIB = $(COQLIB)'
 	@echo 'COQCORELIB = $(COQCORELIB)'
 	@echo 'DOCDIR = $(DOCDIR)'

--- a/tools/coqdoc/cdglobals.ml
+++ b/tools/coqdoc/cdglobals.ml
@@ -88,7 +88,7 @@ let guess_coqlib () =
   let prefix = Filename.dirname coqbin in
   let coqlib = use_suffix prefix Coq_config.coqlibsuffix in
   if Sys.file_exists (coqlib / file) then coqlib else
-  if not Coq_config.local && Sys.file_exists (Coq_config.coqlib / file)
+  if Sys.file_exists (Coq_config.coqlib / file)
   then Coq_config.coqlib else prefix)
 
 let header_trailer = ref true


### PR DESCRIPTION
Recent changes have made `configure`'s `-local` flag practically
obsolete, as we build the large majority of Coq object files in a
separate build directory.

We turn the `-local` flag into a noop, effectively making it
deprecated, and simplifying quite a bit of code that now can assume a
standard installation layout under `_build_vo/default` or
`_build/install/default` depending on the build system chosen.

Closes: #5624
