### PR TITLE
[boot] [meta] Add codeowners for `boot`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,6 +16,8 @@
 
 /META.coq-core.in       @coq/legacy-build-maintainers
 
+/boot/               @coq/build-maintainers
+
 ########## CI infrastructure ##########
 
 /dev/ci/             @coq/ci-maintainers


### PR DESCRIPTION
Rationale is that this component is really a part of the build system,
as it helps the rest of the system to locate components, and will take
care in the future of -Q / -R handling for `coqdep` / `coqc`.

Thanks to Théo Zimmerman for pointing out the omission.

