### PR TITLE
respect debug flag in Ltac2.Std.eauto

### DIFF
--- a/user-contrib/Ltac2/tac2tactics.ml
+++ b/user-contrib/Ltac2/tac2tactics.ml
@@ -402,7 +402,7 @@ let new_auto debug n lems dbs =
 let eauto debug n p lems dbs =
   let lems = List.map (fun c -> delayed_of_thunk Tac2ffi.constr c) lems in
   let dbs = Option.map (fun l -> List.map Id.to_string l) dbs in
-  Eauto.gen_eauto (Eauto.make_dimension n p) lems dbs
+  Eauto.gen_eauto ~debug (Eauto.make_dimension n p) lems dbs
 
 let typeclasses_eauto strategy depth dbs =
   let only_classes, dbs = match dbs with


### PR DESCRIPTION
**Kind:** trivial bug fix

With this PR, the snippet

```coq
Require Import Ltac2.Ltac2.

Goal (forall (a b: nat), a + b = b + a) -> forall x y: nat, x + y = y + x.
Proof.
  intros.
  Std.eauto Std.Info None None [] None.
```

now prints the same as `ltac1:(info_eauto)`, ie

```
(* info eauto: *)
simple apply H.
```

whereas before, no info output was printed.
