### PR TITLE
Derive JMeq_eq from eq_rect_eq

### DIFF
--- a/theories/Logic/JMeq.v
+++ b/theories/Logic/JMeq.v
@@ -17,6 +17,8 @@
 
 *)
 
+Require Import Eqdep.
+
 Set Implicit Arguments.
 
 Unset Elimination Schemes.
@@ -56,7 +58,12 @@ Qed.
 
 Register JMeq_trans as core.JMeq.trans.
 
-Axiom JMeq_eq : forall (A:Type) (x y:A), JMeq x y -> x = y.
+Theorem JMeq_eq : forall (A:Type) (x y:A), JMeq x y -> x = y.
+Proof.
+  intros A x y Heq.
+  inversion Heq.
+  now apply (inj_pairT2 _ _ A x y).
+Qed.
 
 Lemma JMeq_ind : forall (A:Type) (x:A) (P:A -> Prop),
   P x -> forall y, JMeq x y -> P y.


### PR DESCRIPTION
This small change to the standard library would derive `JMeq_eq` from `eq_rect_eq`, rather than axiomatizing both independently. As described in [this issue](https://github.com/coq/coq/issues/14970), the two axioms are equivalent, and so it is redundant to introduce both axiomatically.