### PR TITLE
Remove state explicit management for good

### DIFF
--- a/config/coq_config.mli
+++ b/config/coq_config.mli
@@ -32,7 +32,6 @@ val version : string    (* version number of Coq *)
 val caml_version : string    (* OCaml version used to compile Coq *)
 val caml_version_nums : int list    (* OCaml version used to compile Coq by components *)
 val vo_version : int32
-val state_magic_number : int
 
 val all_src_dirs : string list
 

--- a/doc/changelog/07-vernac-commands-and-options/14940-rm-output-state-for-good.rst
+++ b/doc/changelog/07-vernac-commands-and-options/14940-rm-output-state-for-good.rst
@@ -1,0 +1,5 @@
+- **Removed:**
+  the `-outputstate` command line argument and the corresponding
+  vernacular commands `Write State` and `Restore State`
+  (`#14940 <https://github.com/coq/coq/pull/14940>`_,
+  by Pierre-Marie Pédrot)

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1324,9 +1324,6 @@ command: [
 | REPLACE "Remove" IDENT IDENT LIST1 table_value
 | WITH "Remove" setting_name LIST1 table_value
 | DELETE "Remove" IDENT LIST1 table_value
-| DELETE "Restore" "State" IDENT
-| DELETE "Restore" "State" ne_string
-| "Restore" "State" [ IDENT | ne_string ]
 | DELETE "Show"
 | DELETE "Show" natural
 | DELETE "Show" ident
@@ -1351,9 +1348,6 @@ command: [
 | DELETE "Undo" natural
 | REPLACE "Undo" "To" natural
 | WITH "Undo" OPT ( OPT "To" natural )
-| DELETE "Write" "State" IDENT
-| REPLACE "Write" "State" ne_string
-| WITH "Write" "State" [ IDENT | ne_string ]
 | DELETE "Abort"
 | DELETE "Abort" "All"
 | REPLACE "Abort" identref

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -557,10 +557,6 @@ command: [
 | "Test" setting_name
 | "Remove" IDENT IDENT LIST1 table_value
 | "Remove" IDENT LIST1 table_value
-| "Write" "State" IDENT
-| "Write" "State" ne_string
-| "Restore" "State" IDENT
-| "Restore" "State" ne_string
 | "Reset" "Initial"
 | "Reset" identref
 | "Back"

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -915,8 +915,6 @@ command: [
 | "Add" setting_name LIST1 [ qualid | string ]
 | "Test" setting_name OPT ( "for" LIST1 [ qualid | string ] )
 | "Remove" setting_name LIST1 [ qualid | string ]
-| "Write" "State" [ ident | string ]
-| "Restore" "State" [ ident | string ]
 | "Reset" "Initial"
 | "Reset" ident
 | "Back" OPT natural

--- a/ide/coqide/coq_commands.ml
+++ b/ide/coqide/coq_commands.ml
@@ -103,7 +103,6 @@ let commands = [
    "Require Export";
    "Require Import";
    "Reset Extraction Inline";
-   "Restore State";
    ];
   [  "Scheme";
      "Section";
@@ -152,7 +151,6 @@ let commands = [
   ["Variable";
    "Variant";
    "Variables";];
-  ["Write State";];
 ]
 
 let state_preserving = [

--- a/lib/system.ml
+++ b/lib/system.ml
@@ -151,20 +151,6 @@ let is_in_system_path filename =
     warn_path_not_found ();
     false
 
-let open_trapping_failure name =
-  try open_out_bin name
-  with e when CErrors.noncritical e ->
-    CErrors.user_err ~hdr:"System.open" (str "Can't open " ++ str name)
-
-let warn_cannot_remove_file =
-  CWarnings.create ~name:"cannot-remove-file" ~category:"filesystem"
-  (fun filename -> str"Could not remove file " ++ str filename ++ str" which is corrupted!")
-
-let try_remove filename =
-  try Sys.remove filename
-  with e when CErrors.noncritical e ->
-    warn_cannot_remove_file filename
-
 let error_corrupted file s =
   CErrors.user_err ~hdr:"System" (str file ++ str ": " ++ str s ++ str ". Try to rebuild it.")
 
@@ -177,13 +163,6 @@ let check_caml_version ~caml:s ~file:f =
     be compatible.")
   else ()
 
-let input_binary_int f ch =
-  try input_binary_int ch
-  with
-  | End_of_file -> error_corrupted f "premature end of file"
-  | Failure s -> error_corrupted f s
-let output_binary_int ch x = output_binary_int ch x; flush ch
-
 let marshal_out ch v = Marshal.to_channel ch v []; flush ch
 let marshal_in filename ch =
   try Marshal.from_channel ch
@@ -194,47 +173,6 @@ let marshal_in filename ch =
 type magic_number_error = {filename: string; actual: int32; expected: int32}
 exception Bad_magic_number of magic_number_error
 exception Bad_version_number of magic_number_error
-
-let raw_extern_state magic filename =
-  let channel = open_trapping_failure filename in
-  output_binary_int channel magic;
-  channel
-
-let raw_intern_state magic filename =
-  try
-    let channel = open_in_bin filename in
-    let actual_magic = input_binary_int filename channel in
-    if not (Int.equal actual_magic magic) then
-        raise (Bad_magic_number {
-            filename=filename;
-            actual=Int32.of_int actual_magic;
-            expected=Int32.of_int magic});
-    channel
-  with
-  | End_of_file -> error_corrupted filename "premature end of file"
-  | Failure s | Sys_error s -> error_corrupted filename s
-
-let extern_state magic filename val_0 =
-  try
-    let channel = raw_extern_state magic filename in
-    try
-      marshal_out channel val_0;
-      close_out channel
-    with reraise ->
-      let reraise = Exninfo.capture reraise in
-      let () = try_remove filename in
-      Exninfo.iraise reraise
-  with Sys_error s ->
-    CErrors.user_err ~hdr:"System.extern_state" (str "System error: " ++ str s)
-
-let intern_state magic filename =
-  try
-    let channel = raw_intern_state magic filename in
-    let v = marshal_in filename channel in
-    close_in channel;
-    v
-  with Sys_error s ->
-    CErrors.user_err ~hdr:"System.intern_state" (str "System error: " ++ str s)
 
 let with_magic_number_check f a =
   try f a

--- a/lib/system.mli
+++ b/lib/system.mli
@@ -72,14 +72,6 @@ type magic_number_error = {filename: string; actual: int32; expected: int32}
 exception Bad_magic_number of magic_number_error
 exception Bad_version_number of magic_number_error
 
-val raw_extern_state : int -> string -> out_channel
-
-val raw_intern_state : int -> string -> in_channel
-
-val extern_state : int -> string -> 'a -> unit
-
-val intern_state : int -> string -> 'a
-
 val with_magic_number_check : ('a -> 'b) -> 'a -> 'b
 
 (** Clones of Marshal.to_channel (with flush) and

--- a/tools/configure/configure.ml
+++ b/tools/configure/configure.ml
@@ -21,7 +21,6 @@ let (/) = Filename.concat
 
 let coq_version = "8.15+alpha"
 let vo_magic = 81491
-let state_magic = 581491
 let is_a_released_version = false
 
 (** Default OCaml binaries *)
@@ -449,7 +448,6 @@ let write_configml camlenv coqenv caml_flags caml_version_nums arch arch_is_win3
   let pr s = fprintf o s in
   let pr_s = pr "let %s = %S\n" in
   let pr_b = pr "let %s = %B\n" in
-  let pr_i = pr "let %s = %d\n" in
   let pr_i32 = pr "let %s = %dl\n" in
   let pr_p s o = pr "let %s = %S\n" s
     (match o with Relative s -> s | Absolute s -> s) in
@@ -476,7 +474,6 @@ let write_configml camlenv coqenv caml_flags caml_version_nums arch arch_is_win3
   pr "let gtk_platform = `%s\n" idearchdef;
   pr_b "has_natdynlink" hasnatdynlink;
   pr_i32 "vo_version" vo_magic;
-  pr_i "state_magic_number" state_magic;
   pr_s "browser" browser;
   pr_s "wwwcoq" prefs.coqwebsite;
   pr_s "wwwbugtracker" (prefs.coqwebsite ^ "bugs/");

--- a/toplevel/coqc.ml
+++ b/toplevel/coqc.ml
@@ -8,11 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-let outputstate opts =
-  Option.iter (fun ostate_file ->
-    let fname = CUnix.make_suffix ostate_file ".coq" in
-    Vernacstate.System.dump fname) opts.Coqcargs.outputstate
-
 let coqc_init ((_,color_mode),_) injections ~opts =
   Flags.quiet := true;
   System.trust_file_cache := true;
@@ -56,9 +51,6 @@ let coqc_main ((copts,_),stm_opts) injections ~opts =
      point some stuff may not be safe anymore. *)
   Topfmt.(in_phase ~phase:CompilationPhase)
     Ccompile.do_vio opts copts injections;
-
-  (* Allow the user to output an arbitrary state *)
-  outputstate copts;
 
   flush_all();
 

--- a/toplevel/coqcargs.ml
+++ b/toplevel/coqcargs.ml
@@ -23,7 +23,6 @@ type t =
 
   ; echo : bool
 
-  ; outputstate : string option
   ; glob_out    : Dumpglob.glob_output
 
   ; output_context : bool
@@ -42,7 +41,6 @@ let default =
 
   ; echo = false
 
-  ; outputstate = None
   ; glob_out = Dumpglob.MultFiles
 
   ; output_context = false
@@ -128,19 +126,10 @@ let rec add_vio_args peek next oval =
     add_vio_args peek next oval
   else oval
 
-let warn_deprecated_outputstate =
-  CWarnings.create ~name:"deprecated-outputstate" ~category:"deprecated"
-         (fun () ->
-          Pp.strbrk "The outputstate option is deprecated and discouraged.")
-
 let warn_deprecated_quick =
   CWarnings.create ~name:"deprecated-quick" ~category:"deprecated"
          (fun () ->
           Pp.strbrk "The -quick option is renamed -vio. Please consider using the -vos feature instead.")
-
-let set_outputstate opts s =
-  warn_deprecated_outputstate ();
-  { opts with outputstate = Some s }
 
 let parse arglist : t =
   let echo = ref false in
@@ -211,9 +200,6 @@ let parse arglist : t =
         | "-vio2vo" ->
           let oval = add_compile ~echo:false oval (next ()) in
           set_compilation_mode oval Vio2Vo
-
-        | "-outputstate" ->
-          set_outputstate oval (next ())
 
         (* Glob options *)
         |"-no-glob" | "-noglob" ->

--- a/toplevel/coqcargs.mli
+++ b/toplevel/coqcargs.mli
@@ -37,7 +37,6 @@ type t =
 
   ; echo : bool
 
-  ; outputstate : string option
   ; glob_out    : Dumpglob.glob_output
 
   ; output_context : bool

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -1123,14 +1123,8 @@ GRAMMAR EXTEND Gram
 
   command: TOP
     [ [
-(* State management *)
-        IDENT "Write"; IDENT "State"; s = IDENT -> { VernacWriteState s }
-      | IDENT "Write"; IDENT "State"; s = ne_string -> { VernacWriteState s }
-      | IDENT "Restore"; IDENT "State"; s = IDENT -> { VernacRestoreState s }
-      | IDENT "Restore"; IDENT "State"; s = ne_string -> { VernacRestoreState s }
-
 (* Resetting *)
-      | IDENT "Reset"; IDENT "Initial" -> { VernacResetInitial }
+        IDENT "Reset"; IDENT "Initial" -> { VernacResetInitial }
       | IDENT "Reset"; id = identref -> { VernacResetName id }
       | IDENT "Back" -> { VernacBack 1 }
       | IDENT "Back"; n = natural -> { VernacBack n }

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -727,12 +727,6 @@ let pr_vernac_expr v =
       if Int.equal i 1 then keyword "Back" else keyword "Back" ++ pr_intarg i
     )
 
-  (* State management *)
-  | VernacWriteState s ->
-    return (keyword "Write State" ++ spc () ++ qs s)
-  | VernacRestoreState s ->
-    return  (keyword "Restore State" ++ spc() ++ qs s)
-
   (* Syntax *)
   | VernacOpenCloseScope (opening,sc) ->
     return (

--- a/vernac/vernac_classifier.ml
+++ b/vernac/vernac_classifier.ml
@@ -188,9 +188,6 @@ let classify_vernac e =
     | VernacUndoTo _ | VernacUndo _
     | VernacResetName _ | VernacResetInitial
     | VernacRestart -> VtMeta
-    (* What are these? *)
-    | VernacRestoreState _
-    | VernacWriteState _ -> VtSideff ([], VtNow)
     (* Plugins should classify their commands *)
     | VernacExtend (s,l) ->
         try Vernacextend.get_vernac_classifier s l

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1450,17 +1450,6 @@ let vernac_chdir = function
       end;
       Flags.if_verbose Feedback.msg_info (str (Sys.getcwd()))
 
-(********************)
-(* State management *)
-
-let vernac_write_state file =
-  let file = CUnix.make_suffix file ".coq" in
-  Vernacstate.System.dump file
-
-let vernac_restore_state file =
-  let file = Loadpath.locate_file (CUnix.make_suffix file ".coq") in
-  Vernacstate.System.load file
-
 (************)
 (* Commands *)
 
@@ -2325,16 +2314,6 @@ let translate_vernac ?loc ~atts v = let open Vernacextend in match v with
     vtdefault(fun () -> with_locality ~atts vernac_declare_ml_module l)
   | VernacChdir s ->
     vtdefault(fun () -> unsupported_attributes atts; vernac_chdir s)
-
-  (* State management *)
-  | VernacWriteState s ->
-    vtdefault(fun () ->
-        unsupported_attributes atts;
-        vernac_write_state s)
-  | VernacRestoreState s ->
-    vtdefault(fun () ->
-        unsupported_attributes atts;
-        vernac_restore_state s)
 
   (* Commands *)
   | VernacCreateHintDb (dbname,b) ->

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -394,10 +394,6 @@ type nonrec vernac_expr =
   | VernacDeclareMLModule of string list
   | VernacChdir of string option
 
-  (* State management *)
-  | VernacWriteState of string
-  | VernacRestoreState of string
-
   (* Resetting *)
   | VernacResetName of lident
   | VernacResetInitial

--- a/vernac/vernacstate.ml
+++ b/vernac/vernacstate.ml
@@ -30,9 +30,6 @@ module System : sig
   val freeze : marshallable:bool -> t
   val unfreeze : t -> unit
 
-  val dump : string -> unit
-  val load : string -> unit
-
   module Stm : sig
     val make_shallow : t -> t
     val lib : t -> Lib.frozen
@@ -56,16 +53,6 @@ end = struct
     with reraise ->
       let reraise = Exninfo.capture reraise in
       (unfreeze st; Exninfo.iraise reraise)
-
-  (* These commands may not be very safe due to ML-side plugin loading
-     etc... use at your own risk *)
-  (* XXX: EJGA: this is ignoring parsing state, it works for now? *)
-  let dump s =
-    System.extern_state Coq_config.state_magic_number s (freeze ~marshallable:true)
-
-  let load s =
-    unfreeze (System.with_magic_number_check (System.intern_state Coq_config.state_magic_number) s);
-    Library.overwrite_library_filenames s
 
   (* STM-specific state manipulations *)
   module Stm = struct

--- a/vernac/vernacstate.mli
+++ b/vernac/vernacstate.mli
@@ -27,10 +27,6 @@ module System : sig
   (** [protect f x] runs [f x] and discards changes in the system state  *)
   val protect : ('a -> 'b) -> 'a -> 'b
 
-  (** Load / Dump provide unsafe but convenient state dumping from / to disk *)
-  val dump : string -> unit
-  val load : string -> unit
-
 end
 
 module LemmaStack : sig


### PR DESCRIPTION
Follow-up of #13822.

- We remove the `-outputstate` command line argument, which was mostly useless since `-inputstate` was removed in 8.14.
- We remove the corresponding vernacular commands.
- We remove the remnant API.