### PR TITLE
Fast bound saturation in Micromega

### DIFF
--- a/plugins/micromega/mutils.ml
+++ b/plugins/micromega/mutils.ml
@@ -111,7 +111,7 @@ let find_some pred l = try Some (find_option pred l) with Not_found -> None
 let extract_all pred l =
   List.fold_left
     (fun (s1, s2) e ->
-      match pred e with None -> (s1, e :: s2) | Some v -> ((v, e) :: s1, s2))
+      match pred e with None -> (s1, e :: s2) | Some v -> (v :: s1, s2))
     ([], []) l
 
 let simplify f sys =

--- a/plugins/micromega/mutils.mli
+++ b/plugins/micromega/mutils.mli
@@ -101,7 +101,7 @@ val all_pairs : ('a -> 'a -> 'b) -> 'a list -> 'b list
 val try_any : (('a -> 'b option) * 'c) list -> 'a -> 'b option
 val is_sublist : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
 val extract : ('a -> 'b option) -> 'a list -> ('b * 'a) option * 'a list
-val extract_all : ('a -> 'b option) -> 'a list -> ('b * 'a) list * 'a list
+val extract_all : ('a -> 'b option) -> 'a list -> 'b list * 'a list
 
 val extract_best :
      ('a -> 'b option)

--- a/plugins/micromega/polynomial.mli
+++ b/plugins/micromega/polynomial.mli
@@ -189,8 +189,6 @@ module LinPoly : sig
       a is a constant such that [pred a] *)
   val search_all_linear : (Q.t -> bool) -> t -> var list
 
-  val get_bound : t -> Vect.Bound.t option
-
   (** [product p q]
      @return the product of the polynomial [p*q] *)
   val product : t -> t -> t
@@ -362,5 +360,14 @@ module WithProof : sig
 
   val saturate_subst : bool -> t list -> t list
   val is_substitution : bool -> t -> var option
+end
+
+module BoundWithProof :
+sig
+  type t
+  val compare : t -> t -> int
+  val make : WithProof.t -> t option
   val mul_bound : t -> t -> t option
+  val bound : t -> Vect.Bound.t
+  val proof : t -> WithProof.t
 end

--- a/plugins/micromega/vect.ml
+++ b/plugins/micromega/vect.ml
@@ -313,4 +313,9 @@ module Bound = struct
     | [{var = 0; coe = v}; {var = x; coe = v'}] ->
       Some {cst = v; var = x; coeff = v'}
     | _ -> None
+
+  let to_vect { cst = k; var = v; coeff = c } =
+    let () = assert (not (c =/ Q.zero)) in
+    if k =/ Q.zero then [{var = v; coe = c}]
+    else [{var = 0; coe = k}; {var = v; coe = c}]
 end

--- a/plugins/micromega/vect.mli
+++ b/plugins/micromega/vect.mli
@@ -181,4 +181,5 @@ module Bound : sig
   type t = {cst : Q.t; var : var; coeff : Q.t}
 
   val of_vect : vector -> t option
+  val to_vect : t -> vector
 end


### PR DESCRIPTION
We introduce a dedicated datatype for bounds with proofs in Micromega and prevent back and forth conversion between representations.