### PR TITLE
[build] [test-suite] Move fake_ide to test-suite 

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -98,7 +98,7 @@ states: $(VO_OUT_DIR)theories/Init/Prelude.$(VO)
 
 .PHONY: coqbinaries tools
 
-coqbinaries: $(TOPBINOPT) $(COQC) $(COQTOPEXE) $(CHICKEN) $(CSDPCERT) $(FAKEIDE) $(COQNATIVE)
+coqbinaries: $(TOPBINOPT) $(COQC) $(COQTOPEXE) $(CHICKEN) $(CSDPCERT) $(COQNATIVE)
 tools: $(TOOLS) $(OCAMLLIBDEP) $(COQDEP) $(DOC_GRAM)
 
 ###########################################################################

--- a/Makefile.common
+++ b/Makefile.common
@@ -99,7 +99,6 @@ COQMAKE_BOTH_TIME_FILES:=tools/make-both-time-files.py
 COQMAKE_BOTH_SINGLE_TIMING_FILES:=tools/make-both-single-timing-files.py
 VOTOUR:=$(CBIN)/votour$(EXE)
 OCAMLLIBDEP:=$(CBIN)/ocamllibdep$(EXE)
-FAKEIDE:=$(CBIN)/fake_ide$(EXE)
 USERCONTRIBDIRS:=Ltac2
 CHICKEN:=$(CBIN)/coqchk$(EXE)
 TOOLS:=$(VOTOUR) $(COQDOC) $(COQDOCSTY) $(COQDOCCSS) $(COQWC) $(COQMAKEFILE) $(COQMAKEFILEIN) $(COQNATIVE)

--- a/ide/coqide/dune
+++ b/ide/coqide/dune
@@ -9,13 +9,6 @@
  (libraries coq-core.lib))
 
 (executable
- (name fake_ide)
- (public_name fake_ide)
- (package coqide-server)
- (modules fake_ide)
- (libraries coqide-server.protocol coqide-server.core))
-
-(executable
  (name idetop)
  (public_name coqidetop.opt)
  (package coqide-server)
@@ -33,7 +26,7 @@
 (library
  (name coqide_gui)
  (wrapped false)
- (modules (:standard \ document fake_ide idetop coqide_main default_bindings_src))
+ (modules (:standard \ document idetop coqide_main default_bindings_src))
  (optional)
  (libraries coqide-server.protocol coqide-server.core lablgtk3-sourceview3))
 

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -74,6 +74,12 @@ coqdoc := $(BIN)coqdoc
 coqtop := $(BIN)coqtop -q -test-mode -R prerequisite TestSuite
 coqtopbyte := $(BIN)coqtop.byte -q
 
+ifeq ($(BEST),opt)
+coqidetop := $(BIN)coqidetop.opt
+else
+coqidetop := $(BIN)coqidetop.byte
+endif
+
 coqc_interactive := $(coqc) -test-mode -async-proofs-cache force
 coqdep := $(BIN)coqdep
 
@@ -686,11 +692,15 @@ $(patsubst %.sh,%.log,$(wildcard misc/*.sh)): %.log: %.sh $(PREREQUISITELOG)
 
 ide : $(patsubst %.fake,%.fake.log,$(wildcard ide/*.fake))
 
-%.fake.log : %.fake
+ide/fake_ide.exe : ide/fake_ide.ml
+	$(SHOW) 'OCAMLC  $<'
+	$(HIDE)$(OCAMLBEST) -linkall -linkpkg -package coqide-server.protocol -package coqide-server.core $< -o $@
+
+%.fake.log : %.fake ide/fake_ide.exe
 	@echo "TEST      $<"
 	$(HIDE){ \
 	  echo $(call log_intro,$<); \
-	  $(BIN)fake_ide "$<" "-q -async-proofs on -async-proofs-tactic-error-resilience off -async-proofs-command-error-resilience off $(call get_coq_prog_args,"$<")" 2>&1; \
+	  ide/fake_ide.exe $(coqidetop) "$<" "-q -async-proofs on -async-proofs-tactic-error-resilience off -async-proofs-command-error-resilience off $(call get_coq_prog_args,"$<")" 2>&1; \
 	  if [ $$? = 0 ]; then \
 	    echo $(log_success); \
 	    echo "    $<...Ok"; \

--- a/test-suite/ide/fake_ide.ml
+++ b/test-suite/ide/fake_ide.ml
@@ -8,7 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(** Fake_ide : Simulate a [coqide] talking to a [coqidetop] *)
+(** Fake_ide : Simulate a [coqide] talking to a [coqidetop]. *)
 
 let error s =
   prerr_endline ("fake_ide: error: "^s);
@@ -302,7 +302,7 @@ let grammar =
 let read_command inc = Parser.parse grammar inc
 
 let usage () =
-  prerr_endline (Printf.sprintf "Usage: %s ( file | - ) [ \"<coqtop arguments>\" ]\n\
+  prerr_endline (Printf.sprintf "Usage: %s COQIDETOP ( file | - ) [ \"<coqtop arguments>\" ]\n\
     Input syntax is:\n%s\n"
     (Filename.basename Sys.argv.(0))
     (Parser.print grammar));
@@ -314,12 +314,11 @@ let main =
   if Sys.os_type = "Unix" then Sys.set_signal Sys.sigpipe
     (Sys.Signal_handle
        (fun _ -> prerr_endline "Broken Pipe (coqtop died ?)"; exit 1));
-  let idetop_name = System.get_toplevel_path "coqidetop" in
-  let input_file, args  = match Sys.argv with
-    | [| _; f |] -> f, []
-    | [| _; f; args |] ->
+  let idetop_name, input_file, args  = match Sys.argv with
+    | [| _; p; f |] -> p, f, []
+    | [| _; p; f; args |] ->
         let args = Str.split (Str.regexp " ") args in
-        f, args
+        p, f, args
     | _ -> usage () in
   let def_coqtop_args = ["--xml_format=Ppcmds"] in
   let coqtop_args = Array.of_list(def_coqtop_args @ args) in


### PR DESCRIPTION
This PR fixes #14306 ~~in a very maintainable way~~.

Being only used for testing and nothing else, the `fake-ide` binary can go live in the test-suite/ directory. It'd be nice, if it fit into `test-suite/ide`, but I couldn't figure out how to do this. @ejgallego do you know how to do this? I don't know how to correctly write `test-suite/dune` and `test-suite/ide/dune` (if the latter is even necessary). Changing `./fake-ide.exe` to `ide/fake-ide.exe` in `test-suite/Makefile` would also be necessary.

Behavioral change: `fake-ide` now needs an additional cmd-line argument: the path where it can find `coqidetop`. Previously both binaries lived in the same folder, so this wasn't such a problem. Now this information has to be passed through by the Makefile.

Closes #14306
Succeeds #14611