### PR TITLE
Split Scheme Equality into own vernac + misc cleanup

### DIFF
--- a/dev/ci/user-overlays/14740-alizter-alizter+split-scheme-vernac.sh
+++ b/dev/ci/user-overlays/14740-alizter-alizter+split-scheme-vernac.sh
@@ -1,0 +1,1 @@
+overlay equations https://github.com/alizter/Coq-Equations alizter+split-scheme-vernac 14740

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1224,14 +1224,6 @@ show_zify: [
 | [ "InjTyp" | "BinOp" | "UnOp" | "CstOp" | "BinRel" | "UnOpSpec" | "BinOpSpec" | "Spec" ]  TAG Micromega
 ]
 
-scheme_kind: [
-| DELETE "Induction" "for" smart_global "Sort" sort_family
-| DELETE "Minimality" "for" smart_global "Sort" sort_family
-| DELETE "Elimination" "for" smart_global "Sort" sort_family
-| DELETE "Case" "for" smart_global "Sort" sort_family
-| [ "Induction" | "Minimality" | "Elimination" | "Case" ] "for" smart_global "Sort" sort_family
-]
-
 command: [
 | REPLACE "Print" printable
 | WITH printable

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -815,6 +815,7 @@ gallina: [
 | "CoFixpoint" LIST1 cofix_definition SEP "with"
 | "Let" "CoFixpoint" LIST1 cofix_definition SEP "with"
 | "Scheme" LIST1 scheme SEP "with"
+| "Scheme" "Equality" "for" smart_global
 | "Combined" "Scheme" identref "from" LIST1 identref SEP ","
 | "Register" global "as" qualid
 | "Register" "Inline" global
@@ -975,11 +976,14 @@ scheme: [
 ]
 
 scheme_kind: [
-| "Induction" "for" smart_global "Sort" sort_family
-| "Minimality" "for" smart_global "Sort" sort_family
-| "Elimination" "for" smart_global "Sort" sort_family
-| "Case" "for" smart_global "Sort" sort_family
-| "Equality" "for" smart_global
+| scheme_type "for" smart_global "Sort" sort_family
+]
+
+scheme_type: [
+| "Induction"
+| "Minimality"
+| "Elimination"
+| "Case"
 ]
 
 record_field: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -725,14 +725,20 @@ cofix_definition: [
 ]
 
 scheme_kind: [
-| "Equality" "for" reference
-| [ "Induction" | "Minimality" | "Elimination" | "Case" ] "for" reference "Sort" sort_family
+| scheme_type "for" reference "Sort" sort_family
+]
+
+scheme_type: [
+| "Induction"
+| "Minimality"
+| "Elimination"
+| "Case"
 ]
 
 sort_family: [
-| "Set"
 | "Prop"
 | "SProp"
+| "Set"
 | "Type"
 ]
 
@@ -1045,6 +1051,7 @@ command: [
 | "CoFixpoint" cofix_definition LIST0 ( "with" cofix_definition )
 | "Let" "CoFixpoint" cofix_definition LIST0 ( "with" cofix_definition )
 | "Scheme" OPT ( ident ":=" ) scheme_kind LIST0 ( "with" OPT ( ident ":=" ) scheme_kind )
+| "Scheme" "Equality" "for" reference
 | "Combined" "Scheme" ident "from" LIST1 ident SEP ","
 | "Register" qualid "as" qualid
 | "Register" "Inline" qualid

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -242,6 +242,7 @@ GRAMMAR EXTEND Gram
       | IDENT "Let"; "CoFixpoint"; corecs = LIST1 cofix_definition SEP "with" ->
           { VernacCoFixpoint (DoDischarge, corecs) }
       | IDENT "Scheme"; l = LIST1 scheme SEP "with" -> { VernacScheme l }
+      | IDENT "Scheme"; IDENT "Equality"; IDENT "for" ; id = smart_global -> { VernacSchemeEquality id }
       | IDENT "Combined"; IDENT "Scheme"; id = identref; IDENT "from";
               l = LIST1 identref SEP "," -> { VernacCombinedScheme (id, l) }
       | IDENT "Register"; g = global; "as"; quid = qualid ->
@@ -440,15 +441,16 @@ GRAMMAR EXTEND Gram
       | id = identref; ":="; kind = scheme_kind -> { (Some id,kind) } ] ]
   ;
   scheme_kind:
-    [ [ IDENT "Induction"; "for"; ind = smart_global;
-          IDENT "Sort"; s = sort_family-> { InductionScheme(true,ind,s) }
-      | IDENT "Minimality"; "for"; ind = smart_global;
-          IDENT "Sort"; s = sort_family-> { InductionScheme(false,ind,s) }
-      | IDENT "Elimination"; "for"; ind = smart_global;
-          IDENT "Sort"; s = sort_family-> { CaseScheme(true,ind,s) }
-      | IDENT "Case"; "for"; ind = smart_global;
-          IDENT "Sort"; s = sort_family-> { CaseScheme(false,ind,s) }
-      | IDENT "Equality"; "for" ; ind = smart_global -> { EqualityScheme(ind) } ] ]
+    [ [sch_type = scheme_type; "for"; sch_qualid = smart_global; IDENT "Sort"; sch_sort = sort_family
+      -> { {sch_type; sch_qualid; sch_sort} }
+    ] ]
+  ;
+  scheme_type:
+    [ [ IDENT "Induction" -> { SchemeInduction }
+      | IDENT "Minimality" -> { SchemeMinimality }
+      | IDENT "Elimination" -> { SchemeElimination }
+      | IDENT "Case" -> { SchemeCase }
+    ] ]
   ;
   (* Various Binders *)
 (*

--- a/vernac/indschemes.mli
+++ b/vernac/indschemes.mli
@@ -13,7 +13,14 @@ open Constr
 open Environ
 open Vernacexpr
 
+type resolved_scheme = Names.Id.t CAst.t * Indrec.dep_flag * Names.inductive * Sorts.family
+
 (** See also Auto_ind_decl, Indrec, Eqscheme, Ind_tables, ... *)
+
+(** Resolve the names of a list of inductive schemes with respect to an environment *)
+val name_and_process_schemes : Environ.env
+  -> (lident option * scheme) list
+  -> resolved_scheme list
 
 (** Build and register the boolean equalities associated to an inductive type *)
 
@@ -35,12 +42,16 @@ val declare_rewriting_schemes : inductive -> unit
     By default it is [false] and some of the eliminators are defined as simple case analysis.
  *)
 
-val do_mutual_induction_scheme : ?force_mutual:bool ->
-  (lident * bool * inductive * Sorts.family) list -> unit
+val do_mutual_induction_scheme : ?force_mutual:bool
+  -> Environ.env -> resolved_scheme list -> unit
 
 (** Main calls to interpret the Scheme command *)
 
-val do_scheme : (lident option * scheme) list -> unit
+val do_scheme : Environ.env -> (Names.Id.t CAst.t option * Vernacexpr.scheme) list -> unit
+
+(** Main call to Scheme Equality command *)
+
+val do_scheme_equality : Libnames.qualid Constrexpr.or_by_notation -> unit
 
 (** Combine a list of schemes into a conjunction of them *)
 

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -390,31 +390,17 @@ let pr_binders_arg =
 let pr_and_type_binders_arg bl =
   pr_binders_arg bl
 
-let pr_onescheme (idop,schem) =
-  match schem with
-  | InductionScheme (dep,ind,s) ->
-    (match idop with
-     | Some id -> hov 0 (pr_lident id ++ str" :=") ++ spc()
-     | None -> spc ()
-    ) ++
-    hov 0 ((if dep then keyword "Induction for" else keyword "Minimality for")
-           ++ spc() ++ pr_smart_global ind) ++ spc() ++
-    hov 0 (keyword "Sort" ++ spc() ++ Sorts.pr_sort_family s)
-  | CaseScheme (dep,ind,s) ->
-    (match idop with
-     | Some id -> hov 0 (pr_lident id ++ str" :=") ++ spc()
-     | None -> spc ()
-    ) ++
-    hov 0 ((if dep then keyword "Elimination for" else keyword "Case for")
-           ++ spc() ++ pr_smart_global ind) ++ spc() ++
-    hov 0 (keyword "Sort" ++ spc() ++ Sorts.pr_sort_family s)
-  | EqualityScheme ind ->
-    (match idop with
-     | Some id -> hov 0 (pr_lident id ++ str" :=") ++ spc()
-     | None -> spc()
-    ) ++
-    hov 0 (keyword "Equality for")
-    ++ spc() ++ pr_smart_global ind
+let pr_onescheme (idop, {sch_type; sch_qualid; sch_sort}) =
+  let str_identifier = match idop with
+    | Some id -> pr_lident id ++ str " :="
+    | None -> str "" in
+  let str_scheme = match sch_type with
+    | SchemeInduction ->  keyword "Induction for"
+    | SchemeMinimality ->  keyword "Minimality for"
+    | SchemeElimination ->  keyword "Elimination for"
+    | SchemeCase -> keyword "Case for" in
+  hov 0 str_identifier ++ spc () ++ hov 0 (str_scheme ++ spc() ++ pr_smart_global sch_qualid)
+    ++ spc () ++ hov 0 (keyword "Sort" ++ spc() ++ Sorts.pr_sort_family sch_sort)
 
 let begin_of_inductive = function
   | [] -> 0
@@ -908,6 +894,10 @@ let pr_vernac_expr v =
     return (
       hov 2 (keyword "Scheme" ++ spc() ++
              prlist_with_sep (fun _ -> fnl() ++ keyword "with" ++ spc ()) pr_onescheme l)
+    )
+  | VernacSchemeEquality id ->
+    return (
+      hov 2 (keyword "Scheme Equality for" ++ spc() ++ pr_or_by_notation pr_qualid id)
     )
   | VernacCombinedScheme (id, l) ->
     return (

--- a/vernac/ppvernac.mli
+++ b/vernac/ppvernac.mli
@@ -18,6 +18,9 @@ val pr_syntax_modifier : Vernacexpr.syntax_modifier CAst.t -> Pp.t
 (** Prints a fixpoint body *)
 val pr_rec_definition : Vernacexpr.fixpoint_expr -> Pp.t
 
+(** Prints a scheme *)
+val pr_onescheme : Names.lident option * Vernacexpr.scheme -> Pp.t
+
 (** Prints a vernac expression without dot *)
 val pr_vernac_expr : Vernacexpr.vernac_expr -> Pp.t
 

--- a/vernac/vernac_classifier.ml
+++ b/vernac/vernac_classifier.ml
@@ -152,6 +152,7 @@ let classify_vernac e =
     | VernacRegister _
     | VernacNameSectionHypSet _
     | VernacComments _
+    | VernacSchemeEquality _
     | VernacDeclareInstance _ -> VtSideff ([], VtLater)
     (* Who knows *)
     | VernacLoad _ -> VtSideff ([], VtNow)

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1016,13 +1016,15 @@ let vernac_cofixpoint ~atts ~pm discharge l =
 
 let vernac_scheme l =
   if Dumpglob.dump () then
-    List.iter (fun (lid, s) ->
-               Option.iter (fun lid -> Dumpglob.dump_definition lid false "def") lid;
-               match s with
-               | InductionScheme (_, r, _)
-               | CaseScheme (_, r, _)
-               | EqualityScheme r -> dump_global r) l;
-  Indschemes.do_scheme l
+    List.iter (fun (lid, sch) ->
+      Option.iter (fun lid -> Dumpglob.dump_definition lid false "def") lid;
+      dump_global sch.sch_qualid) l;
+  Indschemes.do_scheme (Global.env ()) l
+
+let vernac_scheme_equality id =
+  if Dumpglob.dump () then
+    dump_global id;
+  Indschemes.do_scheme_equality id
 
 let vernac_combined_scheme lid l =
   if Dumpglob.dump () then
@@ -2231,6 +2233,10 @@ let translate_vernac ?loc ~atts v = let open Vernacextend in match v with
     vtdefault(fun () ->
         unsupported_attributes atts;
         vernac_scheme l)
+  | VernacSchemeEquality id ->
+    vtdefault(fun () ->
+        unsupported_attributes atts;
+        vernac_scheme_equality id)
   | VernacCombinedScheme (id, l) ->
     vtdefault(fun () ->
         unsupported_attributes atts;

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -214,10 +214,18 @@ type proof_end =
   (*                         name in `Save ident` when closing goal *)
   | Proved of opacity_flag * lident option
 
-type scheme =
-  | InductionScheme of bool * qualid or_by_notation * Sorts.family
-  | CaseScheme of bool * qualid or_by_notation * Sorts.family
-  | EqualityScheme of qualid or_by_notation
+type scheme_type =
+  | SchemeInduction
+  | SchemeMinimality
+  | SchemeElimination
+  | SchemeCase
+
+  (* The data of a Scheme decleration *)
+type scheme = {
+  sch_type : scheme_type ;
+  sch_qualid : Libnames.qualid Constrexpr.or_by_notation ;
+  sch_sort : Sorts.family ;
+}
 
 type section_subset_expr =
   | SsEmpty
@@ -342,6 +350,7 @@ type nonrec vernac_expr =
   | VernacFixpoint of discharge * fixpoint_expr list
   | VernacCoFixpoint of discharge * cofixpoint_expr list
   | VernacScheme of (lident option * scheme) list
+  | VernacSchemeEquality of Libnames.qualid Constrexpr.or_by_notation
   | VernacCombinedScheme of lident * lident list
   | VernacUniverse of lident list
   | VernacConstraint of univ_constraint_expr list


### PR DESCRIPTION
The generation of equality schemes and induction schemes seem to have both been bundled together in order to share the vernac command. This however causes a lot of unnecessary work down the line.

We therefore separate these two (very separate) processes. We add a `Scheme Equality for` command which allows us to use the same vernac command as before, but now importantly it doesn't share any work with the induction schemes. The code of the induction schemes has been simplified and cleared up.

There used to be a function called `split_schemes` which was separating equality schemes from induction schemes and extracting some data from the induction schemes. This has now been simplified and renamed to `name_and_process_schemes` and the useless work has been removed.

Separating this data does propagate throughout the code but I have opted to not be too destructive, especially with functions about the actual scheme generation.

Fixes / closes #14735 

- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [x] Documented any new / changed **user messages**.
  - [x] Updated **documented syntax** by running `make -f Makefile.make doc_gram_rsts`.
- [x] Opened **overlay** pull requests. (coq-equations)
  - https://github.com/mattam82/Coq-Equations/pull/475