### PR TITLE
Fix a discrepancy between the doc and reality of `coqworkmgr`

### DIFF
--- a/doc/sphinx/addendum/parallel-proof-processing.rst
+++ b/doc/sphinx/addendum/parallel-proof-processing.rst
@@ -231,7 +231,7 @@ one limit the number of workers, globally.
 The utility accepts the ``-j`` argument to specify the maximum number of
 workers (defaults to 2). ``coqworkmgr`` automatically starts in the
 background and prints an environment variable assignment
-like ``COQWORKMGR_SOCKET=localhost:45634``. The user must set this variable
+like ``COQWORKMGR_SOCK=localhost:45634``. The user must set this variable
 in all the shells from which Coq processes will be started. If one
 uses just one terminal running the bash shell, then
 ``export ‘coqworkmgr -j 4‘`` will do the job.


### PR DESCRIPTION
**Kind:** documentation / bug fix

Fixes / closes #????

- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).

Does this really need a changelog entry?

I noticed this when looking at https://github.com/coq/coq/blob/356e725b520b8178d7c092e3f5189e8d6c82882f/tools/coqworkmgr.ml#L180-L183

Perhaps the code should be updated rather than the documentation, though?  cc @gares 

Also, what's up with the fancy quotes in the doc at `export ‘coqworkmgr -j 4‘`?  This will not work, but I'm not sure how to get literal backticks in the doc (cc @coq/doc-maintainers )