### PR TITLE
Namegen.next_ident_away_in_goal: avoid names of all visible refs

### DIFF
--- a/test-suite/bugs/closed/bug_3523.v
+++ b/test-suite/bugs/closed/bug_3523.v
@@ -1,0 +1,14 @@
+Module Foo.
+  Record foor := C { eq : Type }.
+End Foo.
+
+Module bar.
+
+  Goal forall x : Foo.foor, x = x.
+  Proof.
+    intro x.
+    destruct x.
+    revert eq0.
+    exact (fun f => eq_refl (Foo.C f)).
+  Qed.
+End bar.

--- a/theories/Floats/FloatLemmas.v
+++ b/theories/Floats/FloatLemmas.v
@@ -166,7 +166,7 @@ Theorem ldexp_spec : forall f e, Prim2SF (ldexp f e) = SFldexp prec emax (Prim2S
         intro s0.
         destruct s0.
         unfold shr_1.
-        destruct shr_m; try (simpl; lia).
+        destruct shr_m0; try (simpl; lia).
         - destruct p; unfold Zdigits2, shr_m, digits2_pos; lia.
         - destruct p; unfold Zdigits2, shr_m, digits2_pos; lia.
       }
@@ -286,7 +286,7 @@ Theorem ldexp_spec : forall f e, Prim2SF (ldexp f e) = SFldexp prec emax (Prim2S
         unfold SpecFloat.shr_r, SpecFloat.shr_m.
         intros Hshr_r Hshr_m.
         rewrite Hshr_r, Hshr_m.
-        now destruct shr_s.
+        now destruct shr_s0.
       }
 
       rewrite H0.
@@ -318,7 +318,7 @@ Theorem ldexp_spec : forall f e, Prim2SF (ldexp f e) = SFldexp prec emax (Prim2S
         unfold SpecFloat.shr_r, SpecFloat.shr_m.
         intros Hshr_r Hshr_m.
         rewrite Hshr_r, Hshr_m.
-        now destruct shr_s.
+        now destruct shr_s0.
       }
 
       rewrite Hrne'0.

--- a/theories/Reals/Abstract/ConstructiveLimits.v
+++ b/theories/Reals/Abstract/ConstructiveLimits.v
@@ -72,9 +72,9 @@ Proof.
   - unfold CRminus.
     do 2 rewrite <- (Radd_assoc (CRisRing R)).
     apply CRplus_morph. reflexivity. rewrite CRopp_plus_distr.
-    destruct (CRisRing R). rewrite Radd_comm, <- Radd_assoc.
+    destruct (CRisRing R). rewrite Radd_comm0, <- Radd_assoc0.
     apply CRplus_morph. reflexivity.
-    rewrite Radd_comm. reflexivity.
+    rewrite Radd_comm0. reflexivity.
   - apply (CRle_trans _ _ _ (CRabs_triang _ _)).
     apply (CRle_trans _ (CRplus R (CR_of_Q R (1 # 2*p)) (CR_of_Q R (1 # 2*p)))).
     apply CRplus_le_compat. apply imaj, (le_trans _ _ _ (Nat.le_max_l _ _) H).
@@ -381,18 +381,18 @@ Proof.
   intros. intro r.
   apply (CRplus_lt_compat_r (-l)) in r. rewrite CRplus_opp_r in r.
   destruct (Un_cv_nat_real _ l H0 (A - l) r) as [n H1].
-  apply (H (n+N)%nat).
-  rewrite <- (plus_0_l N). rewrite Nat.add_assoc.
+  apply (H (n+N1)%nat).
+  rewrite <- (plus_0_l N1). rewrite Nat.add_assoc.
   apply Nat.add_le_mono_r. apply le_0_n.
-  specialize (H1 (n+N)%nat). apply (CRplus_lt_reg_r (-l)).
-  assert (n + N >= n)%nat. rewrite <- (plus_0_r n). rewrite <- plus_assoc.
+  specialize (H1 (n+N1)%nat). apply (CRplus_lt_reg_r (-l)).
+  assert (n + N1 >= n)%nat. rewrite <- (plus_0_r n). rewrite <- plus_assoc.
   apply Nat.add_le_mono_l. apply le_0_n. specialize (H1 H2).
-  apply (CRle_lt_trans _ (CRabs R (u (n + N)%nat - l))).
+  apply (CRle_lt_trans _ (CRabs R (u (n + N1)%nat - l))).
   apply CRle_abs. assumption.
 Qed.
 
-Lemma CR_cv_bound_up : forall {R : ConstructiveReals}
-                         (u : nat -> CRcarrier R) (A l : CRcarrier R) (N : nat),
+Lemma CR_cv_bound_up {R : ConstructiveReals}
+      (u : nat -> CRcarrier R) (A l : CRcarrier R) (N : nat) :
     (forall n:nat, le N n -> u n <= A)
     -> CR_cv R u l
     -> l <= A.

--- a/theories/Reals/Abstract/ConstructiveReals.v
+++ b/theories/Reals/Abstract/ConstructiveReals.v
@@ -355,7 +355,7 @@ Qed.
 Lemma CRplus_0_l : forall {R : ConstructiveReals} (x : CRcarrier R),
     0 + x == x.
 Proof.
-  intros. destruct (CRisRing R). apply Radd_0_l.
+  intros. destruct (CRisRing R). apply Radd_0_l0.
 Qed.
 
 Lemma CRplus_0_r : forall {R : ConstructiveReals} (x : CRcarrier R),
@@ -363,7 +363,7 @@ Lemma CRplus_0_r : forall {R : ConstructiveReals} (x : CRcarrier R),
 Proof.
   intros. destruct (CRisRing R).
   transitivity (0 + x).
-  apply Radd_comm. apply Radd_0_l.
+  apply Radd_comm0. apply Radd_0_l0.
 Qed.
 
 Lemma CRplus_opp_l : forall {R : ConstructiveReals} (x : CRcarrier R),
@@ -371,13 +371,13 @@ Lemma CRplus_opp_l : forall {R : ConstructiveReals} (x : CRcarrier R),
 Proof.
   intros. destruct (CRisRing R).
   transitivity (x + - x).
-  apply Radd_comm. apply Ropp_def.
+  apply Radd_comm0. apply Ropp_def0.
 Qed.
 
 Lemma CRplus_opp_r : forall {R : ConstructiveReals} (x : CRcarrier R),
     x + - x == 0.
 Proof.
-  intros. destruct (CRisRing R). apply Ropp_def.
+  intros. destruct (CRisRing R). apply Ropp_def0.
 Qed.
 
 Lemma CRopp_0 : forall {R : ConstructiveReals},
@@ -391,23 +391,23 @@ Lemma CRplus_lt_compat_r : forall {R : ConstructiveReals} (r r1 r2 : CRcarrier R
     r1 < r2 -> r1 + r < r2 + r.
 Proof.
   intros. destruct (CRisRing R).
-  apply (CRlt_proper R (CRplus R r r1) (CRplus R r1 r) (Radd_comm _ _)
+  apply (CRlt_proper R (CRplus R r r1) (CRplus R r1 r) (Radd_comm0 _ _)
                      (CRplus R r2 r) (CRplus R r2 r)).
   apply CReq_refl.
   apply (CRlt_proper R _ _ (CReq_refl _) _ (CRplus R r r2)).
-  apply Radd_comm. apply CRplus_lt_compat_l. exact H.
+  apply Radd_comm0. apply CRplus_lt_compat_l. exact H.
 Qed.
 
 Lemma CRplus_lt_reg_r : forall {R : ConstructiveReals} (r r1 r2 : CRcarrier R),
     r1 + r < r2 + r -> r1 < r2.
 Proof.
   intros. destruct (CRisRing R).
-  apply (CRlt_proper R (CRplus R r r1) (CRplus R r1 r) (Radd_comm _ _)
+  apply (CRlt_proper R (CRplus R r r1) (CRplus R r1 r) (Radd_comm0 _ _)
                      (CRplus R r2 r) (CRplus R r2 r)) in H.
   2: apply CReq_refl.
   apply (CRlt_proper R _ _ (CReq_refl _) _ (CRplus R r r2)) in H.
   apply CRplus_lt_reg_l in H. exact H.
-  apply Radd_comm.
+  apply Radd_comm0.
 Qed.
 
 Lemma CRplus_le_compat_l : forall {R : ConstructiveReals} (r r1 r2 : CRcarrier R),
@@ -476,22 +476,22 @@ Lemma CRplus_eq_reg_l : forall {R : ConstructiveReals} (r r1 r2 : CRcarrier R),
     r + r1 == r + r2 -> r1 == r2.
 Proof.
   intros.
-  destruct (CRisRingExt R). clear Rmul_ext Ropp_ext.
-  pose proof (Radd_ext
+  destruct (CRisRingExt R). clear Rmul_ext0 Ropp_ext0.
+  pose proof (Radd_ext0
                 (CRopp R r) (CRopp R r) (CReq_refl _)
                 _ _ H).
   destruct (CRisRing R).
   apply (CReq_trans r1) in H0.
   apply (CReq_trans _ _ _ H0).
   transitivity ((- r + r) + r2).
-  apply Radd_assoc. transitivity (0 + r2).
-  apply Radd_ext. apply CRplus_opp_l. apply CReq_refl.
-  apply Radd_0_l. apply CReq_sym.
+  apply Radd_assoc0. transitivity (0 + r2).
+  apply Radd_ext0. apply CRplus_opp_l. apply CReq_refl.
+  apply Radd_0_l0. apply CReq_sym.
   transitivity (- r + r + r1).
-  apply Radd_assoc.
+  apply Radd_assoc0.
   transitivity (0 + r1).
-  apply Radd_ext. apply CRplus_opp_l. apply CReq_refl.
-  apply Radd_0_l.
+  apply Radd_ext0. apply CRplus_opp_l. apply CReq_refl.
+  apply Radd_0_l0.
 Qed.
 
 Lemma CRplus_eq_reg_r : forall {R : ConstructiveReals} (r r1 r2 : CRcarrier R),
@@ -590,14 +590,14 @@ Lemma CRopp_gt_lt_contravar
 Proof.
   intros. apply (CRplus_lt_reg_l R r1).
   destruct (CRisRing R).
-  apply (CRle_lt_trans _ 0). apply Ropp_def.
+  apply (CRle_lt_trans _ 0). apply Ropp_def0.
   apply (CRplus_lt_compat_l R (CRopp R r2)) in H.
   apply (CRle_lt_trans _ (CRplus R (CRopp R r2) r2)).
   apply (CRle_trans _ (CRplus R r2 (CRopp R r2))).
-  destruct (Ropp_def r2). exact H0.
-  destruct (Radd_comm r2 (CRopp R r2)). exact H1.
+  destruct (Ropp_def0 r2). exact H0.
+  destruct (Radd_comm0 r2 (CRopp R r2)). exact H1.
   apply (CRlt_le_trans _ _ _ H).
-  destruct (Radd_comm r1 (CRopp R r2)). exact H0.
+  destruct (Radd_comm0 r1 (CRopp R r2)). exact H0.
 Qed.
 
 Lemma CRopp_lt_cancel : forall {R : ConstructiveReals} (r1 r2 : CRcarrier R),
@@ -623,31 +623,31 @@ Lemma CRopp_plus_distr : forall {R : ConstructiveReals} (r1 r2 : CRcarrier R),
 Proof.
   intros. destruct (CRisRing R), (CRisRingExt R).
   apply (CRplus_eq_reg_l (CRplus R r1 r2)).
-  transitivity (CR_of_Q R 0). apply Ropp_def.
+  transitivity (CR_of_Q R 0). apply Ropp_def0.
   transitivity (r2 + r1 + (-r1 + -r2)).
   transitivity (r2 + (r1 + (-r1 + -r2))).
   transitivity (r2 + - r2).
-  apply CReq_sym. apply Ropp_def. apply Radd_ext.
+  apply CReq_sym. apply Ropp_def0. apply Radd_ext0.
   apply CReq_refl.
   transitivity (0 + - r2).
-  apply CReq_sym, Radd_0_l.
+  apply CReq_sym, Radd_0_l0.
   transitivity (r1 + - r1 + - r2).
-  apply Radd_ext. 2: apply CReq_refl. apply CReq_sym, Ropp_def.
-  apply CReq_sym, Radd_assoc. apply Radd_assoc.
-  apply Radd_ext. 2: apply CReq_refl. apply Radd_comm.
+  apply Radd_ext0. 2: apply CReq_refl. apply CReq_sym, Ropp_def0.
+  apply CReq_sym, Radd_assoc0. apply Radd_assoc0.
+  apply Radd_ext0. 2: apply CReq_refl. apply Radd_comm0.
 Qed.
 
 Lemma CRmult_1_l : forall {R : ConstructiveReals} (r : CRcarrier R),
     1 * r == r.
 Proof.
-  intros. destruct (CRisRing R). apply Rmul_1_l.
+  intros. destruct (CRisRing R). apply Rmul_1_l0.
 Qed.
 
 Lemma CRmult_1_r : forall {R : ConstructiveReals} (x : CRcarrier R),
     x * 1 == x.
 Proof.
   intros. destruct (CRisRing R). transitivity (CRmult R 1 x).
-  apply Rmul_comm. apply Rmul_1_l.
+  apply Rmul_comm0. apply Rmul_1_l0.
 Qed.
 
 Lemma CRmult_assoc : forall {R : ConstructiveReals} (r r1 r2 : CRcarrier R),
@@ -667,14 +667,14 @@ Lemma CRmult_plus_distr_l : forall {R : ConstructiveReals} (r1 r2 r3 : CRcarrier
 Proof.
   intros. destruct (CRisRing R).
   transitivity ((r2 + r3) * r1).
-  apply Rmul_comm.
+  apply Rmul_comm0.
   transitivity ((r2 * r1) + (r3 * r1)).
-  apply Rdistr_l.
+  apply Rdistr_l0.
   transitivity ((r1 * r2) + (r3 * r1)).
-  destruct (CRisRingExt R). apply Radd_ext.
-  apply Rmul_comm. apply CReq_refl.
-  destruct (CRisRingExt R). apply Radd_ext.
-  apply CReq_refl. apply Rmul_comm.
+  destruct (CRisRingExt R). apply Radd_ext0.
+  apply Rmul_comm0. apply CReq_refl.
+  destruct (CRisRingExt R). apply Radd_ext0.
+  apply CReq_refl. apply Rmul_comm0.
 Qed.
 
 Lemma CRmult_plus_distr_r : forall {R : ConstructiveReals} (r1 r2 r3 : CRcarrier R),
@@ -698,7 +698,7 @@ Lemma CRmult_0_r : forall {R : ConstructiveReals} (x : CRcarrier R),
 Proof.
   intros. apply CRzero_double.
   transitivity (x * (0 + 0)).
-  destruct (CRisRingExt R). apply Rmul_ext. apply CReq_refl.
+  destruct (CRisRingExt R). apply Rmul_ext0. apply CReq_refl.
   apply CReq_sym, CRplus_0_r.
   destruct (CRisRing R). apply CRmult_plus_distr_l.
 Qed.
@@ -713,13 +713,13 @@ Lemma CRopp_mult_distr_r : forall {R : ConstructiveReals} (r1 r2 : CRcarrier R),
     - (r1 * r2) == r1 * (- r2).
 Proof.
   intros. apply (CRplus_eq_reg_l (CRmult R r1 r2)).
-  destruct (CRisRing R). transitivity (CR_of_Q R 0). apply Ropp_def.
+  destruct (CRisRing R). transitivity (CR_of_Q R 0). apply Ropp_def0.
   transitivity (r1 * (r2 + - r2)).
   2: apply CRmult_plus_distr_l.
   transitivity (r1 * 0).
   apply CReq_sym, CRmult_0_r.
-  destruct (CRisRingExt R). apply Rmul_ext. apply CReq_refl.
-  apply CReq_sym, Ropp_def.
+  destruct (CRisRingExt R). apply Rmul_ext0. apply CReq_refl.
+  apply CReq_sym, Ropp_def0.
 Qed.
 
 Lemma CRopp_mult_distr_l : forall {R : ConstructiveReals} (r1 r2 : CRcarrier R),
@@ -751,7 +751,7 @@ Proof.
   apply CRplus_le_compat_l. destruct (CRplus_opp_l r1). exact H1.
   destruct (Radd_assoc (CRisRing R) r2 (CRopp R r1) r1). exact H2.
   destruct (CRisRing R).
-  destruct (Rdistr_l r2 (CRopp R r1) r). exact H2.
+  destruct (Rdistr_l0 r2 (CRopp R r1) r). exact H2.
   apply CRplus_le_compat_l. destruct (CRopp_mult_distr_l r1 r).
   exact H1.
 Qed.

--- a/theories/Reals/Abstract/ConstructiveRealsMorphisms.v
+++ b/theories/Reals/Abstract/ConstructiveRealsMorphisms.v
@@ -278,8 +278,8 @@ Proof.
              _ (CRplus R1 x (CRplus R1 (CR_of_Q R1 q) (CRopp R1 (CR_of_Q R1 q))))).
     apply (CRle_trans _ (CRplus R1 x 0)).
     destruct (CRplus_0_r x). exact H.
-    apply CRplus_le_compat_l. destruct (Ropp_def (CR_of_Q R1 q)). exact H.
-    destruct (Radd_assoc x (CR_of_Q R1 q) (CRopp R1 (CR_of_Q R1 q))).
+    apply CRplus_le_compat_l. destruct (Ropp_def0 (CR_of_Q R1 q)). exact H.
+    destruct (Radd_assoc0 x (CR_of_Q R1 q) (CRopp R1 (CR_of_Q R1 q))).
     exact H1.
   - intro abs.
     destruct (CR_Q_dense R2 _ _ abs) as [r [H H0]]. clear abs.
@@ -292,10 +292,10 @@ Proof.
     destruct (CRisRing R1).
     apply (CRle_trans
              _ (CRplus R1 x (CRplus R1 (CR_of_Q R1 q) (CRopp R1 (CR_of_Q R1 q))))).
-    destruct (Radd_assoc x (CR_of_Q R1 q) (CRopp R1 (CR_of_Q R1 q))).
+    destruct (Radd_assoc0 x (CR_of_Q R1 q) (CRopp R1 (CR_of_Q R1 q))).
     exact H0.
     apply (CRle_trans _ (CRplus R1 x 0)).
-    apply CRplus_le_compat_l. destruct (Ropp_def (CR_of_Q R1 q)). exact H1.
+    apply CRplus_le_compat_l. destruct (Ropp_def0 (CR_of_Q R1 q)). exact H1.
     destruct (CRplus_0_r x). exact H1.
     apply (CRlt_le_trans _ (CR_of_Q R1 (r-q))).
     apply (CRmorph_increasing_inv f).
@@ -361,16 +361,16 @@ Proof.
     apply (CRlt_le_trans _ _ _ abs) in H4. clear abs.
     apply lt_CR_of_Q in H4. ring_simplify in H4.
     exact (Qlt_not_le _ _ H4 (Qle_refl _)).
-    destruct (CRisRing R2); apply Radd_assoc.
+    destruct (CRisRing R2); apply Radd_assoc0.
     apply CRplus_le_compat_r. destruct (CRisRing R2).
-    destruct (Radd_comm (CRmorph f x) (CR_of_Q R2 (r - q))).
+    destruct (Radd_comm0 (CRmorph f x) (CR_of_Q R2 (r - q))).
     exact H.
     intro abs.
     destruct (CRmorph_plus_rat f y s) as [H _]. apply H. clear H.
     apply (CRlt_le_trans _ (CRplus R2 (CR_of_Q R2 s) (CRmorph f y))).
     apply (CRle_lt_trans _ (CRmorph f (CRplus R1 (CR_of_Q R1 s) y))).
-    apply CRmorph_proper. destruct (CRisRing R1); apply Radd_comm.
-    exact abs. destruct (CRisRing R2); apply Radd_comm. }
+    apply CRmorph_proper. destruct (CRisRing R1); apply Radd_comm0.
+    exact abs. destruct (CRisRing R2); apply Radd_comm0. }
   split.
   - apply H.
   - specialize (H (CRplus R1 x y) (CRopp R1 y)).
@@ -378,10 +378,10 @@ Proof.
     apply (CRle_lt_trans _ (CRmorph f x)).
     apply CRmorph_proper. destruct (CRisRing R1).
     apply (CReq_trans _ (CRplus R1 x (CRplus R1 y (CRopp R1 y)))).
-    apply CReq_sym, Radd_assoc.
+    apply CReq_sym, Radd_assoc0.
     apply (CReq_trans _ (CRplus R1 x 0)). 2: apply CRplus_0_r.
-    destruct (CRisRingExt R1). apply Radd_ext.
-    apply CReq_refl. apply Ropp_def.
+    destruct (CRisRingExt R1). apply Radd_ext0.
+    apply CReq_refl. apply Ropp_def0.
     apply (CRplus_lt_reg_r (CRmorph f y)).
     apply (CRlt_le_trans _ _ _ abs). clear abs.
     apply (CRle_trans _ (CRplus R2 (CRmorph f (CRplus R1 x y)) 0)).
@@ -394,7 +394,7 @@ Proof.
     destruct (CRplus_opp_l (CRmorph f y)). exact H.
     apply CRplus_le_compat_r. destruct (CRmorph_opp f y). exact H.
     destruct (CRisRing R2).
-    destruct (Radd_assoc (CRmorph f (CRplus R1 x y))
+    destruct (Radd_assoc0 (CRmorph f (CRplus R1 x y))
                          (CRmorph f (CRopp R1 y)) (CRmorph f y)).
     exact H0.
 Qed.
@@ -411,22 +411,22 @@ Proof.
     + apply (CReq_trans _ (CRmorph f 0)).
       2: apply CRmorph_zero. apply CRmorph_proper.
       apply (CReq_trans _ (CRmult R1 x 0)).
-      2: apply CRmult_0_r. apply Rmul_ext. apply CReq_refl. reflexivity.
+      2: apply CRmult_0_r. apply Rmul_ext0. apply CReq_refl. reflexivity.
     + apply (CReq_trans _ (CRmult R2 (CRmorph f x) 0)).
       apply CReq_sym, CRmult_0_r. destruct (CRisRingExt R2).
-      apply Rmul_ext0. apply CReq_refl. reflexivity.
+      apply Rmul_ext1. apply CReq_refl. reflexivity.
   - destruct (CRisRingExt R1), (CRisRingExt R2).
     transitivity (CRmorph f (CRplus R1 x (CRmult R1 x (CR_of_Q R1 (Z.of_nat n # 1))))).
     apply CRmorph_proper.
     transitivity (CRmult R1 x (CRplus R1 1 (CR_of_Q R1 (Z.of_nat n # 1)))).
-    apply Rmul_ext. reflexivity.
+    apply Rmul_ext0. reflexivity.
     transitivity (CR_of_Q R1 (1 + (Z.of_nat n # 1))).
     apply CR_of_Q_morph. rewrite Nat2Z.inj_succ. unfold Z.succ.
     rewrite Z.add_comm. rewrite Qinv_plus_distr. reflexivity.
     rewrite CR_of_Q_plus. reflexivity.
     transitivity (CRplus R1 (CRmult R1 x 1)
                          (CRmult R1 x (CR_of_Q R1 (Z.of_nat n # 1)))).
-    apply CRmult_plus_distr_l. apply Radd_ext. apply CRmult_1_r. reflexivity.
+    apply CRmult_plus_distr_l. apply Radd_ext0. apply CRmult_1_r. reflexivity.
     apply (CReq_trans
              _ (CRplus R2 (CRmorph f x)
                        (CRmorph f (CRmult R1 x (CR_of_Q R1 (Z.of_nat n # 1)))))).
@@ -434,18 +434,18 @@ Proof.
     apply (CReq_trans
              _ (CRplus R2 (CRmorph f x)
                        (CRmult R2 (CRmorph f x) (CR_of_Q R2 (Z.of_nat n # 1))))).
-    apply Radd_ext0. apply CReq_refl. exact IHn.
+    apply Radd_ext1. apply CReq_refl. exact IHn.
     apply (CReq_trans
              _ (CRmult R2 (CRmorph f x) (CRplus R2 1 (CR_of_Q R2 (Z.of_nat n # 1))))).
     apply (CReq_trans
              _ (CRplus R2 (CRmult R2 (CRmorph f x) 1)
                        (CRmult R2 (CRmorph f x) (CR_of_Q R2 (Z.of_nat n # 1))))).
-    apply Radd_ext0. 2: apply CReq_refl. apply CReq_sym, CRmult_1_r.
+    apply Radd_ext1. 2: apply CReq_refl. apply CReq_sym, CRmult_1_r.
     apply CReq_sym, CRmult_plus_distr_l.
-    apply Rmul_ext0. apply CReq_refl.
+    apply Rmul_ext1. apply CReq_refl.
     apply (CReq_trans _ (CR_of_Q R2 (1 + (Z.of_nat n # 1)))).
     apply (CReq_trans _ (CRplus R2 (CR_of_Q R2 1) (CR_of_Q R2 (Z.of_nat n # 1)))).
-    apply Radd_ext0. reflexivity. reflexivity.
+    apply Radd_ext1. reflexivity. reflexivity.
     apply CReq_sym, CR_of_Q_plus.
     apply CR_of_Q_morph. rewrite Nat2Z.inj_succ. unfold Z.succ.
     rewrite Z.add_comm. rewrite Qinv_plus_distr. reflexivity.
@@ -474,18 +474,18 @@ Proof.
                _ (CRmorph f (CRopp R1 (CRmult R1 x (CR_of_Q R1 (Z.of_nat p # 1)))))).
       2: apply CRmorph_opp. apply CRmorph_proper.
       apply (CReq_trans _ (CRmult R1 x (CR_of_Q R1 (- (Z.of_nat p # 1))))).
-      destruct (CRisRingExt R1). apply Rmul_ext. apply CReq_refl.
+      destruct (CRisRingExt R1). apply Rmul_ext0. apply CReq_refl.
       apply CR_of_Q_morph. reflexivity.
       apply (CReq_trans _ (CRmult R1 x (CRopp R1 (CR_of_Q R1 (Z.of_nat p # 1))))).
-      destruct (CRisRingExt R1). apply Rmul_ext. apply CReq_refl.
+      destruct (CRisRingExt R1). apply Rmul_ext0. apply CReq_refl.
       apply CR_of_Q_opp. apply CReq_sym, CRopp_mult_distr_r.
     + apply (CReq_trans
                _ (CRopp R2 (CRmult R2 (CRmorph f x) (CR_of_Q R2 (Z.of_nat p # 1))))).
-      destruct (CRisRingExt R2). apply Ropp_ext. apply CRmorph_mult_pos.
+      destruct (CRisRingExt R2). apply Ropp_ext0. apply CRmorph_mult_pos.
       apply (CReq_trans
                _ (CRmult R2 (CRmorph f x) (CRopp R2 (CR_of_Q R2 (Z.of_nat p # 1))))).
       apply CRopp_mult_distr_r. destruct (CRisRingExt R2).
-      apply Rmul_ext. apply CReq_refl.
+      apply Rmul_ext0. apply CReq_refl.
       apply (CReq_trans _ (CR_of_Q R2 (- (Z.of_nat p # 1)))).
       apply CReq_sym, CR_of_Q_opp. apply CR_of_Q_morph. reflexivity.
 Qed.
@@ -507,7 +507,7 @@ Proof.
     apply (CReq_trans
              _ (CRmult R1 x (CRmult R1 (CR_of_Q R1 (1 # p))
                                     (CR_of_Q R1 (Z.pos p # 1))))).
-    destruct (CRisRing R1). apply CReq_sym, Rmul_assoc.
+    destruct (CRisRing R1). apply CReq_sym, Rmul_assoc0.
     apply (CReq_trans _ (CRmult R1 x 1)).
     apply (Rmul_ext (CRisRingExt R1)). apply CReq_refl.
     apply (CReq_trans _ (CR_of_Q R1 ((1#p) * (Z.pos p # 1)))).
@@ -852,7 +852,7 @@ Lemma CRmorph_appart : forall {R1 R2 : ConstructiveReals}
                          (app : x ≶ y),
     CRmorph f x ≶ CRmorph f y.
 Proof.
-  intros. destruct app.
+  intros. destruct app0.
   - left. apply CRmorph_increasing. exact c.
   - right. apply CRmorph_increasing. exact c.
 Defined.
@@ -863,7 +863,7 @@ Lemma CRmorph_appart_zero : forall {R1 R2 : ConstructiveReals}
                               (app : x ≶ 0),
     CRmorph f x ≶ 0.
 Proof.
-  intros. destruct app.
+  intros. destruct app0.
   - left. apply (CRlt_le_trans _ (CRmorph f 0)).
     apply CRmorph_increasing. exact c.
     exact (proj2 (CRmorph_zero f)).

--- a/theories/Reals/Abstract/ConstructiveSum.v
+++ b/theories/Reals/Abstract/ConstructiveSum.v
@@ -30,12 +30,11 @@ Fixpoint CRsum {R : ConstructiveReals}
     | S i => CRsum f i + f (S i)
   end.
 
-Lemma CRsum_eq :
-  forall {R : ConstructiveReals} (An Bn:nat -> CRcarrier R) (N:nat),
+Lemma CRsum_eq {R : ConstructiveReals} (An Bn:nat -> CRcarrier R) (N:nat) :
     (forall i:nat, (i <= N)%nat -> An i == Bn i) ->
     CRsum An N == CRsum Bn N.
 Proof.
-  induction N.
+  induction N as [|N IHN].
   - intros. exact (H O (le_refl _)).
   - intros. simpl. apply CRplus_morph. apply IHN.
     intros. apply H. apply (le_trans _ N _ H0), le_S, le_refl.
@@ -199,12 +198,11 @@ Proof.
     apply CRplus_morph. reflexivity. apply CRplus_comm.
 Qed.
 
-Lemma decomp_sum :
-  forall {R : ConstructiveReals} (An:nat -> CRcarrier R) (N:nat),
+Lemma decomp_sum {R : ConstructiveReals} (An:nat -> CRcarrier R) (N:nat) :
     (0 < N)%nat ->
     CRsum An N == An 0%nat + CRsum (fun i:nat => An (S i)) (pred N).
 Proof.
-  induction N.
+  induction N as [|N IHN].
   - intros. exfalso. inversion H.
   - intros _. destruct N. simpl. reflexivity. simpl.
     rewrite IHN. rewrite CRplus_assoc.
@@ -429,14 +427,14 @@ Proof.
   rewrite <- (CRsum_eq u). apply H0, H1. intros. apply H.
 Qed.
 
-Lemma series_cv_remainder_maj : forall {R : ConstructiveReals} (u : nat -> CRcarrier R)
-                                  (s eps : CRcarrier R)
-                                  (N : nat),
-    series_cv u s
-    -> 0 < eps
-    -> (forall n:nat, 0 <= u n)
-    -> CRabs R (CRsum u N - s) <= eps
-    -> forall n:nat, CRsum (fun k=> u (N + S k)%nat) n <= eps.
+Lemma series_cv_remainder_maj {R : ConstructiveReals} (u : nat -> CRcarrier R)
+      (s eps : CRcarrier R)
+      (N : nat) :
+  series_cv u s
+  -> 0 < eps
+  -> (forall n:nat, 0 <= u n)
+  -> CRabs R (CRsum u N - s) <= eps
+  -> forall n:nat, CRsum (fun k=> u (N + S k)%nat) n <= eps.
 Proof.
   intros. pose proof (sum_assoc u N n).
   rewrite <- (CRsum_eq (fun k : nat => u (S N + k)%nat)).
@@ -453,19 +451,19 @@ Proof.
 Qed.
 
 
-Lemma series_cv_abs_remainder : forall {R : ConstructiveReals} (u : nat -> CRcarrier R)
-                                  (s sAbs : CRcarrier R)
-                                  (n : nat),
-    series_cv u s
-    -> series_cv (fun n => CRabs R (u n)) sAbs
-    -> CRabs R (CRsum u n - s)
-      <= sAbs - CRsum (fun n => CRabs R (u n)) n.
+Lemma series_cv_abs_remainder {R : ConstructiveReals} (u : nat -> CRcarrier R)
+      (s sAbs : CRcarrier R)
+      (n : nat) :
+  series_cv u s
+  -> series_cv (fun n => CRabs R (u n)) sAbs
+  -> CRabs R (CRsum u n - s)
+    <= sAbs - CRsum (fun n => CRabs R (u n)) n.
 Proof.
   intros.
   apply (CR_cv_le (fun N => CRabs R (CRsum u n - (CRsum u (n + N))))
                    (fun N => CRsum (fun n : nat => CRabs R (u n)) (n + N)
                           - CRsum (fun n : nat => CRabs R (u n)) n)).
-  - intro N. destruct N. rewrite plus_0_r. unfold CRminus.
+  - intro N. destruct N as [|N]. rewrite plus_0_r. unfold CRminus.
     rewrite CRplus_opp_r. rewrite CRplus_opp_r.
     rewrite CRabs_right. apply CRle_refl. apply CRle_refl.
     rewrite Nat.add_succ_r.

--- a/theories/Reals/AltSeries.v
+++ b/theories/Reals/AltSeries.v
@@ -65,8 +65,7 @@ Proof.
 Qed.
 
 (**********)
-Lemma CV_ALT_step2 :
-  forall (Un:nat -> R) (N:nat),
+Lemma CV_ALT_step2 (Un:nat -> R) (N:nat) :
     Un_decreasing Un ->
     positivity_seq Un ->
     sum_f_R0 (fun i:nat => tg_alt Un (S i)) (S (2 * N)) <= 0.
@@ -98,8 +97,7 @@ Proof.
 Qed.
 
 (** A more general inequality *)
-Lemma CV_ALT_step3 :
-  forall (Un:nat -> R) (N:nat),
+Lemma CV_ALT_step3 (Un:nat -> R) (N:nat) :
     Un_decreasing Un ->
     positivity_seq Un -> sum_f_R0 (fun i:nat => tg_alt Un (S i)) N <= 0.
 Proof.

--- a/theories/Reals/Cauchy_prod.v
+++ b/theories/Reals/Cauchy_prod.v
@@ -15,8 +15,7 @@ Require Import PartSum.
 Local Open Scope R_scope.
 
   (**********)
-Lemma sum_N_predN :
-  forall (An:nat -> R) (N:nat),
+Lemma sum_N_predN (An:nat -> R) (N:nat) :
     (0 < N)%nat -> sum_f_R0 An N = sum_f_R0 An (pred N) + An N.
 Proof.
   intros.
@@ -27,8 +26,7 @@ Proof.
 Qed.
 
   (**********)
-Lemma sum_plus :
-  forall (An Bn:nat -> R) (N:nat),
+Lemma sum_plus (An Bn:nat -> R) (N:nat) :
     sum_f_R0 (fun l:nat => An l + Bn l) N = sum_f_R0 An N + sum_f_R0 Bn N.
 Proof.
   intros.
@@ -39,8 +37,7 @@ Proof.
 Qed.
 
   (* The main result *)
-Theorem cauchy_finite :
-  forall (An Bn:nat -> R) (N:nat),
+Theorem cauchy_finite (An Bn:nat -> R) (N:nat) :
     (0 < N)%nat ->
     sum_f_R0 An N * sum_f_R0 Bn N =
     sum_f_R0 (fun k:nat => sum_f_R0 (fun p:nat => An p * Bn (k - p)%nat) k) N +

--- a/theories/Reals/Cos_plus.v
+++ b/theories/Reals/Cos_plus.v
@@ -69,8 +69,7 @@ Proof.
   apply RmaxLess1.
 Qed.
 
-Lemma reste1_maj :
-  forall (x y:R) (N:nat),
+Lemma reste1_maj (x y:R) (N:nat) :
     (0 < N)%nat -> Rabs (Reste1 x y N) <= Majxy x y (pred N).
 Proof.
   intros.
@@ -359,8 +358,7 @@ Proof.
   apply S_pred with 0%nat; assumption.
 Qed.
 
-Lemma reste2_maj :
-  forall (x y:R) (N:nat), (0 < N)%nat -> Rabs (Reste2 x y N) <= Majxy x y N.
+Lemma reste2_maj (x y:R) (N:nat) : (0 < N)%nat -> Rabs (Reste2 x y N) <= Majxy x y N.
 Proof.
   intros.
   set (C := Rmax 1 (Rmax (Rabs x) (Rabs y))).

--- a/theories/Reals/Exp_prop.v
+++ b/theories/Reals/Exp_prop.v
@@ -68,25 +68,25 @@ Definition maj_Reste_E (x y:R) (N:nat) : R :=
     Rsqr (INR (fact (div2 (pred N))))).
 
 (**********)
-Lemma div2_double : forall N:nat, div2 (2 * N) = N.
+Lemma div2_double (N:nat) : div2 (2 * N) = N.
 Proof.
-  intro; induction  N as [| N HrecN].
+  induction  N as [| N HrecN].
   reflexivity.
   replace (2 * S N)%nat with (S (S (2 * N))).
   simpl; simpl in HrecN; rewrite HrecN; reflexivity.
   ring.
 Qed.
 
-Lemma div2_S_double : forall N:nat, div2 (S (2 * N)) = N.
+Lemma div2_S_double (N:nat) : div2 (S (2 * N)) = N.
 Proof.
-  intro; induction  N as [| N HrecN].
+  induction  N as [| N HrecN].
   reflexivity.
   replace (2 * S N)%nat with (S (S (2 * N))).
   simpl; simpl in HrecN; rewrite HrecN; reflexivity.
   ring.
 Qed.
 
-Lemma div2_not_R0 : forall N:nat, (1 < N)%nat -> (0 < div2 N)%nat.
+Lemma div2_not_R0 (N:nat) : (1 < N)%nat -> (0 < div2 N)%nat.
 Proof.
   intros; induction N as [| N HrecN].
   - elim (lt_n_O _ H).
@@ -101,8 +101,7 @@ Proof.
     left; apply lt_le_trans with 2%nat; [ apply lt_n_Sn | apply H1 ].
 Qed.
 
-Lemma Reste_E_maj :
-  forall (x y:R) (N:nat),
+Lemma Reste_E_maj (x y:R) (N:nat) :
     (0 < N)%nat -> Rabs (Reste_E x y N) <= maj_Reste_E x y N.
 Proof.
   intros; set (M := Rmax 1 (Rmax (Rabs x) (Rabs y))).

--- a/theories/Reals/MVT.v
+++ b/theories/Reals/MVT.v
@@ -15,14 +15,13 @@ Require Import Rtopology.
 Local Open Scope R_scope.
 
 (* The Mean Value Theorem *)
-Theorem MVT :
-  forall (f g:R -> R) (a b:R) (pr1:forall c:R, a < c < b -> derivable_pt f c)
-    (pr2:forall c:R, a < c < b -> derivable_pt g c),
-    a < b ->
-    (forall c:R, a <= c <= b -> continuity_pt f c) ->
-    (forall c:R, a <= c <= b -> continuity_pt g c) ->
-    exists c : R,
-      (exists P : a < c < b,
+Theorem MVT (f g:R -> R) (a b:R) (pr1:forall c:R, a < c < b -> derivable_pt f c)
+        (pr2:forall c:R, a < c < b -> derivable_pt g c) :
+  a < b ->
+  (forall c:R, a <= c <= b -> continuity_pt f c) ->
+  (forall c:R, a <= c <= b -> continuity_pt g c) ->
+  exists c : R,
+    (exists P : a < c < b,
         (g b - g a) * derive_pt f c (pr1 c P) =
         (f b - f a) * derive_pt g c (pr2 c P)).
 Proof.
@@ -207,8 +206,7 @@ Proof.
           [ left; assumption | split; [ left; assumption | rewrite <- H3; ring ] ] ].
 Qed.
 
-Lemma Rolle :
-  forall (f:R -> R) (a b:R) (pr:forall x:R, a < x < b -> derivable_pt f x),
+Lemma Rolle (f:R -> R) (a b:R) (pr:forall x:R, a < x < b -> derivable_pt f x) :
     (forall x:R, a <= x <= b -> continuity_pt f x) ->
     a < b ->
     f a = f b ->
@@ -228,8 +226,7 @@ Proof.
 Qed.
 
 (**********)
-Lemma nonneg_derivative_1 :
-  forall (f:R -> R) (pr:derivable f),
+Lemma nonneg_derivative_1 (f:R -> R) (pr:derivable f) :
     (forall x:R, 0 <= derive_pt f x (pr x)) -> increasing f.
 Proof.
   intros.
@@ -372,8 +369,7 @@ Proof.
 Qed.
 
 (**********)
-Lemma nonpos_derivative_1 :
-  forall (f:R -> R) (pr:derivable f),
+Lemma nonpos_derivative_1 (f:R -> R) (pr:derivable f) :
     (forall x:R, derive_pt f x (pr x) <= 0) -> decreasing f.
 Proof.
   intros.
@@ -404,8 +400,7 @@ Proof.
 Qed.
 
 (**********)
-Lemma positive_derivative :
-  forall (f:R -> R) (pr:derivable f),
+Lemma positive_derivative (f:R -> R) (pr:derivable f) :
     (forall x:R, 0 < derive_pt f x (pr x)) -> strict_increasing f.
 Proof.
   intros.
@@ -434,8 +429,7 @@ Proof.
 Qed.
 
 (**********)
-Lemma negative_derivative :
-  forall (f:R -> R) (pr:derivable f),
+Lemma negative_derivative (f:R -> R) (pr:derivable f) :
     (forall x:R, derive_pt f x (pr x) < 0) -> strict_decreasing f.
 Proof.
   intros.
@@ -476,8 +470,7 @@ Proof.
 Qed.
 
 (**********)
-Lemma increasing_decreasing :
-  forall f:R -> R, increasing f -> decreasing f -> constant f.
+Lemma increasing_decreasing (f:R -> R) : increasing f -> decreasing f -> constant f.
 Proof.
   unfold increasing, decreasing, constant; intros;
     case (Rtotal_order x y); intro.
@@ -490,8 +483,7 @@ Proof.
 Qed.
 
 (**********)
-Lemma null_derivative_1 :
-  forall (f:R -> R) (pr:derivable f),
+Lemma null_derivative_1 (f:R -> R) (pr:derivable f) :
     (forall x:R, derive_pt f x (pr x) = 0) -> constant f.
 Proof.
   intros.
@@ -506,8 +498,7 @@ Proof.
 Qed.
 
 (**********)
-Lemma derive_increasing_interv_ax :
-  forall (a b:R) (f:R -> R) (pr:derivable f),
+Lemma derive_increasing_interv_ax (a b:R) (f:R -> R) (pr:derivable f) :
     a < b ->
     ((forall t:R, a < t < b -> 0 < derive_pt f t (pr t)) ->
       forall x y:R, a <= x <= b -> a <= y <= b -> x < y -> f x < f y) /\
@@ -554,8 +545,7 @@ Proof.
 Qed.
 
 (**********)
-Lemma derive_increasing_interv :
-  forall (a b:R) (f:R -> R) (pr:derivable f),
+Lemma derive_increasing_interv (a b:R) (f:R -> R) (pr:derivable f) :
     a < b ->
     (forall t:R, a < t < b -> 0 < derive_pt f t (pr t)) ->
     forall x y:R, a <= x <= b -> a <= y <= b -> x < y -> f x < f y.
@@ -579,8 +569,7 @@ Qed.
 
 (**********)
 (**********)
-Theorem IAF :
-  forall (f:R -> R) (a b k:R) (pr:derivable f),
+Theorem IAF (f:R -> R) (a b k:R) (pr:derivable f) :
     a <= b ->
     (forall c:R, a <= c <= b -> derive_pt f c (pr c) <= k) ->
     f b - f a <= k * (b - a).
@@ -600,8 +589,7 @@ Proof.
   elim (Rlt_irrefl _ (Rle_lt_trans _ _ _ H H1)).
 Qed.
 
-Lemma IAF_var :
-  forall (f g:R -> R) (a b:R) (pr1:derivable f) (pr2:derivable g),
+Lemma IAF_var (f g:R -> R) (a b:R) (pr1:derivable f) (pr2:derivable g) :
     a <= b ->
     (forall c:R, a <= c <= b -> derive_pt g c (pr2 c) <= derive_pt f c (pr1 c)) ->
     g b - g a <= f b - f a.
@@ -636,8 +624,7 @@ Qed.
 
 (* If f has a null derivative in ]a,b[ and is continue in [a,b], *)
 (* then f is constant on [a,b] *)
-Lemma null_derivative_loc :
-  forall (f:R -> R) (a b:R) (pr:forall x:R, a < x < b -> derivable_pt f x),
+Lemma null_derivative_loc (f:R -> R) (a b:R) (pr:forall x:R, a < x < b -> derivable_pt f x) :
     (forall x:R, a <= x <= b -> continuity_pt f x) ->
     (forall (x:R) (P:a < x < b), derive_pt f x (pr x P) = 0) ->
     constant_D_eq f (fun x:R => a <= x <= b) (f a).
@@ -679,8 +666,7 @@ Proof.
 Qed.
 
 (* Unicity of the antiderivative *)
-Lemma antiderivative_Ucte :
-  forall (f g1 g2:R -> R) (a b:R),
+Lemma antiderivative_Ucte (f g1 g2:R -> R) (a b:R) :
     antiderivative f g1 a b ->
     antiderivative f g2 a b ->
     exists c : R, (forall x:R, a <= x <= b -> g1 x = g2 x + c).

--- a/theories/Reals/NewtonInt.v
+++ b/theories/Reals/NewtonInt.v
@@ -233,8 +233,7 @@ Proof.
   assert (H7 := H4 _ H5); assert (H8 := H4 _ H6); rewrite H7; rewrite H8; ring.
 Qed.
 
-Lemma antiderivative_P2 :
-  forall (f F0 F1:R -> R) (a b c:R),
+Lemma antiderivative_P2 (f F0 F1:R -> R) (a b c:R) :
     antiderivative f F0 a b ->
     antiderivative f F1 b c ->
     antiderivative f
@@ -453,8 +452,7 @@ Proof.
     elim (Rlt_irrefl _ (Rle_lt_trans _ _ _ H2 Hbc)).
 Qed.
 
-Lemma NewtonInt_P8 :
-  forall (f:R -> R) (a b c:R),
+Lemma NewtonInt_P8 (f:R -> R) (a b c:R) :
     Newton_integrable f a b ->
     Newton_integrable f b c -> Newton_integrable f a c.
 Proof.
@@ -552,9 +550,8 @@ Proof.
 Qed.
 
 (* Chasles' relation *)
-Lemma NewtonInt_P9 :
-  forall (f:R -> R) (a b c:R) (pr1:Newton_integrable f a b)
-    (pr2:Newton_integrable f b c),
+Lemma NewtonInt_P9 (f:R -> R) (a b c:R) (pr1:Newton_integrable f a b)
+    (pr2:Newton_integrable f b c) :
     NewtonInt f a c (NewtonInt_P8 f a b c pr1 pr2) =
     NewtonInt f a b pr1 + NewtonInt f b c pr2.
 Proof.

--- a/theories/Reals/PSeries_reg.v
+++ b/theories/Reals/PSeries_reg.v
@@ -276,8 +276,7 @@ Proof.
 Qed.
 
 (**********)
-Lemma continuity_pt_finite_SF :
-  forall (fn:nat -> R -> R) (N:nat) (x:R),
+Lemma continuity_pt_finite_SF (fn:nat -> R -> R) (N:nat) (x:R) :
     (forall n:nat, (n <= N)%nat -> continuity_pt (fn n) x) ->
     continuity_pt (fun y:R => sum_f_R0 (fun k:nat => fn k y) N) x.
 Proof.

--- a/theories/Reals/PartSum.v
+++ b/theories/Reals/PartSum.v
@@ -15,9 +15,8 @@ Require Import Rcomplete.
 Require Import Max.
 Local Open Scope R_scope.
 
-Lemma tech1 :
-  forall (An:nat -> R) (N:nat),
-    (forall n:nat, (n <= N)%nat -> 0 < An n) -> 0 < sum_f_R0 An N.
+Lemma tech1 (An:nat -> R) (N:nat) :
+  (forall n:nat, (n <= N)%nat -> 0 < An n) -> 0 < sum_f_R0 An N.
 Proof.
   intros; induction  N as [| N HrecN].
   simpl; apply H; apply le_n.
@@ -62,12 +61,11 @@ Proof.
 Qed.
 
 (* Sum of geometric sequences *)
-Lemma tech3 :
-  forall (k:R) (N:nat),
-    k <> 1 -> sum_f_R0 (fun i:nat => k ^ i) N = (1 - k ^ S N) / (1 - k).
+Lemma tech3 (k:R) (N:nat) :
+  k <> 1 -> sum_f_R0 (fun i:nat => k ^ i) N = (1 - k ^ S N) / (1 - k).
 Proof.
   intros; cut (1 - k <> 0).
-  intro; induction  N as [| N HrecN].
+  intro; induction N as [| N HrecN].
   simpl; rewrite Rmult_1_r; unfold Rdiv; rewrite <- Rinv_r_sym.
   reflexivity.
   apply H0.
@@ -89,9 +87,8 @@ Proof.
     assumption.
 Qed.
 
-Lemma tech4 :
-  forall (An:nat -> R) (k:R) (N:nat),
-    0 <= k -> (forall i:nat, An (S i) < k * An i) -> An N <= An 0%nat * k ^ N.
+Lemma tech4 (An:nat -> R) (k:R) (N:nat) :
+  0 <= k -> (forall i:nat, An (S i) < k * An i) -> An N <= An 0%nat * k ^ N.
 Proof.
   intros; induction  N as [| N HrecN].
   simpl; right; ring.
@@ -111,8 +108,7 @@ Proof.
   intros; reflexivity.
 Qed.
 
-Lemma tech6 :
-  forall (An:nat -> R) (k:R) (N:nat),
+Lemma tech6 (An:nat -> R) (k:R) (N:nat) :
     0 <= k ->
     (forall i:nat, An (S i) < k * An i) ->
     sum_f_R0 An N <= An 0%nat * sum_f_R0 (fun i:nat => k ^ i) N.
@@ -138,8 +134,7 @@ Proof.
   elim H1; symmetry ; assumption.
 Qed.
 
-Lemma tech11 :
-  forall (An Bn Cn:nat -> R) (N:nat),
+Lemma tech11 (An Bn Cn:nat -> R) (N:nat) :
     (forall i:nat, An i = Bn i - Cn i) ->
     sum_f_R0 An N = sum_f_R0 Bn N - sum_f_R0 Cn N.
 Proof.
@@ -157,8 +152,7 @@ Proof.
     assumption.
 Qed.
 
-Lemma scal_sum :
-  forall (An:nat -> R) (N:nat) (x:R),
+Lemma scal_sum (An:nat -> R) (N:nat) (x:R) :
     x * sum_f_R0 An N = sum_f_R0 (fun i:nat => An i * x) N.
 Proof.
   intros; induction  N as [| N HrecN].
@@ -167,8 +161,7 @@ Proof.
   rewrite Rmult_plus_distr_l; rewrite <- HrecN; ring.
 Qed.
 
-Lemma decomp_sum :
-  forall (An:nat -> R) (N:nat),
+Lemma decomp_sum (An:nat -> R) (N:nat) :
     (0 < N)%nat ->
     sum_f_R0 An N = An 0%nat + sum_f_R0 (fun i:nat => An (S i)) (pred N).
 Proof.
@@ -191,8 +184,7 @@ Proof.
   left; apply lt_le_trans with 1%nat; [ apply lt_O_Sn | assumption ].
 Qed.
 
-Lemma plus_sum :
-  forall (An Bn:nat -> R) (N:nat),
+Lemma plus_sum (An Bn:nat -> R) (N:nat) :
     sum_f_R0 (fun i:nat => An i + Bn i) N = sum_f_R0 An N + sum_f_R0 Bn N.
 Proof.
   intros; induction  N as [| N HrecN].
@@ -200,8 +192,7 @@ Proof.
   do 3 rewrite tech5; rewrite HrecN; ring.
 Qed.
 
-Lemma sum_eq :
-  forall (An Bn:nat -> R) (N:nat),
+Lemma sum_eq (An Bn:nat -> R) (N:nat) :
     (forall i:nat, (i <= N)%nat -> An i = Bn i) ->
     sum_f_R0 An N = sum_f_R0 Bn N.
 Proof.
@@ -251,8 +242,7 @@ Proof.
   apply Rinv_neq_0_compat; discrR.
 Qed.
 
-Lemma minus_sum :
-  forall (An Bn:nat -> R) (N:nat),
+Lemma minus_sum (An Bn:nat -> R) (N:nat) :
     sum_f_R0 (fun i:nat => An i - Bn i) N = sum_f_R0 An N - sum_f_R0 Bn N.
 Proof.
   intros; induction  N as [| N HrecN].
@@ -260,8 +250,7 @@ Proof.
   do 3 rewrite tech5; rewrite HrecN; ring.
 Qed.
 
-Lemma sum_decomposition :
-  forall (An:nat -> R) (N:nat),
+Lemma sum_decomposition (An:nat -> R) (N:nat) :
     sum_f_R0 (fun l:nat => An (2 * l)%nat) (S N) +
     sum_f_R0 (fun l:nat => An (S (2 * l))) N = sum_f_R0 An (2 * S N).
 Proof.
@@ -278,8 +267,7 @@ Proof.
   ring.
 Qed.
 
-Lemma sum_Rle :
-  forall (An Bn:nat -> R) (N:nat),
+Lemma sum_Rle (An Bn:nat -> R) (N:nat) :
     (forall n:nat, (n <= N)%nat -> An n <= Bn n) ->
     sum_f_R0 An N <= sum_f_R0 Bn N.
 Proof.
@@ -299,8 +287,7 @@ Proof.
   apply le_trans with N; [ assumption | apply le_n_Sn ].
 Qed.
 
-Lemma Rsum_abs :
-  forall (An:nat -> R) (N:nat),
+Lemma Rsum_abs (An:nat -> R) (N:nat) :
     Rabs (sum_f_R0 An N) <= sum_f_R0 (fun l:nat => Rabs (An l)) N.
 Proof.
   intros.
@@ -315,8 +302,7 @@ Proof.
   apply HrecN.
 Qed.
 
-Lemma sum_cte :
-  forall (x:R) (N:nat), sum_f_R0 (fun _:nat => x) N = x * INR (S N).
+Lemma sum_cte (x:R) (N:nat) : sum_f_R0 (fun _:nat => x) N = x * INR (S N).
 Proof.
   intros.
   induction  N as [| N HrecN].
@@ -326,8 +312,7 @@ Proof.
 Qed.
 
 (**********)
-Lemma sum_growing :
-  forall (An Bn:nat -> R) (N:nat),
+Lemma sum_growing (An Bn:nat -> R) (N:nat) :
     (forall n:nat, An n <= Bn n) -> sum_f_R0 An N <= sum_f_R0 Bn N.
 Proof.
   intros.
@@ -341,8 +326,7 @@ Proof.
 Qed.
 
 (**********)
-Lemma Rabs_triang_gen :
-  forall (An:nat -> R) (N:nat),
+Lemma Rabs_triang_gen (An:nat -> R) (N:nat) :
     Rabs (sum_f_R0 An N) <= sum_f_R0 (fun i:nat => Rabs (An i)) N.
 Proof.
   intros.
@@ -357,8 +341,7 @@ Proof.
 Qed.
 
 (**********)
-Lemma cond_pos_sum :
-  forall (An:nat -> R) (N:nat),
+Lemma cond_pos_sum (An:nat -> R) (N:nat) :
     (forall n:nat, 0 <= An n) -> 0 <= sum_f_R0 An N.
 Proof.
   intros.
@@ -483,8 +466,7 @@ Proof.
 Qed.
 
 (**********)
-Lemma sum_eq_R0 :
-  forall (An:nat -> R) (N:nat),
+Lemma sum_eq_R0 (An:nat -> R) (N:nat) :
     (forall n:nat, (n <= N)%nat -> An n = 0) -> sum_f_R0 An N = 0.
 Proof.
   intros; induction  N as [| N HrecN].
@@ -498,8 +480,7 @@ Definition SP (fn:nat -> R -> R) (N:nat) (x:R) : R :=
   sum_f_R0 (fun k:nat => fn k x) N.
 
 (**********)
-Lemma sum_incr :
-  forall (An:nat -> R) (N:nat) (l:R),
+Lemma sum_incr (An:nat -> R) (N:nat) (l:R) :
     Un_cv (fun n:nat => sum_f_R0 An n) l ->
     (forall n:nat, 0 <= An n) -> sum_f_R0 An N <= l.
 Proof.

--- a/theories/Reals/Ranalysis4.v
+++ b/theories/Reals/Ranalysis4.v
@@ -176,12 +176,11 @@ Proof.
 Qed.
 
 (** Finite sums : Sum a_k x^k *)
-Lemma continuity_finite_sum :
-  forall (An:nat -> R) (N:nat),
+Lemma continuity_finite_sum (An:nat -> R) (N:nat) :
     continuity (fun y:R => sum_f_R0 (fun k:nat => An k * y ^ k) N).
 Proof.
   intros; unfold continuity; intro.
-  induction  N as [| N HrecN].
+  induction N as [| N HrecN].
   simpl.
   apply continuity_pt_const.
   unfold constant; intros; reflexivity.
@@ -199,8 +198,7 @@ Proof.
   reflexivity.
 Qed.
 
-Lemma derivable_pt_lim_fs :
-  forall (An:nat -> R) (x:R) (N:nat),
+Lemma derivable_pt_lim_fs (An:nat -> R) (x:R) (N:nat) :
     (0 < N)%nat ->
     derivable_pt_lim (fun y:R => sum_f_R0 (fun k:nat => An k * y ^ k) N) x
     (sum_f_R0 (fun k:nat => INR (S k) * An (S k) * x ^ k) (pred N)).
@@ -256,8 +254,7 @@ Proof.
   right; apply lt_le_trans with 1%nat; [ apply lt_O_Sn | assumption ].
 Qed.
 
-Lemma derivable_pt_lim_finite_sum :
-  forall (An:nat -> R) (x:R) (N:nat),
+Lemma derivable_pt_lim_finite_sum (An:nat -> R) (x:R) (N:nat) :
     derivable_pt_lim (fun y:R => sum_f_R0 (fun k:nat => An k * y ^ k) N) x
     match N with
       | O => 0
@@ -265,7 +262,7 @@ Lemma derivable_pt_lim_finite_sum :
     end.
 Proof.
   intros.
-  induction  N as [| N HrecN].
+  induction N as [| N HrecN].
   simpl.
   rewrite Rmult_1_r.
   replace (fun _:R => An 0%nat) with (fct_cte (An 0%nat));
@@ -273,8 +270,7 @@ Proof.
   apply derivable_pt_lim_fs; apply lt_O_Sn.
 Qed.
 
-Lemma derivable_pt_finite_sum :
-  forall (An:nat -> R) (N:nat) (x:R),
+Lemma derivable_pt_finite_sum (An:nat -> R) (N:nat) (x:R) :
     derivable_pt (fun y:R => sum_f_R0 (fun k:nat => An k * y ^ k) N) x.
 Proof.
   intros.

--- a/theories/Reals/Ranalysis5.v
+++ b/theories/Reals/Ranalysis5.v
@@ -239,7 +239,7 @@ assert (Sublemma : forall x y lb ub, lb <= x <= ub /\ lb <= y <= ub -> lb <= (x+
   intros x y lb ub Hyp.
   lra.
 intros x y P N x_lt_y.
-induction N.
+induction N as [|N IHN].
  simpl ; intuition.
  simpl.
  case (P ((Dichotomy_lb x y P N + Dichotomy_ub x y P N) / 2)).
@@ -269,14 +269,14 @@ intros x y x0 D x_lt_y bnd.
   unfold Un_cv ; intros ; exists 0%nat ; intros ; unfold R_dist ; replace (y -y) with 0 by field ; rewrite Rabs_R0 ; assumption.
 Qed.
 
-Lemma IVT_interv : forall (f : R -> R) (x y : R),
+Lemma IVT_interv (f : R -> R) (x y : R) :
        (forall a, x <= a <= y -> continuity_pt f a) ->
        x < y ->
        f x < 0 ->
        0 < f y ->
        {z : R | x <= z <= y /\ f z = 0}.
 Proof.
-intros. (* f x y f_cont_interv x_lt_y fx_neg fy_pos.*)
+intros. (* f_cont_interv x_lt_y fx_neg fy_pos.*)
   cut (x <= y).
   intro.
   generalize (dicho_lb_cv x y (fun z:R => cond_positivity (f z)) H3).
@@ -465,7 +465,7 @@ Lemma continuity_pt_recip_prelim : forall (f g:R->R) (lb ub : R) (Pr1:lb < ub),
        continuity_pt g b.
 Proof.
 assert (Sublemma : forall x y z, Rmax x y < z <-> x < z /\ y < z).
- intros x y z. split.
+{ intros x y z. split.
   unfold Rmax. case (Rle_dec x y) ; intros Hyp Hyp2.
   split. apply Rle_lt_trans with (r2:=y) ; assumption. assumption.
   split. assumption. apply Rlt_trans with (r2:=x).
@@ -476,9 +476,9 @@ assert (Sublemma : forall x y z, Rmax x y < z <-> x < z /\ y < z).
   intros Hyp.
   unfold Rmax. case (Rle_dec x y).
   intro ; exact (proj2 Hyp).
-  intro ; exact (proj1 Hyp).
+  intro ; exact (proj1 Hyp). }
 assert (Sublemma2 : forall x y z, Rmin x y > z <-> x > z /\ y > z).
- intros x y z. split.
+{ intros x y z. split.
   unfold Rmin. case (Rle_dec x y) ; intros Hyp Hyp2.
   split. assumption.
   apply Rlt_le_trans with (r2:=x) ; intuition.
@@ -491,13 +491,13 @@ assert (Sublemma2 : forall x y z, Rmin x y > z <-> x > z /\ y > z).
   intros Hyp.
   unfold Rmin. case (Rle_dec x y).
   intro ; exact (proj1 Hyp).
-  intro ; exact (proj2 Hyp).
+  intro ; exact (proj2 Hyp). }
 assert (Sublemma3 : forall x y, x <= y /\ x <> y -> x < y).
- intros m n Hyp. unfold Rle in Hyp.
+{ intros m n Hyp. unfold Rle in Hyp.
   destruct Hyp as (Hyp1,Hyp2).
   case Hyp1.
   intuition.
-  intro Hfalse ; apply False_ind ; apply Hyp2 ; exact Hfalse.
+  intro Hfalse ; apply False_ind ; apply Hyp2 ; exact Hfalse. }
 intros f g lb ub lb_lt_ub f_incr_interv f_eq_g f_cont_interv b b_encad.
  assert (f_incr_interv2 : forall x y, lb <= x -> x <= y -> y <= ub -> f x <= f y).
   intros m n cond1 cond2 cond3.
@@ -561,18 +561,18 @@ intros f g lb ub lb_lt_ub f_incr_interv f_eq_g f_cont_interv b b_encad.
  destruct Temp as (_,y_cond).
   rewrite <- f_x_b in y_cond.
   assert (Temp : forall x y d1 d2, d1 > 0 -> d2 > 0 -> Rabs (y - x) < Rmin d1 d2 -> x - d1 <= y <= x + d2).
-   intros.
+  { intros.
     split. assert (H10 : forall x y z, x - y <= z -> x - z <= y). intuition. lra.
     apply H10. apply Rle_trans with (r2:=Rabs (y0 - x0)).
     replace (Rabs (y0 - x0)) with (Rabs (x0 - y0)). apply RRle_abs.
     rewrite <- Rabs_Ropp. unfold Rminus ; rewrite Ropp_plus_distr. rewrite Ropp_involutive.
     intuition.
-    apply Rle_trans with (r2:= Rmin d1 d2). apply Rlt_le ; assumption.
+    apply Rle_trans with (r2:= Rmin d3 d4). apply Rlt_le ; assumption.
     apply Rmin_l.
     assert (H10 : forall x y z, x - y <= z -> x <= y + z). intuition. lra.
     apply H10. apply Rle_trans with (r2:=Rabs (y0 - x0)). apply RRle_abs.
-    apply Rle_trans with (r2:= Rmin d1 d2). apply Rlt_le ; assumption.
-    apply Rmin_r.
+    apply Rle_trans with (r2:= Rmin d3 d4). apply Rlt_le ; assumption.
+    apply Rmin_r. }
   assert (Temp' := Temp (f x) y (f x - f x1) (f x2 - f x)).
   replace (f x - (f x - f x1)) with (f x1) in Temp' by field.
   replace (f x + (f x2 - f x)) with (f x2) in Temp' by field.
@@ -924,18 +924,19 @@ intros f g lb ub x lb_lt_ub x_encad f_eq_g g_wf f_incr f_derivable Df_neq.
    [| |rewrite g_eq_f in g_incr ; rewrite g_eq_f in g_incr| ] ; intuition.
 Qed.
 
-Lemma derivable_pt_recip_interv_decr : forall (f g:R->R) (lb ub x : R)
-         (lb_lt_ub:lb < ub)
-         (x_encad:f ub < x < f lb)
-         (f_eq_g:forall x : R, f ub <= x -> x <= f lb -> comp f g x = id x)
-         (g_wf:forall x : R, f ub <= x -> x <= f lb -> lb <= g x <= ub)
-         (f_decr:forall x y : R, lb <= x -> x < y -> y <= ub -> f y < f x)
-         (f_derivable:forall a : R, lb <= a <= ub -> derivable_pt f a),
-         derive_pt f (g x)
-              (derivable_pt_recip_interv_prelim1_decr f g lb ub x lb_lt_ub
-              x_encad g_wf f_derivable)
-         <> 0 ->
-         derivable_pt g x.
+Lemma derivable_pt_recip_interv_decr (f g:R->R) (lb ub x : R)
+      (lb_lt_ub:lb < ub)
+      (x_encad:f ub < x < f lb)
+      (f_eq_g:forall x : R, f ub <= x -> x <= f lb -> comp f g x = id x)
+      (g_wf:forall x : R, f ub <= x -> x <= f lb -> lb <= g x <= ub)
+      (f_decr:forall x y : R, lb <= x -> x < y -> y <= ub -> f y < f x)
+      (f_derivable:forall a : R, lb <= a <= ub -> derivable_pt f a) :
+  derive_pt f (g x)
+    (derivable_pt_recip_interv_prelim1_decr
+       f g lb ub x lb_lt_ub
+       x_encad g_wf f_derivable)
+  <> 0 ->
+  derivable_pt g x.
 Proof.
   intros.
   apply derivable_pt_opp_rev.
@@ -1055,19 +1056,21 @@ Proof.
   apply f_eq_g; lra.
 Qed.
 
-Lemma derive_pt_recip_interv : forall (f g:R->R) (lb ub x:R)
-       (lb_lt_ub:lb < ub) (x_encad:f lb < x < f ub)
-       (f_incr:forall x y : R, lb <= x -> x < y -> y <= ub -> f x < f y)
-       (g_wf:forall x : R, f lb <= x -> x <= f ub -> lb <= g x <= ub)
-       (Prf:forall a : R, lb <= a <= ub -> derivable_pt f a)
-       (f_eq_g:forall x, f lb <= x -> x <= f ub -> (comp f g) x = id x)
-       (Df_neq:derive_pt f (g x) (derivable_pt_recip_interv_prelim1 f g lb ub x
-                 lb_lt_ub x_encad g_wf Prf) <> 0),
-       derive_pt g x (derivable_pt_recip_interv f g lb ub x lb_lt_ub x_encad f_eq_g
-                 g_wf f_incr Prf Df_neq)
-       =
-       1 / (derive_pt f (g x) (Prf (g x) (derive_pt_recip_interv_prelim1_1 f g lb ub x
-       lb_lt_ub x_encad f_incr g_wf f_eq_g))).
+Lemma derive_pt_recip_interv (f g:R->R) (lb ub x:R)
+      (lb_lt_ub:lb < ub) (x_encad:f lb < x < f ub)
+      (f_incr:forall x y : R, lb <= x -> x < y -> y <= ub -> f x < f y)
+      (g_wf:forall x : R, f lb <= x -> x <= f ub -> lb <= g x <= ub)
+      (Prf:forall a : R, lb <= a <= ub -> derivable_pt f a)
+      (f_eq_g:forall x, f lb <= x -> x <= f ub -> (comp f g) x = id x)
+      (Df_neq:derive_pt f (g x)
+                        (derivable_pt_recip_interv_prelim1 f g lb ub x
+                          lb_lt_ub x_encad g_wf Prf) <> 0)
+  :
+    derive_pt g x
+      (derivable_pt_recip_interv f g lb ub x lb_lt_ub x_encad f_eq_g g_wf f_incr Prf Df_neq)
+    =
+    1 / (derive_pt f (g x) (Prf (g x)
+          (derive_pt_recip_interv_prelim1_1 f g lb ub x lb_lt_ub x_encad f_incr g_wf f_eq_g))).
 Proof.
 intros.
  assert(g_incr := (derive_pt_recip_interv_prelim1_1 f g lb ub x lb_lt_ub
@@ -1081,7 +1084,7 @@ intros.
  exact (derive_pt_recip_interv_prelim1_0 f g lb ub x lb_lt_ub x_encad f_incr g_wf f_eq_g).
 Qed.
 
-Lemma derive_pt_recip_interv_decr : forall (f g:R->R) (lb ub x:R)
+Lemma derive_pt_recip_interv_decr (f g:R->R) (lb ub x:R)
        (lb_lt_ub:lb < ub)
        (x_encad:f ub < x < f lb)
        (f_decr:forall x y : R, lb <= x -> x < y -> y <= ub -> f y < f x)
@@ -1089,7 +1092,7 @@ Lemma derive_pt_recip_interv_decr : forall (f g:R->R) (lb ub x:R)
        (Prf:forall a : R, lb <= a <= ub -> derivable_pt f a)
        (f_eq_g:forall x, f ub <= x -> x <= f lb -> (comp f g) x = id x)
        (Df_neq:derive_pt f (g x) (derivable_pt_recip_interv_prelim1_decr f g lb ub x
-                 lb_lt_ub x_encad g_wf Prf) <> 0),
+                 lb_lt_ub x_encad g_wf Prf) <> 0) :
        derive_pt g x (derivable_pt_recip_interv_decr f g lb ub x lb_lt_ub x_encad f_eq_g
                  g_wf f_decr Prf Df_neq)
        =

--- a/theories/Reals/Ratan.v
+++ b/theories/Reals/Ratan.v
@@ -1032,7 +1032,7 @@ Lemma ps_atanSeq_continuity_pt_1 : forall (N : nat) (x : R),
 Proof.
 assert (Sublemma : forall (x:R) (N:nat), sum_f_R0 (tg_alt (Ratan_seq x)) N = x * (comp (fun x => sum_f_R0 (fun n => (fun i : nat => (-1) ^ i / INR (2 * i + 1)) n * x ^ n) N) (fun x => x ^ 2) x)).
  intros x N.
-  induction N.
+  induction N as [|N IHN].
    unfold tg_alt, Ratan_seq, comp ; simpl ; field.
    simpl sum_f_R0 at 1.
    rewrite IHN.
@@ -1290,7 +1290,7 @@ assert (Tool : forall N, (-1) ^ (S (2 * N))  = - 1).
   reflexivity.
   lia.
 intros N x x_lb x_ub.
- induction N.
+ induction N as [|N IHN].
   unfold Datan_seq, Ratan_seq, tg_alt ; simpl.
   intros eps eps_pos.
    elim (derivable_pt_lim_id x eps eps_pos) ; intros delta Hdelta ; exists delta.

--- a/theories/Reals/RiemannInt.v
+++ b/theories/Reals/RiemannInt.v
@@ -36,16 +36,15 @@ Definition phi_sequence (un:nat -> posreal) (f:R -> R)
   (a b:R) (pr:Riemann_integrable f a b) (n:nat) :=
   projT1 (pr (un n)).
 
-Lemma phi_sequence_prop :
-  forall (un:nat -> posreal) (f:R -> R) (a b:R) (pr:Riemann_integrable f a b)
-    (N:nat),
+Lemma phi_sequence_prop (un:nat -> posreal) (f:R -> R) (a b:R) (pr:Riemann_integrable f a b)
+    (N:nat) :
     { psi:StepFun a b |
       (forall t:R,
         Rmin a b <= t <= Rmax a b ->
         Rabs (f t - phi_sequence un pr N t) <= psi t) /\
       Rabs (RiemannInt_SF psi) < un N }.
 Proof.
-  intros; apply (projT2 (pr (un N))).
+  apply (projT2 (pr (un N))).
 Qed.
 
 Lemma RiemannInt_P1 :
@@ -81,8 +80,7 @@ Proof.
   apply H1.
 Qed.
 
-Lemma RiemannInt_P2 :
-  forall (f:R -> R) (a b:R) (un:nat -> posreal) (vn wn:nat -> StepFun a b),
+Lemma RiemannInt_P2 (f:R -> R) (a b:R) (un:nat -> posreal) (vn wn:nat -> StepFun a b) :
     Un_cv un 0 ->
     a <= b ->
     (forall n:nat,
@@ -133,8 +131,7 @@ Proof.
     assumption.
 Qed.
 
-Lemma RiemannInt_P3 :
-  forall (f:R -> R) (a b:R) (un:nat -> posreal) (vn wn:nat -> StepFun a b),
+Lemma RiemannInt_P3 (f:R -> R) (a b:R) (un:nat -> posreal) (vn wn:nat -> StepFun a b) :
     Un_cv un 0 ->
     (forall n:nat,
       (forall t:R, Rmin a b <= t <= Rmax a b -> Rabs (f t - vn n t) <= wn n t) /\
@@ -583,10 +580,9 @@ Proof.
                ; apply H ] ].
 Qed.
 
-Lemma SubEqui_P3 :
-  forall (N:nat) (a b:R) (del:posreal), length (SubEquiN N a b del) = S N.
+Lemma SubEqui_P3 : forall (N:nat) (a b:R) (del:posreal), length (SubEquiN N a b del) = S N.
 Proof.
-  simple induction N; intros;
+  intro N;elim N; intros;
     [ reflexivity | simpl; rewrite H; reflexivity ].
 Qed.
 
@@ -594,7 +590,7 @@ Lemma SubEqui_P4 :
   forall (N:nat) (a b:R) (del:posreal) (i:nat),
     (i < S N)%nat -> pos_Rl (SubEquiN (S N) a b del) i = a + INR i * del.
 Proof.
-  simple induction N;
+  intro N; elim N;
     [ intros; inversion H; [ simpl; ring | elim (le_Sn_O _ H1) ]
       | intros; induction  i as [| i Hreci];
         [ simpl; ring
@@ -667,8 +663,7 @@ Proof.
     [ apply SubEqui_P7 | apply SubEqui_P1 | apply SubEqui_P2 ].
 Qed.
 
-Lemma RiemannInt_P6 :
-  forall (f:R -> R) (a b:R),
+Lemma RiemannInt_P6 (f:R -> R) (a b:R) :
     a < b ->
     (forall x:R, a <= x <= b -> continuity_pt f x) -> Riemann_integrable f a b.
 Proof.
@@ -1645,13 +1640,12 @@ Proof.
       try assumption; apply RinvN_cv.
 Qed.
 
-Lemma RiemannInt_P18 :
-  forall (f g:R -> R) (a b:R) (pr1:Riemann_integrable f a b)
-    (pr2:Riemann_integrable g a b),
-    a <= b ->
-    (forall x:R, a < x < b -> f x = g x) -> RiemannInt pr1 = RiemannInt pr2.
+Lemma RiemannInt_P18 (f g:R -> R) (a b:R) (pr1:Riemann_integrable f a b)
+      (pr2:Riemann_integrable g a b) :
+  a <= b ->
+  (forall x:R, a < x < b -> f x = g x) -> RiemannInt pr1 = RiemannInt pr2.
 Proof.
-  intro f; intros; unfold RiemannInt;
+  intros; unfold RiemannInt;
     case (RiemannInt_exists pr1 RinvN RinvN_cv) as (x0,HUn_cv0);
     case (RiemannInt_exists pr2 RinvN RinvN_cv) as (x,HUn_cv);
       eapply UL_sequence.
@@ -1741,7 +1735,7 @@ Proof.
   destruct (Req_EM_T x1 b) as [ -> |Hneqb].
   elim H3; intros; elim (Rlt_irrefl _ H5).
   right; reflexivity.
-  intro; assert (H2 := pre (phi2 N)); unfold IsStepFun in H2;
+  intro N; assert (H2 := pre (phi2 N)); unfold IsStepFun in H2;
     unfold is_subdivision in H2; elim H2; clear H2; intros l [lf H2];
       split with l; split with lf; unfold adapted_couple in H2;
         decompose [and] H2; clear H2; unfold adapted_couple;
@@ -2049,8 +2043,7 @@ Proof.
       | elim Hnle; apply Rle_trans with b; [ assumption | left; assumption ] ].
 Qed.
 
-Lemma RiemannInt_P22 :
-  forall (f:R -> R) (a b c:R),
+Lemma RiemannInt_P22 (f:R -> R) (a b c:R) :
     Riemann_integrable f a b -> a <= c <= b -> Riemann_integrable f a c.
 Proof.
   unfold Riemann_integrable; intros; elim (X eps); clear X;
@@ -2120,8 +2113,7 @@ Proof.
   rewrite StepFun_P18; ring.
 Qed.
 
-Lemma RiemannInt_P23 :
-  forall (f:R -> R) (a b c:R),
+Lemma RiemannInt_P23 (f:R -> R) (a b c:R) :
     Riemann_integrable f a b -> a <= c <= b -> Riemann_integrable f c b.
 Proof.
   unfold Riemann_integrable; intros; elim (X eps); clear X;

--- a/theories/Reals/RiemannInt_SF.v
+++ b/theories/Reals/RiemannInt_SF.v
@@ -319,7 +319,7 @@ Lemma StepFun_P10 :
     exists l' : list R,
       (exists lf' : list R, adapted_couple_opt f a b l' lf').
 Proof.
-  induction l as [ | r r0 H].
+  intros f l;induction l as [ | r r0 H].
   intros; unfold adapted_couple in H0; decompose [and] H0; simpl in H4;
     discriminate.
   intros; case (Req_dec a b); intro.
@@ -508,12 +508,11 @@ Proof.
         | unfold Rmax; decide (Rle_dec a b) with H0; reflexivity ].
 Qed.
 
-Lemma StepFun_P11 :
-  forall (a b r r1 r3 s1 s2 r4:R) (r2 lf1 s3 lf2:list R)
-    (f:R -> R),
-    a < b ->
-    adapted_couple f a b (cons r (cons r1 r2)) (cons r3 lf1) ->
-    adapted_couple_opt f a b (cons s1 (cons s2 s3)) (cons r4 lf2) -> r1 <= s2.
+Lemma StepFun_P11 (a b r r1 r3 s1 s2 r4:R) (r2 lf1 s3 lf2:list R)
+      (f:R -> R) :
+  a < b ->
+  adapted_couple f a b (cons r (cons r1 r2)) (cons r3 lf1) ->
+  adapted_couple_opt f a b (cons s1 (cons s2 s3)) (cons r4 lf2) -> r1 <= s2.
 Proof.
   intros; unfold adapted_couple_opt in H1; elim H1; clear H1; intros;
     unfold adapted_couple in H0, H1; decompose [and] H0;
@@ -668,7 +667,7 @@ Lemma StepFun_P14 :
     adapted_couple f a b l1 lf1 ->
     adapted_couple_opt f a b l2 lf2 -> Int_SF lf1 l1 = Int_SF lf2 l2.
 Proof.
-  induction l1 as [ | r r0 H0].
+  intros f l1; induction l1 as [ | r r0 H0].
   intros l2 lf1 lf2 a b Hyp H H0; unfold adapted_couple in H; decompose [and] H;
     clear H H0 H2 H3 H1 H6; simpl in H4; discriminate.
   induction r0 as [|r1 r2 H].
@@ -947,8 +946,7 @@ Proof.
       | simpl; rewrite RList_P18; rewrite RList_P14; reflexivity ].
 Qed.
 
-Lemma StepFun_P21 :
-  forall (a b:R) (f:R -> R) (l:list R),
+Lemma StepFun_P21 (a b:R) (f:R -> R) (l:list R) :
     is_subdivision f a b l -> adapted_couple f a b l (FF l f).
 Proof.
   intros * (x & H & H1 & H0 & H2 & H4).
@@ -1632,8 +1630,7 @@ Proof.
         apply lt_O_Sn ].
 Qed.
 
-Lemma StepFun_P34 :
-  forall (a b:R) (f:StepFun a b),
+Lemma StepFun_P34 (a b:R) (f:StepFun a b) :
     a <= b ->
     Rabs (RiemannInt_SF f) <= RiemannInt_SF (mkStepFun (StepFun_P32 f)).
 Proof.
@@ -1717,8 +1714,7 @@ Proof.
   simpl; apply (H0 0%nat); simpl; apply lt_O_Sn.
 Qed.
 
-Lemma StepFun_P36 :
-  forall (a b:R) (f g:StepFun a b) (l:list R),
+Lemma StepFun_P36 (a b:R) (f g:StepFun a b) (l:list R) :
     a <= b ->
     is_subdivision f a b l ->
     is_subdivision g a b l ->
@@ -1883,8 +1879,7 @@ Proof.
               [ apply lt_S_n; assumption | apply lt_n_Sn ] ].
 Qed.
 
-Lemma StepFun_P39 :
-  forall (a b:R) (f:StepFun a b),
+Lemma StepFun_P39 (a b:R) (f:StepFun a b) :
     RiemannInt_SF f = - RiemannInt_SF (mkStepFun (StepFun_P6 (pre f))).
 Proof.
   intros; unfold RiemannInt_SF; case (Rle_dec a b); case (Rle_dec b a);

--- a/theories/Reals/Rprod.v
+++ b/theories/Reals/Rprod.v
@@ -47,8 +47,7 @@ Proof.
 Qed.
 
 (**********)
-Lemma prod_SO_pos :
-  forall (An:nat -> R) (N:nat),
+Lemma prod_SO_pos (An:nat -> R) (N:nat) :
     (forall n:nat, (n <= N)%nat -> 0 <= An n) -> 0 <= prod_f_R0 An N.
 Proof.
   intros; induction  N as [| N HrecN].
@@ -60,8 +59,7 @@ Proof.
 Qed.
 
 (**********)
-Lemma prod_SO_Rle :
-  forall (An Bn:nat -> R) (N:nat),
+Lemma prod_SO_Rle (An Bn:nat -> R) (N:nat) :
     (forall n:nat, (n <= N)%nat -> 0 <= An n <= Bn n) ->
     prod_f_R0 An N <= prod_f_R0 Bn N.
 Proof.
@@ -106,8 +104,7 @@ Proof.
 Qed.
 
 (** We prove that (N!)^2<=(2N-k)!*k! forall k in [|O;2N|] *)
-Lemma RfactN_fact2N_factk :
-  forall N k:nat,
+Lemma RfactN_fact2N_factk N (k:nat) :
     (k <= 2 * N)%nat ->
     Rsqr (INR (fact N)) <= INR (fact (2 * N - k)) * INR (fact k).
 Proof.
@@ -172,7 +169,7 @@ Proof.
 Qed.
 
 (** We have the following inequality : (C 2N k) <= (C 2N N) forall k in [|O;2N|] *)
-Lemma C_maj : forall N k:nat, (k <= 2 * N)%nat -> C (2 * N) k <= C (2 * N) N.
+Lemma C_maj N (k:nat) : (k <= 2 * N)%nat -> C (2 * N) k <= C (2 * N) N.
 Proof.
   intros; unfold C; unfold Rdiv; apply Rmult_le_compat_l.
   apply pos_INR.

--- a/theories/Reals/Rseries.v
+++ b/theories/Reals/Rseries.v
@@ -219,7 +219,7 @@ Section sequence.
     induction N.
     easy.
     simpl.
-    assert (H6: Un N <= l - eps).
+    assert (H6: Un N1 <= l - eps).
     apply Rle_trans with (2 := H5).
     apply Rge_le.
     apply growing_prop ; try easy.
@@ -259,7 +259,7 @@ Section sequence.
   Lemma finite_greater :
     forall N:nat,  exists M : R, (forall n:nat, (n <= N)%nat -> Un n <= M).
   Proof.
-    intro; induction  N as [| N HrecN].
+    intro N; induction  N as [| N HrecN].
     split with (Un 0); intros; rewrite (le_n_O_eq n H);
       apply (Req_le (Un n) (Un n) (eq_refl (Un n))).
     elim HrecN; clear HrecN; intros; split with (Rmax (Un (S N)) x); intros;

--- a/theories/Reals/Rsqrt_def.v
+++ b/theories/Reals/Rsqrt_def.v
@@ -308,7 +308,7 @@ Proof.
   apply Rlt_trans with 0.
   assumption.
   unfold pow_2_n; apply pow_lt; prove_sup0.
-  simple induction N.
+  intro N;elim N.
   simpl.
   left; apply Rlt_0_1.
   intros.

--- a/theories/Reals/Rtopology.v
+++ b/theories/Reals/Rtopology.v
@@ -1334,7 +1334,7 @@ Proof.
   split.
   exists x0; split; [ reflexivity | rewrite H1; apply (le_INR _ _ H3) ].
   exists N; assumption.
-  unfold ValAdh; intros; unfold ValAdh_un in H;
+  unfold ValAdh; intros ? N ?; unfold ValAdh_un in H;
     unfold intersection_family in H; simpl in H;
       assert
         (H1 :

--- a/theories/Reals/SeqSeries.v
+++ b/theories/Reals/SeqSeries.v
@@ -24,13 +24,12 @@ Require Export Alembert.
 Local Open Scope R_scope.
 
 (**********)
-Lemma sum_maj1 :
-  forall (fn:nat -> R -> R) (An:nat -> R) (x l1 l2:R)
-    (N:nat),
-    Un_cv (fun n:nat => SP fn n x) l1 ->
-    Un_cv (fun n:nat => sum_f_R0 An n) l2 ->
-    (forall n:nat, Rabs (fn n x) <= An n) ->
-    Rabs (l1 - SP fn N x) <= l2 - sum_f_R0 An N.
+Lemma sum_maj1 (fn:nat -> R -> R) (An:nat -> R) (x l1 l2:R)
+      (N:nat) :
+  Un_cv (fun n:nat => SP fn n x) l1 ->
+  Un_cv (fun n:nat => sum_f_R0 An n) l2 ->
+  (forall n:nat, Rabs (fn n x) <= An n) ->
+  Rabs (l1 - SP fn N x) <= l2 - sum_f_R0 An N.
 Proof.
   intros;
     cut { l:R | Un_cv (fun n => sum_f_R0 (fun l => fn (S N + l)%nat x) n) l }.

--- a/theories/micromega/QMicromega.v
+++ b/theories/micromega/QMicromega.v
@@ -183,7 +183,7 @@ Proof.
   unfold Qeval_expr'.
   simpl.
   rewrite Qeval_op2_hold.
-  split ; destruct Fop ; simpl; auto.
+  split ; destruct Fop0 ; simpl; auto.
 Qed.
 
 

--- a/theories/micromega/RMicromega.v
+++ b/theories/micromega/RMicromega.v
@@ -297,14 +297,14 @@ Proof.
           with (Qpower q (Zpos p)).
     rewrite <- N2Z.inj_pos.
     rewrite <- positive_N_nat.
-    rewrite rpow_pow_N.
     rewrite rpow_pow_N0.
+    rewrite rpow_pow_N1.
     apply Q2R_pow_N.
   -
     rewrite  Q2R_inv.
     unfold Qpower_positive.
     rewrite <- positive_N_nat.
-    rewrite rpow_pow_N0.
+    rewrite rpow_pow_N1.
     unfold pow_N.
     rewrite Q2R_pow_pos.
     auto.
@@ -359,10 +359,10 @@ Proof.
       rewrite <- IHc.
       destruct Qpower_theory.
       rewrite <- nat_N_Z.
-      rewrite rpow_pow_N.
+      rewrite rpow_pow_N0.
       destruct R_power_theory.
       rewrite <- (Nnat.Nat2N.id n) at 2.
-      rewrite rpow_pow_N0.
+      rewrite rpow_pow_N1.
       apply Q2R_pow_N.
   - rewrite <- IHc.
     unfold CInvR0.

--- a/theories/rtauto/Bintree.v
+++ b/theories/rtauto/Bintree.v
@@ -268,7 +268,7 @@ Qed.
 Lemma Full_index_one_empty : forall S, Full S -> index S = 1 -> S=empty.
 intros [ind cont] F one; inversion F.
 reflexivity.
-simpl @index in one;assert (h:=Pos.succ_not_1 (index S)).
+simpl @index in one;assert (h:=Pos.succ_not_1 (index S0)).
 congruence.
 Qed.
 
@@ -288,7 +288,7 @@ get i S = PSome x -> In x S F.
 induction F.
 intro i;rewrite get_empty; congruence.
 intro i;rewrite get_push_Full;trivial.
-case_eq (i ?= index S);simpl.
+case_eq (i ?= index S0);simpl.
 left;congruence.
 right;eauto.
 congruence.
@@ -358,7 +358,7 @@ mkStore (index S) (Tmap (contents S)).
 Lemma get_map: forall i S,
 get i (map S)= match get i S with PNone => PNone
 | PSome a => PSome (f a) end.
-destruct S;unfold get,map,contents,index;apply Tget_Tmap.
+destruct S0;unfold get,map,contents,index;apply Tget_Tmap.
 Defined.
 
 Lemma map_push: forall a S,


### PR DESCRIPTION
Fix #3523

Considering the large stdlib changes this is probably not feasible, but let's see CI 