### PR TITLE
Localize the scheme creation functions

### DIFF
--- a/tactics/elimschemes.ml
+++ b/tactics/elimschemes.ml
@@ -24,9 +24,11 @@ open Ind_tables
 
 (* Induction/recursion schemes *)
 
-let optimize_non_type_induction_scheme kind dep sort ind =
+let optimize_non_type_induction_scheme kind dep sort _handle ind =
   let env = Global.env () in
   let sigma = Evd.from_env env in
+  (* This non-local call to [lookup_scheme] is fine since we do not use it on a
+     dependency generated on the fly. *)
   match lookup_scheme kind ind with
   | Some cte ->
     (* in case the inductive has a type elimination, generates only one
@@ -62,15 +64,15 @@ let build_induction_scheme_in_type dep sort ind =
 
 let rect_scheme_kind_from_type =
   declare_individual_scheme_object "_rect_nodep"
-    (fun x -> build_induction_scheme_in_type false InType x)
+    (fun _ x -> build_induction_scheme_in_type false InType x)
 
 let rect_scheme_kind_from_prop =
   declare_individual_scheme_object "_rect" ~aux:"_rect_from_prop"
-    (fun x -> build_induction_scheme_in_type false InType x)
+    (fun _ x -> build_induction_scheme_in_type false InType x)
 
 let rect_dep_scheme_kind_from_type =
   declare_individual_scheme_object "_rect" ~aux:"_rect_from_type"
-    (fun x -> build_induction_scheme_in_type true InType x)
+    (fun _ x -> build_induction_scheme_in_type true InType x)
 
 let rec_scheme_kind_from_type =
   declare_individual_scheme_object "_rec_nodep" ~aux:"_rec_nodep_from_type"
@@ -90,7 +92,7 @@ let ind_scheme_kind_from_type =
 
 let sind_scheme_kind_from_type =
   declare_individual_scheme_object "_sind_nodep"
-  (fun x -> build_induction_scheme_in_type false InSProp x)
+  (fun _ x -> build_induction_scheme_in_type false InSProp x)
 
 let ind_dep_scheme_kind_from_type =
   declare_individual_scheme_object "_ind" ~aux:"_ind_from_type"
@@ -98,7 +100,7 @@ let ind_dep_scheme_kind_from_type =
 
 let sind_dep_scheme_kind_from_type =
   declare_individual_scheme_object "_sind" ~aux:"_sind_from_type"
-  (fun x -> build_induction_scheme_in_type true InSProp x)
+  (fun _ x -> build_induction_scheme_in_type true InSProp x)
 
 let ind_scheme_kind_from_prop =
   declare_individual_scheme_object "_ind" ~aux:"_ind_from_prop"
@@ -106,7 +108,7 @@ let ind_scheme_kind_from_prop =
 
 let sind_scheme_kind_from_prop =
   declare_individual_scheme_object "_sind" ~aux:"_sind_from_prop"
-  (fun x -> build_induction_scheme_in_type false InSProp x)
+  (fun _ x -> build_induction_scheme_in_type false InSProp x)
 
 let nondep_elim_scheme from_kind to_kind =
   match from_kind, to_kind with
@@ -130,24 +132,24 @@ let build_case_analysis_scheme_in_type dep sort ind =
 
 let case_scheme_kind_from_type =
   declare_individual_scheme_object "_case_nodep"
-  (fun x -> build_case_analysis_scheme_in_type false InType x)
+  (fun _ x -> build_case_analysis_scheme_in_type false InType x)
 
 let case_scheme_kind_from_prop =
   declare_individual_scheme_object "_case" ~aux:"_case_from_prop"
-  (fun x -> build_case_analysis_scheme_in_type false InType x)
+  (fun _ x -> build_case_analysis_scheme_in_type false InType x)
 
 let case_dep_scheme_kind_from_type =
   declare_individual_scheme_object "_case" ~aux:"_case_from_type"
-  (fun x -> build_case_analysis_scheme_in_type true InType x)
+  (fun _ x -> build_case_analysis_scheme_in_type true InType x)
 
 let case_dep_scheme_kind_from_type_in_prop =
   declare_individual_scheme_object "_casep_dep"
-  (fun x -> build_case_analysis_scheme_in_type true InProp x)
+  (fun _ x -> build_case_analysis_scheme_in_type true InProp x)
 
 let case_dep_scheme_kind_from_prop =
   declare_individual_scheme_object "_case_dep"
-  (fun x -> build_case_analysis_scheme_in_type true InType x)
+  (fun _ x -> build_case_analysis_scheme_in_type true InType x)
 
 let case_dep_scheme_kind_from_prop_in_prop =
   declare_individual_scheme_object "_casep"
-  (fun x -> build_case_analysis_scheme_in_type true InProp x)
+  (fun _ x -> build_case_analysis_scheme_in_type true InProp x)

--- a/tactics/elimschemes.ml
+++ b/tactics/elimschemes.ml
@@ -24,8 +24,7 @@ open Ind_tables
 
 (* Induction/recursion schemes *)
 
-let optimize_non_type_induction_scheme kind dep sort _handle ind =
-  let env = Global.env () in
+let optimize_non_type_induction_scheme kind dep sort env _handle ind =
   let sigma = Evd.from_env env in
   (* This non-local call to [lookup_scheme] is fine since we do not use it on a
      dependency generated on the fly. *)
@@ -36,8 +35,8 @@ let optimize_non_type_induction_scheme kind dep sort _handle ind =
        appropriate type *)
     let sigma, cte = Evd.fresh_constant_instance env sigma cte in
     let c = mkConstU cte in
-    let t = type_of_constant_in (Global.env()) cte in
-    let (mib,mip) = Global.lookup_inductive ind in
+    let t = type_of_constant_in env cte in
+    let (mib,mip) = Inductive.lookup_mind_specif env ind in
     let npars =
       (* if a constructor of [ind] contains a recursive call, the scheme
          is generalized only wrt recursively uniform parameters *)
@@ -55,8 +54,7 @@ let optimize_non_type_induction_scheme kind dep sort _handle ind =
     let sigma, c = build_induction_scheme env sigma pind dep sort in
       (c, Evd.evar_universe_context sigma)
 
-let build_induction_scheme_in_type dep sort ind =
-  let env = Global.env () in
+let build_induction_scheme_in_type env dep sort ind =
   let sigma = Evd.from_env env in
   let sigma, pind = Evd.fresh_inductive_instance ~rigid:UState.univ_rigid env sigma ind in
   let sigma, c = build_induction_scheme env sigma pind dep sort in
@@ -64,15 +62,15 @@ let build_induction_scheme_in_type dep sort ind =
 
 let rect_scheme_kind_from_type =
   declare_individual_scheme_object "_rect_nodep"
-    (fun _ x -> build_induction_scheme_in_type false InType x)
+    (fun env _ x -> build_induction_scheme_in_type env false InType x)
 
 let rect_scheme_kind_from_prop =
   declare_individual_scheme_object "_rect" ~aux:"_rect_from_prop"
-    (fun _ x -> build_induction_scheme_in_type false InType x)
+    (fun env _ x -> build_induction_scheme_in_type env false InType x)
 
 let rect_dep_scheme_kind_from_type =
   declare_individual_scheme_object "_rect" ~aux:"_rect_from_type"
-    (fun _ x -> build_induction_scheme_in_type true InType x)
+    (fun env _ x -> build_induction_scheme_in_type env true InType x)
 
 let rec_scheme_kind_from_type =
   declare_individual_scheme_object "_rec_nodep" ~aux:"_rec_nodep_from_type"
@@ -92,7 +90,7 @@ let ind_scheme_kind_from_type =
 
 let sind_scheme_kind_from_type =
   declare_individual_scheme_object "_sind_nodep"
-  (fun _ x -> build_induction_scheme_in_type false InSProp x)
+  (fun env _ x -> build_induction_scheme_in_type env false InSProp x)
 
 let ind_dep_scheme_kind_from_type =
   declare_individual_scheme_object "_ind" ~aux:"_ind_from_type"
@@ -100,7 +98,7 @@ let ind_dep_scheme_kind_from_type =
 
 let sind_dep_scheme_kind_from_type =
   declare_individual_scheme_object "_sind" ~aux:"_sind_from_type"
-  (fun _ x -> build_induction_scheme_in_type true InSProp x)
+  (fun env _ x -> build_induction_scheme_in_type env true InSProp x)
 
 let ind_scheme_kind_from_prop =
   declare_individual_scheme_object "_ind" ~aux:"_ind_from_prop"
@@ -108,7 +106,7 @@ let ind_scheme_kind_from_prop =
 
 let sind_scheme_kind_from_prop =
   declare_individual_scheme_object "_sind" ~aux:"_sind_from_prop"
-  (fun _ x -> build_induction_scheme_in_type false InSProp x)
+  (fun env _ x -> build_induction_scheme_in_type env false InSProp x)
 
 let nondep_elim_scheme from_kind to_kind =
   match from_kind, to_kind with
@@ -123,8 +121,7 @@ let nondep_elim_scheme from_kind to_kind =
 
 (* Case analysis *)
 
-let build_case_analysis_scheme_in_type dep sort ind =
-  let env = Global.env () in
+let build_case_analysis_scheme_in_type env dep sort ind =
   let sigma = Evd.from_env env in
   let (sigma, indu) = Evd.fresh_inductive_instance env sigma ind in
   let (sigma, c) = build_case_analysis_scheme env sigma indu dep sort in
@@ -132,24 +129,24 @@ let build_case_analysis_scheme_in_type dep sort ind =
 
 let case_scheme_kind_from_type =
   declare_individual_scheme_object "_case_nodep"
-  (fun _ x -> build_case_analysis_scheme_in_type false InType x)
+  (fun env _ x -> build_case_analysis_scheme_in_type env false InType x)
 
 let case_scheme_kind_from_prop =
   declare_individual_scheme_object "_case" ~aux:"_case_from_prop"
-  (fun _ x -> build_case_analysis_scheme_in_type false InType x)
+  (fun env _ x -> build_case_analysis_scheme_in_type env false InType x)
 
 let case_dep_scheme_kind_from_type =
   declare_individual_scheme_object "_case" ~aux:"_case_from_type"
-  (fun _ x -> build_case_analysis_scheme_in_type true InType x)
+  (fun env _ x -> build_case_analysis_scheme_in_type env true InType x)
 
 let case_dep_scheme_kind_from_type_in_prop =
   declare_individual_scheme_object "_casep_dep"
-  (fun _ x -> build_case_analysis_scheme_in_type true InProp x)
+  (fun env _ x -> build_case_analysis_scheme_in_type env true InProp x)
 
 let case_dep_scheme_kind_from_prop =
   declare_individual_scheme_object "_case_dep"
-  (fun _ x -> build_case_analysis_scheme_in_type true InType x)
+  (fun env _ x -> build_case_analysis_scheme_in_type env true InType x)
 
 let case_dep_scheme_kind_from_prop_in_prop =
   declare_individual_scheme_object "_casep"
-  (fun _ x -> build_case_analysis_scheme_in_type true InProp x)
+  (fun env _ x -> build_case_analysis_scheme_in_type env true InProp x)

--- a/tactics/eqschemes.ml
+++ b/tactics/eqschemes.ml
@@ -95,17 +95,16 @@ let name_context env hyps =
 
 let my_it_mkLambda_or_LetIn s c = it_mkLambda_or_LetIn c s
 let my_it_mkProd_or_LetIn s c = Term.it_mkProd_or_LetIn c s
-let my_it_mkLambda_or_LetIn_name s c =
-  let env = Global.env () in
+let my_it_mkLambda_or_LetIn_name env s c =
   let mkLambda_or_LetIn_name d b = mkLambda_or_LetIn (name_assumption env d) b in
   List.fold_left (fun c d -> mkLambda_or_LetIn_name d c) c s
 
-let get_coq_eq ctx =
+let get_coq_eq env ctx =
   try
     let eq = Globnames.destIndRef (Coqlib.lib_ref "core.eq.type") in
     (* Do not force the lazy if they are not defined *)
     let eq, ctx = with_context_set ctx
-      (UnivGen.fresh_inductive_instance (Global.env ()) eq) in
+      (UnivGen.fresh_inductive_instance env eq) in
       mkIndU eq, mkConstructUi (eq,1), ctx
   with Not_found ->
     user_err Pp.(str "eq not found.")
@@ -199,7 +198,7 @@ let get_non_sym_eq_data env (ind,u) =
 (*                                                                    *)
 (**********************************************************************)
 
-let build_sym_scheme env ind =
+let build_sym_scheme env _handle ind =
   let (ind,u as indu), ctx = UnivGen.fresh_inductive_instance env ind in
   let (mib,mip as specif),nrealargs,realsign,paramsctxt,paramsctxt1 =
     get_sym_eq_data env indu in
@@ -212,12 +211,12 @@ let build_sym_scheme env ind =
   let realsign_ind =
     name_context env ((LocalAssum (make_annot (Name varH) indr,applied_ind))::realsign) in
   let rci = Sorts.Relevant in (* TODO relevance *)
-  let ci = make_case_info (Global.env()) ind rci RegularStyle in
+  let ci = make_case_info env ind rci RegularStyle in
   let c =
   (my_it_mkLambda_or_LetIn paramsctxt
-  (my_it_mkLambda_or_LetIn_name realsign_ind
+  (my_it_mkLambda_or_LetIn_name env realsign_ind
   (mkCase (Inductive.contract_case env (ci,
-     my_it_mkLambda_or_LetIn_name
+     my_it_mkLambda_or_LetIn_name env
        (lift_rel_context (nrealargs+1) realsign_ind)
        (mkApp (mkIndU indu,Array.concat
           [Context.Rel.to_extended_vect mkRel (3*nrealargs+2) paramsctxt1;
@@ -230,9 +229,7 @@ let build_sym_scheme env ind =
 
 let sym_scheme_kind =
   declare_individual_scheme_object "_sym_internal"
-  (fun handle ind ->
-    let c, ctx = build_sym_scheme (Global.env() (* side-effect! *)) ind in
-      (c, ctx))
+  build_sym_scheme
 
 (**********************************************************************)
 (* Build the involutivity of symmetry for an inductive type           *)
@@ -253,14 +250,14 @@ let sym_scheme_kind =
 let const_of_scheme kind env handle ind ctx =
   let sym_scheme = match local_lookup_scheme handle kind ind with Some cst -> cst | None -> assert false in
   let sym, ctx = with_context_set ctx
-    (UnivGen.fresh_constant_instance (Global.env()) sym_scheme) in
+    (UnivGen.fresh_constant_instance env sym_scheme) in
     mkConstU sym, ctx
 
 let build_sym_involutive_scheme env handle ind =
   let (ind,u as indu), ctx = UnivGen.fresh_inductive_instance env ind in
   let (mib,mip as specif),nrealargs,realsign,paramsctxt,paramsctxt1 =
     get_sym_eq_data env indu in
-  let eq,eqrefl,ctx = get_coq_eq ctx in
+  let eq,eqrefl,ctx = get_coq_eq env ctx in
   let sym, ctx = const_of_scheme sym_scheme_kind env handle ind ctx in
   let cstr n = mkApp (mkConstructUi (indu,1),Context.Rel.to_extended_vect mkRel n paramsctxt) in
   let inds = snd (mind_arity mip) in
@@ -275,12 +272,12 @@ let build_sym_involutive_scheme env handle ind =
   let realsign_ind =
     name_context env ((LocalAssum (make_annot (Name varH) indr,applied_ind))::realsign) in
   let rci = Sorts.Relevant in (* TODO relevance *)
-  let ci = make_case_info (Global.env()) ind rci RegularStyle in
+  let ci = make_case_info env ind rci RegularStyle in
   let c =
     (my_it_mkLambda_or_LetIn paramsctxt
-     (my_it_mkLambda_or_LetIn_name realsign_ind
+     (my_it_mkLambda_or_LetIn_name env realsign_ind
       (mkCase (Inductive.contract_case env (ci,
-                my_it_mkLambda_or_LetIn_name
+                my_it_mkLambda_or_LetIn_name env
                 (lift_rel_context (nrealargs+1) realsign_ind)
                 (mkApp (eq,[|
                 mkApp
@@ -305,9 +302,8 @@ let build_sym_involutive_scheme env handle ind =
 
 let sym_involutive_scheme_kind =
   declare_individual_scheme_object "_sym_involutive"
-  ~deps:(fun ind -> [SchemeIndividualDep (ind, sym_scheme_kind)])
-  (fun handle ind ->
-    build_sym_involutive_scheme (Global.env() (* side-effect! *)) handle ind)
+  ~deps:(fun _ ind -> [SchemeIndividualDep (ind, sym_scheme_kind)])
+  build_sym_involutive_scheme
 
 (**********************************************************************)
 (* Build the left-to-right rewriting lemma for conclusion associated  *)
@@ -375,7 +371,7 @@ let build_l2r_rew_scheme dep env handle ind kind =
     get_sym_eq_data env indu in
   let sym, ctx = const_of_scheme sym_scheme_kind env handle ind ctx in
   let sym_involutive, ctx = const_of_scheme sym_involutive_scheme_kind env handle ind ctx in
-  let eq,eqrefl,ctx = get_coq_eq ctx in
+  let eq,eqrefl,ctx = get_coq_eq env ctx in
   let cstr n p =
     mkApp (mkConstructUi(indu,1),
       Array.concat [Context.Rel.to_extended_vect mkRel n paramsctxt1;
@@ -415,8 +411,8 @@ let build_l2r_rew_scheme dep env handle ind kind =
   let ctx = Univ.ContextSet.union ctx ctx' in
   let s = mkSort s in
   let rci = Sorts.Relevant in (* TODO relevance *)
-  let ci = make_case_info (Global.env()) ind rci RegularStyle in
-  let cieq = make_case_info (Global.env()) (fst (destInd eq)) rci RegularStyle in
+  let ci = make_case_info env ind rci RegularStyle in
+  let cieq = make_case_info env (fst (destInd eq)) rci RegularStyle in
   let applied_PC =
     mkApp (mkVar varP,Array.append (Context.Rel.to_extended_vect mkRel 1 realsign)
            (if dep then [|cstr (2*nrealargs+1) 1|] else [||])) in
@@ -438,14 +434,14 @@ let build_l2r_rew_scheme dep env handle ind kind =
                [|mkRel 2|]])|]]) in
   let main_body =
     mkCase (Inductive.contract_case env (ci,
-            my_it_mkLambda_or_LetIn_name realsign_ind_G applied_PG,
+            my_it_mkLambda_or_LetIn_name env realsign_ind_G applied_PG,
             NoInvert,
             applied_sym_C 3,
             [|mkVar varHC|]))
   in
   let c =
   (my_it_mkLambda_or_LetIn paramsctxt
-  (my_it_mkLambda_or_LetIn_name realsign
+  (my_it_mkLambda_or_LetIn_name env realsign
   (mkNamedLambda (make_annot varP indr)
     (my_it_mkProd_or_LetIn (if dep then realsign_ind_P else realsign_P) s)
   (mkNamedLambda (make_annot varHC indr) applied_PC
@@ -523,7 +519,7 @@ let build_l2r_forward_rew_scheme dep env ind kind =
   let ctx = Univ.ContextSet.union ctx ctx' in
   let s = mkSort s in
   let rci = Sorts.Relevant in
-  let ci = make_case_info (Global.env()) ind rci RegularStyle in
+  let ci = make_case_info env ind rci RegularStyle in
   let applied_PC =
     mkApp (mkVar varP,Array.append
            (rel_vect (nrealargs*2+3) nrealargs)
@@ -538,10 +534,10 @@ let build_l2r_forward_rew_scheme dep env ind kind =
            (if dep then [|cstr (3*nrealargs+4) 3|] else [||])) in
   let c =
   (my_it_mkLambda_or_LetIn paramsctxt
-  (my_it_mkLambda_or_LetIn_name realsign
+  (my_it_mkLambda_or_LetIn_name env realsign
   (mkNamedLambda (make_annot varH indr) applied_ind
   (mkCase (Inductive.contract_case env (ci,
-     my_it_mkLambda_or_LetIn_name
+     my_it_mkLambda_or_LetIn_name env
        (lift_rel_context (nrealargs+1) realsign_ind)
        (mkNamedProd (make_annot varP indr)
          (my_it_mkProd_or_LetIn
@@ -605,7 +601,7 @@ let build_r2l_forward_rew_scheme dep env ind kind =
   let ctx = Univ.ContextSet.union ctx ctx' in
   let s = mkSort s in
   let rci = Sorts.Relevant in (* TODO relevance *)
-  let ci = make_case_info (Global.env()) ind rci RegularStyle in
+  let ci = make_case_info env ind rci RegularStyle in
   let applied_PC =
     applist (mkVar varP,if dep then constrargs_cstr else constrargs) in
   let applied_PG =
@@ -614,14 +610,14 @@ let build_r2l_forward_rew_scheme dep env ind kind =
            else Context.Rel.to_extended_vect mkRel 1 realsign) in
   let c =
   (my_it_mkLambda_or_LetIn paramsctxt
-  (my_it_mkLambda_or_LetIn_name realsign_ind
+  (my_it_mkLambda_or_LetIn_name env realsign_ind
   (mkNamedLambda (make_annot varP indr)
     (my_it_mkProd_or_LetIn (lift_rel_context (nrealargs+1)
                              (if dep then realsign_ind else realsign)) s)
   (mkNamedLambda (make_annot varHC indr) (lift 1 applied_PG)
   (mkApp
     (mkCase (Inductive.contract_case env (ci,
-       my_it_mkLambda_or_LetIn_name
+       my_it_mkLambda_or_LetIn_name env
          (lift_rel_context (nrealargs+3) realsign_ind)
          (mkArrow applied_PG indr (lift (2*nrealargs+5) applied_PC)),
        NoInvert,
@@ -649,8 +645,7 @@ let build_r2l_forward_rew_scheme dep env ind kind =
 (*                                                                    *)
 (**********************************************************************)
 
-let fix_r2l_forward_rew_scheme (c, ctx') =
-  let env = Global.env () in
+let fix_r2l_forward_rew_scheme env (c, ctx') =
   let sigma = Evd.from_env env in
   let t = Retyping.get_type_of env sigma (EConstr.of_constr c) in
   let t = EConstr.Unsafe.to_constr t in
@@ -707,11 +702,11 @@ let build_r2l_rew_scheme dep env ind k =
 (**********************************************************************)
 let rew_l2r_dep_scheme_kind =
   declare_individual_scheme_object "_rew_r_dep"
-  ~deps:(fun ind -> [
+  ~deps:(fun _ ind -> [
     SchemeIndividualDep (ind, sym_scheme_kind);
     SchemeIndividualDep (ind, sym_involutive_scheme_kind);
   ])
-  (fun handle ind -> build_l2r_rew_scheme true (Global.env()) handle ind InType)
+  (fun env handle ind -> build_l2r_rew_scheme true env handle ind InType)
 
 (**********************************************************************)
 (* Dependent rewrite from right-to-left in conclusion                 *)
@@ -721,7 +716,7 @@ let rew_l2r_dep_scheme_kind =
 (**********************************************************************)
 let rew_r2l_dep_scheme_kind =
   declare_individual_scheme_object "_rew_dep"
-  (fun _ ind -> build_r2l_rew_scheme true (Global.env()) ind InType)
+  (fun env _ ind -> build_r2l_rew_scheme true env ind InType)
 
 (**********************************************************************)
 (* Dependent rewrite from right-to-left in hypotheses                 *)
@@ -731,7 +726,7 @@ let rew_r2l_dep_scheme_kind =
 (**********************************************************************)
 let rew_r2l_forward_dep_scheme_kind =
   declare_individual_scheme_object "_rew_fwd_dep"
-  (fun _ ind -> build_r2l_forward_rew_scheme true (Global.env()) ind InType)
+  (fun env _ ind -> build_r2l_forward_rew_scheme true env ind InType)
 
 (**********************************************************************)
 (* Dependent rewrite from left-to-right in hypotheses                 *)
@@ -741,7 +736,7 @@ let rew_r2l_forward_dep_scheme_kind =
 (**********************************************************************)
 let rew_l2r_forward_dep_scheme_kind =
   declare_individual_scheme_object "_rew_fwd_r_dep"
-  (fun _ ind -> build_l2r_forward_rew_scheme true (Global.env()) ind InType)
+  (fun env _ ind -> build_l2r_forward_rew_scheme true env ind InType)
 
 (**********************************************************************)
 (* Non-dependent rewrite from either left-to-right in conclusion or   *)
@@ -754,8 +749,8 @@ let rew_l2r_forward_dep_scheme_kind =
 (**********************************************************************)
 let rew_l2r_scheme_kind =
   declare_individual_scheme_object "_rew_r"
-  (fun _ ind -> fix_r2l_forward_rew_scheme
-     (build_r2l_forward_rew_scheme false (Global.env()) ind InType))
+  (fun env _ ind -> fix_r2l_forward_rew_scheme env
+     (build_r2l_forward_rew_scheme false env ind InType))
 
 (**********************************************************************)
 (* Non-dependent rewrite from either right-to-left in conclusion or   *)
@@ -765,7 +760,7 @@ let rew_l2r_scheme_kind =
 (**********************************************************************)
 let rew_r2l_scheme_kind =
   declare_individual_scheme_object "_rew"
-  (fun _ ind -> build_r2l_rew_scheme false (Global.env()) ind InType)
+  (fun env _ ind -> build_r2l_rew_scheme false env ind InType)
 
 (* End of rewriting schemes *)
 
@@ -812,21 +807,21 @@ let build_congr env (eq,refl,ctx) ind =
   let varH,avoid = fresh env (Id.of_string "H") avoid in
   let varf,avoid = fresh env (Id.of_string "f") avoid in
   let rci = Sorts.Relevant in (* TODO relevance *)
-  let ci = make_case_info (Global.env()) ind rci RegularStyle in
+  let ci = make_case_info env ind rci RegularStyle in
   let uni, ctx = Univ.extend_in_context_set (UnivGen.new_global_univ ()) ctx in
   let ctx = (fst ctx, Univ.enforce_leq uni (univ_of_eq env eq) (snd ctx)) in
   let c =
   my_it_mkLambda_or_LetIn paramsctxt
      (mkNamedLambda (make_annot varB Sorts.Relevant) (mkType uni)
      (mkNamedLambda (make_annot varf Sorts.Relevant) (mkArrow (lift 1 ty) tyr (mkVar varB))
-     (my_it_mkLambda_or_LetIn_name (lift_rel_context 2 realsign)
+     (my_it_mkLambda_or_LetIn_name env (lift_rel_context 2 realsign)
      (mkNamedLambda (make_annot varH Sorts.Relevant)
         (applist
            (mkIndU indu,
             Context.Rel.to_extended_list mkRel (mip.mind_nrealargs+2) paramsctxt @
             Context.Rel.to_extended_list mkRel 0 realsign))
      (mkCase (Inductive.contract_case env (ci,
-       my_it_mkLambda_or_LetIn_name
+       my_it_mkLambda_or_LetIn_name env
          (lift_rel_context (mip.mind_nrealargs+3) realsign)
          (mkLambda
            (make_annot Anonymous Sorts.Relevant,
@@ -847,6 +842,6 @@ let build_congr env (eq,refl,ctx) ind =
   in c, UState.of_context_set ctx
 
 let congr_scheme_kind = declare_individual_scheme_object "_congr"
-  (fun _ ind ->
+  (fun env _ ind ->
      (* May fail if equality is not defined *)
-   build_congr (Global.env()) (get_coq_eq Univ.ContextSet.empty) ind)
+   build_congr env (get_coq_eq env Univ.ContextSet.empty) ind)

--- a/tactics/eqschemes.mli
+++ b/tactics/eqschemes.mli
@@ -10,9 +10,6 @@
 
 (** This file builds schemes relative to equality inductive types *)
 
-open Names
-open Constr
-open Environ
 open Ind_tables
 
 (** Builds a left-to-right rewriting scheme for an equality type *)
@@ -24,26 +21,12 @@ val rew_l2r_forward_dep_scheme_kind : individual scheme_kind
 val rew_r2l_dep_scheme_kind : individual scheme_kind
 val rew_r2l_scheme_kind : individual scheme_kind
 
-val build_r2l_rew_scheme : bool -> env -> inductive -> Sorts.family ->
-  constr Evd.in_evar_universe_context
-val build_l2r_rew_scheme : bool -> env -> inductive -> Sorts.family ->
-  constr Evd.in_evar_universe_context
-val build_r2l_forward_rew_scheme :
-  bool -> env -> inductive -> Sorts.family -> constr Evd.in_evar_universe_context
-val build_l2r_forward_rew_scheme :
-  bool -> env -> inductive -> Sorts.family -> constr Evd.in_evar_universe_context
-
 (** Builds a symmetry scheme for a symmetrical equality type *)
 
-val build_sym_scheme : env -> inductive -> constr Evd.in_evar_universe_context
 val sym_scheme_kind : individual scheme_kind
 
-val build_sym_involutive_scheme : env -> inductive ->
-  constr Evd.in_evar_universe_context
 val sym_involutive_scheme_kind : individual scheme_kind
 
 (** Builds a congruence scheme for an equality type *)
 
 val congr_scheme_kind : individual scheme_kind
-val build_congr : env -> constr * constr * Univ.ContextSet.t -> inductive ->
-  constr Evd.in_evar_universe_context

--- a/tactics/ind_tables.mli
+++ b/tactics/ind_tables.mli
@@ -27,21 +27,21 @@ type scheme_dependency =
 | SchemeIndividualDep of inductive * individual scheme_kind
 
 type mutual_scheme_object_function =
-  handle -> MutInd.t -> constr array Evd.in_evar_universe_context
+  Environ.env -> handle -> MutInd.t -> constr array Evd.in_evar_universe_context
 type individual_scheme_object_function =
-  handle -> inductive -> constr Evd.in_evar_universe_context
+  Environ.env -> handle -> inductive -> constr Evd.in_evar_universe_context
 
 (** Main functions to register a scheme builder. Note these functions
    are not safe to be used by plugins as their effects won't be undone
    on backtracking *)
 
 val declare_mutual_scheme_object : string ->
-  ?deps:(MutInd.t -> scheme_dependency list) ->
+  ?deps:(Environ.env -> MutInd.t -> scheme_dependency list) ->
   ?aux:string ->
   mutual_scheme_object_function -> mutual scheme_kind
 
 val declare_individual_scheme_object : string ->
-  ?deps:(inductive -> scheme_dependency list) ->
+  ?deps:(Environ.env -> inductive -> scheme_dependency list) ->
   ?aux:string ->
   individual_scheme_object_function ->
   individual scheme_kind

--- a/tactics/ind_tables.mli
+++ b/tactics/ind_tables.mli
@@ -20,14 +20,16 @@ type mutual
 type individual
 type 'a scheme_kind
 
+type handle
+
 type scheme_dependency =
 | SchemeMutualDep of MutInd.t * mutual scheme_kind
 | SchemeIndividualDep of inductive * individual scheme_kind
 
 type mutual_scheme_object_function =
-  MutInd.t -> constr array Evd.in_evar_universe_context
+  handle -> MutInd.t -> constr array Evd.in_evar_universe_context
 type individual_scheme_object_function =
-  inductive -> constr Evd.in_evar_universe_context
+  handle -> inductive -> constr Evd.in_evar_universe_context
 
 (** Main functions to register a scheme builder. Note these functions
    are not safe to be used by plugins as their effects won't be undone
@@ -57,6 +59,9 @@ val find_scheme : 'a scheme_kind -> inductive -> Constant.t Proofview.tactic
 
 (** Like [find_scheme] but does not generate a constant on the fly *)
 val lookup_scheme : 'a scheme_kind -> inductive -> Constant.t option
+
+(** To be used by scheme-generating functions when looking for a subscheme. *)
+val local_lookup_scheme : handle -> 'a scheme_kind -> inductive -> Constant.t option
 
 val pr_scheme_kind : 'a scheme_kind -> Pp.t
 

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -120,6 +120,10 @@ let check_no_indices mib =
   if Array.exists (fun mip -> mip.mind_nrealargs <> 0) mib.mind_packets then
     raise DecidabilityIndicesNotSupported
 
+let get_scheme handle k ind = match local_lookup_scheme handle k ind with
+| None -> assert false
+| Some c -> c
+
 let beq_scheme_kind_aux = ref (fun _ -> failwith "Undefined")
 
 let get_inductive_deps kn =
@@ -172,7 +176,7 @@ let build_beq_scheme_deps kn =
   let inds = get_inductive_deps kn in
   List.map (fun ind -> SchemeMutualDep (ind, !beq_scheme_kind_aux ())) inds
 
-let build_beq_scheme kn =
+let build_beq_scheme handle kn =
   check_bool_is_defined ();
   (* fetching global env *)
   let env = Global.env() in
@@ -259,10 +263,8 @@ let build_beq_scheme kn =
            if Environ.QMutInd.equal env kn kn' then mkRel(eqA-nlist-i+nb_ind-1)
            else begin
                try
-                 let eq = match lookup_scheme (!beq_scheme_kind_aux()) ind' with
-                   | Some c -> mkConst c
-                   | None -> assert false
-                 in
+                 let c = get_scheme handle (!beq_scheme_kind_aux()) ind' in
+                 let eq = mkConst c in
                  let eqa = Array.of_list @@ List.map aux a in
                  let args =
                    Array.append
@@ -421,10 +423,6 @@ let destruct_ind env sigma c =
 let bl_scheme_kind_aux = ref (fun () -> failwith "Undefined")
 let lb_scheme_kind_aux = ref (fun () -> failwith "Undefined")
 
-let get_scheme k ind = match lookup_scheme k ind with
-| None -> assert false
-| Some c -> Proofview.tclUNIT c
-
 (*
   In the following, avoid is the list of names to avoid.
   If the args of the Inductive type are A1 ... An
@@ -434,7 +432,7 @@ let get_scheme k ind = match lookup_scheme k ind with
 so from Ai we can find the correct eq_Ai bl_ai or lb_ai
 *)
 (* used in the leib -> bool side*)
-let do_replace_lb aavoid narg p q =
+let do_replace_lb handle aavoid narg p q =
   let open EConstr in
   let avoid = Array.of_list aavoid in
   let do_arg env sigma hd v offset =
@@ -465,7 +463,7 @@ let do_replace_lb aavoid narg p q =
     let sigma = Tacmach.New.project gl in
     let env = Tacmach.New.pf_env gl in
     let u,v = destruct_ind env sigma type_of_pq in
-    get_scheme (!lb_scheme_kind_aux ()) (fst u) >>= fun c ->
+    let c = get_scheme handle (!lb_scheme_kind_aux ()) (fst u) in
     let lb_type_of_p = mkConst c in
        Proofview.tclEVARMAP >>= fun sigma ->
        let lb_args = Array.append (Array.append
@@ -480,7 +478,7 @@ let do_replace_lb aavoid narg p q =
   end
 
 (* used in the bool -> leb side *)
-let do_replace_bl (ind,u as indu) aavoid narg lft rgt =
+let do_replace_bl handle (ind,u as indu) aavoid narg lft rgt =
   let open EConstr in
   let avoid = Array.of_list aavoid in
   let do_arg env sigma hd v offset =
@@ -521,7 +519,7 @@ let do_replace_bl (ind,u as indu) aavoid narg lft rgt =
           in if Ind.CanOrd.equal (fst u) ind
              then Tacticals.New.tclTHENLIST [Equality.replace t1 t2; Auto.default_auto ; aux q1 q2 ]
              else (
-               get_scheme (!bl_scheme_kind_aux ()) (fst u) >>= fun c ->
+               let c = get_scheme handle (!bl_scheme_kind_aux ()) (fst u) in
                let bl_t1 = mkConst c in
                let bl_args =
                         Array.append (Array.append
@@ -589,14 +587,10 @@ let avoid_of_list_id list_id =
 (*
   build the right eq_I A B.. N eq_A .. eq_N
 *)
-let eqI ind list_id =
+let eqI handle ind list_id =
   let eA = Array.of_list((List.map (fun (s,_,_,_) -> mkVar s) list_id)@
                            (List.map (fun (_,seq,_,_)-> mkVar seq) list_id ))
-  and e = match lookup_scheme beq_scheme_kind ind with
-  | Some c -> mkConst c
-  | None ->
-    user_err ~hdr:"AutoIndDecl.eqI"
-      (str "The boolean equality on " ++ Printer.pr_inductive (Global.env ()) ind ++ str " is needed.");
+  and e = mkConst (get_scheme handle beq_scheme_kind ind)
   in mkApp(e,eA)
 
 (**********************************************************************)
@@ -604,9 +598,9 @@ let eqI ind list_id =
 
 open Namegen
 
-let compute_bl_goal ind lnamesparrec nparrec =
+let compute_bl_goal handle ind lnamesparrec nparrec =
   let list_id = list_id lnamesparrec in
-  let eqI = eqI ind list_id in
+  let eqI = eqI handle ind list_id in
   let avoid = avoid_of_list_id list_id in
   let x = next_ident_away (Id.of_string "x") avoid in
   let y = next_ident_away (Id.of_string "y") (Id.Set.add x avoid) in
@@ -646,7 +640,7 @@ let compute_bl_goal ind lnamesparrec nparrec =
               (mkApp(eq (),[|mkFullInd (ind,u) (nparrec+3);mkVar x;mkVar y|]))
         )))
 
-let compute_bl_tact ind lnamesparrec nparrec =
+let compute_bl_tact handle ind lnamesparrec nparrec =
   let list_id = list_id lnamesparrec in
   let first_intros =
     ( List.map (fun (s,_,_,_) -> s ) list_id )
@@ -688,7 +682,7 @@ repeat ( apply andb_prop in z;let z1:= fresh "Z" in destruct z as [z1 z]).
                      if GlobRef.equal (GlobRef.IndRef indeq) Coqlib.(lib_ref "core.eq.type")
                      then
                        Tacticals.New.tclTHEN
-                         (do_replace_bl ind
+                         (do_replace_bl handle ind
                             (List.rev fresh_first_intros)
                             nparrec (ca.(2))
                             (ca.(1)))
@@ -705,7 +699,7 @@ repeat ( apply andb_prop in z;let z1:= fresh "Z" in destruct z as [z1 z]).
       ]
     end
 
-let make_bl_scheme mind =
+let make_bl_scheme handle mind =
   let mib = Global.lookup_mind mind in
   if not (Int.equal (Array.length mib.mind_packets) 1) then
     user_err
@@ -715,11 +709,11 @@ let make_bl_scheme mind =
   let nparrec = mib.mind_nparams_rec in
   let lnonparrec,lnamesparrec = (* TODO subst *)
     context_chop (nparams-nparrec) mib.mind_params_ctxt in
-  let bl_goal = compute_bl_goal ind lnamesparrec nparrec in
+  let bl_goal = compute_bl_goal handle ind lnamesparrec nparrec in
   let uctx = UState.from_env (Global.env ()) in
   let bl_goal = EConstr.of_constr bl_goal in
   let (ans, _, _, _, ctx) = Declare.build_by_tactic ~poly:false ~side_eff:false (Global.env()) ~uctx ~typ:bl_goal
-    (compute_bl_tact (ind, EConstr.EInstance.empty) lnamesparrec nparrec)
+    (compute_bl_tact handle (ind, EConstr.EInstance.empty) lnamesparrec nparrec)
   in
   ([|ans|], ctx)
 
@@ -738,11 +732,11 @@ let _ = bl_scheme_kind_aux := fun () -> bl_scheme_kind
 (**********************************************************************)
 (* Leibniz->Boolean *)
 
-let compute_lb_goal ind lnamesparrec nparrec =
+let compute_lb_goal handle ind lnamesparrec nparrec =
   let list_id = list_id lnamesparrec in
   let eq = eq () and tt = tt () and bb = bb () in
   let avoid = avoid_of_list_id list_id in
-  let eqI = eqI ind list_id in
+  let eqI = eqI handle ind list_id in
   let x = next_ident_away (Id.of_string "x") avoid in
   let y = next_ident_away (Id.of_string "y") (Id.Set.add x avoid) in
     let create_input c =
@@ -782,7 +776,7 @@ let compute_lb_goal ind lnamesparrec nparrec =
               (mkApp(eq,[|bb;mkApp(eqI,[|mkVar x;mkVar y|]);tt|]))
         )))
 
-let compute_lb_tact ind lnamesparrec nparrec =
+let compute_lb_tact handle ind lnamesparrec nparrec =
   let list_id = list_id lnamesparrec in
   let first_intros =
     ( List.map (fun (s,_,_,_) -> s ) list_id )
@@ -814,7 +808,7 @@ let compute_lb_tact ind lnamesparrec nparrec =
                 | App(c,ca) -> (match (EConstr.kind sigma ca.(1)) with
                                 | App(c',ca') ->
                                    let n = Array.length ca' in
-                                   do_replace_lb
+                                   do_replace_lb handle
                                      (List.rev fresh_first_intros)
                                      nparrec
                                      ca'.(n-2) ca'.(n-1)
@@ -829,7 +823,7 @@ let compute_lb_tact ind lnamesparrec nparrec =
       ]
     end
 
-let make_lb_scheme mind =
+let make_lb_scheme handle mind =
   let mib = Global.lookup_mind mind in
   if not (Int.equal (Array.length mib.mind_packets) 1) then
     user_err
@@ -839,11 +833,11 @@ let make_lb_scheme mind =
   let nparrec = mib.mind_nparams_rec in
   let lnonparrec,lnamesparrec =
     context_chop (nparams-nparrec) mib.mind_params_ctxt in
-  let lb_goal = compute_lb_goal ind lnamesparrec nparrec in
+  let lb_goal = compute_lb_goal handle ind lnamesparrec nparrec in
   let uctx = UState.from_env (Global.env ()) in
   let lb_goal = EConstr.of_constr lb_goal in
   let (ans, _, _, _, ctx) = Declare.build_by_tactic ~poly:false ~side_eff:false (Global.env()) ~uctx ~typ:lb_goal
-    (compute_lb_tact ind lnamesparrec nparrec)
+    (compute_lb_tact handle ind lnamesparrec nparrec)
   in
   ([|ans|], ctx)
 
@@ -924,12 +918,12 @@ let compute_dec_goal ind lnamesparrec nparrec =
         )
       )
 
-let compute_dec_tact ind lnamesparrec nparrec =
+let compute_dec_tact handle ind lnamesparrec nparrec =
   let eq = eq () and tt = tt ()
       and ff = ff () and bb = bb () in
   let list_id = list_id lnamesparrec in
-  get_scheme beq_scheme_kind ind >>= fun _ ->
-  let _non_fresh_eqI = eqI ind list_id in
+  let _ = get_scheme handle beq_scheme_kind ind in (* This is just an assertion? *)
+  let _non_fresh_eqI = eqI handle ind list_id in
   let eqtrue x = mkApp(eq,[|bb;x;tt|]) in
   let eqfalse x = mkApp(eq,[|bb;x;ff|]) in
   let first_intros =
@@ -947,7 +941,7 @@ let compute_dec_tact ind lnamesparrec nparrec =
       let fresh_list_id =
         List.init n (fun i -> (Array.get a i, Array.get a (i+n),
                                Array.get a (i+2*n), Array.get a (i+3*n))) in
-      eqI ind fresh_list_id
+      eqI handle ind fresh_list_id
     in
     intro_using_then (Id.of_string "x") begin fun freshn ->
       intro_using_then (Id.of_string "y") begin fun freshm ->
@@ -956,9 +950,9 @@ let compute_dec_tact ind lnamesparrec nparrec =
           let eqbnm = mkApp(eqI,[|mkVar freshn;mkVar freshm|]) in
           let arfresh = Array.of_list fresh_first_intros in
           let xargs = Array.sub arfresh 0 (2*nparrec) in
-          get_scheme bl_scheme_kind ind >>= fun c ->
+          let c = get_scheme handle bl_scheme_kind ind in
           let blI = mkConst c in
-          get_scheme lb_scheme_kind ind >>= fun c ->
+          let c = get_scheme handle lb_scheme_kind ind in
           let lbI = mkConst c in
           Tacticals.New.tclTHENLIST [
               (*we do this so we don't have to prove the same goal twice *)
@@ -1010,7 +1004,7 @@ let compute_dec_tact ind lnamesparrec nparrec =
       end
     end
 
-let make_eq_decidability mind =
+let make_eq_decidability handle mind =
   let mib = Global.lookup_mind mind in
   if not (Int.equal (Array.length mib.mind_packets) 1) then
     raise DecidabilityMutualNotSupported;
@@ -1023,7 +1017,7 @@ let make_eq_decidability mind =
     context_chop (nparams-nparrec) mib.mind_params_ctxt in
   let (ans, _, _, _, ctx) = Declare.build_by_tactic ~poly:false ~side_eff:false (Global.env()) ~uctx
       ~typ:(EConstr.of_constr (compute_dec_goal (ind,u) lnamesparrec nparrec))
-      (compute_dec_tact ind lnamesparrec nparrec)
+      (compute_dec_tact handle ind lnamesparrec nparrec)
   in
   ([|ans|], ctx)
 

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -100,8 +100,8 @@ let my_discr_tac = Equality.discr_tac false None
 let my_inj_tac x = Equality.inj inj_flags None false None (EConstr.mkVar x,NoBindings)
 
 (* reconstruct the inductive with the correct de Bruijn indexes *)
-let mkFullInd (ind,u) n =
-  let mib = Global.lookup_mind (fst ind) in
+let mkFullInd env (ind,u) n =
+  let mib = Environ.lookup_mind (fst ind) env in
   let nparams = mib.mind_nparams in
   let nparrec = mib.mind_nparams_rec in
   (* params context divided *)
@@ -126,11 +126,9 @@ let get_scheme handle k ind = match local_lookup_scheme handle k ind with
 
 let beq_scheme_kind_aux = ref (fun _ -> failwith "Undefined")
 
-let get_inductive_deps kn =
-  (* fetching global env *)
-  let env = Global.env() in
+let get_inductive_deps env kn =
   (* fetching the mutual inductive body *)
-  let mib = Global.lookup_mind kn in
+  let mib = Environ.lookup_mind kn env in
   (* number of inductives in the mutual *)
   let nb_ind = Array.length mib.mind_packets in
   (* number of params in the type *)
@@ -172,16 +170,14 @@ let get_inductive_deps kn =
   in
   Array.fold_left_i (fun i accu _ -> make_one_eq accu i) [] mib.mind_packets
 
-let build_beq_scheme_deps kn =
-  let inds = get_inductive_deps kn in
+let build_beq_scheme_deps env kn =
+  let inds = get_inductive_deps env kn in
   List.map (fun ind -> SchemeMutualDep (ind, !beq_scheme_kind_aux ())) inds
 
-let build_beq_scheme handle kn =
+let build_beq_scheme env handle kn =
   check_bool_is_defined ();
-  (* fetching global env *)
-  let env = Global.env() in
   (* fetching the mutual inductive body *)
-  let mib = Global.lookup_mind kn in
+  let mib = Environ.lookup_mind kn env in
   (* number of inductives in the mutual *)
   let nb_ind = Array.length mib.mind_packets in
   (* number of params in the type *)
@@ -306,7 +302,7 @@ let build_beq_scheme handle kn =
     let do_predicate rel_list n =
       List.fold_left (fun a b -> mkLambda(make_annot Anonymous Sorts.Relevant,b,a))
         (mkLambda (make_annot Anonymous Sorts.Relevant,
-                   mkFullInd ind (n+3+(List.length rettyp_l)+nb_ind-1),
+                   mkFullInd env ind (n+3+(List.length rettyp_l)+nb_ind-1),
                    (bb ())))
         (List.rev rettyp_l) in
     (* make_one_eq *)
@@ -370,8 +366,8 @@ let build_beq_scheme handle kn =
         ci pred NoInvert (EConstr.mkVar (Id.of_string "X"))
         (EConstr.of_constr_array ar)
     in
-    mkNamedLambda (make_annot (Id.of_string "X") Sorts.Relevant) (mkFullInd ind (nb_ind-1+1))  (
-        mkNamedLambda (make_annot (Id.of_string "Y") Sorts.Relevant) (mkFullInd ind (nb_ind-1+2))  (
+    mkNamedLambda (make_annot (Id.of_string "X") Sorts.Relevant) (mkFullInd env ind (nb_ind-1+1))  (
+        mkNamedLambda (make_annot (Id.of_string "Y") Sorts.Relevant) (mkFullInd env ind (nb_ind-1+2))  (
             (EConstr.Unsafe.to_constr case)))
   in (* build_beq_scheme *)
 
@@ -381,8 +377,8 @@ let build_beq_scheme handle kn =
   let u = Univ.Instance.empty in
   for i=0 to (nb_ind-1) do
     names.(i) <- make_annot (Name (Id.of_string (rec_name i))) Sorts.Relevant;
-    types.(i) <- mkArrow (mkFullInd ((kn,i),u) 0) Sorts.Relevant
-                  (mkArrow (mkFullInd ((kn,i),u) 1) Sorts.Relevant (bb ()));
+    types.(i) <- mkArrow (mkFullInd env ((kn,i),u) 0) Sorts.Relevant
+                  (mkArrow (mkFullInd env ((kn,i),u) 1) Sorts.Relevant (bb ()));
     let c = make_one_eq i in
     cores.(i) <- c;
   done;
@@ -403,7 +399,7 @@ let build_beq_scheme handle kn =
     in
     create_input fix)
   in
-  res, UState.from_env (Global.env ())
+  res, UState.from_env env
 
 let beq_scheme_kind =
   declare_mutual_scheme_object "_beq"
@@ -598,7 +594,7 @@ let eqI handle ind list_id =
 
 open Namegen
 
-let compute_bl_goal handle ind lnamesparrec nparrec =
+let compute_bl_goal env handle ind lnamesparrec nparrec =
   let list_id = list_id lnamesparrec in
   let eqI = eqI handle ind list_id in
   let avoid = avoid_of_list_id list_id in
@@ -632,12 +628,12 @@ let compute_bl_goal handle ind lnamesparrec nparrec =
     in
       let u = Univ.Instance.empty in
      create_input (
-        mkNamedProd (make_annot x Sorts.Relevant) (mkFullInd (ind,u) nparrec) (
-          mkNamedProd (make_annot y Sorts.Relevant) (mkFullInd (ind,u) (nparrec+1)) (
+        mkNamedProd (make_annot x Sorts.Relevant) (mkFullInd env (ind,u) nparrec) (
+          mkNamedProd (make_annot y Sorts.Relevant) (mkFullInd env (ind,u) (nparrec+1)) (
             mkArrow
               (mkApp(eq (),[|bb ();mkApp(eqI,[|mkVar x;mkVar y|]);tt ()|]))
               Sorts.Relevant
-              (mkApp(eq (),[|mkFullInd (ind,u) (nparrec+3);mkVar x;mkVar y|]))
+              (mkApp(eq (),[|mkFullInd env (ind,u) (nparrec+3);mkVar x;mkVar y|]))
         )))
 
 let compute_bl_tact handle ind lnamesparrec nparrec =
@@ -699,8 +695,8 @@ repeat ( apply andb_prop in z;let z1:= fresh "Z" in destruct z as [z1 z]).
       ]
     end
 
-let make_bl_scheme handle mind =
-  let mib = Global.lookup_mind mind in
+let make_bl_scheme env handle mind =
+  let mib = Environ.lookup_mind mind env in
   if not (Int.equal (Array.length mib.mind_packets) 1) then
     user_err
       (str "Automatic building of boolean->Leibniz lemmas not supported");
@@ -709,16 +705,16 @@ let make_bl_scheme handle mind =
   let nparrec = mib.mind_nparams_rec in
   let lnonparrec,lnamesparrec = (* TODO subst *)
     context_chop (nparams-nparrec) mib.mind_params_ctxt in
-  let bl_goal = compute_bl_goal handle ind lnamesparrec nparrec in
-  let uctx = UState.from_env (Global.env ()) in
+  let bl_goal = compute_bl_goal env handle ind lnamesparrec nparrec in
+  let uctx = UState.from_env env in
   let bl_goal = EConstr.of_constr bl_goal in
-  let (ans, _, _, _, ctx) = Declare.build_by_tactic ~poly:false ~side_eff:false (Global.env()) ~uctx ~typ:bl_goal
+  let (ans, _, _, _, ctx) = Declare.build_by_tactic ~poly:false ~side_eff:false env ~uctx ~typ:bl_goal
     (compute_bl_tact handle (ind, EConstr.EInstance.empty) lnamesparrec nparrec)
   in
   ([|ans|], ctx)
 
-let make_bl_scheme_deps ind =
-  let inds = get_inductive_deps ind in
+let make_bl_scheme_deps env ind =
+  let inds = get_inductive_deps env ind in
   let map ind = SchemeMutualDep (ind, !bl_scheme_kind_aux ()) in
   SchemeMutualDep (ind, beq_scheme_kind) :: List.map map inds
 
@@ -732,7 +728,7 @@ let _ = bl_scheme_kind_aux := fun () -> bl_scheme_kind
 (**********************************************************************)
 (* Leibniz->Boolean *)
 
-let compute_lb_goal handle ind lnamesparrec nparrec =
+let compute_lb_goal env handle ind lnamesparrec nparrec =
   let list_id = list_id lnamesparrec in
   let eq = eq () and tt = tt () and bb = bb () in
   let avoid = avoid_of_list_id list_id in
@@ -768,10 +764,10 @@ let compute_lb_goal handle ind lnamesparrec nparrec =
     in
       let u = Univ.Instance.empty in
       create_input (
-        mkNamedProd (make_annot x Sorts.Relevant) (mkFullInd (ind,u) nparrec) (
-          mkNamedProd (make_annot y Sorts.Relevant) (mkFullInd (ind,u) (nparrec+1)) (
+        mkNamedProd (make_annot x Sorts.Relevant) (mkFullInd env (ind,u) nparrec) (
+          mkNamedProd (make_annot y Sorts.Relevant) (mkFullInd env (ind,u) (nparrec+1)) (
             mkArrow
-              (mkApp(eq,[|mkFullInd (ind,u) (nparrec+2);mkVar x;mkVar y|]))
+              (mkApp(eq,[|mkFullInd env (ind,u) (nparrec+2);mkVar x;mkVar y|]))
               Sorts.Relevant
               (mkApp(eq,[|bb;mkApp(eqI,[|mkVar x;mkVar y|]);tt|]))
         )))
@@ -823,8 +819,8 @@ let compute_lb_tact handle ind lnamesparrec nparrec =
       ]
     end
 
-let make_lb_scheme handle mind =
-  let mib = Global.lookup_mind mind in
+let make_lb_scheme env handle mind =
+  let mib = Environ.lookup_mind mind env in
   if not (Int.equal (Array.length mib.mind_packets) 1) then
     user_err
       (str "Automatic building of Leibniz->boolean lemmas not supported");
@@ -833,16 +829,16 @@ let make_lb_scheme handle mind =
   let nparrec = mib.mind_nparams_rec in
   let lnonparrec,lnamesparrec =
     context_chop (nparams-nparrec) mib.mind_params_ctxt in
-  let lb_goal = compute_lb_goal handle ind lnamesparrec nparrec in
-  let uctx = UState.from_env (Global.env ()) in
+  let lb_goal = compute_lb_goal env handle ind lnamesparrec nparrec in
+  let uctx = UState.from_env env in
   let lb_goal = EConstr.of_constr lb_goal in
-  let (ans, _, _, _, ctx) = Declare.build_by_tactic ~poly:false ~side_eff:false (Global.env()) ~uctx ~typ:lb_goal
+  let (ans, _, _, _, ctx) = Declare.build_by_tactic ~poly:false ~side_eff:false env ~uctx ~typ:lb_goal
     (compute_lb_tact handle ind lnamesparrec nparrec)
   in
   ([|ans|], ctx)
 
-let make_lb_scheme_deps ind =
-  let inds = get_inductive_deps ind in
+let make_lb_scheme_deps env ind =
+  let inds = get_inductive_deps env ind in
   let map ind = SchemeMutualDep (ind, !lb_scheme_kind_aux ()) in
   SchemeMutualDep (ind, beq_scheme_kind) :: List.map map inds
 
@@ -861,7 +857,7 @@ let check_not_is_defined () =
   then raise (UndefinedCst "not")
 
 (* {n=m}+{n<>m}  part  *)
-let compute_dec_goal ind lnamesparrec nparrec =
+let compute_dec_goal env ind lnamesparrec nparrec =
   check_not_is_defined ();
   let eq = eq () and tt = tt () and bb = bb () in
   let list_id = list_id lnamesparrec in
@@ -909,10 +905,10 @@ let compute_dec_goal ind lnamesparrec nparrec =
           in
           mkNamedProd x (RelDecl.get_type decl) a) eq_input lnamesparrec
     in
-        let eqnm = mkApp(eq,[|mkFullInd ind (2*nparrec+2);mkVar x;mkVar y|]) in
+        let eqnm = mkApp(eq,[|mkFullInd env ind (2*nparrec+2);mkVar x;mkVar y|]) in
         create_input (
-          mkNamedProd (make_annot x Sorts.Relevant) (mkFullInd ind (2*nparrec)) (
-            mkNamedProd (make_annot y Sorts.Relevant) (mkFullInd ind (2*nparrec+1)) (
+          mkNamedProd (make_annot x Sorts.Relevant) (mkFullInd env ind (2*nparrec)) (
+            mkNamedProd (make_annot y Sorts.Relevant) (mkFullInd env ind (2*nparrec+1)) (
               mkApp(sumbool(),[|eqnm;mkApp (UnivGen.constr_of_monomorphic_global @@ Coqlib.lib_ref "core.not.type",[|eqnm|])|])
           )
         )
@@ -1004,26 +1000,26 @@ let compute_dec_tact handle ind lnamesparrec nparrec =
       end
     end
 
-let make_eq_decidability handle mind =
-  let mib = Global.lookup_mind mind in
+let make_eq_decidability env handle mind =
+  let mib = Environ.lookup_mind mind env in
   if not (Int.equal (Array.length mib.mind_packets) 1) then
     raise DecidabilityMutualNotSupported;
   let ind = (mind,0) in
   let nparams = mib.mind_nparams in
   let nparrec = mib.mind_nparams_rec in
   let u = Univ.Instance.empty in
-  let uctx = UState.from_env (Global.env ()) in
+  let uctx = UState.from_env env in
   let lnonparrec,lnamesparrec =
     context_chop (nparams-nparrec) mib.mind_params_ctxt in
-  let (ans, _, _, _, ctx) = Declare.build_by_tactic ~poly:false ~side_eff:false (Global.env()) ~uctx
-      ~typ:(EConstr.of_constr (compute_dec_goal (ind,u) lnamesparrec nparrec))
+  let (ans, _, _, _, ctx) = Declare.build_by_tactic ~poly:false ~side_eff:false env ~uctx
+      ~typ:(EConstr.of_constr (compute_dec_goal env (ind,u) lnamesparrec nparrec))
       (compute_dec_tact handle ind lnamesparrec nparrec)
   in
   ([|ans|], ctx)
 
 let eq_dec_scheme_kind =
   declare_mutual_scheme_object "_eq_dec"
-  ~deps:(fun ind -> [SchemeMutualDep (ind, bl_scheme_kind); SchemeMutualDep (ind, lb_scheme_kind)])
+  ~deps:(fun _ ind -> [SchemeMutualDep (ind, bl_scheme_kind); SchemeMutualDep (ind, lb_scheme_kind)])
   make_eq_decidability
 
 (* The eq_dec_scheme proofs depend on the equality and discr tactics


### PR DESCRIPTION
Instead of implicitly querying the global environment, scheme creation functions now access the environment and the registered schemes in a purely functional way.

Despite the appearances, it was not trivial to do this while not breaking everything, since it relies on the previous scheme-related PRs. Hopefully this will pass the CI blissfully.