### PR TITLE
Extend release process with rc announcement.

### DIFF
--- a/dev/doc/release-process.md
+++ b/dev/doc/release-process.md
@@ -162,6 +162,19 @@
   reference manual attached. The PDF can be recovered from the artifacts of the
   `doc:refman-pdf:dune` job from continuous integration.
 
+## For the first release candidate release ##
+
+- [ ] In coordination with platform maintainers, announce the release
+  candidate to Coq-Club and Discourse (coq-club@inria.fr +
+  coq+announcements@discoursemail.com) with the message that:
+  - the release candidate is stable: library authors can safely start
+    preparing compatible releases;
+  - in particular, the authors of packages that are included in the
+    platform should do so as soon as possible to avoid delaying the
+    platform release (and remind the expected calendar);
+  - a further announcement will follow when the platform is ready to
+    install this version of Coq.
+
 ## For each non-preview release ##
 
 - [ ] Modify the version number in the file


### PR DESCRIPTION
Conclusion of today's Coq Call discussion: https://github.com/coq/coq/wiki/Coq-Call-2021-10-27

cc @silene @SkySkimmer @palmskog (present to today's discussion) @MSoegtropIMC @gares @ejgallego (not present to today's discussion)

Note that we forgot to discuss when to update the website. Currently, the release process contains the following:
>- [ ] Modify the version number in the file   [`incl/macros.html`](https://github.com/coq/www/blob/master/incl/macros.html) on the website.
>- [ ] Ping `@Zimmi48` to switch the default version of the reference manual on the website.

It is my understanding that @palmskog would like to get rid of the first point by adopting some more generic documentation (that is not specific to one version of Coq) in the opam-using page.

If we were to decide to delay when we switch the default version of the reference manual, then we should probably emphasize even more (in all communications addressing library maintainers) how to find the documentation of the new release.