### PR TITLE
Add `coq_record_update`, `coqutil`, `kami`, `riscv_coq` to CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -654,10 +654,32 @@ library:ci-argosy:
 library:ci-bbv:
   extends: .ci-template
 
+library:ci-coqutil:
+  extends: .ci-template-flambda
+
+library:ci-kami:
+  extends: .ci-template-flambda
+
+library:ci-coq_record_update:
+  extends: .ci-template-flambda
+
+library:ci-riscv_coq:
+  extends: .ci-template-flambda
+  stage: stage-3
+  needs:
+  - build:edge+flambda
+  - library:ci-coqutil
+
 library:ci-bedrock2:
   extends: .ci-template-flambda
   variables:
     NJOBS: "1"
+  stage: stage-4
+  needs:
+  - build:edge+flambda
+  - library:ci-coq_record_update
+  - library:ci-kami
+  - library:ci-riscv_coq
 
 library:ci-color:
   extends: .ci-template-flambda

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -16,19 +16,22 @@ CI_TARGETS= \
     ci-bignums \
     ci-color \
     ci-compcert \
+    ci-coq_record_update \
     ci-coq_dpdgraph \
-    ci-coqtail \
-    ci-coquelicot \
-    ci-corn \
-    ci-cross_crypto \
     ci-coq_performance_tests \
     ci-coq_tools \
+    ci-coqhammer \
     ci-coqprime \
+    ci-coqtail \
+    ci-coquelicot \
+    ci-coqutil \
+    ci-corn \
+    ci-cross_crypto \
     ci-deriving \
     ci-elpi \
     ci-engine_bench \
-    ci-ext_lib \
     ci-equations \
+    ci-ext_lib \
     ci-fcsl_pcm \
     ci-fiat_crypto \
     ci-fiat_crypto_legacy \
@@ -38,9 +41,9 @@ CI_TARGETS= \
     ci-fourcolor \
     ci-gappa \
     ci-geocoq \
-    ci-coqhammer \
     ci-hott \
     ci-iris \
+    ci-kami \
     ci-math_classes \
     ci-mathcomp \
     ci-mczify \
@@ -54,12 +57,13 @@ CI_TARGETS= \
     ci-reduction_effects \
     ci-relation_algebra \
     ci-rewriter \
+    ci-riscv_coq \
     ci-sf \
     ci-simple_io \
     ci-stdlib2 \
     ci-tlc \
-    ci-unimath \
     ci-unicoq \
+    ci-unimath \
     ci-verdi_raft \
     ci-vscoq \
     ci-vst
@@ -102,6 +106,8 @@ ci-vst: ci-flocq
 
 ci-compcert: ci-menhir ci-flocq
 ci-gappa: ci-flocq
+
+ci-riscv_coq: ci-coqutil
 
 # Generic rule, we use make to ease CI integration
 $(CI_TARGETS): ci-%:

--- a/dev/ci/README-users.md
+++ b/dev/ci/README-users.md
@@ -71,13 +71,15 @@ as "plugins"] do have some special requirements:
 
 ### Add your project by submitting a pull request
 
-Add a new `ci-mydev.sh` script to [`dev/ci`](.); set the corresponding
-variables in [`ci-basic-overlay.sh`](ci-basic-overlay.sh); add the
-corresponding target to [`Makefile.ci`](../../Makefile.ci) and a new job to
-[`.gitlab-ci.yml`](../../.gitlab-ci.yml) so that this new target is run.
-Have a look at [#7656](https://github.com/coq/coq/pull/7656/files) for an
-example. **Do not hesitate to submit an incomplete pull request if you need
-help to finish it.**
+Add a new `ci-mydev.sh` script to [`dev/ci`](.); make sure to mark it
+as executable `chmod +x ci-mydev.sh`; set the corresponding variables
+in [`ci-basic-overlay.sh`](ci-basic-overlay.sh); add the corresponding
+target to [`Makefile.ci`](../../Makefile.ci) and a new job to
+[`.gitlab-ci.yml`](../../.gitlab-ci.yml) so that this new target is
+run.  Have a look at
+[#7656](https://github.com/coq/coq/pull/7656/files) for an
+example. **Do not hesitate to submit an incomplete pull request if you
+need help to finish it.**
 
 You may also be interested in having your project tested in our
 performance benchmark. Currently this is done by providing an OPAM package

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -314,3 +314,23 @@ project deriving "https://github.com/arthuraa/deriving" "master"
 # VsCoq
 ########################################################################
 project vscoq "https://github.com/maximedenes/vscoq" document-manager
+
+########################################################################
+# coqutil
+########################################################################
+project coqutil "https://github.com/mit-plv/coqutil" "master"
+
+########################################################################
+# kami
+########################################################################
+project kami "https://github.com/mit-plv/kami" "rv32i"
+
+########################################################################
+# riscv-coq
+########################################################################
+project riscv_coq "https://github.com/mit-plv/riscv-coq/" "master"
+
+########################################################################
+# coq-record-update
+########################################################################
+project coq_record_update "https://github.com/tchajed/coq-record-update" "master"

--- a/dev/ci/ci-coq_record_update.sh
+++ b/dev/ci/ci-coq_record_update.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+git_download coq_record_update
+
+( cd "${CI_BUILD_DIR}/coq_record_update"
+  make
+  make install
+)

--- a/dev/ci/ci-coqutil.sh
+++ b/dev/ci/ci-coqutil.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+git_download coqutil
+
+( cd "${CI_BUILD_DIR}/coqutil"
+  make
+  make install
+)

--- a/dev/ci/ci-kami.sh
+++ b/dev/ci/ci-kami.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+git_download kami
+
+export COQEXTRAFLAGS='-native-compiler no'
+( cd "${CI_BUILD_DIR}/kami"
+  make
+  make install
+)

--- a/dev/ci/ci-riscv_coq.sh
+++ b/dev/ci/ci-riscv_coq.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+git_download riscv_coq
+
+( cd "${CI_BUILD_DIR}/riscv_coq"
+  make all EXTERNAL_DEPENDENCIES=1
+  make install
+)


### PR DESCRIPTION
The following CI jobs were added:
 - `ci-coq_record_update`
 - `ci-coqutil`
 -  `ci-kami`
 -  `ci-riscv_coq`

These are the dependencies of the job `ci-bedrock2`. All jobs have been put into the correct stage together with their dependencies.

However, due to the makefile of bedrock2 working incorrectly without submodules, we don't use these dependencies for building bedrock2. This has been reported as mit-plv/bedrock2#192.
