### PR TITLE
Small fix of EConstr.to_constr

### DIFF
--- a/engine/univSubst.ml
+++ b/engine/univSubst.ml
@@ -94,9 +94,10 @@ let nf_evars_and_universes_opt_subst f subst =
   let rec aux c =
     match kind c with
     | Evar (evk, args) ->
-      let args' = List.Smart.map aux args in
-      (match try f (evk, args') with Not_found -> None with
-      | None -> if args == args' then c else mkEvar (evk, args')
+      (match try f (evk, args) with Not_found -> None with
+      | None ->
+        let args' = List.Smart.map aux args in
+         if args == args' then c else mkEvar (evk, args')
       | Some c -> aux c)
     | Const pu ->
       let pu' = subst_univs_fn_puniverses lsubst pu in


### PR DESCRIPTION
**Kind:** bug fix

It was failing even in the presence of discarded evars in the instance of other evars.

This fix is one possibility among others. It preserves the algorithm content which applies `to_constr` once for all to all arguments of an evar. Another fix (less intrusive) would have been to recursively apply `to_constr` by need, after substitution of the original instances in the evar.

Note: This replaces #14367 where a wrong diagnosis was made.