### PR TITLE
Implement the warning for typeclass instances without an explicit locality.

### DIFF
--- a/doc/changelog/07-vernac-commands-and-options/14208-warn-unqualified-typeclass-instance.rst
+++ b/doc/changelog/07-vernac-commands-and-options/14208-warn-unqualified-typeclass-instance.rst
@@ -1,0 +1,7 @@
+- **Deprecated:**
+  Like hints, typeclass instances added outside of sections
+  without an explicit locality now generate a deprecation warning. See
+  :ref:`Hint <creating_hints>`
+  (`#14208 <https://github.com/coq/coq/pull/14208>`_,
+  fixes `#13562 <https://github.com/coq/coq/issues/13562>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/addendum/type-classes.rst
+++ b/doc/sphinx/addendum/type-classes.rst
@@ -29,6 +29,10 @@ instantiation of the record type.
 
 We’ll use the following example class in the rest of the chapter:
 
+.. coqtop:: none
+
+   Set Warnings "-deprecated-instance-without-locality".
+
 .. coqtop:: in
 
    Class EqDec (A : Type) :=

--- a/doc/sphinx/addendum/type-classes.rst
+++ b/doc/sphinx/addendum/type-classes.rst
@@ -354,6 +354,13 @@ Summary of the commands
    This command supports the :attr:`local`, :attr:`global` and :attr:`export`
    locality attributes.
 
+   .. deprecated:: 8.14
+
+      The default value for instance locality will change in a future
+      release. Instances added outside of sections without an explicit
+      locality are now deprecated. We recommend using :attr:`export`
+      where possible.
+
    Like :cmd:`Definition`, it also supports the :attr:`program`
    attribute to switch the type checking to `Program` (chapter
    :ref:`programs`) and to use the obligation mechanism to manage missing

--- a/doc/sphinx/language/extensions/implicit-arguments.rst
+++ b/doc/sphinx/language/extensions/implicit-arguments.rst
@@ -577,6 +577,10 @@ this behaviour may be disabled by prefixing the type with a ``!`` or
 by forcing the typeclass name to be an explicit application using
 ``@`` (however the later ignores implicit argument information).
 
+.. coqtop:: none
+
+   Set Warnings "-deprecated-instance-without-locality".
+
 .. coqtop:: all
 
    Class Op (A:Type) := op : A -> A -> A.

--- a/test-suite/output/Notations2.v
+++ b/test-suite/output/Notations2.v
@@ -12,6 +12,7 @@ Check (2 3).
 Record Binop := { binop :> nat -> nat -> nat }.
 Class Plusop := { plusop : Binop; zero : nat }.
 Infix "[+]" := plusop (at level 40).
+#[global]
 Instance Plus : Plusop := {| plusop := {| binop := plus |} ; zero := 0 |}.
 Check 2[+]3.
 

--- a/test-suite/output/NumberNotations.out
+++ b/test-suite/output/NumberNotations.out
@@ -260,28 +260,28 @@ The command has indeed failed with message:
 add is not a constructor of an inductive type.
 The command has indeed failed with message:
 Missing mapping for constructor Iempty.
-File "stdin", line 577, characters 56-61:
+File "stdin", line 580, characters 56-61:
 Warning: Type of I'sum seems incompatible with the type of sum.
 Expected type is: (I' -> I' -> I') instead of (I -> I' -> I').
 This might yield ill typed terms when using the notation.
 [via-type-mismatch,numbers]
-File "stdin", line 582, characters 32-33:
+File "stdin", line 585, characters 32-33:
 Warning: I was already mapped to Set, mapping it also to
 nat might yield ill typed terms when using the notation.
 [via-type-remapping,numbers]
-File "stdin", line 582, characters 37-42:
+File "stdin", line 585, characters 37-42:
 Warning: Type of Iunit seems incompatible with the type of O.
 Expected type is: I instead of I.
 This might yield ill typed terms when using the notation.
 [via-type-mismatch,numbers]
 The command has indeed failed with message:
 'via' and 'abstract' cannot be used together.
-File "stdin", line 662, characters 21-23:
+File "stdin", line 665, characters 21-23:
 Warning: Type of I1 seems incompatible with the type of Fin.F1.
 Expected type is: (nat -> I) instead of I.
 This might yield ill typed terms when using the notation.
 [via-type-mismatch,numbers]
-File "stdin", line 662, characters 35-37:
+File "stdin", line 665, characters 35-37:
 Warning: Type of IS seems incompatible with the type of Fin.FS.
 Expected type is: (nat -> I -> I) instead of (I -> I).
 This might yield ill typed terms when using the notation.

--- a/test-suite/output/NumberNotations.v
+++ b/test-suite/output/NumberNotations.v
@@ -408,8 +408,11 @@ Module Test20.
   | two : known_type bool.
 
   Existing Class known_type.
+  #[global]
   Existing Instances zero one two prop.
+  #[global]
   Existing Instance set | 2.
+  #[global]
   Existing Instance type | 4.
 
   Record > ty := { t : Type ; kt : known_type t }.

--- a/test-suite/output/UnivBinders.v
+++ b/test-suite/output/UnivBinders.v
@@ -24,6 +24,7 @@ Print Wrap.
 Print wrap.
 
 (* Instance in lemma mode used to ignore the binders. *)
+#[global]
 Instance bar@{uu} : Wrap@{uu} Set. Proof. exact nat. Qed.
 Print bar.
 

--- a/theories/Arith/PeanoNat.v
+++ b/theories/Arith/PeanoNat.v
@@ -32,15 +32,25 @@ Set Inline Level 50.
 
 Definition eq_equiv : Equivalence (@eq nat) := eq_equivalence.
 Local Obligation Tactic := simpl_relation.
+#[global]
 Program Instance succ_wd : Proper (eq==>eq) S.
+#[global]
 Program Instance pred_wd : Proper (eq==>eq) pred.
+#[global]
 Program Instance add_wd : Proper (eq==>eq==>eq) plus.
+#[global]
 Program Instance sub_wd : Proper (eq==>eq==>eq) minus.
+#[global]
 Program Instance mul_wd : Proper (eq==>eq==>eq) mult.
+#[global]
 Program Instance pow_wd : Proper (eq==>eq==>eq) pow.
+#[global]
 Program Instance div_wd : Proper (eq==>eq==>eq) div.
+#[global]
 Program Instance mod_wd : Proper (eq==>eq==>eq) modulo.
+#[global]
 Program Instance lt_wd : Proper (eq==>eq==>iff) lt.
+#[global]
 Program Instance testbit_wd : Proper (eq==>eq==>eq) testbit.
 
 (** Bi-directional induction. *)
@@ -57,6 +67,7 @@ Qed.
 Definition recursion {A} : A -> (nat -> A -> A) -> nat -> A :=
   nat_rect (fun _ => A).
 
+#[global]
 Instance recursion_wd {A} (Aeq : relation A) :
  Proper (Aeq ==> (eq==>Aeq==>Aeq) ==> eq ==> Aeq) recursion.
 Proof.

--- a/theories/Bool/BoolOrder.v
+++ b/theories/Bool/BoolOrder.v
@@ -31,6 +31,7 @@ Proof. destr_bool. Qed.
 Lemma false_le : forall b, false <= b.
 Proof. intros; constructor. Qed.
 
+#[global]
 Instance le_compat : Proper (eq ==> eq ==> iff) Bool.le.
 Proof. intuition. Qed.
 
@@ -43,6 +44,7 @@ Lemma lt_trans : forall b1 b2 b3,
   b1 < b2 -> b2 < b3 -> b1 < b3.
 Proof. destr_bool; auto. Qed.
 
+#[global]
 Instance lt_compat : Proper (eq ==> eq ==> iff) Bool.lt.
 Proof. intuition. Qed.
 
@@ -65,6 +67,7 @@ Proof. destr_bool; intuition. Qed.
 (** * Order structures *)
 
 (* Class structure *)
+#[global]
 Instance le_preorder : PreOrder Bool.le.
 Proof.
 split.
@@ -72,6 +75,7 @@ split.
 - intros b1 b2 b3; apply le_trans.
 Qed.
 
+#[global]
 Instance lt_strorder : StrictOrder Bool.lt.
 Proof.
 split.

--- a/theories/Classes/CEquivalence.v
+++ b/theories/Classes/CEquivalence.v
@@ -53,10 +53,13 @@ Infix "=~=" := pequiv (at level 70, no associativity) : equiv_scope.
 
 (** Shortcuts to make proof search easier. *)
 
+#[global]
 Program Instance equiv_reflexive `(sa : Equivalence A) : Reflexive equiv.
 
+#[global]
 Program Instance equiv_symmetric `(sa : Equivalence A) : Symmetric equiv.
 
+#[global]
 Program Instance equiv_transitive `(sa : Equivalence A) : Transitive equiv.
 
   Next Obligation.
@@ -132,15 +135,19 @@ End Respecting.
 
 (** The default equivalence on function spaces, with higher-priority than [eq]. *)
 
+#[global]
 Instance pointwise_reflexive {A} `(reflb : Reflexive B eqB) :
   Reflexive (pointwise_relation A eqB) | 9.
 Proof. firstorder. Qed.
+#[global]
 Instance pointwise_symmetric {A} `(symb : Symmetric B eqB) :
   Symmetric (pointwise_relation A eqB) | 9.
 Proof. firstorder. Qed.
+#[global]
 Instance pointwise_transitive {A} `(transb : Transitive B eqB) :
   Transitive (pointwise_relation A eqB) | 9.
 Proof. firstorder. Qed.
+#[global]
 Instance pointwise_equivalence {A} `(eqb : Equivalence B eqB) :
   Equivalence (pointwise_relation A eqB) | 9.
 Proof. split; apply _. Qed.

--- a/theories/Classes/CMorphisms.v
+++ b/theories/Classes/CMorphisms.v
@@ -245,17 +245,21 @@ Hint Extern 5 (@Proper _ ?H _) => proper_subrelation : typeclass_instances.
 
 (** Essential subrelation instances for [iff], [impl] and [pointwise_relation]. *)
 
+#[global]
 Instance iff_impl_subrelation : subrelation iff impl | 2.
 Proof. firstorder. Qed.
 
+#[global]
 Instance iff_flip_impl_subrelation : subrelation iff (flip impl) | 2.
 Proof. firstorder. Qed.
 
 (** Essential subrelation instances for [iffT] and [arrow]. *)
 
+#[global]
 Instance iffT_arrow_subrelation : subrelation iffT arrow | 2.
 Proof. firstorder. Qed.
 
+#[global]
 Instance iffT_flip_arrow_subrelation : subrelation iffT (flip arrow) | 2.
 Proof. firstorder. Qed.
 
@@ -519,6 +523,7 @@ Ltac partial_application_tactic :=
 
 (** Bootstrap !!! *)
 
+#[global]
 Instance proper_proper {A} : Proper (relation_equivalence ==> eq ==> iffT) (@Proper A).
 Proof.
   intros R R' HRR' x y <-. red in HRR'.
@@ -658,6 +663,7 @@ Qed.
 (** A [PartialOrder] is compatible with its underlying equivalence. *)
 Require Import Relation_Definitions.
 
+#[global]
 Instance PartialOrder_proper_type `(PartialOrder A eqA R) :
   Proper (eqA==>eqA==>iffT) R.
 Proof.

--- a/theories/Classes/CRelationClasses.v
+++ b/theories/Classes/CRelationClasses.v
@@ -195,9 +195,11 @@ Section Defs.
 End Defs.
 
 (** Default rewrite crelations handled by [setoid_rewrite]. *)
+#[global]
 Instance: RewriteRelation impl.
 Defined.
 
+#[global]
 Instance: RewriteRelation iff.
 Defined.
 
@@ -277,25 +279,36 @@ Local Obligation Tactic := simpl_crelation.
 
 (** Logical implication. *)
 
+#[global]
 Program Instance impl_Reflexive : Reflexive impl.
+#[global]
 Program Instance impl_Transitive : Transitive impl.
 
 (** Logical equivalence. *)
 
+#[global]
 Instance iff_Reflexive : Reflexive iff := iff_refl.
+#[global]
 Instance iff_Symmetric : Symmetric iff := iff_sym.
+#[global]
 Instance iff_Transitive : Transitive iff := iff_trans.
 
 (** Logical equivalence [iff] is an equivalence crelation. *)
 
+#[global]
 Program Instance iff_equivalence : Equivalence iff. 
+#[global]
 Program Instance arrow_Reflexive : Reflexive arrow.
+#[global]
 Program Instance arrow_Transitive : Transitive arrow.
 
+#[global]
 Instance iffT_Reflexive : Reflexive iffT. 
 Proof. firstorder. Defined.
+#[global]
 Instance iffT_Symmetric : Symmetric iffT. 
 Proof. firstorder. Defined. 
+#[global]
 Instance iffT_Transitive : Transitive iffT.
 Proof. firstorder. Defined.
 

--- a/theories/Classes/DecidableClass.v
+++ b/theories/Classes/DecidableClass.v
@@ -65,6 +65,7 @@ Tactic Notation "decide" constr(P) :=
 
 Require Import Bool Arith ZArith.
 
+#[global]
 Program Instance Decidable_not {P} `{Decidable P} : Decidable (~ P) := {
   Decidable_witness := negb Decidable_witness
 }.
@@ -75,6 +76,7 @@ Next Obligation.
   - erewrite Decidable_sound_alt; intuition.
 Qed.
 
+#[global]
 Program Instance Decidable_eq_bool : forall (x y : bool), Decidable (eq x y) := {
   Decidable_witness := Bool.eqb x y
 }.
@@ -82,6 +84,7 @@ Next Obligation.
  apply eqb_true_iff.
 Qed.
 
+#[global]
 Program Instance Decidable_eq_nat : forall (x y : nat), Decidable (eq x y) := {
   Decidable_witness := Nat.eqb x y
 }.
@@ -89,6 +92,7 @@ Next Obligation.
  apply Nat.eqb_eq.
 Qed.
 
+#[global]
 Program Instance Decidable_le_nat : forall (x y : nat), Decidable (x <= y) := {
   Decidable_witness := Nat.leb x y
 }.
@@ -96,6 +100,7 @@ Next Obligation.
  apply Nat.leb_le.
 Qed.
 
+#[global]
 Program Instance Decidable_eq_Z : forall (x y : Z), Decidable (eq x y) := {
   Decidable_witness := Z.eqb x y
 }.

--- a/theories/Classes/EquivDec.v
+++ b/theories/Classes/EquivDec.v
@@ -79,10 +79,13 @@ Infix "<>b" := nequiv_decb (no associativity, at level 70).
 (** The equiv is buried inside the setoid, but we can recover it by specifying
    which setoid we're talking about. *)
 
+#[global]
 Program Instance nat_eq_eqdec : EqDec nat eq := eq_nat_dec.
 
+#[global]
 Program Instance bool_eqdec : EqDec bool eq := bool_dec.
 
+#[global]
 Program Instance unit_eqdec : EqDec unit eq := fun x y => in_left.
 
   Next Obligation.
@@ -93,6 +96,7 @@ Program Instance unit_eqdec : EqDec unit eq := fun x y => in_left.
 
 Obligation Tactic := unfold complement, equiv ; program_simpl.
 
+#[global]
 Program Instance prod_eqdec `(EqDec A eq, EqDec B eq) :
   EqDec (prod A B) eq :=
   { equiv_dec x y :=
@@ -103,6 +107,7 @@ Program Instance prod_eqdec `(EqDec A eq, EqDec B eq) :
       else in_right
     else in_right }.
 
+#[global]
 Program Instance sum_eqdec `(EqDec A eq, EqDec B eq) :
   EqDec (sum A B) eq := {
   equiv_dec x y :=
@@ -115,6 +120,7 @@ Program Instance sum_eqdec `(EqDec A eq, EqDec B eq) :
 (** Objects of function spaces with countable domains like bool have decidable
   equality. Proving the reflection requires functional extensionality though. *)
 
+#[global]
 Program Instance bool_function_eqdec `(EqDec A eq) : EqDec (bool -> A) eq :=
   { equiv_dec f g :=
     if f true == g true then
@@ -130,6 +136,7 @@ Program Instance bool_function_eqdec `(EqDec A eq) : EqDec (bool -> A) eq :=
 
 Require Import List.
 
+#[global]
 Program Instance list_eqdec `(eqa : EqDec A eq) : EqDec (list A) eq :=
   { equiv_dec :=
     fix aux (x y : list A) :=

--- a/theories/Classes/Equivalence.v
+++ b/theories/Classes/Equivalence.v
@@ -53,10 +53,13 @@ Infix "=~=" := pequiv (at level 70, no associativity) : equiv_scope.
 
 (** Shortcuts to make proof search easier. *)
 
+#[global]
 Program Instance equiv_reflexive `(sa : Equivalence A) : Reflexive equiv | 1.
 
+#[global]
 Program Instance equiv_symmetric `(sa : Equivalence A) : Symmetric equiv | 1.
 
+#[global]
 Program Instance equiv_transitive `(sa : Equivalence A) : Transitive equiv | 1.
 
   Next Obligation.
@@ -132,15 +135,19 @@ End Respecting.
 
 (** The default equivalence on function spaces, with higher priority than [eq]. *)
 
+#[global]
 Instance pointwise_reflexive {A} `(reflb : Reflexive B eqB) :
   Reflexive (pointwise_relation A eqB) | 9.
 Proof. firstorder. Qed.
+#[global]
 Instance pointwise_symmetric {A} `(symb : Symmetric B eqB) :
   Symmetric (pointwise_relation A eqB) | 9.
 Proof. firstorder. Qed.
+#[global]
 Instance pointwise_transitive {A} `(transb : Transitive B eqB) :
   Transitive (pointwise_relation A eqB) | 9.
 Proof. firstorder. Qed.
+#[global]
 Instance pointwise_equivalence {A} `(eqb : Equivalence B eqB) :
   Equivalence (pointwise_relation A eqB) | 9.
 Proof. split; apply _. Qed.

--- a/theories/Classes/Morphisms.v
+++ b/theories/Classes/Morphisms.v
@@ -243,9 +243,11 @@ Hint Extern 5 (@Proper _ ?H _) => proper_subrelation : typeclass_instances.
 
 (** Essential subrelation instances for [iff], [impl] and [pointwise_relation]. *)
 
+#[global]
 Instance iff_impl_subrelation : subrelation iff impl | 2.
 Proof. firstorder. Qed.
 
+#[global]
 Instance iff_flip_impl_subrelation : subrelation iff (flip impl) | 2.
 Proof. firstorder. Qed.
 
@@ -528,6 +530,7 @@ Ltac partial_application_tactic :=
 
 (** Bootstrap !!! *)
 
+#[global]
 Instance proper_proper {A} : Proper (relation_equivalence ==> eq ==> iff) (@Proper A).
 Proof.
   intros x y H y0 y1 e; destruct e.
@@ -663,6 +666,7 @@ Qed.
 
 (** A [PartialOrder] is compatible with its underlying equivalence. *)
 
+#[global]
 Instance PartialOrder_proper `(PartialOrder A eqA R) :
   Proper (eqA==>eqA==>iff) R.
 Proof.

--- a/theories/Classes/Morphisms_Prop.v
+++ b/theories/Classes/Morphisms_Prop.v
@@ -24,53 +24,67 @@ Local Obligation Tactic := try solve [simpl_relation | firstorder auto].
 
 (** Logical negation. *)
 
+#[global]
 Program Instance not_impl_morphism :
   Proper (impl --> impl) not | 1.
 
+#[global]
 Program Instance not_iff_morphism :
   Proper (iff ++> iff) not.
 
 (** Logical conjunction. *)
 
+#[global]
 Program Instance and_impl_morphism :
   Proper (impl ==> impl ==> impl) and | 1.
 
+#[global]
 Program Instance and_iff_morphism :
   Proper (iff ==> iff ==> iff) and.
 
 (** Logical disjunction. *)
 
+#[global]
 Program Instance or_impl_morphism :
   Proper (impl ==> impl ==> impl) or | 1.
 
+#[global]
 Program Instance or_iff_morphism :
   Proper (iff ==> iff ==> iff) or.
 
 (** Logical implication [impl] is a morphism for logical equivalence. *)
 
+#[global]
 Program Instance iff_iff_iff_impl_morphism : Proper (iff ==> iff ==> iff) impl.
 
 (** Morphisms for quantifiers *)
 
+#[global]
 Program Instance ex_iff_morphism {A : Type} : Proper (pointwise_relation A iff ==> iff) (@ex A).
 
+#[global]
 Program Instance ex_impl_morphism {A : Type} :
   Proper (pointwise_relation A impl ==> impl) (@ex A) | 1.
 
+#[global]
 Program Instance ex_flip_impl_morphism {A : Type} :
   Proper (pointwise_relation A (flip impl) ==> flip impl) (@ex A) | 1.
 
+#[global]
 Program Instance all_iff_morphism {A : Type} :
   Proper (pointwise_relation A iff ==> iff) (@all A).
 
+#[global]
 Program Instance all_impl_morphism {A : Type} :
   Proper (pointwise_relation A impl ==> impl) (@all A) | 1.
 
+#[global]
 Program Instance all_flip_impl_morphism {A : Type} :
   Proper (pointwise_relation A (flip impl) ==> flip impl) (@all A) | 1.
 
 (** Equivalent points are simultaneously accessible or not *)
 
+#[global]
 Instance Acc_pt_morphism {A:Type}(E R : A->A->Prop)
  `(Equivalence _ E) `(Proper _ (E==>E==>iff) R) :
  Proper (E==>iff) (Acc R).
@@ -82,6 +96,7 @@ Qed.
 
 (** Equivalent relations have the same accessible points *)
 
+#[global]
 Instance Acc_rel_morphism {A:Type} :
  Proper (relation_equivalence ==> Logic.eq ==> iff) (@Acc A).
 Proof.
@@ -95,6 +110,7 @@ Qed.
 
 (** Equivalent relations are simultaneously well-founded or not *)
 
+#[global]
 Instance well_founded_morphism {A : Type} :
  Proper (relation_equivalence ==> iff) (@well_founded A).
 Proof.

--- a/theories/Classes/Morphisms_Relations.v
+++ b/theories/Classes/Morphisms_Relations.v
@@ -22,10 +22,12 @@ Generalizable Variables A l.
 
 (** Morphisms for relations *)
 
+#[global]
 Instance relation_conjunction_morphism {A} : Proper (relation_equivalence (A:=A) ==>
   relation_equivalence ==> relation_equivalence) relation_conjunction.
   Proof. firstorder. Qed.
 
+#[global]
 Instance relation_disjunction_morphism {A} : Proper (relation_equivalence (A:=A) ==>
   relation_equivalence ==> relation_equivalence) relation_disjunction.
   Proof. firstorder. Qed.
@@ -43,10 +45,12 @@ Proof. do 2 red. unfold predicate_implication. auto. Qed.
 (** The instantiation at relation allows rewriting applications of relations
     [R x y] to [R' x y]  when [R] and [R'] are in [relation_equivalence]. *)
 
+#[global]
 Instance relation_equivalence_pointwise {A} :
   Proper (relation_equivalence ==> pointwise_relation A (pointwise_relation A iff)) id.
 Proof. intro. apply (predicate_equivalence_pointwise (Tcons A (Tcons A Tnil))). Qed.
 
+#[global]
 Instance subrelation_pointwise {A} :
   Proper (subrelation ==> pointwise_relation A (pointwise_relation A impl)) id.
 Proof. intro. apply (predicate_implication_pointwise (Tcons A (Tcons A Tnil))). Qed.

--- a/theories/Classes/RelationClasses.v
+++ b/theories/Classes/RelationClasses.v
@@ -189,8 +189,10 @@ Section Defs.
 End Defs.
 
 (** Default rewrite relations handled by [setoid_rewrite]. *)
+#[global]
 Instance: RewriteRelation impl.
 Defined.
+#[global]
 Instance: RewriteRelation iff.
 Defined.
 
@@ -276,17 +278,23 @@ Local Obligation Tactic := try solve [ simpl_relation ].
 
 (** Logical implication. *)
 
+#[global]
 Program Instance impl_Reflexive : Reflexive impl.
+#[global]
 Program Instance impl_Transitive : Transitive impl.
 
 (** Logical equivalence. *)
 
+#[global]
 Instance iff_Reflexive : Reflexive iff := iff_refl.
+#[global]
 Instance iff_Symmetric : Symmetric iff := iff_sym.
+#[global]
 Instance iff_Transitive : Transitive iff := iff_trans.
 
 (** Logical equivalence [iff] is an equivalence relation. *)
 
+#[global]
 Program Instance iff_equivalence : Equivalence iff.
 
 (** We now develop a generalization of results on relations for arbitrary predicates.
@@ -407,6 +415,7 @@ Notation "∙⊥∙" := false_predicate : predicate_scope.
 
 (** Predicate equivalence is an equivalence, and predicate implication defines a preorder. *)
 
+#[global]
 Program Instance predicate_equivalence_equivalence {l} :
   Equivalence (@predicate_equivalence l).
 
@@ -425,6 +434,7 @@ Program Instance predicate_equivalence_equivalence {l} :
       firstorder.
   Qed.
 
+#[global]
 Program Instance predicate_implication_preorder {l} :
   PreOrder (@predicate_implication l).
   Next Obligation.
@@ -493,6 +503,7 @@ Hint Extern 3 (PartialOrder (flip _)) => class_apply PartialOrder_inverse : type
 
 (** The partial order defined by subrelation and relation equivalence. *)
 
+#[global]
 Program Instance subrelation_partial_order {A} :
   PartialOrder (@relation_equivalence A) subrelation.
 

--- a/theories/Classes/RelationPairs.v
+++ b/theories/Classes/RelationPairs.v
@@ -61,8 +61,10 @@ Class Measure {A B} (f : A -> B).
 
 (** Standard measures. *)
 
+#[global]
 Instance fst_measure {A B} : @Measure (A * B) A Fst := {}.
 
+#[global]
 Instance snd_measure {A B} : @Measure (A * B) B Snd := {}.
 
 (** We define a product relation over [A*B]: each components should

--- a/theories/Classes/SetoidClass.v
+++ b/theories/Classes/SetoidClass.v
@@ -47,8 +47,11 @@ Proof. typeclasses eauto. Qed.
 Definition setoid_trans `(sa : Setoid A) : Transitive equiv.
 Proof. typeclasses eauto. Qed.
 
+#[global]
 Existing Instance setoid_refl.
+#[global]
 Existing Instance setoid_sym.
+#[global]
 Existing Instance setoid_trans.
 
 (** Standard setoids. *)
@@ -56,6 +59,7 @@ Existing Instance setoid_trans.
 (* Program Instance eq_setoid : Setoid A := *)
 (*   equiv := eq ; setoid_equiv := eq_equivalence. *)
 
+#[global]
 Program Instance iff_setoid : Setoid Prop :=
   { equiv := iff ; setoid_equiv := iff_equivalence }.
 
@@ -120,9 +124,11 @@ Ltac setoidify := repeat setoidify_tac.
 
 (** Every setoid relation gives rise to a morphism, in fact every partial setoid does. *)
 
+#[global]
 Program Instance setoid_morphism `(sa : Setoid A) : Proper (equiv ++> equiv ++> iff) equiv :=
   proper_prf.
 
+#[global]
 Program Instance setoid_partial_app_morphism `(sa : Setoid A) (x : A) : Proper (equiv ++> iff) (equiv x) :=
   proper_prf.
 

--- a/theories/Classes/SetoidDec.v
+++ b/theories/Classes/SetoidDec.v
@@ -80,17 +80,21 @@ Require Import Coq.Arith.Arith.
 (** The equiv is buried inside the setoid, but we can recover
   it by specifying which setoid we're talking about. *)
 
+#[global]
 Program Instance eq_setoid A : Setoid A | 10 :=
   { equiv := eq ; setoid_equiv := eq_equivalence }.
 
+#[global]
 Program Instance nat_eq_eqdec : EqDec (eq_setoid nat) :=
   eq_nat_dec.
 
 Require Import Coq.Bool.Bool.
 
+#[global]
 Program Instance bool_eqdec : EqDec (eq_setoid bool) :=
   bool_dec.
 
+#[global]
 Program Instance unit_eqdec : EqDec (eq_setoid unit) :=
   fun x y => in_left.
 
@@ -100,6 +104,7 @@ Program Instance unit_eqdec : EqDec (eq_setoid unit) :=
     reflexivity.
   Qed.
 
+#[global]
 Program Instance prod_eqdec `(! EqDec (eq_setoid A), ! EqDec (eq_setoid B))
  : EqDec (eq_setoid (prod A B)) :=
   fun x y =>
@@ -115,6 +120,7 @@ Program Instance prod_eqdec `(! EqDec (eq_setoid A), ! EqDec (eq_setoid B))
 (** Objects of function spaces with countable domains like bool
   have decidable equality. *)
 
+#[global]
 Program Instance bool_function_eqdec `(! EqDec (eq_setoid A))
  : EqDec (eq_setoid (bool -> A)) :=
   fun f g =>

--- a/theories/Classes/SetoidTactics.v
+++ b/theories/Classes/SetoidTactics.v
@@ -40,6 +40,7 @@ Definition default_relation `{DefaultRelation A R} := R.
 (** Every [Equivalence] gives a default relation, if no other is given
   (lowest priority). *)
 
+#[global]
 Instance equivalence_default `(Equivalence A R) : DefaultRelation R | 4.
 Defined.
 

--- a/theories/FSets/FSetCompat.v
+++ b/theories/FSets/FSetCompat.v
@@ -263,9 +263,11 @@ Module Update_WSets
 
  Module MF := FSetFacts.WFacts M.
 
+#[global]
  Instance In_compat : Proper (E.eq==>Logic.eq==>iff) In.
  Proof. intros x x' Hx s s' Hs. subst. apply MF.In_eq_iff; auto. Qed.
 
+#[global]
  Instance eq_equiv : Equivalence eq := _.
 
  Section Spec.
@@ -378,6 +380,7 @@ Module Update_Sets
    choose s = Some x -> choose s' = Some y -> Equal s s' -> O.eq x y
    := M.choose_3.
 
+#[global]
   Instance lt_strorder : StrictOrder lt.
   Proof.
    split.
@@ -385,6 +388,7 @@ Module Update_Sets
    exact M.lt_trans.
   Qed.
 
+#[global]
   Instance lt_compat : Proper (eq==>eq==>iff) lt.
   Proof.
   apply proper_sym_impl_iff_2. 1-2: auto with crelations.

--- a/theories/FSets/FSetFacts.v
+++ b/theories/FSets/FSetFacts.v
@@ -291,22 +291,26 @@ End BoolSpec.
 
 (** * [E.eq] and [Equal] are setoid equalities *)
 
+#[global]
 Instance E_ST : Equivalence E.eq.
 Proof.
 constructor ; red; [apply E.eq_refl|apply E.eq_sym|apply E.eq_trans].
 Qed.
 
+#[global]
 Instance Equal_ST : Equivalence Equal.
 Proof.
 constructor ; red; [apply eq_refl | apply eq_sym | apply eq_trans].
 Qed.
 
+#[global]
 Instance In_m : Proper (E.eq ==> Equal ==> iff) In.
 Proof.
 unfold Equal; intros x y H s s' H0.
 rewrite (In_eq_iff s H); auto.
 Qed.
 
+#[global]
 Instance is_empty_m : Proper (Equal==> Logic.eq) is_empty.
 Proof.
 unfold Equal; intros s s' H.
@@ -324,11 +328,13 @@ destruct H1 as (_,H1).
 exact (H1 Logic.eq_refl _ Ha).
 Qed.
 
+#[global]
 Instance Empty_m : Proper (Equal ==> iff) Empty.
 Proof.
 repeat red; intros; do 2 rewrite is_empty_iff; rewrite H; intuition.
 Qed.
 
+#[global]
 Instance mem_m : Proper (E.eq ==> Equal ==> Logic.eq) mem.
 Proof.
 unfold Equal; intros x y H s s' H0.
@@ -337,6 +343,7 @@ generalize (mem_iff s x)(mem_iff s' y).
 destruct (mem x s); destruct (mem y s'); intuition.
 Qed.
 
+#[global]
 Instance singleton_m : Proper (E.eq ==> Equal) singleton.
 Proof.
 unfold Equal; intros x y H a.
@@ -345,41 +352,48 @@ apply E.eq_trans with x; auto.
 apply E.eq_trans with y; auto.
 Qed.
 
+#[global]
 Instance add_m : Proper (E.eq==>Equal==>Equal) add.
 Proof.
 unfold Equal; intros x y H s s' H0 a.
 do 2 rewrite add_iff; rewrite H; rewrite H0; intuition.
 Qed.
 
+#[global]
 Instance remove_m : Proper (E.eq==>Equal==>Equal) remove.
 Proof.
 unfold Equal; intros x y H s s' H0 a.
 do 2 rewrite remove_iff; rewrite H; rewrite H0; intuition.
 Qed.
 
+#[global]
 Instance union_m : Proper (Equal==>Equal==>Equal) union.
 Proof.
 unfold Equal; intros s s' H s'' s''' H0 a.
 do 2 rewrite union_iff; rewrite H; rewrite H0; intuition.
 Qed.
 
+#[global]
 Instance inter_m : Proper (Equal==>Equal==>Equal) inter.
 Proof.
 unfold Equal; intros s s' H s'' s''' H0 a.
 do 2 rewrite inter_iff; rewrite H; rewrite H0; intuition.
 Qed.
 
+#[global]
 Instance diff_m : Proper (Equal==>Equal==>Equal) diff.
 Proof.
 unfold Equal; intros s s' H s'' s''' H0 a.
 do 2 rewrite diff_iff; rewrite H; rewrite H0; intuition.
 Qed.
 
+#[global]
 Instance Subset_m : Proper (Equal==>Equal==>iff) Subset.
 Proof.
 unfold Equal, Subset; firstorder.
 Qed.
 
+#[global]
 Instance subset_m : Proper (Equal ==> Equal ==> Logic.eq) subset.
 Proof.
 intros s s' H s'' s''' H0.
@@ -389,6 +403,7 @@ rewrite H in H1; rewrite H0 in H1; intuition.
 rewrite H in H1; rewrite H0 in H1; intuition.
 Qed.
 
+#[global]
 Instance equal_m : Proper (Equal ==> Equal ==> Logic.eq) equal.
 Proof.
 intros s s' H s'' s''' H0.
@@ -412,6 +427,7 @@ Add Relation t Subset
  transitivity proved by Subset_trans
  as SubsetSetoid.
 
+#[global]
 Instance In_s_m : Morphisms.Proper (E.eq ==> Subset ++> Basics.impl) In | 1.
 Proof.
   simpl_relation. eauto with set.

--- a/theories/MSets/MSetAVL.v
+++ b/theories/MSets/MSetAVL.v
@@ -357,6 +357,7 @@ Proof.
  unfold singleton; intuition_in.
 Qed.
 
+#[global]
 Instance singleton_ok x : Ok (singleton x).
 Proof.
  unfold singleton; auto.
@@ -370,6 +371,7 @@ Proof.
  unfold create; split; [ inversion_clear 1 | ]; intuition.
 Qed.
 
+#[global]
 Instance create_ok l x r `(Ok l, Ok r, lt_tree x l, gt_tree x r) :
  Ok (create l x r).
 Proof.
@@ -383,6 +385,7 @@ Proof.
  rewrite !create_spec; intuition_in.
 Qed.
 
+#[global]
 Instance bal_ok l x r `(Ok l, Ok r, lt_tree x l, gt_tree x r) :
  Ok (bal l x r).
 Proof.
@@ -406,6 +409,7 @@ Lemma add_spec : forall s x y `{Ok s},
  InT y (add x s) <-> X.eq y x \/ InT y s.
 Proof. intros; apply add_spec'. Qed.
 
+#[global]
 Instance add_ok s x `(Ok s) : Ok (add x s).
 Proof.
  induct s x; auto; apply bal_ok; auto;
@@ -448,6 +452,7 @@ Proof.
  apply create_spec.
 Qed.
 
+#[global]
 Instance join_ok : forall l x r `(Ok l, Ok r, lt_tree x l, gt_tree x r),
  Ok (join l x r).
 Proof.
@@ -469,6 +474,7 @@ Proof.
  rewrite bal_spec, In_node_iff, IHp, e0; simpl; intuition.
 Qed.
 
+#[global]
 Instance remove_min_ok l x r : forall h `(Ok (Node h l x r)),
  Ok (remove_min l x r)#1.
 Proof.
@@ -511,6 +517,7 @@ Proof.
  rewrite bal_spec, remove_min_spec, e1; simpl; intuition.
 Qed.
 
+#[global]
 Instance merge_ok s1 s2 : forall `(Ok s1, Ok s2)
  `(forall y1 y2 : elt, InT y1 s1 -> InT y2 s2 -> X.lt y1 y2),
  Ok (merge s1 s2).
@@ -540,6 +547,7 @@ Proof.
  rewrite bal_spec, IHr; clear IHl IHr; intuition; [order|order|intuition_in].
 Qed.
 
+#[global]
 Instance remove_ok s x `(Ok s) : Ok (remove x s).
 Proof.
  induct s x.
@@ -567,6 +575,7 @@ Proof.
  rewrite join_spec, remove_min_spec, e1; simpl; intuition.
 Qed.
 
+#[global]
 Instance concat_ok s1 s2 : forall `(Ok s1, Ok s2)
  `(forall y1 y2 : elt, InT y1 s1 -> InT y2 s2 -> X.lt y1 y2),
  Ok (concat s1 s2).
@@ -634,9 +643,11 @@ Proof.
  intros y; rewrite H; intuition.
 Qed.
 
+#[global]
 Instance split_ok1 s x `(Ok s) : Ok (split x s)#l.
 Proof. intros; destruct (@split_ok s x); auto. Qed.
 
+#[global]
 Instance split_ok2 s x `(Ok s) : Ok (split x s)#r.
 Proof. intros; destruct (@split_ok s x); auto. Qed.
 
@@ -679,6 +690,7 @@ Lemma inter_spec : forall s1 s2 y `{Ok s1, Ok s2},
  (InT y (inter s1 s2) <-> InT y s1 /\ InT y s2).
 Proof. intros; destruct (@inter_spec_ok s1 s2); auto. Qed.
 
+#[global]
 Instance inter_ok s1 s2 `(Ok s1, Ok s2) : Ok (inter s1 s2).
 Proof. intros; destruct (@inter_spec_ok s1 s2); auto. Qed.
 
@@ -714,6 +726,7 @@ Lemma diff_spec : forall s1 s2 y `{Ok s1, Ok s2},
  (InT y (diff s1 s2) <-> InT y s1 /\ ~InT y s2).
 Proof. intros; destruct (@diff_spec_ok s1 s2); auto. Qed.
 
+#[global]
 Instance diff_ok s1 s2 `(Ok s1, Ok s2) : Ok (diff s1 s2).
 Proof. intros; destruct (@diff_spec_ok s1 s2); auto. Qed.
 
@@ -731,6 +744,7 @@ Proof.
  destruct (X.compare_spec y x1); intuition_in.
 Qed.
 
+#[global]
 Instance union_ok s1 s2 : forall `(Ok s1, Ok s2), Ok (union s1 s2).
 Proof.
  functional induction union s1 s2; intros B1 B2; auto.
@@ -765,6 +779,7 @@ Proof.
    * rewrite concat_spec; intuition_in; eauto.
 Qed.
 
+#[global]
 Instance filter_ok s f `(H : Ok s) : Ok (filter f s).
 Proof.
  induction H as [ | h x l r Hl Hfl Hr Hfr Hlt Hgt ].
@@ -805,9 +820,11 @@ Lemma partition_spec2 s f :
  Equal (partition f s)#2 (filter (fun x => negb (f x)) s).
 Proof. now rewrite partition_spec2'. Qed.
 
+#[global]
 Instance partition_ok1 s f `(Ok s) : Ok (partition f s)#1.
 Proof. rewrite partition_spec1'; now apply filter_ok. Qed.
 
+#[global]
 Instance partition_ok2 s f `(Ok s) : Ok (partition f s)#2.
 Proof. rewrite partition_spec2'; now apply filter_ok. Qed.
 

--- a/theories/MSets/MSetFacts.v
+++ b/theories/MSets/MSetFacts.v
@@ -372,18 +372,21 @@ End BoolSpec.
 
 (** * Declarations of morphisms with respects to [E.eq] and [Equal] *)
 
+#[global]
 Instance In_m : Proper (E.eq==>Equal==>iff) In.
 Proof.
 unfold Equal; intros x y H s s' H0.
 rewrite (In_eq_iff s H); auto.
 Qed.
 
+#[global]
 Instance Empty_m : Proper (Equal==>iff) Empty.
 Proof.
 repeat red; unfold Empty; intros s s' E.
 setoid_rewrite E; auto.
 Qed.
 
+#[global]
 Instance is_empty_m : Proper (Equal==>Logic.eq) is_empty.
 Proof.
 intros s s' H.
@@ -391,6 +394,7 @@ generalize (is_empty_iff s). rewrite H at 1. rewrite is_empty_iff.
 destruct (is_empty s); destruct (is_empty s'); intuition.
 Qed.
 
+#[global]
 Instance mem_m : Proper (E.eq==>Equal==>Logic.eq) mem.
 Proof.
 intros x x' Hx s s' Hs.
@@ -398,41 +402,49 @@ generalize (mem_iff s x). rewrite Hs, Hx at 1; rewrite mem_iff.
 destruct (mem x s), (mem x' s'); intuition.
 Qed.
 
+#[global]
 Instance singleton_m : Proper (E.eq==>Equal) singleton.
 Proof.
 intros x y H a. rewrite !singleton_iff, H; intuition.
 Qed.
 
+#[global]
 Instance add_m : Proper (E.eq==>Equal==>Equal) add.
 Proof.
 intros x x' Hx s s' Hs a. rewrite !add_iff, Hx, Hs; intuition.
 Qed.
 
+#[global]
 Instance remove_m : Proper (E.eq==>Equal==>Equal) remove.
 Proof.
 intros x x' Hx s s' Hs a. rewrite !remove_iff, Hx, Hs; intuition.
 Qed.
 
+#[global]
 Instance union_m : Proper (Equal==>Equal==>Equal) union.
 Proof.
 intros s1 s1' Hs1 s2 s2' Hs2 a. rewrite !union_iff, Hs1, Hs2; intuition.
 Qed.
 
+#[global]
 Instance inter_m : Proper (Equal==>Equal==>Equal) inter.
 Proof.
 intros s1 s1' Hs1 s2 s2' Hs2 a. rewrite !inter_iff, Hs1, Hs2; intuition.
 Qed.
 
+#[global]
 Instance diff_m : Proper (Equal==>Equal==>Equal) diff.
 Proof.
 intros s1 s1' Hs1 s2 s2' Hs2 a. rewrite !diff_iff, Hs1, Hs2; intuition.
 Qed.
 
+#[global]
 Instance Subset_m : Proper (Equal==>Equal==>iff) Subset.
 Proof.
 unfold Equal, Subset; firstorder.
 Qed.
 
+#[global]
 Instance subset_m : Proper (Equal==>Equal==>Logic.eq) subset.
 Proof.
 intros s1 s1' Hs1 s2 s2' Hs2.
@@ -440,6 +452,7 @@ generalize (subset_iff s1 s2). rewrite Hs1, Hs2 at 1. rewrite subset_iff.
 destruct (subset s1 s2); destruct (subset s1' s2'); intuition.
 Qed.
 
+#[global]
 Instance equal_m : Proper (Equal==>Equal==>Logic.eq) equal.
 Proof.
 intros s1 s1' Hs1 s2 s2' Hs2.
@@ -447,40 +460,48 @@ generalize (equal_iff s1 s2). rewrite Hs1,Hs2 at 1. rewrite equal_iff.
 destruct (equal s1 s2); destruct (equal s1' s2'); intuition.
 Qed.
 
+#[global]
 Instance SubsetSetoid : PreOrder Subset. (* reflexive + transitive *)
 Proof. firstorder. Qed.
 
 Definition Subset_refl := @PreOrder_Reflexive _ _ SubsetSetoid.
 Definition Subset_trans := @PreOrder_Transitive _ _ SubsetSetoid.
 
+#[global]
 Instance In_s_m : Morphisms.Proper (E.eq ==> Subset ++> impl) In | 1.
 Proof.
   simpl_relation. eauto with set.
 Qed.
 
+#[global]
 Instance Empty_s_m : Proper (Subset-->impl) Empty.
 Proof. firstorder. Qed.
 
+#[global]
 Instance add_s_m : Proper (E.eq==>Subset++>Subset) add.
 Proof.
 intros x x' Hx s s' Hs a. rewrite !add_iff, Hx; intuition.
 Qed.
 
+#[global]
 Instance remove_s_m : Proper (E.eq==>Subset++>Subset) remove.
 Proof.
 intros x x' Hx s s' Hs a. rewrite !remove_iff, Hx; intuition.
 Qed.
 
+#[global]
 Instance union_s_m : Proper (Subset++>Subset++>Subset) union.
 Proof.
 intros s1 s1' Hs1 s2 s2' Hs2 a. rewrite !union_iff, Hs1, Hs2; intuition.
 Qed.
 
+#[global]
 Instance inter_s_m : Proper (Subset++>Subset++>Subset) inter.
 Proof.
 intros s1 s1' Hs1 s2 s2' Hs2 a. rewrite !inter_iff, Hs1, Hs2; intuition.
 Qed.
 
+#[global]
 Instance diff_s_m : Proper (Subset++>Subset-->Subset) diff.
 Proof.
 intros s1 s1' Hs1 s2 s2' Hs2 a. rewrite !diff_iff, Hs1, Hs2; intuition.
@@ -492,12 +513,14 @@ Qed.
 
 Generalizable Variables f.
 
+#[global]
 Instance filter_equal : forall `(Proper _ (E.eq==>Logic.eq) f),
  Proper (Equal==>Equal) (filter f).
 Proof.
 intros f Hf s s' Hs a. rewrite !filter_iff, Hs by auto; intuition.
 Qed.
 
+#[global]
 Instance filter_subset : forall `(Proper _ (E.eq==>Logic.eq) f),
  Proper (Subset==>Subset) (filter f).
 Proof.

--- a/theories/MSets/MSetGenTree.v
+++ b/theories/MSets/MSetGenTree.v
@@ -306,6 +306,7 @@ Definition IsOk := bst.
 
 Class Ok (s:tree) : Prop := ok : bst s.
 
+#[global]
 Instance bst_Ok s (Hs : bst s) : Ok s := { ok := Hs }.
 
 Fixpoint ltb_tree x s :=
@@ -424,6 +425,7 @@ Proof.
  intuition_in.
 Qed.
 
+#[global]
 Instance isok_Ok s : isok s = true -> Ok s | 10.
 Proof. intros; apply <- isok_iff; auto. Qed.
 
@@ -436,6 +438,7 @@ Proof.
 Qed.
 Local Hint Immediate In_1 : core.
 
+#[global]
 Instance In_compat : Proper (X.eq==>eq==>iff) InT.
 Proof.
 apply proper_sym_impl_iff_2; auto with *.
@@ -506,12 +509,14 @@ Proof.
  eauto.
 Qed.
 
+#[global]
 Instance lt_tree_compat : Proper (X.eq ==> Logic.eq ==> iff) lt_tree.
 Proof.
  apply proper_sym_impl_iff_2; auto.
  intros x x' Hx s s' Hs H y Hy. subst. setoid_rewrite <- Hx; auto.
 Qed.
 
+#[global]
 Instance gt_tree_compat : Proper (X.eq ==> Logic.eq ==> iff) gt_tree.
 Proof.
  apply proper_sym_impl_iff_2; auto.
@@ -542,6 +547,7 @@ Proof.
  intros x H. inversion H.
 Qed.
 
+#[global]
 Instance empty_ok : Ok empty.
 Proof.
  auto.
@@ -960,6 +966,7 @@ Qed.
 Module L := MSetInterface.MakeListOrdering X.
 
 Definition eq := Equal.
+#[global]
 Instance eq_equiv : Equivalence eq.
 Proof. firstorder. Qed.
 
@@ -976,6 +983,7 @@ Definition lt (s1 s2 : tree) : Prop :=
 
 Declare Equivalent Keys L.eq equivlistA.
 
+#[global]
 Instance lt_strorder : StrictOrder lt.
 Proof.
  split.
@@ -995,6 +1003,7 @@ Proof.
  rewrite H; auto.
 Qed.
 
+#[global]
 Instance lt_compat : Proper (eq==>eq==>iff) lt.
 Proof.
  intros s1 s2 E12 s3 s4 E34. split.

--- a/theories/MSets/MSetInterface.v
+++ b/theories/MSets/MSetInterface.v
@@ -132,6 +132,7 @@ Module Type WSetsOn (E : DecidableType).
 
   (** Logical predicates *)
   Parameter In : elt -> t -> Prop.
+#[global]
   Declare Instance In_compat : Proper (E.eq==>eq==>iff) In.
 
   Definition Equal s s' := forall a : elt, In a s <-> In a s'.
@@ -350,10 +351,12 @@ Module Type WRawSets (E : DecidableType).
   (** MS: 
     Dangerous instance, the [isok s = true] hypothesis cannot be discharged
    with typeclass resolution. Is it really an instance? *)
+#[global]
   Declare Instance isok_Ok s `(isok s = true) : Ok s | 10.
 
   (** Logical predicates *)
   Parameter In : elt -> t -> Prop.
+#[global]
   Declare Instance In_compat : Proper (E.eq==>eq==>iff) In.
 
   Definition Equal s s' := forall a : elt, In a s <-> In a s'.
@@ -366,19 +369,30 @@ Module Type WRawSets (E : DecidableType).
   Notation "s  [<=]  t" := (Subset s t) (at level 70, no associativity).
 
   Definition eq : t -> t -> Prop := Equal.
+#[global]
   Declare Instance eq_equiv : Equivalence eq.
 
   (** First, all operations are compatible with the well-formed predicate. *)
 
+#[global]
   Declare Instance empty_ok : Ok empty.
+#[global]
   Declare Instance add_ok s x `(Ok s) : Ok (add x s).
+#[global]
   Declare Instance remove_ok s x `(Ok s) : Ok (remove x s).
+#[global]
   Declare Instance singleton_ok x : Ok (singleton x).
+#[global]
   Declare Instance union_ok s s' `(Ok s, Ok s') : Ok (union s s').
+#[global]
   Declare Instance inter_ok s s' `(Ok s, Ok s') : Ok (inter s s').
+#[global]
   Declare Instance diff_ok s s' `(Ok s, Ok s') : Ok (diff s s').
+#[global]
   Declare Instance filter_ok s f `(Ok s) : Ok (filter f s).
+#[global]
   Declare Instance partition_ok1 s f `(Ok s) : Ok (fst (partition f s)).
+#[global]
   Declare Instance partition_ok2 s f `(Ok s) : Ok (snd (partition f s)).
 
   (** Now, the specifications, with constraints on the input sets. *)
@@ -473,11 +487,13 @@ Module WRaw2SetsOn (E:DecidableType)(M:WRawSets E) <: WSetsOn E.
  Definition partition (f : elt -> bool)(s : t) : t * t :=
    let p := M.partition f s in (Mkt (fst p), Mkt (snd p)).
 
+#[global]
  Instance In_compat : Proper (E.eq==>eq==>iff) In.
  Proof. repeat red. intros; apply M.In_compat; congruence. Qed.
 
  Definition eq : t -> t -> Prop := Equal.
 
+#[global]
  Instance eq_equiv : Equivalence eq.
  Proof. firstorder. Qed.
 
@@ -599,12 +615,14 @@ Module Raw2SetsOn (O:OrderedType)(M:RawSets O) <: SetsOn O.
   Definition lt (s s':t) := M.lt s s'.
 
   (** Specification of [lt] *)
+#[global]
   Instance lt_strorder : StrictOrder lt.
   Proof. constructor ; unfold lt; red.
     unfold complement. red. intros. apply (irreflexivity H).
     intros. transitivity y; auto.
   Qed.
 
+#[global]
   Instance lt_compat : Proper (eq==>eq==>iff) lt.
   Proof.
   repeat red. unfold eq, lt.
@@ -666,6 +684,7 @@ End Raw2Sets.
 Module Type IN (O:OrderedType).
  Parameter Inline t : Type.
  Parameter Inline In : O.t -> t -> Prop.
+#[global]
  Declare Instance In_compat : Proper (O.eq==>eq==>iff) In.
  Definition Equal s s' := forall x, In x s <-> In x s'.
  Definition Empty s := forall x, ~In x s.
@@ -676,9 +695,11 @@ Module MakeSetOrdering (O:OrderedType)(Import M:IN O).
 
  Definition eq : t -> t -> Prop := Equal.
 
+#[global]
  Instance eq_equiv : Equivalence eq.
  Proof. firstorder. Qed.
 
+#[global]
  Instance : Proper (O.eq==>eq==>iff) In.
  Proof.
  intros x x' Ex s s' Es. rewrite Ex. apply Es.
@@ -697,36 +718,42 @@ Module MakeSetOrdering (O:OrderedType)(Import M:IN O).
    ((In x s' /\ Below x s) \/
     (In x s  /\ exists y, In y s' /\ O.lt x y /\ EmptyBetween x y s')).
 
+#[global]
  Instance : Proper (O.eq==>eq==>eq==>iff) EquivBefore.
  Proof.
   unfold EquivBefore. intros x x' E s1 s1' E1 s2 s2' E2.
   setoid_rewrite E; setoid_rewrite E1; setoid_rewrite E2; intuition.
  Qed.
 
+#[global]
  Instance : Proper (O.eq==>eq==>iff) Below.
  Proof.
   unfold Below. intros x x' Ex s s' Es.
   setoid_rewrite Ex; setoid_rewrite Es; intuition.
  Qed.
 
+#[global]
  Instance : Proper (O.eq==>eq==>iff) Above.
  Proof.
   unfold Above. intros x x' Ex s s' Es.
   setoid_rewrite Ex; setoid_rewrite Es; intuition.
  Qed.
 
+#[global]
  Instance : Proper (O.eq==>O.eq==>eq==>iff) EmptyBetween.
  Proof.
   unfold EmptyBetween. intros x x' Ex y y' Ey s s' Es.
   setoid_rewrite Ex; setoid_rewrite Ey; setoid_rewrite Es; intuition.
  Qed.
 
+#[global]
  Instance lt_compat : Proper (eq==>eq==>iff) lt.
  Proof.
   unfold lt. intros s1 s1' E1 s2 s2' E2.
   setoid_rewrite E1; setoid_rewrite E2; intuition.
  Qed.
 
+#[global]
  Instance lt_strorder : StrictOrder lt.
  Proof.
   split.
@@ -877,6 +904,7 @@ Module MakeListOrdering (O:OrderedType).
 
  Definition eq s s' := forall x, In x s <-> In x s'.
 
+#[global]
  Instance eq_equiv : Equivalence eq := _.
 
  Inductive lt_list : t -> t -> Prop :=
@@ -892,6 +920,7 @@ Module MakeListOrdering (O:OrderedType).
  #[global]
  Hint Unfold lt : core.
 
+ #[global]
  Instance lt_strorder : StrictOrder lt.
  Proof.
  split.
@@ -915,6 +944,7 @@ Module MakeListOrdering (O:OrderedType).
  constructor 3; auto. transitivity y; auto. unfold lt in *; auto.
  Qed.
 
+#[global]
  Instance lt_compat' :
   Proper (eqlistA O.eq==>eqlistA O.eq==>iff) lt.
  Proof.

--- a/theories/MSets/MSetList.v
+++ b/theories/MSets/MSetList.v
@@ -785,6 +785,7 @@ Module MakeRaw (X: OrderedType) <: RawSets X.
   End ForNotations.
 
   Definition In := InA X.eq.
+#[global]
   Instance In_compat : Proper (X.eq==>eq==> iff) In.
   Proof. repeat red; intros; rewrite H, H0; auto. Qed.
 
@@ -794,6 +795,7 @@ Module MakeRaw (X: OrderedType) <: RawSets X.
   Definition lt l1 l2 :=
     exists l1' l2', Ok l1' /\ Ok l2' /\ eq l1 l1' /\ eq l2 l2' /\ L.lt l1' l2'.
 
+#[global]
   Instance lt_strorder : StrictOrder lt.
   Proof.
   split.
@@ -816,6 +818,7 @@ Module MakeRaw (X: OrderedType) <: RawSets X.
   rewrite H; auto.
   Qed.
 
+#[global]
   Instance lt_compat : Proper (eq==>eq==>iff) lt.
   Proof.
   intros s1 s2 E12 s3 s4 E34. split.

--- a/theories/MSets/MSetPositive.v
+++ b/theories/MSets/MSetPositive.v
@@ -306,6 +306,7 @@ Module PositiveSet <: S with Module E:=PositiveOrderedTypeBits.
 
   (** Specification of [In] *)
 
+#[global]
   Instance In_compat : Proper (E.eq==>Logic.eq==>iff) In.
   Proof.
    intros s s' Hs x x' Hx. rewrite Hs, Hx; intuition.
@@ -599,6 +600,7 @@ Module PositiveSet <: S with Module E:=PositiveOrderedTypeBits.
 
   End lt_spec.
 
+#[global]
   Instance lt_strorder : StrictOrder lt.
   Proof.
    unfold lt. split.
@@ -617,6 +619,7 @@ Module PositiveSet <: S with Module E:=PositiveOrderedTypeBits.
    assert (C:=ct_compare x x' y). rewrite Hx in C. inversion C; auto.
   Qed.
 
+#[global]
   Instance compare_compat : Proper (eq==>eq==>Logic.eq) compare.
   Proof.
    intros x x' Hx y y' Hy. rewrite Hx.

--- a/theories/MSets/MSetProperties.v
+++ b/theories/MSets/MSetProperties.v
@@ -773,6 +773,7 @@ Module WPropertiesOn (Import E : DecidableType)(M : WSetsOn E).
    eauto with set relations.
   Qed.
 
+#[global]
   Instance cardinal_m : Proper (Equal==>Logic.eq) cardinal.
   Proof.
   exact Equal_cardinal.
@@ -962,11 +963,13 @@ Module OrdProperties (M:Sets).
    destruct E.compare; intuition; try discriminate.
   Qed.
 
+#[global]
   Instance gtb_compat x : Proper (E.eq==>Logic.eq) (gtb x).
   Proof.
    intros a b H. unfold gtb. rewrite H; auto.
   Qed.
 
+#[global]
   Instance leb_compat x : Proper (E.eq==>Logic.eq) (leb x).
   Proof.
    intros a b H; unfold leb. rewrite H; auto.

--- a/theories/MSets/MSetRBT.v
+++ b/theories/MSets/MSetRBT.v
@@ -465,6 +465,7 @@ Proof.
  unfold singleton; intuition_in.
 Qed.
 
+#[global]
 Instance singleton_ok x : Ok (singleton x).
 Proof.
  unfold singleton; auto.
@@ -482,11 +483,13 @@ Proof.
  destruct s; simpl; intuition_in.
 Qed.
 
+#[global]
 Instance makeBlack_ok s `{Ok s} : Ok (makeBlack s).
 Proof.
  destruct s; simpl; ok.
 Qed.
 
+#[global]
 Instance makeRed_ok s `{Ok s} : Ok (makeRed s).
 Proof.
  destruct s; simpl; ok.
@@ -621,6 +624,7 @@ Proof.
  case lbal_match; intuition_in.
 Qed.
 
+#[global]
 Instance lbal_ok l x r `(Ok l, Ok r, lt_tree x l, gt_tree x r) :
  Ok (lbal l x r).
 Proof.
@@ -633,6 +637,7 @@ Proof.
  case rbal_match; intuition_in.
 Qed.
 
+#[global]
 Instance rbal_ok l x r `(Ok l, Ok r, lt_tree x l, gt_tree x r) :
  Ok (rbal l x r).
 Proof.
@@ -645,6 +650,7 @@ Proof.
  case rbal'_match; intuition_in.
 Qed.
 
+#[global]
 Instance rbal'_ok l x r `(Ok l, Ok r, lt_tree x l, gt_tree x r) :
  Ok (rbal' l x r).
 Proof.
@@ -672,6 +678,7 @@ Proof.
 Qed.
 Global Hint Rewrite ins_spec : rb.
 
+#[global]
 Instance ins_ok s x `{Ok s} : Ok (ins x s).
 Proof.
  induct s x; auto; descolor;
@@ -693,6 +700,7 @@ Proof.
  apply add_spec'.
 Qed.
 
+#[global]
 Instance add_ok s x `{Ok s} : Ok (add x s).
 Proof.
  unfold add; auto_tc.
@@ -712,6 +720,7 @@ Proof.
    * autorew. intuition_in.
 Qed.
 
+#[global]
 Instance lbalS_ok l x r :
  forall `(Ok l, Ok r, lt_tree x l, gt_tree x r), Ok (lbalS l x r).
 Proof.
@@ -739,6 +748,7 @@ Proof.
    * autorew. intuition_in.
 Qed.
 
+#[global]
 Instance rbalS_ok l x r :
  forall `(Ok l, Ok r, lt_tree x l, gt_tree x r), Ok (rbalS l x r).
 Proof.
@@ -863,6 +873,7 @@ Qed.
 
 Global Hint Rewrite del_spec : rb.
 
+#[global]
 Instance del_ok s x `{Ok s} : Ok (del x s).
 Proof.
 induct s x.
@@ -884,6 +895,7 @@ Qed.
 
 Global Hint Rewrite remove_spec : rb.
 
+#[global]
 Instance remove_ok s x `{Ok s} : Ok (remove x s).
 Proof.
 unfold remove; auto_tc.
@@ -1078,6 +1090,7 @@ Proof.
   now auto_tc.
 Qed.
 
+#[global]
 Instance filter_ok s f `(Ok s) : Ok (filter f s).
 Proof.
  apply elements_sort_ok.
@@ -1114,9 +1127,11 @@ Lemma partition_spec2 s f :
  Equal (snd (partition f s)) (filter (fun x => negb (f x)) s).
 Proof. now rewrite partition_spec. Qed.
 
+#[global]
 Instance partition_ok1 s f `(Ok s) : Ok (fst (partition f s)).
 Proof. rewrite partition_spec; now apply filter_ok. Qed.
 
+#[global]
 Instance partition_ok2 s f `(Ok s) : Ok (snd (partition f s)).
 Proof. rewrite partition_spec; now apply filter_ok. Qed.
 
@@ -1214,12 +1229,14 @@ Proof.
    * apply IH1. eapply INV_sym, INV_lt; eauto. now apply INV_sym.
 Qed.
 
+#[global]
 Instance linear_union_ok s1 s2 `(Ok s1, Ok s2) :
  Ok (linear_union s1 s2).
 Proof.
  unfold linear_union. now apply treeify_ok, union_list_ok, INV_init.
 Qed.
 
+#[global]
 Instance fold_add_ok s1 s2 `(Ok s1, Ok s2) :
  Ok (fold add s1 s2).
 Proof.
@@ -1228,6 +1245,7 @@ Proof.
  induction (rev (elements s1)); simpl; unfold flip in *; auto_tc.
 Qed.
 
+#[global]
 Instance union_ok s1 s2 `(Ok s1, Ok s2) : Ok (union s1 s2).
 Proof.
  unfold union. destruct compare_height; auto_tc.
@@ -1299,12 +1317,14 @@ Proof.
    * apply IH1. eapply INV_drop; eauto.
 Qed.
 
+#[global]
 Instance linear_inter_ok s1 s2 `(Ok s1, Ok s2) :
  Ok (linear_inter s1 s2).
 Proof.
  unfold linear_inter. now apply treeify_ok, inter_list_ok, INV_init.
 Qed.
 
+#[global]
 Instance inter_ok s1 s2 `(Ok s1, Ok s2) : Ok (inter s1 s2).
 Proof.
  unfold inter. destruct compare_height; auto_tc.
@@ -1374,12 +1394,14 @@ Proof.
    * apply IH1. eapply INV_sym, INV_lt; eauto. now apply INV_sym.
 Qed.
 
+#[global]
 Instance diff_inter_ok s1 s2 `(Ok s1, Ok s2) :
  Ok (linear_diff s1 s2).
 Proof.
  unfold linear_inter. now apply treeify_ok, diff_list_ok, INV_init.
 Qed.
 
+#[global]
 Instance fold_remove_ok s1 s2 `(Ok s2) :
  Ok (fold remove s1 s2).
 Proof.
@@ -1388,6 +1410,7 @@ Proof.
  induction (rev (elements s1)); simpl; unfold flip in *; auto_tc.
 Qed.
 
+#[global]
 Instance diff_ok s1 s2 `(Ok s1, Ok s2) : Ok (diff s1 s2).
 Proof.
  unfold diff. destruct compare_height; auto_tc.
@@ -1712,6 +1735,7 @@ Proof.
  intros H. apply (ins_rr_rb x), ifred_or in H. intuition.
 Qed.
 
+#[global]
 Instance add_rb x s : Rbt s -> Rbt (add x s).
 Proof.
  intros (n,H). unfold add. now apply (makeBlack_rb n), ins_arb.
@@ -1775,6 +1799,7 @@ Proof.
     nonzero n. apply rbalS_rb; auto. }
 Qed.
 
+#[global]
 Instance remove_rb s x : Rbt s -> Rbt (remove x s).
 Proof.
  intros (n,H). unfold remove.
@@ -1851,6 +1876,7 @@ Qed.
 (** The black depth of [treeify l] is actually a log2, but
     we don't need to mention that. *)
 
+#[global]
 Instance treeify_rb l : Rbt (treeify l).
 Proof.
  unfold treeify.
@@ -1862,16 +1888,19 @@ Qed.
 
 (** ** Filtering *)
 
+#[global]
 Instance filter_rb f s : Rbt (filter f s).
 Proof.
  unfold filter; auto_tc.
 Qed.
 
+#[global]
 Instance partition_rb1 f s : Rbt (fst (partition f s)).
 Proof.
  unfold partition. destruct partition_aux. simpl. auto_tc.
 Qed.
 
+#[global]
 Instance partition_rb2 f s : Rbt (snd (partition f s)).
 Proof.
  unfold partition. destruct partition_aux. simpl. auto_tc.
@@ -1879,12 +1908,14 @@ Qed.
 
 (** ** Union, intersection, difference *)
 
+#[global]
 Instance fold_add_rb s1 s2 : Rbt s2 -> Rbt (fold add s1 s2).
 Proof.
  intros. rewrite fold_spec, <- fold_left_rev_right. unfold elt in *.
  induction (rev (elements s1)); simpl; unfold flip in *; auto_tc.
 Qed.
 
+#[global]
 Instance fold_remove_rb s1 s2 : Rbt s2 -> Rbt (fold remove s1 s2).
 Proof.
  intros. rewrite fold_spec, <- fold_left_rev_right. unfold elt in *.

--- a/theories/MSets/MSetWeakList.v
+++ b/theories/MSets/MSetWeakList.v
@@ -523,6 +523,7 @@ Module MakeRaw (X:DecidableType) <: WRawSets X.
 
   Definition In := InA X.eq.
   Definition eq := Equal.
+#[global]
   Instance eq_equiv : Equivalence eq := _.
 
 End MakeRaw.

--- a/theories/NArith/BinNat.v
+++ b/theories/NArith/BinNat.v
@@ -166,6 +166,7 @@ Qed.
 Definition recursion {A} : A -> (N -> A -> A) -> N -> A :=
   peano_rect (fun _ => A).
 
+#[global]
 Instance recursion_wd {A} (Aeq : relation A) :
  Proper (Aeq==>(Logic.eq==>Aeq==>Aeq)==>Logic.eq==>Aeq) recursion.
 Proof.

--- a/theories/NArith/Ndigits.v
+++ b/theories/NArith/Ndigits.v
@@ -211,6 +211,7 @@ Qed.
 
 Definition eqf (f g:nat -> bool) := forall n:nat, f n = g n.
 
+#[global]
 Program Instance eqf_equiv : Equivalence eqf.
 
 Local Infix "==" := eqf (at level 70, no associativity).

--- a/theories/Numbers/Cyclic/Abstract/CyclicAxioms.v
+++ b/theories/Numbers/Cyclic/Abstract/CyclicAxioms.v
@@ -326,7 +326,9 @@ End ZnZ.
 
 Module Type CyclicType.
  Parameter t : Set.
+#[global]
  Declare Instance ops : ZnZ.Ops t.
+#[global]
  Declare Instance specs : ZnZ.Specs ops.
 End CyclicType.
 

--- a/theories/Numbers/Cyclic/Abstract/NZCyclic.v
+++ b/theories/Numbers/Cyclic/Abstract/NZCyclic.v
@@ -58,6 +58,7 @@ Ltac zify :=
  autorewrite with cyclic.
 Ltac zcongruence := repeat red; intros; zify; congruence.
 
+#[global]
 Instance eq_equiv : Equivalence eq.
 Proof.
   split. 1-2: firstorder auto with crelations.
@@ -66,10 +67,15 @@ Qed.
 
 Local Obligation Tactic := zcongruence.
 
+#[global]
 Program Instance succ_wd : Proper (eq ==> eq) succ.
+#[global]
 Program Instance pred_wd : Proper (eq ==> eq) pred.
+#[global]
 Program Instance add_wd : Proper (eq ==> eq ==> eq) add.
+#[global]
 Program Instance sub_wd : Proper (eq ==> eq ==> eq) sub.
+#[global]
 Program Instance mul_wd : Proper (eq ==> eq ==> eq) mul.
 
 Theorem gt_wB_1 : 1 < wB.

--- a/theories/Numbers/Cyclic/Int31/Cyclic31.v
+++ b/theories/Numbers/Cyclic/Int31/Cyclic31.v
@@ -1119,6 +1119,7 @@ Section Basics.
 
 End Basics.
 
+#[global]
 Instance int31_ops : ZnZ.Ops int31 :=
 {
  digits      := 31%positive; (* number of digits *)

--- a/theories/Numbers/Cyclic/Int63/Cyclic63.v
+++ b/theories/Numbers/Cyclic/Int63/Cyclic63.v
@@ -57,6 +57,7 @@ Notation pos_mod_int := pos_mod.
 
 Import ZnZ.
 
+#[global]
 Instance int_ops : ZnZ.Ops int :=
 {|
  digits      := Pdigits; (* number of digits *)

--- a/theories/Numbers/Cyclic/ZModulo/ZModulo.v
+++ b/theories/Numbers/Cyclic/ZModulo/ZModulo.v
@@ -939,6 +939,8 @@ End PositiveNotOne.
 
 Module ZModuloCyclicType (P:PositiveNotOne) <: CyclicType.
  Definition t := Z.
+#[global]
  Instance ops : ZnZ.Ops t := zmod_ops P.p.
+#[global]
  Instance specs : ZnZ.Specs ops := zmod_specs P.not_one.
 End ZModuloCyclicType.

--- a/theories/Numbers/Integer/Abstract/ZAxioms.v
+++ b/theories/Numbers/Integer/Abstract/ZAxioms.v
@@ -35,6 +35,7 @@ End OppNotation.
 Module Type Opp' (T:Typ) := Opp T <+ OppNotation T.
 
 Module Type IsOpp (Import Z : NZAxiomsSig')(Import O : Opp' Z).
+#[global]
  Declare Instance opp_wd : Proper (eq==>eq) opp.
  Axiom opp_0 : - 0 == 0.
  Axiom opp_succ : forall n, - (S n) == P (- n).
@@ -98,7 +99,9 @@ End QuotRemNotation.
 Module Type QuotRem' (A : Typ) := QuotRem A <+ QuotRemNotation A.
 
 Module Type QuotRemSpec (Import A : ZAxiomsMiniSig')(Import B : QuotRem' A).
+#[global]
  Declare Instance quot_wd : Proper (eq==>eq==>eq) quot.
+#[global]
  Declare Instance rem_wd : Proper (eq==>eq==>eq) B.rem.
  Axiom quot_rem : forall a b, b ~= 0 -> a == b*(a÷b) + (a rem b).
  Axiom rem_bound_pos : forall a b, 0<=a -> 0<b -> 0 <= a rem b < b.

--- a/theories/Numbers/Integer/Abstract/ZBits.v
+++ b/theories/Numbers/Integer/Abstract/ZBits.v
@@ -53,6 +53,7 @@ Qed.
 Definition b2z (b:bool) := if b then 1 else 0.
 Local Coercion b2z : bool >-> t.
 
+#[global]
 Instance b2z_wd : Proper (Logic.eq ==> eq) b2z := _.
 
 Lemma exists_div2 a : exists a' (b:bool), a == 2*a' + b.
@@ -478,6 +479,7 @@ Qed.
 
 Definition eqf (f g:t -> bool) := forall n:t, f n = g n.
 
+#[global]
 Instance eqf_equiv : Equivalence eqf.
 Proof.
  split; congruence.
@@ -485,6 +487,7 @@ Qed.
 
 Local Infix "===" := eqf (at level 70, no associativity).
 
+#[global]
 Instance testbit_eqf : Proper (eq==>eqf) testbit.
 Proof.
  intros a a' Ha n. now rewrite Ha.
@@ -668,6 +671,7 @@ Qed.
 
 (** Shifts are morphisms *)
 
+#[global]
 Instance shiftr_wd : Proper (eq==>eq==>eq) shiftr.
 Proof.
  intros a a' Ha n n' Hn.
@@ -676,6 +680,7 @@ Proof.
  now rewrite 2 shiftr_div_pow2, Ha, Hn.
 Qed.
 
+#[global]
 Instance shiftl_wd : Proper (eq==>eq==>eq) shiftl.
 Proof.
  intros a a' Ha n n' Hn. now rewrite <- 2 shiftr_opp_r, Ha, Hn.
@@ -805,6 +810,7 @@ Proof.
  intros. rewrite div2_spec, shiftr_div_pow2. now nzsimpl. order'.
 Qed.
 
+#[global]
 Instance div2_wd : Proper (eq==>eq) div2.
 Proof.
  intros a a' Ha. now rewrite 2 div2_div, Ha.
@@ -819,21 +825,25 @@ Qed.
 (** Properties of [lxor] and others, directly deduced
     from properties of [xorb] and others. *)
 
+#[global]
 Instance lxor_wd : Proper (eq ==> eq ==> eq) lxor.
 Proof.
  intros a a' Ha b b' Hb. bitwise. now rewrite Ha, Hb.
 Qed.
 
+#[global]
 Instance land_wd : Proper (eq ==> eq ==> eq) land.
 Proof.
  intros a a' Ha b b' Hb. bitwise. now rewrite Ha, Hb.
 Qed.
 
+#[global]
 Instance lor_wd : Proper (eq ==> eq ==> eq) lor.
 Proof.
  intros a a' Ha b b' Hb. bitwise. now rewrite Ha, Hb.
 Qed.
 
+#[global]
 Instance ldiff_wd : Proper (eq ==> eq ==> eq) ldiff.
 Proof.
  intros a a' Ha b b' Hb. bitwise. now rewrite Ha, Hb.
@@ -1017,9 +1027,11 @@ Proof.
  intros. unfold clearbit. now rewrite shiftl_1_l.
 Qed.
 
+#[global]
 Instance setbit_wd : Proper (eq==>eq==>eq) setbit.
 Proof. unfold setbit. solve_proper. Qed.
 
+#[global]
 Instance clearbit_wd : Proper (eq==>eq==>eq) clearbit.
 Proof. unfold clearbit. solve_proper. Qed.
 
@@ -1159,6 +1171,7 @@ Qed.
 
 Definition lnot a := P (-a).
 
+#[global]
 Instance lnot_wd : Proper (eq==>eq) lnot.
 Proof. unfold lnot. solve_proper. Qed.
 
@@ -1297,6 +1310,7 @@ Qed.
 
 Definition ones n := P (1<<n).
 
+#[global]
 Instance ones_wd : Proper (eq==>eq) ones.
 Proof. unfold ones. solve_proper. Qed.
 

--- a/theories/Numbers/Integer/Abstract/ZGcd.v
+++ b/theories/Numbers/Integer/Abstract/ZGcd.v
@@ -145,6 +145,7 @@ Qed.
 
 Definition Bezout n m p := exists a b, a*n + b*m == p.
 
+#[global]
 Instance Bezout_wd : Proper (eq==>eq==>eq==>iff) Bezout.
 Proof.
  unfold Bezout. intros x x' Hx y y' Hy z z' Hz.

--- a/theories/Numbers/Integer/Abstract/ZLcm.v
+++ b/theories/Numbers/Integer/Abstract/ZLcm.v
@@ -212,6 +212,7 @@ Qed.
 
 Definition lcm a b := abs (a*(b/gcd a b)).
 
+#[global]
 Instance lcm_wd : Proper (eq==>eq==>eq) lcm.
 Proof. unfold lcm. solve_proper. Qed.
 

--- a/theories/Numbers/Integer/Abstract/ZSgnAbs.v
+++ b/theories/Numbers/Integer/Abstract/ZSgnAbs.v
@@ -58,6 +58,7 @@ Ltac destruct_max n :=
  destruct (le_ge_cases 0 n);
   [rewrite (abs_eq n) by auto | rewrite (abs_neq n) by auto].
 
+#[global]
 Instance abs_wd : Proper (eq==>eq) abs.
 Proof.
  intros x y EQ. destruct_max x.
@@ -247,6 +248,7 @@ Ltac destruct_sgn n :=
   rewrite (sgn_null n) by auto with relations|
   rewrite (sgn_neg n) by auto].
 
+#[global]
 Instance sgn_wd : Proper (eq==>eq) sgn.
 Proof.
  intros x y Hxy. destruct_sgn x.

--- a/theories/Numbers/Integer/NatPairs/ZNatPairs.v
+++ b/theories/Numbers/Integer/NatPairs/ZNatPairs.v
@@ -95,6 +95,7 @@ Local Open Scope ZScope.
 Lemma sub_add_opp : forall n m, Z.sub n m = Z.add n (Z.opp m).
 Proof. reflexivity. Qed.
 
+#[global]
 Instance eq_equiv : Equivalence Z.eq.
 Proof.
 split.
@@ -106,35 +107,41 @@ rewrite add_shuffle2, H1, add_shuffle1, H2.
 now rewrite add_shuffle1, (add_comm m1).
 Qed.
 
+#[global]
 Instance pair_wd : Proper (N.eq==>N.eq==>Z.eq) (@pair N.t N.t).
 Proof.
 intros n1 n2 H1 m1 m2 H2; unfold Z.eq; simpl; now rewrite H1, H2.
 Qed.
 
+#[global]
 Instance succ_wd : Proper (Z.eq ==> Z.eq) Z.succ.
 Proof.
 unfold Z.succ, Z.eq; intros n m H; simpl.
 do 2 rewrite add_succ_l; now rewrite H.
 Qed.
 
+#[global]
 Instance pred_wd : Proper (Z.eq ==> Z.eq) Z.pred.
 Proof.
 unfold Z.pred, Z.eq; intros n m H; simpl.
 do 2 rewrite add_succ_r; now rewrite H.
 Qed.
 
+#[global]
 Instance add_wd : Proper (Z.eq ==> Z.eq ==> Z.eq) Z.add.
 Proof.
 unfold Z.eq, Z.add; intros n1 m1 H1 n2 m2 H2; simpl.
 now rewrite add_shuffle1, H1, H2, add_shuffle1.
 Qed.
 
+#[global]
 Instance opp_wd : Proper (Z.eq ==> Z.eq) Z.opp.
 Proof.
 unfold Z.eq, Z.opp; intros (n1,n2) (m1,m2) H; simpl in *.
 now rewrite (add_comm n2), (add_comm m2).
 Qed.
 
+#[global]
 Instance sub_wd : Proper (Z.eq ==> Z.eq ==> Z.eq) Z.sub.
 Proof.
 intros n1 m1 H1 n2 m2 H2. rewrite 2 sub_add_opp. now do 2 f_equiv.
@@ -147,6 +154,7 @@ rewrite (add_comm (m1*n2)%N).
 do 2 f_equiv; apply mul_comm.
 Qed.
 
+#[global]
 Instance mul_wd : Proper (Z.eq ==> Z.eq ==> Z.eq) Z.mul.
 Proof.
 assert (forall n, Proper (Z.eq ==> Z.eq) (Z.mul n)).
@@ -302,6 +310,7 @@ Proof.
 intros. apply lt_nge.
 Qed.
 
+#[global]
 Instance lt_wd : Proper (Z.eq ==> Z.eq ==> iff) Z.lt.
 Proof.
 assert (forall n, Proper (Z.eq==>iff) (Z.lt n)).

--- a/theories/Numbers/NatInt/NZAxioms.v
+++ b/theories/Numbers/NatInt/NZAxioms.v
@@ -35,7 +35,9 @@ Module Type ZeroSuccPred' (T:Typ) :=
  ZeroSuccPred T <+ ZeroSuccPredNotation T.
 
 Module Type IsNZDomain (Import E:Eq')(Import NZ:ZeroSuccPred' E).
+#[global]
  Declare Instance succ_wd : Proper (eq ==> eq) S.
+#[global]
  Declare Instance pred_wd : Proper (eq ==> eq) P.
  Axiom pred_succ : forall n, P (S n) == n.
  Axiom bi_induction :
@@ -86,8 +88,11 @@ End AddSubMulNotation.
 Module Type AddSubMul' (T:Typ) := AddSubMul T <+ AddSubMulNotation T.
 
 Module Type IsAddSubMul (Import E:NZDomainSig')(Import NZ:AddSubMul' E).
+#[global]
  Declare Instance add_wd : Proper (eq ==> eq ==> eq) add.
+#[global]
  Declare Instance sub_wd : Proper (eq ==> eq ==> eq) sub.
+#[global]
  Declare Instance mul_wd : Proper (eq ==> eq ==> eq) mul.
  Axiom add_0_l : forall n, 0 + n == n.
  Axiom add_succ_l : forall n m, (S n) + m == S (n + m).
@@ -112,6 +117,7 @@ Module Type NZOrd' := NZDomainSig' <+ HasLt <+ HasLe <+
                       LtNotation <+ LeNotation <+ LtLeNotation.
 
 Module Type IsNZOrd (Import NZ : NZOrd').
+#[global]
  Declare Instance lt_wd : Proper (eq ==> eq ==> iff) lt.
  Axiom lt_eq_cases : forall n m, n <= m <-> n < m \/ n == m.
  Axiom lt_irrefl : forall n, ~ (n < n).

--- a/theories/Numbers/NatInt/NZBits.v
+++ b/theories/Numbers/NatInt/NZBits.v
@@ -29,6 +29,7 @@ Module Type Bits' (A:Typ) := Bits A <+ BitsNotation A.
 Module Type NZBitsSpec
  (Import A : NZOrdAxiomsSig')(Import B : Bits' A).
 
+#[global]
  Declare Instance testbit_wd : Proper (eq==>eq==>Logic.eq) testbit.
  Axiom testbit_odd_0 : forall a, (2*a+1).[0] = true.
  Axiom testbit_even_0 : forall a, (2*a).[0] = false.

--- a/theories/Numbers/NatInt/NZDiv.v
+++ b/theories/Numbers/NatInt/NZDiv.v
@@ -26,7 +26,9 @@ End DivModNotation.
 Module Type DivMod' (A : Typ) := DivMod A <+ DivModNotation A.
 
 Module Type NZDivSpec (Import A : NZOrdAxiomsSig')(Import B : DivMod' A).
+#[global]
  Declare Instance div_wd : Proper (eq==>eq==>eq) div.
+#[global]
  Declare Instance mod_wd : Proper (eq==>eq==>eq) modulo.
  Axiom div_mod : forall a b, b ~= 0 -> a == b*(a/b) + (a mod b).
  Axiom mod_bound_pos : forall a b, 0<=a -> 0<b -> 0 <= a mod b < b.

--- a/theories/Numbers/NatInt/NZDomain.v
+++ b/theories/Numbers/NatInt/NZDomain.v
@@ -18,6 +18,7 @@ Require Import NZBase NZOrder NZAddOrder Plus Minus.
 
 Local Notation "f ^ n" := (fun x => nat_rect _ x (fun _ => f) n).
 
+#[global]
 Instance nat_rect_wd n {A} (R:relation A) :
  Proper (R==>(R==>R)==>R) (fun x f => nat_rect (fun _ => _) x (fun _ => f) n).
 Proof.

--- a/theories/Numbers/NatInt/NZGcd.v
+++ b/theories/Numbers/NatInt/NZGcd.v
@@ -46,6 +46,7 @@ Module NZGcdProp
 
 (** Results concerning divisibility*)
 
+#[global]
 Instance divide_wd : Proper (eq==>eq==>iff) divide.
 Proof.
  unfold divide. intros x x' Hx y y' Hy.
@@ -107,7 +108,9 @@ Proof.
  now rewrite Hr, Hq, mul_assoc.
 Qed.
 
+#[global]
 Instance divide_reflexive : Reflexive divide | 5 := divide_refl.
+#[global]
 Instance divide_transitive : Transitive divide | 5 := divide_trans.
 
 (** Due to sign, no general antisymmetry result *)
@@ -202,6 +205,7 @@ Proof.
  - now apply gcd_greatest.
 Qed.
 
+#[global]
 Instance gcd_wd : Proper (eq==>eq==>eq) gcd.
 Proof.
  intros x x' Hx y y' Hy.

--- a/theories/Numbers/NatInt/NZLog.v
+++ b/theories/Numbers/NatInt/NZLog.v
@@ -77,6 +77,7 @@ Qed.
 
 (** Hence log2 is a morphism. *)
 
+#[global]
 Instance log2_wd : Proper (eq==>eq) log2.
 Proof.
  intros x x' Hx.
@@ -493,6 +494,7 @@ Proof.
  intros. apply log2_up_eqn0. order'.
 Qed.
 
+#[global]
 Instance log2_up_wd : Proper (eq==>eq) log2_up.
 Proof.
  assert (Proper (eq==>eq==>Logic.eq) compare).

--- a/theories/Numbers/NatInt/NZOrder.v
+++ b/theories/Numbers/NatInt/NZOrder.v
@@ -15,6 +15,7 @@ Require Import NZAxioms NZBase Decidable OrdersTac.
 Module Type NZOrderProp
  (Import NZ : NZOrdSig')(Import NZBase : NZBaseProp NZ).
 
+#[global]
 Instance le_wd : Proper (eq==>eq==>iff) le.
 Proof.
 intros n n' Hn m m' Hm. now rewrite <- !lt_succ_r, Hn, Hm.
@@ -131,12 +132,15 @@ Qed.
 
 (** Some type classes about order *)
 
+#[global]
 Instance lt_strorder : StrictOrder lt.
 Proof. split. - exact lt_irrefl. - exact lt_trans. Qed.
 
+#[global]
 Instance le_preorder : PreOrder le.
 Proof. split. - exact le_refl. - exact le_trans. Qed.
 
+#[global]
 Instance le_partialorder : PartialOrder _ le.
 Proof.
 intros x y. compute. split.

--- a/theories/Numbers/NatInt/NZParity.v
+++ b/theories/Numbers/NatInt/NZParity.v
@@ -27,17 +27,21 @@ Module Type NZParityProp
 
 (** Morphisms *)
 
+#[global]
 Instance Even_wd : Proper (eq==>iff) Even.
 Proof. unfold Even. solve_proper. Qed.
 
+#[global]
 Instance Odd_wd : Proper (eq==>iff) Odd.
 Proof. unfold Odd. solve_proper. Qed.
 
+#[global]
 Instance even_wd : Proper (eq==>Logic.eq) even.
 Proof.
  intros x x' EQ. rewrite eq_iff_eq_true, 2 even_spec. now f_equiv.
 Qed.
 
+#[global]
 Instance odd_wd : Proper (eq==>Logic.eq) odd.
 Proof.
  intros x x' EQ. rewrite eq_iff_eq_true, 2 odd_spec. now f_equiv.

--- a/theories/Numbers/NatInt/NZPow.v
+++ b/theories/Numbers/NatInt/NZPow.v
@@ -25,6 +25,7 @@ End PowNotation.
 Module Type Pow' (A : Typ) := Pow A <+ PowNotation A.
 
 Module Type NZPowSpec (Import A : NZOrdAxiomsSig')(Import B : Pow' A).
+#[global]
  Declare Instance pow_wd : Proper (eq==>eq==>eq) pow.
  Axiom pow_0_r : forall a, a^0 == 1.
  Axiom pow_succ_r : forall a b, 0<=b -> a^(succ b) == a * a^b.

--- a/theories/Numbers/NatInt/NZSqrt.v
+++ b/theories/Numbers/NatInt/NZSqrt.v
@@ -83,6 +83,7 @@ Qed.
 
 (** Hence sqrt is a morphism *)
 
+#[global]
 Instance sqrt_wd : Proper (eq==>eq) sqrt.
 Proof.
  intros x x' Hx.
@@ -436,6 +437,7 @@ Qed.
 
 (** [sqrt_up] is a morphism *)
 
+#[global]
 Instance sqrt_up_wd : Proper (eq==>eq) sqrt_up.
 Proof.
  assert (Proper (eq==>eq==>Logic.eq) compare).

--- a/theories/Numbers/Natural/Abstract/NAxioms.v
+++ b/theories/Numbers/Natural/Abstract/NAxioms.v
@@ -49,6 +49,7 @@ Module Type NAxiomsRec (Import NZ : NZDomainSig').
 
 Parameter Inline recursion : forall {A : Type}, A -> (t -> A -> A) -> t -> A.
 
+#[global]
 Declare Instance recursion_wd {A : Type} (Aeq : relation A) :
  Proper (Aeq ==> (eq==>Aeq==>Aeq) ==> eq ==> Aeq) recursion.
 

--- a/theories/Numbers/Natural/Abstract/NBits.v
+++ b/theories/Numbers/Natural/Abstract/NBits.v
@@ -50,6 +50,7 @@ Qed.
 Definition b2n (b:bool) := if b then 1 else 0.
 Local Coercion b2n : bool >-> t.
 
+#[global]
 Instance b2n_proper : Proper (Logic.eq ==> eq) b2n.
 Proof. solve_proper. Qed.
 
@@ -324,6 +325,7 @@ Qed.
 
 Definition eqf (f g:t -> bool) := forall n:t, f n = g n.
 
+#[global]
 Instance eqf_equiv : Equivalence eqf.
 Proof.
  split; congruence.
@@ -331,6 +333,7 @@ Qed.
 
 Local Infix "===" := eqf (at level 70, no associativity).
 
+#[global]
 Instance testbit_eqf : Proper (eq==>eqf) testbit.
 Proof.
  intros a a' Ha n. now rewrite Ha.
@@ -432,11 +435,13 @@ Proof.
  intros. now rewrite shiftl_mul_pow2, mul_pow2_bits_add.
 Qed.
 
+#[global]
 Instance shiftr_wd : Proper (eq==>eq==>eq) shiftr.
 Proof.
  intros a a' Ha b b' Hb. now rewrite 2 shiftr_div_pow2, Ha, Hb.
 Qed.
 
+#[global]
 Instance shiftl_wd : Proper (eq==>eq==>eq) shiftl.
 Proof.
  intros a a' Ha b b' Hb. now rewrite 2 shiftl_mul_pow2, Ha, Hb.
@@ -534,6 +539,7 @@ Proof.
  intros. rewrite div2_spec, shiftr_div_pow2. now nzsimpl.
 Qed.
 
+#[global]
 Instance div2_wd : Proper (eq==>eq) div2.
 Proof.
  intros a a' Ha. now rewrite 2 div2_div, Ha.
@@ -548,21 +554,25 @@ Qed.
 (** Properties of [lxor] and others, directly deduced
     from properties of [xorb] and others. *)
 
+#[global]
 Instance lxor_wd : Proper (eq ==> eq ==> eq) lxor.
 Proof.
  intros a a' Ha b b' Hb. bitwise. now rewrite Ha, Hb.
 Qed.
 
+#[global]
 Instance land_wd : Proper (eq ==> eq ==> eq) land.
 Proof.
  intros a a' Ha b b' Hb. bitwise. now rewrite Ha, Hb.
 Qed.
 
+#[global]
 Instance lor_wd : Proper (eq ==> eq ==> eq) lor.
 Proof.
  intros a a' Ha b b' Hb. bitwise. now rewrite Ha, Hb.
 Qed.
 
+#[global]
 Instance ldiff_wd : Proper (eq ==> eq ==> eq) ldiff.
 Proof.
  intros a a' Ha b b' Hb. bitwise. now rewrite Ha, Hb.
@@ -746,9 +756,11 @@ Proof.
  intros. unfold clearbit. now rewrite shiftl_1_l.
 Qed.
 
+#[global]
 Instance setbit_wd : Proper (eq==>eq==>eq) setbit.
 Proof. unfold setbit. solve_proper. Qed.
 
+#[global]
 Instance clearbit_wd : Proper (eq==>eq==>eq) clearbit.
 Proof. unfold clearbit. solve_proper. Qed.
 
@@ -898,9 +910,11 @@ Definition ones n := P (1 << n).
 
 Definition lnot a n := lxor a (ones n).
 
+#[global]
 Instance ones_wd : Proper (eq==>eq) ones.
 Proof. unfold ones. solve_proper. Qed.
 
+#[global]
 Instance lnot_wd : Proper (eq==>eq==>eq) lnot.
 Proof. unfold lnot. solve_proper. Qed.
 

--- a/theories/Numbers/Natural/Abstract/NDefOps.v
+++ b/theories/Numbers/Natural/Abstract/NDefOps.v
@@ -27,6 +27,7 @@ Definition if_zero (A : Type) (a b : A) (n : N.t) : A :=
 
 Arguments if_zero [A] a b n.
 
+#[global]
 Instance if_zero_wd (A : Type) :
  Proper (Logic.eq ==> Logic.eq ==> N.eq ==> Logic.eq) (@if_zero A).
 Proof.
@@ -53,6 +54,7 @@ Definition def_add (x y : N.t) := recursion y (fun _ => S) x.
 
 Local Infix "+++" := def_add (at level 50, left associativity).
 
+#[global]
 Instance def_add_wd : Proper (N.eq ==> N.eq ==> N.eq) def_add.
 Proof.
 unfold def_add. f_equiv'.
@@ -83,6 +85,7 @@ Definition def_mul (x y : N.t) := recursion 0 (fun _ p => p +++ x) y.
 
 Local Infix "**" := def_mul (at level 40, left associativity).
 
+#[global]
 Instance def_mul_wd : Proper (N.eq ==> N.eq ==> N.eq) def_mul.
 Proof.
 unfold def_mul. (* TODO : solve_proper SLOW + BUG *)
@@ -119,6 +122,7 @@ recursion
 
 Local Infix "<<" := ltb (at level 70, no associativity).
 
+#[global]
 Instance ltb_wd : Proper (N.eq ==> N.eq ==> Logic.eq) ltb.
 Proof.
 unfold ltb. f_equiv'.
@@ -179,6 +183,7 @@ Qed.
 
 Definition even (x : N.t) := recursion true (fun _ p => negb p) x.
 
+#[global]
 Instance even_wd : Proper (N.eq==>Logic.eq) even.
 Proof.
 unfold even. f_equiv'.
@@ -204,6 +209,7 @@ Definition half_aux (x : N.t) : N.t * N.t :=
 
 Definition half (x : N.t) := snd (half_aux x).
 
+#[global]
 Instance half_aux_wd : Proper (N.eq ==> N.eq*N.eq) half_aux.
 Proof.
 intros x x' Hx. unfold half_aux.
@@ -212,6 +218,7 @@ intros y y' Hy (u,v) (u',v') (Hu,Hv). compute in *.
 rewrite Hu, Hv; auto with *.
 Qed.
 
+#[global]
 Instance half_wd : Proper (N.eq==>N.eq) half.
 Proof.
 unfold half. f_equiv'.
@@ -329,6 +336,7 @@ Definition pow (n m : N.t) := recursion 1 (fun _ r => n*r) m.
 
 Local Infix "^^" := pow (at level 30, right associativity).
 
+#[global]
 Instance pow_wd : Proper (N.eq==>N.eq==>N.eq) pow.
 Proof.
 unfold pow. f_equiv'.
@@ -355,6 +363,7 @@ strong_rec 0
               else S (g (half x)))
            x.
 
+#[global]
 Instance log_prewd :
  Proper ((N.eq==>N.eq)==>N.eq==>N.eq)
    (fun g x => if x<<2 then 0 else S (g (half x))).
@@ -365,6 +374,7 @@ destruct (n' << 2); auto with *.
 f_equiv. apply Hg. now f_equiv.
 Qed.
 
+#[global]
 Instance log_wd : Proper (N.eq==>N.eq) log.
 Proof.
 intros x x' Exx'. unfold log.

--- a/theories/Numbers/Natural/Abstract/NGcd.v
+++ b/theories/Numbers/Natural/Abstract/NGcd.v
@@ -76,6 +76,7 @@ Qed.
 
 Definition Bezout n m p := exists a b, a*n == p + b*m.
 
+#[global]
 Instance Bezout_wd : Proper (eq==>eq==>eq==>iff) Bezout.
 Proof.
  unfold Bezout. intros x x' Hx y y' Hy z z' Hz.

--- a/theories/Numbers/Natural/Abstract/NIso.v
+++ b/theories/Numbers/Natural/Abstract/NIso.v
@@ -22,6 +22,7 @@ Definition homomorphism (f : N1.t -> N2.t) : Prop :=
 Definition natural_isomorphism : N1.t -> N2.t :=
   N1.recursion N2.zero (fun (n : N1.t) (p : N2.t) => N2.succ p).
 
+#[global]
 Instance natural_isomorphism_wd : Proper (N1.eq ==> N2.eq) natural_isomorphism.
 Proof.
 unfold natural_isomorphism.

--- a/theories/Numbers/Natural/Abstract/NLcm.v
+++ b/theories/Numbers/Natural/Abstract/NLcm.v
@@ -96,6 +96,7 @@ Qed.
 
 Definition lcm a b := a*(b/gcd a b).
 
+#[global]
 Instance lcm_wd : Proper (eq==>eq==>eq) lcm.
 Proof. unfold lcm. solve_proper. Qed.
 

--- a/theories/Numbers/Natural/Abstract/NSub.v
+++ b/theories/Numbers/Natural/Abstract/NSub.v
@@ -278,12 +278,14 @@ intro H. exists (m-S n). rewrite add_succ_l, <- add_succ_r.
 apply sub_add. now rewrite le_succ_l.
 Qed.
 
+#[global]
 Instance le_alt_wd : Proper (eq==>eq==>iff) le_alt.
 Proof.
  intros x x' Hx y y' Hy; unfold le_alt.
  setoid_rewrite Hx. setoid_rewrite Hy. auto with *.
 Qed.
 
+#[global]
 Instance lt_alt_wd : Proper (eq==>eq==>iff) lt_alt.
 Proof.
  intros x x' Hx y y' Hy; unfold lt_alt.

--- a/theories/PArith/BinPos.v
+++ b/theories/PArith/BinPos.v
@@ -1100,9 +1100,11 @@ Proof.
   apply lt_succ_r, le_lteq in H. destruct H as [H|H]; subst; auto.
 Qed.
 
+#[global]
 Instance lt_strorder : StrictOrder lt.
 Proof. split. exact lt_irrefl. exact lt_trans. Qed.
 
+#[global]
 Instance lt_compat : Proper (Logic.eq==>Logic.eq==>iff) lt.
 Proof. repeat red. intros. subst; auto. Qed.
 
@@ -1148,9 +1150,11 @@ Proof.
  elim (lt_irrefl p). now transitivity q.
 Qed.
 
+#[global]
 Instance le_preorder : PreOrder le.
 Proof. split. exact le_refl. exact le_trans. Qed.
 
+#[global]
 Instance le_partorder : PartialOrder Logic.eq le.
 Proof.
  intros x y. change (x=y <-> x <= y <= x).

--- a/theories/QArith/QArith_base.v
+++ b/theories/QArith/QArith_base.v
@@ -136,6 +136,7 @@ Hint Resolve Qeq_refl Qeq_trans : qarith.
 
 (** In a word, [Qeq] is a setoid equality. *)
 
+#[global]
 Instance Q_Setoid : Equivalence Qeq.
 Proof. split; red; eauto with qarith. Qed.
 
@@ -436,6 +437,7 @@ Qed.
 
 (** * Setoid compatibility results *)
 
+#[global]
 Instance Qplus_comp : Proper (Qeq==>Qeq==>Qeq) Qplus.
 Proof.
   unfold Qeq, Qplus; simpl.
@@ -450,6 +452,7 @@ Proof.
   Close Scope Z_scope.
 Qed.
 
+#[global]
 Instance Qopp_comp : Proper (Qeq==>Qeq) Qopp.
 Proof.
   unfold Qeq, Qopp; simpl.
@@ -460,12 +463,14 @@ Proof.
   Close Scope Z_scope.
 Qed.
 
+#[global]
 Instance Qminus_comp : Proper (Qeq==>Qeq==>Qeq) Qminus.
 Proof.
   intros x x' Hx y y' Hy.
   unfold Qminus. rewrite Hx, Hy; auto with qarith.
 Qed.
 
+#[global]
 Instance Qmult_comp : Proper (Qeq==>Qeq==>Qeq) Qmult.
 Proof.
   unfold Qeq; simpl.
@@ -480,6 +485,7 @@ Proof.
   Close Scope Z_scope.
 Qed.
 
+#[global]
 Instance Qinv_comp : Proper (Qeq==>Qeq) Qinv.
 Proof.
   unfold Qeq, Qinv; simpl.
@@ -494,12 +500,14 @@ Proof.
   Close Scope Z_scope.
 Qed.
 
+#[global]
 Instance Qdiv_comp : Proper (Qeq==>Qeq==>Qeq) Qdiv.
 Proof.
   intros x x' Hx y y' Hy; unfold Qdiv.
   rewrite Hx, Hy; auto with qarith.
 Qed.
 
+#[global]
 Instance Qcompare_comp : Proper (Qeq==>Qeq==>eq) Qcompare.
 Proof.
   unfold Qeq, Qcompare.
@@ -517,22 +525,26 @@ Proof.
   Close Scope Z_scope.
 Qed.
 
+#[global]
 Instance Qle_comp : Proper (Qeq==>Qeq==>iff) Qle.
 Proof.
   intros p q H r s H'. rewrite 2 Qle_alt, H, H'; auto with *.
 Qed.
 
+#[global]
 Instance Qlt_compat : Proper (Qeq==>Qeq==>iff) Qlt.
 Proof.
   intros p q H r s H'. rewrite 2 Qlt_alt, H, H'; auto with *.
 Qed.
 
+#[global]
 Instance Qeqb_comp : Proper (Qeq==>Qeq==>eq) Qeq_bool.
 Proof.
  intros p q H r s H'; apply eq_true_iff_eq.
  rewrite 2 Qeq_bool_iff, H, H'; split; auto with qarith.
 Qed.
 
+#[global]
 Instance Qleb_comp : Proper (Qeq==>Qeq==>eq) Qle_bool.
 Proof.
  intros p q H r s H'; apply eq_true_iff_eq.
@@ -1186,6 +1198,7 @@ Qed.
 Definition Qpower_positive : Q -> positive -> Q :=
  pow_pos Qmult.
 
+#[global]
 Instance Qpower_positive_comp : Proper (Qeq==>eq==>Qeq) Qpower_positive.
 Proof.
 intros x x' Hx y y' Hy. rewrite <-Hy; clear y' Hy.
@@ -1207,6 +1220,7 @@ Notation " q ^ z " := (Qpower q z) : Q_scope.
 
 Register Qpower as  rat.Q.Qpower.
 
+#[global]
 Instance Qpower_comp : Proper (Qeq==>eq==>Qeq) Qpower.
 Proof.
 intros x x' Hx y y' Hy. rewrite <- Hy; clear y' Hy.

--- a/theories/QArith/QOrderedType.v
+++ b/theories/QArith/QOrderedType.v
@@ -39,9 +39,11 @@ Module Q_as_OT <: OrderedTypeFull.
  Definition le := Qle.
  Definition compare := Qcompare.
 
+#[global]
  Instance lt_strorder : StrictOrder Qlt.
  Proof. split; [ exact Qlt_irrefl | exact Qlt_trans ]. Qed.
 
+#[global]
  Instance lt_compat : Proper (Qeq==>Qeq==>iff) Qlt.
  Proof. auto with *. Qed.
 

--- a/theories/Reals/Abstract/ConstructiveAbs.v
+++ b/theories/Reals/Abstract/ConstructiveAbs.v
@@ -22,6 +22,7 @@ Local Open Scope ConstructiveReals.
     WARNING: this file is experimental and likely to change in future releases.
 *)
 
+#[global]
 Instance CRabs_morph
   : forall {R : ConstructiveReals},
     CMorphisms.Proper

--- a/theories/Reals/Abstract/ConstructiveLimits.v
+++ b/theories/Reals/Abstract/ConstructiveLimits.v
@@ -176,6 +176,7 @@ Proof.
   exists n. intros. unfold CRminus. rewrite <- H0. apply H, H1.
 Qed.
 
+#[global]
 Instance CR_cv_morph
   : forall {R : ConstructiveReals} (un : nat -> CRcarrier R), CMorphisms.Proper
       (CMorphisms.respectful (CReq R) CRelationClasses.iffT) (CR_cv R un).

--- a/theories/Reals/Abstract/ConstructiveMinMax.v
+++ b/theories/Reals/Abstract/ConstructiveMinMax.v
@@ -65,6 +65,7 @@ Proof.
   rewrite H, H0. reflexivity.
 Qed.
 
+#[global]
 Instance CRmin_morphT
   : forall {R : ConstructiveReals},
     CMorphisms.Proper
@@ -356,6 +357,7 @@ Proof.
   rewrite H, H0. reflexivity.
 Qed.
 
+#[global]
 Instance CRmax_morphT
   : forall {R : ConstructiveReals},
     CMorphisms.Proper

--- a/theories/Reals/Abstract/ConstructiveReals.v
+++ b/theories/Reals/Abstract/ConstructiveReals.v
@@ -320,12 +320,14 @@ Add Parametric Relation {R : ConstructiveReals} : (CRcarrier R) (CReq R)
     transitivity proved by (CReq_trans)
       as CReq_rel.
 
+#[global]
 Instance CReq_relT : forall {R : ConstructiveReals},
     CRelationClasses.Equivalence (CReq R).
 Proof.
   split. exact CReq_refl. exact CReq_sym. exact CReq_trans.
 Qed.
 
+#[global]
 Instance CRlt_morph
   : forall {R : ConstructiveReals}, CMorphisms.Proper
       (CMorphisms.respectful (CReq R) (CMorphisms.respectful (CReq R) CRelationClasses.iffT)) (CRlt R).
@@ -534,6 +536,7 @@ Proof.
   apply (CRisRingExt R).
 Qed.
 
+#[global]
 Instance CRplus_morph_T
   : forall {R : ConstructiveReals}, CMorphisms.Proper
       (CMorphisms.respectful (CReq R) (CMorphisms.respectful (CReq R) (CReq R))) (CRplus R).
@@ -541,6 +544,7 @@ Proof.
   intros R x y H z t H1. apply CRplus_morph; assumption.
 Qed.
 
+#[global]
 Instance CRmult_morph_T
   : forall {R : ConstructiveReals}, CMorphisms.Proper
       (CMorphisms.respectful (CReq R) (CMorphisms.respectful (CReq R) (CReq R))) (CRmult R).
@@ -548,6 +552,7 @@ Proof.
   intros R x y H z t H1. apply CRmult_morph; assumption.
 Qed.
 
+#[global]
 Instance CRopp_morph_T
   : forall {R : ConstructiveReals}, CMorphisms.Proper
       (CMorphisms.respectful (CReq R) (CReq R)) (CRopp R).
@@ -562,6 +567,7 @@ Proof.
   intros. unfold CRminus. rewrite H,H0. reflexivity.
 Qed.
 
+#[global]
 Instance CRminus_morph_T
   : forall {R : ConstructiveReals}, CMorphisms.Proper
       (CMorphisms.respectful (CReq R) (CMorphisms.respectful (CReq R) (CReq R))) (CRminus R).
@@ -919,6 +925,7 @@ Proof.
   exfalso. apply (CR_of_Q_lt R r q) in q0. contradiction. exact q0.
 Qed.
 
+#[global]
 Instance CR_of_Q_morph_T
   : forall {R : ConstructiveReals}, CMorphisms.Proper
       (CMorphisms.respectful Qeq (CReq R)) (CR_of_Q R).
@@ -1127,6 +1134,7 @@ Proof.
   right. exact (CRmult_lt_reg_r r _ _ H c).
 Qed.
 
+#[global]
 Instance CRapart_morph
   : forall {R : ConstructiveReals}, CMorphisms.Proper
       (CMorphisms.respectful (CReq R) (CMorphisms.respectful (CReq R) CRelationClasses.iffT)) (CRapart R).

--- a/theories/Reals/Cauchy/ConstructiveCauchyReals.v
+++ b/theories/Reals/Cauchy/ConstructiveCauchyReals.v
@@ -363,6 +363,7 @@ Add Parametric Relation : CReal CRealEq
     transitivity proved by CRealEq_trans
       as CRealEq_rel.
 
+#[global]
 Instance CRealEq_relT : CRelationClasses.Equivalence CRealEq.
 Proof.
   split.
@@ -371,6 +372,7 @@ Proof.
   - exact CRealEq_trans.
 Qed.
 
+#[global]
 Instance CRealLt_morph
   : CMorphisms.Proper
       (CMorphisms.respectful CRealEq (CMorphisms.respectful CRealEq CRelationClasses.iffT)) CRealLt.
@@ -391,6 +393,7 @@ Proof.
         assumption. assumption. contradiction.
 Qed.
 
+#[global]
 Instance CRealGt_morph
   : CMorphisms.Proper
       (CMorphisms.respectful CRealEq (CMorphisms.respectful CRealEq CRelationClasses.iffT)) CRealGt.
@@ -398,6 +401,7 @@ Proof.
   intros x y Hxeqy x0 y0 Hx0eqy0. apply CRealLt_morph; assumption.
 Qed.
 
+#[global]
 Instance CReal_appart_morph
   : CMorphisms.Proper
       (CMorphisms.respectful CRealEq (CMorphisms.respectful CRealEq CRelationClasses.iffT)) CReal_appart.
@@ -556,6 +560,7 @@ Proof.
   all: assert(2^n>0)%Q by (apply Qpower_pos_lt; lra); lra.
 Qed.
 
+#[global]
 Instance inject_Q_morph_T
   : CMorphisms.Proper
       (CMorphisms.respectful Qeq CRealEq) inject_Q.
@@ -841,6 +846,7 @@ Proof.
   - apply CReal_plus_proper_r. apply H.
 Qed.
 
+#[global]
 Instance CReal_plus_morph_T
   : CMorphisms.Proper
       (CMorphisms.respectful CRealEq (CMorphisms.respectful CRealEq CRealEq)) CReal_plus.

--- a/theories/Reals/Cauchy/ConstructiveCauchyRealsMult.v
+++ b/theories/Reals/Cauchy/ConstructiveCauchyRealsMult.v
@@ -466,6 +466,7 @@ Proof.
   apply CReal_isRingExt.
 Qed.
 
+#[global]
 Instance CReal_mult_morph_T
   : CMorphisms.Proper
       (CMorphisms.respectful CRealEq (CMorphisms.respectful CRealEq CRealEq)) CReal_mult.
@@ -480,6 +481,7 @@ Proof.
   apply (Ropp_ext CReal_isRingExt).
 Qed.
 
+#[global]
 Instance CReal_opp_morph_T
   : CMorphisms.Proper
       (CMorphisms.respectful CRealEq CRealEq) CReal_opp.
@@ -494,6 +496,7 @@ Proof.
   intros. unfold CReal_minus. rewrite H,H0. reflexivity.
 Qed.
 
+#[global]
 Instance CReal_minus_morph_T
   : CMorphisms.Proper
       (CMorphisms.respectful CRealEq (CMorphisms.respectful CRealEq CRealEq)) CReal_minus.

--- a/theories/Reals/Cauchy/ConstructiveRcomplete.v
+++ b/theories/Reals/Cauchy/ConstructiveRcomplete.v
@@ -50,6 +50,7 @@ Proof.
   exists n. intros. rewrite <- H0. apply H, H1.
 Qed.
 
+#[global]
 Instance seq_cv_morph
   : forall (un : nat -> CReal), CMorphisms.Proper
       (CMorphisms.respectful CRealEq CRelationClasses.iffT) (seq_cv un).

--- a/theories/Reals/ROrderedType.v
+++ b/theories/Reals/ROrderedType.v
@@ -69,9 +69,11 @@ Module R_as_OT <: OrderedTypeFull.
  Definition le := Rle.
  Definition compare := Rcompare.
 
+#[global]
  Instance lt_strorder : StrictOrder Rlt.
  Proof. split; [ exact Rlt_irrefl | exact Rlt_trans ]. Qed.
 
+#[global]
  Instance lt_compat : Proper (Logic.eq==>Logic.eq==>iff) Rlt.
  Proof. repeat red; intros; subst; auto. Qed.
 

--- a/theories/Sorting/CPermutation.v
+++ b/theories/Sorting/CPermutation.v
@@ -104,6 +104,7 @@ Hint Resolve CPermutation_refl : core.
 
 Local Hint Resolve cperm CPermutation_sym CPermutation_trans : core.
 
+#[global]
 Instance CPermutation_Equivalence A : Equivalence (@CPermutation A) | 10 := {
   Equivalence_Reflexive := @CPermutation_refl A ;
   Equivalence_Symmetric := @CPermutation_sym A ;
@@ -250,6 +251,7 @@ intros f a l l' HP.
 now apply CPermutation_Permutation, Permutation_image in HP.
 Qed.
 
+#[global]
 Instance CPermutation_Forall A (P : A -> Prop) :
   Proper (@CPermutation A ==> Basics.impl) (Forall P).
 Proof.
@@ -257,6 +259,7 @@ intros ? ? [? ?] HF.
 now apply Forall_app in HF; apply Forall_app.
 Qed.
 
+#[global]
 Instance CPermutation_Exists A (P : A -> Prop) :
   Proper (@CPermutation A ==> Basics.impl) (Exists P).
 Proof.

--- a/theories/Sorting/Permutation.v
+++ b/theories/Sorting/Permutation.v
@@ -88,6 +88,7 @@ Local Hint Resolve Permutation_sym Permutation_trans : core.
 (* This provides reflexivity, symmetry and transitivity and rewriting
    on morphims to come *)
 
+#[global]
 Instance Permutation_Equivalence A : Equivalence (@Permutation A) | 10 := {
   Equivalence_Reflexive := @Permutation_refl A ;
   Equivalence_Symmetric := @Permutation_sym A ;
@@ -105,6 +106,7 @@ Proof.
   now apply IHHP; rewrite <- app_assoc.
 Qed.
 
+#[global]
 Instance Permutation_cons A :
  Proper (Logic.eq ==> @Permutation A ==> @Permutation A) (@cons A) | 10.
 Proof.
@@ -812,6 +814,7 @@ Qed.
 
 End Permutation_alt.
 
+#[global]
 Instance Permutation_list_sum : Proper (@Permutation nat ==> eq) list_sum | 10.
 Proof.
   intros l1 l2 HP; induction HP; simpl; intuition.
@@ -820,6 +823,7 @@ Proof.
   - now transitivity (list_sum l').
 Qed.
 
+#[global]
 Instance Permutation_list_max : Proper (@Permutation nat ==> eq) list_max | 10.
 Proof.
   intros l1 l2 HP; induction HP; simpl; intuition.

--- a/theories/Structures/Equalities.v
+++ b/theories/Structures/Equalities.v
@@ -44,6 +44,7 @@ Module Type Eq' := Eq <+ EqNotation.
 (** * Specification of the equality via the [Equivalence] type class *)
 
 Module Type IsEq (Import E:Eq).
+#[global]
   Declare Instance eq_equiv : Equivalence eq.
 End IsEq.
 
@@ -136,6 +137,7 @@ Module BackportEq (E:Eq)(F:IsEq E) <: IsEqOrig E.
 End BackportEq.
 
 Module UpdateEq (E:Eq)(F:IsEqOrig E) <: IsEq E.
+#[global]
  Instance eq_equiv : Equivalence E.eq.
  Proof. exact (Build_Equivalence _ F.eq_refl F.eq_sym F.eq_trans). Qed.
 End UpdateEq.
@@ -190,6 +192,7 @@ Module BoolEqualityFacts (Import E : BooleanEqualityType').
 
 (** [eqb] is compatible with [eq] *)
 
+#[global]
 Instance eqb_compat : Proper (E.eq ==> E.eq ==> Logic.eq) eqb.
 Proof.
 intros x x' Exx' y y' Eyy'.

--- a/theories/Structures/EqualitiesFacts.v
+++ b/theories/Structures/EqualitiesFacts.v
@@ -27,12 +27,15 @@ Module KeyDecidableType(D:DecidableType).
 
  (** eqk, eqke are equalities *)
 
+#[global]
  Instance eqk_equiv {elt} : Equivalence (@eqk elt) := _.
 
+#[global]
  Instance eqke_equiv {elt} : Equivalence (@eqke elt) := _.
 
  (** eqke is stricter than eqk *)
 
+#[global]
  Instance eqke_eqk {elt} : subrelation (@eqke elt) (@eqk elt).
  Proof. firstorder. Qed.
 
@@ -130,6 +133,7 @@ Module KeyDecidableType(D:DecidableType).
   rewrite !In_alt2, Exists_cons; intuition.
  Qed.
 
+#[global]
  Instance MapsTo_compat {elt} :
    Proper (D.eq==>Logic.eq==>equivlistA eqke==>iff) (@MapsTo elt).
  Proof.
@@ -137,6 +141,7 @@ Module KeyDecidableType(D:DecidableType).
   rewrite Hx, He, Hl; intuition.
  Qed.
 
+#[global]
  Instance In_compat {elt} : Proper (D.eq==>equivlistA eqk==>iff) (@In elt).
  Proof.
   intros x x' Hx l l' Hl. rewrite !In_alt.
@@ -192,6 +197,7 @@ Module PairDecidableType(D1 D2:DecidableType) <: DecidableType.
 
  Definition eq := (D1.eq * D2.eq)%signature.
 
+#[global]
  Instance eq_equiv : Equivalence eq := _.
 
  Definition eq_dec : forall x y, { eq x y }+{ ~eq x y }.
@@ -208,6 +214,7 @@ End PairDecidableType.
 Module PairUsualDecidableType(D1 D2:UsualDecidableType) <: UsualDecidableType.
  Definition t := (D1.t * D2.t)%type.
  Definition eq := @eq t.
+#[global]
  Instance eq_equiv : Equivalence eq := _.
  Definition eq_dec : forall x y, { eq x y }+{ ~eq x y }.
  Proof.

--- a/theories/Structures/GenericMinMax.v
+++ b/theories/Structures/GenericMinMax.v
@@ -104,9 +104,11 @@ Proof.
  destruct (max_spec n m); [left|right]; intuition; order.
 Qed.
 
+#[global]
 Instance : Proper (eq==>eq==>iff) le.
 Proof. repeat red. intuition order. Qed.
 
+#[global]
 Instance max_compat : Proper (eq==>eq==>eq) max.
 Proof.
  intros x x' Hx y y' Hy.
@@ -255,6 +257,7 @@ Proof.
  destruct (min_spec n m); [left|right]; intuition; order.
 Qed.
 
+#[global]
 Instance min_compat : Proper (eq==>eq==>eq) min.
 Proof.
 intros x x' Hx y y' Hy.

--- a/theories/Structures/OrderedType.v
+++ b/theories/Structures/OrderedType.v
@@ -78,6 +78,7 @@ End MOT_to_OT.
 
 Module OrderedTypeFacts (Import O: OrderedType).
 
+#[global]
   Instance eq_equiv : Equivalence eq.
   Proof. split; [ exact eq_refl | exact eq_sym | exact eq_trans ]. Qed.
 
@@ -86,6 +87,7 @@ Module OrderedTypeFacts (Import O: OrderedType).
    intros x; intro; absurd (eq x x); auto with ordered_type.
   Qed.
 
+#[global]
   Instance lt_strorder : StrictOrder lt.
   Proof. split; [ exact lt_antirefl | exact lt_trans]. Qed.
 
@@ -103,6 +105,7 @@ Module OrderedTypeFacts (Import O: OrderedType).
    elim (lt_not_eq (lt_trans H0 Hlt))...
   Qed.
 
+#[global]
   Instance lt_compat : Proper (eq==>eq==>iff) lt.
   apply proper_sym_impl_iff_2; auto with *.
   intros x x' Hx y y' Hy H.

--- a/theories/Structures/Orders.v
+++ b/theories/Structures/Orders.v
@@ -59,7 +59,9 @@ Module Type EqLtLe' := EqLtLe <+ EqLtLeNotation.
 (** Versions with logical specifications *)
 
 Module Type IsStrOrder (Import E:EqLt).
+#[global]
   Declare Instance lt_strorder : StrictOrder lt.
+#[global]
   Declare Instance lt_compat : Proper (eq==>eq==>iff) lt.
 End IsStrOrder.
 
@@ -321,6 +323,7 @@ Module TTLB_to_OTF (Import O : TotalTransitiveLeBool') <: OrderedTypeFull.
 
  Include HasEqBool2Dec.
 
+#[global]
  Instance eq_equiv : Equivalence eq.
  Proof.
  split.
@@ -329,6 +332,7 @@ Module TTLB_to_OTF (Import O : TotalTransitiveLeBool') <: OrderedTypeFull.
  - intros x y z; unfold eq, le. intuition; apply leb_trans with y; auto.
  Qed.
 
+#[global]
  Instance lt_strorder : StrictOrder lt.
  Proof.
  split.
@@ -339,6 +343,7 @@ Module TTLB_to_OTF (Import O : TotalTransitiveLeBool') <: OrderedTypeFull.
      apply leb_trans with x; auto.
  Qed.
 
+#[global]
  Instance lt_compat : Proper (eq ==> eq ==> iff) lt.
  Proof.
  apply proper_sym_impl_iff_2; auto with *.

--- a/theories/Structures/OrdersAlt.v
+++ b/theories/Structures/OrdersAlt.v
@@ -48,6 +48,7 @@ Module Update_OT (O:OrderedTypeOrig) <: OrderedType.
 
  Definition lt := O.lt.
 
+#[global]
  Instance lt_strorder : StrictOrder lt.
  Proof.
   split.
@@ -55,6 +56,7 @@ Module Update_OT (O:OrderedTypeOrig) <: OrderedType.
   exact O.lt_trans.
  Qed.
 
+#[global]
  Instance lt_compat : Proper (eq==>eq==>iff) lt.
  Proof.
   apply proper_sym_impl_iff_2; auto with *.
@@ -117,6 +119,7 @@ Module OT_from_Alt (Import O:OrderedTypeAlt) <: OrderedType.
  Definition eq x y := (x?=y) = Eq.
  Definition lt x y := (x?=y) = Lt.
 
+#[global]
  Instance eq_equiv : Equivalence eq.
  Proof.
   split; red.
@@ -131,6 +134,7 @@ Module OT_from_Alt (Import O:OrderedTypeAlt) <: OrderedType.
   apply compare_trans.
  Qed.
 
+#[global]
  Instance lt_strorder : StrictOrder lt.
  Proof.
   split; repeat red; unfold lt; try apply compare_trans.
@@ -159,6 +163,7 @@ Module OT_from_Alt (Import O:OrderedTypeAlt) <: OrderedType.
   rewrite (compare_trans Hxz Hyz) in Hxy; discriminate.
  Qed.
 
+#[global]
  Instance lt_compat : Proper (eq==>eq==>iff) lt.
  Proof.
   apply proper_sym_impl_iff_2; auto with *.

--- a/theories/Structures/OrdersEx.v
+++ b/theories/Structures/OrdersEx.v
@@ -50,6 +50,7 @@ Module PairOrderedType(O1 O2:OrderedType) <: OrderedType.
  Definition lt :=
    (relation_disjunction (O1.lt @@1) (O1.eq * O2.lt))%signature.
 
+#[global]
  Instance lt_strorder : StrictOrder lt.
  Proof.
  split.
@@ -65,6 +66,7 @@ Module PairOrderedType(O1 O2:OrderedType) <: OrderedType.
  right; split; etransitivity; eauto.
  Qed.
 
+#[global]
  Instance lt_compat : Proper (eq==>eq==>iff) lt.
  Proof.
  compute.
@@ -125,11 +127,13 @@ Module PositiveOrderedTypeBits <: UsualOrderedType.
    induction x; destruct y,z; simpl; eauto; intuition.
   Qed.
 
+#[global]
   Instance lt_compat : Proper (eq==>eq==>iff) lt.
   Proof.
    intros x x' Hx y y' Hy. rewrite Hx, Hy; intuition.
   Qed.
 
+#[global]
   Instance lt_strorder : StrictOrder lt.
   Proof.
    split; [ exact bits_lt_antirefl | exact bits_lt_trans ].

--- a/theories/Structures/OrdersFacts.v
+++ b/theories/Structures/OrdersFacts.v
@@ -55,6 +55,7 @@ Module Type CompareFacts (Import O:DecStrOrder').
 
  Global Hint Rewrite compare_eq_iff compare_lt_iff compare_gt_iff : order.
 
+#[global]
  Instance compare_compat : Proper (eq==>eq==>Logic.eq) compare.
  Proof.
  intros x x' Hxx' y y' Hyy'.
@@ -83,15 +84,19 @@ Module OrderedTypeFullFacts (Import O:OrderedTypeFull').
  Ltac order := OrderTac.order.
  Ltac iorder := intuition order.
 
+#[global]
  Instance le_compat : Proper (eq==>eq==>iff) le.
  Proof. repeat red; iorder. Qed.
 
+#[global]
  Instance le_preorder : PreOrder le.
  Proof. split; red; order. Qed.
 
+#[global]
  Instance le_order : PartialOrder eq le.
  Proof. compute; iorder. Qed.
 
+#[global]
  Instance le_antisym : Antisymmetric _ eq le.
  Proof. apply partial_order_antisym; auto with *. Qed.
 
@@ -188,6 +193,7 @@ Module OrderedTypeFacts (Import O: OrderedType').
   unfold eqb; intros; apply if_eq_dec.
   Qed.
 
+#[global]
   Instance eqb_compat : Proper (eq==>eq==>Logic.eq) eqb.
   Proof.
   intros x x' Hxx' y y' Hyy'.
@@ -239,14 +245,17 @@ Module OrderedTypeRev (O:OrderedTypeFull) <: OrderedTypeFull.
 
 Definition t := O.t.
 Definition eq := O.eq.
+#[global]
 Program Instance eq_equiv : Equivalence eq.
 Definition eq_dec := O.eq_dec.
 
 Definition lt := flip O.lt.
 Definition le := flip O.le.
 
+#[global]
 Instance lt_strorder: StrictOrder lt.
 Proof. unfold lt; auto with *. Qed.
+#[global]
 Instance lt_compat : Proper (eq==>eq==>iff) lt.
 Proof. unfold lt; auto with *. Qed.
 

--- a/theories/Structures/OrdersLists.v
+++ b/theories/Structures/OrdersLists.v
@@ -73,16 +73,20 @@ Module KeyOrderedType(O:OrderedType).
 
  (* ltk is a strict order *)
 
+#[global]
  Instance ltk_strorder {elt} : StrictOrder (@ltk elt) := _.
 
+#[global]
  Instance ltk_compat {elt} : Proper (eqk==>eqk==>iff) (@ltk elt).
  Proof. unfold eqk, ltk; auto with *. Qed.
 
+#[global]
  Instance ltk_compat' {elt} : Proper (eqke==>eqke==>iff) (@ltk elt).
  Proof. eapply subrelation_proper; eauto with *. Qed.
 
  (* Additional facts *)
 
+#[global]
  Instance pair_compat {elt} : Proper (O.eq==>Logic.eq==>eqke) (@pair key elt).
  Proof. apply pair_compat. Qed.
 

--- a/theories/ZArith/Zeuclid.v
+++ b/theories/ZArith/Zeuclid.v
@@ -24,8 +24,10 @@ Module ZEuclid.
  Definition modulo a b := Z.modulo a (Z.abs b).
  Definition div a b := (Z.sgn b) * (Z.div a (Z.abs b)).
 
+#[global]
  Instance mod_wd : Proper (eq==>eq==>eq) modulo.
  Proof. congruence. Qed.
+#[global]
  Instance div_wd : Proper (eq==>eq==>eq) div.
  Proof. congruence. Qed.
 

--- a/theories/micromega/DeclConstant.v
+++ b/theories/micromega/DeclConstant.v
@@ -39,14 +39,17 @@ Register DeclaredConstant as micromega.DeclaredConstant.type.
 
 Class GT {T : Type} (F : T).
 
+#[global]
 Instance GT_O {T : Type} (F : T) {DC : DeclaredConstant F} : GT F.
 Defined.
 
+#[global]
 Instance GT_APP1 {T1 T2 : Type} (F : T1 -> T2) (A : T1) :
   DeclaredConstant F ->
   GT A -> GT (F A).
 Defined.
 
+#[global]
 Instance GT_APP2 {T1 T2 T3: Type} (F : T1 -> T2 -> T3)
          {A1 : T1} {A2 : T2} {DC:DeclaredConstant F} :
          GT A1 -> GT A2 -> GT (F A1 A2).
@@ -54,15 +57,26 @@ Defined.
 
 Require Import QArith_base.
 
+#[global]
 Instance DO : DeclaredConstant O := {}.
+#[global]
 Instance DS : DeclaredConstant S := {}.
+#[global]
 Instance DxH: DeclaredConstant xH := {}.
+#[global]
 Instance DxI: DeclaredConstant xI := {}.
+#[global]
 Instance DxO: DeclaredConstant xO := {}.
+#[global]
 Instance DZO: DeclaredConstant Z0 := {}.
+#[global]
 Instance DZpos: DeclaredConstant Zpos := {}.
+#[global]
 Instance DZneg: DeclaredConstant Zneg := {}.
+#[global]
 Instance DZpow_pos : DeclaredConstant Z.pow_pos := {}.
+#[global]
 Instance DZpow     : DeclaredConstant Z.pow     := {}.
 
+#[global]
 Instance DQ : DeclaredConstant Qmake := {}.

--- a/theories/micromega/ZifyBool.v
+++ b/theories/micromega/ZifyBool.v
@@ -13,6 +13,7 @@ Require Import ZifyInst.
 Local Open Scope Z_scope.
 (* Instances of [ZifyClasses] for dealing with boolean operators. *)
 
+#[global]
 Instance Inj_bool_bool : InjTyp bool bool :=
   { inj := (fun x => x) ; pred := (fun b => b = true \/ b = false) ;
     cstr := (ltac:(intro b; destruct b; tauto))}.
@@ -20,14 +21,17 @@ Add Zify InjTyp Inj_bool_bool.
 
 (** Boolean operators *)
 
+#[global]
 Instance Op_andb : BinOp andb :=
   { TBOp := andb ; TBOpInj := fun _ _  => eq_refl}.
 Add Zify BinOp Op_andb.
 
+#[global]
 Instance Op_orb : BinOp orb :=
   { TBOp := orb ; TBOpInj := fun _ _ => eq_refl}.
 Add Zify BinOp Op_orb.
 
+#[global]
 Instance Op_implb : BinOp implb :=
   { TBOp := implb; TBOpInj := fun _ _ => eq_refl }.
 Add Zify BinOp Op_implb.
@@ -38,48 +42,59 @@ Proof.
   destruct b1,b2 ; reflexivity.
 Qed.
 
+#[global]
 Instance Op_xorb : BinOp xorb :=
   { TBOp := fun x y => andb (orb x y) (negb (eqb x y)); TBOpInj := xorb_eq }.
 Add Zify BinOp Op_xorb.
 
+#[global]
 Instance Op_eqb : BinOp eqb :=
   { TBOp := eqb; TBOpInj := fun _ _ => eq_refl }.
 Add Zify BinOp Op_eqb.
 
+#[global]
 Instance Op_negb : UnOp negb :=
   { TUOp := negb ; TUOpInj := fun _ => eq_refl}.
 Add Zify UnOp Op_negb.
 
+#[global]
 Instance Op_eq_bool : BinRel (@eq bool) :=
   {TR := @eq bool ; TRInj := ltac:(reflexivity) }.
 Add Zify BinRel Op_eq_bool.
 
+#[global]
 Instance Op_true : CstOp true :=
   { TCst := true ; TCstInj := eq_refl }.
 Add Zify CstOp Op_true.
 
+#[global]
 Instance Op_false : CstOp false :=
   { TCst := false ; TCstInj := eq_refl }.
 Add Zify CstOp Op_false.
 
 (** Comparison over Z *)
 
+#[global]
 Instance Op_Zeqb : BinOp Z.eqb :=
   { TBOp := Z.eqb ; TBOpInj := fun _ _ => eq_refl }.
 Add Zify BinOp Op_Zeqb.
 
+#[global]
 Instance Op_Zleb : BinOp Z.leb :=
   { TBOp := Z.leb; TBOpInj :=  fun _ _ => eq_refl }.
 Add Zify BinOp Op_Zleb.
 
+#[global]
 Instance Op_Zgeb : BinOp Z.geb :=
   { TBOp := Z.geb; TBOpInj := fun _ _ => eq_refl }.
 Add Zify BinOp Op_Zgeb.
 
+#[global]
 Instance Op_Zltb : BinOp Z.ltb :=
   { TBOp := Z.ltb ; TBOpInj := fun _ _ => eq_refl }.
 Add Zify BinOp Op_Zltb.
 
+#[global]
 Instance Op_Zgtb : BinOp Z.gtb :=
   { TBOp := Z.gtb; TBOpInj := fun _ _  => eq_refl }.
 Add Zify BinOp Op_Zgtb.
@@ -116,14 +131,17 @@ Proof.
   reflexivity.
 Qed.
 
+#[global]
 Instance Op_nat_eqb : BinOp Nat.eqb :=
   { TBOp := Z.eqb; TBOpInj := Z_of_nat_eqb_iff }.
 Add Zify BinOp Op_nat_eqb.
 
+#[global]
 Instance Op_nat_leb : BinOp Nat.leb :=
   { TBOp := Z.leb; TBOpInj := Z_of_nat_leb_iff }.
 Add Zify BinOp Op_nat_leb.
 
+#[global]
 Instance Op_nat_ltb : BinOp Nat.ltb :=
   { TBOp := Z.ltb; TBOpInj := Z_of_nat_ltb_iff }.
 Add Zify BinOp Op_nat_ltb.
@@ -133,10 +151,12 @@ Proof.
   intro. destruct x ; reflexivity.
 Qed.
 
+#[global]
 Instance Op_b2n : UnOp Nat.b2n :=
   { TUOp := Z.b2z; TUOpInj := b2n_b2z }.
 Add Zify UnOp Op_b2n.
 
+#[global]
 Instance Op_b2z : UnOp Z.b2z :=
   { TUOp := Z.b2z; TUOpInj := fun _ => eq_refl }.
 Add Zify UnOp Op_b2z.
@@ -146,6 +166,7 @@ Proof.
   destruct b ; simpl; intuition congruence.
 Qed.
 
+#[global]
 Instance b2zSpec : UnOpSpec Z.b2z :=
   { UPred := fun b r => (b = true /\ r = 1) \/ (b = false /\ r = 0);
     USpec := b2z_spec

--- a/theories/micromega/ZifyComparison.v
+++ b/theories/micromega/ZifyComparison.v
@@ -26,6 +26,7 @@ Proof.
   destruct x ; simpl; compute; intuition congruence.
 Qed.
 
+#[global]
 Instance Inj_comparison_Z : InjTyp comparison Z :=
   { inj := Z_of_comparison ; pred :=(fun x => -1 <= x <= 1) ; cstr := Z_of_comparison_bound}.
 Add Zify InjTyp Inj_comparison_Z.
@@ -33,22 +34,27 @@ Add Zify InjTyp Inj_comparison_Z.
 Definition ZcompareZ (x y : Z) :=
   Z_of_comparison (Z.compare x y).
 
+#[global]
 Program Instance BinOp_Zcompare : BinOp Z.compare :=
   { TBOp := ZcompareZ }.
 Add Zify BinOp BinOp_Zcompare.
 
+#[global]
 Instance Op_eq_comparison : BinRel (@eq comparison) :=
   {TR := @eq Z ; TRInj := ltac:(destruct n,m; simpl ; intuition congruence) }.
 Add Zify BinRel Op_eq_comparison.
 
+#[global]
 Instance Op_Eq : CstOp Eq :=
   { TCst := 0 ; TCstInj := eq_refl }.
 Add Zify CstOp Op_Eq.
 
+#[global]
 Instance Op_Lt : CstOp Lt :=
   { TCst := -1 ; TCstInj := eq_refl }.
 Add Zify CstOp Op_Lt.
 
+#[global]
 Instance Op_Gt : CstOp Gt :=
   { TCst := 1 ; TCstInj := eq_refl }.
 Add Zify CstOp Op_Gt.
@@ -72,6 +78,7 @@ Proof.
     lia.
 Qed.
 
+#[global]
 Instance ZcompareSpec : BinOpSpec ZcompareZ :=
   {| BPred := fun x y r => (x = y -> r = 0)
                            /\

--- a/theories/micromega/ZifyInst.v
+++ b/theories/micromega/ZifyInst.v
@@ -23,116 +23,143 @@ Ltac refl :=
                      end ; reflexivity).
 
 
+#[global]
 Instance Inj_Z_Z : InjTyp Z Z :=
   mkinj _ _ (fun x => x) (fun x =>  True ) (fun _ => I).
 Add Zify InjTyp Inj_Z_Z.
 
 (** Support for nat *)
 
+#[global]
 Instance Inj_nat_Z : InjTyp nat Z :=
   mkinj _ _ Z.of_nat (fun x =>  0 <= x ) Nat2Z.is_nonneg.
 Add Zify InjTyp Inj_nat_Z.
 
 (* zify_nat_rel *)
+#[global]
 Instance Op_ge : BinRel ge :=
   {| TR := Z.ge; TRInj := Nat2Z.inj_ge |}.
 Add Zify BinRel Op_ge.
 
+#[global]
 Instance Op_lt : BinRel lt :=
   {| TR := Z.lt; TRInj := Nat2Z.inj_lt |}.
 Add Zify BinRel Op_lt.
 
+#[global]
 Instance Op_Nat_lt : BinRel Nat.lt := Op_lt.
 Add Zify BinRel Op_Nat_lt.
 
+#[global]
 Instance Op_gt : BinRel gt :=
   {| TR := Z.gt; TRInj := Nat2Z.inj_gt |}.
 Add Zify BinRel Op_gt.
 
+#[global]
 Instance Op_le : BinRel le :=
   {| TR := Z.le; TRInj := Nat2Z.inj_le |}.
 Add Zify BinRel Op_le.
 
+#[global]
 Instance Op_Nat_le : BinRel Nat.le := Op_le.
 Add Zify BinRel Op_Nat_le.
 
+#[global]
 Instance Op_eq_nat : BinRel (@eq nat) :=
   {| TR := @eq Z ; TRInj := fun x y : nat => iff_sym (Nat2Z.inj_iff x y) |}.
 Add Zify BinRel Op_eq_nat.
 
+#[global]
 Instance Op_Nat_eq : BinRel (Nat.eq) := Op_eq_nat.
 Add Zify BinRel Op_Nat_eq.
 
 (* zify_nat_op *)
+#[global]
 Instance Op_plus : BinOp Nat.add :=
   {| TBOp := Z.add; TBOpInj := Nat2Z.inj_add |}.
 Add Zify BinOp Op_plus.
 
+#[global]
 Instance Op_sub : BinOp Nat.sub :=
   {| TBOp := fun n m => Z.max 0 (n - m) ; TBOpInj := Nat2Z.inj_sub_max |}.
 Add Zify BinOp Op_sub.
 
+#[global]
 Instance Op_mul : BinOp Nat.mul :=
   {| TBOp := Z.mul ; TBOpInj := Nat2Z.inj_mul |}.
 Add Zify BinOp Op_mul.
 
+#[global]
 Instance Op_min : BinOp Nat.min :=
   {| TBOp := Z.min ; TBOpInj := Nat2Z.inj_min |}.
 Add Zify BinOp Op_min.
 
+#[global]
 Instance Op_max : BinOp Nat.max :=
   {| TBOp := Z.max ; TBOpInj := Nat2Z.inj_max |}.
 Add Zify BinOp Op_max.
 
+#[global]
 Instance Op_pred : UnOp Nat.pred :=
   {| TUOp := fun n => Z.max 0 (n - 1) ; TUOpInj := Nat2Z.inj_pred_max |}.
 Add Zify UnOp Op_pred.
 
+#[global]
 Instance Op_S : UnOp S :=
   {| TUOp := fun x => Z.add x 1 ; TUOpInj := Nat2Z.inj_succ |}.
 Add Zify UnOp Op_S.
 
+#[global]
 Instance Op_O : CstOp O :=
   {| TCst := Z0 ; TCstInj := eq_refl (Z.of_nat 0) |}.
 Add Zify CstOp Op_O.
 
+#[global]
 Instance Op_Z_abs_nat : UnOp  Z.abs_nat :=
   { TUOp := Z.abs ; TUOpInj := Zabs2Nat.id_abs }.
 Add Zify UnOp Op_Z_abs_nat.
 
 (** Support for positive *)
 
+#[global]
 Instance Inj_pos_Z : InjTyp positive Z :=
   {| inj := Zpos ; pred := (fun x =>  0 < x ) ; cstr := Pos2Z.pos_is_pos |}.
 Add Zify InjTyp Inj_pos_Z.
 
+#[global]
 Instance Op_pos_to_nat : UnOp  Pos.to_nat :=
   {TUOp := (fun x => x); TUOpInj := positive_nat_Z}.
 Add Zify UnOp Op_pos_to_nat.
 
+#[global]
 Instance Inj_N_Z : InjTyp N Z :=
   mkinj _ _ Z.of_N (fun x =>  0 <= x ) N2Z.is_nonneg.
 Add Zify InjTyp Inj_N_Z.
 
 
+#[global]
 Instance Op_N_to_nat : UnOp  N.to_nat :=
   { TUOp := fun x => x ; TUOpInj := N_nat_Z }.
 Add Zify UnOp Op_N_to_nat.
 
 (* zify_positive_rel *)
 
+#[global]
 Instance Op_pos_ge : BinRel Pos.ge :=
   {| TR := Z.ge; TRInj := fun x y => iff_refl (Z.pos x >= Z.pos y) |}.
 Add Zify BinRel Op_pos_ge.
 
+#[global]
 Instance Op_pos_lt : BinRel Pos.lt :=
   {| TR := Z.lt; TRInj := fun x y => iff_refl (Z.pos x < Z.pos y) |}.
 Add Zify BinRel Op_pos_lt.
 
+#[global]
 Instance Op_pos_gt : BinRel Pos.gt :=
   {| TR := Z.gt; TRInj := fun x y => iff_refl (Z.pos x > Z.pos y)  |}.
 Add Zify BinRel Op_pos_gt.
 
+#[global]
 Instance Op_pos_le : BinRel Pos.le :=
   {| TR := Z.le; TRInj := fun x y => iff_refl (Z.pos x <= Z.pos y) |}.
 Add Zify BinRel Op_pos_le.
@@ -143,28 +170,34 @@ Proof.
   apply (iff_sym (Pos2Z.inj_iff x y)).
 Qed.
 
+#[global]
 Instance Op_eq_pos : BinRel (@eq positive) :=
   { TR := @eq Z ; TRInj := eq_pos_inj }.
 Add Zify BinRel Op_eq_pos.
 
 (* zify_positive_op *)
 
+#[global]
 Instance Op_Z_of_N : UnOp Z.of_N :=
   { TUOp := (fun x => x) ; TUOpInj := fun x => eq_refl (Z.of_N x) }.
 Add Zify UnOp Op_Z_of_N.
 
+#[global]
 Instance Op_Z_to_N : UnOp Z.to_N :=
   { TUOp := fun x => Z.max 0 x ; TUOpInj := ltac:(now intro x; destruct x) }.
 Add Zify UnOp Op_Z_to_N.
 
+#[global]
 Instance Op_Z_neg : UnOp Z.neg :=
   { TUOp :=  Z.opp ; TUOpInj := (fun x => eq_refl (Zneg x))}.
 Add Zify UnOp Op_Z_neg.
 
+#[global]
 Instance Op_Z_pos : UnOp Z.pos :=
   { TUOp := (fun x =>  x) ; TUOpInj := (fun x => eq_refl (Z.pos x))}.
 Add Zify UnOp Op_Z_pos.
 
+#[global]
 Instance Op_pos_succ : UnOp Pos.succ :=
   { TUOp := fun x => x + 1; TUOpInj := Pos2Z.inj_succ  }.
 Add Zify UnOp Op_pos_succ.
@@ -172,10 +205,12 @@ Add Zify UnOp Op_pos_succ.
 
 
 
+#[global]
 Instance Op_pos_pred_double : UnOp Pos.pred_double :=
 { TUOp := fun x => 2 * x - 1; TUOpInj := ltac:(refl) }.
 Add Zify UnOp Op_pos_pred_double.
 
+#[global]
 Instance Op_pos_pred : UnOp Pos.pred :=
   { TUOp := fun x => Z.max 1 (x - 1) ;
     TUOpInj := ltac :
@@ -184,146 +219,180 @@ Instance Op_pos_pred : UnOp Pos.pred :=
                     apply Pos2Z.inj_sub_max) }.
 Add Zify UnOp Op_pos_pred.
 
+#[global]
 Instance Op_pos_predN : UnOp Pos.pred_N :=
   { TUOp := fun x => x - 1 ;
     TUOpInj x := ltac: (now destruct x; rewrite N.pos_pred_spec) }.
 Add Zify UnOp Op_pos_predN.
 
+#[global]
 Instance Op_pos_of_succ_nat : UnOp Pos.of_succ_nat :=
   { TUOp := fun x => x + 1 ; TUOpInj := Zpos_P_of_succ_nat }.
 Add Zify UnOp Op_pos_of_succ_nat.
 
+#[global]
 Instance Op_pos_of_nat : UnOp Pos.of_nat :=
   { TUOp := fun x => Z.max 1 x ;
     TUOpInj x := ltac: (now destruct x;
                         [|rewrite <- Pos.of_nat_succ, <- (Nat2Z.inj_max 1)]) }.
 Add Zify UnOp Op_pos_of_nat.
 
+#[global]
 Instance Op_pos_add : BinOp Pos.add :=
   { TBOp := Z.add ; TBOpInj := ltac: (refl) }.
 Add Zify BinOp Op_pos_add.
 
+#[global]
 Instance Op_pos_add_carry : BinOp Pos.add_carry :=
   { TBOp := fun x y => x + y + 1 ;
     TBOpInj := ltac:(now intros; rewrite Pos.add_carry_spec, Pos2Z.inj_succ) }.
 Add Zify BinOp Op_pos_add_carry.
 
+#[global]
 Instance Op_pos_sub : BinOp Pos.sub :=
   { TBOp := fun n m => Z.max 1 (n - m) ;TBOpInj := Pos2Z.inj_sub_max }.
 Add Zify BinOp Op_pos_sub.
 
+#[global]
 Instance Op_pos_mul : BinOp Pos.mul :=
   { TBOp :=  Z.mul ; TBOpInj := ltac: (refl) }.
 Add Zify BinOp Op_pos_mul.
 
+#[global]
 Instance Op_pos_min : BinOp Pos.min :=
   { TBOp := Z.min ; TBOpInj := Pos2Z.inj_min }.
 Add Zify BinOp Op_pos_min.
 
+#[global]
 Instance Op_pos_max : BinOp Pos.max :=
   { TBOp := Z.max ; TBOpInj := Pos2Z.inj_max }.
 Add Zify BinOp Op_pos_max.
 
+#[global]
 Instance Op_pos_pow : BinOp Pos.pow :=
   { TBOp := Z.pow ; TBOpInj := Pos2Z.inj_pow }.
 Add Zify BinOp Op_pos_pow.
 
+#[global]
 Instance Op_pos_square : UnOp Pos.square :=
   { TUOp := Z.square ; TUOpInj := Pos2Z.inj_square }.
 Add Zify UnOp Op_pos_square.
 
+#[global]
 Instance Op_xO : UnOp xO :=
   { TUOp := fun x => 2 * x ; TUOpInj := ltac: (refl) }.
 Add Zify UnOp Op_xO.
 
+#[global]
 Instance Op_xI : UnOp xI :=
   { TUOp := fun x => 2 * x + 1 ; TUOpInj := ltac: (refl) }.
 Add Zify UnOp Op_xI.
 
+#[global]
 Instance Op_xH : CstOp xH :=
   { TCst := 1%Z ; TCstInj := ltac:(refl)}.
 Add Zify CstOp Op_xH.
 
+#[global]
 Instance Op_Z_of_nat : UnOp Z.of_nat:=
   { TUOp := fun x => x ; TUOpInj := (fun x : nat => @eq_refl Z (Z.of_nat x)) }.
 Add Zify UnOp Op_Z_of_nat.
 
 (* zify_N_rel *)
+#[global]
 Instance Op_N_ge : BinRel N.ge :=
   {| TR := Z.ge ; TRInj := N2Z.inj_ge |}.
 Add Zify BinRel Op_N_ge.
 
+#[global]
 Instance Op_N_lt : BinRel N.lt :=
   {| TR := Z.lt ; TRInj := N2Z.inj_lt |}.
 Add Zify BinRel Op_N_lt.
 
+#[global]
 Instance Op_N_gt : BinRel N.gt :=
   {| TR := Z.gt ; TRInj := N2Z.inj_gt |}.
 Add Zify BinRel Op_N_gt.
 
+#[global]
 Instance Op_N_le : BinRel N.le :=
   {| TR := Z.le ; TRInj := N2Z.inj_le |}.
 Add Zify BinRel Op_N_le.
 
+#[global]
 Instance Op_eq_N : BinRel (@eq N) :=
   {| TR := @eq Z ; TRInj := fun x y : N => iff_sym (N2Z.inj_iff x y) |}.
 Add Zify BinRel Op_eq_N.
 
 (* zify_N_op *)
+#[global]
 Instance Op_N_N0 : CstOp  N0 :=
   { TCst := Z0 ; TCstInj := eq_refl }.
 Add Zify CstOp Op_N_N0.
 
+#[global]
 Instance Op_N_Npos : UnOp  Npos :=
   { TUOp := (fun x => x) ; TUOpInj := ltac:(refl) }.
 Add Zify UnOp Op_N_Npos.
 
+#[global]
 Instance Op_N_of_nat : UnOp  N.of_nat :=
   { TUOp := fun x => x ; TUOpInj := nat_N_Z }.
 Add Zify UnOp Op_N_of_nat.
 
+#[global]
 Instance Op_Z_abs_N : UnOp Z.abs_N :=
   { TUOp := Z.abs ; TUOpInj := N2Z.inj_abs_N }.
 Add Zify UnOp Op_Z_abs_N.
 
+#[global]
 Instance Op_N_pos : UnOp N.pos :=
   { TUOp := fun x => x ; TUOpInj := ltac:(refl)}.
 Add Zify UnOp Op_N_pos.
 
+#[global]
 Instance Op_N_add : BinOp N.add :=
   {| TBOp := Z.add ; TBOpInj := N2Z.inj_add |}.
 Add Zify BinOp Op_N_add.
 
+#[global]
 Instance Op_N_min : BinOp N.min :=
   {| TBOp := Z.min ; TBOpInj := N2Z.inj_min |}.
 Add Zify BinOp Op_N_min.
 
+#[global]
 Instance Op_N_max : BinOp N.max :=
   {| TBOp := Z.max ; TBOpInj := N2Z.inj_max |}.
 Add Zify BinOp Op_N_max.
 
+#[global]
 Instance Op_N_mul : BinOp N.mul :=
   {| TBOp := Z.mul ; TBOpInj := N2Z.inj_mul |}.
 Add Zify BinOp Op_N_mul.
 
+#[global]
 Instance Op_N_sub : BinOp N.sub :=
   {| TBOp := fun x y => Z.max 0 (x - y) ; TBOpInj := N2Z.inj_sub_max |}.
 Add Zify BinOp Op_N_sub.
 
+#[global]
 Instance Op_N_div : BinOp N.div :=
   {| TBOp := Z.div ; TBOpInj := N2Z.inj_div |}.
 Add Zify BinOp Op_N_div.
 
+#[global]
 Instance Op_N_mod : BinOp N.modulo :=
   {| TBOp := Z.rem ; TBOpInj := N2Z.inj_rem |}.
 Add Zify BinOp Op_N_mod.
 
+#[global]
 Instance Op_N_pred : UnOp N.pred :=
   { TUOp := fun x  => Z.max 0 (x - 1) ;
     TUOpInj :=
       ltac:(intros; rewrite N.pred_sub; apply N2Z.inj_sub_max) }.
 Add Zify UnOp Op_N_pred.
 
+#[global]
 Instance Op_N_succ : UnOp N.succ :=
   {| TUOp := fun x => x + 1 ; TUOpInj := N2Z.inj_succ |}.
 Add Zify UnOp Op_N_succ.
@@ -331,114 +400,142 @@ Add Zify UnOp Op_N_succ.
 (** Support for Z - injected to itself *)
 
 (* zify_Z_rel *)
+#[global]
 Instance Op_Z_ge : BinRel Z.ge :=
   {| TR := Z.ge ; TRInj := fun x y  => iff_refl (x>= y) |}.
 Add Zify BinRel Op_Z_ge.
 
+#[global]
 Instance Op_Z_lt : BinRel Z.lt :=
   {| TR := Z.lt ;  TRInj := fun x y  => iff_refl (x < y) |}.
 Add Zify BinRel Op_Z_lt.
 
+#[global]
 Instance Op_Z_gt : BinRel Z.gt :=
   {| TR := Z.gt ;TRInj := fun x y  => iff_refl (x > y) |}.
 Add Zify BinRel Op_Z_gt.
 
+#[global]
 Instance Op_Z_le : BinRel Z.le :=
   {| TR := Z.le ;TRInj := fun x y  => iff_refl (x <= y) |}.
 Add Zify BinRel Op_Z_le.
 
+#[global]
 Instance Op_eqZ : BinRel (@eq Z) :=
   { TR := @eq Z ; TRInj := fun x y  => iff_refl (x = y) }.
 Add Zify BinRel Op_eqZ.
 
+#[global]
 Instance Op_Z_Z0 : CstOp Z0 :=
   { TCst := Z0  ; TCstInj := eq_refl }.
 Add Zify CstOp Op_Z_Z0.
 
+#[global]
 Instance Op_Z_add : BinOp Z.add :=
   { TBOp := Z.add  ; TBOpInj := ltac:(refl) }.
 Add Zify BinOp Op_Z_add.
 
+#[global]
 Instance Op_Z_min : BinOp Z.min :=
   { TBOp := Z.min ; TBOpInj := ltac:(refl) }.
 Add Zify BinOp Op_Z_min.
 
+#[global]
 Instance Op_Z_max : BinOp Z.max :=
   { TBOp := Z.max ; TBOpInj := ltac:(refl) }.
 Add Zify BinOp Op_Z_max.
 
+#[global]
 Instance Op_Z_mul : BinOp Z.mul :=
   { TBOp := Z.mul ; TBOpInj := ltac:(refl) }.
 Add Zify BinOp Op_Z_mul.
 
+#[global]
 Instance Op_Z_sub : BinOp Z.sub :=
   { TBOp := Z.sub ; TBOpInj := ltac:(refl) }.
 Add Zify BinOp Op_Z_sub.
 
+#[global]
 Instance Op_Z_div : BinOp Z.div :=
   { TBOp := Z.div ; TBOpInj := ltac:(refl) }.
 Add Zify BinOp Op_Z_div.
 
+#[global]
 Instance Op_Z_mod : BinOp Z.modulo :=
   { TBOp := Z.modulo ; TBOpInj := ltac:(refl) }.
 Add Zify BinOp Op_Z_mod.
 
+#[global]
 Instance Op_Z_rem : BinOp Z.rem :=
   { TBOp := Z.rem ; TBOpInj := ltac:(refl) }.
 Add Zify BinOp Op_Z_rem.
 
+#[global]
 Instance Op_Z_quot : BinOp Z.quot :=
   { TBOp := Z.quot ; TBOpInj := ltac:(refl) }.
 Add Zify BinOp Op_Z_quot.
 
+#[global]
 Instance Op_Z_succ : UnOp Z.succ :=
   { TUOp := fun x => x + 1 ; TUOpInj := ltac:(refl) }.
 Add Zify UnOp Op_Z_succ.
 
+#[global]
 Instance Op_Z_pred : UnOp Z.pred :=
   { TUOp := fun x => x - 1 ; TUOpInj := ltac:(refl) }.
 Add Zify UnOp Op_Z_pred.
 
+#[global]
 Instance Op_Z_opp : UnOp Z.opp :=
   { TUOp := Z.opp ; TUOpInj := ltac:(refl) }.
 Add Zify UnOp Op_Z_opp.
 
+#[global]
 Instance Op_Z_abs : UnOp Z.abs :=
   { TUOp := Z.abs ; TUOpInj := ltac:(refl) }.
 Add Zify UnOp Op_Z_abs.
 
+#[global]
 Instance Op_Z_sgn : UnOp Z.sgn :=
   { TUOp := Z.sgn ; TUOpInj := ltac:(refl) }.
 Add Zify UnOp Op_Z_sgn.
 
+#[global]
 Instance Op_Z_pow : BinOp Z.pow :=
   { TBOp := Z.pow ; TBOpInj := ltac:(refl) }.
 Add Zify BinOp Op_Z_pow.
 
+#[global]
 Instance Op_Z_pow_pos : BinOp Z.pow_pos :=
   { TBOp := Z.pow ; TBOpInj := ltac:(refl) }.
 Add Zify BinOp Op_Z_pow_pos.
 
+#[global]
 Instance Op_Z_double : UnOp Z.double :=
   { TUOp := Z.mul 2 ; TUOpInj := Z.double_spec }.
 Add Zify UnOp Op_Z_double.
 
+#[global]
 Instance Op_Z_pred_double : UnOp Z.pred_double :=
   { TUOp := fun x => 2 * x - 1 ; TUOpInj := Z.pred_double_spec }.
 Add Zify UnOp Op_Z_pred_double.
 
+#[global]
 Instance Op_Z_succ_double : UnOp Z.succ_double :=
   { TUOp := fun x => 2 * x + 1 ; TUOpInj := Z.succ_double_spec }.
 Add Zify UnOp Op_Z_succ_double.
 
+#[global]
 Instance Op_Z_square : UnOp Z.square :=
   { TUOp := fun x => x * x ; TUOpInj := Z.square_spec }.
 Add Zify UnOp Op_Z_square.
 
+#[global]
 Instance Op_Z_div2 : UnOp Z.div2 :=
   { TUOp := fun x => x / 2 ; TUOpInj := Z.div2_div }.
 Add Zify UnOp Op_Z_div2.
 
+#[global]
 Instance Op_Z_quot2 : UnOp Z.quot2 :=
   { TUOp := fun x => Z.quot x 2 ; TUOpInj := Zeven.Zquot2_quot }.
 Add Zify UnOp Op_Z_quot2.
@@ -453,26 +550,31 @@ Proof.
   - reflexivity.
 Qed.
 
+#[global]
 Instance Op_Z_to_nat : UnOp Z.to_nat :=
   { TUOp := fun x => Z.max 0 x ; TUOpInj := of_nat_to_nat_eq }.
 Add Zify UnOp Op_Z_to_nat.
 
 (** Specification of derived operators over Z *)
 
+#[global]
 Instance ZmaxSpec : BinOpSpec Z.max :=
   {| BPred := fun n m r => n < m /\ r = m \/ m <= n /\ r = n ; BSpec := Z.max_spec |}.
 Add Zify BinOpSpec ZmaxSpec.
 
+#[global]
 Instance ZminSpec : BinOpSpec Z.min :=
   {| BPred := fun n m r => n < m /\ r = n \/ m <= n /\ r = m ;
      BSpec := Z.min_spec |}.
 Add Zify BinOpSpec ZminSpec.
 
+#[global]
 Instance ZsgnSpec : UnOpSpec Z.sgn :=
   {| UPred := fun n r : Z => 0 < n /\ r = 1 \/ 0 = n /\ r = 0 \/ n < 0 /\ r = - (1) ;
      USpec := Z.sgn_spec |}.
 Add Zify UnOpSpec ZsgnSpec.
 
+#[global]
 Instance ZabsSpec : UnOpSpec Z.abs :=
   {| UPred := fun n r: Z =>  0 <= n /\ r = n \/ n < 0 /\ r = - n ;
      USpec := Z.abs_spec |}.
@@ -480,6 +582,7 @@ Add Zify UnOpSpec ZabsSpec.
 
 (** Saturate positivity constraints *)
 
+#[global]
 Instance SatPowPos : Saturate Z.pow :=
   {|
     PArg1 := fun x => 0 < x;
@@ -489,6 +592,7 @@ Instance SatPowPos : Saturate Z.pow :=
   |}.
 Add Zify Saturate SatPowPos.
 
+#[global]
 Instance SatPowNonneg : Saturate Z.pow :=
   {|
     PArg1 := fun x => 0 <= x;

--- a/theories/micromega/ZifyInt63.v
+++ b/theories/micromega/ZifyInt63.v
@@ -6,22 +6,27 @@ Import ZifyClasses.
 Lemma to_Z_bounded : forall x, (0 <= to_Z x < 9223372036854775808)%Z.
 Proof. apply to_Z_bounded. Qed.
 
+#[global]
 Instance Inj_int_Z : InjTyp int Z :=
   mkinj _ _ to_Z (fun x => 0 <= x < 9223372036854775808)%Z to_Z_bounded.
 Add Zify InjTyp Inj_int_Z.
 
+#[global]
 Instance Op_max_int : CstOp max_int :=
   { TCst := 9223372036854775807 ; TCstInj := eq_refl }.
 Add Zify CstOp Op_max_int.
 
+#[global]
 Instance Op_digits : CstOp digits :=
   { TCst := 63 ; TCstInj := eq_refl }.
 Add Zify CstOp Op_digits.
 
+#[global]
 Instance Op_size : CstOp size :=
   { TCst := 63 ; TCstInj := eq_refl }.
 Add Zify CstOp Op_size.
 
+#[global]
 Instance Op_wB : CstOp wB :=
   { TCst := 2^63 ; TCstInj := eq_refl }.
 Add Zify CstOp Op_wB.
@@ -34,6 +39,7 @@ Proof.
   apply iff_refl.
 Qed.
 
+#[global]
 Instance Op_ltb : BinOp ltb :=
   {| TBOp := Z.ltb; TBOpInj := ltb_lt |}.
 Add Zify BinOp Op_ltb.
@@ -46,6 +52,7 @@ Proof.
   apply iff_refl.
 Qed.
 
+#[global]
 Instance Op_leb : BinOp leb :=
   {| TBOp := Z.leb; TBOpInj := leb_le |}.
 Add Zify BinOp Op_leb.
@@ -60,6 +67,7 @@ Proof.
   now apply to_Z_inj in H.
 Qed.
 
+#[global]
 Instance Op_eqb : BinOp eqb :=
   {| TBOp := Z.eqb; TBOpInj := eqb_eq |}.
 Add Zify BinOp Op_eqb.
@@ -71,90 +79,112 @@ Proof.
   apply to_Z_inj; auto.
 Qed.
 
+#[global]
 Instance Op_eq : BinRel (@eq int) :=
   {| TR := @eq Z; TRInj := eq_int_inj |}.
 Add Zify BinRel Op_eq.
 
+#[global]
 Instance Op_add : BinOp add :=
   {| TBOp := fun x y => (x + y) mod 9223372036854775808%Z; TBOpInj := add_spec |}%Z.
 Add Zify BinOp Op_add.
 
+#[global]
 Instance Op_sub : BinOp sub :=
   {| TBOp := fun x y => (x - y) mod 9223372036854775808%Z; TBOpInj := sub_spec |}%Z.
 Add Zify BinOp Op_sub.
 
+#[global]
 Instance Op_opp : UnOp Int63.opp :=
   {| TUOp := (fun x => (- x) mod 9223372036854775808)%Z; TUOpInj := (sub_spec 0) |}%Z.
 Add Zify UnOp Op_opp.
 
+#[global]
 Instance Op_oppcarry : UnOp oppcarry :=
   {| TUOp := (fun x => 2^63 -  x - 1)%Z; TUOpInj := oppcarry_spec |}%Z.
 Add Zify UnOp Op_oppcarry.
 
+#[global]
 Instance Op_succ : UnOp succ :=
   {| TUOp := (fun x => (x + 1) mod 2^63)%Z; TUOpInj := succ_spec |}%Z.
 Add Zify UnOp Op_succ.
 
+#[global]
 Instance Op_pred : UnOp Int63.pred :=
   {| TUOp := (fun x => (x - 1) mod 2^63)%Z; TUOpInj := pred_spec |}%Z.
 Add Zify UnOp Op_pred.
 
+#[global]
 Instance Op_mul : BinOp mul :=
   {| TBOp := fun x y => (x * y) mod 9223372036854775808%Z; TBOpInj := mul_spec |}%Z.
 Add Zify BinOp Op_mul.
 
+#[global]
 Instance Op_gcd : BinOp gcd:=
   {| TBOp := (fun x y => Zgcd_alt.Zgcdn (2 * 63)%nat y x) ; TBOpInj := to_Z_gcd |}.
 Add Zify BinOp Op_gcd.
 
+#[global]
 Instance Op_mod : BinOp Int63.mod :=
   {| TBOp := Z.modulo ; TBOpInj := mod_spec |}.
 Add Zify BinOp Op_mod.
 
+#[global]
 Instance Op_subcarry : BinOp subcarry :=
   {| TBOp := (fun x y => (x - y - 1) mod 2^63)%Z ; TBOpInj := subcarry_spec |}.
 Add Zify BinOp Op_subcarry.
 
+#[global]
 Instance Op_addcarry : BinOp addcarry :=
   {| TBOp := (fun x y => (x + y + 1) mod 2^63)%Z ; TBOpInj := addcarry_spec |}.
 Add Zify BinOp Op_addcarry.
 
+#[global]
 Instance Op_lsr : BinOp lsr :=
   {| TBOp := (fun x y => x / 2^ y)%Z ; TBOpInj := lsr_spec |}.
 Add Zify BinOp Op_lsr.
 
+#[global]
 Instance Op_lsl : BinOp lsl :=
   {| TBOp := (fun x y => (x  * 2^ y) mod 2^ 63)%Z ; TBOpInj := lsl_spec |}.
 Add Zify BinOp Op_lsl.
 
+#[global]
 Instance Op_lor : BinOp Int63.lor :=
   {| TBOp := Z.lor ; TBOpInj := lor_spec' |}.
 Add Zify BinOp Op_lor.
 
+#[global]
 Instance Op_land : BinOp Int63.land :=
   {| TBOp := Z.land ; TBOpInj := land_spec' |}.
 Add Zify BinOp Op_land.
 
+#[global]
 Instance Op_lxor : BinOp Int63.lxor :=
   {| TBOp := Z.lxor ; TBOpInj := lxor_spec' |}.
 Add Zify BinOp Op_lxor.
 
+#[global]
 Instance Op_div : BinOp div :=
   {| TBOp := Z.div ; TBOpInj := div_spec |}.
 Add Zify BinOp Op_div.
 
+#[global]
 Instance Op_bit : BinOp bit :=
   {| TBOp := Z.testbit ; TBOpInj := bitE |}.
 Add Zify BinOp Op_bit.
 
+#[global]
 Instance Op_of_Z : UnOp of_Z :=
   { TUOp := (fun x => x mod 9223372036854775808)%Z; TUOpInj := of_Z_spec }.
 Add Zify UnOp Op_of_Z.
 
+#[global]
 Instance Op_to_Z : UnOp to_Z :=
   { TUOp := fun x => x ; TUOpInj := fun x : int => eq_refl }.
 Add Zify UnOp Op_to_Z.
 
+#[global]
 Instance Op_is_zero : UnOp is_zero :=
   { TUOp := (Z.eqb 0) ; TUOpInj := is_zeroE }.
 Add Zify UnOp Op_is_zero.
@@ -170,6 +200,7 @@ Proof.
   symmetry. apply Z.eqb_neq. congruence.
 Qed.
 
+#[global]
 Instance Op_is_even : UnOp is_even :=
   { TUOp := Z.even ; TUOpInj := is_evenE }.
 Add Zify UnOp Op_is_even.

--- a/theories/nsatz/Nsatz.v
+++ b/theories/nsatz/Nsatz.v
@@ -45,9 +45,11 @@ Lemma Rsth : Setoid_Theory R (@eq R).
 constructor;red;intros;subst;trivial.
 Qed.
 
+#[global]
 Instance Rops: (@Ring_ops R 0%R 1%R Rplus Rmult Rminus Ropp (@eq R)).
 Defined.
 
+#[global]
 Instance Rri : (Ring (Ro:=Rops)).
 constructor;
 try (try apply Rsth;
@@ -63,6 +65,7 @@ Class can_compute_Z (z : Z) := dummy_can_compute_Z : True.
 #[global]
 Hint Extern 0 (can_compute_Z ?v) =>
   match isZcst v with true => exact I end : typeclass_instances.
+#[global]
 Instance reify_IZR z lvar {_ : can_compute_Z z} : reify (PEc z) lvar (IZR z).
 Defined.
 
@@ -70,9 +73,11 @@ Lemma R_one_zero: 1%R <> 0%R.
 discrR.
 Qed.
 
+#[global]
 Instance Rcri: (Cring (Rr:=Rri)).
 red. exact Rmult_comm. Defined.
 
+#[global]
 Instance Rdi : (Integral_domain (Rcr:=Rcri)).
 constructor.
 exact Rmult_integral. exact R_one_zero. Defined.

--- a/theories/nsatz/NsatzTactic.v
+++ b/theories/nsatz/NsatzTactic.v
@@ -451,9 +451,11 @@ Tactic Notation "nsatz" "with"
 (* Rational numbers *)
 Require Import QArith.
 
+#[global]
 Instance Qops: (@Ring_ops Q 0%Q 1%Q Qplus Qmult Qminus Qopp Qeq).
 Defined.
 
+#[global]
 Instance Qri : (Ring (Ro:=Qops)).
 constructor.
 try apply Q_Setoid.
@@ -470,9 +472,11 @@ Defined.
 Lemma Q_one_zero: not (Qeq 1%Q 0%Q).
 Proof. unfold Qeq. simpl. lia.  Qed.
 
+#[global]
 Instance Qcri: (Cring (Rr:=Qri)).
 red. exact Qmult_comm. Defined.
 
+#[global]
 Instance Qdi : (Integral_domain (Rcr:=Qcri)).
 constructor.
 exact Qmult_integral. exact Q_one_zero. Defined.
@@ -481,9 +485,11 @@ exact Qmult_integral. exact Q_one_zero. Defined.
 Lemma Z_one_zero: 1%Z <> 0%Z.
 Proof. lia. Qed.
 
+#[global]
 Instance Zcri: (Cring (Rr:=Zr)).
 red. exact Z.mul_comm. Defined.
 
+#[global]
 Instance Zdi : (Integral_domain (Rcr:=Zcri)).
 constructor.
 exact Zmult_integral. exact Z_one_zero. Defined.

--- a/theories/setoid_ring/Cring.v
+++ b/theories/setoid_ring/Cring.v
@@ -128,6 +128,7 @@ Ltac cring:=
   cring_gen;
   cring_compute.
 
+#[global]
 Instance Zcri: (Cring (Rr:=Zr)).
 red. exact Z.mul_comm. Defined.
 

--- a/theories/setoid_ring/Ncring.v
+++ b/theories/setoid_ring/Ncring.v
@@ -28,12 +28,19 @@ Class Ring_ops(T:Type)
    {opp:T->T}
    {ring_eq:T->T->Prop}.
 
+#[global]
 Instance zero_notation(T:Type)`{Ring_ops T}:Zero T:= ring0. 
+#[global]
 Instance one_notation(T:Type)`{Ring_ops T}:One T:= ring1.
+#[global]
 Instance add_notation(T:Type)`{Ring_ops T}:Addition T:= add.
+#[global]
 Instance mul_notation(T:Type)`{Ring_ops T}:@Multiplication T T:= mul.
+#[global]
 Instance sub_notation(T:Type)`{Ring_ops T}:Subtraction T:= sub.
+#[global]
 Instance opp_notation(T:Type)`{Ring_ops T}:Opposite T:= opp.
+#[global]
 Instance eq_notation(T:Type)`{Ring_ops T}:@Equality T:= ring_eq.
 
 Class Ring `{Ro:Ring_ops}:={
@@ -57,10 +64,15 @@ Class Ring `{Ro:Ring_ops}:={
 Instance ring_Ring_ops(R:Type)`{Ring R}
   :@Ring_ops R 0 1 addition multiplication subtraction opposite equality.
 *)
+#[global]
 Existing Instance ring_setoid.
+#[global]
 Existing Instance ring_plus_comp.
+#[global]
 Existing Instance ring_mult_comp.
+#[global]
 Existing Instance ring_sub_comp.
+#[global]
 Existing Instance ring_opp_comp.
 
 Section Ring_power.
@@ -88,6 +100,7 @@ Definition ZN(x:Z):=
     |Zpos p | Zneg p => Npos p
 end.
 
+#[global]
 Instance power_ring {R:Type}`{Ring R} : Power:=
   {power x y := pow_N x (ZN y)}.
 

--- a/theories/setoid_ring/Ncring_initial.v
+++ b/theories/setoid_ring/Ncring_initial.v
@@ -31,9 +31,11 @@ Definition NotConstant := false.
 Lemma Zsth : Equivalence (@eq Z).
 Proof. exact Z.eq_equiv. Qed.
 
+#[global]
 Instance Zops:@Ring_ops Z 0%Z 1%Z Z.add Z.mul Z.sub Z.opp (@eq Z).
 Defined.
 
+#[global]
 Instance Zr: (@Ring _ _ _ _ _ _ _ _ Zops).
 Proof.
 constructor; try apply Zsth; try solve_proper.
@@ -210,5 +212,6 @@ reflexivity.
 
 End ZMORPHISM.
 
+#[global]
 Instance multiplication_phi_ring{R:Type}`{Ring R} : Multiplication  :=
   {multiplication x y := (gen_phiZ x) * y}.

--- a/theories/setoid_ring/Ncring_tac.v
+++ b/theories/setoid_ring/Ncring_tac.v
@@ -25,10 +25,12 @@ Set Implicit Arguments.
 
 Class nth (R:Type) (t:R) (l:list R) (i:nat).
 
+#[global]
 Instance  Ifind0 (R:Type) (t:R) l
  : nth t(t::l) 0.
 Defined.
 
+#[global]
 Instance  IfindS (R:Type) (t2 t1:R) l i 
  {_:nth t1 l i} 
  : nth t1 (t2::l) (S i) | 1.
@@ -36,10 +38,12 @@ Defined.
 
 Class closed (T:Type) (l:list T).
 
+#[global]
 Instance Iclosed_nil T 
  : closed (T:=T) nil.
 Defined.
 
+#[global]
 Instance Iclosed_cons T t (l:list T) 
  {_:closed l} 
  : closed (t::l).
@@ -47,31 +51,37 @@ Defined.
 
 Class reify (R:Type)`{Rr:Ring (T:=R)} (e:PExpr Z) (lvar:list R) (t:R).
 
+#[global]
 Instance  reify_zero (R:Type)  lvar op
  `{Ring (T:=R)(ring0:=op)}
  : reify (ring0:=op)(PEc 0%Z) lvar op.
 Defined.
 
+#[global]
 Instance  reify_one (R:Type)  lvar op
  `{Ring (T:=R)(ring1:=op)}
  : reify (ring1:=op) (PEc 1%Z) lvar op.
 Defined.
 
+#[global]
 Instance  reifyZ0 (R:Type)  lvar 
  `{Ring (T:=R)}
  : reify (PEc Z0) lvar Z0|11.
 Defined.
 
+#[global]
 Instance  reifyZpos (R:Type)  lvar (p:positive)
  `{Ring (T:=R)}
  : reify (PEc (Zpos p)) lvar (Zpos p)|11.
 Defined.
 
+#[global]
 Instance  reifyZneg (R:Type)  lvar (p:positive)
  `{Ring (T:=R)}
  : reify (PEc (Zneg p)) lvar (Zneg p)|11.
 Defined.
 
+#[global]
 Instance  reify_add (R:Type)
   e1 lvar t1 e2 t2 op 
  `{Ring (T:=R)(add:=op)}
@@ -80,6 +90,7 @@ Instance  reify_add (R:Type)
  : reify (add:=op) (PEadd e1 e2) lvar (op t1 t2).
 Defined.
 
+#[global]
 Instance  reify_mul (R:Type) 
   e1 lvar t1 e2 t2 op 
  `{Ring (T:=R)(mul:=op)}
@@ -88,6 +99,7 @@ Instance  reify_mul (R:Type)
  : reify (mul:=op) (PEmul e1 e2) lvar (op t1 t2)|10.
 Defined.
 
+#[global]
 Instance  reify_mul_ext (R:Type) `{Ring R}
   lvar (z:Z) e2 t2 
  `{Ring (T:=R)}
@@ -96,6 +108,7 @@ Instance  reify_mul_ext (R:Type) `{Ring R}
       (@multiplication Z _ _ z t2)|9.
 Defined.
 
+#[global]
 Instance  reify_sub (R:Type)
  e1 lvar t1 e2 t2 op
  `{Ring (T:=R)(sub:=op)}
@@ -104,6 +117,7 @@ Instance  reify_sub (R:Type)
  : reify (sub:=op) (PEsub e1 e2) lvar (op t1 t2).
 Defined.
 
+#[global]
 Instance  reify_opp (R:Type)
  e1 lvar t1  op
  `{Ring (T:=R)(opp:=op)}
@@ -111,6 +125,7 @@ Instance  reify_opp (R:Type)
  : reify (opp:=op) (PEopp e1) lvar (op t1).
 Defined.
 
+#[global]
 Instance  reify_pow (R:Type) `{Ring R}
  e1 lvar t1 n 
  `{Ring (T:=R)}
@@ -118,6 +133,7 @@ Instance  reify_pow (R:Type) `{Ring R}
  : reify (PEpow e1 n) lvar (pow_N t1 n)|1.
 Defined.
 
+#[global]
 Instance  reify_var (R:Type) t lvar i 
  `{nth R t lvar i}
  `{Rr: Ring (T:=R)}
@@ -128,11 +144,13 @@ Defined.
 Class reifylist (R:Type)`{Rr:Ring (T:=R)} (lexpr:list (PExpr Z)) (lvar:list R) 
   (lterm:list R).
 
+#[global]
 Instance reify_nil (R:Type) lvar 
  `{Rr: Ring (T:=R)}
  : reifylist (Rr:= Rr) nil lvar (@nil R).
 Defined.
 
+#[global]
 Instance reify_cons (R:Type) e1 lvar t1 lexpr2 lterm2
  `{Rr: Ring (T:=R)}
  {_:reify (Rr:= Rr) e1 lvar t1}

--- a/theories/setoid_ring/Rings_Q.v
+++ b/theories/setoid_ring/Rings_Q.v
@@ -14,9 +14,11 @@ Require Export Integral_domain.
 (* Rational numbers *)
 Require Import QArith.
 
+#[global]
 Instance Qops: (@Ring_ops Q 0%Q 1%Q Qplus Qmult Qminus Qopp Qeq).
 Defined.
 
+#[global]
 Instance Qri : (Ring (Ro:=Qops)).
 constructor.
 try apply Q_Setoid. 
@@ -30,12 +32,14 @@ apply Qopp_comp.
 reflexivity. exact Qplus_opp_r.
 Defined.
 
+#[global]
 Instance Qcri: (Cring (Rr:=Qri)).
 red. exact Qmult_comm. Defined.
 
 Lemma Q_one_zero: not (Qeq 1%Q 0%Q).
 unfold Qeq. simpl. auto with *. Qed.
 
+#[global]
 Instance Qdi : (Integral_domain (Rcr:=Qcri)). 
 constructor. 
 exact Qmult_integral. exact Q_one_zero. Defined.

--- a/theories/setoid_ring/Rings_R.v
+++ b/theories/setoid_ring/Rings_R.v
@@ -19,9 +19,11 @@ Lemma Rsth : Setoid_Theory R (@eq R).
 constructor;red;intros;subst;trivial.
 Qed.
 
+#[global]
 Instance Rops: (@Ring_ops R 0%R 1%R Rplus Rmult Rminus Ropp (@eq R)).
 Defined.
 
+#[global]
 Instance Rri : (Ring (Ro:=Rops)).
 constructor;
 try (try apply Rsth;
@@ -33,6 +35,7 @@ try (try apply Rsth;
 exact Rplus_opp_r.
 Defined.
 
+#[global]
 Instance Rcri: (Cring (Rr:=Rri)).
 red. exact Rmult_comm. Defined.
 
@@ -40,6 +43,7 @@ Lemma R_one_zero: 1%R <> 0%R.
 discrR.
 Qed.
 
+#[global]
 Instance Rdi : (Integral_domain (Rcr:=Rcri)). 
 constructor. 
 exact Rmult_integral. exact R_one_zero. Defined.

--- a/theories/setoid_ring/Rings_Z.v
+++ b/theories/setoid_ring/Rings_Z.v
@@ -12,12 +12,14 @@ Require Export Cring.
 Require Export Integral_domain.
 Require Export Ncring_initial.
 
+#[global]
 Instance Zcri: (Cring (Rr:=Zr)).
 red. exact Z.mul_comm. Defined.
 
 Lemma Z_one_zero: 1%Z <> 0%Z.
 Proof. discriminate. Qed.
 
+#[global]
 Instance Zdi : (Integral_domain (Rcr:=Zcri)). 
 constructor. 
 exact Zmult_integral. exact Z_one_zero. Defined.

--- a/theories/ssr/ssrclasses.v
+++ b/theories/ssr/ssrclasses.v
@@ -28,5 +28,7 @@ End Defs.
 Register Reflexive as plugins.ssreflect.reflexive_type.
 Register reflexivity as plugins.ssreflect.reflexive_proof.
 
+#[global]
 Instance eq_Reflexive {A : Type} : Reflexive (@eq A) := @eq_refl A.
+#[global]
 Instance iff_Reflexive : Reflexive iff := iff_refl.

--- a/theories/ssr/ssrsetoid.v
+++ b/theories/ssr/ssrsetoid.v
@@ -31,6 +31,7 @@ Require Import Relation_Definitions.
 (** Reconcile [Coq.Classes.RelationClasses.Reflexive] with
     [Coq.ssr.ssrclasses.Reflexive] *)
 
+#[global]
 Instance compat_Reflexive :
   forall {A} {R : relation A},
     RelationClasses.Reflexive R ->


### PR DESCRIPTION
This allows to follow the same transition path as mere hints.

Fixes #13562

- [X] Added / updated test-suite
- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
- [x] Overlay pull requests (if this breaks 3rd party developments in CI, see
https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md for details)

Overlay PR:
- aac-tactics: https://github.com/coq-community/aac-tactics/pull/72