### PR TITLE
Pseudo monomorphic instances

### DIFF
--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -974,20 +974,24 @@ let make_nonalgebraic_variable evd u =
 let fresh_sort_in_family ?loc ?(rigid=univ_flexible) evd s =
   with_context_set ?loc rigid evd (UnivGen.fresh_sort_in_family s)
 
-let fresh_constant_instance ?loc ?(rigid=univ_flexible) env evd c =
-  with_context_set ?loc rigid evd (UnivGen.fresh_constant_instance env c)
+let fresh_instance_for_global ?loc ?rigid ?names env evd gr =
+  let u, uctx = UState.fresh_instance_for_global ?loc ?rigid ?names env evd.universes gr in
+  {evd with universes = uctx}, u
 
-let fresh_inductive_instance ?loc ?(rigid=univ_flexible) env evd i =
-  with_context_set ?loc rigid evd (UnivGen.fresh_inductive_instance env i)
+let fresh_constant_instance ?loc ?rigid env evd c =
+  on_snd (fun u -> c,u) (fresh_instance_for_global ?loc ?rigid env evd (GlobRef.ConstRef c))
 
-let fresh_constructor_instance ?loc ?(rigid=univ_flexible) env evd c =
-  with_context_set ?loc rigid evd (UnivGen.fresh_constructor_instance env c)
+let fresh_inductive_instance ?loc ?rigid env evd i =
+  on_snd (fun u -> i,u) (fresh_instance_for_global ?loc ?rigid env evd (GlobRef.IndRef i))
+
+let fresh_constructor_instance ?loc ?rigid env evd c =
+  on_snd (fun u -> c,u) (fresh_instance_for_global ?loc ?rigid env evd (GlobRef.ConstructRef c))
 
 let fresh_array_instance ?loc ?(rigid=univ_flexible) env evd =
   with_context_set ?loc rigid evd (UnivGen.fresh_array_instance env)
 
-let fresh_global ?loc ?(rigid=univ_flexible) ?names env evd gr =
-  with_context_set ?loc rigid evd (UnivGen.fresh_global_instance ?loc ?names env gr)
+let fresh_global ?loc ?rigid ?names env evd gr =
+  on_snd (fun u -> mkRef (gr,u)) (fresh_instance_for_global ?loc ?rigid ?names env evd gr)
 
 let is_sort_variable evd s = UState.is_sort_variable evd.universes s
 

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -140,6 +140,9 @@ val new_univ_variable : ?loc:Loc.t -> rigid -> Id.t option -> t -> t * Univ.Leve
     univ_flexible_alg for a universe existential variable allowed to
     be instantiated with an algebraic universe *)
 
+val fresh_instance_for_global : ?loc:Loc.t -> ?rigid:rigid -> ?names:Univ.Instance.t
+  -> Environ.env -> t -> GlobRef.t -> Instance.t * t
+
 val add_global_univ : t -> Univ.Level.t -> t
 
 (** [make_flexible_variable g algebraic l]

--- a/engine/univGen.ml
+++ b/engine/univGen.ml
@@ -48,21 +48,21 @@ let fresh_instance_from ?loc ctx = function
 
 (** Fresh universe polymorphic construction *)
 
-let fresh_global_instance ?loc ?names env gr =
+let fresh_instance_for_global ?loc ?names env gr =
   let auctx = Environ.universes_of_global env gr in
   let u, ctx = fresh_instance_from ?loc auctx names in
   u, ctx
 
 let fresh_constant_instance env c =
-  let u, ctx = fresh_global_instance env (GlobRef.ConstRef c) in
+  let u, ctx = fresh_instance_for_global env (GlobRef.ConstRef c) in
   (c, u), ctx
 
 let fresh_inductive_instance env ind =
-  let u, ctx = fresh_global_instance env (GlobRef.IndRef ind) in
+  let u, ctx = fresh_instance_for_global env (GlobRef.IndRef ind) in
   (ind, u), ctx
 
 let fresh_constructor_instance env c =
-  let u, ctx = fresh_global_instance env (GlobRef.ConstructRef c) in
+  let u, ctx = fresh_instance_for_global env (GlobRef.ConstructRef c) in
   (c, u), ctx
 
 let fresh_array_instance env =
@@ -71,12 +71,12 @@ let fresh_array_instance env =
   u, ctx
 
 let fresh_global_instance ?loc ?names env gr =
-  let u, ctx = fresh_global_instance ?loc ?names env gr in
+  let u, ctx = fresh_instance_for_global ?loc ?names env gr in
   mkRef (gr, u), ctx
 
 let constr_of_monomorphic_global gr =
   if not (Global.is_polymorphic gr) then
-    fst (fresh_global_instance (Global.env ()) gr)
+    mkRef (gr, Instance.empty)
   else CErrors.user_err ~hdr:"constr_of_global"
       Pp.(str "globalization of polymorphic reference " ++ Nametab.pr_global_env Id.Set.empty gr ++
           str " would forget universes.")

--- a/engine/univGen.mli
+++ b/engine/univGen.mli
@@ -28,6 +28,9 @@ val fresh_instance : AUContext.t -> Instance.t in_universe_context_set
 val fresh_instance_from : ?loc:Loc.t -> AUContext.t -> Instance.t option ->
   Instance.t in_universe_context_set
 
+val fresh_instance_for_global : ?loc:Loc.t -> ?names:Univ.Instance.t -> env -> GlobRef.t ->
+  Instance.t in_universe_context_set
+
 val fresh_sort_in_family : Sorts.family ->
   Sorts.t in_universe_context_set
 val fresh_constant_instance : env -> Constant.t ->

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -55,6 +55,7 @@ let debug_ho_unification = CDebug.create ~name:"ho-unification" ()
 (* Functions to deal with impossible cases *)
 (*******************************************)
 let impossible_default_case env =
+  (* TODO use evar map *)
   let type_of_id = Coqlib.lib_ref "core.IDProp.type" in
   let c, ctx = UnivGen.fresh_global_instance env (Coqlib.(lib_ref "core.IDProp.idProp")) in
   let (_, u) = Constr.destRef c in


### PR DESCRIPTION
This adds an option "Pseudo Monomorphic Instances" which when set
causes auto-generated instances of polymorphic globals to be memoized
across the lifetime of an evar map.

ie
~~~coq
Set Universe Polymorphism.
Set Pseudo Monomorphic Instances.

Definition typ := Type.

Fail Check typ : typ.
(* they got the same instance *)

Check typ@{_} : typ.
(* explicit instances bypass memoization *)

Definition typ' := typ.
Check typ : typ'.
(* different constants get different instances, the instance used for
typ in typ' is not remembered after the definition ends *)
~~~

The goal was to improve perf by generating less universes when the
lack of generality is acceptable, but it may be too aggressive in
practice.

For instance when equality is univ poly (as in hott) we usually don't
want to memoize its instances.
