### PR TITLE
Namegen.next_ident_away_in_goal: don't avoid names of nonlocal refs

### DIFF
--- a/dev/ci/user-overlays/15071-SkySkimmer-namegen-no-glob.sh
+++ b/dev/ci/user-overlays/15071-SkySkimmer-namegen-no-glob.sh
@@ -1,0 +1,5 @@
+overlay color https://github.com/SkySkimmer/color namegen-no-glob 15071
+
+overlay vst https://github.com/SkySkimmer/VST namegen-no-glob 15071
+
+overlay metacoq https://github.com/SkySkimmer/metacoq namegen-no-glob 15071

--- a/doc/changelog/04-tactics/15071-namegen-no-glob.rst
+++ b/doc/changelog/04-tactics/15071-namegen-no-glob.rst
@@ -1,4 +1,5 @@
-- **Changed:** Name generation does not avoid names of references
+- **Changed:** Name generation no longer avoids names of references
   except for those from the current module and its ancestors (`#15071
   <https://github.com/coq/coq/pull/15071>`_, fixes `#3523
   <https://github.com/coq/coq/issues/3523>`_, by Gaëtan Gilbert).
+  The old behaviour can be restored using :flag:`Avoid Local Imported Names`.

--- a/doc/changelog/04-tactics/15071-namegen-no-glob.rst
+++ b/doc/changelog/04-tactics/15071-namegen-no-glob.rst
@@ -1,0 +1,4 @@
+- **Changed:** Name generation does not avoid names of references
+  except for those from the current module and its ancestors (`#15071
+  <https://github.com/coq/coq/pull/15071>`_, fixes `#3523
+  <https://github.com/coq/coq/issues/3523>`_, by Gaëtan Gilbert).

--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -1199,6 +1199,21 @@ Managing the local context
 
          intros m n H x.
 
+   Name generation for names introduced by :tacn:`intro` and other
+   name introducing tactics avoids the names of objects (constants,
+   inductives, constructors) from the current open module and its
+   ancestors so that those objects may be referred to without awkward
+   quantification.
+
+   .. flag:: Avoid Local Imported Names
+
+      When this flag is on (it is off by default), imported names from
+      modules defined in the current file are also avoided.
+
+      .. deprecated:: TODO
+
+         This flag is provided for compatibility with versions prior to TODO.
+
 .. tacn:: intros {* @intropattern }
           intros until {| @ident | @natural }
 

--- a/test-suite/bugs/bug_3523.v
+++ b/test-suite/bugs/bug_3523.v
@@ -1,0 +1,15 @@
+Module Foo.
+  Record foor := C { foof : Type }.
+End Foo.
+
+Module bar.
+  Import Foo.
+
+  Goal forall x : foor, x = x.
+  Proof.
+    intro x.
+    destruct x.
+    revert foof.
+    exact (fun f => eq_refl (C f)).
+  Qed.
+End bar.

--- a/theories/Compat/Coq814.v
+++ b/theories/Compat/Coq814.v
@@ -15,3 +15,5 @@ Require Export Coq.Compat.Coq815.
 Local Set Warnings "-deprecated".
 
 Export Set Apply With Renaming.
+
+Export Set Avoid Local Imported Names.

--- a/theories/FSets/FMapFacts.v
+++ b/theories/FSets/FMapFacts.v
@@ -1877,9 +1877,9 @@ Module OrdProperties (M:S).
   2: auto with map.
   intros; destruct x; destruct y; destruct p.
   rewrite gtb_1 in H; unfold O.ltk in H; simpl in *.
-  assert (~ltk (t1,e0) (k,e1)).
+  assert (~ltk (t0,e0) (k,e1)).
   - unfold gtb, O.ltk in *; simpl in *.
-    destruct (E.compare k t1); intuition; try discriminate; ME.order.
+    destruct (E.compare k t0); intuition; try discriminate; ME.order.
   - unfold O.ltk in *; simpl in *; ME.order.
   Qed.
 
@@ -1901,9 +1901,9 @@ Module OrdProperties (M:S).
            rewrite leb_1 in H2.
            destruct y; unfold O.ltk in *; simpl in *.
            rewrite <- elements_mapsto_iff in H1.
-           assert (~E.eq x t0).
+           assert (~E.eq x t).
            ++ contradict H.
-              exists e0; apply MapsTo_1 with t0; auto with ordered_type.
+              exists e0; apply MapsTo_1 with t; auto with ordered_type.
            ++ ME.order.
         -- apply (@filter_sort _ eqke). 1-3: auto with typeclass_instances. auto with map.
     + intros.
@@ -1919,12 +1919,12 @@ Module OrdProperties (M:S).
   - red; intros a; destruct a.
     rewrite InA_app_iff, InA_cons, 2 filter_InA,
       <-2 elements_mapsto_iff, leb_1, gtb_1,
-      find_mapsto_iff, (H0 t0), <- find_mapsto_iff,
+      find_mapsto_iff, (H0 t), <- find_mapsto_iff,
       add_mapsto_iff by auto with map.
     unfold O.eqke, O.ltk; simpl.
-    destruct (E.compare t0 x); intuition; try fold (~E.eq x t0); auto with ordered_type.
-    + elim H; exists e0; apply MapsTo_1 with t0; auto.
-    + fold (~E.lt t0 x); auto with ordered_type.
+    destruct (E.compare t x); intuition; try fold (~E.eq x t); auto with ordered_type.
+    + elim H; exists e0; apply MapsTo_1 with t; auto.
+    + fold (~E.lt t x); auto with ordered_type.
   Qed.
 
   Lemma elements_Add_Above : forall m m' x e,
@@ -1948,14 +1948,14 @@ Module OrdProperties (M:S).
       * inversion H3.
   - red; intros a; destruct a.
     rewrite InA_app_iff, InA_cons, InA_nil, <- 2 elements_mapsto_iff,
-      find_mapsto_iff, (H0 t0), <- find_mapsto_iff,
+      find_mapsto_iff, (H0 t), <- find_mapsto_iff,
       add_mapsto_iff.
     unfold O.eqke; simpl. intuition auto with relations.
-    destruct (E.eq_dec x t0) as [Heq|Hneq]; auto.
+    destruct (E.eq_dec x t) as [Heq|Hneq]; auto.
     exfalso.
-    assert (In t0 m).
+    assert (In t m).
     + exists e0; auto.
-    + generalize (H t0 H1).
+    + generalize (H t H1).
       ME.order.
   Qed.
 
@@ -1981,14 +1981,14 @@ Module OrdProperties (M:S).
       * inversion H3.
   - red; intros a; destruct a.
     rewrite InA_cons, <- 2 elements_mapsto_iff,
-      find_mapsto_iff, (H0 t0), <- find_mapsto_iff,
+      find_mapsto_iff, (H0 t), <- find_mapsto_iff,
       add_mapsto_iff.
     unfold O.eqke; simpl. intuition auto with relations.
-    destruct (E.eq_dec x t0) as [Heq|Hneq]; auto.
+    destruct (E.eq_dec x t) as [Heq|Hneq]; auto.
     exfalso.
-    assert (In t0 m) by
+    assert (In t m) by
       (exists e0; auto).
-    generalize (H t0 H1).
+    generalize (H t H1).
     ME.order.
   Qed.
 


### PR DESCRIPTION
Fix #3523

Overlays:
- https://github.com/mit-pdos/argosy/pull/4
- https://github.com/fblanqui/color/pull/36
- https://github.com/DeepSpec/sfdev/pull/401
- https://github.com/PrincetonUniversity/VST/pull/528
- https://github.com/MetaCoq/metacoq/pull/603
- TODO