### PR TITLE
Parameters of inductives in Number Notations can be arbitrary terms

### DIFF
--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -633,7 +633,7 @@ exception NotAValidPrimToken
     what it means for a term to be ground / to be able to be
     considered for parsing. *)
 
-let constr_of_globref allow_constant env sigma = function
+let constr_of_globref ?(allow_constant=true) env sigma = function
   | GlobRef.ConstructRef c ->
      let sigma,c = Evd.fresh_constructor_instance env sigma c in
      sigma,mkConstructU c
@@ -650,11 +650,11 @@ let constr_of_globref allow_constant env sigma = function
     or raises [NotAValidPrimToken]. *)
 let rec check_glob env sigma g c = match DAst.get g, Constr.kind c with
   | Glob_term.GRef (GlobRef.ConstructRef c as g, _), Constr.Construct (c', _)
-       when Construct.CanOrd.equal c c' -> constr_of_globref true env sigma g
+       when Construct.CanOrd.equal c c' -> constr_of_globref env sigma g
   | Glob_term.GRef (GlobRef.IndRef c as g, _), Constr.Ind (c', _)
-       when Ind.CanOrd.equal c c' -> constr_of_globref true env sigma g
+       when Ind.CanOrd.equal c c' -> constr_of_globref env sigma g
   | Glob_term.GRef (GlobRef.ConstRef c as g, _), Constr.Const (c', _)
-       when Constant.CanOrd.equal c c' -> constr_of_globref true env sigma g
+       when Constant.CanOrd.equal c c' -> constr_of_globref env sigma g
   | Glob_term.GApp (gc, gcl), Constr.App (gc', gc'a) ->
      let sigma,c = check_glob env sigma gc gc' in
      let sigma,cl =
@@ -677,17 +677,17 @@ let rec check_glob env sigma g c = match DAst.get g, Constr.kind c with
      sigma,mkSort s
   | _ -> raise NotAValidPrimToken
 
-let rec constr_of_glob allow_constant to_post post env sigma g = match DAst.get g with
+let rec constr_of_glob to_post post env sigma g = match DAst.get g with
   | Glob_term.GRef (r, _) ->
       let o = List.find_opt (fun (_,r',_) -> GlobRef.equal r r') post in
       begin match o with
-      | None -> constr_of_globref allow_constant env sigma r
+      | None -> constr_of_globref ~allow_constant:false env sigma r
       | Some (r, _, a) ->
          (* [g] is not a GApp so check that [post]
             does not expect any actual argument
             (i.e., [a] contains only ToPostHole since they mean "ignore arg") *)
          if List.exists ((<>) ToPostHole) a then raise NotAValidPrimToken;
-         constr_of_globref true env sigma r
+         constr_of_globref env sigma r
       end
   | Glob_term.GApp (gc, gcl) ->
       let o = match DAst.get gc with
@@ -695,15 +695,15 @@ let rec constr_of_glob allow_constant to_post post env sigma g = match DAst.get 
         | _ -> None in
       begin match o with
       | None ->
-         let sigma,c = constr_of_glob allow_constant to_post post env sigma gc in
-         let sigma,cl = List.fold_left_map (constr_of_glob allow_constant to_post post env) sigma gcl in
+         let sigma,c = constr_of_glob to_post post env sigma gc in
+         let sigma,cl = List.fold_left_map (constr_of_glob to_post post env) sigma gcl in
          sigma,mkApp (c, Array.of_list cl)
       | Some (r, _, a) ->
-         let sigma,c = constr_of_globref true env sigma r in
+         let sigma,c = constr_of_globref env sigma r in
          let rec aux sigma a gcl = match a, gcl with
            | [], [] -> sigma,[]
            | ToPostCopy :: a, gc :: gcl ->
-              let sigma,c = constr_of_glob allow_constant [||] [] env sigma gc in
+              let sigma,c = constr_of_glob [||] [] env sigma gc in
               let sigma,cl = aux sigma a gcl in
               sigma, c :: cl
            | ToPostCheck r :: a, gc :: gcl ->
@@ -711,7 +711,7 @@ let rec constr_of_glob allow_constant to_post post env sigma g = match DAst.get 
               let sigma,cl = aux sigma a gcl in
               sigma, c :: cl
            | ToPostAs i :: a, gc :: gcl ->
-              let sigma,c = constr_of_glob allow_constant to_post to_post.(i) env sigma gc in
+              let sigma,c = constr_of_glob to_post to_post.(i) env sigma gc in
               let sigma,cl = aux sigma a gcl in
               sigma, c :: cl
            | ToPostHole :: post, _ :: gcl -> aux sigma post gcl
@@ -724,9 +724,9 @@ let rec constr_of_glob allow_constant to_post post env sigma g = match DAst.get 
   | Glob_term.GFloat f -> sigma, mkFloat f
   | Glob_term.GArray (_,t,def,ty) ->
       let sigma, u' = Evd.fresh_array_instance env sigma in
-      let sigma, def' = constr_of_glob allow_constant to_post post env sigma def in
-      let sigma, t' = Array.fold_left_map (constr_of_glob allow_constant to_post post env) sigma t in
-      let sigma, ty' = constr_of_glob allow_constant to_post post env sigma ty in
+      let sigma, def' = constr_of_glob to_post post env sigma def in
+      let sigma, t' = Array.fold_left_map (constr_of_glob to_post post env) sigma t in
+      let sigma, ty' = constr_of_glob to_post post env sigma ty in
        sigma, mkArray (u',t',def',ty')
   | Glob_term.GSort gs ->
       let sigma,c = Evd.fresh_sort_in_family sigma (Glob_ops.glob_sort_family gs) in
@@ -736,7 +736,7 @@ let rec constr_of_glob allow_constant to_post post env sigma g = match DAst.get 
 
 let constr_of_glob to_post env sigma (Glob_term.AnyGlobConstr g) =
   let post = match to_post with [||] -> [] | _ -> to_post.(0) in
-  constr_of_glob false to_post post env sigma g
+  constr_of_glob to_post post env sigma g
 
 let rec glob_of_constr token_kind ?loc env sigma c = match Constr.kind c with
   | App (c, ca) ->

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -170,7 +170,7 @@ type 'target conversion_kind = 'target * option_kind
    [ToPostCheck r] behaves as [ToPostCopy] except in the reverse
    translation which fails if the copied term is not [r].
    When [n] is null, no translation is performed. *)
-type to_post_arg = ToPostCopy | ToPostAs of int | ToPostHole | ToPostCheck of GlobRef.t
+type to_post_arg = ToPostCopy | ToPostAs of int | ToPostHole | ToPostCheck of Constr.t
 type ('target, 'warning) prim_token_notation_obj =
   { to_kind : 'target conversion_kind;
     to_ty : GlobRef.t;

--- a/plugins/syntax/number.ml
+++ b/plugins/syntax/number.ml
@@ -382,7 +382,7 @@ let elaborate_to_post_via env sigma ty_name ty_ind l =
   to_post, pt_refs
 
 type target_type =
-  | TargetInd of (inductive * GlobRef.t option list)
+  | TargetInd of (inductive * Constr.t option list)
   | TargetPrim of constr_expr * GlobRef.t list * required_module
 
 let locate_global_inductive_with_params allow_params qid =
@@ -394,9 +394,14 @@ let locate_global_inductive_with_params allow_params qid =
     | [], Notation_term.(NApp (NRef (GlobRef.IndRef i,None), l)) ->
        i,
        List.map (function
-           | Notation_term.NRef (r,None) -> Some r
            | Notation_term.NHole _ -> None
-           | _ -> raise Not_found) l
+           | n ->
+              let g = Notation_ops.glob_constr_of_notation_constr n in
+              let c, _ =
+                let env = Global.env () in
+                let sigma = Evd.from_env env in
+                Pretyping.understand env sigma g in
+              Some (EConstr.Unsafe.to_constr c)) l
     | _ -> raise Not_found
 
 let locate_global_inductive allow_params qid =

--- a/plugins/syntax/number.mli
+++ b/plugins/syntax/number.mli
@@ -26,6 +26,6 @@ val vernac_number_notation : locality_flag ->
                              Notation_term.scope_name -> unit
 
 (** These are also used in string notations *)
-val locate_global_inductive : bool -> Libnames.qualid -> Names.inductive * Names.GlobRef.t option list
-val elaborate_to_post_params : Environ.env -> Evd.evar_map -> Names.inductive -> Names.GlobRef.t option list -> (Names.GlobRef.t * Names.GlobRef.t * Notation.to_post_arg list) list array * Names.GlobRef.t list
+val locate_global_inductive : bool -> Libnames.qualid -> Names.inductive * Constr.t option list
+val elaborate_to_post_params : Environ.env -> Evd.evar_map -> Names.inductive -> Constr.t option list -> (Names.GlobRef.t * Names.GlobRef.t * Notation.to_post_arg list) list array * Names.GlobRef.t list
 val elaborate_to_post_via : Environ.env -> Evd.evar_map -> Libnames.qualid -> Names.inductive -> (bool * Libnames.qualid * Libnames.qualid) list -> (Names.GlobRef.t * Names.GlobRef.t * Notation.to_post_arg list) list array * Names.GlobRef.t list

--- a/test-suite/output/NumberNotations.out
+++ b/test-suite/output/NumberNotations.out
@@ -523,3 +523,13 @@ neg_infinity
      : float
 nan
      : float
+2
+     : nunit2
+2
+     : nunit2
+NUnit 3
+     : nunit 3
+NUnit 0
+     : nunit 0
+NUnit (1 + 1)
+     : nunit (1 + 1)

--- a/test-suite/output/NumberNotations.v
+++ b/test-suite/output/NumberNotations.v
@@ -998,3 +998,27 @@ Check neg_infinity.
 Check nan.
 
 End Test29.
+
+Module Test30.
+
+Inductive nunit : nat -> Type := NUnit n : nunit n.
+
+Definition printer2 (x : nunit 2) : Number.uint :=
+  Number.UIntDecimal (Decimal.D2 Decimal.Nil).
+
+Definition parser2 (_ : Number.uint) : nunit 2 := NUnit 2.
+
+Notation nunit2 := (nunit 2).
+Number Notation nunit2 parser2 printer2 : nat_scope.
+
+Check 2.
+Check NUnit (S (S O)).
+Check NUnit (S (S (S O))).
+Check NUnit O.
+
+Check NUnit (S O + S O).
+(* doesn't print as 2, because (S O + S O) is not syntactically equal
+   to (S (S O)), we could want to use a convertibility test rather
+   than a syntactic equality, but this could be more costly *)
+
+End Test30.


### PR DESCRIPTION
Parameter of inductives used for the `Number Notation` command can now be arbitrary terms (rather than just references).

Fixes #14806 

- [x] Added / updated **test-suite**.
