### PR TITLE
More principled implementation of Btermdnet matching

### DIFF
--- a/tactics/btermdn.ml
+++ b/tactics/btermdn.ml
@@ -121,11 +121,7 @@ let constr_val_discr env sigma ts t =
 
 let constr_pat_discr env ts t =
   let open GlobRef in
-  if Option.is_empty ts && not (Patternops.occur_meta_pattern t) then
-    (* Extremely fishy, and breaks very quickly when fiddled with. Why should
-       **ground** terms match **everything** when non-discriminated??? *)
-    None
-  else match decomp_pat t with
+  match decomp_pat t with
   | PRef ((IndRef _) as ref), args
   | PRef ((ConstructRef _ ) as ref), args -> Some (GRLabel ref,args)
   | PRef ((VarRef v) as ref), args ->

--- a/tactics/btermdn.ml
+++ b/tactics/btermdn.ml
@@ -89,7 +89,12 @@ let evaluable_named id env ts =
   (try Environ.evaluable_named id env with Not_found -> true) &&
   (match ts with None -> true | Some ts -> TransparentState.is_transparent_variable ts id)
 
+(* The pattern view functions below try to overapproximate βι-neutral terms up
+   to η-conversion. Some historical design choices are still incorrect w.r.t. to
+   this specification. TODO: try to make them follow the spec. *)
+
 let constr_val_discr env sigma ts t =
+  (* Should we perform weak βι here? *)
   let c, l = decomp sigma t in
   let open GlobRef in
     match EConstr.kind sigma c with
@@ -104,11 +109,14 @@ let constr_val_discr env sigma ts t =
     | Prod (n, d, c) ->
       Label(ProdLabel, [d; c])
     | Lambda (n, d, c) ->
-      if Option.is_empty ts then Nothing
+      if Option.is_empty ts && List.is_empty l then Nothing
       else Everything
     | Sort _ -> Label(SortLabel, [])
     | Evar _ -> if Option.is_empty ts then Nothing else Everything
-    | Rel _ | Meta _ | Cast _ | LetIn _ | App _ | Case _ | Fix _ | CoFix _
+    | Case (_, _, _, _, _, c, _) ->
+      (* Overapproximate wildly. TODO: be less brutal. *)
+      Everything
+    | Rel _ | Meta _ | Cast _ | LetIn _ | App _ | Fix _ | CoFix _
     | Proj _ | Int _ | Float _ | Array _ -> Nothing
 
 let constr_pat_discr env ts t =

--- a/test-suite/bugs/closed/bug_13209.v
+++ b/test-suite/bugs/closed/bug_13209.v
@@ -1,0 +1,8 @@
+Class A (n : nat) := {}.
+Definition three := 3.
+Instance A_three : A three := {}.
+Definition three' := if true then three else 1.
+(* 1 *) Goal A (if true then three else 1). apply _. Qed.
+Hint Opaque three : typeclass_instances.
+(* 2 *) Goal A (if true then three else 1). apply _. Qed.
+(* 3 *) Goal A (three'). apply _. Qed.

--- a/test-suite/bugs/closed/bug_14788.v
+++ b/test-suite/bugs/closed/bug_14788.v
@@ -1,0 +1,17 @@
+Definition ptr64 := false.
+
+Inductive val: Set := Vundef: val.
+
+Inductive lessdef: val -> val -> Prop := lessdef_undef: forall v, lessdef Vundef v.
+
+Global Hint Resolve lessdef_undef : foo.
+
+Axiom memval : Set.
+Axiom load_result : memval -> val.
+
+Lemma foo : forall (v : val)
+  (vl' : memval), lessdef (if ptr64 then load_result vl' else Vundef) v.
+Proof.
+intros vl'.
+auto with foo.
+Qed.


### PR DESCRIPTION
We try to move closer to an overapproximation of neutral forms for βι-reduction, up to η-conversion. Before, case nodes were incorrectly mapped to Nothing, even if they could have ι-reduced to an arbitrary term. Now we consider them to match anything, which is a bit violent and should probably be handled in a more subtle manner in a future patch. We also handle undiscriminated β-redexes as arbitrary patterns for good measure.

Finally, this also removes a very weird part of the code which was probably there for bad reasons. Notably, the dnet matching algorithm was so ad-hoc that it would match (or not) many things erroneously, so that the ground check was there allow to bypass those bugs without much fuss.

Fixes #13209: TC search treats match (if) as TC-opaque.
