### PR TITLE
Further round of simplification of the Future API

### DIFF
--- a/dev/ci/user-overlays/15008-ppedrot-future-pure-shallow.sh
+++ b/dev/ci/user-overlays/15008-ppedrot-future-pure-shallow.sh
@@ -1,0 +1,1 @@
+overlay vscoq https://github.com/ppedrot/vscoq future-pure-shallow 15008

--- a/lib/stateid.ml
+++ b/lib/stateid.ml
@@ -36,8 +36,10 @@ end
 
 module Set = Set.Make(Self)
 
+type exn_info = { id : t; valid : t }
+
 type ('a,'b) request = {
-  exn_info : t * t;
+  exn_info : exn_info;
   stop : t;
   document : 'b;
   loc : Loc.t option;

--- a/lib/stateid.mli
+++ b/lib/stateid.mli
@@ -33,8 +33,10 @@ val newer_than : t -> t -> bool
 val add : Exninfo.info -> valid:t -> t -> Exninfo.info
 val get : Exninfo.info -> (t * t) option
 
+type exn_info = { id : t; valid : t }
+
 type ('a,'b) request = {
-  exn_info : t * t;
+  exn_info : exn_info;
   stop : t;
   document : 'b;
   loc : Loc.t option;

--- a/stm/partac.ml
+++ b/stm/partac.ml
@@ -144,7 +144,7 @@ let assign_tac ~abstract res : unit Proofview.tactic =
     tclUNIT ()
   else
     let open Notations in
-    match Future.join g_solution with
+    match Future.force g_solution with
     | Some (pt, uc) ->
         let push_state ctx =
             Proofview.tclEVARMAP >>= fun sigma ->

--- a/stm/partac.ml
+++ b/stm/partac.ml
@@ -164,7 +164,7 @@ let enable_par ~nworkers = ComTactic.set_par_implementation
     let results = (Proof.data p).Proof.goals |> CList.map_i (fun i g ->
       let g_solution, t_assign =
       Future.create_delegate ~name:(Printf.sprintf "goal %d" i)
-          (fun x -> x) in
+          None in
       TaskQueue.enqueue_task queue
       ~cancel_switch:(ref false)
       { t_state; t_assign; t_ast;

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -1561,7 +1561,7 @@ end = struct (* {{{ *)
       msg_warning Pp.(strbrk("Marshalling error: "^s^". "^
                              "The system state could not be sent to the worker process. "^
                              "Falling back to local, lazy, evaluation."));
-      t_assign(`Comp(Future.create ~fix_exn:None (fun () -> build_proof_here_fun ~doc:dummy_doc (* XXX should be stored in a closure, it is the same doc that was used to generate the task *) ?loc:t_loc ~drop_pt ~id:(fst t_exn_info) t_stop)));
+      t_assign(`Comp(fun () -> build_proof_here_fun ~doc:dummy_doc (* XXX should be stored in a closure, it is the same doc that was used to generate the task *) ?loc:t_loc ~drop_pt ~id:(fst t_exn_info) t_stop));
       feedback (InProgress ~-1)
 
 end (* }}} *)

--- a/vernac/future.ml
+++ b/vernac/future.ml
@@ -59,7 +59,7 @@ end
 module UUIDMap = Map.Make(UUID)
 module UUIDSet = Set.Make(UUID)
 
-type 'a assignment = [ `Val of 'a | `Exn of Exninfo.iexn | `Comp of 'a computation]
+type 'a assignment = [ `Val of 'a | `Exn of Exninfo.iexn | `Comp of (unit -> 'a)]
 
 (* Val is not necessarily a final state, so the
    computation restarts from the state stocked into Val *)
@@ -113,7 +113,7 @@ let create_delegate ?(blocking=true) ~name fix_exn =
     begin match v with
     | `Val v -> c := Val v
     | `Exn e -> c := Exn (eval_fix_exn fix_exn e)
-    | `Comp f -> let _, _, _, comp = get f in c := !comp end;
+    | `Comp f -> c := Closure f end;
     let iter (lock, cond) = CThread.with_lock lock ~scope:(fun () -> Condition.broadcast cond) in
     Option.iter iter sync
   in

--- a/vernac/future.ml
+++ b/vernac/future.ml
@@ -32,11 +32,11 @@ let _ = CErrors.register_handler (function
   | NotHere name -> Some (!not_here_msg name)
   | _ -> None)
 
-type fix_exn = (Stateid.t * Stateid.t) option
+type fix_exn = Stateid.exn_info option
 
 let eval_fix_exn f (e, info) = match f with
 | None -> (e, info)
-| Some (id, valid) ->
+| Some { Stateid.id; valid } ->
   match Stateid.get info with
   | Some _ -> (e, info)
   | None ->

--- a/vernac/future.ml
+++ b/vernac/future.ml
@@ -59,19 +59,15 @@ and 'a comp =
   | Val of 'a
   | Exn of Exninfo.iexn  (* Invariant: this exception is always "fixed" as in fix_exn *)
 
-and 'a comput =
+and 'a computation =
   | Ongoing of string * (UUID.t * fix_exn * 'a comp ref) CEphemeron.key
-  | Finished of 'a
-
-and 'a computation = 'a comput ref
 
 let unnamed = "unnamed"
 
 let create ?(name=unnamed) ?(uuid=UUID.fresh ()) ~fix_exn x =
-  ref (Ongoing (name, CEphemeron.create (uuid, fix_exn, ref x)))
+  Ongoing (name, CEphemeron.create (uuid, fix_exn, ref x))
 let get x =
-  match !x with
-  | Finished v -> unnamed, UUID.invalid, id, ref (Val v)
+  match x with
   | Ongoing (name, x) ->
       try let uuid, fix, c = CEphemeron.get x in name, uuid, fix, c
       with CEphemeron.InvalidKey ->
@@ -155,11 +151,6 @@ let chain x f =
   let y = chain x f in
   if is_over x then ignore(force y);
   y
-
-let join kx =
-  let v = force kx in
-  kx := Finished v;
-  v
 
 let print f kx =
   let open Pp in

--- a/vernac/future.mli
+++ b/vernac/future.mli
@@ -80,11 +80,6 @@ val chain : 'a computation -> ('a -> 'b) -> 'b computation
 val force : 'a computation -> 'a
 val compute : 'a computation -> 'a value
 
-(* Final call.
- * Also the fix_exn function is lost, hence error reporting can be incomplete
- * in a computation obtained by chaining on a joined future. *)
-val join : 'a computation -> 'a
-
 (** Debug: print a computation given an inner printing function. *)
 val print : ('a -> Pp.t) -> 'a computation -> Pp.t
 

--- a/vernac/future.mli
+++ b/vernac/future.mli
@@ -39,7 +39,9 @@ exception NotReady of string
 
 type 'a computation
 type 'a value = [ `Val of 'a | `Exn of Exninfo.iexn ]
-type fix_exn = Exninfo.iexn -> Exninfo.iexn
+
+(* First id is the current state, second id is the last valid state. *)
+type fix_exn = (Stateid.t * Stateid.t) option
 
 (* Build a computation, no snapshot of the global state is taken.  If you need
    to grab a copy of the state start with from_here () and then chain.

--- a/vernac/future.mli
+++ b/vernac/future.mli
@@ -40,8 +40,7 @@ exception NotReady of string
 type 'a computation
 type 'a value = [ `Val of 'a | `Exn of Exninfo.iexn ]
 
-(* First id is the current state, second id is the last valid state. *)
-type fix_exn = (Stateid.t * Stateid.t) option
+type fix_exn = Stateid.exn_info option
 
 (* Build a computation, no snapshot of the global state is taken.  If you need
    to grab a copy of the state start with from_here () and then chain.

--- a/vernac/future.mli
+++ b/vernac/future.mli
@@ -58,7 +58,7 @@ val from_val : 'a -> 'a computation
 (* Run remotely, returns the function to assign.
    If not blocking (the default) it raises NotReady if forced before the
    delegate assigns it. *)
-type 'a assignment = [ `Val of 'a | `Exn of Exninfo.iexn | `Comp of 'a computation]
+type 'a assignment = [ `Val of 'a | `Exn of Exninfo.iexn | `Comp of (unit -> 'a)]
 val create_delegate :
   ?blocking:bool -> name:string ->
   fix_exn -> 'a computation * ('a assignment -> unit)


### PR DESCRIPTION
This PR simplifies quite a bit the Future API and provides new invariants enforced by typing. Each commit message is pretty self-explanatory, but for the sake of completeness let us mention here the major changes.
- Future joining was removed and implemented locally in the opaque table module (the only place that needs it)
- Non-blocking futures (that were never used) have been removed
- The fix_exn type was defunctionalized
- The delegated future implementation was (internally) defunctionalized
- The `par:` implementation does not use futures anymore
- A couple of clean-ups.

Now we only have one call defining delayed futures and one call defining delegated futures in the STM. Very little code actually uses the future API which should make it even easier to turn this into something easy to reason about.

Overlays:
- https://github.com/maximedenes/vscoq/pull/2