### PR TITLE
More modular typed_vernac implementation

### DIFF
--- a/coqpp/coqpp_main.ml
+++ b/coqpp/coqpp_main.ml
@@ -349,21 +349,21 @@ let print_atts_right fmt = function
     fprintf fmt "(Attributes.parse %s%a atts)" nota aux atts
 
 let understand_state = function
-  | "close_proof" -> "VtCloseProof", false
-  | "open_proof" -> "VtOpenProof", true
-  | "proof" -> "VtModifyProof", false
-  | "proof_opt_query" -> "VtReadProofOpt", false
-  | "proof_query" -> "VtReadProof", false
-  | "read_program" -> "VtReadProgram", false
-  | "program" -> "VtModifyProgram", false
-  | "declare_program" -> "VtDeclareProgram", false
-  | "program_interactive" -> "VtOpenProofProgram", false
+  | "close_proof" -> "vtcloseproof", false
+  | "open_proof" -> "vtopenproof", true
+  | "proof" -> "vtmodifyproof", false
+  | "proof_opt_query" -> "vtreadproofopt", false
+  | "proof_query" -> "vtreadproof", false
+  | "read_program" -> "vtreadprogram", false
+  | "program" -> "vtmodifyprogram", false
+  | "declare_program" -> "vtdeclareprogram", false
+  | "program_interactive" -> "vtopenproofprogram", false
   | s -> fatal ("unsupported state specifier: " ^ s)
 
 let print_body_state state fmt r =
   let state = match r.vernac_state with Some _ as s -> s | None -> state in
   match state with
-  | None -> fprintf fmt "Vernacextend.VtDefault (fun () -> %a)" print_code r.vernac_body
+  | None -> fprintf fmt "Vernacextend.vtdefault (fun () -> %a)" print_code r.vernac_body
   | Some "CUSTOM" -> print_code fmt r.vernac_body
   | Some state ->
     let state, unit_wrap = understand_state state in

--- a/dev/ci/user-overlays/14779-SkySkimmer-typed-vernac-modular.sh
+++ b/dev/ci/user-overlays/14779-SkySkimmer-typed-vernac-modular.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/SkySkimmer/coq-elpi typed-vernac-modular 14779

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -573,7 +573,7 @@ let _ =
   let open Vernacextend in
   let ty_constr = Extend.TUentry (get_arg_tag Stdarg.wit_constr) in
   let cmd_sig = TyTerminal("PrintConstr", TyNonTerminal(ty_constr, TyNil)) in
-  let cmd_fn c ?loc:_ ~atts () = VtDefault (fun () -> in_current_context econstr_display c) in
+  let cmd_fn c ?loc:_ ~atts () = vtdefault (fun () -> in_current_context econstr_display c) in
   let cmd_class _ = VtQuery in
   let cmd : ty_ml = TyML (false, cmd_sig, cmd_fn, Some cmd_class) in
   vernac_extend ~command:"PrintConstr" [cmd]
@@ -582,7 +582,7 @@ let _ =
   let open Vernacextend in
   let ty_constr = Extend.TUentry (get_arg_tag Stdarg.wit_constr) in
   let cmd_sig = TyTerminal("PrintPureConstr", TyNonTerminal(ty_constr, TyNil)) in
-  let cmd_fn c ?loc:_ ~atts () = VtDefault (fun () -> in_current_context print_pure_econstr c) in
+  let cmd_fn c ?loc:_ ~atts () = vtdefault (fun () -> in_current_context print_pure_econstr c) in
   let cmd_class _ = VtQuery in
   let cmd : ty_ml = TyML (false, cmd_sig, cmd_fn, Some cmd_class) in
   vernac_extend ~command:"PrintPureConstr" [cmd]

--- a/plugins/funind/g_indfun.mlg
+++ b/plugins/funind/g_indfun.mlg
@@ -210,11 +210,11 @@ VERNAC COMMAND EXTEND Function STATE CUSTOM
     -> {
     let warn = "-unused-pattern-matching-variable,-matching-variable,-non-recursive" in
     if is_interactive recsl then
-      Vernacextend.VtOpenProof (fun () ->
+      Vernacextend.vtopenproof (fun () ->
           CWarnings.with_warn warn
             Gen_principle.do_generate_principle_interactive (List.map snd recsl))
     else
-      Vernacextend.VtDefault (fun () ->
+      Vernacextend.vtdefault (fun () ->
           CWarnings.with_warn warn
             Gen_principle.do_generate_principle (List.map snd recsl))
   }

--- a/plugins/ltac/g_obligations.mlg
+++ b/plugins/ltac/g_obligations.mlg
@@ -151,13 +151,13 @@ VERNAC COMMAND EXTEND Show_Solver CLASSIFIED AS QUERY
 END
 
 VERNAC COMMAND EXTEND Show_Obligations CLASSIFIED AS QUERY STATE read_program
-| [ "Obligations" "of" identref(name) ] -> { fun ~stack:_ -> show_obligations (Some name.CAst.v) }
-| [ "Obligations" ] -> { fun ~stack:_ -> show_obligations None }
+| [ "Obligations" "of" identref(name) ] -> { fun ~pm -> show_obligations ~pm (Some name.CAst.v) }
+| [ "Obligations" ] -> { fun ~pm -> show_obligations ~pm None }
 END
 
 VERNAC COMMAND EXTEND Show_Preterm CLASSIFIED AS QUERY STATE read_program
-| [ "Preterm" "of" identref(name) ] -> { fun ~stack:_ ~pm -> Feedback.msg_notice (show_term ~pm (Some name.CAst.v)) }
-| [ "Preterm" ] -> { fun ~stack:_ ~pm -> Feedback.msg_notice (show_term ~pm None) }
+| [ "Preterm" "of" identref(name) ] -> { fun ~pm -> Feedback.msg_notice (show_term ~pm (Some name.CAst.v)) }
+| [ "Preterm" ] -> { fun ~pm -> Feedback.msg_notice (show_term ~pm None) }
 END
 
 {

--- a/test-suite/bugs/closed/bug_12138.v
+++ b/test-suite/bugs/closed/bug_12138.v
@@ -1,0 +1,2 @@
+Fail {
+Fail }

--- a/test-suite/bugs/closed/bug_14781.v
+++ b/test-suite/bugs/closed/bug_14781.v
@@ -1,0 +1,1 @@
+Fail Proof.

--- a/vernac/vernacextend.mli
+++ b/vernac/vernacextend.mli
@@ -69,18 +69,75 @@ and proof_block_name = string (** open type of delimiters *)
 
 (** Interpretation of extended vernac phrases. *)
 
+module InProg : sig
+  type _ t =
+    | Ignore : unit t
+    | Use : Declare.OblState.t t
+
+  val cast : Declare.OblState.t -> 'a t -> 'a
+end
+
+module OutProg : sig
+  type _ t =
+    | No : unit t
+    | Yes : Declare.OblState.t t
+
+  val cast : 'a -> 'a t -> Declare.OblState.t option
+end
+
+module InProof : sig
+  type _ t =
+    | Ignore : unit t
+    | Reject : unit t
+    | Use : Declare.Proof.t t
+    | UseOpt : Declare.Proof.t option t
+
+  val cast : Declare.Proof.t option -> 'a t -> 'a
+end
+
+module OutProof : sig
+  type _ t =
+    | No : unit t
+    | Close : unit t
+    | Yes : Declare.Proof.t t
+
+  type result =
+    | Ignored
+    | Closed
+    | Open of Declare.Proof.t
+
+  val cast : 'a -> 'a t -> result
+end
+
+type ('inprog,'outprog,'inproof,'outproof) vernac_type = {
+  inprog : 'inprog InProg.t;
+  outprog : 'outprog InProg.t;
+  inproof : 'inproof InProof.t;
+  outproof : 'outproof OutProof.t;
+}
+
 type typed_vernac =
-  | VtDefault of (unit -> unit)
-  | VtNoProof of (unit -> unit)
-  | VtCloseProof of (lemma:Declare.Proof.t -> pm:Declare.OblState.t -> Declare.OblState.t)
-  | VtOpenProof of (unit -> Declare.Proof.t)
-  | VtModifyProof of (pstate:Declare.Proof.t -> Declare.Proof.t)
-  | VtReadProofOpt of (pstate:Declare.Proof.t option -> unit)
-  | VtReadProof of (pstate:Declare.Proof.t -> unit)
-  | VtReadProgram of (stack:Vernacstate.LemmaStack.t option -> pm:Declare.OblState.t -> unit)
-  | VtModifyProgram of (pm:Declare.OblState.t -> Declare.OblState.t)
-  | VtDeclareProgram of (pm:Declare.OblState.t -> Declare.Proof.t)
-  | VtOpenProofProgram of (pm:Declare.OblState.t -> Declare.OblState.t * Declare.Proof.t)
+    TypedVernac : {
+      inprog : 'inprog InProg.t;
+      outprog : 'outprog OutProg.t;
+      inproof : 'inproof InProof.t;
+      outproof : 'outproof OutProof.t;
+      run : pm:'inprog -> proof:'inproof -> 'outprog * 'outproof;
+    } -> typed_vernac
+
+(** Some convenient typed_vernac constructors *)
+
+val vtdefault : (unit -> unit) -> typed_vernac
+val vtnoproof : (unit -> unit) -> typed_vernac
+val vtcloseproof : (lemma:Declare.Proof.t -> pm:Declare.OblState.t -> Declare.OblState.t) -> typed_vernac
+val vtopenproof : (unit -> Declare.Proof.t) -> typed_vernac
+val vtmodifyproof : (pstate:Declare.Proof.t -> Declare.Proof.t) -> typed_vernac
+val vtreadproofopt : (pstate:Declare.Proof.t option -> unit) -> typed_vernac
+val vtreadproof : (pstate:Declare.Proof.t -> unit) -> typed_vernac
+val vtreadprogram : (pm:Declare.OblState.t -> unit) -> typed_vernac
+val vtmodifyprogram : (pm:Declare.OblState.t -> Declare.OblState.t) -> typed_vernac
+val vtdeclareprogram : (pm:Declare.OblState.t -> Declare.Proof.t) -> typed_vernac
+val vtopenproofprogram : (pm:Declare.OblState.t -> Declare.OblState.t * Declare.Proof.t) -> typed_vernac
 
 type vernac_command = ?loc:Loc.t -> atts:Attributes.vernac_flags -> unit -> typed_vernac
 

--- a/vernac/vernacstate.ml
+++ b/vernac/vernacstate.ml
@@ -88,6 +88,7 @@ module LemmaStack = struct
     | pp :: p -> ps, Some (pp, p)
 
   let with_top (p, _) ~f = f p
+  let get_top (p, _) = p
 
   let push ontop a =
     match ontop with

--- a/vernac/vernacstate.mli
+++ b/vernac/vernacstate.mli
@@ -43,6 +43,7 @@ module LemmaStack : sig
   val map : f:(Declare.Proof.t -> Declare.Proof.t) -> t -> t
   val map_top : f:(Declare.Proof.t -> Declare.Proof.t) -> t -> t
   val with_top : t -> f:(Declare.Proof.t -> 'a ) -> 'a
+  val get_top : t -> Declare.Proof.t
 
 end
 


### PR DESCRIPTION
Plugins should keep working unless they used CUSTOM or read_program

CUSTOM is obviously unstable.

As can be seen in the diff, read_program also used to read the proof
stack because it was reused for section/module End. We now use a
special typed vernac for segment end.

coqpp does not yet expose the new system (other than through CUSTOM),
needing some thought into how the syntax should look and/or user demand.

Overlay https://github.com/LPCIC/coq-elpi/pull/281
Waiting for https://github.com/coq/coq/pull/14783