### PR TITLE
Bench zulip bot: skip zulip_edit when zulip posting is disabled

### DIFF
--- a/dev/bench/bench.sh
+++ b/dev/bench/bench.sh
@@ -237,6 +237,7 @@ On packages $coq_opam_packages
 fi
 
 zulip_edit() {
+    if ! [[ $zulip_post ]]; then return; fi
     ending=$1
     if [[ $rendered_results ]]; then
         msg="$zulip_header


### PR DESCRIPTION
Typically when running outside the coq/coq gitlab runners.
