### PR TITLE
Adding user support for naming a variable inhabiting a record type

### DIFF
--- a/dev/ci/user-overlays/14563-herbelin-master+record-with-default-variable-name.sh
+++ b/dev/ci/user-overlays/14563-herbelin-master+record-with-default-variable-name.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/herbelin/coq-elpi master+adapt-coq-pr14563-support-naming-variable-inhabiting-record 14563

--- a/doc/changelog/02-specification-language/14563-master+record-with-default-variable-name.rst
+++ b/doc/changelog/02-specification-language/14563-master+record-with-default-variable-name.rst
@@ -1,0 +1,6 @@
+- **Added:**
+  New clause :n:`as @ident` to the :cmd:`Record` command to specify
+  the name of the main argument to use by default in the type of
+  projections
+  (`#14563 <https://github.com/coq/coq/pull/14563>`_,
+  by Hugo Herbelin).

--- a/doc/sphinx/language/core/inductive.rst
+++ b/doc/sphinx/language/core/inductive.rst
@@ -13,7 +13,7 @@ Inductive types
    .. prodn::
       inductive_definition ::= {? > } @ident {? @cumul_univ_decl } {* @binder } {? %| {* @binder } } {? : @type } {? := {? @constructors_or_record } } {? @decl_notations }
       constructors_or_record ::= {? %| } {+| @constructor }
-      | {? @ident } %{ {*; @record_field } {? ; } %}
+      | {? @ident } %{ {*; @record_field } {? ; } %} {? as @ident }
       constructor ::= @ident {* @binder } {? @of_type }
 
    Defines one or more
@@ -37,7 +37,9 @@ Inductive types
    :attr:`private(matching)` attributes.
 
    When record syntax is used, this command also supports the
-   :attr:`projections(primitive)` :term:`attribute`.
+   :attr:`projections(primitive)` :term:`attribute`. Also, in the
+   record syntax, if given, the :n:`as @ident` part specifies the name
+   to use for inhabitants of the record in the type of projections.
 
    Mutually inductive types can be defined by including multiple :n:`@inductive_definition`\s.
    The :n:`@ident`\s are simultaneously added to the global environment before

--- a/doc/sphinx/language/core/records.rst
+++ b/doc/sphinx/language/core/records.rst
@@ -17,7 +17,7 @@ sense, the :cmd:`Record` construction allows defining“signatures”.
    .. insertprodn record_definition field_def
 
    .. prodn::
-      record_definition ::= {? > } @ident_decl {* @binder } {? : @sort } {? := {? @ident } %{ {*; @record_field } {? ; } %} }
+      record_definition ::= {? > } @ident_decl {* @binder } {? : @sort } {? := {? @ident } %{ {*; @record_field } {? ; } %} {? as @ident } }
       record_field ::= {* #[ {*, @attribute } ] } @name {? @field_body } {? %| @natural } {? @decl_notations }
       field_body ::= {* @binder } @of_type
       | {* @binder } @of_type := @term
@@ -28,7 +28,9 @@ sense, the :cmd:`Record` construction allows defining“signatures”.
    Each :n:`@record_definition` defines a record named by :n:`@ident_decl`.
    The constructor name is given by :n:`@ident`.
    If the constructor name is not specified, then the default name :n:`Build_@ident` is used,
-   where :n:`@ident` is the record name.
+   where :n:`@ident` is the record name. If given, the :n:`as @ident`
+   part specifies the name to use for inhabitants of the record in the
+   type of projections (see below).
 
    If :token:`sort` is omitted, the default sort is Type.
    Notice that the type of an identifier can depend on a previously-given identifier. Thus the

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -559,7 +559,7 @@ eqn: [
 
 (* No constructor syntax, OPT [ "|" binders ] is not supported for Record *)
 record_definition: [
-| opt_coercion ident_decl binders OPT [ ":" sort ] OPT ( ":=" OPT [ identref ] "{" record_fields "}" )
+| opt_coercion ident_decl binders OPT [ ":" sort ] OPT ( ":=" OPT [ identref ] "{" record_fields "}" OPT [ "as" identref ] )
 ]
 
 (* No mutual recursion, no inductive classes, type must be a sort *)
@@ -1516,9 +1516,9 @@ constructors_or_record: [
 | REPLACE identref constructor_type "|" LIST1 constructor SEP "|"
 | WITH OPT "|" LIST1 constructor SEP "|"
 | DELETE identref constructor_type
-| REPLACE identref "{" record_fields "}"
-| WITH OPT identref "{" record_fields "}"
-| DELETE "{" record_fields "}"
+| REPLACE identref "{" record_fields "}" default_inhabitant_ident
+| WITH OPT identref "{" record_fields "}" default_inhabitant_ident
+| DELETE "{" record_fields "}" default_inhabitant_ident
 ]
 
 record_binder: [
@@ -2676,6 +2676,7 @@ SPLICE: [
 | export_token
 | reserv_tuple
 | inst
+| default_inhabitant_ident
 | opt_coercion
 | opt_constructors_or_fields
 | is_module_type

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -942,8 +942,13 @@ constructors_or_record: [
 | "|" LIST1 constructor SEP "|"
 | identref constructor_type "|" LIST1 constructor SEP "|"
 | identref constructor_type
-| identref "{" record_fields "}"
-| "{" record_fields "}"
+| identref "{" record_fields "}" default_inhabitant_ident
+| "{" record_fields "}" default_inhabitant_ident
+|
+]
+
+default_inhabitant_ident: [
+| "as" identref
 |
 ]
 

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -678,7 +678,7 @@ singleton_class_definition: [
 ]
 
 record_definition: [
-| OPT ">" ident_decl LIST0 binder OPT [ ":" sort ] OPT ( ":=" OPT ident "{" LIST0 record_field SEP ";" OPT ";" "}" )
+| OPT ">" ident_decl LIST0 binder OPT [ ":" sort ] OPT ( ":=" OPT ident "{" LIST0 record_field SEP ";" OPT ";" "}" OPT [ "as" ident ] )
 ]
 
 record_field: [
@@ -705,7 +705,7 @@ inductive_definition: [
 
 constructors_or_record: [
 | OPT "|" LIST1 constructor SEP "|"
-| OPT ident "{" LIST0 record_field SEP ";" OPT ";" "}"
+| OPT ident "{" LIST0 record_field SEP ";" OPT ";" "}" OPT ( "as" ident )
 ]
 
 constructor: [

--- a/test-suite/output/InductiveMainName.out
+++ b/test-suite/output/InductiveMainName.out
@@ -1,0 +1,18 @@
+bar : foo -> nat
+
+bar is not universe polymorphic
+Arguments bar id
+bar is transparent
+Expands to: Constant InductiveMainName.bar
+bar' : foo' -> nat
+
+bar' is not universe polymorphic
+Arguments bar' {id'}
+bar' is transparent
+Expands to: Constant InductiveMainName.bar'
+bar'' : foo'' -> foo''
+
+bar'' is not universe polymorphic
+Arguments bar'' id''
+bar'' is transparent
+Expands to: Constant InductiveMainName.bar''

--- a/test-suite/output/InductiveMainName.v
+++ b/test-suite/output/InductiveMainName.v
@@ -1,0 +1,6 @@
+Record foo := { bar : nat } as id.
+About bar.
+Class foo' := { bar' : nat } as id'.
+About bar'.
+CoInductive foo'' := { bar'' : foo'' } as id''.
+About bar''.

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -382,7 +382,7 @@ GRAMMAR EXTEND Gram
   (* Inductives and records *)
   opt_constructors_or_fields:
     [ [ ":="; lc = constructors_or_record -> { lc }
-      | -> { RecordDecl (None, []) } ] ]
+      | -> { RecordDecl (None, [], None) } ] ]
   ;
   inductive_definition:
     [ [ oc = opt_coercion; id = cumul_ident_decl; indpar = binders;
@@ -396,10 +396,14 @@ GRAMMAR EXTEND Gram
       | id = identref ; c = constructor_type; "|"; l = LIST1 constructor SEP "|" ->
           { Constructors ((c id)::l) }
       | id = identref ; c = constructor_type -> { Constructors [ c id ] }
-      | cstr = identref; "{"; fs = record_fields; "}" ->
-          { RecordDecl (Some cstr,fs) }
-      | "{";fs = record_fields; "}" -> { RecordDecl (None,fs) }
+      | cstr = identref; "{"; fs = record_fields; "}"; id = default_inhabitant_ident ->
+          { RecordDecl (Some cstr,fs,id) }
+      | "{";fs = record_fields; "}"; id = default_inhabitant_ident -> { RecordDecl (None,fs,id) }
       |  -> { Constructors [] } ] ]
+  ;
+  default_inhabitant_ident:
+    [ [ "as"; id = identref -> { Some id }
+      | -> { None } ] ]
   ;
 (*
   csort:

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -550,8 +550,9 @@ let pr_record_field (x, { rf_subclass = oc ; rf_priority = pri ; rf_notation = n
   let prpri = match pri with None -> mt() | Some i -> str "| " ++ int i in
   prx ++ prpri ++ prlist (pr_decl_notation @@ pr_constr) ntn
 
-let pr_record_decl c fs =
-  pr_opt pr_lident c ++ pr_record "{" "}" pr_record_field fs
+let pr_record_decl c fs obinder =
+  pr_opt pr_lident c ++ pr_record "{" "}" pr_record_field fs ++
+  pr_opt (fun id -> str "as " ++ pr_lident id) obinder
 
 let pr_printable = function
   | PrintFullContext ->
@@ -853,8 +854,8 @@ let pr_vernac_expr v =
         pr_com_at (begin_of_inductive l) ++
         fnl() ++ str fst_sep ++
         prlist_with_sep (fun _ -> fnl() ++ str" | ") pr_constructor l
-      | RecordDecl (c,fs) ->
-        pr_record_decl c fs
+      | RecordDecl (c,fs,obinder) ->
+        pr_record_decl c fs obinder
     in
     let pr_oneind key (((coe,iddecl),(indupar,indpar),s,lc),ntn) =
       hov 0 (

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -843,13 +843,13 @@ let check_priorities kind records =
     List.exists (fun (_, { rf_priority }) -> not (Option.is_empty rf_priority)) cfs
   in
   if isnot_class && List.exists has_priority records then
-    user_err Pp.(str "Priorities only allowed for type class substructures")
+    user_err Pp.(str "Priorities only allowed for type class substructures.")
 
 let extract_record_data records =
   let data = List.map Ast.to_datai records in
   let pss = List.map (fun { Ast.binders; _ } -> binders) records in
   let ps = match pss with
-  | [] -> CErrors.anomaly (str "Empty record block")
+  | [] -> CErrors.anomaly (str "Empty record block.")
   | ps :: rem ->
     let eq_local_binders bl1 bl2 = List.equal local_binder_eq bl1 bl2 in
     let () =
@@ -866,7 +866,7 @@ let class_struture ~cumulative ~template ~impargs ~univs ~params ~primitive_proj
   let { Ast.name; cfs; idbuild; _ }, rdata = match records, data with
     | [r], [d] -> r, d
     | _, _ ->
-      CErrors.user_err (str "Mutual definitional classes are not handled")
+      CErrors.user_err (str "Mutual definitional classes are not handled.")
   in
   let coers = List.map (fun (_, { rf_subclass; rf_priority }) ->
       match rf_subclass with

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -683,7 +683,7 @@ let build_record_constant ~rdata ~univs ~variances ~cumulative ~template ~primit
 (** [declare_class] will prepare and declare a [Class]. This is done in
    2 steps:
 
-  1. two markely different paths are followed depending on whether the
+  1. two markedly different paths are followed depending on whether the
    class declaration refers to a constant "definitional classes" or to
    a record, that is to say:
 
@@ -862,7 +862,7 @@ let extract_record_data records =
   ps, data
 
 (* declaring structures, common data to refactor *)
-let class_struture ~cumulative ~template ~impargs ~univs ~params ~primitive_proj def records data =
+let class_structure ~cumulative ~template ~impargs ~univs ~params ~primitive_proj def records data =
   let { Ast.name; cfs; idbuild; _ }, rdata = match records, data with
     | [r], [d] -> r, d
     | _, _ ->
@@ -917,7 +917,7 @@ let definition_structure udecl kind ~template ~cumulative ~poly ~primitive_proj
   let template = template, auto_template in
   match kind with
   | Class def ->
-    class_struture ~template ~impargs ~cumulative ~params ~univs ~variances ~primitive_proj
+    class_structure ~template ~impargs ~cumulative ~params ~univs ~variances ~primitive_proj
       def records data
   | Inductive_kw | CoInductive | Variant | Record | Structure ->
     regular_structure ~cumulative ~template ~impargs ~univs ~variances ~params ~finite ~primitive_proj

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -149,6 +149,7 @@ module Data = struct
   ; is_coercion : bool
   ; coers : projection_flags list
   ; rdata : DataR.t
+  ; inhabitant_id : Id.t
   }
 end
 
@@ -422,7 +423,7 @@ let build_proj env mib indsp primitive x rp lifted_fields ~poly paramdecls param
 
 (** [declare_projections] prepares the common context for all record
    projections and then calls [build_proj] for each one. *)
-let declare_projections indsp univs ?(kind=Decls.StructureComponent) binder_name flags fieldimpls fields =
+let declare_projections indsp univs ?(kind=Decls.StructureComponent) inhabitant_id flags fieldimpls fields =
   let env = Global.env() in
   let (mib,mip) = Global.lookup_inductive indsp in
   let poly = Declareops.inductive_is_polymorphic mib in
@@ -434,7 +435,7 @@ let declare_projections indsp univs ?(kind=Decls.StructureComponent) binder_name
   let r = mkIndU (indsp,uinstance) in
   let rp = applist (r, Context.Rel.instance_list mkRel 0 paramdecls) in
   let paramargs = Context.Rel.instance_list mkRel 1 paramdecls in (*def in [[params;x:rp]]*)
-  let x = make_annot (Name binder_name) mip.mind_relevance in
+  let x = make_annot (Name inhabitant_id) mip.mind_relevance in
   let fields = instantiate_possibly_recursive_type (fst indsp) uinstance mib.mind_ntypes paramdecls fields in
   let lifted_fields = Vars.lift_rel_context 1 fields in
   let primitive =
@@ -528,7 +529,7 @@ let bound_names_rdata { DataR.fields; _ } : Id.Set.t =
   List.fold_left add_names Id.Set.empty fields
 
 (** Pick a variable name for a record, avoiding names bound in its fields. *)
-let data_name { Data.id; Data.rdata; _ } =
+let data_name id rdata =
   let name = Id.of_string (Unicode.lowercase_first_char (Id.to_string id)) in
   Namegen.next_ident_away name (bound_names_rdata rdata)
 
@@ -555,11 +556,6 @@ let declare_structure ~cumulative finite ~univs ~variances ~primitive_proj
     match univs with
     | UState.Monomorphic_entry _ -> false, Entries.Monomorphic_entry
     | UState.Polymorphic_entry uctx -> true, Entries.Polymorphic_entry uctx
-  in
-  let binder_name =
-    match name with
-    | None -> Array.map_of_list data_name record_data
-    | Some n -> n
   in
   let ntypes = List.length record_data in
   let mk_block i { Data.id; idbuild; rdata = { DataR.min_univ; arity; fields; _ }; _ } =
@@ -591,7 +587,7 @@ let declare_structure ~cumulative finite ~univs ~variances ~primitive_proj
   let variance = ComInductive.variance_of_entry ~cumulative ~variances univs in
   let mie =
     { mind_entry_params = params;
-      mind_entry_record = Some (if primitive then Some binder_name else None);
+      mind_entry_record = Some (if primitive then Some (Array.map_of_list (fun a -> a.Data.inhabitant_id) record_data) else None);
       mind_entry_finite = finite;
       mind_entry_inds = blocks;
       mind_entry_private = None;
@@ -603,10 +599,10 @@ let declare_structure ~cumulative finite ~univs ~variances ~primitive_proj
   let kn = DeclareInd.declare_mutual_inductive_with_eliminations mie globnames impls
       ~primitive_expected:primitive_proj
   in
-  let map i { Data.is_coercion; coers; rdata = { DataR.implfs; fields; _}; _ } =
+  let map i { Data.is_coercion; coers; rdata = { DataR.implfs; fields; _}; inhabitant_id; id; _ } =
     let rsp = (kn, i) in (* This is ind path of idstruc *)
     let cstr = (rsp, 1) in
-    let projections = declare_projections rsp (projunivs,ubinders) ~kind binder_name.(i) coers implfs fields in
+    let projections = declare_projections rsp (projunivs,ubinders) ~kind inhabitant_id coers implfs fields in
     let build = GlobRef.ConstructRef cstr in
     let () = if is_coercion then ComCoercion.try_add_new_coercion build ~local:false ~poly in
     let struc = Structure.make (Global.env ()) rsp projections in
@@ -658,16 +654,17 @@ let build_class_constant ~univs ~rdata ~primitive_proj field implfs params param
   [cref, [m]]
 
 let build_record_constant ~rdata ~univs ~variances ~cumulative ~template ~primitive_proj
-    fields params paramimpls coers id idbuild binder_name =
+    fields params paramimpls coers id idbuild inhabitant_id =
   let record_data =
     { Data.id
     ; idbuild
     ; is_coercion = false
     ; coers = List.map (fun _ -> { pf_subclass = false ; pf_canonical = true }) fields
     ; rdata
+    ; inhabitant_id
     } in
   let inds = declare_structure ~cumulative Declarations.BiFinite ~univs ~variances ~primitive_proj paramimpls
-      params template ~kind:Decls.Method ~name:[|binder_name|] [record_data]
+      params template ~kind:Decls.Method ~name:[|inhabitant_id|] [record_data]
   in
   let map ind =
     let map decl b y = {
@@ -702,7 +699,7 @@ let build_record_constant ~rdata ~univs ~variances ~cumulative ~template ~primit
   2. declare the class, using the information from 1. in the form of [Classes.typeclass]
 
   *)
-let declare_class def ~cumulative ~univs ~variances ~primitive_proj id idbuild paramimpls params
+let declare_class def ~cumulative ~univs ~variances ~primitive_proj id idbuild inhabitant_id paramimpls params
     rdata template ?(kind=Decls.StructureComponent) coers =
   let implfs =
     (* Make the class implicit in the projections, and the params if applicable. *)
@@ -710,17 +707,16 @@ let declare_class def ~cumulative ~univs ~variances ~primitive_proj id idbuild p
       List.map (fun x -> impls @ x) rdata.DataR.implfs
   in
   let rdata = { rdata with DataR.implfs } in
-  let binder_name = Namegen.next_ident_away id (Termops.vars_of_env (Global.env())) in
   let fields = rdata.DataR.fields in
   let data =
     match fields with
     | [ LocalAssum ({binder_name=Name proj_name} as binder, field)
       | LocalDef ({binder_name=Name proj_name} as binder, _, field) ] when def ->
-      let binder = {binder with binder_name=Name binder_name} in
+      let binder = {binder with binder_name=Name inhabitant_id} in
       build_class_constant ~rdata ~univs ~primitive_proj field implfs params paramimpls coers binder id proj_name
     | _ ->
       build_record_constant ~rdata ~univs ~variances ~cumulative ~template ~primitive_proj
-        fields params paramimpls coers id idbuild binder_name
+        fields params paramimpls coers id idbuild inhabitant_id
   in
   let univs, params, fields =
     match fst univs with
@@ -813,6 +809,7 @@ module Ast = struct
     ; cfs : (local_decl_expr * record_field_attr) list
     ; idbuild : Id.t
     ; sort : constr_expr option
+    ; default_inhabitant_id : Id.t option
     }
 
   let to_datai { name; is_coercion; cfs; idbuild; sort } =
@@ -863,7 +860,7 @@ let extract_record_data records =
 
 (* declaring structures, common data to refactor *)
 let class_structure ~cumulative ~template ~impargs ~univs ~params ~primitive_proj def records data =
-  let { Ast.name; cfs; idbuild; _ }, rdata = match records, data with
+  let { Ast.name; cfs; idbuild; default_inhabitant_id; _ }, rdata = match records, data with
     | [r], [d] -> r, d
     | _, _ ->
       CErrors.user_err (str "Mutual definitional classes are not handled.")
@@ -874,7 +871,12 @@ let class_structure ~cumulative ~template ~impargs ~univs ~params ~primitive_pro
       | Vernacexpr.NoInstance -> None)
       cfs
   in
-  declare_class def ~cumulative ~univs ~primitive_proj name.CAst.v idbuild
+  let inhabitant_id =
+    match default_inhabitant_id with
+    | None -> Namegen.next_ident_away name.CAst.v (Termops.vars_of_env (Global.env()))
+    | Some id -> id
+  in
+  declare_class def ~cumulative ~univs ~primitive_proj name.CAst.v idbuild inhabitant_id
     impargs params rdata template coers
 
 let regular_structure ~cumulative ~template ~impargs ~univs ~variances ~params ~finite ~primitive_proj
@@ -882,14 +884,19 @@ let regular_structure ~cumulative ~template ~impargs ~univs ~variances ~params ~
   let adjust_impls impls = impargs @ [CAst.make None] @ impls in
   let data = List.map (fun ({ DataR.implfs; _ } as d) -> { d with DataR.implfs = List.map adjust_impls implfs }) data in
   (* let map (min_univ, arity, fieldimpls, fields) { Ast.name; is_coercion; cfs; idbuild; _ } = *)
-  let map rdata { Ast.name; is_coercion; cfs; idbuild; _ } =
+  let map rdata { Ast.name; is_coercion; cfs; idbuild; default_inhabitant_id; _ } =
     let coers = List.map (fun (_, { rf_subclass ; rf_canonical }) ->
         { pf_subclass =
             (match rf_subclass with Vernacexpr.BackInstance -> true | Vernacexpr.NoInstance -> false);
           pf_canonical = rf_canonical })
         cfs
     in
-    { Data.id = name.CAst.v; idbuild; rdata; is_coercion; coers }
+    let inhabitant_id =
+      match default_inhabitant_id with
+      | None -> data_name name.CAst.v rdata
+      | Some n -> n
+    in
+    { Data.id = name.CAst.v; idbuild; rdata; is_coercion; coers; inhabitant_id }
   in
   let data = List.map2 map data records in
   let inds = declare_structure ~cumulative finite ~univs ~variances ~primitive_proj

--- a/vernac/record.mli
+++ b/vernac/record.mli
@@ -21,6 +21,7 @@ module Ast : sig
     ; cfs : (local_decl_expr * record_field_attr) list
     ; idbuild : Id.t
     ; sort : constr_expr option
+    ; default_inhabitant_id : Id.t option
     }
 end
 

--- a/vernac/vernac_classifier.ml
+++ b/vernac/vernac_classifier.ml
@@ -124,7 +124,8 @@ let classify_vernac e =
     | VernacInductive (_,l) ->
         let ids = List.map (fun (((_,({v=id},_)),_,_,cl),_) -> id :: match cl with
         | Constructors l -> List.map (fun (_,({v=id},_)) -> id) l
-        | RecordDecl (oid,l) -> (match oid with Some {v=x} -> [x] | _ -> []) @
+        | RecordDecl (oid,l,obinder) -> (match oid with Some {v=x} -> [x] | _ -> []) @
+           (match obinder with Some {v=x} -> [x] | _ -> []) @
            CList.map_filter (function
             | AssumExpr({v=Names.Name n},_,_), _ -> Some n
             | _ -> None) l) l in

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -189,7 +189,7 @@ type record_field_attr = {
 type constructor_expr = (lident * constr_expr) with_coercion
 type constructor_list_or_record_decl_expr =
   | Constructors of constructor_expr list
-  | RecordDecl of lident option * (local_decl_expr * record_field_attr) list
+  | RecordDecl of lident option * (local_decl_expr * record_field_attr) list * lident option
 type inductive_params_expr = local_binder_expr list * local_binder_expr list option
 (** If the option is nonempty the "|" marker was used *)
 


### PR DESCRIPTION
**Kind:** feature

This is an experience in providing a name to be used by default in the definition of projections of records (and similar situations), whether they are primitive or not.

Proposed syntax is:
```
Record foo := { bar : nat } as id.
```

The infrastructure was actually almost already there but with no user control on it.

- [x] Added / updated test-suite
- [x] Corresponding documentation was added / updated
- [x] Entry added in the changelog

Synchronous overlay: LPCIC/coq-elpi#326
