### PR TITLE
Add a criterion to decide when a cyclic evar instantiation is actually valid

### DIFF
--- a/clib/cList.mli
+++ b/clib/cList.mli
@@ -171,6 +171,9 @@ sig
   val fold_left_i :  (int -> 'a -> 'b -> 'a) -> int -> 'a -> 'b list -> 'a
   (** Like [List.fold_left] but with an index *)
 
+  val fold_left2_i :  (int -> 'a -> 'b -> 'c -> 'a) -> int -> 'a -> 'b list -> 'c list -> 'a
+  (** Like [List.fold_left2] but with an index *)
+
   val fold_right_and_left : ('b -> 'a -> 'a list -> 'b) -> 'a list -> 'b -> 'b
   (** [fold_right_and_left f [a1;...;an] hd] is
       [f (f (... (f (f hd an [an-1;...;a1]) an-1 [an-2;...;a1]) ...) a2 [a1]) a1 []] *)
@@ -188,13 +191,20 @@ sig
 
   val fold_left_map : ('a -> 'b -> 'a * 'c) -> 'a -> 'b list -> 'a * 'c list
   (** [fold_left_map f e_0 [a1;...;an]] is [e_n,[k_1...k_n]]
-      where [(e_i,k_i)] is [f e_{i-1} ai] for each i<=n *)
+      where [(e_i,k_i)] is [f e_{i-1} ai] for each 1<=i<=n *)
+
+  val fold_left_map_i : (int -> 'a -> 'b -> 'a * 'c) -> int -> 'a -> 'b list -> 'a * 'c list
+  (** [fold_left_map_i f m e_0 [a1;...;an]] is [e_n,[k_1...k_n]]
+      where [(e_i,k_i)] is [f (m+i-1) e_{i-1} ai] for each 1<=i<=n *)
 
   val fold_right_map : ('b -> 'a -> 'c * 'a) -> 'b list -> 'a -> 'c list * 'a
   (** Same, folding on the right *)
 
   val fold_left2_map : ('a -> 'b -> 'c -> 'a * 'd) -> 'a -> 'b list -> 'c list -> 'a * 'd list
   (** Same with two lists, folding on the left *)
+
+  val fold_left2_map_i : (int -> 'a -> 'b -> 'c -> 'a * 'd) -> int -> 'a -> 'b list -> 'c list -> 'a * 'd list
+  (** Same with a counter *)
 
   val fold_right2_map : ('b -> 'c -> 'a -> 'd * 'a) -> 'b list -> 'c list -> 'a -> 'd list * 'a
   (** Same with two lists, folding on the right *)

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -582,7 +582,6 @@ let rec check_and_clear_in_constr env evdref err ids global c =
               let filter = Evd.Filter.apply_subfilter origfilter filter in
               let evd = !evdref in
               let candidates = Evd.evar_candidates evi in
-              let candidates = Option.map (List.map EConstr.of_constr) candidates in
               let (evd,_) = restrict_evar evd evk filter candidates in
               evdref := evd;
               Evd.existential_value0 !evdref ev

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -135,7 +135,7 @@ val evar_filtered_context : evar_info -> (econstr, etypes) Context.Named.pt
 val evar_hyps : evar_info -> named_context_val
 val evar_filtered_hyps : evar_info -> named_context_val
 val evar_body : evar_info -> evar_body
-val evar_candidates : evar_info -> constr list option
+val evar_candidates : evar_info -> econstr list option
 val evar_filter : evar_info -> Filter.t
 val evar_env : env -> evar_info -> env
 val evar_filtered_env : env -> evar_info -> env

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -566,21 +566,17 @@ let rec evar_conv_x flags env evd pbty term1 term2 =
           | Evar ev, _ when Evd.is_undefined evd (fst ev) && is_evar_allowed flags (fst ev) ->
             (match solve_simple_eqn (conv_fun evar_conv_x) flags env evd
               (position_problem true pbty,ev,term2) with
-              | UnifFailure (_,(OccurCheck _ | NotClean _)) ->
+              | UnifFailure (_,NotClean _) ->
                 (* Eta-expansion might apply *)
-                (* OccurCheck: eta-expansion could solve
-                     ?X = {| foo := ?X.(foo) |}
-                   NotClean: pruning in solve_simple_eqn is incomplete wrt
+                (* NotClean: pruning in solve_simple_eqn is incomplete wrt
                      Miller patterns *)
                 default ()
               | x -> x)
           | _, Evar ev when Evd.is_undefined evd (fst ev) && is_evar_allowed flags (fst ev) ->
             (match solve_simple_eqn (conv_fun evar_conv_x) flags env evd
               (position_problem false pbty,ev,term1) with
-              | UnifFailure (_, (OccurCheck _ | NotClean _)) ->
-                (* OccurCheck: eta-expansion could solve
-                     ?X = {| foo := ?X.(foo) |}
-                   NotClean: pruning in solve_simple_eqn is incomplete wrt
+              | UnifFailure (_, NotClean _) ->
+                (* NotClean: pruning in solve_simple_eqn is incomplete wrt
                      Miller patterns *)
                 default ()
               | x -> x)

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -1380,7 +1380,7 @@ let thin_evars env sigma sign c =
        let evi = Evd.find_undefined !sigma ev in
        let filter = List.map (fun c -> Id.Set.subset (collect_vars !sigma c) ctx) args in
        let filter = Filter.make filter in
-       let candidates = Option.map (List.map EConstr.of_constr) (evar_candidates evi) in
+       let candidates = evar_candidates evi in
        let evd, ev = restrict_evar !sigma ev filter candidates in
        sigma := evd; whd_evar !sigma t
     | Var id ->
@@ -1529,11 +1529,11 @@ let second_order_matching flags env_rhs evd (evk,args) (test,argoccs) rhs =
              let evi = Evd.find evd ev in
                (match evar_candidates evi with
                | Some [t] ->
-                 if not (noccur_evar env_rhs evd ev (EConstr.of_constr t)) then
+                 if not (noccur_evar env_rhs evd ev t) then
                    raise (TypingFailed evd);
-                 instantiate_evar evar_unify flags env_rhs evd ev (EConstr.of_constr t)
+                 instantiate_evar evar_unify flags env_rhs evd ev t
                | Some l when abstract = Abstraction.Abstract &&
-                          List.exists (fun c -> isVarId evd id (EConstr.of_constr c)) l ->
+                          List.exists (fun c -> isVarId evd id c) l ->
                  instantiate_evar evar_unify flags env_rhs evd ev vid
                | _ -> evd)
            with IllTypedInstance _ (* from instantiate_evar *) | TypingFailed _ ->

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -246,6 +246,22 @@ let inductive_alltags env ind =
   let (mib,mip) = Inductive.lookup_mind_specif env ind in
   Context.Rel.to_tags mip.mind_arity_ctxt
 
+let constructor_nparams env (ind,_) =
+  let (mib,mip) = Inductive.lookup_mind_specif env ind in
+  mib.mind_nparams
+
+(* Length of arity (with local defs) *)
+
+let constructor_nparamdecls env (ind,_) =
+  let (mib,mip) = Inductive.lookup_mind_specif env ind in
+  Context.Rel.length mib.mind_params_ctxt
+
+(* Others *)
+
+let constructor_paramdecls env ((ind,_),u) =
+  let (mib,mip) = Inductive.lookup_mind_specif env ind in
+    Inductive.inductive_paramdecls (mib,u)
+
 let constructor_alltags env (ind,j) =
   let (mib,mip) = Inductive.lookup_mind_specif env ind in
   Context.Rel.to_tags (fst mip.mind_nf_lc.(j-1))

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -748,6 +748,24 @@ let type_of_projection_knowing_arg env sigma p c ty =
   let (_,u), pars = dest_ind_family pars in
   substl (c :: List.rev pars) (type_of_projection_constant env (p,u))
 
+module E =
+struct
+
+let instantiate_params t params sign =
+  let _,t = decompose_prod_n_assum (Context.Rel.length sign) t in
+  let open EConstr in
+  let subst = Vars.subst_of_rel_context_instance_list sign params in
+  Vars.substl subst (of_constr t)
+
+let nf_constructor_type_no_params ((ind,u as indu),mib,mip,params) j =
+  assert (j <= Array.length mip.mind_consnames);
+  let typi = mis_nf_constructor_type (indu,mib,mip) j in
+  let open EConstr in
+  let ctx = EConstr.Vars.subst_instance_context u (of_rel_context mib.mind_params_ctxt) in
+  instantiate_params typi params ctx
+
+end
+
 (***********************************************)
 (* Guard condition *)
 

--- a/pretyping/inductiveops.mli
+++ b/pretyping/inductiveops.mli
@@ -118,6 +118,15 @@ val inductive_alldecls_env : env -> pinductive -> Constr.rel_context
 
 (** {7 Extract information from a constructor name} *)
 
+(** @return nb of params without local defs *)
+val constructor_nparams : env -> constructor -> int
+
+(** @return nb of params with local defs *)
+val constructor_nparamdecls : env -> constructor -> int
+
+(** @return params context *)
+val constructor_paramdecls : env -> pconstructor -> Constr.rel_context
+
 (** @return param + args without letin *)
 val constructor_nallargs : env -> constructor -> int
 val constructor_nallargs_env : env -> constructor -> int

--- a/pretyping/inductiveops.mli
+++ b/pretyping/inductiveops.mli
@@ -57,7 +57,7 @@ val mis_is_recursive_subset : int list -> wf_paths -> bool
 val mis_is_recursive :
   inductive * mutual_inductive_body * one_inductive_body -> bool
 val mis_nf_constructor_type :
-  pinductive * mutual_inductive_body * one_inductive_body -> int -> constr
+  pinductive * mutual_inductive_body * one_inductive_body -> int -> types
 
 (** {6 Extract information from an inductive name} *)
 
@@ -229,6 +229,13 @@ val simple_make_case_or_project :
 
 val make_case_invert : env -> inductive_type -> case_info
   -> EConstr.case_invert
+
+module E :
+sig
+val nf_constructor_type_no_params :
+  (inductive * Univ.Instance.t) * mutual_inductive_body * one_inductive_body * EConstr.Vars.instance_list -> int -> EConstr.types
+
+end
 
 (*i Compatibility
 val make_default_case_info : env -> case_style -> inductive -> case_info

--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -167,6 +167,7 @@ val whd_betadeltazeta :  reduction_function
 val whd_zeta_stack : stack_reduction_function
 val whd_zeta : reduction_function
 
+val shrink_eta_all : env -> evar_map -> constr -> constr
 val shrink_eta : evar_map -> constr -> constr
 
 (** Various reduction functions *)

--- a/test-suite/bugs/closed/bug_10026.v
+++ b/test-suite/bugs/closed/bug_10026.v
@@ -1,3 +1,3 @@
 Require Import Coq.Lists.List.
-Set Debug RAKAM.
+Set Debug "RAKAM".
 Check fun _ => fold_right (fun A B => prod A B) unit _.

--- a/test-suite/bugs/closed/bug_3477.v
+++ b/test-suite/bugs/closed/bug_3477.v
@@ -6,5 +6,32 @@ Proof.
   intros A B.
   evar (a : prod A B); evar (f : (prod A B -> Set)).
   let a' := (eval unfold a in a) in
-  set(foo:=eq_refl : a' = (@pair _ _ (fst a') (snd a'))).
+  eset(foo:=eq_refl : a' = (@pair _ _ (fst a') (snd a'))).
+  (* check generated evar names *)
+  [fst]:idtac.
+  [snd]:idtac.
 Abort.
+
+(* Combining eta for arrow type and tuples *)
+Goal forall A B : Set, True.
+Proof.
+  intros A B.
+  evar (a : nat -> prod (A -> A -> A) B); evar (f : (nat -> prod (A -> A -> A) B) -> Set).
+  let a' := (eval unfold a in a) in
+  eset(foo:=eq_refl : a' = (fun x => pair (fun y y' => fst (a' x) y y') (snd (a' x)))).
+  (* check generated evar names *)
+  [fst]:idtac.
+  [snd]:idtac.
+Abort.
+
+Goal forall A B : Set, True.
+Proof.
+  intros A B.
+  evar (a : nat); evar (f : nat -> Set).
+  let a' := (eval unfold a in a) in
+  eset(foo:=eq_refl : a' = S (pred a')).
+Abort.
+
+(* An example with de Bruijn *)
+Check fun (z:nat) (z':z=z) =>
+  eq_refl : ?[q] = (fun x : z'=z' => pair (fun (y:x=x) (y':y=y) => fst (?q x) y y') (snd (?q x))).

--- a/test-suite/bugs/closed/bug_3594.v
+++ b/test-suite/bugs/closed/bug_3594.v
@@ -21,7 +21,7 @@ Goal forall C D : PreCategory,
   exact (path_forall (fun F : Functor C^op D^op => (F^op)^op) _ (@oppositeF_involutive _ _)).
   Undo.
   Unset Printing Notations.
-  Set Debug Unification.
+  Set Debug "unification".
 (*   Check (eq_refl : Build_PreCategory (opposite D).(object) *)
 (*                  (fun s d : (opposite D).(object) =>  *)
 (*                     (opposite D).(morphism) d s) =  *)

--- a/test-suite/bugs/closed/bug_3665.v
+++ b/test-suite/bugs/closed/bug_3665.v
@@ -12,7 +12,7 @@ Goal forall (z : hSet) (T0 : Type -> Type),
        (forall (A : Type) (P : T0 A -> Type) (aa : T0 A), P aa) ->
        forall x0 : setT z, Set.
   clear; intros z T H.
-  Set Debug Unification.
+  Set Debug "unification".
   Fail refine (H _ _). (* Timeout! *)
 Abort.
 End withdefault.
@@ -27,7 +27,7 @@ Goal forall (z : hSet) (T0 : Type -> Type),
        (forall (A : Type) (P : T0 A -> Type) (aa : T0 A), P aa) ->
        forall x0 : setT z, Set.
   clear; intros z T H.
-  Set Debug Unification.
+  Set Debug "unification".
   Fail refine (H _ _). (* Timeout! *)
 Abort.
 End withnondefault.

--- a/test-suite/bugs/closed/bug_3666.v
+++ b/test-suite/bugs/closed/bug_3666.v
@@ -14,7 +14,7 @@ Module NonPrim.
     intros A B H_f H_g C h b a c H3 H'.
     exact (@transport hProp (fun x => x) _ _ H' H3).
     Undo.
-    Set Debug Unification.
+    Set Debug "unification".
     exact (H' # H3).
   Defined.
 End NonPrim.
@@ -29,7 +29,7 @@ Module Prim.
     intros A B H_f H_g C h b a c H3 H'.
     exact (@transport hProp (fun x => x) _ _ H' H3).
     Undo.
-    Set Debug Unification.
+    Set Debug "unification".
     exact (H' # H3).
     (* Toplevel input, characters 7-14:
 Error:

--- a/test-suite/bugs/closed/bug_3782.v
+++ b/test-suite/bugs/closed/bug_3782.v
@@ -43,7 +43,7 @@ Module Prim.
                 (Build_TruncType 0 mc))
              e') as i || fail "too early"); clear i.
     Set Printing Existential Instances.
-    Set Debug Unification.
+    Set Debug "unification".
     pose (@isiso_isequiv'
             _ _ _
             e'). (* Toplevel input, characters 48-50:

--- a/test-suite/bugs/closed/bug_4097.v
+++ b/test-suite/bugs/closed/bug_4097.v
@@ -56,7 +56,7 @@ Definition path_path_sigma_uncurried {A : Type} (P : A -> Type) (u v : sigT P)
 : p = q.
 admit.
 Defined.
-Set Debug Unification.
+Set Debug "unification".
 Definition path_path_sigma {A : Type} (P : A -> Type) (u v : sigT P)
            (p q : u = v)
            (r : p..1 = q..1)

--- a/test-suite/bugs/closed/bug_4103.v
+++ b/test-suite/bugs/closed/bug_4103.v
@@ -8,6 +8,6 @@ Lemma expand : exists n : nat, (ticks n) = (ticks n).(tl _).
 Proof.
   eexists.
   (* Set Debug Tactic Unification. *)
-  (* Set Debug RAKAM. *)
+  (* Set Debug "RAKAM". *)
   reflexivity.
 Abort.

--- a/test-suite/success/unification.v
+++ b/test-suite/success/unification.v
@@ -203,3 +203,51 @@ Check
 (* An example involving SProp *)
 
 Check fun (A:SProp) (f g:A->A) (P:A->Type) a (x : P (f a)) => x : P (g _).
+
+Unset Implicit Arguments.
+
+Module FirstOrderHeuristicAndEta.
+(* An example involving first-order heuristic and eta-expansion *)
+
+Definition P 'tt := nat.
+Axiom Q : (unit -> Type) -> Type.
+
+(* Variant with named variables *)
+Axiom f : unit->Type.
+Axiom z1 : forall f x, f = (fun y => f y) -> Q f -> f x.
+Axiom z2 : forall f x, f = (fun y => f y) -> f x -> Q f.
+Check z1 ?[f] ?[x] eq_refl : Q (fun y => P y) -> P tt.
+Check z2 ?[f] ?[x] eq_refl : P tt -> Q (fun y => P y).
+Check z1 ?[f] ?[x] eq_refl : Q P -> P tt.
+Check z2 ?[f] ?[x] eq_refl : P tt -> Q P.
+
+Axiom z3 : forall f x, Q f -> f = (fun y => f y) -> f x.
+Axiom z4 : forall f x, f x -> f = (fun y => f y) -> Q f.
+Check fun a : Q (fun y => P y) => z3 ?[f] ?[x] a eq_refl : P tt.
+Check fun a : P tt => z4 ?[f] ?[x] a eq_refl : Q (fun y => P y).
+
+(* Variant with de Bruijn indices *)
+Check fun (f:unit->Type) (z:forall f x, f = (fun y => f y) -> Q f -> f x) => z ?[f] ?[x] eq_refl : Q (fun y => P y) -> P tt.
+Check fun (f:unit->Type) (z:forall f x, f = (fun y => f y) -> f x -> Q f) => z ?[f] ?[x] eq_refl : P tt -> Q (fun y => P y).
+Check fun (f:unit->Type) (z:forall f x, f = (fun y => f y) -> Q f -> f x) => z ?[f] ?[x] eq_refl : Q P -> P tt.
+Check fun (f:unit->Type) (z:forall f x, f = (fun y => f y) -> f x -> Q f) => z ?[f] ?[x] eq_refl : P tt -> Q P.
+
+(* Variants with an inner reduction *)
+Axiom z5 : forall f x, f = (fun y => id (f y)) -> f x -> Q f.
+Check z5 ?[f] ?[x] eq_refl : P tt -> Q P.
+Check z5 ?[f] ?[x] eq_refl : P tt -> Q (fun y => id (P y)).
+Check z5 ?[f] ?[x] eq_refl : P tt -> Q (fun y => id P y).
+
+Axiom z6 : forall f x, f = (fun y => id (f y)) -> Q f -> f x.
+Check z6 ?[f] ?[x] eq_refl : Q P -> P tt.
+(* Two following tests fail because conversion [id P ?x == P tt]
+   tries to reduce on the wrong side first *)
+Fail Check z6 ?[f] ?[x] eq_refl : Q (fun y => id (P y)) -> P tt.
+Fail Check z6 ?[f] ?[x] eq_refl : Q (fun y => id P y) -> P tt.
+
+(* Note: the following fail already, without involving eta *)
+Axiom z7 : forall x, id P x.
+Fail Check z7 ?[x] : P tt.
+Fail Check z7 ?[x] : P tt.
+
+End FirstOrderHeuristicAndEta.


### PR DESCRIPTION
**Kind:** unification enhancement

This PR implements a criterion to decide when a cyclic instantiation `?x := C[?x]` is actually acyclic.

The previous criterion included checking if `C` was empty, or, as in 3fdfb3ccb7, to reason module eta to support instantiations such as `?x := (fst ?x, snd ?x)`.

The extended criterion checks that all paths of the instance self-referring to the evar are eta-like paths, that is, looks like:
- C[] = []
- C[] = λx.([] x)
- C[] = S (pred [])
- C[] = {fst := fst []; snd := 0}
- C[] = λx.{fst := fst ([] x); snd := 0}

Interestingly, eta is actually not needed in the process. This is because eta-expansion is idempotent and the proof of idempotency uses only beta/iota.

This refines previous eta-based fixes to issues such as #3477 and this allows to get rid of a unification "hack" in `evar_conv_x` which is blocking #13126.

- [x] Added / updated **test-suite**.