### PR TITLE
Document new coqbot `SKIP_DOCKER=false` feature.

### DIFF
--- a/dev/ci/README-developers.md
+++ b/dev/ci/README-developers.md
@@ -163,13 +163,8 @@ The Docker building job reuses the uploaded image if it is available,
 but if you wish to save more time you can skip the job by setting
 `SKIP_DOCKER` to `true`.
 
-This means you will need to change its value when the Docker image
-needs to be updated. You can do so for a single pipeline by starting
-it through the web interface. Here is a direct link that you can use
-to trigger such a build:
-`https://gitlab.com/coq/coq/pipelines/new?var[SKIP_DOCKER]=false&ref=pr-XXXXX`.
-Note that this link will give a 404 error if you are not logged in or
-a member of the Coq organization on GitLab.  To request to join the
-Coq organization, go to https://gitlab.com/coq to request access.
+In the case of the main Coq repository, this variable is set to true
+by default, but coqbot will set it to `false` anytime a PR modifies a
+path matching `dev/ci/docker/.*Dockerfile.*`.
 
 See also [`docker/README.md`](docker/README.md).

--- a/dev/ci/docker/README.md
+++ b/dev/ci/docker/README.md
@@ -16,19 +16,13 @@ in forked repositories after the initial Docker build in the fork succeeds.
 
 The steps to generate a new Docker image are:
 - Update the `CACHEKEY` variable in .gitlab-ci.yml with the date and md5.
-- Submit the change in a PR. This triggers a Gitlab CI run that
-  immediately fails, as the Docker image is missing and the `SKIP_DOCKER`
-  default value prevents rebuilding the image.
-- Run a new pipeline on Gitlab with that PR branch (e.g. "pr-99999"), using the green
-  "Run pipeline" button on the [web interface](https://gitlab.com/coq/coq/pipelines),
-  with the `SKIP_DOCKER` environment variable set to `false`. This will run a
-  `docker-boot` process, and once completed, a new Docker image will be available in
-  the container registry, with the name set in `CACHEKEY`.
+- Submit the change in a PR. coqbot will detect that the Dockerfile
+  has changed and will trigger a pipeline build with `SKIP_DOCKER` set
+  to `false`. This will run a `docker-boot` process, and once
+  completed, a new Docker image will be available in the container
+  registry, with the name set in `CACHEKEY`.
 - Any pipeline with the same `CACHEKEY` will now automatically reuse that
   image without rebuilding it from scratch.
-
-In case you do not have the rights to run Gitlab CI pipelines, you should ask
-the ci-maintainers Github team to do it for you.
 
 ## Manual Building
 


### PR DESCRIPTION
From now on, coqbot detects when a Dockerfile has been modified, and runs `git push` with option:
`-o ci.variable="SKIP_DOCKER=false"`.

See the GitLab CI documentation of this feature: https://docs.gitlab.com/ee/user/project/push_options.html#push-options-for-gitlab-cicd