### PR TITLE
Update GH PR template to mention grammar doc

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,8 @@ Fixes / closes #????
 - [ ] Added / updated test-suite
 <!-- If this is a feature pull request / breaks compatibility: -->
 <!-- (Otherwise, remove these lines.) -->
-- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified, and including reflecting any changes to the grammar in `common.edit_mlg` and running `make doc_gram_rsts`).
+- [ ] If you modified Coq's grammar, run `make doc_gram_rsts` to update the syntax in the documentation (see `docgram/README.md`).
+- [ ] Corresponding documentation was added / updated, including any changed warning and error messages.
 - [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
 - [ ] Overlay pull requests (if this breaks 3rd party developments in CI, see
 https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md for details)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@ Fixes / closes #????
 - [ ] Added / updated test-suite
 <!-- If this is a feature pull request / breaks compatibility: -->
 <!-- (Otherwise, remove these lines.) -->
-- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
+- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified, and including reflecting any changes to the grammar in `common.edit_mlg` and running `make doc_gram_rsts`).
 - [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
 - [ ] Overlay pull requests (if this breaks 3rd party developments in CI, see
 https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md for details)


### PR DESCRIPTION
I figure it's better to not leave it up to reviewers to remember to
remind people to do this all the time.  See also
https://github.com/coq/coq/pull/14174#discussion_r620522218

