### PR TITLE
Lemmas about list cutting & map

### DIFF
--- a/doc/changelog/10-standard-library/14406-master.rst
+++ b/doc/changelog/10-standard-library/14406-master.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Lemmas showing :g:`firstn` and :g:`skipn` commute with :g:`map`.
+  (`#14406 <https://github.com/coq/coq/pull/14406>`_,
+  by Rudy Peterson).

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -2181,6 +2181,23 @@ Section Cutting.
 
 End Cutting.
 
+Section CuttingMap.
+  Variables A B : Type.
+  Variable f : A -> B.
+
+  Lemma firstn_map : forall n l,
+      firstn n (map f l) = map f (firstn n l).
+  Proof.
+    intro n; induction n; intros []; simpl; f_equal; trivial.
+  Qed.
+
+  Lemma skipn_map : forall n l,
+      skipn n (map f l) = map f (skipn n l).
+  Proof.
+    intro n; induction n; intros []; simpl; trivial.
+  Qed.
+End CuttingMap.
+
 (**************************************************************)
 (** ** Combining pairs of lists of possibly-different lengths *)
 (**************************************************************)


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** feature / standard library

Summary: List lemmas proving `firstn` & `skipn` commute with `map`.
