### PR TITLE
Ignore COQ_USE_DUNE when installing through opam

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,5 +12,9 @@
 ifndef COQ_USE_DUNE
 include Makefile.make
 else
+ifdef OPAM_PACKAGE_NAME # installing through opam: ignore COQ_USE_DUNE
+include Makefile.make
+else
 include Makefile.dune
+endif
 endif


### PR DESCRIPTION
Using OPAM_PACKAGE_NAME to detect if we're in opam is the best
solution I know of.

Fix #14469