### PR TITLE
Fixes #3527: preserves type of coercions through functor instantiation

### DIFF
--- a/doc/changelog/02-specification-language/14668-master+fix3527-coercion-through-functor.rst
+++ b/doc/changelog/02-specification-language/14668-master+fix3527-coercion-through-functor.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Source and target of coercions preserved by module instantiation
+  (`#14668 <https://github.com/coq/coq/pull/14668>`_,
+  fixes `#3527 <https://github.com/coq/coq/issues/3527>`_,
+  by Hugo Herbelin).

--- a/pretyping/coercionops.ml
+++ b/pretyping/coercionops.ml
@@ -73,6 +73,7 @@ module CoeTypMap = GlobRef.Map_env
 
 type coe_info_typ = {
   coe_value : GlobRef.t;
+  coe_typ : Constr.t;
   coe_local : bool;
   coe_is_identity : bool;
   coe_is_projection : Projection.Repr.t option;
@@ -371,13 +372,14 @@ let add_coercion_in_graph env sigma ic =
 let subst_coercion subst c =
   let env = Global.env () in
   let coe = subst_coe_typ subst c.coe_value in
+  let typ = subst_mps subst c.coe_typ in
   let cls = subst_cl_typ env subst c.coe_source in
   let clt = subst_cl_typ env subst c.coe_target in
   let clp = Option.Smart.map (subst_proj_repr subst) c.coe_is_projection in
   if c.coe_value == coe && c.coe_source == cls && c.coe_target == clt &&
      c.coe_is_projection == clp
   then c
-  else { c with coe_value = coe; coe_source = cls; coe_target = clt;
+  else { c with coe_value = coe; coe_typ = typ; coe_source = cls; coe_target = clt;
                 coe_is_projection = clp; }
 
 (* Computation of the class arity *)

--- a/pretyping/coercionops.mli
+++ b/pretyping/coercionops.mli
@@ -37,6 +37,7 @@ type coe_typ = GlobRef.t
 (** This is the type of infos for declared coercions *)
 type coe_info_typ = {
   coe_value : GlobRef.t;
+  coe_typ : Constr.t;
   coe_local : bool;
   coe_is_identity : bool;
   coe_is_projection : Projection.Repr.t option;

--- a/test-suite/bugs/closed/bug_3527.v
+++ b/test-suite/bugs/closed/bug_3527.v
@@ -1,0 +1,26 @@
+Set Implicit Arguments.
+Record Category := { obj :> Type ; hom :> obj -> obj -> Type }.
+Record > PackagedHom (C : Category) := { x : C ; y : C ; unpackage :> C x y }.
+Module Export FMap.
+  Record Functor (C D : Category) := { fobj : C -> D ; map : forall x y, C x y -> D (fobj x) (fobj y) }.
+End FMap.
+Definition mapT1 {C D} (F : Functor C D) := forall x y, C x y -> D (fobj F x) (fobj F y).
+Definition mapT2 {C D} (F : Functor C D) := forall m : PackagedHom C, D (fobj F m.(x)) (fobj F m.(y)).
+Definition annoying_helper {C D F} (map : @ mapT1 C D F) : @ mapT2 C D F := fun m => map _ _ m.
+Coercion annoying_helper : mapT1 >-> mapT2.
+Identity Coercion unfold_mapT2 : mapT2 >-> Funclass.
+Module Type mapT.
+  Definition map {C D} (F : Functor C D) : mapT1 F := map F.
+End mapT.
+Module MapCoercion (T : mapT).
+  Coercion T.map : Functor >-> mapT1.
+End MapCoercion.
+Module Export FunctorMapCoercion := MapCoercion FMap.
+Section foo.
+  Context C D (F : Functor C D) x y (m : C x y).
+  Set Printing All.
+  Check F _. (* @ annoying_helper (@ map C D F) ?48
+     : forall F0 : Functor (@ map C D F) ?48,
+       @ mapT1 (@ map C D F) ?48 F0 -> @ mapT2 (@ map C D F) ?48 F0 *)
+  Definition foo k := F k.
+End foo.


### PR DESCRIPTION
**Kind:** fix

We preserve the type of the coercions in the coercion table, so that even after module instantiation we know the   type the way it was originally formulated, explicitly showing the source and target.

Fixes / closes #3527

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
