### PR TITLE
Fix #15070 (Memory corruption when mixing primitive floats with primitive arrays.)

### DIFF
--- a/kernel/parray.mli
+++ b/kernel/parray.mli
@@ -23,6 +23,7 @@ val copy    : 'a t -> 'a t
 val map : ('a -> 'b) -> 'a t -> 'b t
 
 val to_array : 'a t -> 'a array * 'a (* default *)
+(* /!\ Don't use with 'a = float *)
 
 val of_array : 'a array -> 'a (* default *) -> 'a t
 


### PR DESCRIPTION
Fixes #15070

- [ ] Added bug to **test-suite**.
- [ ] Added **changelog**.
