### PR TITLE
Forbid renaming arguments of section variables

### DIFF
--- a/doc/changelog/02-specification-language/14573-no-rename-var.rst
+++ b/doc/changelog/02-specification-language/14573-no-rename-var.rst
@@ -1,0 +1,4 @@
+- **Removed:**
+  Arguments of section variables may no longer be renamed with :cmd:`Arguments` (this was previously applied inconsistently)
+  (`#14573 <https://github.com/coq/coq/pull/14573>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/language/extensions/arguments-command.rst
+++ b/doc/sphinx/language/extensions/arguments-command.rst
@@ -94,6 +94,9 @@ Setting properties of a function's arguments
          .. exn:: Flag 'rename' expected to rename @name into @name.
             :undocumented:
 
+         .. exn:: Arguments of section variables such as @name may not be renamed.
+            :undocumented:
+
       `clear implicits`
          makes all implicit arguments into explicit arguments
 

--- a/pretyping/arguments_renaming.ml
+++ b/pretyping/arguments_renaming.ml
@@ -64,6 +64,14 @@ let inRenameArgs = declare_object { (default_object "RENAME-ARGUMENTS" ) with
 }
 
 let rename_arguments local r names =
+  let () = match r with
+    | GlobRef.VarRef id ->
+      CErrors.user_err
+        Pp.(str "Arguments of section variables such as "
+            ++ Id.print id
+            ++ str" may not be renamed.")
+    | _ -> ()
+  in
   let req = if local then ReqLocal else ReqGlobal (r, names) in
   Lib.add_anonymous_leaf (inRenameArgs (req, (r, names)))
 

--- a/test-suite/bugs/closed/bug_9367.v
+++ b/test-suite/bugs/closed/bug_9367.v
@@ -2,7 +2,7 @@ Section foo.
 Variable f : forall n : nat, nat.
 Arguments f {_}.
 Check f (n := 3).
-Global Arguments f {bar} : rename.
+Fail Global Arguments f {bar} : rename.
 End foo.
 
 Section foo.

--- a/test-suite/output/Arguments_renaming.out
+++ b/test-suite/output/Arguments_renaming.out
@@ -103,3 +103,5 @@ The command has indeed failed with message:
 Extra arguments: y.
 The command has indeed failed with message:
 Flag "rename" expected to rename A into R.
+The command has indeed failed with message:
+Arguments of section variables such as allTrue may not be renamed.

--- a/test-suite/output/Arguments_renaming.v
+++ b/test-suite/output/Arguments_renaming.v
@@ -52,3 +52,8 @@ Fail Arguments eq {A} x [_] : rename.
 Fail Arguments eq {A} x [z] : rename.
 Fail Arguments eq {F} x z y.
 Fail Arguments eq {R} s t.
+
+Section RenameVar.
+  Variable allTrue : forall P, P.
+  Fail Arguments allTrue Q : rename.
+End RenameVar.

--- a/test-suite/ssr/under.v
+++ b/test-suite/ssr/under.v
@@ -257,7 +257,7 @@ Context {A B : Type} {R : nat -> B -> B -> Prop}
 Variables (F : (A -> A -> B) -> B).
 Hypothesis ex_gen : forall (n : nat) (P1 P2 : A -> A -> B),
   (forall x y : A, R n (P1 x y) (P2 x y)) -> (R n (F P1) (F P2)).
-Arguments ex_gen [n P1] P2 relP12.
+Arguments ex_gen [n P1] P2 _.
 Lemma test_ex_gen (P1 P2 : A -> A -> B) (n : nat) :
   (forall x y : A, P2 x y = P2 y x) ->
   R n (F P1) (F P2) /\ True -> True.
@@ -300,7 +300,7 @@ Hypothesis rel2_gen :
     Rel c1 c2 ->
     (forall a b : A, Rel (P1 a b) (P2 a b)) ->
     Rel (F c1 P1) (F c2 P2).
-Arguments rel2_gen [c1] c2 [P1] P2 relc12 relP12.
+Arguments rel2_gen [c1] c2 [P1] P2 _ _.
 Lemma test_rel2_gen (c : C) (P : A -> A -> B)
   (toy_hyp : forall a b, P a b = P b a) :
   Rel (F c P) (F c (fun a b => P b a)).


### PR DESCRIPTION
This seems likely to lead to bugs when someone clears a section
variable to reuse the name, and does not seem especially useful.

Replaces https://github.com/coq/coq/pull/14498

Overlay (backward compatible): https://github.com/math-comp/math-comp/pull/765