### PR TITLE
Allow existing instances of existing classes of primitive projections, fix #14652

### DIFF
--- a/doc/changelog/07-vernac-commands-and-options/14664-alizter+fix-14652.rst
+++ b/doc/changelog/07-vernac-commands-and-options/14664-alizter+fix-14652.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Incorrect de Bruijn index handling in vernac class decleration, preventing users from marking existing instances of existing classes which are primitive projections.
+  (`#14664 <https://github.com/coq/coq/pull/14664>`_,
+  fixes `#14652 <https://github.com/coq/coq/issues/14652>`_,
+  by Ali Caglayan and Hugo Herbelin).

--- a/test-suite/bugs/closed/bug_14652.v
+++ b/test-suite/bugs/closed/bug_14652.v
@@ -1,0 +1,33 @@
+Record myRecord := {
+  my_class : Type ;
+}.
+
+Fail Instance my_instance : forall x, my_class x.
+
+Existing Class my_class.
+
+Instance my_instance : forall x, my_class x. Abort.
+
+Definition my_existing_instance : forall x, my_class x. Admitted.
+
+#[export]
+Existing Instance my_existing_instance.
+
+Set Primitive Projections.
+
+Record myOtherRecord := {
+  my_other_class : Type ;
+}.
+
+Fail Instance my_other_instance : forall x, my_other_class x.
+
+Existing Class my_other_class.
+
+Instance my_other_instance : forall x, my_other_class x. Abort.
+
+Definition my_other_existing_instance : forall x, my_other_class x. Admitted.
+
+(* ??? *)
+(* Used to be: Constant does not build instances of a declared type class. *)
+#[export]
+Existing Instance my_other_existing_instance.

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -306,8 +306,8 @@ let existing_instance glob g info =
   let env = Global.env() in
   let sigma = Evd.from_env env in
   let instance, _ = Typeops.type_of_global_in_context env c in
-  let _, r = Term.decompose_prod_assum instance in
-    match class_of_constr env sigma (EConstr.of_constr r) with
+  let ctx, r = Term.decompose_prod_assum instance in
+    match class_of_constr (Environ.push_rel_context ctx env) sigma (EConstr.of_constr r) with
       | Some (_, ((tc,u), _)) -> add_instance tc info glob c
       | None -> user_err ?loc:g.CAst.loc
                          ~hdr:"declare_instance"


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->
It was pointed out in #14652 by @herbelin that the is a bug with de Bruijn indices in `vernac/classes.v`. This PR implements the suggested change and adds #14652 to the test-suite. This allows for primitive projections to be declared as existing classes, and terms of those classes to be declared as existing instances which wasn't possible before.

Running the test-suite gives only one error:
```
    complexity/pretyping.v...Error! (should run faster (168 >= 150))
```
So it seems performance took a hit for some reason. Not sure why. This was on my machine however, so we will see what the test-suite on the CI says. 

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #14652


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.
- [x] Added **changelog**.


