### PR TITLE
Run doc_gram_verify target in lint CI job.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,12 +6,31 @@
 Fixes / closes #????
 
 
-<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
-<!-- (Otherwise, remove this line.) -->
-- [ ] Added / updated test-suite
+<!-- Remove anything that doesn't apply in the following checklist. -->
+
+<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
+- [ ] Added / updated **test-suite**.
+
 <!-- If this is a feature pull request / breaks compatibility: -->
-<!-- (Otherwise, remove these lines.) -->
-- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
-- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
-- [ ] Overlay pull requests (if this breaks 3rd party developments in CI, see
-https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md for details)
+- [ ] Added **changelog**.
+- [ ] Added / updated **documentation**.
+  <!-- Check if the following applies, otherwise remove these lines. -->
+  - [ ] Documented any new / changed **user messages**.
+  - [ ] Updated **documented syntax** by running `make -f Makefile.make doc_gram_rsts`.
+
+<!-- If this breaks external libraries or plugins in CI: -->
+- [ ] Opened **overlay** pull requests.
+
+<!-- Pointers to relevant developer documentation:
+
+Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md
+
+Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md
+
+Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md
+
+Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
+Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
+doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md
+
+Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -523,7 +523,7 @@ conflict and this merge cannot be performed automatically, the bot
 will put a `needs: rebase` label, and the tests won't run.
 
 Otherwise, a large suite of tests will be run on GitLab, plus some
-additional tests on Azure for Windows and macOS compatibility.
+additional tests on GitHub Actions for Windows and macOS compatibility.
 
 If a test fails on GitLab, you will see in the GitHub PR interface,
 both the failure of the whole pipeline, and of the specific failed
@@ -569,12 +569,19 @@ We have a linter that checks a few different things:
   your branch with `git rebase --whitespace=fix`.
 - **All files should end with a single newline**.  See the section
   [Style guide](#style-guide) for additional style recommendations.
-- **Code is properly formatted**: for some parts of the codebase,
-  formatting will be enforced using the
-  [`ocamlformat`](https://github.com/ocaml-ppx/ocamlformat) tool.
-  Formatting issues will also be fixed automatically by the pre-commit
-  hook mentioned above (you may also use `dune build @fmt
-  --auto-promote` to fix this kind of errors).
+- **Documented syntax is up-to-date**.  If you update the grammar, you
+  should run `make -f Makefile.make doc_gram_rsts` to update the
+  documented syntax.  You should then update the text describing the
+  syntax in the documentation and commit the changes.  In some cases,
+  the documented syntax is edited to make the documentation more
+  readable.  In this case, you may have to edit
+  `doc/tools/docgram/common.edit_mlg` to make `doc_gram_rsts` pass.
+  See [doc_grammar's README][doc_gram] for details.
+
+  Note that in the case where you added new commands or tactics, you
+  will have to manually insert them in the documentation, the tool
+  won't do that for you, only check that what you documented is
+  consistent with the parser.
 
 You may run the linter yourself with `dev/lint-repository.sh`.
 
@@ -1268,6 +1275,7 @@ can be found [on the wiki][wiki-CUDW].
 [dev-tools-create_overlays.sh]: dev/tools/create_overlays.sh
 [Discourse]: https://coq.discourse.group/
 [Discourse-development-category]: https://coq.discourse.group/c/coq-development
+[doc_gram]: doc/tools/docgram/README.md
 [doc-README]: doc/README.md
 [documentation-github-project]: https://github.com/coq/coq/projects/3
 [dune-doc]: https://dune.readthedocs.io/en/latest/

--- a/Makefile.doc
+++ b/Makefile.doc
@@ -289,10 +289,30 @@ install-doc-sphinx:
 # doc_grammar tool
 ######################################################################
 
-# user-contrib/*/*.mlg omitted for now (e.g. ltac2)
-PLUGIN_MLGS := $(wildcard plugins/*/*.mlg)
-OMITTED_PLUGIN_MLGS :=
-DOC_MLGS := $(wildcard */*.mlg) $(sort $(filter-out $(OMITTED_PLUGIN_MLGS), $(PLUGIN_MLGS))) \
+# List mlg files explicitly to avoid ordering problems (across
+# different installations / make versions).
+DOC_MLGS := \
+	parsing/g_constr.mlg parsing/g_prim.mlg \
+	toplevel/g_toplevel.mlg \
+	vernac/g_proofs.mlg  vernac/g_vernac.mlg \
+	plugins/btauto/g_btauto.mlg \
+	plugins/cc/g_congruence.mlg \
+	plugins/derive/g_derive.mlg \
+	plugins/extraction/g_extraction.mlg \
+	plugins/firstorder/g_ground.mlg \
+	plugins/funind/g_indfun.mlg \
+	plugins/ltac/coretactics.mlg plugins/ltac/extraargs.mlg plugins/ltac/extratactics.mlg \
+	plugins/ltac/g_auto.mlg plugins/ltac/g_class.mlg plugins/ltac/g_eqdecide.mlg \
+	plugins/ltac/g_ltac.mlg plugins/ltac/g_obligations.mlg plugins/ltac/g_rewrite.mlg \
+	plugins/ltac/g_tactic.mlg plugins/ltac/profile_ltac_tactics.mlg \
+	plugins/micromega/g_micromega.mlg  plugins/micromega/g_zify.mlg \
+	plugins/nsatz/g_nsatz.mlg \
+	plugins/ring/g_ring.mlg \
+	plugins/rtauto/g_rtauto.mlg \
+	plugins/ssr/ssrparser.mlg  plugins/ssr/ssrvernac.mlg \
+	plugins/ssrmatching/g_ssrmatching.mlg \
+	plugins/ssrsearch/g_search.mlg \
+	plugins/syntax/g_number_string.mlg \
 	user-contrib/Ltac2/g_ltac2.mlg
 DOC_EDIT_MLGS := $(wildcard doc/tools/docgram/*.edit_mlg)
 DOC_RSTS := $(wildcard doc/sphinx/*/*.rst) $(wildcard doc/sphinx/*/*/*.rst)

--- a/Makefile.doc
+++ b/Makefile.doc
@@ -50,9 +50,9 @@ SPHINXBUILDDIR= doc/sphinx/_build
 
 DOCGRAMWARN ?= 0
 ifeq ($(DOCGRAMWARN),0)
-DOCGRAMWARN=-no-warn
+DOCGRAMWARNFLAG=-no-warn
 else
-DOCGRAMWARN=
+DOCGRAMWARNFLAG=
 endif
 
 # Internal variables.
@@ -304,7 +304,7 @@ doc/tools/docgram/fullGrammar: $(DOC_GRAM) $(DOC_MLGS)
 #todo: add a dependency of sphinx on updated_rsts when we're ready
 doc/tools/docgram/orderedGrammar doc/tools/docgram/updated_rsts: doc/tools/docgram/fullGrammar $(DOC_GRAM) $(DOC_EDIT_MLGS)
 	$(SHOW)'DOC_GRAM_RSTS'
-	$(HIDE)$(DOC_GRAM) $(DOCGRAMWARN) -check-cmds -check-tacs $(DOC_MLGS) $(DOC_RSTS)
+	$(HIDE)$(DOC_GRAM) $(DOCGRAMWARNFLAG) -check-cmds -check-tacs $(DOC_MLGS) $(DOC_RSTS)
 
 .PRECIOUS: doc/tools/docgram/orderedGrammar
 

--- a/dev/lint-repository.sh
+++ b/dev/lint-repository.sh
@@ -35,4 +35,8 @@ dev/tools/check-overlays.sh || CODE=1
 echo Checking CACHEKEY
 dev/tools/check-cachekey.sh || CODE=1
 
+# Check that doc/tools/docgram/fullGrammar is up-to-date
+echo Checking grammar files
+(./configure -profile devel && make -j "$NJOBS" -f Makefile.make doc_gram_verify) || CODE=1
+
 exit $CODE

--- a/doc/tools/docgram/README.md
+++ b/doc/tools/docgram/README.md
@@ -112,6 +112,8 @@ for documentation purposes:
 
 * `make doc_gram_rsts` updates the `*Grammar` and `.rst` files.
 
+* `make doc_gram_rsts DOCGRAMWARN=1` will additionally print warnings.
+
 Changes to `fullGrammar`, `orderedGrammar` and the `.rsts` should be checked in to git.
 The `prodn*` and other `*Grammar` files should not.
 

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -316,8 +316,12 @@ term_let: [
 | MOVETO destructuring_let "let" "'" pattern200 "in" pattern200 ":=" term200 case_type "in" term200
 ]
 
+qualid_annotated: [
+| global univ_annot
+]
+
 atomic_constr: [
-| MOVETO qualid_annotated global univ_annot
+| qualid_annotated
 | MOVETO primitive_notations NUMBER
 | MOVETO primitive_notations string
 | MOVETO term_evar "_"
@@ -407,6 +411,8 @@ term1: [
 ]
 
 term0: [
+| DELETE ident univ_annot
+| DELETE ident Prim.fields univ_annot
 (* @Zimmi48: This rule is a hack, according to Hugo, and should not be shown in the manual. *)
 | DELETE "{" binder_constr "}"
 | REPLACE "{|" record_declaration bar_cbrace

--- a/doc/tools/docgram/doc_grammar.ml
+++ b/doc/tools/docgram/doc_grammar.ml
@@ -1560,8 +1560,10 @@ let finish_with_file old_file args =
   if !exit_code <> 0 then
     Sys.remove temp_file
   else if args.verify then begin
-    if not (files_eq old_file temp_file) then
+    if not (files_eq old_file temp_file) then begin
       error "%s is not current\n" old_file;
+      ignore (CUnix.sys_command "diff" [ old_file ; old_file ^ ".new"])
+    end;
     Sys.remove temp_file
   end else if args.update then
     Sys.rename temp_file old_file

--- a/doc/tools/docgram/dune
+++ b/doc/tools/docgram/dune
@@ -45,6 +45,6 @@
   orderedGrammar)
  (action
   (progn
-   (chdir %{project_root} (run doc_grammar -check-cmds -no-update %{input}))
+   (chdir %{project_root} (run doc_grammar -no-warn -check-cmds -no-update %{input}))
    (diff? fullGrammar fullGrammar.new)
    (diff? orderedGrammar orderedGrammar.new))))

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -112,6 +112,8 @@ term1: [
 term0: [
 | atomic_constr
 | term_match
+| ident Prim.fields univ_annot
+| ident univ_annot
 | "(" term200 ")"
 | "{|" record_declaration bar_cbrace
 | "{" binder_constr "}"
@@ -165,7 +167,6 @@ arg: [
 ]
 
 atomic_constr: [
-| global univ_annot
 | sort
 | NUMBER
 | string


### PR DESCRIPTION
**Kind:** infrastructure.

~~@jfehrle As is, the linter only checks that `fullGrammar` is up-to-date. In #14178, we recommend running the full `doc_gram_rsts` target. Should we extend `doc_gram_verify` to some sort of `doc_gram_rsts_verify`?~~ Done

Include changes originally in: #14178
Now on top of: #14504 (merged)