### PR TITLE
A few miscellaneous typos

### DIFF
--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -469,8 +469,8 @@ We also need additional typing judgments:
   structure :math:`S` in weak head normal form.
 + :math:`\WS{E}{S_1}{S_2}` , denoting that a structure :math:`S_1` is a subtype of a
   structure :math:`S_2`.
-+ :math:`\WS{E}{e_1}{e_2}` , denoting that a structure element e_1 is more
-  precise than a structure element e_2.
++ :math:`\WS{E}{e_1}{e_2}` , denoting that a structure element :math:`e_1` is more
+  precise than a structure element :math:`e_2`.
 
 The rules for forming structures are the following:
 
@@ -534,12 +534,12 @@ reduced term :math:`t_i` in :math:`p`.
 
    \begin{array}{c}
    \WEV{E}{S}{\Struct~e_1 ;…;e_i ;\Assum{}{c}{T_1};e_{i+2} ;… ;e_n ~\End} \\
-   \WS{E;e_1 ;…;e_i }{Def()(c:=t:T)}{\Assum{}{c}{T_1}}
+   \WS{E;e_1 ;…;e_i }{\Def{}{c}{t}{T})}{\Assum{}{c}{T_1}}
    \end{array}
    --------------------------
    \begin{array}{c}
    \WEV{E}{S~\with~c := t:T}{} \\
-   \Struct~e_1 ;…;e_i ;Def()(c:=t:T);e_{i+2} ;… ;e_n ~\End
+   \Struct~e_1 ;…;e_i ;\Def{}{c}{t}{T};e_{i+2} ;… ;e_n ~\End
    \end{array}
 
 .. inference:: WEVAL-WITH-DEF-REC

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -261,7 +261,7 @@ type intern_env = {
 type pattern_intern_env = {
   pat_scopes: Notation_term.subscopes;
   (* ids = Some means accept local variables; this is useful for
-     terms as patterns parsed as pattersn in notations *)
+     terms as patterns parsed as patterns in notations *)
   pat_ids: Id.Set.t option;
 }
 

--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -384,7 +384,7 @@ let set_manual_implicits silent flags enriching autoimps l =
        end :: imps'
     | [], [] -> []
     | [], _ -> assert false
-    (* possibly more automatic than manual implicit arguments n
+    (* possibly more automatic than manual implicit arguments
        when the conclusion is an unfoldable constant *)
     | autoimps, [] -> merge k autoimps [CAst.make None]
   in merge 1 autoimps l

--- a/interp/impargs.mli
+++ b/interp/impargs.mli
@@ -116,7 +116,7 @@ val maybe_declare_manual_implicits : bool -> GlobRef.t -> ?enriching:bool ->
 
 (** [set_implicits local ref l]
    Manual declaration of implicit arguments.
-  `l` is a list of possible sequences of implicit statuses. *)
+  [l] is a list of possible sequences of implicit statuses. *)
 val set_implicits : bool -> GlobRef.t -> (Name.t * Glob_term.binding_kind) list list -> unit
 
 val implicits_of_global : GlobRef.t -> implicits_list list

--- a/interp/implicit_quantifiers.ml
+++ b/interp/implicit_quantifiers.ml
@@ -78,7 +78,7 @@ let is_freevar ids env x =
 
 let ungeneralizable loc id =
   user_err ?loc ~hdr:"Generalization"
-               (str "Unbound and ungeneralizable variable " ++ Id.print id)
+               (str "Unbound and ungeneralizable variable " ++ Id.print id ++ str ".")
 
 let free_vars_of_constr_expr c ?(bound=Id.Set.empty) l =
   let found loc id bdvars l =

--- a/kernel/constr.ml
+++ b/kernel/constr.ml
@@ -1585,7 +1585,7 @@ let rec debug_print c =
   | Ind ((sp,i),u) -> str"Ind(" ++ pr_puniverses (MutInd.print sp ++ str"," ++ int i) u ++ str")"
   | Construct (((sp,i),j),u) ->
       str"Constr(" ++ pr_puniverses (MutInd.print sp ++ str"," ++ int i ++ str"," ++ int j) u ++ str")"
-  | Proj (p,c) -> str"Proj(" ++ Constant.debug_print (Projection.constant p) ++ str"," ++ bool (Projection.unfolded p) ++ debug_print c ++ str")"
+  | Proj (p,c) -> str"Proj(" ++ Constant.debug_print (Projection.constant p) ++ str"," ++ bool (Projection.unfolded p) ++ str"," ++ debug_print c ++ str")"
   | Case (_ci,_u,pms,p,iv,c,bl) ->
     let pr_ctx (nas, c) =
       prvect_with_sep spc (fun na -> Name.print na.binder_name) nas ++ spc () ++ str "|-" ++ spc () ++

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -324,7 +324,7 @@ GRAMMAR EXTEND Gram
     [ [ "return"; ty = term LEVEL "100" -> { ty } ] ]
   ;
   as_return_type:
-    [ [ a = OPT [ na = OPT["as"; na = name -> { na } ];
+    [ [ a = OPT [ na = OPT ["as"; na = name -> { na } ];
                   ty = case_type -> { (na,ty) } ] ->
         { match a with
           | None -> None, None

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -564,7 +564,7 @@ let detype_case computable detype detype_eqns avoid env sigma (ci, univs, params
       let t = mkApp (mkIndU (ci.ci_ind,univs), Array.append params indices) in
       DAst.make @@ GCast (tomatch, CastConv (detype t))
   in
-  let alias, aliastyp, pred=
+  let alias, aliastyp, pred =
     if (not !Flags.raw_print) && synth_type && computable && not (Int.equal (Array.length bl) 0)
     then
       Anonymous, None, None


### PR DESCRIPTION
This fixes a little few miscellaneous typos found here and there: reference manual, comments, unexpected spacing, and a missing period in an error message.