### PR TITLE
Do not rely on the template status to decide keeping proof equalities.

### DIFF
--- a/doc/changelog/05-tactic-language/14439-keep-proof-equality-table.rst
+++ b/doc/changelog/05-tactic-language/14439-keep-proof-equality-table.rst
@@ -1,0 +1,7 @@
+- **Added:**
+  A new :table:`Keep Equalities` table to selectively control the
+  preservation of subterm equalities for the :tacn:`injection` tactic. It allows
+  a finer control than the boolean flag :flag:`Keep Proof Equalities` that acts
+  globally.
+  (`#14439 <https://github.com/coq/coq/pull/14439>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/proofs/writing-proofs/reasoning-inductives.rst
+++ b/doc/sphinx/proofs/writing-proofs/reasoning-inductives.rst
@@ -680,6 +680,15 @@ and an explanation of the underlying technique.
       behavior for objects that are proofs of a statement in :g:`Prop`. This :term:`flag`
       controls this behavior.
 
+   .. table:: Keep Equalities @qualid
+
+      This :term:`table` specifies a set of inductive types for which proof
+      equalities are always kept by :tacn:`injection`. This overrides the
+      :flag:`Keep Proof Equalities` flag for those inductive types.
+      :attr:`Template polymorphic <universes(template)>` inductive types are
+      implicitly added to this table when defined.
+      Use the :cmd:`Add` and :cmd:`Remove` commands to update this set manually.
+
 .. tacn:: inversion @ident
    :name: inversion
 

--- a/library/goptions.ml
+++ b/library/goptions.ml
@@ -130,6 +130,7 @@ module MakeTable =
 
     let v () = !t
     let active x = A.Set.mem x !t
+    let set x b = if b then add_option x else remove_option x
   end
 
 let string_table = ref []

--- a/library/goptions.mli
+++ b/library/goptions.mli
@@ -99,6 +99,7 @@ module MakeRefTable :
 sig
   val v : unit -> A.Set.t
   val active : A.t -> bool
+  val set : A.t -> bool -> unit
 end
 
 

--- a/pretyping/retyping.ml
+++ b/pretyping/retyping.ml
@@ -210,7 +210,7 @@ let retype ?(polyprop=true) sigma =
 
   in type_of, sort_of, type_of_global_reference_knowing_parameters
 
-let get_sort_family_of ?(truncation_style=false) ?(polyprop=true) env sigma t =
+let get_sort_family_of ?(polyprop=true) env sigma t =
   let type_of,_,type_of_global_reference_knowing_parameters = retype ~polyprop sigma in
   let rec sort_family_of env t =
     match EConstr.kind sigma t with
@@ -221,13 +221,11 @@ let get_sort_family_of ?(truncation_style=false) ?(polyprop=true) env sigma t =
         if not (is_impredicative_set env) &&
            s2 == InSet && sort_family_of env t == InType then InType else s2
     | App(f,args) when Termops.is_template_polymorphic_ind env sigma f ->
-        if truncation_style then InType else
         let t = type_of_global_reference_knowing_parameters env f args in
         Sorts.family (sort_of_atomic_type env sigma t args)
     | App(f,args) ->
         Sorts.family (sort_of_atomic_type env sigma (type_of env f) args)
     | Lambda _ | Fix _ | Construct _ -> retype_error NotAType
-    | Ind _ when truncation_style && Termops.is_template_polymorphic_ind env sigma t -> InType
     | _ ->
       Sorts.family (decomp_sort env sigma (type_of env t))
   in sort_family_of env t

--- a/pretyping/retyping.mli
+++ b/pretyping/retyping.mli
@@ -37,11 +37,8 @@ val get_type_of_constr : ?polyprop:bool -> ?lax:bool
 val get_sort_of :
   ?polyprop:bool -> env -> evar_map -> types -> Sorts.t
 
-(* When [truncation_style] is [true], tells if the type has been explicitly
-   truncated to Prop or (impredicative) Set; in particular, singleton type and
-   small inductive types, which have all eliminations to Type, are in Type *)
 val get_sort_family_of :
-  ?truncation_style:bool -> ?polyprop:bool -> env -> evar_map -> types -> Sorts.family
+  ?polyprop:bool -> env -> evar_map -> types -> Sorts.family
 
 (** Makes an unsafe judgment from a constr *)
 val get_judgment_of : env -> evar_map -> constr -> unsafe_judgment

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -749,15 +749,49 @@ let keep_proof_equalities = function
   | None -> !keep_proof_equalities_for_injection
   | Some flags -> flags.keep_proof_equalities
 
+module KeepEqualities =
+struct
+  type t = inductive
+  module Set = Indset_env
+  let encode _env r = Nametab.global_inductive r
+  let subst subst obj = Mod_subst.subst_ind subst obj
+  let printer ind = Nametab.pr_global_env Id.Set.empty (GlobRef.IndRef ind)
+  let key = ["Keep"; "Equalities"]
+  let title = "Prop-valued inductive types for which injection keeps equality proofs"
+  let member_message ind b =
+    let b = if b then mt () else str "not " in
+    str "Equality proofs over " ++ (printer ind) ++
+      str " are " ++ b ++ str "kept by injection"
+end
+
+module KeepEqualitiesTable = Goptions.MakeRefTable(KeepEqualities)
+
+let set_keep_equality = KeepEqualitiesTable.set
+
 (* [keep_proofs] is relevant for types in Prop with elimination in Type *)
 (* In particular, it is relevant for injection but not for discriminate *)
+
+let keep_head_inductive sigma c =
+  (* Note that we do not weak-head normalize c before checking it is an
+     applied inductive, because [get_sort_family_of] did not use to either.
+     As a matter of fact, if it reduces to an applied template inductive
+     type but is not syntactically equal to it, it will fail to project. *)
+  let _, hd = EConstr.decompose_prod sigma c in
+  let hd, _ = Termops.decompose_app_vect sigma hd in
+  match EConstr.kind sigma hd with
+  | Ind (ind, _) -> KeepEqualitiesTable.active ind
+  | _ -> false
 
 let find_positions env sigma ~keep_proofs ~no_discr t1 t2 =
   let project env sorts posn t1 t2 =
     let ty1 = get_type_of env sigma t1 in
-    let s = get_sort_family_of ~truncation_style:true env sigma ty1 in
-    if List.mem_f Sorts.family_equal s sorts
-    then [(List.rev posn,t1,t2)] else []
+    let keep =
+      if keep_head_inductive sigma ty1 then true
+      else
+        let s = get_sort_family_of env sigma ty1 in
+        List.mem_f Sorts.family_equal s sorts
+    in
+    if keep then [(List.rev posn,t1,t2)] else []
   in
   let rec findrec sorts posn t1 t2 =
     let hd1,args1 = whd_all_stack env sigma t1 in

--- a/tactics/equality.mli
+++ b/tactics/equality.mli
@@ -121,6 +121,8 @@ val discriminable : env -> evar_map -> constr -> constr -> bool
 (* Tells if tactic "injection" is applicable *)
 val injectable : env -> evar_map -> keep_proofs:(bool option) -> constr -> constr -> bool
 
+val set_keep_equality : inductive -> bool -> unit
+
 (* Subst *)
 
 (* val unfold_body : Id.t -> tactic *)

--- a/vernac/declareInd.ml
+++ b/vernac/declareInd.ml
@@ -181,6 +181,8 @@ let declare_mutual_inductive_with_eliminations ?(primitive_expected=false) ?typi
         constrimpls)
     impls;
   Flags.if_verbose Feedback.msg_info (minductive_message names);
+  if mie.mind_entry_template then
+    List.iteri (fun i _ -> Equality.set_keep_equality (mind, i) true) mie.mind_entry_inds;
   if mie.mind_entry_private == None
   then Indschemes.declare_default_schemes mind;
   mind


### PR DESCRIPTION
Instead, we add a table to selectively activate the Keep Proof Equality option. This allow decoupling the two feature and easing the eventual removal of template polymorphism. For backwards compatibility, template inductive types are implictly added to the table.

A careful analysis of the previous code indicates that this feature is quite fragile because it depends on the syntactic shape of the type of the argument, which is not normalized. In particular it means that equality proof preservation is not stable by conversion and is sensitive to internals of the retyping algorithm. The new code has the same defect, but we remove the now unused truncation_style flag hack in order not to tempt any innocent bystander.

This problem was observed when enforcing that strictly-Prop-living inductive types shouldn't be template.
