### PR TITLE
Fixes #14124: forbid empty strings in Ltac notations

### DIFF
--- a/doc/changelog/04-tactics/14378-master+fix14124-check-empty-string-ltac-notation.rst
+++ b/doc/changelog/04-tactics/14378-master+fix14124-check-empty-string-ltac-notation.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  anomalies caused by empty strings in Ltac notations are now errors
+  (`#14378 <https://github.com/coq/coq/pull/14378>`_,
+  fixes `#14124 <https://github.com/coq/coq/issues/14124>`_,
+  by Hugo Herbelin).

--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -450,10 +450,13 @@ let pr_ltac_production_item = function
   in
   str arg ++ str "(" ++ Id.print id ++ sep ++ str ")"
 
+let check_non_empty_string ?loc s =
+  if String.is_empty s then CErrors.user_err ?loc (str "Invalid empty string.")
+
 }
 
 VERNAC ARGUMENT EXTEND ltac_production_item PRINTED BY { pr_ltac_production_item }
-| [ string(s) ] -> { Tacentries.TacTerm s }
+| [ string(s) ] -> { check_non_empty_string ~loc s; Tacentries.TacTerm s }
 | [ ident(nt) "(" ident(p) ltac_production_sep_opt(sep) ")" ] ->
   { Tacentries.TacNonTerm (Loc.tag ~loc ((Id.to_string nt, sep), Some p)) }
 | [ ident(nt) ] ->


### PR DESCRIPTION
**Kind:** bug fix

Fixes / closes #14124

- [x] Added / updated test-suite
- [x] Entry added in the changelog
