### PR TITLE
[build] Set dune root explicitly / use --release

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -116,7 +116,7 @@ DOCGRAM_SOURCE_FILES=$(shell find $(addprefix $(COQ_SRC_DIR)/, doc/tools/docgram
 # Override for developer build [to get warn-as-error for example]
 _DDISPLAY?=quiet
 _DPROFILE?=$(CONFIGURE_DPROFILE)
-_DOPT:=--display $(_DDISPLAY) --profile=$(_DPROFILE)
+_DOPT:=--display=$(_DDISPLAY) $(_DPROFILE)
 _DBUILD:=$(FLOCK) .dune.lock dune build $(_DOPT)
 
 # We rerun dune when any of the source files have changed

--- a/configure
+++ b/configure
@@ -11,4 +11,4 @@ then
     exit 1
 fi
 
-dune exec -- $configure "$@"
+dune exec --root . -- $configure "$@"

--- a/tools/configure/cmdArgs.ml
+++ b/tools/configure/cmdArgs.ml
@@ -71,7 +71,7 @@ let default = {
     if os_type_win32 || os_type_cygwin then NativeNo else NativeOndemand;
   coqwebsite = "http://coq.inria.fr/";
   warn_error = false;
-  dune_profile = "release";
+  dune_profile = "--release";
   install_enabled = true;
 }
 
@@ -79,7 +79,7 @@ let devel state = { state with
   bin_annot = true;
   annot = true;
   warn_error = true;
-  dune_profile = "dev";
+  dune_profile = "--profile=dev";
   interactive = true;
   prefix = Some (Filename.concat (Sys.getcwd ()) "_build_vo/default");
   install_enabled = false;


### PR DESCRIPTION
This should fix #14915 , the problem arises with layouts of the form:

```
foo/dune-project
foo/_opam/bar/dune-project
```

so when inside `foo/_opam/bar`, dune will switch to `foo` as the
project root, for example for `dune build` or `dune exec` , however,
as `_opam` is an ignored dir by default in the `foo` context, the
command will fail.

So indeed, it turns out `--profile release` is not enough, but
`--release` must be used when configured for install.

Thanks a lot to Kate for the help!