### PR TITLE
Do not consider scrutinees of projections and cases as heads for hint mode "!"

### DIFF
--- a/doc/changelog/02-specification-language/14392-nohead-evar-application-hea.rst
+++ b/doc/changelog/02-specification-language/14392-nohead-evar-application-hea.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  The hints mode ``!`` matches a term iff the applicative head is not an existential variable.
+  It now also matches projections applied to any term or a `match` on any term.
+  (`#14392 <https://github.com/coq/coq/pull/14392>`_,
+  by Matthieu Sozeau).

--- a/doc/sphinx/proofs/automatic-tactics/auto.rst
+++ b/doc/sphinx/proofs/automatic-tactics/auto.rst
@@ -480,17 +480,16 @@ Creating Hints
       :n:`@qualid` can be applied or not. A mode specification is a list of ``+``,
       ``!`` or ``-`` items that specify if an argument of the identifier is to be
       treated as an input (``+``), if its head only is an input (``!``) or an output
-      (``-``) of the identifier. For a mode to match a list of arguments, input
-      terms and input heads *must not* contain existential variables or be
-      existential variables respectively, while outputs can be any term.
+      (``-``) of the identifier. Mode ``-`` matches any term, mode ``+`` matches a
+      term if and only if it does not contain existential variables, while mode ``!``
+      matches a term if and only if the *head* of the term is not an existential variable.
+      The head of a term is understood here as the applicative head, recursively,
+      ignoring casts.
 
-      The head of a term
-      is understood here as the applicative head, or the match or projection
-      scrutinee’s head, recursively, casts being ignored. :cmd:`Hint Mode` is
-      especially useful for typeclasses, when one does not want to support default
-      instances and avoid ambiguity in general. Setting a parameter of a class as an
-      input forces proof search to be driven by that index of the class, with ``!``
-      allowing existentials to appear in the index but not at its head.
+      :cmd:`Hint Mode` is especially useful for typeclasses, when one does not want
+      to support default instances and wants to avoid ambiguity in general. Setting a parameter
+      of a class as an input forces proof search to be driven by that index of the class,
+      with ``!`` allowing existentials to appear in the index but not at its head.
 
    .. note::
 

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -590,10 +590,8 @@ struct
   let head_evar sigma c =
     let rec hrec c = match EConstr.kind sigma c with
       | Evar (evk,_)   -> evk
-      | Case (_,_,_,_,_,c,_) -> hrec c
       | App (c,_)      -> hrec c
       | Cast (c,_,_)   -> hrec c
-      | Proj (p, c)    -> hrec c
       | _              -> raise Evarutil.NoHeadEvar
     in
     hrec c

--- a/test-suite/success/HintMode.v
+++ b/test-suite/success/HintMode.v
@@ -18,3 +18,20 @@ Goal forall A T `{In A T} `{Empty T} `{EmptyIn A T}, forall x : A, IsIn x empty 
 Qed.
 
 End Postponing.
+
+Module Heads.
+  Set Primitive Projections.
+  Class A (X : Type) := { somex : X }.
+  Local Hint Mode A ! : typeclass_instances.
+
+  Record foo := { car : Type; obj : car }.
+  Local Instance foo_A (f : foo) : A (car f) := { somex := obj f }.
+
+  Definition onef := {| car := nat; obj := 0 |}.
+  Goal  {f : foo & A (car f)}.
+  Proof.
+    unshelve eexists; cycle 1.
+    solve [typeclasses eauto].
+    exact onef.
+  Defined.
+End Heads.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

This reverts a change that made `Proj (p, ?X)` and `match ?X with` not be considered as not headed by evars for matching a hint mode. Experience shows (e.g. in Iris) that these partial terms can usefully be considered as indices in proof search. Now, only ?X u1 ... un is considered headed by an evar.

<!-- Keep what applies -->
**Kind:** feature

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
- [x] Overlay pull requests (if this breaks 3rd party developments in CI, see
https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md for details)
