### PR TITLE
Fix simpl with pattern an ltac variable bound to a term with evars.

### DIFF
--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -717,7 +717,7 @@ let interp_closed_typed_pattern_with_occurrences ist env sigma (occs, a) =
       try Inl (coerce_to_evaluable_ref env sigma x)
       with CannotCoerceTo _ ->
         let c = coerce_to_closed_constr env x in
-        Inr (pattern_of_constr env sigma (EConstr.to_constr sigma c)) in
+        Inr (pattern_of_constr env sigma (EConstr.Unsafe.to_constr c)) in
     (try try_interp_ltac_var coerce_eval_ref_or_constr ist (Some (env,sigma)) (make ?loc id)
      with Not_found as exn ->
        let _, info = Exninfo.capture exn in

--- a/test-suite/bugs/closed/bug_13933.v
+++ b/test-suite/bugs/closed/bug_13933.v
@@ -1,0 +1,8 @@
+Set Warnings "-remaining-shelved-goals".
+Goal 1 + 1 = 2.
+Proof.
+  Fail match goal with |- ?l = ?l => idtac end.
+  let p := open_constr:(_ + _) in simpl p.
+  match goal with |- ?l = ?l => idtac end.
+  reflexivity.
+Qed.


### PR DESCRIPTION
Fix #13933

Not sure if normalizing the term would have an effect.