### PR TITLE
Slightly saner definition of Unification.subst_defined_metas_evars.

### DIFF
--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -619,8 +619,10 @@ let subst_defined_metas_evars sigma (bl,el) c =
     | Evar (evk,args) ->
       let eq c1 c2 = Constr.equal c1 (EConstr.Unsafe.to_constr c2) in
       let select (_,(evk',args'),_) = Evar.equal evk evk' && List.for_all2 eq args args' in
-      (try substrec (EConstr.Unsafe.to_constr (pi3 (List.find select el)))
-       with Not_found -> Constr.map substrec c)
+      begin match List.find select el with
+      | (_, _, c) -> substrec (EConstr.Unsafe.to_constr c)
+      | exception Not_found -> Constr.map substrec c
+      end
     | _ -> Constr.map substrec c
   in try Some (EConstr.of_constr (substrec c)) with Not_found -> None
 


### PR DESCRIPTION
It seems that the intent is to fail whenever the term contains a meta, but the evar case introduced by c9728f6 was catching the error probably incorrectly. The commit message indicates that the goal of this patch was to catch the error when the evar is absent, not when the expanded term contains a meta.

cc @herbelin 