### PR TITLE
Hide useless missing .aux file message in CoqIDE

### DIFF
--- a/lib/aux_file.ml
+++ b/lib/aux_file.ml
@@ -20,7 +20,8 @@ let version = 1
 let oc = ref None
 
 let aux_file_name_for vfile =
-  dirname vfile ^ "/." ^ chop_extension(basename vfile) ^ ".aux"
+  let fn = Printf.sprintf ".%s.aux" (chop_extension(basename vfile)) in
+  Filename.concat (dirname vfile) fn
 
 let mk_absolute vfile =
   let vfile = CUnix.remove_path_dot vfile in
@@ -92,7 +93,7 @@ let load_aux_file_for vfile =
   | End_of_file -> !h
   | Sys_error s | Scanf.Scan_failure s
   | Failure s | Invalid_argument s ->
-    Flags.if_verbose Feedback.msg_info Pp.(str"Loading file "++str aux_fname++str": "++str s);
-     empty_aux_file
+    CDebug.pp_misc Pp.(fun () -> str"Loading file "++str aux_fname++str": "++str s);
+    empty_aux_file
 
 let set ?loc h k v = set h (Option.cata Loc.unloc (0,0) loc) k v


### PR DESCRIPTION
As seen in 8.13:

Whenever you open a .v file in CoqIDE, you get this useless message.  It's sloppy and makes a poor impression.  This hides the message.  We could also delete it entirely if desired.

In addition, mixing Linux and Windows path separators in the pathname doesn't look good either.  Also fixed.

![image](https://user-images.githubusercontent.com/1253341/118153094-57a30800-b3ca-11eb-8ea4-5a7267e410c3.png)