### PR TITLE
[lia] Add Strategy to speed-up conversion

### DIFF
--- a/test-suite/micromega/bug_14604.v
+++ b/test-suite/micromega/bug_14604.v
@@ -1,0 +1,15 @@
+Require Import ZArith Lia.
+
+(* mul z n = Z.of_nat n * z *)
+Fixpoint mul (x:Z) (n : nat) : Z :=
+match n with
+| O => 0%Z
+| S n => mul x n + 1 * x%Z
+end.
+
+Lemma test: forall z : Z, (0 <= z)%Z -> (0 <= mul z 100)%Z.
+Proof.
+cbn -[Z.mul Z.add].
+intros.
+Timeout 2 lia.
+Qed.

--- a/theories/micromega/ZMicromega.v
+++ b/theories/micromega/ZMicromega.v
@@ -142,6 +142,8 @@ Fixpoint Zeval_expr (env : PolEnv Z) (e: PExpr Z) : Z :=
     | PEopp e   => Z.opp (Zeval_expr env e)
   end.
 
+Strategy expand [ Zeval_expr ].
+
 Definition eval_expr := eval_pexpr  Z.add Z.mul Z.sub Z.opp (fun x => x) (fun x => x) (pow_N 1 Z.mul).
 
 Fixpoint Zeval_const  (e: PExpr Z) : option Z :=


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->
Add a `Strategy` directive for `lia` to speed-up conversion.
(The problem seems to be `lia` specific.)

<!-- Keep what applies -->
**Kind:** bug fix / performance 

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes #14604  

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
