### PR TITLE
Correctly set prefix when no default is given.

### DIFF
--- a/tools/configure/configure.ml
+++ b/tools/configure/configure.ml
@@ -1148,7 +1148,9 @@ let write_makefile f =
   List.iter (fun (v,msg,_,_) -> pr "# %s: path for %s\n" v msg) install_dirs;
   List.iter (fun (v,_,dir,_) -> pr "%s=%S\n" v dir) install_dirs;
   pr "\n# Coq version\n";
-  pr "COQPREFIX=%s\n" ((function None -> "local" | Some v -> v) !prefs.prefix);
+  pr "COQPREFIX=%s\n" ((function
+    | None -> if unix then "/usr/local" else "C:/coq"
+    | Some v -> v) !prefs.prefix);
   pr "VERSION=%s\n" coq_version;
   pr "# Objective-Caml compile command\n";
   pr "OCAML=%S\n" camlexec.top;


### PR DESCRIPTION
The behavior before was defaulting on the deprecated "local"
option. This doesn't make sense since "-local" is just an alias for
"-profile devel" which sets the prefix anyway. Therefore, when no
prefix is given, as is often the case, we should use the default
prefix which can be found in `do_one_instdir`. Of course, this is only
a hack to get things working for the time being. The correct solution
would be to rewrite the entire configure.ml file to not have such
ad-hoc reasoning.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #14468

Rewriting configure.ml is currently in progress in #14189 but it doesn't make sense for #14468 to wait for the completion of such a big task. Especially since it is blocking 8.14.