### PR TITLE
[build] Ensure `make world` builds all targets present in `make install`

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -89,7 +89,7 @@ include Makefile.install
 
 world: coq coqide documentation revision
 byte: world
-coq: coqlib coqbinaries tools
+coq: coqlib coqbinaries tools $(BCONTEXT)/coq-core.install $(BCONTEXT)/coqide-server.install
 
 world.timing.diff: coq.timing.diff
 coq.timing.diff: coqlib.timing.diff

--- a/Makefile.ide
+++ b/Makefile.ide
@@ -22,7 +22,7 @@ IDEFILES=$(wildcard ide/*.lang) ide/coq_style.xml ide/coq.png) $(IDEBINDINGS)
 ifeq ($(HASCOQIDE),no)
 coqide:
 else
-coqide: $(COQIDE) $(IDETOP) $(TOPBINOPT) $(IDEBINDINGS) $(VO_OUT_DIR)theories/Init/Prelude.$(VO)
+coqide: $(COQIDE) $(IDETOP) $(TOPBINOPT) $(IDEBINDINGS) $(VO_OUT_DIR)theories/Init/Prelude.$(VO) $(BCONTEXT)/coqide.install
 endif
 
 # $(INSTALLLIB) ide/coq.png ide/*.lang ide/coq_style.xml $(IDEBINDINGS) $(FULLDATADIR)

--- a/Makefile.install
+++ b/Makefile.install
@@ -56,6 +56,13 @@ endif
 .PHONY: install-coq install-dune install-library
 
 # --display quiet should not produce output, dune bug
+
+# Note that dune install paths are setup at dune's build time, thus
+# for example a Debian-built dune will install stuff following
+# Debian's FHS, an opam-built dune will differ and follow OPAM's layout.
+#
+# We ought to improve this, as of today the case of an opam-built dune
+# installing to a global prefix such as /usr/local/ may not follow the FHS
 install-dune: $(BCONTEXT)/coq-core.install $(BCONTEXT)/coqide-server.install
 	dune install --display quiet --mandir="$(MANDIR)" --prefix="$(FULLCOQPREFIX)" coq-core
 	dune install --display quiet --mandir="$(MANDIR)" --prefix="$(FULLCOQPREFIX)" coqide-server


### PR DESCRIPTION
It is important to ensure a phase separation of `make world` and `make
install` as this last one may be called using `sudo` in some contexts
and thus create build objects under the root user, which leads to
disaster usually.

In order to fix that quickly, we just extend the `world` target to be
comprehensive.

Note that dune upstream enforced this by forbidding `dune install` to
build anything, but there is a bit more convenient as the
`foo.install` file depends on all the objects to installed already by
construction.

We should follow a similar path in our make wrappers, but that would
require a bit of rewrite / design, with given the status of the code
may not be a bad idea as it has gotten to a point where cleanup would
be nice.

Fixes #14228 , keeping #14232 open as to try to improve install
locations a little bit for 8.14, tho the issue is subtle.
