### PR TITLE
Fixes #14795: collision between proper pattern variables and "as" clause in elaborating/printing let-pattern coming from a fun-pattern

### DIFF
--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -1519,7 +1519,7 @@ and match_extended_binders ?loc isprod u alp metas na1 na2 bk t sigma b1 b2 =
      | [{CAst.v=(ids,disj_of_patl,b1)}] ->
      let disjpat = List.map (function [pat] -> pat | _ -> assert false) disj_of_patl in
      let disjpat = if occur_glob_constr p b1 then List.map (set_pat_alias p) disjpat else disjpat in
-     let alp,sigma = bind_bindinglist_env alp sigma id [DAst.make ?loc @@ GLocalPattern ((disjpat,ids),p,bk,t)] in
+     let alp,sigma = bind_bindinglist_env alp sigma id [DAst.make ?loc @@ GLocalPattern ((disjpat,ids),(p,Anonymous),bk,t)] in
      match_in u alp metas sigma b1 b2
      | _ -> assert false)
   | Name p, GCases (LetPatternStyle,None,[(e,_)],(_::_ as eqns)), Name id

--- a/pretyping/glob_term.ml
+++ b/pretyping/glob_term.ml
@@ -138,7 +138,7 @@ type cases_pattern_disjunction = [ `any ] cases_pattern_disjunction_g
 type 'a extended_glob_local_binder_r =
   | GLocalAssum   of Name.t * binding_kind * 'a glob_constr_g
   | GLocalDef     of Name.t * 'a glob_constr_g * 'a glob_constr_g option
-  | GLocalPattern of ('a cases_pattern_disjunction_g * Id.t list) * Id.t * binding_kind * 'a glob_constr_g
+  | GLocalPattern of ('a cases_pattern_disjunction_g * Id.t list) * (Id.t * Name.t) * binding_kind * 'a glob_constr_g
 and 'a extended_glob_local_binder_g = ('a extended_glob_local_binder_r, 'a) DAst.t
 
 type extended_glob_local_binder = [ `any ] extended_glob_local_binder_g

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -173,6 +173,12 @@ Found an inductive type while a pattern was expected.
      : Prop
 !!!! (nat, id), nat = true /\ id = false
      : Prop
+!!!!! (x, y), x + y = 0
+     : Prop
+!!!!!! (x, y), x + y = 0
+     : Prop
+!!!!!!! (x, y), x + y = 0
+     : Prop
 ∀ x : nat, x = 0
      : Prop
 ∀₁ x, x = 0

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -371,6 +371,15 @@ Module P.
   Notation "!!!! x , P" := (forall x, P) (at level 200, x strict pattern).
   Check !!!! (nat,id), nat = true /\ id = false.
 
+  Notation "!!!!! x , P" := (forall 'x, P) (at level 200, x strict pattern).
+  Check !!!!! (x,y), x+y = 0.
+
+  Notation "!!!!!! y , P" := (forall 'y, P) (at level 200, y strict pattern).
+  Check !!!!!! (x,y), x+y = 0.
+
+  Notation "!!!!!!! pat , P" := (forall 'pat, P) (at level 200, pat strict pattern).
+  Check !!!!!!! (x,y), x+y = 0.
+
   End NotationBinderNotMixedWithTerms.
 
 End P.

--- a/test-suite/output/PatternsInBinders.out
+++ b/test-suite/output/PatternsInBinders.out
@@ -37,7 +37,8 @@ exists '(x, y) '(z, w), swap (x, y) = (z, w)
 ∀ '(x, y), swap (x, y) = (y, x)
      : Prop
 both_z = 
-fun pat : nat * nat => let '(n, p) as x := pat return (F x) in (Z n, Z p)
+fun pat : nat * nat =>
+let '(n, p) as pat0 := pat return (F pat0) in (Z n, Z p)
      : forall pat : nat * nat, F pat
 
 Arguments both_z pat

--- a/test-suite/output/bug_14795.out
+++ b/test-suite/output/bug_14795.out
@@ -1,0 +1,7 @@
+fun pat : ?T * ?T0 => let '(x, y) as x0 := pat return (x0 = x0) in eq_refl
+     : forall pat : ?T * ?T0, pat = pat
+where
+?T : [pat : ?T * ?T0  p0 : ?T * ?T0  p := p0 : ?T * ?T0 |- Type] (pat, p0,
+     p cannot be used)
+?T0 : [pat : ?T * ?T0  p0 : ?T * ?T0  p := p0 : ?T * ?T0 |- Type] (pat, p0,
+      p cannot be used)

--- a/test-suite/output/bug_14795.v
+++ b/test-suite/output/bug_14795.v
@@ -1,0 +1,1 @@
+Check fun '(x,y) => eq_refl (x,y).


### PR DESCRIPTION
**Kind:** bug fix

We apply the same trick for `fun`-pattern as in compiling `let`-pattern: we force at elaboration time to use the name of the `fun` variable, even if not effectively used, so that a fresh name is used at printing time (no need for a complex computation at printing time).

It is still a bit cheating since printing will continue to print a clashing name if one gives to it a name not fresh enough. But a better fix would require more changes: one would need to detype the pattern and compute its variables before detyping the return clause, which is not what is done currently. Note that this is specific to let-pattern which uses the `as` both for the return clause and for the pattern itself, on the contrary of other forms of `match`.

Note that the compilation of `fun`/`let`-pattern can still be improved independently, e.g. there seems to be a useless 'p := p0' in the environment of the types of the variables.

Fixes / closes #14795

- [x] Added / updated **test-suite**.