### PR TITLE
Make a lookup of the canonical structure table faster

### DIFF
--- a/pretyping/structures.mli
+++ b/pretyping/structures.mli
@@ -87,6 +87,7 @@ type t =
   | Default_cs
 
 val equal : Environ.env -> t -> t -> bool
+val compare : t -> t -> int
 val print : t -> Pp.t
 
 (** Return the form of the component of a canonical structure *)


### PR DESCRIPTION
Currently, it consumes a linear time in the number of instances declared on the same projection.

**Kind:** performance.

Fixes / closes #14422
