### PR TITLE
test-suite: don't use $(wildcard) in approve-output

### DIFF
--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -511,21 +511,21 @@ $(addsuffix .log,$(wildcard output-coqchk/*.v)): %.v.log: %.v %.out $(PREREQUISI
 
 .PHONY: approve-output
 approve-output: output output-coqtop output-coqchk
-	$(HIDE)for f in $(wildcard $(addsuffix /*.out.real,$^)); do \
+	$(HIDE)for f in $(addsuffix /*.out.real,$^); do if [ -f "$$f" ]; then \
 	  mv "$$f" "$${f%.real}"; \
 	  echo "Updated $${f%.real}!"; \
-	done
+	fi; done
 
 approve-coqdoc: coqdoc
 	$(HIDE)(cd coqdoc; \
-	for f in *.html.out; do \
+	for f in *.html.out; do if [ -f "$$f" ]; then \
 	  cp "Coqdoc.$${f%.out}" "$$f"; \
 	  echo "Updated $$f!"; \
-	done; \
-	for f in *.tex.out; do \
+	fi; done; \
+	for f in *.tex.out; do if [ -f "$$f" ]; then \
 	  cat "Coqdoc.$${f%.out}" | grep -v "^%%" > "$$f"; \
 	  echo "Updated $$f!"; \
-	done)
+	fi; done)
 
 # the expected output for the MExtraction test is
 # /plugins/micromega/micromega.ml except with additional newline


### PR DESCRIPTION
It is evaluated before running the dependencies, so from a clean state
it evaluates to nothing even if some tests end up failing and
approve-output has to be run twice.

Instead we are robust to not needing to work (with the glob being
evaluated to itself) by adding a "if [ -f $f ]" evaluated by the
shell.