### PR TITLE
Stop using dune private modules

### DIFF
--- a/boot/dune
+++ b/boot/dune
@@ -4,5 +4,6 @@
  (name boot)
  (public_name coq-core.boot)
  (synopsis "Coq Enviroment and Paths facilities")
- (private_modules util)
+ ; until ocaml/dune#4892 fixed
+ ; (private_modules util)
  (libraries coq-core.config))

--- a/engine/dune
+++ b/engine/dune
@@ -3,5 +3,6 @@
  (synopsis "Coq's Tactic Engine")
  (public_name coq-core.engine)
  (wrapped false)
- (private_modules univSubst)
+ ; until ocaml/dune#4892 fixed
+ ; (private_modules univSubst)
  (libraries library))

--- a/stm/dune
+++ b/stm/dune
@@ -3,5 +3,6 @@
  (synopsis "Coq's Document Manager and Proof Checking Scheduler")
  (public_name coq-core.stm)
  (wrapped false)
- (private_modules dag proofBlockDelimiter tQueue vcs workerPool)
+ ; until ocaml/dune#4892 fixed
+ ; (private_modules dag proofBlockDelimiter tQueue vcs workerPool)
  (libraries sysinit))

--- a/tactics/dune
+++ b/tactics/dune
@@ -3,5 +3,6 @@
  (synopsis "Coq's Core Tactics [ML implementation]")
  (public_name coq-core.tactics)
  (wrapped false)
- (private_modules btermdn dnet dn term_dnet)
+ ; until ocaml/dune#4892 fixed
+ ; (private_modules btermdn dnet dn term_dnet)
  (libraries printing))

--- a/toplevel/dune
+++ b/toplevel/dune
@@ -3,8 +3,10 @@
  (public_name coq-core.toplevel)
  (synopsis "Coq's Interactive Shell [terminal-based]")
  (wrapped false)
- (private_modules g_toplevel)
+ ; until ocaml/dune#4892 fixed
+ ; (private_modules g_toplevel)
  (libraries coq-core.stm))
+
 ; Interp provides the `zarith` library to plugins, we could also use
 ; -linkall in the plugins file, to be discussed.
 

--- a/vernac/dune
+++ b/vernac/dune
@@ -3,7 +3,8 @@
  (synopsis "Coq's Vernacular Language")
  (public_name coq-core.vernac)
  (wrapped false)
- (private_modules comProgramFixpoint egramcoq)
+ ; until ocaml/dune#4892 fixed
+ ; (private_modules comProgramFixpoint egramcoq)
  (libraries tactics parsing))
 
 (coq.pp (modules g_proofs g_vernac))


### PR DESCRIPTION
They break merlin locate (see ocaml/dune#4892) which is an extremely
terrible experience.
