### PR TITLE
Fixing #14443: shift by 1 in locating start of parsing error messages

### DIFF
--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -1574,8 +1574,12 @@ module Parsable = struct
     let efun = entry.estart 0 in
     let ts = p.pa_tok_strm in
     let get_loc () =
-      let loc = LStream.current_loc ts in
+      (* Build the loc spanning from just after what is consumed (count)
+         up to the further token known to have been read (max_peek).
+         Unless there were a Ctrl-C (handled explicitly), there needs
+         to be a next token that caused the parsing failure. *)
       let loc' = LStream.max_peek_loc ts in
+      let loc = LStream.get_loc (LStream.count ts) ts in
       Loc.merge loc loc'
     in
     try efun ts with


### PR DESCRIPTION
**Kind:** bug fix

While fixing #14199 (Ctrl-C anomaly issue), a shift by 1 was added in locating the beginning of a parsing error. This does not seem to be a good idea.

Fixes / closes #14443 (concerns only master)