### PR TITLE
Nix CI: deploy smaller, toolbox-compatible Coq.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -384,26 +384,23 @@ pkg:opam:
   only: *full-ci
 
 .nix-template:
-  image: nixorg/nix:latest # Minimal NixOS image which doesn't even contain git
-  interruptible: true
   stage: stage-1
+  needs: []
+  except:
+    variables:
+      - $ONLY_WINDOWS == "true"
+  interruptible: true
+  image: nixorg/nix:latest # Minimal NixOS image which doesn't even contain git
   variables:
-    # By default we use coq.cachix.org as an extra substituter but this can be overridden
-    EXTRA_SUBSTITUTERS: https://coq.cachix.org
-    EXTRA_PUBLIC_KEYS: coq.cachix.org-1:5QW/wwEnD+l2jvN6QRbRRsa4hBHG3QiQQ26cxu1F5tI=
-    # The following variables should not be overridden
-    GIT_STRATEGY: none
-    NIXOS_PUBLIC_KEY: cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-
-  before_script: [] # We don't want to use the shared 'before_script'
-  script:
+    GIT_STRATEGY: none # Required because we don't have git
+    USER: root # Variable required by Cachix
+  before_script:
     - cat /proc/{cpu,mem}info || true
     # Use current worktree as tmpdir to allow exporting artifacts in case of failure
     - export TMPDIR=$PWD
-    # We build an expression rather than a direct URL to not be dependent on
-    # the URL location; we are forced to put the public key of cache.nixos.org
-    # because there is no --extra-trusted-public-key option.
-    - nix-build -E "import (fetchTarball $CI_PROJECT_URL/-/archive/$CI_COMMIT_SHA.tar.gz) {}" -K --extra-substituters "$EXTRA_SUBSTITUTERS" --trusted-public-keys "$NIXOS_PUBLIC_KEY $EXTRA_PUBLIC_KEYS" | if [ ! -z "$CACHIX_SIGNING_KEY" ]; then cachix push coq; fi
+    # Install Cachix as documented at https://github.com/cachix/cachix
+    - nix-env -iA cachix -f https://cachix.org/api/v1/install
+    - cachix use coq
   artifacts:
     name: "$CI_JOB_NAME.logs"
     when: on_failure
@@ -417,15 +414,13 @@ pkg:nix:deploy:
   environment:
     name: cachix
     url: https://coq.cachix.org
-  before_script:
-    # Install Cachix as documented at https://github.com/cachix/cachix
-    - nix-env -iA cachix --prebuilt-only -f https://cachix.org/api/v1/install
+  script:
+    - nix-build https://coq.inria.fr/nix/toolbox --arg override "{coq = coq:$CI_COMMIT_SHA;}" -K | cachix push coq
   only:
     - master
     - /^v.*\..*$/
-  except:
-    variables:
-      - $ONLY_WINDOWS == "true"
+  # In the future, add a condition to also have $CACHIX_AUTH_TOKEN set.
+  # At the time of writing, we still rely on $CACHIX_SIGNING_KEY for Coq's Cachix.
 
 pkg:nix:deploy:channel:
   extends: .deploy-template
@@ -450,12 +445,8 @@ pkg:nix:deploy:channel:
 
 pkg:nix:
   extends: .nix-template
-  except:
-    refs:
-      - master
-      - /^v.*\..*$/
-    variables:
-      - $ONLY_WINDOWS == "true"
+  script:
+    - nix-build "$CI_PROJECT_URL/-/archive/$CI_COMMIT_SHA.tar.gz" -K
 
 doc:refman:
   extends: .doc-template


### PR DESCRIPTION
**Kind:** infrastructure.

Without switching yet the Nix setup to be entirely based on the Coq Nix Toolbox like #14435 does, this PR ensures that we are building and uploading to Cachix a version of Coq that will be directly useful for users, either for testing locally or for their CI.

Cf. the reworked documentation at https://github.com/coq/coq/wiki/Nix#coq-nix-toolbox.

There will therefore be two Nix jobs that run on `master` and release branches. One that builds the Coq nixpkgs package overridden to use the current version of the sources and that gets pushed to Cachix and one that builds a fuller package with tests and documentation, because this is still useful to detect regressions.

When https://github.com/NixOS/nixpkgs/pull/116690 is merged, it will be possible for users to do `nix-shell https://coq.inria.fr/nix/toolbox --arg override '{coq = "coq/coq-on-cachix:master";}'` instead of `nix-shell https://coq.inria.fr/nix/toolbox --arg override '{coq = "master";}'` to ensure that they always get the latest pre-built version.

cc @vbgl @CohenCyril 