### PR TITLE
[debugger] Restore ~loc parm in "Parsable.make", allow setting loc.bp

### DIFF
--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -17,7 +17,7 @@ module type S = sig
 
   module Parsable : sig
     type t
-    val make : ?source:Loc.source -> char Stream.t -> t
+    val make : ?loc:Loc.t -> char Stream.t -> t
     val comments : t -> ((int * int) * string) list
   end
 
@@ -1614,10 +1614,13 @@ module Parsable = struct
       L.State.drop ();
       Exninfo.iraise (exn,info)
 
-  let make ?source cs =
+  let make ?loc cs =
     let lexer_state = ref (L.State.init ()) in
     L.State.set !lexer_state;
-    let ts = L.tok_func ?source cs in
+    (match loc with
+    | Some loc -> L.State.set_loc_offset Loc.(loc.bp)
+    | None -> ());
+    let ts = L.tok_func ?loc cs in
     lexer_state := L.State.get ();
     {pa_tok_strm = ts; lexer_state}
 

--- a/gramlib/grammar.mli
+++ b/gramlib/grammar.mli
@@ -27,7 +27,7 @@ module type S = sig
 
   module Parsable : sig
     type t
-    val make : ?source:Loc.source -> char Stream.t -> t
+    val make : ?loc:Loc.t -> char Stream.t -> t
     val comments : t -> ((int * int) * string) list
   end
 

--- a/gramlib/plexing.ml
+++ b/gramlib/plexing.ml
@@ -2,7 +2,7 @@
 (* plexing.ml,v *)
 (* Copyright (c) INRIA 2007-2017 *)
 
-type 'te lexer_func = ?source:Loc.source -> char Stream.t -> 'te LStream.t
+type 'te lexer_func = ?loc:Loc.t -> char Stream.t -> 'te LStream.t
 
 module type S = sig
   type te
@@ -23,6 +23,7 @@ module type S = sig
     val get : unit -> t
     val drop : unit -> unit
     val get_comments : t -> ((int * int) * string) list
+    val set_loc_offset : int -> unit
   end
 
 end

--- a/gramlib/plexing.mli
+++ b/gramlib/plexing.mli
@@ -11,7 +11,7 @@
 (** Lexer type *)
 
 (** Returning a stream equipped with a location function *)
-type 'te lexer_func = ?source:Loc.source -> char Stream.t -> 'te LStream.t
+type 'te lexer_func = ?loc:Loc.t -> char Stream.t -> 'te LStream.t
 
 module type S = sig
   type te
@@ -32,6 +32,7 @@ module type S = sig
     val get : unit -> t
     val drop : unit -> unit
     val get_comments : t -> ((int * int) * string) list
+    val set_loc_offset : int -> unit
   end
 
 end

--- a/lib/lStream.ml
+++ b/lib/lStream.ml
@@ -18,7 +18,7 @@ type 'a t = {
   mutable max_peek : int;
 }
 
-let from ?(source=Loc.ToplevelInput) f =
+let from ?(loc=Loc.(initial ToplevelInput)) f =
   let loct = Hashtbl.create 207 in
   let loct_func loct i = Hashtbl.find loct i in
   let loct_add loct i loc = Hashtbl.add loct i loc in
@@ -29,8 +29,7 @@ let from ?(source=Loc.ToplevelInput) f =
         | None -> None
         | Some (a,loc) ->
         loct_add loct i loc; Some a) in
-  let initial = Loc.initial source in
-  let fun_loc i = if i = 0 then initial else loct_func loct (i - 1) in
+  let fun_loc i = if i = 0 then loc else loct_func loct (i - 1) in
   { strm; max_peek = 0; fun_loc }
 
 let count strm = Stream.count strm.strm

--- a/lib/lStream.mli
+++ b/lib/lStream.mli
@@ -11,7 +11,7 @@
 (** Extending streams with a (non-canonical) location function *)
 
 type 'a t
-val from : ?source:Loc.source -> (int -> ('a * Loc.t) option) -> 'a t
+val from : ?loc:Loc.t -> (int -> ('a * Loc.t) option) -> 'a t
 
 (** Returning the loc of the last consumed element or the initial loc
     if no element is consumed *)

--- a/parsing/pcoq.ml
+++ b/parsing/pcoq.ml
@@ -191,9 +191,9 @@ let eoi_entry en =
 (* Parse a string, does NOT check if the entire string was read
    (use eoi_entry) *)
 
-let parse_string f ?source x =
+let parse_string f ?loc x =
   let strm = Stream.of_string x in
-  Entry.parse f (Parsable.make ?source strm)
+  Entry.parse f (Parsable.make ?loc strm)
 
 (* universes not used by Coq build but still used by some plugins *)
 type gram_universe = string

--- a/parsing/pcoq.mli
+++ b/parsing/pcoq.mli
@@ -119,7 +119,7 @@ end
 
 (** Parse a string *)
 
-val parse_string : 'a Entry.t -> ?source:Loc.source -> string -> 'a
+val parse_string : 'a Entry.t -> ?loc:Loc.t -> string -> 'a
 val eoi_entry : 'a Entry.t -> 'a Entry.t
 
 type gram_universe [@@deprecated "Deprecated in 8.13"]

--- a/toplevel/vernac.ml
+++ b/toplevel/vernac.ml
@@ -88,7 +88,7 @@ let load_vernac_core ~echo ~check ~interactive ~state file =
   let input_cleanup () = close_in in_chan; Option.iter close_in in_echo in
 
   let in_pa =
-    Pcoq.Parsable.make ~source:(Loc.InFile file)
+    Pcoq.Parsable.make ~loc:(Loc.(initial (InFile file)))
       (Stream.of_channel in_chan) in
   let open State in
 

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -186,7 +186,7 @@ and vernac_load ~verbosely fname =
   let input =
     let longfname = Loadpath.locate_file fname in
     let in_chan = Util.open_utf8_file_in longfname in
-    Pcoq.Parsable.make ~source:(Loc.InFile longfname) (Stream.of_channel in_chan) in
+    Pcoq.Parsable.make ~loc:(Loc.(initial (InFile longfname))) (Stream.of_channel in_chan) in
   (* Parsing loop *)
   let v_mod = if verbosely then Flags.verbosely else Flags.silently in
   let parse_sentence proof_mode = Flags.with_option Flags.we_are_parsing


### PR DESCRIPTION
Restores the `~loc` parameter to `Grammar.Parsable.make`, reversing some of the change in e07efb3.  It also adds `set_loc_offset` for the benefit of the debugger.  This allows the Coq-returned Loc offset upon hitting a breakpoint to be relative to the beginning of the buffer rather than relative to the beginning of the statement (the latter being useless).  The new function will be used in the next debugger PR.
