### PR TITLE
Fixes #14899: improved output of "Eval red in term" by betaiota-normalizing the type, like Check does

### DIFF
--- a/doc/changelog/07-vernac-commands-and-options/14901-master+wish14899-nf-betaiota-on-result-evai-in.rst
+++ b/doc/changelog/07-vernac-commands-and-options/14901-master+wish14899-nf-betaiota-on-result-evai-in.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  :cmd:`Eval` and :cmd:`Compute` now beta-iota-simplify the type
+  of the result, like :cmd:`Check` does
+  (`#14901 <https://github.com/coq/coq/pull/14901>`_,
+  fixes `#14899 <https://github.com/coq/coq/issues/14899>`_,
+  by Hugo Herbelin)

--- a/test-suite/output/bug_14899.out
+++ b/test-suite/output/bug_14899.out
@@ -1,0 +1,4 @@
+proj2_sig a
+     : 0 < proj1_sig a
+     = le_S 1 2 (le_S 1 1 (le_n 1))
+     : 0 < proj1_sig a

--- a/test-suite/output/bug_14899.v
+++ b/test-suite/output/bug_14899.v
@@ -1,0 +1,6 @@
+Definition a : { x | 0 < x }.
+  exists 3. eauto.
+Defined.
+
+Check (proj2_sig a).
+Compute (proj2_sig a).

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1849,11 +1849,11 @@ let vernac_check_may_eval ~pstate redexp glopt rc =
       (* OK to call kernel which does not support evars *)
       Environ.on_judgment EConstr.of_constr (Arguments_renaming.rename_typing env c)
   in
+  let j = { j with Environ.uj_type = Reductionops.nf_betaiota env sigma j.Environ.uj_type } in
   let pp = match redexp with
     | None ->
         let evars_of_term c = Evarutil.undefined_evars_of_term sigma c in
         let l = Evar.Set.union (evars_of_term j.Environ.uj_val) (evars_of_term j.Environ.uj_type) in
-        let j = { j with Environ.uj_type = Reductionops.nf_betaiota env sigma j.Environ.uj_type } in
         Prettyp.print_judgment env sigma j ++
         pr_ne_evar_set (fnl () ++ str "where" ++ fnl ()) (mt ()) sigma l
     | Some r ->


### PR DESCRIPTION
**Kind:** enhancement/fix

The betaiota-normalization was done for `Check`/`Type` but not for `Eval-in`/`Compute`.

Closes #14899
                                                                                                                                                                                                                                                                                        
 - [x] Added **changelog**.
