### PR TITLE
Legacy build: link whole coq-core into _build_vo

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -59,12 +59,9 @@ $(BUILD_OUT_DIR) $(VO_OUT_DIR):
 	$(SHOW)'MKDIR     BUILD_OUT'
 	$(HIDE)mkdir -p $(BUILD_OUT_DIR)
 	$(HIDE)mkdir -p $(BUILD_OUT_DIR)/lib/coq
-	$(HIDE)mkdir -p $(BUILD_OUT_DIR)/lib/coq-core
 	$(HIDE)ln -s $(shell pwd)/_build/install/default/bin/ $(LEGACY_BIN_DIR)
 	$(HIDE)ln -s $(shell pwd)/_build/install/default/bin/ $(BUILD_OUT_DIR)/bin
-	$(HIDE)ln -s $(shell pwd)/_build/default/plugins/ $(BUILD_OUT_DIR)/lib/coq-core
-	$(HIDE)ln -s $(shell pwd)/_build/default/tools/ $(BUILD_OUT_DIR)/lib/coq-core
-	$(HIDE)ln -s $(shell pwd)/_build/default/kernel/ $(BUILD_OUT_DIR)/lib/coq-core
+	$(HIDE)ln -s $(shell pwd)/_build/install/default/lib/coq-core/ $(BUILD_OUT_DIR)/lib/coq-core
 
 ###########################################################################
 # Executables


### PR DESCRIPTION
This seems to be necessary to make the ci targets work
cf https://coq.zulipchat.com/#narrow/stream/237656-Coq-devs.20.26.20plugin.20devs/topic/Unbound.20module.20Mltop
