### PR TITLE
Bump Sphinx to 3.0.2.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ variables:
   # Format: $IMAGE-V$DATE-$hash
   # The $hash is the first 10 characters of the md5 of the Dockerfile. e.g.
   # echo $(md5sum dev/ci/docker/bionic_coq/Dockerfile | head -c 10)
-  CACHEKEY: "bionic_coq-V2021-07-23-bca07e9228"
+  CACHEKEY: "bionic_coq-V2021-10-01-459f39d2cf"
   IMAGE: "$CI_REGISTRY_IMAGE:$CACHEKEY"
   # By default, jobs run in the base switch; override to select another switch
   OPAM_SWITCH: "base"

--- a/dev/ci/docker/bionic_coq/Dockerfile
+++ b/dev/ci/docker/bionic_coq/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update -qq && apt-get install --no-install-recommends -y -qq \
         texlive-science tipa
 
 # More dependencies of the sphinx doc, pytest for coqtail
-RUN pip3 install docutils==0.16 sphinx==2.3.1 sphinx_rtd_theme==0.4.3 \
+RUN pip3 install docutils==0.16 sphinx==3.0.2 sphinx_rtd_theme==0.4.3 \
         antlr4-python3-runtime==4.7.1 sphinxcontrib-bibtex==0.4.2 \
         pytest==5.4.3
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -30,7 +30,7 @@ To produce the complete documentation in HTML, you will need Coq dependencies
 listed in [`INSTALL.md`](../INSTALL.md). Additionally, the Sphinx-based
 reference manual requires Python 3, and the following Python packages:
 
-  - sphinx >= 2.3.1
+  - sphinx >= 3.0.2
   - sphinx_rtd_theme >= 0.4.3
   - beautifulsoup4 >= 4.0.6
   - antlr4-python3-runtime >= 4.7.1

--- a/doc/changelog/11-infrastructure-and-dependencies/14963-master.rst
+++ b/doc/changelog/11-infrastructure-and-dependencies/14963-master.rst
@@ -1,0 +1,4 @@
+- **Changed:**
+  Sphinx 3.0.2 or above is now required to build the reference manual
+  (`#14963 <https://github.com/coq/coq/pull/14263>`_,
+  by Théo Zimmermann)

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -50,7 +50,7 @@ with open("refman-preamble.rst") as s:
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = '2.3.1'
+needs_sphinx = '3.0.2'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/doc/sphinx/proofs/writing-proofs/equality.rst
+++ b/doc/sphinx/proofs/writing-proofs/equality.rst
@@ -110,9 +110,7 @@ Rewriting with Leibniz and setoid equality
 
       :n:`{? forall @open_binders , } EQ @term__1 @term__2`
 
-   .. todo :term:`Leibniz equality` does not work with Sphinx 2.3.1. It does with Sphinx 3.0.3.
-
-   where :g:`EQ` is the Leibniz equality `eq` or a registered :term:`setoid equality`.
+   where :g:`EQ` is the :term:`Leibniz equality` `eq` or a registered :term:`setoid equality`.
    Note that :n:`eq @term__1 @term__2` is typically written with the infix notation
    :n:`@term__1 = @term__2`.  You must `Require Setoid` to use the tactic
    with a setoid equality or with :ref:`setoid rewriting <generalizedrewriting>`.


### PR DESCRIPTION
To fix an issue with casing in glossary terms.
Sphinx 3.0.2 was released in April 2020.

- [x] Added **changelog**.
- [x] Added / updated **documentation**.