### PR TITLE
[install] [configure] Remove unused variables, notes about install location

### DIFF
--- a/Makefile.install
+++ b/Makefile.install
@@ -56,6 +56,13 @@ install-dune: $(BCONTEXT)/coq-core.install $(BCONTEXT)/coqide-server.install
 	dune install --display quiet $(DESTDIRARG) --mandir="$(MANDIR)" --prefix="$(COQPREFIX)" coq-core
 	dune install --display quiet $(DESTDIRARG) --mandir="$(MANDIR)" --prefix="$(COQPREFIX)" coqide-server
 
+# IMPORTANT NOTE: before Dune 2.9, the --docdir and --etcdir options
+# were not supported, if you are using Dune >= 2.9, you can add
+#
+# --etcdir=$(CONFIGDIR) --docdir=$(DOCDIR) , additionally, you can also add
+# --libdir=$(COQLIBINSTALL) if required by your distribution, but we recommend
+# using the default.
+
 install-coq: install-dune install-library
 
 # This used to be overriden to fix very old bugs with install

--- a/Makefile.install
+++ b/Makefile.install
@@ -51,17 +51,25 @@ endif
 # Debian's FHS, an opam-built dune will differ and follow OPAM's layout.
 #
 # We ought to improve this, as of today the case of an opam-built dune
-# installing to a global prefix such as /usr/local/ may not follow the FHS
+# installing to a global prefix such as /usr/local/ may not follow the FHS.
+# For now, we respect the values given at configure's time.
+ifdef DUNE_29_PLUS
+install-dune: $(BCONTEXT)/coq-core.install $(BCONTEXT)/coqide-server.install
+	dune install --display quiet $(DESTDIRARG) --mandir="$(MANDIR)" --prefix="$(COQPREFIX)" --etcdir="$(CONFIGDIR)" --docdir="$(DOCDIR)" coq-core
+	dune install --display quiet $(DESTDIRARG) --mandir="$(MANDIR)" --prefix="$(COQPREFIX)" --etcdir="$(CONFIGDIR)" --docdir="$(DOCDIR)" coqide-server
+else
 install-dune: $(BCONTEXT)/coq-core.install $(BCONTEXT)/coqide-server.install
 	dune install --display quiet $(DESTDIRARG) --mandir="$(MANDIR)" --prefix="$(COQPREFIX)" coq-core
 	dune install --display quiet $(DESTDIRARG) --mandir="$(MANDIR)" --prefix="$(COQPREFIX)" coqide-server
+endif
 
 # IMPORTANT NOTE: before Dune 2.9, the --docdir and --etcdir options
-# were not supported, if you are using Dune >= 2.9, you can add
+# were not supported, if you are using Dune >= 2.9, you can use `make
+# DUNE_29_PLUS=1 install` to use the call with the right options.
 #
-# --etcdir=$(CONFIGDIR) --docdir=$(DOCDIR) , additionally, you can also add
-# --libdir=$(COQLIBINSTALL) if required by your distribution, but we recommend
-# using the default.
+# Additionally, you can also add --libdir=$(COQLIBINSTALL) if required
+# by your distribution, but we recommend using the default configured
+# with Dune.
 
 install-coq: install-dune install-library
 

--- a/Makefile.install
+++ b/Makefile.install
@@ -16,9 +16,9 @@
 # by dependencies between rules, so do *not* try overly clever things like
 # 'make world install' in one unique command
 
-ifeq ($(COQPREFIX),local)
+ifeq ($(COQ_INSTALL_ENABLED),false)
 install:
-	@echo "Prefix not set in configure, nothing to install."
+	@echo "Working on devel mode, nothing to install."
 else
 install: install-coq install-coqide install-doc-$(WITHDOC)
 endif

--- a/dev/doc/INSTALL.make.md
+++ b/dev/doc/INSTALL.make.md
@@ -34,9 +34,6 @@ please see the [contributing guide](../../CONTRIBUTING.md).
      Binaries, library, and man pages will be respectively
      installed in `<dir>/bin`, `<dir>/lib/coq`, and `<dir>/man`
 
-   * `-bindir <dir>`                   (default: `/usr/local/bin`)
-     Directory where the binaries will be installed
-
    * `-libdir <dir>`                   (default: `/usr/local/lib/coq`)
      Directory where the Coq standard library will be installed
 
@@ -118,6 +115,19 @@ please see the [contributing guide](../../CONTRIBUTING.md).
 7. You can now clean all the sources. (You can even erase them.)
 
         make clean
+
+Notes for packagers
+-------------------
+
+The `make install` target for Coq's OCaml parts calls `dune
+install` internally. Before Dune 2.9, `dune install` didn't support
+configuring some installation paths such as `-docdir` and
+`-configdir`, thus these configure options were ignored by default.
+
+For Dune >= 2.9, we recommend patching `Makefile.install` so these
+options are taken into account. For Dune < 2.9, you may have to
+post-process your package to fix install locations. See
+`Makefile.install` `install-dune` target for more information.
 
 Installation Procedure For Plugin Developers.
 ---------------------------------------------

--- a/dev/doc/INSTALL.make.md
+++ b/dev/doc/INSTALL.make.md
@@ -124,9 +124,9 @@ install` internally. Before Dune 2.9, `dune install` didn't support
 configuring some installation paths such as `-docdir` and
 `-configdir`, thus these configure options were ignored by default.
 
-For Dune >= 2.9, we recommend patching `Makefile.install` so these
-options are taken into account. For Dune < 2.9, you may have to
-post-process your package to fix install locations. See
+For Dune >= 2.9, we defining the `DUNE_29_PLUS` variable so these
+options are taken into account by Coq's Makefile. For Dune < 2.9, you
+may have to post-process your package to fix install locations. See
 `Makefile.install` `install-dune` target for more information.
 
 Installation Procedure For Plugin Developers.

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -31,9 +31,6 @@ COQ_SRC_DIR:=..
 
 ifneq ($(wildcard ../_build/default/config/Makefile),)
 include ../_build/default/config/Makefile
-ifeq ($(COQPREFIX),local)
-COQPREFIX:=$(shell cd ../_build/install/default/ ;pwd)
-endif
 endif
 
 #######################################################################
@@ -51,13 +48,6 @@ ifeq ($(ARCH),win32)
   export FINDLIB_SEP=;
 else
   export FINDLIB_SEP=:
-endif
-
-# Be careful to use COQPREFIX when prefix is not set
-# this assumes we're running inside dune, ie pwd=_build/default/test-suite
-# is this assumption correct?
-ifeq ($(COQPREFIX),local)
-	COQPREFIX:=$(shell cd ../..;pwd)/install/default/
 endif
 
 # The $(shell echo) trick is necessary due to configure quoting

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -60,8 +60,10 @@ ifeq ($(COQPREFIX),local)
 	COQPREFIX:=$(shell cd ../..;pwd)/install/default/
 endif
 
+# The $(shell echo) trick is necessary due to configure quoting
+# filenames, still, this issue is tricky when paths contain spaces
 export OCAMLPATH := $(shell echo $(COQPREFIX)/lib$(FINDLIB_SEP)$$OCAMLPATH)
-export CAML_LD_LIBRARY_PATH:=$(COQPREFIX)/lib/stublibs:$(CAML_LD_LIBRARY_PATH)
+export CAML_LD_LIBRARY_PATH:=$(shell echo $(COQPREFIX)/lib/stublibs):$(CAML_LD_LIBRARY_PATH)
 
 # COQLIB is an env variable so no quotes
 COQLIB?=

--- a/tools/configure/configure.ml
+++ b/tools/configure/configure.ml
@@ -840,6 +840,8 @@ type path_style =
   | Relative of string (* Should not start with a "/" *)
 
 let install = [
+  "COQPREFIX", "Coq", prefs.prefix,
+    Relative "", Relative "";
   "COQLIBINSTALL", "the Coq library", prefs.libdir,
     Relative "lib", Relative "lib/coq";
   "CONFIGDIR", "the Coqide configuration files", prefs.configdir,
@@ -1149,7 +1151,6 @@ let write_makefile f =
   List.iter (fun (v,msg,_,_) -> pr "# %s: path for %s\n" v msg) install_dirs;
   List.iter (fun (v,_,dir,_) -> pr "%s=%S\n" v dir) install_dirs;
   pr "\n# Coq version\n";
-  pr "COQPREFIX=%s\n" ((function None -> "local" | Some v -> v) prefs.prefix);
   pr "VERSION=%s\n" coq_version;
   pr "# Objective-Caml compile command\n";
   pr "OCAML=%S\n" camlexec.top;

--- a/tools/configure/configure.ml
+++ b/tools/configure/configure.ml
@@ -228,6 +228,7 @@ type preferences = {
   force_findlib_version : bool;
   warn_error : bool;
   dune_profile : string;
+  install_enabled : bool;
 }
 
 module Profiles = struct
@@ -264,6 +265,7 @@ let default = {
   force_findlib_version = false;
   warn_error = false;
   dune_profile = "release";
+  install_enabled = true;
 }
 
 let devel state = { state with
@@ -274,7 +276,9 @@ let devel state = { state with
   interactive = false;
   output_summary = true;
   prefix = Some (Filename.concat (Sys.getcwd ()) "_build_vo/default");
+  install_enabled = false;
 }
+
 let devel_doc = "-annot -bin-annot -warn-error yes"
 
 let get = function
@@ -1213,6 +1217,7 @@ let write_makefile f =
   pr "NATIVECOMPUTE=%s\n" (if prefs.nativecompiler = NativeYes then "-native-compiler yes" else "");
   pr "COQWARNERROR=%s\n" (if prefs.warn_error then "-w +default" else "");
   pr "CONFIGURE_DPROFILE=%s\n" prefs.dune_profile;
+  pr "COQ_INSTALL_ENABLED=%b\n" prefs.install_enabled;
   close_out o;
   Unix.chmod f 0o444
 

--- a/tools/configure/configure.ml
+++ b/tools/configure/configure.ml
@@ -203,13 +203,11 @@ type preferences = {
   output_summary : bool;
   vmbyteflags : string option;
   custom : bool option;
-  bindir : string option;
   libdir : string option;
   configdir : string option;
   datadir : string option;
   mandir : string option;
   docdir : string option;
-  coqdocdir : string option;
   ocamlfindcmd : string option;
   arch : string option;
   natdynlink : bool;
@@ -240,13 +238,11 @@ let default = {
   output_summary = true;
   vmbyteflags = None;
   custom = None;
-  bindir = None;
   libdir = None;
   configdir = None;
   datadir = None;
   mandir = None;
   docdir = None;
-  coqdocdir = None;
   ocamlfindcmd = None;
   arch = None;
   natdynlink = true;
@@ -344,6 +340,11 @@ let check_absolute = function
     else ()
 
 let local_warning () = warn "-local option is deprecated, and equivalent to -profile devel"
+let bindir_warning () = warn "-bindir option is deprecated, Coq will now unconditionally use $prefix/bin"
+let coqdocdir_warning () = warn "-coqdordir option is deprecated, Coq will now unconditionally use $datadir/texmf/tex/latex/misc/ to install coqdoc sty files"
+
+let docdir_warning () = warn "-docdir has no effect in configure, see dev/doc/INSTALL.make.md for more details"
+let configdir_warning () = warn "-configdir has no effect in configure, see dev/doc/INSTALL.make.md for more details"
 
 let args_options = Arg.align [
   "-prefix", arg_string_option (fun p prefix -> check_absolute prefix; { p with prefix }),
@@ -357,20 +358,20 @@ let args_options = Arg.align [
     " Build bytecode executables with -custom (not recommended)";
   "-no-custom", arg_clear_option (fun p custom -> { p with custom }),
     " Do not build with -custom on Windows and MacOS";
-  "-bindir", arg_string_option (fun p bindir -> { p with bindir }),
-    "<dir> Where to install bin files";
+  "-bindir", arg_string_option (fun p _ -> bindir_warning (); p ),
+    "deprecated option, Coq will now unconditionally use $prefix/bin";
   "-libdir", arg_string_option (fun p libdir -> { p with libdir }),
     "<dir> Where to install lib files";
-  "-configdir", arg_string_option (fun p configdir -> { p with configdir }),
+  "-configdir", arg_string_option (fun p configdir -> configdir_warning (); { p with configdir }),
     "<dir> Where to install config files";
   "-datadir", arg_string_option (fun p datadir -> { p with datadir }),
     "<dir> Where to install data files";
   "-mandir", arg_string_option (fun p mandir -> { p with mandir }),
     "<dir> Where to install man files";
-  "-docdir", arg_string_option (fun p docdir -> { p with docdir }),
+  "-docdir", arg_string_option (fun p docdir -> docdir_warning (); { p with docdir }),
     "<dir> Where to install doc files";
-  "-coqdocdir", arg_string_option (fun p coqdocdir -> { p with coqdocdir }),
-    "<dir> Where to install Coqdoc style files";
+  "-coqdocdir", arg_string_option (fun p _ -> coqdocdir_warning (); p),
+    "deprecated option, Coq will now unconditionally use $datadir/texmf/tex/latex/misc/ to install coqdoc sty files";
   "-ocamlfind", arg_string_option (fun p ocamlfindcmd -> { p with ocamlfindcmd }),
     "<dir> Specifies the ocamlfind command to use";
   "-flambda-opts", arg_string_list ' ' (fun p flambda_flags -> { p with flambda_flags }),
@@ -839,8 +840,6 @@ type path_style =
   | Relative of string (* Should not start with a "/" *)
 
 let install = [
-  "BINDIR", "the Coq binaries", prefs.bindir,
-    Relative "bin", Relative "bin";
   "COQLIBINSTALL", "the Coq library", prefs.libdir,
     Relative "lib", Relative "lib/coq";
   "CONFIGDIR", "the Coqide configuration files", prefs.configdir,
@@ -851,8 +850,6 @@ let install = [
     Relative "man", Relative "share/man";
   "DOCDIR", "the Coq documentation", prefs.docdir,
     Relative "doc", Relative "share/doc/coq";
-  "COQDOCDIR", "the Coqdoc LaTeX files", prefs.coqdocdir,
-    Relative "latex", Relative "share/texmf/tex/latex/misc";
  ]
 
 let strip_trailing_slash_if_any p =

--- a/tools/configure/configure.ml
+++ b/tools/configure/configure.ml
@@ -343,8 +343,8 @@ let local_warning () = warn "-local option is deprecated, and equivalent to -pro
 let bindir_warning () = warn "-bindir option is deprecated, Coq will now unconditionally use $prefix/bin"
 let coqdocdir_warning () = warn "-coqdordir option is deprecated, Coq will now unconditionally use $datadir/texmf/tex/latex/misc/ to install coqdoc sty files"
 
-let docdir_warning () = warn "-docdir has no effect in configure, see dev/doc/INSTALL.make.md for more details"
-let configdir_warning () = warn "-configdir has no effect in configure, see dev/doc/INSTALL.make.md for more details"
+let docdir_warning () = warn "-docdir will only have effect if using Dune >= 2.9 and setting the DUNE_29_PLUS variable, see dev/doc/INSTALL.make.md for more details"
+let configdir_warning () = warn "-configdir will only have effect if using Dune >= 2.9 and setting the DUNE_29_PLUS variable, see dev/doc/INSTALL.make.md for more details"
 
 let args_options = Arg.align [
   "-prefix", arg_string_option (fun p prefix -> check_absolute prefix; { p with prefix }),


### PR DESCRIPTION
Since the Dune transition, Coq delegates the install of the OCaml
files to the `dune install` command.

The philosophy of `dune install` is to set the installation paths when
building dune at once, so all software using Dune do get correct defaults.

Coq still supports overriding install locations at configure time, but
unfortunately, `dune install` in versions < 2.9 didn't have enough
flexibility as to cover all use cases.

We thus document this problem, and remove two configuration variables
which seem unnecessary for all distribution use cases, `bindir` and
`coqdocdir`, which were already unused but kept in `configure`.

For the `coqdocdir` option, we rely on `datadir` + standard latex
layout, for `bindir` we make it `$prefix/bin`.

We additionally handle COQPREFIX as a regular directory.

Fixes #14232 , fixes #14468
