### PR TITLE
Add the primitive `catch_system` to the logic monad

### DIFF
--- a/engine/logic_monad.ml
+++ b/engine/logic_monad.ml
@@ -92,6 +92,12 @@ struct
         let (src, info) = Exninfo.capture src in
         h (e, info) ()
 
+  let catch_more = fun s cond h -> ();
+    fun () -> try s ()
+      with e when cond e ->
+        let (e, info) = Exninfo.capture e in
+        h (Exception e, info) ()
+
   let read_line = fun () -> try read_line () with e ->
     let (e, info) = Exninfo.capture e in
     raise (e,info) ()
@@ -193,7 +199,7 @@ struct
 
   let (>>) m f =
     { iolist = fun s nil cons ->
-      m.iolist s nil (fun () s next -> f.iolist s next cons) }
+          m.iolist s nil (fun () s next -> f.iolist s next cons) }
 
   let map f m =
     { iolist = fun s nil cons -> m.iolist s nil (fun x s next -> cons (f x) s next) }
@@ -209,6 +215,10 @@ struct
 
   let lift m =
     { iolist = fun s nil cons -> NonLogical.(m >>= fun x -> cons x s nil) }
+
+  let catch_system m cond f =
+    { iolist = fun s nil cons ->
+          NonLogical.catch_more (m.iolist s nil cons) cond (fun x -> nil (f x)) }
 
   (** State related *)
 
@@ -345,6 +355,7 @@ struct
   let break = BackState.break
   let split = BackState.split
   let repr = BackState.repr
+  let catch_system t cond = BackState.catch_system t cond (fun x -> x)
 
   (** State related. We specialize them here to ensure soundness (for reader and
       writer) and efficiency. *)

--- a/engine/logic_monad.mli
+++ b/engine/logic_monad.mli
@@ -74,6 +74,10 @@ module NonLogical : sig
 
   (** [try ... with ...] but restricted to {!Exception}. *)
   val catch : 'a t -> (Exninfo.iexn -> 'a t) -> 'a t
+
+  (** [catch_more t cond inj] catches any exception [e] satisfying [cond e].
+      We wrap [e] into [Exception] when passing to [inj] *)
+  val catch_more : 'a t -> (exn -> bool) -> (Exninfo.iexn -> 'a t) -> 'a t
   val timeout : float -> 'a t -> 'a option t
 
   (** Construct a monadified side-effect. Exceptions raised by the argument are
@@ -149,6 +153,8 @@ module BackState : sig
 
   val run : ('a, 'i, 'o, 'e) t -> 'i -> ('a * 'o, 'e) reified
 
+  val catch_system : ('a, 'i, 'o, 'e) t  -> (exn -> bool) -> (Exninfo.iexn -> 'e) -> ('a, 'i, 'o, 'e) t
+
 end
 
 (** The monad is parametrised in the types of state, environment and
@@ -203,6 +209,8 @@ module Logical (P:Param) : sig
   val repr : 'a reified -> ('a, 'a reified, Exninfo.iexn) list_view NonLogical.t
 
   val run : 'a t -> P.e -> P.s -> ('a * P.s * P.w * P.u) reified
+
+  val catch_system : 'a t -> (exn -> bool) -> 'a t
 
   module Unsafe :
   sig

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -255,6 +255,8 @@ let tclTHEN = Proof.(>>)
     the returned value. *)
 let tclIGNORE = Proof.ignore
 
+let tclCATCHSYSTEM = Proof.catch_system
+
 module Monad = Proof
 
 

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -181,6 +181,12 @@ val tclTHEN : unit tactic -> 'a tactic -> 'a tactic
     the returned value. *)
 val tclIGNORE : 'a tactic -> unit tactic
 
+(** [tclCATCHSYSTEM t cond] catches (non-monadic) system exceptions
+    [e] thrown during the execution of the tactic. Exception [e] is
+    only caught when [cond e] holds. When an exception is caught, the
+    result is isomorphic to [tclZERO (Exception e)]. *)
+val tclCATCHSYSTEM : 'a tactic -> (exn -> bool) -> 'a tactic
+
 (** Generic monadic combinators for tactics. *)
 module Monad : Monad.S with type +'a t = 'a tactic
 

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -1125,3 +1125,12 @@ TACTIC EXTEND with_strategy
   with_set_strategy [(v, q)] (Tacinterp.tactic_of_value ist tac)
 }
 END
+
+TACTIC EXTEND catch_stack_overflow
+| [ "catch_stack_overflow" tactic3(tac) ] -> {
+  Proofview.tclCATCHSYSTEM (Tacinterp.tactic_of_value ist tac)
+    (function
+      | Stack_overflow -> true
+      | _ -> false)
+}
+END


### PR DESCRIPTION
This allows writing a tactical that catches (non-monadic) system exceptions
during the execution of a tactic. As a proof of concept, we introduce the Ltac
tactical `catch_stack_overflow`.

I think that this is the cleanest solution to solve #14144. The only other solution I see is to introduce a new option that modifies `CErrors.noncritical` to accept `Stack_overflow`. But that introduces yet another piece of state. This solution is state-free. Credit for the idea goes to @JasonGross' question here: https://github.com/coq/coq/issues/14144#issuecomment-834608312.

Testcase:
```
Goal 70000 = 70000.
try cbv.
try catch_stack_overflow cbv.
```

Fixes #14144

<!-- Keep what applies -->
**Kind:** feature.

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [ ] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
- [ ] Overlay pull requests (if this breaks 3rd party developments in CI, see
https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md for details)
