### PR TITLE
Do not perform type-checking feedback from the kernel.

### DIFF
--- a/kernel/entries.ml
+++ b/kernel/entries.ml
@@ -70,8 +70,6 @@ type definition_entry = {
   const_entry_body : constr;
   (* List of section variables *)
   const_entry_secctx : Id.Set.t option;
-  (* State id on which the completion of type checking is reported *)
-  const_entry_feedback : Stateid.t option;
   const_entry_type : types option;
   const_entry_universes : universes_entry;
   const_entry_inline_code : bool;
@@ -80,7 +78,6 @@ type definition_entry = {
 type section_def_entry = {
   secdef_body : constr;
   secdef_secctx : Id.Set.t option;
-  secdef_feedback : Stateid.t option;
   secdef_type : types option;
 }
 
@@ -88,8 +85,6 @@ type 'a opaque_entry = {
   opaque_entry_body   : 'a;
   (* List of section variables *)
   opaque_entry_secctx : Id.Set.t;
-  (* State id on which the completion of type checking is reported *)
-  opaque_entry_feedback : Stateid.t option;
   opaque_entry_type        : types;
   opaque_entry_universes   : universes_entry;
 }

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -752,7 +752,6 @@ let constant_entry_of_side_effect eff =
   OpaqueEff {
     opaque_entry_body = p;
     opaque_entry_secctx = Context.Named.to_vars cb.const_hyps;
-    opaque_entry_feedback = None;
     opaque_entry_type = cb.const_type;
     opaque_entry_universes = univs;
   }
@@ -760,7 +759,6 @@ let constant_entry_of_side_effect eff =
   DefinitionEff {
     const_entry_body = p;
     const_entry_secctx = Some (Context.Named.to_vars cb.const_hyps);
-    const_entry_feedback = None;
     const_entry_type = Some cb.const_type;
     const_entry_universes = univs;
     const_entry_inline_code = cb.const_inline_code }

--- a/vernac/opaques.ml
+++ b/vernac/opaques.ml
@@ -88,13 +88,15 @@ let set_opaque_disk i (c, priv) t =
 
 let current_opaques = Summary.state
 
-let declare_defined_opaque i (body : Safe_typing.private_constants const_entry_body) =
+let declare_defined_opaque ?feedback_id i (body : Safe_typing.private_constants const_entry_body) =
   (* Note that the environment in which the variable is checked it the one when
      the thunk is evaluated, not the one where this function is called. It does
      not matter because the former must be an extension of the latter or
      otherwise the call to Safe_typing would throw an anomaly. *)
   let proof = Future.chain body begin fun (body, eff) ->
-      Safe_typing.check_opaque (Global.safe_env ()) i (body, eff)
+      let cert = Safe_typing.check_opaque (Global.safe_env ()) i (body, eff) in
+      let () = Option.iter (fun id -> Feedback.feedback ~id Feedback.Complete) feedback_id in
+      cert
     end
   in
   (* If the proof is already computed we fill it eagerly *)

--- a/vernac/opaques.mli
+++ b/vernac/opaques.mli
@@ -10,7 +10,8 @@
 
 type 'a const_entry_body = 'a Entries.proof_output Future.computation
 
-val declare_defined_opaque : Opaqueproof.opaque_handle -> Safe_typing.private_constants const_entry_body -> unit
+val declare_defined_opaque : ?feedback_id:Stateid.t ->
+  Opaqueproof.opaque_handle -> Safe_typing.private_constants const_entry_body -> unit
 val declare_private_opaque : Safe_typing.exported_opaque -> unit
 
 type opaque_disk


### PR DESCRIPTION
Since we now handle delayed proofs from the upper layers there is no point in polluting the kernel with irrelevant imperative calls whose only goal is to communicate with the STM. Instead we call those feedback functions from the same code where we manage delayed proofs.
