### PR TITLE
Normalize universes before comparing in progress

### DIFF
--- a/engine/univProblem.mli
+++ b/engine/univProblem.mli
@@ -8,7 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open Constr
 open Univ
 
 (** {6 Constraints for type inference}
@@ -43,11 +42,3 @@ val enforce_eq_instances_univs : bool -> Instance.t constraint_function
 (** With [force_weak] UWeak constraints are turned into equalities,
    otherwise they're forgotten. *)
 val to_constraints : force_weak:bool -> UGraph.t -> Set.t -> Constraint.t
-
-(** [eq_constr_univs_infer_With kind1 kind2 univs m n] is a variant of
-    {!eq_constr_univs_infer} taking kind-of-term functions, to expose
-    subterms of [m] and [n], arguments. *)
-val eq_constr_univs_infer_with :
-  (constr -> (constr, types, Sorts.t, Univ.Instance.t) kind_of_term) ->
-  (constr -> (constr, types, Sorts.t, Univ.Instance.t) kind_of_term) ->
-  UGraph.t -> 'a accumulator -> constr -> constr -> 'a -> 'a option

--- a/lib/acyclicGraph.ml
+++ b/lib/acyclicGraph.ml
@@ -189,12 +189,12 @@ module Make (Point:Point) = struct
     match PMap.find u g.entries with
     | Equiv v -> repr g v
     | Canonical arc -> arc
-    | exception Not_found ->
-      CErrors.anomaly ~label:"Univ.repr"
-        Pp.(str"Universe " ++ Point.pr (Index.repr u g.table) ++ str" undefined.")
 
   let repr_node g u =
-    repr g (Index.find u g.table)
+    try repr g (Index.find u g.table)
+    with Not_found ->
+      CErrors.anomaly ~label:"Univ.repr"
+        Pp.(str"Universe " ++ Point.pr u ++ str" undefined.")
 
   exception AlreadyDeclared
 

--- a/test-suite/bugs/closed/bug_14221.v
+++ b/test-suite/bugs/closed/bug_14221.v
@@ -1,0 +1,163 @@
+Axiom proof_admitted : False.
+Tactic Notation "admit" := abstract case proof_admitted.
+Require Coq.Program.Program.
+Export Coq.Program.Program.
+Set Primitive Projections.
+Set Universe Polymorphism.
+
+Close Scope nat_scope.
+Export Coq.Classes.CMorphisms.
+
+Notation "∀  x .. y , P" := (forall x, .. (forall y, P) ..)
+  (at level 200, x binder, y binder, right associativity).
+
+Class Setoid A := {
+  equiv : crelation A;
+  setoid_equiv :> Equivalence equiv
+}.
+
+Notation "f ≈ g" := (equiv f g) (at level 79).
+
+Ltac cat :=
+  intros;
+  autorewrite with categories;
+  auto with category_laws;
+  try reflexivity.
+
+Hint Extern 4 (equiv ?A ?A) => reflexivity : category_laws.
+
+Ltac proper := repeat intro; simpl; try cat; intuition.
+
+Ltac cat_simpl :=
+  program_simpl; autounfold;
+  try solve [
+    program_simpl; autounfold in *;
+    simpl in *; intros;
+    simpl in *; cat];
+  simpl in *.
+
+Global Obligation Tactic := cat_simpl.
+
+Reserved Infix "~>" (at level 90, right associativity).
+
+Class Category := {
+  obj : Type;
+
+  uhom := Type : Type;
+  hom : obj -> obj -> uhom where "a ~> b" := (hom a b);
+  homset :> ∀ X Y, Setoid (X ~> Y);
+
+  id {x} : x ~> x;
+}.
+
+Delimit Scope category_scope with category.
+Delimit Scope object_scope with object.
+
+Notation "x ~> y" := (@hom _%category x%object y%object)
+  (at level 90, right associativity) : homset_scope.
+Notation "x ~{ C }~> y" := (@hom C%category x%object y%object)
+  (at level 90) : homset_scope.
+
+Notation "id[ x ]" := (@id _%category x%object)
+  (at level 9, format "id[ x ]") : morphism_scope.
+
+Coercion obj : Category >-> Sortclass.
+
+Open Scope homset_scope.
+Open Scope morphism_scope.
+
+Class Functor (C D : Category) := {
+  fobj : C -> D;
+  fmap {x y : C} (f : x ~> y) : fobj x ~> fobj y;
+
+  fmap_respects :> ∀ x y, Proper (equiv ==> equiv) (@fmap x y);
+
+  fmap_id {x : C} : fmap (@id C x) ≈ id;
+}.
+Delimit Scope functor_scope with functor.
+
+Coercion fobj : Functor >-> Funclass.
+
+Notation "fmap[ F ]" := (@fmap _ _ F%functor _ _)
+  (at level 9, format "fmap[ F ]") : morphism_scope.
+
+Hint Rewrite @fmap_id : categories.
+
+Definition Product (C D : Category) : Category := {|
+  obj     := C * D;
+  hom     := fun x y => (fst x ~> fst y) * (snd x ~> snd y);
+  homset  := fun x y =>
+    let setoid_C := @homset C (fst x) (fst y) in
+    let setoid_D := @homset D (snd x) (snd y) in
+    {| equiv := fun f g =>
+         (@equiv _ setoid_C (fst f) (fst g) *
+          @equiv _ setoid_D (snd f) (snd g))
+     ; setoid_equiv := _
+         {| Equivalence_Reflexive  := fun x =>
+              (@Equivalence_Reflexive _ _ (@setoid_equiv _ setoid_C) (fst x),
+               @Equivalence_Reflexive _ _ (@setoid_equiv _ setoid_D) (snd x))
+          ; Equivalence_Symmetric  := fun x y f =>
+              (@Equivalence_Symmetric
+                 _ _ (@setoid_equiv _ setoid_C) (fst x) (fst y) (fst f),
+               @Equivalence_Symmetric
+                 _ _ (@setoid_equiv _ setoid_D) (snd x) (snd y) (snd f))
+          ; Equivalence_Transitive := fun x y z f g =>
+              (@Equivalence_Transitive
+                 _ _ (@setoid_equiv _ setoid_C) (fst x) (fst y) (fst z)
+                 (fst f) (fst g),
+               @Equivalence_Transitive
+                 _ _ (@setoid_equiv _ setoid_D) (snd x) (snd y) (snd z)
+                 (snd f) (snd g)) |} |};
+  id      := fun _ => (id, id);
+|}.
+
+Section Bifunctor.
+
+Context {C : Category}.
+Context {D : Category}.
+Context {E : Category}.
+
+Definition bimap {F : Functor (Product C D) E} {x w : C} {y z : D}
+           (f : x ~{C}~> w) (g : y ~{D}~> z) :
+  F (x, y) ~{E}~> F (w, z) := @fmap (Product C D) E F (x, y) (w, z) (f, g).
+
+Global Program Instance bimap_respects {F : Functor (Product C D) E} {x w : C} {y z : D} :
+  Proper (equiv ==> equiv ==> equiv) (@bimap F x w y z).
+Next Obligation.
+admit.
+Defined.
+
+Lemma bimap_id_id {F : Functor (Product C D) E} {x y} :
+  bimap (id[x]) (id[y]) ≈ id.
+admit.
+Defined.
+
+End Bifunctor.
+
+Notation "bimap[ F ]" := (@bimap _ _ _ F%functor _ _ _ _)
+  (at level 9, format "bimap[ F ]") : morphism_scope.
+
+Hint Rewrite @bimap_id_id : categories.
+
+Reserved Infix "⨂" (at level 30, right associativity).
+
+Class Monoidal {C : Category} := {
+  tensor : Functor (Product C C) C where "x ⨂ y" := (tensor (x, y));
+}.
+
+Notation "x ⨂ y" := (@tensor _ _ (x%object, y%object))
+  (at level 30, right associativity) : object_scope.
+Notation "f ⨂ g" := (bimap[@tensor _ _] f g)
+  (at level 30, right associativity) : morphism_scope.
+
+Program Instance PP
+        {C : Category} {D : Category} `{@Monoidal D}
+        {F : Functor C D} {G : Functor C D} : Functor C D := {
+  fobj := fun x => (F x ⨂ G x)%object;
+  fmap := fun _ _ f => fmap[F] f ⨂ fmap[G] f
+}.
+Next Obligation.
+  proper.
+  rewrite X. (* was anomaly undefined universe *)
+  reflexivity.
+Qed.


### PR DESCRIPTION
Fix #14221.

We get to simplify code a bit by merging
UnivProblem.eq_constr_univs_infer_with into
Evarutil.eq_constr_univs_test.

The important bit for the bug is the added
"normalize_universe_instance".

In master the anomaly was an uncaught Not_found since
62169f7e584ef36c5709c88385297f371366868b, we also fix that (without a
test since it's an anomaly).
