### PR TITLE
Only run stale scheduled workflow on main Coq repo.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,9 +4,11 @@ on:
   schedule:
     # Every workday at 2am
     - cron: '0 2 * * 1-5'
+    # Do not run on forks (we want this request to happen only once every night)
+    - if: github.repository_owner == 'coq'
 
 jobs:
   stale_prs:
     runs-on: ubuntu-latest
     steps:
-      - run: curl -d "coq:coq" https://coqbot.herokuapp.com/check-stale-pr
+      - run: curl -d "coq:coq:$DAILY_SCHEDULE_SECRET" https://coqbot.herokuapp.com/check-stale-pr


### PR DESCRIPTION
Fix the curl request following the introduction of a secret.
See coq/bot@1899d6a.