### PR TITLE
Separate nametabs for open modules/modtypes/sections vs closed modules

### DIFF
--- a/dev/ci/user-overlays/15078-SkySkimmer-locatemod-noopen.sh
+++ b/dev/ci/user-overlays/15078-SkySkimmer-locatemod-noopen.sh
@@ -1,0 +1,1 @@
+overlay paramcoq https://github.com/SkySkimmer/paramcoq locatemod-noopen 15078

--- a/doc/changelog/07-vernac-commands-and-options/15078-locatemod-noopen.rst
+++ b/doc/changelog/07-vernac-commands-and-options/15078-locatemod-noopen.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  Closed modules now live in a separate namespace from open modules and sections.
+  (`#15078 <https://github.com/coq/coq/pull/15078>`_,
+  fixes `#14529 <https://github.com/coq/coq/issues/14529>`_,
+  by Gaëtan Gilbert).

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -277,7 +277,7 @@ let start_mod is_type export id mp fs =
   let prefix = Nametab.{ obj_dir = dir; obj_mp = mp; } in
   let exists =
     if is_type then Nametab.exists_cci (make_path id)
-    else Nametab.exists_dir dir
+    else Nametab.exists_module dir
   in
   if exists then
     user_err (Id.print id ++ str " already exists.");

--- a/library/nametab.mli
+++ b/library/nametab.mli
@@ -84,7 +84,6 @@ module GlobDirRef : sig
     | DirOpenModule of object_prefix
     | DirOpenModtype of object_prefix
     | DirOpenSection of object_prefix
-    | DirModule of object_prefix
   val equal : t -> t -> bool
 end
 
@@ -109,6 +108,7 @@ val map_visibility : (int -> int) -> visibility -> visibility
 
 val push : visibility -> full_path -> GlobRef.t -> unit
 val push_modtype : visibility -> full_path -> ModPath.t -> unit
+val push_module : visibility -> DirPath.t -> ModPath.t -> unit
 val push_dir : visibility -> DirPath.t -> GlobDirRef.t -> unit
 val push_syndef : visibility -> full_path -> syndef_name -> unit
 
@@ -145,6 +145,7 @@ val locate_all : qualid -> GlobRef.t list
 val locate_extended_all : qualid -> extended_global_reference list
 val locate_extended_all_dir : qualid -> GlobDirRef.t list
 val locate_extended_all_modtype : qualid -> ModPath.t list
+val locate_extended_all_module : qualid -> ModPath.t list
 
 (** Experimental completion support, API is _unstable_ *)
 val completion_canditates : qualid -> extended_global_reference list
@@ -161,6 +162,7 @@ val extended_global_of_path : full_path -> extended_global_reference
 
 val exists_cci : full_path -> bool
 val exists_modtype : full_path -> bool
+val exists_module : DirPath.t -> bool
 val exists_dir : DirPath.t -> bool
 val exists_universe : full_path -> bool
 

--- a/test-suite/bugs/closed/bug_14529.v
+++ b/test-suite/bugs/closed/bug_14529.v
@@ -1,0 +1,21 @@
+
+Module Import Foo_DOT_A.
+  Module Foo.
+    Module A.
+      Axiom a : Set.
+    End A.
+  End Foo.
+End Foo_DOT_A.
+
+Module Foo.
+  Import Foo.A.
+  Module A.
+    Axiom b : Prop.
+    Import Foo.A.
+    Locate Foo.A.
+  End A.
+  Section A.
+    Import Foo.A.
+    Locate Foo.A.
+  End A.
+End Foo.

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -36,7 +36,7 @@ type object_pr = {
   print_constant_with_infos : Constant.t -> UnivNames.univ_name_list option -> Pp.t;
   print_section_variable    : env -> Evd.evar_map -> variable -> Pp.t;
   print_syntactic_def       : env -> KerName.t -> Pp.t;
-  print_module              : bool -> ModPath.t -> Pp.t;
+  print_module              : ModPath.t -> Pp.t;
   print_modtype             : ModPath.t -> Pp.t;
   print_named_decl          : env -> Evd.evar_map -> Constr.named_declaration -> Pp.t;
   print_library_entry       : env -> Evd.evar_map -> bool -> (object_name * Lib.node) -> Pp.t option;
@@ -45,7 +45,7 @@ type object_pr = {
   print_eval                : Reductionops.reduction_function -> env -> Evd.evar_map -> Constrexpr.constr_expr -> EConstr.unsafe_judgment -> Pp.t;
 }
 
-let gallina_print_module  = print_module
+let gallina_print_module mp = print_module ~with_body:true mp
 let gallina_print_modtype = print_modtype
 
 (**************)
@@ -692,7 +692,7 @@ let gallina_print_leaf_entry env sigma with_values ((sp, kn),lobj) =
     handle handler o
   | ModuleObject _ ->
     let (mp,l) = KerName.repr kn in
-    Some (print_module with_values (MPdot (mp,l)))
+    Some (print_module ~with_body:with_values (MPdot (mp,l)))
   | ModuleTypeObject _ ->
     let (mp,l) = KerName.repr kn in
           Some (print_modtype (MPdot (mp,l)))
@@ -825,7 +825,7 @@ let print_full_pure_context env sigma =
   | ((_,kn),Lib.Leaf ModuleObject _)::rest ->
           (* TODO: make it reparsable *)
     let (mp,l) = KerName.repr kn in
-          prec rest ++ print_module true (MPdot (mp,l)) ++ str "." ++ fnl () ++ fnl ()
+          prec rest ++ print_module (MPdot (mp,l)) ++ str "." ++ fnl () ++ fnl ()
   | ((_,kn),Lib.Leaf ModuleTypeObject _)::rest ->
           (* TODO: make it reparsable *)
     let (mp,l) = KerName.repr kn in
@@ -878,7 +878,7 @@ let print_any_name env sigma na udecl =
   | Term (VarRef sp) -> print_section_variable env sigma sp
   | Syntactic kn -> print_syntactic_def env kn
   | Dir (Nametab.GlobDirRef.DirModule Nametab.{ obj_dir; obj_mp; _ } ) ->
-    print_module (printable_body obj_dir) obj_mp
+    print_module obj_mp
   | Dir _ -> mt ()
   | ModuleType mp -> print_modtype mp
   | Other (obj, info) -> info.print obj

--- a/vernac/prettyp.mli
+++ b/vernac/prettyp.mli
@@ -96,7 +96,7 @@ type object_pr = {
   print_constant_with_infos : Constant.t -> UnivNames.univ_name_list option -> Pp.t;
   print_section_variable    : env -> Evd.evar_map -> variable -> Pp.t;
   print_syntactic_def       : env -> KerName.t -> Pp.t;
-  print_module              : bool -> ModPath.t -> Pp.t;
+  print_module              : ModPath.t -> Pp.t;
   print_modtype             : ModPath.t -> Pp.t;
   print_named_decl          : env -> Evd.evar_map -> Constr.named_declaration -> Pp.t;
   print_library_entry       : env -> Evd.evar_map -> bool -> (Libobject.object_name * Lib.node) -> Pp.t option;

--- a/vernac/printmod.ml
+++ b/vernac/printmod.ml
@@ -391,18 +391,6 @@ and print_modtype extent env mp locals mtb = match mtb.mod_type_alg with
   | Some me -> print_expression true extent env mp locals me
   | None -> print_signature true extent env mp locals mtb.mod_type
 
-let rec printable_body dir =
-  let dir = pop_dirpath dir in
-    DirPath.is_empty dir ||
-    try
-      let open Nametab.GlobDirRef in
-      match Nametab.locate_dir (qualid_of_dirpath dir) with
-          DirOpenModtype _ -> false
-        | DirModule _ | DirOpenModule _ -> printable_body dir
-        | _ -> true
-    with
-        Not_found -> true
-
 (** Since we might play with nametab above, we should reset to prior
     state after the printing *)
 
@@ -433,7 +421,7 @@ let unsafe_print_module extent env mp with_body mb =
 
 exception ShortPrinting
 
-let print_module with_body mp =
+let print_module ~with_body mp =
   let me = Global.lookup_module mp in
   try
     if !short then raise ShortPrinting;

--- a/vernac/printmod.ml
+++ b/vernac/printmod.ml
@@ -61,7 +61,7 @@ let keyword s = tag_keyword (str s)
 let get_new_id locals id =
   let rec get_id l id =
     let dir = DirPath.make [id] in
-      if not (Nametab.exists_dir dir) then
+      if not (Nametab.exists_module dir || Nametab.exists_dir dir) then
         id
       else
         get_id (Id.Set.add id l) (Namegen.next_ident_away id l)
@@ -212,7 +212,7 @@ let print_kn locals kn =
 let nametab_register_dir obj_mp =
   let id = mk_fake_top () in
   let obj_dir = DirPath.make [id] in
-  Nametab.(push_dir (Until 1) obj_dir (GlobDirRef.DirModule { obj_dir; obj_mp; }))
+  Nametab.(push_module (Until 1) obj_dir obj_mp)
 
 (** Nota: the [global_reference] we register in the nametab below
     might differ from internal ones, since we cannot recreate here
@@ -268,7 +268,7 @@ let nametab_register_modparam mbid mtb =
     with e when CErrors.noncritical e ->
       (* Otherwise, we try to play with the nametab ourselves *)
       let mp = MPbound mbid in
-      let check id = Nametab.exists_dir (DirPath.make [id]) in
+      let check id = Nametab.exists_module (DirPath.make [id]) in
       let id = Namegen.next_ident_away_from id check in
       let dir = DirPath.make [id] in
       nametab_register_dir mp;

--- a/vernac/printmod.mli
+++ b/vernac/printmod.mli
@@ -10,12 +10,9 @@
 
 open Names
 
-(** false iff the module is an element of an open module type *)
-val printable_body : DirPath.t -> bool
-
 val pr_mutual_inductive_body : Environ.env ->
   MutInd.t -> Declarations.mutual_inductive_body ->
   UnivNames.univ_name_list option -> Pp.t
 
-val print_module : bool -> ModPath.t -> Pp.t
+val print_module : with_body:bool -> ModPath.t -> Pp.t
 val print_modtype : ModPath.t -> Pp.t

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -175,15 +175,9 @@ let print_libraries () =
 
 
 let print_module qid =
-  try
-    let open Nametab.GlobDirRef in
-    let globdir = Nametab.locate_dir qid in
-      match globdir with
-          DirModule Nametab.{ obj_dir; obj_mp; _ } ->
-          Printmod.print_module (Printmod.printable_body obj_dir) obj_mp
-        | _ -> raise Not_found
-  with
-    Not_found -> user_err (str"Unknown Module " ++ pr_qualid qid)
+  match Nametab.locate_module qid with
+  | mp -> Printmod.print_module ~with_body:true mp
+  | exception Not_found -> user_err (str"Unknown Module " ++ pr_qualid qid)
 
 let print_modtype qid =
   try
@@ -193,7 +187,7 @@ let print_modtype qid =
     (* Is there a module of this name ? If yes we display its type *)
     try
       let mp = Nametab.locate_module qid in
-      Printmod.print_module false mp
+      Printmod.print_module ~with_body:false mp
     with Not_found ->
       user_err (str"Unknown Module Type or Module " ++ pr_qualid qid)
 


### PR DESCRIPTION
Fix #14529

Overlays:
- https://github.com/coq-community/paramcoq/pull/86