### PR TITLE
make sure Ltac2 module Option is available when requiring Ltac2.Ltac2

### DIFF
--- a/user-contrib/Ltac2/Ltac2.v
+++ b/user-contrib/Ltac2/Ltac2.v
@@ -10,19 +10,23 @@
 
 Require Export Ltac2.Init.
 
-Require Ltac2.Int.
-Require Ltac2.Char.
-Require Ltac2.String.
-Require Ltac2.Ident.
 Require Ltac2.Array.
-Require Ltac2.Message.
+Require Ltac2.Bool.
+Require Ltac2.Char.
 Require Ltac2.Constr.
 Require Ltac2.Control.
-Require Ltac2.Fresh.
-Require Ltac2.Pattern.
-Require Ltac2.Std.
 Require Ltac2.Env.
+Require Ltac2.Fresh.
+Require Ltac2.Ident.
 Require Ltac2.Ind.
-Require Ltac2.Printf.
+Require Ltac2.Int.
+Require Ltac2.List.
 Require Ltac2.Ltac1.
+Require Ltac2.Message.
+Require Ltac2.Option.
+Require Ltac2.Pattern.
+Require Ltac2.Printf.
+Require Ltac2.Std.
+Require Ltac2.String.
+
 Require Export Ltac2.Notations.


### PR DESCRIPTION
Fixes #14222

Also changed import order to (mostly) alphabetic so that one can compare to `ls` output.
