### PR TITLE
Debugger: mapping between absolute filenames and dirpaths

### DIFF
--- a/dev/ci/user-overlays/14354-jfehrle-modpath_in_loct.sh
+++ b/dev/ci/user-overlays/14354-jfehrle-modpath_in_loct.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/jfehrle/coq-elpi modpath_in_loct2 14354

--- a/lib/feedback.ml
+++ b/lib/feedback.ml
@@ -101,7 +101,7 @@ let console_feedback_listener fmt =
     | None     -> fprintf fmt ""
     | Some loc ->
       let where =
-        match loc.fname with InFile f -> f | ToplevelInput -> "Toplevel input" in
+        match loc.fname with InFile { file } -> file | ToplevelInput -> "Toplevel input" in
       fprintf fmt "\"%s\", line %d, characters %d-%d:@\n"
         where loc.line_nb (loc.bp-loc.bol_pos) (loc.ep-loc.bol_pos) in
   let checker_feed (fb : feedback) =

--- a/lib/loc.ml
+++ b/lib/loc.ml
@@ -11,7 +11,8 @@
 (* Locations management *)
 
 type source =
-  | InFile of string
+  (* OCaml won't allow using DirPath.t in InFile *)
+  | InFile of { dirpath : string option; file : string }
   | ToplevelInput
 
 type t = {

--- a/lib/loc.mli
+++ b/lib/loc.mli
@@ -11,7 +11,7 @@
 (** {5 Basic types} *)
 
 type source =
-  | InFile of string
+  | InFile of { dirpath : string option; file : string }
   | ToplevelInput
 
 type t = {

--- a/library/libnames.ml
+++ b/library/libnames.ml
@@ -160,6 +160,7 @@ let idset_mem_qualid qid s =
   qualid_is_ident qid && Id.Set.mem (qualid_basename qid) s
 
 (* Default paths *)
+(* todo: contrary to the comment, this does not give "Top" *)
 let default_library = Names.DirPath.initial (* = ["Top"] *)
 
 (*s Roots of the space of absolute names *)

--- a/toplevel/ccompile.ml
+++ b/toplevel/ccompile.ml
@@ -140,7 +140,7 @@ let compile opts stm_options injections copts ~echo ~f_in ~f_out =
 
       let wall_clock1 = Unix.gettimeofday () in
       let check = Stm.AsyncOpts.(stm_options.async_proofs_mode = APoff) in
-      let state = Vernac.load_vernac ~echo ~check ~interactive:false ~state long_f_dot_in in
+      let state = Vernac.load_vernac ~echo ~check ~interactive:false ~state ~ldir long_f_dot_in in
       let _doc = Stm.join ~doc:state.doc in
       let wall_clock2 = Unix.gettimeofday () in
       check_pending_proofs ();

--- a/toplevel/vernac.ml
+++ b/toplevel/vernac.ml
@@ -81,14 +81,15 @@ let interp_vernac ~check ~interactive ~state ({CAst.loc;_} as com) =
       Exninfo.iraise (reraise, info)
 
 (* Load a vernac file. CErrors are annotated with file and location *)
-let load_vernac_core ~echo ~check ~interactive ~state file =
+let load_vernac_core ~echo ~check ~interactive ~state ?ldir file =
   (* Keep in sync *)
   let in_chan = open_utf8_file_in file in
   let in_echo = if echo then Some (open_utf8_file_in file) else None in
   let input_cleanup () = close_in in_chan; Option.iter close_in in_echo in
 
-  let in_pa =
-    Pcoq.Parsable.make ~loc:(Loc.(initial (InFile file)))
+  let dirpath = Option.cata (fun ldir -> Some Names.DirPath.(to_string ldir))
+      None ldir in
+  let in_pa = Pcoq.Parsable.make ~loc:Loc.(initial (InFile {dirpath; file}))
       (Stream.of_channel in_chan) in
   let open State in
 
@@ -167,8 +168,8 @@ let beautify_pass ~doc ~comments ~ids ~filename =
 
 (* Main driver for file loading. For now, we only do one beautify
    pass. *)
-let load_vernac ~echo ~check ~interactive ~state filename =
-  let ostate, ids, comments = load_vernac_core ~echo ~check ~interactive ~state filename in
+let load_vernac ~echo ~check ~interactive ~state ?ldir filename =
+  let ostate, ids, comments = load_vernac_core ~echo ~check ~interactive ~state ?ldir filename in
   (* Pass for beautify *)
   if !Flags.beautify then beautify_pass ~doc:ostate.State.doc ~comments ~ids:(List.rev ids) ~filename;
   (* End pass *)

--- a/toplevel/vernac.mli
+++ b/toplevel/vernac.mli
@@ -30,4 +30,4 @@ val process_expr : state:State.t -> Vernacexpr.vernac_control -> State.t
     echo the commands if [echo] is set. Callers are expected to handle
     and print errors in form of exceptions. *)
 val load_vernac : echo:bool -> check:bool -> interactive:bool ->
-  state:State.t -> string -> State.t
+  state:State.t -> ?ldir:Names.DirPath.t -> string -> State.t

--- a/vernac/loadpath.ml
+++ b/vernac/loadpath.ml
@@ -32,7 +32,7 @@ let pp p =
 let get_load_paths () = !load_paths
 
 let anomaly_too_many_paths path =
-  CErrors.anomaly Pp.(str "Several logical paths are associated to" ++ spc () ++ str path ++ str ".")
+  CErrors.anomaly Pp.(str "Several logical paths are associated with" ++ spc () ++ str path ++ str ".")
 
 let find_load_path phys_dir =
   let phys_dir = CUnix.canonical_path_name phys_dir in
@@ -42,6 +42,10 @@ let find_load_path phys_dir =
   | [] -> raise Not_found
   | [p] -> p
   | _ -> anomaly_too_many_paths phys_dir
+
+(* get the list of load paths that correspond to a given logical path *)
+let find_with_logical_path dirpath =
+  List.filter (fun p -> Names.DirPath.equal p.path_logical dirpath) !load_paths
 
 let remove_load_path dir =
   let filter p = not (String.equal p.path_physical dir) in

--- a/vernac/loadpath.mli
+++ b/vernac/loadpath.mli
@@ -23,6 +23,9 @@ type t
 val logical : t -> DirPath.t
 (** Get the logical path (Coq module hierarchy) of a loadpath. *)
 
+val physical : t -> CUnix.physical_path
+(** Get the physical path of a loadpath *)
+
 val pp : t -> Pp.t
 (** Print a load path *)
 
@@ -34,8 +37,11 @@ val remove_load_path : CUnix.physical_path -> unit
     if any. *)
 
 val find_load_path : CUnix.physical_path -> t
-(** Get the binding associated to a physical path. Raises [Not_found] if there
+(** Get the binding associated with a physical path. Raises [Not_found] if there
     is none. *)
+
+val find_with_logical_path : Names.DirPath.t -> t list
+(** get the list of load paths that correspond to a given logical path *)
 
 val locate_file : string -> string
 (** Locate a file among the registered paths. Do not use this function, as

--- a/vernac/topfmt.ml
+++ b/vernac/topfmt.ml
@@ -370,8 +370,8 @@ let pr_loc loc =
     | Loc.ToplevelInput ->
       Loc.(str"Toplevel input, characters " ++ int loc.bp ++
            str"-" ++ int loc.ep ++ str":")
-    | Loc.InFile fname ->
-      Loc.(str"File " ++ str "\"" ++ str fname ++ str "\"" ++
+    | Loc.InFile { file } ->
+      Loc.(str"File " ++ str "\"" ++ str file ++ str "\"" ++
            str", line " ++ int loc.line_nb ++ str", characters " ++
            int (loc.bp-loc.bol_pos) ++ str"-" ++ int (loc.ep-loc.bol_pos) ++
            str":")

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -186,7 +186,8 @@ and vernac_load ~verbosely fname =
   let input =
     let longfname = Loadpath.locate_file fname in
     let in_chan = Util.open_utf8_file_in longfname in
-    Pcoq.Parsable.make ~loc:(Loc.(initial (InFile longfname))) (Stream.of_channel in_chan) in
+    Pcoq.Parsable.make ~loc:Loc.(initial (InFile { dirpath=None; file=longfname}))
+        (Stream.of_channel in_chan) in
   (* Parsing loop *)
   let v_mod = if verbosely then Flags.verbosely else Flags.silently in
   let parse_sentence proof_mode = Flags.with_option Flags.we_are_parsing


### PR DESCRIPTION
Server side code for managing breakpoints.  Supercedes #14251.

`Loc.source.Infile` is extended to include module information as a DirPath in string form, for example `Coq.Init.Tactics` for the compilation of `./theories/Init/Tactics.v`.  On the server, breakpoints are identified by a (dirpath, file offset) pairs from the `Loc.t`.  In CoqIDE or another GUI, breakpoints are identified by (absolute pathname of the .v file, file offset).

This includes the server side code for:
- setting breakpoints (mapping an absolute pathname to a dirpath)
- detecting when the debugger has reached a breakpoint
- mapping a dirpath back to an absolute pathname

This code works correctly for Jason's [functor example](https://github.com/coq/coq/pull/14251#issuecomment-833490249).

There's a little more explanation [here](https://github.com/coq/coq/issues/14311#issuecomment-842758947)