### PR TITLE
Opaque API for serialized opaque tables

### DIFF
--- a/checker/check.ml
+++ b/checker/check.ml
@@ -51,7 +51,7 @@ let pr_path sp =
 type compilation_unit_name = DirPath.t
 
 type seg_univ = Univ.ContextSet.t * bool
-type seg_proofs = Opaqueproof.opaque_proofterm array
+type seg_proofs = Opaqueproof.opaque_disk
 
 type library_t = {
   library_name : compilation_unit_name;
@@ -97,8 +97,7 @@ let access_opaque_table dp i =
     try LibraryMap.find dp !opaque_tables
     with Not_found -> assert false
   in
-  assert (i < Array.length t);
-  t.(i)
+  Opaqueproof.get_opaque_disk i t
 
 let access_discharge = Cooking.cook_constr
 

--- a/kernel/opaqueproof.ml
+++ b/kernel/opaqueproof.ml
@@ -24,11 +24,11 @@ type 'a delayed_universes =
 | PrivateMonomorphic of 'a
 | PrivatePolymorphic of int * Univ.ContextSet.t
 
-type opaque_proofterm = (Constr.t * unit delayed_universes) option
+type opaque_proofterm = Constr.t * unit delayed_universes
 
 type indirect_accessor = {
-  access_proof : DirPath.t -> int -> opaque_proofterm;
-  access_discharge : cooking_info list -> (Constr.t * unit delayed_universes) -> (Constr.t * unit delayed_universes);
+  access_proof : DirPath.t -> int -> opaque_proofterm option;
+  access_discharge : cooking_info list -> opaque_proofterm -> opaque_proofterm;
 }
 
 let drop_mono = function
@@ -127,7 +127,7 @@ let force_constraints _access { opaque_val = prfs; opaque_dir = odp; _ } = funct
 
 module FMap = Future.UUIDMap
 
-type opaque_disk = opaque_proofterm array
+type opaque_disk = opaque_proofterm option array
 type opaque_handle = int
 
 let dump ?(except = Future.UUIDSet.empty) { opaque_val = otab; opaque_len = n; _ } =

--- a/kernel/opaqueproof.ml
+++ b/kernel/opaqueproof.ml
@@ -127,6 +127,9 @@ let force_constraints _access { opaque_val = prfs; opaque_dir = odp; _ } = funct
 
 module FMap = Future.UUIDMap
 
+type opaque_disk = opaque_proofterm array
+type opaque_handle = int
+
 let dump ?(except = Future.UUIDSet.empty) { opaque_val = otab; opaque_len = n; _ } =
   let opaque_table = Array.make n None in
   let f2t_map = ref FMap.empty in
@@ -147,3 +150,15 @@ let dump ?(except = Future.UUIDSet.empty) { opaque_val = otab; opaque_len = n; _
   in
   let () = Int.Map.iter iter otab in
   opaque_table, !f2t_map
+
+let get_opaque_disk i t =
+  let () = assert (0 <= i && i < Array.length t) in
+  t.(i)
+
+let set_opaque_disk i (c, priv) t =
+  let () = assert (0 <= i && i < Array.length t) in
+  let () = assert (Option.is_empty t.(i)) in
+  let c = Constr.hcons c in
+  t.(i) <- Some (c, priv)
+
+let repr_handle i = i

--- a/kernel/opaqueproof.mli
+++ b/kernel/opaqueproof.mli
@@ -39,14 +39,13 @@ type cooking_info = {
   modlist : work_list;
   abstract : Constr.named_context * Univ.Instance.t * Univ.AUContext.t }
 
-type opaque_proofterm = (Constr.t * unit delayed_universes) option
+type opaque_proofterm = Constr.t * unit delayed_universes
 
 type opaque_handle
 
 type indirect_accessor = {
-  access_proof : DirPath.t -> opaque_handle -> opaque_proofterm;
-  access_discharge : cooking_info list ->
-    (Constr.t * unit delayed_universes) -> (Constr.t * unit delayed_universes);
+  access_proof : DirPath.t -> opaque_handle -> opaque_proofterm option;
+  access_discharge : cooking_info list -> opaque_proofterm -> opaque_proofterm;
 }
 (** Opaque terms are indexed by their library
     dirpath and an integer index. The two functions above activate
@@ -55,7 +54,7 @@ type indirect_accessor = {
 
 (** From a [opaque] back to a [constr]. This might use the
     indirect opaque accessor given as an argument. *)
-val force_proof : indirect_accessor -> opaquetab -> opaque -> constr * unit delayed_universes
+val force_proof : indirect_accessor -> opaquetab -> opaque -> opaque_proofterm
 val force_constraints : indirect_accessor -> opaquetab -> opaque -> Univ.ContextSet.t
 
 val subst_opaque : substitution -> opaque -> opaque
@@ -71,8 +70,8 @@ type opaque_disk
 
 val dump : ?except:Future.UUIDSet.t -> opaquetab -> opaque_disk * opaque_handle Future.UUIDMap.t
 
-val get_opaque_disk : opaque_handle -> opaque_disk -> opaque_proofterm
-val set_opaque_disk : opaque_handle -> constr * unit delayed_universes -> opaque_disk -> unit
+val get_opaque_disk : opaque_handle -> opaque_disk -> opaque_proofterm option
+val set_opaque_disk : opaque_handle -> opaque_proofterm -> opaque_disk -> unit
 
 (** Only used for pretty-printing *)
 val repr_handle : opaque_handle -> int

--- a/kernel/opaqueproof.mli
+++ b/kernel/opaqueproof.mli
@@ -41,8 +41,10 @@ type cooking_info = {
 
 type opaque_proofterm = (Constr.t * unit delayed_universes) option
 
+type opaque_handle
+
 type indirect_accessor = {
-  access_proof : DirPath.t -> int -> opaque_proofterm;
+  access_proof : DirPath.t -> opaque_handle -> opaque_proofterm;
   access_discharge : cooking_info list ->
     (Constr.t * unit delayed_universes) -> (Constr.t * unit delayed_universes);
 }
@@ -63,6 +65,14 @@ val discharge_opaque :
 
 val join_opaque : ?except:Future.UUIDSet.t -> opaquetab -> opaque -> unit
 
-val dump : ?except:Future.UUIDSet.t -> opaquetab ->
-  opaque_proofterm array *
-  int Future.UUIDMap.t
+(** {5 Serialization} *)
+
+type opaque_disk
+
+val dump : ?except:Future.UUIDSet.t -> opaquetab -> opaque_disk * opaque_handle Future.UUIDMap.t
+
+val get_opaque_disk : opaque_handle -> opaque_disk -> opaque_proofterm
+val set_opaque_disk : opaque_handle -> constr * unit delayed_universes -> opaque_disk -> unit
+
+(** Only used for pretty-printing *)
+val repr_handle : opaque_handle -> int

--- a/vernac/library.mli
+++ b/vernac/library.mli
@@ -34,7 +34,7 @@ type seg_sum
 type seg_lib
 type seg_univ = (* all_cst, finished? *)
   Univ.ContextSet.t * bool
-type seg_proofs = Opaqueproof.opaque_proofterm array
+type seg_proofs = Opaqueproof.opaque_disk
 
 (** End the compilation of a library and save it to a ".vo" file,
     a ".vio" file, or a ".vos" file, depending on the todo_proofs


### PR DESCRIPTION
This prevents the STM from poking into the representation of the table for vio-to-vo compilation, and centralizes opaque proof hashconsing.

Ultimately we could even switch the implementation, but this is left to future work.