### PR TITLE
Fix setoid_rewrite under non dependent binders

### DIFF
--- a/doc/changelog/04-tactics/14986-rewr-lambdas-clenv.rst
+++ b/doc/changelog/04-tactics/14986-rewr-lambdas-clenv.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  :tacn:`setoid_rewrite` now works when the rewriting lemma has non dependent arguments and rewriting under binders
+  (`#14986 <https://github.com/coq/coq/pull/14986>`_,
+  fixes `#5369 <https://github.com/coq/coq/issues/5369>`_,
+  by Gaëtan Gilbert).

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -779,7 +779,7 @@ let make_evar_clause env sigma ?len t =
         (* We fix it later *)
         hole_name = na.binder_name;
       } in
-      let t2 = if dep then subst1 ev t2 else t2 in
+      let t2 = subst1 ev t2 in
       clrec (sigma, hole :: holes) inst (pred n) t2
     | LetIn (na, b, _, t) -> clrec (sigma, holes) inst n (subst1 b t)
     | _ -> (sigma, holes, t)

--- a/test-suite/bugs/closed/bug_5369.v
+++ b/test-suite/bugs/closed/bug_5369.v
@@ -1,0 +1,15 @@
+Require Import Coq.Classes.Morphisms Coq.Setoids.Setoid.
+Axiom f g : nat -> nat -> nat.
+Axiom Hfg : forall n m, n = n -> f n m = g n m.
+Axiom LetIn : forall {A B} (x : A) (f : A -> B), B.
+Axiom LetIn_Proper : forall A B, Proper (eq ==> pointwise_relation _ eq ==> eq)
+(@ LetIn A B).
+Existing Instance LetIn_Proper.
+
+Goal forall n, LetIn n (fun n' => f 1 n') = LetIn n (fun n' => g 1 n').
+Proof.
+  intros.
+  setoid_rewrite Hfg.
+  - reflexivity.
+  - exact (eq_refl 1).
+Qed.


### PR DESCRIPTION
Fix #5369

The substitution made unconditional is necessary as an anti-lift even
if the binder is nondependent.

Overlay: https://github.com/mit-plv/fiat/pull/58
