### PR TITLE
Remove ancient "Print Modules" syntax

### DIFF
--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1256,7 +1256,6 @@ printable: [
 | "Grammar" IDENT
 | "Custom" "Grammar" IDENT
 | "LoadPath" OPT dirpath
-| "Modules"
 | "Libraries"
 | "ML" "Path"
 | "ML" "Modules"

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -876,7 +876,6 @@ command: [
 | "Print" "Grammar" ident
 | "Print" "Custom" "Grammar" ident
 | "Print" "LoadPath" OPT dirpath
-| "Print" "Modules"
 | "Print" "Libraries"
 | "Print" "ML" "Path"
 | "Print" "ML" "Modules"

--- a/ide/coqide/coq_commands.ml
+++ b/ide/coqide/coq_commands.ml
@@ -186,7 +186,7 @@ let state_preserving = [
   "Print ML Path";
   "Print Module";
   "Print Module Type";
-  "Print Modules";
+  "Print Libraries";
   "Print Proof";
   "Print Rewrite HintDb";
   "Print Setoids";

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -985,9 +985,7 @@ GRAMMAR EXTEND Gram
           (* Should also be in "syntax" section *)
           { PrintCustomGrammar ent }
       | IDENT "LoadPath"; dir = OPT dirpath -> { PrintLoadPath dir }
-      | IDENT "Modules" ->
-          { user_err ~loc Pp.(str "Print Modules is obsolete; use Print Libraries instead") }
-      | IDENT "Libraries" -> { PrintModules }
+      | IDENT "Libraries" -> { PrintLibraries }
 
       | IDENT "ML"; IDENT "Path" -> { PrintMLLoadPath }
       | IDENT "ML"; IDENT "Modules" -> { PrintMLModules }

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -559,8 +559,8 @@ let pr_printable = function
     keyword "Print Custom Grammar" ++ spc() ++ str ent
   | PrintLoadPath dir ->
     keyword "Print LoadPath" ++ pr_opt DirPath.print dir
-  | PrintModules ->
-    keyword "Print Modules"
+  | PrintLibraries ->
+    keyword "Print Libraries"
   | PrintMLLoadPath ->
     keyword "Print ML Path"
   | PrintMLModules ->

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -168,7 +168,7 @@ let print_loadpath dir =
   str "Logical Path / Physical path:" ++ fnl () ++
     prlist_with_sep fnl Loadpath.pp l
 
-let print_modules () =
+let print_libraries () =
   let loaded = Library.loaded_libraries () in
   str"Loaded library files: " ++
   pr_vertical_list DirPath.print loaded
@@ -1943,7 +1943,7 @@ let vernac_print ~pstate =
   | PrintGrammar ent -> Metasyntax.pr_grammar ent
   | PrintCustomGrammar ent -> Metasyntax.pr_custom_grammar ent
   | PrintLoadPath dir -> (* For compatibility ? *) print_loadpath dir
-  | PrintModules -> print_modules ()
+  | PrintLibraries -> print_libraries ()
   | PrintModule qid -> print_module qid
   | PrintModuleType qid -> print_modtype qid
   | PrintNamespace ns -> print_namespace ~pstate ns

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -32,7 +32,7 @@ type printable =
   | PrintGrammar of string
   | PrintCustomGrammar of string
   | PrintLoadPath of DirPath.t option
-  | PrintModules
+  | PrintLibraries
   | PrintModule of qualid
   | PrintModuleType of qualid
   | PrintNamespace of DirPath.t


### PR DESCRIPTION
It has been replaced by Print Libraries since ff94dcd516111978dfd7b782cbda2d9eae837a60 (2008)
