### PR TITLE
Add `hex_{Z,N,positive}_scope`

### DIFF
--- a/doc/changelog/10-standard-library/14263-hex-z.rst
+++ b/doc/changelog/10-standard-library/14263-hex-z.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  ``Z``, ``positive`` and ``N`` constants can now be printed in hexadecimal by
+  opening ``hex_Z_scope``, ``hex_positive_scope``, and ``hex_N_scope``
+  respectively (`#14263 <https://github.com/coq/coq/pull/14263>`_, by Jason
+  Gross).

--- a/test-suite/output/NSyntax.out
+++ b/test-suite/output/NSyntax.out
@@ -1,0 +1,86 @@
+32%N
+     : N
+eq_refl : 42%N = 42%N
+     : 42%N = 42%N
+fun f : nat -> N => (f 0%nat + 0)%N
+     : (nat -> N) -> N
+fun x : positive => N.pos x~0
+     : positive -> N
+fun x : positive => (N.pos x + 1)%N
+     : positive -> N
+fun x : positive => N.pos x
+     : positive -> N
+fun x : positive => N.pos x~1
+     : positive -> N
+fun x : positive => (N.pos x~0 + 0)%N
+     : positive -> N
+(N.of_nat 0 + 1)%N
+     : N
+(0 + N.of_nat (0 + 0))%N
+     : N
+N.of_nat 0 = 0%N
+     : Prop
+0%N : N
+     : N
+1%N : N
+     : N
+2%N : N
+     : N
+255%N : N
+     : N
+255%N : N
+     : N
+0%N : N
+     : N
+1%N : N
+     : N
+2%N : N
+     : N
+255%N : N
+     : N
+255%N : N
+     : N
+0x2a
+     : N
+0x0
+     : N
+0x2a
+     : N
+0x0
+     : N
+0x0 : N
+     : N
+0x1 : N
+     : N
+0x2 : N
+     : N
+0xff : N
+     : N
+0xff : N
+     : N
+0x0 : N
+     : N
+0x0 : N
+     : N
+0x1 : N
+     : N
+0x2 : N
+     : N
+0xff : N
+     : N
+0xff : N
+     : N
+0x0 : N
+     : N
+0x0 : N
+     : N
+0x1 : N
+     : N
+0x2 : N
+     : N
+0xff : N
+     : N
+0xff : N
+     : N
+(0 + N.of_nat 11)%N
+     : N

--- a/test-suite/output/NSyntax.v
+++ b/test-suite/output/NSyntax.v
@@ -1,0 +1,50 @@
+Require Import NArith.
+Check 32%N.
+Check (eq_refl : 0x2a%N = 42%N).
+Check (fun f : nat -> N => (f 0%nat + 0)%N).
+Check (fun x : positive => Npos (xO x)).
+Check (fun x : positive => (Npos x + 1)%N).
+Check (fun x : positive => Npos x).
+Check (fun x : positive => Npos (xI x)).
+Check (fun x : positive => (Npos (xO x) + 0)%N).
+Check (N.of_nat 0 + 1)%N.
+Check (0 + N.of_nat (0 + 0))%N.
+Check (N.of_nat 0 = 0%N).
+Check 0x00%N : N.
+Check 0x01%N : N.
+Check 0x02%N : N.
+Check 0xff%N : N.
+Check 0xFF%N : N.
+Check 0x00%xN : N.
+Check 0x01%xN : N.
+Check 0x02%xN : N.
+Check 0xff%xN : N.
+Check 0xFF%xN : N.
+
+(* Check hexadecimal printing *)
+Open Scope hex_N_scope.
+Check 42%N.
+Check 0%N.
+Check 42%xN.
+Check 0%xN.
+Check 0x00%N : N.
+Check 0x01%N : N.
+Check 0x02%N : N.
+Check 0xff%N : N.
+Check 0xFF%N : N.
+Check 0x0%xN : N.
+Check 0x00%xN : N.
+Check 0x01%xN : N.
+Check 0x02%xN : N.
+Check 0xff%xN : N.
+Check 0xFF%xN : N.
+Check 0x0 : N.
+Check 0x00 : N.
+Check 0x01 : N.
+Check 0x02 : N.
+Check 0xff : N.
+Check 0xFF : N.
+Close Scope hex_N_scope.
+
+Require Import Arith.
+Check (0 + N.of_nat 11)%N.

--- a/test-suite/output/PosSyntax.out
+++ b/test-suite/output/PosSyntax.out
@@ -1,0 +1,86 @@
+32%positive
+     : positive
+eq_refl : 42%positive = 42%positive
+     : 42%positive = 42%positive
+fun f : nat -> positive => (f 0%nat + 1)%positive
+     : (nat -> positive) -> positive
+fun x : positive => (x~0)%positive
+     : positive -> positive
+fun x : positive => (x + 1)%positive
+     : positive -> positive
+fun x : positive => x
+     : positive -> positive
+fun x : positive => (x~1)%positive
+     : positive -> positive
+fun x : positive => (x~0 + 1)%positive
+     : positive -> positive
+(Pos.of_nat 0 + 1)%positive
+     : positive
+(1 + Pos.of_nat (0 + 0))%positive
+     : positive
+Pos.of_nat 1 = 1%positive
+     : Prop
+The command has indeed failed with message:
+Cannot interpret this number as a value of type positive
+The command has indeed failed with message:
+Cannot interpret this number as a value of type positive
+The command has indeed failed with message:
+Cannot interpret this number as a value of type positive
+1%positive : positive
+     : positive
+2%positive : positive
+     : positive
+255%positive : positive
+     : positive
+255%positive : positive
+     : positive
+1%positive : positive
+     : positive
+2%positive : positive
+     : positive
+255%positive : positive
+     : positive
+255%positive : positive
+     : positive
+0x2a
+     : positive
+0x1
+     : positive
+The command has indeed failed with message:
+Cannot interpret this number as a value of type positive
+The command has indeed failed with message:
+Cannot interpret this number as a value of type positive
+0x1 : positive
+     : positive
+0x2 : positive
+     : positive
+0xff : positive
+     : positive
+0xff : positive
+     : positive
+The command has indeed failed with message:
+Cannot interpret this number as a value of type positive
+The command has indeed failed with message:
+Cannot interpret this number as a value of type positive
+0x1 : positive
+     : positive
+0x2 : positive
+     : positive
+0xff : positive
+     : positive
+0xff : positive
+     : positive
+The command has indeed failed with message:
+Cannot interpret this number as a value of type positive
+The command has indeed failed with message:
+Cannot interpret this number as a value of type positive
+0x1 : positive
+     : positive
+0x2 : positive
+     : positive
+0xff : positive
+     : positive
+0xff : positive
+     : positive
+(1 + Pos.of_nat 11)%positive
+     : positive

--- a/test-suite/output/PosSyntax.v
+++ b/test-suite/output/PosSyntax.v
@@ -1,0 +1,50 @@
+Require Import PArith.
+Check 32%positive.
+Check (eq_refl : 0x2a%positive = 42%positive).
+Check (fun f : nat -> positive => (f 0%nat + 1)%positive).
+Check (fun x : positive => xO x).
+Check (fun x : positive => (x + 1)%positive).
+Check (fun x : positive => x).
+Check (fun x : positive => xI x).
+Check (fun x : positive => (xO x + 1)%positive).
+Check (Pos.of_nat 0 + 1)%positive.
+Check (1 + Pos.of_nat (0 + 0))%positive.
+Check (Pos.of_nat 1 = 1%positive).
+Fail Check 0%positive : positive.
+Fail Check 0x0%positive : positive.
+Fail Check 0x00%positive : positive.
+Check 0x01%positive : positive.
+Check 0x02%positive : positive.
+Check 0xff%positive : positive.
+Check 0xFF%positive : positive.
+Check 0x01%xpositive : positive.
+Check 0x02%xpositive : positive.
+Check 0xff%xpositive : positive.
+Check 0xFF%xpositive : positive.
+
+(* Check hexadecimal printing *)
+Open Scope hex_positive_scope.
+Check 42%positive.
+Check 1%positive.
+Fail Check 0x0%positive : positive.
+Fail Check 0x00%positive : positive.
+Check 0x01%positive : positive.
+Check 0x02%positive : positive.
+Check 0xff%positive : positive.
+Check 0xFF%positive : positive.
+Fail Check 0x0 : positive.
+Fail Check 0x00 : positive.
+Check 0x01 : positive.
+Check 0x02 : positive.
+Check 0xff : positive.
+Check 0xFF : positive.
+Fail Check 0x0%xpositive : positive.
+Fail Check 0x00%xpositive : positive.
+Check 0x01%xpositive : positive.
+Check 0x02%xpositive : positive.
+Check 0xff%xpositive : positive.
+Check 0xFF%xpositive : positive.
+Close Scope hex_positive_scope.
+
+Require Import Arith.
+Check (1 + Pos.of_nat 11)%positive.

--- a/test-suite/output/ZSyntax.out
+++ b/test-suite/output/ZSyntax.out
@@ -24,11 +24,125 @@ fun x : positive => (- Z.pos x~0 + 0)%Z
      : Z
 Z.of_nat 0 = 0%Z
      : Prop
+0%Z : Z
+     : Z
+0%Z : Z
+     : Z
+1%Z : Z
+     : Z
+2%Z : Z
+     : Z
+255%Z : Z
+     : Z
+255%Z : Z
+     : Z
+(- 0)%Z : Z
+     : Z
+(- 0)%Z : Z
+     : Z
+(-1)%Z : Z
+     : Z
+(-2)%Z : Z
+     : Z
+(-255)%Z : Z
+     : Z
+(-255)%Z : Z
+     : Z
+0%Z : Z
+     : Z
+0%Z : Z
+     : Z
+1%Z : Z
+     : Z
+2%Z : Z
+     : Z
+255%Z : Z
+     : Z
+255%Z : Z
+     : Z
+(- 0)%Z : Z
+     : Z
+(- 0)%Z : Z
+     : Z
+(-1)%Z : Z
+     : Z
+(-2)%Z : Z
+     : Z
+(-255)%Z : Z
+     : Z
+(-255)%Z : Z
+     : Z
+0x2a
+     : Z
+-0x2a
+     : Z
+0x0
+     : Z
+0x2a
+     : Z
+-0x2a
+     : Z
+0x0
+     : Z
+0x0 : Z
+     : Z
+0x0 : Z
+     : Z
+0x1 : Z
+     : Z
+0x2 : Z
+     : Z
+0xff : Z
+     : Z
+0xff : Z
+     : Z
+(- 0)%Z : Z
+     : Z
+(- 0)%Z : Z
+     : Z
+-0x1 : Z
+     : Z
+-0x2 : Z
+     : Z
+-0xff : Z
+     : Z
+-0xff : Z
+     : Z
+0x0 : Z
+     : Z
+0x0 : Z
+     : Z
+0x1 : Z
+     : Z
+0x2 : Z
+     : Z
+0xff : Z
+     : Z
+0xff : Z
+     : Z
+0x0 : Z
+     : Z
+0x0 : Z
+     : Z
+0x1 : Z
+     : Z
+0x2 : Z
+     : Z
+0xff : Z
+     : Z
+0xff : Z
+     : Z
+(- 0)%Z : Z
+     : Z
+(- 0)%Z : Z
+     : Z
+-0x1 : Z
+     : Z
+-0x2 : Z
+     : Z
+-0xff : Z
+     : Z
+-0xff : Z
+     : Z
 (0 + Z.of_nat 11)%Z
-     : Z
-0x2a%Z
-     : Z
-(-0x2a)%Z
-     : Z
-0x0%Z
      : Z

--- a/test-suite/output/ZSyntax.v
+++ b/test-suite/output/ZSyntax.v
@@ -12,14 +12,71 @@ Check (fun x : positive => (- Zpos (xO x) + 0)%Z).
 Check (Z.of_nat 0 + 1)%Z.
 Check (0 + Z.of_nat (0 + 0))%Z.
 Check (Z.of_nat 0 = 0%Z).
+Check 0x0%Z : Z.
+Check 0x00%Z : Z.
+Check 0x01%Z : Z.
+Check 0x02%Z : Z.
+Check 0xff%Z : Z.
+Check 0xFF%Z : Z.
+Check (-0x0)%Z : Z.
+Check (-0x00)%Z : Z.
+Check (-0x01)%Z : Z.
+Check (-0x02)%Z : Z.
+Check (-0xff)%Z : Z.
+Check (-0xFF)%Z : Z.
+Check 0x0%xZ : Z.
+Check 0x00%xZ : Z.
+Check 0x01%xZ : Z.
+Check 0x02%xZ : Z.
+Check 0xff%xZ : Z.
+Check 0xFF%xZ : Z.
+Check (-0x0)%xZ%Z : Z.
+Check (-0x00)%xZ%Z : Z.
+Check (-0x01)%xZ : Z.
+Check (-0x02)%xZ : Z.
+Check (-0xff)%xZ : Z.
+Check (-0xFF)%xZ : Z.
+
+(* Check hexadecimal printing *)
+Open Scope hex_Z_scope.
+Check 42%Z.
+Check (-42)%Z.
+Check 0%Z.
+Check 42%xZ.
+Check (-42)%xZ.
+Check 0%xZ.
+Check 0x0%Z : Z.
+Check 0x00%Z : Z.
+Check 0x01%Z : Z.
+Check 0x02%Z : Z.
+Check 0xff%Z : Z.
+Check 0xFF%Z : Z.
+Check (-0x0)%Z : Z.
+Check (-0x00)%Z : Z.
+Check (-0x01)%Z : Z.
+Check (-0x02)%Z : Z.
+Check (-0xff)%Z : Z.
+Check (-0xFF)%Z : Z.
+Check 0x0 : Z.
+Check 0x00 : Z.
+Check 0x01 : Z.
+Check 0x02 : Z.
+Check 0xff : Z.
+Check 0xFF : Z.
+Check 0x0%xZ : Z.
+Check 0x00%xZ : Z.
+Check 0x01%xZ : Z.
+Check 0x02%xZ : Z.
+Check 0xff%xZ : Z.
+Check 0xFF%xZ : Z.
+Check (-0x0)%xZ%Z : Z.
+Check (-0x00)%xZ%Z : Z.
+Check (-0x01)%xZ : Z.
+Check (-0x02)%xZ : Z.
+Check (-0xff)%xZ : Z.
+Check (-0xFF)%xZ : Z.
+Close Scope hex_Z_scope.
 
 (* Submitted by Pierre Casteran *)
 Require Import Arith.
 Check (0 + Z.of_nat 11)%Z.
-
-(* Check hexadecimal printing *)
-Definition to_num_int n := Number.IntHexadecimal (Z.to_hex_int n).
-Number Notation Z Z.of_num_int to_num_int : Z_scope.
-Check 42%Z.
-Check (-42)%Z.
-Check 0%Z.

--- a/theories/NArith/BinNat.v
+++ b/theories/NArith/BinNat.v
@@ -1107,3 +1107,7 @@ Definition N_ind_double a P f0 f2 fS2 := N.binary_ind P f0 f2 fS2 a.
 Definition N_rec_double a P f0 f2 fS2 := N.binary_rec P f0 f2 fS2 a.
 
 (** Not kept : Ncompare_n_Sm Nplus_lt_cancel_l *)
+
+(** Re-export the notation for those who just [Import BinNat] *)
+Number Notation N N.of_num_uint N.to_num_hex_uint : hex_N_scope.
+Number Notation N N.of_num_uint N.to_num_uint : N_scope.

--- a/theories/NArith/BinNatDef.v
+++ b/theories/NArith/BinNatDef.v
@@ -428,15 +428,21 @@ Definition to_hex_uint n :=
 
 Definition to_num_uint n := Number.UIntDecimal (to_uint n).
 
+Definition to_num_hex_uint n := Number.UIntHexadecimal (to_hex_uint n).
+
 Definition to_int n := Decimal.Pos (to_uint n).
 
 Definition to_hex_int n := Hexadecimal.Pos (to_hex_uint n).
 
 Definition to_num_int n := Number.IntDecimal (to_int n).
 
+Definition to_num_hex_int n := Number.IntHexadecimal (to_hex_int n).
+
+Number Notation N of_num_uint to_num_hex_uint : hex_N_scope.
 Number Notation N of_num_uint to_num_uint : N_scope.
 
 End N.
 
 (** Re-export the notation for those who just [Import NatIntDef] *)
+Number Notation N N.of_num_uint N.to_num_hex_uint : hex_N_scope.
 Number Notation N N.of_num_uint N.to_num_uint : N_scope.

--- a/theories/Numbers/BinNums.v
+++ b/theories/Numbers/BinNums.v
@@ -29,6 +29,9 @@ Bind Scope positive_scope with positive.
 Arguments xO _%positive.
 Arguments xI _%positive.
 
+Declare Scope hex_positive_scope.
+Delimit Scope hex_positive_scope with xpositive.
+
 Register positive as num.pos.type.
 Register xI as num.pos.xI.
 Register xO as num.pos.xO.
@@ -47,6 +50,9 @@ Declare Scope N_scope.
 Delimit Scope N_scope with N.
 Bind Scope N_scope with N.
 Arguments Npos _%positive.
+
+Declare Scope hex_N_scope.
+Delimit Scope hex_N_scope with xN.
 
 Register N as num.N.type.
 Register N0 as num.N.N0.
@@ -69,6 +75,9 @@ Delimit Scope Z_scope with Z.
 Bind Scope Z_scope with Z.
 Arguments Zpos _%positive.
 Arguments Zneg _%positive.
+
+Declare Scope hex_Z_scope.
+Delimit Scope hex_Z_scope with xZ.
 
 Register Z as num.Z.type.
 Register Z0 as num.Z.Z0.

--- a/theories/PArith/BinPos.v
+++ b/theories/PArith/BinPos.v
@@ -2147,3 +2147,7 @@ Qed.
  - [Pmult_nat] cannot be unfolded (unfold [Pos.iter_op] instead).
 
 *)
+
+(** Re-export the notation for those who just [Import BinPos] *)
+Number Notation positive Pos.of_num_int Pos.to_num_hex_uint : hex_positive_scope.
+Number Notation positive Pos.of_num_int Pos.to_num_uint : positive_scope.

--- a/theories/PArith/BinPosDef.v
+++ b/theories/PArith/BinPosDef.v
@@ -691,15 +691,21 @@ Definition to_hex_uint p := Hexadecimal.rev (to_little_hex_uint p).
 
 Definition to_num_uint p := Number.UIntDecimal (to_uint p).
 
+Definition to_num_hex_uint n := Number.UIntHexadecimal (to_hex_uint n).
+
 Definition to_int n := Decimal.Pos (to_uint n).
 
 Definition to_hex_int p := Hexadecimal.Pos (to_hex_uint p).
 
 Definition to_num_int n := Number.IntDecimal (to_int n).
 
+Definition to_num_hex_int n := Number.IntHexadecimal (to_hex_int n).
+
+Number Notation positive of_num_int to_num_hex_uint : hex_positive_scope.
 Number Notation positive of_num_int to_num_uint : positive_scope.
 
 End Pos.
 
 (** Re-export the notation for those who just [Import BinPosDef] *)
+Number Notation positive Pos.of_num_int Pos.to_num_hex_uint : hex_positive_scope.
 Number Notation positive Pos.of_num_int Pos.to_num_uint : positive_scope.

--- a/theories/ZArith/BinInt.v
+++ b/theories/ZArith/BinInt.v
@@ -1794,3 +1794,7 @@ Lemma Z_eq_mult n m : m = 0 -> m * n = 0.
 Proof.
  intros; now subst.
 Qed.
+
+(** Re-export the notation for those who just [Import BinInt] *)
+Number Notation Z Z.of_num_int Z.to_num_hex_int : hex_Z_scope.
+Number Notation Z Z.of_num_int Z.to_num_int : Z_scope.

--- a/theories/ZArith/BinIntDef.v
+++ b/theories/ZArith/BinIntDef.v
@@ -351,6 +351,8 @@ Definition to_hex_int n :=
 
 Definition to_num_int n := Number.IntDecimal (to_int n).
 
+Definition to_num_hex_int n := Number.IntHexadecimal (to_hex_int n).
+
 (** ** Iteration of a function
 
     By convention, iterating a negative number of times is identity.
@@ -668,9 +670,11 @@ Definition lxor a b :=
    | neg a, neg b => of_N (N.lxor (Pos.pred_N a) (Pos.pred_N b))
  end.
 
+Number Notation Z of_num_int to_num_hex_int : hex_Z_scope.
 Number Notation Z of_num_int to_num_int : Z_scope.
 
 End Z.
 
 (** Re-export the notation for those who just [Import BinIntDef] *)
+Number Notation Z Z.of_num_int Z.to_num_hex_int : hex_Z_scope.
 Number Notation Z Z.of_num_int Z.to_num_int : Z_scope.


### PR DESCRIPTION
I have no idea why these were not already present.

**Kind:** feature

- [x] Added / updated test-suite
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
- [ ] Overlay pull requests (if this breaks 3rd party developments in CI, see
https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md for details)
