### PR TITLE
Add Float64.to_float

### DIFF
--- a/kernel/float64.mli
+++ b/kernel/float64.mli
@@ -29,12 +29,16 @@ val to_hex_string : t -> string
 (** Print a float as a decimal value. The printing is not exact (the
  * real value printed is not always the given floating-point value),
  * however printing is precise enough that forall float [f],
- * [of_string (to_decimal_string f) = f].  *)
+ * [of_string (to_decimal_string f) = f]. *)
 val to_string : t -> string
 
 val compile : t -> string
 
 val of_float : float -> t
+
+(** All NaNs are normalized to [Stdlib.nan].
+ * @since 8.15 *)
+val to_float : t -> float
 
 (** Return [true] for "-", [false] for "+". *)
 val sign : t -> bool

--- a/kernel/float64_common.ml
+++ b/kernel/float64_common.ml
@@ -43,6 +43,8 @@ let compile f =
 
 let of_float f = f
 
+let to_float f = if is_nan f then nan else f
+
 let sign f = copysign 1. f < 0.
 
 let opp = ( ~-. )

--- a/kernel/float64_common.mli
+++ b/kernel/float64_common.mli
@@ -36,6 +36,10 @@ val compile : t -> string
 
 val of_float : float -> t
 
+(** All NaNs are normalized to [Stdlib.nan].
+ * @since 8.15 *)
+val to_float : t -> float
+
 (** Return [true] for "-", [false] for "+". *)
 val sign : t -> bool
 


### PR DESCRIPTION
There was already `Float64.of_float`, this is easy to implement and may be useful for external tools.
