### PR TITLE
Fix unexpected vertical formatting of goal conclusion

### DIFF
--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -470,7 +470,7 @@ let pr_goal ?(diffs=false) ?og_s g_s =
     else
       pr_context_of env sigma ++ cut () ++
         str "============================" ++ cut ()  ++
-        pr_letype_env ~goal_concl_style:true env sigma concl
+        hov 0 (pr_letype_env ~goal_concl_style:true env sigma concl)
   in
   str "  " ++ v 0 goal
 

--- a/test-suite/output/Notations3.out
+++ b/test-suite/output/Notations3.out
@@ -249,3 +249,15 @@ myfoo01 tt
      : nat
 1 ⪯ 2 ⪯ 3 ⪯ 4
      : Prop
+1 goal
+  
+  x : nat
+  ============================
+  |-_0 x
+1 goal
+  
+  xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx : nat
+  ============================
+  |-_0
+   xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx *
+   xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/test-suite/output/Notations3.v
+++ b/test-suite/output/Notations3.v
@@ -420,3 +420,20 @@ Notation "x  ⪯ y  ⪯ ..  ⪯ z  ⪯ t" :=
 Check 1 ⪯ 2 ⪯ 3 ⪯ 4.
 
 End RecursiveNotationPartialApp.
+
+Module GoalConclBox.
+
+(* The conclusion was sometimes printed vertically (see
+https://coq.zulipchat.com/#narrow/stream/237977-Coq-users/topic/Strange.20newline.20in.20printing)
+*)
+
+Notation "|-_0 x" := (x = 0) (at level 70, format "|-_0 '/'  x").
+Lemma test x : |-_0 x.
+Show.
+Abort.
+
+Lemma test xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx : |-_0 xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx * xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.
+Show.
+Abort.
+
+End GoalConclBox.


### PR DESCRIPTION

This addresses a remark from @RalfJung on [zulip](https://coq.zulipchat.com/#narrow/stream/237977-Coq-users/topic/Strange.20newline.20in.20printing).

```coq
Notation "|-_0 x" := (x = 0) (at level 70, format "|-_0 '/'  x").
Lemma test x : |-_0 x.
Show.
```
Before:
```
  x : nat
  ============================
  |-_0
   x
```
After:
```
  x : nat
  ============================
  |-_0 x
```
- [x] Added / updated **test-suite**.
