### PR TITLE
Install expat and libxml2 in macOS deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          brew install gnu-time opam gtksourceview3 adwaita-icon-theme
+          brew install gnu-time opam gtksourceview3 adwaita-icon-theme expat libxml2
           pip3 install macpack
 
       - name: Install OCaml dependencies


### PR DESCRIPTION
I'm not sure which opam packages require `expat` and `libxml2`. Hopefully this will stop the CI from failing. 