### PR TITLE
Use names as given by About in "with" clause on applied reference (subsumed by #13837)

### DIFF
--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -979,8 +979,8 @@ let rec make_rewrite_list expr_info max = function
                    (* dep proofs also: *) ~dep:true ~with_evars:false
                    ( mkVar hp
                    , ExplicitBindings
-                       [ CAst.make @@ (NamedHyp def, expr_info.f_constr)
-                       ; CAst.make @@ (NamedHyp k, f_S max) ] )
+                       [ CAst.make @@ (CAst.make @@ NamedHyp def, expr_info.f_constr)
+                       ; CAst.make @@ (CAst.make @@ NamedHyp k, f_S max) ] )
                    )))
          [ make_rewrite_list expr_info max l
          ; New.observe_tclTHENLIST
@@ -1014,8 +1014,8 @@ let make_rewrite expr_info l hp max =
                     (* dep proofs also: *) ~dep:true ~with_evars:false
                     ( mkVar hp
                     , ExplicitBindings
-                        [ CAst.make @@ (NamedHyp def, expr_info.f_constr)
-                        ; CAst.make @@ (NamedHyp k, f_S (f_S max)) ] )
+                        [ CAst.make @@ (CAst.make @@ NamedHyp def, expr_info.f_constr)
+                        ; CAst.make @@ (CAst.make @@ NamedHyp k, f_S (f_S max)) ] )
                     )))
           [ New.observe_tac
               (fun _ _ -> str "make_rewrite finalize")

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -310,8 +310,8 @@ GRAMMAR EXTEND Gram
       | pat = naming_intropattern -> { CAst.make ~loc @@ IntroNaming pat } ] ]
   ;
   simple_binding:
-    [ [ "("; id = ident; ":="; c = lconstr; ")" -> { CAst.make ~loc (NamedHyp id, c) }
-      | "("; n = natural; ":="; c = lconstr; ")" -> { CAst.make ~loc (AnonHyp n, c) } ] ]
+    [ [ "("; id = identref; ":="; c = lconstr; ")" -> { CAst.make ~loc (CAst.make ?loc:id.CAst.loc (NamedHyp id.CAst.v), c) }
+      | "("; n = natural; ":="; c = lconstr; ")" -> { CAst.make ~loc (CAst.make @@ AnonHyp n, c) } ] ]
   ;
   bindings:
     [ [ test_lpar_idnum_coloneq; bl = LIST1 simple_binding ->

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -908,9 +908,9 @@ let interp_declared_or_quantified_hypothesis ist env sigma = function
             (coerce_to_decl_or_quant_hyp sigma) ist (Some (env,sigma)) (make id)
       with Not_found -> NamedHyp id
 
-let interp_binding ist env sigma {loc;v=(b,c)} =
+let interp_binding ist env sigma {loc;v=({loc=loc';v=b},c)} =
   let sigma, c = interp_open_constr ist env sigma c in
-  sigma, (make ?loc (interp_binding_name ist env sigma b,c))
+  sigma, (make ?loc ((make ?loc:loc' (interp_binding_name ist env sigma b),c)))
 
 let interp_bindings ist env sigma = function
 | NoBindings ->

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -719,7 +719,9 @@ let make_clenv_binding_gen hyps_only n env sigma (c,t) = function
       let clause = mk_clenv_from_env env sigma n (c,t) in
       clenv_constrain_dep_args hyps_only largs clause
   | ExplicitBindings lbind ->
-      let t = rename_bound_vars_as_displayed sigma Id.Set.empty [] t in
+      let t = match EConstr.kind sigma (fst (decompose_app sigma c)) with
+        | (Const _ | Ind _ | Construct _) -> t
+        | _ -> rename_bound_vars_as_displayed sigma Id.Set.empty [] t in
       let clause = mk_clenv_from_env env sigma n
         (c, t)
       in clenv_match_args lbind clause

--- a/proofs/miscprint.ml
+++ b/proofs/miscprint.ml
@@ -45,8 +45,8 @@ and pr_or_and_intro_pattern prc = function
 
 (** Printing of bindings *)
 let pr_binding prc = let open CAst in function
-  | {loc;v=(NamedHyp id, c)} -> hov 1 (Names.Id.print id ++ str " := " ++ cut () ++ prc c)
-  | {loc;v=(AnonHyp n, c)} -> hov 1 (int n ++ str " := " ++ cut () ++ prc c)
+  | {loc;v=({v=NamedHyp id}, c)} -> hov 1 (Names.Id.print id ++ str " := " ++ cut () ++ prc c)
+  | {loc;v=({v=AnonHyp n}, c)} -> hov 1 (int n ++ str " := " ++ cut () ++ prc c)
 
 let pr_bindings prc prlc = function
   | ImplicitBindings l ->

--- a/proofs/tactypes.ml
+++ b/proofs/tactypes.ml
@@ -34,7 +34,7 @@ and 'constr or_and_intro_pattern_expr =
 
 type quantified_hypothesis = AnonHyp of int | NamedHyp of Id.t
 
-type 'a explicit_bindings = (quantified_hypothesis * 'a) CAst.t list
+type 'a explicit_bindings = (quantified_hypothesis CAst.t * 'a) CAst.t list
 
 type 'a bindings =
   | ImplicitBindings of 'a list

--- a/test-suite/success/RecTutorial.v
+++ b/test-suite/success/RecTutorial.v
@@ -787,7 +787,7 @@ with   Odd_induction  := Minimality for odd  Sort Prop.
 Theorem even_plus_four : forall n:nat, even n -> even (4+n).
 Proof.
  intros n H.
- elim H using Even_induction with (P0 := fun n => odd (4+n));
+ elim H using Even_induction with (P := fun n => odd (4+n));
  simpl;repeat constructor;assumption.
 Qed.
 

--- a/theories/Vectors/VectorSpec.v
+++ b/theories/Vectors/VectorSpec.v
@@ -517,7 +517,7 @@ split; intros HF.
   remember (to_list v2) as l2.
   revert n v1 v2 Heql1 Heql2; induction HF; intros n v1 v2 Heql1 Heql2.
   + destruct v1; [ | inversion Heql1 ].
-    apply case0 with (P0 := fun x => Forall2 P (nil A) x); constructor.
+    apply case0 with (P := fun x => Forall2 P (nil A) x); constructor.
   + destruct v1; inversion Heql1; subst.
     rewrite (eta v2) in Heql2; inversion Heql2; subst.
     rewrite (eta v2); constructor; auto.

--- a/user-contrib/Ltac2/tac2tactics.ml
+++ b/user-contrib/Ltac2/tac2tactics.ml
@@ -42,7 +42,7 @@ let delayed_of_thunk r tac env sigma =
 let mk_bindings = function
 | ImplicitBindings l -> Tactypes.ImplicitBindings l
 | ExplicitBindings l ->
-  let l = List.map CAst.make l in
+  let l = List.map (fun (x,c) -> CAst.make (CAst.make x,c)) l in
   Tactypes.ExplicitBindings l
 | NoBindings -> Tactypes.NoBindings
 


### PR DESCRIPTION
**Kind:** enhancement

I.e., we stop renaming "as displayed" which is less intuitive and less stable than relying on `About`

At the current time, we evaluate the impact on CI.

Incidentally, this:
- fixes #3273
- fixes #4536
- fixes #14632

- [ ] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
- [ ] Overlay pull requests (if this breaks 3rd party developments in CI, see
https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md for details)
