### PR TITLE
[termops] do not strip casts from evars (fix #14972)

### DIFF
--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -977,25 +977,11 @@ let rec strip_outer_cast sigma c = match EConstr.kind sigma c with
   | Cast (c,_,_) -> strip_outer_cast sigma c
   | _ -> c
 
-(* flattens application lists throwing casts in-between *)
-let collapse_appl sigma c = match EConstr.kind sigma c with
-  | App (f,cl) ->
-    if EConstr.isCast sigma f then
-      let rec collapse_rec f cl2 =
-        match EConstr.kind sigma (strip_outer_cast sigma f) with
-        | App (g,cl1) -> collapse_rec g (Array.append cl1 cl2)
-        | _ -> EConstr.mkApp (f,cl2)
-      in
-      collapse_rec f cl
-    else c
-  | _ -> c
-
 (* First utilities for avoiding telescope computation for subst_term *)
 
 let prefix_application sigma eq_fun k l1 t =
   let open EConstr in
-  let t' = collapse_appl sigma t in
-  if 0 < l1 then match EConstr.kind sigma t' with
+  if 0 < l1 then match EConstr.kind sigma t with
     | App (f2,cl2) ->
         let l2 = Array.length cl2 in
         if l1 <= l2
@@ -1032,7 +1018,6 @@ let replace_term_gen sigma eq_fun ar by_c in_t =
 
 let replace_term sigma c byc t =
   let cache = ref Int.Map.empty in
-  let c = collapse_appl sigma c in
   let ar = Array.length (snd (decompose_app_vect sigma c)) in
   let eq sigma k t = eq_upto_lift cache c sigma k t in
   replace_term_gen sigma eq ar byc t

--- a/engine/termops.mli
+++ b/engine/termops.mli
@@ -144,9 +144,6 @@ val eq_constr : Evd.evar_map -> constr -> constr -> bool (* FIXME rename: erases
 
 val eta_reduce_head : Evd.evar_map -> constr -> constr
 
-(** Flattens application lists *)
-val collapse_appl : Evd.evar_map -> constr -> constr
-
 (** [prod_applist] [forall (x1:B1;...;xn:Bn), B] [a1...an] @return [B[a1...an]] *)
 val prod_applist : Evd.evar_map -> constr -> constr list -> constr
 

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -758,7 +758,7 @@ let rec detype d flags avoid env sigma t =
   delay d detype_r flags avoid env sigma t
 
 and detype_r d flags avoid env sigma t =
-  match EConstr.kind sigma (collapse_appl sigma t) with
+  match EConstr.kind sigma t with
     | Rel n ->
       (try match lookup_name_of_rel n (fst env) with
          | Name id   -> GVar id

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -1155,7 +1155,7 @@ let () =
     Used in the partial application tactic. *)
 
 let rec head_of_constr sigma t =
-  let t = strip_outer_cast sigma (collapse_appl sigma t) in
+  let t = strip_outer_cast sigma t in
     match EConstr.kind sigma t with
     | Prod (_,_,c2)  -> head_of_constr sigma c2
     | LetIn (_,_,_,c2) -> head_of_constr sigma c2

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -2900,7 +2900,6 @@ let generalize_goal_gen env sigma ids i ((occs,c,b),na) t cl =
   let decls,cl = decompose_prod_n_assum sigma i cl in
   let dummy_prod = it_mkProd_or_LetIn mkProp decls in
   let newdecls,_ =
-    let c = Termops.collapse_appl sigma c in
     let arity = Array.length (snd (Termops.decompose_app_vect sigma c)) in
     let cache = ref Int.Map.empty in
     let eq sigma k t =

--- a/test-suite/output/detype_cast.out
+++ b/test-suite/output/detype_cast.out
@@ -1,0 +1,8 @@
+(Nat.add : forall (_ : nat) (_ : nat), nat) O O
+     : nat
+(Nat.add O : forall _ : nat, nat) O
+     : nat
+(?n O : forall _ : nat, nat) O
+     : nat
+where
+?n : [ |- forall (_ : nat) (_ : nat), nat]

--- a/test-suite/output/detype_cast.v
+++ b/test-suite/output/detype_cast.v
@@ -1,0 +1,4 @@
+Set Printing All.
+Check (plus : nat -> nat -> nat) O O.
+Check (plus O : nat -> nat) O.
+Check (_ O : nat -> nat) O.


### PR DESCRIPTION
This PR makes `constr -> glob -> constr` a bit more reliable.

If this is is sufficiently CI-green that we can consider it.
If we get a full green CI, I'll try be even bolder and just remove the call, since I don't see what is the point of it (especially of its special case, which this PR makes less special). If there is a cast in the term, why would we want to erase it?

Fixes #14972
Fixes LPCIC/coq-elpi#294
Overlay https://github.com/mattam82/Coq-Equations/pull/433