### PR TITLE
Fix test-suite after change of output of print grammar.

### DIFF
--- a/test-suite/output/PrintGrammarConstr.out
+++ b/test-suite/output/PrintGrammarConstr.out
@@ -45,8 +45,8 @@ and term is
 | "8" LEFTA
   [  ]
 | "1" LEFTA
-  [ SELF; ".("; "@"; global; LIST0 (term LEVEL "9"); ")"
-  | SELF; ".("; global; LIST0 arg; ")"
+  [ SELF; ".("; "@"; global; univ_annot; LIST0 (term LEVEL "9"); ")"
+  | SELF; ".("; global; univ_annot; LIST0 arg; ")"
   | SELF; "%"; IDENT ]
 | "0" LEFTA
   [ "["; term LEVEL "10"; "+"; "+"; "*"; LIST1 (term LEVEL "10") SEP ["+";


### PR DESCRIPTION
Test-suite is currently broken in master, seemingly some race condition between merges of PRs. This fixes the issue.