### PR TITLE
Introduce a CoqIDE option to deactivate unicode binding completetion.

### DIFF
--- a/doc/changelog/09-coqide/14863-coqide-opt-unicode-binding.rst
+++ b/doc/changelog/09-coqide/14863-coqide-opt-unicode-binding.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  It is now possible to deactivate the unicode completion
+  mechanism in CoqIDE
+  (`#14863 <https://github.com/coq/coq/pull/14863>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/practical-tools/coqide.rst
+++ b/doc/sphinx/practical-tools/coqide.rst
@@ -252,6 +252,9 @@ https://github.com/coq/coq/blob/master/ide/coqide/default_bindings_src.ml
 
 Custom bindings may be added, as explained further on.
 
+The mechanism is active by default, but can be turned off in the Editor section
+of the preferences.
+
 .. note::
 
     It remains possible to input non-ASCII symbols using system-wide

--- a/ide/coqide/coqide.ml
+++ b/ide/coqide/coqide.ml
@@ -1252,6 +1252,12 @@ let build_ui () =
   if Coq_config.gtk_platform <> `QUARTZ
   then vbox#pack (Coqide_ui.ui_m#get_widget "/CoqIDE MenuBar");
 
+  (* Connect some specific actions *)
+  let unicode = Coqide_ui.ui_m#get_action "ui/CoqIDE MenuBar/Tools/LaTeX-to-unicode" in
+  let callback b = unicode#set_sensitive b in
+  let () = callback unicode_binding#get in
+  let _ = unicode_binding#connect#changed ~callback in
+
   (* Toolbar *)
   let tbar = GtkButton.Toolbar.cast
       ((Coqide_ui.ui_m#get_widget "/CoqIDE ToolBar")#as_widget)

--- a/ide/coqide/preferences.ml
+++ b/ide/coqide/preferences.ml
@@ -385,6 +385,9 @@ let window_width =
 let window_height =
   new preference ~name:["window_height"] ~init:600 ~repr:Repr.(int)
 
+let unicode_binding =
+  new preference ~name:["unicode_binding"] ~init:true ~repr:Repr.(bool)
+
 let auto_complete =
   new preference ~name:["auto_complete"] ~init:false ~repr:Repr.(bool)
 
@@ -853,6 +856,7 @@ let configure ?(apply=(fun () -> ())) parent =
     let () = button "Dynamic word wrap" dynamic_word_wrap in
     let () = button "Show line number" show_line_number in
     let () = button "Auto indentation" auto_indent in
+    let () = button "Unicode binding completion" unicode_binding in
     let () = button "Auto completion" auto_complete in
     let () = spin "Auto completion delay" ~min:0 ~max:5000 auto_complete_delay in
     let () = button "Show spaces" show_spaces in

--- a/ide/coqide/preferences.mli
+++ b/ide/coqide/preferences.mli
@@ -80,6 +80,7 @@ val text_font : string preference
 val show_toolbar : bool preference
 val window_width : int preference
 val window_height : int preference
+val unicode_binding : bool preference
 val auto_complete : bool preference
 val auto_complete_delay : int preference
 val stop_before : bool preference


### PR DESCRIPTION
Provides a better workaround to #14856.
