### PR TITLE
Cleanup old overlay files

### DIFF
--- a/dev/ci/user-overlays/09710-ppedrot-compact-case-repr.sh
+++ b/dev/ci/user-overlays/09710-ppedrot-compact-case-repr.sh
@@ -1,9 +1,0 @@
-overlay coq_dpdgraph https://github.com/ppedrot/coq-dpdgraph compact-case-repr 13563
-overlay coqhammer https://github.com/ppedrot/coqhammer compact-case-repr 13563
-overlay elpi https://github.com/ppedrot/coq-elpi compact-case-repr 13563
-overlay equations https://github.com/ppedrot/Coq-Equations compact-case-repr 13563
-overlay metacoq https://github.com/ppedrot/metacoq compact-case-repr 13563
-overlay mtac2 https://github.com/ppedrot/Mtac2 compact-case-repr 13563
-overlay paramcoq https://github.com/ppedrot/paramcoq compact-case-repr 13563
-overlay relation_algebra https://github.com/ppedrot/relation-algebra compact-case-repr 13563
-overlay unicoq https://github.com/ppedrot/unicoq compact-case-repr 13563

--- a/dev/ci/user-overlays/13202-SkySkimmer-debug-infra.sh
+++ b/dev/ci/user-overlays/13202-SkySkimmer-debug-infra.sh
@@ -1,1 +1,0 @@
-overlay elpi https://github.com/SkySkimmer/coq-elpi debug-infra 13202

--- a/dev/ci/user-overlays/13299-jashug-preserve-universes-notation.sh
+++ b/dev/ci/user-overlays/13299-jashug-preserve-universes-notation.sh
@@ -1,6 +1,0 @@
-if [ "$CI_PULL_REQUEST" = "13299" ] || [ "$CI_BRANCH" = "preserve-universes-notation" ]; then
-
-    elpi_CI_REF=overlay-universes-in-notations
-    elpi_CI_GITURL=https://github.com/jashug/coq-elpi
-
-fi

--- a/dev/ci/user-overlays/13321-ppedrot-mv-evaluable-global-ref-out-of-kernel.sh
+++ b/dev/ci/user-overlays/13321-ppedrot-mv-evaluable-global-ref-out-of-kernel.sh
@@ -1,1 +1,0 @@
-overlay equations https://github.com/ppedrot/Coq-Equations mv-evaluable-global-ref-out-of-kernel 13321

--- a/dev/ci/user-overlays/13512-herbelin-master+fix13413-apply-on-intro-pattern-fresh-names.sh
+++ b/dev/ci/user-overlays/13512-herbelin-master+fix13413-apply-on-intro-pattern-fresh-names.sh
@@ -1,5 +1,0 @@
-if [ "$CI_PULL_REQUEST" = "13415" ] || [ "$CI_BRANCH" = "intern-univs" ]; then
-
-    overlay perennial https://github.com/herbelin/perennial master+adapt13512-fresness-names-apply-in-introduction-pattern
-
-fi

--- a/dev/ci/user-overlays/13537-ppedrot-lazy-subst-kernel.sh
+++ b/dev/ci/user-overlays/13537-ppedrot-lazy-subst-kernel.sh
@@ -1,5 +1,0 @@
-if [ "$CI_PULL_REQUEST" = "13537" ] || [ "$CI_BRANCH" = "lazy-subst-kernel" ]; then
-
-    overlay mtac2 https://github.com/ppedrot/Mtac2 lazy-subst-kernel
-
-fi

--- a/dev/ci/user-overlays/13617-ejgallego-make+use_dune_for_ocaml.sh
+++ b/dev/ci/user-overlays/13617-ejgallego-make+use_dune_for_ocaml.sh
@@ -1,6 +1,0 @@
-# HoTT overaly is not needed anymore after they were able to build their own stdlib
-# overlay hott https://github.com/ejgallego/HoTT make+use_dune_for_ocaml 13617
-
-# Overlays disabled in favor of update of ci-basic-overlay.sh
-# overlay gappa https://gitlab.inria.fr/egallego/gappa-coq make+use_dune_for_ocaml 13617
-# overlay interval https://gitlab.inria.fr/egallego/interval make+use_dune_for_ocaml 13617

--- a/dev/ci/user-overlays/13725-SkySkimmer-hint-rw-local.sh
+++ b/dev/ci/user-overlays/13725-SkySkimmer-hint-rw-local.sh
@@ -1,1 +1,0 @@
-overlay equations https://github.com/SkySkimmer/Coq-Equations hint-rw-local 13725

--- a/dev/ci/user-overlays/13842-proux01-remove-decimal.sh
+++ b/dev/ci/user-overlays/13842-proux01-remove-decimal.sh
@@ -1,1 +1,0 @@
-overlay hott https://github.com/proux01/HoTT coq-13842 13842

--- a/dev/ci/user-overlays/13844-gares-command-loc.sh
+++ b/dev/ci/user-overlays/13844-gares-command-loc.sh
@@ -1,1 +1,0 @@
-overlay elpi https://github.com/LPCIC/coq-elpi command-loc 13844

--- a/dev/ci/user-overlays/13847-gares-elpi-1.13-coq-elpi-1.9.0.sh
+++ b/dev/ci/user-overlays/13847-gares-elpi-1.13-coq-elpi-1.9.0.sh
@@ -1,1 +1,0 @@
-overlay elpi https://github.com/LPCIC/coq-elpi coq-master+1.9.0 13847

--- a/dev/ci/user-overlays/13852-Lysxia-no-collision-projection.sh
+++ b/dev/ci/user-overlays/13852-Lysxia-no-collision-projection.sh
@@ -1,1 +1,0 @@
-overlay compcert https://github.com/Lysxia/CompCert no-collision-projection 13852

--- a/dev/ci/user-overlays/13885-ejgallego-ocaml+4.12.sh
+++ b/dev/ci/user-overlays/13885-ejgallego-ocaml+4.12.sh
@@ -1,1 +1,0 @@
-overlay elpi https://github.com/ejgallego/coq-elpi ocaml+4.12 13885

--- a/dev/ci/user-overlays/13911-Zimmi48-remove_type_cast.sh
+++ b/dev/ci/user-overlays/13911-Zimmi48-remove_type_cast.sh
@@ -1,2 +1,0 @@
-overlay equations https://github.com/Zimmi48/Coq-Equations coq-13911 13911 remove_type_cast
-overlay elpi https://github.com/Zimmi48/coq-elpi patch-1 13911 remove_type_cast

--- a/dev/ci/user-overlays/13912-pi8027-remove-bijint.sh
+++ b/dev/ci/user-overlays/13912-pi8027-remove-bijint.sh
@@ -1,1 +1,0 @@
-overlay elpi https://github.com/pi8027/coq-elpi coq-overlay-13912 13912

--- a/dev/ci/user-overlays/13958-gares-recordops-api.sh
+++ b/dev/ci/user-overlays/13958-gares-recordops-api.sh
@@ -1,6 +1,0 @@
-overlay metacoq https://github.com/gares/metacoq recordops-api 13958
-overlay mtac2 https://github.com/gares/Mtac2 recordops-api 13958
-overlay elpi https://github.com/gares/coq-elpi recordops-api 13958
-overlay unicoq https://github.com/gares/unicoq recordops-api 13958
-overlay equations https://github.com/gares/Coq-Equations recordops-api 13958
-overlay hierarchy_builder https://github.com/gares/hierarchy-builder coq-master 13958

--- a/dev/ci/user-overlays/14050-SkySkimmer-no-remote-counter-alt.sh
+++ b/dev/ci/user-overlays/14050-SkySkimmer-no-remote-counter-alt.sh
@@ -1,1 +1,0 @@
-overlay metacoq https://github.com/SkySkimmer/metacoq no-remote-counter-alt 14050

--- a/dev/ci/user-overlays/14075-herbelin-master+new-level-abstraction-streams-with-location.sh
+++ b/dev/ci/user-overlays/14075-herbelin-master+new-level-abstraction-streams-with-location.sh
@@ -1,1 +1,0 @@
-overlay elpi https://github.com/herbelin/coq-elpi coq-master+adapt-coq-pr14075-new-module-lstream-change-of_parser 14075

--- a/dev/ci/user-overlays/14099-LasseBlaauwbroek-fix-destruct-type.sh
+++ b/dev/ci/user-overlays/14099-LasseBlaauwbroek-fix-destruct-type.sh
@@ -1,1 +1,0 @@
-overlay coq_dpdgraph https://github.com/LasseBlaauwbroek/coq-dpdgraph fix-destruct-type 14099

--- a/dev/ci/user-overlays/14111-gares-update-elpi.sh
+++ b/dev/ci/user-overlays/14111-gares-update-elpi.sh
@@ -1,2 +1,0 @@
-overlay elpi https://github.com/LPCIC/coq-elpi coq-master+1.9.5 14111
-overlay hierarchy_builder https://github.com/math-comp/hierarchy-builder coq-master+1.1.0 14111

--- a/dev/ci/user-overlays/14148-ppedrot-export-instance-take-two.sh
+++ b/dev/ci/user-overlays/14148-ppedrot-export-instance-take-two.sh
@@ -1,9 +1,0 @@
-overlay elpi https://github.com/ppedrot/coq-elpi export-instance-take-two 14148
-
-overlay equations https://github.com/ppedrot/Coq-Equations export-instance-take-two 14148
-
-overlay metacoq https://github.com/ppedrot/metacoq export-instance-take-two 14148
-
-overlay mtac2 https://github.com/ppedrot/Mtac2 export-instance-take-two 14148
-
-overlay quickchick https://github.com/ppedrot/QuickChick export-instance-take-two 14148

--- a/dev/ci/user-overlays/14224-jfehrle-ltac_loc_info.sh
+++ b/dev/ci/user-overlays/14224-jfehrle-ltac_loc_info.sh
@@ -1,8 +1,0 @@
-overlay aac_tactics https://github.com/jfehrle/aac-tactics ltac_loc_info 14224
-overlay coqhammer https://github.com/jfehrle/coqhammer ltac_loc_info 14224
-overlay elpi https://github.com/jfehrle/coq-elpi ltac_loc_info2 14224
-overlay equations https://github.com/jfehrle/Coq-Equations ltac_loc_info 14224
-overlay metacoq https://github.com/jfehrle/metacoq ltac_loc_info 14224
-overlay mtac2 https://github.com/jfehrle/Mtac2 ltac_loc_info 14224
-overlay relation_algebra https://github.com/jfehrle/relation-algebra ltac_loc_info 14224
-overlay rewriter https://github.com/jfehrle/rewriter ltac_loc_info 14224

--- a/dev/ci/user-overlays/14247-SkySkimmer-usubst-clean.sh
+++ b/dev/ci/user-overlays/14247-SkySkimmer-usubst-clean.sh
@@ -1,1 +1,0 @@
-overlay equations https://github.com/SkySkimmer/Coq-Equations usubst-clean 14247

--- a/dev/ci/user-overlays/14295-gares-export-ind-parsing-rules.sh
+++ b/dev/ci/user-overlays/14295-gares-export-ind-parsing-rules.sh
@@ -1,1 +1,0 @@
-overlay elpi https://github.com/gares/coq-elpi export-ind-parsing-rules 14295

--- a/dev/ci/user-overlays/14337-ppedrot-eager-constr-mod-subst.sh
+++ b/dev/ci/user-overlays/14337-ppedrot-eager-constr-mod-subst.sh
@@ -1,1 +1,0 @@
-overlay metacoq https://github.com/ppedrot/metacoq eager-constr-mod-subst 14337

--- a/dev/ci/user-overlays/14357-gares-update-elpi-1.10.sh
+++ b/dev/ci/user-overlays/14357-gares-update-elpi-1.10.sh
@@ -1,1 +1,0 @@
-overlay elpi https://github.com/gares/coq-elpi update-elpi-1.10 14357


### PR DESCRIPTION
I left 13965-gares-syndef-principal-scope.sh to serve as an
example (picked because 3 overlays shows how you can have more than 1
without overdoing it).