### PR TITLE
Take into account position of main argument of a projection when inserting implicit arguments for syntax t.(f)

### DIFF
--- a/doc/changelog/02-specification-language/14606-master+proj-nodes-in-concrete-syntax.rst
+++ b/doc/changelog/02-specification-language/14606-master+proj-nodes-in-concrete-syntax.rst
@@ -1,0 +1,7 @@
+- **Fixed:**
+  The :n:`@term.(@qualid {* @arg })` syntax now takes into account the position of
+  the main argument :n:`@term` when computing the implicit arguments of
+  :n:`@qualid`
+  (`#14606 <https://github.com/coq/coq/pull/14606>`_,
+  fixes `#4167 <https://github.com/coq/coq/issues/4167>`_,
+  by Hugo Herbelin).

--- a/interp/impargs.mli
+++ b/interp/impargs.mli
@@ -134,3 +134,11 @@ val projection_implicits : env -> Projection.t -> implicit_status list ->
 val select_impargs_size : int -> implicits_list list -> implicit_status list
 
 val select_stronger_impargs : implicits_list list -> implicit_status list
+
+val select_impargs_size_for_proj :
+  nexpectedparams:int -> ngivenparams:int -> nextraargs:int ->
+  implicits_list list -> (implicit_status list * implicit_status list, int list Lazy.t) Util.union
+
+val impargs_for_proj :
+  nexpectedparams:int -> nextraargs:int ->
+  implicit_status list -> implicit_status list * implicit_status list

--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -272,6 +272,8 @@ let pr_sequence pr l = prlist_sep_lastsep true spc spc pr l
    [pr a ++ str "," ++ pr b ++ str "," ++ ... ++ str "and" ++ pr c] *)
 let pr_enum pr l = prlist_sep_lastsep true pr_comma (fun () -> str " and" ++ spc ()) pr l
 
+let pr_choice pr l = prlist_sep_lastsep true pr_comma (fun () -> str " or" ++ spc ()) pr l
+
 let pr_vertical_list pr = function
   | [] -> str "none" ++ fnl ()
   | l -> fnl () ++ str "  " ++ hov 0 (prlist_with_sep fnl pr l) ++ fnl ()

--- a/lib/pp.mli
+++ b/lib/pp.mli
@@ -173,6 +173,10 @@ val pr_enum : ('a -> t) -> 'a list -> t
 (** [pr_enum pr [a ; b ; ... ; c]] outputs
     [pr a ++ str "," ++ spc () ++ pr b ++ str "," ++ spc () ++ ... ++ str "and" ++ spc () ++ pr c]. *)
 
+val pr_choice : ('a -> t) -> 'a list -> t
+(** [pr_choice pr [a ; b ; ... ; c]] outputs
+    [pr a ++ str "," ++ spc () ++ pr b ++ str "," ++ spc () ++ ... ++ str "or" ++ spc () ++ pr c]. *)
+
 val pr_sequence : ('a -> t) -> 'a list -> t
 (** Sequence of objects separated by space (unless an element is empty). *)
 

--- a/test-suite/output/Record.out
+++ b/test-suite/output/Record.out
@@ -74,3 +74,5 @@ fun x : R => 0
              +++
              x.(field) 0
      : R -> nat
+The command has indeed failed with message:
+Projection f expected 1 explicit parameter.

--- a/test-suite/output/Record.v
+++ b/test-suite/output/Record.v
@@ -74,3 +74,14 @@ Set Printing Projections.
 Check fun x => 0 +++ x.(field) 0.
 
 End ProjectionPrinting.
+
+Module RecordImplicitParameters.
+
+(* Check that implicit parameters are treated independently of extra
+   implicit arguments (at some time they did not and it was failing at
+   typing time) *)
+
+Record R A := { f : A -> A }.
+Fail Check fun x => x.(f).
+
+End RecordImplicitParameters.

--- a/test-suite/output/bug_4167.out
+++ b/test-suite/output/bug_4167.out
@@ -1,0 +1,4 @@
+foo = foo
+     : Prop
+t1.(foo) = t2.(foo)
+     : Prop

--- a/test-suite/output/bug_4167.v
+++ b/test-suite/output/bug_4167.v
@@ -1,0 +1,5 @@
+Class test {y x: nat} : Set := { foo: nat }.
+Context (x y:nat) (t1 t2: @ test x y).
+Check t1.(foo) = t2.(foo).
+Set Printing Projections.
+Check t1.(foo) = t2.(foo).

--- a/test-suite/success/Record.v
+++ b/test-suite/success/Record.v
@@ -108,3 +108,11 @@ Record U (c:True) := {
  u := c;
  v := reflI : eqI u;
  }.
+
+Module MaximalImplicit.
+
+Record T := { f : forall a, a = 0 }.
+Arguments f _ {a}.
+Check fun x => x.(f) : 0 = 0.
+
+End MaximalImplicit.


### PR DESCRIPTION
**Kind:** fix and enhancement

Depends on mattam82/Coq-Equations#413 (or at worst on tolerant `Loc.merge` in #14618).

Fixes #4167 and improve error message when a field has a wrong number of explicit parameters

This is done by introducing special functions for interning/externing which cut the implicit arguments signature of a projection into a parameter part and an extra functional part (if ever the projection happens to return a function with its own implicit arguments).

- [X] Added / updated test-suite
- [X] Entry added in the changelog