### PR TITLE
Import categories

### DIFF
--- a/checker/values.ml
+++ b/checker/values.ml
@@ -376,16 +376,7 @@ let v_compiled_lib =
 
 let v_obj = Dyn
 
-let v_globref = Sum("globref",0,[|
-    [|v_id|];
-    [|v_cst|];
-    [|v_ind|];
-    [|v_cons|]
-  |])
-
-let v_ext_gref = Sum("extended_global_reference",0,[|[|v_globref|];[|v_kn|]|])
-
-let v_open_filter = Sum ("open_filter",1,[|[|v_hset v_ext_gref|]|])
+let v_open_filter = Sum ("open_filter",1,[|[|v_pred String|]|])
 
 let rec v_aobjs = Sum("algebraic_objects", 0,
   [| [|v_libobjs|];

--- a/clib/cString.ml
+++ b/clib/cString.ml
@@ -28,6 +28,7 @@ sig
   val is_suffix : string -> string -> bool
   module Set : Set.S with type elt = t
   module Map : CMap.ExtS with type key = t and module Set := Set
+  module Pred : Predicate.S with type elt = t
   module List : CList.MonoS with type elt = t
   val hcons : string -> string
 end
@@ -134,6 +135,7 @@ end
 
 module Set = Set.Make(Self)
 module Map = CMap.Make(Self)
+module Pred = Predicate.Make(Self)
 
 module List = struct
   type elt = string

--- a/clib/cString.mli
+++ b/clib/cString.mli
@@ -65,6 +65,8 @@ sig
   module Map : CMap.ExtS with type key = t and module Set := Set
   (** Finite maps on [string] *)
 
+  module Pred : Predicate.S with type elt = t
+
   module List : CList.MonoS with type elt = t
   (** Association lists with [string] as keys *)
 

--- a/clib/predicate.ml
+++ b/clib/predicate.ml
@@ -45,6 +45,7 @@ module type S =
     val equal: t -> t -> bool
     val subset: t -> t -> bool
     val elements: t -> bool * elt list
+    val is_finite : t -> bool
   end
 
 module Make(Ord: OrderedType) =
@@ -56,6 +57,8 @@ module Make(Ord: OrderedType) =
     (* (false, s) represents a set which is equal to the set s
        (true, s)  represents a set which is equal to the complement of set s *)
     type t = bool * EltSet.t
+
+    let is_finite (b,_) = not b
 
     let elements (b,s) = (b, EltSet.elements s)
 

--- a/clib/predicate.mli
+++ b/clib/predicate.mli
@@ -78,6 +78,11 @@ module type S =
         (** Gives a finite representation of the predicate: if the
            boolean is false, then the predicate is given in extension.
            if it is true, then the complement is given *)
+
+    val is_finite : t -> bool
+    (** [true] if the predicate can be given as a finite set (if [elt]
+       is a finite type, we can have [is_finite x = false] yet [x] is
+       finite, but we don't know how to list its elements) *)
   end
 
 (** The [Make] functor constructs an implementation for any [OrderedType]. *)

--- a/dev/ci/user-overlays/14892-SkySkimmer-import-cat.sh
+++ b/dev/ci/user-overlays/14892-SkySkimmer-import-cat.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/SkySkimmer/coq-elpi import-cat 14892

--- a/doc/changelog/07-vernac-commands-and-options/14892-import-cat.rst
+++ b/doc/changelog/07-vernac-commands-and-options/14892-import-cat.rst
@@ -1,0 +1,3 @@
+- **Added:** Syntax for :token:`import_categories` providing selective
+  import of module components (eg ``Import(notations) M`` (`#14892
+  <https://github.com/coq/coq/pull/14892>`_, by Gaëtan Gilbert).

--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -198,11 +198,12 @@ are now available through the dot notation.
    If :n:`@module_binder`\s are specified, declares a functor with parameters given by the list of
    :token:`module_binder`\s.
 
-.. cmd:: Import {+ @filtered_import }
+.. cmd:: Import {? @import_categories } {+ @filtered_import }
 
-   .. insertprodn filtered_import filtered_import
+   .. insertprodn import_categories filtered_import
 
    .. prodn::
+      import_categories ::= {? - } ( {+, @ident } )
       filtered_import ::= @qualid {? ( {+, @qualid {? ( .. ) } } ) }
 
    If :token:`qualid` denotes a valid basic module (i.e. its module type is a
@@ -287,7 +288,7 @@ are now available through the dot notation.
       This warning is printed when a name in the list of names to
       import was declared as a local constant, and the name is not imported.
 
-.. cmd:: Export {+ @filtered_import }
+.. cmd:: Export {? @import_categories } {+ @filtered_import }
 
    Similar to :cmd:`Import`, except that when the module containing this command
    is imported, the :n:`{+ @qualid }` are imported as well.

--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -203,7 +203,7 @@ are now available through the dot notation.
    .. insertprodn import_categories filtered_import
 
    .. prodn::
-      import_categories ::= {? - } ( {+, @ident } )
+      import_categories ::= {? - } ( {+, @qualid } )
       filtered_import ::= @qualid {? ( {+, @qualid {? ( .. ) } } ) }
 
    If :token:`qualid` denotes a valid basic module (i.e. its module type is a

--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -288,6 +288,29 @@ are now available through the dot notation.
       This warning is printed when a name in the list of names to
       import was declared as a local constant, and the name is not imported.
 
+   Putting a list of :n:`@import_categories` after ``Import`` will
+   restrict activation of features according to those categories.
+   Currently supported categories are:
+
+   - ``coercions`` corresponding to :cmd:`Coercion`.
+
+   - ``hints`` corresponding to the `Hint` commands (e.g. :cmd:`Hint
+     Resolve` or :cmd:`Hint Rewrite`) and :ref:`typeclass
+     <typeclasses>` instances.
+
+   - ``canonicals`` corresponding to :cmd:`Canonical Structure`.
+
+   - ``notations`` corresponding to :cmd:`Notation` (including
+     :cmd:`Reserved Notation`), scope controls (:cmd:`Delimit Scope`,
+     :cmd:`Bind Scope`, :cmd:`Open Scope`) and :ref:`Abbreviations`.
+
+   - ``ltac.notations`` corresponding to :cmd:`Tactic Notation`.
+
+   - ``ltac2.notations`` corresponding to :cmd:`Ltac2 Notation`
+     (including Ltac2 abbreviations).
+
+   Plugins may define their own categories.
+
 .. cmd:: Export {? @import_categories } {+ @filtered_import }
 
    Similar to :cmd:`Import`, except that when the module containing this command

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1057,7 +1057,7 @@ gallina_ext: [
 ]
 
 import_categories: [
-| OPT "-" "(" LIST1 identref SEP "," ")"
+| OPT "-" "(" LIST1 qualid SEP "," ")"
 ]
 
 filtered_import: [

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1029,8 +1029,8 @@ gallina_ext: [
 | "Collection" identref ":=" section_subset_expr
 | "Require" export_token LIST1 global
 | "From" global "Require" export_token LIST1 global
-| "Import" LIST1 filtered_import
-| "Export" LIST1 filtered_import
+| "Import" OPT import_categories LIST1 filtered_import
+| "Export" OPT import_categories LIST1 filtered_import
 | "Include" module_type_inl LIST0 ext_module_expr
 | "Include" "Type" module_type_inl LIST0 ext_module_type
 | "Transparent" LIST1 smart_global
@@ -1054,6 +1054,10 @@ gallina_ext: [
 | "Export" "Set" setting_name option_setting
 | "Export" "Unset" setting_name
 | "Import" "Prenex" "Implicits"      (* SSR plugin *)
+]
+
+import_categories: [
+| OPT "-" "(" LIST1 identref SEP "," ")"
 ]
 
 filtered_import: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -712,7 +712,7 @@ constructor: [
 ]
 
 import_categories: [
-| OPT "-" "(" LIST1 ident SEP "," ")"
+| OPT "-" "(" LIST1 qualid SEP "," ")"
 ]
 
 filtered_import: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -711,6 +711,10 @@ constructor: [
 | ident LIST0 binder OPT of_type
 ]
 
+import_categories: [
+| OPT "-" "(" LIST1 ident SEP "," ")"
+]
+
 filtered_import: [
 | qualid OPT [ "(" LIST1 ( qualid OPT [ "(" ".." ")" ] ) SEP "," ")" ]
 ]
@@ -1059,8 +1063,8 @@ command: [
 | "End" ident
 | "Collection" ident ":=" section_var_expr
 | OPT [ "From" dirpath ] "Require" OPT [ "Import" | "Export" ] LIST1 qualid
-| "Import" LIST1 filtered_import
-| "Export" LIST1 filtered_import
+| "Import" OPT import_categories LIST1 filtered_import
+| "Export" OPT import_categories LIST1 filtered_import
 | "Include" module_type_inl LIST0 ( "<+" module_expr_inl )
 | "Include" "Type" LIST1 module_type_inl SEP "<+"
 | "Transparent" LIST1 reference

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -25,6 +25,9 @@ open NumTok
 
 (*i*)
 
+let notation_cat = Libobject.create_category "notations"
+
+
 (*s A scope is a set of notations; it includes
 
   - a set of ML interpreters/parsers for positive (e.g. 0, 1, 15, ...) and
@@ -249,7 +252,7 @@ let classify_scope (local,_,_ as o) =
 let inScope : bool * bool * scope_item -> obj =
   declare_object {(default_object "SCOPE") with
       cache_function = cache_scope;
-      open_function = simple_open open_scope;
+      open_function = simple_open ~cat:notation_cat open_scope;
       subst_function = subst_scope;
       discharge_function = discharge_scope;
       classify_function = classify_scope }
@@ -1364,7 +1367,7 @@ let open_prim_token_interpretation i o =
 
 let inPrimTokenInterp : prim_token_infos -> obj =
   declare_object {(default_object "PRIM-TOKEN-INTERP") with
-     open_function  = simple_open open_prim_token_interpretation;
+     open_function  = simple_open ~cat:notation_cat open_prim_token_interpretation;
      cache_function = cache_prim_token_interpretation;
      subst_function = subst_prim_token_interpretation;
      classify_function = classify_prim_token_interpretation}

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -16,6 +16,8 @@ open Notation_term
 
 (** Notations *)
 
+val notation_cat : Libobject.category
+
 val pr_notation : notation -> Pp.t
 (** Printing *)
 

--- a/interp/syntax_def.ml
+++ b/interp/syntax_def.ml
@@ -71,17 +71,11 @@ let subst_syntax_constant (subst,(local,syndef)) =
 let classify_syntax_constant (local,_ as o) =
   if local then Dispose else Substitute o
 
-let filtered_open_syntax_constant f i ((_,kn),_ as o) =
-  let in_f = match f with
-    | Unfiltered -> true
-  in
-  if in_f then open_syntax_constant i o
-
 let in_syntax_constant : (bool * syndef) -> obj =
   declare_object {(default_object "SYNDEF") with
     cache_function = cache_syntax_constant;
     load_function = load_syntax_constant;
-    open_function = filtered_open_syntax_constant;
+    open_function = simple_open open_syntax_constant;
     subst_function = subst_syntax_constant;
     classify_function = classify_syntax_constant }
 

--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -65,16 +65,9 @@ struct
 
   let print id = str id
 
-  module Self =
-  struct
-    type t = string
-    let compare = compare
-  end
-
-  module Set = Set.Make(Self)
-  module Map = CMap.Make(Self)
-
-  module Pred = Predicate.Make(Self)
+  module Set = CString.Set
+  module Map = CString.Map
+  module Pred = CString.Pred
 
   module List = String.List
 

--- a/library/libobject.mli
+++ b/library/libobject.mli
@@ -72,7 +72,7 @@ type 'a substitutivity =
 
 type object_name = full_path * Names.KerName.t
 
-type open_filter = Unfiltered
+type open_filter
 
 type 'a object_declaration = {
   object_name : string;
@@ -84,15 +84,33 @@ type 'a object_declaration = {
   discharge_function : object_name * 'a -> 'a option;
   rebuild_function : 'a -> 'a }
 
-val simple_open : (int -> object_name * 'a -> unit) -> open_filter -> int -> object_name * 'a -> unit
-(** Combinator for making objects which are only opened by unfiltered Import *)
+val unfiltered : open_filter
+
+val make_filter : finite:bool -> string CAst.t list -> open_filter
+(** Anomaly when the list is empty. *)
+
+type category
+
+val create_category : string -> category
+(** Anomaly if called more than once for a given string. *)
+
+val in_filter : cat:category option -> open_filter -> bool
+(** On [cat:None], returns whether the filter allows opening
+   uncategorized objects.
+
+    On [cat:(Some category)], returns whether the filter allows
+   opening objects in the given [category]. *)
+
+val simple_open : ?cat:category -> (int -> object_name * 'a -> unit) ->
+  open_filter -> int -> object_name * 'a -> unit
+(** Combinator for making objects with simple category-based open
+   behaviour. When [cat:None], can be opened by Unfiltered, but also
+   by Filtered with a negative set. *)
 
 val filter_and : open_filter -> open_filter -> open_filter option
 (** Returns [None] when the intersection is empty. *)
 
 val filter_or :  open_filter -> open_filter -> open_filter
-
-val in_filter_ref : Names.GlobRef.t -> open_filter -> bool
 
 (** The default object is a "Keep" object with empty methods.
    Object creators are advised to use the construction
@@ -170,13 +188,13 @@ val local_object_nodischarge : string ->
   cache:(object_name * 'a -> unit) ->
   'a object_declaration
 
-val global_object : string ->
+val global_object : ?cat:category -> string ->
   cache:(object_name * 'a -> unit) ->
   subst:(Mod_subst.substitution * 'a -> 'a) option ->
   discharge:(object_name * 'a -> 'a option) ->
   'a object_declaration
 
-val global_object_nodischarge : string ->
+val global_object_nodischarge : ?cat:category -> string ->
   cache:(object_name * 'a -> unit) ->
   subst:(Mod_subst.substitution * 'a -> 'a) option ->
   'a object_declaration

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -296,9 +296,11 @@ let subst_tactic_notation (subst, tobj) =
 
 let classify_tactic_notation tacobj = Substitute tacobj
 
+let ltac_notation_cat = Libobject.create_category "ltac.notations"
+
 let inTacticGrammar : tactic_grammar_obj -> obj =
   declare_object {(default_object "TacticGrammar") with
-       open_function = simple_open open_tactic_notation;
+       open_function = simple_open ~cat:ltac_notation_cat open_tactic_notation;
        load_function = load_tactic_notation;
        cache_function = cache_tactic_notation;
        subst_function = subst_tactic_notation;

--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -214,7 +214,7 @@ let inGlobalHintRewrite : string * HintDN.t -> Libobject.obj =
 
 let inExportHintRewrite : string * HintDN.t -> Libobject.obj =
   let open Libobject in
-  declare_object @@ global_object_nodischarge "HINT_REWRITE_EXPORT"
+  declare_object @@ global_object_nodischarge ~cat:Hints.hint_cat "HINT_REWRITE_EXPORT"
     ~cache:cache_hintrewrite
     ~subst:(Some subst_hintrewrite)
 

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1226,11 +1226,13 @@ let discharge_autohint (_, obj) =
     if is_trivial_action action then None
     else Some { obj with hint_action = action }
 
+let hint_cat = create_category "hints"
+
 let inAutoHint : hint_obj -> obj =
   declare_object {(default_object "AUTOHINT") with
                     cache_function = cache_autohint;
                     load_function = load_autohint;
-                    open_function = simple_open open_autohint;
+                    open_function = simple_open ~cat:hint_cat open_autohint;
                     subst_function = subst_autohint;
                     classify_function = classify_autohint;
                     discharge_function = discharge_autohint;

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -28,6 +28,8 @@ val secvars_of_hyps : ('c, 't) Context.Named.pt -> Id.Pred.t
 
 val empty_hint_info : 'a Typeclasses.hint_info_gen
 
+val hint_cat : Libobject.category
+
 (** Pre-created hint databases *)
 
 type 'a hint_ast =

--- a/test-suite/success/ImportCat.v
+++ b/test-suite/success/ImportCat.v
@@ -16,10 +16,14 @@ Module M.
   End Alt.
 
   Notation "x <<< y" := (x + y) (at level 22).
+
+  Reserved Notation "@@".
+
+  Tactic Notation "@@" := idtac.
 End M.
 
 Module N.
-    Notation "x <<< y" := (x + y) (at level 23).
+    Notation "x <<< y" := (x - y) (at level 23).
 End N.
 
 Fail Import(coercions) M(AB).
@@ -65,8 +69,30 @@ Module TestExport.
     Export(coercions) Y.
   End X.
 
+  Import(notations) X.
+  Fail Check a : B.
+
   Import X.
   Check a : B.
   Fail Check bla.
   Check Y.bla.
 End TestExport.
+
+Module Notas.
+  Import -(ltac.notations,notations) M.
+
+  Import N.
+
+  Check eq_refl : 1 <<< 1 = 0.
+
+  Module X.
+      Tactic Notation "@@" := fail.
+      Lemma foo : False.
+      Proof. Fail @@. Abort.
+  End X.
+
+  Import (ltac.notations) M.
+
+  Lemma foo : False.
+  Proof. @@. Abort.
+End Notas.

--- a/test-suite/success/ImportCat.v
+++ b/test-suite/success/ImportCat.v
@@ -1,0 +1,72 @@
+Axioms A B C D : Type.
+Axiom a : A.
+Module M.
+  Axiom AB : A -> B.
+  Coercion AB : A >-> B.
+
+  Module Inner.
+    Axiom BC : B -> C.
+    Coercion BC : B >-> C.
+  End Inner.
+  Export Inner.
+
+  Module Alt.
+    Axiom BD : B -> D.
+    Coercion BD : B >-> D.
+  End Alt.
+
+  Notation "x <<< y" := (x + y) (at level 22).
+End M.
+
+Module N.
+    Notation "x <<< y" := (x + y) (at level 23).
+End N.
+
+Fail Import(coercions) M(AB).
+
+Module Test1.
+  Import(coercions) M.
+  Check a : B.
+  Check a : C.
+  Fail Check a : D.
+
+  (* names not imported *)
+  Fail Import Alt.
+  Fail Check AB.
+  Check M.AB.
+
+  Import M.Alt.
+  Check a : D.
+
+  Import N. (* notations didn't get imported *)
+End Test1.
+
+Module Test2.
+  Import -(coercions) M.
+  Fail Check a : B.
+  Check AB.
+  Fail Check AB a : C.
+
+  Fail Import N.
+
+  Check Inner.BC.
+  Import Inner.
+  Check AB a : C.
+  Fail Check a : C.
+End Test2.
+
+Module TestExport.
+  Import M(AB).
+  Module X.
+    Module Y.
+      Definition bla := 0.
+      Coercion AB : A >-> B.
+    End Y.
+    Export(coercions) Y.
+  End X.
+
+  Import X.
+  Check a : B.
+  Fail Check bla.
+  Check Y.bla.
+End TestExport.

--- a/user-contrib/Ltac2/tac2entries.ml
+++ b/user-contrib/Ltac2/tac2entries.ml
@@ -706,10 +706,12 @@ let subst_synext (subst, syn) =
 let classify_synext o =
   if o.synext_loc then Dispose else Substitute o
 
+let ltac2_notation_cat = Libobject.create_category "ltac2.notations"
+
 let inTac2Notation : synext -> obj =
   declare_object {(default_object "TAC2-NOTATION") with
      cache_function  = cache_synext;
-     open_function   = simple_open open_synext;
+     open_function   = simple_open ~cat:ltac2_notation_cat open_synext;
      subst_function = subst_synext;
      classify_function = classify_synext}
 
@@ -740,7 +742,7 @@ let inTac2Abbreviation : abbreviation -> obj =
   declare_object {(default_object "TAC2-ABBREVIATION") with
      cache_function  = cache_abbreviation;
      load_function   = load_abbreviation;
-     open_function   = simple_open open_abbreviation;
+     open_function   = simple_open ~cat:ltac2_notation_cat open_abbreviation;
      subst_function = subst_abbreviation;
      classify_function = classify_abbreviation}
 

--- a/vernac/canonical.ml
+++ b/vernac/canonical.ml
@@ -25,10 +25,11 @@ let discharge_canonical_structure (_,(x, local)) =
   if local || (Globnames.isVarRef gref && Lib.is_in_section gref) then None
   else Some (x, local)
 
+let canon_cat = create_category "canonicals"
 
 let inCanonStruc : Instance.t * bool -> obj =
   declare_object {(default_object "CANONICAL-STRUCTURE") with
-                  open_function = simple_open open_canonical_structure;
+                  open_function = simple_open ~cat:canon_cat open_canonical_structure;
                   cache_function = cache_canonical_structure;
                   subst_function = (fun (subst,(c,local)) -> Instance.subst subst c, local);
                   classify_function = (fun x -> Substitute x);

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -148,7 +148,7 @@ let instance_input : instance_obj -> obj =
     { (default_object "type classes instances state") with
       cache_function = cache_instance;
       load_function = load_instance;
-      open_function = simple_open open_instance;
+      open_function = simple_open ~cat:Hints.hint_cat open_instance;
       classify_function = classify_instance;
       discharge_function = discharge_instance;
       rebuild_function = rebuild_instance;

--- a/vernac/comCoercion.ml
+++ b/vernac/comCoercion.ml
@@ -257,9 +257,11 @@ let rebuild_coercion c =
 let classify_coercion obj =
   if obj.coe_local then Dispose else Substitute obj
 
+let coe_cat = create_category "coercions"
+
 let inCoercion : coe_info_typ -> obj =
   declare_object {(default_object "COERCION") with
-    open_function = simple_open open_coercion;
+    open_function = simple_open ~cat:coe_cat open_coercion;
     cache_function = cache_coercion;
     subst_function = (fun (subst,c) -> subst_coercion subst c);
     classify_function = classify_coercion;

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -179,14 +179,13 @@ let load_constant i ((sp,kn), obj) =
   end
 
 (* Opening means making the name without its module qualification available *)
-let open_constant f i ((sp,kn), obj) =
+let open_constant i ((sp,kn), obj) =
   (* Never open a local definition *)
   match obj.cst_locl with
   | Locality.ImportNeedQualified -> ()
   | Locality.ImportDefaultBehavior ->
     let con = Global.constant_of_delta_kn kn in
-    if Libobject.in_filter_ref (GlobRef.ConstRef con) f then
-      Nametab.push (Nametab.Exactly i) sp (GlobRef.ConstRef con)
+    Nametab.push (Nametab.Exactly i) sp (GlobRef.ConstRef con)
 
 let exists_name id =
   Decls.variable_exists id || Global.exists_objlabel (Label.of_id id)
@@ -216,7 +215,7 @@ let (objConstant : constant_obj Libobject.Dyn.tag) =
   declare_object_full { (default_object "CONSTANT") with
     cache_function = cache_constant;
     load_function = load_constant;
-    open_function = open_constant;
+    open_function = simple_open open_constant;
     classify_function = classify_constant;
     subst_function = ident_subst_function;
     discharge_function = discharge_constant }

--- a/vernac/declareInd.ml
+++ b/vernac/declareInd.ml
@@ -49,12 +49,9 @@ let load_inductive i ((sp, kn), names) =
   let names = inductive_names sp kn names in
   List.iter (fun (sp, ref) -> Nametab.push (Nametab.Until i) sp ref ) names
 
-let open_inductive f i ((sp, kn), names) =
+let open_inductive i ((sp, kn), names) =
   let names = inductive_names sp kn names in
-  List.iter (fun (sp, ref) ->
-      if Libobject.in_filter_ref ref f then
-        Nametab.push (Nametab.Exactly i) sp ref)
-    names
+  List.iter (fun (sp, ref) -> Nametab.push (Nametab.Exactly i) sp ref) names
 
 let cache_inductive ((sp, kn), names) =
   let names = inductive_names sp kn names in
@@ -68,7 +65,7 @@ let objInductive : inductive_obj Libobject.Dyn.tag =
   declare_object_full {(default_object "INDUCTIVE") with
     cache_function = cache_inductive;
     load_function = load_inductive;
-    open_function = open_inductive;
+    open_function = simple_open open_inductive;
     classify_function = (fun a -> Substitute a);
     subst_function = ident_subst_function;
     discharge_function = discharge_inductive;

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -585,8 +585,8 @@ GRAMMAR EXTEND Gram
         VernacInclude(e::l) } ] ]
   ;
   import_categories:
-  [ [ negative = OPT "-"; "("; cats = LIST1 identref SEP ","; ")" ->
-      { let cats = List.map (CAst.map Id.to_string) cats in
+  [ [ negative = OPT "-"; "("; cats = LIST1 qualid SEP ","; ")" ->
+      { let cats = List.map (fun cat -> CAst.make ?loc:cat.CAst.loc (Libnames.string_of_qualid cat)) cats in
         { negative=Option.has_some negative; import_cats = cats } }
   ] ]
   ;

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -574,13 +574,21 @@ GRAMMAR EXTEND Gram
       | IDENT "From" ; ns = global ; IDENT "Require"; export = export_token
         ; qidl = LIST1 global ->
         { VernacRequire (Some ns, export, qidl) }
-      | IDENT "Import"; qidl = LIST1 filtered_import -> { VernacImport (false,qidl) }
-      | IDENT "Export"; qidl = LIST1 filtered_import -> { VernacImport (true,qidl) }
+      | IDENT "Import"; cats = OPT import_categories; qidl = LIST1 filtered_import ->
+        { VernacImport (false,cats,qidl) }
+      | IDENT "Export"; cats = OPT import_categories; qidl = LIST1 filtered_import ->
+        { VernacImport (true,cats,qidl) }
       | IDENT "Include"; e = module_type_inl; l = LIST0 ext_module_expr ->
           { VernacInclude(e::l) }
       | IDENT "Include"; "Type"; e = module_type_inl; l = LIST0 ext_module_type ->
          { warn_deprecated_include_type ~loc ();
         VernacInclude(e::l) } ] ]
+  ;
+  import_categories:
+  [ [ negative = OPT "-"; "("; cats = LIST1 identref SEP ","; ")" ->
+      { let cats = List.map (CAst.map Id.to_string) cats in
+        { negative=Option.has_some negative; import_cats = cats } }
+  ] ]
   ;
   filtered_import:
     [ [ m = global -> { (m, ImportAll) }

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -341,7 +341,7 @@ let load_require _ (_,(needed,modl,_)) =
 
 let open_require i (_,(_,modl,export)) =
   Option.iter (fun export ->
-      let mpl = List.map (fun m -> Unfiltered, MPfile m) modl in
+      let mpl = List.map (fun m -> unfiltered, MPfile m) modl in
       (* TODO support filters in Require *)
       Declaremods.import_modules ~export mpl)
     export
@@ -383,7 +383,7 @@ let require_library_from_dirpath ~lib_resolver modrefl export =
       add_anonymous_leaf (in_require (needed,modrefl,None));
       Option.iter (fun export ->
           (* TODO import filters *)
-          List.iter (fun m -> Declaremods.import_module Unfiltered ~export (MPfile m)) modrefl)
+          List.iter (fun m -> Declaremods.import_module unfiltered ~export (MPfile m)) modrefl)
         export
     end
   else

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -850,7 +850,7 @@ let open_syntax_extension i o =
 
 let inSyntaxExtension : syntax_extension_obj -> obj =
   declare_object {(default_object "SYNTAX-EXTENSION") with
-       open_function = simple_open open_syntax_extension;
+       open_function = simple_open ~cat:notation_cat open_syntax_extension;
        cache_function = cache_syntax_extension;
        subst_function = subst_syntax_extension;
        classify_function = classify_syntax_definition}
@@ -1433,7 +1433,7 @@ let classify_notation nobj =
 
 let inNotation : notation_obj -> obj =
   declare_object {(default_object "NOTATION") with
-       open_function = simple_open open_notation;
+       open_function = simple_open ~cat:notation_cat open_notation;
        cache_function = cache_notation;
        subst_function = subst_notation;
        load_function = load_notation;
@@ -1794,7 +1794,7 @@ let classify_scope_command (local, _, _ as o) =
 let inScopeCommand : locality_flag * scope_name * scope_command -> obj =
   declare_object {(default_object "DELIMITERS") with
       cache_function = cache_scope_command;
-      open_function = simple_open open_scope_command;
+      open_function = simple_open ~cat:notation_cat open_scope_command;
       load_function = load_scope_command;
       subst_function = subst_scope_command;
       classify_function = classify_scope_command}

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -125,6 +125,14 @@ let pr_ltac_ref = Libnames.pr_qualid
 
 let pr_module = Libnames.pr_qualid
 
+let pr_import_cats = function
+  | None -> mt()
+  | Some {negative;import_cats=cats} ->
+    (if negative then str "-" else mt()) ++
+    str "(" ++
+    prlist_with_sep (fun () -> str ",") (fun x -> str x.v) cats ++
+    str ")"
+
 let pr_one_import_filter_name (q,etc) =
   Libnames.pr_qualid q ++ if etc then str "(..)" else mt()
 
@@ -938,9 +946,9 @@ let pr_vernac_expr v =
         (from ++ keyword "Require" ++ spc() ++ pr_require_token exp ++
          prlist_with_sep sep pr_module l)
     )
-  | VernacImport (f,l) ->
+  | VernacImport (f,cats,l) ->
     return (
-      (if f then keyword "Export" else keyword "Import") ++ spc() ++
+      (if f then keyword "Export" else keyword "Import") ++ pr_import_cats cats ++ spc() ++
       prlist_with_sep sep pr_import_module l
     )
   | VernacCanonical q ->

--- a/vernac/printmod.ml
+++ b/vernac/printmod.ml
@@ -239,7 +239,8 @@ let nametab_register_body mp dir (l,body) =
             mip.mind_consnames)
         mib.mind_packets
 
-let import_module = Declaremods.import_module Libobject.Unfiltered
+(* TODO only import printing-relevant objects (or find a way to print without importing) *)
+let import_module = Declaremods.import_module Libobject.unfiltered
 let process_module_binding = Declaremods.process_module_binding
 
 let nametab_register_module_body mp struc =

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -109,6 +109,11 @@ type instance_flag  = BackInstance | NoInstance
 
 type export_flag    = bool (* true = Export;        false = Import         *)
 
+type import_categories = {
+  negative : bool;
+  import_cats : string CAst.t list;
+}
+
 type infix_flag     = bool (* true = Infix;         false = Notation       *)
 
 type one_import_filter_name = qualid * bool (* import inductive components *)
@@ -346,7 +351,7 @@ type nonrec vernac_expr =
   | VernacEndSegment of lident
   | VernacRequire of
       qualid option * export_flag option * qualid list
-  | VernacImport of export_flag * (qualid * import_filter_expr) list
+  | VernacImport of export_flag * import_categories option * (qualid * import_filter_expr) list
   | VernacCanonical of qualid or_by_notation
   | VernacCoercion of qualid or_by_notation *
       class_rawexpr * class_rawexpr


### PR DESCRIPTION
This PR allows to do eg `Import(coercions) X Y.` and `Import(-coercions) X Y.` meaning respectively "import only coercions" and "import everything except coercions".
Currently only the `coercions` category is defined. We may want to add a few more before merging.

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/301