### PR TITLE
[debugger] Preserve Loc.t info for Ltac constructs

### DIFF
--- a/dev/ci/user-overlays/14224-jfehrle-ltac_loc_info.sh
+++ b/dev/ci/user-overlays/14224-jfehrle-ltac_loc_info.sh
@@ -1,0 +1,8 @@
+overlay aac_tactics https://github.com/jfehrle/aac-tactics ltac_loc_info 14224
+overlay coqhammer https://github.com/jfehrle/coqhammer ltac_loc_info 14224
+overlay elpi https://github.com/jfehrle/coq-elpi ltac_loc_info2 14224
+overlay equations https://github.com/jfehrle/Coq-Equations ltac_loc_info 14224
+overlay metacoq https://github.com/jfehrle/metacoq ltac_loc_info 14224
+overlay mtac2 https://github.com/jfehrle/Mtac2 ltac_loc_info 14224
+overlay relation_algebra https://github.com/jfehrle/relation-algebra ltac_loc_info 14224
+overlay rewriter https://github.com/jfehrle/rewriter ltac_loc_info 14224

--- a/plugins/firstorder/g_ground.mlg
+++ b/plugins/firstorder/g_ground.mlg
@@ -39,7 +39,7 @@ let default_intuition_tac =
   let name = { Tacexpr.mltac_plugin = "firstorder_plugin"; mltac_tactic = "auto_with"; } in
   let entry = { Tacexpr.mltac_name = name; mltac_index = 0 } in
   Tacenv.register_ml_tactic name [| tac |];
-  Tacexpr.TacML (CAst.make (entry, []))
+  CAst.make (Tacexpr.TacML (entry, []))
 
 let (set_default_solver, default_solver, print_default_solver) =
   Tactic_option.declare_tactic_option ~default:default_intuition_tac "Firstorder default solver"

--- a/plugins/ltac/coretactics.mlg
+++ b/plugins/ltac/coretactics.mlg
@@ -308,7 +308,7 @@ open Tacexpr
 let initial_atomic () =
   let nocl = {onhyps=Some[];concl_occs=AllOccurrences} in
   let iter (s, t) =
-    let body = TacAtom (CAst.make t) in
+    let body = CAst.make (TacAtom t) in
     Tacenv.register_ltac false false (Names.Id.of_string s) body
   in
   let () = List.iter iter
@@ -321,9 +321,9 @@ let initial_atomic () =
   in
   let iter (s, t) = Tacenv.register_ltac false false (Names.Id.of_string s) t in
   List.iter iter
-      [ "idtac",TacId [];
-        "fail", TacFail(TacLocal,ArgArg 0,[]);
-        "fresh", TacArg(CAst.make @@ TacFreshId [])
+      [ "idtac", CAst.make (TacId []);
+        "fail", CAst.make (TacFail (TacLocal,ArgArg 0,[]));
+        "fresh", CAst.make @@ TacArg(TacFreshId [])
       ]
 
 let () = Mltop.declare_cache_obj initial_atomic "ltac_plugin"
@@ -354,8 +354,10 @@ let initial_tacticals () =
   let varn n = Reference (ArgVar (CAst.make (idn n))) in
   let iter (s, t) = Tacenv.register_ltac false false (Id.of_string s) t in
   List.iter iter [
-    "first", TacFun ([Name (idn 0)], TacML (CAst.make (initial_entry "first", [varn 0])));
-    "solve", TacFun ([Name (idn 0)], TacML (CAst.make (initial_entry "solve", [varn 0])));
+    "first", CAst.make (TacFun
+        ([Name (idn 0)], CAst.make (TacML (initial_entry "first", [varn 0]))));
+    "solve", CAst.make (TacFun
+        ([Name (idn 0)], CAst.make (TacML (initial_entry "solve", [varn 0]))));
   ]
 
 let () = Mltop.declare_cache_obj initial_tacticals "ltac_plugin"

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -772,7 +772,7 @@ let case_eq_intros_rewrite x =
 let rec find_a_destructable_match sigma t =
   let cl = induction_arg_of_quantified_hyp (NamedHyp (Id.of_string "x")) in
   let cl = [cl, (None, None), None], None in
-  let dest = TacAtom (CAst.make @@ TacInductionDestruct(false, false, cl)) in
+  let dest = CAst.make @@ TacAtom (TacInductionDestruct(false, false, cl)) in
   match EConstr.kind sigma t with
     | Case (_,_,_,_,_,x,_) when closed0 sigma x ->
         if isVar sigma x then

--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -32,7 +32,7 @@ open Pltac
 let fail_default_value = Locus.ArgArg 0
 
 let arg_of_expr = function
-    TacArg { CAst.v } -> v
+    { CAst.v=(TacArg v) } -> v
   | e -> Tacexp (e:raw_tactic_expr)
 
 let genarg_of_unit () = in_gen (rawwit Stdarg.wit_unit) ()
@@ -80,17 +80,17 @@ GRAMMAR EXTEND Gram
 
   tactic_then_last:
     [ [ "|"; lta = LIST0 (OPT ltac_expr) SEP "|" ->
-        { Array.map (function None -> TacId [] | Some t -> t) (Array.of_list lta) }
+        { Array.map (function None -> CAst.make ~loc (TacId []) | Some t -> t) (Array.of_list lta) }
       | -> { [||] }
     ] ]
   ;
   for_each_goal:
     [ [ ta = ltac_expr; "|"; tg = for_each_goal -> { let (first,last) = tg in (ta::first, last) }
       | ta = ltac_expr; ".."; l = tactic_then_last -> { ([], Some (ta, l)) }
-      | ".."; l = tactic_then_last -> { ([], Some (TacId [], l)) }
+      | ".."; l = tactic_then_last -> { ([], Some (CAst.make ~loc (TacId []), l)) }
       | ta = ltac_expr -> { ([ta], None) }
-      | "|"; tg = for_each_goal -> { let (first,last) = tg in (TacId [] :: first, last) }
-      | -> { ([TacId []], None) }
+      | "|"; tg = for_each_goal -> { let (first,last) = tg in (CAst.make ~loc (TacId []) :: first, last) }
+      | -> { ([CAst.make ~loc (TacId [])], None) }
     ] ]
   ;
   tactic_then_locality: (* [true] for the local variant [TacThens] and [false]
@@ -101,67 +101,68 @@ GRAMMAR EXTEND Gram
     [ "5" RIGHTA
       [ te = binder_tactic -> { te } ]
     | "4" LEFTA
-      [ ta0 = ltac_expr; ";"; ta1 = binder_tactic -> { TacThen (ta0, ta1) }
-      | ta0 = ltac_expr; ";"; ta1 = ltac_expr -> { TacThen (ta0,ta1) }
+      [ ta0 = ltac_expr; ";"; ta1 = binder_tactic -> { CAst.make ~loc (TacThen (ta0, ta1)) }
+      | ta0 = ltac_expr; ";"; ta1 = ltac_expr -> { CAst.make ~loc (TacThen (ta0,ta1)) }
       | ta0 = ltac_expr; ";"; l = tactic_then_locality; tg = for_each_goal; "]" -> {
           let (first,tail) = tg in
           match l , tail with
-          | false , Some (t,last) -> TacThen (ta0,TacExtendTac (Array.of_list first, t, last))
-          | true  , Some (t,last) -> TacThens3parts (ta0, Array.of_list first, t, last)
-          | false , None -> TacThen (ta0,TacDispatch first)
-          | true  , None -> TacThens (ta0,first) } ]
+          | false , Some (t,last) -> CAst.make ~loc (TacThen (ta0,
+              CAst.make ~loc (TacExtendTac (Array.of_list first, t, last))))
+          | true  , Some (t,last) -> CAst.make ~loc (TacThens3parts (ta0, Array.of_list first, t, last))
+          | false , None -> CAst.make ~loc (TacThen (ta0, CAst.make ~loc (TacDispatch first)))
+          | true  , None -> CAst.make ~loc (TacThens (ta0,first)) } ]
     | "3" RIGHTA
-      [ IDENT "try"; ta = ltac_expr -> { TacTry ta }
-      | IDENT "do"; n = nat_or_var; ta = ltac_expr -> { TacDo (n,ta) }
-      | IDENT "timeout"; n = nat_or_var; ta = ltac_expr -> { TacTimeout (n,ta) }
-      | IDENT "time"; s = OPT string; ta = ltac_expr -> { TacTime (s,ta) }
-      | IDENT "repeat"; ta = ltac_expr -> { TacRepeat ta }
-      | IDENT "progress"; ta = ltac_expr -> { TacProgress ta }
-      | IDENT "once"; ta = ltac_expr -> { TacOnce ta }
-      | IDENT "exactly_once"; ta = ltac_expr -> { TacExactlyOnce ta }
-      | IDENT "infoH"; ta = ltac_expr -> { TacShowHyps ta }
+      [ IDENT "try"; ta = ltac_expr -> { CAst.make ~loc (TacTry ta) }
+      | IDENT "do"; n = nat_or_var; ta = ltac_expr -> { CAst.make ~loc (TacDo (n,ta)) }
+      | IDENT "timeout"; n = nat_or_var; ta = ltac_expr -> { CAst.make ~loc (TacTimeout (n,ta)) }
+      | IDENT "time"; s = OPT string; ta = ltac_expr -> { CAst.make ~loc (TacTime (s,ta)) }
+      | IDENT "repeat"; ta = ltac_expr -> { CAst.make ~loc (TacRepeat ta) }
+      | IDENT "progress"; ta = ltac_expr -> { CAst.make ~loc (TacProgress ta) }
+      | IDENT "once"; ta = ltac_expr -> { CAst.make ~loc (TacOnce  ta) }
+      | IDENT "exactly_once"; ta = ltac_expr -> { CAst.make ~loc (TacExactlyOnce ta) }
+      | IDENT "infoH"; ta = ltac_expr -> { CAst.make ~loc (TacShowHyps ta) }
 (*To do: put Abstract in Refiner*)
-      | IDENT "abstract"; tc = NEXT -> { TacAbstract (tc,None) }
+      | IDENT "abstract"; tc = NEXT -> { CAst.make ~loc (TacAbstract (tc,None)) }
       | IDENT "abstract"; tc = NEXT; "using";  s = ident ->
-        { TacAbstract (tc,Some s) }
-      | IDENT "only"; sel = selector; ":"; ta = ltac_expr -> { TacSelect (sel, ta) } ]
+        { CAst.make ~loc (TacAbstract (tc,Some s)) }
+      | IDENT "only"; sel = selector; ":"; ta = ltac_expr -> { CAst.make ~loc (TacSelect (sel, ta)) } ]
 (*End of To do*)
     | "2" RIGHTA
-      [ ta0 = ltac_expr; "+"; ta1 = binder_tactic -> { TacOr (ta0,ta1) }
-      | ta0 = ltac_expr; "+"; ta1 = ltac_expr -> { TacOr (ta0,ta1) }
+      [ ta0 = ltac_expr; "+"; ta1 = binder_tactic -> { CAst.make ~loc (TacOr (ta0,ta1)) }
+      | ta0 = ltac_expr; "+"; ta1 = ltac_expr -> { CAst.make ~loc (TacOr (ta0,ta1)) }
       | IDENT "tryif" ; ta = ltac_expr ;
               "then" ; tat = ltac_expr ;
-              "else" ; tae = ltac_expr -> { TacIfThenCatch(ta,tat,tae) }
-      | ta0 = ltac_expr; "||"; ta1 = binder_tactic -> { TacOrelse (ta0,ta1) }
-      | ta0 = ltac_expr; "||"; ta1 = ltac_expr -> { TacOrelse (ta0,ta1) } ]
+              "else" ; tae = ltac_expr -> { CAst.make ~loc (TacIfThenCatch (ta,tat,tae)) }
+      | ta0 = ltac_expr; "||"; ta1 = binder_tactic -> { CAst.make ~loc (TacOrelse (ta0,ta1)) }
+      | ta0 = ltac_expr; "||"; ta1 = ltac_expr -> { CAst.make ~loc (TacOrelse (ta0,ta1)) } ]
     | "1" RIGHTA
       [ b = match_key; IDENT "goal"; "with"; mrl = match_context_list; "end" ->
-          { TacMatchGoal (b,false,mrl) }
+          { CAst.make ~loc (TacMatchGoal (b,false,mrl)) }
       | b = match_key; IDENT "reverse"; IDENT "goal"; "with";
         mrl = match_context_list; "end" ->
-          { TacMatchGoal (b,true,mrl) }
+          { CAst.make ~loc (TacMatchGoal (b,true,mrl)) }
       |	b = match_key; c = ltac_expr; "with"; mrl = match_list; "end" ->
-          { TacMatch (b,c,mrl) }
+          { CAst.make ~loc (TacMatch (b,c,mrl)) }
       | IDENT "first" ; "["; l = LIST0 ltac_expr SEP "|"; "]" ->
-          { TacFirst l }
+          { CAst.make ~loc (TacFirst l) }
       | IDENT "solve" ; "["; l = LIST0 ltac_expr SEP "|"; "]" ->
-          { TacSolve l }
-      | IDENT "idtac"; l = LIST0 message_token -> { TacId l }
+          { CAst.make ~loc (TacSolve l) }
+      | IDENT "idtac"; l = LIST0 message_token -> { CAst.make ~loc (TacId l) }
       | g=failkw; n = [ n = nat_or_var -> { n } | -> { fail_default_value } ];
-          l = LIST0 message_token -> { TacFail (g,n,l) }
+          l = LIST0 message_token -> { CAst.make ~loc (TacFail (g,n,l)) }
       | st = simple_tactic -> { st }
-      | a = tactic_value -> { TacArg(CAst.make ~loc a) }
+      | a = tactic_value -> { CAst.make ~loc (TacArg a) }
       | r = reference; la = LIST0 tactic_arg ->
-        { TacArg(CAst.make ~loc @@ TacCall (CAst.make ~loc (r,la))) } ]
+        { CAst.make ~loc @@ TacArg (TacCall (CAst.make ~loc (r,la))) } ]
     | "0"
       [ "("; a = ltac_expr; ")" -> { a }
       | "["; ">"; tg = for_each_goal; "]" -> {
           let (tf,tail) = tg in
           begin match tail with
-          | Some (t,tl) -> TacExtendTac(Array.of_list tf,t,tl)
-          | None -> TacDispatch tf
+          | Some (t,tl) -> CAst.make ~loc (TacExtendTac (Array.of_list tf,t,tl))
+          | None -> CAst.make ~loc (TacDispatch tf)
           end }
-      | a = tactic_atom -> { TacArg (CAst.make ~loc a) } ] ]
+      | a = tactic_atom -> { CAst.make ~loc (TacArg a) } ] ]
   ;
   failkw:
   [ [ IDENT "fail" -> { TacLocal } | IDENT "gfail" -> { TacGlobal } ] ]
@@ -170,10 +171,10 @@ GRAMMAR EXTEND Gram
   binder_tactic:
     [ RIGHTA
       [ "fun"; it = LIST1 input_fun ; "=>"; body = ltac_expr LEVEL "5" ->
-          { TacFun (it,body) }
+          { CAst.make ~loc (TacFun (it,body)) }
       | "let"; isrec = [IDENT "rec" -> { true } | -> { false } ];
           llc = LIST1 let_clause SEP "with"; "in";
-          body = ltac_expr LEVEL "5" -> { TacLetIn (isrec,llc,body) } ] ]
+          body = ltac_expr LEVEL "5" -> { CAst.make ~loc (TacLetIn (isrec,llc,body)) } ] ]
   ;
   (* Tactic arguments to the right of an application *)
   tactic_arg:
@@ -228,7 +229,7 @@ GRAMMAR EXTEND Gram
       | na = ["_" -> { CAst.make ~loc Anonymous } ]; ":="; te = ltac_expr ->
          { (na, arg_of_expr te) }
       | idr = identref; args = LIST1 input_fun; ":="; te = ltac_expr ->
-         { (CAst.map (fun id -> Name id) idr, arg_of_expr (TacFun(args,te))) } ] ]
+         { (CAst.map (fun id -> Name id) idr, arg_of_expr (CAst.make ~loc (TacFun (args,te)))) } ] ]
   ;
   match_pattern:
     [ [ IDENT "context";  oid = OPT Constr.ident;
@@ -283,10 +284,10 @@ GRAMMAR EXTEND Gram
   tacdef_body:
     [ [ name = Constr.global; it=LIST1 input_fun;
         redef = ltac_def_kind; body = ltac_expr ->
-        { if redef then Tacexpr.TacticRedefinition (name, TacFun (it, body))
+        { if redef then Tacexpr.TacticRedefinition (name, CAst.make ~loc (TacFun (it, body)))
           else
             let id = reference_to_id name in
-            Tacexpr.TacticDefinition (id, TacFun (it, body)) }
+            Tacexpr.TacticDefinition (id, CAst.make ~loc (TacFun (it, body))) }
       | name = Constr.global; redef = ltac_def_kind;
         body = ltac_expr ->
         { if redef then Tacexpr.TacticRedefinition (name, body)
@@ -386,11 +387,16 @@ END
 
 {
 
-let rm_abstract = function
+let rm_abstract tac =
+  let (loc, tac2) = CAst.(tac.loc, tac.v) in
+  match tac2 with
   | TacAbstract (t,_) -> t, true
-  | TacSolve [TacAbstract (t,_)] -> TacSolve [t], true
-  | x -> x, false
-let is_explicit_terminator = function TacSolve _ -> true | _ -> false
+  | TacSolve [ {CAst.loc; v=TacAbstract(t,_)} ] -> CAst.make ?loc (TacSolve [t]), true
+  | _ -> tac, false
+
+let is_explicit_terminator = function
+  | {CAst.v=(TacSolve _)} -> true
+  | _ -> false
 
 }
 
@@ -486,7 +492,7 @@ let pr_tacdef_body env sigma tacdef_body =
   in
   let idl, body =
     match body with
-      | Tacexpr.TacFun (idl,b) -> idl,b
+      | {CAst.v=(Tacexpr.TacFun (idl,b))} -> idl,b
       | _ -> [], body in
   id ++
     prlist (function Name.Anonymous -> str " _"

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -503,194 +503,194 @@ GRAMMAR EXTEND Gram
     [ [
       (* Basic tactics *)
         IDENT "intros"; pl = ne_intropatterns ->
-          { TacAtom (CAst.make ~loc @@ TacIntroPattern (false,pl)) }
+          { CAst.make ~loc @@ TacAtom (TacIntroPattern (false,pl)) }
       | IDENT "intros" ->
-          { TacAtom (CAst.make ~loc @@ TacIntroPattern (false,[CAst.make ~loc @@IntroForthcoming false])) }
+          { CAst.make ~loc @@ TacAtom (TacIntroPattern (false,[CAst.make ~loc @@IntroForthcoming false])) }
       | IDENT "eintros"; pl = ne_intropatterns ->
-          { TacAtom (CAst.make ~loc @@ TacIntroPattern (true,pl)) }
+          { CAst.make ~loc @@ TacAtom (TacIntroPattern (true,pl)) }
       | IDENT "eintros" ->
-          { TacAtom (CAst.make ~loc @@ TacIntroPattern (true,[CAst.make ~loc @@IntroForthcoming false])) }
+          { CAst.make ~loc @@ TacAtom (TacIntroPattern (true,[CAst.make ~loc @@IntroForthcoming false])) }
 
       | IDENT "apply"; cl = LIST1 constr_with_bindings_arg SEP ",";
-          inhyp = in_hyp_as -> { TacAtom (CAst.make ~loc @@ TacApply (true,false,cl,inhyp)) }
+          inhyp = in_hyp_as -> { CAst.make ~loc @@ TacAtom (TacApply (true,false,cl,inhyp)) }
       | IDENT "eapply"; cl = LIST1 constr_with_bindings_arg SEP ",";
-          inhyp = in_hyp_as -> { TacAtom (CAst.make ~loc @@ TacApply (true,true,cl,inhyp)) }
+          inhyp = in_hyp_as -> { CAst.make ~loc @@ TacAtom (TacApply (true,true,cl,inhyp)) }
       | IDENT "simple"; IDENT "apply";
           cl = LIST1 constr_with_bindings_arg SEP ",";
-          inhyp = in_hyp_as -> { TacAtom (CAst.make ~loc @@ TacApply (false,false,cl,inhyp)) }
+          inhyp = in_hyp_as -> { CAst.make ~loc @@ TacAtom (TacApply (false,false,cl,inhyp)) }
       | IDENT "simple"; IDENT "eapply";
           cl = LIST1 constr_with_bindings_arg SEP",";
-          inhyp = in_hyp_as -> { TacAtom (CAst.make ~loc @@ TacApply (false,true,cl,inhyp)) }
+          inhyp = in_hyp_as -> { CAst.make ~loc @@ TacAtom (TacApply (false,true,cl,inhyp)) }
       | IDENT "elim"; cl = constr_with_bindings_arg; el = OPT eliminator ->
-          { TacAtom (CAst.make ~loc @@ TacElim (false,cl,el)) }
+          { CAst.make ~loc @@ TacAtom (TacElim (false,cl,el)) }
       | IDENT "eelim"; cl = constr_with_bindings_arg; el = OPT eliminator ->
-          { TacAtom (CAst.make ~loc @@ TacElim (true,cl,el)) }
-      | IDENT "case"; icl = induction_clause_list -> { TacAtom (CAst.make ~loc @@ mkTacCase false icl) }
-      | IDENT "ecase"; icl = induction_clause_list -> { TacAtom (CAst.make ~loc @@ mkTacCase true icl) }
+          { CAst.make ~loc @@ TacAtom (TacElim (true,cl,el)) }
+      | IDENT "case"; icl = induction_clause_list -> { CAst.make ~loc @@ TacAtom (mkTacCase false icl) }
+      | IDENT "ecase"; icl = induction_clause_list -> { CAst.make ~loc @@ TacAtom (mkTacCase true icl) }
       | "fix"; id = ident; n = natural; "with"; fd = LIST1 fixdecl ->
-          { TacAtom (CAst.make ~loc @@ TacMutualFix (id,n,List.map mk_fix_tac fd)) }
+          { CAst.make ~loc @@ TacAtom (TacMutualFix (id,n,List.map mk_fix_tac fd)) }
       | "cofix"; id = ident; "with"; fd = LIST1 cofixdecl ->
-          { TacAtom (CAst.make ~loc @@ TacMutualCofix (id,List.map mk_cofix_tac fd)) }
+          { CAst.make ~loc @@ TacAtom (TacMutualCofix (id,List.map mk_cofix_tac fd)) }
 
       | IDENT "pose"; bl = bindings_with_parameters ->
-          { let (id,b) = bl in TacAtom (CAst.make ~loc @@ TacLetTac (false,Names.Name.Name id,b,Locusops.nowhere,true,None)) }
+          { let (id,b) = bl in CAst.make ~loc @@ TacAtom (TacLetTac (false,Names.Name.Name id,b,Locusops.nowhere,true,None)) }
       | IDENT "pose"; b = constr; na = as_name ->
-          { TacAtom (CAst.make ~loc @@ TacLetTac (false,na,b,Locusops.nowhere,true,None)) }
+          { CAst.make ~loc @@ TacAtom (TacLetTac (false,na,b,Locusops.nowhere,true,None)) }
       | IDENT "epose"; bl = bindings_with_parameters ->
-          { let (id,b) = bl in TacAtom (CAst.make ~loc @@ TacLetTac (true,Names.Name id,b,Locusops.nowhere,true,None)) }
+          { let (id,b) = bl in CAst.make ~loc @@ TacAtom (TacLetTac (true,Names.Name id,b,Locusops.nowhere,true,None)) }
       | IDENT "epose"; b = constr; na = as_name ->
-          { TacAtom (CAst.make ~loc @@ TacLetTac (true,na,b,Locusops.nowhere,true,None)) }
+          { CAst.make ~loc @@ TacAtom (TacLetTac (true,na,b,Locusops.nowhere,true,None)) }
       | IDENT "set"; bl = bindings_with_parameters; p = clause_dft_concl ->
-          { let (id,c) = bl in TacAtom (CAst.make ~loc @@ TacLetTac (false,Names.Name.Name id,c,p,true,None)) }
+          { let (id,c) = bl in CAst.make ~loc @@ TacAtom (TacLetTac (false,Names.Name.Name id,c,p,true,None)) }
       | IDENT "set"; c = constr; na = as_name; p = clause_dft_concl ->
-          { TacAtom (CAst.make ~loc @@ TacLetTac (false,na,c,p,true,None)) }
+          { CAst.make ~loc @@ TacAtom (TacLetTac (false,na,c,p,true,None)) }
       | IDENT "eset"; bl = bindings_with_parameters; p = clause_dft_concl ->
-          { let (id,c) = bl in TacAtom (CAst.make ~loc @@ TacLetTac (true,Names.Name id,c,p,true,None)) }
+          { let (id,c) = bl in CAst.make ~loc @@ TacAtom (TacLetTac (true,Names.Name id,c,p,true,None)) }
       | IDENT "eset"; c = constr; na = as_name; p = clause_dft_concl ->
-          { TacAtom (CAst.make ~loc @@ TacLetTac (true,na,c,p,true,None)) }
+          { CAst.make ~loc @@ TacAtom (TacLetTac (true,na,c,p,true,None)) }
       | IDENT "remember"; c = constr; na = as_name; e = eqn_ipat;
           p = clause_dft_all ->
-          { TacAtom (CAst.make ~loc @@ TacLetTac (false,na,c,p,false,e)) }
+          { CAst.make ~loc @@ TacAtom (TacLetTac (false,na,c,p,false,e)) }
       | IDENT "eremember"; c = constr; na = as_name; e = eqn_ipat;
           p = clause_dft_all ->
-          { TacAtom (CAst.make ~loc @@ TacLetTac (true,na,c,p,false,e)) }
+          { CAst.make ~loc @@ TacAtom (TacLetTac (true,na,c,p,false,e)) }
 
       (* Alternative syntax for "pose proof c as id" *)
       | IDENT "assert"; test_lpar_id_coloneq; "("; lid = identref; ":=";
           c = lconstr; ")" ->
           { let { CAst.loc = loc; v = id } = lid in
-          TacAtom (CAst.make ?loc @@ TacAssert (false,true,None,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
+          CAst.make ?loc @@ TacAtom ( TacAssert (false,true,None,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
       | IDENT "eassert"; test_lpar_id_coloneq; "("; lid = identref; ":=";
           c = lconstr; ")" ->
           { let { CAst.loc = loc; v = id } = lid in
-          TacAtom (CAst.make ?loc @@ TacAssert (true,true,None,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
+          CAst.make ?loc @@ TacAtom ( TacAssert (true,true,None,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
 
       (* Alternative syntax for "assert c as id by tac" *)
       | IDENT "assert"; test_lpar_id_colon; "("; lid = identref; ":";
           c = lconstr; ")"; tac=by_tactic ->
           { let { CAst.loc = loc; v = id } = lid in
-          TacAtom (CAst.make ?loc @@ TacAssert (false,true,Some tac,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
+          CAst.make ?loc @@ TacAtom ( TacAssert (false,true,Some tac,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
       | IDENT "eassert"; test_lpar_id_colon; "("; lid = identref; ":";
           c = lconstr; ")"; tac=by_tactic ->
           { let { CAst.loc = loc; v = id } = lid in
-          TacAtom (CAst.make ?loc @@ TacAssert (true,true,Some tac,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
+          CAst.make ?loc @@ TacAtom ( TacAssert (true,true,Some tac,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
 
       (* Alternative syntax for "enough c as id by tac" *)
       | IDENT "enough"; test_lpar_id_colon; "("; lid = identref; ":";
           c = lconstr; ")"; tac=by_tactic ->
           { let { CAst.loc = loc; v = id } = lid in
-          TacAtom (CAst.make ?loc @@ TacAssert (false,false,Some tac,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
+          CAst.make ?loc @@ TacAtom ( TacAssert (false,false,Some tac,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
       | IDENT "eenough"; test_lpar_id_colon; "("; lid = identref; ":";
           c = lconstr; ")"; tac=by_tactic ->
           { let { CAst.loc = loc; v = id } = lid in
-          TacAtom (CAst.make ?loc @@ TacAssert (true,false,Some tac,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
+          CAst.make ?loc @@ TacAtom ( TacAssert (true,false,Some tac,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
 
       | IDENT "assert"; c = constr; ipat = as_ipat; tac = by_tactic ->
-          { TacAtom (CAst.make ~loc @@ TacAssert (false,true,Some tac,ipat,c)) }
+          { CAst.make ~loc @@ TacAtom (TacAssert (false,true,Some tac,ipat,c)) }
       | IDENT "eassert"; c = constr; ipat = as_ipat; tac = by_tactic ->
-          { TacAtom (CAst.make ~loc @@ TacAssert (true,true,Some tac,ipat,c)) }
+          { CAst.make ~loc @@ TacAtom (TacAssert (true,true,Some tac,ipat,c)) }
 
       (* Alternative syntax for "pose proof c as id by tac" *)
       | IDENT "pose"; IDENT "proof"; test_lpar_id_coloneq; "("; lid = identref; ":=";
           c = lconstr; ")" ->
           { let { CAst.loc = loc; v = id } = lid in
-          TacAtom (CAst.make ?loc @@ TacAssert (false,true,None,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
+          CAst.make ?loc @@ TacAtom (TacAssert (false,true,None,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
       | IDENT "epose"; IDENT "proof"; test_lpar_id_coloneq; "("; lid = identref; ":=";
           c = lconstr; ")" ->
           { let { CAst.loc = loc; v = id } = lid in
-          TacAtom (CAst.make ?loc @@ TacAssert (true,true,None,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
+          CAst.make ?loc @@ TacAtom ( TacAssert (true,true,None,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
       | IDENT "pose"; IDENT "proof"; c = lconstr; ipat = as_ipat ->
-          { TacAtom (CAst.make ~loc @@ TacAssert (false,true,None,ipat,c)) }
+          { CAst.make ~loc @@ TacAtom (TacAssert (false,true,None,ipat,c)) }
       | IDENT "epose"; IDENT "proof"; c = lconstr; ipat = as_ipat ->
-          { TacAtom (CAst.make ~loc @@ TacAssert (true,true,None,ipat,c)) }
+          { CAst.make ~loc @@ TacAtom (TacAssert (true,true,None,ipat,c)) }
       | IDENT "enough"; c = constr; ipat = as_ipat; tac = by_tactic ->
-          { TacAtom (CAst.make ~loc @@ TacAssert (false,false,Some tac,ipat,c)) }
+          { CAst.make ~loc @@ TacAtom (TacAssert (false,false,Some tac,ipat,c)) }
       | IDENT "eenough"; c = constr; ipat = as_ipat; tac = by_tactic ->
-          { TacAtom (CAst.make ~loc @@ TacAssert (true,false,Some tac,ipat,c)) }
+          { CAst.make ~loc @@ TacAtom (TacAssert (true,false,Some tac,ipat,c)) }
 
       | IDENT "generalize"; c = constr ->
-          { TacAtom (CAst.make ~loc @@ TacGeneralize [((AllOccurrences,c),Names.Name.Anonymous)]) }
+          { CAst.make ~loc @@ TacAtom (TacGeneralize [((AllOccurrences,c),Names.Name.Anonymous)]) }
       | IDENT "generalize"; c = constr; l = LIST1 constr ->
           { let gen_everywhere c = ((AllOccurrences,c),Names.Name.Anonymous) in
-          TacAtom (CAst.make ~loc @@ TacGeneralize (List.map gen_everywhere (c::l))) }
+          CAst.make ~loc @@ TacAtom (TacGeneralize (List.map gen_everywhere (c::l))) }
       | IDENT "generalize"; c = constr; lookup_at_as_comma; nl = occs;
           na = as_name;
           l = LIST0 [","; c = pattern_occ; na = as_name -> { (c,na) } ] ->
-          { TacAtom (CAst.make ~loc @@ TacGeneralize (((nl,c),na)::l)) }
+          { CAst.make ~loc @@ TacAtom (TacGeneralize (((nl,c),na)::l)) }
 
       (* Derived basic tactics *)
       | IDENT "induction"; ic = induction_clause_list ->
-          { TacAtom (CAst.make ~loc @@ TacInductionDestruct (true,false,ic)) }
+          { CAst.make ~loc @@ TacAtom (TacInductionDestruct (true,false,ic)) }
       | IDENT "einduction"; ic = induction_clause_list ->
-          { TacAtom (CAst.make ~loc @@ TacInductionDestruct(true,true,ic)) }
+          { CAst.make ~loc @@ TacAtom (TacInductionDestruct(true,true,ic)) }
       | IDENT "destruct"; icl = induction_clause_list ->
-          { TacAtom (CAst.make ~loc @@ TacInductionDestruct(false,false,icl)) }
+          { CAst.make ~loc @@ TacAtom (TacInductionDestruct(false,false,icl)) }
       | IDENT "edestruct";  icl = induction_clause_list ->
-          { TacAtom (CAst.make ~loc @@ TacInductionDestruct(false,true,icl)) }
+          { CAst.make ~loc @@ TacAtom (TacInductionDestruct(false,true,icl)) }
 
       (* Equality and inversion *)
       | IDENT "rewrite"; l = LIST1 oriented_rewriter SEP ",";
-          cl = clause_dft_concl; t=by_tactic -> { TacAtom (CAst.make ~loc @@ TacRewrite (false,l,cl,t)) }
+          cl = clause_dft_concl; t=by_tactic -> { CAst.make ~loc @@ TacAtom (TacRewrite (false,l,cl,t)) }
       | IDENT "erewrite"; l = LIST1 oriented_rewriter SEP ",";
-          cl = clause_dft_concl; t=by_tactic -> { TacAtom (CAst.make ~loc @@ TacRewrite (true,l,cl,t)) }
+          cl = clause_dft_concl; t=by_tactic -> { CAst.make ~loc @@ TacAtom (TacRewrite (true,l,cl,t)) }
       | IDENT "dependent"; k =
           [ IDENT "simple"; IDENT "inversion" -> { SimpleInversion }
           | IDENT "inversion" -> { FullInversion }
           | IDENT "inversion_clear" -> { FullInversionClear } ];
           hyp = quantified_hypothesis;
           ids = as_or_and_ipat; co = OPT ["with"; c = constr -> { c } ] ->
-            { TacAtom (CAst.make ~loc @@ TacInversion (DepInversion (k,co,ids),hyp)) }
+            { CAst.make ~loc @@ TacAtom (TacInversion (DepInversion (k,co,ids),hyp)) }
       | IDENT "simple"; IDENT "inversion";
           hyp = quantified_hypothesis; ids = as_or_and_ipat;
           cl = in_hyp_list ->
-            { TacAtom (CAst.make ~loc @@ TacInversion (NonDepInversion (SimpleInversion, cl, ids), hyp)) }
+            { CAst.make ~loc @@ TacAtom (TacInversion (NonDepInversion (SimpleInversion, cl, ids), hyp)) }
       | IDENT "inversion";
           hyp = quantified_hypothesis; ids = as_or_and_ipat;
           cl = in_hyp_list ->
-            { TacAtom (CAst.make ~loc @@ TacInversion (NonDepInversion (FullInversion, cl, ids), hyp)) }
+            { CAst.make ~loc @@ TacAtom (TacInversion (NonDepInversion (FullInversion, cl, ids), hyp)) }
       | IDENT "inversion_clear";
           hyp = quantified_hypothesis; ids = as_or_and_ipat;
           cl = in_hyp_list ->
-            { TacAtom (CAst.make ~loc @@ TacInversion (NonDepInversion (FullInversionClear, cl, ids), hyp)) }
+            { CAst.make ~loc @@ TacAtom (TacInversion (NonDepInversion (FullInversionClear, cl, ids), hyp)) }
       | IDENT "inversion"; hyp = quantified_hypothesis;
           "using"; c = constr; cl = in_hyp_list ->
-            { TacAtom (CAst.make ~loc @@ TacInversion (InversionUsing (c,cl), hyp)) }
+            { CAst.make ~loc @@ TacAtom (TacInversion (InversionUsing (c,cl), hyp)) }
 
       (* Conversion *)
       | IDENT "red"; cl = clause_dft_concl ->
-          { TacAtom (CAst.make ~loc @@ TacReduce (Red false, cl)) }
+          { CAst.make ~loc @@ TacAtom (TacReduce (Red false, cl)) }
       | IDENT "hnf"; cl = clause_dft_concl ->
-          { TacAtom (CAst.make ~loc @@ TacReduce (Hnf, cl)) }
+          { CAst.make ~loc @@ TacAtom (TacReduce (Hnf, cl)) }
       | IDENT "simpl"; d = delta_flag; po = OPT ref_or_pattern_occ; cl = clause_dft_concl ->
-          { TacAtom (CAst.make ~loc @@ TacReduce (Simpl (all_with d, po), cl)) }
+          { CAst.make ~loc @@ TacAtom (TacReduce (Simpl (all_with d, po), cl)) }
       | IDENT "cbv"; s = strategy_flag; cl = clause_dft_concl ->
-          { TacAtom (CAst.make ~loc @@ TacReduce (Cbv s, cl)) }
+          { CAst.make ~loc @@ TacAtom (TacReduce (Cbv s, cl)) }
       | IDENT "cbn"; s = strategy_flag; cl = clause_dft_concl ->
-          { TacAtom (CAst.make ~loc @@ TacReduce (Cbn s, cl)) }
+          { CAst.make ~loc @@ TacAtom (TacReduce (Cbn s, cl)) }
       | IDENT "lazy"; s = strategy_flag; cl = clause_dft_concl ->
-          { TacAtom (CAst.make ~loc @@ TacReduce (Lazy s, cl)) }
+          { CAst.make ~loc @@ TacAtom (TacReduce (Lazy s, cl)) }
       | IDENT "compute"; delta = delta_flag; cl = clause_dft_concl ->
-          { TacAtom (CAst.make ~loc @@ TacReduce (Cbv (all_with delta), cl)) }
+          { CAst.make ~loc @@ TacAtom (TacReduce (Cbv (all_with delta), cl)) }
       | IDENT "vm_compute"; po = OPT ref_or_pattern_occ; cl = clause_dft_concl ->
-          { TacAtom (CAst.make ~loc @@ TacReduce (CbvVm po, cl)) }
+          { CAst.make ~loc @@ TacAtom (TacReduce (CbvVm po, cl)) }
       | IDENT "native_compute"; po = OPT ref_or_pattern_occ; cl = clause_dft_concl ->
-          { TacAtom (CAst.make ~loc @@ TacReduce (CbvNative po, cl)) }
+          { CAst.make ~loc @@ TacAtom (TacReduce (CbvNative po, cl)) }
       | IDENT "unfold"; ul = LIST1 unfold_occ SEP ","; cl = clause_dft_concl ->
-          { TacAtom (CAst.make ~loc @@ TacReduce (Unfold ul, cl)) }
+          { CAst.make ~loc @@ TacAtom (TacReduce (Unfold ul, cl)) }
       | IDENT "fold"; l = LIST1 constr; cl = clause_dft_concl ->
-          { TacAtom (CAst.make ~loc @@ TacReduce (Fold l, cl)) }
+          { CAst.make ~loc @@ TacAtom (TacReduce (Fold l, cl)) }
       | IDENT "pattern"; pl = LIST1 pattern_occ SEP","; cl = clause_dft_concl ->
-          { TacAtom (CAst.make ~loc @@ TacReduce (Pattern pl, cl)) }
+          { CAst.make ~loc @@ TacAtom (TacReduce (Pattern pl, cl)) }
 
       (* Change ne doit pas s'appliquer dans un Definition t := Eval ... *)
       | IDENT "change"; c = conversion; cl = clause_dft_concl ->
           { let (oc, c) = c in
           let p,cl = merge_occurrences loc cl oc in
-          TacAtom (CAst.make ~loc @@ TacChange (true,p,c,cl)) }
+          CAst.make ~loc @@ TacAtom (TacChange (true,p,c,cl)) }
       | IDENT "change_no_check"; c = conversion; cl = clause_dft_concl ->
           { let (oc, c) = c in
           let p,cl = merge_occurrences loc cl oc in
-          TacAtom (CAst.make ~loc @@ TacChange (false,p,c,cl)) }
+          CAst.make ~loc @@ TacAtom (TacChange (false,p,c,cl)) }
     ] ]
   ;
 END

--- a/plugins/ltac/profile_ltac.ml
+++ b/plugins/ltac/profile_ltac.ml
@@ -241,8 +241,8 @@ let string_of_call ck =
        | Tacexpr.LtacNameCall cst -> Pptactic.pr_ltac_constant cst
        | Tacexpr.LtacVarCall (id, t) -> Names.Id.print id
        | Tacexpr.LtacAtomCall te ->
-         (Pptactic.pr_glob_tactic (Global.env ())
-            (Tacexpr.TacAtom (CAst.make te)))
+         Pptactic.pr_glob_tactic (Global.env ())
+            (CAst.make (Tacexpr.TacAtom te))
        | Tacexpr.LtacConstrInterp (c, _) ->
          let env = Global.env () in
          pr_glob_constr_env env (Evd.from_env env) c

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -1930,7 +1930,7 @@ let add_setoid atts binders a aeq t n =
 let make_tactic name =
   let open Tacexpr in
   let tacqid = Libnames.qualid_of_string name in
-  TacArg (CAst.make @@ (TacCall (CAst.make (tacqid, []))))
+  CAst.make @@ TacArg (TacCall (CAst.make (tacqid, [])))
 
 let add_morphism_as_parameter atts m n : unit =
   init_setoid ();

--- a/plugins/ltac/tacexpr.ml
+++ b/plugins/ltac/tacexpr.ml
@@ -178,8 +178,8 @@ constraint 'a = <
     't : terms, 'p : patterns, 'c : constants, 'i : inductive,
     'r : ltac refs, 'n : idents, 'l : levels *)
 
-and 'a gen_tactic_expr =
-  | TacAtom of ('a gen_atomic_tactic_expr) CAst.t
+and 'a gen_tactic_expr_r =
+  | TacAtom of 'a gen_atomic_tactic_expr
   | TacThen of
       'a gen_tactic_expr *
       'a gen_tactic_expr
@@ -234,12 +234,25 @@ and 'a gen_tactic_expr =
   | TacMatchGoal of lazy_flag * direction_flag *
       ('p,'a gen_tactic_expr) match_rule list
   | TacFun of 'a gen_tactic_fun_ast
-  | TacArg of 'a gen_tactic_arg CAst.t
+  | TacArg of 'a gen_tactic_arg
   | TacSelect of Goal_select.t * 'a gen_tactic_expr
   (* For ML extensions *)
-  | TacML of (ml_tactic_entry * 'a gen_tactic_arg list) CAst.t
+  | TacML of ml_tactic_entry * 'a gen_tactic_arg list
   (* For syntax extensions *)
-  | TacAlias of (KerName.t * 'a gen_tactic_arg list) CAst.t
+  | TacAlias of KerName.t * 'a gen_tactic_arg list
+
+constraint 'a = <
+    term:'t;
+    dterm: 'dtrm;
+    pattern:'p;
+    constant:'c;
+    reference:'r;
+    name:'n;
+    tacexpr:'tacexpr;
+    level:'l
+>
+and 'a gen_tactic_expr =
+  'a gen_tactic_expr_r CAst.t
 
 constraint 'a = <
     term:'t;

--- a/plugins/ltac/tacexpr.mli
+++ b/plugins/ltac/tacexpr.mli
@@ -177,8 +177,8 @@ constraint 'a = <
     't : terms, 'p : patterns, 'c : constants, 'i : inductive,
     'r : ltac refs, 'n : idents, 'l : levels *)
 
-and 'a gen_tactic_expr =
-  | TacAtom of ('a gen_atomic_tactic_expr) CAst.t
+and 'a gen_tactic_expr_r =
+  | TacAtom of 'a gen_atomic_tactic_expr
   | TacThen of
       'a gen_tactic_expr *
       'a gen_tactic_expr
@@ -233,12 +233,26 @@ and 'a gen_tactic_expr =
   | TacMatchGoal of lazy_flag * direction_flag *
       ('p,'a gen_tactic_expr) match_rule list
   | TacFun of 'a gen_tactic_fun_ast
-  | TacArg of 'a gen_tactic_arg CAst.t
+  | TacArg of 'a gen_tactic_arg
   | TacSelect of Goal_select.t * 'a gen_tactic_expr
   (* For ML extensions *)
-  | TacML of (ml_tactic_entry * 'a gen_tactic_arg list) CAst.t
+  | TacML of ml_tactic_entry * 'a gen_tactic_arg list
   (* For syntax extensions *)
-  | TacAlias of (KerName.t * 'a gen_tactic_arg list) CAst.t
+  | TacAlias of KerName.t * 'a gen_tactic_arg list
+
+constraint 'a = <
+    term:'t;
+    dterm: 'dtrm;
+    pattern:'p;
+    constant:'c;
+    reference:'r;
+    name:'n;
+    tacexpr:'tacexpr;
+    level:'l
+>
+
+and 'a gen_tactic_expr =
+  'a gen_tactic_expr_r CAst.t
 
 constraint 'a = <
     term:'t;

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -72,8 +72,6 @@ let intern_name l ist = function
 
 let strict_check = ref false
 
-let adjust_loc loc = if !strict_check then None else loc
-
 (* Globalize a name which must be bound -- actually just check it is bound *)
 let intern_hyp ist ({loc;v=id} as locid) =
   if not !strict_check then
@@ -599,99 +597,102 @@ let rec intern_atomic lf ist x =
 
 and intern_tactic onlytac ist tac = snd (intern_tactic_seq onlytac ist tac)
 
-and intern_tactic_seq onlytac ist = function
-  | TacAtom { loc; v=t } ->
+and intern_tactic_seq onlytac ist tac =
+  let (loc, tac) = CAst.(tac.loc, tac.v) in
+  match tac with
+  | TacAtom t ->
       let lf = ref ist.ltacvars in
       let t = intern_atomic lf ist t in
-      !lf, TacAtom (CAst.make ?loc:(adjust_loc loc) t)
-  | TacFun tacfun -> ist.ltacvars, TacFun (intern_tactic_fun ist tacfun)
+      !lf, CAst.make ?loc (TacAtom t)
+  | TacFun tacfun -> ist.ltacvars, (CAst.make ?loc (TacFun (intern_tactic_fun ist tacfun)))
   | TacLetIn (isrec,l,u) ->
       let ltacvars = Id.Set.union (extract_let_names l) ist.ltacvars in
       let ist' = { ist with ltacvars } in
       let l = List.map (fun (n,b) ->
           (n,intern_tacarg !strict_check false (if isrec then ist' else ist) b)) l in
-      ist.ltacvars, TacLetIn (isrec,l,intern_tactic onlytac ist' u)
+      ist.ltacvars, CAst.make ?loc (TacLetIn (isrec,l,intern_tactic onlytac ist' u))
 
   | TacMatchGoal (lz,lr,lmr) ->
-      ist.ltacvars, TacMatchGoal(lz,lr, intern_match_rule onlytac ist ~as_type:true lmr)
+      ist.ltacvars, CAst.make ?loc (TacMatchGoal (lz,lr, intern_match_rule onlytac ist ~as_type:true lmr))
   | TacMatch (lz,c,lmr) ->
       ist.ltacvars,
-      TacMatch (lz,intern_tactic_or_tacarg ist c,intern_match_rule onlytac ist lmr)
-  | TacId l -> ist.ltacvars, TacId (intern_message ist l)
+       CAst.make ?loc (TacMatch (lz,intern_tactic_or_tacarg ist c,intern_match_rule onlytac ist lmr))
+  | TacId l -> ist.ltacvars, CAst.make ?loc (TacId (intern_message ist l))
   | TacFail (g,n,l) ->
-      ist.ltacvars, TacFail (g,intern_int_or_var ist n,intern_message ist l)
-  | TacProgress tac -> ist.ltacvars, TacProgress (intern_pure_tactic ist tac)
-  | TacShowHyps tac -> ist.ltacvars, TacShowHyps (intern_pure_tactic ist tac)
+      ist.ltacvars, CAst.make ?loc (TacFail (g,intern_int_or_var ist n,intern_message ist l))
+  | TacProgress tac -> ist.ltacvars, CAst.make ?loc (TacProgress (intern_pure_tactic ist tac))
+  | TacShowHyps tac -> ist.ltacvars, CAst.make ?loc (TacShowHyps (intern_pure_tactic ist tac))
   | TacAbstract (tac,s) ->
-      ist.ltacvars, TacAbstract (intern_pure_tactic ist tac,s)
+      ist.ltacvars, CAst.make ?loc (TacAbstract (intern_pure_tactic ist tac,s))
   | TacThen (t1,t2) ->
       let lfun', t1 = intern_tactic_seq onlytac ist t1 in
       let lfun'', t2 = intern_tactic_seq onlytac { ist with ltacvars = lfun' } t2 in
-      lfun'', TacThen (t1,t2)
+      lfun'', CAst.make ?loc (TacThen (t1,t2))
   | TacDispatch tl ->
-      ist.ltacvars , TacDispatch (List.map (intern_pure_tactic ist) tl)
+      ist.ltacvars , CAst.make ?loc (TacDispatch (List.map (intern_pure_tactic ist) tl))
   | TacExtendTac (tf,t,tl) ->
-      ist.ltacvars ,
+      ist.ltacvars, CAst.make ?loc (
       TacExtendTac (Array.map (intern_pure_tactic ist) tf,
                     intern_pure_tactic ist t,
-                    Array.map (intern_pure_tactic ist) tl)
+                    Array.map (intern_pure_tactic ist) tl))
   | TacThens3parts (t1,tf,t2,tl) ->
       let lfun', t1 = intern_tactic_seq onlytac ist t1 in
       let ist' = { ist with ltacvars = lfun' } in
       (* Que faire en cas de (tac complexe avec Match et Thens; tac2) ?? *)
-      lfun', TacThens3parts (t1,Array.map (intern_pure_tactic ist') tf,intern_pure_tactic ist' t2,
-                       Array.map (intern_pure_tactic ist') tl)
+      lfun', CAst.make ?loc (TacThens3parts
+                      (t1,Array.map (intern_pure_tactic ist') tf,intern_pure_tactic ist' t2,
+                      Array.map (intern_pure_tactic ist') tl))
   | TacThens (t,tl) ->
       let lfun', t = intern_tactic_seq true ist t in
       let ist' = { ist with ltacvars = lfun' } in
       (* Que faire en cas de (tac complexe avec Match et Thens; tac2) ?? *)
-      lfun', TacThens (t, List.map (intern_pure_tactic ist') tl)
+      lfun', CAst.make ?loc (TacThens (t, List.map (intern_pure_tactic ist') tl))
   | TacDo (n,tac) ->
-      ist.ltacvars, TacDo (intern_int_or_var ist n,intern_pure_tactic ist tac)
-  | TacTry tac -> ist.ltacvars, TacTry (intern_pure_tactic ist tac)
-  | TacRepeat tac -> ist.ltacvars, TacRepeat (intern_pure_tactic ist tac)
+      ist.ltacvars, CAst.make ?loc (TacDo (intern_int_or_var ist n,intern_pure_tactic ist tac))
+  | TacTry tac -> ist.ltacvars, CAst.make ?loc (TacTry (intern_pure_tactic ist tac))
+  | TacRepeat tac -> ist.ltacvars, CAst.make ?loc (TacRepeat (intern_pure_tactic ist tac))
   | TacTimeout (n,tac) ->
-      ist.ltacvars, TacTimeout (intern_int_or_var ist n,intern_tactic onlytac ist tac)
+      ist.ltacvars, CAst.make ?loc (TacTimeout (intern_int_or_var ist n,intern_tactic onlytac ist tac))
   | TacTime (s,tac) ->
-      ist.ltacvars, TacTime (s,intern_tactic onlytac ist tac)
+      ist.ltacvars, CAst.make ?loc (TacTime (s,intern_tactic onlytac ist tac))
   | TacOr (tac1,tac2) ->
-      ist.ltacvars, TacOr (intern_pure_tactic ist tac1,intern_pure_tactic ist tac2)
+      ist.ltacvars, CAst.make ?loc (TacOr (intern_pure_tactic ist tac1,intern_pure_tactic ist tac2))
   | TacOnce tac ->
-      ist.ltacvars, TacOnce (intern_pure_tactic ist tac)
+      ist.ltacvars, CAst.make ?loc (TacOnce (intern_pure_tactic ist tac))
   | TacExactlyOnce tac ->
-      ist.ltacvars, TacExactlyOnce (intern_pure_tactic ist tac)
+      ist.ltacvars, CAst.make ?loc (TacExactlyOnce (intern_pure_tactic ist tac))
   | TacIfThenCatch (tac,tact,tace) ->
       ist.ltacvars,
-      TacIfThenCatch (
+      CAst.make ?loc (TacIfThenCatch (
         intern_pure_tactic ist tac,
         intern_pure_tactic ist tact,
-        intern_pure_tactic ist tace)
+        intern_pure_tactic ist tace))
   | TacOrelse (tac1,tac2) ->
-      ist.ltacvars, TacOrelse (intern_pure_tactic ist tac1,intern_pure_tactic ist tac2)
-  | TacFirst l -> ist.ltacvars, TacFirst (List.map (intern_pure_tactic ist) l)
-  | TacSolve l -> ist.ltacvars, TacSolve (List.map (intern_pure_tactic ist) l)
-  | TacComplete tac -> ist.ltacvars, TacComplete (intern_pure_tactic ist tac)
-  | TacArg { loc; v=a } -> ist.ltacvars, intern_tactic_as_arg loc onlytac ist a
+      ist.ltacvars, CAst.make ?loc (TacOrelse (intern_pure_tactic ist tac1,intern_pure_tactic ist tac2))
+  | TacFirst l -> ist.ltacvars, CAst.make ?loc (TacFirst (List.map (intern_pure_tactic ist) l))
+  | TacSolve l -> ist.ltacvars, CAst.make ?loc (TacSolve (List.map (intern_pure_tactic ist) l))
+  | TacComplete tac -> ist.ltacvars, CAst.make ?loc (TacComplete (intern_pure_tactic ist tac))
+  | TacArg a -> ist.ltacvars, intern_tactic_as_arg loc onlytac ist a
   | TacSelect (sel, tac) ->
-      ist.ltacvars, TacSelect (sel, intern_pure_tactic ist tac)
+      ist.ltacvars, CAst.make ?loc (TacSelect (sel, intern_pure_tactic ist tac))
 
   (* For extensions *)
-  | TacAlias { loc; v=(s,l) } ->
+  | TacAlias (s,l) ->
       let alias = Tacenv.interp_alias s in
       Option.iter (fun o -> warn_deprecated_alias ?loc (s,o)) @@ alias.Tacenv.alias_deprecation;
       let l = List.map (intern_tacarg !strict_check false ist) l in
-      ist.ltacvars, TacAlias (CAst.make ?loc (s,l))
-  | TacML { loc; v=(opn,l) } ->
+      ist.ltacvars, CAst.make ?loc (TacAlias (s,l))
+  | TacML (opn,l) ->
       let _ignore = Tacenv.interp_ml_tactic opn in
-      ist.ltacvars, TacML CAst.(make ?loc (opn,List.map (intern_tacarg !strict_check false ist) l))
+      ist.ltacvars, CAst.make ?loc (TacML (opn,List.map (intern_tacarg !strict_check false ist) l))
 
 and intern_tactic_as_arg loc onlytac ist a =
   match intern_tacarg !strict_check onlytac ist a with
   | TacCall _ | Reference _
-  | TacGeneric _ as a -> TacArg CAst.(make ?loc a)
+  | TacGeneric _ as a -> CAst.make ?loc (TacArg a)
   | Tacexp a -> a
   | ConstrMayEval _ | TacFreshId _ | TacPretype _ | TacNumgoals as a ->
-      if onlytac then error_tactic_expected ?loc else TacArg CAst.(make ?loc a)
+      if onlytac then error_tactic_expected ?loc else CAst.make ?loc (TacArg a)
 
 and intern_tactic_or_tacarg ist = intern_tactic false ist
 
@@ -829,6 +830,6 @@ let notation_subst bindings tac =
   (* This is theoretically not correct due to potential variable
      capture, but Ltac has no true variables so one cannot simply
      substitute *)
-  TacLetIn (false, bindings, tac)
+  CAst.make (TacLetIn (false, bindings, tac))
 
 let () = Genintern.register_ntn_subst0 wit_tactic notation_subst

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -239,7 +239,7 @@ let pr_inspect env expr result =
     if has_type result (topwit wit_tacvalue) then
     match to_tacvalue result with
     | VFun (_, _, _, ist, ul, b) ->
-      let body = if List.is_empty ul then b else (TacFun (ul, b)) in
+      let body = if List.is_empty ul then b else CAst.make (TacFun (ul, b)) in
       str "a closure with body " ++ fnl() ++ pr_closure env ist body
     | VRec (ist, body) ->
       str "a recursive closure" ++ fnl () ++ pr_closure env !ist body
@@ -266,7 +266,7 @@ let propagate_trace ist loc id v =
     let tacv = to_tacvalue v in
     match tacv with
     | VFun (appl,_,_,lfun,it,b) ->
-        let t = if List.is_empty it then b else TacFun (it,b) in
+        let t = if List.is_empty it then b else CAst.make (TacFun (it,b)) in
         let trace = push_trace(loc,LtacVarCall (id,t)) ist in
         let ans = VFun (appl,trace,loc,lfun,it,b) in
         Proofview.tclUNIT (of_tacvalue ans)
@@ -1076,17 +1076,19 @@ let rec val_interp ist ?(appl=UnnamedAppl) (tac:glob_tactic_expr) : Val.t Ftacti
      [VFun]. Otherwise a [Ltac t := let x := .. in tac] would never
      register its name since it is syntactically a let, not a
      function.  *)
-  let value_interp ist = match tac with
+  let (loc,tac2) = CAst.(tac.loc, tac.v) in
+  let value_interp ist =
+  match tac2 with
   | TacFun (it, body) ->
     Ftactic.return (of_tacvalue (VFun (UnnamedAppl, extract_trace ist, extract_loc ist, ist.lfun, it, body)))
   | TacLetIn (true,l,u) -> interp_letrec ist l u
   | TacLetIn (false,l,u) -> interp_letin ist l u
   | TacMatchGoal (lz,lr,lmr) -> interp_match_goal ist lz lr lmr
   | TacMatch (lz,c,lmr) -> interp_match ist lz c lmr
-  | TacArg {loc;v} -> interp_tacarg ist v
-  | t ->
+  | TacArg v -> interp_tacarg ist v
+  | _ ->
     (* Delayed evaluation *)
-    Ftactic.return (of_tacvalue (VFun (UnnamedAppl, extract_trace ist, extract_loc ist, ist.lfun, [], t)))
+    Ftactic.return (of_tacvalue (VFun (UnnamedAppl, extract_trace ist, extract_loc ist, ist.lfun, [], tac)))
   in
   let open Ftactic in
   Control.check_for_interrupt ();
@@ -1100,8 +1102,10 @@ let rec val_interp ist ?(appl=UnnamedAppl) (tac:glob_tactic_expr) : Val.t Ftacti
   | _ -> value_interp ist >>= fun v -> return (name_vfun appl v)
 
 
-and eval_tactic_ist ist tac : unit Proofview.tactic = match tac with
-  | TacAtom {loc;v=t} ->
+and eval_tactic_ist ist tac : unit Proofview.tactic =
+  let (loc, tac2) = CAst.(tac.loc, tac.v) in
+  match tac2 with
+  | TacAtom t ->
       let call = LtacAtomCall t in
       let trace = push_trace(loc,call) ist in
       Profile_ltac.do_profile "eval_tactic:2" trace
@@ -1179,10 +1183,10 @@ and eval_tactic_ist ist tac : unit Proofview.tactic = match tac with
   | TacFirst l -> Tacticals.New.tclFIRST (List.map (interp_tactic ist) l)
   | TacSolve l -> Tacticals.New.tclSOLVE (List.map (interp_tactic ist) l)
   | TacComplete tac -> Tacticals.New.tclCOMPLETE (interp_tactic ist tac)
-  | TacArg {CAst.loc} -> Ftactic.run (val_interp (ensure_loc loc ist) tac) (fun v -> tactic_of_value ist v)
+  | TacArg _ -> Ftactic.run (val_interp (ensure_loc loc ist) tac) (fun v -> tactic_of_value ist v)
   | TacSelect (sel, tac) -> Goal_select.tclSELECT sel (interp_tactic ist tac)
   (* For extensions *)
-  | TacAlias {loc; v=(s,l)} ->
+  | TacAlias (s,l) ->
       let alias = Tacenv.interp_alias s in
       Proofview.tclProofInfo [@ocaml.warning "-3"] >>= fun (_name, poly) ->
       let (>>=) = Ftactic.bind in
@@ -1218,7 +1222,7 @@ and eval_tactic_ist ist tac : unit Proofview.tactic = match tac with
       in
       Ftactic.run tac (fun () -> Proofview.tclUNIT ())
 
-  | TacML {loc; v=(opn,l)} ->
+  | TacML (opn,l) ->
       let trace = push_trace (Loc.tag ?loc @@ LtacMLCall tac) ist in
       let ist = { ist with extra = TacStore.set ist.extra f_trace trace; } in
       let tac = Tacenv.interp_ml_tactic opn in
@@ -1319,7 +1323,11 @@ and interp_app loc ist fv largs : Val.t Ftactic.t =
          a VFun back on body, and then interp_app is called again...) *)
     | (VFun(appl,trace,_,olfun,(_::_ as var),body)
       |VFun(appl,trace,_,olfun,([] as var),
-         (TacFun _|TacLetIn _|TacMatchGoal _|TacMatch _| TacArg _ as body))) ->
+          (   {CAst.v=(TacFun _)}
+            | {CAst.v=(TacLetIn _)}
+            | {CAst.v=(TacMatchGoal _)}
+            | {CAst.v=(TacMatch _)}
+            | {CAst.v=(TacArg _)} as body))) ->
         let (extfun,lvar,lval)=head_with_value (var,largs) in
         let fold accu (id, v) = Id.Map.add id v accu in
         let newlfun = List.fold_left fold olfun extfun in
@@ -1429,7 +1437,7 @@ and interp_letrec ist llc u =
   Proofview.tclUNIT () >>= fun () -> (* delay for the effects of [lref], just in case. *)
   let lref = ref ist.lfun in
   let fold accu ({v=na}, b) =
-    let v = of_tacvalue (VRec (lref, TacArg (CAst.make b))) in
+    let v = of_tacvalue (VRec (lref, CAst.make (TacArg b))) in
     Name.fold_right (fun id -> Id.Map.add id v) na accu
   in
   let lfun = List.fold_left fold ist.lfun llc in
@@ -1467,7 +1475,8 @@ and interp_match_success ist { Tactic_matching.subst ; context ; terms ; lhs } =
         ; extra = TacStore.set ist.extra f_trace trace
         } in
       let tac = eval_tactic_ist ist t in
-      let dummy = VFun (appl, extract_trace ist, loc, Id.Map.empty, [], TacId []) in
+      let dummy = VFun (appl, extract_trace ist, loc, Id.Map.empty, [],
+        CAst.make (TacId [])) in
       catch_error_tac trace (tac <*> Ftactic.return (of_tacvalue dummy))
   | _ -> Ftactic.return v
   else Ftactic.return v
@@ -1972,7 +1981,7 @@ module Value = struct
     let (_, args, lfun) = List.fold_right fold args (0, [], Id.Map.empty) in
     let lfun = Id.Map.add (Id.of_string "F") f lfun in
     let ist = { (default_ist ()) with lfun = lfun; } in
-    ist, TacArg(CAst.make @@ TacCall (CAst.make (ArgVar CAst.(make @@ Id.of_string "F"),args)))
+    ist, CAst.make @@ TacArg (TacCall (CAst.make (ArgVar CAst.(make @@ Id.of_string "F"),args)))
 
 
   (** Apply toplevel tactic values *)

--- a/plugins/ltac/tacsubst.ml
+++ b/plugins/ltac/tacsubst.ml
@@ -171,14 +171,14 @@ let rec subst_atomic subst (t:glob_atomic_tactic_expr) = match t with
   | TacInversion (InversionUsing (c,cl),hyp) ->
       TacInversion (InversionUsing (subst_glob_constr subst c,cl),hyp)
 
-and subst_tactic subst (t:glob_tactic_expr) = match t with
-  | TacAtom { CAst.v=t } -> TacAtom (CAst.make @@ subst_atomic subst t)
+and subst_tactic subst = CAst.map (function
+  | TacAtom t -> TacAtom (subst_atomic subst t)
   | TacFun tacfun -> TacFun (subst_tactic_fun subst tacfun)
   | TacLetIn (r,l,u) ->
       let l = List.map (fun (n,b) -> (n,subst_tacarg subst b)) l in
       TacLetIn (r,l,subst_tactic subst u)
   | TacMatchGoal (lz,lr,lmr) ->
-      TacMatchGoal(lz,lr, subst_match_rule subst lmr)
+      TacMatchGoal (lz,lr, subst_match_rule subst lmr)
   | TacMatch (lz,c,lmr) ->
       TacMatch (lz,subst_tactic subst c,subst_match_rule subst lmr)
   | TacId _ | TacFail _ as x -> x
@@ -218,14 +218,15 @@ and subst_tactic subst (t:glob_tactic_expr) = match t with
   | TacFirst l -> TacFirst (List.map (subst_tactic subst) l)
   | TacSolve l -> TacSolve (List.map (subst_tactic subst) l)
   | TacComplete tac -> TacComplete (subst_tactic subst tac)
-  | TacArg { CAst.v=a } -> TacArg (CAst.make @@ subst_tacarg subst a)
+  | TacArg a -> TacArg (subst_tacarg subst a)
   | TacSelect (s, tac) -> TacSelect (s, subst_tactic subst tac)
 
   (* For extensions *)
-  | TacAlias { CAst.v=(s,l) } ->
+  | TacAlias (s,l) ->
       let s = subst_kn subst s in
-      TacAlias (CAst.make (s,List.map (subst_tacarg subst) l))
-  | TacML { CAst.loc; v=(opn,l)} -> TacML CAst.(make ?loc (opn,List.map (subst_tacarg subst) l))
+      TacAlias (s,List.map (subst_tacarg subst) l)
+  | TacML (opn,l) -> TacML (opn,List.map (subst_tacarg subst) l)
+  )
 
 and subst_tactic_fun subst (var,body) = (var,subst_tactic subst body)
 

--- a/plugins/ltac/tactic_debug.ml
+++ b/plugins/ltac/tactic_debug.ml
@@ -341,7 +341,7 @@ let explain_ltac_call_trace last trace loc =
       quote (Id.print id) ++ strbrk " (bound to " ++
         prtac t ++ str ")"
   | Tacexpr.LtacAtomCall te ->
-      quote (prtac (Tacexpr.TacAtom (CAst.make te)))
+      quote (prtac (CAst.make (Tacexpr.TacAtom te)))
   | Tacexpr.LtacConstrInterp (c, { Ltac_pretype.ltac_constrs = vars }) ->
     (* XXX: This hooks into the CErrors's additional error info API so
        it is tricky to provide the right env for now. *)

--- a/plugins/ltac/tactic_option.ml
+++ b/plugins/ltac/tactic_option.ml
@@ -11,7 +11,7 @@
 open Libobject
 open Pp
 
-let declare_tactic_option ?(default=Tacexpr.TacId []) name =
+let declare_tactic_option ?(default=CAst.make (Tacexpr.TacId[])) name =
   let locality = Summary.ref false ~name:(name^"-locality") in
   let default_tactic : Tacexpr.glob_tactic_expr ref =
     Summary.ref default ~name:(name^"-default-tactic")

--- a/plugins/ltac/tauto.ml
+++ b/plugins/ltac/tauto.ml
@@ -200,10 +200,10 @@ let make_unfold name =
   Locus.(AllOccurrences, ArgArg (const, None))
 
 let reduction_not_iff _ ist =
-  let make_reduce c = TacAtom (CAst.make @@ TacReduce (Genredexpr.Unfold c, Locusops.allHypsAndConcl)) in
+  let make_reduce c = CAst.make @@ TacAtom (TacReduce (Genredexpr.Unfold c, Locusops.allHypsAndConcl)) in
   let tac = match !negation_unfolding with
     | true -> make_reduce [make_unfold "core.not.type"]
-    | false -> TacId []
+    | false -> CAst.make (TacId [])
   in
   eval_tactic_ist ist tac
 
@@ -251,7 +251,7 @@ let with_flags flags _ ist =
   let x = CAst.make @@ Id.of_string "x" in
   let arg = Val.Dyn (tag_tauto_flags, flags) in
   let ist = { ist with lfun = Id.Map.add x.CAst.v arg ist.lfun } in
-  eval_tactic_ist ist (TacArg (CAst.make @@ TacCall (CAst.make (Locus.ArgVar f, [Reference (Locus.ArgVar x)]))))
+  eval_tactic_ist ist (CAst.make @@ TacArg (TacCall (CAst.make (Locus.ArgVar f, [Reference (Locus.ArgVar x)]))))
 
 let register_tauto_tactic tac name0 args =
   let ids = List.map (fun id -> Id.of_string id) args in
@@ -259,7 +259,7 @@ let register_tauto_tactic tac name0 args =
   let name = { mltac_plugin = tauto_plugin; mltac_tactic = name0; } in
   let entry = { mltac_name = name; mltac_index = 0 } in
   let () = Tacenv.register_ml_tactic name [| tac |] in
-  let tac = TacFun (ids, TacML (CAst.make (entry, []))) in
+  let tac = CAst.make (TacFun (ids, CAst.make (TacML (entry, [])))) in
   let obj () = Tacenv.register_ltac true true (Id.of_string name0) tac in
   Mltop.declare_cache_obj obj tauto_plugin
 

--- a/plugins/ring/ring.ml
+++ b/plugins/ring/ring.ml
@@ -125,10 +125,11 @@ let closed_term_ast =
   } in
   fun l ->
   let l = List.map (fun gr -> ArgArg(Loc.tag gr)) l in
-  TacFun([Name(Id.of_string"t")],
-  TacML(CAst.make (tacname,
-  [TacGeneric (None, Genarg.in_gen (Genarg.glbwit Stdarg.wit_constr) (DAst.make @@ GVar(Id.of_string"t"),None));
-   TacGeneric (None, Genarg.in_gen (Genarg.glbwit (Genarg.wit_list Stdarg.wit_ref)) l)])))
+  CAst.make (TacFun
+    ([Name(Id.of_string"t")],
+    CAst.make (TacML (tacname,
+    [TacGeneric (None, Genarg.in_gen (Genarg.glbwit Stdarg.wit_constr) (DAst.make @@ GVar(Id.of_string"t"),None));
+     TacGeneric (None, Genarg.in_gen (Genarg.glbwit (Genarg.wit_list Stdarg.wit_ref)) l)]))))
 (*
 let _ = add_tacdef false ((Loc.ghost,Id.of_string"ring_closed_term"
 *)
@@ -159,7 +160,7 @@ let decl_constant na suff univs c =
 
 (* Calling a global tactic *)
 let ltac_call tac (args:glob_tactic_arg list) =
-  TacArg(CAst.make @@ TacCall (CAst.make (ArgArg(Loc.tag @@ Lazy.force tac),args)))
+  CAst.make @@ TacArg (TacCall (CAst.make (ArgArg(Loc.tag @@ Lazy.force tac),args)))
 
 let dummy_goal env sigma =
   let (gl,_,sigma) =
@@ -196,8 +197,8 @@ let exec_tactic env sigma n f args =
   (* Build the getter *)
   let lid = List.init n (fun i -> Id.of_string("x"^string_of_int i)) in
   let n = Genarg.in_gen (Genarg.glbwit Stdarg.wit_int) n in
-  let get_res = TacML (CAst.make (get_res, [TacGeneric (None, n)])) in
-  let getter = Tacexp (TacFun (List.map (fun n -> Name n) lid, get_res)) in
+  let get_res = CAst.make (TacML (get_res, [TacGeneric (None, n)])) in
+  let getter = Tacexp (CAst.make (TacFun (List.map (fun n -> Name n) lid, get_res))) in
   (* Evaluate the whole result *)
   let gl = dummy_goal env sigma in
   let gls = Proofview.V82.of_tactic (Tacinterp.eval_tactic_ist ist (ltac_call f (args@[getter]))) gl in
@@ -504,7 +505,7 @@ let interp_cst_tac env sigma rk kind (zero,one,add,mul,opp) cst_tac =
         closed_term_ast (List.map Smartlocate.global_with_alias lc)
     | None ->
         let t = ArgArg(Loc.tag @@ Lazy.force ltac_inv_morph_nothing) in
-              TacArg(CAst.make (TacCall(CAst.make (t,[]))))
+              CAst.make (TacArg (TacCall (CAst.make (t,[]))))
 
 let make_hyp env sigma c =
   let t = Retyping.get_type_of env sigma c in
@@ -529,7 +530,7 @@ let interp_power env sigma pow =
   | None ->
       let t = ArgArg(Loc.tag (Lazy.force ltac_inv_morph_nothing)) in
       let sigma, c = plapp sigma coq_None [|carrier|] in
-      sigma, (TacArg(CAst.make (TacCall(CAst.make (t,[])))), c)
+      sigma, (CAst.make (TacArg (TacCall (CAst.make (t,[])))), c)
   | Some (tac, spec) ->
       let tac =
         match tac with
@@ -582,11 +583,11 @@ let add_theory0 env sigma name rth eqth morphth cst_tac (pre,post) power sign di
   let pretac =
     match pre with
         Some t -> Tacintern.glob_tactic t
-      | _ -> TacId [] in
+      | _ -> CAst.make (TacId []) in
   let posttac =
     match post with
         Some t -> Tacintern.glob_tactic t
-      | _ -> TacId [] in
+      | _ -> CAst.make (TacId []) in
   let r = EConstr.to_constr sigma r in
   let req = EConstr.to_constr sigma req in
   let sth = EConstr.to_constr sigma sth in
@@ -675,8 +676,8 @@ let ltac_ring_structure e =
   let pow_tac = tacarg e.ring_pow_tac in
   let lemma1 = carg e.ring_lemma1 in
   let lemma2 = carg e.ring_lemma2 in
-  let pretac = tacarg (TacFun([Anonymous],e.ring_pre_tac)) in
-  let posttac = tacarg (TacFun([Anonymous],e.ring_post_tac)) in
+  let pretac =  tacarg (CAst.make (TacFun ([Anonymous],e.ring_pre_tac))) in
+  let posttac = tacarg (CAst.make (TacFun ([Anonymous],e.ring_post_tac))) in
   [req;sth;ext;morph;th;cst_tac;pow_tac;
    lemma1;lemma2;pretac;posttac]
 
@@ -906,11 +907,11 @@ let add_field_theory0 env sigma name fth eqth morphth cst_tac inj (pre,post) pow
   let pretac =
     match pre with
         Some t -> Tacintern.glob_tactic t
-      | _ -> TacId [] in
+      | _ -> CAst.make (TacId []) in
   let posttac =
     match post with
         Some t -> Tacintern.glob_tactic t
-      | _ -> TacId [] in
+      | _ -> CAst.make (TacId []) in
   let r = EConstr.to_constr sigma r in
   let req = EConstr.to_constr sigma req in
   let _ =
@@ -968,8 +969,8 @@ let ltac_field_structure e =
   let field_simpl_eq_ok = carg e.field_simpl_eq_ok in
   let field_simpl_eq_in_ok = carg e.field_simpl_eq_in_ok in
   let cond_ok = carg e.field_cond in
-  let pretac = tacarg (TacFun([Anonymous],e.field_pre_tac)) in
-  let posttac = tacarg (TacFun([Anonymous],e.field_post_tac)) in
+  let pretac =  tacarg (CAst.make (TacFun ([Anonymous],e.field_pre_tac))) in
+  let posttac = tacarg (CAst.make (TacFun ([Anonymous],e.field_post_tac))) in
   [req;cst_tac;pow_tac;field_ok;field_simpl_ok;field_simpl_eq_ok;
    field_simpl_eq_in_ok;cond_ok;pretac;posttac]
 

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -885,8 +885,8 @@ let ssr_n_tac seed n =
     with Not_found ->
       if n = -1 then fail "The ssreflect library was not loaded"
       else fail ("The tactic "^name^" was not found") in
-  let tacexpr = CAst.make @@ Tacexpr.Reference (ArgArg (Loc.tag @@ tacname)) in
-  Tacinterp.eval_tactic (Tacexpr.TacArg tacexpr)
+  let tacexpr = Tacexpr.Reference (ArgArg (Loc.tag @@ tacname)) in
+  Tacinterp.eval_tactic @@ CAst.make (Tacexpr.TacArg tacexpr)
   end
 
 let donetac n = ssr_n_tac "done" n

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -102,7 +102,7 @@ let register_ssrtac name f prods =
     | TacTerm s -> None
     | TacNonTerm (_, (_, ido)) -> ido in
   let ids = List.map_filter get_id prods in
-  let tac = TacML (CAst.make (ssrtac_entry name, List.map map ids)) in
+  let tac = CAst.make (TacML (ssrtac_entry name, List.map map ids)) in
   let key = KerName.make path (Label.make ("ssrparser_" ^ name)) in
   let body = Tacenv.{ alias_args = ids; alias_body = tac; alias_deprecation = None } in
   let parule = {
@@ -688,7 +688,7 @@ let get_intro_id = function
   | _ -> assert false
 
 let rec add_intro_pattern_hyps ipat hyps =
-  let {CAst.loc=loc;v=ipat} = ipat in
+  let {CAst.loc; v=ipat} = ipat in
   match ipat with
   | IntroNaming (IntroIdentifier id) ->
     if not_section_id id then SsrHyp (loc, id) :: hyps else
@@ -1599,12 +1599,12 @@ let test_ssrseqvar =
     lk_ident_except sq_brace_tacnames >> (lk_kws ["[";"first";"last"])
   end
 
-let swaptacarg (loc, b) = (b, []), Some (TacId [])
+let swaptacarg (loc, b) = (b, []), Some (CAst.make ~loc (TacId []))
 
 let check_seqtacarg dir arg = match snd arg, dir with
-  | ((true, []), Some (TacAtom { CAst.loc })), L2R ->
+  | ((true, []), Some { CAst.loc; v=(TacAtom _)}), L2R ->
     CErrors.user_err ?loc (str "expected \"last\"")
-  | ((false, []), Some (TacAtom { CAst.loc })), R2L ->
+  | ((false, []), Some { CAst.loc; v=(TacAtom _) }), R2L ->
     CErrors.user_err ?loc (str "expected \"first\"")
   | _, _ -> arg
 
@@ -1696,7 +1696,7 @@ let _ = add_internal_name (is_tagged perm_tag)
 {
 
   let ssrtac_expr ?loc key args =
-    TacAlias (CAst.make ?loc (key, (List.map (fun x -> Tacexpr.TacGeneric (None, x)) args)))
+    CAst.make ?loc (TacAlias (key, (List.map (fun x -> Tacexpr.TacGeneric (None, x)) args)))
 
 let mk_non_term wit id =
   let open Pptactic in
@@ -1739,7 +1739,7 @@ END
 GRAMMAR EXTEND Gram
   GLOBAL: ltac_expr;
   ssrparentacarg: [[ "("; tac = ltac_expr; ")" -> { CAst.make ~loc (Tacexp tac) } ]];
-  ltac_expr: LEVEL "0" [[ arg = ssrparentacarg -> { TacArg arg } ]];
+  ltac_expr: LEVEL "0" [[ arg = ssrparentacarg -> { CAst.make ~loc (TacArg CAst.(arg.v)) } ]];
 END
 
 (** The internal "done" and "ssrautoprop" tactics. *)
@@ -1760,7 +1760,7 @@ let ssrautoprop =
       try Tacenv.locate_tactic (qualid_of_ident (Id.of_string "ssrautoprop"))
       with Not_found -> Tacenv.locate_tactic (ssrqid "ssrautoprop") in
     let tacexpr = CAst.make @@ Tacexpr.Reference (ArgArg (Loc.tag @@ tacname)) in
-    eval_tactic (Tacexpr.TacArg tacexpr)
+    eval_tactic (CAst.make @@ Tacexpr.TacArg CAst.(tacexpr.v))
   with Not_found -> Auto.full_trivial []
   end
 
@@ -1875,14 +1875,14 @@ GRAMMAR EXTEND Gram
   GLOBAL: ltac_expr;
   ssr_first: [
     [ tac = ssr_first; ipats = ssrintros_ne -> { tclintros_expr ~loc tac ipats }
-    | "["; tacl = LIST0 ltac_expr SEP "|"; "]" -> { TacFirst tacl }
+    | "["; tacl = LIST0 ltac_expr SEP "|"; "]" -> { CAst.make ~loc (TacFirst tacl) }
     ] ];
   ssr_first_else: [
-    [ tac1 = ssr_first; tac2 = ssrorelse -> { TacOrelse (tac1, tac2) }
+    [ tac1 = ssr_first; tac2 = ssrorelse -> { CAst.make ~loc (TacOrelse (tac1, tac2)) }
     | tac = ssr_first -> { tac } ]];
   ltac_expr: LEVEL "4" [ LEFTA
     [ tac1 = ltac_expr; ";"; IDENT "first"; tac2 = ssr_first_else ->
-      { TacThen (tac1, tac2) }
+      { CAst.make ~loc (TacThen (tac1, tac2)) }
     | tac = ltac_expr; ";"; IDENT "first"; arg = ssrseqarg ->
       { tclseq_expr ~loc tac L2R arg }
     | tac = ltac_expr; ";"; IDENT "last"; arg = ssrseqarg ->
@@ -2490,7 +2490,7 @@ GRAMMAR EXTEND Gram
   GLOBAL: ltac_expr;
   ltac_expr: LEVEL "3"
     [ RIGHTA [ IDENT "abstract"; gens = ssrdgens ->
-               { TacML (CAst.make ~loc (
+               { CAst.make ~loc (TacML (
                      ssrtac_entry "abstract", [Tacexpr.TacGeneric (None, Genarg.in_gen (Genarg.rawwit wit_ssrdgens) gens)]))
                  } ]];
 END

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -1312,8 +1312,8 @@ let () =
   let name = { mltac_plugin = "ssrmatching_plugin"; mltac_tactic = "ssrpattern"; } in
   let () = Tacenv.register_ml_tactic name [|mltac|] in
   let tac =
-    TacFun ([Name (Id.of_string "pattern")],
-      TacML (CAst.make ({ mltac_name = name; mltac_index = 0 }, []))) in
+    CAst.make (TacFun ([Name (Id.of_string "pattern")],
+      CAst.make (TacML ({ mltac_name = name; mltac_index = 0 }, [])))) in
   let obj () =
     Tacenv.register_ltac true false (Id.of_string "ssrpattern") tac in
   Mltop.declare_cache_obj obj "ssrmatching_plugin"

--- a/user-contrib/Ltac2/tac2core.ml
+++ b/user-contrib/Ltac2/tac2core.ml
@@ -1171,7 +1171,7 @@ let () = define3 "ltac1_apply" ltac1 (list ltac1) closure begin fun f args k ->
   let (_, args, lfun) = List.fold_right fold args (0, [], Id.Map.empty) in
   let lfun = Id.Map.add (Id.of_string "F") f lfun in
   let ist = { (Tacinterp.default_ist ()) with Tacinterp.lfun = lfun; } in
-  let tac = TacArg(CAst.make @@ TacCall (CAst.make (ArgVar CAst.(make @@ Id.of_string "F"),args))) in
+  let tac = CAst.make @@ TacArg (TacCall (CAst.make (ArgVar CAst.(make @@ Id.of_string "F"),args))) in
   Tacinterp.val_interp ist tac k >>= fun () ->
   return v_unit
 end
@@ -1551,7 +1551,7 @@ let () =
   let () = Geninterp.register_interp0 wit_ltac2_val interp_fun in
   define1 "ltac1_lambda" valexpr begin fun f ->
     let body = Tacexpr.TacGeneric (Some "ltac2", in_gen (glbwit wit_ltac2_val) ()) in
-    let clos = Tacexpr.TacFun ([Name arg_id], Tacexpr.TacArg (CAst.make body)) in
+    let clos = CAst.make (Tacexpr.TacFun ([Name arg_id], CAst.make (Tacexpr.TacArg body))) in
     let f = Geninterp.Val.inject (Geninterp.Val.Base typ_ltac2) f in
     let lfun = Id.Map.singleton tac_id f in
     let ist = { (Tacinterp.default_ist ()) with Tacinterp.lfun } in
@@ -1583,7 +1583,8 @@ let () =
   let interp ist (ids, tac) = match ids with
   | [] ->
     (* Evaluate the Ltac2 quotation eagerly *)
-    let idtac = Value.of_closure { ist with lfun = Id.Map.empty } (Tacexpr.TacId []) in
+    let idtac = Value.of_closure { ist with lfun = Id.Map.empty }
+        (CAst.make (Tacexpr.TacId [])) in
     let ist = { env_ist = Id.Map.empty } in
     Tac2interp.interp ist tac >>= fun _ ->
     Ftactic.return idtac
@@ -1594,7 +1595,8 @@ let () =
     let nas = List.map (fun id -> Name id) ids in
     let mk_arg id = Tacexpr.Reference (Locus.ArgVar (CAst.make id)) in
     let args = List.map mk_arg ids in
-    let clos = Tacexpr.TacFun (nas, Tacexpr.TacML (CAst.make (ltac2_eval, mk_arg self_id :: args))) in
+    let clos = CAst.make (Tacexpr.TacFun
+        (nas, CAst.make (Tacexpr.TacML (ltac2_eval, mk_arg self_id :: args)))) in
     let self = GTacFun (List.map (fun id -> Name id) ids, tac) in
     let self = Tac2interp.interp_value { env_ist = Id.Map.empty } self in
     let self = Geninterp.Val.inject (Geninterp.Val.Base typ_ltac2) self in


### PR DESCRIPTION
This preserves the Loc.t info the debugger needs to display the source code at a break point.  The info will be used in the next debugger PR.

I had to remove the call to `adjust_loc` in `Tacticintern.intern_tactic_seq` to preserve the information (in the .vo files, IIRC).  That ignores `!strict_check`.  I'm not sure that's entirely correct, but the debugger definitely needs to have the location info in the vo files to be able to jump to the breakpoint location (if it's a secondary script file).  Please advise.