### PR TITLE
Added argument for replacing line break between error messages.

### DIFF
--- a/toplevel/coqc.ml
+++ b/toplevel/coqc.ml
@@ -69,13 +69,14 @@ let coqc_main ((copts,_),stm_opts) injections ~opts =
   CProfile.print_profile ()
 
 let coqc_run copts ~opts injections =
+  let err_suf = Option.map Pp.str (fst (fst copts)).Coqcargs.error_suffix in
   let _feeder = Feedback.add_feeder Coqloop.coqloop_feed in
   try
     coqc_main ~opts copts injections;
     exit 0
   with exn ->
     flush_all();
-    Topfmt.print_err_exn exn;
+    Topfmt.print_err_exn ?err_suf exn;
     flush_all();
     let exit_code = if (CErrors.is_anomaly exn) then 129 else 1 in
     exit exit_code

--- a/toplevel/coqcargs.ml
+++ b/toplevel/coqcargs.ml
@@ -27,6 +27,8 @@ type t =
   ; glob_out    : Dumpglob.glob_output
 
   ; output_context : bool
+
+  ; error_suffix : string option (* custom linebreak between error messages *)
   }
 
 let default =
@@ -46,6 +48,8 @@ let default =
   ; glob_out = Dumpglob.MultFiles
 
   ; output_context = false
+
+  ; error_suffix = None
   }
 
 let depr opt =
@@ -177,6 +181,12 @@ let parse arglist : t =
         | "-verbose" ->
           echo := true;
           oval
+
+        (* Custom break between error messages *)
+        | "-errorsuffix" ->
+          let suf = next () in
+          { oval with error_suffix = Some suf }
+
         (* Output filename *)
         | "-o" ->
           { oval with compilation_output_name = Some (next ()) }
@@ -185,10 +195,10 @@ let parse arglist : t =
           set_compilation_mode oval BuildVio
         | "-vio" ->
           set_compilation_mode oval BuildVio
-        |"-vos" ->
+        | "-vos" ->
           Flags.load_vos_libraries := true;
           { oval with compilation_mode = BuildVos }
-        |"-vok" ->
+        | "-vok" ->
           Flags.load_vos_libraries := true;
           { oval with compilation_mode = BuildVok }
 

--- a/toplevel/coqcargs.mli
+++ b/toplevel/coqcargs.mli
@@ -41,6 +41,8 @@ type t =
   ; glob_out    : Dumpglob.glob_output
 
   ; output_context : bool
+
+  ; error_suffix : string option (* custom linebreak between error messages *)
   }
 
 val default : t

--- a/vernac/topfmt.ml
+++ b/vernac/topfmt.ml
@@ -394,11 +394,11 @@ let pr_phase ?loc () =
      (* Note: interactive messages such as "foo is defined" are not located *)
      None
 
-let print_err_exn any =
+let print_err_exn ?(err_suf = fnl ()) any =
   let (e, info) = Exninfo.capture any in
   let loc = Loc.get_loc info in
   let pre_hdr = pr_phase ?loc () in
-  let msg = CErrors.iprint (e, info) ++ fnl () in
+  let msg = CErrors.iprint (e, info) ++ err_suf in
   std_logger ?pre_hdr Feedback.Error msg
 
 let with_output_to_file fname func input =

--- a/vernac/topfmt.mli
+++ b/vernac/topfmt.mli
@@ -67,7 +67,7 @@ val in_phase : phase:execution_phase -> ('a -> 'b) -> 'a -> 'b
 
 val pr_loc : Loc.t -> Pp.t
 val pr_phase : ?loc:Loc.t -> unit -> Pp.t option
-val print_err_exn : exn -> unit
+val print_err_exn : ?err_suf:Pp.t -> exn -> unit
 
 (** [with_output_to_file file f x] executes [f x] with logging
     redirected to a file [file] *)


### PR DESCRIPTION
We add the `-errorsuffix` argument to coqc which lets users pass a string which will be used seperate error messages. When this option is not set it defaults to a linebreak. This is useful for users wanting to parse the output of coqc.

TODO:
 - [ ] Perhaps come up with a better name for the argument?

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #14120


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**. (Not sure if I can really test this).
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
