### PR TITLE
Fix missing evar normalization when reifying match in vm/native norm

### DIFF
--- a/test-suite/bugs/closed/bug_13950.v
+++ b/test-suite/bugs/closed/bug_13950.v
@@ -1,0 +1,5 @@
+
+
+Record r := mk_r { x : unit }.
+Definition f y := Eval vm_compute in y.(x).
+Definition g y := Eval native_compute in y.(x).


### PR DESCRIPTION
Fix #13950
