### PR TITLE
[Debugger] Visual debugger in CoqIDE

### DIFF
--- a/dev/ci/user-overlays/14252-jfehrle-debugger_stack.sh
+++ b/dev/ci/user-overlays/14252-jfehrle-debugger_stack.sh
@@ -1,0 +1,1 @@
+overlay coqtail https://github.com/jfehrle/coqtail change_add 14252

--- a/dev/doc/xml-protocol.md
+++ b/dev/doc/xml-protocol.md
@@ -31,6 +31,9 @@ Changes to the XML protocol are documented as part of [`dev/doc/changes.md`](/de
   - [PrintAst](#command-printast)
   - [Annotate](#command-annotate)
   - [Db_cmd](#command-db_cmd)
+  - [Db_loc](#command-db_loc)
+  - [Db_upd_bpts](#command-db_upd_bpts)
+  - [Db_continue](#command-db_continue)
 * [Feedback messages](#feedback)
   - [Added Axiom](#feedback-addedaxiom)
   - [Processing](#feedback-processing)
@@ -640,8 +643,101 @@ take `<call val="Annotate"><string>Theorem plus_0_r : forall n : nat, n + 0 = n.
 #### *Returns*
 *
 
-`<call val="Db_cmd"><string>h</string></call>` passes the command "h" to the debugger.
-It returns unit.
+`<call val="Db_cmd"><string>h</string></call>` directs Coq to process the debugger command "h".
+It returns unit.  This call is processed only when the debugger is stopped and has just
+sent a `prompt` message.
+
+
+
+-------------------------------
+
+
+
+### <a name="command-db_loc">**Db_loc()**</a>
+Returns the location where the debugger has stopped, consisting of the absolute filename
+of the .v file (or "ToplevelInput") and the beginning and ending offset therein.
+```html
+<call val="Db_loc"><unit/></call>
+```
+#### *Returns*
+
+
+```html
+<value val="good">
+  <pair>
+    <string>ToplevelInput</string>
+    <list>
+      <int>22</int>
+      <int>31</int>
+    </list>
+  </pair>
+</value>
+```
+
+
+
+-------------------------------
+
+
+
+### <a name="command-db_upd_bpts">**Db_upd_bpts(...)**</a>
+The call passes a list of breakpoints to set or clear.  The string is the
+absolute pathname of the .v file (or "ToplevelInput"), the int is the offset within the file
+and the boolean is true to set a breakpoint and false to clear it.  Breakpoints can
+be updated when Coq is not busy or when Coq is stopped in the debugger.  If this
+message is sent in other states, it will be received and processed when Coq is no longer busy
+or execution stops in the debugger.
+
+```html
+<call val="Db_upd_bpts">
+  <list>
+    <pair>
+      <pair>
+        <string>/home/proj/coq/ide/coqide/debug.v</string>
+        <int>22</int>
+      </pair>
+      <bool val="true"/>
+    </pair>
+  </list>
+</call>
+```
+#### *Returns*
+* Unit.
+
+
+
+-------------------------------
+
+
+
+
+### <a name="command-db_continue">**Db_continue()**</a>
+
+Tells Coq to continue processing the proof when it is stopped in the debugger.
+The integer indicates when the debugger should stop again:
+
+```
+0: StepIn - step one tactic.  If it is an Ltac tactic, stop at the first tactic within it
+1: StepOver - step over one tactic.  if it is an Ltac tactic, don't stop within it
+2: StepOut - stop on the first tactic after exiting the current Ltac tactic
+3: Continue - continue running until the next breakpoint or the debugger exits
+4: Interrupt - generate a User interrupt (for use when stopped in the debugger; otherwise
+     interrupt is sent as a signal)
+```
+
+If the debugger encounters a breakpoint during a StepOver or a StepOut, it will
+stop at the breakpoint.
+
+```html
+<call val="Db_continue">
+  <int>1</int>
+</call>
+```
+
+#### *Returns*
+* Unit.
+
+
 
 -------------------------------
 

--- a/doc/changelog/09-coqide/14252-debugger_stack.rst
+++ b/doc/changelog/09-coqide/14252-debugger_stack.rst
@@ -1,0 +1,7 @@
+- **Added:**
+  Adds a preliminary visual debugger.  Supports setting breakpoints
+  visually, jumping to the stopping point plus continue, step over,
+  step in and step out operations.  See documentation `HERE - TBA`.
+  (`#14252 <https://github.com/coq/coq/pull/14252>`_,
+  fixes `#13967 <https://github.com/coq/coq/issues/13967>`_,
+  by Jim Fehrle).

--- a/ide/coqide/coq.ml
+++ b/ide/coqide/coq.ml
@@ -503,9 +503,10 @@ let setup_script_editable coqtop f = coqtop.set_script_editable <- f
 
 let is_computing coqtop = (coqtop.status = Busy)
 
-let is_ready coqtop = (coqtop.status = Ready)
-
 let is_stopped_in_debugger coqtop = coqtop.stopped_in_debugger
+
+let is_ready_or_stopped_in_debugger coqtop =
+  coqtop.status = Ready || (is_stopped_in_debugger coqtop)
 
 let set_stopped_in_debugger coqtop v =
   coqtop.stopped_in_debugger <- v

--- a/ide/coqide/coq.ml
+++ b/ide/coqide/coq.ml
@@ -422,6 +422,7 @@ let pstatus = function
 *)
 
 let can_send_db_msg coqtop =
+  coqtop.handle.db_waiting_for = None &&
   match coqtop.status with
   | Busy -> coqtop.stopped_in_debugger
   | Ready -> true
@@ -439,7 +440,7 @@ let mkready coqtop db =
       coqtop.status <- Ready;
       coqtop.set_script_editable true
     end;
-    if coqtop.status = Ready then begin
+    if coqtop.status = Ready || db then begin
       let q = coqtop.do_when_ready in
       if not (Queue.is_empty q) then
         let f = Queue.pop q in f ()

--- a/ide/coqide/coq.mli
+++ b/ide/coqide/coq.mli
@@ -68,11 +68,11 @@ type reset_kind = Planned | Unexpected
 val is_computing : coqtop -> bool
 (** Check if coqtop is computing, i.e. already has a current task *)
 
-val is_ready : coqtop -> bool
-(** Check if coqtop is Ready *)
-
 val is_stopped_in_debugger : coqtop -> bool
 (** Returns true if coqtop is stopped in the debugger *)
+
+val is_ready_or_stopped_in_debugger : coqtop -> bool
+(** Check if coqtop is Ready or stopped in the debugger *)
 
 val set_stopped_in_debugger : coqtop -> bool -> unit
 (** Records whether coqtop is stopped in the debugger *)

--- a/ide/coqide/coq.mli
+++ b/ide/coqide/coq.mli
@@ -21,6 +21,15 @@ type coqtop
     abrupt failure. It is also called when explicitly requesting coqtop to
     reset. *)
 
+type status = New | Ready | Busy | Closed
+(** Coqtop process status :
+  - New    : a process has been spawned, but not initialized via [init_coqtop].
+             It will reject tasks given via [try_grab].
+  - Ready  : no current task, accepts new tasks via [try_grab].
+  - Busy   : has accepted a task via [init_coqtop] or [try_grab],
+  - Closed : the coqide buffer has been closed, we discard any further task.
+*)
+
 type 'a task
 (** Coqtop tasks.
 
@@ -59,6 +68,15 @@ type reset_kind = Planned | Unexpected
 val is_computing : coqtop -> bool
 (** Check if coqtop is computing, i.e. already has a current task *)
 
+val is_ready : coqtop -> bool
+(** Check if coqtop is Ready *)
+
+val is_stopped_in_debugger : coqtop -> bool
+(** Returns true if coqtop is stopped in the debugger *)
+
+val set_stopped_in_debugger : coqtop -> bool -> unit
+(** Records whether coqtop is stopped in the debugger *)
+
 val spawn_coqtop : string list -> coqtop
 (** Create a coqtop process with some command-line arguments. *)
 
@@ -71,12 +89,19 @@ val set_feedback_handler : coqtop -> (Feedback.feedback -> unit) -> unit
 val set_debug_prompt_handler : coqtop -> (tag:string -> Pp.t -> unit) -> unit
 (** Register a handler called when the Ltac debugger sends a feedback message *)
 
+val add_do_when_ready : coqtop -> (unit -> unit) -> unit
+(** Register a function to be called when coqtop becomes Ready *)
+
+val setup_script_editable : coqtop -> (bool -> unit) -> unit
+(** Register setter function to make proof script panel editable or not,
+    e.g. to disable editing while any non-debugger message is being processed *)
+
 val init_coqtop : coqtop -> unit task -> unit
 (** Finish initializing a freshly spawned coqtop, by running a first task on it.
     The task should run its inner continuation at the end. *)
 
-val break_coqtop : coqtop -> string list -> unit
-(** Interrupt the current computation of coqtop or the worker if coqtop it not running. *)
+val interrupt_coqtop : coqtop -> string list -> unit
+(** Terminate the current computation of coqtop or the worker if coqtop is not running. *)
 
 val close_coqtop : coqtop -> unit
 (** Close coqtop. Subsequent requests will be discarded. Hook ignored. *)
@@ -96,10 +121,10 @@ val gio_channel_of_descr_socket : (Unix.file_descr -> Glib.Io.channel) ref
 
 (** {5 Task processing} *)
 
-val try_grab : ?db:bool -> coqtop -> unit task -> (unit -> unit) -> unit
+val try_grab : ?db:bool -> coqtop -> unit task -> (unit -> unit) -> bool
 (** Try to schedule a task on a coqtop. If coqtop is available, the task
     callback is run (asynchronously), otherwise the [(unit->unit)] callback
-    is triggered.
+    is triggered.  Returns true if the task is run.
     - If coqtop ever dies during the computation, this function restarts coqtop
       and calls the restart hook with the fresh coqtop.
     - If the argument function raises an exception, a coqtop reset occurs.
@@ -132,6 +157,9 @@ val search     : Interface.search_sty     -> Interface.search_rty query
 val init       : Interface.init_sty       -> Interface.init_rty query
 val proof_diff : Interface.proof_diff_sty -> Interface.proof_diff_rty query
 val db_cmd     : Interface.db_cmd_sty     -> Interface.db_cmd_rty query
+val db_loc     : Interface.db_loc_sty     -> Interface.db_loc_rty query
+val db_upd_bpts: Interface.db_upd_bpts_sty-> Interface.db_upd_bpts_rty query
+val db_continue: Interface.db_continue_sty-> Interface.db_continue_rty query
 
 val stop_worker: Interface.stop_worker_sty-> Interface.stop_worker_rty query
 
@@ -183,6 +211,9 @@ val check_connection : string list -> unit
     may terminate coqide in case of trouble *)
 
 val interrupter : (int -> unit) ref
+val breaker : (int -> unit) ref
+val send_break : coqtop -> unit
+
 val save_all : (unit -> unit) ref
 
 (* Flags to be used for ideslave *)

--- a/ide/coqide/coqOps.ml
+++ b/ide/coqide/coqOps.ml
@@ -324,7 +324,7 @@ object(self)
 
   method scroll_to_start_of_input () =
     let start = buffer#get_iter_at_mark (`NAME "start_of_input") in
-    ignore (script#scroll_to_iter ~use_align:true ~yalign:0. start)
+    ignore (script#scroll_to_iter start)
 
   method set_forward_clear_db_highlight f =
     forward_clear_db_highlight <- f

--- a/ide/coqide/coqOps.mli
+++ b/ide/coqide/coqOps.mli
@@ -18,6 +18,12 @@ object
   method process_next_phrase : unit task
   method process_db_cmd : string ->
     next:(Interface.db_cmd_rty Interface.value -> unit task) -> unit task
+  method process_db_loc :
+    next:(Interface.db_loc_rty Interface.value -> unit task) -> unit task
+  method process_db_upd_bpts : ((string * int) * bool) list ->
+    next:(Interface.db_upd_bpts_rty Interface.value -> unit task) -> unit task
+  method process_db_continue : db_continue_opt ->
+    next:(Interface.db_continue_rty Interface.value -> unit task) -> unit task
   method process_until_end_or_error : unit task
   method handle_reset_initial : unit task
   method raw_coq_query :
@@ -36,6 +42,10 @@ object
   method handle_failure : handle_exn_rty -> unit task
 
   method destroy : unit -> unit
+  method scroll_to_start_of_input : unit -> unit
+  method set_forward_clear_db_highlight : (unit -> unit) -> unit
+  method set_forward_set_goals_of_dbg_session : (Pp.t -> unit) -> unit
+  method set_debug_goal : Pp.t -> unit
 end
 
 class coqops :

--- a/ide/coqide/coqide.ml
+++ b/ide/coqide/coqide.ml
@@ -768,9 +768,8 @@ let maybe_update_breakpoints () =
 module Nav = struct
   let forward_one _ =
     maybe_update_breakpoints ();
-    if not (resume_debugger Interface.StepOver) then begin
+    if not (resume_debugger Interface.StepOver) then
       send_to_coq (fun sn -> sn.coqops#process_next_phrase)
-    end
   let continue _ = maybe_update_breakpoints ();
     ignore (resume_debugger Interface.Continue)
   let step_in _ = maybe_update_breakpoints ();
@@ -1069,7 +1068,8 @@ let toggle_breakpoint_i sn =
   | None -> ()
 
 let all_sessions_ready _ =
-  List.fold_left (fun rdy sn -> rdy && Coq.is_ready sn.coqtop) true notebook#pages
+  List.fold_left (fun rdy sn -> rdy && Coq.is_ready_or_stopped_in_debugger sn.coqtop)
+      true notebook#pages
 
 let toggle_breakpoint _ =
   if all_sessions_ready () then

--- a/ide/coqide/coqide.mli
+++ b/ide/coqide/coqide.mli
@@ -24,10 +24,6 @@ val read_coqide_args : string list -> string list
 (** Prepare the widgets, load the given files in tabs *)
 val main : string list -> GWindow.window
 
-(** Function to save anything and kill all coqtops
-    @return [false] if you're allowed to quit. *)
-val forbid_quit : unit -> bool
-
 (** Terminate coqide after closing all coqtops and waiting
     for their death *)
 val close_and_quit : unit -> unit

--- a/ide/coqide/coqide_ui.ml
+++ b/ide/coqide/coqide_ui.ml
@@ -91,6 +91,11 @@ let init () =
 \n    <menuitem action='Set diff' />\
 \n    <menuitem action='Set removed diff' />\
 \n    <menuitem action='Show Proof Diffs' />\
+\n    <menuitem action='Toggle breakpoint' />\
+\n    <menuitem action='Continue' />\
+\n    <menuitem action='Step in' />\
+\n    <menuitem action='Step out' />\
+\n    <menuitem action='Break' />\
 \n  </menu>\
 \n  <menu action='Navigation'>\
 \n    <menuitem action='Forward' />\
@@ -145,6 +150,7 @@ let init () =
 \n    <menuitem action='Browse Coq Library' />\
 \n    <menuitem action='Help for keyword' />\
 \n    <menuitem action='Help for μPG mode' />\
+\n    <menuitem action='Memory usage' />\
 \n    <separator />\
 \n    <menuitem name='Abt' action='About Coq' />\
 \n  </menu>\

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -365,6 +365,59 @@ let debug_cmd = ref ""
 let db_cmd cmd =
   debug_cmd := cmd
 
+let db_loc () =
+  let open Loc in
+  let open DebugHook in
+  match debugger_state.cur_loc with
+  | Some {fname=ToplevelInput; bp; ep} ->
+    Some ("ToplevelInput", [bp; ep])
+  | Some {fname=InFile {dirpath=None; file}; bp; ep} ->
+    Some (file, [bp; ep])  (* for Load command *)
+  | Some {fname=InFile {dirpath=Some dirpath}; bp; ep} ->
+    (* todo: check what's in Loc.t on Windows *)
+    let open Names in
+    let dirpath = DirPath.make
+        (List.rev_map (fun i -> Id.of_string i) (String.split_on_char '.' dirpath)) in
+    let pfx = DirPath.make (List.tl (DirPath.repr dirpath)) in
+    let paths = Loadpath.find_with_logical_path pfx in
+    let basename = match DirPath.repr dirpath with
+    | hd :: tl -> (Id.to_string hd) ^ ".v"
+    | [] -> ""
+    in
+    let vs_files = List.map (fun p -> (Filename.concat (Loadpath.physical p) basename)) paths in
+    let filtered = List.filter (fun p -> Sys.file_exists p) vs_files in
+    begin match filtered with
+    | [] -> (* todo: maybe tweak this later to allow showing a popup dialog in the GUI *)
+      let msg = Pp.(fnl () ++ str "Unable to locate source code for module " ++
+                      str (Names.DirPath.to_string dirpath)) in
+      let msg = if vs_files = [] then msg else
+        (List.fold_left (fun msg f -> msg ++ fnl() ++ str f) (msg ++ str " in:") vs_files) in
+      Feedback.msg_warning msg;
+      None
+    | [f] -> Some (f, [bp; ep])
+    | f :: tl ->
+      let msg = Pp.(fnl () ++ str "Multiple files found matching module " ++
+          str (Names.DirPath.to_string dirpath) ++ str ":") in
+      let msg = List.fold_left (fun msg f -> msg ++ fnl() ++ str f) msg vs_files in
+      Feedback.msg_warning msg;
+      Some (f, [bp; ep]) (* be arbitrary unless we can tell which file was loaded *)
+    end
+  | _ -> None
+
+let db_upd_bpts updates =
+  let open DebugHook in
+  List.iter (fun op ->
+      let ((file, offset), opt) = op in
+      let bp = { file; offset } in
+      match opt with
+      | true ->
+        ide_breakpoints := IBPSet.add bp !ide_breakpoints;
+        DebugHook.update_bpt true bp
+      | false ->
+        ide_breakpoints := IBPSet.remove bp !ide_breakpoints;
+        DebugHook.update_bpt false bp
+    ) updates
+
 let get_options () =
   let table = Goptions.get_tables () in
   let fold key state accu = (key, export_option_state state) :: accu in

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -29,7 +29,9 @@ let catch_break = ref false
 
 let init_signal_handler () =
   let f _ = if !catch_break then raise Sys.Break else Control.interrupt := true in
-  Sys.set_signal Sys.sigint (Sys.Signal_handle f)
+  Sys.set_signal Sys.sigint (Sys.Signal_handle f);
+  Sys.set_signal Sys.sigusr1 (Sys.Signal_handle
+    (fun _ -> Control.break := true))
 
 let pr_with_pid s = Printf.eprintf "[pid %d] %s\n%!" (Unix.getpid ()) s
 
@@ -76,9 +78,11 @@ let ide_doc = ref None
 let get_doc () = Option.get !ide_doc
 let set_doc doc = ide_doc := Some doc
 
-let add ((s,eid),(sid,verbose)) =
+let add (((s,eid),(sid,verbose)),off) =
   let doc = get_doc () in
-  let pa = Pcoq.Parsable.make (Stream.of_string s) in
+  let open Loc in
+  let loc = { (initial ToplevelInput) with bp = off } in
+  let pa = Pcoq.Parsable.make ~loc (Stream.of_string s) in
   match Stm.parse_sentence ~doc sid ~entry:Pvernac.main_entry pa with
   | None -> assert false (* s may not be empty *)
   | Some ast ->
@@ -87,7 +91,7 @@ let add ((s,eid),(sid,verbose)) =
     let rc = match rc with `NewTip -> CSig.Inl () | `Unfocus id -> CSig.Inr id in
     ide_cmd_warns ~id:newid ast;
     (* All output is sent through the feedback mechanism rather than stdout/stderr *)
-    newid, (rc, "")
+    newid, rc
 
 let edit_at id =
   let doc = get_doc () in
@@ -360,10 +364,10 @@ let proof_diff (diff_opt, sid) =
       let old = Stm.get_prev_proof ~doc sid in
       Proof_diffs.diff_proofs ~diff_opt ?old proof
 
-let debug_cmd = ref ""
+let debug_cmd = ref DebugHook.Action.Ignore
 
 let db_cmd cmd =
-  debug_cmd := cmd
+  debug_cmd := DebugHook.Action.Command cmd
 
 let db_loc () =
   let open Loc in
@@ -373,8 +377,7 @@ let db_loc () =
     Some ("ToplevelInput", [bp; ep])
   | Some {fname=InFile {dirpath=None; file}; bp; ep} ->
     Some (file, [bp; ep])  (* for Load command *)
-  | Some {fname=InFile {dirpath=Some dirpath}; bp; ep} ->
-    (* todo: check what's in Loc.t on Windows *)
+  | Some {fname=InFile {dirpath=(Some dirpath)}; bp; ep} ->
     let open Names in
     let dirpath = DirPath.make
         (List.rev_map (fun i -> Id.of_string i) (String.split_on_char '.' dirpath)) in
@@ -402,7 +405,16 @@ let db_loc () =
       Feedback.msg_warning msg;
       Some (f, [bp; ep]) (* be arbitrary unless we can tell which file was loaded *)
     end
-  | _ -> None
+  | _ -> None (* nothing to highlight, e.g. not in a .v file *)
+
+let db_continue opt =
+  let open DebugHook.Action in
+  debug_cmd := match opt with
+  | Interface.StepIn -> StepIn
+  | Interface.StepOver -> StepOver
+  | Interface.StepOut -> StepOut
+  | Interface.Continue -> Continue
+  | Interface.Interrupt -> Interrupt
 
 let db_upd_bpts updates =
   let open DebugHook in
@@ -507,7 +519,10 @@ let eval_call c =
     Interface.status = interruptible status;
     Interface.search = interruptible search;
     Interface.proof_diff = interruptible proof_diff;
-    Interface.db_cmd = interruptible db_cmd;   (* todo: interruptible or not? *)
+    Interface.db_cmd = db_cmd;
+    Interface.db_loc = db_loc;
+    Interface.db_upd_bpts = db_upd_bpts;
+    Interface.db_continue = db_continue;
     Interface.get_options = interruptible get_options;
     Interface.set_options = interruptible set_options;
     Interface.mkcases = interruptible idetop_make_cases;
@@ -615,18 +630,23 @@ let loop ( { Coqtop.run_mode; color_mode },_) ~opts:_ state =
   (* XXX: no need to have a ref here *)
   let ltac_debug_parse () =
     let raw_cmd =
+      debug_cmd := DebugHook.Action.Ignore;
       process_xml_msg xml_ic xml_oc out_ch;
       !debug_cmd
     in
     let open DebugHook in
-    match Action.parse raw_cmd with
-    | Ok act -> act
-    | Error error -> ltac_debug_answer (Answer.Output (str error)); Action.Failed
+    match raw_cmd with
+    | Action.Command cmd ->
+      (match Action.parse cmd with
+      | Ok act -> act
+      | Error error -> ltac_debug_answer (Answer.Output (str error)); Action.Failed)
+    | act -> act
   in
 
   DebugHook.Intf.(set
       { read_cmd = ltac_debug_parse
       ; submit_answer = ltac_debug_answer
+      ; isTerminal = false;
       });
 
   while not !quit do

--- a/ide/coqide/minilib.ml
+++ b/ide/coqide/minilib.ml
@@ -17,7 +17,6 @@ type level = [
   | `DEBUG
   | `INFO
   | `NOTICE
-  | `PROMPT
   | `WARNING
   | `ERROR
   | `FATAL ]
@@ -38,7 +37,6 @@ let log_pp ?(level = `DEBUG) msg =
   | `DEBUG -> "DEBUG"
   | `INFO -> "INFO"
   | `NOTICE -> "NOTICE"
-  | `PROMPT -> "PROMPT"
   | `WARNING -> "WARNING"
   | `ERROR -> "ERROR"
   | `FATAL -> "FATAL"

--- a/ide/coqide/minilib.mli
+++ b/ide/coqide/minilib.mli
@@ -17,7 +17,6 @@ type level = [
   | `DEBUG
   | `INFO
   | `NOTICE
-  | `PROMPT
   | `WARNING
   | `ERROR
   | `FATAL ]

--- a/ide/coqide/preferences.ml
+++ b/ide/coqide/preferences.ml
@@ -419,16 +419,6 @@ let attach_bg (pref : string preference) (tag : GText.tag) =
 
 let attach_fg (pref : string preference) (tag : GText.tag) =
   attach_tag pref tag (fun c -> `FOREGROUND c)
-
-let processing_color =
-  new preference ~name:["processing_color"] ~init:"light blue" ~repr:Repr.(string)
-
-let incompletely_processed_color =
-  new preference ~name:["incompletely_processed_color"] ~init:"light sky blue" ~repr:Repr.(string)
-
-let _ = attach_bg processing_color Tags.Script.to_process
-let _ = attach_bg incompletely_processed_color Tags.Script.incomplete
-
 let tags = ref Util.String.Map.empty
 
 let list_tags () = !tags
@@ -523,6 +513,29 @@ let processed_color =
 
 let _ = attach_bg processed_color Tags.Script.processed
 let _ = attach_bg processed_color Tags.Proof.highlight
+
+let processing_color =
+  new preference ~name:["processing_color"] ~init:"light blue" ~repr:Repr.(string)
+
+let incompletely_processed_color =
+  new preference ~name:["incompletely_processed_color"] ~init:"light sky blue" ~repr:Repr.(string)
+
+let _ = attach_bg processing_color Tags.Script.to_process
+let _ = attach_bg incompletely_processed_color Tags.Script.incomplete
+
+let breakpoint_color =
+  new preference ~name:["breakpoint_color"] ~init:"#db5860" ~repr:Repr.(string)
+let white = (* worth showing on preferences menu?? *)
+  new preference ~name:["white"] ~init:"white" ~repr:Repr.(string)
+
+let _ = attach_bg breakpoint_color Tags.Script.breakpoint
+let _ = attach_fg white Tags.Script.breakpoint
+
+let db_stopping_point_color =
+  new preference ~name:["db_stopping_point_color"] ~init:"#2154a6" ~repr:Repr.(string)
+
+let _ = attach_bg db_stopping_point_color Tags.Script.debugging
+let _ = attach_fg white Tags.Script.debugging
 
 let error_color =
   new preference ~name:["error_color"] ~init:"#FFCCCC" ~repr:Repr.(string)
@@ -785,6 +798,8 @@ let configure ?(apply=(fun () -> ())) parent =
       ("Background color of processed text", processed_color);
       ("Background color of text being processed", processing_color);
       ("Background color of incompletely processed Qed", incompletely_processed_color);
+      ("Background color of breakpoints", breakpoint_color);
+      ("Background color of debugger stopping point", db_stopping_point_color);
       ("Background color of errors", error_color);
       ("Foreground color of errors", error_fg_color);
     ] in

--- a/ide/coqide/protocol/interface.ml
+++ b/ide/coqide/protocol/interface.ml
@@ -114,6 +114,14 @@ type coq_info = {
   compile_date : string;
 }
 
+(* a subset of DebugHook.Action.t *)
+type db_continue_opt =
+  | StepIn
+  | StepOver
+  | StepOut
+  | Continue
+  | Interrupt
+
 (** Calls result *)
 
 type location = (int * int) option (* start and end of the error *)
@@ -133,18 +141,16 @@ type ('a, 'b) union = ('a, 'b) Util.union
 
 (* Request/Reply message protocol between Coq and CoqIDE *)
 
-(**  [add ((s,eid),(sid,v))] adds the phrase [s] with edit id [eid]
-     on top of the current edit position (that is asserted to be [sid])
-     verbosely if [v] is true.  The response [(id,(rc,s)] is the new state
+(**  [add (((s,eid),(sid,v)), off)] adds the phrase [s] with edit id [eid]
+     on top of the current edit position (that is asserted to be [sid]).
+     [v] set to true indicates "verbose".  The response [(id,rc)] is the new state
      [id] assigned to the phrase. [rc] is [Inl] if the new
      state id is the tip of the edit point, or [Inr tip] if the new phrase
-     closes a focus and [tip] is the new edit tip
-
-     [s] used to contain Coq's console output and has been deprecated
-     in favor of sending feedback, it will be removed in a future
-     version of the protocol.  *)
-type add_sty = (string * edit_id) * (state_id * verbose)
-type add_rty = state_id * ((unit, state_id) union * string)
+     closes a focus and [tip] is the new edit tip.  [off] is the offset of
+     phrase in the buffer, needed to return the correct location for [s]
+     to the debugger *)
+type add_sty = ((string * edit_id) * (state_id * verbose)) * int
+type add_rty = state_id * (unit, state_id) union
 
 (** [edit_at id] declares the user wants to edit just after [id].
     The response is [Inl] if the document has been rewound to that point,
@@ -196,6 +202,18 @@ type proof_diff_rty = Pp.t
 (** A debugger command *)
 type db_cmd_sty = string
 type db_cmd_rty = unit
+
+(** fetch the loc of the current stop point *)
+type db_loc_sty = unit
+type db_loc_rty = (string * int list) option
+
+(** update one or more breakpoints in the specified file *)
+type db_upd_bpts_sty = ((string * int) * bool) list
+type db_upd_bpts_rty = unit
+
+(** continue execution (in various ways) *)
+type db_continue_sty = db_continue_opt
+type db_continue_rty = unit
 
 (** Retrieve the list of options of the current toplevel *)
 type get_options_sty = unit
@@ -264,6 +282,9 @@ type handler = {
   annotate    : annotate_sty    -> annotate_rty;
   proof_diff  : proof_diff_sty  -> proof_diff_rty;
   db_cmd      : db_cmd_sty      -> db_cmd_rty;
+  db_loc      : db_loc_sty      -> db_loc_rty;
+  db_upd_bpts : db_upd_bpts_sty -> db_upd_bpts_rty;
+  db_continue : db_continue_sty -> db_continue_rty;
   handle_exn  : handle_exn_sty  -> handle_exn_rty;
   init        : init_sty        -> init_rty;
   quit        : quit_sty        -> quit_rty;

--- a/ide/coqide/protocol/xmlprotocol.mli
+++ b/ide/coqide/protocol/xmlprotocol.mli
@@ -39,6 +39,9 @@ val print_ast   : print_ast_sty   -> print_ast_rty call
 val annotate    : annotate_sty    -> annotate_rty call
 val proof_diff  : proof_diff_sty  -> proof_diff_rty call
 val db_cmd      : db_cmd_sty      -> db_cmd_rty call
+val db_loc      : db_loc_sty      -> db_loc_rty call
+val db_upd_bpts : db_upd_bpts_sty -> db_upd_bpts_rty call
+val db_continue : db_continue_sty -> db_continue_rty call
 
 val abstract_eval_call : handler -> 'a call -> 'a value
 

--- a/ide/coqide/session.ml
+++ b/ide/coqide/session.ml
@@ -28,6 +28,10 @@ class type control =
 
 type errpage = (int * string) list page
 type jobpage = string CString.Map.t page
+type breakpoint = {
+  mark_id : string;
+  mutable prev_offset : int; (* may differ from mark#offset as the script is edited *)
+}
 
 type session = {
   buffer : GText.buffer;
@@ -44,6 +48,10 @@ type session = {
   errpage : errpage;
   jobpage : jobpage;
   mutable control : control;
+  mutable abs_file_name : string option;
+  mutable debug_stop_pt : (session * int * int) option;
+  mutable breakpoints : breakpoint list;
+  mutable last_db_goals : Pp.t
 }
 
 let create_buffer () =
@@ -101,6 +109,8 @@ let create_script coqtop source_buffer =
   point. At the end, the zone between the mark and the cursor is to be
   untagged and then retagged. *)
 
+let misc () = CDebug.(get_flag misc)
+
 let set_buffer_handlers
   (buffer : GText.buffer) script (coqops : CoqOps.ops) coqtop
 =
@@ -128,7 +138,7 @@ let set_buffer_handlers
         match !running_action with
         | Some aid when aid = action -> ()
         | _ -> cancel_signal ~stop_emit:false "Coq busy" in
-    Coq.try_grab coqtop action fallback in
+    ignore @@ Coq.try_grab coqtop action fallback in
   let get_start () = buffer#get_iter_at_mark (`NAME "start_of_input") in
   let get_stop () = buffer#get_iter_at_mark (`NAME "stop_of_input") in
   let ensure_marks_exist () =
@@ -154,7 +164,7 @@ let set_buffer_handlers
       else None in
     aux it it#copy in
   let insert_cb it s = if String.length s = 0 then () else begin
-    Minilib.log ("insert_cb " ^ string_of_int it#offset);
+    if misc () then Minilib.log ("insert_cb " ^ string_of_int it#offset);
     let text_mark = add_mark it in
     let () = update_prev it in
     if it#has_tag Tags.Script.to_process then
@@ -171,7 +181,7 @@ let set_buffer_handlers
           call_coq_or_cancel_action (coqops#go_to_mark (`MARK text_mark))
     end end in
   let delete_cb ~start ~stop =
-    Minilib.log (Printf.sprintf "delete_cb %d %d" start#offset stop#offset);
+    if misc () then Minilib.log (Printf.sprintf "delete_cb %d %d" start#offset stop#offset);
     let min_iter, max_iter =
       if start#compare stop < 0 then start, stop else stop, start in
     let () = update_prev min_iter in
@@ -193,17 +203,17 @@ let set_buffer_handlers
       else aux min_iter#forward_char in
     aux min_iter in
   let begin_action_cb () =
-    Minilib.log "begin_action_cb";
+    if misc () then Minilib.log "begin_action_cb";
     action_was_cancelled := false;
     no_coq_action_required := true;
     cur_action := new_action_id ();
     let where = get_insert () in
     buffer#move_mark (`NAME "prev_insert") ~where in
   let end_action_cb () =
-    Minilib.log "end_action_cb";
+    if misc () then Minilib.log "end_action_cb";
     ensure_marks_exist ();
     if not !action_was_cancelled then begin
-      (* If coq was asked to backtrack, the clenup must be done by the
+      (* If coq was asked to backtrack, the cleanup must be done by the
          backtrack_until function, since it may move the stop_of_input
          to a point indicated by coq. *)
       if !no_coq_action_required then begin
@@ -216,7 +226,7 @@ let set_buffer_handlers
   let mark_deleted_cb m =
     match GtkText.Mark.get_name m with
     | Some "insert" -> ()
-    | Some s -> Minilib.log (s^" deleted")
+    | Some s -> if misc () then Minilib.log (s^" deleted")
     | None -> ()
   in
   let mark_set_cb it m =
@@ -225,7 +235,7 @@ let set_buffer_handlers
     let () = Ideutils.display_location ins in
     match GtkText.Mark.get_name m with
     | Some "insert" -> ()
-    | Some s -> Minilib.log (s^" moved")
+    | Some s -> if misc () then Minilib.log (s^" moved")
     | None -> ()
   in
   (* Pluging callbacks *)
@@ -335,7 +345,7 @@ let create_jobpage coqtop coqops : jobpage =
         let row = store#get_iter tp in
         let w = store#get ~row ~column:(find_string_col "Worker" columns) in
         let info () = Minilib.log ("Coq busy, discarding query") in
-        Coq.try_grab coqtop (coqops#stop_worker w) info
+        ignore @@ Coq.try_grab coqtop (coqops#stop_worker w) info
       ) in
   let tip = GMisc.label ~text:"Double click to interrupt worker" () in
   let box = GPack.vbox ~homogeneous:false () in
@@ -385,19 +395,24 @@ let dummy_control : control =
     method detach () = ()
   end
 
+let to_abs_file_name f =
+  if Filename.is_relative f then Filename.concat (Unix.getcwd ()) f else f
+
 let create file coqtop_args =
-  let basename = match file with
-    |None -> "*scratch*"
-    |Some f -> Glib.Convert.filename_to_utf8 (Filename.basename f)
+  let (basename, abs_file_name) = match file with
+    | None -> ("*scratch*", None)
+    | Some f -> (Glib.Convert.filename_to_utf8 (Filename.basename f), Some (to_abs_file_name f))
   in
   let coqtop = Coq.spawn_coqtop coqtop_args in
   let reset () = Coq.reset_coqtop coqtop in
   let buffer = create_buffer () in
   let script = create_script coqtop buffer in
+  Coq.setup_script_editable coqtop (fun v -> script#set_editable v;script#set_editable2 v);
   let proof = create_proof () in
   let messages = create_messages () in
   let segment = new Wg_Segment.segment () in
   let finder = new Wg_Find.finder basename (script :> GText.view) in
+  finder#setup_is_script_editable (fun _ -> script#editable2);
   let fops = new FileOps.fileops (buffer :> GText.buffer) file reset in
   let _ = fops#update_stats in
   let cops =
@@ -408,6 +423,19 @@ let create file coqtop_args =
   let _ = set_buffer_handlers (buffer :> GText.buffer) script cops coqtop in
   let _ = Coq.set_reset_handler coqtop cops#handle_reset_initial in
   let _ = Coq.init_coqtop coqtop cops#initialize in
+  let tab_label = GMisc.label ~text:basename () in
+(*  todo: ugly custom tooltips...*)
+(*
+  tab_label#misc#set_size_request ~height:100 ~width:200 ();
+  tab_label#misc#modify_bg [`NORMAL, `NAME "#FF0000"];
+  (match abs_file_name with
+  | Some f ->
+    GtkBase.Widget.Tooltip.set_markup tab_label#as_widget
+      ("<span background=\"yellow\" foreground=\"black\">" ^ f ^ "</span>");
+    let label2 = GMisc.label ~text:"hello?" () in
+    GtkBase.Tooltip.set_custom (label2#coerce : Gtk.tooltip) label
+  | None -> ());
+*)
   {
     buffer = (buffer :> GText.buffer);
     script=script;
@@ -419,10 +447,14 @@ let create file coqtop_args =
     coqtop=coqtop;
     command=command;
     finder=finder;
-    tab_label= GMisc.label ~text:basename ();
+    tab_label= tab_label;
     errpage=errpage;
     jobpage=jobpage;
     control = dummy_control;
+    abs_file_name = abs_file_name;
+    debug_stop_pt = None;
+    breakpoints = [];
+    last_db_goals = Pp.mt ()
   }
 
 let kill (sn:session) =

--- a/ide/coqide/session.mli
+++ b/ide/coqide/session.mli
@@ -27,6 +27,11 @@ class type control =
 type errpage = (int * string) list page
 type jobpage = string CString.Map.t page
 
+type breakpoint = {
+  mark_id : string;
+  mutable prev_offset : int;
+}
+
 type session = {
   buffer : GText.buffer;
   script : Wg_ScriptView.script_view;
@@ -42,10 +47,16 @@ type session = {
   errpage : errpage;
   jobpage : jobpage;
   mutable control : control;
+  mutable abs_file_name : string option;
+  mutable debug_stop_pt : (session * int * int) option;
+  mutable breakpoints : breakpoint list;
+  mutable last_db_goals : Pp.t
 }
 
 (** [create filename coqtop_args] *)
 val create : string option -> string list -> session
+
+val to_abs_file_name : string -> string
 
 val kill : session -> unit
 

--- a/ide/coqide/tags.ml
+++ b/ide/coqide/tags.ml
@@ -24,15 +24,18 @@ struct
   let error_bg = make_tag table ~name:"error_bg" []
   let to_process = make_tag table ~name:"to_process" []
   let processed = make_tag table ~name:"processed" []
+  let debugging = make_tag table ~name:"debugging" []
   let incomplete = make_tag table ~name:"incomplete" []
   let unjustified = make_tag table ~name:"unjustified" [`BACKGROUND "gold"]
   let tooltip = make_tag table ~name:"tooltip" [] (* debug:`BACKGROUND "blue" *)
   let ephemere =
-    [error; warning; error_bg; tooltip; processed; to_process; incomplete; unjustified]
+    [warning; error; error_bg; to_process; processed; debugging;
+     incomplete; unjustified; tooltip]
   let comment = make_tag table ~name:"comment" []
   let sentence = make_tag table ~name:"sentence" []
+  let breakpoint = make_tag table ~name:"breakpoint" []
   let edit_zone = make_tag table ~name:"edit_zone" [`UNDERLINE `SINGLE] (* for debugging *)
-  let all = edit_zone :: comment :: sentence :: ephemere
+  let all = comment :: sentence :: breakpoint :: edit_zone :: ephemere
 end
 module Proof =
 struct

--- a/ide/coqide/tags.mli
+++ b/ide/coqide/tags.mli
@@ -17,6 +17,8 @@ sig
   val error_bg : GText.tag
   val to_process : GText.tag
   val processed : GText.tag
+  val breakpoint : GText.tag
+  val debugging : GText.tag
   val incomplete : GText.tag
   val unjustified : GText.tag
   val sentence : GText.tag

--- a/ide/coqide/wg_Command.ml
+++ b/ide/coqide/wg_Command.ml
@@ -129,7 +129,7 @@ object(self)
         coqops#raw_coq_query ~route_id ~next phrase
       in
       result#set (Pp.str ("Result for command " ^ phrase ^ ":\n"));
-      Coq.try_grab coqtop process ignore
+      ignore @@ Coq.try_grab coqtop process ignore
     in
     ignore (combo#entry#connect#activate ~callback);
     ignore (ok_b#connect#clicked ~callback);

--- a/ide/coqide/wg_Completion.ml
+++ b/ide/coqide/wg_Completion.ml
@@ -129,7 +129,7 @@ class completion_provider buffer coqtop =
         let query = Coq.bind (get_semantic_completion w synt) next in
         (* If coqtop is computing, do the syntactic completion altogether *)
         let occupied () = update synt in
-        Coq.try_grab coqtop query occupied
+        ignore @@ Coq.try_grab coqtop query occupied
 
     method matched ctx = !active
 

--- a/ide/coqide/wg_Find.mli
+++ b/ide/coqide/wg_Find.mli
@@ -17,4 +17,5 @@ class finder : string -> GText.view ->
     method replace_all : unit -> unit
     method find_backward : unit -> unit
     method find_forward : unit -> unit
+    method setup_is_script_editable : (unit -> bool) -> unit
   end

--- a/ide/coqide/wg_MessageView.ml
+++ b/ide/coqide/wg_MessageView.ml
@@ -34,7 +34,6 @@ class type message_view =
     method add : Pp.t -> unit
     method add_string : string -> unit
     method set : Pp.t -> unit
-    method refresh : bool -> unit
     method push : Ideutils.logger
       (** same as [add], but with an explicit level instead of [Notice] *)
 
@@ -43,10 +42,14 @@ class type message_view =
 
     method has_selection : bool
     method get_selected_text : string
+    method editable2 : bool
+    method set_editable2 : bool -> unit
+    method set_forward_send_db_cmd : (string -> unit) -> unit
+    method set_forward_send_db_loc : (unit -> unit) -> unit
   end
 
-let forward_send_db_cmd = ref ((fun x -> failwith "forward_send_db_cmd")
-    : string -> unit)
+let forward_keystroke = ref ((fun x -> failwith "forward_keystroke")
+    : int -> bool)
 
 (* The buffer can contain prompt or feedback messages *)
 type message_entry_kind =
@@ -66,7 +69,7 @@ let message_view () : message_view =
     ~vpolicy:`AUTOMATIC ~hpolicy:`AUTOMATIC ~packing:(box#pack ~expand:true) () in
   let view = GSourceView3.source_view
     ~source_buffer:buffer ~packing:scroll#add
-    ~editable:false ~cursor_visible:false ~wrap_mode:`WORD ()
+    ~editable:false ~cursor_visible:false ~wrap_mode:`CHAR ()
   in
   let () = Gtk_parsing.fix_double_click view in
   let default_clipboard = GData.clipboard Gdk.Atom.primary in
@@ -90,12 +93,18 @@ let message_view () : message_view =
     let mark = `MARK mark in
     let width = Ideutils.textview_width view in
     Ideutils.insert_xml ~mark buffer ~tags (Richpp.richpp_of_pp width msg);
-    buffer#insert ~iter:(buffer#get_iter_at_mark mark) "\n";
+    buffer#insert ~iter:(buffer#end_iter) "\n";
     buffer#move_mark (`NAME "end_of_output") ~where:buffer#end_iter;
+    view#scroll_to_mark `INSERT; (* scroll to end *)
   in
 
+  let forward_send_db_loc = ref ((fun x -> failwith "forward_send_db_loc")
+    : unit -> unit) in
+
   (* Insert a prompt and make the buffer editable. *)
-  let insert_ltac_debug_prompt msg =
+  let insert_ltac_debug_prompt ?(refresh=false) msg =
+    if not refresh then
+      !forward_send_db_loc ();
     let tags = [] in
     let mark = `MARK mark in
     let width = Ideutils.textview_width view in
@@ -109,23 +118,63 @@ let message_view () : message_view =
     buffer#select_range ins ins;  (* avoid highlighting *)
   in
 
-  let insert_msg = function
+  let insert_msg  ?(refresh=false) = function
     | Fb (lvl,msg) -> insert_fb_msg (lvl,msg)
-    | Prompt msg -> insert_ltac_debug_prompt msg
+    | Prompt msg -> insert_ltac_debug_prompt ~refresh msg
 
   in
+
+  (* List of displayed messages *)
   let msgs : message_entry_kind list ref = ref [] in
+  let last_width = ref (-1) in
+
+  let refresh force =
+    (* We need to block updates here due to the following race:
+       insertion of messages may create a vertical scrollbar, this
+       will trigger a width change, calling refresh again and
+       going into an infinite loop. *)
+    let width = Ideutils.textview_width view  in
+    (* Could still this method race if the scrollbar changes the
+       textview_width ?? *)
+    let needed = force || !last_width <> width in
+    if needed then begin
+      last_width := width;
+      buffer#set_text "";
+      buffer#move_mark (`MARK mark) ~where:buffer#start_iter;
+      List.(iter (insert_msg ~refresh:true) (rev !msgs))
+    end
+  in
+
+  (* todo: this is crude and slow.  Improve if we're going to generate a lot of output.
+     Also verify whether msgs is still needed *)
+  let add_msg msg =
+    let max = 1000 in
+    let rec nthcdr n list = if n <= 0 then list else nthcdr (n-1) (List.tl list) in
+    if (List.length !msgs) >= max then begin
+      (* limit size of output *)
+      msgs := List.rev @@ nthcdr (max/2) (List.rev !msgs);
+      refresh true
+    end;
+    msgs := msg :: !msgs
+  in
+
   let (return, _) = GtkData.AccelGroup.parse "Return" in
   let (backspace, _) = GtkData.AccelGroup.parse "BackSpace" in
   let (delete, _) = GtkData.AccelGroup.parse "Delete" in
 
+  let forward_send_db_cmd = ref ((fun x -> failwith "forward_send_db_cmd")
+    : string -> unit) in
+
   (* Keypress handler *)
   let keypress_cb ev =
     let ev_key = GdkEvent.Key.keyval ev in
+    let state = GdkEvent.Key.state ev in
     let ins = buffer#get_iter_at_mark `INSERT in
     let eoo = buffer#get_iter_at_mark (`NAME "end_of_output") in
     let delta = ins#offset - eoo#offset in
-    if not view#editable then
+    if !forward_keystroke ev_key then
+      true (* support some function keys when Messages is detached *)
+    else if not view#editable || List.mem `CONTROL state || List.mem `MOD1 state then
       false
     else if ev_key = delete && delta < 0 then
       true (* ignore DELETE before end of output *)
@@ -143,7 +192,7 @@ let message_view () : message_view =
       end else if ev_key = return then begin
         let ins = buffer#get_iter_at_mark `INSERT in
         let cmd = buffer#get_text ~start:eoo ~stop:ins () in
-        msgs := Fb (Feedback.Notice, Pp.str cmd) :: !msgs;
+        add_msg (Fb (Feedback.Notice, Pp.str cmd));
         buffer#insert "\n";
         buffer#move_mark `INSERT ~where:buffer#end_iter;
         view#scroll_to_mark `INSERT; (* scroll to insertion point *)
@@ -164,9 +213,6 @@ let message_view () : message_view =
   let mv = object (self)
     inherit GObj.widget box#as_widget
 
-    (* List of displayed messages *)
-    val mutable last_width = -1
-
     val push = new GUtil.signal ()
 
     method source_buffer = buffer
@@ -174,32 +220,16 @@ let message_view () : message_view =
     method connect =
       new message_view_signals_impl box#as_widget push
 
-    method refresh force =
-      (* We need to block updates here due to the following race:
-         insertion of messages may create a vertical scrollbar, this
-         will trigger a width change, calling refresh again and
-         going into an infinite loop. *)
-      let width = Ideutils.textview_width view  in
-      (* Could still this method race if the scrollbar changes the
-         textview_width ?? *)
-      let needed = force || last_width <> width in
-      if needed then begin
-        last_width <- width;
-        buffer#set_text "";
-        buffer#move_mark (`MARK mark) ~where:buffer#start_iter;
-        List.(iter insert_msg (rev !msgs))
-      end
-
     method clear =
-      msgs := []; self#refresh true
+      msgs := []; refresh true
 
     method push level msg =
-      msgs := Fb (level, msg) :: !msgs;
+      add_msg (Fb (level, msg));
       insert_fb_msg (level, msg);
       push#call (level, msg)
 
     method debug_prompt msg =
-      msgs := Prompt msg :: !msgs;
+      add_msg (Prompt msg);
       insert_ltac_debug_prompt msg
 
     method add msg = self#push Feedback.Notice msg
@@ -214,10 +244,13 @@ let message_view () : message_view =
         let start, stop = buffer#selection_bounds in
         buffer#get_text ~slice:true ~start ~stop ()
       else ""
-
+    method editable2 = view#editable
+    method set_editable2 v = view#set_editable v; view#set_cursor_visible v
+    method set_forward_send_db_cmd f = forward_send_db_cmd := f
+    method set_forward_send_db_loc f = forward_send_db_loc := f
   end
   in
   (* Is there a better way to connect the signal ? *)
-  let w_cb (_ : Gtk.rectangle) = mv#refresh false in
+  let w_cb (_ : Gtk.rectangle) = refresh false in
   ignore (view#misc#connect#size_allocate ~callback:w_cb);
   mv

--- a/ide/coqide/wg_MessageView.mli
+++ b/ide/coqide/wg_MessageView.mli
@@ -24,7 +24,6 @@ class type message_view =
     method add : Pp.t -> unit
     method add_string : string -> unit
     method set : Pp.t -> unit
-    method refresh : bool -> unit
     method push : Ideutils.logger
       (** same as [add], but with an explicit level instead of [Notice] *)
 
@@ -33,8 +32,12 @@ class type message_view =
 
     method has_selection : bool
     method get_selected_text : string
+    method editable2 : bool
+    method set_editable2 : bool -> unit
+    method set_forward_send_db_cmd : (string -> unit) -> unit
+    method set_forward_send_db_loc : (unit -> unit) -> unit
   end
 
 val message_view : unit -> message_view
 
-val forward_send_db_cmd : (string -> unit) ref
+val forward_keystroke : (int -> bool) ref

--- a/ide/coqide/wg_Notebook.ml
+++ b/ide/coqide/wg_Notebook.ml
@@ -58,6 +58,10 @@ object(self)
 
   method current_term =
     List.nth term_list super#current_page
+
+  method goto_term term =
+    List.iteri (fun i sn -> if sn == term then self#goto_page i) term_list
+
 end
 
 let create make kill =

--- a/ide/coqide/wg_Notebook.mli
+++ b/ide/coqide/wg_Notebook.mli
@@ -22,6 +22,7 @@ object
   method pages : 'a list
   method remove_page : int -> unit
   method current_term : 'a
+  method goto_term : 'a -> unit
 end
 
 val create :

--- a/ide/coqide/wg_ProofView.ml
+++ b/ide/coqide/wg_ProofView.ml
@@ -21,6 +21,7 @@ class type proof_view =
     method clear : unit -> unit
     method set_goals : Interface.goals option -> unit
     method set_evars : Interface.evar list option -> unit
+    method set_debug_goal : Pp.t -> unit
   end
 
 (* tag is the tag to be hooked, item is the item covered by this tag, make_menu
@@ -218,10 +219,11 @@ let proof_view () =
   let cb ft = view#misc#modify_font (GPango.font_description_from_string ft) in
   stick text_font view cb;
 
-  let pf = object
+  let pf = object(self)
     inherit GObj.widget view#as_widget
     val mutable goals = None
     val mutable evars = None
+    val mutable debug_goal = None
     val mutable last_width = -1
 
     method source_buffer = buffer
@@ -230,9 +232,19 @@ let proof_view () =
 
     method clear () = buffer#set_text ""
 
-    method set_goals gls = goals <- gls
+    method set_goals gls = goals <- gls; debug_goal <- None
 
     method set_evars evs = evars <- evs
+
+    method set_debug_goal msg =
+      (* Appearance is a bit different from the regular goals display.
+         That's probably a feature rather than a bug--it will remind the user
+         they're in the debugger. *)
+      self#clear ();
+      debug_goal <- Some msg;
+      let tags = [] in
+      let width = Ideutils.textview_width view in
+      Ideutils.insert_xml buffer ~tags (Richpp.richpp_of_pp width msg);
 
     method refresh ~force =
       (* We need to block updates here due to the following race:
@@ -245,8 +257,11 @@ let proof_view () =
       let needed = force || last_width <> width in
       if needed then begin
         last_width <- width;
-        let dummy _ () = () in
-        display (mode_tactic dummy) view goals None evars
+        match debug_goal with
+        | None ->
+          let dummy _ () = () in
+          display (mode_tactic dummy) view goals None evars
+        | Some msg -> self#set_debug_goal msg
       end
   end
   in

--- a/ide/coqide/wg_ProofView.mli
+++ b/ide/coqide/wg_ProofView.mli
@@ -17,6 +17,7 @@ class type proof_view =
     method clear : unit -> unit
     method set_goals : Interface.goals option -> unit
     method set_evars : Interface.evar list option -> unit
+    method set_debug_goal : Pp.t -> unit
   end
 
 val proof_view : unit -> proof_view

--- a/ide/coqide/wg_ScriptView.ml
+++ b/ide/coqide/wg_ScriptView.ml
@@ -307,8 +307,17 @@ object (self)
   method editable2 = editable2
 
   method recenter_insert =
-    self#scroll_to_mark
-      ~use_align:false ~yalign:0.75 ~within_margin:0.25 `INSERT
+    let rec fwd iter =
+      if iter#is_end then iter
+      else
+        let c = iter#char in
+        if Glib.Unichar.isspace c || c = 0 then fwd (iter#forward_char)
+        else iter
+    in
+
+    let where = fwd (self#buffer#get_iter_at_mark `INSERT) in
+    ignore @@ self#scroll_to_iter
+      ~use_align:true ~yalign:0.75 ~within_margin:0.25 where
 
   (* HACK: missing gtksourceview features *)
   method! right_margin_position =

--- a/ide/coqide/wg_ScriptView.mli
+++ b/ide/coqide/wg_ScriptView.mli
@@ -20,6 +20,8 @@ object
   method clear_undo : unit -> unit
   method auto_complete : bool
   method set_auto_complete : bool -> unit
+  method set_editable2 : bool -> unit
+  method editable2 : bool
   method right_margin_position : int
   method set_right_margin_position : int -> unit
   method show_right_margin : bool
@@ -29,6 +31,8 @@ object
   method apply_unicode_binding : unit -> unit
   method recenter_insert : unit
   method proposal : string option
+  method set_debugging_highlight : int -> int -> unit
+  method clear_debugging_highlight : int -> int -> unit
 end
 
 val script_view : Coq.coqtop ->

--- a/lib/cDebug.ml
+++ b/lib/cDebug.ml
@@ -50,6 +50,8 @@ let create ~name () =
 
 let get_flag flag = !flag
 
+let set_flag flag v = flag := v
+
 let warn_unknown_debug = CWarnings.create ~name:"unknown-debug-flag" ~category:"option"
     Pp.(fun name -> str "There is no debug flag \"" ++ str name ++ str "\".")
 

--- a/lib/cDebug.mli
+++ b/lib/cDebug.mli
@@ -35,6 +35,8 @@ val create_full : name:string -> unit -> flag * t
 
 val get_flag : flag -> bool
 
+val set_flag : flag -> bool -> unit
+
 (** [get_flags] and [set_flags] use the user syntax: a comma separated
     list of activated "component" and "-component"s. [get_flags] starts
     with "all" or "-all" and lists all components after it (even if redundant). *)

--- a/lib/control.ml
+++ b/lib/control.ml
@@ -12,6 +12,9 @@
 
 let interrupt = ref false
 
+let break = ref false
+(* causes the Ltac debugger to stop at the next step *)
+
 let steps = ref 0
 
 let enable_thread_delay = ref false

--- a/lib/control.mli
+++ b/lib/control.mli
@@ -20,6 +20,9 @@ val interrupt : bool ref
 (** Coq interruption: set the following boolean reference to interrupt Coq
     (it eventually raises [Break], simulating a Ctrl-C) *)
 
+val break : bool ref
+(** Set to true to cause the Ltac debugger to stop at the next step *)
+
 val check_for_interrupt : unit -> unit
 (** Use this function as a potential yield function. If {!interrupt} has been
     set, il will raise [Sys.Break]. *)

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -1354,7 +1354,7 @@ and interp_app loc ist fv largs : Val.t Ftactic.t =
               let ist =
                 { lfun = newlfun
                 ; poly
-                ; extra = TacStore.set ist.extra f_trace trace
+                ; extra = TacStore.set ist.extra f_trace []
                 } in
               Profile_ltac.do_profile "interp_app" trace ~count_call:false
                 (catch_error_tac_loc loc false trace (val_interp (ensure_loc loc ist) body)) >>= fun v ->
@@ -1403,7 +1403,7 @@ and tactic_of_value ist vle =
       let ist = {
         lfun = lfun;
         poly;
-        extra = TacStore.set ist.extra f_trace trace; } in
+        extra = TacStore.set ist.extra f_trace []; } in
       let tac = name_if_glob appl (eval_tactic_ist ist t) in
       Profile_ltac.do_profile "tactic_of_value" trace (catch_error_tac_loc loc false trace tac)
   | VFun (appl,_,loc,vmap,vars,_) ->

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -82,11 +82,6 @@ let pr_argument_type arg =
   let Val.Dyn (tag, _) = arg in
   Val.pr tag
 
-let safe_msgnl s =
-  Proofview.NonLogical.catch
-    (Proofview.NonLogical.print_debug (s++fnl()))
-    (fun _ -> Proofview.NonLogical.print_warning (str "bug in the debugger: an exception is raised while printing debug information"++fnl()))
-
 type value = Val.t
 
 let push_appl appl args =
@@ -344,8 +339,8 @@ let is_variable env id =
 (* todo in review: these messages should go through Tactic_debug.defer_output *)
 let debugging_step ist pp = (*Tactic_debug.defer_output (fun () ->*)
   match curr_debug ist with
-  | DebugOn lev ->
-      safe_msgnl (str "Level " ++ int lev ++ str": " ++ pp () ++ fnl())
+  | DebugOn lev -> Tactic_debug.defer_output
+      (fun _ -> (str "Level " ++ int lev ++ str": " ++ pp () ++ fnl()))
   | _ -> Proofview.NonLogical.return ()
 
 let debugging_exception_step ist signal_anomaly e pp =

--- a/plugins/ltac/tactic_debug.ml
+++ b/plugins/ltac/tactic_debug.ml
@@ -8,6 +8,8 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+module StdList = List
+
 open Util
 open Names
 open Pp
@@ -37,17 +39,41 @@ type debug_info =
 let explain_logic_error e = CErrors.print e
 let explain_logic_error_no_anomaly e = CErrors.print_no_report e
 
+[@@@ocaml.warning "-32"]
+let cmd_to_str cmd =
+  let open DebugHook.Action in
+  match cmd with
+  | Continue -> "Continue"
+  | StepIn -> "StepIn"
+  | StepOver -> "StepOver"
+  | StepOut -> "StepOut"
+  | Skip -> "Skip"
+  | Interrupt -> "Interrput"
+  | Help -> "Help"
+  | RunCnt _ -> "RunCnt"
+  | RunBreakpoint _ -> "RunBreakpoint"
+  | Command _ -> "Command"
+  | Failed -> "Failed"
+  | Ignore -> "Ignore"
+[@@@ocaml.warning "+32"]
+
+let action = ref DebugHook.Action.StepOver
+
 (* Communications with the outside world *)
 module Comm = struct
 
   (* TODO: ideally we would check that the debugger hooks are
      correctly set, however we don't do this yet as debugger
-     initialiation is unconditionally done for example in coqc, which
-     doesn't support the debugger interface. Improving this would
-     require some tweaks in tacinterp which are out of scope for the
-     current refactoring. *)
-  let init () = match DebugHook.Intf.get () with
-    | Some _ -> ()
+     initialiation is unconditionally done for example in coqc.
+     Improving this would require some tweaks in tacinterp which
+     are out of scope for the current refactoring. *)
+  let init () =
+    let open DebugHook in
+    match Intf.get () with
+    | Some intf ->
+      action := if Intf.(intf.isTerminal) then Action.StepIn else Action.Continue;
+      Control.break := false;
+      ()
     | None -> ()
       (* CErrors.user_err
        *   (Pp.str "Your user interface does not support the Ltac debugger.") *)
@@ -61,9 +87,34 @@ module Comm = struct
   let prompt g = wrap (fun () -> (hook ()).submit_answer (Prompt g))
   let goal g = wrap (fun () -> (hook ()).submit_answer (Goal g))
   let output g = wrap (fun () -> (hook ()).submit_answer (Output g))
-  let read = wrap (fun () -> (hook ()).read_cmd ())
+
+  (* routines for deferring output; output is sent only if
+     the debugger stops at the next step *)
+  let out_queue = Queue.create ()
+  let defer_output f = wrap (fun () -> Queue.add f out_queue)
+  let print_deferred () = wrap (fun () ->
+    while not (Queue.is_empty out_queue)
+    do
+      (hook ()).submit_answer (Output ((Queue.pop out_queue) ()))
+    done)
+  let clear_queue () = wrap (fun () -> Queue.clear out_queue)
+
+  [@@@ocaml.warning "-32"]
+  let print g = (hook ()).submit_answer (Output (str g))
+  [@@@ocaml.warning "+32"]
+  let isTerminal () = (hook ()).isTerminal
+  let read = wrap (fun () ->
+    let rec l () =
+      let cmd = (hook ()).read_cmd () in
+      match cmd with
+      | DebugHook.Action.Ignore -> l ()
+      | _ -> action := cmd; cmd
+    in
+    l ())
 
 end
+
+let defer_output = Comm.defer_output
 
 (* Prints the goal *)
 
@@ -92,20 +143,85 @@ let help () =
      str "          s = Skip" ++ fnl() ++
      str "          x = Exit")
 
+[@@@ocaml.warning "-32"]
+let tac_loc tac =
+  let open Tacexpr in
+  let open CAst in
+  let loc, tac = tac.loc, tac.v in
+  let rv = match tac with
+  | TacAtom _ -> "TacAtom"
+  | TacThen _ -> "TacThen"
+  | TacDispatch _ -> "TacDispatch"
+  | TacExtendTac _ -> "TacExtendTac"
+  | TacThens _ -> "TacThens"
+  | TacThens3parts _ -> "TacThens3parts"
+  | TacFirst _ -> "TacFirst"
+  | TacComplete _ -> "TacComplete"
+  | TacSolve _ -> "TacSolve"
+  | TacTry _ -> "TacTry"
+  | TacOr _ -> "TacOr"
+  | TacOnce _ -> "TacOnce"
+  | TacExactlyOnce _ -> "TacExactlyOnce"
+  | TacIfThenCatch _ -> "TacIfThenCatch"
+  | TacOrelse _ -> "TacOrelse"
+  | TacDo _ -> "TacDo"
+  | TacTimeout _ -> "TacTimeout"
+  | TacTime _ -> "TacTime"
+  | TacRepeat _ -> "TacRepeat"
+  | TacProgress _ -> "TacProgress"
+  | TacShowHyps _ -> "TacShowHyps"
+  | TacAbstract _ -> "TacAbstract"
+  | TacId _ -> "TacId"
+  | TacFail _ -> "TacFail"
+  | TacLetIn _ -> "TacLetIn"
+  | TacMatch _ -> "TacMatch"
+  | TacMatchGoal _ -> "TacMatchGoal"
+  | TacFun _ -> "TacFun"
+  | TacArg _ -> "TacArg"
+  | TacSelect _ -> "TacSelect"
+  | TacML _ -> "TacML"
+  | TacAlias _ -> "TacAlias"
+  in
+(*  Printf.printf "  %s\n%!" (fst rv);*)
+  rv, loc
+
+let print_loc tac =
+  let open Loc in
+  let (desc, loc) = tac_loc tac in
+  match loc with
+  | Some loc ->
+    let src = (match loc.fname with
+    | InFile {file} -> file
+    | ToplevelInput -> "ToplevelInput")
+    in
+    Printf.sprintf "%s: %s %d %d:%d\n" desc src loc.line_nb
+      (loc.bp - loc.bol_pos_last) (loc.ep - loc.bol_pos_last)
+  | None -> Printf.sprintf "%s: loc is None" desc
+[@@@ocaml.warning "+32"]
+
+let save_loc tac =
+(*  Comm.print (print_loc tac);*)
+  DebugHook.(debugger_state.cur_loc <- CAst.(tac.loc))
+
 (* Prints the goal and the command to be executed *)
 let goal_com tac =
+  save_loc tac;
   Proofview.tclTHEN
     db_pr_goal
-    (Proofview.tclLIFT (Comm.output (str "Going to execute:" ++ fnl () ++ prtac tac)))
+    (if Comm.isTerminal () || DebugHook.(debugger_state.cur_loc) = None then
+      (Proofview.tclLIFT (Comm.output (str "Going to execute:" ++ fnl () ++ prtac tac)))
+    else
+      Proofview.tclLIFT (Proofview.NonLogical.return ()))
 
 (* [run (new_ref _)] gives us a ref shared among [NonLogical.t]
    expressions. It avoids parametrizing everything over a
    reference. *)
 let skipped = Proofview.NonLogical.run (Proofview.NonLogical.ref 0)
 let skip = Proofview.NonLogical.run (Proofview.NonLogical.ref 0)
-let breakpoint = Proofview.NonLogical.run (Proofview.NonLogical.ref None)
+let idtac_breakpt = Proofview.NonLogical.run (Proofview.NonLogical.ref None)
 
 let batch = ref false
+let prev_stack = ref (Some [])  (* previous stopping point in debugger *)
 
 open Goptions
 
@@ -118,21 +234,21 @@ let () =
 
 let prev_load_paths = ref []
 
-(* (Re-)initialize debugger *)
-let db_initialize =
+(* (Re-)initialize debugger. is_tac controls whether to set the action *)
+let db_initialize is_tac =
   let load_paths = Loadpath.get_load_paths () in
   if load_paths != !prev_load_paths then begin
     prev_load_paths := load_paths;
     DebugHook.refresh_bpts ()
   end;
   let open Proofview.NonLogical in
-  make Comm.init >>
-  (skip:=0) >> (skipped:=0) >> (breakpoint:=None)
+  let x = (skip:=0) >> (skipped:=0) >> (idtac_breakpt:=None) in
+  if is_tac then make Comm.init >> x else x
 
 (* Prints the run counter *)
-let run ini =
+let print_run_ctr print =
   let open Proofview.NonLogical in
-  if not ini then
+  if print then
     begin
       !skipped >>= fun skipped ->
       Comm.output (str "Executed expressions: " ++ int skipped ++ fnl())
@@ -144,28 +260,32 @@ let run ini =
 
 (* Prints the prompt *)
 let rec prompt level =
-  (* spiwack: avoid overriding by the open below *)
-  let runtrue = run true in
+  let runnoprint = print_run_ctr false in
     let open Proofview.NonLogical in
     let nl = if Util.(!batch) then "\n" else "" in
+    Comm.print_deferred () >>
     Comm.prompt (tag "message.prompt"
                    @@ fnl () ++ str "TcDebug (" ++ int level ++ str (") > " ^ nl)) >>
-    if Util.(!batch) then return (DebugOn (level+1)) else
+    if Util.(!batch) && Comm.isTerminal () then return (DebugOn (level+1)) else
     let exit = (skip:=0) >> (skipped:=0) >> raise (Sys.Break, Exninfo.null) in
     Comm.read >>= fun inst ->
     let open DebugHook.Action in
     match inst with
-    | Step -> return (DebugOn (level+1))
+    | Continue
+    | StepIn
+    | StepOver
+    | StepOut -> return (DebugOn (level+1))
     | Skip -> return (DebugOff)
-    | Exit -> Proofview.NonLogical.print_char '\b' >> exit
+    | Interrupt -> Proofview.NonLogical.print_char '\b' >> exit  (* todo: why the \b? *)
     | Help -> help () >> prompt level
     | RunCnt num -> (skip:=num) >> (skipped:=0) >>
-        runtrue >> return (DebugOn (level+1))
-    | RunBreakpoint s -> (breakpoint:=(Some s)) >>
-        runtrue >> return (DebugOn (level+1))
+        runnoprint >> return (DebugOn (level+1))
+    | RunBreakpoint s -> (idtac_breakpt:=(Some s)) >> (* todo: look in Continue? *)
+        runnoprint >> return (DebugOn (level+1))
+    | Command _ -> failwith "Command"  (* not possible *)
     | Failed -> prompt level
+    | Ignore -> failwith "Ignore" (* not possible *)
 
-[@@@ocaml.warning "-32"]
 let at_breakpoint tac =
   let open DebugHook in
   let open Loc in
@@ -176,6 +296,30 @@ let at_breakpoint tac =
   | Some {fname=InFile {dirpath=Some dirpath}; bp} -> checkbpt dirpath bp
   | Some {fname=ToplevelInput;                 bp} -> checkbpt "Top"   bp
   | _ -> false
+
+[@@@ocaml.warning "-32"]
+open Tacexpr
+
+let pr_call_kind n k =
+  let (loc, k) = k in
+  let kind = (match k with
+  | LtacMLCall _ -> "LtacMLCall"
+  | LtacNotationCall _ -> "LtacNotationCall"
+  | LtacNameCall l ->
+    let name = KerName.to_string l in
+    Printf.printf "%s\n%!" name; Feedback.msg_notice (Pp.str name); "LtacNameCall"
+  | LtacAtomCall _ -> "LtacAtomCall"
+  | LtacVarCall _ -> "LtacVarCall"
+  | LtacConstrInterp _ -> "LtacConstrInterp") in
+  Printf.printf "stack %d: %s\n%!" n kind
+
+let dump_stack msg stack =
+  match stack with
+  | Some stack ->
+    let s = Printf.sprintf "%s: stack len = %d" msg (StdList.length stack) in
+    Feedback.msg_notice (Pp.str s);
+    StdList.iteri pr_call_kind stack;
+  | None -> ()
 [@@@ocaml.warning "+32"]
 
 (* Prints the state and waits for an instruction *)
@@ -184,25 +328,62 @@ let at_breakpoint tac =
    be that [f] is wrapped in with "explain_logic_error". I don't think
    it serves any purpose in the current design, so we could just drop
    that. *)
-let debug_prompt lev tac f =
-  (* spiwack: avoid overriding by the open below *)
-  let runfalse = run false in
+let debug_prompt lev tac f stack =
+  let runprint = print_run_ctr true in
   let open Proofview.NonLogical in
   let (>=) = Proofview.tclBIND in
   (* What to print and to do next *)
   let newlevel =
-    Proofview.tclLIFT !skip >= fun initial_skip ->
-    if Int.equal initial_skip 0 then
-      Proofview.tclLIFT !breakpoint >= fun breakpoint ->
-      if Option.is_empty breakpoint then Proofview.tclTHEN (goal_com tac) (Proofview.tclLIFT (prompt lev))
-      else Proofview.tclLIFT(runfalse >> return (DebugOn (lev+1)))
-    else Proofview.tclLIFT begin
-      (!skip >>= fun s -> skip:=s-1) >>
-      runfalse >>
-      !skip >>= fun new_skip ->
-      (if Int.equal new_skip 0 then skipped:=0 else return ()) >>
-      return (DebugOn (lev+1))
-    end in
+    Proofview.tclLIFT !skip >= fun s ->
+(*      dump_stack "at debug_prompt" stack;*)
+      let stop_here () =
+        prev_stack.contents <- stack;
+        Proofview.tclTHEN (goal_com tac) (Proofview.tclLIFT (prompt lev))
+      in
+      let p_stack = prev_stack.contents in
+      if action.contents = DebugHook.Action.Continue && at_breakpoint tac then
+        (* todo: skip := 0 *)
+        stop_here ()
+      else if Control.break.contents then begin
+        Control.break.contents <- false;
+        stop_here ()
+      end else if s > 0 then
+        Proofview.tclLIFT ((skip := s-1) >>
+          runprint >>
+          !skip >>= fun new_skip ->
+          (if new_skip = 0 then skipped := 0 else return ()) >>
+          return (DebugOn (lev+1)))
+      else (* todo: move this block before skip logic? *)
+        Proofview.tclLIFT !idtac_breakpt >= fun idtac_breakpt ->
+          if Option.has_some idtac_breakpt then
+            Proofview.tclLIFT(runprint >> return (DebugOn (lev+1)))
+          else begin
+            let open DebugHook.Action in
+            let stop = match action.contents with
+              | Continue -> false
+              | StepIn   -> true
+              | StepOver -> (* todo: cache list lengths for performance? *)
+                            let st, st_prev = (Option.default [] stack), (Option.default [] p_stack) in
+                            let l_cur, l_prev = StdList.length st, StdList.length st_prev in
+                            if l_cur < l_prev || l_cur = 0 || l_prev = 0 then true (* stepped out *)
+                            else
+                              let peq = StdList.nth st (l_cur - l_prev) == (StdList.hd st_prev) in
+                              (l_cur > l_prev && (not peq)) ||  (* stepped out *)
+                              (l_cur = l_prev && peq)  (* stepped over *)
+              | StepOut  -> let st, st_prev = (Option.default [] stack), (Option.default [] p_stack) in
+                              let l_cur, l_prev = StdList.length st, StdList.length st_prev in
+                              if l_cur < l_prev then true
+                              else
+                                StdList.nth st (l_cur - l_prev) != (StdList.hd st_prev)
+              | _ -> failwith "action op"
+            in
+            if stop then begin
+              stop_here ()
+            end else
+              Proofview.tclLIFT (Comm.clear_queue () >>
+              return (DebugOn (lev+1)))
+          end
+    in
   newlevel >= fun newlevel ->
   (* What to execute *)
   Proofview.tclOR
@@ -211,27 +392,27 @@ let debug_prompt lev tac f =
       Proofview.tclTHEN
         (Proofview.tclLIFT begin
           (skip:=0) >> (skipped:=0) >>
-          Comm.output (str "Level " ++ int lev ++ str ": " ++ explain_logic_error reraise)
+          Comm.defer_output (fun () -> str "Level " ++ int lev ++ str ": " ++ explain_logic_error reraise)
         end)
         (Proofview.tclZERO ~info reraise)
     end
 
 let is_debug db =
   let open Proofview.NonLogical in
-  !breakpoint >>= fun breakpoint ->
-  match db, breakpoint with
+  !idtac_breakpt >>= fun idtac_breakpt ->
+  match db, idtac_breakpt with
   | DebugOff, _ -> return false
   | _, Some _ -> return false
   | _ ->
       !skip >>= fun skip ->
-      return (Int.equal skip 0)
+      return (skip = 0)
 
 (* Prints a constr *)
 let db_constr debug env sigma c =
   let open Proofview.NonLogical in
   is_debug debug >>= fun db ->
   if db then
-    Comm.output (str "Evaluated term: " ++ Printer.pr_econstr_env env sigma c)
+    Comm.defer_output (fun () -> str "Evaluated term: " ++ Printer.pr_econstr_env env sigma c)
   else return ()
 
 (* Prints the pattern rule *)
@@ -240,9 +421,9 @@ let db_pattern_rule debug env sigma num r =
   is_debug debug >>= fun db ->
   if db then
   begin
-    Comm.output
-      (str "Pattern rule " ++ int num ++ str ":" ++ fnl () ++
-       str "|" ++ spc () ++ prmatchrl env sigma r)
+    Comm.defer_output (fun () ->
+        str "Pattern rule " ++ int num ++ str ":" ++ fnl () ++
+        str "|" ++ spc () ++ prmatchrl env sigma r)
   end
   else return ()
 
@@ -256,9 +437,9 @@ let db_matched_hyp debug env sigma (id,_,c) ido =
   let open Proofview.NonLogical in
   is_debug debug >>= fun db ->
   if db then
-    Comm.output
-      (str "Hypothesis " ++ Id.print id ++ hyp_bound ido ++
-       str " has been matched: " ++ Printer.pr_econstr_env env sigma c)
+    Comm.defer_output (fun () ->
+      str "Hypothesis " ++ Id.print id ++ hyp_bound ido ++
+      str " has been matched: " ++ Printer.pr_econstr_env env sigma c)
   else return ()
 
 (* Prints the matched conclusion *)
@@ -266,8 +447,8 @@ let db_matched_concl debug env sigma c =
   let open Proofview.NonLogical in
   is_debug debug >>= fun db ->
   if db then
-    Comm.output
-      (str "Conclusion has been matched: " ++ Printer.pr_econstr_env env sigma c)
+    Comm.defer_output (fun () ->
+      str "Conclusion has been matched: " ++ Printer.pr_econstr_env env sigma c)
   else return ()
 
 (* Prints a success message when the goal has been matched *)
@@ -275,20 +456,20 @@ let db_mc_pattern_success debug =
   let open Proofview.NonLogical in
   is_debug debug >>= fun db ->
   if db then
-    Comm.output
-      (str "The goal has been successfully matched!" ++ fnl() ++
-       str "Let us execute the right-hand side part..." ++ fnl())
+    Comm.defer_output (fun () ->
+      str "The goal has been successfully matched!" ++ fnl() ++
+      str "Let us execute the right-hand side part..." ++ fnl())
   else return ()
 
-(* Prints a failure message for an hypothesis pattern *)
+(* Prints a failure message for a hypothesis pattern *)
 let db_hyp_pattern_failure debug env sigma (na,hyp) =
   let open Proofview.NonLogical in
   is_debug debug >>= fun db ->
   if db then
-    Comm.output
-      (str "The pattern hypothesis" ++ hyp_bound na ++
-       str " cannot match: " ++
-       prmatchpatt env sigma hyp)
+    Comm.defer_output (fun () ->
+      str "The pattern hypothesis" ++ hyp_bound na ++
+      str " cannot match: " ++
+      prmatchpatt env sigma hyp)
   else return ()
 
 (* Prints a matching failure message for a rule *)
@@ -296,9 +477,9 @@ let db_matching_failure debug =
   let open Proofview.NonLogical in
   is_debug debug >>= fun db ->
   if db then
-    Comm.output
-      (str "This rule has failed due to matching errors!" ++ fnl() ++
-       str "Let us try the next one...")
+    Comm.defer_output (fun () ->
+      str "This rule has failed due to matching errors!" ++ fnl() ++
+      str "Let us try the next one...")
   else return ()
 
 (* Prints an evaluation failure message for a rule *)
@@ -307,9 +488,9 @@ let db_eval_failure debug s =
   is_debug debug >>= fun db ->
   if db then
     let s = str "message \"" ++ s ++ str "\"" in
-    Comm.output
-      (str "This rule has failed due to \"Fail\" tactic (" ++
-       s ++ str ", level 0)!" ++ fnl() ++ str "Let us try the next one...")
+    Comm.defer_output (fun () ->
+      str "This rule has failed due to \"Fail\" tactic (" ++
+      s ++ str ", level 0)!" ++ fnl() ++ str "Let us try the next one...")
   else return ()
 
 (* Prints a logic failure message for a rule *)
@@ -318,11 +499,10 @@ let db_logic_failure debug err =
   is_debug debug >>= fun db ->
   if db then
   begin
-    Comm.output
-      (explain_logic_error err) >>
-    Comm.output
-      (str "This rule has failed due to a logic error!" ++ fnl() ++
-       str "Let us try the next one...")
+    Comm.defer_output (fun () -> explain_logic_error err) >>
+    Comm.defer_output (fun () ->
+      str "This rule has failed due to a logic error!" ++ fnl() ++
+      str "Let us try the next one...")
   end
   else return ()
 
@@ -332,10 +512,10 @@ let is_breakpoint brkname s = match brkname, s with
 
 let db_breakpoint debug s =
   let open Proofview.NonLogical in
-  !breakpoint >>= fun opt_breakpoint ->
+  !idtac_breakpt >>= fun opt_breakpoint ->
   match debug with
   | DebugOn lev when not (CList.is_empty s) && is_breakpoint opt_breakpoint s ->
-      breakpoint:=None
+      idtac_breakpt:=None
   | _ ->
       return ()
 

--- a/plugins/ltac/tactic_debug.mli
+++ b/plugins/ltac/tactic_debug.mli
@@ -30,10 +30,11 @@ type debug_info =
 
 (** Prints the state and waits *)
 val debug_prompt :
-  int -> glob_tactic_expr -> (debug_info -> 'a Proofview.tactic) -> 'a Proofview.tactic
+  int -> glob_tactic_expr -> (debug_info -> 'a Proofview.tactic) ->
+  Tacexpr.ltac_trace option -> 'a Proofview.tactic
 
 (** Initializes debugger *)
-val db_initialize : unit Proofview.NonLogical.t
+val db_initialize : bool -> unit Proofview.NonLogical.t
 
 (** Prints a constr *)
 val db_constr : debug_info -> env -> evar_map -> constr -> unit Proofview.NonLogical.t
@@ -80,3 +81,6 @@ val db_breakpoint : debug_info ->
 
 val extract_ltac_trace :
   ?loc:Loc.t -> Tacexpr.ltac_trace -> Pp.t Loc.located
+
+(** Prints a message only if debugger stops at the next step *)
+val defer_output : (unit -> Pp.t) -> unit Proofview.NonLogical.t

--- a/test-suite/ide/fake_ide.ml
+++ b/test-suite/ide/fake_ide.ml
@@ -191,9 +191,9 @@ module GUILogic = struct
 
   let after_add = function
     | Interface.Fail (_,_,s) -> print_error s; exit 1
-    | Interface.Good (id, (Util.Inl (), _)) ->
+    | Interface.Good (id, Util.Inl ()) ->
         Document.assign_tip_id doc id
-    | Interface.Good (id, (Util.Inr tip, _)) ->
+    | Interface.Good (id, Util.Inr tip) ->
         Document.assign_tip_id doc id;
         Document.unfocus doc;
         ignore(Document.cut_at doc tip);
@@ -240,13 +240,13 @@ let eval_print l coq =
   match l with
   | [ Tok(_,"ADD"); Top []; Tok(_,phrase) ] ->
       let eid, tip = add_sentence phrase in
-      after_add (base_eval_call (add ((phrase,eid),(tip,true))) coq)
+      after_add (base_eval_call (add (((phrase,eid),(tip,true)),0)) coq)
   | [ Tok(_,"ADD"); Top [Tok(_,name)]; Tok(_,phrase) ] ->
       let eid, tip = add_sentence ~name phrase in
-      after_add (base_eval_call (add ((phrase,eid),(tip,true))) coq)
+      after_add (base_eval_call (add (((phrase,eid),(tip,true)),0)) coq)
   | [ Tok(_,"FAILADD"); Tok(_,phrase) ] ->
       let eid, tip = add_sentence phrase in
-      after_fail coq (base_eval_call ~fail:false (add ((phrase,eid),(tip,true))) coq)
+      after_fail coq (base_eval_call ~fail:false (add (((phrase,eid),(tip,true)),0)) coq)
   | [ Tok(_,"GOALS"); ] ->
       eval_call (goals ()) coq
   | [ Tok(_,"FAILGOALS"); ] ->

--- a/toplevel/coqc.ml
+++ b/toplevel/coqc.ml
@@ -20,6 +20,7 @@ let coqc_init ((_,color_mode),_) injections ~opts =
   DebugHook.Intf.(set
     { read_cmd = Coqtop.ltac_debug_parse
     ; submit_answer = Coqtop.ltac_debug_answer
+    ; isTerminal = true
     });
   injections
 

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -144,7 +144,7 @@ let ltac_debug_parse () =
   let open DebugHook in
   let act =
     try Action.parse (read_line ())
-    with End_of_file -> Ok Action.Exit
+    with End_of_file -> Ok Action.Interrupt
   in
   match act with
   | Ok act -> act
@@ -187,6 +187,7 @@ let coqtop_init ({ run_mode; color_mode }, async_opts) injections ~opts =
   DebugHook.Intf.(set
     { read_cmd = ltac_debug_parse
     ; submit_answer = ltac_debug_answer
+    ; isTerminal = true
     });
   init_toploop opts async_opts injections
 

--- a/vernac/debugHook.ml
+++ b/vernac/debugHook.ml
@@ -77,3 +77,68 @@ module Intf = struct
   let get () = !ltac_debug_ref
 
 end
+
+(* breakpoints as used by tactic_debug *)
+type breakpoint = {
+  dirpath : string;
+  offset : int;
+}
+
+module BPSet = CSet.Make(struct
+  type t = breakpoint
+  let compare b1 b2 =
+    let c1 = Int.compare b1.offset b2.offset in
+    if c1 <> 0 then c1 else String.compare b1.dirpath b2.dirpath
+  end)
+
+let breakpoints = ref BPSet.empty
+
+(* breakpoints as defined by the debugger IDE, using absolute file names *)
+type ide_breakpoint = {
+  file : string;
+  offset : int;
+}
+
+module IBPSet = CSet.Make(struct
+  type t = ide_breakpoint
+  let compare b1 b2 =
+    let c1 = Int.compare b1.offset b2.offset in
+    if c1 <> 0 then c1 else String.compare b1.file b2.file
+  end)
+
+let ide_breakpoints = ref IBPSet.empty
+
+let update_bpt opt ide_bpt =
+  let open Names in
+  let fname = ide_bpt.file in
+  let dp =
+    if fname = "ToplevelInput" then  (* todo: or None? *)
+      DirPath.make [Id.of_string "Top"]
+    else begin (* find the DirPath matching the absolute pathname of the file *)
+      (* ? check for .v extension? *)
+      let dirname = Filename.dirname fname in
+      let basename = Filename.basename fname in
+      let base_id = Id.of_string (Filename.remove_extension basename) in
+      DirPath.make (base_id ::
+          (try
+            let p = Loadpath.find_load_path (CUnix.physical_path_of_string dirname) in
+            DirPath.repr (Loadpath.logical p)
+          with _ -> []))
+    end
+  in
+  let dirpath = DirPath.to_string dp in
+  let bp = { dirpath; offset=ide_bpt.offset } in
+  match opt with
+  | true  -> breakpoints := BPSet.add bp !breakpoints
+  | false -> breakpoints := BPSet.remove bp !breakpoints
+
+(* refresh breakpoints, for use when loadpaths are updated *)
+let refresh_bpts () =
+  breakpoints := BPSet.empty;
+  IBPSet.iter (update_bpt true) !ide_breakpoints
+
+type debugger_state = {
+  mutable cur_loc : Loc.t option
+}
+
+let debugger_state = { cur_loc=None; }

--- a/vernac/debugHook.ml
+++ b/vernac/debugHook.ml
@@ -12,15 +12,18 @@
    with their provided interface. *)
 module Action = struct
   type t =
-    | Step
-    (** Step one tactic *)
+    | StepIn
+    | StepOver
+    | StepOut
+    | Continue
     | Skip
-    (** Skip one tactic *)
-    | Exit
+    | Interrupt
     | Help
     | RunCnt of int
     | RunBreakpoint of string
+    | Command of string
     | Failed
+    | Ignore (* do nothing, read another command *)
 
   (* XXX: Could we move this to the CString utility library? *)
   let possibly_unquote s =
@@ -49,9 +52,9 @@ module Action = struct
   (* XXX: Should be moved to the clients *)
   let parse inst : (t, string) result =
     match inst with
-    | ""  -> Ok Step
+    | ""  -> Ok StepIn
     | "s" -> Ok Skip
-    | "x" -> Ok Exit
+    | "x" -> Ok Interrupt
     | "h"| "?" -> Ok Help
     | _ -> parse_complex inst
 end
@@ -70,6 +73,8 @@ module Intf = struct
     (** request a debugger command from the client *)
     ; submit_answer : Answer.t -> unit
     (** receive a debugger answer from Ltac *)
+    ; isTerminal : bool
+    (** whether the debugger is running as a terminal (non-visual) *)
     }
 
   let ltac_debug_ref : t option ref = ref None

--- a/vernac/debugHook.mli
+++ b/vernac/debugHook.mli
@@ -44,3 +44,31 @@ module Intf : sig
   val set : t -> unit
   val get : unit -> t option
 end
+
+(** breakpoints as used by tactic_debug *)
+type breakpoint = {
+  dirpath : string;
+  offset : int;
+}
+
+module BPSet : CSet.S with type elt = breakpoint
+
+val breakpoints : BPSet.t ref
+
+(** breakpoints as defined by the debugger IDE, using absolute file names *)
+type ide_breakpoint = {
+  file : string;
+  offset : int;
+}
+module IBPSet : CSet.S with type elt = ide_breakpoint
+
+val ide_breakpoints : IBPSet.t ref
+
+val update_bpt : bool -> ide_breakpoint -> unit
+val refresh_bpts : unit -> unit
+
+type debugger_state = {
+  mutable cur_loc : Loc.t option;
+}
+
+val debugger_state : debugger_state

--- a/vernac/debugHook.mli
+++ b/vernac/debugHook.mli
@@ -12,15 +12,18 @@
    with their provided interface. *)
 module Action : sig
   type t =
-    | Step
-    (** Step one tactic *)
+    | StepIn
+    | StepOver
+    | StepOut
+    | Continue
     | Skip
-    (** Skip one tactic *)
-    | Exit
+    | Interrupt
     | Help
     | RunCnt of int
     | RunBreakpoint of string
+    | Command of string
     | Failed
+    | Ignore (* do nothing, read another command *)
 
   (* XXX: Should be moved to the clients *)
   val parse : string -> (t, string) result
@@ -39,6 +42,8 @@ module Intf : sig
     (** request a debugger command from the client *)
     ; submit_answer : Answer.t -> unit
     (** receive a debugger answer from Ltac *)
+    ; isTerminal : bool
+    (** whether the debugger is running as a terminal (non-visual) *)
     }
 
   val set : t -> unit


### PR DESCRIPTION
The second Ltac debugger PR.  This version allows adding breakpoints in primary or secondary script files and highlights the statement it stops on.  It also supports resume, step over, step in and step out operations at stopping points.

Even if this has some bugs, I think it will be a big step forward for users.  For that reason, I would very much like to get this into 8.14 so they can start to get some value from it and give feedback on how to make it better.  The user documentation will set appropriate expectations, e.g. the feature is "under development" or "preliminary" and there may be known issues.  Therefore I suggest the reviewers give careful attention to anything that might disrupt users who don't use the debugger.  For debugger-specific changes, I think it's not critical to fix *everything* before merging (versus in later PRs).  I am, after all, still in the middle of the development process.

I'm looking for a volunteer who's willing to test the debugger more realistically than I can well before the 8.14 freeze.  I'll try to fix any egregious issues for 8.14 (and likely in this PR) if time permits. I don't do a lot of proofs :-(.  Perhaps @JasonGross or @MSoegtropIMC would be willing guinea pigs?

A couple details I'll mention:
- See the "to do" regarding the Ltac call stack in `Tacinterp.eval_tactic_ist`
- I added 4 entries to the `View` menu.  Surely the wrong place for them.  Maybe they should just be buttons that show in the debugger panel in a future PR?

Due to a small change to the XML `Add` message, an overlay is needed for Coqtail.

~Depends on (and incorporates with minor differences): #14220 #14224 #14354~
User documentation is in #14281
Fixes: #13967 by making the script read-only while Coq is busy or in the debugger.