### PR TITLE
CoqIDE Unicode: parentheses: use math, not CJK

### DIFF
--- a/doc/changelog/09-coqide/14452-btj+patch-1.rst
+++ b/doc/changelog/09-coqide/14452-btj+patch-1.rst
@@ -1,0 +1,4 @@
+- **Changed:**
+  CoqIDE unicode keys for brackets (e.g. `\langle`) now bind to unicode mathematical symbols rather than unicode CJK brackets
+  (`#14452 <https://github.com/coq/coq/pull/14452>`_,
+  by Bart Jacobs).

--- a/ide/coqide/default_bindings_src.ml
+++ b/ide/coqide/default_bindings_src.ml
@@ -1177,18 +1177,18 @@ let bindings_set_1 = [
 (* {{{ parenteses *)
  ["\\laquo"                                          ], "«", [delimiter] ;
  ["\\raquo"                                          ], "»", [delimiter] ;
- ["\\lang"; "\\langle"; "\\LeftAngleBracket"           ], "〈", [delimiter] ;
- ["\\rang"; "\\rangle"; "\\RightAngleBracket"          ], "〉", [delimiter] ;
+ ["\\lang"; "\\langle"; "\\LeftAngleBracket"           ], "⟨", [delimiter] ;
+ ["\\rang"; "\\rangle"; "\\RightAngleBracket"          ], "⟩", [delimiter] ;
  ["\\lmoust"; "\\lmoustache"                          ], "⎰", [delimiter] ;
  ["\\rmoust"; "\\rmoustache"                          ], "⎱", [delimiter] ;
- ["\\Lang"                                           ], "《", [delimiter] ;
- ["\\Rang"                                           ], "》", [delimiter] ;
- ["\\lbbrk"                                          ], "〔", [delimiter] ;
- ["\\rbbrk"                                          ], "〕", [delimiter] ;
- ["\\lopar"                                          ], "〘", [delimiter] ;
- ["\\ropar"                                          ], "〙", [delimiter] ;
- ["\\lobrk"; "\\LeftDoubleBracket"                    ], "〚", [delimiter] ;
- ["\\robrk"; "\\RightDoubleBracket"                   ], "〛", [delimiter] ;
+ ["\\Lang"                                           ], "⟪", [delimiter] ;
+ ["\\Rang"                                           ], "⟫", [delimiter] ;
+ ["\\lbbrk"                                          ], "⦗", [delimiter] ;
+ ["\\rbbrk"                                          ], "⦘", [delimiter] ;
+ ["\\lopar"                                          ], "⦅", [delimiter] ;
+ ["\\ropar"                                          ], "⦆", [delimiter] ;
+ ["\\lobrk"; "\\LeftDoubleBracket"                    ], "⟦", [delimiter] ;
+ ["\\robrk"; "\\RightDoubleBracket"                   ], "⟧", [delimiter] ;
 (* }}} *)
 
 (* {{{ Missing font *)


### PR DESCRIPTION
Use Unicode symbols from the Unicode mathematical/technical blocks rather than CJK punctuation for open brackets and other special parentheses.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** aesthetic.

- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
