### PR TITLE
[8.14] [nativelib] Don't pass to $LD non-existing dirs.

### DIFF
--- a/kernel/nativelib.ml
+++ b/kernel/nativelib.ml
@@ -59,7 +59,8 @@ let get_include_dirs () =
     let coqcorelib = Envars.coqcorelib () in
     [ coqcorelib / "kernel" ; coqcorelib / "kernel/.kernel.objs/byte/"
     ; coqcorelib / "library"; coqcorelib / "library/.library.objs/byte/"
-    ]
+    ] |>
+    List.filter Sys.file_exists
   | _::_ as l -> l
   in
   if Lazy.is_val my_temp_dir


### PR DESCRIPTION
This is already fixed in master, but 8.14 will produce a warning on
OSX users.
