### PR TITLE
Force dune to use locally built coqide for the shim

### DIFF
--- a/dev/shim/dune
+++ b/dev/shim/dune
@@ -38,6 +38,11 @@
 (rule
  (targets coqide-prelude)
  (deps
+  ; without this if the gtk libs are not available dune can try to use
+  ; coqide from PATH instead of giving a nice error
+  ; there is no problem with the other shims since they don't depend on optional build products
+  %{project_root}/ide/coqide/coqide_main.exe
+
   %{bin:coqqueryworker.opt}
   %{bin:coqtacticworker.opt}
   %{bin:coqproofworker.opt}


### PR DESCRIPTION
Fix #14292
