### PR TITLE
Slightly more type-safe Library API for vio tasks.

### DIFF
--- a/stm/stm.mli
+++ b/stm/stm.mli
@@ -150,8 +150,10 @@ val snapshot_vio : create_vos:bool -> doc:doc -> output_native_objects:bool -> D
  * after having built a .vio in batch mode *)
 val reset_task_queue : unit -> unit
 
+type document
+
 (* A .vio contains tasks to be completed *)
-type tasks
+type tasks = (Opaqueproof.opaque_handle option, document) Library.tasks
 val check_task : string -> tasks -> int -> bool
 val info_tasks : tasks -> (string * float * int) list
 val finish_tasks : string ->
@@ -294,6 +296,5 @@ val get_all_proof_names : doc:doc -> Id.t list
 (** Enable STM debugging *)
 val stm_debug : bool ref
 
-type document
 val backup : unit -> document
 val restore : document -> unit

--- a/vernac/library.mli
+++ b/vernac/library.mli
@@ -41,10 +41,12 @@ type seg_proofs = Opaques.opaque_disk
     argument.
     [output_native_objects]: when producing vo objects, also compile the native-code version. *)
 
-type 'document todo_proofs =
+type ('uid, 'doc) tasks = (('uid, 'doc) Stateid.request * bool) list
+
+type 'doc todo_proofs =
  | ProofsTodoNone (* for .vo *)
  | ProofsTodoSomeEmpty of Future.UUIDSet.t (* for .vos *)
- | ProofsTodoSome of Future.UUIDSet.t * ((Future.UUID.t,'document) Stateid.request * bool) list (* for .vio *)
+ | ProofsTodoSome of Future.UUIDSet.t * (Future.UUID.t, 'doc) tasks (* for .vio *)
 
 val save_library_to :
   'document todo_proofs ->
@@ -53,7 +55,7 @@ val save_library_to :
 
 val load_library_todo
   :  CUnix.physical_path
-  -> seg_sum * seg_lib * seg_univ * 'tasks * seg_proofs
+  -> seg_sum * seg_lib * seg_univ * (Opaqueproof.opaque_handle option, 'doc) tasks * seg_proofs
 
 val save_library_raw : string -> seg_sum -> seg_lib -> seg_univ -> seg_proofs -> unit
 

--- a/vernac/opaques.ml
+++ b/vernac/opaques.ml
@@ -147,17 +147,17 @@ let dump ?(except=Future.UUIDSet.empty) () =
     else (Opaqueproof.repr_handle @@ fst @@ Opaqueproof.HandleMap.max_binding !current_opaques) + 1
   in
   let opaque_table = Array.make n None in
-  let fold i cu f2t_map = match cu with
+  let fold h cu f2t_map = match cu with
   | OpaqueValue p ->
-    let i = Opaqueproof.repr_handle i in
+    let i = Opaqueproof.repr_handle h in
     let () = opaque_table.(i) <- Some p in
     f2t_map
   | OpaqueCertif c ->
-    let i = Opaqueproof.repr_handle i in
+    let i = Opaqueproof.repr_handle h in
     let f2t_map, proof = match !c with
     | Computation cert ->
       let uid = Future.uuid cert in
-      let f2t_map = Future.UUIDMap.add uid i f2t_map in
+      let f2t_map = Future.UUIDMap.add uid h f2t_map in
       let c = Future.peek_val cert in
       let () = if Option.is_empty c && (not @@ Future.UUIDSet.mem uid except) then
         CErrors.anomaly

--- a/vernac/opaques.mli
+++ b/vernac/opaques.mli
@@ -21,7 +21,7 @@ val set_opaque_disk : Opaqueproof.opaque_handle -> Opaqueproof.opaque_proofterm 
 val get_current_opaque : Opaqueproof.opaque_handle -> Opaqueproof.opaque_proofterm option
 val get_current_constraints : Opaqueproof.opaque_handle -> Univ.ContextSet.t option
 
-val dump : ?except:Future.UUIDSet.t -> unit -> opaque_disk * int Future.UUIDMap.t
+val dump : ?except:Future.UUIDSet.t -> unit -> opaque_disk * Opaqueproof.opaque_handle Future.UUIDMap.t
 
 module Summary :
 sig


### PR DESCRIPTION
I got bitten enough times by this type-unsafe API to write this patch. The document type is still polymorphic in the marshalling API, but this shouldn't be too problematic since in practice there is only a single instance ever.

To further strengthen my claim, this actually captured the fact that we were silently converting between integers and opaque handles. Thankfully the underlying representations were the same but nothing was enforcing it.