### PR TITLE
Tweaks for running doc_gram_verify in CI

### DIFF
--- a/Makefile.doc
+++ b/Makefile.doc
@@ -48,6 +48,13 @@ endif
 SPHINXBUILD= sphinx-build
 SPHINXBUILDDIR= doc/sphinx/_build
 
+DOCGRAMWARN ?= 0
+ifeq ($(DOCGRAMWARN),0)
+DOCGRAMWARN=-no-warn
+else
+DOCGRAMWARN=
+endif
+
 # Internal variables.
 ALLSPHINXOPTS= -d $(SPHINXBUILDDIR)/doctrees $(SPHINXOPTS)
 
@@ -288,7 +295,7 @@ doc/tools/docgram/fullGrammar: $(DOC_GRAM) $(DOC_MLGS)
 #todo: add a dependency of sphinx on updated_rsts when we're ready
 doc/tools/docgram/orderedGrammar doc/tools/docgram/updated_rsts: doc/tools/docgram/fullGrammar $(DOC_GRAM) $(DOC_EDIT_MLGS)
 	$(SHOW)'DOC_GRAM_RSTS'
-	$(HIDE)$(DOC_GRAM) -check-cmds -check-tacs $(DOC_MLGS) $(DOC_RSTS)
+	$(HIDE)$(DOC_GRAM) $(DOCGRAMWARN) -check-cmds -check-tacs $(DOC_MLGS) $(DOC_RSTS)
 
 doc/tools/docgram/updated_rsts: doc/tools/docgram/orderedGrammar
 
@@ -296,9 +303,9 @@ doc/tools/docgram/updated_rsts: doc/tools/docgram/orderedGrammar
 
 doc_gram: doc/tools/docgram/fullGrammar
 
-doc_gram_verify: doc/tools/docgram/fullGrammar
+doc_gram_verify: $(DOC_GRAM) $(DOC_MLGS)
 	$(SHOW)'DOC_GRAM_VERIFY'
-	$(HIDE)$(DOC_GRAM) -short -no-warn -verify $(DOC_MLGS) $(DOC_RSTS)
+	$(HIDE)$(DOC_GRAM) -no-warn -verify $(DOC_MLGS) $(DOC_RSTS)
 
 doc_gram_rsts: doc/tools/docgram/updated_rsts
 

--- a/doc/tools/docgram/README.md
+++ b/doc/tools/docgram/README.md
@@ -91,17 +91,29 @@ for documentation purposes:
 
 5.  For reference, the tool generates `prodnGrammar`, which has the entire grammar in the form of `prodns`.
 
+6.  The tool generates `prodnCommands` (for commands) and `prodnTactics` (for tactics).
+    The former lists all commands that are under `command` in `orderedGrammar` and
+    compares it to the `:cmd:` and `:cmdv:` given in the rst files.  The latter
+    lists all tactics that are under `simple_tactic` in the grammar and compares it
+    to the `:tacn:` and `:tacv:`.  The tags at the beginning of each line mean:
+
+    - (no tag) - the grammar and the rst match exactly and uniquely
+    - `-` - a grammar production that can't be matched to an rst file entry
+    - `+` - an rst entry that doesn't match a grammar production
+    - `v` - the rst entry is a `:cmdv:` or `:tacv:`
+    - `?` - the match between the grammar and the rst files is not unique
+
 ## How to use the tool
 
 * `make doc_gram` updates `fullGrammar`.
 
-* `make doc_gram_verify` verifies that `fullGrammar` is consistent with the `.mlg` files.
-  This is for use by CI.
+* `make doc_gram_verify` verifies that `fullGrammar`, `orderedGrammar` and `*.rst`
+  are consistent with the `.mlg` files.  This is for use by CI.
 
 * `make doc_gram_rsts` updates the `*Grammar` and `.rst` files.
 
 Changes to `fullGrammar`, `orderedGrammar` and the `.rsts` should be checked in to git.
-The other `*Grammar` files should not.
+The `prodn*` and other `*Grammar` files should not.
 
 ### Command line arguments
 


### PR DESCRIPTION
`-no-warn` now works.  I also tweaked the makefile and some cleanup/doc.  Perhaps there should be a `make doc_gram_rsts_warn` make target that still prints warnings?

The previous dependency `doc_gram_verify: doc/tools/docgram/fullGrammar` would run `doc_gram_rsts` followed by a run in verify mode, so the verify would never report a difference!

As I mentioned elsewhere, `doc_grammar.exe` is not rebuilt if `doc_grammar.ml` is changed.