### PR TITLE
Attribute to define namespace policy for an inductive type

### DIFF
--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -1520,7 +1520,7 @@ let do_build_inductive evd (funconstants : pconstant list)
   try
     with_full_print
       (Flags.silently
-         (ComInductive.do_mutual_inductive ~template:(Some false) None rel_inds
+         (ComInductive.do_mutual_inductive ~template:(Some false) ~namespace:Attributes.Both None rel_inds
             ~cumulative:false ~poly:false ~private_ind:false
             ~uniform:ComInductive.NonUniformParameters))
       Declarations.Finite

--- a/test-suite/success/indnamespace.v
+++ b/test-suite/success/indnamespace.v
@@ -1,0 +1,41 @@
+Module InductiveProper.
+
+Module A.
+#[namespace=proper]
+Inductive myunit := mytt.
+Fail Check mytt.
+Check myunit.mytt.
+End A.
+
+Fail Check mytt.
+Fail Check myunit.mytt.
+Check A.myunit.mytt.
+
+Import A.
+
+Fail Check mytt.
+Check myunit.mytt.
+Check A.myunit.mytt.
+
+End InductiveProper.
+
+Module InductiveBoth.
+
+Module A.
+#[namespace=both]
+Inductive myunit := mytt.
+Check mytt.
+Check myunit.mytt.
+End A.
+
+Fail Check mytt.
+Fail Check myunit.mytt.
+Check A.myunit.mytt.
+
+Import A.
+
+Check mytt.
+Check myunit.mytt.
+Check A.myunit.mytt.
+
+End InductiveBoth.

--- a/vernac/attributes.ml
+++ b/vernac/attributes.ml
@@ -275,6 +275,14 @@ let template =
   qualify_attribute ukey
     (bool_attribute ~name:"template")
 
+type inductive_namespace = Proper | Flat | Both
+
+let proper_namespace =
+  let values = ["proper", Proper; "flat", Flat; "both", Both] in
+  fun attrs -> match key_value_attribute ~key:"namespace" ~default:None ~values attrs with
+  | extra, None -> extra, Both
+  | extra, Some b -> extra, b
+
 let deprecation_parser : Deprecation.t key_parser = fun orig args ->
   assert_once ~name:"deprecation" orig;
   match args with

--- a/vernac/attributes.ml
+++ b/vernac/attributes.ml
@@ -141,8 +141,7 @@ let key_value_attribute ~key ~default ~(values : (string * 'a) list) : 'a option
                     str "use one of " ++ pr_possible_values ~values)
             | value -> value
           end
-        | VernacFlagEmpty ->
-          default
+        | VernacFlagEmpty when Option.has_some default -> Option.get default (* compatibility case *)
         | err ->
           CErrors.user_err
             Pp.(str "Invalid syntax " ++ pr_vernac_flag (key, err) ++ str ", try "
@@ -153,7 +152,7 @@ let key_value_attribute ~key ~default ~(values : (string * 'a) list) : 'a option
 
 let bool_attribute ~name : bool option attribute =
   let values = ["yes", true; "no", false] in
-  key_value_attribute ~key:name ~default:true ~values
+  key_value_attribute ~key:name ~default:(Some true) ~values
 
 (* Variant of the [bool] attribute with only two values (bool has three). *)
 let get_bool_value ~key ~default =

--- a/vernac/attributes.mli
+++ b/vernac/attributes.mli
@@ -63,6 +63,9 @@ val hint_locality : default:(unit -> Hints.hint_locality) -> Hints.hint_locality
 (** With the warning for Hint (and not for Instance etc) *)
 val really_hint_locality : Hints.hint_locality attribute
 
+type inductive_namespace = Proper | Flat | Both
+val proper_namespace : inductive_namespace attribute
+
 (** Enable/Disable universe checking *)
 val typing_flags : Declarations.typing_flags option attribute
 

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -638,7 +638,7 @@ type uniform_inductive_flag =
   | UniformParameters
   | NonUniformParameters
 
-let do_mutual_inductive ~template udecl indl ~cumulative ~poly ?typing_flags ~private_ind ~uniform finite =
+let do_mutual_inductive ~template ~namespace udecl indl ~cumulative ~poly ?typing_flags ~private_ind ~uniform finite =
   let (params,indl),coes,ntns = extract_mutual_inductive_declaration_components indl in
   let ntns = List.map Metasyntax.prepare_where_notation ntns in
   (* Interpret the types *)
@@ -660,7 +660,7 @@ let do_mutual_inductive ~template udecl indl ~cumulative ~poly ?typing_flags ~pr
   (* Declare the global universes *)
   DeclareUctx.declare_universe_context ~poly:false ctx;
   (* Declare the mutual inductive block with its associated schemes *)
-  ignore (DeclareInd.declare_mutual_inductive_with_eliminations ?typing_flags mie binders impls);
+  ignore (DeclareInd.declare_mutual_inductive_with_eliminations ~namespace ?typing_flags mie binders impls);
   (* Declare the possible notations of inductive types *)
   List.iter (Metasyntax.add_notation_interpretation ~local:false (Global.env ())) ntns;
   (* Declare the coercions *)

--- a/vernac/comInductive.mli
+++ b/vernac/comInductive.mli
@@ -22,6 +22,7 @@ type uniform_inductive_flag =
 
 val do_mutual_inductive
   :  template:bool option
+  -> namespace:Attributes.inductive_namespace
   -> cumul_univ_decl_expr option
   -> (one_inductive_expr * decl_notation list) list
   -> cumulative:bool

--- a/vernac/declareInd.mli
+++ b/vernac/declareInd.mli
@@ -18,6 +18,7 @@ type one_inductive_impls =
 val declare_mutual_inductive_with_eliminations
   : ?primitive_expected:bool
   -> ?typing_flags:Declarations.typing_flags
+  -> namespace:Attributes.inductive_namespace
   -> Entries.mutual_inductive_entry
   -> UState.named_universes_entry
   -> one_inductive_impls list

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -547,7 +547,7 @@ let data_name { Data.id; Data.rdata; _ } =
   - prepares and declares the corresponding record projections, mainly taken care of by
     [declare_projections]
 *)
-let declare_structure ~cumulative finite ~univs ~variances ~primitive_proj
+let declare_structure ~cumulative ~namespace finite ~univs ~variances ~primitive_proj
   paramimpls params template ?(kind=Decls.StructureComponent) ?name (record_data : Data.t list) =
   let nparams = List.length params in
   let (univs, ubinders) = univs in
@@ -600,7 +600,7 @@ let declare_structure ~cumulative finite ~univs ~variances ~primitive_proj
     }
   in
   let impls = List.map (fun _ -> paramimpls, []) record_data in
-  let kn = DeclareInd.declare_mutual_inductive_with_eliminations mie globnames impls
+  let kn = DeclareInd.declare_mutual_inductive_with_eliminations ~namespace mie globnames impls
       ~primitive_expected:primitive_proj
   in
   let map i { Data.is_coercion; coers; rdata = { DataR.implfs; fields; _}; _ } =
@@ -656,7 +656,7 @@ let build_class_constant ~univs ~rdata ~primitive_proj field implfs params param
   } in
   [cref, [m]]
 
-let build_record_constant ~rdata ~univs ~variances ~cumulative ~template ~primitive_proj
+let build_record_constant ~rdata ~univs ~variances ~cumulative ~template ~namespace ~primitive_proj
     fields params paramimpls coers id idbuild binder_name =
   let record_data =
     { Data.id
@@ -665,7 +665,7 @@ let build_record_constant ~rdata ~univs ~variances ~cumulative ~template ~primit
     ; coers = List.map (fun _ -> { pf_subclass = false ; pf_canonical = true }) fields
     ; rdata
     } in
-  let inds = declare_structure ~cumulative Declarations.BiFinite ~univs ~variances ~primitive_proj paramimpls
+  let inds = declare_structure ~cumulative ~namespace Declarations.BiFinite ~univs ~variances ~primitive_proj paramimpls
       params template ~kind:Decls.Method ~name:[|binder_name|] [record_data]
   in
   let map ind =
@@ -701,7 +701,7 @@ let build_record_constant ~rdata ~univs ~variances ~cumulative ~template ~primit
   2. declare the class, using the information from 1. in the form of [Classes.typeclass]
 
   *)
-let declare_class def ~cumulative ~univs ~variances ~primitive_proj id idbuild paramimpls params
+let declare_class def ~cumulative ~namespace ~univs ~variances ~primitive_proj id idbuild paramimpls params
     rdata template ?(kind=Decls.StructureComponent) coers =
   let implfs =
     (* Make the class implicit in the projections, and the params if applicable. *)
@@ -718,7 +718,7 @@ let declare_class def ~cumulative ~univs ~variances ~primitive_proj id idbuild p
       let binder = {binder with binder_name=Name binder_name} in
       build_class_constant ~rdata ~univs ~primitive_proj field implfs params paramimpls coers binder id proj_name
     | _ ->
-      build_record_constant ~rdata ~univs ~variances ~cumulative ~template ~primitive_proj
+      build_record_constant ~rdata ~univs ~variances ~cumulative ~template ~namespace ~primitive_proj
         fields params paramimpls coers id idbuild binder_name
   in
   let univs, params, fields =
@@ -860,7 +860,7 @@ let extract_record_data records =
   ps, data
 
 (* declaring structures, common data to refactor *)
-let class_struture ~cumulative ~template ~impargs ~univs ~params ~primitive_proj def records data =
+let class_struture ~cumulative ~template ~namespace ~impargs ~univs ~params ~primitive_proj def records data =
   let { Ast.name; cfs; idbuild; _ }, rdata = match records, data with
     | [r], [d] -> r, d
     | _, _ ->
@@ -872,10 +872,10 @@ let class_struture ~cumulative ~template ~impargs ~univs ~params ~primitive_proj
       | Vernacexpr.NoInstance -> None)
       cfs
   in
-  declare_class def ~cumulative ~univs ~primitive_proj name.CAst.v idbuild
+  declare_class def ~cumulative ~namespace ~univs ~primitive_proj name.CAst.v idbuild
     impargs params rdata template coers
 
-let regular_structure ~cumulative ~template ~impargs ~univs ~variances ~params ~finite ~primitive_proj
+let regular_structure ~cumulative ~namespace ~template ~impargs ~univs ~variances ~params ~finite ~primitive_proj
     records data =
   let adjust_impls impls = impargs @ [CAst.make None] @ impls in
   let data = List.map (fun ({ DataR.implfs; _ } as d) -> { d with DataR.implfs = List.map adjust_impls implfs }) data in
@@ -890,7 +890,7 @@ let regular_structure ~cumulative ~template ~impargs ~univs ~variances ~params ~
     { Data.id = name.CAst.v; idbuild; rdata; is_coercion; coers }
   in
   let data = List.map2 map data records in
-  let inds = declare_structure ~cumulative finite ~univs ~variances ~primitive_proj
+  let inds = declare_structure ~cumulative ~namespace finite ~univs ~variances ~primitive_proj
       impargs params template data
   in
   List.map (fun ind -> GlobRef.IndRef ind) inds
@@ -898,7 +898,7 @@ let regular_structure ~cumulative ~template ~impargs ~univs ~variances ~params ~
 (** [fs] corresponds to fields and [ps] to parameters; [coers] is a
     list telling if the corresponding fields must me declared as coercions
     or subinstances. *)
-let definition_structure udecl kind ~template ~cumulative ~poly ~primitive_proj
+let definition_structure udecl kind ~template ~namespace ~cumulative ~poly ~primitive_proj
     finite (records : Ast.t list) : GlobRef.t list =
   let () = check_unique_names records in
   let () = check_priorities kind records in
@@ -915,10 +915,10 @@ let definition_structure udecl kind ~template ~cumulative ~poly ~primitive_proj
   let template = template, auto_template in
   match kind with
   | Class def ->
-    class_struture ~template ~impargs ~cumulative ~params ~univs ~variances ~primitive_proj
+    class_struture ~template ~namespace ~impargs ~cumulative ~params ~univs ~variances ~primitive_proj
       def records data
   | Inductive_kw | CoInductive | Variant | Record | Structure ->
-    regular_structure ~cumulative ~template ~impargs ~univs ~variances ~params ~finite ~primitive_proj
+    regular_structure ~cumulative ~template ~namespace ~impargs ~univs ~variances ~params ~finite ~primitive_proj
       records data
 
 module Internal = struct

--- a/vernac/record.mli
+++ b/vernac/record.mli
@@ -28,6 +28,7 @@ val definition_structure
   :  cumul_univ_decl_expr option
   -> inductive_kind
   -> template:bool option
+  -> namespace:Attributes.inductive_namespace
   -> cumulative:bool
   -> poly:bool
   -> primitive_proj:bool


### PR DESCRIPTION
**Kind:** feature

This is an experiment in declaring constructors of inductive types in a sub-namespace named after the name of the inductive type. Example:
```
#[namespace=proper]
Inductive foo := bar :  foo' -> foo with foo' := bar' : foo -> foo'.
Locate bar.
(* Constructor Top.foo.bar (shorter name to refer to it in current context is foo.bar) *)
Locate bar'.
(* Constructor Top.foo'.bar' (shorter name to refer to it in current context is foo'.bar') *)
```

Alternative values for the attribute are `flat` (current mode), and `both` (made to be the default in the PR).

Possible extensions: do the same for projections and elimination schemes.

- [ ] Added / updated test-suite
- [ ] Corresponding documentation was added / updated
- [ ] Entry added in the changelog
