### PR TITLE
 Fixes #14938: in the reference manual, mentions the role of non-recursively uniform parameters in the strict positivity condition

### DIFF
--- a/doc/changelog/02-specification-language/14967-master+fix-non-rec-uniform-positivity-doc.rst
+++ b/doc/changelog/02-specification-language/14967-master+fix-non-rec-uniform-positivity-doc.rst
@@ -1,0 +1,7 @@
+- **Fixed:**
+  Made reference manual consistent with the implementation regarding
+  the role of recursively non-uniform parameters of inductive types in the nested
+  positivity condition
+  (`#14967 <https://github.com/coq/coq/pull/14967>`_,
+  fixes `#14938 <https://github.com/coq/coq/issues/14938>`_,
+  by Hugo Herbelin)

--- a/doc/sphinx/language/core/inductive.rst
+++ b/doc/sphinx/language/core/inductive.rst
@@ -736,21 +736,25 @@ cases:
   inductive definition of the form
 
   .. math::
-     \ind{m}{I:A}{c_1 :∀ p_1 :P_1 ,… ∀p_m :P_m ,~C_1 ;~…;~c_n :∀ p_1 :P_1 ,… ∀p_m :P_m ,~C_n}
+     \ind{p}{I:A}{c_1 :∀ p_1 :P_1 ,… ∀p_p :P_p ,~C_1 ;~…;~c_n :∀ p_1 :P_1 ,… ∀p_p :P_p ,~C_n}
 
   (in particular, it is
-  not mutually defined and it has :math:`m` parameters) and :math:`X` does not occur in
+  not mutually defined and it has :math:`p` parameters) and :math:`X` does not occur in
   any of the :math:`t_i`, and the (instantiated) types of constructor
-  :math:`\subst{C_i}{p_j}{a_j}_{j=1… m}` of :math:`I` satisfy the nested positivity condition for :math:`X`
+  :math:`\subst{C_i}{p_j}{a_j}_{j=1… p}` of :math:`I` satisfy the nested positivity condition for :math:`X`
 
 Nested Positivity
 +++++++++++++++++
 
-The type of constructor :math:`T` of :math:`I` *satisfies the nested positivity
-condition* for a constant :math:`X` in the following cases:
+If :math:`I` is a non-mutual inductive type with :math:`p`
+parameters, then
+the type of constructor :math:`T` of :math:`I` satisfies the *nested
+positivity condition* for a constant :math:`X` in the following
+cases:
 
-+ :math:`T=(I~b_1 … b_m~u_1 … u_p)`, :math:`I` is an inductive type with :math:`m`
-  parameters and :math:`X` does not occur in any :math:`u_i`
++ :math:`T=(I~b_1 … b_p~u_1 … u_q)` and :math:`X` does not occur in
+  any :math:`u_i`
+
 + :math:`T=∀ x:U,~V` and :math:`X` occurs only strictly positively in :math:`U` and the type :math:`V`
   satisfies the nested positivity condition for :math:`X`
 

--- a/doc/sphinx/language/core/inductive.rst
+++ b/doc/sphinx/language/core/inductive.rst
@@ -695,13 +695,23 @@ sort :math:`s`.
 
    :math:`A→ \Set` and :math:`∀ A:\Prop,~A→ \Prop` are arities.
 
+..
+   Convention in describing inductive types:
+   k is the number of inductive types (I_i : forall params, A_i)
+   n is the number of constructors in the whole block (c_i : forall params, C_i)
+   r is the number of parameters
+   l is the size of the context of parameters (p_i : P_i)
+   m is the number of recursively non-uniform parameters among parameters
+   s is the number of indices
+   q = r+s is the number of parameters and indices
+
 
 Type of constructor
 +++++++++++++++++++
 We say that :math:`T` is a *type of constructor of* :math:`I` in one of the following
 two cases:
 
-+ :math:`T` is :math:`(I~t_1 … t_n )`
++ :math:`T` is :math:`(I~t_1 … t_q )`
 + :math:`T` is :math:`∀ x:U,~T'` where :math:`T'` is also a type of constructor of :math:`I`
 
 .. example::
@@ -717,7 +727,7 @@ Positivity Condition
 The type of constructor :math:`T` will be said to *satisfy the positivity
 condition* for a set of constants :math:`X_1 … X_k` in the following cases:
 
-+ :math:`T=(X_j~t_1 … t_n )` for some :math:`j` and no :math:`X_1 … X_k` occur free in any :math:`t_i`
++ :math:`T=(X_j~t_1 … t_q )` for some :math:`j` and no :math:`X_1 … X_k` occur free in any :math:`t_i`
 + :math:`T=∀ x:U,~V` and :math:`X_1 … X_k` occur only strictly positively in :math:`U` and the type :math:`V`
   satisfies the positivity condition for :math:`X_1 … X_k`.
 
@@ -729,33 +739,33 @@ cases:
 
 
 + no :math:`X_1 … X_k` occur in :math:`T`
-+ :math:`T` converts to :math:`(X_j~t_1 … t_n )` for some :math:`j` and no :math:`X_1 … X_k` occur in any of :math:`t_i`
++ :math:`T` converts to :math:`(X_j~t_1 … t_q )` for some :math:`j` and no :math:`X_1 … X_k` occur in any of :math:`t_i`
 + :math:`T` converts to :math:`∀ x:U,~V` and :math:`X_1 … X_k` occur
   strictly positively in type :math:`V` but none of them occur in :math:`U`
-+ :math:`T` converts to :math:`(I~a_1 … a_p~t_1 … t_q )` where :math:`I` is the name of an
++ :math:`T` converts to :math:`(I~a_1 … a_r~t_1 … t_s )` where :math:`I` is the name of an
   inductive definition of the form
 
   .. math::
-     \ind{p}{I:A}{c_1 :∀ p_1 :P_1 ,… ∀p_p :P_p ,~C_1 ;~…;~c_n :∀ p_1 :P_1 ,… ∀p_p :P_p ,~C_n}
+     \ind{r}{I:A}{c_1 :∀ p_1 :P_1 ,… ∀p_r :P_r ,~C_1 ;~…;~c_n :∀ p_1 :P_1 ,… ∀p_r :P_r ,~C_n}
 
   (in particular, it is
-  not mutually defined and it has :math:`p` parameters) and no :math:`X_1 … X_k` occur in
-  any of the :math:`t_i` nor in any of the :math:`a_j` for :math:`m < j ≤ p` where :math:`m ≤ p`
+  not mutually defined and it has :math:`r` parameters) and no :math:`X_1 … X_k` occur in
+  any of the :math:`t_i` nor in any of the :math:`a_j` for :math:`m < j ≤ r` where :math:`m ≤ r`
   is the number of recursively uniform parameters, and the (instantiated) types of constructor
-  :math:`\subst{C_i}{p_j}{a_j}_{j=1… p}` of :math:`I` satisfy the nested positivity condition for :math:`X_1 … X_k`
+  :math:`\subst{C_i}{p_j}{a_j}_{j=1… m}` of :math:`I` satisfy the nested positivity condition for :math:`X_1 … X_k`
 
 Nested Positivity
 +++++++++++++++++
 
-If :math:`I` is a non-mutual inductive type with :math:`p`
+If :math:`I` is a non-mutual inductive type with :math:`r`
 parameters, then,
 the type of constructor :math:`T` of :math:`I` *satisfies the nested
 positivity condition* for a set of constants :math:`X_1 … X_k` in the following
 cases:
 
-+ :math:`T=(I~b_1 … b_p~u_1 … u_q)` and no :math:`X_1 … X_k` occur in
++ :math:`T=(I~b_1 … b_r~u_1 … u_s)` and no :math:`X_1 … X_k` occur in
   any :math:`u_i` nor in
-  any of the :math:`b_j` for :math:`m < j ≤ p` where :math:`m ≤ p` is
+  any of the :math:`b_j` for :math:`m < j ≤ r` where :math:`m ≤ r` is
   the number of recursively uniform parameters
 
 + :math:`T=∀ x:U,~V` and :math:`X_1 … X_k` occur only strictly positively in :math:`U` and the type :math:`V`
@@ -807,14 +817,13 @@ such that :math:`Γ_I` is :math:`[I_1 :∀ Γ_P ,A_1 ;~…;~I_k :∀ Γ_P ,A_k]`
    \WFE{Γ_P}
    (E[Γ_I ;Γ_P ] ⊢ C_i : s_{q_i} )_{i=1… n}
    ------------------------------------------
-   \WF{E;~\ind{p}{Γ_I}{Γ_C}}{}
+   \WF{E;~\ind{l}{Γ_I}{Γ_C}}{}
 
 
 provided that the following side conditions hold:
 
     + :math:`k>0` and all of :math:`I_j` and :math:`c_i` are distinct names for :math:`j=1… k` and :math:`i=1… n`,
-    + :math:`p` is the number of parameters of :math:`\ind{p}{Γ_I}{Γ_C}` and :math:`Γ_P` is the
-      context of parameters,
+    + :math:`l` is the size of :math:`Γ_P` which is called the context of parameters,
     + for :math:`j=1… k` we have that :math:`A_j` is an arity of sort :math:`s_j` and :math:`I_j ∉ E`,
     + for :math:`i=1… n` we have that :math:`C_i` is a type of constructor of :math:`I_{q_i}` which
       satisfies the positivity condition for :math:`I_1 … I_k` and :math:`c_i ∉  E`.

--- a/doc/sphinx/language/core/inductive.rst
+++ b/doc/sphinx/language/core/inductive.rst
@@ -732,28 +732,32 @@ cases:
 + :math:`T` converts to :math:`(X~t_1 … t_n )` and :math:`X` does not occur in any of :math:`t_i`
 + :math:`T` converts to :math:`∀ x:U,~V` and :math:`X` does not occur in type :math:`U` but occurs
   strictly positively in type :math:`V`
-+ :math:`T` converts to :math:`(I~a_1 … a_m~t_1 … t_p )` where :math:`I` is the name of an
++ :math:`T` converts to :math:`(I~a_1 … a_p~t_1 … t_q )` where :math:`I` is the name of an
   inductive definition of the form
 
   .. math::
      \ind{p}{I:A}{c_1 :∀ p_1 :P_1 ,… ∀p_p :P_p ,~C_1 ;~…;~c_n :∀ p_1 :P_1 ,… ∀p_p :P_p ,~C_n}
 
-  (in particular, it is
-  not mutually defined and it has :math:`p` parameters) and :math:`X` does not occur in
-  any of the :math:`t_i`, and the (instantiated) types of constructor
-  :math:`\subst{C_i}{p_j}{a_j}_{j=1… p}` of :math:`I` satisfy the nested positivity condition for :math:`X`
+  (in particular, it is not mutually defined and it has :math:`p`
+  parameters) and :math:`X` does not occur in any of the :math:`t_i`
+  nor in any of the :math:`a_j` for :math:`m < j ≤ p` where :math:`m ≤
+  p` is the number of recursively uniform parameters, and the
+  (instantiated) types of constructor
+
+  :math:`\subst{C_i}{p_j}{a_j}_{j=1… m}` of :math:`I` satisfy the nested positivity condition for :math:`X`
 
 Nested Positivity
 +++++++++++++++++
 
 If :math:`I` is a non-mutual inductive type with :math:`p`
-parameters, then
-the type of constructor :math:`T` of :math:`I` satisfies the *nested
+parameters, then,
+the type of constructor :math:`T` of :math:`I` *satisfies the nested
 positivity condition* for a constant :math:`X` in the following
 cases:
 
-+ :math:`T=(I~b_1 … b_p~u_1 … u_q)` and :math:`X` does not occur in
-  any :math:`u_i`
++ :math:`T=(I~b_1 … b_p~u_1 … u_q)` and :math:`X` does not occur in any :math:`u_i` nor in
+  any of the :math:`b_j` for :math:`m < j ≤ p` where :math:`m ≤ p` is
+  the number of recursively uniform parameters
 
 + :math:`T=∀ x:U,~V` and :math:`X` occurs only strictly positively in :math:`U` and the type :math:`V`
   satisfies the nested positivity condition for :math:`X`

--- a/doc/sphinx/language/core/inductive.rst
+++ b/doc/sphinx/language/core/inductive.rst
@@ -715,36 +715,34 @@ Positivity Condition
 ++++++++++++++++++++
 
 The type of constructor :math:`T` will be said to *satisfy the positivity
-condition* for a constant :math:`X` in the following cases:
+condition* for a set of constants :math:`X_1 … X_k` in the following cases:
 
-+ :math:`T=(X~t_1 … t_n )` and :math:`X` does not occur free in any :math:`t_i`
-+ :math:`T=∀ x:U,~V` and :math:`X` occurs only strictly positively in :math:`U` and the type :math:`V`
-  satisfies the positivity condition for :math:`X`.
++ :math:`T=(X_j~t_1 … t_n )` for some :math:`j` and no :math:`X_1 … X_k` occur free in any :math:`t_i`
++ :math:`T=∀ x:U,~V` and :math:`X_1 … X_k` occur only strictly positively in :math:`U` and the type :math:`V`
+  satisfies the positivity condition for :math:`X_1 … X_k`.
 
 Strict positivity
 +++++++++++++++++
 
-The constant :math:`X` *occurs strictly positively* in :math:`T` in the following
+The constants :math:`X_1 … X_k` *occur strictly positively* in :math:`T` in the following
 cases:
 
 
-+ :math:`X` does not occur in :math:`T`
-+ :math:`T` converts to :math:`(X~t_1 … t_n )` and :math:`X` does not occur in any of :math:`t_i`
-+ :math:`T` converts to :math:`∀ x:U,~V` and :math:`X` does not occur in type :math:`U` but occurs
-  strictly positively in type :math:`V`
++ no :math:`X_1 … X_k` occur in :math:`T`
++ :math:`T` converts to :math:`(X_j~t_1 … t_n )` for some :math:`j` and no :math:`X_1 … X_k` occur in any of :math:`t_i`
++ :math:`T` converts to :math:`∀ x:U,~V` and :math:`X_1 … X_k` occur
+  strictly positively in type :math:`V` but none of them occur in :math:`U`
 + :math:`T` converts to :math:`(I~a_1 … a_p~t_1 … t_q )` where :math:`I` is the name of an
   inductive definition of the form
 
   .. math::
      \ind{p}{I:A}{c_1 :∀ p_1 :P_1 ,… ∀p_p :P_p ,~C_1 ;~…;~c_n :∀ p_1 :P_1 ,… ∀p_p :P_p ,~C_n}
 
-  (in particular, it is not mutually defined and it has :math:`p`
-  parameters) and :math:`X` does not occur in any of the :math:`t_i`
-  nor in any of the :math:`a_j` for :math:`m < j ≤ p` where :math:`m ≤
-  p` is the number of recursively uniform parameters, and the
-  (instantiated) types of constructor
-
-  :math:`\subst{C_i}{p_j}{a_j}_{j=1… m}` of :math:`I` satisfy the nested positivity condition for :math:`X`
+  (in particular, it is
+  not mutually defined and it has :math:`p` parameters) and no :math:`X_1 … X_k` occur in
+  any of the :math:`t_i` nor in any of the :math:`a_j` for :math:`m < j ≤ p` where :math:`m ≤ p`
+  is the number of recursively uniform parameters, and the (instantiated) types of constructor
+  :math:`\subst{C_i}{p_j}{a_j}_{j=1… p}` of :math:`I` satisfy the nested positivity condition for :math:`X_1 … X_k`
 
 Nested Positivity
 +++++++++++++++++
@@ -752,15 +750,16 @@ Nested Positivity
 If :math:`I` is a non-mutual inductive type with :math:`p`
 parameters, then,
 the type of constructor :math:`T` of :math:`I` *satisfies the nested
-positivity condition* for a constant :math:`X` in the following
+positivity condition* for a set of constants :math:`X_1 … X_k` in the following
 cases:
 
-+ :math:`T=(I~b_1 … b_p~u_1 … u_q)` and :math:`X` does not occur in any :math:`u_i` nor in
++ :math:`T=(I~b_1 … b_p~u_1 … u_q)` and no :math:`X_1 … X_k` occur in
+  any :math:`u_i` nor in
   any of the :math:`b_j` for :math:`m < j ≤ p` where :math:`m ≤ p` is
   the number of recursively uniform parameters
 
-+ :math:`T=∀ x:U,~V` and :math:`X` occurs only strictly positively in :math:`U` and the type :math:`V`
-  satisfies the nested positivity condition for :math:`X`
++ :math:`T=∀ x:U,~V` and :math:`X_1 … X_k` occur only strictly positively in :math:`U` and the type :math:`V`
+  satisfies the nested positivity condition for :math:`X_1 … X_k`
 
 
 .. example::

--- a/kernel/indtypes.ml
+++ b/kernel/indtypes.ml
@@ -201,7 +201,7 @@ let check_positivity_one ~chkpos recursive (env,_,ntypes,_ as ienv) paramsctxt (
   (** Positivity of one argument [c] of a constructor (i.e. the
       constructor [cn] has a type of the shape [… -> c … -> P], where,
       more generally, the arrows may be dependent). *)
-  let rec check_pos (env, n, ntypes, ra_env as ienv) nmr c =
+  let rec check_strict_positivity (env, n, ntypes, ra_env as ienv) nmr c =
     let x,largs = decompose_app (whd_all env c) in
       match kind x with
         | Prod (na,b,d) ->
@@ -215,9 +215,9 @@ let check_positivity_one ~chkpos recursive (env,_,ntypes,_ as ienv) paramsctxt (
               | None when chkpos ->
                   failwith_non_pos_list n ntypes [b]
               | None ->
-                  check_pos (ienv_push_var ienv (na, b, mk_norec)) nmr d
+                  check_strict_positivity (ienv_push_var ienv (na, b, mk_norec)) nmr d
               | Some b ->
-                  check_pos (ienv_push_var ienv (na, b, mk_norec)) nmr d)
+                  check_strict_positivity (ienv_push_var ienv (na, b, mk_norec)) nmr d)
         | Rel k ->
             (try let (ra,rarg) = List.nth ra_env (k-1) in
             let largs = List.map (whd_all env) largs in
@@ -238,12 +238,12 @@ let check_positivity_one ~chkpos recursive (env,_,ntypes,_ as ienv) paramsctxt (
             (** If one of the inductives of the mutually inductive
                 block being defined appears in a parameter, then we
                 have a nested inductive type. The positivity is then
-                discharged to the [check_positive_nested] function. *)
+                discharged to the [check_positivity_nested] function. *)
             if List.for_all (noccur_between n ntypes) largs then (nmr,mk_norec)
-            else check_positive_nested ienv nmr (ind_kn, largs)
+            else check_positivity_nested ienv nmr (ind_kn, largs)
         | Const (c,_) when is_primitive_positive_container env c ->
           if List.for_all (noccur_between n ntypes) largs then (nmr,mk_norec)
-          else check_positive_nested_primitive ienv nmr (c, largs)
+          else check_positivity_nested_primitive ienv nmr (c, largs)
         | _err ->
             (** If an inductive of the mutually inductive block
                 appears in any other way, then the positivy check gives
@@ -254,14 +254,14 @@ let check_positivity_one ~chkpos recursive (env,_,ntypes,_ as ienv) paramsctxt (
             then (nmr,mk_norec)
             else failwith_non_pos_list n ntypes (x::largs)
 
-  (** [check_positive_nested] handles the case of nested inductive
+  (** [check_positivity_nested] handles the case of nested inductive
       calls, that is, when an inductive types from the mutually
       inductive block is called as an argument of an inductive types
       (for the moment, this inductive type must be a previously
       defined types, not one of the types of the mutually inductive
       block being defined). *)
   (* accesses to the environment are not factorised, but is it worth? *)
-  and check_positive_nested (env,n,ntypes,_ra_env as ienv) nmr (((mind,_ as ind),u), largs) =
+  and check_positivity_nested (env,n,ntypes,_ra_env as ienv) nmr (((mind,_ as ind),u), largs) =
     let (mib,mip) = lookup_mind_specif env ind in
     let auxnrecpar = mib.mind_nparams_rec in
     let auxnnonrecpar = mib.mind_nparams - auxnrecpar in
@@ -303,20 +303,20 @@ let check_positivity_one ~chkpos recursive (env,_,ntypes,_ as ienv) paramsctxt (
         in
           (nmr',(Rtree.mk_rec [|mk_paths (Nested (NestedInd ind)) irecargs|]).(0))
 
-  and check_positive_nested_primitive (env,n,ntypes,ra_env) nmr (c, largs) =
+  and check_positivity_nested_primitive (env,n,ntypes,ra_env) nmr (c, largs) =
     (* We model the primitive type c X1 ... Xn as if it had one constructor
        C : X1 -> ... -> Xn -> c X1 ... Xn
        The subterm relation is defined for each primitive in `inductive.ml`. *)
     let ra_env = List.map (fun (r,t) -> (r,Rtree.lift 1 t)) ra_env in
     let ienv = (env,n,ntypes,ra_env) in
-    let nmr',recargs = List.fold_left_map (check_pos ienv) nmr largs in
+    let nmr',recargs = List.fold_left_map (check_strict_positivity ienv) nmr largs in
     (nmr', (Rtree.mk_rec [| mk_paths (Nested (NestedPrimitive c)) [| recargs |] |]).(0))
 
   (** [check_constructors ienv check_head nmr c] checks the positivity
       condition in the type [c] of a constructor (i.e. that recursive
       calls to the inductives of the mutually inductive definition
       appear strictly positively in each of the arguments of the
-      constructor, see also [check_pos]). If [check_head] is [true],
+      constructor, see also [check_strict_positivity]). If [check_head] is [true],
       then the type of the fully applied constructor (the "head" of
       the type [c]) is checked to be the right (properly applied)
       inductive type. *)
@@ -329,7 +329,7 @@ let check_positivity_one ~chkpos recursive (env,_,ntypes,_ as ienv) paramsctxt (
               let () = assert (List.is_empty largs) in
               if not recursive && not (noccur_between n ntypes b) then
                 raise (InductiveError Type_errors.BadEntry);
-              let nmr',recarg = check_pos ienv nmr b in
+              let nmr',recarg = check_strict_positivity ienv nmr b in
               let ienv' = ienv_push_var ienv (na,b,mk_norec) in
                 check_constr_rec ienv' nmr' (recarg::lrec) d
           | hd ->


### PR DESCRIPTION
**Kind:** fix

Fixes / closes #14938

- [x] Added **changelog**.
- [X] Added / updated **documentation**.

We also slightly reformulate the nested positivity condition to clarify that we are recursively talking about the same type.