### PR TITLE
Remove -debug option

### DIFF
--- a/sysinit/coqargs.mli
+++ b/sysinit/coqargs.mli
@@ -53,7 +53,6 @@ type coqargs_config = {
   native_compiler : native_compiler;
   native_output_dir : CUnix.physical_path;
   native_include_dirs : CUnix.physical_path list;
-  debug       : bool;
   time        : bool;
   print_emacs : bool;
 }

--- a/sysinit/usage.ml
+++ b/sysinit/usage.ml
@@ -65,13 +65,17 @@ let print_usage_common co command =
 \n  -quiet                 unset display of extra information (implies -w \"-all\")\
 \n  -w (w1,..,wn)          configure display of warnings\
 \n  -d (d1,..,dn)          configure display of debug messages\
+\n                         some common values are:\
+\n                           all         print all debugging information\
+\n                           backtrace   same as -bt\
+\n                         use the vernac command \"Test Debug\" to see all\
+\n\
 \n  -color (yes|no|auto)   configure color output\
 \n  -emacs                 tells Coq it is executed under Emacs\
 \n\
 \n  -q                     skip loading of rcfile\
 \n  -init-file f           set the rcfile to f\
-\n  -bt                    print backtraces (requires configure debug flag)\
-\n  -debug                 debug mode (implies -bt)\
+\n  -bt                    print OCaml backtraces\
 \n  -xml-debug             debug mode and print XML messages to/from coqide\
 \n  -diffs (on|off|removed) highlight differences between proof steps\
 \n  -impredicative-set     set sort Set impredicative\


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->
I've removed the -debug option and added an error message as follows:
```
Error: The -debug option has been removed.
Use the -d option for enabling debug output.
For an OCaml backtrace use -bt instead.
See -help for the syntax of supported options.
```
I've also added some documentation/help in `-help`.

Also I did a quick pass on the error messages here and ended them with a period where needed. Hopefully that doesn't break the CI, if so I will drop the commit.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #14944


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make -f Makefile.make doc_gram_rsts`.

