### PR TITLE
Ad hoc fix for #12298: flushing defined Ltac evars in tactical abstract

### DIFF
--- a/doc/changelog/04-tactics/14671-master+partial-fix12298-abstract-ltac-value-with-unflushed-evar.rst
+++ b/doc/changelog/04-tactics/14671-master+partial-fix12298-abstract-ltac-value-with-unflushed-evar.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  :tacn:`abstract` more robust with respect to Ltac `constr` bindings containing
+  existential variables
+  (`#14671 <https://github.com/coq/coq/pull/14671>`_,
+  fixes `#10796 <https://github.com/coq/coq/issues/10796>`_,
+  by Hugo Herbelin).

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -309,6 +309,23 @@ let extend_values_with_bindings (ln,lm) lfun =
   let accu = lfun +++ accu in
   Id.Map.fold (fun id c accu -> Id.Map.add id (of_cub c) accu) lm accu
 
+let flush_value_evars sigma v =
+  if has_type v (topwit wit_constr) then
+    let c = out_gen (topwit wit_constr) v in
+    let c =
+      try EConstr.of_constr (Evarutil.flush_and_check_evars sigma c)
+      with Evarutil.Uninstantiated_evar _ ->
+        (* How to tell to not use this binding anymore? *)
+        (* If it is used it might fail because of the evar *)
+        (* But this has to work if it is not used *)
+        c
+    in
+    in_gen (topwit wit_constr) c
+  else v
+
+let flush_ist_evars sigma ist =
+  { ist with lfun = Id.Map.map (flush_value_evars sigma) ist.lfun }
+
 (***************************************************************************)
 (* Evaluation/interpretation *)
 
@@ -1148,7 +1165,7 @@ and eval_tactic_ist ist tac : unit Proofview.tactic =
       Profile_ltac.do_profile "eval_tactic:TacAbstract" trace
         (catch_error_tac trace begin
       Proofview.Goal.enter begin fun gl -> Abstract.tclABSTRACT
-        (Option.map (interp_ident ist (pf_env gl) (project gl)) ido) (interp_tactic ist t)
+        (Option.map (interp_ident ist (pf_env gl) (project gl)) ido) (interp_tactic (flush_ist_evars (project gl) ist) t)
       end end)
   | TacThen (t1,t) ->
       Tacticals.New.tclTHEN (interp_tactic ist t1) (interp_tactic ist t)

--- a/test-suite/bugs/closed/bug_12298.v
+++ b/test-suite/bugs/closed/bug_12298.v
@@ -1,0 +1,9 @@
+Goal True -> True.
+  simple refine (let H : True -> True := _ in
+                 _);
+    [ intro x; exact x | ];
+    lazymatch goal with
+    | [ H := ?v |- _ ]
+      => abstract exact v
+    end.
+Qed.


### PR DESCRIPTION
**Kind:** fix

This is an ad hoc fix for #12298 to mitigate the difficult interaction between `abstract` and defined existential variables occurring in Ltac values.

Fixes / closes #12298

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
