### PR TITLE
[build] [compat] Declare coq.kernel as a compat library for 8.14

### DIFF
--- a/kernel/dune
+++ b/kernel/dune
@@ -32,3 +32,7 @@
 (env
  (dev (flags :standard -w +a-4-44-50)))
  ; (ocaml408 (flags :standard -w +a-3-4-44-50)))
+
+(deprecated_library_name
+ (old_public_name coq.kernel)
+ (new_public_name coq-core.kernel))


### PR DESCRIPTION
After a bit of discussion we decided to keep this alias for now, as
there is some tooling that uses `ocamlfind coq.kernel` to pass the
correct paths to the native compiler, and that renaming breaks it in a
way that it is not easy to update.
