### PR TITLE
Embedding user-side universes names in Univ.UContext

### DIFF
--- a/checker/checkInductive.ml
+++ b/checker/checkInductive.ml
@@ -38,7 +38,7 @@ let to_entry (mb:mutual_inductive_body) : Entries.mutual_inductive_entry =
       | Some ctx -> ctx.template_context
       in
       Monomorphic_entry univs
-    | Polymorphic auctx -> Polymorphic_entry (AUContext.names auctx, AUContext.repr auctx)
+    | Polymorphic auctx -> Polymorphic_entry (AUContext.repr auctx)
   in
   let mind_entry_inds = Array.map_to_list (fun ind ->
       let mind_entry_arity = match ind.mind_arity with

--- a/dev/ci/user-overlays/14692-herbelin-master+UContext-include-names.sh
+++ b/dev/ci/user-overlays/14692-herbelin-master+UContext-include-names.sh
@@ -1,0 +1,4 @@
+overlay elpi https://github.com/herbelin/coq-elpi coq-master+adapt-coq-pr14692-slight-simplification-UContext 14692
+overlay equations https://github.com/herbelin/Coq-Equations master+adapt-coq-pr14692-slight-simplification-UContext 14692
+overlay paramcoq https://github.com/herbelin/paramcoq master+adapt-coq-pr14692-slight-simplification-UContext 14692
+overlay metacoq https://github.com/herbelin/template-coq master+adapt-coq-pr14692-slight-simplification-UContext 14692

--- a/dev/doc/changes.md
+++ b/dev/doc/changes.md
@@ -1,3 +1,10 @@
+## Changes between Coq 8.14 and Coq 8.15
+
+### Universes
+
+- Type `Univ.UContext` now embeds universe user names, generally
+  resulting in more concise code.
+
 ## Changes between Coq 8.13 and Coq 8.14
 
 ### Build system and library infrastructure

--- a/interp/modintern.ml
+++ b/interp/modintern.ml
@@ -110,8 +110,8 @@ let transl_with_decl env base kind = function
     let c, ectx = interp_constr env sigma c in
     let poly = lookup_polymorphism env base kind fqid in
     begin match UState.check_univ_decl ~poly ectx udecl with
-      | Entries.Polymorphic_entry (nas, ctx) ->
-        let inst, ctx = Univ.abstract_universes nas ctx in
+      | Entries.Polymorphic_entry ctx ->
+        let inst, ctx = Univ.abstract_universes ctx in
         let c = EConstr.Vars.subst_univs_level_constr (Univ.make_instance_subst inst) c in
         let c = EConstr.to_constr sigma c in
         WithDef (fqid,(c, Some ctx)), Univ.ContextSet.empty

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -63,8 +63,8 @@ let universes_context = function
 let abstract_universes = function
   | Entries.Monomorphic_entry ctx ->
     Univ.empty_level_subst, Monomorphic ctx
-  | Entries.Polymorphic_entry (nas, ctx) ->
-    let (inst, auctx) = Univ.abstract_universes nas ctx in
+  | Entries.Polymorphic_entry uctx ->
+    let (inst, auctx) = Univ.abstract_universes uctx in
     let inst = Univ.make_instance_subst inst in
     (inst, Polymorphic auctx)
 

--- a/kernel/entries.ml
+++ b/kernel/entries.ml
@@ -18,7 +18,7 @@ open Constr
 
 type universes_entry =
   | Monomorphic_entry of Univ.ContextSet.t
-  | Polymorphic_entry of Name.t array * Univ.UContext.t
+  | Polymorphic_entry of Univ.UContext.t
 
 type variance_entry = Univ.Variance.t option array
 

--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -333,7 +333,7 @@ let typecheck_inductive env ~sec_univs (mie:mutual_inductive_entry) =
       else
         (* In the regular case, all universes are [> Set] *)
         push_context_set ~strict:true ctx env
-    | Polymorphic_entry (_, ctx) -> push_context ctx env
+    | Polymorphic_entry ctx -> push_context ctx env
   in
 
   (* Params *)
@@ -375,7 +375,7 @@ let typecheck_inductive env ~sec_univs (mie:mutual_inductive_entry) =
       match mie.mind_entry_universes with
       | Monomorphic_entry _ ->
         CErrors.user_err Pp.(str "Inductive cannot be both monomorphic and universe cumulative.")
-      | Polymorphic_entry (_,uctx) ->
+      | Polymorphic_entry uctx ->
         let univs = Instance.to_array @@ UContext.instance uctx in
         let univs = Array.map2 (fun a b -> a,b) univs variances in
         let univs = match sec_univs with

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -522,11 +522,11 @@ let push_named_assum (x,t) senv =
   let env'' = safe_push_named (LocalAssum (x,t)) senv.env in
   { senv with sections=Some sections; env = env'' }
 
-let push_section_context (nas, ctx) senv =
+let push_section_context uctx senv =
   let sections = get_section senv.sections in
-  let sections = Section.push_context (nas, ctx) sections in
+  let sections = Section.push_context uctx sections in
   let senv = { senv with sections=Some sections } in
-  let ctx = Univ.ContextSet.of_context ctx in
+  let ctx = Univ.ContextSet.of_context uctx in
   (* We check that the universes are fresh. FIXME: This should be done
      implicitly, but we have to work around the API. *)
   let () = assert (Univ.LSet.for_all (fun u -> not (Univ.LSet.mem u (fst senv.univ))) (fst ctx)) in
@@ -767,7 +767,7 @@ let constant_entry_of_side_effect eff =
     | Monomorphic uctx ->
       Monomorphic_entry uctx
     | Polymorphic auctx ->
-      Polymorphic_entry (Univ.AUContext.names auctx, Univ.AUContext.repr auctx)
+      Polymorphic_entry (Univ.AUContext.repr auctx)
   in
   let p =
     match cb.const_body with

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -155,7 +155,7 @@ val push_named_def :
   Id.t * Entries.section_def_entry -> safe_transformer0
 
 (** Add local universes to a polymorphic section *)
-val push_section_context : (Name.t array * Univ.UContext.t) -> safe_transformer0
+val push_section_context : Univ.UContext.t -> safe_transformer0
 
 (** {6 Interactive module functions } *)
 

--- a/kernel/section.mli
+++ b/kernel/section.mli
@@ -44,7 +44,7 @@ val close_section : 'a t -> 'a t option * section_entry list * ContextSet.t * 'a
 val push_local : 'a t -> 'a t
 (** Extend the current section with a local definition (cf. push_named). *)
 
-val push_context : Name.t array * UContext.t -> 'a t -> 'a t
+val push_context : UContext.t -> 'a t -> 'a t
 (** Extend the current section with a local universe context. Assumes that the
     last opened section is polymorphic. *)
 

--- a/kernel/uGraph.ml
+++ b/kernel/uGraph.ml
@@ -198,7 +198,9 @@ let constraints_for ~kept g = G.constraints_for ~kept:(LSet.remove Level.sprop k
 
 let check_subtype ~lbound univs ctxT ctx =
   if AUContext.size ctxT == AUContext.size ctx then
-    let (inst, cst) = UContext.dest (AUContext.repr ctx) in
+    let uctx = AUContext.repr ctx in
+    let inst = UContext.instance uctx in
+    let cst = UContext.constraints uctx in
     let cstT = UContext.constraints (AUContext.repr ctxT) in
     let push accu v = add_universe v ~lbound ~strict:false accu in
     let univs = Array.fold_left push univs (Instance.to_array inst) in

--- a/kernel/univ.mli
+++ b/kernel/univ.mli
@@ -325,13 +325,14 @@ val in_punivs : 'a -> 'a puniverses
 val eq_puniverses : ('a -> 'a -> bool) -> 'a puniverses -> 'a puniverses -> bool
 
 (** A vector of universe levels with universe Constraint.t,
-    representing local universe variables and associated Constraint.t *)
+    representing local universe variables and associated Constraint.t;
+    the names are user-facing names for printing *)
 
 module UContext :
 sig
   type t
 
-  val make : Instance.t constrained -> t
+  val make : Names.Name.t array -> Instance.t constrained -> t
 
   val empty : t
   val is_empty : t -> bool
@@ -339,13 +340,17 @@ sig
   val instance : t -> Instance.t
   val constraints : t -> Constraint.t
 
-  val dest : t -> Instance.t * Constraint.t
-
-  (** Keeps the order of the instances *)
   val union : t -> t -> t
+  (** Keeps the order of the instances *)
 
-  (** the number of universes in the context *)
   val size : t -> int
+  (** The number of universes in the context *)
+
+  val names : t -> Names.Name.t array
+  (** Return the user names of the universes *)
+
+  val refine_names : Names.Name.t array -> t -> t
+  (** Use names to name the possibly yet unnamed universes *)
 
 end
 
@@ -415,16 +420,20 @@ sig
   val add_constraints : Constraint.t -> t -> t
   val add_instance : Instance.t -> t -> t
 
-  (** Arbitrary choice of linear order of the variables *)
   val sort_levels : Level.t array -> Level.t array
-  val to_context : t -> UContext.t
+  (** Arbitrary choice of linear order of the variables *)
+
+  val to_context : (Instance.t -> Names.Name.t array) -> t -> UContext.t
+  (** Build a vector of universe levels assuming a function generating names *)
+
   val of_context : UContext.t -> t
 
   val constraints : t -> Constraint.t
   val levels : t -> LSet.t
 
-  (** the number of universes in the context *)
   val size : t -> int
+  (** The number of universes in the context *)
+
 end
 
 (** A value in a universe context (resp. context set). *)
@@ -462,7 +471,7 @@ val make_instance_subst : Instance.t -> universe_level_subst
 
 val make_inverse_instance_subst : Instance.t -> universe_level_subst
 
-val abstract_universes : Names.Name.t array -> UContext.t -> Instance.t * AUContext.t
+val abstract_universes : UContext.t -> Instance.t * AUContext.t
 (** TODO: move universe abstraction out of the kernel *)
 
 val make_abstract_instance : AUContext.t -> Instance.t

--- a/library/global.mli
+++ b/library/global.mli
@@ -47,7 +47,7 @@ val sprop_allowed : unit -> bool
 
 val push_named_assum : (Id.t * Constr.types) -> unit
 val push_named_def   : (Id.t * Entries.section_def_entry) -> unit
-val push_section_context : (Name.t array * Univ.UContext.t) -> unit
+val push_section_context : Univ.UContext.t -> unit
 
 val export_private_constants :
   Safe_typing.private_constants ->

--- a/tactics/declareUctx.ml
+++ b/tactics/declareUctx.ml
@@ -27,8 +27,7 @@ let name_instance inst =
 
 let declare_universe_context ~poly ctx =
   if poly then
-    let uctx = Univ.ContextSet.to_context ctx in
-    let nas = name_instance (Univ.UContext.instance uctx) in
-    Global.push_section_context (nas, uctx)
+    let uctx = Univ.ContextSet.to_context name_instance ctx in
+    Global.push_section_context uctx
   else
     Global.push_context_set ~strict:true ctx

--- a/test-suite/misc/poly-capture-global-univs/src/evilImpl.ml
+++ b/test-suite/misc/poly-capture-global-univs/src/evilImpl.ml
@@ -14,7 +14,7 @@ let evil name name_f =
   let tc = mkConst tc in
 
   let fe = Declare.definition_entry
-      ~univs:(Polymorphic_entry ([|Anonymous|], UContext.make (Instance.of_array [|u|],Constraint.empty)))
+      ~univs:(Polymorphic_entry (UContext.make [|Anonymous|] (Instance.of_array [|u|],Constraint.empty)))
       ~types:(Term.mkArrowR tc tu)
       (mkLambda (Context.nameR (Id.of_string "x"), tc, mkRel 1))
   in

--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -34,7 +34,7 @@ let declare_variable is_coe ~kind typ imps impl {CAst.v=name} =
   ()
 
 let instance_of_univ_entry = function
-  | Polymorphic_entry (_, univs) -> Univ.UContext.instance univs
+  | Polymorphic_entry univs -> Univ.UContext.instance univs
   | Monomorphic_entry _ -> Univ.Instance.empty
 
 let declare_axiom is_coe ~poly ~local ~kind typ (univs, pl) imps nl {CAst.v=name} =
@@ -83,7 +83,7 @@ let next_univs =
   | Monomorphic_entry _, _ -> empty_univs
 
 let context_set_of_entry = function
-  | Polymorphic_entry (_,uctx) -> Univ.ContextSet.of_context uctx
+  | Polymorphic_entry uctx -> Univ.ContextSet.of_context uctx
   | Monomorphic_entry uctx -> uctx
 
 let declare_assumptions ~poly ~scope ~kind univs nl l =
@@ -198,7 +198,7 @@ let context_insection sigma ~poly ctx =
         declare_variable false ~kind t [] impl (CAst.make name)
       | name, Some b, t, impl ->
         (* We need to get poly right for check_same_poly *)
-        let univs = if poly then Polymorphic_entry ([| |], Univ.UContext.empty)
+        let univs = if poly then Polymorphic_entry Univ.UContext.empty
           else Monomorphic_entry Univ.ContextSet.empty
         in
         let entry = Declare.definition_entry ~univs ~types:t b in

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -384,11 +384,11 @@ let check_trivial_variances variances =
 let variance_of_entry ~cumulative ~variances uctx =
   match uctx with
   | Monomorphic_entry _ -> check_trivial_variances variances; None
-  | Polymorphic_entry (nas,_) ->
+  | Polymorphic_entry uctx ->
     if not cumulative then begin check_trivial_variances variances; None end
     else
       let lvs = Array.length variances in
-      let lus = Array.length nas in
+      let lus = Univ.UContext.size uctx in
       assert (lvs <= lus);
       Some (Array.append variances (Array.make (lus - lvs) None))
 

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -421,7 +421,7 @@ let declare_variable_core ~name ~kind d =
       let () = export_side_effects eff in
       let poly, entry_ui = match de.proof_entry_universes with
         | Entries.Monomorphic_entry uctx -> false, uctx
-        | Entries.Polymorphic_entry (_, uctx) -> true, Univ.ContextSet.of_context uctx
+        | Entries.Polymorphic_entry uctx -> true, Univ.ContextSet.of_context uctx
       in
       let univs = Univ.ContextSet.union body_ui entry_ui in
       (* We must declare the universe constraints before type-checking the
@@ -918,7 +918,7 @@ let declare_obligation prg obl ~uctx ~types ~body =
     definition_message obl.obl_name;
     let body =
       match univs with
-      | Entries.Polymorphic_entry (_, uctx) ->
+      | Entries.Polymorphic_entry uctx ->
         Some (DefinedObl (constant, Univ.UContext.instance uctx))
       | Entries.Monomorphic_entry _ ->
         Some
@@ -1764,7 +1764,7 @@ let declare_abstract ~name ~poly ~kind ~sign ~secsign ~opaque ~solve_tac sigma c
   let cst, eff = Impargs.with_implicit_protection cst () in
   let inst = match const.proof_entry_universes with
   | Entries.Monomorphic_entry _ -> EConstr.EInstance.empty
-  | Entries.Polymorphic_entry (_, ctx) ->
+  | Entries.Polymorphic_entry ctx ->
     (* We mimic what the kernel does, that is ensuring that no additional
        constraints appear in the body of polymorphic constants. Ideally this
        should be enforced statically. *)
@@ -2053,7 +2053,7 @@ let save_lemma_admitted_delayed ~pm ~proof =
   let { proof_entry_secctx; proof_entry_type; proof_entry_universes } = List.hd entries in
   let poly = match proof_entry_universes with
     | Entries.Monomorphic_entry _ -> false
-    | Entries.Polymorphic_entry (_, _) -> true in
+    | Entries.Polymorphic_entry _ -> true in
   let univs = UState.univ_entry ~poly uctx in
   let sec_vars = if get_keep_admitted_vars () then proof_entry_secctx else None in
   finish_admitted ~pm ~uctx ~pinfo ~sec_vars ~univs

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -432,8 +432,8 @@ let declare_projections indsp univs ?(kind=Decls.StructureComponent) binder_name
   let (mib,mip) = Global.lookup_inductive indsp in
   let poly = Declareops.inductive_is_polymorphic mib in
   let uinstance = match univs with
-    | Polymorphic_entry (_, ctx) -> Univ.UContext.instance ctx
-    | Monomorphic_entry ctx -> Univ.Instance.empty
+    | Monomorphic_entry _ -> Univ.Instance.empty
+    | Polymorphic_entry uctx -> Univ.UContext.instance uctx
   in
   let paramdecls = Inductive.inductive_paramdecls (mib, uinstance) in
   let r = mkIndU (indsp,uinstance) in
@@ -556,10 +556,8 @@ let declare_structure ~cumulative finite ~ubind ~univs ~variances paramimpls par
   let nparams = List.length params in
   let poly, ctx =
     match univs with
-    | Monomorphic_entry ctx ->
-      false, Monomorphic_entry Univ.ContextSet.empty
-    | Polymorphic_entry (nas, ctx) ->
-      true, Polymorphic_entry (nas, ctx)
+    | Monomorphic_entry _ -> false, Monomorphic_entry Univ.ContextSet.empty
+    | Polymorphic_entry uctx -> true, Polymorphic_entry uctx
   in
   let binder_name =
     match name with
@@ -623,8 +621,8 @@ let build_class_constant ~univs ~rdata field implfs params paramimpls coers bind
       (Declare.DefinitionEntry class_entry) ~kind:Decls.(IsDefinition Definition)
   in
   let inst, univs = match univs with
-    | Polymorphic_entry (_, uctx) -> Univ.UContext.instance uctx, univs
     | Monomorphic_entry _ -> Univ.Instance.empty, Monomorphic_entry Univ.ContextSet.empty
+    | Polymorphic_entry uctx -> Univ.UContext.instance uctx, univs
   in
   let cstu = (cst, inst) in
   let inst_type = appvectc (mkConstU cstu)
@@ -716,8 +714,8 @@ let declare_class def ~cumulative ~ubind ~univs ~variances id idbuild paramimpls
   in
   let univs, params, fields =
     match univs with
-    | Polymorphic_entry (nas, univs) ->
-      let usubst, auctx = Univ.abstract_universes nas univs in
+    | Polymorphic_entry uctx ->
+      let usubst, auctx = Univ.abstract_universes uctx in
       let usubst = Univ.make_instance_subst usubst in
       let map c = Vars.subst_univs_level_constr usubst c in
       let fields = Context.Rel.map map fields in


### PR DESCRIPTION
**Kind:** cleanup

A discussion on Zulip concluded that this was worth, and it indeed makes the relevant code more concise and intelligible.

- [X] Updated `dev/doc/changes.md`
- [X] Synchronous overlays:  LPCIC/coq-elpi#273,  coq-community/paramcoq#68, mattam82/Coq-Equations#418, MetaCoq/metacoq#576
 
Note that the MetaCoq overlay is very large and is raising questions as there is a correspondence between the data structures of the Coq's kernel and template-coq, as well as a correspondence between a part of the Coq kernel and the certified pcuic checker. I wonder whether the sources should not be maintained jointly.