### PR TITLE
Printing of projections was missing a box opening

### DIFF
--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -576,7 +576,7 @@ let tag_var = tag Tag.variable
         let c,l1 = List.sep_last l1 in
         let p = pr_proj (pr mt) pr_appexpl c (f,us) l1 in
         if not (List.is_empty l2) then
-          return (p ++ prlist (pr spc (LevelLt lapp)) l2, lapp)
+          return (hov 0 (p ++ prlist (pr spc (LevelLt lapp)) l2), lapp)
         else
           return (p, lproj)
       | CAppExpl ((None,qid,us),[t])
@@ -595,7 +595,7 @@ let tag_var = tag Tag.variable
         let p = pr_proj (pr mt) pr_app (fst c) f l1 in
         if not (List.is_empty l2) then
           return (
-            p ++ prlist (fun a -> spc () ++ pr_expl_args (pr mt) a) l2,
+            hov 0 (p ++ prlist (fun a -> spc () ++ pr_expl_args (pr mt) a) l2),
             lapp
           )
         else

--- a/test-suite/output/Record.out
+++ b/test-suite/output/Record.out
@@ -70,3 +70,7 @@ fun '{| |} => 0
               |} => (a, b, c, d)
        |}
      : T
+fun x : R => 0
+             +++
+             x.(field) 0
+     : R -> nat

--- a/test-suite/output/Record.v
+++ b/test-suite/output/Record.v
@@ -64,3 +64,13 @@ Import LongModuleName.
 Eval compute in {|a:=c;b:=d|}.
 
 End FormattingIssue13142.
+
+Module ProjectionPrinting.
+
+Notation "a +++ b" := (a * b) (at level 40, format "'[v' a '/' +++ '/' b ']'").
+
+Record R := { field : nat -> nat }.
+Set Printing Projections.
+Check fun x => 0 +++ x.(field) 0.
+
+End ProjectionPrinting.


### PR DESCRIPTION
**Kind:**  bug fix 

In situations of a projection applied to arguments, line breaks were unexpected due to a missing box.

This is particularly visible when enforcing a vertical box:
```
Notation "a +++ b" := (a * b) (at level 40, format "'[v' a '/' +++ '/' b ']'").
Record R := { field : nat -> nat }.
Set Printing Projections.
Check fun x => 0 +++ x.(field) 0.
(*
fun x : R => 0
             +++
             x.(field)
             0
*)
```
The PR fixes this to:
```
fun x : R => 0
             +++
             x.(field) 0
```
(one can incidentally wonder why there is no line break after `=>` but this is the OCaml strategy for vertical box which do not exceed the line).
- [X] Added / updated test-suite
