### PR TITLE
Move cooking types to Declarations from Opaqueproof

### DIFF
--- a/checker/mod_checking.mli
+++ b/checker/mod_checking.mli
@@ -8,6 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-val set_indirect_accessor : Opaqueproof.indirect_accessor -> unit
+val set_indirect_accessor : Declarations.cooking_info Opaqueproof.indirect_accessor -> unit
 
 val check_module : Environ.env -> Names.Cset.t Names.Cmap.t -> Names.ModPath.t -> Declarations.module_body -> Names.Cset.t Names.Cmap.t

--- a/dev/ci/user-overlays/14417-SkySkimmer-cooking-info-decls.sh
+++ b/dev/ci/user-overlays/14417-SkySkimmer-cooking-info-decls.sh
@@ -1,0 +1,1 @@
+overlay metacoq https://github.com/SkySkimmer/metacoq cooking-info-decls 14417

--- a/kernel/cooking.ml
+++ b/kernel/cooking.ml
@@ -152,7 +152,7 @@ let abstract_as_body c (hyps, subst) =
   let c = Vars.subst_vars subst c in
   it_mkLambda_or_LetIn c hyps
 
-type recipe = { from : Opaqueproof.opaque constant_body; info : Opaqueproof.cooking_info }
+type recipe = { from : constant_body; info : cooking_info }
 type inline = bool
 
 type 'opaque result = {
@@ -201,7 +201,7 @@ let lift_univs subst auctx0 = function
     let subst, auctx = discharge_abstract_universe_context subst auctx0 auctx in
     subst, (Polymorphic auctx)
 
-let cook_constr { Opaqueproof.modlist ; abstract } (c, priv) =
+let cook_constr { modlist ; abstract } (c, priv) =
   let cache = RefTable.create 13 in
   let abstract, usubst, abs_ctx = abstract in
   let usubst, priv = match priv with
@@ -227,7 +227,7 @@ let cook_constr infos c =
   List.fold_right fold infos c
 
 let cook_constant { from = cb; info } =
-  let { Opaqueproof.modlist; abstract } = info in
+  let { modlist; abstract } = info in
   let cache = RefTable.create 13 in
   let abstract, usubst, abs_ctx = abstract in
   let usubst, univs = lift_univs usubst abs_ctx cb.const_universes in
@@ -335,7 +335,7 @@ let cook_one_ind ~ntypes
     mind_reloc_tbl = mip.mind_reloc_tbl;
   }
 
-let cook_inductive { Opaqueproof.modlist; abstract } mib =
+let cook_inductive { modlist; abstract } mib =
   let (section_decls, subst, abs_uctx) = abstract in
   let subst, mind_universes = lift_univs subst abs_uctx mib.mind_universes in
   let cache = RefTable.create 13 in

--- a/kernel/cooking.mli
+++ b/kernel/cooking.mli
@@ -13,7 +13,7 @@ open Declarations
 
 (** {6 Cooking the constants. } *)
 
-type recipe = { from : Opaqueproof.opaque constant_body; info : Opaqueproof.cooking_info }
+type recipe = { from : constant_body; info : cooking_info }
 
 type inline = bool
 
@@ -27,14 +27,13 @@ type 'opaque result = {
   cook_flags : typing_flags;
 }
 
-val cook_constant : recipe -> Opaqueproof.opaque result
-val cook_constr : Opaqueproof.cooking_info list ->
+val cook_constant : recipe -> cooking_info Opaqueproof.opaque result
+val cook_constr : cooking_info list ->
   (constr * unit Opaqueproof.delayed_universes) -> (constr * unit Opaqueproof.delayed_universes)
 
 val cook_inductive :
-  Opaqueproof.cooking_info -> mutual_inductive_body -> mutual_inductive_body
+  cooking_info -> mutual_inductive_body -> mutual_inductive_body
 
 (** {6 Utility functions used in module [Discharge]. } *)
 
-val expmod_constr : Opaqueproof.work_list -> constr -> constr
-
+val expmod_constr : work_list -> constr -> constr

--- a/kernel/declarations.ml
+++ b/kernel/declarations.ml
@@ -100,9 +100,17 @@ type typing_flags = {
 
 }
 
+type work_list = (Univ.Instance.t * Id.t array) Cmap.t *
+  (Univ.Instance.t * Id.t array) Mindmap.t
+
+type cooking_info = {
+  modlist : work_list;
+  abstract : Constr.named_context * Univ.Instance.t * Univ.AUContext.t;
+}
+
 (* some contraints are in constant_constraints, some other may be in
  * the OpaqueDef *)
-type 'opaque constant_body = {
+type 'opaque pconstant_body = {
     const_hyps : Constr.named_context; (** New: younger hyp at top *)
     const_body : (Constr.t, 'opaque) constant_def;
     const_type : types;
@@ -114,6 +122,8 @@ type 'opaque constant_body = {
                                            were used for
                                            type-checking. *)
 }
+
+type constant_body = cooking_info Opaqueproof.opaque pconstant_body
 
 (** {6 Representation of mutual inductive types in the kernel } *)
 type nested_type =
@@ -270,7 +280,7 @@ type module_alg_expr =
 (** A component of a module structure *)
 
 type structure_field_body =
-  | SFBconst of Opaqueproof.opaque constant_body
+  | SFBconst of constant_body
   | SFBmind of mutual_inductive_body
   | SFBmodule of module_body
   | SFBmodtype of module_type_body

--- a/kernel/declarations.ml
+++ b/kernel/declarations.ml
@@ -103,9 +103,19 @@ type typing_flags = {
 type work_list = (Univ.Instance.t * Id.t array) Cmap.t *
   (Univ.Instance.t * Id.t array) Mindmap.t
 
+(** Data needed to abstract over the section variable and universe hypotheses *)
+type abstr_info = {
+  abstr_ctx : Constr.named_context;
+  (** Section variables of this prefix *)
+  abstr_subst : Univ.Instance.t;
+  (** Actual names of the abstracted variables *)
+  abstr_uctx : Univ.AUContext.t;
+  (** Universe quantification, same length as the substitution *)
+}
+
 type cooking_info = {
   modlist : work_list;
-  abstract : Constr.named_context * Univ.Instance.t * Univ.AUContext.t;
+  abstract : abstr_info;
 }
 
 (* some contraints are in constant_constraints, some other may be in

--- a/kernel/declareops.mli
+++ b/kernel/declareops.mli
@@ -26,21 +26,21 @@ val map_decl_arity : ('a -> 'c) -> ('b -> 'd) ->
 
 (** {6 Constants} *)
 
-val subst_const_body : substitution -> Opaqueproof.opaque constant_body -> Opaqueproof.opaque constant_body
+val subst_const_body : substitution -> constant_body -> constant_body
 
 (** Is there a actual body in const_body ? *)
 
-val constant_has_body : 'a constant_body -> bool
+val constant_has_body : 'a pconstant_body -> bool
 
-val constant_polymorphic_context : 'a constant_body -> AUContext.t
+val constant_polymorphic_context : 'a pconstant_body -> AUContext.t
 
 (** Is the constant polymorphic? *)
-val constant_is_polymorphic : 'a constant_body -> bool
+val constant_is_polymorphic : 'a pconstant_body -> bool
 
 (** Return the universe context, in case the definition is polymorphic, otherwise
     the context is empty. *)
 
-val is_opaque : 'a constant_body -> bool
+val is_opaque : 'a pconstant_body -> bool
 
 (** {6 Inductive types} *)
 
@@ -86,7 +86,7 @@ val safe_flags : Conv_oracle.oracle -> typing_flags
     of the structure, but simply hash-cons all inner constr
     and other known elements *)
 
-val hcons_const_body : 'a constant_body -> 'a constant_body
+val hcons_const_body : 'a pconstant_body -> 'a pconstant_body
 val hcons_mind : mutual_inductive_body -> mutual_inductive_body
 val hcons_module_body : module_body -> module_body
 val hcons_module_type : module_type_body -> module_type_body

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -45,7 +45,7 @@ type link_info =
   | Linked of string
   | NotLinked
 
-type constant_key = Opaqueproof.opaque constant_body * (link_info ref * key)
+type constant_key = constant_body * (link_info ref * key)
 
 type mind_key = mutual_inductive_body * link_info ref
 

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -41,7 +41,7 @@ type link_info =
 
 type key = int CEphemeron.key option ref
 
-type constant_key = Opaqueproof.opaque constant_body * (link_info ref * key)
+type constant_key = constant_body * (link_info ref * key)
 
 type mind_key = mutual_inductive_body * link_info ref
 
@@ -196,20 +196,20 @@ val reset_with_named_context : named_context_val -> env -> env
 val pop_rel_context : int -> env -> env
 
 (** Useful for printing *)
-val fold_constants : (Constant.t -> Opaqueproof.opaque constant_body -> 'a -> 'a) -> env -> 'a -> 'a
+val fold_constants : (Constant.t -> constant_body -> 'a -> 'a) -> env -> 'a -> 'a
 val fold_inductives : (MutInd.t -> Declarations.mutual_inductive_body -> 'a -> 'a) -> env -> 'a -> 'a
 
 (** {5 Global constants }
   {6 Add entries to global environment } *)
 
-val add_constant : Constant.t -> Opaqueproof.opaque constant_body -> env -> env
-val add_constant_key : Constant.t -> Opaqueproof.opaque constant_body -> link_info ->
+val add_constant : Constant.t -> constant_body -> env -> env
+val add_constant_key : Constant.t -> constant_body -> link_info ->
   env -> env
 val lookup_constant_key :  Constant.t -> env -> constant_key
 
 (** Looks up in the context of global constant names
    raises an anomaly if the required path is not found *)
-val lookup_constant    : Constant.t -> env -> Opaqueproof.opaque constant_body
+val lookup_constant    : Constant.t -> env -> constant_body
 val evaluable_constant : Constant.t -> env -> bool
 
 val mem_constant : Constant.t -> env -> bool

--- a/kernel/nativecode.mli
+++ b/kernel/nativecode.mli
@@ -66,7 +66,7 @@ val register_native_file : string -> unit
 val is_loaded_native_file : string -> bool
 
 val compile_constant_field : env -> Constant.t ->
-  global list -> 'a constant_body -> global list
+  global list -> 'a pconstant_body -> global list
 
 val compile_mind_field : ModPath.t -> Label.t ->
   global list -> mutual_inductive_body -> global list

--- a/kernel/opaqueproof.ml
+++ b/kernel/opaqueproof.ml
@@ -9,16 +9,8 @@
 (************************************************************************)
 
 open Names
-open Univ
 open Constr
 open Mod_subst
-
-type work_list = (Instance.t * Id.t array) Cmap.t *
-  (Instance.t * Id.t array) Mindmap.t
-
-type cooking_info = {
-  modlist : work_list;
-  abstract : Constr.named_context * Univ.Instance.t * Univ.AUContext.t }
 
 type 'a delayed_universes =
 | PrivateMonomorphic of 'a
@@ -26,9 +18,9 @@ type 'a delayed_universes =
 
 type opaque_proofterm = Constr.t * unit delayed_universes
 
-type indirect_accessor = {
+type 'cooking_info indirect_accessor = {
   access_proof : DirPath.t -> int -> opaque_proofterm option;
-  access_discharge : cooking_info list -> opaque_proofterm -> opaque_proofterm;
+  access_discharge : 'cooking_info list -> opaque_proofterm -> opaque_proofterm;
 }
 
 let drop_mono = function
@@ -37,8 +29,8 @@ let drop_mono = function
 
 type proofterm = (constr * Univ.ContextSet.t delayed_universes) Future.computation
 
-type opaque =
-| Indirect of substitution list * cooking_info list * DirPath.t * int (* subst, discharge, lib, index *)
+type 'cooking_info opaque =
+| Indirect of substitution list * 'cooking_info list * DirPath.t * int (* subst, discharge, lib, index *)
 
 type opaquetab = {
   opaque_val : proofterm Int.Map.t;

--- a/kernel/opaqueproof.mli
+++ b/kernel/opaqueproof.mli
@@ -25,27 +25,20 @@ type 'a delayed_universes =
 
 type proofterm = (constr * Univ.ContextSet.t delayed_universes) Future.computation
 type opaquetab
-type opaque
+type 'cooking_info opaque
 
 val empty_opaquetab : opaquetab
 
 (** From a [proofterm] to some [opaque]. *)
-val create : DirPath.t -> proofterm -> opaquetab -> opaque * opaquetab
-
-type work_list = (Univ.Instance.t * Id.t array) Cmap.t *
-  (Univ.Instance.t * Id.t array) Mindmap.t
-
-type cooking_info = {
-  modlist : work_list;
-  abstract : Constr.named_context * Univ.Instance.t * Univ.AUContext.t }
+val create : DirPath.t -> proofterm -> opaquetab -> 'c opaque * opaquetab
 
 type opaque_proofterm = Constr.t * unit delayed_universes
 
 type opaque_handle
 
-type indirect_accessor = {
+type 'cooking_info indirect_accessor = {
   access_proof : DirPath.t -> opaque_handle -> opaque_proofterm option;
-  access_discharge : cooking_info list -> opaque_proofterm -> opaque_proofterm;
+  access_discharge : 'cooking_info list -> opaque_proofterm -> opaque_proofterm;
 }
 (** Opaque terms are indexed by their library
     dirpath and an integer index. The two functions above activate
@@ -54,15 +47,15 @@ type indirect_accessor = {
 
 (** From a [opaque] back to a [constr]. This might use the
     indirect opaque accessor given as an argument. *)
-val force_proof : indirect_accessor -> opaquetab -> opaque -> opaque_proofterm
-val force_constraints : indirect_accessor -> opaquetab -> opaque -> Univ.ContextSet.t
+val force_proof : 'c indirect_accessor -> opaquetab -> 'c opaque -> opaque_proofterm
+val force_constraints : 'c indirect_accessor -> opaquetab -> 'c opaque -> Univ.ContextSet.t
 
-val subst_opaque : substitution -> opaque -> opaque
+val subst_opaque : substitution -> 'c opaque -> 'c opaque
 
 val discharge_opaque :
-  cooking_info -> opaque -> opaque
+  'cooking_info -> 'cooking_info opaque -> 'cooking_info opaque
 
-val join_opaque : ?except:Future.UUIDSet.t -> opaquetab -> opaque -> unit
+val join_opaque : ?except:Future.UUIDSet.t -> opaquetab -> 'c opaque -> unit
 
 (** {5 Serialization} *)
 

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -322,7 +322,7 @@ end
 type side_effect = {
   seff_certif : Certificate.t CEphemeron.key;
   seff_constant : Constant.t;
-  seff_body : Constr.t Declarations.constant_body;
+  seff_body : Constr.t Declarations.pconstant_body;
 }
 (* Invariant: For any senv, if [Certificate.check senv seff_certif] then
   senv where univs := Certificate.universes seff_certif] +
@@ -1388,7 +1388,7 @@ let close_section senv =
   let cooking_info seg =
     let { abstr_ctx; abstr_subst; abstr_uctx } = seg in
     let abstract = (abstr_ctx, abstr_subst, abstr_uctx) in
-    { Opaqueproof.modlist; abstract }
+    { modlist; abstract }
   in
   let fold senv = function
   | `Definition (kn, cb) ->

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1385,11 +1385,7 @@ let close_section senv =
   (* Third phase: replay the discharged section contents *)
   let senv = push_context_set ~strict:true cstrs senv in
   let modlist = Section.replacement_context env0 sections0 in
-  let cooking_info seg =
-    let { abstr_ctx; abstr_subst; abstr_uctx } = seg in
-    let abstract = (abstr_ctx, abstr_subst, abstr_uctx) in
-    { modlist; abstract }
-  in
+  let cooking_info abstract = { Declarations.modlist; abstract; } in
   let fold senv = function
   | `Definition (kn, cb) ->
     let info = cooking_info (Section.segment_of_constant env0 kn sections0) in

--- a/kernel/section.ml
+++ b/kernel/section.ml
@@ -11,6 +11,7 @@
 open Util
 open Names
 open Univ
+open Declarations
 
 module NamedDecl = Context.Named.Declaration
 
@@ -116,12 +117,6 @@ let push_global ~poly e sec =
 let push_constant ~poly con s = push_global ~poly (SecDefinition con) s
 
 let push_inductive ~poly ind s = push_global ~poly (SecInductive ind) s
-
-type abstr_info = {
-  abstr_ctx : Constr.named_context;
-  abstr_subst : Instance.t;
-  abstr_uctx : AUContext.t;
-}
 
 let empty_segment = {
   abstr_ctx = [];

--- a/kernel/section.mli
+++ b/kernel/section.mli
@@ -88,7 +88,7 @@ val segment_of_constant : Environ.env -> Constant.t -> 'a t -> abstr_info
 val segment_of_inductive : Environ.env -> MutInd.t -> 'a t -> abstr_info
 (** Section segment at the time of the inductive declaration *)
 
-val replacement_context : Environ.env -> 'a t -> Opaqueproof.work_list
+val replacement_context : Environ.env -> 'a t -> Declarations.work_list
 (** Section segments of all declarations from this section. *)
 
 val is_in_section : Environ.env -> GlobRef.t -> 'a t -> bool

--- a/kernel/section.mli
+++ b/kernel/section.mli
@@ -68,24 +68,13 @@ val all_poly_univs : 'a t -> Univ.Level.t array
    constraints about monomorphic universes, which prevent declaring
    monomorphic globals. *)
 
-type abstr_info = private {
-  abstr_ctx : Constr.named_context;
-  (** Section variables of this prefix *)
-  abstr_subst : Univ.Instance.t;
-  (** Actual names of the abstracted variables *)
-  abstr_uctx : Univ.AUContext.t;
-  (** Universe quantification, same length as the substitution *)
-}
-(** Data needed to abstract over the section variable and universe hypotheses *)
-
-
-val empty_segment : abstr_info
+val empty_segment : Declarations.abstr_info
 (** Nothing to abstract *)
 
-val segment_of_constant : Environ.env -> Constant.t -> 'a t -> abstr_info
+val segment_of_constant : Environ.env -> Constant.t -> 'a t -> Declarations.abstr_info
 (** Section segment at the time of the constant declaration *)
 
-val segment_of_inductive : Environ.env -> MutInd.t -> 'a t -> abstr_info
+val segment_of_inductive : Environ.env -> MutInd.t -> 'a t -> Declarations.abstr_info
 (** Section segment at the time of the inductive declaration *)
 
 val replacement_context : Environ.env -> 'a t -> Declarations.work_list

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -31,7 +31,7 @@ open Mod_subst
    an inductive type. It can also be useful to allow reorderings in
    inductive types *)
 type namedobject =
-  | Constant of Opaqueproof.opaque constant_body
+  | Constant of constant_body
   | IndType of inductive * mutual_inductive_body
   | IndConstr of constructor * mutual_inductive_body
 

--- a/kernel/term_typing.mli
+++ b/kernel/term_typing.mli
@@ -31,13 +31,13 @@ val translate_local_assum : env -> types -> types * Sorts.relevance
 
 val translate_constant :
   env -> Constant.t -> constant_entry ->
-    'a constant_body
+    'a pconstant_body
 
 val translate_opaque :
   env -> Constant.t -> 'a opaque_entry ->
-    unit constant_body * typing_context
+    unit pconstant_body * typing_context
 
-val translate_recipe : env -> Constant.t -> Cooking.recipe -> Opaqueproof.opaque constant_body
+val translate_recipe : env -> Constant.t -> Cooking.recipe -> constant_body
 
 val check_delayed : 'a effect_handler -> typing_context -> 'a proof_output -> (Constr.t * Univ.ContextSet.t Opaqueproof.delayed_universes)
 
@@ -47,4 +47,4 @@ val infer_declaration : env ->
   constant_entry -> typing_context Cooking.result
 
 val build_constant_declaration :
-  env -> Opaqueproof.proofterm Cooking.result -> Opaqueproof.proofterm constant_body
+  env -> Opaqueproof.proofterm Cooking.result -> Opaqueproof.proofterm pconstant_body

--- a/library/global.mli
+++ b/library/global.mli
@@ -9,6 +9,7 @@
 (************************************************************************)
 
 open Names
+open Declarations
 
 (** This module defines the global environment of Coq. The functions
    below are exactly the same as the ones in [Safe_typing], operating on
@@ -29,13 +30,13 @@ val named_context : unit -> Constr.named_context
 (** {6 Enriching the global environment } *)
 
 (** Changing the (im)predicativity of the system *)
-val set_engagement : Declarations.engagement -> unit
+val set_engagement : engagement -> unit
 val set_indices_matter : bool -> unit
-val set_typing_flags : Declarations.typing_flags -> unit
+val set_typing_flags : typing_flags -> unit
 val set_check_guarded : bool -> unit
 val set_check_positive : bool -> unit
 val set_check_universes : bool -> unit
-val typing_flags : unit -> Declarations.typing_flags
+val typing_flags : unit -> typing_flags
 val set_cumulative_sprop : bool -> unit
 val is_cumulative_sprop : unit -> bool
 val set_allow_sprop : bool -> unit
@@ -52,12 +53,12 @@ val export_private_constants :
   Safe_typing.exported_private_constant list
 
 val add_constant :
-  ?typing_flags:Declarations.typing_flags ->
+  ?typing_flags:typing_flags ->
   Id.t -> Safe_typing.global_declaration -> Constant.t
 val add_private_constant :
   Id.t -> Safe_typing.side_effect_declaration -> Constant.t * Safe_typing.private_constants
 val add_mind :
-  ?typing_flags:Declarations.typing_flags ->
+  ?typing_flags:typing_flags ->
   Id.t -> Entries.mutual_inductive_entry -> MutInd.t
 
 (** Extra universe constraints *)
@@ -68,12 +69,12 @@ val push_context_set : strict:bool -> Univ.ContextSet.t -> unit
 (** Non-interactive modules and module types *)
 
 val add_module :
-  Id.t -> Entries.module_entry -> Declarations.inline ->
+  Id.t -> Entries.module_entry -> inline ->
     ModPath.t * Mod_subst.delta_resolver
 val add_modtype :
-  Id.t -> Entries.module_type_entry -> Declarations.inline -> ModPath.t
+  Id.t -> Entries.module_type_entry -> inline -> ModPath.t
 val add_include :
-  Entries.module_struct_entry -> bool -> Declarations.inline ->
+  Entries.module_struct_entry -> bool -> inline ->
     Mod_subst.delta_resolver
 
 (** Sections *)
@@ -93,26 +94,26 @@ val start_module : Id.t -> ModPath.t
 val start_modtype : Id.t -> ModPath.t
 
 val end_module : Summary.frozen -> Id.t ->
-  (Entries.module_struct_entry * Declarations.inline) option ->
+  (Entries.module_struct_entry * inline) option ->
     ModPath.t * MBId.t list * Mod_subst.delta_resolver
 
 val end_modtype : Summary.frozen -> Id.t -> ModPath.t * MBId.t list
 
 val add_module_parameter :
-  MBId.t -> Entries.module_struct_entry -> Declarations.inline ->
+  MBId.t -> Entries.module_struct_entry -> inline ->
     Mod_subst.delta_resolver
 
 (** {6 Queries in the global environment } *)
 
 val lookup_named     : variable -> Constr.named_declaration
-val lookup_constant  : Constant.t -> Opaqueproof.opaque Declarations.constant_body
+val lookup_constant  : Constant.t -> constant_body
 val lookup_inductive : inductive ->
-  Declarations.mutual_inductive_body * Declarations.one_inductive_body
+  mutual_inductive_body * one_inductive_body
 val lookup_pinductive : Constr.pinductive ->
-  Declarations.mutual_inductive_body * Declarations.one_inductive_body
-val lookup_mind      : MutInd.t -> Declarations.mutual_inductive_body
-val lookup_module    : ModPath.t -> Declarations.module_body
-val lookup_modtype   : ModPath.t -> Declarations.module_type_body
+  mutual_inductive_body * one_inductive_body
+val lookup_mind      : MutInd.t -> mutual_inductive_body
+val lookup_module    : ModPath.t -> module_body
+val lookup_modtype   : ModPath.t -> module_type_body
 val exists_objlabel  : Label.t -> bool
 
 val constant_of_delta_kn : KerName.t -> Constant.t
@@ -120,17 +121,17 @@ val mind_of_delta_kn : KerName.t -> MutInd.t
 
 val opaque_tables : unit -> Opaqueproof.opaquetab
 
-val body_of_constant : Opaqueproof.indirect_accessor -> Constant.t ->
+val body_of_constant : cooking_info Opaqueproof.indirect_accessor -> Constant.t ->
   (Constr.constr * unit Opaqueproof.delayed_universes * Univ.AUContext.t) option
 (** Returns the body of the constant if it has any, and the polymorphic context
     it lives in. For monomorphic constant, the latter is empty, and for
     polymorphic constants, the term contains De Bruijn universe variables that
     need to be instantiated. *)
 
-val body_of_constant_body : Opaqueproof.indirect_accessor ->
-  Opaqueproof.opaque Declarations.constant_body ->
+val body_of_constant_body : cooking_info Opaqueproof.indirect_accessor ->
+  constant_body ->
     (Constr.constr * unit Opaqueproof.delayed_universes * Univ.AUContext.t) option
-(** Same as {!body_of_constant} but on {!Declarations.constant_body}. *)
+(** Same as {!body_of_constant} but on {!constant_body}. *)
 
 (** {6 Compiled libraries } *)
 

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -406,8 +406,8 @@ let instance_from_variable_context =
   List.rev %> List.filter is_local_assum %> List.map NamedDecl.get_id %> Array.of_list
 
 let extract_worklist info =
-  let args = instance_from_variable_context info.Section.abstr_ctx in
-  info.Section.abstr_subst, args
+  let args = instance_from_variable_context info.Declarations.abstr_ctx in
+  info.Declarations.abstr_subst, args
 
 let sections () = Safe_typing.sections_of_safe_env @@ Global.safe_env ()
 
@@ -433,7 +433,7 @@ let section_segment_of_reference = let open GlobRef in function
 | VarRef _ -> empty_segment
 
 let variable_section_segment_of_reference gr =
-  (section_segment_of_reference gr).Section.abstr_ctx
+  (section_segment_of_reference gr).Declarations.abstr_ctx
 
 let is_in_section ref = match sections () with
   | None -> false
@@ -551,7 +551,7 @@ let discharge_proj_repr =
       let _, newpars = Mindmap.find mind (snd modlist) in
       mind, npars + Array.length newpars)
 
-let discharge_abstract_universe_context { Section.abstr_subst = subst; abstr_uctx = abs_ctx } auctx =
+let discharge_abstract_universe_context { Declarations.abstr_subst = subst; abstr_uctx = abs_ctx } auctx =
   let open Univ in
   let ainst = make_abstract_instance auctx in
   let subst = Instance.append subst ainst in

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -161,9 +161,9 @@ val drop_objects : frozen -> frozen
 val init : unit -> unit
 
 (** {6 Section management for discharge } *)
-val section_segment_of_constant : Constant.t -> Section.abstr_info
-val section_segment_of_mutual_inductive: MutInd.t -> Section.abstr_info
-val section_segment_of_reference : GlobRef.t -> Section.abstr_info
+val section_segment_of_constant : Constant.t -> Declarations.abstr_info
+val section_segment_of_mutual_inductive: MutInd.t -> Declarations.abstr_info
+val section_segment_of_reference : GlobRef.t -> Declarations.abstr_info
 
 val variable_section_segment_of_reference : GlobRef.t -> Constr.named_context
 
@@ -178,4 +178,4 @@ val replacement_context : unit -> Declarations.work_list
 
 val discharge_proj_repr : Projection.Repr.t -> Projection.Repr.t
 val discharge_abstract_universe_context :
-  Section.abstr_info -> Univ.AUContext.t -> Univ.universe_level_subst * Univ.AUContext.t
+  Declarations.abstr_info -> Univ.AUContext.t -> Univ.universe_level_subst * Univ.AUContext.t

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -170,7 +170,7 @@ val variable_section_segment_of_reference : GlobRef.t -> Constr.named_context
 val section_instance : GlobRef.t -> Univ.Instance.t * Id.t array
 val is_in_section : GlobRef.t -> bool
 
-val replacement_context : unit -> Opaqueproof.work_list
+val replacement_context : unit -> Declarations.work_list
 
 (** {6 Discharge: decrease the section level if in the current section } *)
 

--- a/plugins/extraction/extraction.mli
+++ b/plugins/extraction/extraction.mli
@@ -16,9 +16,9 @@ open Environ
 open Evd
 open Miniml
 
-val extract_constant : env -> Constant.t -> Opaqueproof.opaque constant_body -> ml_decl
+val extract_constant : env -> Constant.t -> constant_body -> ml_decl
 
-val extract_constant_spec : env -> Constant.t -> 'a constant_body -> ml_spec
+val extract_constant_spec : env -> Constant.t -> 'a pconstant_body -> ml_spec
 
 (** For extracting "module ... with ..." declaration *)
 

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -109,7 +109,7 @@ let labels_of_ref r =
 
 (*s Constants tables. *)
 
-let typedefs = ref (Cmap_env.empty : (Opaqueproof.opaque constant_body * ml_type) Cmap_env.t)
+let typedefs = ref (Cmap_env.empty : (constant_body * ml_type) Cmap_env.t)
 let init_typedefs () = typedefs := Cmap_env.empty
 let add_typedef kn cb t =
   typedefs := Cmap_env.add kn (cb,t) !typedefs
@@ -120,7 +120,7 @@ let lookup_typedef kn cb =
   with Not_found -> None
 
 let cst_types =
-  ref (Cmap_env.empty : (Opaqueproof.opaque constant_body * ml_schema) Cmap_env.t)
+  ref (Cmap_env.empty : (constant_body * ml_schema) Cmap_env.t)
 let init_cst_types () = cst_types := Cmap_env.empty
 let add_cst_type kn cb s = cst_types := Cmap_env.add kn (cb,s) !cst_types
 let lookup_cst_type kn cb =

--- a/plugins/extraction/table.mli
+++ b/plugins/extraction/table.mli
@@ -72,11 +72,11 @@ val labels_of_ref : GlobRef.t -> ModPath.t * Label.t list
    [mutual_inductive_body] as checksum. In both case, we should ideally
    also check the env *)
 
-val add_typedef : Constant.t -> Opaqueproof.opaque constant_body -> ml_type -> unit
-val lookup_typedef : Constant.t -> Opaqueproof.opaque constant_body -> ml_type option
+val add_typedef : Constant.t -> constant_body -> ml_type -> unit
+val lookup_typedef : Constant.t -> constant_body -> ml_type option
 
-val add_cst_type : Constant.t -> Opaqueproof.opaque constant_body -> ml_schema -> unit
-val lookup_cst_type : Constant.t -> Opaqueproof.opaque constant_body -> ml_schema option
+val add_cst_type : Constant.t -> constant_body -> ml_schema -> unit
+val lookup_cst_type : Constant.t -> constant_body -> ml_schema option
 
 val add_ind : MutInd.t -> mutual_inductive_body -> ml_ind -> unit
 val lookup_ind : MutInd.t -> mutual_inductive_body -> ml_ind option

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -242,7 +242,7 @@ let discharge_class (_,cl) =
   in
   try
     let info = abs_context cl in
-    let ctx = info.Section.abstr_ctx in
+    let ctx = info.Declarations.abstr_ctx in
     let ctx, subst = rel_of_variable_context ctx in
     let usubst, cl_univs' = Lib.discharge_abstract_universe_context info cl.cl_univs in
     let context = discharge_context ctx (subst, usubst) cl.cl_context in

--- a/vernac/library.mli
+++ b/vernac/library.mli
@@ -75,4 +75,4 @@ val overwrite_library_filenames : string -> unit
 val native_name_from_filename : string -> string
 
 (** {6 Opaque accessors} *)
-val indirect_accessor : Opaqueproof.indirect_accessor
+val indirect_accessor : Declarations.cooking_info Opaqueproof.indirect_accessor


### PR DESCRIPTION
This is the highest they can go and may fit better (opaqueproof doesn't care what the cooking_info type contains).

Overlay: https://github.com/MetaCoq/metacoq/pull/560