### PR TITLE
Stale workflow: fix syntax for using secret.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,4 +11,4 @@ jobs:
     if: github.repository_owner == 'coq'
     runs-on: ubuntu-latest
     steps:
-      - run: curl -d "coq:coq:$DAILY_SCHEDULE_SECRET" https://coqbot.herokuapp.com/check-stale-pr
+      - run: curl -d "coq:coq:${{ secrets.DAILY_SCHEDULE_SECRET }}" https://coqbot.herokuapp.com/check-stale-pr


### PR DESCRIPTION
Hopefully, this will be the last iteration fixing this workflow.
Currently, the pipeline runs but coqbot answers "Error: Incorrect secret".

cc @ppedrot 