### PR TITLE
Purify calls to Proof.refine_by_tactic w.r.t. the global state.

### DIFF
--- a/proofs/proof.mli
+++ b/proofs/proof.mli
@@ -238,3 +238,9 @@ val get_goal_context_gen : t -> int -> Evd.evar_map * Environ.env
 (** [get_proof_context ()] gets the goal context for the first subgoal
     of the proof *)
 val get_proof_context : t -> Evd.evar_map * Environ.env
+
+(** {6 Internal} *)
+
+type purify = { purify : 'a. (unit -> 'a) -> 'a }
+
+val purify_hook : purify Hook.t

--- a/vernac/vernacstate.ml
+++ b/vernac/vernacstate.ml
@@ -270,3 +270,17 @@ module Stm = struct
 
 end
 module Declare = Declare_
+
+let () =
+  let purify f =
+    let state = freeze_interp_state ~marshallable:false in
+    try
+      let ans = f () in
+      let () = unfreeze_interp_state state in
+      ans
+    with e ->
+      let e = Exninfo.capture e in
+      let () = unfreeze_interp_state state in
+      Exninfo.iraise e
+  in
+  Hook.set Proof.purify_hook { Proof.purify = purify }


### PR DESCRIPTION
This is very hackish but I do not see a way around while the side-effect API is imperative.

Fixes #13324.