### PR TITLE
Changing the δ flag semantics in CClosure

### DIFF
--- a/dev/ci/user-overlays/14810-ppedrot-cclosure-cleanup-fdelta.sh
+++ b/dev/ci/user-overlays/14810-ppedrot-cclosure-cleanup-fdelta.sh
@@ -1,0 +1,2 @@
+overlay equations https://github.com/ppedrot/Coq-Equations cclosure-cleanup-fdelta 14810
+overlay mtac2 https://github.com/ppedrot/Mtac2 cclosure-cleanup-fdelta 14810

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -1394,7 +1394,7 @@ let rec knr info tab m stk =
       (match get_args n tys f e stk with
           Inl e', s -> knit info tab e' f s
         | Inr lam, s -> (lam,s))
-  | FFlex fl when transparent_ref info.i_flags fl ->
+  | FFlex fl when red_set info.i_flags fDELTA && transparent_ref info.i_flags fl ->
       (match ref_value_cache info.i_cache.i_env tab fl with
         | Def v -> kni info tab v stk
         | Primitive op ->

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -76,7 +76,6 @@ let with_stats c =
     Lazy.force c
 
 let all_opaque = TransparentState.empty
-let all_transparent = TransparentState.full
 
 module type RedFlagsSig = sig
   type reds
@@ -95,6 +94,7 @@ module type RedFlagsSig = sig
   val red_add_transparent : reds -> TransparentState.t -> reds
   val red_transparent : reds -> TransparentState.t
   val mkflags : red_kind list -> reds
+  val mkfullflags : red_kind list -> reds
   val red_set : reds -> red_kind -> bool
   val red_projection : reds -> Projection.t -> bool
 end
@@ -138,7 +138,7 @@ module RedFlags : RedFlagsSig = struct
 
   let red_add red = function
     | BETA -> { red with r_beta = true }
-    | DELTA -> { red with r_delta = true; r_const = all_transparent }
+    | DELTA -> { red with r_delta = true }
     | CONST kn ->
       let r = red.r_const in
       { red with r_const = { r with tr_cst = Cpred.add kn r.tr_cst } }
@@ -171,6 +171,8 @@ module RedFlags : RedFlagsSig = struct
 
   let mkflags = List.fold_left red_add no_red
 
+  let mkfullflags = List.fold_left red_add { no_red with r_const = TransparentState.full }
+
   let red_set red = function
     | BETA -> incr_cnt red.r_beta beta
     | CONST kn ->
@@ -194,14 +196,14 @@ end
 
 open RedFlags
 
-let all = mkflags [fBETA;fDELTA;fZETA;fMATCH;fFIX;fCOFIX]
-let allnolet = mkflags [fBETA;fDELTA;fMATCH;fFIX;fCOFIX]
+let all = mkfullflags [fBETA;fDELTA;fZETA;fMATCH;fFIX;fCOFIX]
+let allnolet = mkfullflags [fBETA;fDELTA;fMATCH;fFIX;fCOFIX]
 let beta = mkflags [fBETA]
-let betadeltazeta = mkflags [fBETA;fDELTA;fZETA]
+let betadeltazeta = mkfullflags [fBETA;fDELTA;fZETA]
 let betaiota = mkflags [fBETA;fMATCH;fFIX;fCOFIX]
 let betaiotazeta = mkflags [fBETA;fMATCH;fFIX;fCOFIX;fZETA]
 let betazeta = mkflags [fBETA;fZETA]
-let delta = mkflags [fDELTA]
+let delta = mkfullflags [fDELTA]
 let zeta = mkflags [fZETA]
 let nored = no_red
 

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -1034,6 +1034,10 @@ module FNativeEntries =
     type evd = unit
     type uinstance = Univ.Instance.t
 
+    let mk_construct c =
+      (* All constructors used in primitive functions are relevant *)
+      { mark = mark Cstr KnownR; term = FConstruct (Univ.in_punivs c) }
+
     let get = Array.get
 
     let get_int () e =
@@ -1082,8 +1086,8 @@ module FNativeEntries =
       match retro.Retroknowledge.retro_bool with
       | Some (ct,cf) ->
         defined_bool := true;
-        ftrue := { mark = mark Cstr KnownR; term = FConstruct (Univ.in_punivs ct) };
-        ffalse := { mark = mark Cstr KnownR; term = FConstruct (Univ.in_punivs cf) }
+        ftrue := mk_construct ct;
+        ffalse := mk_construct cf;
       | None -> defined_bool :=false
 
     let defined_carry = ref false
@@ -1094,8 +1098,8 @@ module FNativeEntries =
       match retro.Retroknowledge.retro_carry with
       | Some(c0,c1) ->
         defined_carry := true;
-        fC0 := { mark = mark Cstr KnownR; term = FConstruct (Univ.in_punivs c0) };
-        fC1 := { mark = mark Cstr KnownR; term = FConstruct (Univ.in_punivs c1) }
+        fC0 := mk_construct c0;
+        fC1 := mk_construct c1;
       | None -> defined_carry := false
 
     let defined_pair = ref false
@@ -1105,7 +1109,7 @@ module FNativeEntries =
       match retro.Retroknowledge.retro_pair with
       | Some c ->
         defined_pair := true;
-        fPair := { mark = mark Cstr KnownR; term = FConstruct (Univ.in_punivs c) }
+        fPair := mk_construct c;
       | None -> defined_pair := false
 
     let defined_cmp = ref false
@@ -1118,9 +1122,9 @@ module FNativeEntries =
       match retro.Retroknowledge.retro_cmp with
       | Some (cEq, cLt, cGt) ->
         defined_cmp := true;
-        fEq := { mark = mark Cstr KnownR; term = FConstruct (Univ.in_punivs cEq) };
-        fLt := { mark = mark Cstr KnownR; term = FConstruct (Univ.in_punivs cLt) };
-        fGt := { mark = mark Cstr KnownR; term = FConstruct (Univ.in_punivs cGt) };
+        fEq := mk_construct cEq;
+        fLt := mk_construct cLt;
+        fGt := mk_construct cGt;
         let (icmp, _) = cEq in
         fcmp := { mark = mark Ntrl KnownR; term = FInd (Univ.in_punivs icmp) }
       | None -> defined_cmp := false
@@ -1135,11 +1139,10 @@ module FNativeEntries =
       match retro.Retroknowledge.retro_f_cmp with
       | Some (cFEq, cFLt, cFGt, cFNotComparable) ->
         defined_f_cmp := true;
-        fFEq := { mark = mark Cstr KnownR; term = FConstruct (Univ.in_punivs cFEq) };
-        fFLt := { mark = mark Cstr KnownR; term = FConstruct (Univ.in_punivs cFLt) };
-        fFGt := { mark = mark Cstr KnownR; term = FConstruct (Univ.in_punivs cFGt) };
-        fFNotComparable :=
-          { mark = mark Cstr KnownR; term = FConstruct (Univ.in_punivs cFNotComparable) };
+        fFEq := mk_construct cFEq;
+        fFLt := mk_construct cFLt;
+        fFGt := mk_construct cFGt;
+        fFNotComparable := mk_construct cFNotComparable;
       | None -> defined_f_cmp := false
 
     let defined_f_class = ref false
@@ -1158,15 +1161,15 @@ module FNativeEntries =
       | Some (cPNormal, cNNormal, cPSubn, cNSubn, cPZero, cNZero,
               cPInf, cNInf, cNaN) ->
         defined_f_class := true;
-        fPNormal := { mark = mark Cstr KnownR; term = FConstruct (Univ.in_punivs cPNormal) };
-        fNNormal := { mark = mark Cstr KnownR; term = FConstruct (Univ.in_punivs cNNormal) };
-        fPSubn := { mark = mark Cstr KnownR; term = FConstruct (Univ.in_punivs cPSubn) };
-        fNSubn := { mark = mark Cstr KnownR; term = FConstruct (Univ.in_punivs cNSubn) };
-        fPZero := { mark = mark Cstr KnownR; term = FConstruct (Univ.in_punivs cPZero) };
-        fNZero := { mark = mark Cstr KnownR; term = FConstruct (Univ.in_punivs cNZero) };
-        fPInf := { mark = mark Cstr KnownR; term = FConstruct (Univ.in_punivs cPInf) };
-        fNInf := { mark = mark Cstr KnownR; term = FConstruct (Univ.in_punivs cNInf) };
-        fNaN := { mark = mark Cstr KnownR; term = FConstruct (Univ.in_punivs cNaN) };
+        fPNormal := mk_construct cPNormal;
+        fNNormal := mk_construct cNNormal;
+        fPSubn := mk_construct cPSubn;
+        fNSubn := mk_construct cNSubn;
+        fPZero := mk_construct cPZero;
+        fNZero := mk_construct cNZero;
+        fPInf := mk_construct cPInf;
+        fNInf := mk_construct cNInf;
+        fNaN := mk_construct cNaN;
       | None -> defined_f_class := false
 
     let defined_array = ref false

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -220,7 +220,8 @@ val eta_expand_ind_stack : env -> inductive -> fconstr -> stack ->
 (** Conversion auxiliary functions to do step by step normalisation *)
 
 (** [unfold_reference] unfolds references in a [fconstr] *)
-val unfold_reference : clos_infos -> clos_tab -> table_key -> (fconstr, Util.Empty.t) constant_def
+val unfold_reference : Environ.env -> TransparentState.t ->
+  clos_tab -> table_key -> (fconstr, Util.Empty.t) constant_def
 
 (** Hook for Reduction *)
 val set_conv : (clos_infos -> clos_tab -> fconstr -> fconstr -> bool) -> unit

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -26,7 +26,7 @@ val with_stats: 'a Lazy.t -> 'a
   a LetIn expression is Letin reduction *)
 
 (** Sets of reduction kinds. *)
-module type RedFlagsSig = sig
+module RedFlags : sig
   type reds
   type red_kind
 
@@ -67,7 +67,6 @@ module type RedFlagsSig = sig
   val red_projection : reds -> Projection.t -> bool
 end
 
-module RedFlags : RedFlagsSig
 open RedFlags
 
 (* These flags do not contain eta *)

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -296,7 +296,9 @@ let conv_table_key infos ~nargs k1 k2 cuniv =
   | _ -> raise NotConvertible
 
 let unfold_ref_with_args infos tab fl v =
-  match unfold_reference infos tab fl with
+  let env = info_env infos in
+  let flags = RedFlags.red_transparent (info_flags infos) in
+  match unfold_reference env flags tab fl with
   | Def def -> Some (def, v)
   | Primitive op when check_native_args op v ->
     let c = match fl with ConstKey c -> c | _ -> assert false in

--- a/plugins/firstorder/ground.ml
+++ b/plugins/firstorder/ground.ml
@@ -25,7 +25,7 @@ let update_flags ()=
   let flags = List.fold_left f TransparentState.full (Coercionops.coercions ()) in
     red_flags:=
     CClosure.RedFlags.red_add_transparent
-      CClosure.betaiotazeta
+      CClosure.all
       flags
 
 let ground_tac solver startseq =

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -1310,9 +1310,11 @@ let clr_of_wgen gen clrs = match gen with
 let reduct_in_concl ~check t = Tactics.reduct_in_concl ~check (t, DEFAULTcast)
 let unfold cl =
   let module R = Reductionops in let module F = CClosure.RedFlags in
-  reduct_in_concl ~check:false (R.clos_norm_flags (F.mkflags
-    (List.map (fun c -> F.fCONST (fst (destConst (EConstr.Unsafe.to_constr c)))) cl @
-       [F.fBETA; F.fMATCH; F.fFIX; F.fCOFIX])))
+  let flags = F.mkflags [F.fBETA; F.fMATCH; F.fFIX; F.fCOFIX; F.fDELTA] in
+  let flags = F.red_add_transparent flags TransparentState.empty in
+  let fold accu c = F.red_add accu (F.fCONST (fst (destConst (EConstr.Unsafe.to_constr c)))) in
+  let flags = List.fold_left fold flags cl in
+  reduct_in_concl ~check:false (R.clos_norm_flags flags)
 
 open Proofview
 open Notations
@@ -1524,16 +1526,13 @@ let tacDEST_CONST c =
  * to change that behaviour in the standard unfold code *)
 let unprotecttac =
   tacMK_SSR_CONST "protect_term" >>= tacDEST_CONST >>= fun prot ->
+  let open CClosure.RedFlags in
+  let flags = red_add_transparent CClosure.allnolet TransparentState.empty in
+  let flags = red_add flags (fCONST prot) in
   Tacticals.New.onClause (fun idopt ->
     let hyploc = Option.map (fun id -> id, InHyp) idopt in
     Tactics.reduct_option ~check:false
-      (Reductionops.clos_norm_flags
-        (CClosure.RedFlags.mkflags
-          [CClosure.RedFlags.fBETA;
-           CClosure.RedFlags.fCONST prot;
-           CClosure.RedFlags.fMATCH;
-           CClosure.RedFlags.fFIX;
-           CClosure.RedFlags.fCOFIX]), DEFAULTcast) hyploc)
+      (Reductionops.clos_norm_flags flags, DEFAULTcast) hyploc)
     allHypsAndConcl
 
 

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -1311,7 +1311,6 @@ let reduct_in_concl ~check t = Tactics.reduct_in_concl ~check (t, DEFAULTcast)
 let unfold cl =
   let module R = Reductionops in let module F = CClosure.RedFlags in
   let flags = F.mkflags [F.fBETA; F.fMATCH; F.fFIX; F.fCOFIX; F.fDELTA] in
-  let flags = F.red_add_transparent flags TransparentState.empty in
   let fold accu c = F.red_add accu (F.fCONST (fst (destConst (EConstr.Unsafe.to_constr c)))) in
   let flags = List.fold_left fold flags cl in
   reduct_in_concl ~check:false (R.clos_norm_flags flags)

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -1166,10 +1166,11 @@ let string_of_evaluable_ref env = function
 let unfold_side_flags = RedFlags.[fBETA;fMATCH;fFIX;fCOFIX;fZETA]
 let unfold_side_red = RedFlags.(mkflags [fBETA;fMATCH;fFIX;fCOFIX;fZETA])
 let unfold_red kn =
+  (* FIXME: fDELTA should not set everybody transparent *)
   let flag = match kn with
     | EvalVarRef id -> RedFlags.fVAR id
     | EvalConstRef kn -> RedFlags.fCONST kn in
-  RedFlags.mkflags (flag::unfold_side_flags)
+  RedFlags.red_add (RedFlags.red_add_transparent (RedFlags.mkflags (RedFlags.fDELTA::unfold_side_flags)) TransparentState.empty) flag
 
 let unfold env sigma name c =
   if is_evaluable env name then

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -1166,11 +1166,10 @@ let string_of_evaluable_ref env = function
 let unfold_side_flags = RedFlags.[fBETA;fMATCH;fFIX;fCOFIX;fZETA]
 let unfold_side_red = RedFlags.(mkflags [fBETA;fMATCH;fFIX;fCOFIX;fZETA])
 let unfold_red kn =
-  (* FIXME: fDELTA should not set everybody transparent *)
   let flag = match kn with
     | EvalVarRef id -> RedFlags.fVAR id
     | EvalConstRef kn -> RedFlags.fCONST kn in
-  RedFlags.red_add (RedFlags.red_add_transparent (RedFlags.mkflags (RedFlags.fDELTA::unfold_side_flags)) TransparentState.empty) flag
+  RedFlags.mkflags (flag::RedFlags.fDELTA::unfold_side_flags)
 
 let unfold env sigma name c =
   if is_evaluable env name then

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -392,7 +392,7 @@ let autounfolds ids csts gl cls =
   let flags =
     List.fold_left (fun flags cst -> CClosure.RedFlags.(red_add flags (fCONST cst)))
       (List.fold_left (fun flags id -> CClosure.RedFlags.(red_add flags (fVAR id)))
-         CClosure.betaiotazeta ids) csts
+         (CClosure.RedFlags.red_add_transparent CClosure.all TransparentState.empty) ids) csts
   in reduct_option ~check:false (Reductionops.clos_norm_flags flags, DEFAULTcast) cls
 
 let cons a l = a :: l

--- a/tactics/redexpr.ml
+++ b/tactics/redexpr.ml
@@ -149,7 +149,7 @@ let make_flag env f =
           (fun v red -> red_sub red (make_flag_constant v))
           f.rConst red
     else (* Only rConst *)
-        let red = red_add_transparent (red_add red fDELTA) TransparentState.empty in
+        let red = red_add red fDELTA in
         List.fold_right
           (fun v red -> red_add red (make_flag_constant v))
           f.rConst red


### PR DESCRIPTION
This PR is a series of cleanup patches revolving around the behaviour of reference unfolding in CClosure.

There was a confusion between the reduction flags and the transparent state. It turns out we only need the latter to decide whether to unfold a reference, since when *converting* RelKey we *must not* check the delta flag, i.e. we unfold unconditionally.

This highlighted another suspicious point, which is that fDELTA had little to do with what is usually called δ-reduction, i.e. constant unfolding. This flag only controlled unfolding of rel variables from the external environment. It did not even affect unfolding of named variables.

In the upper layers, some places used it with the clear intent to mean that it should allow unfolding of constants in the kernel, which is not what it was doing. Thankfully these calls were often wrapped in modifications of the transparent state through CClosure.RedFlags.red_add_transparent, which worked around the borken semantics of the delta flag.

The main observable changes of this PR are the following.
- The CClosure machine now only unfolds references when the fDELTA flag is set, and the status of the transparent state is only checked after that.
- Setting fDELTA with red_add now leaves the transparent state untouched, when it would reset it to full transparency before. This makes red_add and red_sub symmetrical.

Overlays:
- https://github.com/Mtac2/Mtac2/pull/339
- https://github.com/mattam82/Coq-Equations/pull/421