### PR TITLE
Allowing certain non-local hint commands inside sections

### DIFF
--- a/doc/changelog/07-vernac-commands-and-options/14697-hint-section-locality.rst
+++ b/doc/changelog/07-vernac-commands-and-options/14697-hint-section-locality.rst
@@ -1,0 +1,8 @@
+- **Added:**
+  The :cmd:`Hint Cut`, :cmd:`Hint Mode`, :cmd:`Hint Transparent` and
+  :cmd:`Hint Opaque` commands now accept the :attr:`export` and :attr:`global`
+  locality attributes inside sections. With either attribute, the commands will
+  trigger the `non-local-section-hint` warning if the arguments refer to local
+  section variables
+  (`#14697 <https://github.com/coq/coq/pull/14697>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/proofs/automatic-tactics/auto.rst
+++ b/doc/sphinx/proofs/automatic-tactics/auto.rst
@@ -348,8 +348,12 @@ Creating Hints
    are given, the hint is added to the `core` database.)
 
    Outside of sections, these commands support the :attr:`local`, :attr:`export`
-   and :attr:`global` attributes. :attr:`global` is the default.  Inside sections,
-   only the :attr:`local` attribute is supported because hints are local to sections.
+   and :attr:`global` attributes. :attr:`global` is the default.
+
+   Inside sections, some commands only support the :attr:`local` attribute. These are
+   :cmd:`Hint Immediate`, :cmd:`Hint Resolve`, :cmd:`Hint Constructors`,
+   :cmd:`Hint Unfold`, :cmd:`Hint Extern` and :cmd:`Hint Rewrite`.
+   :attr:`local` is the default for all hint commands inside sections.
 
    + :attr:`local` hints are never visible from other modules, even if they
      :cmd:`Import` or :cmd:`Require` the current module.
@@ -584,6 +588,12 @@ Creating Hints
         :cmd:`Hint Cut`, or :cmd:`Hint Mode`, for typeclass
         resolution, do not forget to put them in the
         ``typeclass_instances`` hint database.
+
+   .. warn:: This hint is not local but depends on a section variable. It will disappear when the section is closed.
+
+      A hint with a non-local attribute was added inside a section, but it
+      refers to a local variable that will go out of scope when closing the
+      section. As a result the hint will not survive either.
 
 .. cmd:: Hint Rewrite {? {| -> | <- } } {+ @one_term } {? using @ltac_expr } {? : {* @ident } }
 

--- a/plugins/ltac/g_auto.mlg
+++ b/plugins/ltac/g_auto.mlg
@@ -241,19 +241,7 @@ END
 
 VERNAC COMMAND EXTEND HintCut CLASSIFIED AS SIDEFF
 | #[ locality = Attributes.option_locality; ] [ "Hint" "Cut" "[" hints_path(p) "]" opthints(dbnames) ] -> {
-  let open Goptions in
   let entry = Hints.HintsCutEntry (Hints.glob_hints_path p) in
-  let () = match locality with
-  | OptGlobal ->
-    if Global.sections_are_opened () then
-    CErrors.user_err Pp.(str
-      "This command does not support the global attribute in sections.");
-  | OptExport ->
-    if Global.sections_are_opened () then
-    CErrors.user_err Pp.(str
-      "This command does not support the export attribute in sections.");
-  | OptDefault | OptLocal -> ()
-  in
   Hints.add_hints ~locality
     (match dbnames with None -> ["core"] | Some l -> l) entry;
  }

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1296,6 +1296,7 @@ let interp_locality = function
 | Goptions.OptLocal -> Local
 
 let remove_hints ~locality dbnames grs =
+  let () = check_hint_locality locality in
   let local = interp_locality locality in
   let dbnames = if List.is_empty dbnames then ["core"] else dbnames in
     List.iter
@@ -1441,6 +1442,7 @@ let prepare_hint check env init (sigma,c) =
     (c', diff)
 
 let add_hints ~locality dbnames h =
+  let () = check_hint_locality locality in
   let local = interp_locality locality in
   if String.List.mem "nocore" dbnames then
     user_err Pp.(str "The hint database \"nocore\" is meant to stay empty.");

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -174,8 +174,6 @@ val searchtable_map : hint_db_name -> hint_db
 
 val searchtable_add : (hint_db_name * hint_db) -> unit
 
-val check_hint_locality : Goptions.option_locality -> unit
-
 (** [create_hint_db local name st use_dn].
    [st] is a transparency state for unification using this db
    [use_dn] switches the use of the discrimination net for all hints

--- a/test-suite/output/HintLocality.out
+++ b/test-suite/output/HintLocality.out
@@ -85,3 +85,19 @@ For any goal ->
 For nat ->   simple apply 0 ; trivial(level 1, pattern nat, id 0) 
 For S (modes !) ->   
 
+File "./output/HintLocality.v", line 92, characters 0-39:
+Warning: This hint is not local but depends on a section variable. It will
+disappear when the section is closed. [non-local-section-hint,automation]
+File "./output/HintLocality.v", line 94, characters 0-40:
+Warning: This hint is not local but depends on a section variable. It will
+disappear when the section is closed. [non-local-section-hint,automation]
+File "./output/HintLocality.v", line 98, characters 0-39:
+Warning: This hint is not local but depends on a section variable. It will
+disappear when the section is closed. [non-local-section-hint,automation]
+Non-discriminated database
+Unfoldable variable definitions: all
+Unfoldable constant definitions: all
+Cut: emp
+For any goal ->   
+For refl (modes - !) ->   
+

--- a/test-suite/output/HintLocality.out
+++ b/test-suite/output/HintLocality.out
@@ -69,24 +69,19 @@ For S (modes !) ->
 
 The command has indeed failed with message:
 This command does not support the global attribute in sections.
-The command has indeed failed with message:
-This command does not support the global attribute in sections.
-The command has indeed failed with message:
-This command does not support the global attribute in sections.
-The command has indeed failed with message:
-This command does not support the global attribute in sections.
+Non-discriminated database
+Unfoldable variable definitions: all
+Unfoldable constant definitions: all except: id
+Cut: (_ | _)
+For any goal ->   
+For nat ->   
+For S (modes !, !) ->   
+
 Non-discriminated database
 Unfoldable variable definitions: all
 Unfoldable constant definitions: all except: id
 Cut: _
 For any goal ->   
-For nat ->   
-For S (modes !) ->   
-
-Non-discriminated database
-Unfoldable variable definitions: all
-Unfoldable constant definitions: all
-Cut: emp
-For any goal ->   
 For nat ->   simple apply 0 ; trivial(level 1, pattern nat, id 0) 
+For S (modes !) ->   
 

--- a/test-suite/output/HintLocality.v
+++ b/test-suite/output/HintLocality.v
@@ -70,3 +70,33 @@ Print HintDb secdb.
 End Sec.
 
 Print HintDb secdb.
+
+(** Variant of the above test
+    - modes are correctly generalized at section closure
+    - non-local section-specific hints trigger a warning
+*)
+
+Create HintDb seclocaldb.
+
+Set Warnings "non-local-section-hint".
+
+Section SecLocal.
+
+Variable A : Type.
+
+Definition refl (n : A) : n = n := eq_refl.
+
+Variable prf : forall n : nat, n = 0.
+
+#[export] Hint Mode refl ! : seclocaldb.
+#[export] Hint Mode prf ! : seclocaldb.
+
+#[export] Hint Cut [ prf ] : seclocaldb.
+
+#[export] Hint Variables Transparent : seclocaldb.
+#[export] Hint Constants Transparent : seclocaldb.
+#[export] Hint Opaque prf : seclocaldb.
+
+End SecLocal.
+
+Print HintDb seclocaldb.

--- a/test-suite/output/HintLocality.v
+++ b/test-suite/output/HintLocality.v
@@ -55,9 +55,9 @@ Create HintDb secdb.
 
 Section Sec.
 
-Fail #[global] Hint Cut [ _ ] : secdb.
-Fail #[global] Hint Mode S ! : secdb.
-Fail #[global] Hint Opaque id : secdb.
+#[global] Hint Cut [ _ ] : secdb.
+#[global] Hint Mode S ! : secdb.
+#[global] Hint Opaque id : secdb.
 Fail #[global] Remove Hints O : secdb.
 
 #[local] Hint Cut [ _ ] : secdb.

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -29,7 +29,7 @@ module NamedDecl = Context.Named.Declaration
 (*i*)
 
 let set_typeclass_transparency c local b =
-  let locality = if local then Goptions.OptLocal else Goptions.OptGlobal in
+  let locality = if local || Global.sections_are_opened () then Goptions.OptLocal else Goptions.OptGlobal in
   Hints.add_hints ~locality [typeclasses_db]
     (Hints.HintsTransparencyEntry (Hints.HintsReferences [c], b))
 

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -892,7 +892,7 @@ let shrink_body c ty =
 let unfold_entry cst = Hints.HintsUnfoldEntry [Tacred.EvalConstRef cst]
 
 let add_hint local prg cst =
-  let locality = if local then Goptions.OptLocal else Goptions.OptExport in
+  let locality = if local || Global.sections_are_opened () then Goptions.OptLocal else Goptions.OptExport in
   Hints.add_hints ~locality [Id.to_string prg.prg_cinfo.CInfo.name] (unfold_entry cst)
 
 let declare_obligation prg obl ~uctx ~types ~body =

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1403,7 +1403,6 @@ let warn_implicit_core_hint_db =
 
 let vernac_remove_hints ~atts dbnames ids =
   let locality = Attributes.(parse option_locality atts) in
-  let () = Hints.check_hint_locality locality in
   let dbnames =
     if List.is_empty dbnames then
       (warn_implicit_core_hint_db (); ["core"])
@@ -1418,7 +1417,6 @@ let vernac_hints ~atts dbnames h =
     else dbnames
   in
   let locality, poly = Attributes.(parse Notations.(option_locality ++ polymorphic) atts) in
-  let () = Hints.check_hint_locality locality in
   Hints.add_hints ~locality dbnames (ComHints.interp_hints ~poly h)
 
 let vernac_syntactic_definition ~atts lid x only_parsing =


### PR DESCRIPTION
Namely, we now allow non-local `Hint Cut`, `Hint Mode` and the various hint transparency commands. For sordid reasons that will require a bit of upfront cleanup, "standard" hint commands like `Hint Resolve` are still rejecting any non-local section qualifier.

A non-local hint command that refers to a section variable also works, but will trigger a warning informing the user it will die when leaving the section regardless of the locality qualifier.

cc @Janno 

- [X] Added / updated **test-suite**.
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
