### PR TITLE
Post bench updates to zulip

### DIFF
--- a/dev/bench/bench.sh
+++ b/dev/bench/bench.sh
@@ -52,7 +52,7 @@ check_variable "CI_JOB_URL"
 : "${new_coq_opam_archive_git_branch:=master}"
 : "${old_coq_opam_archive_git_branch:=master}"
 : "${num_of_iterations:=1}"
-: "${coq_opam_packages:=coq-performance-tests-lite coq-engine-bench-lite coq-hott coq-bignums coq-mathcomp-ssreflect coq-mathcomp-fingroup coq-mathcomp-algebra coq-mathcomp-solvable coq-mathcomp-field coq-mathcomp-character coq-mathcomp-odd-order coq-math-classes coq-corn coq-flocq coq-compcert coq-geocoq coq-color coq-coqprime coq-coqutil coq-bedrock2 coq-rewriter coq-fiat-core coq-fiat-parsers coq-fiat-crypto coq-unimath coq-coquelicot coq-lambda-rust coq-verdi coq-verdi-raft coq-fourcolor coq-rewriter-perf-SuperFast coq-perennial coq-vst}"
+: "${coq_opam_packages:=coq-bignums coq-hott coq-performance-tests-lite coq-engine-bench-lite coq-mathcomp-ssreflect coq-mathcomp-fingroup coq-mathcomp-algebra coq-mathcomp-solvable coq-mathcomp-field coq-mathcomp-character coq-mathcomp-odd-order coq-math-classes coq-corn coq-flocq coq-compcert coq-geocoq coq-color coq-coqprime coq-coqutil coq-bedrock2 coq-rewriter coq-fiat-core coq-fiat-parsers coq-fiat-crypto coq-unimath coq-coquelicot coq-lambda-rust coq-verdi coq-verdi-raft coq-fourcolor coq-rewriter-perf-SuperFast coq-perennial coq-vst}"
 
 new_coq_commit=$(git rev-parse HEAD^2)
 old_coq_commit=$(git merge-base HEAD^1 $new_coq_commit)

--- a/dev/bench/gitlab-bench.yml
+++ b/dev/bench/gitlab-bench.yml
@@ -21,3 +21,4 @@ bench:
       - _bench/opam.OLD/**/*.timing
     when: always
     expire_in: 1 year
+  environment: bench

--- a/dev/bench/gitlab-bench.yml
+++ b/dev/bench/gitlab-bench.yml
@@ -4,7 +4,7 @@ bench:
   when: manual
   before_script:
     - printenv -0 | sort -z | tr '\0' '\n'
-  script: dev/bench/gitlab.sh
+  script: dev/bench/bench.sh
   tags:
     - timing
   variables:

--- a/dev/bench/render_results
+++ b/dev/bench/render_results
@@ -141,7 +141,7 @@ module Table :
 sig
   type header = string
   type row = string list list
-  val print : header list -> row list -> string
+  val print : header list -> row -> row list -> string
 end =
 struct
   type header = string
@@ -162,13 +162,6 @@ struct
     in
     let ls = List.map split ls in
     List.split ls
-
-  let rec last = function
-  | [] -> assert false
-  | [x] -> [], x
-  | x :: l ->
-    let (l, y) = last l in
-    (x :: l, y)
 
   let justify n s =
     let len = String.length s in
@@ -224,7 +217,7 @@ struct
 
   (* Invariant : all rows must have the same shape *)
 
-  let print (headers : header list) (rows : row list) =
+  let print (headers : header list) (top : row) (rows : row list) =
     (* Sanitize input *)
     let ncolums = List.length headers in
     let shape = ref None in
@@ -254,7 +247,7 @@ struct
         let data = match !data with None -> [] | Some s -> s in
         data :: ans
     in
-    let layout = layout ncolums rows in
+    let layout = layout ncolums (top::rows) in
     let map hd shape =
       let data_size = match shape with
       | [] -> 0
@@ -265,17 +258,16 @@ struct
     let col_size = List.map2 map headers layout in
     (* Justify the data *)
     let headers = List.map2 justify col_size headers in
+    let top = List.map2 justify col_size (List.map2 justify_row layout top) in
     let rows = List.map (fun row -> List.map2 justify col_size (List.map2 justify_row layout row)) rows in
     (* Print the table *)
-    let rows, last = last rows in
-    let sep = print_separator `Mid col_size in
-    let rows = List.concat @@ List.map (fun r -> [print_row r; sep]) rows in
     let lines =
       print_separator `Top col_size ::
       print_row headers ::
       print_blank col_size ::
-      rows @
-      print_row last ::
+      print_row top ::
+      print_separator `Mid col_size ::
+      List.map print_row rows @
       print_separator `Bot col_size ::
       []
     in
@@ -419,7 +411,7 @@ coq_opam_packages
     let descr = ["NEW"; "OLD"; "PDIFF"] in
     let top = [ [ "package_name" ]; descr; descr; descr; descr; descr ] in
 
-    printf "%s%!" (Table.print headers (top :: measurements))
+    printf "%s%!" (Table.print headers top measurements)
 ;
 
 (* ejgallego: disable this as it is very verbose and brings up little info in the log. *)


### PR DESCRIPTION
We create a post in `GitHub notifications` / `Bench Notifications` at bench start (after successfully cloning old/new coq repositories) and edit when we print the result table and at bench end.

The API key is in a variable restricted to the (new) `bench` environment on gitlab.

PR also includes some small cleanups.

Example result can be seen at https://coq.zulipchat.com/#narrow/stream/288483-test/topic/Bench.20notifications (but the zulip_autofail trap had a typo so when I made the job fail the post wasn't updated with `Failed $com...`)