### PR TITLE
[8.14] [build] Set dune root explicitly / use --release

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -116,7 +116,7 @@ DOCGRAM_SOURCE_FILES=$(shell find $(addprefix $(COQ_SRC_DIR)/, doc/tools/docgram
 # Override for developer build [to get warn-as-error for example]
 _DDISPLAY?=quiet
 _DPROFILE?=$(CONFIGURE_DPROFILE)
-_DOPT:=--display $(_DDISPLAY) --profile=$(_DPROFILE)
+_DOPT:=--display=$(_DDISPLAY) $(_DPROFILE)
 _DBUILD:=$(FLOCK) .dune.lock dune build $(_DOPT)
 
 # We rerun dune when any of the source files have changed

--- a/configure
+++ b/configure
@@ -11,4 +11,4 @@ then
     exit 1
 fi
 
-dune exec -- $configure "$@"
+dune exec --root . -- $configure "$@"

--- a/tools/configure/configure.ml
+++ b/tools/configure/configure.ml
@@ -267,14 +267,14 @@ let default = {
   force_caml_version = false;
   force_findlib_version = false;
   warn_error = false;
-  dune_profile = "release";
+  dune_profile = "--release";
 }
 
 let devel state = { state with
   bin_annot = true;
   annot = true;
   warn_error = true;
-  dune_profile = "dev";
+  dune_profile = "--profile=dev";
   interactive = false;
   output_summary = true;
   prefix = Some (Filename.concat (Sys.getcwd ()) "_build_vo/default");


### PR DESCRIPTION
This should fix #14915 , the problem arises with layouts of the form:

```
foo/dune-project
foo/_opam/bar/dune-project
```

so when inside `foo/_opam/bar`, dune will switch to `foo` as the
project root, for example for `dune build` or `dune exec` , however,
as `_opam` is an ignored dir by default in the `foo` context, the
command will fail.

So indeed, it turns out `--profile release` is not enough, but
`--release` must be used when configured for install.

Thanks a lot to Kate for the help!

[This the 8.14 version of #14919]