### PR TITLE
Fixing #14283: coqdoc does not report the name of file where an error occurs

### DIFF
--- a/doc/changelog/08-cli-tools/14285-master+coqdoc-error-reports-line.rst
+++ b/doc/changelog/08-cli-tools/14285-master+coqdoc-error-reports-line.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  File name was missing in coqdoc error position reporting
+  (`#14285 <https://github.com/coq/coq/pull/14285>`_,
+  fixes `#14283 <https://github.com/coq/coq/issues/14283>`_,
+  by Arthur Charguéraud and Hugo Herbelin).

--- a/tools/coqdoc/cpretty.mll
+++ b/tools/coqdoc/cpretty.mll
@@ -1434,7 +1434,8 @@ and st_subtitle = parse
     reset ();
     let c = open_in f in
     let lb = from_channel c in
-    let lb = { lb with lex_start_p = { lb.lex_start_p with pos_fname = f } } in
+    let lb = { lb with lex_curr_p = { lb.lex_curr_p with pos_fname = f };
+                       lex_start_p = { lb.lex_start_p with pos_fname = f } } in
       (Index.current_library := m;
        Output.initialize ();
        Output.start_module ();


### PR DESCRIPTION
**Kind:** bug fix

Thanks to @charguer for diagnosis and suggested fix (see #14283)

Fixes / closes #14283.

- [x] Entry added in the changelog
