### PR TITLE
Store the closedness of a term on its leave in unification matchrec.

### DIFF
--- a/test-suite/success/rewrite_closed.v
+++ b/test-suite/success/rewrite_closed.v
@@ -1,0 +1,42 @@
+From Coq Require Import Setoid Morphisms.
+
+Axiom lattice_for : Type -> Type.
+Axiom constant : forall {T : Type}, T -> lattice_for T.
+
+Axiom lattice_for_rect :
+forall [T : Type] (P : Type), (forall t : T, P) -> forall l : lattice_for T, P.
+
+#[local]
+Declare Instance lattice_for_rect_Proper_85 : forall {A},
+  Proper (forall_relation (fun _ => eq) ==> eq ==> Basics.flip Basics.impl)
+           (@lattice_for_rect A Prop) | 3.
+
+Axiom lattice_rewrite :
+  forall (A T T' : Type) (x : T -> T') (c : A -> lattice_for T)
+      (v : lattice_for A),
+    lattice_for_rect T' x (lattice_for_rect (lattice_for T) c v) =
+    lattice_for_rect T' (fun x0 : A => lattice_for_rect T' x (c x0)) v.
+
+Axiom collapse_might_be_empty : bool.
+
+Axiom PosSet : Type.
+Axiom PosSet_inter : PosSet -> PosSet -> PosSet.
+
+Goal
+forall
+  (l2 : lattice_for PosSet)
+  (l0 : lattice_for PosSet),
+  lattice_for_rect Prop
+    (fun x : PosSet =>
+     lattice_for_rect Prop
+       (fun _ : PosSet => True)
+       (lattice_for_rect (lattice_for PosSet)
+          (fun y' : PosSet =>
+           constant
+             (if collapse_might_be_empty then PosSet_inter x y' else y')) l0)) l2
+.
+Proof.
+intros.
+(* This should not capture a variable *)
+Fail rewrite lattice_rewrite.
+Abort.


### PR DESCRIPTION
We introduce a new internal type of annotated terms which are essentially a pair of a term and an annotation, in a recursive way. The annotation is a boolean standing for the closedness of the term. This guarantees a O(1) access to the underlying term, as well as a O(1) access to closedness. Building the annotation is O(n) in the term and is an upfront cost payed before entering the recursion.

This trick could be generalized to any annotation which is local, i.e. only depends on the data of the direct subterms of a term. There are various places that could benefit from it, but for the time being I do not want to introduce yet another generic term API.

Fixes #12600.