### PR TITLE
simple congruence tactic

### DIFF
--- a/doc/changelog/04-tactics/14657-simple_congruence.rst
+++ b/doc/changelog/04-tactics/14657-simple_congruence.rst
@@ -1,0 +1,8 @@
+- **Added:**
+  :tacn:`simple congruence` tactic which works like :tacn:`congruence`
+  but does not unfold definitions.
+  (`#14657 <https://github.com/coq/coq/pull/14657>`_,
+  fixes `#13778 <https://github.com/coq/coq/issues/13778>`_
+  and `#5394 <https://github.com/coq/coq/issues/5394>`_
+  and `#13189 <https://github.com/coq/coq/issues/13189>`_,
+  by Andrej Dudenhefner).

--- a/doc/sphinx/proofs/automatic-tactics/logic.rst
+++ b/doc/sphinx/proofs/automatic-tactics/logic.rst
@@ -166,6 +166,10 @@ Solvers for logic and equality
    You may want to use :tacn:`assert` to add some lemmas as
    hypotheses so that :tacn:`congruence` can use them.
 
+   .. tacn:: simple congruence {? @natural } {? with {+ @one_term } }
+
+      Behaves like :tacn:`congruence`, but does not unfold definitions.
+
    .. example::
 
       .. coqtop:: reset all

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1119,11 +1119,12 @@ simple_tactic: [
 | REPLACE "subst" LIST1 hyp
 | WITH "subst" LIST0 hyp
 | DELETE "subst"
-| DELETE "congruence"
-| DELETE "congruence" natural
-| DELETE "congruence" "with" LIST1 constr
-| REPLACE "congruence" natural "with" LIST1 constr
+| DELETE "congruence" OPT natural
+| REPLACE "congruence" OPT natural "with" LIST1 constr
 | WITH "congruence" OPT natural OPT ( "with" LIST1 constr )
+| DELETE "simple" "congruence" OPT natural
+| REPLACE "simple" "congruence" OPT natural "with" LIST1 constr
+| WITH "simple" "congruence" OPT natural OPT ( "with" LIST1 constr )
 | DELETE "show" "ltac" "profile"
 | REPLACE "show" "ltac" "profile" "cutoff" integer
 | WITH "show" "ltac" "profile" OPT [ "cutoff" integer | string ]

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1465,10 +1465,10 @@ binder_interp: [
 
 simple_tactic: [
 | "btauto"
-| "congruence"
-| "congruence" natural
-| "congruence" "with" LIST1 constr
-| "congruence" natural "with" LIST1 constr
+| "congruence" OPT natural
+| "congruence" OPT natural "with" LIST1 constr
+| "simple" "congruence" OPT natural
+| "simple" "congruence" OPT natural "with" LIST1 constr
 | "f_equal"
 | "firstorder" OPT tactic firstorder_using
 | "firstorder" OPT tactic "with" LIST1 preident

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1825,6 +1825,7 @@ simple_tactic: [
 | "btauto"
 | "rtauto"
 | "congruence" OPT natural OPT ( "with" LIST1 one_term )
+| "simple" "congruence" OPT natural OPT ( "with" LIST1 one_term )
 | "f_equal"
 | "firstorder" OPT ltac_expr OPT ( "using" LIST1 qualid SEP "," ) OPT ( "with" LIST1 ident )
 | "gintuition" OPT ltac_expr

--- a/plugins/cc/cctac.mli
+++ b/plugins/cc/cctac.mli
@@ -12,8 +12,10 @@ open EConstr
 
 val proof_tac: Ccproof.proof -> unit Proofview.tactic
 
-val cc_tactic : int -> constr list ->  unit Proofview.tactic
+val cc_tactic : int -> constr list -> bool -> unit Proofview.tactic
 
 val congruence_tac : int -> constr list -> unit Proofview.tactic
+
+val simple_congruence_tac : int -> constr list -> unit Proofview.tactic
 
 val f_equal : unit Proofview.tactic

--- a/plugins/cc/g_congruence.mlg
+++ b/plugins/cc/g_congruence.mlg
@@ -21,11 +21,14 @@ DECLARE PLUGIN "cc_plugin"
 (* Tactic registration *)
 
 TACTIC EXTEND cc
-| [ "congruence" ] -> { congruence_tac 1000 [] }
-| [ "congruence" natural(n) ] -> { congruence_tac n [] }
-| [ "congruence" "with" ne_constr_list(l) ] -> { congruence_tac 1000 l }
-| [ "congruence" natural(n) "with" ne_constr_list(l) ] ->
-   { congruence_tac n l }
+| [ "congruence" natural_opt(n) ] ->
+   { congruence_tac (Option.default 1000 n) [] }
+| [ "congruence" natural_opt(n) "with" ne_constr_list(l) ] ->
+   { congruence_tac (Option.default 1000 n) l }
+| [ "simple" "congruence" natural_opt(n) ] ->
+   { simple_congruence_tac (Option.default 1000 n) [] }
+| [ "simple" "congruence" natural_opt(n) "with" ne_constr_list(l) ] ->
+   { simple_congruence_tac (Option.default 1000 n) l }
 END
 
 TACTIC EXTEND f_equal

--- a/test-suite/success/simple_congruence.v
+++ b/test-suite/success/simple_congruence.v
@@ -1,0 +1,112 @@
+Axiom P : Prop.
+Definition Q := True -> P.
+
+(* bug 13778, 5394 *)
+Goal Q -> Q.
+Proof.
+  intro.
+  Fail congruence.
+  simple congruence.
+Qed.
+
+Goal (not P) -> P -> False.
+Proof. simple congruence. Qed.
+
+Goal (P -> False) -> not P.
+Proof.
+  simple congruence.
+Qed.
+
+Fixpoint slow (n: nat): bool :=
+  match n with
+  | O => true
+  | S m => andb (slow m) (slow (pred m))
+  end.
+
+Parameter f: nat -> nat.
+
+Definition foo(n b: nat): Prop :=
+  if slow n then (forall a, f a = f b) else True.
+
+(* fail fast symbolically *)
+(* bug 13189 *)
+Goal forall a b, foo 27 b -> f a = f b.
+Proof.
+  Timeout 1 Fail Time simple congruence.
+  (* Fail Timeout 1 Time congruence. *)
+Admitted.
+
+(* succeed fast symbolically *)
+(* bug 13189 *)
+Goal forall a b, foo 29 b -> f b = f a -> f a = f b.
+Proof.
+  (* Fail Timeout 1 Time congruence. *)
+  Timeout 1 simple congruence.
+Qed.
+
+Goal True -> not True -> P.
+Proof. simple congruence. Qed.
+
+(* consider final not *)
+Goal False -> not True.
+Proof. simple congruence. Qed.
+
+(* consider final not *)
+Goal not (true = false).
+Proof. simple congruence. Qed.
+
+Fixpoint stupid (n : nat) : unit :=
+match n with
+| 0 => tt
+| S n =>
+  let () := stupid n in
+  let () := stupid n in
+  tt
+end.
+
+(* do not try to unify 23 with stupid 23 *)
+Goal 23 = 23 -> stupid 23 = stupid 23.
+Proof. Timeout 1 simple congruence. Qed.
+
+Inductive Fin : nat -> Set :=
+| F1 : forall n : nat, Fin (S n)
+| FS : forall n : nat, Fin n -> Fin (S n).
+
+(* indexed inductives *)
+Goal forall n (f : Fin n), FS n f = F1 n -> False.
+Proof. intros n f H. simple congruence. Qed.
+
+Axiom R : Prop.
+Axiom R' : Prop.
+
+Goal (not P) -> not P.
+Proof. simple congruence. Qed.
+
+Goal (P -> False) -> P -> False.
+Proof. simple congruence. Qed.
+
+Goal (not (true = true)) -> P.
+Proof. simple congruence. Qed.
+
+Goal Q -> (Q = R) -> R.
+Proof. simple congruence. Qed.
+
+(* unfortunately, common usecase *)
+Goal P -> Q.
+Proof.
+  Fail simple congruence.
+  repeat intro. simple congruence.
+Qed.
+
+(* bug 13778 *)
+Goal R -> (R = not P) -> not P.
+Proof.
+  Fail congruence.
+  simple congruence.
+Qed.
+
+Definition per_unit := forall u, match u with tt => True end.
+
+(* bug 5394 *)
+Goal per_unit -> per_unit.
+Proof. simple congruence. Qed.


### PR DESCRIPTION
This PR proposes a `simple congruence` tactic (similar to the `simple tac` family).
`simple congruence` is (almost purely symbolic) `congruence` without delta-reduction.
This is fast (see performance issues below) and has no unexpected unfolding issues (see bugs below).

This is more clear cut than PR #14612, which uses (somewhat unclear) heuristics.

The added test shows common use cases and advantages over `congruence`.
Also, this opens up design space (see #3549) to strengthen `congruence` with more reasoning wrt. delta-reduction.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Closes #13778, closes #5394, closes #13189

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
