### PR TITLE
Correctly declare scheme dependencies

### DIFF
--- a/tactics/ind_tables.ml
+++ b/tactics/ind_tables.ml
@@ -28,7 +28,7 @@ open Pp
 type inline_flag = InlineDeps | KeepDeps
 
 type mutual_scheme_object_function =
-  inline_flag -> MutInd.t -> constr array Evd.in_evar_universe_context
+  MutInd.t -> constr array Evd.in_evar_universe_context
 type individual_scheme_object_function =
   inductive -> constr Evd.in_evar_universe_context
 
@@ -125,7 +125,7 @@ and define_individual_scheme kind mode names (mind,i as ind) =
 
 (* Assumes that dependencies are already defined *)
 and define_mutual_scheme_base kind suff f mode names mind eff =
-  let (cl, ctx) = f mode mind in
+  let (cl, ctx) = f mind in
   let mib = Global.lookup_mind mind in
   let ids = Array.init (Array.length mib.mind_packets) (fun i ->
       try Int.List.assoc i names

--- a/tactics/ind_tables.ml
+++ b/tactics/ind_tables.ml
@@ -25,8 +25,6 @@ open Pp
 (**********************************************************************)
 (* Registering schemes in the environment *)
 
-type inline_flag = InlineDeps | KeepDeps
-
 type mutual_scheme_object_function =
   MutInd.t -> constr array Evd.in_evar_universe_context
 type individual_scheme_object_function =
@@ -102,29 +100,28 @@ let define internal role id c poly univs =
   !declare_definition_scheme ~internal ~univs ~role ~name:id c
 
 (* Assumes that dependencies are already defined *)
-let rec define_individual_scheme_base kind suff f mode idopt (mind,i as ind) eff =
+let rec define_individual_scheme_base kind suff f ~internal idopt (mind,i as ind) eff =
   let (c, ctx) = f ind in
   let mib = Global.lookup_mind mind in
   let id = match idopt with
     | Some id -> id
     | None -> add_suffix mib.mind_packets.(i).mind_typename suff in
   let role = Evd.Schema (ind, kind) in
-  let internal = mode == InlineDeps in
   let const, neff = define internal role id c (Declareops.inductive_is_polymorphic mib) ctx in
   let eff = Evd.concat_side_effects neff eff in
   DeclareScheme.declare_scheme kind [|ind,const|];
   const, eff
 
-and define_individual_scheme kind mode names (mind,i as ind) =
+and define_individual_scheme kind ~internal names (mind,i as ind) =
   match Hashtbl.find scheme_object_table kind with
   | _,MutualSchemeFunction _ -> assert false
   | s,IndividualSchemeFunction (f, deps) ->
     let deps = match deps with None -> [] | Some deps -> deps ind in
-    let eff = List.fold_left (fun eff dep -> declare_scheme_dependence mode eff dep) Evd.empty_side_effects deps in
-    define_individual_scheme_base kind s f mode names ind eff
+    let eff = List.fold_left (fun eff dep -> declare_scheme_dependence eff dep) Evd.empty_side_effects deps in
+    define_individual_scheme_base kind s f ~internal names ind eff
 
 (* Assumes that dependencies are already defined *)
-and define_mutual_scheme_base kind suff f mode names mind eff =
+and define_mutual_scheme_base kind suff f ~internal names mind eff =
   let (cl, ctx) = f mind in
   let mib = Global.lookup_mind mind in
   let ids = Array.init (Array.length mib.mind_packets) (fun i ->
@@ -132,7 +129,6 @@ and define_mutual_scheme_base kind suff f mode names mind eff =
       with Not_found -> add_suffix mib.mind_packets.(i).mind_typename suff) in
   let fold i effs id cl =
     let role = Evd.Schema ((mind, i), kind)in
-    let internal = mode == InlineDeps in
     let cst, neff = define internal role id cl (Declareops.inductive_is_polymorphic mib) ctx in
     (Evd.concat_side_effects neff effs, cst)
   in
@@ -141,24 +137,24 @@ and define_mutual_scheme_base kind suff f mode names mind eff =
   DeclareScheme.declare_scheme kind schemes;
   consts, eff
 
-and define_mutual_scheme kind mode names mind =
+and define_mutual_scheme kind ~internal names mind =
   match Hashtbl.find scheme_object_table kind with
   | _,IndividualSchemeFunction _ -> assert false
   | s,MutualSchemeFunction (f, deps) ->
     let deps = match deps with None -> [] | Some deps -> deps mind in
-    let eff = List.fold_left (fun eff dep -> declare_scheme_dependence mode eff dep) Evd.empty_side_effects deps in
-    define_mutual_scheme_base kind s f mode names mind eff
+    let eff = List.fold_left (fun eff dep -> declare_scheme_dependence eff dep) Evd.empty_side_effects deps in
+    define_mutual_scheme_base kind s f ~internal names mind eff
 
-and declare_scheme_dependence mode eff = function
+and declare_scheme_dependence eff = function
 | SchemeIndividualDep (ind, kind) ->
   if check_scheme kind ind then eff
   else
-    let _, eff' = define_individual_scheme kind mode None ind in
+    let _, eff' = define_individual_scheme kind ~internal:true None ind in
     Evd.concat_side_effects eff' eff
 | SchemeMutualDep (mind, kind) ->
   if check_scheme kind (mind, 0) then eff
   else
-    let _, eff' = define_mutual_scheme kind mode [] mind in
+    let _, eff' = define_mutual_scheme kind ~internal:true [] mind in
     Evd.concat_side_effects eff' eff
 
 let find_scheme kind (mind,i as ind) =
@@ -170,21 +166,20 @@ let find_scheme kind (mind,i as ind) =
     Proofview.tclEFFECTS Evd.empty_side_effects <*>
     Proofview.tclUNIT s
   | None ->
-  let mode = InlineDeps in
   match Hashtbl.find scheme_object_table kind with
   | s,IndividualSchemeFunction (f, deps) ->
     let deps = match deps with None -> [] | Some deps -> deps ind in
-    let eff = List.fold_left (fun eff dep -> declare_scheme_dependence mode eff dep) Evd.empty_side_effects deps in
-    let c, eff = define_individual_scheme_base kind s f mode None ind eff in
+    let eff = List.fold_left (fun eff dep -> declare_scheme_dependence eff dep) Evd.empty_side_effects deps in
+    let c, eff = define_individual_scheme_base kind s f ~internal:true None ind eff in
     Proofview.tclEFFECTS eff <*> Proofview.tclUNIT c
   | s,MutualSchemeFunction (f, deps) ->
     let deps = match deps with None -> [] | Some deps -> deps mind in
-    let eff = List.fold_left (fun eff dep -> declare_scheme_dependence mode eff dep) Evd.empty_side_effects deps in
-    let ca, eff = define_mutual_scheme_base kind s f mode [] mind eff in
+    let eff = List.fold_left (fun eff dep -> declare_scheme_dependence eff dep) Evd.empty_side_effects deps in
+    let ca, eff = define_mutual_scheme_base kind s f ~internal:true [] mind eff in
     Proofview.tclEFFECTS eff <*> Proofview.tclUNIT ca.(i)
 
 let define_individual_scheme kind names ind =
-  ignore (define_individual_scheme kind KeepDeps names ind)
+  ignore (define_individual_scheme kind ~internal:false names ind)
 
 let define_mutual_scheme kind names mind =
-  ignore (define_mutual_scheme kind KeepDeps names mind)
+  ignore (define_mutual_scheme kind ~internal:false names mind)

--- a/tactics/ind_tables.mli
+++ b/tactics/ind_tables.mli
@@ -20,14 +20,12 @@ type mutual
 type individual
 type 'a scheme_kind
 
-type inline_flag = InlineDeps | KeepDeps
-
 type scheme_dependency =
 | SchemeMutualDep of MutInd.t * mutual scheme_kind
 | SchemeIndividualDep of inductive * individual scheme_kind
 
 type mutual_scheme_object_function =
-  inline_flag -> MutInd.t -> constr array Evd.in_evar_universe_context
+  MutInd.t -> constr array Evd.in_evar_universe_context
 type individual_scheme_object_function =
   inductive -> constr Evd.in_evar_universe_context
 

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -169,7 +169,7 @@ let build_beq_scheme_deps kn =
   in
   Array.fold_left_i (fun i accu _ -> make_one_eq accu i) [] mib.mind_packets
 
-let build_beq_scheme _ kn =
+let build_beq_scheme kn =
   check_bool_is_defined ();
   (* fetching global env *)
   let env = Global.env() in
@@ -698,7 +698,7 @@ repeat ( apply andb_prop in z;let z1:= fresh "Z" in destruct z as [z1 z]).
       ]
     end
 
-let make_bl_scheme _ mind =
+let make_bl_scheme mind =
   let mib = Global.lookup_mind mind in
   if not (Int.equal (Array.length mib.mind_packets) 1) then
     user_err
@@ -817,7 +817,7 @@ let compute_lb_tact ind lnamesparrec nparrec =
       ]
     end
 
-let make_lb_scheme _ mind =
+let make_lb_scheme mind =
   let mib = Global.lookup_mind mind in
   if not (Int.equal (Array.length mib.mind_packets) 1) then
     user_err
@@ -993,7 +993,7 @@ let compute_dec_tact ind lnamesparrec nparrec =
       end
     end
 
-let make_eq_decidability mode mind =
+let make_eq_decidability mind =
   let mib = Global.lookup_mind mind in
   if not (Int.equal (Array.length mib.mind_packets) 1) then
     raise DecidabilityMutualNotSupported;

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -698,11 +698,7 @@ repeat ( apply andb_prop in z;let z1:= fresh "Z" in destruct z as [z1 z]).
       ]
     end
 
-let side_effect_of_mode = function
-| InlineDeps -> true
-| KeepDeps -> false
-
-let make_bl_scheme mode mind =
+let make_bl_scheme _ mind =
   let mib = Global.lookup_mind mind in
   if not (Int.equal (Array.length mib.mind_packets) 1) then
     user_err
@@ -714,9 +710,8 @@ let make_bl_scheme mode mind =
     context_chop (nparams-nparrec) mib.mind_params_ctxt in
   let bl_goal = compute_bl_goal ind lnamesparrec nparrec in
   let uctx = UState.from_env (Global.env ()) in
-  let side_eff = side_effect_of_mode mode in
   let bl_goal = EConstr.of_constr bl_goal in
-  let (ans, _, _, _, ctx) = Declare.build_by_tactic ~poly:false ~side_eff (Global.env()) ~uctx ~typ:bl_goal
+  let (ans, _, _, _, ctx) = Declare.build_by_tactic ~poly:false ~side_eff:false (Global.env()) ~uctx ~typ:bl_goal
     (compute_bl_tact (ind, EConstr.EInstance.empty) lnamesparrec nparrec)
   in
   ([|ans|], ctx)
@@ -822,7 +817,7 @@ let compute_lb_tact ind lnamesparrec nparrec =
       ]
     end
 
-let make_lb_scheme mode mind =
+let make_lb_scheme _ mind =
   let mib = Global.lookup_mind mind in
   if not (Int.equal (Array.length mib.mind_packets) 1) then
     user_err
@@ -834,9 +829,8 @@ let make_lb_scheme mode mind =
     context_chop (nparams-nparrec) mib.mind_params_ctxt in
   let lb_goal = compute_lb_goal ind lnamesparrec nparrec in
   let uctx = UState.from_env (Global.env ()) in
-  let side_eff = side_effect_of_mode mode in
   let lb_goal = EConstr.of_constr lb_goal in
-  let (ans, _, _, _, ctx) = Declare.build_by_tactic ~poly:false ~side_eff (Global.env()) ~uctx ~typ:lb_goal
+  let (ans, _, _, _, ctx) = Declare.build_by_tactic ~poly:false ~side_eff:false (Global.env()) ~uctx ~typ:lb_goal
     (compute_lb_tact ind lnamesparrec nparrec)
   in
   ([|ans|], ctx)
@@ -1010,8 +1004,7 @@ let make_eq_decidability mode mind =
   let uctx = UState.from_env (Global.env ()) in
   let lnonparrec,lnamesparrec =
     context_chop (nparams-nparrec) mib.mind_params_ctxt in
-  let side_eff = side_effect_of_mode mode in
-  let (ans, _, _, _, ctx) = Declare.build_by_tactic ~poly:false ~side_eff (Global.env()) ~uctx
+  let (ans, _, _, _, ctx) = Declare.build_by_tactic ~poly:false ~side_eff:false (Global.env()) ~uctx
       ~typ:(EConstr.of_constr (compute_dec_goal (ind,u) lnamesparrec nparrec))
       (compute_dec_tact ind lnamesparrec nparrec)
   in

--- a/vernac/auto_ind_decl.mli
+++ b/vernac/auto_ind_decl.mli
@@ -31,16 +31,12 @@ exception ConstructorWithNonParametricInductiveType of inductive
 exception DecidabilityIndicesNotSupported
 
 val beq_scheme_kind : mutual scheme_kind
-val build_beq_scheme : mutual_scheme_object_function
 
 (** {6 Build equivalence between boolean equality and Leibniz equality } *)
 
 val lb_scheme_kind : mutual scheme_kind
-val make_lb_scheme : mutual_scheme_object_function
 val bl_scheme_kind : mutual scheme_kind
-val make_bl_scheme : mutual_scheme_object_function
 
 (** {6 Build decidability of equality } *)
 
 val eq_dec_scheme_kind : mutual scheme_kind
-val make_eq_decidability : mutual_scheme_object_function

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -289,6 +289,8 @@ let declare_rewriting_schemes ind =
     (* needs eq *)
     ignore_error (define_individual_scheme rew_l2r_scheme_kind None) ind;
     ignore_error
+      (define_individual_scheme sym_involutive_scheme_kind None) ind;
+    ignore_error
       (define_individual_scheme rew_l2r_dep_scheme_kind None) ind;
     ignore_error
       (define_individual_scheme rew_l2r_forward_dep_scheme_kind None) ind


### PR DESCRIPTION
We fix the computation of scheme dependencies, allowing the scheme functions to expect their dependencies to be in the environment instead of declaring them on the fly. As a side-effect, this remove the last uses of the inlining flag passed to these functions and results in a net cleanup.

I believe this supersedes #9838. Next step is to rely on proof-local scheme registration, which brings closer the fix of abstract + backtrack issues.