### PR TITLE
[build] Don't buffer output of sphinx calls

### DIFF
--- a/Makefile.dune
+++ b/Makefile.dune
@@ -105,10 +105,10 @@ test-suite:
 	dune runtest --no-buffer $(DUNEOPT)
 
 refman-html:
-	dune build @refman-html
+	dune build --no-buffer @refman-html
 
 refman-pdf:
-	dune build @refman-pdf
+	dune build --no-buffer @refman-pdf
 
 stdlib-html:
 	dune build @stdlib-html


### PR DESCRIPTION
It is a bit more practical as the wait for the sphinx build is long.

Note current master produces all these warnings:
```
Duplicate cmd name:  Extraction
Duplicate tacn name:  first (ssreflect)
Duplicate tacn name:  have
Duplicate tacn name:  move (ssreflect)
Duplicate tacn name:  apply (ssreflect)
Duplicate tacn name:  under
Duplicate tacn name:  over
Duplicate tacn name:  wlog
Duplicate tacn name:  set (ssreflect)
Duplicate tacn name:  unlock
Duplicate tacn name:  congr
Duplicate cmd name:  Hint View for apply
Duplicate cmd name:  Prenex Implicits
Duplicate exn name:  Not the right number of missing arguments
Duplicate exn name:  No such hypothesis in current goal
Duplicate exn name:  No such hypothesis
Duplicate exn name:  ‘ident’ is used in the hypothesis ‘ident’
Duplicate exn name:  No such hypothesis
Duplicate exn name:  No such hypothesis
Duplicate exn name:  ‘ident’ is already used
Duplicate exn name:  No such assumption
Duplicate exn name:  Not an inductive product
Duplicate exn name:  Not equal
Duplicate exn name:  Not equal (due to universes)
Duplicate exn name:  Unable to unify ‘term’ with ‘term’
Duplicate exn name:  No focused proof (No proof-editing in progress)
/usr/lib/python3/dist-packages/sphinx_rtd_theme/search.html:20: RemovedInSphinx30
Warning: To modify script_files in the theme is deprecated. Please insert a <script> tag directly in your theme instead.
  {{ super() }}

```
