### PR TITLE
Fixing bug in PR #14606: wrong split of scopes in t.(f) notation

### DIFF
--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -2428,7 +2428,7 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
             user_err ?loc:qid.CAst.loc (str "Projection " ++ pr_qualid qid ++ str " expected " ++ pr_choice int l ++
                            str (String.plural n " explicit parameter") ++ str ".")
       in
-      let subscopes1, subscopes2 = List.chop (List.length args1 + 1) subscopes in
+      let subscopes1, subscopes2 = List.chop (nexpectedparams + 1) subscopes in
       let c,args1 = List.sep_last (intern_impargs f env imps1 subscopes1 (args1@[c])) in
       let p = DAst.make ?loc:qid.CAst.loc (GRef (GlobRef.ConstRef p,us)) in
       let args2 = intern_impargs p env imps2 subscopes2 args2 in

--- a/test-suite/success/Scopes.v
+++ b/test-suite/success/Scopes.v
@@ -38,3 +38,14 @@ Check (@f 0) 0.
 Record R := { p : bool -> nat }.
 Check fun r => r.(@p) 0.
 End PropagateIndirect.
+
+Module ScopeProjNotation.
+
+Declare Scope foo_scope.
+Delimit Scope foo_scope with foo.
+Record prod A B := pair { fst : A ; snd : B }.
+Notation "[[ t , u ]]" := (pair _ _ t u) : foo_scope.
+Arguments fst {A B} p%foo.
+Check [[2,3]].(fst).
+
+End ScopeProjNotation.


### PR DESCRIPTION
This is a short amendment to #14606 fixing a miscount in scopes, as reported by @RalfJung in this [comment](https://github.com/coq/coq/pull/14606#issuecomment-885753680).

- [x] Added / updated **test-suite**.
