### PR TITLE
Nix CI: follow-up of #14590.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -417,10 +417,11 @@ pkg:nix:deploy:
   script:
     - nix-build https://coq.inria.fr/nix/toolbox --argstr job coq --arg override "{coq = coq:$CI_COMMIT_SHA;}" -K | cachix push coq
   only:
-    - master
-    - /^v.*\..*$/
-  # In the future, add a condition to also have $CACHIX_AUTH_TOKEN set.
-  # At the time of writing, we still rely on $CACHIX_SIGNING_KEY for Coq's Cachix.
+    refs:
+      - master
+      - /^v.*\..*$/
+    variables:
+      - $CACHIX_AUTH_TOKEN
 
 pkg:nix:deploy:channel:
   extends: .deploy-template
@@ -432,7 +433,8 @@ pkg:nix:deploy:channel:
       - master
       - /^v.*\..*$/
     variables:
-      - $CACHIX_DEPLOYMENT_KEY
+      - $CACHIX_AUTH_TOKEN && $CACHIX_DEPLOYMENT_KEY
+       # if the $CACHIX_AUTH_TOKEN variable isn't set, the job it depends on doesn't exist
   needs:
     - pkg:nix:deploy
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -415,7 +415,7 @@ pkg:nix:deploy:
     name: cachix
     url: https://coq.cachix.org
   script:
-    - nix-build https://coq.inria.fr/nix/toolbox --arg override "{coq = coq:$CI_COMMIT_SHA;}" -K | cachix push coq
+    - nix-build https://coq.inria.fr/nix/toolbox --argstr job coq --arg override "{coq = coq:$CI_COMMIT_SHA;}" -K | cachix push coq
   only:
     - master
     - /^v.*\..*$/


### PR DESCRIPTION
1. Build only Coq and not `coq-shell`.

   For some reason I do not understand, while Coq is built on CI, it is not uploaded to Cachix and not required when fetching `coq-shell` from Cachix.

   Cf. https://gitlab.com/coq/coq/-/jobs/1464705325 (first success) vs https://gitlab.com/coq/coq/-/jobs/1465481056 (retry).

2. Test that `CACHIX_AUTH_TOKEN` is set to run `pkg:nix:deploy`.

   Coq has now a managed Cachix so this variable should be defined and we check for its presence. This will avoid failures when building on forks where it is not defined.

   - Tested without `CACHIX_AUTH_TOKEN` set at: https://gitlab.com/Zimmi48/coq/-/pipelines/345552922 (no `pkg:nix:deploy` job)
   - Tested with `CACHIX_AUTH_TOKEN` set at: https://gitlab.com/Zimmi48/coq/-/pipelines/345554673 (there is a `pkg:nix:deploy` job).