### PR TITLE
Using the name of inductive types in inductive blocks rather than indices

### DIFF
--- a/dev/ci/user-overlays/14846-herbelin-master+inlining-inductive-names-in-inductive-blocks.sh
+++ b/dev/ci/user-overlays/14846-herbelin-master+inlining-inductive-names-in-inductive-blocks.sh
@@ -1,0 +1,5 @@
+overlay coq_dpdgraph https://github.com/herbelin/coq-dpdgraph.git coq-master+adapt-coq-pr14846-ind-as-ind-rather-than-rel-in-constructor-types 14846 master+inlining-inductive-names-in-inductive-blocks
+overlay elpi https://github.com/herbelin/coq-elpi coq-master+adapt-coq-pr14846-ind-as-ind-rather-than-rel-in-constructor-types 14846 master+inlining-inductive-names-in-inductive-blocks
+overlay equations https://github.com/herbelin/Coq-Equations master+adapt-coq-pr14846-ind-as-ind-rather-than-rel-in-constructor-types 14846 master+inlining-inductive-names-in-inductive-blocks
+overlay paramcoq https://github.com/herbelin/paramcoq master+adapt-coq-pr14846-ind-as-ind-rather-than-rel-in-constructor-types 14846 master+inlining-inductive-names-in-inductive-blocks
+overlay metacoq https://github.com/herbelin/template-coq master+adapt-coq-pr14846-ind-as-ind-rather-than-rel-in-constructor-types 14846 master+inlining-inductive-names-in-inductive-blocks

--- a/dev/doc/changes.md
+++ b/dev/doc/changes.md
@@ -1,5 +1,21 @@
 ## Changes between Coq 8.14 and Coq 8.15
 
+### Internal representation of the type of constructors
+
+The type of constructors in fields `mind_user_lc` and `mind_nf_lc` of
+an inductive packet (see `declarations.ml`) now directly refer to the
+inductive type rather than to a `Rel` poimting in a context made of the
+declaration of the inductive types of the block. Thus, instead of `Rel
+n`, one finds `Ind((mind,ntypes-n),u)` where `ntypes` is the number of
+types in the block and `u` is the canonical instance of polymoprhic
+universes (i.e. `Level.Var 0` ... `Level.Var (nbuniv-1)`).
+
+In general, code can be adapted by:
+- either removing a substitution `Rel`->`Ind` if such substitution was applied
+- or inserting a call to
+  `Inductive.abstract_constructor_type_relatively_to_inductive_types_context`
+  to restore `Rel`s in place of `Ind`s if `Rel`s were expected.
+
 ### Universes
 
 - Type `Univ.UContext` now embeds universe user names, generally

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -392,10 +392,9 @@ let expand_branch env _sigma u pms (ind, i) (nas, _br) =
   let (mib, mip) = Inductive.lookup_mind_specif env ind in
   let paramdecl = Vars.subst_instance_context u mib.mind_params_ctxt in
   let paramsubst = Vars.subst_of_rel_context_instance paramdecl pms in
-  let subst = paramsubst @ Inductive.ind_subst (fst ind) mib u in
   let (ctx, _) = mip.mind_nf_lc.(i - 1) in
   let (ctx, _) = List.chop mip.mind_consnrealdecls.(i - 1) ctx in
-  let ans = Inductive.instantiate_context u subst nas ctx in
+  let ans = Inductive.instantiate_context u paramsubst nas ctx in
   let ans : rel_context = match Evd.MiniEConstr.unsafe_eq with Refl -> ans in
   ans
 

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -708,6 +708,9 @@ let subst_univs_level_constr subst c =
 let subst_instance_context subst ctx =
   cast_rel_context (sym unsafe_eq) (Vars.subst_instance_context subst (cast_rel_context unsafe_eq ctx))
 
+let subst_instance_constr subst c =
+  of_constr (Vars.subst_instance_constr subst (to_constr c))
+
 (** Operations that dot NOT commute with evar-normalization *)
 let noccurn sigma n term =
   let rec occur_rec n c = match kind sigma c with

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -301,6 +301,7 @@ val closed0 : Evd.evar_map -> t -> bool
 
 val subst_univs_level_constr : Univ.universe_level_subst -> t -> t
 val subst_instance_context : Univ.Instance.t -> rel_context -> rel_context
+val subst_instance_constr : Univ.Instance.t -> t -> t
 
 val subst_of_rel_context_instance : rel_context -> instance -> substl
 val subst_of_rel_context_instance_list : rel_context -> instance_list -> substl

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -880,16 +880,9 @@ let drop_parameters depth n argstk =
   (* we know that n < stack_args_size(argstk) (if well-typed term) *)
   anomaly (Pp.str "ill-typed term: found a match on a partially applied constructor.")
 
-let inductive_subst (ind, _) mib u pms e =
-  let rec self i accu =
-    if Int.equal i mib.mind_ntypes then accu
-    else
-      let c = inject (mkIndU ((ind, i), u)) in
-      self (i + 1) (subs_cons c accu)
-  in
-  let self = self 0 (subs_id 0) in
+let inductive_subst mib u pms e =
   let rec mk_pms i ctx = match ctx with
-  | [] -> self
+  | [] -> subs_id 0
   | RelDecl.LocalAssum _ :: ctx ->
     let c = mk_clos e pms.(i) in
     let subs = mk_pms (i - 1) ctx in
@@ -930,7 +923,7 @@ let get_branch infos depth ci u pms (ind, c) br e args =
     | Zshift _ | ZcaseT _ | Zproj _ | Zfix _ | Zupdate _ | Zprimitive _ ->
       assert false
     in
-    let ind_subst = inductive_subst ind mib u pms e in
+    let ind_subst = inductive_subst mib u pms e in
     let args = Array.concat (List.map map args) in
     let rec push i e = function
     | [] -> []

--- a/kernel/declarations.ml
+++ b/kernel/declarations.ml
@@ -182,21 +182,33 @@ type regular_inductive_arity = {
 
 type inductive_arity = (regular_inductive_arity, template_arity) declaration_arity
 
+(** {7 Datas specific to a single type of a block of mutually inductive type } *)
 type one_inductive_body = {
 (** {8 Primitive datas } *)
 
     mind_typename : Id.t; (** Name of the type: [Ii] *)
 
-    mind_arity_ctxt : Constr.rel_context; (** Arity context of [Ii] with parameters: [forall params, Ui] *)
+    mind_arity_ctxt : Constr.rel_context;
+ (** Arity context of [Ii]. It includes the context of parameters,
+     that is, it has the form [paramdecls, realdecls_i] such that [Ui]
+     (see above) is [forall realdecls_i, si] for some sort [si] and
+     such that [Ii] has thus type [forall paramdecls, forall
+     realdecls_i, si]. The context itself is represented internally as
+     a list in reverse order
+     [[realdecl_i{r_i};...;realdecl_i1;paramdecl_m;...;paramdecl_1]]. *)
 
     mind_arity : inductive_arity; (** Arity sort and original user arity *)
 
     mind_consnames : Id.t array; (** Names of the constructors: [cij] *)
 
     mind_user_lc : types array;
- (** Types of the constructors with parameters:  [forall params, Tij],
-     where the Ik are replaced by de Bruijn index in the
-     context I1:forall params, U1 ..  In:forall params, Un *)
+ (** Types of the constructors with parameters: [forall params, Tij],
+     where the recursive occurrences of the inductive types in [Tij]
+     (i.e. in the type of the j-th constructor of the i-th types of
+     the block a shown above) have the form [Ind ((mind,0),u)], ...,
+     [Ind ((mind,n-1),u)] for [u] the canonical abstract instance
+     associated to [mind_universes] and [mind] the name to which the
+     inductive block is bound in the environment. *)
 
 (** {8 Derived datas } *)
 
@@ -206,7 +218,18 @@ type one_inductive_body = {
 
     mind_kelim : Sorts.family; (** Highest allowed elimination sort *)
 
-    mind_nf_lc : (rel_context * types) array; (** Head normalized constructor types so that their conclusion exposes the inductive type *)
+    mind_nf_lc : (rel_context * types) array;
+ (** Head normalized constructor types so that their conclusion
+     exposes the inductive type. It includes the parameters, i.e. each
+     component of the array has the form [(decls_ij, Ii params realargs_ij)]
+     where [decls_ij] is the concatenation of the context of parameters
+     (possibly with let-ins) and of the arguments of the constructor
+     (possibly with let-ins). This context is internally represented
+     as a list [[cstrdecl_ij{q_ij};...;cstrdecl_ij1;paramdecl_m;...;paramdecl_1]]
+     such that the constructor in fine has type [forall paramdecls,
+     forall cstrdecls_ij, Ii params realargs_ij]] with [params] referring to
+     the assumptions of [paramdecls] and [realargs_ij] being the
+     "indices" specific to the constructor. *)
 
     mind_consnrealargs : int array;
  (** Number of expected proper arguments of the constructors (w/o params) *)
@@ -231,6 +254,8 @@ type recursivity_kind =
   | Finite (** = inductive *)
   | CoFinite (** = coinductive *)
   | BiFinite (** = non-recursive, like in "Record" definitions *)
+
+(** {7 Datas associated to a full block of mutually inductive types } *)
 
 type mutual_inductive_body = {
 

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -60,18 +60,6 @@ let instantiate_inductive_constraints mib u =
 
 (************************************************************************)
 
-(* Build the substitution that replaces Rels by the appropriate *)
-(* inductives *)
-let ind_subst mind mib u =
-  let ntypes = mib.mind_ntypes in
-  let make_Ik k = mkIndU ((mind,ntypes-k-1),u) in
-  List.init ntypes make_Ik
-
-(* Instantiate inductives in constructor type *)
-let constructor_instantiate mind u mib c =
-  let s = ind_subst mind mib u in
-    substl s (subst_instance_constr u c)
-
 let instantiate_params t u args sign =
   let fail () =
     anomaly ~label:"instantiate_params" (Pp.str "type, ctxt and args mismatch.") in
@@ -94,8 +82,8 @@ let full_inductive_instantiate mib u params sign =
   let t = Term.mkArity (Vars.subst_instance_context u sign,dummy) in
     fst (Term.destArity (instantiate_params t u params mib.mind_params_ctxt))
 
-let full_constructor_instantiate ((mind,_),u,(mib,_),params) t =
-  let inst_ind = constructor_instantiate mind u mib t in
+let full_constructor_instantiate (_,u,(mib,_),params) t =
+  let inst_ind = subst_instance_constr u t in
    instantiate_params inst_ind u params mib.mind_params_ctxt
 
 (************************************************************************)
@@ -261,32 +249,35 @@ let max_inductive_sort =
 
 let type_of_constructor (cstr, u) (mib,mip) =
   check_instance mib u;
-  let ind = inductive_of_constructor cstr in
-  let specif = mip.mind_user_lc in
   let i = index_of_constructor cstr in
   let nconstr = Array.length mip.mind_consnames in
   if i > nconstr then user_err Pp.(str "Not enough constructors in the type.");
-  constructor_instantiate (fst ind) u mib specif.(i-1)
+  subst_instance_constr u mip.mind_user_lc.(i-1)
 
 let constrained_type_of_constructor (_cstr,u as cstru) (mib,_mip as ind) =
   let ty = type_of_constructor cstru ind in
   let cst = instantiate_inductive_constraints mib u in
     (ty, cst)
 
-let arities_of_specif (kn,u) (mib,mip) =
-  let specif = mip.mind_nf_lc in
+let arities_of_constructors (_,u) (_,mip) =
   let map (ctx, c) =
     let cty = Term.it_mkProd_or_LetIn c ctx in
-    constructor_instantiate kn u mib cty
+    subst_instance_constr u cty
   in
-  Array.map map specif
+  Array.map map mip.mind_nf_lc
 
-let arities_of_constructors ind specif =
-  arities_of_specif (fst (fst ind), snd ind) specif
+let type_of_constructors (_,u) (_,mip) =
+  Array.map (subst_instance_constr u) mip.mind_user_lc
 
-let type_of_constructors (ind,u) (mib,mip) =
-  let specif = mip.mind_user_lc in
-    Array.map (constructor_instantiate (fst ind) u mib) specif
+let abstract_constructor_type_relatively_to_inductive_types_context ntyps mind t =
+  let rec replace_ind k c =
+    let hd, args = decompose_appvect c in
+    match kind hd with
+    | Ind ((mind',i),_) when MutInd.CanOrd.equal mind mind' ->
+       mkApp (mkRel (ntyps+k-i), Array.map (replace_ind k) args)
+    | _ -> map_with_binders succ replace_ind k c
+  in
+  replace_ind 0 t
 
 (************************************************************************)
 
@@ -415,11 +406,10 @@ let expand_case_specif mib (ci, u, params, p, iv, c, br) =
     Term.it_mkLambda_or_LetIn p realdecls
   in
   (* Expand the branches *)
-  let subst = paramsubst @ ind_subst (fst ci.ci_ind) mib u in
   let ebr =
     let build_one_branch i (nas, br) (ctx, _) =
       let ctx, _ = List.chop mip.mind_consnrealdecls.(i) ctx in
-      let ctx = instantiate_context u subst nas ctx in
+      let ctx = instantiate_context u paramsubst nas ctx in
       Term.it_mkLambda_or_LetIn br ctx
     in
     Array.map2_i build_one_branch br mip.mind_nf_lc
@@ -696,10 +686,10 @@ let ienv_push_var (env, lra) (x,a,ra) =
 let ienv_push_inductive (env, ra_env) ((mind,u),lpar) =
   let mib = Environ.lookup_mind mind env in
   let ntypes = mib.mind_ntypes in
-  let push_ind specif env =
-    let r = specif.mind_relevance in
+  let push_ind mip env =
+    let r = mip.mind_relevance in
     let anon = Context.make_annot Anonymous r in
-    let decl = LocalAssum (anon, hnf_prod_applist env (type_of_inductive ((mib,specif),u)) lpar) in
+    let decl = LocalAssum (anon, hnf_prod_applist env (type_of_inductive ((mib,mip),u)) lpar) in
     push_rel decl env
   in
   let env = Array.fold_right push_ind mib.mind_packets env in
@@ -717,25 +707,29 @@ let rec ienv_decompose_prod (env,_ as ienv) n c =
      ienv_decompose_prod ienv' (n-1) b
      | _ -> assert false
 
-let dummy_univ = Level.(make (UGlobal.make (DirPath.make [Id.of_string "implicit"]) "" 0))
-let dummy_implicit_sort = mkType (Universe.make dummy_univ)
-let lambda_implicit_lift n a =
-  let anon = Context.make_annot Anonymous Sorts.Relevant in
-  let lambda_implicit a = mkLambda (anon, dummy_implicit_sort, a) in
-  iterate lambda_implicit n (lift n a)
-
 (* This removes global parameters of the inductive types in lc (for
    nested inductive types only ) *)
-let abstract_mind_lc ntyps npars lc =
+let dummy_univ = Level.(make (UGlobal.make (DirPath.make [Id.of_string "implicit"]) "" 0))
+let dummy_implicit_sort = mkType (Universe.make dummy_univ)
+let lambda_implicit n a =
+  let anon = Context.make_annot Anonymous Sorts.Relevant in
+  let lambda_implicit a = mkLambda (anon, dummy_implicit_sort, a) in
+  iterate lambda_implicit n a
+
+let abstract_mind_lc ntyps npars mind lc =
   let lc = Array.map (fun (ctx, c) -> Term.it_mkProd_or_LetIn c ctx) lc in
-  if Int.equal npars 0 then
-    lc
-  else
-    let make_abs =
-      List.init ntyps
-        (function i -> lambda_implicit_lift npars (mkRel (i+1)))
-    in
-    Array.map (substl make_abs) lc
+  let rec replace_ind k c =
+    let hd, args = decompose_app c in
+    match kind hd with
+    | Ind ((mind',i),_) when MutInd.CanOrd.equal mind mind' ->
+      let rec drop_params n = function
+        | _ :: args when n > 0 -> drop_params (n-1) args
+        | args -> lambda_implicit n (Term.applist (mkRel (ntyps+n+k-i), List.Smart.map (replace_ind (n+k)) args))
+      in
+      drop_params npars args
+    | _ -> map_with_binders succ replace_ind k c
+  in
+  Array.map (replace_ind 0) lc
 
 let is_primitive_positive_container env c =
   match env.retroknowledge.Retroknowledge.retro_array with
@@ -796,9 +790,9 @@ let get_recargs_approx env tree ind args =
       if Int.equal auxntyp 1 then [|dest_subterms tree|]
       else Array.map (fun mip -> dest_subterms mip.mind_recargs) mib.mind_packets
     in
-    let mk_irecargs j specif =
+    let mk_irecargs j mip =
       (* The nested inductive type with parameters removed *)
-      let auxlcvect = abstract_mind_lc auxntyp auxnpar specif.mind_nf_lc in
+      let auxlcvect = abstract_mind_lc auxntyp auxnpar mind mip.mind_nf_lc in
       let paths = Array.mapi
         (fun k c ->
          let c' = hnf_prod_applist env' c lpar' in

--- a/kernel/inductive.mli
+++ b/kernel/inductive.mli
@@ -34,8 +34,6 @@ type mind_specif = mutual_inductive_body * one_inductive_body
 val lookup_mind_specif : env -> inductive -> mind_specif
 
 (** {6 Functions to build standard types related to inductive } *)
-val ind_subst : MutInd.t -> mutual_inductive_body -> Instance.t -> constr list
-
 val inductive_paramdecls : mutual_inductive_body puniverses -> Constr.rel_context
 
 val instantiate_inductive_constraints :
@@ -74,8 +72,13 @@ val arities_of_constructors : pinductive -> mind_specif -> types array
 (** Return constructor types in user form *)
 val type_of_constructors : pinductive -> mind_specif -> types array
 
-(** Transforms inductive specification into types (in nf) *)
-val arities_of_specif : MutInd.t puniverses -> mind_specif -> types array
+(** Turns a constructor type recursively referring to inductive types
+    into the same constructor type referring instead to a context made
+    from the abstract declaration of the inductive types (e.g. turns
+    [nat->nat] into [Rel 1 -> Rel 1]); takes as arguments the number
+    of inductive types in the block and the name of the block *)
+val abstract_constructor_type_relatively_to_inductive_types_context :
+  int -> MutInd.t -> types -> types
 
 val inductive_params : mind_specif -> int
 
@@ -166,6 +169,4 @@ type stack_element = |SClosure of guard_env*constr |SArg of subterm_spec Lazy.t
 
 val subterm_specif : guard_env -> stack_element list -> constr -> subterm_spec
 
-val lambda_implicit_lift : int -> constr -> constr
-
-val abstract_mind_lc : int -> Int.t -> (rel_context * constr) array -> constr array
+val abstract_mind_lc : int -> int -> MutInd.t -> (rel_context * constr) array -> constr array

--- a/kernel/inductive.mli
+++ b/kernel/inductive.mli
@@ -75,7 +75,7 @@ val type_of_constructors : pinductive -> mind_specif -> types array
 (** Turns a constructor type recursively referring to inductive types
     into the same constructor type referring instead to a context made
     from the abstract declaration of the inductive types (e.g. turns
-    [nat->nat] into [Rel 1 -> Rel 1]); takes as arguments the number
+    [nat->nat] into [mkArrowR (Rel 1) (Rel 2)]); takes as arguments the number
     of inductive types in the block and the name of the block *)
 val abstract_constructor_type_relatively_to_inductive_types_context :
   int -> MutInd.t -> types -> types

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1418,7 +1418,7 @@ let check_register_ind (type t) ind (r : t CPrimitives.prim_ind) env =
     check_if (Constr.equal t ob.mind_user_lc.(pos))
       Pp.(str"the " ++ int (pos + 1) ++ str
        "th constructor does not have the expected type") in
-  let check_type_cte pos = check_type pos (Constr.mkRel 1) in
+  let check_type_cte pos = check_type pos (Constr.mkInd ind) in
   match r with
   | CPrimitives.PIT_bool ->
     check_nparams 0;
@@ -1439,7 +1439,7 @@ let check_register_ind (type t) ind (r : t CPrimitives.prim_ind) env =
       check_if (Constr.is_Type d) s;
       check_if
         (Constr.equal
-                (mkProd (Context.anonR,mkRel 1, mkApp (mkRel 3,[|mkRel 2|])))
+                (mkProd (Context.anonR,mkRel 1, mkApp (mkInd ind,[|mkRel 2|])))
                 cd)
         s in
     check_name 0 "C0";
@@ -1458,7 +1458,7 @@ let check_register_ind (type t) ind (r : t CPrimitives.prim_ind) env =
         check_if (is_Type _B) s;
         check_if (Constr.equal a (mkRel 2)) s;
         check_if (Constr.equal b (mkRel 2)) s;
-        check_if (Constr.equal codom (mkApp (mkRel 5,[|mkRel 4; mkRel 3|]))) s
+        check_if (Constr.equal codom (mkApp (mkInd ind,[|mkRel 4; mkRel 3|]))) s
       | _ -> check_if false s
     end
   | CPrimitives.PIT_cmp ->

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -156,14 +156,14 @@ let check_inductive cst env mp1 l info1 mp2 mib2 spec2 subst1 subst2 reso1 reso2
         cst
   in
   let mind = MutInd.make1 kn1 in
-  let check_cons_types _i cst p1 p2 =
+  let check_cons_types i cst p1 p2 =
     Array.fold_left3
       (fun cst id t1 t2 -> check_conv (NotConvertibleConstructorField id) cst
         (inductive_is_polymorphic mib1) (infer_conv ?l2r:None ?evars:None ?ts:None) env t1 t2)
       cst
       p2.mind_consnames
-      (arities_of_specif (mind, inst) (mib1, p1))
-      (arities_of_specif (mind, inst) (mib2, p2))
+      (arities_of_constructors ((mind,i), inst) (mib1, p1))
+      (arities_of_constructors ((mind,i), inst) (mib2, p2))
   in
   let check f test why = if not (test (f mib1) (f mib2)) then error (why (f mib2)) in
   check (fun mib -> mib.mind_finite<>CoFinite) (==) (fun x -> FiniteInductiveFieldExpected x);

--- a/pretyping/cbv.ml
+++ b/pretyping/cbv.ml
@@ -413,10 +413,9 @@ let expand_branch env u pms (ind, i) br =
   let (mib, mip) = Inductive.lookup_mind_specif env ind in
   let paramdecl = Vars.subst_instance_context u mib.mind_params_ctxt in
   let paramsubst = Vars.subst_of_rel_context_instance paramdecl pms in
-  let subst = paramsubst @ Inductive.ind_subst (fst ind) mib u in
   let (ctx, _) = mip.mind_nf_lc.(i - 1) in
   let (ctx, _) = List.chop mip.mind_consnrealdecls.(i - 1) ctx in
-  Inductive.instantiate_context u subst nas ctx
+  Inductive.instantiate_context u paramsubst nas ctx
 
 let cbv_subst_of_rel_context_instance_list mkclos sign args env =
   let rec aux subst sign l =

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -96,10 +96,9 @@ let branch env sigma (ind, i) u params (nas, br) =
     let mip = mib.mind_packets.(snd ind) in
     let paramdecl = subst_instance_context u mib.mind_params_ctxt in
     let paramsubst = subst_of_rel_context_instance paramdecl params in
-    let subst = paramsubst @ Inductive.ind_subst (fst ind) mib u in
     let (ctx, _) = mip.mind_nf_lc.(i - 1) in
     let ctx, _ = List.chop mip.mind_consnrealdecls.(i - 1) ctx in
-    let ctx = instantiate_context u subst nas ctx in
+    let ctx = instantiate_context u paramsubst nas ctx in
     List.map EConstr.of_rel_decl ctx, br
   with e when CErrors.noncritical e ->
     let dummy na = LocalAssum (na, EConstr.mkProp) in

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -104,13 +104,10 @@ let mis_is_recursive (ind,mib,mip) =
     mip.mind_recargs
 
 let mis_nf_constructor_type ((ind,u),mib,mip) j =
-  let specif = mip.mind_nf_lc
-  and ntypes = mib.mind_ntypes
-  and nconstr = Array.length mip.mind_consnames in
-  let make_Ik k = mkIndU (((fst ind),ntypes-k-1),u) in
+  let nconstr = Array.length mip.mind_consnames in
   if j > nconstr then user_err Pp.(str "Not enough constructors in the type.");
-  let (ctx, cty) = specif.(j - 1) in
-  substl (List.init ntypes make_Ik) (subst_instance_constr u (Term.it_mkProd_or_LetIn cty ctx))
+  let (ctx, cty) = mip.mind_nf_lc.(j - 1) in
+  subst_instance_constr u (Term.it_mkProd_or_LetIn cty ctx)
 
 (* Number of constructors *)
 
@@ -486,10 +483,8 @@ let compute_projections env (kn, i as ind) =
   in
   let pkt = mib.mind_packets.(i) in
   let { mind_nparams = nparamargs; mind_params_ctxt = params } = mib in
-  let subst = List.init mib.mind_ntypes (fun i -> mkIndU ((kn, mib.mind_ntypes - i - 1), u)) in
-  let ctx, cty = pkt.mind_nf_lc.(0) in
-  let rctx, _ = decompose_prod_assum (substl subst (Term.it_mkProd_or_LetIn cty ctx)) in
-  let ctx, paramslet = List.chop pkt.mind_consnrealdecls.(0) rctx in
+  let ctx, _ = pkt.mind_nf_lc.(0) in
+  let ctx, paramslet = List.chop pkt.mind_consnrealdecls.(0) ctx in
   (* We build a substitution smashing the lets in the record parameters so
      that typechecking projections requires just a substitution and not
      matching with a parameter context. *)

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -118,8 +118,7 @@ let find_rectype_a env sigma c =
 
 let type_constructor mind mib u (ctx, typ) params =
   let typ = it_mkProd_or_LetIn typ ctx in
-  let s = ind_subst mind mib u in
-  let ctyp = substl s typ in
+  let ctyp = subst_instance_constr u typ in
   let nparams = Array.length params in
   if Int.equal nparams 0 then ctyp
   else

--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -72,9 +72,7 @@ let find_rectype_a env sigma c =
 
 let type_constructor mind mib u (ctx, typ) params =
   let typ = it_mkProd_or_LetIn typ ctx in
-  let s = ind_subst mind mib u in
-  let ctyp = substl s typ in
-  let ctyp = subst_instance_constr u ctyp in
+  let ctyp = subst_instance_constr u typ in
   let ndecls = Context.Rel.length mib.mind_params_ctxt in
   if Int.equal ndecls 0 then ctyp
   else

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -21,7 +21,6 @@ open CErrors
 open Util
 open Names
 open Constr
-open Context
 open Declarations
 open Mod_subst
 open Printer
@@ -265,33 +264,19 @@ and traverse_inductive (curr, data, ax2ty) mind obj =
    (* Invariant : I_0 \in data iff I_i \in data iff c_ij \in data
       where I_0, I_1, ... are in the same mutual definition and c_ij
       are all their constructors. *)
-   if GlobRef.Map_env.mem firstind_ref data then data, ax2ty else
+   if
+     (* recursive call: *) GlobRef.Set_env.mem firstind_ref curr ||
+     (* already in: *) GlobRef.Map_env.mem firstind_ref data
+   then data, ax2ty
+   else
+     (* Take into account potential recursivity of ind in itself *)
+     let curr = GlobRef.Set_env.add firstind_ref GlobRef.Set_env.empty in
+     let accu = (curr, data, ax2ty) in
      let mib = lookup_mind mind in
      (* Collects references of parameters *)
      let param_ctx = mib.mind_params_ctxt in
      let nparam = List.length param_ctx in
-     let accu =
-       traverse_context label Context.Rel.empty
-                        (GlobRef.Set_env.empty, data, ax2ty) param_ctx
-     in
-     (* Build the context of all arities *)
-     let arities_ctx =
-       let instance =
-         let open Univ in
-         Instance.of_array
-           (Array.init
-              (AbstractContext.size
-                 (Declareops.inductive_polymorphic_context mib))
-              Level.var)
-       in
-       Array.fold_left (fun accu oib ->
-          let pspecif = ((mib, oib), instance) in
-          let ind_type = Inductive.type_of_inductive pspecif in
-          let indr = oib.mind_relevance in
-          let ind_name = Name oib.mind_typename in
-          Context.Rel.add (Context.Rel.Declaration.LocalAssum (make_annot ind_name indr, ind_type)) accu)
-          Context.Rel.empty mib.mind_packets
-     in
+     let accu = traverse_context label Context.Rel.empty accu param_ctx in
      (* For each inductive, collects references in their arity and in the type
         of constructors*)
      let (contents, data, ax2ty) = Array.fold_left (fun accu oib ->
@@ -304,20 +289,21 @@ and traverse_inductive (curr, data, ax2ty) mind obj =
          in
          Array.fold_left (fun accu cst_typ ->
             let param_ctx, cst_typ_wo_param = Term.decompose_prod_n_assum nparam cst_typ in
-            let ctx = Context.(Rel.fold_outside Context.Rel.add ~init:arities_ctx param_ctx) in
-            traverse label ctx accu cst_typ_wo_param)
+            traverse label param_ctx accu cst_typ_wo_param)
           accu oib.mind_user_lc)
        accu mib.mind_packets
      in
      (* Maps all these dependencies to inductives and constructors*)
-     let data = Array.fold_left_i (fun n data oib ->
+     let data =
+       let contents = GlobRef.Set_env.remove firstind_ref contents in
+       Array.fold_left_i (fun n data oib ->
        let ind = (mind, n) in
        let data = GlobRef.Map_env.add (GlobRef.IndRef ind) contents data in
        Array.fold_left_i (fun k data _ ->
          GlobRef.Map_env.add (GlobRef.ConstructRef (ind, k+1)) contents data
        ) data oib.mind_consnames) data mib.mind_packets
      in
-     data, ax2ty
+     (data, ax2ty)
   in
   (GlobRef.Set_env.add obj curr, data, ax2ty)
 

--- a/vernac/assumptions.mli
+++ b/vernac/assumptions.mli
@@ -18,6 +18,8 @@ open Printer
     WARNING: some terms may not make sense in the environment, because they are
     sealed inside opaque modules. Do not try to do anything fancy with those
     terms apart from printing them, otherwise demons may fly out of your nose.
+
+    NOTE: this function is used in the plugin paramcoq.
 *)
 val traverse :
   Label.t -> constr ->


### PR DESCRIPTION
**Kind:** representation of kernel structures

Experimenting using the name of inductive types in inductive blocks rather than indices. This is priori more intuitive and it [saves](https://github.com/coq/coq/pull/14846#issuecomment-915834340) a couple of instantiations every time we are looking for the type of a constructor.

On the other side, this introduces a dependency of a block of mutual inductive types in the kernel name it will be bound to, but this dependency actually already exists anyway in the type of projections. So, if we don't want this dependency, the type of projections should be changed instead.

A risk is that this might require plugins working on kernel structures to be adapted.

Incidentally, it allowed to observe that substitution of polymorphic universes was missing in `kernel/nativenorm.ml` and `kernel/vnorm.ml` for the type of constructors (is that exploitable? can it lead to universes `Var` being bound at the wrong level of binders?).

- [x] Added **changelog** (in `dev/doc/changes.md` but probably also in main changelog as this is a bit disruptive)
- [x] Opened **overlay** pull requests:
  - Karmaki/coq-dpdgraph#83
  - LPCIC/coq-elpi#289
  - mattam82/Coq-Equations#425
  - coq-community/paramcoq#77 
  -  MetaCoq/metacoq#586
- [x] Decide about using Unicode indices in documentation of `declarations.ml` (no Unicode)
