### PR TITLE
Small fix of has_undefined_evars

### DIFF
--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -77,7 +77,7 @@ let tj_nf_evar sigma {utj_val=v;utj_type=t} =
   {utj_val=nf_evar sigma v;utj_type=t}
 
 let nf_evars_universes evm =
-  UnivSubst.nf_evars_and_universes_opt_subst (safe_evar_value evm)
+  UnivSubst.nf_evars_and_universes_opt_subst (fun ~inner -> safe_evar_value evm)
     (Evd.universe_subst evm)
 
 let nf_named_context_evar sigma ctx =

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1518,16 +1518,16 @@ module MiniEConstr = struct
 
   let to_constr ?(abort_on_undefined_evars=true) sigma c =
     let evar_value =
-      if not abort_on_undefined_evars then fun ev -> safe_evar_value sigma ev
-      else fun ev ->
+      if not abort_on_undefined_evars then fun ~inner ev -> safe_evar_value sigma ev
+      else fun ~inner ev ->
         match safe_evar_value sigma ev with
         | Some _ as v -> v
-        | None -> anomaly ~label:"econstr" Pp.(str "grounding a non evar-free term")
+        | None -> if inner then None else anomaly ~label:"econstr" Pp.(str "grounding a non evar-free term")
     in
     UnivSubst.nf_evars_and_universes_opt_subst evar_value (universe_subst sigma) c
 
   let to_constr_opt sigma c =
-    let evar_value ev = Some (existential_value sigma ev) in
+    let evar_value ~inner ev = Some (existential_value sigma ev) in
     try
       Some (UnivSubst.nf_evars_and_universes_opt_subst evar_value (universe_subst sigma) c)
     with NotInstantiatedEvar ->

--- a/engine/univSubst.mli
+++ b/engine/univSubst.mli
@@ -29,7 +29,7 @@ val normalize_opt_subst : universe_opt_subst -> universe_opt_subst
 
 (** Full universes substitutions into terms *)
 
-val nf_evars_and_universes_opt_subst : (existential -> constr option) ->
+val nf_evars_and_universes_opt_subst : (inner:bool -> existential -> constr option) ->
   universe_opt_subst -> constr -> constr
 
 (** Pretty-printing *)

--- a/tactics/ind_tables.ml
+++ b/tactics/ind_tables.ml
@@ -101,7 +101,7 @@ let check_scheme kind ind = Option.has_some (lookup_scheme kind ind)
 let define internal role id c poly univs =
   let id = compute_name internal id in
   let uctx = UState.minimize univs in
-  let c = UnivSubst.nf_evars_and_universes_opt_subst (fun _ -> None) (UState.subst uctx) c in
+  let c = UnivSubst.nf_evars_and_universes_opt_subst (fun ~inner _ -> None) (UState.subst uctx) c in
   let univs = UState.univ_entry ~poly uctx in
   !declare_definition_scheme ~internal ~univs ~role ~name:id c
 

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1639,7 +1639,7 @@ let close_proof_delayed ~feedback_id ps (fpl : closed_proof_output Future.comput
   (* Because of dependent subgoals at the beginning of proofs, we could
      have existential variables in the initial types of goals, we need to
      normalise them for the kernel. *)
-  let subst_evar k = Evd.existential_opt_value0 sigma k in
+  let subst_evar ~inner k = Evd.existential_opt_value0 sigma k in
   let nf = UnivSubst.nf_evars_and_universes_opt_subst subst_evar (UState.subst initial_euctx) in
 
   (* We only support opaque proofs, this will be enforced by using


### PR DESCRIPTION
**Kind:** bug fix

`has_undefined_evars` was not looking inside the instance of lazily-instantiated evars.

The impact is difficult to evaluate. It possibly had let believe in some cases that a failing call to `infer_conv` in `evar_conv_x` was not worth falling back on `evar_eqappr_x`?? On the other side, it may have taken the benefit of full conversion on terms with evars seen as axioms, what `evar_eqappr_x` would not have been able to do??

To comply with the intended meaning, I believe it should nevertheless be fixed.