### PR TITLE
Fast monomial implementation in Micromega

### DIFF
--- a/plugins/micromega/polynomial.ml
+++ b/plugins/micromega/polynomial.ml
@@ -82,7 +82,7 @@ end = struct
     let s1 = sum_degree m1 and s2 = sum_degree m2 in
     if Int.equal s1 s2 then Map.compare Int.compare m1 m2 else Int.compare s1 s2
 
-  let is_const m = m = Map.empty
+  let is_const = Map.is_empty
 
   (* The monomial 'x' *)
   let var x = Map.add x 1 Map.empty

--- a/plugins/micromega/polynomial.mli
+++ b/plugins/micromega/polynomial.mli
@@ -20,49 +20,9 @@ module Monomial : sig
   (** A monomial is represented by a multiset of variables  *)
   type t
 
-  (** [fold f m acc]
-       folds over the variables with multiplicities *)
-  val fold : (var -> int -> 'a -> 'a) -> t -> 'a -> 'a
-
   (** [degree m] is the sum of the degrees of each variable *)
   val degree : t -> int
 
-  (** [const]
-      @return the empty monomial i.e. without any variable *)
-  val const : t
-
-  val is_const : t -> bool
-
-  (** [var x]
-      @return the monomial x^1 *)
-  val var : var -> t
-
-  (** [prod n m]
-      @return the monomial n*m *)
-  val prod : t -> t -> t
-
-  (** [sqrt m]
-      @return [Some r] iff r^2 = m *)
-  val sqrt : t -> t option
-
-  (** [is_var m]
-      @return [true] iff m = x^1 for some variable x *)
-  val is_var : t -> bool
-
-  (** [get_var m]
-      @return [x] iff m = x^1 for  variable x *)
-  val get_var : t -> var option
-
-  (** [div m1 m2]
-      @return a pair [mr,n] such that mr * (m2)^n = m1 where n is maximum *)
-  val div : t -> t -> t * int
-
-  (** [compare m1 m2] provides a total order over monomials*)
-  val compare : t -> t -> int
-
-  (** [variables m]
-      @return the set of variables with (strictly) positive multiplicities *)
-  val variables : t -> ISet.t
 end
 
 module MonMap : sig


### PR DESCRIPTION
We use an algorithmically more efficient representation of monomials in micromega tactics.
- Instead of a map from variables to exponents, we use a compact array representation.
- In particular, getting the multidegree is O(1) where it was O(n) before.
- Monomial comparison exploits this as a short path
- Division and exponent in have been replaced with a single factorisation primitive.
