### PR TITLE
When terms in SProp do not unify, rely on proof irrelevance

### DIFF
--- a/test-suite/success/unification.v
+++ b/test-suite/success/unification.v
@@ -199,3 +199,7 @@ Check
     H ?[y] a p : x = 0.
 (* We have to solve "?P ?y[x] == x = 0" knowing from
    "p : (x=0) == (?y[x] = 0)" that "?y := x" *)
+
+(* An example involving SProp *)
+
+Check fun (A:SProp) (f g:A->A) (P:A->Type) a (x : P (f a)) => x : P (g _).


### PR DESCRIPTION
**Kind:** experimental feature

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes #14370

- [ ] Added / updated test-suite
- [ ] Entry added in the changelog