### PR TITLE
Remove optional header in UserError

### DIFF
--- a/checker/check.ml
+++ b/checker/check.ml
@@ -225,12 +225,12 @@ let locate_qualified_library qid =
 
 let error_unmapped_dir qid =
   let prefix = qid.dirpath in
-  user_err ~hdr:"load_absolute_library_from"
+  user_err
     (str "Cannot load " ++ pr_path qid ++ str ":" ++ spc () ++
      str "no physical path bound to" ++ spc () ++ pr_dirlist prefix ++ fnl ())
 
 let error_lib_not_found qid =
-  user_err ~hdr:"load_absolute_library_from"
+  user_err
     (str"Cannot find library " ++ pr_path qid ++ str" in loadpath")
 
 let try_locate_absolute_library dir =
@@ -354,15 +354,15 @@ let intern_from_file ~intern_mode (dir, f) =
       let () = close_in ch in
       let () = System.check_caml_version ~caml:sd.md_ocaml ~file:f in
       if dir <> sd.md_name then
-        user_err ~hdr:"intern_from_file"
+        user_err
           (name_clash_message dir sd.md_name f);
       if tasks <> None then
-        user_err ~hdr:"intern_from_file"
+        user_err
           (str "The file "++str f++str " contains unfinished tasks");
       if opaque_csts <> None then begin
        Flags.if_verbose chk_pp (str " (was a vio file) ");
       Option.iter (fun (_,b) -> if not b then
-        user_err ~hdr:"intern_from_file"
+        user_err
           (str "The file "++str f++str " is still a .vio"))
         opaque_csts;
       end;

--- a/checker/checker.ml
+++ b/checker/checker.ml
@@ -216,11 +216,6 @@ let report () = strbrk (". Please report at " ^ Coq_config.wwwbugtracker ^ ".")
 
 let guill s = str "\"" ++ str s ++ str "\""
 
-let where = function
-| None -> mt ()
-| Some s ->
-  if CDebug.(get_flag misc) then  (str"in " ++ str s ++ str":" ++ spc ()) else (mt ())
-
 let explain_exn = function
   | Stream.Failure ->
       hov 0 (anomaly_string () ++ str "uncaught Stream.Failure.")
@@ -228,8 +223,8 @@ let explain_exn = function
       hov 0 (str "Syntax error: " ++ str txt)
   | Sys_error msg ->
       hov 0 (anomaly_string () ++ str "uncaught exception Sys_error " ++ guill msg ++ report() )
-  | UserError(s,pps) ->
-      hov 1 (str "User error: " ++ where s ++ pps)
+  | UserError pps ->
+      hov 1 (str "User error: " ++ pps)
   | Out_of_memory ->
       hov 0 (str "Out of memory")
   | Stack_overflow ->

--- a/dev/ci/user-overlays/15003-SkySkimmer-nohdr.sh
+++ b/dev/ci/user-overlays/15003-SkySkimmer-nohdr.sh
@@ -1,0 +1,7 @@
+overlay coqhammer https://github.com/SkySkimmer/coqhammer nohdr 15003
+
+overlay equations https://github.com/SkySkimmer/Coq-Equations nohdr 15003
+
+overlay mtac2 https://github.com/SkySkimmer/Mtac2 nohdr 15003
+
+overlay vscoq https://github.com/SkySkimmer/vscoq nohdr 15003

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -284,7 +284,7 @@ let rec to_lambda sigma n prod =
     match kind sigma prod with
       | Prod (na,ty,bd) -> mkLambda (na,ty,to_lambda sigma (n-1) bd)
       | Cast (c,_,_) -> to_lambda sigma n c
-      | _   -> user_err ~hdr:"to_lambda" (Pp.mt ())
+      | _   -> user_err (Pp.mt ())
 
 let decompose_prod sigma c =
   let rec proddec_rec l c = match kind sigma c with

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -919,7 +919,7 @@ let tclPROGRESS t =
     tclUNIT res
   else
     let info = Exninfo.reify () in
-    tclZERO ~info (CErrors.UserError (Some "Proofview.tclPROGRESS", Pp.str "Failed to progress."))
+    tclZERO ~info (CErrors.UserError Pp.(str "Failed to progress."))
 
 let _ = CErrors.register_handler begin function
   | Logic_monad.Tac_Timeout ->

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -151,7 +151,7 @@ let algebraics uctx = uctx.univ_algebraic
 
 let add_names ?loc s l (names, names_rev) =
   if UNameMap.mem s names
-  then user_err ?loc ~hdr:"add_names"
+  then user_err ?loc
       Pp.(str "Universe " ++ Names.Id.print s ++ str" already bound.");
   (UNameMap.add s l names, Level.Map.add l { uname = Some s; uloc = loc } names_rev)
 
@@ -384,7 +384,7 @@ let error_unbound_universes left uctx =
       info.uloc
     with Not_found -> None
   in
-  user_err ?loc ~hdr:"universe_context"
+  user_err ?loc
     ((str(CString.plural n "Universe") ++ spc () ++
       Level.Set.pr (pr_uctx_level uctx) left ++
       spc () ++ str (CString.conjugate_verb_to_be n) ++
@@ -427,7 +427,7 @@ let check_implication uctx cstrs cstrs' =
   let grext = UGraph.merge_constraints cstrs gr in
   let cstrs' = Constraints.filter (fun c -> not (UGraph.check_constraint grext c)) cstrs' in
   if Constraints.is_empty cstrs' then ()
-  else CErrors.user_err ~hdr:"check_univ_decl"
+  else CErrors.user_err
       (str "Universe constraints are not implied by the ones declared: " ++
        pr_constraints (pr_uctx_level uctx) cstrs')
 

--- a/engine/univGen.ml
+++ b/engine/univGen.ml
@@ -36,7 +36,7 @@ let existing_instance ?loc auctx inst =
     let len1 = Array.length (Instance.to_array inst)
     and len2 = AbstractContext.size auctx in
       if not (len1 == len2) then
-        CErrors.user_err ?loc ~hdr:"Universes"
+        CErrors.user_err ?loc
           Pp.(str "Universe instance should have length " ++ int len2 ++ str ".")
       else ()
   in
@@ -77,7 +77,7 @@ let fresh_global_instance ?loc ?names env gr =
 let constr_of_monomorphic_global gr =
   if not (Global.is_polymorphic gr) then
     fst (fresh_global_instance (Global.env ()) gr)
-  else CErrors.user_err ~hdr:"constr_of_global"
+  else CErrors.user_err
       Pp.(str "globalization of polymorphic reference " ++ Nametab.pr_global_env Id.Set.empty gr ++
           str " would forget universes.")
 

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -309,7 +309,7 @@ let dirpath_of_string_list s =
   let id =
     try Nametab.full_name_module qid
     with Not_found ->
-      CErrors.user_err ~hdr:"Search.interface_search"
+      CErrors.user_err
         (str "Module " ++ str path ++ str " not found.")
   in
   id

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -618,21 +618,20 @@ let mkCLambdaN ?loc bll c =
 let coerce_reference_to_id qid =
   if qualid_is_ident qid then qualid_basename qid
   else
-    CErrors.user_err ?loc:qid.CAst.loc ~hdr:"coerce_reference_to_id"
+    CErrors.user_err ?loc:qid.CAst.loc
       (str "This expression should be a simple identifier.")
 
 let coerce_to_id = function
   | { CAst.loc; v = CRef (qid,None) } when qualid_is_ident qid ->
     CAst.make ?loc @@ qualid_basename qid
   | { CAst.loc; _ } -> CErrors.user_err ?loc
-                         ~hdr:"coerce_to_id"
                          (str "This expression should be a simple identifier.")
 
 let coerce_to_name = function
   | { CAst.loc; v = CRef (qid,None) } when qualid_is_ident qid ->
     CAst.make ?loc @@ Name (qualid_basename qid)
   | { CAst.loc; v = CHole (None,IntroAnonymous,None) } -> CAst.make ?loc Anonymous
-  | { CAst.loc; _ } -> CErrors.user_err ?loc ~hdr:"coerce_to_name"
+  | { CAst.loc; _ } -> CErrors.user_err ?loc
                          (str "This expression should be a name.")
 
 let mkCPatOr ?loc = function
@@ -645,13 +644,11 @@ let mkAppPattern ?loc p lp =
   make ?loc @@ (match p.v with
   | CPatAtom (Some r) -> CPatCstr (r, None, lp)
   | CPatCstr (r, None, l2) ->
-     CErrors.user_err ?loc:p.loc ~hdr:"compound_pattern"
+     CErrors.user_err ?loc:p.loc
                       (Pp.str "Nested applications not supported.")
   | CPatCstr (r, l1, l2) -> CPatCstr (r, l1 , l2@lp)
   | CPatNotation (inscope, n, s, l) -> CPatNotation (inscope, n , s, l@lp)
-  | _ -> CErrors.user_err
-           ?loc:p.loc ~hdr:"compound_pattern"
-           (Pp.str "Such pattern cannot have arguments."))
+  | _ -> CErrors.user_err ?loc:p.loc (Pp.str "Such pattern cannot have arguments."))
 
 let rec coerce_to_cases_pattern_expr c = CAst.map_with_loc (fun ?loc -> function
   | CRef (r,None) ->
@@ -677,5 +674,5 @@ let rec coerce_to_cases_pattern_expr c = CAst.map_with_loc (fun ?loc -> function
   | CCast (p,Constr.DEFAULTcast, t) ->
      CPatCast (coerce_to_cases_pattern_expr p,t)
   | _ ->
-     CErrors.user_err ?loc ~hdr:"coerce_to_cases_pattern_expr"
+     CErrors.user_err ?loc
                       (str "This expression should be coercible to a pattern.")) c

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -144,7 +144,7 @@ let deactivate_notation nr =
   | NotationRule (inscope, ntn) ->
      let scopt = match inscope with NotationInScope sc -> Some sc | LastLonelyNotation -> None in
      match availability_of_notation (inscope, ntn) (scopt, []) with
-     | None -> user_err ~hdr:"Notation"
+     | None -> user_err
                         (pr_notation ntn ++ spc () ++ str "does not exist"
                          ++ (match inscope with
                              | LastLonelyNotation -> spc () ++ str "in the empty scope."
@@ -244,7 +244,7 @@ let is_record indsp =
 let encode_record r =
   let indsp = Nametab.global_inductive r in
   if not (is_record indsp) then
-    user_err ?loc:r.CAst.loc ~hdr:"encode_record"
+    user_err ?loc:r.CAst.loc
       (str "This type is not a structure type.");
   indsp
 

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -1100,7 +1100,7 @@ let intern_var env (ltacvars,ntnvars) namedctx loc id us =
     else gvar (loc,id) us
   else if Id.Set.mem id ltacvars.ltac_bound then
     (* Is [id] bound to a free name in ltac (this is an ltac error message) *)
-    user_err ?loc ~hdr:"intern_var"
+    user_err ?loc
      (str "variable " ++ Id.print id ++ str " should be bound to a term.")
   else
     (* Is [id] a goal or section variable *)
@@ -1330,7 +1330,7 @@ let warn_nonprimitive_projection =
     Pp.(fun f -> pr_qualid f ++ str " used as a primitive projection but is not one.")
 
 let error_nonprojection_syntax ?loc qid =
-  CErrors.user_err ?loc ~hdr:"nonprojection-syntax" Pp.(pr_qualid qid ++ str" is not a projection.")
+  CErrors.user_err ?loc Pp.(pr_qualid qid ++ str" is not a projection.")
 
 let check_applied_projection isproj realref qid =
   if isproj then
@@ -1497,10 +1497,10 @@ let find_constructor_head ?loc ref =
   | ConstructRef cstr -> cstr
   | IndRef _ ->
     let error = str "There is an inductive name deep in a \"in\" clause." in
-    user_err ?loc ~hdr:"find_constructor" error
+    user_err ?loc error
   | ConstRef _ | VarRef _ ->
     let error = str "This reference is not a constructor." in
-    user_err ?loc ~hdr:"find_constructor" error
+    user_err ?loc error
 
 let find_inductive_head ?loc ref =
   let open GlobRef in
@@ -2173,7 +2173,7 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
        in
        begin
           match fields with
-            | None -> user_err ?loc ~hdr:"intern" (str"No constructor inference.")
+            | None -> user_err ?loc (str"No constructor inference.")
             | Some (n, constrname, args) ->
                 let args_scopes = find_arguments_scope constrname in
                 let pars = List.make n (CAst.make ?loc @@ CHole (None, IntroAnonymous, None)) in
@@ -2799,7 +2799,7 @@ let interp_univ_constraints env evd cstrs =
         evd, cstrs'
     with Univ.UniverseInconsistency e as exn ->
       let _, info = Exninfo.capture exn in
-      CErrors.user_err ~hdr:"interp_constraint" ~info
+      CErrors.user_err ~info
         (Univ.explain_universe_inconsistency (Termops.pr_evd_level evd) e)
   in
   List.fold_left interp (evd,Univ.Constraints.empty) cstrs

--- a/interp/implicit_quantifiers.ml
+++ b/interp/implicit_quantifiers.ml
@@ -29,11 +29,11 @@ let generalizable_table = Summary.ref Id.Pred.empty ~name:"generalizable-ident"
 
 let declare_generalizable_ident table {CAst.loc;v=id} =
   if not (Id.equal id (root_of_id id)) then
-    user_err ?loc ~hdr:"declare_generalizable_ident"
+    user_err ?loc
     ((Id.print id ++ str
       " is not declarable as generalizable identifier: it must have no trailing digits, quote, or _"));
   if Id.Pred.mem id table then
-    user_err ?loc ~hdr:"declare_generalizable_ident"
+    user_err ?loc
                 ((Id.print id++str" is already declared as a generalizable identifier"))
   else Id.Pred.add id table
 
@@ -77,7 +77,7 @@ let is_freevar ids env x =
 (* Auxiliary functions for the inference of implicitly quantified variables. *)
 
 let ungeneralizable loc id =
-  user_err ?loc ~hdr:"Generalization"
+  user_err ?loc
                (str "Unbound and ungeneralizable variable " ++ Id.print id ++ str ".")
 
 let free_vars_of_constr_expr c ?(bound=Id.Set.empty) l =

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -166,7 +166,7 @@ let declare_scope scope =
     scope_map := String.Map.add scope empty_scope !scope_map
 
 let error_unknown_scope ~info sc =
-  user_err ~hdr:"Notation" ~info
+  user_err ~info
     (str "Scope " ++ str sc ++ str " is not declared.")
 
 let find_scope ?(tolerant=false) scope =
@@ -308,7 +308,7 @@ let remove_delimiters scope =
 let find_delimiters_scope ?loc key =
   try String.Map.find key !delimiters_map
   with Not_found ->
-    user_err ?loc ~hdr:"find_delimiters"
+    user_err ?loc
       (str "Unknown scope delimiting key " ++ str key ++ str ".")
 
 (* Uninterpretation tables *)
@@ -1039,7 +1039,7 @@ let int63_of_pos_bigint ?loc n =
   mkInt i
 
 let error_overflow ?loc n =
-  CErrors.user_err ?loc ~hdr:"interp_int63" Pp.(str "overflow in int63 literal: " ++ str (Z.to_string n))
+  CErrors.user_err ?loc Pp.(str "overflow in int63 literal: " ++ str (Z.to_string n))
 
 let coqpos_neg_int63_of_bigint ?loc ind (sign,n) =
   let uint = int63_of_pos_bigint ?loc n in
@@ -1211,7 +1211,7 @@ let coqbyte_of_string ?loc byte s =
         if Int.equal (String.length s) 3 && is_digit s.[0] && is_digit s.[1] && is_digit s.[2]
         then int_of_string s else 256 in
       if n < 256 then n else
-       user_err ?loc ~hdr:"coqbyte_of_string"
+       user_err ?loc
          (str "Expects a single character or a three-digit ASCII code.") in
   coqbyte_of_char_code byte p
 
@@ -1316,7 +1316,7 @@ let hashtbl_check_and_set allow_overwrite uid f h eq =
    | _ when allow_overwrite -> Hashtbl.add h uid f
    | g when eq f g -> ()
    | _ ->
-      user_err ~hdr:"prim_token_interpreter"
+      user_err
        (str "Unique identifier " ++ str uid ++
         str " already used to register a number or string (un)interpreter.")
 
@@ -1410,11 +1410,11 @@ let check_required_module ?loc sc (sp,d) =
     let _, info = Exninfo.capture exn in
     match d with
     | [] ->
-      user_err ?loc ~info ~hdr:"prim_token_interpreter"
+      user_err ?loc ~info
         (str "Cannot interpret in " ++ str sc ++ str " because " ++ pr_path sp ++
          str " could not be found in the current environment.")
     | _ ->
-      user_err ?loc ~info ~hdr:"prim_token_interpreter"
+      user_err ?loc ~info
         (str "Cannot interpret in " ++ str sc ++ str " without requiring first module " ++
          str (List.last d) ++ str ".")
 
@@ -1608,7 +1608,7 @@ let interp_prim_token_gen ?loc g p local_scopes =
     pat, (loc,sc)
   with Not_found as exn ->
     let _, info = Exninfo.capture exn in
-    user_err ?loc ~info ~hdr:"interp_prim_token"
+    user_err ?loc ~info
     ((match p with
       | Number _ ->
          str "No interpretation for number " ++ pr_notation (notation_of_prim_token p)
@@ -2328,7 +2328,7 @@ let rec find_pattern nt xl = function
   | _, Break s :: _ | Break s :: _, _ ->
       user_err Pp.(str ("A break occurs on one side of \"..\" but not on the other side."))
   | _, Terminal s :: _ | Terminal s :: _, _ ->
-      user_err ~hdr:"Metasyntax.find_pattern"
+      user_err
         (str "The token \"" ++ str s ++ str "\" occurs on one side of \"..\" but not on the other side.")
   | _, [] ->
       user_err Pp.(str msg_expected_form_of_recursive_notation)

--- a/interp/reserve.ml
+++ b/interp/reserve.ml
@@ -82,12 +82,12 @@ let add_reserved_type (id,t) =
 
 let declare_reserved_type_binding {CAst.loc;v=id} t =
   if not (Id.equal id (root_of_id id)) then
-    user_err ?loc ~hdr:"declare_reserved_type"
+    user_err ?loc
       ((Id.print id ++ str
       " is not reservable: it must have no trailing digits, quote, or _"));
   begin try
     let _ = Id.Map.find id !reserve_table in
-    user_err ?loc ~hdr:"declare_reserved_type"
+    user_err ?loc
     ((Id.print id++str" is already bound to a type"))
   with Not_found -> () end;
   add_reserved_type (id,t)

--- a/interp/smartlocate.ml
+++ b/interp/smartlocate.ml
@@ -58,7 +58,7 @@ let global_constant_with_alias qid  =
   try match locate_global_with_alias qid with
   | Names.GlobRef.ConstRef c -> c
   | ref ->
-      user_err ?loc:qid.CAst.loc ~hdr:"global_inductive"
+      user_err ?loc:qid.CAst.loc
         (pr_qualid qid ++ spc () ++ str "is not a reference to a constant.")
   with Not_found as exn ->
     let _, info = Exninfo.capture exn in
@@ -68,7 +68,7 @@ let global_inductive_with_alias qid  =
   try match locate_global_with_alias qid with
   | Names.GlobRef.IndRef ind -> ind
   | ref ->
-      user_err ?loc:qid.CAst.loc ~hdr:"global_inductive"
+      user_err ?loc:qid.CAst.loc
         (pr_qualid qid ++ spc () ++ str "is not an inductive type.")
   with Not_found as exn ->
     let _, info = Exninfo.capture exn in
@@ -78,7 +78,7 @@ let global_constructor_with_alias qid  =
   try match locate_global_with_alias qid with
   | Names.GlobRef.ConstructRef c -> c
   | ref ->
-      user_err ?loc:qid.CAst.loc ~hdr:"global_inductive"
+      user_err ?loc:qid.CAst.loc
         (pr_qualid qid ++ spc () ++ str "is not a constructor of an inductive type.")
   with Not_found as exn ->
     let _, info = Exninfo.capture exn in

--- a/interp/syntax_def.ml
+++ b/interp/syntax_def.ml
@@ -34,7 +34,7 @@ let add_syntax_constant kn syndef =
 
 let load_syntax_constant i ((sp,kn),(_local,syndef)) =
   if Nametab.exists_cci sp then
-    user_err ~hdr:"cache_syntax_constant"
+    user_err
       (Id.print (basename sp) ++ str " already exists");
   add_syntax_constant kn syndef;
   Nametab.push_syndef (Nametab.Until i) sp kn

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1297,7 +1297,7 @@ let export ~output_native_objects senv dir =
 let import lib cst vodigest senv =
   check_required senv.required lib.comp_deps;
   if DirPath.equal (ModPath.dp senv.modpath) lib.comp_name then
-    CErrors.user_err ~hdr:"Safe_typing.import"
+    CErrors.user_err
       Pp.(strbrk "Cannot load a library with the same name as the current one ("
           ++ DirPath.print lib.comp_name ++ str").");
   let mp = MPfile lib.comp_name in
@@ -1419,7 +1419,7 @@ let check_register_ind (type t) ind (r : t CPrimitives.prim_ind) env =
   let (mb,ob as spec) = Inductive.lookup_mind_specif env ind in
   let check_if b msg =
     if not b then
-      CErrors.user_err ~hdr:"check_register_ind" msg in
+      CErrors.user_err msg in
   check_if (Int.equal (Array.length mb.mind_packets) 1) Pp.(str "A non mutual inductive is expected");
   let is_monomorphic = function Monomorphic -> true | Polymorphic _ -> false in
   check_if (is_monomorphic mb.mind_universes) Pp.(str "A universe monomorphic inductive type is expected");

--- a/kernel/term.ml
+++ b/kernel/term.ml
@@ -123,7 +123,7 @@ let rec to_lambda n prod =
     match kind prod with
       | Prod (na,ty,bd) -> mkLambda (na,ty,to_lambda (n-1) bd)
       | Cast (c,_,_) -> to_lambda n c
-      | _   -> user_err ~hdr:"to_lambda" (mt ())
+      | _   -> user_err (mt ())
 
 let rec to_prod n lam =
   if Int.equal n 0 then
@@ -132,7 +132,7 @@ let rec to_prod n lam =
     match kind lam with
       | Lambda (na,ty,bd) -> mkProd (na,ty,to_prod (n-1) bd)
       | Cast (c,_,_) -> to_prod n c
-      | _   -> user_err ~hdr:"to_prod" (mt ())
+      | _   -> user_err (mt ())
 
 let it_mkProd_or_LetIn   = List.fold_left (fun c d -> mkProd_or_LetIn d c)
 let it_mkLambda_or_LetIn = List.fold_left (fun c d -> mkLambda_or_LetIn d c)

--- a/kernel/vmbytegen.ml
+++ b/kernel/vmbytegen.ml
@@ -879,7 +879,7 @@ let compile ~fail_on_error ?universes:(universes=0) env sigma c =
   with TooLargeInductive msg as exn ->
     let _, info = Exninfo.capture exn in
     let fn = if fail_on_error then
-        CErrors.user_err ?loc:None ~info ~hdr:"compile"
+        CErrors.user_err ?loc:None ~info
       else
         (fun x -> Feedback.msg_warning x) in
     fn msg; None

--- a/lib/cErrors.ml
+++ b/lib/cErrors.ml
@@ -30,13 +30,12 @@ let anomaly ?loc ?info ?label pp =
   let info = Option.cata (Loc.add_loc info) info loc in
   Exninfo.iraise (Anomaly (label, pp), info)
 
-(* TODO remove the option *)
-exception UserError of string option * Pp.t (* User errors *)
+exception UserError of Pp.t (* User errors *)
 
 let user_err ?loc ?info ?hdr strm =
   let info = Option.default Exninfo.null info in
   let info = Option.cata (Loc.add_loc info) info loc in
-  Exninfo.iraise (UserError (hdr, strm), info)
+  Exninfo.iraise (UserError strm, info)
 
 exception Timeout = Control.Timeout
 
@@ -133,7 +132,7 @@ let print_no_report e = iprint_no_report (e, Exninfo.info e)
 (** Predefined handlers **)
 
 let _ = register_handler begin function
-  | UserError(s, pps) ->
+  | UserError pps ->
     Some pps
   | _ -> None
   end

--- a/lib/cErrors.ml
+++ b/lib/cErrors.ml
@@ -32,7 +32,7 @@ let anomaly ?loc ?info ?label pp =
 
 exception UserError of Pp.t (* User errors *)
 
-let user_err ?loc ?info ?hdr strm =
+let user_err ?loc ?info strm =
   let info = Option.default Exninfo.null info in
   let info = Option.cata (Loc.add_loc info) info loc in
   Exninfo.iraise (UserError strm, info)

--- a/lib/cErrors.mli
+++ b/lib/cErrors.mli
@@ -34,9 +34,9 @@ exception UserError of Pp.t
 (** Main error signaling exception. It carries a header plus a pretty printing
     doc *)
 
-val user_err : ?loc:Loc.t -> ?info:Exninfo.info -> ?hdr:string -> Pp.t -> 'a
-(** Main error raising primitive. [user_err ?loc ?hdr pp] signals an
-    error [pp] with optional header and location [hdr] [loc] *)
+val user_err : ?loc:Loc.t -> ?info:Exninfo.info -> Pp.t -> 'a
+(** Main error raising primitive. [user_err ?loc pp] signals an
+    error [pp] with optional header and location [loc] *)
 
 exception Timeout
 

--- a/lib/cErrors.mli
+++ b/lib/cErrors.mli
@@ -30,7 +30,7 @@ val is_anomaly : exn -> bool
     This is mostly provided for compatibility. Please avoid doing specific
     tricks with anomalies thanks to it. See rather [noncritical] below. *)
 
-exception UserError of string option * Pp.t
+exception UserError of Pp.t
 (** Main error signaling exception. It carries a header plus a pretty printing
     doc *)
 

--- a/lib/objFile.ml
+++ b/lib/objFile.ml
@@ -14,12 +14,12 @@ open System
 let magic_number = 0x436F7121l (* "Coq!" *)
 
 let error_corrupted file s =
-  CErrors.user_err ~hdr:"System" (str file ++ str ": " ++ str s ++ str ". Try to rebuild it.")
+  CErrors.user_err (str file ++ str ": " ++ str s ++ str ". Try to rebuild it.")
 
 let open_trapping_failure name =
   try open_out_bin name
   with e when CErrors.noncritical e ->
-    CErrors.user_err ~hdr:"System.open" (str "Can't open " ++ str name)
+    CErrors.user_err (str "Can't open " ++ str name)
 
 (*
 

--- a/lib/system.ml
+++ b/lib/system.ml
@@ -123,7 +123,7 @@ let find_file_in_path ?(warn=true) paths filename =
       let root = Filename.dirname filename in
       root, filename
     else
-      CErrors.user_err ~hdr:"System.find_file_in_path"
+      CErrors.user_err
         (hov 0 (str "Can't find file" ++ spc () ++ str filename))
   else
     (* the name is considered to be the transcription as a relative
@@ -131,7 +131,7 @@ let find_file_in_path ?(warn=true) paths filename =
        to be locate respecting case *)
     try where_in_path ~warn paths filename
     with Not_found ->
-      CErrors.user_err ~hdr:"System.find_file_in_path"
+      CErrors.user_err
         (hov 0 (str "Can't find file" ++ spc () ++ str filename ++ spc () ++
                 str "on loadpath"))
 
@@ -152,7 +152,7 @@ let is_in_system_path filename =
     false
 
 let error_corrupted file s =
-  CErrors.user_err ~hdr:"System" (str file ++ str ": " ++ str s ++ str ". Try to rebuild it.")
+  CErrors.user_err (str file ++ str ": " ++ str s ++ str ". Try to rebuild it.")
 
 let check_caml_version ~caml:s ~file:f =
   if not (String.equal Coq_config.caml_version s) then
@@ -178,13 +178,13 @@ let with_magic_number_check f a =
   try f a
   with
   | Bad_magic_number {filename=fname; actual; expected} ->
-    CErrors.user_err ~hdr:"with_magic_number_check"
+    CErrors.user_err
     (str"File " ++ str fname ++ strbrk" has bad magic number " ++
     (str @@ Int32.to_string actual) ++ str" (expected " ++ (str @@ Int32.to_string expected) ++ str")." ++
     spc () ++
     strbrk "It is corrupted or was compiled with another version of Coq.")
   | Bad_version_number {filename=fname;actual=actual;expected=expected} ->
-    CErrors.user_err ~hdr:"with_magic_number_check"
+    CErrors.user_err
     (str"File " ++ str fname ++ strbrk" has bad version number " ++
     (str @@ Int32.to_string actual) ++ str" (expected " ++ (str @@ Int32.to_string expected) ++ str")." ++
     spc () ++

--- a/library/coqlib.ml
+++ b/library/coqlib.ml
@@ -113,7 +113,7 @@ let check_required_library d =
       | _ -> false
     in
     if not in_current_dir then
-      user_err ~hdr:"Coqlib.check_required_library"
+      user_err
         (str "Library " ++ DirPath.print dir ++ str " has to be required first.")
 
 (************************************************************************)

--- a/library/goptions.ml
+++ b/library/goptions.ml
@@ -40,11 +40,11 @@ type option_state = {
 let nickname table = String.concat " " table
 
 let error_no_table_of_this_type ~kind key =
-  user_err ~hdr:"Goptions"
+  user_err
     (str ("There is no " ^ kind ^ "-valued table with this name: \"" ^ nickname key ^ "\"."))
 
 let error_undeclared_key key =
-  user_err ~hdr:"Goptions"
+  user_err
     (str ("There is no flag, option or table with this name: \"" ^ nickname key ^ "\"."))
 
 (****************************************************************************)

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -88,7 +88,7 @@ let classify_segment seg =
     end
     | (_,OpenedSection _) :: _ -> user_err Pp.(str "there are still opened sections")
     | (_,OpenedModule (ty,_,_,_)) :: _ ->
-      user_err ~hdr:"Lib.classify_segment"
+      user_err
         (str "there are still opened " ++ str (module_kind ty) ++ str "s")
   in
     clean ([],[],[]) (List.rev seg)
@@ -280,7 +280,7 @@ let start_mod is_type export id mp fs =
     else Nametab.exists_dir dir
   in
   if exists then
-    user_err ~hdr:"open_module" (Id.print id ++ str " already exists.");
+    user_err (Id.print id ++ str " already exists.");
   add_entry (make_foname id) (OpenedModule (is_type,export,prefix,fs));
   lib_state := { !lib_state with path_prefix = prefix} ;
   prefix
@@ -340,7 +340,7 @@ let open_blocks_message es =
 let end_compilation_checks dir =
   let _ = match find_entries_p is_opening_node with
     | [] -> ()
-    | es -> user_err ~hdr:"Lib.end_compilation_checks" (open_blocks_message es) in
+    | es -> user_err (open_blocks_message es) in
   let is_opening_lib = function _,CompilingLibrary _ -> true | _ -> false
   in
   let oname =
@@ -388,7 +388,7 @@ let find_opening_node id =
     let oname,entry = find_entry_p is_opening_node in
     let id' = basename (fst oname) in
     if not (Names.Id.equal id id') then
-      user_err ~hdr:"Lib.find_opening_node"
+      user_err
         (str "Last block to end has name " ++ Id.print id' ++ str ".");
     entry
   with Not_found -> user_err Pp.(str "There is nothing to end.")
@@ -459,7 +459,7 @@ let open_section id =
   let obj_dir = add_dirpath_suffix opp.Nametab.obj_dir id in
   let prefix = Nametab.{ obj_dir; obj_mp = opp.obj_mp; } in
   if Nametab.exists_dir obj_dir then
-    user_err ~hdr:"open_section" (Id.print id ++ str " already exists.");
+    user_err (Id.print id ++ str " already exists.");
   let fs = Summary.freeze_summaries ~marshallable:false in
   add_entry (make_foname id) (OpenedSection (prefix, fs));
   (*Pushed for the lifetime of the section: removed by unfrozing the summary*)

--- a/library/nametab.ml
+++ b/library/nametab.ml
@@ -501,7 +501,7 @@ let global qid =
   try match locate_extended qid with
     | TrueGlobal ref -> ref
     | SynDef _ ->
-        user_err ?loc:qid.CAst.loc ~hdr:"global"
+        user_err ?loc:qid.CAst.loc
           (str "Unexpected reference to a notation: " ++
            pr_qualid qid)
   with Not_found as exn ->
@@ -582,5 +582,5 @@ let global_inductive qid =
   match global qid with
   | IndRef ind -> ind
   | ref ->
-      user_err ?loc:qid.CAst.loc ~hdr:"global_inductive"
+      user_err ?loc:qid.CAst.loc
         (pr_qualid qid ++ spc () ++ str "is not an inductive type")

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -300,7 +300,7 @@ let pr_long_global ref = pr_path (Nametab.path_of_global ref)
 
 (*S Warning and Error messages. *)
 
-let err ?loc s = user_err ?loc ~hdr:"Extraction" s
+let err ?loc s = user_err ?loc s
 
 let warn_extraction_axiom_to_realize =
   CWarnings.create ~name:"extraction-axiom-to-realize" ~category:"extraction"

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -68,7 +68,7 @@ let build_newrecursive lnameargsardef =
         let def = abstract_glob_constr body_def binders in
         interp_casted_constr_with_implicits rec_sign sigma rec_impls def
       | None ->
-        CErrors.user_err ~hdr:"Function"
+        CErrors.user_err
           (Pp.str "Body of Function must be given")
     in
     Vernacstate.System.protect (List.map f) lnameargsardef
@@ -397,7 +397,7 @@ let register_struct is_rec fixpoint_exprl =
       match body_def with
       | Some body -> body
       | None ->
-        CErrors.user_err ~hdr:"Function"
+        CErrors.user_err
           Pp.(str "Body of Function must be given")
     in
     ComDefinition.do_definition ~name:fname.CAst.v ~poly:false
@@ -1776,7 +1776,7 @@ let do_generate_principle_aux pconstants on_error register_built
         match body_def with
         | Some body -> body
         | None ->
-          CErrors.user_err ~hdr:"Function"
+          CErrors.user_err
             (Pp.str "Body of Function must be given")
       in
       let recdefs, rec_impls = build_newrecursive fixpoint_exprl in
@@ -1807,7 +1807,7 @@ let do_generate_principle_aux pconstants on_error register_built
         match body_def with
         | Some body -> body
         | None ->
-          CErrors.user_err ~hdr:"Function"
+          CErrors.user_err
             Pp.(str "Body of Function must be given")
       in
       let pre_hook pconstants =
@@ -2164,7 +2164,7 @@ let build_scheme fas =
         let f_as_constant =
           try Smartlocate.global_with_alias f
           with Not_found ->
-            CErrors.user_err ~hdr:"FunInd.build_scheme"
+            CErrors.user_err
               Pp.(str "Cannot find " ++ Libnames.pr_qualid f)
         in
         let evd', f = Evd.fresh_global (Global.env ()) !evd f_as_constant in
@@ -2209,7 +2209,7 @@ let build_case_scheme fa =
       | ConstRef c -> c
       | IndRef _ | ConstructRef _ | VarRef _ -> assert false
     with Not_found ->
-      CErrors.user_err ~hdr:"FunInd.build_case_scheme"
+      CErrors.user_err
         Pp.(str "Cannot find " ++ Libnames.pr_qualid f)
   in
   let sigma, (_, u) = Evd.fresh_constant_instance env sigma funs in

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -1217,7 +1217,7 @@ let rec compute_cst_params relnames params gt =
       | GSort _ -> params
       | GHole _ -> params
       | GIf _ | GRec _ | GCast _ | GArray _ ->
-        CErrors.user_err ~hdr:"compute_cst_params" (str "Not handled case"))
+        CErrors.user_err (str "Not handled case"))
     gt
 
 and compute_cst_params_from_app acc (params, rtl) =

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -1525,7 +1525,7 @@ let do_build_inductive evd (funconstants : pconstant list)
             ~uniform:ComInductive.NonUniformParameters))
       Declarations.Finite
   with
-  | UserError (s, msg) as e ->
+  | UserError msg as e ->
     let _time3 = System.get_time () in
     (* 	Pp.msgnl (str "error : "++ str (string_of_float (System.time_difference time2 time3))); *)
     let repacked_rel_inds =

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -47,7 +47,7 @@ let chop_rlambda_n =
       | Glob_term.GLetIn (name, v, t, b) ->
         chop_lambda_n ((name, v, t) :: acc) (n - 1) b
       | _ ->
-        CErrors.user_err ~hdr:"chop_rlambda_n"
+        CErrors.user_err
           (str "chop_rlambda_n: Not enough Lambdas")
   in
   chop_lambda_n []
@@ -60,7 +60,7 @@ let chop_rprod_n =
       | Glob_term.GProd (name, k, t, b) ->
         chop_prod_n ((name, t) :: acc) (n - 1) b
       | _ ->
-        CErrors.user_err ~hdr:"chop_rprod_n"
+        CErrors.user_err
           (str "chop_rprod_n: Not enough products")
   in
   chop_prod_n []

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -288,7 +288,7 @@ let check_not_nested env sigma forbidden e =
     | Int _ | Float _ -> ()
     | Var x ->
       if Id.List.mem x forbidden then
-        user_err ~hdr:"Recdef.check_not_nested"
+        user_err
           (str "check_not_nested: failure " ++ Id.print x)
     | Meta _ | Evar _ | Sort _ -> ()
     | Cast (e, _, t) -> check_not_nested e; check_not_nested t
@@ -315,7 +315,7 @@ let check_not_nested env sigma forbidden e =
   in
   try check_not_nested e
   with UserError p ->
-    user_err ~hdr:"_"
+    user_err
       (str "on expr : " ++ Printer.pr_leconstr_env env sigma e ++ str " " ++ p)
 
 (* ['a info] contains the local information for traveling *)
@@ -460,7 +460,7 @@ let rec travel_aux jinfo continuation_tac (expr_info : constr infos) =
             expr_info.info;
           jinfo.otherS () expr_info continuation_tac expr_info
         with e when CErrors.noncritical e ->
-          user_err ~hdr:"Recdef.travel"
+          user_err
             ( str "the term "
             ++ Printer.pr_leconstr_env env sigma expr_info.info
             ++ str " can not contain a recursive call to "
@@ -472,7 +472,7 @@ let rec travel_aux jinfo continuation_tac (expr_info : constr infos) =
             expr_info.info;
           jinfo.otherS () expr_info continuation_tac expr_info
         with e when CErrors.noncritical e ->
-          user_err ~hdr:"Recdef.travel"
+          user_err
             ( str "the term "
             ++ Printer.pr_leconstr_env env sigma expr_info.info
             ++ str " can not contain a recursive call to "
@@ -500,7 +500,7 @@ let rec travel_aux jinfo continuation_tac (expr_info : constr infos) =
             travel_args jinfo expr_info.is_main_branch new_continuation_tac
               new_infos
           | Case _ ->
-            user_err ~hdr:"Recdef.travel"
+            user_err
               ( str "the term "
               ++ Printer.pr_leconstr_env env sigma expr_info.info
               ++ str
@@ -1735,7 +1735,7 @@ let recursive_definition ~interactive_proof ~is_mes function_name rec_impls
           Feedback.msg_debug
             (str "Cannot create equation Lemma " ++ CErrors.print e)
         else
-          CErrors.user_err ~hdr:"Cannot create equation Lemma"
+          CErrors.user_err
             ( str "Cannot create equation lemma."
             ++ spc ()
             ++ str "This may be because the function is nested-recursive." );

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -105,10 +105,11 @@ let mk_fix_tac (loc,id,bl,ann,ty) =
   (id,n, CAst.make ~loc @@ CProdN(bl,ty))
 
 let mk_cofix_tac (loc,id,bl,ann,ty) =
-  let _ = Option.map (fun { CAst.loc = aloc } ->
-    user_err ?loc:aloc
-      ~hdr:"Constr:mk_cofix_tac"
-      (Pp.str"Annotation forbidden in cofix expression.")) ann in
+  let () = Option.iter (fun { CAst.loc = aloc } ->
+      user_err ?loc:aloc
+        (Pp.str"Annotation forbidden in cofix expression."))
+      ann
+  in
   let bl = List.map (fun (nal,bk,t) -> CLocalAssum (nal,bk,t)) bl in
   (id,if bl = [] then ty else CAst.make ~loc @@ CProdN(bl,ty))
 

--- a/plugins/ltac/leminv.ml
+++ b/plugins/ltac/leminv.ml
@@ -264,7 +264,7 @@ let lemInv id c =
     | NoSuchBinding ->
         user_err
           (hov 0 (pr_econstr_env (pf_env gls) (project gls) c ++ spc () ++ str "does not refer to an inversion lemma."))
-    | UserError (a,b) ->
+    | UserError _ ->
          user_err ~hdr:"LemInv"
            (str "Cannot refine current goal with the lemma " ++
               pr_leconstr_env (pf_env gls) (project gls) c)

--- a/plugins/ltac/leminv.ml
+++ b/plugins/ltac/leminv.ml
@@ -187,7 +187,7 @@ let inversion_scheme ~name ~poly env sigma t sort dep_option inv_op =
   let ind =
     try find_rectype env sigma i
     with Not_found ->
-      user_err ~hdr:"inversion_scheme" (no_inductive_inconstr env sigma i)
+      user_err (no_inductive_inconstr env sigma i)
   in
   let (invEnv,invGoal) =
     compute_first_inversion_scheme env sigma ind sort dep_option
@@ -197,7 +197,7 @@ let inversion_scheme ~name ~poly env sigma t sort dep_option inv_op =
        (global_vars env sigma invGoal)
        (ids_of_named_context (named_context invEnv)));
   (*
-    user_err ~hdr:"lemma_inversion"
+    user_err
     (str"Computed inversion goal was not closed in initial signature.");
   *)
   let pf = Proof.start ~name ~poly (Evd.from_ctx (evar_universe_context sigma)) [invEnv,invGoal] in
@@ -265,7 +265,7 @@ let lemInv id c =
         user_err
           (hov 0 (pr_econstr_env (pf_env gls) (project gls) c ++ spc () ++ str "does not refer to an inversion lemma."))
     | UserError _ ->
-         user_err ~hdr:"LemInv"
+         user_err
            (str "Cannot refine current goal with the lemma " ++
               pr_leconstr_env (pf_env gls) (project gls) c)
   end

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -1470,7 +1470,7 @@ let cl_rewrite_clause_aux ?(abs=None) strat env avoid sigma concl is_hyp : resul
       Evar.Set.iter
         (fun ev ->
            if not (Evd.is_defined evars ev) then
-             user_err ~hdr:"rewrite"
+             user_err
                (str "Unsolved constraint remaining: " ++ spc () ++
                 Termops.pr_evar_info env evars (Evd.find evars ev)))
         cstrs

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -583,7 +583,7 @@ let print_ltac id =
   print_ltac_body id tac
  with
   Not_found ->
-   user_err ~hdr:"print_ltac"
+   user_err
     (pr_qualid id ++ spc() ++ str "is not a user defined tactic.")
 
 (** Grammar *)

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -505,9 +505,11 @@ let rec intern_match_goal_hyps ist ?(as_type=false) lfun = function
 let extract_let_names lrc =
   let fold accu ({loc;v=name}, _) =
     Nameops.Name.fold_right (fun id accu ->
-    if Id.Set.mem id accu then user_err ?loc
-      ~hdr:"glob_tactic" (str "This variable is bound several times.")
-    else Id.Set.add id accu) name accu
+        if Id.Set.mem id accu then
+          user_err ?loc (str "This variable is bound several times.")
+        else Id.Set.add id accu)
+      name
+      accu
   in
   List.fold_left fold Id.Set.empty lrc
 

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -389,7 +389,7 @@ let interp_intro_pattern_naming_var loc ist env sigma id =
 let interp_int ist ({loc;v=id} as locid) =
   try try_interp_ltac_var coerce_to_int ist None locid
   with Not_found ->
-    user_err ?loc ~hdr:"interp_int"
+    user_err ?loc
      (str "Unbound variable "  ++ Id.print id ++ str".")
 
 let interp_int_or_var ist = function
@@ -775,7 +775,7 @@ let interp_may_eval f ist env sigma = function
         Typing.solve_evars env sigma (EConstr.of_constr c)
       with
         | Not_found ->
-            user_err ?loc ~hdr:"interp_may_eval"
+            user_err ?loc
             (str "Unbound context identifier" ++ Id.print s ++ str"."))
   | ConstrTypeOf c ->
       let (sigma,c_interp) = f ist env sigma c in
@@ -980,7 +980,7 @@ let interp_destruction_arg ist gl arg =
           (keep, ElimOnConstr begin fun env sigma ->
           try (sigma, (constr_of_id env id', NoBindings))
           with Not_found ->
-            user_err ?loc  ~hdr:"interp_destruction_arg" (
+            user_err ?loc  (
             Id.print id ++ strbrk " binds to " ++ Id.print id' ++ strbrk " which is neither a declared nor a quantified hypothesis.")
           end)
       in
@@ -1046,7 +1046,7 @@ let read_pattern lfun ist env sigma = function
 (* Reads the hypotheses of a Match Context rule *)
 let cons_and_check_name id l =
   if Id.List.mem id l then
-    user_err ~hdr:"read_match_goal_hyps" (
+    user_err (
       str "Hypothesis pattern-matching variable " ++ Id.print id ++
       str " used twice in the same pattern.")
   else id::l

--- a/plugins/ltac/tactic_matching.ml
+++ b/plugins/ltac/tactic_matching.ml
@@ -108,7 +108,7 @@ let verify_metas_coherence env sigma (ln1,lcm) (ln,lm) =
   (merged, Id.Map.merge merge lcm lm)
 
 let matching_error =
-  CErrors.UserError (Some "tactic matching" , Pp.str "No matching clauses for match.")
+  CErrors.UserError Pp.(str "No matching clauses for match.")
 
 let imatching_error = (matching_error, Exninfo.null)
 

--- a/plugins/ring/ring.ml
+++ b/plugins/ring/ring.ml
@@ -70,7 +70,7 @@ let add_map s m = protect_maps := String.Map.add s m !protect_maps
 let lookup_map map =
   try String.Map.find map !protect_maps
   with Not_found ->
-    CErrors.user_err ~hdr:"lookup_map" (str"Map "++qs map++str"not found")
+    CErrors.user_err (str"Map "++qs map++str"not found")
 
 let protect_red map env sigma c0 =
   let c = EConstr.Unsafe.to_constr c0 in
@@ -344,13 +344,13 @@ let find_ring_structure env sigma l =
         let check c =
           let ty' = Retyping.get_type_of env sigma c in
           if not (Reductionops.is_conv env sigma ty ty') then
-            CErrors.user_err ~hdr:"ring"
+            CErrors.user_err
               (str"Arguments of ring_simplify do not have all the same type.")
         in
         List.iter check cl';
         (try ring_for_carrier (EConstr.to_constr sigma ty)
         with Not_found ->
-          CErrors.user_err ~hdr:"ring"
+          CErrors.user_err
             (str"Cannot find a declared ring structure over"++
              spc() ++ str"\"" ++ pr_econstr_env env sigma ty ++ str"\"."))
     | [] -> assert false
@@ -793,13 +793,13 @@ let find_field_structure env sigma l =
         let check c =
           let ty' = Retyping.get_type_of env sigma c in
           if not (Reductionops.is_conv env sigma ty ty') then
-            CErrors.user_err ~hdr:"field"
+            CErrors.user_err
               (str"Arguments of field_simplify do not have all the same type.")
         in
         List.iter check cl';
         (try field_for_carrier (EConstr.to_constr sigma ty)
         with Not_found ->
-          CErrors.user_err ~hdr:"field"
+          CErrors.user_err
             (str"Cannot find a declared field structure over"++
              spc()++str"\""++pr_econstr_env env sigma ty++str"\"."))
     | [] -> assert false

--- a/plugins/rtauto/refl_tauto.ml
+++ b/plugins/rtauto/refl_tauto.ml
@@ -245,7 +245,7 @@ let rtauto_tac =
     let gamma={next=1;env=[]} in
     let () =
       if Retyping.get_sort_family_of env sigma concl != InProp
-      then user_err ~hdr:"rtauto" (Pp.str "goal should be in Prop") in
+      then user_err (Pp.str "goal should be in Prop") in
     let glf = make_form env sigma gamma concl in
     let hyps = make_hyps env sigma gamma [concl] hyps in
     let formula=
@@ -264,7 +264,7 @@ let rtauto_tac =
     let prf =
       try project (search_fun (init_state [] formula))
       with Not_found ->
-        user_err ~hdr:"rtauto" (Pp.str "rtauto couldn't find any proof") in
+        user_err (Pp.str "rtauto couldn't find any proof") in
     let search_end_time = System.get_time () in
     let () = if verbose () then
         begin

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -36,7 +36,7 @@ module NamedDecl = Context.Named.Declaration
  * we thus save the lexer to restore it at the end of the file *)
 let frozen_lexer = CLexer.get_keyword_state () ;;
 
-let errorstrm x = CErrors.user_err ~hdr:"ssreflect" x
+let errorstrm x = CErrors.user_err x
 
 let allocc = Some(false,[])
 
@@ -51,7 +51,7 @@ let allocc = Some(false,[])
 let hyp_id (SsrHyp (_, id)) = id
 
 let hyp_err ?loc msg id =
-  CErrors.user_err ?loc ~hdr:"ssrhyp" Pp.(str msg ++ Id.print id)
+  CErrors.user_err ?loc Pp.(str msg ++ Id.print id)
 
 let not_section_id id = not (Termops.is_section_variable id)
 
@@ -155,7 +155,7 @@ open Genarg
 open Stdarg
 open Pp
 
-let errorstrm x = CErrors.user_err ~hdr:"ssreflect" x
+let errorstrm x = CErrors.user_err x
 let anomaly s = CErrors.anomaly (str s)
 
 (* Tentative patch from util.ml *)
@@ -1256,7 +1256,7 @@ let abs_wgen keep_let f gen (gl,args,c) =
   let sigma, env = project gl, pf_env gl in
   let evar_closed t p =
     if occur_existential sigma t then
-      CErrors.user_err ?loc:(loc_of_cpattern p) ~hdr:"ssreflect"
+      CErrors.user_err ?loc:(loc_of_cpattern p)
         (pr_econstr_pat env sigma t ++
         str" contains holes and matches no subterm of the goal") in
   match gen with

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -1125,9 +1125,9 @@ let tclDO n tac =
   let tac_err_at i gl =
     try Proofview.V82.of_tactic tac gl
     with
-    | CErrors.UserError (l, s) as e ->
+    | CErrors.UserError s as e ->
       let _, info = Exninfo.capture e in
-      let e' = CErrors.UserError (l, prefix i ++ s) in
+      let e' = CErrors.UserError (prefix i ++ s) in
       Exninfo.iraise (e', info)
   in
   let rec loop i gl =

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -901,7 +901,7 @@ ARGUMENT EXTEND ssripats_ne TYPED AS ssripat PRINTED BY { pr_ssripats }
 
 (* TODO: review what this function does, it looks suspicious *)
 let check_ssrhpats loc w_binders ipats =
-  let err_loc s = CErrors.user_err ~loc ~hdr:"ssreflect" s in
+  let err_loc s = CErrors.user_err ~loc s in
   let clr, ipats =
     let opt_app = function None -> fun l -> Some l
       | Some l1 -> fun l2 -> Some (l1 @ l2) in

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -38,8 +38,8 @@ open Constrexpr_ops
 
 type ssrtermkind = | InParens | WithAt | NoFlag | Cpattern
 
-let errorstrm = CErrors.user_err ~hdr:"ssrmatching"
-let loc_error loc msg = CErrors.user_err ?loc ~hdr:msg (str msg)
+let errorstrm = CErrors.user_err
+let loc_error loc msg = CErrors.user_err ?loc (str msg)
 let ppnl = Feedback.msg_info
 
 (* 0 cost pp function. Active only if env variable SSRDEBUG is set *)

--- a/plugins/ssrsearch/g_search.mlg
+++ b/plugins/ssrsearch/g_search.mlg
@@ -45,7 +45,7 @@ let is_ident s = try CLexer.check_ident s; true with _ -> false
 let is_ident_part s = is_ident ("H" ^ s)
 
 let interp_search_notation ?loc tag okey =
-  let err msg = CErrors.user_err ?loc ~hdr:"interp_search_notation" msg in
+  let err msg = CErrors.user_err ?loc msg in
   let mk_pntn s for_key =
     let n = String.length s in
     let s' = Bytes.make (n + 2) ' ' in

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -588,7 +588,7 @@ let check_unused_pattern env used matx =
 
 let extract_rhs pb =
   match pb.mat with
-    | [] -> user_err ~hdr:"build_leaf" (msg_may_need_inversion())
+    | [] -> user_err (msg_may_need_inversion())
     | eqn::_ -> ([eqn.orig,eqn.catch_all_vars], eqn.rhs)
 
 (**********************************************************************)

--- a/pretyping/coercionops.ml
+++ b/pretyping/coercionops.ml
@@ -450,7 +450,7 @@ let inheritance_graph () =
 let coercion_of_reference r =
   let ref = Nametab.global r in
   if not (coercion_exists ref) then
-    user_err ~hdr:"try_add_coercion"
+    user_err
       (Nametab.pr_global_env Id.Set.empty ref ++ str" is not a coercion.");
   ref
 

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -221,14 +221,14 @@ let isomorphic_to_tuple lc = Int.equal (Array.length lc) 1
 let encode_bool env ({CAst.loc} as r) =
   let (x,lc) = encode_inductive env r in
   if not (has_two_constructors lc) then
-    user_err ?loc ~hdr:"encode_if"
+    user_err ?loc
       (str "This type has not exactly two constructors.");
   x
 
 let encode_tuple env ({CAst.loc} as r) =
   let (x,lc) = encode_inductive env r in
   if not (isomorphic_to_tuple lc) then
-    user_err ?loc ~hdr:"encode_tuple"
+    user_err ?loc
       (str "This type cannot be seen as a tuple type.");
   x
 

--- a/pretyping/indrec.ml
+++ b/pretyping/indrec.ml
@@ -646,7 +646,7 @@ let lookup_eliminator env ind_sp s =
     (* using short name (e.g. for "eq_rec") *)
     try Nametab.locate (qualid_of_ident id)
     with Not_found ->
-      user_err ~hdr:"default_elim"
+      user_err
         (strbrk "Cannot find the elimination combinator " ++
          Id.print id ++ strbrk ", the elimination of the inductive definition " ++
          Nametab.pr_global_env Id.Set.empty (GlobRef.IndRef ind_sp) ++

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -352,7 +352,7 @@ let make_project env sigma ind pred c branches ps =
     let mib, _ = Inductive.lookup_mind_specif env ind in
     if (* dependent *) not (Vars.noccurn sigma 1 t) &&
          not (has_dependent_elim mib) then
-      user_err ~hdr:"make_case_or_project"
+      user_err
         Pp.(str"Dependent case analysis not allowed" ++
               str" on inductive type " ++ Termops.Internal.print_constr_env env sigma (mkInd ind))
   in

--- a/pretyping/patternops.ml
+++ b/pretyping/patternops.ml
@@ -409,7 +409,7 @@ let mkPLambda_or_LetIn (na,_,bo,t) c =
 let it_mkPProd_or_LetIn = List.fold_left (fun c d -> mkPProd_or_LetIn d c)
 let it_mkPLambda_or_LetIn = List.fold_left (fun c d -> mkPLambda_or_LetIn d c)
 
-let err ?loc pp = user_err ?loc ~hdr:"pattern_of_glob_constr" pp
+let err ?loc pp = user_err ?loc pp
 
 let warn_cast_in_pattern =
   CWarnings.create ~name:"cast-in-pattern" ~category:"automation"

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -112,7 +112,7 @@ let search_guard ?loc env possible_indexes fixdefs =
             with TypeError _ -> ())
          (List.combinations possible_indexes);
        let errmsg = "Cannot guess decreasing argument of fix." in
-         user_err ?loc ~hdr:"search_guard" (Pp.str errmsg)
+         user_err ?loc (Pp.str errmsg)
      with Found indexes -> indexes)
 
 let esearch_guard ?loc env sigma indexes fix =
@@ -136,7 +136,7 @@ let universe_level_name evd ({CAst.v=id} as lid) =
   with Not_found ->
     if not (is_strict_universe_declarations ()) then
       new_univ_level_variable ?loc:lid.CAst.loc ~name:id univ_rigid evd
-    else user_err ?loc:lid.CAst.loc ~hdr:"universe_level_name"
+    else user_err ?loc:lid.CAst.loc
         (Pp.(str "Undeclared universe: " ++ Id.print id))
 
 let sort_name sigma = function
@@ -156,7 +156,7 @@ let sort_info ?loc evd l =
       | 0 -> u'
       | 1 -> Univ.Universe.super u'
       | n ->
-        user_err ?loc ~hdr:"sort_info"
+        user_err ?loc
           (Pp.(str "Cannot interpret universe increment +" ++ int n))
       in (evd', Univ.sup u u'))
     (evd, Univ.Universe.type0m) l
@@ -388,7 +388,7 @@ let known_glob_level evd = function
   | GLocalUniv lid ->
     try known_universe_level_name evd lid
     with Not_found ->
-      user_err ?loc:lid.CAst.loc ~hdr:"known_level_info"
+      user_err ?loc:lid.CAst.loc
         (str "Undeclared universe " ++ Id.print lid.CAst.v)
 
 let glob_level ?loc evd : glob_level -> _ = function
@@ -404,7 +404,7 @@ let instance ?loc evd l =
       l
   in
   if List.exists (fun l -> Univ.Level.is_prop l) l' then
-    user_err ?loc ~hdr:"pretype"
+    user_err ?loc
       (str "Universe instances cannot contain Prop, polymorphic" ++
        str " universe instances must be greater or equal to Set.");
   evd, Some (Univ.Instance.of_array (Array.of_list (List.rev l')))
@@ -1266,7 +1266,7 @@ let pretype_type self c ?loc ~program_mode ~poly resolve_tc valcon (env : GlobEn
         let resj =
           try Typing.judge_of_int !!env i
           with Invalid_argument _ ->
-            user_err ?loc ~hdr:"pretype" (str "Type of int63 should be registered first.")
+            user_err ?loc (str "Type of int63 should be registered first.")
         in
         discard_trace @@ inh_conv_coerce_to_tycon ?loc ~program_mode resolve_tc env sigma resj tycon
 
@@ -1275,7 +1275,7 @@ let pretype_type self c ?loc ~program_mode ~poly resolve_tc valcon (env : GlobEn
       let resj =
         try Typing.judge_of_float !!env f
         with Invalid_argument _ ->
-          user_err ?loc ~hdr:"pretype" (str "Type of float should be registered first.")
+          user_err ?loc (str "Type of float should be registered first.")
         in
         discard_trace @@ inh_conv_coerce_to_tycon ?loc ~program_mode resolve_tc env sigma resj tycon
 

--- a/pretyping/structures.ml
+++ b/pretyping/structures.ml
@@ -269,7 +269,7 @@ let subst subst (gref,ind as obj) =
 (*s High-level declaration of a canonical structure *)
 
 let error_not_structure ref description =
-  user_err ~hdr:"object_declare"
+  user_err
     (str"Could not declare a canonical structure " ++
        (Id.print (Nametab.basename_of_global ref) ++ str"." ++ spc() ++
           description))

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -63,7 +63,7 @@ let subst_evaluable_reference subst = function
   | EvalConstRef kn -> EvalConstRef (Mod_subst.subst_constant subst kn)
 
 let error_not_evaluable r =
-  user_err ~hdr:"error_not_evaluable"
+  user_err
     (str "Cannot coerce" ++ spc () ++ Nametab.pr_global_env Id.Set.empty r ++
      spc () ++ str "to an evaluable reference.")
 

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1689,7 +1689,7 @@ let make_abstraction_core name (test,out) env sigma c ty occs check_occs concl =
     let ids = Environ.ids_of_named_context_val (named_context_val env) in
     if name == Anonymous then next_ident_away_in_goal x ids else
     if mem_named_context_val x (named_context_val env) then
-      user_err ~hdr:"Unification.make_abstraction_core"
+      user_err
         (str "The variable " ++ Id.print x ++ str " is already declared.")
     else
       x

--- a/printing/ppextend.ml
+++ b/printing/ppextend.ml
@@ -120,5 +120,5 @@ let add_notation_extra_printing_rule ntn k v =
         } in
       NotationMap.add ntn rules !generic_notation_printing_rules
   with Not_found ->
-    user_err ~hdr:"add_notation_extra_printing_rule"
+    user_err
       (str "No such Notation.")

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -189,7 +189,7 @@ let universe_binders_with_opt_names orig names =
           | Name id -> Name id) orig udecl
     with Invalid_argument _ ->
       let len = List.length orig in
-      CErrors.user_err ~hdr:"universe_binders_with_opt_names"
+      CErrors.user_err
         Pp.(str "Universe instance should have length " ++ int len)
   in
   let fold_named i ubind = function

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -146,12 +146,12 @@ let mentions clenv mv0 =
 let error_incompatible_inst clenv mv  =
   let na = meta_name clenv.evd mv in
   match na with
-      Name id ->
-        user_err ~hdr:"clenv_assign"
-          Pp.(str "An incompatible instantiation has already been found for " ++
-           Id.print id)
-    | _ ->
-        anomaly ~label:"clenv_assign" (Pp.str "non dependent metavar already assigned.")
+  | Name id ->
+    user_err
+      Pp.(str "An incompatible instantiation has already been found for " ++
+          Id.print id)
+  | _ ->
+    anomaly ~label:"clenv_assign" (Pp.str "non dependent metavar already assigned.")
 
 (* TODO: replace by clenv_unify (mkMeta mv) rhs ? *)
 let clenv_assign mv rhs clenv =

--- a/proofs/goal_select.ml
+++ b/proofs/goal_select.ml
@@ -70,9 +70,8 @@ let tclSELECT ?nosuchgoal g tac = match g with
     if n == 1 then tac
     else
       let e = CErrors.UserError
-          (None,
-           Pp.(str "Expected a single focused goal but " ++
-               int n ++ str " goals are focused."))
+          Pp.(str "Expected a single focused goal but " ++
+              int n ++ str " goals are focused.")
       in
       let info = Exninfo.reify () in
       Proofview.tclZERO ~info e

--- a/proofs/logic.ml
+++ b/proofs/logic.ml
@@ -99,7 +99,7 @@ let reorder_context env sigma sign ord =
       | top::ord' when mem_q top moved_hyps ->
           let ((d,h),mh) = find_q top moved_hyps in
           if occur_vars_in_decl env sigma h d then
-            user_err ~hdr:"reorder_context"
+            user_err
               (str "Cannot move declaration " ++ Id.print top ++ spc() ++
               str "before " ++
               pr_sequence Id.print
@@ -134,7 +134,7 @@ let check_decl_position env sigma sign d =
   let needed = global_vars_set_of_decl env sigma d in
   let deps = dependency_closure env sigma (named_context_of_val sign) needed in
   if Id.List.mem x deps then
-    user_err ~hdr:"Logic.check_decl_position"
+    user_err
       (str "Cannot create self-referring hypothesis " ++ Id.print x);
   x::deps
 
@@ -532,10 +532,10 @@ let convert_hyp ~check ~reorder env sigma d =
   | d' ->
     let c = Option.map EConstr.of_constr (NamedDecl.get_value d') in
     if check && not (is_conv env sigma (NamedDecl.get_type d) (EConstr.of_constr (NamedDecl.get_type d'))) then
-      user_err ~hdr:"Logic.convert_hyp"
+      user_err
         (str "Incorrect change of the type of " ++ Id.print id ++ str ".");
     if check && not (Option.equal (is_conv env sigma) b c) then
-      user_err ~hdr:"Logic.convert_hyp"
+      user_err
         (str "Incorrect change of the body of "++ Id.print id ++ str ".");
     let sign' = apply_to_hyp sign id (fun _ _ _ -> EConstr.Unsafe.to_named_decl d) in
     if reorder then reorder_val_context env sigma sign' (check_decl_position env sigma sign d)

--- a/proofs/logic.mli
+++ b/proofs/logic.mli
@@ -61,6 +61,9 @@ val pr_move_location :
 val convert_hyp : check:bool -> reorder:bool -> Environ.env -> evar_map ->
   EConstr.named_declaration -> Environ.named_context_val
 
+type cannot_move_hyp
+exception CannotMoveHyp of cannot_move_hyp
+
 val move_hyp_in_named_context : Environ.env -> Evd.evar_map -> Id.t -> Id.t move_location ->
   Environ.named_context_val -> Environ.named_context_val
 

--- a/stm/partac.ml
+++ b/stm/partac.ml
@@ -119,7 +119,7 @@ end = struct (* {{{ *)
                 let t = EConstr.Unsafe.to_constr t in
                 RespBuiltSubProof (t, Evd.evar_universe_context sigma)
               else
-                CErrors.user_err ~hdr:"STM"
+                CErrors.user_err
                   Pp.(str"The par: selector requires a tactic that makes no progress or fully" ++
                       str" solves the goal and leaves no unresolved existential variables. The following" ++
                       str" existentials remain unsolved: " ++ prlist (Termops.pr_existential_key sigma) (Evar.Set.elements evars))

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -1168,7 +1168,7 @@ end = struct (* {{{ *)
       | _ -> anomaly Pp.(str "incorrect VtMeta classification")
     with
     | Not_found ->
-       CErrors.user_err ~hdr:"undo_vernac_classifier"
+       CErrors.user_err
         Pp.(str "Cannot undo")
 
   let get_prev_proof ~doc id =
@@ -1250,7 +1250,7 @@ let proof_block_delimiters = ref []
 
 let register_proof_block_delimiter name static dynamic =
   if List.mem_assoc name !proof_block_delimiters then
-    CErrors.user_err ~hdr:"STM" Pp.(str "Duplicate block delimiter " ++ str name);
+    CErrors.user_err Pp.(str "Duplicate block delimiter " ++ str name);
   proof_block_delimiters := (name, (static,dynamic)) :: !proof_block_delimiters
 
 let mk_doc_node id = function
@@ -1285,7 +1285,7 @@ let detect_proof_block id name =
           VCS.create_proof_block decl name
       end
     with Not_found ->
-      CErrors.user_err ~hdr:"STM"
+      CErrors.user_err
         Pp.(str "Unknown proof block delimiter " ++ str name)
   )
 (****************************** THE SCHEDULER *********************************)
@@ -2068,7 +2068,7 @@ let known_state ~doc ?(redefine_qed=false) ~cache id =
            | _ -> assert false
         end
       with Not_found ->
-          CErrors.user_err ~hdr:"STM"
+          CErrors.user_err
             (str "Unknown proof block delimiter " ++ str name)
   in
 
@@ -2511,7 +2511,7 @@ let handle_failure (e, info) vcs =
 let snapshot_vio ~create_vos ~doc ~output_native_objects ldir long_f_dot_vo =
   let doc = finish ~doc in
   if List.length (VCS.branches ()) > 1 then
-    CErrors.user_err ~hdr:"stm" (str"Cannot dump a vio with open proofs");
+    CErrors.user_err (str"Cannot dump a vio with open proofs");
   (* LATER: when create_vos is true, it could be more efficient to not allocate the futures; but for now it seems useful for synchronization of the workers,
   below, [snapshot] gets computed even if [create_vos] is true. *)
   let tasks = Slaves.dump_snapshot() in
@@ -2752,7 +2752,7 @@ let add ~doc ~ontop ?newtip verb ast =
   let loc = ast.CAst.loc in
   let cur_tip = VCS.cur_tip () in
   if not (Stateid.equal ontop cur_tip) then
-    user_err ?loc ~hdr:"Stm.add"
+    user_err ?loc
       (str "Stm.add called for a different state (" ++ str (Stateid.to_string ontop) ++
        str ") than the tip: " ++ str (Stateid.to_string cur_tip) ++ str "." ++ fnl () ++
        str "This is not supported yet, sorry.");

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -2602,7 +2602,7 @@ let process_transaction ~doc ?(newtip=Stateid.fresh ()) x c =
            This error probably means that you forgot to close the last \"Proof.\" with \"Qed.\" or \"Defined.\". \
            If you really intended to use nested proofs, you can do so by turning the \"Nested Proofs Allowed\" flag on."
            |> Pp.strbrk
-           |> (fun s -> (UserError (None, s), Exninfo.null))
+           |> (fun s -> (UserError s, Exninfo.null))
            |> State.exn_on ~valid:Stateid.dummy newtip
            |> Exninfo.iraise
          else

--- a/sysinit/coqargs.ml
+++ b/sysinit/coqargs.ml
@@ -221,10 +221,10 @@ let get_compat_file = function
   | "8.13" -> "Coq.Compat.Coq813"
   | "8.12" -> "Coq.Compat.Coq812"
   | ("8.11" | "8.10" | "8.9" | "8.8" | "8.7" | "8.6" | "8.5" | "8.4" | "8.3" | "8.2" | "8.1" | "8.0") as s ->
-    CErrors.user_err ~hdr:"get_compat_file"
+    CErrors.user_err
       Pp.(str "Compatibility with version " ++ str s ++ str " not supported.")
   | s ->
-    CErrors.user_err ~hdr:"get_compat_file"
+    CErrors.user_err
       Pp.(str "Unknown compatibility version \"" ++ str s ++ str "\".")
 
 let to_opt_key = Str.(split (regexp " +"))

--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -64,7 +64,7 @@ let raw_find_base bas = String.Map.find bas !rewtab
 let find_base bas =
   try raw_find_base bas
   with Not_found ->
-    user_err ~hdr:"AutoRewrite"
+    user_err
       (str "Rewriting base " ++ str bas ++ str " does not exist.")
 
 let find_rewrites bas =
@@ -251,7 +251,7 @@ let find_applied_relation ?loc env sigma c left2right =
     match decompose_applied_relation env sigma c ctype left2right with
     | Some c -> c
     | None ->
-        user_err ?loc ~hdr:"decompose_applied_relation"
+        user_err ?loc
                     (str"The type" ++ spc () ++ Printer.pr_econstr_env env sigma ctype ++
                        spc () ++ str"of this term does not end with an applied relation.")
 

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -401,7 +401,7 @@ exception UnknownDatabase of string
 
 let autounfold db cls =
   if not (Locusops.clause_with_generic_occurrences cls) then
-    user_err ~hdr:"autounfold" (str "\"at\" clause not supported");
+    user_err (str "\"at\" clause not supported");
   match List.fold_left (fun (ids, csts) dbname ->
     let db = try searchtable_map dbname
       with Not_found -> raise (UnknownDatabase dbname)
@@ -468,7 +468,7 @@ let autounfold_one db cl =
   let st =
     List.fold_left (fun (i,c) dbname ->
       let db = try searchtable_map dbname
-        with Not_found -> user_err ~hdr:"autounfold" (str "Unknown database " ++ str dbname)
+        with Not_found -> user_err (str "Unknown database " ++ str dbname)
       in
       let (ids, csts) = Hint_db.unfolds db in
         (Id.Set.union ids i, Cset.union csts c)) (Id.Set.empty, Cset.empty) db

--- a/tactics/elim.ml
+++ b/tactics/elim.ml
@@ -64,7 +64,7 @@ let general_elim_then_using mk_elim
             | Const _ | Var _ -> str " " ++ Printer.pr_econstr_env env sigma elim
             | _ -> mt ()
           in
-          CErrors.user_err ~hdr:"Tacticals.general_elim_then_using"
+          CErrors.user_err
             (str "The elimination combinator " ++ name_elim ++ str " is unknown.")
     in
     let elimclause' = clenv_instantiate indmv elimclause (mkVar id, mkApp (mkIndU (ind, u), args)) in

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -373,7 +373,7 @@ let find_elim hdcncl lft2rgt dep cls ot =
             let l' = Label.of_id (add_suffix (Label.to_id l) "_r")  in
             let c1' = Global.constant_of_delta_kn (KerName.make mp l') in
             if not (Environ.mem_constant c1' (Global.env ())) then
-              user_err ~hdr:"Equality.find_elim"
+              user_err
                 (str "Cannot find rewrite principle " ++ Label.print l' ++ str ".");
             c1'
           end
@@ -942,7 +942,7 @@ let build_selector env sigma dirn c ind special default =
           on (c bool true) = (c bool false)
           CP : changed assert false in a more informative error
        *)
-      user_err ~hdr:"Equality.construct_discriminator"
+      user_err
         (str "Cannot discriminate on inductive constructors with \
                  dependent types.") in
   let (indp,_) = dest_ind_family indf in
@@ -1746,7 +1746,7 @@ let check_non_indirectly_dependent_section_variable gl x =
     let where = match pos with
       | Some id -> str "hypothesis " ++ Id.print id
       | None -> str "the conclusion of the goal" in
-    user_err ~hdr:"Subst"
+    user_err
       (strbrk "Section variable " ++ Id.print x ++
        strbrk " occurs implicitly in global declaration " ++ Printer.pr_global gr ++
        strbrk " present in " ++ where ++ strbrk ".")
@@ -1803,7 +1803,7 @@ let subst_one_var dep_proof_ok x =
           let hyps = Proofview.Goal.hyps gl in
           let test hyp _ = is_eq_x gl x hyp in
           Context.Named.fold_outside test ~init:() hyps;
-          user_err ~hdr:"Subst"
+          user_err
             (str "Cannot find any non-recursive equality over " ++ Id.print x ++
                str".")
         with FoundHyp res -> res in

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1722,7 +1722,7 @@ let run_hint tac k = match warn_hint () with
   if is_imported tac then k tac.obj
   else
     let info = Exninfo.reify () in
-    Proofview.tclZERO ~info (UserError (None, (str "Tactic failure.")))
+    Proofview.tclZERO ~info (UserError (str "Tactic failure."))
 
 module FullHint =
 struct

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -765,7 +765,7 @@ let current_db () = Hintdbmap.bindings !searchtable
 let current_pure_db () = List.map snd (current_db ())
 
 let error_no_such_hint_database x =
-  user_err ~hdr:"Hints" (str "No such Hint database: " ++ str x ++ str ".")
+  user_err (str "No such Hint database: " ++ str x ++ str ".")
 
 (**************************************************************************)
 (*             Auxiliary functions to prepare AUTOHINT objects            *)
@@ -871,7 +871,7 @@ let make_resolves env sigma (eapply, hnf) info ~check ?name cr =
                               make_apply_entry env sigma hnf info ?name]
   in
   if check && List.is_empty ents then
-    user_err ~hdr:"Hint"
+    user_err
       (pr_leconstr_env env sigma c ++ spc() ++
         (if eapply then str"cannot be used as a hint."
         else str "can be used as a hint only for eauto."));
@@ -925,7 +925,7 @@ let make_mode ref m =
   let n = List.length ctx in
   let m' = Array.of_list m in
     if not (n == Array.length m') then
-      user_err ~hdr:"Hint"
+      user_err
         (pr_global ref ++ str" has " ++ int n ++
            str" arguments while the mode declares " ++ int (Array.length m'))
     else m'

--- a/tactics/ind_tables.ml
+++ b/tactics/ind_tables.ml
@@ -62,7 +62,7 @@ let declare_scheme_object s aux f =
   try
     let _ = Hashtbl.find scheme_object_table key in
 (*    let aux_msg = if aux="" then "" else " (with key "^aux^")" in*)
-    user_err ~hdr:"IndTables.declare_scheme_object"
+    user_err
       (str "Scheme object " ++ str key ++ str " already declared.")
   with Not_found ->
     Hashtbl.add scheme_object_table key (s,f);

--- a/tactics/inv.ml
+++ b/tactics/inv.ml
@@ -90,7 +90,7 @@ let make_inv_predicate env evd indf realargs id status concl =
             (hyps_arity,concl)
       | Dep dflt_concl ->
           if not (occur_var env !evd id concl) then
-            user_err ~hdr:"make_inv_predicate"
+            user_err
               (str "Current goal does not depend on " ++ Id.print id ++ str".");
           (* We abstract the conclusion of goal with respect to
              realargs and c to * be concl in order to rewrite and have

--- a/tactics/redexpr.ml
+++ b/tactics/redexpr.ml
@@ -62,7 +62,7 @@ let set_strategy_one ref l  =
         let cb = Global.lookup_constant sp in
         (match cb.const_body with
           | OpaqueDef _ ->
-            user_err ~hdr:"set_transparent_const"
+            user_err
               (str "Cannot make" ++ spc () ++
                  Nametab.pr_global_env Id.Set.empty (GlobRef.ConstRef sp) ++
                  spc () ++ str "transparent because it was declared opaque.");
@@ -165,19 +165,19 @@ let red_expr_tab = Summary.ref String.Map.empty ~name:"Declare Reduction"
 
 let declare_reduction s f =
   if String.Map.mem s !reduction_tab || String.Map.mem s !red_expr_tab
-  then user_err ~hdr:"Redexpr.declare_reduction"
+  then user_err
     (str "There is already a reduction expression of name " ++ str s)
   else reduction_tab := String.Map.add s f !reduction_tab
 
 let check_custom = function
   | ExtraRedExpr s ->
       if not (String.Map.mem s !reduction_tab || String.Map.mem s !red_expr_tab)
-      then user_err ~hdr:"Redexpr.check_custom" (str "Reference to undefined reduction expression " ++ str s)
+      then user_err (str "Reference to undefined reduction expression " ++ str s)
   |_ -> ()
 
 let decl_red_expr s e =
   if String.Map.mem s !reduction_tab || String.Map.mem s !red_expr_tab
-  then user_err ~hdr:"Redexpr.decl_red_expr"
+  then user_err
     (str "There is already a reduction expression of name " ++ str s)
   else begin
     check_custom e;
@@ -257,7 +257,7 @@ let reduction_of_red_expr_val = function
   | ExtraRedExpr s ->
       (try (e_red (String.Map.find s !reduction_tab),DEFAULTcast)
       with Not_found ->
-           user_err ~hdr:"Redexpr.reduction_of_red_expr"
+           user_err
              (str "unknown user-defined reduction \"" ++ str s ++ str "\""))
   | CbvVm o -> (contextualize cbv_vm cbv_vm o, VMcast)
   | CbvNative o -> (contextualize cbv_native cbv_native o, NATIVEcast)

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -467,7 +467,7 @@ module New = struct
     | None -> info
     | Some loc -> Loc.add_loc info loc
     in
-    let err = UserError (None, msg) in
+    let err = UserError msg in
     tclZERO ~info err
 
   let catch_failerror e =

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -58,7 +58,7 @@ let tclIDTAC_MESSAGE s gls =
   Feedback.msg_info (hov 0 s); tclIDTAC gls
 
 (* General failure tactic *)
-let tclFAIL_s s gls = user_err ~hdr:"Refiner.tclFAIL_s" (str s)
+let tclFAIL_s s gls = user_err (str s)
 
 (* The Fail tactic *)
 let tclFAIL lvl s g = raise (FailError (lvl,lazy s))
@@ -77,7 +77,7 @@ let thens3parts_tac tacfi tac tacli (sigr,gs) =
   let nf = Array.length tacfi in
   let nl = Array.length tacli in
   let ng = List.length gs in
-  if ng<nf+nl then user_err ~hdr:"Refiner.thensn_tac" (str "Not enough subgoals.");
+  if ng<nf+nl then user_err (str "Not enough subgoals.");
   let gll =
       (List.map_i (fun i ->
         apply_sig_tac sigr (if i<nf then tacfi.(i) else if i>=ng-nl then tacli.(nl-ng+i) else tac))
@@ -156,7 +156,7 @@ the goal unchanged *)
 let tclPROGRESS tac ptree =
   let rslt = tac ptree in
   if Goal.V82.progress rslt ptree then rslt
-  else user_err ~hdr:"Refiner.PROGRESS" (str"Failed to progress.")
+  else user_err (str"Failed to progress.")
 
 (* Execute tac, show the names of new hypothesis names created by tac
    in the "as" format and then forget everything. From the logical
@@ -238,7 +238,7 @@ let tclCOMPLETE tac = tclTHEN tac (tclFAIL_s "Proof is not complete.")
 
 let tclDO n t =
   let rec dorec k =
-    if k < 0 then user_err ~hdr:"Refiner.tclDO"
+    if k < 0 then user_err
       (str"Wrong argument : Do needs a positive integer.");
     if Int.equal k 0 then tclIDTAC
     else if Int.equal k 1 then t else (tclTHEN t (dorec (k-1)))

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -3296,7 +3296,7 @@ let safe_dest_intro_patterns with_evars avoid thin dest pat tac =
   Proofview.tclORELSE
     (dest_intro_patterns with_evars avoid thin dest pat tac)
     begin function (e, info) -> match e with
-      | UserError (Some "move_hyp",_) ->
+      | CannotMoveHyp _ ->
        (* May happen e.g. with "destruct x using s" with an hypothesis
           which is morally an induction hypothesis to be "MoveLast" if
           known as such but which is considered instead as a subterm of

--- a/topbin/coqnative_bin.ml
+++ b/topbin/coqnative_bin.ml
@@ -151,7 +151,7 @@ let rec intern_library (needed, contents) dir =
   let f = Loadpath.locate_absolute_library dir in
   let m = intern_from_file f in
   if not (DirPath.equal dir m.library_name) then
-    user_err ~hdr:"load_physical_library"
+    user_err
       (str "The file " ++ str f ++ str " contains library" ++ spc () ++
        DirPath.print m.library_name ++ spc () ++ str "and not library" ++
        spc() ++ DirPath.print dir);

--- a/user-contrib/Ltac2/tac2match.ml
+++ b/user-contrib/Ltac2/tac2match.ml
@@ -70,7 +70,7 @@ let verify_metas_coherence env sigma s1 s2 =
   Id.Map.merge merge s1 s2
 
 let matching_error =
-  CErrors.UserError (Some "tactic matching" , Pp.str "No matching clauses for match.")
+  CErrors.UserError Pp.(str "No matching clauses for match.")
 
 let imatching_error = (matching_error, Exninfo.null)
 

--- a/vernac/attributes.ml
+++ b/vernac/attributes.ml
@@ -182,7 +182,7 @@ let qualify_attribute qual (parser:'a attribute) : 'a attribute =
       | (key,attv) :: rem when String.equal key qual ->
         (match attv with
          | VernacFlagEmpty | VernacFlagLeaf _ ->
-           CErrors.user_err ~hdr:"qualified_attribute"
+           CErrors.user_err
              Pp.(str "Malformed attribute " ++ str qual ++ str ": attribute list expected.")
          | VernacFlagList atts ->
            extract extra (atts::qualified) rem)

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -438,7 +438,7 @@ let do_replace_lb handle aavoid narg p q =
     let rec find i =
       if Id.equal avoid.(n-i) s then avoid.(n-i-x)
       else (if i<n then find (i+1)
-            else user_err ~hdr:"AutoIndDecl.do_replace_lb"
+            else user_err
                    (str "Var " ++ Id.print s ++ str " seems unknown.")
       )
     in mkVar (find 1)
@@ -484,7 +484,7 @@ let do_replace_bl handle (ind,u as indu) aavoid narg lft rgt =
     let rec find i =
       if Id.equal avoid.(n-i) s then avoid.(n-i-x)
       else (if i<n then find (i+1)
-            else user_err ~hdr:"AutoIndDecl.do_replace_bl"
+            else user_err
                    (str "Var " ++ Id.print s ++ str " seems unknown.")
       )
     in mkVar (find 1)

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -310,8 +310,7 @@ let existing_instance glob g info =
     match class_of_constr (Environ.push_rel_context ctx env) sigma (EConstr.of_constr r) with
       | Some (_, ((tc,u), _)) -> add_instance tc info glob c
       | None -> user_err ?loc:g.CAst.loc
-                         ~hdr:"declare_instance"
-                         (Pp.str "Constant does not build instances of a declared type class.")
+                  (Pp.str "Constant does not build instances of a declared type class.")
 
 (* Declare everything in the parameters as implicit, and the class instance as well *)
 

--- a/vernac/comArguments.ml
+++ b/vernac/comArguments.ml
@@ -116,12 +116,12 @@ let vernac_arguments ~section_local reference args more_implicits flags =
   (* Checks *)
 
   let err_extra_args names =
-    CErrors.user_err ~hdr:"vernac_declare_arguments"
+    CErrors.user_err
       Pp.(strbrk "Extra arguments: " ++
           prlist_with_sep pr_comma Name.print names ++ str ".")
   in
   let err_missing_args names =
-    CErrors.user_err ~hdr:"vernac_declare_arguments"
+    CErrors.user_err
       Pp.(strbrk "The following arguments are not declared: " ++
           prlist_with_sep pr_comma Name.print names ++ str ".")
   in
@@ -210,7 +210,7 @@ let vernac_arguments ~section_local reference args more_implicits flags =
       | Some (o,n) ->
         strbrk "Flag \"rename\" expected to rename " ++ Name.print o ++
         strbrk " into " ++ Name.print n ++ str "."
-    in CErrors.user_err ~hdr:"vernac_declare_arguments" msg
+    in CErrors.user_err msg
   end;
 
   let implicits =

--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -111,7 +111,7 @@ let declare_assumptions ~poly ~scope ~kind univs nl l =
 
 let maybe_error_many_udecls = function
   | ({CAst.loc;v=id}, Some _) ->
-    user_err ?loc ~hdr:"many_universe_declarations"
+    user_err ?loc
       Pp.(str "When declaring multiple axioms in one command, " ++
           str "only the first is allowed a universe binder " ++
           str "(which will be shared by the whole block).")

--- a/vernac/comCoercion.ml
+++ b/vernac/comCoercion.ml
@@ -95,7 +95,7 @@ let class_of_global = function
   | GlobRef.IndRef sp -> CL_IND sp
   | GlobRef.VarRef id -> CL_SECVAR id
   | GlobRef.ConstructRef _ as c ->
-      user_err ~hdr:"class_of_global"
+      user_err
         (str "Constructors, such as " ++ Printer.pr_global c ++
            str ", cannot be used as a class.")
 
@@ -171,7 +171,7 @@ let ident_key_of_class = function
 (* Identity coercion *)
 
 let error_not_transparent source =
-  user_err ~hdr:"build_id_coercion"
+  user_err
     (pr_class source ++ str " must be a transparent constant.")
 
 let build_id_coercion idf_opt source poly =
@@ -338,7 +338,7 @@ let add_new_coercion_core coef stre poly source target isid : unit =
 let try_add_new_coercion_core ref ~local c d e f =
   try add_new_coercion_core ref (loc_of_bool local) c d e f
   with CoercionError e ->
-      user_err ~hdr:"try_add_new_coercion_core"
+      user_err
         (explain_coercion_error ref e ++ str ".")
 
 let try_add_new_coercion ref ~local ~poly =

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -130,16 +130,15 @@ let build_wellfounded pm (recname,pl,bl,arityc,body) poly ?typing_flags ?using r
   let relargty =
     let error () =
       user_err ?loc:(constr_loc r)
-               ~hdr:"Command.build_wellfounded"
-                    (Printer.pr_econstr_env env sigma rel ++ str " is not an homogeneous binary relation.")
+        (Printer.pr_econstr_env env sigma rel ++ str " is not an homogeneous binary relation.")
     in
-      try
-        let ctx, ar = Reductionops.splay_prod_n env sigma 2 relty in
-          match ctx, EConstr.kind sigma ar with
-          | [LocalAssum (_,t); LocalAssum (_,u)], Sort s
-              when Sorts.is_prop (ESorts.kind sigma s) && Reductionops.is_conv env sigma t u -> t
-          | _, _ -> error ()
-      with e when CErrors.noncritical e -> error ()
+    try
+      let ctx, ar = Reductionops.splay_prod_n env sigma 2 relty in
+      match ctx, EConstr.kind sigma ar with
+      | [LocalAssum (_,t); LocalAssum (_,u)], Sort s
+        when Sorts.is_prop (ESorts.kind sigma s) && Reductionops.is_conv env sigma t u -> t
+      | _, _ -> error ()
+    with e when CErrors.noncritical e -> error ()
   in
   let sigma, measure = interp_casted_constr_evars ~program_mode:true binders_env sigma measure relargty in
   let sigma, wf_rel, wf_rel_fun, measure_fn =
@@ -364,7 +363,7 @@ let do_fixpoint ~pm ~scope ~poly ?typing_flags ?using l =
       let l = List.map2 (fun fix rec_order -> { fix with Vernacexpr.rec_order }) l annots in
       do_program_recursive ~pm ~scope ~poly ?typing_flags ?using fixkind l
     | _, _ ->
-      CErrors.user_err ~hdr:"do_fixpoint"
+      CErrors.user_err
         (str "Well-founded fixpoints not allowed in mutually recursive blocks")
 
 let do_cofixpoint ~pm ~scope ~poly ?using fixl =

--- a/vernac/comSearch.ml
+++ b/vernac/comSearch.ml
@@ -22,7 +22,7 @@ open Goptions
 let global_module qid =
   try Nametab.full_name_module qid
   with Not_found ->
-    user_err ?loc:qid.CAst.loc ~hdr:"global_module"
+    user_err ?loc:qid.CAst.loc
      (str "Module/section " ++ Ppconstr.pr_qualid qid ++ str " not found.")
 
 let interp_search_restriction = function
@@ -74,7 +74,7 @@ let interp_search_item env sigma =
             ~head:false (fun _ -> true) s sc in
         GlobSearchSubPattern (where,head,Pattern.PRef ref)
       with UserError _ ->
-        user_err ~hdr:"interp_search_item"
+        user_err
           (str "Unable to interpret " ++ quote (str s) ++ str " as a reference."))
   | SearchKind k ->
      match kind_searcher k with

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1038,7 +1038,7 @@ let not_transp_msg =
     ++ str "Use 'Defined' instead.")
 
 let err_not_transp () =
-  CErrors.user_err ~hdr:"Program" not_transp_msg
+  CErrors.user_err not_transp_msg
 
 module ProgMap = Id.Map
 
@@ -1091,7 +1091,7 @@ let check_solved_obligations ~pm ~what_for : unit =
   if not (ProgMap.is_empty pm) then
     let keys = map_keys pm in
     let have_string = if Int.equal (List.length keys) 1 then " has " else " have " in
-    CErrors.user_err ~hdr:"Program"
+    CErrors.user_err
       Pp.(
         str "Unsolved obligations when closing "
         ++ what_for ++ str ":" ++ spc ()
@@ -2282,7 +2282,7 @@ let solve_by_tac prg obls i tac =
   | Tacticals.FailError (_, s) as exn ->
     let _ = Exninfo.capture exn in
     let loc = fst obl.obl_location in
-    CErrors.user_err ?loc ~hdr:"solve_obligation" (Lazy.force s)
+    CErrors.user_err ?loc (Lazy.force s)
   (* If the proof is open we absorb the error and leave the obligation open *)
   | Proof_.OpenProof _ ->
     None

--- a/vernac/declareUniv.ml
+++ b/vernac/declareUniv.ml
@@ -121,7 +121,7 @@ let do_universe ~poly l =
   let in_section = Global.sections_are_opened () in
   let () =
     if poly && not in_section then
-      CErrors.user_err ~hdr:"Constraints"
+      CErrors.user_err
         (Pp.str"Cannot declare polymorphic universes outside sections")
   in
   let l = List.map (fun {CAst.v=id} -> (id, UnivGen.new_univ_global ())) l in

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -202,13 +202,13 @@ let consistency_checks exists dir dirinfo =
     let globref =
       try Nametab.locate_dir (qualid_of_dirpath dir)
       with Not_found ->
-        user_err ~hdr:"consistency_checks"
+        user_err
           (DirPath.print dir ++ str " should already exist!")
     in
     assert (Nametab.GlobDirRef.equal globref dirinfo)
   else
     if Nametab.exists_dir dir then
-      user_err ~hdr:"consistency_checks"
+      user_err
         (DirPath.print dir ++ str " already exists.")
 
 let compute_visibility exists i =

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -173,7 +173,7 @@ let try_declare_scheme what f internal names kn =
   in
   match msg with
   | None -> ()
-  | Some msg -> Exninfo.iraise (UserError (None, msg), snd e)
+  | Some msg -> Exninfo.iraise (UserError msg, snd e)
 
 let beq_scheme_msg mind =
   let mib = Global.lookup_mind mind in

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -129,7 +129,7 @@ let find_library dir =
 let try_find_library dir =
   try find_library dir
   with Not_found ->
-    user_err ~hdr:"Library.find_library"
+    user_err
       (str "Unknown library " ++ DirPath.print dir)
 
 let register_library_filename dir f =
@@ -192,7 +192,7 @@ let access_table what tables dp i =
       let t =
         try fetch_delayed f
         with Faulty f ->
-          user_err ~hdr:"Library.access_table"
+          user_err
             (str "The file " ++ str f ++ str " (bound to " ++ str dir_path ++
              str ") is corrupted,\ncannot load some " ++
              str what ++ str " in it.\n")
@@ -275,7 +275,7 @@ let rec intern_library ~lib_resolver (needed, contents) (dir, f) from =
   let f = match f with Some f -> f | None -> lib_resolver dir in
   let m = intern_from_file f in
   if not (DirPath.equal dir m.library_name) then
-    user_err ~hdr:"load_physical_library"
+    user_err
       (str "The file " ++ str f ++ str " contains library" ++ spc () ++
        DirPath.print m.library_name ++ spc () ++ str "and not library" ++
        spc() ++ DirPath.print dir);
@@ -402,9 +402,9 @@ let load_library_todo f =
   let (s4 : seg_proofs), _ = ObjFile.marshal_in_segment ch ~segment:"opaques" in
   ObjFile.close_in ch;
   System.check_caml_version ~caml:s0.md_ocaml ~file:f;
-  if tasks = None then user_err ~hdr:"restart" (str"not a .vio file");
-  if s2 = None then user_err ~hdr:"restart" (str"not a .vio file");
-  if snd (Option.get s2) then user_err ~hdr:"restart" (str"not a .vio file");
+  if tasks = None then user_err (str"not a .vio file");
+  if s2 = None then user_err (str"not a .vio file");
+  if snd (Option.get s2) then user_err (str"not a .vio file");
   s0, s1, Option.get s2, Option.get tasks, s4
 
 (************************************************************************)

--- a/vernac/loadpath.ml
+++ b/vernac/loadpath.ml
@@ -200,7 +200,7 @@ let locate_qualified_library ?root ?(warn = true) qid :
 
 let error_unmapped_dir qid =
   let prefix, _ = Libnames.repr_qualid qid in
-  CErrors.user_err ~hdr:"load_absolute_library_from"
+  CErrors.user_err
     Pp.(seq [ str "Cannot load "; Libnames.pr_qualid qid; str ":"; spc ()
             ; str "no physical path bound to"; spc ()
             ; DP.print prefix; fnl ()
@@ -209,7 +209,7 @@ let error_unmapped_dir qid =
 let error_lib_not_found qid =
   let vos = !Flags.load_vos_libraries in
   let vos_msg = if vos then [Pp.str " (while searching for a .vos file)"] else [] in
-  CErrors.user_err ~hdr:"load_absolute_library_from"
+  CErrors.user_err
     Pp.(seq ([ str "Cannot find library "; Libnames.pr_qualid qid; str" in loadpath"]@vos_msg))
 
 let try_locate_absolute_library dir =

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -217,7 +217,7 @@ let analyze_notation_tokens ~onlyprinting ~infix entry df =
   (if not onlyprinting then
     match List.duplicates Id.equal (mainvars @ List.map snd recvars) with
     | id :: _ ->
-        user_err ~hdr:"Metasyntax.get_notation_vars"
+        user_err
           (str "Variable " ++ Id.print id ++ str " occurs more than once.")
     | _ -> ());
   let isnumeral = is_numeral_in_constr entry symbols in
@@ -255,7 +255,7 @@ let check_no_syntax_modifiers_for_numeral = function
   | l -> List.iter (function {CAst.loc} -> warn_unexpected_primitive_token_modifier ?loc ()) l
 
 let error_not_same_scope x y =
-  user_err ~hdr:"Metasyntax.error_not_name_scope"
+  user_err
     (str "Variables " ++ Id.print x ++ str " and " ++ Id.print y ++ str " must be in the same scope.")
 
 (**********************************************************************)
@@ -908,7 +908,7 @@ let interp_modifiers entry modl = let open NotationMods in
     | SetEntryType (s,typ) ->
         let id = Id.of_string s in
         if Id.List.mem_assoc id acc.etyps then
-          user_err ?loc ~hdr:"Metasyntax.interp_modifiers"
+          user_err ?loc
             (str s ++ str " is already assigned to an entry or constr level.");
         interp subtyps { acc with etyps = (id,typ) :: acc.etyps; } l
     | SetItemLevel ([],bko,n) ->
@@ -916,7 +916,7 @@ let interp_modifiers entry modl = let open NotationMods in
     | SetItemLevel (s::idl,bko,n) ->
         let id = Id.of_string s in
         if Id.List.mem_assoc id acc.etyps then
-          user_err ?loc ~hdr:"Metasyntax.interp_modifiers"
+          user_err ?loc
             (str s ++ str " is already assigned to an entry or constr level.");
         interp ((id,bko,n)::subtyps) acc ((CAst.make ?loc @@ SetItemLevel (idl,bko,n))::l)
     | SetLevel n ->
@@ -960,7 +960,7 @@ let interp_modifiers entry modl = let open NotationMods in
 let check_useless_entry_types recvars mainvars etyps =
   let vars = let (l1,l2) = List.split recvars in l1@l2@mainvars in
   match List.filter (fun (x,etyp) -> not (List.mem x vars)) etyps with
-  | (x,_)::_ -> user_err ~hdr:"Metasyntax.check_useless_entry_types"
+  | (x,_)::_ -> user_err
                   (Id.print x ++ str " is unbound in the notation.")
   | _ -> ()
 

--- a/vernac/mltop.ml
+++ b/vernac/mltop.ml
@@ -148,7 +148,7 @@ let get_ml_object_suffix name =
 let file_of_name name =
   let suffix = get_ml_object_suffix name in
   let fail s =
-    user_err ~hdr:"Mltop.load_object"
+    user_err
       (str"File not found on loadpath : " ++ str s ++ str"\n" ++
        str"Loadpath: " ++ str(String.concat ":" !coq_mlpath_copy)) in
   if not (Filename.is_relative name) then
@@ -275,7 +275,7 @@ let trigger_ml_object verb cache reinit ?path name =
     add_loaded_module name (known_module_path name);
     if cache then perform_cache_obj name
   end else if not has_dynlink then
-    user_err ~hdr:"Mltop.trigger_ml_object"
+    user_err
       (str "Dynamic link not supported (module " ++ str name ++ str ")")
   else begin
     let file = file_of_name (Option.default name path) in

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -844,7 +844,7 @@ let read_sec_context qid =
   let dir =
     try Nametab.locate_section qid
     with Not_found ->
-      user_err ?loc:qid.loc ~hdr:"read_sec_context" (str "Unknown section.") in
+      user_err ?loc:qid.loc (str "Unknown section.") in
   let rec get_cxt in_cxt = function
     | (_,Lib.OpenedSection ({Nametab.obj_dir;_},_) as hd)::rest ->
         if DirPath.equal dir obj_dir then (hd::in_cxt) else get_cxt (hd::in_cxt) rest
@@ -866,7 +866,7 @@ let maybe_error_reject_univ_decl na udecl =
   | _, None | Term (ConstRef _ | IndRef _ | ConstructRef _), Some _ -> ()
   | (Term (VarRef _) | Syntactic _ | Dir _ | ModuleType _ | Other _ | Undefined _), Some udecl ->
     (* TODO Print na somehow *)
-    user_err ~hdr:"reject_univ_decl" (str "This object does not support universe names.")
+    user_err (str "This object does not support universe names.")
 
 let print_any_name env sigma na udecl =
   maybe_error_reject_univ_decl na udecl;
@@ -888,9 +888,7 @@ let print_any_name env sigma na udecl =
     if not (DirPath.is_empty dir) then raise Not_found;
     str |> Global.lookup_named |> print_named_decl env sigma
 
-  with Not_found ->
-    user_err
-      ~hdr:"print_name" (pr_qualid qid ++ spc () ++ str "not a defined object.")
+  with Not_found -> user_err (pr_qualid qid ++ spc () ++ str "not a defined object.")
 
 let print_name env sigma na udecl =
   match na with
@@ -988,7 +986,7 @@ let print_path_between cls clt =
     try
       lookup_path_between_class (cls, clt)
     with Not_found ->
-      user_err ~hdr:"index_cl_of_id"
+      user_err
         (str"No path between " ++ pr_class cls ++ str" and " ++ pr_class clt
          ++ str ".")
   in

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -101,7 +101,7 @@ let check_anonymous_type ind =
 let error_parameters_must_be_named bk {CAst.loc; v=name} =
   match bk, name with
   | Default _, Anonymous ->
-    CErrors.user_err ?loc ~hdr:"record" (str "Record parameters must be named")
+    CErrors.user_err ?loc (str "Record parameters must be named")
   | _ -> ()
 
 let check_parameters_must_be_named = function
@@ -285,7 +285,7 @@ let warning_or_error ~info coe indsp err =
           | _ ->
               (Id.print fi ++ strbrk " cannot be defined because it is not typable.")
   in
-  if coe then user_err ~hdr:"structure" ~info st;
+  if coe then user_err ~info st;
   warn_cannot_define_projection (hov 0 st)
 
 type field_status =
@@ -798,7 +798,7 @@ let declare_existing_class g =
     match g with
     | GlobRef.ConstRef x -> add_constant_class env sigma x
     | GlobRef.IndRef x -> add_inductive_class env sigma x
-    | _ -> user_err ~hdr:"declare_existing_class"
+    | _ -> user_err
              (Pp.str"Unsupported class type, only constants and inductives are allowed")
 
 open Vernacexpr

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2130,7 +2130,7 @@ let vernac_check_guard ~pstate =
       let { Evd.it=gl ; sigma=sigma } = Proof.V82.top_goal pts in
       Inductiveops.control_only_guard (Goal.V82.env sigma gl) sigma pfterm;
       (str "The condition holds up to here")
-    with UserError(_,s) ->
+    with UserError s ->
       (str ("Condition violated: ") ++s)
   in message
 

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -469,7 +469,6 @@ let err_unmapped_library ?from qid =
     str " and prefix " ++ DirPath.print from ++ str "."
   in
   user_err ?loc:qid.CAst.loc
-    ~hdr:"locate_library"
     (strbrk "Cannot find a physical path bound to logical path matching suffix " ++
        DirPath.print dir ++ prefix)
 
@@ -481,7 +480,7 @@ let err_notfound_library ?from qid =
   in
   let bonus =
     if !Flags.load_vos_libraries then " (While searching for a .vos file.)" else "" in
-  user_err ?loc:qid.CAst.loc ~hdr:"locate_library"
+  user_err ?loc:qid.CAst.loc
      (strbrk "Unable to locate library " ++ pr_qualid qid ++ prefix ++ str bonus)
 
 let print_located_library qid =
@@ -567,7 +566,7 @@ let vernac_set_used_variables ~pstate using : Declare.Proof.t =
   let vars = Environ.named_context env in
   Names.Id.Set.iter (fun id ->
       if not (List.exists (NamedDecl.get_id %> Id.equal id) vars) then
-        user_err ~hdr:"vernac_set_used_variables"
+        user_err
           (str "Unknown variable: " ++ Id.print id))
     using;
   let _, pstate = Declare.Proof.set_used_variables pstate ~using in
@@ -821,7 +820,7 @@ let extract_inductive_udecl (indl:(inductive_expr * decl_notation list) list) =
   | (((coe,(id,udecl)),b,c,d),e) :: rest ->
     let rest = List.map (fun (((coe,(id,udecl)),b,c,d),e) ->
         if Option.has_some udecl
-        then user_err ~hdr:"inductive udecl" Pp.(strbrk "Universe binders must be on the first inductive of the block.")
+        then user_err Pp.(strbrk "Universe binders must be on the first inductive of the block.")
         else (((coe,id),b,c,d),e))
         rest
     in
@@ -1028,14 +1027,14 @@ let vernac_combined_scheme lid l =
 
 let vernac_universe ~poly l =
   if poly && not (Global.sections_are_opened ()) then
-    user_err ~hdr:"vernac_universe"
+    user_err
                  (str"Polymorphic universes can only be declared inside sections, " ++
                   str "use Monomorphic Universe instead");
   DeclareUniv.do_universe ~poly l
 
 let vernac_constraint ~poly l =
   if poly && not (Global.sections_are_opened ()) then
-    user_err ~hdr:"vernac_constraint"
+    user_err
                  (str"Polymorphic universe constraints can only be declared"
                   ++ str " inside sections, use Monomorphic Constraint instead");
   DeclareUniv.do_constraint ~poly l
@@ -1818,7 +1817,7 @@ let get_current_context_of_args ~pstate =
 let query_command_selector ?loc = function
   | None -> None
   | Some (Goal_select.SelectNth n) -> Some n
-  | _ -> user_err ?loc ~hdr:"query_command_selector"
+  | _ -> user_err ?loc
       (str "Query commands only support the single numbered goal selector.")
 
 let vernac_check_may_eval ~pstate redexp glopt rc =
@@ -1905,7 +1904,7 @@ let print_about_hyp_globs ~pstate ?loc ref_or_by_not udecl glopt =
       | Some n,AN qid when qualid_is_ident qid ->  (* goal number given, catch if wong *)
          (try get_nth_goal ~pstate n, qualid_basename qid
           with
-            Failure _ -> user_err ?loc ~hdr:"print_about_hyp_globs"
+            Failure _ -> user_err ?loc
                           (str "No such goal: " ++ int n ++ str "."))
       | _ , _ -> raise NoHyp in
     let hyps = Tacmach.pf_hyps gl in
@@ -2077,7 +2076,7 @@ let vernac_subproof gln ~pstate =
     | None -> Proof.focus subproof_cond () 1 p
     | Some (Goal_select.SelectNth n) -> Proof.focus subproof_cond () n p
     | Some (Goal_select.SelectId id) -> Proof.focus_id subproof_cond () id p
-    | _ -> user_err ~hdr:"bracket_selector"
+    | _ -> user_err
              (str "Brackets do not support multi-goal selectors."))
     pstate
 

--- a/vernac/vernacextend.ml
+++ b/vernac/vernacextend.ml
@@ -221,14 +221,14 @@ let vinterp_add depr s f =
   try
     Hashtbl.add vernac_tab s (depr, f)
   with Failure _ ->
-    user_err ~hdr:"vinterp_add"
+    user_err
       (str"Cannot add the vernac command " ++ str (fst s) ++ str" twice.")
 
 let vinterp_map s =
   try
     Hashtbl.find vernac_tab s
   with Failure _ | Not_found ->
-    user_err ~hdr:"Vernac Interpreter"
+    user_err
       (str"Cannot find vernac command " ++ str (fst s) ++ str".")
 
 let warn_deprecated_command =

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -82,7 +82,7 @@ let with_fail ~st f =
   Vernacstate.unfreeze_interp_state st;
   match res with
   | Error () ->
-    CErrors.user_err ~hdr:"Fail" (Pp.str "The command has not failed!")
+    CErrors.user_err (Pp.str "The command has not failed!")
   | Ok msg ->
     if not !Flags.quiet || !test_mode
     then Feedback.msg_notice Pp.(str "The command has indeed failed with message:" ++ fnl () ++ msg)


### PR DESCRIPTION
It was only used in coqchk -debug ie completely useless.

Note the 2 places where we did `try ... with UserError (Some "foo", _) -> ...` 
- tactics.ml for "move_hyp", the user_err was converted to a custom exception
- funind recdef.ml for "Refined.thensn_tac3" (can't find any user_err
  with this header) and "Refiner.tclFAIL_s" (raised by old engine
  tclTHENS, so this catch has been dead code since the port to the
  Tacticals.New).
  Conclusion: catch removed.

Overlays:
- https://github.com/maximedenes/vscoq/pull/1
- https://github.com/Mtac2/Mtac2/pull/346
- https://github.com/mattam82/Coq-Equations/pull/432
- https://github.com/lukaszcz/coqhammer/pull/111

Backwards compatible (uses only user_err, not UserError):
- https://github.com/coq-community/paramcoq/pull/83
- https://github.com/MetaCoq/metacoq/pull/591
- https://github.com/LPCIC/coq-elpi/pull/298
- https://github.com/coq/bignums/pull/61