### PR TITLE
Recommend `make -C test-suite` over other methods.

### DIFF
--- a/dev/doc/build-system.dune.md
+++ b/dev/doc/build-system.dune.md
@@ -126,10 +126,11 @@ There are two ways to run the test suite using Dune:
   Makefile.dune test-suite` or `dune runtest`. This is convenient for
   full runs from scratch, for instance in CI.
 
-Since `dune` still invokes the test-suite makefile, the
-environment variable `NJOBS` is used to set the `-j` option
-that is passed to make (for example, with the command `NJOBS=8 dune runtest`). This use of `NJOBS`
-will be removed when the test suite is fully ported to Dune.
+  Since `dune` still invokes the test-suite makefile, the
+  environment variable `NJOBS` is used to set the `-j` option
+  that is passed to make (for example, with the command
+  `NJOBS=8 dune runtest`). This use of `NJOBS` will be
+  removed when the test suite is fully ported to Dune.
 
 There is preliminary support to build the API documentation and
 reference manual in HTML format, use `dune build {@doc,@refman-html}`

--- a/dev/doc/build-system.dune.md
+++ b/dev/doc/build-system.dune.md
@@ -112,13 +112,24 @@ ml files in quick mode.
 Dune also provides targets for documentation, testing, and release
 builds, please see below.
 
-## Documentation and testing targets
+## Testing and documentation targets
 
-Coq's test-suite can be run with `dune runtest`; given that `dune`
-still invokes the test-suite makefile, the environment variable
-`NJOBS` will control the value of the `-j` option that is passed to
-make; common call `NJOBS=8 dune runtest`. This will be resolved in the
-future once the test suite is ported to Dune rules.
+There are two ways to run the test-suite when using Dune:
+
+- You can run the test-suite in-place, with output artifacts in the
+  tree using `make -C test-suite` (equivalent to running `make` inside
+  the `test-suite` directory), after having built Coq with `make -f
+  Makefile.dune world`. This will allow for incremental usage as
+  artifacts will be preserved.
+
+- You can also run the test-suite in an hygienic way using `make -f
+  Makefile.dune test-suite` or `dune runtest`. This is convenient for
+  full runs from scracth, for instance in CI.
+
+Given that `dune` still invokes the test-suite makefile, the
+environment variable `NJOBS` will control the value of the `-j` option
+that is passed to make; common call `NJOBS=8 dune runtest`. This will
+be resolved in the future once the test suite is ported to Dune rules.
 
 There is preliminary support to build the API documentation and
 reference manual in HTML format, use `dune build {@doc,@refman-html}`

--- a/dev/doc/build-system.dune.md
+++ b/dev/doc/build-system.dune.md
@@ -114,22 +114,22 @@ builds, please see below.
 
 ## Testing and documentation targets
 
-There are two ways to run the test-suite when using Dune:
+There are two ways to run the test suite using Dune:
 
-- You can run the test-suite in-place, with output artifacts in the
-  tree using `make -C test-suite` (equivalent to running `make` inside
-  the `test-suite` directory), after having built Coq with `make -f
-  Makefile.dune world`. This will allow for incremental usage as
-  artifacts will be preserved.
+- After building Coq with `make -f Makefile.dune world`, you can run the test-suite
+  in place, generating output files in the source tree
+  by running `make -C test-suite` from the top directory of the source tree
+  (equivalent to running `make test-suite` from the `test-suite` directory).
+  This permits incremental usage since output files will be preserved.
 
-- You can also run the test-suite in an hygienic way using `make -f
+- You can also run the test suite in a hygienic way using `make -f
   Makefile.dune test-suite` or `dune runtest`. This is convenient for
-  full runs from scracth, for instance in CI.
+  full runs from scratch, for instance in CI.
 
-Given that `dune` still invokes the test-suite makefile, the
-environment variable `NJOBS` will control the value of the `-j` option
-that is passed to make; common call `NJOBS=8 dune runtest`. This will
-be resolved in the future once the test suite is ported to Dune rules.
+Since `dune` still invokes the test-suite makefile, the
+environment variable `NJOBS` is used to set the `-j` option
+that is passed to make (for example, with the command `NJOBS=8 dune runtest`). This use of `NJOBS`
+will be removed when the test suite is fully ported to Dune.
 
 There is preliminary support to build the API documentation and
 reference manual in HTML format, use `dune build {@doc,@refman-html}`

--- a/test-suite/README.md
+++ b/test-suite/README.md
@@ -1,10 +1,10 @@
 # Coq Test Suite
 
 The test suite can be run from the Coq root directory by `make test-suite`.
-However, for incremental test-suite builds, we recommend running `make` directly
+However, for incremental test suite builds, we recommend running `make`
 from the test-suite directory (or with `make -C test-suite`).
-This Makefile is compatible with both a full Dune build
-or a legacy hybrid build.
+This Makefile is compatible with both Dune
+and legacy hybrid builds.
 
 You can also run `make aaa/bbb/ccc.v.log` to build the log for one test,
 or `make ddd` where `ddd` is on of the sub-directories of `test-suite`

--- a/test-suite/README.md
+++ b/test-suite/README.md
@@ -1,10 +1,11 @@
 # Coq Test Suite
 
 The test suite can be run from the Coq root directory by `make test-suite`.
-This does a clean step first, so if you've already run it, then change something,
-you'll have to do a lot of work again.
+However, for incremental test-suite builds, we recommend running `make` directly
+from the test-suite directory (or with `make -C test-suite`).
+This Makefile is compatible with both a full Dune build
+or a legacy hybrid build.
 
-If you run `make` from the `test-suite` directory, there is no clean step.
 You can also run `make aaa/bbb/ccc.v.log` to build the log for one test,
 or `make ddd` where `ddd` is on of the sub-directories of `test-suite`
 to just build the logs for that directory.


### PR DESCRIPTION
This is split out of #14677 because this part should wait for #14625 before being merged.