### PR TITLE
Adapt coq_makefile after the introduction of the coqnative binary.

### DIFF
--- a/doc/changelog/08-cli-tools/14265-native-vo-to-cmxs-coq-makefile.rst
+++ b/doc/changelog/08-cli-tools/14265-native-vo-to-cmxs-coq-makefile.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  `coq_makefile` now uses the `coqnative` binary to generate
+  native compilation files. Project files also understand directly the
+  `-native-compiler` flag without having to wrap it with `-arg`
+  (`#14265 <https://github.com/coq/coq/pull/14265>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/practical-tools/utilities.rst
+++ b/doc/sphinx/practical-tools/utilities.rst
@@ -70,7 +70,7 @@ A simple example of a ``_CoqProject`` file follows:
     src/bazaux.ml
     src/qux_plugin.mlpack
 
-where options ``-R``, ``-Q`` and ``-I`` are natively recognized, as well as
+where options ``-R``, ``-Q``, ``-I`` and ``-native-compiler`` are natively recognized, as well as
 file names. The lines of the form ``-arg foo`` are used in order to tell
 to literally pass an argument ``foo`` to ``coqc``: in the
 example, this allows to pass the two-word option ``-w all`` (see
@@ -79,6 +79,9 @@ example, this allows to pass the two-word option ``-w all`` (see
 Note that it is mandatory to specify a ``-R/-Q`` flag for your
 project, so its modules are properly qualified. Omitting it will
 generate object files that are not usable except for expert cases.
+
+The ``-native-compiler`` option given in the ``_CoqProject`` file will override
+the global one passed at configure time.
 
 CoqIDE, Proof-General and VSCoq all
 understand ``_CoqProject`` files and can be used to invoke Coq with the desired options.

--- a/lib/coqProject_file.mli
+++ b/lib/coqProject_file.mli
@@ -19,6 +19,7 @@ type project = {
   makefile : string option;
   install_kind  : install option;
   use_ocamlopt : bool;
+  native_compiler : native_compiler option;
 
   v_files : string sourced list;
   mli_files : string sourced list;
@@ -49,6 +50,10 @@ and install =
   | NoInstall
   | TraditionalInstall
   | UserInstall
+and native_compiler =
+| NativeYes
+| NativeNo
+| NativeOndemand
 
 val cmdline_args_to_project : warning_fn:(string -> unit) -> curdir:string -> string list -> project
 val read_project_file : warning_fn:(string -> unit) -> string -> project

--- a/test-suite/coq-makefile/native3/_CoqProject
+++ b/test-suite/coq-makefile/native3/_CoqProject
@@ -1,0 +1,11 @@
+-R src test
+-R theories test
+-I src
+-native-compiler yes
+
+src/test_plugin.mlpack
+src/test.mlg
+src/test.mli
+src/test_aux.ml
+src/test_aux.mli
+theories/test.v

--- a/test-suite/coq-makefile/native3/run.sh
+++ b/test-suite/coq-makefile/native3/run.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+NONATIVECOMP=$(grep "let native_compiler = NativeOff" ../../../config/coq_config.ml)||true
+if [[ $(which ocamlopt) && ! $NONATIVECOMP ]]; then
+
+. ../template/init.sh
+
+coq_makefile -f _CoqProject -o Makefile
+cat Makefile.conf
+make
+make html mlihtml
+make install DSTROOT="$PWD/tmp"
+#make debug
+(cd "$(find tmp -name user-contrib)" && find .) | sort > actual
+sort > desired <<EOT
+.
+./test
+./test/test.glob
+./test/test_plugin.cmi
+./test/test_plugin.cmx
+./test/test_plugin.cmxa
+./test/test_plugin.cmxs
+./test/test.v
+./test/test.vo
+./test/.coq-native
+./test/.coq-native/Ntest_test.cmi
+./test/.coq-native/Ntest_test.cmx
+./test/.coq-native/Ntest_test.cmxs
+EOT
+exec diff -u desired actual
+
+fi
+exit 0 # test skipped

--- a/test-suite/coq-makefile/native4/_CoqProject
+++ b/test-suite/coq-makefile/native4/_CoqProject
@@ -1,0 +1,11 @@
+-R src test
+-R theories test
+-I src
+-native-compiler no
+
+src/test_plugin.mlpack
+src/test.mlg
+src/test.mli
+src/test_aux.ml
+src/test_aux.mli
+theories/test.v

--- a/test-suite/coq-makefile/native4/run.sh
+++ b/test-suite/coq-makefile/native4/run.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+NONATIVECOMP=$(grep "let native_compiler = NativeOff" ../../../config/coq_config.ml)||true
+if [[ $(which ocamlopt) && ! $NONATIVECOMP ]]; then
+
+. ../template/init.sh
+
+# Shoud override the _CoqProject flag "-native-compiler no"
+export COQEXTRAFLAGS="-native-compiler yes"
+
+coq_makefile -f _CoqProject -o Makefile
+cat Makefile.conf
+make
+make html mlihtml
+make install DSTROOT="$PWD/tmp"
+#make debug
+(cd "$(find tmp -name user-contrib)" && find .) | sort > actual
+sort > desired <<EOT
+.
+./test
+./test/test.glob
+./test/test_plugin.cmi
+./test/test_plugin.cmx
+./test/test_plugin.cmxa
+./test/test_plugin.cmxs
+./test/test.v
+./test/test.vo
+./test/.coq-native
+./test/.coq-native/Ntest_test.cmi
+./test/.coq-native/Ntest_test.cmx
+./test/.coq-native/Ntest_test.cmxs
+EOT
+exec diff -u desired actual
+
+fi
+exit 0 # test skipped

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -90,6 +90,7 @@ endif
 COQC     ?= "$(COQBIN)coqc"
 COQTOP   ?= "$(COQBIN)coqtop"
 COQCHK   ?= "$(COQBIN)coqchk"
+COQNATIVE ?= "$(COQBIN)coqnative"
 COQDEP   ?= "$(COQBIN)coqdep"
 COQDOC   ?= "$(COQBIN)coqdoc"
 COQPP    ?= "$(COQBIN)coqpp"
@@ -208,8 +209,33 @@ COQEXTRAFLAGS?=
 COQCHKEXTRAFLAGS?=
 COQDOCEXTRAFLAGS?=
 
+# Find the last argument of the form "-native-compiler FLAG"
+COQUSERNATIVEFLAG:=$(strip \
+$(subst -native-compiler-,,\
+$(lastword \
+$(filter -native-compiler-%,\
+$(subst -native-compiler ,-native-compiler-,\
+$(strip $(COQEXTRAFLAGS)))))))
+
+COQFILTEREDEXTRAFLAGS:=$(strip \
+$(filter-out -native-compiler-%,\
+$(subst -native-compiler ,-native-compiler-,\
+$(strip $(COQEXTRAFLAGS)))))
+
+ifneq (,$(COQUSERNATIVEFLAG))
+  COQNATIVEFLAG="-native-compiler" "$(COQUSERNATIVEFLAG)"
+  COQDONATIVE=$(COQUSERNATIVEFLAG)
+else
+ifeq '$(COQMF_COQ_NATIVE_COMPILER_DEFAULT)' 'yes'
+  COQNATIVEFLAG="-native-compiler" "ondemand"
+  COQDONATIVE="yes"
+else
+  COQNATIVEFLAG=
+endif
+endif
+
 # these flags do NOT contain the libraries, to make them easier to overwrite
-COQFLAGS?=-q $(OTHERFLAGS) $(COQEXTRAFLAGS)
+COQFLAGS?=-q $(OTHERFLAGS) $(COQFILTEREDEXTRAFLAGS) $(COQNATIVEFLAG)
 COQCHKFLAGS?=-silent -o $(COQCHKEXTRAFLAGS)
 COQDOCFLAGS?=-interpolate -utf8 $(COQDOCEXTRAFLAGS)
 
@@ -723,6 +749,10 @@ endif
 $(VOFILES): %.vo: %.v
 	$(SHOW)COQC $<
 	$(HIDE)$(TIMER) $(COQC) $(COQDEBUG) $(TIMING_ARG) $(COQFLAGS) $(COQLIBS) $< $(TIMING_EXTRA)
+ifeq ($(COQDONATIVE), "yes")
+	$(SHOW)COQNATIVE $@
+	$(HIDE)$(COQNATIVE) $(COQLIBS) $@
+endif
 
 # FIXME ?merge with .vo / .vio ?
 $(GLOBFILES): %.glob: %.v

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -222,15 +222,18 @@ $(filter-out -native-compiler-%,\
 $(subst -native-compiler ,-native-compiler-,\
 $(strip $(COQEXTRAFLAGS)))))
 
-ifneq (,$(COQUSERNATIVEFLAG))
-  COQNATIVEFLAG="-native-compiler" "$(COQUSERNATIVEFLAG)"
-  COQDONATIVE=$(COQUSERNATIVEFLAG)
-else
-ifeq '$(COQMF_COQ_NATIVE_COMPILER_DEFAULT)' 'yes'
+COQACTUALNATIVEFLAG:=$(lastword $(COQMF_COQ_NATIVE_COMPILER_DEFAULT) $(COQMF_COQPROJECTNATIVEFLAG) $(COQUSERNATIVEFLAG))
+
+ifeq '$(COQACTUALNATIVEFLAG)' 'yes'
   COQNATIVEFLAG="-native-compiler" "ondemand"
   COQDONATIVE="yes"
 else
-  COQNATIVEFLAG=
+ifeq '$(COQACTUALNATIVEFLAG)' 'ondemand'
+  COQNATIVEFLAG="-native-compiler" "ondemand"
+  COQDONATIVE="no"
+else
+  COQNATIVEFLAG="-native-compiler" "no"
+  COQDONATIVE="no"
 endif
 endif
 


### PR DESCRIPTION
Not ready yet, I have to find a way to parse `COQEXTRAFLAGS` from within Makefile to check the status of native compilation.