### PR TITLE
Prefilter unfold hints without an associated head global.

### DIFF
--- a/dev/ci/user-overlays/14876-ppedrot-hint-filter-unfold.sh
+++ b/dev/ci/user-overlays/14876-ppedrot-hint-filter-unfold.sh
@@ -1,0 +1,3 @@
+overlay hott https://github.com/ppedrot/HoTT hint-filter-unfold 14876
+
+overlay math_classes https://github.com/ppedrot/math-classes hint-filter-unfold 14876


### PR DESCRIPTION
For some reason, undiscriminated hint bases associate no head constant to unfold hints over transparent constants. A consequence is that they are applied to any goal. This cannot be changed without breaking everything, but this leads to exponential proof searches that attempt to perform dummy unfoldings on goals without the constant.

In order to speed up the search, we simply prefilter such hints depending on whether the constant appears on the goal. If not, we know that applying the hint is actually useless, so this should not change the observable behaviour of auto tactics, except for a change in search depth.

Fixes #14874: Exponential blowup with Hint Unfold.
