### PR TITLE
2nd phase of deprecation of "x ident" in constr notation (now an error)

### DIFF
--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -118,12 +118,12 @@ let real  r  = str (string_of_float r)
 let bool  b  = str (string_of_bool b)
 
 (* XXX: To Remove *)
-let strbrk s =
+let strbrk ?(indent=0) s =
   let rec aux p n =
     if n < String.length s then
       if s.[n] = ' ' then
-        if p = n then spc() :: aux (n+1) (n+1)
-        else str (String.sub s p (n-p)) :: spc () :: aux (n+1) (n+1)
+        if p = n then brk (1,indent) :: aux (n+1) (n+1)
+        else str (String.sub s p (n-p)) :: brk (1,indent) :: aux (n+1) (n+1)
       else aux p (n + 1)
     else if p = n then [] else [str (String.sub s p (n-p))]
   in Ppcmd_glue (aux 0 0)

--- a/lib/pp.mli
+++ b/lib/pp.mli
@@ -96,7 +96,7 @@ val bool : bool -> t
 val qstring : string -> t
 val qs : string -> t
 val quote : t -> t
-val strbrk : string -> t
+val strbrk : ?indent:int -> string -> t
 
 (** {6 Boxing commands} *)
 

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -319,6 +319,7 @@ Module P.
   Set Warnings "-deprecated-ident-entry". (* We do want ident! *)
   Notation "▢_ n P" := (pseudo_force n (fun n => P))
     (at level 0, n ident, P at level 9, format "▢_ n  P").
+  Set Warnings "+deprecated-ident-entry".
   Check exists p, ▢_p (p >= 1).
   Section S.
   Variable n:nat.

--- a/test-suite/success/Notations2.v
+++ b/test-suite/success/Notations2.v
@@ -123,7 +123,7 @@ End M13.
 (* 14. Check that a notation with a "ident" binder does not include a pattern *)
 Module M14.
 Notation "'myexists' x , p" := (ex (fun x => p))
-  (at level 200, x ident, p at level 200, right associativity) : type_scope.
+  (at level 200, x name, p at level 200, right associativity) : type_scope.
 Check myexists I, I = 0. (* Should not be seen as a constructor *)
 End M14.
 

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -1251,7 +1251,7 @@ GRAMMAR EXTEND Gram
     ] ]
   ;
   explicit_subentry:
-    [ [ (* Warning to be turn into an error at the end of deprecation phase (for 8.14) *)
+    [ [ (* To be removed at the end of transitory phase (for 8.15) *)
         IDENT "ident" -> { ETName false }
         (* To be activated at the end of transitory phase (for 8.15)
       | IDENT "ident" -> { ETIdent }


### PR DESCRIPTION
**Kind:** deprecation

This is the 8.14 step of the transition of `x ident` to be changed into `x name` into (non custom) notations. See protocol in this [comment](https://github.com/coq/coq/pull/11841#issuecomment-728756462) of #11841.
