### PR TITLE
[build] Fix coqtop shim in byte mode.

### DIFF
--- a/dev/shim/dune
+++ b/dev/shim/dune
@@ -25,9 +25,33 @@
 (rule
  (targets coqbyte-prelude)
  (deps
+  %{project_root}/theories/Init/Prelude.vo
   %{bin:coqtop.byte}
-  %{lib:coq-core.kernel:../../stublibs/dllcoqrun_stubs.so}
-  %{project_root}/theories/Init/Prelude.vo)
+  %{lib:coq-core.config:config.cma}
+  %{lib:coq-core.clib:clib.cma}
+  %{lib:coq-core.lib:lib.cma}
+  %{lib:coq-core.kernel:kernel.cma}
+  %{lib:coq-core.vm:coqrun.cma}
+  %{lib:coq-core.vm:../../stublibs/dllcoqrun_stubs.so}
+  %{lib:coq-core.library:library.cma}
+  %{lib:coq-core.engine:engine.cma}
+  %{lib:coq-core.pretyping:pretyping.cma}
+  %{lib:coq-core.gramlib:gramlib.cma}
+  %{lib:coq-core.interp:interp.cma}
+  %{lib:coq-core.proofs:proofs.cma}
+  %{lib:coq-core.parsing:parsing.cma}
+  %{lib:coq-core.printing:printing.cma}
+  %{lib:coq-core.tactics:tactics.cma}
+  %{lib:coq-core.vernac:vernac.cma}
+  %{lib:coq-core.stm:stm.cma}
+  %{lib:coq-core.sysinit:sysinit.cma}
+  %{lib:coq-core.toplevel:toplevel.cma}
+  %{lib:coq-core.plugins.number_string_notation:number_string_notation_plugin.cma}
+  %{lib:coq-core.plugins.float_syntax:float_syntax_plugin.cma}
+  %{lib:coq-core.plugins.tauto:tauto_plugin.cma}
+  %{lib:coq-core.plugins.cc:cc_plugin.cma}
+  %{lib:coq-core.plugins.firstorder:firstorder_plugin.cma}
+  %{lib:coq-core.plugins.ltac:ltac_plugin.cma})
  (action
   (with-stdout-to %{targets}
    (progn


### PR DESCRIPTION
Indeed, depending on `Prelude.vo` is not enough as dune will use the
`coqc` native compiler so plugins will

Fixes #14543

The current setup remains messy tho, but there are two solutions
coming in dune 3.0 that will help to clean it up:

- dune 3.0 can use generated dune files without a problem, so we will
  actually generate the shims rules automatically, avoiding this problem

- moreover, `dune coqtop --byte --theories=Coq` will correctly track
  this, and in particular allow the choice of `coqc` or `coqc.native` to
  build the `Coq` theory.
