### PR TITLE
Fixes #11402: Reserved Infix supports infix notations with extra parameters among the list of symbols

### DIFF
--- a/doc/changelog/03-notations/14379-master+fix11402-reserved-infix-with-extra-parameters.rst
+++ b/doc/changelog/03-notations/14379-master+fix11402-reserved-infix-with-extra-parameters.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  :cmd:`Reserved Infix` now accept further parameters in the infix notation
+  (`#14379 <https://github.com/coq/coq/pull/14379>`_,
+  fixes `#11402 <https://github.com/coq/coq/issues/11402>`_,
+  by Hugo Herbelin).

--- a/test-suite/bugs/closed/bug_11402.v
+++ b/test-suite/bugs/closed/bug_11402.v
@@ -1,0 +1,3 @@
+Reserved Infix "||->{ f }" (at level 50, left associativity).
+Infix "||->{ f }" := f.
+Check 0 ||->{ Nat.add } 0.

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -1179,7 +1179,7 @@ GRAMMAR EXTEND Gram
      | IDENT "Infix"; op = ne_lstring; ":="; p = constr;
          modl = syntax_modifiers;
          sc = OPT [ ":"; sc = IDENT -> { sc } ] ->
-         { VernacInfix ((op,modl),p,sc) }
+         { VernacNotation (true,p,(op,modl),sc) }
      | IDENT "Notation"; id = identref; idl = LIST0 ident;
          ":="; c = constr; modl = syntax_modifiers ->
            { VernacSyntacticDefinition (id,(idl,c), modl) }
@@ -1187,19 +1187,14 @@ GRAMMAR EXTEND Gram
          c = constr;
          modl = syntax_modifiers;
          sc = OPT [ ":"; sc = IDENT -> { sc } ] ->
-           { VernacNotation (c,(s,modl),sc) }
+           { VernacNotation (false,c,(s,modl),sc) }
      | IDENT "Format"; IDENT "Notation"; n = STRING; s = STRING; fmt = STRING ->
            { VernacNotationAddFormat (n,s,fmt) }
 
-     | IDENT "Reserved"; IDENT "Infix"; s = ne_lstring;
-         l = syntax_modifiers ->
-           { let s = CAst.map (fun s -> "x '"^s^"' y") s in
-           VernacReservedNotation (true,(s,l)) }
-
-     | IDENT "Reserved"; IDENT "Notation";
-         s = ne_lstring;
-         l = syntax_modifiers
-         -> { VernacReservedNotation (false, (s,l)) }
+     | IDENT "Reserved"; IDENT "Infix"; s = ne_lstring; l = syntax_modifiers ->
+           { VernacReservedNotation (true,(s,l)) }
+     | IDENT "Reserved"; IDENT "Notation"; s = ne_lstring; l = syntax_modifiers ->
+           { VernacReservedNotation (false,(s,l)) }
 
      (* "Print" "Grammar" and "Declare" "Scope" should be here but are in "command" entry in order
         to factorize with other "Print"-based or "Declare"-based vernac entries *)

--- a/vernac/metasyntax.mli
+++ b/vernac/metasyntax.mli
@@ -19,10 +19,7 @@ val add_token_obj : string -> unit
 
 (** Adding a (constr) notation in the environment*)
 
-val add_infix : local:bool -> Deprecation.t option -> env -> (lstring * syntax_modifier CAst.t list) ->
-  constr_expr -> scope_name option -> unit
-
-val add_notation : local:bool -> Deprecation.t option -> env -> constr_expr ->
+val add_notation : local:bool -> infix:bool -> Deprecation.t option -> env -> constr_expr ->
   (lstring * syntax_modifier CAst.t list) -> scope_name option -> unit
 
 val add_notation_extra_printing_rule : string -> string -> string -> unit

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -757,22 +757,14 @@ let pr_vernac_expr v =
       keyword "Bind Scope" ++ spc () ++ str sc ++
       spc() ++ keyword "with" ++ spc () ++ prlist_with_sep spc pr_class_rawexpr cll
     )
-  | VernacInfix (({v=s},mv),q,sn) -> (* A Verifier *)
+  | VernacNotation (infix,c,({v=s},l),opt) ->
     return (
-      hov 0 (hov 0 (keyword "Infix "
-                    ++ qs s ++ str " :=" ++ pr_constrarg q) ++
-             pr_syntax_modifiers mv ++
-             (match sn with
-              | None -> mt()
-              | Some sc -> spc() ++ str":" ++ spc() ++ str sc))
-    )
-  | VernacNotation (c,({v=s},l),opt) ->
-    return (
-      hov 2 (keyword "Notation" ++ spc() ++ qs s ++
-             str " :=" ++ Flags.without_option Flags.beautify pr_constrarg c ++ pr_syntax_modifiers l ++
+      hov 2 (hov 0 (keyword (if infix then "Infix" else "Notation") ++ spc() ++ qs s ++
+             str " :=" ++ Flags.without_option Flags.beautify pr_constrarg c) ++
+             pr_syntax_modifiers l ++
              (match opt with
               | None -> mt()
-              | Some sc -> str" :" ++ spc() ++ str sc))
+              | Some sc -> spc() ++ str":" ++ spc() ++ str sc))
     )
   | VernacReservedNotation (_, (s, l)) ->
     return (

--- a/vernac/vernac_classifier.ml
+++ b/vernac/vernac_classifier.ml
@@ -169,7 +169,7 @@ let classify_vernac e =
     | VernacDeclareCustomEntry _
     | VernacOpenCloseScope _ | VernacDeclareScope _
     | VernacDelimiters _ | VernacBindScope _
-    | VernacInfix _ | VernacNotation _ | VernacNotationAddFormat _
+    | VernacNotation _ | VernacNotationAddFormat _
     | VernacReservedNotation _
     | VernacSyntacticDefinition _
     | VernacRequire _ | VernacImport _ | VernacInclude _

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -521,13 +521,9 @@ let vernac_bind_scope ~module_local sc cll =
 let vernac_open_close_scope ~section_local (b,s) =
   Notation.open_close_scope (section_local,b,s)
 
-let vernac_infix ~atts =
+let vernac_notation ~atts ~infix =
   let module_local, deprecation = Attributes.(parse Notations.(module_locality ++ deprecation) atts) in
-  Metasyntax.add_infix ~local:module_local deprecation (Global.env())
-
-let vernac_notation ~atts =
-  let module_local, deprecation = Attributes.(parse Notations.(module_locality ++ deprecation) atts) in
-  Metasyntax.add_notation ~local:module_local deprecation (Global.env())
+  Metasyntax.add_notation ~local:module_local ~infix deprecation (Global.env())
 
 let vernac_custom_entry ~module_local s =
   Metasyntax.declare_custom_entry module_local s
@@ -2099,10 +2095,8 @@ let translate_vernac ?loc ~atts v = let open Vernacextend in match v with
     VtDefault(fun () -> with_module_locality ~atts vernac_bind_scope sc rl)
   | VernacOpenCloseScope (b, s) ->
     VtDefault(fun () -> with_section_locality ~atts vernac_open_close_scope (b,s))
-  | VernacInfix (mv,qid,sc) ->
-    VtDefault(fun () -> vernac_infix ~atts mv qid sc)
-  | VernacNotation (c,infpl,sc) ->
-    VtDefault(fun () -> vernac_notation ~atts c infpl sc)
+  | VernacNotation (infix,c,infpl,sc) ->
+    VtDefault(fun () -> vernac_notation ~atts ~infix c infpl sc)
   | VernacNotationAddFormat(n,k,v) ->
     VtDefault(fun () ->
         unsupported_attributes atts;

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -109,6 +109,8 @@ type instance_flag  = BackInstance | NoInstance
 
 type export_flag    = bool (* true = Export;        false = Import         *)
 
+type infix_flag     = bool (* true = Infix;         false = Notation       *)
+
 type one_import_filter_name = qualid * bool (* import inductive components *)
 type import_filter_expr =
   | ImportAll
@@ -313,15 +315,13 @@ type nonrec vernac_expr =
 
   | VernacLoad of verbose_flag * string
   (* Syntax *)
-  | VernacReservedNotation of bool * (lstring * syntax_modifier CAst.t list)
+  | VernacReservedNotation of infix_flag * (lstring * syntax_modifier CAst.t list)
   | VernacOpenCloseScope of bool * scope_name
   | VernacDeclareScope of scope_name
   | VernacDelimiters of scope_name * string option
   | VernacBindScope of scope_name * class_rawexpr list
-  | VernacInfix of (lstring * syntax_modifier CAst.t list) *
-      constr_expr * scope_name option
   | VernacNotation of
-      constr_expr * (lstring * syntax_modifier CAst.t list) *
+      infix_flag * constr_expr * (lstring * syntax_modifier CAst.t list) *
       scope_name option
   | VernacNotationAddFormat of string * string * string
   | VernacDeclareCustomEntry of string


### PR DESCRIPTION
**Kind:** enhancement

Fixes / closes #11402

~~Note that `Reserved Infix` is still a hack though.~~ 27 June 21: A new fix is adopted, on top of #13353. 

- [X] Added / updated test-suite
- [X] Entry added in the changelog