### PR TITLE
[stdlib] Arith: deprecate files mentioned as (mostly) obsolete

### DIFF
--- a/doc/changelog/10-standard-library/14736-Arith2.rst
+++ b/doc/changelog/10-standard-library/14736-Arith2.rst
@@ -1,0 +1,12 @@
+- **Deprecated:**
+  some obsolete files from the ``Arith`` part of the standard library
+  (``Div2``, ``Even``, ``Gt``, ``Le``, ``Lt``, ``Max``, ``Min``, ``Minus``, ``Mult``, ``NPeano``, ``Plus``).
+  Import ``Arith_base`` instead of these files.  References to items in the deprecated files should be replaced
+  with references to ``PeanoNat.Nat`` as suggested by the warning messages.
+  All ``Hint`` declarations in the ``arith`` database have been moved to ``Arith_prebase`` and
+  ``Arith_base``.  To use the results about Peano arithmetic, we recommend importing
+  ``PeanoNat`` (or ``Arith_base`` to base it on the ``arith`` hint database) and using the ``Nat`` module.
+  ``Arith_prebase`` has been introduced temporarily to ensure compatibility, but it will be removed at the end of the
+  deprecation phase, e.g. in 8.18.  Its use is thus discouraged.
+  (`#14736 <https://github.com/coq/coq/pull/14736>`_,
+  by Olivier Laurent).

--- a/doc/stdlib/hidden-files
+++ b/doc/stdlib/hidden-files
@@ -1,3 +1,14 @@
+theories/Arith/Arith_prebase.v
+theories/Arith/Le.v
+theories/Arith/Lt.v
+theories/Arith/Plus.v
+theories/Arith/Minus.v
+theories/Arith/Mult.v
+theories/Arith/Gt.v
+theories/Arith/Min.v
+theories/Arith/Max.v
+theories/Arith/Div2.v
+theories/Arith/Even.v
 theories/btauto/Algebra.v
 theories/btauto/Btauto.v
 theories/btauto/Reflect.v
@@ -60,6 +71,7 @@ theories/micromega/ZifyPow.v
 theories/micromega/Zify.v
 theories/nsatz/NsatzTactic.v
 theories/nsatz/Nsatz.v
+theories/Numbers/Natural/Peano/NPeano.v
 theories/omega/OmegaLemmas.v
 theories/omega/PreOmega.v
 theories/quote/Quote.v

--- a/doc/stdlib/index-list.html.template
+++ b/doc/stdlib/index-list.html.template
@@ -115,24 +115,14 @@ through the <tt>Require Import</tt> command.</p>
   </dt>
   <dd>
     theories/Arith/PeanoNat.v
-    theories/Arith/Le.v
-    theories/Arith/Lt.v
-    theories/Arith/Plus.v
-    theories/Arith/Minus.v
-    theories/Arith/Mult.v
-    theories/Arith/Gt.v
     theories/Arith/Between.v
     theories/Arith/Peano_dec.v
     theories/Arith/Compare_dec.v
     (theories/Arith/Arith_base.v)
     (theories/Arith/Arith.v)
-    theories/Arith/Min.v
-    theories/Arith/Max.v
     theories/Arith/Compare.v
-    theories/Arith/Div2.v
     theories/Arith/EqNat.v
     theories/Arith/Euclid.v
-    theories/Arith/Even.v
     theories/Arith/Bool_nat.v
     theories/Arith/Factorial.v
     theories/Arith/Wf_nat.v
@@ -319,7 +309,6 @@ through the <tt>Require Import</tt> command.</p>
     theories/Numbers/Natural/Abstract/NBits.v
     theories/Numbers/Natural/Abstract/NProperties.v
     theories/Numbers/Natural/Binary/NBinary.v
-    theories/Numbers/Natural/Peano/NPeano.v
     </dd>
 
     <dt> <b>&nbsp;&nbsp;Integer</b>:

--- a/test-suite/bugs/closed/bug_3037.v
+++ b/test-suite/bugs/closed/bug_3037.v
@@ -1,6 +1,6 @@
 (* Anomaly before 4a8950ec7a0d9f2b216e67e69b446c064590a8e9 *)
 
-Require Import Recdef.
+Require Import Arith_base Recdef.
 
 Function f_R (a: nat) {wf (fun x y: nat => False)  a}:Prop:=
   match a:nat with

--- a/test-suite/bugs/closed/bug_4456.v
+++ b/test-suite/bugs/closed/bug_4456.v
@@ -586,7 +586,7 @@ Defined.
               | _ => discriminate
               | [ H : forall x, (_ * _)%type -> _ |- _ ] => specialize (fun x y z => H x (y, z))
               | _ => solve [ eauto with nocore ]
-              | _ => solve [ apply Min.min_case_strong; lia ]
+              | _ => solve [ apply Nat.min_case_strong; lia ]
               | _ => lia
               | [ H : production_valid (_::_) |- _ ]
                 => let H' := fresh in
@@ -627,7 +627,7 @@ Defined.
                   => parse_production'_helper
                        _
                        (let parse_item := (fun n pf => parse_item' (parse_nonterminal (take n str) (len := min n len) (eq_trans take_length (f_equal (min _) Hlen)) pf) it) in
-                        let parse_item := (fun n => parse_item n (Min.min_case_strong n len (fun k => k <= len0) (fun Hlen => (Nat.le_trans _ _ _ Hlen pf)) (fun Hlen => pf))) in
+                        let parse_item := (fun n => parse_item n (Nat.min_case_strong n len (fun k => k <= len0) (fun Hlen => (Nat.le_trans _ _ _ Hlen pf)) (fun Hlen => pf))) in
                         let parse_production := (fun n => parse_production' (pf_helper it its Hreachable) (drop n str) (len - n) (eq_trans (drop_length _ _) (f_equal (fun x => x - _) Hlen)) (Nat.le_trans _ _ _ (Nat.le_sub_l _ _) pf)) in
                         match dec_In
                                 (fun n => dec_prod (parse_item n) (parse_production n))

--- a/test-suite/bugs/opened/bug_1596.v
+++ b/test-suite/bugs/opened/bug_1596.v
@@ -154,7 +154,7 @@ Module MessageSpi.
       unfold eq;unfold lt.
       induction x;destruct y;simpl;try tauto;intro;red;intro;try (discriminate
 H0);injection H0;intros.
-      elim (lt_irrefl n); lia.
+      elim (Nat.lt_irrefl n); lia.
     Qed.
 
     Definition compare : forall (x y:t),(Compare lt eq x y).

--- a/test-suite/prerequisite/ssr_ssrsyntax1.v
+++ b/test-suite/prerequisite/ssr_ssrsyntax1.v
@@ -15,7 +15,7 @@ Require Import Arith.
 
 Goal (forall a b, a + b = b + a).
 intros.
-rewrite plus_comm, plus_comm.
+rewrite Nat.add_comm, Nat.add_comm.
 split.
 Abort.
 
@@ -24,13 +24,13 @@ Import ssreflect.
 
 Goal (forall a b, a + b = b + a).
 intros.
-rewrite 2![_ + _]plus_comm.
+rewrite 2![_ + _]Nat.add_comm.
 split.
 Abort.
 End Foo.
 
 Goal (forall a b, a + b = b + a).
 intros.
-rewrite plus_comm, plus_comm.
+rewrite Nat.add_comm, Nat.add_comm.
 split.
 Abort.

--- a/test-suite/ssr/ssrsyntax2.v
+++ b/test-suite/ssr/ssrsyntax2.v
@@ -15,6 +15,6 @@ Require Import Arith.
 
 Goal (forall a b, a + b = b + a).
 intros.
-rewrite plus_comm, plus_comm.
+rewrite Nat.add_comm, Nat.add_comm.
 split.
 Qed.

--- a/test-suite/stm/Nijmegen_QArithSternBrocot_Zaux.v
+++ b/test-suite/stm/Nijmegen_QArithSternBrocot_Zaux.v
@@ -1255,13 +1255,13 @@ Proof.
  apply Zle_lt_succ.
  change (Z_of_nat 0 <= Z_of_nat n)%Z in |- *.
  apply Znat.inj_le.
- apply le_O_n.
+ apply Nat.le_0_l.
  apply Z.lt_gt.
  change (0 < Z.succ (Z_of_nat m))%Z in |- *.
  apply Zle_lt_succ.
  change (Z_of_nat 0 <= Z_of_nat m)%Z in |- *.
  apply Znat.inj_le.
- apply le_O_n.
+ apply Nat.le_0_l.
 Qed.
 
 
@@ -1432,7 +1432,7 @@ Proof.
  rewrite S_predn.
  symmetry  in |- *; apply ZL9.
  clear Hp;
-  apply sym_not_equal; apply lt_O_neq; apply lt_O_nat_of_P.
+  apply Nat.neq_0_lt_0, lt_O_nat_of_P.
 Qed.
 
 
@@ -1442,7 +1442,7 @@ Lemma le_absolu :
  (0 <= x)%Z -> (0 <= y)%Z -> (x <= y)%Z -> Z.abs_nat x <= Z.abs_nat y.
 Proof.
  intros [| x| x] [| y| y] Hx Hy Hxy;
-  apply le_O_n ||
+  apply Nat.le_0_l ||
     (try
       match goal with
       | id1:(0 <= Zneg _)%Z |- _ =>
@@ -1522,7 +1522,7 @@ Qed.
 Let pred_nat_unfolded_subproof px :
   Pos.to_nat px <> 0.
 Proof.
-apply sym_not_equal; apply lt_O_neq; apply lt_O_nat_of_P.
+apply Nat.neq_0_lt_0, lt_O_nat_of_P.
 Qed.
 
 Lemma pred_nat_unfolded :
@@ -2430,7 +2430,7 @@ Proof.
  replace (- p + p)%Z with (Z_of_nat 0).
  ring_simplify (- p + (p + Z_of_nat k))%Z.
  apply Znat.inj_le.
- apply le_O_n.
+ apply Nat.le_0_l.
  ring_simplify; auto with arith.
  assumption.
  rewrite (Znat.inj_S k).
@@ -2487,7 +2487,7 @@ Proof.
  replace (- p + p)%Z with (Z_of_nat 0).
  replace (- p + (p + Z_of_nat k))%Z with (Z_of_nat k).
  apply Znat.inj_le.
- apply le_O_n.
+ apply Nat.le_0_l.
  rewrite Zplus_assoc; rewrite Zplus_opp_l; reflexivity.
  rewrite Zplus_opp_l; reflexivity.
  assumption.
@@ -2551,7 +2551,7 @@ Proof.
  apply Z.ge_le.
  apply Zge_opp.
  apply Znat.inj_le.
- apply le_O_n.
+ apply Nat.le_0_l.
  unfold Zminus in |- *; rewrite Zplus_assoc; rewrite Zplus_opp_l; reflexivity.
  rewrite Zplus_opp_l; reflexivity.
  assumption.
@@ -2621,7 +2621,7 @@ Proof.
  apply Z.ge_le.
  apply Zge_opp.
  apply Znat.inj_le.
- apply le_O_n.
+ apply Nat.le_0_l.
  ring.
  ring_simplify; auto with arith.
  assumption.

--- a/test-suite/success/PPFix.v
+++ b/test-suite/success/PPFix.v
@@ -1,9 +1,8 @@
 
 (* To test PP of fixpoints *)
-Require Import Arith.
+Require Import PeanoNat.
 Check fix a(n: nat): n<5 -> nat :=
   match n return n<5 -> nat with
     | 0 => fun _ => 0
-    | S n => fun h => S (a n (lt_S_n _ _ (lt_S _ _ h)))
+    | S n => fun h => S (a n (proj2 (Nat.succ_lt_mono _ _) (Nat.lt_lt_succ_r _ _ h)))
   end.
-

--- a/test-suite/success/RecTutorial.v
+++ b/test-suite/success/RecTutorial.v
@@ -264,32 +264,32 @@ Qed.
 
 Require Import Arith.
 
-Check mult_1_l.
+Check Nat.mul_1_l.
 (*
-mult_1_l
+Nat.mul_1_l
      : forall n : nat, 1 * n = n
 *)
 
-Check mult_plus_distr_r.
+Check Nat.mul_add_distr_r.
 (*
-mult_plus_distr_r
+Nat.mul_add_distr_r
      : forall n m p : nat, (n + m) * p = n * p + m * p
 
 *)
 
-Lemma mult_distr_S : forall n p : nat, n * p + p = (S n)* p.
- simpl;auto with arith.
+Lemma mul_distr_S : forall n p : nat, n * p + p = (S n)* p.
+ simpl; auto with arith.
 Qed.
 
 Lemma four_n : forall n:nat, n+n+n+n = 4*n.
- intro n;rewrite <- (mult_1_l n).
+ intro n;rewrite <- (Nat.mul_1_l n).
 
  Undo.
  intro n; pattern n at 1.
 
 
- rewrite <- mult_1_l.
- repeat rewrite   mult_distr_S.
+ rewrite <- Nat.mul_1_l.
+ repeat rewrite mul_distr_S.
  trivial.
 Qed.
 
@@ -313,9 +313,9 @@ End Le_case_analysis.
 
 Lemma predecessor_of_positive : forall n, 1 <= n ->  exists p:nat, n = S p.
 Proof.
- intros n  H; case H.
+ intros n H; case H.
  exists 0; trivial.
- intros m Hm; exists m;trivial.
+ intros m Hm; exists m; trivial.
 Qed.
 
 Definition Vtail_total

--- a/test-suite/success/TestRefine.v
+++ b/test-suite/success/TestRefine.v
@@ -203,8 +203,7 @@ exact lt_wf.
 Abort.
 
 
-Require Import Compare_dec.
-Require Import Lt.
+Require Import Arith_base.
 
 Lemma fibo : nat -> nat.
  refine
@@ -220,6 +219,5 @@ Lemma fibo : nat -> nat.
      end)).
 exact lt_wf.
 auto with arith.
-apply lt_trans with (m := pred x0); auto with arith.
+apply Nat.lt_trans with (m := pred x0); auto with arith.
 Qed.
-

--- a/test-suite/success/import_lib.v
+++ b/test-suite/success/import_lib.v
@@ -28,35 +28,36 @@ End Test_Read.
 
 (****************************************************************)
 
+(* Arith.Compare containes Require Export Wf_nat. *)
 Definition le_decide := 1.  (* from Arith/Compare *)
-Definition min := 0.            (* from Arith/Min *)
+Definition lt_wf := 0.      (* from Arith/Wf_nat *)
 
 Module Test_Require.
 
   Module M.
-    Require Import Compare.              (* Imports Min as well *)
+    Require Import Compare.              (* Imports Compare_dec as well *)
 
-    Lemma th1 : le_decide = le_decide.
+    Lemma th1 n : le_decide n = le_decide n.
       reflexivity.
     Qed.
 
-    Lemma th2 : min = min.
+    Lemma th2 n : lt_wf n = lt_wf n.
       reflexivity.
     Qed.
 
   End M.
 
-  (* Checks that Compare and List are loaded *)
+  (* Checks that Compare and Wf_nat are loaded *)
   Check Compare.le_decide.
-  Check Min.min.
+  Check Wf_nat.lt_wf.
 
 
-  (* Checks that Compare and List are _not_ imported *)
+  (* Checks that Compare and Wf_nat are _not_ imported *)
   Lemma th1 : le_decide = 1.
     reflexivity.
   Qed.
 
-  Lemma th2 : min = 0.
+  Lemma th2 : lt_wf = 0.
     reflexivity.
   Qed.
 
@@ -67,7 +68,7 @@ Module Test_Require.
     reflexivity.
   Qed.
 
-  Lemma th4 : min = 0.
+  Lemma th4 : lt_wf = 0.
     reflexivity.
   Qed.
 
@@ -77,29 +78,29 @@ End Test_Require.
 
 Module Test_Import.
   Module M.
-    Import Compare.              (* Imports Min as well *)
+    Import Compare.              (* Imports Wf_nat as well *)
 
-    Lemma th1 : le_decide = le_decide.
+    Lemma th1 n : le_decide n = le_decide n.
       reflexivity.
     Qed.
 
-    Lemma th2 : min = min.
+    Lemma th2 n : lt_wf n = lt_wf n.
       reflexivity.
     Qed.
 
   End M.
 
-  (* Checks that Compare and List are loaded *)
+  (* Checks that Compare and Wf_nat are loaded *)
   Check Compare.le_decide.
-  Check Min.min.
+  Check Wf_nat.lt_wf.
 
 
-  (* Checks that Compare and List are _not_ imported *)
+  (* Checks that Compare and Wf_nat are _not_ imported *)
   Lemma th1 : le_decide = 1.
     reflexivity.
   Qed.
 
-  Lemma th2 : min = 0.
+  Lemma th2 : lt_wf = 0.
     reflexivity.
   Qed.
 
@@ -110,7 +111,7 @@ Module Test_Import.
     reflexivity.
   Qed.
 
-  Lemma th4 : min = 0.
+  Lemma th4 : lt_wf = 0.
     reflexivity.
   Qed.
 End Test_Import.
@@ -119,25 +120,25 @@ End Test_Import.
 
 Module Test_Export.
   Module M.
-    Export Compare.              (* Exports Min as well *)
+    Export Compare.              (* Exports Wf_nat as well *)
 
-    Lemma th1 : le_decide = le_decide.
+    Lemma th1 n : le_decide n = le_decide n.
       reflexivity.
     Qed.
 
-    Lemma th2 : min = min.
+    Lemma th2 n : lt_wf n = lt_wf n.
       reflexivity.
     Qed.
 
   End M.
 
 
-  (* Checks that Compare and List are _not_ imported *)
+  (* Checks that Compare and Wf_nat are _not_ imported *)
   Lemma th1 : le_decide = 1.
     reflexivity.
   Qed.
 
-  Lemma th2 : min = 0.
+  Lemma th2 : lt_wf = 0.
     reflexivity.
   Qed.
 
@@ -146,11 +147,11 @@ Module Test_Export.
 
   Import M.
 
-  Lemma th3 : le_decide = le_decide.
+  Lemma th3 n : le_decide n = le_decide n.
     reflexivity.
   Qed.
 
-  Lemma th4 : min = min.
+  Lemma th4 n : lt_wf n = lt_wf n.
     reflexivity.
   Qed.
 End Test_Export.
@@ -160,29 +161,29 @@ End Test_Export.
 
 Module Test_Require_Export.
 
-  Definition mult_sym := 1.    (* from Arith/Mult *)
-  Definition plus_sym := 0.        (* from Arith/Plus *)
+  Definition le_decide := 1.    (* from Arith/Compare *)
+  Definition lt_wf := 0.        (* from Arith/Wf_nat *)
 
   Module M.
-    Require Export Mult.         (* Exports Plus as well *)
+    Require Export Compare.       (* Exports Wf_nat as well *)
 
-    Lemma th1 : mult_comm = mult_comm.
+    Lemma th1 n : le_decide n = le_decide n.
       reflexivity.
     Qed.
 
-    Lemma th2 : plus_comm = plus_comm.
+    Lemma th2 n : lt_wf n = lt_wf n.
       reflexivity.
     Qed.
 
   End M.
 
 
-  (* Checks that Mult and Plus are _not_ imported *)
-  Lemma th1 : mult_sym = 1.
+  (* Checks that Compare and Wf_nat are _not_ imported *)
+  Lemma th1 : le_decide = 1.
     reflexivity.
   Qed.
 
-  Lemma th2 : plus_sym = 0.
+  Lemma th2 : lt_wf = 0.
     reflexivity.
   Qed.
 
@@ -191,11 +192,11 @@ Module Test_Require_Export.
 
   Import M.
 
-  Lemma th3 : mult_comm = mult_comm.
+  Lemma th3 n : le_decide n = le_decide n.
     reflexivity.
   Qed.
 
-  Lemma th4 : plus_comm = plus_comm.
+  Lemma th4 n : lt_wf n = lt_wf n.
     reflexivity.
   Qed.
 

--- a/test-suite/success/rewrite.v
+++ b/test-suite/success/rewrite.v
@@ -36,7 +36,7 @@ Require Import Arith.
 
 Goal forall n, 0 + n = n -> True.
 intros n H.
-rewrite plus_0_l in H.
+rewrite Nat.add_0_l in H.
 Abort.
 
 (* Rewrite dependent proofs from left-to-right *)

--- a/theories/Arith/Arith_base.v
+++ b/theories/Arith/Arith_base.v
@@ -8,7 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-Require Export PeanoNat.
+Require Export Arith_prebase.
 
 Require Export Le.
 Require Export Lt.
@@ -16,9 +16,23 @@ Require Export Plus.
 Require Export Gt.
 Require Export Minus.
 Require Export Mult.
+
+Require Export Factorial.
 Require Export Between.
 Require Export Peano_dec.
 Require Export Compare_dec.
-Require Export Factorial.
 Require Export EqNat.
 Require Export Wf_nat.
+
+(* ** [eq_nat] *)
+#[global]
+Hint Resolve eq_nat_refl: arith.
+#[global]
+Hint Immediate eq_eq_nat eq_nat_eq: arith.
+
+(* ** [between] *)
+#[global]
+Hint Resolve nth_O bet_S bet_emp bet_eq between_Sk_l exists_S exists_le
+  in_int_S in_int_intro: arith.
+#[global]
+Hint Immediate in_int_Sp_q exists_le_S exists_S_le: arith.

--- a/theories/Arith/Arith_prebase.v
+++ b/theories/Arith/Arith_prebase.v
@@ -1,0 +1,324 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+
+(** * DO NOT REQUIRE OR IMPORT! This is a temporary file preparing deprecation *)
+
+
+
+
+Require Export PeanoNat.
+
+(** * [arith] hint database *)
+
+(** ** [lt] and [le] *)
+#[global]
+Hint Resolve Nat.le_trans: arith. (* Le.le_trans *)
+#[global]
+Hint Immediate Nat.le_antisymm: arith. (* Le.le_antisym *)
+#[global]
+Hint Resolve Nat.le_0_l Nat.nle_succ_0: arith. (* Le.le_0_n Le.le_Sn_0*)
+#[global]
+Hint Resolve Peano.le_n_S Nat.le_succ_diag_r Nat.nle_succ_diag_l : arith. (* Le.le_n_S Le.le_n_Sn Le.le_Sn_n *)
+#[local]
+Definition le_n_0_eq_stt := fun n Hle => eq_sym (proj1 (Nat.le_0_r n) Hle).
+Opaque le_n_0_eq_stt.
+#[global]
+Hint Immediate le_n_0_eq_stt Nat.lt_le_incl Peano.le_S_n : arith. (* Le.le_n_0_eq Le.le_Sn_le Le.le_S_n *)
+#[global]
+Hint Resolve Nat.le_pred_l: arith. (* Le.le_pred_n *)
+#[global]
+Hint Resolve Nat.lt_irrefl: arith. (* Lt.lt_irrefl *)
+#[local]
+Definition lt_le_S_stt := fun n m => (proj2 (Nat.le_succ_l n m)).
+Opaque lt_le_S_stt.
+#[global]
+Hint Immediate lt_le_S_stt: arith. (* Lt.lt_le_S *)
+#[local]
+Definition lt_n_Sm_le_stt := fun n m => (proj1 (Nat.lt_succ_r n m)).
+Opaque lt_n_Sm_le_stt.
+#[global]
+Hint Immediate lt_n_Sm_le_stt: arith. (* Lt.lt_n_Sm_le *)
+#[local]
+Definition le_lt_n_Sm_stt := fun n m => (proj2 (Nat.lt_succ_r n m)).
+Opaque le_lt_n_Sm_stt.
+#[global]
+Hint Immediate le_lt_n_Sm_stt: arith. (* Lt.le_lt_n_Sm *)
+#[local]
+Definition le_not_lt_stt := fun n m => (proj1 (Nat.le_ngt n m)).
+Opaque le_not_lt_stt.
+#[global]
+Hint Immediate le_not_lt_stt: arith. (* Lt.le_not_lt *)
+#[local]
+Definition lt_not_le_stt := fun n m => (proj1 (Nat.lt_nge n m)).
+Opaque lt_not_le_stt.
+#[global]
+Hint Immediate lt_not_le_stt: arith. (* Lt.lt_not_le *)
+#[global]
+Hint Resolve Nat.lt_0_succ Nat.nlt_0_r: arith. (* Lt.lt_0_Sn Lt.lt_n_0 *)
+#[local]
+Definition neq_0_lt_stt := fun n Hn => proj1 (Nat.neq_0_lt_0 n) (Nat.neq_sym 0 n Hn).
+Opaque neq_0_lt_stt.
+#[local]
+Definition lt_0_neq_stt := fun n Hlt => Nat.neq_sym n 0 (proj2 (Nat.neq_0_lt_0 n) Hlt).
+Opaque lt_0_neq_stt.
+#[global]
+Hint Immediate neq_0_lt_stt lt_0_neq_stt: arith. (* Lt.neq_0_lt Lt.lt_0_neq *)
+#[global]
+Hint Resolve Nat.lt_succ_diag_r Nat.lt_lt_succ_r: arith. (* Lt.lt_n_Sn Lt.lt_S *)
+#[local]
+Definition lt_n_S_stt := fun n m => (proj1 (Nat.succ_lt_mono n m)).
+Opaque lt_n_S_stt.
+#[global]
+Hint Resolve lt_n_S_stt: arith. (* Lt.lt_n_S *)
+#[local]
+Definition lt_S_n_stt := fun n m => (proj2 (Nat.succ_lt_mono n m)).
+Opaque lt_S_n_stt.
+#[global]
+Hint Immediate lt_S_n_stt: arith. (* Lt.lt_S_n *)
+#[local]
+Definition lt_pred_stt := fun n m => proj1 (Nat.lt_succ_lt_pred n m).
+Opaque lt_pred_stt.
+#[global]
+Hint Immediate lt_pred_stt: arith. (* Lt.lt_pred *)
+#[local]
+Definition lt_pred_n_n_stt := fun n Hlt => Nat.lt_pred_l n (proj2 (Nat.neq_0_lt_0 n) Hlt).
+Opaque lt_pred_n_n_stt.
+#[global]
+Hint Resolve lt_pred_n_n_stt: arith. (* Lt.lt_pred_n_n *)
+#[global]
+Hint Resolve Nat.lt_trans Nat.lt_le_trans Nat.le_lt_trans: arith. (* Lt.lt_trans Lt.lt_le_trans Lt.le_lt_trans *)
+#[global]
+Hint Immediate Nat.lt_le_incl: arith. (* Lt.lt_le_weak *)
+#[local]
+Definition gt_Sn_O_stt : forall n, S n > 0 := Nat.lt_0_succ.
+Opaque gt_Sn_O_stt.
+#[global]
+Hint Resolve gt_Sn_O_stt: arith. (* Gt.gt_Sn_O *)
+#[local]
+Definition gt_Sn_n_stt : forall n, S n > n := Nat.lt_succ_diag_r.
+Opaque gt_Sn_n_stt.
+#[global]
+Hint Resolve gt_Sn_n_stt: arith. (* Gt.gt_Sn_n *)
+#[local]
+Definition gt_n_S_stt : forall n m, n > m -> S n > S m := fun n m Hgt => proj1 (Nat.succ_lt_mono m n) Hgt.
+Opaque gt_n_S_stt.
+#[global]
+Hint Resolve gt_n_S_stt: arith. (* Gt.gt_n_S *)
+#[local]
+Definition gt_S_n_stt : forall n m, S m > S n -> m > n := fun n m Hgt => proj2 (Nat.succ_lt_mono n m) Hgt.
+Opaque gt_S_n_stt.
+#[global]
+Hint Immediate gt_S_n_stt: arith. (* Gt.gt_S_n *)
+#[local]
+Definition gt_pred_stt : forall n m, m > S n -> pred m > n := fun n m Hgt => proj1 (Nat.lt_succ_lt_pred n m) Hgt.
+Opaque gt_pred_stt.
+#[global]
+Hint Immediate gt_pred_stt: arith. (* Gt.gt_pred *)
+#[local]
+Definition gt_irrefl_stt : forall n, ~ n > n := Nat.lt_irrefl.
+Opaque gt_irrefl_stt.
+#[global]
+Hint Resolve gt_irrefl_stt: arith. (* Gt.gt_irrefl *)
+#[local]
+Definition gt_asym_stt : forall n m, n > m -> ~ m > n := fun n m => Nat.lt_asymm m n.
+Opaque gt_asym_stt.
+#[global]
+Hint Resolve gt_asym_stt: arith. (* Gt.gt_asym *)
+#[local]
+Definition le_not_gt_stt : forall n m, n <= m -> ~ n > m := fun n m => proj1 (Nat.le_ngt n m).
+Opaque le_not_gt_stt.
+#[global]
+Hint Resolve le_not_gt_stt: arith. (* Gt.le_not_gt *)
+#[local]
+Definition gt_not_le_stt: forall n m, n > m -> ~ n <= m := fun n m => proj1 (Nat.lt_nge m n).
+Opaque gt_not_le_stt.
+#[global]
+Hint Resolve gt_not_le_stt: arith. (* Gt.gt_not_le *)
+#[local]
+Definition le_S_gt_stt: forall n m, S n <= m -> m > n := fun n m => proj1 (Nat.le_succ_l n m).
+Opaque le_S_gt_stt.
+#[global]
+Hint Immediate le_S_gt_stt:arith. (* Gt.le_S_gt *)
+#[local]
+Definition gt_S_le_stt : forall n m, S m > n -> n <= m := fun n m => proj2 (Nat.succ_le_mono n m).
+Opaque gt_S_le_stt.
+#[global]
+Hint Immediate gt_S_le_stt:arith. (* Gt.gt_S_le *)
+#[local]
+Definition gt_le_S_stt : forall n m, m > n -> S n <= m := fun n m => proj2 (Nat.le_succ_l n m).
+Opaque gt_le_S_stt.
+#[global]
+Hint Resolve gt_le_S_stt:arith. (* Gt.gt_le_S *)
+#[local]
+Definition le_gt_S_stt : forall n m, n <= m -> S m > n := fun n m => proj1 (Nat.succ_le_mono n m).
+Opaque le_gt_S_stt.
+#[global]
+Hint Resolve le_gt_S_stt:arith. (* Gt.le_gt_S *)
+#[local]
+Definition gt_trans_S_stt : forall n m p, S n > m -> m > p -> n > p
+                          := fun n m p Hgt1 Hgt2 => Nat.lt_le_trans p m n Hgt2 (proj2 (Nat.succ_le_mono _ _) Hgt1).
+Opaque gt_trans_S_stt.
+#[global]
+Hint Resolve gt_trans_S_stt:arith. (* Gt.gt_trans_S *)
+#[local]
+Definition le_gt_trans_stt : forall n m p, m <= n -> m > p -> n > p
+                           := fun n m p Hle Hgt => Nat.lt_le_trans p m n Hgt Hle.
+Opaque le_gt_trans_stt.
+#[global]
+Hint Resolve le_gt_trans_stt:arith. (* Gt.le_gt_trans *)
+#[local]
+Definition gt_le_trans_stt : forall n m p, n > m -> p <= m -> n > p
+                           := fun n m p Hgt Hle => Nat.le_lt_trans p m n Hle Hgt.
+Opaque gt_le_trans_stt.
+#[global]
+Hint Resolve gt_le_trans_stt:arith. (* Gt.gt_le_trans *)
+#[local]
+Definition plus_gt_compat_l_stt : forall n m p, n > m -> p + n > p + m
+                                := fun n m p Hgt => proj1 (Nat.add_lt_mono_l m n p) Hgt.
+Opaque plus_gt_compat_l_stt.
+#[global]
+Hint Resolve plus_gt_compat_l_stt:arith. (* Gt.plus_gt_compat_l *)
+
+(* ** [add] *)
+#[global]
+Hint Immediate Nat.add_comm : arith. (* Plus.plus_comm *)
+#[global]
+Hint Resolve Nat.add_assoc : arith. (* Plus.plus_assoc *)
+#[local]
+Definition plus_assoc_reverse_stt := fun n m p => eq_sym (Nat.add_assoc n m p).
+Opaque plus_assoc_reverse_stt.
+#[global]
+Hint Resolve plus_assoc_reverse_stt : arith. (* Plus.plus_assoc_reverse *)
+#[global]
+Hint Resolve -> Nat.add_le_mono_l : arith. (* Plus.plus_le_compat_l *)
+#[global]
+Hint Resolve -> Nat.add_le_mono_r : arith. (* Plus.plus_le_compat_r *)
+#[local]
+Definition le_plus_r_stt := (fun n m => eq_ind _ _ (Nat.le_add_r m n) _ (Nat.add_comm m n)).
+Definition le_plus_trans_stt := (fun n m p Hle => Nat.le_trans n _ _ Hle (Nat.le_add_r m p)).
+Opaque le_plus_r_stt le_plus_trans_stt.
+#[global]
+Hint Resolve Nat.le_add_r le_plus_r_stt le_plus_trans_stt : arith. (* Plus.le_plus_l Plus.le_plus_r_stt Plus.le_plus_trans_stt *)
+#[local]
+Definition lt_plus_trans_stt := (fun n m p Hlt => Nat.lt_le_trans n _ _ Hlt (Nat.le_add_r m p)).
+Opaque lt_plus_trans_stt.
+#[global]
+Hint Immediate lt_plus_trans_stt : arith. (* Plus.lt_plus_trans_stt *)
+#[global]
+Hint Resolve -> Nat.add_lt_mono_l : arith. (* Plus_lt_compat_l *)
+#[global]
+Hint Resolve -> Nat.add_lt_mono_r : arith. (* Plus_lt_compat_r *)
+
+
+(* ** [sub] *)
+#[local]
+Definition minus_n_O_stt := fun n => eq_sym (Nat.sub_0_r n).
+Opaque minus_n_O_stt.
+#[global]
+Hint Resolve minus_n_O_stt: arith. (* Minus.minus_n_O *)
+#[local]
+Definition minus_Sn_m_stt := fun n m Hle => eq_sym (Nat.sub_succ_l m n Hle).
+Opaque minus_Sn_m_stt.
+#[global]
+Hint Resolve minus_Sn_m_stt: arith. (* Minus.minus_Sn_m *)
+#[local]
+Definition minus_diag_reverse_stt := fun n => eq_sym (Nat.sub_diag n).
+Opaque minus_diag_reverse_stt.
+#[global]
+Hint Resolve minus_diag_reverse_stt: arith. (* Minus.minus_diag_reverse *)
+#[local]
+Definition minus_plus_simpl_l_reverse_stt n m p : n - m = p + n - (p + m).
+Proof.
+ now rewrite Nat.sub_add_distr, Nat.add_comm, Nat.add_sub.
+Qed.
+#[global]
+Hint Resolve minus_plus_simpl_l_reverse_stt: arith. (* Minus.minus_plus_simpl_l_reverse *)
+#[local]
+Definition plus_minus_stt := fun n m p Heq => eq_sym (Nat.add_sub_eq_l n m p (eq_sym Heq)).
+Opaque plus_minus_stt.
+#[global]
+Hint Immediate plus_minus_stt: arith. (* Minus.plus_minus *)
+#[local]
+Definition minus_plus_stt := (fun n m => eq_ind _ (fun x => x - n = m) (Nat.add_sub m n) _ (Nat.add_comm _ _)).
+Opaque minus_plus_stt.
+#[global]
+Hint Resolve minus_plus_stt: arith. (* Minus.minus_plus *)
+#[local]
+Definition le_plus_minus_stt := fun n m Hle => eq_sym (eq_trans (Nat.add_comm _ _) (Nat.sub_add n m Hle)).
+Opaque le_plus_minus_stt.
+#[global]
+Hint Resolve le_plus_minus_stt: arith. (* Minus.le_plus_minus *)
+#[local]
+Definition le_plus_minus_r_stt := fun n m Hle => eq_trans (Nat.add_comm _ _) (Nat.sub_add n m Hle).
+Opaque le_plus_minus_r_stt.
+#[global]
+Hint Resolve le_plus_minus_r_stt: arith. (* Minus.le_plus_minus_r *)
+#[global]
+Hint Resolve Nat.sub_lt: arith. (* Minus.lt_minus *)
+#[local]
+Definition lt_O_minus_lt_stt : forall n m, 0 < n - m -> m < n
+                            := fun n m => proj2 (Nat.lt_add_lt_sub_r 0 n m).
+Opaque lt_O_minus_lt_stt.
+#[global]
+Hint Immediate lt_O_minus_lt_stt: arith. (* Minus.lt_O_minus_lt *)
+
+(* ** [mul] *)
+#[global]
+Hint Resolve Nat.mul_1_l Nat.mul_1_r: arith. (* Mult.mult_1_l Mult.mult_1_r *)
+#[global]
+Hint Resolve Nat.mul_comm: arith. (* Mult.mult_comm *)
+#[global]
+Hint Resolve Nat.mul_add_distr_r: arith. (* Mult.mult_plus_distr_r *)
+#[global]
+Hint Resolve Nat.mul_sub_distr_r: arith. (* Mult.mult_minus_distr_r *)
+#[global]
+Hint Resolve Nat.mul_sub_distr_l: arith. (* Mult.mult_minus_distr_l *)
+#[local]
+Definition mult_assoc_reverse_stt := fun n m p => eq_sym (Nat.mul_assoc n m p).
+Opaque mult_assoc_reverse_stt.
+#[global]
+Hint Resolve mult_assoc_reverse_stt Nat.mul_assoc: arith. (* Mult.mult_assoc_reverse Mult.mult_assoc *)
+#[local]
+Definition mult_O_le_stt n m : m = 0 \/ n <= m * n.
+Proof.
+ destruct m; [left|right]; simpl; trivial using Nat.le_add_r.
+Qed.
+#[global]
+Hint Resolve mult_O_le_stt: arith. (* Mult.mult_O_le *)
+#[global]
+Hint Resolve Nat.mul_le_mono_l: arith. (* Mult.mult_le_compat_l *)
+#[local]
+Definition mult_S_lt_compat_l_stt := (fun n m p Hlt => proj1 (Nat.mul_lt_mono_pos_l (S n) m p (Nat.lt_0_succ n)) Hlt).
+Opaque mult_S_lt_compat_l_stt.
+#[global]
+Hint Resolve mult_S_lt_compat_l_stt: arith. (* Mult.mult_S_lt_compat_l *)
+
+(* ** [min] and [max] *)
+#[global]
+Hint Resolve Nat.max_l Nat.max_r Nat.le_max_l Nat.le_max_r: arith.
+#[global]
+Hint Resolve Nat.min_l Nat.min_r Nat.le_min_l Nat.le_min_r: arith.
+
+
+(* Register *)
+#[local]
+Definition lt_n_Sm_le := (fun n m => (proj1 (Nat.lt_succ_r n m))).
+Register lt_n_Sm_le as num.nat.lt_n_Sm_le.
+#[local]
+Definition le_lt_n_Sm := (fun n m => (proj2 (Nat.lt_succ_r n m))).
+Register le_lt_n_Sm as num.nat.le_lt_n_Sm.
+#[local]
+Definition lt_S_n := (fun n m => (proj2 (Nat.succ_lt_mono n m))).
+Register lt_S_n as num.nat.lt_S_n.
+Register Nat.le_lt_trans as num.nat.le_lt_trans.
+#[local]
+Definition pred_of_minus := (fun n => eq_sym (Nat.sub_1_r n)).
+Register pred_of_minus as num.nat.pred_of_minus.

--- a/theories/Arith/Between.v
+++ b/theories/Arith/Between.v
@@ -8,8 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-Require Import Le.
-Require Import Lt.
+Require Import PeanoNat.
 
 Local Open Scope nat_scope.
 
@@ -25,34 +24,40 @@ Section Between.
     | bet_S : forall l, between k l -> P l -> between k (S l).
 
   #[local]
-  Hint Constructors between: arith.
+  Hint Constructors between: core.
 
   Lemma bet_eq : forall k l, l = k -> between k l.
   Proof.
-    intros * ->; auto with arith.
+    intros * ->; constructor.
   Qed.
 
   #[local]
-  Hint Resolve bet_eq: arith.
+  Hint Resolve bet_eq: core.
 
   Lemma between_le : forall k l, between k l -> k <= l.
   Proof.
-    induction 1; auto with arith.
+    induction 1; auto.
   Qed.
   #[local]
-  Hint Immediate between_le: arith.
+  Hint Immediate between_le: core.
 
   Lemma between_Sk_l : forall k l, between k l -> S k <= l -> between (S k) l.
   Proof.
-    induction 1 as [|* [|]]; auto with arith.
+    induction 1 as [|* [|]]; auto.
+    - intros Hle; exfalso; apply (Nat.nle_succ_diag_l _ Hle).
+    - intros Hle; inversion Hle; constructor; auto.
   Qed.
   #[local]
-  Hint Resolve between_Sk_l: arith.
+  Hint Resolve between_Sk_l: core.
 
   Lemma between_restr :
     forall k l (m:nat), k <= l -> l <= m -> between k m -> between l m.
   Proof.
-    induction 1; auto with arith.
+    induction 1; auto.
+    intros; auto.
+    apply between_Sk_l; auto.
+    apply IHle; auto.
+    transitivity (S m0); auto.
   Qed.
 
   (** The [exists_between] type expresses the concept
@@ -62,24 +67,25 @@ Section Between.
     | exists_le : forall l, k <= l -> Q l -> exists_between k (S l).
 
   #[local]
-  Hint Constructors exists_between: arith.
+  Hint Constructors exists_between: core.
 
   Lemma exists_le_S : forall k l, exists_between k l -> S k <= l.
   Proof.
-    induction 1; auto with arith.
+    induction 1; auto.
+    apply -> Nat.succ_le_mono; assumption.
   Qed.
 
   Lemma exists_lt : forall k l, exists_between k l -> k < l.
   Proof exists_le_S.
   #[local]
-  Hint Immediate exists_le_S exists_lt: arith.
+  Hint Immediate exists_le_S exists_lt: core.
 
   Lemma exists_S_le : forall k l, exists_between k (S l) -> k <= l.
   Proof.
-    intros; apply le_S_n; auto with arith.
+    intros; apply le_S_n; auto.
   Qed.
   #[local]
-  Hint Immediate exists_S_le: arith.
+  Hint Immediate exists_S_le: core.
 
   Definition in_int p q r := p <= r /\ r < q.
 
@@ -88,62 +94,65 @@ Section Between.
     split; assumption.
   Qed.
   #[local]
-  Hint Resolve in_int_intro: arith.
+  Hint Resolve in_int_intro: core.
 
   Lemma in_int_lt : forall p q r, in_int p q r -> p < q.
   Proof.
     intros * [].
-    eapply le_lt_trans; eassumption.
+    eapply Nat.le_lt_trans; eassumption.
   Qed.
 
   Lemma in_int_p_Sq :
     forall p q r, in_int p (S q) r -> in_int p q r \/ r = q.
   Proof.
     intros p q r [].
-    destruct (le_lt_or_eq r q); auto with arith.
+    destruct (proj1 (Nat.lt_eq_cases r q)); auto.
+    apply Nat.lt_succ_r; assumption.
   Qed.
 
   Lemma in_int_S : forall p q r, in_int p q r -> in_int p (S q) r.
   Proof.
-    intros * []; auto with arith.
+    intros * []; auto.
   Qed.
   #[local]
-  Hint Resolve in_int_S: arith.
+  Hint Resolve in_int_S: core.
 
   Lemma in_int_Sp_q : forall p q r, in_int (S p) q r -> in_int p q r.
   Proof.
-    intros * []; auto with arith.
+    intros * []; auto.
+    apply in_int_intro; auto.
+    transitivity (S p); auto.
   Qed.
   #[local]
-  Hint Immediate in_int_Sp_q: arith.
+  Hint Immediate in_int_Sp_q: core.
 
   Lemma between_in_int :
     forall k l, between k l -> forall r, in_int k l r -> P r.
   Proof.
     intro k; induction 1 as [|l]; intros r ?.
-    - absurd (k < k). { auto with arith. }
+    - absurd (k < k). { apply Nat.lt_irrefl. }
       eapply in_int_lt; eassumption.
-    - destruct (in_int_p_Sq k l r) as [| ->]; auto with arith.
+    - destruct (in_int_p_Sq k l r) as [| ->]; auto.
   Qed.
 
   Lemma in_int_between :
     forall k l, k <= l -> (forall r, in_int k l r -> P r) -> between k l.
   Proof.
-    induction 1; auto with arith.
+    induction 1; auto.
   Qed.
 
   Lemma exists_in_int :
     forall k l, exists_between k l -> exists2 m : nat, in_int k l m & Q m.
   Proof.
     induction 1 as [* ? (p, ?, ?)|l].
-    - exists p; auto with arith.
-    - exists l; auto with arith.
+    - exists p; auto.
+    - exists l; auto.
   Qed.
 
   Lemma in_int_exists : forall k l r, in_int k l r -> Q r -> exists_between k l.
   Proof.
     intros * (?, lt_r_l) ?.
-    induction lt_r_l; auto with arith.
+    induction lt_r_l; auto.
   Qed.
 
   Lemma between_or_exists :
@@ -153,10 +162,10 @@ Section Between.
       between k l \/ exists_between k l.
   Proof.
     induction 1 as [|m ? IHle].
-    - auto with arith.
+    - auto.
     - intros P_or_Q.
-      destruct IHle; auto with arith.
-      destruct (P_or_Q m); auto with arith.
+      destruct IHle; auto.
+      destruct (P_or_Q m); auto.
   Qed.
 
   Lemma between_not_exists :
@@ -165,14 +174,15 @@ Section Between.
       (forall n:nat, in_int k l n -> P n -> ~ Q n) -> ~ exists_between k l.
   Proof.
     intro k; induction 1 as [|l]; red; intros.
-    - absurd (k < k); auto with arith.
-    - absurd (Q l). { auto with arith. }
+    - absurd (k < k). { apply Nat.lt_irrefl. } auto.
+    - absurd (Q l). { auto. }
       destruct (exists_in_int k (S l)) as (l',[],?).
-      + auto with arith.
+      + auto.
       + replace l with l'. { trivial. }
-        destruct (le_lt_or_eq l' l); auto with arith.
-        absurd (exists_between k l). { auto with arith. }
-        eapply in_int_exists; eauto with arith.
+        destruct (proj1 (Nat.lt_eq_cases l' l)); auto.
+        * apply Nat.lt_succ_r; assumption.
+        * absurd (exists_between k l). { auto. }
+          apply in_int_exists with l'; auto.
   Qed.
 
   Inductive P_nth (init:nat) : nat -> nat -> Prop :=
@@ -183,9 +193,11 @@ Section Between.
 
   Lemma nth_le : forall (init:nat) l (n:nat), P_nth init l n -> init <= l.
   Proof.
-    induction 1.
-    - auto with arith.
-    - eapply le_trans; eauto with arith.
+    induction 1 as [|a b c H0 H1 H2 H3].
+    - auto.
+    - eapply Nat.le_trans; eauto.
+      apply between_le in H2.
+      transitivity (S a); auto.
   Qed.
 
   Definition eventually (n:nat) :=  exists2 k : nat, k <= n & Q k.
@@ -193,13 +205,11 @@ Section Between.
   Lemma event_O : eventually 0 -> Q 0.
   Proof.
     intros (x, ?, ?).
-    replace 0 with x; auto with arith.
+    replace 0 with x; auto.
+    apply Nat.le_0_r; assumption.
   Qed.
 
 End Between.
 
-#[global]
-Hint Resolve nth_O bet_S bet_emp bet_eq between_Sk_l exists_S exists_le
-  in_int_S in_int_intro: arith.
-#[global]
-Hint Immediate in_int_Sp_q exists_le_S exists_S_le: arith.
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Import Le Lt.

--- a/theories/Arith/Compare.v
+++ b/theories/Arith/Compare.v
@@ -33,21 +33,26 @@ Lemma le_decide : forall n m, n <= m -> lt_or_eq n m.
 Proof le_lt_eq_dec.
 
 Lemma le_le_S_eq : forall n m, n <= m -> S n <= m \/ n = m.
-Proof le_lt_or_eq.
+Proof (fun n m Hle => proj1 (Nat.lt_eq_cases n m) Hle).
 
 (* By special request of G. Kahn - Used in Group Theory *)
 Lemma discrete_nat :
   forall n m, n < m -> S n = m \/ (exists r : nat, m = S (S (n + r))).
 Proof.
   intros m n H.
-  lapply (lt_le_S m n); auto with arith.
-  intro H'; lapply (le_lt_or_eq (S m) n); auto with arith.
-  induction 1; auto with arith.
+  lapply (proj1 (Nat.le_succ_l m n)); auto.
+  intro H'; lapply (proj1 (Nat.lt_eq_cases (S m) n)); auto.
+  induction 1; auto.
   right; exists (n - S (S m)); simpl.
-  rewrite (plus_comm m (n - S (S m))).
+  rewrite (Nat.add_comm m (n - S (S m))).
   rewrite (plus_n_Sm (n - S (S m)) m).
   rewrite (plus_n_Sm (n - S (S m)) (S m)).
-  rewrite (plus_comm (n - S (S m)) (S (S m))); auto with arith.
+  rewrite (Nat.add_comm (n - S (S m)) (S (S m))).
+  rewrite Nat.add_sub_assoc; [ | assumption ].
+  rewrite Nat.add_comm.
+  rewrite <- Nat.add_sub_assoc; [ | reflexivity ].
+  rewrite Nat.sub_diag.
+  symmetry; apply Nat.add_0_r.
 Qed.
 
 Require Export Wf_nat.

--- a/theories/Arith/Div2.v
+++ b/theories/Arith/Div2.v
@@ -20,12 +20,14 @@ Implicit Type n : nat.
 
 (** Here we define [n/2] and prove some of its properties *)
 
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete. Use Nat.div2 instead.")]
 Notation div2 := Nat.div2 (only parsing).
 
 (** Since [div2] is recursively defined on [0], [1] and [(S (S n))], it is
     useful to prove the corresponding induction principle *)
 
-Lemma ind_0_1_SS :
+#[local]
+Definition ind_0_1_SS_stt :
   forall P:nat -> Prop,
     P 0 -> P 1 -> (forall n, P n -> P (S (S n))) -> forall n, P n.
 Proof.
@@ -36,78 +38,101 @@ Proof.
   - exact H1.
   - apply H2, ind_0_1_SS.
 Qed.
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete.")]
+Notation ind_0_1_SS := ind_0_1_SS_stt.
 
 (** [0 <n  =>  n/2 < n] *)
 
-Lemma lt_div2 n : 0 < n -> div2 n < n.
-Proof. apply Nat.lt_div2. Qed.
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete. Use Nat.lt_div2 instead.")]
+Notation lt_div2 := Nat.lt_div2 (only parsing).
 
 #[global]
-Hint Resolve lt_div2: arith.
+Hint Resolve Nat.lt_div2: arith.
 
 (** Properties related to the parity *)
 
-Lemma even_div2 n : even n -> div2 n = div2 (S n).
+#[local]
+Definition even_div2_stt n : even n -> Nat.div2 n = Nat.div2 (S n).
 Proof.
- rewrite Even.even_equiv. intros (p,->).
+ rewrite Even.even_equiv_stt. intros (p,->).
  rewrite Nat.div2_succ_double. apply Nat.div2_double.
 Qed.
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete.")]
+Notation even_div2 := even_div2_stt.
 
-Lemma odd_div2 n : odd n -> S (div2 n) = div2 (S n).
+#[local]
+Definition odd_div2_stt n : odd n -> S (Nat.div2 n) = Nat.div2 (S n).
 Proof.
- rewrite Even.odd_equiv. intros (p,->).
+ rewrite Even.odd_equiv_stt. intros (p,->).
  rewrite Nat.add_1_r, Nat.div2_succ_double.
  simpl. f_equal. symmetry. apply Nat.div2_double.
 Qed.
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete.")]
+Notation odd_div2 := odd_div2_stt.
 
-Lemma div2_even n : div2 n = div2 (S n) -> even n.
+#[local]
+Definition div2_even_stt n : Nat.div2 n = Nat.div2 (S n) -> even n.
 Proof.
- destruct (even_or_odd n) as [Ev|Od]; trivial.
- apply odd_div2 in Od. rewrite <- Od. intro Od'.
+ destruct (Even.even_or_odd_stt n) as [Ev|Od]; trivial.
+ apply odd_div2_stt in Od. rewrite <- Od. intro Od'.
  elim (n_Sn _ Od').
 Qed.
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete.")]
+Notation div2_even := div2_even_stt.
 
-Lemma div2_odd n : S (div2 n) = div2 (S n) -> odd n.
+#[local]
+Definition div2_odd_stt n : S (Nat.div2 n) = Nat.div2 (S n) -> odd n.
 Proof.
- destruct (even_or_odd n) as [Ev|Od]; trivial.
- apply even_div2 in Ev. rewrite <- Ev. intro Ev'.
+ destruct (Even.even_or_odd_stt n) as [Ev|Od]; trivial.
+ apply even_div2_stt in Ev. rewrite <- Ev. intro Ev'.
  symmetry in Ev'. elim (n_Sn _ Ev').
 Qed.
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete.")]
+Notation div2_odd := div2_odd_stt.
 
 #[global]
-Hint Resolve even_div2 div2_even odd_div2 div2_odd: arith.
+Hint Resolve even_div2_stt div2_even_stt odd_div2_stt div2_odd_stt: arith.
 
-Lemma even_odd_div2 n :
- (even n <-> div2 n = div2 (S n)) /\
- (odd n <-> S (div2 n) = div2 (S n)).
+#[local]
+Definition even_odd_div2_stt n :
+ (even n <-> Nat.div2 n = Nat.div2 (S n)) /\
+ (odd n <-> S (Nat.div2 n) = Nat.div2 (S n)).
 Proof.
- split; split; auto using div2_odd, div2_even, odd_div2, even_div2.
+ split; split; auto using div2_odd_stt, div2_even_stt, odd_div2_stt, even_div2_stt.
 Qed.
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete.")]
+Notation even_odd_div2 := even_odd_div2_stt.
 
 
 
 (** Properties related to the double ([2n]) *)
 
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete. Use Nat.double instead.")]
 Notation double := Nat.double (only parsing).
 
 #[global]
-Hint Unfold double Nat.double: arith.
+Hint Unfold Nat.double: arith.
 
-Lemma double_S n : double (S n) = S (S (double n)).
-Proof.
-  apply Nat.add_succ_r.
-Qed.
+#[local]
+Definition double_S_stt : forall n, Nat.double (S n) = S (S (Nat.double n))
+                        := fun n => Nat.add_succ_r (S n) n.
+Opaque double_S_stt.
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete. Use Nat.add_succ_r instead.")]
+Notation double_S := double_S_stt.
 
-Lemma double_plus n m : double (n + m) = double n + double m.
-Proof.
-  apply Nat.add_shuffle1.
-Qed.
+#[local]
+Definition double_plus_stt : forall n m, Nat.double (n + m) = Nat.double n + Nat.double m
+                           := fun n m => Nat.add_shuffle1 n m n m.
+Opaque double_plus_stt.
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete. Use Nat.add_shuffle1 instead.")]
+Notation double_plus := double_plus_stt.
 
 #[global]
-Hint Resolve double_S: arith.
+Hint Resolve double_S_stt: arith.
 
-Lemma even_odd_double n :
-  (even n <-> n = double (div2 n)) /\ (odd n <-> n = S (double (div2 n))).
+#[local]
+Definition even_odd_double_stt n :
+  (even n <-> n = Nat.double (Nat.div2 n)) /\ (odd n <-> n = S (Nat.double (Nat.div2 n))).
 Proof.
   revert n. fix even_odd_double 1. intros n; destruct n as [|[|n]].
   - (* n = 0 *)
@@ -116,29 +141,43 @@ Proof.
     split; split; auto with arith. inversion_clear 1 as [|? H0]. inversion H0.
   - (* n = (S (S n')) *)
     destruct (even_odd_double n) as ((Ev,Ev'),(Od,Od')).
-    split; split; simpl div2; rewrite ?double_S.
+    split; split; simpl Nat.div2; rewrite ?double_S_stt.
     + inversion_clear 1 as [|? H0]. inversion_clear H0. auto.
     + injection 1. auto with arith.
     + inversion_clear 1 as [? H0]. inversion_clear H0. auto.
     + injection 1. auto with arith.
 Qed.
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete.")]
+Notation even_odd_double := even_odd_double_stt.
 
 (** Specializations *)
 
-Lemma even_double n : even n -> n = double (div2 n).
-Proof proj1 (proj1 (even_odd_double n)).
+#[local]
+Definition even_double_stt n : even n -> n = Nat.double (Nat.div2 n).
+Proof proj1 (proj1 (even_odd_double_stt n)).
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete.")]
+Notation even_double := even_double_stt.
 
-Lemma double_even n : n = double (div2 n) -> even n.
-Proof proj2 (proj1 (even_odd_double n)).
+#[local]
+Definition double_even_stt n : n = Nat.double (Nat.div2 n) -> even n.
+Proof proj2 (proj1 (even_odd_double_stt n)).
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete.")]
+Notation double_even := double_even_stt.
 
-Lemma odd_double n : odd n -> n = S (double (div2 n)).
-Proof proj1 (proj2 (even_odd_double n)).
+#[local]
+Definition odd_double_stt n : odd n -> n = S (Nat.double (Nat.div2 n)).
+Proof proj1 (proj2 (even_odd_double_stt n)).
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete.")]
+Notation odd_double := odd_double_stt.
 
-Lemma double_odd n : n = S (double (div2 n)) -> odd n.
-Proof proj2 (proj2 (even_odd_double n)).
+#[local]
+Definition double_odd_stt n : n = S (Nat.double (Nat.div2 n)) -> odd n.
+Proof proj2 (proj2 (even_odd_double_stt n)).
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete.")]
+Notation double_odd := double_odd_stt.
 
 #[global]
-Hint Resolve even_double double_even odd_double double_odd: arith.
+Hint Resolve even_double_stt double_even_stt odd_double_stt double_odd_stt: arith.
 
 (** Application:
     - if [n] is even then there is a [p] such that [n = 2p]
@@ -146,20 +185,32 @@ Hint Resolve even_double double_even odd_double double_odd: arith.
 
     (Immediate: it is [n/2]) *)
 
-Lemma even_2n : forall n, even n -> {p : nat | n = double p}.
+#[local]
+Definition even_2n_stt : forall n, even n -> {p : nat | n = Nat.double p}.
 Proof.
-  intros n H. exists (div2 n). auto with arith.
+  intros n H. exists (Nat.div2 n). auto with arith.
 Defined.
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete.")]
+Notation even_2n := even_2n_stt.
 
-Lemma odd_S2n : forall n, odd n -> {p : nat | n = S (double p)}.
+#[local]
+Definition odd_S2n_stt : forall n, odd n -> {p : nat | n = S (Nat.double p)}.
 Proof.
-  intros n H. exists (div2 n). auto with arith.
+  intros n H. exists (Nat.div2 n). auto with arith.
 Defined.
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete.")]
+Notation odd_S2n := odd_S2n_stt.
 
 (** Doubling before dividing by two brings back to the initial number. *)
 
-Lemma div2_double n : div2 (2*n) = n.
+#[local]
+Definition div2_double_stt n : Nat.div2 (2*n) = n.
 Proof. apply Nat.div2_double. Qed.
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete. Use Nat.div2_double instead.")]
+Notation div2_double := div2_double_stt.
 
-Lemma div2_double_plus_one n : div2 (S (2*n)) = n.
+#[local]
+Definition div2_double_plus_one_stt n : Nat.div2 (S (2*n)) = n.
 Proof. apply Nat.div2_succ_double. Qed.
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete. Use Nat.div2_succ_double instead.")]
+Notation div2_double_plus_one := div2_double_plus_one_stt.

--- a/theories/Arith/EqNat.v
+++ b/theories/Arith/EqNat.v
@@ -27,8 +27,6 @@ Theorem eq_nat_refl n : eq_nat n n.
 Proof.
   induction n; simpl; auto.
 Qed.
-#[global]
-Hint Resolve eq_nat_refl: arith.
 
 (** [eq] restricted to [nat] and [eq_nat] are equivalent *)
 
@@ -49,13 +47,10 @@ Proof.
  apply eq_nat_is_eq.
 Qed.
 
-#[global]
-Hint Immediate eq_eq_nat eq_nat_eq: arith.
-
 Theorem eq_nat_elim :
   forall n (P:nat -> Prop), P n -> forall m, eq_nat n m -> P m.
 Proof.
-  intros n P ? m ?; replace m with n; auto with arith.
+  intros n P ? m ?; replace m with n; [ | apply eq_nat_eq ]; assumption.
 Qed.
 
 Theorem eq_nat_decide : forall n m, {eq_nat n m} + {~ eq_nat n m}.
@@ -73,34 +68,35 @@ Defined.
    We reuse the one already defined in module [Nat].
    In scope [nat_scope], the notation "=?" can be used. *)
 
+#[deprecated(since="8.16",note="Use Nat.eqb instead.")]
 Notation beq_nat := Nat.eqb (only parsing).
 
+#[deprecated(since="8.16",note="Use Nat.eqb_eq instead.")]
 Notation beq_nat_true_iff := Nat.eqb_eq (only parsing).
+#[deprecated(since="8.16",note="Use Nat.eqb_neq instead.")]
 Notation beq_nat_false_iff := Nat.eqb_neq (only parsing).
 
-Lemma beq_nat_refl n : true = (n =? n).
-Proof.
- symmetry. apply Nat.eqb_refl.
-Qed.
+#[local]
+Definition beq_nat_refl_stt := fun n => eq_sym (Nat.eqb_refl n).
+Opaque beq_nat_refl_stt.
+#[deprecated(since="8.16",note="Use Nat.eqb_refl instead.")]
+Notation beq_nat_refl := beq_nat_refl_stt.
 
-Lemma beq_nat_true n m : (n =? m) = true -> n=m.
-Proof.
- apply Nat.eqb_eq.
-Qed.
+#[local]
+Definition beq_nat_true_stt := fun n m => proj1 (Nat.eqb_eq n m).
+Opaque beq_nat_true_stt.
+#[deprecated(since="8.16",note="Use Nat.eqb_eq instead.")]
+Notation beq_nat_true := beq_nat_true_stt.
 
-Lemma beq_nat_false n m : (n =? m) = false -> n<>m.
-Proof.
- apply Nat.eqb_neq.
-Qed.
+#[local]
+Definition beq_nat_false_stt := fun n m => proj1 (Nat.eqb_neq n m).
+Opaque beq_nat_false_stt.
+#[deprecated(since="8.16",note="Use Nat.eqb_neq instead.")]
+Notation beq_nat_false := beq_nat_false_stt.
 
-(** TODO: is it really useful here to have a Defined ?
-    Otherwise we could use Nat.eqb_eq *)
-
-Definition beq_nat_eq : forall n m, true = (n =? m) -> n = m.
-Proof.
-  intro n; induction n as [|n IHn]; intro m; destruct m; simpl.
-  - reflexivity.
-  - discriminate.
-  - discriminate.
-  - intros H. case (IHn _ H). reflexivity.
-Defined.
+(* previously was given as transparent *)
+#[local]
+Definition beq_nat_eq_stt := fun n m Heq => proj1 (Nat.eqb_eq n m) (eq_sym Heq).
+Opaque beq_nat_eq_stt.
+#[deprecated(since="8.16",note="Use Nat.eqb_eq instead.")]
+Notation beq_nat_eq := beq_nat_eq_stt.

--- a/theories/Arith/Euclid.v
+++ b/theories/Arith/Euclid.v
@@ -8,7 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-Require Import Mult.
+Require Import PeanoNat.
 Require Import Compare_dec.
 Require Import Wf_nat.
 
@@ -23,9 +23,9 @@ Lemma eucl_dev : forall n, n > 0 -> forall m:nat, diveucl m n.
 Proof.
   intros n H m; induction m as (m,H0) using gt_wf_rec.
   destruct (le_gt_dec n m) as [Hlebn|Hgtbn].
-  destruct (H0 (m - n)) as (q,r,Hge0,Heq); auto with arith.
+  destruct (H0 (m - n)) as (q,r,Hge0,Heq); [ apply Nat.sub_lt; auto | ].
   apply divex with (S q) r; trivial.
-  simpl; rewrite <- plus_assoc, <- Heq; auto with arith.
+  simpl; rewrite <- Nat.add_assoc, <- Heq, Nat.add_comm, Nat.sub_add; trivial.
   apply divex with 0 m; simpl; trivial.
 Defined.
 
@@ -36,10 +36,10 @@ Lemma quotient :
 Proof.
   intros n H m; induction m as (m,H0) using gt_wf_rec.
   destruct (le_gt_dec n m) as [Hlebn|Hgtbn].
-  destruct (H0 (m - n)) as (q & Hq); auto with arith; exists (S q).
-  destruct Hq as (r & Heq & Hgt); exists r; split; trivial.
-  simpl; rewrite <- plus_assoc, <- Heq; auto with arith.
-  exists 0; exists m; simpl; auto with arith.
+  destruct (H0 (m - n)) as (q & Hq); [ apply Nat.sub_lt; auto | ].
+  exists (S q); destruct Hq as (r & Heq & Hgt); exists r; split; trivial.
+  simpl; rewrite <- Nat.add_assoc, <- Heq, Nat.add_comm, Nat.sub_add; trivial.
+  exists 0; exists m; simpl; auto.
 Defined.
 
 Lemma modulo :
@@ -49,8 +49,11 @@ Lemma modulo :
 Proof.
   intros n H m; induction m as (m,H0) using gt_wf_rec.
   destruct (le_gt_dec n m) as [Hlebn|Hgtbn].
-  destruct (H0 (m - n)) as (r & Hr); auto with arith; exists r.
-  destruct Hr as (q & Heq & Hgt); exists (S q); split; trivial.
-  simpl; rewrite <- plus_assoc, <- Heq; auto with arith.
-  exists m; exists 0; simpl; auto with arith.
+  destruct (H0 (m - n)) as (r & Hr); [ apply Nat.sub_lt; auto | ].
+  exists r; destruct Hr as (q & Heq & Hgt); exists (S q); split; trivial.
+  simpl; rewrite <- Nat.add_assoc, <- Heq, Nat.add_comm, Nat.sub_add; trivial.
+  exists m; exists 0; simpl; auto.
 Defined.
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Import Mult.

--- a/theories/Arith/Even.v
+++ b/theories/Arith/Even.v
@@ -38,7 +38,8 @@ Hint Constructors odd: arith.
 
 (** * Equivalence with predicates [Nat.Even] and [Nat.odd] *)
 
-Lemma even_equiv : forall n, even n <-> Nat.Even n.
+#[local]
+Definition even_equiv_stt : forall n, even n <-> Nat.Even n.
 Proof.
  fix even_equiv 1.
  intros n; destruct n as [|[|n]]; simpl.
@@ -51,8 +52,11 @@ Proof.
    + inversion_clear 1 as [|? H0]. now inversion_clear H0.
    + now do 2 constructor.
 Qed.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+Notation even_equiv := even_equiv_stt.
 
-Lemma odd_equiv : forall n, odd n <-> Nat.Odd n.
+#[local]
+Definition odd_equiv_stt : forall n, odd n <-> Nat.Odd n.
 Proof.
  fix odd_equiv 1.
  intros n; destruct n as [|[|n]]; simpl.
@@ -65,122 +69,217 @@ Proof.
    + inversion_clear 1 as [? H0]. now inversion_clear H0.
    + now do 2 constructor.
 Qed.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+Notation odd_equiv := odd_equiv_stt.
 
 (** Basic facts *)
 
-Lemma even_or_odd n : even n \/ odd n.
+#[local]
+Definition even_or_odd_stt n : even n \/ odd n.
 Proof.
   induction n as [|n IHn].
   - auto with arith.
   - elim IHn; auto with arith.
 Qed.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Even_or_Odd instead.")]
+Notation even_or_odd := even_or_odd_stt.
 
-Lemma even_odd_dec n : {even n} + {odd n}.
+#[local]
+Definition even_odd_dec_stt n : {even n} + {odd n}.
 Proof.
   induction n as [|n IHn].
   - auto with arith.
   - elim IHn; auto with arith.
 Defined.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+Notation even_odd_dec := even_odd_dec_stt.
 
-Lemma not_even_and_odd n : even n -> odd n -> False.
+#[local]
+Definition not_even_and_odd_stt n : even n -> odd n -> False.
 Proof.
   induction n.
   - intros Ev Od. inversion Od.
   - intros Ev Od. inversion Ev. inversion Od. auto with arith.
 Qed.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Even_Odd_False instead.")]
+Notation not_even_and_odd := not_even_and_odd_stt (only parsing).
 
 
 (** * Facts about [even] & [odd] wrt. [plus] *)
 
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
 Ltac parity2bool :=
- rewrite ?even_equiv, ?odd_equiv, <- ?Nat.even_spec, <- ?Nat.odd_spec.
+ rewrite ?even_equiv_stt, ?odd_equiv_stt, <- ?Nat.even_spec, <- ?Nat.odd_spec.
 
+#[local]
+Ltac parity2bool_dep :=
+ rewrite ?even_equiv_stt, ?odd_equiv_stt, <- ?Nat.even_spec, <- ?Nat.odd_spec.
+
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
 Ltac parity_binop_spec :=
  rewrite ?Nat.even_add, ?Nat.odd_add, ?Nat.even_mul, ?Nat.odd_mul.
 
+#[local]
+Ltac parity_binop_spec_dep :=
+ rewrite ?Nat.even_add, ?Nat.odd_add, ?Nat.even_mul, ?Nat.odd_mul.
+
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
 Ltac parity_binop :=
- parity2bool; parity_binop_spec; unfold Nat.odd;
+ parity2bool_dep; parity_binop_spec_dep; unfold Nat.odd;
  do 2 destruct Nat.even; simpl; tauto.
 
+#[local]
+Ltac parity_binop_dep :=
+ parity2bool_dep; parity_binop_spec_dep; unfold Nat.odd;
+ do 2 destruct Nat.even; simpl; tauto.
 
-Lemma even_plus_split n m :
+#[local]
+Definition even_plus_split_stt n m :
   even (n + m) -> even n /\ even m \/ odd n /\ odd m.
-Proof. parity_binop. Qed.
+Proof. parity_binop_dep. Qed.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+Notation even_plus_split := even_plus_split_stt.
 
-Lemma odd_plus_split n m :
+#[local]
+Definition odd_plus_split_stt n m :
   odd (n + m) -> odd n /\ even m \/ even n /\ odd m.
-Proof. parity_binop. Qed.
+Proof. parity_binop_dep. Qed.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+Notation odd_plus_split := odd_plus_split_stt.
 
-Lemma even_even_plus n m : even n -> even m -> even (n + m).
-Proof. parity_binop. Qed.
+#[local]
+Definition even_even_plus_stt n m: even n -> even m -> even (n + m).
+Proof. parity_binop_dep. Qed.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+Notation even_even_plus := even_even_plus_stt.
 
-Lemma odd_plus_l n m : odd n -> even m -> odd (n + m).
-Proof. parity_binop. Qed.
+#[local]
+Definition odd_plus_l_stt n m : odd n -> even m -> odd (n + m).
+Proof. parity_binop_dep. Qed.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+Notation odd_plus_l := odd_plus_l_stt.
 
-Lemma odd_plus_r n m : even n -> odd m -> odd (n + m).
-Proof. parity_binop. Qed.
+#[local]
+Definition odd_plus_r_stt n m : even n -> odd m -> odd (n + m).
+Proof. parity_binop_dep. Qed.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+Notation odd_plus_r := odd_plus_r_stt.
 
-Lemma odd_even_plus n m : odd n -> odd m -> even (n + m).
-Proof. parity_binop. Qed.
+#[local]
+Definition odd_even_plus_stt n m : odd n -> odd m -> even (n + m).
+Proof. parity_binop_dep. Qed.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+Notation odd_even_plus := odd_even_plus_stt.
 
-Lemma even_plus_aux n m :
+#[local]
+Definition even_plus_aux_stt n m :
     (odd (n + m) <-> odd n /\ even m \/ even n /\ odd m) /\
     (even (n + m) <-> even n /\ even m \/ odd n /\ odd m).
-Proof. parity_binop. Qed.
+Proof. parity_binop_dep. Qed.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+Notation even_plus_aux := even_plus_aux_stt.
 
-Lemma even_plus_even_inv_r n m : even (n + m) -> even n -> even m.
-Proof. parity_binop. Qed.
+#[local]
+Definition even_plus_even_inv_r_stt n m : even (n + m) -> even n -> even m.
+Proof. parity_binop_dep. Qed.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+Notation even_plus_even_inv_r := even_plus_even_inv_r_stt.
 
-Lemma even_plus_even_inv_l n m : even (n + m) -> even m -> even n.
-Proof. parity_binop. Qed.
+#[local]
+Definition even_plus_even_inv_l_stt n m : even (n + m) -> even m -> even n.
+Proof. parity_binop_dep. Qed.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+Notation even_plus_even_inv_l := even_plus_even_inv_l_stt.
 
-Lemma even_plus_odd_inv_r n m : even (n + m) -> odd n -> odd m.
-Proof. parity_binop. Qed.
+#[local]
+Definition even_plus_odd_inv_r_stt n m : even (n + m) -> odd n -> odd m.
+Proof. parity_binop_dep. Qed.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+Notation even_plus_odd_inv_r := even_plus_odd_inv_r_stt.
 
-Lemma even_plus_odd_inv_l n m : even (n + m) -> odd m -> odd n.
-Proof. parity_binop. Qed.
+#[local]
+Definition even_plus_odd_inv_l_stt n m : even (n + m) -> odd m -> odd n.
+Proof. parity_binop_dep. Qed.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+Notation even_plus_odd_inv_l := even_plus_odd_inv_l_stt.
 
-Lemma odd_plus_even_inv_l n m : odd (n + m) -> odd m -> even n.
-Proof. parity_binop. Qed.
+#[local]
+Definition odd_plus_even_inv_l_stt n m : odd (n + m) -> odd m -> even n.
+Proof. parity_binop_dep. Qed.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+Notation odd_plus_even_inv_l := odd_plus_even_inv_l_stt.
 
-Lemma odd_plus_even_inv_r n m : odd (n + m) -> odd n -> even m.
-Proof. parity_binop. Qed.
+#[local]
+Definition odd_plus_even_inv_r_stt n m : odd (n + m) -> odd n -> even m.
+Proof. parity_binop_dep. Qed.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+Notation odd_plus_even_inv_r := odd_plus_even_inv_r_stt.
 
-Lemma odd_plus_odd_inv_l n m : odd (n + m) -> even m -> odd n.
-Proof. parity_binop. Qed.
+#[local]
+Definition odd_plus_odd_inv_l_stt n m : odd (n + m) -> even m -> odd n.
+Proof. parity_binop_dep. Qed.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+Notation odd_plus_odd_inv_l := odd_plus_odd_inv_l_stt.
 
-Lemma odd_plus_odd_inv_r n m : odd (n + m) -> even n -> odd m.
-Proof. parity_binop. Qed.
+#[local]
+Definition odd_plus_odd_inv_r_stt n m : odd (n + m) -> even n -> odd m.
+Proof. parity_binop_dep. Qed.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+Notation odd_plus_odd_inv_r := odd_plus_odd_inv_r_stt.
 
 
 (** * Facts about [even] and [odd] wrt. [mult] *)
 
-Lemma even_mult_aux n m :
+#[local]
+Definition even_mult_aux_stt n m :
   (odd (n * m) <-> odd n /\ odd m) /\ (even (n * m) <-> even n \/ even m).
-Proof. parity_binop. Qed.
+Proof. parity_binop_dep. Qed.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+Notation even_mult_aux := even_mult_aux_stt.
 
-Lemma even_mult_l n m : even n -> even (n * m).
-Proof. parity_binop. Qed.
+#[local]
+Definition even_mult_l_stt n m : even n -> even (n * m).
+Proof. parity_binop_dep. Qed.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+Notation even_mult_l := even_mult_l_stt.
 
-Lemma even_mult_r n m : even m -> even (n * m).
-Proof. parity_binop. Qed.
+#[local]
+Definition even_mult_r_stt n m : even m -> even (n * m).
+Proof. parity_binop_dep. Qed.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+Notation even_mult_r := even_mult_r_stt.
 
-Lemma even_mult_inv_r n m : even (n * m) -> odd n -> even m.
-Proof. parity_binop. Qed.
+#[local]
+Definition even_mult_inv_r_stt n m : even (n * m) -> odd n -> even m.
+Proof. parity_binop_dep. Qed.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+Notation even_mult_inv_r := even_mult_inv_r_stt.
 
-Lemma even_mult_inv_l n m : even (n * m) -> odd m -> even n.
-Proof. parity_binop. Qed.
+#[local]
+Definition even_mult_inv_l_stt n m : even (n * m) -> odd m -> even n.
+Proof. parity_binop_dep. Qed.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+Notation even_mult_inv_l := even_mult_inv_l_stt.
 
-Lemma odd_mult n m : odd n -> odd m -> odd (n * m).
-Proof. parity_binop. Qed.
+#[local]
+Definition odd_mult_stt n m : odd n -> odd m -> odd (n * m).
+Proof. parity_binop_dep. Qed.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+Notation odd_mult := odd_mult_stt.
 
-Lemma odd_mult_inv_l n m : odd (n * m) -> odd n.
-Proof. parity_binop. Qed.
+#[local]
+Definition odd_mult_inv_l_stt n m : odd (n * m) -> odd n.
+Proof. parity_binop_dep. Qed.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+Notation odd_mult_inv_l := odd_mult_inv_l_stt.
 
-Lemma odd_mult_inv_r n m : odd (n * m) -> odd m.
-Proof. parity_binop. Qed.
+#[local]
+Definition odd_mult_inv_r_stt n m : odd (n * m) -> odd m.
+Proof. parity_binop_dep. Qed.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+Notation odd_mult_inv_r := odd_mult_inv_r_stt.
 
 #[global]
 Hint Resolve
- even_even_plus odd_even_plus odd_plus_l odd_plus_r
- even_mult_l even_mult_r even_mult_l even_mult_r odd_mult : arith.
+ even_even_plus_stt odd_even_plus_stt odd_plus_l_stt odd_plus_r_stt
+ even_mult_l_stt even_mult_r_stt even_mult_l_stt even_mult_r_stt odd_mult_stt : arith.

--- a/theories/Arith/Factorial.v
+++ b/theories/Arith/Factorial.v
@@ -8,7 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-Require Import PeanoNat Plus Mult Lt.
+Require Import PeanoNat.
 Local Open Scope nat_scope.
 
 (** Factorial *)
@@ -23,7 +23,8 @@ Arguments fact n%nat.
 
 Lemma lt_O_fact n : 0 < fact n.
 Proof.
-  induction n; simpl; auto with arith.
+  induction n; simpl; auto.
+  apply Nat.lt_lt_add_r; assumption.
 Qed.
 
 Lemma fact_neq_0 n : fact n <> 0.
@@ -37,3 +38,6 @@ Proof.
   - apply le_n.
   - simpl. transitivity (fact m). trivial. apply Nat.le_add_r.
 Qed.
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Import Plus Mult Lt.

--- a/theories/Arith/Gt.v
+++ b/theories/Arith/Gt.v
@@ -8,150 +8,94 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(** Theorems about [gt] in [nat].
+(** Theorems about [gt] in [nat]. *)
 
- This file is DEPRECATED now, see module [PeanoNat.Nat] instead,
- which favor [lt] over [gt].
+(** * This file is OBSOLETE, see [Arith_base] instead. *)
 
- [gt] is defined in [Init/Peano.v] as:
-<<
-Definition gt (n m:nat) := m < n.
->>
-*)
+Require Export Arith_prebase.
 
-Require Import PeanoNat Le Lt Plus.
+
 Local Open Scope nat_scope.
 
 (** * Order and successor *)
 
-Theorem gt_Sn_O n : S n > 0.
-Proof Nat.lt_0_succ _.
-
-Theorem gt_Sn_n n : S n > n.
-Proof Nat.lt_succ_diag_r _.
-
-Theorem gt_n_S n m : n > m -> S n > S m.
-Proof.
- apply Nat.succ_lt_mono.
-Qed.
-
-Lemma gt_S_n n m : S m > S n -> m > n.
-Proof.
- apply Nat.succ_lt_mono.
-Qed.
-
-Theorem gt_S n m : S n > m -> n > m \/ m = n.
-Proof.
- intro. now apply Nat.lt_eq_cases, Nat.succ_le_mono.
-Qed.
-
-Lemma gt_pred n m : m > S n -> pred m > n.
-Proof.
- apply Nat.lt_succ_lt_pred.
-Qed.
+#[deprecated(since="8.16",note="The Arith.Gt file is obsolete. Use Nat.lt_0_succ instead.")]
+Notation gt_Sn_O := Arith_prebase.gt_Sn_O_stt.
+#[deprecated(since="8.16",note="The Arith.Gt file is obsolete. Use Nat.lt_succ_diag_r instead.")]
+Notation gt_Sn_n := Arith_prebase.gt_Sn_n_stt.
+#[deprecated(since="8.16",note="The Arith.Gt file is obsolete. Use Nat.succ_lt_mono instead.")]
+Notation gt_n_S := Arith_prebase.gt_n_S_stt.
+#[deprecated(since="8.16",note="The Arith.Gt file is obsolete. Use Nat.succ_lt_mono instead.")]
+Notation gt_S_n := Arith_prebase.gt_S_n_stt.
+#[local]
+Definition gt_S_stt : forall n m, S n > m -> n > m \/ m = n := fun n m Hgt => proj1 (Nat.lt_eq_cases m n) (proj2 (Nat.succ_le_mono m n) Hgt).
+Opaque gt_S_stt.
+#[deprecated(since="8.16",note="The Arith.Gt file is obsolete. Use Nat.lt_eq_cases instead.")]
+Notation gt_S := gt_S_stt.
+#[deprecated(since="8.16",note="The Arith.Gt file is obsolete. Use Nat.lt_succ_lt_pred instead.")]
+Notation gt_pred := Arith_prebase.gt_pred_stt.
 
 (** * Irreflexivity *)
 
-Lemma gt_irrefl n : ~ n > n.
-Proof Nat.lt_irrefl _.
+#[deprecated(since="8.16",note="The Arith.Gt file is obsolete. Use Nat.lt_irrefl instead.")]
+Notation gt_irrefl := Arith_prebase.gt_irrefl_stt.
 
 (** * Asymmetry *)
 
-Lemma gt_asym n m : n > m -> ~ m > n.
-Proof Nat.lt_asymm _ _.
+#[deprecated(since="8.16",note="The Arith.Gt file is obsolete. Use Nat.lt_asymm instead.")]
+Notation gt_asym := Arith_prebase.gt_asym_stt.
 
 (** * Relating strict and large orders *)
 
-Lemma le_not_gt n m : n <= m -> ~ n > m.
-Proof.
- apply Nat.le_ngt.
-Qed.
-
-Lemma gt_not_le n m : n > m -> ~ n <= m.
-Proof.
- apply Nat.lt_nge.
-Qed.
-
-Theorem le_S_gt n m : S n <= m -> m > n.
-Proof.
- apply Nat.le_succ_l.
-Qed.
-
-Lemma gt_S_le n m : S m > n -> n <= m.
-Proof.
- apply Nat.succ_le_mono.
-Qed.
-
-Lemma gt_le_S n m : m > n -> S n <= m.
-Proof.
- apply Nat.le_succ_l.
-Qed.
-
-Lemma le_gt_S n m : n <= m -> S m > n.
-Proof.
- apply Nat.succ_le_mono.
-Qed.
+#[deprecated(since="8.16",note="The Arith.Gt file is obsolete. Use Nat.le_ngt instead.")]
+Notation le_not_gt := Arith_prebase.le_not_gt_stt.
+#[deprecated(since="8.16",note="The Arith.Gt file is obsolete. Use Nat.lt_nge instead.")]
+Notation gt_not_le := Arith_prebase.gt_not_le_stt.
+#[deprecated(since="8.16",note="The Arith.Gt file is obsolete. Use Nat.le_succ_l instead.")]
+Notation le_S_gt := Arith_prebase.le_S_gt_stt.
+#[deprecated(since="8.16",note="The Arith.Gt file is obsolete. Use Nat.succ_le_mono instead.")]
+Notation gt_S_le := Arith_prebase.gt_S_le_stt.
+#[deprecated(since="8.16",note="The Arith.Gt file is obsolete. Use Nat.le_succ_l instead.")]
+Notation gt_le_S := Arith_prebase.gt_le_S_stt.
+#[deprecated(since="8.16",note="The Arith.Gt file is obsolete. Use Nat.succ_le_mono instead.")]
+Notation le_gt_S := Arith_prebase.le_gt_S_stt.
 
 (** * Transitivity *)
 
-Theorem le_gt_trans n m p : m <= n -> m > p -> n > p.
-Proof.
- intros. now apply Nat.lt_le_trans with m.
-Qed.
-
-Theorem gt_le_trans n m p : n > m -> p <= m -> n > p.
-Proof.
- intros. now apply Nat.le_lt_trans with m.
-Qed.
-
-Lemma gt_trans n m p : n > m -> m > p -> n > p.
-Proof.
- intros. now apply Nat.lt_trans with m.
-Qed.
-
-Theorem gt_trans_S n m p : S n > m -> m > p -> n > p.
-Proof.
- intros. apply Nat.lt_le_trans with m; trivial. now apply Nat.succ_le_mono.
-Qed.
+#[deprecated(since="8.16",note="The Arith.Gt file is obsolete. Use Nat.lt_le_trans instead.")]
+Notation le_gt_trans := Arith_prebase.le_gt_trans_stt.
+#[deprecated(since="8.16",note="The Arith.Gt file is obsolete. Use Nat.lt_le_trans instead.")]
+Notation gt_le_trans := Arith_prebase.gt_le_trans_stt.
+#[local]
+Definition gt_trans_stt : forall n m p, n > m -> m > p -> n > p := fun n m p Hgt1 Hgt2 => Nat.lt_trans p m n Hgt2 Hgt1.
+Opaque gt_trans_stt.
+#[deprecated(since="8.16",note="The Arith.Gt file is obsolete. Use Nat.lt_trans instead.")]
+Notation gt_trans := gt_trans_stt.
+#[deprecated(since="8.16",note="The Arith.Gt file is obsolete. Use Nat.lt_trans instead.")]
+Notation gt_trans_S := Arith_prebase.gt_trans_S_stt.
 
 (** * Comparison to 0 *)
 
-Theorem gt_0_eq n : n > 0 \/ 0 = n.
+#[local]
+Definition gt_0_eq_stt n : n > 0 \/ 0 = n.
 Proof.
  destruct n; [now right | left; apply Nat.lt_0_succ].
 Qed.
+#[deprecated(since="8.16",note="The Arith.Gt file is obsolete.")]
+Notation gt_0_eq := gt_0_eq_stt.
+(* begin hide *)
+#[deprecated(since="8.16",note="The Arith.Gt file is obsolete.")]
+Notation gt_O_eq := gt_0_eq_stt (only parsing).
+(* end hide *)
 
 (** * Simplification and compatibility *)
 
-Lemma plus_gt_reg_l n m p : p + n > p + m -> n > m.
-Proof.
- apply Nat.add_lt_mono_l.
-Qed.
+#[local]
+Definition plus_gt_reg_l_stt : forall n m p, p + n > p + m -> n > m := fun n m p Hgt => proj2 (Nat.add_lt_mono_l m n p) Hgt.
+Opaque plus_gt_reg_l_stt.
+#[deprecated(since="8.16",note="The Arith.Gt file is obsolete. Use Nat.add_lt_mono_l instead.")]
+Notation plus_gt_reg_l := plus_gt_reg_l_stt.
+#[deprecated(since="8.16",note="The Arith.Gt file is obsolete. Use Nat.add_lt_mono_l instead.")]
+Notation plus_gt_compat_l := Arith_prebase.plus_gt_compat_l_stt.
 
-Lemma plus_gt_compat_l n m p : n > m -> p + n > p + m.
-Proof.
- apply Nat.add_lt_mono_l.
-Qed.
-
-(** * Hints *)
-
-#[global]
-Hint Resolve gt_Sn_O gt_Sn_n gt_n_S : arith.
-#[global]
-Hint Immediate gt_S_n gt_pred : arith.
-#[global]
-Hint Resolve gt_irrefl gt_asym : arith.
-#[global]
-Hint Resolve le_not_gt gt_not_le : arith.
-#[global]
-Hint Immediate le_S_gt gt_S_le : arith.
-#[global]
-Hint Resolve gt_le_S le_gt_S : arith.
-#[global]
-Hint Resolve gt_trans_S le_gt_trans gt_le_trans: arith.
-#[global]
-Hint Resolve plus_gt_compat_l: arith.
-
-(* begin hide *)
-Notation gt_O_eq := gt_0_eq (only parsing).
-(* end hide *)
+Require Import Le Lt Plus.

--- a/theories/Arith/Le.v
+++ b/theories/Arith/Le.v
@@ -8,79 +8,58 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(** Order on natural numbers.
+(** Order on natural numbers. *)
 
- This file is mostly OBSOLETE now, see module [PeanoNat.Nat] instead.
+(** * This file is OBSOLETE, see [Arith_base] instead. *)
 
- [le] is defined in [Init/Peano.v] as:
-<<
-Inductive le (n:nat) : nat -> Prop :=
-  | le_n : n <= n
-  | le_S : forall m:nat, n <= m -> n <= S m
+Require Export Arith_prebase.
 
-where "n <= m" := (le n m) : nat_scope.
->>
-*)
-
-Require Import PeanoNat.
-
-Local Open Scope nat_scope.
 
 (** * [le] is an order on [nat] *)
 
+#[deprecated(since="8.16",note="The Arith.Le file is obsolete. Use Nat.le_refl instead.")]
 Notation le_refl := Nat.le_refl (only parsing).
+#[deprecated(since="8.16",note="The Arith.Le file is obsolete. Use Nat.le_trans instead.")]
 Notation le_trans := Nat.le_trans (only parsing).
+#[deprecated(since="8.16",note="The Arith.Le file is obsolete. Use Nat.le_antisym instead.")]
 Notation le_antisym := Nat.le_antisymm (only parsing).
-
-#[global]
-Hint Resolve le_trans: arith.
-#[global]
-Hint Immediate le_antisym: arith.
 
 (** * Properties of [le] w.r.t 0 *)
 
+#[deprecated(since="8.16",note="The Arith.Le file is obsolete. Use Nat.le_0_l instead.")]
 Notation le_0_n := Nat.le_0_l (only parsing).  (* 0 <= n *)
+#[deprecated(since="8.16",note="The Arith.Le file is obsolete. Use Nat.nle_succ_0 instead.")]
 Notation le_Sn_0 := Nat.nle_succ_0 (only parsing).  (* ~ S n <= 0 *)
-
-Lemma le_n_0_eq n : n <= 0 -> 0 = n.
-Proof.
- intros. symmetry. now apply Nat.le_0_r.
-Qed.
+#[deprecated(since="8.16",note="The Arith.Le file is obsolete. Use Nat.le_0_r instead.")]
+Notation le_n_0_eq := Arith_prebase.le_n_0_eq_stt.
 
 (** * Properties of [le] w.r.t successor *)
 
-(** See also [Nat.succ_le_mono]. *)
-
-Theorem le_n_S : forall n m, n <= m -> S n <= S m.
-Proof Peano.le_n_S.
-
-Theorem le_S_n : forall n m, S n <= S m -> n <= m.
-Proof Peano.le_S_n.
-
+#[deprecated(since="8.16",note="The Arith.Le file is obsolete. Use Nat.succ_le_mono instead.")]
+Notation le_n_S := Peano.le_n_S (only parsing).
+#[deprecated(since="8.16",note="The Arith.Le file is obsolete. Use Nat.succ_le_mono instead.")]
+Notation le_S_n := Peano.le_S_n (only parsing).
+#[deprecated(since="8.16",note="The Arith.Le file is obsolete. Use Nat.le_succ_diag_r instead.")]
 Notation le_n_Sn := Nat.le_succ_diag_r (only parsing). (* n <= S n *)
+#[deprecated(since="8.16",note="The Arith.Le file is obsolete. Use Nat.nle_succ_diag_l instead.")]
 Notation le_Sn_n := Nat.nle_succ_diag_l (only parsing). (* ~ S n <= n *)
-
-Theorem le_Sn_le : forall n m, S n <= m -> n <= m.
-Proof Nat.lt_le_incl.
-
-#[global]
-Hint Resolve le_0_n le_Sn_0: arith.
-#[global]
-Hint Resolve le_n_S le_n_Sn le_Sn_n : arith.
-#[global]
-Hint Immediate le_n_0_eq le_Sn_le le_S_n : arith.
+#[local]
+Definition le_Sn_le_stt : forall n m, S n <= m -> n <= m := Nat.lt_le_incl.
+Opaque le_Sn_le_stt.
+#[deprecated(since="8.16",note="The Arith.Le file is obsolete. Use Nat.lt_le_incl instead.")]
+Notation le_Sn_le := le_Sn_le_stt.
 
 (** * Properties of [le] w.r.t predecessor *)
 
+#[deprecated(since="8.16",note="The Arith.Le file is obsolete. Use Nat.le_pred_l instead.")]
 Notation le_pred_n := Nat.le_pred_l (only parsing). (* pred n <= n *)
+#[deprecated(since="8.16",note="The Arith.Le file is obsolete. Use Nat.pred_le_mono instead.")]
 Notation le_pred := Nat.pred_le_mono (only parsing). (* n<=m -> pred n <= pred m *)
-
-#[global]
-Hint Resolve le_pred_n: arith.
 
 (** * A different elimination principle for the order on natural numbers *)
 
-Lemma le_elim_rel :
+#[local]
+Definition le_elim_rel_stt :
  forall P:nat -> nat -> Prop,
    (forall p, P 0 p) ->
    (forall p (q:nat), p <= q -> P p q -> P (S p) (S q)) ->
@@ -88,11 +67,16 @@ Lemma le_elim_rel :
 Proof.
   intros P H0 HS n.
   induction n; trivial.
-  intros m Le. elim Le; auto with arith.
- Qed.
+  intros m Le. elim Le; intuition.
+Qed.
+#[deprecated(since="8.16",note="The Arith.Le file is obsolete.")]
+Notation le_elim_rel := le_elim_rel_stt.
 
 (* begin hide *)
-Notation le_O_n := le_0_n (only parsing).
-Notation le_Sn_O := le_Sn_0 (only parsing).
-Notation le_n_O_eq := le_n_0_eq (only parsing).
+#[deprecated(since="8.16",note="The Arith.Le file is obsolete. Use Nat.le_0_l instead.")]
+Notation le_O_n := Nat.le_0_l (only parsing).
+#[deprecated(since="8.16",note="The Arith.Le file is obsolete. Use Nat.nle_succ_0 instead.")]
+Notation le_Sn_O := Nat.nle_succ_0 (only parsing).
+#[deprecated(since="8.16",note="The Arith.Le file is obsolete. Use Nat.le_0_r instead.")]
+Notation le_n_O_eq := Arith_prebase.le_n_0_eq_stt.
 (* end hide *)

--- a/theories/Arith/Lt.v
+++ b/theories/Arith/Lt.v
@@ -8,183 +8,115 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(** Strict order on natural numbers.
+(** Strict order on natural numbers. *)
 
- This file is mostly OBSOLETE now, see module [PeanoNat.Nat] instead.
+(** * This file is OBSOLETE, see [Arith_base] instead. *)
 
- [lt] is defined in library [Init/Peano.v] as:
-<<
-Definition lt (n m:nat) := S n <= m.
-Infix "<" := lt : nat_scope.
->>
-*)
+Require Export Arith_prebase.
 
-Require Import PeanoNat.
-
-Local Open Scope nat_scope.
 
 (** * Irreflexivity *)
 
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.lt_irrefl instead.")]
 Notation lt_irrefl := Nat.lt_irrefl (only parsing). (* ~ x < x *)
-
-#[global]
-Hint Resolve lt_irrefl: arith.
 
 (** * Relationship between [le] and [lt] *)
 
-Theorem lt_le_S n m : n < m -> S n <= m.
-Proof.
- apply Nat.le_succ_l.
-Qed.
-
-Theorem lt_n_Sm_le n m : n < S m -> n <= m.
-Proof.
- apply Nat.lt_succ_r.
-Qed.
-
-Register lt_n_Sm_le as num.nat.lt_n_Sm_le.
-
-Theorem le_lt_n_Sm n m : n <= m -> n < S m.
-Proof.
- apply Nat.lt_succ_r.
-Qed.
-
-Register le_lt_n_Sm as num.nat.le_lt_n_Sm.
-
-#[global]
-Hint Immediate lt_le_S: arith.
-#[global]
-Hint Immediate lt_n_Sm_le: arith.
-#[global]
-Hint Immediate le_lt_n_Sm: arith.
-
-Theorem le_not_lt n m : n <= m -> ~ m < n.
-Proof.
- apply Nat.le_ngt.
-Qed.
-
-Theorem lt_not_le n m : n < m -> ~ m <= n.
-Proof.
- apply Nat.lt_nge.
-Qed.
-
-#[global]
-Hint Immediate le_not_lt lt_not_le: arith.
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.le_succ_l instead.")]
+Notation lt_le_S := Arith_prebase.lt_le_S_stt.
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.lt_succ_r instead.")]
+Notation lt_n_Sm_le := Arith_prebase.lt_n_Sm_le_stt.
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.lt_succ_r instead.")]
+Notation le_lt_n_Sm := Arith_prebase.le_lt_n_Sm_stt (only parsing).
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.le_ngt instead.")]
+Notation le_not_lt := Arith_prebase.le_not_lt_stt.
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.lt_nge instead.")]
+Notation lt_not_le := Arith_prebase.lt_not_le_stt.
 
 (** * Asymmetry *)
 
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.lt_asymm instead.")]
 Notation lt_asym := Nat.lt_asymm (only parsing). (* n<m -> ~m<n *)
 
 (** * Order and 0 *)
 
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.lt_0_succ instead.")]
 Notation lt_0_Sn := Nat.lt_0_succ (only parsing). (* 0 < S n *)
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.nlt_0_r instead.")]
 Notation lt_n_0 := Nat.nlt_0_r (only parsing). (* ~ n < 0 *)
-
-Theorem neq_0_lt n : 0 <> n -> 0 < n.
-Proof.
- intros. now apply Nat.neq_0_lt_0, Nat.neq_sym.
-Qed.
-
-Theorem lt_0_neq n : 0 < n -> 0 <> n.
-Proof.
- intros. now apply Nat.neq_sym, Nat.neq_0_lt_0.
-Qed.
-
-#[global]
-Hint Resolve lt_0_Sn lt_n_0 : arith.
-#[global]
-Hint Immediate neq_0_lt lt_0_neq: arith.
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.neq_0_lt_0 instead.")]
+Notation neq_0_lt := Arith_prebase.neq_0_lt_stt.
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.neq_0_lt_0 instead.")]
+Notation lt_0_neq := Arith_prebase.lt_0_neq_stt.
 
 (** * Order and successor *)
 
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.lt_succ_diag_r instead.")]
 Notation lt_n_Sn := Nat.lt_succ_diag_r (only parsing). (* n < S n *)
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.lt_lt_succ_r instead.")]
 Notation lt_S := Nat.lt_lt_succ_r (only parsing). (* n < m -> n < S m *)
-
-Theorem lt_n_S n m : n < m -> S n < S m.
-Proof.
- apply Nat.succ_lt_mono.
-Qed.
-
-Theorem lt_S_n n m : S n < S m -> n < m.
-Proof.
- apply Nat.succ_lt_mono.
-Qed.
-
-Register lt_S_n as num.nat.lt_S_n.
-
-#[global]
-Hint Resolve lt_n_Sn lt_S lt_n_S : arith.
-#[global]
-Hint Immediate lt_S_n : arith.
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.succ_lt_mono instead.")]
+Notation lt_n_S := Arith_prebase.lt_n_S_stt.
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.succ_lt_mono instead.")]
+Notation lt_S_n := Arith_prebase.lt_S_n_stt.
 
 (** * Predecessor *)
 
-Lemma S_pred n m : m < n -> n = S (pred n).
-Proof.
- intros. symmetry. now apply Nat.lt_succ_pred with m.
-Qed.
-
-Lemma S_pred_pos n: O < n -> n = S (pred n).
-Proof.
- apply S_pred.
-Qed.
-
-Lemma lt_pred n m : S n < m -> n < pred m.
-Proof.
- apply Nat.lt_succ_lt_pred.
-Qed.
-
-Lemma lt_pred_n_n n : 0 < n -> pred n < n.
-Proof.
- intros. now apply Nat.lt_pred_l, Nat.neq_0_lt_0.
-Qed.
-
-#[global]
-Hint Immediate lt_pred: arith.
-#[global]
-Hint Resolve lt_pred_n_n: arith.
+#[local]
+Definition S_pred_stt := fun n m Hlt => eq_sym (Nat.lt_succ_pred m n Hlt).
+Opaque S_pred_stt.
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.lt_succ_pred instead.")]
+Notation S_pred := S_pred_stt.
+#[local]
+Definition S_pred_pos_stt := fun n Hlt => eq_sym (Nat.lt_succ_pred 0 n Hlt).
+Opaque S_pred_pos_stt.
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.lt_succ_pred instead.")]
+Notation S_pred_pos := S_pred_pos_stt (only parsing).
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.lt_succ_lt_pred instead.")]
+Notation lt_pred := Arith_prebase.lt_pred_stt.
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.lt_pred_l instead.")]
+Notation lt_pred_n_n := Arith_prebase.lt_pred_n_n_stt.
 
 (** * Transitivity properties *)
 
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.lt_trans instead.")]
 Notation lt_trans := Nat.lt_trans (only parsing).
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.lt_le_trans instead.")]
 Notation lt_le_trans := Nat.lt_le_trans (only parsing).
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.le_lt_trans instead.")]
 Notation le_lt_trans := Nat.le_lt_trans (only parsing).
-
-Register le_lt_trans as num.nat.le_lt_trans.
-
-#[global]
-Hint Resolve lt_trans lt_le_trans le_lt_trans: arith.
 
 (** * Large = strict or equal *)
 
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.lt_eq_cases instead.")]
 Notation le_lt_or_eq_iff := Nat.lt_eq_cases (only parsing).
-
-Theorem le_lt_or_eq n m : n <= m -> n < m \/ n = m.
-Proof.
- apply Nat.lt_eq_cases.
-Qed.
-
+#[local]
+Definition le_lt_or_eq_stt := fun n m => proj1 (Nat.lt_eq_cases n m).
+Opaque le_lt_or_eq_stt.
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.lt_eq_cases instead.")]
+Notation le_lt_or_eq := le_lt_or_eq_stt.
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.lt_le_incl instead.")]
 Notation lt_le_weak := Nat.lt_le_incl (only parsing).
-
-#[global]
-Hint Immediate lt_le_weak: arith.
 
 (** * Dichotomy *)
 
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.le_gt_cases instead.")]
 Notation le_or_lt := Nat.le_gt_cases (only parsing). (* n <= m \/ m < n *)
-
-Theorem nat_total_order n m : n <> m -> n < m \/ m < n.
-Proof.
- apply Nat.lt_gt_cases.
-Qed.
+#[local]
+Definition nat_total_order_stt := fun n m => proj1 (Nat.lt_gt_cases n m).
+Opaque nat_total_order_stt.
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.lt_gt_cases instead.")]
+Notation nat_total_order := nat_total_order_stt.
 
 (* begin hide *)
-Notation lt_O_Sn := lt_0_Sn (only parsing).
-Notation neq_O_lt := neq_0_lt (only parsing).
-Notation lt_O_neq := lt_0_neq (only parsing).
-Notation lt_n_O := lt_n_0 (only parsing).
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.lt_0_succ instead.")]
+Notation lt_O_Sn := Nat.lt_0_succ (only parsing).
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.neq_0_lt_0 instead.")]
+Notation neq_O_lt := Arith_prebase.neq_0_lt_stt.
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.neq_0_lt_0 instead.")]
+Notation lt_O_neq := Arith_prebase.lt_0_neq_stt.
+#[deprecated(since="8.16",note="The Arith.Lt file is obsolete. Use Nat.nlt_0_r instead.")]
+Notation lt_n_O := Nat.nlt_0_r (only parsing).
 (* end hide *)
-
-(** For compatibility, we "Require" the same files as before *)
 
 Require Import Le.

--- a/theories/Arith/Max.v
+++ b/theories/Arith/Max.v
@@ -8,45 +8,65 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(** THIS FILE IS DEPRECATED. Use [PeanoNat.Nat] instead. *)
+(** * THIS FILE IS DEPRECATED. Use [PeanoNat.Nat] or [Arith.Arith_base] instead. *)
 
 Require Import PeanoNat.
+
 
 Local Open Scope nat_scope.
 Implicit Types m n p : nat.
 
+#[deprecated(since="8.16",note="The Arith.Max file is obsolete. Use Nat.max instead.")]
 Notation max := Nat.max (only parsing).
 
-Definition max_0_l := Nat.max_0_l.
-Definition max_0_r := Nat.max_0_r.
-Definition succ_max_distr := Nat.succ_max_distr.
-Definition plus_max_distr_l := Nat.add_max_distr_l.
-Definition plus_max_distr_r := Nat.add_max_distr_r.
-Definition max_case_strong := Nat.max_case_strong.
-Definition max_spec := Nat.max_spec.
-Definition max_dec := Nat.max_dec.
-Definition max_case := Nat.max_case.
-Definition max_idempotent := Nat.max_id.
-Definition max_assoc := Nat.max_assoc.
-Definition max_comm := Nat.max_comm.
-Definition max_l := Nat.max_l.
-Definition max_r := Nat.max_r.
-Definition le_max_l := Nat.le_max_l.
-Definition le_max_r := Nat.le_max_r.
-Definition max_lub_l := Nat.max_lub_l.
-Definition max_lub_r := Nat.max_lub_r.
-Definition max_lub := Nat.max_lub.
+#[deprecated(since="8.16",note="The Arith.Max file is obsolete. Use Nat.max_0_l instead.")]
+Notation max_0_l := Nat.max_0_l (only parsing).
+#[deprecated(since="8.16",note="The Arith.Max file is obsolete. Use Nat.max_0_r instead.")]
+Notation max_0_r := Nat.max_0_r (only parsing).
+#[deprecated(since="8.16",note="The Arith.Max file is obsolete. Use Nat.succ_max_distr instead.")]
+Notation succ_max_distr := Nat.succ_max_distr (only parsing).
+#[deprecated(since="8.16",note="The Arith.Max file is obsolete. Use Nat.add_max_distr_l instead.")]
+Notation plus_max_distr_l := Nat.add_max_distr_l (only parsing).
+#[deprecated(since="8.16",note="The Arith.Max file is obsolete. Use Nat.add_max_distr_r instead.")]
+Notation plus_max_distr_r := Nat.add_max_distr_r (only parsing).
+#[deprecated(since="8.16",note="The Arith.Max file is obsolete. Use Nat.max_case_strong instead.")]
+Notation max_case_strong := Nat.max_case_strong (only parsing).
+#[deprecated(since="8.16",note="The Arith.Max file is obsolete. Use Nat.max_spec instead.")]
+Notation max_spec := Nat.max_spec (only parsing).
+#[deprecated(since="8.16",note="The Arith.Max file is obsolete. Use Nat.max_dec instead.")]
+Notation max_dec := Nat.max_dec (only parsing).
+#[deprecated(since="8.16",note="The Arith.Max file is obsolete. Use Nat.max_case instead.")]
+Notation max_case := Nat.max_case (only parsing).
+#[deprecated(since="8.16",note="The Arith.Max file is obsolete. Use Nat.max_id instead.")]
+Notation max_idempotent := Nat.max_id (only parsing).
+#[deprecated(since="8.16",note="The Arith.Max file is obsolete. Use Nat.max_assoc instead.")]
+Notation max_assoc := Nat.max_assoc (only parsing).
+#[deprecated(since="8.16",note="The Arith.Max file is obsolete. Use Nat.max_comm instead.")]
+Notation max_comm := Nat.max_comm (only parsing).
+#[deprecated(since="8.16",note="The Arith.Max file is obsolete. Use Nat.max_l instead.")]
+Notation max_l := Nat.max_l (only parsing).
+#[deprecated(since="8.16",note="The Arith.Max file is obsolete. Use Nat.max_r instead.")]
+Notation max_r := Nat.max_r (only parsing).
+#[deprecated(since="8.16",note="The Arith.Max file is obsolete. Use Nat.le_max_l instead.")]
+Notation le_max_l := Nat.le_max_l (only parsing).
+#[deprecated(since="8.16",note="The Arith.Max file is obsolete. Use Nat.le_max_r instead.")]
+Notation le_max_r := Nat.le_max_r (only parsing).
+#[deprecated(since="8.16",note="The Arith.Max file is obsolete. Use Nat.max_lub_l instead.")]
+Notation max_lub_l := Nat.max_lub_l (only parsing).
+#[deprecated(since="8.16",note="The Arith.Max file is obsolete. Use Nat.max_lub_r instead.")]
+Notation max_lub_r := Nat.max_lub_r (only parsing).
+#[deprecated(since="8.16",note="The Arith.Max file is obsolete. Use Nat.max_lub instead.")]
+Notation max_lub := Nat.max_lub (only parsing).
 
 (* begin hide *)
 (* Compatibility *)
-Notation max_case2 := max_case (only parsing).
+#[deprecated(since="8.16",note="The Arith.Max file is obsolete. Use Nat.max_case instead.")]
+Notation max_case2 := Nat.max_case (only parsing).
+#[deprecated(since="8.16",note="The Arith.Max file is obsolete. Use Nat.succ_max_distr instead.")]
 Notation max_SS := Nat.succ_max_distr (only parsing).
 (* end hide *)
 
 #[global]
-Hint Resolve
- Nat.max_l Nat.max_r Nat.le_max_l Nat.le_max_r : arith.
-
+Hint Resolve Nat.max_l Nat.max_r Nat.le_max_l Nat.le_max_r: arith.
 #[global]
-Hint Resolve
- Nat.min_l Nat.min_r Nat.le_min_l Nat.le_min_r : arith.
+Hint Resolve Nat.min_l Nat.min_r Nat.le_min_l Nat.le_min_r: arith.

--- a/theories/Arith/Min.v
+++ b/theories/Arith/Min.v
@@ -8,37 +8,60 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(** THIS FILE IS DEPRECATED. Use [PeanoNat.Nat] instead. *)
+(** * THIS FILE IS DEPRECATED. Use [PeanoNat.Nat] or [Arith.Arith_base] instead. *)
 
 Require Import PeanoNat.
+
 
 Local Open Scope nat_scope.
 Implicit Types m n p : nat.
 
+#[deprecated(since="8.16",note="The Arith.Min file is obsolete. Use Nat.min instead.")]
 Notation min := Nat.min (only parsing).
 
-Definition min_0_l := Nat.min_0_l.
-Definition min_0_r := Nat.min_0_r.
-Definition succ_min_distr := Nat.succ_min_distr.
-Definition plus_min_distr_l := Nat.add_min_distr_l.
-Definition plus_min_distr_r := Nat.add_min_distr_r.
-Definition min_case_strong := Nat.min_case_strong.
-Definition min_spec := Nat.min_spec.
-Definition min_dec := Nat.min_dec.
-Definition min_case := Nat.min_case.
-Definition min_idempotent := Nat.min_id.
-Definition min_assoc := Nat.min_assoc.
-Definition min_comm := Nat.min_comm.
-Definition min_l := Nat.min_l.
-Definition min_r := Nat.min_r.
-Definition le_min_l := Nat.le_min_l.
-Definition le_min_r := Nat.le_min_r.
-Definition min_glb_l := Nat.min_glb_l.
-Definition min_glb_r := Nat.min_glb_r.
-Definition min_glb := Nat.min_glb.
+#[deprecated(since="8.16",note="The Arith.Min file is obsolete. Use Nat.min_0_l instead.")]
+Notation min_0_l := Nat.min_0_l (only parsing).
+#[deprecated(since="8.16",note="The Arith.Min file is obsolete. Use Nat.min_0_r instead.")]
+Notation min_0_r := Nat.min_0_r (only parsing).
+#[deprecated(since="8.16",note="The Arith.Min file is obsolete. Use Nat.succ_min_distr instead.")]
+Notation succ_min_distr := Nat.succ_min_distr (only parsing).
+#[deprecated(since="8.16",note="The Arith.Min file is obsolete. Use Nat.add_min_distr_l instead.")]
+Notation plus_min_distr_l := Nat.add_min_distr_l (only parsing).
+#[deprecated(since="8.16",note="The Arith.Min file is obsolete. Use Nat.add_min_distr_r instead.")]
+Notation plus_min_distr_r := Nat.add_min_distr_r (only parsing).
+#[deprecated(since="8.16",note="The Arith.Min file is obsolete. Use Nat.min_case_strong instead.")]
+Notation min_case_strong := Nat.min_case_strong (only parsing).
+#[deprecated(since="8.16",note="The Arith.Min file is obsolete. Use Nat.min_spec instead.")]
+Notation min_spec := Nat.min_spec (only parsing).
+#[deprecated(since="8.16",note="The Arith.Min file is obsolete. Use Nat.min_dec instead.")]
+Notation min_dec := Nat.min_dec (only parsing).
+#[deprecated(since="8.16",note="The Arith.Min file is obsolete. Use Nat.min_case instead.")]
+Notation min_case := Nat.min_case (only parsing).
+#[deprecated(since="8.16",note="The Arith.Min file is obsolete. Use Nat.min_id instead.")]
+Notation min_idempotent := Nat.min_id (only parsing).
+#[deprecated(since="8.16",note="The Arith.Min file is obsolete. Use Nat.min_assoc instead.")]
+Notation min_assoc := Nat.min_assoc (only parsing).
+#[deprecated(since="8.16",note="The Arith.Min file is obsolete. Use Nat.min_comm instead.")]
+Notation min_comm := Nat.min_comm (only parsing).
+#[deprecated(since="8.16",note="The Arith.Min file is obsolete. Use Nat.min_l instead.")]
+Notation min_l := Nat.min_l (only parsing).
+#[deprecated(since="8.16",note="The Arith.Min file is obsolete. Use Nat.min_r instead.")]
+Notation min_r := Nat.min_r (only parsing).
+#[deprecated(since="8.16",note="The Arith.Min file is obsolete. Use Nat.le_min_l instead.")]
+Notation le_min_l := Nat.le_min_l (only parsing).
+#[deprecated(since="8.16",note="The Arith.Min file is obsolete. Use Nat.le_min_r instead.")]
+Notation le_min_r := Nat.le_min_r (only parsing).
+#[deprecated(since="8.16",note="The Arith.Min file is obsolete. Use Nat.min_glb_l instead.")]
+Notation min_glb_l := Nat.min_glb_l (only parsing).
+#[deprecated(since="8.16",note="The Arith.Min file is obsolete. Use Nat.min_glb_r instead.")]
+Notation min_glb_r := Nat.min_glb_r (only parsing).
+#[deprecated(since="8.16",note="The Arith.Min file is obsolete. Use Nat.min_glb instead.")]
+Notation min_glb := Nat.min_glb (only parsing).
 
 (* begin hide *)
 (* Compatibility *)
-Notation min_case2 := min_case (only parsing).
+#[deprecated(since="8.16",note="The Arith.Min file is obsolete. Use Nat.min_case instead.")]
+Notation min_case2 := Nat.min_case (only parsing).
+#[deprecated(since="8.16",note="The Arith.Min file is obsolete. Use Nat.succ_min_distr instead.")]
 Notation min_SS := Nat.succ_min_distr (only parsing).
 (* end hide *)

--- a/theories/Arith/Minus.v
+++ b/theories/Arith/Minus.v
@@ -8,126 +8,74 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(** Properties of subtraction between natural numbers.
+(** Properties of subtraction between natural numbers. *)
 
- This file is mostly OBSOLETE now, see module [PeanoNat.Nat] instead.
+(** * This file is OBSOLETE, see [Arith_base] instead. *)
 
- [minus] is now an alias for [Nat.sub], which is defined in [Init/Nat.v] as:
-<<
-Fixpoint sub (n m:nat) : nat :=
-  match n, m with
-  | S k, S l => k - l
-  | _, _ => n
-  end
-where "n - m" := (sub n m) : nat_scope.
->>
-*)
+Require Export Arith_prebase.
 
-Require Import PeanoNat Lt Le.
 
 Local Open Scope nat_scope.
 
 (** * 0 is right neutral *)
 
-Lemma minus_n_O n : n = n - 0.
-Proof.
- symmetry. apply Nat.sub_0_r.
-Qed.
+#[deprecated(since="8.16",note="The Arith.Minus file is obsolete. Use Nat.sub_0_r instead.")]
+Notation minus_n_O := Arith_prebase.minus_n_O_stt.
 
 (** * Permutation with successor *)
 
-Lemma minus_Sn_m n m : m <= n -> S (n - m) = S n - m.
-Proof.
- intros. symmetry. now apply Nat.sub_succ_l.
-Qed.
-
-Theorem pred_of_minus n : pred n = n - 1.
-Proof.
- symmetry. apply Nat.sub_1_r.
-Qed.
-
-Register pred_of_minus as num.nat.pred_of_minus.
+#[deprecated(since="8.16",note="The Arith.Minus file is obsolete. Use Nat.sub_succ_l instead.")]
+Notation minus_Sn_m := Arith_prebase.minus_Sn_m_stt.
+#[local]
+Definition pred_of_minus_stt := fun n => eq_sym (Nat.sub_1_r n).
+Opaque pred_of_minus_stt.
+#[deprecated(since="8.16",note="The Arith.Minus file is obsolete. Use Nat.sub_1_r instead.")]
+Notation pred_of_minus:= pred_of_minus_stt.
 
 (** * Diagonal *)
 
+#[deprecated(since="8.16",note="The Arith.Minus file is obsolete. Use Nat.sub_diag instead.")]
 Notation minus_diag := Nat.sub_diag (only parsing). (* n - n = 0 *)
-
-Lemma minus_diag_reverse n : 0 = n - n.
-Proof.
- symmetry. apply Nat.sub_diag.
-Qed.
-
-Notation minus_n_n := minus_diag_reverse.
+#[deprecated(since="8.16",note="The Arith.Minus file is obsolete. Use Nat.sub_diag instead.")]
+Notation minus_diag_reverse := Arith_prebase.minus_diag_reverse_stt.
+#[local]
+Definition minus_n_n_stt := fun n => eq_sym (Nat.sub_diag n).
+Opaque minus_n_n_stt.
+#[deprecated(since="8.16",note="The Arith.Minus file is obsolete. Use Nat.sub_diag instead.")]
+Notation minus_n_n := minus_n_n_stt.
 
 (** * Simplification *)
 
-Lemma minus_plus_simpl_l_reverse n m p : n - m = p + n - (p + m).
-Proof.
- now rewrite Nat.sub_add_distr, Nat.add_comm, Nat.add_sub.
-Qed.
+#[deprecated(since="8.16",note="The Arith.Minus file is obsolete.")]
+Notation minus_plus_simpl_l_reverse := Arith_prebase.minus_plus_simpl_l_reverse_stt.
 
 (** * Relation with plus *)
 
-Lemma plus_minus n m p : n = m + p -> p = n - m.
-Proof.
- symmetry. now apply Nat.add_sub_eq_l.
-Qed.
-
-Lemma minus_plus n m : n + m - n = m.
-Proof.
- rewrite Nat.add_comm. apply Nat.add_sub.
-Qed.
-
-Lemma le_plus_minus_r n m : n <= m -> n + (m - n) = m.
-Proof.
- rewrite Nat.add_comm. apply Nat.sub_add.
-Qed.
-
-Lemma le_plus_minus n m : n <= m -> m = n + (m - n).
-Proof.
- intros. symmetry. rewrite Nat.add_comm. now apply Nat.sub_add.
-Qed.
+#[deprecated(since="8.16",note="The Arith.Minus file is obsolete. Use Nat.add_sub_eq_l instead.")]
+Notation plus_minus := Arith_prebase.plus_minus_stt.
+#[deprecated(since="8.16",note="The Arith.Minus file is obsolete. Use Nat.add_sub instead.")]
+Notation minus_plus := Arith_prebase.minus_plus_stt.
+#[deprecated(since="8.16",note="The Arith.Minus file is obsolete. Use Nat.sub_add instead.")]
+Notation le_plus_minus_r := Arith_prebase.le_plus_minus_r_stt.
+#[deprecated(since="8.16",note="The Arith.Minus file is obsolete. Use Nat.sub_add instead.")]
+Notation le_plus_minus := Arith_prebase.le_plus_minus_stt.
 
 (** * Relation with order *)
 
-Notation minus_le_compat_r :=
-  Nat.sub_le_mono_r (only parsing). (* n <= m -> n - p <= m - p. *)
-
-Notation minus_le_compat_l :=
-  Nat.sub_le_mono_l (only parsing). (* n <= m -> p - m <= p - n. *)
-
+#[deprecated(since="8.16",note="The Arith.Minus file is obsolete. Use Nat.sub_le_mono_r instead.")]
+Notation minus_le_compat_r := Nat.sub_le_mono_r (only parsing). (* n <= m -> n - p <= m - p. *)
+#[deprecated(since="8.16",note="The Arith.Minus file is obsolete. Use Nat.sub_le_mono_l instead.")]
+Notation minus_le_compat_l := Nat.sub_le_mono_l (only parsing). (* n <= m -> p - m <= p - n. *)
+#[deprecated(since="8.16",note="The Arith.Minus file is obsolete. Use Nat.le_sub_l instead.")]
 Notation le_minus := Nat.le_sub_l (only parsing). (* n - m <= n *)
+#[deprecated(since="8.16",note="The Arith.Minus file is obsolete. Use Nat.sub_lt instead.")]
 Notation lt_minus := Nat.sub_lt (only parsing). (* m <= n -> 0 < m -> n-m < n *)
+#[deprecated(since="8.16",note="The Arith.Minus file is obsolete. Use Nat.lt_add_lt_sub_r instead.")]
+Notation lt_O_minus_lt := Arith_prebase.lt_O_minus_lt_stt.
+#[local]
+Definition not_le_minus_0_stt := fun n m Hn => proj2 (Nat.sub_0_le n m) (Nat.lt_le_incl _ _ (proj2 (Nat.lt_nge _ _) Hn)).
+Opaque not_le_minus_0_stt.
+#[deprecated(since="8.16",note="The Arith.Minus file is obsolete. Use Nat.sub_0_le instead.")]
+Notation not_le_minus_0 := not_le_minus_0_stt.
 
-Lemma lt_O_minus_lt n m : 0 < n - m -> m < n.
-Proof.
- apply Nat.lt_add_lt_sub_r.
-Qed.
-
-Theorem not_le_minus_0 n m : ~ m <= n -> n - m = 0.
-Proof.
- intros. now apply Nat.sub_0_le, Nat.lt_le_incl, Nat.lt_nge.
-Qed.
-
-(** * Hints *)
-
-#[global]
-Hint Resolve minus_n_O: arith.
-#[global]
-Hint Resolve minus_Sn_m: arith.
-#[global]
-Hint Resolve minus_diag_reverse: arith.
-#[global]
-Hint Resolve minus_plus_simpl_l_reverse: arith.
-#[global]
-Hint Immediate plus_minus: arith.
-#[global]
-Hint Resolve minus_plus: arith.
-#[global]
-Hint Resolve le_plus_minus: arith.
-#[global]
-Hint Resolve le_plus_minus_r: arith.
-#[global]
-Hint Resolve lt_minus: arith.
-#[global]
-Hint Immediate lt_O_minus_lt: arith.
+Require Import Lt Le.

--- a/theories/Arith/Mult.v
+++ b/theories/Arith/Mult.v
@@ -8,16 +8,12 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(** * Properties of multiplication.
+(** * Properties of multiplication. *)
 
- This file is mostly OBSOLETE now, see module [PeanoNat.Nat] instead.
+(** * This file is OBSOLETE, see [Arith_base] instead. *)
 
- [Nat.mul] is defined in [Init/Nat.v].
-*)
+Require Export Arith_prebase.
 
-Require Import PeanoNat.
-(** For Compatibility: *)
-Require Export Plus Minus Le Lt.
 
 Local Open Scope nat_scope.
 
@@ -25,164 +21,116 @@ Local Open Scope nat_scope.
 
 (** ** Zero property *)
 
+#[deprecated(since="8.16",note="The Arith.Mult file is obsolete. Use Nat.mul_0_l instead.")]
 Notation mult_0_l := Nat.mul_0_l (only parsing). (* 0 * n = 0 *)
+#[deprecated(since="8.16",note="The Arith.Mult file is obsolete. Use Nat.mul_0_r instead.")]
 Notation mult_0_r := Nat.mul_0_r (only parsing). (* n * 0 = 0 *)
 
 (** ** 1 is neutral *)
 
+#[deprecated(since="8.16",note="The Arith.Mult file is obsolete. Use Nat.mul_1_l instead.")]
 Notation mult_1_l := Nat.mul_1_l (only parsing). (* 1 * n = n *)
+#[deprecated(since="8.16",note="The Arith.Mult file is obsolete. Use Nat.mul_1_r instead.")]
 Notation mult_1_r := Nat.mul_1_r (only parsing). (* n * 1 = n *)
-
-#[global]
-Hint Resolve mult_1_l mult_1_r: arith.
 
 (** ** Commutativity *)
 
+#[deprecated(since="8.16",note="The Arith.Mult file is obsolete. Use Nat.mul_comm instead.")]
 Notation mult_comm := Nat.mul_comm (only parsing). (* n * m = m * n *)
-
-#[global]
-Hint Resolve mult_comm: arith.
 
 (** ** Distributivity *)
 
+#[deprecated(since="8.16",note="The Arith.Mult file is obsolete. Use Nat.mul_add_distr_r instead.")]
 Notation mult_plus_distr_r :=
   Nat.mul_add_distr_r (only parsing). (* (n+m)*p = n*p + m*p *)
-
+#[deprecated(since="8.16",note="The Arith.Mult file is obsolete. Use Nat.mul_add_distr_l instead.")]
 Notation mult_plus_distr_l :=
   Nat.mul_add_distr_l (only parsing). (* n*(m+p) = n*m + n*p *)
-
+#[deprecated(since="8.16",note="The Arith.Mult file is obsolete. Use Nat.mul_sub_distr_r instead.")]
 Notation mult_minus_distr_r :=
   Nat.mul_sub_distr_r (only parsing). (* (n-m)*p = n*p - m*p *)
-
+#[deprecated(since="8.16",note="The Arith.Mult file is obsolete. Use Nat.mul_sub_distr_l instead.")]
 Notation mult_minus_distr_l :=
   Nat.mul_sub_distr_l (only parsing). (* n*(m-p) = n*m - n*p *)
 
-#[global]
-Hint Resolve mult_plus_distr_r: arith.
-#[global]
-Hint Resolve mult_minus_distr_r: arith.
-#[global]
-Hint Resolve mult_minus_distr_l: arith.
-
 (** ** Associativity *)
 
+#[deprecated(since="8.16",note="The Arith.Mult file is obsolete. Use Nat.mul_assoc instead.")]
 Notation mult_assoc := Nat.mul_assoc (only parsing). (* n*(m*p)=n*m*p *)
-
-Lemma mult_assoc_reverse n m p : n * m * p = n * (m * p).
-Proof.
- symmetry. apply Nat.mul_assoc.
-Qed.
-
-#[global]
-Hint Resolve mult_assoc_reverse: arith.
-#[global]
-Hint Resolve mult_assoc: arith.
+#[deprecated(since="8.16",note="The Arith.Mult file is obsolete. Use Nat.mul_assoc instead.")]
+Notation mult_assoc_reverse := Arith_prebase.mult_assoc_reverse_stt.
 
 (** ** Inversion lemmas *)
 
-Lemma mult_is_O n m : n * m = 0 -> n = 0 \/ m = 0.
-Proof.
- apply Nat.eq_mul_0.
-Qed.
-
-Lemma mult_is_one n m : n * m = 1 -> n = 1 /\ m = 1.
-Proof.
- apply Nat.eq_mul_1.
-Qed.
+#[local]
+Definition mult_is_O_stt := fun n m Heq => proj1 (Nat.eq_mul_0 n m) Heq.
+Opaque mult_is_O_stt.
+#[deprecated(since="8.16",note="The Arith.Mult file is obsolete. Use Nat.eq_mul_0 instead.")]
+Notation mult_is_O := mult_is_O_stt.
+#[local]
+Definition mult_is_one_stt := fun n m Heq => proj1 (Nat.eq_mul_1 n m) Heq.
+Opaque mult_is_one_stt.
+#[deprecated(since="8.16",note="The Arith.Mult file is obsolete. Use Nat.eq_mul_1 instead.")]
+Notation mult_is_one := mult_is_one_stt.
 
 (** ** Multiplication and successor *)
 
+#[deprecated(since="8.16",note="The Arith.Mult file is obsolete. Use Nat.mul_succ_l instead.")]
 Notation mult_succ_l := Nat.mul_succ_l (only parsing). (* S n * m = n * m + m *)
+#[deprecated(since="8.16",note="The Arith.Mult file is obsolete. Use Nat.mul_succ_r instead.")]
 Notation mult_succ_r := Nat.mul_succ_r (only parsing). (* n * S m = n * m + n *)
 
 (** * Compatibility with orders *)
 
-Lemma mult_O_le n m : m = 0 \/ n <= m * n.
-Proof.
- destruct m; [left|right]; simpl; trivial using Nat.le_add_r.
-Qed.
-#[global]
-Hint Resolve mult_O_le: arith.
-
-Lemma mult_le_compat_l n m p : n <= m -> p * n <= p * m.
-Proof.
- apply Nat.mul_le_mono_nonneg_l, Nat.le_0_l. (* TODO : get rid of 0<=n hyp *)
-Qed.
-#[global]
-Hint Resolve mult_le_compat_l: arith.
-
-Lemma mult_le_compat_r n m p : n <= m -> n * p <= m * p.
-Proof.
- apply Nat.mul_le_mono_nonneg_r, Nat.le_0_l.
-Qed.
-
-Lemma mult_le_compat n m p q : n <= m -> p <= q -> n * p <= m * q.
-Proof.
-  intros. apply Nat.mul_le_mono_nonneg; trivial; apply Nat.le_0_l.
-Qed.
-
-Lemma mult_S_lt_compat_l n m p : m < p -> S n * m < S n * p.
-Proof.
-  apply Nat.mul_lt_mono_pos_l, Nat.lt_0_succ.
-Qed.
-
-#[global]
-Hint Resolve mult_S_lt_compat_l: arith.
-
-Lemma mult_lt_compat_l n m p : n < m -> 0 < p -> p * n < p * m.
-Proof.
- intros. now apply Nat.mul_lt_mono_pos_l.
-Qed.
-
-Lemma mult_lt_compat_r n m p : n < m -> 0 < p -> n * p < m * p.
-Proof.
- intros. now apply Nat.mul_lt_mono_pos_r.
-Qed.
-
-Lemma mult_S_le_reg_l n m p : S n * m <= S n * p -> m <= p.
-Proof.
- apply Nat.mul_le_mono_pos_l, Nat.lt_0_succ.
-Qed.
+#[deprecated(since="8.16",note="The Arith.Mult file is obsolete.")]
+Notation mult_O_le := Arith_prebase.mult_O_le_stt.
+#[deprecated(since="8.16",note="The Arith.Mult file is obsolete. Use Nat.mul_le_mono_l instead.")]
+Notation mult_le_compat_l := Nat.mul_le_mono_l (only parsing).
+#[deprecated(since="8.16",note="The Arith.Mult file is obsolete. Use Nat.mul_le_mono_r instead.")]
+Notation mult_le_compat_r := Nat.mul_le_mono_r (only parsing).
+#[deprecated(since="8.16",note="The Arith.Mult file is obsolete. Use Nat.mul_le_mono instead.")]
+Notation mult_le_compat := Nat.mul_le_mono (only parsing).
+#[deprecated(since="8.16",note="The Arith.Mult file is obsolete. Use Nat.mul_lt_mono_pos_l instead.")]
+Notation mult_S_lt_compat_l := Arith_prebase.mult_S_lt_compat_l_stt.
+#[local]
+Definition mult_lt_compat_l_stt := fun n m p Hlt Hp => proj1 (Nat.mul_lt_mono_pos_l p n m Hp) Hlt.
+Opaque mult_lt_compat_l_stt.
+#[deprecated(since="8.16",note="The Arith.Mult file is obsolete. Use Nat.mul_lt_mono_pos_l instead.")]
+Notation mult_lt_compat_l := mult_lt_compat_l_stt.
+#[local]
+Definition mult_lt_compat_r_stt := fun n m p Hlt Hp => proj1 (Nat.mul_lt_mono_pos_r p n m Hp) Hlt.
+Opaque mult_lt_compat_r_stt.
+#[deprecated(since="8.16",note="The Arith.Mult file is obsolete. Use Nat.mul_lt_mono_pos_r instead.")]
+Notation mult_lt_compat_r := mult_lt_compat_r_stt.
+#[local]
+Definition mult_S_le_reg_l_stt := fun n m p Hle => proj2 (Nat.mul_le_mono_pos_l m p (S n) (Nat.lt_0_succ n)) Hle.
+Opaque mult_S_le_reg_l_stt.
+#[deprecated(since="8.16",note="The Arith.Mult file is obsolete. Use Nat.mul_le_mono_pos_l instead.")]
+Notation mult_S_le_reg_l := mult_S_le_reg_l_stt.
 
 (** * n|->2*n and n|->2n+1 have disjoint image *)
 
-Theorem odd_even_lem p q : 2 * p + 1 <> 2 * q.
+#[local]
+Definition odd_even_lem_stt p q : 2 * p + 1 <> 2 * q.
 Proof.
  intro. apply (Nat.Even_Odd_False (2*q)).
  - now exists q.
  - now exists p.
 Qed.
+#[deprecated(since="8.16",note="The Arith.Mult file is obsolete.")]
+Notation odd_even_lem := odd_even_lem_stt.
 
+(** * Tail-recursive [mult] *)
 
-(** * Tail-recursive mult *)
-
-(** [tail_mult] is an alternative definition for [mult] which is
-    tail-recursive, whereas [mult] is not. This can be useful
-    when extracting programs. *)
-
-Fixpoint mult_acc (s:nat) m n : nat :=
-  match n with
-    | O => s
-    | S p => mult_acc (tail_plus m s) m p
-  end.
-
-Lemma mult_acc_aux : forall n m p, m + n * p = mult_acc m p n.
-Proof.
-  intro n; induction n as [| n IHn]; simpl; auto.
-  intros. rewrite Nat.add_assoc, IHn. f_equal.
-  rewrite Nat.add_comm. apply plus_tail_plus.
-Qed.
-
-Definition tail_mult n m := mult_acc 0 m n.
-
-Lemma mult_tail_mult : forall n m, n * m = tail_mult n m.
-Proof.
-  intros; unfold tail_mult; rewrite <- mult_acc_aux; auto.
-Qed.
-
-(** [TailSimpl] transforms any [tail_plus] and [tail_mult] into [plus]
-    and [mult] and simplify *)
-
+#[deprecated(since="8.16",note="The Arith.Mult file is obsolete. Use Nat.tail_mul instead.")]
+Notation tail_mult := Nat.tail_mul (only parsing).
+#[local]
+Definition mult_tail_mult_stt := fun n m => eq_sym (Nat.tail_mul_spec n m).
+Opaque mult_tail_mult_stt.
+#[deprecated(since="8.16",note="The Arith.Mult file is obsolete. Use Nat.tail_mul_spec instead.")]
+Notation mult_tail_mult := mult_tail_mult_stt.
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete.")]
 Ltac tail_simpl :=
-  repeat rewrite <- plus_tail_plus; repeat rewrite <- mult_tail_mult;
-    simpl.
+  repeat rewrite Nat.tail_add_spec; repeat rewrite Nat.tail_mul_spec; simpl.
+
+Require Export Plus Minus Le Lt.

--- a/theories/Arith/Peano_dec.v
+++ b/theories/Arith/Peano_dec.v
@@ -61,5 +61,5 @@ destruct le_mn1 as [|? le_mn1]; intros le_mn2; destruct le_mn2 as [|? le_mn2].
 now rewrite H.
 Qed.
 
-(** For compatibility *)
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
 Require Import Le Lt.

--- a/theories/Arith/Plus.v
+++ b/theories/Arith/Plus.v
@@ -8,190 +8,146 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(** Properties of addition.
+(** Properties of addition. *)
 
- This file is mostly OBSOLETE now, see module [PeanoNat.Nat] instead.
+(** * This file is OBSOLETE, see [Arith_base] instead. *)
 
- [Nat.add] is defined in [Init/Nat.v] as:
-<<
-Fixpoint add (n m:nat) : nat :=
-  match n with
-  | O => m
-  | S p => S (p + m)
-  end
-where "n + m" := (add n m) : nat_scope.
->>
-*)
+Require Export Arith_prebase.
 
-Require Import PeanoNat.
 
 Local Open Scope nat_scope.
 
 (** * Neutrality of 0, commutativity, associativity *)
 
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.add_0_l instead.")]
 Notation plus_0_l := Nat.add_0_l (only parsing).
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.add_0_r instead.")]
 Notation plus_0_r := Nat.add_0_r (only parsing).
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.add_comm instead.")]
 Notation plus_comm := Nat.add_comm (only parsing).
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.add_assoc instead.")]
 Notation plus_assoc := Nat.add_assoc (only parsing).
-
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.add_shuffle3 instead.")]
 Notation plus_permute := Nat.add_shuffle3 (only parsing).
-
-Definition plus_Snm_nSm : forall n m, S n + m = n + S m :=
- Peano.plus_n_Sm.
-
-Lemma plus_assoc_reverse n m p : n + m + p = n + (m + p).
-Proof.
-  symmetry. apply Nat.add_assoc.
-Qed.
+#[local]
+Definition plus_Snm_nSm_stt : forall n m, S n + m = n + S m := Peano.plus_n_Sm.
+Opaque plus_Snm_nSm_stt.
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.add_succ_r instead.")]
+Notation plus_Snm_nSm := plus_Snm_nSm_stt.
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.add_assoc instead.")]
+Notation plus_assoc_reverse := Arith_prebase.plus_assoc_reverse_stt.
 
 (** * Simplification *)
 
-Lemma plus_reg_l n m p : p + n = p + m -> n = m.
-Proof.
- apply Nat.add_cancel_l.
-Qed.
-
-Lemma plus_le_reg_l n m p : p + n <= p + m -> n <= m.
-Proof.
- apply Nat.add_le_mono_l.
-Qed.
-
-Lemma plus_lt_reg_l n m p : p + n < p + m -> n < m.
-Proof.
- apply Nat.add_lt_mono_l.
-Qed.
+#[local]
+Definition plus_reg_l_stt := fun n m p => proj1 (Nat.add_cancel_l n m p).
+Opaque plus_reg_l_stt.
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.add_cancel_l instead.")]
+Notation plus_reg_l := plus_reg_l_stt.
+#[local]
+Definition plus_le_reg_l_stt := fun n m p => proj2 (Nat.add_le_mono_l n m p).
+Opaque plus_le_reg_l_stt.
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.add_le_mono_l instead.")]
+Notation plus_le_reg_l := plus_le_reg_l_stt.
+#[local]
+Definition plus_lt_reg_l_stt := fun n m p => proj2 (Nat.add_lt_mono_l n m p).
+Opaque plus_lt_reg_l_stt.
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.add_lt_mono_l instead.")]
+Notation plus_lt_reg_l := plus_lt_reg_l_stt.
 
 (** * Compatibility with order *)
 
-Lemma plus_le_compat_l n m p : n <= m -> p + n <= p + m.
-Proof.
- apply Nat.add_le_mono_l.
-Qed.
+#[local]
+Definition plus_le_compat_l_stt := fun n m p => proj1 (Nat.add_le_mono_l n m p).
+Opaque plus_le_compat_l_stt.
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.add_le_mono_l instead.")]
+Notation plus_le_compat_l := plus_le_compat_l_stt.
+#[local]
+Definition plus_le_compat_r_stt := fun n m p => proj1 (Nat.add_le_mono_r n m p).
+Opaque plus_le_compat_r_stt.
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.add_le_mono_r instead.")]
+Notation plus_le_compat_r := plus_le_compat_r_stt.
+#[local]
+Definition plus_lt_compat_l_stt := fun n m p => proj1 (Nat.add_lt_mono_l n m p).
+Opaque plus_lt_compat_l_stt.
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.add_lt_mono_l instead.")]
+Notation plus_lt_compat_l := plus_lt_compat_l_stt.
+#[local]
+Definition plus_lt_compat_r_stt := fun n m p => proj1 (Nat.add_lt_mono_r n m p).
+Opaque plus_lt_compat_r_stt.
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.add_lt_mono_r instead.")]
+Notation plus_lt_compat_r := plus_lt_compat_r_stt.
 
-Lemma plus_le_compat_r n m p : n <= m -> n + p <= m + p.
-Proof.
- apply Nat.add_le_mono_r.
-Qed.
-
-Lemma plus_lt_compat_l n m p : n < m -> p + n < p + m.
-Proof.
- apply Nat.add_lt_mono_l.
-Qed.
-
-Lemma plus_lt_compat_r n m p : n < m -> n + p < m + p.
-Proof.
- apply Nat.add_lt_mono_r.
-Qed.
-
-Lemma plus_le_compat n m p q : n <= m -> p <= q -> n + p <= m + q.
-Proof.
- apply Nat.add_le_mono.
-Qed.
-
-Lemma plus_le_lt_compat n m p q : n <= m -> p < q -> n + p < m + q.
-Proof.
- apply Nat.add_le_lt_mono.
-Qed.
-
-Lemma plus_lt_le_compat n m p q : n < m -> p <= q -> n + p < m + q.
-Proof.
- apply Nat.add_lt_le_mono.
-Qed.
-
-Lemma plus_lt_compat n m p q : n < m -> p < q -> n + p < m + q.
-Proof.
- apply Nat.add_lt_mono.
-Qed.
-
-Lemma le_plus_l n m : n <= n + m.
-Proof.
- apply Nat.le_add_r.
-Qed.
-
-Lemma le_plus_r n m : m <= n + m.
-Proof.
- rewrite Nat.add_comm. apply Nat.le_add_r.
-Qed.
-
-Theorem le_plus_trans n m p : n <= m -> n <= m + p.
-Proof.
-  intros. now rewrite <- Nat.le_add_r.
-Qed.
-
-Theorem lt_plus_trans n m p : n < m -> n < m + p.
-Proof.
-  intros. apply Nat.lt_le_trans with m. trivial. apply Nat.le_add_r.
-Qed.
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.add_le_mono instead.")]
+Notation plus_le_compat := Nat.add_le_mono (only parsing).
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.add_le_lt_mono instead.")]
+Notation plus_le_lt_compat := Nat.add_le_lt_mono (only parsing).
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.add_lt_le_mono instead.")]
+Notation plus_lt_le_compat := Nat.add_lt_le_mono (only parsing).
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.add_lt_mono instead.")]
+Notation plus_lt_compat := Nat.add_lt_mono (only parsing).
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.le_add_r instead.")]
+Notation le_plus_l := Nat.le_add_r (only parsing).
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.le_add_r instead.")]
+Notation le_plus_r := Arith_prebase.le_plus_r_stt.
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.le_add_r instead.")]
+Notation le_plus_trans := Arith_prebase.le_plus_trans_stt.
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.le_add_r instead.")]
+Notation lt_plus_trans := Arith_prebase.lt_plus_trans_stt.
 
 (** * Inversion lemmas *)
 
-Lemma plus_is_O n m : n + m = 0 -> n = 0 /\ m = 0.
+#[local]
+Definition plus_is_O_stt n m : n + m = 0 -> n = 0 /\ m = 0.
 Proof.
   destruct n; now split.
 Qed.
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete.")]
+Notation plus_is_O := plus_is_O_stt.
 
-Definition plus_is_one m n :
+#[local]
+Definition plus_is_one_stt m n :
   m + n = 1 -> {m = 0 /\ n = 1} + {m = 1 /\ n = 0}.
 Proof.
   destruct m as [| m]; auto.
   destruct m; auto.
   discriminate.
 Defined.
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete.")]
+Notation plus_is_one := plus_is_one_stt.
 
 (** * Derived properties *)
 
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.add_shuffle1 instead.")]
 Notation plus_permute_2_in_4 := Nat.add_shuffle1 (only parsing).
-
-(** * Tail-recursive plus *)
-
-(** [tail_plus] is an alternative definition for [plus] which is
-    tail-recursive, whereas [plus] is not. This can be useful
-    when extracting programs. *)
-
-Fixpoint tail_plus n m : nat :=
-  match n with
-    | O => m
-    | S n => tail_plus n (S m)
-  end.
-
-Lemma plus_tail_plus : forall n m, n + m = tail_plus n m.
-Proof.
-intro n; induction n as [| n IHn]; simpl; auto.
-intro m; rewrite <- IHn; simpl; auto.
-Qed.
 
 (** * Discrimination *)
 
-Lemma succ_plus_discr n m : n <> S (m+n).
-Proof.
- apply Nat.succ_add_discr.
-Qed.
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.succ_add_discr instead.")]
+Notation succ_plus_discr := Nat.succ_add_discr (only parsing).
+#[local]
+Definition n_SSn_stt : forall n, n <> S (S n) := fun n => Nat.succ_add_discr 1 n.
+Opaque n_SSn_stt.
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.succ_add_discr instead.")]
+Notation n_SSn := n_SSn_stt.
+#[local]
+Definition n_SSSn_stt : forall n, n <> S (S (S n)) := fun n => Nat.succ_add_discr 2 n.
+Opaque n_SSSn_stt.
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.succ_add_discr instead.")]
+Notation n_SSSn := n_SSSn_stt.
+#[local]
+Definition n_SSSSn_stt : forall n, n <> S (S (S (S n))) := fun n => Nat.succ_add_discr 3 n.
+Opaque n_SSSSn_stt.
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.succ_add_discr instead.")]
+Notation n_SSSSn := n_SSSSn_stt.
 
-Lemma n_SSn n : n <> S (S n).
-Proof (succ_plus_discr n 1).
-
-Lemma n_SSSn n : n <> S (S (S n)).
-Proof (succ_plus_discr n 2).
-
-Lemma n_SSSSn n : n <> S (S (S (S n))).
-Proof (succ_plus_discr n 3).
-
-
-(** * Compatibility Hints *)
-
-#[global]
-Hint Immediate plus_comm : arith.
-#[global]
-Hint Resolve plus_assoc plus_assoc_reverse : arith.
-#[global]
-Hint Resolve plus_le_compat_l plus_le_compat_r : arith.
-#[global]
-Hint Resolve le_plus_l le_plus_r le_plus_trans : arith.
-#[global]
-Hint Immediate lt_plus_trans : arith.
-#[global]
-Hint Resolve plus_lt_compat_l plus_lt_compat_r : arith.
-
-(** For compatibility, we "Require" the same files as before *)
+(** * Tail-recursive [plus] *)
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.tail_add instead.")]
+Notation tail_plus := Nat.tail_add (only parsing).
+#[local]
+Definition plus_tail_plus_stt := fun n m => eq_sym (Nat.tail_add_spec n m).
+Opaque plus_tail_plus_stt.
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.tail_add_spec instead.")]
+Notation plus_tail_plus := plus_tail_plus_stt.
 
 Require Import Le Lt.

--- a/theories/Arith/Wf_nat.v
+++ b/theories/Arith/Wf_nat.v
@@ -10,7 +10,7 @@
 
 (** Well-founded relations and natural numbers *)
 
-Require Import PeanoNat Lt.
+Require Import PeanoNat.
 
 Local Open Scope nat_scope.
 
@@ -28,10 +28,10 @@ Theorem well_founded_ltof : well_founded ltof.
 Proof.
   assert (H : forall n (a:A), f a < n -> Acc ltof a).
   { intro n; induction n as [|n IHn].
-    - intros a Ha; absurd (f a < 0); auto with arith.
+    - intros a Ha; absurd (f a < 0); auto. apply Nat.nlt_0_r.
     - intros a Ha. apply Acc_intro. unfold ltof at 1. intros b Hb.
-      apply IHn. apply Nat.lt_le_trans with (f a); auto with arith. }
-  intros a. apply (H (S (f a))). auto with arith.
+      apply IHn. apply Nat.lt_le_trans with (f a); auto. now apply Nat.succ_le_mono. }
+  intros a. apply (H (S (f a))). apply Nat.lt_succ_diag_r.
 Defined.
 
 Register well_founded_ltof as num.nat.well_founded_ltof.
@@ -70,10 +70,10 @@ Proof.
   intros P F.
   assert (H : forall n (a:A), f a < n -> P a).
   { intro n; induction n as [|n IHn].
-    - intros a Ha; absurd (f a < 0); auto with arith.
+    - intros a Ha; absurd (f a < 0); auto. apply Nat.nlt_0_r.
     - intros a Ha. apply F. unfold ltof. intros b Hb.
-      apply IHn. apply Nat.lt_le_trans with (f a); auto with arith. }
-  intros a. apply (H (S (f a))). auto with arith.
+      apply IHn. apply Nat.lt_le_trans with (f a); auto. now apply Nat.succ_le_mono. }
+  intros a. apply (H (S (f a))). apply Nat.lt_succ_diag_r.
 Defined.
 
 Theorem induction_gtof1 :
@@ -108,10 +108,10 @@ Theorem well_founded_lt_compat : well_founded R.
 Proof.
   assert (H : forall n (a:A), f a < n -> Acc R a).
   { intro n; induction n as [|n IHn].
-    - intros a Ha; absurd (f a < 0); auto with arith.
+    - intros a Ha; absurd (f a < 0); auto. apply Nat.nlt_0_r.
     - intros a Ha. apply Acc_intro. intros b Hb.
-      apply IHn. apply Nat.lt_le_trans with (f a); auto with arith. }
-  intros a. apply (H (S (f a))). auto with arith.
+      apply IHn. apply Nat.lt_le_trans with (f a); auto. now apply Nat.succ_le_mono. }
+  intros a. apply (H (S (f a))). apply Nat.lt_succ_diag_r.
 Defined.
 
 End Well_founded_Nat.
@@ -148,7 +148,7 @@ Defined.
 Lemma lt_wf_ind :
   forall n (P:nat -> Prop), (forall n, (forall m, m < n -> P m) -> P n) -> P n.
 Proof.
-  intro p; intros; elim (lt_wf p); auto with arith.
+  intro p; intros; elim (lt_wf p); auto.
 Qed.
 
 Lemma gt_wf_rect :
@@ -174,7 +174,7 @@ Lemma lt_wf_double_rect :
      (forall p, p < m -> P n p) -> P n m) -> forall n m, P n m.
 Proof.
   intros P Hrec p; pattern p; apply lt_wf_rect.
-  intros n H q; pattern q; apply lt_wf_rect; auto with arith.
+  intros n H q; pattern q; apply lt_wf_rect; auto.
 Defined.
 
 Lemma lt_wf_double_rec :
@@ -184,7 +184,7 @@ Lemma lt_wf_double_rec :
      (forall p, p < m -> P n p) -> P n m) -> forall n m, P n m.
 Proof.
   intros P Hrec p; pattern p; apply lt_wf_rec.
-  intros n H q; pattern q; apply lt_wf_rec; auto with arith.
+  intros n H q; pattern q; apply lt_wf_rec; auto.
 Defined.
 
 Lemma lt_wf_double_ind :
@@ -194,7 +194,7 @@ Lemma lt_wf_double_ind :
       (forall p, p < m -> P n p) -> P n m) -> forall n m, P n m.
 Proof.
   intros P Hrec p; pattern p; apply lt_wf_ind.
-  intros n H q; pattern q; apply lt_wf_ind; auto with arith.
+  intros n H q; pattern q; apply lt_wf_ind; auto.
 Qed.
 
 #[global]
@@ -241,7 +241,6 @@ Qed.
 
 Set Implicit Arguments.
 
-Require Import Le.
 Require Import Compare_dec.
 Require Import Decidable.
 
@@ -259,9 +258,9 @@ Proof.
   { intro n; induction n as [|n IHn].
     - right. intros. apply Nat.le_0_l.
     - destruct IHn as [(n' & IH1 & IH2)|IH].
-      + left. exists n'; auto with arith.
+      + left. exists n'; auto.
       + destruct (Pdec n) as [HP|HP].
-        * left. exists n; auto with arith.
+        * left. exists n; auto.
         * right. intros n' Hn'.
           apply Nat.le_neq; split; auto. intros <-. auto. }
   destruct (H n0) as [(n & H1 & H2 & H3)|H0]; [exists n | exists n0];
@@ -272,3 +271,6 @@ Qed.
 Unset Implicit Arguments.
 
 Notation iter_nat n A f x := (nat_rect (fun _ => A) x (fun _ => f) n) (only parsing).
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Import Le Lt.

--- a/theories/Bool/Bvector.v
+++ b/theories/Bool/Bvector.v
@@ -13,7 +13,6 @@
 Require Export Bool Sumbool.
 Require Vector.
 Export Vector.VectorNotations.
-Require Import Minus.
 
 Local Open Scope nat_scope.
 
@@ -111,3 +110,6 @@ Infix    "^|"   := (BVor   _) (at level 50, left  associativity) : Bvector_scope
 Infix    "=?"   := (BVeq _ _) (at level 70, no    associativity) : Bvector_scope.
 Open Scope Bvector_scope.
 End BvectorNotations.
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Import Minus.

--- a/theories/FSets/FSetPositive.v
+++ b/theories/FSets/FSetPositive.v
@@ -18,7 +18,7 @@
    Sandrine Blazy (used for building certified compilers).
 *)
 
-Require Import Bool BinPos OrderedType OrderedTypeEx FSetInterface.
+Require Import Bool PeanoNat BinPos OrderedType OrderedTypeEx FSetInterface.
 
 Set Implicit Arguments.
 Local Open Scope lazy_bool_scope.
@@ -783,10 +783,10 @@ Module PositiveSet <: S with Module E:=PositiveOrderedTypeBits.
 
     induction s as [|l IHl b r IHr]; intros j acc; simpl; trivial. destruct b.
       rewrite <- IHl. simpl. rewrite <- IHr.
-       rewrite <- plus_n_Sm, Plus.plus_assoc. reflexivity.
-      rewrite <- IHl, <- IHr. rewrite Plus.plus_assoc. reflexivity.
+       rewrite <- plus_n_Sm, Nat.add_assoc. reflexivity.
+      rewrite <- IHl, <- IHr. rewrite Nat.add_assoc. reflexivity.
 
-    intros. rewrite <- H. simpl. rewrite Plus.plus_comm. reflexivity.
+    intros. rewrite <- H. simpl. rewrite Nat.add_comm. reflexivity.
   Qed.
 
   (** Specification of [filter] *)

--- a/theories/FSets/FSetProperties.v
+++ b/theories/FSets/FSetProperties.v
@@ -17,7 +17,7 @@
     [Equal s s'] instead of [equal s s'=true], etc. *)
 
 Require Export FSetInterface.
-Require Import DecidableTypeEx FSetFacts FSetDecide.
+Require Import PeanoNat DecidableTypeEx FSetFacts FSetDecide.
 Set Implicit Arguments.
 Unset Strict Implicit.
 
@@ -821,7 +821,8 @@ Module WProperties_fun (Import E : DecidableType)(M : WSfun E).
   intros.
   rewrite <- (diff_inter_cardinal s' s).
   rewrite (inter_sym s' s).
-  rewrite (inter_subset_equal H); auto with arith.
+  rewrite (inter_subset_equal H).
+  rewrite Nat.add_comm; apply Nat.le_add_r.
   Qed.
 
   Lemma subset_cardinal_lt :
@@ -837,7 +838,7 @@ Module WProperties_fun (Import E : DecidableType)(M : WSfun E).
   set_iff; auto.
   intros _.
   change (0 + cardinal s < S n + cardinal s).
-  apply Plus.plus_lt_le_compat; auto with arith.
+  apply Nat.add_lt_le_mono; [ apply Nat.lt_0_succ | reflexivity ].
   Qed.
 
   Theorem union_inter_cardinal :
@@ -853,9 +854,8 @@ Module WProperties_fun (Import E : DecidableType)(M : WSfun E).
    forall s s', cardinal (union s s') = cardinal s + cardinal s' - cardinal (inter s s').
   Proof.
   intros.
-  rewrite <- union_inter_cardinal.
-  rewrite Plus.plus_comm.
-  auto with arith.
+  rewrite <- union_inter_cardinal, Nat.add_sub.
+  reflexivity.
   Qed.
 
   Lemma union_cardinal_le :

--- a/theories/Logic/ConstructiveEpsilon.v
+++ b/theories/Logic/ConstructiveEpsilon.v
@@ -232,7 +232,7 @@ Proof.
   intro e; destruct (linear_search_from_0_conform e) as [found r]; exists found.
   split.
   - apply (rel_ls_post r).
-  - intros k pk. apply (rel_ls_lower_bound r pk), le_0_n.
+  - intros k pk. apply (rel_ls_lower_bound r pk), Nat.le_0_l.
 Defined.
 
 (** NB. The previous version used a negative formulation:
@@ -286,7 +286,7 @@ Proof.
   intro e. exists (linear_search_from_0 e). split.
   - apply (rel_ls_post (linear_search_from_0_rel e)).
   - intros k pk.
-    apply (@rel_ls_lower_bound _ 0 (linear_search_from_0_rel e) k pk), le_0_n.
+    apply (@rel_ls_lower_bound _ 0 (linear_search_from_0_rel e) k pk), Nat.le_0_l.
 Defined.
 
 End ConstructiveIndefiniteGroundDescription_Direct.

--- a/theories/Logic/FinFun.v
+++ b/theories/Logic/FinFun.v
@@ -13,7 +13,7 @@
 (** Main result : for functions [f:A->A] with finite [A],
     f injective <-> f bijective <-> f surjective. *)
 
-Require Import List Compare_dec EqNat Decidable ListDec. Require Fin.
+Require Import List PeanoNat Compare_dec EqNat Decidable ListDec. Require Fin.
 Set Implicit Arguments.
 
 (** General definitions *)
@@ -264,7 +264,7 @@ Definition restrict n (f:nat->nat)(hf : bFun n f) : (Fin.t n -> Fin.t n) :=
 Ltac break_dec H :=
  let H' := fresh "H" in
  destruct le_lt_dec as [H'|H'];
-  [elim (Lt.le_not_lt _ _ H' H)
+  [elim (proj1 (Nat.le_ngt _ _) H' H)
   |try rewrite (n2f_ext H' H) in *; try clear H'].
 
 Lemma extend_ok n f : bFun n (@extend n f).

--- a/theories/MSets/MSetPositive.v
+++ b/theories/MSets/MSetPositive.v
@@ -18,7 +18,7 @@
    Sandrine Blazy (used for building certified compilers).
 *)
 
-Require Import Bool BinPos Orders OrdersEx MSetInterface.
+Require Import Bool PeanoNat BinPos Orders OrdersEx MSetInterface.
 
 Set Implicit Arguments.
 Local Open Scope lazy_bool_scope.
@@ -718,10 +718,10 @@ Module PositiveSet <: S with Module E:=PositiveOrderedTypeBits.
 
     induction s as [|l IHl b r IHr]; intros j acc; simpl; trivial. destruct b.
       rewrite <- IHl. simpl. rewrite <- IHr.
-       rewrite <- plus_n_Sm, Plus.plus_assoc. reflexivity.
-      rewrite <- IHl, <- IHr. rewrite Plus.plus_assoc. reflexivity.
+       rewrite <- plus_n_Sm, Nat.add_assoc. reflexivity.
+      rewrite <- IHl, <- IHr. rewrite Nat.add_assoc. reflexivity.
 
-    intros. rewrite <- H. simpl. rewrite Plus.plus_comm. reflexivity.
+    intros. rewrite <- H. simpl. rewrite Nat.add_comm. reflexivity.
   Qed.
 
   (** Specification of [filter] *)

--- a/theories/MSets/MSetProperties.v
+++ b/theories/MSets/MSetProperties.v
@@ -17,7 +17,7 @@
     [Equal s s'] instead of [equal s s'=true], etc. *)
 
 Require Export MSetInterface.
-Require Import DecidableTypeEx OrdersLists MSetFacts MSetDecide.
+Require Import PeanoNat DecidableTypeEx OrdersLists MSetFacts MSetDecide.
 Set Implicit Arguments.
 Unset Strict Implicit.
 
@@ -829,7 +829,8 @@ Module WPropertiesOn (Import E : DecidableType)(M : WSetsOn E).
   intros.
   rewrite <- (diff_inter_cardinal s' s).
   rewrite (inter_sym s' s).
-  rewrite (inter_subset_equal H); auto with arith.
+  rewrite (inter_subset_equal H).
+  rewrite Nat.add_comm; apply Nat.le_add_r.
   Qed.
 
   Lemma subset_cardinal_lt :
@@ -845,7 +846,7 @@ Module WPropertiesOn (Import E : DecidableType)(M : WSetsOn E).
   set_iff; auto.
   intros _.
   change (0 + cardinal s < S n + cardinal s).
-  apply Plus.plus_lt_le_compat; auto with arith.
+  apply Nat.add_lt_le_mono; [ apply Nat.lt_0_succ | reflexivity ].
   Qed.
 
   Theorem union_inter_cardinal :
@@ -862,9 +863,8 @@ Module WPropertiesOn (Import E : DecidableType)(M : WSetsOn E).
    forall s s', cardinal (union s s') = cardinal s + cardinal s' - cardinal (inter s s').
   Proof.
   intros.
-  rewrite <- union_inter_cardinal.
-  rewrite Plus.plus_comm.
-  auto with arith.
+  rewrite <- union_inter_cardinal, Nat.add_sub.
+  reflexivity.
   Qed.
 
   Lemma union_cardinal_le :

--- a/theories/MSets/MSetRBT.v
+++ b/theories/MSets/MSetRBT.v
@@ -990,10 +990,11 @@ Proof.
  specialize (Hf acc).
  destruct (f acc) as (t1,acc1).
  destruct Hf as (Hf1,Hf2).
-  { transitivity size; trivial. subst. auto with arith. }
+  { transitivity size; trivial. subst. rewrite <- Nat.add_succ_r. apply Nat.le_add_r. }
  destruct acc1 as [|x acc1].
   { exfalso. revert LE. apply Nat.lt_nge. subst.
-    rewrite app_nil_r, <- elements_cardinal; auto with arith. }
+    rewrite app_nil_r, <- elements_cardinal.
+    apply (Nat.succ_le_mono (cardinal t1)), Nat.le_add_r. }
  specialize (Hg acc1).
  destruct (g acc1) as (t2,acc2).
  destruct Hg as (Hg1,Hg2).
@@ -1570,7 +1571,7 @@ Proof.
  - simpl. rewrite <- Nat.succ_le_mono.
    apply Nat.max_lub; eapply Nat.le_trans; eauto;
    [destree l | destree r]; simpl;
-   rewrite !Nat.add_0_r, ?Nat.add_1_r; auto with arith.
+   rewrite !Nat.add_0_r, ?Nat.add_1_r, ?Nat.add_succ_r; auto.
 Qed.
 
 Lemma rb_mindepth s n : rbt n s -> n + redcarac s <= mindepth s.
@@ -1583,7 +1584,11 @@ Proof.
    replace (redcarac r) with 0 in * by now destree r.
    now apply Nat.min_glb.
  - apply -> Nat.succ_le_mono. rewrite Nat.add_0_r.
-   apply Nat.min_glb; eauto with arith.
+   apply Nat.min_glb.
+   + refine (Nat.le_trans _ _ _ _ IHrbt1).
+     apply Nat.le_add_r.
+   + refine (Nat.le_trans _ _ _ _ IHrbt2).
+     apply Nat.le_add_r.
 Qed.
 
 Lemma maxdepth_upperbound s : Rbt s ->
@@ -1594,7 +1599,7 @@ Proof.
  transitivity (2*(n+redcarac s)).
  - rewrite Nat.mul_add_distr_l. apply Nat.add_le_mono_l.
    rewrite <- Nat.mul_1_l at 1. apply Nat.mul_le_mono_r.
-   auto with arith.
+   auto.
  - apply Nat.mul_le_mono_l.
    transitivity (mindepth s).
    + now apply rb_mindepth.
@@ -1837,10 +1842,12 @@ Proof.
  unfold treeify_cont.
  specialize (Hf acc).
  destruct (f acc) as (l, acc1). simpl in *.
- destruct Hf as (Hf1, Hf2). { subst. eauto with arith. }
+ destruct Hf as (Hf1, Hf2).
+ { subst. refine (Nat.le_trans _ _ _ _ Hacc).
+   rewrite <- Nat.add_succ_r. apply Nat.le_add_r. }
  destruct acc1 as [|x acc2]; simpl in *.
  - exfalso. revert Hacc. apply Nat.lt_nge. rewrite H, <- Hf2.
-   auto with arith.
+   rewrite Nat.add_0_r. apply (Nat.succ_le_mono size1), Nat.le_add_r.
  - specialize (Hg acc2).
    destruct (g acc2) as (r, acc3). simpl in *.
    destruct Hg as (Hg1, Hg2).

--- a/theories/NArith/Ndec.v
+++ b/theories/NArith/Ndec.v
@@ -160,7 +160,7 @@ Lemma Nleb_ltb_trans a b c :
   Nleb a b = true -> Nleb c b = false -> Nleb c a = false.
 Proof.
   unfold Nleb. intros. apply leb_correct_conv.
-  apply le_lt_trans with (m := N.to_nat b).
+  apply Nat.le_lt_trans with (m := N.to_nat b).
   apply leb_complete. assumption.
   apply leb_complete_conv. assumption.
 Qed.
@@ -169,7 +169,7 @@ Lemma Nltb_leb_trans a b c :
   Nleb b a = false -> Nleb b c = true -> Nleb c a = false.
 Proof.
   unfold Nleb. intros. apply leb_correct_conv.
-  apply lt_le_trans with (m := N.to_nat b).
+  apply Nat.lt_le_trans with (m := N.to_nat b).
   apply leb_complete_conv. assumption.
   apply leb_complete. assumption.
 Qed.
@@ -178,14 +178,14 @@ Lemma Nltb_trans a b c :
   Nleb b a = false -> Nleb c b = false -> Nleb c a = false.
 Proof.
   unfold Nleb. intros. apply leb_correct_conv.
-  apply lt_trans with (m := N.to_nat b).
+  apply Nat.lt_trans with (m := N.to_nat b).
   apply leb_complete_conv. assumption.
   apply leb_complete_conv. assumption.
 Qed.
 
 Lemma Nltb_leb_weak a b : Nleb b a = false -> Nleb a b = true.
 Proof.
-  unfold Nleb. intros. apply leb_correct. apply lt_le_weak.
+  unfold Nleb. intros. apply leb_correct. apply Nat.lt_le_incl.
   apply leb_complete_conv. assumption.
 Qed.
 
@@ -193,7 +193,7 @@ Lemma Nleb_double_mono a b :
   Nleb a b = true -> Nleb (N.double a) (N.double b) = true.
 Proof.
   unfold Nleb. intros. rewrite !N2Nat.inj_double. apply leb_correct.
-  apply mult_le_compat_l. now apply leb_complete.
+  apply Nat.mul_le_mono_l. now apply leb_complete.
 Qed.
 
 Lemma Nleb_double_plus_one_mono a b :
@@ -201,14 +201,15 @@ Lemma Nleb_double_plus_one_mono a b :
    Nleb (N.succ_double a) (N.succ_double b) = true.
 Proof.
   unfold Nleb. intros. rewrite !N2Nat.inj_succ_double. apply leb_correct.
-  apply le_n_S, mult_le_compat_l. now apply leb_complete.
+  apply le_n_S, Nat.mul_le_mono_l. now apply leb_complete.
 Qed.
 
 Lemma Nleb_double_mono_conv a b :
   Nleb (N.double a) (N.double b) = true -> Nleb a b = true.
 Proof.
   unfold Nleb. rewrite !N2Nat.inj_double. intro. apply leb_correct.
-  apply (mult_S_le_reg_l 1). now apply leb_complete.
+  apply <- (Nat.mul_le_mono_pos_l (N.to_nat a) (N.to_nat b) 2); auto.
+  now apply leb_complete.
 Qed.
 
 Lemma Nleb_double_plus_one_mono_conv a b :
@@ -216,7 +217,8 @@ Lemma Nleb_double_plus_one_mono_conv a b :
    Nleb a b = true.
 Proof.
   unfold Nleb. rewrite !N2Nat.inj_succ_double. intro. apply leb_correct.
-  apply (mult_S_le_reg_l 1). apply le_S_n. now apply leb_complete.
+  apply <- (Nat.mul_le_mono_pos_l (N.to_nat a) (N.to_nat b) 2); auto.
+  now apply leb_complete.
 Qed.
 
 Lemma Nltb_double_mono a b :

--- a/theories/NArith/Ndigits.v
+++ b/theories/NArith/Ndigits.v
@@ -105,8 +105,8 @@ Lemma Nshiftr_nat_spec : forall a n m,
   N.testbit_nat (N.shiftr_nat a n) m = N.testbit_nat a (m+n).
 Proof.
  intros a n; induction n as [|n IHn]; intros m.
- now rewrite <- plus_n_O.
- simpl. rewrite <- plus_n_Sm, <- plus_Sn_m, <- IHn.
+ now rewrite Nat.add_0_r.
+ simpl. rewrite Nat.add_succ_r, <- Nat.add_succ_l, <- IHn.
  destruct (N.shiftr_nat a n) as [|[p|p|]]; simpl; trivial.
 Qed.
 
@@ -129,7 +129,7 @@ Proof.
  rewrite Nshiftl_nat_S.
  destruct m as [|m].
  - destruct (N.shiftl_nat a n); trivial.
- - apply Lt.lt_S_n in H.
+ - apply Nat.succ_lt_mono in H.
    specialize (IHn m H).
    destruct (N.shiftl_nat a n); trivial.
 Qed.
@@ -582,8 +582,8 @@ Lemma Bv2N_Nsize_1 : forall n (bv:Bvector (S n)),
 Proof.
 apply Vector.rectS ; intros a ; simpl.
 destruct a ; compute ; split ; intros x ; now inversion x.
- intros n v IH; destruct a, (Bv2N (S n) v) ;
-  simpl ;intuition ; try discriminate.
+intros n v IH; destruct a, (Bv2N (S n) v) ;
+  simpl ; intuition ; try discriminate.
 Qed.
 
 Lemma Bv2N_upper_bound (n : nat) (bv : Bvector n) :
@@ -674,8 +674,8 @@ Proof.
 intros n bv; induction bv as [|h n bv IHbv]; intros p H.
 inversion H.
 destruct p as [|p]; simpl.
-  destruct (Bv2N n bv); destruct h; simpl in *; auto.
-  specialize IHbv with p (Lt.lt_S_n _ _ H).
+  + destruct (Bv2N n bv); destruct h; simpl in *; auto.
+  + specialize IHbv with p (proj2 (Nat.succ_lt_mono _ _) H).
     simpl in * ; destruct (Bv2N n bv); destruct h; simpl in *; auto.
 Qed.
 
@@ -692,9 +692,9 @@ Lemma Nbit_Bth: forall n p (H:p < N.size_nat n),
   N.testbit_nat n p = Bnth (N2Bv n) H.
 Proof.
 intro n; destruct n as [|n].
-intros p H; inversion H.
-induction n ; intro p; destruct p ; unfold Vector.nth_order in *; simpl in * ; auto.
-intros H ; destruct (Lt.lt_n_O _ (Lt.lt_S_n _ _ H)).
+- intros p H; inversion H.
+- induction n ; destruct p ; unfold Vector.nth_order in *; simpl in * ; auto.
+  intros H ; destruct (Nat.nlt_0_r _ (proj2 (Nat.succ_lt_mono _ _) H)).
 Qed.
 
 (** Binary bitwise operations are the same in the two worlds. *)

--- a/theories/NArith/Ndist.v
+++ b/theories/NArith/Ndist.v
@@ -8,7 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 Require Import Arith.
-Require Import Min.
 Require Import BinPos.
 Require Import BinNat.
 Require Import Ndigits.
@@ -49,7 +48,7 @@ Proof.
   simple induction k. trivial.
   generalize H0. case n. intros. inversion H3.
   intros. simpl. unfold N.testbit_nat in H. apply (H n0). simpl in H1. inversion H1. reflexivity.
-  exact (lt_S_n n1 n0 H3).
+  exact (proj2 (Nat.succ_lt_mono n1 n0) H3).
   simpl. intros n H. inversion H. intros. inversion H0.
 Qed.
 
@@ -74,7 +73,7 @@ Proof.
   intros. generalize H0 H1. case n. intros. simpl in H3. discriminate H3.
   intros. simpl. unfold Nplength in H.
   enough (ni (Pplength p0) = ni n0) by (inversion H4; reflexivity).
-  apply H. intros. change (N.testbit_nat (Npos (xO p0)) (S k) = false). apply H2. apply lt_n_S. exact H4.
+  apply H. intros. change (N.testbit_nat (Npos (xO p0)) (S k) = false). apply H2. apply -> Nat.succ_lt_mono. exact H4.
   exact H3.
   intro. case n. trivial.
   intros. simpl in H0. discriminate H0.
@@ -212,7 +211,7 @@ Qed.
 
 Lemma ni_le_le : forall m n:nat, ni_le (ni m) (ni n) -> m <= n.
 Proof.
-  unfold ni_le. unfold ni_min. intros. inversion H. apply le_min_r.
+  unfold ni_le. unfold ni_min. intros. inversion H. apply Nat.le_min_r.
 Qed.
 
 Lemma Nplength_lb :
@@ -220,7 +219,7 @@ Lemma Nplength_lb :
    (forall k:nat, k < n -> N.testbit_nat a k = false) -> ni_le (ni n) (Nplength a).
 Proof.
   simple induction a. intros. exact (ni_min_inf_r (ni n)).
-  intros. unfold Nplength. apply le_ni_le. case (le_or_lt n (Pplength p)). trivial.
+  intros. unfold Nplength. apply le_ni_le. case (Nat.le_gt_cases n (Pplength p)). trivial.
   intro. absurd (N.testbit_nat (Npos p) (Pplength p) = false).
   rewrite
    (Nplength_one (Npos p) (Pplength p)
@@ -233,7 +232,7 @@ Lemma Nplength_ub :
  forall (a:N) (n:nat), N.testbit_nat a n = true -> ni_le (Nplength a) (ni n).
 Proof.
   simple induction a. intros. discriminate H.
-  intros. unfold Nplength. apply le_ni_le. case (le_or_lt (Pplength p) n). trivial.
+  intros. unfold Nplength. apply le_ni_le. case (Nat.le_gt_cases (Pplength p) n). trivial.
   intro. absurd (N.testbit_nat (Npos p) n = true).
   rewrite
    (Nplength_zeros (Npos p) (Pplength p)
@@ -303,7 +302,7 @@ Proof.
   destruct a'. trivial.
   enough (N.testbit_nat (Npos p1) k = false) as -> by reflexivity.
   apply Nplength_zeros with (n := Pplength p1). reflexivity.
-  apply (lt_le_trans k (Pplength p) (Pplength p1)). exact H0.
+  apply (Nat.lt_le_trans k (Pplength p) (Pplength p1)). exact H0.
   apply ni_le_le. exact H.
 Qed.
 
@@ -327,3 +326,6 @@ Proof.
   rewrite N.lxor_assoc. rewrite <- (N.lxor_assoc a'' a'' a'). rewrite N.lxor_nilpotent.
   rewrite N.lxor_0_l. reflexivity.
 Qed.
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Import Min.

--- a/theories/Numbers/Cyclic/Int31/Cyclic31.v
+++ b/theories/Numbers/Cyclic/Int31/Cyclic31.v
@@ -17,7 +17,6 @@ Author: Arnaud Spiwack (+ Pierre Letouzey)
 *)
 
 Require Import List.
-Require Import Min.
 Require Export Int31.
 Require Import Znumtheory.
 Require Import Zgcd_alt.
@@ -254,7 +253,7 @@ Section Basics.
  f_equal.
  change (shiftr (nshiftr x (size - S n))) with (nshiftr x (S (size - S n))).
  replace (S (size - S n))%nat with (size - n)%nat by lia.
- apply IHn; auto with arith.
+ apply IHn; auto with zarith.
  Qed.
 
  Lemma recr_eqn : forall x, iszero x = false ->
@@ -264,7 +263,7 @@ Section Basics.
  intros.
  unfold recr.
  change x with (nshiftr x (size - size)).
- rewrite (recr_aux_converges size (S size)); auto with arith.
+ rewrite (recr_aux_converges size (S size)); auto.
  rewrite recr_aux_eqn; auto.
  Qed.
 
@@ -551,8 +550,7 @@ Section Basics.
  rewrite 2 firstr_firstl.
  f_equal.
  apply EqShiftL_le with k; auto.
- unfold size.
- auto with arith.
+ apply Nat.lt_succ_r; assumption.
  Qed.
 
  Lemma EqShiftL_twice : forall k x y,
@@ -618,7 +616,7 @@ Section Basics.
  induction n.
  intros.
  assert (firstn (size-0) (i2l x) = i2l x).
-  rewrite <- minus_n_O, <- (i2l_length x).
+  rewrite Nat.sub_0_r, <- (i2l_length x).
   induction (i2l x); simpl; f_equal; auto.
  rewrite H0; clear H0.
  reflexivity.
@@ -1563,7 +1561,7 @@ Section Int31_Specs.
  simpl; auto.
  intros.
  simpl addmuldiv31_alt.
- replace (S n) with (n+1)%nat by (rewrite plus_comm; auto).
+ replace (S n) with (n+1)%nat by (rewrite Nat.add_comm; auto).
  rewrite nat_rect_plus; simpl; auto.
  Qed.
 
@@ -1731,7 +1729,7 @@ Section Int31_Specs.
  change On with (phi_inv (Z.of_nat (31-size))).
  replace (head031_alt size x) with
    (head031_alt size x + (31 - size))%nat by auto.
- assert (size <= 31)%nat by auto with arith.
+ assert (size <= 31)%nat by reflexivity.
 
  revert x H; induction size; intros.
  simpl; auto.
@@ -1839,7 +1837,7 @@ Section Int31_Specs.
  change On with (phi_inv (Z.of_nat (31-size))).
  replace (tail031_alt size x) with
    (tail031_alt size x + (31 - size))%nat by auto.
- assert (size <= 31)%nat by auto with arith.
+ assert (size <= 31)%nat by reflexivity.
 
  revert x H; induction size; intros.
  simpl; auto.
@@ -2532,3 +2530,6 @@ Module Int31Cyclic <: CyclicType.
   Definition ops := int31_ops.
   Definition specs := int31_specs.
 End Int31Cyclic.
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Import Min.

--- a/theories/Numbers/DecimalQ.v
+++ b/theories/Numbers/DecimalQ.v
@@ -56,8 +56,7 @@ Proof.
         now revert Hn; case nzhead.
     + revert He_den'; case nb_digits as [|n]; [now simpl; rewrite Nat.add_0_r|].
       intro Hn.
-      rewrite Nat.add_succ_r, Nat.add_comm.
-      now rewrite <-le_plus_minus; [|apply le_S_n].
+      rewrite Nat.add_succ_r, Nat.sub_add; [|apply le_S_n]; auto.
 Qed.
 
 Lemma IZ_of_Z_IZ_to_Z z z' : IZ_to_Z z = Some z' -> IZ_of_Z z' = z.
@@ -295,7 +294,7 @@ Proof.
   replace m with (Neg (unorm ni)); [|now unfold m; revert Ha; case nzhead].
   case (uint_eq_dec (nzhead ni) Nil); intro Hni.
   { rewrite <-nzhead_app_nzhead, Hni, app_nil_l.
-    intro H; exfalso; revert H; apply le_not_lt, nb_digits_nzhead. }
+    intro H; exfalso; revert H; apply Nat.le_ngt, nb_digits_nzhead. }
   clear m; set (m := match nzhead ni with Nil => _ | _ => _ end).
   replace m with (Neg (nzhead ni)); [|now unfold m; revert Hni; case nzhead].
   now rewrite (unorm_nzhead _ Hni).

--- a/theories/Numbers/DecimalR.v
+++ b/theories/Numbers/DecimalR.v
@@ -39,7 +39,7 @@ Proof.
     case Nat.ltb_spec; intro He_den'.
     - apply del_head_nonnil.
       revert He_den'; case nb_digits as [|n]; [now simpl|].
-      now intro H; simpl; apply le_lt_n_Sm, Nat.le_sub_l.
+      now intro H; simpl; apply Nat.lt_succ_r, Nat.le_sub_l.
     - apply nb_digits_n0.
       now rewrite nb_digits_iter_D0, Nat.sub_add. }
   replace (match den with 1%positive => _ | _ => _ end)

--- a/theories/Numbers/HexadecimalFacts.v
+++ b/theories/Numbers/HexadecimalFacts.v
@@ -156,7 +156,7 @@ Qed.
 Lemma del_head_spec_large n d : length (to_list d) < n -> del_head n d = zero.
 Proof.
   revert d; induction n; intro d; [now case d|].
-  now case d; [|intro d'; simpl; intro H; rewrite (IHn _ (lt_S_n _ _ H))..].
+  now case d; [|intro d'; simpl; intro H; rewrite (IHn _ (proj2 (Nat.succ_lt_mono _ _) H))..].
 Qed.
 
 Lemma nb_digits_0 d : nb_digits d = 0 -> d = Nil.
@@ -236,7 +236,7 @@ Proof.
   { unfold unorm; rewrite Hn; simpl; intro H.
     revert H Hn; induction d; [now simpl|intros _|now intros _..].
     case (uint_eq_dec d Nil); simpl; intros H Hn; [now rewrite H|].
-    rewrite Nat.sub_0_r, (le_plus_minus 1 (nb_digits d)).
+    rewrite Nat.sub_0_r, <- (Nat.sub_add 1 (nb_digits d)), Nat.add_comm.
     { now simpl; rewrite IHd. }
     revert H; case d; [now simpl|intros u _; apply le_n_S, Nat.le_0_l..]. }
   intros _; rewrite (unorm_nzhead _ Hn); apply iter_D0_nzhead.
@@ -249,7 +249,7 @@ Proof.
   intro Hl; apply to_list_inj; revert Hl.
   rewrite !nb_digits_spec, app_spec, !nzhead_spec, app_spec.
   induction (to_list d) as [|h t IHl].
-  { now simpl; intro H; exfalso; revert H; apply le_not_lt, length_lnzhead. }
+  { now simpl; intro H; exfalso; revert H; apply Nat.le_ngt, length_lnzhead. }
   rewrite <-List.app_comm_cons.
   now case h; [simpl; intro Hl; apply IHl|..].
 Qed.
@@ -263,7 +263,7 @@ Proof.
   induction (to_list d) as [|h t IHl]; [now simpl|].
   rewrite <-List.app_comm_cons.
   now case h; [| simpl; rewrite List.app_length; intro Hl; exfalso; revert Hl;
-    apply le_not_lt, le_plus_r..].
+    apply Nat.le_ngt; rewrite Nat.add_comm; apply Nat.le_add_r..].
 Qed.
 
 Lemma nzhead_app_nil_r d d' : nzhead (app d d') = Nil -> nzhead d' = Nil.
@@ -278,8 +278,8 @@ Proof.
   rewrite !nb_digits_spec, !nzhead_spec, app_spec.
   induction (to_list d) as [|h t IHl]; [now simpl|].
   now case h; [now simpl|..];
-    simpl;intro H; exfalso; revert H; apply le_not_lt;
-    rewrite List.app_length; apply le_plus_r.
+    simpl;intro H; exfalso; revert H; apply Nat.le_ngt;
+    rewrite List.app_length, Nat.add_comm; apply Nat.le_add_r.
 Qed.
 
 Lemma nzhead_app_nil_l d d' : nzhead (app d d') = Nil -> nzhead d = Nil.
@@ -315,7 +315,7 @@ Lemma unorm_app_l d d' :
 Proof.
   case (uint_eq_dec d' Nil); [now intros->; rewrite !app_nil_r|intro Hd'].
   case (uint_eq_dec (nzhead (app d d')) Nil).
-  { unfold unorm; intros->; simpl; intro H; exfalso; revert H; apply le_not_lt.
+  { unfold unorm; intros->; simpl; intro H; exfalso; revert H; apply Nat.le_ngt.
     now revert Hd'; case d'; [|intros d'' _; apply le_n_S, Peano.le_0_n..]. }
   intro Ha; rewrite (unorm_nzhead _ Ha).
   intro Hn; generalize Hn; rewrite (nzhead_app_l _ _ Hn).
@@ -345,15 +345,15 @@ Proof.
   case d as [d|d]; [now simpl; intro H; apply f_equal, unorm_app_l|].
   simpl; unfold unorm.
   case (uint_eq_dec (nzhead (app d d')) Nil).
-  { intros->; simpl; intro H; exfalso; revert H; apply le_not_lt.
-    now revert Hd'; case d'; [|intros d'' _; apply le_n_S, Peano.le_0_n..]. }
+  { intros->; simpl; intro H; exfalso; revert H; apply Nat.le_ngt.
+    now revert Hd'; case d'; [|intros d'' _; apply -> Nat.succ_le_mono; apply Nat.le_0_l..]. }
   set (m := match nzhead _ with Nil => _ | _ => _ end).
   intro Ha.
   replace m with (nzhead (app d d')).
   2:{ now unfold m; revert Ha; case nzhead. }
   intro Hn; generalize Hn; rewrite (nzhead_app_l _ _ Hn).
   case (uint_eq_dec (app (nzhead d) d') Nil).
-  { intros->; simpl; intro H; exfalso; revert H; apply le_not_lt, Nat.le_0_l. }
+  { intros->; simpl; intro H; exfalso; revert H; apply Nat.le_ngt, Nat.le_0_l. }
   clear m; set (m := match app _ _ with Nil => _ | _ => _ end).
   intro Ha'.
   replace m with (Neg (app (nzhead d) d')); [|now unfold m; revert Ha'; case app].
@@ -380,7 +380,7 @@ Proof.
   rewrite nb_digits_spec; intro Hn.
   apply to_list_inj.
   rewrite del_head_spec_small.
-  2:{ now rewrite app_spec, List.app_length; apply le_plus_trans. }
+  2:{ now rewrite app_spec, List.app_length, <- Nat.le_add_r. }
   rewrite !app_spec, (del_head_spec_small _ _ Hn).
   rewrite List.skipn_app.
   now rewrite (proj2 (Nat.sub_0_le _ _) Hn).
@@ -413,7 +413,8 @@ Proof.
   rewrite rev_spec.
   set (n' := _ - n).
   assert (Hn' : n = length (to_list d) - n').
-  { now apply plus_minus; rewrite  Nat.add_comm; symmetry; apply le_plus_minus_r. }
+  { now rewrite <- (Nat.add_sub (length (to_list d)) n), Nat.add_comm,
+                <- 2 Nat.add_sub_assoc, Nat.sub_diag; trivial. }
   now rewrite Hn', <-List.firstn_skipn_rev, List.firstn_skipn, of_list_to_list.
 Qed.
 
@@ -430,7 +431,7 @@ Proof.
   replace (_ - _) with (nb_digits (unorm (abs i))).
   - now rewrite del_head_app; [rewrite del_head_nb_digits|].
   - rewrite !nb_digits_spec, app_spec, List.app_length.
-    now rewrite Nat.add_comm, minus_plus.
+    symmetry; apply Nat.add_sub.
 Qed.
 
 Lemma del_tail_app_int_exact i f :
@@ -558,7 +559,7 @@ Lemma del_head_nonnil n u :
   n < nb_digits u -> del_head n u <> Nil.
 Proof.
   now revert n; induction u; intro n;
-    [|case n; [|intro n'; simpl; intro H; apply IHu, lt_S_n]..].
+    [|case n; [|intro n'; simpl; intro H; apply IHu, Nat.succ_lt_mono]..].
 Qed.
 
 Lemma del_tail_nonnil n u :
@@ -619,7 +620,7 @@ Proof.
   rewrite List.skipn_rev, List.rev_involutive.
   generalize (f_equal to_list Hu) Hn; rewrite nzhead_spec; intro Hu'.
   case (to_list u) as [|h t].
-  { simpl; intro H; exfalso; revert H; apply le_not_lt, Peano.le_0_n. }
+  { simpl; intro H; exfalso; revert H; apply Nat.le_ngt, Nat.le_0_l. }
   intro Hn'; generalize (Nat.sub_gt _ _ Hn'); rewrite List.rev_length.
   case (_ - _); [now simpl|]; intros n' _.
   rewrite List.firstn_cons, lnzhead_head_nd0; [now simpl|].
@@ -637,7 +638,7 @@ Lemma unorm_del_tail_unorm n u :
 Proof.
   case (uint_eq_dec (nzhead u) Nil).
   - unfold unorm; intros->; case n; [now simpl|]; intro n'.
-    now simpl; intro H; exfalso; generalize (lt_S_n _ _ H).
+    now simpl; intro H; exfalso; generalize (proj2 (Nat.succ_lt_mono _ _) H).
   - unfold unorm.
     set (m := match nzhead u with Nil => zero | _ => _ end).
     intros H.
@@ -655,7 +656,7 @@ Proof.
   case d; clear d; intros u; simpl.
   - now intro H; simpl; rewrite unorm_del_tail_unorm.
   - case (uint_eq_dec (nzhead u) Nil); intro Hu.
-    + now rewrite Hu; case n; [|intros n' Hn'; generalize (lt_S_n _ _ Hn')].
+    + now rewrite Hu; case n; [|intros n' Hn'; generalize (proj2 (Nat.succ_lt_mono _ _) Hn')].
     + set (m := match nzhead u with Nil => Pos zero | _ => _ end).
       replace m with (Neg (nzhead u)); [|now unfold m; revert Hu; case nzhead].
       unfold del_tail_int.

--- a/theories/Numbers/HexadecimalQ.v
+++ b/theories/Numbers/HexadecimalQ.v
@@ -57,8 +57,7 @@ Proof.
         now revert Hn; case nzhead.
     + revert He_den'; case nb_digits as [|n]; [now simpl; rewrite Nat.add_0_r|].
       intro Hn.
-      rewrite Nat.add_succ_r, Nat.add_comm.
-      now rewrite <-le_plus_minus; [|apply le_S_n].
+      rewrite Nat.add_succ_r, Nat.sub_add; [|apply le_S_n]; auto.
 Qed.
 
 Lemma IZ_of_Z_IZ_to_Z z z' : IZ_to_Z z = Some z' -> IZ_of_Z z' = z.
@@ -295,7 +294,7 @@ Proof.
   replace m with (Neg (unorm ni)); [|now unfold m; revert Ha; case nzhead].
   case (uint_eq_dec (nzhead ni) Nil); intro Hni.
   { rewrite <-nzhead_app_nzhead, Hni, app_nil_l.
-    intro H; exfalso; revert H; apply le_not_lt, nb_digits_nzhead. }
+    intro H; exfalso; revert H; apply Nat.le_ngt, nb_digits_nzhead. }
   clear m; set (m := match nzhead ni with Nil => _ | _ => _ end).
   replace m with (Neg (nzhead ni)); [|now unfold m; revert Hni; case nzhead].
   now rewrite (unorm_nzhead _ Hni).

--- a/theories/Numbers/HexadecimalR.v
+++ b/theories/Numbers/HexadecimalR.v
@@ -41,7 +41,7 @@ Proof.
     case Nat.ltb_spec; intro He_den'.
     - apply del_head_nonnil.
       revert He_den'; case nb_digits as [|n]; [now simpl|].
-      now intro H; simpl; apply le_lt_n_Sm, Nat.le_sub_l.
+      now intro H; simpl; apply Nat.lt_succ_r, Nat.le_sub_l.
     - apply nb_digits_n0.
       now rewrite nb_digits_iter_D0, Nat.sub_add. }
   replace (match den with 1%positive => _ | _ => _ end)

--- a/theories/Numbers/NatInt/NZDomain.v
+++ b/theories/Numbers/NatInt/NZDomain.v
@@ -9,7 +9,7 @@
 (************************************************************************)
 
 Require Export NumPrelude NZAxioms.
-Require Import NZBase NZOrder NZAddOrder Plus Minus.
+Require Import NZBase NZOrder NZAddOrder PeanoNat.
 
 (** In this file, we investigate the shape of domains satisfying
     the [NZDomainSig] interface. In particular, we define a
@@ -292,20 +292,21 @@ Proof.
 induction n as [|n IH]; destruct m; repeat rewrite ofnat_zero; split.
 intro H; elim (lt_irrefl _ H).
 inversion 1.
-auto with arith.
+intros _; apply Nat.lt_0_succ.
 intros; apply ofnat_S_gt_0.
 intro H; elim (lt_asymm _ _ H); apply ofnat_S_gt_0.
 inversion 1.
-rewrite !ofnat_succ, <- succ_lt_mono, IH; auto with arith.
-rewrite !ofnat_succ, <- succ_lt_mono, IH; auto with arith.
+rewrite !ofnat_succ, <- succ_lt_mono, IH; apply Nat.succ_lt_mono.
+rewrite !ofnat_succ, <- succ_lt_mono, IH; apply Nat.succ_lt_mono.
 Qed.
 
 Lemma ofnat_le : forall n m : nat, [n]<=[m] <-> (n<=m)%nat.
 Proof.
 intros. rewrite lt_eq_cases, ofnat_lt, ofnat_eq.
 split.
-destruct 1; subst; auto with arith.
-apply Lt.le_lt_or_eq.
+destruct 1; subst; auto.
+apply Nat.lt_le_incl; assumption.
+apply Nat.lt_eq_cases.
 Qed.
 
 End NZOfNatOrd.
@@ -336,7 +337,7 @@ Lemma ofnat_mul : forall n m, [n*m] == [n]*[m].
 Proof.
  induction n; simpl; intros.
  symmetry. apply mul_0_l.
- rewrite plus_comm.
+ rewrite Nat.add_comm.
  rewrite ofnat_add, mul_succ_l.
  now f_equiv.
 Qed.
@@ -352,14 +353,17 @@ Lemma ofnat_sub : forall n m, m<=n -> [n-m] == [n]-[m].
 Proof.
  intros n m H. rewrite ofnat_sub_r.
  revert n H. induction m. intros.
- rewrite <- minus_n_O. now simpl.
+ rewrite Nat.sub_0_r. now simpl.
  intros.
  destruct n.
  inversion H.
  rewrite nat_rect_succ_r.
  simpl.
- etransitivity. apply IHm. auto with arith.
+ etransitivity. apply IHm; apply <- Nat.succ_le_mono; assumption.
     eapply nat_rect_wd; [symmetry;apply pred_succ|apply pred_wd].
 Qed.
 
 End NZOfNatOps.
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Import Plus Minus.

--- a/theories/Numbers/Natural/Peano/NPeano.v
+++ b/theories/Numbers/Natural/Peano/NPeano.v
@@ -10,7 +10,7 @@
 (*                      Evgeny Makarov, INRIA, 2007                     *)
 (************************************************************************)
 
-Require Import PeanoNat Even NAxioms.
+Require Import PeanoNat NAxioms.
 
 (** This file is DEPRECATED ! Use [PeanoNat] (or [Arith]) instead. *)
 
@@ -20,73 +20,128 @@ Module Nat <: NAxiomsSig := Nat.
 
 (** Compat notations for stuff that used to be at the beginning of NPeano. *)
 
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.leb instead.")]
 Notation leb := Nat.leb (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.ltb instead.")]
 Notation ltb := Nat.ltb (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.leb_le instead.")]
 Notation leb_le := Nat.leb_le (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.ltb_lt instead.")]
 Notation ltb_lt := Nat.ltb_lt (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.pow instead.")]
 Notation pow := Nat.pow (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.pow_0_r instead.")]
 Notation pow_0_r := Nat.pow_0_r (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.pow_succ_r instead.")]
 Notation pow_succ_r := Nat.pow_succ_r (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.square instead.")]
 Notation square := Nat.square (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.square_rec instead.")]
 Notation square_spec := Nat.square_spec (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.Even instead.")]
 Notation Even := Nat.Even (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.Odd instead.")]
 Notation Odd := Nat.Odd (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.even instead.")]
 Notation even := Nat.even (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.odd instead.")]
 Notation odd := Nat.odd (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.even_spec instead.")]
 Notation even_spec := Nat.even_spec (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.odd_spec instead.")]
 Notation odd_spec := Nat.odd_spec (only parsing).
 
-Lemma Even_equiv n : Even n <-> Even.even n.
-Proof. symmetry. apply Even.even_equiv. Qed.
-Lemma Odd_equiv n : Odd n <-> Even.odd n.
-Proof. symmetry. apply Even.odd_equiv. Qed.
-
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.divmod instead.")]
 Notation divmod := Nat.divmod (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.div instead.")]
 Notation div := Nat.div (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.modulo instead.")]
 Notation modulo := Nat.modulo (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.divmod_spec instead.")]
 Notation divmod_spec := Nat.divmod_spec (only parsing).
-Notation div_mod := Nat.div_mod (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.mod_bound_pos instead.")]
 Notation mod_bound_pos := Nat.mod_bound_pos (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.sqrt_iter instead.")]
 Notation sqrt_iter := Nat.sqrt_iter (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.sqrt instead.")]
 Notation sqrt := Nat.sqrt (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.sqrt_iter_spec instead.")]
 Notation sqrt_iter_spec := Nat.sqrt_iter_spec (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.sqrt_spec instead.")]
 Notation sqrt_spec := Nat.sqrt_spec (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.log2_iter instead.")]
 Notation log2_iter := Nat.log2_iter (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.log2 instead.")]
 Notation log2 := Nat.log2 (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.log2_iter_spec instead.")]
 Notation log2_iter_spec := Nat.log2_iter_spec (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.log2_spec instead.")]
 Notation log2_spec := Nat.log2_spec (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.log2_nonpos instead.")]
 Notation log2_nonpos := Nat.log2_nonpos (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.gcd instead.")]
 Notation gcd := Nat.gcd (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.divide instead.")]
 Notation divide := Nat.divide (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.gcd_divide instead.")]
 Notation gcd_divide := Nat.gcd_divide (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.gcd_divide_l instead.")]
 Notation gcd_divide_l := Nat.gcd_divide_l (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.gcd_divide_r instead.")]
 Notation gcd_divide_r := Nat.gcd_divide_r (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.gcd_greatest instead.")]
 Notation gcd_greatest := Nat.gcd_greatest (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.testbit instead.")]
 Notation testbit := Nat.testbit (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.shiftl instead.")]
 Notation shiftl := Nat.shiftl (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.shiftr instead.")]
 Notation shiftr := Nat.shiftr (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.bitwise instead.")]
 Notation bitwise := Nat.bitwise (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.land instead.")]
 Notation land := Nat.land (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.lor instead.")]
 Notation lor := Nat.lor (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.ldiff instead.")]
 Notation ldiff := Nat.ldiff (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.lxor instead.")]
 Notation lxor := Nat.lxor (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.double_twice instead.")]
 Notation double_twice := Nat.double_twice (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.testbit_0_l instead.")]
 Notation testbit_0_l := Nat.testbit_0_l (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.testbit_odd_0 instead.")]
 Notation testbit_odd_0 := Nat.testbit_odd_0 (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.testbit_even_0 instead.")]
 Notation testbit_even_0 := Nat.testbit_even_0 (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.testbit_odd_succ instead.")]
 Notation testbit_odd_succ := Nat.testbit_odd_succ (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.testbit_even_succ instead.")]
 Notation testbit_even_succ := Nat.testbit_even_succ (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.shiftr_spec instead.")]
 Notation shiftr_spec := Nat.shiftr_spec (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.shiftr_spec_high instead.")]
 Notation shiftl_spec_high := Nat.shiftl_spec_high (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.shiftr_spec_low instead.")]
 Notation shiftl_spec_low := Nat.shiftl_spec_low (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.div2_bitwise instead.")]
 Notation div2_bitwise := Nat.div2_bitwise (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.odd_bitwise instead.")]
 Notation odd_bitwise := Nat.odd_bitwise (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.div2_decr instead.")]
 Notation div2_decr := Nat.div2_decr (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.testbit_bitwise_1 instead.")]
 Notation testbit_bitwise_1 := Nat.testbit_bitwise_1 (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.testbit_bitwise_2 instead.")]
 Notation testbit_bitwise_2 := Nat.testbit_bitwise_2 (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.land_spec instead.")]
 Notation land_spec := Nat.land_spec (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.ldiff_spec instead.")]
 Notation ldiff_spec := Nat.ldiff_spec (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.lor_spec instead.")]
 Notation lor_spec := Nat.lor_spec (only parsing).
+#[deprecated(since="8.16",note="The NPeano file is obsolete. Use Nat.lxor_spec instead.")]
 Notation lxor_spec := Nat.lxor_spec (only parsing).
 
 Infix "<=?" := Nat.leb (at level 70) : nat_scope.
@@ -95,3 +150,5 @@ Infix "^" := Nat.pow : nat_scope.
 Infix "/" := Nat.div : nat_scope.
 Infix "mod" := Nat.modulo (at level 40, no associativity) : nat_scope.
 Notation "( x | y )" := (Nat.divide x y) (at level 0) : nat_scope.
+
+Require Import Even.

--- a/theories/PArith/BinPos.v
+++ b/theories/PArith/BinPos.v
@@ -11,7 +11,7 @@
 
 Require Export BinNums.
 Require Import Eqdep_dec EqdepFacts RelationClasses Morphisms Setoid
- Equalities Orders OrdersFacts GenericMinMax Le Plus.
+ Equalities Orders OrdersFacts GenericMinMax PeanoNat.
 
 Require Export BinPosDef.
 
@@ -1823,17 +1823,17 @@ Proof.
  destruct a as [a|a|], b as [b|b|]; simpl; try case compare_spec; simpl; auto.
  (* Lt *)
  intros LT LE p Hp1 Hp2. apply IHn; clear IHn; trivial.
- apply le_S_n in LE. eapply Le.le_trans; [|eapply LE].
- rewrite plus_comm, <- plus_n_Sm, <- plus_Sn_m.
- apply plus_le_compat; trivial.
+ apply le_S_n in LE. eapply Nat.le_trans; [|eapply LE].
+ rewrite Nat.add_comm, <- plus_n_Sm, <- plus_Sn_m.
+ apply Nat.add_le_mono; trivial.
  apply size_nat_monotone, sub_decr, LT.
  apply divide_xO_xI with a; trivial.
  apply (divide_add_cancel_l p _ a~1); trivial.
  now rewrite <- sub_xI_xI, sub_add.
  (* Gt *)
  intros LT LE p Hp1 Hp2. apply IHn; clear IHn; trivial.
- apply le_S_n in LE. eapply Le.le_trans; [|eapply LE].
- apply plus_le_compat; trivial.
+ apply le_S_n in LE. eapply Nat.le_trans; [|eapply LE].
+ apply Nat.add_le_mono; trivial.
  apply size_nat_monotone, sub_decr, LT.
  apply divide_xO_xI with b; trivial.
  apply (divide_add_cancel_l p _ b~1); trivial.
@@ -1852,12 +1852,12 @@ Proof.
  change (gcdn n a b)~0 with (2*(gcdn n a b)).
  apply divide_mul_r.
  apply IHn; clear IHn.
- apply le_S_n in LE. apply le_Sn_le. now rewrite plus_n_Sm.
+ apply le_S_n in LE. rewrite <- plus_n_Sm in LE. now apply Nat.lt_le_incl.
  apply divide_xO_xI with p; trivial. now exists 1.
  apply divide_xO_xI with p; trivial. now exists 1.
  apply divide_xO_xO.
  apply IHn; clear IHn.
- apply le_S_n in LE. apply le_Sn_le. now rewrite plus_n_Sm.
+ apply le_S_n in LE. rewrite <- plus_n_Sm in LE. now apply Nat.lt_le_incl.
  now apply divide_xO_xO.
  now apply divide_xO_xO.
  exists (gcdn n a b)~0. now rewrite mul_1_r.
@@ -2151,3 +2151,6 @@ Qed.
 (** Re-export the notation for those who just [Import BinPos] *)
 Number Notation positive Pos.of_num_int Pos.to_num_hex_uint : hex_positive_scope.
 Number Notation positive Pos.of_num_int Pos.to_num_uint : positive_scope.
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Import Le Plus.

--- a/theories/PArith/Pnat.v
+++ b/theories/PArith/Pnat.v
@@ -73,7 +73,7 @@ Qed.
 
 Lemma is_pos p : 0 < to_nat p.
 Proof.
- destruct (is_succ p) as (n,->). auto with arith.
+ destruct (is_succ p) as (n,->). apply Nat.lt_0_succ.
 Qed.
 
 (** [Pos.to_nat] is a bijection between [positive] and

--- a/theories/Reals/Abstract/ConstructiveLUB.v
+++ b/theories/Reals/Abstract/ConstructiveLUB.v
@@ -262,7 +262,7 @@ Proof.
   exists l. split.
   - intros. (* find an upper point between the limit and r *)
     destruct (CR_cv_open_above _ (CR_of_Q R r) l lcv H0) as [p pmaj].
-    specialize (pmaj p (le_refl p)).
+    specialize (pmaj p (Nat.le_refl p)).
     unfold proj1_sig in pmaj.
     destruct (DDcut_limit upcut (1 # Pos.of_nat p) eq_refl) as [q qmaj].
     apply (DDinterval upcut q). 2: apply qmaj.
@@ -284,7 +284,7 @@ Proof.
     destruct (CRup_nat (CRinv R _ (inr H2))) as [i imaj].
     destruct i. exfalso. simpl in imaj.
     exact (CRlt_asym _ _ imaj (CRinv_0_lt_compat R _ (inr H2) H2)).
-    specialize (pmaj (max (S i) (S p)) (le_trans p (S p) _ (le_S p p (le_refl p)) (Nat.le_max_r (S i) (S p)))).
+    specialize (pmaj (max (S i) (S p)) (Nat.le_trans p (S p) _ (le_S p p (Nat.le_refl p)) (Nat.le_max_r (S i) (S p)))).
     unfold proj1_sig in pmaj.
     destruct (DDcut_limit upcut (1 # Pos.of_nat (max (S i) (S p))) eq_refl)
       as [q qmaj].

--- a/theories/Reals/Abstract/ConstructiveLimits.v
+++ b/theories/Reals/Abstract/ConstructiveLimits.v
@@ -77,8 +77,8 @@ Proof.
     rewrite Radd_comm. reflexivity.
   - apply (CRle_trans _ _ _ (CRabs_triang _ _)).
     apply (CRle_trans _ (CRplus R (CR_of_Q R (1 # 2*p)) (CR_of_Q R (1 # 2*p)))).
-    apply CRplus_le_compat. apply imaj, (le_trans _ _ _ (Nat.le_max_l _ _) H).
-    apply jmaj, (le_trans _ _ _ (Nat.le_max_r _ _) H).
+    apply CRplus_le_compat. apply imaj, (Nat.le_trans _ _ _ (Nat.le_max_l _ _) H).
+    apply jmaj, (Nat.le_trans _ _ _ (Nat.le_max_r _ _) H).
     apply (CRle_trans _ (CR_of_Q R ((1 # 2 * p) + (1 # 2 * p)))).
     apply CR_of_Q_plus. apply CR_of_Q_le.
     rewrite Qinv_plus_distr. setoid_replace (1 + 1 # 2 * p) with (1 # p).
@@ -104,7 +104,7 @@ Proof.
   - intro abs. destruct (CR_Q_dense R _ _ abs) as [q [H0 H]].
     destruct (Qarchimedean (/(-q))) as [p pmaj].
     specialize (H1 p) as [n nmaj].
-    specialize (nmaj n (le_refl n)). apply nmaj.
+    specialize (nmaj n (Nat.le_refl n)). apply nmaj.
     apply (CRlt_trans _ (CR_of_Q R (-q))). apply CR_of_Q_lt.
     apply H2 in pmaj.
     apply (Qmult_lt_r _ _ (1#p)) in pmaj. 2: reflexivity.
@@ -124,7 +124,7 @@ Proof.
   - intro abs. destruct (CR_Q_dense R _ _ abs) as [q [H0 H]].
     destruct (Qarchimedean (/q)) as [p pmaj].
     specialize (H1 p) as [n nmaj].
-    specialize (nmaj n (le_refl n)). apply nmaj.
+    specialize (nmaj n (Nat.le_refl n)). apply nmaj.
     apply (CRlt_trans _ (CR_of_Q R q)). apply CR_of_Q_lt.
     apply H2 in pmaj.
     apply (Qmult_lt_r _ _ (1#p)) in pmaj. 2: reflexivity.
@@ -244,7 +244,7 @@ Proof.
   intros. intro abs.
   destruct (Un_cv_nat_real _ l H (-l)) as [N H1].
   rewrite <- CRopp_0. apply CRopp_gt_lt_contravar. apply abs.
-  specialize (H1 N (le_refl N)).
+  specialize (H1 N (Nat.le_refl N)).
   pose proof (CRabs_def R (An N - l) (CRabs R (An N - l))) as [_ H2].
   apply (CRle_lt_trans _ _ _ (CRle_abs _)) in H1.
   apply (H0 N). apply (CRplus_lt_reg_r (-l)).
@@ -382,11 +382,11 @@ Proof.
   apply (CRplus_lt_compat_r (-l)) in r. rewrite CRplus_opp_r in r.
   destruct (Un_cv_nat_real _ l H0 (A - l) r) as [n H1].
   apply (H (n+N)%nat).
-  rewrite <- (plus_0_l N). rewrite Nat.add_assoc.
-  apply Nat.add_le_mono_r. apply le_0_n.
+  rewrite <- (Nat.add_0_l N), Nat.add_assoc.
+  apply Nat.add_le_mono_r, Nat.le_0_l.
   specialize (H1 (n+N)%nat). apply (CRplus_lt_reg_r (-l)).
-  assert (n + N >= n)%nat. rewrite <- (plus_0_r n). rewrite <- plus_assoc.
-  apply Nat.add_le_mono_l. apply le_0_n. specialize (H1 H2).
+  assert (n + N >= n)%nat. rewrite <- (Nat.add_0_r n), <- Nat.add_assoc.
+  apply Nat.add_le_mono_l, Nat.le_0_l. specialize (H1 H2).
   apply (CRle_lt_trans _ (CRabs R (u (n + N)%nat - l))).
   apply CRle_abs. assumption.
 Qed.
@@ -401,15 +401,15 @@ Proof.
   apply (CRplus_lt_compat_r (-A)) in r. rewrite CRplus_opp_r in r.
   destruct (Un_cv_nat_real _ l H0 (l-A) r) as [n H1].
   apply (H (n+N)%nat).
-  - rewrite <- (plus_0_l N). apply Nat.add_le_mono_r. apply le_0_n.
+  - rewrite <- (Nat.add_0_l N). apply Nat.add_le_mono_r, Nat.le_0_l.
   - specialize (H1 (n+N)%nat). apply (CRplus_lt_reg_l R (l - A - u (n+N)%nat)).
     unfold CRminus. repeat rewrite CRplus_assoc.
     rewrite CRplus_opp_l, CRplus_0_r, (CRplus_comm (-A)).
     rewrite CRplus_assoc, CRplus_opp_r, CRplus_0_r.
     apply (CRle_lt_trans _ _ _ (CRle_abs _)).
     fold (l - u (n+N)%nat). rewrite CRabs_minus_sym. apply H1.
-    rewrite <- (plus_0_r n). rewrite <- plus_assoc.
-    apply Nat.add_le_mono_l. apply le_0_n.
+    rewrite <- (Nat.add_0_r n), <- Nat.add_assoc.
+    apply Nat.add_le_mono_l, Nat.le_0_l.
 Qed.
 
 Lemma CR_cv_le : forall {R : ConstructiveReals}
@@ -464,9 +464,9 @@ Proof.
   specialize (H eps) as [N Nmaj].
   exists (N+k)%nat. intros n H.
   destruct (Nat.le_exists_sub k n).
-  apply (le_trans _ (N + k)). 2: exact H.
-  apply (le_trans _ (0 + k)). apply le_refl.
-  rewrite <- Nat.add_le_mono_r. apply le_0_n.
+  apply (Nat.le_trans _ (N + k)). 2: exact H.
+  apply (Nat.le_trans _ (0 + k)). apply Nat.le_refl.
+  rewrite <- Nat.add_le_mono_r. apply Nat.le_0_l.
   destruct H0.
   subst n. apply Nmaj. unfold ge in H.
   rewrite <- Nat.add_le_mono_r in H. exact H.
@@ -477,5 +477,6 @@ Lemma CR_cv_shift' :
     CR_cv R f l -> CR_cv R (fun n => f (n + k)%nat) l.
 Proof.
   intros R f' k l cvf eps; destruct (cvf eps) as [N Pn].
-  exists N; intros n nN; apply Pn; auto with arith.
+  exists N; intros n nN; apply Pn; auto.
+  apply Nat.le_trans with n; [ assumption | apply Nat.le_add_r ].
 Qed.

--- a/theories/Reals/Abstract/ConstructivePower.v
+++ b/theories/Reals/Abstract/ConstructivePower.v
@@ -239,7 +239,7 @@ Proof.
     exfalso. inversion H0. pose proof (Pos2Nat.is_pos n).
     rewrite H3 in H2. inversion H2.
     apply Pos2Z.pos_le_pos. apply Pos2Nat.inj_le.
-    apply (le_trans _ _ _ H0). rewrite SuccNat2Pos.id_succ. apply le_refl.
+    apply (Nat.le_trans _ _ _ H0). rewrite SuccNat2Pos.id_succ. apply Nat.le_refl.
     apply (CRmult_eq_reg_l (CR_of_Q R 2)). right. exact H1.
     rewrite CRinv_r. rewrite <- CR_of_Q_mult.
     setoid_replace (2 * (1 # 2))%Q with 1%Q.

--- a/theories/Reals/Abstract/ConstructiveRealsMorphisms.v
+++ b/theories/Reals/Abstract/ConstructiveRealsMorphisms.v
@@ -1027,11 +1027,11 @@ Proof.
     rewrite <- CR_of_Q_plus. apply CR_of_Q_le. apply Qplus_le_r.
     unfold Qle, Qnum, Qden. do 2 rewrite Z.mul_1_l.
     apply Pos2Z.pos_le_pos, Pos2Nat.inj_le.
-    destruct n. destruct n0. apply le_refl.
-    rewrite (Nat2Pos.id (S n0)). apply le_n_S, le_0_n. discriminate.
+    destruct n. destruct n0. apply Nat.le_refl.
+    rewrite (Nat2Pos.id (S n0)). apply -> Nat.succ_le_mono; apply Nat.le_0_l. discriminate.
     destruct n0. exfalso; inversion H1.
     rewrite Nat2Pos.id, Nat2Pos.id. exact H1. discriminate. discriminate.
-  - specialize (nmaj n (le_refl n)).
+  - specialize (nmaj n (Nat.le_refl n)).
     destruct (CR_Q_limit x n). apply CR_of_Q_lt.
     rewrite <- CR_of_Q_plus in nmaj. apply lt_CR_of_Q in nmaj. exact nmaj.
 Qed.

--- a/theories/Reals/Abstract/ConstructiveSum.v
+++ b/theories/Reals/Abstract/ConstructiveSum.v
@@ -36,10 +36,10 @@ Lemma CRsum_eq :
     CRsum An N == CRsum Bn N.
 Proof.
   induction N.
-  - intros. exact (H O (le_refl _)).
+  - intros. exact (H O (Nat.le_refl _)).
   - intros. simpl. apply CRplus_morph. apply IHN.
-    intros. apply H. apply (le_trans _ N _ H0), le_S, le_refl.
-    apply H, le_refl.
+    intros. apply H. apply (Nat.le_trans _ N _ H0), le_S, Nat.le_refl.
+    apply H, Nat.le_refl.
 Qed.
 
 Lemma sum_eq_R0 : forall {R : ConstructiveReals} (un : nat -> CRcarrier R) (n : nat),
@@ -94,10 +94,10 @@ Lemma sum_Rle : forall {R : ConstructiveReals} (un vn : nat -> CRcarrier R) (n :
     -> CRsum un n <= CRsum vn n.
 Proof.
   induction n.
-  - intros. apply H. apply le_refl.
+  - intros. apply H. apply Nat.le_refl.
   - intros. simpl. apply CRplus_le_compat. apply IHn.
-    intros. apply H. apply (le_trans _ n _ H0). apply le_S, le_refl.
-    apply H. apply le_refl.
+    intros. apply H. apply (Nat.le_trans _ n _ H0). apply le_S, Nat.le_refl.
+    apply H. apply Nat.le_refl.
 Qed.
 
 Lemma Abs_sum_maj : forall {R : ConstructiveReals} (un vn : nat -> CRcarrier R),
@@ -127,7 +127,7 @@ Proof.
     unfold CRminus. rewrite CRopp_plus_distr, CRopp_involutive, CRplus_comm.
     reflexivity. assumption. assumption.
   - destruct (Nat.le_exists_sub p n) as [k [maj _]]. unfold lt in l.
-    apply (le_trans p (S p)). apply le_S. apply le_refl. assumption.
+    apply (Nat.le_trans p (S p)). apply le_S. apply Nat.le_refl. assumption.
     subst n. rewrite max_l. rewrite min_r.
     destruct k. simpl. unfold CRminus. rewrite CRplus_opp_r.
     rewrite CRplus_opp_r. rewrite CRabs_right. apply CRle_refl.
@@ -142,8 +142,8 @@ Proof.
     apply (CRle_trans _ (CRsum (fun k0 : nat => CRabs R (un (S p + k0)%nat)) k)).
     apply multiTriangleIneg. apply sum_Rle. intros.
     apply H. rewrite Nat.add_comm, Nat.add_succ_r. reflexivity.
-    apply (le_trans p (S p)). apply le_S. apply le_refl. assumption.
-    apply (le_trans p (S p)). apply le_S. apply le_refl. assumption.
+    apply (Nat.le_trans p (S p)). apply le_S. apply Nat.le_refl. assumption.
+    apply (Nat.le_trans p (S p)). apply le_S. apply Nat.le_refl. assumption.
 Qed.
 
 Lemma cond_pos_sum : forall {R : ConstructiveReals} (un : nat -> CRcarrier R) (n : nat),
@@ -162,8 +162,8 @@ Lemma pos_sum_more : forall {R : ConstructiveReals} (u : nat -> CRcarrier R)
     -> le n p -> CRsum u n <= CRsum u p.
 Proof.
   intros. destruct (Nat.le_exists_sub n p H0). destruct H1. subst p.
-  rewrite plus_comm.
-  destruct x. rewrite plus_0_r. apply CRle_refl. rewrite Nat.add_succ_r.
+  rewrite Nat.add_comm.
+  destruct x. rewrite Nat.add_0_r. apply CRle_refl. rewrite Nat.add_succ_r.
   replace (S (n + x)) with (S n + x)%nat. rewrite sum_assoc.
   rewrite <- CRplus_0_r, CRplus_assoc.
   apply CRplus_le_compat_l. rewrite CRplus_0_l.
@@ -209,7 +209,7 @@ Proof.
   - intros _. destruct N. simpl. reflexivity. simpl.
     rewrite IHN. rewrite CRplus_assoc.
     apply CRplus_morph. reflexivity. reflexivity.
-    apply le_n_S, le_0_n.
+    apply le_n_S, Nat.le_0_l.
 Qed.
 
 Lemma reverse_sum : forall {R : ConstructiveReals} (u : nat -> CRcarrier R) (n : nat),
@@ -219,7 +219,7 @@ Proof.
   - intros. reflexivity.
   - rewrite (decomp_sum (fun k : nat => u (S n - k)%nat)). simpl.
     rewrite CRplus_comm. apply CRplus_morph. reflexivity. assumption.
-    unfold lt. apply le_n_S. apply le_0_n.
+    unfold lt. apply -> Nat.succ_le_mono; apply Nat.le_0_l.
 Qed.
 
 Lemma Rplus_le_pos : forall {R : ConstructiveReals} (a b : CRcarrier R),
@@ -290,9 +290,9 @@ Proof.
     setoid_replace (1#n)%Q with ((1#2*n) + (1#2*n))%Q.
     rewrite CR_of_Q_plus.
     apply CRplus_le_compat.
-    apply maj. apply (le_trans _ i). assumption. apply Nat.le_max_l.
+    apply maj. apply (Nat.le_trans _ i). assumption. apply Nat.le_max_l.
     rewrite CRabs_opp. apply maj.
-    apply Nat.min_case. apply (le_trans _ i). assumption. apply le_refl.
+    apply Nat.min_case. apply (Nat.le_trans _ i). assumption. apply Nat.le_refl.
     assumption. rewrite Qinv_plus_distr. reflexivity.
     unfold CRminus. rewrite CRplus_assoc. apply CRplus_morph.
     reflexivity. rewrite CRopp_plus_distr, CRopp_involutive.
@@ -302,7 +302,7 @@ Proof.
     rewrite <- (CRplus_opp_r (CRsum vn (Init.Nat.min i j))).
     apply CRplus_le_compat. apply pos_sum_more.
     intros. apply (CRle_trans _ (CRabs R (un k))). apply CRabs_pos.
-    apply H. apply (le_trans _ i). apply Nat.le_min_l. apply Nat.le_max_l.
+    apply H. apply (Nat.le_trans _ i). apply Nat.le_min_l. apply Nat.le_max_l.
     apply CRle_refl.
   - exists x. split. assumption.
     (* x <= s *)
@@ -465,7 +465,7 @@ Proof.
   apply (CR_cv_le (fun N => CRabs R (CRsum u n - (CRsum u (n + N))))
                    (fun N => CRsum (fun n : nat => CRabs R (u n)) (n + N)
                           - CRsum (fun n : nat => CRabs R (u n)) n)).
-  - intro N. destruct N. rewrite plus_0_r. unfold CRminus.
+  - intro N. destruct N. rewrite Nat.add_0_r. unfold CRminus.
     rewrite CRplus_opp_r. rewrite CRplus_opp_r.
     rewrite CRabs_right. apply CRle_refl. apply CRle_refl.
     rewrite Nat.add_succ_r.
@@ -477,14 +477,14 @@ Proof.
     rewrite CRplus_0_l. apply multiTriangleIneg.
   - apply CR_cv_dist_cont. intros eps.
     specialize (H eps) as [N lim].
-    exists N. intros. rewrite plus_comm. apply lim. apply (le_trans N i).
-    assumption. rewrite <- (plus_0_r i). rewrite <- plus_assoc.
-    apply Nat.add_le_mono_l. apply le_0_n.
+    exists N. intros. rewrite Nat.add_comm. apply lim. apply (Nat.le_trans N i).
+    assumption. rewrite <- (Nat.add_0_r i), <- Nat.add_assoc.
+    apply Nat.add_le_mono_l, Nat.le_0_l.
   - apply CR_cv_plus. 2: apply CR_cv_const. intros eps.
     specialize (H0 eps) as [N lim].
-    exists N. intros. rewrite plus_comm. apply lim. apply (le_trans N i).
-    assumption. rewrite <- (plus_0_r i). rewrite <- plus_assoc.
-    apply Nat.add_le_mono_l. apply le_0_n.
+    exists N. intros. rewrite Nat.add_comm. apply lim. apply (Nat.le_trans N i).
+    assumption. rewrite <- (Nat.add_0_r i), <- Nat.add_assoc.
+    apply Nat.add_le_mono_l, Nat.le_0_l.
 Qed.
 
 Lemma series_cv_triangle : forall {R : ConstructiveReals}
@@ -506,8 +506,8 @@ Lemma series_cv_shift :
 Proof.
   intros. intro p. specialize (H p) as [n nmaj].
   exists (S k+n)%nat. intros. destruct (Nat.le_exists_sub (S k) i).
-  apply (le_trans _ (S k + 0)). rewrite Nat.add_0_r. apply le_refl.
-  apply (le_trans _ (S k + n)). apply Nat.add_le_mono_l, le_0_n.
+  apply (Nat.le_trans _ (S k + 0)). rewrite Nat.add_0_r. apply Nat.le_refl.
+  apply (Nat.le_trans _ (S k + n)). apply Nat.add_le_mono_l, Nat.le_0_l.
   exact H. destruct H0. subst i.
   rewrite Nat.add_comm in H. rewrite <- Nat.add_le_mono_r in H.
   specialize (nmaj x H). unfold CRminus.
@@ -532,12 +532,12 @@ Proof.
   intros. destruct shift as [|p].
   - unfold CRminus. rewrite CRopp_0. rewrite CRplus_0_r.
     apply (series_cv_eq un). intros.
-    rewrite plus_0_r. reflexivity. apply H.
+    rewrite Nat.add_0_r. reflexivity. apply H.
   - apply (CR_cv_eq _ (fun n => CRsum un (n + S p) - CRsum un p)).
-    intros. rewrite plus_comm. unfold CRminus.
+    intros. rewrite Nat.add_comm. unfold CRminus.
     rewrite sum_assoc. simpl. rewrite CRplus_comm, <- CRplus_assoc.
     rewrite CRplus_opp_l, CRplus_0_l.
-    apply CRsum_eq. intros. rewrite (plus_comm i). reflexivity.
+    apply CRsum_eq. intros. rewrite (Nat.add_comm i). reflexivity.
     apply CR_cv_plus. apply (CR_cv_shift' _ (S p) _ H).
     intros n. exists (Pos.to_nat n). intros.
     unfold CRminus. simpl.

--- a/theories/Reals/Alembert.v
+++ b/theories/Reals/Alembert.v
@@ -13,7 +13,6 @@ Require Import Rfunctions.
 Require Import Rseries.
 Require Import SeqProp.
 Require Import PartSum.
-Require Import Max.
 
 Local Open Scope R_scope.
 
@@ -144,10 +143,10 @@ Proof.
   apply Rabs_triang.
   rewrite Rabs_Ropp; apply Rlt_le_trans with (eps / 2 + eps / 2).
   apply Rplus_lt_compat.
-  unfold R_dist in H8; apply H8; unfold ge; apply le_trans with N;
-    [ unfold N; apply le_max_l | assumption ].
-  unfold R_dist in H9; apply H9; unfold ge; apply le_trans with N;
-    [ unfold N; apply le_max_r | assumption ].
+  unfold R_dist in H8; apply H8; unfold ge; apply Nat.le_trans with N;
+    [ unfold N; apply Nat.le_max_l | assumption ].
+  unfold R_dist in H9; apply H9; unfold ge; apply Nat.le_trans with N;
+    [ unfold N; apply Nat.le_max_r | assumption ].
   right; symmetry ; apply double_var.
   symmetry ; apply tech11; intro; unfold Vn, Wn;
     unfold Rdiv; do 2 rewrite <- (Rmult_comm (/ 2));
@@ -387,7 +386,7 @@ Proof.
   induction  n as [| n Hrecn].
   simpl; ring.
   rewrite tech5; rewrite Hrecn;
-    [ rewrite H; simpl; ring | unfold ge; apply le_O_n ].
+    [ rewrite H; simpl; ring | unfold ge; apply Nat.le_0_l ].
 Qed.
 
 (** A useful criterion of convergence for power series *)
@@ -656,7 +655,7 @@ Proof.
   rewrite tech5.
   rewrite <- Hrecn.
   rewrite Heq; simpl; ring.
-  unfold ge; apply le_O_n.
+  unfold ge; apply Nat.le_0_l.
   eapply Alembert_C5 with (k * Rabs x).
   split.
   unfold Rdiv; apply Rmult_le_pos.
@@ -719,3 +718,6 @@ Proof.
   apply Rinv_0_lt_compat; apply Rabs_pos_lt.
   red; intro H7; rewrite H7 in Hgt; elim (Rlt_irrefl _ Hgt).
 Qed.
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Import Max.

--- a/theories/Reals/AltSeries.v
+++ b/theories/Reals/AltSeries.v
@@ -13,7 +13,6 @@ Require Import Rfunctions.
 Require Import Rseries.
 Require Import SeqProp.
 Require Import PartSum.
-Require Import Max.
 Local Open Scope R_scope.
 
 (**********)
@@ -144,7 +143,7 @@ Proof.
   apply Rplus_le_compat_l.
   apply CV_ALT_step3; assumption.
   unfold tg_alt; simpl; ring.
-  apply lt_O_Sn.
+  apply Nat.lt_0_succ.
 Qed.
 
 (** This lemma gives an interesting result about alternated series *)
@@ -185,9 +184,9 @@ Proof.
     rewrite pow_1_abs; rewrite Rmult_1_l; unfold Rminus in H6;
       rewrite Ropp_0 in H6; rewrite <- (Rplus_0_r (Un (S n)));
 	apply H6.
-  unfold ge; apply le_trans with n.
-  apply le_trans with N; [ unfold N; apply le_max_r | assumption ].
-  apply le_n_Sn.
+  unfold ge; apply Nat.le_trans with n.
+  apply Nat.le_trans with N; [ unfold N; apply Nat.le_max_r | assumption ].
+  apply Nat.le_succ_diag_r.
   rewrite tech5; ring.
   rewrite H12; apply Rlt_trans with (eps / 2).
   apply H7; assumption.
@@ -199,16 +198,16 @@ Proof.
   pattern eps at 1; rewrite <- (Rplus_0_r eps); apply Rplus_lt_compat_l;
     assumption.
   elim H10; intro; apply le_double.
-  rewrite <- H11; apply le_trans with N.
-  unfold N; apply le_trans with (S (2 * N1));
-    [ apply le_n_Sn | apply le_max_l ].
+  rewrite <- H11; apply Nat.le_trans with N.
+  unfold N; apply Nat.le_trans with (S (2 * N1));
+    [ apply Nat.le_succ_diag_r | apply Nat.le_max_l ].
   assumption.
-  apply lt_n_Sm_le.
+  apply Nat.lt_succ_r.
   rewrite <- H11.
-  apply lt_le_trans with N.
-  unfold N; apply lt_le_trans with (S (2 * N1)).
-  apply lt_n_Sn.
-  apply le_max_l.
+  apply Nat.lt_le_trans with N.
+  unfold N; apply Nat.lt_le_trans with (S (2 * N1)).
+  apply Nat.lt_succ_diag_r.
+  apply Nat.le_max_l.
   assumption.
 Qed.
 
@@ -249,27 +248,16 @@ Proof.
   elim (H1 eps H2); intros.
   exists x; intros.
   apply H3.
-  unfold ge; apply le_trans with (2 * n)%nat.
-  apply le_trans with n.
-  assumption.
-  assert (H5 := mult_O_le n 2).
-  elim H5; intro.
-  cut (0%nat <> 2%nat);
-    [ intro; elim H7; symmetry ; assumption | discriminate ].
-  assumption.
-  apply le_n_Sn.
+  apply Nat.le_trans with n; [ assumption | ].
+  apply Nat.le_le_succ_r.
+  rewrite <- Nat.double_twice; apply Nat.le_add_r.
   unfold Un_cv; unfold R_dist; unfold Un_cv in H1;
     unfold R_dist in H1; intros.
   elim (H1 eps H2); intros.
   exists x; intros.
   apply H3.
-  unfold ge; apply le_trans with n.
-  assumption.
-  assert (H5 := mult_O_le n 2).
-  elim H5; intro.
-  cut (0%nat <> 2%nat);
-    [ intro; elim H7; symmetry ; assumption | discriminate ].
-  assumption.
+  apply Nat.le_trans with n; [ assumption | ].
+  rewrite <- Nat.double_twice; apply Nat.le_add_r.
 Qed.
 
 (***************************************)
@@ -281,7 +269,7 @@ Definition PI_tg (n:nat) := / INR (2 * n + 1).
 Lemma PI_tg_pos : forall n:nat, 0 <= PI_tg n.
 Proof.
   intro; unfold PI_tg; left; apply Rinv_0_lt_compat; apply lt_INR_0;
-    replace (2 * n + 1)%nat with (S (2 * n)); [ apply lt_O_Sn | ring ].
+    replace (2 * n + 1)%nat with (S (2 * n)); [ apply Nat.lt_0_succ | ring ].
 Qed.
 
 Lemma PI_tg_decreasing : Un_decreasing PI_tg.
@@ -289,16 +277,16 @@ Proof.
   unfold PI_tg, Un_decreasing; intro.
   apply Rmult_le_reg_l with (INR (2 * n + 1)).
   apply lt_INR_0.
-  replace (2 * n + 1)%nat with (S (2 * n)); [ apply lt_O_Sn | ring ].
+  replace (2 * n + 1)%nat with (S (2 * n)); [ apply Nat.lt_0_succ | ring ].
   rewrite <- Rinv_r_sym.
   apply Rmult_le_reg_l with (INR (2 * S n + 1)).
   apply lt_INR_0.
-  replace (2 * S n + 1)%nat with (S (2 * S n)); [ apply lt_O_Sn | ring ].
+  replace (2 * S n + 1)%nat with (S (2 * S n)); [ apply Nat.lt_0_succ | ring ].
   rewrite (Rmult_comm (INR (2 * S n + 1))); rewrite Rmult_assoc;
     rewrite <- Rinv_l_sym.
   do 2 rewrite Rmult_1_r; apply le_INR.
   replace (2 * S n + 1)%nat with (S (S (2 * n + 1))).
-  apply le_trans with (S (2 * n + 1)); apply le_n_Sn.
+  apply Nat.le_trans with (S (2 * n + 1)); apply Nat.le_succ_diag_r.
   ring.
   apply not_O_INR; discriminate.
   apply not_O_INR; replace (2 * n + 1)%nat with (S (2 * n));
@@ -323,29 +311,29 @@ Proof.
   apply Rmult_lt_reg_l with (INR (2 * n)).
   apply lt_INR_0.
   replace (2 * n)%nat with (n + n)%nat; [ idtac | ring ].
-  apply lt_le_trans with n.
+  apply Nat.lt_le_trans with n.
   assumption.
-  apply le_plus_l.
+  apply Nat.le_add_r.
   rewrite <- Rinv_r_sym.
   apply Rmult_lt_reg_l with (INR (2 * n + 1)).
   apply lt_INR_0.
-  replace (2 * n + 1)%nat with (S (2 * n)); [ apply lt_O_Sn | ring ].
+  replace (2 * n + 1)%nat with (S (2 * n)); [ apply Nat.lt_0_succ | ring ].
   rewrite (Rmult_comm (INR (2 * n + 1))).
   rewrite Rmult_assoc; rewrite <- Rinv_l_sym.
   do 2 rewrite Rmult_1_r; apply lt_INR.
-  replace (2 * n + 1)%nat with (S (2 * n)); [ apply lt_n_Sn | ring ].
+  replace (2 * n + 1)%nat with (S (2 * n)); [ apply Nat.lt_succ_diag_r | ring ].
   apply not_O_INR; replace (2 * n + 1)%nat with (S (2 * n));
     [ discriminate | ring ].
   replace n with (S (pred n)).
   apply not_O_INR; discriminate.
-  symmetry ; apply S_pred with 0%nat.
+  apply Nat.lt_succ_pred with 0%nat.
   assumption.
   apply Rle_lt_trans with (/ INR (2 * N)).
   apply Rinv_le_contravar.
   rewrite mult_INR; apply Rmult_lt_0_compat;
     [ simpl; prove_sup0 | apply lt_INR_0; assumption ].
   apply le_INR.
-  now apply mult_le_compat_l.
+  now apply Nat.mul_le_mono_nonneg_l; [ apply Nat.le_0_l | ].
   rewrite mult_INR.
   apply Rmult_lt_reg_l with (INR N / eps).
   apply Rdiv_lt_0_compat with (2 := H).
@@ -360,7 +348,7 @@ Proof.
   now apply Rgt_not_eq, (lt_INR 0).
   now apply Rgt_not_eq.
   apply Rle_ge; apply PI_tg_pos.
-  apply lt_le_trans with N; assumption.
+  apply Nat.lt_le_trans with N; assumption.
   elim H1; intros H5 _.
   destruct (lt_eq_lt_dec 0 N) as [[| <- ]|H6].
   assumption.
@@ -368,7 +356,7 @@ Proof.
   simpl in H5.
   cut (0 < / (2 * eps)); [ intro | apply Rinv_0_lt_compat; assumption ].
   elim (Rlt_irrefl _ (Rlt_trans _ _ _ H6 H5)).
-  elim (lt_n_O _ H6).
+  elim (Nat.nlt_0_r _ H6).
   apply le_IZR.
   left; apply Rlt_trans with (/ (2 * eps)).
   apply Rinv_0_lt_compat; assumption.
@@ -422,3 +410,6 @@ Proof.
     apply Rplus_lt_compat_l; prove_sup0.
   assumption.
 Qed.
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Import Max.

--- a/theories/Reals/ArithProp.v
+++ b/theories/Reals/ArithProp.v
@@ -10,8 +10,6 @@
 
 Require Import Rdefinitions Raxioms RIneq.
 Require Import Rbasic_fun.
-Require Import Even.
-Require Import Div2.
 Require Import ArithRing.
 
 Local Open Scope Z_scope.
@@ -19,63 +17,35 @@ Local Open Scope R_scope.
 
 Lemma minus_neq_O : forall n i:nat, (i < n)%nat -> (n - i)%nat <> 0%nat.
 Proof.
-  intros; red; intro.
-  cut (forall n m:nat, (m <= n)%nat -> (n - m)%nat = 0%nat -> n = m).
-  intro; assert (H2 := H1 _ _ (lt_le_weak _ _ H) H0); rewrite H2 in H;
-    elim (lt_irrefl _ H).
-  set (R := fun n m:nat => (m <= n)%nat -> (n - m)%nat = 0%nat -> n = m).
-  cut
-    ((forall n m:nat, R n m) ->
-      forall n0 m:nat, (m <= n0)%nat -> (n0 - m)%nat = 0%nat -> n0 = m).
-  intro; apply H1.
-  apply nat_double_ind.
-  unfold R; intros; inversion H2; reflexivity.
-  unfold R; intros; simpl in H3; assumption.
-  unfold R; intros; simpl in H4; assert (H5 := le_S_n _ _ H3);
-    assert (H6 := H2 H5 H4); rewrite H6; reflexivity.
-  unfold R; intros; apply H1; assumption.
+  intros n i Hlt.
+  apply Nat.neq_0_lt_0, Nat.lt_add_lt_sub_r; assumption.
 Qed.
 
 Lemma le_minusni_n : forall n i:nat, (i <= n)%nat -> (n - i <= n)%nat.
 Proof.
-  set (R := fun m n:nat => (n <= m)%nat -> (m - n <= m)%nat).
-  cut
-    ((forall m n:nat, R m n) -> forall n i:nat, (i <= n)%nat -> (n - i <= n)%nat).
-  intro; apply H.
-  apply nat_double_ind.
-  unfold R; intros; simpl; apply le_n.
-  unfold R; intros; simpl; apply le_n.
-  unfold R; intros; simpl; apply le_trans with n.
-  apply H0; apply le_S_n; assumption.
-  apply le_n_Sn.
-  unfold R; intros; apply H; assumption.
+  intros n i _.
+  induction i as [ | i IHi ].
+  - rewrite Nat.sub_0_r; reflexivity.
+  - etransitivity; [ | apply IHi ].
+    rewrite Nat.sub_succ_r.
+    apply Nat.le_pred_l.
 Qed.
 
 Lemma lt_minus_O_lt : forall m n:nat, (m < n)%nat -> (0 < n - m)%nat.
 Proof.
-  intros n m; pattern n, m; apply nat_double_ind;
-    [ intros; rewrite <- minus_n_O; assumption
-      | intros; elim (lt_n_O _ H)
-      | intros; simpl; apply H; apply lt_S_n; assumption ].
+  intros n i Hlt.
+  apply Nat.lt_add_lt_sub_r; assumption.
 Qed.
 
 Lemma even_odd_cor :
-  forall n:nat,  exists p : nat, n = (2 * p)%nat \/ n = S (2 * p).
+  forall n:nat, exists p : nat, n = (2 * p)%nat \/ n = S (2 * p).
 Proof.
-  intro.
-  assert (H := even_or_odd n).
-  exists (div2 n).
-  assert (H0 := even_odd_double n).
-  elim H0; intros.
-  elim H1; intros H3 _.
-  elim H2; intros H4 _.
-  replace (2 * div2 n)%nat with (double (div2 n)).
-  elim H; intro.
-  left.
-  apply H3; assumption.
-  right.
-  apply H4; assumption.
-  unfold double;ring.
+  intros n; exists (Nat.div2 n).
+  case_eq (Nat.odd n); intros H; [right|left].
+  - assert (Nat.b2n (Nat.odd n) = 1%nat) as Hb by now rewrite H.
+    rewrite Nat.div2_odd at 1; rewrite Hb, Nat.add_1_r; reflexivity.
+  - assert (Nat.b2n (Nat.odd n) = 0%nat) as Hb by now rewrite H.
+    rewrite Nat.div2_odd at 1; rewrite Hb, Nat.add_0_r; reflexivity.
 Qed.
 
   (* 2m <= 2n => m<=n *)
@@ -179,8 +149,11 @@ Qed.
 Lemma tech8 : forall n i:nat, (n <= S n + i)%nat.
 Proof.
   intros; induction  i as [| i Hreci].
-  replace (S n + 0)%nat with (S n); [ apply le_n_Sn | ring ].
+  replace (S n + 0)%nat with (S n); [ apply Nat.le_succ_diag_r | ring ].
   replace (S n + S i)%nat with (S (S n + i)).
   apply le_S; assumption.
   apply INR_eq; rewrite S_INR; do 2 rewrite plus_INR; do 2 rewrite S_INR; ring.
 Qed.
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Import Even Div2.

--- a/theories/Reals/Binomial.v
+++ b/theories/Reals/Binomial.v
@@ -21,7 +21,7 @@ Proof.
   intros; unfold C; replace (n - (n - i))%nat with i.
   rewrite Rmult_comm.
   reflexivity.
-  apply plus_minus; rewrite plus_comm; apply le_plus_minus; assumption.
+  symmetry; apply Nat.add_sub_eq_l, Nat.sub_add; assumption.
 Qed.
 
 Lemma pascal_step2 :
@@ -42,7 +42,7 @@ Proof.
   apply not_O_INR; discriminate.
   apply INR_fact_neq_0.
   intro; reflexivity.
-  apply minus_Sn_m; assumption.
+  symmetry; apply Nat.sub_succ_l; assumption.
 Qed.
 
 Lemma pascal_step3 :
@@ -69,9 +69,9 @@ Proof.
   apply INR_fact_neq_0.
   apply prod_neq_R0; [ apply not_O_INR; discriminate | apply INR_fact_neq_0 ].
   apply INR_fact_neq_0.
-  rewrite minus_Sn_m.
+  rewrite <- Nat.sub_succ_l.
   simpl; reflexivity.
-  apply lt_le_S; assumption.
+  apply -> Nat.le_succ_l; assumption.
   intro; reflexivity.
 Qed.
 
@@ -88,21 +88,19 @@ Proof.
   rewrite Rmult_comm; replace (S i) with (S n - (n - i))%nat.
   rewrite <- pascal_step2.
   apply pascal_step1.
-  apply le_trans with n.
+  apply Nat.le_trans with n.
   apply le_minusni_n.
-  apply lt_le_weak; assumption.
-  apply le_n_Sn.
+  apply Nat.lt_le_incl; assumption.
+  apply Nat.le_succ_diag_r.
   apply le_minusni_n.
-  apply lt_le_weak; assumption.
-  rewrite <- minus_Sn_m.
+  apply Nat.lt_le_incl; assumption.
+  rewrite Nat.sub_succ_l.
   cut ((n - (n - i))%nat = i).
   intro; rewrite H0; reflexivity.
-  symmetry ; apply plus_minus.
-  rewrite plus_comm; rewrite le_plus_minus_r.
-  reflexivity.
-  apply lt_le_weak; assumption.
-  apply le_minusni_n; apply lt_le_weak; assumption.
-  apply lt_le_weak; assumption.
+  apply Nat.add_sub_eq_l, Nat.sub_add.
+  apply Nat.lt_le_incl; assumption.
+  apply le_minusni_n; apply Nat.lt_le_incl; assumption.
+  apply Nat.lt_le_incl; assumption.
   unfold Rdiv.
   repeat rewrite S_INR.
   rewrite minus_INR.
@@ -117,7 +115,7 @@ Proof.
   ring.
   rewrite <- S_INR.
   apply not_O_INR; discriminate.
-  apply lt_le_weak; assumption.
+  apply Nat.lt_le_incl; assumption.
 Qed.
 
   (*********************)
@@ -135,7 +133,7 @@ Proof.
   rewrite tech5.
   cut (forall p:nat, C p p = 1).
   cut (forall p:nat, C p 0 = 1).
-  intros; rewrite H0; rewrite <- minus_n_n; rewrite Rmult_1_l.
+  intros; rewrite H0; rewrite Nat.sub_diag; rewrite Rmult_1_l.
   replace (y ^ 0) with 1; [ rewrite Rmult_1_r | simpl; reflexivity ].
   induction  n as [| n Hrecn0].
   simpl; do 2 rewrite H; ring.
@@ -169,39 +167,39 @@ Proof.
   replace (pred N) with n.
   ring.
   unfold N; simpl; reflexivity.
-  unfold N; apply lt_O_Sn.
+  unfold N; apply Nat.lt_0_succ.
   unfold Cn; rewrite H; simpl; ring.
   apply sum_eq.
   intros; apply H1.
-  unfold N; apply le_lt_trans with n; [ assumption | apply lt_n_Sn ].
+  unfold N; apply Nat.le_lt_trans with n; [ assumption | apply Nat.lt_succ_diag_r ].
   reflexivity.
-  unfold An; fold N; rewrite <- minus_n_n; rewrite H0;
+  unfold An; fold N; rewrite Nat.sub_diag; rewrite H0;
     simpl; ring.
   apply sum_eq.
   intros; unfold An, Bn.
   change (S N - S i)%nat with (N - i)%nat.
   rewrite <- pascal;
     [ ring
-      | apply le_lt_trans with n; [ assumption | unfold N; apply lt_n_Sn ] ].
+      | apply Nat.le_lt_trans with n; [ assumption | unfold N; apply Nat.lt_succ_diag_r ] ].
   unfold N; reflexivity.
-  unfold N; apply lt_O_Sn.
+  unfold N; apply Nat.lt_0_succ.
   rewrite <- (Rmult_comm y); rewrite scal_sum; apply sum_eq.
   intros; replace (S N - i)%nat with (S (N - i)).
   replace (S (N - i)) with (N - i + 1)%nat; [ idtac | ring ].
   rewrite pow_add; replace (y ^ 1) with y; [ idtac | simpl; ring ];
     ring.
-  apply minus_Sn_m; assumption.
+  symmetry; apply Nat.sub_succ_l; assumption.
   rewrite <- (Rmult_comm x); rewrite scal_sum; apply sum_eq.
   intros; replace (S i) with (i + 1)%nat; [ idtac | ring ]; rewrite pow_add;
     replace (x ^ 1) with x; [ idtac | simpl; ring ];
       ring.
   intro; unfold C.
   replace (INR (fact 0)) with 1; [ idtac | reflexivity ].
-  replace (p - 0)%nat with p; [ idtac | apply minus_n_O ].
+  replace (p - 0)%nat with p; [ idtac | symmetry; apply Nat.sub_0_r ].
   rewrite Rmult_1_l; unfold Rdiv; rewrite <- Rinv_r_sym;
     [ reflexivity | apply INR_fact_neq_0 ].
   intro; unfold C.
-  replace (p - p)%nat with 0%nat; [ idtac | apply minus_n_n ].
+  replace (p - p)%nat with 0%nat; [ idtac | symmetry; apply Nat.sub_diag ].
   replace (INR (fact 0)) with 1; [ idtac | reflexivity ].
   rewrite Rmult_1_r; unfold Rdiv; rewrite <- Rinv_r_sym;
     [ reflexivity | apply INR_fact_neq_0 ].

--- a/theories/Reals/Cauchy/ConstructiveCauchyRealsMult.v
+++ b/theories/Reals/Cauchy/ConstructiveCauchyRealsMult.v
@@ -1045,7 +1045,7 @@ Proof.
     assert (0 < inject_Q (Z.of_nat (S n) #1)) as nPos.
     { apply inject_Q_lt. unfold Qlt, Qnum, Qden.
       do 2 rewrite Z.mul_1_r. apply Z2Nat.inj_lt. discriminate.
-      apply Zle_0_nat. rewrite Nat2Z.id. apply le_n_S, le_0_n. }
+      apply Zle_0_nat. rewrite Nat2Z.id. apply -> Nat.succ_le_mono; apply Nat.le_0_l. }
     assert (b * (/ inject_Q (Z.of_nat (S n) #1)) (inr nPos) < -(a*b)).
     { apply (CReal_mult_lt_reg_r (inject_Q (Z.of_nat (S n) #1))). apply nPos.
       rewrite CReal_mult_assoc, CReal_inv_l, CReal_mult_1_r.

--- a/theories/Reals/Cauchy/ConstructiveRcomplete.v
+++ b/theories/Reals/Cauchy/ConstructiveRcomplete.v
@@ -209,11 +209,11 @@ Proof.
   (xcau (4 * q)%positive) as [j jmaj].
   assert (CReal_abs (xn i - xn j) <= inject_Q (1 # 4 * n)).
   { destruct (le_lt_dec i j).
-    apply (CReal_le_trans _ _ _ (imaj i j (le_refl _) l)).
+    apply (CReal_le_trans _ _ _ (imaj i j (Nat.le_refl _) l)).
     apply inject_Q_le. unfold Qle, Qnum, Qden.
     rewrite Z.mul_1_l, Z.mul_1_l. apply Pos2Z.pos_le_pos.
     apply Pos.mul_le_mono_l, Hp. apply le_S, le_S_n in l.
-    apply (CReal_le_trans _ _ _ (jmaj i j l (le_refl _))).
+    apply (CReal_le_trans _ _ _ (jmaj i j l (Nat.le_refl _))).
     apply inject_Q_le. unfold Qle, Qnum, Qden.
     rewrite Z.mul_1_l, Z.mul_1_l. apply Pos2Z.pos_le_pos.
     apply Pos.mul_le_mono_l, Hq. }
@@ -287,12 +287,12 @@ Proof.
   assert (CReal_abs (xn i - xn j) <= inject_Q (1 # 4 * 2^n')).
   {
     destruct (le_lt_dec i j).
-    apply (CReal_le_trans _ _ _ (imaj i j (le_refl _) l)).
+    apply (CReal_le_trans _ _ _ (imaj i j (Nat.le_refl _) l)).
     apply inject_Q_le. unfold Qle, Qnum, Qden.
     rewrite Z.mul_1_l, Z.mul_1_l. apply Pos2Z.pos_le_pos.
     subst; apply Pos.mul_le_mono_l, Pos_pow_le_mono_r, CReal_from_cauchy_cm_mono, Hp.
     apply le_S, le_S_n in l.
-    apply (CReal_le_trans _ _ _ (jmaj i j l (le_refl _))).
+    apply (CReal_le_trans _ _ _ (jmaj i j l (Nat.le_refl _))).
     apply inject_Q_le. unfold Qle, Qnum, Qden.
     rewrite Z.mul_1_l, Z.mul_1_l. apply Pos2Z.pos_le_pos.
     subst; apply Pos.mul_le_mono_l, Pos_pow_le_mono_r, CReal_from_cauchy_cm_mono, Hq.
@@ -499,11 +499,11 @@ Proof.
   assert (CReal_abs (xn i' - xn j') <= inject_Q (1#4)) as Hxij.
     {
     destruct (le_lt_dec i' j').
-    - apply (CReal_le_trans _ _ _ (imaj i' j' (le_refl _) l)).
+    - apply (CReal_le_trans _ _ _ (imaj i' j' (Nat.le_refl _) l)).
       apply inject_Q_le; unfold Qle, Qnum, Qden; ring_simplify.
       apply Pos2Z_pos_is_pos.
     - apply le_S, le_S_n in l.
-      apply (CReal_le_trans _ _ _ (jmaj i' j' l (le_refl _))).
+      apply (CReal_le_trans _ _ _ (jmaj i' j' l (Nat.le_refl _))).
       apply inject_Q_le; unfold Qle, Qnum, Qden; ring_simplify.
       apply Pos2Z_pos_is_pos.
     }
@@ -600,7 +600,7 @@ Proof.
        pose proof Qpower_0_lt 2 (Z.neg p)%Z; lra. }
 
   (* Use imaj to relate xn i and xn j *)
-  specialize (imaj j i (le_trans _ _ _ (Nat.le_max_r _ _) H0) (le_refl _)).
+  specialize (imaj j i (Nat.le_trans _ _ _ (Nat.le_max_r _ _) H0) (Nat.le_refl _)).
     apply (CReal_le_trans _ (inject_Q (1 # 4 * p) + inject_Q (1 # 4 * p))).
     setoid_replace (xn j - inject_Q (seq (xn i) (Z.neg i' - 2)))
     with (xn j - xn i + (xn i - inject_Q (seq (xn i) (Z.neg i' - 2)))).

--- a/theories/Reals/Cauchy_prod.v
+++ b/theories/Reals/Cauchy_prod.v
@@ -23,7 +23,7 @@ Proof.
   replace N with (S (pred N)).
   rewrite tech5.
   reflexivity.
-  symmetry ; apply S_pred with 0%nat; assumption.
+  apply Nat.lt_succ_pred with 0%nat; assumption.
 Qed.
 
   (**********)
@@ -50,7 +50,7 @@ Theorem cauchy_finite :
       (pred (N - k))) (pred N).
 Proof.
   intros; induction  N as [| N HrecN].
-  elim (lt_irrefl _ H).
+  elim (Nat.lt_irrefl _ H).
   cut (N = 0%nat \/ (0 < N)%nat).
   intro; elim H0; intro.
   rewrite H1; simpl; ring.
@@ -66,7 +66,7 @@ Proof.
   repeat rewrite <- Rplus_assoc;
     do 2 rewrite <- (Rplus_comm (An (S N) * Bn (S N)));
       repeat rewrite Rplus_assoc; apply Rplus_eq_compat_l.
-  rewrite <- minus_n_n; cut (N = 1%nat \/ (2 <= N)%nat).
+  rewrite Nat.sub_diag; cut (N = 1%nat \/ (2 <= N)%nat).
   intro; elim H2; intro.
   rewrite H3; simpl; ring.
   replace
@@ -149,7 +149,7 @@ Proof.
       (pred (pred N))).
   repeat rewrite Rplus_assoc; apply Rplus_eq_compat_l.
   replace (pred (N - pred N)) with 0%nat.
-  simpl; rewrite <- minus_n_O.
+  simpl; rewrite Nat.sub_0_r.
   replace (S (pred N)) with N.
   replace (sum_f_R0 (fun k:nat => An (S N) * Bn (S k)) (pred (pred N))) with
     (sum_f_R0 (fun k:nat => Bn (S k) * An (S N)) (pred (pred N))).
@@ -157,17 +157,17 @@ Proof.
     rewrite (sum_N_predN (fun l:nat => Bn (S l)) (pred N)).
   replace (S (pred N)) with N.
   ring.
-  apply S_pred with 0%nat; assumption.
-  apply lt_pred; apply lt_le_trans with 2%nat; [ apply lt_n_Sn | assumption ].
+  symmetry; apply Nat.lt_succ_pred with 0%nat; assumption.
+  apply Nat.lt_succ_lt_pred; apply Nat.lt_le_trans with 2%nat; [ apply Nat.lt_succ_diag_r | assumption ].
   apply sum_eq; intros; apply Rmult_comm.
-  apply S_pred with 0%nat; assumption.
+  symmetry; apply Nat.lt_succ_pred with 0%nat; assumption.
   replace (N - pred N)%nat with 1%nat.
   reflexivity.
   pattern N at 1; replace N with (S (pred N)).
-  rewrite <- minus_Sn_m.
-  rewrite <- minus_n_n; reflexivity.
+  rewrite Nat.sub_succ_l.
+  rewrite Nat.sub_diag; reflexivity.
   apply le_n.
-  symmetry ; apply S_pred with 0%nat; assumption.
+  apply Nat.lt_succ_pred with 0%nat; assumption.
   apply sum_eq; intros;
     rewrite
       (sum_N_predN (fun l:nat => An (S (S (l + i))) * Bn (N - l)%nat)
@@ -175,58 +175,58 @@ Proof.
   replace (S (S (pred (N - i) + i))) with (S N).
   replace (N - pred (N - i))%nat with (S i).
   reflexivity.
-  rewrite pred_of_minus; apply INR_eq; repeat rewrite minus_INR.
+  rewrite <- Nat.sub_1_r; apply INR_eq; repeat rewrite minus_INR.
   rewrite S_INR; simpl; ring.
-  apply le_trans with (pred (pred N)).
+  apply Nat.le_trans with (pred (pred N)).
   assumption.
-  apply le_trans with (pred N); apply le_pred_n.
+  apply Nat.le_trans with (pred N); apply Nat.le_pred_l.
   apply INR_le; rewrite minus_INR.
   apply Rplus_le_reg_l with (INR i - 1).
   replace (INR i - 1 + INR 1) with (INR i); [ idtac | simpl; ring ].
   replace (INR i - 1 + (INR N - INR i)) with (INR N - INR 1);
     [ idtac | simpl; ring ].
   rewrite <- minus_INR.
-  apply le_INR; apply le_trans with (pred (pred N)).
+  apply le_INR; apply Nat.le_trans with (pred (pred N)).
   assumption.
-  rewrite <- pred_of_minus; apply le_pred_n.
-  apply le_trans with 2%nat.
-  apply le_n_Sn.
+  rewrite Nat.sub_1_r; apply Nat.le_pred_l.
+  apply Nat.le_trans with 2%nat.
+  apply Nat.le_succ_diag_r.
   assumption.
-  apply le_trans with (pred (pred N)).
+  apply Nat.le_trans with (pred (pred N)).
   assumption.
-  apply le_trans with (pred N); apply le_pred_n.
-  rewrite <- pred_of_minus.
-  apply le_trans with (pred N).
+  apply Nat.le_trans with (pred N); apply Nat.le_pred_l.
+  rewrite Nat.sub_1_r.
+  apply Nat.le_trans with (pred N).
   apply le_S_n.
   replace (S (pred N)) with N.
   replace (S (pred (N - i))) with (N - i)%nat.
-  apply (fun p n m:nat => plus_le_reg_l n m p) with i; rewrite le_plus_minus_r.
-  apply le_plus_r.
-  apply le_trans with (pred (pred N));
-    [ assumption | apply le_trans with (pred N); apply le_pred_n ].
-  apply S_pred with 0%nat.
-  apply plus_lt_reg_l with i; rewrite le_plus_minus_r.
+  apply (fun p n m:nat => Nat.add_le_mono_l n m p) with i;
+    rewrite Nat.add_comm, Nat.sub_add, Nat.add_comm; [ apply Nat.le_add_r | ].
+  apply Nat.le_trans with (pred (pred N));
+    [ assumption | apply Nat.le_trans with (pred N); apply Nat.le_pred_l ].
+  symmetry; apply Nat.lt_succ_pred with 0%nat.
+  apply Nat.add_lt_mono_l with i; rewrite (Nat.add_comm _ (N - i)), Nat.sub_add.
   replace (i + 0)%nat with i; [ idtac | ring ].
-  apply le_lt_trans with (pred (pred N));
-    [ assumption | apply lt_trans with (pred N); apply lt_pred_n_n ].
-  apply lt_S_n.
+  apply Nat.le_lt_trans with (pred (pred N));
+    [ assumption | apply Nat.lt_trans with (pred N); apply Nat.lt_pred_l ].
+  apply Nat.neq_0_lt_0, Nat.succ_lt_mono.
   replace (S (pred N)) with N.
-  apply lt_le_trans with 2%nat.
-  apply lt_n_Sn.
+  apply Nat.lt_le_trans with 2%nat.
+  apply Nat.lt_succ_diag_r.
   assumption.
-  apply S_pred with 0%nat; assumption.
+  symmetry; apply Nat.lt_succ_pred with 0%nat; assumption.
+  apply Nat.neq_0_lt_0; assumption.
+  apply Nat.le_trans with (pred (pred N)).
   assumption.
-  apply le_trans with (pred (pred N)).
-  assumption.
-  apply le_trans with (pred N); apply le_pred_n.
-  apply S_pred with 0%nat; assumption.
-  apply le_pred_n.
-  apply INR_eq; rewrite pred_of_minus; do 3 rewrite S_INR; rewrite plus_INR;
+  apply Nat.le_trans with (pred N); apply Nat.le_pred_l.
+  symmetry; apply Nat.lt_succ_pred with 0%nat; assumption.
+  apply Nat.le_pred_l.
+  apply INR_eq; rewrite <- Nat.sub_1_r; do 3 rewrite S_INR; rewrite plus_INR;
     repeat rewrite minus_INR.
   simpl; ring.
-  apply le_trans with (pred (pred N)).
+  apply Nat.le_trans with (pred (pred N)).
   assumption.
-  apply le_trans with (pred N); apply le_pred_n.
+  apply Nat.le_trans with (pred N); apply Nat.le_pred_l.
   apply INR_le.
   rewrite minus_INR.
   apply Rplus_le_reg_l with (INR i - 1).
@@ -235,58 +235,58 @@ Proof.
     [ idtac | simpl; ring ].
   rewrite <- minus_INR.
   apply le_INR.
-  apply le_trans with (pred (pred N)).
+  apply Nat.le_trans with (pred (pred N)).
   assumption.
-  rewrite <- pred_of_minus.
-  apply le_pred_n.
-  apply le_trans with 2%nat.
-  apply le_n_Sn.
+  rewrite Nat.sub_1_r.
+  apply Nat.le_pred_l.
+  apply Nat.le_trans with 2%nat.
+  apply Nat.le_succ_diag_r.
   assumption.
-  apply le_trans with (pred (pred N)).
+  apply Nat.le_trans with (pred (pred N)).
   assumption.
-  apply le_trans with (pred N); apply le_pred_n.
-  apply lt_le_trans with 1%nat.
-  apply lt_O_Sn.
+  apply Nat.le_trans with (pred N); apply Nat.le_pred_l.
+  apply Nat.lt_le_trans with 1%nat.
+  apply Nat.lt_0_succ.
   apply INR_le.
-  rewrite pred_of_minus.
+  rewrite <- Nat.sub_1_r.
   repeat rewrite minus_INR.
   apply Rplus_le_reg_l with (INR i - 1).
   replace (INR i - 1 + INR 1) with (INR i); [ idtac | simpl; ring ].
   replace (INR i - 1 + (INR N - INR i - INR 1)) with (INR N - INR 1 - INR 1).
   repeat rewrite <- minus_INR.
   apply le_INR.
-  apply le_trans with (pred (pred N)).
+  apply Nat.le_trans with (pred (pred N)).
   assumption.
-  do 2 rewrite <- pred_of_minus.
+  do 2 rewrite Nat.sub_1_r.
   apply le_n.
-  apply (fun p n m:nat => plus_le_reg_l n m p) with 1%nat.
-  rewrite le_plus_minus_r.
+  apply (fun p n m:nat => Nat.add_le_mono_l n m p) with 1%nat.
+  rewrite (Nat.add_comm _ (N - 1)), Nat.sub_add.
   simpl; assumption.
-  apply le_trans with 2%nat; [ apply le_n_Sn | assumption ].
-  apply le_trans with 2%nat; [ apply le_n_Sn | assumption ].
+  apply Nat.le_trans with 2%nat; [ apply Nat.le_succ_diag_r | assumption ].
+  apply Nat.le_trans with 2%nat; [ apply Nat.le_succ_diag_r | assumption ].
   simpl; ring.
-  apply le_trans with (pred (pred N)).
+  apply Nat.le_trans with (pred (pred N)).
   assumption.
-  apply le_trans with (pred N); apply le_pred_n.
-  apply (fun p n m:nat => plus_le_reg_l n m p) with i.
-  rewrite le_plus_minus_r.
+  apply Nat.le_trans with (pred N); apply Nat.le_pred_l.
+  apply (fun p n m:nat => Nat.add_le_mono_l n m p) with i.
+  rewrite (Nat.add_comm _ (N - i)), Nat.sub_add.
   replace (i + 1)%nat with (S i).
   replace N with (S (pred N)).
   apply le_n_S.
-  apply le_trans with (pred (pred N)).
+  apply Nat.le_trans with (pred (pred N)).
   assumption.
-  apply le_pred_n.
-  symmetry ; apply S_pred with 0%nat; assumption.
+  apply Nat.le_pred_l.
+  apply Nat.lt_succ_pred with 0%nat; assumption.
   apply INR_eq; rewrite S_INR; rewrite plus_INR; reflexivity.
-  apply le_trans with (pred (pred N)).
+  apply Nat.le_trans with (pred (pred N)).
   assumption.
-  apply le_trans with (pred N); apply le_pred_n.
-  apply lt_le_trans with 1%nat.
-  apply lt_O_Sn.
+  apply Nat.le_trans with (pred N); apply Nat.le_pred_l.
+  apply Nat.lt_le_trans with 1%nat.
+  apply Nat.lt_0_succ.
   apply le_S_n.
   replace (S (pred N)) with N.
   assumption.
-  apply S_pred with 0%nat; assumption.
+  symmetry; apply Nat.lt_succ_pred with 0%nat; assumption.
   replace
     (sum_f_R0
       (fun k:nat =>
@@ -308,7 +308,7 @@ Proof.
       (decomp_sum (fun l:nat => An (S (l + i)) * Bn (S N - l)%nat)
 	(pred (S N - i))).
   replace (0 + i)%nat with i; [ idtac | ring ].
-  rewrite <- minus_n_O; apply Rplus_eq_compat_l.
+  rewrite Nat.sub_0_r; apply Rplus_eq_compat_l.
   replace (pred (pred (S N - i))) with (pred (N - i)).
   apply sum_eq; intros.
   replace (S N - S i0)%nat with (N - i0)%nat; [ idtac | reflexivity ].
@@ -317,70 +317,70 @@ Proof.
   apply INR_eq; rewrite S_INR; do 2 rewrite plus_INR; rewrite S_INR; simpl; ring.
   cut ((N - i)%nat = pred (S N - i)).
   intro; rewrite H5; reflexivity.
-  rewrite pred_of_minus.
+  rewrite <- Nat.sub_1_r.
   apply INR_eq; repeat rewrite minus_INR.
   rewrite S_INR; simpl; ring.
-  apply le_trans with N.
-  apply le_trans with (pred N).
+  apply Nat.le_trans with N.
+  apply Nat.le_trans with (pred N).
   assumption.
-  apply le_pred_n.
-  apply le_n_Sn.
-  apply (fun p n m:nat => plus_le_reg_l n m p) with i.
-  rewrite le_plus_minus_r.
+  apply Nat.le_pred_l.
+  apply Nat.le_succ_diag_r.
+  apply (fun p n m:nat => Nat.add_le_mono_l n m p) with i.
+  rewrite (Nat.add_comm _ (S N - i)), Nat.sub_add.
   replace (i + 1)%nat with (S i).
   apply le_n_S.
-  apply le_trans with (pred N).
+  apply Nat.le_trans with (pred N).
   assumption.
-  apply le_pred_n.
+  apply Nat.le_pred_l.
   apply INR_eq; rewrite S_INR; rewrite plus_INR; simpl; ring.
-  apply le_trans with N.
-  apply le_trans with (pred N).
+  apply Nat.le_trans with N.
+  apply Nat.le_trans with (pred N).
   assumption.
-  apply le_pred_n.
-  apply le_n_Sn.
-  apply le_trans with (pred N).
+  apply Nat.le_pred_l.
+  apply Nat.le_succ_diag_r.
+  apply Nat.le_trans with (pred N).
   assumption.
-  apply le_pred_n.
+  apply Nat.le_pred_l.
   replace (pred (S N - i)) with (S N - S i)%nat.
   replace (S N - S i)%nat with (N - i)%nat; [ idtac | reflexivity ].
-  apply plus_lt_reg_l with i.
-  rewrite le_plus_minus_r.
+  apply Nat.add_lt_mono_l with i.
+  rewrite (Nat.add_comm _ (N - i)), Nat.sub_add.
   replace (i + 0)%nat with i; [ idtac | ring ].
-  apply le_lt_trans with (pred N).
+  apply Nat.le_lt_trans with (pred N).
   assumption.
-  apply lt_pred_n_n.
+  apply Nat.lt_pred_l, Nat.neq_0_lt_0.
   assumption.
-  apply le_trans with (pred N).
+  apply Nat.le_trans with (pred N).
   assumption.
-  apply le_pred_n.
-  rewrite pred_of_minus.
+  apply Nat.le_pred_l.
+  rewrite <- Nat.sub_1_r.
   apply INR_eq; repeat rewrite minus_INR.
   repeat rewrite S_INR; simpl; ring.
-  apply le_trans with N.
-  apply le_trans with (pred N).
+  apply Nat.le_trans with N.
+  apply Nat.le_trans with (pred N).
   assumption.
-  apply le_pred_n.
-  apply le_n_Sn.
-  apply (fun p n m:nat => plus_le_reg_l n m p) with i.
-  rewrite le_plus_minus_r.
+  apply Nat.le_pred_l.
+  apply Nat.le_succ_diag_r.
+  apply (fun p n m:nat => Nat.add_lt_mono_l n m p) with i.
+  rewrite (Nat.add_comm _ (S N - i)), Nat.sub_add.
   replace (i + 1)%nat with (S i).
   apply le_n_S.
-  apply le_trans with (pred N).
-  assumption.
-  apply le_pred_n.
+  apply Nat.le_trans with (pred N).
+  rewrite Nat.add_0_r; assumption.
+  apply Nat.le_pred_l.
   apply INR_eq; rewrite S_INR; rewrite plus_INR; simpl; ring.
-  apply le_trans with N.
-  apply le_trans with (pred N).
+  apply Nat.le_trans with N.
+  apply Nat.le_trans with (pred N).
   assumption.
-  apply le_pred_n.
-  apply le_n_Sn.
+  apply Nat.le_pred_l.
+  apply Nat.le_succ_diag_r.
   apply le_n_S.
-  apply le_trans with (pred N).
+  apply Nat.le_trans with (pred N).
   assumption.
-  apply le_pred_n.
+  apply Nat.le_pred_l.
   rewrite Rplus_comm.
   rewrite (decomp_sum (fun p:nat => An p * Bn (S N - p)%nat) N).
-  rewrite <- minus_n_O.
+  rewrite Nat.sub_0_r.
   apply Rplus_eq_compat_l.
   apply sum_eq; intros.
   reflexivity.
@@ -391,7 +391,7 @@ Proof.
       (fun k:nat =>
 	sum_f_R0 (fun l:nat => An (S (l + k)) * Bn (N - l)%nat) (pred (N - k)))
       (pred N)).
-  rewrite <- minus_n_O.
+  rewrite Nat.sub_0_r.
   replace (sum_f_R0 (fun l:nat => An (S (l + 0)) * Bn (N - l)%nat) (pred N))
     with (sum_f_R0 (fun l:nat => An (S l) * Bn (N - l)%nat) (pred N)).
   apply Rplus_eq_compat_l.
@@ -403,60 +403,60 @@ Proof.
   apply INR_eq; rewrite S_INR; do 2 rewrite plus_INR; rewrite S_INR; simpl; ring.
   cut (pred (N - i) = (N - S i)%nat).
   intro; rewrite H5; reflexivity.
-  rewrite pred_of_minus.
+  rewrite <- Nat.sub_1_r.
   apply INR_eq.
   repeat rewrite minus_INR.
   repeat rewrite S_INR; simpl; ring.
-  apply le_trans with (S (pred (pred N))).
+  apply Nat.le_trans with (S (pred (pred N))).
   apply le_n_S; assumption.
   replace (S (pred (pred N))) with (pred N).
-  apply le_pred_n.
-  apply S_pred with 0%nat.
-  apply lt_S_n.
+  apply Nat.le_pred_l.
+  symmetry; apply Nat.lt_succ_pred with 0%nat.
+  apply Nat.succ_lt_mono.
   replace (S (pred N)) with N.
-  apply lt_le_trans with 2%nat.
-  apply lt_n_Sn.
+  apply Nat.lt_le_trans with 2%nat.
+  apply Nat.lt_succ_diag_r.
   assumption.
-  apply S_pred with 0%nat; assumption.
-  apply le_trans with (pred (pred N)).
+  symmetry; apply Nat.lt_succ_pred with 0%nat; assumption.
+  apply Nat.le_trans with (pred (pred N)).
   assumption.
-  apply le_trans with (pred N); apply le_pred_n.
-  apply (fun p n m:nat => plus_le_reg_l n m p) with i.
-  rewrite le_plus_minus_r.
+  apply Nat.le_trans with (pred N); apply Nat.le_pred_l.
+  apply (fun p n m:nat => Nat.add_le_mono_l n m p) with i.
+  rewrite (Nat.add_comm _ (N - i)), Nat.sub_add.
   replace (i + 1)%nat with (S i).
   replace N with (S (pred N)).
   apply le_n_S.
-  apply le_trans with (pred (pred N)).
+  apply Nat.le_trans with (pred (pred N)).
   assumption.
-  apply le_pred_n.
-  symmetry ; apply S_pred with 0%nat; assumption.
+  apply Nat.le_pred_l.
+  apply Nat.lt_succ_pred with 0%nat; assumption.
   apply INR_eq; rewrite S_INR; rewrite plus_INR; simpl; ring.
-  apply le_trans with (pred (pred N)).
+  apply Nat.le_trans with (pred (pred N)).
   assumption.
-  apply le_trans with (pred N); apply le_pred_n.
+  apply Nat.le_trans with (pred N); apply Nat.le_pred_l.
   apply sum_eq; intros.
   replace (i + 0)%nat with i; [ reflexivity | trivial ].
-  apply lt_S_n.
+  apply Nat.succ_lt_mono.
   replace (S (pred N)) with N.
-  apply lt_le_trans with 2%nat; [ apply lt_n_Sn | assumption ].
-  apply S_pred with 0%nat; assumption.
+  apply Nat.lt_le_trans with 2%nat; [ apply Nat.lt_succ_diag_r | assumption ].
+  symmetry; apply Nat.lt_succ_pred with 0%nat; assumption.
   inversion H1.
   left; reflexivity.
   right; apply le_n_S; assumption.
   simpl.
   replace (S (pred N)) with N.
   reflexivity.
-  apply S_pred with 0%nat; assumption.
+  symmetry; apply Nat.lt_succ_pred with 0%nat; assumption.
   simpl.
   cut ((N - pred N)%nat = 1%nat).
   intro; rewrite H2; reflexivity.
-  rewrite pred_of_minus.
+  rewrite <- Nat.sub_1_r.
   apply INR_eq; repeat rewrite minus_INR.
   simpl; ring.
-  apply lt_le_S; assumption.
-  rewrite <- pred_of_minus; apply le_pred_n.
-  simpl; symmetry ; apply S_pred with 0%nat; assumption.
+  apply Nat.le_succ_l; assumption.
+  rewrite Nat.sub_1_r; apply Nat.le_pred_l.
+  simpl; apply Nat.lt_succ_pred with 0%nat; assumption.
   inversion H.
   left; reflexivity.
-  right; apply lt_le_trans with 1%nat; [ apply lt_n_Sn | exact H1 ].
+  right; apply Nat.lt_le_trans with 1%nat; [ apply Nat.lt_succ_diag_r | exact H1 ].
 Qed.

--- a/theories/Reals/ClassicalDedekindReals.v
+++ b/theories/Reals/ClassicalDedekindReals.v
@@ -343,7 +343,7 @@ Proof.
   destruct (DRealQlim x (pred (2^n))%nat) as [q qmaj].
   exists q.
   rewrite Nat.succ_pred_pos in qmaj.
-    2: apply neq_0_lt, not_eq_sym, Nat.pow_nonzero; intros contra; inversion contra.
+    2: apply Nat.neq_0_lt_0, Nat.pow_nonzero; intros contra; inversion contra.
   exact qmaj.
 Qed.
 
@@ -480,7 +480,7 @@ Proof.
     apply Qplus_le_r. apply (Qle_trans _ (1 # p)).
     unfold Qle, Qnum, Qden. do 2 rewrite Z.mul_1_l.
     apply Pos2Z.pos_le_pos. apply Pos2Nat.inj_le.
-    rewrite Nat2Pos.id. apply le_S, le_refl. discriminate.
+    rewrite Nat2Pos.id. apply le_S, Nat.le_refl. discriminate.
     apply (Qmult_le_l _ _ ( (Z.pos p # 1) / (r-q))).
     rewrite <- (Qmult_0_r (Z.pos p #1)). apply Qmult_lt_l.
     reflexivity. apply Qinv_lt_0_compat.

--- a/theories/Reals/Cos_plus.v
+++ b/theories/Reals/Cos_plus.v
@@ -13,7 +13,6 @@ Require Import Rfunctions.
 Require Import SeqSeries.
 Require Import Rtrigo_def.
 Require Import Cos_rel.
-Require Import Max.
 Require Import Lia.
 Local Open Scope nat_scope.
 Local Open Scope R_scope.
@@ -167,28 +166,28 @@ Proof.
   apply INR_eq; rewrite plus_INR; do 3 rewrite mult_INR.
   rewrite minus_INR.
   repeat rewrite S_INR; do 2 rewrite plus_INR; ring.
-  apply le_trans with (pred (N - n)).
+  apply Nat.le_trans with (pred (N - n)).
   exact H1.
   apply le_S_n.
   replace (S (pred (N - n))) with (N - n)%nat.
-  apply le_trans with N.
-  apply (fun p n m:nat => plus_le_reg_l n m p) with n.
-  rewrite <- le_plus_minus.
-  apply le_plus_r.
-  apply le_trans with (pred N).
+  apply Nat.le_trans with N.
+  apply (fun p n m:nat => Nat.add_le_mono_l n m p) with n.
+  rewrite Nat.add_comm, Nat.sub_add.
+  rewrite Nat.add_comm; apply Nat.le_add_r.
+  apply Nat.le_trans with (pred N).
   assumption.
-  apply le_pred_n.
-  apply le_n_Sn.
-  apply S_pred with 0%nat.
-  apply plus_lt_reg_l with n.
-  rewrite <- le_plus_minus.
+  apply Nat.le_pred_l.
+  apply Nat.le_succ_diag_r.
+  symmetry; apply Nat.lt_succ_pred with 0%nat.
+  apply Nat.add_lt_mono_l with n.
+  rewrite (Nat.add_comm _ (N - n)), Nat.sub_add.
   replace (n + 0)%nat with n; [ idtac | ring ].
-  apply le_lt_trans with (pred N).
+  apply Nat.le_lt_trans with (pred N).
   assumption.
-  apply lt_pred_n_n; assumption.
-  apply le_trans with (pred N).
+  apply Nat.lt_pred_l, Nat.neq_0_lt_0; assumption.
+  apply Nat.le_trans with (pred N).
   assumption.
-  apply le_pred_n.
+  apply Nat.le_pred_l.
   apply INR_fact_neq_0.
   apply INR_fact_neq_0.
   apply Rle_ge; left; apply Rinv_0_lt_compat; apply INR_fact_lt_0.
@@ -208,11 +207,11 @@ Proof.
   apply Rle_pow.
   unfold C; apply RmaxLess1.
   replace (4 * N)%nat with (2 * (2 * N))%nat; [ idtac | ring ].
-  apply (fun m n p:nat => mult_le_compat_l p n m).
+  apply (fun m n p:nat => Nat.mul_le_mono_nonneg_l p n m). apply Nat.le_0_l.
   replace (2 * N)%nat with (S (N + pred N)).
   apply le_n_S.
-  apply plus_le_compat_l; assumption.
-  rewrite pred_of_minus.
+  apply Nat.add_le_mono_l; assumption.
+  rewrite <- Nat.sub_1_r.
   lia.
   apply Rle_trans with
     (sum_f_R0
@@ -292,7 +291,7 @@ Proof.
   rewrite <- Rinv_r_sym.
   rewrite Rmult_1_r.
   apply (le_INR 1).
-  apply lt_le_S.
+  apply Nat.le_succ_l.
   apply INR_lt; apply INR_fact_lt_0.
   apply INR_fact_neq_0.
   apply Rmult_le_reg_l with (INR (fact (S (N + n)))).
@@ -307,8 +306,8 @@ Proof.
   rewrite Rmult_1_r.
   apply le_INR.
   apply fact_le.
-  apply le_n_S.
-  apply le_plus_l.
+  apply -> Nat.succ_le_mono.
+  apply Nat.le_add_r.
   apply INR_fact_neq_0.
   apply INR_fact_neq_0.
   rewrite sum_cte.
@@ -335,28 +334,28 @@ Proof.
   apply Rmult_le_compat_l.
   left; apply Rinv_0_lt_compat; apply INR_fact_lt_0.
   apply Rmult_le_reg_l with (INR (S N)).
-  apply lt_INR_0; apply lt_O_Sn.
+  apply lt_INR_0; apply Nat.lt_0_succ.
   rewrite <- Rmult_assoc; rewrite <- Rinv_r_sym.
   rewrite Rmult_1_r; rewrite Rmult_1_l.
-  apply le_INR; apply le_n_Sn.
+  apply le_INR; apply Nat.le_succ_diag_r.
   apply not_O_INR; discriminate.
   apply not_O_INR.
-  red; intro; rewrite H1 in H; elim (lt_irrefl _ H).
+  red; intro; rewrite H1 in H; elim (Nat.lt_irrefl _ H).
   apply not_O_INR.
-  red; intro; rewrite H1 in H; elim (lt_irrefl _ H).
+  red; intro; rewrite H1 in H; elim (Nat.lt_irrefl _ H).
   apply INR_fact_neq_0.
   apply not_O_INR; discriminate.
   apply prod_neq_R0.
   apply not_O_INR.
-  red; intro; rewrite H1 in H; elim (lt_irrefl _ H).
+  red; intro; rewrite H1 in H; elim (Nat.lt_irrefl _ H).
   apply INR_fact_neq_0.
-  symmetry ; apply S_pred with 0%nat; assumption.
+  apply Nat.lt_succ_pred with 0%nat; assumption.
   right.
   unfold Majxy.
   unfold C.
   replace (S (pred N)) with N.
   reflexivity.
-  apply S_pred with 0%nat; assumption.
+  symmetry; apply Nat.lt_succ_pred with 0%nat; assumption.
 Qed.
 
 Lemma reste2_maj :
@@ -480,13 +479,13 @@ Proof.
   apply Rle_pow.
   unfold C; apply RmaxLess1.
   replace (4 * S N)%nat with (2 * (2 * S N))%nat; [ idtac | ring ].
-  apply (fun m n p:nat => mult_le_compat_l p n m).
+  apply (fun m n p:nat => Nat.mul_le_mono_nonneg_l p n m). apply Nat.le_0_l.
   replace (2 * S N)%nat with (S (S (N + N))).
   repeat apply le_n_S.
-  apply plus_le_compat_l.
-  apply le_trans with (pred N).
+  apply Nat.add_le_mono_l.
+  apply Nat.le_trans with (pred N).
   assumption.
-  apply le_pred_n.
+  apply Nat.le_pred_l.
   ring.
   apply Rle_trans with
     (sum_f_R0
@@ -513,9 +512,9 @@ Proof.
   apply Rmult_le_compat_l.
   left; apply Rinv_0_lt_compat; apply INR_fact_lt_0.
   apply C_maj.
-  apply le_trans with (2 * S (S (n0 + n)))%nat.
+  apply Nat.le_trans with (2 * S (S (n0 + n)))%nat.
   replace (2 * S (S (n0 + n)))%nat with (S (2 * S (n0 + n) + 1)).
-  apply le_n_Sn.
+  apply Nat.le_succ_diag_r.
   ring.
   lia.
   right.
@@ -577,7 +576,7 @@ Proof.
   rewrite <- Rinv_r_sym.
   rewrite Rmult_1_r.
   apply (le_INR 1).
-  apply lt_le_S.
+  apply Nat.le_succ_l.
   apply INR_lt; apply INR_fact_lt_0.
   apply INR_fact_neq_0.
   apply Rmult_le_reg_l with (INR (fact (S (S (N + n))))).
@@ -615,22 +614,22 @@ Proof.
   rewrite (Rmult_comm (INR (S (S N)))).
   apply Rmult_le_compat_l.
   repeat apply Rmult_le_pos.
-  left; apply Rinv_0_lt_compat; apply lt_INR_0; apply lt_O_Sn.
-  left; apply Rinv_0_lt_compat; apply lt_INR_0; apply lt_O_Sn.
+  left; apply Rinv_0_lt_compat; apply lt_INR_0; apply Nat.lt_0_succ.
+  left; apply Rinv_0_lt_compat; apply lt_INR_0; apply Nat.lt_0_succ.
   left; apply Rinv_0_lt_compat.
   apply INR_fact_lt_0.
   apply pos_INR.
   apply le_INR.
-  apply le_trans with (S N); apply le_n_Sn.
+  apply Nat.le_trans with (S N); apply Nat.le_succ_diag_r.
   repeat rewrite <- Rmult_assoc.
   rewrite <- Rinv_r_sym.
   rewrite Rmult_1_l.
   apply Rle_trans with (/ INR (S N) * / INR (fact N) * INR (S N)).
   repeat rewrite Rmult_assoc.
   repeat apply Rmult_le_compat_l.
-  left; apply Rinv_0_lt_compat; apply lt_INR_0; apply lt_O_Sn.
+  left; apply Rinv_0_lt_compat; apply lt_INR_0; apply Nat.lt_0_succ.
   left; apply Rinv_0_lt_compat; apply INR_fact_lt_0.
-  apply le_INR; apply le_n_Sn.
+  apply le_INR; apply Nat.le_succ_diag_r.
   rewrite (Rmult_comm (/ INR (S N))).
   rewrite Rmult_assoc.
   rewrite <- Rinv_l_sym.
@@ -641,7 +640,7 @@ Proof.
   apply INR_fact_neq_0.
   apply not_O_INR; discriminate.
   apply prod_neq_R0; [ apply not_O_INR; discriminate | apply INR_fact_neq_0 ].
-  symmetry ; apply S_pred with 0%nat; assumption.
+  apply Nat.lt_succ_pred with 0%nat; assumption.
   right.
   unfold Majxy.
   unfold C.
@@ -660,8 +659,8 @@ Proof.
   apply Rle_lt_trans with (Rabs (Majxy x y (pred n))).
   rewrite (Rabs_right (Majxy x y (pred n))).
   apply reste1_maj.
-  apply lt_le_trans with (S N0).
-  apply lt_O_Sn.
+  apply Nat.lt_le_trans with (S N0).
+  apply Nat.lt_0_succ.
   assumption.
   apply Rle_ge.
   unfold Majxy.
@@ -676,8 +675,8 @@ Proof.
   unfold ge; apply le_S_n.
   replace (S (pred n)) with n.
   assumption.
-  apply S_pred with 0%nat.
-  apply lt_le_trans with (S N0); [ apply lt_O_Sn | assumption ].
+  symmetry; apply Nat.lt_succ_pred with 0%nat.
+  apply Nat.lt_le_trans with (S N0); [ apply Nat.lt_0_succ | assumption ].
 Qed.
 
 Lemma reste2_cv_R0 : forall x y:R, Un_cv (Reste2 x y) 0.
@@ -692,8 +691,8 @@ Proof.
   apply Rle_lt_trans with (Rabs (Majxy x y n)).
   rewrite (Rabs_right (Majxy x y n)).
   apply reste2_maj.
-  apply lt_le_trans with (S N0).
-  apply lt_O_Sn.
+  apply Nat.lt_le_trans with (S N0).
+  apply Nat.lt_0_succ.
   assumption.
   apply Rle_ge.
   unfold Majxy.
@@ -705,8 +704,8 @@ Proof.
   left; apply Rinv_0_lt_compat; apply INR_fact_lt_0.
   replace (Majxy x y n) with (Majxy x y n - 0); [ idtac | ring ].
   apply H1.
-  unfold ge; apply le_trans with (S N0).
-  apply le_n_Sn.
+  unfold ge; apply Nat.le_trans with (S N0).
+  apply Nat.le_succ_diag_r.
   exact H2.
 Qed.
 
@@ -733,9 +732,9 @@ Proof.
   elim (H0 eps H1); intros N0 H2.
   exists N0; intros.
   apply H2.
-  unfold ge; apply le_trans with (S N0).
-  apply le_n_Sn.
-  apply le_n_S; assumption.
+  unfold ge; apply Nat.le_trans with (S N0).
+  apply Nat.le_succ_diag_r.
+  apply -> Nat.succ_le_mono; assumption.
   unfold An, Bn.
   intro.
   replace 0 with (0 - 0); [ idtac | ring ].
@@ -787,13 +786,13 @@ Proof.
   replace eps with (eps / 3 + (eps / 3 + eps / 3)).
   apply Rplus_lt_compat.
   apply H8.
-  unfold ge; apply le_trans with N.
+  unfold ge; apply Nat.le_trans with N.
   unfold N.
-  apply le_trans with (max N1 N2).
-  apply le_max_l.
-  apply le_trans with (max (max N1 N2) N3).
-  apply le_max_l.
-  apply le_trans with (S (max (max N1 N2) N3)); apply le_n_Sn.
+  apply Nat.le_trans with (max N1 N2).
+  apply Nat.le_max_l.
+  apply Nat.le_trans with (max (max N1 N2) N3).
+  apply Nat.le_max_l.
+  apply Nat.le_trans with (S (max (max N1 N2) N3)); apply Nat.le_succ_diag_r.
   assumption.
   apply Rle_lt_trans with
     (Rabs (sin x * sin y - B1 x (pred n) * B1 y (pred n)) +
@@ -803,28 +802,28 @@ Proof.
   rewrite <- Rabs_Ropp.
   rewrite Ropp_minus_distr.
   apply H9.
-  unfold ge; apply le_trans with (max N1 N2).
-  apply le_max_r.
-  apply le_S_n.
+  unfold ge; apply Nat.le_trans with (max N1 N2).
+  apply Nat.le_max_r.
+  apply Nat.succ_le_mono.
   rewrite <- H12.
-  apply le_trans with N.
+  apply Nat.le_trans with N.
   unfold N.
-  apply le_n_S.
-  apply le_trans with (max (max N1 N2) N3).
-  apply le_max_l.
-  apply le_n_Sn.
+  apply -> Nat.succ_le_mono.
+  apply Nat.le_trans with (max (max N1 N2) N3).
+  apply Nat.le_max_l.
+  apply Nat.le_succ_diag_r.
   assumption.
   replace (Reste x y (pred n)) with (Reste x y (pred n) - 0).
   apply H10.
   unfold ge.
-  apply le_S_n.
+  apply Nat.succ_le_mono.
   rewrite <- H12.
-  apply le_trans with N.
+  apply Nat.le_trans with N.
   unfold N.
-  apply le_n_S.
-  apply le_trans with (max (max N1 N2) N3).
-  apply le_max_r.
-  apply le_n_Sn.
+  apply -> Nat.succ_le_mono.
+  apply Nat.le_trans with (max (max N1 N2) N3).
+  apply Nat.le_max_r.
+  apply Nat.le_succ_diag_r.
   assumption.
   ring.
   pattern eps at 4; replace eps with (3 * (eps / 3)).
@@ -833,8 +832,8 @@ Proof.
   rewrite <- Rmult_assoc.
   apply Rinv_r_simpl_m.
   discrR.
-  apply lt_le_trans with (pred N).
-  unfold N; simpl; apply lt_O_Sn.
+  apply Nat.lt_le_trans with (pred N).
+  unfold N; simpl; apply Nat.lt_0_succ.
   apply le_S_n.
   rewrite <- H12.
   replace (S (pred N)) with N.
@@ -844,7 +843,10 @@ Proof.
   intro.
   cut (0 < n)%nat.
   intro.
-  apply S_pred with 0%nat; assumption.
-  apply lt_le_trans with N; assumption.
-  unfold N; apply lt_O_Sn.
+  symmetry; apply Nat.lt_succ_pred with 0%nat; assumption.
+  apply Nat.lt_le_trans with N; assumption.
+  unfold N; apply Nat.lt_0_succ.
 Qed.
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Import Max.

--- a/theories/Reals/Cos_rel.v
+++ b/theories/Reals/Cos_rel.v
@@ -201,7 +201,7 @@ simpl.
 pattern i at 2; replace i with (i0 + (i - i0))%nat.
 rewrite pow_add.
 ring.
-symmetry ; apply le_plus_minus; assumption.
+rewrite Nat.add_comm; apply Nat.sub_add; assumption.
 unfold C.
 unfold Rdiv; repeat rewrite <- Rmult_assoc.
 rewrite <- Rinv_l_sym.
@@ -216,7 +216,7 @@ apply INR_fact_neq_0.
 apply INR_fact_neq_0.
 apply INR_fact_neq_0.
 reflexivity.
-apply lt_O_Sn.
+apply Nat.lt_0_succ.
 (* ring. *)
 apply sum_eq; intros.
 rewrite scal_sum.
@@ -232,7 +232,7 @@ ring.
 pattern i at 2; replace i with (i0 + (i - i0))%nat.
 rewrite pow_add.
 ring.
-symmetry ; apply le_plus_minus; assumption.
+rewrite Nat.add_comm; apply Nat.sub_add; assumption.
 unfold C.
 unfold Rdiv; repeat rewrite <- Rmult_assoc.
 rewrite <- Rinv_l_sym.
@@ -250,7 +250,7 @@ unfold Rdiv; ring.
 unfold Reste1; apply sum_eq; intros.
 apply sum_eq; intros.
 unfold Rdiv; ring.
-apply lt_O_Sn.
+apply Nat.lt_0_succ.
 Qed.
 
 Lemma pow_sqr : forall (x:R) (i:nat), x ^ (2 * i) = (x * x) ^ i.
@@ -319,7 +319,7 @@ induction  n as [| n Hrecn].
 simpl; ring.
 rewrite tech5; rewrite <- Hrecn.
 simpl; ring.
-unfold ge; apply le_O_n.
+unfold ge; apply Nat.le_0_l.
 unfold sin. destruct (exist_sin (Rsqr x)) as (x0,p).
 unfold sin_in, sin_n, infinite_sum, R_dist in p.
 unfold Un_cv, R_dist; intros.

--- a/theories/Reals/DiscrR.v
+++ b/theories/Reals/DiscrR.v
@@ -14,7 +14,7 @@ Local Open Scope R_scope.
 
 Lemma Rlt_R0_R2 : 0 < 2.
 Proof.
-change 2 with (INR 2); apply lt_INR_0; apply lt_O_Sn.
+change 2 with (INR 2); apply lt_INR_0; apply Nat.lt_0_succ.
 Qed.
 
 Notation Rplus_lt_pos := Rplus_lt_0_compat (only parsing).

--- a/theories/Reals/Exp_prop.v
+++ b/theories/Reals/Exp_prop.v
@@ -14,9 +14,6 @@ Require Import SeqSeries.
 Require Import Rtrigo1.
 Require Import Ranalysis1.
 Require Import PSeries_reg.
-Require Import Div2.
-Require Import Even.
-Require Import Max.
 Require Import Lia.
 Local Open Scope nat_scope.
 Local Open Scope R_scope.
@@ -65,10 +62,10 @@ Qed.
 Definition maj_Reste_E (x y:R) (N:nat) : R :=
   4 *
   (Rmax 1 (Rmax (Rabs x) (Rabs y)) ^ (2 * N) /
-    Rsqr (INR (fact (div2 (pred N))))).
+    Rsqr (INR (fact (Nat.div2 (pred N))))).
 
 (**********)
-Lemma div2_double : forall N:nat, div2 (2 * N) = N.
+Lemma div2_double : forall N:nat, Nat.div2 (2 * N) = N.
 Proof.
   intro; induction  N as [| N HrecN].
   reflexivity.
@@ -77,7 +74,7 @@ Proof.
   ring.
 Qed.
 
-Lemma div2_S_double : forall N:nat, div2 (S (2 * N)) = N.
+Lemma div2_S_double : forall N:nat, Nat.div2 (S (2 * N)) = N.
 Proof.
   intro; induction  N as [| N HrecN].
   reflexivity.
@@ -86,19 +83,17 @@ Proof.
   ring.
 Qed.
 
-Lemma div2_not_R0 : forall N:nat, (1 < N)%nat -> (0 < div2 N)%nat.
+Lemma div2_not_R0 : forall N:nat, (1 < N)%nat -> (0 < Nat.div2 N)%nat.
 Proof.
   intros; induction N as [| N HrecN].
-  - elim (lt_n_O _ H).
+  - elim (Nat.nlt_0_r _ H).
   - cut ((1 < N)%nat \/ N = 1%nat).
     { intro; elim H0; intro.
-      + destruct (even_odd_dec N) as [Heq|Heq].
-        * rewrite <- (even_div2 _ Heq); apply HrecN; assumption.
-        * rewrite <- (odd_div2 _ Heq); apply lt_O_Sn.
-      + rewrite H1; simpl; apply lt_O_Sn. }
+      + destruct N; cbn; [ auto |  apply Nat.lt_0_succ ].
+      + subst N; simpl; apply Nat.lt_0_succ. }
     inversion H.
     right; reflexivity.
-    left; apply lt_le_trans with 2%nat; [ apply lt_n_Sn | apply H1 ].
+    left; apply Nat.lt_le_trans with 2%nat; [ apply Nat.lt_succ_diag_r | assumption ].
 Qed.
 
 Lemma Reste_E_maj :
@@ -110,7 +105,7 @@ Proof.
     (M ^ (2 * N) *
       sum_f_R0
       (fun k:nat =>
-        sum_f_R0 (fun l:nat => / Rsqr (INR (fact (div2 (S N)))))
+        sum_f_R0 (fun l:nat => / Rsqr (INR (fact (Nat.div2 (S N)))))
         (pred (N - k))) (pred N)).
   unfold Reste_E.
   apply Rle_trans with
@@ -178,7 +173,7 @@ Proof.
   apply Rinv_le_contravar.
   apply INR_fact_lt_0.
   apply le_INR; apply fact_le; apply le_n_S.
-  apply le_plus_l.
+  apply Nat.le_add_r.
   rewrite (Rmult_comm (M ^ (2 * N))); rewrite Rmult_assoc;
     apply Rmult_le_compat_l.
   left; apply Rinv_0_lt_compat; apply INR_fact_lt_0.
@@ -205,36 +200,37 @@ Proof.
   apply Rle_pow.
   unfold M; apply RmaxLess1.
   replace (2 * N)%nat with (N + N)%nat; [ idtac | ring ].
-  apply plus_le_compat_l.
+  apply Nat.add_le_mono_l.
   replace N with (S (pred N)).
   apply le_n_S; apply H0.
-  symmetry ; apply S_pred with 0%nat; apply H.
+  apply Nat.lt_succ_pred with 0%nat; apply H.
   apply INR_eq; do 2 rewrite plus_INR; do 2 rewrite S_INR; rewrite plus_INR;
     rewrite minus_INR.
   ring.
-  apply le_trans with (pred (N - n)).
+  apply Nat.le_trans with (pred (N - n)).
   apply H1.
-  apply le_S_n.
+  apply Nat.succ_le_mono.
   replace (S (pred (N - n))) with (N - n)%nat.
-  apply le_trans with N.
-  apply (fun p n m:nat => plus_le_reg_l n m p) with n.
-  rewrite <- le_plus_minus.
-  apply le_plus_r.
-  apply le_trans with (pred N).
+  apply Nat.le_trans with N.
+  apply (fun p n m:nat => Nat.add_le_mono_l n m p) with n.
+  rewrite Nat.add_comm, Nat.sub_add.
+  rewrite Nat.add_comm; apply Nat.le_add_r.
+  apply Nat.le_trans with (pred N).
   apply H0.
-  apply le_pred_n.
-  apply le_n_Sn.
-  apply S_pred with 0%nat.
-  apply plus_lt_reg_l with n.
-  rewrite <- le_plus_minus.
+  apply Nat.le_pred_l.
+  apply Nat.le_succ_diag_r.
+  symmetry; apply Nat.lt_succ_pred with 0%nat.
+  apply Nat.add_lt_mono_l with n.
+  rewrite (Nat.add_comm _ (N - n)), Nat.sub_add.
   replace (n + 0)%nat with n; [ idtac | ring ].
-  apply le_lt_trans with (pred N).
+  apply Nat.le_lt_trans with (pred N).
   apply H0.
-  apply lt_pred_n_n.
+  apply Nat.lt_pred_l.
+  apply Nat.neq_0_lt_0.
   apply H.
-  apply le_trans with (pred N).
+  apply Nat.le_trans with (pred N).
   apply H0.
-  apply le_pred_n.
+  apply Nat.le_pred_l.
   apply Rle_ge; left; apply Rinv_0_lt_compat; apply INR_fact_lt_0.
   apply Rle_ge; left; apply Rinv_0_lt_compat; apply INR_fact_lt_0.
   rewrite scal_sum.
@@ -242,7 +238,7 @@ Proof.
   rewrite <- Rmult_comm.
   rewrite scal_sum.
   apply sum_Rle; intros.
-  rewrite (Rmult_comm (/ Rsqr (INR (fact (div2 (S N)))))).
+  rewrite (Rmult_comm (/ Rsqr (INR (fact (Nat.div2 (S N)))))).
   rewrite Rmult_assoc; apply Rmult_le_compat_l.
   apply pow_le.
   apply Rle_trans with 1.
@@ -259,7 +255,7 @@ Proof.
   apply INR_fact_lt_0.
   apply le_INR.
   apply fact_le.
-  apply le_n_Sn.
+  apply Nat.le_succ_diag_r.
   replace (/ INR (fact n0) * / INR (fact (N - n0))) with
   (C N n0 / INR (fact N)).
   pattern N at 1; rewrite H4.
@@ -269,29 +265,30 @@ Proof.
   left; apply Rinv_0_lt_compat; apply INR_fact_lt_0.
   rewrite H4.
   apply C_maj.
-  rewrite <- H4; apply le_trans with (pred (N - n)).
+  rewrite <- H4; apply Nat.le_trans with (pred (N - n)).
   apply H1.
-  apply le_S_n.
+  apply Nat.succ_le_mono.
   replace (S (pred (N - n))) with (N - n)%nat.
-  apply le_trans with N.
-  apply (fun p n m:nat => plus_le_reg_l n m p) with n.
-  rewrite <- le_plus_minus.
-  apply le_plus_r.
-  apply le_trans with (pred N).
+  apply Nat.le_trans with N.
+  apply (fun p n m:nat => Nat.add_le_mono_l n m p) with n.
+  rewrite (Nat.add_comm _ (N - n)), Nat.sub_add.
+  rewrite Nat.add_comm; apply Nat.le_add_r.
+  apply Nat.le_trans with (pred N).
   apply H0.
-  apply le_pred_n.
-  apply le_n_Sn.
-  apply S_pred with 0%nat.
-  apply plus_lt_reg_l with n.
-  rewrite <- le_plus_minus.
+  apply Nat.le_pred_l.
+  apply Nat.le_succ_diag_r.
+  symmetry; apply Nat.lt_succ_pred with 0%nat.
+  apply Nat.add_lt_mono_l with n.
+  rewrite (Nat.add_comm _ (N - n)), Nat.sub_add.
   replace (n + 0)%nat with n; [ idtac | ring ].
-  apply le_lt_trans with (pred N).
+  apply Nat.le_lt_trans with (pred N).
   apply H0.
-  apply lt_pred_n_n.
+  apply Nat.lt_pred_l.
+  apply Nat.neq_0_lt_0.
   apply H.
-  apply le_trans with (pred N).
+  apply Nat.le_trans with (pred N).
   apply H0.
-  apply le_pred_n.
+  apply Nat.le_pred_l.
   replace (C N N0 / INR (fact N)) with (/ Rsqr (INR (fact N0))).
   rewrite H4; rewrite div2_S_double; right; reflexivity.
   unfold Rsqr, C, Rdiv.
@@ -302,7 +299,7 @@ Proof.
   rewrite Rmult_1_r; replace (N - N0)%nat with N0.
   ring.
   replace N with (N0 + N0)%nat.
-  symmetry ; apply minus_plus.
+  symmetry; apply Nat.add_sub.
   rewrite H4.
   ring.
   apply INR_fact_neq_0.
@@ -328,29 +325,30 @@ Proof.
   cut (S N = (2 * S N0)%nat).
   intro; rewrite H5; apply C_maj.
   rewrite <- H5; apply le_n_S.
-  apply le_trans with (pred (N - n)).
+  apply Nat.le_trans with (pred (N - n)).
   apply H1.
-  apply le_S_n.
+  apply Nat.succ_le_mono.
   replace (S (pred (N - n))) with (N - n)%nat.
-  apply le_trans with N.
-  apply (fun p n m:nat => plus_le_reg_l n m p) with n.
-  rewrite <- le_plus_minus.
-  apply le_plus_r.
-  apply le_trans with (pred N).
+  apply Nat.le_trans with N.
+  apply (fun p n m:nat => Nat.add_le_mono_l n m p) with n.
+  rewrite (Nat.add_comm _ (N - n)), Nat.sub_add.
+  rewrite Nat.add_comm; apply Nat.le_add_r.
+  apply Nat.le_trans with (pred N).
   apply H0.
-  apply le_pred_n.
-  apply le_n_Sn.
-  apply S_pred with 0%nat.
-  apply plus_lt_reg_l with n.
-  rewrite <- le_plus_minus.
+  apply Nat.le_pred_l.
+  apply Nat.le_succ_diag_r.
+  symmetry; apply Nat.lt_succ_pred with 0%nat.
+  apply Nat.add_lt_mono_l with n.
+  rewrite (Nat.add_comm _ (N - n)), Nat.sub_add.
   replace (n + 0)%nat with n; [ idtac | ring ].
-  apply le_lt_trans with (pred N).
+  apply Nat.le_lt_trans with (pred N).
   apply H0.
-  apply lt_pred_n_n.
+  apply Nat.lt_pred_l.
+  apply Nat.neq_0_lt_0.
   apply H.
-  apply le_trans with (pred N).
+  apply Nat.le_trans with (pred N).
   apply H0.
-  apply le_pred_n.
+  apply Nat.le_pred_l.
   rewrite H4; ring.
   cut (S N = (2 * S N0)%nat).
   intro.
@@ -366,7 +364,7 @@ Proof.
   rewrite Rmult_1_r; reflexivity.
   apply INR_fact_neq_0.
   replace (S N) with (S N0 + S N0)%nat.
-  symmetry ; apply minus_plus.
+  symmetry; apply Nat.add_sub.
   rewrite H5; ring.
   apply INR_fact_neq_0.
   apply INR_fact_neq_0.
@@ -390,54 +388,55 @@ Proof.
   left; apply Rlt_0_1.
   apply RmaxLess1.
   apply Rle_trans with
-    (sum_f_R0 (fun k:nat => INR (N - k) * / Rsqr (INR (fact (div2 (S N)))))
+    (sum_f_R0 (fun k:nat => INR (N - k) * / Rsqr (INR (fact (Nat.div2 (S N)))))
       (pred N)).
   apply sum_Rle; intros.
   rewrite sum_cte.
   replace (S (pred (N - n))) with (N - n)%nat.
   right; apply Rmult_comm.
-  apply S_pred with 0%nat.
-  apply plus_lt_reg_l with n.
-  rewrite <- le_plus_minus.
+  symmetry; apply Nat.lt_succ_pred with 0%nat.
+  apply Nat.add_lt_mono_l with n.
+  rewrite (Nat.add_comm _ (N - n)), Nat.sub_add.
   replace (n + 0)%nat with n; [ idtac | ring ].
-  apply le_lt_trans with (pred N).
+  apply Nat.le_lt_trans with (pred N).
   apply H0.
-  apply lt_pred_n_n.
+  apply Nat.lt_pred_l.
+  apply Nat.neq_0_lt_0.
   apply H.
-  apply le_trans with (pred N).
+  apply Nat.le_trans with (pred N).
   apply H0.
-  apply le_pred_n.
+  apply Nat.le_pred_l.
   apply Rle_trans with
-    (sum_f_R0 (fun k:nat => INR N * / Rsqr (INR (fact (div2 (S N))))) (pred N)).
+    (sum_f_R0 (fun k:nat => INR N * / Rsqr (INR (fact (Nat.div2 (S N))))) (pred N)).
   apply sum_Rle; intros.
-  do 2 rewrite <- (Rmult_comm (/ Rsqr (INR (fact (div2 (S N)))))).
+  do 2 rewrite <- (Rmult_comm (/ Rsqr (INR (fact (Nat.div2 (S N)))))).
   apply Rmult_le_compat_l.
   left; apply Rinv_0_lt_compat; apply Rsqr_pos_lt.
   apply INR_fact_neq_0.
   apply le_INR.
-  apply (fun p n m:nat => plus_le_reg_l n m p) with n.
-  rewrite <- le_plus_minus.
-  apply le_plus_r.
-  apply le_trans with (pred N).
+  apply (fun p n m:nat => Nat.add_le_mono_l n m p) with n.
+  rewrite (Nat.add_comm _ (N - n)), Nat.sub_add.
+  rewrite Nat.add_comm; apply Nat.le_add_r.
+  apply Nat.le_trans with (pred N).
   apply H0.
-  apply le_pred_n.
+  apply Nat.le_pred_l.
   rewrite sum_cte; replace (S (pred N)) with N.
-  cut (div2 (S N) = S (div2 (pred N))).
+  cut (Nat.div2 (S N) = S (Nat.div2 (pred N))).
   intro; rewrite H0.
-  rewrite fact_simpl; rewrite mult_comm; rewrite mult_INR; rewrite Rsqr_mult.
+  rewrite fact_simpl; rewrite Nat.mul_comm; rewrite mult_INR; rewrite Rsqr_mult.
   rewrite Rinv_mult_distr.
   rewrite (Rmult_comm (INR N)); repeat rewrite Rmult_assoc;
     apply Rmult_le_compat_l.
   left; apply Rinv_0_lt_compat; apply Rsqr_pos_lt; apply INR_fact_neq_0.
   rewrite <- H0.
-  cut (INR N <= INR (2 * div2 (S N))).
-  intro; apply Rmult_le_reg_l with (Rsqr (INR (div2 (S N)))).
+  cut (INR N <= INR (2 * Nat.div2 (S N))).
+  intro; apply Rmult_le_reg_l with (Rsqr (INR (Nat.div2 (S N)))).
   apply Rsqr_pos_lt.
   apply not_O_INR; red; intro.
   cut (1 < S N)%nat.
   intro; assert (H4 := div2_not_R0 _ H3).
-  rewrite H2 in H4; elim (lt_n_O _ H4).
-  apply lt_n_S; apply H.
+  rewrite H2 in H4; elim (Nat.nlt_0_r _ H4).
+  apply -> Nat.succ_lt_mono; apply H.
   repeat rewrite <- Rmult_assoc.
   rewrite <- Rinv_r_sym.
   rewrite Rmult_1_l.
@@ -449,13 +448,13 @@ Proof.
   left; apply lt_INR_0; apply H.
   left; apply Rmult_lt_0_compat.
   apply lt_INR_0; apply div2_not_R0.
-  apply lt_n_S; apply H.
+  apply -> Nat.succ_lt_mono; apply H.
   now apply IZR_lt.
   cut (1 < S N)%nat.
   intro; unfold Rsqr; apply prod_neq_R0; apply not_O_INR; intro;
     assert (H4 := div2_not_R0 _ H2); rewrite H3 in H4;
-      elim (lt_n_O _ H4).
-  apply lt_n_S; apply H.
+      elim (Nat.nlt_0_r _ H4).
+  apply -> Nat.succ_lt_mono; apply H.
   assert (H1 := even_odd_cor N).
   elim H1; intros N0 H2.
   elim H2; intro.
@@ -486,7 +485,7 @@ Proof.
   replace (2 * N0)%nat with (S (S (2 * pred N0))).
   replace (pred (S (S (2 * pred N0)))) with (S (2 * pred N0)).
   rewrite div2_S_double.
-  apply S_pred with 0%nat; apply H3.
+  symmetry; apply Nat.lt_succ_pred with 0%nat; apply H3.
   reflexivity.
   lia.
   lia.
@@ -496,7 +495,7 @@ Proof.
   do 2 rewrite div2_double.
   reflexivity.
   ring.
-  apply S_pred with 0%nat; apply H.
+  symmetry; apply Nat.lt_succ_pred with 0%nat; apply H.
 Qed.
 
 Lemma maj_Reste_cv_R0 : forall x y:R, Un_cv (maj_Reste_E x y) 0.
@@ -514,14 +513,14 @@ Proof.
   rewrite Rabs_right.
   apply Rle_lt_trans with
     (4 *
-      (Rmax 1 (Rmax (Rabs x) (Rabs y)) ^ (4 * S (div2 (pred n))) /
-        INR (fact (div2 (pred n))))).
+      (Rmax 1 (Rmax (Rabs x) (Rabs y)) ^ (4 * S (Nat.div2 (pred n))) /
+        INR (fact (Nat.div2 (pred n))))).
   apply Rmult_le_compat_l.
   left; prove_sup0.
   unfold Rdiv, Rsqr; rewrite Rinv_mult_distr.
   rewrite (Rmult_comm (Rmax 1 (Rmax (Rabs x) (Rabs y)) ^ (2 * n)));
     rewrite
-      (Rmult_comm (Rmax 1 (Rmax (Rabs x) (Rabs y)) ^ (4 * S (div2 (pred n)))))
+      (Rmult_comm (Rmax 1 (Rmax (Rabs x) (Rabs y)) ^ (4 * S (Nat.div2 (pred n)))))
       ; rewrite Rmult_assoc; apply Rmult_le_compat_l.
   left; apply Rinv_0_lt_compat; apply INR_fact_lt_0.
   apply Rle_trans with (Rmax 1 (Rmax (Rabs x) (Rabs y)) ^ (2 * n)).
@@ -531,11 +530,11 @@ Proof.
   apply pow_le; apply Rle_trans with 1.
   left; apply Rlt_0_1.
   apply RmaxLess1.
-  apply Rmult_le_reg_l with (INR (fact (div2 (pred n)))).
+  apply Rmult_le_reg_l with (INR (fact (Nat.div2 (pred n)))).
   apply INR_fact_lt_0.
   rewrite Rmult_1_r; rewrite <- Rinv_r_sym.
   apply (le_INR 1).
-  apply lt_le_S.
+  apply Nat.le_succ_l.
   apply INR_lt.
   apply INR_fact_lt_0.
   apply INR_fact_neq_0.
@@ -552,19 +551,19 @@ Proof.
   lia.
   lia.
   assert (0 < n)%nat.
-  apply lt_le_trans with 2%nat.
-  apply lt_O_Sn.
-  apply le_trans with (max (2 * S N0) 2).
-  apply le_max_r.
+  apply Nat.lt_le_trans with 2%nat.
+  apply Nat.lt_0_succ.
+  apply Nat.le_trans with (max (2 * S N0) 2).
+  apply Nat.le_max_r.
   apply H3.
   lia.
   rewrite H6.
   replace (pred (S (2 * N1))) with (2 * N1)%nat.
   rewrite div2_double.
   replace (4 * S N1)%nat with (2 * (2 * S N1))%nat.
-  apply (fun m n p:nat => mult_le_compat_l p n m).
+  apply (fun m n p:nat => Nat.mul_le_mono_nonneg_l p n m). apply Nat.le_0_l.
   replace (2 * S N1)%nat with (S (S (2 * N1))).
-  apply le_n_Sn.
+  apply Nat.le_succ_diag_r.
   ring.
   ring.
   reflexivity.
@@ -575,18 +574,18 @@ Proof.
   rewrite <- Rmult_assoc; rewrite <- Rinv_l_sym.
   rewrite Rmult_1_l; rewrite Rmult_comm.
   replace
-  (Rmax 1 (Rmax (Rabs x) (Rabs y)) ^ (4 * S (div2 (pred n))) /
-    INR (fact (div2 (pred n)))) with
+  (Rmax 1 (Rmax (Rabs x) (Rabs y)) ^ (4 * S (Nat.div2 (pred n))) /
+    INR (fact (Nat.div2 (pred n)))) with
   (Rabs
-    (Rmax 1 (Rmax (Rabs x) (Rabs y)) ^ (4 * S (div2 (pred n))) /
-      INR (fact (div2 (pred n))) - 0)).
+    (Rmax 1 (Rmax (Rabs x) (Rabs y)) ^ (4 * S (Nat.div2 (pred n))) /
+      INR (fact (Nat.div2 (pred n))) - 0)).
   apply H2; unfold ge.
   cut (2 * S N0 <= n)%nat.
   intro; apply le_S_n.
   apply INR_le; apply Rmult_le_reg_l with (INR 2).
   simpl; prove_sup0.
   do 2 rewrite <- mult_INR; apply le_INR.
-  apply le_trans with n.
+  apply Nat.le_trans with n.
   apply H4.
   assert (H5 := even_odd_cor n).
   elim H5; intros N1 H6.
@@ -594,37 +593,37 @@ Proof.
   cut (0 < N1)%nat.
   intro.
   rewrite H7.
-  apply (fun m n p:nat => mult_le_compat_l p n m).
+  apply (fun m n p:nat => Nat.mul_le_mono_nonneg_l p n m). apply Nat.le_0_l.
   replace (pred (2 * N1)) with (S (2 * pred N1)).
   rewrite div2_S_double.
   replace (S (pred N1)) with N1.
   apply le_n.
-  apply S_pred with 0%nat; apply H8.
+  symmetry; apply Nat.lt_succ_pred with 0%nat; apply H8.
   replace (2 * N1)%nat with (S (S (2 * pred N1))).
   reflexivity.
   pattern N1 at 2; replace N1 with (S (pred N1)).
   ring.
-  symmetry ; apply S_pred with 0%nat; apply H8.
+  apply Nat.lt_succ_pred with 0%nat; apply H8.
   apply INR_lt.
   apply Rmult_lt_reg_l with (INR 2).
   simpl; prove_sup0.
   rewrite Rmult_0_r; rewrite <- mult_INR.
   apply lt_INR_0.
   rewrite <- H7.
-  apply lt_le_trans with 2%nat.
-  apply lt_O_Sn.
-  apply le_trans with (max (2 * S N0) 2).
-  apply le_max_r.
+  apply Nat.lt_le_trans with 2%nat.
+  apply Nat.lt_0_succ.
+  apply Nat.le_trans with (max (2 * S N0) 2).
+  apply Nat.le_max_r.
   apply H3.
   rewrite H7.
   replace (pred (S (2 * N1))) with (2 * N1)%nat.
   rewrite div2_double.
   replace (2 * S N1)%nat with (S (S (2 * N1))).
-  apply le_n_Sn.
+  apply Nat.le_succ_diag_r.
   ring.
   reflexivity.
-  apply le_trans with (max (2 * S N0) 2).
-  apply le_max_l.
+  apply Nat.le_trans with (max (2 * S N0) 2).
+  apply Nat.le_max_l.
   apply H3.
   rewrite Rminus_0_r; apply Rabs_right.
   apply Rle_ge.
@@ -655,24 +654,24 @@ Proof.
   unfold R_dist; rewrite Rminus_0_r.
   apply Rle_lt_trans with (maj_Reste_E x y n).
   apply Reste_E_maj.
-  apply lt_le_trans with 1%nat.
-  apply lt_O_Sn.
-  apply le_trans with (max x0 1).
-  apply le_max_r.
+  apply Nat.lt_le_trans with 1%nat.
+  apply Nat.lt_0_succ.
+  apply Nat.le_trans with (max x0 1).
+  apply Nat.le_max_r.
   apply H2.
   replace (maj_Reste_E x y n) with (R_dist (maj_Reste_E x y n) 0).
   apply H1.
-  unfold ge; apply le_trans with (max x0 1).
-  apply le_max_l.
+  unfold ge; apply Nat.le_trans with (max x0 1).
+  apply Nat.le_max_l.
   apply H2.
   unfold R_dist; rewrite Rminus_0_r; apply Rabs_right.
   apply Rle_ge; apply Rle_trans with (Rabs (Reste_E x y n)).
   apply Rabs_pos.
   apply Reste_E_maj.
-  apply lt_le_trans with 1%nat.
-  apply lt_O_Sn.
-  apply le_trans with (max x0 1).
-  apply le_max_r.
+  apply Nat.lt_le_trans with 1%nat.
+  apply Nat.lt_0_succ.
+  apply Nat.le_trans with (max x0 1).
+  apply Nat.le_max_r.
   apply H2.
 Qed.
 
@@ -692,11 +691,11 @@ Proof.
   rewrite <- (exp_form x y n).
   rewrite Rminus_0_r in H5.
   apply H5.
-  unfold ge; apply le_trans with (S x0).
-  apply le_n_Sn.
+  unfold ge; apply Nat.le_trans with (S x0).
+  apply Nat.le_succ_diag_r.
   apply H6.
-  apply lt_le_trans with (S x0).
-  apply lt_O_Sn.
+  apply Nat.lt_le_trans with (S x0).
+  apply Nat.lt_0_succ.
   apply H6.
 Qed.
 
@@ -786,7 +785,7 @@ Proof.
   unfold Rdiv; do 2 rewrite Rmult_0_l; reflexivity.
   unfold fn; simpl.
   unfold Rdiv; rewrite Rinv_1; rewrite Rmult_1_r; reflexivity.
-  apply lt_le_trans with 1%nat; [ apply lt_n_Sn | apply H9 ].
+  apply Nat.lt_le_trans with 1%nat; [ apply Nat.lt_succ_diag_r | apply H9 ].
   unfold SFL, exp.
   case (cv h) as (x0,Hu); case (exist_exp h) as (x,Hexp); simpl.
   eapply UL_sequence.
@@ -808,9 +807,9 @@ Proof.
   rewrite (Rmult_comm (Rabs h)).
   apply H10.
   unfold ge.
-  apply le_trans with (S N0).
-  apply le_n_Sn.
-  apply le_n_S; apply H11.
+  apply Nat.le_trans with (S N0).
+  apply Nat.le_succ_diag_r.
+  apply -> Nat.succ_le_mono; apply H11.
   rewrite decomp_sum.
   replace (/ INR (fact 0) * h ^ 0) with 1.
   unfold Rminus.
@@ -828,7 +827,7 @@ Proof.
   unfold Rdiv; ring.
   simpl; ring.
   simpl; rewrite Rinv_1; rewrite Rmult_1_r; reflexivity.
-  apply lt_O_Sn.
+  apply Nat.lt_0_succ.
   unfold Rdiv.
   rewrite <- Rmult_assoc.
   symmetry ; apply Rinv_r_simpl_m.
@@ -932,9 +931,9 @@ Proof.
   apply Rinv_neq_0_compat; apply Rabs_no_R0; apply INR_fact_neq_0.
   apply INR_fact_neq_0.
   apply INR_fact_neq_0.
-  unfold ge; apply le_trans with n.
+  unfold ge; apply Nat.le_trans with n.
   apply H5.
-  apply le_n_Sn.
+  apply Nat.le_succ_diag_r.
   assert (H1 := cond_pos r); red; intro; rewrite H2 in H1;
     elim (Rlt_irrefl _ H1).
 Qed.
@@ -968,3 +967,6 @@ Proof.
     rewrite Rmult_minus_distr_l.
   rewrite Rmult_1_r; rewrite exp_plus; reflexivity.
 Qed.
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Import Div2 Even Max.

--- a/theories/Reals/PSeries_reg.v
+++ b/theories/Reals/PSeries_reg.v
@@ -13,8 +13,6 @@ Require Import Rfunctions.
 Require Import SeqSeries.
 Require Import Ranalysis1.
 Require Import MVT.
-Require Import Max.
-Require Import Even.
 Require Import Lra.
 Local Open Scope R_scope.
 
@@ -290,7 +288,7 @@ Proof.
   apply continuity_pt_plus.
   apply HrecN.
   intros; apply H.
-  apply le_trans with N; [ assumption | apply le_n_Sn ].
+  apply Nat.le_trans with N; [ assumption | apply Nat.le_succ_diag_r ].
   apply (H (S N)); apply le_n.
 Qed.
 
@@ -592,8 +590,8 @@ assert (CVU rho_ rho c d ).
   destruct (cvrho y b_y _ ep2) as [N2 Pn2].
   apply Rle_lt_trans with (1 := R_dist_tri _ _ (rho_ (max N N2) y)).
   apply Rplus_lt_le_compat.
-   solve[rewrite R_dist_sym; apply Pn2, Max.le_max_r].
-  apply unif_ac; auto; solve [apply Max.le_max_l].
+   solve[rewrite R_dist_sym; apply Pn2, Nat.le_max_r].
+  apply unif_ac; auto; solve [apply Nat.le_max_l].
  exists N; intros; apply unif_ac'; solve[auto].
 intros eps ep.
 destruct (CVU_continuity _ _ _ _ H ctrho x bx eps ep) as [delta [dp Pd]].
@@ -608,3 +606,6 @@ unfold rho; destruct (Req_EM_T (x + h) x) as [abs | _];[ | ].
  case hn0; replace h with (x + h - x) by ring; rewrite abs; ring.
 replace (x + h - x) with h by ring; reflexivity.
 Qed.
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Import Max Even.

--- a/theories/Reals/PartSum.v
+++ b/theories/Reals/PartSum.v
@@ -12,7 +12,6 @@ Require Import Rbase.
 Require Import Rfunctions.
 Require Import Rseries.
 Require Import Rcomplete.
-Require Import Max.
 Local Open Scope R_scope.
 
 Lemma tech1 :
@@ -34,7 +33,7 @@ Lemma tech2 :
     sum_f_R0 An m + sum_f_R0 (fun i:nat => An (S m + i)%nat) (n - S m).
 Proof.
   intros; induction  n as [| n Hrecn].
-  elim (lt_n_O _ H).
+  elim (Nat.nlt_0_r _ H).
   cut ((m < n)%nat \/ m = n).
   intro; elim H0; intro.
   replace (sum_f_R0 An (S n)) with (sum_f_R0 An n + An (S n));
@@ -49,16 +48,16 @@ Proof.
   apply INR_eq; rewrite S_INR; rewrite plus_INR; do 2 rewrite S_INR;
     rewrite minus_INR.
   rewrite S_INR; ring.
-  apply lt_le_S; assumption.
+  apply Nat.le_succ_l; assumption.
   apply INR_eq; rewrite S_INR; repeat rewrite minus_INR.
   repeat rewrite S_INR; ring.
-  apply le_n_S; apply lt_le_weak; assumption.
-  apply lt_le_S; assumption.
-  rewrite H1; rewrite <- minus_n_n; simpl.
+  apply le_n_S; apply Nat.lt_le_incl; assumption.
+  apply Nat.le_succ_l; assumption.
+  rewrite H1; rewrite Nat.sub_diag; simpl.
   replace (n + 0)%nat with n; [ reflexivity | ring ].
   inversion H.
   right; reflexivity.
-  left; apply lt_le_trans with (S m); [ apply lt_n_Sn | assumption ].
+  left; apply Nat.lt_le_trans with (S m); [ apply Nat.lt_succ_diag_r | assumption ].
 Qed.
 
 (* Sum of geometric sequences *)
@@ -173,7 +172,7 @@ Lemma decomp_sum :
     sum_f_R0 An N = An 0%nat + sum_f_R0 (fun i:nat => An (S i)) (pred N).
 Proof.
   intros; induction  N as [| N HrecN].
-  elim (lt_irrefl _ H).
+  elim (Nat.lt_irrefl _ H).
   cut ((0 < N)%nat \/ N = 0%nat).
   intro; elim H0; intro.
   cut (S (pred N) = pred (S N)).
@@ -184,11 +183,11 @@ Proof.
   rewrite H2; simpl; reflexivity.
   destruct (O_or_S N) as [(m,<-)|<-].
   simpl; reflexivity.
-  elim (lt_irrefl _ H1).
+  elim (Nat.lt_irrefl _ H1).
   rewrite H1; simpl; reflexivity.
   inversion H.
   right; reflexivity.
-  left; apply lt_le_trans with 1%nat; [ apply lt_O_Sn | assumption ].
+  left; apply Nat.lt_le_trans with 1%nat; [ apply Nat.lt_0_succ | assumption ].
 Qed.
 
 Lemma plus_sum :
@@ -209,7 +208,7 @@ Proof.
   simpl; apply H; apply le_n.
   do 2 rewrite tech5; rewrite HrecN.
   rewrite (H (S N)); [ reflexivity | apply le_n ].
-  intros; apply H; apply le_trans with N; [ assumption | apply le_n_Sn ].
+  intros; apply H; apply Nat.le_trans with N; [ assumption | apply Nat.le_succ_diag_r ].
 Qed.
 
 (* Unicity of the limit defined by convergent series *)
@@ -236,7 +235,7 @@ Proof.
   elim (Rlt_irrefl _ H11).
   apply Rabs_right; left; change (0 < / 2); apply Rinv_0_lt_compat;
     cut (0%nat <> 2%nat);
-      [ intro H20; generalize (lt_INR_0 2 (neq_O_lt 2 H20)); unfold INR;
+      [ intro H20; generalize (lt_INR_0 2 (proj1 (Nat.neq_0_lt_0 2) (Nat.neq_sym 0 2 H20))); unfold INR;
         intro; assumption
         | discriminate ].
   unfold R_dist; rewrite <- (Rabs_Ropp (sum_f_R0 An N - l1));
@@ -244,8 +243,8 @@ Proof.
   replace (l1 - l2) with (l1 - sum_f_R0 An N + (sum_f_R0 An N - l2));
   [ idtac | ring ].
   apply Rabs_triang.
-  unfold ge; unfold N; apply le_max_r.
-  unfold ge; unfold N; apply le_max_l.
+  unfold ge; unfold N; apply Nat.le_max_r.
+  unfold ge; unfold N; apply Nat.le_max_l.
   unfold Rdiv; apply prod_neq_R0.
   apply Rminus_eq_contra; assumption.
   apply Rinv_neq_0_compat; discrR.
@@ -296,7 +295,7 @@ Proof.
   apply Rplus_le_compat_l.
   apply HrecN.
   intros; apply H.
-  apply le_trans with N; [ assumption | apply le_n_Sn ].
+  apply Nat.le_trans with N; [ assumption | apply Nat.le_succ_diag_r ].
 Qed.
 
 Lemma Rsum_abs :
@@ -491,7 +490,7 @@ Proof.
   simpl; apply H; apply le_n.
   rewrite tech5; rewrite HrecN;
     [ rewrite Rplus_0_l; apply H; apply le_n
-      | intros; apply H; apply le_trans with N; [ assumption | apply le_n_Sn ] ].
+      | intros; apply H; apply Nat.le_trans with N; [ assumption | apply Nat.le_succ_diag_r ] ].
 Qed.
 
 Definition SP (fn:nat -> R -> R) (N:nat) (x:R) : R :=
@@ -527,8 +526,8 @@ Proof.
   unfold l1; apply Rge_le;
     apply (growing_prop (fun k:nat => sum_f_R0 An k)).
   apply H1.
-  unfold ge, N0; apply le_max_r.
-  unfold ge, N0; apply le_max_l.
+  unfold ge, N0; apply Nat.le_max_r.
+  unfold ge, N0; apply Nat.le_max_l.
   apply Rplus_lt_reg_l with l; rewrite Rplus_0_r;
     replace (l + (l1 - l)) with l1; [ apply Hgt | ring ].
   unfold Un_growing; intro; simpl;
@@ -600,8 +599,8 @@ Proof.
           unfold Rdiv; ring.
   apply Rle_lt_trans with (Rabs (SP fn N x - l1)).
   rewrite <- Rabs_Ropp; rewrite Ropp_minus_distr'; apply Rabs_triang_inv2.
-  apply H4; unfold ge, N; apply le_max_l.
-  apply H5; unfold ge, N; apply le_max_r.
+  apply H4; unfold ge, N; apply Nat.le_max_l.
+  apply H5; unfold ge, N; apply Nat.le_max_r.
   unfold Rdiv; apply Rmult_lt_0_compat.
   apply Rplus_lt_reg_l with l2.
   rewrite Rplus_0_r; replace (l2 + (Rabs l1 - l2)) with (Rabs l1);
@@ -618,3 +617,6 @@ Proof.
   apply Rplus_le_compat_l; apply Hrecn0.
   apply Rplus_le_compat_l; apply H1.
 Qed.
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Import Max.

--- a/theories/Reals/RIneq.v
+++ b/theories/Reals/RIneq.v
@@ -1696,10 +1696,10 @@ Hint Resolve plus_INR: real.
 (**********)
 Lemma minus_INR : forall n m:nat, (m <= n)%nat -> INR (n - m) = INR n - INR m.
 Proof.
-  intros n m le; pattern m, n; apply le_elim_rel; auto with real.
-  intros; rewrite <- minus_n_O; auto with real.
-  intros; repeat rewrite S_INR; simpl.
-  rewrite H0; ring.
+intros n m le; induction le.
+- now rewrite Nat.sub_diag, Rminus_eq_0.
+- rewrite Nat.sub_succ_l; [ | assumption ].
+  rewrite ? S_INR, IHle; ring.
 Qed.
 #[global]
 Hint Resolve minus_INR: real.
@@ -1772,7 +1772,7 @@ Proof.
     apply pos_INR.
   - destruct n as [|n].
     apply Nat.lt_0_succ.
-    apply lt_n_S, IHm.
+    apply -> Nat.succ_lt_mono; apply IHm.
     rewrite 2!S_INR in H.
     apply Rplus_lt_reg_r with (1 := H).
 Qed.
@@ -1812,8 +1812,8 @@ Hint Resolve not_0_INR: real.
 
 Lemma not_INR : forall n m:nat, n <> m -> INR n <> INR m.
 Proof.
-  intros n m H; case (le_or_lt n m); intros H1.
-  case (le_lt_or_eq _ _ H1); intros H2.
+  intros n m H; case (Nat.le_gt_cases n m); intros H1.
+  case (proj1 (Nat.lt_eq_cases _ _) H1); intros H2.
   apply Rlt_dichotomy_converse; auto with real.
   exfalso; auto.
   apply not_eq_sym; apply Rlt_dichotomy_converse; auto with real.
@@ -1910,10 +1910,10 @@ Proof.
   case Pos.compare_spec; intros H; unfold IZR.
   subst. ring.
   rewrite <- 3!INR_IPR, Pos2Nat.inj_sub by trivial.
-  rewrite minus_INR by (now apply lt_le_weak, Pos2Nat.inj_lt).
+  rewrite minus_INR by (now apply Nat.lt_le_incl, Pos2Nat.inj_lt).
   ring.
   rewrite <- 3!INR_IPR, Pos2Nat.inj_sub by trivial.
-  rewrite minus_INR by (now apply lt_le_weak, Pos2Nat.inj_lt).
+  rewrite minus_INR by (now apply Nat.lt_le_incl, Pos2Nat.inj_lt).
   ring.
 Qed.
 

--- a/theories/Reals/RList.v
+++ b/theories/Reals/RList.v
@@ -158,7 +158,7 @@ Lemma pos_Rl_P1 :
     pos_Rl (a :: l) (length l) = pos_Rl l (pred (length l)).
 Proof.
   intros; induction  l as [| r l Hrecl];
-    [ elim (lt_n_O _ H)
+    [ elim (Nat.nlt_0_r _ H)
       | simpl; case (length l); [ reflexivity | intro; reflexivity ] ].
 Qed.
 
@@ -168,20 +168,20 @@ Lemma pos_Rl_P2 :
 Proof.
   intros; induction  l as [| r l Hrecl].
   split; intro;
-    [ elim H | elim H; intros; elim H0; intros; elim (lt_n_O _ H1) ].
+    [ elim H | elim H; intros; elim H0; intros; elim (Nat.nlt_0_r _ H1) ].
   split; intro.
   elim H; intro.
   exists 0%nat; split;
-    [ simpl; apply lt_O_Sn | simpl; symmetry; apply H0 ].
+    [ simpl; apply Nat.lt_0_succ | simpl; symmetry; apply H0 ].
   elim Hrecl; intros; assert (H3 := H1 H0); elim H3; intros; elim H4; intros;
     exists (S x0); split;
-      [ simpl; apply lt_n_S; assumption | simpl; assumption ].
+      [ simpl; apply -> Nat.succ_lt_mono; assumption | simpl; assumption ].
   elim H; intros; elim H0; intros; destruct (zerop x0) as [->|].
   simpl in H2; left; symmetry; assumption.
   right; elim Hrecl; intros H4 H5; apply H5; assert (H6 : S (pred x0) = x0).
-  symmetry ; apply S_pred with 0%nat; assumption.
+  apply Nat.lt_succ_pred with 0%nat; assumption.
   exists (pred x0); split;
-    [ simpl in H1; apply lt_S_n; rewrite H6; assumption
+    [ simpl in H1; apply Nat.succ_lt_mono; rewrite H6; assumption
       | rewrite <- H6 in H2; simpl in H2; assumption ].
 Qed.
 
@@ -194,7 +194,7 @@ Lemma Rlist_P1 :
 Proof.
   intros; induction  l as [| r l Hrecl].
   exists nil; intros; split;
-    [ reflexivity | intros; simpl in H0; elim (lt_n_O _ H0) ].
+    [ reflexivity | intros; simpl in H0; elim (Nat.nlt_0_r _ H0) ].
   assert (H0 : In r (r :: l)).
   simpl; left; reflexivity.
   assert (H1 := H _ H0);
@@ -206,8 +206,8 @@ Proof.
   intros; destruct (zerop i) as [->|].
   simpl; assumption.
   assert (H9 : i = S (pred i)).
-  apply S_pred with 0%nat; assumption.
-  rewrite H9; simpl; apply H6; simpl in H7; apply lt_S_n; rewrite <- H9;
+  symmetry; apply Nat.lt_succ_pred with 0%nat; assumption.
+  rewrite H9; simpl; apply H6; simpl in H7; apply Nat.succ_lt_mono; rewrite <- H9;
     assumption.
 Qed.
 
@@ -263,15 +263,15 @@ Lemma RList_P1 :
 Proof.
   intros; induction  l as [| r l Hrecl].
   simpl; unfold ordered_Rlist; intros; simpl in H0;
-    elim (lt_n_O _ H0).
+    elim (Nat.nlt_0_r _ H0).
   simpl; case (Rle_dec r a); intro.
   assert (H1 : ordered_Rlist l).
   unfold ordered_Rlist; unfold ordered_Rlist in H; intros;
     assert (H1 : (S i < pred (length (r :: l)))%nat);
       [ simpl; replace (length l) with (S (pred (length l)));
-        [ apply lt_n_S; assumption
-          | symmetry ; apply S_pred with 0%nat; apply neq_O_lt; red;
-            intro; rewrite <- H1 in H0; simpl in H0; elim (lt_n_O _ H0) ]
+        [ apply -> Nat.succ_lt_mono; assumption
+          | apply Nat.lt_succ_pred with 0%nat; apply Nat.neq_0_lt_0; red;
+            intro; rewrite H1 in H0; simpl in H0; elim (Nat.nlt_0_r _ H0) ]
         | apply (H _ H1) ].
   assert (H2 := Hrecl H1); unfold ordered_Rlist; intros;
     induction  i as [| i Hreci].
@@ -279,16 +279,16 @@ Proof.
   rewrite H4; assumption.
   induction  l as [| r1 l Hrecl0];
     [ simpl; assumption
-      | rewrite H4; apply (H 0%nat); simpl; apply lt_O_Sn ].
-  simpl; apply H2; simpl in H0; apply lt_S_n;
+      | rewrite H4; apply (H 0%nat); simpl; apply Nat.lt_0_succ ].
+  simpl; apply H2; simpl in H0; apply Nat.succ_lt_mono;
     replace (S (pred (length (insert l a)))) with (length (insert l a));
     [ assumption
-      | apply S_pred with 0%nat; apply neq_O_lt; red; intro;
-        rewrite <- H3 in H0; elim (lt_n_O _ H0) ].
+      | symmetry; apply Nat.lt_succ_pred with 0%nat; apply Nat.neq_0_lt_0; red; intro;
+        rewrite H3 in H0; elim (Nat.nlt_0_r _ H0) ].
   unfold ordered_Rlist; intros; induction  i as [| i Hreci];
     [ simpl; auto with real
       | change (pos_Rl (r :: l) i <= pos_Rl (r :: l) (S i)); apply H;
-        simpl in H0; simpl; apply (lt_S_n _ _ H0) ].
+        simpl in H0; simpl; apply (proj2 (Nat.succ_lt_mono _ _) H0) ].
 Qed.
 
 Lemma RList_P2 :
@@ -307,15 +307,15 @@ Proof.
     [ induction  l as [| r l Hrecl] | induction  l as [| r l Hrecl] ].
   elim H.
   elim H; intro;
-    [ exists 0%nat; split; [ symmetry; apply H0 | simpl; apply lt_O_Sn ]
+    [ exists 0%nat; split; [ symmetry; apply H0 | simpl; apply Nat.lt_0_succ ]
       | elim (Hrecl H0); intros; elim H1; clear H1; intros; exists (S x0); split;
-        [ apply H1 | simpl; apply lt_n_S; assumption ] ].
-  elim H; intros; elim H0; intros; elim (lt_n_O _ H2).
+        [ apply H1 | simpl; apply -> Nat.succ_lt_mono; assumption ] ].
+  elim H; intros; elim H0; intros; elim (Nat.nlt_0_r _ H2).
   simpl; elim H; intros; elim H0; clear H0; intros;
     induction  x0 as [| x0 Hrecx0];
       [ left; symmetry; apply H0
         | right; apply Hrecl; exists x0; split;
-          [ apply H0 | simpl in H1; apply lt_S_n; assumption ] ].
+          [ apply H0 | simpl in H1; apply Nat.succ_lt_mono; assumption ] ].
 Qed.
 
 Lemma RList_P4 :
@@ -323,9 +323,9 @@ Lemma RList_P4 :
 Proof.
   intros; unfold ordered_Rlist; intros; apply (H (S i)); simpl;
     replace (length l1) with (S (pred (length l1)));
-    [ apply lt_n_S; assumption
-      | symmetry ; apply S_pred with 0%nat; apply neq_O_lt; red;
-        intro; rewrite <- H1 in H0; elim (lt_n_O _ H0) ].
+    [ apply -> Nat.succ_lt_mono; assumption
+      | apply Nat.lt_succ_pred with 0%nat; apply Nat.neq_0_lt_0; red;
+        intro; rewrite H1 in H0; elim (Nat.nlt_0_r _ H0) ].
 Qed.
 
 Lemma RList_P5 :
@@ -337,7 +337,7 @@ Proof.
         [ rewrite H1; right; reflexivity
           | apply Rle_trans with (pos_Rl l 0);
             [ apply (H 0%nat); simpl; induction  l as [| r0 l Hrecl0];
-              [ elim H1 | simpl; apply lt_O_Sn ]
+              [ elim H1 | simpl; apply Nat.lt_0_succ ]
               | apply Hrecl; [ eapply RList_P4; apply H | assumption ] ] ] ].
 Qed.
 
@@ -349,26 +349,26 @@ Lemma RList_P6 :
 Proof.
   induction l as [ | r r0 H]; split; intro.
   intros; right; reflexivity.
-  unfold ordered_Rlist;intros; simpl in H0; elim (lt_n_O _ H0).
-  intros; induction  i as [| i Hreci];
-    [ induction  j as [| j Hrecj];
+  unfold ordered_Rlist;intros; simpl in H0; elim (Nat.nlt_0_r _ H0).
+  intros; induction i as [| i Hreci];
+    [ induction j as [| j Hrecj];
       [ right; reflexivity
         | simpl; apply Rle_trans with (pos_Rl r0 0);
-          [ apply (H0 0%nat); simpl; simpl in H2; apply neq_O_lt;
-            red; intro; rewrite <- H3 in H2;
-              assert (H4 := lt_S_n _ _ H2); elim (lt_n_O _ H4)
+          [ apply (H0 0%nat); simpl; simpl in H2; apply Nat.neq_0_lt_0;
+            red; intro; rewrite H3 in H2;
+              assert (H4 := proj2 (Nat.succ_lt_mono _ _) H2); elim (Nat.nlt_0_r _ H4)
             | elim H; intros; apply H3;
               [ apply RList_P4 with r; assumption
-                | apply le_O_n
-                | simpl in H2; apply lt_S_n; assumption ] ] ]
-      | induction  j as [| j Hrecj];
-        [ elim (le_Sn_O _ H1)
+                | apply Nat.le_0_l
+                | simpl in H2; apply Nat.succ_lt_mono; assumption ] ] ]
+      | induction j as [| j Hrecj];
+        [ elim (Nat.nle_succ_0 _ H1)
           | simpl; elim H; intros; apply H3;
             [ apply RList_P4 with r; assumption
               | apply le_S_n; assumption
-              | simpl in H2; apply lt_S_n; assumption ] ] ].
+              | simpl in H2; apply Nat.succ_lt_mono; assumption ] ] ].
   unfold ordered_Rlist; intros; apply H0;
-    [ apply le_n_Sn | simpl; simpl in H1; apply lt_n_S; assumption ].
+    [ apply Nat.le_succ_diag_r | simpl; simpl in H1; apply -> Nat.succ_lt_mono; assumption ].
 Qed.
 
 Lemma RList_P7 :
@@ -380,12 +380,12 @@ Proof.
       clear H1; intros; assert (H4 := H1 H0); elim H4; clear H4;
         intros; elim H4; clear H4; intros; rewrite H4;
           assert (H6 : length l = S (pred (length l))).
-  apply S_pred with 0%nat; apply neq_O_lt; red; intro;
-    rewrite <- H6 in H5; elim (lt_n_O _ H5).
+  symmetry; apply Nat.lt_succ_pred with 0%nat; apply Nat.neq_0_lt_0; red; intro;
+    rewrite H6 in H5; elim (Nat.nlt_0_r _ H5).
   apply H3;
-    [ rewrite H6 in H5; apply lt_n_Sm_le; assumption
-      | apply lt_pred_n_n; apply neq_O_lt; red; intro; rewrite <- H7 in H5;
-        elim (lt_n_O _ H5) ].
+    [ rewrite H6 in H5; apply Nat.lt_succ_r; assumption
+      | apply Nat.lt_pred_l; red; intro; rewrite H7 in H5;
+        elim (Nat.nlt_0_r _ H5) ].
 Qed.
 
 Lemma RList_P8 :
@@ -461,9 +461,9 @@ Lemma RList_P12 :
     (i < length l)%nat -> pos_Rl (map f l) i = f (pos_Rl l i).
 Proof.
   simple induction l;
-    [ intros; elim (lt_n_O _ H)
+    [ intros; elim (Nat.nlt_0_r _ H)
       | intros; induction  i as [| i Hreci];
-        [ reflexivity | simpl; apply H; apply lt_S_n; apply H0 ] ].
+        [ reflexivity | simpl; apply H; apply Nat.succ_lt_mono; apply H0 ] ].
 Qed.
 
 Lemma RList_P13 :
@@ -472,15 +472,15 @@ Lemma RList_P13 :
     pos_Rl (mid_Rlist l a) (S i) = (pos_Rl l i + pos_Rl l (S i)) / 2.
 Proof.
   induction l as [ | r r0 H].
-  intros; simpl in H; elim (lt_n_O _ H).
+  intros; simpl in H; elim (Nat.nlt_0_r _ H).
   induction r0 as [ | r1 r2 H0].
-  intros; simpl in H0; elim (lt_n_O _ H0).
+  intros; simpl in H0; elim (Nat.nlt_0_r _ H0).
   intros; simpl in H1; induction  i as [| i Hreci].
   reflexivity.
   change
     (pos_Rl (mid_Rlist (r1 :: r2) r) (S i) =
       (pos_Rl (r1 :: r2) i + pos_Rl (r1 :: r2) (S i)) / 2).
-    apply H; simpl; apply lt_S_n; assumption.
+    apply H; simpl; apply Nat.succ_lt_mono; assumption.
 Qed.
 
 Lemma RList_P14 : forall (l:list R) (a:R), length (mid_Rlist l a) = length l.
@@ -514,7 +514,7 @@ Proof.
           (RList_P3 (cons_ORlist (r :: l1) l2)
             (pos_Rl (cons_ORlist (r :: l1) l2) 0));
           intros; apply H3; exists 0%nat; split;
-            [ reflexivity | rewrite RList_P11; simpl; apply lt_O_Sn ]
+            [ reflexivity | rewrite RList_P11; simpl; apply Nat.lt_0_succ ]
           | elim (RList_P9 (r :: l1) l2 (pos_Rl (cons_ORlist (r :: l1) l2) 0));
             intros; assert (H5 := H3 H2); elim H5; intro;
               [ apply RList_P5; assumption
@@ -543,7 +543,7 @@ Proof.
         (pos_Rl (cons_ORlist (r :: l1) l2)
           (pred (length (cons_ORlist (r :: l1) l2)))));
       intros; apply H3; exists (pred (length (cons_ORlist (r :: l1) l2)));
-        split; [ reflexivity | rewrite RList_P11; simpl; apply lt_n_Sn ]
+        split; [ reflexivity | rewrite RList_P11; simpl; apply Nat.lt_succ_diag_r ]
       | elim
         (RList_P9 (r :: l1) l2
           (pos_Rl (cons_ORlist (r :: l1) l2)
@@ -562,7 +562,7 @@ Proof.
         [ left; change (In (pos_Rl (r :: l1) (length l1)) (r :: l1));
           elim (RList_P3 (r :: l1) (pos_Rl (r :: l1) (length l1)));
             intros; apply H5; exists (length l1); split;
-              [ reflexivity | simpl; apply lt_n_Sn ]
+              [ reflexivity | simpl; apply Nat.lt_succ_diag_r ]
           | assert (H5 := H3 H4); apply RList_P7;
             [ apply RList_P2; assumption
               | elim
@@ -573,7 +573,7 @@ Proof.
                     (RList_P3 (r :: l1)
                       (pos_Rl (r :: l1) (pred (length (r :: l1)))));
                     intros; apply H9; exists (pred (length (r :: l1)));
-                      split; [ reflexivity | simpl; apply lt_n_Sn ] ] ].
+                      split; [ reflexivity | simpl; apply Nat.lt_succ_diag_r ] ] ].
 Qed.
 
 Lemma RList_P17 :
@@ -591,21 +591,21 @@ Proof.
   simpl; simpl in H2; elim H1; intro.
   rewrite <- H4 in H2; assert (H5 : r <= pos_Rl r0 i);
     [ apply Rle_trans with (pos_Rl r0 0);
-      [ apply (H0 0%nat); simpl; simpl in H3; apply neq_O_lt;
-        red; intro; rewrite <- H5 in H3; elim (lt_n_O _ H3)
+      [ apply (H0 0%nat); simpl; simpl in H3; apply Nat.neq_0_lt_0;
+        red; intro; rewrite H5 in H3; elim (Nat.nlt_0_r _ H3)
         | elim (RList_P6 r0); intros; apply H5;
           [ apply RList_P4 with r; assumption
-            | apply le_O_n
-            | simpl in H3; apply lt_S_n; apply lt_trans with (length r0);
-              [ apply H3 | apply lt_n_Sn ] ] ]
+            | apply Nat.le_0_l
+            | simpl in H3; apply Nat.succ_lt_mono; apply Nat.lt_trans with (length r0);
+              [ apply H3 | apply Nat.lt_succ_diag_r ] ] ]
       | elim (Rlt_irrefl _ (Rle_lt_trans _ _ _ H5 H2)) ].
   apply H; try assumption;
     [ apply RList_P4 with r; assumption
-      | simpl in H3; apply lt_S_n;
+      | simpl in H3; apply Nat.succ_lt_mono;
         replace (S (pred (length r0))) with (length r0);
         [ apply H3
-          | apply S_pred with 0%nat; apply neq_O_lt; red; intro;
-            rewrite <- H5 in H3; elim (lt_n_O _ H3) ] ].
+          | symmetry; apply Nat.lt_succ_pred with 0%nat; apply Nat.neq_0_lt_0; red; intro;
+            rewrite H5 in H3; elim (Nat.nlt_0_r _ H3) ] ].
 Qed.
 
 Lemma RList_P18 :
@@ -630,9 +630,9 @@ Lemma RList_P20 :
       (exists r1 : R, (exists l' : list R, l = r :: r1 :: l')).
 Proof.
   intros; induction  l as [| r l Hrecl];
-    [ simpl in H; elim (le_Sn_O _ H)
+    [ simpl in H; elim (Nat.nle_succ_0 _ H)
       | induction  l as [| r0 l Hrecl0];
-        [ simpl in H; elim (le_Sn_O _ (le_S_n _ _ H))
+        [ simpl in H; elim (Nat.nle_succ_0 _ (le_S_n _ _ H))
           | exists r; exists r0; exists l; reflexivity ] ].
 Qed.
 
@@ -683,21 +683,21 @@ Proof.
     simpl in H3.
   induction  i as [| i Hreci].
   simpl; assumption.
-  change (pos_Rl l2 i <= pos_Rl l2 (S i)); apply (H1 i); apply lt_S_n;
+  change (pos_Rl l2 i <= pos_Rl l2 (S i)); apply (H1 i); apply Nat.succ_lt_mono;
     replace (S (pred (length l2))) with (length l2);
     [ assumption
-      | apply S_pred with 0%nat; apply neq_O_lt; red; intro;
-        rewrite <- H4 in H3; elim (lt_n_O _ H3) ].
+      | symmetry; apply Nat.lt_succ_pred with 0%nat; apply Nat.neq_0_lt_0; red; intro;
+        rewrite H4 in H3; elim (Nat.nlt_0_r _ H3) ].
   intros; assert (H4 : ordered_Rlist (app (r1 :: r2) l2)).
   apply H; try assumption.
   apply RList_P4 with r; assumption.
   unfold ordered_Rlist; intros i H5; simpl in H5.
     induction  i as [| i Hreci].
-  simpl; apply (H1 0%nat); simpl; apply lt_O_Sn.
+  simpl; apply (H1 0%nat); simpl; apply Nat.lt_0_succ.
   change
     (pos_Rl (app (r1 :: r2) l2) i <=
       pos_Rl (app (r1 :: r2) l2) (S i));
-    apply (H4 i); simpl; apply lt_S_n; assumption.
+    apply (H4 i); simpl; apply Nat.succ_lt_mono; assumption.
 Qed.
 
 Lemma RList_P26 :
@@ -705,10 +705,10 @@ Lemma RList_P26 :
     (i < length l1)%nat -> pos_Rl (app l1 l2) i = pos_Rl l1 i.
 Proof.
   simple induction l1.
-  intros; elim (lt_n_O _ H).
+  intros; elim (Nat.nlt_0_r _ H).
   intros; induction  i as [| i Hreci].
   apply RList_P22; discriminate.
-  apply (H l2 i); simpl in H0; apply lt_S_n; assumption.
+  apply (H l2 i); simpl in H0; apply Nat.succ_lt_mono; assumption.
 Qed.
 
 Lemma RList_P29 :
@@ -718,28 +718,28 @@ Lemma RList_P29 :
     pos_Rl (app l1 l2) i = pos_Rl l2 (i - length l1).
 Proof.
   induction l2 as [ | r r0 H].
-  intros; rewrite app_nil_r in H0; elim (lt_irrefl _ (le_lt_trans _ _ _ H H0)).
+  intros; rewrite app_nil_r in H0; elim (Nat.lt_irrefl _ (Nat.le_lt_trans _ _ _ H H0)).
   intros;
     replace (app l1 (r :: r0)) with
     (app (app l1 (r :: nil)) r0).
   inversion H0.
-  rewrite <- minus_n_n; simpl; rewrite RList_P26.
+  rewrite Nat.sub_diag; simpl; rewrite RList_P26.
   clear r0 H i H0 H1 H2; induction  l1 as [| r0 l1 Hrecl1].
   reflexivity.
   simpl; assumption.
-  rewrite app_length; rewrite plus_comm; simpl; apply lt_n_Sn.
+  rewrite app_length; rewrite Nat.add_comm; simpl; apply Nat.lt_succ_diag_r.
   replace (S m - length l1)%nat with (S (S m - S (length l1))).
   rewrite H3; simpl;
     replace (S (length l1)) with (length (app l1 (r :: nil))).
   apply (H (app l1 (r :: nil)) i).
-  rewrite app_length; rewrite plus_comm; simpl; rewrite <- H3;
+  rewrite app_length; rewrite Nat.add_comm; simpl; rewrite <- H3;
     apply le_n_S; assumption.
   repeat rewrite app_length; simpl; rewrite app_length in H1;
-    rewrite plus_comm in H1; simpl in H1; rewrite (plus_comm (length l1));
-      simpl; rewrite plus_comm; apply H1.
-  rewrite app_length; rewrite plus_comm; reflexivity.
+    rewrite Nat.add_comm in H1; simpl in H1; rewrite (Nat.add_comm (length l1));
+      simpl; rewrite Nat.add_comm; apply H1.
+  rewrite app_length; rewrite Nat.add_comm; reflexivity.
   change (S (m - length l1) = (S m - length l1)%nat);
-    apply minus_Sn_m; assumption.
+    symmetry; apply Nat.sub_succ_l; assumption.
   replace (r :: r0) with (app (r :: nil) r0);
   [ symmetry ; apply app_assoc | reflexivity ].
 Qed.

--- a/theories/Reals/R_sqrt.v
+++ b/theories/Reals/R_sqrt.v
@@ -479,4 +479,3 @@ Proof.
   reflexivity.
   reflexivity.
 Qed.
-

--- a/theories/Reals/Ranalysis1.v
+++ b/theories/Reals/Ranalysis1.v
@@ -1210,7 +1210,7 @@ Lemma derivable_pt_lim_pow_pos :
 Proof.
   intros.
   induction  n as [| n Hrecn].
-  elim (lt_irrefl _ H).
+  elim (Nat.lt_irrefl _ H).
   cut (n = 0%nat \/ (0 < n)%nat).
   intro; elim H0; intro.
   rewrite H1; simpl.
@@ -1233,14 +1233,14 @@ Proof.
   pattern n at 1 5; replace n with (S (pred n)).
   unfold id; rewrite S_INR; simpl.
   ring.
-  symmetry ; apply S_pred with 0%nat; assumption.
+  apply Nat.lt_succ_pred with 0%nat; assumption.
   unfold mult_fct, id; reflexivity.
   reflexivity.
   inversion H.
   left; reflexivity.
   right.
-  apply lt_le_trans with 1%nat.
-  apply lt_O_Sn.
+  apply Nat.lt_le_trans with 1%nat.
+  apply Nat.lt_0_succ.
   assumption.
 Qed.
 
@@ -1255,7 +1255,7 @@ Proof.
   replace (fun _:R => 1) with (fct_cte 1);
   [ apply derivable_pt_lim_const | reflexivity ].
   apply derivable_pt_lim_pow_pos.
-  apply lt_O_Sn.
+  apply Nat.lt_0_succ.
 Qed.
 
 Lemma derivable_pt_pow :

--- a/theories/Reals/Ranalysis4.v
+++ b/theories/Reals/Ranalysis4.v
@@ -206,7 +206,7 @@ Lemma derivable_pt_lim_fs :
     (sum_f_R0 (fun k:nat => INR (S k) * An (S k) * x ^ k) (pred N)).
 Proof.
   intros; induction  N as [| N HrecN].
-  elim (lt_irrefl _ H).
+  elim (Nat.lt_irrefl _ H).
   cut (N = 0%nat \/ (0 < N)%nat).
   intro; elim H0; intro.
   rewrite H1.
@@ -248,12 +248,12 @@ Proof.
   replace (pred (S N)) with N; [ idtac | reflexivity ].
   ring.
   simpl.
-  apply S_pred with 0%nat; assumption.
+  symmetry; apply Nat.lt_succ_pred with 0%nat; assumption.
   unfold plus_fct.
   simpl; reflexivity.
   inversion H.
   left; reflexivity.
-  right; apply lt_le_trans with 1%nat; [ apply lt_O_Sn | assumption ].
+  right; apply Nat.lt_le_trans with 1%nat; [ apply Nat.lt_0_succ | assumption ].
 Qed.
 
 Lemma derivable_pt_lim_finite_sum :
@@ -270,7 +270,7 @@ Proof.
   rewrite Rmult_1_r.
   replace (fun _:R => An 0%nat) with (fct_cte (An 0%nat));
   [ apply derivable_pt_lim_const | reflexivity ].
-  apply derivable_pt_lim_fs; apply lt_O_Sn.
+  apply derivable_pt_lim_fs; apply Nat.lt_0_succ.
 Qed.
 
 Lemma derivable_pt_finite_sum :
@@ -404,4 +404,3 @@ unfold Rminus at 1 in Pc; rewrite Pc; apply Rmult_lt_0_compat;[ | ].
  now apply Rplus_lt_0_compat; apply exp_pos.
 now apply Rlt_Rminus; assumption.
 Qed.
-

--- a/theories/Reals/Ranalysis5.v
+++ b/theories/Reals/Ranalysis5.v
@@ -12,10 +12,8 @@ Require Import Rbase.
 Require Import Ranalysis_reg.
 Require Import Rfunctions.
 Require Import Rseries.
-Require Import Lra.
 Require Import RiemannInt.
 Require Import SeqProp.
-Require Import Max.
 Require Import Lia.
 Require Import Lra.
 Local Open Scope R_scope.
@@ -1425,3 +1423,6 @@ assert (Main : Rabs ((f (x+h) - fn N (x+h)) - (f x - fn N x) + (fn N (x+h) - fn 
  assumption.
  field. assumption.
 Qed.
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Import Max.

--- a/theories/Reals/Ratan.v
+++ b/theories/Reals/Ratan.v
@@ -95,7 +95,7 @@ intros [ | N] Npos n decr to0 cv nN.
   rewrite <- (sum_eq (tg_alt (fun i => (-1) ^ S N * f(S N + i)%nat))).
    tauto.
    intros i _; unfold tg_alt.
-   rewrite <- Rmult_assoc, <- pow_add, !(plus_comm i); reflexivity.
+   rewrite <- Rmult_assoc, <- pow_add, !(Nat.add_comm i); reflexivity.
   lia.
   assert (cv'' : Un_cv (sum_f_R0 (tg_alt (fun i => f (S N + i)%nat)))
                    ((-1) ^ S N * (l - sum_f_R0 (tg_alt f) N))).
@@ -104,7 +104,7 @@ intros [ | N] Npos n decr to0 cv nN.
    intros n0; rewrite scal_sum; apply sum_eq; intros i _.
    unfold tg_alt; ring_simplify; replace (((-1) ^ S N) ^ 2) with 1.
     ring.
-   rewrite <- pow_mult, mult_comm, pow_mult; replace ((-1) ^2) with 1 by ring.
+   rewrite <- pow_mult, Nat.mul_comm, pow_mult; replace ((-1) ^2) with 1 by ring.
    rewrite pow1; reflexivity.
   apply CV_mult.
    solve[intros eps ep; exists 0%nat; intros; rewrite R_dist_eq; auto].
@@ -988,7 +988,7 @@ unfold ps_atan.
  apply (UL_sequence _ _ _ P).
   apply (Un_cv_ext (fun n => 0)).
   symmetry;apply sum_eq_R0.
-  intros i _; unfold tg_alt, Ratan_seq; rewrite plus_comm; simpl.
+  intros i _; unfold tg_alt, Ratan_seq; rewrite Nat.add_comm; simpl.
   unfold Rdiv; rewrite !Rmult_0_l, Rmult_0_r; reflexivity.
  intros eps ep; exists 0%nat; intros n _; unfold R_dist.
  rewrite Rminus_0_r, Rabs_pos_eq; auto with real.
@@ -1410,7 +1410,7 @@ case (Rtotal_order 0 x) as [xgt0 | [x0 | x0]].
  rewrite <- (sum_eq (fun _ => 0)), sum_cte, Rmult_0_l, Rminus_0_r, Rabs_pos_eq.
    assumption.
   apply Rle_refl.
- intros i _; unfold tg_alt, Ratan_seq, Rdiv; rewrite plus_comm; simpl.
+ intros i _; unfold tg_alt, Ratan_seq, Rdiv; rewrite Nat.add_comm; simpl.
  solve[rewrite !Rmult_0_l, Rmult_0_r; auto].
 replace (ps_atan x - sum_f_R0 (tg_alt (Ratan_seq x)) n) with
   (-(ps_atan (-x) - sum_f_R0 (tg_alt (Ratan_seq (-x))) n)).

--- a/theories/Reals/Rcomplete.v
+++ b/theories/Reals/Rcomplete.v
@@ -12,7 +12,6 @@ Require Import Rbase.
 Require Import Rfunctions.
 Require Import Rseries.
 Require Import SeqProp.
-Require Import Max.
 Local Open Scope R_scope.
 
 (****************************************************)
@@ -85,20 +84,20 @@ Proof.
   repeat apply Rplus_lt_compat.
   unfold R_dist in H1.
   apply H1.
-  unfold ge; apply le_trans with (max x1 x2).
-  apply le_max_l.
+  unfold ge; apply Nat.le_trans with (max x1 x2).
+  apply Nat.le_max_l.
   assumption.
   rewrite <- Rabs_Ropp.
   replace (- (x - Vn n)) with (Vn n - x); [ idtac | ring ].
   unfold R_dist in H3.
   apply H3.
-  unfold ge; apply le_trans with (max x1 x2).
-  apply le_max_r.
+  unfold ge; apply Nat.le_trans with (max x1 x2).
+  apply Nat.le_max_r.
   assumption.
   unfold R_dist in H3.
   apply H3.
-  unfold ge; apply le_trans with (max x1 x2).
-  apply le_max_r.
+  unfold ge; apply Nat.le_trans with (max x1 x2).
+  apply Nat.le_max_r.
   assumption.
   right.
   pattern eps at 4; replace eps with (3 * (eps / 3)).
@@ -131,7 +130,7 @@ Proof.
   rewrite <- Rabs_Ropp.
   replace (- (x - Wn N)) with (Wn N - x); [ apply H4 | ring ].
   unfold ge, N.
-  apply le_trans with (max N1 N2); apply le_max_l.
+  apply Nat.le_trans with (max N1 N2); apply Nat.le_max_l.
   unfold Wn, Vn.
   unfold sequence_majorant, sequence_minorant.
   assert
@@ -169,22 +168,22 @@ Proof.
   assumption.
   apply H6.
   unfold ge.
-  apply le_trans with N.
-  unfold N; apply le_max_r.
-  apply le_plus_l.
+  apply Nat.le_trans with N.
+  unfold N; apply Nat.le_max_r.
+  apply Nat.le_add_r.
   unfold ge.
-  apply le_trans with N.
-  unfold N; apply le_max_r.
-  apply le_plus_l.
+  apply Nat.le_trans with N.
+  unfold N; apply Nat.le_max_r.
+  apply Nat.le_add_r.
   rewrite <- Rabs_Ropp.
   replace (- (Un (N + k1)%nat - Vn N)) with (Vn N - Un (N + k1)%nat);
   [ assumption | ring ].
   reflexivity.
   reflexivity.
   apply H5.
-  unfold ge; apply le_trans with (max N1 N2).
-  apply le_max_r.
-  unfold N; apply le_max_l.
+  unfold ge; apply Nat.le_trans with (max N1 N2).
+  apply Nat.le_max_r.
+  unfold N; apply Nat.le_max_l.
   pattern eps at 4; replace eps with (5 * (eps / 5)).
   ring.
   unfold Rdiv; rewrite <- Rmult_assoc; apply Rinv_r_simpl_m.
@@ -192,5 +191,8 @@ Proof.
   unfold Rdiv; apply Rmult_lt_0_compat.
   assumption.
   apply Rinv_0_lt_compat.
-  prove_sup0; try apply lt_O_Sn.
+  prove_sup0.
 Qed.
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Import Max.

--- a/theories/Reals/Rderiv.v
+++ b/theories/Reals/Rderiv.v
@@ -324,7 +324,7 @@ Proof.
   simple induction n; intros.
   simpl; rewrite Rmult_0_l; apply Dconst.
   intros; cut (n0 = (S n0 - 1)%nat);
-    [ intro a; rewrite <- a; clear a | simpl; apply minus_n_O ].
+    [ intro a; rewrite <- a; clear a | simpl; symmetry; apply Nat.sub_0_r ].
   generalize
     (Dmult D (fun _:R => 1) (fun x:R => INR n0 * x ^ (n0 - 1)) (
       fun x:R => x) (fun x:R => x ^ n0) x0 (Dx D x0) (

--- a/theories/Reals/Rfunctions.v
+++ b/theories/Reals/Rfunctions.v
@@ -151,10 +151,8 @@ Proof.
   apply pow_lt; auto with real.
   apply Rlt_trans with (r2 := 1); auto with real.
   apply Rlt_minus; auto with real.
-  apply Rlt_pow_R1; auto with arith.
-  apply plus_lt_reg_l with (p := n); auto with arith.
-  rewrite le_plus_minus_r; auto with arith; rewrite <- plus_n_O; auto.
-  rewrite plus_comm; auto with arith.
+  apply Rlt_pow_R1; [ | apply lt_minus_O_lt ]; assumption.
+  apply Nat.sub_add, Nat.lt_le_incl; assumption.
 Qed.
 #[global]
 Hint Resolve Rlt_pow: real.
@@ -194,7 +192,7 @@ Proof.
   simpl; rewrite Rmult_0_l; unfold Rle; right; auto.
   unfold Rle; left; generalize Rmult_gt_0_compat; unfold Rgt;
     intro; fold (Rsqr x);
-      apply (H3 (INR (S n1)) (Rsqr x) (lt_INR_0 (S n1) (lt_O_Sn n1)));
+      apply (H3 (INR (S n1)) (Rsqr x) (lt_INR_0 (S n1) (Nat.lt_0_succ n1)));
         fold (x > 0) in H;
           apply (Rlt_0_sqr x (Rlt_dichotomy_converse x 0 (or_intror (x < 0) H))).
   rewrite (S_INR n0); ring.
@@ -481,8 +479,7 @@ Proof.
   apply Rmult_le_compat_l.
   apply pow_le; left; apply Rlt_le_trans with 1; [ apply Rlt_0_1 | assumption ].
   apply pow_R1_Rle; assumption.
-  rewrite plus_comm.
-  symmetry ; apply le_plus_minus; assumption.
+  apply Nat.sub_add; assumption.
 Qed.
 
 Lemma pow1 : forall n:nat, 1 ^ n = 1.
@@ -608,13 +605,12 @@ Proof.
  - rewrite Pos2Nat.inj_sub by trivial.
    rewrite Pos2Nat.inj_lt in H.
    rewrite (pow_RN_plus x _ (Pos.to_nat n)) by auto with real.
-   rewrite plus_comm, le_plus_minus_r by auto with real.
+   rewrite Nat.sub_add; [ | apply Nat.lt_le_incl; assumption ].
    rewrite Rinv_mult_distr, Rinv_involutive; auto with real.
  - rewrite Pos2Nat.inj_sub by trivial.
    rewrite Pos2Nat.inj_lt in H.
    rewrite (pow_RN_plus x _ (Pos.to_nat m)) by auto with real.
-   rewrite plus_comm, le_plus_minus_r by auto with real.
-   reflexivity.
+   rewrite Nat.sub_add; [ reflexivity | apply Nat.lt_le_incl; assumption ].
 Qed.
 
 Lemma powerRZ_add :

--- a/theories/Reals/Rgeom.v
+++ b/theories/Reals/Rgeom.v
@@ -89,7 +89,7 @@ Proof.
                     sqrt (Rsqr (x2 - x1) + Rsqr (y2 - y1))));
                 [ apply Rmult_le_compat_l;
                   [ left; cut (0%nat <> 2%nat);
-                    [ intros; generalize (lt_INR_0 2 (neq_O_lt 2 H));
+                    [ intros; generalize (lt_INR_0 2 (proj1 (Nat.neq_0_lt_0 2) (Nat.neq_sym 0 2 H)));
                       intro H0; assumption
                       | discriminate ]
                     | apply sqrt_cauchy ]

--- a/theories/Reals/RiemannInt.v
+++ b/theories/Reals/RiemannInt.v
@@ -14,7 +14,6 @@ Require Import SeqSeries.
 Require Import Ranalysis_reg.
 Require Import Rbase.
 Require Import RiemannInt_SF.
-Require Import Max.
 Require Import RList.
 Local Open Scope R_scope.
 
@@ -275,9 +274,9 @@ Proof.
   apply RRle_abs.
   assumption.
   replace (pos (un n)) with (Rabs (un n - 0));
-  [ apply H; unfold ge; apply le_trans with N; try assumption;
-    unfold N; apply le_trans with (max N0 N1);
-      apply le_max_l
+  [ apply H; unfold ge; apply Nat.le_trans with N; try assumption;
+    unfold N; apply Nat.le_trans with (max N0 N1);
+      apply Nat.le_max_l
     | unfold Rminus; rewrite Ropp_0; rewrite Rplus_0_r; apply Rabs_right;
       apply Rle_ge; left; apply (cond_pos (un n)) ].
   apply Rlt_trans with (pos (vn n)).
@@ -285,9 +284,9 @@ Proof.
   apply RRle_abs; assumption.
   assumption.
   replace (pos (vn n)) with (Rabs (vn n - 0));
-  [ apply H0; unfold ge; apply le_trans with N; try assumption;
-    unfold N; apply le_trans with (max N0 N1);
-      [ apply le_max_r | apply le_max_l ]
+  [ apply H0; unfold ge; apply Nat.le_trans with N; try assumption;
+    unfold N; apply Nat.le_trans with (max N0 N1);
+      [ apply Nat.le_max_r | apply Nat.le_max_l ]
     | unfold Rminus; rewrite Ropp_0; rewrite Rplus_0_r; apply Rabs_right;
       apply Rle_ge; left; apply (cond_pos (vn n)) ].
   rewrite StepFun_P39; rewrite Rabs_Ropp;
@@ -335,9 +334,9 @@ Proof.
   rewrite <- Rabs_Ropp; apply RRle_abs.
   assumption.
   replace (pos (vn n)) with (Rabs (vn n - 0));
-  [ apply H0; unfold ge; apply le_trans with N; try assumption;
-    unfold N; apply le_trans with (max N0 N1);
-      [ apply le_max_r | apply le_max_l ]
+  [ apply H0; unfold ge; apply Nat.le_trans with N; try assumption;
+    unfold N; apply Nat.le_trans with (max N0 N1);
+      [ apply Nat.le_max_r | apply Nat.le_max_l ]
     | unfold R_dist; unfold Rminus; rewrite Ropp_0;
       rewrite Rplus_0_r; apply Rabs_right; apply Rle_ge;
         left; apply (cond_pos (vn n)) ].
@@ -346,13 +345,13 @@ Proof.
   rewrite <- Rabs_Ropp; apply RRle_abs; assumption.
   assumption.
   replace (pos (un n)) with (Rabs (un n - 0));
-  [ apply H; unfold ge; apply le_trans with N; try assumption;
-    unfold N; apply le_trans with (max N0 N1);
-      apply le_max_l
+  [ apply H; unfold ge; apply Nat.le_trans with N; try assumption;
+    unfold N; apply Nat.le_trans with (max N0 N1);
+      apply Nat.le_max_l
     | unfold Rminus; rewrite Ropp_0; rewrite Rplus_0_r; apply Rabs_right;
       apply Rle_ge; left; apply (cond_pos (un n)) ].
-  apply H1; unfold ge; apply le_trans with N; try assumption;
-    unfold N; apply le_max_r.
+  apply H1; unfold ge; apply Nat.le_trans with N; try assumption;
+    unfold N; apply Nat.le_max_r.
   apply Rmult_eq_reg_l with 3;
     [ unfold Rdiv; rewrite Rmult_plus_distr_l;
       do 2 rewrite (Rmult_comm 3); repeat rewrite Rmult_assoc;
@@ -439,7 +438,7 @@ Proof.
     split.
   apply H3.
   destruct (total_order_T (a + INR (S x) * del) b) as [[Hlt|Heq]|Hgt].
-  assert (H5 := H4 (S x) Hlt); elim (le_Sn_n _ H5).
+  assert (H5 := H4 (S x) Hlt); elim (Nat.nle_succ_diag_l _ H5).
   right; symmetry ; assumption.
   left; apply Hgt.
   assert (H1 : 0 <= (b - a) / del).
@@ -595,12 +594,12 @@ Lemma SubEqui_P4 :
     (i < S N)%nat -> pos_Rl (SubEquiN (S N) a b del) i = a + INR i * del.
 Proof.
   simple induction N;
-    [ intros; inversion H; [ simpl; ring | elim (le_Sn_O _ H1) ]
+    [ intros; inversion H; [ simpl; ring | elim (Nat.nle_succ_0 _ H1) ]
       | intros; induction  i as [| i Hreci];
         [ simpl; ring
           | change
             (pos_Rl (SubEquiN (S n) (a + del) b del) i = a + INR (S i) * del)
-           ; rewrite H; [ rewrite S_INR; ring | apply lt_S_n; apply H0 ] ] ].
+           ; rewrite H; [ rewrite S_INR; ring | apply Nat.succ_lt_mono; apply H0 ] ] ].
 Qed.
 
 Lemma SubEqui_P5 :
@@ -627,10 +626,10 @@ Proof.
   rewrite SubEqui_P2; unfold max_N; case (maxN del h) as (?&?&?); left;
     assumption.
   rewrite SubEqui_P5; reflexivity.
-  apply lt_n_Sn.
+  apply Nat.lt_succ_diag_r.
   repeat rewrite SubEqui_P6.
   3: assumption.
-  2: apply le_lt_n_Sm; assumption.
+  2: apply Nat.lt_succ_r; assumption.
   apply Rplus_le_compat_l; rewrite S_INR; rewrite Rmult_plus_distr_r;
     pattern (INR i * del) at 1; rewrite <- Rplus_0_r;
       apply Rplus_le_compat_l; rewrite Rmult_1_l; left;
@@ -722,10 +721,10 @@ Proof.
   elim H9; clear H9; intros I [H9 H10]; assert (H11 := H6 I H9 t H10);
     rewrite H11; left; apply H4.
   assumption.
-  apply SubEqui_P8; apply lt_trans with (pred (length (SubEqui del H))).
+  apply SubEqui_P8; apply Nat.lt_trans with (pred (length (SubEqui del H))).
   assumption.
-  apply lt_pred_n_n; apply neq_O_lt; red; intro; rewrite <- H12 in H9;
-    elim (lt_n_O _ H9).
+  apply Nat.lt_pred_l; red; intro; rewrite H12 in H9;
+    elim (Nat.nlt_0_r _ H9).
   unfold co_interval in H10; elim H10; clear H10; intros; rewrite Rabs_right.
   rewrite SubEqui_P5 in H9; simpl in H9; inversion H9.
   apply Rplus_lt_reg_l with (pos_Rl (SubEqui del H) (max_N del H)).
@@ -738,7 +737,7 @@ Proof.
   rewrite SubEqui_P5; reflexivity.
   rewrite H13 in H12; rewrite SubEqui_P2 in H12; apply H12.
   rewrite SubEqui_P6.
-  2: apply lt_n_Sn.
+  2: apply Nat.lt_succ_diag_r.
   unfold max_N; destruct (maxN del H) as (?&?&H13);
     replace (a + INR x * del + del) with (a + INR (S x) * del);
       [ assumption | rewrite S_INR; ring ].
@@ -750,7 +749,7 @@ Proof.
   repeat rewrite SubEqui_P6.
   rewrite S_INR; ring.
   assumption.
-  apply le_lt_n_Sm; assumption.
+  apply Nat.lt_succ_r; assumption.
   apply Rge_minus; apply Rle_ge; assumption.
   intros; clear H0 H1 H4 phi H5 H6 t H7; case (Req_dec t0 b); intro.
   left; assumption.
@@ -793,9 +792,9 @@ Proof.
   rewrite SubEqui_P5; reflexivity.
   rewrite SubEqui_P6.
   destruct (Rle_dec (a + INR (S N) * del) t0) as [Hle|Hnle].
-  assert (H11 := H6 (S N) Hle); elim (le_Sn_n _ H11).
+  assert (H11 := H6 (S N) Hle); elim (Nat.nle_succ_diag_l _ H11).
   auto with real.
-  apply le_lt_n_Sm; assumption.
+  apply Nat.lt_succ_r; assumption.
 Qed.
 
 Lemma RiemannInt_P7 : forall (f:R -> R) (a:R), Riemann_integrable f a a.
@@ -917,8 +916,8 @@ Proof.
     [ apply RRle_abs
       | apply Rlt_trans with (pos (RinvN n));
         [ assumption
-          | apply H4; unfold ge; apply le_trans with (max N0 N1);
-            [ apply le_max_l | assumption ] ] ].
+          | apply H4; unfold ge; apply Nat.le_trans with (max N0 N1);
+            [ apply Nat.le_max_l | assumption ] ] ].
   elim (H n); intros;
     rewrite <-
       (Ropp_involutive (RiemannInt_SF (mkStepFun (StepFun_P6 (pre (psi2 n))))))
@@ -927,8 +926,8 @@ Proof.
           [ rewrite <- Rabs_Ropp; apply RRle_abs
             | apply Rlt_trans with (pos (RinvN n));
               [ assumption
-                | apply H4; unfold ge; apply le_trans with (max N0 N1);
-                  [ apply le_max_l | assumption ] ] ].
+                | apply H4; unfold ge; apply Nat.le_trans with (max N0 N1);
+                  [ apply Nat.le_max_l | assumption ] ] ].
   assert (Hyp : b <= a).
   auto with real.
   rewrite StepFun_P39; rewrite Rabs_Ropp;
@@ -972,16 +971,16 @@ Proof.
           [ rewrite <- Rabs_Ropp; apply RRle_abs
             | apply Rlt_trans with (pos (RinvN n));
               [ assumption
-                | apply H4; unfold ge; apply le_trans with (max N0 N1);
-                  [ apply le_max_l | assumption ] ] ].
+                | apply H4; unfold ge; apply Nat.le_trans with (max N0 N1);
+                  [ apply Nat.le_max_l | assumption ] ] ].
   elim (H n); intros; apply Rle_lt_trans with (Rabs (RiemannInt_SF (psi2 n)));
     [ apply RRle_abs
       | apply Rlt_trans with (pos (RinvN n));
         [ assumption
-          | apply H4; unfold ge; apply le_trans with (max N0 N1);
-            [ apply le_max_l | assumption ] ] ].
+          | apply H4; unfold ge; apply Nat.le_trans with (max N0 N1);
+            [ apply Nat.le_max_l | assumption ] ] ].
   unfold R_dist in H1; apply H1; unfold ge;
-    apply le_trans with (max N0 N1); [ apply le_max_r | assumption ].
+    apply Nat.le_trans with (max N0 N1); [ apply Nat.le_max_r | assumption ].
   apply Rmult_eq_reg_l with 3;
     [ unfold Rdiv; rewrite Rmult_plus_distr_l;
       do 2 rewrite (Rmult_comm 3); repeat rewrite Rmult_assoc;
@@ -1114,8 +1113,8 @@ Proof.
   apply RRle_abs.
   assumption.
   replace (pos (un n)) with (R_dist (un n) 0).
-  apply H; unfold ge; apply le_trans with N; try assumption.
-  unfold N; apply le_max_l.
+  apply H; unfold ge; apply Nat.le_trans with N; try assumption.
+  unfold N; apply Nat.le_max_l.
   unfold R_dist; unfold Rminus; rewrite Ropp_0;
     rewrite Rplus_0_r; apply Rabs_right.
   apply Rle_ge; left; apply (cond_pos (un n)).
@@ -1124,13 +1123,13 @@ Proof.
   apply RRle_abs; assumption.
   assumption.
   replace (pos (un n)) with (R_dist (un n) 0).
-  apply H; unfold ge; apply le_trans with N; try assumption;
-    unfold N; apply le_max_l.
+  apply H; unfold ge; apply Nat.le_trans with N; try assumption;
+    unfold N; apply Nat.le_max_l.
   unfold R_dist; unfold Rminus; rewrite Ropp_0;
     rewrite Rplus_0_r; apply Rabs_right; apply Rle_ge;
       left; apply (cond_pos (un n)).
-  unfold R_dist in H2; apply H2; unfold ge; apply le_trans with N;
-    try assumption; unfold N; apply le_max_r.
+  unfold R_dist in H2; apply H2; unfold ge; apply Nat.le_trans with N;
+    try assumption; unfold N; apply Nat.le_max_r.
   apply Rmult_eq_reg_l with 3;
     [ unfold Rdiv; rewrite Rmult_plus_distr_l;
       do 2 rewrite (Rmult_comm 3); repeat rewrite Rmult_assoc;
@@ -1206,8 +1205,8 @@ Proof.
   rewrite <- Rabs_Ropp; apply RRle_abs.
   assumption.
   replace (pos (un n)) with (R_dist (un n) 0).
-  apply H; unfold ge; apply le_trans with N; try assumption.
-  unfold N; apply le_max_l.
+  apply H; unfold ge; apply Nat.le_trans with N; try assumption.
+  unfold N; apply Nat.le_max_l.
   unfold R_dist; unfold Rminus; rewrite Ropp_0;
     rewrite Rplus_0_r; apply Rabs_right.
   apply Rle_ge; left; apply (cond_pos (un n)).
@@ -1216,13 +1215,13 @@ Proof.
   rewrite <- Rabs_Ropp; apply RRle_abs; assumption.
   assumption.
   replace (pos (un n)) with (R_dist (un n) 0).
-  apply H; unfold ge; apply le_trans with N; try assumption;
-    unfold N; apply le_max_l.
+  apply H; unfold ge; apply Nat.le_trans with N; try assumption;
+    unfold N; apply Nat.le_max_l.
   unfold R_dist; unfold Rminus; rewrite Ropp_0;
     rewrite Rplus_0_r; apply Rabs_right; apply Rle_ge;
       left; apply (cond_pos (un n)).
-  unfold R_dist in H2; apply H2; unfold ge; apply le_trans with N;
-    try assumption; unfold N; apply le_max_r.
+  unfold R_dist in H2; apply H2; unfold ge; apply Nat.le_trans with N;
+    try assumption; unfold N; apply Nat.le_max_r.
   apply Rmult_eq_reg_l with 3;
     [ unfold Rdiv; rewrite Rmult_plus_distr_l;
       do 2 rewrite (Rmult_comm 3); repeat rewrite Rmult_assoc;
@@ -1424,16 +1423,16 @@ Proof.
   apply Rlt_trans with (pos (RinvN n));
     [ apply Rle_lt_trans with (Rabs (RiemannInt_SF (psi3 n)));
       [ apply RRle_abs | elim (H9 n); intros; assumption ]
-      | apply H4; unfold ge; apply le_trans with N;
-        [ apply le_trans with (max N0 N1);
-          [ apply le_max_r | unfold N; apply le_max_l ]
+      | apply H4; unfold ge; apply Nat.le_trans with N;
+        [ apply Nat.le_trans with (max N0 N1);
+          [ apply Nat.le_max_r | unfold N; apply Nat.le_max_l ]
           | assumption ] ].
   apply Rlt_trans with (pos (RinvN n));
     [ apply Rle_lt_trans with (Rabs (RiemannInt_SF (psi1 n)));
       [ apply RRle_abs | elim (H7 n); intros; assumption ]
-      | apply H4; unfold ge; apply le_trans with N;
-        [ apply le_trans with (max N0 N1);
-          [ apply le_max_r | unfold N; apply le_max_l ]
+      | apply H4; unfold ge; apply Nat.le_trans with N;
+        [ apply Nat.le_trans with (max N0 N1);
+          [ apply Nat.le_max_r | unfold N; apply Nat.le_max_l ]
           | assumption ] ].
   apply Rmult_lt_reg_l with (/ Rabs l).
   apply Rinv_0_lt_compat; apply Rabs_pos_lt; assumption.
@@ -1442,23 +1441,23 @@ Proof.
   apply Rlt_trans with (pos (RinvN n));
     [ apply Rle_lt_trans with (Rabs (RiemannInt_SF (psi2 n)));
       [ apply RRle_abs | elim (H8 n); intros; assumption ]
-      | apply H5; unfold ge; apply le_trans with N;
-        [ apply le_trans with (max N2 N3);
-          [ apply le_max_r | unfold N; apply le_max_r ]
+      | apply H5; unfold ge; apply Nat.le_trans with N;
+        [ apply Nat.le_trans with (max N2 N3);
+          [ apply Nat.le_max_r | unfold N; apply Nat.le_max_r ]
           | assumption ] ].
   unfold Rdiv; rewrite Rinv_mult_distr;
     [ ring | discrR | apply Rabs_no_R0; assumption ].
   apply Rabs_no_R0; assumption.
-  apply H3; unfold ge; apply le_trans with (max N0 N1);
-    [ apply le_max_l
-      | apply le_trans with N; [ unfold N; apply le_max_l | assumption ] ].
+  apply H3; unfold ge; apply Nat.le_trans with (max N0 N1);
+    [ apply Nat.le_max_l
+      | apply Nat.le_trans with N; [ unfold N; apply Nat.le_max_l | assumption ] ].
   apply Rmult_lt_reg_l with (/ Rabs l).
   apply Rinv_0_lt_compat; apply Rabs_pos_lt; assumption.
   rewrite <- Rmult_assoc; rewrite <- Rinv_l_sym.
   rewrite Rmult_1_l; replace (/ Rabs l * (eps / 5)) with (eps / (5 * Rabs l)).
-  apply H6; unfold ge; apply le_trans with (max N2 N3);
-    [ apply le_max_l
-      | apply le_trans with N; [ unfold N; apply le_max_r | assumption ] ].
+  apply H6; unfold ge; apply Nat.le_trans with (max N2 N3);
+    [ apply Nat.le_max_l
+      | apply Nat.le_trans with N; [ unfold N; apply Nat.le_max_r | assumption ] ].
   unfold Rdiv; rewrite Rinv_mult_distr;
     [ ring | discrR | apply Rabs_no_R0; assumption ].
   apply Rabs_no_R0; assumption.
@@ -1569,7 +1568,7 @@ Proof.
     replace (- l2 + (l1 + l2) / 2) with ((l1 - l2) / 2).
   rewrite Rplus_comm; apply Rle_lt_trans with (Rabs (Vn N - l2)).
   apply RRle_abs.
-  apply H1; unfold ge; unfold N; apply le_max_r.
+  apply H1; unfold ge; unfold N; apply Nat.le_max_r.
   apply Rmult_eq_reg_l with 2;
     [ unfold Rdiv; do 2 rewrite (Rmult_comm 2);
       rewrite (Rmult_plus_distr_r (- l2) ((l1 + l2) * / 2) 2);
@@ -1580,7 +1579,7 @@ Proof.
     replace (l1 + - ((l1 + l2) / 2)) with ((l1 - l2) / 2).
   apply Rle_lt_trans with (Rabs (Un N - l1)).
   rewrite <- Rabs_Ropp; rewrite Ropp_minus_distr; apply RRle_abs.
-  apply H0; unfold ge; unfold N; apply le_max_l.
+  apply H0; unfold ge; unfold N; apply Nat.le_max_l.
   apply Rmult_eq_reg_l with 2;
     [ unfold Rdiv; do 2 rewrite (Rmult_comm 2);
       rewrite (Rmult_plus_distr_r l1 (- ((l1 + l2) * / 2)) 2);
@@ -1752,16 +1751,16 @@ Proof.
   replace a with (Rmin a b).
   rewrite <- H5; elim (RList_P6 l); intros; apply H10.
   assumption.
-  apply le_O_n.
-  apply lt_trans with (pred (length l)); [ assumption | apply lt_pred_n_n ].
-  apply neq_O_lt; intro; rewrite <- H12 in H6; discriminate.
+  apply Nat.le_0_l.
+  apply Nat.lt_trans with (pred (length l)); [ assumption | apply Nat.lt_pred_l ].
+  intro; rewrite H12 in H6; discriminate.
   unfold Rmin; decide (Rle_dec a b) with H; reflexivity.
   assert (H11 : pos_Rl l (S i) <= b).
   replace b with (Rmax a b).
   rewrite <- H4; elim (RList_P6 l); intros; apply H11.
   assumption.
-  apply lt_le_S; assumption.
-  apply lt_pred_n_n; apply neq_O_lt; intro; rewrite <- H13 in H6; discriminate.
+  apply Nat.le_succ_l; assumption.
+  apply Nat.lt_pred_l; intro; rewrite H13 in H6; discriminate.
   unfold Rmax; decide (Rle_dec a b) with H; reflexivity.
   elim H7; clear H7; intros; unfold phi2_aux; destruct (Req_EM_T x1 a) as [Heq|Hneq];
     destruct (Req_EM_T x1 b) as [Heq'|Hneq'].
@@ -1959,10 +1958,9 @@ Proof.
   apply Rle_lt_trans with (pos_Rl l1 i).
   replace b with (Rmin b c).
   rewrite <- H5; elim (RList_P6 l1); intros; apply H10; try assumption.
-  apply le_O_n.
-  apply lt_trans with (pred (length l1)); try assumption; apply lt_pred_n_n;
-    apply neq_O_lt; red; intro; rewrite <- H12 in H6;
-      discriminate.
+  apply Nat.le_0_l.
+  apply Nat.lt_trans with (pred (length l1)); try assumption; apply Nat.lt_pred_l;
+    red; intro; rewrite H12 in H6; discriminate.
   unfold Rmin; decide (Rle_dec b c) with Hyp2;
     reflexivity.
   elim H7; intros; assumption.
@@ -1983,17 +1981,15 @@ Proof.
   elim H7; intros; left; assumption.
   replace b with (Rmax a b).
   rewrite <- H4; elim (RList_P6 l1); intros; apply H10; try assumption.
-  apply lt_pred_n_n; apply neq_O_lt; red; intro; rewrite <- H12 in H6;
-    discriminate.
+  apply Nat.lt_pred_l; red; intro; rewrite H12 in H6; discriminate.
   unfold Rmax; decide (Rle_dec a b) with Hyp1; reflexivity.
   assert (H11 : a <= x).
   apply Rle_trans with (pos_Rl l1 i).
   replace a with (Rmin a b).
   rewrite <- H5; elim (RList_P6 l1); intros; apply H11; try assumption.
-  apply le_O_n.
-  apply lt_trans with (pred (length l1)); try assumption; apply lt_pred_n_n;
-    apply neq_O_lt; red; intro; rewrite <- H13 in H6;
-      discriminate.
+  apply Nat.le_0_l.
+  apply Nat.lt_trans with (pred (length l1)); try assumption; apply Nat.lt_pred_l;
+    red; intro; rewrite H13 in H6; discriminate.
   unfold Rmin; decide (Rle_dec a b) with Hyp1; reflexivity.
   left; elim H7; intros; assumption.
   decide (Rle_dec a x) with H11; decide (Rle_dec x b) with H10; reflexivity.
@@ -2010,17 +2006,15 @@ Proof.
   elim H7; intros; left; assumption.
   replace b with (Rmax a b).
   rewrite <- H4; elim (RList_P6 l1); intros; apply H10; try assumption.
-  apply lt_pred_n_n; apply neq_O_lt; red; intro; rewrite <- H12 in H6;
-    discriminate.
+  apply Nat.lt_pred_l; red; intro; rewrite H12 in H6; discriminate.
   unfold Rmax; decide (Rle_dec a b) with Hyp1; reflexivity.
   assert (H11 : a <= x).
   apply Rle_trans with (pos_Rl l1 i).
   replace a with (Rmin a b).
   rewrite <- H5; elim (RList_P6 l1); intros; apply H11; try assumption.
-  apply le_O_n.
-  apply lt_trans with (pred (length l1)); try assumption; apply lt_pred_n_n;
-    apply neq_O_lt; red; intro; rewrite <- H13 in H6;
-      discriminate.
+  apply Nat.le_0_l.
+  apply Nat.lt_trans with (pred (length l1)); try assumption; apply Nat.lt_pred_l;
+    red; intro; rewrite H13 in H6; discriminate.
   unfold Rmin; decide (Rle_dec a b) with Hyp1; reflexivity.
   left; elim H7; intros; assumption.
   unfold phi3; decide (Rle_dec a x) with H11; decide (Rle_dec x b) with H10;
@@ -2036,10 +2030,9 @@ Proof.
   apply Rle_lt_trans with (pos_Rl l1 i).
   replace b with (Rmin b c).
   rewrite <- H5; elim (RList_P6 l1); intros; apply H10; try assumption.
-  apply le_O_n.
-  apply lt_trans with (pred (length l1)); try assumption; apply lt_pred_n_n;
-    apply neq_O_lt; red; intro; rewrite <- H12 in H6;
-      discriminate.
+  apply Nat.le_0_l.
+  apply Nat.lt_trans with (pred (length l1)); try assumption; apply Nat.lt_pred_l;
+    red; intro; rewrite H12 in H6; discriminate.
   unfold Rmin; decide (Rle_dec b c) with Hyp2; reflexivity.
   elim H7; intros; assumption.
   unfold phi3; destruct (Rle_dec a x) as [Hle|Hnle]; destruct (Rle_dec x b) as [Hle'|Hnle']; intros;
@@ -2261,8 +2254,8 @@ Proof.
   unfold R_dist in H3; cut (n >= N3)%nat.
   intro; assert (H6 := H3 _ H5); unfold Rminus in H6; rewrite Ropp_0 in H6;
     rewrite Rplus_0_r in H6; apply H6.
-  unfold ge; apply le_trans with N0;
-    [ unfold N0; apply le_max_r | assumption ].
+  unfold ge; apply Nat.le_trans with N0;
+    [ unfold N0; apply Nat.le_max_r | assumption ].
   apply Rle_lt_trans with
     (Rabs (RiemannInt_SF (phi_sequence RinvN pr1 n) - x1) +
       Rabs (RiemannInt_SF (phi_sequence RinvN pr2 n) - x0)).
@@ -2274,14 +2267,14 @@ Proof.
   [ apply Rabs_triang | ring ].
   apply Rplus_lt_compat.
   unfold R_dist in H1; apply H1.
-  unfold ge; apply le_trans with N0;
-    [ apply le_trans with (max N1 N2);
-      [ apply le_max_l | unfold N0; apply le_max_l ]
+  unfold ge; apply Nat.le_trans with N0;
+    [ apply Nat.le_trans with (max N1 N2);
+      [ apply Nat.le_max_l | unfold N0; apply Nat.le_max_l ]
       | assumption ].
   unfold R_dist in H2; apply H2.
-  unfold ge; apply le_trans with N0;
-    [ apply le_trans with (max N1 N2);
-      [ apply le_max_r | unfold N0; apply le_max_l ]
+  unfold ge; apply Nat.le_trans with N0;
+    [ apply Nat.le_trans with (max N1 N2);
+      [ apply Nat.le_max_r | unfold N0; apply Nat.le_max_l ]
       | assumption ].
   apply Rmult_eq_reg_l with 3;
     [ unfold Rdiv; repeat rewrite Rmult_plus_distr_l;
@@ -3256,3 +3249,6 @@ apply Riemann_integrable_scal; assumption.
 Qed.
 
 Arguments Riemann_integrable_Ropp [f a b] _ eps.
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Import Max.

--- a/theories/Reals/RiemannInt_SF.v
+++ b/theories/Reals/RiemannInt_SF.v
@@ -49,7 +49,7 @@ Proof.
   destruct H2 as (x0,H6). remember H6 as H7. destruct H7 as (x1,(H8,H9)).
     apply Rle_trans with x0;
       [ rewrite <- H9; change (INR 0 <= INR x1); apply le_INR;
-        apply le_O_n
+        apply Nat.le_0_l
         | apply H4; assumption ].
   assert (H7 := archimed x); elim H7; clear H7; intros;
     assert (H9 : x <= IZR (up x) - 1).
@@ -61,7 +61,7 @@ Proof.
   assert (H14 : (0 <= up x)%Z).
   apply le_IZR; apply Rle_trans with x; [ apply H6 | left; assumption ].
   destruct (IZN _ H14) as (x2,H15).
-    rewrite H15, <- INR_IZR_INZ; apply le_INR; apply lt_le_S.
+    rewrite H15, <- INR_IZR_INZ; apply le_INR; apply Nat.le_succ_l.
       apply INR_lt; apply Rle_lt_trans with x;
         [ assumption | rewrite INR_IZR_INZ; rewrite <- H15; assumption ].
   assert (H10 : x = IZR (up x) - 1).
@@ -85,16 +85,16 @@ Proof.
   replace (1 + (x - 1)) with x; [ idtac | ring ]; rewrite <- H18;
     replace (1 + INR x1) with (INR (S x1)); [ idtac | rewrite S_INR; ring ].
   cut (x = INR (pred x0)).
-  intro H19; rewrite H19; apply le_INR; apply lt_le_S; apply INR_lt; rewrite H18;
+  intro H19; rewrite H19; apply le_INR; apply Nat.le_succ_l; apply INR_lt; rewrite H18;
     rewrite <- H19; assumption.
   rewrite H10; rewrite H8; rewrite <- INR_IZR_INZ;
     rewrite <- (minus_INR _ 1).
   apply f_equal;
-    case x0; [ reflexivity | intro; apply sym_eq, minus_n_O ].
+    case x0; [ reflexivity | intro; apply Nat.sub_0_r ].
   induction x0 as [|x0 Hrecx0].
     rewrite H8 in H3. rewrite <- INR_IZR_INZ in H3; simpl in H3.
       elim (Rlt_irrefl _ (Rle_lt_trans _ _ _ H6 H3)).
-    apply le_n_S; apply le_O_n.
+    apply le_n_S; apply Nat.le_0_l.
     rewrite H15 in H13; elim H12; assumption.
   split with (pred x0); unfold E in H13; elim H13; intros; elim H12; intros;
     rewrite H10 in H15; rewrite H8 in H15; rewrite <- INR_IZR_INZ in H15;
@@ -202,11 +202,11 @@ Lemma StepFun_P3 :
 Proof.
   intros; unfold adapted_couple; repeat split.
   unfold ordered_Rlist; intros; simpl in H0; inversion H0;
-    [ simpl; assumption | elim (le_Sn_O _ H2) ].
+    [ simpl; assumption | elim (Nat.nle_succ_0 _ H2) ].
   simpl; unfold Rmin; decide (Rle_dec a b) with H; reflexivity.
   simpl; unfold Rmax; decide (Rle_dec a b) with H; reflexivity.
   unfold constant_D_eq, open_interval; intros; simpl in H0;
-    inversion H0; [ reflexivity | elim (le_Sn_O _ H3) ].
+    inversion H0; [ reflexivity | elim (Nat.nle_succ_0 _ H3) ].
 Qed.
 
 Lemma StepFun_P4 : forall a b c:R, IsStepFun (fct_cte c) a b.
@@ -259,7 +259,7 @@ Proof.
   intros; unfold constant_D_eq, open_interval; intros;
     unfold constant_D_eq, open_interval in H6;
       assert (H9 : (S i < pred (length (cons r1 (cons r2 l))))%nat).
-  simpl; simpl in H0; apply lt_n_S; assumption.
+  simpl; simpl in H0; apply -> Nat.succ_lt_mono; assumption.
   assert (H10 := H6 _ H9); apply H10; assumption.
 Qed.
 
@@ -289,7 +289,7 @@ Proof.
       case (Rle_dec a b); intro; [ assumption | reflexivity ].
 
   unfold adapted_couple in H1; decompose [and] H1; intros; apply Rle_antisym.
-  apply (H3 0%nat); simpl; apply lt_O_Sn.
+  apply (H3 0%nat); simpl; apply Nat.lt_0_succ.
   simpl in H5; rewrite H2 in H5; rewrite H5; replace (Rmin b b) with (Rmax a b);
     [ rewrite <- H4; apply RList_P7;
       [ assumption | simpl; right; left; reflexivity ]
@@ -309,7 +309,7 @@ Proof.
             unfold Rmin, Rmax; case (Rle_dec a b);
               intros; elim H0; rewrite <- H5; rewrite <- H7;
                 reflexivity
-            | simpl; do 2 apply le_n_S; apply le_O_n ] ].
+            | simpl; do 2 apply le_n_S; apply Nat.le_0_l ] ].
 Qed.
 
 Lemma StepFun_P10 :
@@ -325,7 +325,7 @@ Proof.
   intros; case (Req_dec a b); intro.
   exists (cons a nil); exists nil; unfold adapted_couple_opt;
     unfold adapted_couple; unfold ordered_Rlist;
-      repeat split; try (intros; simpl in H3; elim (lt_n_O _ H3)).
+      repeat split; try (intros; simpl in H3; elim (Nat.nlt_0_r _ H3)).
   simpl; rewrite <- H2; unfold Rmin; case (Rle_dec a a); intro;
     reflexivity.
   simpl; rewrite <- H2; unfold Rmax; case (Rle_dec a a); intro;
@@ -349,20 +349,20 @@ Proof.
     unfold adapted_couple_opt; unfold adapted_couple;
       repeat split.
   unfold ordered_Rlist; intros; simpl in H8; inversion H8;
-    [ simpl; assumption | elim (le_Sn_O _ H10) ].
+    [ simpl; assumption | elim (Nat.nle_succ_0 _ H10) ].
   simpl; unfold Rmin; decide (Rle_dec a b) with H0; reflexivity.
   simpl; unfold Rmax; decide (Rle_dec a b) with H0; reflexivity.
   intros; simpl in H8; inversion H8.
   unfold constant_D_eq, open_interval; intros; simpl;
     simpl in H9; rewrite H3 in H1; unfold adapted_couple in H1;
       decompose [and] H1; apply (H16 0%nat).
-  simpl; apply lt_O_Sn.
+  simpl; apply Nat.lt_0_succ.
   unfold open_interval; simpl; rewrite H7; simpl in H13;
     rewrite H13; unfold Rmin; decide (Rle_dec a b) with H0; assumption.
-  elim (le_Sn_O _ H10).
-  intros; simpl in H8; elim (lt_n_O _ H8).
+  elim (Nat.nle_succ_0 _ H10).
+  intros; simpl in H8; elim (Nat.nlt_0_r _ H8).
   intros; simpl in H8; inversion H8;
-    [ simpl; assumption | elim (le_Sn_O _ H10) ].
+    [ simpl; assumption | elim (Nat.nle_succ_0 _ H10) ].
   assert (Hyp_min : Rmin t2 b = t2).
   unfold Rmin; decide (Rle_dec t2 b) with H5; reflexivity.
   unfold adapted_couple in H6; elim H6; clear H6; intros;
@@ -382,9 +382,9 @@ Proof.
   simpl; apply Rle_trans with s1.
   replace s1 with t2.
   apply (H12 0%nat).
-  simpl; apply lt_O_Sn.
+  simpl; apply Nat.lt_0_succ.
   simpl in H19; rewrite H19; symmetry ; apply Hyp_min.
-  apply (H16 0%nat); simpl; apply lt_O_Sn.
+  apply (H16 0%nat); simpl; apply Nat.lt_0_succ.
   change (pos_Rl (cons s2 s3) i <= pos_Rl (cons s2 s3) (S i));
     apply (H16 (S i)); simpl; assumption.
   simpl; simpl in H14; rewrite H14; reflexivity.
@@ -395,12 +395,12 @@ Proof.
     induction  i as [| i Hreci].
   simpl; simpl in H6; destruct (total_order_T x t2) as [[Hlt|Heq]|Hgt].
   apply (H17 0%nat);
-    [ simpl; apply lt_O_Sn
+    [ simpl; apply Nat.lt_0_succ
       | unfold open_interval; simpl; elim H6; intros; split;
         assumption ].
   rewrite Heq; assumption.
   rewrite H10; apply (H22 0%nat);
-    [ simpl; apply lt_O_Sn
+    [ simpl; apply Nat.lt_0_succ
       | unfold open_interval; simpl; replace s1 with t2;
         [ elim H6; intros; split; assumption
           | simpl in H19; rewrite H19; rewrite Hyp_min; reflexivity ] ].
@@ -415,9 +415,9 @@ Proof.
         simpl; apply H1.
   intros; induction  i as [| i Hreci].
   simpl; red; intro; elim Hyp_eq; apply Rle_antisym.
-  apply (H12 0%nat); simpl; apply lt_O_Sn.
+  apply (H12 0%nat); simpl; apply Nat.lt_0_succ.
   rewrite <- Hyp_min; rewrite H6; simpl in H19; rewrite <- H19;
-    apply (H16 0%nat); simpl; apply lt_O_Sn.
+    apply (H16 0%nat); simpl; apply Nat.lt_0_succ.
   elim H8; intros; rewrite H9 in H21; apply (H21 (S i)); simpl;
     simpl in H1; apply H1.
   exists (cons t1 l'); exists (cons r1 (cons r2 lf')); rewrite H9 in H6;
@@ -428,11 +428,11 @@ Proof.
   rewrite H9; unfold ordered_Rlist; intros; simpl in H1;
     induction  i as [| i Hreci].
   simpl; replace s1 with t2.
-  apply (H16 0%nat); simpl; apply lt_O_Sn.
+  apply (H16 0%nat); simpl; apply Nat.lt_0_succ.
   simpl in H14; rewrite H14; rewrite Hyp_min; reflexivity.
   change
     (pos_Rl (cons s1 (cons s2 s3)) i <= pos_Rl (cons s1 (cons s2 s3)) (S i))
-   ; apply (H12 i); simpl; apply lt_S_n;
+   ; apply (H12 i); simpl; apply Nat.succ_lt_mono;
       assumption.
   simpl; simpl in H19; apply H19.
   rewrite H9; simpl; simpl in H13; rewrite H13; unfold Rmax;
@@ -441,27 +441,27 @@ Proof.
   intros; simpl in H1; unfold constant_D_eq, open_interval; intros;
     induction  i as [| i Hreci].
   simpl; rewrite H9 in H6; simpl in H6; apply (H22 0%nat).
-  simpl; apply lt_O_Sn.
+  simpl; apply Nat.lt_0_succ.
   unfold open_interval; simpl.
   replace t2 with s1.
   assumption.
   simpl in H14; rewrite H14; rewrite Hyp_min; reflexivity.
   change (f x = pos_Rl (cons r2 lf') i); clear Hreci; apply (H17 i).
-  simpl; rewrite H9 in H1; simpl in H1; apply lt_S_n; apply H1.
+  simpl; rewrite H9 in H1; simpl in H1; apply Nat.succ_lt_mono; apply H1.
   rewrite H9 in H6; unfold open_interval; apply H6.
   intros; simpl in H1; induction  i as [| i Hreci].
   simpl; rewrite H9; right; simpl; replace s1 with t2.
   assumption.
   simpl in H14; rewrite H14; rewrite Hyp_min; reflexivity.
   elim H8; intros; apply (H6 i).
-  simpl; apply lt_S_n; apply H1.
+  simpl; apply Nat.succ_lt_mono; apply H1.
   intros; rewrite H9; induction  i as [| i Hreci].
   simpl; red; intro; elim Hyp_eq; apply Rle_antisym.
-  apply (H16 0%nat); simpl; apply lt_O_Sn.
+  apply (H16 0%nat); simpl; apply Nat.lt_0_succ.
   rewrite <- Hyp_min; rewrite H6; simpl in H14; rewrite <- H14; right;
     reflexivity.
   elim H8; intros; rewrite <- H9; apply (H21 i); rewrite H9; rewrite H9 in H1;
-    simpl; simpl in H1; apply lt_S_n; apply H1.
+    simpl; simpl in H1; apply Nat.succ_lt_mono; apply H1.
   exists (cons t1 l'); exists (cons r1 (cons r2 lf')); rewrite H9 in H6;
     rewrite H3 in H1; unfold adapted_couple in H1, H6;
       decompose [and] H6; decompose [and] H1; clear H6 H1;
@@ -470,11 +470,11 @@ Proof.
   rewrite H9; unfold ordered_Rlist; intros; simpl in H1;
     induction  i as [| i Hreci].
   simpl; replace s1 with t2.
-  apply (H15 0%nat); simpl; apply lt_O_Sn.
+  apply (H15 0%nat); simpl; apply Nat.lt_0_succ.
   simpl in H13; rewrite H13; rewrite Hyp_min; reflexivity.
   change
     (pos_Rl (cons s1 (cons s2 s3)) i <= pos_Rl (cons s1 (cons s2 s3)) (S i))
-   ; apply (H11 i); simpl; apply lt_S_n;
+   ; apply (H11 i); simpl; apply Nat.succ_lt_mono;
       assumption.
   simpl; simpl in H18; apply H18.
   rewrite H9; simpl; simpl in H12; rewrite H12; unfold Rmax;
@@ -483,24 +483,24 @@ Proof.
   intros; simpl in H1; unfold constant_D_eq, open_interval; intros;
     induction  i as [| i Hreci].
   simpl; rewrite H9 in H6; simpl in H6; apply (H21 0%nat).
-  simpl; apply lt_O_Sn.
+  simpl; apply Nat.lt_0_succ.
   unfold open_interval; simpl; replace t2 with s1.
   assumption.
   simpl in H13; rewrite H13; rewrite Hyp_min; reflexivity.
   change (f x = pos_Rl (cons r2 lf') i); clear Hreci; apply (H16 i).
-  simpl; rewrite H9 in H1; simpl in H1; apply lt_S_n; apply H1.
+  simpl; rewrite H9 in H1; simpl in H1; apply Nat.succ_lt_mono; apply H1.
   rewrite H9 in H6; unfold open_interval; apply H6.
   intros; simpl in H1; induction  i as [| i Hreci].
   simpl; left; assumption.
   elim H8; intros; apply (H6 i).
-  simpl; apply lt_S_n; apply H1.
+  simpl; apply Nat.succ_lt_mono; apply H1.
   intros; rewrite H9; induction  i as [| i Hreci].
   simpl; red; intro; elim Hyp_eq; apply Rle_antisym.
-  apply (H15 0%nat); simpl; apply lt_O_Sn.
+  apply (H15 0%nat); simpl; apply Nat.lt_0_succ.
   rewrite <- Hyp_min; rewrite H6; simpl in H13; rewrite <- H13; right;
     reflexivity.
   elim H8; intros; rewrite <- H9; apply (H20 i); rewrite H9; rewrite H9 in H1;
-    simpl; simpl in H1; apply lt_S_n; apply H1.
+    simpl; simpl in H1; apply Nat.succ_lt_mono; apply H1.
   rewrite H3 in H1; clear H4; unfold adapted_couple in H1; decompose [and] H1;
     clear H1; clear H H7 H9; cut (Rmax a b = b);
       [ intro; rewrite H in H5; rewrite <- H5; apply RList_P7;
@@ -519,8 +519,8 @@ Proof.
     unfold adapted_couple in H0, H1; decompose [and] H0;
       decompose [and] H1; clear H0 H1; assert (H12 : r = s1).
   simpl in H10; simpl in H5; rewrite H10; rewrite H5; reflexivity.
-  assert (H14 := H3 0%nat (lt_O_Sn _)); simpl in H14; elim H14; intro.
-  assert (H15 := H7 0%nat (lt_O_Sn _)); simpl in H15; elim H15; intro.
+  assert (H14 := H3 0%nat (Nat.lt_0_succ _)); simpl in H14; elim H14; intro.
+  assert (H15 := H7 0%nat (Nat.lt_0_succ _)); simpl in H15; elim H15; intro.
   rewrite <- H12 in H1; destruct (Rle_dec r1 s2) as [Hle|Hnle]; try assumption.
   assert (H16 : s2 < r1); auto with real.
   induction  s3 as [| r0 s3 Hrecs3].
@@ -531,8 +531,8 @@ Proof.
   clear Hrecs3; induction  lf2 as [| r5 lf2 Hreclf2].
   simpl in H11; discriminate.
   clear Hreclf2; assert (H17 : r3 = r4).
-  set (x := (r + s2) / 2); assert (H17 := H8 0%nat (lt_O_Sn _));
-    assert (H18 := H13 0%nat (lt_O_Sn _));
+  set (x := (r + s2) / 2); assert (H17 := H8 0%nat (Nat.lt_0_succ _));
+    assert (H18 := H13 0%nat (Nat.lt_0_succ _));
       unfold constant_D_eq, open_interval in H17, H18; simpl in H17;
         simpl in H18; rewrite <- (H17 x).
   rewrite <- (H18 x).
@@ -569,16 +569,16 @@ Proof.
       | assumption ].
   assert (H18 : f s2 = r3).
   apply (H8 0%nat);
-    [ simpl; apply lt_O_Sn
+    [ simpl; apply Nat.lt_0_succ
       | unfold open_interval; simpl; split; assumption ].
   assert (H19 : r3 = r5).
   assert (H19 := H7 1%nat); simpl in H19;
-    assert (H20 := H19 (lt_n_S _ _ (lt_O_Sn _))); elim H20;
+    assert (H20 := H19 (proj1 (Nat.succ_lt_mono _ _) (Nat.lt_0_succ _))); elim H20;
       intro.
   set (x := (s2 + Rmin r1 r0) / 2); assert (H22 := H8 0%nat);
     assert (H23 := H13 1%nat); simpl in H22; simpl in H23;
-      rewrite <- (H22 (lt_O_Sn _) x).
-  rewrite <- (H23 (lt_n_S _ _ (lt_O_Sn _)) x).
+      rewrite <- (H22 (Nat.lt_0_succ _) x).
+  rewrite <- (H23 (proj1 (Nat.succ_lt_mono _ _) (Nat.lt_0_succ _)) x).
   reflexivity.
   unfold open_interval; simpl; unfold x; split.
   apply Rmult_lt_reg_l with 2;
@@ -621,15 +621,15 @@ Proof.
                 | apply Rplus_le_compat_l; apply Rmin_l ]
             | discrR ] ].
   elim H2; clear H2; intros; assert (H23 := H22 1%nat); simpl in H23;
-    assert (H24 := H23 (lt_n_S _ _ (lt_O_Sn _))); elim H24;
+    assert (H24 := H23 (proj1 (Nat.succ_lt_mono _ _) (Nat.lt_0_succ _))); elim H24;
       assumption.
   elim H2; intros; assert (H22 := H20 0%nat); simpl in H22;
-    assert (H23 := H22 (lt_O_Sn _)); elim H23; intro;
+    assert (H23 := H22 (Nat.lt_0_succ _)); elim H23; intro;
       [ elim H24; rewrite <- H17; rewrite <- H19; reflexivity
         | elim H24; rewrite <- H17; assumption ].
   elim H2; clear H2; intros; assert (H17 := H16 0%nat); simpl in H17;
-    elim (H17 (lt_O_Sn _)); assumption.
-  rewrite <- H0; rewrite H12; apply (H7 0%nat); simpl; apply lt_O_Sn.
+    elim (H17 (Nat.lt_0_succ _)); assumption.
+  rewrite <- H0; rewrite H12; apply (H7 0%nat); simpl; apply Nat.lt_0_succ.
 Qed.
 
 Lemma StepFun_P12 :
@@ -676,7 +676,7 @@ Proof.
   unfold adapted_couple_opt in H2; elim H2; intros; rewrite (StepFun_P8 H4 H3);
     rewrite (StepFun_P8 H1 H3); reflexivity.
   assert (H4 := StepFun_P9 H1 H3); simpl in H4;
-    elim (le_Sn_O _ (le_S_n _ _ H4)).
+    elim (Nat.nle_succ_0 _ (le_S_n _ _ H4)).
   intros; clear H; unfold adapted_couple_opt in H3; elim H3; clear H3; intros;
     case (Req_dec a b); intro.
   rewrite (StepFun_P8 H2 H4); rewrite (StepFun_P8 H H4); reflexivity.
@@ -702,10 +702,10 @@ Proof.
   intro; unfold adapted_couple in H2, H; decompose [and] H; decompose [and] H2;
     clear H H2; set (x := (r + r1) / 2); assert (H18 := H14 0%nat);
       assert (H20 := H19 0%nat); unfold constant_D_eq, open_interval in H18, H20;
-        simpl in H18; simpl in H20; rewrite <- (H18 (lt_O_Sn _) x).
-  rewrite <- (H20 (lt_O_Sn _) x).
+        simpl in H18; simpl in H20; rewrite <- (H18 (Nat.lt_0_succ _) x).
+  rewrite <- (H20 (Nat.lt_0_succ _) x).
   reflexivity.
-  assert (H21 := H13 0%nat (lt_O_Sn _)); simpl in H21; elim H21; intro;
+  assert (H21 := H13 0%nat (Nat.lt_0_succ _)); simpl in H21; elim H21; intro;
     [ idtac | elim H7; assumption ]; unfold x;
       split.
   apply Rmult_lt_reg_l with 2;
@@ -721,7 +721,7 @@ Proof.
           [ rewrite Rmult_1_l; rewrite <- (Rplus_comm r1); rewrite double;
             apply Rplus_lt_compat_l; apply H
             | discrR ] ].
-  rewrite <- H6; assert (H21 := H13 0%nat (lt_O_Sn _)); simpl in H21; elim H21;
+  rewrite <- H6; assert (H21 := H13 0%nat (Nat.lt_0_succ _)); simpl in H21; elim H21;
     intro; [ idtac | elim H7; assumption ]; unfold x;
       split.
   apply Rmult_lt_reg_l with 2;
@@ -776,29 +776,29 @@ Proof.
   unfold adapted_couple; repeat split.
   unfold ordered_Rlist; intros; simpl in H; induction  i as [| i Hreci].
   simpl; rewrite <- H20; apply (H11 0%nat).
-  simpl; apply lt_O_Sn.
+  simpl; apply Nat.lt_0_succ.
   induction  i as [| i Hreci0].
   simpl; assumption.
   change (pos_Rl (cons s2 s3) i <= pos_Rl (cons s2 s3) (S i));
-    apply (H15 (S i)); simpl; apply lt_S_n; assumption.
+    apply (H15 (S i)); simpl; apply Nat.succ_lt_mono; assumption.
   simpl; symmetry ; apply Hyp_min.
   rewrite <- H17; reflexivity.
   simpl in H19; simpl; rewrite H19; reflexivity.
   intros; simpl in H; unfold constant_D_eq, open_interval; intros;
     induction  i as [| i Hreci].
   simpl; apply (H16 0%nat).
-  simpl; apply lt_O_Sn.
+  simpl; apply Nat.lt_0_succ.
   simpl in H2; rewrite <- H20 in H2; unfold open_interval;
     simpl; apply H2.
   clear Hreci; induction  i as [| i Hreci].
   simpl; simpl in H2; rewrite H9; apply (H21 0%nat).
-  simpl; apply lt_O_Sn.
+  simpl; apply Nat.lt_0_succ.
   unfold open_interval; simpl; elim H2; intros; split.
   apply Rle_lt_trans with r1; try assumption; rewrite <- H6; apply (H11 0%nat);
-    simpl; apply lt_O_Sn.
+    simpl; apply Nat.lt_0_succ.
   assumption.
   clear Hreci; simpl; apply (H21 (S i)).
-  simpl; apply lt_S_n; assumption.
+  simpl; apply Nat.succ_lt_mono; assumption.
   unfold open_interval; apply H2.
   elim H3; clear H3; intros; split.
   rewrite H9;
@@ -830,7 +830,7 @@ Proof.
   unfold adapted_couple; repeat split.
   unfold ordered_Rlist; intros; simpl in H; induction  i as [| i Hreci].
   simpl; rewrite <- H20; apply (H11 0%nat); simpl;
-    apply lt_O_Sn.
+    apply Nat.lt_0_succ.
   rewrite H10; apply (H15 (S i)); simpl; assumption.
   simpl; symmetry ; apply Hyp_min.
   rewrite <- H17; rewrite H10; reflexivity.
@@ -838,7 +838,7 @@ Proof.
   intros; simpl in H; unfold constant_D_eq, open_interval; intros;
     induction  i as [| i Hreci].
   simpl; apply (H16 0%nat).
-  simpl; apply lt_O_Sn.
+  simpl; apply Nat.lt_0_succ.
   simpl in H2; rewrite <- H20 in H2; unfold open_interval;
     simpl; apply H2.
   clear Hreci; simpl; apply (H21 (S i)).
@@ -847,11 +847,11 @@ Proof.
   elim H3; clear H3; intros; split.
   rewrite H5 in H3; intros; apply (H3 (S i)).
   simpl; replace (length lf2) with (S (pred (length lf2))).
-  apply lt_n_S; apply H12.
-  symmetry ; apply S_pred with 0%nat; apply neq_O_lt; red;
-    intro; rewrite <- H13 in H12; elim (lt_n_O _ H12).
+  apply -> Nat.succ_lt_mono; apply H12.
+  apply Nat.lt_succ_pred with 0%nat; apply Nat.neq_0_lt_0; red;
+    intro; rewrite H13 in H12; elim (Nat.nlt_0_r _ H12).
   intros; simpl in H12; rewrite H10; rewrite H5 in H11; apply (H11 (S i));
-    simpl; apply lt_n_S; apply H12.
+    simpl; apply -> Nat.succ_lt_mono; apply H12.
   simpl; rewrite H9; unfold Rminus; rewrite Rplus_opp_r;
     rewrite Rmult_0_r; rewrite Rplus_0_l;
       change
@@ -943,7 +943,7 @@ Lemma StepFun_P20 :
     (0 < length l)%nat -> length l = S (length (FF l f)).
 Proof.
   intros l f H; induction l;
-    [ elim (lt_irrefl _ H)
+    [ elim (Nat.lt_irrefl _ H)
       | simpl; rewrite RList_P18; rewrite RList_P14; reflexivity ].
 Qed.
 
@@ -953,7 +953,7 @@ Lemma StepFun_P21 :
 Proof.
   intros * (x & H & H1 & H0 & H2 & H4).
   repeat split; try assumption.
-  apply StepFun_P20; rewrite H2; apply lt_O_Sn.
+  apply StepFun_P20; rewrite H2; apply Nat.lt_0_succ.
   intros; assert (H5 := H4 _ H3); unfold constant_D_eq, open_interval in H5;
     unfold constant_D_eq, open_interval; intros;
       induction  l as [| r l Hrecl].
@@ -1011,25 +1011,25 @@ Proof.
     (RList_P3 (cons_ORlist (cons r lf) lg)
       (pos_Rl (cons_ORlist (cons r lf) lg) 0)); intros _ H10;
     apply H10; exists 0%nat; split;
-      [ reflexivity | rewrite RList_P11; simpl; apply lt_O_Sn ].
+      [ reflexivity | rewrite RList_P11; simpl; apply Nat.lt_0_succ ].
   elim (RList_P9 (cons r lf) lg (pos_Rl (cons_ORlist (cons r lf) lg) 0));
     intros H12 _; assert (H13 := H12 H10); elim H13; intro.
   elim (RList_P3 (cons r lf) (pos_Rl (cons_ORlist (cons r lf) lg) 0));
     intros H11 _; assert (H14 := H11 H8); elim H14; intros;
       elim H15; clear H15; intros; rewrite H15; rewrite <- H6;
         elim (RList_P6 (cons r lf)); intros; apply H17;
-          [ assumption | apply le_O_n | assumption ].
+          [ assumption | apply Nat.le_0_l | assumption ].
   elim (RList_P3 lg (pos_Rl (cons_ORlist (cons r lf) lg) 0)); intros H11 _;
     assert (H14 := H11 H8); elim H14; intros; elim H15;
       clear H15; intros; rewrite H15; rewrite <- H1; elim (RList_P6 lg);
-        intros; apply H17; [ assumption | apply le_O_n | assumption ].
+        intros; apply H17; [ assumption | apply Nat.le_0_l | assumption ].
   induction  lf as [| r lf Hreclf].
   simpl; right; assumption.
   assert (H8 : In a (cons_ORlist (cons r lf) lg)).
   elim (RList_P9 (cons r lf) lg a); intros; apply H10; left;
     elim (RList_P3 (cons r lf) a); intros; apply H12;
       exists 0%nat; split;
-        [ symmetry ; assumption | simpl; apply lt_O_Sn ].
+        [ symmetry ; assumption | simpl; apply Nat.lt_0_succ ].
   apply RList_P5; [ apply RList_P2; assumption | assumption ].
   rewrite Hyp_max; apply Rle_antisym.
   induction  lf as [| r lf Hreclf].
@@ -1046,7 +1046,7 @@ Proof.
         (pred (length (cons_ORlist (cons r lf) lg)))));
     intros _ H10; apply H10;
       exists (pred (length (cons_ORlist (cons r lf) lg)));
-        split; [ reflexivity | rewrite RList_P11; simpl; apply lt_n_Sn ].
+        split; [ reflexivity | rewrite RList_P11; simpl; apply Nat.lt_succ_diag_r ].
   elim
     (RList_P9 (cons r lf) lg
       (pos_Rl (cons_ORlist (cons r lf) lg)
@@ -1061,8 +1061,8 @@ Proof.
       elim H15; clear H15; intros; rewrite H15; rewrite <- H5;
         elim (RList_P6 (cons r lf)); intros; apply H17;
           [ assumption
-            | simpl; simpl in H14; apply lt_n_Sm_le; assumption
-            | simpl; apply lt_n_Sn ].
+            | simpl; simpl in H14; apply Nat.lt_succ_r; assumption
+            | simpl; apply Nat.lt_succ_diag_r ].
   elim
     (RList_P3 lg
       (pos_Rl (cons_ORlist (cons r lf) lg)
@@ -1070,22 +1070,22 @@ Proof.
     intros H13 _; assert (H14 := H13 H12); elim H14; intros;
       elim H15; clear H15; intros.
   rewrite H15; assert (H17 : length lg = S (pred (length lg))).
-  apply S_pred with 0%nat; apply neq_O_lt; red; intro;
-    rewrite <- H17 in H16; elim (lt_n_O _ H16).
+  symmetry; apply Nat.lt_succ_pred with 0%nat. apply Nat.neq_0_lt_0; red; intro;
+    rewrite H17 in H16; elim (Nat.nlt_0_r _ H16).
   rewrite <- H0; elim (RList_P6 lg); intros; apply H18;
     [ assumption
-      | rewrite H17 in H16; apply lt_n_Sm_le; assumption
-      | apply lt_pred_n_n; rewrite H17; apply lt_O_Sn ].
+      | rewrite H17 in H16; apply Nat.lt_succ_r; assumption
+      | apply Nat.lt_pred_l; rewrite H17; intros Heq; discriminate ].
   induction  lf as [| r lf Hreclf].
   simpl; right; symmetry ; assumption.
   assert (H8 : In b (cons_ORlist (cons r lf) lg)).
   elim (RList_P9 (cons r lf) lg b); intros; apply H10; left;
     elim (RList_P3 (cons r lf) b); intros; apply H12;
       exists (pred (length (cons r lf))); split;
-        [ symmetry ; assumption | simpl; apply lt_n_Sn ].
+        [ symmetry ; assumption | simpl; apply Nat.lt_succ_diag_r ].
   apply RList_P7; [ apply RList_P2; assumption | assumption ].
   apply StepFun_P20; rewrite RList_P11; rewrite H2; rewrite H7; simpl;
-    apply lt_O_Sn.
+    apply Nat.lt_0_succ.
   intros; unfold constant_D_eq, open_interval; intros;
     cut
       (exists l : R,
@@ -1096,7 +1096,7 @@ Proof.
     assert
       (Hyp_cons :
         exists r : R, (exists r0 : list R, cons_ORlist lf lg = cons r r0)).
-  apply RList_P19; red; intro; rewrite H13 in H8; elim (lt_n_O _ H8).
+  apply RList_P19; red; intro; rewrite H13 in H8; elim (Nat.nlt_0_r _ H8).
   elim Hyp_cons; clear Hyp_cons; intros r [r0 Hyp_cons]; rewrite Hyp_cons;
     unfold FF; rewrite RList_P12.
   change (f x = f (pos_Rl (mid_Rlist (cons r r0) r) (S i)));
@@ -1133,11 +1133,11 @@ Proof.
   rewrite <- H6; rewrite <- (RList_P15 lf lg).
   elim (RList_P6 (cons_ORlist lf lg)); intros; apply H11.
   apply RList_P2; assumption.
-  apply le_O_n.
-  apply lt_trans with (pred (length (cons_ORlist lf lg)));
+  apply Nat.le_0_l.
+  apply Nat.lt_trans with (pred (length (cons_ORlist lf lg)));
     [ assumption
-      | apply lt_pred_n_n; apply neq_O_lt; red; intro;
-        rewrite <- H13 in H8; elim (lt_n_O _ H8) ].
+      | apply Nat.lt_pred_l; apply Nat.neq_0_lt_0; apply Nat.neq_0_lt_0; red; intro;
+        rewrite H13 in H8; elim (Nat.nlt_0_r _ H8) ].
   assumption.
   assumption.
   rewrite H1; assumption.
@@ -1146,9 +1146,9 @@ Proof.
   rewrite <- H5; rewrite <- (RList_P16 lf lg); try assumption.
   elim (RList_P6 (cons_ORlist lf lg)); intros; apply H11.
   apply RList_P2; assumption.
-  apply lt_n_Sm_le; apply lt_n_S; assumption.
-  apply lt_pred_n_n; apply neq_O_lt; red; intro; rewrite <- H13 in H8;
-    elim (lt_n_O _ H8).
+  apply Nat.lt_succ_r; apply -> Nat.succ_lt_mono; assumption.
+  apply Nat.lt_pred_l; red; intro; rewrite H13 in H8;
+    elim (Nat.nlt_0_r _ H8).
   rewrite H0; assumption.
   set
     (I :=
@@ -1156,7 +1156,7 @@ Proof.
         pos_Rl lf j <= pos_Rl (cons_ORlist lf lg) i /\ (j < length lf)%nat);
     assert (H12 : Nbound I).
   unfold Nbound; exists (length lf); intros; unfold I in H12; elim H12;
-    intros; apply lt_le_weak; assumption.
+    intros; apply Nat.lt_le_incl; assumption.
   assert (H13 :  exists n : nat, I n).
   exists 0%nat; unfold I; split.
   apply Rle_trans with (pos_Rl (cons_ORlist lf lg) 0).
@@ -1164,20 +1164,20 @@ Proof.
   apply RList_P15; try assumption; rewrite H1; assumption.
   elim (RList_P6 (cons_ORlist lf lg)); intros; apply H13.
   apply RList_P2; assumption.
-  apply le_O_n.
-  apply lt_trans with (pred (length (cons_ORlist lf lg))).
+  apply Nat.le_0_l.
+  apply Nat.lt_trans with (pred (length (cons_ORlist lf lg))).
   assumption.
-  apply lt_pred_n_n; apply neq_O_lt; red; intro; rewrite <- H15 in H8;
-    elim (lt_n_O _ H8).
-  apply neq_O_lt; red; intro; rewrite <- H13 in H5;
+  apply Nat.lt_pred_l; red; intro; rewrite H15 in H8;
+    elim (Nat.nlt_0_r _ H8).
+  apply Nat.neq_0_lt_0; red; intro; rewrite H13 in H5;
     rewrite <- H6 in H11; rewrite <- H5 in H11; elim (Rlt_irrefl _ H11).
   assert (H14 := Nzorn H13 H12); elim H14; clear H14; intros x0 H14;
     exists (pos_Rl lf0 x0); unfold constant_D_eq, open_interval;
       intros; assert (H16 := H9 x0); assert (H17 : (x0 < pred (length lf))%nat).
   elim H14; clear H14; intros; unfold I in H14; elim H14; clear H14; intros;
-    apply lt_S_n; replace (S (pred (length lf))) with (length lf).
+    apply Nat.succ_lt_mono; replace (S (pred (length lf))) with (length lf).
   inversion H18.
-  2: apply lt_n_S; assumption.
+  2: apply -> Nat.succ_lt_mono; assumption.
   cut (x0 = pred (length lf)).
   intro; rewrite H19 in H14; rewrite H5 in H14;
     cut (pos_Rl (cons_ORlist lf lg) i < b).
@@ -1189,13 +1189,13 @@ Proof.
       (pos_Rl (cons_ORlist lf lg) (pred (length (cons_ORlist lf lg)))).
   elim (RList_P6 (cons_ORlist lf lg)); intros; apply H21.
   apply RList_P2; assumption.
-  apply lt_n_Sm_le; apply lt_n_S; assumption.
-  apply lt_pred_n_n; apply neq_O_lt; red; intro; rewrite <- H23 in H8;
-    elim (lt_n_O _ H8).
+  apply Nat.lt_succ_r; apply -> Nat.succ_lt_mono; assumption.
+  apply Nat.lt_pred_l; red; intro; rewrite H23 in H8;
+    elim (Nat.nlt_0_r _ H8).
   right; apply RList_P16; try assumption; rewrite H0; assumption.
   rewrite <- H20; reflexivity.
-  apply S_pred with 0%nat; apply neq_O_lt; red; intro;
-    rewrite <- H19 in H18; elim (lt_n_O _ H18).
+  symmetry; apply Nat.lt_succ_pred with 0%nat; apply Nat.neq_0_lt_0; red; intro;
+    rewrite H19 in H18; elim (Nat.nlt_0_r _ H18).
   assert (H18 := H16 H17); unfold constant_D_eq, open_interval in H18;
     rewrite (H18 x1).
   reflexivity.
@@ -1205,13 +1205,13 @@ Proof.
   apply Rlt_le_trans with (pos_Rl (cons_ORlist lf lg) (S i)); try assumption.
   assert (H22 : (S x0 < length lf)%nat).
   replace (length lf) with (S (pred (length lf)));
-  [ apply lt_n_S; assumption
-    | symmetry ; apply S_pred with 0%nat; apply neq_O_lt; red;
-      intro; rewrite <- H22 in H21; elim (lt_n_O _ H21) ].
+  [ apply -> Nat.succ_lt_mono; assumption
+    | apply Nat.lt_succ_pred with 0%nat; apply Nat.neq_0_lt_0; red;
+      intro; rewrite H22 in H21; elim (Nat.nlt_0_r _ H21) ].
   elim (Rle_dec (pos_Rl lf (S x0)) (pos_Rl (cons_ORlist lf lg) i)); intro a0.
   assert (H23 : (S x0 <= x0)%nat).
   apply H20; unfold I; split; assumption.
-  elim (le_Sn_n _ H23).
+  elim (Nat.nle_succ_diag_l _ H23).
   assert (H23 : pos_Rl (cons_ORlist lf lg) i < pos_Rl lf (S x0)).
   auto with real.
   clear a0; apply RList_P17; try assumption.
@@ -1261,25 +1261,25 @@ Proof.
     (RList_P3 (cons_ORlist (cons r lf) lg)
       (pos_Rl (cons_ORlist (cons r lf) lg) 0)); intros _ H10;
     apply H10; exists 0%nat; split;
-      [ reflexivity | rewrite RList_P11; simpl; apply lt_O_Sn ].
+      [ reflexivity | rewrite RList_P11; simpl; apply Nat.lt_0_succ ].
   elim (RList_P9 (cons r lf) lg (pos_Rl (cons_ORlist (cons r lf) lg) 0));
     intros H12 _; assert (H13 := H12 H10); elim H13; intro.
   elim (RList_P3 (cons r lf) (pos_Rl (cons_ORlist (cons r lf) lg) 0));
     intros H11 _; assert (H14 := H11 H8); elim H14; intros;
       elim H15; clear H15; intros; rewrite H15; rewrite <- H6;
         elim (RList_P6 (cons r lf)); intros; apply H17;
-          [ assumption | apply le_O_n | assumption ].
+          [ assumption | apply Nat.le_0_l | assumption ].
   elim (RList_P3 lg (pos_Rl (cons_ORlist (cons r lf) lg) 0)); intros H11 _;
     assert (H14 := H11 H8); elim H14; intros; elim H15;
       clear H15; intros; rewrite H15; rewrite <- H1; elim (RList_P6 lg);
-        intros; apply H17; [ assumption | apply le_O_n | assumption ].
+        intros; apply H17; [ assumption | apply Nat.le_0_l | assumption ].
   induction  lf as [| r lf Hreclf].
   simpl; right; assumption.
   assert (H8 : In a (cons_ORlist (cons r lf) lg)).
   elim (RList_P9 (cons r lf) lg a); intros; apply H10; left;
     elim (RList_P3 (cons r lf) a); intros; apply H12;
       exists 0%nat; split;
-        [ symmetry ; assumption | simpl; apply lt_O_Sn ].
+        [ symmetry ; assumption | simpl; apply Nat.lt_0_succ ].
   apply RList_P5; [ apply RList_P2; assumption | assumption ].
   rewrite Hyp_max; apply Rle_antisym.
   induction  lf as [| r lf Hreclf].
@@ -1296,7 +1296,7 @@ Proof.
         (pred (length (cons_ORlist (cons r lf) lg)))));
     intros _ H10; apply H10;
       exists (pred (length (cons_ORlist (cons r lf) lg)));
-        split; [ reflexivity | rewrite RList_P11; simpl; apply lt_n_Sn ].
+        split; [ reflexivity | rewrite RList_P11; simpl; apply Nat.lt_succ_diag_r ].
   elim
     (RList_P9 (cons r lf) lg
       (pos_Rl (cons_ORlist (cons r lf) lg)
@@ -1310,8 +1310,8 @@ Proof.
       elim H15; clear H15; intros; rewrite H15; rewrite <- H5;
         elim (RList_P6 (cons r lf)); intros; apply H17;
           [ assumption
-            | simpl; simpl in H14; apply lt_n_Sm_le; assumption
-            | simpl; apply lt_n_Sn ].
+            | simpl; simpl in H14; apply Nat.lt_succ_r; assumption
+            | simpl; apply Nat.lt_succ_diag_r ].
   elim
     (RList_P3 lg
       (pos_Rl (cons_ORlist (cons r lf) lg)
@@ -1319,22 +1319,22 @@ Proof.
     intros H13 _; assert (H14 := H13 H12); elim H14; intros;
       elim H15; clear H15; intros; rewrite H15;
         assert (H17 : length lg = S (pred (length lg))).
-  apply S_pred with 0%nat; apply neq_O_lt; red; intro;
-    rewrite <- H17 in H16; elim (lt_n_O _ H16).
+  symmetry; apply Nat.lt_succ_pred with 0%nat; apply Nat.neq_0_lt_0; red; intro;
+    rewrite H17 in H16; elim (Nat.nlt_0_r _ H16).
   rewrite <- H0; elim (RList_P6 lg); intros; apply H18;
     [ assumption
-      | rewrite H17 in H16; apply lt_n_Sm_le; assumption
-      | apply lt_pred_n_n; rewrite H17; apply lt_O_Sn ].
+      | rewrite H17 in H16; apply Nat.lt_succ_r; assumption
+      | apply Nat.lt_pred_l; rewrite H17; intros Heq; discriminate ].
   induction  lf as [| r lf Hreclf].
   simpl; right; symmetry ; assumption.
   assert (H8 : In b (cons_ORlist (cons r lf) lg)).
   elim (RList_P9 (cons r lf) lg b); intros; apply H10; left;
     elim (RList_P3 (cons r lf) b); intros; apply H12;
       exists (pred (length (cons r lf))); split;
-        [ symmetry ; assumption | simpl; apply lt_n_Sn ].
+        [ symmetry ; assumption | simpl; apply Nat.lt_succ_diag_r ].
   apply RList_P7; [ apply RList_P2; assumption | assumption ].
   apply StepFun_P20; rewrite RList_P11; rewrite H7; rewrite H2; simpl;
-    apply lt_O_Sn.
+    apply Nat.lt_0_succ.
   unfold constant_D_eq, open_interval; intros;
     cut
       (exists l : R,
@@ -1345,7 +1345,7 @@ Proof.
     assert
       (Hyp_cons :
         exists r : R, (exists r0 : list R, cons_ORlist lf lg = cons r r0)).
-  apply RList_P19; red; intro; rewrite H13 in H8; elim (lt_n_O _ H8).
+  apply RList_P19; red; intro; rewrite H13 in H8; elim (Nat.nlt_0_r _ H8).
   elim Hyp_cons; clear Hyp_cons; intros r [r0 Hyp_cons]; rewrite Hyp_cons;
     unfold FF; rewrite RList_P12.
   change (g x = g (pos_Rl (mid_Rlist (cons r r0) r) (S i)));
@@ -1382,20 +1382,20 @@ Proof.
   rewrite <- H6; rewrite <- (RList_P15 lf lg); try assumption.
   elim (RList_P6 (cons_ORlist lf lg)); intros; apply H11.
   apply RList_P2; assumption.
-  apply le_O_n.
-  apply lt_trans with (pred (length (cons_ORlist lf lg)));
+  apply Nat.le_0_l.
+  apply Nat.lt_trans with (pred (length (cons_ORlist lf lg)));
     [ assumption
-      | apply lt_pred_n_n; apply neq_O_lt; red; intro;
-        rewrite <- H13 in H8; elim (lt_n_O _ H8) ].
+      | apply Nat.lt_pred_l; red; intro;
+        rewrite H13 in H8; elim (Nat.nlt_0_r _ H8) ].
   rewrite H1; assumption.
   apply Rlt_le_trans with (pos_Rl (cons_ORlist lf lg) (S i)).
   elim H10; intros; apply Rlt_trans with x; assumption.
   rewrite <- H5; rewrite <- (RList_P16 lf lg); try assumption.
   elim (RList_P6 (cons_ORlist lf lg)); intros; apply H11.
   apply RList_P2; assumption.
-  apply lt_n_Sm_le; apply lt_n_S; assumption.
-  apply lt_pred_n_n; apply neq_O_lt; red; intro; rewrite <- H13 in H8;
-    elim (lt_n_O _ H8).
+  apply Nat.lt_succ_r; apply -> Nat.succ_lt_mono; assumption.
+  apply Nat.lt_pred_l; red; intro; rewrite H13 in H8;
+    elim (Nat.nlt_0_r _ H8).
   rewrite H0; assumption.
   set
     (I :=
@@ -1403,7 +1403,7 @@ Proof.
         pos_Rl lg j <= pos_Rl (cons_ORlist lf lg) i /\ (j < length lg)%nat);
     assert (H12 : Nbound I).
   unfold Nbound; exists (length lg); intros; unfold I in H12; elim H12;
-    intros; apply lt_le_weak; assumption.
+    intros; apply Nat.lt_le_incl; assumption.
   assert (H13 :  exists n : nat, I n).
   exists 0%nat; unfold I; split.
   apply Rle_trans with (pos_Rl (cons_ORlist lf lg) 0).
@@ -1411,20 +1411,20 @@ Proof.
     try assumption; rewrite H1; assumption.
   elim (RList_P6 (cons_ORlist lf lg)); intros; apply H13;
     [ apply RList_P2; assumption
-      | apply le_O_n
-      | apply lt_trans with (pred (length (cons_ORlist lf lg)));
+      | apply Nat.le_0_l
+      | apply Nat.lt_trans with (pred (length (cons_ORlist lf lg)));
         [ assumption
-          | apply lt_pred_n_n; apply neq_O_lt; red; intro;
-            rewrite <- H15 in H8; elim (lt_n_O _ H8) ] ].
-  apply neq_O_lt; red; intro; rewrite <- H13 in H0;
+          | apply Nat.lt_pred_l; red; intro;
+            rewrite H15 in H8; elim (Nat.nlt_0_r _ H8) ] ].
+  apply Nat.neq_0_lt_0; red; intro; rewrite H13 in H0;
     rewrite <- H1 in H11; rewrite <- H0 in H11; elim (Rlt_irrefl _ H11).
   assert (H14 := Nzorn H13 H12); elim H14; clear H14; intros x0 H14;
     exists (pos_Rl lg0 x0); unfold constant_D_eq, open_interval;
       intros; assert (H16 := H4 x0); assert (H17 : (x0 < pred (length lg))%nat).
   elim H14; clear H14; intros; unfold I in H14; elim H14; clear H14; intros;
-    apply lt_S_n; replace (S (pred (length lg))) with (length lg).
+    apply Nat.succ_lt_mono; replace (S (pred (length lg))) with (length lg).
   inversion H18.
-  2: apply lt_n_S; assumption.
+  2: apply -> Nat.succ_lt_mono; assumption.
   cut (x0 = pred (length lg)).
   intro; rewrite H19 in H14; rewrite H0 in H14;
     cut (pos_Rl (cons_ORlist lf lg) i < b).
@@ -1436,14 +1436,14 @@ Proof.
       (pos_Rl (cons_ORlist lf lg) (pred (length (cons_ORlist lf lg)))).
   elim (RList_P6 (cons_ORlist lf lg)); intros; apply H21.
   apply RList_P2; assumption.
-  apply lt_n_Sm_le; apply lt_n_S; assumption.
-  apply lt_pred_n_n; apply neq_O_lt; red; intro; rewrite <- H23 in H8;
-    elim (lt_n_O _ H8).
+  apply Nat.lt_succ_r; apply -> Nat.succ_lt_mono; assumption.
+  apply Nat.lt_pred_l; red; intro; rewrite H23 in H8;
+    elim (Nat.nlt_0_r _ H8).
   right; rewrite H0; rewrite <- H5; apply RList_P16; try assumption.
   rewrite H0; assumption.
   rewrite <- H20; reflexivity.
-  apply S_pred with 0%nat; apply neq_O_lt; red; intro;
-    rewrite <- H19 in H18; elim (lt_n_O _ H18).
+  symmetry; apply Nat.lt_succ_pred with 0%nat; apply Nat.neq_0_lt_0; red; intro;
+    rewrite H19 in H18; elim (Nat.nlt_0_r _ H18).
   assert (H18 := H16 H17); unfold constant_D_eq, open_interval in H18;
     rewrite (H18 x1).
   reflexivity.
@@ -1453,12 +1453,12 @@ Proof.
   apply Rlt_le_trans with (pos_Rl (cons_ORlist lf lg) (S i)); try assumption.
   assert (H22 : (S x0 < length lg)%nat).
   replace (length lg) with (S (pred (length lg))).
-  apply lt_n_S; assumption.
-  symmetry ; apply S_pred with 0%nat; apply neq_O_lt; red;
-    intro; rewrite <- H22 in H21; elim (lt_n_O _ H21).
+  apply -> Nat.succ_lt_mono; assumption.
+  apply Nat.lt_succ_pred with 0%nat; apply Nat.neq_0_lt_0; red;
+    intro; rewrite H22 in H21; elim (Nat.nlt_0_r _ H21).
   elim (Rle_dec (pos_Rl lg (S x0)) (pos_Rl (cons_ORlist lf lg) i)); intro a0.
   assert (H23 : (S x0 <= x0)%nat);
-    [ apply H20; unfold I; split; assumption | elim (le_Sn_n _ H23) ].
+    [ apply H20; unfold I; split; assumption | elim (Nat.nle_succ_diag_l _ H23) ].
   assert (H23 : pos_Rl (cons_ORlist lf lg) i < pos_Rl lg (S x0)).
   auto with real.
   clear a0; apply RList_P17; try assumption;
@@ -1494,7 +1494,7 @@ Proof.
   intros i H8 x1 H10; unfold open_interval in H10, H9, H4;
     rewrite (H9 _ H8 _ H10); rewrite (H4 _ H8 _ H10);
       assert (H11 : l1 <> nil).
-  red; intro H11; rewrite H11 in H8; elim (lt_n_O _ H8).
+  red; intro H11; rewrite H11 in H8; elim (Nat.nlt_0_r _ H8).
   destruct (RList_P19 _ H11) as (r,(r0,H12));
     rewrite H12; unfold FF;
       change
@@ -1523,7 +1523,7 @@ Proof.
                     | discrR ] ] ]).
   rewrite <- H12; assumption.
   rewrite RList_P14; simpl; rewrite H12 in H8; simpl in H8;
-    apply lt_n_S; apply H8.
+    apply -> Nat.succ_lt_mono; apply H8.
 Qed.
 
 Lemma StepFun_P27 :
@@ -1629,7 +1629,7 @@ Proof.
   rewrite Rabs_mult; rewrite (Rabs_right (r2 - r1));
     [ apply Rplus_le_compat_l; apply H; apply RList_P4 with r1; assumption
       | apply Rge_minus; apply Rle_ge; apply (H0 0%nat); simpl;
-        apply lt_O_Sn ].
+        apply Nat.lt_0_succ ].
 Qed.
 
 Lemma StepFun_P34 :
@@ -1667,7 +1667,7 @@ Proof.
   rewrite H4; right; ring.
   do 2 rewrite <- (Rmult_comm (r0 - r)); apply Rmult_le_compat_l.
   apply Rge_le; apply Rge_minus; apply Rle_ge; apply (H0 0%nat); simpl;
-    apply lt_O_Sn.
+    apply Nat.lt_0_succ.
   apply H3; split.
   apply Rmult_lt_reg_l with 2.
   prove_sup0.
@@ -1676,7 +1676,7 @@ Proof.
   assert (H5 : r = a).
   apply H1.
   rewrite H5; rewrite Rmult_1_l; rewrite double; apply Rplus_lt_compat_l.
-  assert (H6 := H0 0%nat (lt_O_Sn _)).
+  assert (H6 := H0 0%nat (Nat.lt_0_succ _)).
   simpl in H6.
   elim H6; intro.
   rewrite H5 in H7; apply H7.
@@ -1693,14 +1693,14 @@ Proof.
   elim (RList_P6 (cons r (cons r0 r1))); intros; apply H5.
   assumption.
   simpl; apply le_n_S.
-  apply le_O_n.
-  simpl; apply lt_n_Sn.
+  apply Nat.le_0_l.
+  simpl; apply Nat.lt_succ_diag_r.
   reflexivity.
   apply Rle_lt_trans with (r + b).
   apply Rplus_le_compat_l; assumption.
   rewrite (Rplus_comm r); apply Rplus_lt_compat_l.
   apply Rlt_le_trans with r0.
-  assert (H6 := H0 0%nat (lt_O_Sn _)).
+  assert (H6 := H0 0%nat (Nat.lt_0_succ _)).
   simpl in H6.
   elim H6; intro.
   apply H7.
@@ -1714,7 +1714,7 @@ Proof.
   intros; apply H3; elim H4; intros; split; try assumption.
   apply Rle_lt_trans with r0; try assumption.
   rewrite <- H1.
-  simpl; apply (H0 0%nat); simpl; apply lt_O_Sn.
+  simpl; apply (H0 0%nat); simpl; apply Nat.lt_0_succ.
 Qed.
 
 Lemma StepFun_P36 :
@@ -1769,11 +1769,11 @@ Proof.
   intros a H H0 H1; simpl in H0; simpl in H1;
     exists (mkStepFun (StepFun_P4 a b (f b))); split.
   reflexivity.
-  intros; elim (lt_n_O _ H2).
+  intros; elim (Nat.nlt_0_r _ H2).
   intros; destruct l as [| r1 l].
   simpl in H1; simpl in H0; exists (mkStepFun (StepFun_P4 a b (f b))); split.
   reflexivity.
-  intros i H2; elim (lt_n_O _ H2).
+  intros i H2; elim (Nat.nlt_0_r _ H2).
   intros; assert (H2 : ordered_Rlist (cons r1 l)).
   apply RList_P4 with r; assumption.
   assert (H3 : pos_Rl (cons r1 l) 0 = r1).
@@ -1799,13 +1799,13 @@ Proof.
   unfold ordered_Rlist; intros; simpl in H9;
     induction  i as [| i Hreci].
   simpl; rewrite H12; replace (Rmin r1 b) with r1.
-  simpl in H0; rewrite <- H0; apply (H 0%nat); simpl; apply lt_O_Sn.
+  simpl in H0; rewrite <- H0; apply (H 0%nat); simpl; apply Nat.lt_0_succ.
   unfold Rmin; decide (Rle_dec r1 b) with H7; reflexivity.
-  apply (H10 i); apply lt_S_n.
+  apply (H10 i); apply Nat.succ_lt_mono.
   replace (S (pred (length lg))) with (length lg).
   apply H9.
-  apply S_pred with 0%nat; apply neq_O_lt; intro; rewrite <- H14 in H9;
-    elim (lt_n_O _ H9).
+  symmetry; apply Nat.lt_succ_pred with 0%nat; apply Nat.neq_0_lt_0; intro; rewrite H14 in H9;
+    elim (Nat.nlt_0_r _ H9).
   simpl; assert (H14 : a <= b).
   rewrite <- H1; simpl in H0; rewrite <- H0; apply RList_P7;
     [ assumption | left; reflexivity ].
@@ -1832,11 +1832,11 @@ Proof.
     (constant_D_eq g' (open_interval (pos_Rl lg i) (pos_Rl lg (S i)))
       (pos_Rl lg2 i)); clear Hreci; assert (H16 := H15 i);
     assert (H17 : (i < pred (length lg))%nat).
-  apply lt_S_n.
+  apply Nat.succ_lt_mono.
   replace (S (pred (length lg))) with (length lg).
   assumption.
-  apply S_pred with 0%nat; apply neq_O_lt; red; intro;
-    rewrite <- H14 in H9; elim (lt_n_O _ H9).
+  symmetry; apply Nat.lt_succ_pred with 0%nat; apply Nat.neq_0_lt_0; red; intro;
+    rewrite H14 in H9; elim (Nat.nlt_0_r _ H9).
   assert (H18 := H16 H17); unfold constant_D_eq, open_interval in H18;
     unfold constant_D_eq, open_interval; intros;
       assert (H19 := H18 _ H14); rewrite <- H19; unfold g';
@@ -1849,9 +1849,9 @@ Proof.
   assumption.
   elim (RList_P3 lg (pos_Rl lg i)); intros; apply H21; exists i; split.
   reflexivity.
-  apply lt_trans with (pred (length lg)); try assumption.
-  apply lt_pred_n_n; apply neq_O_lt; red; intro; rewrite <- H22 in H17;
-    elim (lt_n_O _ H17).
+  apply Nat.lt_trans with (pred (length lg)); try assumption.
+  apply Nat.lt_pred_l; red; intro; rewrite H22 in H17;
+    elim (Nat.nlt_0_r _ H17).
   unfold Rmin; decide (Rle_dec r1 b) with H7; reflexivity.
   exists (mkStepFun H8); split.
   simpl; unfold g'; decide (Rle_dec r1 b) with H7; assumption.
@@ -1867,7 +1867,7 @@ Proof.
         (co_interval (pos_Rl (cons r1 l) i) (pos_Rl (cons r1 l) (S i)))
         (f (pos_Rl (cons r1 l) i))); assert (H10 := H6 i);
       assert (H11 : (i < pred (length (cons r1 l)))%nat).
-  simpl; apply lt_S_n; assumption.
+  simpl; apply Nat.succ_lt_mono; assumption.
   assert (H12 := H10 H11); unfold constant_D_eq, co_interval in H12;
     unfold constant_D_eq, co_interval; intros;
       rewrite <- (H12 _ H13); simpl; unfold g';
@@ -1878,9 +1878,9 @@ Proof.
       change (pos_Rl (cons r1 l) 0 <= pos_Rl (cons r1 l) i);
         elim (RList_P6 (cons r1 l)); intros; apply H15;
           [ assumption
-            | apply le_O_n
-            | simpl; apply lt_trans with (length l);
-              [ apply lt_S_n; assumption | apply lt_n_Sn ] ].
+            | apply Nat.le_0_l
+            | simpl; apply Nat.lt_trans with (length l);
+              [ apply Nat.succ_lt_mono; assumption | apply Nat.lt_succ_diag_r ] ].
 Qed.
 
 Lemma StepFun_P39 :
@@ -1947,20 +1947,19 @@ Proof.
         | left; assumption ].
   red; intro; rewrite H1 in H11; discriminate.
   apply StepFun_P20.
-  rewrite app_length; apply neq_O_lt; red; intro.
-  assert (H2 : (length l1 + length l2)%nat = 0%nat).
-  symmetry ; apply H1.
-  elim (plus_is_O _ _ H2); intros; rewrite H12 in H6; discriminate.
+  rewrite app_length; apply Nat.neq_0_lt_0; red; intro.
+  assert (List.length l1 = 0)%nat as H12 by now destruct (List.length l1); inversion H1.
+  rewrite H12 in H6; discriminate.
   unfold constant_D_eq, open_interval; intros;
-    elim (le_or_lt (S (S i)) (length l1)); intro.
+    elim (Nat.le_gt_cases (S (S i)) (length l1)); intro.
   assert (H14 : pos_Rl (app l1 l2) i = pos_Rl l1 i).
-  apply RList_P26; apply lt_S_n; apply le_lt_n_Sm; apply le_S_n;
-    apply le_trans with (length l1); [ assumption | apply le_n_Sn ].
+  apply RList_P26; apply Nat.succ_lt_mono; apply Nat.lt_succ_r; apply Nat.succ_le_mono;
+    apply Nat.le_trans with (length l1); [ assumption | apply Nat.le_succ_diag_r ].
   assert (H15 : pos_Rl (app l1 l2) (S i) = pos_Rl l1 (S i)).
-  apply RList_P26; apply lt_S_n; apply le_lt_n_Sm; assumption.
+  apply RList_P26; apply Nat.succ_lt_mono; apply Nat.lt_succ_r; assumption.
   rewrite H14 in H2; rewrite H15 in H2; assert (H16 : (2 <= length l1)%nat).
-  apply le_trans with (S (S i));
-    [ repeat apply le_n_S; apply le_O_n | assumption ].
+  apply Nat.le_trans with (S (S i));
+    [ repeat apply -> Nat.succ_le_mono; apply Nat.le_0_l | assumption ].
   elim (RList_P20 _ H16); intros r1 [r2 [r3 H17]]; rewrite H17;
     change
       (f x = pos_Rl (map f (mid_Rlist (app (cons r2 r3) l2) r1)) i)
@@ -1969,12 +1968,12 @@ Proof.
   simpl; assert (H18 := H8 0%nat);
     unfold constant_D_eq, open_interval in H18;
       assert (H19 : (0 < pred (length l1))%nat).
-  rewrite H17; simpl; apply lt_O_Sn.
+  rewrite H17; simpl; apply Nat.lt_0_succ.
   assert (H20 := H18 H19); repeat rewrite H20.
   reflexivity.
   assert (H21 : r1 <= r2).
   rewrite H17 in H3; apply (H3 0%nat).
-  simpl; apply lt_O_Sn.
+  simpl; apply Nat.lt_0_succ.
   elim H21; intro.
   split.
   rewrite H17; simpl; apply Rmult_lt_reg_l with 2;
@@ -2005,11 +2004,11 @@ Proof.
         rewrite H15; assert (H18 := H8 (S i));
           unfold constant_D_eq, open_interval in H18;
             assert (H19 : (S i < pred (length l1))%nat).
-  apply lt_pred; apply lt_S_n; apply le_lt_n_Sm; assumption.
+  apply -> Nat.lt_succ_lt_pred; apply Nat.succ_lt_mono; apply Nat.lt_succ_r; assumption.
   assert (H20 := H18 H19); repeat rewrite H20.
   reflexivity.
   rewrite <- H17; assert (H21 : pos_Rl l1 (S i) <= pos_Rl l1 (S (S i))).
-  apply (H3 (S i)); apply lt_pred; apply lt_S_n; apply le_lt_n_Sm; assumption.
+  apply (H3 (S i)); apply -> Nat.lt_succ_lt_pred; apply Nat.succ_lt_mono; apply Nat.lt_succ_r; assumption.
   elim H21; intro.
   split.
   apply Rmult_lt_reg_l with 2;
@@ -2028,40 +2027,40 @@ Proof.
   elim H2; intros; rewrite H22 in H23;
     elim (Rlt_irrefl _ (Rlt_trans _ _ _ H23 H24)).
   assumption.
-  simpl; rewrite H17 in H1; simpl in H1; apply lt_S_n; assumption.
+  simpl; rewrite H17 in H1; simpl in H1; apply Nat.succ_lt_mono; assumption.
   rewrite RList_P14; rewrite H17 in H1; simpl in H1; apply H1.
   inversion H12.
   assert (H16 : pos_Rl (app l1 l2) (S i) = b).
   rewrite RList_P29.
-  rewrite H15; rewrite <- minus_n_n; rewrite H10; unfold Rmin;
+  rewrite H15; rewrite Nat.sub_diag; rewrite H10; unfold Rmin;
     case (Rle_dec b c) as [|[]]; [ reflexivity | left; assumption ].
   rewrite H15; apply le_n.
   induction  l1 as [| r l1 Hrecl1].
   simpl in H15; discriminate.
-  clear Hrecl1; simpl in H1; simpl; apply lt_n_S; assumption.
+  clear Hrecl1; simpl in H1; simpl; apply -> Nat.succ_lt_mono; assumption.
   assert (H17 : pos_Rl (app l1 l2) i = b).
   rewrite RList_P26.
   replace i with (pred (length l1));
   [ rewrite H4; unfold Rmax; case (Rle_dec a b) as [|[]];
     [ reflexivity | left; assumption ]
     | rewrite H15; reflexivity ].
-  rewrite H15; apply lt_n_Sn.
+  rewrite H15; apply Nat.lt_succ_diag_r.
   rewrite H16 in H2; rewrite H17 in H2; elim H2; intros;
     elim (Rlt_irrefl _ (Rlt_trans _ _ _ H14 H18)).
   assert (H16 : pos_Rl (app l1 l2) i = pos_Rl l2 (i - length l1)).
   apply RList_P29.
-  apply le_S_n; assumption.
-  apply lt_le_trans with (pred (length (app l1 l2)));
-    [ assumption | apply le_pred_n ].
+  apply Nat.succ_le_mono; assumption.
+  apply Nat.lt_le_trans with (pred (length (app l1 l2)));
+    [ assumption | apply Nat.le_pred_l ].
   assert
     (H17 : pos_Rl (app l1 l2) (S i) = pos_Rl l2 (S (i - length l1))).
   replace (S (i - length l1)) with (S i - length l1)%nat.
   apply RList_P29.
-  apply le_S_n; apply le_trans with (S i); [ assumption | apply le_n_Sn ].
+  apply le_S_n; apply Nat.le_trans with (S i); [ assumption | apply Nat.le_succ_diag_r ].
   induction  l1 as [| r l1 Hrecl1].
   simpl in H6; discriminate.
-  clear Hrecl1; simpl in H1; simpl; apply lt_n_S; assumption.
-  symmetry ; apply minus_Sn_m; apply le_S_n; assumption.
+  clear Hrecl1; simpl in H1; simpl; apply -> Nat.succ_lt_mono; assumption.
+  apply Nat.sub_succ_l, Nat.succ_le_mono; assumption.
   assert (H18 : (2 <= length l1)%nat).
   clear f c l2 lf2 H0 H3 H8 H7 H10 H9 H11 H13 i H1 x H2 H12 m H14 H15 H16 H17;
     induction  l1 as [| r l1 Hrecl1].
@@ -2071,14 +2070,14 @@ Proof.
   unfold Rmin, Rmax; case (Rle_dec a b) as [|[]];
     [ assumption | left; assumption ].
   rewrite <- H5 in H0; rewrite <- H4 in H0; elim (Rlt_irrefl _ H0).
-  clear Hrecl1; simpl; repeat apply le_n_S; apply le_O_n.
+  clear Hrecl1; simpl; repeat apply -> Nat.succ_le_mono; apply Nat.le_0_l.
   elim (RList_P20 _ H18); intros r1 [r2 [r3 H19]]; rewrite H19;
     change
       (f x = pos_Rl (map f (mid_Rlist (app (cons r2 r3) l2) r1)) i)
      ; rewrite RList_P12.
   induction  i as [| i Hreci].
-  assert (H20 := le_S_n _ _ H15); assert (H21 := le_trans _ _ _ H18 H20);
-    elim (le_Sn_O _ H21).
+  assert (H20 := le_S_n _ _ H15); assert (H21 := Nat.le_trans _ _ _ H18 H20);
+    elim (Nat.nle_succ_0 _ H21).
   clear Hreci; rewrite RList_P13.
   rewrite H19 in H16; rewrite H19 in H17;
     change
@@ -2091,24 +2090,24 @@ Proof.
           in H17; rewrite H17; assert (H20 := H13 (S i - length l1)%nat);
             unfold constant_D_eq, open_interval in H20;
               assert (H21 : (S i - length l1 < pred (length l2))%nat).
-  apply lt_pred; rewrite minus_Sn_m.
-  apply plus_lt_reg_l with (length l1); rewrite <- le_plus_minus.
+  apply Nat.lt_succ_lt_pred; rewrite <- Nat.sub_succ_l.
+  apply Nat.add_lt_mono_l with (length l1); rewrite Nat.add_comm, Nat.sub_add.
   rewrite H19 in H1; simpl in H1; rewrite H19; simpl;
-    rewrite app_length in H1; apply lt_n_S; assumption.
-  apply le_trans with (S i); [ apply le_S_n; assumption | apply le_n_Sn ].
-  apply le_S_n; assumption.
+    rewrite app_length in H1; apply -> Nat.succ_lt_mono; assumption.
+  apply Nat.le_trans with (S i); [ apply Nat.succ_le_mono; assumption | apply Nat.le_succ_diag_r ].
+  apply Nat.succ_le_mono; assumption.
   assert (H22 := H20 H21); repeat rewrite H22.
   reflexivity.
   rewrite <- H19;
     assert
       (H23 : pos_Rl l2 (S i - length l1) <= pos_Rl l2 (S (S i - length l1))).
-  apply H7; apply lt_pred.
-  rewrite minus_Sn_m.
-  apply plus_lt_reg_l with (length l1); rewrite <- le_plus_minus.
+  apply H7; apply Nat.lt_succ_lt_pred.
+  rewrite <- Nat.sub_succ_l.
+  apply Nat.add_lt_mono_l with (length l1); rewrite Nat.add_comm, Nat.sub_add.
   rewrite H19 in H1; simpl in H1; rewrite H19; simpl;
-    rewrite app_length in H1; apply lt_n_S; assumption.
-  apply le_trans with (S i); [ apply le_S_n; assumption | apply le_n_Sn ].
-  apply le_S_n; assumption.
+    rewrite app_length in H1; apply -> Nat.succ_lt_mono; assumption.
+  apply Nat.le_trans with (S i); [ apply Nat.succ_le_mono; assumption | apply Nat.le_succ_diag_r ].
+  apply Nat.succ_le_mono; assumption.
   elim H23; intro.
   split.
   apply Rmult_lt_reg_l with 2;
@@ -2136,7 +2135,7 @@ Proof.
       pos_Rl (app l1 l2) (S (S i)) = pos_Rl l2 (S (S i - length l1))).
   rewrite H19; simpl; simpl in H17; apply H17.
   rewrite <- H23; rewrite <- H24; assumption.
-  simpl; rewrite H19 in H1; simpl in H1; apply lt_S_n; assumption.
+  simpl; rewrite H19 in H1; simpl in H1; apply Nat.succ_lt_mono; assumption.
   rewrite RList_P14; rewrite H19 in H1; simpl in H1; simpl; apply H1.
 Qed.
 
@@ -2438,19 +2437,19 @@ Proof.
       | elim H0; intros; apply Rle_trans with c; assumption ].
   elim H0; clear H0; intros; unfold adapted_couple; repeat split.
   rewrite H6; unfold ordered_Rlist; intros; simpl in H8; inversion H8;
-    [ simpl; assumption | elim (le_Sn_O _ H10) ].
+    [ simpl; assumption | elim (Nat.nle_succ_0 _ H10) ].
   simpl; unfold Rmin; decide (Rle_dec a c) with H; assumption.
   simpl; unfold Rmax; decide (Rle_dec a c) with H; reflexivity.
   unfold constant_D_eq, open_interval; intros; simpl in H8;
     inversion H8.
   simpl; assert (H10 := H7 0%nat);
     assert (H12 : (0 < pred (length (cons r (cons r1 r2))))%nat).
-  simpl; apply lt_O_Sn.
+  simpl; apply Nat.lt_0_succ.
   apply (H10 H12); unfold open_interval; simpl;
     rewrite H11 in H9; simpl in H9; elim H9; clear H9;
       intros; split; try assumption.
   apply Rlt_le_trans with c; assumption.
-  elim (le_Sn_O _ H11).
+  elim (Nat.nle_succ_0 _ H11).
   cut (adapted_couple f r1 b (cons r1 r2) lf1).
   cut (r1 <= c <= b).
   intros.
@@ -2468,10 +2467,10 @@ Proof.
   unfold ordered_Rlist; intros; simpl in H; induction  i as [| i Hreci].
   simpl; replace r4 with r1.
   apply (H5 0%nat).
-  simpl; apply lt_O_Sn.
+  simpl; apply Nat.lt_0_succ.
   simpl in H12; rewrite H12; unfold Rmin; case (Rle_dec r1 c) as [|[]];
     [ reflexivity | left; assumption ].
-  apply (H9 i); simpl; apply lt_S_n; assumption.
+  apply (H9 i); simpl; apply Nat.succ_lt_mono; assumption.
   simpl; unfold Rmin; case (Rle_dec a c) as [|[]];
     [ assumption | elim H0; intros; assumption ].
   replace (Rmax a c) with (Rmax r1 c).
@@ -2486,7 +2485,7 @@ Proof.
     induction  i as [| i Hreci].
   simpl; assert (H17 := H10 0%nat);
     assert (H18 : (0 < pred (length (cons r (cons r1 r2))))%nat).
-  simpl; apply lt_O_Sn.
+  simpl; apply Nat.lt_0_succ.
   apply (H17 H18); unfold open_interval; simpl; simpl in H4;
     elim H4; clear H4; intros; split; try assumption;
       replace r1 with r4.
@@ -2494,7 +2493,7 @@ Proof.
   simpl in H12; rewrite H12; unfold Rmin; case (Rle_dec r1 c) as [|[]];
     [ reflexivity | left; assumption ].
   clear Hreci; simpl; apply H15.
-  simpl; apply lt_S_n; assumption.
+  simpl; apply Nat.succ_lt_mono; assumption.
   unfold open_interval; apply H4.
   split.
   left; assumption.
@@ -2560,7 +2559,7 @@ Proof.
   intros; simpl in H; induction  i as [| i Hreci].
   unfold constant_D_eq, open_interval; intros; simpl;
     apply (H7 0%nat).
-  simpl; apply lt_O_Sn.
+  simpl; apply Nat.lt_0_succ.
   unfold open_interval; simpl; simpl in H6; elim H6; clear H6;
     intros; split; try assumption; apply Rle_lt_trans with c;
       try assumption; replace r with a.

--- a/theories/Reals/Rlimit.v
+++ b/theories/Reals/Rlimit.v
@@ -469,7 +469,7 @@ Proof.
   apply Rabs_pos_lt; assumption.
   apply Rabs_pos_lt; assumption.
   apply Rinv_0_lt_compat; cut (0%nat <> 2%nat);
-    [ intro H17; generalize (lt_INR_0 2 (neq_O_lt 2 H17)); unfold INR;
+    [ intro H17; generalize (lt_INR_0 2 (proj1 (Nat.neq_0_lt_0 2) (Nat.neq_sym 0 2 H17))); unfold INR;
       intro H18; assumption
       | discriminate ].
   replace (Rabs (f x) * Rabs l * / 2 * / Rabs (f x)) with (Rabs l / 2).
@@ -517,7 +517,7 @@ Proof.
   unfold Rdiv; apply Rmult_lt_0_compat.
   apply Rabs_pos_lt; assumption.
   apply Rinv_0_lt_compat; cut (0%nat <> 2%nat);
-    [ intro H17; generalize (lt_INR_0 2 (neq_O_lt 2 H17)); unfold INR;
+    [ intro H17; generalize (lt_INR_0 2 (proj1 (Nat.neq_0_lt_0 2) (Nat.neq_sym 0 2 H17))); unfold INR;
       intro; assumption
       | discriminate ].
   pattern (Rabs l) at 3; rewrite double_var.
@@ -535,13 +535,13 @@ Proof.
   assumption.
   apply Rmult_lt_0_compat. apply Rsqr_pos_lt; assumption.
   apply Rinv_0_lt_compat; cut (0%nat <> 2%nat);
-    [ intro H3; generalize (lt_INR_0 2 (neq_O_lt 2 H3)); unfold INR;
+    [ intro H3; generalize (lt_INR_0 2 (proj1 (Nat.neq_0_lt_0 2) (Nat.neq_sym 0 2 H3))); unfold INR;
       intro; assumption
       | discriminate ].
   change (0 < Rabs l / 2); unfold Rdiv; apply Rmult_lt_0_compat;
     [ apply Rabs_pos_lt; assumption
       | apply Rinv_0_lt_compat; cut (0%nat <> 2%nat);
-        [ intro H3; generalize (lt_INR_0 2 (neq_O_lt 2 H3)); unfold INR;
+        [ intro H3; generalize (lt_INR_0 2 (proj1 (Nat.neq_0_lt_0 2) (Nat.neq_sym 0 2 H3))); unfold INR;
           intro; assumption
           | discriminate ] ].
 Qed.

--- a/theories/Reals/Rlogic.v
+++ b/theories/Reals/Rlogic.v
@@ -40,7 +40,7 @@ assert (Bu: forall n, (u n <= 1)%R).
   apply Rle_0_1.
   rewrite <- S_INR, <- Rinv_1.
   apply Rinv_le_contravar with (1 := Rlt_0_1).
-  apply (le_INR 1), le_n_S, le_0_n.
+  apply (le_INR 1); apply -> Nat.succ_le_mono; apply Nat.le_0_l.
 set (E y := exists n, y = u n).
 destruct (completeness E) as [l [ub lub]].
   exists R1.
@@ -106,16 +106,16 @@ apply Rinv_le_contravar.
 apply Hi.
 apply Rplus_le_compat_r.
 apply le_INR.
-destruct (le_or_lt n N) as [Hn|Hn].
-  2: now apply lt_le_S.
+destruct (Nat.le_gt_cases n N) as [Hn|Hn].
+  2: now apply Nat.le_succ_l.
 exfalso.
-destruct (le_lt_or_eq _ _ Hn) as [Hn'| ->].
+destruct (proj1 (Nat.lt_eq_cases _ _) Hn) as [Hn'| ->].
 2: now apply Hp.
 apply Rlt_not_le with (2 := Hnp _ Hp).
 rewrite <- (Rinv_involutive l) by now apply Rgt_not_eq.
 apply Rinv_1_lt_contravar.
 rewrite <- S_INR.
-apply (le_INR 1), le_n_S, le_0_n.
+apply (le_INR 1); apply -> Nat.succ_le_mono; apply Nat.le_0_l.
 apply Rlt_le_trans with (INR N + 1)%R.
 apply Rplus_lt_compat_r.
 now apply lt_INR.

--- a/theories/Reals/Rpower.v
+++ b/theories/Reals/Rpower.v
@@ -68,7 +68,7 @@ Proof.
   rewrite <- Rinv_r_sym.
   rewrite Rmult_1_r; rewrite Rmult_comm; rewrite Rmult_assoc;
     rewrite <- Rinv_l_sym.
-  rewrite Rmult_1_r; apply le_INR; apply fact_le; apply le_n_Sn.
+  rewrite Rmult_1_r; apply le_INR; apply fact_le; apply Nat.le_succ_diag_r.
   apply INR_fact_neq_0.
   apply INR_fact_neq_0.
   assert (H0 := cv_speed_pow_fact 1); unfold Un_cv; unfold Un_cv in H0;

--- a/theories/Reals/Rprod.v
+++ b/theories/Reals/Rprod.v
@@ -54,9 +54,9 @@ Proof.
   intros; induction  N as [| N HrecN].
   simpl; apply H; trivial.
   simpl; apply Rmult_le_pos.
-  apply HrecN; intros; apply H; apply le_trans with N;
-    [ assumption | apply le_n_Sn ].
-  apply H; apply le_n.
+  apply HrecN; intros; apply H; apply Nat.le_trans with N;
+    [ assumption | apply Nat.le_succ_diag_r ].
+  apply H; apply Nat.le_refl.
 Qed.
 
 (**********)
@@ -69,13 +69,13 @@ Proof.
   elim  H with O; trivial.
   simpl; apply Rle_trans with (prod_f_R0 An N * Bn (S N)).
   apply Rmult_le_compat_l.
-  apply prod_SO_pos; intros; elim (H n (le_trans _ _ _ H0 (le_n_Sn N))); intros;
+  apply prod_SO_pos; intros; elim (H n (Nat.le_trans _ _ _ H0 (Nat.le_succ_diag_r N))); intros;
     assumption.
   elim (H (S N) (le_n (S N))); intros; assumption.
   do 2 rewrite <- (Rmult_comm (Bn (S N))); apply Rmult_le_compat_l.
   elim (H (S N) (le_n (S N))); intros.
   apply Rle_trans with (An (S N)); assumption.
-  apply HrecN; intros; elim (H n (le_trans _ _ _ H0 (le_n_Sn N))); intros;
+  apply HrecN; intros; elim (H n (Nat.le_trans _ _ _ H0 (Nat.le_succ_diag_r N))); intros;
     split; assumption.
 Qed.
 
@@ -167,8 +167,8 @@ Qed.
 (**********)
 Lemma INR_fact_lt_0 : forall n:nat, 0 < INR (fact n).
 Proof.
-  intro; apply lt_INR_0; apply neq_O_lt; red; intro;
-    elim (fact_neq_0 n); symmetry ; assumption.
+  intro; apply lt_INR_0; apply Nat.neq_0_lt_0; red; intro;
+    elim (fact_neq_0 n); assumption.
 Qed.
 
 (** We have the following inequality : (C 2N k) <= (C 2N N) forall k in [|O;2N|] *)

--- a/theories/Reals/Rseries.v
+++ b/theories/Reals/Rseries.v
@@ -208,7 +208,7 @@ Section sequence.
     exists N.
     apply Rnot_le_lt.
     intros H5.
-    apply Rlt_not_le with (1 := H4 _ (le_refl _)).
+    apply Rlt_not_le with (1 := H4 _ (Nat.le_refl _)).
     rewrite Rabs_pos_eq. 2: now apply Rlt_le.
     apply Hm2.
     intros x (n, H6).
@@ -223,15 +223,16 @@ Section sequence.
     apply Rle_trans with (2 := H5).
     apply Rge_le.
     apply growing_prop ; try easy.
-    apply le_n_Sn.
+    apply Nat.le_succ_diag_r.
     rewrite (IHN H6), Rplus_0_l.
     unfold test.
     destruct Rle_lt_dec as [Hle|Hlt].
     apply eq_refl.
     now elim Rlt_not_le with (1 := Hlt).
 
-    destruct (le_or_lt N n) as [Hn|Hn].
-    rewrite le_plus_minus with (1 := Hn).
+    destruct (Nat.le_gt_cases N n) as [Hn|Hn].
+
+    rewrite <- (Nat.sub_add _ _ Hn), Nat.add_comm.
     apply Rle_trans with (1 := proj2 (Hsum' N (n - N)%nat)).
     rewrite Hs, Rplus_0_l.
     set (k := (N + (n - N))%nat).
@@ -239,8 +240,8 @@ Section sequence.
     apply Rplus_lt_reg_l with ((/2)^k - (/2)^N).
     now ring_simplify.
     apply Rle_trans with (sum N).
-    rewrite le_plus_minus with (1 := Hn).
-    rewrite plus_Snm_nSm.
+    rewrite <- (Nat.sub_add _ _ Hn), Nat.add_comm.
+    simpl Nat.add; rewrite <- Nat.add_succ_r.
     exact (proj1 (Hsum' _ _)).
     rewrite Hs.
     now apply Rlt_le.
@@ -260,8 +261,8 @@ Section sequence.
     forall N:nat,  exists M : R, (forall n:nat, (n <= N)%nat -> Un n <= M).
   Proof.
     intro; induction  N as [| N HrecN].
-    split with (Un 0); intros; rewrite (le_n_O_eq n H);
-      apply (Req_le (Un n) (Un n) (eq_refl (Un n))).
+    split with (Un 0); intros. rewrite (proj1 (Nat.le_0_r n) H);
+      apply (Req_le (Un 0) (Un 0) (eq_refl (Un 0))).
     elim HrecN; clear HrecN; intros; split with (Rmax (Un (S N)) x); intros;
       elim (Rmax_Rle (Un (S N)) x (Un n)); intros; clear H1;
         inversion H0.
@@ -399,7 +400,7 @@ Lemma CV_shift :
   forall f k l, Un_cv (fun n => f (n + k)%nat) l -> Un_cv f l.
 intros f' k l cvfk eps ep; destruct (cvfk eps ep) as [N Pn].
 exists (N + k)%nat; intros n nN; assert (tmp: (n = (n - k) + k)%nat).
- rewrite Nat.sub_add;[ | apply le_trans with (N + k)%nat]; auto with arith.
+ rewrite Nat.sub_add;[ | apply Nat.le_trans with (N + k)%nat]; auto with arith.
 rewrite tmp; apply Pn; apply Nat.le_add_le_sub_r; assumption.
 Qed.
 

--- a/theories/Reals/Rsigma.v
+++ b/theories/Reals/Rsigma.v
@@ -31,11 +31,11 @@ Section Sigma.
   Proof.
     intros; induction  k as [| k Hreck].
     cut (low = 0%nat).
-    intro; rewrite H1; unfold sigma; rewrite <- minus_n_n;
-      rewrite <- minus_n_O; simpl; replace (high - 1)%nat with (pred high).
+    intro; rewrite H1; unfold sigma; rewrite Nat.sub_diag, Nat.sub_0_r;
+      simpl; replace (high - 1)%nat with (pred high).
     apply (decomp_sum (fun k:nat => f k)).
     assumption.
-    apply pred_of_minus.
+    symmetry; apply Nat.sub_1_r.
     inversion H; reflexivity.
     cut ((low <= k)%nat \/ low = S k).
     intro; elim H1; intro.
@@ -44,7 +44,7 @@ Section Sigma.
       replace (f (S k) + sigma (S (S k)) high) with (sigma (S k) high).
     apply Hreck.
     assumption.
-    apply lt_trans with (S k); [ apply lt_n_Sn | assumption ].
+    apply Nat.lt_trans with (S k); [ apply Nat.lt_succ_diag_r | assumption ].
     unfold sigma; replace (high - S (S k))%nat with (pred (high - S k)).
     pattern (S k) at 3; replace (S k) with (S k + 0)%nat;
       [ idtac | ring ].
@@ -56,20 +56,20 @@ Section Sigma.
     reflexivity.
     ring.
     replace (high - S (S k))%nat with (high - S k - 1)%nat.
-    apply pred_of_minus.
+    symmetry; apply Nat.sub_1_r.
     lia.
     unfold sigma; replace (S k - low)%nat with (S (k - low)).
     pattern (S k) at 1; replace (S k) with (low + S (k - low))%nat.
     symmetry ; apply (tech5 (fun i:nat => f (low + i))).
     lia.
     lia.
-    rewrite <- H2; unfold sigma; rewrite <- minus_n_n; simpl;
+    rewrite <- H2; unfold sigma; rewrite Nat.sub_diag; simpl;
       replace (high - S low)%nat with (pred (high - low)).
     replace (sum_f_R0 (fun k0:nat => f (S (low + k0))) (pred (high - low))) with
     (sum_f_R0 (fun k0:nat => f (low + S k0)) (pred (high - low))).
     apply (decomp_sum (fun k0:nat => f (low + k0))).
     apply lt_minus_O_lt.
-    apply le_lt_trans with (S k); [ rewrite H2; apply le_n | assumption ].
+    apply Nat.le_lt_trans with (S k); [ rewrite H2; apply Nat.le_refl | assumption ].
     apply sum_eq; intros; replace (S (low + i)) with (low + S i)%nat.
     reflexivity.
     ring.
@@ -97,13 +97,13 @@ Section Sigma.
     forall low high:nat,
       (low < high)%nat -> sigma low high = f low + sigma (S low) high.
   Proof.
-    intros low high H1; generalize (lt_le_S low high H1); intro H2;
-      generalize (lt_le_weak low high H1); intro H3;
+    intros low high H1; generalize (proj2 (Nat.le_succ_l low high) H1); intro H2;
+      generalize (Nat.lt_le_incl low high H1); intro H3;
         replace (f low) with (sigma low low).
     apply sigma_split.
     apply le_n.
     assumption.
-    unfold sigma; rewrite <- minus_n_n.
+    unfold sigma; rewrite Nat.sub_diag.
     simpl.
     replace (low + 0)%nat with low; [ reflexivity | ring ].
   Qed.
@@ -112,23 +112,23 @@ Section Sigma.
     forall low high:nat,
       (low < high)%nat -> sigma low high = f high + sigma low (pred high).
   Proof.
-    intros low high H1; generalize (lt_le_S low high H1); intro H2;
-      generalize (lt_le_weak low high H1); intro H3;
+    intros low high H1; generalize (proj2 (Nat.le_succ_l low high) H1); intro H2;
+      generalize (Nat.lt_le_incl low high H1); intro H3;
         replace (f high) with (sigma high high).
     rewrite Rplus_comm; cut (high = S (pred high)).
     intro; pattern high at 3; rewrite H.
     apply sigma_split.
-    apply le_S_n; rewrite <- H; apply lt_le_S; assumption.
-    apply lt_pred_n_n; apply le_lt_trans with low; [ apply le_O_n | assumption ].
-    apply S_pred with 0%nat; apply le_lt_trans with low;
-      [ apply le_O_n | assumption ].
-    unfold sigma; rewrite <- minus_n_n; simpl;
+    apply le_S_n; rewrite <- H; apply Nat.le_succ_l; assumption.
+    apply Nat.lt_pred_l, Nat.neq_0_lt_0; apply Nat.le_lt_trans with low; [ apply Nat.le_0_l | assumption ].
+    symmetry; apply Nat.lt_succ_pred with 0%nat; apply Nat.le_lt_trans with low;
+      [ apply Nat.le_0_l | assumption ].
+    unfold sigma; rewrite Nat.sub_diag; simpl;
       replace (high + 0)%nat with high; [ reflexivity | ring ].
   Qed.
 
   Theorem sigma_eq_arg : forall low:nat, sigma low low = f low.
   Proof.
-    intro; unfold sigma; rewrite <- minus_n_n.
+    intro; unfold sigma; rewrite Nat.sub_diag.
     simpl; replace (low + 0)%nat with low; [ reflexivity | ring ].
   Qed.
 

--- a/theories/Reals/Rsqrt_def.v
+++ b/theories/Reals/Rsqrt_def.v
@@ -129,7 +129,7 @@ Proof.
   apply decreasing_prop.
   assert (H0 := dicho_up_decreasing x y P H).
   assumption.
-  apply le_O_n.
+  apply Nat.le_0_l.
 Qed.
 
 Lemma dicho_lb_maj :
@@ -166,7 +166,7 @@ Proof.
   apply tech9.
   assert (H0 := dicho_lb_growing x y P H).
   assumption.
-  apply le_O_n.
+  apply Nat.le_0_l.
   assumption.
   assumption.
 Qed.

--- a/theories/Reals/Rtrigo1.v
+++ b/theories/Reals/Rtrigo1.v
@@ -685,14 +685,14 @@ Proof.
     apply Rmult_lt_compat_l.
   apply pow_lt; assumption.
   rewrite <- H1; apply Rmult_lt_reg_l with (INR (fact (2 * n + 1))).
-  apply lt_INR_0; apply neq_O_lt.
+  apply lt_INR_0; apply Nat.neq_0_lt_0.
   assert (H2 := fact_neq_0 (2 * n + 1)).
-  red in |- *; intro; elim H2; symmetry  in |- *; assumption.
+  red in |- *; intro; elim H2; assumption.
   rewrite <- Rinv_r_sym.
   apply Rmult_lt_reg_l with (INR (fact (2 * S n + 1))).
-  apply lt_INR_0; apply neq_O_lt.
+  apply lt_INR_0; apply Nat.neq_0_lt_0.
   assert (H2 := fact_neq_0 (2 * S n + 1)).
-  red in |- *; intro; elim H2; symmetry  in |- *; assumption.
+  red in |- *; intro; elim H2; assumption.
   rewrite (Rmult_comm (INR (fact (2 * S n + 1)))); repeat rewrite Rmult_assoc;
     rewrite <- Rinv_l_sym.
   do 2 rewrite Rmult_1_r; apply Rle_lt_trans with (INR (fact (2 * n + 1)) * 4).
@@ -713,9 +713,9 @@ Proof.
   repeat rewrite <- Rmult_assoc.
   rewrite <- (Rmult_comm (INR (fact (2 * n + 1)))).
   apply Rmult_lt_compat_l.
-  apply lt_INR_0; apply neq_O_lt.
+  apply lt_INR_0; apply Nat.neq_0_lt_0.
   assert (H2 := fact_neq_0 (2 * n + 1)).
-  red in |- *; intro; elim H2; symmetry  in |- *; assumption.
+  red in |- *; intro; elim H2; assumption.
   do 2 rewrite S_INR; rewrite plus_INR; rewrite mult_INR; set (x := INR n);
     unfold INR in |- *.
   replace (((1 + 1) * x + 1 + 1 + 1) * ((1 + 1) * x + 1 + 1)) with (4 * x * x + 10 * x + 6);

--- a/theories/Reals/Rtrigo_alt.v
+++ b/theories/Reals/Rtrigo_alt.v
@@ -85,8 +85,8 @@ Proof.
   unfold Rdiv; rewrite Rmult_assoc; apply Rmult_le_compat_l.
   left; apply pow_lt; assumption.
   apply Rmult_le_reg_l with (INR (fact (S (S (2 * S n0 + 1))))).
-  rewrite <- H3; apply lt_INR_0; apply neq_O_lt; red; intro;
-    assert (H5 := eq_sym H4); elim (fact_neq_0 _ H5).
+  rewrite <- H3; apply lt_INR_0; apply Nat.neq_0_lt_0; red; intro;
+    elim (fact_neq_0 _ H4).
   rewrite <- H3; rewrite (Rmult_comm (INR (fact (2 * S (S n0) + 1))));
     rewrite Rmult_assoc; rewrite <- Rinv_l_sym.
   rewrite Rmult_1_r; rewrite H3; do 2 rewrite fact_simpl; do 2 rewrite mult_INR;
@@ -126,13 +126,13 @@ Proof.
       intros; elim (H3 eps H4); intros N H5.
   exists N; intros; apply H5.
   replace (2 * S n0 + 1)%nat with (S (2 * S n0)).
-  unfold ge; apply le_trans with (2 * S n0)%nat.
-  apply le_trans with (2 * S N)%nat.
-  apply le_trans with (2 * N)%nat.
+  unfold ge; apply Nat.le_trans with (2 * S n0)%nat.
+  apply Nat.le_trans with (2 * S N)%nat.
+  apply Nat.le_trans with (2 * N)%nat.
   apply le_n_2n.
-  apply (fun m n p:nat => mult_le_compat_l p n m); apply le_n_Sn.
-  apply (fun m n p:nat => mult_le_compat_l p n m); apply le_n_S; assumption.
-  apply le_n_Sn.
+  apply (fun m n p:nat => Nat.mul_le_mono_nonneg_l p n m). apply Nat.le_0_l. apply Nat.le_succ_diag_r.
+  apply (fun m n p:nat => Nat.mul_le_mono_nonneg_l p n m). apply Nat.le_0_l. apply -> Nat.succ_le_mono; assumption.
+  apply Nat.le_succ_diag_r.
   ring.
   unfold sin.
   destruct (exist_sin (Rsqr a)) as (x,p).
@@ -156,7 +156,7 @@ Proof.
       rewrite (Rmult_comm (/ Rabs a)),
         <- Rabs_Ropp, Ropp_plus_distr, Ropp_involutive, Rmult_1_l.
           unfold Rminus, Rdiv in H6. apply H6; unfold ge;
-            apply le_trans with n0; [ exact H5 | apply le_n_Sn ].
+            apply Nat.le_trans with n0; [ exact H5 | apply Nat.le_succ_diag_r ].
   rewrite (decomp_sum (fun i:nat => sin_n i * Rsqr a ^ i) (S n0)).
   replace (sin_n 0) with 1.
   simpl; rewrite Rmult_1_r; unfold Rminus;
@@ -172,7 +172,7 @@ Proof.
   simpl; ring.
   unfold sin_n; unfold Rdiv; simpl; rewrite Rinv_1;
     rewrite Rmult_1_r; reflexivity.
-  apply lt_O_Sn.
+  apply Nat.lt_0_succ.
   unfold Rdiv; apply Rmult_lt_0_compat.
   assumption.
   apply Rinv_0_lt_compat; apply Rabs_pos_lt; assumption.
@@ -207,10 +207,10 @@ Proof.
   unfold sin_term; simpl; unfold Rdiv; rewrite Rinv_1;
     ring.
   replace (2 * (n + 1))%nat with (S (S (2 * n))).
-  apply lt_O_Sn.
+  apply Nat.lt_0_succ.
   ring.
   replace (2 * n + 1)%nat with (S (2 * n)).
-  apply lt_O_Sn.
+  apply Nat.lt_0_succ.
   ring.
   inversion H; [ assumption | elim Hyp_a; symmetry ; assumption ].
 Qed.
@@ -264,8 +264,8 @@ Proof.
   unfold Rdiv; rewrite Rmult_assoc; apply Rmult_le_compat_l.
   apply pow_le; assumption.
   apply Rmult_le_reg_l with (INR (fact (S (S (2 * S n1))))).
-  rewrite <- H4; apply lt_INR_0; apply neq_O_lt; red; intro;
-    assert (H6 := eq_sym H5); elim (fact_neq_0 _ H6).
+  rewrite <- H4; apply lt_INR_0; apply Nat.neq_0_lt_0; red; intro;
+    elim (fact_neq_0 _ H5).
   rewrite <- H4; rewrite (Rmult_comm (INR (fact (2 * S (S n1)))));
     rewrite Rmult_assoc; rewrite <- Rinv_l_sym.
   rewrite Rmult_1_r; rewrite H4; do 2 rewrite fact_simpl; do 2 rewrite mult_INR;
@@ -301,11 +301,11 @@ Proof.
   assert (H4 := cv_speed_pow_fact a0); unfold Un; unfold Un_cv in H4;
     unfold R_dist in H4; unfold Un_cv; unfold R_dist;
       intros; elim (H4 eps H5); intros N H6; exists N; intros.
-  apply H6; unfold ge; apply le_trans with (2 * S N)%nat.
-  apply le_trans with (2 * N)%nat.
+  apply H6; unfold ge; apply Nat.le_trans with (2 * S N)%nat.
+  apply Nat.le_trans with (2 * N)%nat.
   apply le_n_2n.
-  apply (fun m n p:nat => mult_le_compat_l p n m); apply le_n_Sn.
-  apply (fun m n p:nat => mult_le_compat_l p n m); apply le_n_S; assumption.
+  apply (fun m n p:nat => Nat.mul_le_mono_nonneg_l p n m). apply Nat.le_0_l. apply Nat.le_succ_diag_r.
+  apply (fun m n p:nat => Nat.mul_le_mono_nonneg_l p n m). apply Nat.le_0_l. apply -> Nat.succ_le_mono; assumption.
   unfold cos. destruct (exist_cos (Rsqr a0)) as (x,p).
   unfold cos_in, infinite_sum, R_dist in p;
    unfold Un_cv, R_dist; intros.
@@ -319,9 +319,9 @@ Proof.
         rewrite Rplus_opp_l; rewrite Rplus_0_r; rewrite <- Rabs_Ropp;
           rewrite Ropp_plus_distr; rewrite Ropp_involutive;
             unfold Rminus in H6; apply H6.
-  unfold ge; apply le_trans with n1.
+  unfold ge; apply Nat.le_trans with n1.
   exact H5.
-  apply le_n_Sn.
+  apply Nat.le_succ_diag_r.
   rewrite (decomp_sum (fun i:nat => cos_n i * Rsqr a0 ^ i) (S n1)).
   replace (cos_n 0) with 1.
   simpl; rewrite Rmult_1_r; unfold Rminus;
@@ -339,7 +339,7 @@ Proof.
   simpl; ring.
   unfold cos_n; unfold Rdiv; simpl; rewrite Rinv_1;
     rewrite Rmult_1_r; reflexivity.
-  apply lt_O_Sn.
+  apply Nat.lt_0_succ.
   intros; elim H3; intros; replace (cos a0 - 1) with (- (1 - cos a0));
     [ idtac | ring ].
   split; apply Ropp_le_contravar; assumption.
@@ -369,10 +369,10 @@ Proof.
   unfold cos_term; simpl; unfold Rdiv; rewrite Rinv_1;
     ring.
   replace (2 * (n0 + 1))%nat with (S (S (2 * n0))).
-  apply lt_O_Sn.
+  apply Nat.lt_0_succ.
   ring.
   replace (2 * n0 + 1)%nat with (S (2 * n0)).
-  apply lt_O_Sn.
+  apply Nat.lt_0_succ.
   ring.
   intros; destruct (total_order_T 0 a) as [[Hlt|Heq]|Hgt].
   apply H; [ left; assumption | assumption ].

--- a/theories/Reals/Rtrigo_calc.v
+++ b/theories/Reals/Rtrigo_calc.v
@@ -128,7 +128,7 @@ Proof.
         | generalize (Rlt_le 0 2 Hyp); intro H1; assert (Hyp2 : 0 < 3);
           [ prove_sup0
             | generalize (Rlt_le 0 3 Hyp2); intro H2;
-              generalize (lt_INR_0 1 (neq_O_lt 1 H0));
+              generalize (lt_INR_0 1 (proj1 (Nat.neq_0_lt_0 1) (Nat.neq_sym 0 1 H0)));
                 unfold INR; intro H3;
                   generalize (Rplus_lt_compat_l 2 0 1 H3);
                     rewrite Rplus_comm; rewrite Rplus_0_l; replace (2 + 1) with 3;

--- a/theories/Reals/Rtrigo_def.v
+++ b/theories/Reals/Rtrigo_def.v
@@ -8,7 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-Require Import Rbase Rfunctions SeqSeries Rtrigo_fun Max.
+Require Import Rbase Rfunctions SeqSeries Rtrigo_fun.
 Local Open Scope R_scope.
 
 (********************************)
@@ -38,7 +38,7 @@ Definition exp (x:R) : R := proj1_sig (exist_exp x).
 Lemma pow_i : forall i:nat, (0 < i)%nat -> 0 ^ i = 0.
 Proof.
   intros; apply pow_ne_zero.
-  red; intro; rewrite H0 in H; elim (lt_irrefl _ H).
+  red; intro; rewrite H0 in H; elim (Nat.lt_irrefl _ H).
 Qed.
 
 (* Value of [exp 0] *)
@@ -59,7 +59,7 @@ Proof.
   rewrite <- Hrecn.
   simpl.
   ring.
-  unfold ge; apply le_O_n.
+  unfold ge; apply Nat.le_0_l.
 Qed.
 
 (*****************************************)
@@ -133,15 +133,15 @@ Proof.
   apply Rmult_le_reg_l with (IZR (Z.of_nat (max x 1))).
   apply Rlt_le_trans with (IZR (Z.of_nat x)).
   assumption.
-  repeat rewrite <- INR_IZR_INZ; apply le_INR; apply le_max_l.
+  repeat rewrite <- INR_IZR_INZ; apply le_INR; apply Nat.le_max_l.
   rewrite Rmult_1_r; rewrite (Rmult_comm (IZR (Z.of_nat (max x 1))));
     rewrite Rmult_assoc; rewrite <- Rinv_l_sym.
   rewrite Rmult_1_r; repeat rewrite <- INR_IZR_INZ; apply le_INR;
-    apply le_max_l.
+    apply Nat.le_max_l.
   rewrite <- INR_IZR_INZ; apply not_O_INR.
-  red; intro; assert (H6 := le_max_r x 1); cut (0 < 1)%nat;
-    [ intro | apply lt_O_Sn ]; assert (H8 := lt_le_trans _ _ _ H7 H6);
-      rewrite H5 in H8; elim (lt_irrefl _ H8).
+  red; intro; assert (H6 := Nat.le_max_r x 1); cut (0 < 1)%nat;
+    [ intro | apply Nat.lt_0_succ ]; assert (H8 := Nat.lt_le_trans _ _ _ H7 H6);
+      rewrite H5 in H8; elim (Nat.lt_irrefl _ H8).
   pattern eps at 1; rewrite <- Rinv_involutive.
   apply Rinv_lt_contravar.
   apply Rmult_lt_0_compat; [ apply Rinv_0_lt_compat; assumption | assumption ].
@@ -150,7 +150,7 @@ Proof.
   apply Rlt_trans with (/ eps).
   apply Rinv_0_lt_compat; assumption.
   rewrite H3 in H0; assumption.
-  apply lt_le_trans with 1%nat; [ apply lt_O_Sn | apply le_max_r ].
+  apply Nat.lt_le_trans with 1%nat; [ apply Nat.lt_0_succ | apply Nat.le_max_r ].
   apply le_IZR; left;
     apply Rlt_trans with (/ eps);
       [ apply Rinv_0_lt_compat; assumption | assumption ].
@@ -173,7 +173,7 @@ Proof.
   apply Rmult_gt_0_lt_compat; try assumption.
   change (0 < / INR (2 * n + 1)); apply Rinv_0_lt_compat;
     apply lt_INR_0.
-  replace (2 * n + 1)%nat with (S (2 * n)); [ apply lt_O_Sn | ring ].
+  replace (2 * n + 1)%nat with (S (2 * n)); [ apply Nat.lt_0_succ | ring ].
   apply Rlt_0_1.
   cut (x < 2 * n + 1)%nat.
   intro; assert (H5 := lt_INR _ _ H4).
@@ -183,23 +183,23 @@ Proof.
   apply lt_INR_0.
   elim H1; intros; assumption.
   apply lt_INR_0; replace (2 * n + 1)%nat with (S (2 * n));
-    [ apply lt_O_Sn | ring ].
+    [ apply Nat.lt_0_succ | ring ].
   assumption.
   elim H1; intros; assumption.
-  apply lt_le_trans with (S n).
-  unfold ge in H2; apply le_lt_n_Sm; assumption.
+  apply Nat.lt_le_trans with (S n).
+  unfold ge in H2; apply Nat.lt_succ_r; assumption.
   replace (2 * n + 1)%nat with (S (2 * n)) by ring.
   apply le_n_S; apply le_n_2n.
   apply Rmult_lt_reg_l with (INR (2 * S n)).
   apply lt_INR_0; replace (2 * S n)%nat with (S (S (2 * n))).
-  apply lt_O_Sn.
+  apply Nat.lt_0_succ.
   replace (S n) with (n + 1)%nat by ring.
   ring.
   rewrite <- Rinv_r_sym.
   rewrite Rmult_1_r.
   apply (lt_INR 1).
   replace (2 * S n)%nat with (S (S (2 * n))).
-  apply lt_n_S; apply lt_O_Sn.
+  apply -> Nat.succ_lt_mono; apply Nat.lt_0_succ.
   ring.
   apply not_O_INR; discriminate.
   apply not_O_INR; discriminate.
@@ -208,7 +208,7 @@ Proof.
   apply Rle_ge; left; apply Rinv_0_lt_compat.
   apply lt_INR_0.
   replace (2 * S n * (2 * n + 1))%nat with (2 + (4 * (n * n) + 6 * n))%nat by ring.
-  apply lt_O_Sn.
+  apply Nat.lt_0_succ.
 Qed.
 
 Lemma cosn_no_R0 : forall n:nat, cos_n n <> 0.
@@ -265,7 +265,7 @@ Proof.
   replace (n + 1)%nat with (S n); [ apply not_O_INR; discriminate | ring ].
   apply not_O_INR; discriminate.
   replace (n + 1)%nat with (S n); [ apply not_O_INR; discriminate | ring ].
-  rewrite mult_plus_distr_l; cut (forall n:nat, S n = (n + 1)%nat).
+  rewrite Nat.mul_add_distr_l; cut (forall n:nat, S n = (n + 1)%nat).
   intros; rewrite (H (2 * n + 1)%nat).
   ring.
   intros; ring.
@@ -296,7 +296,7 @@ Proof.
     apply Rmult_gt_0_lt_compat; try assumption.
   change (0 < / INR (2 * S n + 1)); apply Rinv_0_lt_compat;
     apply lt_INR_0; replace (2 * S n + 1)%nat with (S (2 * S n));
-      [ apply lt_O_Sn | ring ].
+      [ apply Nat.lt_0_succ | ring ].
   apply Rlt_0_1.
   cut (x < 2 * S n + 1)%nat.
   intro; assert (H5 := lt_INR _ _ H4); apply Rlt_trans with (/ INR x).
@@ -304,21 +304,21 @@ Proof.
   apply Rmult_lt_0_compat.
   apply lt_INR_0; elim H1; intros; assumption.
   apply lt_INR_0; replace (2 * S n + 1)%nat with (S (2 * S n));
-    [ apply lt_O_Sn | ring ].
+    [ apply Nat.lt_0_succ | ring ].
   assumption.
   elim H1; intros; assumption.
-  apply lt_le_trans with (S n).
-  unfold ge in H2; apply le_lt_n_Sm; assumption.
+  apply Nat.lt_le_trans with (S n).
+  unfold ge in H2; apply Nat.lt_succ_r; assumption.
   replace (2 * S n + 1)%nat with (S (2 * S n)) by ring.
   apply le_S; apply le_n_2n.
   apply Rmult_lt_reg_l with (INR (2 * S n)).
   apply lt_INR_0; replace (2 * S n)%nat with (S (S (2 * n)));
-    [ apply lt_O_Sn | ring ].
+    [ apply Nat.lt_0_succ | ring ].
   rewrite <- Rinv_r_sym.
   rewrite Rmult_1_r.
   apply (lt_INR 1).
   replace (2 * S n)%nat with (S (S (2 * n))).
-  apply lt_n_S; apply lt_O_Sn.
+  apply -> Nat.succ_lt_mono; apply Nat.lt_0_succ.
   ring.
   apply not_O_INR; discriminate.
   apply not_O_INR; discriminate.
@@ -327,7 +327,7 @@ Proof.
   apply lt_INR_0.
   replace ((2 * S n + 1) * (2 * S n))%nat with
   (6 + (4 * (n * n) + 10 * n))%nat by ring.
-  apply lt_O_Sn.
+  apply Nat.lt_0_succ.
 Qed.
 
 Lemma sin_no_R0 : forall n:nat, sin_n n <> 0.
@@ -395,6 +395,9 @@ Proof.
   rewrite tech5.
   replace (cos_n (S n) * 0 ^ S n) with 0.
   rewrite Rplus_0_r.
-  apply Hrecn; unfold ge; apply le_O_n.
+  apply Hrecn; unfold ge; apply Nat.le_0_l.
   simpl; ring.
 Qed.
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Import Max.

--- a/theories/Reals/Rtrigo_fun.v
+++ b/theories/Reals/Rtrigo_fun.v
@@ -49,7 +49,7 @@ Proof.
         rewrite (let (H1, H2) := Rmult_ne eps in H2); unfold Rgt in H;
           assumption.
     unfold Rgt in H1; apply Rlt_le; assumption.
-    unfold Rgt; apply Rinv_0_lt_compat; apply lt_INR_0; apply lt_O_Sn.
+    unfold Rgt; apply Rinv_0_lt_compat; apply lt_INR_0; apply Nat.lt_0_succ.
   - cut (0 <= up (/ eps - 1))%Z.
     intro; elim (IZN (up (/ eps - 1)) H0); intros; split with x; intros;
       rewrite (simpl_fact n); unfold R_dist;
@@ -81,7 +81,7 @@ Proof.
     elim (archimed (/ eps - 1)); intros; clear H6; unfold Rgt in H5;
       rewrite H4 in H5; rewrite INR_IZR_INZ; assumption.
     unfold Rgt in H1; apply Rlt_le; assumption.
-    unfold Rgt; apply Rinv_0_lt_compat; apply lt_INR_0; apply lt_O_Sn.
+    unfold Rgt; apply Rinv_0_lt_compat; apply lt_INR_0; apply Nat.lt_0_succ.
     apply (le_O_IZR (up (/ eps - 1)));
       apply (Rle_trans 0 (/ eps - 1) (IZR (up (/ eps - 1)))).
     generalize (Rnot_gt_le eps 1 Hnotgt); clear Hnotgt; unfold Rle; intro; elim H0;

--- a/theories/Reals/Rtrigo_reg.v
+++ b/theories/Reals/Rtrigo_reg.v
@@ -211,7 +211,7 @@ Proof.
       apply Rplus_eq_compat_l.
   symmetry ; apply sum_eq_R0; intros.
   rewrite Rmult_0_l; rewrite Rmult_0_r; reflexivity.
-  unfold ge in H10; apply lt_le_trans with 1%nat; [ apply lt_n_Sn | apply H10 ].
+  unfold ge in H10; apply Nat.lt_le_trans with 1%nat; [ apply Nat.lt_succ_diag_r | apply H10 ].
   apply H5.
   split.
   unfold D_x, no_cond; split.

--- a/theories/Reals/Runcountable.v
+++ b/theories/Reals/Runcountable.v
@@ -103,7 +103,7 @@ Proof.
   destruct pen as [uv _]. intros x H H0 H1 x_uc.
   assert (ihi : in_holed_interval a b h u (v x)).
   { split. rewrite -> uv. assumption. rewrite -> uv. split; assumption. }
-  destruct (le_lt_or_eq _ _ (beyond (v x) ihi)) as [lcvx | ecvx].
+  destruct (proj1 (Nat.lt_eq_cases _ _) (beyond (v x) ihi)) as [lcvx | ecvx].
   - exact lcvx.
   - exfalso. apply x_uc. rewrite ecvx. rewrite -> uv. reflexivity.
 Qed.
@@ -199,8 +199,8 @@ Lemma split_lt_succ : forall n m : nat, lt n (S m) -> lt n m \/ n = m.
 Proof.
   intros n m. generalize dependent n. induction m.
   - intros. destruct n. right. reflexivity. exfalso. inversion H. inversion H1.
-  - intros. destruct n. left. unfold lt. apply le_n_S. apply le_0_n.
-    apply lt_pred in H. simpl in H. specialize (IHm n H). destruct IHm. left. apply lt_n_S. assumption.
+  - intros. destruct n. left. unfold lt. apply -> Nat.succ_le_mono; apply Nat.le_0_l.
+    apply Nat.lt_succ_lt_pred in H. simpl in H. specialize (IHm n H). destruct IHm. left. apply -> Nat.succ_lt_mono. assumption.
     subst. right. reflexivity.
 Qed.
 
@@ -379,21 +379,21 @@ Proof.
   intros u [v [H3 H4]]. pose proof (conj H4 H3) as H.
   assert (forall n : nat, n + v (fst (proj1_sig (tearing_sequences u v H 1)))
                    <= v (fst (proj1_sig (tearing_sequences u v H (S n))))).
-  { induction n. simpl. apply le_refl.
-    apply (le_trans (S n + v (fst (proj1_sig (tearing_sequences u v H 1))))
+  { induction n. simpl. apply Nat.le_refl.
+    apply (Nat.le_trans (S n + v (fst (proj1_sig (tearing_sequences u v H 1))))
                     (S (v (fst (proj1_sig (tearing_sequences u v H (S n))))))).
-    simpl. apply le_n_S. assumption. apply first_indices_increasing.
+    simpl. apply -> Nat.succ_le_mono. assumption. apply first_indices_increasing.
     intro H1. discriminate. }
   assert (v (proj1_sig (torn_number u v H)) + v (fst (proj1_sig (tearing_sequences u v H 1)))
           < v (proj1_sig (torn_number u v H))).
   { pose proof (limit_index_above_all_indices u v H (v (proj1_sig (torn_number u v H)))).
     specialize (H0 (v (proj1_sig (torn_number u v H)))).
-    apply (le_lt_trans (v (proj1_sig (torn_number u v H))
+    apply (Nat.le_lt_trans (v (proj1_sig (torn_number u v H))
                         + v (fst (proj1_sig (tearing_sequences u v H 1))))
                        (v (fst (proj1_sig (tearing_sequences u v H (S (v (proj1_sig (torn_number u v H))))))))).
     assumption. assumption. }
   assert (forall n m : nat, ~(n + m < n)).
   { induction n. intros. intro H2. inversion H2. intro m. intro H2. simpl in H2.
-    apply lt_pred in H2. simpl in H2. apply IHn in H2. contradiction. }
+    apply Nat.lt_succ_lt_pred in H2. simpl in H2. apply IHn in H2. contradiction. }
   apply H2 in H1. contradiction.
 Qed.

--- a/theories/Reals/SeqProp.v
+++ b/theories/Reals/SeqProp.v
@@ -11,7 +11,6 @@
 Require Import Rbase.
 Require Import Rfunctions.
 Require Import Rseries.
-Require Import Max.
 Require Import Lia.
 Local Open Scope R_scope.
 
@@ -535,7 +534,7 @@ Proof.
   rewrite <- VUI.
   rewrite Rabs_minus_sym.
   apply Hn.
-  apply le_refl.
+  apply Nat.le_refl.
 
   apply Rle_antisym.
   apply Hl.
@@ -600,8 +599,8 @@ Proof.
   [ apply Rabs_triang | ring ].
   rewrite (double_var eps); apply Rplus_lt_compat.
   rewrite <- Rabs_Ropp; rewrite Ropp_minus_distr; apply H3;
-    unfold ge, N; apply le_max_l.
-  apply H4; unfold ge, N; apply le_max_r.
+    unfold ge, N; apply Nat.le_max_l.
+  apply H4; unfold ge, N; apply Nat.le_max_r.
 Qed.
 
 (**********)
@@ -623,10 +622,10 @@ Proof.
   apply Rle_lt_trans with (Rabs (An n - l1) + Rabs (Bn n - l2)).
   apply Rabs_triang.
   rewrite (double_var eps); apply Rplus_lt_compat.
-  apply H3; unfold ge; apply le_trans with N;
-    [ unfold N; apply le_max_l | assumption ].
-  apply H4; unfold ge; apply le_trans with N;
-    [ unfold N; apply le_max_r | assumption ].
+  apply H3; unfold ge; apply Nat.le_trans with N;
+    [ unfold N; apply Nat.le_max_l | assumption ].
+  apply H4; unfold ge; apply Nat.le_trans with N;
+    [ unfold N; apply Nat.le_max_r | assumption ].
 Qed.
 
 (**********)
@@ -781,8 +780,8 @@ Proof.
   rewrite Rmult_1_l; rewrite (Rmult_comm (/ M)).
   apply Rlt_le_trans with (eps / (2 * M)).
   apply H10.
-  unfold ge; apply le_trans with N.
-  unfold N; apply le_max_r.
+  unfold ge; apply Nat.le_trans with N.
+  unfold N; apply Nat.le_max_r.
   assumption.
   unfold Rdiv; rewrite Rinv_mult_distr.
   right; ring.
@@ -794,8 +793,8 @@ Proof.
   rewrite <- Rmult_assoc; rewrite <- Rinv_l_sym.
   rewrite Rmult_1_l; apply Rlt_le_trans with (eps / (2 * Rabs l2)).
   apply H9.
-  unfold ge; apply le_trans with N.
-  unfold N; apply le_max_l.
+  unfold ge; apply Nat.le_trans with N.
+  unfold N; apply Nat.le_max_l.
   assumption.
   unfold Rdiv; right; rewrite Rinv_mult_distr.
   ring.
@@ -825,7 +824,7 @@ Proof.
   induction  n as [| n Hrecn].
   induction  m as [| m Hrecm].
   right; reflexivity.
-  elim (le_Sn_O _ H0).
+  elim (Nat.nle_succ_0 _ H0).
   cut ((m <= n)%nat \/ m = S n).
   intro; elim H1; intro.
   apply Rle_trans with (Un n).
@@ -900,12 +899,12 @@ Proof.
   apply Rle_lt_trans with (Rabs (Un N - l)).
   apply RRle_abs.
   apply H2.
-  unfold ge, N; apply le_max_r.
+  unfold ge, N; apply Nat.le_max_r.
   unfold Rminus; do 2 rewrite <- (Rplus_comm (- l));
     apply Rplus_le_compat_l.
   apply tech9.
   assumption.
-  unfold N; apply le_max_l.
+  unfold N; apply Nat.le_max_l.
   apply Rplus_lt_reg_l with l.
   rewrite Rplus_0_r.
   replace (l + (Un n - l)) with (Un n); [ assumption | ring ].
@@ -987,7 +986,7 @@ Proof.
   induction  n as [| n Hrecn].
   induction  m as [| m Hrecm].
   right; reflexivity.
-  elim (le_Sn_O _ H0).
+  elim (Nat.nle_succ_0 _ H0).
   cut ((m <= n)%nat \/ m = S n).
   intro; elim H1; intro.
   apply Rle_trans with (Un n).
@@ -1012,7 +1011,7 @@ Proof.
   rewrite H1; unfold Rminus; rewrite Ropp_0; rewrite Rplus_0_r;
     rewrite Rabs_R0; rewrite pow_ne_zero;
       [ unfold Rdiv; rewrite Rmult_0_l; rewrite Rabs_R0; assumption
-        | red; intro; rewrite H3 in H2; elim (le_Sn_n _ H2) ].
+        | red; intro; rewrite H3 in H2; elim (Nat.nle_succ_diag_l _ H2) ].
   assert (H2 := Rabs_pos_lt x H1); set (M := up (Rabs x)); cut (0 <= M)%Z.
   intro; elim (IZN M H3); intros M_nat H4.
   set (Un := fun n:nat => Rabs x ^ (M_nat + n) / INR (fact (M_nat + n))).
@@ -1024,14 +1023,14 @@ Proof.
   elim H9; intros; rewrite H11; unfold Un in H6; apply H6; assumption.
   exists (n - M_nat)%nat.
   split.
-  unfold ge; apply (fun p n m:nat => plus_le_reg_l n m p) with M_nat;
-    rewrite <- le_plus_minus.
+  unfold ge; apply (fun p n m:nat => Nat.add_le_mono_l n m p) with M_nat;
+    rewrite (Nat.add_comm _ (n - M_nat)), Nat.sub_add.
   assumption.
-  apply le_trans with (M_nat + N)%nat.
-  apply le_plus_l.
+  apply Nat.le_trans with (M_nat + N)%nat.
+  apply Nat.le_add_r.
   assumption.
-  apply le_plus_minus; apply le_trans with (M_nat + N)%nat;
-    [ apply le_plus_l | assumption ].
+  rewrite Nat.add_comm, Nat.sub_add; [reflexivity | ];
+    apply Nat.le_trans with (M_nat + N)%nat; [ apply Nat.le_add_r | assumption ].
   set (Vn := fun n:nat => Rabs x * (Un 0%nat / INR (S n))).
   cut (1 <= M_nat)%nat.
   intro; cut (forall n:nat, 0 < Un n).
@@ -1095,8 +1094,8 @@ Proof.
   unfold cv_infty; intro;
     destruct (total_order_T M0 0) as [[Hlt|Heq]|Hgt].
   exists 0%nat; intros.
-  apply Rlt_trans with 0; [ assumption | apply lt_INR_0; apply lt_O_Sn ].
-  exists 0%nat; intros; rewrite Heq; apply lt_INR_0; apply lt_O_Sn.
+  apply Rlt_trans with 0; [ assumption | apply lt_INR_0; apply Nat.lt_0_succ ].
+  exists 0%nat; intros; rewrite Heq; apply lt_INR_0; apply Nat.lt_0_succ.
   set (M0_z := up M0).
   assert (H10 := archimed M0).
   cut (0 <= M0_z)%Z.
@@ -1105,7 +1104,7 @@ Proof.
   apply Rlt_le_trans with (IZR M0_z).
   elim H10; intros; assumption.
   rewrite H12; rewrite <- INR_IZR_INZ; apply le_INR.
-  apply le_trans with n; [ assumption | apply le_n_Sn ].
+  apply Nat.le_trans with n; [ assumption | apply Nat.le_succ_diag_r ].
   apply le_IZR; left; simpl; unfold M0_z;
     apply Rlt_trans with M0; [ assumption | elim H10; intros; assumption ].
   intro; apply Rle_trans with (Rabs x * Un n * / INR (S n)).
@@ -1117,17 +1116,17 @@ Proof.
   apply Rabs_pos.
   left; apply pow_lt; assumption.
   replace (M_nat + n + 1)%nat with (S (M_nat + n)).
-  rewrite fact_simpl; rewrite mult_comm; rewrite mult_INR;
+  rewrite fact_simpl; rewrite Nat.mul_comm; rewrite mult_INR;
     rewrite Rinv_mult_distr.
   apply Rmult_le_compat_l.
-  left; apply Rinv_0_lt_compat; apply lt_INR_0; apply neq_O_lt; red;
-    intro; assert (H10 := eq_sym H9); elim (fact_neq_0 _ H10).
+  left; apply Rinv_0_lt_compat; apply lt_INR_0; apply -> Nat.neq_0_lt_0; red;
+    intro; elim (fact_neq_0 _ H9).
   left; apply Rinv_lt_contravar.
-  apply Rmult_lt_0_compat; apply lt_INR_0; apply lt_O_Sn.
-  apply lt_INR; apply lt_n_S.
+  apply Rmult_lt_0_compat; apply lt_INR_0; apply Nat.lt_0_succ.
+  apply lt_INR; apply -> Nat.succ_lt_mono.
   pattern n at 1; replace n with (0 + n)%nat; [ idtac | reflexivity ].
-  apply plus_lt_compat_r.
-  apply lt_le_trans with 1%nat; [ apply lt_O_Sn | assumption ].
+  apply Nat.add_lt_mono_r.
+  apply Nat.lt_le_trans with 1%nat; [ apply Nat.lt_0_succ | assumption ].
   apply INR_fact_neq_0.
   apply not_O_INR; discriminate.
   ring.
@@ -1136,8 +1135,8 @@ Proof.
     rewrite (Rmult_comm (Un 0%nat)); rewrite (Rmult_comm (Un n)).
   repeat apply Rmult_le_compat_l.
   apply Rabs_pos.
-  left; apply Rinv_0_lt_compat; apply lt_INR_0; apply lt_O_Sn.
-  apply decreasing_prop; [ assumption | apply le_O_n ].
+  left; apply Rinv_0_lt_compat; apply lt_INR_0; apply Nat.lt_0_succ.
+  apply decreasing_prop; [ assumption | apply Nat.le_0_l ].
   unfold Un_decreasing; intro; unfold Un.
   replace (M_nat + S n)%nat with (M_nat + n + 1)%nat.
   rewrite pow_add; unfold Rdiv; rewrite Rmult_assoc;
@@ -1146,8 +1145,8 @@ Proof.
   replace (Rabs x ^ 1) with (Rabs x); [ idtac | simpl; ring ].
   replace (M_nat + n + 1)%nat with (S (M_nat + n)).
   apply Rmult_le_reg_l with (INR (fact (S (M_nat + n)))).
-  apply lt_INR_0; apply neq_O_lt; red; intro; assert (H9 := eq_sym H8);
-    elim (fact_neq_0 _ H9).
+  apply lt_INR_0; apply Nat.neq_0_lt_0; red; intro;
+    elim (fact_neq_0 _ H8).
   rewrite (Rmult_comm (Rabs x)); rewrite <- Rmult_assoc; rewrite <- Rinv_r_sym.
   rewrite Rmult_1_l.
   rewrite fact_simpl; rewrite mult_INR; rewrite Rmult_assoc;
@@ -1162,15 +1161,14 @@ Proof.
   ring.
   intro; unfold Un; unfold Rdiv; apply Rmult_lt_0_compat.
   apply pow_lt; assumption.
-  apply Rinv_0_lt_compat; apply lt_INR_0; apply neq_O_lt; red; intro;
-    assert (H8 := eq_sym H7); elim (fact_neq_0 _ H8).
+  apply Rinv_0_lt_compat; apply lt_INR_0; apply Nat.neq_0_lt_0; red; intro;
+    elim (fact_neq_0 _ H7).
   clear Un Vn; apply INR_le; simpl.
   induction  M_nat as [| M_nat HrecM_nat].
   assert (H6 := archimed (Rabs x)); fold M in H6; elim H6; intros.
   rewrite H4 in H7; rewrite <- INR_IZR_INZ in H7.
   simpl in H7; elim (Rlt_irrefl _ (Rlt_trans _ _ _ H2 H7)).
-  apply (le_INR 1); apply le_n_S;
-    apply le_O_n.
+  apply (le_INR 1); apply le_n_S; apply Nat.le_0_l.
   apply le_IZR; simpl; left; apply Rlt_trans with (Rabs x).
   assumption.
   elim (archimed (Rabs x)); intros; assumption.
@@ -1181,8 +1179,8 @@ Proof.
     rewrite (Rabs_right (Rabs x ^ n / INR (fact n))).
   unfold Rdiv; rewrite Rabs_mult; rewrite (Rabs_right (/ INR (fact n))).
   rewrite RPow_abs; right; reflexivity.
-  apply Rle_ge; left; apply Rinv_0_lt_compat; apply lt_INR_0; apply neq_O_lt;
-    red; intro; assert (H4 := eq_sym H3); elim (fact_neq_0 _ H4).
+  apply Rle_ge; left; apply Rinv_0_lt_compat; apply lt_INR_0; apply Nat.neq_0_lt_0;
+    red; intro; elim (fact_neq_0 _ H3).
   apply Rle_ge; unfold Rdiv; apply Rmult_le_pos.
   case (Req_dec x 0); intro.
   rewrite H3; rewrite Rabs_R0.
@@ -1190,7 +1188,10 @@ Proof.
     [ simpl; left; apply Rlt_0_1
       | simpl; rewrite Rmult_0_l; right; reflexivity ].
   left; apply pow_lt; apply Rabs_pos_lt; assumption.
-  left; apply Rinv_0_lt_compat; apply lt_INR_0; apply neq_O_lt; red;
-    intro; assert (H4 := eq_sym H3); elim (fact_neq_0 _ H4).
+  left; apply Rinv_0_lt_compat; apply lt_INR_0; apply Nat.neq_0_lt_0; red;
+    intro; elim (fact_neq_0 _ H3).
   apply H1; assumption.
 Qed.
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Import Max.

--- a/theories/Reals/SeqSeries.v
+++ b/theories/Reals/SeqSeries.v
@@ -10,7 +10,6 @@
 
 Require Import Rbase.
 Require Import Rfunctions.
-Require Import Max.
 Require Export Rseries.
 Require Export SeqProp.
 Require Export Rcomplete.
@@ -57,16 +56,16 @@ Proof.
       [ idtac | ring ].
   replace (sum_f_R0 An N + sum_f_R0 (fun l:nat => An (S N + l)%nat) n) with
   (sum_f_R0 An (S (N + n))).
-  apply H6; unfold ge; apply le_trans with n.
+  apply H6; unfold ge; apply Nat.le_trans with n.
   apply H7.
-  apply le_trans with (N + n)%nat.
-  apply le_plus_r.
-  apply le_n_Sn.
+  apply Nat.le_trans with (N + n)%nat.
+  rewrite Nat.add_comm; apply Nat.le_add_r.
+  apply Nat.le_succ_diag_r.
   cut (0 <= N)%nat.
   cut (N < S (N + n))%nat.
   intros; assert (H10 := sigma_split An H9 H8).
   unfold sigma in H10.
-  do 2 rewrite <- minus_n_O in H10.
+  do 2 rewrite Nat.sub_0_r in H10.
   replace (sum_f_R0 An (S (N + n))) with
   (sum_f_R0 (fun k:nat => An (0 + k)%nat) (S (N + n))).
   replace (sum_f_R0 An N) with (sum_f_R0 (fun k:nat => An (0 + k)%nat) N).
@@ -75,13 +74,13 @@ Proof.
   apply H10.
   apply INR_eq; rewrite minus_INR.
   do 2 rewrite S_INR; rewrite plus_INR; ring.
-  apply le_n_S; apply le_plus_l.
+  apply le_n_S; apply Nat.le_add_r.
   apply sum_eq; intros.
   reflexivity.
   apply sum_eq; intros.
   reflexivity.
-  apply le_lt_n_Sm; apply le_plus_l.
-  apply le_O_n.
+  apply Nat.lt_succ_r; apply Nat.le_add_r.
+  apply Nat.le_0_l.
   symmetry ; eapply UL_sequence.
   apply H2.
   unfold Un_cv in H; unfold Un_cv; intros.
@@ -98,16 +97,16 @@ Proof.
   (sum_f_R0 (fun k:nat => fn k x) N +
     sum_f_R0 (fun l:nat => fn (S N + l)%nat x) n) with
   (sum_f_R0 (fun k:nat => fn k x) (S (N + n))).
-  unfold SP in H5; apply H5; unfold ge; apply le_trans with n.
+  unfold SP in H5; apply H5; unfold ge; apply Nat.le_trans with n.
   apply H6.
-  apply le_trans with (N + n)%nat.
-  apply le_plus_r.
-  apply le_n_Sn.
+  apply Nat.le_trans with (N + n)%nat.
+  rewrite Nat.add_comm; apply Nat.le_add_r.
+  apply Nat.le_succ_diag_r.
   cut (0 <= N)%nat.
   cut (N < S (N + n))%nat.
   intros; assert (H9 := sigma_split (fun k:nat => fn k x) H8 H7).
   unfold sigma in H9.
-  do 2 rewrite <- minus_n_O in H9.
+  do 2 rewrite Nat.sub_0_r in H9.
   replace (sum_f_R0 (fun k:nat => fn k x) (S (N + n))) with
   (sum_f_R0 (fun k:nat => fn (0 + k)%nat x) (S (N + n))).
   replace (sum_f_R0 (fun k:nat => fn k x) N) with
@@ -117,14 +116,14 @@ Proof.
   apply H9.
   apply INR_eq; rewrite minus_INR.
   do 2 rewrite S_INR; rewrite plus_INR; ring.
-  apply le_n_S; apply le_plus_l.
+  apply le_n_S; apply Nat.le_add_r.
   apply sum_eq; intros.
   reflexivity.
   apply sum_eq; intros.
   reflexivity.
-  apply le_lt_n_Sm.
-  apply le_plus_l.
-  apply le_O_n.
+  apply Nat.lt_succ_r.
+  apply Nat.le_add_r.
+  apply Nat.le_0_l.
   exists (l2 - sum_f_R0 An N).
   unfold Un_cv in H0; unfold Un_cv; intros.
   elim (H0 eps H2); intros N0 H3.
@@ -135,16 +134,16 @@ Proof.
       [ idtac | ring ].
   replace (sum_f_R0 An N + sum_f_R0 (fun l:nat => An (S N + l)%nat) n) with
   (sum_f_R0 An (S (N + n))).
-  apply H3; unfold ge; apply le_trans with n.
+  apply H3; unfold ge; apply Nat.le_trans with n.
   apply H4.
-  apply le_trans with (N + n)%nat.
-  apply le_plus_r.
-  apply le_n_Sn.
+  apply Nat.le_trans with (N + n)%nat.
+  rewrite Nat.add_comm; apply Nat.le_add_r.
+  apply Nat.le_succ_diag_r.
   cut (0 <= N)%nat.
   cut (N < S (N + n))%nat.
   intros; assert (H7 := sigma_split An H6 H5).
   unfold sigma in H7.
-  do 2 rewrite <- minus_n_O in H7.
+  do 2 rewrite Nat.sub_0_r in H7.
   replace (sum_f_R0 An (S (N + n))) with
   (sum_f_R0 (fun k:nat => An (0 + k)%nat) (S (N + n))).
   replace (sum_f_R0 An N) with (sum_f_R0 (fun k:nat => An (0 + k)%nat) N).
@@ -153,14 +152,14 @@ Proof.
   apply H7.
   apply INR_eq; rewrite minus_INR.
   do 2 rewrite S_INR; rewrite plus_INR; ring.
-  apply le_n_S; apply le_plus_l.
+  apply -> Nat.succ_le_mono; apply Nat.le_add_r.
   apply sum_eq; intros.
   reflexivity.
   apply sum_eq; intros.
   reflexivity.
-  apply le_lt_n_Sm.
-  apply le_plus_l.
-  apply le_O_n.
+  apply Nat.lt_succ_r.
+  apply Nat.le_add_r.
+  apply Nat.le_0_l.
   exists (l1 - SP fn N x).
   unfold Un_cv in H; unfold Un_cv; intros.
   elim (H eps H2); intros N0 H3.
@@ -177,16 +176,16 @@ Proof.
     sum_f_R0 (fun l:nat => fn (S N + l)%nat x) n) with
   (sum_f_R0 (fun k:nat => fn k x) (S (N + n))).
   unfold SP in H3; apply H3.
-  unfold ge; apply le_trans with n.
+  unfold ge; apply Nat.le_trans with n.
   apply H4.
-  apply le_trans with (N + n)%nat.
-  apply le_plus_r.
-  apply le_n_Sn.
+  apply Nat.le_trans with (N + n)%nat.
+  rewrite Nat.add_comm; apply Nat.le_add_r.
+  apply Nat.le_succ_diag_r.
   cut (0 <= N)%nat.
   cut (N < S (N + n))%nat.
   intros; assert (H7 := sigma_split (fun k:nat => fn k x) H6 H5).
   unfold sigma in H7.
-  do 2 rewrite <- minus_n_O in H7.
+  do 2 rewrite Nat.sub_0_r in H7.
   replace (sum_f_R0 (fun k:nat => fn k x) (S (N + n))) with
   (sum_f_R0 (fun k:nat => fn (0 + k)%nat x) (S (N + n))).
   replace (sum_f_R0 (fun k:nat => fn k x) N) with
@@ -196,14 +195,14 @@ Proof.
   apply H7.
   apply INR_eq; rewrite minus_INR.
   do 2 rewrite S_INR; rewrite plus_INR; ring.
-  apply le_n_S; apply le_plus_l.
+  apply -> Nat.succ_le_mono; apply Nat.le_add_r.
   apply sum_eq; intros.
   reflexivity.
   apply sum_eq; intros.
   reflexivity.
-  apply le_lt_n_Sm.
-  apply le_plus_l.
-  apply le_O_n.
+  apply Nat.lt_succ_r.
+  apply Nat.le_add_r.
+  apply Nat.le_0_l.
 Qed.
 
 (** Comparaison of convergence for series *)
@@ -308,8 +307,8 @@ Proof with trivial.
       replace (sum_f_R0 (fun k:nat => An k * Bn k) n / sum_f_R0 An n - l) with
       (sum_f_R0 (fun k:nat => An k * (Bn k - l)) n / sum_f_R0 An n)...
   assert (H9 : (N1 < n)%nat)...
-  apply lt_le_trans with (S N)...
-  apply le_lt_n_Sm; unfold N; apply le_max_l...
+  apply Nat.lt_le_trans with (S N)...
+  apply Nat.lt_succ_r; unfold N; apply Nat.le_max_l...
   rewrite (tech2 (fun k:nat => An k * (Bn k - l)) _ _ H9); unfold Rdiv;
     rewrite Rmult_plus_distr_r;
       apply Rle_lt_trans with
@@ -320,8 +319,8 @@ Proof with trivial.
   apply Rabs_triang...
   rewrite (double_var eps); apply Rplus_lt_compat...
   unfold Rdiv; rewrite Rabs_mult; fold C; rewrite Rabs_right...
-  apply (H7 n); apply le_trans with (S N)...
-  apply le_trans with N; [ unfold N; apply le_max_r | apply le_n_Sn ]...
+  apply (H7 n); apply Nat.le_trans with (S N)...
+  apply Nat.le_trans with N; [ unfold N; apply Nat.le_max_r | apply Nat.le_succ_diag_r ]...
   apply Rle_ge; left; apply Rinv_0_lt_compat...
 
   unfold R_dist in H; unfold Rdiv; rewrite Rabs_mult;
@@ -344,8 +343,8 @@ Proof with trivial.
       rewrite <- (Rabs_right (An (S N1 + n0)%nat))...
   apply Rmult_le_compat_l...
   apply Rabs_pos...
-  left; apply H; unfold ge; apply le_trans with (S N1);
-    [ apply le_n_Sn | apply le_plus_l ]...
+  left; apply H; unfold ge; apply Nat.le_trans with (S N1);
+    [ apply Nat.le_succ_diag_r | apply Nat.le_add_r ]...
   apply Rle_ge; left...
   rewrite <- (scal_sum (fun i:nat => An (S N1 + i)%nat) (n - S N1) (eps / 2));
     unfold Rdiv; repeat rewrite Rmult_assoc; apply Rmult_lt_compat_l...
@@ -386,7 +385,7 @@ Proof with trivial.
     rewrite Rmult_1_l; apply Rlt_trans with (IZR (up M))...
   apply Rle_lt_trans with (INR x)...
   rewrite INR_IZR_INZ; fold m; rewrite <- H6; right...
-  apply lt_INR; apply le_lt_n_Sm...
+  apply lt_INR; apply Nat.lt_succ_r...
   assert (H3 := Cesaro _ _ _ H H0 H2)...
   unfold Un_cv; unfold Un_cv in H3; intros; elim (H3 _ H4); intros;
     exists (S x); intros; unfold R_dist; unfold R_dist in H5;
@@ -402,10 +401,13 @@ Proof with trivial.
     replace (sum_f_R0 (fun k:nat => 1 * Bn k) (pred n)) with
     (sum_f_R0 Bn (pred n))...
   rewrite sum_cte; rewrite Rmult_1_l; replace (S (pred n)) with n...
-  apply S_pred with 0%nat; apply lt_le_trans with (S x)...
-  apply lt_O_Sn...
+  symmetry; apply Nat.lt_succ_pred with 0%nat; apply Nat.lt_le_trans with (S x)...
+  apply Nat.lt_0_succ...
   apply sum_eq; intros; ring...
   apply H5; unfold ge; apply le_S_n; replace (S (pred n)) with n...
-  apply S_pred with 0%nat; apply lt_le_trans with (S x)...
-  apply lt_O_Sn...
+  symmetry; apply Nat.lt_succ_pred with 0%nat; apply Nat.lt_le_trans with (S x)...
+  apply Nat.lt_0_succ...
 Qed.
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Import Max.

--- a/theories/Sets/Finite_sets_facts.v
+++ b/theories/Sets/Finite_sets_facts.v
@@ -33,8 +33,7 @@ Require Export Classical_sets.
 Require Export Powerset.
 Require Export Powerset_facts.
 Require Export Powerset_Classical_facts.
-Require Export Gt.
-Require Export Lt.
+Require Export PeanoNat.
 
 Section Finite_sets_facts.
   Variable U : Type.
@@ -110,11 +109,8 @@ Section Finite_sets_facts.
   Proof.
     induction 1 as [x H'].
     intros n H'0.
-    elim (gt_O_eq n); auto with sets.
-    intro H'1; generalize H'; generalize H'0.
-    rewrite <- H'1; intro H'2.
-    rewrite (cardinalO_empty X); auto with sets.
-    intro H'3; elim H'3.
+    destruct n; [ exfalso | apply Nat.lt_0_succ ].
+    rewrite (cardinalO_empty X) in H'; [ elim H' | assumption ].
   Qed.
 
   Lemma card_soustr_1 :
@@ -139,9 +135,8 @@ Section Finite_sets_facts.
     red; intro H'6; elim H'6.
     intros H'7 H'8; try assumption.
     elim H'1; auto with sets.
-    unfold pred at 2; symmetry .
-    apply S_pred with (m := 0).
-    change (n > 0).
+    unfold pred at 2.
+    apply (Nat.lt_succ_pred 0).
     apply inh_card_gt_O with (X := X); auto with sets.
     apply Inhabited_intro with (x := x0); auto with sets.
     red; intro H'3.
@@ -237,47 +232,47 @@ Section Finite_sets_facts.
 	cardinal U Y c2 -> Strict_Included U X Y -> c2 > c1.
   Proof.
     intros X c1 H'; elim H'.
-    intros Y c2 H'0; elim H'0; auto with sets arith.
+    intros Y c2 H'0; elim H'0; [ | intros; apply Nat.lt_0_succ ].
     intro H'1.
-    elim (Strict_Included_strict U (Empty_set U)); auto with sets arith.
+    elim (Strict_Included_strict U (Empty_set U)); auto.
     clear H' c1 X.
     intros X n H' H'0 x H'1 Y c2 H'2.
     elim H'2.
-    intro H'3; elim (not_SIncl_empty U (Add U X x)); auto with sets arith.
+    intro H'3; elim (not_SIncl_empty U (Add U X x)); assumption.
     clear H'2 c2 Y.
     intros X0 c2 H'2 H'3 x0 H'4 H'5; elim (classic (In U X0 x)).
-    intro H'6; apply gt_n_S.
+    intro H'6; apply -> Nat.succ_lt_mono.
     apply H'0 with (Y := Subtract U (Add U X0 x0) x).
-    elimtype (pred (S c2) = c2); auto with sets arith.
-    apply card_soustr_1; auto with sets arith.
-    apply incl_st_add_soustr; auto with sets arith.
+    elimtype (pred (S c2) = c2); [ | reflexivity ].
+    apply card_soustr_1; auto with sets.
+    apply incl_st_add_soustr; assumption.
     elim (classic (x = x0)).
-    intros H'6 H'7; apply gt_n_S.
-    apply H'0 with (Y := X0); auto with sets arith.
+    intros H'6 H'7; apply -> Nat.succ_lt_mono.
+    apply H'0 with (Y := X0); [ assumption | ].
     apply sincl_add_x with (x := x0).
-    rewrite <- H'6; auto with sets arith.
-    pattern x0 at 1; rewrite <- H'6; trivial with sets arith.
+    rewrite <- H'6; assumption.
+    pattern x0 at 1; rewrite <- H'6; trivial.
     intros H'6 H'7; red in H'5.
     elim H'5; intros H'8 H'9; try exact H'8; clear H'5.
     red in H'8.
     generalize (H'8 x).
-    intro H'5; lapply H'5; auto with sets arith.
-    intro H; elim Add_inv with U X0 x0 x; auto with sets arith.
-    intro; absurd (In U X0 x); auto with sets arith.
-    intro; absurd (x = x0); auto with sets arith.
+    intro H'5; lapply H'5; auto with sets.
+    intro H; elim Add_inv with U X0 x0 x; [ | | assumption ].
+    intro; absurd (In U X0 x); assumption.
+    intro; absurd (x = x0); [ assumption | subst x0; reflexivity ].
   Qed.
 
   Lemma incl_card_le :
     forall (X Y:Ensemble U) (n m:nat),
       cardinal U X n -> cardinal U Y m -> Included U X Y -> n <= m.
   Proof.
-    intros; elim Included_Strict_Included with U X Y; auto with sets arith; intro.
-    cut (m > n); auto with sets arith.
-    apply incl_st_card_lt with (X := X) (Y := Y); auto with sets arith.
+    intros; elim Included_Strict_Included with U X Y; [ | | assumption ]; intro.
+    cut (m > n); [ apply Nat.lt_le_incl | ].
+    apply incl_st_card_lt with (X := X) (Y := Y); assumption.
     generalize H0; rewrite <- H2; intro.
     cut (n = m).
-    intro E; rewrite E; auto with sets arith.
-    apply cardinal_unicity with X; auto with sets arith.
+    intro E; rewrite E; auto with sets.
+    apply cardinal_unicity with X; assumption.
   Qed.
 
   Lemma G_aux :
@@ -342,3 +337,6 @@ Section Finite_sets_facts.
   Qed.
 
 End Finite_sets_facts.
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Export Gt Lt.

--- a/theories/Sets/Image.v
+++ b/theories/Sets/Image.v
@@ -33,9 +33,6 @@ Require Export Classical_sets.
 Require Export Powerset.
 Require Export Powerset_facts.
 Require Export Powerset_Classical_facts.
-Require Export Gt.
-Require Export Lt.
-Require Export Le.
 Require Export Finite_sets_facts.
 
 Section Image.
@@ -172,9 +169,9 @@ Section Image.
     rewrite (Im_add A x f).
     elim cardinal_Im_intro with A f n; trivial with sets.
     intros p C H'3.
-    apply le_trans with (S p).
+    apply Nat.le_trans with (S p).
     apply card_Add_gen with V (Im A f) (f x); trivial with sets.
-    apply le_n_S; auto with sets.
+    apply -> Nat.succ_le_mono; auto with sets.
   Qed.
 
   Theorem Pigeonhole :
@@ -184,7 +181,7 @@ Section Image.
   Proof.
     unfold not; intros A f n CAn n' CIfn' ltn'n I.
     cut (n' = n).
-    intro E; generalize ltn'n; rewrite E; exact (lt_irrefl n).
+    intro E; generalize ltn'n; rewrite E; exact (Nat.lt_irrefl n).
     apply injective_preserves_cardinal with (A := A) (f := f) (n := n);
       trivial with sets.
   Qed.
@@ -204,3 +201,6 @@ End Image.
 
 #[global]
 Hint Resolve Im_def image_empty finite_image: sets.
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Export Gt Lt Le.

--- a/theories/Sets/Infinite_sets.v
+++ b/theories/Sets/Infinite_sets.v
@@ -33,9 +33,6 @@ Require Export Classical_sets.
 Require Export Powerset.
 Require Export Powerset_facts.
 Require Export Powerset_Classical_facts.
-Require Export Gt.
-Require Export Lt.
-Require Export Le.
 Require Export Finite_sets_facts.
 Require Export Image.
 
@@ -225,7 +222,7 @@ Section Infinite_sets.
     rewrite (Non_disjoint_union V (Im U V x f) (f x0)); auto with sets.
     rewrite H'4; auto with sets.
     elim (Extension V (Im U V x f) (Im U V A f)); auto with sets.
-    apply le_lt_n_Sm.
+    apply Nat.lt_succ_r.
     apply cardinal_decreases with (U := U) (V := V) (A := x) (f := f);
       auto with sets.
     rewrite H'4; auto with sets.
@@ -243,3 +240,6 @@ Section Infinite_sets.
   Qed.
 
 End Infinite_sets.
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Export Gt Lt Le.

--- a/theories/Sets/Integers.v
+++ b/theories/Sets/Integers.v
@@ -33,9 +33,6 @@ Require Export Classical_sets.
 Require Export Powerset.
 Require Export Powerset_facts.
 Require Export Powerset_Classical_facts.
-Require Export Gt.
-Require Export Lt.
-Require Export Le.
 Require Export Finite_sets_facts.
 Require Export Image.
 Require Export Infinite_sets.
@@ -56,12 +53,12 @@ Section Integers_sect.
 
   Lemma le_antisym : Antisymmetric nat le.
   Proof.
-    red; intros x y H H'; rewrite (le_antisym x y); auto.
+    red; intros x y H H'; rewrite (Nat.le_antisymm x y); auto.
   Qed.
 
   Lemma le_trans : Transitive nat le.
   Proof.
-    red; intros; apply le_trans with y; auto.
+    red; intros; apply Nat.le_trans with y; auto.
   Qed.
 
   Lemma le_Order : Order nat le.
@@ -87,10 +84,10 @@ Section Integers_sect.
     apply Totally_ordered_definition.
     simpl.
     intros H' x y H'0.
-    elim le_or_lt with (n := x) (m := y).
+    elim Nat.le_gt_cases with (n := x) (m := y).
     intro H'1; left; auto with sets arith.
     intro H'1; right.
-    cut (y <= x); auto with sets arith.
+    apply Nat.lt_le_incl; assumption.
   Qed.
 
   Lemma Finite_subset_has_lub :
@@ -144,8 +141,7 @@ Section Integers_sect.
     intro H'3.
     specialize H'2 with (y := S x); lapply H'2;
       [ intro H'5; clear H'2 | try assumption; clear H'2 ].
-    simpl in H'5.
-    absurd (S x <= x); auto with arith.
+    apply Nat.nle_succ_diag_l in H'5; assumption.
     apply triv_nat.
  Qed.
 
@@ -159,6 +155,5 @@ Section Integers_sect.
 
 End Integers_sect.
 
-
-
-
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Export Gt Lt Le.

--- a/theories/Sets/Multiset.v
+++ b/theories/Sets/Multiset.v
@@ -10,8 +10,7 @@
 
 (* G. Huet 1-9-95 *)
 
-Require Import Permut Setoid.
-Require Plus. (* comm. and ass. of plus *)
+Require Import PeanoNat Permut Setoid.
 
 Set Implicit Arguments.
 
@@ -73,14 +72,14 @@ Section multiset_defs.
   Lemma munion_comm : forall x y:multiset, meq (munion x y) (munion y x).
   Proof.
     unfold meq; unfold multiplicity; unfold munion.
-    destruct x; destruct y; auto with arith.
+    destruct x; destruct y; intros; apply Nat.add_comm.
   Qed.
 
   Lemma munion_ass :
     forall x y z:multiset, meq (munion (munion x y) z) (munion x (munion y z)).
   Proof.
     unfold meq; unfold munion; unfold multiplicity.
-    destruct x; destruct y; destruct z; auto with arith.
+    destruct x; destruct y; destruct z; intros; symmetry; apply Nat.add_assoc.
   Qed.
 
   Lemma meq_left :
@@ -88,7 +87,7 @@ Section multiset_defs.
   Proof.
     unfold meq; unfold munion; unfold multiplicity.
     destruct x; destruct y; destruct z.
-    intros; elim H; auto with arith.
+    intros; elim H; reflexivity.
   Qed.
 
   Lemma meq_right :
@@ -177,7 +176,6 @@ Section multiset_defs.
   Qed.
 
 (*i theory of minter to do similarly
-Require Min.
 (* multiset intersection *)
 Definition minter := [m1,m2:multiset]
     (Bag [a:A](min (multiplicity m1 a)(multiplicity m2 a))).
@@ -194,3 +192,6 @@ Hint Resolve munion_empty_right munion_comm munion_ass meq_left meq_right
   munion_empty_left: datatypes.
 #[global]
 Hint Immediate meq_sym: datatypes.
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Plus.

--- a/theories/Sets/Uniset.v
+++ b/theories/Sets/Uniset.v
@@ -213,7 +213,6 @@ Qed.
 
 
 (*i theory of minter to do similarly
-Require Min.
 (* uniset intersection *)
 Definition minter := [m1,m2:uniset]
     (Charac [a:A](andb (charac m1 a)(charac m2 a))).

--- a/theories/Sorting/PermutEq.v
+++ b/theories/Sorting/PermutEq.v
@@ -8,7 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-Require Import Relations Setoid SetoidList List Multiset PermutSetoid Permutation Lia.
+Require Import Relations Setoid SetoidList List Multiset PermutSetoid Permutation.
 
 Set Implicit Arguments.
 
@@ -85,7 +85,13 @@ Section Perm.
     rewrite multiplicity_NoDup in H, H0.
     generalize (H a) (H0 a) (H1 a); clear H H0 H1.
     do 2 rewrite multiplicity_In.
-    destruct 3; lia.
+    intros H H' [H0 H0'].
+    destruct (multiplicity (list_contents l) a) as [|[|n]],
+             (multiplicity (list_contents l') a) as [|[|n']];
+    [ tauto | intuition | | intuition | tauto | intuition |  | intuition | ]; exfalso.
+    - now inversion H'.
+    - now inversion H.
+    - now inversion H.
   Qed.
 
   (** Permutation is compatible with In. *)
@@ -223,4 +229,3 @@ Section Perm.
   Qed.
 
 End Perm.
-

--- a/theories/Sorting/Permutation.v
+++ b/theories/Sorting/Permutation.v
@@ -650,7 +650,8 @@ Proof.
  * now rewrite map_length.
  * intros x. rewrite in_map_iff. intros (y & <- & Hy').
    rewrite in_seq in *. simpl in *.
-   destruct Hy' as (_,Hy'). auto with arith.
+   destruct Hy' as (_,Hy').
+   split; [ apply Nat.le_0_l | auto ].
 Qed.
 
 Section Permutation_alt.
@@ -669,18 +670,18 @@ Proof.
  unfold adapt. intros Hf x y EQ.
  destruct le_lt_dec as [LE|LT]; destruct le_lt_dec as [LE'|LT'].
  - now apply eq_add_S, Hf.
- - apply Lt.le_lt_or_eq in LE.
+ - apply Nat.lt_eq_cases in LE.
    destruct LE as [LT|EQ']; [|now apply Hf in EQ'].
    unfold lt in LT. rewrite EQ in LT.
-   rewrite <- (Lt.S_pred _ _ LT') in LT.
-   elim (Lt.lt_not_le _ _ LT' LT).
- - apply Lt.le_lt_or_eq in LE'.
+   rewrite (Nat.lt_succ_pred _ _ LT') in LT.
+   elim (proj1 (Nat.lt_nge _ _) LT' LT).
+ - apply Nat.lt_eq_cases in LE'.
    destruct LE' as [LT'|EQ']; [|now apply Hf in EQ'].
    unfold lt in LT'. rewrite <- EQ in LT'.
-   rewrite <- (Lt.S_pred _ _ LT) in LT'.
-   elim (Lt.lt_not_le _ _ LT LT').
+   rewrite (Nat.lt_succ_pred _ _ LT) in LT'.
+   elim (proj1 (Nat.lt_nge _ _) LT LT').
  - apply eq_add_S, Hf.
-   now rewrite (Lt.S_pred _ _ LT), (Lt.S_pred _ _ LT'), EQ.
+   now rewrite <- (Nat.lt_succ_pred _ _ LT), <- (Nat.lt_succ_pred _ _ LT'), EQ.
 Qed.
 
 Let adapt_ok a l1 l2 f : Injective f -> length l1 = f 0 ->
@@ -688,14 +689,17 @@ Let adapt_ok a l1 l2 f : Injective f -> length l1 = f 0 ->
 Proof.
  unfold adapt. intros Hf E n.
  destruct le_lt_dec as [LE|LT].
- - apply Lt.le_lt_or_eq in LE.
+ - apply Nat.lt_eq_cases in LE.
    destruct LE as [LT|EQ]; [|now apply Hf in EQ].
    rewrite <- E in LT.
    rewrite 2 nth_error_app1; auto.
- - rewrite (Lt.S_pred _ _ LT) at 1.
-   rewrite <- E, (Lt.S_pred _ _ LT) in LT.
-   rewrite 2 nth_error_app2; auto with arith.
-   rewrite <- Minus.minus_Sn_m; auto with arith.
+ - rewrite <- (Nat.lt_succ_pred _ _ LT) at 1.
+   rewrite <- E, <- (Nat.lt_succ_pred _ _ LT) in LT.
+   rewrite 2 nth_error_app2.
+   + rewrite Nat.sub_succ_l; [ reflexivity | ].
+     apply Nat.lt_succ_r; assumption.
+   + apply Nat.lt_succ_r; assumption.
+   + apply Nat.lt_le_incl; assumption.
 Qed.
 
 Lemma Permutation_nth_error l l' :
@@ -752,21 +756,21 @@ Proof.
  - intros (E & f & Hf & Hf').
    exists f. do 2 (split; trivial).
    intros n Hn.
-   destruct (Lt.le_or_lt (length l) (f n)) as [LE|LT]; trivial.
+   destruct (Nat.le_gt_cases (length l) (f n)) as [LE|LT]; trivial.
    rewrite <- nth_error_None, <- Hf', nth_error_None, <- E in LE.
-   elim (Lt.lt_not_le _ _ Hn LE).
+   elim (proj1 (Nat.lt_nge _ _) Hn LE).
  - intros (f & Hf & Hf2 & Hf3); split; [|exists f; auto].
-   assert (H : length l' <= length l') by auto with arith.
+   assert (H : length l' <= length l') by auto.
    rewrite <- nth_error_None, Hf3, nth_error_None in H.
-   destruct (Lt.le_or_lt (length l) (length l')) as [LE|LT];
-    [|apply Hf2 in LT; elim (Lt.lt_not_le _ _ LT H)].
-   apply Lt.le_lt_or_eq in LE. destruct LE as [LT|EQ]; trivial.
+   destruct (Nat.le_gt_cases (length l) (length l')) as [LE|LT];
+    [|apply Hf2 in LT; elim (proj1 (Nat.lt_nge _ _) LT H)].
+   apply Nat.lt_eq_cases in LE. destruct LE as [LT|EQ]; trivial.
    rewrite <- nth_error_Some, Hf3, nth_error_Some in LT.
    assert (Hf' : bInjective (length l) f).
    { intros x y _ _ E. now apply Hf. }
    rewrite (bInjective_bSurjective Hf2) in Hf'.
    destruct (Hf' _ LT) as (y & Hy & Hy').
-   apply Hf in Hy'. subst y. elim (Lt.lt_irrefl _ Hy).
+   apply Hf in Hy'. subst y. elim (Nat.lt_irrefl _ Hy).
 Qed.
 
 Lemma Permutation_nth l l' d :
@@ -797,9 +801,9 @@ Proof.
      destruct le_lt_dec as [LE|LT];
       destruct le_lt_dec as [LE'|LT']; auto.
      + apply Hf1 in LT'. intros ->.
-       elim (Lt.lt_irrefl (f y)). eapply Lt.lt_le_trans; eauto.
+       elim (Nat.lt_irrefl (f y)). eapply Nat.lt_le_trans; eauto.
      + apply Hf1 in LT. intros <-.
-       elim (Lt.lt_irrefl (f x)). eapply Lt.lt_le_trans; eauto.
+       elim (Nat.lt_irrefl (f x)). eapply Nat.lt_le_trans; eauto.
    * intros n.
      destruct le_lt_dec as [LE|LT].
      + assert (LE' : length l' <= n) by (now rewrite E).

--- a/theories/Strings/String.v
+++ b/theories/Strings/String.v
@@ -203,7 +203,7 @@ intros s1; elim s1; simpl; auto.
 intros s2 n H; inversion H.
 intros a s1' Rec s2 n; case n; simpl; auto.
 intros n0 H; apply Rec; auto.
-apply lt_S_n; auto.
+apply Nat.succ_lt_mono; auto.
 Qed.
 
 (** The last elements of [s1 ++ s2] are the ones of [s2] *)
@@ -213,10 +213,11 @@ Theorem append_correct2 :
  get n s2 = get (n + length s1) (s1 ++ s2).
 Proof.
 intros s1; elim s1; simpl; auto.
-intros s2 n; rewrite plus_comm; simpl; auto.
+intros s2 n; rewrite Nat.add_comm; simpl; auto.
 intros a s1' Rec s2 n; case n; simpl; auto.
 generalize (Rec s2 O); simpl; auto. intros.
-rewrite <- Plus.plus_Snm_nSm; auto.
+(replace (n0 + S (length s1'))
+    with (S n0 + length s1') by now rewrite Nat.add_succ_r); auto.
 Qed.
 
 (** *** Substrings *)
@@ -248,8 +249,8 @@ intros m; case m; simpl; auto.
 intros p H; inversion H.
 intros m' p; case p; simpl; auto.
 intros n0 H; apply Rec; simpl; auto.
-apply Lt.lt_S_n; auto.
-intros n' m p H; rewrite <- Plus.plus_Snm_nSm; simpl; auto.
+apply <- Nat.succ_lt_mono; auto.
+intros n' m p H; rewrite Nat.add_succ_r; auto.
 Qed.
 
 (** The substring has at most [m] elements *)
@@ -265,7 +266,7 @@ intros m; case m; simpl; auto.
 intros m' p; case p; simpl; auto.
 intros H; inversion H.
 intros n0 H; apply Rec; simpl; auto.
-apply Le.le_S_n; auto.
+apply <- Nat.succ_le_mono; auto.
 Qed.
 
 (** *** Concatenating lists of strings *)
@@ -406,8 +407,8 @@ intros H2 H3; red; intros H4; case H0.
 intros H5 H6; absurd (false = true); auto with bool.
 intros n0 H2 H3; apply H; auto.
 injection H1; auto.
-apply Le.le_O_n.
-apply Lt.lt_S_n; auto.
+apply Nat.le_0_l.
+apply <- Nat.succ_lt_mono; auto.
 intros; discriminate.
 intros n'; case m; simpl; auto.
 case (index n' s1 s2'); intros; discriminate.
@@ -416,8 +417,8 @@ intros x H H0 p; case p; simpl; auto.
 intros H1; inversion H1; auto.
 intros n0 H1 H2; apply H; auto.
 injection H0; auto.
-apply Le.le_S_n; auto.
-apply Lt.lt_S_n; auto.
+apply <- Nat.succ_le_mono; auto.
+apply <- Nat.succ_lt_mono; auto.
 intros; discriminate.
 Qed.
 
@@ -451,13 +452,13 @@ intros a s n0 H H0 H1 H2;
  apply (Rec O); auto.
 generalize H0; case (index 0 (String a s) s2'); simpl; auto; intros;
  discriminate.
-apply Le.le_O_n.
+apply Nat.le_0_l.
 intros n'; case m; simpl; auto.
 intros H H0 H1; inversion H1.
 intros n0 H H0 H1; apply (Rec n'); auto.
 generalize H; case (index n' s1 s2'); simpl; auto; intros;
  discriminate.
-apply Le.le_S_n; auto.
+apply Nat.succ_le_mono; auto.
 Qed.
 
 (* Back to normal for prefix *)
@@ -473,13 +474,13 @@ Proof.
 intros n s; generalize n; clear n; elim s; simpl; auto.
 intros n; case n; simpl; auto.
 intros; discriminate.
-intros; apply Lt.lt_O_Sn.
+intros; apply Nat.lt_0_succ.
 intros a s' H n; case n; simpl; auto.
 intros; discriminate.
 intros n'; generalize (H n'); case (index n' EmptyString s'); simpl;
  auto.
 intros; discriminate.
-intros H0 H1; apply Lt.lt_n_S; auto.
+intros H0 H1. apply -> Nat.succ_lt_mono; auto.
 Qed.
 
 (** Same as [index] but with no optional type, we return [0] when it

--- a/theories/Structures/OrderedTypeEx.v
+++ b/theories/Structures/OrderedTypeEx.v
@@ -10,10 +10,9 @@
 
 Require Import OrderedType.
 Require Import ZArith_base.
-Require Import PeanoNat.
+Require Import PeanoNat Peano_dec Compare_dec.
 Require Import Ascii String.
 Require Import NArith Ndec.
-Require Import Compare_dec.
 
 (** * Examples of Ordered Type structures. *)
 
@@ -51,7 +50,7 @@ Module Nat_as_OT <: UsualOrderedType.
   Definition lt := lt.
 
   Lemma lt_trans : forall x y z : t, lt x y -> lt y z -> lt x z.
-  Proof. unfold lt; intros; apply lt_trans with y; auto. Qed.
+  Proof. unfold lt; intros; apply Nat.lt_trans with y; auto. Qed.
 
   Lemma lt_not_eq : forall x y : t, lt x y -> ~ eq x y.
   Proof. unfold lt, eq; intros ? ? LT ->; revert LT; apply Nat.lt_irrefl. Qed.
@@ -425,7 +424,7 @@ Module String_as_OT <: UsualOrderedType.
   Proof.
     intro H; inversion H; subst; auto.
     remember (nat_of_ascii a) as x.
-    apply lt_irrefl in H1; inversion H1.
+    apply Nat.lt_irrefl in H1; inversion H1.
   Qed.
 
   Lemma lt_trans : forall x y z : t, lt x y -> lt y z -> lt x z.
@@ -438,7 +437,7 @@ Module String_as_OT <: UsualOrderedType.
       + constructor. eapply IHx; eauto.
       + constructor; assumption.
       + constructor; assumption.
-      + constructor. eapply lt_trans; eassumption.
+      + constructor. eapply Nat.lt_trans; eassumption.
   Qed.
 
   Lemma lt_not_eq : forall x y : t, lt x y -> ~ eq x y.

--- a/theories/Vectors/Fin.v
+++ b/theories/Vectors/Fin.v
@@ -8,6 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+Require Import PeanoNat.
 Require Arith_base.
 
 (** [fin n] is a convenient way to represent \[1 .. n\]
@@ -74,8 +75,8 @@ end.
 (** [to_nat f] = p iff [f] is the p{^ th} element of [fin m]. *)
 Fixpoint to_nat {m} (n : t m) : {i | i < m} :=
   match n with
-    |@F1 j => exist _ 0 (Lt.lt_0_Sn j)
-    |FS p => match to_nat p with |exist _ i P => exist _ (S i) (Lt.lt_n_S _ _ P) end
+    |@F1 j => exist _ 0 (Nat.lt_0_succ j)
+    |FS p => match to_nat p with |exist _ i P => exist _ (S i) (proj1 (Nat.succ_lt_mono _ _) P) end
   end.
 
 (** [of_nat p n] answers the p{^ th} element of [fin n] if p < n or a proof of
@@ -97,10 +98,10 @@ Fixpoint of_nat (p n : nat) : (t n) + { exists m, p = n + m } :=
 it behaves much better than [of_nat p n] on open term *)
 Fixpoint of_nat_lt {p n : nat} : p < n -> t n :=
   match n with
-    |0 => fun H : p < 0 => False_rect _ (Lt.lt_n_O p H)
+    |0 => fun H : p < 0 => False_rect _ (PeanoNat.Nat.nlt_0_r p H)
     |S n' => match p with
       |0 => fun _ => @F1 n'
-      |S p' => fun H => FS (of_nat_lt (Lt.lt_S_n _ _ H))
+      |S p' => fun H => FS (of_nat_lt (proj2 (Nat.succ_lt_mono _ _) H))
     end
   end.
 
@@ -119,8 +120,8 @@ Qed.
 Lemma to_nat_of_nat {p}{n} (h : p < n) : to_nat (of_nat_lt h) = exist _ p h.
 Proof.
  revert n h.
- induction p as [|p IHp]; (intro n; destruct n as [|n]; intros h; [ destruct (Lt.lt_n_O _ h) | cbn]);
- [ | rewrite (IHp _ (Lt.lt_S_n p n h))];  f_equal; apply Peano_dec.le_unique.
+ induction p as [|p IHp]; (intro n; destruct n as [|n]; intros h; [ destruct (Nat.nlt_0_r _ h) | cbn]);
+ [ | rewrite (IHp _ (proj2 (Nat.succ_lt_mono p n) h))]; f_equal; apply Peano_dec.le_unique.
 Qed.
 
 Lemma to_nat_inj {n} (p q : t n) :
@@ -194,16 +195,15 @@ Lemma depair_sanity {m n} (o : t m) (p : t n) :
   proj1_sig (to_nat (depair o p)) = n * (proj1_sig (to_nat o)) + (proj1_sig (to_nat p)).
 Proof.
 induction o as [|? o IHo] ; simpl.
-- rewrite L_sanity. now rewrite Mult.mult_0_r.
-
+- rewrite L_sanity. now rewrite Nat.mul_0_r.
 - rewrite R_sanity. rewrite IHo.
-  rewrite Plus.plus_assoc. destruct (to_nat o); simpl; rewrite Mult.mult_succ_r.
-    now rewrite (Plus.plus_comm n).
+  rewrite Nat.add_assoc. destruct (to_nat o); simpl; rewrite Nat.mul_succ_r.
+    now rewrite (Nat.add_comm n).
 Qed.
 
 Fixpoint eqb {m n} (p : t m) (q : t n) :=
 match p, q with
-| @F1 m', @F1 n' => EqNat.beq_nat m' n'
+| @F1 m', @F1 n' => Nat.eqb m' n'
 | FS _, F1 => false
 | F1, FS _ => false
 | FS p', FS q' => eqb p' q'
@@ -213,7 +213,7 @@ Lemma eqb_nat_eq : forall m n (p : t m) (q : t n), eqb p q = true -> m = n.
 Proof.
 intros m n p; revert n; induction p as [|? p IHp];
  intros ? q; destruct q; simpl; intros; f_equal.
-- now apply EqNat.beq_nat_true.
+- now apply Nat.eqb_eq.
 - easy.
 - easy.
 - eapply IHp. eassumption.
@@ -222,7 +222,7 @@ Qed.
 Lemma eqb_eq : forall n (p q : t n), eqb p q = true <-> p = q.
 Proof.
 apply rect2; simpl; intros.
-- split; intros ; [ reflexivity | now apply EqNat.beq_nat_true_iff ].
+- split; intros ; [ reflexivity | now apply Nat.eqb_eq ].
 - now split.
 - now split.
 - eapply iff_trans.

--- a/theories/Vectors/VectorDef.v
+++ b/theories/Vectors/VectorDef.v
@@ -168,12 +168,12 @@ Lemma trunc : forall {A} {n} (p:nat), n > p -> t A n
   -> t A (n - p).
 Proof.
   intros A n p; induction p as [| p f]; intros H v.
-  rewrite <- minus_n_O.
+  rewrite Nat.sub_0_r.
   exact v.
 
   apply shiftout.
 
-  rewrite minus_Sn_m.
+  rewrite <- Nat.sub_succ_l.
   apply f.
   auto with *.
   exact v.
@@ -204,7 +204,7 @@ reverses the first one *)
 
 (** This one has the exact expected computational behavior *)
 Fixpoint rev_append_tail {A n p} (v : t A n) (w: t A p)
-  : t A (tail_plus n p) :=
+  : t A (Nat.tail_add n p) :=
   match v with
   | [] => w
   | a :: v' => rev_append_tail v' (a :: w)
@@ -215,7 +215,7 @@ Import EqdepFacts.
 (** This one has a better type *)
 Definition rev_append {A n p} (v: t A n) (w: t A p)
   :t A (n + p) :=
-  rew <- (plus_tail_plus n p) in (rev_append_tail v w).
+  rew (Nat.tail_add_spec n p) in (rev_append_tail v w).
 
 (** rev [a₁ ; a₂ ; .. ; an] is [an ; a{n-1} ; .. ; a₁]
 

--- a/theories/Vectors/VectorSpec.v
+++ b/theories/Vectors/VectorSpec.v
@@ -57,7 +57,7 @@ intros n; induction n; intros k v H HS.
 - inversion H.
 - rewrite (eta v).
   unfold nth_order; simpl.
-  now rewrite (Fin.of_nat_ext H (Lt.lt_S_n _ _ HS)).
+  now rewrite (Fin.of_nat_ext H (proj2 (Nat.succ_lt_mono _ _) HS)).
 Qed.
 
 Lemma nth_order_last A: forall n (v: t A (S n)) (H: n < S n),
@@ -436,7 +436,7 @@ Lemma to_list_nth_order A n (v : t A n) p (H : p < n) d:
 Proof.
 revert n v H; induction p as [ | p IHp ]; intros n v H;
   (destruct n; [ inversion H | rewrite (eta v) ]); trivial.
-now rewrite <- nth_order_tl with (H:=Lt.lt_S_n _ _ H), IHp.
+now rewrite <- nth_order_tl with (H:=proj2 (Nat.succ_lt_mono _ _) H), IHp.
 Qed.
 
 Lemma to_list_tl A n (v : t A (S n)):
@@ -456,7 +456,7 @@ Proof. now revert m v2; induction v1 as [ | ? ? ? IHv1 ]; intros; [ | simpl; rew
 
 Lemma to_list_rev_append A n m (v1 : t A n) (v2 : t A m):
   to_list (rev_append v1 v2) = List.rev_append (to_list v1) (to_list v2).
-Proof. unfold rev_append; rewrite (Plus.plus_tail_plus n m); apply to_list_rev_append_tail. Qed.
+Proof. unfold rev_append; rewrite <- (Nat.tail_add_spec n m); apply to_list_rev_append_tail. Qed.
 
 Lemma to_list_rev A n (v : t A n):
   to_list (rev v) = List.rev (to_list v).

--- a/theories/ZArith/Zcompare.v
+++ b/theories/ZArith/Zcompare.v
@@ -17,7 +17,6 @@
     for results already present in BinInt.Z. *)
 
 Require Export BinPos BinInt.
-Require Import Lt Gt Plus Mult. (* Useless now, for compatibility only *)
 
 Local Open Scope Z_scope.
 
@@ -191,3 +190,6 @@ Notation Zsgn_1 := Z.sgn_pos (only parsing).
 Notation Zsgn_m1 := Z.sgn_neg (only parsing).
 
 (** Not kept: Zcompare_egal_dec *)
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Import Lt Gt Plus Mult.

--- a/theories/ZArith/Zgcd_alt.v
+++ b/theories/ZArith/Zgcd_alt.v
@@ -201,7 +201,7 @@ Open Scope Z_scope.
    intros _.
    induction p as [p IHp|p IHp|]; [ | | compute; auto ];
     simpl Zgcd_bound in *;
-    rewrite plus_comm; simpl plus;
+    rewrite Nat.add_comm; simpl plus;
     set (n:= (Pos.size_nat p+Pos.size_nat p)%nat) in *; simpl;
     assert (n <> O) as H by (unfold n; destruct p; simpl; auto).
 
@@ -234,7 +234,7 @@ Open Scope Z_scope.
   simpl Zgcd_bound in *.
   remember (Pos.size_nat a+Pos.size_nat a)%nat as m eqn:Heqm.
   assert (1 < m)%nat as H0.
-  { rewrite Heqm; destruct a; simpl; rewrite 1?plus_comm;
+  { rewrite Heqm; destruct a; simpl; rewrite 1? Nat.add_comm;
     auto with arith. }
   destruct m as [ |m]; [inversion H0; auto| ].
   destruct n as [ |n]; [inversion H; auto| ].
@@ -272,5 +272,3 @@ Open Scope Z_scope.
  Proof.
   unfold Zgcd_alt; intros; apply Zgcdn_is_gcd; auto.
  Qed.
-
-

--- a/theories/ZArith/Znat.v
+++ b/theories/ZArith/Znat.v
@@ -1056,5 +1056,5 @@ Notation Zabs_N_mult := Zabs2N.inj_mul (only parsing).
 
 Theorem inj_minus2 : forall n m:nat, (m > n)%nat -> Z.of_nat (n - m) = 0.
 Proof.
- intros. rewrite not_le_minus_0; auto with arith.
+ intros n m ->%Nat.lt_le_incl%Nat.sub_0_le; auto.
 Qed.

--- a/theories/ZArith/Zwf.v
+++ b/theories/ZArith/Zwf.v
@@ -49,7 +49,7 @@ Section wf_proof.
     unfold Zwf in H1.
     case (Z.le_gt_cases c y); intro. 2: lia.
     left.
-    apply lt_le_trans with (f a); auto with arith.
+    apply Nat.lt_le_trans with (f a); auto with arith.
     unfold f.
     lia.
     apply (H (S (f a))); auto.

--- a/theories/extraction/ExtrHaskellNatNum.v
+++ b/theories/extraction/ExtrHaskellNatNum.v
@@ -22,7 +22,7 @@ Extract Inlined Constant Init.Nat.min => "Prelude.min".
 Extract Inlined Constant Compare_dec.lt_dec => "(Prelude.<)".
 Extract Inlined Constant Compare_dec.leb => "(Prelude.<=)".
 Extract Inlined Constant Compare_dec.le_lt_dec => "(Prelude.<=)".
-Extract Inlined Constant EqNat.beq_nat => "(Prelude.==)".
+Extract Inlined Constant Nat.eqb => "(Prelude.==)".
 Extract Inlined Constant EqNat.eq_nat_decide => "(Prelude.==)".
 Extract Inlined Constant Peano_dec.eq_nat_dec => "(Prelude.==)".
 

--- a/theories/extraction/ExtrOcamlNatBigInt.v
+++ b/theories/extraction/ExtrOcamlNatBigInt.v
@@ -44,7 +44,7 @@ Extract Constant minus =>
 Extract Constant max => "Big_int_Z.max_big_int".
 Extract Constant min => "Big_int_Z.min_big_int".
 (*Extract Constant nat_beq => "Big.eq".*)
-Extract Constant EqNat.beq_nat => "Big_int_Z.eq_big_int".
+Extract Constant Nat.eqb => "Big_int_Z.eq_big_int".
 Extract Constant EqNat.eq_nat_decide => "Big_int_Z.eq_big_int".
 
 Extract Constant Peano_dec.eq_nat_dec => "Big_int_Z.eq_big_int".
@@ -59,10 +59,10 @@ Extract Constant Compare_dec.lt_eq_lt_dec =>
  "(fun x y -> let s = Big_int_Z.compare_big_int x y in
   if s = 0 then (Some false) else if s < 0 then (Some true) else None)".
 
-Extract Constant Even.even_odd_dec =>
+Extract Constant Nat.Even_or_Odd =>
  "(fun n -> Big_int_Z.sign_big_int
   (Big_int_Z.mod_big_int n (Big_int_Z.big_int_of_int 2)) = 0)".
-Extract Constant Div2.div2 => "(fun n -> Big_int_Z.div_big_int n (Big_int_Z.big_int_of_int 2))".
+Extract Constant Nat.div2 => "(fun n -> Big_int_Z.div_big_int n (Big_int_Z.big_int_of_int 2))".
 
 Extract Inductive Euclid.diveucl => "(Big_int_Z.big_int * Big_int_Z.big_int)" [""].
 Extract Constant Euclid.eucl_dev => "(fun n m -> Big_int_Z.quomod_big_int m n)".

--- a/theories/extraction/ExtrOcamlNatInt.v
+++ b/theories/extraction/ExtrOcamlNatInt.v
@@ -54,7 +54,7 @@ Extract Constant mult => "( * )".
 Extract Inlined Constant max => "Pervasives.max".
 Extract Inlined Constant min => "Pervasives.min".
 (*Extract Inlined Constant nat_beq => "(=)".*)
-Extract Inlined Constant EqNat.beq_nat => "(=)".
+Extract Inlined Constant Nat.eqb => "(=)".
 Extract Inlined Constant EqNat.eq_nat_decide => "(=)".
 
 Extract Inlined Constant Peano_dec.eq_nat_dec => "(=)".
@@ -67,8 +67,8 @@ Extract Inlined Constant Compare_dec.lt_dec => "(<)".
 Extract Constant Compare_dec.lt_eq_lt_dec =>
  "fun n m -> if n>m then None else Some (n<m)".
 
-Extract Constant Even.even_odd_dec => "fun n -> n mod 2 = 0".
-Extract Constant Div2.div2 => "fun n -> n/2".
+Extract Constant Nat.Even_or_Odd => "fun n -> n mod 2 = 0".
+Extract Constant Nat.div2 => "fun n -> n/2".
 
 Extract Inductive Euclid.diveucl => "(int * int)" [ "" ].
 Extract Constant Euclid.eucl_dev => "fun n m -> (m/n, m mod n)".

--- a/theories/micromega/Lia.v
+++ b/theories/micromega/Lia.v
@@ -29,9 +29,5 @@ Ltac zchecker :=
                                 (@find Z Z0 __varmap)).
 
 Ltac lia := Zify.zify; xlia zchecker.
-               
-Ltac nia := Zify.zify; xnlia zchecker.
 
-(* Local Variables: *)
-(* coding: utf-8 *)
-(* End: *)
+Ltac nia := Zify.zify; xnlia zchecker.

--- a/theories/micromega/QMicromega.v
+++ b/theories/micromega/QMicromega.v
@@ -272,7 +272,3 @@ Proof.
     eapply QWeakChecker_sound; eauto.
     tauto.
 Qed.
-
-(* Local Variables: *)
-(* coding: utf-8 *)
-(* End: *)

--- a/theories/micromega/VarMap.v
+++ b/theories/micromega/VarMap.v
@@ -16,7 +16,6 @@
 (************************************************************************)
 
 Require Import ZArith_base.
-Require Import Coq.Arith.Max.
 Require Import List.
 Set Implicit Arguments.
 
@@ -80,5 +79,7 @@ Section MakeVarMap.
       end
     end.
 
-  
-End MakeVarMap.  
+End MakeVarMap.
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Import Max.

--- a/theories/micromega/ZMicromega.v
+++ b/theories/micromega/ZMicromega.v
@@ -1153,7 +1153,7 @@ Proof.
   generalize (      (fold_right (fun (pf : ZArithProof) (x : nat) => Nat.max (bdepth pf) x) 0%nat
          l)).
   intros.
-  eapply lt_le_trans. eassumption.
+  eapply Nat.lt_le_trans. eassumption.
   rewrite <- Nat.succ_le_mono.
   apply Nat.le_max_r.
 Qed.
@@ -1865,9 +1865,3 @@ Definition eval := eval_formula.
 Definition prod_pos_nat := prod positive nat.
 
 Notation n_of_Z := Z.to_N (only parsing).
-
-(* Local Variables: *)
-(* coding: utf-8 *)
-(* End: *)
-
-

--- a/theories/micromega/ZifyInst.v
+++ b/theories/micromega/ZifyInst.v
@@ -12,7 +12,7 @@
    Each instance is registered using a Add 'class' 'name_of_instance'.
  *)
 
-Require Import Arith Max Min BinInt BinNat Znat Nnat.
+Require Import Arith BinInt BinNat Znat Nnat.
 Require Import ZifyClasses.
 Declare ML Module "zify_plugin".
 Local Open Scope Z_scope.
@@ -635,3 +635,6 @@ Instance SatPowNonneg : Saturate Z.pow :=
     PRes r := 0 <= r;
     SatOk a b Ha _ := @Z.pow_nonneg a b Ha }.
 Add Zify Saturate SatPowNonneg.
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Import Max Min.

--- a/theories/omega/PreOmega.v
+++ b/theories/omega/PreOmega.v
@@ -8,7 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-Require Import Arith Max Min BinInt BinNat Znat Nnat.
+Require Import Arith BinInt BinNat Znat Nnat.
 
 Local Open Scope Z_scope.
 
@@ -128,9 +128,12 @@ Module Z.
   Ltac to_euclidean_division_equations := div_mod_to_equations'; quot_rem_to_equations'; euclidean_division_equations_cleanup.
 End Z.
 
-Require  Import ZifyClasses ZifyInst.
-Require  Zify.
+Require Import ZifyClasses ZifyInst.
+Require Zify.
 
 Ltac Zify.zify_internal_to_euclidean_division_equations ::= Z.to_euclidean_division_equations.
 
 Ltac zify := Zify.zify.
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Import Max Min.

--- a/theories/rtauto/Bintree.v
+++ b/theories/rtauto/Bintree.v
@@ -10,7 +10,6 @@
 
 Require Export List.
 Require Export BinPos.
-Require Arith.EqNat.
 
 Open Scope positive_scope.
 
@@ -62,7 +61,7 @@ simpl;auto.
 Qed.
 
 Lemma Lget_app : forall (A:Set) (a:A) l i,
-Lget i (l ++ a :: nil) = if Arith.EqNat.beq_nat i (length l) then Some a else Lget i l.
+Lget i (l ++ a :: nil) = if Nat.eqb i (length l) then Some a else Lget i l.
 Proof.
 induction l;simpl Lget;simpl length.
 intros [ | i];simpl;reflexivity.
@@ -383,3 +382,6 @@ Arguments map [A B] f S.
 Arguments Full_map [A B f] S _.
 
 Notation "hyps \ A" := (push A hyps) (at level 72,left associativity).
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Arith.EqNat.

--- a/theories/setoid_ring/ArithRing.v
+++ b/theories/setoid_ring/ArithRing.v
@@ -8,7 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-Require Import Mult.
+Require Import PeanoNat.
 Require Import BinNat.
 Require Import Nnat.
 Require Export Ring.
@@ -16,9 +16,9 @@ Set Implicit Arguments.
 
 Lemma natSRth : semi_ring_theory O (S O) plus mult (@eq nat).
  Proof.
-  constructor. exact plus_0_l. exact plus_comm. exact plus_assoc.
-  exact mult_1_l. exact mult_0_l. exact mult_comm. exact mult_assoc.
-  exact mult_plus_distr_r.
+  constructor. exact Nat.add_0_l. exact Nat.add_comm. exact Nat.add_assoc.
+  exact Nat.mul_1_l. exact Nat.mul_0_l. exact Nat.mul_comm. exact Nat.mul_assoc.
+  exact Nat.mul_add_distr_r.
  Qed.
 
 Lemma nat_morph_N :
@@ -73,3 +73,6 @@ Add Ring natr : natSRth
   (morphism nat_morph_N, constants [natcst],
    preprocess [natprering], postprocess [natpostring]).
 
+
+(* TODO #14736 for compatibility only, should be removed after deprecation *)
+Require Import Mult.

--- a/theories/setoid_ring/RealField.v
+++ b/theories/setoid_ring/RealField.v
@@ -126,8 +126,8 @@ Lemma R_power_theory : power_theory 1%R Rmult (@eq R) N.to_nat pow.
 Proof.
  constructor. destruct n. reflexivity.
  simpl. induction p.
- - rewrite Pos2Nat.inj_xI. simpl. now rewrite plus_0_r, Rdef_pow_add, IHp.
- - rewrite Pos2Nat.inj_xO. simpl. now rewrite plus_0_r, Rdef_pow_add, IHp.
+ - rewrite Pos2Nat.inj_xI. simpl. now rewrite Nat.add_0_r, Rdef_pow_add, IHp.
+ - rewrite Pos2Nat.inj_xO. simpl. now rewrite Nat.add_0_r, Rdef_pow_add, IHp.
  - simpl. rewrite Rmult_comm;apply Rmult_1_l.
 Qed.
 


### PR DESCRIPTION
This PR follows the discussion in #11356 with the restricted goal of making `stdlib` independent from some obsolete files. Using these files should now generate deprecation warnings, so that one could consider removing them in the future.
The files considered so far are:
- `Arith.Le`
- `Arith.Lt`
- `Arith.Plus`
- `Arith.Gt`
- `Arith.Minus`
- `Arith.Mult`
- `Arith.Min`
- `Arith.Max`
- `Arith.Even`
- `Arith.Div2`
- `NPeano`

Hint declarations from the deprecated files are moved to a new (temporary) file `Arith.Arith_prebase`. Everything is not 100% conservative but requiring `Arith.Arith_base` instead of the `Arith._` files above should have minor impact only.
`stdlib` is made independent from the files listed above. Making the deprecated files disappear should then allow to merge `Arith.Arith_prebase` and `Arith.Arith_base` without any impact.



<!-- Remove anything that doesn't apply in the following checklist. -->

- [X] Added / updated **test-suite**.
- [x] Added **changelog**.
- [X] Added / updated **documentation**.
- [x] Opened **overlay** pull requests.
  - mit-plv/cross-crypto#25

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
