### PR TITLE
Update doc after changes to PrimInt63 and Sint63

### DIFF
--- a/checker/values.ml
+++ b/checker/values.ml
@@ -318,7 +318,7 @@ let v_ind_pack = v_tuple "mutual_inductive_body"
     v_typing_flags|]
 
 let v_prim_ind = v_enum "prim_ind" 6
-(* Number of "Register ... as kernel.ind_..." in Int63.v and PrimFloat.v *)
+(* Number of "Register ... as kernel.ind_..." in PrimInt63.v and PrimFloat.v *)
 
 let v_prim_type = v_enum "prim_type" 3
 (* Number of constructors of prim_type in "kernel/cPrimitives.ml" *)

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -1042,7 +1042,7 @@ Exposing constants to OCaml libraries
    to know where the constant is defined (what file, module, library, etc.).
 
    As a special case, when the first segment of :n:`@qualid__2` is :g:`kernel`,
-   the constant is exposed to the kernel. For instance, the `Int63` module
+   the constant is exposed to the kernel. For instance, the `PrimInt63` module
    features the following declaration:
 
    .. coqdoc::
@@ -1073,14 +1073,14 @@ Registering primitive operations
    replacements.  No space is allowed after the `#`.  Invalid values give a syntax
    error.
 
-   For example, the standard library files `Int63.v` and `PrimFloat.v` use :cmd:`Primitive`
+   For example, the standard library files `PrimInt63.v` and `PrimFloat.v` use :cmd:`Primitive`
    to support, respectively, the features described in :ref:`primitive-integers` and
    :ref:`primitive-floats`.
 
    The types associated with an operator must be declared to the kernel before declaring operations
    that use the type.  Do this with :cmd:`Primitive` for primitive types and
    :cmd:`Register` with the :g:`kernel` prefix for other types.  For example,
-   in `Int63.v`, `#int63_type` must be declared before the associated operations.
+   in `PrimInt63.v`, `#int63_type` must be declared before the associated operations.
 
    .. exn:: The type @ident must be registered before this construction can be typechecked.
       :undocumented:

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -1721,8 +1721,8 @@ Number notations
             * :n:`Number.uint -> option @qualid__type`
             * :n:`Z -> @qualid__type`
             * :n:`Z -> option @qualid__type`
-            * :n:`Int63.int -> @qualid__type`
-            * :n:`Int63.int -> option @qualid__type`
+            * :n:`PrimInt63.int -> @qualid__type`
+            * :n:`PrimInt63.int -> option @qualid__type`
             * :n:`Number.number -> @qualid__type`
             * :n:`Number.number -> option @qualid__type`
 
@@ -1735,8 +1735,8 @@ Number notations
             * :n:`@qualid__type -> option Number.uint`
             * :n:`@qualid__type -> Z`
             * :n:`@qualid__type -> option Z`
-            * :n:`@qualid__type -> Int63.int`
-            * :n:`@qualid__type -> option Int63.int`
+            * :n:`@qualid__type -> PrimInt63.int`
+            * :n:`@qualid__type -> option PrimInt63.int`
             * :n:`@qualid__type -> Number.number`
             * :n:`@qualid__type -> option Number.number`
 
@@ -1842,20 +1842,17 @@ Number notations
      only for integers or non-negative integers, and the given number
      has a fractional or exponent part or is negative.
 
-   .. exn:: int63 are only non-negative numbers.
-
-      :n:`Int63.int` are unsigned integers.
-
    .. exn:: overflow in int63 literal @bigint
 
-      The constant is too big to fit into an unsigned 63-bit integer :n:`Int63.int`.
+      The constant's absolute value is too big to fit into a 63-bit integer :n:`PrimInt63.int`.
 
-   .. exn:: @qualid__parse should go from Number.int to @type or (option @type). Instead of Number.int, the types Number.uint or Z or Int63.int or Number.number could be used (you may need to require BinNums or Number or Int63 first).
+   .. exn:: @qualid__parse should go from Number.int to @type or (option @type). Instead of Number.int, the types Number.uint or Z or PrimInt63.pos_neg_int63 or Number.number could be used (you may need to require BinNums or Number or PrimInt63 first).
 
      The parsing function given to the :cmd:`Number Notation`
      command is not of the right type.
 
-   .. exn:: @qualid__print should go from @type to Number.int or (option Number.int).  Instead of Number.int, the types Number.uint or Z or Int63.int or Number.number could be used (you may need to require BinNums or Number or Int63 first).
+   .. exn:: @qualid__print should go from @type to Number.int or (option Number.int). Instead of Number.int, the types Number.uint or Z or PrimInt63.pos_neg_int63 or Number.number could be used (you may need to require BinNums or Number or PrimInt63 first).
+
 
      The printing function given to the :cmd:`Number Notation`
      command is not of the right type.

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1005,14 +1005,8 @@ let int63_of_pos_bigint ?loc n =
   let i = int63_of_pos_bigint n in
   mkInt i
 
-let error_negative ?loc =
-  CErrors.user_err ?loc ~hdr:"interp_int63" (Pp.str "int63 are only non-negative numbers.")
-
 let error_overflow ?loc n =
   CErrors.user_err ?loc ~hdr:"interp_int63" Pp.(str "overflow in int63 literal: " ++ str (Z.to_string n))
-
-let error_underflow ?loc n =
-  CErrors.user_err ?loc ~hdr:"interp_int63" Pp.(str "underflow in int63 literal: " ++ str (Z.to_string n))
 
 let coqpos_neg_int63_of_bigint ?loc ind (sign,n) =
   let uint = int63_of_pos_bigint ?loc n in
@@ -1021,13 +1015,10 @@ let coqpos_neg_int63_of_bigint ?loc ind (sign,n) =
 
 let interp_int63 ?loc ind n =
   let sign = if Z.(compare n zero >= 0) then SPlus else SMinus in
-  let n = Z.abs n in
-  if Z.(leq zero n)
-  then
-    if Z.(lt n (pow z_two 63))
-    then coqpos_neg_int63_of_bigint ?loc ind (sign,n)
-    else match sign with SPlus -> error_overflow ?loc n | SMinus -> error_underflow ?loc n
-  else error_negative ?loc
+  let an = Z.abs n in
+  if Z.(lt an (pow z_two 63))
+  then coqpos_neg_int63_of_bigint ?loc ind (sign,an)
+  else error_overflow ?loc n
 
 let bigint_of_int63 c =
   match Constr.kind c with


### PR DESCRIPTION
Some parts of the docs were not updated after the creation of `PrimInt63.v` and `Sint63.v`.

This also updates some errors in the doc that were changed or added in #13559, and cleans up a function in `interp/notation.ml` that as far as I can tell had a spurious if-then-else.

**Kind:** documentation / cleanup.
