### PR TITLE
more descriptive universe length mismatch message

### DIFF
--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -32,7 +32,7 @@ Displaying
    .. exn:: @qualid not a defined object.
       :undocumented:
 
-   .. exn:: Universe instance should have length @natural.
+   .. exn:: Universe instance length is @natural but should be @natural.
       :undocumented:
 
    .. exn:: This object does not support universe names.

--- a/engine/univGen.ml
+++ b/engine/univGen.ml
@@ -13,6 +13,20 @@ open Names
 open Constr
 open Univ
 
+type univ_length_mismatch = {
+  actual : int ;
+  expect : int ;
+}
+(* Due to an OCaml bug ocaml/ocaml#10027 inlining this record will cause
+compliation with -rectypes to crash. *)
+exception UniverseLengthMismatch of univ_length_mismatch
+
+let () = CErrors.register_handler (function
+  | UniverseLengthMismatch { actual; expect } ->
+      Some Pp.(str "Universe instance length is " ++ int actual
+        ++ str " but should be " ++ int expect ++ str ".")
+  | _ -> None)
+
 (* Generator of levels *)
 let new_univ_id =
   let cnt = ref 0 in
@@ -33,11 +47,10 @@ let fresh_instance auctx =
 
 let existing_instance ?loc auctx inst =
   let () =
-    let len1 = Array.length (Instance.to_array inst)
-    and len2 = AbstractContext.size auctx in
-      if not (len1 == len2) then
-        CErrors.user_err ?loc
-          Pp.(str "Universe instance should have length " ++ int len2 ++ str ".")
+    let actual = Array.length (Instance.to_array inst)
+    and expect = AbstractContext.size auctx in
+      if not (Int.equal actual expect) then
+        raise (UniverseLengthMismatch { actual; expect })
       else ()
   in
   inst, (Level.Set.empty, AbstractContext.instantiate inst auctx)

--- a/engine/univGen.mli
+++ b/engine/univGen.mli
@@ -13,6 +13,14 @@ open Constr
 open Environ
 open Univ
 
+type univ_length_mismatch = {
+  actual : int ;
+  expect : int ;
+}
+(* Due to an OCaml bug ocaml/ocaml#10027 inlining this record will cause
+compliation with -rectypes to crash. *)
+exception UniverseLengthMismatch of univ_length_mismatch
+
 (** Side-effecting functions creating new universe levels. *)
 
 val new_univ_global : unit -> Level.UGlobal.t

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -188,9 +188,11 @@ let universe_binders_with_opt_names orig names =
           | Anonymous -> orig
           | Name id -> Name id) orig udecl
     with Invalid_argument _ ->
-      let len = List.length orig in
-      CErrors.user_err
-        Pp.(str "Universe instance should have length " ++ int len)
+      let open UnivGen in
+      raise (UniverseLengthMismatch {
+          actual = List.length orig;
+          expect = List.length udecl;
+        })
   in
   let fold_named i ubind = function
     | Name id -> Id.Map.add id (Univ.Level.var i) ubind

--- a/test-suite/output/UnivBinders.out
+++ b/test-suite/output/UnivBinders.out
@@ -97,9 +97,9 @@ Arguments punwrap A%type_scope p
 punwrap is transparent
 Expands to: Constant UnivBinders.punwrap
 The command has indeed failed with message:
-Universe instance should have length 3
+Universe instance length is 3 but should be 1.
 The command has indeed failed with message:
-Universe instance should have length 0
+Universe instance length is 0 but should be 1.
 The command has indeed failed with message:
 This object does not support universe names.
 The command has indeed failed with message:


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->
We now also print the length of the provided universes which can make it easier to amend universe contexts when things change.

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [x] Documented any new / changed **user messages**.

