### PR TITLE
Deprecate undocumented syntax (arg_n:=term) for explicitation of implicit arguments

### DIFF
--- a/dev/ci/user-overlays/14597-herbelin-master+remove-syntax-implicit-arguments-arg_X.sh
+++ b/dev/ci/user-overlays/14597-herbelin-master+remove-syntax-implicit-arguments-arg_X.sh
@@ -1,0 +1,1 @@
+overlay paramcoq https://github.com/herbelin/paramcoq master+naming-depending-variables 14597

--- a/engine/evar_kinds.ml
+++ b/engine/evar_kinds.ml
@@ -21,6 +21,10 @@ type matching_var_kind = FirstOrderPatVar of Id.t | SecondOrderPatVar of Id.t
 
 type subevar_kind = Domain | Codomain | Body
 
+type explicitation =
+  | ExplByName of Id.t
+  | ExplByPos of int (* a reference to the n-th non-dependent implicit starting from left *)
+
 (* maybe this should be a Projection.t *)
 type record_field = { fieldname : Constant.t; recordname : Names.inductive }
 
@@ -37,7 +41,7 @@ let default_question_mark = {
 }
 
 type t =
-  | ImplicitArg of GlobRef.t * (int * Id.t option)
+  | ImplicitArg of GlobRef.t * (int * explicitation option)
      * bool (** Force inference *)
   | BinderType of Name.t
   | EvarType of Id.t option * Evar.t (* type of an optionally named evar *)
@@ -53,7 +57,7 @@ type t =
   | SubEvar of subevar_kind option * Evar.t
 
 type glob_evar_kind =
-  | GImplicitArg of GlobRef.t * (int * Id.t option) * bool (** Force inference *)
+  | GImplicitArg of GlobRef.t * (int * explicitation option) * bool (** Force inference *)
   | GBinderType of Name.t
   | GNamedHole of bool (* fresh? *) * Id.t (* coming from some ?[id] syntax *)
   | GQuestionMark of question_mark

--- a/engine/evar_kinds.mli
+++ b/engine/evar_kinds.mli
@@ -21,6 +21,10 @@ type matching_var_kind = FirstOrderPatVar of Id.t | SecondOrderPatVar of Id.t
 
 type subevar_kind = Domain | Codomain | Body
 
+type explicitation =
+  | ExplByName of Id.t
+  | ExplByPos of int (* a reference to the n-th non-dependent implicit starting from left *)
+
 (* maybe this should be a Projection.t *)
 (* Represents missing record field *)
 type record_field = { fieldname : Constant.t; recordname : Names.inductive }
@@ -36,7 +40,7 @@ type question_mark = {
 val default_question_mark : question_mark
 
 type t =
-  | ImplicitArg of GlobRef.t * (int * Id.t option)
+  | ImplicitArg of GlobRef.t * (int * explicitation option)
      * bool (** Force inference *)
   | BinderType of Name.t
   | EvarType of Id.t option * Evar.t (* type of an optionally named evar *)
@@ -52,7 +56,7 @@ type t =
   | SubEvar of subevar_kind option * Evar.t
 
 type glob_evar_kind =
-  | GImplicitArg of GlobRef.t * (int * Id.t option) * bool (** Force inference *)
+  | GImplicitArg of GlobRef.t * (int * explicitation option) * bool (** Force inference *)
   | GBinderType of Name.t
   | GNamedHole of bool (* fresh? *) * Id.t (* coming from some ?[id] syntax *)
   | GQuestionMark of question_mark

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -752,8 +752,8 @@ let mark_in_evm ~goal evd evars =
             - GoalEvar (morally not dependent)
             - VarInstance (morally dependent of some name).
             This is a heuristic for naming these evars. *)
-        | loc, (Evar_kinds.QuestionMark { Evar_kinds.qm_name=Names.Name id} |
-                Evar_kinds.ImplicitArg (_,(_,Some id),_)) -> loc, Evar_kinds.VarInstance id
+        | loc, Evar_kinds.(QuestionMark { Evar_kinds.qm_name=Names.Name id} |
+                ImplicitArg (_,(_,Some (ExplByName id)),_)) -> loc, Evar_kinds.VarInstance id
         | _, (Evar_kinds.VarInstance _ | Evar_kinds.GoalEvar) as x -> x
         | loc,_ -> loc,Evar_kinds.GoalEvar
         in

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -111,7 +111,7 @@ let evar_suggested_name env sigma evk =
   match evar_ident evk' sigma with
   | Some id -> id
   | None -> match Evd.evar_source evi with
-  | _,Evar_kinds.ImplicitArg (c,(n,Some id),b) -> id
+  | _,Evar_kinds.ImplicitArg (c,(n,Some (Evar_kinds.ExplByName id)),b) -> id
   | _,Evar_kinds.VarInstance id -> id
   | _,Evar_kinds.QuestionMark {Evar_kinds.qm_name = Name id} -> id
   | _,Evar_kinds.GoalEvar -> Id.of_string "Goal"
@@ -195,8 +195,11 @@ let pr_evar_source env sigma = function
           with (* defined *) Not_found -> str "an internal placeholder" in
      str "type of " ++ pp
   | Evar_kinds.ImplicitArg (c,(n,ido),b) ->
-      let id = Option.get ido in
-      str "parameter " ++ Id.print id ++ spc () ++ str "of" ++
+      let open Evar_kinds in
+      let pos = match ido with
+        | Some (ExplByName id) -> str "parameter " ++ Id.print id
+        | Some (ExplByPos n) -> str "parameter at non-dependent position " ++ int n | None -> str "some parameter" in
+      pos ++ spc () ++ str "of" ++
       spc () ++ pr_global_env env c
   | Evar_kinds.InternalHole -> str "internal placeholder"
   | Evar_kinds.TomatchTypeParameter (ind,n) ->

--- a/interp/constrexpr.mli
+++ b/interp/constrexpr.mli
@@ -10,6 +10,7 @@
 
 open Names
 open Libnames
+open Evar_kinds
 
 (** {6 Concrete syntax for terms } *)
 
@@ -83,10 +84,6 @@ type 'a or_by_notation = 'a or_by_notation_r CAst.t
 
 (* NB: the last string in [ByNotation] is actually a [Notation.delimiters],
    but this formulation avoids a useless dependency. *)
-
-type explicitation =
-  | ExplByName of Id.t
-  | ExplByPos of int (* a reference to the n-th non-dependent implicit starting from left *)
 
 type binder_kind =
   | Default of Glob_term.binding_kind

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -16,6 +16,7 @@ open Libnames
 open Glob_term
 open Notationextern
 open Constrexpr
+open Evar_kinds
 
 (***********)
 (* Universes *)

--- a/interp/constrexpr_ops.mli
+++ b/interp/constrexpr_ops.mli
@@ -20,7 +20,7 @@ val sort_name_expr_eq : sort_name_expr -> sort_name_expr -> bool
 val univ_level_expr_eq : univ_level_expr -> univ_level_expr -> bool
 val sort_expr_eq : sort_expr -> sort_expr -> bool
 
-val explicitation_eq : explicitation -> explicitation -> bool
+val explicitation_eq : Evar_kinds.explicitation -> Evar_kinds.explicitation -> bool
 (** Equality on [explicitation]. *)
 
 val constr_expr_eq_gen : (constr_expr -> constr_expr -> bool) -> constr_expr -> constr_expr -> bool

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -586,7 +586,7 @@ let adjust_implicit_arguments inctx n args impl =
            is_significant_implicit (Lazy.force a))
         in
         if visible then
-          (Lazy.force a,Some (make @@ explicitation imp)) :: tail
+          (Lazy.force a,Some (make @@ name_of_implicit imp)) :: tail
         else
           tail
     | a::args, _::impl -> (Lazy.force a,None) :: exprec (args,impl)

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -348,7 +348,7 @@ let warn_shadowed_implicit_name =
     Pp.(fun (na,id) -> str "Renaming shadowed implicit argument name to " ++ Id.print id ++ str ".")
 
 let exists_id id l =
-  List.exists (function Some { impl_pos = (Name id', _, _) } -> Id.equal id id' | _ -> false) l
+  List.exists (function Some { impl_pos = { arg_explicitation = ByName (id', _) } } -> Id.equal id id' | _ -> false) l
 
 let build_impls ?loc n bk na acc =
   let impl_status max =
@@ -356,7 +356,7 @@ let build_impls ?loc n bk na acc =
       match na with
       | Name id ->
         if exists_id id acc then
-          let avoid = Id.Set.of_list (List.map_filter (function Some { impl_pos = (Name id,_,_) } -> Some id | _ -> None) acc) in
+          let avoid = Id.Set.of_list (List.map_filter (function Some { impl_pos = { arg_explicitation = ByName (id,_) } } -> Some id | _ -> None) acc) in
           let id = next_name_away na avoid in
           begin warn_shadowed_implicit_name ?loc (na,id); id end
         else id
@@ -365,7 +365,7 @@ let build_impls ?loc n bk na acc =
         user_err ?loc (str "Local implicit argument requires a name.")
     in
     Some {
-      impl_pos = (na, n, ExplByName id);
+      impl_pos = { arg_explicitation = ByName (id,None); arg_absolute_pos = n };
       impl_expl = Manual;
       impl_max = max;
       impl_force = true
@@ -2097,7 +2097,7 @@ let exists_implicit_name id =
   List.exists (fun imp -> is_status_implicit imp && match_implicit imp (ExplByName id))
 
 let print_allowed_named_implicit imps =
-  let l = List.map_filter (function Some { impl_pos = (_, _, ExplByName id) } -> Some id | _ -> None) imps in
+  let l = List.map_filter (function Some { impl_pos = { arg_explicitation = ByName (id,_) } } -> Some id | _ -> None) imps in
   match l with
   | [] -> mt ()
   | l ->
@@ -2106,7 +2106,7 @@ let print_allowed_named_implicit imps =
     pr_sequence Id.print l ++ str ")"
 
 let print_allowed_nondep_implicit imps =
-  let l = List.map_filter (function Some { impl_pos = (_, _, ExplByPos n) } -> Some n | _ -> None) imps in
+  let l = List.map_filter (function Some { impl_pos = { arg_explicitation = ByNonDepPos n } } -> Some n | _ -> None) imps in
   match l with
   | [] -> mt ()
   | l ->

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -20,6 +20,7 @@ open Context
 open Libnames
 open Globnames
 open Impargs
+open Evar_kinds
 open Glob_term
 open Glob_ops
 open Patternops
@@ -2086,7 +2087,7 @@ let set_hole_implicit i b c =
   Loc.tag ?loc (GImplicitArg (r,i,b))
 
 let exists_implicit_name id =
-  List.exists (fun imp -> is_status_implicit imp && Id.equal id (name_of_implicit imp))
+  List.exists (fun imp -> is_status_implicit imp && match name_of_implicit imp with Evar_kinds.ExplByName id' -> Id.equal id id' | ExplByPos k -> Id.equal (name_of_pos k) id)
 
 let print_allowed_named_implicit imps =
   let l = List.map_filter (function Some { impl_pos = (Name id, _, _) } -> Some id | _ -> None) imps in
@@ -2611,8 +2612,7 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
           intern_no_implicit enva a :: aux (n+1) impl' subscopes' eargs rargs'
       | (imp::impl', []) ->
           if not (List.is_empty eargs) then
-            (let pr_position = function ExplByName id -> Id.print id | ExplByPos n -> str "position " ++ int n in
-            let (pos,(loc,_)) = List.hd eargs in
+            (let (pos,(loc,_)) = List.hd eargs in
                user_err ?loc (str "Not enough non implicit \
             arguments to accept the argument bound to " ++
                  pr_position pos ++ str"."));

--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -19,7 +19,7 @@ open Declarations
 open Libobject
 open EConstr
 open Reductionops
-open Constrexpr
+open Evar_kinds
 
 let whd_prod env sigma typ =
   let open CClosure in
@@ -343,8 +343,9 @@ let binding_kind_of_status = function
 
 let name_of_implicit = function
   | None -> anomaly (Pp.str "Not an implicit argument.")
-  | Some { impl_pos = (Name id, _, _) } -> id
-  | Some { impl_pos = (Anonymous, k, _) } -> name_of_pos k
+  | Some { impl_pos = (Name id, _, _) } -> ExplByName id (* Note: may have a name even if non-dependent *)
+  | Some { impl_pos = (Anonymous, _, Some n) } -> ExplByPos n
+  | Some _ -> assert false
 
 let match_implicit imp pos = match imp, pos with
   | None, _ -> anomaly (Pp.str "Not an implicit argument.")
@@ -390,6 +391,10 @@ let positions_of_implicits (_,impls) =
     | Some _ :: l -> n :: aux (n+1) l
     | None :: l -> aux (n+1) l
   in aux 1 impls
+
+let pr_position = function
+  | ExplByName id -> Id.print id
+  | ExplByPos n -> str "at non-dependent position " ++ int n
 
 (* Manage user-given implicit arguments *)
 

--- a/interp/impargs.mli
+++ b/interp/impargs.mli
@@ -68,10 +68,17 @@ type maximal_insertion = bool (** true = maximal contextual insertion *)
 
 type force_inference = bool (** true = always infer, never turn into evar/subgoal *)
 
-type implicit_position = Name.t * int * Evar_kinds.explicitation
+type argument_explicitation =
+  | ByName of Id.t * int option (* Named and optionally non-dependent *)
+  | ByNonDepPos of int (* [n]-th non-dependent arg (implicit or not) *)
+
+type argument_denotation = {
+  arg_absolute_pos : int;
+  arg_explicitation : argument_explicitation;
+}
 
 type implicit_status_info = {
-  impl_pos : implicit_position;
+  impl_pos : argument_denotation;
   impl_expl : implicit_explanation;
   impl_max : maximal_insertion;
   impl_force : force_inference;
@@ -92,7 +99,7 @@ val match_implicit : ?warn:bool -> implicit_status -> Evar_kinds.explicitation -
 val maximal_insertion_of : implicit_status -> bool
 val force_inference_of : implicit_status -> bool
 val is_nondep_implicit : int -> implicit_status list -> bool
-val explicitation : implicit_status -> Evar_kinds.explicitation
+(*val explicitation : implicit_status -> Evar_kinds.explicitation*)
 
 val positions_of_implicits : implicits_list -> int list
 
@@ -103,7 +110,8 @@ type manual_implicits = (Name.t * bool) option CAst.t list
 val compute_implicits_with_manual : env -> Evd.evar_map -> types -> bool ->
   manual_implicits -> implicit_status list
 
-val compute_implicits_names : env -> Evd.evar_map -> types -> implicit_position list
+val compute_implicits_names : env -> Evd.evar_map -> types -> argument_denotation list
+val name_of_argument : argument_denotation -> Name.t
 
 (** {6 Computation of implicits (done using the global environment). } *)
 

--- a/interp/impargs.mli
+++ b/interp/impargs.mli
@@ -68,7 +68,7 @@ type maximal_insertion = bool (** true = maximal contextual insertion *)
 
 type force_inference = bool (** true = always infer, never turn into evar/subgoal *)
 
-type implicit_position = Name.t * int * int option
+type implicit_position = Name.t * int * Evar_kinds.explicitation
 
 type implicit_status_info = {
   impl_pos : implicit_position;

--- a/interp/impargs.mli
+++ b/interp/impargs.mli
@@ -84,17 +84,20 @@ type implicit_side_condition
 
 type implicits_list = implicit_side_condition * implicit_status list
 
+val name_of_pos : int -> Id.t
 val is_status_implicit : implicit_status -> bool
 val binding_kind_of_status : implicit_status -> Glob_term.binding_kind
 val is_inferable_implicit : bool -> int -> implicit_status -> bool
-val name_of_implicit : implicit_status -> Id.t
-val match_implicit : implicit_status -> Constrexpr.explicitation -> bool
+val name_of_implicit : implicit_status -> Evar_kinds.explicitation
+val match_implicit : implicit_status -> Evar_kinds.explicitation -> bool
 val maximal_insertion_of : implicit_status -> bool
 val force_inference_of : implicit_status -> bool
 val is_nondep_implicit : int -> implicit_status list -> bool
-val explicitation : implicit_status -> Constrexpr.explicitation
+val explicitation : implicit_status -> Evar_kinds.explicitation
 
 val positions_of_implicits : implicits_list -> int list
+
+val pr_position : Evar_kinds.explicitation -> Pp.t
 
 type manual_implicits = (Name.t * bool) option CAst.t list
 

--- a/interp/impargs.mli
+++ b/interp/impargs.mli
@@ -84,12 +84,11 @@ type implicit_side_condition
 
 type implicits_list = implicit_side_condition * implicit_status list
 
-val name_of_pos : int -> Id.t
 val is_status_implicit : implicit_status -> bool
 val binding_kind_of_status : implicit_status -> Glob_term.binding_kind
 val is_inferable_implicit : bool -> int -> implicit_status -> bool
 val name_of_implicit : implicit_status -> Evar_kinds.explicitation
-val match_implicit : implicit_status -> Evar_kinds.explicitation -> bool
+val match_implicit : ?warn:bool -> implicit_status -> Evar_kinds.explicitation -> bool
 val maximal_insertion_of : implicit_status -> bool
 val force_inference_of : implicit_status -> bool
 val is_nondep_implicit : int -> implicit_status list -> bool

--- a/interp/implicit_quantifiers.ml
+++ b/interp/implicit_quantifiers.ml
@@ -21,6 +21,7 @@ open Pp
 open Libobject
 open Nameops
 open Context.Rel.Declaration
+open Evar_kinds
 
 module RelDecl = Context.Rel.Declaration
 (*i*)

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -16,6 +16,7 @@ open Names
 open Constr
 open Libnames
 open Glob_term
+open Evar_kinds
 open Constrexpr
 open Constrexpr_ops
 open Util

--- a/parsing/pcoq.mli
+++ b/parsing/pcoq.mli
@@ -199,7 +199,7 @@ module Constr :
     val binders_fixannot : (local_binder_expr list * recursion_order_expr option) Entry.t
     val typeclass_constraint : (lname * bool * constr_expr) Entry.t
     val record_declaration : constr_expr Entry.t
-    val arg : (constr_expr * explicitation CAst.t option) Entry.t
+    val arg : (constr_expr * Evar_kinds.explicitation CAst.t option) Entry.t
     val type_cstr : constr_expr Entry.t
   end
 

--- a/pretyping/glob_term.mli
+++ b/pretyping/glob_term.mli
@@ -77,7 +77,7 @@ type cases_pattern = [ `any ] cases_pattern_g
 type binding_kind = Explicit | MaxImplicit | NonMaxImplicit
 
 type glob_evar_kind = Evar_kinds.glob_evar_kind =
-  | GImplicitArg of GlobRef.t * (int * Id.t option) * bool (** Force inference *)
+  | GImplicitArg of GlobRef.t * (int * Evar_kinds.explicitation option) * bool (** Force inference *)
   | GBinderType of Name.t
   | GNamedHole of bool (* fresh? *) * Id.t (* coming from some ?[id] syntax *)
   | GQuestionMark of Evar_kinds.question_mark

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -19,6 +19,7 @@ open Pputils
 open Ppextend
 open Glob_term
 open Constrexpr
+open Evar_kinds
 open Constrexpr_ops
 (*i*)
 

--- a/test-suite/bugs/bug_12001.v
+++ b/test-suite/bugs/bug_12001.v
@@ -13,8 +13,8 @@ Fail Arguments bar a a0 : assert.
 (* This definition caused an anomaly in a version of this PR
 without the change to prepare_implicits *)
 Set Implicit Arguments.
-Definition foo (_ : nat) (_ : @eq nat ltac:(assumption) 2) : True := I.
-Fail Check foo (H := 2).
+Definition foo (x : nat) (_ : @eq nat ltac:(assumption) 2) : True := I.
+Check foo (x := 2).
 
 Definition baz (a b : nat) := b.
 Arguments baz a {b}.

--- a/test-suite/bugs/bug_3554.v
+++ b/test-suite/bugs/bug_3554.v
@@ -1,2 +1,2 @@
-Example foo (f : forall {_ : Type}, Type) : Type.
+Example foo (f : forall {A : Type}, Type) : Type.
 Abort.

--- a/test-suite/output/ClassMissingInstance.out
+++ b/test-suite/output/ClassMissingInstance.out
@@ -2,7 +2,7 @@ File "./output/ClassMissingInstance.v", line 7, characters 0-28:
 The command has indeed failed with message:
 Unable to satisfy the following constraints:
 
-?arg_2 : "Foo 1"
+?f : "Foo 1"
 
-?arg_20 : "Foo 2"
+?f0 : "Foo 2"
 

--- a/test-suite/output/Errors.out
+++ b/test-suite/output/Errors.out
@@ -17,8 +17,8 @@ The command has indeed failed with message:
 Cannot infer ?T in the partial instance "?T -> nat" found for the type of f.
 File "./output/Errors.v", line 35, characters 22-24:
 The command has indeed failed with message:
-Cannot infer ?T in the partial instance "?T -> nat" found for the implicit
-parameter A of id whose type is "Type".
+Cannot infer ?T in the partial instance "?T -> nat" found for
+the implicit parameter A of id whose type is "Type".
 File "./output/Errors.v", line 36, characters 17-18:
 The command has indeed failed with message:
 Cannot infer ?T in the partial instance "forall x : nat, ?T" found for the

--- a/test-suite/success/implicit.v
+++ b/test-suite/success/implicit.v
@@ -155,7 +155,7 @@ Check let f := fun [x:nat] y => y=true in f false.
 
 (* Isn't the name "arg_1" a bit fragile, here? *)
 
-Check fun f : forall {_:nat}, nat => f (arg_1:=0).
+Check fun f : forall {n:nat}, nat => f (n:=0).
 
 (* This test was wrongly warning/failing at some time *)
 

--- a/test-suite/success/implicit.v
+++ b/test-suite/success/implicit.v
@@ -133,12 +133,12 @@ Section D. Global Arguments eq [A] _ _. End D.
 (* Gives a warning and make the second x anonymous *)
 (* Isn't the name "arg_1" a bit fragile though? *)
 
-Check fun f : forall {x:nat} {x:bool} (x:unit), unit => f (x:=1) (arg_2:=true) tt.
+Check fun f : forall {x:nat} {x:bool} (x:unit), unit => f (x:=1) (x0:=true) tt.
 
 (* Check the existence of a shadowing warning *)
 
 Set Warnings "+syntax".
-Fail Check fun f : forall {x:nat} {x:bool} (x:unit), unit => f (x:=1) (arg_2:=true) tt.
+Fail Check fun f : forall {x:nat} {x:bool} (x:unit), unit => f (x:=1) (x0:=true) tt.
 Set Warnings "syntax".
 
 (* Test failure when implicit arguments are mentioned in subterms

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -582,7 +582,7 @@ let build_beq_scheme env handle kn =
               interpreted as the pair of the whole fix and of the
               translated recursive call building the equality
            2. something to do around either packaging the type with
-              its equality, or begin able for a match to have a return
+              its equality, or being able for a match to have a return
               predicate different though convertible to itself, namely
               here a fix of match (see test-suite) *)
       let mkfix j = mkFix ((recindxs,j),recdef) in

--- a/vernac/comArguments.ml
+++ b/vernac/comArguments.ml
@@ -113,7 +113,7 @@ let vernac_arguments ~section_local reference args more_implicits flags =
   let sr = smart_global reference in
   let inf_names =
     let ty, _ = Typeops.type_of_global_in_context env sr in
-    List.map pi1 (Impargs.compute_implicits_names env sigma (EConstr.of_constr ty))
+    Impargs.(List.map name_of_argument (compute_implicits_names env sigma (EConstr.of_constr ty)))
   in
   let prev_names =
     try Arguments_renaming.arguments_names sr with Not_found -> inf_names

--- a/vernac/comCoercion.ml
+++ b/vernac/comCoercion.ml
@@ -184,6 +184,7 @@ let build_id_coercion idf_opt source poly =
     | Some c -> c
     | None -> error_not_transparent source in
   let lams,t = decompose_lambda_decls c in
+  let lams = EConstr.Unsafe.to_rel_context (Namegen.name_context env sigma (EConstr.of_rel_context lams)) in
   let val_f =
     Term.it_mkLambda_or_LetIn
       (mkLambda (make_annot (Name Namegen.default_dependent_ident) Sorts.Relevant,

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -204,7 +204,7 @@ let build_wellfounded pm (recname,pl,bl,arityc,body) poly ?typing_flags ?depreca
     in
     let id = Id.of_string "recproof" in
     let impl = Some Impargs.{
-      impl_pos = (Name id, 1, Evar_kinds.ExplByName id);
+      impl_pos = { arg_explicitation = ByName (id,None); arg_absolute_pos = 1 };
       impl_expl = Manual;
       impl_max = true;
       impl_force = false;

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -202,8 +202,9 @@ let build_wellfounded pm (recname,pl,bl,arityc,body) poly ?typing_flags ?depreca
       Constrintern.compute_internalization_data env sigma recname
         Constrintern.Recursive full_arity impls
     in
+    let id = Id.of_string "recproof" in
     let impl = Some Impargs.{
-      impl_pos = (Name (Id.of_string "recproof"), 1, None);
+      impl_pos = (Name id, 1, Evar_kinds.ExplByName id);
       impl_expl = Manual;
       impl_max = true;
       impl_force = false;

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -619,8 +619,10 @@ let rec explain_evar_kind env sigma evk ty =
           with (* defined *) Not_found -> strbrk "an internal placeholder" in
       strbrk "the type of " ++ pp
   | Evar_kinds.ImplicitArg (c,(n,ido),b) ->
-      let id = Option.get ido in
-      strbrk "the implicit parameter " ++ Id.print id ++ spc () ++ str "of" ++
+      let pos = match ido with
+        | Some pos -> str "the implicit parameter " ++ Impargs.pr_position pos
+        | None -> str "some implicit parameter" in
+      pos ++ spc () ++ str "of" ++
       spc () ++ Nametab.pr_global_env Id.Set.empty c ++
       strbrk " whose type is " ++ ty
   | Evar_kinds.InternalHole -> strbrk "an internal placeholder of type " ++ ty

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -85,7 +85,7 @@ let print_ref reduce ref udecl =
 (********************************)
 (** Printing implicit arguments *)
 
-let pr_impl_name imp = Id.print (name_of_implicit imp)
+let pr_impl_name imp = pr_position (name_of_implicit imp)
 
 let print_impargs_by_name max = function
   | []  -> []

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -242,7 +242,7 @@ let needs_extra_scopes ref scopes =
 
 let implicit_kind_of_status = function
   | None -> Anonymous, Glob_term.Explicit
-  | Some imp -> pi1 imp.impl_pos, if imp.impl_max then Glob_term.MaxImplicit else Glob_term.NonMaxImplicit
+  | Some imp -> name_of_argument imp.impl_pos, if imp.impl_max then Glob_term.MaxImplicit else Glob_term.NonMaxImplicit
 
 let extra_implicit_kind_of_status imp =
   let _,imp = implicit_kind_of_status imp in
@@ -315,7 +315,7 @@ let print_arguments ref =
     with Not_found ->
       let env = Global.env () in
       let ty, _ = Typeops.type_of_global_in_context env ref in
-      List.map pi1 (Impargs.compute_implicits_names env (Evd.from_env env) (EConstr.of_constr ty)), true in
+      List.map name_of_argument (Impargs.compute_implicits_names env (Evd.from_env env) (EConstr.of_constr ty)), true in
   let scopes = Notation.find_arguments_scope ref in
   let flags = if needs_extra_scopes ref scopes then `ExtraScopes::flags else flags in
   let impls = Impargs.extract_impargs_data (Impargs.implicits_of_global ref) in


### PR DESCRIPTION
**Kind:** deprecation

Depends on #11099 (merged).

Alternative syntax is `(p:=term)` for `p` nth non-dependent implicit argument (provided by #11099).

Assuming no changelog since undocumented.

Note: some issues to fix with local implicit arguments. See test-suite.

- [X] Added / updated test-suite
