### PR TITLE
Fixing #7393: do not consider periods occurring in comments as end of Coq lines for coqdep

### DIFF
--- a/doc/changelog/08-cli-tools/14996-master+coqdep-period-in-comment.rst
+++ b/doc/changelog/08-cli-tools/14996-master+coqdep-period-in-comment.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  :n:`coqdep` was confusing periods occurring in comments with periods ending Coq sentences
+  (`#14996 <https://github.com/coq/coq/pull/14996>`_,
+  fixes `#7393 <https://github.com/coq/coq/issues/7393>`_,
+  by Hugo Herbelin).

--- a/test-suite/misc/7393.sh
+++ b/test-suite/misc/7393.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+
+$coqdep misc/bug_7393.v

--- a/test-suite/misc/bug_7393.v
+++ b/test-suite/misc/bug_7393.v
@@ -1,0 +1,9 @@
+Goal forall x, x -> x.
+Proof.
+  intros.
+  match goal with
+  | [ |- _ ] => idtac
+  (* . From *)
+  end.
+  assumption.
+Qed.

--- a/tools/coqdep_lexer.mll
+++ b/tools/coqdep_lexer.mll
@@ -194,6 +194,8 @@ and require_file from = parse
       { syntax_error lexbuf }
 
 and skip_to_dot = parse
+  | "(*"
+      { comment lexbuf; skip_to_dot lexbuf }
   | dot { () }
   | eof { syntax_error lexbuf }
   | _   { skip_to_dot lexbuf }


### PR DESCRIPTION
**Kind:** fix

Fixes / closes #7393

- [x] Added / updated **test-suite**
- [x] Added **changelog**.
