### PR TITLE
Update nixpkgs to use Dune 2.9.

### DIFF
--- a/dev/nixpkgs.nix
+++ b/dev/nixpkgs.nix
@@ -1,4 +1,4 @@
 import (fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/5c7a370a208d93d458193fc05ed84ced0ba7f387.tar.gz";
-  sha256 = "1jkn71xscsk4rb0agbp5saf06hy36qvy512zzh3881pkkn67i9js";
+  url = "https://github.com/NixOS/nixpkgs/archive/a6a0964eacef611f364ca22256d6882d8670721c.tar.gz";
+  sha256 = "0h2cv4zdlmf1di55i64vcavc0rfh7cvbnax4wll2vbjj7bahawyc";
 })


### PR DESCRIPTION
FTR, I reused the exact same nixpkgs version that is currently set in the master branch of the Coq Nix Toolbox (a few days behind current nixpkgs-unstable).