### PR TITLE
Convert the tactics chapter to prodn

### DIFF
--- a/doc/sphinx/addendum/generalized-rewriting.rst
+++ b/doc/sphinx/addendum/generalized-rewriting.rst
@@ -569,8 +569,8 @@ pass additional arguments such as ``using relation``.
           setoid_symmetry {? in @ident }
           setoid_transitivity @one_term
           setoid_etransitivity
-          setoid_rewrite {? {| -> | <- } } @one_term {? with @bindings } {? at @rewrite_occs } {? in @ident }
-          setoid_rewrite {? {| -> | <- } } @one_term {? with @bindings } in @ident at @rewrite_occs
+          setoid_rewrite {? {| -> | <- } } @one_term_with_bindings {? at @rewrite_occs } {? in @ident }
+          setoid_rewrite {? {| -> | <- } } @one_term_with_bindings in @ident at @rewrite_occs
           setoid_replace @one_term with @one_term {? using relation @one_term } {? in @ident } {? at {+ @int_or_var } } {? by @ltac_expr3 }
    :name: setoid_reflexivity; setoid_symmetry; setoid_transitivity; setoid_etransitivity; setoid_rewrite; _; setoid_replace
 

--- a/doc/sphinx/changes.rst
+++ b/doc/sphinx/changes.rst
@@ -140,7 +140,7 @@ Tactics
 
 - **Changed:**
   The ``RewriteRelation`` type class is now used to declare relations
-  inferrable by the :tacn:`setoid_rewrite` tactic to construct
+  inferable by the :tacn:`setoid_rewrite` tactic to construct
   ``Proper`` instances. This can break developments that relied on
   existing ``Reflexive`` instances to infer relations. The fix is
   to simply add a (backwards compatible) ``RewriteRelation`` declaration
@@ -2698,7 +2698,8 @@ Tactics
 
 - **Changed:**
   In :tacn:`refine`, new existential variables unified with existing ones are no
-  longer considered as fresh. The behavior of :tacn:`simple refine` no longer depends on
+  longer considered as fresh. The behavior of :tacn:`simple refine <refine>` no
+  longer depends on
   the orientation of evar-evar unification problems, and new existential variables
   are always turned into (unshelved) goals. This can break compatibility in
   some cases (`#7825 <https://github.com/coq/coq/pull/7825>`_, by Matthieu
@@ -2742,7 +2743,7 @@ Tactics
   (As `lia` gets more powerful, this may break proof scripts relying on `lia` failure.)
   (`#11906 <https://github.com/coq/coq/pull/11906>`_,  by Frédéric Besson).
 - **Added:**
-  :tacn:`apply … in` supports several hypotheses
+  :tacn:`apply … in <apply>` supports several hypotheses
   (`#12246 <https://github.com/coq/coq/pull/12246>`_,
   by Hugo Herbelin; grants
   `#9816 <https://github.com/coq/coq/pull/9816>`_).

--- a/doc/sphinx/history.rst
+++ b/doc/sphinx/history.rst
@@ -1373,7 +1373,7 @@ Tactics
 - Equality tactics (Rewrite, Reflexivity, Symmetry, Transitivity) now
   understand JM equality
 - Simpl and Change now apply to subterms also
-- "Simpl f" reduces subterms whose head constant is f
+- "Simpl f" reduces subterms whose :term:`head constant` is f
 - Double Induction now referring to hypotheses like "Intros until"
 - "Inversion" now applies also on quantified hypotheses (naming as
   for Intros until)

--- a/doc/sphinx/language/cic.rst
+++ b/doc/sphinx/language/cic.rst
@@ -129,7 +129,8 @@ or a definition giving the type :math:`T` to :math:`x` in :math:`Γ`.
 If :math:`Γ` defines :math:`x:=t:T`, we also write :math:`(x:=t:T) ∈ Γ`.
 For the rest of the chapter, :math:`Γ::(y:T)` denotes the local context :math:`Γ`
 enriched with the local assumption :math:`y:T`. Similarly, :math:`Γ::(y:=t:T)` denotes
-the local context :math:`Γ` enriched with the local definition :math:`(y:=t:T)`. The
+the local context :math:`Γ` enriched with the :term:`local definition <context-local definition>`
+:math:`(y:=t:T)`. The
 notation :math:`[]` denotes the empty local context. Writing :math:`Γ_1 ; Γ_2` means
 concatenation of the local context :math:`Γ_1` and the local context :math:`Γ_2`.
 

--- a/doc/sphinx/language/coq-library.rst
+++ b/doc/sphinx/language/coq-library.rst
@@ -942,9 +942,6 @@ tactics (see Chapter :ref:`tactics`), there are also:
     Goal forall x y z:R, x * y * z <> 0.
     intros; split_Rmult.
 
-These tactics has been written with the tactic language |Ltac|
-described in Chapter :ref:`ltac`.
-
 List library
 ~~~~~~~~~~~~
 

--- a/doc/sphinx/language/core/assumptions.rst
+++ b/doc/sphinx/language/core/assumptions.rst
@@ -90,7 +90,9 @@ These terms are also useful:
 
 * `n : nat` is a :gdef:`dependent premise` of `forall n:nat, n + 0 = n` because
   `n` appears both in the binder of the `forall` and in the quantified statement
-  `n + 0 = n`.
+  `n + 0 = n`.  Note that if `n` isn't used in the statement, Coq considers it
+  a non-dependent premise.  Similarly, :n:`let n := ... in @term` is a
+  dependent premise only if `n` is used in :n:`@term`.
 
 * `A` and `B` are :gdef:`non-dependent premises <non-dependent premise>`
   (or, often, just ":gdef:`premises <premise>`") of `A -> B -> C` because they don't appear

--- a/doc/sphinx/language/core/sections.rst
+++ b/doc/sphinx/language/core/sections.rst
@@ -32,8 +32,8 @@ usable outside the section as shown in this :ref:`example <section_local_declara
    See :ref:`Terminating an interactive module or module type definition <terminating_module>`
    for a description of its use with modules.
 
-   After closing the
-   section, the local declarations (variables and local definitions, see :cmd:`Variable`) are
+   After closing the section, the section-local declarations (variables and
+   :gdef:`section-local definitions <section-local definition>`, see :cmd:`Variable`) are
    *discharged*, meaning that they stop being visible and that all global
    objects defined in the section are generalized with respect to the
    variables and local definitions they each depended on in the section.

--- a/doc/sphinx/language/extensions/match.rst
+++ b/doc/sphinx/language/extensions/match.rst
@@ -827,7 +827,7 @@ to build incomplete proofs beginning with a :g:`match` construction.
 Pattern-matching on inductive objects involving local definitions
 -----------------------------------------------------------------
 
-If local definitions occur in the type of a constructor, then there
+If local definitions (`let :=`) occur in the type of a constructor, then there
 are two ways to match on this constructor. Either the local
 definitions are skipped and matching is done only on the true
 arguments of the constructors, or the bindings for local definitions

--- a/doc/sphinx/proof-engine/ltac.rst
+++ b/doc/sphinx/proof-engine/ltac.rst
@@ -816,6 +816,9 @@ We can check if a tactic made progress with:
    .. exn:: Failed to progress.
       :undocumented:
 
+.. tacn:: progress_evars @ltac_expr
+   :undocumented:
+
 Success and failure
 -------------------
 

--- a/doc/sphinx/proof-engine/ssreflect-proof-language.rst
+++ b/doc/sphinx/proof-engine/ssreflect-proof-language.rst
@@ -3094,9 +3094,9 @@ A :token:`r_item` can be one of the following.
   other rewrite operations specified by the list of :token:`r_item`.
 + A *folding/unfolding* :token:`r_item`. The tactic
   ``rewrite /term`` unfolds the
-  head constant of ``term`` in every occurrence of the first matching of
+  :term:`head constant` of ``term`` in every occurrence of the first matching of
   ``term`` in the goal. In particular, if ``my_def`` is a (local or global)
-  defined constant, the tactic ``rewrite /my_def.`` is analogous to
+  defined constant, the tactic ``rewrite /my_def.`` is analogous to:
   ``unfold my_def``.
   Conversely, ``rewrite -/my_def.`` is equivalent to ``fold my_def``.
   When an unfold :token:`r_item` is combined with a
@@ -4446,7 +4446,7 @@ Contextual patterns in rewrite
 
      rewrite [_.+1 in X in f _ X](addnC x.+1).
 
-  The explicit redex ``_.+1`` is important, since its head constant ``S``
+  The explicit redex ``_.+1`` is important, since its :term:`head constant` ``S``
   differs from the head constant inferred from
   ``(addnC x.+1)`` (that is ``+``).
   Moreover, the pattern ``f _ X`` is important to rule out

--- a/doc/sphinx/proofs/automatic-tactics/logic.rst
+++ b/doc/sphinx/proofs/automatic-tactics/logic.rst
@@ -97,6 +97,9 @@ Solvers for logic and equality
       This :term:`flag` controls whether :tacn:`intuition` unfolds inner negations which do not need
       to be unfolded. It is on by default.
 
+.. tacn:: gintuition {? @ltac_expr }
+   :undocumented:
+
 .. tacn:: rtauto
 
    Solves propositional tautologies similarly to

--- a/doc/sphinx/proofs/writing-proofs/equality.rst
+++ b/doc/sphinx/proofs/writing-proofs/equality.rst
@@ -99,11 +99,10 @@ Rewriting with Leibniz and setoid equality
 
 .. tacn:: rewrite {+, @oriented_rewriter } {? @occurrences } {? by @ltac_expr3 }
 
-   .. insertprodn oriented_rewriter one_term_with_bindings
+   .. insertprodn oriented_rewriter oriented_rewriter
 
    .. prodn::
-      oriented_rewriter ::= {? {| -> | <- } } {? @natural } {? {| ? | ! } } @one_term_with_bindings
-      one_term_with_bindings ::= {? > } @one_term {? with @bindings }
+      oriented_rewriter ::= {? {| -> | <- } } {? @natural } {? {| ? | ! } } {? > } @one_term_with_bindings
 
    Replaces subterms with other subterms that have been proven to be equal.
    The type of :n:`@one_term` must have the form:
@@ -270,7 +269,7 @@ Rewriting with Leibniz and setoid equality
 
          Use :tacn:`replace` instead.
 
-.. tacn:: substitute {? {| -> | <- } } @one_term {? with @bindings }
+.. tacn:: substitute {? {| -> | <- } } @one_term_with_bindings
    :undocumented:
 
 .. tacn:: subst {* @ident }
@@ -282,8 +281,8 @@ Rewriting with Leibniz and setoid equality
    the first one is used.  If no :n:`@ident` is given, replacement is done for all
    hypotheses in the appropriate form in top to bottom order.
 
-   If :n:`@ident` is a local definition of the form :n:`@ident := @term`, it is also
-   unfolded and cleared.
+   If :n:`@ident` is a :term:`local definition <context-local definition>` of the form
+   :n:`@ident := @term`, it is also unfolded and cleared.
 
    If :n:`@ident` is a section variable it must have no
    indirect occurrences in the goal, i.e. no global declarations
@@ -311,8 +310,9 @@ Rewriting with Leibniz and setoid equality
         and :n:`@ident__2 = g @ident__1` which without the
         flag would be a cause of failure of :tacn:`subst`.
 
-      Additionally, it prevents a local definition such as :n:`@ident := t` from being
-      unfolded which otherwise it would exceptionally unfold in configurations
+      Additionally, it prevents a :term:`local definition <context-local definition>`
+      such as :n:`@ident := t` from being
+      unfolded which otherwise would exceptionally unfold in configurations
       containing hypotheses of the form :n:`@ident = u`, or :n:`u′ = @ident`
       with `u′` not a variable. Finally, it preserves the initial order of
       hypotheses, which without the flag it may break.
@@ -567,7 +567,7 @@ which reduction engine to use.  See :ref:`type-cast`.)  For example:
 
       A variant form of :tacn:`cbv`.
 
-   :opt:`Debug` ``"Cbv"`` makes :tacn:`cbv` (and its derivative :tacn:`compute`) print
+   Setting :opt:`Debug` ``"Cbv"`` makes :tacn:`cbv` (and its derivative :tacn:`compute`) print
    information about the constants it encounters and the unfolding decisions it
    makes.
 
@@ -619,7 +619,7 @@ which reduction engine to use.  See :ref:`type-cast`.)  For example:
    :tacn:`cbn` may unfold constants even when they cannot be reused in recursive calls:
    in the previous example, :g:`succ t` is reduced to :g:`S t`.
 
-   :opt:`Debug` ``"RAKAM"`` makes :tacn:`cbn` print various debugging information.
+   Setting :opt:`Debug` ``"RAKAM"`` makes :tacn:`cbn` print various debugging information.
    ``RAKAM`` is the Refolding Algebraic Krivine Abstract Machine.
 
 .. tacn:: hnf @simple_occurrences
@@ -640,17 +640,20 @@ which reduction engine to use.  See :ref:`type-cast`.)  For example:
 
 .. tacn:: red @simple_occurrences
 
-   βιζ-reduces the constant at the head of `T` (which may be called
-   the :gdef:`head constant`; :gdef:`head` means the beginning
-   of the term), if possible,
-   in the selected hypotheses and/or the goal, which must have the form:
+   βιζ-reduces the :term:`head constant` of `T`, if possible, in the selected
+   hypotheses and/or the goal which have the form:
 
-     :n:`{? forall @open_binders,} T`
+     :n:`{? forall @open_binders , } T`
 
    (where `T` does not begin with a `forall`) to :n:`c t__1 … t__n`
    where :g:`c` is a constant.
    If :g:`c` is transparent then it replaces :g:`c` with its
    definition and reduces again until no further reduction is possible.
+
+   In the term :n:`{? forall @open_binders , } t__1 ... t__n`, where :n:`t__1` is not a
+   :n:`term_application`, :n:`t__1` is the :gdef:`head` of the term.
+   In a term with the form :n:`{? forall @open_binders , } c t__1 ... t__n`, where
+   :n:`c` is a :term:`constant`, :n:`c` is the :gdef:`head constant`.
 
    .. exn:: No head constant to reduce.
       :undocumented:
@@ -665,8 +668,8 @@ which reduction engine to use.  See :ref:`type-cast`.)  For example:
 
    :n:`@reference_occs`
      If :n:`@reference` is a :n:`@qualid`, it must be a defined transparent
-     constant or local definition (see :ref:`gallina-definitions` and
-     :ref:`controlling-the-reduction-strategies`).
+     constant or :term:`local definition <context-local definition>`
+     (see :ref:`gallina-definitions` and :ref:`controlling-the-reduction-strategies`).
 
      If :n:`@reference` is a :n:`@string {? @scope_key}`, the :n:`@string` is
      the discriminating
@@ -783,6 +786,8 @@ which reduction engine to use.  See :ref:`type-cast`.)  For example:
 
    This tactic can be used, for instance, when the tactic :tacn:`apply` fails
    on matching or to better control the behavior of :tacn:`rewrite`.
+
+   See the example :ref:`here <example_apply_pattern>`.
 
 Fast reduction tactics: vm_compute and native_compute
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -988,7 +993,7 @@ which supports additional fine-tuning.
    constants, both at the tactic level and at the kernel level. This
    command associates a :n:`@strategy_level` with the qualified names in the :n:`@reference`
    sequence. Whenever two
-   expressions with two distinct head constants are compared (for
+   expressions with two distinct :term:`head constants <head constant>` are compared (for
    example, typechecking `f x` where `f : A -> B` and `x : C` will result in
    converting `A` and `C`), the one
    with lower level is expanded first. In case of a tie, the second one

--- a/doc/sphinx/proofs/writing-proofs/proof-mode.rst
+++ b/doc/sphinx/proofs/writing-proofs/proof-mode.rst
@@ -82,8 +82,9 @@ tactic to specific goals.  The local context is only shown for the first goal.
 
    split.
 
-"Variables" may refer specifically to local context items for which the type of their type
-is `Set` or `Type`, and :gdef:`"hypotheses" <hypothesis>` refers to items that are
+:gdef:`"Variables" <variable>` may refer specifically to local context items introduced
+from :n:`forall` variables for which the type of their type
+is `Set` or `Type`. :gdef:`"Hypotheses" <hypothesis>` refers to items that are
 :term:`propositions <proposition>`,
 for which the type of their type is `Prop` or `SProp`,
 but these terms are also used interchangeably.
@@ -1213,6 +1214,8 @@ Delaying solving unification constraints
    problems are resolved using heuristics. Unsetting this :term:`flag` disables this
    behavior, allowing tactics to leave unification constraints unsolved. Use the
    :tacn:`solve_constraints` tactic at any point to solve the constraints.
+
+.. _proof-maintenance:
 
 Proof maintenance
 -----------------

--- a/doc/sphinx/proofs/writing-proofs/reasoning-inductives.rst
+++ b/doc/sphinx/proofs/writing-proofs/reasoning-inductives.rst
@@ -126,7 +126,7 @@ analysis on inductive or coinductive objects (see :ref:`variants`).
 
    .. prodn::
       induction_clause ::= @induction_arg {? as @or_and_intropattern } {? eqn : @naming_intropattern } {? @occurrences }
-      induction_arg ::= @one_term_with_bindings
+      induction_arg ::= {? > } @one_term_with_bindings
       | @natural
 
    Performs case analysis by generating a subgoal for each constructor of the
@@ -146,7 +146,7 @@ analysis on inductive or coinductive objects (see :ref:`variants`).
      + If :n:`@one_term` (in :n:`@one_term_with_bindings`)
        is an identifier :n:`@ident`:
 
-       + If :n:`@ident` denotes a quantified variable of the
+       + If :n:`@ident` denotes a :n:`forall` variable in the
          goal, then :n:`destruct @ident` behaves like
          :tacn:`intros` :n:`until @ident; destruct @ident`.
 
@@ -214,8 +214,8 @@ analysis on inductive or coinductive objects (see :ref:`variants`).
    .. tacn:: edestruct {+, @induction_clause } {? @induction_principle }
 
       If the type of :n:`@one_term` (in :n:`@induction_arg`) has
-      :term:`dependent premises <dependent premise>` or dependent premises
-      whose values are not inferrable from the :n:`with @bindings` clause,
+      :term:`dependent premises <dependent premise>`
+      whose values can't be inferred from the :n:`with @bindings` clause,
       :n:`edestruct` turns them into existential variables to be resolved later on.
 
 .. tacn:: case {+, @induction_clause } {? @induction_principle }
@@ -227,8 +227,8 @@ analysis on inductive or coinductive objects (see :ref:`variants`).
    .. tacn:: ecase {+, @induction_clause } {? @induction_principle }
 
       If the type of :n:`@one_term` (in :n:`@induction_arg`) has
-      :term:`dependent premises <dependent premise>` or dependent premises
-      whose values are not inferrable from the :n:`with @bindings` clause,
+      :term:`dependent premises <dependent premise>`
+      whose values can't be inferred from the :n:`with @bindings` clause,
       :n:`ecase` turns them into existential variables to be resolved later on.
 
    .. tacn:: case_eq @one_term
@@ -245,7 +245,7 @@ analysis on inductive or coinductive objects (see :ref:`variants`).
 .. tacn:: simple destruct {| @ident | @natural }
 
    Equivalent to :tacn:`intros` :n:`until {| @ident | @natural }; case @ident`
-   where :n:`@ident` is a quantified variable of the goal and otherwise fails.
+   where :n:`@ident` is a :n:`forall` variable in the goal and otherwise fails.
 
 .. tacn:: dependent destruction @ident {? generalizing {+ @ident } } {? using @one_term }
    :undocumented:
@@ -261,7 +261,7 @@ Induction
    .. insertprodn induction_principle induction_principle
 
    .. prodn::
-      induction_principle ::= using @one_term {? with @bindings } {? @occurrences }
+      induction_principle ::= using @one_term_with_bindings {? @occurrences }
 
    Applies an :term:`induction principle` to generate a subgoal for
    each constructor of an inductive type.
@@ -342,11 +342,11 @@ Induction
    .. tacn:: einduction {+, @induction_clause } {? @induction_principle }
 
       Behaves like :tacn:`induction` except that it does not fail if
-      some dependent premise of the type of :n:`@one_term` is not inferrable. Instead,
+      some :term:`dependent premise` of the type of :n:`@one_term` can't be inferred. Instead,
       the unresolved premises are posed as existential variables to be inferred
       later, in the same way as :tacn:`eapply` does.
 
-.. tacn:: elim @one_term_with_bindings {? using @one_term {? with @bindings } }
+.. tacn:: elim {? > } @one_term_with_bindings {? using @one_term_with_bindings }
 
    An older, more basic induction tactic.  Unlike :tacn:`induction`, ``elim`` only
    modifies the goal; it does not modify the :term:`local context`.  We recommend
@@ -356,13 +356,13 @@ Induction
      Explicitly gives instances to the premises of the type of :n:`@one_term`
      (see :ref:`bindings`).
 
-   :n:`{? using @one_term {? with @bindings } }`
+   :n:`{? using @one_term_with_bindings }`
      Allows explicitly giving an induction principle :n:`@one_term` that
      is not the standard one for the underlying inductive type of :n:`@one_term`. The
      :n:`@bindings` clause allows instantiating premises of the type of
      :n:`@one_term`.
 
-   .. tacn:: eelim @one_term_with_bindings {? using @one_term {? with @bindings } }
+   .. tacn:: eelim {? > } @one_term_with_bindings {? using @one_term_with_bindings }
 
       If the type of :n:`@one_term` has dependent premises, this turns them into
       existential variables to be resolved later on.
@@ -379,7 +379,7 @@ Induction
 .. tacn:: simple induction {| @ident | @natural }
 
    Behaves like :n:`intros until {| @ident | @natural }; elim @ident` when
-   :n:`@ident` is a quantified variable of the goal.
+   :n:`@ident` is a :n:`forall` variable in the goal.
 
 .. tacn:: dependent induction @ident {? {| generalizing | in } {+ @ident } } {? using @one_term }
 

--- a/doc/sphinx/using/libraries/funind.rst
+++ b/doc/sphinx/using/libraries/funind.rst
@@ -169,7 +169,7 @@ terminating functions.
 Tactics
 -------
 
-.. tacn:: functional induction @term {? using @one_term {? with @bindings } } {? as @simple_intropattern }
+.. tacn:: functional induction @term {? using @one_term_with_bindings } {? as @simple_intropattern }
 
    Performs case analysis and induction following the definition of a function
    :token:`qualid`, which must be fully applied to its arguments as part of
@@ -219,7 +219,7 @@ Tactics
    .. exn:: Not the right number of induction arguments.
       :undocumented:
 
-.. tacn:: soft functional induction {+ @one_term } {? using @one_term {? with @bindings } } {? as @simple_intropattern }
+.. tacn:: soft functional induction {+ @one_term } {? using @one_term_with_bindings } {? as @simple_intropattern }
    :undocumented:
 
 .. tacn:: functional inversion {| @ident | @natural } {? @qualid }

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -979,6 +979,8 @@ simple_occurrences: [
 ]
 
 simple_tactic: [
+| DELETE "assert" "(" identref ":=" lconstr ")"
+| DELETE "eassert" "(" identref ":=" lconstr ")"
 | DELETE "autorewrite" "with" LIST1 preident clause
 | DELETE "autorewrite" "with" LIST1 preident clause "using" tactic
 | DELETE "autorewrite" "*" "with" LIST1 preident clause
@@ -1002,6 +1004,10 @@ simple_tactic: [
 | WITH "cbn" strategy_flag simple_occurrences
 | REPLACE "fold" LIST1 constr clause_dft_concl
 | WITH "fold" LIST1 constr simple_occurrences
+| DELETE "clear" LIST0 hyp
+| DELETE "clear" natural
+| REPLACE "clear" "-" LIST1 hyp
+| WITH "clear" [ OPT ( OPT "-" LIST1 hyp ) | natural ]
 | DELETE "cofix" ident
 | REPLACE "cofix" ident "with" LIST1 cofixdecl
 | WITH "cofix" ident OPT ( "with" LIST1 cofixdecl )
@@ -1045,6 +1051,9 @@ simple_tactic: [
 | REPLACE "einjection" destruction_arg "as" LIST0 simple_intropattern
 | WITH "einjection" OPT destruction_arg OPT ( "as" LIST0 simple_intropattern )
 | EDIT "simple" "injection" ADD_OPT destruction_arg
+| REPLACE "instantiate" "(" ident ":=" lglob ")"
+| WITH "instantiate" OPT ( "(" ident ":=" lglob ")" )
+| DELETE "instantiate"
 | DELETE "intro"  (* todo: change the mlg to simplify! *)
 | DELETE "intro" ident
 | DELETE "intro" ident "at" "top"
@@ -1066,7 +1075,12 @@ simple_tactic: [
 | DELETE "move" hyp "at" "bottom"
 | DELETE "move" hyp "after" hyp
 | DELETE "move" hyp "before" hyp
-| "move" ident OPT where
+| "move" ident where
+| REPLACE "refine" uconstr
+| WITH OPT "simple" OPT "notypeclasses" "refine" uconstr
+| DELETE "simple" "refine" uconstr
+| DELETE "notypeclasses" "refine" uconstr
+| DELETE "simple" "notypeclasses" "refine" uconstr
 | DELETE "replace" "->" uconstr clause
 | DELETE "replace" "<-" uconstr clause
 | DELETE "replace" uconstr clause
@@ -1854,6 +1868,7 @@ document: [
 (* add in ltac and Tactic Notation tactics that appear in the doc: *)
 ltac_defined_tactics: [
 | "case_eq" constr
+(* | "case_eq" induction_clause_list ??? *)
 | "classical_left"
 | "classical_right"
 | "contradict" ident
@@ -1867,6 +1882,7 @@ ltac_defined_tactics: [
 | "now_show" constr
 | "nra"
 | "over"  TAG SSR
+| "rapply" constr
 | "split_Rabs"
 | "split_Rmult"
 | "tauto"
@@ -1889,6 +1905,7 @@ tactic_notation_tactics: [
 | "now" ltac_expr5
 | "nsatz" OPT ( "with" "radicalmax" ":=" constr "strategy" ":=" constr "parameters" ":=" constr "variables" ":=" constr )
 | "psatz" constr OPT nat_or_var
+| "revert" "dependent" hyp
 | "ring" OPT ( "[" LIST1 constr "]" )
 | "ring_simplify" OPT ( "[" LIST1 constr "]" ) LIST1 constr OPT ( "in" ident )  (* todo: ident was "hyp", worth keeping? *)
 ]
@@ -2755,7 +2772,6 @@ SPLICE: [
 | fun_ind_using
 | with_names
 | eauto_search_strategy_name
-| constr_with_bindings
 | simple_binding
 | ssexpr35 (* strange in mlg, ssexpr50 is after this *)
 | number_string_mapping
@@ -2786,6 +2802,7 @@ SPLICE: [
 | induction_clause_list
 | as_or_and_ipat
 | singleton_class_definition
+| constr_with_bindings_arg
 ] (* end SPLICE *)
 
 RENAME: [
@@ -2843,7 +2860,7 @@ RENAME: [
 | pattern_occ pattern_occs
 | hypident_occ hyp_occs
 | concl_occ concl_occs
-| constr_with_bindings_arg one_term_with_bindings
+| constr_with_bindings one_term_with_bindings
 | red_flag reduction
 | strategy_flag reductions
 | delta_flag delta_reductions

--- a/doc/tools/docgram/doc_grammar.ml
+++ b/doc/tools/docgram/doc_grammar.ml
@@ -1737,7 +1737,7 @@ let process_rst g file args seen tac_prods cmd_prods =
 
   let cmd_exclude_files = [
     "doc/sphinx/proof-engine/ssreflect-proof-language.rst";
-    "doc/sphinx/proof-engine/tactics.rst";
+    "doc/sphinx/proof-engine/tactics.rst"; (* soon, but not yet *)
   ]
   in
 

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -299,8 +299,8 @@ ssr_one_term_pattern: [
 where: [
 | "at" "top"
 | "at" "bottom"
-| "after" ident
 | "before" ident
+| "after" ident
 ]
 
 add_zify: [
@@ -1605,7 +1605,7 @@ simple_tactic: [
 | "eright" OPT ( "with" bindings )
 | "constructor" OPT nat_or_var OPT ( "with" bindings )
 | "econstructor" OPT ( nat_or_var OPT ( "with" bindings ) )
-| "specialize" one_term OPT ( "with" bindings ) OPT ( "as" simple_intropattern )
+| "specialize" one_term_with_bindings OPT ( "as" simple_intropattern )
 | "symmetry" OPT simple_occurrences
 | "split" OPT ( "with" bindings )
 | "esplit" OPT ( "with" bindings )
@@ -1613,17 +1613,14 @@ simple_tactic: [
 | "eexists" LIST0 bindings SEP ","
 | "intros" "until" [ ident | natural ]
 | "intro" OPT ident OPT where
-| "move" ident OPT where
+| "move" ident where
 | "rename" LIST1 ( ident "into" ident ) SEP ","
 | "revert" LIST1 ident
 | "simple" "induction" [ ident | natural ]
 | "simple" "destruct" [ ident | natural ]
 | "admit"
-| "clear" LIST0 ident
-| "clear" "-" LIST1 ident
+| "clear" [ OPT ( OPT "-" LIST1 ident ) | natural ]
 | "clearbody" LIST1 ident
-| "generalize" "dependent" one_term
-| "replace" one_term "with" one_term OPT occurrences OPT ( "by" ltac_expr3 )
 | "simplify_eq" OPT induction_arg
 | "esimplify_eq" OPT induction_arg
 | "discriminate" OPT induction_arg
@@ -1677,22 +1674,18 @@ simple_tactic: [
 | "decompose" "sum" one_term
 | "decompose" "record" one_term
 | "absurd" one_term
-| "contradiction" OPT ( one_term OPT ( "with" bindings ) )
+| "contradiction" OPT one_term_with_bindings
 | "autorewrite" OPT "*" "with" LIST1 ident OPT occurrences OPT ( "using" ltac_expr )
 | "rewrite" "*" OPT [ "->" | "<-" ] one_term OPT ( "in" ident ) OPT ( "at" rewrite_occs ) OPT ( "by" ltac_expr3 )
 | "rewrite" "*" OPT [ "->" | "<-" ] one_term "at" rewrite_occs "in" ident OPT ( "by" ltac_expr3 )
-| "refine" one_term
-| "simple" "refine" one_term
-| "notypeclasses" "refine" one_term
-| "simple" "notypeclasses" "refine" one_term
+| OPT "simple" OPT "notypeclasses" "refine" one_term
 | "solve_constraints"
 | "subst" LIST0 ident
 | "simple" "subst"
 | "evar" "(" ident ":" term ")"
 | "evar" one_term
-| "instantiate" "(" ident ":=" term ")"
+| "instantiate" OPT ( "(" ident ":=" term ")" )
 | "instantiate" "(" integer ":=" term ")" OPT hloc
-| "instantiate"
 | "stepl" one_term OPT ( "by" ltac_expr )
 | "stepr" one_term OPT ( "by" ltac_expr )
 | "generalize_eqs" ident
@@ -1757,9 +1750,9 @@ simple_tactic: [
 | "progress_evars" ltac_expr
 | "rewrite_strat" rewstrategy OPT ( "in" ident )
 | "rewrite_db" ident OPT ( "in" ident )
-| "substitute" OPT [ "->" | "<-" ] one_term OPT ( "with" bindings )
-| "setoid_rewrite" OPT [ "->" | "<-" ] one_term OPT ( "with" bindings ) OPT ( "at" rewrite_occs ) OPT ( "in" ident )
-| "setoid_rewrite" OPT [ "->" | "<-" ] one_term OPT ( "with" bindings ) "in" ident "at" rewrite_occs
+| "substitute" OPT [ "->" | "<-" ] one_term_with_bindings
+| "setoid_rewrite" OPT [ "->" | "<-" ] one_term_with_bindings OPT ( "at" rewrite_occs ) OPT ( "in" ident )
+| "setoid_rewrite" OPT [ "->" | "<-" ] one_term_with_bindings "in" ident "at" rewrite_occs
 | "setoid_symmetry" OPT ( "in" ident )
 | "setoid_reflexivity"
 | "setoid_transitivity" one_term
@@ -1768,12 +1761,12 @@ simple_tactic: [
 | "eintros" LIST0 intropattern
 | "decide" "equality"
 | "compare" one_term one_term
-| "apply" LIST1 one_term_with_bindings SEP "," OPT in_hyp_as
-| "eapply" LIST1 one_term_with_bindings SEP "," OPT in_hyp_as
-| "simple" "apply" LIST1 one_term_with_bindings SEP "," OPT in_hyp_as
-| "simple" "eapply" LIST1 one_term_with_bindings SEP "," OPT in_hyp_as
-| "elim" one_term_with_bindings OPT ( "using" one_term OPT ( "with" bindings ) )
-| "eelim" one_term_with_bindings OPT ( "using" one_term OPT ( "with" bindings ) )
+| "apply" LIST1 ( OPT ">" one_term_with_bindings ) SEP "," OPT in_hyp_as
+| "eapply" LIST1 ( OPT ">" one_term_with_bindings ) SEP "," OPT in_hyp_as
+| "simple" "apply" LIST1 ( OPT ">" one_term_with_bindings ) SEP "," OPT in_hyp_as
+| "simple" "eapply" LIST1 ( OPT ">" one_term_with_bindings ) SEP "," OPT in_hyp_as
+| "elim" OPT ">" one_term_with_bindings OPT ( "using" one_term_with_bindings )
+| "eelim" OPT ">" one_term_with_bindings OPT ( "using" one_term_with_bindings )
 | "case" LIST1 induction_clause SEP "," OPT induction_principle
 | "ecase" LIST1 induction_clause SEP "," OPT induction_principle
 | "fix" ident natural OPT ( "with" LIST1 ( "(" ident LIST0 simple_binder OPT ( "{" "struct" name "}" ) ":" type ")" ) )
@@ -1782,26 +1775,26 @@ simple_tactic: [
 | "pose" one_term OPT as_name
 | "epose" bindings_with_parameters
 | "epose" one_term OPT as_name
+| "pose" "proof" "(" ident ":=" term ")"
+| "pose" "proof" term OPT as_ipat
+| "epose" "proof" "(" ident ":=" term ")"
+| "epose" "proof" term OPT as_ipat
 | "set" bindings_with_parameters OPT occurrences
 | "set" one_term OPT as_name OPT occurrences
 | "eset" bindings_with_parameters OPT occurrences
 | "eset" one_term OPT as_name OPT occurrences
 | "remember" one_term OPT as_name OPT ( "eqn" ":" naming_intropattern ) OPT ( "in" goal_occurrences )
 | "eremember" one_term OPT as_name OPT ( "eqn" ":" naming_intropattern ) OPT ( "in" goal_occurrences )
-| "assert" "(" ident ":=" term ")"
-| "eassert" "(" ident ":=" term ")"
 | "assert" "(" ident ":" term ")" OPT ( "by" ltac_expr3 )
+| "assert" one_term OPT as_ipat OPT ( "by" ltac_expr3 )
 | "eassert" "(" ident ":" term ")" OPT ( "by" ltac_expr3 )
+| "eassert" one_term OPT as_ipat OPT ( "by" ltac_expr3 )
 | "enough" "(" ident ":" term ")" OPT ( "by" ltac_expr3 )
 | "eenough" "(" ident ":" term ")" OPT ( "by" ltac_expr3 )
-| "assert" one_term OPT as_ipat OPT ( "by" ltac_expr3 )
-| "eassert" one_term OPT as_ipat OPT ( "by" ltac_expr3 )
-| "pose" "proof" "(" ident ":=" term ")"
-| "epose" "proof" "(" ident ":=" term ")"
-| "pose" "proof" term OPT as_ipat
-| "epose" "proof" term OPT as_ipat
 | "enough" one_term OPT as_ipat OPT ( "by" ltac_expr3 )
 | "eenough" one_term OPT as_ipat OPT ( "by" ltac_expr3 )
+| "generalize" "dependent" one_term
+| "replace" one_term "with" one_term OPT occurrences OPT ( "by" ltac_expr3 )
 | "generalize" one_term OPT ( LIST1 one_term )
 | "generalize" one_term OPT ( "at" occs_nums ) OPT as_name LIST0 [ "," pattern_occs OPT as_name ]
 | "induction" LIST1 induction_clause SEP "," OPT induction_principle
@@ -1836,8 +1829,8 @@ simple_tactic: [
 | "firstorder" OPT ltac_expr OPT ( "using" LIST1 qualid SEP "," ) OPT ( "with" LIST1 ident )
 | "gintuition" OPT ltac_expr
 | "functional" "inversion" [ ident | natural ] OPT qualid      (* funind plugin *)
-| "functional" "induction" term OPT ( "using" one_term OPT ( "with" bindings ) ) OPT ( "as" simple_intropattern )      (* funind plugin *)
-| "soft" "functional" "induction" LIST1 one_term OPT ( "using" one_term OPT ( "with" bindings ) ) OPT ( "as" simple_intropattern )      (* funind plugin *)
+| "functional" "induction" term OPT ( "using" one_term_with_bindings ) OPT ( "as" simple_intropattern )      (* funind plugin *)
+| "soft" "functional" "induction" LIST1 one_term OPT ( "using" one_term_with_bindings ) OPT ( "as" simple_intropattern )      (* funind plugin *)
 | "xlra_Q" ltac_expr      (* micromega plugin *)
 | "wlra_Q" ident one_term      (* micromega plugin *)
 | "xlra_R" ltac_expr      (* micromega plugin *)
@@ -1870,7 +1863,6 @@ simple_tactic: [
 | "ring_lookup" ltac_expr0 "[" LIST0 one_term "]" LIST1 one_term      (* ring plugin *)
 | "field_lookup" ltac_expr "[" LIST0 one_term "]" LIST1 one_term      (* ring plugin *)
 | "by" ssrhintarg      (* SSR plugin *)
-| "clear" natural      (* SSR plugin *)
 | "move" OPT ( OPT ssrarg [ "->" | "<-" ] )      (* SSR plugin *)
 | "move" ssrarg OPT ssr_in      (* SSR plugin *)
 | "case" OPT ( ssrarg OPT ssr_in )      (* SSR plugin *)
@@ -1920,6 +1912,7 @@ simple_tactic: [
 | "now_show" one_term
 | "nra"
 | "over"      (* SSR plugin *)
+| "rapply" one_term
 | "split_Rabs"
 | "split_Rmult"
 | "tauto"
@@ -1936,6 +1929,7 @@ simple_tactic: [
 | "now" ltac_expr
 | "nsatz" OPT ( "with" "radicalmax" ":=" one_term "strategy" ":=" one_term "parameters" ":=" one_term "variables" ":=" one_term )
 | "psatz" one_term OPT nat_or_var
+| "revert" "dependent" ident
 | "ring" OPT ( "[" LIST1 one_term "]" )
 | "ring_simplify" OPT ( "[" LIST1 one_term "]" ) LIST1 one_term OPT ( "in" ident )
 | "match" ltac2_expr5 "with" OPT ltac2_branches "end"
@@ -1950,6 +1944,10 @@ hloc: [
 | "in" "(" "value" "of" ident ")"
 ]
 
+in_hyp_as: [
+| "in" LIST1 [ ident OPT as_ipat ] SEP ","
+]
+
 as_ipat: [
 | "as" simple_intropattern
 ]
@@ -1959,11 +1957,7 @@ as_name: [
 ]
 
 oriented_rewriter: [
-| OPT [ "->" | "<-" ] OPT natural OPT [ "?" | "!" ] one_term_with_bindings
-]
-
-one_term_with_bindings: [
-| OPT ">" one_term OPT ( "with" bindings )
+| OPT [ "->" | "<-" ] OPT natural OPT [ "?" | "!" ] OPT ">" one_term_with_bindings
 ]
 
 induction_clause: [
@@ -1971,12 +1965,12 @@ induction_clause: [
 ]
 
 induction_arg: [
-| one_term_with_bindings
+| OPT ">" one_term_with_bindings
 | natural
 ]
 
 induction_principle: [
-| "using" one_term OPT ( "with" bindings ) OPT occurrences
+| "using" one_term_with_bindings OPT occurrences
 ]
 
 auto_using: [
@@ -2023,9 +2017,13 @@ equality_intropattern: [
 | "[=" LIST0 intropattern "]"
 ]
 
+one_term_with_bindings: [
+| one_term OPT ( "with" bindings )
+]
+
 bindings: [
-| LIST1 ( "(" [ ident | natural ] ":=" term ")" )
 | LIST1 one_term
+| LIST1 ( "(" [ ident | natural ] ":=" term ")" )
 ]
 
 int_or_var: [
@@ -2042,6 +2040,11 @@ comparison: [
 
 bindings_with_parameters: [
 | "(" ident LIST0 simple_binder ":=" term ")"
+]
+
+simple_binder: [
+| name
+| "(" LIST1 name ":" term ")"
 ]
 
 q_clause: [
@@ -2419,15 +2422,6 @@ tac2mode: [
 | "SearchPattern" one_pattern OPT ( [ "inside" | "in" | "outside" ] LIST1 qualid )
 | "SearchRewrite" one_pattern OPT ( [ "inside" | "in" | "outside" ] LIST1 qualid )
 | "Search" LIST1 ( search_query ) OPT ( [ "inside" | "in" | "outside" ] LIST1 qualid )
-]
-
-in_hyp_as: [
-| "in" LIST1 [ ident OPT as_ipat ] SEP ","
-]
-
-simple_binder: [
-| name
-| "(" LIST1 name ":" term ")"
 ]
 
 func_scheme_def: [


### PR DESCRIPTION
Update syntax and descriptions in the tactics chapter.

Done: ~~Still tons of updating I have to do, but perhaps you would be willing to suggest how to reorganize the "Semantics" subsection in the ltac chapter?  Having 30 or so items under "Semantics" is silly.  I'd think about creating 4-5 new categories to replace "Semantics".  Perhaps, "Control Structures" (repeat, if, ...) and "Handling tactic failures" are reasonable categories.  I could give it shot, but why should I have all the fun?~~

~~Perhaps @JasonGross has some good ideas.~~