### PR TITLE
Remove and clean up redundant rewriting API in Equality.

### DIFF
--- a/dev/ci/user-overlays/14449-ppedrot-clean-equality-generic-rewrite-api.sh
+++ b/dev/ci/user-overlays/14449-ppedrot-clean-equality-generic-rewrite-api.sh
@@ -1,0 +1,3 @@
+overlay aac_tactics https://github.com/ppedrot/aac-tactics clean-equality-generic-rewrite-api 14449
+
+overlay coqhammer https://github.com/ppedrot/coqhammer clean-equality-generic-rewrite-api 14449

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -1346,8 +1346,8 @@ let rec rewrite_eqs_in_eqs eqs =
              (Format.sprintf "rewrite %s in %s " (Id.to_string eq)
                 (Id.to_string id))
              (tclTRY
-                (Equality.general_rewrite_in true Locus.AllOccurrences true
-                   (* dep proofs also: *) true id (mkVar eq) false)))
+                (Equality.general_rewrite_ebindings_clause (Some id) true Locus.AllOccurrences true
+                   (* dep proofs also: *) true (mkVar eq, Tactypes.NoBindings) false)))
          eqs)
       (rewrite_eqs_in_eqs eqs)
 

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -1346,8 +1346,8 @@ let rec rewrite_eqs_in_eqs eqs =
              (Format.sprintf "rewrite %s in %s " (Id.to_string eq)
                 (Id.to_string id))
              (tclTRY
-                (Equality.general_rewrite_ebindings_clause (Some id) true Locus.AllOccurrences true
-                   (* dep proofs also: *) true (mkVar eq, Tactypes.NoBindings) false)))
+                (Equality.general_rewrite ~where:(Some id) ~l2r:true Locus.AllOccurrences ~freeze:true
+                   (* dep proofs also: *) ~dep:true ~with_evars:false (mkVar eq, Tactypes.NoBindings))))
          eqs)
       (rewrite_eqs_in_eqs eqs)
 

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -975,13 +975,13 @@ let rec make_rewrite_list expr_info max = function
                    ( Nameops.Name.get_id k_na.binder_name
                    , Nameops.Name.get_id def_na.binder_name )
                  in
-                 general_rewrite_ebindings_clause None false Locus.AllOccurrences true
-                   (* dep proofs also: *) true
+                 general_rewrite ~where:None ~l2r:false Locus.AllOccurrences ~freeze:true
+                   (* dep proofs also: *) ~dep:true ~with_evars:false
                    ( mkVar hp
                    , ExplicitBindings
                        [ CAst.make @@ (NamedHyp def, expr_info.f_constr)
                        ; CAst.make @@ (NamedHyp k, f_S max) ] )
-                   false)))
+                   )))
          [ make_rewrite_list expr_info max l
          ; New.observe_tclTHENLIST
              (fun _ _ -> str "make_rewrite_list")
@@ -1010,13 +1010,13 @@ let make_rewrite expr_info l hp max =
                in
                New.observe_tac
                  (fun _ _ -> str "general_rewrite_bindings")
-                 (general_rewrite_ebindings_clause None false Locus.AllOccurrences true
-                    (* dep proofs also: *) true
+                 (general_rewrite ~where:None ~l2r:false Locus.AllOccurrences ~freeze:true
+                    (* dep proofs also: *) ~dep:true ~with_evars:false
                     ( mkVar hp
                     , ExplicitBindings
                         [ CAst.make @@ (NamedHyp def, expr_info.f_constr)
                         ; CAst.make @@ (NamedHyp k, f_S (f_S max)) ] )
-                    false)))
+                    )))
           [ New.observe_tac
               (fun _ _ -> str "make_rewrite finalize")
               ((* tclORELSE( h_reflexivity) *)

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -975,7 +975,7 @@ let rec make_rewrite_list expr_info max = function
                    ( Nameops.Name.get_id k_na.binder_name
                    , Nameops.Name.get_id def_na.binder_name )
                  in
-                 general_rewrite_bindings false Locus.AllOccurrences true
+                 general_rewrite_ebindings_clause None false Locus.AllOccurrences true
                    (* dep proofs also: *) true
                    ( mkVar hp
                    , ExplicitBindings
@@ -1010,7 +1010,7 @@ let make_rewrite expr_info l hp max =
                in
                New.observe_tac
                  (fun _ _ -> str "general_rewrite_bindings")
-                 (general_rewrite_bindings false Locus.AllOccurrences true
+                 (general_rewrite_ebindings_clause None false Locus.AllOccurrences true
                     (* dep proofs also: *) true
                     ( mkVar hp
                     , ExplicitBindings

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -277,7 +277,7 @@ END
 let rewrite_star ist clause orient occs c (tac : Geninterp.Val.t option) =
   let tac' = Option.map (fun t -> Tacinterp.tactic_of_value ist t, FirstSolved) tac in
   with_delayed_uconstr ist c
-    (fun c -> general_rewrite_ebindings_clause clause orient occs ?tac:tac' true true (c,NoBindings) true)
+    (fun c -> general_rewrite ~where:clause ~l2r:orient occs ?tac:tac' ~freeze:true ~dep:true ~with_evars:true (c,NoBindings))
 
 }
 
@@ -722,7 +722,7 @@ let rewrite_except h =
   Proofview.Goal.enter begin fun gl ->
   let hyps = Tacmach.New.pf_ids_of_hyps gl in
   Tacticals.New.tclMAP (fun id -> if Id.equal id h then Proofview.tclUNIT () else
-      Tacticals.New.tclTRY (Equality.general_rewrite_ebindings_clause (Some id) true Locus.AllOccurrences true true (mkVar h, NoBindings) false))
+      Tacticals.New.tclTRY (Equality.general_rewrite ~where:(Some id) ~l2r:true Locus.AllOccurrences ~freeze:true ~dep:true ~with_evars:false (mkVar h, NoBindings)))
     hyps
   end
 

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -722,7 +722,7 @@ let rewrite_except h =
   Proofview.Goal.enter begin fun gl ->
   let hyps = Tacmach.New.pf_ids_of_hyps gl in
   Tacticals.New.tclMAP (fun id -> if Id.equal id h then Proofview.tclUNIT () else
-      Tacticals.New.tclTRY (Equality.general_rewrite_in true Locus.AllOccurrences true true id (mkVar h) false))
+      Tacticals.New.tclTRY (Equality.general_rewrite_ebindings_clause (Some id) true Locus.AllOccurrences true true (mkVar h, NoBindings) false))
     hyps
   end
 

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -854,7 +854,7 @@ let rewritetac ?(under=false) dir c =
   (* Due to the new optional arg ?tac, application shouldn't be too partial *)
   let open Proofview.Notations in
   Proofview.Goal.enter begin fun _ ->
-      Equality.general_rewrite_ebindings_clause None (dir = L2R) AllOccurrences true false (c, Tactypes.NoBindings) false <*>
+      Equality.general_rewrite ~where:None ~l2r:(dir = L2R) AllOccurrences ~freeze:true ~dep:false ~with_evars:false (c, Tactypes.NoBindings) <*>
         if under then Proofview.cycle 1 else Proofview.tclUNIT ()
   end
 

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -854,7 +854,7 @@ let rewritetac ?(under=false) dir c =
   (* Due to the new optional arg ?tac, application shouldn't be too partial *)
   let open Proofview.Notations in
   Proofview.Goal.enter begin fun _ ->
-      Equality.general_rewrite (dir = L2R) AllOccurrences true false c <*>
+      Equality.general_rewrite_ebindings_clause None (dir = L2R) AllOccurrences true false (c, Tactypes.NoBindings) false <*>
         if under then Proofview.cycle 1 else Proofview.tclUNIT ()
   end
 

--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -126,7 +126,7 @@ let autorewrite ?(conds=Naive) tac_main lbas =
        Tacticals.New.tclTHEN tac
         (one_base (fun dir c tac ->
           let tac = (tac, conds) in
-            general_rewrite dir AllOccurrences true false ~tac (EConstr.of_constr c))
+            general_rewrite_ebindings_clause None dir AllOccurrences true false ~tac (EConstr.of_constr c, Tactypes.NoBindings) false)
           tac_main bas))
       (Proofview.tclUNIT()) lbas))
 
@@ -136,7 +136,7 @@ let autorewrite_multi_in ?(conds=Naive) idl tac_main lbas =
   let _ = List.map (fun id -> Tacmach.New.pf_get_hyp id gl) idl in
   let general_rewrite_in id dir cstr tac =
     let cstr = EConstr.of_constr cstr in
-    general_rewrite_in dir AllOccurrences true ~tac:(tac, conds) false id cstr false
+    general_rewrite_ebindings_clause (Some id) dir AllOccurrences true ~tac:(tac, conds) false (cstr, Tactypes.NoBindings) false
   in
  Tacticals.New.tclMAP (fun id ->
   Tacticals.New.tclREPEAT_MAIN (Proofview.tclPROGRESS

--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -126,7 +126,7 @@ let autorewrite ?(conds=Naive) tac_main lbas =
        Tacticals.New.tclTHEN tac
         (one_base (fun dir c tac ->
           let tac = (tac, conds) in
-            general_rewrite_ebindings_clause None dir AllOccurrences true false ~tac (EConstr.of_constr c, Tactypes.NoBindings) false)
+            general_rewrite ~where:None ~l2r:dir AllOccurrences ~freeze:true ~dep:false ~with_evars:false ~tac (EConstr.of_constr c, Tactypes.NoBindings))
           tac_main bas))
       (Proofview.tclUNIT()) lbas))
 
@@ -136,7 +136,7 @@ let autorewrite_multi_in ?(conds=Naive) idl tac_main lbas =
   let _ = List.map (fun id -> Tacmach.New.pf_get_hyp id gl) idl in
   let general_rewrite_in id dir cstr tac =
     let cstr = EConstr.of_constr cstr in
-    general_rewrite_ebindings_clause (Some id) dir AllOccurrences true ~tac:(tac, conds) false (cstr, Tactypes.NoBindings) false
+    general_rewrite ~where:(Some id) ~l2r:dir AllOccurrences ~freeze:true ~dep:false ~with_evars:false ~tac:(tac, conds) (cstr, Tactypes.NoBindings)
   in
  Tacticals.New.tclMAP (fun id ->
   Tacticals.New.tclREPEAT_MAIN (Proofview.tclPROGRESS

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -490,28 +490,6 @@ let general_rewrite_ebindings_clause cls lft2rgt occs frzevars dep_proof_ok ?tac
             end
     end
 
-let general_rewrite_ebindings =
-  general_rewrite_ebindings_clause None
-
-let general_rewrite_bindings l2r occs frzevars dep_proof_ok ?tac (c,bl) =
-  general_rewrite_ebindings_clause None l2r occs
-    frzevars dep_proof_ok ?tac (c,bl)
-
-let general_rewrite l2r occs frzevars dep_proof_ok ?tac c =
-  general_rewrite_bindings l2r occs
-    frzevars dep_proof_ok ?tac (c,NoBindings) false
-
-let general_rewrite_ebindings_in l2r occs frzevars dep_proof_ok ?tac id =
-  general_rewrite_ebindings_clause (Some id) l2r occs frzevars dep_proof_ok ?tac
-
-let general_rewrite_bindings_in l2r occs frzevars dep_proof_ok ?tac id (c,bl) =
-  general_rewrite_ebindings_clause (Some id) l2r occs
-    frzevars dep_proof_ok ?tac (c,bl)
-
-let general_rewrite_in l2r occs frzevars dep_proof_ok ?tac id c =
-  general_rewrite_ebindings_clause (Some id) l2r occs
-    frzevars dep_proof_ok ?tac (c,NoBindings)
-
 let general_rewrite_clause l2r with_evars ?tac c cl =
   let occs_of = occurrences_map (List.fold_left
     (fun acc ->
@@ -526,12 +504,12 @@ let general_rewrite_clause l2r with_evars ?tac c cl =
           | [] -> Proofview.tclUNIT ()
           | ((occs,id),_) :: l ->
             tclTHENFIRST
-              (general_rewrite_ebindings_in l2r (occs_of occs) false true ?tac id c with_evars)
+              (general_rewrite_ebindings_clause (Some id) l2r (occs_of occs) false true ?tac c with_evars)
               (do_hyps l)
         in
         if cl.concl_occs == NoOccurrences then do_hyps l else
           tclTHENFIRST
-            (general_rewrite_ebindings l2r (occs_of cl.concl_occs) false true ?tac c with_evars)
+            (general_rewrite_ebindings_clause None l2r (occs_of cl.concl_occs) false true ?tac c with_evars)
             (do_hyps l)
     | None ->
         (* Otherwise, if we are told to rewrite in all hypothesis via the
@@ -540,7 +518,7 @@ let general_rewrite_clause l2r with_evars ?tac c cl =
           | [] -> tclZEROMSG (Pp.str"Nothing to rewrite.")
           | id :: l ->
             tclIFTHENFIRSTTRYELSEMUST
-             (general_rewrite_ebindings_in l2r AllOccurrences false true ?tac id c with_evars)
+             (general_rewrite_ebindings_clause (Some id) l2r AllOccurrences false true ?tac c with_evars)
              (do_hyps_atleastonce l)
         in
         let do_hyps =
@@ -556,7 +534,7 @@ let general_rewrite_clause l2r with_evars ?tac c cl =
         in
         if cl.concl_occs == NoOccurrences then do_hyps else
           tclIFTHENFIRSTTRYELSEMUST
-           (general_rewrite_ebindings l2r (occs_of cl.concl_occs) false true ?tac c with_evars)
+           (general_rewrite_ebindings_clause None l2r (occs_of cl.concl_occs) false true ?tac c with_evars)
            do_hyps
 
 let apply_special_clear_request clear_flag f =
@@ -602,8 +580,11 @@ let general_multi_rewrite with_evars l cl tac =
           (tclTHEN (doN l2r c m) (apply_special_clear_request clear_flag c)) (loop l)
   in loop l
 
-let rewriteLR = general_rewrite true AllOccurrences true true
-let rewriteRL = general_rewrite false AllOccurrences true true
+let rewriteLR c =
+  general_rewrite_ebindings_clause None true AllOccurrences true true (c, NoBindings) false
+let rewriteRL c =
+  general_rewrite_ebindings_clause None false AllOccurrences true true (c, NoBindings) false
+
 
 (* Replacing tactics *)
 
@@ -1788,7 +1769,7 @@ let subst_one dep_proof_ok x (hyp,rhs,dir) =
   tclTHENLIST
     ((if need_rewrite then
       [revert (List.map snd dephyps);
-       general_rewrite dir AtLeastOneOccurrence true dep_proof_ok (mkVar hyp);
+       general_rewrite_ebindings_clause None dir AtLeastOneOccurrence true dep_proof_ok (mkVar hyp, NoBindings) false;
        (tclMAP (fun (dest,id) -> intro_move (Some id) dest) dephyps)]
       else
        [Proofview.tclUNIT ()]) @

--- a/tactics/equality.mli
+++ b/tactics/equality.mli
@@ -41,9 +41,9 @@ val general_setoid_rewrite_clause :
   (Id.t option -> orientation -> occurrences -> constr with_bindings ->
    new_goals:constr list -> unit Proofview.tactic) Hook.t
 
-val general_rewrite_ebindings_clause : Id.t option ->
-  orientation -> occurrences -> freeze_evars_flag -> dep_proof_flag ->
-  ?tac:(unit Proofview.tactic * conditions) -> constr with_bindings -> evars_flag -> unit Proofview.tactic
+val general_rewrite : where:Id.t option ->
+  l2r:orientation -> occurrences -> freeze:freeze_evars_flag -> dep:dep_proof_flag -> with_evars:evars_flag ->
+  ?tac:(unit Proofview.tactic * conditions) -> constr with_bindings -> unit Proofview.tactic
 
 type multi =
   | Precisely of int

--- a/tactics/equality.mli
+++ b/tactics/equality.mli
@@ -31,16 +31,9 @@ type conditions =
 
 val eq_elimination_ref : orientation -> Sorts.family -> GlobRef.t option
 
-val general_rewrite_bindings :
-  orientation -> occurrences -> freeze_evars_flag -> dep_proof_flag ->
-  ?tac:(unit Proofview.tactic * conditions) -> constr with_bindings -> evars_flag -> unit Proofview.tactic
-val general_rewrite :
-  orientation -> occurrences -> freeze_evars_flag -> dep_proof_flag ->
-  ?tac:(unit Proofview.tactic * conditions) -> constr -> unit Proofview.tactic
-
 (* Equivalent to [general_rewrite l2r] *)
-val rewriteLR : ?tac:(unit Proofview.tactic * conditions) -> constr -> unit Proofview.tactic
-val rewriteRL : ?tac:(unit Proofview.tactic * conditions) -> constr  -> unit Proofview.tactic
+val rewriteLR : constr -> unit Proofview.tactic
+val rewriteRL : constr  -> unit Proofview.tactic
 
 (* Warning: old [general_rewrite_in] is now [general_rewrite_bindings_in] *)
 
@@ -51,17 +44,6 @@ val general_setoid_rewrite_clause :
 val general_rewrite_ebindings_clause : Id.t option ->
   orientation -> occurrences -> freeze_evars_flag -> dep_proof_flag ->
   ?tac:(unit Proofview.tactic * conditions) -> constr with_bindings -> evars_flag -> unit Proofview.tactic
-
-val general_rewrite_bindings_in :
-  orientation -> occurrences -> freeze_evars_flag -> dep_proof_flag ->
-  ?tac:(unit Proofview.tactic * conditions) ->
-  Id.t -> constr with_bindings -> evars_flag -> unit Proofview.tactic
-val general_rewrite_in          :
-  orientation -> occurrences -> freeze_evars_flag -> dep_proof_flag ->
-  ?tac:(unit Proofview.tactic * conditions) -> Id.t -> constr -> evars_flag -> unit Proofview.tactic
-
-val general_rewrite_clause :
-  orientation -> evars_flag -> ?tac:(unit Proofview.tactic * conditions) -> constr with_bindings -> clause -> unit Proofview.tactic
 
 type multi =
   | Precisely of int

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -982,12 +982,12 @@ let compute_dec_tact handle ind lnamesparrec nparrec =
                                  apply (EConstr.of_constr (mkApp(lbI,Array.map mkVar xargs)));
                                  Auto.default_auto
                             ]);
-                          Equality.general_rewrite_ebindings_clause (Some freshH3) true
-                            Locus.AllOccurrences true false
+                          Equality.general_rewrite ~where:(Some freshH3) ~l2r:true
+                            Locus.AllOccurrences ~freeze:true ~dep:false ~with_evars:true
                             ((EConstr.mkVar freshH2),
                              NoBindings
                             )
-                            true;
+                            ;
                           my_discr_tac
                         ]
                       end

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -982,9 +982,8 @@ let compute_dec_tact handle ind lnamesparrec nparrec =
                                  apply (EConstr.of_constr (mkApp(lbI,Array.map mkVar xargs)));
                                  Auto.default_auto
                             ]);
-                          Equality.general_rewrite_bindings_in true
+                          Equality.general_rewrite_ebindings_clause (Some freshH3) true
                             Locus.AllOccurrences true false
-                            freshH3
                             ((EConstr.mkVar freshH2),
                              NoBindings
                             )


### PR DESCRIPTION
We only expose the most general combinator and equip it with labelled arguments.

I have lost too many neurons jumping from one definition to another in Equality, the time has come.

Overlays:
- https://github.com/coq-community/aac-tactics/pull/76
- https://github.com/lukaszcz/coqhammer/pull/107