### PR TITLE
More uniform handling of variable patterns in Btermdn.

### DIFF
--- a/doc/changelog/04-tactics/14722-btermdn-check-var-transparency.rst
+++ b/doc/changelog/04-tactics/14722-btermdn-check-var-transparency.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  Correctly consider variables without a body to be rigid
+  for the pattern recognition algorithm of discriminated
+  hints
+  (`#14722 <https://github.com/coq/coq/pull/14722>`_,
+  by Pierre-Marie Pédrot).

--- a/test-suite/bugs/closed/bug_14722.v
+++ b/test-suite/bugs/closed/bug_14722.v
@@ -1,0 +1,34 @@
+Module map.
+  Class map {value} := mk {
+    rep : Type;
+    get: rep -> option value;
+    empty : rep;
+    put : rep -> value -> rep;
+  }.
+  Arguments map : clear implicits.
+  Class ok {value : Type} {map : map value}: Prop := {
+    get_put_diff : forall m v, get (put m v) = None;
+  }.
+  Arguments ok {_} _.
+
+End map.
+
+Axiom wordX : Set.
+Axiom e : wordX.
+
+Section Equiv.
+
+Context {Registers: map.map wordX}
+        {mem: map.map Coq.Init.Byte.byte}.
+
+Context (Registers_ok: @map.ok wordX Registers)
+        (mem_ok: @map.ok Byte.byte mem).
+
+(** Check that cleared variables are correctly handled *)
+Goal map.get (map.put map.empty e) = None.
+Proof.
+clear -Registers_ok.
+apply map.get_put_diff.
+Qed.
+
+End Equiv.


### PR DESCRIPTION
We first check that a pattern variable has a body before looking it up in the transparent state. This only affects discriminated nets. The behaviour or non-discriminated nets is very weird and asymmetrical since in patterns variables match everything but in terms they match only variables, regardless of the existence of a body.
