### PR TITLE
Fixes #14211: ident notation modifier wrongly classified for printing

### DIFF
--- a/doc/changelog/03-notations/14257-master+fix14211-buggy-ident-notation-modifier-for-printing-custom-entry.rst
+++ b/doc/changelog/03-notations/14257-master+fix14211-buggy-ident-notation-modifier-for-printing-custom-entry.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  :g:`ident` modifier in custom entry notations gave fatal errors at printing time
+  (`#14257 <https://github.com/coq/coq/pull/14257>`_,
+  fixes `#14211 <https://github.com/coq/coq/issues/14211>`_,
+  by Hugo Herbelin).

--- a/test-suite/bugs/closed/bug_14211.v
+++ b/test-suite/bugs/closed/bug_14211.v
@@ -1,0 +1,13 @@
+Axiom SForUp: nat -> nat.
+
+Declare Custom Entry snippet.
+
+Notation "## s " := s (at level 0, s custom snippet at level 100).
+Notation "'for' i0 " := (SForUp i0) (in custom snippet at level 0, i0 ident).
+
+(* Another check without a custom entry *)
+
+Check fun i => ## for i.
+
+Notation "'succ' i0 " := (S i0) (at level 0, i0 ident).
+Check fun i => S i.

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -340,9 +340,9 @@ let unparsing_metavar i from typs =
   let x = List.nth typs (i-1) in
   let prec,side = unparsing_precedence_of_entry_type from x in
   match x with
-  | ETConstr _ | ETGlobal | ETBigint | ETIdent ->
+  | ETConstr _ | ETGlobal | ETBigint ->
      UnpMetaVar (prec,side)
-  | ETPattern _ | ETName _ ->
+  | ETPattern _ | ETName _ | ETIdent ->
      UnpBinderMetaVar (prec,NotQuotedPattern)
   | ETBinder isopen ->
      UnpBinderMetaVar (prec,QuotedPattern)


### PR DESCRIPTION
**Kind:** bug fix 

Fixes / closes #14211.

This was visible in custom entries only because `ident` is currently supported only in custom entries.

- [X] Added / updated test-suite
- [x] Entry added in the changelog
