### PR TITLE
Fixes #14199 and other Ctrl-C issues in coqtop

### DIFF
--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -1599,7 +1599,7 @@ module Parsable = struct
       let info =
         match Loc.get_loc info with
         | Some _ -> info
-        | None -> Loc.add_loc info (get_loc ())
+        | None -> if exc = Sys.Break then info else Loc.add_loc info (get_loc ())
       in
       Exninfo.iraise (exc,info)
 

--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -1582,7 +1582,7 @@ module Parsable = struct
     let efun = entry.estart 0 in
     let ts = p.pa_tok_strm in
     let get_loc () =
-      let loc = LStream.get_loc (LStream.count ts) ts in
+      let loc = LStream.current_loc ts in
       let loc' = LStream.max_peek_loc ts in
       Loc.merge loc loc'
     in

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -275,7 +275,13 @@ let read_sentence ~state input =
        - if a Ctrl-C arrives after a valid start of sentence, do not
          discard_to_dot since Ctrl-C is the last read character and
          there is nothing left to discard. *)
-    if fst reraise <> Sys.Break then discard_to_dot ();
+    (match fst reraise with
+     | Sys.Break -> Pp.pp_with !Topfmt.err_ft (Pp.fnl ())
+     | _ ->
+        try discard_to_dot ()
+        with Sys.Break ->
+          Pp.pp_with !Topfmt.err_ft (Pp.fnl ());
+          raise Sys.Break);
     (* The caller of read_sentence does the error printing now, this
        should be re-enabled once we rely on the feedback error
        printer again *)

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -257,7 +257,7 @@ let rec discard_to_dot () =
   try
     Pcoq.Entry.parse parse_to_dot top_buffer.tokens
   with
-    | CLexer.Error.E _ -> discard_to_dot ()
+    | CLexer.Error.E _ -> (* Lexer failed *) discard_to_dot ()
     | e when CErrors.noncritical e -> ()
 
 let read_sentence ~state input =
@@ -266,7 +266,16 @@ let read_sentence ~state input =
   try Stm.parse_sentence ~doc:state.doc state.sid ~entry:G_toplevel.vernac_toplevel input
   with reraise ->
     let reraise = Exninfo.capture reraise in
-    discard_to_dot ();
+    (* When typing Ctrl-C, two situations may arise:
+       - if a lexer/parsing arrived first, the rest of the ill-formed
+         sentence needs to be discarded, and, if Ctrl-C is found while
+         trying to discarding (in discard_to_dot), let it bypass the
+         reporting of the parsing error and report the Sys.Break
+         instead.
+       - if a Ctrl-C arrives after a valid start of sentence, do not
+         discard_to_dot since Ctrl-C is the last read character and
+         there is nothing left to discard. *)
+    if fst reraise <> Sys.Break then discard_to_dot ();
     (* The caller of read_sentence does the error printing now, this
        should be re-enabled once we rely on the feedback error
        printer again *)

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1420,7 +1420,7 @@ let explain_exn_default = function
   | Out_of_memory -> hov 0 (str "Out of memory.")
   | Stack_overflow -> hov 0 (str "Stack overflow.")
   | CErrors.Timeout -> hov 0 (str "Timeout!")
-  | Sys.Break -> hov 0 (fnl () ++ str "User interrupt.")
+  | Sys.Break -> hov 0 (str "User interrupt.")
   (* Otherwise, not handled here *)
   | _ -> raise Unhandled
 


### PR DESCRIPTION
**Kind:** bug fix

Fixes / closes #14199 as well as other issues with Ctrl-C in coqtop

At the current time, the PR produces the following:
```
Coq < some-text-then-interrupt^CError:
User interrupt.
```
which is not very nicely presented. We would at least like to have `Error:` on the next line, or no `Error:` at all. I don't know well how to do that. See discussion at #14199. Cc @ejgallego.
