### PR TITLE
Fixes issues with From in coqdep (#11631 and #14539) + new unifying semantics of coqdep and coqc

### DIFF
--- a/clib/cList.ml
+++ b/clib/cList.ml
@@ -113,6 +113,7 @@ sig
   val distinct : 'a list -> bool
   val distinct_f : 'a cmp -> 'a list -> bool
   val duplicates : 'a eq -> 'a list -> 'a list
+  val uniquize_key : ('a -> 'b) -> 'a list -> 'a list
   val uniquize : 'a list -> 'a list
   val sort_uniquize : 'a cmp -> 'a list -> 'a list
   val min : 'a cmp -> 'a list -> 'a
@@ -947,17 +948,21 @@ let distinct_f cmp l =
 
 (* FIXME: again, generic hash function *)
 
-let uniquize l =
+let uniquize_key f l =
   let visited = Hashtbl.create 23 in
   let rec aux acc changed = function
-    | h :: t -> if Hashtbl.mem visited h then aux acc true t else
+    | h :: t ->
+        let x = f h in
+        if Hashtbl.mem visited x then aux acc true t else
           begin
-            Hashtbl.add visited h h;
+            Hashtbl.add visited x x;
             aux (h :: acc) changed t
           end
     | [] -> if changed then List.rev acc else l
   in
   aux [] false l
+
+let uniquize l = uniquize_key (fun x -> x) l
 
 (** [sort_uniquize] might be an alternative to the hashtbl-based
     [uniquize], when the order of the elements is irrelevant *)

--- a/clib/cList.mli
+++ b/clib/cList.mli
@@ -363,6 +363,11 @@ sig
   (** Return the list of unique elements which appear at least twice. Elements
       are kept in the order of their first appearance. *)
 
+  val uniquize_key : ('a -> 'b) -> 'a list -> 'a list
+  (** Return the list of elements without duplicates using the
+      function to associate a comparison key to each element.
+      This is the list unchanged if there was none. *)
+
   val uniquize : 'a list -> 'a list
   (** Return the list of elements without duplicates.
       This is the list unchanged if there was none. *)

--- a/doc/changelog/08-cli-tools/14718-master+fix-coqdoc-anomaly-non-existing-dir.rst
+++ b/doc/changelog/08-cli-tools/14718-master+fix-coqdoc-anomaly-non-existing-dir.rst
@@ -1,0 +1,18 @@
+- **Changed:**
+  :cmd:`Require` now selects files whose logical name
+  exactly matches the required name, making it possible to unambiguously select
+  a given file: if several :n:`-Q` or :n:`-R` options bind the same
+  logical name to a different file, the option appearing last on the
+  command line takes precedence.  Moreover, it is now an error to
+  require a file using a partial logical name which does not resolve
+  to a non-ambiguous path (`#14718
+  <https://github.com/coq/coq/pull/14718>`_, by Hugo Herbelin).
+
+- **Fixed:**
+  Various `coqdep` issues with the `From` clause of :cmd:`Require` and
+  a few inconsistencies between `coqdep` and `coqc` disambiguation
+  of :cmd:`Require`
+  (`#14718 <https://github.com/coq/coq/pull/14718>`_,
+  fixes `#11631 <https://github.com/coq/coq/issues/11631>`_
+  and `#14539 <https://github.com/coq/coq/issues/14539>`_,
+  by Hugo Herbelin).

--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -958,9 +958,6 @@ accessible, absolute names can never be hidden.
 Libraries and filesystem
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. note:: The questions described here have been subject to redesign in Coq 8.5.
-   Former versions of Coq use the same terminology to describe slightly different things.
-
 Compiled files (``.vo`` and ``.vio``) store sub-libraries. In order to refer
 to them inside Coq, a translation from file-system names to Coq names
 is needed. In this translation, names in the file system are called

--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -965,17 +965,18 @@ is needed. In this translation, names in the file system are called
 names.
 
 A logical prefix Lib can be associated with a physical path using
-the command line option ``-Q`` `path` ``Lib``. All subfolders of path are
+either the command line option ``-Q`` `path` ``Lib`` or the command
+line option ``-R`` `path` ``Lib``. All subfolders of path are
 recursively associated with the logical path ``Lib`` extended with the
 corresponding suffix coming from the physical path. For instance, the
-folder ``path/foo/Bar`` maps to ``Lib.foo.Bar``. Subdirectories corresponding
+folder ``path/Foo/Bar`` maps to ``Lib.Foo.Bar``. Subdirectories corresponding
 to invalid Coq identifiers are skipped, and, by convention,
 subdirectories named ``CVS`` or ``_darcs`` are skipped too.
 
 Thanks to this mechanism, ``.vo`` files are made available through the
 logical name of the folder they are in, extended with their own
 basename. For example, the name associated with the file
-``path/foo/Bar/File.vo`` is ``Lib.foo.Bar.File``. The same caveat applies for
+``path/Foo/Bar/File.vo`` is ``Lib.Foo.Bar.File``. The same caveat applies for
 invalid identifiers. When compiling a source file, the ``.vo`` file stores
 its logical name, so that an error is issued if it is loaded with the
 wrong loadpath afterwards.
@@ -992,18 +993,8 @@ with the same physical-to-logical translation and with an empty logical prefix.
 .. todo: Needs a more better explanation of COQPATH and XDG* with example(s)
    and suggest best practices for their use
 
-The command line option ``-R`` is a variant of ``-Q`` which has the strictly
-same behavior regarding loadpaths, but which also makes the
-corresponding ``.vo`` files available through their short names in a way
-similar to the :cmd:`Import` command. For instance, ``-R path Lib``
-associates the file ``/path/foo/Bar/File.vo`` with the logical name
-``Lib.foo.Bar.File`` but allows this file to be accessed through the
-short names ``foo.Bar.File``, ``Bar.File`` and ``File``. If several files with
-identical base name are present in different subdirectories of a
-recursive loadpath, which of these files is found first may be system-
-dependent and explicit qualification is recommended. The ``From`` argument
-of the ``Require`` command can be used to bypass the implicit shortening
-by providing an absolute root to the required file (see :ref:`compiled-files`).
+The choice between ``-Q`` and ``-R`` impacts how ambiguous names are
+resolved in :cmd:`Require` (see :ref:`compiled-files`).
 
 There also exists another independent loadpath mechanism attached to
 OCaml object files (``.cmo`` or ``.cmxs``) rather than Coq object

--- a/doc/sphinx/practical-tools/utilities.rst
+++ b/doc/sphinx/practical-tools/utilities.rst
@@ -795,8 +795,9 @@ format readable by make. When a directory is given as argument, it is
 recursively looked at.
 
 Dependencies of Coq modules are computed by looking at ``Require``
-commands (``Require``, ``Require Export``, ``Require Import``), but also at the
-command ``Declare ML Module``.
+commands (``Require``, ``Require Export``, ``Require Import``,
+possibly preceded by a ``From`` clause), but also at the command
+``Declare ML Module``.
 
 See the man page of ``coqdep`` for more details and options.
 

--- a/doc/sphinx/practical-tools/utilities.rst
+++ b/doc/sphinx/practical-tools/utilities.rst
@@ -794,10 +794,8 @@ programs, and prints the dependencies on the standard output in a
 format readable by make. When a directory is given as argument, it is
 recursively looked at.
 
-Dependencies of Coq modules are computed by looking at ``Require``
-commands (``Require``, ``Require Export``, ``Require Import``,
-possibly preceded by a ``From`` clause), but also at the command
-``Declare ML Module``.
+Dependencies of Coq modules are computed by looking at :cmd:`Require`
+and :cmd:`Declare ML Module` commands.
 
 See the man page of ``coqdep`` for more details and options.
 

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -719,8 +719,9 @@ gallina_ext: [
 | REPLACE "Instance" instance_name ":" term200 hint_info [ ":=" "{" record_declaration "}" | ":=" lconstr | ]
 | WITH "Instance" instance_name ":" type hint_info OPT [ ":=" "{" record_declaration "}" | ":=" lconstr ]
 
+| DELETE "Require" export_token LIST1 global
 | REPLACE "From" global "Require" export_token LIST1 global
-| WITH "From" dirpath "Require" export_token LIST1 global
+| WITH OPT [ "From" dirpath ] "Require" export_token LIST1 global
 ]
 
 (* lexer stuff *)

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1058,8 +1058,7 @@ command: [
 | "Section" ident
 | "End" ident
 | "Collection" ident ":=" section_var_expr
-| "Require" OPT [ "Import" | "Export" ] LIST1 qualid
-| "From" dirpath "Require" OPT [ "Import" | "Export" ] LIST1 qualid
+| OPT [ "From" dirpath ] "Require" OPT [ "Import" | "Export" ] LIST1 qualid
 | "Import" LIST1 filtered_import
 | "Export" LIST1 filtered_import
 | "Include" module_type_inl LIST0 ( "<+" module_expr_inl )

--- a/lib/system.ml
+++ b/lib/system.ml
@@ -115,6 +115,11 @@ let where_in_path ?(warn=true) path filename =
     let f = Filename.concat lpe filename in
     if file_exists_respecting_case lpe filename then [lpe,f] else []))
 
+let all_in_path path filename =
+  search path (fun lpe ->
+      let f = Filename.concat lpe filename in
+      if file_exists_respecting_case lpe filename then [lpe,f] else [])
+
 let find_file_in_path ?(warn=true) paths filename =
   if not (Filename.is_implicit filename) then
     (* the name is considered to be a physical name and we use the file

--- a/lib/system.ml
+++ b/lib/system.ml
@@ -116,9 +116,9 @@ let where_in_path ?(warn=true) path filename =
     if file_exists_respecting_case lpe filename then [lpe,f] else []))
 
 let all_in_path path filename =
-  search path (fun lpe ->
-      let f = Filename.concat lpe filename in
-      if file_exists_respecting_case lpe filename then [lpe,f] else [])
+  search path (fun (physicaldir,logicaldir) ->
+      let f = Filename.concat physicaldir filename in
+      if file_exists_respecting_case physicaldir filename then [logicaldir,f] else [])
 
 let find_file_in_path ?(warn=true) paths filename =
   if not (Filename.is_implicit filename) then

--- a/lib/system.mli
+++ b/lib/system.mli
@@ -51,8 +51,21 @@ val is_in_system_path : string -> bool
 val where_in_path :
   ?warn:bool -> CUnix.load_path -> string -> CUnix.physical_path * string
 
+(** [find_file_in_path ?warn loadpath filename] returns the directory
+    name and long name of the first physical occurrence [filename] in
+    one of the directory of the [loadpath];
+    fails with a user error if no such file exists;
+    warn if two or more files exist in the loadpath;
+    returns instead the directory name of [filename] is [filename] is
+    an absolute path *)
 val find_file_in_path :
   ?warn:bool -> CUnix.load_path -> string -> CUnix.physical_path * string
+
+(** [all_in_path loadpath filename] returns the list of the directory
+    name and full name of all physical occurrences of [filename] in the
+    given [loadpath] *)
+val all_in_path :
+  CUnix.load_path -> string -> (CUnix.physical_path * string) list
 
 val trust_file_cache : bool ref
 (** [trust_file_cache] indicates whether we trust the underlying

--- a/lib/system.mli
+++ b/lib/system.mli
@@ -62,10 +62,10 @@ val find_file_in_path :
   ?warn:bool -> CUnix.load_path -> string -> CUnix.physical_path * string
 
 (** [all_in_path loadpath filename] returns the list of the directory
-    name and full name of all physical occurrences of [filename] in the
-    given [loadpath] *)
+    name and full name of all physical occurrences of [filename] in a
+    [loadpath] binding physical paths to some arbitrary key *)
 val all_in_path :
-  CUnix.load_path -> string -> (CUnix.physical_path * string) list
+  (CUnix.physical_path * 'a) list -> string -> ('a * string) list
 
 val trust_file_cache : bool ref
 (** [trust_file_cache] indicates whether we trust the underlying

--- a/man/coqdep.1
+++ b/man/coqdep.1
@@ -23,17 +23,20 @@ coqdep \- Compute inter-module dependencies for Coq programs
 .SH DESCRIPTION
 
 .B coqdep
-compute inter-module dependencies for Coq programs,
+computes inter-module dependencies for Coq programs,
 and prints the dependencies on the standard output in a format
 readable by make.
 When a directory is given as argument, it is recursively looked at.
 
 Dependencies of Coq modules are computed by looking at
 .IR Require \&
-commands (Require, Require Export, Require Import),
+commands (Require, Require Export, Require Import, possibly restricted by a From clause),
 .IR Declare \&
 .IR ML \&
 .IR Module \&
+commands,
+.IR Add \&
+.IR LoadPath \&
 commands and
 .IR Load \&
 commands. Dependencies relative to modules from the Coq library are not
@@ -49,7 +52,7 @@ Read filenames and options -I, -R and -Q from a _CoqProject FILE.
 .TP
 .BI \-I/\-Q/\-R \ options
 Have the same effects on load path and modules names as for other
-coq commands (coqtop, coqc).
+Coq commands (coqtop, coqc).
 .TP
 .BI \-coqlib \ directory
 Indicates where is the Coq library. The default value has been
@@ -73,12 +76,17 @@ For coq developers, prints dependencies over coq library files
 .TP
 .B \-noinit
 Currently no effect.
-
+.TP
+.B \-vos
+Includes dependencies about .vos files.
+.TP
+.B \-dyndep (opt|byte|both|no|var)
+Set how dependencies over ML modules are printed.
 
 .SH EXIT STATUS
 .IP "1"
-A file given on the command line cannot be found or some file
-cannot be opened.
+A file given on the command line cannot be found, or some file
+cannot be opened, or there is a syntax error in one of the commands recognized by coqdep.
 .IP "0"
 In all other cases. In particular, when a dependency cannot be
 found or an invalid option is encountered,
@@ -96,7 +104,7 @@ prints a warning and exits with status
 
 .SH NOTES
 
-Lexers (for Coq and Caml) correctly handle nested comments
+Lexers (for Coq and OCaml) correctly handle nested comments
 and strings.
 
 The treatment of symbolic links is primitive.
@@ -112,46 +120,32 @@ directories.
 .LP
 Consider the files (in the same directory):
 
-	A.ml B.ml C.ml D.ml X.v Y.v and Z.v
+	a.mllib X.v Y.v and Z.v
 
 where
 .TP
 .BI \+
-D.ml contains the commands `open A', `open B' and `type t = C.t' ;
+a.mllib contains the module names `B' and `C';
 .TP
 .BI \+
-Y.v contains the command `Require X' ;
+Y.v contains the command `Require Foo.X' ;
 .TP
 .BI \+
-Z.v contains the commands `Require X' and `Declare ML Module "D"'.
+Z.v contains the commands `From Foo Require X' and `Declare ML Module "a"'.
 .LP
 To get the dependencies of the Coq files:
 .IP
 .B
-example% coqdep \-I . *.v
+example% coqdep \-I . -Q . Foo *.v
 .RS
 .sp .5
 .nf
-.B Z.vo: Z.v ./X.vo ./D.cmo
-.B Y.vo: Y.v ./X.vo
-.B X.vo: X.v
-.fi
-.RE
-.br
-.ne 7
-.LP
-With a warning:
-.IP
-.B
-example% coqdep \-I . *.v
-.RS
-.sp .5
-.nf
-.B Z.vo: Z.v ./X.vo ./D.cmo
-.B Y.vo: Y.v ./X.vo
-.B X.vo: X.v
-### Warning : In file Z.v, the ML modules declaration should be
-### Declare ML Module "A" "B" "C" "D".
+.B X.vo X.glob X.v.beautified X.required_vo: X.v 
+.B X.vio: X.v 
+.B Y.vo Y.glob Y.v.beautified Y.required_vo: Y.v X.vo
+.B Y.vio: Y.v X.vio
+.B Z.vo Z.glob Z.v.beautified Z.required_vo: Z.v X.vo ./a.cma ./a.cmxs
+.B Z.vio: Z.v X.vio ./a.cma ./a.cmxs
 .fi
 .RE
 .br

--- a/test-suite/misc/deps-order-distinct-root.sh
+++ b/test-suite/misc/deps-order-distinct-root.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Check that both coqdep and coqtop/coqc support -R
+# Check that both coqdep and coqtop/coqc take the latter -R
+# See also bugs #2242, #2337, #2339
+rm -f misc/deps/DistinctRoot/*.vo misc/deps/DistinctRoot/*.vo/{A,B}/*.vo
+tmpoutput=$(mktemp /tmp/coqcheck.XXXXXX)
+(cd misc/deps; $coqdep -f _CoqDistinctRoot) > "$tmpoutput" 2>&1
+diff -u --strip-trailing-cr misc/deps/DistinctRootDeps.out "$tmpoutput"
+R=$?
+times
+$coqc -R misc/deps/DistinctRoot/A A -R misc/deps/DistinctRoot/B B misc/deps/DistinctRoot/A/File1.v
+$coqc -R misc/deps/DistinctRoot/A A -R misc/deps/DistinctRoot/B B misc/deps/DistinctRoot/B/File1.v
+$coqc -R misc/deps/DistinctRoot/A A -R misc/deps/DistinctRoot/B B misc/deps/DistinctRoot/File2.v
+S=$?
+if [ $R = 0 ] && [ $S = 0 ]; then
+    printf "coqdep and coqc agree.\n"
+    exit 0
+else
+    printf "coqdep and coqc disagree.\n"
+    exit 1
+fi

--- a/test-suite/misc/deps-order-from.sh
+++ b/test-suite/misc/deps-order-from.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Check that both coqdep and coqtop/coqc support -R
+# Check that both coqdep and coqtop/coqc take the latter -R
+# See bugs #11631, #14539
+rm -f misc/deps/test-from/A/C.vo misc/deps/test-from/B/C.vo misc/deps/test-from/D.vo misc/deps/test-from/E.vo
+tmpoutput=$(mktemp /tmp/coqcheck.XXXXXX)
+$coqdep -R misc/deps/test-from T misc/deps/test-from/D.v misc/deps/test-from/E.v > "$tmpoutput" 2>&1
+diff -u --strip-trailing-cr misc/deps/deps-from.out "$tmpoutput"
+R=$?
+times
+$coqc -R misc/deps/test-from T misc/deps/test-from/A/C.v
+$coqc -R misc/deps/test-from T misc/deps/test-from/B/C.v
+$coqc -R misc/deps/test-from T misc/deps/test-from/D.v
+$coqc -R misc/deps/test-from T misc/deps/test-from/E.v
+S=$?
+if [ $R = 0 ] && [ $S = 0 ]; then
+    printf "coqdep and coqc agree\n"
+    exit 0
+else
+    printf "coqdep and coqc disagree.\n"
+    exit 1
+fi

--- a/test-suite/misc/deps-order-subdir1-file.sh
+++ b/test-suite/misc/deps-order-subdir1-file.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Check that both coqdep and coqtop/coqc takes a file matching exactly
+# the logical path (if any)
+rm -f misc/deps/Theory1/*.vo misc/deps/Theory1/Subtheory?/*.vo misc/deps/Theory1/Subtheory?/Subsubtheory?/*.vo
+tmpoutput=$(mktemp /tmp/coqcheck.XXXXXX)
+(cd misc/deps; $coqdep -f _CoqTheory1Project) > "$tmpoutput" 2>&1
+diff -u --strip-trailing-cr misc/deps/Theory1Deps.out "$tmpoutput"
+R=$?
+times
+$coqc -Q misc/deps/Theory1 Theory misc/deps/Theory1/File1.v
+$coqc -Q misc/deps/Theory1 Theory misc/deps/Theory1/Subtheory1/File1.v
+$coqc -Q misc/deps/Theory1 Theory misc/deps/Theory1/Subtheory1/Subsubtheory1/File1.v
+$coqc -Q misc/deps/Theory1 Theory misc/deps/Theory1/Subtheory1/Subsubtheory2/File1.v
+$coqc -Q misc/deps/Theory1 Theory misc/deps/Theory1/Subtheory2/File1.v
+$coqc -Q misc/deps/Theory1 Theory misc/deps/Theory1/Subtheory2/Subsubtheory1/File1.v
+$coqc -Q misc/deps/Theory1 Theory misc/deps/Theory1/Subtheory2/Subsubtheory2/File1.v
+$coqc -Q misc/deps/Theory1 Theory misc/deps/Theory1/File2.v
+S=$?
+if [ $R = 0 ] && [ $S = 0 ]; then
+    printf "coqdep and coqc agree.\n"
+    exit 0
+else
+    printf "coqdep and coqc disagree.\n"
+    exit 1
+fi

--- a/test-suite/misc/deps-order-subdir2-file.sh
+++ b/test-suite/misc/deps-order-subdir2-file.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Check that coqtop/coqc and coqdep behave the same in the presence of ambiguity
+# over child and sibling directories
+# Same test as deps-order-subdir1-file.sh but without Theory1/File1.v
+
+# This test is platform-dependent, we renounce to it
+dotest=true
+if [ $dotest = false ]; then exit 0; fi
+rm -f misc/deps/Theory2/*.vo misc/deps/Theory2/Subtheory?/*.vo misc/deps/Theory2/Subtheory?/Subsubtheory?/*.vo
+tmpoutput=$(mktemp /tmp/coqcheck.XXXXXX)
+(cd misc/deps; $coqdep -f _CoqTheory2Project) > "$tmpoutput" 2>&1
+diff -u --strip-trailing-cr misc/deps/Theory2Deps.out $tmpoutput
+R=$?
+if [ $R != 0 ]; then
+    printf "Unexpected coqdep result.\n"
+    exit 1
+fi
+times
+$coqc -Q misc/deps/Theory2 Theory misc/deps/Theory2/Subtheory1/File1.v
+$coqc -Q misc/deps/Theory2 Theory misc/deps/Theory2/Subtheory1/Subsubtheory2/File1.v
+$coqc -Q misc/deps/Theory2 Theory misc/deps/Theory2/Subtheory1/Subsubtheory2/File1.v
+$coqc -Q misc/deps/Theory2 Theory misc/deps/Theory2/Subtheory2/File1.v
+$coqc -Q misc/deps/Theory2 Theory misc/deps/Theory2/Subtheory2/Subsubtheory2/File1.v
+$coqc -Q misc/deps/Theory2 Theory misc/deps/Theory2/Subtheory2/Subsubtheory2/File1.v
+$coqc -Q misc/deps/Theory2 Theory misc/deps/Theory2/File2.v
+S=$?
+if [ $S = 0 ]; then
+    printf "Unexpected coqc success.\n"
+    exit 1
+fi
+printf "coqdep and coqc ok.\n"

--- a/test-suite/misc/deps-order-subdir3-file.sh
+++ b/test-suite/misc/deps-order-subdir3-file.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Check that coqtop/coqc and coqdep behave the same in the presence of ambiguity
+# over child and sibling directories
+# Same test as deps-order-subdir2-file.sh but without Subtheory2/Subsubtheory?
+# so that it checks what comes first between siblings and (non immediate) children
+
+# This test is platform-dependent, we renounce to it
+dotest=true
+if [ $dotest = false ]; then exit 0; fi
+rm -f misc/deps/Theory3/*.vo misc/deps/Theory3/Subtheory?/*.vo misc/deps/Theory3/Subtheory?/Subsubtheory?/*.vo
+tmpoutput=$(mktemp /tmp/coqcheck.XXXXXX)
+(cd misc/deps; $coqdep -f _CoqTheory3Project) > "$tmpoutput" 2>&1
+diff -u --strip-trailing-cr misc/deps/Theory3Deps.out $tmpoutput
+R=$?
+if [ $R != 0 ]; then
+    printf "Unexpected coqdep result.\n"
+    exit 1
+fi
+times
+$coqc -Q misc/deps/Theory3 Theory misc/deps/Theory3/Subtheory1/File1.v
+$coqc -Q misc/deps/Theory3 Theory misc/deps/Theory3/Subtheory1/Subsubtheory2/File1.v
+$coqc -Q misc/deps/Theory3 Theory misc/deps/Theory3/Subtheory1/Subsubtheory2/File1.v
+$coqc -Q misc/deps/Theory3 Theory misc/deps/Theory3/Subtheory2/File1.v
+$coqc -Q misc/deps/Theory3 Theory misc/deps/Theory3/File2.v
+S=$?
+if [ $S = 0 ]; then
+    printf "Unexpected coqc success.\n"
+    exit 1
+fi
+printf "coqdep and coqc ok.\n"

--- a/test-suite/misc/deps/DistinctRoot/File2.v
+++ b/test-suite/misc/deps/DistinctRoot/File2.v
@@ -1,0 +1,1 @@
+Require File1.

--- a/test-suite/misc/deps/DistinctRootDeps.out
+++ b/test-suite/misc/deps/DistinctRootDeps.out
@@ -1,0 +1,6 @@
+DistinctRoot/A/File1.vo DistinctRoot/A/File1.glob DistinctRoot/A/File1.v.beautified DistinctRoot/A/File1.required_vo: DistinctRoot/A/File1.v 
+DistinctRoot/A/File1.vio: DistinctRoot/A/File1.v 
+DistinctRoot/B/File1.vo DistinctRoot/B/File1.glob DistinctRoot/B/File1.v.beautified DistinctRoot/B/File1.required_vo: DistinctRoot/B/File1.v 
+DistinctRoot/B/File1.vio: DistinctRoot/B/File1.v 
+DistinctRoot/File2.vo DistinctRoot/File2.glob DistinctRoot/File2.v.beautified DistinctRoot/File2.required_vo: DistinctRoot/File2.v DistinctRoot/B/File1.vo
+DistinctRoot/File2.vio: DistinctRoot/File2.v DistinctRoot/B/File1.vio

--- a/test-suite/misc/deps/Theory1/File1.v
+++ b/test-suite/misc/deps/Theory1/File1.v
@@ -1,0 +1,1 @@
+Definition a := 0.

--- a/test-suite/misc/deps/Theory1/File2.v
+++ b/test-suite/misc/deps/Theory1/File2.v
@@ -1,0 +1,2 @@
+From Theory Require File1.
+Check eq_refl : File1.a = 0.

--- a/test-suite/misc/deps/Theory1/Subtheory1/File1.v
+++ b/test-suite/misc/deps/Theory1/Subtheory1/File1.v
@@ -1,0 +1,1 @@
+Definition a := 1.

--- a/test-suite/misc/deps/Theory1/Subtheory1/Subsubtheory1/File1.v
+++ b/test-suite/misc/deps/Theory1/Subtheory1/Subsubtheory1/File1.v
@@ -1,0 +1,1 @@
+Definition a := 11.

--- a/test-suite/misc/deps/Theory1/Subtheory1/Subsubtheory2/File1.v
+++ b/test-suite/misc/deps/Theory1/Subtheory1/Subsubtheory2/File1.v
@@ -1,0 +1,1 @@
+Definition a := 12.

--- a/test-suite/misc/deps/Theory1/Subtheory2/File1.v
+++ b/test-suite/misc/deps/Theory1/Subtheory2/File1.v
@@ -1,0 +1,1 @@
+Definition a := 2.

--- a/test-suite/misc/deps/Theory1/Subtheory2/Subsubtheory1/File1.v
+++ b/test-suite/misc/deps/Theory1/Subtheory2/Subsubtheory1/File1.v
@@ -1,0 +1,1 @@
+Definition a := 21.

--- a/test-suite/misc/deps/Theory1/Subtheory2/Subsubtheory2/File1.v
+++ b/test-suite/misc/deps/Theory1/Subtheory2/Subsubtheory2/File1.v
@@ -1,0 +1,1 @@
+Definition a := 22.

--- a/test-suite/misc/deps/Theory1Deps.out
+++ b/test-suite/misc/deps/Theory1Deps.out
@@ -1,0 +1,16 @@
+Theory1/File1.vo Theory1/File1.glob Theory1/File1.v.beautified Theory1/File1.required_vo: Theory1/File1.v 
+Theory1/File1.vio: Theory1/File1.v 
+Theory1/File2.vo Theory1/File2.glob Theory1/File2.v.beautified Theory1/File2.required_vo: Theory1/File2.v Theory1/File1.vo
+Theory1/File2.vio: Theory1/File2.v Theory1/File1.vio
+Theory1/Subtheory1/File1.vo Theory1/Subtheory1/File1.glob Theory1/Subtheory1/File1.v.beautified Theory1/Subtheory1/File1.required_vo: Theory1/Subtheory1/File1.v 
+Theory1/Subtheory1/File1.vio: Theory1/Subtheory1/File1.v 
+Theory1/Subtheory1/Subsubtheory1/File1.vo Theory1/Subtheory1/Subsubtheory1/File1.glob Theory1/Subtheory1/Subsubtheory1/File1.v.beautified Theory1/Subtheory1/Subsubtheory1/File1.required_vo: Theory1/Subtheory1/Subsubtheory1/File1.v 
+Theory1/Subtheory1/Subsubtheory1/File1.vio: Theory1/Subtheory1/Subsubtheory1/File1.v 
+Theory1/Subtheory1/Subsubtheory2/File1.vo Theory1/Subtheory1/Subsubtheory2/File1.glob Theory1/Subtheory1/Subsubtheory2/File1.v.beautified Theory1/Subtheory1/Subsubtheory2/File1.required_vo: Theory1/Subtheory1/Subsubtheory2/File1.v 
+Theory1/Subtheory1/Subsubtheory2/File1.vio: Theory1/Subtheory1/Subsubtheory2/File1.v 
+Theory1/Subtheory2/File1.vo Theory1/Subtheory2/File1.glob Theory1/Subtheory2/File1.v.beautified Theory1/Subtheory2/File1.required_vo: Theory1/Subtheory2/File1.v 
+Theory1/Subtheory2/File1.vio: Theory1/Subtheory2/File1.v 
+Theory1/Subtheory2/Subsubtheory1/File1.vo Theory1/Subtheory2/Subsubtheory1/File1.glob Theory1/Subtheory2/Subsubtheory1/File1.v.beautified Theory1/Subtheory2/Subsubtheory1/File1.required_vo: Theory1/Subtheory2/Subsubtheory1/File1.v 
+Theory1/Subtheory2/Subsubtheory1/File1.vio: Theory1/Subtheory2/Subsubtheory1/File1.v 
+Theory1/Subtheory2/Subsubtheory2/File1.vo Theory1/Subtheory2/Subsubtheory2/File1.glob Theory1/Subtheory2/Subsubtheory2/File1.v.beautified Theory1/Subtheory2/Subsubtheory2/File1.required_vo: Theory1/Subtheory2/Subsubtheory2/File1.v 
+Theory1/Subtheory2/Subsubtheory2/File1.vio: Theory1/Subtheory2/Subsubtheory2/File1.v 

--- a/test-suite/misc/deps/Theory2/File2.v
+++ b/test-suite/misc/deps/Theory2/File2.v
@@ -1,0 +1,2 @@
+From Theory Require File1.
+Check eq_refl : File1.a = 1.

--- a/test-suite/misc/deps/Theory2/Subtheory1/File1.v
+++ b/test-suite/misc/deps/Theory2/Subtheory1/File1.v
@@ -1,0 +1,1 @@
+Definition a := 1.

--- a/test-suite/misc/deps/Theory2/Subtheory1/Subsubtheory1/File1.v
+++ b/test-suite/misc/deps/Theory2/Subtheory1/Subsubtheory1/File1.v
@@ -1,0 +1,1 @@
+Definition a := 11.

--- a/test-suite/misc/deps/Theory2/Subtheory1/Subsubtheory2/File1.v
+++ b/test-suite/misc/deps/Theory2/Subtheory1/Subsubtheory2/File1.v
@@ -1,0 +1,1 @@
+Definition a := 12.

--- a/test-suite/misc/deps/Theory2/Subtheory2/File1.v
+++ b/test-suite/misc/deps/Theory2/Subtheory2/File1.v
@@ -1,0 +1,1 @@
+Definition a := 2.

--- a/test-suite/misc/deps/Theory2/Subtheory2/Subsubtheory1/File1.v
+++ b/test-suite/misc/deps/Theory2/Subtheory2/Subsubtheory1/File1.v
@@ -1,0 +1,1 @@
+Definition a := 21.

--- a/test-suite/misc/deps/Theory2/Subtheory2/Subsubtheory2/File1.v
+++ b/test-suite/misc/deps/Theory2/Subtheory2/Subsubtheory2/File1.v
@@ -1,0 +1,1 @@
+Definition a := 22.

--- a/test-suite/misc/deps/Theory2Deps.out
+++ b/test-suite/misc/deps/Theory2Deps.out
@@ -1,0 +1,17 @@
+Theory2/File2.vo Theory2/File2.glob Theory2/File2.v.beautified Theory2/File2.required_vo: Theory2/File2.v Theory2/Subtheory1/File1.vo Theory2/Subtheory1/Subsubtheory1/File1.vo Theory2/Subtheory1/Subsubtheory2/File1.vo Theory2/Subtheory2/File1.vo Theory2/Subtheory2/Subsubtheory1/File1.vo Theory2/Subtheory2/Subsubtheory2/File1.vo
+Theory2/File2.vio: Theory2/File2.v Theory2/Subtheory1/File1.vio Theory2/Subtheory1/Subsubtheory1/File1.vio Theory2/Subtheory1/Subsubtheory2/File1.vio Theory2/Subtheory2/File1.vio Theory2/Subtheory2/Subsubtheory1/File1.vio Theory2/Subtheory2/Subsubtheory2/File1.vio
+Theory2/Subtheory1/File1.vo Theory2/Subtheory1/File1.glob Theory2/Subtheory1/File1.v.beautified Theory2/Subtheory1/File1.required_vo: Theory2/Subtheory1/File1.v 
+Theory2/Subtheory1/File1.vio: Theory2/Subtheory1/File1.v 
+Theory2/Subtheory1/Subsubtheory1/File1.vo Theory2/Subtheory1/Subsubtheory1/File1.glob Theory2/Subtheory1/Subsubtheory1/File1.v.beautified Theory2/Subtheory1/Subsubtheory1/File1.required_vo: Theory2/Subtheory1/Subsubtheory1/File1.v 
+Theory2/Subtheory1/Subsubtheory1/File1.vio: Theory2/Subtheory1/Subsubtheory1/File1.v 
+Theory2/Subtheory1/Subsubtheory2/File1.vo Theory2/Subtheory1/Subsubtheory2/File1.glob Theory2/Subtheory1/Subsubtheory2/File1.v.beautified Theory2/Subtheory1/Subsubtheory2/File1.required_vo: Theory2/Subtheory1/Subsubtheory2/File1.v 
+Theory2/Subtheory1/Subsubtheory2/File1.vio: Theory2/Subtheory1/Subsubtheory2/File1.v 
+Theory2/Subtheory2/File1.vo Theory2/Subtheory2/File1.glob Theory2/Subtheory2/File1.v.beautified Theory2/Subtheory2/File1.required_vo: Theory2/Subtheory2/File1.v 
+Theory2/Subtheory2/File1.vio: Theory2/Subtheory2/File1.v 
+Theory2/Subtheory2/Subsubtheory1/File1.vo Theory2/Subtheory2/Subsubtheory1/File1.glob Theory2/Subtheory2/Subsubtheory1/File1.v.beautified Theory2/Subtheory2/Subsubtheory1/File1.required_vo: Theory2/Subtheory2/Subsubtheory1/File1.v 
+Theory2/Subtheory2/Subsubtheory1/File1.vio: Theory2/Subtheory2/Subsubtheory1/File1.v 
+Theory2/Subtheory2/Subsubtheory2/File1.vo Theory2/Subtheory2/Subsubtheory2/File1.glob Theory2/Subtheory2/Subsubtheory2/File1.v.beautified Theory2/Subtheory2/Subsubtheory2/File1.required_vo: Theory2/Subtheory2/Subsubtheory2/File1.v 
+Theory2/Subtheory2/Subsubtheory2/File1.vio: Theory2/Subtheory2/Subsubtheory2/File1.v 
+*** Warning: in file Theory2/File2.v, 
+    required library File1 matches several files in path
+    (found File1.v in Theory2/Subtheory2/Subsubtheory2, Theory2/Subtheory2/Subsubtheory1, Theory2/Subtheory2, Theory2/Subtheory1/Subsubtheory2, Theory2/Subtheory1/Subsubtheory1 and Theory2/Subtheory1; Require will fail).

--- a/test-suite/misc/deps/Theory3/File2.v
+++ b/test-suite/misc/deps/Theory3/File2.v
@@ -1,0 +1,2 @@
+From Theory Require File1.
+Check eq_refl : File1.a = 1.

--- a/test-suite/misc/deps/Theory3/Subtheory1/File1.v
+++ b/test-suite/misc/deps/Theory3/Subtheory1/File1.v
@@ -1,0 +1,1 @@
+Definition a := 1.

--- a/test-suite/misc/deps/Theory3/Subtheory1/Subsubtheory1/File1.v
+++ b/test-suite/misc/deps/Theory3/Subtheory1/Subsubtheory1/File1.v
@@ -1,0 +1,1 @@
+Definition a := 11.

--- a/test-suite/misc/deps/Theory3/Subtheory1/Subsubtheory2/File1.v
+++ b/test-suite/misc/deps/Theory3/Subtheory1/Subsubtheory2/File1.v
@@ -1,0 +1,1 @@
+Definition a := 12.

--- a/test-suite/misc/deps/Theory3/Subtheory2/File1.v
+++ b/test-suite/misc/deps/Theory3/Subtheory2/File1.v
@@ -1,0 +1,1 @@
+Definition a := 2.

--- a/test-suite/misc/deps/Theory3Deps.out
+++ b/test-suite/misc/deps/Theory3Deps.out
@@ -1,0 +1,13 @@
+Theory3/File2.vo Theory3/File2.glob Theory3/File2.v.beautified Theory3/File2.required_vo: Theory3/File2.v Theory3/Subtheory1/File1.vo Theory3/Subtheory1/Subsubtheory1/File1.vo Theory3/Subtheory1/Subsubtheory2/File1.vo Theory3/Subtheory2/File1.vo
+Theory3/File2.vio: Theory3/File2.v Theory3/Subtheory1/File1.vio Theory3/Subtheory1/Subsubtheory1/File1.vio Theory3/Subtheory1/Subsubtheory2/File1.vio Theory3/Subtheory2/File1.vio
+Theory3/Subtheory1/File1.vo Theory3/Subtheory1/File1.glob Theory3/Subtheory1/File1.v.beautified Theory3/Subtheory1/File1.required_vo: Theory3/Subtheory1/File1.v 
+Theory3/Subtheory1/File1.vio: Theory3/Subtheory1/File1.v 
+Theory3/Subtheory1/Subsubtheory1/File1.vo Theory3/Subtheory1/Subsubtheory1/File1.glob Theory3/Subtheory1/Subsubtheory1/File1.v.beautified Theory3/Subtheory1/Subsubtheory1/File1.required_vo: Theory3/Subtheory1/Subsubtheory1/File1.v 
+Theory3/Subtheory1/Subsubtheory1/File1.vio: Theory3/Subtheory1/Subsubtheory1/File1.v 
+Theory3/Subtheory1/Subsubtheory2/File1.vo Theory3/Subtheory1/Subsubtheory2/File1.glob Theory3/Subtheory1/Subsubtheory2/File1.v.beautified Theory3/Subtheory1/Subsubtheory2/File1.required_vo: Theory3/Subtheory1/Subsubtheory2/File1.v 
+Theory3/Subtheory1/Subsubtheory2/File1.vio: Theory3/Subtheory1/Subsubtheory2/File1.v 
+Theory3/Subtheory2/File1.vo Theory3/Subtheory2/File1.glob Theory3/Subtheory2/File1.v.beautified Theory3/Subtheory2/File1.required_vo: Theory3/Subtheory2/File1.v 
+Theory3/Subtheory2/File1.vio: Theory3/Subtheory2/File1.v 
+*** Warning: in file Theory3/File2.v, 
+    required library File1 matches several files in path
+    (found File1.v in Theory3/Subtheory2, Theory3/Subtheory1/Subsubtheory2, Theory3/Subtheory1/Subsubtheory1 and Theory3/Subtheory1; Require will fail).

--- a/test-suite/misc/deps/_CoqDistinctRoot
+++ b/test-suite/misc/deps/_CoqDistinctRoot
@@ -1,0 +1,5 @@
+-R DistinctRoot/A A
+-R DistinctRoot/B B
+DistinctRoot/A/File1.v
+DistinctRoot/B/File1.v
+DistinctRoot/File2.v

--- a/test-suite/misc/deps/_CoqTheory1Project
+++ b/test-suite/misc/deps/_CoqTheory1Project
@@ -1,0 +1,9 @@
+-Q Theory1/ Theory
+Theory1/File1.v
+Theory1/File2.v
+Theory1/Subtheory1/File1.v
+Theory1/Subtheory1/Subsubtheory1/File1.v
+Theory1/Subtheory1/Subsubtheory2/File1.v
+Theory1/Subtheory2/File1.v
+Theory1/Subtheory2/Subsubtheory1/File1.v
+Theory1/Subtheory2/Subsubtheory2/File1.v

--- a/test-suite/misc/deps/_CoqTheory2Project
+++ b/test-suite/misc/deps/_CoqTheory2Project
@@ -1,0 +1,8 @@
+-Q Theory2/ Theory
+Theory2/File2.v
+Theory2/Subtheory1/File1.v
+Theory2/Subtheory1/Subsubtheory1/File1.v
+Theory2/Subtheory1/Subsubtheory2/File1.v
+Theory2/Subtheory2/File1.v
+Theory2/Subtheory2/Subsubtheory1/File1.v
+Theory2/Subtheory2/Subsubtheory2/File1.v

--- a/test-suite/misc/deps/_CoqTheory3Project
+++ b/test-suite/misc/deps/_CoqTheory3Project
@@ -1,0 +1,6 @@
+-Q Theory3/ Theory
+Theory3/File2.v
+Theory3/Subtheory1/File1.v
+Theory3/Subtheory1/Subsubtheory1/File1.v
+Theory3/Subtheory1/Subsubtheory2/File1.v
+Theory3/Subtheory2/File1.v

--- a/test-suite/misc/deps/deps-from.out
+++ b/test-suite/misc/deps/deps-from.out
@@ -1,0 +1,4 @@
+misc/deps/test-from/D.vo misc/deps/test-from/D.glob misc/deps/test-from/D.v.beautified misc/deps/test-from/D.required_vo: misc/deps/test-from/D.v misc/deps/test-from/A/C.vo
+misc/deps/test-from/D.vio: misc/deps/test-from/D.v misc/deps/test-from/A/C.vio
+misc/deps/test-from/E.vo misc/deps/test-from/E.glob misc/deps/test-from/E.v.beautified misc/deps/test-from/E.required_vo: misc/deps/test-from/E.v misc/deps/test-from/B/C.vo
+misc/deps/test-from/E.vio: misc/deps/test-from/E.v misc/deps/test-from/B/C.vio

--- a/test-suite/misc/deps/test-from/A/C.v
+++ b/test-suite/misc/deps/test-from/A/C.v
@@ -1,0 +1,1 @@
+Definition c := true.

--- a/test-suite/misc/deps/test-from/B/C.v
+++ b/test-suite/misc/deps/test-from/B/C.v
@@ -1,0 +1,1 @@
+Definition c := false.

--- a/test-suite/misc/deps/test-from/D.v
+++ b/test-suite/misc/deps/test-from/D.v
@@ -1,0 +1,8 @@
+(* Assumed to be compiled with -R test-from T *)
+From T.A Require C.
+
+Definition c := C.c.
+Lemma foo : c = true.
+Proof.
+reflexivity.
+Qed.

--- a/test-suite/misc/deps/test-from/E.v
+++ b/test-suite/misc/deps/test-from/E.v
@@ -1,0 +1,8 @@
+(* Assumed to be compiled with -R test-from T *)
+From T.B Require C.
+
+Definition c := C.c.
+Lemma foo : c = false.
+Proof.
+reflexivity.
+Qed.

--- a/test-suite/success/TestRefine.v
+++ b/test-suite/success/TestRefine.v
@@ -188,7 +188,7 @@ Qed.
 
 (* Quelques essais de recurrence bien fondée *)
 
-Require Import Wf.
+Require Import Init.Wf.
 Require Import Wf_nat.
 
 Lemma essai_wf : nat -> nat.

--- a/tools/coqdep.ml
+++ b/tools/coqdep.ml
@@ -17,7 +17,7 @@ let coqdep () =
      common coq.boot library *)
   (* Add current dir with empty logical path if not set by options above. *)
   (try ignore (CD.find_dir_logpath (Sys.getcwd()))
-   with Not_found -> CD.add_norec_dir_import CD.add_known "." []);
+   with Not_found -> CD.add_norec_dir_import CD.add_v_known "." []);
   (* We don't setup any loadpath if the -boot is passed *)
   if not !CD.option_boot then begin
     let env = Boot.Env.init () in

--- a/tools/coqdep_common.ml
+++ b/tools/coqdep_common.ml
@@ -163,11 +163,11 @@ let error_cannot_parse_project_file file msg =
   exit 1
 
 let error_cannot_stat s unix_error =
-  Printf.eprintf "%s: %s\n" s (error_message unix_error);
+  Printf.eprintf "%s\n" (error_message unix_error);
   exit 1
 
 let error_cannot_stat_in f s unix_error =
-  Printf.eprintf "In file \"%s\": %s: %s\n" f s (error_message unix_error);
+  Printf.eprintf "In file \"%s\": %s\n" f (error_message unix_error);
   exit 1
 
 let error_cannot_open s msg =

--- a/tools/coqdep_common.ml
+++ b/tools/coqdep_common.ml
@@ -37,8 +37,6 @@ let option_noglob = ref false
 let option_dynlink = ref Both
 let option_boot = ref false
 
-let norec_dirs = ref StrSet.empty
-
 type dir = string option
 
 (** [get_extension f l] checks whether [f] has one of the extensions
@@ -231,8 +229,8 @@ let absolute_file_name basename odir =
     if it has been given one. Raise [Not_found] otherwise. In
     particular we can check if "." has been attributed a logical path
     after processing all options and silently give the default one if
-    it hasn't. We may also use this to warn if ap hysical path is met
-    twice.*)
+    it hasn't. We may also use this to warn if a physical path is met
+    twice. *)
 let register_dir_logpath,find_dir_logpath =
   let tbl: (string, string list) Hashtbl.t = Hashtbl.create 19 in
   let reg physdir logpath = Hashtbl.add tbl (absolute_dir physdir) logpath in
@@ -452,16 +450,13 @@ let add_known recur phys_dir log_dir f =
 
 (* Visits all the directories under [dir], including [dir] *)
 
-let is_not_seen_directory phys_f =
-  not (StrSet.mem phys_f !norec_dirs)
-
 let rec add_directory recur add_file phys_dir log_dir =
   if exists_dir phys_dir then
     begin
       register_dir_logpath phys_dir log_dir;
       let f = function
         | FileDir (phys_f,f) ->
-            if is_not_seen_directory phys_f && recur then
+            if recur then
               add_directory true add_file phys_f (log_dir @ [f])
         | FileRegular f ->
             add_file phys_dir log_dir f

--- a/tools/coqdep_common.ml
+++ b/tools/coqdep_common.ml
@@ -468,11 +468,11 @@ let add_known recur phys_dir log_dir f =
     │   │       └── E.v
     │   │   └── G.v
     │   └── G.v
-    it goes in this order:
-    B.C1.E, B.C1.F, B.C1.G,
-    B.C1.D1.E, B.C1.D2.E,
-    B.C2.E, B.C2.F, B.C2.G
+    it goes in this (reverse) order:
     B.C2.D1.E, B.C2.D2.E,
+    B.C2.E, B.C2.F, B.C2.G
+    B.C1.D1.E, B.C1.D2.E,
+    B.C1.E, B.C1.F, B.C1.G,
     B.E, B.F, B.G,
     (see discussion at PR #14718)
 *)
@@ -492,7 +492,7 @@ let add_directory recur add_file phys_dir log_dir =
                 curdirfiles := []; subdirfiles := [];
                 aux phys_f (log_dir @ [f]);
                 let curdirfiles', subdirfiles' = List.hd !stack in
-                subdirfiles := subdirfiles' @ !curdirfiles @ !subdirfiles;
+                subdirfiles := subdirfiles' @ !subdirfiles @ !curdirfiles;
                 curdirfiles := curdirfiles'; stack := List.tl !stack
               end
           | FileRegular f ->

--- a/tools/coqdep_common.ml
+++ b/tools/coqdep_common.ml
@@ -510,11 +510,11 @@ let add_directory recur add_file phys_dir log_dir =
 (** Simply add this directory and imports it, no subdirs. This is used
     by the implicit adding of the current path (which is not recursive). *)
 let add_norec_dir_import add_file phys_dir log_dir =
-  try add_directory false (add_file true) phys_dir log_dir with Unix_error _ -> ()
+  add_directory false (add_file true) phys_dir log_dir
 
 (** -Q semantic: go in subdirs but only full logical paths are known. *)
 let add_rec_dir_no_import add_file phys_dir log_dir =
-  try add_directory true (add_file false) phys_dir log_dir with Unix_error _ -> ()
+  add_directory true (add_file false) phys_dir log_dir
 
 (** -R semantic: go in subdirs and suffixes of logical paths are known. *)
 let add_rec_dir_import add_file phys_dir log_dir =

--- a/tools/coqdep_common.mli
+++ b/tools/coqdep_common.mli
@@ -12,13 +12,19 @@ module StrSet : Set.S with type elt = string
 
 val coqdep_warning : ('a, Format.formatter, unit, unit) format4 -> 'a
 
+type dirname = string
+type basename = string
+type filename = string
+type dirpath = string list
+type root = filename * dirpath
+
 (** [find_dir_logpath dir] Return the logical path of directory [dir]
     if it has been given one. Raise [Not_found] otherwise. In
     particular we can check if "." has been attributed a logical path
     after processing all options and silently give the default one if
     it hasn't. We may also use this to warn if ap hysical path is met
     twice.*)
-val find_dir_logpath: string -> string list
+val find_dir_logpath: dirname -> dirpath
 
 (** Options *)
 val option_sort : bool ref
@@ -26,21 +32,21 @@ val option_boot : bool ref
 
 (** ML-related manipulation *)
 val coq_dependencies : unit -> unit
-val add_known : bool -> string -> string list -> string -> unit
-val add_coqlib_known : bool -> string -> string list -> string -> unit
+val add_v_known : bool -> root -> dirname -> dirpath -> basename -> unit
+val add_coqlib_known : bool -> root -> dirname -> dirpath -> basename -> unit
 
 (** Simply add this directory and imports it, no subdirs. This is used
     by the implicit adding of the current path. *)
 val add_norec_dir_import :
-  (bool -> string -> string list -> string -> unit) -> string -> string list -> unit
+  (bool -> root -> dirname -> dirpath -> basename -> unit) -> dirname -> dirpath -> unit
 
 (** -Q semantic: go in subdirs but only full logical paths are known. *)
 val add_rec_dir_no_import :
-  (bool -> string -> string list -> string -> unit) -> string -> string list -> unit
+  (bool -> root -> dirname -> dirpath -> basename -> unit) -> dirname -> dirpath -> unit
 
 (** -R semantic: go in subdirs and suffixes of logical paths are known. *)
 val add_rec_dir_import :
-  (bool -> string -> string list -> string -> unit) -> string -> string list -> unit
+  (bool -> root -> dirname -> dirpath -> basename -> unit) -> dirname -> dirpath -> unit
 
 val sort : unit -> unit
 

--- a/tools/coqdep_lexer.mli
+++ b/tools/coqdep_lexer.mli
@@ -10,10 +10,12 @@
 
 type qualid = string list
 
+type load = Logical of string | Physical of string
+
 type coq_token =
   | Require of qualid option * qualid list
   | Declare of string list
-  | Load of string
+  | Load of load
   | AddLoadPath of string
   | AddRecLoadPath of string * qualid
 

--- a/tools/coqdep_lexer.mll
+++ b/tools/coqdep_lexer.mll
@@ -15,10 +15,12 @@
 
   type qualid = string list
 
+  type load = Logical of string | Physical of string
+
   type coq_token =
     | Require of qualid option * qualid list
     | Declare of string list
-    | Load of string
+    | Load of load
     | AddLoadPath of string
     | AddRecLoadPath of string * qualid
 
@@ -170,9 +172,9 @@ and load_file = parse
   | '"' [^ '"']* '"' (*'"'*)
       { let s = lexeme lexbuf in
 	parse_dot lexbuf;
-	Load (unquote_vfile_string s) }
+        Load (Physical (unquote_vfile_string s)) }
   | coq_ident
-      { let s = get_ident lexbuf in skip_to_dot lexbuf; Load s }
+      { let s = get_ident lexbuf in skip_to_dot lexbuf; Load (Logical s) }
   | eof
       { syntax_error lexbuf }
   | _

--- a/vernac/loadpath.ml
+++ b/vernac/loadpath.ml
@@ -277,6 +277,8 @@ let add_vo_path lp =
         ()
     in
     let add (path, dir) = add_load_path path ~implicit dir in
+    (* deeper dirs registered first and thus be found last *)
+    let dirs = List.rev dirs in
     let () = List.iter add dirs in
     add_load_path unix_path ~implicit lp.coq_path
   else

--- a/vernac/loadpath.ml
+++ b/vernac/loadpath.ml
@@ -17,6 +17,7 @@ type t = {
   path_physical : CUnix.physical_path;
   path_logical : DP.t;
   path_implicit : bool;
+  path_root : (CUnix.physical_path * DP.t);
 }
 
 let load_paths = Summary.ref ([] : t list) ~name:"LOADPATHS"
@@ -58,13 +59,14 @@ let warn_overriding_logical_loadpath =
                ; DP.print old_path; strbrk "; it is remapped to "
                ; DP.print coq_path]))
 
-let add_load_path phys_path coq_path ~implicit =
+let add_load_path root phys_path coq_path ~implicit =
   let phys_path = CUnix.canonical_path_name phys_path in
   let filter p = String.equal p.path_physical phys_path in
   let binding = {
     path_logical = coq_path;
     path_physical = phys_path;
     path_implicit = implicit;
+    path_root = root;
   } in
   match List.filter filter !load_paths with
   | [] ->
@@ -96,20 +98,39 @@ let filter_path f =
   in
   aux !load_paths
 
+let eq_root (phys,log_path) (phys',log_path') =
+  String.equal phys phys' && Names.DirPath.equal log_path log_path'
+
+let add_path root file = function
+  | [] -> [root,[file]]
+  | (root',l) :: l' as l'' -> if eq_root root root' then (root', file::l) :: l' else (root,[file]) :: l''
+
 let expand_path ?root dir =
+  let exact_path = match root with None -> dir | Some root -> Libnames.append_dirpath root dir in
   let rec aux = function
-  | [] -> []
-  | { path_physical = ph; path_logical = lg; path_implicit = implicit } :: l ->
+  | [] -> [], []
+  | { path_physical = ph; path_logical = lg; path_implicit = implicit; path_root } :: l ->
+    let full, others = aux l in
+    if DP.equal exact_path lg then
+      (* Most recent full match comes first *)
+      (ph, lg) :: full, others
+    else
     let success =
       match root with
-      | None ->
-        if implicit then Libnames.is_dirpath_suffix_of dir lg
-        else DP.equal dir lg
+      | None -> implicit && Libnames.is_dirpath_suffix_of dir lg
       | Some root ->
         Libnames.(is_dirpath_prefix_of root lg &&
-                  is_dirpath_suffix_of dir (drop_dirpath_prefix root lg)) in
-    if success then (ph, lg) :: aux l else aux l in
-  aux !load_paths
+                  is_dirpath_suffix_of dir (drop_dirpath_prefix root lg))
+    in
+    if success then
+      (* Only keep partial path in the same "-R" block *)
+      full, add_path path_root (ph, lg) others
+    else
+      full, others in
+  let full, others = aux !load_paths in
+  (* Returns the dirpath matching exactly and the ordered list of
+     -R/-Q blocks with subdirectories that matches *)
+  full, List.map snd others
 
 let locate_file fname =
   let paths = List.map physical !load_paths in
@@ -129,17 +150,14 @@ let warn_several_object_files =
     Pp.(fun (vi, vo) ->
         seq [ str "Loading"; spc (); str vi
             ; strbrk " instead of "; str vo
-            ; strbrk " because it is more recent"
+            ; strbrk " because it is more recent."
             ])
 
-
-let select_vo_file ~warn loadpath base =
+let select_vo_file ~find base =
   let find ext =
-    let loadpath = List.map fst loadpath in
     try
       let name = Names.Id.to_string base ^ ext in
-      let lpath, file =
-        System.where_in_path ~warn loadpath name in
+      let lpath, file = find name in
       Some (lpath, file)
     with Not_found -> None in
   (* If [!Flags.load_vos_libraries]
@@ -168,6 +186,19 @@ let select_vo_file ~warn loadpath base =
     | _ -> load_most_recent_of_vo_and_vio()
   end else load_most_recent_of_vo_and_vio()
 
+let find_first loadpath base =
+  match System.all_in_path loadpath base with
+  | [] -> raise Not_found
+  | f :: _ -> f
+
+let find_unique fullqid loadpath base =
+  match System.all_in_path loadpath base with
+  | [] -> raise Not_found
+  | [f] -> f
+  | _::_ as l ->
+    CErrors.user_err Pp.(str "Required library " ++ Libnames.pr_qualid fullqid ++
+      strbrk " matches several files in path (found " ++ pr_enum str (List.map snd l) ++ str ").")
+
 let locate_absolute_library dir : CUnix.physical_path locate_result =
   (* Search in loadpath *)
   let pref, base = Libnames.split_dirpath dir in
@@ -175,28 +206,41 @@ let locate_absolute_library dir : CUnix.physical_path locate_result =
   match loadpath with
   | [] -> Error LibUnmappedDir
   | _ ->
-    match select_vo_file ~warn:false loadpath base with
+    match select_vo_file ~find:(find_first loadpath) base with
     | Ok (_, file) -> Ok file
     | Error fail -> Error fail
 
-let locate_qualified_library ?root ?(warn = true) qid :
+let locate_qualified_library ?root qid :
   (library_location * DP.t * CUnix.physical_path) locate_result =
   (* Search library in loadpath *)
   let dir, base = Libnames.repr_qualid qid in
-  let loadpath = expand_path ?root dir in
-  match loadpath with
-  | [] -> Error LibUnmappedDir
-  | _ ->
-    match select_vo_file ~warn loadpath base with
-    | Ok (lpath, file) ->
-      let dir = Libnames.add_dirpath_suffix
-          (CString.List.assoc lpath loadpath) base in
+  match expand_path ?root dir with
+  | [], [] -> Error LibUnmappedDir
+  | full_matches, others ->
+    let result =
+      (* Priority to exact matches *)
+      match select_vo_file ~find:(find_first full_matches) base with
+      | Ok _ as x -> x
+      | Error _ ->
+         (* Looking otherwise in -R/-Q blocks of partial matches *)
+        let rec aux = function
+          | [] -> Error LibUnmappedDir
+          | block :: rest ->
+            match select_vo_file ~find:(find_unique qid block) base with
+            | Ok _ as x -> x
+            | Error _ -> aux rest
+        in
+        aux others
+    in
+    match result with
+    | Ok (dir,file) ->
+      let library = Libnames.add_dirpath_suffix dir base in
       (* Look if loaded *)
-      if Library.library_is_loaded dir
-      then Ok (LibLoaded, dir, Library.library_full_filename dir)
+      if Library.library_is_loaded library
+      then Ok (LibLoaded, library, Library.library_full_filename library)
       (* Otherwise, look for it in the file system *)
-      else Ok (LibInPath, dir, file)
-    | Error fail -> Error fail
+      else Ok (LibInPath, library, file)
+    | Error _ as e -> e
 
 let error_unmapped_dir qid =
   let prefix, _ = Libnames.repr_qualid qid in
@@ -276,10 +320,11 @@ let add_vo_path lp =
       else
         ()
     in
-    let add (path, dir) = add_load_path path ~implicit dir in
+    let root = (unix_path,lp.coq_path) in
+    let add (path, dir) = add_load_path root path ~implicit dir in
     (* deeper dirs registered first and thus be found last *)
     let dirs = List.rev dirs in
     let () = List.iter add dirs in
-    add_load_path unix_path ~implicit lp.coq_path
+    add_load_path root unix_path ~implicit lp.coq_path
   else
     warn_cannot_open_path unix_path

--- a/vernac/loadpath.mli
+++ b/vernac/loadpath.mli
@@ -54,7 +54,6 @@ type 'a locate_result = ('a, locate_error) result
 
 val locate_qualified_library
   :  ?root:DirPath.t
-  -> ?warn:bool
   -> Libnames.qualid
   -> (library_location * DirPath.t * CUnix.physical_path) locate_result
 

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -485,7 +485,7 @@ let err_notfound_library ?from qid =
 
 let print_located_library qid =
   let open Loadpath in
-  match locate_qualified_library ~warn:false qid with
+  match locate_qualified_library qid with
   | Ok lib -> msg_found_library lib
   | Error LibUnmappedDir -> err_unmapped_library qid
   | Error LibNotFound -> err_notfound_library qid
@@ -1327,8 +1327,7 @@ let vernac_require from import qidl =
   in
   let locate qid =
     let open Loadpath in
-    let warn = not !Flags.quiet in
-    match locate_qualified_library ?root ~warn qid with
+    match locate_qualified_library ?root qid with
     | Ok (_,dir,f) -> dir, f
     | Error LibUnmappedDir -> err_unmapped_library ?from:root qid
     | Error LibNotFound -> err_notfound_library ?from:root qid


### PR DESCRIPTION
**Kind:** fix / enhancements

This PR first addresses the following:
- spurious clash warnings with `From foo Require bar`: this is a hot fix while waiting for @ejgallgo's loadpath cleanup  (#11631, #14539)

It later extended to what is described in the [comment](https://github.com/coq/coq/pull/14718#issuecomment-947862065) below.

Fixes #11631
Fixes #14539
Fixes #15053 

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.

----
Previously, it addressed anomalies or internal errors with non-existent directories and paths but this moved to proper PR. So the following is not anymore in the PR:

<details>
<summary>List of changes initially in this PR but later moved to another PR</summary>

  - `ocamllib`: changing `Uncaught exception: Sys_error("foo: No such file or directory")` into `*** Warning: foo: No such file or directory` on non-existent include (should it be an error or a warning?)
  
     → moved to #14824
  - `coqdep` on non-existent file, after #14024 which fixed a silent ignoring: from `File "foo", line 1: No such file or directory` to `Error: foo: No such file or directory` from the command line, or `*** Warning: In "_FooProject": bar: No such file or directory` if indirectly through a `_CoqProject`

     → moved to #14827

   - `coqdep` on non-existent directory: from a "please report" anomaly to `*** Warning: cannot open foo` (should it be an error?)
     
     → moved to #14826

   - `coqdep`: when a file exists but not with the expected `From root`, clarify the message that it does not exist only wrt this root

     → moved to #14829

  - `coq_makefile` on non-existent project file: changing `Fatal error: exception Sys_error("foo: No such file or directory")` into `Error: foo: No such file or directory`
   
  → moved to #14828

  - `coqdep` failing nicely and with better message where it used to fail with an anomaly of the form `Unknown option /home/coq/foo` when reading a Coq project with dirname `/home/coq` and some uninterpretable string `foo` is present in the file [Added 8/8/21]
  
  → moved to #14825

  - `coq_makefile` accepts option `-impredicative-set` when on the command line (or should it be `-arg -impredicative-set` even on the command line??) [Added 8/8/21]
  
  → abandoned

  - `coqdep` fails nicely rather than with an anomaly on parsing error of a project file [Added 8/8/21]
   
  → moved to #14828
</details>
