### PR TITLE
Fixes the kernel name comparison used when deactivating notations

### DIFF
--- a/doc/changelog/03-notations/14493-master+fix14486-part-wrong-eq-kn-notation.rst
+++ b/doc/changelog/03-notations/14493-master+fix14486-part-wrong-eq-kn-notation.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Useless self reference when printing abbreviations declared in nested modules
+  (`#14493 <https://github.com/coq/coq/pull/14493>`_,
+  fixes one part of `#12777 <https://github.com/coq/coq/issues/12777>`_
+  and `#14486 <https://github.com/coq/coq/issues/14486>`_,
+  by Hugo Herbelin).

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -97,7 +97,11 @@ let is_reserved_type na t =
 (* Turning notations and scopes on and off for printing *)
 module IRuleSet = Set.Make(struct
     type t = interp_rule
-    let compare x y = compare x y
+    let compare x y = match x, y with
+      | SynDefRule kn, SynDefRule kn' -> KerName.compare kn kn'
+      | NotationRule (scope,ntn), NotationRule (scope',ntn') -> compare x y
+      | SynDefRule _, NotationRule _ -> -1
+      | NotationRule _, SynDefRule _ -> 1
   end)
 
 let inactive_notations_table =

--- a/test-suite/output/bug_12777.out
+++ b/test-suite/output/bug_12777.out
@@ -1,0 +1,1 @@
+Notation tt' := tt

--- a/test-suite/output/bug_12777.v
+++ b/test-suite/output/bug_12777.v
@@ -1,0 +1,7 @@
+Module Import M1.
+Module Export M2.
+Notation tt' := tt.
+End M2.
+End M1.
+
+Print tt'.


### PR DESCRIPTION
**Kind:** bug fix

Kernel names use a sordid® hask key which breaks the naive comparison of kernel names, with the debugger printer not showing it (can we make the debugger print it?).

Using a home-made comparison function allow to fix the issue reported in [#12777](https://github.com/coq/coq/issues/12777#issuecomment-763918324) and presumably also #14486.

- [X] Added / updated test-suite
- [x] Entry added in the changelog