### PR TITLE
Storing a full env rather than just a named env in evars.

### DIFF
--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -55,7 +55,7 @@ val new_pure_evar :
   ?naming:intro_pattern_naming_expr ->
   ?typeclass_candidate:bool ->
   ?principal:bool ->
-  named_context_val -> evar_map -> types -> evar_map * Evar.t
+  env -> evar_map -> types -> evar_map * Evar.t
 
 (** Create a new Type existential variable, as we keep track of
     them during type-checking and unification. *)
@@ -263,7 +263,7 @@ val push_rel_decl_to_named_context : ?hypnaming:naming_mode ->
 
 val push_rel_context_to_named_context : ?hypnaming:naming_mode ->
   Environ.env -> evar_map -> types ->
-  named_context_val * types * constr list * csubst
+  env * types * constr list * csubst
 
 val generalize_evar_over_rels : evar_map -> existential -> types * constr list
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -107,8 +107,8 @@ type evar_body =
 type evar_info = {
   evar_concl : econstr;
   (** Type of the evar. *)
-  evar_hyps : named_context_val; (* TODO econstr? *)
-  (** Context of the evar. *)
+  evar_env : env;
+  (** Environment of the evar. *)
   evar_body : evar_body;
   (** Optional content of the evar. *)
   evar_filter : Filter.t;
@@ -128,8 +128,9 @@ type evar_info = {
       filtered environment. *)
 }
 
-val make_evar : named_context_val -> etypes -> evar_info
+val make_evar : env -> etypes -> evar_info
 val evar_concl : evar_info -> econstr
+val evar_context_constr : evar_info -> (constr, types) Context.Named.pt
 val evar_context : evar_info -> (econstr, etypes) Context.Named.pt
 val evar_filtered_context : evar_info -> (econstr, etypes) Context.Named.pt
 val evar_hyps : evar_info -> named_context_val
@@ -137,9 +138,10 @@ val evar_filtered_hyps : evar_info -> named_context_val
 val evar_body : evar_info -> evar_body
 val evar_candidates : evar_info -> constr list option
 val evar_filter : evar_info -> Filter.t
-val evar_env : env -> evar_info -> env
-val evar_filtered_env : env -> evar_info -> env
+val evar_env : evar_info -> env
+val evar_filtered_env : evar_info -> env
 val evar_identity_subst : evar_info -> econstr list
+val evar_ids : evar_info -> Id.Set.t
 
 val map_evar_body : (econstr -> econstr) -> evar_body -> evar_body
 val map_evar_info : (econstr -> econstr) -> evar_info -> evar_info

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -45,7 +45,7 @@ let evar_suggested_name evk sigma =
   | _,Evar_kinds.QuestionMark {Evar_kinds.qm_name = Name id} -> id
   | _,Evar_kinds.GoalEvar -> Id.of_string "Goal"
   | _ ->
-      let env = reset_with_named_context evi.evar_hyps (Global.env()) in
+      let env = evar_env evi in
       Namegen.id_of_name_using_hdchar env sigma evi.evar_concl Anonymous
   in
   let names = EvMap.mapi base_id (undefined_map sigma) in

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -201,6 +201,9 @@ let map_named_val f ctxt =
   if map == ctxt.env_named_map then ctxt
   else { env_named_ctx = ctx; env_named_map = map; env_named_var = ctxt.env_named_var }
 
+let map_with_named_val f env =
+  {env with env_named_context = map_named_val f env.env_named_context}
+
 let push_named d env =
   {env with env_named_context = push_named_context_val d env.env_named_context}
 

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -150,6 +150,8 @@ val ids_of_named_context_val : named_context_val -> Id.Set.t
    *** /!\ ***   [f t] should be convertible with t, and preserve the name *)
 val map_named_val :
    (named_declaration -> named_declaration) -> named_context_val -> named_context_val
+val map_with_named_val :
+   (named_declaration -> named_declaration) -> env -> env
 
 val push_named : Constr.named_declaration -> env -> env
 val push_named_context : Constr.named_context -> env -> env

--- a/plugins/ltac/evar_tactics.ml
+++ b/plugins/ltac/evar_tactics.ml
@@ -29,7 +29,7 @@ let instantiate_evar evk (ist,rawc) =
   Proofview.Goal.enter begin fun gl ->
   let sigma = Proofview.Goal.sigma gl in
   let evi = Evd.find sigma evk in
-  let filtered = Evd.evar_filtered_env env evi in
+  let filtered = Evd.evar_filtered_env evi in
   let constrvars = Tacinterp.extract_ltac_constr_values ist filtered in
   let lvar = {
     ltac_constrs = constrvars;
@@ -37,7 +37,7 @@ let instantiate_evar evk (ist,rawc) =
     ltac_idents = Names.Id.Map.empty;
     ltac_genargs = ist.Geninterp.lfun;
   } in
-  let sigma' = w_refine (evk,evi) (lvar ,rawc) env sigma in
+  let sigma' = w_refine (evk,evi) (lvar,rawc) env sigma in
   Proofview.Unsafe.tclEVARS sigma'
   end
 

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -630,7 +630,7 @@ let solve_remaining_by env sigma holes by =
       | None -> sigma
         (* Evar should not be defined, but just in case *)
       | Some evi ->
-        let env = Environ.reset_with_named_context evi.evar_hyps env in
+        let env = evar_env evi in
         let ty = evi.evar_concl in
         let name, poly = Id.of_string "rewrite", false in
         let c, sigma = Proof.refine_by_tactic ~name ~poly env sigma ty solve_tac in

--- a/plugins/ring/ring.ml
+++ b/plugins/ring/ring.ml
@@ -162,8 +162,7 @@ let ltac_call tac (args:glob_tactic_arg list) =
   CAst.make @@ TacArg (TacCall (CAst.make (ArgArg(Loc.tag @@ Lazy.force tac),args)))
 
 let dummy_goal env sigma =
-  let (gl,_,sigma) =
-    Goal.V82.mk_goal sigma (named_context_val env) EConstr.mkProp in
+  let (gl,_,sigma) = Goal.V82.mk_goal sigma env EConstr.mkProp in
   {Evd.it = gl; Evd.sigma = sigma}
 
 let constr_of sigma v = match Value.to_constr v with

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -1350,12 +1350,11 @@ let tacTYPEOF c = Goal.enter_one ~__LOC__ (fun g ->
 let unsafe_intro env decl b =
   let open Context.Named.Declaration in
   Refine.refine ~typecheck:false begin fun sigma ->
-    let ctx = Environ.named_context_val env in
-    let nctx = EConstr.push_named_context_val decl ctx in
+    let nenv = EConstr.push_named decl env in
     let inst = EConstr.identity_subst_val (Environ.named_context_val env) in
     let ninst = EConstr.mkRel 1 :: inst in
     let nb = EConstr.Vars.subst1 (EConstr.mkVar (get_id decl)) b in
-    let sigma, ev = Evarutil.new_pure_evar ~principal:true nctx sigma nb in
+    let sigma, ev = Evarutil.new_pure_evar ~principal:true nenv sigma nb in
     sigma, EConstr.mkNamedLambda_or_LetIn decl (EConstr.mkEvar (ev, ninst))
   end
 

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -971,7 +971,7 @@ let thin id sigma goal =
   match ans with
   | None -> sigma
   | Some (sigma, hyps, concl) ->
-    let (gl,ev,sigma) = Goal.V82.mk_goal sigma hyps concl in
+    let (gl,ev,sigma) = Goal.V82.mk_goal sigma (Environ.reset_with_named_context hyps env) concl in
     let sigma = Goal.V82.partial_solution_to env sigma goal gl ev in
     sigma
 

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -1398,9 +1398,8 @@ let second_order_matching flags env_rhs evd (evk,args) (test,argoccs) rhs =
   try
   let evi = Evd.find_undefined evd evk in
   let evi = nf_evar_info evd evi in
-  let env_evar_unf = evar_env env_rhs evi in
-  let env_evar = evar_filtered_env env_rhs evi in
-  let sign = named_context_val env_evar in
+  let env_evar_unf = evar_env evi in
+  let env_evar = evar_filtered_env evi in
   let ctxt = evar_filtered_context evi in
   debug_ho_unification (fun () ->
      Pp.(str"env rhs: " ++ Termops.Internal.print_env env_rhs ++ fnl () ++
@@ -1469,7 +1468,7 @@ let second_order_matching flags env_rhs evd (evk,args) (test,argoccs) rhs =
               refresh_universes ~status:Evd.univ_flexible (Some true)
                 env_evar_unf evd evty
             else evd, evty in
-          let (evd, evk) = new_pure_evar sign evd evty ~filter in
+          let (evd, evk) = new_pure_evar (evar_env evi) evd evty ~filter in
           let fixed = Evar.Set.add evk fixed in
           evsref := (evk,evty,inst,prefer_abstraction)::!evsref;
           evd, fixed, mkEvar (evk, instance)
@@ -1541,7 +1540,7 @@ let second_order_matching flags env_rhs evd (evk,args) (test,argoccs) rhs =
          else
            ((debug_ho_unification (fun () ->
                let evi = Evd.find evd evk in
-               let env = Evd.evar_env env_rhs evi in
+               let env = Evd.evar_env evi in
                Pp.(str"evar is defined: " ++
                  int (Evar.repr evk) ++ spc () ++
                  prc env evd (match evar_body evi with Evar_defined c -> c
@@ -1557,7 +1556,7 @@ let second_order_matching flags env_rhs evd (evk,args) (test,argoccs) rhs =
        (debug_ho_unification (fun () ->
           begin
             let evi = Evd.find evd evk in
-            let evenv = evar_env env_rhs evi in
+            let evenv = evar_env evi in
             let body = match evar_body evi with Evar_empty -> assert false | Evar_defined c -> c in
             Pp.(str"evar was defined already as: " ++ prc evenv evd body)
           end);
@@ -1565,7 +1564,7 @@ let second_order_matching flags env_rhs evd (evk,args) (test,argoccs) rhs =
      else
        try
          let evi = Evd.find_undefined evd evk in
-         let evenv = evar_env env_rhs evi in
+         let evenv = evar_env evi in
          let rhs' = nf_evar evd rhs' in
            debug_ho_unification (fun () ->
              Pp.(str"abstracted type before second solve_evars: " ++

--- a/pretyping/evarsolve.mli
+++ b/pretyping/evarsolve.mli
@@ -172,7 +172,7 @@ val noccur_evar : env -> evar_map -> Evar.t -> constr -> bool
 exception IllTypedInstance of env * types * types
 
 val check_evar_instance : unifier -> unify_flags ->
-  env -> evar_map -> Evar.t -> constr -> evar_map
+  evar_map -> Evar.t -> constr -> evar_map
   (** May raise IllTypedInstance if types are not convertible *)
 
 val remove_instance_local_defs :

--- a/pretyping/globEnv.ml
+++ b/pretyping/globEnv.ml
@@ -106,7 +106,7 @@ let new_evar env sigma ?src ?naming typ =
   let instance = rel_list (nb_rel env.renamed_env) inst_vars in
   let (subst, _, sign) = Lazy.force env.extra in
   let typ' = csubst_subst subst typ in
-  let (sigma, evk) = new_pure_evar sign sigma typ' ?src ?naming in
+  let (sigma, evk) = new_pure_evar (reset_with_named_context sign env.renamed_env) sigma typ' ?src ?naming in
   (sigma, mkEvar (evk, instance))
 
 let new_type_evar env sigma ~src =

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -388,7 +388,7 @@ let dummy = mkProp
 (* Mark every occurrence of substituted vars (associated to a function)
    as a problem variable: an evar that can be instantiated either by
    vfx (expanded fixpoint) or vfun (named function). *)
-let substl_with_function subst sigma constr =
+let substl_with_function subst env sigma constr =
   let evd = ref sigma in
   let minargs = ref Evar.Map.empty in
   let v = Array.of_list subst in
@@ -398,7 +398,7 @@ let substl_with_function subst sigma constr =
       match v.(i-k-1) with
       | (fx, Some (min, ref)) ->
         let sigma = !evd in
-        let (sigma, evk) = Evarutil.new_pure_evar empty_named_context_val sigma dummy in
+        let (sigma, evk) = Evarutil.new_pure_evar (reset_context env) sigma dummy in
         evd := sigma;
         minargs := Evar.Map.add evk (min, fx, ref) !minargs;
         mkEvar (evk, [])
@@ -442,7 +442,7 @@ let solve_arity_problem env sigma fxminargs c =
 
 let substl_checking_arity env subst sigma c =
   (* we initialize the problem: *)
-  let body,sigma,minargs = substl_with_function subst sigma c in
+  let body,sigma,minargs = substl_with_function subst env sigma c in
   (* we collect arity constraints *)
   let ans = solve_arity_problem env sigma minargs body in
   (* we propagate the constraints: solved problems are substituted;

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -503,8 +503,8 @@ let pr_concl n ?(diffs=false) ?og_s sigma g =
   header ++ str " is:" ++ cut () ++ str" "  ++ pc
 
 (* display evar type: a context and a type *)
-let pr_evgl_sign env sigma evi =
-  let env = evar_env env evi in
+let pr_evgl_sign sigma evi =
+  let env = evar_env evi in
   let ps = pr_named_context_of env sigma in
   let _, l = match Filter.repr (evar_filter evi) with
   | None -> [], []
@@ -530,8 +530,7 @@ let pr_evgl_sign env sigma evi =
 (* Print an existential variable *)
 
 let pr_evar sigma (evk, evi) =
-  let env = Global.env () in
-  let pegl = pr_evgl_sign env sigma evi in
+  let pegl = pr_evgl_sign sigma evi in
   hov 0 (pr_existential_key sigma evk ++ str " : " ++ pegl)
 
 (* Print an enumerated list of existential variables *)

--- a/proofs/evar_refiner.ml
+++ b/proofs/evar_refiner.ml
@@ -47,7 +47,7 @@ let define_and_solve_constraints evk c env evd =
 let w_refine (evk,evi) (ltac_var,rawc) env sigma =
   if Evd.is_defined sigma evk then
     user_err Pp.(str "Instantiate called on already-defined evar");
-  let env = Evd.evar_filtered_env env evi in
+  let env = Evd.evar_filtered_env evi in
   let sigma',typed_c =
     let flags = {
       Pretyping.use_typeclasses = Pretyping.UseTC;

--- a/proofs/goal.ml
+++ b/proofs/goal.ml
@@ -30,9 +30,8 @@ module V82 = struct
 
   (* Old style env primitive *)
   let env evars gl =
-    let env = Global.env () in
     let evi = Evd.find evars gl in
-    Evd.evar_filtered_env env evi
+    Evd.evar_filtered_env evi
 
   (* Old style hyps primitive *)
   let hyps evars gl =
@@ -51,15 +50,15 @@ module V82 = struct
     evi.Evd.evar_concl
 
   (* Old style mk_goal primitive *)
-  let mk_goal evars hyps concl =
+  let mk_goal evars env concl =
     (* A goal created that way will not be used by refine and will not
        be shelved. It must not appear as a future_goal, so the future
        goals are restored to their initial value after the evar is
        created. *)
     let evars = Evd.push_future_goals evars in
-    let inst = EConstr.identity_subst_val hyps in
+    let inst = EConstr.identity_subst_val (Environ.named_context_val env) in
     let (evars,evk) =
-      Evarutil.new_pure_evar ~src:(Loc.tag Evar_kinds.GoalEvar) ~typeclass_candidate:false ~identity:inst hyps evars concl
+      Evarutil.new_pure_evar ~src:(Loc.tag Evar_kinds.GoalEvar) ~typeclass_candidate:false ~identity:inst env evars concl
     in
     let _, evars = Evd.pop_future_goals evars in
     let ev = EConstr.mkEvar (evk,inst) in

--- a/proofs/goal.mli
+++ b/proofs/goal.mli
@@ -43,7 +43,7 @@ module V82 : sig
        hypotheses and conclusion, together with a term which is precisely
        the evar corresponding to the goal, and an updated evar_map. *)
   val mk_goal : Evd.evar_map ->
-                         Environ.named_context_val ->
+                         Environ.env ->
                          EConstr.constr ->
                          goal * EConstr.constr * Evd.evar_map
 

--- a/proofs/logic.ml
+++ b/proofs/logic.ml
@@ -317,7 +317,6 @@ let goal_type_of ~check env sigma c =
   else (sigma, EConstr.Unsafe.to_constr (Retyping.get_type_of env sigma (EConstr.of_constr c)))
 
 let rec mk_refgoals ~check env sigma goalacc conclty trm =
-  let hyps = Environ.named_context_val env in
   let mk_goal hyps concl =
     Goal.V82.mk_goal sigma hyps concl
   in
@@ -332,7 +331,7 @@ let rec mk_refgoals ~check env sigma goalacc conclty trm =
         let conclty = nf_betaiota env sigma conclty in
           if check && occur_meta sigma conclty then
             raise (RefinerError (env, sigma, MetaInType conclty));
-          let (gl,ev,sigma) = mk_goal hyps conclty in
+          let (gl,ev,sigma) = mk_goal env conclty in
           let ev = EConstr.Unsafe.to_constr ev in
           let conclty = EConstr.Unsafe.to_constr conclty in
           gl::goalacc, conclty, sigma, ev
@@ -401,13 +400,12 @@ let rec mk_refgoals ~check env sigma goalacc conclty trm =
  * Metas should be casted. *)
 
 and mk_hdgoals ~check env sigma goalacc trm =
-  let hyps = Environ.named_context_val env in
   let mk_goal hyps concl =
     Goal.V82.mk_goal sigma hyps concl in
   match kind trm with
     | Cast (c,_, ty) when isMeta c ->
         let sigma = check_typability ~check env sigma ty in
-        let (gl,ev,sigma) = mk_goal hyps (nf_betaiota env sigma (EConstr.of_constr ty)) in
+        let (gl,ev,sigma) = mk_goal env (nf_betaiota env sigma (EConstr.of_constr ty)) in
         let ev = EConstr.Unsafe.to_constr ev in
         gl::goalacc,ty,sigma,ev
 

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -446,7 +446,7 @@ module V82 = struct
         else
           CList.nth evl (n-1)
       in
-      let env = Evd.evar_filtered_env env evi in
+      let env = Evd.evar_filtered_env evi in
       let rawc = intern env sigma in
       let ltac_vars = Glob_ops.empty_lvar in
       let sigma = Evar_refiner.w_refine (evk, evi) (ltac_vars, rawc) env sigma in

--- a/user-contrib/Ltac2/tac2core.ml
+++ b/user-contrib/Ltac2/tac2core.ml
@@ -700,7 +700,7 @@ let () = define3 "constr_in_context" ident constr closure begin fun id t c ->
       let open Context.Named.Declaration in
       let nenv = EConstr.push_named (LocalAssum (Context.make_annot id Sorts.Relevant, t)) env in
       let (sigma, (evt, _)) = Evarutil.new_type_evar nenv sigma Evd.univ_flexible in
-      let (sigma, evk) = Evarutil.new_pure_evar (Environ.named_context_val nenv) sigma evt in
+      let (sigma, evk) = Evarutil.new_pure_evar nenv sigma evt in
       Proofview.Unsafe.tclEVARS sigma >>= fun () ->
       Proofview.Unsafe.tclSETGOALS [Proofview.with_empty_state evk] >>= fun () ->
       thaw c >>= fun _ ->

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -2115,7 +2115,7 @@ end
 
 let default_tactic = ref (Proofview.tclUNIT ())
 
-let evar_of_obligation o = Evd.make_evar (Global.named_context_val ()) (EConstr.of_constr o.obl_type)
+let evar_of_obligation o = Evd.make_evar (Global.env ()) (EConstr.of_constr o.obl_type)
 
 let subst_deps expand obls deps t =
   let osubst = Obls_.obl_substitution expand obls deps in

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -614,7 +614,7 @@ let rec explain_evar_kind env sigma evk ty =
 let explain_typeclass_resolution env sigma evi k =
   match Typeclasses.class_of_constr env sigma evi.evar_concl with
   | Some _ ->
-    let env = Evd.evar_filtered_env env evi in
+    let env = Evd.evar_filtered_env evi in
       fnl () ++ str "Could not find an instance for " ++
       pr_leconstr_env env sigma evi.evar_concl ++
       pr_trailing_ne_context_of env sigma
@@ -631,7 +631,7 @@ let explain_placeholder_kind env sigma c e =
 
 let explain_unsolvable_implicit env sigma evk explain =
   let evi = Evarutil.nf_evar_info sigma (Evd.find_undefined sigma evk) in
-  let env = Evd.evar_filtered_env env evi in
+  let env = Evd.evar_filtered_env evi in
   let type_of_hole = pr_leconstr_env env sigma evi.evar_concl in
   let pe = pr_trailing_ne_context_of env sigma in
   strbrk "Cannot infer " ++
@@ -826,10 +826,10 @@ let explain_cannot_unify_occurrences env sigma nested ((cl2,pos2),t2) ((cl1,pos1
 let pr_constraints printenv env sigma evars cstrs =
   let (ev, evi) = Evar.Map.choose evars in
     if Evar.Map.for_all (fun ev' evi' ->
-      eq_named_context_val evi.evar_hyps evi'.evar_hyps) evars
+      eq_named_context_val (evar_hyps evi) (evar_hyps evi')) evars
     then
       let l = Evar.Map.bindings evars in
-      let env' = reset_with_named_context evi.evar_hyps env in
+      let env' = evar_env evi in
       let pe =
         if printenv then
           pr_ne_context_of (str "In environment:") env' sigma

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -542,7 +542,7 @@ let program_inference_hook env sigma ev =
   let tac = !Declare.Obls.default_tactic in
   let evi = Evd.find sigma ev in
   let evi = Evarutil.nf_evar_info sigma evi in
-  let env = Evd.evar_filtered_env env evi in
+  let env = Evd.evar_filtered_env evi in
   try
     let concl = evi.Evd.evar_concl in
     if not (Evarutil.is_ground_env sigma env &&


### PR DESCRIPTION
**Kind:** refactoring

First this is more intuitive than reconstructing an env from hyps every time. Second, it would eventually allow hidding some global references locally to an evar.

At the current time, experimenting CI and bench.