### PR TITLE
[build] Fix missing deps to trigger coqide rebuild in bridge mode

### DIFF
--- a/Makefile.ide
+++ b/Makefile.ide
@@ -19,6 +19,15 @@ IDEFILES=$(wildcard ide/*.lang) ide/coq_style.xml ide/coq.png) $(IDEBINDINGS)
 
 .PHONY: coqide
 
+ALL_IDE_FILES=$(shell find ide/coqide -name '*.ml' -or -name '*.mli' -or -name '*.mll' -or -name '*.c' -or -name '*.h')
+PROTO_IDE_FILES=$(shell find ide/coqide/protocol -name '*.ml' -or -name '*.mli' -or -name '*.mll' -or -name '*.c' -or -name '*.h')
+
+# We depend on all ide source files to trigger the dune rebuild
+$(COQIDE): $(ALL_IDE_FILES)
+
+# For idetop we depend on idetop.ml + all source files as it links to Coq
+$(IDETOP): $(ALL_ML_SOURCE_FILES) $(PROTO_IDE_FILES) ide/coqide/idetop.ml
+
 ifeq ($(HASCOQIDE),no)
 coqide:
 else


### PR DESCRIPTION
Indeed we didn't specify the right dependencies for those in the
bridge, as coqide is a different "package" and not included in `ALL_SOURCE_FILES`

Fixes #14197
