### PR TITLE
Addressing coqdoc warnings in theories

### DIFF
--- a/theories/Logic/Berardi.v
+++ b/theories/Logic/Berardi.v
@@ -24,7 +24,8 @@
    number    = {3},
    pages     = {519-525}
 }
->> *)
+>>
+*)
 
 Set Implicit Arguments.
 

--- a/theories/Logic/SetoidChoice.v
+++ b/theories/Logic/SetoidChoice.v
@@ -25,7 +25,7 @@
   [[Carlström04]] Jesper Carlström, EM + Ext_ + AC_int is equivalent to
   AC_ext, Mathematical Logic Quaterly, vol 50(3), pp 236-240, 2004.
 
-  [[Martin-Löf05] Per Martin-Löf, 100 years of Zermelo’s axiom of
+  [[Martin-Löf05]] Per Martin-Löf, 100 years of Zermelo’s axiom of
   choice: what was the problem with it?, lecture notes for KTH/SU
   colloquium, 2005.
 


### PR DESCRIPTION
**Kind:** bug fix

In passing, fixing two warnings produced by `coqdoc` on `theories`.

Targetting 8.14 a priori but targetting 8.15 would be fine too.