### PR TITLE
Correctly prevent backtracking in clear dependent.

### DIFF
--- a/doc/changelog/04-tactics/14984-fix-clear-dependent-backtrack.rst
+++ b/doc/changelog/04-tactics/14984-fix-clear-dependent-backtrack.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  The :tacn:`clear dependent <clear>` tactic now does not backtrack
+  internally, preventing an exponential blowup
+  (`#14984 <https://github.com/coq/coq/pull/14984>`_,
+  fixes `#11689 <https://github.com/coq/coq/issues/11689>`_,
+  by Pierre-Marie Pédrot).

--- a/theories/Init/Tactics.v
+++ b/theories/Init/Tactics.v
@@ -232,7 +232,7 @@ Tactic Notation "decide" constr(lemma) "with" constr(H) :=
 Tactic Notation "clear" "dependent" hyp(h) :=
  let rec depclear h :=
   clear h ||
-  match goal with
+  lazymatch goal with
    | H : context [ h ] |- _ => depclear H; depclear h
    | H := context [ h ] |- _ => depclear H; depclear h
   end ||


### PR DESCRIPTION
Fixes #11689: clear dependent takes worst-case exponential time to fail.
