### PR TITLE
Default HintDb option

### DIFF
--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -316,6 +316,7 @@ let add_rewrite_hint ~locality ~poly bases ort t lcsr =
       CAst.make ?loc:(Constrexpr_ops.constr_loc ce) ((c, ctx), ort, Option.map (in_gen (rawwit wit_ltac)) t) in
   let eqs = List.map f lcsr in
   let add_hints base = add_rew_rules ~locality base eqs in
+  let bases = Hints.process_hint_db_names bases in
   List.iter add_hints bases
 
 let classify_hint _ = VtSideff ([], VtLater)
@@ -331,9 +332,9 @@ VERNAC COMMAND EXTEND HintRewrite CLASSIFIED BY { classify_hint }
     ":" preident_list(bl) ] ->
   { add_rewrite_hint ~locality ~poly:polymorphic bl o (Some t) l }
 | #[ polymorphic; locality = hint_rewrite_locality; ] [ "Hint" "Rewrite" orient(o) ne_constr_list(l) ] ->
-  { add_rewrite_hint ~locality ~poly:polymorphic ["core"] o None l }
+  { add_rewrite_hint ~locality ~poly:polymorphic [] o None l }
 | #[ polymorphic; locality = hint_rewrite_locality; ] [ "Hint" "Rewrite" orient(o) ne_constr_list(l) "using" tactic(t) ] ->
-  { add_rewrite_hint ~locality ~poly:polymorphic ["core"] o (Some t) l }
+  { add_rewrite_hint ~locality ~poly:polymorphic [] o (Some t) l }
 END
 
 (**********************************************************************)

--- a/plugins/ltac/g_auto.mlg
+++ b/plugins/ltac/g_auto.mlg
@@ -170,9 +170,9 @@ END
 
 TACTIC EXTEND autounfold_one
 | [ "autounfold_one" hintbases(db) "in" hyp(id) ] ->
-    { Eauto.autounfold_one (match db with None -> ["core"] | Some x -> "core"::x) (Some (id, Locus.InHyp)) }
+    { Eauto.autounfold_one (Option.default [] db) (Some (id, Locus.InHyp)) }
 | [ "autounfold_one" hintbases(db) ] ->
-    { Eauto.autounfold_one (match db with None -> ["core"] | Some x -> "core"::x) None }
+    { Eauto.autounfold_one (Option.default [] db) None }
       END
 
 TACTIC EXTEND unify
@@ -242,7 +242,6 @@ END
 VERNAC COMMAND EXTEND HintCut CLASSIFIED AS SIDEFF
 | #[ locality = Attributes.really_hint_locality; ] [ "Hint" "Cut" "[" hints_path(p) "]" opthints(dbnames) ] -> {
   let entry = Hints.HintsCutEntry (Hints.glob_hints_path p) in
-  Hints.add_hints ~locality
-    (match dbnames with None -> ["core"] | Some l -> l) entry;
+  Hints.add_hints ~locality (Option.default [] dbnames) entry;
  }
 END

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -346,9 +346,6 @@ and trivial_resolve env sigma dbg db_list local_db secvars cl =
             (my_find_search env sigma db_list local_db secvars head cl))
   with Not_found -> []
 
-(** The use of the "core" database can be de-activated by passing
-    "nocore" amongst the databases. *)
-
 let trivial ?(debug=Off) lems dbnames =
   Hints.wrap_hint_warning @@
   Proofview.Goal.enter begin fun gl ->

--- a/tactics/auto.mli
+++ b/tactics/auto.mli
@@ -34,15 +34,12 @@ val conclPattern : constr -> constr_pattern option -> Genarg.glob_generic_argume
 
 (** The Auto tactic *)
 
-(** The use of the "core" database can be de-activated by passing
-    "nocore" amongst the databases. *)
-
 val auto : ?debug:debug ->
   int -> delayed_open_constr list -> hint_db_name list -> unit Proofview.tactic
 
 (** Auto with more delta. *)
 
-(** auto with default search depth and with the hint database "core" *)
+(** auto with default search depth *)
 val default_auto : unit Proofview.tactic
 
 (** auto with all hint databases *)

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -422,9 +422,7 @@ let autounfold_tac db cls =
   Proofview.tclUNIT () >>= fun () ->
   let dbs = match db with
   | None -> String.Set.elements (current_db_names ())
-  | Some [] -> ["core"]
-  | Some l -> l
-  in
+  | Some l -> process_hint_db_names l in
   autounfold dbs cls
 
 let unfold_head env sigma (ids, csts) c =
@@ -461,6 +459,7 @@ let unfold_head env sigma (ids, csts) c =
   in aux c
 
 let autounfold_one db cl =
+  let db = process_hint_db_names db in
   Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
   let sigma = Tacmach.New.project gl in

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -192,6 +192,15 @@ val current_db_names : unit -> String.Set.t
 
 val current_pure_db : unit -> hint_db list
 
+val get_default_hint_db_name : unit -> hint_db_name option
+(** Get the set default hint database name. *)
+
+val default_hint_db_name : unit -> hint_db_name
+(** Get the set default hint database name, but raise an exception if no default is set. *)
+
+val process_hint_db_names : hint_db_name list -> hint_db_name list
+(** If the list is empty, returns a singleton containing the default name. Otherwise returns the same list. *)
+
 val add_hints : locality:hint_locality -> hint_db_name list -> hints_entry -> unit
 
 val hint_globref : GlobRef.t -> hint_term

--- a/test-suite/output/DefaultHintDb.out
+++ b/test-suite/output/DefaultHintDb.out
@@ -1,0 +1,11 @@
+Current value of Default HintDb is "core"
+The command has indeed failed with message:
+No such Hint database: foo.
+Current value of Default HintDb is "foo"
+The command has indeed failed with message:
+Failed to progress.
+Current value of Default HintDb is "core"
+The command has indeed failed with message:
+No default hint database set. Set one with the option Default HintDb.
+The command has indeed failed with message:
+No default hint database set. Set one with the option Default HintDb.

--- a/test-suite/output/DefaultHintDb.v
+++ b/test-suite/output/DefaultHintDb.v
@@ -34,10 +34,10 @@ Abort.
 
 Set Default HintDb "core".
 
-Lemma foo : nat := 5.
+Definition foo : nat := 5.
 
-Succeed Hint Resolve foo.
+Succeed #[local] Hint Resolve foo.
 
 Unset Default HintDb.
 
-Fail Hint Resolve foo.
+Fail #[local] Hint Resolve foo.

--- a/test-suite/output/DefaultHintDb.v
+++ b/test-suite/output/DefaultHintDb.v
@@ -1,0 +1,43 @@
+Print Table Default HintDb.
+
+Fail Set Default HintDb "foo".
+
+Goal forall x y, S x = S y -> x = y.
+progress auto.
+Qed.
+
+Module Foo.
+
+Create HintDb foo.
+
+Set Default HintDb "foo".
+
+Print Table Default HintDb.
+
+Goal forall x y, S x = S y -> x = y.
+Fail progress auto.
+Abort.
+
+End Foo.
+
+Print Table Default HintDb.
+
+Goal forall x y, S x = S y -> x = y.
+progress auto.
+Qed.
+
+Unset Default HintDb.
+
+Goal forall x y, S x = S y -> x = y.
+Fail progress auto.
+Abort.
+
+Set Default HintDb "core".
+
+Lemma foo : nat := 5.
+
+Succeed Hint Resolve foo.
+
+Unset Default HintDb.
+
+Fail Hint Resolve foo.

--- a/theories/Init/Logic.v
+++ b/theories/Init/Logic.v
@@ -39,15 +39,20 @@ Register not as core.not.type.
 
 (** Create the "core" hint database, and set its transparent state for
   variables and constants explicitly. *)
-
 Create HintDb core.
-#[global]
-Hint Variables Opaque : core.
-#[global]
-Hint Constants Opaque : core.
+#[global] Hint Variables Opaque : core.
+#[global] Hint Constants Opaque : core.
+
+(** Set "core" as the default hint database. *)
+#[global] Set Default HintDb "core".
+
+(** Create the "nocore" hint database. This hint database has a special status
+    in that trying to add hints will result in an error. It can be used in order
+    to not specify a hint database when using [auto], [eauto], etc.*)
+Create HintDb nocore.
 
 #[global]
-Hint Unfold not: core.
+Hint Unfold not : core.
 
   (** [and A B], written [A /\ B], is the conjunction of [A] and [B]
 

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1419,26 +1419,11 @@ let vernac_restore_state file =
 let vernac_create_hintdb ~module_local id b =
   Hints.create_hint_db module_local id TransparentState.full b
 
-let warn_implicit_core_hint_db =
-  CWarnings.create ~name:"implicit-core-hint-db" ~category:"deprecated"
-         (fun () -> strbrk "Adding and removing hints in the core database implicitly is deprecated. "
-             ++ strbrk"Please specify a hint database.")
-
 let vernac_remove_hints ~atts dbnames ids =
   let locality = Attributes.(parse really_hint_locality atts) in
-  let dbnames =
-    if List.is_empty dbnames then
-      (warn_implicit_core_hint_db (); ["core"])
-    else dbnames
-  in
   Hints.remove_hints ~locality dbnames (List.map Smartlocate.global_with_alias ids)
 
 let vernac_hints ~atts dbnames h =
-  let dbnames =
-    if List.is_empty dbnames then
-      (warn_implicit_core_hint_db (); ["core"])
-    else dbnames
-  in
   let locality, poly = Attributes.(parse Notations.(really_hint_locality ++ polymorphic) atts) in
   Hints.add_hints ~locality dbnames (ComHints.interp_hints ~poly h)
 


### PR DESCRIPTION
We add a `Default HintDb` optional string that will let users set which hint database we fall back on when tactics such as `auto` and `eauto` are used. At the moment, such behavior is de facto claimed by `core`, so we set `core` as the default hint database in the stdlib globally.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #10559

Related is #14752 but there is a more bold feature proposed there.

- [x] Added / updated **test-suite**.
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make -f Makefile.make doc_gram_rsts`.
- [ ] Opened **overlay** pull requests.
  - Expected overlays (these don't use stdlib so "core" is not set to default):
    - [ ] Overlay for stdlib2
    - [ ] Overlay for HoTT

I've marked this PR as a draft as there is more work to do:

I've changed the semantics (by accident) for "nocore". I've found #2188 discussing the indented semantics. When I first wrote this patch, I completely removed the nocore database and tried to replace it with setting and unsetting the default hint database, but this didn't really work as intended. I therefore reverted to touching the behaviour of nocore as little as possible but it seems I haven't been successful in this regard.

I would like to perhaps add a modifier to `auto` and `eauto` which lets them skip the addition of the default hint database to a list. This ought to subsume the behaviour of nocore.

`typeclasses eauto` is another problem I didn't really want to get into but, I suppose needs to be discussed. It acts like `typeclass_instances` is it's core database, and I have even seen uses of it using the (psuedo)database nocore in the test-suite. I am unsure what needs to be done here.
