### PR TITLE
Slightly more tolerant condition for an identifier to be a keyword.

### DIFF
--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -175,6 +175,10 @@ GRAMMAR EXTEND Gram
     | "0"
       [ c = atomic_constr -> { c }
       | c = term_match -> { c }
+      | id = ident; f = Prim.fields; i = univ_annot ->
+        { let (l,id') = f in CAst.make ~loc @@ CRef (make_qualid ~loc (DirPath.make (l@[id])) id', i) }
+      | id = ident; i = univ_annot ->
+        { CAst.make ~loc @@ CRef (qualid_of_ident ~loc id, i) }
       | "("; c = term LEVEL "200"; ")" ->
         { (* Preserve parentheses around numbers so that constrintern does not
              collapse -(3) into the number -3. *)
@@ -259,8 +263,7 @@ GRAMMAR EXTEND Gram
       | c=term LEVEL "9" -> { (c,None) } ] ]
   ;
   atomic_constr:
-    [ [ g = global; i = univ_annot -> { CAst.make ~loc @@ CRef (g,i) }
-      | s = sort   -> { CAst.make ~loc @@  CSort s }
+    [ [ s = sort   -> { CAst.make ~loc @@ CSort s }
       | n = NUMBER-> { CAst.make ~loc @@ CPrim (Number (NumTok.SPlus,n)) }
       | s = string -> { CAst.make ~loc @@ CPrim (String s) }
       | "_"      -> { CAst.make ~loc @@ CHole (None, IntroAnonymous, None) }

--- a/parsing/g_prim.mlg
+++ b/parsing/g_prim.mlg
@@ -48,7 +48,7 @@ GRAMMAR EXTEND Gram
     bignat bigint natural integer identref name ident hyp preident
     fullyqualid qualid reference dirpath ne_lstring
     ne_string string lstring pattern_ident by_notation
-    smart_global bar_cbrace strategy_level;
+    smart_global bar_cbrace strategy_level fields;
   preident:
     [ [ s = IDENT -> { s } ] ]
   ;

--- a/parsing/pcoq.ml
+++ b/parsing/pcoq.ml
@@ -245,6 +245,7 @@ module Prim =
     let string = Entry.create "string"
     let lstring = Entry.create "lstring"
     let reference = Entry.create "reference"
+    let fields = Entry.create "fields"
     let by_notation = Entry.create "by_notation"
     let smart_global = Entry.create "smart_global"
     let strategy_level = Entry.create "strategy_level"

--- a/parsing/pcoq.mli
+++ b/parsing/pcoq.mli
@@ -148,6 +148,7 @@ module Prim :
     val string : string Entry.t
     val lstring : lstring Entry.t
     val reference : qualid Entry.t
+    val fields : (Id.t list * Id.t) Entry.t
     val qualid : qualid Entry.t
     val fullyqualid : Id.t list CAst.t Entry.t
     val by_notation : (string * string option) Entry.t

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -205,3 +205,13 @@ fun f : ## a (a = 0) => f 1 eq_refl
      : ## a (a = 0) -> 1 = 0
 [MyNotation 0]
      : nat
+fun MyNone : nat => MyNone
+     : nat -> nat
+MyNone+
+     : option ?A
+where
+?A : [ |- Type]
+Some MyNone+
+     : option (option ?A)
+where
+?A : [ |- Type]

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -474,3 +474,12 @@ Notation "[ 'MyNotation' G ]" := (G+0) (at level 0, only parsing) : bool_scope.
 Notation "[ 'MyNotation' G ]" := (G*0).
 Check 0*0.
 End GenericFormatPrecedence.
+
+Module LeadingIdent.
+
+Notation "'MyNone' +" := None (format "'MyNone' +").
+Check fun MyNone : nat => MyNone.
+Check MyNone+.
+Check Some MyNone+.
+
+End LeadingIdent.

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -640,7 +640,7 @@ let keyword_needed need s =
       need
     | _ -> true
 
-let make_production etyps symbols =
+let make_production (_,lev,_) etyps symbols =
   let rec aux need = function
     | [] -> [[]]
     | NonTerminal m :: l ->
@@ -668,7 +668,8 @@ let make_production etyps symbols =
               [GramConstrNonTerminal (ETProdBinderList typ, Some x)] (aux false l)
         | _ ->
            user_err Pp.(str "Components of recursive patterns in notation must be terms or binders.") in
-  aux true symbols
+  let need = (* a leading ident/number factorizes iff at level 0 *) lev <> 0 in
+  aux need symbols
 
 let rec find_symbols c_current c_next c_last = function
   | [] -> []
@@ -1467,7 +1468,7 @@ let recover_squash_syntax sy =
 let make_pa_rule (typs,symbols) parsing_data =
   let { ntn_for_grammar; prec_for_grammar; typs_for_grammar; need_squash } = parsing_data in
   let assoc = recompute_assoc typs in
-  let prod = make_production typs symbols in
+  let prod = make_production prec_for_grammar typs symbols in
   let sy = {
     notgram_level = prec_for_grammar;
     notgram_assoc = assoc;


### PR DESCRIPTION
**Kind:** enhancement

This PR accepts that (parsing) notations at level 0 starting with an identifier do not declare the identifier as a keyword.

We do it by inlining the ident part of `atomic_constr` in constr at level 0.

One may wonder whether this make level 0 less readable. It seems to me no. Moreover, the (partial) inlining of `atomic_constr` makes `Print Grammar constr` more informative.

Example of what this PR now allows:
```
Notation "'MyNone' +" := None (format "'MyNone' +").
Check fun MyNone : nat => MyNone. (* was failing *)
```

- [X] Added / updated test-suite
- [ ] Entry added in the changelog (probably too minor to be worth)
