### PR TITLE
[parsing] expose parsing rules for inductive declarations

### DIFF
--- a/dev/ci/user-overlays/14295-gares-export-ind-parsing-rules.sh
+++ b/dev/ci/user-overlays/14295-gares-export-ind-parsing-rules.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/gares/coq-elpi export-ind-parsing-rules 14295

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -205,7 +205,7 @@ let test_variance_ident =
 (* Gallina declarations *)
 GRAMMAR EXTEND Gram
   GLOBAL: gallina gallina_ext thm_token def_token assumption_token def_body of_type
-    record_field decl_notations fix_definition ident_decl univ_decl;
+    record_field decl_notations fix_definition ident_decl univ_decl inductive_definition;
 
   gallina:
       (* Definition, Theorem, Variable, Axiom, ... *)

--- a/vernac/pvernac.ml
+++ b/vernac/pvernac.ml
@@ -43,6 +43,7 @@ module Vernac_ =
     let command = Entry.create "command"
     let syntax = Entry.create "syntax_command"
     let vernac_control = Entry.create "Vernac.vernac_control"
+    let inductive_definition = Entry.create "Vernac.inductive_definition"
     let fix_definition = Entry.create "Vernac.fix_definition"
     let rec_definition = fix_definition
     let red_expr = Entry.create "red_expr"

--- a/vernac/pvernac.mli
+++ b/vernac/pvernac.mli
@@ -25,6 +25,7 @@ module Vernac_ :
     val command : vernac_expr Entry.t
     val syntax : vernac_expr Entry.t
     val vernac_control : vernac_control Entry.t
+    val inductive_definition : (inductive_expr * decl_notation list) Entry.t
     val fix_definition : fixpoint_expr Entry.t
     val rec_definition : fixpoint_expr Entry.t
       [@@deprecated "Deprecated in 8.13; use 'fix_definition' instead"]


### PR DESCRIPTION
Currently the parsing rule for inductive types is not exported, and Coq-Elpi has to duplicate the grammar on its side.
I did prepare an overlay for Coq-Elpi in order to test if this parsing entry is sufficient (it is).

Fix LPCIC/coq-elpi#145

Overlay: https://github.com/LPCIC/coq-elpi/pull/240