### PR TITLE
Show a warning instead of an anomaly for Diff_Failure exception

### DIFF
--- a/doc/changelog/04-tactics/14457-proof_diffs_anomaly.rst
+++ b/doc/changelog/04-tactics/14457-proof_diffs_anomaly.rst
@@ -1,0 +1,7 @@
+- **Fixed:**
+  Print a message instead of a Diff_Failure anomaly when
+  old and new goals can't be matched; show the goal without
+  diff highlights
+  (`#14457 <https://github.com/coq/coq/pull/14457>`_,
+  fixes `#14425 <https://github.com/coq/coq/issues/14425>`_,
+  by Jim Fehrle).

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -212,8 +212,12 @@ let goals () =
     let newp = Vernacstate.Declare.give_me_the_proof () in
     if Proof_diffs.show_diffs () then begin
       let oldp = Stm.get_prev_proof ~doc (Stm.get_current_state ~doc) in
-      let diff_goal_map = Proof_diffs.make_goal_map oldp newp in
-      Some (export_pre_goals Proof.(data newp) (process_goal_diffs diff_goal_map oldp))
+      (try
+        let diff_goal_map = Proof_diffs.make_goal_map oldp newp in
+        Some (export_pre_goals Proof.(data newp) (process_goal_diffs diff_goal_map oldp))
+       with Pp_diff.Diff_Failure msg ->
+         Proof_diffs.notify_proof_diff_failure msg;
+         Some (export_pre_goals Proof.(data newp) process_goal))
     end else
       Some (export_pre_goals Proof.(data newp) process_goal)
   with Vernacstate.Declare.NoCurrentProof -> None

--- a/lib/pp_diff.ml
+++ b/lib/pp_diff.ml
@@ -244,7 +244,7 @@ let add_diff_tags which pp diffs  =
       Buffer.add_char buf c
     else begin
       cprintf "mismatch: expected '%c' but got '%c'\n" !diff_str.[!diff_ind] c;
-      raise (Diff_Failure "string mismatch, shouldn't happen")
+      raise (Diff_Failure "string mismatch, should be impossible")
     end
   in
 

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -822,9 +822,13 @@ let pr_open_subgoals_diff ?(quiet=false) ?(diffs=false) ?oproof proof =
      let unfocused_if_needed = if should_unfoc() then bgoals_unfocused else [] in
      let os_map = match oproof with
        | Some op when diffs ->
-         let Proof.{sigma=osigma} = Proof.data op in
-         let diff_goal_map = Proof_diffs.make_goal_map oproof proof in
-         Some (osigma, diff_goal_map)
+         (try
+           let Proof.{sigma=osigma} = Proof.data op in
+           let diff_goal_map = Proof_diffs.make_goal_map oproof proof in
+           Some (osigma, diff_goal_map)
+         with Pp_diff.Diff_Failure msg ->
+           Proof_diffs.notify_proof_diff_failure msg;
+           None)
        | _ -> None
      in
      pr_subgoals ~pr_first:true ~diffs ?os_map None bsigma ~seeds ~shelf ~stack:[]

--- a/printing/proof_diffs.mli
+++ b/printing/proof_diffs.mli
@@ -90,3 +90,5 @@ type hyp_info = {
 val diff_hyps : string list list -> hyp_info CString.Map.t -> string list list -> hyp_info CString.Map.t -> Pp.t list
 
 val diff_proofs : diff_opt:diffOpt -> ?old:Proof.t -> Proof.t -> Pp.t
+
+val notify_proof_diff_failure : string -> unit

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -160,11 +160,7 @@ let with_diffs pm pn =
   with Pp_diff.Diff_Failure msg ->
     begin
       try ignore(Sys.getenv("HIDEDIFFFAILUREMSG"))
-      with Not_found ->
-        Feedback.msg_warning Pp.(
-            hov 0 (str ("Diff failure: " ^ msg) ++ spc () ++
-            hov 0 (str "Showing message without diff highlighting" ++ spc () ++
-            hov 0 (str "Please report at " ++ str Coq_config.wwwbugtracker ++ str "."))))
+      with Not_found -> Proof_diffs.notify_proof_diff_failure msg
     end;
     pm, pn
 


### PR DESCRIPTION
Proof diffs was generating an anomaly when the goal-matching heuristic failed.  This PR changes the anomaly to a warning and displays the proof state without highlights when the warning appears, making it minimally disruptive.

I hope we can get this into 8.14 if that train hasn't left the station.  Or even 8.3.13 if we create such a release.  While there is a workaround for the anomaly (described in the issue), it's a bit of a pain in the neck (or perhaps lower down) for those who wish to see diffs.

Fixes: #14425

Perhaps @ejgallego would be sufficient to review the code and @Zimmi48 could take a look at the small addition to the documentation.

A redesign of the goal-matching code may be able to handle the failing case and likely would no long be a heuristic.  This would require preserving a mapping between the kernel's evar numbers and the goals presented at the higher levels of the code, such as in `proof.ml`.  I'm sure the replacement code would be much shorter and simpler.  The current `Proof_diffs.match_goals` code, about 200 lines, could go away.