### PR TITLE
Add support for extracting subterms of invertible constructors in unification

### DIFF
--- a/checker/checkInductive.ml
+++ b/checker/checkInductive.ml
@@ -166,7 +166,7 @@ let check_same_record r1 r2 = match r1, r2 with
 let check_inductive env mind mb =
   let entry = to_entry mind mb in
   let { mind_packets; mind_record; mind_finite; mind_ntypes; mind_hyps;
-        mind_nparams; mind_nparams_rec; mind_params_ctxt;
+        mind_nparams; mind_nparamdecls; mind_nparams_rec; mind_params_ctxt;
         mind_universes; mind_template; mind_variance; mind_sec_variance;
         mind_private; mind_typing_flags; }
     =
@@ -182,6 +182,7 @@ let check_inductive env mind mb =
   check "mind_ntypes" Int.(equal mb.mind_ntypes mind_ntypes);
   check "mind_hyps" (Context.Named.equal Constr.equal mb.mind_hyps mind_hyps);
   check "mind_nparams" Int.(equal mb.mind_nparams mind_nparams);
+  check "mind_nparamdecls" Int.(equal mb.mind_nparamdecls mind_nparamdecls);
 
   check "mind_nparams_rec" (mb.mind_nparams_rec <= mind_nparams_rec);
   (* module substitution can increase the real number of recursively

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -306,6 +306,7 @@ let v_ind_pack = v_tuple "mutual_inductive_body"
     v_section_ctxt;
     Int;
     Int;
+    Int;
     v_rctxt;
     v_univs; (* universes *)
     Opt v_template_universes;

--- a/kernel/cooking.ml
+++ b/kernel/cooking.ml
@@ -394,6 +394,7 @@ let cook_inductive { modlist; abstract={abstr_ctx; abstr_subst; abstr_uctx;}; } 
     mind_ntypes = mib.mind_ntypes;
     mind_hyps;
     mind_nparams = mib.mind_nparams + nnewparams;
+    mind_nparamdecls = List.length mind_params_ctxt;
     mind_nparams_rec = mib.mind_nparams_rec + nnewparams;
     mind_params_ctxt;
     mind_universes;

--- a/kernel/declarations.ml
+++ b/kernel/declarations.ml
@@ -271,6 +271,8 @@ type mutual_inductive_body = {
 
     mind_nparams : int;  (** Number of expected parameters including non-uniform ones (i.e. length of mind_params_ctxt w/o let-in) *)
 
+    mind_nparamdecls : int;  (** Length of parameter context, with let-in, and including non-uniform parameters *)
+
     mind_nparams_rec : int;  (** Number of recursively uniform (i.e. ordinary) parameters *)
 
     mind_params_ctxt : Constr.rel_context;  (** The context of parameters (includes let-in declaration) *)

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -271,6 +271,7 @@ let subst_mind_body sub mib =
     mind_ntypes = mib.mind_ntypes ;
     mind_hyps = (match mib.mind_hyps with [] -> [] | _ -> assert false);
     mind_nparams = mib.mind_nparams;
+    mind_nparamdecls = mib.mind_nparamdecls;
     mind_nparams_rec = mib.mind_nparams_rec;
     mind_params_ctxt =
       Context.Rel.map (subst_mps sub) mib.mind_params_ctxt;

--- a/kernel/indtypes.ml
+++ b/kernel/indtypes.ml
@@ -547,6 +547,7 @@ let build_inductive env ~sec_univs names prv univs template variance
       mind_finite = isfinite;
       mind_hyps = hyps;
       mind_nparams = nparamargs;
+      mind_nparamdecls = List.length paramsctxt;
       mind_nparams_rec = nmr;
       mind_params_ctxt = paramsctxt;
       mind_packets = packets;

--- a/pretyping/inductiveops.mli
+++ b/pretyping/inductiveops.mli
@@ -226,8 +226,12 @@ val make_default_case_info : env -> case_style -> inductive -> case_info
 i*)
 
 val compute_projections : Environ.env -> inductive -> (constr * types) array
-(** Given a primitive record type, for every field computes the eta-expanded
+(** Given a record type, for every field computes the eta-expanded
     projection and its type. *)
+
+val compute_applied_projection : Environ.env -> evar_map -> int -> econstr * etypes -> econstr * etypes
+(** Given a record type and a term in this type, computes the i-th
+    projection of this term. *)
 
 (********************)
 

--- a/pretyping/pretype_errors.ml
+++ b/pretyping/pretype_errors.ml
@@ -15,7 +15,7 @@ open Type_errors
 
 type unification_error =
   | OccurCheck of Evar.t * constr
-  | NotClean of existential * env * constr (* Constr is a variable not in scope *)
+  | NotClean of Evar.t * constr list * env * constr (* Constr is a variable not in scope *)
   | NotSameArgSize
   | NotSameHead
   | NoCanonicalStructure

--- a/pretyping/pretype_errors.mli
+++ b/pretyping/pretype_errors.mli
@@ -18,7 +18,7 @@ open Type_errors
 
 type unification_error =
   | OccurCheck of Evar.t * constr
-  | NotClean of existential * env * constr
+  | NotClean of Evar.t * constr list * env * constr (* Constr is a variable not in scope *)
   | NotSameArgSize
   | NotSameHead
   | NoCanonicalStructure

--- a/pretyping/structures.ml
+++ b/pretyping/structures.ml
@@ -53,7 +53,8 @@ type t = {
 }
 
 let make env name projections =
-  let nparams = Inductiveops.inductive_nparams env name in
+  let (mib,mip) = Inductive.lookup_mind_specif env name in
+  let nparams = mib.Declarations.mind_nparams in
   { name; projections; nparams }
 
 let structure_table =

--- a/test-suite/bugs/closed/bug_5264.v
+++ b/test-suite/bugs/closed/bug_5264.v
@@ -1,0 +1,8 @@
+(* This is one part of wish #5264 *)
+
+Goal forall T1 (P1 : T1 -> Type), sigT P1 -> sigT P1.
+  intros T1 P1 H1.
+  eexists ?[x].
+  destruct H1 as [x1 H1].
+  apply H1.
+Qed.

--- a/test-suite/bugs/closed/bug_6633.v
+++ b/test-suite/bugs/closed/bug_6633.v
@@ -1,0 +1,19 @@
+Goal True.
+  lazymatch constr:(fun T (a : T) (b : T -> T) => b a) with
+  | fun (x : ?T) => ?f
+    => pose (match nat with
+             | x => f
+             end)
+  end.
+Check eq_refl : n = fun (a : nat) (b : nat -> nat) => b a.
+Abort.
+
+Goal True.
+  lazymatch constr:(fun T (a : T) (b : T -> T) => b a) with
+  | fun T => ?f
+    => pose (match nat as T return _ with
+             | T => f
+             end)
+  end.
+Check eq_refl : n = fun (a : nat) (b : nat -> nat) => b a.
+Abort.

--- a/test-suite/output/unification.out
+++ b/test-suite/output/unification.out
@@ -1,12 +1,4 @@
 The command has indeed failed with message:
-In environment
-x : T
-T : Type
-a : T
-Unable to unify "T" with "?X@{x0:=x; x:=C a}" (cannot instantiate 
-"?X" because "T" is not in its scope: available arguments are 
-"x" "C a").
-The command has indeed failed with message:
 The term "id" has type "ID" while it is expected to have type 
 "Type -> ?T" (cannot instantiate "?T" because "A" is not in its scope).
 1 focused goal (shelved: 1)

--- a/test-suite/output/unification.v
+++ b/test-suite/output/unification.v
@@ -4,10 +4,6 @@
 
 Module A.
 
-(* Check regression of an UNBOUND_REL bug *)
-Inductive T := C : forall {A}, A -> T.
-Fail Check fun x => match x return ?[X] with C a => a end.
-
 (* Bug #3634 *)
 Fail Check (id:Type -> _).
 

--- a/test-suite/success/LetPat.v
+++ b/test-suite/success/LetPat.v
@@ -76,3 +76,20 @@ Record sigT' (A : Type) (P : A -> Type) : Type := { projT1' : A ; projT2' : P pr
 Check fun '{| projT1' := x; projT2' := y |} => (eq_refl x,eq_refl y).
 
 End Inference.
+
+Module PatternUnificationPrimitiveConstructors.
+
+Set Primitive Projections.
+
+Record prod A B := pair { fst : A ; snd : B }.
+
+Definition Let_In {A P} (x : A) (f : forall a : A, P a) : P x := let y := x in f y.
+
+Context {Z F:Type}.
+
+Check fun (xy:prod F F) =>
+      Let_In true (fun b =>
+      let 'pair _ _ x y := xy in
+      (pair _ _ x y)).
+
+End PatternUnificationPrimitiveConstructors.

--- a/test-suite/success/LetPat.v
+++ b/test-suite/success/LetPat.v
@@ -53,3 +53,26 @@ Definition functor_composition (a b c : category) : functor a b -> functor b c -
   let 'C :& homB :& CB := c in
     fun f g =>
       fun x => g (f x).
+
+Module Inference.
+
+Check fun '(x,y) => (eq_refl x,eq_refl y).
+Check fun '((x,y):nat*bool) => (eq_refl x,eq_refl y).
+Check fun '(existT _ x y) => (eq_refl x,eq_refl y).
+
+Check fun '((x,y),(z,w)) => (eq_refl x,eq_refl y,eq_refl z,eq_refl w).
+Check fun '(existT _ x (existT _ z w)) => (eq_refl x,eq_refl z,eq_refl w).
+Check fun '(existT _ (existT _ x y) w) => (eq_refl x,eq_refl y,eq_refl w).
+
+(* Unfortunately this still fails due to limits in solving *)
+Fail Check fun '(existT _ (existT _ x y) (existT _ z w)) => (eq_refl x,eq_refl y,eq_refl z,eq_refl w).
+
+Record sigT (A : Type) (P : A -> Type) : Type := { projT1 : A ; projT2 : P projT1 }.
+Check fun '{| projT1 := x; projT2 := y |} => (eq_refl x,eq_refl y).
+
+Set Primitive Projections.
+
+Record sigT' (A : Type) (P : A -> Type) : Type := { projT1' : A ; projT2' : P projT1' }.
+Check fun '{| projT1' := x; projT2' := y |} => (eq_refl x,eq_refl y).
+
+End Inference.

--- a/test-suite/success/unification.v
+++ b/test-suite/success/unification.v
@@ -203,3 +203,13 @@ Check
 (* An example involving SProp *)
 
 Check fun (A:SProp) (f g:A->A) (P:A->Type) a (x : P (f a)) => x : P (g _).
+
+(* An example succeeding thanks to the inversion of constructors in
+   evar instances *)
+
+Module ConstructorInversion.
+
+Inductive T := C : forall {A}, A -> T.
+Check fun x => match x return ?[X] with C a => a end.
+
+End ConstructorInversion.

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -65,9 +65,9 @@ let contract1 env sigma a v =
 let rec contract3' env sigma a b c = function
   | OccurCheck (evk,d) ->
     let x,d = contract4 env sigma a b c d in x,OccurCheck(evk, d)
-  | NotClean ((evk,args),env',d) ->
-      let env',d,args = contract1 env' sigma d args in
-      contract3 env sigma a b c,NotClean((evk,args),env',d)
+  | NotClean (evk,subst,env',d) ->
+      let env',d,subst = contract1 env' sigma d subst in
+      contract3 env sigma a b c,NotClean(evk,subst,env',d)
   | ConversionFailed (env',t1,t2) ->
       let (env',t1,t2) = contract2 env' sigma t1 t2 in
       contract3 env sigma a b c, ConversionFailed (env',t1,t2)
@@ -300,14 +300,14 @@ let explain_unification_error env sigma p1 p2 = function
         [str "cannot define " ++ quote (pr_existential_key sigma evk) ++
         strbrk " with term " ++ pr_leconstr_env env sigma rhs ++
         strbrk " that would depend on itself"]
-     | NotClean ((evk,args),env,c) ->
+     | NotClean (evk,subst,env,c) ->
         let env = make_all_name_different env sigma in
         [str "cannot instantiate " ++ quote (pr_existential_key sigma evk)
         ++ strbrk " because " ++ pr_leconstr_env env sigma c ++
         strbrk " is not in its scope" ++
-        (if List.is_empty args then mt() else
+        (if List.is_empty subst then mt() else
          strbrk ": available arguments are " ++
-         pr_sequence (pr_leconstr_env env sigma) (List.rev args))]
+         pr_sequence (pr_leconstr_env env sigma) (List.rev subst))]
      | NotSameArgSize | NotSameHead | NoCanonicalStructure ->
         (* Error speaks from itself *) []
      | ConversionFailed (env,t1,t2) ->


### PR DESCRIPTION
**Kind:** feature / enhancement

Depends on #14794 (merged).

A unification equation `?e@{a:=(x,y)} := x+y` is in principle solvable by extracting `x` and `y` out of the pair. This is what this PR allows: any subterm of an invertible constructor argument of an existential variable can now be used to solve a unification problem.

This allows for instance to have the return clause inferred in the following examples:
```
Check fun '(x,y) => (eq_refl x,eq_refl y).
Check fun '(existT _ x y) => (eq_refl x,eq_refl y).
```

For constructors in a primitive record, we extract with the native projection. For constructors in a "fake" record, we use the registered projection names. For other one-constructor types, we build the projection on the fly.

For pattern-unification, we invert only constructors of primitive records since eta is required to ensure the reversibility. (This is yet another argument to provide eta also for non primitive records!)

In theory, we could invert non-record types also, e.g. inverting `S x` by using `pred` (see e.g. second example of #5264). This is left for future work.

It is also a bit different from solving equations of the form `fst ?e@{a:=(x,y)} == x` (see [#3419](https://github.com/coq/coq/issues/3419#issuecomment-337520865)).

Fixes the first example of #5264.

- [x] Added / updated **test-suite**.
- [ ] Added **changelog**.
