### PR TITLE
Handle delayed opaque proofs in Print Assumptions

### DIFF
--- a/doc/changelog/07-vernac-commands-and-options/14382-assumptions-delayed-opaque.rst
+++ b/doc/changelog/07-vernac-commands-and-options/14382-assumptions-delayed-opaque.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Print Assumptions now treats delayed opaque proofs generated
+  by vos compilation as if they were axioms
+  (`#14382 <https://github.com/coq/coq/pull/14382>`_,
+  fixes `#13589 <https://github.com/coq/coq/issues/13589>`_,
+  by Pierre-Marie Pédrot).

--- a/test-suite/misc/print-assumptions-vok.sh
+++ b/test-suite/misc/print-assumptions-vok.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+# Use coqc instead of $coqc to work in async mode
+export PATH="$BIN:$PATH"
+
+coqc -R misc/print-assumptions-vok/ PrintAssumptionsVOK -vos misc/print-assumptions-vok/file1.v
+coqc -R misc/print-assumptions-vok/ PrintAssumptionsVOK -vos misc/print-assumptions-vok/file2.v
+coqc -R misc/print-assumptions-vok/ PrintAssumptionsVOK -vok misc/print-assumptions-vok/file2.v

--- a/test-suite/misc/print-assumptions-vok/file1.v
+++ b/test-suite/misc/print-assumptions-vok/file1.v
@@ -1,0 +1,5 @@
+Lemma hidden : False.
+Proof. Admitted.
+
+Lemma aux : False.
+Proof. apply hidden. Qed.

--- a/test-suite/misc/print-assumptions-vok/file2.v
+++ b/test-suite/misc/print-assumptions-vok/file2.v
@@ -1,0 +1,6 @@
+From PrintAssumptionsVOK Require file1.
+
+Lemma main : False.
+Proof. apply file1.aux. Qed.
+
+Print Assumptions main. (* this fails *)


### PR DESCRIPTION
Instead of using Global.body_of_constant_body and tinkering with the result we roll up our own version of the accessor which is delayed-proof-aware.

Fixes #13589: Print Assumptions for vok.

Supersedes #13614.