### PR TITLE
Do not register abstracted subproofs in the nametab

### DIFF
--- a/doc/changelog/04-tactics/14937-abstract-no-nametab.rst
+++ b/doc/changelog/04-tactics/14937-abstract-no-nametab.rst
@@ -1,0 +1,8 @@
+- **Changed:**
+  the :tacn:`abstract` tactic now only registers a name
+  for the sublemma after the whole tactic block has run,
+  i.e. after a dot. In particular, the sublemma cannot
+  be accessed by its name while the tactic call has not
+  returned
+  (`#14937 <https://github.com/coq/coq/pull/14937>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/proofs/writing-proofs/proof-mode.rst
+++ b/doc/sphinx/proofs/writing-proofs/proof-mode.rst
@@ -885,8 +885,14 @@ Proving a subgoal as a separate lemma: abstract
 
    .. warning::
 
-      Provide :n:`@ident__name` at your own risk; explicitly named and reused subterms
-      don’t play well with asynchronous proofs.
+      There are no guarantees with fresh name generation. In particular,
+      you should not rely on the generated constant being available in your
+      proof script. Even when providing an explicit :n:`@ident__name`, do it at
+      your own risk. Explicitly named and reused subterms don't play well with
+      asynchronous proofs. Furthermore the binding is only made available when
+      exiting the current tactic block, i.e. after a dot. The only guarantee
+      with explicit naming is that the subproof will be accessible with this
+      name after the :cmd:`Defined` command.
 
    .. tacn:: transparent_abstract @ltac_expr3 {? using @ident }
 

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -198,7 +198,7 @@ let qualid_of_global = function
 
 let default_extern_reference ?loc vars r =
   try Nametab.shortest_qualid_of_global ?loc vars r
-  with Not_found when GlobRef.is_bound r -> qualid_of_global r
+  with Not_found -> qualid_of_global r
 
 let my_extern_reference = ref default_extern_reference
 

--- a/interp/dumpglob.ml
+++ b/interp/dumpglob.ml
@@ -126,9 +126,11 @@ let type_of_global_ref gr =
     let open Names.GlobRef in
     match gr with
     | ConstRef cst ->
-      type_of_logical_kind (constant_kind cst)
+      let knd = try constant_kind cst with Not_found -> IsDefinition Definition in
+      type_of_logical_kind knd
     | VarRef v ->
-      "var" ^ type_of_logical_kind (Decls.variable_kind v)
+      let knd = try Decls.variable_kind v with Not_found -> IsDefinition Definition in
+      "var" ^ type_of_logical_kind knd
     | IndRef ind ->
         let (mib,oib) = Inductive.lookup_mind_specif (Global.env ()) ind in
           if mib.Declarations.mind_record <> Declarations.NotRecord then

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -485,6 +485,10 @@ let universes_of_private eff =
   let fold acc eff = Univ.ContextSet.union eff.seff_univs acc in
   List.fold_left fold Univ.ContextSet.empty (side_effects_of_private_constants eff)
 
+let constants_of_private eff =
+  let fold acc eff = eff.seff_constant :: acc in
+  List.fold_left fold [] (side_effects_of_private_constants eff)
+
 let env_of_safe_env senv = senv.env
 let env_of_senv = env_of_safe_env
 

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -66,6 +66,8 @@ val push_private_constants : Environ.env -> private_constants -> Environ.env
 
 val universes_of_private : private_constants -> Univ.ContextSet.t
 
+val constants_of_private : private_constants -> Constant.t list
+
 val is_curmod_library : safe_environment -> bool
 
 val is_joined_environment : safe_environment -> bool

--- a/tactics/abstract.ml
+++ b/tactics/abstract.ml
@@ -78,8 +78,15 @@ let cache_term_by_tactic_then ~opaque ~name_op ?(goal_type=None) tac tacK =
     let effs, sigma, lem, args, safe =
       !declare_abstract ~name ~poly ~sign ~secsign ~opaque ~solve_tac sigma concl
     in
+    let pose_tac = match name_op with
+    | None -> Proofview.tclUNIT ()
+    | Some id ->
+      if opaque then Tactics.pose_proof (Names.Name id) lem
+      else Tactics.pose_tac (Names.Name id) lem
+    in
     let solve =
       Proofview.tclEFFECTS effs <*>
+      pose_tac <*>
       tacK lem args
     in
     let tac = if not safe then Proofview.mark_as_unsafe <*> solve else solve in

--- a/test-suite/output-coqtop/bug_16462.out
+++ b/test-suite/output-coqtop/bug_16462.out
@@ -11,8 +11,8 @@ Rocq < 1 goal
   ============================
   True
 
-Unnamed_thm < Unnamed_thm_subproof
-Unnamed_thm_subproof
+Unnamed_thm < Top.Unnamed_thm_subproof
+Top.Unnamed_thm_subproof
 Toplevel input, characters 2-7:
 >   baz I.
 >   ^^^^^
@@ -22,8 +22,9 @@ In nested Ltac calls to "baz", "f" (bound to fun f x y => idtac v; f x),
 "f" (bound to
 fun _ => let v' := v in
          constr:((fun _ => ltac:(idtac v'; fail 1)))) and
-"(fun _ => ltac:(idtac v'; fail 1))" (with x:=I, v':=Unnamed_thm_subproof,
-v:=Unnamed_thm_subproof, H:=H), last term evaluation failed.
+"(fun _ => ltac:(idtac v'; fail 1))" (with x:=I,
+v':=Top.Unnamed_thm_subproof, v:=Top.Unnamed_thm_subproof, H:=H), last term
+evaluation failed.
 
 
 Unnamed_thm < 

--- a/test-suite/output-coqtop/bug_16745.out
+++ b/test-suite/output-coqtop/bug_16745.out
@@ -10,8 +10,8 @@ Unnamed_thm < Unnamed_thm < Unnamed_thm < Toplevel input, characters 111-112:
 >                                             ^
 Error:
 In environment
-x := Unnamed_thm_subproof : nat
-The term "Unnamed_thm_subproof" has type "nat"
+x := Top.Unnamed_thm_subproof : nat
+The term "Top.Unnamed_thm_subproof" has type "nat"
 while it is expected to have type "True".
 
 Unnamed_thm < 

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -665,7 +665,7 @@ let declare_constant ~loc ?(local = Locality.ImportDefaultBehavior) ~name ~kind 
   if unsafe || is_unsafe_typing_flags typing_flags then feedback_axiom();
   kn
 
-let declare_private_constant ?role ?(local = Locality.ImportDefaultBehavior) ~name ~kind ~opaque de =
+let declare_private_constant ?role ~name ~opaque de =
   let de, ctx =
     if not opaque then
       let de, ctx = cast_pure_proof_entry de in
@@ -673,13 +673,13 @@ let declare_private_constant ?role ?(local = Locality.ImportDefaultBehavior) ~na
     else
       let de, ctx = cast_opaque_proof_entry PureEntry de in
       OpaqueEff de, ctx
+
   in
   let kn, eff = Global.add_private_constant name ctx de in
   let () = if Univ.Level.Set.is_empty (fst ctx) then ()
     else DeclareUniv.declare_univ_binders (ConstRef kn)
         (Monomorphic_entry ctx, UnivNames.empty_binders)
   in
-  let () = register_constant (fallback_loc ~warn:false name None) kn kind local in
   let seff_roles = match role with None -> Cmap.empty | Some r -> Cmap.singleton kn r in
   let eff = { Evd.seff_private = eff; Evd.seff_roles; } in
   kn, eff
@@ -898,7 +898,8 @@ let ustate_of_proof = function
 let declare_definition_scheme ~internal ~univs ~role ~name ?loc c =
   let kind = Decls.(IsDefinition Scheme) in
   let entry = pure_definition_entry ~univs c in
-  let kn, eff = declare_private_constant ~role ~kind ~name ~opaque:false entry in
+  let kn, eff = declare_private_constant ~role ~name ~opaque:false entry in
+  let () = register_constant (fallback_loc ~warn:false name None) kn kind Locality.ImportDefaultBehavior in
   Dumpglob.dump_definition
     (CAst.make ?loc (Constant.label kn |> Label.to_id)) false "scheme";
   let () = if internal then () else definition_message name in
@@ -2159,10 +2160,6 @@ let build_by_tactic env ~uctx ~poly ~typ tac =
   body, ce.proof_entry_type, ce.proof_entry_universes, status, uctx
 
 let declare_abstract ~name ~poly ~sign ~secsign ~opaque ~solve_tac sigma concl =
-  let kind = if opaque
-    then Decls.(IsProof Lemma)
-    else Decls.(IsDefinition Definition)
-  in
   let (const, safe, sigma') =
     try build_constant_by_tactic ~warn_incomplete:false ~name ~poly ~sigma ~sign:secsign concl solve_tac
     with Logic_monad.TacticFailure e as src ->
@@ -2181,15 +2178,11 @@ let declare_abstract ~name ~poly ~sign ~secsign ~opaque ~solve_tac sigma concl =
      `if poly && opaque && private_poly_univs ()` in `close_proof`
      kernel will boom. This deserves more investigation. *)
   let body, typ, args = ProofEntry.shrink_entry sign body const.proof_entry_type in
-  let cst () =
-    (* do not compute the implicit arguments, it may be costly *)
-    let () = Impargs.make_implicit_args false in
+  let cst, eff =
     (* No side-effects in the entry, they already exist in the ambient environment *)
     let const = { const with proof_entry_body = body; proof_entry_type = typ } in
-    (* ppedrot: seems legit to have abstracted subproofs as local*)
-    declare_private_constant ~local:Locality.ImportNeedQualified ~name ~kind ~opaque const
+    declare_private_constant ~name ~opaque const
   in
-  let cst, eff = Impargs.with_implicit_protection cst () in
   let inst = instance_of_univs const.proof_entry_universes in
   let lem = EConstr.of_constr (Constr.mkConstU (cst, inst)) in
   let effs = Evd.concat_side_effects eff effs in


### PR DESCRIPTION
This only affects users of the `abstract ... using` feature. Let's see how violent this is.

EDIT: the current version of the PR still declares the lemma in the nametab for a slightly better backward compatibility, but only after the whole tactic block has run, i.e. after a dot. Hence sublemmas cannot be accessed by name while the block enclosing the abstract has not finished.