### PR TITLE
added test-suite/ide/fake_ide.exe to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ test-suite/output/*.out.real
 test-suite/oUnit-anon.cache
 test-suite/redirect_test.out
 test-suite/unit-tests/**/*.test
+test-suite/ide/fake_ide.exe
 
 # documentation
 


### PR DESCRIPTION
At the moment `test-suite/ide/fake_ide.exe` gets built when making the test-suite. This is from #14656.

We now .gitignore it.