### PR TITLE
[ci] Disable windows64 job until platform is fixed.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -341,17 +341,18 @@ build:quick:
   artifacts:
     when: always
 
-windows64:
-  extends: .platform-template
-  variables:
-    ARCH: "64"
-  script:
-    - call dev/ci/platform-windows.bat
-  tags:
-    - windows-inria
-  only:
-    variables:
-      - $WINDOWS =~ /enabled/
+# Disabled until the platform gets fixed
+# windows64:
+#   extends: .platform-template
+#   variables:
+#     ARCH: "64"
+#   script:
+#     - call dev/ci/platform-windows.bat
+#   tags:
+#     - windows-inria
+#   only:
+#     variables:
+#       - $WINDOWS =~ /enabled/
 
 lint:
   stage: stage-1


### PR DESCRIPTION
The job has been broken for at least a dozen of days, and a solution
doesn't seem in works; disabling until it is fixed to prevent resource
waste thus.
