### PR TITLE
Makefile.dune install target does not succeed

### DIFF
--- a/Makefile.dune
+++ b/Makefile.dune
@@ -124,6 +124,7 @@ release:
 install:
 	@echo "To install Coq using dune, use 'dune build -p P && dune install P'"
 	@echo "where P is any of the packages defined by opam files in the root dir"
+	@false
 
 fmt:
 	dune build @fmt --auto-promote


### PR DESCRIPTION
This should help with confusion when installing through opam when
COQ_USE_DUNE is set

cf https://coq.zulipchat.com/#narrow/stream/237656-Coq-devs.20.26.20plugin.20devs/topic/Installing.20coq.2Edev.20through.20opam.2C.20missing.20binaries

(it would still be good to have opam work properly when COQ_USE_DUNE
is set)