### PR TITLE
Deprecate the new auto tactic.

### DIFF
--- a/doc/sphinx/changes.rst
+++ b/doc/sphinx/changes.rst
@@ -199,6 +199,10 @@ Tactics
 - **Deprecated:**
   The micromega option :flag:`Simplex`, which is currently set by default
   (`#13781 <https://github.com/coq/coq/pull/13781>`_, by Frédéric Besson).
+- **Deprecated:**
+  the undocumented `new auto` tactic
+  (`#14528 <https://github.com/coq/coq/pull/14528>`_,
+  by Pierre-Marie Pédrot).
 - **Added:**
   :tacn:`lia` supports the boolean operator `Bool.implb` (`#13715 <https://github.com/coq/coq/pull/13715>`_, by Frédéric Besson).
 - **Added:**

--- a/plugins/ltac/g_auto.mlg
+++ b/plugins/ltac/g_auto.mlg
@@ -136,7 +136,7 @@ TACTIC EXTEND eauto
       Eauto.gen_eauto (Eauto.make_dimension n p) (eval_uconstrs ist lems) db }
 END
 
-TACTIC EXTEND new_eauto (* todo: name doesn't match syntax *)
+TACTIC EXTEND new_eauto (* todo: name doesn't match syntax *) DEPRECATED { Deprecation.make () }
 | [ "new" "auto" nat_or_var_opt(n) auto_using(lems)
     hintbases(db) ] ->
     { match db with

--- a/user-contrib/Ltac2/Notations.v
+++ b/user-contrib/Ltac2/Notations.v
@@ -565,14 +565,20 @@ Ltac2 Notation "auto" n(opt(tactic(0)))
 
 Ltac2 Notation auto := auto.
 
+Set Warnings "-deprecated-ltac2-definition".
+
+#[deprecated(since="8.14")]
 Ltac2 new_eauto0 n use dbs :=
   let dbs := default_db dbs in
   let use := default_list use in
   Std.new_auto Std.Off n use dbs.
 
+#[deprecated(since="8.14")]
 Ltac2 Notation "new" "auto" n(opt(tactic(0)))
   use(opt(seq("using", list1(thunk(constr), ","))))
   dbs(opt(seq("with", hintdb))) := new_eauto0 n use dbs.
+
+Set Warnings "deprecated-ltac2-definition".
 
 Ltac2 eauto0 n p use dbs :=
   let dbs := default_db dbs in

--- a/user-contrib/Ltac2/Std.v
+++ b/user-contrib/Ltac2/Std.v
@@ -254,6 +254,7 @@ Ltac2 @ external trivial : debug -> (unit -> constr) list -> ident list option -
 
 Ltac2 @ external auto : debug -> int option -> (unit -> constr) list -> ident list option -> unit := "ltac2" "tac_auto".
 
+#[deprecated(since="8.14")]
 Ltac2 @ external new_auto : debug -> int option -> (unit -> constr) list -> ident list option -> unit := "ltac2" "tac_newauto".
 
 Ltac2 @ external eauto : debug -> int option -> int option -> (unit -> constr) list -> ident list option -> unit := "ltac2" "tac_eauto".


### PR DESCRIPTION
It was not documented and not used in the CI either. It seems to have been introduced by e961ace3 but never really took off. Since this is responsible for a big chunk of code in Auto, it looks like it is worthwhile to deprecate it in order to remove it as soon as possible.

- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
