### PR TITLE
Debugger part 3: display call stack and variable values

### DIFF
--- a/dev/ci/user-overlays/14644-jfehrle-debugger_gui.sh
+++ b/dev/ci/user-overlays/14644-jfehrle-debugger_gui.sh
@@ -1,0 +1,1 @@
+overlay coqtail https://github.com/jfehrle/coqtail change_add 14644

--- a/dev/doc/changes.md
+++ b/dev/doc/changes.md
@@ -1,5 +1,11 @@
 ## Changes between Coq 8.14 and Coq 8.15
 
+### Ltac Visual Debugger in CoqIDE
+
+- Updated the XML protocol (4 new "db_*" messages and added location info
+  to the "add" message) and added support for these primarily in tactic_debug.ml.
+  See the protocol description in xmlprotocol.md.
+
 ### Internal representation of the type of constructors
 
 The type of constructors in fields `mind_user_lc` and `mind_nf_lc` of

--- a/dev/doc/xml-protocol.md
+++ b/dev/doc/xml-protocol.md
@@ -31,7 +31,6 @@ Changes to the XML protocol are documented as part of [`dev/doc/changes.md`](/de
   - [PrintAst](#command-printast)
   - [Annotate](#command-annotate)
   - [Db_cmd](#command-db_cmd)
-  - [Db_loc](#command-db_loc)
   - [Db_upd_bpts](#command-db_upd_bpts)
   - [Db_continue](#command-db_continue)
   - [Db_stack](#command-db_stack)
@@ -661,36 +660,6 @@ take `<call val="Annotate"><string>Theorem plus_0_r : forall n : nat, n + 0 = n.
 `<call val="Db_cmd"><string>h</string></call>` directs Coq to process the debugger command "h".
 It returns unit.  This call is processed only when the debugger is stopped and has just
 sent a `prompt` message.
-
-
-
--------------------------------
-
-
-
-### <a name="command-db_loc">**Db_loc()**</a>
-Returns the location where the debugger has stopped, consisting of the absolute filename
-of the .v file (or "ToplevelInput") and the beginning and ending offset therein.  Offsets
-are in bytes, not counts of unicode characters.
-```html
-<call val="Db_loc">
-  <unit/>
-</call>
-```
-#### *Returns*
-
-
-```html
-<value val="good">
-  <pair>
-    <string>ToplevelInput</string>
-    <list>
-      <int>22</int>
-      <int>31</int>
-    </list>
-  </pair>
-</value>
-```
 
 
 

--- a/doc/changelog/09-coqide/14644-debugger_stack.rst
+++ b/doc/changelog/09-coqide/14644-debugger_stack.rst
@@ -1,0 +1,8 @@
+- **Added:**
+  Initial version of a visual debugger.  Supports setting breakpoints
+  visually and jumping to the stopping point plus continue, step over,
+  step in and step out operations.  Displays the call stack and
+  variable values for each stack frame.  Currently only for Ltac.
+  (`#14644 <https://github.com/coq/coq/pull/14644>`_,
+  fixes `#13967 <https://github.com/coq/coq/issues/13967>`_,
+  by Jim Fehrle).

--- a/ide/coqide/coq.ml
+++ b/ide/coqide/coq.ml
@@ -558,7 +558,7 @@ let try_grab ?(db=false) coqtop task abort =
     | _ when db && coqtop.handle.db_waiting_for <> None -> (abort (); false)
     | Closed -> abort (); false
     | Busy when db ->
-      if coqtop.stopped_in_debugger && coqtop.handle.db_waiting_for = None then
+      if (*coqtop.stopped_in_debugger &&*) coqtop.handle.db_waiting_for = None then
         (process_task ~db coqtop task; true)
       else
         (abort (); false)
@@ -611,6 +611,7 @@ let db_upd_bpts x = eval_call ~db:true (Xmlprotocol.db_upd_bpts x)
 let db_continue x = eval_call ~db:true (Xmlprotocol.db_continue x)
 let db_stack x = eval_call ~db:true (Xmlprotocol.db_stack x)
 let db_vars x = eval_call ~db:true (Xmlprotocol.db_vars x)
+let db_configd x = eval_call ~db:true (Xmlprotocol.db_configd x)
 
 let interrupt_coqtop coqtop workers =
   if coqtop.status = Busy then

--- a/ide/coqide/coq.mli
+++ b/ide/coqide/coq.mli
@@ -164,6 +164,7 @@ val db_upd_bpts: Interface.db_upd_bpts_sty-> Interface.db_upd_bpts_rty query
 val db_continue: Interface.db_continue_sty-> Interface.db_continue_rty query
 val db_stack   : Interface.db_stack_sty   -> Interface.db_stack_rty query
 val db_vars    : Interface.db_vars_sty    -> Interface.db_vars_rty query
+val db_configd : Interface.db_configd_sty -> Interface.db_configd_rty query
 
 val stop_worker: Interface.stop_worker_sty-> Interface.stop_worker_rty query
 

--- a/ide/coqide/coq.mli
+++ b/ide/coqide/coq.mli
@@ -21,6 +21,15 @@ type coqtop
     abrupt failure. It is also called when explicitly requesting coqtop to
     reset. *)
 
+type status = New | Ready | Busy | Closed
+(** Coqtop process status :
+  - New    : a process has been spawned, but not initialized via [init_coqtop].
+             It will reject tasks given via [try_grab].
+  - Ready  : no current task, accepts new tasks via [try_grab].
+  - Busy   : has accepted a task via [init_coqtop] or [try_grab],
+  - Closed : the coqide buffer has been closed, we discard any further task.
+*)
+
 type 'a task
 (** Coqtop tasks.
 
@@ -59,8 +68,20 @@ type reset_kind = Planned | Unexpected
 val is_computing : coqtop -> bool
 (** Check if coqtop is computing, i.e. already has a current task *)
 
-val spawn_coqtop : string list -> coqtop
+val is_stopped_in_debugger : coqtop -> bool
+(** Returns true if coqtop is stopped in the debugger *)
+
+val is_ready_or_stopped_in_debugger : coqtop -> bool
+(** Check if coqtop is Ready or stopped in the debugger *)
+
+val set_stopped_in_debugger : coqtop -> bool -> unit
+(** Records whether coqtop is stopped in the debugger *)
+
+val spawn_coqtop : string -> string list -> coqtop
 (** Create a coqtop process with some command-line arguments. *)
+
+val set_restore_bpts : coqtop -> (unit -> unit) -> unit
+(** Register callback to restore breakpoints after a session has been reset *)
 
 val set_reset_handler : coqtop -> unit task -> unit
 (** Register a handler called when a coqtop dies (badly or on purpose) *)
@@ -71,12 +92,19 @@ val set_feedback_handler : coqtop -> (Feedback.feedback -> unit) -> unit
 val set_debug_prompt_handler : coqtop -> (tag:string -> Pp.t -> unit) -> unit
 (** Register a handler called when the Ltac debugger sends a feedback message *)
 
+val add_do_when_ready : coqtop -> (unit -> unit) -> unit
+(** Register a function to be called when coqtop becomes Ready *)
+
+val setup_script_editable : coqtop -> (bool -> unit) -> unit
+(** Register setter function to make proof script panel editable or not,
+    e.g. to disable editing while any non-debugger message is being processed *)
+
 val init_coqtop : coqtop -> unit task -> unit
 (** Finish initializing a freshly spawned coqtop, by running a first task on it.
     The task should run its inner continuation at the end. *)
 
-val break_coqtop : coqtop -> string list -> unit
-(** Interrupt the current computation of coqtop or the worker if coqtop it not running. *)
+val interrupt_coqtop : coqtop -> string list -> unit
+(** Terminate the current computation of coqtop or the worker if coqtop is not running. *)
 
 val close_coqtop : coqtop -> unit
 (** Close coqtop. Subsequent requests will be discarded. Hook ignored. *)
@@ -96,10 +124,10 @@ val gio_channel_of_descr_socket : (Unix.file_descr -> Glib.Io.channel) ref
 
 (** {5 Task processing} *)
 
-val try_grab : ?db:bool -> coqtop -> unit task -> (unit -> unit) -> unit
+val try_grab : ?db:bool -> coqtop -> unit task -> (unit -> unit) -> bool
 (** Try to schedule a task on a coqtop. If coqtop is available, the task
     callback is run (asynchronously), otherwise the [(unit->unit)] callback
-    is triggered.
+    is triggered.  Returns true if the task is run.
     - If coqtop ever dies during the computation, this function restarts coqtop
       and calls the restart hook with the fresh coqtop.
     - If the argument function raises an exception, a coqtop reset occurs.
@@ -132,6 +160,10 @@ val search     : Interface.search_sty     -> Interface.search_rty query
 val init       : Interface.init_sty       -> Interface.init_rty query
 val proof_diff : Interface.proof_diff_sty -> Interface.proof_diff_rty query
 val db_cmd     : Interface.db_cmd_sty     -> Interface.db_cmd_rty query
+val db_upd_bpts: Interface.db_upd_bpts_sty-> Interface.db_upd_bpts_rty query
+val db_continue: Interface.db_continue_sty-> Interface.db_continue_rty query
+val db_stack   : Interface.db_stack_sty   -> Interface.db_stack_rty query
+val db_vars    : Interface.db_vars_sty    -> Interface.db_vars_rty query
 
 val stop_worker: Interface.stop_worker_sty-> Interface.stop_worker_rty query
 
@@ -183,6 +215,9 @@ val check_connection : string list -> unit
     may terminate coqide in case of trouble *)
 
 val interrupter : (int -> unit) ref
+val breaker : (int -> unit) ref
+val send_break : coqtop -> unit
+
 val save_all : (unit -> unit) ref
 
 (* Flags to be used for ideslave *)

--- a/ide/coqide/coqOps.ml
+++ b/ide/coqide/coqOps.ml
@@ -140,6 +140,14 @@ object
   method process_next_phrase : unit task
   method process_db_cmd : string ->
     next:(Interface.db_cmd_rty Interface.value -> unit task) -> unit task
+  method process_db_upd_bpts : ((string * int) * bool) list ->
+    next:(Interface.db_upd_bpts_rty Interface.value -> unit task) -> unit task
+  method process_db_continue : db_continue_opt ->
+    next:(Interface.db_continue_rty Interface.value -> unit task) -> unit task
+  method process_db_stack :
+    next:(Interface.db_stack_rty Interface.value -> unit task) -> unit task
+  method process_db_vars : int ->
+    next:(Interface.db_vars_rty Interface.value -> unit task) -> unit task
   method process_until_end_or_error : unit task
   method handle_reset_initial : unit task
   method raw_coq_query :
@@ -158,6 +166,10 @@ object
   method handle_failure : handle_exn_rty -> unit task
 
   method destroy : unit -> unit
+  method scroll_to_start_of_input : unit -> unit
+  method set_forward_clear_db_highlight : (unit -> unit) -> unit
+  method set_forward_set_goals_of_dbg_session : (Pp.t -> unit) -> unit
+  method set_debug_goal : Pp.t -> unit
 end
 
 let flags_to_color f =
@@ -246,17 +258,18 @@ object(self)
   val mutable processed = 0
   val mutable slaves_status = CString.Map.empty
 
-  val feedbacks : queue_msg Queue.t = Queue.create ()
-  val feedback_timer = Ideutils.mktimer ()
+  val mutable forward_clear_db_highlight = ((fun x -> failwith "forward_clear_db_highlight")
+                  : unit -> unit)
 
+  val mutable forward_set_goals_of_dbg_session = ((fun x -> failwith "forward_set_goals_of_dbg_session")
+                  : Pp.t -> unit)
   initializer
     Coq.set_feedback_handler _ct
-        (fun msg -> self#enqueue_feedback (MsgFeedback msg));
+        (fun msg -> self#process_feedback (MsgFeedback msg));
     Coq.set_debug_prompt_handler _ct
-        (fun ~tag msg -> self#enqueue_feedback (MsgDebug (tag, msg)));
+        (fun ~tag msg -> self#process_feedback (MsgDebug (tag, msg)));
     script#misc#set_has_tooltip true;
     ignore(script#misc#connect#query_tooltip ~callback:self#tooltip_callback);
-    feedback_timer.Ideutils.run ~ms:300 ~callback:self#process_feedback;
     let md = segment_model document in
     segment#set_model md;
     let on_click id =
@@ -304,8 +317,17 @@ object(self)
     end;
     false
 
-  method destroy () =
-    feedback_timer.Ideutils.kill ()
+  method destroy () = ()
+
+  method scroll_to_start_of_input () =
+    let start = buffer#get_iter_at_mark (`NAME "start_of_input") in
+    ignore (script#scroll_to_iter ~use_align:true ~yalign:0. start)
+
+  method set_forward_clear_db_highlight f =
+    forward_clear_db_highlight <- f
+
+  method set_forward_set_goals_of_dbg_session f =
+    forward_set_goals_of_dbg_session <- f
 
   method private print_stack =
     Minilib.log "document:";
@@ -431,27 +453,21 @@ object(self)
     buffer#apply_tag Tags.Script.tooltip ~start ~stop;
     add_tooltip sentence pre post markup
 
-  method private enqueue_feedback msg =
-    (* Minilib.log ("Feedback received: " ^ Xml_printer.to_string_fmt Xmlprotocol.(of_feedback Ppcmds msg)); *)
-    Queue.add msg feedbacks
-
   method private debug_prompt ~tag msg =
     match tag with
     | "prompt" ->
       messages#default_route#debug_prompt msg
+    | "goal" ->
+      forward_set_goals_of_dbg_session msg
     | _ ->
       messages#default_route#push Debug msg
 
-  (* todo: is it necessary to have a queue and to call this routine on a timer? *)
-  method private process_feedback () =
-    let rec eat_feedback n =
-      (* todo: why not just check if feedbacks is empty? *)
-      if n = 0 then true else
-      let msg = Queue.pop feedbacks in
-      match msg with
-      | MsgFeedback msg2 -> pr_feedback n msg2
-      | MsgDebug (tag, msg2) -> self#debug_prompt ~tag msg2; eat_feedback (n-1)
-    and pr_feedback n msg =
+  method set_debug_goal msg =
+    proof#set_debug_goal msg
+
+  method private process_feedback msg =
+    (* Minilib.log ("Feedback received: " ^ Xml_printer.to_string_fmt Xmlprotocol.(of_feedback Ppcmds msg)); *)
+    let pr_feedback msg =
       let id = msg.span_id in
       let sentence =
         let finder _ state_id s =
@@ -460,9 +476,15 @@ object(self)
           | _ -> None in
         try Some (Doc.find_map document finder)
         with Not_found -> None in
-      let log_pp ?id s=
+      let log_pp ?id s =
         Minilib.log_pp Pp.(seq
                 [str "Feedback "; s; pr_opt (fun id -> str " on " ++ str (Stateid.to_string id)) id])
+      in
+      let msg_wo_sent mtype =
+        Minilib.log (mtype ^ " feedback message without a sentence") in
+      let unsupp_msg mtype =
+        if sentence <> None then
+          Minilib.log ("Unsupported feedback message " ^ mtype ^ " with a sentence")
       in
       let log ?id s = log_pp ?id (Pp.str s) in
       begin match msg.contents, sentence with
@@ -472,26 +494,33 @@ object(self)
           remove_flag sentence `ERROR;
           add_flag sentence `UNSAFE;
           self#mark_as_needed sentence
+      | AddedAxiom, None ->  msg_wo_sent "AddedAxiom"
       | Processed, Some (id,sentence) ->
           log ?id "Processed" ;
           remove_flag sentence `PROCESSING;
-          self#mark_as_needed sentence
+          self#mark_as_needed sentence;
+          forward_clear_db_highlight ()
+      | Processed, None ->  msg_wo_sent "Processed"
       | ProcessingIn _,  Some (id,sentence) ->
           log ?id "ProcessingIn";
           add_flag sentence `PROCESSING;
           self#mark_as_needed sentence
+      | ProcessingIn _, None ->  msg_wo_sent "ProcessingIn"
       | Incomplete, Some (id, sentence) ->
           log ?id "Incomplete";
           add_flag sentence `INCOMPLETE;
           self#mark_as_needed sentence
+      | Incomplete, None ->  msg_wo_sent "Incomplete"
       | Complete, Some (id, sentence) ->
           log ?id "Complete";
           remove_flag sentence `INCOMPLETE;
           self#mark_as_needed sentence
+      | Complete, None ->  msg_wo_sent "Complete"
       | GlobRef(loc, filepath, modpath, ident, ty), Some (id,sentence) ->
           log ?id "GlobRef";
           self#attach_tooltip ~loc sentence
             (Printf.sprintf "%s %s %s" filepath ident ty)
+      | GlobRef (_, _, _, _, _), None -> msg_wo_sent "GlobRef"
       | Message(Error, loc, msg), Some (id,sentence) ->
           log_pp ?id Pp.(str "ErrorMsg " ++ msg);
           remove_flag sentence `PROCESSING;
@@ -522,19 +551,23 @@ object(self)
       | WorkerStatus(id,status), _ ->
           log "WorkerStatus";
           slaves_status <- CString.Map.add id status slaves_status
-      | _ ->
-          if sentence <> None then Minilib.log "Unsupported feedback message"
-          else if Doc.is_empty document then ()
-          else
-            try
-              match id, Doc.tip document with
-              | id1, id2 when Stateid.newer_than id2 id1 -> ()
-              | _ -> Queue.add (MsgFeedback msg) feedbacks
-            with Doc.Empty | Invalid_argument _ -> Queue.add (MsgFeedback msg) feedbacks
-      end;
-      eat_feedback (n-1)
+      (* log unused feedback messages with a sentence *)
+      | GlobDef (_, _, _, _), _ -> unsupp_msg "GlobDef"
+      | FileDependency (_, _), _ -> unsupp_msg "FileDependency"
+      | FileLoaded (_, _), _ -> unsupp_msg "FileLoaded"
+      | Custom (_, _, _), _  -> unsupp_msg "Custom"
+      end
     in
-    eat_feedback (Queue.length feedbacks)
+    try match msg with
+      | MsgFeedback msg2 -> pr_feedback msg2
+      | MsgDebug (tag, msg2) ->
+        if tag = "prompt" then
+          Coq.set_stopped_in_debugger _ct true;
+        self#debug_prompt ~tag msg2
+    with e -> (Printf.printf "Exception: %s\n%!" (Printexc.to_string e);
+        Printexc.print_backtrace stdout;
+        flush stdout;
+        raise e)
 
   method private commit_queue_transaction sentence =
     (* A queued command has been successfully done, we push it to [cmd_stack].
@@ -550,8 +583,8 @@ object(self)
     | Some loc ->
       let start, stop = Loc.unloc loc in
       buffer#apply_tag tag
-        ~start:(iter_start#forward_chars (b2c phrase start))
-        ~stop:(iter_start#forward_chars (b2c phrase stop))
+        ~start:(buffer#get_iter (`OFFSET (b2c phrase start)))
+        ~stop:(buffer#get_iter (`OFFSET (b2c phrase stop)))
 
   method private position_tag_at_sentence ?loc tag sentence =
     let start, stop, phrase = self#get_sentence sentence in
@@ -585,6 +618,7 @@ object(self)
   method private fill_command_queue until queue =
     let topstack =
       if Doc.focused document then fst (Doc.context document) else [] in
+    self#scroll_to_start_of_input ();
     let rec loop n iter =
       match Sentence.find buffer iter with
       | None -> ()
@@ -660,20 +694,21 @@ object(self)
         | `Sentence ({ edit_id } as sentence), [] ->
             add_flag sentence `PROCESSING;
             Doc.push document sentence;
-            let _, _, phrase = self#get_sentence sentence in
-            let coq_query = Coq.add ((phrase,edit_id),(tip,verbose)) in
+            let start, _, phrase = self#get_sentence sentence in
+            let bp = start#offset in
+            let line_nb = start#line + 1 in
+            let bol_pos = start#line_offset in
+            let coq_query = Coq.add ((((phrase,edit_id),(tip,verbose)),bp),(line_nb,bol_pos)) in
             let handle_answer = function
-              | Good (id, (Util.Inl (* NewTip *) (), msg)) ->
+              | Good (id, Util.Inl (* NewTip *) ()) ->
                   Doc.assign_tip_id document id;
-                  logger Feedback.Notice (Pp.str msg);
                   self#commit_queue_transaction sentence;
                   loop id []
-              | Good (id, (Util.Inr (* Unfocus *) tip, msg)) ->
+              | Good (id, Util.Inr (* Unfocus *) tip) ->
                   Doc.assign_tip_id document id;
                   let topstack, _ = Doc.context document in
                   self#exit_focus;
                   self#cleanup (Doc.cut_at document tip);
-                  logger Feedback.Notice (Pp.str msg);
                   self#mark_as_needed sentence;
                   if Queue.is_empty queue then loop tip []
                   else loop tip (List.rev topstack)
@@ -730,6 +765,22 @@ object(self)
   method process_db_cmd cmd ~next : unit Coq.task =
     let db_cmd = Coq.db_cmd cmd in
     Coq.bind db_cmd next
+
+  method process_db_upd_bpts updates ~next : unit Coq.task =
+    let db_upd_bpts = Coq.db_upd_bpts updates in
+    Coq.bind db_upd_bpts next
+
+  method process_db_continue opt ~next : unit Coq.task =
+    let db_continue = Coq.db_continue opt in
+    Coq.bind db_continue next
+
+  method process_db_stack ~next : unit Coq.task =
+    let db_stack = Coq.db_stack () in
+    Coq.bind db_stack next
+
+  method process_db_vars framenum ~next : unit Coq.task =
+    let db_vars = Coq.db_vars framenum in
+    Coq.bind db_vars next
 
   method private process_until_iter iter =
     let until _ start stop =
@@ -818,7 +869,6 @@ object(self)
     ?(move_insert=false) (safe_id, (loc : (int * int) option), msg)
   =
     messages#default_route#push Feedback.Error msg;
-    ignore(self#process_feedback ());
     if Stateid.equal safe_id Stateid.dummy then Coq.lift (fun () -> ())
     else
       Coq.seq
@@ -839,9 +889,12 @@ object(self)
     Coq.bind (Coq.return ()) (fun () ->
     messages#default_route#clear;
     let point = self#get_insert in
-    if point#compare self#get_start_of_input >= 0
-    then self#process_until_iter point
-    else self#backtrack_to_iter ~move_insert:false point)
+    if point#compare self#get_start_of_input >= 0 then
+      self#process_until_iter point
+    else begin
+      self#scroll_to_start_of_input ();
+      self#backtrack_to_iter ~move_insert:false point
+    end)
 
   method go_to_mark m =
     Coq.bind (Coq.return ()) (fun () ->
@@ -864,7 +917,7 @@ object(self)
       done;
       List.iter
         (buffer#remove_tag ~start:buffer#start_iter ~stop:buffer#end_iter)
-        Tags.Script.all;
+        Tags.Script.all_but_bpt;
       (* reset the buffer *)
       buffer#move_mark ~where:buffer#start_iter (`NAME "start_of_input");
       buffer#move_mark ~where:buffer#end_iter (`NAME "stop_of_input");

--- a/ide/coqide/coqOps.mli
+++ b/ide/coqide/coqOps.mli
@@ -18,6 +18,14 @@ object
   method process_next_phrase : unit task
   method process_db_cmd : string ->
     next:(Interface.db_cmd_rty Interface.value -> unit task) -> unit task
+  method process_db_upd_bpts : ((string * int) * bool) list ->
+    next:(Interface.db_upd_bpts_rty Interface.value -> unit task) -> unit task
+  method process_db_continue : db_continue_opt ->
+    next:(Interface.db_continue_rty Interface.value -> unit task) -> unit task
+  method process_db_stack :
+    next:(Interface.db_stack_rty Interface.value -> unit task) -> unit task
+  method process_db_vars : int ->
+    next:(Interface.db_vars_rty Interface.value -> unit task) -> unit task
   method process_until_end_or_error : unit task
   method handle_reset_initial : unit task
   method raw_coq_query :
@@ -36,6 +44,10 @@ object
   method handle_failure : handle_exn_rty -> unit task
 
   method destroy : unit -> unit
+  method scroll_to_start_of_input : unit -> unit
+  method set_forward_clear_db_highlight : (unit -> unit) -> unit
+  method set_forward_set_goals_of_dbg_session : (Pp.t -> unit) -> unit
+  method set_debug_goal : Pp.t -> unit
 end
 
 class coqops :

--- a/ide/coqide/coqOps.mli
+++ b/ide/coqide/coqOps.mli
@@ -18,6 +18,8 @@ object
   method process_next_phrase : unit task
   method process_db_cmd : string ->
     next:(Interface.db_cmd_rty Interface.value -> unit task) -> unit task
+  method process_db_configd : unit ->
+    next:(Interface.db_configd_rty Interface.value -> unit task) -> unit task
   method process_db_upd_bpts : ((string * int) * bool) list ->
     next:(Interface.db_upd_bpts_rty Interface.value -> unit task) -> unit task
   method process_db_continue : db_continue_opt ->
@@ -47,6 +49,7 @@ object
   method scroll_to_start_of_input : unit -> unit
   method set_forward_clear_db_highlight : (unit -> unit) -> unit
   method set_forward_set_goals_of_dbg_session : (Pp.t -> unit) -> unit
+  method set_forward_init_db : (unit -> unit) -> unit
   method set_debug_goal : Pp.t -> unit
 end
 

--- a/ide/coqide/coqide.mli
+++ b/ide/coqide/coqide.mli
@@ -24,10 +24,6 @@ val read_coqide_args : string list -> string list
 (** Prepare the widgets, load the given files in tabs *)
 val main : string list -> GWindow.window
 
-(** Function to save anything and kill all coqtops
-    @return [false] if you're allowed to quit. *)
-val forbid_quit : unit -> bool
-
 (** Terminate coqide after closing all coqtops and waiting
     for their death *)
 val close_and_quit : unit -> unit

--- a/ide/coqide/coqide_ui.ml
+++ b/ide/coqide/coqide_ui.ml
@@ -95,10 +95,10 @@ let init () =
 \n  <menu action='Navigation'>\
 \n    <menuitem action='Forward' />\
 \n    <menuitem action='Backward' />\
-\n    <menuitem action='Go to' />\
-\n    <menuitem action='Start' />\
-\n    <menuitem action='End' />\
+\n    <menuitem action='Run to cursor' />\
+\n    <menuitem action='Run to end' />\
 \n    <menuitem action='Interrupt' />\
+\n    <menuitem action='Reset' />\
 \n    <menuitem action='Previous' />\
 \n    <menuitem action='Next' />\
 \n  </menu>\
@@ -137,14 +137,23 @@ let init () =
 \n    <menuitem action='Next error' />\
 \n    <menuitem action='Make makefile' />\
 \n  </menu>\
+\n  <menu action='Debug'>\
+\n    <menuitem action='Toggle breakpoint' />\
+\n    <menuitem action='Continue' />\
+\n    <menuitem action='Step in' />\
+\n    <menuitem action='Step out' />\
+\n    <menuitem action='Break' />\
+\n    <menuitem action='Show debug panel' />\
+\n  </menu>\
 \n  <menu action='Windows'>\
-\n    <menuitem action='Detach View' />\
+\n    <menuitem action='Detach Proof' />\
 \n  </menu>\
 \n  <menu name='Help' action='Help'>\
 \n    <menuitem action='Browse Coq Manual' />\
 \n    <menuitem action='Browse Coq Library' />\
 \n    <menuitem action='Help for keyword' />\
 \n    <menuitem action='Help for μPG mode' />\
+\n    <menuitem action='Memory usage' />\
 \n    <separator />\
 \n    <menuitem name='Abt' action='About Coq' />\
 \n  </menu>\
@@ -154,11 +163,11 @@ let init () =
 \n  <toolitem action='Close buffer' />\
 \n  <toolitem action='Forward' />\
 \n  <toolitem action='Backward' />\
-\n  <toolitem action='Go to' />\
-\n  <toolitem action='Start' />\
-\n  <toolitem action='End' />\
+\n  <toolitem action='Run to cursor' />\
+\n  <toolitem action='Run to end' />\
 \n  <toolitem action='Force' />\
 \n  <toolitem action='Interrupt' />\
+\n  <toolitem action='Reset' />\
 \n  <toolitem action='Previous' />\
 \n  <toolitem action='Next' />\
 \n</toolbar>\

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -429,11 +429,7 @@ let db_continue opt =
   | Interface.Interrupt -> Interrupt
 
 let db_upd_bpts updates =
-  List.iter (fun op ->
-      let ((file, offset), opt) = op in
-(*      Printf.printf "db_upd %s %d %b\n%!" file offset opt;*)
-      DebugHook.upd_ide_bpt file offset opt;
-    ) updates
+  debug_cmd := DebugHook.Action.UpdBpts updates
 
 
 let format_frame text loc =
@@ -482,6 +478,9 @@ let db_stack () =
 
 let db_vars framenum =
   !DebugHook.forward_get_vars framenum
+
+let db_configd () =
+  debug_cmd := DebugHook.Action.Configd
 
 let get_options () =
   let table = Goptions.get_tables () in
@@ -577,6 +576,7 @@ let eval_call c =
     Interface.db_continue = db_continue;
     Interface.db_stack = db_stack;
     Interface.db_vars = db_vars;
+    Interface.db_configd = db_configd;
     Interface.get_options = interruptible get_options;
     Interface.set_options = interruptible set_options;
     Interface.mkcases = interruptible idetop_make_cases;
@@ -678,6 +678,7 @@ let loop ( { Coqtop.run_mode; color_mode },_) ~opts:_ state =
       | Prompt msg -> "prompt", msg
       | Goal msg -> "goal", (str "Goal:" ++ fnl () ++ msg)
       | Output msg -> "output", msg
+      | Init -> "init", str ""
     in
     print_xml xml_oc Xmlprotocol.(of_ltac_debug_answer ~tag msg) in
 

--- a/ide/coqide/ideutils.mli
+++ b/ide/coqide/ideutils.mli
@@ -16,10 +16,9 @@ val cb : GData.clipboard
 val browse : (string -> unit) -> string -> unit
 val browse_keyword : (string -> unit) -> string -> unit
 
-(* These two functions are equivalent, the latter is named following
-   glib schema, and exists in glib but is not in lablgtk2 *)
 val byte_offset_to_char_offset : string -> int -> int
-val glib_utf8_pos_to_offset : string -> off:int -> int
+val byte_off_to_buffer_off : GText.buffer -> int -> int
+val buffer_off_to_byte_off : GText.buffer -> int -> int
 
 type timer = { run : ms:int -> callback:(unit->bool) -> unit;
                kill : unit -> unit }
@@ -118,3 +117,7 @@ val encode_string_list : string list -> string
     quote or another backslash. *)
 
 val decode_string_list : string -> string list
+
+(** filter key event to keep only the interesting modifiers *)
+
+val filter_key : GdkEvent.Key.t -> Gdk.keysym * Gdk.Tags.modifier list

--- a/ide/coqide/microPG.ml
+++ b/ide/coqide/microPG.ml
@@ -271,7 +271,7 @@ let pg = insert emacs "Proof General" [mC,_c,"c"] [
   mkE _n "n" "Advance 1 sentence" (Action("Navigation", "Forward"));
   mkE _u "u" "Retract 1 sentence" (Action("Navigation", "Backward"));
   mkE _b "b" "Advance" (Action("Navigation", "End"));
-  mkE _r "r" "Restart" (Action("Navigation", "Start"));
+  mkE _r "r" "Reset" (Action("Navigation", "Reset"));
   mkE _c "c" "Stop"    (Action("Navigation", "Interrupt"));
   ]
 

--- a/ide/coqide/minilib.ml
+++ b/ide/coqide/minilib.ml
@@ -17,7 +17,6 @@ type level = [
   | `DEBUG
   | `INFO
   | `NOTICE
-  | `PROMPT
   | `WARNING
   | `ERROR
   | `FATAL ]
@@ -38,7 +37,6 @@ let log_pp ?(level = `DEBUG) msg =
   | `DEBUG -> "DEBUG"
   | `INFO -> "INFO"
   | `NOTICE -> "NOTICE"
-  | `PROMPT -> "PROMPT"
   | `WARNING -> "WARNING"
   | `ERROR -> "ERROR"
   | `FATAL -> "FATAL"

--- a/ide/coqide/minilib.mli
+++ b/ide/coqide/minilib.mli
@@ -17,7 +17,6 @@ type level = [
   | `DEBUG
   | `INFO
   | `NOTICE
-  | `PROMPT
   | `WARNING
   | `ERROR
   | `FATAL ]

--- a/ide/coqide/preferences.ml
+++ b/ide/coqide/preferences.ml
@@ -423,15 +423,6 @@ let attach_bg (pref : string preference) (tag : GText.tag) =
 let attach_fg (pref : string preference) (tag : GText.tag) =
   attach_tag pref tag (fun c -> `FOREGROUND c)
 
-let processing_color =
-  new preference ~name:["processing_color"] ~init:"light blue" ~repr:Repr.(string)
-
-let incompletely_processed_color =
-  new preference ~name:["incompletely_processed_color"] ~init:"light sky blue" ~repr:Repr.(string)
-
-let _ = attach_bg processing_color Tags.Script.to_process
-let _ = attach_bg incompletely_processed_color Tags.Script.incomplete
-
 let tags = ref Util.String.Map.empty
 
 let list_tags () = !tags
@@ -526,6 +517,29 @@ let processed_color =
 
 let _ = attach_bg processed_color Tags.Script.processed
 let _ = attach_bg processed_color Tags.Proof.highlight
+
+let processing_color =
+  new preference ~name:["processing_color"] ~init:"light blue" ~repr:Repr.(string)
+
+let incompletely_processed_color =
+  new preference ~name:["incompletely_processed_color"] ~init:"light sky blue" ~repr:Repr.(string)
+
+let _ = attach_bg processing_color Tags.Script.to_process
+let _ = attach_bg incompletely_processed_color Tags.Script.incomplete
+
+let breakpoint_color =
+  new preference ~name:["breakpoint_color"] ~init:"#db5860" ~repr:Repr.(string)
+let white = (* worth showing on preferences menu?? *)
+  new preference ~name:["white"] ~init:"white" ~repr:Repr.(string)
+
+let _ = attach_bg breakpoint_color Tags.Script.breakpoint
+let _ = attach_fg white Tags.Script.breakpoint
+
+let db_stopping_point_color =
+  new preference ~name:["db_stopping_point_color"] ~init:"#2154a6" ~repr:Repr.(string)
+
+let _ = attach_bg db_stopping_point_color Tags.Script.debugging
+let _ = attach_fg white Tags.Script.debugging
 
 let error_color =
   new preference ~name:["error_color"] ~init:"#FFCCCC" ~repr:Repr.(string)
@@ -788,6 +802,8 @@ let configure ?(apply=(fun () -> ())) parent =
       ("Background color of processed text", processed_color);
       ("Background color of text being processed", processing_color);
       ("Background color of incompletely processed Qed", incompletely_processed_color);
+      ("Background color of breakpoints", breakpoint_color);
+      ("Background color of debugger stopping point", db_stopping_point_color);
       ("Background color of errors", error_color);
       ("Foreground color of errors", error_fg_color);
     ] in

--- a/ide/coqide/preferences.mli
+++ b/ide/coqide/preferences.mli
@@ -91,6 +91,7 @@ val opposite_tabs : bool preference
 (* val background_color : string preference *)
 val processing_color : string preference
 val processed_color : string preference
+val db_stopping_point_color : string preference
 val error_color : string preference
 val error_fg_color : string preference
 val dynamic_word_wrap : bool preference

--- a/ide/coqide/protocol/interface.ml
+++ b/ide/coqide/protocol/interface.ml
@@ -114,6 +114,14 @@ type coq_info = {
   compile_date : string;
 }
 
+(* a subset of DebugHook.Action.t *)
+type db_continue_opt =
+  | StepIn
+  | StepOver
+  | StepOut
+  | Continue
+  | Interrupt
+
 (** Calls result *)
 
 type location = (int * int) option (* start and end of the error *)
@@ -133,18 +141,16 @@ type ('a, 'b) union = ('a, 'b) Util.union
 
 (* Request/Reply message protocol between Coq and CoqIDE *)
 
-(**  [add ((s,eid),(sid,v))] adds the phrase [s] with edit id [eid]
-     on top of the current edit position (that is asserted to be [sid])
-     verbosely if [v] is true.  The response [(id,(rc,s)] is the new state
+(**  [add ((((s,eid),(sid,v)), bp), (line_nb, bol_pos) ] adds the phrase [s] with edit id [eid]
+     on top of the current edit position (that is asserted to be [sid]).
+     [v] set to true indicates "verbose".  The response [(id,rc)] is the new state
      [id] assigned to the phrase. [rc] is [Inl] if the new
      state id is the tip of the edit point, or [Inr tip] if the new phrase
-     closes a focus and [tip] is the new edit tip
-
-     [s] used to contain Coq's console output and has been deprecated
-     in favor of sending feedback, it will be removed in a future
-     version of the protocol.  *)
-type add_sty = (string * edit_id) * (state_id * verbose)
-type add_rty = state_id * ((unit, state_id) union * string)
+     closes a focus and [tip] is the new edit tip.  [bp], [line_nb] and [bol_pos]
+     are the Loc.t values for the phrase in the buffer, needed to return the correct
+     location for [s] to the debugger *)
+type add_sty = (((string * edit_id) * (state_id * verbose)) * int) * (int * int)
+type add_rty = state_id * (unit, state_id) union
 
 (** [edit_at id] declares the user wants to edit just after [id].
     The response is [Inl] if the document has been rewound to that point,
@@ -197,11 +203,31 @@ type proof_diff_rty = Pp.t
 type db_cmd_sty = string
 type db_cmd_rty = unit
 
+(** fetch the loc of the current stop point *)
+type db_loc_sty = unit
+type db_loc_rty = (string * int list) option
+
+(** update one or more breakpoints in the specified file *)
+type db_upd_bpts_sty = ((string * int) * bool) list
+type db_upd_bpts_rty = unit
+
+(** continue execution (in various ways) *)
+type db_continue_sty = db_continue_opt
+type db_continue_rty = unit
+
+(** fetch the stack *)
+type db_stack_sty = unit
+type db_stack_rty = (string * (string * int list) option) list
+
+(** fetch variable names and values for a stack frame *)
+type db_vars_sty = int
+type db_vars_rty = (string * Pp.t) list
+
 (** Retrieve the list of options of the current toplevel *)
 type get_options_sty = unit
 type get_options_rty = (option_name * option_state) list
 
-(** Set the options to the given value. Warning: this is not atomic, so whenever
+(** Set the options to the given values. Warning: this is not atomic, so whenever
     the call fails, the option state can be messed up... This is the caller duty
     to check that everything is correct. *)
 type set_options_sty = (option_name * option_value) list
@@ -264,6 +290,10 @@ type handler = {
   annotate    : annotate_sty    -> annotate_rty;
   proof_diff  : proof_diff_sty  -> proof_diff_rty;
   db_cmd      : db_cmd_sty      -> db_cmd_rty;
+  db_upd_bpts : db_upd_bpts_sty -> db_upd_bpts_rty;
+  db_continue : db_continue_sty -> db_continue_rty;
+  db_stack    : db_stack_sty    -> db_stack_rty;
+  db_vars     : db_vars_sty     -> db_vars_rty;
   handle_exn  : handle_exn_sty  -> handle_exn_rty;
   init        : init_sty        -> init_rty;
   quit        : quit_sty        -> quit_rty;

--- a/ide/coqide/protocol/interface.ml
+++ b/ide/coqide/protocol/interface.ml
@@ -223,6 +223,10 @@ type db_stack_rty = (string * (string * int list) option) list
 type db_vars_sty = int
 type db_vars_rty = (string * Pp.t) list
 
+(** indicate debugger config is complete *)
+type db_configd_sty = unit
+type db_configd_rty = unit
+
 (** Retrieve the list of options of the current toplevel *)
 type get_options_sty = unit
 type get_options_rty = (option_name * option_state) list
@@ -294,6 +298,7 @@ type handler = {
   db_continue : db_continue_sty -> db_continue_rty;
   db_stack    : db_stack_sty    -> db_stack_rty;
   db_vars     : db_vars_sty     -> db_vars_rty;
+  db_configd  : db_configd_sty  -> db_configd_rty;
   handle_exn  : handle_exn_sty  -> handle_exn_rty;
   init        : init_sty        -> init_rty;
   quit        : quit_sty        -> quit_rty;

--- a/ide/coqide/protocol/interface.ml
+++ b/ide/coqide/protocol/interface.ml
@@ -203,10 +203,6 @@ type proof_diff_rty = Pp.t
 type db_cmd_sty = string
 type db_cmd_rty = unit
 
-(** fetch the loc of the current stop point *)
-type db_loc_sty = unit
-type db_loc_rty = (string * int list) option
-
 (** update one or more breakpoints in the specified file *)
 type db_upd_bpts_sty = ((string * int) * bool) list
 type db_upd_bpts_rty = unit

--- a/ide/coqide/protocol/xmlprotocol.ml
+++ b/ide/coqide/protocol/xmlprotocol.ml
@@ -9,11 +9,10 @@
 (************************************************************************)
 
 (** Protocol version of this file. This is the date of the last modification. *)
-let protocol_version = "20210506"
-
-(** WARNING: TO BE UPDATED WHEN MODIFIED! *)
+let protocol_version = "20210918"
 
 (** See xml-protocol.md for a description of the protocol. *)
+(** UPDATE xml-protocol.md WHEN YOU UPDATE THE PROTOCOL *)
 
 type msg_format = Richpp of { width : int; depth : int } | Ppcmds
 let msg_format = ref (Richpp { width = 72; depth = max_int })
@@ -156,6 +155,25 @@ let of_pp (pp : Pp.t) =
     of_richpp (Richpp.richpp_of_pp ~width ~depth pp)
   | Ppcmds        -> of_pp pp
 
+let of_dbcontinue_opt opt =
+  let code = match opt with
+  | StepIn -> 0
+  | StepOver -> 1
+  | StepOut -> 2
+  | Continue -> 3
+  | Interrupt -> 4
+  in
+  of_int code
+
+let to_dbcontinue_opt opt =
+  match to_int opt with
+  | 0 -> StepIn
+  | 1 -> StepOver
+  | 2 -> StepOut
+  | 3 -> Continue
+  | 4 -> Interrupt
+  | _ -> failwith "to_dbcontinue_opt"
+
 let of_value f = function
 | Good x -> Element ("value", ["val", "good"], [f x])
 | Fail (id,loc, msg) ->
@@ -283,6 +301,7 @@ module ReifType : sig
   val route_id_t     : route_id val_t
   val search_cst_t   : search_constraint val_t
   val pp_t           : Pp.t val_t
+  val db_cont_opt_t  : db_continue_opt val_t
 
   val of_value_type : 'a val_t -> 'a -> xml
   val to_value_type : 'a val_t -> xml -> 'a
@@ -320,6 +339,7 @@ end = struct
     | Route_id : route_id val_t
     | Search_cst : search_constraint val_t
     | Pp : Pp.t val_t
+    | DbContinueOpt : db_continue_opt val_t
 
   type value_type = Value_type : 'a val_t -> value_type
 
@@ -347,6 +367,7 @@ end = struct
   let route_id_t     = Route_id
   let search_cst_t   = Search_cst
   let pp_t           = Pp
+  let db_cont_opt_t  = DbContinueOpt
 
   let of_value_type (ty : 'a val_t) : 'a -> xml =
     let rec convert : type a. a val_t -> a -> xml = function
@@ -370,6 +391,7 @@ end = struct
       | Route_id      -> of_routeid
       | Search_cst    -> of_search_cst
       | Pp            -> of_pp
+      | DbContinueOpt -> of_dbcontinue_opt
     in
       convert ty
 
@@ -395,6 +417,7 @@ end = struct
       | Route_id      -> to_routeid
       | Search_cst    -> to_search_cst
       | Pp            -> to_pp
+      | DbContinueOpt -> to_dbcontinue_opt
     in
       convert ty
 
@@ -444,6 +467,12 @@ end = struct
   let pr_pair pr1 pr2 (a,b) = "("^pr1 a^","^pr2 b^")"
   let pr_union pr1 pr2 = function Inl x -> "Inl "^pr1 x | Inr x -> "Inr "^pr2 x
   let pr_state_id = Stateid.to_string
+  let pr_db_continue_opt = function
+    | StepIn -> "StepIn"
+    | StepOver -> "StepOver"
+    | StepOut -> "StepOut"
+    | Continue -> "Continue"
+    | Interrupt -> "Interrupt"
 
   let pr_search_cst = function
     | Name_Pattern s -> "Name_Pattern " ^ s
@@ -475,6 +504,7 @@ end = struct
   | State_id      -> pr_state_id
   | Route_id      -> pr_int
   | Pp            -> pr_pp
+  | DbContinueOpt -> pr_db_continue_opt
 
   (* This is to break if a rename/refactoring makes the strings below outdated *)
   type 'a exists = bool
@@ -502,6 +532,7 @@ end = struct
   | State_id      -> assert(true : Stateid.t exists); "Stateid.t"
   | Route_id      -> assert(true : route_id exists); "route_id"
   | Pp            -> assert(true : Pp.t exists); "Pp.t"
+  | DbContinueOpt -> assert(true : db_continue_opt exists); "Interface.dbcontinue_opt"
 
   let print_type = function Value_type ty -> print_val_t ty
 
@@ -533,7 +564,8 @@ open ReifType
 
 (** Types reification, checked with explicit casts *)
 let add_sty_t : add_sty val_t =
-  pair_t (pair_t string_t int_t) (pair_t state_id_t bool_t)
+  pair_t (pair_t (pair_t (pair_t string_t int_t) (pair_t state_id_t bool_t)) int_t)
+  (pair_t int_t int_t)
 let edit_at_sty_t : edit_at_sty val_t = state_id_t
 let query_sty_t : query_sty val_t = pair_t route_id_t (pair_t string_t state_id_t)
 let goals_sty_t : goals_sty val_t = unit_t
@@ -555,9 +587,14 @@ let print_ast_sty_t : print_ast_sty val_t = state_id_t
 let annotate_sty_t : annotate_sty val_t = string_t
 let proof_diff_sty_t : proof_diff_sty val_t = pair_t string_t state_id_t
 let db_cmd_sty_t : db_cmd_sty val_t = string_t
+let db_upd_bpts_sty_t : db_upd_bpts_sty val_t =
+  list_t (pair_t (pair_t string_t int_t) bool_t)
+let db_continue_sty_t : db_continue_sty val_t = db_cont_opt_t
+let db_stack_sty_t : db_stack_sty val_t = unit_t
+let db_vars_sty_t : db_vars_sty val_t = int_t
 
 let add_rty_t : add_rty val_t =
-  pair_t state_id_t (pair_t (union_t unit_t state_id_t) string_t)
+  pair_t state_id_t (union_t unit_t state_id_t)
 let edit_at_rty_t : edit_at_rty val_t =
   union_t unit_t (pair_t state_id_t (pair_t state_id_t state_id_t))
 let query_rty_t : query_rty val_t = unit_t
@@ -582,6 +619,12 @@ let print_ast_rty_t : print_ast_rty val_t = xml_t
 let annotate_rty_t : annotate_rty val_t = xml_t
 let proof_diff_rty_t : proof_diff_rty val_t = pp_t
 let db_cmd_rty_t : db_cmd_rty val_t = unit_t
+let db_upd_bpts_rty_t : db_upd_bpts_rty val_t = unit_t
+let db_continue_rty_t : db_continue_rty val_t = unit_t
+let db_stack_rty_t : db_stack_rty val_t =
+  list_t (pair_t string_t (option_t (pair_t string_t (list_t int_t))))
+let db_vars_rty_t : db_vars_rty val_t =
+  list_t (pair_t string_t pp_t)
 
 let ($) x = erase x
 let calls = [|
@@ -606,6 +649,10 @@ let calls = [|
   "Annotate",   ($)annotate_sty_t,    ($)annotate_rty_t;
   "PDiff",      ($)proof_diff_sty_t,  ($)proof_diff_rty_t;
   "Db_cmd",     ($)db_cmd_sty_t,      ($)db_cmd_rty_t;
+  "Db_upd_bpts",($)db_upd_bpts_sty_t, ($)db_upd_bpts_rty_t;
+  "Db_continue",($)db_continue_sty_t, ($)db_continue_rty_t;
+  "Db_stack",   ($)db_stack_sty_t,    ($)db_stack_rty_t;
+  "Db_vars",    ($)db_vars_sty_t,     ($)db_vars_rty_t;
 |]
 
 type 'a call =
@@ -632,6 +679,10 @@ type 'a call =
   | Annotate   : annotate_sty -> annotate_rty call
   | PDiff      : proof_diff_sty -> proof_diff_rty call
   | Db_cmd     : db_cmd_sty -> db_cmd_rty call
+  | Db_upd_bpts: db_upd_bpts_sty -> db_upd_bpts_rty call
+  | Db_continue: db_continue_sty -> db_continue_rty call
+  | Db_stack   : db_stack_sty -> db_stack_rty call
+  | Db_vars    : db_vars_sty -> db_vars_rty call
 
 (* the order of the entries must match the order in "calls" above *)
 let id_of_call : type a. a call -> int = function
@@ -656,6 +707,10 @@ let id_of_call : type a. a call -> int = function
   | Annotate _   -> 18
   | PDiff _      -> 19
   | Db_cmd _     -> 20
+  | Db_upd_bpts _-> 21
+  | Db_continue _-> 22
+  | Db_stack _   -> 23
+  | Db_vars _    -> 24
 
 let str_of_call c = pi1 calls.(id_of_call c)
 
@@ -682,6 +737,10 @@ let print_ast x   : print_ast_rty call   = PrintAst x
 let annotate x    : annotate_rty call    = Annotate x
 let proof_diff x  : proof_diff_rty call  = PDiff x
 let db_cmd x      : db_cmd_rty call      = Db_cmd x
+let db_upd_bpts x : db_upd_bpts_rty call = Db_upd_bpts x
+let db_continue x : db_continue_rty call = Db_continue x
+let db_stack x    : db_stack_rty call    = Db_stack x
+let db_vars x     : db_vars_rty call     = Db_vars x
 
 let abstract_eval_call : type a. _ -> a call -> a value = fun handler c ->
   let mkGood : type a. a -> a value = fun x -> Good x in
@@ -708,6 +767,10 @@ let abstract_eval_call : type a. _ -> a call -> a value = fun handler c ->
     | Annotate x   -> mkGood (handler.annotate x)
     | PDiff x      -> mkGood (handler.proof_diff x)
     | Db_cmd x     -> mkGood (handler.db_cmd x)
+    | Db_upd_bpts x-> mkGood (handler.db_upd_bpts x)
+    | Db_continue x-> mkGood (handler.db_continue x)
+    | Db_stack x   -> mkGood (handler.db_stack x)
+    | Db_vars x    -> mkGood (handler.db_vars x)
   with any ->
     let any = Exninfo.capture any in
     Fail (handler.handle_exn any)
@@ -735,6 +798,10 @@ let of_answer : type a. a call -> a value -> xml = function
   | Annotate _   -> of_value (of_value_type annotate_rty_t   )
   | PDiff _      -> of_value (of_value_type proof_diff_rty_t )
   | Db_cmd _     -> of_value (of_value_type db_cmd_rty_t     )
+  | Db_upd_bpts _-> of_value (of_value_type db_upd_bpts_rty_t)
+  | Db_continue _-> of_value (of_value_type db_continue_rty_t)
+  | Db_stack _   -> of_value (of_value_type db_stack_rty_t   )
+  | Db_vars _    -> of_value (of_value_type db_vars_rty_t    )
 
 let of_answer msg_fmt =
   msg_format := msg_fmt; of_answer
@@ -761,6 +828,10 @@ let to_answer : type a. a call -> xml -> a value = function
   | Annotate _   -> to_value (to_value_type annotate_rty_t   )
   | PDiff _      -> to_value (to_value_type proof_diff_rty_t )
   | Db_cmd _     -> to_value (to_value_type db_cmd_rty_t     )
+  | Db_upd_bpts _-> to_value (to_value_type db_upd_bpts_rty_t)
+  | Db_continue _-> to_value (to_value_type db_continue_rty_t)
+  | Db_stack _   -> to_value (to_value_type db_stack_rty_t   )
+  | Db_vars _    -> to_value (to_value_type db_vars_rty_t    )
 
 let of_call : type a. a call -> xml = fun q ->
   let mkCall x = constructor "call" (str_of_call q) [x] in
@@ -786,6 +857,10 @@ let of_call : type a. a call -> xml = fun q ->
   | Annotate x   -> mkCall (of_value_type annotate_sty_t    x)
   | PDiff x      -> mkCall (of_value_type proof_diff_sty_t  x)
   | Db_cmd x     -> mkCall (of_value_type db_cmd_sty_t      x)
+  | Db_upd_bpts x-> mkCall (of_value_type db_upd_bpts_sty_t x)
+  | Db_continue x-> mkCall (of_value_type db_continue_sty_t x)
+  | Db_stack x   -> mkCall (of_value_type db_stack_sty_t    x)
+  | Db_vars x    -> mkCall (of_value_type db_vars_sty_t     x)
 
 let to_call : xml -> unknown_call =
   do_match "call" (fun s a ->
@@ -812,6 +887,10 @@ let to_call : xml -> unknown_call =
     | "Annotate"   -> Unknown (Annotate   (mkCallArg annotate_sty_t    a))
     | "PDiff"      -> Unknown (PDiff      (mkCallArg proof_diff_sty_t  a))
     | "Db_cmd"     -> Unknown (Db_cmd     (mkCallArg db_cmd_sty_t      a))
+    | "Db_upd_bpts"-> Unknown (Db_upd_bpts(mkCallArg db_upd_bpts_sty_t a))
+    | "Db_continue"-> Unknown (Db_continue(mkCallArg db_continue_sty_t a))
+    | "Db_stack"   -> Unknown (Db_stack   (mkCallArg db_stack_sty_t    a))
+    | "Db_vars"    -> Unknown (Db_vars    (mkCallArg db_vars_sty_t     a))
     | x -> raise (Marshal_error("call",PCData x)))
 
 (** Debug printing *)
@@ -845,6 +924,10 @@ let pr_full_value : type a. a call -> a value -> string = fun call value -> matc
   | Annotate _   -> pr_value_gen (print annotate_rty_t   ) value
   | PDiff _      -> pr_value_gen (print proof_diff_rty_t ) value
   | Db_cmd _     -> pr_value_gen (print db_cmd_rty_t     ) value
+  | Db_upd_bpts _-> pr_value_gen (print db_upd_bpts_rty_t) value
+  | Db_continue _-> pr_value_gen (print db_continue_rty_t) value
+  | Db_stack _   -> pr_value_gen (print db_stack_rty_t   ) value
+  | Db_vars _    -> pr_value_gen (print db_vars_rty_t    ) value
 let pr_call : type a. a call -> string = fun call ->
   let return what x = str_of_call call ^ " " ^ print what x in
   match call with
@@ -869,6 +952,10 @@ let pr_call : type a. a call -> string = fun call ->
     | Annotate x   -> return annotate_sty_t x
     | PDiff x      -> return proof_diff_sty_t x
     | Db_cmd x     -> return db_cmd_sty_t x
+    | Db_upd_bpts x-> return db_upd_bpts_sty_t x
+    | Db_continue x-> return db_continue_sty_t x
+    | Db_stack x   -> return db_stack_sty_t x
+    | Db_vars x    -> return db_vars_sty_t x
 
 let document to_string_fmt =
   Printf.printf "=== Available calls ===\n\n";

--- a/ide/coqide/protocol/xmlprotocol.mli
+++ b/ide/coqide/protocol/xmlprotocol.mli
@@ -45,7 +45,7 @@ val db_stack    : db_stack_sty    -> db_stack_rty call
 val db_vars     : db_vars_sty     -> db_vars_rty call
 val db_configd  : db_configd_sty  -> db_configd_rty call
 
-val abstract_eval_call : handler -> 'a call -> 'a value
+val abstract_eval_call : handler -> 'a call -> bool * 'a value
 
 (** * Protocol version *)
 
@@ -86,3 +86,9 @@ val to_feedback : xml -> Feedback.feedback
 (** * Serialization of debugger output *)
 val of_ltac_debug_answer : tag:string -> Pp.t -> xml
 val to_ltac_debug_answer : xml -> string * Pp.t
+
+(** * reply for db_vars message *)
+val of_vars : (string * Pp.t) list -> xml
+
+(** * reply for db_stack message *)
+val of_stack : (string * (string * int list) option) list -> xml

--- a/ide/coqide/protocol/xmlprotocol.mli
+++ b/ide/coqide/protocol/xmlprotocol.mli
@@ -39,6 +39,10 @@ val print_ast   : print_ast_sty   -> print_ast_rty call
 val annotate    : annotate_sty    -> annotate_rty call
 val proof_diff  : proof_diff_sty  -> proof_diff_rty call
 val db_cmd      : db_cmd_sty      -> db_cmd_rty call
+val db_upd_bpts : db_upd_bpts_sty -> db_upd_bpts_rty call
+val db_continue : db_continue_sty -> db_continue_rty call
+val db_stack    : db_stack_sty    -> db_stack_rty call
+val db_vars     : db_vars_sty     -> db_vars_rty call
 
 val abstract_eval_call : handler -> 'a call -> 'a value
 

--- a/ide/coqide/protocol/xmlprotocol.mli
+++ b/ide/coqide/protocol/xmlprotocol.mli
@@ -43,6 +43,7 @@ val db_upd_bpts : db_upd_bpts_sty -> db_upd_bpts_rty call
 val db_continue : db_continue_sty -> db_continue_rty call
 val db_stack    : db_stack_sty    -> db_stack_rty call
 val db_vars     : db_vars_sty     -> db_vars_rty call
+val db_configd  : db_configd_sty  -> db_configd_rty call
 
 val abstract_eval_call : handler -> 'a call -> 'a value
 

--- a/ide/coqide/session.mli
+++ b/ide/coqide/session.mli
@@ -27,6 +27,12 @@ class type control =
 type errpage = (int * string) list page
 type jobpage = string CString.Map.t page
 
+type breakpoint = {
+  mark_id : string;
+  mutable prev_byte_offset : int; (* UTF-8 byte offset for Coq *)
+  mutable prev_uni_offset : int;  (* unicode offset for GTK *)
+}
+
 type session = {
   buffer : GText.buffer;
   script : Wg_ScriptView.script_view;
@@ -38,14 +44,23 @@ type session = {
   coqtop : Coq.coqtop;
   command : Wg_Command.command_window;
   finder : Wg_Find.finder;
+  debugger : Wg_Debugger.debugger_view;
   tab_label : GMisc.label;
   errpage : errpage;
   jobpage : jobpage;
+  sid : int;
+  basename : string;
   mutable control : control;
+  mutable abs_file_name : string option;
+  mutable debug_stop_pt : (session * int * int) option;
+  mutable breakpoints : breakpoint list;
+  mutable last_db_goals : Pp.t
 }
 
 (** [create filename coqtop_args] *)
 val create : string option -> string list -> session
+
+val to_abs_file_name : string -> string
 
 val kill : session -> unit
 

--- a/ide/coqide/tags.ml
+++ b/ide/coqide/tags.ml
@@ -24,15 +24,18 @@ struct
   let error_bg = make_tag table ~name:"error_bg" []
   let to_process = make_tag table ~name:"to_process" []
   let processed = make_tag table ~name:"processed" []
+  let debugging = make_tag table ~name:"debugging" []
   let incomplete = make_tag table ~name:"incomplete" []
   let unjustified = make_tag table ~name:"unjustified" [`BACKGROUND "gold"]
   let tooltip = make_tag table ~name:"tooltip" [] (* debug:`BACKGROUND "blue" *)
   let ephemere =
-    [error; warning; error_bg; tooltip; processed; to_process; incomplete; unjustified]
+    [warning; error; error_bg; to_process; processed; debugging;
+     incomplete; unjustified; tooltip]
   let comment = make_tag table ~name:"comment" []
   let sentence = make_tag table ~name:"sentence" []
+  let breakpoint = make_tag table ~name:"breakpoint" []
   let edit_zone = make_tag table ~name:"edit_zone" [`UNDERLINE `SINGLE] (* for debugging *)
-  let all = edit_zone :: comment :: sentence :: ephemere
+  let all_but_bpt = comment :: sentence :: edit_zone :: ephemere (* omit breakpoint marks *)
 end
 module Proof =
 struct

--- a/ide/coqide/tags.mli
+++ b/ide/coqide/tags.mli
@@ -17,13 +17,15 @@ sig
   val error_bg : GText.tag
   val to_process : GText.tag
   val processed : GText.tag
+  val breakpoint : GText.tag
+  val debugging : GText.tag
   val incomplete : GText.tag
   val unjustified : GText.tag
   val sentence : GText.tag
   val tooltip : GText.tag
   val edit_zone : GText.tag (* for debugging *)
   val ephemere : GText.tag list
-  val all : GText.tag list
+  val all_but_bpt : GText.tag list
 end
 
 module Proof :

--- a/ide/coqide/wg_Command.ml
+++ b/ide/coqide/wg_Command.ml
@@ -10,7 +10,7 @@
 
 open Preferences
 
-class command_window name coqtop coqops router =
+class command_window name coqtop coqops router sid =
   let frame = Wg_Detachable.detachable
     ~title:(Printf.sprintf "Query pane (%s)" name) () in
   let _ = frame#hide in
@@ -96,7 +96,7 @@ object(self)
         ~vpolicy:`AUTOMATIC
         ~hpolicy:`AUTOMATIC
         ~packing:(vbox#pack ~fill:true ~expand:true) () in
-    let result = Wg_MessageView.message_view () in
+    let result = Wg_MessageView.message_view sid in
     router#register_route route_id result;
     r_bin#add_with_viewport (result :> GObj.widget);
     views <- (frame#coerce, result, combo#entry) :: views;
@@ -129,7 +129,7 @@ object(self)
         coqops#raw_coq_query ~route_id ~next phrase
       in
       result#set (Pp.str ("Result for command " ^ phrase ^ ":\n"));
-      Coq.try_grab coqtop process ignore
+      ignore @@ Coq.try_grab coqtop process ignore
     in
     ignore (combo#entry#connect#activate ~callback);
     ignore (ok_b#connect#clicked ~callback);

--- a/ide/coqide/wg_Command.mli
+++ b/ide/coqide/wg_Command.mli
@@ -8,7 +8,8 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-class command_window : string -> Coq.coqtop -> CoqOps.coqops -> Wg_RoutedMessageViews.message_views_router ->
+class command_window : string -> Coq.coqtop -> CoqOps.coqops ->
+    Wg_RoutedMessageViews.message_views_router -> int ->
   object
     method new_query : ?command:string -> ?term:string -> unit -> unit
     method pack_in : (GObj.widget -> unit) -> unit

--- a/ide/coqide/wg_Completion.ml
+++ b/ide/coqide/wg_Completion.ml
@@ -129,7 +129,7 @@ class completion_provider buffer coqtop =
         let query = Coq.bind (get_semantic_completion w synt) next in
         (* If coqtop is computing, do the syntactic completion altogether *)
         let occupied () = update synt in
-        Coq.try_grab coqtop query occupied
+        ignore @@ Coq.try_grab coqtop query occupied
 
     method matched ctx = !active
 

--- a/ide/coqide/wg_Debugger.ml
+++ b/ide/coqide/wg_Debugger.ml
@@ -1,0 +1,353 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+type stack_t = (string * (string * int list) option) list
+type vars_t = (string * Pp.t) list
+
+class type debugger_view =
+  object
+    method coerce : GObj.widget
+    method set_stack : stack_t -> unit
+    method set_vars : vars_t -> unit
+    method hide : unit -> unit
+    method show : unit -> unit
+    method set_forward_highlight_code : (string * int * int -> unit) -> unit
+    method set_forward_clear_db_highlight : (unit -> unit) -> unit
+    method set_forward_db_vars : (int -> unit) -> unit
+    method set_forward_paned_pos : (int -> unit) -> unit
+    method set_forward_get_basename : (unit -> string) -> unit
+  end
+
+let forward_keystroke = ref ((fun x -> failwith "forward_keystroke (db)")
+    : Gdk.keysym * Gdk.Tags.modifier list -> int -> bool)
+
+let find_string_col s l =
+  match List.assoc s l with `StringC c -> c | _ -> assert false
+
+let make_table_widget cd cb =
+  let frame = GBin.scrolled_window ~hpolicy:`AUTOMATIC ~vpolicy:`AUTOMATIC () in
+  let columns, store =
+    let cols = new GTree.column_list in
+    let columns = List.map (function
+      | (`Int,n,_)    -> n, `IntC (cols#add Gobject.Data.int)
+      | (`String,n,_) -> n, `StringC (cols#add Gobject.Data.string))
+    cd in
+    columns, GTree.tree_store cols in
+  let data = GTree.view  (* todo: call "view" *)
+      ~vadjustment:frame#vadjustment ~hadjustment:frame#hadjustment
+      ~rules_hint:true ~headers_visible:false
+      ~model:store ~packing:frame#add () in
+
+  let selection = data#selection in
+  selection#set_mode `MULTIPLE;
+  let copy = GtkData.AccelGroup.parse "<Ctrl>C" in
+
+  let vars_keypress_cb ev =
+    let key_ev = Ideutils.filter_key ev in
+    if key_ev = copy then begin
+      let rows = selection#get_selected_rows in
+      let get_value iter = store#get ~row:iter ~column:(find_string_col "Var" columns) in
+      let buf = Buffer.create 100 in
+      List.iter (fun row ->
+          let iter = store#get_iter row in
+          let depth = store#iter_depth iter in
+          let top_iter = Option.default iter (store#iter_parent iter) in
+          if depth = 0 || not (selection#iter_is_selected top_iter) then begin
+            let value =
+              if store#iter_has_child top_iter then
+                (get_value top_iter) ^ "\n" ^
+                (get_value (store#iter_children (Some top_iter)))
+              else
+                get_value top_iter
+            in
+            Buffer.add_string buf (value ^ "\n\n");
+          end
+        ) rows;
+      (GData.clipboard Gdk.Atom.clipboard)#set_text (Buffer.contents buf);
+      true
+    end else
+      false
+  in
+  let _ = data#event#connect#key_press ~callback:vars_keypress_cb in
+
+(* FIXME: handle this using CSS *)
+(*   let refresh clr = data#misc#modify_bg [`NORMAL, `NAME clr] in *)
+(*   let _ = background_color#connect#changed ~callback:refresh in *)
+(*   let _ = data#misc#connect#realize ~callback:(fun () -> refresh background_color#get) in *)
+  let mk_rend c = GTree.cell_renderer_text [], ["text",c] in
+  let cols =
+    List.map2 (fun (_,c) (_,n,v) ->
+      let c = match c with
+        | `IntC c -> GTree.view_column ~renderer:(mk_rend c) ()
+        | `StringC c -> GTree.view_column ~renderer:(mk_rend c) () in
+      c#set_title n;
+      c#set_visible v;
+      c#set_sizing `AUTOSIZE;
+      c)
+    columns cd in
+  List.iter (fun c -> ignore(data#append_column c)) cols;
+  ignore @@ data#connect#row_activated ~callback:(fun tp vc -> cb columns store tp vc);
+  let cb view ft = view#misc#modify_font (GPango.font_description_from_string ft) in
+  Preferences.(stick text_font data (cb data));
+  frame, (fun f -> f columns store), store
+
+let debugger title sid =
+  let forward_set_paned_pos = ref ((fun x -> failwith "forward_set_paned_pos")
+    : int -> unit) in
+
+  let forward_get_basename = ref ((fun x -> failwith "forward_get_basename")
+    : unit -> string) in
+
+  let debugger_detachable = Wg_Detachable.detachable ~title () in
+  debugger_detachable#close_button#misc#show ();
+  ignore(debugger_detachable#close_button#connect#clicked
+    ~callback:(fun _ -> !forward_set_paned_pos 1000000));
+
+  let paned = GPack.paned `HORIZONTAL ~packing:(debugger_detachable#pack ~expand:true) () in
+
+  let stack_view = GText.view ~editable:false ~cursor_visible:false ~wrap_mode:`NONE () in
+  let stack_buffer = stack_view#buffer in
+  let stack = ref [] in
+
+  let vb_stack = GPack.vbox ~packing:(paned#pack1 ~shrink:false ~resize:true) () in
+  let _ = GMisc.label ~text:"Call Stack" ~xalign:0.02 (* todo: use padding instead of xalign *)
+    ~packing:(vb_stack#pack ~expand:false ~fill:true ~padding:3) () in
+  let stack_scroll = GBin.scrolled_window
+    ~vpolicy:`AUTOMATIC ~hpolicy:`AUTOMATIC ~packing:(vb_stack#pack ~expand:true) () in
+  stack_scroll#add stack_view#coerce;
+
+  let tree, access, store =
+    make_table_widget
+      [`String, "Var", true]
+      (fun columns store tp vc ->
+        let row = store#get_iter tp in
+        let _ = store#get ~row ~column:(find_string_col "Var" columns) in ()) in
+
+  let vars_view = GText.view ~editable:false ~cursor_visible:false ~wrap_mode:`NONE () in
+  let cb view ft = view#misc#modify_font (GPango.font_description_from_string ft) in
+  Preferences.(stick text_font vars_view (cb vars_view));
+  Preferences.(stick text_font stack_view (cb stack_view));
+
+  let vars = ref [] in
+
+  let vb_vars = GPack.vbox ~packing:(paned#pack2 ~shrink:false ~resize:true) () in
+  let _ = GMisc.label ~text:"Variables" ~xalign:0.02 (* todo: use padding instead of xalign *)
+    ~packing:(vb_vars#pack ~expand:false ~fill:true ~padding:3) () in
+  let () = vb_vars#pack ~expand:true tree#coerce in
+
+(* doesn't help, not getting the correct widths
+  ignore @@ Glib.Idle.add (fun _ ->
+    let open Gtk in
+    let open GtkBase in
+    let dwidth = (Widget.allocation debugger_detachable#as_widget).width in
+    let bwidth = (Widget.allocation debugger_detachable#close_button#as_widget).width in
+    Printf.printf "dwidth = %d bwidth = %d\n%!" dwidth bwidth;
+    paned #set_position (dwidth/2 - bwidth);
+    false);
+*)
+
+  let highlighted_line = ref None in
+  let forward_highlight_code = ref ((fun x -> failwith "forward_highlight_code")
+    : (string * int * int) -> unit) in
+  let forward_clear_db_highlight = ref ((fun x -> failwith "forward_clear_db_highlight")
+    : unit -> unit) in
+  let forward_db_vars = ref ((fun x -> failwith "forward_db_vars")
+    : int -> unit) in
+
+  (* workaround *)
+  let relayout () =
+    paned#remove vb_stack#coerce; (* appears not to be destroyed *)
+    paned#remove vb_vars#coerce;
+    paned#pack1 ~shrink:false ~resize:true vb_stack#coerce;
+    paned#pack2 ~shrink:false ~resize:true vb_vars#coerce;
+  in
+
+  let attach_cb _ =
+    debugger_detachable#show;
+    relayout ()
+  in
+  let () = debugger_detachable#connect#attached ~callback:attach_cb in
+
+  let detach_cb _ =
+    let open Gtk in
+    let open GtkBase in
+    let alloc = Widget.allocation debugger_detachable#as_widget in
+    ignore @@ Glib.Idle.add (fun _ ->
+      debugger_detachable#win#resize ~width:alloc.width ~height:alloc.height;
+      false);
+    relayout ();
+    !forward_set_paned_pos 1000000;  (* looks OK but debugger_paned in main window is still resizable *)
+  in
+  let () = debugger_detachable#connect#detached ~callback:detach_cb in
+
+  (* todo: better to share with Tags.Script.debugging, but it isn't set for GText *)
+  let debugging_tag = stack_buffer#create_tag
+    [ `BACKGROUND_SET true; `BACKGROUND Preferences.db_stopping_point_color#get;
+      `FOREGROUND_SET true; `FOREGROUND "white"] in
+
+  let clear_highlight () =
+    let start = stack_buffer#get_iter `START in
+    let stop = stack_buffer#get_iter `END in
+    stack_buffer#remove_tag debugging_tag ~start ~stop;
+    highlighted_line := None
+  in
+
+  let highlight line =
+    if line < List.length !stack then begin
+      let start = stack_buffer#get_iter (`LINE line) in
+      let stop = stack_buffer#get_iter (`LINE (line+1)) in
+      stack_buffer#apply_tag debugging_tag ~start ~stop;
+      highlighted_line := Some line;
+      let (_, loc) = List.nth !stack line in
+      !forward_db_vars line;
+      match loc with
+      | Some (file, bp :: ep :: _) ->
+        !forward_highlight_code (file, bp, ep)
+      | _ -> !forward_clear_db_highlight ()  (* e.g. for simple tactic call *)
+    end
+  in
+
+  let up = GtkData.AccelGroup.parse "Up" in
+  let down = GtkData.AccelGroup.parse "Down" in
+
+  let stack_keypress_cb ev =
+    let move dir =
+      match !highlighted_line with
+      | Some l ->
+        let line = l+dir in
+        if line >= 0 && line < List.length !stack then
+          (clear_highlight (); highlight line)
+      | None -> ()
+    in
+
+    let key_ev = Ideutils.filter_key ev in
+    if key_ev = up then
+      (move (-1); true)
+    else if key_ev = down then
+      (move 1; true)
+    else
+      !forward_keystroke key_ev sid (* support some function keys when Debugger is detached *)
+  in
+  let _ = stack_view#event#connect#key_press ~callback:stack_keypress_cb in
+
+  let keypress_cb2 ev =
+    let key_ev = Ideutils.filter_key ev in
+    !forward_keystroke key_ev sid (* support some function keys when Debugger is detached *)
+  in
+  let _ = paned#event#connect#key_press ~callback:keypress_cb2 in
+
+  (* click handler *)
+  let click_cb ev =
+    let open GdkEvent.Button in
+    let y = y ev in
+    let button = button ev in
+    let scroll_pos = stack_scroll#vadjustment#value in
+    let metrics = stack_view#coerce#misc#pango_context#get_metrics () in
+    let line_height = GPango.to_pixels (metrics#ascent+metrics#descent) in
+    let line = (truncate (y +. scroll_pos))/line_height in
+    if button = 1 && line < List.length !stack then
+      (clear_highlight (); highlight line);
+    false (* let the panel get the focus *)
+  in
+  let _ = stack_view#event#connect#button_press ~callback:click_cb in
+
+  let debugger = object (self)
+
+    method coerce = debugger_detachable#coerce
+    method set_stack (stack_v : stack_t) =
+      stack := if stack_v = [] then [] else begin
+        (* adjust text in the bottom frame of the stack *)
+        let rs = List.rev stack_v in
+        let (text, loc) = List.hd rs in
+        match loc with
+          | Some (_, locs) ->
+            let basename = !forward_get_basename () in
+            let basename = if basename = "*scratch*" then "Top" else basename in
+            let s = Printf.sprintf "%s, %s" text basename in
+            List.rev ((s, loc) :: (List.tl rs))
+          | _ -> stack_v
+      end;
+      stack_buffer#set_text
+        (String.concat "\n" (List.map (fun i -> let (tacn, loc) = i in tacn) !stack));
+      clear_highlight ();
+      if !stack <> [] then
+        highlight 0
+
+    method set_vars (vars_v : vars_t) =
+      vars := vars_v;
+      store#clear ();
+      let cwidth () =
+        let open Gtk in
+        let open GtkBase in
+        let pixel_width = (Widget.allocation tree#as_widget).width in
+        let metrics = vars_view#misc#pango_context#get_metrics ()  in
+        let char_width = GPango.to_pixels metrics#approx_char_width in
+        (pixel_width - 100) / char_width
+      in
+      let print_pp width pp =
+        let pp_buffer = Buffer.create 180 in
+        let open Format in
+        let ft = formatter_of_buffer pp_buffer in
+        pp_set_margin ft width;
+        pp_set_max_indent ft width;
+      (*  pp_set_max_boxes ft 50 ;*)
+      (*  pp_set_ellipsis_text ft "..."*)
+        Pp.pp_with ft pp;
+        pp_print_flush ft ();
+        Buffer.contents pp_buffer
+      in
+      let show width =
+        let insert = store#get_iter_first = None in
+        let path = GtkTree.TreePath.from_string "0" in
+        List.iter (fun (name, value) ->
+            let width = max width 30 in
+            let value = print_pp width value in
+            access (fun columns store ->
+                let column = (find_string_col "Var" columns) in
+                let row = if insert then store#append () else store#get_iter path in
+                GtkTree.TreePath.next path;
+                if String.length value < width && (not (String.contains value '\n')) then begin
+                  store#set ~row ~column (name ^ " = " ^ value);
+                  if store#iter_has_child row then
+                    ignore @@ store#remove (store#iter_children (Some row));
+                end else begin
+                  store#set ~row ~column (name ^ " = ");
+                  let row2 = if insert || (not (store#iter_has_child row)) then
+                    store#append ~parent:row ()
+                  else
+                    store#iter_children (Some row) in
+                  store#set ~row:row2 ~column:(find_string_col "Var" columns) value
+                end
+              )
+          ) vars_v
+      in
+      let width = cwidth () in
+      let pwidth = ref width in (* initially negative if not allocated *)
+      if paned#position > 0 then show width;
+
+      let w_cb (_ : Gtk.rectangle) =
+        let width = cwidth () in
+        if width <> !pwidth then begin
+          pwidth := width;
+          show width
+        end
+      in
+      ignore (paned#misc#connect#size_allocate ~callback:w_cb)
+
+    method hide () = debugger_detachable#hide  (* todo: give up focus *)
+    method show () = debugger_detachable#show  (* todo: take focus? *)
+    method set_forward_highlight_code f = forward_highlight_code := f
+    method set_forward_clear_db_highlight f = forward_clear_db_highlight := f
+    method set_forward_db_vars f = forward_db_vars := f
+    method set_forward_paned_pos f = forward_set_paned_pos := f
+    method set_forward_get_basename f = forward_get_basename := f
+  end
+  in
+  debugger

--- a/ide/coqide/wg_Debugger.mli
+++ b/ide/coqide/wg_Debugger.mli
@@ -8,14 +8,23 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-class finder : string -> GText.view ->
+type stack_t = (string * (string * int list) option) list
+type vars_t = (string * Pp.t) list
+
+class type debugger_view =
   object
     method coerce : GObj.widget
+    method set_stack : stack_t -> unit
+    method set_vars : vars_t -> unit
     method hide : unit -> unit
     method show : unit -> unit
-    method replace : unit -> unit
-    method replace_all : unit -> unit
-    method find_backward : unit -> unit
-    method find_forward : unit -> unit
-    method setup_is_script_editable : (unit -> bool) -> unit
+    method set_forward_highlight_code : (string * int * int -> unit) -> unit
+    method set_forward_clear_db_highlight : (unit -> unit) -> unit
+    method set_forward_db_vars : (int -> unit) -> unit
+    method set_forward_paned_pos : (int -> unit) -> unit
+    method set_forward_get_basename : (unit -> string) -> unit
   end
+
+val debugger : string -> int -> debugger_view
+
+val forward_keystroke : (Gdk.keysym * Gdk.Tags.modifier list -> int -> bool) ref

--- a/ide/coqide/wg_Detachable.ml
+++ b/ide/coqide/wg_Detachable.ml
@@ -24,6 +24,7 @@ class detachable (obj : ([> Gtk.box] as 'a) Gobject.obj) =
     inherit GPack.box_skel (obj :> Gtk.box Gobject.obj) as super
 
     val but = GButton.button ()
+    val close_but = GButton.button ()
     val win = GWindow.window ~type_hint:`DIALOG ()
     val frame = GBin.frame ~shadow_type:`NONE ()
     val mutable detached = false
@@ -55,9 +56,13 @@ class detachable (obj : ([> Gtk.box] as 'a) Gobject.obj) =
 
     method visible = win#misc#visible || self#misc#visible
 
+    method win = win
+
     method frame = frame
 
     method button = but
+
+    method close_button = close_but
 
     method attach () =
       win#misc#hide ();
@@ -73,8 +78,13 @@ class detachable (obj : ([> Gtk.box] as 'a) Gobject.obj) =
       detached_cb self#child
 
     initializer
+      let vb = GPack.vbox ~packing:(super#pack ~expand:false ~fill:false) () in
+      close_but#add (Ideutils.stock_to_widget ~size:(`CUSTOM(12,12)) `CLOSE);
+      close_but#misc#hide ();
+      ignore(close_but#connect#clicked ~callback:(fun _ -> self#misc#hide (); win#misc#hide ()));
       self#set_homogeneous false;
-      super#pack ~expand:false but#coerce;
+      vb#pack ~expand:false close_but#coerce;
+      vb#pack ~expand:false but#coerce;
       super#pack ~expand:true ~fill:true frame#coerce;
       win#misc#hide ();
       but#add (GMisc.label

--- a/ide/coqide/wg_Detachable.mli
+++ b/ide/coqide/wg_Detachable.mli
@@ -27,6 +27,8 @@ class detachable : ([> Gtk.box] as 'a) Gobject.obj ->
     method title : string
     method set_title : string -> unit
     method button : GButton.button
+    method close_button : GButton.button
+    method win : GWindow.window
     method frame : GBin.frame
     method detach : unit -> unit
     method attach : unit -> unit

--- a/ide/coqide/wg_MessageView.ml
+++ b/ide/coqide/wg_MessageView.ml
@@ -34,7 +34,6 @@ class type message_view =
     method add : Pp.t -> unit
     method add_string : string -> unit
     method set : Pp.t -> unit
-    method refresh : bool -> unit
     method push : Ideutils.logger
       (** same as [add], but with an explicit level instead of [Notice] *)
 
@@ -43,22 +42,28 @@ class type message_view =
 
     method has_selection : bool
     method get_selected_text : string
+    method editable2 : bool
+    method set_editable2 : bool -> unit
+    method set_forward_send_db_cmd : (string -> unit) -> unit
+    method set_forward_send_db_stack : (unit -> unit) -> unit
+    method set_forward_show_debugger : (unit -> unit) -> unit
   end
 
-let forward_send_db_cmd = ref ((fun x -> failwith "forward_send_db_cmd")
-    : string -> unit)
+let forward_keystroke = ref ((fun x -> failwith "forward_keystroke (mv)")
+    : Gdk.keysym * Gdk.Tags.modifier list -> int -> bool)
 
 (* The buffer can contain prompt or feedback messages *)
 type message_entry_kind =
   | Fb of Feedback.level * Pp.t
   | Prompt of Pp.t
 
-let message_view () : message_view =
+let message_view sid : message_view =
   let buffer = GSourceView3.source_buffer
     ~highlight_matching_brackets:true
     ~tag_table:Tags.Message.table
     ?style_scheme:(style_manager#style_scheme source_style#get) ()
   in
+  buffer#set_max_undo_levels 0;
   let mark = buffer#create_mark ~left_gravity:false buffer#start_iter in
   let _ = buffer#create_mark ~name:"end_of_output" buffer#end_iter in
   let box = GPack.vbox () in
@@ -66,7 +71,7 @@ let message_view () : message_view =
     ~vpolicy:`AUTOMATIC ~hpolicy:`AUTOMATIC ~packing:(box#pack ~expand:true) () in
   let view = GSourceView3.source_view
     ~source_buffer:buffer ~packing:scroll#add
-    ~editable:false ~cursor_visible:false ~wrap_mode:`WORD ()
+    ~editable:false ~cursor_visible:false ~wrap_mode:`CHAR ()
   in
   let () = Gtk_parsing.fix_double_click view in
   let default_clipboard = GData.clipboard Gdk.Atom.primary in
@@ -80,6 +85,13 @@ let message_view () : message_view =
   let cb ft = view#misc#modify_font (GPango.font_description_from_string ft) in
   stick text_font view cb;
 
+  let insert_xml ~mark buffer ~tags msg =
+    let width = Ideutils.textview_width view in
+    let before = buffer#line_count in
+    Ideutils.insert_xml ~mark buffer ~tags (Richpp.richpp_of_pp ~width msg);
+    buffer#line_count - before
+  in
+
   (* Inserts at point, advances the mark *)
   let insert_fb_msg (level, msg) =
     let tags = match level with
@@ -88,18 +100,27 @@ let message_view () : message_view =
       | _ -> []
     in
     let mark = `MARK mark in
-    let width = Ideutils.textview_width view in
-    Ideutils.insert_xml ~mark buffer ~tags (Richpp.richpp_of_pp ~width msg);
-    buffer#insert ~iter:(buffer#get_iter_at_mark mark) "\n";
+    let lines = insert_xml ~mark buffer ~tags msg in
+    buffer#insert ~iter:(buffer#end_iter) "\n";
     buffer#move_mark (`NAME "end_of_output") ~where:buffer#end_iter;
+    view#scroll_to_mark `INSERT; (* scroll to end *)
+    lines
   in
 
+  let forward_send_db_stack = ref ((fun x -> failwith "forward_send_db_stack")
+    : unit -> unit) in
+  let forward_show_debugger = ref ((fun x -> failwith "forward_show_debugger")
+    : unit -> unit) in
+
   (* Insert a prompt and make the buffer editable. *)
-  let insert_ltac_debug_prompt msg =
+  let insert_ltac_debug_prompt ?(refresh=false) msg =
+    if not refresh then begin
+      !forward_send_db_stack ();
+      !forward_show_debugger ();
+    end;
     let tags = [] in
     let mark = `MARK mark in
-    let width = Ideutils.textview_width view in
-    Ideutils.insert_xml ~mark buffer ~tags (Richpp.richpp_of_pp ~width msg);
+    let lines = insert_xml ~mark buffer ~tags msg in
     buffer#move_mark (`NAME "end_of_output") ~where:buffer#end_iter;
     view#set_editable true;
     view#set_cursor_visible true;
@@ -107,43 +128,91 @@ let message_view () : message_view =
     buffer#move_mark `INSERT ~where:buffer#end_iter;
     let ins = buffer#get_iter_at_mark `INSERT in
     buffer#select_range ins ins;  (* avoid highlighting *)
+(*    Ideutils.push_info "Coq is stopped in the debugger"; needs work *)
+    lines
   in
 
-  let insert_msg = function
+  let insert_msg  ?(refresh=false) = function
     | Fb (lvl,msg) -> insert_fb_msg (lvl,msg)
-    | Prompt msg -> insert_ltac_debug_prompt msg
-
+    | Prompt msg -> insert_ltac_debug_prompt ~refresh msg
   in
-  let msgs : message_entry_kind list ref = ref [] in
-  let (return, _) = GtkData.AccelGroup.parse "Return" in
-  let (backspace, _) = GtkData.AccelGroup.parse "BackSpace" in
-  let (delete, _) = GtkData.AccelGroup.parse "Delete" in
+
+  (* List of displayed messages *)
+  let msgs : (message_entry_kind * int) list ref = ref [] in
+  let last_width = ref (-1) in
+
+  let refresh force =
+    (* We need to block updates here due to the following race:
+       insertion of messages may create a vertical scrollbar, this
+       will trigger a width change, calling refresh again and
+       going into an infinite loop. *)
+    let width = Ideutils.textview_width view  in
+    (* Could still this method race if the scrollbar changes the
+       textview_width ?? *)
+    let needed = force || !last_width <> width in
+    if needed then begin
+      last_width := width;
+      buffer#set_text "";
+      buffer#move_mark (`MARK mark) ~where:buffer#start_iter;
+      List.(iter (fun (m,_) -> ignore @@ insert_msg ~refresh:true m) (rev !msgs))
+    end
+  in
+
+  (* todo: verify whether msgs is still needed *)
+  let add_msg msg =
+    let mlines = insert_msg msg in
+    msgs := (msg, mlines) :: !msgs;
+    let max_lines = 1000 in
+    if buffer#line_count > max_lines then begin
+      let rec trim lcnt res msgs =
+        match msgs with
+        | (m,len) :: tl when lcnt < max_lines ->
+            trim (lcnt+len) ((m,len) :: res) tl
+        | _ -> lcnt, res
+      in
+      let lcnt, res = trim 0 [] !msgs in
+      msgs := res;
+      let stop = buffer#start_iter#forward_lines (buffer#line_count - lcnt) in
+      buffer#delete ~start:buffer#start_iter ~stop;
+    end
+  in
+
+  let return    = GtkData.AccelGroup.parse "Return" in
+  let backspace = GtkData.AccelGroup.parse "BackSpace" in
+  let delete    = GtkData.AccelGroup.parse "Delete" in
+
+  let forward_send_db_cmd = ref ((fun x -> failwith "forward_send_db_cmd")
+    : string -> unit) in
 
   (* Keypress handler *)
   let keypress_cb ev =
-    let ev_key = GdkEvent.Key.keyval ev in
+    let key_ev = Ideutils.filter_key ev in
+    let state = GdkEvent.Key.state ev in
     let ins = buffer#get_iter_at_mark `INSERT in
     let eoo = buffer#get_iter_at_mark (`NAME "end_of_output") in
     let delta = ins#offset - eoo#offset in
-    if not view#editable then
+    if !forward_keystroke key_ev sid then
+      true (* support some function keys when Messages is detached *)
+    else if not view#editable || List.mem `CONTROL state || List.mem `MOD1 state then
       false
-    else if ev_key = delete && delta < 0 then
+    else if key_ev = delete && delta < 0 then
       true (* ignore DELETE before end of output *)
-    else if ev_key = backspace && delta <= 0 then
+    else if key_ev = backspace && delta <= 0 then
       true (* ignore BACKSPACE before eoo *)
     else begin
       if delta < 0 then
         buffer#move_mark `INSERT ~where:buffer#end_iter;
-      if (ev_key >= Char.code ' ' && ev_key <= Char.code '~') then begin
-        buffer#insert (String.make 1 (Char.chr ev_key));
+      let key_code = GdkEvent.Key.keyval ev in
+      if (key_code >= Char.code ' ' && key_code <= Char.code '~') then begin
+        buffer#insert (String.make 1 (Char.chr key_code));
         view#scroll_to_mark `INSERT; (* scroll to insertion point *)
         let ins = buffer#get_iter_at_mark `INSERT in
         buffer#select_range ins ins;  (* avoid highlighting *)
         true (* consume the event *)
-      end else if ev_key = return then begin
+      end else if key_ev = return then begin
         let ins = buffer#get_iter_at_mark `INSERT in
         let cmd = buffer#get_text ~start:eoo ~stop:ins () in
-        msgs := Fb (Feedback.Notice, Pp.str cmd) :: !msgs;
+        add_msg (Fb (Feedback.Notice, Pp.str cmd));
         buffer#insert "\n";
         buffer#move_mark `INSERT ~where:buffer#end_iter;
         view#scroll_to_mark `INSERT; (* scroll to insertion point *)
@@ -164,9 +233,6 @@ let message_view () : message_view =
   let mv = object (self)
     inherit GObj.widget box#as_widget
 
-    (* List of displayed messages *)
-    val mutable last_width = -1
-
     val push = new GUtil.signal ()
 
     method source_buffer = buffer
@@ -174,33 +240,15 @@ let message_view () : message_view =
     method connect =
       new message_view_signals_impl box#as_widget push
 
-    method refresh force =
-      (* We need to block updates here due to the following race:
-         insertion of messages may create a vertical scrollbar, this
-         will trigger a width change, calling refresh again and
-         going into an infinite loop. *)
-      let width = Ideutils.textview_width view  in
-      (* Could still this method race if the scrollbar changes the
-         textview_width ?? *)
-      let needed = force || last_width <> width in
-      if needed then begin
-        last_width <- width;
-        buffer#set_text "";
-        buffer#move_mark (`MARK mark) ~where:buffer#start_iter;
-        List.(iter insert_msg (rev !msgs))
-      end
-
     method clear =
-      msgs := []; self#refresh true
+      msgs := []; refresh true
 
     method push level msg =
-      msgs := Fb (level, msg) :: !msgs;
-      insert_fb_msg (level, msg);
+      add_msg (Fb (level, msg));
       push#call (level, msg)
 
     method debug_prompt msg =
-      msgs := Prompt msg :: !msgs;
-      insert_ltac_debug_prompt msg
+      add_msg (Prompt msg);
 
     method add msg = self#push Feedback.Notice msg
 
@@ -214,10 +262,14 @@ let message_view () : message_view =
         let start, stop = buffer#selection_bounds in
         buffer#get_text ~slice:true ~start ~stop ()
       else ""
-
+    method editable2 = view#editable
+    method set_editable2 v = view#set_editable v; view#set_cursor_visible v
+    method set_forward_send_db_cmd f = forward_send_db_cmd := f
+    method set_forward_send_db_stack f = forward_send_db_stack := f
+    method set_forward_show_debugger f = forward_show_debugger := f
   end
   in
   (* Is there a better way to connect the signal ? *)
-  let w_cb (_ : Gtk.rectangle) = mv#refresh false in
+  let w_cb (_ : Gtk.rectangle) = refresh false in
   ignore (view#misc#connect#size_allocate ~callback:w_cb);
   mv

--- a/ide/coqide/wg_MessageView.mli
+++ b/ide/coqide/wg_MessageView.mli
@@ -24,17 +24,19 @@ class type message_view =
     method add : Pp.t -> unit
     method add_string : string -> unit
     method set : Pp.t -> unit
-    method refresh : bool -> unit
     method push : Ideutils.logger
       (** same as [add], but with an explicit level instead of [Notice] *)
 
-    (** In use by the ltac debugger *)
     method debug_prompt : Pp.t -> unit
-
     method has_selection : bool
     method get_selected_text : string
+    method editable2 : bool
+    method set_editable2 : bool -> unit
+    method set_forward_send_db_cmd : (string -> unit) -> unit
+    method set_forward_send_db_stack : (unit -> unit) -> unit
+    method set_forward_show_debugger : (unit -> unit) -> unit
   end
 
-val message_view : unit -> message_view
+val message_view : int -> message_view
 
-val forward_send_db_cmd : (string -> unit) ref
+val forward_keystroke : (Gdk.keysym * Gdk.Tags.modifier list -> int -> bool) ref

--- a/ide/coqide/wg_Notebook.ml
+++ b/ide/coqide/wg_Notebook.ml
@@ -58,6 +58,10 @@ object(self)
 
   method current_term =
     List.nth term_list super#current_page
+
+  method goto_term term =
+    List.iteri (fun i sn -> if sn == term then self#goto_page i) term_list
+
 end
 
 let create make kill =

--- a/ide/coqide/wg_Notebook.mli
+++ b/ide/coqide/wg_Notebook.mli
@@ -22,6 +22,7 @@ object
   method pages : 'a list
   method remove_page : int -> unit
   method current_term : 'a
+  method goto_term : 'a -> unit
 end
 
 val create :

--- a/ide/coqide/wg_ProofView.mli
+++ b/ide/coqide/wg_ProofView.mli
@@ -17,6 +17,7 @@ class type proof_view =
     method clear : unit -> unit
     method set_goals : Interface.goals option -> unit
     method set_evars : Interface.evar list option -> unit
+    method set_debug_goal : Pp.t -> unit
   end
 
 val proof_view : unit -> proof_view

--- a/ide/coqide/wg_ScriptView.mli
+++ b/ide/coqide/wg_ScriptView.mli
@@ -20,6 +20,8 @@ object
   method clear_undo : unit -> unit
   method auto_complete : bool
   method set_auto_complete : bool -> unit
+  method set_editable2 : bool -> unit
+  method editable2 : bool
   method right_margin_position : int
   method set_right_margin_position : int -> unit
   method show_right_margin : bool
@@ -29,6 +31,8 @@ object
   method apply_unicode_binding : unit -> unit
   method recenter_insert : unit
   method proposal : string option
+  method set_debugging_highlight : int -> int -> unit
+  method clear_debugging_highlight : int -> int -> unit
 end
 
 val script_view : Coq.coqtop ->

--- a/lib/cDebug.ml
+++ b/lib/cDebug.ml
@@ -50,6 +50,8 @@ let create ~name () =
 
 let get_flag flag = !flag
 
+let set_flag flag v = flag := v
+
 let warn_unknown_debug = CWarnings.create ~name:"unknown-debug-flag" ~category:"option"
     Pp.(fun name -> str "There is no debug flag \"" ++ str name ++ str "\".")
 

--- a/lib/cDebug.mli
+++ b/lib/cDebug.mli
@@ -35,6 +35,8 @@ val create_full : name:string -> unit -> flag * t
 
 val get_flag : flag -> bool
 
+val set_flag : flag -> bool -> unit
+
 (** [get_flags] and [set_flags] use the user syntax: a comma separated
     list of activated "component" and "-component"s. [get_flags] starts
     with "all" or "-all" and lists all components after it (even if redundant). *)

--- a/plugins/ltac/profile_ltac.ml
+++ b/plugins/ltac/profile_ltac.ml
@@ -239,7 +239,8 @@ let string_of_call ck =
     (match ck with
        | Tacexpr.LtacNotationCall s -> Pptactic.pr_alias_key s
        | Tacexpr.LtacNameCall cst -> Pptactic.pr_ltac_constant cst
-       | Tacexpr.LtacVarCall (id, t) -> Names.Id.print id
+       (* todo: don't want the KerName instead? *)
+       | Tacexpr.LtacVarCall (_, id, t) -> Names.Id.print id
        | Tacexpr.LtacAtomCall te ->
          Pptactic.pr_glob_tactic (Global.env ())
             (CAst.make (Tacexpr.TacAtom te))
@@ -358,7 +359,6 @@ let do_profile s call_trace ?(count_call=true) tac =
   | true ->
     tclWRAPFINALLY
       (Proofview.tclLIFT (Proofview.NonLogical.make (fun () ->
-           if !is_profiling then
              match call_trace, Local.(!stack) with
              | (_, c) :: _, parent :: rest ->
                let name = string_of_call c in
@@ -367,7 +367,7 @@ let do_profile s call_trace ?(count_call=true) tac =
                Some (time ())
              | _ :: _, [] -> assert false
              | _ -> None
-           else None)))
+           )))
       tac
       (function
         | Some start_time ->

--- a/plugins/ltac/taccoerce.mli
+++ b/plugins/ltac/taccoerce.mli
@@ -106,7 +106,7 @@ type appl =
        (** For calls to global constants, some may alias other. *)
 
 type tacvalue =
-  | VFun of appl *Tacexpr.ltac_trace * Loc.t option * Val.t Id.Map.t *
+  | VFun of appl * Tacexpr.ltac_trace * Loc.t option * Val.t Id.Map.t *
       Name.t list * Tacexpr.glob_tactic_expr
   | VRec of Val.t Id.Map.t ref * Tacexpr.glob_tactic_expr
 

--- a/plugins/ltac/tacenv.ml
+++ b/plugins/ltac/tacenv.ml
@@ -158,6 +158,7 @@ let load_md i ((sp, kn), (local, id, b, t, deprecation)) = match id with
 
 let open_md i ((sp, kn), (local, id, b, t, deprecation)) = match id with
 | None ->
+  (* todo: generate a warning when non-unique, record choices for non-unique mappings *)
   let () = if not local then push_tactic (Nametab.Exactly i) sp kn in
   add ~deprecation kn b t
 | Some kn0 -> replace kn0 kn t

--- a/plugins/ltac/tacexpr.ml
+++ b/plugins/ltac/tacexpr.ml
@@ -366,10 +366,11 @@ type ltac_call_kind =
   | LtacNotationCall of KerName.t
   | LtacNameCall of ltac_constant
   | LtacAtomCall of glob_atomic_tactic_expr
-  | LtacVarCall of Id.t * glob_tactic_expr
+  | LtacVarCall of KerName.t option * Id.t * glob_tactic_expr
   | LtacConstrInterp of Glob_term.glob_constr * Ltac_pretype.ltac_var_map
 
-type ltac_trace = ltac_call_kind Loc.located list
+type ltac_stack = ltac_call_kind Loc.located list
+type ltac_trace = ltac_stack * Geninterp.Val.t Id.Map.t list
 
 type tacdef_body =
   | TacticDefinition of lident * raw_tactic_expr (* indicates that user employed ':=' in Ltac body *)

--- a/plugins/ltac/tacexpr.mli
+++ b/plugins/ltac/tacexpr.mli
@@ -366,10 +366,11 @@ type ltac_call_kind =
   | LtacNotationCall of KerName.t
   | LtacNameCall of ltac_constant
   | LtacAtomCall of glob_atomic_tactic_expr
-  | LtacVarCall of Id.t * glob_tactic_expr
+  | LtacVarCall of KerName.t option * Id.t * glob_tactic_expr
   | LtacConstrInterp of Glob_term.glob_constr * Ltac_pretype.ltac_var_map
 
-type ltac_trace = ltac_call_kind Loc.located list
+type ltac_stack = ltac_call_kind Loc.located list
+type ltac_trace = ltac_stack * Geninterp.Val.t Id.Map.t list
 
 type tacdef_body =
   | TacticDefinition of lident * raw_tactic_expr (* indicates that user employed ':=' in Ltac body *)

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -1985,9 +1985,13 @@ let default_ist () =
   { lfun = Id.Map.empty; poly = false; extra = extra }
 
 let eval_tactic t =
-  Proofview.tclUNIT () >>= fun () -> (* delay for [default_ist] *)
-  Proofview.tclLIFT (db_initialize true) <*>
-  eval_tactic_ist (default_ist ()) t
+  if get_debug () <> DebugOff then
+    Proofview.tclUNIT () >>= fun () -> (* delay for [default_ist] *)
+    Proofview.tclLIFT (db_initialize true) <*>
+    eval_tactic_ist (default_ist ()) t
+  else
+    Proofview.tclUNIT () >>= fun () -> (* delay for [default_ist] *)
+    eval_tactic_ist (default_ist ()) t
 
 let eval_tactic_ist ist t =
   Proofview.tclLIFT (db_initialize false) <*>

--- a/plugins/ltac/tacinterp.mli
+++ b/plugins/ltac/tacinterp.mli
@@ -16,7 +16,7 @@ open Genarg
 open Redexpr
 open Tactypes
 
-val ltac_trace_info : ltac_trace Exninfo.t
+val ltac_trace_info : ltac_stack Exninfo.t
 
 module Value :
 sig

--- a/plugins/ltac/tactic_debug.ml
+++ b/plugins/ltac/tactic_debug.ml
@@ -8,12 +8,14 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+module StdList = List
+
 open Util
 open Names
 open Pp
 open Tacexpr
 
-let (ltac_trace_info : ltac_trace Exninfo.t) = Exninfo.make ()
+let (ltac_trace_info : ltac_stack Exninfo.t) = Exninfo.make ()
 
 let prtac x =
   let env = Global.env () in
@@ -37,17 +39,41 @@ type debug_info =
 let explain_logic_error e = CErrors.print e
 let explain_logic_error_no_anomaly e = CErrors.print_no_report e
 
+[@@@ocaml.warning "-32"]
+let cmd_to_str cmd =
+  let open DebugHook.Action in
+  match cmd with
+  | Continue -> "Continue"
+  | StepIn -> "StepIn"
+  | StepOver -> "StepOver"
+  | StepOut -> "StepOut"
+  | Skip -> "Skip"
+  | Interrupt -> "Interrput"
+  | Help -> "Help"
+  | RunCnt _ -> "RunCnt"
+  | RunBreakpoint _ -> "RunBreakpoint"
+  | Command _ -> "Command"
+  | Failed -> "Failed"
+  | Ignore -> "Ignore"
+[@@@ocaml.warning "+32"]
+
+let action = ref DebugHook.Action.StepOver
+
 (* Communications with the outside world *)
 module Comm = struct
 
   (* TODO: ideally we would check that the debugger hooks are
      correctly set, however we don't do this yet as debugger
-     initialiation is unconditionally done for example in coqc, which
-     doesn't support the debugger interface. Improving this would
-     require some tweaks in tacinterp which are out of scope for the
-     current refactoring. *)
-  let init () = match DebugHook.Intf.get () with
-    | Some _ -> ()
+     initialiation is unconditionally done for example in coqc.
+     Improving this would require some tweaks in tacinterp which
+     are out of scope for the current refactoring. *)
+  let init () =
+    let open DebugHook in
+    match Intf.get () with
+    | Some intf ->
+      action := if Intf.(intf.isTerminal) then Action.StepIn else Action.Continue;
+      DebugHook.set_break false;
+      ()
     | None -> ()
       (* CErrors.user_err
        *   (Pp.str "Your user interface does not support the Ltac debugger.") *)
@@ -61,9 +87,34 @@ module Comm = struct
   let prompt g = wrap (fun () -> (hook ()).submit_answer (Prompt g))
   let goal g = wrap (fun () -> (hook ()).submit_answer (Goal g))
   let output g = wrap (fun () -> (hook ()).submit_answer (Output g))
-  let read = wrap (fun () -> (hook ()).read_cmd ())
+
+  (* routines for deferring output; output is sent only if
+     the debugger stops at the next step *)
+  let out_queue = Queue.create ()
+  let defer_output f = wrap (fun () -> Queue.add f out_queue)
+  let print_deferred () = wrap (fun () ->
+    while not (Queue.is_empty out_queue)
+    do
+      (hook ()).submit_answer (Output ((Queue.pop out_queue) ()))
+    done)
+  let clear_queue () = wrap (fun () -> Queue.clear out_queue)
+
+  [@@@ocaml.warning "-32"]
+  let print g = (hook ()).submit_answer (Output (str g))
+  [@@@ocaml.warning "+32"]
+  let isTerminal () = (hook ()).isTerminal
+  let read = wrap (fun () ->
+    let rec l () =
+      let cmd = (hook ()).read_cmd () in
+      match cmd with
+      | DebugHook.Action.Ignore -> l ()
+      | _ -> action := cmd; cmd
+    in
+    l ())
 
 end
+
+let defer_output = Comm.defer_output
 
 (* Prints the goal *)
 
@@ -92,18 +143,133 @@ let help () =
      str "          s = Skip" ++ fnl() ++
      str "          x = Exit")
 
+[@@@ocaml.warning "-32"]
+let tac_loc tac =
+  let open Tacexpr in
+  let open CAst in
+  let loc, tac = tac.loc, tac.v in
+  let rv = match tac with
+  | TacAtom _ -> "TacAtom"
+  | TacThen _ -> "TacThen"
+  | TacDispatch _ -> "TacDispatch"
+  | TacExtendTac _ -> "TacExtendTac"
+  | TacThens _ -> "TacThens"
+  | TacThens3parts _ -> "TacThens3parts"
+  | TacFirst _ -> "TacFirst"
+  | TacComplete _ -> "TacComplete"
+  | TacSolve _ -> "TacSolve"
+  | TacTry _ -> "TacTry"
+  | TacOr _ -> "TacOr"
+  | TacOnce _ -> "TacOnce"
+  | TacExactlyOnce _ -> "TacExactlyOnce"
+  | TacIfThenCatch _ -> "TacIfThenCatch"
+  | TacOrelse _ -> "TacOrelse"
+  | TacDo _ -> "TacDo"
+  | TacTimeout _ -> "TacTimeout"
+  | TacTime _ -> "TacTime"
+  | TacRepeat _ -> "TacRepeat"
+  | TacProgress _ -> "TacProgress"
+  | TacAbstract _ -> "TacAbstract"
+  | TacId _ -> "TacId"
+  | TacFail _ -> "TacFail"
+  | TacLetIn _ -> "TacLetIn"
+  | TacMatch _ -> "TacMatch"
+  | TacMatchGoal _ -> "TacMatchGoal"
+  | TacFun _ -> "TacFun"
+  | TacArg _ -> "TacArg"
+  | TacSelect _ -> "TacSelect"
+  | TacML _ -> "TacML"
+  | TacAlias _ -> "TacAlias"
+  in
+(*  Printf.printf "  %s\n%!" (fst rv);*)
+  rv, loc
+
+let print_loc desc loc =
+  let open Loc in
+  match loc with
+  | Some loc ->
+    let src = (match loc.fname with
+    | InFile {file} -> file
+    | ToplevelInput -> "ToplevelInput")
+    in
+    Printf.sprintf "%s: %s %d/%d %d:%d\n" desc src loc.bp loc.line_nb
+      (loc.bp - loc.bol_pos_last) (loc.ep - loc.bol_pos_last)
+  | None -> Printf.sprintf "%s: loc is None" desc
+
+let print_loc_tac tac =
+  let (desc, loc) = tac_loc tac in
+  print_loc desc loc
+[@@@ocaml.warning "+32"]
+
+let cvt_stack stack =
+  List.map (fun k ->
+    let (loc, k) = k in
+    (* todo: compare to explain_ltac_call_trace below *)
+    match k with
+    | LtacNameCall l -> KerName.to_string l, loc
+    | LtacMLCall _ -> "??? LtacMLCall", loc
+      (* LtacMLCall should not even show the stack frame, but profiling may need it *)
+    | LtacNotationCall l -> "??? LtacNotationCall", loc
+      (* LtacNotationCall should not even show the stack frame, but profiling may need it *)
+    | LtacAtomCall _ -> "??? LtacAtomCall", loc (* not found in stack *)
+    | LtacVarCall (kn, id, e) ->
+      let fn_name =
+        match kn with
+        | Some kn -> KerName.to_string kn
+        | None -> "" (* anonymous function *)
+      in
+      fn_name, loc
+    | LtacConstrInterp (c,_) -> "", loc
+    ) stack
+
+(* Each list entry contains multiple trace frames. *)
+let trace_chunks : ltac_trace list ref = ref [([], [])]
+let push_chunk trace = trace_chunks := trace :: !trace_chunks
+let pop_chunk trace = trace_chunks := List.tl !trace_chunks
+
+let prev_stack = ref (Some [])  (* previous stopping point in debugger *)
+let prev_trace_chunks : ltac_trace list ref = ref [([], [])]
+
+
+type debugger_state = {
+  (* location of next code to execute, is not in stack *)
+  mutable cur_loc : Loc.t option;
+  (* yields the call stack *)
+  mutable stack : (string * Loc.t option) list;
+  (* variable value maps for each stack frame *)
+  mutable varmaps : Geninterp.Val.t Names.Id.Map.t list;
+}
+
+let debugger_state = { cur_loc=None; stack=[]; varmaps=[] }
+
+let save_loc tac varmap trace =
+(*  Comm.print (print_loc_tac tac);*)
+  let stack, varmaps = match trace with
+    | Some (stack, varmaps) -> stack, varmaps
+    | None -> [], []
+  in
+  debugger_state.cur_loc <- CAst.(tac.loc);
+  let (pstack, pvars) = List.fold_right (fun (s,v) (os, ov) -> (s @ os), (v @ ov))
+    !trace_chunks ([],[]) in
+  debugger_state.stack <- cvt_stack (stack @ pstack);
+  debugger_state.varmaps <- varmap :: (varmaps @ pvars)
+
 (* Prints the goal and the command to be executed *)
-let goal_com tac =
+let goal_com tac varmap trace =
+  save_loc tac varmap trace;
   Proofview.tclTHEN
     db_pr_goal
-    (Proofview.tclLIFT (Comm.output (str "Going to execute:" ++ fnl () ++ prtac tac)))
+    (if Comm.isTerminal () || debugger_state.cur_loc = None then
+      (Proofview.tclLIFT (Comm.output (str "Going to execute:" ++ fnl () ++ prtac tac)))
+    else
+      Proofview.tclLIFT (Proofview.NonLogical.return ()))
 
 (* [run (new_ref _)] gives us a ref shared among [NonLogical.t]
-   expressions. It avoids parametrizing everything over a
+   expressions. It avoids parameterizing everything over a
    reference. *)
 let skipped = Proofview.NonLogical.run (Proofview.NonLogical.ref 0)
 let skip = Proofview.NonLogical.run (Proofview.NonLogical.ref 0)
-let breakpoint = Proofview.NonLogical.run (Proofview.NonLogical.ref None)
+let idtac_breakpt = Proofview.NonLogical.run (Proofview.NonLogical.ref None)
 
 let batch = ref false
 
@@ -116,16 +282,23 @@ let () =
       optread  = (fun () -> !batch);
       optwrite = (fun x -> batch := x) }
 
-(* (Re-)initialize debugger *)
-let db_initialize =
+let prev_load_paths = ref []
+
+(* (Re-)initialize debugger. is_tac controls whether to set the action *)
+let db_initialize is_tac =
+  let load_paths = Loadpath.get_load_paths () in
+  if load_paths != !prev_load_paths then begin
+    prev_load_paths := load_paths;
+    DebugHook.refresh_bpts ()
+  end;
   let open Proofview.NonLogical in
-  make Comm.init >>
-  (skip:=0) >> (skipped:=0) >> (breakpoint:=None)
+  let x = (skip:=0) >> (skipped:=0) >> (idtac_breakpt:=None) in
+  if is_tac then make Comm.init >> x else x
 
 (* Prints the run counter *)
-let run ini =
+let print_run_ctr print =
   let open Proofview.NonLogical in
-  if not ini then
+  if print then
     begin
       !skipped >>= fun skipped ->
       Comm.output (str "Executed expressions: " ++ int skipped ++ fnl())
@@ -137,26 +310,80 @@ let run ini =
 
 (* Prints the prompt *)
 let rec prompt level =
-  (* spiwack: avoid overriding by the open below *)
-  let runtrue = run true in
+  let runnoprint = print_run_ctr false in
     let open Proofview.NonLogical in
     let nl = if Util.(!batch) then "\n" else "" in
+    Comm.print_deferred () >>
     Comm.prompt (tag "message.prompt"
                    @@ fnl () ++ str "TcDebug (" ++ int level ++ str (") > " ^ nl)) >>
-    if Util.(!batch) then return (DebugOn (level+1)) else
+    if Util.(!batch) && Comm.isTerminal () then return (DebugOn (level+1)) else
     let exit = (skip:=0) >> (skipped:=0) >> raise (Sys.Break, Exninfo.null) in
     Comm.read >>= fun inst ->
     let open DebugHook.Action in
     match inst with
-    | Step -> return (DebugOn (level+1))
+    | Continue
+    | StepIn
+    | StepOver
+    | StepOut -> return (DebugOn (level+1))
     | Skip -> return (DebugOff)
-    | Exit -> Proofview.NonLogical.print_char '\b' >> exit
+    | Interrupt -> Proofview.NonLogical.print_char '\b' >> exit  (* todo: why the \b? *)
     | Help -> help () >> prompt level
     | RunCnt num -> (skip:=num) >> (skipped:=0) >>
-        runtrue >> return (DebugOn (level+1))
-    | RunBreakpoint s -> (breakpoint:=(Some s)) >>
-        runtrue >> return (DebugOn (level+1))
+        runnoprint >> return (DebugOn (level+1))
+    | RunBreakpoint s -> (idtac_breakpt:=(Some s)) >> (* todo: look in Continue? *)
+        runnoprint >> return (DebugOn (level+1))
+    | Command _ -> failwith "Command"  (* not possible *)
     | Failed -> prompt level
+    | Ignore -> failwith "Ignore" (* not possible *)
+
+let at_breakpoint tac =
+  let open Loc in
+  let check_bpt dirpath offset =
+(*    Printf.printf "In tactic_debug, dirpath = %s offset = %d\n%!" dirpath bp;*)
+    DebugHook.check_bpt dirpath offset
+  in
+  match CAst.(tac.loc) with
+  | Some {fname=InFile {dirpath=Some dirpath}; bp} -> check_bpt dirpath bp
+  | Some {fname=ToplevelInput;                 bp} -> check_bpt "Top"   bp
+  | _ -> false
+
+[@@@ocaml.warning "-32"]
+open Tacexpr
+
+let pr_call_kind n k =
+  let (loc, k) = k in
+  let kind = (match k with
+  | LtacMLCall _ -> "LtacMLCall"
+  | LtacNotationCall _ -> "LtacNotationCall"
+  | LtacNameCall l ->
+    let name = (KerName.to_string l) ^ (print_loc "" loc) in
+    Printf.printf "%s\n%!" name; Feedback.msg_notice (Pp.str name); "LtacNameCall"
+  | LtacAtomCall _ -> "LtacAtomCall"
+  | LtacVarCall _ -> "LtacVarCall"
+  | LtacConstrInterp _ -> "LtacConstrInterp") in
+  Printf.printf "stack %d: %s\n%!" n kind
+
+let dump_stack msg stack =
+  match stack with
+  | Some stack ->
+    Printf.printf "%s: stack len = %d\n" msg (StdList.length stack);
+    StdList.iteri pr_call_kind stack;
+  | None -> ()
+
+let dump_varmaps msg varmaps =
+  match varmaps with
+  | Some varmaps ->
+    List.iter (fun varmap ->
+        Printf.printf "%s: varmap len = %d\n" msg (Id.Map.cardinal varmap);
+        List.iter (fun b ->
+            let (k, b) = b in
+            Printf.printf "id = %s\n%!" (Id.to_string k);
+            ignore @@ Pptactic.pr_value Constrexpr.LevelSome b (* todo: LevelSome?? *)
+            (* b is Geninterp.Val.t Names.Id.Map.t *)
+          ) (Id.Map.bindings varmap)
+      ) varmaps
+  | None -> ()
+[@@@ocaml.warning "+32"]
 
 (* Prints the state and waits for an instruction *)
 (* spiwack: the only reason why we need to take the continuation [f]
@@ -164,25 +391,76 @@ let rec prompt level =
    be that [f] is wrapped in with "explain_logic_error". I don't think
    it serves any purpose in the current design, so we could just drop
    that. *)
-let debug_prompt lev tac f =
-  (* spiwack: avoid overriding by the open below *)
-  let runfalse = run false in
+let debug_prompt lev tac f varmap trace =
+  (* trace omits the currently-running tactic, so add separately *)
+  let stack, varmaps = match trace with
+    | Some (stack, varmaps) -> Some stack, Some (varmap :: varmaps)
+    | None -> None, Some [varmap] in
+  let runprint = print_run_ctr true in
   let open Proofview.NonLogical in
   let (>=) = Proofview.tclBIND in
   (* What to print and to do next *)
   let newlevel =
-    Proofview.tclLIFT !skip >= fun initial_skip ->
-    if Int.equal initial_skip 0 then
-      Proofview.tclLIFT !breakpoint >= fun breakpoint ->
-      if Option.is_empty breakpoint then Proofview.tclTHEN (goal_com tac) (Proofview.tclLIFT (prompt lev))
-      else Proofview.tclLIFT(runfalse >> return (DebugOn (lev+1)))
-    else Proofview.tclLIFT begin
-      (!skip >>= fun s -> skip:=s-1) >>
-      runfalse >>
-      !skip >>= fun new_skip ->
-      (if Int.equal new_skip 0 then skipped:=0 else return ()) >>
-      return (DebugOn (lev+1))
-    end in
+    Proofview.tclLIFT !skip >= fun s ->
+      let stop_here () =
+(*        dump_stack "at debug_prompt" stack;*)
+(*        dump_varmaps "at debug_prompt" varmaps;*)
+        prev_stack.contents <- stack;
+        prev_trace_chunks.contents <- trace_chunks.contents;
+        Proofview.tclTHEN (goal_com tac varmap trace) (Proofview.tclLIFT (prompt lev))
+      in
+      let stacks_info stack p_stack =
+        (* performance impact? *)
+        let st_chunks =  StdList.map (fun (s, _) -> s) trace_chunks.contents in
+        let st =      StdList.concat ((Option.default [] stack) :: st_chunks) in
+        let prev_st_chunks = StdList.map (fun (s, _) -> s) prev_trace_chunks.contents in
+        let st_prev = StdList.concat ((Option.default [] p_stack) :: prev_st_chunks) in
+        let l_cur, l_prev = StdList.length st, StdList.length st_prev in
+        st, st_prev, l_cur, l_prev
+      in
+      let p_stack = prev_stack.contents in
+      if action.contents = DebugHook.Action.Continue && at_breakpoint tac then
+        (* todo: skip := 0 *)
+        stop_here ()
+      else if DebugHook.get_break () then begin
+        DebugHook.set_break false;
+        stop_here ()
+      end else if s > 0 then
+        Proofview.tclLIFT ((skip := s-1) >>
+          runprint >>
+          !skip >>= fun new_skip ->
+          (if new_skip = 0 then skipped := 0 else return ()) >>
+          return (DebugOn (lev+1)))
+      else (* todo: move this block before skip logic? *)
+        Proofview.tclLIFT !idtac_breakpt >= fun idtac_breakpt ->
+          if Option.has_some idtac_breakpt then
+            Proofview.tclLIFT(runprint >> return (DebugOn (lev+1)))
+          else begin
+            let open DebugHook.Action in
+            let stop = match action.contents with
+              | Continue -> false
+              | StepIn   -> true
+              | StepOver -> let st, st_prev, l_cur, l_prev = stacks_info stack p_stack in
+                            if l_cur = 0 || l_cur < l_prev then true (* stepped out *)
+                            else if l_prev = 0 (*&& l_cur > 0*) then false
+                            else
+                              let peq = StdList.nth st (l_cur - l_prev) == (StdList.hd st_prev) in
+                              (l_cur > l_prev && (not peq)) ||  (* stepped out *)
+                              (l_cur = l_prev && peq)  (* stepped over *)
+              | StepOut  -> let st, st_prev, l_cur, l_prev = stacks_info stack p_stack in
+                            if l_cur < l_prev then true
+                            else if l_prev = 0 then false
+                            else
+                              StdList.nth st (l_cur - l_prev) != (StdList.hd st_prev)
+              | _ -> failwith "action op"
+            in
+            if stop then begin
+              stop_here ()
+            end else
+              Proofview.tclLIFT (Comm.clear_queue () >>
+              return (DebugOn (lev+1)))
+          end
+    in
   newlevel >= fun newlevel ->
   (* What to execute *)
   Proofview.tclOR
@@ -191,27 +469,27 @@ let debug_prompt lev tac f =
       Proofview.tclTHEN
         (Proofview.tclLIFT begin
           (skip:=0) >> (skipped:=0) >>
-          Comm.output (str "Level " ++ int lev ++ str ": " ++ explain_logic_error reraise)
+          Comm.defer_output (fun () -> str "Level " ++ int lev ++ str ": " ++ explain_logic_error reraise)
         end)
         (Proofview.tclZERO ~info reraise)
     end
 
 let is_debug db =
   let open Proofview.NonLogical in
-  !breakpoint >>= fun breakpoint ->
-  match db, breakpoint with
+  !idtac_breakpt >>= fun idtac_breakpt ->
+  match db, idtac_breakpt with
   | DebugOff, _ -> return false
   | _, Some _ -> return false
   | _ ->
       !skip >>= fun skip ->
-      return (Int.equal skip 0)
+      return (skip = 0)
 
 (* Prints a constr *)
 let db_constr debug env sigma c =
   let open Proofview.NonLogical in
   is_debug debug >>= fun db ->
   if db then
-    Comm.output (str "Evaluated term: " ++ Printer.pr_econstr_env env sigma c)
+    Comm.defer_output (fun () -> str "Evaluated term: " ++ Printer.pr_econstr_env env sigma c)
   else return ()
 
 (* Prints the pattern rule *)
@@ -220,9 +498,9 @@ let db_pattern_rule debug env sigma num r =
   is_debug debug >>= fun db ->
   if db then
   begin
-    Comm.output
-      (str "Pattern rule " ++ int num ++ str ":" ++ fnl () ++
-       str "|" ++ spc () ++ prmatchrl env sigma r)
+    Comm.defer_output (fun () ->
+        str "Pattern rule " ++ int num ++ str ":" ++ fnl () ++
+        str "|" ++ spc () ++ prmatchrl env sigma r)
   end
   else return ()
 
@@ -236,9 +514,9 @@ let db_matched_hyp debug env sigma (id,_,c) ido =
   let open Proofview.NonLogical in
   is_debug debug >>= fun db ->
   if db then
-    Comm.output
-      (str "Hypothesis " ++ Id.print id ++ hyp_bound ido ++
-       str " has been matched: " ++ Printer.pr_econstr_env env sigma c)
+    Comm.defer_output (fun () ->
+      str "Hypothesis " ++ Id.print id ++ hyp_bound ido ++
+      str " has been matched: " ++ Printer.pr_econstr_env env sigma c)
   else return ()
 
 (* Prints the matched conclusion *)
@@ -246,8 +524,8 @@ let db_matched_concl debug env sigma c =
   let open Proofview.NonLogical in
   is_debug debug >>= fun db ->
   if db then
-    Comm.output
-      (str "Conclusion has been matched: " ++ Printer.pr_econstr_env env sigma c)
+    Comm.defer_output (fun () ->
+      str "Conclusion has been matched: " ++ Printer.pr_econstr_env env sigma c)
   else return ()
 
 (* Prints a success message when the goal has been matched *)
@@ -255,20 +533,20 @@ let db_mc_pattern_success debug =
   let open Proofview.NonLogical in
   is_debug debug >>= fun db ->
   if db then
-    Comm.output
-      (str "The goal has been successfully matched!" ++ fnl() ++
-       str "Let us execute the right-hand side part..." ++ fnl())
+    Comm.defer_output (fun () ->
+      str "The goal has been successfully matched!" ++ fnl() ++
+      str "Let us execute the right-hand side part..." ++ fnl())
   else return ()
 
-(* Prints a failure message for an hypothesis pattern *)
+(* Prints a failure message for a hypothesis pattern *)
 let db_hyp_pattern_failure debug env sigma (na,hyp) =
   let open Proofview.NonLogical in
   is_debug debug >>= fun db ->
   if db then
-    Comm.output
-      (str "The pattern hypothesis" ++ hyp_bound na ++
-       str " cannot match: " ++
-       prmatchpatt env sigma hyp)
+    Comm.defer_output (fun () ->
+      str "The pattern hypothesis" ++ hyp_bound na ++
+      str " cannot match: " ++
+      prmatchpatt env sigma hyp)
   else return ()
 
 (* Prints a matching failure message for a rule *)
@@ -276,9 +554,9 @@ let db_matching_failure debug =
   let open Proofview.NonLogical in
   is_debug debug >>= fun db ->
   if db then
-    Comm.output
-      (str "This rule has failed due to matching errors!" ++ fnl() ++
-       str "Let us try the next one...")
+    Comm.defer_output (fun () ->
+      str "This rule has failed due to matching errors!" ++ fnl() ++
+      str "Let us try the next one...")
   else return ()
 
 (* Prints an evaluation failure message for a rule *)
@@ -287,9 +565,9 @@ let db_eval_failure debug s =
   is_debug debug >>= fun db ->
   if db then
     let s = str "message \"" ++ s ++ str "\"" in
-    Comm.output
-      (str "This rule has failed due to \"Fail\" tactic (" ++
-       s ++ str ", level 0)!" ++ fnl() ++ str "Let us try the next one...")
+    Comm.defer_output (fun () ->
+      str "This rule has failed due to \"Fail\" tactic (" ++
+      s ++ str ", level 0)!" ++ fnl() ++ str "Let us try the next one...")
   else return ()
 
 (* Prints a logic failure message for a rule *)
@@ -298,11 +576,10 @@ let db_logic_failure debug err =
   is_debug debug >>= fun db ->
   if db then
   begin
-    Comm.output
-      (explain_logic_error err) >>
-    Comm.output
-      (str "This rule has failed due to a logic error!" ++ fnl() ++
-       str "Let us try the next one...")
+    Comm.defer_output (fun () -> explain_logic_error err) >>
+    Comm.defer_output (fun () ->
+      str "This rule has failed due to a logic error!" ++ fnl() ++
+      str "Let us try the next one...")
   end
   else return ()
 
@@ -312,14 +589,14 @@ let is_breakpoint brkname s = match brkname, s with
 
 let db_breakpoint debug s =
   let open Proofview.NonLogical in
-  !breakpoint >>= fun opt_breakpoint ->
+  !idtac_breakpt >>= fun opt_breakpoint ->
   match debug with
   | DebugOn lev when not (CList.is_empty s) && is_breakpoint opt_breakpoint s ->
-      breakpoint:=None
+      idtac_breakpt:=None
   | _ ->
       return ()
 
-(** Extrating traces *)
+(** Extracting traces *)
 
 let is_defined_ltac trace =
   let rec aux = function
@@ -337,7 +614,7 @@ let explain_ltac_call_trace last trace loc =
   | Tacexpr.LtacNameCall cst -> quote (Pptactic.pr_ltac_constant cst)
   | Tacexpr.LtacMLCall t ->
       quote (prtac t)
-  | Tacexpr.LtacVarCall (id,t) ->
+  | Tacexpr.LtacVarCall (_,id,t) ->
       quote (Id.print id) ++ strbrk " (bound to " ++
         prtac t ++ str ")"
   | Tacexpr.LtacAtomCall te ->
@@ -410,3 +687,25 @@ let get_ltac_trace info =
   | Some trace -> Some (extract_ltac_trace ?loc trace)
 
 let () = CErrors.register_additional_error_info get_ltac_trace
+
+let get_stack () =
+  let rec shift s prev_loc res =
+    match s with
+    | (tacn, loc) :: tl ->
+      shift tl loc (((Some tacn), prev_loc) :: res)
+    | [] -> (None, prev_loc) :: res
+  in
+  List.rev (shift debugger_state.stack debugger_state.cur_loc [])
+
+let () = DebugHook.forward_get_stack := get_stack
+
+let get_vars framenum =
+  let open Names in
+(*  Printf.printf "server: db_vars call\n%!";*)
+  let vars = List.nth debugger_state.varmaps framenum in
+  List.map (fun b ->
+      let (id, v) = b in
+      (Id.to_string id, Pptactic.pr_value Constrexpr.LevelSome v)
+    ) (Id.Map.bindings vars)
+
+let () = DebugHook.forward_get_vars := get_vars

--- a/plugins/ltac/tactic_debug.mli
+++ b/plugins/ltac/tactic_debug.mli
@@ -17,7 +17,7 @@ open Evd
 
 (** TODO: Move those definitions somewhere sensible *)
 
-val ltac_trace_info : ltac_trace Exninfo.t
+val ltac_trace_info : ltac_stack Exninfo.t
 
 (** This module intends to be a beginning of debugger for tactic expressions.
    Currently, it is quite simple and we can hope to have, in the future, a more
@@ -30,10 +30,11 @@ type debug_info =
 
 (** Prints the state and waits *)
 val debug_prompt :
-  int -> glob_tactic_expr -> (debug_info -> 'a Proofview.tactic) -> 'a Proofview.tactic
+  int -> glob_tactic_expr -> (debug_info -> 'a Proofview.tactic) ->
+  Geninterp.Val.t Id.Map.t -> Tacexpr.ltac_trace option -> 'a Proofview.tactic
 
 (** Initializes debugger *)
-val db_initialize : unit Proofview.NonLogical.t
+val db_initialize : bool -> unit Proofview.NonLogical.t
 
 (** Prints a constr *)
 val db_constr : debug_info -> env -> evar_map -> constr -> unit Proofview.NonLogical.t
@@ -74,9 +75,18 @@ val explain_logic_error_no_anomaly : exn -> Pp.t
 (** Prints a logic failure message for a rule *)
 val db_logic_failure : debug_info -> exn -> unit Proofview.NonLogical.t
 
-(** Prints a logic failure message for a rule *)
+(** Check for/process idtac breakpoint *)
 val db_breakpoint : debug_info ->
   lident message_token list -> unit Proofview.NonLogical.t
 
 val extract_ltac_trace :
-  ?loc:Loc.t -> Tacexpr.ltac_trace -> Pp.t Loc.located
+  ?loc:Loc.t -> Tacexpr.ltac_stack -> Pp.t Loc.located
+
+(** Prints a message only if debugger stops at the next step *)
+val defer_output : (unit -> Pp.t) -> unit Proofview.NonLogical.t
+
+(** Push a trace chunk (multiple frames) onto the trace chunk stack *)
+val push_chunk : ltac_trace -> unit
+
+(** Pop a trace chunk (multiple frames) from the trace chunk stack *)
+val pop_chunk : unit -> unit

--- a/test-suite/ide/fake_ide.ml
+++ b/test-suite/ide/fake_ide.ml
@@ -191,9 +191,9 @@ module GUILogic = struct
 
   let after_add = function
     | Interface.Fail (_,_,s) -> print_error s; exit 1
-    | Interface.Good (id, (Util.Inl (), _)) ->
+    | Interface.Good (id, Util.Inl ()) ->
         Document.assign_tip_id doc id
-    | Interface.Good (id, (Util.Inr tip, _)) ->
+    | Interface.Good (id, Util.Inr tip) ->
         Document.assign_tip_id doc id;
         Document.unfocus doc;
         ignore(Document.cut_at doc tip);
@@ -240,13 +240,13 @@ let eval_print l coq =
   match l with
   | [ Tok(_,"ADD"); Top []; Tok(_,phrase) ] ->
       let eid, tip = add_sentence phrase in
-      after_add (base_eval_call (add ((phrase,eid),(tip,true))) coq)
+      after_add (base_eval_call (add ((((phrase,eid),(tip,true)),0),(0,0))) coq)
   | [ Tok(_,"ADD"); Top [Tok(_,name)]; Tok(_,phrase) ] ->
       let eid, tip = add_sentence ~name phrase in
-      after_add (base_eval_call (add ((phrase,eid),(tip,true))) coq)
+      after_add (base_eval_call (add ((((phrase,eid),(tip,true)),0),(0,0))) coq)
   | [ Tok(_,"FAILADD"); Tok(_,phrase) ] ->
       let eid, tip = add_sentence phrase in
-      after_fail coq (base_eval_call ~fail:false (add ((phrase,eid),(tip,true))) coq)
+      after_fail coq (base_eval_call ~fail:false (add ((((phrase,eid),(tip,true)),0),(0,0))) coq)
   | [ Tok(_,"GOALS"); ] ->
       eval_call (goals ()) coq
   | [ Tok(_,"FAILGOALS"); ] ->

--- a/toplevel/coqc.ml
+++ b/toplevel/coqc.ml
@@ -15,6 +15,7 @@ let coqc_init ((_,color_mode),_) injections ~opts =
   DebugHook.Intf.(set
     { read_cmd = Coqtop.ltac_debug_parse
     ; submit_answer = Coqtop.ltac_debug_answer
+    ; isTerminal = true
     });
   injections
 

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -141,6 +141,8 @@ let ltac_debug_answer = let open DebugHook.Answer in function
       Format.fprintf !Topfmt.err_ft "@[%a@]@\n%!" Pp.pp_with o
     | Init ->
       Format.fprintf !Topfmt.err_ft "@[%a@]@\n%!" Pp.pp_with (str "Init")
+    | Stack _
+    | Vars _ -> CErrors.anomaly (str "ltac_debug_answer: unsupported Answer type")
 
 let ltac_debug_parse () =
   let open DebugHook in

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -139,6 +139,8 @@ let ltac_debug_answer = let open DebugHook.Answer in function
       Format.fprintf !Topfmt.err_ft "@[%a@]@\n%!" Pp.pp_with (str "Goal:" ++ fnl () ++ g)
     | Output o ->
       Format.fprintf !Topfmt.err_ft "@[%a@]@\n%!" Pp.pp_with o
+    | Init ->
+      Format.fprintf !Topfmt.err_ft "@[%a@]@\n%!" Pp.pp_with (str "Init")
 
 let ltac_debug_parse () =
   let open DebugHook in

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -144,7 +144,7 @@ let ltac_debug_parse () =
   let open DebugHook in
   let act =
     try Action.parse (read_line ())
-    with End_of_file -> Ok Action.Exit
+    with End_of_file -> Ok Action.Interrupt
   in
   match act with
   | Ok act -> act
@@ -187,6 +187,7 @@ let coqtop_init ({ run_mode; color_mode }, async_opts) injections ~opts =
   DebugHook.Intf.(set
     { read_cmd = ltac_debug_parse
     ; submit_answer = ltac_debug_answer
+    ; isTerminal = true
     });
   init_toploop opts async_opts injections
 

--- a/vernac/debugHook.ml
+++ b/vernac/debugHook.ml
@@ -12,15 +12,18 @@
    with their provided interface. *)
 module Action = struct
   type t =
-    | Step
-    (** Step one tactic *)
+    | StepIn
+    | StepOver
+    | StepOut
+    | Continue
     | Skip
-    (** Skip one tactic *)
-    | Exit
+    | Interrupt
     | Help
     | RunCnt of int
     | RunBreakpoint of string
+    | Command of string
     | Failed
+    | Ignore (* do nothing, read another command *)
 
   (* XXX: Could we move this to the CString utility library? *)
   let possibly_unquote s =
@@ -49,9 +52,9 @@ module Action = struct
   (* XXX: Should be moved to the clients *)
   let parse inst : (t, string) result =
     match inst with
-    | ""  -> Ok Step
+    | ""  -> Ok StepIn
     | "s" -> Ok Skip
-    | "x" -> Ok Exit
+    | "x" -> Ok Interrupt
     | "h"| "?" -> Ok Help
     | _ -> parse_complex inst
 end
@@ -70,6 +73,8 @@ module Intf = struct
     (** request a debugger command from the client *)
     ; submit_answer : Answer.t -> unit
     (** receive a debugger answer from Ltac *)
+    ; isTerminal : bool
+    (** whether the debugger is running as a terminal (non-visual) *)
     }
 
   let ltac_debug_ref : t option ref = ref None
@@ -77,3 +82,102 @@ module Intf = struct
   let get () = !ltac_debug_ref
 
 end
+
+(* tactic_debug defines breakpoints in terms of the module dirpath and
+   the offset in the source file.  The ide client identifies
+   breakpoints by absolute file names of the source file and the offset
+   within.  The client doesn't know the module dirpath.
+
+   Users may set breakpoints in files before they have been "Load"ed,
+   when their dirpaths are unknown.  To address this, the Load code
+   calls refresh_bpts so that such breakpoints can then by seen by tactic_debug.
+*)
+
+(* breakpoints as used by tactic_debug *)
+type breakpoint = {
+  dirpath : string;  (* module dirpath *)
+  offset : int;
+}
+
+module BPSet = CSet.Make(struct
+  type t = breakpoint
+  let compare b1 b2 =
+    let c1 = Int.compare b1.offset b2.offset in
+    if c1 <> 0 then c1 else String.compare b1.dirpath b2.dirpath
+  end)
+
+let breakpoints = ref BPSet.empty
+
+let check_bpt dirpath offset =
+  BPSet.mem { dirpath; offset } !breakpoints
+
+(* breakpoints as defined by the debugger IDE, using absolute file names *)
+type ide_breakpoint = {
+  file : string;
+  offset : int;
+}
+
+module IBPSet = CSet.Make(struct
+  type t = ide_breakpoint
+  let compare b1 b2 =
+    let c1 = Int.compare b1.offset b2.offset in
+    if c1 <> 0 then c1 else String.compare b1.file b2.file
+  end)
+
+(* breakpoints as defined by the debugger IDE, using absolute file names *)
+let ide_breakpoints = ref IBPSet.empty
+
+(** add or remove a single breakpoint.  Maps the breakpoint from
+  IDE format (absolute path name, offset) to (module dirpath, offset)
+  opt - true to add, false to remove
+  ide_bpt - the breakpoint (absolute path name, offset)
+  *)
+let update_bpt opt ide_bpt =
+  let open Names in
+  let fname = ide_bpt.file in
+  let dp =
+    if fname = "ToplevelInput" then  (* todo: or None? *)
+      DirPath.make [Id.of_string "Top"]
+    else begin (* find the DirPath matching the absolute pathname of the file *)
+      (* ? check for .v extension? *)
+      let dirname = Filename.dirname fname in
+      let basename = Filename.basename fname in
+      let base_id = Id.of_string (Filename.remove_extension basename) in
+      DirPath.make (base_id ::
+          (try
+            let p = Loadpath.find_load_path (CUnix.physical_path_of_string dirname) in
+            DirPath.repr (Loadpath.logical p)
+          with _ -> []))
+    end
+  in
+  let dirpath = DirPath.to_string dp in
+  let bp = { dirpath; offset=ide_bpt.offset } in
+(*  Printf.printf "update_bpt: %s -> %s  %d\n%!" fname dirpath ide_bpt.offset;*)
+  match opt with
+  | true  -> breakpoints := BPSet.add bp !breakpoints
+  | false -> breakpoints := BPSet.remove bp !breakpoints
+
+(** refresh breakpoints, for use when loadpaths are updated, e.g. by the "Load" command *)
+let refresh_bpts () =
+  breakpoints := BPSet.empty;
+  IBPSet.iter (update_bpt true) !ide_breakpoints
+
+(** opt = true to add a breakpoint, false to remove *)
+let upd_ide_bpt file offset opt =
+  let bp = { file; offset } in
+  match opt with
+  | true ->
+    ide_breakpoints := IBPSet.add bp !ide_breakpoints;  (* todo: error if already set? *)
+    update_bpt true bp
+  | false ->
+    ide_breakpoints := IBPSet.remove bp !ide_breakpoints; (* todo: error if not found? *)
+    update_bpt false bp
+
+let forward_get_stack = ref (fun x -> failwith "forward_get_stack")
+let forward_get_vars = ref (fun x -> failwith "forward_get_vars")
+
+let break = ref false
+(* causes the debugger to stop at the next step *)
+
+let get_break () = !break
+let set_break b = break := b

--- a/vernac/debugHook.ml
+++ b/vernac/debugHook.ml
@@ -19,6 +19,8 @@ module Action = struct
     | Skip
     | Interrupt
     | Help
+    | UpdBpts of ((string * int) * bool) list
+    | Configd
     | RunCnt of int
     | RunBreakpoint of string
     | Command of string
@@ -64,6 +66,7 @@ module Answer = struct
     | Prompt of Pp.t
     | Goal of Pp.t
     | Output of Pp.t
+    | Init
 end
 
 module Intf = struct
@@ -82,96 +85,6 @@ module Intf = struct
   let get () = !ltac_debug_ref
 
 end
-
-(* tactic_debug defines breakpoints in terms of the module dirpath and
-   the offset in the source file.  The ide client identifies
-   breakpoints by absolute file names of the source file and the offset
-   within.  The client doesn't know the module dirpath.
-
-   Users may set breakpoints in files before they have been "Load"ed,
-   when their dirpaths are unknown.  To address this, the Load code
-   calls refresh_bpts so that such breakpoints can then by seen by tactic_debug.
-*)
-
-(* breakpoints as used by tactic_debug *)
-type breakpoint = {
-  dirpath : string;  (* module dirpath *)
-  offset : int;
-}
-
-module BPSet = CSet.Make(struct
-  type t = breakpoint
-  let compare b1 b2 =
-    let c1 = Int.compare b1.offset b2.offset in
-    if c1 <> 0 then c1 else String.compare b1.dirpath b2.dirpath
-  end)
-
-let breakpoints = ref BPSet.empty
-
-let check_bpt dirpath offset =
-  BPSet.mem { dirpath; offset } !breakpoints
-
-(* breakpoints as defined by the debugger IDE, using absolute file names *)
-type ide_breakpoint = {
-  file : string;
-  offset : int;
-}
-
-module IBPSet = CSet.Make(struct
-  type t = ide_breakpoint
-  let compare b1 b2 =
-    let c1 = Int.compare b1.offset b2.offset in
-    if c1 <> 0 then c1 else String.compare b1.file b2.file
-  end)
-
-(* breakpoints as defined by the debugger IDE, using absolute file names *)
-let ide_breakpoints = ref IBPSet.empty
-
-(** add or remove a single breakpoint.  Maps the breakpoint from
-  IDE format (absolute path name, offset) to (module dirpath, offset)
-  opt - true to add, false to remove
-  ide_bpt - the breakpoint (absolute path name, offset)
-  *)
-let update_bpt opt ide_bpt =
-  let open Names in
-  let fname = ide_bpt.file in
-  let dp =
-    if fname = "ToplevelInput" then  (* todo: or None? *)
-      DirPath.make [Id.of_string "Top"]
-    else begin (* find the DirPath matching the absolute pathname of the file *)
-      (* ? check for .v extension? *)
-      let dirname = Filename.dirname fname in
-      let basename = Filename.basename fname in
-      let base_id = Id.of_string (Filename.remove_extension basename) in
-      DirPath.make (base_id ::
-          (try
-            let p = Loadpath.find_load_path (CUnix.physical_path_of_string dirname) in
-            DirPath.repr (Loadpath.logical p)
-          with _ -> []))
-    end
-  in
-  let dirpath = DirPath.to_string dp in
-  let bp = { dirpath; offset=ide_bpt.offset } in
-(*  Printf.printf "update_bpt: %s -> %s  %d\n%!" fname dirpath ide_bpt.offset;*)
-  match opt with
-  | true  -> breakpoints := BPSet.add bp !breakpoints
-  | false -> breakpoints := BPSet.remove bp !breakpoints
-
-(** refresh breakpoints, for use when loadpaths are updated, e.g. by the "Load" command *)
-let refresh_bpts () =
-  breakpoints := BPSet.empty;
-  IBPSet.iter (update_bpt true) !ide_breakpoints
-
-(** opt = true to add a breakpoint, false to remove *)
-let upd_ide_bpt file offset opt =
-  let bp = { file; offset } in
-  match opt with
-  | true ->
-    ide_breakpoints := IBPSet.add bp !ide_breakpoints;  (* todo: error if already set? *)
-    update_bpt true bp
-  | false ->
-    ide_breakpoints := IBPSet.remove bp !ide_breakpoints; (* todo: error if not found? *)
-    update_bpt false bp
 
 let forward_get_stack = ref (fun x -> failwith "forward_get_stack")
 let forward_get_vars = ref (fun x -> failwith "forward_get_vars")

--- a/vernac/debugHook.ml
+++ b/vernac/debugHook.ml
@@ -21,6 +21,8 @@ module Action = struct
     | Help
     | UpdBpts of ((string * int) * bool) list
     | Configd
+    | GetStack
+    | GetVars of int
     | RunCnt of int
     | RunBreakpoint of string
     | Command of string
@@ -67,6 +69,8 @@ module Answer = struct
     | Goal of Pp.t
     | Output of Pp.t
     | Init
+    | Stack of (string * (string * int list) option) list
+    | Vars of (string * Pp.t) list
 end
 
 module Intf = struct
@@ -85,12 +89,3 @@ module Intf = struct
   let get () = !ltac_debug_ref
 
 end
-
-let forward_get_stack = ref (fun x -> failwith "forward_get_stack")
-let forward_get_vars = ref (fun x -> failwith "forward_get_vars")
-
-let break = ref false
-(* causes the debugger to stop at the next step *)
-
-let get_break () = !break
-let set_break b = break := b

--- a/vernac/debugHook.mli
+++ b/vernac/debugHook.mli
@@ -19,6 +19,8 @@ module Action : sig
     | Skip
     | Interrupt
     | Help
+    | UpdBpts of ((string * int) * bool) list
+    | Configd
     | RunCnt of int
     | RunBreakpoint of string
     | Command of string
@@ -34,6 +36,7 @@ module Answer : sig
     | Prompt of Pp.t
     | Goal of Pp.t
     | Output of Pp.t
+    | Init
 end
 
 module Intf : sig
@@ -49,14 +52,6 @@ module Intf : sig
   val set : t -> unit
   val get : unit -> t option
 end
-
-(* set or clear a breakpoint at the given filepath and offset *)
-val upd_ide_bpt : string -> int -> bool -> unit
-
-(* test if (module dirpath, offset) has a breakpoint *)
-val check_bpt : string -> int -> bool
-
-val refresh_bpts : unit -> unit
 
 val forward_get_stack : (unit -> (string option * Loc.t option) list) ref
 val forward_get_vars : (int -> (string * Pp.t) list) ref

--- a/vernac/debugHook.mli
+++ b/vernac/debugHook.mli
@@ -12,15 +12,18 @@
    with their provided interface. *)
 module Action : sig
   type t =
-    | Step
-    (** Step one tactic *)
+    | StepIn
+    | StepOver
+    | StepOut
+    | Continue
     | Skip
-    (** Skip one tactic *)
-    | Exit
+    | Interrupt
     | Help
     | RunCnt of int
     | RunBreakpoint of string
+    | Command of string
     | Failed
+    | Ignore (* do nothing, read another command *)
 
   (* XXX: Should be moved to the clients *)
   val parse : string -> (t, string) result
@@ -39,8 +42,24 @@ module Intf : sig
     (** request a debugger command from the client *)
     ; submit_answer : Answer.t -> unit
     (** receive a debugger answer from Ltac *)
+    ; isTerminal : bool
+    (** whether the debugger is running as a terminal (non-visual) *)
     }
 
   val set : t -> unit
   val get : unit -> t option
 end
+
+(* set or clear a breakpoint at the given filepath and offset *)
+val upd_ide_bpt : string -> int -> bool -> unit
+
+(* test if (module dirpath, offset) has a breakpoint *)
+val check_bpt : string -> int -> bool
+
+val refresh_bpts : unit -> unit
+
+val forward_get_stack : (unit -> (string option * Loc.t option) list) ref
+val forward_get_vars : (int -> (string * Pp.t) list) ref
+
+val get_break : unit -> bool
+val set_break : bool -> unit

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1437,7 +1437,8 @@ let expand filename =
 let vernac_add_loadpath ~implicit pdir coq_path =
   let open Loadpath in
   let pdir = expand pdir in
-  add_vo_path { unix_path = pdir; coq_path; has_ml = true; implicit; recursive = true }
+  add_vo_path { unix_path = pdir; coq_path; has_ml = true; implicit; recursive = true };
+  DebugHook.refresh_bpts ()
 
 let vernac_remove_loadpath path =
   Loadpath.remove_load_path (expand path)

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1437,8 +1437,7 @@ let expand filename =
 let vernac_add_loadpath ~implicit pdir coq_path =
   let open Loadpath in
   let pdir = expand pdir in
-  add_vo_path { unix_path = pdir; coq_path; has_ml = true; implicit; recursive = true };
-  DebugHook.refresh_bpts ()
+  add_vo_path { unix_path = pdir; coq_path; has_ml = true; implicit; recursive = true }
 
 let vernac_remove_loadpath path =
   Loadpath.remove_load_path (expand path)


### PR DESCRIPTION
@MSoegtropIMC I hope you'll try this version soon.  Please see the documentation in #14281.  In addition: Clicking on call stack entries (or the Up/Down keys) jump to the associated location and show variable values for that stack frame.  In the variables panel, click on the triangle to see lengthy values.  I recommend detaching the debugger panel for debugging multi-file scripts.

Some current limitations:
- Some variable values are not shown in a useful form, e.g. as "<genarg:tacvalue>"

Please create issues for any bugs you find, including usability issues.  Email me with your questions and comments.  I'll address those ASAP.

~Depends on and incorporates #14252~

Overlay:
- https://github.com/whonore/Coqtail/pull/209