### PR TITLE
Remove most calls to Global from engine/

### DIFF
--- a/dev/ci/user-overlays/15069-ppedrot-engine-without-global.sh
+++ b/dev/ci/user-overlays/15069-ppedrot-engine-without-global.sh
@@ -1,0 +1,17 @@
+overlay aac_tactics https://github.com/ppedrot/aac-tactics engine-without-global 15069
+
+overlay elpi https://github.com/ppedrot/coq-elpi engine-without-global 15069
+
+overlay equations https://github.com/ppedrot/Coq-Equations engine-without-global 15069
+
+overlay gappa https://gitlab.inria.fr/pedrot/coq engine-without-global 15069
+
+overlay metacoq https://github.com/ppedrot/metacoq engine-without-global 15069
+
+overlay mtac2 https://github.com/ppedrot/Mtac2 engine-without-global 15069
+
+overlay paramcoq https://github.com/ppedrot/paramcoq engine-without-global 15069
+
+overlay relation_algebra https://github.com/ppedrot/relation-algebra engine-without-global 15069
+
+overlay vscoq https://github.com/ppedrot/vscoq engine-without-global 15069

--- a/doc/plugin_tutorial/tuto3/src/construction_game.ml
+++ b/doc/plugin_tutorial/tuto3/src/construction_game.ml
@@ -19,8 +19,8 @@ let c_one sigma =
 (* the long name of "S" was found with the command "About S." *)
   let gr_O =
     find_reference "Tuto3" ["Coq"; "Init"; "Datatypes"] "O" in
-  let sigma, c_O = Evarutil.new_global sigma gr_O in
-  let sigma, c_S = Evarutil.new_global sigma gr_S in
+  let sigma, c_O = Evarutil.new_global (Global.env ()) sigma gr_O in
+  let sigma, c_S = Evarutil.new_global (Global.env ()) sigma gr_S in
 (* Here is the construction of a new term by applying functions to argument. *)
   sigma, EConstr.mkApp (c_S, [| c_O |])
 
@@ -67,43 +67,43 @@ let example_sort_app_lambda () =
 
 let c_S sigma =
   let gr = find_reference "Tuto3" ["Coq"; "Init"; "Datatypes"] "S" in
-  Evarutil.new_global sigma gr
+  Evarutil.new_global (Global.env ()) sigma gr
 
 let c_O sigma =
   let gr = find_reference "Tuto3" ["Coq"; "Init"; "Datatypes"] "O" in
-  Evarutil.new_global sigma gr
+  Evarutil.new_global (Global.env ()) sigma gr
 
 let c_E sigma =
   let gr = find_reference "Tuto3" ["Tuto3"; "Data"] "EvenNat" in
-  Evarutil.new_global sigma gr
+  Evarutil.new_global (Global.env ()) sigma gr
 
 let c_D sigma =
   let gr = find_reference "Tuto3" ["Tuto3"; "Data"] "tuto_div2" in
-  Evarutil.new_global sigma gr
+  Evarutil.new_global (Global.env ()) sigma gr
 
 let c_Q sigma =
   let gr = find_reference "Tuto3" ["Coq"; "Init"; "Logic"] "eq" in
-  Evarutil.new_global sigma gr
+  Evarutil.new_global (Global.env ()) sigma gr
 
 let c_R sigma =
   let gr = find_reference "Tuto3" ["Coq"; "Init"; "Logic"] "eq_refl" in
-  Evarutil.new_global sigma gr
+  Evarutil.new_global (Global.env ()) sigma gr
 
 let c_N sigma =
   let gr = find_reference "Tuto3" ["Coq"; "Init"; "Datatypes"] "nat" in
-  Evarutil.new_global sigma gr
+  Evarutil.new_global (Global.env ()) sigma gr
 
 let c_C sigma =
   let gr = find_reference "Tuto3" ["Tuto3"; "Data"] "C" in
-  Evarutil.new_global sigma gr
+  Evarutil.new_global (Global.env ()) sigma gr
 
 let c_F sigma =
   let gr = find_reference "Tuto3" ["Tuto3"; "Data"] "S_ev" in
-  Evarutil.new_global sigma gr
+  Evarutil.new_global (Global.env ()) sigma gr
 
 let c_P sigma =
   let gr = find_reference "Tuto3" ["Tuto3"; "Data"] "s_half_proof" in
-  Evarutil.new_global sigma gr
+  Evarutil.new_global (Global.env ()) sigma gr
 
 (* If c_S was universe polymorphic, we should have created a new constant
    at each iteration of buildup. *)

--- a/doc/plugin_tutorial/tuto3/src/construction_game.ml
+++ b/doc/plugin_tutorial/tuto3/src/construction_game.ml
@@ -19,8 +19,8 @@ let c_one sigma =
 (* the long name of "S" was found with the command "About S." *)
   let gr_O =
     find_reference "Tuto3" ["Coq"; "Init"; "Datatypes"] "O" in
-  let sigma, c_O = Evarutil.new_global (Global.env ()) sigma gr_O in
-  let sigma, c_S = Evarutil.new_global (Global.env ()) sigma gr_S in
+  let sigma, c_O = Evd.fresh_global (Global.env ()) sigma gr_O in
+  let sigma, c_S = Evd.fresh_global (Global.env ()) sigma gr_S in
 (* Here is the construction of a new term by applying functions to argument. *)
   sigma, EConstr.mkApp (c_S, [| c_O |])
 
@@ -67,43 +67,43 @@ let example_sort_app_lambda () =
 
 let c_S sigma =
   let gr = find_reference "Tuto3" ["Coq"; "Init"; "Datatypes"] "S" in
-  Evarutil.new_global (Global.env ()) sigma gr
+  Evd.fresh_global (Global.env ()) sigma gr
 
 let c_O sigma =
   let gr = find_reference "Tuto3" ["Coq"; "Init"; "Datatypes"] "O" in
-  Evarutil.new_global (Global.env ()) sigma gr
+  Evd.fresh_global (Global.env ()) sigma gr
 
 let c_E sigma =
   let gr = find_reference "Tuto3" ["Tuto3"; "Data"] "EvenNat" in
-  Evarutil.new_global (Global.env ()) sigma gr
+  Evd.fresh_global (Global.env ()) sigma gr
 
 let c_D sigma =
   let gr = find_reference "Tuto3" ["Tuto3"; "Data"] "tuto_div2" in
-  Evarutil.new_global (Global.env ()) sigma gr
+  Evd.fresh_global (Global.env ()) sigma gr
 
 let c_Q sigma =
   let gr = find_reference "Tuto3" ["Coq"; "Init"; "Logic"] "eq" in
-  Evarutil.new_global (Global.env ()) sigma gr
+  Evd.fresh_global (Global.env ()) sigma gr
 
 let c_R sigma =
   let gr = find_reference "Tuto3" ["Coq"; "Init"; "Logic"] "eq_refl" in
-  Evarutil.new_global (Global.env ()) sigma gr
+  Evd.fresh_global (Global.env ()) sigma gr
 
 let c_N sigma =
   let gr = find_reference "Tuto3" ["Coq"; "Init"; "Datatypes"] "nat" in
-  Evarutil.new_global (Global.env ()) sigma gr
+  Evd.fresh_global (Global.env ()) sigma gr
 
 let c_C sigma =
   let gr = find_reference "Tuto3" ["Tuto3"; "Data"] "C" in
-  Evarutil.new_global (Global.env ()) sigma gr
+  Evd.fresh_global (Global.env ()) sigma gr
 
 let c_F sigma =
   let gr = find_reference "Tuto3" ["Tuto3"; "Data"] "S_ev" in
-  Evarutil.new_global (Global.env ()) sigma gr
+  Evd.fresh_global (Global.env ()) sigma gr
 
 let c_P sigma =
   let gr = find_reference "Tuto3" ["Tuto3"; "Data"] "s_half_proof" in
-  Evarutil.new_global (Global.env ()) sigma gr
+  Evd.fresh_global (Global.env ()) sigma gr
 
 (* If c_S was universe polymorphic, we should have created a new constant
    at each iteration of buildup. *)

--- a/doc/plugin_tutorial/tuto3/src/tuto_tactic.ml
+++ b/doc/plugin_tutorial/tuto3/src/tuto_tactic.ml
@@ -15,7 +15,7 @@ let collect_constants () =
     let gr_R = find_reference "Tuto3" ["Coq"; "Init"; "Datatypes"] "pair" in
     let gr_P = find_reference "Tuto3" ["Coq"; "Init"; "Datatypes"] "prod" in
     let gr_U = find_reference "Tuto3" ["Tuto3"; "Data"] "uncover" in
-    constants := List.map (fun x -> of_constr (constr_of_monomorphic_global x))
+    constants := List.map (fun x -> of_constr (constr_of_monomorphic_global (Global.env ()) x))
       [gr_H; gr_M; gr_R; gr_P; gr_U];
     !constants
   else

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -21,10 +21,6 @@ open Namegen
 module RelDecl = Context.Rel.Declaration
 module NamedDecl = Context.Named.Declaration
 
-let new_global env evd x =
-  let (evd, c) = Evd.fresh_global env evd x in
-  (evd, c)
-
 let create_clos_infos env sigma flags =
   let open CClosure in
   let evars ev = Evd.existential_opt_value0 sigma ev in

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -21,8 +21,8 @@ open Namegen
 module RelDecl = Context.Rel.Declaration
 module NamedDecl = Context.Named.Declaration
 
-let new_global evd x =
-  let (evd, c) = Evd.fresh_global (Global.env()) evd x in
+let new_global env evd x =
+  let (evd, c) = Evd.fresh_global env evd x in
   (evd, c)
 
 let create_clos_infos env sigma flags =

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -360,7 +360,7 @@ let push_rel_decl_to_named_context
   | Some id0 when hypnaming = KeepUserNameAndRenameExistingEvenSectionNames ||
                   (hypnaming = KeepUserNameAndRenameExistingButSectionNames ||
                    hypnaming = ProgramNaming) &&
-                  not (is_section_variable id0) ->
+                  not (is_section_variable (Global.env ()) id0) ->
       (* spiwack: if [id<>id0], rather than introducing a new
           binding named [id], we will keep [id0] (the name given
           by the user) and rename [id0] into [id] in the named
@@ -574,7 +574,7 @@ let rec check_and_clear_in_constr env evdref err ids global c =
             let _nconcl =
               try
                 let nids = Id.Map.domain rids in
-                let global = Id.Set.exists is_section_variable nids in
+                let global = Id.Set.exists (fun id -> is_section_variable (Global.env ()) id) nids in
                 let concl = EConstr.Unsafe.to_constr (evar_concl evi) in
                 check_and_clear_in_constr env evdref (EvarTypingBreak ev) nids global concl
               with ClearDependencyError (rid,err,where) ->
@@ -599,7 +599,7 @@ let clear_hyps_in_evi_main env sigma hyps terms ids =
      the contexts of the evars occurring in evi *)
   let evdref = ref sigma in
   let terms = List.map EConstr.Unsafe.to_constr terms in
-  let global = Id.Set.exists is_section_variable ids in
+  let global = Id.Set.exists (fun id -> is_section_variable (Global.env ()) id) ids in
   let terms =
     List.map (check_and_clear_in_constr env evdref (OccurHypInSimpleClause None) ids global) terms in
   let nhyps =

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -68,10 +68,6 @@ val new_type_evar :
 
 val new_Type : ?rigid:rigid -> evar_map -> evar_map * constr
 
-(** Polymorphic constants *)
-
-val new_global : env -> evar_map -> GlobRef.t -> evar_map * constr
-
 val make_pure_subst : evar_info -> 'a list -> (Id.t * 'a) list
 
 (** {6 Evars/Metas switching...} *)

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -70,7 +70,7 @@ val new_Type : ?rigid:rigid -> evar_map -> evar_map * constr
 
 (** Polymorphic constants *)
 
-val new_global : evar_map -> GlobRef.t -> evar_map * constr
+val new_global : env -> evar_map -> GlobRef.t -> evar_map * constr
 
 val make_pure_subst : evar_info -> 'a list -> (Id.t * 'a) list
 

--- a/engine/namegen.mli
+++ b/engine/namegen.mli
@@ -86,7 +86,7 @@ val next_ident_away_from : Id.t -> (Id.t -> bool) -> Id.t
 val next_ident_away : Id.t -> Id.Set.t -> Id.t
 
 (** Avoid clashing with a name already used in current module *)
-val next_ident_away_in_goal : Id.t -> Id.Set.t -> Id.t
+val next_ident_away_in_goal : Environ.env -> Id.t -> Id.Set.t -> Id.t
 
 (** Avoid clashing with a name already used in current module
    but tolerate overwriting section variables, as in goals *)
@@ -113,15 +113,15 @@ type renaming_flags =
 val make_all_name_different : env -> evar_map -> env
 
 val compute_displayed_name_in :
-  evar_map -> renaming_flags -> Id.Set.t -> Name.t -> constr -> Name.t * Id.Set.t
+  Environ.env -> evar_map -> renaming_flags -> Id.Set.t -> Name.t -> constr -> Name.t * Id.Set.t
 val compute_and_force_displayed_name_in :
-  evar_map -> renaming_flags -> Id.Set.t -> Name.t -> constr -> Name.t * Id.Set.t
+  Environ.env -> evar_map -> renaming_flags -> Id.Set.t -> Name.t -> constr -> Name.t * Id.Set.t
 val compute_displayed_let_name_in :
-  evar_map -> renaming_flags -> Id.Set.t -> Name.t -> 'a -> Name.t * Id.Set.t
+  Environ.env -> evar_map -> renaming_flags -> Id.Set.t -> Name.t -> 'a -> Name.t * Id.Set.t
 val rename_bound_vars_as_displayed :
-  evar_map -> Id.Set.t -> Name.t list -> types -> types
+  Environ.env -> evar_map -> Id.Set.t -> Name.t list -> types -> types
 
 (* Generic function expecting a "not occurn" function *)
 val compute_displayed_name_in_gen :
   (evar_map -> int -> 'a -> bool) ->
-  evar_map -> Id.Set.t -> Name.t -> 'a -> Name.t * Id.Set.t
+  Environ.env -> evar_map -> Id.Set.t -> Name.t -> 'a -> Name.t * Id.Set.t

--- a/engine/termops.mli
+++ b/engine/termops.mli
@@ -257,7 +257,7 @@ val global_app_of_constr : Evd.evar_map -> constr -> (GlobRef.t * EInstance.t) *
 val dependency_closure : env -> Evd.evar_map -> named_context -> Id.Set.t -> Id.t list
 
 (** Test if an identifier is the basename of a global reference *)
-val is_section_variable : Id.t -> bool
+val is_section_variable : env -> Id.t -> bool
 
 val global_of_constr : Evd.evar_map -> constr -> GlobRef.t * EInstance.t
 [@@ocaml.deprecated "Use [EConstr.destRef] instead (throws DestKO instead of Not_found)."]
@@ -280,9 +280,9 @@ val reference_of_level : Evd.evar_map -> Univ.Level.t -> Libnames.qualid option
 
 open Evd
 
-val pr_existential_key : evar_map -> Evar.t -> Pp.t
+val pr_existential_key : env -> evar_map -> Evar.t -> Pp.t
 
-val evar_suggested_name : Evar.t -> evar_map -> Id.t
+val evar_suggested_name : env -> evar_map -> Evar.t -> Id.t
 
 val pr_evar_info : env -> evar_map -> evar_info -> Pp.t
 val pr_evar_constraints : evar_map -> evar_constraint list -> Pp.t

--- a/engine/univGen.ml
+++ b/engine/univGen.ml
@@ -87,9 +87,9 @@ let fresh_global_instance ?loc ?names env gr =
   let u, ctx = fresh_global_instance ?loc ?names env gr in
   mkRef (gr, u), ctx
 
-let constr_of_monomorphic_global gr =
-  if not (Global.is_polymorphic gr) then
-    fst (fresh_global_instance (Global.env ()) gr)
+let constr_of_monomorphic_global env gr =
+  if not (Environ.is_polymorphic env gr) then
+    fst (fresh_global_instance env gr)
   else CErrors.user_err
       Pp.(str "globalization of polymorphic reference " ++ Nametab.pr_global_env Id.Set.empty gr ++
           str " would forget universes.")

--- a/engine/univGen.mli
+++ b/engine/univGen.mli
@@ -55,9 +55,9 @@ val fresh_global_instance : ?loc:Loc.t -> ?names:Univ.Instance.t -> env -> GlobR
 val fresh_universe_context_set_instance : ContextSet.t ->
   universe_level_subst * ContextSet.t
 
-(** Create a fresh global in the global environment, without side effects.
+(** Create a fresh global in the environment argument, without side effects.
     BEWARE: this raises an error on polymorphic constants/inductives:
     the constraints should be properly added to an evd.
     See Evd.fresh_global, Evarutil.new_global, and pf_constr_of_global for
     the proper way to get a fresh copy of a polymorphic global reference. *)
-val constr_of_monomorphic_global : GlobRef.t -> constr
+val constr_of_monomorphic_global : env -> GlobRef.t -> constr

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -172,7 +172,7 @@ let concl_next_tac =
 let process_goal sigma g =
   let env = Goal.V82.env sigma g in
   let min_env = Environ.reset_context env in
-  let name = if Printer.print_goal_names () then Some (Names.Id.to_string (Termops.evar_suggested_name g sigma)) else None in
+  let name = if Printer.print_goal_names () then Some (Names.Id.to_string (Termops.evar_suggested_name (Global.env ()) sigma g)) else None in
   let ccl =
     pr_letype_env ~goal_concl_style:true env sigma (Goal.V82.concl sigma g)
   in
@@ -187,7 +187,7 @@ let process_goal sigma g =
 
 let process_goal_diffs diff_goal_map oldp nsigma ng =
   let open Evd in
-  let name = if Printer.print_goal_names () then Some (Names.Id.to_string (Termops.evar_suggested_name ng nsigma)) else None in
+  let name = if Printer.print_goal_names () then Some (Names.Id.to_string (Termops.evar_suggested_name (Global.env ()) nsigma ng)) else None in
   let og_s = match oldp with
     | Some oldp ->
       let Proof.{ sigma=osigma } = Proof.data oldp in

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -172,7 +172,7 @@ let concl_next_tac =
 let process_goal sigma g =
   let env = Goal.V82.env sigma g in
   let min_env = Environ.reset_context env in
-  let name = if Printer.print_goal_names () then Some (Names.Id.to_string (Termops.evar_suggested_name (Global.env ()) sigma g)) else None in
+  let name = if Printer.print_goal_names () then Some (Names.Id.to_string (Termops.evar_suggested_name env sigma g)) else None in
   let ccl =
     pr_letype_env ~goal_concl_style:true env sigma (Goal.V82.concl sigma g)
   in

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -1487,16 +1487,16 @@ let rec glob_of_pat avoid env sigma pat = DAst.make @@ match pat with
       GApp (DAst.make @@ GPatVar (Evar_kinds.SecondOrderPatVar n),
         List.map (glob_of_pat avoid env sigma) args)
   | PProd (na,t,c) ->
-      let na',avoid' = compute_displayed_name_in_pattern sigma avoid na c in
+      let na',avoid' = compute_displayed_name_in_pattern (Global.env ()) sigma avoid na c in
       let env' = Termops.add_name na' env in
       GProd (na',Explicit,glob_of_pat avoid env sigma t,glob_of_pat avoid' env' sigma c)
   | PLetIn (na,b,t,c) ->
-      let na',avoid' = Namegen.compute_displayed_let_name_in sigma Namegen.RenamingForGoal avoid na c in
+      let na',avoid' = Namegen.compute_displayed_let_name_in (Global.env ()) sigma Namegen.RenamingForGoal avoid na c in
       let env' = Termops.add_name na' env in
       GLetIn (na',glob_of_pat avoid env sigma b, Option.map (glob_of_pat avoid env sigma) t,
               glob_of_pat avoid' env' sigma c)
   | PLambda (na,t,c) ->
-      let na',avoid' = compute_displayed_name_in_pattern sigma avoid na c in
+      let na',avoid' = compute_displayed_name_in_pattern (Global.env ()) sigma avoid na c in
       let env' = Termops.add_name na' env in
       GLambda (na',Explicit,glob_of_pat avoid env sigma t, glob_of_pat avoid' env' sigma c)
   | PIf (c,b1,b2) ->
@@ -1574,7 +1574,7 @@ let rec glob_of_pat avoid env sigma pat = DAst.make @@ match pat with
 
 and glob_of_pat_under_context avoid env sigma (nas, pat) =
   let fold (avoid, env, nas, epat) na =
-    let na, avoid = compute_displayed_name_in_pattern sigma avoid na epat in
+    let na, avoid = compute_displayed_name_in_pattern (Global.env ()) sigma avoid na epat in
     let env = Termops.add_name na env in
     let epat = match epat with PLambda (_, _, p) -> p | _ -> assert false in
     (avoid, env, na :: nas, epat)

--- a/plugins/btauto/refl_btauto.ml
+++ b/plugins/btauto/refl_btauto.ml
@@ -10,7 +10,7 @@
 
 open Constr
 
-let bt_lib_constr n = lazy (UnivGen.constr_of_monomorphic_global @@ Coqlib.lib_ref n)
+let bt_lib_constr n = lazy (UnivGen.constr_of_monomorphic_global (Global.env ()) @@ Coqlib.lib_ref n)
 
 let decomp_term sigma (c : Constr.t) =
   Constr.kind (EConstr.Unsafe.to_constr (Termops.strip_outer_cast sigma (EConstr.of_constr c)))

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -333,15 +333,15 @@ let rec_pte_id = Id.of_string "Hrec"
 let clean_hyp_with_heq ptes_infos eq_hyps hyp_id env sigma =
   let coq_False =
     EConstr.of_constr
-      (UnivGen.constr_of_monomorphic_global @@ Coqlib.lib_ref "core.False.type")
+      (UnivGen.constr_of_monomorphic_global (Global.env ()) @@ Coqlib.lib_ref "core.False.type")
   in
   let coq_True =
     EConstr.of_constr
-      (UnivGen.constr_of_monomorphic_global @@ Coqlib.lib_ref "core.True.type")
+      (UnivGen.constr_of_monomorphic_global (Global.env ()) @@ Coqlib.lib_ref "core.True.type")
   in
   let coq_I =
     EConstr.of_constr
-      (UnivGen.constr_of_monomorphic_global @@ Coqlib.lib_ref "core.True.I")
+      (UnivGen.constr_of_monomorphic_global (Global.env ()) @@ Coqlib.lib_ref "core.True.I")
   in
   let open Tacticals.New in
   let rec scan_type context type_of_hyp : unit Proofview.tactic =
@@ -1494,7 +1494,7 @@ let prove_principle_for_gen (f_ref, functional_ref, eq_ref) tcc_lemma_ref is_mes
         | Value lemma -> EConstr.of_constr lemma
         | Not_needed ->
           EConstr.of_constr
-            ( UnivGen.constr_of_monomorphic_global
+            ( UnivGen.constr_of_monomorphic_global (Global.env ())
             @@ Coqlib.lib_ref "core.True.I" )
       in
       (*   let rec list_diff del_list check_list = *)

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -333,15 +333,15 @@ let rec_pte_id = Id.of_string "Hrec"
 let clean_hyp_with_heq ptes_infos eq_hyps hyp_id env sigma =
   let coq_False =
     EConstr.of_constr
-      (UnivGen.constr_of_monomorphic_global (Global.env ()) @@ Coqlib.lib_ref "core.False.type")
+      (UnivGen.constr_of_monomorphic_global env @@ Coqlib.lib_ref "core.False.type")
   in
   let coq_True =
     EConstr.of_constr
-      (UnivGen.constr_of_monomorphic_global (Global.env ()) @@ Coqlib.lib_ref "core.True.type")
+      (UnivGen.constr_of_monomorphic_global env @@ Coqlib.lib_ref "core.True.type")
   in
   let coq_I =
     EConstr.of_constr
-      (UnivGen.constr_of_monomorphic_global (Global.env ()) @@ Coqlib.lib_ref "core.True.I")
+      (UnivGen.constr_of_monomorphic_global env @@ Coqlib.lib_ref "core.True.I")
   in
   let open Tacticals.New in
   let rec scan_type context type_of_hyp : unit Proofview.tactic =

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -1512,7 +1512,7 @@ let prove_principle_for_gen (f_ref, functional_ref, eq_ref) tcc_lemma_ref is_mes
         Proofview.Goal.enter (fun gls ->
             let hyps = Tacmach.New.pf_ids_of_hyps gls in
             let hid =
-              next_ident_away_in_goal (Id.of_string "prov")
+              next_ident_away_in_goal (Global.env ()) (Id.of_string "prov")
                 (Id.Set.of_list hyps)
             in
             tclTHENLIST

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -795,7 +795,7 @@ let generalize_non_dep hyp =
               Id.List.mem hyp hyps
               || List.exists (Termops.occur_var_in_decl env sigma hyp) keep
               || Termops.occur_var env sigma hyp hyp_typ
-              || Termops.is_section_variable hyp
+              || Termops.is_section_variable (Global.env ()) hyp
               (* should be dangerous *)
             then (clear, decl :: keep)
             else (hyp :: clear, keep))

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -489,10 +489,10 @@ let generate_type evd g_to_f f graph =
   in
   let named_ctxt = Id.Set.of_list (List.map_filter filter fun_ctxt) in
   let res_id =
-    Namegen.next_ident_away_in_goal (Id.of_string "_res") named_ctxt
+    Namegen.next_ident_away_in_goal (Global.env ()) (Id.of_string "_res") named_ctxt
   in
   let fv_id =
-    Namegen.next_ident_away_in_goal (Id.of_string "fv")
+    Namegen.next_ident_away_in_goal (Global.env ()) (Id.of_string "fv")
       (Id.Set.add res_id named_ctxt)
   in
   (*i we can then type the argument to be applied to the function [f] i*)
@@ -588,7 +588,7 @@ let find_induction_principle evd f =
 let rec generate_fresh_id x avoid i =
   if i == 0 then []
   else
-    let id = Namegen.next_ident_away_in_goal x (Id.Set.of_list avoid) in
+    let id = Namegen.next_ident_away_in_goal (Global.env ()) x (Id.Set.of_list avoid) in
     id :: generate_fresh_id x (id :: avoid) (pred i)
 
 let prove_fun_correct evd graphs_constr schemes lemmas_types_infos i :
@@ -623,7 +623,7 @@ let prove_fun_correct evd graphs_constr schemes lemmas_types_infos i :
          using a name
       *)
       let principle_id =
-        Namegen.next_ident_away_in_goal (Id.of_string "princ")
+        Namegen.next_ident_away_in_goal (Global.env ()) (Id.of_string "princ")
           (Id.Set.of_list ids)
       in
       let ids = principle_id :: ids in

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -969,7 +969,7 @@ and intros_with_rewrite_aux () : unit Proofview.tactic =
         | Ind _
           when EConstr.eq_constr sigma t
                  (EConstr.of_constr
-                    ( UnivGen.constr_of_monomorphic_global
+                    ( UnivGen.constr_of_monomorphic_global (Global.env ())
                     @@ Coqlib.lib_ref "core.False.type" )) ->
           tauto
         | Case (_, _, _, _, _, v, _) ->

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -11,7 +11,7 @@ let mk_complete_id id = Nameops.add_suffix (mk_rel_id id) "_complete"
 let mk_equation_id id = Nameops.add_suffix id "_equation"
 
 let fresh_id avoid s =
-  Namegen.next_ident_away_in_goal (Id.of_string s) (Id.Set.of_list avoid)
+  Namegen.next_ident_away_in_goal (Global.env ()) (Id.of_string s) (Id.Set.of_list avoid)
 
 let fresh_name avoid s = Name (fresh_id avoid s)
 

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -73,7 +73,7 @@ let list_union_eq eq_fun l1 l2 =
   urec l1
 
 let list_add_set_eq eq_fun x l = if List.exists (eq_fun x) l then l else x :: l
-let coq_constant s = UnivGen.constr_of_monomorphic_global @@ Coqlib.lib_ref s
+let coq_constant s = UnivGen.constr_of_monomorphic_global (Global.env ()) @@ Coqlib.lib_ref s
 
 let find_reference sl s =
   let dp = Names.DirPath.make (List.rev_map Id.of_string sl) in
@@ -383,14 +383,14 @@ exception ToShow of exn
 let jmeq () =
   try
     Coqlib.check_required_library Coqlib.jmeq_module_name;
-    EConstr.of_constr @@ UnivGen.constr_of_monomorphic_global
+    EConstr.of_constr @@ UnivGen.constr_of_monomorphic_global (Global.env ())
     @@ Coqlib.lib_ref "core.JMeq.type"
   with e when CErrors.noncritical e -> raise (ToShow e)
 
 let jmeq_refl () =
   try
     Coqlib.check_required_library Coqlib.jmeq_module_name;
-    EConstr.of_constr @@ UnivGen.constr_of_monomorphic_global
+    EConstr.of_constr @@ UnivGen.constr_of_monomorphic_global (Global.env ())
     @@ Coqlib.lib_ref "core.JMeq.refl"
   with e when CErrors.noncritical e -> raise (ToShow e)
 
@@ -414,7 +414,7 @@ let ltof_ref = function () -> find_reference ["Coq"; "Arith"; "Wf_nat"] "ltof"
 let make_eq () =
   try
     EConstr.of_constr
-      (UnivGen.constr_of_monomorphic_global (Coqlib.lib_ref "core.eq.type"))
+      (UnivGen.constr_of_monomorphic_global (Global.env ()) (Coqlib.lib_ref "core.eq.type"))
   with _ -> assert false
 
 let evaluable_of_global_reference r =

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -101,12 +101,12 @@ let pf_get_new_ids idl g =
     idl []
 
 let next_ident_away_in_goal ids avoid =
-  next_ident_away_in_goal ids (Id.Set.of_list avoid)
+  next_ident_away_in_goal (Global.env ()) ids (Id.Set.of_list avoid)
 
 let compute_renamed_type gls id =
   let t = Tacmach.New.pf_get_hyp_typ id gls in
   if Clenv.rename_with () then
-    rename_bound_vars_as_displayed (Proofview.Goal.sigma gls)
+    rename_bound_vars_as_displayed (Global.env ()) (Proofview.Goal.sigma gls)
       (*no avoid*) Id.Set.empty (*no rels*) []
       t
   else

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -42,10 +42,10 @@ open Context.Rel.Declaration
 (* Ugly things which should not be here *)
 
 let coq_constant s =
-  EConstr.of_constr @@ UnivGen.constr_of_monomorphic_global @@ Coqlib.lib_ref s
+  EConstr.of_constr @@ UnivGen.constr_of_monomorphic_global (Global.env ()) @@ Coqlib.lib_ref s
 
 let coq_init_constant s =
-  EConstr.of_constr (UnivGen.constr_of_monomorphic_global @@ Coqlib.lib_ref s)
+  EConstr.of_constr (UnivGen.constr_of_monomorphic_global (Global.env ()) @@ Coqlib.lib_ref s)
 
 let find_reference sl s =
   let dp = Names.DirPath.make (List.rev_map Id.of_string sl) in
@@ -85,7 +85,7 @@ let type_of_const sigma t =
     Typeops.type_of_constant_in (Global.env ()) (sp, u)
   | _ -> assert false
 
-let constant sl s = UnivGen.constr_of_monomorphic_global (find_reference sl s)
+let constant sl s = UnivGen.constr_of_monomorphic_global (Global.env ()) (find_reference sl s)
 
 let const_of_ref = function
   | GlobRef.ConstRef kn -> kn
@@ -131,7 +131,7 @@ let iter_ref () =
   with Not_found -> user_err Pp.(str "Module Recdef not loaded.")
 
 let iter_rd = function
-  | () -> constr_of_monomorphic_global (delayed_force iter_ref)
+  | () -> constr_of_monomorphic_global (Global.env ()) (delayed_force iter_ref)
 
 let eq = function () -> coq_init_constant "core.eq.type"
 let le_lt_SS = function () -> constant ["Recdef"] "le_lt_SS"
@@ -151,7 +151,7 @@ let max_ref = function () -> find_reference ["Recdef"] "max"
 
 let max_constr = function
   | () ->
-    EConstr.of_constr (constr_of_monomorphic_global (delayed_force max_ref))
+    EConstr.of_constr (constr_of_monomorphic_global (Global.env ()) (delayed_force max_ref))
 
 let f_S t = mkApp (delayed_force coq_S, [|t|])
 
@@ -1164,7 +1164,7 @@ let compute_terminate_type nb_args func =
   let open Constr in
   let open CVars in
   let _, a_arrow_b, _ =
-    destLambda (def_of_const (constr_of_monomorphic_global func))
+    destLambda (def_of_const (constr_of_monomorphic_global (Global.env ()) func))
   in
   let rev_args, b = decompose_prod_n nb_args a_arrow_b in
   let left =
@@ -1172,7 +1172,7 @@ let compute_terminate_type nb_args func =
       ( delayed_force iter_rd
       , Array.of_list
           ( lift 5 a_arrow_b :: mkRel 3
-          :: constr_of_monomorphic_global func
+          :: constr_of_monomorphic_global (Global.env ()) func
           :: mkRel 1
           :: List.rev (List.map_i (fun i _ -> mkRel (6 + i)) 0 rev_args) ) )
   in
@@ -1197,7 +1197,7 @@ let compute_terminate_type nb_args func =
   in
   let value =
     mkApp
-      ( constr_of_monomorphic_global (Util.delayed_force coq_sig_ref)
+      ( constr_of_monomorphic_global (Global.env ()) (Util.delayed_force coq_sig_ref)
       , [|b; mkLambda (make_annot (Name v_id) Sorts.Relevant, b, nb_iter)|] )
   in
   compose_prod rev_args value
@@ -1279,7 +1279,7 @@ let whole_start concl_tac nb_args is_mes func input_type relation rec_arg_num :
       let sigma = Proofview.Goal.sigma g in
       let hyps = Proofview.Goal.hyps g in
       let ids = Termops.ids_of_named_context hyps in
-      let func_body = def_of_const (constr_of_monomorphic_global func) in
+      let func_body = def_of_const (constr_of_monomorphic_global (Global.env ()) func) in
       let func_body = EConstr.of_constr func_body in
       let f_name, _, body1 = destLambda sigma func_body in
       let f_id =
@@ -1339,7 +1339,7 @@ exception EmptySubgoals
 
 let build_and_l sigma l =
   let and_constr =
-    UnivGen.constr_of_monomorphic_global @@ Coqlib.lib_ref "core.and.type"
+    UnivGen.constr_of_monomorphic_global (Global.env ()) @@ Coqlib.lib_ref "core.and.type"
   in
   let conj_constr = Coqlib.lib_ref "core.and.conj" in
   let mk_and p1 p2 = mkApp (EConstr.of_constr and_constr, [|p1; p2|]) in
@@ -1363,7 +1363,7 @@ let build_and_l sigma l =
       let c, tac, nb = f pl in
       ( mk_and p1 c
       , tclTHENS
-          (apply (EConstr.of_constr (constr_of_monomorphic_global conj_constr)))
+          (apply (EConstr.of_constr (constr_of_monomorphic_global (Global.env ()) conj_constr)))
           [tclIDTAC; tac]
       , nb + 1 )
   in
@@ -1552,7 +1552,7 @@ let start_equation (f : GlobRef.t) (term_f : GlobRef.t)
   Proofview.Goal.enter (fun g ->
       let sigma = Proofview.Goal.sigma g in
       let ids = Tacmach.New.pf_ids_of_hyps g in
-      let terminate_constr = constr_of_monomorphic_global term_f in
+      let terminate_constr = constr_of_monomorphic_global (Global.env ()) term_f in
       let terminate_constr = EConstr.of_constr terminate_constr in
       let nargs =
         nb_prod sigma (EConstr.of_constr (type_of_const sigma terminate_constr))
@@ -1580,7 +1580,7 @@ let com_eqn uctx nb_arg eq_name functional_ref f_ref terminate_ref
     | _ -> anomaly ~label:"terminate_lemma" (Pp.str "not a constant.")
   in
   let evd = Evd.from_ctx uctx in
-  let f_constr = constr_of_monomorphic_global f_ref in
+  let f_constr = constr_of_monomorphic_global (Global.env ()) f_ref in
   let equation_lemma_type = subst1 f_constr equation_lemma_type in
   let info = Declare.Info.make () in
   let cinfo =
@@ -1598,7 +1598,7 @@ let com_eqn uctx nb_arg eq_name functional_ref f_ref terminate_ref
                 { nb_arg
                 ; f_terminate =
                     EConstr.of_constr
-                      (constr_of_monomorphic_global terminate_ref)
+                      (constr_of_monomorphic_global (Global.env ()) terminate_ref)
                 ; f_constr = EConstr.of_constr f_constr
                 ; concl_tac = Tacticals.New.tclIDTAC
                 ; func = functional_ref
@@ -1606,7 +1606,7 @@ let com_eqn uctx nb_arg eq_name functional_ref f_ref terminate_ref
                     instantiate_lambda Evd.empty
                       (EConstr.of_constr
                          (def_of_const
-                            (constr_of_monomorphic_global functional_ref)))
+                            (constr_of_monomorphic_global (Global.env ()) functional_ref)))
                       (EConstr.of_constr f_constr :: List.map mkVar x)
                 ; is_main_branch = true
                 ; is_final = true
@@ -1743,10 +1743,10 @@ let recursive_definition ~interactive_proof ~is_mes function_name rec_impls
     in
     if not stop then
       let eq_ref = Nametab.locate (qualid_of_ident equation_id) in
-      let f_ref = destConst (constr_of_monomorphic_global f_ref)
+      let f_ref = destConst (constr_of_monomorphic_global (Global.env ()) f_ref)
       and functional_ref =
-        destConst (constr_of_monomorphic_global functional_ref)
-      and eq_ref = destConst (constr_of_monomorphic_global eq_ref) in
+        destConst (constr_of_monomorphic_global (Global.env ()) functional_ref)
+      and eq_ref = destConst (constr_of_monomorphic_global (Global.env ()) eq_ref) in
       generate_induction_principle f_ref tcc_lemma_constr functional_ref eq_ref
         rec_arg_num
         (EConstr.of_constr rec_arg_type)

--- a/plugins/ltac/evar_tactics.ml
+++ b/plugins/ltac/evar_tactics.ml
@@ -93,7 +93,7 @@ let let_evar name typ =
     let sigma, _ = Typing.sort_of env sigma typ in
     let id = match name with
     | Name.Anonymous ->
-      let id = Namegen.id_of_name_using_hdchar (Global.env ()) sigma typ name in
+      let id = Namegen.id_of_name_using_hdchar env sigma typ name in
       Namegen.next_ident_away_in_goal env id (Termops.vars_of_env env)
     | Name.Name id -> id
     in

--- a/plugins/ltac/evar_tactics.ml
+++ b/plugins/ltac/evar_tactics.ml
@@ -93,8 +93,8 @@ let let_evar name typ =
     let sigma, _ = Typing.sort_of env sigma typ in
     let id = match name with
     | Name.Anonymous ->
-      let id = Namegen.id_of_name_using_hdchar env sigma typ name in
-      Namegen.next_ident_away_in_goal id (Termops.vars_of_env env)
+      let id = Namegen.id_of_name_using_hdchar (Global.env ()) sigma typ name in
+      Namegen.next_ident_away_in_goal env id (Termops.vars_of_env env)
     | Name.Name id -> id
     in
     let (sigma, evar) = Evarutil.new_evar env sigma ~src ~naming:(Namegen.IntroFresh id) typ in

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -184,12 +184,12 @@ end) = struct
 
   let proper_type env (sigma,cstrs) =
     let l = (proper_class env sigma).cl_impl in
-    let (sigma, c) = Evarutil.new_global (Global.env ()) sigma l in
+    let (sigma, c) = Evarutil.new_global env sigma l in
     (sigma, cstrs), c
 
   let proper_proxy_type env (sigma,cstrs) =
     let l = (proper_proxy_class env sigma).cl_impl in
-    let (sigma, c) = Evarutil.new_global (Global.env ()) sigma l in
+    let (sigma, c) = Evarutil.new_global env sigma l in
     (sigma, cstrs), c
 
   let proper_proof env evars carrier relation x =

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -74,7 +74,7 @@ type evars = evar_map * Evar.Set.t (* goal evars, constraint evars *)
 let find_global dir s =
   let gr = lazy (find_reference dir s) in
     fun (evd,cstrs) ->
-      let (evd, c) = Evarutil.new_global (Global.env ()) evd (Lazy.force gr) in
+      let (evd, c) = Evd.fresh_global (Global.env ()) evd (Lazy.force gr) in
         (evd, cstrs), c
 
 (** Utility for dealing with polymorphic applications *)
@@ -184,12 +184,12 @@ end) = struct
 
   let proper_type env (sigma,cstrs) =
     let l = (proper_class env sigma).cl_impl in
-    let (sigma, c) = Evarutil.new_global env sigma l in
+    let (sigma, c) = Evd.fresh_global env sigma l in
     (sigma, cstrs), c
 
   let proper_proxy_type env (sigma,cstrs) =
     let l = (proper_proxy_class env sigma).cl_impl in
-    let (sigma, c) = Evarutil.new_global env sigma l in
+    let (sigma, c) = Evd.fresh_global env sigma l in
     (sigma, cstrs), c
 
   let proper_proof env evars carrier relation x =
@@ -743,7 +743,7 @@ let default_flags = { under_lambdas = true; on_morphisms = true; }
 let get_opt_rew_rel = function RewPrf (rel, prf) -> Some rel | _ -> None
 
 let new_global (evars, cstrs) gr =
-  let (sigma,c) = Evarutil.new_global (Global.env ()) evars gr in
+  let (sigma,c) = Evd.fresh_global (Global.env ()) evars gr in
   (sigma, cstrs), c
 
 let make_eq sigma =

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -74,7 +74,7 @@ type evars = evar_map * Evar.Set.t (* goal evars, constraint evars *)
 let find_global dir s =
   let gr = lazy (find_reference dir s) in
     fun (evd,cstrs) ->
-      let (evd, c) = Evarutil.new_global evd (Lazy.force gr) in
+      let (evd, c) = Evarutil.new_global (Global.env ()) evd (Lazy.force gr) in
         (evd, cstrs), c
 
 (** Utility for dealing with polymorphic applications *)
@@ -184,12 +184,12 @@ end) = struct
 
   let proper_type env (sigma,cstrs) =
     let l = (proper_class env sigma).cl_impl in
-    let (sigma, c) = Evarutil.new_global sigma l in
+    let (sigma, c) = Evarutil.new_global (Global.env ()) sigma l in
     (sigma, cstrs), c
 
   let proper_proxy_type env (sigma,cstrs) =
     let l = (proper_proxy_class env sigma).cl_impl in
-    let (sigma, c) = Evarutil.new_global sigma l in
+    let (sigma, c) = Evarutil.new_global (Global.env ()) sigma l in
     (sigma, cstrs), c
 
   let proper_proof env evars carrier relation x =
@@ -743,7 +743,7 @@ let default_flags = { under_lambdas = true; on_morphisms = true; }
 let get_opt_rew_rel = function RewPrf (rel, prf) -> Some rel | _ -> None
 
 let new_global (evars, cstrs) gr =
-  let (sigma,c) = Evarutil.new_global evars gr in
+  let (sigma,c) = Evarutil.new_global (Global.env ()) evars gr in
   (sigma, cstrs), c
 
 let make_eq sigma =

--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -139,7 +139,7 @@ let selecti s m =
     *)
 
 let constr_of_ref str =
-  EConstr.of_constr (UnivGen.constr_of_monomorphic_global (Coqlib.lib_ref str))
+  EConstr.of_constr (UnivGen.constr_of_monomorphic_global (Global.env ()) (Coqlib.lib_ref str))
 
 let coq_and = lazy (constr_of_ref "core.and.type")
 let coq_or = lazy (constr_of_ref "core.or.type")

--- a/plugins/micromega/zify.ml
+++ b/plugins/micromega/zify.ml
@@ -20,7 +20,7 @@ let debug_zify = CDebug.create ~name:"zify" ()
 
 let zify str =
   EConstr.of_constr
-    (UnivGen.constr_of_monomorphic_global
+    (UnivGen.constr_of_monomorphic_global (Global.env ())
        (Coqlib.lib_ref ("ZifyClasses." ^ str)))
 
 (** classes *)
@@ -675,7 +675,7 @@ module MakeTable (E : Elt) = struct
      *)
   let register c =
     try
-      let c = UnivGen.constr_of_monomorphic_global (Nametab.locate c) in
+      let c = UnivGen.constr_of_monomorphic_global (Global.env ()) (Nametab.locate c) in
       let _ = Lib.add_anonymous_leaf (register_obj c) in
       ()
     with Not_found ->

--- a/plugins/nsatz/nsatz.ml
+++ b/plugins/nsatz/nsatz.ml
@@ -125,7 +125,7 @@ let mul = function
   | (Const n,q) when Q.(equal one) n -> q
   | (p,q) -> Mul(p,q)
 
-let gen_constant n = lazy (UnivGen.constr_of_monomorphic_global (Coqlib.lib_ref n))
+let gen_constant n = lazy (UnivGen.constr_of_monomorphic_global (Global.env ()) (Coqlib.lib_ref n))
 
 let tpexpr  = gen_constant "plugins.ring.pexpr"
 let ttconst = gen_constant "plugins.ring.const"
@@ -533,7 +533,7 @@ let nsatz lpol =
 
 let return_term t =
   let a =
-    mkApp (UnivGen.constr_of_monomorphic_global @@ Coqlib.lib_ref "core.eq.refl",[|tllp ();t|]) in
+    mkApp (UnivGen.constr_of_monomorphic_global (Global.env ()) @@ Coqlib.lib_ref "core.eq.refl",[|tllp ();t|]) in
   let a = EConstr.of_constr a in
   generalize [a]
 

--- a/plugins/ring/ring.ml
+++ b/plugins/ring/ring.ml
@@ -204,7 +204,7 @@ let exec_tactic env sigma n f args =
   let nf c = constr_of sigma c in
   Array.map nf !tactic_res, Evd.universe_context_set sigma
 
-let gen_constant n = lazy (EConstr.of_constr (UnivGen.constr_of_monomorphic_global (Coqlib.lib_ref n)))
+let gen_constant n = lazy (EConstr.of_constr (UnivGen.constr_of_monomorphic_global (Global.env ()) (Coqlib.lib_ref n)))
 let gen_reference n = lazy (Coqlib.lib_ref n)
 
 let coq_mk_Setoid = gen_constant "plugins.ring.Build_Setoid_Theory"
@@ -248,7 +248,7 @@ let plugin_modules =
     ]
 
 let my_constant c =
-  lazy (EConstr.of_constr (UnivGen.constr_of_monomorphic_global @@ Coqlib.gen_reference_in_modules "Ring" plugin_modules c))
+  lazy (EConstr.of_constr (UnivGen.constr_of_monomorphic_global (Global.env ()) @@ Coqlib.gen_reference_in_modules "Ring" plugin_modules c))
     [@@ocaml.warning "-3"]
 let my_reference c =
   lazy (Coqlib.gen_reference_in_modules "Ring" plugin_modules c)
@@ -853,7 +853,7 @@ let ftheory_to_obj : field_info -> obj =
 let field_equality env sigma r inv req =
   match EConstr.kind sigma req with
     | App (f, [| _ |]) when eq_constr_nounivs sigma f (Lazy.force coq_eq) ->
-        let c = UnivGen.constr_of_monomorphic_global Coqlib.(lib_ref "core.eq.congr") in
+        let c = UnivGen.constr_of_monomorphic_global (Global.env ()) Coqlib.(lib_ref "core.eq.congr") in
         let c = EConstr.of_constr c in
         mkApp(c,[|r;r;inv|])
     | _ ->

--- a/plugins/ring/ring.ml
+++ b/plugins/ring/ring.ml
@@ -218,7 +218,7 @@ let coq_nil = gen_reference "core.list.nil"
 let lapp f args = mkApp(Lazy.force f,args)
 
 let plapp sigma f args =
-  let sigma, fc = Evarutil.new_global (Global.env ()) sigma (Lazy.force f) in
+  let sigma, fc = Evd.fresh_global (Global.env ()) sigma (Lazy.force f) in
   sigma, mkApp(fc,args)
 
 let dest_rel0 sigma t =
@@ -510,7 +510,7 @@ let make_hyp env sigma c =
   plapp sigma coq_mkhypo [|t;c|]
 
 let make_hyp_list env sigma lH =
-  let sigma, carrier = Evarutil.new_global env sigma (Lazy.force coq_hypo) in
+  let sigma, carrier = Evd.fresh_global env sigma (Lazy.force coq_hypo) in
   let sigma, l =
     List.fold_right
       (fun c (sigma,l) ->
@@ -523,7 +523,7 @@ let make_hyp_list env sigma lH =
   sigma, Evarutil.nf_evars_universes sigma l'
 
 let interp_power env sigma pow =
-  let sigma, carrier = Evarutil.new_global env sigma (Lazy.force coq_hypo) in
+  let sigma, carrier = Evd.fresh_global env sigma (Lazy.force coq_hypo) in
   match pow with
   | None ->
       let t = ArgArg(Loc.tag (Lazy.force ltac_inv_morph_nothing)) in
@@ -541,7 +541,7 @@ let interp_power env sigma pow =
       sigma, (tac, pow)
 
 let interp_sign env sigma sign =
-  let sigma, carrier = Evarutil.new_global env sigma (Lazy.force coq_hypo) in
+  let sigma, carrier = Evd.fresh_global env sigma (Lazy.force coq_hypo) in
   match sign with
   | None -> plapp sigma coq_None [|carrier|]
   | Some spec ->
@@ -550,7 +550,7 @@ let interp_sign env sigma sign =
        (* Same remark on ill-typed terms ... *)
 
 let interp_div env sigma div =
-  let sigma, carrier = Evarutil.new_global env sigma (Lazy.force coq_hypo) in
+  let sigma, carrier = Evd.fresh_global env sigma (Lazy.force coq_hypo) in
   match div with
   | None -> plapp sigma coq_None [|carrier|]
   | Some spec ->

--- a/plugins/ring/ring.ml
+++ b/plugins/ring/ring.ml
@@ -510,7 +510,7 @@ let make_hyp env sigma c =
   plapp sigma coq_mkhypo [|t;c|]
 
 let make_hyp_list env sigma lH =
-  let sigma, carrier = Evarutil.new_global (Global.env ()) sigma (Lazy.force coq_hypo) in
+  let sigma, carrier = Evarutil.new_global env sigma (Lazy.force coq_hypo) in
   let sigma, l =
     List.fold_right
       (fun c (sigma,l) ->
@@ -523,7 +523,7 @@ let make_hyp_list env sigma lH =
   sigma, Evarutil.nf_evars_universes sigma l'
 
 let interp_power env sigma pow =
-  let sigma, carrier = Evarutil.new_global (Global.env ()) sigma (Lazy.force coq_hypo) in
+  let sigma, carrier = Evarutil.new_global env sigma (Lazy.force coq_hypo) in
   match pow with
   | None ->
       let t = ArgArg(Loc.tag (Lazy.force ltac_inv_morph_nothing)) in
@@ -541,7 +541,7 @@ let interp_power env sigma pow =
       sigma, (tac, pow)
 
 let interp_sign env sigma sign =
-  let sigma, carrier = Evarutil.new_global (Global.env ()) sigma (Lazy.force coq_hypo) in
+  let sigma, carrier = Evarutil.new_global env sigma (Lazy.force coq_hypo) in
   match sign with
   | None -> plapp sigma coq_None [|carrier|]
   | Some spec ->
@@ -550,7 +550,7 @@ let interp_sign env sigma sign =
        (* Same remark on ill-typed terms ... *)
 
 let interp_div env sigma div =
-  let sigma, carrier = Evarutil.new_global (Global.env ()) sigma (Lazy.force coq_hypo) in
+  let sigma, carrier = Evarutil.new_global env sigma (Lazy.force coq_hypo) in
   match div with
   | None -> plapp sigma coq_None [|carrier|]
   | Some spec ->

--- a/plugins/ring/ring.ml
+++ b/plugins/ring/ring.ml
@@ -218,7 +218,7 @@ let coq_nil = gen_reference "core.list.nil"
 let lapp f args = mkApp(Lazy.force f,args)
 
 let plapp sigma f args =
-  let sigma, fc = Evarutil.new_global sigma (Lazy.force f) in
+  let sigma, fc = Evarutil.new_global (Global.env ()) sigma (Lazy.force f) in
   sigma, mkApp(fc,args)
 
 let dest_rel0 sigma t =
@@ -510,7 +510,7 @@ let make_hyp env sigma c =
   plapp sigma coq_mkhypo [|t;c|]
 
 let make_hyp_list env sigma lH =
-  let sigma, carrier = Evarutil.new_global sigma (Lazy.force coq_hypo) in
+  let sigma, carrier = Evarutil.new_global (Global.env ()) sigma (Lazy.force coq_hypo) in
   let sigma, l =
     List.fold_right
       (fun c (sigma,l) ->
@@ -523,7 +523,7 @@ let make_hyp_list env sigma lH =
   sigma, Evarutil.nf_evars_universes sigma l'
 
 let interp_power env sigma pow =
-  let sigma, carrier = Evarutil.new_global sigma (Lazy.force coq_hypo) in
+  let sigma, carrier = Evarutil.new_global (Global.env ()) sigma (Lazy.force coq_hypo) in
   match pow with
   | None ->
       let t = ArgArg(Loc.tag (Lazy.force ltac_inv_morph_nothing)) in
@@ -541,7 +541,7 @@ let interp_power env sigma pow =
       sigma, (tac, pow)
 
 let interp_sign env sigma sign =
-  let sigma, carrier = Evarutil.new_global sigma (Lazy.force coq_hypo) in
+  let sigma, carrier = Evarutil.new_global (Global.env ()) sigma (Lazy.force coq_hypo) in
   match sign with
   | None -> plapp sigma coq_None [|carrier|]
   | Some spec ->
@@ -550,7 +550,7 @@ let interp_sign env sigma sign =
        (* Same remark on ill-typed terms ... *)
 
 let interp_div env sigma div =
-  let sigma, carrier = Evarutil.new_global sigma (Lazy.force coq_hypo) in
+  let sigma, carrier = Evarutil.new_global (Global.env ()) sigma (Lazy.force coq_hypo) in
   match div with
   | None -> plapp sigma coq_None [|carrier|]
   | Some spec ->

--- a/plugins/rtauto/refl_tauto.ml
+++ b/plugins/rtauto/refl_tauto.ml
@@ -26,11 +26,11 @@ let step_count = ref 0
 
 let node_count = ref 0
 
-let li_False = lazy (destInd (UnivGen.constr_of_monomorphic_global @@ Coqlib.lib_ref "core.False.type"))
-let li_and   = lazy (destInd (UnivGen.constr_of_monomorphic_global @@ Coqlib.lib_ref "core.and.type"))
-let li_or    = lazy (destInd (UnivGen.constr_of_monomorphic_global @@ Coqlib.lib_ref "core.or.type"))
+let li_False = lazy (destInd (UnivGen.constr_of_monomorphic_global (Global.env ()) @@ Coqlib.lib_ref "core.False.type"))
+let li_and   = lazy (destInd (UnivGen.constr_of_monomorphic_global (Global.env ()) @@ Coqlib.lib_ref "core.and.type"))
+let li_or    = lazy (destInd (UnivGen.constr_of_monomorphic_global (Global.env ()) @@ Coqlib.lib_ref "core.or.type"))
 
-let gen_constant n = lazy (UnivGen.constr_of_monomorphic_global (Coqlib.lib_ref n))
+let gen_constant n = lazy (UnivGen.constr_of_monomorphic_global (Global.env ()) (Coqlib.lib_ref n))
 
 let l_xI = gen_constant "num.pos.xI"
 let l_xO = gen_constant "num.pos.xO"

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -1198,7 +1198,7 @@ let genclrtac cl cs clr =
       (fun type_err gl ->
          tclTHEN
            (tclTHEN (Proofview.V82.of_tactic (Tactics.elim_type (EConstr.of_constr
-             (UnivGen.constr_of_monomorphic_global @@ Coqlib.(lib_ref "core.False.type"))))) (old_cleartac clr))
+             (UnivGen.constr_of_monomorphic_global (Global.env ()) @@ Coqlib.(lib_ref "core.False.type"))))) (old_cleartac clr))
            (fun gl -> raise type_err)
            gl))
     (old_cleartac clr)

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -53,7 +53,7 @@ let hyp_id (SsrHyp (_, id)) = id
 let hyp_err ?loc msg id =
   CErrors.user_err ?loc Pp.(str msg ++ Id.print id)
 
-let not_section_id id = not (Termops.is_section_variable id)
+let not_section_id id = not (Termops.is_section_variable (Global.env ()) id)
 
 let hyps_ids = List.map hyp_id
 

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -502,7 +502,7 @@ let lz_setoid_relation =
   | Some (env', srel) when env' == env -> srel
   | _ ->
     let srel =
-       try Some (UnivGen.constr_of_monomorphic_global @@
+       try Some (UnivGen.constr_of_monomorphic_global (Global.env ()) @@
                  Coqlib.find_reference "Class_setoid" ("Coq"::sdir) "RewriteRelation" [@ocaml.warning "-3"])
        with _ -> None in
     last_srel := Some (env, srel); srel

--- a/pretyping/coercion.ml
+++ b/pretyping/coercion.ml
@@ -405,7 +405,7 @@ let apply_coercion env sigma p hj typ_cl =
       (fun (ja,typ_cl,trace,sigma) i ->
          let isid = i.coe_is_identity in
          let isproj = i.coe_is_projection in
-         let sigma, c = new_global (Global.env ()) sigma i.coe_value in
+         let sigma, c = new_global env sigma i.coe_value in
          let u = instance_of_global_constr sigma c in
          let typ = EConstr.of_constr (CVars.subst_instance_constr u i.coe_typ) in
          let fv = make_judge c typ in
@@ -448,7 +448,7 @@ let mu env sigma t =
         let sigma, (f, ct, trace) = aux u in
         let p = hnf_nodelta env sigma p in
         let p1 = delayed_force sig_proj1 in
-        let sigma, p1 = Evarutil.new_global (Global.env ()) sigma p1 in
+        let sigma, p1 = Evarutil.new_global env sigma p1 in
         sigma,
           (Some (fun sigma x ->
                    app_opt env sigma

--- a/pretyping/coercion.ml
+++ b/pretyping/coercion.ml
@@ -405,7 +405,7 @@ let apply_coercion env sigma p hj typ_cl =
       (fun (ja,typ_cl,trace,sigma) i ->
          let isid = i.coe_is_identity in
          let isproj = i.coe_is_projection in
-         let sigma, c = new_global env sigma i.coe_value in
+         let sigma, c = Evd.fresh_global env sigma i.coe_value in
          let u = instance_of_global_constr sigma c in
          let typ = EConstr.of_constr (CVars.subst_instance_constr u i.coe_typ) in
          let fv = make_judge c typ in
@@ -448,7 +448,7 @@ let mu env sigma t =
         let sigma, (f, ct, trace) = aux u in
         let p = hnf_nodelta env sigma p in
         let p1 = delayed_force sig_proj1 in
-        let sigma, p1 = Evarutil.new_global env sigma p1 in
+        let sigma, p1 = Evd.fresh_global env sigma p1 in
         sigma,
           (Some (fun sigma x ->
                    app_opt env sigma

--- a/pretyping/coercion.ml
+++ b/pretyping/coercion.ml
@@ -405,7 +405,7 @@ let apply_coercion env sigma p hj typ_cl =
       (fun (ja,typ_cl,trace,sigma) i ->
          let isid = i.coe_is_identity in
          let isproj = i.coe_is_projection in
-         let sigma, c = new_global sigma i.coe_value in
+         let sigma, c = new_global (Global.env ()) sigma i.coe_value in
          let u = instance_of_global_constr sigma c in
          let typ = EConstr.of_constr (CVars.subst_instance_constr u i.coe_typ) in
          let fv = make_judge c typ in
@@ -448,7 +448,7 @@ let mu env sigma t =
         let sigma, (f, ct, trace) = aux u in
         let p = hnf_nodelta env sigma p in
         let p1 = delayed_force sig_proj1 in
-        let sigma, p1 = Evarutil.new_global sigma p1 in
+        let sigma, p1 = Evarutil.new_global (Global.env ()) sigma p1 in
         sigma,
           (Some (fun sigma x ->
                    app_opt env sigma

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -832,7 +832,7 @@ and detype_r d flags avoid env sigma t =
       let id,l =
         try
           let id = match Evd.evar_ident evk sigma with
-          | None -> Termops.evar_suggested_name evk sigma
+          | None -> Termops.evar_suggested_name (Global.env ()) sigma evk
           | Some id -> id
           in
           let l = Evd.evar_instance_array bound_to_itself_or_letin (Evd.find sigma evk) cl in

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -153,8 +153,8 @@ match avoid with
     else RenamingElsewhereFor (fst env, c)
   in
   let na, avoid =
-    if let_in then compute_displayed_let_name_in sigma flags avoid na c
-    else compute_displayed_name_in sigma flags avoid na c
+    if let_in then compute_displayed_let_name_in (Global.env ()) sigma flags avoid na c
+    else compute_displayed_name_in (Global.env ()) sigma flags avoid na c
   in
   na, Nice avoid
 | Fast avoid ->
@@ -329,11 +329,11 @@ let computable sigma (nas, ccl) =
 let lookup_name_as_displayed env sigma t s =
   let rec lookup avoid n c = match EConstr.kind sigma c with
     | Prod (name,_,c') ->
-        (match compute_displayed_name_in sigma RenamingForGoal avoid name.binder_name c' with
+        (match compute_displayed_name_in (Global.env ()) sigma RenamingForGoal avoid name.binder_name c' with
            | (Name id,avoid') -> if Id.equal id s then Some n else lookup avoid' (n+1) c'
            | (Anonymous,avoid') -> lookup avoid' (n+1) (pop c'))
     | LetIn (name,_,_,c') ->
-        (match Namegen.compute_displayed_name_in sigma RenamingForGoal avoid name.binder_name c' with
+        (match Namegen.compute_displayed_name_in (Global.env ()) sigma RenamingForGoal avoid name.binder_name c' with
            | (Name id,avoid') -> if Id.equal id s then Some n else lookup avoid' (n+1) c'
            | (Anonymous,avoid') -> lookup avoid' (n+1) (pop c'))
     | Cast (c,_,_) -> lookup avoid n c
@@ -343,7 +343,7 @@ let lookup_name_as_displayed env sigma t s =
 let lookup_index_as_renamed env sigma t n =
   let rec lookup n d c = match EConstr.kind sigma c with
     | Prod (name,_,c') ->
-          (match Namegen.compute_displayed_name_in sigma RenamingForGoal Id.Set.empty name.binder_name c' with
+          (match Namegen.compute_displayed_name_in (Global.env ()) sigma RenamingForGoal Id.Set.empty name.binder_name c' with
                (Name _,_) -> lookup n (d+1) c'
              | (Anonymous,_) ->
                  if Int.equal n 0 then
@@ -353,7 +353,7 @@ let lookup_index_as_renamed env sigma t n =
                  else
                    lookup (n-1) (d+1) c')
     | LetIn (name,_,_,c') ->
-          (match Namegen.compute_displayed_name_in sigma RenamingForGoal Id.Set.empty name.binder_name c' with
+          (match Namegen.compute_displayed_name_in (Global.env ()) sigma RenamingForGoal Id.Set.empty name.binder_name c' with
              | (Name _,_) -> lookup n (d+1) c'
              | (Anonymous,_) ->
                  if Int.equal n 0 then

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -564,7 +564,7 @@ let pretype_instance self ~program_mode ~poly resolve_tc env sigma loc hyps evk 
       | Some b, Some c ->
          if not (is_conv !!env sigma b c) then
            user_err ?loc  (str "Cannot interpret " ++
-             pr_existential_key sigma evk ++
+             pr_existential_key (Global.env ()) sigma evk ++
              strbrk " in current context: binding for " ++ Id.print id ++
              strbrk " is not convertible to its expected definition (cannot unify " ++
              quote (Termops.Internal.print_constr_env !!env sigma b) ++
@@ -573,14 +573,14 @@ let pretype_instance self ~program_mode ~poly resolve_tc env sigma loc hyps evk 
              str ").")
       | Some b, None ->
            user_err ?loc  (str "Cannot interpret " ++
-             pr_existential_key sigma evk ++
+             pr_existential_key (Global.env ()) sigma evk ++
              strbrk " in current context: " ++ Id.print id ++
              strbrk " should be bound to a local definition.")
       | None, _ -> () in
     let check_type sigma id t' =
       if not (is_conv !!env sigma t t') then
         user_err ?loc  (str "Cannot interpret " ++
-          pr_existential_key sigma evk ++
+          pr_existential_key (Global.env ()) sigma evk ++
           strbrk " in current context: binding for " ++ Id.print id ++
           strbrk " is not well-typed.") in
     let sigma, c, update =
@@ -603,7 +603,7 @@ let pretype_instance self ~program_mode ~poly resolve_tc env sigma loc hyps evk 
         sigma, mkVar id, update
       with Not_found ->
         user_err ?loc  (str "Cannot interpret " ++
-          pr_existential_key sigma evk ++
+          pr_existential_key (Global.env ()) sigma evk ++
           str " in current context: no binding for " ++ Id.print id ++ str ".") in
     ((id,c)::subst, update, sigma) in
   let subst,inst,sigma = List.fold_right f hyps ([],update,sigma) in

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -564,7 +564,7 @@ let pretype_instance self ~program_mode ~poly resolve_tc env sigma loc hyps evk 
       | Some b, Some c ->
          if not (is_conv !!env sigma b c) then
            user_err ?loc  (str "Cannot interpret " ++
-             pr_existential_key (Global.env ()) sigma evk ++
+             pr_existential_key !!env sigma evk ++
              strbrk " in current context: binding for " ++ Id.print id ++
              strbrk " is not convertible to its expected definition (cannot unify " ++
              quote (Termops.Internal.print_constr_env !!env sigma b) ++
@@ -573,14 +573,14 @@ let pretype_instance self ~program_mode ~poly resolve_tc env sigma loc hyps evk 
              str ").")
       | Some b, None ->
            user_err ?loc  (str "Cannot interpret " ++
-             pr_existential_key (Global.env ()) sigma evk ++
+             pr_existential_key !!env sigma evk ++
              strbrk " in current context: " ++ Id.print id ++
              strbrk " should be bound to a local definition.")
       | None, _ -> () in
     let check_type sigma id t' =
       if not (is_conv !!env sigma t t') then
         user_err ?loc  (str "Cannot interpret " ++
-          pr_existential_key (Global.env ()) sigma evk ++
+          pr_existential_key !!env sigma evk ++
           strbrk " in current context: binding for " ++ Id.print id ++
           strbrk " is not well-typed.") in
     let sigma, c, update =
@@ -603,7 +603,7 @@ let pretype_instance self ~program_mode ~poly resolve_tc env sigma loc hyps evk 
         sigma, mkVar id, update
       with Not_found ->
         user_err ?loc  (str "Cannot interpret " ++
-          pr_existential_key (Global.env ()) sigma evk ++
+          pr_existential_key !!env sigma evk ++
           str " in current context: no binding for " ++ Id.print id ++ str ".") in
     ((id,c)::subst, update, sigma) in
   let subst,inst,sigma = List.fold_right f hyps ([],update,sigma) in

--- a/pretyping/program.ml
+++ b/pretyping/program.ml
@@ -14,7 +14,7 @@ open Util
 let papp sigma r args =
   let open EConstr in
   let gr = delayed_force r in
-  let evd, hd = Evarutil.new_global sigma gr in
+  let evd, hd = Evarutil.new_global (Global.env ()) sigma gr in
   sigma, mkApp (hd, args)
 
 let sig_typ   () = Coqlib.lib_ref "core.sig.type"
@@ -38,7 +38,7 @@ let coq_eq_refl_ref () = Coqlib.lib_ref "core.eq.refl"
 let coq_eq_rect     () = Coqlib.lib_ref "core.eq.rect"
 
 let mk_coq_not sigma x =
-  let sigma, notc = Evarutil.new_global sigma Coqlib.(lib_ref "core.not.type") in
+  let sigma, notc = Evarutil.new_global (Global.env ()) sigma Coqlib.(lib_ref "core.not.type") in
   sigma, EConstr.mkApp (notc, [| x |])
 
 let coq_JMeq_ind  () =
@@ -55,7 +55,7 @@ let unsafe_fold_right f = function
   | [] -> invalid_arg "unsafe_fold_right"
 
 let mk_coq_and sigma l =
-  let sigma, and_typ = Evarutil.new_global sigma Coqlib.(lib_ref "core.and.type") in
+  let sigma, and_typ = Evarutil.new_global (Global.env ()) sigma Coqlib.(lib_ref "core.and.type") in
   sigma, unsafe_fold_right
       (fun c conj ->
          EConstr.(mkApp (and_typ, [| c ; conj |])))

--- a/pretyping/program.ml
+++ b/pretyping/program.ml
@@ -14,7 +14,7 @@ open Util
 let papp sigma r args =
   let open EConstr in
   let gr = delayed_force r in
-  let evd, hd = Evarutil.new_global (Global.env ()) sigma gr in
+  let evd, hd = Evd.fresh_global (Global.env ()) sigma gr in
   sigma, mkApp (hd, args)
 
 let sig_typ   () = Coqlib.lib_ref "core.sig.type"
@@ -38,7 +38,7 @@ let coq_eq_refl_ref () = Coqlib.lib_ref "core.eq.refl"
 let coq_eq_rect     () = Coqlib.lib_ref "core.eq.rect"
 
 let mk_coq_not sigma x =
-  let sigma, notc = Evarutil.new_global (Global.env ()) sigma Coqlib.(lib_ref "core.not.type") in
+  let sigma, notc = Evd.fresh_global (Global.env ()) sigma Coqlib.(lib_ref "core.not.type") in
   sigma, EConstr.mkApp (notc, [| x |])
 
 let coq_JMeq_ind  () =
@@ -55,7 +55,7 @@ let unsafe_fold_right f = function
   | [] -> invalid_arg "unsafe_fold_right"
 
 let mk_coq_and sigma l =
-  let sigma, and_typ = Evarutil.new_global (Global.env ()) sigma Coqlib.(lib_ref "core.and.type") in
+  let sigma, and_typ = Evd.fresh_global (Global.env ()) sigma Coqlib.(lib_ref "core.and.type") in
   sigma, unsafe_fold_right
       (fun c conj ->
          EConstr.(mkApp (and_typ, [| c ; conj |])))

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1687,7 +1687,7 @@ let make_abstraction_core name (test,out) env sigma c ty occs check_occs concl =
     let t = match ty with Some t -> t | None -> get_type_of env sigma c in
     let x = id_of_name_using_hdchar env sigma t name in
     let ids = Environ.ids_of_named_context_val (named_context_val env) in
-    if name == Anonymous then next_ident_away_in_goal x ids else
+    if name == Anonymous then next_ident_away_in_goal (Global.env ()) x ids else
     if mem_named_context_val x (named_context_val env) then
       user_err
         (str "The variable " ++ Id.print x ++ str " is already declared.")

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1687,7 +1687,7 @@ let make_abstraction_core name (test,out) env sigma c ty occs check_occs concl =
     let t = match ty with Some t -> t | None -> get_type_of env sigma c in
     let x = id_of_name_using_hdchar env sigma t name in
     let ids = Environ.ids_of_named_context_val (named_context_val env) in
-    if name == Anonymous then next_ident_away_in_goal (Global.env ()) x ids else
+    if name == Anonymous then next_ident_away_in_goal env x ids else
     if mem_named_context_val x (named_context_val env) then
       user_err
         (str "The variable " ++ Id.print x ++ str " is already declared.")

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -483,13 +483,13 @@ let pr_goal_tag g =
 
 (* display a goal name *)
 let pr_goal_name sigma g =
-  if should_gname() then str " " ++ Pp.surround (pr_existential_key sigma g)
+  if should_gname() then str " " ++ Pp.surround (pr_existential_key (Global.env ()) sigma g)
   else mt ()
 
 let pr_goal_header nme sigma g =
   let (g,sigma) = Goal.V82.nf_evar sigma g in
   str "goal " ++ nme ++ (if should_tag() then pr_goal_tag g else str"")
-  ++ (if should_gname() then str " " ++ Pp.surround (pr_existential_key sigma g) else mt ())
+  ++ (if should_gname() then str " " ++ Pp.surround (pr_existential_key (Global.env ()) sigma g) else mt ())
 
 (* display the conclusion of a goal *)
 let pr_concl n ?(diffs=false) ?og_s sigma g =
@@ -534,7 +534,7 @@ let pr_evgl_sign env sigma evi =
 let pr_evar sigma (evk, evi) =
   let env = Global.env () in
   let pegl = pr_evgl_sign env sigma evi in
-  hov 0 (pr_existential_key sigma evk ++ str " : " ++ pegl)
+  hov 0 (pr_existential_key (Global.env ()) sigma evk ++ str " : " ++ pegl)
 
 (* Print an enumerated list of existential variables *)
 let rec pr_evars_int_hd pr sigma i = function
@@ -649,7 +649,7 @@ let print_dependent_evars gl sigma seeds =
         let sep = if s = mt_pp then "" else ", " in
         s ++ str sep ++ e' ++
             (match i with
-            | None -> str ":" ++ (Termops.pr_existential_key sigma e)
+            | None -> str ":" ++ (Termops.pr_existential_key (Global.env ()) sigma e)
             | Some i ->
               let using = Evar.Set.fold (fun d s ->
                   s ++ str " " ++ (pr_internal_existential_key d))

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -534,7 +534,7 @@ let pr_evgl_sign env sigma evi =
 let pr_evar sigma (evk, evi) =
   let env = Global.env () in
   let pegl = pr_evgl_sign env sigma evi in
-  hov 0 (pr_existential_key (Global.env ()) sigma evk ++ str " : " ++ pegl)
+  hov 0 (pr_existential_key env sigma evk ++ str " : " ++ pegl)
 
 (* Print an enumerated list of existential variables *)
 let rec pr_evars_int_hd pr sigma i = function

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -150,7 +150,7 @@ val pr_global_env          : Id.Set.t -> GlobRef.t -> Pp.t
 val pr_global              : GlobRef.t -> Pp.t
 
 val pr_constant            : env -> Constant.t -> Pp.t
-val pr_existential_key     : evar_map -> Evar.t -> Pp.t
+val pr_existential_key     : env -> evar_map -> Evar.t -> Pp.t
 val pr_existential         : env -> evar_map -> existential -> Pp.t
 val pr_constructor         : env -> constructor -> Pp.t
 val pr_inductive           : env -> inductive -> Pp.t

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -576,7 +576,7 @@ let to_constr pf =
 
 module GoalMap = Evar.Map
 
-let goal_to_evar g sigma = Id.to_string (Termops.evar_suggested_name g sigma)
+let goal_to_evar g sigma = Id.to_string (Termops.evar_suggested_name (Global.env ()) sigma g)
 
 open Goal.Set
 

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -715,7 +715,7 @@ let make_clenv_binding_gen hyps_only n env sigma (c,t) = function
       let clause = mk_clenv_from_env env sigma n (c,t) in
       clenv_constrain_dep_args hyps_only largs clause
   | ExplicitBindings lbind ->
-      let t = if rename_with () then rename_bound_vars_as_displayed (Global.env ()) sigma Id.Set.empty [] t else t in
+      let t = if rename_with () then rename_bound_vars_as_displayed env sigma Id.Set.empty [] t else t in
       let clause = mk_clenv_from_env env sigma n (c, t) in clenv_match_args lbind clause
   | NoBindings ->
       mk_clenv_from_env env sigma n (c,t)
@@ -754,7 +754,7 @@ let make_evar_clause env sigma ?len t =
   | None -> -1
   | Some n -> assert (0 <= n); n
   in
-  let t = if rename_with () then rename_bound_vars_as_displayed (Global.env ()) sigma Id.Set.empty [] t else t in
+  let t = if rename_with () then rename_bound_vars_as_displayed env sigma Id.Set.empty [] t else t in
   let rec clrec (sigma, holes) inst n t =
     if n = 0 then (sigma, holes, t)
     else match EConstr.kind sigma t with

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -715,7 +715,7 @@ let make_clenv_binding_gen hyps_only n env sigma (c,t) = function
       let clause = mk_clenv_from_env env sigma n (c,t) in
       clenv_constrain_dep_args hyps_only largs clause
   | ExplicitBindings lbind ->
-      let t = if rename_with () then rename_bound_vars_as_displayed sigma Id.Set.empty [] t else t in
+      let t = if rename_with () then rename_bound_vars_as_displayed (Global.env ()) sigma Id.Set.empty [] t else t in
       let clause = mk_clenv_from_env env sigma n (c, t) in clenv_match_args lbind clause
   | NoBindings ->
       mk_clenv_from_env env sigma n (c,t)
@@ -754,7 +754,7 @@ let make_evar_clause env sigma ?len t =
   | None -> -1
   | Some n -> assert (0 <= n); n
   in
-  let t = if rename_with () then rename_bound_vars_as_displayed sigma Id.Set.empty [] t else t in
+  let t = if rename_with () then rename_bound_vars_as_displayed (Global.env ()) sigma Id.Set.empty [] t else t in
   let rec clrec (sigma, holes) inst n t =
     if n = 0 then (sigma, holes, t)
     else match EConstr.kind sigma t with

--- a/proofs/evar_refiner.ml
+++ b/proofs/evar_refiner.ml
@@ -63,6 +63,6 @@ let w_refine (evk,evi) (ltac_var,rawc) env sigma =
       let loc = Glob_ops.loc_of_glob_constr rawc in
       user_err ?loc
                 (str "Instance is not well-typed in the environment of " ++
-                 Termops.pr_existential_key (Global.env ()) sigma evk ++ str ".")
+                 Termops.pr_existential_key env sigma evk ++ str ".")
   in
   define_and_solve_constraints evk typed_c env (evars_reset_evd sigma' sigma)

--- a/proofs/evar_refiner.ml
+++ b/proofs/evar_refiner.ml
@@ -63,6 +63,6 @@ let w_refine (evk,evi) (ltac_var,rawc) env sigma =
       let loc = Glob_ops.loc_of_glob_constr rawc in
       user_err ?loc
                 (str "Instance is not well-typed in the environment of " ++
-                 Termops.pr_existential_key sigma evk ++ str ".")
+                 Termops.pr_existential_key (Global.env ()) sigma evk ++ str ".")
   in
   define_and_solve_constraints evk typed_c env (evars_reset_evd sigma' sigma)

--- a/stm/partac.ml
+++ b/stm/partac.ml
@@ -128,7 +128,7 @@ end = struct (* {{{ *)
                 CErrors.user_err
                   Pp.(str"The par: selector requires a tactic that makes no progress or fully" ++
                       str" solves the goal and leaves no unresolved existential variables. The following" ++
-                      str" existentials remain unsolved: " ++ prlist (Termops.pr_existential_key sigma) (Evar.Set.elements evars))
+                      str" existentials remain unsolved: " ++ prlist (Termops.pr_existential_key (Global.env ()) sigma) (Evar.Set.elements evars))
        )
     with e when CErrors.noncritical e ->
       RespError (CErrors.print e ++ spc() ++ str "(for goal "++int r_goalno ++ str ")")

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -1807,7 +1807,7 @@ let subst_one_var dep_proof_ok x =
             (str "Cannot find any non-recursive equality over " ++ Id.print x ++
                str".")
         with FoundHyp res -> res in
-      if is_section_variable x then
+      if is_section_variable (Global.env ()) x then
         check_non_indirectly_dependent_section_variable gl x;
       subst_one dep_proof_ok x res
   end

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -781,7 +781,7 @@ let with_uid c = { obj = c; uid = fresh_key () }
 
 let secvars_of_idset s =
   Id.Set.fold (fun id p ->
-      if is_section_variable id then
+      if is_section_variable (Global.env ()) id then
         Id.Pred.add id p
       else p) s Id.Pred.empty
 

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -153,7 +153,7 @@ let clear_dependency_msg env sigma id err inglobal =
       Printer.pr_existential env sigma ev ++ str"."
   | Evarutil.NoCandidatesLeft ev ->
       str "Cannot remove " ++ ppid id ++ str " as it would leave the existential " ++
-      Printer.pr_existential_key sigma ev ++ str" without candidates."
+      Printer.pr_existential_key (Global.env ()) sigma ev ++ str" without candidates."
 
 let replacing_dependency_msg env sigma id err inglobal =
   let pp = clear_in_global_msg inglobal in
@@ -169,7 +169,7 @@ let replacing_dependency_msg env sigma id err inglobal =
       Printer.pr_existential env sigma ev ++ str"."
   | Evarutil.NoCandidatesLeft ev ->
       str "Cannot change " ++ Id.print id ++ str " as it would leave the existential " ++
-      Printer.pr_existential_key sigma ev ++ str" without candidates."
+      Printer.pr_existential_key (Global.env ()) sigma ev ++ str" without candidates."
 
 let msg_quantified_hypothesis = function
   | NamedHyp id ->

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -502,7 +502,7 @@ let rename_hyp repl =
 let fresh_id_in_env avoid id env =
   let avoid' = ids_of_named_context_val (named_context_val env) in
   let avoid = if Id.Set.is_empty avoid then avoid' else Id.Set.union avoid' avoid in
-  next_ident_away_in_goal id avoid
+  next_ident_away_in_goal (Global.env ()) id avoid
 
 let fresh_id avoid id gl =
   fresh_id_in_env avoid id (Tacmach.pf_env gl)
@@ -2798,7 +2798,7 @@ let pose_tac na c =
       id
     | Anonymous ->
       let id = id_of_name_using_hdchar env sigma t Anonymous in
-      next_ident_away_in_goal id (ids_of_named_context_val hyps)
+      next_ident_away_in_goal (Global.env ()) id (ids_of_named_context_val hyps)
     in
     Proofview.Unsafe.tclEVARS sigma <*>
     Refine.refine ~typecheck:false begin fun sigma ->

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -153,7 +153,7 @@ let clear_dependency_msg env sigma id err inglobal =
       Printer.pr_existential env sigma ev ++ str"."
   | Evarutil.NoCandidatesLeft ev ->
       str "Cannot remove " ++ ppid id ++ str " as it would leave the existential " ++
-      Printer.pr_existential_key (Global.env ()) sigma ev ++ str" without candidates."
+      Printer.pr_existential_key env sigma ev ++ str" without candidates."
 
 let replacing_dependency_msg env sigma id err inglobal =
   let pp = clear_in_global_msg inglobal in
@@ -169,7 +169,7 @@ let replacing_dependency_msg env sigma id err inglobal =
       Printer.pr_existential env sigma ev ++ str"."
   | Evarutil.NoCandidatesLeft ev ->
       str "Cannot change " ++ Id.print id ++ str " as it would leave the existential " ++
-      Printer.pr_existential_key (Global.env ()) sigma ev ++ str" without candidates."
+      Printer.pr_existential_key env sigma ev ++ str" without candidates."
 
 let msg_quantified_hypothesis = function
   | NamedHyp id ->

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -3699,12 +3699,12 @@ let make_up_names n ind_opt cname =
 
 let error_ind_scheme s = error (NotAnInductionScheme s)
 
-let coq_eq sigma       = Evarutil.new_global (Global.env ()) sigma Coqlib.(lib_ref "core.eq.type")
-let coq_eq_refl sigma  = Evarutil.new_global (Global.env ()) sigma Coqlib.(lib_ref "core.eq.refl")
+let coq_eq sigma       = Evd.fresh_global (Global.env ()) sigma Coqlib.(lib_ref "core.eq.type")
+let coq_eq_refl sigma  = Evd.fresh_global (Global.env ()) sigma Coqlib.(lib_ref "core.eq.refl")
 
 let coq_heq_ref        = lazy (Coqlib.lib_ref "core.JMeq.type")
-let coq_heq sigma      = Evarutil.new_global (Global.env ()) sigma (Lazy.force coq_heq_ref)
-let coq_heq_refl sigma = Evarutil.new_global (Global.env ()) sigma (Coqlib.lib_ref "core.JMeq.refl")
+let coq_heq sigma      = Evd.fresh_global (Global.env ()) sigma (Lazy.force coq_heq_ref)
+let coq_heq_refl sigma = Evd.fresh_global (Global.env ()) sigma (Coqlib.lib_ref "core.JMeq.refl")
 (* let coq_heq_refl = lazy (glob (lib_ref "core.JMeq.refl")) *)
 
 let mkEq sigma t x y =

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -3699,12 +3699,12 @@ let make_up_names n ind_opt cname =
 
 let error_ind_scheme s = error (NotAnInductionScheme s)
 
-let coq_eq sigma       = Evarutil.new_global sigma Coqlib.(lib_ref "core.eq.type")
-let coq_eq_refl sigma  = Evarutil.new_global sigma Coqlib.(lib_ref "core.eq.refl")
+let coq_eq sigma       = Evarutil.new_global (Global.env ()) sigma Coqlib.(lib_ref "core.eq.type")
+let coq_eq_refl sigma  = Evarutil.new_global (Global.env ()) sigma Coqlib.(lib_ref "core.eq.refl")
 
 let coq_heq_ref        = lazy (Coqlib.lib_ref "core.JMeq.type")
-let coq_heq sigma      = Evarutil.new_global sigma (Lazy.force coq_heq_ref)
-let coq_heq_refl sigma = Evarutil.new_global sigma (Coqlib.lib_ref "core.JMeq.refl")
+let coq_heq sigma      = Evarutil.new_global (Global.env ()) sigma (Lazy.force coq_heq_ref)
+let coq_heq_refl sigma = Evarutil.new_global (Global.env ()) sigma (Coqlib.lib_ref "core.JMeq.refl")
 (* let coq_heq_refl = lazy (glob (lib_ref "core.JMeq.refl")) *)
 
 let mkEq sigma t x y =

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -63,20 +63,20 @@ exception ConstructorWithNonParametricInductiveType of inductive
 exception DecidabilityIndicesNotSupported
 
 (* Some pre declaration of constant we are going to use *)
-let andb_prop = fun _ -> UnivGen.constr_of_monomorphic_global (Coqlib.lib_ref "core.bool.andb_prop")
+let andb_prop = fun _ -> UnivGen.constr_of_monomorphic_global (Global.env ()) (Coqlib.lib_ref "core.bool.andb_prop")
 
 let andb_true_intro = fun _ ->
-  UnivGen.constr_of_monomorphic_global
+  UnivGen.constr_of_monomorphic_global (Global.env ())
     (Coqlib.lib_ref "core.bool.andb_true_intro")
 
 (* We avoid to use lazy as the binding of constants can change *)
-let bb () = UnivGen.constr_of_monomorphic_global (Coqlib.lib_ref "core.bool.type")
-let tt () = UnivGen.constr_of_monomorphic_global (Coqlib.lib_ref "core.bool.true")
-let ff () = UnivGen.constr_of_monomorphic_global (Coqlib.lib_ref "core.bool.false")
-let eq () = UnivGen.constr_of_monomorphic_global (Coqlib.lib_ref "core.eq.type")
+let bb () = UnivGen.constr_of_monomorphic_global (Global.env ()) (Coqlib.lib_ref "core.bool.type")
+let tt () = UnivGen.constr_of_monomorphic_global (Global.env ()) (Coqlib.lib_ref "core.bool.true")
+let ff () = UnivGen.constr_of_monomorphic_global (Global.env ()) (Coqlib.lib_ref "core.bool.false")
+let eq () = UnivGen.constr_of_monomorphic_global (Global.env ()) (Coqlib.lib_ref "core.eq.type")
 
-let sumbool () = UnivGen.constr_of_monomorphic_global (Coqlib.lib_ref "core.sumbool.type")
-let andb = fun _ -> UnivGen.constr_of_monomorphic_global (Coqlib.lib_ref "core.bool.andb")
+let sumbool () = UnivGen.constr_of_monomorphic_global (Global.env ()) (Coqlib.lib_ref "core.sumbool.type")
+let andb = fun _ -> UnivGen.constr_of_monomorphic_global (Global.env ()) (Coqlib.lib_ref "core.bool.andb")
 
 let induct_on  c = induction false None c None None
 let destruct_on c = destruct false None c None None
@@ -908,7 +908,7 @@ let compute_dec_goal env ind lnamesparrec nparrec =
         create_input (
           mkNamedProd (make_annot x Sorts.Relevant) (mkFullInd env ind (2*nparrec)) (
             mkNamedProd (make_annot y Sorts.Relevant) (mkFullInd env ind (2*nparrec+1)) (
-              mkApp(sumbool(),[|eqnm;mkApp (UnivGen.constr_of_monomorphic_global @@ Coqlib.lib_ref "core.not.type",[|eqnm|])|])
+              mkApp(sumbool(),[|eqnm;mkApp (UnivGen.constr_of_monomorphic_global (Global.env ()) @@ Coqlib.lib_ref "core.not.type",[|eqnm|])|])
           )
         )
       )

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -156,7 +156,7 @@ type ('constr, 'types) recursive_preentry =
 (* Wellfounded definition *)
 
 let fix_proto sigma =
-  Evarutil.new_global sigma (Coqlib.lib_ref "program.tactic.fix_proto")
+  Evarutil.new_global (Global.env ()) sigma (Coqlib.lib_ref "program.tactic.fix_proto")
 
 let interp_recursive env ~program_mode ~cofix (fixl : 'a Vernacexpr.fix_expr_gen list) =
   let open Context.Named.Declaration in

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -156,7 +156,7 @@ type ('constr, 'types) recursive_preentry =
 (* Wellfounded definition *)
 
 let fix_proto sigma =
-  Evarutil.new_global (Global.env ()) sigma (Coqlib.lib_ref "program.tactic.fix_proto")
+  Evd.fresh_global (Global.env ()) sigma (Coqlib.lib_ref "program.tactic.fix_proto")
 
 let interp_recursive env ~program_mode ~cofix (fixl : 'a Vernacexpr.fix_expr_gen list) =
   let open Context.Named.Declaration in

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -31,14 +31,14 @@ module RelDecl = Context.Rel.Declaration
 
 open Coqlib
 
-let init_constant sigma rf = Evarutil.new_global sigma rf
+let init_constant sigma rf = Evd.fresh_global sigma rf
 let fix_sub_ref () = lib_ref "program.wf.fix_sub"
 let measure_on_R_ref () = lib_ref "program.wf.mr"
 let well_founded sigma = init_constant (Global.env ()) sigma (lib_ref "core.wf.well_founded")
 
 let mkSubset sigma name typ prop =
   let open EConstr in
-  let sigma, app_h = Evarutil.new_global (Global.env ()) sigma (delayed_force build_sigma).typ in
+  let sigma, app_h = Evd.fresh_global (Global.env ()) sigma (delayed_force build_sigma).typ in
   sigma, mkApp (app_h, [| typ; mkLambda (make_annot name Sorts.Relevant, typ, prop) |])
 
 let make_qref s = qualid_of_string s
@@ -59,7 +59,7 @@ let get_sigmatypes sigma ~sort ~predsort =
     | PropF, TypeF -> "sig", TypeF
     | TypeF, (PropF|TypeF) -> "sigT", TypeF
   in
-  let sigma, ty = Evarutil.new_global (Global.env ()) sigma (lib_ref ("core."^which^".type")) in
+  let sigma, ty = Evd.fresh_global (Global.env ()) sigma (lib_ref ("core."^which^".type")) in
   let uinstance = snd (destRef sigma ty) in
   let intro = mkRef (lib_ref ("core."^which^".intro"), uinstance) in
   let p1 = mkRef (lib_ref ("core."^which^".proj1"), uinstance) in
@@ -146,7 +146,7 @@ let build_wellfounded pm (recname,pl,bl,arityc,body) poly ?typing_flags ?using r
       it_mkLambda_or_LetIn measure letbinders,
       it_mkLambda_or_LetIn measure binders
     in
-    let sigma, comb = Evarutil.new_global (Global.env ()) sigma (delayed_force measure_on_R_ref) in
+    let sigma, comb = Evd.fresh_global (Global.env ()) sigma (delayed_force measure_on_R_ref) in
     let wf_rel = mkApp (comb, [| argtyp; relargty; rel; measure |]) in
     let wf_rel_fun x y =
       mkApp (rel, [| subst1 x measure_body;
@@ -165,7 +165,7 @@ let build_wellfounded pm (recname,pl,bl,arityc,body) poly ?typing_flags ?using r
     sigma, wfa :: [arg]
   in
   let _intern_env = push_rel_context intern_bl env in
-  let sigma, proj = Evarutil.new_global (Global.env ()) sigma (delayed_force build_sigma).Coqlib.proj1 in
+  let sigma, proj = Evd.fresh_global (Global.env ()) sigma (delayed_force build_sigma).Coqlib.proj1 in
   let wfargpred = mkLambda (make_annot (Name argid') Sorts.Relevant, argtyp, wf_rel_fun (mkRel 1) (mkRel 3)) in
   let projection = (* in wfarg :: arg :: before *)
     mkApp (proj, [| argtyp ; wfargpred ; mkRel 1 |])
@@ -180,7 +180,7 @@ let build_wellfounded pm (recname,pl,bl,arityc,body) poly ?typing_flags ?using r
                                       intern_fun_arity_prod) in
   let sigma, curry_fun =
     let wfpred = mkLambda (make_annot (Name argid') Sorts.Relevant, argtyp, wf_rel_fun (mkRel 1) (mkRel (2 * len + 4))) in
-    let sigma, intro = Evarutil.new_global (Global.env ()) sigma (delayed_force build_sigma).Coqlib.intro in
+    let sigma, intro = Evd.fresh_global (Global.env ()) sigma (delayed_force build_sigma).Coqlib.intro in
     let arg = mkApp (intro, [| argtyp; wfpred; lift 1 make; mkRel 1 |]) in
     let app = mkApp (mkRel (2 * len + 2 (* recproof + orig binders + current binders *)), [| arg |]) in
     let rcurry = mkApp (rel, [| measure; lift len measure |]) in
@@ -209,7 +209,7 @@ let build_wellfounded pm (recname,pl,bl,arityc,body) poly ?typing_flags ?using r
   (* XXX: Previous code did parallel evdref update, so possible old
      weak ordering semantics may bite here. *)
   let sigma, def =
-    let sigma, h_a_term = Evarutil.new_global (Global.env ()) sigma (delayed_force fix_sub_ref) in
+    let sigma, h_a_term = Evd.fresh_global (Global.env ()) sigma (delayed_force fix_sub_ref) in
     let sigma, h_e_term = Evarutil.new_evar env sigma
         ~src:(Loc.tag @@ Evar_kinds.QuestionMark {
             Evar_kinds.default_question_mark with Evar_kinds.qm_obligation=Evar_kinds.Define false;
@@ -229,7 +229,7 @@ let build_wellfounded pm (recname,pl,bl,arityc,body) poly ?typing_flags ?using r
       (* XXX: Mutating the evar_map in the hook! *)
       (* XXX: Likely the sigma is out of date when the hook is called .... *)
       let hook sigma { Declare.Hook.S.dref; _ } =
-        let sigma, h_body = Evarutil.new_global (Global.env ()) sigma dref in
+        let sigma, h_body = Evd.fresh_global (Global.env ()) sigma dref in
         let body = it_mkLambda_or_LetIn (mkApp (h_body, [|make|])) binders_rel in
         let ty = it_mkProd_or_LetIn top_arity binders_rel in
         let ty = EConstr.Unsafe.to_constr ty in

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -34,11 +34,11 @@ open Coqlib
 let init_constant sigma rf = Evarutil.new_global sigma rf
 let fix_sub_ref () = lib_ref "program.wf.fix_sub"
 let measure_on_R_ref () = lib_ref "program.wf.mr"
-let well_founded sigma = init_constant sigma (lib_ref "core.wf.well_founded")
+let well_founded sigma = init_constant (Global.env ()) sigma (lib_ref "core.wf.well_founded")
 
 let mkSubset sigma name typ prop =
   let open EConstr in
-  let sigma, app_h = Evarutil.new_global sigma (delayed_force build_sigma).typ in
+  let sigma, app_h = Evarutil.new_global (Global.env ()) sigma (delayed_force build_sigma).typ in
   sigma, mkApp (app_h, [| typ; mkLambda (make_annot name Sorts.Relevant, typ, prop) |])
 
 let make_qref s = qualid_of_string s
@@ -59,7 +59,7 @@ let get_sigmatypes sigma ~sort ~predsort =
     | PropF, TypeF -> "sig", TypeF
     | TypeF, (PropF|TypeF) -> "sigT", TypeF
   in
-  let sigma, ty = Evarutil.new_global sigma (lib_ref ("core."^which^".type")) in
+  let sigma, ty = Evarutil.new_global (Global.env ()) sigma (lib_ref ("core."^which^".type")) in
   let uinstance = snd (destRef sigma ty) in
   let intro = mkRef (lib_ref ("core."^which^".intro"), uinstance) in
   let p1 = mkRef (lib_ref ("core."^which^".proj1"), uinstance) in
@@ -146,7 +146,7 @@ let build_wellfounded pm (recname,pl,bl,arityc,body) poly ?typing_flags ?using r
       it_mkLambda_or_LetIn measure letbinders,
       it_mkLambda_or_LetIn measure binders
     in
-    let sigma, comb = Evarutil.new_global sigma (delayed_force measure_on_R_ref) in
+    let sigma, comb = Evarutil.new_global (Global.env ()) sigma (delayed_force measure_on_R_ref) in
     let wf_rel = mkApp (comb, [| argtyp; relargty; rel; measure |]) in
     let wf_rel_fun x y =
       mkApp (rel, [| subst1 x measure_body;
@@ -165,7 +165,7 @@ let build_wellfounded pm (recname,pl,bl,arityc,body) poly ?typing_flags ?using r
     sigma, wfa :: [arg]
   in
   let _intern_env = push_rel_context intern_bl env in
-  let sigma, proj = Evarutil.new_global sigma (delayed_force build_sigma).Coqlib.proj1 in
+  let sigma, proj = Evarutil.new_global (Global.env ()) sigma (delayed_force build_sigma).Coqlib.proj1 in
   let wfargpred = mkLambda (make_annot (Name argid') Sorts.Relevant, argtyp, wf_rel_fun (mkRel 1) (mkRel 3)) in
   let projection = (* in wfarg :: arg :: before *)
     mkApp (proj, [| argtyp ; wfargpred ; mkRel 1 |])
@@ -180,7 +180,7 @@ let build_wellfounded pm (recname,pl,bl,arityc,body) poly ?typing_flags ?using r
                                       intern_fun_arity_prod) in
   let sigma, curry_fun =
     let wfpred = mkLambda (make_annot (Name argid') Sorts.Relevant, argtyp, wf_rel_fun (mkRel 1) (mkRel (2 * len + 4))) in
-    let sigma, intro = Evarutil.new_global sigma (delayed_force build_sigma).Coqlib.intro in
+    let sigma, intro = Evarutil.new_global (Global.env ()) sigma (delayed_force build_sigma).Coqlib.intro in
     let arg = mkApp (intro, [| argtyp; wfpred; lift 1 make; mkRel 1 |]) in
     let app = mkApp (mkRel (2 * len + 2 (* recproof + orig binders + current binders *)), [| arg |]) in
     let rcurry = mkApp (rel, [| measure; lift len measure |]) in
@@ -209,7 +209,7 @@ let build_wellfounded pm (recname,pl,bl,arityc,body) poly ?typing_flags ?using r
   (* XXX: Previous code did parallel evdref update, so possible old
      weak ordering semantics may bite here. *)
   let sigma, def =
-    let sigma, h_a_term = Evarutil.new_global sigma (delayed_force fix_sub_ref) in
+    let sigma, h_a_term = Evarutil.new_global (Global.env ()) sigma (delayed_force fix_sub_ref) in
     let sigma, h_e_term = Evarutil.new_evar env sigma
         ~src:(Loc.tag @@ Evar_kinds.QuestionMark {
             Evar_kinds.default_question_mark with Evar_kinds.qm_obligation=Evar_kinds.Define false;
@@ -229,7 +229,7 @@ let build_wellfounded pm (recname,pl,bl,arityc,body) poly ?typing_flags ?using r
       (* XXX: Mutating the evar_map in the hook! *)
       (* XXX: Likely the sigma is out of date when the hook is called .... *)
       let hook sigma { Declare.Hook.S.dref; _ } =
-        let sigma, h_body = Evarutil.new_global sigma dref in
+        let sigma, h_body = Evarutil.new_global (Global.env ()) sigma dref in
         let body = it_mkLambda_or_LetIn (mkApp (h_body, [|make|])) binders_rel in
         let ty = it_mkProd_or_LetIn top_arity binders_rel in
         let ty = EConstr.Unsafe.to_constr ty in

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -2089,7 +2089,7 @@ let finish_proved_equations ~pm ~kind ~hook i proof_obj types sigma0 =
         let entry, args = Internal.shrink_entry local_context entry in
         let entry = Internal.pmap_entry_body ~f:Future.from_val entry in
         let cst = declare_constant ~name:id ~kind ~typing_flags:None (DefinitionEntry entry) in
-        let sigma, app = Evarutil.new_global sigma (GlobRef.ConstRef cst) in
+        let sigma, app = Evarutil.new_global (Global.env ()) sigma (GlobRef.ConstRef cst) in
         let sigma = Evd.define ev (EConstr.applist (app, List.map EConstr.of_constr args)) sigma in
         sigma, cst) sigma0
       types proof_obj.entries

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -2089,7 +2089,7 @@ let finish_proved_equations ~pm ~kind ~hook i proof_obj types sigma0 =
         let entry, args = Internal.shrink_entry local_context entry in
         let entry = Internal.pmap_entry_body ~f:Future.from_val entry in
         let cst = declare_constant ~name:id ~kind ~typing_flags:None (DefinitionEntry entry) in
-        let sigma, app = Evarutil.new_global (Global.env ()) sigma (GlobRef.ConstRef cst) in
+        let sigma, app = Evd.fresh_global (Global.env ()) sigma (GlobRef.ConstRef cst) in
         let sigma = Evd.define ev (EConstr.applist (app, List.map EConstr.of_constr args)) sigma in
         sigma, cst) sigma0
       types proof_obj.entries

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -741,7 +741,7 @@ let declare_parameter ~name ~scope ~hook ~impargs ~uctx pe =
 (* Preparing proof entries *)
 let error_unresolved_evars env sigma t evars =
   let pr_unresolved_evar e =
-    hov 2 (str"- " ++ Printer.pr_existential_key sigma e ++  str ": " ++
+    hov 2 (str"- " ++ Printer.pr_existential_key (Global.env ()) sigma e ++  str ": " ++
       Himsg.explain_pretype_error env sigma
         (Pretype_errors.UnsolvableImplicit (e,None)))
   in

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -741,7 +741,7 @@ let declare_parameter ~name ~scope ~hook ~impargs ~uctx pe =
 (* Preparing proof entries *)
 let error_unresolved_evars env sigma t evars =
   let pr_unresolved_evar e =
-    hov 2 (str"- " ++ Printer.pr_existential_key (Global.env ()) sigma e ++  str ": " ++
+    hov 2 (str"- " ++ Printer.pr_existential_key env sigma e ++  str ": " ++
       Himsg.explain_pretype_error env sigma
         (Pretype_errors.UnsolvableImplicit (e,None)))
   in

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -297,12 +297,12 @@ let explain_unification_error env sigma p1 p2 = function
   | Some e ->
      let rec aux p1 p2 = function
      | OccurCheck (evk,rhs) ->
-        [str "cannot define " ++ quote (pr_existential_key (Global.env ()) sigma evk) ++
+        [str "cannot define " ++ quote (pr_existential_key env sigma evk) ++
         strbrk " with term " ++ pr_leconstr_env env sigma rhs ++
         strbrk " that would depend on itself"]
      | NotClean ((evk,args),env,c) ->
         let env = make_all_name_different env sigma in
-        [str "cannot instantiate " ++ quote (pr_existential_key (Global.env ()) sigma evk)
+        [str "cannot instantiate " ++ quote (pr_existential_key env sigma evk)
         ++ strbrk " because " ++ pr_leconstr_env env sigma c ++
         strbrk " is not in its scope" ++
         (if List.is_empty args then mt() else
@@ -327,13 +327,13 @@ let explain_unification_error env sigma p1 p2 = function
         let t1, t2 = pr_explicit env sigma t1 t2 in
         [ev ++ strbrk " has otherwise to unify with " ++ t1 ++ str " which is incompatible with " ++ t2]
      | MetaOccurInBody evk ->
-        [str "instance for " ++ quote (pr_existential_key (Global.env ()) sigma evk) ++
+        [str "instance for " ++ quote (pr_existential_key env sigma evk) ++
         strbrk " refers to a metavariable - please report your example" ++
         strbrk "at " ++ str Coq_config.wwwbugtracker ++ str "."]
      | InstanceNotSameType (evk,env,t,u) ->
         let t, u = pr_explicit env sigma t u in
         [str "unable to find a well-typed instantiation for " ++
-        quote (pr_existential_key (Global.env ()) sigma evk) ++
+        quote (pr_existential_key env sigma evk) ++
         strbrk ": cannot ensure that " ++
         t ++ strbrk " is a subtype of " ++ u]
      | InstanceNotFunctionalType (evk,env,f,u) ->
@@ -341,7 +341,7 @@ let explain_unification_error env sigma p1 p2 = function
         let f = pr_leconstr_env env sigma f in
         let u = pr_leconstr_env env sigma u in
         [str "unable to find a well-typed instantiation for " ++
-        quote (pr_existential_key (Global.env ()) sigma evk) ++
+        quote (pr_existential_key env sigma evk) ++
         strbrk ": " ++ f ++
         strbrk " is expected to have a functional type but it has type " ++ u]
      | UnifUnivInconsistency p ->
@@ -556,7 +556,7 @@ let explain_cant_find_case_type env sigma c =
 let explain_occur_check env sigma ev rhs =
   let env = make_all_name_different env sigma in
   let pt = pr_leconstr_env env sigma rhs in
-  str "Cannot define " ++ pr_existential_key (Global.env ()) sigma ev ++ str " with term" ++
+  str "Cannot define " ++ pr_existential_key env sigma ev ++ str " with term" ++
   brk(1,1) ++ pt ++ spc () ++ str "that would depend on itself."
 
 let pr_trailing_ne_context_of env sigma =
@@ -587,7 +587,7 @@ let rec explain_evar_kind env sigma evk ty =
       let pp = match ido with
         | Some id -> str "?" ++ Id.print id
         | None ->
-          try pr_existential_key (Global.env ()) sigma evk
+          try pr_existential_key env sigma evk
           with (* defined *) Not_found -> strbrk "an internal placeholder" in
       strbrk "the type of " ++ pp
   | Evar_kinds.ImplicitArg (c,(n,ido),b) ->
@@ -620,7 +620,7 @@ let rec explain_evar_kind env sigma evk ty =
       | Evar_defined c -> pr_leconstr_env env sigma c
       | Evar_empty -> assert false in
       let ty' = evi.evar_concl in
-      pr_existential_key (Global.env ()) sigma evk ++
+      pr_existential_key env sigma evk ++
       strbrk " in the partial instance " ++ pc ++
       strbrk " found for " ++
       explain_evar_kind env sigma evk

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -297,12 +297,12 @@ let explain_unification_error env sigma p1 p2 = function
   | Some e ->
      let rec aux p1 p2 = function
      | OccurCheck (evk,rhs) ->
-        [str "cannot define " ++ quote (pr_existential_key sigma evk) ++
+        [str "cannot define " ++ quote (pr_existential_key (Global.env ()) sigma evk) ++
         strbrk " with term " ++ pr_leconstr_env env sigma rhs ++
         strbrk " that would depend on itself"]
      | NotClean ((evk,args),env,c) ->
         let env = make_all_name_different env sigma in
-        [str "cannot instantiate " ++ quote (pr_existential_key sigma evk)
+        [str "cannot instantiate " ++ quote (pr_existential_key (Global.env ()) sigma evk)
         ++ strbrk " because " ++ pr_leconstr_env env sigma c ++
         strbrk " is not in its scope" ++
         (if List.is_empty args then mt() else
@@ -327,13 +327,13 @@ let explain_unification_error env sigma p1 p2 = function
         let t1, t2 = pr_explicit env sigma t1 t2 in
         [ev ++ strbrk " has otherwise to unify with " ++ t1 ++ str " which is incompatible with " ++ t2]
      | MetaOccurInBody evk ->
-        [str "instance for " ++ quote (pr_existential_key sigma evk) ++
+        [str "instance for " ++ quote (pr_existential_key (Global.env ()) sigma evk) ++
         strbrk " refers to a metavariable - please report your example" ++
         strbrk "at " ++ str Coq_config.wwwbugtracker ++ str "."]
      | InstanceNotSameType (evk,env,t,u) ->
         let t, u = pr_explicit env sigma t u in
         [str "unable to find a well-typed instantiation for " ++
-        quote (pr_existential_key sigma evk) ++
+        quote (pr_existential_key (Global.env ()) sigma evk) ++
         strbrk ": cannot ensure that " ++
         t ++ strbrk " is a subtype of " ++ u]
      | InstanceNotFunctionalType (evk,env,f,u) ->
@@ -341,7 +341,7 @@ let explain_unification_error env sigma p1 p2 = function
         let f = pr_leconstr_env env sigma f in
         let u = pr_leconstr_env env sigma u in
         [str "unable to find a well-typed instantiation for " ++
-        quote (pr_existential_key sigma evk) ++
+        quote (pr_existential_key (Global.env ()) sigma evk) ++
         strbrk ": " ++ f ++
         strbrk " is expected to have a functional type but it has type " ++ u]
      | UnifUnivInconsistency p ->
@@ -556,7 +556,7 @@ let explain_cant_find_case_type env sigma c =
 let explain_occur_check env sigma ev rhs =
   let env = make_all_name_different env sigma in
   let pt = pr_leconstr_env env sigma rhs in
-  str "Cannot define " ++ pr_existential_key sigma ev ++ str " with term" ++
+  str "Cannot define " ++ pr_existential_key (Global.env ()) sigma ev ++ str " with term" ++
   brk(1,1) ++ pt ++ spc () ++ str "that would depend on itself."
 
 let pr_trailing_ne_context_of env sigma =
@@ -587,7 +587,7 @@ let rec explain_evar_kind env sigma evk ty =
       let pp = match ido with
         | Some id -> str "?" ++ Id.print id
         | None ->
-          try pr_existential_key sigma evk
+          try pr_existential_key (Global.env ()) sigma evk
           with (* defined *) Not_found -> strbrk "an internal placeholder" in
       strbrk "the type of " ++ pp
   | Evar_kinds.ImplicitArg (c,(n,ido),b) ->
@@ -620,7 +620,7 @@ let rec explain_evar_kind env sigma evk ty =
       | Evar_defined c -> pr_leconstr_env env sigma c
       | Evar_empty -> assert false in
       let ty' = evi.evar_concl in
-      pr_existential_key sigma evk ++
+      pr_existential_key (Global.env ()) sigma evk ++
       strbrk " in the partial instance " ++ pc ++
       strbrk " found for " ++
       explain_evar_kind env sigma evk
@@ -662,7 +662,7 @@ let explain_var_not_found env id =
 let explain_evar_not_found env sigma id =
   let undef = Evar.Map.domain (Evd.undefined_map sigma) in
   let all_undef_evars = Evar.Set.elements undef in
-  let f ev = Id.equal id (Termops.evar_suggested_name ev sigma) in
+  let f ev = Id.equal id (Termops.evar_suggested_name (Global.env ()) sigma ev) in
   if List.exists f all_undef_evars then
     (* The name is used for printing but is not user-given *)
     str "?" ++ Id.print id ++
@@ -852,7 +852,7 @@ let pr_constraints printenv env sigma evars cstrs =
       in
       let evs =
         prlist
-        (fun (ev, evi) -> fnl () ++ pr_existential_key sigma ev ++
+        (fun (ev, evi) -> fnl () ++ pr_existential_key (Global.env ()) sigma ev ++
             str " : " ++ pr_leconstr_env env' sigma evi.evar_concl ++ fnl ()) l
       in
       h (pe ++ evs ++ pr_evar_constraints sigma cstrs)

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -452,11 +452,11 @@ let fold_left' f = function
     [] -> invalid_arg "fold_left'"
   | hd :: tl -> List.fold_left f hd tl
 
-let mk_coq_and sigma = Evarutil.new_global sigma (Coqlib.lib_ref "core.and.type")
-let mk_coq_conj sigma = Evarutil.new_global sigma (Coqlib.lib_ref "core.and.conj")
+let mk_coq_and sigma = Evarutil.new_global (Global.env ()) sigma (Coqlib.lib_ref "core.and.type")
+let mk_coq_conj sigma = Evarutil.new_global (Global.env ()) sigma (Coqlib.lib_ref "core.and.conj")
 
-let mk_coq_prod sigma = Evarutil.new_global sigma (Coqlib.lib_ref "core.prod.type")
-let mk_coq_pair sigma = Evarutil.new_global sigma (Coqlib.lib_ref "core.prod.intro")
+let mk_coq_prod sigma = Evarutil.new_global (Global.env ()) sigma (Coqlib.lib_ref "core.prod.type")
+let mk_coq_pair sigma = Evarutil.new_global (Global.env ()) sigma (Coqlib.lib_ref "core.prod.intro")
 
 let build_combined_scheme env schemes =
   let sigma = Evd.from_env env in

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -452,11 +452,11 @@ let fold_left' f = function
     [] -> invalid_arg "fold_left'"
   | hd :: tl -> List.fold_left f hd tl
 
-let mk_coq_and sigma = Evarutil.new_global (Global.env ()) sigma (Coqlib.lib_ref "core.and.type")
-let mk_coq_conj sigma = Evarutil.new_global (Global.env ()) sigma (Coqlib.lib_ref "core.and.conj")
+let mk_coq_and sigma = Evd.fresh_global (Global.env ()) sigma (Coqlib.lib_ref "core.and.type")
+let mk_coq_conj sigma = Evd.fresh_global (Global.env ()) sigma (Coqlib.lib_ref "core.and.conj")
 
-let mk_coq_prod sigma = Evarutil.new_global (Global.env ()) sigma (Coqlib.lib_ref "core.prod.type")
-let mk_coq_pair sigma = Evarutil.new_global (Global.env ()) sigma (Coqlib.lib_ref "core.prod.intro")
+let mk_coq_prod sigma = Evd.fresh_global (Global.env ()) sigma (Coqlib.lib_ref "core.prod.type")
+let mk_coq_pair sigma = Evd.fresh_global (Global.env ()) sigma (Coqlib.lib_ref "core.prod.intro")
 
 let build_combined_scheme env schemes =
   let sigma = Evd.from_env env in

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -532,7 +532,7 @@ let vernac_custom_entry ~module_local s =
 
 let check_name_freshness locality {CAst.loc;v=id} : unit =
   (* We check existence here: it's a bit late at Qed time *)
-  if Nametab.exists_cci (Lib.make_path id) || Termops.is_section_variable id ||
+  if Nametab.exists_cci (Lib.make_path id) || Termops.is_section_variable (Global.env ()) id ||
      locality <> Locality.Discharge && Nametab.exists_cci (Lib.make_path_except_section id)
   then
     user_err ?loc  (Id.print id ++ str " already exists.")


### PR DESCRIPTION
Most calls are replaced by an environment explicitly passed as an argument. The callers have been adapted to use an environment that was lying around when available and obviously innocuous, and otherwise explicitly turned into a call to `Global.env`.

The remaining calls are the tricky ones related to side-effects and section name manipulation. Their turn will come.

Overlays:
- https://github.com/coq-community/aac-tactics/pull/96
- https://github.com/LPCIC/coq-elpi/pull/302
- https://github.com/mattam82/Coq-Equations/pull/442
- https://github.com/MetaCoq/metacoq/pull/600
- https://github.com/Mtac2/Mtac2/pull/347
- https://github.com/coq-community/paramcoq/pull/85
- https://github.com/damien-pous/relation-algebra/pull/23
- https://github.com/maximedenes/vscoq/pull/3
- https://gitlab.inria.fr/gappa/coq/-/merge_requests/4