### PR TITLE
Check that convertible occurrences of a tactic-selected pattern are of the same type

### DIFF
--- a/doc/changelog/04-tactics/14610-master+fix-14609-set-tactic-not-typing.rst
+++ b/doc/changelog/04-tactics/14610-master+fix-14609-set-tactic-not-typing.rst
@@ -1,0 +1,7 @@
+- **Fixed:**
+  Correct convertibility of multiple terms selected by patterns in
+  tactics such as :tacn:`set` when these terms have subterms in
+  `SProp`
+  (`#14610 <https://github.com/coq/coq/pull/14610>`_,
+  fixes `#14609 <https://github.com/coq/coq/issues/14609>`_,
+  by Hugo Herbelin).

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1655,7 +1655,12 @@ let make_pattern_test from_prefix_of_ind is_correct_type env sigma (pending,c) =
     match c1, c2 with
     | Some (evd,c1,x), Some (_,c2,_) ->
       begin match infer_conv ~pb:CONV env evd c1 c2 with
-      | Some evd -> Some (evd, c1, x)
+      | Some evd ->
+       (let t1 = get_type_of env evd c1 in
+        let t2 = get_type_of env evd c2 in
+        match infer_conv ~pb:CONV env evd t1 t2 with
+        | Some evd -> Some (evd, c1, x)
+        | None -> raise (NotUnifiable None))
       | None -> raise (NotUnifiable None)
       end
     | Some _, None -> c1

--- a/test-suite/success/set.v
+++ b/test-suite/success/set.v
@@ -15,5 +15,14 @@ intros.
 set (f _ _).
 Abort.
 
+Module UsingSProp.
 
+Inductive STrue : SProp := I.
+Inductive SBool : SProp := T | F.
+Axiom f : forall {A B:SProp}, A -> B -> unit.
+Goal f (fun _ : nat => F) (fun _:nat => I) = f (fun _ : nat => F) (fun _:nat => I).
+set (x := fun _ => _).
+reflexivity.
+Qed. (* Was failing because all 4 "fun _ => ..." were identified *)
 
+End UsingSProp.


### PR DESCRIPTION
**Kind:** bug fix

Note that this is broken by the use of SProp. See #14609.

More generally, that would be broken if conversion of implicit arguments were eventually dropped.

Fixes #14609.

- [X] Added / updated test-suite
- [X] Entry added in the changelog
