### PR TITLE
Experiment calling again solve_simple_eqn in heuristics when the first-order heuristic fails

### DIFF
--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -1615,8 +1615,13 @@ let second_order_matching_with_args flags env evd with_ho pbty ev l t =
     else
       UnifFailure (evd, ConversionFailed (env,mkApp(mkEvar ev,l),t))
   else
-    let pb = (pbty,env,mkApp(mkEvar ev,l),t) in
-    UnifFailure (evd, CannotSolveConstraint (pb,ProblemBeyondCapabilities))
+    if
+      Array.for_all (fun c -> isRel evd c || isVar evd c) l then
+      let evd,ev = evar_absorb_arguments env evd ev (Array.to_list l) in
+      solve_simple_eqn ~choose:false ~imitate_defs:false
+        evar_unify flags env evd (None,ev,t)
+    else
+      UnifFailure (evd, ConversionFailed (env,mkApp(mkEvar ev,l),t))
 
 let is_beyond_capabilities = function
   | CannotSolveConstraint (pb,ProblemBeyondCapabilities) -> true

--- a/test-suite/bugs/HoTT_coq_117.v
+++ b/test-suite/bugs/HoTT_coq_117.v
@@ -16,26 +16,26 @@ Definition path_forall `{Funext} {A : Type} {P : A -> Type} (f g : forall x : A,
 Admitted.
 
 Inductive Empty : Set := .
-Fail Instance contr_from_Empty {_ : Funext} (A : Type) :
+Instance contr_from_Empty {_ : Funext} (A : Type) :
   Contr_internal (Empty -> A) :=
   BuildContr _
              (Empty_rect (fun _ => A))
              (fun f => path_forall _ f (fun x => Empty_rect _ x)).
 
-Fail Instance contr_from_Empty {F : Funext} (A : Type) :
+Instance contr_from_Empty' {F : Funext} (A : Type) :
   Contr_internal (Empty -> A) :=
   BuildContr _
              (Empty_rect (fun _ => A))
              (fun f => path_forall _ f (fun x => Empty_rect _ x)).
 
 (** This could be disallowed, this uses the Funext argument *)
-Instance contr_from_Empty {_ : Funext} (A : Type) :
+Instance contr_from_Empty'' {_ : Funext} (A : Type) :
   Contr_internal (Empty -> A) :=
   BuildContr _
              (Empty_rect (fun _ => A))
              (fun f => path_forall _ f (fun x => Empty_rect (fun _ => _ x = f x) x)).
 
-Instance contr_from_Empty' {_ : Funext} (A : Type) :
+Instance contr_from_Empty''' {_ : Funext} (A : Type) :
   Contr_internal (Empty -> A) :=
   BuildContr _
              (Empty_rect (fun _ => A))

--- a/test-suite/bugs/bug_2310.v
+++ b/test-suite/bugs/bug_2310.v
@@ -14,7 +14,8 @@ Definition replace a (y:Nest (prod a a)) : a = a -> Nest a.
    (P:=\a.Nest (prod a a) and P:=\_.Nest (prod a a)) and refine should either
    leave P as subgoal or choose itself one solution *)
 
-  intros. Fail refine (Cons (cast H _ y)).
+  intros. refine (Cons (cast H _ y)).
+  Undo.
   Unset Solve Unification Constraints. (* Keep the unification constraint around *)
   refine (Cons (cast H _ y)).
   intros.

--- a/test-suite/output/unifconstraints.out
+++ b/test-suite/output/unifconstraints.out
@@ -65,6 +65,6 @@ In environment
 P : nat -> Type
 x : nat
 h : P x
-Unable to unify "P x" with "?P x"
+Unable to unify "P x" with "(fun x0 : nat => ?P) x"
 (unable to find a well-typed instantiation for "?P": cannot ensure that
-"nat -> Type" is a subtype of "nat -> Prop").
+"Type" is a subtype of "Prop").


### PR DESCRIPTION
*Kind:* Experiment

The heuristic algorithm is not able to solve non-first-order non strictly-simple problems like `?P x == x`. We add a call to `solve_simple_eqn` after absorption of the arguments to solve them.

Testing compatibility at the current time.

- [x] Added / updated **test-suite**.
