### PR TITLE
Introducing a proper interpretation path for t.(f) distinct from (f t) when f is a primitive projection

### DIFF
--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -212,9 +212,6 @@ let toggle_notation_printing ?scope ~notation ~activate () =
   else
     deactivate_notation (NotationRule (inscope, notation))
 
-(* This governs printing of projections using the dot notation symbols *)
-let print_projections = ref false
-
 let print_meta_as_hole = ref false
 
 let with_universes f = Flags.with_option print_universes f

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -818,8 +818,10 @@ let match_coercion_app c = match DAst.get c with
   | GApp (r, args) ->
     begin match DAst.get r with
     | GRef (r,_) -> Some (c.CAst.loc, r, args)
+    | GProj ((cst,_), args', b) -> Some (c.CAst.loc, GlobRef.ConstRef cst, args' @ b :: args)
     | _ -> None
     end
+  | GProj ((cst,_), args, b) -> Some (c.CAst.loc, GlobRef.ConstRef cst, args @ [b])
   | _ -> None
 
 let remove_one_coercion inctx c =

--- a/interp/constrextern.mli
+++ b/interp/constrextern.mli
@@ -59,7 +59,6 @@ val print_coercions : bool ref
 val print_parentheses : bool ref
 val print_universes : bool ref
 val print_no_symbol : bool ref
-val print_projections : bool ref
 val print_raw_literal : bool ref
 
 (** Customization of the global_reference printer *)

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -329,7 +329,7 @@ let apply_cases_pattern ?loc (ids_disjpat,id) c =
 let glob_constr_of_notation_constr_with_binders ?loc g f ?(h=default_binder_status_fun) e nc =
   let lt x = DAst.make ?loc x in lt @@ match nc with
   | NVar id -> GVar id
-  | NApp (a,args) -> let e = h.no e in DAst.get (mkGApp (f e a) (List.map (f e) args))
+  | NApp (a,args) -> let e = h.no e in mkGAppR (f e a) (List.map (f e) args)
   | NProj (p,args,c) -> let e = h.no e in GProj (p, List.map (f e) args, f e c)
   | NList (x,y,iter,tail,swap) ->
       let t = f e tail in let it = f e iter in

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -1393,7 +1393,7 @@ let rec match_ inner u alp metas sigma a1 a2 =
   | GApp (f1,l1), NProj ((cst2,u2),l2,a2) ->
      (match DAst.get f1 with
      | GRef (r1,u1) when GlobRef.equal r1 (GlobRef.ConstRef cst2) && compare_glob_universe_instances_le u1 u2 &&
-         List.length l1 = List.length l2 + 1 ->
+         List.length l1 = List.length l2 + 1 && not (Structures.PrimitiveProjections.mem cst2) ->
         List.fold_left2 (match_in u alp metas) sigma l1 (l2@[a2])
      | _ -> raise No_match)
   | GLambda (na1,bk1,t1,b1), NLambda (na2,t2,b2) ->

--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -931,7 +931,7 @@ struct
 
   type t = Repr.t * bool
 
-  let make c b = (c, b)
+  let make c _ = (c, true)
 
   let mind (c,_) = Repr.mind c
   let inductive (c,_) = Repr.inductive c
@@ -940,7 +940,7 @@ struct
   let constant (c,_) = Repr.constant c
   let label (c,_) = Repr.label c
   let repr = fst
-  let unfolded = snd
+  let unfolded _ = true
   let unfold (c, b as p) = if b then p else (c, true)
 
   let equal (c, b) (c', b') = Repr.equal c c' && b == b'

--- a/pretyping/coercionops.ml
+++ b/pretyping/coercionops.ml
@@ -134,9 +134,11 @@ let find_class_type env sigma t =
   let t', args = Reductionops.whd_betaiotazeta_stack env sigma t in
   match EConstr.kind sigma t' with
     | Var id -> CL_SECVAR id, EInstance.empty, args
-    | Const (sp,u) -> CL_CONST sp, u, args
-    | Proj (p, c) when not (Projection.unfolded p) ->
-      CL_PROJ (Projection.repr p), EInstance.empty, (c :: args)
+    | Const (sp,u) ->
+       (match Structures.PrimitiveProjections.find_opt sp with
+        | Some p -> CL_PROJ p, u, List.skipn (Projection.Repr.npars p) args (* ?? *)
+        | None -> CL_CONST sp, u, args)
+    | Proj (p, c) -> CL_PROJ (Projection.repr p), EInstance.empty, (c :: args)
     | Ind (ind_sp,u) -> CL_IND ind_sp, u, args
     | Prod _ -> CL_FUN, EInstance.empty, []
     | Sort _ -> CL_SORT, EInstance.empty, []

--- a/pretyping/constr_matching.ml
+++ b/pretyping/constr_matching.ml
@@ -299,7 +299,7 @@ let matches_core env sigma allow_bound_rels
             Array.fold_left2 (sorec ctx env) subst args1 args22
           else (* Might be a projection on the right *)
             match EConstr.kind sigma c2 with
-            | Proj (pr, c) when not (Projection.unfolded pr) ->
+            | Proj (pr, c) ->
               (try let term = Retyping.expand_projection env sigma pr c (Array.to_list args2) in
                      sorec ctx env subst p term
                with Retyping.RetypeError _ -> raise PatternMatchingFailure)
@@ -307,15 +307,14 @@ let matches_core env sigma allow_bound_rels
 
       | PApp (c1,arg1), App (c2,arg2) ->
         (match c1, EConstr.kind sigma c2 with
-        | PRef (GlobRef.ConstRef r), Proj (pr,c) when not (Environ.QConstant.equal env r (Projection.constant pr))
-            || Projection.unfolded pr ->
+        | PRef (GlobRef.ConstRef r), Proj (pr,c) when not (Environ.QConstant.equal env r (Projection.constant pr)) ->
           raise PatternMatchingFailure
         | PProj (pr1,c1), Proj (pr,c) ->
           if Environ.QProjection.equal env pr1 pr then
             try Array.fold_left2 (sorec ctx env) (sorec ctx env subst c1 c) arg1 arg2
             with Invalid_argument _ -> raise PatternMatchingFailure
           else raise PatternMatchingFailure
-        | _, Proj (pr,c) when not (Projection.unfolded pr) ->
+        | _, Proj (pr,c) ->
           (try let term = Retyping.expand_projection env sigma pr c (Array.to_list arg2) in
                  sorec ctx env subst p term
            with Retyping.RetypeError _ -> raise PatternMatchingFailure)
@@ -324,7 +323,7 @@ let matches_core env sigma allow_bound_rels
           with Invalid_argument _ -> raise PatternMatchingFailure)
 
       | PApp (PRef (GlobRef.ConstRef c1), _), Proj (pr, c2)
-        when Projection.unfolded pr || not (Environ.QConstant.equal env c1 (Projection.constant pr)) ->
+        when not (Environ.QConstant.equal env c1 (Projection.constant pr)) ->
         raise PatternMatchingFailure
 
       | PApp (c, args), Proj (pr, c2) ->

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -796,13 +796,7 @@ and detype_r d flags avoid env sigma t =
     | Lambda (na,ty,c) -> detype_binder d flags BLambda avoid env sigma (LocalAssum (na,ty)) c
     | LetIn (na,b,ty,c) -> detype_binder d flags BLetIn avoid env sigma (LocalDef (na,b,ty)) c
     | App (f,args) ->
-      let mkapp f' args' =
-        match DAst.get f' with
-        | GApp (f',args'') ->
-          GApp (f',args''@args')
-        | _ -> GApp (f',args')
-      in
-      mkapp (detype d flags avoid env sigma f)
+      Glob_ops.mkGAppR (detype d flags avoid env sigma f)
         (Array.map_to_list (detype d flags avoid env sigma) args)
     | Const (sp,u) -> GRef (GlobRef.ConstRef sp, detype_instance sigma u)
     | Proj (p,c) ->

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -804,8 +804,8 @@ and detype_r d flags avoid env sigma t =
         let pars = Projection.npars p in
         let hole = DAst.make @@ GHole(Evar_kinds.InternalHole,Namegen.IntroAnonymous,None) in
         let args = List.make pars hole in
-        GApp (DAst.make @@ GRef (GlobRef.ConstRef (Projection.constant p), None),
-              (args @ [detype d flags avoid env sigma c]))
+        let c = detype d flags avoid env sigma c in
+        GProj ((Projection.constant p, None), args, c)
       in
       if flags.flg_lax || !Flags.in_debugger || !Flags.in_toplevel then
         try noparams ()

--- a/pretyping/detyping.mli
+++ b/pretyping/detyping.mli
@@ -21,6 +21,9 @@ type _ delay =
 | Now : 'a delay
 | Later : [ `thunk ] delay
 
+(** This governs printing of non-primitive projections using the dot notation symbols *)
+val print_projections : bool ref
+
 (** Should we keep details of universes during detyping ? *)
 val print_universes : bool ref
 

--- a/pretyping/glob_ops.ml
+++ b/pretyping/glob_ops.ml
@@ -34,10 +34,13 @@ let cases_predicate_names tml =
     | (tm,(na,None)) -> [na]
     | (tm,(na,Some {v=(_,nal)})) -> na::nal) tml)
 
-let mkGApp ?loc p l = DAst.make ?loc @@
-  match DAst.get p with
-  | GApp (f,l') -> GApp (f,l'@l)
-  | _          -> GApp (p,l)
+let mkGAppR f args =
+  match DAst.get f with
+  | GApp (f',args') -> GApp (f',args'@args)
+  | _ -> GApp (f,args)
+
+let mkGApp ?loc p l =
+  DAst.make ?loc @@ mkGAppR p l
 
 let map_glob_decl_left_to_right f (na,k,obd,ty) =
   let comp1 = Option.map f obd in

--- a/pretyping/glob_ops.mli
+++ b/pretyping/glob_ops.mli
@@ -50,6 +50,7 @@ val cases_predicate_names : 'a tomatch_tuples_g -> Name.t list
 
 (** Apply a list of arguments to a glob_constr *)
 val mkGApp : ?loc:Loc.t -> 'a glob_constr_g -> 'a glob_constr_g list -> 'a glob_constr_g
+val mkGAppR : 'a glob_constr_g -> 'a glob_constr_g list -> 'a glob_constr_r
 
 val map_glob_constr :
   (glob_constr -> glob_constr) -> glob_constr -> glob_constr

--- a/test-suite/bugs/closed/bug_11366.v
+++ b/test-suite/bugs/closed/bug_11366.v
@@ -1,0 +1,4 @@
+Set Primitive Projections.
+Record Box (A B:nat) := box { unbox : nat }.
+Coercion unbox : nat >-> Funclass.
+Check (0 0).

--- a/test-suite/output/Record.out
+++ b/test-suite/output/Record.out
@@ -76,3 +76,20 @@ fun x : R => 0
      : R -> nat
 The command has indeed failed with message:
 Projection f expected 1 explicit parameter.
+b =
+fun (A : Type) (c : A) (f : Foo A c) => f.(b)
+     : forall (A : Type) (c : A) (f : Foo A c), f.(a) = c
+
+Arguments b {A}%type_scope {c} _
+fun x : Foo nat 0 => b nat 0 x
+     : forall x : Foo nat 0, x.(a _ _) = 0
+fun x : Foo nat 0 => x.(b _ _)
+     : forall x : Foo nat 0, x.(a _ _) = 0
+fun x : Foo nat 0 => b nat 0 x
+     : forall x : Foo nat 0, a nat 0 x = 0
+fun x : Foo nat 0 => b nat 0 x
+     : forall x : Foo nat 0, a nat 0 x = 0
+fun x : Foo nat 0 => x.(b nat 0)
+     : forall x : Foo nat 0, x.(a nat 0) = 0
+fun x : Foo nat 0 => x.(b nat 0)
+     : forall x : Foo nat 0, x.(a nat 0) = 0

--- a/test-suite/output/Record.out
+++ b/test-suite/output/Record.out
@@ -93,3 +93,15 @@ fun x : Foo nat 0 => x.(b nat 0)
      : forall x : Foo nat 0, x.(a nat 0) = 0
 fun x : Foo nat 0 => x.(b nat 0)
      : forall x : Foo nat 0, x.(a nat 0) = 0
+fun x : u => x -> nat
+     : u -> Type
+fun x : u => x -> nat
+     : u -> Type
+F x y = F x y
+     : Prop
+fun x : u => x -> nat
+     : u -> Type
+fun x : u => x -> nat
+     : u -> Type
+F x y = F x y
+     : Prop

--- a/test-suite/output/Record.v
+++ b/test-suite/output/Record.v
@@ -85,3 +85,29 @@ Record R A := { f : A -> A }.
 Fail Check fun x => x.(f).
 
 End RecordImplicitParameters.
+
+Module PrimProj.
+
+Set Primitive Projections.
+
+Record Foo A c := { a : A; b : a = c }.
+
+(* Two different paths for primitive projections *)
+Check fun x => b nat 0 x.
+Check fun x => x.(b nat 0).
+
+End PrimProj.
+
+Module NonPrimProj.
+
+Record Foo A c := { a : A; b : a = c }.
+
+(* Same paths for primitive projections *)
+Check fun x => b nat 0 x.
+Check fun x => x.(b nat 0).
+
+Set Printing Projections.
+Check fun x => b nat 0 x.
+Check fun x => x.(b nat 0).
+
+End NonPrimProj.

--- a/test-suite/output/Record.v
+++ b/test-suite/output/Record.v
@@ -111,3 +111,33 @@ Check fun x => b nat 0 x.
 Check fun x => x.(b nat 0).
 
 End NonPrimProj.
+
+Module Coercions.
+
+Record t := { a :> Type }. Record u := { b :> t }.
+Check fun x : u => x.(b).(a) -> nat.
+Check fun x : u => x -> nat.
+
+Record PreCategory := { object :> Type }.
+Record Functor (C D : PreCategory) := { object_of :> C -> D }.
+Definition functor_category (C D : PreCategory) : PreCategory := {| object := Functor C D |}.
+Context (C1 C2 D : PreCategory) (F : Functor C1 (functor_category C2 D)) (x:C1) (y:C2).
+Check F x y = F x y.
+
+End Coercions.
+
+Module PrimitiveCoercions.
+
+Set Primitive Projections.
+
+Record t := { a :> Type }. Record u := { b :> t }.
+Check fun x : u => x.(b).(a) -> nat.
+Check fun x : u => x -> nat.
+
+Record PreCategory := { object :> Type }.
+Record Functor (C D : PreCategory) := { object_of :> C -> D }.
+Definition functor_category (C D : PreCategory) : PreCategory := {| object := Functor C D |}.
+Context (C1 C2 D : PreCategory) (F : Functor C1 (functor_category C2 D)) (x:C1) (y:C2).
+Check F x y = F x y.
+
+End PrimitiveCoercions.

--- a/vernac/comCoercion.ml
+++ b/vernac/comCoercion.ml
@@ -269,7 +269,10 @@ let inCoercion : coe_info_typ -> obj =
 let declare_coercion coef typ ?(local = false) ~isid ~src:cls ~target:clt ~params:ps () =
   let isproj =
     match coef with
-    | GlobRef.ConstRef c -> Structures.PrimitiveProjections.find_opt c
+    | GlobRef.ConstRef c ->
+      (match Structures.PrimitiveProjections.find_opt c with
+       | Some p when ps >= Names.Projection.Repr.npars p -> Some p
+       | _ -> None)
     | _ -> None
   in
   let c = {

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1574,8 +1574,8 @@ let () =
   declare_bool_option
     { optdepr  = false;
       optkey   = ["Printing";"Projections"];
-      optread  = (fun () -> !Constrextern.print_projections);
-      optwrite = (fun b ->  Constrextern.print_projections := b) }
+      optread  = (fun () -> !Detyping.print_projections);
+      optwrite = (fun b ->  Detyping.print_projections := b) }
 
 let () =
   declare_bool_option


### PR DESCRIPTION
**Kind:** "feature"

Depends on #14606 (merged), #14706 (merged) and #14598 (merged).

PR #14598 introduced a specific node for projections in `glob_term` and `notation_term` but #14598 preserved an equivalence between the `GProj` representation and the `GApp`-based representation.

This PR makes the interpretation path for `t.(f)`, and more generally `t.(f params)`, clearly distinct from the `f params t` path:
- a syntactic expression `f params t` when `f` is a primitive projection is now bound to a kernel `App` (not optimized) rather than to a kernel `Proj` (dropping the parameters) as before
- conversely, kernel (primitive) proj are directed to `GProj`, then `CProj` and thus always printed as `t.(f _ ⣀ _)` while before they were directed to `GApp` (losing the proj status) and re-directed to `CProj` only when the flag `Printing Projections` was set
- notations referring to `f params t` and to `t.(f params)` are no more identified when `f` is primitive

The code for `pretype_proj` is temporary. Afaiu, @ppedrot has somewhere a code ready for projections.

A next step is to decide whether the `f params t` path should eventually be fully removed, or kept only for partially applied projections, or kept as an non-optimized alternative (see coq/ceps#57).