### PR TITLE
CI: call git submodule in git_download instead of by hand

### DIFF
--- a/dev/ci/ci-argosy.sh
+++ b/dev/ci/ci-argosy.sh
@@ -5,10 +5,9 @@ set -e
 ci_dir="$(dirname "$0")"
 . "${ci_dir}/ci-common.sh"
 
-FORCE_GIT=1
+WITH_SUBMODULES=1
 git_download argosy
 
 ( cd "${CI_BUILD_DIR}/argosy"
-  git submodule update --init --recursive
   make
 )

--- a/dev/ci/ci-bedrock2.sh
+++ b/dev/ci/ci-bedrock2.sh
@@ -5,12 +5,11 @@ set -e
 ci_dir="$(dirname "$0")"
 . "${ci_dir}/ci-common.sh"
 
-FORCE_GIT=1
+WITH_SUBMODULES=1
 git_download bedrock2
 
 export COQEXTRAFLAGS='-native-compiler no'
 ( cd "${CI_BUILD_DIR}/bedrock2"
-  git submodule update --init --recursive
   COQMF_ARGS='-arg "-async-proofs-tac-j 1"' make
   make install
 )

--- a/dev/ci/ci-common.sh
+++ b/dev/ci/ci-common.sh
@@ -118,7 +118,7 @@ git_download()
 
   if [ -d "$dest" ]; then
     echo "Warning: download and unpacking of $project skipped because $dest already exists."
-  elif [[ $ov_url ]] || [ "$FORCE_GIT" = "1" ] || [ "$CI" = "" ]; then
+  elif [[ $ov_url ]] || [ "$WITH_SUBMODULES" = "1" ] || [ "$CI" = "" ]; then
     git clone "$giturl" "$dest"
     pushd "$dest"
     git checkout "$ref"
@@ -139,6 +139,9 @@ git_download()
             git rebase "$ref"
             git log -n 1
         fi
+    fi
+    if [ "$WITH_SUBMODULES" = 1 ]; then
+        git submodule update --init --recursive
     fi
     popd
   else # When possible, we download tarballs to reduce bandwidth and latency

--- a/dev/ci/ci-cross_crypto.sh
+++ b/dev/ci/ci-cross_crypto.sh
@@ -5,10 +5,9 @@ set -e
 ci_dir="$(dirname "$0")"
 . "${ci_dir}/ci-common.sh"
 
-FORCE_GIT=1
+WITH_SUBMODULES=1
 git_download cross_crypto
 
 ( cd "${CI_BUILD_DIR}/cross_crypto"
-  git submodule update --init --recursive
   make
 )

--- a/dev/ci/ci-fiat_crypto.sh
+++ b/dev/ci/ci-fiat_crypto.sh
@@ -5,7 +5,7 @@ set -e
 ci_dir="$(dirname "$0")"
 . "${ci_dir}/ci-common.sh"
 
-FORCE_GIT=1
+WITH_SUBMODULES=1
 git_download fiat_crypto
 
 # We need a larger stack size to not overflow ocamlopt+flambda when
@@ -19,7 +19,6 @@ stacksize=32768
 make_args=(EXTERNAL_REWRITER=1 EXTERNAL_COQPRIME=1)
 
 ( cd "${CI_BUILD_DIR}/fiat_crypto"
-  git submodule update --init --recursive
   ulimit -s $stacksize
   make "${make_args[@]}" pre-standalone-extracted printlite lite
   make -j 1 "${make_args[@]}" all-except-compiled

--- a/dev/ci/ci-fiat_crypto_legacy.sh
+++ b/dev/ci/ci-fiat_crypto_legacy.sh
@@ -5,7 +5,7 @@ set -e
 ci_dir="$(dirname "$0")"
 . "${ci_dir}/ci-common.sh"
 
-FORCE_GIT=1
+WITH_SUBMODULES=1
 git_download fiat_crypto_legacy
 
 targets1=(
@@ -24,7 +24,6 @@ targets2=(
 
 export COQEXTRAFLAGS='-native-compiler no'
 ( cd "${CI_BUILD_DIR}/fiat_crypto_legacy"
-  git submodule update --init --recursive
   make "${targets1[@]}"
   make -j 1 "${targets2[@]}"
 )

--- a/dev/ci/ci-fiat_parsers.sh
+++ b/dev/ci/ci-fiat_parsers.sh
@@ -5,7 +5,7 @@ set -e
 ci_dir="$(dirname "$0")"
 . "${ci_dir}/ci-common.sh"
 
-FORCE_GIT=1
+WITH_SUBMODULES=1
 git_download fiat_parsers
 
 ulimit -s

--- a/dev/ci/ci-perennial.sh
+++ b/dev/ci/ci-perennial.sh
@@ -5,13 +5,12 @@ set -e
 ci_dir="$(dirname "$0")"
 . "${ci_dir}/ci-common.sh"
 
-FORCE_GIT=1
+WITH_SUBMODULES=1
 git_download perennial
 
 ulimit -s
 ulimit -s 65536
 ulimit -s
 ( cd "${CI_BUILD_DIR}/perennial"
-  git submodule update --init --recursive
   make TIMED=false lite
 )


### PR DESCRIPTION
This avoids resetting submodules in the overlay workflow:
- make ci-foo
- edit some submodule
- make ci-foo (git submodule would reset changes)
