### PR TITLE
Added #[projections(primitive)] attribute for structures.

### DIFF
--- a/doc/changelog/07-vernac-commands-and-options/14699-alizter+primitive-attribute.rst
+++ b/doc/changelog/07-vernac-commands-and-options/14699-alizter+primitive-attribute.rst
@@ -1,0 +1,6 @@
+- **Added:**
+  :attr:`projections(primitive)` attribute to make a record use
+  primitive projections
+  (`#14699 <https://github.com/coq/coq/pull/14699>`_,
+  fixes `#13150 <https://github.com/coq/coq/issues/13150>`_,
+  by Ali Caglayan).

--- a/doc/sphinx/addendum/type-classes.rst
+++ b/doc/sphinx/addendum/type-classes.rst
@@ -325,8 +325,10 @@ Summary of the commands
 
    Like any command declaring a record, this command supports the
    :attr:`universes(polymorphic)`, :attr:`universes(template)`,
-   :attr:`universes(cumulative)`, and :attr:`private(matching)`
-   attributes.
+   :attr:`universes(cumulative)` and :attr:`private(matching)` attributes.
+
+   When record syntax is used, this command also supports the
+   :attr:`projections(primitive)` :term:`attribute`.
 
    .. cmd:: Existing Class @qualid
 

--- a/doc/sphinx/language/core/coinductive.rst
+++ b/doc/sphinx/language/core/coinductive.rst
@@ -28,7 +28,10 @@ More information on co-inductive definitions can be found in
    This command supports the :attr:`universes(polymorphic)`,
    :attr:`universes(template)`, :attr:`universes(cumulative)`,
    :attr:`private(matching)`, :attr:`bypass_check(universes)`,
-   :attr:`bypass_check(positivity)`, and :attr:`using` attributes.
+   :attr:`bypass_check(positivity)` and :attr:`using` attributes.
+
+   When record syntax is used, this command also supports the
+   :attr:`projections(primitive)` :term:`attribute`.
 
 .. example::
 

--- a/doc/sphinx/language/core/inductive.rst
+++ b/doc/sphinx/language/core/inductive.rst
@@ -33,8 +33,11 @@ Inductive types
 
    This command supports the :attr:`universes(polymorphic)`,
    :attr:`universes(template)`, :attr:`universes(cumulative)`,
-   :attr:`bypass_check(positivity)`, :attr:`bypass_check(universes)`, and
+   :attr:`bypass_check(positivity)`, :attr:`bypass_check(universes)` and
    :attr:`private(matching)` attributes.
+
+   When record syntax is used, this command also supports the
+   :attr:`projections(primitive)` :term:`attribute`.
 
    Mutually inductive types can be defined by including multiple :n:`@inductive_definition`\s.
    The :n:`@ident`\s are simultaneously added to the global environment before

--- a/doc/sphinx/language/core/records.rst
+++ b/doc/sphinx/language/core/records.rst
@@ -3,12 +3,11 @@
 Record types
 ----------------
 
-The :cmd:`Record` construction is a macro allowing the definition of
-records as is done in many programming languages. Its syntax is
-described in the grammar below. In fact, the :cmd:`Record` macro is more general
-than the usual record types, since it allows also for “manifest”
-expressions. In this sense, the :cmd:`Record` construction allows defining
-“signatures”.
+The :cmd:`Record` construction is a :term:`command` allowing the definition of
+records as is done in many programming languages. Its syntax is described in the
+grammar below. In fact, the :cmd:`Record` :term:`command` is more general than
+the usual record types, since it allows also for “manifest”expressions. In this
+sense, the :cmd:`Record` construction allows defining“signatures”.
 
 .. _record_grammar:
 
@@ -53,8 +52,8 @@ expressions. In this sense, the :cmd:`Record` construction allows defining
    :cmd:`Record` and :cmd:`Structure` are synonyms.
 
    This command supports the :attr:`universes(polymorphic)`,
-   :attr:`universes(template)`, :attr:`universes(cumulative)`, and
-   :attr:`private(matching)` attributes.
+   :attr:`universes(template)`, :attr:`universes(cumulative)`,
+   :attr:`private(matching)` and :attr:`projections(primitive)` attributes.
 
 More generally, a record may have explicitly defined (a.k.a. manifest)
 fields. For instance, we might have:
@@ -79,7 +78,7 @@ in which case the correctness of :n:`@type__3` may rely on the instance :n:`@ter
    Note here that the fields ``Rat_bottom_cond`` depends on the field ``bottom``
    and ``Rat_irred_cond`` depends on both ``top`` and ``bottom``.
 
-Let us now see the work done by the ``Record`` macro. First the macro
+Let us now see the work done by the :cmd:`Record` command. First the command
 generates a variant type definition with just one constructor:
 :n:`Variant @ident {* @binder } : @sort := @ident__0 {* @binder }`.
 
@@ -139,7 +138,7 @@ This syntax can also be used for pattern matching.
      | _ => 0
      end).
 
-The macro generates also, when it is possible, the projection
+The :term:`command` generates also, when it is possible, the projection
 functions for destructuring an object of type :token:`ident`. These
 projection functions are given the names of the corresponding
 fields. If a field is named `_` then no projection is built
@@ -189,16 +188,16 @@ In each case, :token:`term0` is the object projected and the
 other arguments are the parameters of the inductive type.
 
 
-.. note:: Records defined with the ``Record`` keyword are not allowed to be
+.. note:: Records defined with the :cmd:`Record` command are not allowed to be
    recursive (references to the record's name in the type of its field
-   raises an  error). To define recursive records, one can use the ``Inductive``
-   and ``CoInductive`` keywords, resulting in an inductive or co-inductive record.
+   raises an  error). To define recursive records, one can use the
+   :cmd:`Inductive` and :cmd:`CoInductive` commands, resulting in an inductive or co-inductive record.
    Definition of mutually inductive or co-inductive records are also allowed, as long
    as all of the types in the block are records.
 
 .. note:: Induction schemes are automatically generated for inductive records.
    Automatic generation of induction schemes for non-recursive records
-   defined with the ``Record`` keyword can be activated with the
+   defined with the :cmd:`Record` command can be activated with the
    :flag:`Nonrecursive Elimination Schemes` flag (see :ref:`proofschemes-induction-principles`).
 
 .. warn:: @ident cannot be defined.
@@ -216,7 +215,8 @@ other arguments are the parameters of the inductive type.
 .. exn:: Records declared with the keyword Record or Structure cannot be recursive.
 
    The record name :token:`ident` appears in the type of its fields, but uses
-   the keyword ``Record``. Use  the keyword ``Inductive`` or ``CoInductive`` instead.
+   the :cmd:`Record` command. Use  the :cmd:`Inductive` or
+   :cmd:`CoInductive` command instead.
 
 .. exn:: Cannot handle mutually (co)inductive records.
 
@@ -235,20 +235,53 @@ the errors of inductive definitions, as described in Section
 Primitive Projections
 ~~~~~~~~~~~~~~~~~~~~~
 
+When the :flag:`Primitive Projections` flag is on or the
+:attr:`projections(primitive)` attribute is supplied for a :n:`Record` definition, its
+:g:`match` construct is disabled. To eliminate the record type, one must
+use its defined primitive projections.
+
+For compatibility, the parameters still appear when printing terms
+even though they are absent in the actual AST manipulated by the kernel. This
+can be changed by unsetting the :flag:`Printing Primitive Projection Parameters`
+flag.
+
+There are currently two ways to introduce primitive records types:
+
+#. Through the :cmd:`Record` command, in which case the type has to be
+   non-recursive. The defined type enjoys eta-conversion definitionally,
+   that is the generalized form of surjective pairing for records:
+   `r` ``= Build_``\ `R` ``(``\ `r`\ ``.(``\ |p_1|\ ``) …`` `r`\ ``.(``\ |p_n|\ ``))``.
+   Eta-conversion allows to define dependent elimination for these types as well.
+#. Through the :cmd:`Inductive` and :cmd:`CoInductive` commands, when
+   the :term:`body` of the definition is a record declaration of the form
+   ``Build_``\ `R` ``{`` |p_1| ``:`` |t_1|\ ``; … ;`` |p_n| ``:`` |t_n| ``}``.
+   In this case the types can be recursive and eta-conversion is disallowed.
+   Dependent elimination is not available for such types;
+   you must use non-dependent case analysis for these.
+
+For both cases the :flag:`Primitive Projections` :term:`flag` must be set or
+the :attr:`projections(primitive)` :term:`attribute`  must be supplied.
+
 .. flag:: Primitive Projections
 
-   This :term:`flag` turns on the use of primitive
-   projections when defining subsequent records (even through the ``Inductive``
-   and ``CoInductive`` commands). Primitive projections
-   extended the Calculus of Inductive Constructions with a new binary
-   term constructor `r.(p)` representing a primitive projection `p` applied
-   to a record object `r` (i.e., primitive projections are always applied).
-   Even if the record type has parameters, these do not appear
-   in the internal representation of
-   applications of the projection, considerably reducing the sizes of
-   terms when manipulating parameterized records and type checking time.
-   On the user level, primitive projections can be used as a replacement
-   for the usual defined ones, although there are a few notable differences.
+   This :term:`flag` turns on the use of primitive projections when defining
+   subsequent records (even through the :cmd:`Inductive` and :cmd:`CoInductive`
+   commands). Primitive projections extend the Calculus of Inductive
+   Constructions with a new binary term constructor `r.(p)` representing a
+   primitive projection `p` applied to a record object `r` (i.e., primitive
+   projections are always applied). Even if the record type has parameters,
+   these do not appear in the internal representation of applications of the
+   projection, considerably reducing the sizes of terms when manipulating
+   parameterized records and type checking time. On the user level, primitive
+   projections can be used as a replacement for the usual defined ones, although
+   there are a few notable differences.
+
+.. attr:: projections(primitive{? = {| yes | no } })
+   :name: projections(primitive)
+
+   This :term:`boolean attribute` can be used to override the value of the
+   :flag:`Primitive Projections` :term:`flag` for the record type being
+   defined.
 
 .. flag:: Printing Primitive Projection Parameters
 
@@ -256,47 +289,17 @@ Primitive Projections
    printing time (even though they are absent in the actual AST manipulated
    by the kernel).
 
-Primitive Record Types
-++++++++++++++++++++++
-
-When the :flag:`Primitive Projections` flag is on, definitions of
-record types change meaning. When a type is declared with primitive
-projections, its :g:`match` construct is disabled (see :ref:`primitive_projections` though).
-To eliminate the (co-)inductive type, one must use its defined primitive projections.
-
-.. The following paragraph is quite redundant with what is above
-
-For compatibility, the parameters still appear to the user when
-printing terms even though they are absent in the actual AST
-manipulated by the kernel. This can be changed by unsetting the
-:flag:`Printing Primitive Projection Parameters` flag.
-
-There are currently two ways to introduce primitive records types:
-
-#. Through the ``Record`` command, in which case the type has to be
-   non-recursive. The defined type enjoys eta-conversion definitionally,
-   that is the generalized form of surjective pairing for records:
-   `r` ``= Build_``\ `R` ``(``\ `r`\ ``.(``\ |p_1|\ ``) …`` `r`\ ``.(``\ |p_n|\ ``))``.
-   Eta-conversion allows to define dependent elimination for these types as well.
-#. Through the ``Inductive`` and ``CoInductive`` commands, when
-   the :term:`body` of the definition is a record declaration of the form
-   ``Build_``\ `R` ``{`` |p_1| ``:`` |t_1|\ ``; … ;`` |p_n| ``:`` |t_n| ``}``.
-   In this case the types can be recursive and eta-conversion is disallowed. These kind of record types
-   differ from their traditional versions in the sense that dependent
-   elimination is not available for them and only non-dependent case analysis
-   can be defined.
-
 Reduction
 +++++++++
 
 The basic reduction rule of a primitive projection is
 |p_i| ``(Build_``\ `R` |t_1| … |t_n|\ ``)`` :math:`{\rightarrow_{\iota}}` |t_i|.
-However, to take the δ flag into
-account, projections can be in two states: folded or unfolded. An
-unfolded primitive projection application obeys the rule above, while
-the folded version delta-reduces to the unfolded version. This allows to
-precisely mimic the usual unfolding rules of :term:`constants <constant>`. Projections
-obey the usual ``simpl`` flags of the ``Arguments`` command in particular.
+However, to take the δ flag into account, projections can be in two states:
+folded or unfolded. An unfolded primitive projection application obeys the rule
+above, while the folded version delta-reduces to the unfolded version. This
+allows to precisely mimic the usual unfolding rules of :term:`constants <constant>`.
+Projections obey the usual ``simpl`` flags of the :cmd:`Arguments`
+command in particular.
 There is currently no way to input unfolded primitive projections at the
 user-level, and there is no way to display unfolded projections differently
 from folded ones.
@@ -305,17 +308,16 @@ from folded ones.
 Compatibility Projections and :g:`match`
 ++++++++++++++++++++++++++++++++++++++++
 
-To ease compatibility with ordinary record types, each primitive
-projection is also defined as an ordinary :term:`constant` taking parameters and
-an object of the record type as arguments, and whose :term:`body` is an
-application of the unfolded primitive projection of the same name. These
-constants are used when elaborating partial applications of the
-projection. One can distinguish them from applications of the primitive
-projection if the :flag:`Printing Primitive Projection Parameters` flag
-is off: For a primitive projection application, parameters are printed
-as underscores while for the compatibility projections they are printed
-as usual.
+To ease compatibility with ordinary record types, each primitive projection is
+also defined as an ordinary :term:`constant` taking parameters and an object of
+the record type as arguments, and whose :term:`body` is an application of the
+unfolded primitive projection of the same name. These constants are used when
+elaborating partial applications of the projection. One can distinguish them
+from applications of the primitive projection if the :flag:`Printing Primitive
+Projection Parameters` flag is off: For a primitive projection application,
+parameters are printed as underscores while for the compatibility projections
+they are printed as usual.
 
-Additionally, user-written :g:`match` constructs on primitive records
-are desugared into substitution of the projections, they cannot be
-printed back as :g:`match` constructs.
+Additionally, user-written :g:`match` constructs on primitive records are
+desugared into substitution of the projections, they cannot be printed back as
+:g:`match` constructs.

--- a/test-suite/failure/PrimitiveProjectionsAttribute_Inductives.v
+++ b/test-suite/failure/PrimitiveProjectionsAttribute_Inductives.v
@@ -1,0 +1,22 @@
+Unset Primitive Projections.
+
+(* Definitional classes *don't* support primitive projections. *)
+Fail #[projections(primitive)]
+Class A := a : nat.
+
+(* Variants *don't* support primitive projections. *)
+Fail #[projections(primitive)]
+Variant D := .
+
+(* Inductives *don't* support primitive projections. *)
+Fail #[projections(primitive)]
+Inductive E := .
+
+(* (positive) CoInductives *don't* support primitive projections. *)
+Fail #[projections(primitive)]
+CoInductive F := .
+
+(* Mutual inductives *don't* support primitive projections. *)
+Fail #[projections(primitive)]
+Inductive H :=
+with I := .

--- a/test-suite/output/PrimitiveProjectionsAttribute.out
+++ b/test-suite/output/PrimitiveProjectionsAttribute.out
@@ -1,0 +1,37 @@
+Foo0 : Type
+
+Foo0 is not universe polymorphic
+Expands to: Inductive PrimitiveProjectionsAttribute.Foo0
+Foo1 : Type
+
+Foo1 is not universe polymorphic
+Foo1 has primitive projections with eta conversion.
+Expands to: Inductive PrimitiveProjectionsAttribute.Foo1
+Foo2 : Type
+
+Foo2 is not universe polymorphic
+Foo2 has primitive projections with eta conversion.
+Expands to: Inductive PrimitiveProjectionsAttribute.Foo2
+Foo3 : Type
+
+Foo3 is not universe polymorphic
+Expands to: Inductive PrimitiveProjectionsAttribute.Foo3
+Foo4 : Type
+
+Foo4 is not universe polymorphic
+Foo4 has primitive projections with eta conversion.
+Expands to: Inductive PrimitiveProjectionsAttribute.Foo4
+Foo5 : Type
+
+Foo5 is not universe polymorphic
+Foo5 has primitive projections with eta conversion.
+Expands to: Inductive PrimitiveProjectionsAttribute.Foo5
+Foo6 : Type
+
+Foo6 is not universe polymorphic
+Foo6 has primitive projections with eta conversion.
+Expands to: Inductive PrimitiveProjectionsAttribute.Foo6
+Foo7 : Type
+
+Foo7 is not universe polymorphic
+Expands to: Inductive PrimitiveProjectionsAttribute.Foo7

--- a/test-suite/output/PrimitiveProjectionsAttribute.v
+++ b/test-suite/output/PrimitiveProjectionsAttribute.v
@@ -1,0 +1,57 @@
+Unset Primitive Projections.
+
+Record Foo0 := {
+  bar0 : Type ;
+}.
+
+About Foo0.
+
+#[projections(primitive)]
+Record Foo1 := {
+  bar1 : Type ;
+}.
+
+About Foo1.
+
+#[projections(primitive=yes)]
+Record Foo2 := {
+  bar2 : Type ;
+}.
+
+About Foo2.
+
+#[projections(primitive=no)]
+Record Foo3 := {
+  bar3 : Type ;
+}.
+
+About Foo3.
+
+Set Primitive Projections.
+
+Record Foo4 := {
+  bar4 : Type ;
+}.
+
+About Foo4.
+
+#[projections(primitive)]
+Record Foo5 := {
+  bar5 : Type ;
+}.
+
+About Foo5.
+
+#[projections(primitive=yes)]
+Record Foo6 := {
+  bar6 : Type ;
+}.
+
+About Foo6.
+
+#[projections(primitive=no)]
+Record Foo7 := {
+  bar7 : Type ;
+}.
+
+About Foo7.

--- a/test-suite/output/PrimitiveProjectionsAttribute_Records.out
+++ b/test-suite/output/PrimitiveProjectionsAttribute_Records.out
@@ -1,0 +1,15 @@
+B : Set
+
+B is not universe polymorphic
+B has primitive projections with eta conversion.
+Expands to: Inductive PrimitiveProjectionsAttribute_Records.B
+C : Set
+
+C is not universe polymorphic
+C has primitive projections with eta conversion.
+Expands to: Inductive PrimitiveProjectionsAttribute_Records.C
+G : Type
+
+G is template universe polymorphic 
+G has primitive projections without eta conversion.
+Expands to: Inductive PrimitiveProjectionsAttribute_Records.G

--- a/test-suite/output/PrimitiveProjectionsAttribute_Records.v
+++ b/test-suite/output/PrimitiveProjectionsAttribute_Records.v
@@ -1,0 +1,16 @@
+Unset Primitive Projections.
+
+(* Classes *do* support primitive projections. *)
+#[projections(primitive)]
+Class B := { b : nat ; }.
+About B.
+
+(* Structures *do* support primitive projections. *)
+#[projections(primitive)]
+Structure C := { c : nat ; }.
+About C.
+
+(* (negative) CoInductives *do* support primitive projections. *)
+#[projections(primitive)]
+CoInductive G := { g : G }.
+About G.

--- a/vernac/record.mli
+++ b/vernac/record.mli
@@ -30,6 +30,7 @@ val definition_structure
   -> template:bool option
   -> cumulative:bool
   -> poly:bool
+  -> primitive_proj:bool
   -> Declarations.recursivity_kind
   -> Ast.t list
   -> GlobRef.t list


### PR DESCRIPTION
We move the flag `primitive_flag ()` to `vernacentries.ml` and instead pass a bool for enabling primitive projections. An attribute `#[projections(primitive{={yes|no}})]` is added allowing structures to have primitive projections enabled or disabled locally. By default, `primitive_flag ()` gets passed to the bool values, which appear in the decleration of structures.

Fixes / closes #13150

I've opted for `#[projections(...)]` as `#[primitive]` could be confused with the primitive data structures.

I'm waiting for more feedback before writing the documentation.

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  - [x] Documented any new / changed **user messages**.
  - [x] Updated **documented syntax** by running `make -f Makefile.make doc_gram_rsts`.

