### PR TITLE
Debugger: Support setting line number and begin of line offset when calling parser

### DIFF
--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -1642,9 +1642,6 @@ module Parsable = struct
   let make ?loc cs =
     let lexer_state = ref (L.State.init ()) in
     L.State.set !lexer_state;
-    (match loc with
-    | Some loc -> L.State.set_loc_offset Loc.(loc.bp)
-    | None -> ());
     let ts = L.tok_func ?loc cs in
     lexer_state := L.State.get ();
     {pa_tok_strm = ts; lexer_state}

--- a/gramlib/plexing.ml
+++ b/gramlib/plexing.ml
@@ -23,7 +23,6 @@ module type S = sig
     val get : unit -> t
     val drop : unit -> unit
     val get_comments : t -> ((int * int) * string) list
-    val set_loc_offset : int -> unit
   end
 
 end

--- a/gramlib/plexing.mli
+++ b/gramlib/plexing.mli
@@ -32,7 +32,6 @@ module type S = sig
     val get : unit -> t
     val drop : unit -> unit
     val get_comments : t -> ((int * int) * string) list
-    val set_loc_offset : int -> unit
   end
 
 end


### PR DESCRIPTION
c518c206ae7a1e7756170e32c2061470dbe88f22 allowed the caller to set the buffer offset when initializing the parser.  This change allows setting the line number and the beginning of line offset.

CoqIDE invokes the parser separately for each statement.  The earlier change made it possible to return offsets relative to the beginning of the buffer, which was sufficient for CoqIDE to highlight the code being executed.  The stack panel in the debugger shows the line number.  This change ensures that Coq returns correct line numbers in the Loc.t.

I extracted this code from #14644 to make the review of this piece easy.