### PR TITLE
Grammar engine does not locate itself the errors produced by right-hand side of grammar rules

### DIFF
--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -99,8 +99,8 @@ let mk_fix_tac (loc,id,bl,ann,ty) =
       | _, Some x ->
           let ids = List.map (fun x -> x.CAst.v) (List.flatten (List.map (fun (nal,_,_) -> nal) bl)) in
           (try List.index Names.Name.equal x.CAst.v ids
-          with Not_found -> user_err Pp.(str "No such fix variable."))
-      | _ -> user_err Pp.(str "Cannot guess decreasing argument of fix.") in
+          with Not_found -> user_err ~loc Pp.(str "No such fix variable."))
+      | _ -> user_err ~loc Pp.(str "Cannot guess decreasing argument of fix.") in
   let bl = List.map (fun (nal,bk,t) -> CLocalAssum (nal,bk,t)) bl in
   (id,n, CAst.make ~loc @@ CProdN(bl,ty))
 
@@ -163,7 +163,7 @@ let merge_occurrences loc cl = function
   | None ->
       if Locusops.clause_with_generic_occurrences cl then (None, cl)
       else
-        user_err ~loc  (str "Found an \"at\" clause without \"with\" clause.")
+        user_err ~loc (str "Found an \"at\" clause without \"with\" clause.")
   | Some (occs, p) ->
     let ans = match occs with
     | AllOccurrences -> cl
@@ -458,8 +458,8 @@ GRAMMAR EXTEND Gram
     [ [ "as"; ipat = or_and_intropattern_loc -> { Some ipat }
       | "as"; ipat = equality_intropattern ->
         { match ipat with
-          | IntroRewrite _ -> user_err Pp.(str "Disjunctive/conjunctive pattern expected.")
-          | IntroInjection _ -> user_err Pp.(strbrk "Found an injection pattern while a disjunctive/conjunctive pattern was expected; use " ++ str "\"injection as pattern\"" ++ strbrk " instead.")
+          | IntroRewrite _ -> user_err ~loc Pp.(str "Disjunctive/conjunctive pattern expected.")
+          | IntroInjection _ -> user_err ~loc Pp.(strbrk "Found an injection pattern while a disjunctive/conjunctive pattern was expected; use " ++ str "\"injection as pattern\"" ++ strbrk " instead.")
           | _ -> assert false }
       | -> { None } ] ]
   ;

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -446,8 +446,8 @@ GRAMMAR EXTEND Gram
       (match b with
           CLocalAssum(l,ty) -> (l,ty)
         | CLocalDef _ ->
-            Util.user_err_loc
-              (loc,"fix_param",Pp.str"defined binder not allowed here.")) ] ]
+            user_err ~loc
+              (Pp.str"defined binder not allowed here.")) ] ]
   ;
 *)
   (* ... with coercions *)
@@ -810,7 +810,7 @@ GRAMMAR EXTEND Gram
     | "("; items = LIST1 argument_spec; ")"; sc = OPT scope_delimiter ->
        { let f x = match sc, x with
          | None, x -> x | x, None -> Option.map (fun y -> CAst.make ~loc y) x
-         | Some _, Some _ -> user_err Pp.(str "scope declared twice") in
+         | Some _, Some _ -> user_err ~loc Pp.(str "scope declared twice") in
        List.map (fun (name,recarg_like,notation_scope) ->
            RealArg { name=name; recarg_like=recarg_like;
                  notation_scope=f notation_scope;
@@ -818,7 +818,7 @@ GRAMMAR EXTEND Gram
     | "["; items = LIST1 argument_spec; "]"; sc = OPT scope_delimiter ->
        { let f x = match sc, x with
          | None, x -> x | x, None -> Option.map (fun y -> CAst.make ~loc y) x
-         | Some _, Some _ -> user_err Pp.(str "scope declared twice") in
+         | Some _, Some _ -> user_err ~loc Pp.(str "scope declared twice") in
        List.map (fun (name,recarg_like,notation_scope) ->
            RealArg { name=name; recarg_like=recarg_like;
                  notation_scope=f notation_scope;
@@ -826,7 +826,7 @@ GRAMMAR EXTEND Gram
     | "{"; items = LIST1 argument_spec; "}"; sc = OPT scope_delimiter ->
        { let f x = match sc, x with
          | None, x -> x | x, None -> Option.map (fun y -> CAst.make ~loc y) x
-         | Some _, Some _ -> user_err Pp.(str "scope declared twice") in
+         | Some _, Some _ -> user_err ~loc Pp.(str "scope declared twice") in
        List.map (fun (name,recarg_like,notation_scope) ->
            RealArg { name=name; recarg_like=recarg_like;
                  notation_scope=f notation_scope;
@@ -984,7 +984,7 @@ GRAMMAR EXTEND Gram
           { PrintCustomGrammar ent }
       | IDENT "LoadPath"; dir = OPT dirpath -> { PrintLoadPath dir }
       | IDENT "Modules" ->
-          { user_err Pp.(str "Print Modules is obsolete; use Print Libraries instead") }
+          { user_err ~loc Pp.(str "Print Modules is obsolete; use Print Libraries instead") }
       | IDENT "Libraries" -> { PrintModules }
 
       | IDENT "ML"; IDENT "Path" -> { PrintMLLoadPath }


### PR DESCRIPTION
**Kind:** bug fix

Fixes / closes #14530

This PR gives what seems to be the final answer to a couple of preexisting unexpected behaviors revealed by the new abstraction level for streams with location in #14075:
  1. Ctrl-C was not properly located (it was causing the next command to fail)
  2. errors sent by the right-hand side of a grammar rule were located on the next token

- Issue 1 was realized in issue #14199 (after #14075 turned the existing issue into an anomaly)
  This was fixed in PR #14259 but to the price of less intuitive highlighting of errors in the middle of a sequence of symbols. The latter was observed in issue #14443 and fixed by PR #14444. 
- Issue 2 was realized in issue #14530 after #14075 (then again #14444 after #14259 hid it again) made it visible as an anomaly.

This PR completes the fixing of issue 1 by fixing issue 2 without falling in #14443.

E.g.:
- `Print Modules.` was previously failing and highlighting the `.`, it now highlights `Modules`.
- `Arguments id (A%type)%type.` was previously failing and highlighting the `.`, it now highlights `(A%type)%type`.

