### PR TITLE
Handle coq project parsing errors in coqdep

### DIFF
--- a/lib/coqProject_file.mli
+++ b/lib/coqProject_file.mli
@@ -43,7 +43,16 @@ and native_compiler =
 | NativeOndemand
 
 val cmdline_args_to_project : warning_fn:(string -> unit) -> curdir:string -> string list -> project
+
+exception UnableToOpenProjectFile of string
+
 val read_project_file : warning_fn:(string -> unit) -> string -> project
+(** [read_project_file warning_fn file] parses [file] as a Coq project;
+    use [warning_fn] for deprecate options;
+    raise [Parsing_error] on illegal options or arguments;
+    raise [UnableToOpenProjectFile msg] if the file could not be opened;
+    fails on some illegal non-project-file options *)
+
 val coqtop_args_from_project : project -> string list
 val find_project_file : from:string -> projfile_name:string -> string option
 


### PR DESCRIPTION
**Kind:**

Handle explicitly parsing errors of a Coq project for coqdep rather than raising `*** Error: Anomaly "Uncaught exception CoqProject_file.Parsing_error(...)"`

This also gives an explicit error message on non-existent Coq project for `coq_makefile` (`Error: foo: No such file or directory.` instead of `Fatal error: exception Sys_error("foo: No such file or directory")`).