### PR TITLE
Factorize pattern compilation in Btermdn

### DIFF
--- a/tactics/btermdn.ml
+++ b/tactics/btermdn.ml
@@ -95,49 +95,51 @@ let constr_val_discr env sigma ts t =
     | Rel _ | Meta _ | Cast _ | LetIn _ | App _ | Case _ | Fix _ | CoFix _
     | Proj _ | Int _ | Float _ | Array _ -> Nothing
 
-let constr_pat_discr env t =
-  if not (Patternops.occur_meta_pattern t) then
-    None
-  else
-    let open GlobRef in
-    match decomp_pat t with
-    | PRef ((IndRef _) as ref), args
-    | PRef ((ConstructRef _ ) as ref), args -> Some (GRLabel ref,args)
-    | PRef ((VarRef v) as ref), args -> Some(GRLabel ref,args)
-    | PRef ((ConstRef c) as ref), args ->
-      if evaluable_constant c env then None
-      else Some (GRLabel ref, args)
-    | _ -> None
-
-let constr_pat_discr_st env ts t =
+let constr_pat_discr env ts t =
   let open GlobRef in
-  match decomp_pat t with
+  if Option.is_empty ts && not (Patternops.occur_meta_pattern t) then
+    (* Extremely fishy, and breaks very quickly when fiddled with. Why should
+       **ground** terms match **everything** when non-discriminated??? *)
+    None
+  else match decomp_pat t with
   | PRef ((IndRef _) as ref), args
   | PRef ((ConstructRef _ ) as ref), args -> Some (GRLabel ref,args)
   | PRef ((VarRef v) as ref), args ->
-    if Environ.evaluable_named v env && (TransparentState.is_transparent_variable ts v) then None
-    else Some(GRLabel ref,args)
+    begin match ts with
+    | None -> Some(GRLabel ref,args)
+    | Some ts ->
+      if Environ.evaluable_named v env && (TransparentState.is_transparent_variable ts v) then None
+      else Some(GRLabel ref,args)
+    end
   | PRef ((ConstRef c) as ref), args ->
-    if evaluable_constant c env && TransparentState.is_transparent_constant ts c then None
-    else Some (GRLabel ref, args)
-  | PVar v, args when not (TransparentState.is_transparent_variable ts v) ->
-      Some(GRLabel (VarRef v),args)
-  | PProd (_, d, c), [] -> Some (ProdLabel, [d ; c])
-  | PLambda (_, d, c), [] -> Some (LambdaLabel, [d ; c])
-  | PSort s, [] -> Some (SortLabel, [])
+    begin match ts with
+    | None ->
+      if evaluable_constant c env then None
+      else Some (GRLabel ref, args)
+    | Some ts ->
+      if evaluable_constant c env && TransparentState.is_transparent_constant ts c then None
+      else Some (GRLabel ref, args)
+    end
+  | PVar v, args ->
+    begin match ts with
+    | None -> None
+    | Some ts ->
+      if TransparentState.is_transparent_variable ts v then None
+      else Some(GRLabel (VarRef v),args)
+    end
+  | PProd (_, d, c), [] ->
+    if Option.is_empty ts then None else Some (ProdLabel, [d ; c])
+  | PLambda (_, d, c), [] ->
+    if Option.is_empty ts then None else Some (LambdaLabel, [d ; c])
+  | PSort s, [] ->
+    if Option.is_empty ts then None else Some (SortLabel, [])
   | _ -> None
 
 let bounded_constr_pat_discr env st (t,depth) =
-  if Int.equal depth 0 then
-    None
-  else
-    let ans = match st with
-    | None -> constr_pat_discr env t
-    | Some st -> constr_pat_discr_st env st t
-    in
-    match ans with
-      | None -> None
-      | Some (c,l) -> Some(c,List.map (fun c -> (c,depth-1)) l)
+  if Int.equal depth 0 then None
+  else match constr_pat_discr env st t with
+  | None -> None
+  | Some (c,l) -> Some(c,List.map (fun c -> (c,depth-1)) l)
 
 let bounded_constr_val_discr env st sigma (t,depth) =
   if Int.equal depth 0 then

--- a/tactics/btermdn.ml
+++ b/tactics/btermdn.ml
@@ -88,8 +88,7 @@ let constr_val_discr_st env sigma ts t =
       else Label(GRLabel (VarRef id),l)
     | Prod (n, d, c) -> Label(ProdLabel, [d; c])
     | Lambda (n, d, c) ->
-      if List.is_empty l then
-        Label(LambdaLabel, [d; c] @ l)
+      if List.is_empty l then Label(LambdaLabel, [d; c])
       else Everything
     | Sort _ -> Label(SortLabel, [])
     | Evar _ -> Everything

--- a/tactics/btermdn.ml
+++ b/tactics/btermdn.ml
@@ -74,20 +74,6 @@ let constr_val_discr env sigma t =
       else Label(GRLabel (ConstRef c),l)
     | _ -> Nothing
 
-let constr_pat_discr env t =
-  if not (Patternops.occur_meta_pattern t) then
-    None
-  else
-    let open GlobRef in
-    match decomp_pat t with
-    | PRef ((IndRef _) as ref), args
-    | PRef ((ConstructRef _ ) as ref), args -> Some (GRLabel ref,args)
-    | PRef ((VarRef v) as ref), args -> Some(GRLabel ref,args)
-    | PRef ((ConstRef c) as ref), args ->
-      if evaluable_constant c env then None
-      else Some (GRLabel ref, args)
-    | _ -> None
-
 let constr_val_discr_st env sigma ts t =
   let c, l = decomp sigma t in
   let open GlobRef in
@@ -110,6 +96,20 @@ let constr_val_discr_st env sigma ts t =
     | Rel _ | Meta _ | Cast _ | LetIn _ | App _ | Case _ | Fix _ | CoFix _
     | Proj _ | Int _ | Float _ | Array _ -> Nothing
 
+let constr_pat_discr env t =
+  if not (Patternops.occur_meta_pattern t) then
+    None
+  else
+    let open GlobRef in
+    match decomp_pat t with
+    | PRef ((IndRef _) as ref), args
+    | PRef ((ConstructRef _ ) as ref), args -> Some (GRLabel ref,args)
+    | PRef ((VarRef v) as ref), args -> Some(GRLabel ref,args)
+    | PRef ((ConstRef c) as ref), args ->
+      if evaluable_constant c env then None
+      else Some (GRLabel ref, args)
+    | _ -> None
+
 let constr_pat_discr_st env ts t =
   let open GlobRef in
   match decomp_pat t with
@@ -128,36 +128,27 @@ let constr_pat_discr_st env ts t =
   | PSort s, [] -> Some (SortLabel, [])
   | _ -> None
 
-let bounded_constr_pat_discr_st env st (t,depth) =
+let bounded_constr_pat_discr env st (t,depth) =
   if Int.equal depth 0 then
     None
   else
-    match constr_pat_discr_st env st t with
+    let ans = match st with
+    | None -> constr_pat_discr env t
+    | Some st -> constr_pat_discr_st env st t
+    in
+    match ans with
       | None -> None
       | Some (c,l) -> Some(c,List.map (fun c -> (c,depth-1)) l)
 
-let bounded_constr_val_discr_st env sigma st (t,depth) =
+let bounded_constr_val_discr env st sigma (t,depth) =
   if Int.equal depth 0 then
     Nothing
   else
-    match constr_val_discr_st env sigma st t with
-      | Label (c,l) -> Label(c,List.map (fun c -> (c,depth-1)) l)
-      | Nothing -> Nothing
-      | Everything -> Everything
-
-let bounded_constr_pat_discr env (t,depth) =
-  if Int.equal depth 0 then
-    None
-  else
-    match constr_pat_discr env t with
-      | None -> None
-      | Some (c,l) -> Some(c,List.map (fun c -> (c,depth-1)) l)
-
-let bounded_constr_val_discr env sigma (t,depth) =
-  if Int.equal depth 0 then
-    Nothing
-  else
-    match constr_val_discr env sigma t with
+    let ans = match st with
+    | None -> constr_val_discr env sigma t
+    | Some st -> constr_val_discr_st env sigma st t
+    in
+    match ans with
       | Label (c,l) -> Label(c,List.map (fun c -> (c,depth-1)) l)
       | Nothing -> Nothing
       | Everything -> Everything
@@ -177,21 +168,14 @@ struct
 
   type pattern = Dn.pattern
 
-  let pattern env st pat = match st with
-  | None -> Dn.pattern (bounded_constr_pat_discr env) (pat, !dnet_depth)
-  | Some st -> Dn.pattern (bounded_constr_pat_discr_st env st) (pat, !dnet_depth)
+  let pattern env st pat =
+    Dn.pattern (bounded_constr_pat_discr env st) (pat, !dnet_depth)
 
   let empty = Dn.empty
   let add = Dn.add
   let rmv = Dn.rmv
 
-  let lookup env sigma = function
-    | None ->
-        (fun dn t ->
-             Dn.lookup dn (bounded_constr_val_discr env sigma) (t,!dnet_depth))
-    | Some st ->
-        (fun dn t ->
-             Dn.lookup dn (bounded_constr_val_discr_st env sigma st) (t,!dnet_depth))
+  let lookup env sigma st dn t =
+    Dn.lookup dn (bounded_constr_val_discr env st sigma) (t,!dnet_depth)
 
 end
-


### PR DESCRIPTION
We merge the two variants of the code (discriminated vs. non-discriminated) in Btermdn in a single one. This is the 100% backwards compatible subset of #13081, and up to carelessly introduced bug there should be no observable difference with the previous code, including performance. It makes obvious the behaviour differences between the two variants since they are now at the same place.

When this is merged, I will slice the remaining parts of #13081 above this PR to assess the performance effects of individual changes trying to bring the two semantics closer.