### PR TITLE
Present parameter_entry as a record by consistency with other entries

### DIFF
--- a/dev/ci/user-overlays/14686-herbelin-master+parameter-entry-record.sh
+++ b/dev/ci/user-overlays/14686-herbelin-master+parameter-entry-record.sh
@@ -1,0 +1,1 @@
+overlay metacoq https://github.com/herbelin/template-coq master+adapt-coq-pr14686-parameter-entry-record 14686

--- a/kernel/declarations.ml
+++ b/kernel/declarations.ml
@@ -123,7 +123,7 @@ type cooking_info = {
 (* some contraints are in constant_constraints, some other may be in
  * the OpaqueDef *)
 type 'opaque pconstant_body = {
-    const_hyps : Constr.named_context; (** New: younger hyp at top *)
+    const_hyps : Constr.named_context; (** younger hyp at top *)
     const_body : (Constr.t, 'opaque) constant_def;
     const_type : types;
     const_relevance : Sorts.relevance;

--- a/kernel/entries.ml
+++ b/kernel/entries.ml
@@ -40,7 +40,8 @@ type one_inductive_entry = {
   mind_entry_typename : Id.t;
   mind_entry_arity : constr;
   mind_entry_consnames : Id.t list;
-  mind_entry_lc : constr list }
+  mind_entry_lc : constr list;
+}
 
 type mutual_inductive_entry = {
   mind_entry_record : (Id.t array option) option;
@@ -69,7 +70,8 @@ type definition_entry = {
   const_entry_feedback : Stateid.t option;
   const_entry_type : types option;
   const_entry_universes : universes_entry;
-  const_entry_inline_code : bool }
+  const_entry_inline_code : bool;
+}
 
 type section_def_entry = {
   secdef_body : constr;
@@ -90,8 +92,12 @@ type 'a opaque_entry = {
 
 type inline = int option (* inlining level, None for no inlining *)
 
-type parameter_entry =
-    Id.Set.t option * types in_universes_entry * inline
+type parameter_entry = {
+  parameter_entry_secctx : Id.Set.t option;
+  parameter_entry_type : types;
+  parameter_entry_universes : universes_entry;
+  parameter_entry_inline_code : inline;
+}
 
 type primitive_entry = {
   prim_entry_type : types in_universes_entry option;

--- a/kernel/term_typing.ml
+++ b/kernel/term_typing.ml
@@ -129,22 +129,22 @@ let infer_primitive env { prim_entry_type = utyp; prim_entry_content = p; } =
 
 let infer_declaration env (dcl : constant_entry) =
   match dcl with
-  | ParameterEntry (ctx,(t,uctx),nl) ->
-    let env = match uctx with
+  | ParameterEntry entry ->
+    let env = match entry.parameter_entry_universes with
       | Monomorphic_entry uctx -> push_context_set ~strict:true uctx env
       | Polymorphic_entry uctx -> push_context ~strict:false uctx env
     in
-    let j = Typeops.infer env t in
-    let usubst, univs = Declareops.abstract_universes uctx in
+    let j = Typeops.infer env entry.parameter_entry_type in
+    let usubst, univs = Declareops.abstract_universes entry.parameter_entry_universes in
     let r = Typeops.assumption_of_judgment env j in
     let t = Vars.subst_univs_level_constr usubst j.uj_val in
     {
-      Cooking.cook_body = Undef nl;
+      Cooking.cook_body = Undef entry.parameter_entry_inline_code;
       cook_type = t;
       cook_universes = univs;
       cook_relevance = r;
       cook_inline = false;
-      cook_context = ctx;
+      cook_context = entry.parameter_entry_secctx;
       cook_flags = Environ.typing_flags env;
     }
 

--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -50,7 +50,13 @@ let declare_axiom is_coe ~poly ~local ~kind typ (univs, pl) imps nl {CAst.v=name
     | InlineAt i -> Some i
   in
   let kind = Decls.IsAssumption kind in
-  let decl = Declare.ParameterEntry (None,(typ,univs),inl) in
+  let entry = {
+      parameter_entry_secctx = None;
+      parameter_entry_type = typ;
+      parameter_entry_universes = univs;
+      parameter_entry_inline_code = inl;
+    } in
+  let decl = Declare.ParameterEntry entry in
   let kn = Declare.declare_constant ~name ~local ~kind decl in
   let gr = GlobRef.ConstRef kn in
   let () = maybe_declare_manual_implicits false gr imps in
@@ -232,7 +238,13 @@ let context_nosection sigma ~poly ctx =
     let kind = Decls.(IsAssumption Logical) in
     let decl = match b with
       | None ->
-        Declare.ParameterEntry (None,(t,univs),None)
+        let entry = {
+            parameter_entry_secctx = None;
+            parameter_entry_type = t;
+            parameter_entry_universes = univs;
+            parameter_entry_inline_code = None;
+          } in
+        Declare.ParameterEntry entry
       | Some b ->
         let entry = Declare.definition_entry ~univs ~types:t b in
         Declare.DefinitionEntry entry

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -710,7 +710,13 @@ let prepare_parameter ~poly ~udecl ~types sigma =
       sigma (fun nf -> nf types)
   in
   let univs = Evd.check_univ_decl ~poly sigma udecl in
-  sigma, (None(*proof using*), (typ, univs), None(*inline*))
+  let pe = Entries.{
+      parameter_entry_secctx = None;
+      parameter_entry_type = typ;
+      parameter_entry_universes = univs;
+      parameter_entry_inline_code = None;
+    } in
+  sigma, pe
 
 type progress = Remain of int | Dependent | Defined of GlobRef.t
 
@@ -1880,7 +1886,12 @@ end = struct
     let { Info.scope; hook } = pinfo.Proof_info.info in
     List.map_i (
       fun i { CInfo.name; typ; impargs } ->
-        let pe = (sec_vars, (typ, univs), None) in
+        let pe = Entries.{
+            parameter_entry_secctx = sec_vars;
+            parameter_entry_type = typ;
+            parameter_entry_universes = univs;
+            parameter_entry_inline_code = None;
+          } in
         declare_assumption ~name ~scope ~hook ~impargs ~uctx pe
     ) 0 pinfo.Proof_info.cinfo
 

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -331,7 +331,7 @@ let is_unsafe_typing_flags flags =
   let open Declarations in
   not (flags.check_universes && flags.check_guarded && flags.check_positive)
 
-let define_constant ~name ~typing_flags cd =
+let declare_constant_core ~name ~typing_flags cd =
   (* Logically define the constant and its subproofs, no libobject tampering *)
   let decl, unsafe = match cd with
     | DefinitionEntry de ->
@@ -361,7 +361,7 @@ let define_constant ~name ~typing_flags cd =
 
 let declare_constant ?(local = Locality.ImportDefaultBehavior) ~name ~kind ~typing_flags cd =
   let () = check_exists name in
-  let kn = define_constant ~typing_flags ~name cd in
+  let kn = declare_constant_core ~typing_flags ~name cd in
   (* Register the libobjects attached to the constants *)
   let () = register_constant kn kind local in
   kn
@@ -1808,7 +1808,7 @@ let get_current_context pf =
    mutuals previously on this file. *)
 module MutualEntry : sig
 
-  val declare_variable
+  val declare_toplevel_assumption
     : pinfo:Proof_info.t
     -> uctx:UState.t
     -> sec_vars:Id.Set.t option
@@ -1882,7 +1882,7 @@ end = struct
     in
     List.map_i (declare_mutdef ~pinfo ~uctx pe) 0 pinfo.Proof_info.cinfo
 
-  let declare_variable ~pinfo ~uctx ~sec_vars ~univs =
+  let declare_toplevel_assumption ~pinfo ~uctx ~sec_vars ~univs =
     let { Info.scope; hook } = pinfo.Proof_info.info in
     List.map_i (
       fun i { CInfo.name; typ; impargs } ->
@@ -1922,7 +1922,7 @@ let compute_proof_using_for_admitted proof typ pproofs =
     | _ -> None
 
 let finish_admitted ~pm ~pinfo ~uctx ~sec_vars ~univs =
-  let cst = MutualEntry.declare_variable ~pinfo ~uctx ~sec_vars ~univs in
+  let cst = MutualEntry.declare_toplevel_assumption ~pinfo ~uctx ~sec_vars ~univs in
   (* If the constant was an obligation we need to update the program map *)
   match CEphemeron.default pinfo.Proof_info.proof_ending Proof_ending.Regular with
   | Proof_ending.End_obligation oinfo ->

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -632,7 +632,7 @@ let warn_let_as_axiom =
     Pp.(fun id -> strbrk "Let definition" ++ spc () ++ Names.Id.print id ++
                   spc () ++ strbrk "declared as an axiom.")
 
-let declare_assumption ~name ~scope ~hook ~impargs ~uctx pe =
+let declare_parameter ~name ~scope ~hook ~impargs ~uctx pe =
   let local = match scope with
     | Locality.Discharge -> warn_let_as_axiom name; Locality.ImportNeedQualified
     | Locality.Global local -> local
@@ -1808,7 +1808,7 @@ let get_current_context pf =
    mutuals previously on this file. *)
 module MutualEntry : sig
 
-  val declare_toplevel_assumption
+  val declare_possibly_mutual_parameters
     : pinfo:Proof_info.t
     -> uctx:UState.t
     -> sec_vars:Id.Set.t option
@@ -1882,7 +1882,7 @@ end = struct
     in
     List.map_i (declare_mutdef ~pinfo ~uctx pe) 0 pinfo.Proof_info.cinfo
 
-  let declare_toplevel_assumption ~pinfo ~uctx ~sec_vars ~univs =
+  let declare_possibly_mutual_parameters ~pinfo ~uctx ~sec_vars ~univs =
     let { Info.scope; hook } = pinfo.Proof_info.info in
     List.map_i (
       fun i { CInfo.name; typ; impargs } ->
@@ -1892,7 +1892,7 @@ end = struct
             parameter_entry_universes = univs;
             parameter_entry_inline_code = None;
           } in
-        declare_assumption ~name ~scope ~hook ~impargs ~uctx pe
+        declare_parameter ~name ~scope ~hook ~impargs ~uctx pe
     ) 0 pinfo.Proof_info.cinfo
 
 end
@@ -1922,7 +1922,7 @@ let compute_proof_using_for_admitted proof typ pproofs =
     | _ -> None
 
 let finish_admitted ~pm ~pinfo ~uctx ~sec_vars ~univs =
-  let cst = MutualEntry.declare_toplevel_assumption ~pinfo ~uctx ~sec_vars ~univs in
+  let cst = MutualEntry.declare_possibly_mutual_parameters ~pinfo ~uctx ~sec_vars ~univs in
   (* If the constant was an obligation we need to update the program map *)
   match CEphemeron.default pinfo.Proof_info.proof_ending Proof_ending.Regular with
   | Proof_ending.End_obligation oinfo ->

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -128,15 +128,6 @@ val declare_definition
   -> Evd.evar_map
   -> GlobRef.t
 
-val declare_assumption
-  :  name:Id.t
-  -> scope:Locality.locality
-  -> hook:Hook.t option
-  -> impargs:Impargs.manual_implicits
-  -> uctx:UState.t
-  -> Entries.parameter_entry
-  -> GlobRef.t
-
 type lemma_possible_guards = int list list
 
 val declare_mutually_recursive
@@ -319,7 +310,7 @@ module Proof : sig
 
 end
 
-(** {2 low-level, internla API, avoid using unless you have special needs } *)
+(** {2 low-level, internal API, avoid using unless you have special needs } *)
 
 (** Proof entries represent a proof that has been finished, but still
    not registered with the kernel.


### PR DESCRIPTION
For consistency of style, easier understanding of the code, and self-documentation of the code, we change `parameter_entry` from a tuple to a record.

I believe this is consensual enough to be proposed as a PR "in passing" while further works on coq/ceps#51, on #13445, on universes in sections are in preparation.

- [x] Overlay pull request: MetaCoq/metacoq#575
