### PR TITLE
Cached term in congruence

### DIFF
--- a/doc/changelog/04-tactics/14683-fast_congruence.rst
+++ b/doc/changelog/04-tactics/14683-fast_congruence.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Added caching to congruence initialization to avoid quadratic runtime.
+  (`#14683 <https://github.com/coq/coq/pull/14683>`_,
+  fixes `#5548 <https://github.com/coq/coq/issues/5548>`_,
+  by Andrej Dudenhefner).

--- a/plugins/cc/ccproof.mli
+++ b/plugins/cc/ccproof.mli
@@ -14,16 +14,16 @@ open Constr
 type rule=
     Ax of constr
   | SymAx of constr
-  | Refl of term
+  | Refl of ATerm.t
   | Trans of proof*proof
   | Congr of proof*proof
   | Inject of proof*pconstructor*int*int
 and proof =
-    private {p_lhs:term;p_rhs:term;p_rule:rule}
+    private {p_lhs:ATerm.t;p_rhs:ATerm.t;p_rule:rule}
 
 (** Proof smart constructors *)
 
-val prefl:term -> proof
+val prefl:ATerm.t -> proof
 
 val pcongr: proof -> proof -> proof
 
@@ -31,10 +31,10 @@ val ptrans: proof -> proof -> proof
 
 val psym: proof -> proof
 
-val pax : (Ccalgo.term * Ccalgo.term) Ccalgo.Constrhash.t ->
+val pax : (ATerm.t * ATerm.t) Ccalgo.Constrhash.t ->
            Ccalgo.Constrhash.key -> proof
 
-val psymax :  (Ccalgo.term * Ccalgo.term) Ccalgo.Constrhash.t ->
+val psymax :  (ATerm.t * ATerm.t) Ccalgo.Constrhash.t ->
            Ccalgo.Constrhash.key -> proof
 
 val pinject :  proof -> pconstructor -> int -> int -> proof

--- a/test-suite/complexity/bug_5548.v
+++ b/test-suite/complexity/bug_5548.v
@@ -1,0 +1,9 @@
+Axiom f: nat -> Type.
+
+(* Expected time < 1.00s *)
+Goal forall o, let n := 10*10*10*8 in f n ->
+  o = Some tt -> o = None -> False.
+Proof.
+  cbv.
+  Time congruence.
+Qed.


### PR DESCRIPTION
Hashing in `congruence` exposes quadratic behavior on large terms.
This PR implements a (lazy) caching `ATerm` structure to make hasing and conversion to `constr` linear.

Fixes / closes #5548

#### Example

```coq
Axiom f: nat -> Type.

Goal forall o, let n := 10*10*10*10 in f n ->
  o = Some tt -> o = None -> False.
Proof.
  cbv.
  Timeout 1 time congruence. (* before: 4.001 secs / after:  0.038 secs *)
Qed.
```

`f_equal` which is based on `congruence` suffers from similar problem
```coq
Goal let n := 10*10*10*10 in forall (x : f n) y,
  x = y ->
  Some x = Some y.
Proof.
  cbv. intros.
  Timeout 1 time f_equal.  (* before: 4.612 secs / after: 0.648 secs *)
  assumption.
Qed.
```

For example, if `congruence` encounters the term `S (S (S O))` it needs to consider linearly many subterms.
Hashing each individual subterm separately requires (for each subterm) linearly many hashes.
If those intermediate hashes are cached as this PR proposes quadratic runtime is avoided.


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.