### PR TITLE
port additions made in math-comp PR #757

### DIFF
--- a/doc/changelog/06-ssreflect/15059-reflect-combinators.rst
+++ b/doc/changelog/06-ssreflect/15059-reflect-combinators.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  port the additions made to `ssrbool.v` in math-comp PR #757
+  (`#15059 <https://github.com/coq/coq/pull/15059>`_,
+  by Christian Doczkal).

--- a/doc/changelog/06-ssreflect/15059-reflect-combinators.rst
+++ b/doc/changelog/06-ssreflect/15059-reflect-combinators.rst
@@ -1,4 +1,5 @@
 - **Added:**
-  port the additions made to `ssrbool.v` in math-comp PR #757
+  port the additions made to `ssrbool.v` in math-comp `PR #757 <https://github.com/math-comp/math-comp/pull/757>`_,
+  namely `reflect` combinators `negPP`, `orPP`, `andPP` and `implyPP`
   (`#15059 <https://github.com/coq/coq/pull/15059>`_,
   by Christian Doczkal).

--- a/theories/ssr/ssrbool.v
+++ b/theories/ssr/ssrbool.v
@@ -978,6 +978,32 @@ Arguments implyP {b1 b2}.
 Prenex Implicits idP idPn negP negPn negPf.
 Prenex Implicits andP and3P and4P and5P orP or3P or4P nandP norP implyP.
 
+Section ReflectCombinators.
+
+Variables (P Q : Prop) (p q : bool).
+
+Hypothesis rP : reflect P p.
+Hypothesis rQ : reflect Q q.
+
+Lemma negPP : reflect (~ P) (~~ p).
+Proof. by apply:(iffP negP); apply: contra_not => /rP. Qed.
+
+Lemma andPP : reflect (P /\ Q) (p && q).
+Proof. by apply: (iffP andP) => -[/rP ? /rQ ?]. Qed.
+
+Lemma orPP : reflect (P \/ Q) (p || q).
+Proof. by apply: (iffP orP) => -[/rP ?|/rQ ?]; tauto. Qed.
+
+Lemma implyPP : reflect (P -> Q) (p ==> q).
+Proof. by apply: (iffP implyP) => pq /rP /pq /rQ. Qed.
+
+End ReflectCombinators.
+Arguments negPP {P p}.
+Arguments andPP {P Q p q}.
+Arguments orPP {P Q p q}.
+Arguments implyPP {P Q p q}.
+Prenex Implicits negPP andPP orPP implyPP.
+
 (**  Shorter, more systematic names for the boolean connectives laws.        **)
 
 Lemma andTb : left_id true andb.       Proof. by []. Qed.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->
This ports the additions made to `ssrbool.v` in https://github.com/math-comp/math-comp/pull/757

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->



<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make -f Makefile.make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
