### PR TITLE
Added reminder to not end with period in make-changelog.

### DIFF
--- a/dev/tools/make-changelog.sh
+++ b/dev/tools/make-changelog.sh
@@ -35,7 +35,7 @@ if [ ! -z "$fixes_string" ]; then fixes_string="$(printf '\n  fixes %s,' "$fixes
 # the ` are regular strings, this is intended
 # use %s for the leading - to avoid looking like an option (not sure
 # if necessary but doesn't hurt)
-printf '%s **%s:**\n  Bla bla\n  (`#%s <https://github.com/coq/coq/pull/%s>`_,%s\n  by %s).' - "$type_full" "$PR" "$PR" "$fixes_string" "$(git config user.name)" > "$where"
+printf '%s **%s:**\n  Describe your change here but don't end with a period\n  (`#%s <https://github.com/coq/coq/pull/%s>`_,%s\n  by %s)' - "$type_full" "$PR" "$PR" "$fixes_string" "$(git config user.name)" > "$where"
 
 printf "Name of created changelog file:\n"
 printf "$where\n"


### PR DESCRIPTION
We add a quick reminder to not end the sentence in the changelog with a period.

 As discussed in #14699 