### PR TITLE
Fixes #14256, extraction: unsafeCoerce moved to different module in GHC >= 9.0.0

### DIFF
--- a/plugins/extraction/haskell.ml
+++ b/plugins/extraction/haskell.ml
@@ -64,13 +64,18 @@ let preamble mod_name comment used_modules usf =
   ++
   (if not usf.magic then mt ()
    else
-     str "#ifdef __GLASGOW_HASKELL__" ++ fnl () ++
+     str "#ifdef __GLASGOW_HASKELL__ < 900" ++ fnl () ++
      str "unsafeCoerce :: a -> b" ++ fnl () ++
      str "unsafeCoerce = GHC.Base.unsafeCoerce#" ++ fnl () ++
      str "#else" ++ fnl () ++
+     str " #ifdef __GLASGOW_HASKELL__" ++ fnl () ++
+     str "unsafeCoerce :: a -> b" ++ fnl () ++
+     str "unsafeCoerce = GHC.Exts.unsafeCoerce#" ++ fnl () ++
+     str " #else" ++ fnl () ++
      str "-- HUGS" ++ fnl () ++
      str "unsafeCoerce :: a -> b" ++ fnl () ++
      str "unsafeCoerce = IOExts.unsafeCoerce" ++ fnl () ++
+     str " #endif" ++ fnl () ++
      str "#endif" ++ fnl2 ())
   ++
   (if not usf.tunknown then mt ()


### PR DESCRIPTION
**Kind:** enhancement

Fixes / closes #14256. This adds unsafeCoerce compatibility with GHC >= 9.0.0.

- [ ] Entry added in the changelog