### PR TITLE
Split level creation from level population in Grammar

### DIFF
--- a/coqpp/coqpp_ast.mli
+++ b/coqpp/coqpp_ast.mli
@@ -40,12 +40,10 @@ type tactic_rule = {
 type level = string
 
 type position =
-| Top
 | First
 | Last
 | Before of level
 | After of level
-| Level of level
 
 type assoc =
 | LeftA
@@ -80,10 +78,13 @@ type gram_rule = {
   grule_prods : gram_prod list;
 }
 
+type grammar_rules =
+| GDataFresh of position option * gram_rule list
+| GDataReuse of string option * gram_prod list
+
 type grammar_entry = {
   gentry_name : string;
-  gentry_pos : position option;
-  gentry_rules : gram_rule list;
+  gentry_rules : grammar_rules;
 }
 
 type grammar_ext = {

--- a/coqpp/coqpp_ast.mli
+++ b/coqpp/coqpp_ast.mli
@@ -40,6 +40,7 @@ type tactic_rule = {
 type level = string
 
 type position =
+| Top
 | First
 | Last
 | Before of level

--- a/coqpp/coqpp_lex.mll
+++ b/coqpp/coqpp_lex.mll
@@ -119,6 +119,7 @@ rule extend = parse
 | "AS" { AS }
 (** Camlp5 specific keywords *)
 | "GLOBAL" { GLOBAL }
+| "TOP" { TOP }
 | "FIRST" { FIRST }
 | "LAST" { LAST }
 | "BEFORE" { BEFORE }

--- a/coqpp/coqpp_main.ml
+++ b/coqpp/coqpp_main.ml
@@ -122,6 +122,7 @@ let print_local fmt ext =
     fprintf fmt "in@ "
 
 let print_position fmt pos = match pos with
+| Top -> fprintf fmt "Gramlib.Gramext.Top"
 | First -> fprintf fmt "Gramlib.Gramext.First"
 | Last -> fprintf fmt "Gramlib.Gramext.Last"
 | Before s -> fprintf fmt "Gramlib.Gramext.Before@ \"%s\"" s

--- a/coqpp/coqpp_main.ml
+++ b/coqpp/coqpp_main.ml
@@ -264,11 +264,26 @@ let print_rule fmt r =
   let pr_prd fmt prd = print_list fmt print_prod prd in
   fprintf fmt "@[(%a,@ %a,@ %a)@]" pr_lvl r.grule_label pr_asc r.grule_assoc pr_prd (List.rev r.grule_prods)
 
-let print_entry fmt e =
-  let print_position_opt fmt pos = print_opt fmt print_position pos in
+let print_entry fmt e = match e.gentry_pos with
+| Some (Level _ | Top as pos) ->
+  let pos = match pos with Level n -> Some n | Top -> None | _ -> assert false in
+  let rules = match e.gentry_rules with
+  | [r] -> List.rev r.grule_prods
+  | _ -> assert false
+  in
+  let pr_pos fmt pos = print_opt fmt print_string pos in
+  let pr_prd fmt prd = print_list fmt print_prod prd in
+  fprintf fmt "let () =@ @[Pcoq.grammar_extend@ %s@ @[(Pcoq.Reuse (%a, %a))@]@]@ in@ "
+    e.gentry_name pr_pos pos pr_prd rules
+| None | Some (First | Last | Before _ | After _) as pos ->
+  let pos = match pos with None -> First | Some p -> p in
   let print_rules fmt rules = print_list fmt print_rule rules in
-  fprintf fmt "let () =@ @[Pcoq.grammar_extend@ %s@ @[{ Pcoq.pos=%a; data=%a}@]@]@ in@ "
-    e.gentry_name print_position_opt e.gentry_pos print_rules e.gentry_rules
+  let pr_check fmt = function
+  | None -> fprintf fmt "let () =@ @[assert@ (Pcoq.Entry.is_empty@ %s)@]@ in@ " e.gentry_name
+  | Some _ -> fprintf fmt ""
+  in
+  fprintf fmt "%alet () =@ @[Pcoq.grammar_extend@ %s@ @[(Pcoq.Fresh@ (%a, %a))@]@]@ in@ "
+    pr_check e.gentry_pos e.gentry_name print_position pos print_rules e.gentry_rules
 
 let print_ast fmt ext =
   let () = fprintf fmt "let _ = @[" in

--- a/coqpp/coqpp_parse.mly
+++ b/coqpp/coqpp_parse.mly
@@ -71,7 +71,7 @@ let no_code = { code = ""; loc = { loc_start=Lexing.dummy_pos; loc_end=Lexing.du
 %token COMMAND CLASSIFIED STATE PRINTED TYPED INTERPRETED GLOBALIZED SUBSTITUTED BY AS
 %token BANGBRACKET HASHBRACKET LBRACKET RBRACKET PIPE ARROW FUN COMMA EQUAL STAR
 %token LPAREN RPAREN COLON SEMICOLON
-%token GLOBAL FIRST LAST BEFORE AFTER LEVEL LEFTA RIGHTA NONA
+%token GLOBAL TOP FIRST LAST BEFORE AFTER LEVEL LEFTA RIGHTA NONA
 %token EOF
 
 %type <Coqpp_ast.t> file
@@ -339,6 +339,7 @@ position_opt:
 ;
 
 position:
+| TOP { Top }
 | FIRST { First }
 | LAST { Last }
 | BEFORE STRING { Before $2 }

--- a/coqpp/coqpp_parse.mly
+++ b/coqpp/coqpp_parse.mly
@@ -329,8 +329,15 @@ gram_entries:
 ;
 
 gram_entry:
+| qualid_or_ident COLON reuse LBRACKET LBRACKET rules_opt RBRACKET RBRACKET SEMICOLON
+  { { gentry_name = $1; gentry_rules = GDataReuse ($3, $6); } }
 | qualid_or_ident COLON position_opt LBRACKET levels RBRACKET SEMICOLON
-  { { gentry_name = $1; gentry_pos = $3; gentry_rules = $5; } }
+  { { gentry_name = $1; gentry_rules = GDataFresh ($3, $5); } }
+;
+
+reuse:
+| TOP { None }
+| LEVEL STRING { Some $2 }
 ;
 
 position_opt:
@@ -339,12 +346,10 @@ position_opt:
 ;
 
 position:
-| TOP { Top }
 | FIRST { First }
 | LAST { Last }
 | BEFORE STRING { Before $2 }
 | AFTER STRING { After $2 }
-| LEVEL STRING { Level $2 }
 ;
 
 string_opt:
@@ -427,11 +432,11 @@ doc_gram_entries:
 
 doc_gram_entry:
 | qualid_or_ident COLON LBRACKET PIPE doc_gram_rules RBRACKET
-  { { gentry_name = $1; gentry_pos = None;
-      gentry_rules = [{ grule_label = None; grule_assoc = None; grule_prods = $5; }] } }
+  { { gentry_name = $1;
+      gentry_rules = GDataFresh (None, [{ grule_label = None; grule_assoc = None; grule_prods = $5; }]) } }
 | qualid_or_ident COLON LBRACKET RBRACKET
-  { { gentry_name = $1; gentry_pos = None;
-      gentry_rules = [{ grule_label = None; grule_assoc = None; grule_prods = []; }] } }
+  { { gentry_name = $1;
+      gentry_rules = GDataFresh (None, [{ grule_label = None; grule_assoc = None; grule_prods = []; }]) } }
 ;
 
 doc_gram_rules:

--- a/dev/doc/changes.md
+++ b/dev/doc/changes.md
@@ -35,6 +35,18 @@
 - A few functions change their interfaces to take benefit of a new
   abstraction level `LStream` for streams with location function.
 
+- Grammar extensions now require specifying whether they create a level or they
+  reuse an existing one. In addition to the Gramlib API changes, GRAMMAR EXTEND
+  stanzas may need a few tweaks. Their grammar was changed so that level and
+  associativity arguments that would have been ignored are now forbidden.
+  Furthermore, extensions without an explicit position now expect the entry to
+  be empty. If it is not the case, the extension will fail at runtime with an
+  assertion failure located near the offending entry. To recover the old
+  behaviour, one needs to explicitly add the new TOP position to the extension.
+  This position expects the entry to be non-empty and populates the topmost
+  defined level with the provided rules. Note that this differs from FIRST,
+  which creates a new level and prepends it to the list of levels of the entry.
+
 ## Changes between Coq 8.12 and Coq 8.13
 
 ### Code formatting

--- a/gramlib/gramext.ml
+++ b/gramlib/gramext.ml
@@ -3,11 +3,9 @@
 (* Copyright (c) INRIA 2007-2017 *)
 
 type position =
-  | Top
   | First
   | Last
   | Before of string
   | After of string
-  | Level of string
 
 type g_assoc = NonA | RightA | LeftA

--- a/gramlib/gramext.ml
+++ b/gramlib/gramext.ml
@@ -3,7 +3,8 @@
 (* Copyright (c) INRIA 2007-2017 *)
 
 type position =
-    First
+  | Top
+  | First
   | Last
   | Before of string
   | After of string

--- a/gramlib/gramext.mli
+++ b/gramlib/gramext.mli
@@ -3,11 +3,9 @@
 (* Copyright (c) INRIA 2007-2017 *)
 
 type position =
-  | Top
   | First
   | Last
   | Before of string
   | After of string
-  | Level of string
 
 type g_assoc = NonA | RightA | LeftA

--- a/gramlib/gramext.mli
+++ b/gramlib/gramext.mli
@@ -3,7 +3,8 @@
 (* Copyright (c) INRIA 2007-2017 *)
 
 type position =
-    First
+  | Top
+  | First
   | Last
   | Before of string
   | After of string

--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -573,9 +573,18 @@ let get_level entry position levs =
               let (levs1, rlev, levs2) = get levs in lev :: levs1, rlev, levs2
       in
       get levs
+  | Some Top ->
+    begin match levs with
+        lev :: levs -> [], change_lev lev "<top>", levs
+      | [] ->
+        let msg = sprintf "Grammar.extend: No top level in entry \"%s\"" entry.ename in
+        failwith msg
+    end
   | None ->
       match levs with
-        lev :: levs -> [], change_lev lev "<top>", levs
+      | _ :: _ ->
+        let msg = sprintf "Grammar.extend: Entry \"%s\" not empty" entry.ename in
+        failwith msg
       | [] -> [], empty_lev, []
 
 let change_to_self0 (type s) (type trec) (type a) (entry : s ty_entry) : (s, trec, a) ty_symbol -> (s, a) ty_mayrec_symbol =

--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -33,6 +33,7 @@ module type S = sig
     val of_parser : string -> 'a parser_fun -> 'a t
     val parse_token_stream : 'a t -> te LStream.t -> 'a
     val print : Format.formatter -> 'a t -> unit
+    val is_empty : 'a t -> bool
   end
 
   module rec Symbol : sig
@@ -82,9 +83,8 @@ module type S = sig
     string option * Gramext.g_assoc option * 'a Production.t list
 
   type 'a extend_statement =
-    { pos : Gramext.position option
-    ; data : 'a single_extend_statement list
-    }
+  | Reuse of string option * 'a Production.t list
+  | Fresh of Gramext.position * 'a single_extend_statement list
 
   val generalize_symbol : ('a, 'tr, 'c) Symbol.t -> ('a, norec, 'c) Symbol.t option
 
@@ -515,77 +515,53 @@ let empty_lev lname assoc =
   Level
   {assoc = assoc; lname = lname; lsuffix = DeadEnd; lprefix = DeadEnd}
 
-let change_lev (Level lev) n lname assoc =
-  let a =
-    match assoc with
-      None -> lev.assoc
-    | Some a ->
-      if a <> lev.assoc then
-        Feedback.msg_warning (Pp.str ("<W> Changing associativity of level \""^n^"\""));
-      a
-  in
-  begin
-    match lname with
-    | Some n ->
-      (* warning disabled; it was in the past *)
-      if false && lname <> lev.lname then
-        Feedback.msg_warning (Pp.str ("<W> Level label \""^n^"\" ignored"))
-    | None -> ()
-  end;
-  Level
-  {assoc = a; lname = lev.lname; lsuffix = lev.lsuffix; lprefix = lev.lprefix}
-
 let err_no_level lev e =
   let msg = sprintf "Grammar.extend: No level labelled \"%s\" in entry \"%s\"" lev e in
   failwith msg
 
-let get_level entry position levs =
+let get_position entry position levs =
   match position with
-    Some First -> [], empty_lev, levs
-  | Some Last -> levs, empty_lev, []
-  | Some (Level n) ->
+    First -> [], levs
+  | Last -> levs, []
+  | Before n ->
       let rec get =
         function
           [] -> err_no_level n entry.ename
         | lev :: levs ->
-            if is_level_labelled n lev then [], change_lev lev n, levs
+            if is_level_labelled n lev then [], lev :: levs
             else
-              let (levs1, rlev, levs2) = get levs in lev :: levs1, rlev, levs2
+              let (levs1, levs2) = get levs in lev :: levs1, levs2
       in
       get levs
-  | Some (Before n) ->
+  | After n ->
       let rec get =
         function
           [] -> err_no_level n entry.ename
         | lev :: levs ->
-            if is_level_labelled n lev then [], empty_lev, lev :: levs
+            if is_level_labelled n lev then [lev], levs
             else
-              let (levs1, rlev, levs2) = get levs in lev :: levs1, rlev, levs2
+              let (levs1, levs2) = get levs in lev :: levs1, levs2
       in
       get levs
-  | Some (After n) ->
+
+let get_level entry name levs = match name with
+  | Some n ->
       let rec get =
         function
           [] -> err_no_level n entry.ename
         | lev :: levs ->
-            if is_level_labelled n lev then [lev], empty_lev, levs
+            if is_level_labelled n lev then [], lev, levs
             else
               let (levs1, rlev, levs2) = get levs in lev :: levs1, rlev, levs2
       in
       get levs
-  | Some Top ->
+  | None ->
     begin match levs with
-        lev :: levs -> [], change_lev lev "<top>", levs
+        lev :: levs -> [], lev, levs
       | [] ->
         let msg = sprintf "Grammar.extend: No top level in entry \"%s\"" entry.ename in
         failwith msg
     end
-  | None ->
-      match levs with
-      | _ :: _ ->
-        let msg = sprintf "Grammar.extend: Entry \"%s\" not empty" entry.ename in
-        failwith msg
-      | [] -> [], empty_lev, []
 
 let change_to_self0 (type s) (type trec) (type a) (entry : s ty_entry) : (s, trec, a) ty_symbol -> (s, a) ty_mayrec_symbol =
   function
@@ -634,7 +610,20 @@ let insert_tokens gram symbols =
   in
   linsert symbols
 
-let levels_of_rules entry position rules =
+type 'a single_extend_statement =
+  string option * Gramext.g_assoc option * 'a ty_production list
+
+type 'a extend_statement =
+| Reuse of string option * 'a ty_production list
+| Fresh of Gramext.position * 'a single_extend_statement list
+
+let add_prod entry lev (TProd (symbols, action)) =
+  let MayRecRule symbols = change_to_self entry symbols in
+  let AnyS (symbols, pf) = get_symbols symbols in
+  insert_tokens egram symbols;
+  insert_level entry.ename symbols pf action lev
+
+let levels_of_rules entry st =
   let elev =
     match entry.edesc with
       Dlevels elev -> elev
@@ -642,26 +631,20 @@ let levels_of_rules entry position rules =
         let msg = sprintf "Grammar.extend: entry not extensible: \"%s\"" entry.ename in
         failwith msg
   in
-  match rules with
-  | [] -> elev
-  | _ ->
-    let (levs1, make_lev, levs2) = get_level entry position elev in
-    let (levs, _) =
-      List.fold_left
-        (fun (levs, make_lev) (lname, assoc, level) ->
-           let lev = make_lev lname assoc in
-           let lev =
-             List.fold_left
-               (fun lev (TProd (symbols, action)) ->
-                  let MayRecRule symbols = change_to_self entry symbols in
-                  let AnyS (symbols, pf) = get_symbols symbols in
-                  insert_tokens egram symbols;
-                  insert_level entry.ename symbols pf action lev)
-               lev level
-           in
-           lev :: levs, empty_lev)
-        ([], make_lev) rules
+  match st with
+  | Reuse (name, []) -> elev
+  | Reuse (name, prods) ->
+    let (levs1, lev, levs2) = get_level entry name elev in
+    let lev = List.fold_left (fun lev prod -> add_prod entry lev prod) lev prods in
+    levs1 @ [lev] @ levs2
+  | Fresh (position, rules) ->
+    let (levs1, levs2) = get_position entry position elev in
+    let fold levs (lname, assoc, prods) =
+      let lev = empty_lev lname assoc in
+      let lev = List.fold_left (fun lev prod -> add_prod entry lev prod) lev prods in
+      lev :: levs
     in
+    let levs = List.fold_left fold [] rules in
     levs1 @ List.rev levs @ levs2
 
 let logically_eq_symbols entry =
@@ -1558,8 +1541,8 @@ let init_entry_functions entry =
        let f = continue_parser_of_entry entry in
        entry.econtinue <- f; f lev bp a strm)
 
-let extend_entry entry position rules =
-    let elev = levels_of_rules entry position rules in
+let extend_entry entry statement =
+    let elev = levels_of_rules entry statement in
     entry.edesc <- Dlevels elev; init_entry_functions entry
 
 (* Deleting a rule *)
@@ -1658,6 +1641,10 @@ module Entry = struct
         (fun _ _ _ (strm__ : _ LStream.t) -> raise Stream.Failure);
       edesc = Dparser p}
   let print ppf e = fprintf ppf "%a@." print_entry e
+
+  let is_empty e = match e.edesc with
+  | Dparser _ -> failwith "Arbitrary parser entry"
+  | Dlevels elev -> List.is_empty elev
 end
 
 module rec Symbol : sig
@@ -1745,16 +1732,8 @@ module Unsafe = struct
 
 end
 
-type 'a single_extend_statement =
-  string option * Gramext.g_assoc option * 'a ty_production list
-
-type 'a extend_statement =
-  { pos : Gramext.position option
-  ; data : 'a single_extend_statement list
-  }
-
-let safe_extend (e : 'a Entry.t) { pos; data } =
-  extend_entry e pos data
+let safe_extend (e : 'a Entry.t) data =
+  extend_entry e data
 
 let safe_delete_rule e (TProd (r,_act)) =
   let AnyS (symbols, _) = get_symbols r in

--- a/gramlib/grammar.mli
+++ b/gramlib/grammar.mli
@@ -43,6 +43,7 @@ module type S = sig
     val of_parser : string -> 'a parser_fun -> 'a t
     val parse_token_stream : 'a t -> te LStream.t -> 'a
     val print : Format.formatter -> 'a t -> unit
+    val is_empty : 'a t -> bool
   end
 
   module rec Symbol : sig
@@ -92,9 +93,10 @@ module type S = sig
     string option * Gramext.g_assoc option * 'a Production.t list
 
   type 'a extend_statement =
-    { pos : Gramext.position option
-    ; data : 'a single_extend_statement list
-    }
+  | Reuse of string option * 'a Production.t list
+    (** Extend an existing level by its optional given name. If None, picks the topmost level. *)
+  | Fresh of Gramext.position * 'a single_extend_statement list
+    (** Create a level at the given position. *)
 
   val generalize_symbol : ('a, 'tr, 'c) Symbol.t -> ('a, norec, 'c) Symbol.t option
 

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -93,7 +93,7 @@ GRAMMAR EXTEND Gram
   Constr.ident:
     [ [ id = Prim.ident -> { id } ] ]
   ;
-  Prim.name:
+  Prim.name: TOP
     [ [ "_" -> { CAst.make ~loc Anonymous } ] ]
   ;
   global:

--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -184,7 +184,7 @@ GRAMMAR EXTEND Gram
       | "()" -> { TacGeneric (None, genarg_of_unit ()) } ] ]
   ;
   (* Can be used as argument and at toplevel in tactic expressions. *)
-  tactic_value:
+  tactic_value: TOP
     [ [ c = constr_eval -> { ConstrMayEval c }
       | IDENT "fresh"; l = LIST0 fresh_id -> { TacFreshId l }
       | IDENT "type_term"; c=uconstr -> { TacPretype c }
@@ -328,7 +328,7 @@ GRAMMAR EXTEND Gram
     [ [ g = OPT toplevel_selector; tac = G_vernac.query_command -> { tac g }
       | g = OPT toplevel_selector; "{" -> { Vernacexpr.VernacSubproof g } ] ]
   ;
-  command:
+  command: TOP
     [ [ IDENT "Proof"; "with"; ta = Pltac.tactic;
         l = OPT [ IDENT "using"; l = G_vernac.section_subset_expr -> { l } ] ->
           { Vernacexpr.VernacProof (Some (in_tac ta), l) }
@@ -336,7 +336,7 @@ GRAMMAR EXTEND Gram
         "with"; ta = Pltac.tactic ->
           { Vernacexpr.VernacProof (Some (in_tac ta),Some l) } ] ]
   ;
-  hint:
+  hint: TOP
     [ [ IDENT "Extern"; n = natural; c = OPT Constr.constr_pattern ; "=>";
         tac = Pltac.tactic ->
         { Vernacexpr.HintsExtern (n,c, in_tac tac) } ] ]

--- a/plugins/ltac/g_obligations.mlg
+++ b/plugins/ltac/g_obligations.mlg
@@ -68,7 +68,7 @@ GRAMMAR EXTEND Gram
       | -> { None } ] ]
   ;
 
-  Constr.closed_binder:
+  Constr.closed_binder: TOP
     [[ "("; id=Prim.name; ":"; t=Constr.lconstr; "|"; c=Constr.lconstr; ")" -> {
           let typ = mkAppC (sigref loc, [mkLambdaC ([id], default_binder_kind, t, c)]) in
           [CLocalAssum ([id], default_binder_kind, typ)] }

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -112,9 +112,9 @@ let interp_entry_name interp symb =
 
 let get_tactic_entry n =
   if Int.equal n 0 then
-    Pltac.simple_tactic, None
+    Pltac.simple_tactic, Some Gramlib.Gramext.Top
   else if Int.equal n 5 then
-    Pltac.binder_tactic, None
+    Pltac.binder_tactic, Some Gramlib.Gramext.Top
   else if 1<=n && n<5 then
     Pltac.ltac_expr, Some (Gramlib.Gramext.Level (string_of_int n))
   else
@@ -391,6 +391,10 @@ let add_ml_tactic_notation name ~level ?deprecation prods =
 
 let ltac_quotations = ref String.Set.empty
 
+let () =
+  let dummy = (None, None, []) in
+  Pcoq.grammar_extend Pltac.tactic_value {pos=None; data=[dummy]}
+
 let create_ltac_quotation name cast (e, l) =
   let () =
     if String.Set.mem name !ltac_quotations then
@@ -420,7 +424,7 @@ let create_ltac_quotation name cast (e, l) =
   in
   let action _ v _ _ _ loc = cast (Some loc, v) in
   let gram = (level, assoc, [Pcoq.Production.make rule action]) in
-  Pcoq.grammar_extend Pltac.tactic_value {pos=None; data=[gram]}
+  Pcoq.grammar_extend Pltac.tactic_value {pos=Some Gramlib.Gramext.Top; data=[gram]}
 
 (** Command *)
 

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -112,11 +112,11 @@ let interp_entry_name interp symb =
 
 let get_tactic_entry n =
   if Int.equal n 0 then
-    Pltac.simple_tactic, Some Gramlib.Gramext.Top
+    Pltac.simple_tactic, None
   else if Int.equal n 5 then
-    Pltac.binder_tactic, Some Gramlib.Gramext.Top
+    Pltac.binder_tactic, None
   else if 1<=n && n<5 then
-    Pltac.ltac_expr, Some (Gramlib.Gramext.Level (string_of_int n))
+    Pltac.ltac_expr, Some (string_of_int n)
   else
     user_err Pp.(str ("Invalid Tactic Notation level: "^(string_of_int n)^"."))
 
@@ -188,7 +188,7 @@ let add_tactic_entry (kn, ml, tg) state =
   in
   let prods = List.map map tg.tacgram_prods in
   let rules = make_rule mkact prods in
-  let r = ExtendRule (entry, { pos; data=[(None, None, [rules])]}) in
+  let r = ExtendRule (entry, Pcoq.Reuse (pos, [rules])) in
   ([r], state)
 
 let tactic_grammar =
@@ -392,8 +392,7 @@ let add_ml_tactic_notation name ~level ?deprecation prods =
 let ltac_quotations = ref String.Set.empty
 
 let () =
-  let dummy = (None, None, []) in
-  Pcoq.grammar_extend Pltac.tactic_value {pos=None; data=[dummy]}
+  Pcoq.grammar_extend Pltac.tactic_value (Pcoq.Fresh (Gramlib.Gramext.First, [None, None, []]))
 
 let create_ltac_quotation name cast (e, l) =
   let () =
@@ -405,9 +404,6 @@ let create_ltac_quotation name cast (e, l) =
   | None -> Pcoq.Symbol.nterm e
   | Some l -> Pcoq.Symbol.nterml e (string_of_int l)
   in
-(*   let level = Some "1" in *)
-  let level = None in
-  let assoc = None in
   let rule =
     Pcoq.(
       Rule.next
@@ -423,8 +419,8 @@ let create_ltac_quotation name cast (e, l) =
         (Symbol.token (CLexer.terminal ")")))
   in
   let action _ v _ _ _ loc = cast (Some loc, v) in
-  let gram = (level, assoc, [Pcoq.Production.make rule action]) in
-  Pcoq.grammar_extend Pltac.tactic_value {pos=Some Gramlib.Gramext.Top; data=[gram]}
+  let gram = [Pcoq.Production.make rule action] in
+  Pcoq.grammar_extend Pltac.tactic_value (Pcoq.Reuse (None, gram))
 
 (** Command *)
 
@@ -909,7 +905,7 @@ let argument_extend (type a b c) ~name (arg : (a, b, c) tactic_argument) =
     e
   | Vernacextend.Arg_rules rules ->
     let e = Pcoq.create_generic_entry2 name (Genarg.rawwit wit) in
-    let () = Pcoq.grammar_extend e {pos=None; data=[(None, None, rules)]} in
+    let () = Pcoq.grammar_extend e (Pcoq.Fresh (Gramlib.Gramext.First, [None, None, rules])) in
     e
   in
   let (rpr, gpr, tpr) = arg.arg_printer in

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -134,7 +134,7 @@ ARGUMENT EXTEND ssrtacarg TYPED AS tactic PRINTED BY { pr_ssrtacarg env sigma }
 END
 GRAMMAR EXTEND Gram
   GLOBAL: ssrtacarg;
-  ssrtacarg: [[ tac = ltac_expr LEVEL "5" -> { tac } ]];
+  ssrtacarg: TOP [[ tac = ltac_expr LEVEL "5" -> { tac } ]];
 END
 
 (* Copy of ssrtacarg with LEVEL "3", useful for: "under ... do ..." *)
@@ -142,7 +142,7 @@ ARGUMENT EXTEND ssrtac3arg TYPED AS tactic PRINTED BY { pr_ssrtacarg env sigma }
 END
 GRAMMAR EXTEND Gram
   GLOBAL: ssrtac3arg;
-  ssrtac3arg: [[ tac = ltac_expr LEVEL "3" -> { tac } ]];
+  ssrtac3arg: TOP [[ tac = ltac_expr LEVEL "3" -> { tac } ]];
 END
 
 {
@@ -318,7 +318,7 @@ END
 (* Pcoq.Prim. *)
 GRAMMAR EXTEND Gram
   GLOBAL: ssrsimpl_ne;
-  ssrsimpl_ne: [
+  ssrsimpl_ne: TOP [
     [ test_ssrslashnum11; "/"; n = natural; "/"; m = natural; "=" -> { SimplCut(n,m) }
     | test_ssrslashnum10; "/"; n = natural; "/" -> { Cut n }
     | test_ssrslashnum10; "/"; n = natural; "=" -> { Simpl n }
@@ -540,7 +540,7 @@ END
 
 GRAMMAR EXTEND Gram
   GLOBAL: ssrterm;
-  ssrterm: [[ k = ssrtermkind; c = Pcoq.Constr.constr -> { mk_term k c } ]];
+  ssrterm: TOP [[ k = ssrtermkind; c = Pcoq.Constr.constr -> { mk_term k c } ]];
 END
 
 (* New terms *)
@@ -587,7 +587,7 @@ END
 (* Pcoq *)
 GRAMMAR EXTEND Gram
   GLOBAL: ssrbwdview;
-  ssrbwdview: [
+  ssrbwdview: TOP [
     [  test_not_ssrslashnum; "/"; c = Pcoq.Constr.constr -> { [mk_term NoFlag c] }
     |  test_not_ssrslashnum; "/"; c = Pcoq.Constr.constr; w = ssrbwdview -> {
                     (mk_term NoFlag c) :: w } ]];
@@ -610,7 +610,7 @@ END
 (* Pcoq *)
 GRAMMAR EXTEND Gram
   GLOBAL: ssrfwdview;
-  ssrfwdview: [
+  ssrfwdview: TOP [
     [  test_not_ssrslashnum; "/"; c = ast_closure_term -> { [c] }
     |  test_not_ssrslashnum; "/"; c = ast_closure_term; w = ssrfwdview -> { c :: w } ]];
 END
@@ -775,7 +775,7 @@ END
 
 GRAMMAR EXTEND Gram
   GLOBAL: ident_no_do;
-  ident_no_do: [ [ test_ident_no_do; id = IDENT -> { Id.of_string id } ] ];
+  ident_no_do: TOP [ [ test_ident_no_do; id = IDENT -> { Id.of_string id } ] ];
 END
 
 ARGUMENT EXTEND ssripat TYPED AS ssripatrep list PRINTED BY { pr_ssripats }
@@ -876,7 +876,7 @@ GRAMMAR EXTEND Gram
   | "^~"; id = ident -> { SuffixId id }
   | "^~"; n = natural -> { SuffixNum n }
   ]];
-  ssrcpat: [
+  ssrcpat: TOP [
    [ test_nohidden; "["; hat_id = hat; "]" -> {
       IPatCase (Block(hat_id)) }
    | test_nohidden; "["; iorpat = ssriorpat; "]" -> {
@@ -887,7 +887,7 @@ END
 
 GRAMMAR EXTEND Gram
   GLOBAL: ssripat;
-  ssripat: [[ pat = ssrcpat -> { [pat] } ]];
+  ssripat: TOP [[ pat = ssrcpat -> { [pat] } ]];
 END
 
 ARGUMENT EXTEND ssripats_ne TYPED AS ssripat PRINTED BY { pr_ssripats }
@@ -1019,7 +1019,7 @@ let test_ssrfwdid =
 
 GRAMMAR EXTEND Gram
   GLOBAL: ssrfwdid;
-  ssrfwdid: [[ test_ssrfwdid; id = Prim.ident -> { id } ]];
+  ssrfwdid: TOP [[ test_ssrfwdid; id = Prim.ident -> { id } ]];
   END
 
 
@@ -1361,7 +1361,7 @@ ARGUMENT EXTEND ssrbinder TYPED AS (ssrfwdfmt * constr) PRINTED BY { pr_ssrbinde
 
 GRAMMAR EXTEND Gram
   GLOBAL: ssrbinder;
-  ssrbinder: [
+  ssrbinder: TOP [
   [  ["of" -> { () } | "&" -> { () } ]; c = term LEVEL "99" -> {
      (FwdPose, [BFvar]),
      CAst.make ~loc @@ CLambdaN ([CLocalAssum ([CAst.make ~loc Anonymous],Default Glob_term.Explicit,c)],mkCHole (Some loc)) } ]
@@ -1620,7 +1620,7 @@ GRAMMAR EXTEND Gram
     ] ];
   ssrswap: [[ IDENT "first" -> { loc, true } | IDENT "last" -> { loc, false } ]];
   ssrorelse: [[ "||"; tac = ltac_expr LEVEL "2" -> { tac } ]];
-  ssrseqarg: [
+  ssrseqarg: TOP [
     [ arg = ssrswap -> { noindex, swaptacarg arg }
     | i = ssrseqidx; tac = ssrortacarg; def = OPT ssrorelse -> { i, (tac, def) }
     | i = ssrseqidx; arg = ssrswap -> { i, swaptacarg arg }
@@ -1679,7 +1679,7 @@ let ssr_null_entry = Pcoq.Entry.(of_parser "ssr_null" { parser_fun = fun _ -> ()
 
 GRAMMAR EXTEND Gram
   GLOBAL: Prim.ident;
-  Prim.ident: [[ s = IDENT; ssr_null_entry -> { ssr_id_of_string loc s } ]];
+  Prim.ident: TOP [[ s = IDENT; ssr_null_entry -> { ssr_id_of_string loc s } ]];
 END
 
 {
@@ -1792,7 +1792,7 @@ END
 
 GRAMMAR EXTEND Gram
   GLOBAL: ssrhint simple_tactic;
-  ssrhint: [[ "by"; arg = ssrhintarg -> { arg } ]];
+  ssrhint: TOP [[ "by"; arg = ssrhintarg -> { arg } ]];
 END
 
 (** The "do" tactical. ********************************************************)
@@ -2017,7 +2017,7 @@ GRAMMAR EXTEND Gram
     | "->" -> { IPatRewrite (allocc, L2R) }
     | "<-" -> { IPatRewrite (allocc, R2L) }
     ]];
-  ssreqid: [
+  ssreqid: TOP [
     [ test_ssreqid; pat = ssreqpat -> { Some pat }
     | test_ssreqid -> { None }
     ]];
@@ -2308,7 +2308,7 @@ END
 
 GRAMMAR EXTEND Gram
   GLOBAL: ssrrule_ne;
-  ssrrule_ne : [
+  ssrrule_ne : TOP [
     [ test_not_ssrslashnum; x =
         [ "/"; t = ssrterm -> { RWdef, t }
         | t = ssrterm -> { RWeq, t }
@@ -2419,7 +2419,7 @@ let test_ssr_rw_syntax =
 
 GRAMMAR EXTEND Gram
   GLOBAL: ssrrwargs;
-  ssrrwargs: [[ test_ssr_rw_syntax; a = LIST1 ssrrwarg -> { a } ]];
+  ssrrwargs: TOP [[ test_ssr_rw_syntax; a = LIST1 ssrrwarg -> { a } ]];
 END
 
 (** The "rewrite" tactic *)
@@ -2629,7 +2629,7 @@ let test_idcomma =
 
 GRAMMAR EXTEND Gram
   GLOBAL: ssr_idcomma;
-  ssr_idcomma: [ [ test_idcomma;
+  ssr_idcomma: TOP [ [ test_idcomma;
     ip = [ id = IDENT -> { Some (Id.of_string id) } | "_" -> { None } ]; "," ->
     { Some ip }
   ] ];

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -1722,7 +1722,7 @@ let tclintros_expr ?loc tac ipats =
 
 GRAMMAR EXTEND Gram
   GLOBAL: ltac_expr;
-  ltac_expr: LEVEL "1" [ RIGHTA
+  ltac_expr: LEVEL "1" [
     [ tac = ltac_expr; intros = ssrintros_ne -> { tclintros_expr ~loc tac intros }
     ] ];
 END
@@ -1822,7 +1822,7 @@ GRAMMAR EXTEND Gram
     [ tac = ltac_expr LEVEL "3" -> { mk_hint tac }
     | tacs = ssrortacarg -> { tacs }
   ] ];
-  ltac_expr: LEVEL "3" [ RIGHTA
+  ltac_expr: LEVEL "3" [
     [ IDENT "do"; m = ssrmmod; tac = ssrdotac; clauses = ssrclauses ->
       { ssrdotac_expr ~loc noindex m tac clauses }
     | IDENT "do"; tac = ssrortacarg; clauses = ssrclauses ->
@@ -1880,7 +1880,7 @@ GRAMMAR EXTEND Gram
   ssr_first_else: [
     [ tac1 = ssr_first; tac2 = ssrorelse -> { CAst.make ~loc (TacOrelse (tac1, tac2)) }
     | tac = ssr_first -> { tac } ]];
-  ltac_expr: LEVEL "4" [ LEFTA
+  ltac_expr: LEVEL "4" [
     [ tac1 = ltac_expr; ";"; IDENT "first"; tac2 = ssr_first_else ->
       { CAst.make ~loc (TacThen (tac1, tac2)) }
     | tac = ltac_expr; ";"; IDENT "first"; arg = ssrseqarg ->
@@ -2489,7 +2489,7 @@ END
 GRAMMAR EXTEND Gram
   GLOBAL: ltac_expr;
   ltac_expr: LEVEL "3"
-    [ RIGHTA [ IDENT "abstract"; gens = ssrdgens ->
+    [ [ IDENT "abstract"; gens = ssrdgens ->
                { CAst.make ~loc (TacML (
                      ssrtac_entry "abstract", [Tacexpr.TacGeneric (None, Genarg.in_gen (Genarg.rawwit wit_ssrdgens) gens)]))
                  } ]];

--- a/plugins/ssr/ssrvernac.mlg
+++ b/plugins/ssr/ssrvernac.mlg
@@ -95,7 +95,7 @@ GRAMMAR EXTEND Gram
   ssr_dthen: [[ dp = ssr_dpat; "then"; c = lconstr -> { mk_dthen ~loc dp c } ]];
   ssr_elsepat: [[ "else" -> { [[CAst.make ~loc @@ CPatAtom None]] } ]];
   ssr_else: [[ mp = ssr_elsepat; c = lconstr -> { CAst.make ~loc (mp, c) } ]];
-  binder_constr: [
+  binder_constr: TOP [
     [ "if"; c = term LEVEL "200"; "is"; db1 = ssr_dthen; b2 = ssr_else ->
       { let b1, ct, rt = db1 in CAst.make ~loc @@ CCases (MatchStyle, rt, [mk_pat c ct], [b1; b2]) }
     | "if"; c = term LEVEL "200";"isn't";db1 = ssr_dthen; b2 = ssr_else ->
@@ -118,7 +118,7 @@ END
 
 GRAMMAR EXTEND Gram
   GLOBAL: closed_binder;
-  closed_binder: [
+  closed_binder: TOP [
     [ ["of" -> { () } | "&" -> { () } ]; c = term LEVEL "99" ->
       { [CLocalAssum ([CAst.make ~loc Anonymous], Default Explicit, c)] }
   ] ];
@@ -175,7 +175,7 @@ END
 
 GRAMMAR EXTEND Gram
   GLOBAL: gallina_ext;
-  gallina_ext:
+  gallina_ext: TOP
    [ [ IDENT "Import"; IDENT "Prenex"; IDENT "Implicits" ->
       { Vernacexpr.VernacSetOption (false, ["Printing"; "Implicit"; "Defensive"], Vernacexpr.OptionUnset) }
    ] ]
@@ -310,7 +310,7 @@ open G_vernac
 GRAMMAR EXTEND Gram
   GLOBAL: query_command;
 
-  query_command:
+  query_command: TOP
     [ [ IDENT "Search"; s = search_query; l = search_queries; "." ->
           { let (sl,m) = l in
             fun g ->
@@ -341,7 +341,7 @@ open Pltac
 
 GRAMMAR EXTEND Gram
   GLOBAL: hypident;
-  hypident: [
+  hypident: TOP [
   [ "("; IDENT "type"; "of"; id = Prim.identref; ")" -> { id, Locus.InHypTypeOnly }
   | "("; IDENT "value"; "of"; id = Prim.identref; ")" -> { id, Locus.InHypValueOnly }
   ] ];
@@ -349,7 +349,7 @@ END
 
 GRAMMAR EXTEND Gram
   GLOBAL: hloc;
-hloc: [
+hloc: TOP [
   [ "in"; "("; "Type"; "of"; id = ident; ")" ->
     { Tacexpr.HypLocation (CAst.make id, Locus.InHypTypeOnly) }
   | "in"; "("; IDENT "Value"; "of"; id = ident; ")" ->
@@ -359,7 +359,7 @@ END
 
 GRAMMAR EXTEND Gram
   GLOBAL: constr_eval;
-  constr_eval: [
+  constr_eval: TOP [
     [ IDENT "type"; "of"; c = Constr.constr -> { Genredexpr.ConstrTypeOf c }]
   ];
 END

--- a/plugins/ssrmatching/g_ssrmatching.mlg
+++ b/plugins/ssrmatching/g_ssrmatching.mlg
@@ -76,7 +76,7 @@ let ssrtermkind = Pcoq.Entry.(of_parser "ssrtermkind" { parser_fun = input_ssrte
 
 GRAMMAR EXTEND Gram
   GLOBAL: cpattern;
-  cpattern: [[ k = ssrtermkind; c = constr -> {
+  cpattern: TOP [[ k = ssrtermkind; c = constr -> {
     let pattern = mk_term k c None in
     if loc_of_cpattern pattern <> Some loc && k = InParens
     then mk_term Cpattern c None
@@ -95,7 +95,7 @@ END
 
 GRAMMAR EXTEND Gram
   GLOBAL: lcpattern;
-  lcpattern: [[ k = ssrtermkind; c = lconstr -> {
+  lcpattern: TOP [[ k = ssrtermkind; c = lconstr -> {
     let pattern = mk_term k c None in
     if loc_of_cpattern pattern <> Some loc && k = InParens
     then mk_term Cpattern c None

--- a/plugins/ssrsearch/g_search.mlg
+++ b/plugins/ssrsearch/g_search.mlg
@@ -279,7 +279,7 @@ END
 GRAMMAR EXTEND Gram
   GLOBAL: ssr_modlocs;
   modloc: [[ "-"; m = global -> { true, m } | m = global -> { false, m } ]];
-  ssr_modlocs: [[ "in"; ml = LIST1 modloc -> { ml } ]];
+  ssr_modlocs: TOP [[ "in"; ml = LIST1 modloc -> { ml } ]];
 END
 
 {

--- a/user-contrib/Ltac2/g_ltac2.mlg
+++ b/user-contrib/Ltac2/g_ltac2.mlg
@@ -925,6 +925,10 @@ END
 
 {
 
+let () =
+  let dummy = (None, None, []) in
+  Pcoq.grammar_extend tac2mode {pos=None; data=[dummy]}
+
 let _ = Pvernac.register_proof_mode "Ltac2" tac2mode
 
 open G_ltac
@@ -941,7 +945,7 @@ END
 
 GRAMMAR EXTEND Gram
   GLOBAL: tac2mode;
-  tac2mode:
+  tac2mode: TOP
     [ [ tac = G_vernac.query_command -> { tac None } ] ];
 END
 

--- a/user-contrib/Ltac2/g_ltac2.mlg
+++ b/user-contrib/Ltac2/g_ltac2.mlg
@@ -880,7 +880,7 @@ let rules = [
 ] in
 
 Hook.set Tac2entries.register_constr_quotations begin fun () ->
-  Pcoq.grammar_extend Pcoq.Constr.term {pos=Some (Gramlib.Gramext.Level "0"); data=[(None, None, rules)]}
+  Pcoq.grammar_extend Pcoq.Constr.term (Pcoq.Reuse (Some"0", rules))
 end
 
 }
@@ -924,10 +924,6 @@ VERNAC COMMAND EXTEND VernacDeclareTactic2Definition
 END
 
 {
-
-let () =
-  let dummy = (None, None, []) in
-  Pcoq.grammar_extend tac2mode {pos=None; data=[dummy]}
 
 let _ = Pvernac.register_proof_mode "Ltac2" tac2mode
 

--- a/user-contrib/Ltac2/tac2entries.ml
+++ b/user-contrib/Ltac2/tac2entries.ml
@@ -683,8 +683,8 @@ let perform_notation syn st =
     CAst.make ~loc @@ CTacLet (false, bnd, syn.synext_exp)
   in
   let rule = Pcoq.Production.make rule (act mk) in
-  let pos = Some (Gramlib.Gramext.Level (string_of_int syn.synext_lev)) in
-  let rule = {Pcoq.pos; data = [(None, None, [rule])] } in
+  let pos = Some (string_of_int syn.synext_lev) in
+  let rule = Pcoq.Reuse (pos, [rule]) in
   match get_reinit syn.synext_lev with
   | None ->
     ([Pcoq.ExtendRule (Pltac.ltac2_expr, rule)], st)

--- a/vernac/egramcoq.ml
+++ b/vernac/egramcoq.ml
@@ -96,7 +96,7 @@ let create_pos = function
 let find_position_gen current ensure assoc lev =
   match lev with
   | None ->
-    current, (None, None, None, None)
+    current, (Some Gramlib.Gramext.Top, None, None, None)
   | Some n ->
     let after = ref None in
     let init = ref None in

--- a/vernac/egramcoq.ml
+++ b/vernac/egramcoq.ml
@@ -89,14 +89,16 @@ let error_level_assoc p current expected =
      pr_assoc current ++ str " associative while it is now expected to be " ++
      pr_assoc expected ++ str " associative.")
 
+type position = NewFirst | NewAfter of int | ReuseFirst | ReuseLevel of int
+
 let create_pos = function
-  | None -> Gramlib.Gramext.First
-  | Some lev -> Gramlib.Gramext.After (constr_level lev)
+  | None -> NewFirst
+  | Some lev -> NewAfter lev
 
 let find_position_gen current ensure assoc lev =
   match lev with
   | None ->
-    current, (Some Gramlib.Gramext.Top, None, None, None)
+    current, (ReuseFirst, None, None, None)
   | Some n ->
     let after = ref None in
     let init = ref None in
@@ -105,7 +107,7 @@ let find_position_gen current ensure assoc lev =
       | (p,a,reinit)::l when Int.equal p n ->
         if reinit then
           let a' = create_assoc assoc in
-          (init := Some (a',create_pos q); (p,a',false)::l)
+          (init := Some (a', q); (p,a',false)::l)
         else if admissible_assoc (a,assoc) then
           raise Exit
         else
@@ -118,16 +120,16 @@ let find_position_gen current ensure assoc lev =
       begin match !init with
         | None ->
           (* Create the entry *)
-          updated, (Some (create_pos !after), Some assoc, Some (constr_level n), None)
+          updated, (create_pos !after, Some assoc, Some (constr_level n), None)
         | _ ->
           (* The reinit flag has been updated *)
-          updated, (Some (Gramlib.Gramext.Level (constr_level n)), None, None, !init)
+          updated, (ReuseLevel n, None, None, !init)
       end
     with
     (* Nothing has changed *)
       Exit ->
       (* Just inherit the existing associativity and name (None) *)
-      current, (Some (Gramlib.Gramext.Level (constr_level n)), None, None, None)
+      current, (ReuseLevel n, None, None, None)
 
 let rec list_mem_assoc_triple x = function
   | [] -> false
@@ -517,11 +519,18 @@ let target_to_bool : type r. r target -> bool = function
 | ForPattern -> true
 
 let prepare_empty_levels forpat (where,(pos,p4assoc,name,reinit)) =
-  let empty = { pos; data = [(name, p4assoc, [])] } in
+  let empty = match pos with
+  | ReuseFirst -> Pcoq.Reuse (None, [])
+  | ReuseLevel n -> Pcoq.Reuse (Some (constr_level n), [])
+  | NewFirst -> Pcoq.Fresh (Gramlib.Gramext.First, [(name, p4assoc, [])])
+  | NewAfter n -> Pcoq.Fresh (Gramlib.Gramext.After (constr_level n), [(name, p4assoc, [])])
+  in
   match reinit with
   | None ->
     ExtendRule (target_entry where forpat, empty)
-  | Some reinit ->
+  | Some (assoc, pos) ->
+    let pos = match pos with None -> Gramlib.Gramext.First | Some n -> Gramlib.Gramext.After (constr_level n) in
+    let reinit = (assoc, pos) in
     ExtendRuleReinit (target_entry where forpat, reinit, empty)
 
 let different_levels (custom,opt_level) (custom',string_level) =
@@ -575,12 +584,20 @@ let extend_constr state forpat ng =
         | MayRecRNo symbs -> Pcoq.Production.make symbs act
         | MayRecRMay symbs -> Pcoq.Production.make symbs act
       in
-      name, p4assoc, [r] in
+      let rule = name, p4assoc, [r] in
+      match pos with
+      | NewFirst -> Pcoq.Fresh (Gramlib.Gramext.First, [rule])
+      | NewAfter n -> Pcoq.Fresh (Gramlib.Gramext.After (constr_level n), [rule])
+      | ReuseFirst -> Pcoq.Reuse (None, [r])
+      | ReuseLevel n -> Pcoq.Reuse (Some (constr_level n), [r])
+    in
     let r = match reinit with
       | None ->
-        ExtendRule (entry, { pos; data = [rule]})
-      | Some reinit ->
-        ExtendRuleReinit (entry, reinit, { pos; data = [rule]})
+        ExtendRule (entry, rule)
+      | Some (assoc, pos) ->
+        let pos = match pos with None -> Gramlib.Gramext.First | Some n -> Gramlib.Gramext.After (constr_level n) in
+        let reinit = (assoc, pos) in
+        ExtendRuleReinit (entry, reinit, rule)
     in
     (accu @ empty_rules @ [r], state)
   in

--- a/vernac/egramml.ml
+++ b/vernac/egramml.ml
@@ -90,4 +90,4 @@ let extend_vernac_command_grammar s nt gl =
   vernac_exts := (s,gl) :: !vernac_exts;
   let mkact loc l = VernacExtend (s, l) in
   let rules = [make_rule mkact gl] in
-  grammar_extend nt { pos=None; data=[None, None, rules]}
+  grammar_extend nt { pos=Some Gramlib.Gramext.Top; data=[None, None, rules]}

--- a/vernac/egramml.ml
+++ b/vernac/egramml.ml
@@ -90,4 +90,8 @@ let extend_vernac_command_grammar s nt gl =
   vernac_exts := (s,gl) :: !vernac_exts;
   let mkact loc l = VernacExtend (s, l) in
   let rules = [make_rule mkact gl] in
-  grammar_extend nt { pos=Some Gramlib.Gramext.Top; data=[None, None, rules]}
+  if Pcoq.Entry.is_empty nt then
+    (* Small hack to tolerate empty entries in VERNAC { ... } EXTEND *)
+    grammar_extend nt (Pcoq.Fresh (Gramlib.Gramext.First, [None, None, rules]))
+  else
+    grammar_extend nt (Pcoq.Reuse (None, rules))

--- a/vernac/g_proofs.mlg
+++ b/vernac/g_proofs.mlg
@@ -52,7 +52,7 @@ GRAMMAR EXTEND Gram
   [ [ -> { [] }
     | ":"; l = LIST1 [id = IDENT -> { id } ] -> { l } ] ]
   ;
-  command:
+  command: TOP
     [ [ IDENT "Goal"; c = lconstr ->
         { VernacDefinition (Decls.(NoDischarge, Definition), ((CAst.make ~loc Names.Anonymous), None), ProveBody ([], c)) }
       | IDENT "Proof" -> { VernacProof (None,None) }

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -691,7 +691,7 @@ END
 GRAMMAR EXTEND Gram
   GLOBAL: gallina_ext hint_info scope_delimiter;
 
-  gallina_ext:
+  gallina_ext: TOP
     [ [ (* Transparent and Opaque *)
         IDENT "Transparent"; l = LIST1 smart_global ->
           { VernacSetOpacity (Conv_oracle.transparent, l) }
@@ -867,7 +867,7 @@ END
 GRAMMAR EXTEND Gram
   GLOBAL: command query_command class_rawexpr gallina_ext search_query search_queries;
 
-  gallina_ext:
+  gallina_ext: TOP
     [ [ IDENT "Export"; "Set"; table = setting_name; v = option_setting ->
         { VernacSetOption (true, table, v) }
       | IDENT "Export"; IDENT "Unset"; table = setting_name ->
@@ -1121,7 +1121,7 @@ END
 GRAMMAR EXTEND Gram
   GLOBAL: command;
 
-  command:
+  command: TOP
     [ [
 (* State management *)
         IDENT "Write"; IDENT "State"; s = IDENT -> { VernacWriteState s }

--- a/vernac/pvernac.ml
+++ b/vernac/pvernac.ml
@@ -59,7 +59,7 @@ module Vernac_ =
         Pcoq.(Production.make (Rule.next Rule.stop (Symbol.token Tok.PEOI)) act_eoi);
         Pcoq.(Production.make (Rule.next Rule.stop (Symbol.nterm vernac_control)) act_vernac);
       ] in
-      Pcoq.(grammar_extend main_entry {pos=None; data=[None, None, rule]})
+      Pcoq.(grammar_extend main_entry (Fresh (Gramlib.Gramext.First, [None, None, rule])))
 
     let select_tactic_entry spec =
       match spec with

--- a/vernac/vernacextend.ml
+++ b/vernac/vernacextend.ml
@@ -247,7 +247,7 @@ let vernac_argument_extend ~name arg =
     e
   | Arg_rules rules ->
     let e = Pcoq.create_generic_entry2 name (Genarg.rawwit wit) in
-    let () = Pcoq.grammar_extend e {Pcoq.pos=None; data=[(None, None, rules)]} in
+    let () = Pcoq.grammar_extend e (Pcoq.Fresh (Gramlib.Gramext.First, [None, None, rules])) in
     e
   in
   let pr = arg.arg_printer in


### PR DESCRIPTION
We split the constructor for grammar extension in two, depending on whether the extension command should create new levels or populate a previously defined one. In the latter case, level meta-data is ensured not to be present.

Before this patch, adding rules to an entry without specifying a position selector would result in two very different behaviours depending on the dynamic content of the entry.

+ If the entry was empty, it would create a fresh level and populate it with the provided rules.

+ If the entry was not empty, it would reuse the topmost level to populate it with the provided rules. In case the extension also contained a level name or an associativity status, it would ignore the name and replace the old associativity by the new one.

The new representation allows giving an explicit intent that disambiguates between those two possible behaviours. It also enforces the static invariant that expanding existing levels cannot change their name nor their associativity. The warnings for this situation were present in the code but deactivated.

We adapt both coqpp and the grammar extension mechanism to this change.

This is somehow the dual of #9067 and it eases the proper implementation of that feature since now it is much more obvious when a level is supposed to exist.
