### PR TITLE
Removing deprecated Pcoq.pattern_identref

### DIFF
--- a/parsing/pcoq.ml
+++ b/parsing/pcoq.ml
@@ -259,7 +259,6 @@ module Prim =
     let univ_decl = Entry.create "univ_decl"
     let ident_decl = Entry.create "ident_decl"
     let pattern_ident = Entry.create "pattern_ident"
-    let pattern_identref = pattern_ident (* To remove in 8.14 *)
 
     (* A synonym of ident - maybe ident will be located one day *)
     let base_ident = Entry.create "base_ident"

--- a/parsing/pcoq.mli
+++ b/parsing/pcoq.mli
@@ -139,7 +139,6 @@ module Prim :
     val univ_decl : universe_decl_expr Entry.t
     val ident_decl : ident_decl Entry.t
     val pattern_ident : lident Entry.t
-    val pattern_identref : lident Entry.t [@@ocaml.deprecated "Use Prim.pattern_identref"]
     val base_ident : Id.t Entry.t
     val bignat : string Entry.t
     val natural : int Entry.t


### PR DESCRIPTION
**Kind:** deprecation

`Pcoq.pattern_identref` was scheduled in #13099 to be removed in 8.14.
