### PR TITLE
Tweak the DebugFlag test.

### DIFF
--- a/test-suite/output/DebugFlags.out
+++ b/test-suite/output/DebugFlags.out
@@ -1,44 +1,6 @@
-File "./output/DebugFlags.v", line 1, characters 0-16:
-Warning: There is no debug flag "cbn". [unknown-debug-flag,option]
-Debug: [RAKAM] <<forall A : Type, A -> A -> Prop|>>
-Debug: [RAKAM] <><><><><>
-Debug: [RAKAM] <<forall A : Type, A -> A -> Prop|>>
-Debug: [RAKAM] <><><><><>
-Debug: [RAKAM] <<?A -> ?A -> Prop|>>
-Debug: [RAKAM] <><><><><>
-Debug: [RAKAM] <<?A -> ?A -> Prop|>>
-Debug: [RAKAM] <><><><><>
-Debug: [RAKAM] <<nat -> nat -> nat|>>
-Debug: [RAKAM] <><><><><>
-Debug: [RAKAM] <<nat -> nat -> nat|>>
-Debug: [RAKAM] <><><><><>
-Debug: [RAKAM] <<nat -> nat|>>
-Debug: [RAKAM] <><><><><>
-Debug: [RAKAM] <<nat -> nat|>>
-Debug: [RAKAM] <><><><><>
-Debug: [RAKAM] <<nat -> nat|>>
-Debug: [RAKAM] <><><><><>
-Debug: [RAKAM] <<nat -> nat|>>
-Debug: [RAKAM] <><><><><>
-Debug: [RAKAM] <<nat -> nat|>>
-Debug: [RAKAM] <><><><><>
-Debug: [RAKAM] <<nat -> nat|>>
-Debug: [RAKAM] <><><><><>
-Debug: [RAKAM] <<nat -> nat|>>
-Debug: [RAKAM] <><><><><>
-Debug: [RAKAM] <<nat -> nat|>>
-Debug: [RAKAM] <><><><><>
-Debug: [RAKAM] <<nat -> nat|>>
-Debug: [RAKAM] <><><><><>
-Debug: [RAKAM] <<nat -> nat|>>
-Debug: [RAKAM] <><><><><>
-Debug: [RAKAM] <<nat -> nat|>>
-Debug: [RAKAM] <><><><><>
-Debug: [RAKAM] <<nat -> nat|>>
-Debug: [RAKAM] <><><><><>
-Debug: [RAKAM] <<nat -> Prop|>>
-Debug: [RAKAM] <><><><><>
-Debug: [RAKAM] <<nat -> Prop|>>
-Debug: [RAKAM] <><><><><>
-2 + 3 = 0
-     : Prop
+File "./output/DebugFlags.v", line 1, characters 0-33:
+Warning: There is no debug flag "ThisFlagDoesNotExist".
+[unknown-debug-flag,option]
+Debug: [Cbv] Unfolding Coq.Init.Datatypes.id
+     = tt
+     : unit

--- a/test-suite/output/DebugFlags.v
+++ b/test-suite/output/DebugFlags.v
@@ -1,5 +1,5 @@
-Set Debug "cbn".
+Set Debug "ThisFlagDoesNotExist".
 
-Set Debug "RAKAM".
+Set Debug "Cbv".
 
-Check 2 + 3 = 0.
+Eval cbv in id tt.


### PR DESCRIPTION
We make explicit the fact that the first flag is not supposed to exist, and we do not rely on an implicit call to the RAKAM for the other output. This makes the test much more robust.

This makes the life of #14521 easier.