### PR TITLE
Emit error on EOF with unsolved obligations

### DIFF
--- a/test-suite/output/bug_14550.out
+++ b/test-suite/output/bug_14550.out
@@ -1,0 +1,2 @@
+Error: Unsolved obligations when closing file: foo has unsolved obligations
+

--- a/test-suite/output/bug_14550.v
+++ b/test-suite/output/bug_14550.v
@@ -1,0 +1,2 @@
+Require Import Coq.Program.Tactics.
+Program Definition foo : exists n, n = 0 := _.

--- a/toplevel/ccompile.ml
+++ b/toplevel/ccompile.ml
@@ -103,6 +103,10 @@ let compile opts stm_options injections copts ~echo ~f_in ~f_out =
                         |> List.rev
                         |> prlist_with_sep pr_comma Names.Id.print)
                     ++ str ".")
+    else
+      let pstate = Vernacstate.freeze_interp_state ~marshallable:false in
+      Declare.Obls.check_solved_obligations ~pm:pstate.Vernacstate.program ~what_for:(Pp.str "file");
+      Vernacstate.unfreeze_interp_state pstate
   in
   let output_native_objects = match opts.config.native_compiler with
     | NativeOff -> false | NativeOn {ondemand} -> not ondemand


### PR DESCRIPTION
Previously, the following file would compile without error, but
without solving the obligations.
```coq
Require Import Coq.Program.Tactics.
Program Definition foo : exists n, n = 0 := _.
```
This patch catches such runaway obligations.

**Kind:** bug fix / feature.

Closes first part of #14550.

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [ ] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
