### PR TITLE
Fix printing mutual fixpoints

### DIFF
--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -461,7 +461,8 @@ let tag_var = tag Tag.variable
   let pr_recursive kw pr_decl id = function
     | [] -> anomaly (Pp.str "(co)fixpoint with no definition.")
     | [d1] -> pr_decl kw false d1
-    | dl ->
+    | d1::dl ->
+      pr_decl kw true d1 ++ fnl() ++
       prlist_with_sep (fun () -> fnl())
         (pr_decl "with" true) dl ++
         fnl() ++ keyword "for" ++ spc () ++ pr_id id

--- a/test-suite/output/bug_14815.out
+++ b/test-suite/output/bug_14815.out
@@ -1,0 +1,16 @@
+f = 
+fix f (n : nat) : nat :=
+  match n with
+  | 0 => 0
+  | S n0 => g n0
+  end
+with g (n : nat) : nat :=
+  match n with
+  | 0 => 0
+  | S n0 => f n0
+  end
+for
+f
+     : nat -> nat
+
+Arguments f n%nat_scope

--- a/test-suite/output/bug_14815.v
+++ b/test-suite/output/bug_14815.v
@@ -1,0 +1,4 @@
+Fixpoint f n := match n with S n => g n | O => O end
+with g n := match n with S n => f n | O => O end.
+
+Print f.


### PR DESCRIPTION
The printer does not print mutual fixpoints as reported in #14815 . This PR fixes it.

- [x] Added / updated **test-suite**.

Fixes #14815.