### PR TITLE
Stop running platform script test on PR branches.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -351,6 +351,9 @@ windows64:
   only:
     variables:
       - $WINDOWS =~ /enabled/
+    refs:
+      - master
+      - /^v.*\..*$/
 
 lint:
   stage: stage-1


### PR DESCRIPTION
Since it actually builds coq.dev (see the discussion in #14202).

This is only a minor workaround for now.

@gares The platform script should be amended to test the correct Coq version. If it cannot, this should be replaced by a scheduled test on the platform repository itself.