### PR TITLE
[CI failure] Fix bad interaction between merging of #13664 and #14598

### DIFF
--- a/test-suite/output/PrintGrammarConstr.out
+++ b/test-suite/output/PrintGrammarConstr.out
@@ -45,8 +45,8 @@ and term is
 | "8" LEFTA
   [  ]
 | "1" LEFTA
-  [ SELF; ".("; "@"; global; LIST0 (term LEVEL "9"); ")"
-  | SELF; ".("; global; LIST0 arg; ")"
+  [ SELF; ".("; "@"; global; univ_annot; LIST0 (term LEVEL "9"); ")"
+  | SELF; ".("; global; univ_annot; LIST0 arg; ")"
   | SELF; "%"; IDENT ]
 | "0" LEFTA
   [ "["; term LEVEL "10"; "+"; "+"; "*"; LIST1 (term LEVEL "10") SEP ["+";


### PR DESCRIPTION
We should have rerun CI before merging #13664, this would have avoided
missing that #13664 forgot to take #14598 into account.

This should fix the test-suite jobs in the CI that are broken since the merging of #13664 
