### PR TITLE
Fixes #13966: broken invariant when overriding notation with different applicability to "match" patterns

### DIFF
--- a/doc/changelog/03-notations/14377-master+fix13966-broken-invariant-notation-overriden-different-pattern-applicability.rst
+++ b/doc/changelog/03-notations/14377-master+fix13966-broken-invariant-notation-overriden-different-pattern-applicability.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  anomaly when overriding a notation with different applicability in
+  :g:`match` patterns
+  (`#14377 <https://github.com/coq/coq/pull/14377>`_,
+  fixes `#13966 <https://github.com/coq/coq/issues/13966>`_,
+  by Hugo Herbelin).

--- a/test-suite/bugs/closed/bug_13966.v
+++ b/test-suite/bugs/closed/bug_13966.v
@@ -1,0 +1,6 @@
+Inductive expr  := Const : nat -> expr.
+
+Declare Custom Entry expr.
+Notation "'[' e ']'" := e (e custom expr at level 0).
+Notation "x" := (Const x) (in custom expr at level 0, x bigint).
+Notation "x" := x (in custom expr at level 0, x ident).


### PR DESCRIPTION
**Kind:** bug fix

This was introduced in 26a456cbf1.

We do not expect anymore a notation overriding another one to have the same applicability in "match" pattern.

In particular, when a notation interpretation overrides another one, this deactivates also the use of the previous one in patterns, if ever the new one does not apply to patterns (and vice-versa).

Fixes / closes #13966

- [X] Added / updated test-suite
- [x] Entry added in the changelog
