### PR TITLE
Use arguments renaming for variables in Typing

### DIFF
--- a/doc/changelog/02-specification-language/14498-typing-rename.rst
+++ b/doc/changelog/02-specification-language/14498-typing-rename.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Argument renaming works more consistently on section variables
+  (`#14498 <https://github.com/coq/coq/pull/14498>`_,
+  by Gaëtan Gilbert).
+  This may cause issues when a variable with renamed arguments is cleared and its name is reused by a proof variable.

--- a/pretyping/arguments_renaming.ml
+++ b/pretyping/arguments_renaming.ml
@@ -100,6 +100,10 @@ let rename_type_of_constructor env cstruct =
   let ty = Inductiveops.type_of_constructor env cstruct in
   rename_type ty (GlobRef.ConstructRef (fst cstruct))
 
+let rename_type_of_variable env id =
+  let ty = Typeops.type_of_variable env id in
+  rename_type ty (GlobRef.VarRef id)
+
 let rename_typing env c =
   let j = Typeops.infer env c in
   let j' =
@@ -107,6 +111,7 @@ let rename_typing env c =
     | Const (c,u) -> { j with uj_type = rename_type j.uj_type (GlobRef.ConstRef c) }
     | Ind (i,u) -> { j with uj_type = rename_type j.uj_type (GlobRef.IndRef i) }
     | Construct (k,u) -> { j with uj_type = rename_type j.uj_type (GlobRef.ConstructRef k) }
+    | Var id -> { j with uj_type = rename_type j.uj_type (GlobRef.VarRef id) }
     | _ -> j
   in j'
 

--- a/pretyping/arguments_renaming.mli
+++ b/pretyping/arguments_renaming.mli
@@ -22,4 +22,5 @@ val rename_type : types -> GlobRef.t -> types
 val rename_type_of_constant : env -> pconstant -> types
 val rename_type_of_inductive : env -> pinductive -> types
 val rename_type_of_constructor : env -> pconstructor -> types
+val rename_type_of_variable : env -> Id.t -> types
 val rename_typing : env -> constr -> unsafe_judgment

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -250,10 +250,11 @@ let judge_of_relative env v =
   Environ.on_judgment EConstr.of_constr (judge_of_relative env v)
 
 let type_of_variable env id =
-  EConstr.of_constr (type_of_variable env id)
+  EConstr.of_constr (rename_type_of_variable env id)
 
 let judge_of_variable env id =
-  Environ.on_judgment EConstr.of_constr (judge_of_variable env id)
+  Environ.on_judgment EConstr.of_constr
+    (rename_typing env (Constr.mkVar id))
 
 let judge_of_projection env sigma p cj =
   let pty = lookup_projection p env in

--- a/test-suite/output/Arguments_renaming.out
+++ b/test-suite/output/Arguments_renaming.out
@@ -103,3 +103,5 @@ The command has indeed failed with message:
 Extra arguments: y.
 The command has indeed failed with message:
 Flag "rename" expected to rename A into R.
+someVar
+     : forall Q : Type, Q

--- a/test-suite/output/Arguments_renaming.v
+++ b/test-suite/output/Arguments_renaming.v
@@ -52,3 +52,9 @@ Fail Arguments eq {A} x [_] : rename.
 Fail Arguments eq {A} x [z] : rename.
 Fail Arguments eq {F} x z y.
 Fail Arguments eq {R} s t.
+
+Section RenameVar.
+  Variable someVar : forall P, P.
+  Arguments someVar Q : rename.
+  Check someVar.
+End RenameVar.


### PR DESCRIPTION
Alternatively maybe we should forbid renaming arguments of variables,
it seems dangerous since confusion between section and proof variables
is possible.