### PR TITLE
ConstructiveEpsilon 

### DIFF
--- a/doc/changelog/10-standard-library/14601-CEJF.rst
+++ b/doc/changelog/10-standard-library/14601-CEJF.rst
@@ -1,0 +1,11 @@
+- **Changed:**
+  The new type of  `epsilon_smallest` is
+  `(exists n : nat, P n) -> { n : nat | P n /\ forall k, P k -> n <= k }`.
+  Here the minimality of [n] is expressed by `forall k, P k -> n <= k`
+  corresponding to the intuitive meaning of minimality
+  "the others are greater", whereas the previous version used
+  the negative equivalent formulation `forall k, k < n -> ~P k`.
+  Scripts using `epsilon_smallest` can easily be adapted using
+  lemmas `le_not_lt` and `lt_not_le` from the standard library.
+  (`#14601 <https://github.com/coq/coq/pull/14601>`_,
+  by Jean-Francois Monin).

--- a/doc/changelog/10-standard-library/14601-CEJF.rst
+++ b/doc/changelog/10-standard-library/14601-CEJF.rst
@@ -1,7 +1,7 @@
 - **Changed:**
   The new type of  `epsilon_smallest` is
   `(exists n : nat, P n) -> { n : nat | P n /\ forall k, P k -> n <= k }`.
-  Here the minimality of [n] is expressed by `forall k, P k -> n <= k`
+  Here the minimality of `n` is expressed by `forall k, P k -> n <= k`
   corresponding to the intuitive meaning of minimality
   "the others are greater", whereas the previous version used
   the negative equivalent formulation `forall k, k < n -> ~P k`.

--- a/theories/Logic/ConstructiveEpsilon.v
+++ b/theories/Logic/ConstructiveEpsilon.v
@@ -36,7 +36,7 @@ For the first one we provide explicit and short proof terms. *)
 
 (** The method based on [before_witness] (2009) can be seen as an ancestor
 of the first ingredient of the Braga method, by Dominique Larchey-Wendling
-and Jean-François Monin (Types'18, then in more details in [1]).
+and Jean-François Monin (Types'18, then in more details in [[1]]).
 In this approach, the termination certificate is usually combined
 with an inductive relational presentation of the recursive function
 of interest. This became especially useful here since the introduction
@@ -67,7 +67,7 @@ In simple situations such as linear search, one can as well
 directly define the type of the termination certificate and
 the n+1-ary Coq version of [f].
 Several variants of the proofs are offered for the record:
-- a version that follows the steps in [1], named linear_search_conform];
+- a version that follows the steps in [[1]], named [linear_search_conform];
 - a variant of the latter, named [linear_search_conform'],
   where the recursive call is no longer encapsulated in a
   pattern-matching (avoiding packing-unpacking steps which
@@ -90,7 +90,7 @@ and [linear_search_conform'] are purposely presented in a
 very similar manner, using [refine] and postponing proof obligations
 related to conformity to [rel_ls].
 
- [1] Dominique Larchey-Wendling and Jean-François Monin.
+ [[1]] Dominique Larchey-Wendling and Jean-François Monin.
      The Braga Method: Extracting Certified Algorithms from
      Complex Recursive Schemes in Coq, chapter 8, pages 305--386.
      In K. Mainzer, P. Schuster, and H. Schwichtenberg, editors.

--- a/theories/Logic/ConstructiveEpsilon.v
+++ b/theories/Logic/ConstructiveEpsilon.v
@@ -79,7 +79,7 @@ Several variants of the proofs are offered for the record:
   its output are separately proven.
 It is interesting to see that in the last version, the conformity
 proof slightly deviates from the definition of [prog_linear_search],
-resulting in an unplasant duplication of proof obligations, because
+resulting in an unpleasant duplication of proof obligations, because
 the first pattern-matching is performed on [P_dec start] in the
 function and on the termination certificate in the conformity proof.
 This deviation seems to be unavoidable because crucial proof steps

--- a/theories/Logic/ConstructiveEpsilon.v
+++ b/theories/Logic/ConstructiveEpsilon.v
@@ -214,6 +214,10 @@ Proof.
     + apply (IH _ pk), le_n_S, greater.
 Qed.
 
+(** For compatibility with previous version *)
+Definition linear_search start (b : before_witness start) : {n : nat | P n} :=
+  let (n, p) := linear_search_conform start b in exist _ n (rel_ls_post p).
+
 (** Main definitions *)
 Definition constructive_indefinite_ground_description_nat :
   (exists n, P n) -> {n:nat | P n}.

--- a/theories/Logic/ConstructiveEpsilon.v
+++ b/theories/Logic/ConstructiveEpsilon.v
@@ -70,22 +70,68 @@ Fixpoint O_witness (n : nat) : before_witness n -> before_witness 0 :=
 is structurally smaller even in the [stop] case. *)
 Definition inv_before_witness :
   forall n, before_witness n -> ~(P n) -> before_witness (S n) :=
-  fun n b =>
-    match b return ~ P n -> before_witness (S n) with
-      | stop _ p => fun not_p => match (not_p p) with end
-      | next _ b => fun _ => b
+  fun n b not_p =>
+    match b with
+      | stop _ p => match not_p p with end
+      | next _ b => b
     end.
 
+(** Relational version of linear search
+    (output-input order so that [found] is a parameter) *)
+Inductive Rls (found : nat) : nat -> Prop :=
+| Rstop : P found -> Rls found found
+| Rnext : forall start, ~(P start) -> Rls found (S start) -> Rls found start.
+
+(* A VIRER
 Fixpoint linear_search m (b : before_witness m) : {n : nat | P n} :=
   match P_dec m with
     | left yes => exist (fun n => P n) m yes
     | right no => linear_search (S m) (inv_before_witness m b no)
   end.
+ *)
 
+(** Program *)
+Fixpoint linear_search start (b : before_witness start) : nat :=
+  match P_dec start with
+    | left yes => start
+    | right no => linear_search (S start) (inv_before_witness start b no)
+  end.
+
+(** Linear_search satisfies Rls *)
+Fixpoint ls_spec start b : Rls (linear_search start b) start.
+Proof.
+  refine (match b with stop _ p => _ | next _ b => _  end);
+  refine (match P_dec start as x return Rls (if x then _ else _) start with
+          | left yes => Rstop start yes
+          | right no => _
+          end); fold linear_search.
+  - case (no p).
+  - apply (Rnext _ _ no), ls_spec.
+Qed.
+
+(** Rls entails P on the output *)
+Theorem Rls_P : forall start {found}, Rls found start -> P found.
+Proof.
+  intros * rls. induction rls as [p | n b rls IHrls].
+  - exact p.
+  - exact IHrls.
+Qed.
+
+(* A VIRER
 Definition constructive_indefinite_ground_description_nat :
   (exists n, P n) -> {n:nat | P n} :=
   fun e => linear_search O (let (n, p) := e in O_witness n (stop n p)).
+ *)
 
+Definition constructive_indefinite_ground_description_nat :
+  (exists n, P n) -> {n:nat | P n} :=
+  fun e =>
+    let b := let (n, p) := e in O_witness n (stop n p) in
+    let found := linear_search 0 b in
+    let g : Rls found 0 := ls_spec 0 b in
+    exist P found (Rls_P 0 g).
+
+(* A VIRER
 Fixpoint linear_search_smallest (start : nat) (pr : before_witness start) :
   forall k : nat, start <= k < proj1_sig (linear_search start pr) -> ~P k.
 Proof.
@@ -110,6 +156,42 @@ Proof.
   destruct (linear_search 0 wit) as [n pr] eqn:ls. exists n. split. assumption. intros.
   apply (linear_search_smallest 0 wit). split. apply le_0_n.
   rewrite -> ls. assumption.
+Qed.
+*)
+
+(** Rls entails minimality of the output *)
+Lemma Rls_lower_bound {found start} :
+  Rls found start -> forall {k}, P k -> start <= k -> found <= k.
+Proof.
+  induction 1 as [p | start no _ IH]; intros k pk greater.
+  - exact greater.
+  - destruct greater as [ | k greater].
+    + case (no pk).
+    + apply (IH _ pk), le_n_S, greater.
+Qed.
+
+Definition epsilon_smallest :
+  (exists n : nat, P n)
+  -> { n : nat | P n /\ forall k, P k -> n <= k }.
+Proof.
+  refine (
+  fun e =>
+    let b := let (n, p) := e in O_witness n (stop n p) in
+    let found := linear_search 0 b in
+    let g : Rls found 0 := ls_spec 0 b in
+    exist _ found _).
+  split.
+  - apply (Rls_P 0 g).
+  - intros k pk. apply (Rls_lower_bound g pk), le_0_n.
+Defined.
+
+Definition epsilon_smallest_compat :
+  (exists n : nat, P n)
+  -> { n : nat | P n /\ forall k : nat, k < n -> ~P k }.
+Proof.
+  intro e; destruct (epsilon_smallest e) as [n [p nk]]; exists n; split.
+  - exact p.
+  - intros k kn pk. apply (le_not_lt n k (nk k pk) kn).
 Qed.
 
 End ConstructiveIndefiniteGroundDescription_Direct.

--- a/theories/Logic/ConstructiveEpsilon.v
+++ b/theories/Logic/ConstructiveEpsilon.v
@@ -52,7 +52,7 @@ whereas the output of [linear_search] is [n] packed with a proof
 of [(P n)]. The inductive relation for linear search is named [rel_ls].
 
 The Braga method usually consists in defining a function [f_conform]
-intended to be extracted as (the OCaml translation of) a n-ary
+intended to be extracted as (the OCaml translation of) an n-ary
 function [f], with inputs [x...] and output type [{y | R x... y}]
 where [R] is an inductive n+1-ary relational presentation of [f].
 An additional input of [f_conform] is a termination certificate
@@ -68,14 +68,14 @@ directly define the type of the termination certificate and
 the n+1-ary Coq version of [f].
 Several variants of the proofs are offered for the record:
 - a version that follows the steps in [[1]], named [linear_search_conform];
-- a variant of the latter, named [linear_search_conform'],
+- a variant of the latter, named [linear_search_conform_alt],
   where the recursive call is no longer encapsulated in a
   pattern-matching (avoiding packing-unpacking steps which
   are for instance removed at extraction at the price of
   an additional optimization step).
 - a version where [prog_linear_search] is directly programmed
   and its conformity to [rel_ls] (by dependent induction on
-  the termination certificate, and then the properties of
+  the termination certificate), and then the properties of
   its output are separately proven.
 It is interesting to see that in the last version, the conformity
 proof slightly deviates from the definition of [prog_linear_search],
@@ -86,7 +86,7 @@ This deviation seems to be unavoidable because crucial proof steps
 require the guard argument of the fixpoint to start with a constructor.
 
 The three programs [prog_linear_search], [linear_search_conform]
-and [linear_search_conform'] are purposely presented in a
+and [linear_search_conform_alt] are purposely presented in a
 very similar manner, using [refine] and postponing proof obligations
 related to conformity to [rel_ls].
 
@@ -174,7 +174,7 @@ Defined.
     implication [rq] they are equivalent (but only one direction is needed);
     and as linear search is tail recursive, [Q] can be fixed (but [rq] varies,
     behaving like a logical continuation). *)
-Definition linear_search_conform' start (b : before_witness start) : {n : nat | rel_ls start n}.
+Definition linear_search_conform_alt start (b : before_witness start) : {n : nat | rel_ls start n}.
   refine ((fun Q: nat -> Prop => _ : (forall y, rel_ls start y -> Q y) -> {n | Q n})
             (rel_ls start) (fun y r => r)).
   revert start b.

--- a/theories/Reals/Runcountable.v
+++ b/theories/Reals/Runcountable.v
@@ -86,9 +86,9 @@ Qed.
 Definition first_in_holed_interval (u : nat -> R) (v : R -> nat) (a b h : R)
   : enumeration R u v -> Rlt a b
     -> { n : nat | in_holed_interval a b h u n
-                /\ forall k : nat, k < n -> ~in_holed_interval a b h u k }.
+                /\ forall k : nat, in_holed_interval a b h u k -> n <= k }.
 Proof.
-  intros. apply epsilon_smallest_compat. apply (in_holed_interval_dec a b h u).
+  intros. apply epsilon_smallest. apply (in_holed_interval_dec a b h u).
   exists (v (point_in_holed_interval a b h)).
   destruct H. unfold in_holed_interval. rewrite -> H.
   apply point_in_holed_interval_works. assumption.
@@ -99,15 +99,13 @@ Lemma first_in_holed_interval_works (u : nat -> R) (v : R -> nat) (a b h : R)
   let (c,_) := first_in_holed_interval u v a b h pen plow in
   forall x:R, Rlt a x -> Rlt x b -> x <> h -> x <> u c -> c < v x.
 Proof.
-  destruct (first_in_holed_interval u v a b h pen plow) as [c]. intros.
-  destruct (c ?= v x) eqn:order.
-  - exfalso. apply Nat.compare_eq_iff in order. rewrite -> order in H2.
-    destruct pen. rewrite -> H3 in H2. exact (H2 eq_refl).
-  - apply Nat.compare_lt_iff in order. assumption.
-  - exfalso. apply Nat.compare_gt_iff in order.
-    destruct a0. specialize (H4 (v x) order). assert (in_holed_interval a b h u (v x)).
-    { destruct pen. split. rewrite -> H5. assumption. rewrite -> H5. split; assumption. }
-    contradiction.
+  destruct (first_in_holed_interval u v a b h pen plow) as [c [_ beyond]].
+  destruct pen as [uv _]. intros x H H0 H1 x_uc.
+  assert (ihi : in_holed_interval a b h u (v x)).
+  { split. rewrite -> uv. assumption. rewrite -> uv. split; assumption. }
+  destruct (le_lt_or_eq _ _ (beyond (v x) ihi)) as [lcvx | ecvx].
+  - exact lcvx.
+  - exfalso. apply x_uc. rewrite ecvx. rewrite -> uv. reflexivity.
 Qed.
 
 Definition first_two_in_interval (u : nat -> R) (v : R -> nat) (a b : R)
@@ -118,8 +116,7 @@ Definition first_two_in_interval (u : nat -> R) (v : R -> nat) (a b : R)
   if Rle_dec (u first_index) (u second_index) then (u first_index, u second_index)
   else (u second_index, u first_index).
 
-
-Lemma split_couple_eq : forall a b c d : R, (a,b) = (c,d) -> a = c /\ b = d.
+Lemma split_couple_eq : forall {a b c d : R}, (a,b) = (c,d) -> a = c /\ b = d.
 Proof.
   intros. injection H. intros. split. subst. reflexivity. subst. reflexivity.
 Qed.
@@ -132,25 +129,28 @@ Lemma first_two_in_interval_works (u : nat -> R) (v : R -> nat) (a b : R)
   /\ Rlt c d
   /\ (forall x:R, Rlt a x -> Rlt x b -> x <> c -> x <> d -> v c < v x).
 Proof.
-  intros. destruct (first_two_in_interval u v a b) eqn:ft.
+  intros. destruct (first_two_in_interval u v a b) as [r r0] eqn:ft.
   unfold first_two_in_interval in ft.
-  pose proof (first_in_holed_interval_works u v a b b pen plow).
+  pose proof (first_in_holed_interval_works u v a b b pen plow) as Wb.
   destruct (first_in_holed_interval u v a b b pen plow) as [first_index pr].
-  pose proof (first_in_holed_interval_works u v a b (u first_index) pen plow).
-  destruct pr. destruct H1. destruct H3.
+  pose proof (first_in_holed_interval_works u v a b (u first_index) pen plow) as Wu.
+  destruct pr as [[H1 [H3 H4]] H2].
   destruct (first_in_holed_interval u v a b (u first_index) pen plow)
     as [second_index pr2].
-  destruct pr2. destruct H5. destruct H7.
-  destruct (Rle_dec (u first_index) (u second_index)).
-  - apply split_couple_eq in ft as [ft ft0]. subst. split. assumption.
-    split. assumption. split. assumption. split. assumption. split.
-    apply Rle_lt_or_eq_dec in r1. destruct r1. assumption. exfalso.
-    rewrite -> e in H8. exact (H8 eq_refl). intros. destruct pen. rewrite -> H14.
-    apply H. assumption. assumption. apply Rlt_not_eq. assumption. assumption.
-  - apply split_couple_eq in ft as [ft ft0]. subst. split. assumption.
-    split. assumption. split. assumption. split. assumption. split.
-    apply Rnot_le_lt in n. assumption. intros. destruct pen. rewrite -> H14.
-    apply H0. assumption. assumption. assumption. assumption.
+  destruct pr2 as [[H5 [H7 diff]] H6].
+  destruct pen as [_ pen2].
+  destruct (Rle_dec (u first_index) (u second_index)) as [lfs | nlfs].
+  - destruct (split_couple_eq ft); subst;
+    repeat (split; [assumption | idtac]); split.
+    + destruct (Rle_lt_or_eq_dec _ _ lfs).
+      * assumption.
+      * exfalso. apply diff. symmetry. apply e.
+    + intros. rewrite -> pen2.
+      apply Wb; try assumption. apply Rlt_not_eq; assumption.
+  - destruct (split_couple_eq ft); subst;
+    repeat (split; [assumption | idtac]); split.
+    + apply Rnot_le_lt, nlfs.
+    + intros. rewrite -> pen2. apply Wu; assumption.
 Qed.
 
 (* If u,v is an enumeration of R, this sequence of open intervals

--- a/theories/Reals/Runcountable.v
+++ b/theories/Reals/Runcountable.v
@@ -88,7 +88,7 @@ Definition first_in_holed_interval (u : nat -> R) (v : R -> nat) (a b h : R)
     -> { n : nat | in_holed_interval a b h u n
                 /\ forall k : nat, k < n -> ~in_holed_interval a b h u k }.
 Proof.
-  intros. apply epsilon_smallest. apply (in_holed_interval_dec a b h u).
+  intros. apply epsilon_smallest_compat. apply (in_holed_interval_dec a b h u).
   exists (v (point_in_holed_interval a b h)).
   destruct H. unfold in_holed_interval. rewrite -> H.
   apply point_in_holed_interval_works. assumption.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

<!-- Keep what applies -->
**Kind:** feature / infrastructure.
Unsure of the kind : actually, code improvements in coq/theories
<!-- If this is a feature pull request / breaks compatibility: -->
1. Improvements in `ConstructiveEpsilon.v`: 

    1. the "old" version of `linear_search` was tuned towards `constructive_indefinite_ground_description_nat` but inconvenient for proving minimality of the output (`epsilon_smallest`), added later, entailing unpleasant complications in the script. The new version uses instead an agnostic auxiliary inductive relation Rls, and the basic algorithm just sticks to it (Braga method). Postcondition and minimality are easily proved on Rls and transported on the function.
    2. Slight change in the formulation of `smallest_epsilon`: "smallest"  means "the others are greater". The script is more natural and shorter with this formulation. It is trivial to recover the previous (negative) formulation using `lt_not_le` or `le_not_lt`, when needed.

2. Modification in `theories/Reals/Runcountable.v`: the only place where `smallest_epsilon` is used in the standard library.  In passing, slight cleaning in the impacted lemmas (structure of proofs, explicit names and simplifications), because I had to understand what happened at these places.
