### PR TITLE
Added error for use of `Scheme _ := Equality for _`.

### DIFF
--- a/test-suite/output/SchemeEqualityNoName.out
+++ b/test-suite/output/SchemeEqualityNoName.out
@@ -1,0 +1,3 @@
+File "./output/SchemeEqualityNoName.v", line 2, characters 0-27:
+Error: Naming of identifiers for Scheme Equality not supported.
+

--- a/test-suite/output/SchemeEqualityNoName.v
+++ b/test-suite/output/SchemeEqualityNoName.v
@@ -1,0 +1,2 @@
+Inductive A := a.
+Scheme x := Equality for A.

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -147,23 +147,23 @@ let try_declare_scheme what f internal names kn =
         alarm what internal
           (strbrk "Required constant " ++ str s ++ str " undefined.")
     | DeclareUniv.AlreadyDeclared (kind, id) as exn ->
-      let msg = CErrors.print exn in
-      alarm what internal msg
+        let msg = CErrors.print exn in
+        alarm what internal msg
     | DecidabilityMutualNotSupported ->
         alarm what internal
           (str "Decidability lemma for mutual inductive types not supported.")
     | EqUnknown s ->
-         alarm what internal
-           (str "Found unsupported " ++ str s ++ str " while building Boolean equality.")
+        alarm what internal
+          (str "Found unsupported " ++ str s ++ str " while building Boolean equality.")
     | NoDecidabilityCoInductive ->
-         alarm what internal
-           (str "Scheme Equality is only for inductive types.")
+        alarm what internal
+          (str "Scheme Equality is only for inductive types.")
     | DecidabilityIndicesNotSupported ->
-         alarm what internal
-           (str "Inductive types with annotations not supported.")
+        alarm what internal
+          (str "Inductive types with annotations not supported.")
     | ConstructorWithNonParametricInductiveType ind ->
-         alarm what internal
-           (strbrk "Unsupported constructor with an argument whose type is a non-parametric inductive type." ++
+        alarm what internal
+          (strbrk "Unsupported constructor with an argument whose type is a non-parametric inductive type." ++
             strbrk " Type " ++ quote (Printer.pr_inductive (Global.env()) ind) ++
             str " is applied to an argument which is not a variable.")
     | e when CErrors.noncritical e ->
@@ -433,6 +433,8 @@ tried to declare different schemes at once *)
       if not (List.is_empty ischeme) then do_mutual_induction_scheme ischeme
       else
         let mind,l = get_common_underlying_mutual_inductive env escheme in
+        if l <> [] then  (* we don't yet support naming here *)
+          user_err Pp.(str "Naming of identifiers for Scheme Equality not supported.");
         declare_beq_scheme_with l mind;
         declare_eq_decidability_scheme_with l mind
     )


### PR DESCRIPTION
This results in an identifier conflict:
```coq
Scheme x := Equality for bool.
```
```
Error: Unexpected error during scheme creation: The label x is already declared.
```
We now make this clear that it is not supported.
```
Naming of identifiers for Scheme Equality not supported.
```
Fixes / closes #14735.

There is perhaps more work to be done in the documentation of `Scheme` since as written it basically looks like `Equality` can have identifiers named. Perhaps this is symptom of a larger issue with the design of the `Scheme` command however, therefore I am hesitant to change it.

cc @coq/doc-maintainers Should I consider changing the documented syntax for scheme to disallow `Equality` to appear together with `:=` or is documenting the error enough? 

At least now the error message is more clear that this behaviour is not supported.

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make -f Makefile.make doc_gram_rsts`.
