### PR TITLE
Optimizing the propagation of the guard condition under a match on a type with indices by discarding only the type information from the indices

### DIFF
--- a/test-suite/bugs/bug_17062.v
+++ b/test-suite/bugs/bug_17062.v
@@ -1,0 +1,11 @@
+Inductive box P := box_intro : P -> box P.
+Inductive P := P_intro : box P -> P.
+
+Fixpoint size (d : P) {struct d} : nat :=
+  let 'P_intro p := d in
+  match tt as t
+  return box (match t with tt => P end) -> nat
+  with
+  | tt => fun tu =>
+      size (let 'box_intro _ tu' := tu in tu')
+  end p.

--- a/test-suite/failure/subterm3.v
+++ b/test-suite/failure/subterm3.v
@@ -27,3 +27,36 @@ Fail Fixpoint loop (x : True2) : False :=
 match x with
 I3 f => (match T3F_FT3F in _=T return T with eq_refl=> loop end) f
 end.
+
+(* Variant *)
+
+Inductive I: Prop := C: (False -> I) -> I.
+
+Lemma I_eq_True: I = True.
+Proof.
+  apply prop_ext. split.
+  - trivial.
+  - intros. constructor. apply False_rect.
+Defined.
+
+Lemma I_eq_False_impl_I: I = (False -> I).
+Proof.
+  apply prop_ext. split.
+  - trivial.
+  - exact C.
+Defined.
+
+Inductive eq': Prop -> Prop := eq_refl': eq' I.
+
+Lemma I_eq_False_impl_I': eq' (False -> I).
+Proof.
+  rewrite <- I_eq_False_impl_I. constructor.
+Defined.
+
+Fail Fixpoint loop x :=
+  match x with
+    C f =>
+    match I_eq_False_impl_I' in eq' T return T -> False with
+      eq_refl' => fun x => loop x
+    end f
+  end.

--- a/test-suite/success/CasesDep.v
+++ b/test-suite/success/CasesDep.v
@@ -550,6 +550,8 @@ Definition test (s:step E E) :=
     | _ => false
   end.
 
+Unset Implicit Arguments.
+
 (* Testing regression of bug 2454 ("get" used not be type-checkable when
    defined with its type constraint) *)
 
@@ -569,3 +571,48 @@ Check fun e t (d1 d2:EQ e t) =>
       with
       | R _ _, R _ _ => fun _ _ => eq_refl
       end.
+
+Module Map3.
+
+Inductive vector (A : Type) : nat -> Set :=
+    Cons : forall n : nat, vector A n -> vector A (S n).
+
+Fixpoint map3
+  (A0 A1 A2 B : Type) (n : nat) (v0 : vector A0 n)
+  (v1 : vector A1 n) (v2 : vector A2 n) {struct v2} : vector B n :=
+  match
+    v0 in (vector _ H) return (vector A2 H -> vector A1 H -> vector B H)
+  with
+  | Cons _ x tl0 =>
+      fun (H : vector A2 (S x)) (H0 : vector A1 (S x)) =>
+      match
+        H0 as v3 in (vector _ H1)
+        return
+          (match H1 as H2 return (vector A1 H2 -> Set) with
+           | 0 => fun _ : vector A1 0 => IDProp
+           | S x0 =>
+               fun _ : vector A1 (S x0) =>
+               vector A0 x0 -> vector A2 (S x0) -> vector B (S x0)
+           end v3)
+      with
+      | Cons _ x0 tl1 =>
+          fun (tl2 : vector A0 x0) (H1 : vector A2 (S x0)) =>
+          match
+            H1 as v3 in (vector _ H2)
+            return
+              (match H2 as H3 return (vector A2 H3 -> Set) with
+               | 0 => fun _ : vector A2 0 => IDProp
+               | S x1 =>
+                   fun _ : vector A2 (S x1) =>
+                   vector A0 x1 -> vector A1 x1 -> vector B (S x1)
+               end v3)
+          with
+          | Cons _ x1 tl4 =>
+              fun (tl7 : vector A0 x1)
+                (tl8 : vector A1 x1) =>
+              Cons B x1 (map3 A0 A1 A2 B x1 tl7 tl8 tl4)
+          end tl2 tl1
+      end tl0 H
+  end v2 v1.
+
+End Map3.


### PR DESCRIPTION
**Kind:** enhancement

~~The type-based filtering of decreasing arguments passed across a `match` was not taking into account that the return predicate had a specific instance in each branch. We take this instance into account and this allows to recognize more useful fixpoints as guarded (e.g. map3 on vectors when mechanically generated with small inversion).~~

We observe that the protection against the inconsistency of propositional extensionality obtained by not using _at all_ the indices of the type of the term to match in propagating the subterm status through a `match` (see 9b272a8 and further commits) is finally overly restrictive: only the type information present in the indices needs to be ignored (see [comment](https://github.com/coq/coq/pull/14359#issuecomment-1664239930) below for a proof sketch).

This allows to:
- fix #17062,
- support complex forms of small inversion,
- (virtually) provide definitional UIP on the subset of rewriting not involving types without breaking normalization.

Here is a typical example of small inversion exploiting the PR:
```coq
Inductive vector (A : Type) : nat -> Set :=                                                                         
    Cons : forall n : nat, vector A n -> vector A (S n).                                                            

Fixpoint degenerated_map3
  (A : Type) (n : nat) (v0 v1 v2 : vector A n) {struct v2} : vector A n :=
match v0 in vector _ n0 return vector A n0 -> vector A n0 -> vector A n0 with
| Cons _ n0 tl0 =>
  fun (v1 : vector A (S n0)) (v2 : vector A (S n0)) =>
  match
    v1 in vector _ n1
    return match n1 with  
    | 0 => IDProp
    | S n1 => vector A n1 -> vector A (S n1) -> vector A (S n1)
    end
  with
  | Cons _ n1 tl1 =>  
    fun (tl0 : vector A n1) (v2 : vector A (S n1)) =>
    match
      v2 in (vector _ n2)
      (* This return type was not recognized as casting tl0 with a
         "vector" type because n2 was left as an uninstantiated variable,
         blocking the reduction of the "match", while it could have been
         instantiated with its value in the branch, i.e. (S n1), allowing the 
         match on n2 to reduce *)
      return match n2 with
      | 0 => IDProp
      | S p => vector A p -> vector A p -> vector A (S p)
      end
    with  
    | Cons _ n2 tl2 =>
      fun (tl0 tl1 : vector A n2) =>  
      Cons A n2 (degenerated_map3 A n2 tl0 tl1 tl2)
    end tl0 tl1
  end tl0 v2
end v1 v2.
```

- [X] Added / updated test-suite
- [ ] Entry added in the changelog

TODO: apply it to `restrict_spec` too.