### PR TITLE
Allow undefined evars during firstorder

### DIFF
--- a/plugins/firstorder/instances.ml
+++ b/plugins/firstorder/instances.ml
@@ -148,7 +148,7 @@ let left_instance_tac (inst,id) continue seq=
                             (deepen (record (id,None) seq))]];
             tclTRY assumption]
     | Real((m,t),_)->
-        let c = (m, EConstr.to_constr sigma t) in
+        let c = (m, EConstr.to_constr ~abort_on_undefined_evars:false sigma t) in
         if lookup env sigma (id,Some c) seq then
           tclFAIL 0 (Pp.str "already done")
         else

--- a/test-suite/bugs/closed/bug_14264.v
+++ b/test-suite/bugs/closed/bug_14264.v
@@ -1,0 +1,17 @@
+Axiom P : unit -> Prop.
+Axiom l : forall (x : unit), P x -> True.
+Axiom m : forall (x : unit), P x.
+
+Goal True.
+pose proof m.
+eapply l.
+firstorder.
+Abort. (* Works, no error *)
+
+Goal True.
+eapply l.
+pose proof m.
+firstorder.
+Abort.
+(* Used to give:
+Anomaly "in econstr: grounding a non evar-free term" *)


### PR DESCRIPTION
This one is a bit strange, because it depends on whether or not a term is posed before or after the introduction of an evar. As such I´m not entirely sure if this is the correct fix, or if there is a deeper problem here.

Testcase:
```
Axiom P : unit -> Prop.
Axiom l : forall (x : unit), P x -> True.
Axiom m : forall (x : unit), P x.

Goal True.
pose proof m.
eapply l.
firstorder.
Abort. (* Works, no error *)

Goal True.
eapply l.
pose proof m.
firstorder.
Abort.
(* Used to give:
Anomaly "in econstr: grounding a non evar-free term" *)
```

<!-- Keep what applies -->
**Kind:** bug fix

- [x] Added / updated test-suite