### PR TITLE
Fixes #7228: anomaly with Set Extraction Conservative Types on singletons

### DIFF
--- a/doc/changelog/07-vernac-commands-and-options/14669-master+fix7228-anomaly-extraction-singleton-conservative.rst
+++ b/doc/changelog/07-vernac-commands-and-options/14669-master+fix7228-anomaly-extraction-singleton-conservative.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  anomaly with :flag:`Extraction Conservative Types` when extracting
+  pattern-matching on singleton types
+  (`#14669 <https://github.com/coq/coq/pull/14669>`_,
+  fixes `#3527 <https://github.com/coq/coq/issues/3527>`_,
+  by Hugo Herbelin).

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -488,7 +488,7 @@ and extract_really_ind env kn mib =
         if p.ip_logical then raise (I Standard);
         if not (Int.equal (Array.length p.ip_types) 1) then raise (I Standard);
         let typ = p.ip_types.(0) in
-        let l = List.filter (fun t -> not (isTdummy (expand env t))) typ in
+        let l = if conservative_types () then [] else List.filter (fun t -> not (isTdummy (expand env t))) typ in
         if not (keep_singleton ()) &&
             Int.equal (List.length l) 1 && not (type_mem_kn kn (List.hd l))
         then raise (I Singleton);

--- a/test-suite/bugs/closed/bug_7228.v
+++ b/test-suite/bugs/closed/bug_7228.v
@@ -1,0 +1,7 @@
+Require Extraction.
+Set Extraction Conservative Types.
+
+Inductive data := Data : forall (T:Type), T -> data.
+Definition t_of d := match d with Data t _ => t end.
+Definition v_of (d : data) := match d return t_of d with Data _ v => v end.
+Extraction v_of.


### PR DESCRIPTION
**Kind:** fix

We fix it by taking into account the `Extraction Conservative Types` option when computing if an inductive type is singleton.

Fixes #7228
Fixes (probably) #12831

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
