### PR TITLE
On-the-fly η-reduction of dnet patterns and terms.

### DIFF
--- a/doc/changelog/04-tactics/14732-btermdn-up-to-eta-match.rst
+++ b/doc/changelog/04-tactics/14732-btermdn-up-to-eta-match.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Correctly handle matching up to η-expansion in discriminated
+  hints
+  (`#14732 <https://github.com/coq/coq/pull/14731>`_,
+  fixes `#14731 <https://github.com/coq/coq/issues/14731>`_,
+  by Pierre-Marie Pédrot).

--- a/tactics/btermdn.ml
+++ b/tactics/btermdn.ml
@@ -23,7 +23,6 @@ let dnet_depth = ref 8
 type term_label =
 | GRLabel of GlobRef.t
 | ProdLabel
-| LambdaLabel
 | SortLabel
 
 let compare_term_label t1 t2 = match t1, t2 with
@@ -107,7 +106,6 @@ let constr_val_discr env sigma ts t =
       Label(ProdLabel, [d; c])
     | Lambda (n, d, c) ->
       if Option.is_empty ts then Nothing
-      else if List.is_empty l then Label(LambdaLabel, [d; c])
       else Everything
     | Sort _ -> Label(SortLabel, [])
     | Evar _ -> if Option.is_empty ts then Nothing else Everything
@@ -139,8 +137,7 @@ let constr_pat_discr env ts t =
     end
   | PProd (_, d, c), [] ->
     Some (ProdLabel, [d ; c])
-  | PLambda (_, d, c), [] ->
-    if Option.is_empty ts then None else Some (LambdaLabel, [d ; c])
+  | PLambda (_, d, c), [] -> None
   | PSort s, [] ->
     Some (SortLabel, [])
   | _ -> None

--- a/test-suite/bugs/closed/bug_14731.v
+++ b/test-suite/bugs/closed/bug_14731.v
@@ -58,3 +58,24 @@ Declare Instance myInst {X : Type} (x : X) : Contr {y : X & @paths X x y}.
 Definition foo {X : Type} (x : X) : Contr {y' : X & @paths X x y'} := _.
 
 End RelCapture.
+
+Module Collapse.
+
+Class Test {A : Type} (R : A -> Prop) : Prop := {}.
+
+Axiom t : Type -> Type.
+Axiom map2 : forall [elt : Type], (elt -> Prop) -> t elt -> Prop.
+
+Definition lift_relation {A} (R : A -> Prop) (defaultA : A) (m1 : t A) : Prop :=
+  map2 (fun x1 => R defaultA) m1.
+
+Definition Q : Prop -> Prop := fun H => H.
+
+#[local]
+Declare Instance lift0 : forall (A : Type) (default : A) (R : A -> Prop),
+   Test (fun x : A => Q (R x)) ->
+   Test (fun x : t A => Q (lift_relation R default x)).
+
+Definition foo {A R} {HR : @Test A R} {default} : Test (@lift_relation A R default) := _.
+
+End Collapse.

--- a/test-suite/bugs/closed/bug_14731.v
+++ b/test-suite/bugs/closed/bug_14731.v
@@ -79,3 +79,21 @@ Declare Instance lift0 : forall (A : Type) (default : A) (R : A -> Prop),
 Definition foo {A R} {HR : @Test A R} {default} : Test (@lift_relation A R default) := _.
 
 End Collapse.
+
+From Coq Require List.
+
+Module FMap.
+
+Import List. Import ListNotations.
+
+Monomorphic Universe i o.
+Class FMap (M : Type@{i} -> Type@{o}) :=
+  fmap : forall {A:Type@{i}} {B:Type@{o}}, (A -> B) -> M A -> M B.
+Global Arguments fmap {_ _ _ _} _ !_ / : assert.
+#[local]
+Monomorphic Instance fmap_list@{a b} : FMap (fun T => list T) :=
+  fun (A : Type@{a}) (B : Type@{b}) f => @map A B f.
+Fail Fail Monomorphic Constraint i < list.u0.
+Fail Fail Example instance_found := fmap (id) [1;2;3].
+
+End FMap.

--- a/test-suite/bugs/closed/bug_14731.v
+++ b/test-suite/bugs/closed/bug_14731.v
@@ -1,0 +1,60 @@
+(* Check that hints are correctly applied up to η-expansion. *)
+
+Module Unary.
+
+Class Test {A : Type} (R : A -> Prop) : Prop := {}.
+
+Axiom A : Type.
+
+Definition foo {R : A -> Prop} {HR : @Test A (fun x => R x)} : @Test A R := _.
+Definition bar {R : A -> Prop} {HR : @Test A R} : @Test A (fun x => R x) := _.
+
+Axiom R₀ : A -> Prop.
+
+Definition foo₀ {HR : @Test A (fun x => R₀ x)} : @Test A R₀ := _.
+Definition bar₀ {HR : @Test A R₀} : @Test A (fun x => R₀ x) := _.
+
+Inductive R₁ : A -> Prop :=.
+
+Definition foo₁ {HR : @Test A (fun x => R₁ x)} : @Test A R₁ := _.
+Definition bar₁ {HR : @Test A R₁} : @Test A (fun x => R₁ x) := _.
+
+End Unary.
+
+(* For good measure, check that η-expansion works with functions of arity 2 *)
+
+Module Binary.
+
+Class Test {A B : Type} (R : A -> B -> Prop) : Prop := {}.
+
+Axiom A B : Type.
+
+Definition foo {R : A -> B -> Prop} {HR : @Test A B (fun x y => R x y)} : @Test A B R := _.
+Definition bar {R : A -> B -> Prop} {HR : @Test A B R} : @Test A B (fun x y => R x y) := _.
+
+Axiom R₀ : A -> B -> Prop.
+
+Definition foo₀ {HR : @Test A B (fun x y => R₀ x y)} : @Test A B R₀ := _.
+Definition bar₀ {HR : @Test A B R₀} : @Test A B (fun x y => R₀ x y) := _.
+
+Inductive R₁ : A -> B -> Prop :=.
+
+Definition foo₁ {HR : @Test A B (fun x y => R₁ x y)} : @Test A B R₁ := _.
+Definition bar₁ {HR : @Test A B R₁} : @Test A B (fun x y => R₁ x y) := _.
+
+End Binary.
+
+(* Check that η-expansion correctly handles holes in patterns *)
+
+Module RelCapture.
+
+Inductive paths {A : Type} (a : A) : A -> Type :=.
+
+Class Contr (A : Type) : Type := {}.
+
+#[export]
+Declare Instance myInst {X : Type} (x : X) : Contr {y : X & @paths X x y}.
+
+Definition foo {X : Type} (x : X) : Contr {y' : X & @paths X x y'} := _.
+
+End RelCapture.


### PR DESCRIPTION
Due to the way opaque terms are handled, dnet pattern matching was failing to recognize that the η-expansion of a term was matching that term, in both directions. To solve this, we simply η-reduce both terms and patterns before adding and retrieving them from the dnet. We furthermore stop considering lambda abstractions as special pattern nodes since they are part of the η-expansion quotient.

Fixes #14731: Term matching in discriminated hints is not up-to η-expansion.
