### PR TITLE
Mini-improvement formatting printing Arguments

### DIFF
--- a/test-suite/output/Arguments.out
+++ b/test-suite/output/Arguments.out
@@ -121,3 +121,10 @@ volatilematch is transparent
 Expands to: Constant Arguments.volatilematch
      = fun n : nat => volatilematch n
      : nat -> nat
+*** [ f : 
+A ->
+forall xxxxxxxxxxxxxx' xxxxxxxxxxxxxx'' : nat,
+nat -> xxxxxxxxxxxxxx' + xxxxxxxxxxxxxx' + xxxxxxxxxxxxxx'' = 0 ]
+
+Arguments f xxxxxxxxxxxxxx
+  (xxxxxxxxxxxxxx' xxxxxxxxxxxxxx'' xxxxxxxxxxxxxx''')%nat_scope

--- a/test-suite/output/Arguments.v
+++ b/test-suite/output/Arguments.v
@@ -64,3 +64,11 @@ Definition volatilematch (n : nat) :=
 Arguments volatilematch / n : simpl nomatch.
 About volatilematch.
 Eval simpl in fun n => volatilematch n.
+
+Module Formatting.
+
+Parameter A : Type.
+Parameter f : forall (xxxxxxxxxxxxxx : A) (xxxxxxxxxxxxxx' : nat) (xxxxxxxxxxxxxx'' : nat) (xxxxxxxxxxxxxx''' : nat), xxxxxxxxxxxxxx' + xxxxxxxxxxxxxx' + xxxxxxxxxxxxxx'' = 0.
+Print f.
+
+End Formatting.

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -1133,8 +1133,8 @@ let pr_vernac_expr v =
                       notation_scope = s;
                       implicit_status = imp } :: tl ->
             let extra, tl = get_arguments_like s imp tl in
-            spc() ++ pr_br imp (extra<>[]) (prlist_with_sep spc pr_one_arg ((id,k)::extra)) ++
-            pr_s s ++ print_arguments tl
+            spc() ++ hov 1 (pr_br imp (extra<>[]) (prlist_with_sep spc pr_one_arg ((id,k)::extra)) ++
+            pr_s s) ++ print_arguments tl
         in
         let rec print_implicits = function
           | [] -> mt ()


### PR DESCRIPTION
**Kind:** enhancement

It happened that `Arguments` is sometimes formatted as follows:
```
Arguments f x {x'
  x''}
```
This PR ensures that a surrounded block of similar arguments is treated as a formatting box, giving instead:
```
Arguments f x
  {x' x''}
```
or, if a cut is really needed:
```
Arguments f x
  {longname
   otherlongname}
```
- [x] Added / updated **test-suite**.