### PR TITLE
Clean the Reductionops.Stack API

### DIFF
--- a/dev/base_include
+++ b/dev/base_include
@@ -24,7 +24,6 @@
 #install_printer  (* Cpred.t *) pp_cpred;;
 #install_printer ppzipper;;
 #install_printer ppstack;;
-#install_printer (* Reductionops.Stack.t *) pp_stack_t;;
 #install_printer ppatom;;
 #install_printer ppwhd;;
 #install_printer ppvblock;;

--- a/dev/include_printers
+++ b/dev/include_printers
@@ -29,8 +29,6 @@
 #install_printer  (* id set *) ppidmapgen;;
 #install_printer  (* int set *) ppintmapgen;;
 
-#install_printer  (* Reductionops machine stack *) pp_stack_t;;
-
 (*#install_printer  (* hint_db *)  print_hint_db;;*)
 (*#install_printer  (* hints_path *)  pphintspath;;*)
 #install_printer  (* goal *)  ppgoal;;

--- a/dev/top_printers.dbg
+++ b/dev/top_printers.dbg
@@ -45,7 +45,6 @@ install_printer Top_printers.ppdelta
 install_printer Top_printers.pp_idpred
 install_printer Top_printers.pp_cpred
 install_printer Top_printers.pp_transparent_state
-install_printer Top_printers.pp_stack_t
 install_printer Top_printers.pp_estack_t
 install_printer Top_printers.pp_state_t
 install_printer Top_printers.ppmetas

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -177,7 +177,6 @@ let ppdelta s = pp (Mod_subst.debug_pr_delta s)
 let pp_idpred s = pp (pr_idpred s)
 let pp_cpred s = pp (pr_cpred s)
 let pp_transparent_state s = pp (pr_transparent_state s)
-let pp_stack_t n = pp (Reductionops.Stack.pr (EConstr.of_constr %> pr_econstr) n)
 let pp_estack_t n = pp (Reductionops.Stack.pr pr_econstr n)
 let pp_state_t n = pp (Reductionops.pr_state Global.(env()) Evd.empty n)
 

--- a/dev/top_printers.mli
+++ b/dev/top_printers.mli
@@ -106,8 +106,7 @@ val pp_idpred : Names.Id.Pred.t -> unit
 val pp_cpred : Names.Cpred.t -> unit
 val pp_transparent_state : TransparentState.t -> unit
 
-val pp_stack_t : Constr.t Reductionops.Stack.t -> unit
-val pp_estack_t : EConstr.t Reductionops.Stack.t -> unit
+val pp_estack_t : Reductionops.Stack.t -> unit
 val pp_state_t : Reductionops.state -> unit
 
 val ppmetas : Evd.Metaset.t -> unit

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -110,11 +110,13 @@ type flex_kind_of_term =
   | MaybeFlexible of EConstr.t (* reducible but not necessarily reduced *)
   | Flexible of EConstr.existential
 
+let has_arg s = Option.has_some (Stack.strip_n_app 0 s)
+
 let flex_kind_of_term flags env evd c sk =
   match EConstr.kind evd c with
     | LetIn _ | Rel _ | Const _ | Var _ | Proj _ ->
       Option.cata (fun x -> MaybeFlexible x) Rigid (eval_flexible_term flags.open_ts env evd c)
-    | Lambda _ when not (Option.is_empty (Stack.decomp sk)) ->
+    | Lambda _ when has_arg sk ->
        if flags.modulo_betaiota then MaybeFlexible c
        else Rigid
     | Evar ev ->

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -371,10 +371,9 @@ let rec ise_stack2 no_app env evd f sk1 sk2 =
       else None, x in
     match revsk1, revsk2 with
     | [], [] -> None, Success i
-    | Stack.Case (ci1,u1,pms1,t1,iv1,c1)::q1, Stack.Case (ci2,u2,pms2,t2,iv2,c2)::q2 ->
-      let dummy = mkProp in
-      let (_, t1, _, _, c1) = EConstr.expand_case env evd (ci1,u1,pms1,t1,iv1,dummy,c1) in
-      let (_, t2, _, _, c2) = EConstr.expand_case env evd (ci2,u2,pms2,t2,iv2,dummy,c2) in
+    | Stack.Case cse1 :: q1, Stack.Case cse2 :: q2 ->
+      let (t1, c1) = Stack.expand_case env evd cse1 in
+      let (t2, c2) = Stack.expand_case env evd cse2 in
       begin
         match ise_and i [
           (fun i -> f env i CONV t1 t2);
@@ -411,10 +410,9 @@ let rec exact_ise_stack2 env evd f sk1 sk2 =
   let rec ise_rev_stack2 i revsk1 revsk2 =
     match revsk1, revsk2 with
     | [], [] -> Success i
-    | Stack.Case (ci1,u1,pms1,t1,iv1,c1)::q1, Stack.Case (ci2,u2,pms2,t2,iv2,c2)::q2 ->
-      let dummy = mkProp in
-      let (_, t1, _, _, c1) = EConstr.expand_case env evd (ci1,u1,pms1,t1,iv1,dummy,c1) in
-      let (_, t2, _, _, c2) = EConstr.expand_case env evd (ci2,u2,pms2,t2,iv2,dummy,c2) in
+    | Stack.Case cse1 :: q1, Stack.Case cse2 :: q2 ->
+      let (t1, c1) = Stack.expand_case env evd cse1 in
+      let (t2, c2) = Stack.expand_case env evd cse2 in
       ise_and i [
       (fun i -> ise_rev_stack2 i q1 q2);
       (fun i -> ise_array2 i (fun ii -> f env ii CONV) c1 c2);

--- a/pretyping/evarconv.mli
+++ b/pretyping/evarconv.mli
@@ -79,9 +79,9 @@ val check_problems_are_solved : env -> evar_map -> unit
 val check_conv_record : env -> evar_map ->
   state -> state ->
   evar_map * (constr * constr)
-  * constr * constr list * (constr Stack.t * constr Stack.t) *
-    (constr Stack.t * constr Stack.t) *
-    (constr Stack.t * constr Stack.t) * constr *
+  * constr * constr list * (Stack.t * Stack.t) *
+    (Stack.t * Stack.t) *
+    (Stack.t * Stack.t) * constr *
     (int option * constr)
 
 (** Compares two constants/inductives/constructors unifying their universes.

--- a/pretyping/evarconv.mli
+++ b/pretyping/evarconv.mli
@@ -79,8 +79,8 @@ val check_problems_are_solved : env -> evar_map -> unit
 val check_conv_record : env -> evar_map ->
   state -> state ->
   evar_map * (constr * constr)
-  * constr * constr list * (Stack.t * Stack.t) *
-    (Stack.t * Stack.t) *
+  * constr * constr list * (EConstr.t list * EConstr.t list) *
+    (EConstr.t list * EConstr.t list) *
     (Stack.t * Stack.t) * constr *
     (int option * constr)
 

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -214,6 +214,7 @@ sig
   val zip : evar_map -> constr * constr t -> constr
   val check_native_args : CPrimitives.t -> 'a t -> bool
   val get_next_primitive_args : CPrimitives.args_red -> 'a t -> CPrimitives.args_red * ('a t * 'a * 'a t) option
+  val expand_case : env -> evar_map -> constr case_stk -> constr * constr array
 end =
 struct
   open EConstr
@@ -438,6 +439,11 @@ struct
     in
     let n = nargs kargs in
     (List.skipn (n+1) kargs, strip_n_app n stk)
+
+  let expand_case env sigma ((ci, u, pms, t, iv, br) : _ case_stk) =
+    let dummy = mkProp in
+    let (_, t, _, _, br) = EConstr.expand_case env sigma (ci, u, pms, t, iv, dummy, br) in
+    (t, br)
 
 end
 

--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -95,9 +95,6 @@ module Stack : sig
       if there enough of those *)
   val strip_n_app : int -> t -> (t * EConstr.t * t) option
 
-  (** [decomp sk] extracts the first argument of [sk] is there is some *)
-  val decomp : t -> (EConstr.t * t) option
-
   (** [decomp sk] extracts the first argument of reversed stack [sk] is there is some *)
   val decomp_rev : t -> (EConstr.t * t) option
 

--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -57,8 +57,7 @@ module Stack : sig
 
   val pr_app_node : ('a -> Pp.t) -> 'a app_node -> Pp.t
 
-  type 'a case_stk =
-    case_info * EInstance.t * 'a array * 'a pcase_return * 'a pcase_invert * 'a pcase_branch array
+  type 'a case_stk
 
   type 'a member =
   | App of 'a app_node
@@ -132,6 +131,8 @@ module Stack : sig
 
   (** [zip sigma t sk] *)
   val zip : evar_map -> constr * constr t -> constr
+
+  val expand_case : env -> evar_map -> constr case_stk -> constr * constr array
 end
 
 (************************************************************************)

--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -109,10 +109,6 @@ module Stack : sig
       head of [sk] *)
   val args_size : t -> int
 
-  (** [tail n sk] drops the [n] first arguments of [sk]
-      @raise [Invalid_argument] if there are not enough arguments *)
-  val tail : int -> t -> t
-
   (** [zip sigma t sk] *)
   val zip : evar_map -> constr * t -> constr
 

--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -72,9 +72,6 @@ module Stack : sig
   val empty : t
   val is_empty : t -> bool
 
-  val decomp_node_last : app_node -> t -> (EConstr.t * t)
-  [@@ocaml.deprecated "Use decomp_rev"]
-
   val compare_shape : t -> t -> bool
 
   exception IncompatibleFold2
@@ -83,7 +80,6 @@ module Stack : sig
       @return the result and the lifts to apply on the terms
       @raise IncompatibleFold2 when [sk1] and [sk2] have incompatible shapes *)
   val fold2 : ('a -> constr -> constr -> 'a) -> 'a -> t -> t -> 'a
-  val map : (EConstr.t -> EConstr.t) -> t -> t
 
   (** [append_app args sk] pushes array of arguments [args] on [sk] *)
   val append_app : EConstr.t array -> t -> t
@@ -112,10 +108,6 @@ module Stack : sig
       arguments if [sk] is purely applicative and [None] otherwise *)
   val list_of_app_stack : t -> constr list option
 
-  (** [assign sk n a] changes the [n]th argument of [sk] with [a], counting from 0
-      @raise an anomaly if there is less that [n] arguments available *)
-  val assign : t -> int -> EConstr.t -> t
-
   (** [args_size sk] returns the number of arguments available at the
       head of [sk] *)
   val args_size : t -> int
@@ -123,10 +115,6 @@ module Stack : sig
   (** [tail n sk] drops the [n] first arguments of [sk]
       @raise [Invalid_argument] if there are not enough arguments *)
   val tail : int -> t -> t
-
-  (** [nth sk n] returns the [n]-th argument of [sk], counting from 0
-      @raise [Not_found] if there is no [n]th argument *)
-  val nth : t -> int -> EConstr.t
 
   (** [zip sigma t sk] *)
   val zip : evar_map -> constr * t -> constr

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1117,12 +1117,13 @@ let rec unify_0_with_initial_metas (sigma,ms,es as subst : subst0) conv_at_top e
       in
       try
       let opt' = {opt with with_types = false} in
-      let substn = Reductionops.Stack.fold2
-                           (fun s u1 u -> unirec_rec curenvnb pb opt' s u1 (substl ks u))
-                           (evd,ms,es) us2 us in
-      let substn = Reductionops.Stack.fold2
-                           (fun s u1 u -> unirec_rec curenvnb pb opt' s u1 (substl ks u))
-                           substn params1 params in
+      let fold u1 u s = unirec_rec curenvnb pb opt' s u1 (substl ks u) in
+      let foldl acc l1 l2 =
+        try List.fold_right2 fold l1 l2 acc
+        with Invalid_argument _ -> assert false (* check_conv_record ensures lengths coincide *)
+      in
+      let substn = foldl (evd,ms,es) us2 us in
+      let substn = foldl substn params1 params in
       let substn = Reductionops.Stack.fold2 (fun s u1 u2 -> unirec_rec curenvnb pb opt' s u1 u2) substn ts ts1 in
       let app = mkApp (c, Array.rev_of_list ks) in
       (* let substn = unirec_rec curenvnb pb b false substn t cN in *)


### PR DESCRIPTION
This PR reduces the attack surface of the `Reductionops.Stack` API.
- Remove the useless type parameter
- Enforce static invariants in the callers
- Factorize the set of exported functions