### PR TITLE
Don't bench opam's overhead.

### DIFF
--- a/dev/bench/render_results
+++ b/dev/bench/render_results
@@ -278,25 +278,40 @@ end
 (* END Copied from batteries, to remove *)
 (******************************************************************************)
 
+let add_timings a b =
+  { user_time = a.user_time +. b.user_time;
+    num_instr = a.num_instr + b.num_instr;
+    num_cycles = a.num_cycles + b.num_cycles;
+    num_mem = a.num_mem + b.num_mem;
+    num_faults = a.num_faults + b.num_faults;
+  }
+
 let mk_pkg_timings work_dir pkg_name suffix iteration =
   let command_prefix = "cat " ^ work_dir ^ "/" ^ pkg_name ^ suffix ^ string_of_int iteration in
-  let time_command_output = command_prefix ^ ".time" |> run |> String.rchop ~n:1 |> String.split_on_char ' ' in
+  let ncoms = command_prefix ^ ".ncoms" |> run |> String.rchop ~n:1 |> int_of_string in
+  let timings = List.init ncoms (fun ncom ->
+      let command_prefix = command_prefix ^ "." ^ string_of_int (ncom+1) in
+      let time_command_output = command_prefix ^ ".time" |> run |> String.rchop ~n:1 |> String.split_on_char ' ' in
 
-  let nth x i = List.nth i x in
+      let nth x i = List.nth i x in
 
-  { user_time = time_command_output |> nth 0 |> float_of_string
-  (* Perf can indeed be not supported in some systems, so we must fail gracefully *)
-  ; num_instr =
-      (try command_prefix ^ ".perf | grep instructions:u | awk '{print $1}' | sed 's/,//g'" |>
-           run |> String.rchop ~n:1 |> int_of_string
-       with Failure _ -> 0)
-  ; num_cycles =
-      (try command_prefix ^ ".perf | grep cycles:u | awk '{print $1}' | sed 's/,//g'" |>
-           run |> String.rchop ~n:1 |> int_of_string
-       with Failure _ -> 0)
-  ; num_mem = time_command_output |> nth 1 |> int_of_string
-  ; num_faults = time_command_output |> nth 2 |> int_of_string
-  }
+      { user_time = time_command_output |> nth 0 |> float_of_string
+      (* Perf can indeed be not supported in some systems, so we must fail gracefully *)
+      ; num_instr =
+          (try command_prefix ^ ".perf | grep instructions:u | awk '{print $1}' | sed 's/,//g'" |>
+               run |> String.rchop ~n:1 |> int_of_string
+           with Failure _ -> 0)
+      ; num_cycles =
+          (try command_prefix ^ ".perf | grep cycles:u | awk '{print $1}' | sed 's/,//g'" |>
+               run |> String.rchop ~n:1 |> int_of_string
+           with Failure _ -> 0)
+      ; num_mem = time_command_output |> nth 1 |> int_of_string
+      ; num_faults = time_command_output |> nth 2 |> int_of_string
+      })
+  in
+  match timings with
+  | [] -> assert false
+  | timing :: rest -> List.fold_left add_timings timing rest
 ;;
 
 (* process command line paramters *)

--- a/dev/bench/wrapper.sh
+++ b/dev/bench/wrapper.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+log_dir=$COQ_LOG_DIR
+runner=$COQ_RUNNER
+package=$COQ_OPAM_PACKAGE
+iteration=$COQ_ITERATION
+
+echo "wrap[$package.$runner.$iteration|$OPAM_PACKAGE_NAME]" "$@" >> "$log_dir/wraplog.txt"
+echo >> "$log_dir/wraplog.txt"
+
+# we could be running commands for a dependency
+if [ "$package" ] && [ "$OPAM_PACKAGE_NAME" = "$package" ] ; then
+    prefix=$log_dir/$package.$runner.$iteration
+    if [ -e "$prefix.ncoms" ]; then
+        ncoms=$(cat "$prefix.ncoms")
+        ncoms=$((ncoms+1))
+    else
+        ncoms=1
+    fi
+    echo $ncoms > "$prefix.ncoms"
+    exec /usr/bin/time \
+         -o "$prefix.$ncoms.time" --format="%U %M %F" \
+         perf stat -e instructions:u,cycles:u -o "$prefix.$ncoms.perf" \
+         "$@"
+else
+    exec "$@"
+fi


### PR DESCRIPTION
We do the perf and time inside the "wrap-build-commands" hook system
of opam, instead of wrapping the whole opam call.

A few env variables are used to communicate with the wrapper, see wrapper.sh

A little care is needed to handle packages with multiple build
commands (eg corn does configure; make): we sum the command timings in
render_results.

Tested at https://gitlab.com/SkySkimmer/coq/-/jobs/1568571689 and
https://gitlab.com/SkySkimmer/coq/-/jobs/1568718247 on the new
machines.
The new machine instability does not appear, which is the main goal of
this PR. Fix #14159?
Package timings are less than previously so small instabilities can
produce bigger percentages, eg in the 2nd run ssreflect reports -1.48%
but this is just 0.4s.
(ignore the "coq" job, it is not printed in normal operation and is
just there to debug multi-command packages)

Perhaps we should also be wrapping the install commands, however it's
unclear how much information that would give.