### PR TITLE
Uniformly use dnets for goals with evars in all auto tactics

### DIFF
--- a/dev/ci/user-overlays/14848-ppedrot-btermdn-discriminate-evar.sh
+++ b/dev/ci/user-overlays/14848-ppedrot-btermdn-discriminate-evar.sh
@@ -1,0 +1,1 @@
+overlay coqhammer https://github.com/ppedrot/coqhammer btermdn-discriminate-evar 14848

--- a/doc/changelog/04-tactics/14848-btermdn-discriminate-evar.rst
+++ b/doc/changelog/04-tactics/14848-btermdn-discriminate-evar.rst
@@ -1,0 +1,7 @@
+- **Changed:**
+  Use discrimination nets for goals containing evars in all
+  :tacn:`auto` tactics. It essentially makes the behavior of undiscriminated
+  databases to be the one of discriminated databases where all constants are
+  considered transparent. This may be incompatible with previous behavior in
+  very rare cases (`#14848 <https://github.com/coq/coq/pull/14848>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/proofs/automatic-tactics/auto.rst
+++ b/doc/sphinx/proofs/automatic-tactics/auto.rst
@@ -322,19 +322,15 @@ and `Constants`, while implicitly created databases have the `Opaque` setting.
 .. cmd:: Create HintDb @ident {? discriminated }
 
    Creates a new hint database named :n:`@ident`. The database is
-   implemented by a Discrimination Tree (DT) that serves as an index of
-   all the lemmas. The DT can use transparency information to decide if a
-   constant should be indexed or not
-   making the retrieval more efficient. The legacy implementation (the default one
-   for new databases) uses the DT only on goals without existentials (i.e., :tacn:`auto`
-   goals), for non-Immediate hints and does not make use of transparency
-   hints, putting more work on the unification that is run after
-   retrieval (it keeps a list of the lemmas in case the DT is not used).
-   The new implementation enabled by the discriminated option makes use
-   of DTs in all cases and takes transparency information into account.
-   However, the order in which hints are retrieved from the DT may differ
-   from the order in which they were inserted, making this implementation
-   observationally different from the legacy one.
+   implemented by a Discrimination Tree (DT) that serves as a filter to select
+   the lemmas that will be applied. When discriminated, the DT uses
+   transparency information to decide if a constant should considered rigid for
+   filtering, making the retrieval more efficient. By contrast, undiscriminated
+   databases treat all constants as transparent, resulting in a larger
+   number of selected lemmas to be applied, and thus putting more pressure on
+   unification.
+
+   By default, hint databases are undiscriminated.
 
 .. _creating_hints:
 

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -263,7 +263,7 @@ let hintmap_of env sigma secvars hdc concl =
   | None -> Hint_db.map_none ~secvars
   | Some hdc ->
      if occur_existential sigma concl then
-       (fun db -> match Hint_db.map_existential sigma ~secvars hdc concl db with
+       (fun db -> match Hint_db.map_eauto env sigma ~secvars hdc concl db with
                   | ModeMatch l -> l
                   | ModeMismatch -> [])
      else Hint_db.map_auto env sigma ~secvars hdc concl

--- a/tactics/btermdn.ml
+++ b/tactics/btermdn.ml
@@ -112,7 +112,7 @@ let constr_val_discr env sigma ts t =
       if Option.is_empty ts && List.is_empty l then Nothing
       else Everything
     | Sort _ -> Label(SortLabel, [])
-    | Evar _ -> if Option.is_empty ts then Nothing else Everything
+    | Evar _ -> Everything
     | Case (_, _, _, _, _, c, _) ->
       (* Overapproximate wildly. TODO: be less brutal. *)
       Everything

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -260,10 +260,7 @@ let hintmap_of env sigma hdc secvars concl =
   match hdc with
   | None -> fun db -> ModeMatch (Hint_db.map_none ~secvars db)
   | Some hdc ->
-     fun db ->
-       if Hint_db.use_dn db then (* Using dnet *)
-         Hint_db.map_eauto env sigma ~secvars hdc concl db
-      else Hint_db.map_existential sigma ~secvars hdc concl db
+    fun db -> Hint_db.map_eauto env sigma ~secvars hdc concl db
 
 (** Hack to properly solve dependent evars that are typeclasses *)
 let rec e_trivial_fail_db only_classes db_list local_db secvars =

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -77,7 +77,7 @@ let hintmap_of env sigma secvars concl =
   | Some hdc ->
      if occur_existential sigma concl then
        (fun db ->
-          match Hint_db.map_existential sigma ~secvars hdc concl db with
+          match Hint_db.map_eauto env sigma ~secvars hdc concl db with
           | ModeMatch l -> l
           | ModeMismatch -> [])
      else (fun db -> Hint_db.map_auto env sigma ~secvars hdc concl db)

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -118,13 +118,6 @@ module Hint_db :
     val map_all : secvars:Id.Pred.t -> GlobRef.t -> t -> FullHint.t list
 
     (** All hints associated to the reference, respecting modes if evars appear in the
-        arguments, _not_ using the discrimination net.
-        Returns a [ModeMismatch] if there are declared modes and none matches.
-        *)
-    val map_existential : evar_map -> secvars:Id.Pred.t ->
-      (GlobRef.t * constr array) -> constr -> t -> FullHint.t list with_mode
-
-    (** All hints associated to the reference, respecting modes if evars appear in the
         arguments and using the discrimination net.
         Returns a [ModeMismatch] if there are declared modes and none matches. *)
     val map_eauto : env -> evar_map -> secvars:Id.Pred.t -> (GlobRef.t * constr array) -> constr -> t -> FullHint.t list with_mode


### PR DESCRIPTION
Use discrimination nets for evar-containing goals in all auto-like tactics. It essentially makes the behaviour of undiscriminated databases to be the one of discriminated databases where all constants are considered transparent. This may introduce very rare fringe incompatibilities, but CI shows none.

Overlay:
- https://github.com/lukaszcz/coqhammer/pull/109