### PR TITLE
Preserve \r in XML and don't bump the line count for it

### DIFF
--- a/ide/coqide/coq.ml
+++ b/ide/coqide/coq.ml
@@ -319,7 +319,7 @@ let unsafe_handle_input handle (feedback_processor, ltac_debug_processor) state 
   let lex = Lexing.from_string s in
   let p = Xml_parser.make (Xml_parser.SLexbuf lex) in
   let rec loop () =
-    let xml = Xml_parser.parse ~do_not_canonicalize:true p in
+    let xml = Xml_parser.parse ~canonicalize:false p in
     let l_end = Lexing.lexeme_end lex in
     state.fragment <- String.sub s l_end (String.length s - l_end);
     state.lexerror <- None;

--- a/ide/coqide/protocol/xml_lexer.mll
+++ b/ide/coqide/protocol/xml_lexer.mll
@@ -94,7 +94,11 @@ let entitychar = ['A'-'Z' 'a'-'z']
 let pcchar = [^ '\r' '\n' '<' '>' '&']
 
 rule token = parse
-        | newline | (newline break) | break
+        | break
+                {
+                        PCData "\r"
+                }
+        | newline
                 {
                         newline lexbuf;
                         PCData "\n"
@@ -153,7 +157,11 @@ rule token = parse
                 { error lexbuf ENodeExpected }
 
 and ignore_spaces = parse
-        | newline | (newline break) | break
+        | break
+                {
+                        ignore_spaces lexbuf
+                }
+        | newline
                 {
                         newline lexbuf;
                         ignore_spaces lexbuf
@@ -164,7 +172,11 @@ and ignore_spaces = parse
                 { () }
 
 and comment = parse
-        | newline | (newline break) | break
+        | break
+                {
+                        comment lexbuf
+                }
+        | newline
                 {
                         newline lexbuf;
                         comment lexbuf
@@ -177,7 +189,11 @@ and comment = parse
                 { comment lexbuf }
 
 and header = parse
-        | newline | (newline break) | break
+        | break
+                {
+                        header lexbuf
+                }
+        | newline
                 {
                         newline lexbuf;
                         header lexbuf
@@ -190,7 +206,12 @@ and header = parse
                 { header lexbuf }
 
 and pcdata = parse
-        | newline | (newline break) | break
+        | break
+                {
+                        Buffer.add_char tmp '\r';
+                        pcdata lexbuf
+                }
+        | newline
                 {
                         Buffer.add_char tmp '\n';
                         newline lexbuf;

--- a/ide/coqide/protocol/xml_parser.mli
+++ b/ide/coqide/protocol/xml_parser.mli
@@ -101,6 +101,5 @@ val check_eof : t -> bool -> unit
 (** Once the parser is configured, you can run the parser on a any kind
     of xml document source to parse its contents into an Xml data structure.
 
-    When [do_not_canonicalize] is set, the XML document is given as
-    is, without trying to remove blank PCDATA elements. *)
-val parse : ?do_not_canonicalize:bool -> t -> xml
+    When [canonicalize] is set, the parser tries to remove blank PCDATA elements. *)
+val parse : ?canonicalize:bool -> t -> xml


### PR DESCRIPTION
`xml_lexer.mll` converts `\n\r` in XML strings to a single `\n`, which throws off the character offsets and line numbers that the debugger relies on for setting breakpoints and highlighting code.

The lexer also converts a single `\r` to a `\n`.  This makes sense for the old Mac line ending convention, which was a `\r` without `\n`.  IIUC MacOS now uses `\n`, like Linux.  If that's correct, then this should be a reasonable and clean fix.  Is there Mac maven in the house?

Also, BTW, the Windows convention is `\r\n`, not `\n\r`.  I'd expect that would throw things off on Windows though I didn't check (I don't develop on native Windows now, rather WSL/Ubuntu).

This change preserves `\r` and doesn't bump the line number.

Alternative fixes are:
- in the lexer, convert `\r\n` and `\n\r`  to "` \n`" and keep bare `\r` as is
- something similar on the CoqIDE side

I ran into this problem by creating my .v with a Windows native editor and then running CoqIDE in Ubuntu.  Good idea to address this in the name of robustness.

The PR includes a bit of unrelated code cleanup.