### PR TITLE
ci: override coq url in platform script

### DIFF
--- a/dev/ci/platform-windows.bat
+++ b/dev/ci/platform-windows.bat
@@ -48,7 +48,10 @@ call coq_platform_make_windows.bat ^
   -extent=i ^
   -parallel=p ^
   -jobs=2 ^
-  -switch=d || GOTO ErrorCopyLogFilesAndExit
+  -switch=d ^
+  -override-dev-pkg="coq=%CI_PROJECT_URL%/-/archive/%CI_COMMIT_SHA%/coq-%CI_COMMIT_SHA%.tar.gz" ^
+  -override-dev-pkg="coqide=%CI_PROJECT_URL%/-/archive/%CI_COMMIT_SHA%/coq-%CI_COMMIT_SHA%.tar.gz" ^
+  || GOTO ErrorCopyLogFilesAndExit
 
 cd ..
 


### PR DESCRIPTION
This PR passes to the platform script a flag to override the coq archive url.
Depends on https://github.com/coq/platform/pull/103

CC @MSoegtropIMC 

Closes #14204