### PR TITLE
Fix running test suite (unit tests) outside dune with pure dune build

### DIFF
--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -29,6 +29,13 @@ COQ_SRC_DIR:=..
 
 -include ../config/Makefile
 
+ifneq ($(wildcard ../_build/default/config/Makefile),)
+include ../_build/default/config/Makefile
+ifeq ($(COQPREFIX),local)
+COQPREFIX:=$(shell cd ../_build/install/default/ ;pwd)
+endif
+endif
+
 #######################################################################
 # Variables
 #######################################################################
@@ -47,16 +54,14 @@ else
 endif
 
 # Be careful to use COQPREFIX when prefix is not set
+# this assumes we're running inside dune, ie pwd=_build/default/test-suite
+# is this assumption correct?
 ifeq ($(COQPREFIX),local)
 	COQPREFIX:=$(shell cd ../..;pwd)/install/default/
 endif
 
 export OCAMLPATH := $(shell echo $(COQPREFIX)/lib$(FINDLIB_SEP)$$OCAMLPATH)
 export CAML_LD_LIBRARY_PATH:=$(COQPREFIX)/lib/stublibs:$(CAML_LD_LIBRARY_PATH)
-
-ifneq ($(wildcard ../_build/default/config/Makefile),)
-include ../_build/default/config/Makefile
-endif
 
 # COQLIB is an env variable so no quotes
 COQLIB?=


### PR DESCRIPTION
Fix #14624

I have no idea if the test suite works with legacy build configured -profile devel
(ie with prefix = local)
