### PR TITLE
Stop replacing file names by "stdin" in output tests

### DIFF
--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -434,7 +434,6 @@ $(addsuffix .log,$(wildcard output/*.v)): %.v.log: %.v %.out $(PREREQUISITELOG)
 	    | grep -a -v "\[Loading ML file" \
 	    | grep -a -v "Skipping rcfile loading" \
 	    | grep -a -v "^<W>" \
-	    | sed 's/File "[^"]*"/File "stdin"/' \
 	    > $$output; \
 	  diff -a -u --strip-trailing-cr $*.out $$output 2>&1; R=$$?; times; \
 	  if [ $$R = 0 ]; then \
@@ -458,7 +457,6 @@ $(addsuffix .log,$(wildcard output-coqtop/*.v)): %.v.log: %.v %.out $(PREREQUISI
 	    | grep -v "\[Loading ML file" \
 	    | grep -v "Skipping rcfile loading" \
 	    | grep -v "^<W>" \
-	    | sed 's/File "[^"]*"/File "stdin"/' \
 	    > $$output; \
 	  diff -u --strip-trailing-cr $*.out $$output 2>&1; R=$$?; times; \
 	  if [ $$R = 0 ]; then \
@@ -494,9 +492,7 @@ $(addsuffix .log,$(wildcard output-coqchk/*.v)): %.v.log: %.v %.out $(PREREQUISI
 	  output=$*.out.real; \
 	  export LC_CTYPE=C; \
 	  export LANG=C; \
-	  $(coqchk) -o -silent $(call get_set_impredicativity,$<) $(if $(findstring modules/,$<),-R modules Mods -norec Mods.$(shell basename $< .v),-Q $(shell dirname $<) "" -norec $(shell basename $< .v)) 2>&1 \
-	    | sed 's/File "[^"]*"/File "stdin"/' \
-	    > $$output; \
+	  $(coqchk) -o -silent $(call get_set_impredicativity,$<) $(if $(findstring modules/,$<),-R modules Mods -norec Mods.$(shell basename $< .v),-Q $(shell dirname $<) "" -norec $(shell basename $< .v)) > $$output 2>&1 ; \
 	  diff -a -u --strip-trailing-cr $*.out $$output 2>&1; R=$$?; times; \
 	  if [ $$R = 0 ]; then \
 	    echo $(log_success); \

--- a/test-suite/output/Arguments_renaming.out
+++ b/test-suite/output/Arguments_renaming.out
@@ -1,6 +1,6 @@
 The command has indeed failed with message:
 Flag "rename" expected to rename A into B.
-File "stdin", line 3, characters 0-25:
+File "./output/Arguments_renaming.v", line 3, characters 0-25:
 Warning: This command is just asserting the names of arguments of identity.
 If this is what you want, add ': assert' to silence the warning. If you want
 to clear implicit arguments, add ': clear implicits'. If you want to clear

--- a/test-suite/output/Cases.out
+++ b/test-suite/output/Cases.out
@@ -181,7 +181,7 @@ match N with
 | _ => Node
 end
      : Tree -> Tree
-File "stdin", line 253, characters 4-5:
+File "./output/Cases.v", line 253, characters 4-5:
 Warning: Unused variable B catches more than one case.
 [unused-pattern-matching-variable,pattern-matching]
 The command has indeed failed with message:
@@ -232,12 +232,12 @@ match x with
 | @D' _ _ _ _ n _ p _ => (n, p)
 end
      : J' bool (true, true) -> nat * nat
-File "stdin", line 313, characters 3-4:
+File "./output/Cases.v", line 313, characters 3-4:
 Warning: Unused variable x catches more than one case.
 [unused-pattern-matching-variable,pattern-matching]
-File "stdin", line 314, characters 6-7:
+File "./output/Cases.v", line 314, characters 6-7:
 Warning: Unused variable y catches more than one case.
 [unused-pattern-matching-variable,pattern-matching]
-File "stdin", line 314, characters 3-4:
+File "./output/Cases.v", line 314, characters 3-4:
 Warning: Unused variable x catches more than one case.
 [unused-pattern-matching-variable,pattern-matching]

--- a/test-suite/output/DebugFlags.out
+++ b/test-suite/output/DebugFlags.out
@@ -1,4 +1,4 @@
-File "stdin", line 1, characters 0-16:
+File "./output/DebugFlags.v", line 1, characters 0-16:
 Warning: There is no debug flag "cbn". [unknown-debug-flag,option]
 Debug: [RAKAM] <<forall A : Type, A -> A -> Prop|>>
 Debug: [RAKAM] <><><><><>

--- a/test-suite/output/Deprecation.out
+++ b/test-suite/output/Deprecation.out
@@ -1,3 +1,3 @@
-File "stdin", line 5, characters 0-3:
+File "./output/Deprecation.v", line 5, characters 0-3:
 Warning: Tactic foo is deprecated since X.Y. Use idtac instead.
 [deprecated-tactic,deprecated]

--- a/test-suite/output/ErrorInCanonicalStructures.out
+++ b/test-suite/output/ErrorInCanonicalStructures.out
@@ -1,4 +1,4 @@
-File "stdin", line 3, characters 0-24:
+File "./output/ErrorInCanonicalStructures.v", line 3, characters 0-24:
 Error: Could not declare a canonical structure Foo.
 Expected an instance of a record or structure.
 

--- a/test-suite/output/ErrorInCanonicalStructures2.out
+++ b/test-suite/output/ErrorInCanonicalStructures2.out
@@ -1,4 +1,4 @@
-File "stdin", line 3, characters 0-24:
+File "./output/ErrorInCanonicalStructures2.v", line 3, characters 0-24:
 Error: Could not declare a canonical structure bar.
 Expected an instance of a record or structure.
 

--- a/test-suite/output/ErrorInModule.out
+++ b/test-suite/output/ErrorInModule.out
@@ -1,3 +1,3 @@
-File "stdin", line 3, characters 20-31:
+File "./output/ErrorInModule.v", line 3, characters 20-31:
 Error: The reference nonexistent was not found in the current environment.
 

--- a/test-suite/output/ErrorInSection.out
+++ b/test-suite/output/ErrorInSection.out
@@ -1,3 +1,3 @@
-File "stdin", line 3, characters 20-31:
+File "./output/ErrorInSection.v", line 3, characters 20-31:
 Error: The reference nonexistent was not found in the current environment.
 

--- a/test-suite/output/ErrorLocation_12152_1.out
+++ b/test-suite/output/ErrorLocation_12152_1.out
@@ -1,3 +1,3 @@
-File "stdin", line 3, characters 0-7:
+File "./output/ErrorLocation_12152_1.v", line 3, characters 0-7:
 Error: No product even after head-reduction.
 

--- a/test-suite/output/ErrorLocation_12152_2.out
+++ b/test-suite/output/ErrorLocation_12152_2.out
@@ -1,3 +1,3 @@
-File "stdin", line 3, characters 0-8:
+File "./output/ErrorLocation_12152_2.v", line 3, characters 0-8:
 Error: No product even after head-reduction.
 

--- a/test-suite/output/ErrorLocation_12255.out
+++ b/test-suite/output/ErrorLocation_12255.out
@@ -1,4 +1,4 @@
-File "stdin", line 4, characters 0-16:
+File "./output/ErrorLocation_12255.v", line 4, characters 0-16:
 Error: Ltac variable x is bound to i > 0 which cannot be coerced to
 an evaluable reference.
 

--- a/test-suite/output/ErrorLocation_12774_1.out
+++ b/test-suite/output/ErrorLocation_12774_1.out
@@ -1,3 +1,3 @@
-File "stdin", line 2, characters 13-14:
+File "./output/ErrorLocation_12774_1.v", line 2, characters 13-14:
 Error: The term "0" has type "nat" while it is expected to have type "Type".
 

--- a/test-suite/output/ErrorLocation_12774_2.out
+++ b/test-suite/output/ErrorLocation_12774_2.out
@@ -1,3 +1,3 @@
-File "stdin", line 3, characters 9-10:
+File "./output/ErrorLocation_12774_2.v", line 3, characters 9-10:
 Error: The term "0" has type "nat" while it is expected to have type "Type".
 

--- a/test-suite/output/ErrorLocation_12774_3.out
+++ b/test-suite/output/ErrorLocation_12774_3.out
@@ -1,3 +1,3 @@
-File "stdin", line 3, characters 0-1:
+File "./output/ErrorLocation_12774_3.v", line 3, characters 0-1:
 Error: No product even after head-reduction.
 

--- a/test-suite/output/ErrorLocation_13241_1.out
+++ b/test-suite/output/ErrorLocation_13241_1.out
@@ -1,3 +1,3 @@
-File "stdin", line 4, characters 0-1:
+File "./output/ErrorLocation_13241_1.v", line 4, characters 0-1:
 Error: No product even after head-reduction.
 

--- a/test-suite/output/ErrorLocation_13241_2.out
+++ b/test-suite/output/ErrorLocation_13241_2.out
@@ -1,3 +1,3 @@
-File "stdin", line 4, characters 0-1:
+File "./output/ErrorLocation_13241_2.v", line 4, characters 0-1:
 Error: No product even after head-reduction.
 

--- a/test-suite/output/ErrorLocation_ltac_1.out
+++ b/test-suite/output/ErrorLocation_ltac_1.out
@@ -1,3 +1,3 @@
-File "stdin", line 2, characters 7-11:
+File "./output/ErrorLocation_ltac_1.v", line 2, characters 7-11:
 Error: Tactic failure: Cannot solve this goal.
 

--- a/test-suite/output/ErrorLocation_ltac_2.out
+++ b/test-suite/output/ErrorLocation_ltac_2.out
@@ -1,3 +1,3 @@
-File "stdin", line 3, characters 7-8:
+File "./output/ErrorLocation_ltac_2.v", line 3, characters 7-8:
 Error: Tactic failure.
 

--- a/test-suite/output/ErrorLocation_ltac_3.out
+++ b/test-suite/output/ErrorLocation_ltac_3.out
@@ -1,3 +1,3 @@
-File "stdin", line 3, characters 7-10:
+File "./output/ErrorLocation_ltac_3.v", line 3, characters 7-10:
 Error: Not a negated primitive equality.
 

--- a/test-suite/output/ErrorLocation_ltac_4.out
+++ b/test-suite/output/ErrorLocation_ltac_4.out
@@ -1,3 +1,3 @@
-File "stdin", line 2, characters 22-23:
+File "./output/ErrorLocation_ltac_4.v", line 2, characters 22-23:
 Error: Tactic failure.
 

--- a/test-suite/output/ErrorLocation_tac_in_term_1.out
+++ b/test-suite/output/ErrorLocation_tac_in_term_1.out
@@ -1,4 +1,4 @@
-File "stdin", line 2, characters 21-25:
+File "./output/ErrorLocation_tac_in_term_1.v", line 2, characters 21-25:
 Error:
 The term "true" has type "bool" while it is expected to have type "nat".
 

--- a/test-suite/output/ErrorLocation_tac_in_term_2.out
+++ b/test-suite/output/ErrorLocation_tac_in_term_2.out
@@ -1,4 +1,4 @@
-File "stdin", line 4, characters 12-20:
+File "./output/ErrorLocation_tac_in_term_2.v", line 4, characters 12-20:
 Error:
 The term "true" has type "bool" while it is expected to have type "nat".
 

--- a/test-suite/output/Error_msg_diffs.out
+++ b/test-suite/output/Error_msg_diffs.out
@@ -1,4 +1,4 @@
-File "stdin", line 32, characters 0-11:
+File "./output/Error_msg_diffs.v", line 32, characters 0-11:
 [37;41;1mError:[0m
 In environment
 T : [33;1mType[0m

--- a/test-suite/output/Fixpoint.out
+++ b/test-suite/output/Fixpoint.out
@@ -12,26 +12,26 @@ let fix f (m : nat) : nat := match m with
 Ltac f id1 id2 := fix id1 2 with (id2 (n:_) (H:odd n) {struct H} : n >= 1)
      = cofix inf : Inf := {| projS := inf |}
      : Inf
-File "stdin", line 57, characters 0-51:
+File "./output/Fixpoint.v", line 57, characters 0-51:
 Warning: Not a truly recursive fixpoint. [non-recursive,fixpoints]
-File "stdin", line 60, characters 0-103:
+File "./output/Fixpoint.v", line 60, characters 0-103:
 Warning: Not a fully mutually defined fixpoint
 (k1 depends on k2 but not conversely).
 Well-foundedness check may fail unexpectedly.
  [non-full-mutual,fixpoints]
-File "stdin", line 62, characters 0-106:
+File "./output/Fixpoint.v", line 62, characters 0-106:
 Warning: Not a fully mutually defined fixpoint
 (l2 and l1 are not mutually dependent).
 Well-foundedness check may fail unexpectedly.
  [non-full-mutual,fixpoints]
-File "stdin", line 64, characters 0-103:
+File "./output/Fixpoint.v", line 64, characters 0-103:
 Warning: Not a fully mutually defined fixpoint
 (m2 and m1 are not mutually dependent).
 Well-foundedness check may fail unexpectedly.
  [non-full-mutual,fixpoints]
-File "stdin", line 72, characters 0-25:
+File "./output/Fixpoint.v", line 72, characters 0-25:
 Warning: Not a truly recursive fixpoint. [non-recursive,fixpoints]
-File "stdin", line 75, characters 0-48:
+File "./output/Fixpoint.v", line 75, characters 0-48:
 Warning: Not a fully mutually defined fixpoint
 (a2 and a1 are not mutually dependent).
 Well-foundedness check may fail unexpectedly.

--- a/test-suite/output/FloatExtraction.out
+++ b/test-suite/output/FloatExtraction.out
@@ -1,16 +1,16 @@
-File "stdin", line 25, characters 8-12:
+File "./output/FloatExtraction.v", line 25, characters 8-12:
 Warning: The constant 0.01 is not a binary64 floating-point value. A closest
 value 0x1.47ae147ae147bp-7 will be used and unambiguously printed 0.01.
 [inexact-float,parsing]
-File "stdin", line 25, characters 20-25:
+File "./output/FloatExtraction.v", line 25, characters 20-25:
 Warning: The constant -0.01 is not a binary64 floating-point value. A closest
 value -0x1.47ae147ae147bp-7 will be used and unambiguously printed -0.01.
 [inexact-float,parsing]
-File "stdin", line 25, characters 27-35:
+File "./output/FloatExtraction.v", line 25, characters 27-35:
 Warning: The constant 1.7e+308 is not a binary64 floating-point value. A
 closest value 0x1.e42d130773b76p+1023 will be used and unambiguously printed
 1.6999999999999999e+308. [inexact-float,parsing]
-File "stdin", line 25, characters 37-46:
+File "./output/FloatExtraction.v", line 25, characters 37-46:
 Warning: The constant -1.7e-308 is not a binary64 floating-point value. A
 closest value -0x0.c396c98f8d899p-1022 will be used and unambiguously printed
 -1.7000000000000002e-308. [inexact-float,parsing]

--- a/test-suite/output/FloatSyntax.out
+++ b/test-suite/output/FloatSyntax.out
@@ -4,13 +4,13 @@
      : float
 (-2.5)%float
      : float
-File "stdin", line 9, characters 6-13:
+File "./output/FloatSyntax.v", line 9, characters 6-13:
 Warning: The constant 2.5e123 is not a binary64 floating-point value. A
 closest value 0x1.e412f0f768fadp+409 will be used and unambiguously printed
 2.4999999999999999e+123. [inexact-float,parsing]
 2.4999999999999999e+123%float
      : float
-File "stdin", line 10, characters 7-16:
+File "./output/FloatSyntax.v", line 10, characters 7-16:
 Warning: The constant -2.5e-123 is not a binary64 floating-point value. A
 closest value -0x1.a71368f0f3047p-408 will be used and unambiguously printed
 -2.5000000000000001e-123. [inexact-float,parsing]
@@ -26,13 +26,13 @@ closest value -0x1.a71368f0f3047p-408 will be used and unambiguously printed
      : float
 -2.5
      : float
-File "stdin", line 19, characters 6-13:
+File "./output/FloatSyntax.v", line 19, characters 6-13:
 Warning: The constant 2.5e123 is not a binary64 floating-point value. A
 closest value 0x1.e412f0f768fadp+409 will be used and unambiguously printed
 2.4999999999999999e+123. [inexact-float,parsing]
 2.4999999999999999e+123
      : float
-File "stdin", line 20, characters 7-16:
+File "./output/FloatSyntax.v", line 20, characters 7-16:
 Warning: The constant -2.5e-123 is not a binary64 floating-point value. A
 closest value -0x1.a71368f0f3047p-408 will be used and unambiguously printed
 -2.5000000000000001e-123. [inexact-float,parsing]
@@ -54,13 +54,13 @@ closest value -0x1.a71368f0f3047p-408 will be used and unambiguously printed
      : float
 -2.79296875
      : float
-File "stdin", line 30, characters 6-11:
+File "./output/FloatSyntax.v", line 30, characters 6-11:
 Warning: The constant 1e309 is not a binary64 floating-point value. A closest
 value infinity will be used and unambiguously printed infinity.
 [inexact-float,parsing]
 infinity
      : float
-File "stdin", line 31, characters 6-12:
+File "./output/FloatSyntax.v", line 31, characters 6-12:
 Warning: The constant -1e309 is not a binary64 floating-point value. A
 closest value neg_infinity will be used and unambiguously printed
 neg_infinity. [inexact-float,parsing]

--- a/test-suite/output/Naming.out
+++ b/test-suite/output/Naming.out
@@ -61,18 +61,18 @@
   H : a = 0 -> forall a : nat, a = 0
   ============================
   a = 0
-File "stdin", line 101, characters 47-48:
+File "./output/Naming.v", line 101, characters 47-48:
 Warning: Ignoring implicit binder declaration in unexpected position.
 [unexpected-implicit-declaration,syntax]
-File "stdin", line 105, characters 36-37:
+File "./output/Naming.v", line 105, characters 36-37:
 Warning: Ignoring implicit binder declaration in unexpected position.
 [unexpected-implicit-declaration,syntax]
-File "stdin", line 106, characters 34-35:
+File "./output/Naming.v", line 106, characters 34-35:
 Warning: Ignoring implicit binder declaration in unexpected position.
 [unexpected-implicit-declaration,syntax]
-File "stdin", line 112, characters 22-23:
+File "./output/Naming.v", line 112, characters 22-23:
 Warning: Ignoring implicit binder declaration in unexpected position.
 [unexpected-implicit-declaration,syntax]
-File "stdin", line 112, characters 30-31:
+File "./output/Naming.v", line 112, characters 30-31:
 Warning: Ignoring implicit binder declaration in unexpected position.
 [unexpected-implicit-declaration,syntax]

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -79,18 +79,18 @@ fun x : nat => [x]
      : nat -> nat
 ∀ x : nat, x = x
      : Prop
-File "stdin", line 185, characters 0-160:
+File "./output/Notations4.v", line 185, characters 0-160:
 Warning: Notation "∀ _ .. _ , _" was already defined with a different format
 in scope type_scope. [notation-incompatible-format,parsing]
 ∀x : nat,x = x
      : Prop
-File "stdin", line 198, characters 0-60:
+File "./output/Notations4.v", line 198, characters 0-60:
 Warning: Notation "_ %%% _" was already defined with a different format.
 [notation-incompatible-format,parsing]
-File "stdin", line 202, characters 0-64:
+File "./output/Notations4.v", line 202, characters 0-64:
 Warning: Notation "_ %%% _" was already defined with a different format.
 [notation-incompatible-format,parsing]
-File "stdin", line 207, characters 0-62:
+File "./output/Notations4.v", line 207, characters 0-62:
 Warning: Lonely notation "_ %%%% _" was already defined with a different
 format. [notation-incompatible-format,parsing]
 3  %%  4
@@ -99,10 +99,10 @@ format. [notation-incompatible-format,parsing]
      : nat
 3   %%   4
      : nat
-File "stdin", line 235, characters 0-61:
+File "./output/Notations4.v", line 235, characters 0-61:
 Warning: The format modifier is irrelevant for only parsing rules.
 [irrelevant-format-only-parsing,parsing]
-File "stdin", line 239, characters 0-63:
+File "./output/Notations4.v", line 239, characters 0-63:
 Warning: The only parsing modifier has no effect in Reserved Notation.
 [irrelevant-reserved-notation-only-parsing,parsing]
 fun x : nat => U (S x)
@@ -113,7 +113,7 @@ fun x : nat => V x
      : forall x : nat, nat * (?T -> ?T)
 where
 ?T : [x : nat  x0 : ?T |- Type] (x0 cannot be used)
-File "stdin", line 256, characters 0-30:
+File "./output/Notations4.v", line 256, characters 0-30:
 Warning: Notation "_ :=: _" was already used. [notation-overridden,parsing]
 0 :=: 0
      : Prop

--- a/test-suite/output/NumberNotations.out
+++ b/test-suite/output/NumberNotations.out
@@ -27,7 +27,7 @@ let v := 0%upp in v : unit
      : unit
 let v := 0%ppps in v : punit
      : punit
-File "stdin", line 91, characters 2-46:
+File "./output/NumberNotations.v", line 91, characters 2-46:
 Warning: To avoid stack overflow, large numbers in punit are interpreted as
 applications of pto_punits. [abstract-large-number,numbers]
 The command has indeed failed with message:
@@ -75,7 +75,7 @@ The command has indeed failed with message:
 In environment
 v := 0 : nat
 The term "v" has type "nat" while it is expected to have type "wuint".
-File "stdin", line 203, characters 2-71:
+File "./output/NumberNotations.v", line 203, characters 2-71:
 Warning: The 'abstract after' directive has no effect when the parsing
 function (of_uint) targets an option type.
 [abstract-large-number-no-op,numbers]
@@ -260,28 +260,28 @@ The command has indeed failed with message:
 add is not a constructor of an inductive type.
 The command has indeed failed with message:
 Missing mapping for constructor Iempty.
-File "stdin", line 580, characters 56-61:
+File "./output/NumberNotations.v", line 580, characters 56-61:
 Warning: Type of I'sum seems incompatible with the type of sum.
 Expected type is: (I' -> I' -> I') instead of (I -> I' -> I').
 This might yield ill typed terms when using the notation.
 [via-type-mismatch,numbers]
-File "stdin", line 585, characters 32-33:
+File "./output/NumberNotations.v", line 585, characters 32-33:
 Warning: I was already mapped to Set, mapping it also to
 nat might yield ill typed terms when using the notation.
 [via-type-remapping,numbers]
-File "stdin", line 585, characters 37-42:
+File "./output/NumberNotations.v", line 585, characters 37-42:
 Warning: Type of Iunit seems incompatible with the type of O.
 Expected type is: I instead of I.
 This might yield ill typed terms when using the notation.
 [via-type-mismatch,numbers]
 The command has indeed failed with message:
 'via' and 'abstract' cannot be used together.
-File "stdin", line 665, characters 21-23:
+File "./output/NumberNotations.v", line 665, characters 21-23:
 Warning: Type of I1 seems incompatible with the type of Fin.F1.
 Expected type is: (nat -> I) instead of I.
 This might yield ill typed terms when using the notation.
 [via-type-mismatch,numbers]
-File "stdin", line 665, characters 35-37:
+File "./output/NumberNotations.v", line 665, characters 35-37:
 Warning: Type of IS seems incompatible with the type of Fin.FS.
 Expected type is: (nat -> I -> I) instead of (I -> I).
 This might yield ill typed terms when using the notation.

--- a/test-suite/output/UnboundRef.out
+++ b/test-suite/output/UnboundRef.out
@@ -1,3 +1,3 @@
-File "stdin", line 1, characters 11-12:
+File "./output/UnboundRef.v", line 1, characters 11-12:
 Error: The reference a was not found in the current environment.
 

--- a/test-suite/output/Warnings.out
+++ b/test-suite/output/Warnings.out
@@ -1,4 +1,4 @@
-File "stdin", line 4, characters 0-22:
+File "./output/Warnings.v", line 4, characters 0-22:
 Warning: Projection value has no head constant: let H := tt in True in
 canonical instance a of b, ignoring it.
 [projection-no-head-constant,typechecker]

--- a/test-suite/output/bug_12908.out
+++ b/test-suite/output/bug_12908.out
@@ -1,6 +1,6 @@
 forall m n : nat, m * n = (2 * m * n)%nat
      : Prop
-File "stdin", line 11, characters 0-31:
+File "./output/bug_12908.v", line 11, characters 0-31:
 Warning: Notation "_ * _" was already used in scope nat_scope.
 [notation-overridden,parsing]
 forall m n : nat, m * n = Nat.mul (Nat.mul 2 m) n

--- a/test-suite/output/bug_8206.out
+++ b/test-suite/output/bug_8206.out
@@ -1,4 +1,4 @@
-File "stdin", line 11, characters 0-23:
+File "./output/bug_8206.v", line 11, characters 0-23:
 Error: Signature components for label homework do not match: expected type
 "forall a b : nat, bug_8206.M.add a b = bug_8206.M.add b a" but found type
 "nat -> forall b : nat, bug_8206.M.add 0 b = bug_8206.M.add b 0".

--- a/test-suite/output/ltac2_deprecated.out
+++ b/test-suite/output/ltac2_deprecated.out
@@ -1,12 +1,12 @@
-File "stdin", line 13, characters 11-14:
+File "./output/ltac2_deprecated.v", line 13, characters 11-14:
 Warning: Ltac2 definition foo is deprecated. test_definition
 [deprecated-ltac2-definition,deprecated]
 - : unit = ()
-File "stdin", line 14, characters 11-14:
+File "./output/ltac2_deprecated.v", line 14, characters 11-14:
 Warning: Ltac2 alias bar is deprecated. test_notation
 [deprecated-ltac2-alias,deprecated]
 - : unit = ()
-File "stdin", line 15, characters 11-14:
+File "./output/ltac2_deprecated.v", line 15, characters 11-14:
 Warning: Ltac2 definition qux is deprecated. test_external
 [deprecated-ltac2-definition,deprecated]
 - : 'a array -> int = <fun>

--- a/test-suite/output/notation_principal_scope.out
+++ b/test-suite/output/notation_principal_scope.out
@@ -15,6 +15,6 @@ The command has indeed failed with message:
 Illegal application (Non-functional construction): 
 The expression "I" of type "True" cannot be applied to the term
  "I" : "True"
-File "stdin", line 21, characters 0-50:
+File "./output/notation_principal_scope.v", line 21, characters 0-50:
 Warning: This notation will not be used for printing as it is bound to a
 single variable. [notation-bound-to-variable,parsing]

--- a/test-suite/output/qualification.out
+++ b/test-suite/output/qualification.out
@@ -1,4 +1,4 @@
-File "stdin", line 20, characters 0-7:
+File "./output/qualification.v", line 20, characters 0-7:
 Error: Signature components for label test do not match: expected type
 "qualification.M2.t = qualification.M2.M.t" but found type
 "qualification.M2.t = qualification.M2.t".

--- a/test-suite/output/relaxed_ambiguous_paths.out
+++ b/test-suite/output/relaxed_ambiguous_paths.out
@@ -1,8 +1,8 @@
-File "stdin", line 13, characters 0-29:
+File "./output/relaxed_ambiguous_paths.v", line 13, characters 0-29:
 Warning:
 New coercion path [g1; f2] : A >-> B' is ambiguous with existing 
 [f1; g2] : A >-> B'. [ambiguous-paths,typechecker]
-File "stdin", line 14, characters 0-29:
+File "./output/relaxed_ambiguous_paths.v", line 14, characters 0-29:
 Warning:
 New coercion path [h1; f3] : B >-> C' is ambiguous with existing 
 [f2; h2] : B >-> C'. [ambiguous-paths,typechecker]
@@ -18,7 +18,7 @@ New coercion path [h1; f3] : B >-> C' is ambiguous with existing
 [f2; h2] : B >-> C'
 [h2] : B' >-> C'
 [f3] : C >-> C'
-File "stdin", line 33, characters 0-28:
+File "./output/relaxed_ambiguous_paths.v", line 33, characters 0-28:
 Warning:
 New coercion path [ab; bc] : A >-> C is ambiguous with existing 
 [ac] : A >-> C. [ambiguous-paths,typechecker]
@@ -28,11 +28,11 @@ New coercion path [ab; bc] : A >-> C is ambiguous with existing
 [bc] : B >-> C
 [bc; cd] : B >-> D
 [cd] : C >-> D
-File "stdin", line 50, characters 0-28:
+File "./output/relaxed_ambiguous_paths.v", line 50, characters 0-28:
 Warning:
 New coercion path [ab; bc] : A >-> C is ambiguous with existing 
 [ac] : A >-> C. [ambiguous-paths,typechecker]
-File "stdin", line 51, characters 0-28:
+File "./output/relaxed_ambiguous_paths.v", line 51, characters 0-28:
 Warning:
 New coercion path [ba; ab] : B >-> B is not definitionally an identity function.
 New coercion path [ab; ba] : A >-> A is not definitionally an identity function.
@@ -55,7 +55,7 @@ New coercion path [ab; ba] : A >-> A is not definitionally an identity function.
 [D_B; B_A'] : D >-> A'
 [D_B] : D >-> B
 [D_C] : D >-> C
-File "stdin", line 147, characters 0-86:
+File "./output/relaxed_ambiguous_paths.v", line 147, characters 0-86:
 Warning:
 New coercion path [D_C; C_A'] : D >-> A' is ambiguous with existing 
 [D_B; B_A'] : D >-> A'. [ambiguous-paths,typechecker]
@@ -68,15 +68,15 @@ New coercion path [D_C; C_A'] : D >-> A' is ambiguous with existing
 [D_B; B_A'] : D >-> A'
 [D_B] : D >-> B
 [D_C] : D >-> C
-File "stdin", line 156, characters 0-47:
+File "./output/relaxed_ambiguous_paths.v", line 156, characters 0-47:
 Warning:
 New coercion path [unwrap_nat; wrap_nat] : NAT >-> NAT is not definitionally an identity function.
 [ambiguous-paths,typechecker]
-File "stdin", line 157, characters 0-64:
+File "./output/relaxed_ambiguous_paths.v", line 157, characters 0-64:
 Warning:
 New coercion path [unwrap_list; wrap_list] : LIST >-> LIST is not definitionally an identity function.
 [ambiguous-paths,typechecker]
-File "stdin", line 158, characters 0-51:
+File "./output/relaxed_ambiguous_paths.v", line 158, characters 0-51:
 Warning:
 New coercion path [unwrap_Type; wrap_Type] : TYPE >-> TYPE is not definitionally an identity function.
 [ambiguous-paths,typechecker]

--- a/test-suite/output/ssr_error_multiple_intro_after_case.out
+++ b/test-suite/output/ssr_error_multiple_intro_after_case.out
@@ -1,3 +1,3 @@
-File "stdin", line 3, characters 0-11:
+File "./output/ssr_error_multiple_intro_after_case.v", line 3, characters 0-11:
 Error: x already used
 

--- a/test-suite/output/ssr_explain_match.out
+++ b/test-suite/output/ssr_explain_match.out
@@ -1,34 +1,34 @@
-File "stdin", line 12, characters 0-61:
+File "./output/ssr_explain_match.v", line 12, characters 0-61:
 Warning: Notation "_ - _" was already used in scope nat_scope.
 [notation-overridden,parsing]
-File "stdin", line 12, characters 0-61:
+File "./output/ssr_explain_match.v", line 12, characters 0-61:
 Warning: Notation "_ <= _" was already used in scope nat_scope.
 [notation-overridden,parsing]
-File "stdin", line 12, characters 0-61:
+File "./output/ssr_explain_match.v", line 12, characters 0-61:
 Warning: Notation "_ < _" was already used in scope nat_scope.
 [notation-overridden,parsing]
-File "stdin", line 12, characters 0-61:
+File "./output/ssr_explain_match.v", line 12, characters 0-61:
 Warning: Notation "_ >= _" was already used in scope nat_scope.
 [notation-overridden,parsing]
-File "stdin", line 12, characters 0-61:
+File "./output/ssr_explain_match.v", line 12, characters 0-61:
 Warning: Notation "_ > _" was already used in scope nat_scope.
 [notation-overridden,parsing]
-File "stdin", line 12, characters 0-61:
+File "./output/ssr_explain_match.v", line 12, characters 0-61:
 Warning: Notation "_ <= _ <= _" was already used in scope nat_scope.
 [notation-overridden,parsing]
-File "stdin", line 12, characters 0-61:
+File "./output/ssr_explain_match.v", line 12, characters 0-61:
 Warning: Notation "_ < _ <= _" was already used in scope nat_scope.
 [notation-overridden,parsing]
-File "stdin", line 12, characters 0-61:
+File "./output/ssr_explain_match.v", line 12, characters 0-61:
 Warning: Notation "_ <= _ < _" was already used in scope nat_scope.
 [notation-overridden,parsing]
-File "stdin", line 12, characters 0-61:
+File "./output/ssr_explain_match.v", line 12, characters 0-61:
 Warning: Notation "_ < _ < _" was already used in scope nat_scope.
 [notation-overridden,parsing]
-File "stdin", line 12, characters 0-61:
+File "./output/ssr_explain_match.v", line 12, characters 0-61:
 Warning: Notation "_ + _" was already used in scope nat_scope.
 [notation-overridden,parsing]
-File "stdin", line 12, characters 0-61:
+File "./output/ssr_explain_match.v", line 12, characters 0-61:
 Warning: Notation "_ * _" was already used in scope nat_scope.
 [notation-overridden,parsing]
 BEGIN INSTANCES

--- a/test-suite/output/undeclared_key.out
+++ b/test-suite/output/undeclared_key.out
@@ -2,7 +2,7 @@ The command has indeed failed with message:
 There is no flag, option or table with this name: "Search Blacklists".
 The command has indeed failed with message:
 There is no qualid-valued table with this name: "Search Blacklist".
-File "stdin", line 3, characters 0-22:
+File "./output/undeclared_key.v", line 3, characters 0-22:
 Warning: There is no flag or option with this name: "Search Blacklists".
 [unknown-option,option]
 The command has indeed failed with message:


### PR DESCRIPTION
In 2016 these file names were absolute paths leading to #5111, but
nowadays they are relative paths so we don't need to hide them anymore.
