### PR TITLE
Redesign import filter system for acceptable performance.

### DIFF
--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -282,6 +282,11 @@ are now available through the dot notation.
          Fail Check B.U.
          Check A.B.U.
 
+   .. warn:: Cannot import local constant, it will be ignored.
+
+      This warning is printed when a name in the list of names to
+      import was declared as a local constant, and the name is not imported.
+
 .. cmd:: Export {+ @filtered_import }
 
    Similar to :cmd:`Import`, except that when the module containing this command

--- a/interp/syntax_def.ml
+++ b/interp/syntax_def.ml
@@ -56,6 +56,10 @@ let open_syntax_constant i ((sp,kn),(_local,syndef)) =
       Notation.declare_uninterpretation ~also_in_cases_pattern:syndef.syndef_also_in_cases_pattern (Notation.SynDefRule kn) pat
   end
 
+let import_syntax_constant i sp kn =
+  let syndef = KNmap.get kn !syntax_table in
+  open_syntax_constant i ((sp,kn),(false,syndef))
+
 let cache_syntax_constant d =
   load_syntax_constant 1 d;
   open_syntax_constant 1 d
@@ -70,7 +74,6 @@ let classify_syntax_constant (local,_ as o) =
 let filtered_open_syntax_constant f i ((_,kn),_ as o) =
   let in_f = match f with
     | Unfiltered -> true
-    | Names ns -> Globnames.(ExtRefSet.mem (SynDef kn) ns)
   in
   if in_f then open_syntax_constant i o
 

--- a/interp/syntax_def.mli
+++ b/interp/syntax_def.mli
@@ -20,3 +20,5 @@ val search_syntactic_definition : ?loc:Loc.t -> KerName.t -> interpretation
 
 val search_filtered_syntactic_definition : ?loc:Loc.t ->
   (interpretation -> 'a option) -> KerName.t -> 'a option
+
+val import_syntax_constant : int -> Libnames.full_path -> KerName.t -> unit

--- a/library/libobject.ml
+++ b/library/libobject.ml
@@ -18,30 +18,22 @@ type 'a substitutivity =
 
 type object_name = Libnames.full_path * Names.KerName.t
 
-module NSet = Globnames.ExtRefSet
-
 type open_filter =
   | Unfiltered
-  | Names of NSet.t
+
 
 let simple_open f filter i o = match filter with
   | Unfiltered -> f i o
-  | Names _ -> ()
+
 
 let filter_and f1 f2 = match f1, f2 with
-  | Unfiltered, f | f, Unfiltered -> Some f
-  | Names n1, Names n2 ->
-    let n = NSet.inter n1 n2 in
-    if NSet.is_empty n then None
-    else Some (Names n)
+  | Unfiltered, f -> Some f
 
 let filter_or f1 f2 = match f1, f2 with
-  | Unfiltered, f | f, Unfiltered -> Unfiltered
-  | Names n1, Names n2 -> Names (NSet.union n1 n2)
+  | Unfiltered, f -> Unfiltered
 
 let in_filter_ref gr = function
   | Unfiltered -> true
-  | Names ns -> NSet.mem (Globnames.TrueGlobal gr) ns
 
 type 'a object_declaration = {
   object_name : string;

--- a/library/libobject.mli
+++ b/library/libobject.mli
@@ -72,7 +72,7 @@ type 'a substitutivity =
 
 type object_name = full_path * Names.KerName.t
 
-type open_filter = Unfiltered | Names of Globnames.ExtRefSet.t
+type open_filter = Unfiltered
 
 type 'a object_declaration = {
   object_name : string;

--- a/test-suite/success/PartialImport.v
+++ b/test-suite/success/PartialImport.v
@@ -56,3 +56,50 @@ Module WithExport.
   Fail Check b.
 
 End WithExport.
+
+Module IgnoreLocals.
+  Module X.
+    Local Definition x := 0.
+    Definition y := 1.
+  End X.
+
+  Set Warnings "+not-importable".
+  Fail Import X(x,y).
+  Set Warnings "-not-importable".
+  Import X(x,y).
+  Check y.
+  Fail Check x.
+  Check X.x.
+End IgnoreLocals.
+
+Module FancyFunctor.
+  (* A fancy behaviour with functors, not sure if we want to keep it
+     but at least the test will ensure changes are deliberate. *)
+
+  Module Type T.
+    Parameter x : nat.
+  End T.
+  Module X.
+    Definition x := 0.
+    Definition y := 1.
+  End X.
+
+  Module Y.
+    Local Definition x := 2.
+  End Y.
+
+  Module F(A:T).
+    Export A(x).
+  End F.
+  Module Import M := F X.
+  Check x.
+  Fail Check y.
+
+  Module N := F Y.
+  Set Warnings "+not-importable".
+  Fail Import N.
+  Set Warnings "-not-importable".
+  Import N.
+  Check eq_refl : x = 0.
+
+End FancyFunctor.

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -542,6 +542,8 @@ val check_program_libraries : unit -> unit
 
 end
 
+val is_local_constant : Constant.t -> bool
+
 (** {6 For internal support, do not use}  *)
 
 module Internal : sig

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -84,13 +84,6 @@ let sobjs_no_functor (mbids,_) = List.is_empty mbids
 let subst_filtered sub (f,mp) =
   let f = match f with
     | Unfiltered -> Unfiltered
-    | Names ns ->
-      let module NSet = Globnames.ExtRefSet in
-      let ns =
-        NSet.fold (fun n ns -> NSet.add (Globnames.subst_extended_reference sub n) ns)
-          ns NSet.empty
-      in
-      Names ns
   in
   f, subst_mp sub mp
 
@@ -375,7 +368,7 @@ and open_module f i obj_dir obj_mp sobjs =
   consistency_checks true obj_dir dirinfo;
   (match f with
    | Unfiltered -> Nametab.push_dir (Nametab.Exactly i) obj_dir dirinfo
-   | Names _ -> ());
+  );
   (* If we're not a functor, let's iter on the internal components *)
   if sobjs_no_functor sobjs then begin
     let modobjs = ModObjs.get obj_mp in


### PR DESCRIPTION
Fix #14570

Instead of running through all objects and testing that they match the
filter, we lookup the specific things we want to import.

Tested with a file all_stdlib.v containing
~~~coq
Require Export Reals.ROrderedType
Reals.Alembert
...

Definition toimport := Prop.
~~~
(similar to the one used in test-suite/misc/universes but with Export
+ a dummy definition)

then
~~~coq
Require all_stdlib.

Time Import all_stdlib(toimport).
~~~
Unfiltered import before and after the patch takes between 0.2s and 0.3s.
Filtered import:
- before the patch: 9s
- after the patch: 0s
- with another patch which tried to be smarter in
  Declaremods.open_module: 0.9s (this was not satisfying so I made the
  present redesign)

Dummy filters are still present for code compatibility, they may be
removed in a future commit, or reused for non-names types of
filters (eg filtering by kind of object (notations,coercions,etc)
should be faster as there is no need to compare many strings).
