### PR TITLE
[ssr] change `suff` to use a fixed number of holes in the proof term

### DIFF
--- a/doc/changelog/06-ssreflect/14687-alizter+fix-14678.rst
+++ b/doc/changelog/06-ssreflect/14687-alizter+fix-14678.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  A bug where :tacn:`suff` would fail due to use of :tacn:`apply` under the hood.
+  (`#14687 <https://github.com/coq/coq/pull/14687>`_,
+  fixes `#14678 <https://github.com/coq/coq/issues/14678>`_,
+  by Ali Caglayan helped by Enrico Tassi).

--- a/plugins/ssr/ssrfwd.ml
+++ b/plugins/ssr/ssrfwd.ml
@@ -96,6 +96,13 @@ let basecuttac name t =
   Ssrcommon.tacTYPEOF t >>= fun _ty ->
   Tactics.apply t
 
+let basesufftac t =
+  let open Proofview.Notations in
+  Ssrcommon.tacMK_SSR_CONST "ssr_suff" >>= fun hd ->
+  let t = EConstr.mkApp (hd, [|t|]) in
+  Ssrcommon.tacTYPEOF t >>= fun _ty ->
+  Ssrcommon.applyn ~with_evars:true 3 t
+
 let evarcuttac name cs =
   let open Proofview.Notations in
   Ssrcommon.tacMK_SSR_CONST name >>= fun hd ->
@@ -330,7 +337,7 @@ let sufftac ist ((((clr, pats),binders),simpl), ((_, c), hint)) =
   let ctac =
     Proofview.V82.tactic begin fun gl ->
     let _,ty,_,uc = pf_interp_ty (pf_env gl) (project gl) ist c in let gl = pf_merge_uc uc gl in
-    Proofview.V82.of_tactic (basecuttac "ssr_suff" ty) gl
+    Proofview.V82.of_tactic (basesufftac ty) gl
   end in
   Tacticals.New.tclTHENS ctac [htac; Tacticals.New.tclTHEN (cleartac clr) (introstac (binders@simpl))]
 

--- a/plugins/ssr/ssrfwd.mli
+++ b/plugins/ssr/ssrfwd.mli
@@ -31,6 +31,8 @@ val havetac : ist ->
 
 val basecuttac : string -> EConstr.t -> unit Proofview.tactic
 
+val basesufftac : EConstr.t -> unit Proofview.tactic
+
 val wlogtac :
   Ltac_plugin.Tacinterp.interp_sign ->
   ((Ssrast.ssrclear option * Ssrast.ssripats) * 'a) * 'b ->

--- a/test-suite/bugs/closed/bug_14678.v
+++ b/test-suite/bugs/closed/bug_14678.v
@@ -1,0 +1,4 @@
+Require Import ssreflect.
+Lemma toto (P Q:Prop) : P -> Q.
+suff h : P.
+Abort.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->
We add a variant of `basecuttac` called `basecuttac_applyn` which calls `Ssrcommon.applyn` instead of `Tactics.apply`. This fixes a bug where suff wasn't working.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #14678


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.
- [x] Added **changelog**.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
