### PR TITLE
Deprecate -native-compiler option for coqc.

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -218,7 +218,7 @@ NATIVEINCLUDES=$(addprefix -nI _build/default/, kernel/.kernel.objs/byte)
 USERCONTRIBINCLUDES=$(addprefix -I _build/default/user-contrib/,$(USERCONTRIBDIRS))
 
 ifdef NATIVECOMPUTE
-  COQOPTS += -native-compiler ondemand
+  COQOPTS += -w -deprecated-native-compiler-option -native-compiler ondemand
 endif
 COQOPTS += $(COQWARNERROR) $(COQUSERFLAGS)
 # Beware this depends on the makefile being in a particular dir, we

--- a/doc/changelog/08-cli-tools/14309-native-deprecate-coqc-native-compiler-flag.rst
+++ b/doc/changelog/08-cli-tools/14309-native-deprecate-coqc-native-compiler-flag.rst
@@ -1,0 +1,6 @@
+- **Deprecated:**
+  the `-native-compiler` option for coqc. It is now recommended
+  to use the :ref:`coqnative` binary instead to generate native
+  compilation files ahead of time
+  (`#14309 <https://github.com/coq/coq/pull/14309>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/practical-tools/coq-commands.rst
+++ b/doc/sphinx/practical-tools/coq-commands.rst
@@ -272,6 +272,14 @@ and ``coqtop``, unless stated otherwise:
 
   .. _native-compiler-options:
 
+  .. deprecated:: 8.14
+
+     This flag has been deprecated in favor of the :ref:`coqnative` binary. The
+     toolchain has been adapted to transparently rely on the latter, so if you
+     use :ref:`coq_makefile` there is nothing to do. Otherwise you should
+     substitute calls to `coqc -native-compiler yes` to calls to `coqc` followed
+     by `coqnative` on the resulting `vo` file.
+
   .. versionchanged:: 8.13
 
      The default value is set at configure time,

--- a/sysinit/coqargs.ml
+++ b/sysinit/coqargs.ml
@@ -37,6 +37,7 @@ type injection_command =
   | OptionInjection of (Goptions.option_name * option_command)
   | RequireInjection of (string * string option * bool option)
   | WarnNoNative of string
+  | WarnNativeDeprecated
 
 type coqargs_logic_config = {
   impredicative_set : Declarations.set_predicativity;
@@ -249,8 +250,8 @@ let get_native_compiler s =
     | _ ->
        error_wrong_arg ("Error: (yes|no|ondemand) expected after option -native-compiler") in
   if Coq_config.native_compiler = NativeOff && n <> NativeOff then
-    NativeOff, Some (WarnNoNative s)
-  else n, None
+    NativeOff, [WarnNativeDeprecated; WarnNoNative s]
+  else n, [WarnNativeDeprecated]
 
 (* Main parsing routine *)
 (*s Parsing of the command line *)
@@ -357,7 +358,7 @@ let parse_args ~usage ~init arglist : t * string list =
     |"-native-compiler" ->
       let native_compiler, warn = get_native_compiler (next ()) in
       { oval with config = { oval.config with native_compiler };
-                  pre = { oval.pre with injections = Option.List.cons warn oval.pre.injections }}
+                  pre = { oval.pre with injections = warn @ oval.pre.injections }}
 
     | "-set" ->
       let opt, v = parse_option_set @@ next() in

--- a/sysinit/coqargs.mli
+++ b/sysinit/coqargs.mli
@@ -34,6 +34,9 @@ type injection_command =
      does not cause a warning. The native option must be processed
      before injections (because it affects require), so the
      instruction to emit a message is separated. *)
+  | WarnNativeDeprecated
+  (** Used so that "-w -native-compiler-deprecated-option -native-compiler FLAG"
+      does not cause a warning, similarly to above. *)
 
 type coqargs_logic_config = {
   impredicative_set : Declarations.set_predicativity;

--- a/sysinit/coqinit.ml
+++ b/sysinit/coqinit.ml
@@ -132,10 +132,17 @@ let warn_no_native_compiler =
                    strbrk " -native-compiler " ++ strbrk s ++
                    strbrk " option ignored.")
 
+let warn_deprecated_native_compiler =
+  CWarnings.create ~name:"deprecated-native-compiler-option" ~category:"deprecated"
+         (fun () ->
+          Pp.strbrk "The native-compiler option is deprecated. To compile native \
+          files ahead of time, use the coqnative binary instead.")
+
 let handle_injection = let open Coqargs in function
   | RequireInjection r -> require_file r
   | OptionInjection o -> set_option o
   | WarnNoNative s -> warn_no_native_compiler s
+  | WarnNativeDeprecated -> warn_deprecated_native_compiler ()
 
 let start_library ~top injections =
   Flags.verbosely Declaremods.start_library top;

--- a/test-suite/output/bug_13821_native_command_line_warn.v
+++ b/test-suite/output/bug_13821_native_command_line_warn.v
@@ -1,1 +1,1 @@
-(* -*- coq-prog-args: ("-w" "-native-compiler-disabled" "-native-compiler" "ondemand"); -*- *)
+(* -*- coq-prog-args: ("-w" "-deprecated-native-compiler-option" "-w" "-native-compiler-disabled" "-native-compiler" "ondemand"); -*- *)

--- a/theories/dune
+++ b/theories/dune
@@ -2,7 +2,7 @@
  (name Coq)
  (package coq-stdlib)
  (synopsis "Coq's Standard Library")
- (flags -q)
+ (flags -q -w -deprecated-native-compiler-option)
  ; (mode native)
  (boot)
  ; (per_file

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -225,14 +225,14 @@ $(strip $(COQEXTRAFLAGS)))))
 COQACTUALNATIVEFLAG:=$(lastword $(COQMF_COQ_NATIVE_COMPILER_DEFAULT) $(COQMF_COQPROJECTNATIVEFLAG) $(COQUSERNATIVEFLAG))
 
 ifeq '$(COQACTUALNATIVEFLAG)' 'yes'
-  COQNATIVEFLAG="-native-compiler" "ondemand"
+  COQNATIVEFLAG="-w" "-deprecated-native-compiler-option" "-native-compiler" "ondemand"
   COQDONATIVE="yes"
 else
 ifeq '$(COQACTUALNATIVEFLAG)' 'ondemand'
-  COQNATIVEFLAG="-native-compiler" "ondemand"
+  COQNATIVEFLAG="-w" "-deprecated-native-compiler-option" "-native-compiler" "ondemand"
   COQDONATIVE="no"
 else
-  COQNATIVEFLAG="-native-compiler" "no"
+  COQNATIVEFLAG="-w" "-deprecated-native-compiler-option" "-native-compiler" "no"
   COQDONATIVE="no"
 endif
 endif

--- a/user-contrib/Ltac2/dune
+++ b/user-contrib/Ltac2/dune
@@ -2,6 +2,7 @@
  (name Ltac2)
  (package coq-stdlib)
  (synopsis "Ltac2 tactic language")
+ (flags -w -deprecated-native-compiler-option)
  (libraries coq-core.plugins.ltac2))
 
 (library


### PR DESCRIPTION
The goal is to ensure that everybody is going to go through `coqnative` instead.

Not ready yet.
- The dune build spits warnings but I don't know where it is passed the -native-compiler flag.
- Should we provide a user-facing option to deactivate at runtime *native computation* (i.e. kernel native conversion / `native_compute` tactic) and replace this with the VM? AFAIK we don't have a similar option for the VM even though it would make sense. It would provide the missing quadrant of the two possible axes for native-compiler.
