### PR TITLE
[build] Some more fixes to Dune-Make bridge + ci-* targets

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -260,9 +260,7 @@ MAKE_TSOPTS=-C test-suite -s VERBOSE=$(VERBOSE)
 
 check: validate test-suite
 
-TEST_SUITE_TOOLING=$(BCONTEXT)/tools/CoqMakefile.in $(BCONTEXT)/tools/coqdoc/coqdoc.sty $(BCONTEXT)/tools/coqdoc/coqdoc.css
-
-test-suite: world $(TEST_SUITE_TOOLING)
+test-suite: world
 	$(MAKE) $(MAKE_TSOPTS) clean
 	$(MAKE) $(MAKE_TSOPTS) all
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -64,6 +64,7 @@ TOPBINOPT:=$(addsuffix .opt$(EXE), $(addprefix $(CBIN)/, coqproofworker coqtacti
 COQDEP:=$(CBIN)/coqdep$(EXE)
 DOC_GRAM:=_build/default/doc/tools/docgram/doc_grammar.exe
 COQMAKEFILE:=$(CBIN)/coq_makefile$(EXE)
+COQMAKEFILEIN:=$(BCONTEXT)/tools/CoqMakefile.in
 COQTEX:=$(CBIN)/coq-tex$(EXE)
 COQWC:=$(CBIN)/coqwc$(EXE)
 COQDOC:=$(CBIN)/coqdoc$(EXE)
@@ -79,14 +80,14 @@ OCAMLLIBDEP:=$(CBIN)/ocamllibdep$(EXE)
 FAKEIDE:=$(CBIN)/fake_ide$(EXE)
 USERCONTRIBDIRS:=Ltac2
 CHICKEN:=$(CBIN)/coqchk$(EXE)
-TOOLS:=$(VOTOUR) $(COQDOC) $(COQWC) $(COQMAKEFILE)
+TOOLS:=$(VOTOUR) $(COQDOC) $(COQDOCSTY) $(COQDOCCSS) $(COQWC) $(COQMAKEFILE) $(COQMAKEFILEIN)
 CSDPCERT:=$(CBIN)/csdpcert$(EXE)
 
 ifeq ($(origin COQ_SRC_DIR),undefined)
 COQ_SRC_DIR=.
 endif
 
-COQ_CM_LIBS=coqpp lib clib kernel library engine pretyping gramlib interp printing parsing proofs tactics vernac stm toplevel topbin
+COQ_CM_LIBS=coqpp lib clib kernel library engine pretyping gramlib interp printing parsing proofs tactics vernac stm toplevel topbin tools
 ML_SOURCE_DIRS=$(addprefix $(COQ_SRC_DIR)/,$(COQ_CM_LIBS))
 ALL_ML_SOURCE_FILES=$(shell find $(ML_SOURCE_DIRS) -name '*.ml' -or -name '*.mli' -or -name '*.c' -or -name '*.h')
 
@@ -165,10 +166,12 @@ ALL_CONTRIB_SOURCE_FILES=$(shell find $(COQ_SRC_DIR)/user-contrib -name '*.ml' -
 _build/default/user-contrib/%.cmxs: $(ALL_CONTRIB_SOURCE_FILES)
 	$(SHOW)'DUNE      $@'
 	$(HIDE)$(_DBUILD) $@
+	$(HIDE)touch $@
 
 _build/default/user-contrib/%.cma: $(ALL_CONTRIB_SOURCE_FILES)
 	$(SHOW)'DUNE      $@'
 	$(HIDE)$(_DBUILD) $@
+	$(HIDE)touch $@
 
 .PHONY: all-src
 
@@ -181,12 +184,14 @@ all-src: $(ALL_SOURCE_FILES)
 _build/default/doc/tools/%: $(ALL_ML_SOURCE_FILES)
 	$(SHOW)'DUNE      $@'
 	$(HIDE)$(_DBUILD) $@
+	$(HIDE)touch $@
 
 PLUGINTUTO := doc/plugin_tutorial
 
 revision:
 	$(SHOW)'DUNE      $@'
 	$(HIDE)$(_DBUILD) $@
+	$(HIDE)touch $@
 
 # For emacs:
 # Local Variables:

--- a/dune
+++ b/dune
@@ -25,6 +25,7 @@
 
 (rule
  (targets revision)
+ (mode fallback)
  (deps (:rev-script dev/tools/make_git_revision.sh))
  (action (with-stdout-to revision (bash %{rev-script}))))
 

--- a/kernel/nativelib.ml
+++ b/kernel/nativelib.ml
@@ -56,8 +56,9 @@ let include_dirs = ref []
 let get_include_dirs () =
   let base = match !include_dirs with
   | [] ->
-    [ Envars.coqlib () / "../coq-core/kernel"; Envars.coqlib () / "kernel/.kernel.objs/byte/"
-    ; Envars.coqlib () / "../coq-core/library"; Envars.coqlib () / "library/.library.objs/byte/"
+    let coqcorelib = Envars.coqcorelib () in
+    [ coqcorelib / "kernel" ; coqcorelib / "kernel/.kernel.objs/byte/"
+    ; coqcorelib / "library"; coqcorelib / "library/.library.objs/byte/"
     ]
   | _::_ as l -> l
   in

--- a/test-suite/misc/coq_environment.sh
+++ b/test-suite/misc/coq_environment.sh
@@ -9,6 +9,7 @@ cd $TMP
 cat > coq_environment.txt <<EOT
 # we override COQLIB because we can
 COQLIB="$TMP/overridden" # bla bla
+COQCORELIB="$TMP/overridden" # bla bla
 OCAMLFIND="$TMP/overridden"
 FOOBAR="one more"
 EOT
@@ -16,7 +17,7 @@ EOT
 cp $BIN/coqc .
 cp $BIN/coq_makefile .
 mkdir -p overridden/tools/
-cp $COQLIB/tools/CoqMakefile.in overridden/tools/ || cp $COQLIB/../coq-core/tools/CoqMakefile.in overridden/tools/
+cp $COQLIB/../coq-core/tools/CoqMakefile.in overridden/tools/
 
 unset COQLIB
 N=`./coqc -config | grep COQLIB | grep /overridden | wc -l`

--- a/tools/coq_makefile.ml
+++ b/tools/coq_makefile.ml
@@ -123,19 +123,11 @@ let read_whole_file s =
 let quote s = if String.contains s ' ' || CString.is_empty s then "'" ^ s ^ "'" else s
 
 let generate_makefile oc conf_file local_file dep_file args project =
-  let coqlib = Envars.coqlib () in
-  let makefile_template =
-    CPath.choose_existing
-      [ CPath.make [ coqlib; "tools"; "CoqMakefile.in" ]
-      ; CPath.make [ coqlib; ".."; "coq-core"; "tools"; "CoqMakefile.in" ]
-      ]
-  in
-  let makefile_template = match makefile_template with
-    | None ->
-      Format.eprintf "Error: cannot find CoqMakefile.in";
-      exit 1
-    | Some v -> (v :> string)
-  in
+  let coqcorelib = Envars.coqcorelib () in
+  let makefile_template = Filename.concat coqcorelib "tools/CoqMakefile.in" in
+  if not (Sys.file_exists makefile_template) then
+    (Format.eprintf "Error: cannot find CoqMakefile.in in %s" makefile_template;
+     exit 1);
   let s = read_whole_file makefile_template in
   let s = List.fold_left
     (* We use global_substitute to avoid running into backslash issues due to \1 etc. *)


### PR DESCRIPTION
We fix a few problems remaining from the transition:

- some dependencies were missing in the bridge, in particular legacy
  mode didn't rebuild tools always
- we didn't install CoqMakefile.in sometimes
- we forgot to update the timestamp on a couple of bridges
- parameter setup for ci-common was wrong after removal of -local
- we use `coqcorelib` in more places, this fixes `ci-*` targets with a local build when native is enabled

Fixes #14187