### PR TITLE
Do not link libraries in coqnative.

### DIFF
--- a/topbin/coqnative_bin.ml
+++ b/topbin/coqnative_bin.ml
@@ -114,9 +114,8 @@ let libraries_table : string DPmap.t ref = ref DPmap.empty
 let register_loaded_library senv libname file =
   let () = assert (not @@ DPmap.mem libname !libraries_table) in
   let () = libraries_table := DPmap.add libname file !libraries_table in
-  let dirname = Filename.dirname file in
-  let () = Nativelib.enable_library dirname libname in
-  let () = Nativelib.link_libraries () in
+  let prefix = Nativecode.mod_uid_of_dirpath libname ^ "." in
+  let () = Nativecode.register_native_file prefix in
   senv
 
 let mk_library sd f md digests univs =


### PR DESCRIPTION
This is not actually required since we never evaluate any native program. The only thing that the native compiler needs to correctly perform the compilation is the association dirpath → file prefix. We explictly register this instead of going through the linking phase.
