### PR TITLE
Do not apply discriminated unfold hints on arbitrary goals.

### DIFF
--- a/doc/changelog/04-tactics/14679-hint-unfold-head-constant-index.rst
+++ b/doc/changelog/04-tactics/14679-hint-unfold-head-constant-index.rst
@@ -1,0 +1,25 @@
+- **Changed:**
+  :cmd:`Hint Unfold` in discriminated databases now respects its
+  specification, namely that a constant may be unfolded only when
+  it is the head of the goal. The previous behavior was to perform
+  unfolding on any goal, without any limitation.
+
+  An unexpected side-effect of this was that a database that
+  contained ``Unfold`` hints would sometimes trigger silent
+  strong βι-normalization of the goal. Indeed, :tacn:`unfold`
+  performs such a normalization regardless of the presence of its
+  argument in the goal. This does introduce a bit of backwards
+  incompatibility, but it occurs in very specific situations
+  and is easily circumvented. Since by default hint bases
+  are not discriminated, it means that incompatibilities are
+  typically observed when adding unfold hints to the typeclass
+  database.
+
+  In order to recover the previous behavior, it is enough
+  to replace instances of ``Hint Unfold foo.``
+  with ``Hint Extern 4 => progress (unfold foo).``. A less compatible but
+  finer-grained change can be achieved by only adding the missing normalization
+  phase with ``Hint Extern 4 => progress (lazy beta iota).``.
+  (`#14679 <https://github.com/coq/coq/pull/14679>`_,
+  fixes `#14874 <https://github.com/coq/coq/issues/14874>`_,
+  by Pierre-Marie Pédrot).

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -312,11 +312,6 @@ let lookup_tacs env sigma concl se =
   let sl' = List.stable_sort pri_order_int l' in
   List.merge pri_order_int se.sentry_nopat sl'
 
-let is_transparent_gr ts = let open GlobRef in function
-  | VarRef id -> TransparentState.is_transparent_variable ts id
-  | ConstRef cst -> TransparentState.is_transparent_constant ts cst
-  | IndRef _ | ConstructRef _ -> false
-
 let strip_params env sigma c =
   match EConstr.kind sigma c with
   | App (f, args) ->
@@ -653,18 +648,9 @@ struct
     | Give_exact _ -> true
     | _ -> false
 
-  let is_unfold = function
-    | Unfold_nth _ -> true
-    | _ -> false
-
   let addkv gr id v db =
     let idv = id, { v with db = db.hintdb_name } in
-    let k = match gr with
-      | Some gr -> if db.use_dn && is_transparent_gr db.hintdb_state gr &&
-          is_unfold v.code.obj then None else Some gr
-      | None -> None
-    in
-      match k with
+      match gr with
       | None ->
           let is_present (_, (_, v')) = KerName.equal v.code.uid v'.code.uid in
           if not (List.exists is_present db.hintdb_nopat) then

--- a/test-suite/success/hint_discr_unfold.v
+++ b/test-suite/success/hint_discr_unfold.v
@@ -1,0 +1,40 @@
+Create HintDb foo discriminated.
+
+Definition myid (A : Prop) := A.
+
+Section Test1.
+
+#[local] Hint Constructors True : foo.
+
+Lemma test1 : myid True.
+Proof.
+Fail typeclasses eauto with foo.
+Abort.
+
+End Test1.
+
+Section Test2.
+
+Definition hide (A : Prop) := A.
+
+#[local] Hint Extern 1 => match goal with [ |- hide True ] => constructor end : foo.
+#[local] Hint Unfold myid : foo.
+
+Lemma test2 : hide (myid True).
+Proof.
+Fail typeclasses eauto with foo.
+Abort.
+
+End Test2.
+
+Section Test3.
+
+#[local] Hint Constructors True : foo.
+#[local] Hint Unfold myid : foo.
+
+Lemma test3 : myid True.
+Proof.
+typeclasses eauto with foo.
+Qed.
+
+End Test3.


### PR DESCRIPTION
The current behaviour was to indiscriminately try to apply on any goal unfold hints for transparent constants from discriminated databases, since they were not indexed by the head constant. In particular, this might have unfolded the constant even if it was at the head of the goal, contrarily to what the documentation claimed.

I think it was written this way out of fear of the dnet pattern algorithm. In discriminated mode, transparent constants are considered to match everything, but maybe the author of the code was confused by the complexity of the dnet implementation.

This patch changes the semantics of auto tactics in fringe cases, and should be mostly backwards compatible.

Fixes #14874: Exponential blowup with Hint Unfold.
