### PR TITLE
test-suite: don't double build COMMON_MODULE_DEPENDENCIES

### DIFF
--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -649,12 +649,8 @@ COMMON_MODULE_DEPENDENCIES := modules/plik.v modules/Nat.v
 # We exclude Nat.v.log and plik.v.log because these log files do not
 # depend on having the corresponding .vo files built first, and we end
 # up with pseudo-cyclic build rules if we don't exclude them (See
-# COQBUG(https://github.com/coq/coq/issues/12582)). Additionally, we
-# impose order-only dependencies to ensure that we won't rebuild the
-# .vo files in the .log target after we've already built them.
-$(addsuffix .log,$(filter-out $(COMMON_MODULE_DEPENDENCIES),$(wildcard modules/*.v))): %.v.log: $(COMMON_MODULE_DEPENDENCIES:.v=.vo) | $(COMMON_MODULE_DEPENDENCIES:.v=.v.log)
-modules/%.vo: modules/%.v
-	$(HIDE)$(coqc) -R modules Mods $<
+# COQBUG(https://github.com/coq/coq/issues/12582)).
+$(addsuffix .log,$(filter-out $(COMMON_MODULE_DEPENDENCIES),$(wildcard modules/*.v))): %.v.log: $(COMMON_MODULE_DEPENDENCIES:.v=.v.log)
 
 #######################################################################
 # Miscellaneous tests


### PR DESCRIPTION
This is unsound if someone deletes the .vo while leaving the .v.log
alone, but that's their problem.

The hidden coqc would leak a warning from modules/Nat.v
