### PR TITLE
Correctly handle a test introduced in #14758 in async mode.

### DIFF
--- a/test-suite/bugs/closed/bug_14734.v
+++ b/test-suite/bugs/closed/bug_14734.v
@@ -1,3 +1,5 @@
+(* coq-prog-args: ("-async-proofs" "off") *)
+
 #[universes(cumulative=yes)]
  Polymorphic Class t@{+s} (S : Type@{s}) (A B : Prop) :=
   T {


### PR DESCRIPTION
We simply turn asynchronous computation off to ensure the constraints are added eagerly to the environment.

cc @gares @SkySkimmer 