### PR TITLE
Remove the eta flag from CClosure redflags.

### DIFF
--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -41,7 +41,6 @@ let stats = ref false
 (* Profiling *)
 let beta = ref 0
 let delta = ref 0
-let eta = ref 0
 let zeta = ref 0
 let evar = ref 0
 let nb_match = ref 0
@@ -55,7 +54,7 @@ let reset () =
 
 let stop() =
   Feedback.msg_debug (str "[Reds: beta=" ++ int !beta ++ str" delta=" ++ int !delta ++
-         str " eta=" ++ int !eta ++ str" zeta=" ++ int !zeta ++ str" evar=" ++
+         str" zeta=" ++ int !zeta ++ str" evar=" ++
          int !evar ++ str" match=" ++ int !nb_match ++ str" fix=" ++ int !fix ++
          str " cofix=" ++ int !cofix ++ str" prune=" ++ int !prune ++
          str"]")
@@ -84,7 +83,6 @@ module type RedFlagsSig = sig
   type red_kind
   val fBETA : red_kind
   val fDELTA : red_kind
-  val fETA : red_kind
   val fMATCH : red_kind
   val fFIX : red_kind
   val fCOFIX : red_kind
@@ -112,19 +110,17 @@ module RedFlags : RedFlagsSig = struct
   type reds = {
     r_beta : bool;
     r_delta : bool;
-    r_eta : bool;
     r_const : TransparentState.t;
     r_zeta : bool;
     r_match : bool;
     r_fix : bool;
     r_cofix : bool }
 
-  type red_kind = BETA | DELTA | ETA | MATCH | FIX
+  type red_kind = BETA | DELTA | MATCH | FIX
               | COFIX | ZETA
               | CONST of Constant.t | VAR of Id.t
   let fBETA = BETA
   let fDELTA = DELTA
-  let fETA = ETA
   let fMATCH = MATCH
   let fFIX = FIX
   let fCOFIX = COFIX
@@ -134,7 +130,6 @@ module RedFlags : RedFlagsSig = struct
   let no_red = {
     r_beta = false;
     r_delta = false;
-    r_eta = false;
     r_const = all_opaque;
     r_zeta = false;
     r_match = false;
@@ -143,7 +138,6 @@ module RedFlags : RedFlagsSig = struct
 
   let red_add red = function
     | BETA -> { red with r_beta = true }
-    | ETA -> { red with r_eta = true }
     | DELTA -> { red with r_delta = true; r_const = all_transparent }
     | CONST kn ->
       let r = red.r_const in
@@ -158,7 +152,6 @@ module RedFlags : RedFlagsSig = struct
 
   let red_sub red = function
     | BETA -> { red with r_beta = false }
-    | ETA -> { red with r_eta = false }
     | DELTA -> { red with r_delta = false }
     | CONST kn ->
       let r = red.r_const in
@@ -180,7 +173,6 @@ module RedFlags : RedFlagsSig = struct
 
   let red_set red = function
     | BETA -> incr_cnt red.r_beta beta
-    | ETA -> incr_cnt red.r_eta eta
     | CONST kn ->
       let c = is_transparent_constant red.r_const kn in
         incr_cnt c delta

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -34,8 +34,6 @@ module type RedFlagsSig = sig
 
   val fBETA : red_kind
   val fDELTA : red_kind
-  val fETA : red_kind
-  (** The fETA flag is never used by the kernel reduction but pretyping does *)
   val fMATCH : red_kind
   val fFIX : red_kind
   val fCOFIX : red_kind

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -230,7 +230,7 @@ let occur_rigidly flags env evd (evk,_) t =
 let check_conv_record env sigma (t1,sk1) (t2,sk2) =
   let open ValuePattern in
   let (proji, u), arg = Termops.global_app_of_constr sigma t1 in
-  let t2, sk2' = decompose_app_vect sigma (shrink_eta env sigma t2) in
+  let t2, sk2' = decompose_app_vect sigma (shrink_eta sigma t2) in
   let sk2 = Stack.append_app sk2' sk2 in
   let (sigma, solution), sk2_effective =
     let t2 =

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -230,7 +230,7 @@ let occur_rigidly flags env evd (evk,_) t =
 let check_conv_record env sigma (t1,sk1) (t2,sk2) =
   let open ValuePattern in
   let (proji, u), arg = Termops.global_app_of_constr sigma t1 in
-  let t2, sk2' = decompose_app_vect sigma (shrink_eta env t2) in
+  let t2, sk2' = decompose_app_vect sigma (shrink_eta env sigma t2) in
   let sk2 = Stack.append_app sk2' sk2 in
   let (sigma, solution), sk2_effective =
     let t2 =

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -686,7 +686,7 @@ let solve_pattern_eqn env sigma l c =
     l c in
   (* Warning: we may miss some opportunity to eta-reduce more since c'
      is not in normal form *)
-  shrink_eta env c'
+  shrink_eta env sigma c'
 
 (*****************************************)
 (* Refining/solving unification problems *)

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -686,7 +686,7 @@ let solve_pattern_eqn env sigma l c =
     l c in
   (* Warning: we may miss some opportunity to eta-reduce more since c'
      is not in normal form *)
-  shrink_eta env sigma c'
+  shrink_eta sigma c'
 
 (*****************************************)
 (* Refining/solving unification problems *)

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -938,48 +938,44 @@ let whd_allnolet = red_of_state_red whd_allnolet_state
 
 (* 4. Ad-hoc eta reduction *)
 
-let shrink_eta env sigma c =
-  let rec whrec (x, stack) =
-    let s = (x, stack) in
-    match EConstr.kind sigma x with
-    | Cast (c,_,_) -> whrec (c, stack)
-    | App (f,cl)  -> whrec (f, Stack.append_app cl stack)
-    | Lambda (_,_,c) ->
-      (match Stack.decomp stack with
-      | None ->
-        (match EConstr.kind sigma (Stack.zip sigma (whrec (c, Stack.empty))) with
-        | App (f,cl) ->
-          let napp = Array.length cl in
-          if napp > 0 then
-            let x', l' = whrec (Array.last cl, Stack.empty) in
-            match EConstr.kind sigma x', l' with
-            | Rel 1, [] ->
-              let lc = Array.sub cl 0 (napp-1) in
-              let u = if Int.equal napp 1 then f else mkApp (f,lc) in
-              if noccurn sigma 1 u then (pop u,Stack.empty) else s
-            | _ -> s
-          else s
-        | _ -> s)
-      | Some _ -> s)
-
+let shrink_eta sigma c =
+  let rec whrec n x = match EConstr.kind sigma x with
+    | Cast (c, _, _) -> whrec n c
+    | App (f, cl)  ->
+      let ncl = Array.length cl in
+      let f = whrec (n + ncl) f in
+      let hd, args = decompose_app_vect sigma f in
+      begin match EConstr.kind sigma hd with
+      | Fix ((ri, i), _) when ri.(i) < Array.length args + ncl ->
+        let args = Array.append args cl in
+        let () = args.(ri.(i)) <- whrec 0 args.(ri.(i)) in
+        mkApp (hd, args)
+      | _ -> mkApp (f, cl)
+      end
+    | Lambda (_, _, c) ->
+      if 0 < n then x
+      else
+        let (f, cl) = decompose_app_vect sigma (whrec 0 c) in
+        let napp = Array.length cl in
+        if napp > 0 then
+          let x' = whrec 0 (Array.last cl) in
+          match EConstr.kind sigma x' with
+          | Rel 1 ->
+            let lc = Array.sub cl 0 (napp-1) in
+            let u = if Int.equal napp 1 then f else mkApp (f,lc) in
+            if noccurn sigma 1 u then pop u else x
+          | _ -> x
+        else x
     | Case (ci,u,pms,p,iv,d,lf) ->
-      whrec (d, Stack.Case (ci,u,pms,p,iv,lf) :: stack)
-
-    | Fix ((ri,n),_ as f) ->
-      (match Stack.strip_n_app ri.(n) stack with
-      |None -> s
-      |Some (bef,arg,s') -> whrec (arg, Stack.Fix(f,bef)::s'))
-
+      mkCase (ci, u, pms, p, iv, whrec 0 d, lf)
     | Meta ev ->
       (match safe_meta_value sigma ev with
-        Some c -> whrec (c,stack)
-      | None -> s)
-
-    | Construct _ | CoFix _ | Evar _ | Rel _ | Var _ | Sort _ | Prod _
-    | LetIn _ | Const _  | Ind _ | Proj _ | Int _ | Float _ | Array _ -> s
-
+        Some c -> whrec n c
+      | None -> x)
+    | Fix _ | Construct _ | CoFix _ | Evar _ | Rel _ | Var _ | Sort _ | Prod _
+    | LetIn _ | Const _  | Ind _ | Proj _ | Int _ | Float _ | Array _ -> x
   in
-  Stack.zip sigma (whrec (c, Stack.empty))
+  whrec 0 c
 
 (* 5. Zeta Reduction Functions *)
 

--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -167,7 +167,7 @@ val whd_betadeltazeta :  reduction_function
 val whd_zeta_stack : stack_reduction_function
 val whd_zeta : reduction_function
 
-val shrink_eta : Environ.env -> evar_map -> constr -> constr
+val shrink_eta : evar_map -> constr -> constr
 
 (** Various reduction functions *)
 

--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -167,7 +167,7 @@ val whd_betadeltazeta :  reduction_function
 val whd_zeta_stack : stack_reduction_function
 val whd_zeta : reduction_function
 
-val shrink_eta : Environ.env -> constr -> constr
+val shrink_eta : Environ.env -> evar_map -> constr -> constr
 
 (** Various reduction functions *)
 

--- a/pretyping/structures.ml
+++ b/pretyping/structures.ml
@@ -229,7 +229,7 @@ let compute_canonical_projections env ~warn (gref,ind) =
   let lpj = keep_true_projections lpj in
   let nenv = Termops.push_rels_assum sign env in
   List.fold_left2 (fun acc (spopt, canonical) t ->
-      let t = EConstr.Unsafe.to_constr (shrink_eta env (EConstr.of_constr t)) in
+      let t = EConstr.Unsafe.to_constr (shrink_eta env (Evd.from_env env) (EConstr.of_constr t)) in
       if canonical
       then
         Option.cata (fun proji_sp ->

--- a/pretyping/structures.ml
+++ b/pretyping/structures.ml
@@ -229,7 +229,7 @@ let compute_canonical_projections env ~warn (gref,ind) =
   let lpj = keep_true_projections lpj in
   let nenv = Termops.push_rels_assum sign env in
   List.fold_left2 (fun acc (spopt, canonical) t ->
-      let t = EConstr.Unsafe.to_constr (shrink_eta env (Evd.from_env env) (EConstr.of_constr t)) in
+      let t = EConstr.Unsafe.to_constr (shrink_eta (Evd.from_env env) (EConstr.of_constr t)) in
       if canonical
       then
         Option.cata (fun proji_sp ->

--- a/tactics/cbn.ml
+++ b/tactics/cbn.ml
@@ -546,7 +546,7 @@ let apply_branch env sigma (ind, i) args (ci, u, pms, iv, r, lf) =
   in
   Vars.substl subst (snd br)
 
-let rec whd_state_gen ?csts flags env sigma =
+let whd_state_gen ?csts flags env sigma =
   let open Context.Named.Declaration in
   let open ReductionBehaviour in
   let rec whrec cst_l (x, stack) =
@@ -685,22 +685,6 @@ let rec whd_state_gen ?csts flags env sigma =
       (match Stack.decomp stack with
       | Some _ when CClosure.RedFlags.red_set flags CClosure.RedFlags.fBETA ->
         apply_subst (fun _ -> whrec) [] sigma cst_l x stack
-      | None when CClosure.RedFlags.red_set flags CClosure.RedFlags.fETA ->
-        let env' = push_rel (LocalAssum (na, t)) env in
-        let whrec' = whd_state_gen flags env' sigma in
-        (match EConstr.kind sigma (Stack.zip ~refold:true sigma (whrec' (c, Stack.empty))) with
-        | App (f,cl) ->
-          let napp = Array.length cl in
-          if napp > 0 then
-            let (x', l') = whrec' (Array.last cl, Stack.empty) in
-            match EConstr.kind sigma x', l' with
-            | Rel 1, [] ->
-              let lc = Array.sub cl 0 (napp-1) in
-              let u = if Int.equal napp 1 then f else mkApp (f,lc) in
-              if noccurn sigma 1 u then (pop u,Stack.empty),Cst_stack.empty else fold ()
-            | _ -> fold ()
-          else fold ()
-        | _ -> fold ())
       | _ -> fold ())
 
     | Case (ci,u,pms,p,iv,d,lf) ->


### PR DESCRIPTION
This flag was never used in the kernel, and the only user was the `shrink_eta` function which did not use it with any other reduction flag. This caused quite a bit of duplication in the various upper layer machines for nothing. Furthermore the semantics was already dubious in some corner cases with the eta flag alone, but it would have been worse if trying to mix eta with additional reductions.

We inline the only call in the `shrink_eta` function, and take advantage of the operation to make it correct w.r.t. evars.