### PR TITLE
Extracts empty type as an abstract (empty-by-construction) type in OCaml

### DIFF
--- a/doc/changelog/07-vernac-commands-and-options/14802-master+extract-empty-type-as-empty-type.rst
+++ b/doc/changelog/07-vernac-commands-and-options/14802-master+extract-empty-type-as-empty-type.rst
@@ -1,0 +1,7 @@
+- **Changed:**
+  In extraction to OCaml, empty types in :n:`Type` (such as
+  :n:`Empty_set`) are now extracted to an abstract type (empty by
+  construction) rather than to the OCaml's :n:`unit` type
+  (`#14802 <https://github.com/coq/coq/pull/14802>`_,
+  fixes a remark at `#14801 <https://github.com/coq/coq/issues/14801>`_,
+  by Hugo Herbelin).

--- a/plugins/extraction/ocaml.ml
+++ b/plugins/extraction/ocaml.ml
@@ -494,9 +494,9 @@ let pp_one_ind prefix ip_equiv pl name cnames ctyps =
             (fun () -> spc () ++ str "* ") (pp_type true pl) typs)
   in
   pp_parameters pl ++ str prefix ++ name ++
-  pp_equiv pl name ip_equiv ++ str " =" ++
-  if Int.equal (Array.length ctyps) 0 then str " unit (* empty inductive *)"
-  else fnl () ++ v 0 (prvecti pp_constructor ctyps)
+  pp_equiv pl name ip_equiv ++
+  if Int.equal (Array.length ctyps) 0 then str "" (* Note: OCaml 4.07.0 provides "type foo = |" *)
+  else str " =" ++ fnl () ++ v 0 (prvecti pp_constructor ctyps)
 
 let pp_logical_ind packet =
   pp_comment (Id.print packet.ip_typename ++ str " : logical inductive") ++

--- a/test-suite/output/EmptyExtraction.out
+++ b/test-suite/output/EmptyExtraction.out
@@ -1,0 +1,43 @@
+
+type empty_set
+
+Extracted code successfully compiled
+
+type empty_set
+
+type 'x not = 'x -> empty_set
+
+Extracted code successfully compiled
+
+type empty_set
+
+type 'x not = 'x -> empty_set
+
+(** val foo : 'a1 not not not -> 'a1 not **)
+
+let foo p q =
+  p (fun r -> r q)
+
+Extracted code successfully compiled
+
+type empty
+
+Extracted code successfully compiled
+
+type empty
+
+(** val empty_rect : empty -> 'a1 **)
+
+let empty_rect _ =
+  assert false (* absurd case *)
+
+Extracted code successfully compiled
+
+type empty
+
+(** val bar : empty -> 'a1 **)
+
+let bar _ =
+  assert false (* absurd case *)
+
+Extracted code successfully compiled

--- a/test-suite/output/EmptyExtraction.v
+++ b/test-suite/output/EmptyExtraction.v
@@ -1,0 +1,47 @@
+From Coq Require Extraction.
+
+(** Testing extraction of stdlib Empty_set *)
+
+Recursive Extraction Empty_set.
+Extraction TestCompile Empty_set.
+
+(** Testing extraction of a type level not *)
+
+Definition not : Type -> Type := fun X => X -> Empty_set.
+
+Recursive Extraction not.
+Extraction TestCompile not.
+
+(** Testing extraction of a simple proof using not but no elimination. *)
+
+Definition foo : forall X, not (not (not X)) -> not X.
+Proof.
+  intros X.
+  intros p q.
+  apply p.
+  intros r.
+  apply r.
+  exact q.
+Defined.
+
+Recursive Extraction foo.
+Extraction TestCompile foo.
+
+(** Testing extraction of a user defined Empty *)
+
+Inductive Empty : Set := .
+
+Recursive Extraction Empty.
+Extraction TestCompile Empty.
+
+(** Testing extraction of Empty eliminator *)
+
+Recursive Extraction Empty_rect.
+Extraction TestCompile Empty_rect.
+
+(** Testing extraction of an slightly different eliminator *)
+
+Definition bar : Empty -> forall A, A := fun x => Empty_rect _ x.
+
+Recursive Extraction bar.
+Extraction TestCompile bar.


### PR DESCRIPTION
**Kind:** enhancement

It is unclear why the empty type is extracted as the unit type in extraction to OCaml. This PR extracts the empty type to the empty type.

Addresses a remark at [#14801](https://github.com/coq/coq/issues/14801#issuecomment-903827850).

- [x] Added / updated test-suite
- [x] Entry added in the changelog

Would need to be done in Haskell too.