### PR TITLE
[build] Install coqdoc.sty in global share prefix.

### DIFF
--- a/tools/coqdoc/dune
+++ b/tools/coqdoc/dune
@@ -7,7 +7,7 @@
 
 ; File needs to be here too.
 (install
- (section share)
+ (section share_root)
  (package coq-core)
  (files
   (coqdoc.sty as texmf/tex/latex/misc/coqdoc.sty)))


### PR DESCRIPTION
This was a mistake on #14308 , now the sty file is installed in the
proper place hopefully.

Fixes a part of #14306
