### PR TITLE
[kernel] rework opaques definitions with no type

### DIFF
--- a/interp/decls.ml
+++ b/interp/decls.ml
@@ -38,6 +38,10 @@ type definition_object_kind =
   | Method
   | Let
 
+type definition_kind =
+  | DefLike of definition_object_kind
+  | ThmLike of theorem_kind
+
 type assumption_object_kind = Definitional | Logical | Conjectural | Context
 
 (* [assumption_kind]

--- a/interp/decls.mli
+++ b/interp/decls.mli
@@ -35,6 +35,10 @@ type definition_object_kind =
   | Method
   | Let
 
+type definition_kind =
+  | DefLike of definition_object_kind
+  | ThmLike of theorem_kind
+
 type assumption_object_kind = Definitional | Logical | Conjectural | Context
 
 (* [assumption_kind]

--- a/kernel/entries.ml
+++ b/kernel/entries.ml
@@ -69,7 +69,9 @@ type definition_entry = {
   const_entry_feedback : Stateid.t option;
   const_entry_type : types option;
   const_entry_universes : universes_entry;
-  const_entry_inline_code : bool }
+  const_entry_inline_code : bool;
+  const_entry_opaque : bool;
+}
 
 type section_def_entry = {
   secdef_body : constr;
@@ -78,14 +80,14 @@ type section_def_entry = {
   secdef_type : types option;
 }
 
-type 'a opaque_entry = {
-  opaque_entry_body   : 'a;
+type 'a delayed_entry = {
+  delayed_entry_body   : 'a;
   (* List of section variables *)
-  opaque_entry_secctx : Id.Set.t;
+  delayed_entry_secctx : Id.Set.t;
   (* State id on which the completion of type checking is reported *)
-  opaque_entry_feedback : Stateid.t option;
-  opaque_entry_type        : types;
-  opaque_entry_universes   : universes_entry;
+  delayed_entry_feedback : Stateid.t option;
+  delayed_entry_type        : types;
+  delayed_entry_universes   : universes_entry;
 }
 
 type inline = int option (* inlining level, None for no inlining *)

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -79,11 +79,11 @@ val is_joined_environment : safe_environment -> bool
 
 type global_declaration =
 | ConstantEntry : Entries.constant_entry -> global_declaration
-| OpaqueEntry : private_constants Entries.const_entry_body Entries.opaque_entry -> global_declaration
+| DelayedEntry : private_constants Entries.const_entry_body Entries.delayed_entry -> global_declaration
 
 type side_effect_declaration =
 | DefinitionEff : Entries.definition_entry -> side_effect_declaration
-| OpaqueEff : Constr.constr Entries.opaque_entry -> side_effect_declaration
+| OpaqueEff : Constr.constr Entries.delayed_entry -> side_effect_declaration
 
 type exported_private_constant = Constant.t
 

--- a/kernel/term_typing.mli
+++ b/kernel/term_typing.mli
@@ -31,10 +31,10 @@ val translate_local_assum : env -> types -> types * Sorts.relevance
 
 val translate_constant :
   env -> Constant.t -> constant_entry ->
-    'a constant_body
+    'a constant_body * bool (* true -> to opacify *)
 
-val translate_opaque :
-  env -> Constant.t -> 'a opaque_entry ->
+val translate_delayed :
+  env -> Constant.t -> 'a delayed_entry ->
     unit constant_body * typing_context
 
 val translate_recipe : env -> Constant.t -> Cooking.recipe -> Opaqueproof.opaque constant_body
@@ -44,7 +44,7 @@ val check_delayed : 'a effect_handler -> typing_context -> 'a proof_output -> (C
 (** Internal functions, mentioned here for debug purpose only *)
 
 val infer_declaration : env ->
-  constant_entry -> typing_context Cooking.result
+  constant_entry -> typing_context Cooking.result * bool
 
 val build_constant_declaration :
-  env -> Opaqueproof.proofterm Cooking.result -> Opaqueproof.proofterm constant_body
+  env -> Opaqueproof.proofterm Cooking.result * bool -> Opaqueproof.proofterm constant_body

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -402,7 +402,7 @@ let register_struct is_rec fixpoint_exprl =
     in
     ComDefinition.do_definition ~name:fname.CAst.v ~poly:false
       ~scope:(Locality.Global Locality.ImportDefaultBehavior)
-      ~kind:Decls.Definition univs binders None body (Some rtype);
+      ~kind:Decls.(DefLike Definition) univs binders None body (Some rtype);
     let evd, rev_pconstants =
       List.fold_left
         (fun (evd, l) {Vernacexpr.fname} ->

--- a/test-suite/output/lemma_body.out
+++ b/test-suite/output/lemma_body.out
@@ -1,0 +1,9 @@
+The command has indeed failed with message:
+toto1 is opaque.
+The command has indeed failed with message:
+toto2 is opaque.
+The command has indeed failed with message:
+toto3 is opaque.
+File "stdin", line 11, characters 5-45:
+Error: Mutual theorems with a body are not supported
+

--- a/test-suite/output/lemma_body.v
+++ b/test-suite/output/lemma_body.v
@@ -1,0 +1,12 @@
+Lemma toto1 := 3.
+Lemma toto2 : nat := 3.
+Theorem toto3 A : A -> A := fun x : A => x.
+
+Goal True.
+unfold plus. (* we check that a non-occurring def is OK *)
+Fail unfold toto1.
+Fail unfold toto2.
+Fail unfold toto3.
+
+Fail Lemma titi1 : nat with titi2 : bool := 3.
+Fail Lemma tata.

--- a/vernac/comDefinition.ml
+++ b/vernac/comDefinition.ml
@@ -125,11 +125,14 @@ let do_definition ?hook ~name ~scope ~poly ?typing_flags ~kind ?using udecl bl r
     interp_definition ~program_mode env evd empty_internalization_env bl red_option c ctypopt
   in
   let using = definition_using env evd ~body ~types ~using in
-  let kind = Decls.IsDefinition kind in
+  let opaque, kind = let open Decls in
+    match kind with
+    | DefLike d -> false, IsDefinition d
+    | ThmLike t -> true, IsProof t in
   let cinfo = Declare.CInfo.make ~name ~impargs ~typ:types ?using () in
   let info = Declare.Info.make ~scope ~kind ?hook ~udecl ~poly ?typing_flags () in
   let _ : Names.GlobRef.t =
-    Declare.declare_definition ~info ~cinfo ~opaque:false ~body evd
+    Declare.declare_definition ~info ~cinfo ~opaque ~body evd
   in ()
 
 let do_definition_program ?hook ~pm ~name ~scope ~poly ?typing_flags ~kind ?using udecl bl red_option c ctypopt =

--- a/vernac/comDefinition.mli
+++ b/vernac/comDefinition.mli
@@ -31,7 +31,7 @@ val do_definition
   -> scope:Locality.locality
   -> poly:bool
   -> ?typing_flags:Declarations.typing_flags
-  -> kind:Decls.definition_object_kind
+  -> kind:Decls.definition_kind
   -> ?using:Vernacexpr.section_subset_expr
   -> universe_decl_expr option
   -> local_binder_expr list

--- a/vernac/g_proofs.mlg
+++ b/vernac/g_proofs.mlg
@@ -54,7 +54,7 @@ GRAMMAR EXTEND Gram
   ;
   command:
     [ [ IDENT "Goal"; c = lconstr ->
-        { VernacDefinition (Decls.(NoDischarge, Definition), ((CAst.make ~loc Names.Anonymous), None), ProveBody ([], c)) }
+        { VernacDefinition (Decls.(NoDischarge, DefLike Definition), ((CAst.make ~loc Names.Anonymous), None), ProveBody ([], c)) }
       | IDENT "Proof" -> { VernacProof (None,None) }
       | IDENT "Proof"; IDENT "using"; l = G_vernac.section_subset_expr ->
           { VernacProof (None,Some l) }

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -209,11 +209,17 @@ GRAMMAR EXTEND Gram
 
   gallina:
       (* Definition, Theorem, Variable, Axiom, ... *)
-    [ [ thm = thm_token; id = ident_decl; bl = binders; ":"; c = lconstr;
-        l = LIST0
-          [ "with"; id = ident_decl; bl = binders; ":"; c = lconstr ->
-          { (id,(bl,c)) } ] ->
-          { VernacStartTheoremProof (thm, (id,(bl,c))::l) }
+    [ [ thm = thm_token; id = ident_decl; bl = binders;
+        ty = OPT [ ":"; c = lconstr -> { c } ];
+        with_ = LIST0 [ "with"; id = ident_decl; bl = binders; ":"; c = lconstr -> { (id,(bl,c)) } ];
+        body = OPT [ ":="; red = reduce; b = lconstr -> { red,b } ] ->
+          {
+            match body, ty, with_ with
+            | Some(red,b), _, [] -> VernacDefinition ((NoDischarge,ThmLike thm), name_of_ident_decl id, DefineBody (bl, red, b, ty))
+            | None, Some c, _ -> VernacStartTheoremProof (thm, (id,(bl,c))::with_)
+            | Some _, _, _ :: _ -> user_err ~loc (str "Mutual theorems with a body are not supported")
+            | None, None, _ -> user_err ~loc (str "Theorems with no body and no statement are not supported")
+          }
       | stre = assumption_token; nl = inline; bl = assum_list ->
           { VernacAssumption (stre, nl, bl) }
       | tk = assumptions_token; nl = inline; bl = assum_list ->
@@ -221,9 +227,9 @@ GRAMMAR EXTEND Gram
             test_plural_form loc kwd bl;
             VernacAssumption (stre, nl, bl) }
       | d = def_token; id = ident_decl; b = def_body ->
-          { VernacDefinition (d, name_of_ident_decl id, b) }
+          { VernacDefinition ((fst d, DefLike (snd d)), name_of_ident_decl id, b) }
       | IDENT "Let"; id = ident_decl; b = def_body ->
-          { VernacDefinition ((DoDischarge, Let), name_of_ident_decl id, b) }
+          { VernacDefinition ((DoDischarge, DefLike Let), name_of_ident_decl id, b) }
       (* Gallina inductive declarations *)
       | f = finite_token; indl = LIST1 inductive_definition SEP "with" ->
           { VernacInductive (f, indl) }
@@ -707,14 +713,14 @@ GRAMMAR EXTEND Gram
              VernacCanonical CAst.(make ?loc:qid.CAst.loc @@ AN qid)
            | Some (u,d) ->
              let s = coerce_reference_to_id qid in
-             VernacDefinition ((NoDischarge,CanonicalStructure),((CAst.make ?loc:qid.CAst.loc (Name s)),u),d) }
+             VernacDefinition ((NoDischarge,DefLike CanonicalStructure),((CAst.make ?loc:qid.CAst.loc (Name s)),u),d) }
       | IDENT "Canonical"; OPT [ IDENT "Structure" -> {()} ]; ntn = by_notation ->
           { VernacCanonical CAst.(make ~loc @@ ByNotation ntn) }
 
       (* Coercions *)
       | IDENT "Coercion"; qid = global; u = OPT univ_decl; d = def_body ->
           { let s = coerce_reference_to_id qid in
-          VernacDefinition ((NoDischarge,Coercion),((CAst.make ?loc:qid.CAst.loc (Name s)),u),d) }
+          VernacDefinition ((NoDischarge,DefLike Coercion),((CAst.make ?loc:qid.CAst.loc (Name s)),u),d) }
       | IDENT "Identity"; IDENT "Coercion"; f = identref; ":";
          s = class_rawexpr; ">->"; t = class_rawexpr ->
            { VernacIdentityCoercion (f, s, t) }

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -168,6 +168,10 @@ let string_of_assumption_kind = let open Decls in function
     | Conjectural -> "Conjecture"
     | Context -> "Context"
 
+let string_of_definition_kind = let open Decls in function
+    | DefLike d -> string_of_definition_object_kind d
+    | ThmLike t -> string_of_theorem_kind t
+
 let string_of_logical_kind = let open Decls in function
     | IsAssumption k -> string_of_assumption_kind k
     | IsDefinition k -> string_of_definition_object_kind k
@@ -794,7 +798,7 @@ let pr_vernac_expr v =
       keyword (
         if Name.is_anonymous (fst id).v
         then "Goal"
-        else string_of_definition_object_kind dk)
+        else string_of_definition_kind dk)
     in
     let pr_reduce = function
       | None -> mt()

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -323,7 +323,7 @@ type nonrec vernac_expr =
   | VernacDeclareCustomEntry of string
 
   (* Gallina *)
-  | VernacDefinition of (discharge * Decls.definition_object_kind) * name_decl * definition_expr
+  | VernacDefinition of (discharge * Decls.definition_kind) * name_decl * definition_expr
   | VernacStartTheoremProof of Decls.theorem_kind * proof_expr list
   | VernacEndProof of proof_end
   | VernacExactProof of constr_expr


### PR DESCRIPTION
This PR does two things:
- [x] improve kernel API so that one can declare an opaque constant without giving its type (Fix LPCIC/coq-elpi#168)
- [ ] provide user syntax for it as per coq/ceps#42 , CC @Zimmi48 

I open this early because I need feedback on the kernel API, in particular I could not find which invariant the generalized/instantiated type variable `'opaque` of `constant_def` was imposing. Also, most of this patch is a renaming since opaque != delayed.