### PR TITLE
[configure] Make configure a regular executable, modularize

### DIFF
--- a/config/dune
+++ b/config/dune
@@ -16,10 +16,9 @@
  (targets coq_config.ml coq_config.py Makefile dune.c_flags)
  (mode fallback)
  (deps
-   %{project_root}/configure.ml
    %{project_root}/dev/ocamldebug-coq.run
    %{project_root}/dev/header.c
    ; Needed to generate include lists for coq_makefile
    plugin_list
   (env_var COQ_CONFIGURE_PREFIX))
- (action (chdir %{project_root} (run %{ocaml} configure.ml -no-ask -native-compiler no -bin-annot))))
+ (action (chdir %{project_root} (run %{project_root}/tools/configure/configure.exe -no-ask -native-compiler no -bin-annot))))

--- a/configure
+++ b/configure
@@ -2,37 +2,13 @@
 
 ## This micro-configure shell script is here only to
 ## launch the real configuration via ocaml
+configure=./tools/configure/configure.exe
 
-ocaml=ocaml
-script=./configure.ml
-
-if [ ! -f $script ]; then
-    echo "Error: file $script not found in the current directory."
-    echo "Please run the configure script from the root of the coq sources."
-    echo "Configuration script failed!"
+## Check that dune is available, provide an error message otherwise
+if ! command -v dune > /dev/null
+then
+    1>&2 echo "Dune could not be found, please ensure you have a working OCaml enviroment"
     exit 1
 fi
 
-## Parse the args, only looking for -camldir
-## We avoid using shift to keep "$@" intact
-
-cmd=$ocaml
-last=
-for i; do
-   case $last in
-       -camldir) cmd="$i/$ocaml"; break;;
-   esac
-   last=$i
-done
-
-## We check that $cmd is ok before the real exec $cmd
-
-`$cmd -version > /dev/null 2>&1` && exec $cmd -w "-3" $script "$@"
-
-## If we're still here, something is wrong with $cmd
-
-echo "Error: failed to run $cmd"
-echo "Please use the option -camldir <dir> if 'ocaml' is installed"
-echo "in directory <dir>, or add <dir> to your path."
-echo "Configuration script failed!"
-exit 1
+dune exec -- $configure "$@"

--- a/dev/tools/update-compat.py
+++ b/dev/tools/update-compat.py
@@ -58,7 +58,7 @@ from io import open
 # robust to users who choose to run the script from any location.
 SCRIPT_PATH = os.path.dirname(os.path.realpath(__file__))
 ROOT_PATH = os.path.realpath(os.path.join(SCRIPT_PATH, '..', '..'))
-CONFIGURE_PATH = os.path.join(ROOT_PATH, 'configure.ml')
+CONFIGURE_PATH = os.path.join(ROOT_PATH, 'tools/configure/configure.ml')
 HEADER_PATH = os.path.join(ROOT_PATH, 'dev', 'header.ml')
 DEFAULT_NUMBER_OF_OLD_VERSIONS = 2
 RELEASE_NUMBER_OF_OLD_VERSIONS = 2

--- a/tools/configure/configure.ml
+++ b/tools/configure/configure.ml
@@ -1,15 +1,16 @@
-(**********************************)
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
 
+(**********************************)
 (**  Configuration script for Coq *)
-
 (**********************************)
-
-
-(** This file should be run via: ocaml configure.ml <opts>
-    You could also use our wrapper ./configure <opts> *)
-
-#load "unix.cma"
-#load "str.cma"
 open Printf
 
 let coq_version = "8.14+alpha"

--- a/tools/configure/dune
+++ b/tools/configure/dune
@@ -1,0 +1,3 @@
+(executable
+ (name configure)
+ (libraries unix str))


### PR DESCRIPTION
Thanks to dune being used to build the OCaml parts, we can now turn
Coq's `configure` into a regular executable. This has a few positive
side-effects, in particular merlin does now work, and will allow us to
perform further refactoring of configure, for example linking to
`findlib` or modularizing several components.

This first step just sets the infrastructure.

This also removes one file from the root of the tree cc #6137
