### PR TITLE
[CI] Reactivate native-compile for some jobs

### DIFF
--- a/dev/ci/ci-color.sh
+++ b/dev/ci/ci-color.sh
@@ -7,7 +7,9 @@ ci_dir="$(dirname "$0")"
 
 git_download color
 
-export COQEXTRAFLAGS='-native-compiler no'
+ulimit -s
+ulimit -s 65536
+ulimit -s
 ( cd "${CI_BUILD_DIR}/color"
   make
 )

--- a/dev/ci/ci-coqprime.sh
+++ b/dev/ci/ci-coqprime.sh
@@ -7,7 +7,9 @@ ci_dir="$(dirname "$0")"
 
 git_download coqprime
 
-export COQEXTRAFLAGS='-native-compiler no'
+ulimit -s
+ulimit -s 65536
+ulimit -s
 ( cd "${CI_BUILD_DIR}/coqprime"
   make
   make install

--- a/dev/ci/ci-fiat_crypto.sh
+++ b/dev/ci/ci-fiat_crypto.sh
@@ -18,7 +18,6 @@ stacksize=32768
 # version of other developments
 make_args=(EXTERNAL_REWRITER=1 EXTERNAL_COQPRIME=1)
 
-export COQEXTRAFLAGS='-native-compiler no'
 ( cd "${CI_BUILD_DIR}/fiat_crypto"
   git submodule update --init --recursive
   ulimit -s $stacksize

--- a/dev/ci/ci-fiat_crypto_ocaml.sh
+++ b/dev/ci/ci-fiat_crypto_ocaml.sh
@@ -7,7 +7,6 @@ ci_dir="$(dirname "$0")"
 
 make_args=(EXTERNAL_REWRITER=1 EXTERNAL_COQPRIME=1)
 
-export COQEXTRAFLAGS='-native-compiler no'
 ( cd "${CI_BUILD_DIR}/fiat_crypto"
   make "${make_args[@]}" standalone-ocaml lite-generated-files
 )

--- a/dev/ci/ci-fiat_parsers.sh
+++ b/dev/ci/ci-fiat_parsers.sh
@@ -8,7 +8,9 @@ ci_dir="$(dirname "$0")"
 FORCE_GIT=1
 git_download fiat_parsers
 
-export COQEXTRAFLAGS='-native-compiler no'
+ulimit -s
+ulimit -s 65536
+ulimit -s
 ( cd "${CI_BUILD_DIR}/fiat_parsers"
   make parsers parsers-examples
   make fiat-core

--- a/dev/ci/ci-perennial.sh
+++ b/dev/ci/ci-perennial.sh
@@ -8,7 +8,9 @@ ci_dir="$(dirname "$0")"
 FORCE_GIT=1
 git_download perennial
 
-export COQEXTRAFLAGS='-native-compiler no'
+ulimit -s
+ulimit -s 65536
+ulimit -s
 ( cd "${CI_BUILD_DIR}/perennial"
   git submodule update --init --recursive
   make TIMED=false lite

--- a/dev/ci/ci-rewriter.sh
+++ b/dev/ci/ci-rewriter.sh
@@ -7,7 +7,6 @@ ci_dir="$(dirname "$0")"
 
 git_download rewriter
 
-export COQEXTRAFLAGS='-native-compiler no'
 ( cd "${CI_BUILD_DIR}/rewriter"
   make
   make install

--- a/dev/ci/ci-vst.sh
+++ b/dev/ci/ci-vst.sh
@@ -9,7 +9,9 @@ git_download vst
 
 export COMPCERT=bundled
 
-sed -i.bak 's/\(COQC=.*\)/\1 -native-compiler no/' "$CI_BUILD_DIR/vst/Makefile"
+ulimit -s
+ulimit -s 65536
+ulimit -s
 ( cd "${CI_BUILD_DIR}/vst"
   make IGNORECOQVERSION=true
 )


### PR DESCRIPTION
~In #13467 it was noted that Interval did not build with native-compile on the CI despite being designed to do so with a regular 8mB stack size. This appears to be due to flambda consuming much more stack. We workaround it by increasing the stack size limit.~ (interval has since been removed from CI)

We take the opportunity to also increase stack limit for the following jobs:
* color
* coqprime
* fiat_parsers
* vst
* perennial

Thus after this PR, the list of CI jobs with native-compiler no or ondemand is down to
* bedrock2
* category_theory
* compcert
* corn
* engine_bench (ondemand)
* equations
* fiat_crypto_legacy
* metacoq
* unimath

compcert seems to suffer a Makefile issue and equations give strange errors that will need to be investigated later, the remaining ones might be hopeless.

Note that hott and fiat_crypto (and rewriter) also dis-activate native-compile upstream (native-compiler=no and native-compiler=ondemand respectively).