### PR TITLE
coqchk respects sharing flag per-definition

### DIFF
--- a/checker/checkFlags.ml
+++ b/checker/checkFlags.ml
@@ -17,6 +17,7 @@ let set_local_flags flags env =
       check_positive = flags.check_positive;
       check_universes = flags.check_universes;
       conv_oracle = flags.conv_oracle;
+      share_reduction = flags.share_reduction;
       cumulative_sprop = flags.cumulative_sprop;
       allow_uip = flags.allow_uip;
     }

--- a/doc/changelog/08-cli-tools/14957-coqchk-share-red.rst
+++ b/doc/changelog/08-cli-tools/14957-coqchk-share-red.rst
@@ -1,0 +1,4 @@
+- **Changed:**
+  ``coqchk`` respects the ``Kernel Term Sharing`` flag instead of forcing it on
+  (`#14957 <https://github.com/coq/coq/pull/14957>`_,
+  by Gaëtan Gilbert)


### PR DESCRIPTION
Fix #7086
