### PR TITLE
[build] [dune] Add world-prelude target to produce a subset of world

### DIFF
--- a/Makefile.dune
+++ b/Makefile.dune
@@ -3,7 +3,7 @@
 
 .PHONY: help help-install states world watch check    # Main developer targets
 .PHONY: refman-html refman-pdf stdlib-html apidoc     # Documentation targets
-.PHONY: test-suite
+.PHONY: test-suite dev-targets
 .PHONY: fmt ocheck ireport clean                      # Maintenance targets
 .PHONY: voboot release install                        # Added just not to break old scripts
 
@@ -46,6 +46,15 @@ help:
 	@echo "  - help:    show this message"
 	@echo ""
 	@echo " Type 'make help-install' for installation instructions"
+	@echo " Type 'make dev-targets' for more developer targets"
+
+dev-targets:
+	@echo ""
+	@echo "In order to get a functional Coq install layout, the world target is required."
+	@echo "However, This is often inconvenient for developers, due to the large amount of"
+	@echo "files that world will build. We provide some useful subtargets here:"
+	@echo ""
+	@echo "  - world-prelude: build Coq's prelude and setup a functional layout on _build/install"
 
 help-install:
 	@echo ""
@@ -128,6 +137,40 @@ ireport:
 
 clean:
 	dune clean
+
+# Custom targets to create subsets of the world target but with less
+# compiled files. This is desired when we want to have our Coq Dune
+# build with Coq developments that are not dunerized and thus still
+# expect an install layout with a working Coq setup, but smaller than
+# world.
+#
+# Unfortunately, Dune still lacks the capability to refer to install
+# targets in rules, see https://github.com/ocaml/dune/issues/3192 ;
+# thus we can't simply yet use `%{pkg:coq:theories/Arith/Arith.vo` to
+# have the rule install the target, we thus imitate such behavior
+# using make as a helper.
+
+.PHONY: world-prelude
+
+# We could use more refined rules like below, however it is not really
+# worth it as in general ci-packages want everything in coq-core
+CORE_TOOLS=coq-core.install
+
+# Exe suffix, likely needed on windows
+# EXE=
+# CORE_TOOLS=coqdep coqc coq_makefile coqdoc
+# CORE_TOOLS_PATH=$(addsuffix, $(EXE), $(addprefix _build/install/default/bin/, $(CORE_TOOLS)))
+# CORE_FILES=_build/install/default/lib/coq-core/tools/CoqMakefile.in
+
+# Would be nice to determine a pattern for this, but it is tricky.
+# PLUGIN_FILES=$(shell ls plugins/*/*.mllib)
+# PLUGIN_FILES_PATH=$(addprefix _build/install/default/lib/coq-core/, $(PLUGIN_FILES:.mllib=.cmxs))
+
+PRELUDE_FILES=$(wildcard theories/Init/*.v)
+PRELUDE_FILES_PATH=$(addprefix _build/install/default/lib/coq/, $(PRELUDE_FILES:.v=.vo))
+
+world-prelude:
+	@dune build $(CORE_TOOLS) $(PRELUDE_FILES_PATH)
 
 # Other common dev targets:
 #


### PR DESCRIPTION
Some users want to have a subset of the world target for faster
interaction with non-dunerized builds.

This is not seamless done in Dune due to install layouts not composing
in general [so implementing `%{pkg:coq:foo}` is hard when the `coq`
package is not in the workspace]

Instead, we provide a convenience target to build some subsets of
world until we improve support in dune.

Likely, Dune should support the `@install` alias scoped to
sub-directories but there seems to be a problem with it as of today.
