### PR TITLE
More accurate IllTypedInstance error messages

### DIFF
--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -1672,7 +1672,7 @@ let apply_conversion_problem_heuristic flags env evd with_ho pbty t1 t2 =
                  (evar_define evar_unify flags ~choose:true)
                  evar_unify flags env evd
                  (position_problem true pbty) ev1 ev2)
-      with IllTypedInstance (env,t,u) ->
+      with IllTypedInstance (env,evd,t,u) ->
             UnifFailure (evd,InstanceNotSameType (evk1,env,t,u)))
   | Evar ev1,_ when is_evar_allowed flags (fst ev1) && Array.length l1 <= Array.length l2 ->
       (* On "?n t1 .. tn = u u1 .. u(n+p)", try first-order unification *)

--- a/pretyping/evarsolve.mli
+++ b/pretyping/evarsolve.mli
@@ -169,7 +169,7 @@ val solve_pattern_eqn : env -> evar_map -> alias list -> constr -> constr
 
 val noccur_evar : env -> evar_map -> Evar.t -> constr -> bool
 
-exception IllTypedInstance of env * types * types
+exception IllTypedInstance of env * evar_map * types * types
 
 val check_evar_instance : unifier -> unify_flags ->
   env -> evar_map -> Evar.t -> constr -> evar_map

--- a/pretyping/pretype_errors.ml
+++ b/pretyping/pretype_errors.ml
@@ -23,6 +23,7 @@ type unification_error =
   | IncompatibleInstances of env * existential * constr * constr
   | MetaOccurInBody of Evar.t
   | InstanceNotSameType of Evar.t * env * types * types
+  | InstanceNotFunctionalType of Evar.t * env * constr * types
   | UnifUnivInconsistency of Univ.univ_inconsistency
   | CannotSolveConstraint of Evd.evar_constraint * unification_error
   | ProblemBeyondCapabilities

--- a/pretyping/pretype_errors.mli
+++ b/pretyping/pretype_errors.mli
@@ -26,6 +26,7 @@ type unification_error =
   | IncompatibleInstances of env * existential * constr * constr
   | MetaOccurInBody of Evar.t
   | InstanceNotSameType of Evar.t * env * types * types
+  | InstanceNotFunctionalType of Evar.t * env * constr * types
   | UnifUnivInconsistency of Univ.univ_inconsistency
   | CannotSolveConstraint of Evd.evar_constraint * unification_error
   | ProblemBeyondCapabilities

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -74,8 +74,8 @@ let rec contract3' env sigma a b c = function
   | IncompatibleInstances (env',ev,t1,t2) ->
       let (env',ev,t1,t2) = contract3 env' sigma (EConstr.mkEvar ev) t1 t2 in
       contract3 env sigma a b c, IncompatibleInstances (env',EConstr.destEvar sigma ev,t1,t2)
-  | NotSameArgSize | NotSameHead | NoCanonicalStructure
-  | MetaOccurInBody _ | InstanceNotSameType _ | ProblemBeyondCapabilities
+  | NotSameArgSize | NotSameHead | NoCanonicalStructure | MetaOccurInBody _
+  | InstanceNotSameType _ | InstanceNotFunctionalType _ | ProblemBeyondCapabilities
   | UnifUnivInconsistency _ as x -> contract3 env sigma a b c, x
   | CannotSolveConstraint ((pb,env',t,u),x) ->
       let env',t,u = contract2 env' sigma t u in
@@ -336,6 +336,14 @@ let explain_unification_error env sigma p1 p2 = function
         quote (pr_existential_key sigma evk) ++
         strbrk ": cannot ensure that " ++
         t ++ strbrk " is a subtype of " ++ u]
+     | InstanceNotFunctionalType (evk,env,f,u) ->
+        let env = make_all_name_different env sigma in
+        let f = pr_leconstr_env env sigma f in
+        let u = pr_leconstr_env env sigma u in
+        [str "unable to find a well-typed instantiation for " ++
+        quote (pr_existential_key sigma evk) ++
+        strbrk ": " ++ f ++
+        strbrk " is expected to have a functional type but it has type " ++ u]
      | UnifUnivInconsistency p ->
        [str "universe inconsistency: " ++
         Univ.explain_universe_inconsistency (Termops.pr_evd_level sigma) p]


### PR DESCRIPTION
**Kind:** fix

While debugging, I realized that two instances of the "unable to find a well-typed instantiation" unification error messages were not mentioning the right types. They also had outdated evar_map. This PR fixes it.

I don't know how much these two instances of the error can arrive in practice. I found the first one while working on not yet correct code.