### PR TITLE
[configure] Detect Dune 2.9, use right install options in this case.

### DIFF
--- a/Makefile.doc
+++ b/Makefile.doc
@@ -255,9 +255,9 @@ $(DOC_STDLIB_DIR)/FullLibrary.pdf: $(DOCCOMMON) $(DOC_STDLIB_DIR)/FullLibrary.co
 # Due to Windows paths not starting with / we can't just set the
 # default to / and always use --destdir
 ifeq ($(DESTDIR),)
-DOCDIRDEST=$(DOCDIR)
+DOCDIRDEST=$(DOCDIR)/coq
 else
-DOCDIRDEST=$(DESTDIR)/$(DOCDIR)
+DOCDIRDEST=$(DESTDIR)/$(DOCDIR)/coq
 endif
 
 install-doc: install-doc-meta install-doc-html install-doc-printable

--- a/Makefile.install
+++ b/Makefile.install
@@ -64,8 +64,8 @@ install-dune: $(BCONTEXT)/coq-core.install $(BCONTEXT)/coqide-server.install
 endif
 
 # IMPORTANT NOTE: before Dune 2.9, the --docdir and --etcdir options
-# were not supported, if you are using Dune >= 2.9, you can use `make
-# DUNE_29_PLUS=1 install` to use the call with the right options.
+# were not supported, if using Dune >= 2.9, Coq's configure will set
+# the DUNE_29_PLUS=yes` variable to use the call with the right options.
 #
 # Additionally, you can also add --libdir=$(COQLIBINSTALL) if required
 # by your distribution, but we recommend using the default configured
@@ -101,9 +101,15 @@ endif
 ifeq ($(HASCOQIDE),no)
 install-coqide:
 else
+ifdef DUNE_29_PLUS
 install-coqide: $(BCONTEXT)/coqide.install
+	dune install --display quiet $(DESTDIRARG) --mandir="$(MANDIR)" --prefix="$(COQPREFIX)" --etcdir="$(CONFIGDIR)" --docdir="$(DOCDIR)" coqide
+else
 	dune install --display quiet $(DESTDIRARG) --mandir="$(MANDIR)" --prefix="$(COQPREFIX)" coqide
 endif
+endif
+
+
 
 # For emacs:
 # Local Variables:

--- a/dev/doc/INSTALL.make.md
+++ b/dev/doc/INSTALL.make.md
@@ -119,15 +119,19 @@ please see the [contributing guide](../../CONTRIBUTING.md).
 Notes for packagers
 -------------------
 
-The `make install` target for Coq's OCaml parts calls `dune
-install` internally. Before Dune 2.9, `dune install` didn't support
-configuring some installation paths such as `-docdir` and
-`-configdir`, thus these configure options were ignored by default.
+The `make install` target for Coq's OCaml parts calls `dune install`
+internally. Before Dune 2.9, `dune install` didn't support configuring
+the `-docdir` and `-configdir` installation paths, thus these
+configure options were ignored for the `coq-core` package.
 
-For Dune >= 2.9, we defining the `DUNE_29_PLUS` variable so these
-options are taken into account by Coq's Makefile. For Dune < 2.9, you
-may have to post-process your package to fix install locations. See
-`Makefile.install` `install-dune` target for more information.
+Coq will try to detect if Dune >= 2.9 is being used, and perform the
+right call to Dune in that case. If Dune < 2.9 is being used, Coq's
+configure will emit a warning. As a packager/user, you have two
+options: a) manually correct the install locations of `doc` and `etc`
+for `coq-core`, or to use a tool such as `opam-install` which already
+supports these options correctly. `dune build -p coq-core &&
+opam-installer $OPTS _build/default/coq-core.install` should do the
+trick.
 
 Installation Procedure For Plugin Developers.
 ---------------------------------------------

--- a/doc/README.md
+++ b/doc/README.md
@@ -136,5 +136,7 @@ To install all produced documents, do:
     make install-doc
 
 This will install the documentation in `/usr/share/doc/coq` unless you
-specify another value through the `-docdir` option of `./configure` or the
-`DOCDIR` environment variable.
+specify another value through the `-docdir` option of `./configure` or
+the `DOCDIR` environment variable. Note that `DOCDIR` controls the
+root of the documentation, that is to say, in the example above, the
+root is `/usr/share/doc`.

--- a/doc/sphinx/changes.rst
+++ b/doc/sphinx/changes.rst
@@ -662,11 +662,17 @@ Infrastructure and dependencies
   by Emilio Jesus Gallego Arias, review by Vincent Laporte, Guillaume
   Melquiond, Enrico Tassi, and Théo Zimmerman).
 - **Changed:**
-  Coq's OCaml parts and tools [coq-core] are now built using Dune.
+  Coq's OCaml parts and tools [``coq-core``] are now built using Dune.
   The main user-facing change is that Dune >= 2.5 is now required to
-  build Coq, most recent Dune is usually recommended.
+  build Coq. This was a large and complex change. If you are packager
+  you may find some minor differences if you were using a lot of custom
+  optimizations. Note that, in particular, the configure option
+  ``-datadir`` is not customizable anymore, and ``-bindir`` has been
+  removed in favor of ``$prefix/bin``. Moreover, the install procedure
+  will ignore ``-docdir`` and ``-etcdir`` for Dune < 2.9.
+  We usually recommended using a recent Dune version, if possible.
   For developers and plugin authors, see the entry in
-  `dev/doc/changes.md`.
+  `dev/doc/changes.md`. For packagers and users, see `dev/doc/INSTALL.make.md`.
   (`#13617 <https://github.com/coq/coq/pull/13617>`_,
   by Emilio Jesús Gallego Arias, Rudi Grinberg, and Théo Zimmerman;
   review and testing by Gaëtan Gilbert, Guillaume Melquiond, and
@@ -677,6 +683,12 @@ Infrastructure and dependencies
   install`` does support the more standard ``DESTDIR`` variable, akin
   to what ``coq_makefile`` does.
   (`#14258 <https://github.com/coq/coq/pull/14258>`_,
+  by Emilio Jesus Gallego Arias).
+- **Changed:**
+  The ``-docdir`` configure option now refers to root path for documentation.
+  If you would like to install Coq documentation in ``foo/coq``, use
+  ``-docdir foo``.
+  (`#14844 <https://github.com/coq/coq/pull/14844>`_,
   by Emilio Jesus Gallego Arias).
 - **Added:**
   Support OCaml 4.12

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -169,7 +169,7 @@ destination_path = $(if $(DESTDIR),$(DESTDIR)/$(call windrive_path,$(1)),$(1))
 
 # Installation paths of libraries and documentation.
 COQLIBINSTALL ?= $(call destination_path,$(COQLIB)/user-contrib)
-COQDOCINSTALL ?= $(call destination_path,$(DOCDIR)/user-contrib)
+COQDOCINSTALL ?= $(call destination_path,$(DOCDIR)/coq/user-contrib)
 COQTOPINSTALL ?= $(call destination_path,$(COQLIB)/toploop) # FIXME: Unused variable?
 
 ########## End of parameters ##################################################


### PR DESCRIPTION
We check Dune's version with configure, and provide a warning if Dune
< 2.9 about it ignoring `-docdir` and `-configdir` options.

We also mention the easiest workaround, using `opam-install` which
supports these options correctly.

Note that as Coq now consists of multiple packages, the `-docdir`
option has been changed to denote the root for the documentation of
all packages, as opposed to the previous behavior where it was used to
point to the absolute documentation path.

Should help with #14232 and #14833
