### PR TITLE
include Makefile.ci in Makefile.dune

### DIFF
--- a/Makefile.ci
+++ b/Makefile.ci
@@ -109,6 +109,15 @@ ci-gappa: ci-flocq
 $(CI_TARGETS): ci-%:
 	+./dev/ci/ci-wrapper.sh $*
 
+# if we do eg "make states ci-foo", ci-foo will wait for states
+# if we just do "make ci-foo" it will just run ci-foo
+# (technically the ci-* targets depend on world but it can be
+# convenient to run them with less than world compiled)
+NON_CI_GOALS:=$(strip $(filter-out ci-%,$(MAKECMDGOALS)))
+ifneq (,$(NON_CI_GOALS))
+$(CI_TARGETS): $(NON_CI_GOALS)
+endif
+
 # For emacs:
 # Local Variables:
 # mode: makefile

--- a/Makefile.dune
+++ b/Makefile.dune
@@ -138,6 +138,12 @@ ireport:
 clean:
 	dune clean
 
+# ci-* targets
+
+CI_PURE_DUNE:=1
+export CI_PURE_DUNE
+include Makefile.ci
+
 # Custom targets to create subsets of the world target but with less
 # compiled files. This is desired when we want to have our Coq Dune
 # build with Coq developments that are not dunerized and thus still

--- a/dev/ci/ci-common.sh
+++ b/dev/ci/ci-common.sh
@@ -26,7 +26,7 @@ then
     then
         export CI_PULL_REQUEST="${CI_BRANCH#pr-}"
     fi
-elif [ -d "$PWD/_build_vo/" ];
+elif [ -d "$PWD/_build_vo/" ] && [ -z "$CI_PURE_DUNE" ]
 then
     # Dune Ocaml build, vo build using make
     export OCAMLPATH="$PWD/_build_vo/default/lib/:$OCAMLPATH"


### PR DESCRIPTION
We make it so that ci targets called from Makefile.dune are detected
as not using the legacy system's _build_vo.

We also ensure that calling eg "make -f Makefile.dune other-target ci-foo"
correctly waits for "other-target" before running ci-foo, without
making ci-foo depend on any specific target (which would have to be
world, even though world is way more than eg ci-hott needs).