### PR TITLE
Substitute universes in types of proof-mode mutual fixpoints.

### DIFF
--- a/test-suite/bugs/closed/bug_14057.v
+++ b/test-suite/bugs/closed/bug_14057.v
@@ -1,0 +1,42 @@
+Module Mono.
+  Module Transparent.
+    Fixpoint F (n : nat) (A : Type) {struct n} : nat
+    with G (n : nat) (A:Type@{_})  {struct n} : nat.
+    Proof.
+      1: pose (G n A).
+      all: exact 0.
+    Defined.
+  End Transparent.
+
+  Module Opaque.
+    Fixpoint F (n : nat) (A : Type) {struct n} : nat
+    with G (n : nat) (A:Type@{_})  {struct n} : nat.
+    Proof.
+      1: pose (G n A).
+      all: exact 0.
+    Qed.
+  End Opaque.
+End Mono.
+
+Module Poly.
+  Set Universe Polymorphism.
+  Module Transparent.
+    Fixpoint F (n : nat) (A : Type) {struct n} : nat
+    with G (n : nat) (A:Type@{_})  {struct n} : nat.
+    Proof.
+      1: pose (G n A).
+      all: exact 0.
+    Defined.
+    Check F@{_}. Check G@{_}.
+  End Transparent.
+
+  Module Opaque.
+    Fixpoint F (n : nat) (A : Type) {struct n} : nat
+    with G (n : nat) (A:Type@{_})  {struct n} : nat.
+    Proof.
+      1: pose (G n A).
+      all: exact 0.
+    Qed.
+    Check F@{_}. Check G@{_}.
+  End Opaque.
+End Poly.

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1847,7 +1847,13 @@ end = struct
     *)
     let pe, ubind =
       if i > 0 && not (CList.is_empty compute_guard)
-      then Internal.map_entry_type pe ~f:(fun _ -> Some typ), UnivNames.empty_binders
+      then
+        let typ =
+          UnivSubst.nf_evars_and_universes_opt_subst (fun _ -> None)
+            (UState.subst uctx)
+            typ
+        in
+        Internal.map_entry_type pe ~f:(fun _ -> Some typ), UnivNames.empty_binders
       else pe, UState.universe_binders uctx
     in
     (* We when compute_guard was [] in the previous step we should not


### PR DESCRIPTION
Fix #14057
