### PR TITLE
Extended internal pattern language of the congruence tactic

### DIFF
--- a/doc/changelog/04-tactics/14650-match_congruence.rst
+++ b/doc/changelog/04-tactics/14650-match_congruence.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  More flexible hypothesis specialization in :tacn:`congruence`.
+  (`#14650 <https://github.com/coq/coq/pull/14650>`_,
+  fixes `#14651 <https://github.com/coq/coq/issues/14651>`_
+  and `#14662 <https://github.com/coq/coq/issues/14662>`_,
+  by Andrej Dudenhefner).

--- a/plugins/cc/ccalgo.mli
+++ b/plugins/cc/ccalgo.mli
@@ -42,7 +42,7 @@ module Termhash : Hashtbl.S with type key = term
 
 type ccpattern =
     PApp of term * ccpattern list
-  | PVar of int
+  | PVar of int * ccpattern list
 
 type rule=
     Congruence

--- a/test-suite/bugs/closed/bug_14651.v
+++ b/test-suite/bugs/closed/bug_14651.v
@@ -1,0 +1,26 @@
+Axiom p : (nat -> nat) -> nat.
+Goal (forall f, p f = f 0) -> forall f, p f = f 0.
+Proof. congruence. Qed.
+
+Definition ap {X Y : Type} (f : X -> Y) (x : X) := f x.
+
+Goal (forall f, p f = ap f 0) -> forall f, p f = ap f 0.
+Proof. congruence. Qed.
+
+Goal (forall f, p f = ap f (f 0)) -> forall f, p f = ap f (f 0).
+Proof. congruence. Qed.
+
+Definition twice (f: nat -> nat) x := f (f x).
+
+Lemma twice_def f x : twice f x = f (f x).
+Proof. reflexivity. Qed.
+
+Definition twice_spec f := forall x, twice f x = f (f x).
+
+Goal forall f x, twice f x = f (f x).
+Proof.
+  intros f x.
+  Fail congruence. (* expected, no unfolding *)
+  pose proof (H := twice_def).
+  congruence.
+Qed.

--- a/test-suite/bugs/closed/bug_14662.v
+++ b/test-suite/bugs/closed/bug_14662.v
@@ -1,0 +1,12 @@
+Goal False.
+Proof.
+  evar (e : Prop). assert e.
+  { subst e. Timeout 1 Fail congruence. admit. }
+Abort.
+
+Goal False -> False.
+Proof.
+  evar (e : Prop). assert (H : e -> e).
+  { subst e. Timeout 1 congruence. }
+  exact H.
+Qed.


### PR DESCRIPTION
This PR extends patterns used by the congruence tactic.
Now it allows to represent patterns `?f p1..pn` with `n > 0`.
For example the following failing example is now successful (see zulip [discussion](https://coq.zulipchat.com/#narrow/stream/237977-Coq-users/topic/congruence.20and.20specialization)).

```coq
Axiom p : (nat -> nat) -> nat.
Goal (forall f, p f = f 0) -> forall f, p f = f 0.
Proof. Fail congruence. Admitted.
```

The main observation (also in correspondence with the documentation) is that in the pattern `p ?f = ?f 0` the lhs fully suffices for pattern matching (see example below).

```coq
Definition ap {X Y : Type} (f : X -> Y) (x : X) := f x.

Goal (forall f, p f = ap f 0) -> forall f, p f = ap f 0.
Proof. congruence. Qed.
```

Let us see whether ci will like this one.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Closes  #14651, closes #14662


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite
- [x] Entry added in the changelog.
