### PR TITLE
coq_makefile: Disable missing-mli error

### DIFF
--- a/doc/sphinx/practical-tools/utilities.rst
+++ b/doc/sphinx/practical-tools/utilities.rst
@@ -270,7 +270,7 @@ section of the generated makefile. These include:
    can be used to specify additional flags to the OCaml
    compiler, like ``-bin-annot`` or ``-w``....
 :OCAMLWARN:
-   it contains a default of ``-warn-error +a-3``, useful to modify
+   it contains a default of ``-warn-error +a-3-70``, useful to modify
    this setting; beware this is not recommended for projects in
    Coq's CI.
 :COQC, COQDEP, COQDOC:

--- a/lib/envars.ml
+++ b/lib/envars.ml
@@ -177,7 +177,7 @@ let print_config ?(prefix_var_name="") f =
   fprintf f "%sDOCDIR=%s/\n" prefix_var_name (docdir ());
   fprintf f "%sOCAMLFIND=%s\n" prefix_var_name (ocamlfind ());
   fprintf f "%sCAMLFLAGS=%s\n" prefix_var_name Coq_config.caml_flags;
-  fprintf f "%sWARN=%s\n" prefix_var_name "-warn-error +a-3";
+  fprintf f "%sWARN=%s\n" prefix_var_name "-warn-error +a-3-70";
   fprintf f "%sHASNATDYNLINK=%s\n" prefix_var_name
     (if Coq_config.has_natdynlink then "true" else "false");
   fprintf f "%sCOQ_SRC_SUBDIRS=%s\n" prefix_var_name (String.concat " " Coq_config.all_src_dirs);


### PR DESCRIPTION
In plugins, `.mlg` files produce `.ml` files without `.mli`, so this new error from the OCaml compiler breaks existing builds.