### PR TITLE
[build] Build stdlib with -warn-error in dev profile.

### DIFF
--- a/dune
+++ b/dune
@@ -1,6 +1,7 @@
 ; Default flags for all Coq libraries.
 (env
- (dev     (flags :standard -rectypes -w -9-27@60-70 \ -short-paths))
+ (dev     (flags :standard -rectypes -w -9-27@60-70 \ -short-paths)
+          (coq (flags :standard -w +default)))
  (release (flags :standard -rectypes)
           (ocamlopt_flags :standard -O3 -unbox-closures))
  (ireport (flags :standard -rectypes -w -9-27+60-70)


### PR DESCRIPTION
We could still have configure generate the flag set, but IMHO it is not worth it.

This seems broken tho, the initial implementation of `(env ... (coq (flags ...))` was indeed buggy, but it seems we still have some more bugs lurking around.