### PR TITLE
Warn when Collection and Variable names clash

### DIFF
--- a/doc/sphinx/proofs/writing-proofs/proof-mode.rst
+++ b/doc/sphinx/proofs/writing-proofs/proof-mode.rst
@@ -306,7 +306,7 @@ When the proof is completed, you can exit proof mode with commands such as
 
    .. warn:: @ident is both name of a Collection and Variable, Collection @ident takes precedence over Variable.
 
-      If a specified name is ambiguous (could be either a :cmd:`Collection` or a :cmd:`Variable`),
+      If a specified name is ambiguous (it could be either a :cmd:`Collection` or a :cmd:`Variable`),
       then it is assumed to be a :cmd:`Collection` name.
 
    .. warn:: Variable All is shadowed by Collection named All containing all variables.
@@ -392,7 +392,7 @@ Name a set of section hypotheses for ``Proof using``
 
          Collection Many := Fewer - (x y)
 
-   .. exn:: "All" is a predefined collection containg all variables, you can't redefine it.
+   .. exn:: "All" is a predefined collection containing all variables. It can't be redefined.
 
       When issuing a :cmd:`Proof using` command, **All** used as a collection name always means
       "use all variables".
@@ -401,9 +401,9 @@ Name a set of section hypotheses for ``Proof using``
 
       Redefining a :cmd:`Collection` overwrites the previous definition.
 
-   .. warn:: @ident was already a defined varaible, the name @ident will refer to Collection when executing "Proof using" command.
+   .. warn:: @ident was already a defined Variable, the name @ident will refer to Collection when executing "Proof using" command.
 
-      :cmd:`Proof using` command allows to specify both :cmd:`Collection` and
+      The :cmd:`Proof using` command allows specifying both :cmd:`Collection` and
       :cmd:`Variable` names. In case of ambiguity, a name is assumed to be Collection name.
 
 Proof modes

--- a/doc/sphinx/proofs/writing-proofs/proof-mode.rst
+++ b/doc/sphinx/proofs/writing-proofs/proof-mode.rst
@@ -304,6 +304,15 @@ When the proof is completed, you can exit proof mode with commands such as
    :n:`All`
      Use all section variables.
 
+   .. warn:: @ident is both name of a Collection and Variable, Collection @ident takes precedence over Variable.
+
+      If a specified name is ambiguous (could be either a :cmd:`Collection` or a :cmd:`Variable`),
+      then it is assumed to be a :cmd:`Collection` name.
+
+   .. warn:: Variable All is shadowed by Collection named All containing all variables.
+
+      This is variant of the previous warning for the **All** collection.
+
    .. seealso:: :ref:`tactics-implicit-automation`
 
 .. attr:: using
@@ -382,6 +391,20 @@ Name a set of section hypotheses for ``Proof using``
       ``Fewer`` and the unnamed collection ``x y``::
 
          Collection Many := Fewer - (x y)
+
+   .. exn:: "All" is a predefined collection containg all variables, you can't redefine it.
+
+      When issuing a :cmd:`Proof using` command, **All** used as a collection name always means
+      "use all variables".
+
+   .. warn:: New Collection definition of @ident shadows the previous one.
+
+      Redefining a :cmd:`Collection` overwrites the previous definition.
+
+   .. warn:: @ident was already a defined varaible, the name @ident will refer to Collection when executing "Proof using" command.
+
+      :cmd:`Proof using` command allows to specify both :cmd:`Collection` and
+      :cmd:`Variable` names. In case of ambiguity, a name is assumed to be Collection name.
 
 Proof modes
 -----------

--- a/test-suite/output/ProofUsingClashWarning.out
+++ b/test-suite/output/ProofUsingClashWarning.out
@@ -1,12 +1,12 @@
 File "./output/ProofUsingClashWarning.v", line 3, characters 2-39:
 Warning:
-clashing_name was already a defined varaible, the name clashing_name will refer to Collection when executing "Proof using" command.
+clashing_name was already a defined Variable, the name clashing_name will refer to Collection when executing "Proof using" command.
 [variable-shadowing,deprecated]
 File "./output/ProofUsingClashWarning.v", line 6, characters 2-39:
 Warning: New Collection definition of redefined_col shadows the previous one.
 [collection-redefinition,deprecated]
 The command has indeed failed with message:
-"All" is a predefined collection containg all variables, you can't redefine it.
+"All" is a predefined collection containing all variables. It can't be redefined.
 File "./output/ProofUsingClashWarning.v", line 11, characters 2-28:
 Warning:
 clashing_name is both name of a Collection and Variable, Collection clashing_name takes precedence over Variable.

--- a/test-suite/output/ProofUsingClashWarning.out
+++ b/test-suite/output/ProofUsingClashWarning.out
@@ -1,0 +1,21 @@
+File "./output/ProofUsingClashWarning.v", line 3, characters 2-39:
+Warning:
+clashing_name was already a defined varaible, the name clashing_name will refer to Collection when executing "Proof using" command.
+[variable-shadowing,deprecated]
+File "./output/ProofUsingClashWarning.v", line 6, characters 2-39:
+Warning: New Collection definition of redefined_col shadows the previous one.
+[collection-redefinition,deprecated]
+The command has indeed failed with message:
+"All" is a predefined collection containg all variables, you can't redefine it.
+File "./output/ProofUsingClashWarning.v", line 11, characters 2-28:
+Warning:
+clashing_name is both name of a Collection and Variable, Collection clashing_name takes precedence over Variable.
+[collection-precedence,deprecated]
+File "./output/ProofUsingClashWarning.v", line 16, characters 2-18:
+Warning:
+Variable All is shadowed by Collection named All containing all variables.
+[all-collection-precedence,deprecated]
+foo : bool -> True
+     : bool -> True
+bar : bool -> nat -> unit -> True
+     : bool -> nat -> unit -> True

--- a/test-suite/output/ProofUsingClashWarning.v
+++ b/test-suite/output/ProofUsingClashWarning.v
@@ -1,0 +1,23 @@
+Section Test.
+  Variables (bool_var : bool) (clashing_name : nat) (All : unit).
+  Collection clashing_name := bool_var.
+
+  Collection redefined_col := bool_var.
+  Collection redefined_col := bool_var.
+
+  Fail Collection All := bool_var.
+
+  Lemma foo : True.
+  Proof using clashing_name.
+    trivial.
+  Qed.
+
+  Lemma bar : True.
+  Proof using All.
+    trivial.
+  Qed.
+
+End Test.
+
+Check foo : bool -> True.
+Check bar : bool -> nat -> unit -> True.


### PR DESCRIPTION
Closes  #13296

This PR adds "Collection"-related and "Proof using"-related warnings for some corner cases.
It has one breaking change (I don't think this affects anyone though):

* Error is signalled when user tries to define collecion named "All" (was previously allowed, but defining such collection had no effect)

Otherwise, there are new warnings without any semantics change.
Warning is signalled when:

* User redefines a collection
* User defines collection using name of already existing variable
* User invokes "Proof using" using collection whose name clashes with already existing variable (repeating previous warning)
* User invokes "Proof using" using "All" collection, if "All" is also name of a variable

- [x] Added / updated **test-suite**.


- [ ] Added **changelog**. <- This is insignificant change, should it get a changelog?
- [x] Added / updated **documentation**.
  - [x] Documented any new / changed **user messages**.
