### PR TITLE
Use typing rather than retyping in with clause of tactics

### DIFF
--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1334,7 +1334,7 @@ let w_coerce env evd mv c =
 
 let unify_to_type env sigma flags c status u =
   let sigma, c = refresh_universes (Some false) env sigma c in
-  let t = get_type_of env sigma (nf_meta env sigma c) in
+  let sigma, t = Typing.type_of env sigma (nf_meta env sigma c) in
   let t = nf_betaiota env sigma (nf_meta env sigma t) in
     unify_0 env sigma CUMUL flags t u
 

--- a/test-suite/success/rewrite.v
+++ b/test-suite/success/rewrite.v
@@ -173,3 +173,11 @@ Proof.
   exact I.
   exact I.
 Qed.
+
+Module IllTypeWithClause.
+
+Axiom L : forall A (f : A -> A) (x:A), f x = x.
+Goal S 0 = 0.
+Fail rewrite L with (f:=0). (* should not be an anomaly *)
+
+End IllTypedWithClause.


### PR DESCRIPTION
**Kind:** ad hoc fix

The following failed with an anomaly:
```
Axiom L : forall A (f : A -> A) (x:A), f x = x.
Goal S 0 = 0.
rewrite L with (f:=0).
(* in retyping: Non-functional construction *)
```
Apparently due to `f:=0` not fully type-checked (in the hope of a possible coercion), but nevertheless substituted in `?f ?x`. The latter is assumed well-typed, using retyping to get the type, but it is not necessarily well-typed.

A correct fix would be to either renouncing to a possible coercion and force the typing of `f` before substituting it in `?f ?x` or to have explicit markers for possible coercions.

In the meantime, we replace retyping by typing.

- [X] Added / updated **test-suite**.
