### PR TITLE
[build] [vm] Fix flags declaration in dune file.

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -5,6 +5,10 @@
 (formatting
  (enabled_for ocaml))
 
+; See discussion in https://github.com/coq/coq/pull/14519
+; we handle our CC flags at the low-level ourselves
+(use_standard_c_and_cxx_flags true)
+
 ; After Dune 2.8 we can use this, but let's wait for the build consolidation PR
 ; (generate_opam_files true)
 

--- a/kernel/byterun/dune
+++ b/kernel/byterun/dune
@@ -5,7 +5,7 @@
  (foreign_stubs
   (language c)
   (names coq_fix_code coq_float64 coq_memory coq_values coq_interp)
-  (flags :standard (:include %{project_root}/config/dune.c_flags))))
+  (flags -fPIC (:include %{project_root}/config/dune.c_flags))))
 
 (rule
  (targets coq_instruct.h)


### PR DESCRIPTION
Before Dune 2.7, Dune was implicitly adding the `:standard` set of
variables to our CC invocation for `kernel/byterun`.

This set is `-O2 -fno-strict-aliasing -fwrapv -fPIC`, but after
discussion we want to make it only `-fPIC` and control the rest
ourselves with the genearation of `config/dune.c_flags`


