### PR TITLE
Minor parsing/lexing refactorings

### DIFF
--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -21,8 +21,6 @@ module type S = sig
     val comments : t -> ((int * int) * string) list
   end
 
-  val tokens : string -> (string option * int) list
-
   module Entry : sig
     type 'a t
     val make : string -> 'a t
@@ -122,13 +120,6 @@ type grammar =
 
 let egram =
   { gtokens = Hashtbl.create 301 }
-
-let tokens con =
-  let list = ref [] in
-  Hashtbl.iter
-    (fun (p_con, p_prm) c -> if p_con = con then list := (p_prm, !c) :: !list)
-    egram.gtokens;
-  !list
 
 (** Used to propagate possible presence of SELF/NEXT in a rule (binary and) *)
 type ('a, 'b, 'c) ty_and_rec =

--- a/gramlib/grammar.mli
+++ b/gramlib/grammar.mli
@@ -31,8 +31,6 @@ module type S = sig
     val comments : t -> ((int * int) * string) list
   end
 
-  val tokens : string -> (string option * int) list
-
   module Entry : sig
     type 'a t
     val make : string -> 'a t

--- a/parsing/cLexer.ml
+++ b/parsing/cLexer.ml
@@ -798,14 +798,6 @@ let next_token ~diff_mode loc s =
 
 (** {6 The lexer of Coq} *)
 
-(** Note: removing a token.
-   We do nothing because [remove_token] is called only when removing a grammar
-   rule with [Grammar.delete_rule]. The latter command is called only when
-   unfreezing the state of the grammar entries (see GRAMMAR summary, file
-   env/metasyntax.ml). Therefore, instead of removing tokens one by one,
-   we unfreeze the state of the lexer. This restores the behaviour of the
-   lexer. B.B. *)
-
 let func next_token ?(loc=Loc.(initial ToplevelInput)) cs =
   let cur_loc = ref loc in
   LStream.from ~loc
@@ -824,7 +816,12 @@ module MakeLexer (Diff : sig val mode : bool end) = struct
     | PKEYWORD s -> add_keyword ~quotation:NoQuotation s
     | PQUOTATION s -> add_keyword ~quotation:Quotation s
     | _ -> ()
-  let tok_removing = (fun _ -> ())
+  let tok_removing : type c. c pattern -> unit = function
+    (* Normally useless because backtracking relies on state freezing *)
+    (* Nevertheless consistent with tok_using *)
+    | PKEYWORD s -> remove_keyword s
+    | PQUOTATION s -> remove_keyword s
+    | _ -> ()
   let tok_match = Tok.match_pattern
   let tok_text = Tok.token_text
 

--- a/parsing/cLexer.ml
+++ b/parsing/cLexer.ml
@@ -806,26 +806,6 @@ let next_token ~diff_mode loc s =
    we unfreeze the state of the lexer. This restores the behaviour of the
    lexer. B.B. *)
 
-(** Names of tokens, for this lexer, used in Grammar error messages *)
-
-let token_text : type c. c Tok.p -> string = function
-  | PKEYWORD t -> "'" ^ t ^ "'"
-  | PIDENT None -> "identifier"
-  | PIDENT (Some t) -> "'" ^ t ^ "'"
-  | PNUMBER None -> "number"
-  | PNUMBER (Some n) -> "'" ^ NumTok.Unsigned.sprint n ^ "'"
-  | PSTRING None -> "string"
-  | PSTRING (Some s) -> "STRING \"" ^ s ^ "\""
-  | PLEFTQMARK -> "LEFTQMARK"
-  | PEOI -> "end of input"
-  | PPATTERNIDENT None -> "PATTERNIDENT"
-  | PPATTERNIDENT (Some s) -> "PATTERNIDENT \"" ^ s ^ "\""
-  | PFIELD None -> "FIELD"
-  | PFIELD (Some s) -> "FIELD \"" ^ s ^ "\""
-  | PBULLET None -> "BULLET"
-  | PBULLET (Some s) -> "BULLET \"" ^ s ^ "\""
-  | PQUOTATION lbl -> "QUOTATION \"" ^ lbl ^ "\""
-
 let func next_token ?(loc=Loc.(initial ToplevelInput)) cs =
   let cur_loc = ref loc in
   LStream.from ~loc
@@ -846,7 +826,7 @@ module MakeLexer (Diff : sig val mode : bool end) = struct
     | _ -> ()
   let tok_removing = (fun _ -> ())
   let tok_match = Tok.match_pattern
-  let tok_text = token_text
+  let tok_text = Tok.token_text
 
   (* The state of the lexer visible from outside *)
   module State = struct

--- a/parsing/tok.ml
+++ b/parsing/tok.ml
@@ -54,9 +54,11 @@ let equal_p (type a b) (t1 : a p) (t2 : b p) : (a, b) Util.eq option =
   let streq s1 s2 = match s1, s2 with None, None -> true
     | Some s1, Some s2 -> string_equal s1 s2 | _ -> false in
   match t1, t2 with
-  | PKEYWORD s1, PKEYWORD s2 when string_equal s1 s2 -> Some Util.Refl
-  | PPATTERNIDENT s1, PPATTERNIDENT s2 when streq s1 s2 -> Some Util.Refl
   | PIDENT s1, PIDENT s2 when streq s1 s2 -> Some Util.Refl
+  | PKEYWORD s1, PKEYWORD s2 when string_equal s1 s2 -> Some Util.Refl
+  | PIDENT (Some s1), PKEYWORD s2 when string_equal s1 s2 -> Some Util.Refl
+  | PKEYWORD s1, PIDENT (Some s2) when string_equal s1 s2 -> Some Util.Refl
+  | PPATTERNIDENT s1, PPATTERNIDENT s2 when streq s1 s2 -> Some Util.Refl
   | PFIELD s1, PFIELD s2 when streq s1 s2 -> Some Util.Refl
   | PNUMBER None, PNUMBER None -> Some Util.Refl
   | PNUMBER (Some n1), PNUMBER (Some n2) when NumTok.Unsigned.equal n1 n2 -> Some Util.Refl

--- a/parsing/tok.ml
+++ b/parsing/tok.ml
@@ -81,6 +81,24 @@ let equal t1 t2 = match t1, t2 with
 | QUOTATION(s1,t1), QUOTATION(s2,t2) -> string_equal s1 s2 && string_equal t1 t2
 | _ -> false
 
+let token_text : type c. c p -> string = function
+  | PKEYWORD t -> "'" ^ t ^ "'"
+  | PIDENT None -> "identifier"
+  | PIDENT (Some t) -> "'" ^ t ^ "'"
+  | PNUMBER None -> "number"
+  | PNUMBER (Some n) -> "'" ^ NumTok.Unsigned.sprint n ^ "'"
+  | PSTRING None -> "string"
+  | PSTRING (Some s) -> "STRING \"" ^ s ^ "\""
+  | PLEFTQMARK -> "LEFTQMARK"
+  | PEOI -> "end of input"
+  | PPATTERNIDENT None -> "PATTERNIDENT"
+  | PPATTERNIDENT (Some s) -> "PATTERNIDENT \"" ^ s ^ "\""
+  | PFIELD None -> "FIELD"
+  | PFIELD (Some s) -> "FIELD \"" ^ s ^ "\""
+  | PBULLET None -> "BULLET"
+  | PBULLET (Some s) -> "BULLET \"" ^ s ^ "\""
+  | PQUOTATION lbl -> "QUOTATION \"" ^ lbl ^ "\""
+
 let extract_string diff_mode = function
   | KEYWORD s -> s
   | IDENT s -> s

--- a/parsing/tok.mli
+++ b/parsing/tok.mli
@@ -42,6 +42,10 @@ val equal : t -> t -> bool
 (* pass true for diff_mode *)
 val extract_string : bool -> t -> string
 
+(** Names of tokens, used in Grammar error messages *)
+
+val token_text : 'c p -> string
+
 (** Utility function for the test returned by a QUOTATION token:
     It returns the delimiter parenthesis, if any, and the text
     without delimiters. Eg `{{{ text }}}` -> Some '{', ` text ` *)


### PR DESCRIPTION
**Kind:** misc "cleanup"

This is extracted from #14071 so as to make it smaller. It contains the following few minor changes:

- moving `token_text` from `cLexer.ml` to `tok.ml` which looks more natural
- introducing symmetry between `token_using` and `token_removing` (even if the effect of `token_removing` is overriden by state unfreezing) [incidentally, there is a problem with the state of keywords in plugins which need to be fixed]
- add symmetry in the interchangeability of `IDENT` and `KEYWORD` when the corresponding identifier is a keyword

