### PR TITLE
[Debugger] Convert Loc.t filenames in Ltac tactic definitions to absolute paths at load time

### DIFF
--- a/plugins/ltac/coretactics.mlg
+++ b/plugins/ltac/coretactics.mlg
@@ -321,8 +321,8 @@ let initial_atomic () =
   in
   let iter (s, t) = Tacenv.register_ltac false false (Names.Id.of_string s) t in
   List.iter iter
-      [ "idtac",TacId [];
-        "fail", TacFail(TacLocal,ArgArg 0,[]);
+      [ "idtac",TacId (CAst.make []);
+        "fail", TacFail (CAst.make (TacLocal,ArgArg 0,[]));
         "fresh", TacArg(CAst.make @@ TacFreshId [])
       ]
 
@@ -354,8 +354,10 @@ let initial_tacticals () =
   let varn n = Reference (ArgVar (CAst.make (idn n))) in
   let iter (s, t) = Tacenv.register_ltac false false (Id.of_string s) t in
   List.iter iter [
-    "first", TacFun ([Name (idn 0)], TacML (CAst.make (initial_entry "first", [varn 0])));
-    "solve", TacFun ([Name (idn 0)], TacML (CAst.make (initial_entry "solve", [varn 0])));
+    "first", TacFun (CAst.make
+        ([Name (idn 0)], TacML (CAst.make (initial_entry "first", [varn 0]))));
+    "solve", TacFun (CAst.make
+        ([Name (idn 0)], TacML (CAst.make (initial_entry "solve", [varn 0]))));
   ]
 
 let () = Mltop.declare_cache_obj initial_tacticals "ltac_plugin"

--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -80,17 +80,17 @@ GRAMMAR EXTEND Gram
 
   tactic_then_last:
     [ [ "|"; lta = LIST0 (OPT ltac_expr) SEP "|" ->
-        { Array.map (function None -> TacId [] | Some t -> t) (Array.of_list lta) }
+        { Array.map (function None -> TacId (CAst.make ~loc []) | Some t -> t) (Array.of_list lta) }
       | -> { [||] }
     ] ]
   ;
   for_each_goal:
     [ [ ta = ltac_expr; "|"; tg = for_each_goal -> { let (first,last) = tg in (ta::first, last) }
       | ta = ltac_expr; ".."; l = tactic_then_last -> { ([], Some (ta, l)) }
-      | ".."; l = tactic_then_last -> { ([], Some (TacId [], l)) }
+      | ".."; l = tactic_then_last -> { ([], Some (TacId (CAst.make ~loc []), l)) }
       | ta = ltac_expr -> { ([ta], None) }
-      | "|"; tg = for_each_goal -> { let (first,last) = tg in (TacId [] :: first, last) }
-      | -> { ([TacId []], None) }
+      | "|"; tg = for_each_goal -> { let (first,last) = tg in (TacId (CAst.make ~loc []) :: first, last) }
+      | -> { ([TacId (CAst.make ~loc [])], None) }
     ] ]
   ;
   tactic_then_locality: (* [true] for the local variant [TacThens] and [false]
@@ -101,65 +101,66 @@ GRAMMAR EXTEND Gram
     [ "5" RIGHTA
       [ te = binder_tactic -> { te } ]
     | "4" LEFTA
-      [ ta0 = ltac_expr; ";"; ta1 = binder_tactic -> { TacThen (ta0, ta1) }
-      | ta0 = ltac_expr; ";"; ta1 = ltac_expr -> { TacThen (ta0,ta1) }
+      [ ta0 = ltac_expr; ";"; ta1 = binder_tactic -> { TacThen (CAst.make ~loc (ta0, ta1)) }
+      | ta0 = ltac_expr; ";"; ta1 = ltac_expr -> { TacThen (CAst.make ~loc (ta0,ta1)) }
       | ta0 = ltac_expr; ";"; l = tactic_then_locality; tg = for_each_goal; "]" -> {
           let (first,tail) = tg in
           match l , tail with
-          | false , Some (t,last) -> TacThen (ta0,TacExtendTac (Array.of_list first, t, last))
-          | true  , Some (t,last) -> TacThens3parts (ta0, Array.of_list first, t, last)
-          | false , None -> TacThen (ta0,TacDispatch first)
-          | true  , None -> TacThens (ta0,first) } ]
+          | false , Some (t,last) -> TacThen (CAst.make ~loc (ta0,
+              TacExtendTac (CAst.make ~loc (Array.of_list first, t, last))))
+          | true  , Some (t,last) -> TacThens3parts (CAst.make ~loc (ta0, Array.of_list first, t, last))
+          | false , None -> TacThen (CAst.make ~loc (ta0,TacDispatch (CAst.make ~loc first)))
+          | true  , None -> TacThens (CAst.make ~loc (ta0,first)) } ]
     | "3" RIGHTA
-      [ IDENT "try"; ta = ltac_expr -> { TacTry ta }
-      | IDENT "do"; n = nat_or_var; ta = ltac_expr -> { TacDo (n,ta) }
-      | IDENT "timeout"; n = nat_or_var; ta = ltac_expr -> { TacTimeout (n,ta) }
-      | IDENT "time"; s = OPT string; ta = ltac_expr -> { TacTime (s,ta) }
-      | IDENT "repeat"; ta = ltac_expr -> { TacRepeat ta }
-      | IDENT "progress"; ta = ltac_expr -> { TacProgress ta }
-      | IDENT "once"; ta = ltac_expr -> { TacOnce ta }
-      | IDENT "exactly_once"; ta = ltac_expr -> { TacExactlyOnce ta }
-      | IDENT "infoH"; ta = ltac_expr -> { TacShowHyps ta }
+      [ IDENT "try"; ta = ltac_expr -> { TacTry (CAst.make ~loc ta) }
+      | IDENT "do"; n = nat_or_var; ta = ltac_expr -> { TacDo (CAst.make ~loc (n,ta)) }
+      | IDENT "timeout"; n = nat_or_var; ta = ltac_expr -> { TacTimeout (CAst.make ~loc (n,ta)) }
+      | IDENT "time"; s = OPT string; ta = ltac_expr -> { TacTime (CAst.make ~loc (s,ta)) }
+      | IDENT "repeat"; ta = ltac_expr -> { TacRepeat (CAst.make ~loc ta) }
+      | IDENT "progress"; ta = ltac_expr -> { TacProgress (CAst.make ~loc ta) }
+      | IDENT "once"; ta = ltac_expr -> { TacOnce (CAst.make ~loc ta) }
+      | IDENT "exactly_once"; ta = ltac_expr -> { TacExactlyOnce (CAst.make ~loc ta) }
+      | IDENT "infoH"; ta = ltac_expr -> { TacShowHyps (CAst.make ~loc ta) }
 (*To do: put Abstract in Refiner*)
-      | IDENT "abstract"; tc = NEXT -> { TacAbstract (tc,None) }
+      | IDENT "abstract"; tc = NEXT -> { TacAbstract (CAst.make ~loc (tc,None)) }
       | IDENT "abstract"; tc = NEXT; "using";  s = ident ->
-        { TacAbstract (tc,Some s) }
-      | IDENT "only"; sel = selector; ":"; ta = ltac_expr -> { TacSelect (sel, ta) } ]
+        { TacAbstract (CAst.make ~loc (tc,Some s)) }
+      | IDENT "only"; sel = selector; ":"; ta = ltac_expr -> { TacSelect (CAst.make ~loc (sel, ta)) } ]
 (*End of To do*)
     | "2" RIGHTA
-      [ ta0 = ltac_expr; "+"; ta1 = binder_tactic -> { TacOr (ta0,ta1) }
-      | ta0 = ltac_expr; "+"; ta1 = ltac_expr -> { TacOr (ta0,ta1) }
+      [ ta0 = ltac_expr; "+"; ta1 = binder_tactic -> { TacOr (CAst.make ~loc (ta0,ta1)) }
+      | ta0 = ltac_expr; "+"; ta1 = ltac_expr -> { TacOr (CAst.make ~loc (ta0,ta1)) }
       | IDENT "tryif" ; ta = ltac_expr ;
               "then" ; tat = ltac_expr ;
-              "else" ; tae = ltac_expr -> { TacIfThenCatch(ta,tat,tae) }
-      | ta0 = ltac_expr; "||"; ta1 = binder_tactic -> { TacOrelse (ta0,ta1) }
-      | ta0 = ltac_expr; "||"; ta1 = ltac_expr -> { TacOrelse (ta0,ta1) } ]
+              "else" ; tae = ltac_expr -> { TacIfThenCatch (CAst.make ~loc (ta,tat,tae)) }
+      | ta0 = ltac_expr; "||"; ta1 = binder_tactic -> { TacOrelse (CAst.make ~loc (ta0,ta1)) }
+      | ta0 = ltac_expr; "||"; ta1 = ltac_expr -> { TacOrelse (CAst.make ~loc (ta0,ta1)) } ]
     | "1" RIGHTA
       [ b = match_key; IDENT "goal"; "with"; mrl = match_context_list; "end" ->
-          { TacMatchGoal (b,false,mrl) }
+          { TacMatchGoal (CAst.make ~loc (b,false,mrl)) }
       | b = match_key; IDENT "reverse"; IDENT "goal"; "with";
         mrl = match_context_list; "end" ->
-          { TacMatchGoal (b,true,mrl) }
+          { TacMatchGoal (CAst.make ~loc (b,true,mrl)) }
       |	b = match_key; c = ltac_expr; "with"; mrl = match_list; "end" ->
-          { TacMatch (b,c,mrl) }
+          { TacMatch (CAst.make ~loc (b,c,mrl)) }
       | IDENT "first" ; "["; l = LIST0 ltac_expr SEP "|"; "]" ->
-          { TacFirst l }
+          { TacFirst (CAst.make ~loc l) }
       | IDENT "solve" ; "["; l = LIST0 ltac_expr SEP "|"; "]" ->
-          { TacSolve l }
-      | IDENT "idtac"; l = LIST0 message_token -> { TacId l }
+          { TacSolve (CAst.make ~loc l) }
+      | IDENT "idtac"; l = LIST0 message_token -> { TacId (CAst.make ~loc l) }
       | g=failkw; n = [ n = nat_or_var -> { n } | -> { fail_default_value } ];
-          l = LIST0 message_token -> { TacFail (g,n,l) }
+          l = LIST0 message_token -> { TacFail (CAst.make ~loc (g,n,l)) }
       | st = simple_tactic -> { st }
-      | a = tactic_value -> { TacArg(CAst.make ~loc a) }
+      | a = tactic_value -> { TacArg (CAst.make ~loc a) }
       | r = reference; la = LIST0 tactic_arg ->
-        { TacArg(CAst.make ~loc @@ TacCall (CAst.make ~loc (r,la))) } ]
+        { TacArg (CAst.make ~loc @@ TacCall (CAst.make ~loc (r,la))) } ]
     | "0"
       [ "("; a = ltac_expr; ")" -> { a }
       | "["; ">"; tg = for_each_goal; "]" -> {
           let (tf,tail) = tg in
           begin match tail with
-          | Some (t,tl) -> TacExtendTac(Array.of_list tf,t,tl)
-          | None -> TacDispatch tf
+          | Some (t,tl) -> TacExtendTac (CAst.make ~loc (Array.of_list tf,t,tl))
+          | None -> TacDispatch (CAst.make ~loc tf)
           end }
       | a = tactic_atom -> { TacArg (CAst.make ~loc a) } ] ]
   ;
@@ -170,10 +171,10 @@ GRAMMAR EXTEND Gram
   binder_tactic:
     [ RIGHTA
       [ "fun"; it = LIST1 input_fun ; "=>"; body = ltac_expr LEVEL "5" ->
-          { TacFun (it,body) }
+          { TacFun (CAst.make ~loc(it,body)) }
       | "let"; isrec = [IDENT "rec" -> { true } | -> { false } ];
           llc = LIST1 let_clause SEP "with"; "in";
-          body = ltac_expr LEVEL "5" -> { TacLetIn (isrec,llc,body) } ] ]
+          body = ltac_expr LEVEL "5" -> { TacLetIn (CAst.make ~loc (isrec,llc,body)) } ] ]
   ;
   (* Tactic arguments to the right of an application *)
   tactic_arg:
@@ -228,7 +229,7 @@ GRAMMAR EXTEND Gram
       | na = ["_" -> { CAst.make ~loc Anonymous } ]; ":="; te = ltac_expr ->
          { (na, arg_of_expr te) }
       | idr = identref; args = LIST1 input_fun; ":="; te = ltac_expr ->
-         { (CAst.map (fun id -> Name id) idr, arg_of_expr (TacFun(args,te))) } ] ]
+         { (CAst.map (fun id -> Name id) idr, arg_of_expr (TacFun (CAst.make ~loc(args,te)))) } ] ]
   ;
   match_pattern:
     [ [ IDENT "context";  oid = OPT Constr.ident;
@@ -283,10 +284,10 @@ GRAMMAR EXTEND Gram
   tacdef_body:
     [ [ name = Constr.global; it=LIST1 input_fun;
         redef = ltac_def_kind; body = ltac_expr ->
-        { if redef then Tacexpr.TacticRedefinition (name, TacFun (it, body))
+        { if redef then Tacexpr.TacticRedefinition (name, TacFun (CAst.make ~loc(it, body)))
           else
             let id = reference_to_id name in
-            Tacexpr.TacticDefinition (id, TacFun (it, body)) }
+            Tacexpr.TacticDefinition (id, TacFun (CAst.make ~loc(it, body))) }
       | name = Constr.global; redef = ltac_def_kind;
         body = ltac_expr ->
         { if redef then Tacexpr.TacticRedefinition (name, body)
@@ -387,8 +388,8 @@ END
 {
 
 let rm_abstract = function
-  | TacAbstract (t,_) -> t, true
-  | TacSolve [TacAbstract (t,_)] -> TacSolve [t], true
+  | TacAbstract { CAst.loc; v=(t,_) } -> t, true
+  | TacSolve { CAst.loc; v=[TacAbstract { CAst.loc=loc2; v=(t,_) }]} -> TacSolve (CAst.make ?loc [t]), true
   | x -> x, false
 let is_explicit_terminator = function TacSolve _ -> true | _ -> false
 
@@ -486,7 +487,7 @@ let pr_tacdef_body env sigma tacdef_body =
   in
   let idl, body =
     match body with
-      | Tacexpr.TacFun (idl,b) -> idl,b
+      | Tacexpr.TacFun {CAst.v=(idl,b)} -> idl,b
       | _ -> [], body in
   id ++
     prlist (function Name.Anonymous -> str " _"

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -600,7 +600,7 @@ let pr_goal_selector ~toplevel s =
             str " ]")
 
   let pr_opt_tactic pr = function
-    | TacId [] -> mt ()
+    | TacId {CAst.loc; v=[] } -> mt ()
     | t -> pr t
 
   let pr_tac_extend_gen pr tf tm tl =
@@ -883,22 +883,21 @@ let pr_goal_selector ~toplevel s =
       pr_atom1
 
     let make_pr_tac env sigma pr strip_prod_binders tag_atom tag =
-
         let extract_binders = function
-          | Tacexp (TacFun (lvar,body)) -> (lvar,Tacexp body)
+          | Tacexp (TacFun { CAst.loc; v=(lvar,body)}) -> (lvar,Tacexp body)
           | body -> ([],body) in
         let rec pr_tac inherited tac =
           let return (doc, l) = (tag tac doc, l) in
           let (strm, prec) = return (match tac with
-            | TacAbstract (t,None) ->
+            | TacAbstract { CAst.loc; v=(t,None) } ->
               keyword "abstract " ++ pr_tac (LevelLt labstract) t, labstract
-            | TacAbstract (t,Some s) ->
+            | TacAbstract { CAst.loc; v=(t,Some s) } ->
               hov 0 (
                 keyword "abstract"
                 ++ str" (" ++ pr_tac (LevelLt labstract) t ++ str")" ++ spc ()
                 ++ keyword "using" ++ spc () ++ pr_id s),
               labstract
-            | TacLetIn (recflag,llc,u) ->
+            | TacLetIn { CAst.loc; v=(recflag,llc,u) } ->
               let llc = List.map (fun (id,t) -> (id,extract_binders t)) llc in
               v 0
                 (hv 0 (
@@ -906,7 +905,7 @@ let pr_goal_selector ~toplevel s =
                   ++ spc () ++ keyword "in"
                  ) ++ fnl () ++ pr_tac (LevelLe llet) u),
               llet
-            | TacMatch (lz,t,lrul) ->
+            | TacMatch { CAst.loc; v=(lz,t,lrul) } ->
               hov 0 (
                 pr_lazy lz ++ keyword "match" ++ spc ()
                 ++ pr_tac ltop t ++ spc () ++ keyword "with"
@@ -916,7 +915,7 @@ let pr_goal_selector ~toplevel s =
                 ) lrul
                 ++ fnl() ++ keyword "end"),
               lmatch
-            | TacMatchGoal (lz,lr,lrul) ->
+            | TacMatchGoal { CAst.loc; v=(lz,lr,lrul) } ->
               hov 0 (
                 pr_lazy lz
                 ++ keyword (if lr then "match reverse goal with" else "match goal with")
@@ -925,97 +924,97 @@ let pr_goal_selector ~toplevel s =
                   ++ pr_match_rule false (pr_tac ltop) (pr.pr_lpattern env sigma) r
                 ) lrul ++ fnl() ++ keyword "end"),
               lmatch
-            | TacFun (lvar,body) ->
+            | TacFun { CAst.loc; v=(lvar,body) } ->
               hov 2 (
                 keyword "fun"
                 ++ prlist pr_funvar lvar ++ str " =>" ++ spc ()
                 ++ pr_tac (LevelLe lfun) body),
               lfun
-            | TacThens (t,tl) ->
+            | TacThens { CAst.loc; v=(t,tl) } ->
               hov 1 (
                 pr_tac (LevelLe lseq) t ++ pr_then () ++ spc ()
                 ++ pr_seq_body (pr_opt_tactic (pr_tac ltop)) tl),
               lseq
-            | TacThen (t1,t2) ->
+            | TacThen { CAst.loc; v=(t1,t2) } ->
               hov 1 (
                 pr_tac (LevelLe lseq) t1 ++ pr_then () ++ spc ()
                 ++ pr_tac (LevelLt lseq) t2),
               lseq
-            | TacDispatch tl ->
+            | TacDispatch { CAst.loc; v=tl } ->
               pr_dispatch (pr_tac ltop) tl, lseq
-            | TacExtendTac (tf,t,tr) ->
+            | TacExtendTac { CAst.loc; v=(tf,t,tr) } ->
               pr_tac_extend (pr_tac ltop) tf t tr , lseq
-            | TacThens3parts (t1,tf,t2,tl) ->
+            | TacThens3parts { CAst.loc; v=(t1,tf,t2,tl) } ->
               hov 1 (
                 pr_tac (LevelLe lseq) t1 ++ pr_then () ++ spc ()
                 ++ pr_then_gen (pr_tac ltop) tf t2 tl),
               lseq
-            | TacTry t ->
+            | TacTry { CAst.loc; v=t } ->
               hov 1 (
                 keyword "try" ++ spc () ++ pr_tac (LevelLe ltactical) t),
               ltactical
-            | TacDo (n,t) ->
+            | TacDo { CAst.loc; v=(n,t) } ->
               hov 1 (
                 str "do" ++ spc ()
                 ++ pr_or_var int n ++ spc ()
                 ++ pr_tac (LevelLe ltactical) t),
               ltactical
-            | TacTimeout (n,t) ->
+            | TacTimeout { CAst.loc; v=(n,t) } ->
               hov 1 (
                 keyword "timeout "
                 ++ pr_or_var int n ++ spc ()
                 ++ pr_tac (LevelLe ltactical) t),
               ltactical
-            | TacTime (s,t) ->
+            | TacTime { CAst.loc; v=(s,t) } ->
               hov 1 (
                 keyword "time"
                 ++ pr_opt qstring s ++ spc ()
                 ++ pr_tac (LevelLe ltactical) t),
               ltactical
-            | TacRepeat t ->
+            | TacRepeat { CAst.loc; v=t } ->
               hov 1 (
                 keyword "repeat" ++ spc ()
                 ++ pr_tac (LevelLe ltactical) t),
               ltactical
-            | TacProgress t ->
+            | TacProgress { CAst.loc; v=t } ->
               hov 1 (
                 keyword "progress" ++ spc ()
                 ++ pr_tac (LevelLe ltactical) t),
               ltactical
-            | TacShowHyps t ->
+            | TacShowHyps { CAst.loc; v=t } ->
               hov 1 (
                 keyword "infoH" ++ spc ()
                 ++ pr_tac (LevelLe ltactical) t),
               ltactical
-            | TacOr (t1,t2) ->
+            | TacOr { CAst.loc; v=(t1,t2) } ->
               hov 1 (
                 pr_tac (LevelLt lorelse) t1 ++ spc ()
                 ++ str "+" ++ brk (1,1)
                 ++ pr_tac (LevelLe lorelse) t2),
               lorelse
-            | TacOnce t ->
+            | TacOnce { CAst.loc; v=t } ->
               hov 1 (
                 keyword "once" ++ spc ()
                 ++ pr_tac (LevelLe ltactical) t),
               ltactical
-            | TacExactlyOnce t ->
+            | TacExactlyOnce { CAst.loc; v=t } ->
               hov 1 (
                 keyword "exactly_once" ++ spc ()
                 ++ pr_tac (LevelLe ltactical) t),
               ltactical
-            | TacIfThenCatch (t,tt,te) ->
+            | TacIfThenCatch { CAst.loc; v=(t,tt,te) } ->
                 hov 1 (
                  str"tryif" ++ spc() ++ pr_tac (LevelLe ltactical) t ++ brk(1,1) ++
                  str"then" ++ spc() ++ pr_tac (LevelLe ltactical) tt ++ brk(1,1) ++
                  str"else" ++ spc() ++ pr_tac (LevelLe ltactical) te ++ brk(1,1)),
                 ltactical
-            | TacOrelse (t1,t2) ->
+            | TacOrelse { CAst.loc; v=(t1,t2) } ->
               hov 1 (
                 pr_tac (LevelLt lorelse) t1 ++ spc ()
                 ++ str "||" ++ brk (1,1)
                 ++ pr_tac (LevelLe lorelse) t2),
               lorelse
-            | TacFail (g,n,l) ->
+            | TacFail { CAst.loc; v=(g,n,l) } ->
               let arg =
                 match n with
                   | ArgArg 0 -> mt ()
@@ -1030,14 +1029,14 @@ let pr_goal_selector ~toplevel s =
                 name ++ arg
                 ++ prlist (pr_arg (pr_message_token pr.pr_name)) l),
               latom
-            | TacFirst tl ->
+            | TacFirst { CAst.loc; v=tl } ->
               keyword "first" ++ spc () ++ pr_seq_body (pr_tac ltop) tl, llet
-            | TacSolve tl ->
+            | TacSolve { CAst.loc; v=tl } ->
               keyword "solve" ++ spc () ++ pr_seq_body (pr_tac ltop) tl, llet
             | TacComplete t ->
               pr_tac (LevelLe lcomplete) t, lcomplete
-            | TacSelect (s, tac) -> pr_goal_selector ~toplevel:false s ++ spc () ++ pr_tac ltop tac, latom
-            | TacId l ->
+            | TacSelect { CAst.loc; v=(s, tac) } -> pr_goal_selector ~toplevel:false s ++ spc () ++ pr_tac ltop tac, latom
+            | TacId { CAst.loc; v=l } ->
               keyword "idtac" ++ prlist (pr_arg (pr_message_token pr.pr_name)) l, latom
             | TacAtom { CAst.loc; v=t } ->
               pr_with_comments ?loc (hov 1 (pr_atom env sigma pr strip_prod_binders tag_atom t)), ltatom

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -518,7 +518,7 @@ let print_ltacs () =
   let entries = List.map_filter map entries in
   let pr_entry (qid, body) =
     let (l, t) = match body with
-    | Tacexpr.TacFun (l, t) -> (l, t)
+    | Tacexpr.TacFun {CAst.v=(l, t)} -> (l, t)
     | _ -> ([], body)
     in
     let pr_ltac_fun_arg n = spc () ++ Name.print n in
@@ -529,7 +529,7 @@ let print_ltacs () =
 let locatable_ltac = "Ltac"
 
 let split_ltac_fun = function
-  | Tacexpr.TacFun (l,t) -> (l,t)
+  | Tacexpr.TacFun {CAst.v=(l,t)} -> (l,t)
   | t -> ([],t)
 
 let pr_ltac_fun_arg n = spc () ++ Name.print n
@@ -707,7 +707,8 @@ let tactic_extend plugin_name tacname ~level ?deprecation sign =
        node, the ML tactic retrieves its arguments in the [ist]
        environment instead.  This is the rôle of the
        [lift_constr_tac_to_ml_tac] function. *)
-    let body = Tacexpr.TacFun (vars, Tacexpr.TacML (CAst.make (ml, [])))in
+    let body = Tacexpr.TacFun (CAst.make
+        (vars, Tacexpr.TacML (CAst.make (ml, [])))) in
     let id = Names.Id.of_string name in
     let obj () = Tacenv.register_ltac true false id body ?deprecation in
     let () = Tacenv.register_ml_tactic ml_tactic_name [|tac|] in
@@ -747,7 +748,8 @@ let ml_tactic_extend ~plugin ~name ~local ?deprecation sign tac =
   let args = List.init len (fun i -> Id.of_string (Printf.sprintf "arg%i" i)) in
   let vars = List.map (fun id -> Name id) args in
   let args = List.map (fun id -> Reference (Locus.ArgVar (CAst.make id))) args in
-  let body = Tacexpr.TacFun (vars, Tacexpr.TacML (CAst.make (ml, args))) in
+  let body = Tacexpr.TacFun (CAst.make
+    (vars, Tacexpr.TacML (CAst.make (ml, args)))) in
   let id = Names.Id.of_string name in
   let obj () = Tacenv.register_ltac true local id body ?deprecation in
   let () = Tacenv.register_ml_tactic ml_tactic_name [|tac|] in
@@ -816,7 +818,8 @@ let ml_val_tactic_extend ~plugin ~name ~local ?deprecation sign tac =
   let vars = List.init len (fun i -> Id.of_string (Printf.sprintf "arg%i" i)) in
   let body = TacGeneric (None, in_tacval { tacval_tac = ml_tactic_name;  tacval_var = vars }) in
   let vars = List.map (fun id -> Name id) vars in
-  let body = Tacexpr.TacFun (vars, Tacexpr.TacArg (CAst.make body)) in
+  let body = Tacexpr.TacFun (CAst.make
+      (vars, Tacexpr.TacArg (CAst.make body))) in
   let id = Names.Id.of_string name in
   let obj () = Tacenv.register_ltac true local id body ?deprecation in
   let () = assert (not @@ MLTacMap.mem ml_tactic_name !ml_table) in

--- a/plugins/ltac/tacenv.ml
+++ b/plugins/ltac/tacenv.ml
@@ -150,6 +150,85 @@ let replace kn path t =
 let tac_deprecation kn =
   try (KNmap.find kn !mactab).tac_deprecation with Not_found -> None
 
+(* replace the fname in Loc.t's in tac *)
+let convert tac fname =
+  let open Loc in
+  let open CAst in
+  let fname = InFile fname in
+  let make2 loc v =
+    match loc with
+    | Some loc -> make ~loc:{ loc with fname } v
+    | None -> make v
+  in
+  let rec cvt_list l = List.map cvt l
+  and cvt_arr a = Array.map cvt a
+  and cvt tac =
+    match tac with
+    | TacAtom {loc; v} -> if loc = None then tac else TacAtom (make2 loc v)
+    | TacThen {loc; v=(t1,t2)} -> TacThen (make2 loc (cvt t1, cvt t2))
+    | TacDispatch {loc; v} -> TacDispatch (make2 loc (cvt_list v))
+    | TacExtendTac {loc; v=(a1,t2,a3)} -> TacExtendTac (make2 loc (cvt_arr a1, cvt t2, cvt_arr a3))
+    | TacThens {loc; v=(t1,t2)} -> TacThens (make2 loc (cvt t1, cvt_list t2))
+    | TacThens3parts {loc; v=(t1,a2,t3,a4)} -> TacThens3parts (make2 loc (cvt t1, cvt_arr a2, cvt t3, cvt_arr a4))
+    | TacFirst {loc; v} -> TacFirst (make2 loc (cvt_list v))
+    | TacComplete _ -> tac
+    | TacSolve {loc; v} -> TacSolve (make2 loc (cvt_list v))
+    | TacTry {loc; v} -> TacTry (make2 loc (cvt v))
+    | TacOr {loc; v=(t1,t2)} -> TacOr (make2 loc (cvt t1, cvt t2))
+    | TacOnce {loc; v} -> TacOnce (make2 loc (cvt v))
+    | TacExactlyOnce {loc; v} -> TacExactlyOnce (make2 loc (cvt v))
+    | TacIfThenCatch {loc; v=(t1,t2,t3)} -> TacIfThenCatch (make2 loc (cvt t1, cvt t2, cvt t3))
+    | TacOrelse {loc; v=(t1,t2)} -> TacOrelse (make2 loc (cvt t1, cvt t2))
+    | TacDo {loc; v=(i,t2)} -> TacDo (make2 loc (i, cvt t2))
+    | TacTimeout {loc; v=(i,t2)} -> TacTimeout (make2 loc (i, cvt t2))
+    | TacTime {loc; v=(i,t2)} -> TacTime (make2 loc (i, cvt t2))
+    | TacRepeat {loc; v} -> TacRepeat (make2 loc (cvt v))
+    | TacProgress {loc; v} -> TacProgress (make2 loc (cvt v))
+    | TacShowHyps {loc; v} -> TacShowHyps (make2 loc (cvt v))
+    | TacAbstract {loc; v=(t1,id)} -> TacAbstract (make2 loc (cvt t1, id))
+    | TacId {loc; v} -> if loc = None then tac else TacId (make2 loc v)
+    | TacFail {loc; v} -> if loc = None then tac else TacFail (make2 loc v)
+    | TacLetIn {loc; v=(i1,i2,t3)} -> TacLetIn (make2 loc (i1, i2, cvt t3))
+    | TacMatch {loc; v=(i1,t2,l3)} -> TacMatch (make2 loc (i1, cvt t2,
+        (List.map (fun m -> match m with
+                            | Pat (a,b,t) -> Pat (a, b, cvt t)
+                            | All t -> All (cvt t))
+                   l3)))
+    | TacMatchGoal {loc; v=(i1,i2,l3)} -> TacMatchGoal (make2 loc (i1, i2,
+        (List.map (fun m -> match m with
+                            | Pat (a,b,t) -> Pat (a, b, cvt t)
+                            | All t -> All (cvt t))
+                   l3)))
+    | TacFun {loc; v} -> if loc = None then tac else TacFun (make2 loc v)
+    | TacArg {loc; v} -> if loc = None then tac else TacArg (make2 loc v)
+    | TacSelect {loc; v=(i,t2)} -> TacSelect (make2 loc (i, cvt t2))
+    | TacML {loc; v} -> if loc = None then tac else TacML (make2 loc v)
+    | TacAlias {loc; v} -> if loc = None then tac else TacAlias (make2 loc v)
+  in
+  cvt tac
+
+(* todo: will this have any effect on performance? *)
+let maybe_convert t sp =
+  (*  let name = (Libnames.string_of_path sp) in*)
+  let dirpath = ref (DirPath.repr (Libnames.dirpath sp)) in
+  let phys = ref "" in
+  if "Coq.Init.Ltac" <> (DirPath.to_string (Libnames.dirpath sp)) then begin
+    while
+      let suffix = Names.Id.to_string (List.hd !dirpath) in
+      if List.length !dirpath > 1 then
+        dirpath := List.tl !dirpath;
+      (try
+        phys := Loadpath.(physical (find_logical (DirPath.make !dirpath))) ^ "/" ^ suffix ^ ".v"
+      with
+      | Not_found -> ());
+(*      Printf.printf "phys = %s\n%!" !phys;*)
+      !phys = "" && List.length !dirpath > 1
+      do ()
+    done;
+  end;
+(*  Printf.printf "\nNAME = %s converted to phys '%s'\n%!" name !phys;*)
+  if !phys <> "" then convert t !phys else t
+
 let load_md i ((sp, kn), (local, id, b, t, deprecation)) = match id with
 | None ->
   let () = if not local then push_tactic (Nametab.Until i) sp kn in
@@ -158,6 +237,7 @@ let load_md i ((sp, kn), (local, id, b, t, deprecation)) = match id with
 
 let open_md i ((sp, kn), (local, id, b, t, deprecation)) = match id with
 | None ->
+  let t = maybe_convert t sp in
   let () = if not local then push_tactic (Nametab.Exactly i) sp kn in
   add ~deprecation kn b t
 | Some kn0 -> replace kn0 kn t

--- a/plugins/ltac/tacexpr.ml
+++ b/plugins/ltac/tacexpr.ml
@@ -181,61 +181,58 @@ constraint 'a = <
 and 'a gen_tactic_expr =
   | TacAtom of ('a gen_atomic_tactic_expr) CAst.t
   | TacThen of
-      'a gen_tactic_expr *
-      'a gen_tactic_expr
+      ('a gen_tactic_expr *
+      'a gen_tactic_expr) CAst.t
   | TacDispatch of
-      'a gen_tactic_expr list
+      'a gen_tactic_expr list CAst.t
   | TacExtendTac of
-      'a gen_tactic_expr array *
+      ('a gen_tactic_expr array *
       'a gen_tactic_expr *
-      'a gen_tactic_expr array
+      'a gen_tactic_expr array) CAst.t
   | TacThens of
-      'a gen_tactic_expr *
-      'a gen_tactic_expr list
+      ('a gen_tactic_expr *
+      'a gen_tactic_expr list) CAst.t
   | TacThens3parts of
-      'a gen_tactic_expr *
+      ('a gen_tactic_expr *
       'a gen_tactic_expr array *
       'a gen_tactic_expr *
-      'a gen_tactic_expr array
-  | TacFirst of 'a gen_tactic_expr list
+      'a gen_tactic_expr array) CAst.t
+  | TacFirst of 'a gen_tactic_expr list CAst.t
   | TacComplete of 'a gen_tactic_expr
-  | TacSolve of 'a gen_tactic_expr list
-  | TacTry of 'a gen_tactic_expr
+  | TacSolve of 'a gen_tactic_expr list CAst.t
+  | TacTry of 'a gen_tactic_expr CAst.t
   | TacOr of
-      'a gen_tactic_expr *
-      'a gen_tactic_expr
-  | TacOnce of
-      'a gen_tactic_expr
-  | TacExactlyOnce of
-      'a gen_tactic_expr
+      ('a gen_tactic_expr *
+      'a gen_tactic_expr) CAst.t
+  | TacOnce of 'a gen_tactic_expr CAst.t
+  | TacExactlyOnce of 'a gen_tactic_expr CAst.t
   | TacIfThenCatch of
+      ('a gen_tactic_expr *
       'a gen_tactic_expr *
-      'a gen_tactic_expr *
-      'a gen_tactic_expr
+      'a gen_tactic_expr) CAst.t
   | TacOrelse of
-      'a gen_tactic_expr *
-      'a gen_tactic_expr
-  | TacDo of int or_var * 'a gen_tactic_expr
-  | TacTimeout of int or_var * 'a gen_tactic_expr
-  | TacTime of string option * 'a gen_tactic_expr
-  | TacRepeat of 'a gen_tactic_expr
-  | TacProgress of 'a gen_tactic_expr
-  | TacShowHyps of 'a gen_tactic_expr
-  | TacAbstract of
-      'a gen_tactic_expr * Id.t option
-  | TacId of 'n message_token list
-  | TacFail of global_flag * int or_var * 'n message_token list
-  | TacLetIn of rec_flag *
+      ('a gen_tactic_expr *
+      'a gen_tactic_expr) CAst.t
+  | TacDo of (int or_var * 'a gen_tactic_expr) CAst.t
+  | TacTimeout of (int or_var * 'a gen_tactic_expr) CAst.t
+  | TacTime of (string option * 'a gen_tactic_expr) CAst.t
+  | TacRepeat of 'a gen_tactic_expr CAst.t
+  | TacProgress of 'a gen_tactic_expr CAst.t
+  | TacShowHyps of 'a gen_tactic_expr CAst.t
+  | TacAbstract of ('a gen_tactic_expr * Id.t option) CAst.t
+  | TacId of 'n message_token list CAst.t
+  | TacFail of (global_flag * int or_var * 'n message_token list) CAst.t
+  | TacLetIn of (rec_flag *
       (lname * 'a gen_tactic_arg) list *
-      'a gen_tactic_expr
-  | TacMatch of lazy_flag *
+      'a gen_tactic_expr) CAst.t
+  | TacMatch of (lazy_flag *
       'a gen_tactic_expr *
-      ('p,'a gen_tactic_expr) match_rule list
-  | TacMatchGoal of lazy_flag * direction_flag *
-      ('p,'a gen_tactic_expr) match_rule list
-  | TacFun of 'a gen_tactic_fun_ast
+      ('p,'a gen_tactic_expr) match_rule list) CAst.t
+  | TacMatchGoal of (lazy_flag * direction_flag *
+      ('p,'a gen_tactic_expr) match_rule list) CAst.t
+  | TacFun of 'a gen_tactic_fun_ast CAst.t
   | TacArg of 'a gen_tactic_arg CAst.t
-  | TacSelect of Goal_select.t * 'a gen_tactic_expr
+  | TacSelect of (Goal_select.t * 'a gen_tactic_expr) CAst.t
   (* For ML extensions *)
   | TacML of (ml_tactic_entry * 'a gen_tactic_arg list) CAst.t
   (* For syntax extensions *)

--- a/plugins/ltac/tacexpr.mli
+++ b/plugins/ltac/tacexpr.mli
@@ -180,61 +180,58 @@ constraint 'a = <
 and 'a gen_tactic_expr =
   | TacAtom of ('a gen_atomic_tactic_expr) CAst.t
   | TacThen of
-      'a gen_tactic_expr *
-      'a gen_tactic_expr
+      ('a gen_tactic_expr *
+      'a gen_tactic_expr) CAst.t
   | TacDispatch of
-      'a gen_tactic_expr list
+      'a gen_tactic_expr list CAst.t
   | TacExtendTac of
-      'a gen_tactic_expr array *
+      ('a gen_tactic_expr array *
       'a gen_tactic_expr *
-      'a gen_tactic_expr array
+      'a gen_tactic_expr array) CAst.t
   | TacThens of
-      'a gen_tactic_expr *
-      'a gen_tactic_expr list
+      ('a gen_tactic_expr *
+      'a gen_tactic_expr list) CAst.t
   | TacThens3parts of
-      'a gen_tactic_expr *
+      ('a gen_tactic_expr *
       'a gen_tactic_expr array *
       'a gen_tactic_expr *
-      'a gen_tactic_expr array
-  | TacFirst of 'a gen_tactic_expr list
+      'a gen_tactic_expr array) CAst.t
+  | TacFirst of 'a gen_tactic_expr list CAst.t
   | TacComplete of 'a gen_tactic_expr
-  | TacSolve of 'a gen_tactic_expr list
-  | TacTry of 'a gen_tactic_expr
+  | TacSolve of 'a gen_tactic_expr list CAst.t
+  | TacTry of 'a gen_tactic_expr CAst.t
   | TacOr of
-      'a gen_tactic_expr *
-      'a gen_tactic_expr
-  | TacOnce of
-      'a gen_tactic_expr
-  | TacExactlyOnce of
-      'a gen_tactic_expr
+      ('a gen_tactic_expr *
+      'a gen_tactic_expr) CAst.t
+  | TacOnce of 'a gen_tactic_expr CAst.t
+  | TacExactlyOnce of 'a gen_tactic_expr CAst.t
   | TacIfThenCatch of
+      ('a gen_tactic_expr *
       'a gen_tactic_expr *
-      'a gen_tactic_expr *
-      'a gen_tactic_expr
+      'a gen_tactic_expr) CAst.t
   | TacOrelse of
-      'a gen_tactic_expr *
-      'a gen_tactic_expr
-  | TacDo of int or_var * 'a gen_tactic_expr
-  | TacTimeout of int or_var * 'a gen_tactic_expr
-  | TacTime of string option * 'a gen_tactic_expr
-  | TacRepeat of 'a gen_tactic_expr
-  | TacProgress of 'a gen_tactic_expr
-  | TacShowHyps of 'a gen_tactic_expr
-  | TacAbstract of
-      'a gen_tactic_expr * Id.t option
-  | TacId of 'n message_token list
-  | TacFail of global_flag * int or_var * 'n message_token list
-  | TacLetIn of rec_flag *
+      ('a gen_tactic_expr *
+      'a gen_tactic_expr) CAst.t
+  | TacDo of (int or_var * 'a gen_tactic_expr) CAst.t
+  | TacTimeout of (int or_var * 'a gen_tactic_expr) CAst.t
+  | TacTime of (string option * 'a gen_tactic_expr) CAst.t
+  | TacRepeat of 'a gen_tactic_expr CAst.t
+  | TacProgress of 'a gen_tactic_expr CAst.t
+  | TacShowHyps of 'a gen_tactic_expr CAst.t
+  | TacAbstract of ('a gen_tactic_expr * Id.t option) CAst.t
+  | TacId of 'n message_token list CAst.t
+  | TacFail of (global_flag * int or_var * 'n message_token list) CAst.t
+  | TacLetIn of (rec_flag *
       (lname * 'a gen_tactic_arg) list *
-      'a gen_tactic_expr
-  | TacMatch of lazy_flag *
+      'a gen_tactic_expr) CAst.t
+  | TacMatch of (lazy_flag *
       'a gen_tactic_expr *
-      ('p,'a gen_tactic_expr) match_rule list
-  | TacMatchGoal of lazy_flag * direction_flag *
-      ('p,'a gen_tactic_expr) match_rule list
-  | TacFun of 'a gen_tactic_fun_ast
+      ('p,'a gen_tactic_expr) match_rule list) CAst.t
+  | TacMatchGoal of (lazy_flag * direction_flag *
+      ('p,'a gen_tactic_expr) match_rule list) CAst.t
+  | TacFun of 'a gen_tactic_fun_ast CAst.t
   | TacArg of 'a gen_tactic_arg CAst.t
-  | TacSelect of Goal_select.t * 'a gen_tactic_expr
+  | TacSelect of (Goal_select.t * 'a gen_tactic_expr) CAst.t
   (* For ML extensions *)
   | TacML of (ml_tactic_entry * 'a gen_tactic_arg list) CAst.t
   (* For syntax extensions *)

--- a/plugins/ltac/tacsubst.ml
+++ b/plugins/ltac/tacsubst.ml
@@ -172,54 +172,57 @@ let rec subst_atomic subst (t:glob_atomic_tactic_expr) = match t with
       TacInversion (InversionUsing (subst_glob_constr subst c,cl),hyp)
 
 and subst_tactic subst (t:glob_tactic_expr) = match t with
-  | TacAtom { CAst.v=t } -> TacAtom (CAst.make @@ subst_atomic subst t)
-  | TacFun tacfun -> TacFun (subst_tactic_fun subst tacfun)
-  | TacLetIn (r,l,u) ->
+  | TacAtom { CAst.loc; v=t } -> TacAtom (CAst.make ?loc @@ subst_atomic subst t)
+  | TacFun { CAst.loc; v=tacfun } -> TacFun (CAst.make ?loc(subst_tactic_fun subst tacfun))
+  | TacLetIn { CAst.loc; v=(r,l,u) } ->
       let l = List.map (fun (n,b) -> (n,subst_tacarg subst b)) l in
-      TacLetIn (r,l,subst_tactic subst u)
-  | TacMatchGoal (lz,lr,lmr) ->
-      TacMatchGoal(lz,lr, subst_match_rule subst lmr)
-  | TacMatch (lz,c,lmr) ->
-      TacMatch (lz,subst_tactic subst c,subst_match_rule subst lmr)
-  | TacId _ | TacFail _ as x -> x
-  | TacProgress tac -> TacProgress (subst_tactic subst tac:glob_tactic_expr)
-  | TacShowHyps tac -> TacShowHyps (subst_tactic subst tac:glob_tactic_expr)
-  | TacAbstract (tac,s) -> TacAbstract (subst_tactic subst tac,s)
-  | TacThen (t1,t2) ->
-      TacThen (subst_tactic subst t1, subst_tactic subst t2)
-  | TacDispatch tl -> TacDispatch (List.map (subst_tactic subst) tl)
-  | TacExtendTac (tf,t,tl) ->
-      TacExtendTac (Array.map (subst_tactic subst) tf,
+      TacLetIn (CAst.make ?loc (r,l,subst_tactic subst u))
+  | TacMatchGoal { CAst.loc; v=(lz,lr,lmr) } ->
+      TacMatchGoal (CAst.make ?loc (lz,lr, subst_match_rule subst lmr))
+  | TacMatch { CAst.loc; v=(lz,c,lmr) } ->
+      TacMatch (CAst.make ?loc (lz,subst_tactic subst c,subst_match_rule subst lmr))
+  | TacId {CAst.loc; v=t} as x -> x
+  | TacFail  {CAst.loc; v=t} as x -> x
+  | TacProgress { CAst.loc; v=tac } -> TacProgress (CAst.make ?loc (subst_tactic subst tac:glob_tactic_expr))
+  | TacShowHyps { CAst.loc; v=tac } -> TacShowHyps (CAst.make ?loc (subst_tactic subst tac:glob_tactic_expr))
+  | TacAbstract { CAst.loc; v=(tac,s) } -> TacAbstract (CAst.make ?loc (subst_tactic subst tac,s))
+  | TacThen { CAst.loc; v=(t1,t2) } ->
+      TacThen (CAst.make ?loc (subst_tactic subst t1, subst_tactic subst t2))
+  | TacDispatch { CAst.loc; v=tl } -> TacDispatch (CAst.make ?loc (List.map (subst_tactic subst) tl))
+  | TacExtendTac { CAst.loc; v=(tf,t,tl) } ->
+      TacExtendTac (CAst.make ?loc
+                    (Array.map (subst_tactic subst) tf,
                     subst_tactic subst t,
-                    Array.map (subst_tactic subst) tl)
-  | TacThens (t,tl) ->
-      TacThens (subst_tactic subst t, List.map (subst_tactic subst) tl)
-  | TacThens3parts (t1,tf,t2,tl) ->
-      TacThens3parts (subst_tactic subst t1,Array.map (subst_tactic subst) tf,
-               subst_tactic subst t2,Array.map (subst_tactic subst) tl)
-  | TacDo (n,tac) -> TacDo (n,subst_tactic subst tac)
-  | TacTimeout (n,tac) -> TacTimeout (n,subst_tactic subst tac)
-  | TacTime (s,tac) -> TacTime (s,subst_tactic subst tac)
-  | TacTry tac -> TacTry (subst_tactic subst tac)
-  | TacRepeat tac -> TacRepeat (subst_tactic subst tac)
-  | TacOr (tac1,tac2) ->
-      TacOr (subst_tactic subst tac1,subst_tactic subst tac2)
-  | TacOnce tac ->
-      TacOnce (subst_tactic subst tac)
-  | TacExactlyOnce tac ->
-      TacExactlyOnce (subst_tactic subst tac)
-  | TacIfThenCatch (tac,tact,tace) ->
-      TacIfThenCatch (
+                    Array.map (subst_tactic subst) tl))
+  | TacThens { CAst.loc; v=(t,tl) } ->
+      TacThens (CAst.make ?loc (subst_tactic subst t, List.map (subst_tactic subst) tl))
+  | TacThens3parts { CAst.loc; v=(t1,tf,t2,tl) } ->
+      TacThens3parts (CAst.make ?loc
+              (subst_tactic subst t1,Array.map (subst_tactic subst) tf,
+               subst_tactic subst t2,Array.map (subst_tactic subst) tl))
+  | TacDo { CAst.loc; v=(n,tac) } -> TacDo (CAst.make ?loc (n,subst_tactic subst tac))
+  | TacTimeout { CAst.loc; v=(n,tac) } -> TacTimeout (CAst.make ?loc (n,subst_tactic subst tac))
+  | TacTime { CAst.loc; v=(s,tac) } -> TacTime (CAst.make ?loc (s,subst_tactic subst tac))
+  | TacTry { CAst.loc; v=tac } -> TacTry (CAst.make ?loc (subst_tactic subst tac))
+  | TacRepeat { CAst.loc; v=tac } -> TacRepeat (CAst.make ?loc (subst_tactic subst tac))
+  | TacOr { CAst.loc; v=(tac1,tac2) } ->
+      TacOr (CAst.make ?loc (subst_tactic subst tac1,subst_tactic subst tac2))
+  | TacOnce { CAst.loc; v=tac } ->
+      TacOnce (CAst.make ?loc (subst_tactic subst tac))
+  | TacExactlyOnce { CAst.loc; v=tac } ->
+      TacExactlyOnce (CAst.make ?loc (subst_tactic subst tac))
+  | TacIfThenCatch { CAst.loc; v=(tac,tact,tace) } ->
+      TacIfThenCatch (CAst.make ?loc (
         subst_tactic subst tac,
         subst_tactic subst tact,
-        subst_tactic subst tace)
-  | TacOrelse (tac1,tac2) ->
-      TacOrelse (subst_tactic subst tac1,subst_tactic subst tac2)
-  | TacFirst l -> TacFirst (List.map (subst_tactic subst) l)
-  | TacSolve l -> TacSolve (List.map (subst_tactic subst) l)
+        subst_tactic subst tace))
+  | TacOrelse { CAst.loc; v=(tac1,tac2) } ->
+      TacOrelse (CAst.make ?loc (subst_tactic subst tac1,subst_tactic subst tac2))
+  | TacFirst { CAst.loc; v=l } -> TacFirst (CAst.make ?loc (List.map (subst_tactic subst) l))
+  | TacSolve { CAst.loc; v=l } -> TacSolve (CAst.make ?loc (List.map (subst_tactic subst) l))
   | TacComplete tac -> TacComplete (subst_tactic subst tac)
   | TacArg { CAst.v=a } -> TacArg (CAst.make @@ subst_tacarg subst a)
-  | TacSelect (s, tac) -> TacSelect (s, subst_tactic subst tac)
+  | TacSelect { CAst.loc; v=(s, tac) } -> TacSelect (CAst.make ?loc (s, subst_tactic subst tac))
 
   (* For extensions *)
   | TacAlias { CAst.v=(s,l) } ->

--- a/plugins/ltac/tactic_option.ml
+++ b/plugins/ltac/tactic_option.ml
@@ -11,7 +11,8 @@
 open Libobject
 open Pp
 
-let declare_tactic_option ?(default=Tacexpr.TacId []) name =
+let declare_tactic_option ?(default=Tacexpr.TacId
+    (CAst.make [])) name =
   let locality = Summary.ref false ~name:(name^"-locality") in
   let default_tactic : Tacexpr.glob_tactic_expr ref =
     Summary.ref default ~name:(name^"-default-tactic")

--- a/plugins/ltac/tauto.ml
+++ b/plugins/ltac/tauto.ml
@@ -203,7 +203,7 @@ let reduction_not_iff _ ist =
   let make_reduce c = TacAtom (CAst.make @@ TacReduce (Genredexpr.Unfold c, Locusops.allHypsAndConcl)) in
   let tac = match !negation_unfolding with
     | true -> make_reduce [make_unfold "core.not.type"]
-    | false -> TacId []
+    | false -> TacId (CAst.make [])
   in
   eval_tactic_ist ist tac
 
@@ -259,7 +259,8 @@ let register_tauto_tactic tac name0 args =
   let name = { mltac_plugin = tauto_plugin; mltac_tactic = name0; } in
   let entry = { mltac_name = name; mltac_index = 0 } in
   let () = Tacenv.register_ml_tactic name [| tac |] in
-  let tac = TacFun (ids, TacML (CAst.make (entry, []))) in
+  let tac = TacFun (CAst.make
+    (ids, TacML (CAst.make (entry, [])))) in
   let obj () = Tacenv.register_ltac true true (Id.of_string name0) tac in
   Mltop.declare_cache_obj obj tauto_plugin
 

--- a/plugins/ring/ring.ml
+++ b/plugins/ring/ring.ml
@@ -125,10 +125,11 @@ let closed_term_ast =
   } in
   fun l ->
   let l = List.map (fun gr -> ArgArg(Loc.tag gr)) l in
-  TacFun([Name(Id.of_string"t")],
-  TacML(CAst.make (tacname,
-  [TacGeneric (None, Genarg.in_gen (Genarg.glbwit Stdarg.wit_constr) (DAst.make @@ GVar(Id.of_string"t"),None));
-   TacGeneric (None, Genarg.in_gen (Genarg.glbwit (Genarg.wit_list Stdarg.wit_ref)) l)])))
+  TacFun (CAst.make
+    ([Name(Id.of_string"t")],
+    TacML(CAst.make (tacname,
+    [TacGeneric (None, Genarg.in_gen (Genarg.glbwit Stdarg.wit_constr) (DAst.make @@ GVar(Id.of_string"t"),None));
+     TacGeneric (None, Genarg.in_gen (Genarg.glbwit (Genarg.wit_list Stdarg.wit_ref)) l)]))))
 (*
 let _ = add_tacdef false ((Loc.ghost,Id.of_string"ring_closed_term"
 *)
@@ -197,7 +198,8 @@ let exec_tactic env sigma n f args =
   let lid = List.init n (fun i -> Id.of_string("x"^string_of_int i)) in
   let n = Genarg.in_gen (Genarg.glbwit Stdarg.wit_int) n in
   let get_res = TacML (CAst.make (get_res, [TacGeneric (None, n)])) in
-  let getter = Tacexp (TacFun (List.map (fun n -> Name n) lid, get_res)) in
+  let getter = Tacexp (TacFun (CAst.make
+      (List.map (fun n -> Name n) lid, get_res))) in
   (* Evaluate the whole result *)
   let gl = dummy_goal env sigma in
   let gls = Proofview.V82.of_tactic (Tacinterp.eval_tactic_ist ist (ltac_call f (args@[getter]))) gl in
@@ -582,11 +584,11 @@ let add_theory0 env sigma name rth eqth morphth cst_tac (pre,post) power sign di
   let pretac =
     match pre with
         Some t -> Tacintern.glob_tactic t
-      | _ -> TacId [] in
+      | _ -> TacId (CAst.make []) in
   let posttac =
     match post with
         Some t -> Tacintern.glob_tactic t
-      | _ -> TacId [] in
+      | _ -> TacId (CAst.make []) in
   let r = EConstr.to_constr sigma r in
   let req = EConstr.to_constr sigma req in
   let sth = EConstr.to_constr sigma sth in
@@ -675,8 +677,10 @@ let ltac_ring_structure e =
   let pow_tac = tacarg e.ring_pow_tac in
   let lemma1 = carg e.ring_lemma1 in
   let lemma2 = carg e.ring_lemma2 in
-  let pretac = tacarg (TacFun([Anonymous],e.ring_pre_tac)) in
-  let posttac = tacarg (TacFun([Anonymous],e.ring_post_tac)) in
+  let pretac = tacarg (TacFun (CAst.make
+      ([Anonymous],e.ring_pre_tac))) in
+  let posttac = tacarg (TacFun (CAst.make
+      ([Anonymous],e.ring_post_tac))) in
   [req;sth;ext;morph;th;cst_tac;pow_tac;
    lemma1;lemma2;pretac;posttac]
 
@@ -906,11 +910,11 @@ let add_field_theory0 env sigma name fth eqth morphth cst_tac inj (pre,post) pow
   let pretac =
     match pre with
         Some t -> Tacintern.glob_tactic t
-      | _ -> TacId [] in
+      | _ -> TacId (CAst.make []) in
   let posttac =
     match post with
         Some t -> Tacintern.glob_tactic t
-      | _ -> TacId [] in
+      | _ -> TacId (CAst.make []) in
   let r = EConstr.to_constr sigma r in
   let req = EConstr.to_constr sigma req in
   let _ =
@@ -968,8 +972,10 @@ let ltac_field_structure e =
   let field_simpl_eq_ok = carg e.field_simpl_eq_ok in
   let field_simpl_eq_in_ok = carg e.field_simpl_eq_in_ok in
   let cond_ok = carg e.field_cond in
-  let pretac = tacarg (TacFun([Anonymous],e.field_pre_tac)) in
-  let posttac = tacarg (TacFun([Anonymous],e.field_post_tac)) in
+  let pretac = tacarg (TacFun (CAst.make
+      ([Anonymous],e.field_pre_tac))) in
+  let posttac = tacarg (TacFun (CAst.make
+      ([Anonymous],e.field_post_tac))) in
   [req;cst_tac;pow_tac;field_ok;field_simpl_ok;field_simpl_eq_ok;
    field_simpl_eq_in_ok;cond_ok;pretac;posttac]
 

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -1599,7 +1599,7 @@ let test_ssrseqvar =
     lk_ident_except sq_brace_tacnames >> (lk_kws ["[";"first";"last"])
   end
 
-let swaptacarg (loc, b) = (b, []), Some (TacId [])
+let swaptacarg (loc, b) = (b, []), Some (TacId (CAst.make ~loc []))
 
 let check_seqtacarg dir arg = match snd arg, dir with
   | ((true, []), Some (TacAtom { CAst.loc })), L2R ->
@@ -1875,14 +1875,14 @@ GRAMMAR EXTEND Gram
   GLOBAL: ltac_expr;
   ssr_first: [
     [ tac = ssr_first; ipats = ssrintros_ne -> { tclintros_expr ~loc tac ipats }
-    | "["; tacl = LIST0 ltac_expr SEP "|"; "]" -> { TacFirst tacl }
+    | "["; tacl = LIST0 ltac_expr SEP "|"; "]" -> { TacFirst (CAst.make ~loc tacl) }
     ] ];
   ssr_first_else: [
-    [ tac1 = ssr_first; tac2 = ssrorelse -> { TacOrelse (tac1, tac2) }
+    [ tac1 = ssr_first; tac2 = ssrorelse -> { TacOrelse (CAst.make ~loc (tac1, tac2)) }
     | tac = ssr_first -> { tac } ]];
   ltac_expr: LEVEL "4" [ LEFTA
     [ tac1 = ltac_expr; ";"; IDENT "first"; tac2 = ssr_first_else ->
-      { TacThen (tac1, tac2) }
+      { TacThen (CAst.make ~loc (tac1, tac2)) }
     | tac = ltac_expr; ";"; IDENT "first"; arg = ssrseqarg ->
       { tclseq_expr ~loc tac L2R arg }
     | tac = ltac_expr; ";"; IDENT "last"; arg = ssrseqarg ->

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -1312,8 +1312,9 @@ let () =
   let name = { mltac_plugin = "ssrmatching_plugin"; mltac_tactic = "ssrpattern"; } in
   let () = Tacenv.register_ml_tactic name [|mltac|] in
   let tac =
-    TacFun ([Name (Id.of_string "pattern")],
-      TacML (CAst.make ({ mltac_name = name; mltac_index = 0 }, []))) in
+    TacFun (CAst.make
+      ([Name (Id.of_string "pattern")],
+      TacML (CAst.make ({ mltac_name = name; mltac_index = 0 }, [])))) in
   let obj () =
     Tacenv.register_ltac true false (Id.of_string "ssrpattern") tac in
   Mltop.declare_cache_obj obj "ssrmatching_plugin"

--- a/test-suite/coq-makefile/template/theories/sub/testsub.v
+++ b/test-suite/coq-makefile/template/theories/sub/testsub.v
@@ -1,1 +1,3 @@
 Require Import test.
+Print LoadPath.
+error

--- a/user-contrib/Ltac2/tac2core.ml
+++ b/user-contrib/Ltac2/tac2core.ml
@@ -1551,7 +1551,8 @@ let () =
   let () = Geninterp.register_interp0 wit_ltac2_val interp_fun in
   define1 "ltac1_lambda" valexpr begin fun f ->
     let body = Tacexpr.TacGeneric (Some "ltac2", in_gen (glbwit wit_ltac2_val) ()) in
-    let clos = Tacexpr.TacFun ([Name arg_id], Tacexpr.TacArg (CAst.make body)) in
+    let clos = Tacexpr.TacFun (CAst.make
+        ([Name arg_id], Tacexpr.TacArg (CAst.make body))) in
     let f = Geninterp.Val.inject (Geninterp.Val.Base typ_ltac2) f in
     let lfun = Id.Map.singleton tac_id f in
     let ist = { (Tacinterp.default_ist ()) with Tacinterp.lfun } in
@@ -1583,7 +1584,8 @@ let () =
   let interp ist (ids, tac) = match ids with
   | [] ->
     (* Evaluate the Ltac2 quotation eagerly *)
-    let idtac = Value.of_closure { ist with lfun = Id.Map.empty } (Tacexpr.TacId []) in
+    let idtac = Value.of_closure { ist with lfun = Id.Map.empty }
+        (Tacexpr.TacId (CAst.make [])) in
     let ist = { env_ist = Id.Map.empty } in
     Tac2interp.interp ist tac >>= fun _ ->
     Ftactic.return idtac
@@ -1594,7 +1596,8 @@ let () =
     let nas = List.map (fun id -> Name id) ids in
     let mk_arg id = Tacexpr.Reference (Locus.ArgVar (CAst.make id)) in
     let args = List.map mk_arg ids in
-    let clos = Tacexpr.TacFun (nas, Tacexpr.TacML (CAst.make (ltac2_eval, mk_arg self_id :: args))) in
+    let clos = Tacexpr.TacFun (CAst.make
+        (nas, Tacexpr.TacML (CAst.make (ltac2_eval, mk_arg self_id :: args)))) in
     let self = GTacFun (List.map (fun id -> Name id) ids, tac) in
     let self = Tac2interp.interp_value { env_ist = Id.Map.empty } self in
     let self = Geninterp.Val.inject (Geninterp.Val.Base typ_ltac2) self in

--- a/vernac/loadpath.ml
+++ b/vernac/loadpath.ml
@@ -32,7 +32,7 @@ let pp p =
 let get_load_paths () = !load_paths
 
 let anomaly_too_many_paths path =
-  CErrors.anomaly Pp.(str "Several logical paths are associated to" ++ spc () ++ str path ++ str ".")
+  CErrors.anomaly Pp.(str "Several logical paths are associated with" ++ spc () ++ str path ++ str ".")
 
 let find_load_path phys_dir =
   let phys_dir = CUnix.canonical_path_name phys_dir in
@@ -42,6 +42,15 @@ let find_load_path phys_dir =
   | [] -> raise Not_found
   | [p] -> p
   | _ -> anomaly_too_many_paths phys_dir
+
+let find_logical modname =
+  let modname = Names.DirPath.to_string modname in
+  let filter p = String.equal (Names.DirPath.to_string p.path_logical) modname in
+  let paths = List.filter filter !load_paths in
+  match paths with
+  | [] -> raise Not_found
+  | [p] -> p
+  | _ ->   CErrors.anomaly Pp.(str "Several physical paths are associated with" ++ spc () ++ str modname ++ str ".")
 
 let remove_load_path dir =
   let filter p = not (String.equal p.path_physical dir) in

--- a/vernac/loadpath.ml
+++ b/vernac/loadpath.ml
@@ -50,7 +50,14 @@ let find_logical modname =
   match paths with
   | [] -> raise Not_found
   | [p] -> p
-  | _ ->   CErrors.anomaly Pp.(str "Several physical paths are associated with" ++ spc () ++ str modname ++ str ".")
+  | hd :: tl ->
+    (* there may be duplicate entries *)
+    let p' = List.filter (fun e -> e <> hd) tl in
+    match p' with
+    | [] -> hd
+    | l -> List.iter (fun p -> Printf.eprintf "Physical path: %s\n%!" p.path_physical) (hd :: l);
+      CErrors.anomaly Pp.(str "Several physical paths are associated with"
+        ++ spc () ++ str modname ++ str ".")
 
 let remove_load_path dir =
   let filter p = not (String.equal p.path_physical dir) in

--- a/vernac/loadpath.ml
+++ b/vernac/loadpath.ml
@@ -56,8 +56,11 @@ let find_logical modname =
     match p' with
     | [] -> hd
     | l -> List.iter (fun p -> Printf.eprintf "Physical path: %s\n%!" p.path_physical) (hd :: l);
+    hd
+(*
       CErrors.anomaly Pp.(str "Several physical paths are associated with"
         ++ spc () ++ str modname ++ str ".")
+*)
 
 let remove_load_path dir =
   let filter p = not (String.equal p.path_physical dir) in

--- a/vernac/loadpath.mli
+++ b/vernac/loadpath.mli
@@ -23,6 +23,9 @@ type t
 val logical : t -> DirPath.t
 (** Get the logical path (Coq module hierarchy) of a loadpath. *)
 
+val physical : t -> CUnix.physical_path
+(** Get the physical path of a loadpath *)
+
 val pp : t -> Pp.t
 (** Print a load path *)
 
@@ -34,7 +37,11 @@ val remove_load_path : CUnix.physical_path -> unit
     if any. *)
 
 val find_load_path : CUnix.physical_path -> t
-(** Get the binding associated to a physical path. Raises [Not_found] if there
+(** Get the binding associated with a physical path. Raises [Not_found] if there
+    is none. *)
+
+val find_logical : DirPath.t -> t
+(** Get the binding associated with a logical path. Raises [Not_found] if there
     is none. *)
 
 val locate_file : string -> string


### PR DESCRIPTION
When the debugger stops at a breakpoint, it needs to find (from the Loc.t)  the associated `.v` file so it can be opened and displayed, and to highlight the stopping point in the buffer.  However, `coqc` generates `Loc.t`s with relative pathnames--which it must because modules can be installed in any directory.  This code replaces relative pathnames in the tactic objects with absolute pathnames when the tactic object is loaded.

I considered trying to map from the relative pathname to a module name and thence to a directory, but that is not necessarily unique.  I don't want to force the user to tell CoqIDE which of the possible matches is the correct one.  (They could pick the wrong one, too, generating great confusion.)

For now, the debugger will assume that the `.vo` and the `.v` file are in the same directory.  We can always relax that restriction in future versions.

I expect this has a negligible performance impact.  I don't understand the difference between `open_md` (which is where the change is) and `load_md` (which was my initial guess), or how often `open_md` is called.

This code is necessary to support the 2nd PR for the Ltac Debugger (which I will submit shortly).  That adds a lot of great functionality that users would benefit from in 8.14 even if it's somewhat incomplete or has some bugs.  I hope someone will be able to review this soon.

Depends on and incorporates #14224 