### PR TITLE
Compromise for printing module-bound names in #5622 and printing part of #14505

### DIFF
--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -307,8 +307,25 @@ let extern_evar n l = CEvar (n,l)
     For instance, in the debugger the tables of global references
     may be inaccurate *)
 
+let rec dirpath_of_modpath = function
+  | MPfile dp -> dp
+  | MPbound mbid -> let (_,id,_) = MBId.repr mbid in DirPath.make [id]
+  | MPdot (t, l) -> Libnames.add_dirpath_suffix (dirpath_of_modpath t) (Label.to_id l)
+
+let path_of_global = function
+  | GlobRef.VarRef id -> Libnames.make_path DirPath.empty id
+  (* We rely on the tacite invariant that the label of a constant is used to build its internal name *)
+  | GlobRef.ConstRef cst -> Libnames.make_path (dirpath_of_modpath (Constant.modpath cst)) (Label.to_id (Constant.label cst))
+  (* We rely on the tacite invariant that an inductive block inherits the name of its first type *)
+  | GlobRef.IndRef (ind,1) -> Libnames.make_path (dirpath_of_modpath (MutInd.modpath ind)) (Label.to_id (MutInd.label ind))
+  (* These are hacks *)
+  | GlobRef.IndRef (ind,n) -> Libnames.make_path (dirpath_of_modpath (MutInd.modpath ind)) (Id.of_string_soft ("<inductive:" ^ Label.to_string (MutInd.label ind) ^ ":" ^ string_of_int n ^ ">"))
+  | GlobRef.ConstructRef ((ind,1),p) -> Libnames.make_path (dirpath_of_modpath (MutInd.modpath ind)) (Id.of_string_soft ("<constructor:" ^ Label.to_string (MutInd.label ind) ^ ":" ^ string_of_int (p+1) ^ ">"))
+  | GlobRef.ConstructRef ((ind,n),p) -> Libnames.make_path (dirpath_of_modpath (MutInd.modpath ind)) (Id.of_string_soft ("<constructor:" ^ Label.to_string (MutInd.label ind) ^ ":" ^ string_of_int n ^ ":" ^ string_of_int (p+1) ^ ">"))
+
 let default_extern_reference ?loc vars r =
-  Nametab.shortest_qualid_of_global ?loc vars r
+  try Nametab.shortest_qualid_of_global ?loc vars r
+  with Not_found when GlobRef.is_bound r -> qualid_of_path (path_of_global r)
 
 let my_extern_reference = ref default_extern_reference
 

--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -1090,6 +1090,11 @@ module GlobRef = struct
     let hash gr = GlobRefInternal.global_hash_gen Constant.SyntacticOrd.hash Ind.SyntacticOrd.hash Construct.SyntacticOrd.hash gr
   end
 
+  let is_bound = function
+  | VarRef _ -> false
+  | ConstRef cst -> ModPath.is_bound (Constant.modpath cst)
+  | IndRef (ind,_) | ConstructRef ((ind,_),_) -> ModPath.is_bound (MutInd.modpath ind)
+
   module Map = HMap.Make(CanOrd)
   module Set = Map.Set
 

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -702,6 +702,8 @@ module GlobRef : sig
 
   val equal : t -> t -> bool
 
+  val is_bound : t -> bool
+
   include QNameS with type t := t
 
   module Set_env : CSig.SetS with type elt = t

--- a/test-suite/bugs/closed/bug_5622.v
+++ b/test-suite/bugs/closed/bug_5622.v
@@ -1,0 +1,7 @@
+Module Type HasType.
+  Axiom t:Type.
+End HasType.
+
+(* This should fail graciously *)
+Fail Module M (T1:HasType) <: HasType
+  with Definition t := Nat.mul T1.t T1.t.


### PR DESCRIPTION
**Kind:** Compromise to avoid an anomaly

When printing errors in the context of a module parameter, the nametab is missing, so we cannot print neither a shortest qualid nor the names of inductive types and constructors.

We show ugly "unknown-inductive" and "unknown-constructor" rather than failing with `Not_found` as in #5622 or in the superficial part of #14505.

- [x] Added / updated **test-suite** (I put a test for the non "ugly" part)
- [ ] Added **changelog** (unsure it is worth communicating on it)
