### PR TITLE
[build] Ensure `dune install` is called with the right root detection options

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -35,7 +35,7 @@ _DBUILD_DEPS+=$(FLOCK)
 
 $(FLOCK): tools/flock/coq_flock.ml tools/flock/flock.c
 	$(SHOW)'DUNE      $@'
-	$(HIDE)dune build $@
+	$(HIDE)dune build --root . $@
 else
 FLOCK:=flock
 endif

--- a/Makefile.install
+++ b/Makefile.install
@@ -55,12 +55,12 @@ endif
 # For now, we respect the values given at configure's time.
 ifdef DUNE_29_PLUS
 install-dune: $(BCONTEXT)/coq-core.install $(BCONTEXT)/coqide-server.install
-	dune install --display quiet $(DESTDIRARG) --mandir="$(MANDIR)" --prefix="$(COQPREFIX)" --etcdir="$(CONFIGDIR)" --docdir="$(DOCDIR)" coq-core
-	dune install --display quiet $(DESTDIRARG) --mandir="$(MANDIR)" --prefix="$(COQPREFIX)" --etcdir="$(CONFIGDIR)" --docdir="$(DOCDIR)" coqide-server
+	dune install $(_DOPT) $(DESTDIRARG) --mandir="$(MANDIR)" --prefix="$(COQPREFIX)" --etcdir="$(CONFIGDIR)" --docdir="$(DOCDIR)" coq-core
+	dune install $(_DOPT) $(DESTDIRARG) --mandir="$(MANDIR)" --prefix="$(COQPREFIX)" --etcdir="$(CONFIGDIR)" --docdir="$(DOCDIR)" coqide-server
 else
 install-dune: $(BCONTEXT)/coq-core.install $(BCONTEXT)/coqide-server.install
-	dune install --display quiet $(DESTDIRARG) --mandir="$(MANDIR)" --prefix="$(COQPREFIX)" coq-core
-	dune install --display quiet $(DESTDIRARG) --mandir="$(MANDIR)" --prefix="$(COQPREFIX)" coqide-server
+	dune install $(_DOPT) $(DESTDIRARG) --mandir="$(MANDIR)" --prefix="$(COQPREFIX)" coq-core
+	dune install $(_DOPT) $(DESTDIRARG) --mandir="$(MANDIR)" --prefix="$(COQPREFIX)" coqide-server
 endif
 
 # IMPORTANT NOTE: before Dune 2.9, the --docdir and --etcdir options
@@ -103,9 +103,9 @@ install-coqide:
 else
 ifdef DUNE_29_PLUS
 install-coqide: $(BCONTEXT)/coqide.install
-	dune install --display quiet $(DESTDIRARG) --mandir="$(MANDIR)" --prefix="$(COQPREFIX)" --etcdir="$(CONFIGDIR)" --docdir="$(DOCDIR)" coqide
+	dune install $(_DOPT) $(DESTDIRARG) --mandir="$(MANDIR)" --prefix="$(COQPREFIX)" --etcdir="$(CONFIGDIR)" --docdir="$(DOCDIR)" coqide
 else
-	dune install --display quiet $(DESTDIRARG) --mandir="$(MANDIR)" --prefix="$(COQPREFIX)" coqide
+	dune install $(_DOPT) $(DESTDIRARG) --mandir="$(MANDIR)" --prefix="$(COQPREFIX)" coqide
 endif
 endif
 


### PR DESCRIPTION
Should fix #15044