### PR TITLE
Added locality attributes for Typeclasses Opaque and Transparent

### DIFF
--- a/dev/ci/user-overlays/14685-SkySkimmer-alizter+locality-typeclasses-opaque.sh
+++ b/dev/ci/user-overlays/14685-SkySkimmer-alizter+locality-typeclasses-opaque.sh
@@ -1,0 +1,1 @@
+overlay equations https://github.com/SkySkimmer/Coq-Equations alizter+locality-typeclasses-opaque 14685

--- a/doc/changelog/07-vernac-commands-and-options/14685-alizter+locality-typeclasses-opaque.rst
+++ b/doc/changelog/07-vernac-commands-and-options/14685-alizter+locality-typeclasses-opaque.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  :cmd:`Typeclasses Transparent` and :cmd:`Typeclasses Opaque` support ``#[local]``, ``#[export]`` and ``#[global]`` attributes
+  (`#14685 <https://github.com/coq/coq/pull/14685>`_,
+  fixes `#14513 <https://github.com/coq/coq/issues/14513>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/addendum/type-classes.rst
+++ b/doc/sphinx/addendum/type-classes.rst
@@ -520,6 +520,17 @@ type, like:
 .. coqdoc::
    Definition relation A := A -> A -> Prop.
 
+.. versionadded:: 8.15
+
+   :cmd:`Typeclasses Transparent` and :cmd:`Typeclasses Opaque`
+   support locality attributes like :cmd:`Hint <Hint Opaque>` commands.
+
+.. deprecated:: 8.15
+
+   The default value for typeclass transparency hints will change in a future
+   release. Hints added outside of sections without an explicit
+   locality are now deprecated. We recommend using :attr:`export`
+   where possible.
 
 Settings
 ~~~~~~~~

--- a/plugins/ltac/g_class.mlg
+++ b/plugins/ltac/g_class.mlg
@@ -13,28 +13,7 @@
 open Class_tactics
 open Stdarg
 open Tacarg
-open Tacred
 open Classes
-
-let warn_deprecated_tc_transparency_without_locality =
-  CWarnings.create ~name:"deprecated-typeclasses-transparency-without-locality" ~category:"deprecated"
-    Pp.(fun () -> strbrk
-  "The default value for Typeclasses Opaque and Typeclasses \
-   Transparent locality is currently \"local\" in a section and \
-   \"global\" otherwise, but is scheduled to change in a future \
-   release. For the time being, adding typeclass transparency hints outside of \
-   sections without specifying an explicit locality attribute is \
-   therefore deprecated. It is recommended to use \"export\" whenever \
-   possible. Use the attributes #[local], #[global] and #[export] \
-   depending on your choice. For example: \"#[export] Typeclasses Transparent foo.\"")
-
-let default_tc_transparency_locality () =
-  if Global.sections_are_opened () then Hints.Local
-  else
-    let () = warn_deprecated_tc_transparency_without_locality () in
-    Hints.SuperGlobal
-
-let tc_transparency_locality = Attributes.hint_locality ~default:default_tc_transparency_locality
 
 }
 
@@ -45,23 +24,15 @@ DECLARE PLUGIN "ltac_plugin"
 VERNAC COMMAND EXTEND Typeclasses_Unfold_Settings CLASSIFIED AS SIDEFF
 | #[ locality = tc_transparency_locality ]
   [ "Typeclasses" "Transparent" ne_reference_list(cl) ] -> {
-  let conv = List.map
-      (fun x -> evaluable_of_global_reference (Global.env ())
-          (Smartlocate.global_with_alias x))
-      cl
-  in
-  set_typeclass_transparency ~locality conv true }
+    set_typeclass_transparency_com ~locality cl true
+  }
 END
 
 VERNAC COMMAND EXTEND Typeclasses_Rigid_Settings CLASSIFIED AS SIDEFF
 | #[ locality = tc_transparency_locality ]
   [ "Typeclasses" "Opaque" ne_reference_list(cl) ] -> {
-  let conv = List.map
-      (fun x -> evaluable_of_global_reference (Global.env ())
-          (Smartlocate.global_with_alias x))
-      cl
-  in
-  set_typeclass_transparency ~locality conv false }
+    set_typeclass_transparency_com ~locality cl false
+  }
 END
 
 {

--- a/plugins/ltac/g_class.mlg
+++ b/plugins/ltac/g_class.mlg
@@ -13,6 +13,8 @@
 open Class_tactics
 open Stdarg
 open Tacarg
+open Tacred
+open Classes
 
 }
 
@@ -20,24 +22,26 @@ DECLARE PLUGIN "ltac_plugin"
 
 (** Options: depth, debug and transparency settings. *)
 
-{
-
-let set_transparency cl b =
-  List.iter (fun r ->
-    let gr = Smartlocate.global_with_alias r in
-    let ev = Tacred.evaluable_of_global_reference (Global.env ()) gr in
-      Classes.set_typeclass_transparency ev (Locality.make_section_locality None) b) cl
-
-}
-
 VERNAC COMMAND EXTEND Typeclasses_Unfold_Settings CLASSIFIED AS SIDEFF
-| [ "Typeclasses" "Transparent" ne_reference_list(cl) ] -> {
-    set_transparency cl true }
+| #[ locality = Attributes.really_hint_locality ]
+  [ "Typeclasses" "Transparent" ne_reference_list(cl) ] -> {
+  let conv = List.map
+      (fun x -> evaluable_of_global_reference (Global.env ())
+          (Smartlocate.global_with_alias x))
+      cl
+  in
+  set_typeclass_transparency ~locality conv true }
 END
 
 VERNAC COMMAND EXTEND Typeclasses_Rigid_Settings CLASSIFIED AS SIDEFF
-| [ "Typeclasses" "Opaque" ne_reference_list(cl) ] -> {
-    set_transparency cl false }
+| #[ locality = Attributes.really_hint_locality ]
+  [ "Typeclasses" "Opaque" ne_reference_list(cl) ] -> {
+  let conv = List.map
+      (fun x -> evaluable_of_global_reference (Global.env ())
+          (Smartlocate.global_with_alias x))
+      cl
+  in
+  set_typeclass_transparency ~locality conv false }
 END
 
 {

--- a/plugins/ltac/g_class.mlg
+++ b/plugins/ltac/g_class.mlg
@@ -16,6 +16,26 @@ open Tacarg
 open Tacred
 open Classes
 
+let warn_deprecated_tc_transparency_without_locality =
+  CWarnings.create ~name:"deprecated-typeclasses-transparency-without-locality" ~category:"deprecated"
+    Pp.(fun () -> strbrk
+  "The default value for Typeclasses Opaque and Typeclasses \
+   Transparent locality is currently \"local\" in a section and \
+   \"global\" otherwise, but is scheduled to change in a future \
+   release. For the time being, adding typeclass transparency hints outside of \
+   sections without specifying an explicit locality attribute is \
+   therefore deprecated. It is recommended to use \"export\" whenever \
+   possible. Use the attributes #[local], #[global] and #[export] \
+   depending on your choice. For example: \"#[export] Typeclasses Transparent foo.\"")
+
+let default_tc_transparency_locality () =
+  if Global.sections_are_opened () then Hints.Local
+  else
+    let () = warn_deprecated_tc_transparency_without_locality () in
+    Hints.SuperGlobal
+
+let tc_transparency_locality = Attributes.hint_locality ~default:default_tc_transparency_locality
+
 }
 
 DECLARE PLUGIN "ltac_plugin"
@@ -23,7 +43,7 @@ DECLARE PLUGIN "ltac_plugin"
 (** Options: depth, debug and transparency settings. *)
 
 VERNAC COMMAND EXTEND Typeclasses_Unfold_Settings CLASSIFIED AS SIDEFF
-| #[ locality = Attributes.really_hint_locality ]
+| #[ locality = tc_transparency_locality ]
   [ "Typeclasses" "Transparent" ne_reference_list(cl) ] -> {
   let conv = List.map
       (fun x -> evaluable_of_global_reference (Global.env ())
@@ -34,7 +54,7 @@ VERNAC COMMAND EXTEND Typeclasses_Unfold_Settings CLASSIFIED AS SIDEFF
 END
 
 VERNAC COMMAND EXTEND Typeclasses_Rigid_Settings CLASSIFIED AS SIDEFF
-| #[ locality = Attributes.really_hint_locality ]
+| #[ locality = tc_transparency_locality ]
   [ "Typeclasses" "Opaque" ne_reference_list(cl) ] -> {
   let conv = List.map
       (fun x -> evaluable_of_global_reference (Global.env ())

--- a/test-suite/success/TypeclassesOpaque.v
+++ b/test-suite/success/TypeclassesOpaque.v
@@ -1,0 +1,108 @@
+
+(** Testing the Typeclasses Opaque hints. We create two identical typeclasses [P] and [Q] and compare the behaviour of Typeclasses Opaque and Hint Opaque. They should be the same. *)
+
+Axiom A : Type.
+Axiom P : A -> Type.
+Axiom Q : A -> Type.
+
+Existing Class P.
+Existing Class Q.
+
+Axiom a : A.
+Axiom pa : P a.
+Axiom qa : Q a.
+#[local] Existing Instance pa.
+#[local] Existing Instance qa.
+
+Definition b := a.
+Definition c := a.
+
+(** b is transparent so typeclass search should find it. *)
+
+Goal P b.
+Proof.
+  Succeed typeclasses eauto.
+Abort.
+
+(** c is transparent so typeclass search should find it. *)
+
+Goal Q c.
+Proof.
+  Succeed typeclasses eauto.
+Abort.
+
+(** Creating a local hint in a module or a section *)
+Section Foo.
+  #[local] Hint Opaque b : typeclass_instances.
+  #[local] Typeclasses Opaque c.
+End Foo.
+
+(** Closing the module/section should get rid of the hint, so we expect the same behaviour as before. *)
+
+(** b is transparent so typeclass search should find it. *)
+
+Goal P b.
+Proof.
+  Succeed typeclasses eauto.
+Abort.
+
+(** c is transparent so typeclass search should find it. *)
+
+Goal Q c.
+Proof.
+  Succeed typeclasses eauto.
+Abort.
+
+(** Now setting the locality as export *)
+Module Foo.
+  #[export] Hint Opaque b : typeclass_instances.
+  #[export] Typeclasses Opaque c.
+  (** Things should fail inside *)
+
+  Goal P b.
+  Proof.
+    Fail typeclasses eauto.
+  Abort.
+  Goal Q c.
+  Proof.
+    Fail typeclasses eauto.
+  Abort.
+End Foo.
+
+(** But succeed outside *)
+
+Goal P b.
+Proof.
+  Succeed typeclasses eauto.
+Abort.
+Goal Q c.
+Proof.
+  Succeed typeclasses eauto.
+Abort.
+
+(** Until of course we export the module *)
+Export Foo.
+
+Goal P b.
+Proof.
+  Fail typeclasses eauto.
+Abort.
+Goal Q c.
+Proof.
+  Fail typeclasses eauto.
+Abort.
+
+(** Finally we test the localities for this alias *)
+
+Succeed #[local] Typeclasses Opaque b.
+Succeed #[global] Typeclasses Opaque b.
+Succeed #[export] Typeclasses Opaque b.
+Succeed #[local] Typeclasses Transparent b.
+Succeed #[global] Typeclasses Transparent b.
+Succeed #[export] Typeclasses Transparent b.
+
+Notation bar := (0 + 0).
+Fail Local Typeclasses Transparent bar.
+
+Notation baz := b.
+Succeed Local Typeclasses Transparent baz.

--- a/theories/Classes/CMorphisms.v
+++ b/theories/Classes/CMorphisms.v
@@ -212,7 +212,7 @@ Section Relations.
     subrelation (forall_relation P R) (forall_relation P S).
   Proof. reduce. firstorder. Qed.
 End Relations.
-Typeclasses Opaque respectful pointwise_relation forall_relation.
+Global Typeclasses Opaque respectful pointwise_relation forall_relation.
 Arguments forall_relation {A P}%type sig%signature _ _.
 Arguments pointwise_relation A%type {B}%type R%signature _ _.
   

--- a/theories/Classes/CRelationClasses.v
+++ b/theories/Classes/CRelationClasses.v
@@ -388,6 +388,4 @@ Hint Extern 3 (PartialOrder (flip _)) => class_apply PartialOrder_inverse : type
 (*   intros x. refine (fun x => x). *)
 (* Qed. *)
 
-Typeclasses Opaque relation_equivalence.
-
-
+Global Typeclasses Opaque relation_equivalence.

--- a/theories/Classes/Init.v
+++ b/theories/Classes/Init.v
@@ -19,7 +19,7 @@
 
 Require Import Coq.Program.Basics.
 
-Typeclasses Opaque id const flip compose arrow impl iff not all.
+Global Typeclasses Opaque id const flip compose arrow impl iff not all.
 
 (** Apply using the same opacity information as typeclass proof search. *)
 

--- a/theories/Classes/Morphisms.v
+++ b/theories/Classes/Morphisms.v
@@ -210,7 +210,7 @@ Section Relations.
   Proof. intros H x y H0 a. apply H. apply H0. Qed.
 End Relations.
 
-Typeclasses Opaque respectful pointwise_relation forall_relation.
+Global Typeclasses Opaque respectful pointwise_relation forall_relation.
 Arguments forall_relation {A P}%type sig%signature _ _.
 Arguments pointwise_relation A%type {B}%type R%signature _ _.
   

--- a/theories/Classes/RelationClasses.v
+++ b/theories/Classes/RelationClasses.v
@@ -512,5 +512,5 @@ Proof.
   unfold relation_equivalence in *. compute; firstorder.
 Qed.
 
-Typeclasses Opaque arrows predicate_implication predicate_equivalence
+Global Typeclasses Opaque arrows predicate_implication predicate_equivalence
             relation_equivalence pointwise_lifting.

--- a/theories/Classes/RelationPairs.v
+++ b/theories/Classes/RelationPairs.v
@@ -46,7 +46,7 @@ Definition RelCompFun {A} {B : Type}(R:relation B)(f:A->B) : relation A :=
  fun a a' => R (f a) (f a').
 
 (** Instances on RelCompFun must match syntactically *)
-Typeclasses Opaque RelCompFun. 
+Global Typeclasses Opaque RelCompFun.
 
 Infix "@@" := RelCompFun (at level 30, right associativity) : signature_scope.
 
@@ -73,7 +73,7 @@ Instance snd_measure {A B} : @Measure (A * B) B Snd := {}.
 Definition RelProd {A : Type} {B : Type} (RA:relation A)(RB:relation B) : relation (A*B) :=
  relation_conjunction (@RelCompFun (A * B) A RA fst) (RB @@2).
 
-Typeclasses Opaque RelProd.
+Global Typeclasses Opaque RelProd.
 
 Infix "*" := RelProd : signature_scope.
 

--- a/theories/ssr/ssrbool.v
+++ b/theories/ssr/ssrbool.v
@@ -1382,8 +1382,7 @@ Definition eq_mem {T} mp1 mp2 := forall x : T, in_mem x mp1 = in_mem x mp2.
 Definition sub_mem {T} mp1 mp2 := forall x : T, in_mem x mp1 -> in_mem x mp2.
 
 Arguments in_mem {T} x mp : simpl never.
-Typeclasses Opaque eq_mem.
-Typeclasses Opaque sub_mem.
+Global Typeclasses Opaque eq_mem sub_mem.
 
 (** The [simpl_of_mem; pred_of_simpl] path provides a new mem_pred >-> pred
   coercion, but does _not_ override the pred_of_mem : mem_pred >-> pred_sort

--- a/theories/ssr/ssrfun.v
+++ b/theories/ssr/ssrfun.v
@@ -447,8 +447,7 @@ Lemma rrefl r : eqrel r r. Proof. by []. Qed.
 
 End ExtensionalEquality.
 
-Typeclasses Opaque eqfun.
-Typeclasses Opaque eqrel.
+Global Typeclasses Opaque eqfun eqrel.
 
 #[global]
 Hint Resolve frefl rrefl : core.

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -28,11 +28,9 @@ module RelDecl = Context.Rel.Declaration
 module NamedDecl = Context.Named.Declaration
 (*i*)
 
-let set_typeclass_transparency c local b =
-  (* XXX checking sections here is suspicious but matches historical (unintended?) behaviour *)
-  let locality = if local || Global.sections_are_opened () then Hints.Local else Hints.SuperGlobal in
+let set_typeclass_transparency ~locality c b =
   Hints.add_hints ~locality [typeclasses_db]
-    (Hints.HintsTransparencyEntry (Hints.HintsReferences [c], b))
+    (Hints.HintsTransparencyEntry (Hints.HintsReferences c, b))
 
 let classes_transparent_state () =
   try
@@ -265,7 +263,7 @@ let discharge_class (_,cl) =
 let rebuild_class cl =
   try
     let cst = Tacred.evaluable_of_global_reference (Global.env ()) cl.cl_impl in
-      set_typeclass_transparency cst false false; cl
+      set_typeclass_transparency ~locality:Hints.Local [cst] false; cl
   with e when CErrors.noncritical e -> cl
 
 let class_input : typeclass -> obj =

--- a/vernac/classes.mli
+++ b/vernac/classes.mli
@@ -74,7 +74,11 @@ val add_class : env -> Evd.evar_map -> typeclass -> unit
 
 (** Setting opacity *)
 
-val set_typeclass_transparency : Tacred.evaluable_global_reference -> bool -> bool -> unit
+val set_typeclass_transparency
+  :  locality:Hints.hint_locality
+  -> Tacred.evaluable_global_reference list
+  -> bool
+  -> unit
 
 (** For generation on names based on classes only *)
 

--- a/vernac/classes.mli
+++ b/vernac/classes.mli
@@ -80,6 +80,14 @@ val set_typeclass_transparency
   -> bool
   -> unit
 
+val tc_transparency_locality : Hints.hint_locality Attributes.attribute
+
+val set_typeclass_transparency_com
+  :  locality:Hints.hint_locality
+  -> Libnames.qualid list
+  -> bool
+  -> unit
+
 (** For generation on names based on classes only *)
 
 val id_of_class : typeclass -> Id.t

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -647,7 +647,8 @@ let build_class_constant ~univs ~rdata ~primitive_proj field implfs params param
   let cref = GlobRef.ConstRef cst in
   Impargs.declare_manual_implicits false cref paramimpls;
   Impargs.declare_manual_implicits false (GlobRef.ConstRef proj_cst) (List.hd implfs);
-  Classes.set_typeclass_transparency (Tacred.EvalConstRef cst) false false;
+  Classes.set_typeclass_transparency ~locality:Hints.SuperGlobal
+    [Tacred.EvalConstRef cst] false;
   let sub = List.hd coers in
   let m = {
     meth_name = Name proj_name;
@@ -766,7 +767,8 @@ let add_constant_class env sigma cst =
     }
   in
   Classes.add_class env sigma tc;
-    Classes.set_typeclass_transparency (Tacred.EvalConstRef cst) false false
+  Classes.set_typeclass_transparency ~locality:Hints.SuperGlobal
+    [Tacred.EvalConstRef cst] false
 
 let add_inductive_class env sigma ind =
   let mind, oneind = Inductive.lookup_mind_specif env ind in


### PR DESCRIPTION
We extend the grammar of `Typeclasses Opaque` and `Typeclasses Transparent` to include locality attributes, and then pass these attributes to the underlying `Hint Opaque` command. Like the underlying command, we deprecate usage without an attribute.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #14513


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.

Should I document the fact that `Typeclasses Opaque` will throw the Hint warning?

Overlays:
- https://github.com/mattam82/Coq-Equations/pull/439