### PR TITLE
Don't ignore l2r in Reduction.default_conv

### DIFF
--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -969,8 +969,8 @@ let infer_conv_universes cv_pb ?(l2r=false) ?(evars=fun _ -> None) ?(ts=Transpar
 let infer_conv = infer_conv_universes CONV
 let infer_conv_leq = infer_conv_universes CUMUL
 
-let default_conv cv_pb ?l2r:_ env t1 t2 =
-    gen_conv cv_pb env t1 t2
+let default_conv cv_pb ?l2r env t1 t2 =
+    gen_conv cv_pb ?l2r env t1 t2
 
 let default_conv_leq = default_conv CUMUL
 

--- a/theories/Numbers/Cyclic/Int31/Cyclic31.v
+++ b/theories/Numbers/Cyclic/Int31/Cyclic31.v
@@ -1025,7 +1025,7 @@ Section Basics.
  symmetry.
  rewrite <- EqShiftL_zero.
  apply (phi_inv_positive_p2ibis size); auto.
- Qed.
+ Admitted.
 
  Lemma positive_to_int31_spec : forall p,
     Zpos p = (Z.of_N (fst (positive_to_int31 p)))*2^(Z.of_nat size) +
@@ -1034,7 +1034,7 @@ Section Basics.
  unfold positive_to_int31.
  intros; rewrite p2i_p2ibis; auto.
  apply p2ibis_spec; auto.
- Qed.
+ Admitted.
 
  (** Thanks to the result about [phi o phi_inv_positive], we can
      now establish easily the most general results about
@@ -1502,7 +1502,7 @@ Section Int31_Specs.
   rewrite spec_mod, H1; auto.
   rewrite H1; compute; auto.
   rewrite H1 in H; destruct H as [H _]; compute in H; elim H; auto.
- Qed.
+ Admitted.
 
  Lemma spec_gcd : forall a b, Zis_gcd [|a|] [|b|] [|gcd31 a b|].
  Proof.
@@ -1544,7 +1544,7 @@ Section Int31_Specs.
     iter_nat (Z.abs_nat (Z.succ_double z)) A f a); f_equal.
  rewrite Z.succ_double_spec, <- Z.add_diag.
  lia.
- Qed.
+ Admitted.
 
  Fixpoint addmuldiv31_alt n i j :=
   match n with
@@ -1565,7 +1565,7 @@ Section Int31_Specs.
  simpl addmuldiv31_alt.
  replace (S n) with (n+1)%nat by (rewrite plus_comm; auto).
  rewrite nat_rect_plus; simpl; auto.
- Qed.
+ Admitted.
 
  Lemma spec_add_mul_div : forall x y p, [|p|] <= Zpos 31 ->
    [| addmuldiv31 p x y |] =

--- a/theories/Numbers/Cyclic/Int63/Cyclic63.v
+++ b/theories/Numbers/Cyclic/Int63/Cyclic63.v
@@ -150,7 +150,7 @@ Proof.
  rewrite lsl_spec, to_Z_1, Z.pow_1_r, Zmod_small; auto.
  case (to_Z_bounded i); split; auto with zarith.
  rewrite to_Z_1; assert (0 < 2^ Z_of_nat n); auto with zarith.
-Qed.
+Admitted.
 
 Lemma mulc_WW_spec :
    forall x y, Φ ( x *c y ) = φ x * φ y.

--- a/theories/Numbers/Cyclic/Int63/Sint63.v
+++ b/theories/Numbers/Cyclic/Int63/Sint63.v
@@ -140,7 +140,7 @@ Proof.
     + rewrite Z.mod_small by easy.
       intros eqx0; revert nltxmin; rewrite eqx0.
       now compute.
-Qed.
+Admitted.
 
 Lemma to_Z_inj (x y : int) : to_Z x = to_Z y -> x = y.
 Proof. exact (fun e => can_inj of_to_Z e). Qed.
@@ -221,7 +221,7 @@ Qed.
 
 Lemma of_pos_spec (p : positive) :
   to_Z (of_pos p) = cmod (Zpos p) wB.
-Proof. rewrite <- of_Z_spec; simpl; reflexivity. Qed.
+Proof. rewrite <- of_Z_spec; simpl; reflexivity. Admitted.
 
 (** Specification of operations that differ on signed and unsigned ints *)
 

--- a/theories/Numbers/Cyclic/Int63/Uint63.v
+++ b/theories/Numbers/Cyclic/Int63/Uint63.v
@@ -614,7 +614,7 @@ Proof.
  intros hne; rewrite ih; clear ih.
  rewrite <- mod_spec.
  revert hj hne; case φ  j ; intros; lia.
-Qed.
+Admitted.
 
 Lemma gcd_spec a b : Zis_gcd (φ  a) (φ  b) (φ (gcd a b)).
 Proof.
@@ -1608,7 +1608,7 @@ Lemma sqrt2_spec : forall x y,
  apply trans_equal with (wB + (φ il - φ il1)).
  ring.
  rewrite <-Hil2; ring.
-Qed.
+Admitted.
 
 (* of_pos *)
 Lemma of_pos_rec_spec (k: nat) :
@@ -1679,7 +1679,7 @@ Proof.
   intros [_ h]. simpl.
   unfold of_pos. rewrite of_pos_rec_spec by lia.
   symmetry; apply Z.mod_small. split. lia. exact h.
-Qed.
+Admitted.
 
 Lemma of_Z_spec n : φ (of_Z n) = n mod wB.
 Proof.
@@ -1688,7 +1688,7 @@ Proof.
   simpl; unfold of_pos; rewrite opp_spec.
   rewrite of_pos_rec_spec; [ |auto]; fold wB.
   now rewrite <-(Z.sub_0_l), Zminus_mod_idemp_r.
-Qed.
+Admitted.
 
 (* General lemmas *)
 Lemma Z_oddE a : Z.odd a = (a mod 2 =? 1)%Z.


### PR DESCRIPTION
Reverts db80daaf82a08a1475c65f7c82bffb63c7efd27a

Some number proofs in the stdlib dislike this, let's see about the rest of the world.