### PR TITLE
Windows action: run make -f Makefile.dune world

### DIFF
--- a/dev/ci/azure-build.sh
+++ b/dev/ci/azure-build.sh
@@ -5,4 +5,4 @@ set -e -x
 cd $(dirname $0)/../..
 
 eval $(opam env)
-dune build coq.install coqide-server.install
+make -f Makefile.dune world


### PR DESCRIPTION


coq.install does nothing since the split.

