### PR TITLE
Check typability of the "cut formula" before trying first order heuristic on second-order unification problems

### DIFF
--- a/test-suite/bugs/closed/bug_13134.v
+++ b/test-suite/bugs/closed/bug_13134.v
@@ -1,0 +1,20 @@
+Set Implicit Arguments.
+Set Primitive Projections.
+Record prod (A B:Type) : Type := pair { fst : A ; snd : B }.
+Infix "*" := prod : type_scope.
+Add Printing Let prod.
+Notation "( x , y , .. , z )" := (pair .. (pair x y) .. z) : core_scope.
+Arguments pair {A B} _ _.
+Arguments fst {A B} _.
+Arguments snd {A B} _.
+Record Category := { object :> Type; morphism : object -> object -> Type }.
+Record Functor (C D : Category) :=
+  { object_of :> C -> D;
+    morphism_of : forall s d, morphism C s d -> morphism D (object_of s) (object_of d) }.
+Arguments morphism_of {_ _} _ {_ _}.
+
+Axiom functor_eq
+  : forall {C D} (F G : Functor C D),
+    (forall s d (m : morphism C s d),
+        existT _ (_, _) (morphism_of F m) = existT _ (_, _) (morphism_of G m) :> { sd & morphism D (fst sd) (snd sd) })
+    -> F = G.


### PR DESCRIPTION
**Kind:** tentative enhancement of unification + fix

We check typability of the resulting first-order unification problem before trying first-order heuristics. We use retyping which should be rather quick. Maybe the overhead shall actually compensate the time passed in ill-typed unification paths.
    
To possibly do later:
- Use rather than discard the result of type unification?
- Add a compare_shape_tail in ise_stack2 to check if it helps for efficiency

Fixes / closes #13134 (but possibly other issues).

- [x] Added / updated **test-suite**.
- [ ] Added **changelog**.
