### PR TITLE
Reduce the attack surface of the Future API

### DIFF
--- a/dev/ci/user-overlays/14982-ppedrot-simplify-future-api.sh
+++ b/dev/ci/user-overlays/14982-ppedrot-simplify-future-api.sh
@@ -1,0 +1,1 @@
+overlay equations https://github.com/ppedrot/Coq-Equations simplify-future-api 14982

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -109,7 +109,7 @@ type 'a pproof_entry = {
   proof_entry_inline_code : bool;
 }
 
-type 'a proof_entry = 'a Opaques.const_entry_body pproof_entry
+type proof_entry = Evd.side_effects Opaques.const_entry_body pproof_entry
 
 type parameter_entry = {
   parameter_entry_secctx : Id.Set.t option;
@@ -153,8 +153,8 @@ let primitive_entry ?types c = {
   prim_entry_content = c;
 }
 
-type 'a constant_entry =
-  | DefinitionEntry of 'a proof_entry
+type constant_entry =
+  | DefinitionEntry of proof_entry
   | ParameterEntry of parameter_entry
   | PrimitiveEntry of primitive_entry
 
@@ -482,7 +482,7 @@ let inline_private_constants ~uctx env ce =
 
 (** Declaration of section variables and local definitions *)
 type variable_declaration =
-  | SectionLocalDef of Evd.side_effects proof_entry
+  | SectionLocalDef of proof_entry
   | SectionLocalAssum of { typ:Constr.types; impl:Glob_term.binding_kind ;
                            univs:UState.named_universes_entry }
 
@@ -1612,7 +1612,7 @@ let get_open_goals ps =
 type proof_object =
   { name : Names.Id.t
   (* [name] only used in the STM *)
-  ; entries : Evd.side_effects proof_entry list
+  ; entries : proof_entry list
   ; uctx: UState.t
   ; pinfo : Proof_info.t
   }
@@ -1913,7 +1913,7 @@ module MutualEntry : sig
     (* Common to all recthms *)
     : pinfo:Proof_info.t
     -> uctx:UState.t
-    -> entry:Evd.side_effects proof_entry
+    -> entry:proof_entry
     -> Names.GlobRef.t list
 
 end = struct

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -318,7 +318,7 @@ end
    XXX: This is an internal, low-level API and could become scheduled
    for removal from the public API, use higher-level declare APIs
    instead *)
-type 'a proof_entry
+type proof_entry
 type parameter_entry
 type primitive_entry
 
@@ -329,7 +329,7 @@ val definition_entry
   -> ?types:Constr.types
   -> ?univs:UState.named_universes_entry
   -> Constr.constr
-  -> Evd.side_effects proof_entry
+  -> proof_entry
 
 val parameter_entry
   :  ?inline:int
@@ -352,7 +352,7 @@ val declare_entry
   -> ?hook:Hook.t
   -> impargs:Impargs.manual_implicits
   -> uctx:UState.t
-  -> Evd.side_effects proof_entry
+  -> proof_entry
   -> GlobRef.t
 
 (** Declaration of local constructions (Variable/Hypothesis/Local) *)
@@ -370,8 +370,8 @@ val declare_variable
    XXX: This is an internal, low-level API and could become scheduled
    for removal from the public API, use higher-level declare APIs
    instead *)
-type 'a constant_entry =
-  | DefinitionEntry of 'a proof_entry
+type constant_entry =
+  | DefinitionEntry of proof_entry
   | ParameterEntry of parameter_entry
   | PrimitiveEntry of primitive_entry
 
@@ -394,7 +394,7 @@ val declare_constant
   -> name:Id.t
   -> kind:Decls.logical_kind
   -> ?typing_flags:Declarations.typing_flags
-  -> Evd.side_effects constant_entry
+  -> constant_entry
   -> Constant.t
 
 (** Declaration messages, for internal use *)

--- a/vernac/future.ml
+++ b/vernac/future.ml
@@ -161,17 +161,6 @@ let join kx =
   kx := Finished v;
   v
 
-let split2 x =
-  chain x (fun x -> fst x), chain x (fun x -> snd x)
-
-let map2 f x l =
-  CList.map_i (fun i y ->
-    let xi = chain x (fun x ->
-        try List.nth x i
-        with Failure _ | Invalid_argument _ ->
-          CErrors.anomaly (Pp.str "Future.map2 length mismatch.")) in
-    f xi y) 0 l
-
 let print f kx =
   let open Pp in
   let name, uid, _, x = get kx in

--- a/vernac/future.ml
+++ b/vernac/future.ml
@@ -83,10 +83,6 @@ let is_over kx = let _, _, _, x = get kx in match !x with
   | Val _ | Exn _ -> true
   | Closure _ | Delegated _ -> false
 
-let is_val kx = let _, _, _, x = get kx in match !x with
-  | Val _ -> true
-  | Exn _ | Closure _ | Delegated _ -> false
-
 let is_exn kx = let _, _, _, x = get kx in match !x with
   | Exn _ -> true
   | Val _ | Closure _ | Delegated _ -> false

--- a/vernac/future.mli
+++ b/vernac/future.mli
@@ -66,7 +66,6 @@ val replace : 'a computation -> 'a computation -> unit
 
 (* Inspect a computation *)
 val is_over : 'a computation -> bool
-val is_val : 'a computation -> bool
 val is_exn : 'a computation -> bool
 val peek_val : 'a computation -> 'a option
 val uuid : 'a computation -> UUID.t

--- a/vernac/future.mli
+++ b/vernac/future.mli
@@ -85,13 +85,6 @@ val compute : 'a computation -> 'a value
  * in a computation obtained by chaining on a joined future. *)
 val join : 'a computation -> 'a
 
-(*** Utility functions ************************************************* ***)
-val split2 :
-  ('a * 'b) computation -> 'a computation * 'b computation
-val map2 :
-  ('a computation -> 'b -> 'c) ->
-     'a list computation -> 'b list -> 'c list
-
 (** Debug: print a computation given an inner printing function. *)
 val print : ('a -> Pp.t) -> 'a computation -> Pp.t
 

--- a/vernac/opaques.ml
+++ b/vernac/opaques.ml
@@ -140,15 +140,16 @@ let dump ?(except=Future.UUIDSet.empty) () =
     let i = Opaqueproof.repr_handle i in
     let uid = Future.uuid cert in
     let f2t_map = Future.UUIDMap.add uid i f2t_map in
-    let c =
-      if Future.is_val cert then
-        let (c, priv) = Safe_typing.repr_certificate (Future.force cert) in
-        let priv = match priv with
-        | Opaqueproof.PrivateMonomorphic _ -> Opaqueproof.PrivateMonomorphic ()
-        | Opaqueproof.PrivatePolymorphic _ as p -> p
-        in
-        Some (c, priv)
-      else if Future.UUIDSet.mem uid except then None
+    let c = match Future.peek_val cert with
+    | Some cert ->
+      let (c, priv) = Safe_typing.repr_certificate cert in
+      let priv = match priv with
+      | Opaqueproof.PrivateMonomorphic _ -> Opaqueproof.PrivateMonomorphic ()
+      | Opaqueproof.PrivatePolymorphic _ as p -> p
+      in
+      Some (c, priv)
+    | None ->
+      if Future.UUIDSet.mem uid except then None
       else
         CErrors.anomaly
           Pp.(str"Proof object "++int i++str" is not checked nor to be checked")


### PR DESCRIPTION
This PR simplifies the Future API by removing combinators only used once, and performs some cleanup in vernac/declare related to that. The major cleanup is the removal of a useless back and forth between forced values and thunks in Declare by simply relying on the type system to check that a value is expected. This should be 100% observationally equivalent.

Overlays:
- https://github.com/mattam82/Coq-Equations/pull/431