### PR TITLE
Fix for losing space between adjacent italic words

### DIFF
--- a/doc/sphinx/practical-tools/coq-commands.rst
+++ b/doc/sphinx/practical-tools/coq-commands.rst
@@ -177,7 +177,7 @@ and ``coqtop``, unless stated otherwise:
 
      :ref:`names-of-libraries` and the
      command Declare ML Module Section :ref:`compiled-files`.
-:-Q *directory* *dirpath*: Add physical path *directory* to the list of
+:-Q *directory dirpath*: Add physical path *directory* to the list of
   directories where Coq looks for a file and bind it to the logical
   directory *dirpath*. The subdirectory structure of *directory* is
   recursively available from Coq using absolute names (extending the
@@ -191,7 +191,7 @@ and ``coqtop``, unless stated otherwise:
   disallow two files differing only in the case in the same directory.
 
   .. seealso:: Section :ref:`names-of-libraries`.
-:-R *directory* *dirpath*: Do as ``-Q`` *directory* *dirpath* but make the
+:-R *directory dirpath*: Do as ``-Q`` *directory dirpath* but make the
   subdirectory structure of *directory* recursively visible so that the
   recursive contents of physical *directory* is available from Coq using
   short or partially qualified names.
@@ -231,7 +231,7 @@ and ``coqtop``, unless stated otherwise:
      :cmd:`Unset` commands will be executed in the order specified on
      the command-line.
 
-:-rfrom *dirpath* *qualid*: Load Coq compiled library :n:`@qualid`.
+:-rfrom *dirpath qualid*: Load Coq compiled library :n:`@qualid`.
   This is equivalent to running :cmd:`From <From … Require>`
   :n:`@dirpath` :cmd:`Require <From … Require>` :n:`@qualid`.
   See the :ref:`note above <interleave-command-line>` regarding the order
@@ -244,13 +244,13 @@ and ``coqtop``, unless stated otherwise:
   This is equivalent to running :cmd:`Require Export` :n:`@qualid`.
   See the :ref:`note above <interleave-command-line>` regarding the order
   of command-line options.
-:-rifrom *dirpath* *qualid*, -require-import-from *dirpath* *qualid*:
+:-rifrom *dirpath qualid*, -require-import-from *dirpath qualid*:
   Load Coq compiled library :n:`@qualid` and import it.  This is
   equivalent to running :cmd:`From <From … Require>` :n:`@dirpath`
   :cmd:`Require Import <From … Require>` :n:`@qualid`.  See the
   :ref:`note above <interleave-command-line>` regarding the order of
   command-line options.
-:-refrom *dirpath* *qualid*, -require-export-from *dirpath* *qualid*:
+:-refrom *dirpath qualid*, -require-export-from *dirpath qualid*:
   Load Coq compiled library :n:`@qualid` and transitively import it.
   This is equivalent to running :cmd:`From <From … Require>`
   :n:`@dirpath` :cmd:`Require Export <From … Require>` :n:`@qualid`.


### PR DESCRIPTION
The space between separately italicized words is being lost inside colon-enclosed text, as in `:-R *directory* *dirpath*:`.
The fix is changing to `:-R *directory dirpath*:`.  (When not colon-enclosed, `*foo* *bar*` works as expected, though it is equivalent to the simpler `*foo bar*`.)

Old appearance:
![image](https://user-images.githubusercontent.com/1253341/138744383-56542f76-1d78-4c4a-a502-094cab861b51.png)

New appearance:
![image](https://user-images.githubusercontent.com/1253341/138744456-aefc2726-92e5-44dd-9537-f1fa6e234260.png)
