### PR TITLE
Disable the Sphinx correct copyright date misfeature.

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -35,6 +35,10 @@ sys.setrecursionlimit(3000)
 sys.path.append(os.path.abspath('../tools/'))
 sys.path.append(os.path.abspath('../../config/'))
 
+# Disable the correct_copyright_year misfeature from Sphinx
+# See https://github.com/coq/coq/issues/7378
+sphinx.config.correct_copyright_year = lambda *args, **kwargs: None
+
 import coq_config
 
 # -- Prolog ---------------------------------------------------------------


### PR DESCRIPTION
Fixes / closes #7378

See the issue for the explanation.