### PR TITLE
Clean up Clenv API

### DIFF
--- a/plugins/ltac/leminv.ml
+++ b/plugins/ltac/leminv.ml
@@ -257,7 +257,7 @@ let add_inversion_lemma_exn ~poly na com comsort bool tac =
 let lemInv id c =
   Proofview.Goal.enter begin fun gls ->
   try
-    let clause = mk_clenv_from_env (pf_env gls) (project gls) None (c, pf_get_type_of gls c) in
+    let clause = mk_clenv_from (pf_env gls) (project gls) (c, pf_get_type_of gls c) in
     let clause = clenv_constrain_last_binding (EConstr.mkVar id) clause in
     Clenv.res_pf clause ~flags:(Unification.elim_flags ()) ~with_evars:false
   with

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -424,6 +424,11 @@ let fchain_flags () =
   { (default_unify_flags ()) with
     allow_K_in_toplevel_higher_order_unification = true }
 
+let clenv_instantiate ?(flags=fchain_flags ()) mv clenv (c, ty) =
+  (* unify the type of the template of [nextclenv] with the type of [mv] *)
+  let clenv = clenv_unify ~flags CUMUL ty (clenv_meta_type clenv mv) clenv in
+  clenv_assign mv c clenv
+
 let clenv_fchain ?with_univs ?(flags=fchain_flags ()) mv clenv nextclenv =
   (* Add the metavars of [nextclenv] to [clenv], with their name-environment *)
   let evd = meta_merge ?with_univs nextclenv.evd clenv.evd in

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -64,8 +64,6 @@ let clenv_hnf_constr ce t = hnf_constr (cl_env ce) (cl_sigma ce) t
 
 let clenv_get_type_of ce c = Retyping.get_type_of (cl_env ce) (cl_sigma ce) c
 
-exception NotExtensibleClause
-
 let clenv_push_prod cl =
   let typ = whd_all (cl_env cl) (cl_sigma cl) (clenv_type cl) in
   let rec clrec typ = match EConstr.kind cl.evd typ with
@@ -77,12 +75,12 @@ let clenv_push_prod cl =
         let e' = meta_declare mv t ~name:na' cl.evd in
         let concl = if dep then subst1 (mkMeta mv) u else u in
         let def = applist (cl.templval.rebus,[mkMeta mv]) in
-        { templval = mk_freelisted def;
+        Some (mv, dep, { templval = mk_freelisted def;
           templtyp = mk_freelisted concl;
           evd = e';
           env = cl.env;
-          cache = create_meta_instance_subst e' }
-    | _ -> raise NotExtensibleClause
+          cache = create_meta_instance_subst e' })
+    | _ -> None
   in clrec typ
 
 (* Instantiate the first [bound] products of [t] with metas (all products if

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -126,12 +126,8 @@ let mk_clenv_from_env env sigma n (c,cty) =
     env = env;
     cache = create_meta_instance_subst evd }
 
-let mk_clenv_from_n gls n (c,cty) =
-  let env = Proofview.Goal.env gls in
-  let sigma = Tacmach.New.project gls in
-  mk_clenv_from_env env sigma n (c, cty)
-
-let mk_clenv_from gls = mk_clenv_from_n gls None
+let mk_clenv_from env sigma c = mk_clenv_from_env env sigma None c
+let mk_clenv_from_n env sigma n c = mk_clenv_from_env env sigma (Some n) c
 
 (******************************************************************)
 

--- a/proofs/clenv.mli
+++ b/proofs/clenv.mli
@@ -44,10 +44,8 @@ val clenv_type      : clausenv -> types
 (** type of a meta in clenv context *)
 val clenv_meta_type : clausenv -> metavariable -> types
 
-val mk_clenv_from : Proofview.Goal.t -> EConstr.constr * EConstr.types -> clausenv
-val mk_clenv_from_n :
-  Proofview.Goal.t -> int option -> EConstr.constr * EConstr.types -> clausenv
-val mk_clenv_from_env : env -> evar_map -> int option -> EConstr.constr * EConstr.types -> clausenv
+val mk_clenv_from : env -> evar_map -> EConstr.constr * EConstr.types -> clausenv
+val mk_clenv_from_n : env -> evar_map -> int -> EConstr.constr * EConstr.types -> clausenv
 
 (** {6 linking of clenvs } *)
 

--- a/proofs/clenv.mli
+++ b/proofs/clenv.mli
@@ -87,8 +87,7 @@ val make_clenv_binding :
   env -> evar_map -> EConstr.constr * EConstr.constr -> constr bindings -> clausenv
 
 (** if the clause is a product, add an extra meta for this product *)
-exception NotExtensibleClause
-val clenv_push_prod : clausenv -> clausenv
+val clenv_push_prod : clausenv -> (metavariable * bool * clausenv) option
 
 (** {6 Clenv tactics} *)
 

--- a/proofs/clenv.mli
+++ b/proofs/clenv.mli
@@ -51,6 +51,8 @@ val mk_clenv_from_env : env -> evar_map -> int option -> EConstr.constr * EConst
 
 (** {6 linking of clenvs } *)
 
+val clenv_instantiate : ?flags:unify_flags -> metavariable -> clausenv -> (constr * types) -> clausenv
+
 val clenv_fchain :
   ?with_univs:bool -> ?flags:unify_flags -> metavariable -> clausenv -> clausenv -> clausenv
 

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -163,7 +163,7 @@ let unify_resolve ~with_evars flags h diff = match diff with
   let env = Proofview.Goal.env gl in
   let sigma = Tacmach.New.project gl in
   let sigma, c = Hints.fresh_hint env sigma h in
-  let clenv = mk_clenv_from_env env sigma (Some diff) (c, ty) in
+  let clenv = mk_clenv_from_n env sigma diff (c, ty) in
   Clenv.res_pf ~with_evars ~with_classes:false ~flags clenv
   end
 
@@ -1192,7 +1192,9 @@ let autoapply c i =
   let flags = auto_unif_flags
     (Hints.Hint_db.transparent_state hintdb) in
   let cty = Tacmach.New.pf_get_type_of gl c in
-  let ce = mk_clenv_from gl (c,cty) in
+  let env = Proofview.Goal.env gl in
+  let sigma = Proofview.Goal.sigma gl in
+  let ce = mk_clenv_from env sigma (c,cty) in
   Clenv.res_pf ~with_evars:true ~with_classes:false ~flags ce <*>
       Proofview.tclEVARMAP >>= (fun sigma ->
       let sigma = Typeclasses.make_unresolvables

--- a/tactics/elim.ml
+++ b/tactics/elim.ml
@@ -48,7 +48,7 @@ let general_elim_then_using mk_elim
       Evd.fresh_global env sigma gr
     in
     (* applying elimination_scheme just a little modified *)
-    let elimclause = mk_clenv_from_env env sigma None (elim, Retyping.get_type_of env sigma elim) in
+    let elimclause = mk_clenv_from env sigma (elim, Retyping.get_type_of env sigma elim) in
     let indmv =
       match EConstr.kind elimclause.evd (last_arg elimclause.evd elimclause.templval.Evd.rebus) with
       | Meta mv -> mv

--- a/tactics/elim.ml
+++ b/tactics/elim.ml
@@ -47,7 +47,6 @@ let general_elim_then_using mk_elim
       let gr = Indrec.lookup_eliminator env ind sort in
       Evd.fresh_global env sigma gr
     in
-    let indclause = mk_clenv_from_env env sigma None (mkVar id, mkApp (mkIndU (ind, u), args)) in
     (* applying elimination_scheme just a little modified *)
     let elimclause = mk_clenv_from_env env sigma None (elim, Retyping.get_type_of env sigma elim) in
     let indmv =
@@ -68,7 +67,7 @@ let general_elim_then_using mk_elim
           CErrors.user_err ~hdr:"Tacticals.general_elim_then_using"
             (str "The elimination combinator " ++ name_elim ++ str " is unknown.")
     in
-    let elimclause' = clenv_fchain ~with_univs:false indmv elimclause indclause in
+    let elimclause' = clenv_instantiate indmv elimclause (mkVar id, mkApp (mkIndU (ind, u), args)) in
     let branchsigns = Tacticals.compute_constructor_signatures ~rec_flag (ind, u) in
     let brnames = Tacticals.compute_induction_names false branchsigns allnames in
     let flags = Unification.elim_flags () in

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -339,7 +339,7 @@ let merge_context_set_opt sigma ctx = match ctx with
 let instantiate_hint env sigma p =
   let mk_clenv (c, cty, ctx) =
     let sigma = merge_context_set_opt sigma ctx in
-    let cl = mk_clenv_from_env env sigma None (c,cty) in
+    let cl = mk_clenv_from env sigma (c,cty) in
     let templval = { cl.templval with rebus = strip_params env sigma cl.templval.rebus } in
     let cl = mk_clausenv empty_env cl.evd templval cl.templtyp in
     { hint_term = c; hint_type = cty; hint_uctx = ctx; hint_clnv = cl; }
@@ -839,7 +839,7 @@ let make_apply_entry env sigma hnf info ?(name=PathAny) (c, cty, ctx) =
   match EConstr.kind sigma cty with
   | Prod _ ->
     let sigma' = merge_context_set_opt sigma ctx in
-    let ce = mk_clenv_from_env env sigma' None (c,cty) in
+    let ce = mk_clenv_from env sigma' (c,cty) in
     let c' = clenv_type (* ~reduce:false *) ce in
     let hd =
       try head_bound ce.evd c'
@@ -957,7 +957,7 @@ let make_trivial env sigma ?(name=PathAny) r =
   let sigma = merge_context_set_opt sigma ctx in
   let t = hnf_constr env sigma (Retyping.get_type_of env sigma c) in
   let hd = head_constr sigma t in
-  let ce = mk_clenv_from_env env sigma None (c,t) in
+  let ce = mk_clenv_from env sigma (c,t) in
   (Some hd,
    { pri=1;
      pat = Some (Patternops.pattern_of_constr env ce.evd (EConstr.to_constr sigma (clenv_type ce)));
@@ -1263,7 +1263,7 @@ let add_resolves env sigma clist ~local dbnames =
       let check (_, hint) = match hint.code.obj with
       | ERes_pf (c, cty, ctx) ->
         let sigma' = merge_context_set_opt sigma ctx in
-        let ce = mk_clenv_from_env env sigma' None (c,cty) in
+        let ce = mk_clenv_from env sigma' (c,cty) in
         let miss = clenv_missing ce in
         let nmiss = List.length miss in
         let variables = str (CString.plural nmiss "variable") in

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1379,7 +1379,7 @@ let general_elim_clause with_evars flags where indclause elim =
     let elimt = Retyping.get_type_of env sigma elimc in
     let i = index_of_ind_arg sigma elimt in
     let elimc = contract_letin_in_lam_header sigma elimc in
-    let elimclause = mk_clenv_from_env env sigma None (elimc, elimt) in
+    let elimclause = mk_clenv_from env sigma (elimc, elimt) in
     elimclause, Some i
   | ElimClause (elimc, lbindelimc) ->
     let elimt = Retyping.get_type_of env sigma elimc in
@@ -1760,7 +1760,7 @@ let apply_list = function
 exception UnableToApply
 
 let progress_with_clause flags (id, t) clause =
-  let innerclause = mk_clenv_from_env clause.env clause.evd (Some 0) (mkVar id, t) in
+  let innerclause = mk_clenv_from_n clause.env clause.evd 0 (mkVar id, t) in
   let ordered_metas = List.rev (clenv_independent clause) in
   if List.is_empty ordered_metas then raise UnableToApply;
   let f mv =
@@ -4260,7 +4260,7 @@ let induction_tac with_evars params indvars (elim, elimt) =
     (* elimclause contains this: (elimc ?i ?j ?k...?l) *)
     let elimc = contract_letin_in_lam_header sigma elimc in
     let elimc = mkCast (elimc, DEFAULTcast, elimt) in
-    let elimclause = Tacmach.New.pf_apply mk_clenv_from_env gl None (elimc, elimt) in
+    let elimclause = Tacmach.New.pf_apply mk_clenv_from gl (elimc, elimt) in
     (* elimclause' is built from elimclause by instantiating all args and params. *)
     recolle_clenv (Some i) params indvars elimclause gl
   | ElimClause (elimc, lbindelimc) ->
@@ -4717,7 +4717,7 @@ let elim_scheme_type elim t =
   let env = Proofview.Goal.env gl in
   let sigma = Proofview.Goal.sigma gl in
   let sigma, elimt = Typing.type_of env sigma elim in
-  let clause = mk_clenv_from_env env sigma None (elim,elimt) in
+  let clause = mk_clenv_from env sigma (elim,elimt) in
   match EConstr.kind clause.evd (last_arg clause.evd clause.templval.rebus) with
     | Meta mv ->
         let clause' =


### PR DESCRIPTION
This PR introduces various cleanups of the Clenv API, including:
- inlining of functions used only once
- exposing static knowledge through typing
- reduction of attack surface