### PR TITLE
Handling universe context and names together and centrally treating in declare.ml

### DIFF
--- a/dev/ci/user-overlays/14711-herbelin-master+univs-ctx-and-binders-centralized.sh
+++ b/dev/ci/user-overlays/14711-herbelin-master+univs-ctx-and-binders-centralized.sh
@@ -1,0 +1,6 @@
+overlay equations https://github.com/herbelin/Coq-Equations master+adapt-coq-pr14711-univs-ctx-and-binders-centralized 14711 master+univs-ctx-and-binders-centralized
+overlay elpi https://github.com/herbelin/coq-elpi coq-master+adapt-coq-pr14711-univs-ctx-and-binders-centralized 14711 master+univs-ctx-and-binders-centralized
+overlay paramcoq https://github.com/herbelin/paramcoq master+adapt-coq-pr14711-univs-ctx-and-binders-centralized 14711 master+univs-ctx-and-binders-centralized
+overlay mtac2 https://github.com/herbelin/Mtac2 master+adapt-coq-pr14711-univs-ctx-and-binders-centralized 14711 master+univs-ctx-and-binders-centralized
+overlay rewriter https://github.com/herbelin/rewriter master+adapt-coq-pr14711-univs-ctx-and-binders-centralized 14711 master+univs-ctx-and-binders-centralized
+overlay metacoq https://github.com/herbelin/template-coq master+adapt-coq-pr14711-univs-ctx-and-binders-centralized 14711 master+univs-ctx-and-binders-centralized

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -667,9 +667,9 @@ val universes : evar_map -> UGraph.t
     [Univ.ContextSet.to_context]. *)
 val to_universe_context : evar_map -> Univ.UContext.t
 
-val univ_entry : poly:bool -> evar_map -> Entries.universes_entry * UnivNames.universe_binders
+val univ_entry : poly:bool -> evar_map -> UState.named_universes_entry
 
-val check_univ_decl : poly:bool -> evar_map -> UState.universe_decl -> Entries.universes_entry * UnivNames.universe_binders
+val check_univ_decl : poly:bool -> evar_map -> UState.universe_decl -> UState.named_universes_entry
 
 val merge_universe_context : evar_map -> UState.t -> evar_map
 val set_universe_context : evar_map -> UState.t -> evar_map

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -667,9 +667,9 @@ val universes : evar_map -> UGraph.t
     [Univ.ContextSet.to_context]. *)
 val to_universe_context : evar_map -> Univ.UContext.t
 
-val univ_entry : poly:bool -> evar_map -> Entries.universes_entry
+val univ_entry : poly:bool -> evar_map -> Entries.universes_entry * UnivNames.universe_binders
 
-val check_univ_decl : poly:bool -> evar_map -> UState.universe_decl -> Entries.universes_entry
+val check_univ_decl : poly:bool -> evar_map -> UState.universe_decl -> Entries.universes_entry * UnivNames.universe_binders
 
 val merge_universe_context : evar_map -> UState.t -> evar_map
 val set_universe_context : evar_map -> UState.t -> evar_map

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -121,6 +121,8 @@ let context uctx =
   let (_, rbinders) = uctx.names in
   ContextSet.to_context (compute_instance_binders rbinders) uctx.local
 
+type named_universes_entry = Entries.universes_entry * UnivNames.universe_binders
+
 let univ_entry ~poly uctx =
   let open Entries in
   let (binders, _) = uctx.names in

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -123,8 +123,11 @@ let context uctx =
 
 let univ_entry ~poly uctx =
   let open Entries in
-  if poly then Polymorphic_entry (context uctx)
-  else Monomorphic_entry (context_set uctx)
+  let (binders, _) = uctx.names in
+  let entry =
+    if poly then Polymorphic_entry (context uctx)
+    else Monomorphic_entry (context_set uctx) in
+  entry, binders
 
 let of_context_set local = { empty with local }
 
@@ -440,15 +443,15 @@ let check_univ_decl ~poly uctx decl =
       (ContextSet.constraints uctx.local);
   let names = decl.univdecl_instance in
   let extensible = decl.univdecl_extensible_instance in
+  let (binders, rbinders) = uctx.names in
   if poly then
-    let (_, rbinders) = uctx.names in
     let inst, csts = universe_context ~names ~extensible uctx in
     let nas = compute_instance_binders rbinders inst in
     let uctx = UContext.make nas (inst, csts) in
-    Entries.Polymorphic_entry uctx
+    Entries.Polymorphic_entry uctx, binders
   else
     let () = check_universe_context_set ~names ~extensible uctx in
-    Entries.Monomorphic_entry uctx.local
+    Entries.Monomorphic_entry uctx.local, binders
 
 let is_bound l lbound = match lbound with
   | UGraph.Bound.Prop -> Level.is_prop l

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -81,7 +81,7 @@ val constraints : t -> Univ.Constraints.t
 val context : t -> Univ.UContext.t
 (** Shorthand for {!context_set} with {!Context_set.to_context}. *)
 
-val univ_entry : poly:bool -> t -> Entries.universes_entry
+val univ_entry : poly:bool -> t -> Entries.universes_entry * UnivNames.universe_binders
 (** Pick from {!context} or {!context_set} based on [poly]. *)
 
 val universe_binders : t -> UnivNames.universe_binders
@@ -202,7 +202,7 @@ val default_univ_decl : universe_decl
    When polymorphic, the universes corresponding to
    [decl.univdecl_instance] come first in the order defined by that
    list. *)
-val check_univ_decl : poly:bool -> t -> universe_decl -> Entries.universes_entry
+val check_univ_decl : poly:bool -> t -> universe_decl -> Entries.universes_entry * UnivNames.universe_binders
 
 val check_mono_univ_decl : t -> universe_decl -> Univ.ContextSet.t
 

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -81,7 +81,9 @@ val constraints : t -> Univ.Constraints.t
 val context : t -> Univ.UContext.t
 (** Shorthand for {!context_set} with {!Context_set.to_context}. *)
 
-val univ_entry : poly:bool -> t -> Entries.universes_entry * UnivNames.universe_binders
+type named_universes_entry = Entries.universes_entry * UnivNames.universe_binders
+
+val univ_entry : poly:bool -> t -> named_universes_entry
 (** Pick from {!context} or {!context_set} based on [poly]. *)
 
 val universe_binders : t -> UnivNames.universe_binders
@@ -202,7 +204,7 @@ val default_univ_decl : universe_decl
    When polymorphic, the universes corresponding to
    [decl.univdecl_instance] come first in the order defined by that
    list. *)
-val check_univ_decl : poly:bool -> t -> universe_decl -> Entries.universes_entry * UnivNames.universe_binders
+val check_univ_decl : poly:bool -> t -> universe_decl -> named_universes_entry
 
 val check_mono_univ_decl : t -> universe_decl -> Univ.ContextSet.t
 

--- a/interp/modintern.ml
+++ b/interp/modintern.ml
@@ -109,7 +109,7 @@ let transl_with_decl env base kind = function
     let sigma, udecl = interp_univ_decl_opt env udecl in
     let c, ectx = interp_constr env sigma c in
     let poly = lookup_polymorphism env base kind fqid in
-    begin match UState.check_univ_decl ~poly ectx udecl with
+    begin match fst (UState.check_univ_decl ~poly ectx udecl) with
       | Entries.Polymorphic_entry ctx ->
         let inst, ctx = Univ.abstract_universes ctx in
         let c = EConstr.Vars.subst_univs_level_constr (Univ.make_instance_subst inst) c in

--- a/plugins/ring/ring.ml
+++ b/plugins/ring/ring.ml
@@ -148,7 +148,7 @@ let decl_constant name univs c =
   let univs = UState.restrict_universe_context ~lbound:(Global.universes_lbound ()) univs vars in
   let () = DeclareUctx.declare_universe_context ~poly:false univs in
   let types = (Typeops.infer (Global.env ()) c).uj_type in
-  let univs = Monomorphic_entry Univ.ContextSet.empty in
+  let univs = Monomorphic_entry Univ.ContextSet.empty, UnivNames.empty_binders in
   mkConst(declare_constant ~name
             ~kind:Decls.(IsProof Lemma)
             (DefinitionEntry (definition_entry ~opaque:true ~types ~univs c)))

--- a/tactics/ind_tables.mli
+++ b/tactics/ind_tables.mli
@@ -67,7 +67,7 @@ val pr_scheme_kind : 'a scheme_kind -> Pp.t
 
 val declare_definition_scheme :
   (internal : bool
-   -> univs:Entries.universes_entry
+   -> univs:(Entries.universes_entry * UnivNames.universe_binders)
    -> role:Evd.side_effect_role
    -> name:Id.t
    -> Constr.t

--- a/tactics/ind_tables.mli
+++ b/tactics/ind_tables.mli
@@ -67,7 +67,7 @@ val pr_scheme_kind : 'a scheme_kind -> Pp.t
 
 val declare_definition_scheme :
   (internal : bool
-   -> univs:(Entries.universes_entry * UnivNames.universe_binders)
+   -> univs:UState.named_universes_entry
    -> role:Evd.side_effect_role
    -> name:Id.t
    -> Constr.t

--- a/test-suite/misc/poly-capture-global-univs/src/evilImpl.ml
+++ b/test-suite/misc/poly-capture-global-univs/src/evilImpl.ml
@@ -8,13 +8,13 @@ let evil name name_f =
   let u = Level.var 0 in
   let tu = mkType (Universe.make u) in
   let te = Declare.definition_entry
-      ~univs:(Monomorphic_entry (ContextSet.singleton u)) tu
+      ~univs:(Monomorphic_entry (ContextSet.singleton u), UnivNames.empty_binders) tu
   in
   let tc = Declare.declare_constant ~name ~kind (Declare.DefinitionEntry te) in
   let tc = mkConst tc in
 
   let fe = Declare.definition_entry
-      ~univs:(Polymorphic_entry (UContext.make [|Anonymous|] (Instance.of_array [|u|],Constraint.empty)))
+      ~univs:(Polymorphic_entry (UContext.make [|Anonymous|] (Instance.of_array [|u|],Constraint.empty)), UnivNames.empty_binders)
       ~types:(Term.mkArrowR tc tu)
       (mkLambda (Context.nameR (Id.of_string "x"), tc, mkRel 1))
   in

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -365,7 +365,6 @@ let do_declare_instance sigma ~locality ~poly k u ctx ctx' pri udecl impargs sub
   let sigma, entry = Declare.prepare_parameter ~poly sigma ~udecl ~types:termtype in
   let cst = Declare.declare_constant ~name
       ~kind:Decls.(IsAssumption Logical) (Declare.ParameterEntry entry) in
-  DeclareUniv.declare_univ_binders (GlobRef.ConstRef cst) (Evd.universe_binders sigma);
   let cst = (GlobRef.ConstRef cst) in
   Impargs.maybe_declare_manual_implicits false cst impargs;
   instance_hook pri locality cst

--- a/vernac/comAssumption.mli
+++ b/vernac/comAssumption.mli
@@ -36,7 +36,7 @@ val declare_variable
   : coercion_flag
   -> kind:Decls.assumption_object_kind
   -> Constr.types
-  -> Entries.universes_entry * UnivNames.universe_binders
+  -> UState.named_universes_entry
   -> Impargs.manual_implicits
   -> Glob_term.binding_kind
   -> variable CAst.t
@@ -48,7 +48,7 @@ val declare_axiom
   -> local:Locality.import_status
   -> kind:Decls.assumption_object_kind
   -> Constr.types
-  -> Entries.universes_entry * UnivNames.universe_binders
+  -> UState.named_universes_entry
   -> Impargs.manual_implicits
   -> Declaremods.inline
   -> variable CAst.t

--- a/vernac/comAssumption.mli
+++ b/vernac/comAssumption.mli
@@ -36,6 +36,7 @@ val declare_variable
   : coercion_flag
   -> kind:Decls.assumption_object_kind
   -> Constr.types
+  -> Entries.universes_entry * UnivNames.universe_binders
   -> Impargs.manual_implicits
   -> Glob_term.binding_kind
   -> variable CAst.t

--- a/vernac/comPrimitive.ml
+++ b/vernac/comPrimitive.ml
@@ -27,7 +27,7 @@ let do_primitive id udecl prim typopt =
     if Option.has_some udecl then
       CErrors.user_err ?loc
         Pp.(strbrk "Cannot use a universe declaration without a type when declaring primitives.");
-    declare id {Entries.prim_entry_type = None; prim_entry_content = prim}
+    declare id ({Entries.prim_entry_type = None; prim_entry_content = prim}, UnivNames.empty_binders)
   | Some typ ->
     let env = Global.env () in
     let evd, udecl = Constrintern.interp_univ_decl_opt env udecl in
@@ -49,10 +49,10 @@ let do_primitive id udecl prim typopt =
     let uvars = EConstr.universes_of_constr evd typ in
     let evd = Evd.restrict_universe_context evd uvars in
     let typ = EConstr.to_constr evd typ in
-    let univs = Evd.check_univ_decl ~poly:(not (Univ.AbstractContext.is_empty auctx)) evd udecl in
+    let univ_entry, ubinders = Evd.check_univ_decl ~poly:(not (Univ.AbstractContext.is_empty auctx)) evd udecl in
     let entry = {
-      Entries.prim_entry_type = Some (typ,univs);
+      Entries.prim_entry_type = Some (typ,univ_entry);
       prim_entry_content = prim;
     }
     in
-    declare id entry
+    declare id (entry, ubinders)

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -104,7 +104,7 @@ type 'a proof_entry = {
   (* State id on which the completion of type checking is reported *)
   proof_entry_feedback : Stateid.t option;
   proof_entry_type        : Constr.types option;
-  proof_entry_universes   : Entries.universes_entry * UnivNames.universe_binders;
+  proof_entry_universes   : UState.named_universes_entry;
   proof_entry_opaque      : bool;
   proof_entry_inline_code : bool;
 }
@@ -405,7 +405,7 @@ let inline_private_constants ~uctx env ce =
 type variable_declaration =
   | SectionLocalDef of Evd.side_effects proof_entry
   | SectionLocalAssum of { typ:Constr.types; impl:Glob_term.binding_kind ;
-                           univs:Entries.universes_entry * UnivNames.universe_binders }
+                           univs:UState.named_universes_entry }
 
 (* This object is only for things which iterate over objects to find
    variables (only Prettyp.print_context AFAICT) *)
@@ -1826,7 +1826,7 @@ module MutualEntry : sig
     : pinfo:Proof_info.t
     -> uctx:UState.t
     -> sec_vars:Id.Set.t option
-    -> univs:Entries.universes_entry * UnivNames.universe_binders
+    -> univs:UState.named_universes_entry
     -> Names.GlobRef.t list
 
   val declare_mutdef

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -348,6 +348,7 @@ val declare_variable
   -> kind:Decls.logical_kind
   -> typ:Constr.types
   -> impl:Glob_term.binding_kind
+  -> univs:Entries.universes_entry * UnivNames.universe_binders
   -> unit
 
 (** Declaration of global constructions

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -325,7 +325,7 @@ val definition_entry
   -> ?using:Names.Id.Set.t
   -> ?inline:bool
   -> ?types:Constr.types
-  -> ?univs:Entries.universes_entry
+  -> ?univs:Entries.universes_entry * UnivNames.universe_binders
   -> Constr.constr
   -> Evd.side_effects proof_entry
 
@@ -358,15 +358,15 @@ val declare_variable
    instead *)
 type 'a constant_entry =
   | DefinitionEntry of 'a proof_entry
-  | ParameterEntry of Entries.parameter_entry
-  | PrimitiveEntry of Entries.primitive_entry
+  | ParameterEntry of (Entries.parameter_entry * UnivNames.universe_binders)
+  | PrimitiveEntry of (Entries.primitive_entry * UnivNames.universe_binders)
 
 val prepare_parameter
   : poly:bool
   -> udecl:UState.universe_decl
   -> types:EConstr.types
   -> Evd.evar_map
-  -> Evd.evar_map * Entries.parameter_entry
+  -> Evd.evar_map * (Entries.parameter_entry * UnivNames.universe_binders)
 
 (** [declare_constant id cd] declares a global declaration
    (constant/parameter) with name [id] in the current section; it returns
@@ -400,7 +400,7 @@ val build_by_tactic
   -> poly:bool
   -> typ:EConstr.types
   -> unit Proofview.tactic
-  -> Constr.constr * Constr.types option * Entries.universes_entry * bool * UState.t
+  -> Constr.constr * Constr.types option * (Entries.universes_entry * UnivNames.universe_binders) * bool * UState.t
 
 (** {2 Program mode API} *)
 

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -325,7 +325,7 @@ val definition_entry
   -> ?using:Names.Id.Set.t
   -> ?inline:bool
   -> ?types:Constr.types
-  -> ?univs:Entries.universes_entry * UnivNames.universe_binders
+  -> ?univs:UState.named_universes_entry
   -> Constr.constr
   -> Evd.side_effects proof_entry
 
@@ -348,7 +348,7 @@ val declare_variable
   -> kind:Decls.logical_kind
   -> typ:Constr.types
   -> impl:Glob_term.binding_kind
-  -> univs:Entries.universes_entry * UnivNames.universe_binders
+  -> univs:UState.named_universes_entry
   -> unit
 
 (** Declaration of global constructions
@@ -401,7 +401,7 @@ val build_by_tactic
   -> poly:bool
   -> typ:EConstr.types
   -> unit Proofview.tactic
-  -> Constr.constr * Constr.types option * (Entries.universes_entry * UnivNames.universe_binders) * bool * UState.t
+  -> Constr.constr * Constr.types option * (UState.named_universes_entry) * bool * UState.t
 
 (** {2 Program mode API} *)
 

--- a/vernac/declareInd.ml
+++ b/vernac/declareInd.ml
@@ -154,7 +154,7 @@ type one_inductive_impls =
   Impargs.manual_implicits (* for inds *) *
   Impargs.manual_implicits list (* for constrs *)
 
-let declare_mutual_inductive_with_eliminations ?(primitive_expected=false) ?typing_flags mie pl impls =
+let declare_mutual_inductive_with_eliminations ?(primitive_expected=false) ?typing_flags mie binders impls =
   (* spiwack: raises an error if the structure is supposed to be non-recursive,
         but isn't *)
   begin match mie.mind_entry_finite with
@@ -169,7 +169,7 @@ let declare_mutual_inductive_with_eliminations ?(primitive_expected=false) ?typi
   let (_, kn), prim = declare_mind ?typing_flags mie in
   let mind = Global.mind_of_delta_kn kn in
   if primitive_expected && not prim then warn_non_primitive_record (mind,0);
-  DeclareUniv.declare_univ_binders (GlobRef.IndRef (mind,0)) pl;
+  DeclareUniv.declare_univ_binders (GlobRef.IndRef (mind,0)) binders;
   List.iteri (fun i (indimpls, constrimpls) ->
       let ind = (mind,i) in
       let gr = GlobRef.IndRef ind in

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -182,7 +182,7 @@ type tc_result =
   bool
   * Impargs.manual_implicits
   (* Part relative to closing the definitions *)
-  * (Entries.universes_entry * UnivNames.universe_binders)
+  * UState.named_universes_entry
   * Entries.variance_entry
   * Constr.rel_context
   * DataR.t list

--- a/vernac/record.mli
+++ b/vernac/record.mli
@@ -47,7 +47,7 @@ module Internal : sig
 
   val declare_projections
     : Names.inductive
-    -> Entries.universes_entry * UnivNames.universe_binders
+    -> UState.named_universes_entry
     -> ?kind:Decls.definition_object_kind
     -> Names.Id.t
     -> projection_flags list

--- a/vernac/record.mli
+++ b/vernac/record.mli
@@ -47,7 +47,7 @@ module Internal : sig
 
   val declare_projections
     : Names.inductive
-    -> Entries.universes_entry
+    -> Entries.universes_entry * UnivNames.universe_binders
     -> ?kind:Decls.definition_object_kind
     -> Names.Id.t
     -> projection_flags list


### PR DESCRIPTION
**Kind:** refactoring

Actual declarations of universe contexts and universe names in `comAssumption.ml` were done at various times in scattered places. We centralize them in `Declare.declare_variable` to so that it is easier to follow the code paths, and potentially easier to do further extensions.

Synchronous overlays:
- LPCIC/coq-elpi#286
- mattam82/Coq-Equations#423
- coq-community/paramcoq#76
- Mtac2/Mtac2#342
- mit-plv/rewriter#30 
- https://github.com/MetaCoq/metacoq/pull/584