### PR TITLE
Explicit Projection nodes in concrete syntax

### DIFF
--- a/dev/ci/user-overlays/14598-herbelin-master+proj-nodes-in-concrete-syntax.sh
+++ b/dev/ci/user-overlays/14598-herbelin-master+proj-nodes-in-concrete-syntax.sh
@@ -1,0 +1,2 @@
+overlay elpi https://github.com/herbelin/coq-elpi coq-master+adapt-coq-pr14598-adding-proj-syntax-constructor 14598
+overlay quickchick https://github.com/herbelin/QuickChick master+adapt-coq-pr14598-adding-proj-syntax-constructor 14598

--- a/dev/doc/changes.md
+++ b/dev/doc/changes.md
@@ -9,6 +9,14 @@
 
 - Renaming `LSet` into `Level.Set` and `LMap` into `Level.Map`
 
+### Concrete syntax
+
+- Explicit nodes `CProj` and `GProj` have been added for the syntax of
+  projections `t.(f)` in `constr_expr` et `glob_constr`, while they
+  were previously encoded in the `CApp` and `GApp` nodes. There may be
+  a need for add a new case in pattern-matching. The types of `CApp`
+  and `CAppExpl` have been simplified accordingly.
+
 ## Changes between Coq 8.13 and Coq 8.14
 
 ### Build system and library infrastructure

--- a/dev/doc/changes.md
+++ b/dev/doc/changes.md
@@ -12,7 +12,7 @@
 ### Concrete syntax
 
 - Explicit nodes `CProj` and `GProj` have been added for the syntax of
-  projections `t.(f)` in `constr_expr` et `glob_constr`, while they
+  projections `t.(f)` in `constr_expr` and `glob_constr`, while they
   were previously encoded in the `CApp` and `GApp` nodes. There may be
   a need for add a new case in pattern-matching. The types of `CApp`
   and `CAppExpl` have been simplified accordingly.

--- a/dev/doc/changes.md
+++ b/dev/doc/changes.md
@@ -14,7 +14,7 @@
 - Explicit nodes `CProj` and `GProj` have been added for the syntax of
   projections `t.(f)` in `constr_expr` and `glob_constr`, while they
   were previously encoded in the `CApp` and `GApp` nodes. There may be
-  a need for add a new case in pattern-matching. The types of `CApp`
+  a need for adding a new case in pattern-matching. The types of `CApp`
   and `CAppExpl` have been simplified accordingly.
 
 ## Changes between Coq 8.13 and Coq 8.14

--- a/doc/sphinx/language/core/records.rst
+++ b/doc/sphinx/language/core/records.rst
@@ -178,8 +178,8 @@ Syntax of Record Projections
   .. insertprodn term_projection term_projection
 
   .. prodn::
-     term_projection ::= @term0 .( @qualid {* @arg } )
-     | @term0 .( @ @qualid {* @term1 } )
+     term_projection ::= @term0 .( @qualid {? @univ_annot } {* @arg } )
+     | @term0 .( @ @qualid {? @univ_annot } {* @term1 } )
 
 The corresponding grammar rules are given in the preceding grammar. When :token:`qualid`
 denotes a projection, the syntax :n:`@term0.(@qualid)` is equivalent to :n:`@qualid @term0`,

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -401,13 +401,13 @@ term9: [
 ]
 
 term1: [
-| REPLACE term0 ".(" global LIST0 arg ")"
-| WITH    term0 ".(" global LIST0 arg ")" (* huh? *)
+| REPLACE term0 ".(" global univ_annot LIST0 arg ")"
+| WITH    term0 ".(" global univ_annot LIST0 arg ")" (* huh? *)
 | REPLACE term0 "%" IDENT
 | WITH term0 "%" scope_key
 | MOVETO term_scope term0 "%" scope_key
-| MOVETO term_projection term0 ".(" global LIST0 arg ")"
-| MOVETO term_projection term0 ".(" "@" global LIST0 ( term9 ) ")"
+| MOVETO term_projection term0 ".(" global univ_annot LIST0 arg ")"
+| MOVETO term_projection term0 ".(" "@" global univ_annot LIST0 ( term9 ) ")"
 ]
 
 term0: [

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -103,8 +103,8 @@ term8: [
 ]
 
 term1: [
-| term0 ".(" global LIST0 arg ")"
-| term0 ".(" "@" global LIST0 ( term9 ) ")"
+| term0 ".(" global univ_annot LIST0 arg ")"
+| term0 ".(" "@" global univ_annot LIST0 ( term9 ) ")"
 | term0 "%" IDENT
 | term0
 ]

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -55,8 +55,8 @@ term_ltac: [
 ]
 
 term_projection: [
-| term0 ".(" qualid LIST0 arg ")"
-| term0 ".(" "@" qualid LIST0 ( term1 ) ")"
+| term0 ".(" qualid OPT univ_annot LIST0 arg ")"
+| term0 ".(" "@" qualid OPT univ_annot LIST0 ( term1 ) ")"
 ]
 
 term_scope: [

--- a/interp/constrexpr.ml
+++ b/interp/constrexpr.ml
@@ -71,7 +71,7 @@ type binder_kind =
 
 type abstraction_kind = AbsLambda | AbsPi
 
-type proj_flag = int option (** [Some n] = proj of the n-th visible argument *)
+type explicit_flag = bool (** true = with "@" *)
 
 type prim_token =
   | Number of NumTok.Signed.t
@@ -108,9 +108,10 @@ and constr_expr_r =
   | CProdN   of local_binder_expr list * constr_expr
   | CLambdaN of local_binder_expr list * constr_expr
   | CLetIn   of lname * constr_expr * constr_expr option * constr_expr
-  | CAppExpl of (proj_flag * qualid * instance_expr option) * constr_expr list
-  | CApp     of (proj_flag * constr_expr) *
-                (constr_expr * explicitation CAst.t option) list
+  | CAppExpl of (qualid * instance_expr option) * constr_expr list
+  | CApp     of constr_expr * (constr_expr * explicitation CAst.t option) list
+  | CProj    of explicit_flag * (qualid * instance_expr option)
+              * (constr_expr * explicitation CAst.t option) list * constr_expr
   | CRecord  of (qualid * constr_expr) list
 
   (* representation of the "let" and "match" constructs *)

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -141,15 +141,19 @@ let rec constr_expr_eq e1 e2 =
       constr_expr_eq a1 a2 &&
       Option.equal constr_expr_eq t1 t2 &&
       constr_expr_eq b1 b2
-    | CAppExpl((proj1,r1,u1),al1), CAppExpl((proj2,r2,u2),al2) ->
-      Option.equal Int.equal proj1 proj2 &&
+    | CAppExpl((r1,u1),al1), CAppExpl((r2,u2),al2) ->
       qualid_eq r1 r2 &&
       eq_universes u1 u2 &&
       List.equal constr_expr_eq al1 al2
-    | CApp((proj1,e1),al1), CApp((proj2,e2),al2) ->
-      Option.equal Int.equal proj1 proj2 &&
+    | CApp(e1,al1), CApp(e2,al2) ->
       constr_expr_eq e1 e2 &&
       List.equal args_eq al1 al2
+    | CProj(e1,(p1,u1),al1,c1), CProj(e2,(p2,u2),al2,c2) ->
+      e1 = (e2:bool) &&
+      qualid_eq p1 p2 &&
+      eq_universes u1 u2 &&
+      List.equal args_eq al1 al2 &&
+      constr_expr_eq c1 c2
     | CRecord l1, CRecord l2 ->
       let field_eq (r1, e1) (r2, e2) =
         qualid_eq r1 r2 && constr_expr_eq e1 e2
@@ -199,7 +203,7 @@ let rec constr_expr_eq e1 e2 =
       constr_expr_eq def1 def2 && constr_expr_eq ty1 ty2 &&
       eq_universes u1 u2
   | (CRef _ | CFix _ | CCoFix _ | CProdN _ | CLambdaN _ | CLetIn _ | CAppExpl _
-     | CApp _ | CRecord _ | CCases _ | CLetTuple _ | CIf _ | CHole _
+     | CApp _ | CProj _ | CRecord _ | CCases _ | CLetTuple _ | CIf _ | CHole _
      | CPatVar _ | CEvar _ | CSort _ | CCast _ | CNotation _ | CPrim _
      | CGeneralization _ | CDelimiters _ | CArray _), _ -> false
 
@@ -338,8 +342,9 @@ let rec fold_local_binders g f n acc b = let open CAst in function
     f n acc b
 
 let fold_constr_expr_with_binders g f n acc = CAst.with_val (function
-    | CAppExpl ((_,_,_),l) -> List.fold_left (f n) acc l
-    | CApp ((_,t),l) -> List.fold_left (f n) (f n acc t) (List.map fst l)
+    | CAppExpl ((_,_),l) -> List.fold_left (f n) acc l
+    | CApp (t,l) -> List.fold_left (f n) (f n acc t) (List.map fst l)
+    | CProj (e,_,l,t) -> f n (List.fold_left (f n) acc (List.map fst l)) t
     | CProdN (l,b) | CLambdaN (l,b) -> fold_local_binders g f n acc b l
     | CLetIn (na,a,t,b) ->
       f (Name.fold_right g (na.CAst.v) n) (Option.fold_left (f n) (f n acc a) t) b
@@ -447,8 +452,10 @@ let fold_map_local_binders f g e bl =
 
 let map_constr_expr_with_binders g f e = CAst.map (function
     | CAppExpl (r,l) -> CAppExpl (r,List.map (f e) l)
-    | CApp ((p,a),l) ->
-      CApp ((p,f e a),List.map (fun (a,i) -> (f e a,i)) l)
+    | CApp (a,l) ->
+      CApp (f e a,List.map (fun (a,i) -> (f e a,i)) l)
+    | CProj (expl,p,l,a) ->
+      CProj (expl,p,List.map (fun (a,i) -> (f e a,i)) l,f e a)
     | CProdN (bl,b) ->
       let (e,bl) = fold_map_local_binders f g e bl in CProdN (bl,f e b)
     | CLambdaN (bl,b) ->
@@ -585,7 +592,7 @@ let mkAppC (f,l) =
   let l = List.map (fun x -> (x,None)) l in
   match CAst.(f.v) with
   | CApp (g,l') -> CAst.make @@ CApp (g, l' @ l)
-  | _           -> CAst.make @@ CApp ((None, f), l)
+  | _           -> CAst.make @@ CApp (f, l)
 
 let mkProdCN ?loc bll c =
   if bll = [] then c else
@@ -646,9 +653,9 @@ let rec coerce_to_cases_pattern_expr c = CAst.map_with_loc (fun ?loc -> function
   | CLetIn ({CAst.loc;v=Name id},b,None,{ CAst.v = CRef (qid,None) })
       when qualid_is_ident qid && Id.equal id (qualid_basename qid) ->
       CPatAlias (coerce_to_cases_pattern_expr b, CAst.(make ?loc @@ Name id))
-  | CApp ((None,p),args) when List.for_all (fun (_,e) -> e=None) args ->
+  | CApp (p,args) when List.for_all (fun (_,e) -> e=None) args ->
      (mkAppPattern (coerce_to_cases_pattern_expr p) (List.map (fun (a,_) -> coerce_to_cases_pattern_expr a) args)).CAst.v
-  | CAppExpl ((None,r,i),args) ->
+  | CAppExpl ((r,i),args) ->
      CPatCstr (r,Some (List.map coerce_to_cases_pattern_expr args),[])
   | CNotation (inscope,ntn,(c,cl,[],[])) ->
      CPatNotation (inscope,ntn,(List.map coerce_to_cases_pattern_expr c,

--- a/interp/implicit_quantifiers.ml
+++ b/interp/implicit_quantifiers.ml
@@ -178,7 +178,7 @@ let destClassAppExpl cl =
   let open CAst in
   let loc = cl.loc in
   match cl.v with
-    | CApp ((None, { v = CRef (ref, inst) } ), l) -> CAst.make ?loc (ref, l, inst)
+    | CApp ({ v = CRef (ref, inst) }, l) -> CAst.make ?loc (ref, l, inst)
     | CRef (ref, inst) -> CAst.make ?loc:cl.loc (ref, [], inst)
     | _ -> raise Not_found
 
@@ -200,7 +200,7 @@ let implicit_application env ty =
     let sigma = Evd.from_env env in
     let c = class_info env sigma gr in
     let args, avoid = combine_params avoid par (List.rev c.cl_context) in
-    CAst.make ?loc @@ CAppExpl ((None, id, inst), args), avoid
+    CAst.make ?loc @@ CAppExpl ((id, inst), args), avoid
 
 let warn_ignoring_implicit_status =
   CWarnings.create ~name:"ignoring_implicit_status" ~category:"implicits"

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -380,6 +380,7 @@ let glob_prim_constr_key c = match DAst.get c with
     | GRef (ref, _) -> Some (canonical_gr ref)
     | _ -> None
     end
+  | GProj ((cst,_), _, _) -> Some (canonical_gr (GlobRef.ConstRef cst))
   | _ -> None
 
 let glob_constr_keys c = match DAst.get c with
@@ -388,6 +389,7 @@ let glob_constr_keys c = match DAst.get c with
     | GRef (ref, _) -> [RefKey (canonical_gr ref); Oth]
     | _ -> [Oth]
     end
+  | GProj ((cst,_), _, _) -> [RefKey (canonical_gr (GlobRef.ConstRef cst))]
   | GRef (ref,_) -> [RefKey (canonical_gr ref)]
   | _ -> [Oth]
 
@@ -397,6 +399,7 @@ let cases_pattern_key c = match DAst.get c with
 
 let notation_constr_key = function (* Rem: NApp(NRef ref,[]) stands for @ref *)
   | NApp (NRef (ref,_),args) -> RefKey(canonical_gr ref), AppBoundedNotation (List.length args)
+  | NProj ((cst,_),args,_) -> RefKey(canonical_gr (GlobRef.ConstRef cst)), AppBoundedNotation (List.length args + 1)
   | NList (_,_,NApp (NRef (ref,_),args),_,_)
   | NBinderList (_,_,NApp (NRef (ref,_),args),_,_) ->
       RefKey (canonical_gr ref), AppBoundedNotation (List.length args)

--- a/interp/notation_term.ml
+++ b/interp/notation_term.ml
@@ -24,6 +24,7 @@ type notation_constr =
   | NRef of GlobRef.t * glob_level list option
   | NVar of Id.t
   | NApp of notation_constr * notation_constr list
+  | NProj of (Constant.t * glob_level list option) * notation_constr list * notation_constr
   | NHole of Evar_kinds.t * Namegen.intro_pattern_naming_expr * Genarg.glob_generic_argument option
   | NList of Id.t * Id.t * notation_constr * notation_constr * (* associativity: *) bool
   (* Part only in [glob_constr] *)

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -140,7 +140,7 @@ GRAMMAR EXTEND Gram
   ;
   constr:
     [ [ c = term LEVEL "8" -> { c }
-      | "@"; f=global; i = univ_annot -> { CAst.make ~loc @@ CAppExpl((None,f,i),[]) } ] ]
+      | "@"; f=global; i = univ_annot -> { CAst.make ~loc @@ CAppExpl((f,i),[]) } ] ]
   ;
   term:
     [ "200" RIGHTA
@@ -155,22 +155,22 @@ GRAMMAR EXTEND Gram
     | "99" RIGHTA [ ]
     | "90" RIGHTA [ ]
     | "10" LEFTA
-      [ f = term; args = LIST1 arg -> { CAst.make ~loc @@ CApp((None,f),args) }
-      | "@"; f = global; i = univ_annot; args = LIST0 NEXT -> { CAst.make ~loc @@ CAppExpl((None,f,i),args) }
+      [ f = term; args = LIST1 arg -> { CAst.make ~loc @@ CApp(f,args) }
+      | "@"; f = global; i = univ_annot; args = LIST0 NEXT -> { CAst.make ~loc @@ CAppExpl((f,i),args) }
       | "@"; lid = pattern_ident; args = LIST1 identref ->
         { let { CAst.loc = locid; v = id } = lid in
           let args = List.map (fun x -> CAst.make @@ CRef (qualid_of_ident ?loc:x.CAst.loc x.CAst.v, None), None) args in
-          CAst.make ~loc @@ CApp((None, CAst.make ?loc:locid @@ CPatVar id),args) } ]
+          CAst.make ~loc @@ CApp(CAst.make ?loc:locid @@ CPatVar id,args) } ]
     | "9"
       [ ".."; c = term LEVEL "0"; ".." ->
-        { CAst.make ~loc @@ CAppExpl ((None, (qualid_of_ident ~loc ldots_var), None),[c]) } ]
+        { CAst.make ~loc @@ CAppExpl ((qualid_of_ident ~loc ldots_var, None),[c]) } ]
     | "8" [ ]
     | "1" LEFTA
-      [ c = term; ".("; f = global; args = LIST0 arg; ")" ->
-        { CAst.make ~loc @@ CApp((Some (List.length args+1), CAst.make @@ CRef (f,None)),args@[c,None]) }
-      | c = term; ".("; "@"; f = global;
+      [ c = term; ".("; f = global; i = univ_annot; args = LIST0 arg; ")" ->
+        { CAst.make ~loc @@ CProj(false, (f,i), args, c) }
+      | c = term; ".("; "@"; f = global; i = univ_annot;
         args = LIST0 (term LEVEL "9"); ")" ->
-        { CAst.make ~loc @@ CAppExpl((Some (List.length args+1),f,None),args@[c]) }
+        { CAst.make ~loc @@ CProj(true, (f,i), List.map (fun a -> (a,None)) args, c) }
       | c = term; "%"; key = IDENT -> { CAst.make ~loc @@ CDelimiters (key,c) } ]
     | "0"
       [ c = atomic_constr -> { c }

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -103,7 +103,7 @@ let is_rec names =
               (fun acc na -> Nameops.Name.fold_right Id.Set.remove na acc)
               names nal)
            b
-    | GApp (f, args) -> List.exists (lookup names) (f :: args)
+    | GApp (c, args) | GProj (_, args, c) -> List.exists (lookup names) (c :: args)
     | GArray (_u, t, def, ty) ->
       Array.exists (lookup names) t || lookup names def || lookup names ty
     | GCases (_, _, el, brl) ->
@@ -1660,7 +1660,7 @@ let register_wf interactive_proof ?(is_mes = false) fname rec_impls wf_rel_expr
     let f_app_args =
       CAst.make
       @@ Constrexpr.CAppExpl
-           ( (None, Libnames.qualid_of_ident fname, None)
+           ( (Libnames.qualid_of_ident fname, None)
            , List.map
                (function
                  | {CAst.v = Anonymous} -> assert false
@@ -1669,7 +1669,7 @@ let register_wf interactive_proof ?(is_mes = false) fname rec_impls wf_rel_expr
     in
     CAst.make
     @@ Constrexpr.CApp
-         ( (None, Constrexpr_ops.mkRefC (Libnames.qualid_of_string "Logic.eq"))
+         ( Constrexpr_ops.mkRefC (Libnames.qualid_of_string "Logic.eq")
          , [(f_app_args, None); (body, None)] )
   in
   let eq = Constrexpr_ops.mkCProdN args unbounded_eq in
@@ -1951,7 +1951,7 @@ let rec add_args id new_args =
   CAst.map (function
     | CRef (qid, _) as b ->
       if qualid_is_ident qid && Id.equal (qualid_basename qid) id then
-        CAppExpl ((None, qid, None), new_args)
+        CAppExpl ((qid, None), new_args)
       else b
     | CFix _ | CCoFix _ -> CErrors.anomaly ~label:"add_args " (Pp.str "todo.")
     | CProdN (nal, b1) ->
@@ -1990,15 +1990,20 @@ let rec add_args id new_args =
         , add_args id new_args b1
         , Option.map (add_args id new_args) t
         , add_args id new_args b2 )
-    | CAppExpl ((pf, qid, us), exprl) ->
+    | CAppExpl ((qid, us), exprl) ->
       if qualid_is_ident qid && Id.equal (qualid_basename qid) id then
         CAppExpl
-          ((pf, qid, us), new_args @ List.map (add_args id new_args) exprl)
-      else CAppExpl ((pf, qid, us), List.map (add_args id new_args) exprl)
-    | CApp ((pf, b), bl) ->
+          ((qid, us), new_args @ List.map (add_args id new_args) exprl)
+      else CAppExpl ((qid, us), List.map (add_args id new_args) exprl)
+    | CApp (b, bl) ->
       CApp
-        ( (pf, add_args id new_args b)
+        ( add_args id new_args b
         , List.map (fun (e, o) -> (add_args id new_args e, o)) bl )
+    | CProj (expl, f, bl, b) ->
+      CProj
+        (expl, f
+        , List.map (fun (e, o) -> (add_args id new_args e, o)) bl
+        , add_args id new_args b)
     | CCases (sty, b_option, cel, cal) ->
       CCases
         ( sty

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -1757,11 +1757,11 @@ let rec strategy_of_ast ist = function
 
 (* By default the strategy for "rewrite_db" is top-down *)
 
-let mkappc s l = CAst.make @@ CAppExpl ((None,qualid_of_ident (Id.of_string s),None),l)
+let mkappc s l = CAst.make @@ CAppExpl ((qualid_of_ident (Id.of_string s),None),l)
 
 let declare_an_instance n s args =
   (((CAst.make @@ Name n),None),
-   CAst.make @@ CAppExpl ((None, qualid_of_string s,None), args))
+   CAst.make @@ CAppExpl ((qualid_of_string s,None), args))
 
 let declare_instance a aeq n s = declare_an_instance n s [a;aeq]
 
@@ -1978,7 +1978,7 @@ let add_morphism atts binders m s n =
   let instance_name = (CAst.make @@ Name instance_id),None in
   let instance_t =
     CAst.make @@ CAppExpl
-      ((None, Libnames.qualid_of_string "Coq.Classes.Morphisms.Proper",None),
+      ((Libnames.qualid_of_string "Coq.Classes.Morphisms.Proper",None),
        [cHole; s; m])
   in
   let tac = Tacinterp.interp (make_tactic "add_morphism_tactic") in

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -406,7 +406,7 @@ let intern_typed_pattern_or_ref_with_occurrences ist (l,p) =
           Inr (bound_names,(c,None),dummy_pat) in
   (l, match p with
   | Inl r -> interp_ref r
-  | Inr { v = CAppExpl((None,r,None),[]) } ->
+  | Inr { v = CAppExpl((r,None),[]) } ->
       (* We interpret similarly @ref and ref *)
       interp_ref (make @@ AN r)
   | Inr c ->

--- a/plugins/ssr/ssrvernac.mlg
+++ b/plugins/ssr/ssrvernac.mlg
@@ -193,10 +193,10 @@ END
 {
 
 let pr_raw_ssrhintref env sigma prc _ _ = let open CAst in function
-  | { v = CAppExpl ((None, r,x), args) } when isCHoles args ->
+  | { v = CAppExpl ((r,x), args) } when isCHoles args ->
     prc env sigma (CAst.make @@ CRef (r,x)) ++ str "|" ++ int (List.length args)
-  | { v = CApp ((_, { v = CRef _ }), _) } as c -> prc env sigma c
-  | { v = CApp ((_, c), args) } when isCxHoles args ->
+  | { v = CApp ({ v = CRef _ }, _) } as c -> prc env sigma c
+  | { v = CApp (c, args) } when isCxHoles args ->
     prc env sigma c ++ str "|" ++ int (List.length args)
   | c -> prc env sigma c
 
@@ -211,7 +211,7 @@ let pr_glob_ssrhintref env sigma _ _ _ (c, _) = pr_rawhintref env sigma c
 let pr_ssrhintref env sigma prc _ _ = prc env sigma
 
 let mkhintref ?loc c n = match c.CAst.v with
-  | CRef (r,x) -> CAst.make ?loc @@ CAppExpl ((None, r, x), mkCHoles ?loc n)
+  | CRef (r,x) -> CAst.make ?loc @@ CAppExpl ((r, x), mkCHoles ?loc n)
   | _ -> mkAppC (c, mkCHoles ?loc n)
 
 }

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -940,7 +940,7 @@ let id_of_cpattern {pattern = (c1, c2); _} =
   match DAst.get c1, c2 with
   | _, Some { v = CRef (qid, _) } when qualid_is_ident qid ->
     Some (qualid_basename qid)
-  | _, Some { v = CAppExpl ((_, qid, _), []) } when qualid_is_ident qid ->
+  | _, Some { v = CAppExpl ((qid, _), []) } when qualid_is_ident qid ->
     Some (qualid_basename qid)
   | GRef (GlobRef.VarRef x, _), None -> Some x
   | _ -> None

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -1072,6 +1072,15 @@ let rec subst_glob_constr env subst = DAst.map (function
         if r' == r && rl' == rl then raw else
           GApp(r',rl')
 
+  | GProj ((cst,u),rl,r) as raw ->
+      let rl' = List.Smart.map (subst_glob_constr env subst) rl
+      and r' = subst_glob_constr env subst r in
+      let ref = GlobRef.ConstRef cst in
+      let ref',t = subst_global subst ref in
+      assert (t = None); (* projection *)
+        if ref' == ref && rl' == rl && r' == r then raw else
+          GProj((destConstRef ref',u),rl',r')
+
   | GLambda (n,bk,r1,r2) as raw ->
       let r1' = subst_glob_constr env subst r1 and r2' = subst_glob_constr env subst r2 in
         if r1' == r1 && r2' == r2 then raw else

--- a/pretyping/glob_ops.ml
+++ b/pretyping/glob_ops.ml
@@ -171,13 +171,17 @@ let mk_glob_constr_eq f c1 c2 = match DAst.get c1, DAst.get c2 with
     Namegen.intro_pattern_naming_eq nam1 nam2
   | GCast (c1, t1), GCast (c2, t2) ->
     f c1 c2 && cast_type_eq f t1 t2
+  | GProj ((cst1, u1), args1, c1), GProj ((cst2, u2), args2, c2) ->
+    GlobRef.(equal (ConstRef cst1) (ConstRef cst2)) &&
+    Option.equal (List.equal glob_level_eq) u1 u2 &&
+    List.equal f args1 args2 && f c1 c2
   | GInt i1, GInt i2 -> Uint63.equal i1 i2
   | GFloat f1, GFloat f2 -> Float64.equal f1 f2
   | GArray (u1, t1, def1, ty1), GArray (u2, t2, def2, ty2) ->
     Array.equal f t1 t2 && f def1 def2 && f ty1 ty2 &&
     Option.equal (List.equal glob_level_eq) u1 u2
   | (GRef _ | GVar _ | GEvar _ | GPatVar _ | GApp _ | GLambda _ | GProd _ | GLetIn _ |
-     GCases _ | GLetTuple _ | GIf _ | GRec _ | GSort _ | GHole _ | GCast _ |
+     GCases _ | GLetTuple _ | GIf _ | GRec _ | GSort _ | GHole _ | GCast _ | GProj _ |
      GInt _ | GFloat _ | GArray _), _ -> false
 
 let rec glob_constr_eq c = mk_glob_constr_eq glob_constr_eq c
@@ -237,6 +241,10 @@ let map_glob_constr_left_to_right f = DAst.map (function
       let comp1 = f c in
       let comp2 = map_cast_type f k in
       GCast (comp1,comp2)
+  | GProj (p,args,c) ->
+      let comp1 = Util.List.map_left f args in
+      let comp2 = f c in
+      GProj (p,comp1,comp2)
   | GArray (u,t,def,ty) ->
       let comp1 = Array.map_left f t in
       let comp2 = f def in
@@ -274,6 +282,8 @@ let fold_glob_constr f acc = DAst.with_val (function
     let acc = match k with
       | CastConv t | CastVM t | CastNative t -> f acc t in
     f acc c
+  | GProj (p,args,c) ->
+    f (List.fold_left f acc args) c
   | GArray (_u,t,def,ty) -> f (f (Array.fold_left f acc t) def) ty
   | (GSort _ | GHole _ | GRef _ | GEvar _ | GPatVar _ | GInt _ | GFloat _) -> acc
   )
@@ -317,6 +327,8 @@ let fold_glob_constr_with_binders g f v acc = DAst.(with_val (function
     let acc = match k with
       | CastConv t | CastVM t | CastNative t -> f v acc t in
     f v acc c
+  | GProj (p,args,c) ->
+    f v (List.fold_left (f v) acc args) c
   | GArray (_u, t, def, ty) -> f v (f v (Array.fold_left (f v) acc t) def) ty
   | (GSort _ | GHole _ | GRef _ | GEvar _ | GPatVar _ | GInt _ | GFloat _) -> acc))
 

--- a/pretyping/glob_term.ml
+++ b/pretyping/glob_term.ml
@@ -95,6 +95,7 @@ type 'a glob_constr_r =
   | GSort of glob_sort
   | GHole of Evar_kinds.t * Namegen.intro_pattern_naming_expr * Genarg.glob_generic_argument option
   | GCast of 'a glob_constr_g * 'a glob_constr_g cast_type
+  | GProj of (Constant.t * glob_level list option) * 'a glob_constr_g list * 'a glob_constr_g
   | GInt of Uint63.t
   | GFloat of Float64.t
   | GArray of glob_level list option * 'a glob_constr_g array * 'a glob_constr_g * 'a glob_constr_g

--- a/pretyping/patternops.ml
+++ b/pretyping/patternops.ml
@@ -432,6 +432,13 @@ let rec pat_of_raw metas vars = DAst.with_loc_val (fun ?loc -> function
       PApp (pat_of_raw metas vars c,
             Array.of_list (List.map (pat_of_raw metas vars) cl))
     end
+  | GProj ((p,_), cl, c) ->
+    if Structures.PrimitiveProjections.mem p then
+      let p = Option.get @@ Structures.PrimitiveProjections.find_opt p in
+      let p = Projection.make p false in
+      PProj (p, pat_of_raw metas vars c)
+    else
+      PApp (PRef (GlobRef.ConstRef p), Array.map_of_list (pat_of_raw metas vars) (cl @ [c]))
   | GLambda (na,bk,c1,c2) ->
       Name.iter (fun n -> metas := n::!metas) na;
       PLambda (na, pat_of_raw metas vars c1,

--- a/pretyping/pretyping.mli
+++ b/pretyping/pretyping.mli
@@ -150,6 +150,7 @@ type pretyper = {
   pretype_evar : pretyper -> existential_name CAst.t * (lident * glob_constr) list -> unsafe_judgment pretype_fun;
   pretype_patvar : pretyper -> Evar_kinds.matching_var_kind -> unsafe_judgment pretype_fun;
   pretype_app : pretyper -> glob_constr * glob_constr list -> unsafe_judgment pretype_fun;
+  pretype_proj : pretyper -> (Constant.t * glob_level list option) * glob_constr list * glob_constr -> unsafe_judgment pretype_fun;
   pretype_lambda : pretyper -> Name.t * binding_kind * glob_constr * glob_constr -> unsafe_judgment pretype_fun;
   pretype_prod : pretyper -> Name.t * binding_kind * glob_constr * glob_constr -> unsafe_judgment pretype_fun;
   pretype_letin : pretyper -> Name.t * glob_constr * glob_constr option * glob_constr -> unsafe_judgment pretype_fun;

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -500,12 +500,16 @@ let match_goals ot nt =
       constr_expr ogname c1 c12;
       constr_expr_opt ogname t t2;
       constr_expr ogname c2 c22
-    | CAppExpl ((isproj,ref,us),args), CAppExpl ((isproj2,ref2,us2),args2) ->
+    | CAppExpl ((ref,us),args), CAppExpl ((ref2,us2),args2) ->
       iter2 (constr_expr ogname) args args2
-    | CApp ((isproj,f),args), CApp ((isproj2,f2),args2) ->
+    | CApp (f,args), CApp (f2,args2) ->
       constr_expr ogname f f2;
       iter2 (fun a a2 -> let (c, _) = a and (c2, _) = a2 in
           constr_expr ogname c c2) args args2
+    | CProj (expl,f,args,c), CProj (expl2,f2,args2,c2) ->
+      iter2 (fun a a2 -> let (c, _) = a and (c2, _) = a2 in
+          constr_expr ogname c c2) args args2;
+      constr_expr ogname c c2;
     | CRecord fs, CRecord fs2 ->
       iter2 (fun a a2 -> let (_, c) = a and (_, c2) = a2 in
           constr_expr ogname c c2) fs fs2

--- a/test-suite/output/bug_6764.out
+++ b/test-suite/output/bug_6764.out
@@ -1,0 +1,8 @@
+forall f : foo, ■ f = ■ f
+     : Prop
+forall f : foo, ■ f = ■ f
+     : Prop
+fun x : T => %% x
+     : T -> nat
+fun x : T => %% x
+     : T -> nat

--- a/test-suite/output/bug_6764.v
+++ b/test-suite/output/bug_6764.v
@@ -1,0 +1,27 @@
+Module A.
+Set Primitive Projections.
+Record foo := Foo { foo_n : nat }.
+Notation "'■' x" := (foo_n x) (at level 50).
+Check forall (f:foo), ■ f = ■ f.
+End A.
+
+Module A'.
+Set Primitive Projections.
+Record foo := Foo { foo_n : nat }.
+Notation "'■' x" := x.(foo_n) (at level 50).
+Check forall (f:foo), ■ f = ■ f.
+End A'.
+
+(* Variant with non-primitive projections *)
+
+Module B.
+Record T := {a:nat}.
+Notation "%% x" := (a x) (at level 0, x at level 0).
+Check fun x => %%x.
+End B.
+
+Module B'.
+Record T := {a:nat}.
+Notation "%% x" := x.(a) (at level 0, x at level 0).
+Check fun x => %%x.
+End B'.

--- a/test-suite/success/Funind.v
+++ b/test-suite/success/Funind.v
@@ -504,10 +504,22 @@ reflexivity.
 simpl;rewrite IHn0;reflexivity.
 Qed.
 
+(* An example with projections *)
 
+Require Import FunInd.
+Require Import List.
 
+Record foo (X:Type):= {a:nat; b:X}.
 
+Inductive ind X: Type :=
+| C: foo X -> ind X
+| D: ind X -> ind X.
 
-
-
-
+Function f X (deflt:X) (x:ind X) {struct x} :=
+  match x with
+    @C _ fo => match fo.(a X) with
+             O => fo.(b X)
+           | S n => deflt
+           end
+  | D _ d => f _ deflt d
+  end.


### PR DESCRIPTION
**Kind:** infrastructure.

This PR changes the isproj-based encoding of `CApp`/`CAppExpl` to explicit `CProj`/`GProj`/`NProj` constructors.

There is also support for universes in the `r.(f)` syntax.

It is similar to #6651 but purely restricted to the change of representation. In particular, in this PR, `NProj` behaves like `NApp` and `GProj` like `GApp` (for instance, reversibility of parsing as in #6764 works). Compared to #6651, it includes parameters in the `CProj`/`GProj`/`NProj` so as to cover the case of non-primitive projections too. Also, it implements appropriate code for these extra constructors (up to one exception in funind which I suspect should not occur).

- [x] Added / updated test-suite (need tests...)
- [x]  note in `dev/doc/changes.md`
- [x] Overlay pull requests: QuickChick/QuickChick#230 and LPCIC/coq-elpi#274

Note: The PR originally included an improvement about using implicit arguments with the `r.(f)` syntax though. It moved to #14606 on which it depended. #14606 itself evolved to also fix #4167.