### PR TITLE
Use a uniform representation for the internal persistent arrays.

### DIFF
--- a/dev/doc/critical-bugs
+++ b/dev/doc/critical-bugs
@@ -354,6 +354,17 @@ Conversion machines
   GH issue number: #13998
   risk: none, unless using primitive array operations; systematic otherwise
 
+  component: "virtual machine" (compilation to bytecode ran by a C-interpreter)
+  summary: arbitrary code execution on arrays of floating point numbers
+  introduced: 8.13
+  impacted released versions: 8.13.0, 8.13.1, 8.14.0
+  impacted coqchk versions: none (no virtual machine in coqchk)
+  fixed in: 8.14.1
+  found by: Melquiond
+  GH issue number: #15070
+  risk: none, unless mixing open terms and primitive floats inside primitive
+  arrays; critical otherwise
+
 Side-effects
 
   component: side-effects

--- a/doc/sphinx/changes.rst
+++ b/doc/sphinx/changes.rst
@@ -831,6 +831,19 @@ Miscellaneous
   (`#13586 <https://github.com/coq/coq/pull/13586>`_,
   by Lasse Blaauwbroek).
 
+Changes in 8.14.1
+~~~~~~~~~~~~~~~~~
+
+Kernel
+^^^^^^
+
+- **Fixed:**
+  Fix the implementation of persistent arrays used by the VM and native compute
+  so that it uses a uniform representation. Previously, storing primitive floats
+  inside primitive arrays could cause memory corruption
+  (`#15081 <https://github.com/coq/coq/pull/15081>`_,
+  closes `#15070 <https://github.com/coq/coq/issues/15070>`_,
+  by Pierre-Marie Pédrot).
 
 Version 8.13
 ------------

--- a/kernel/nativevalues.ml
+++ b/kernel/nativevalues.ml
@@ -799,7 +799,7 @@ let arraylength accu vA t =
   else accu vA t
 
 let parray_of_array t def =
-  (Obj.magic (Parray.unsafe_of_array t def) : t)
+  (Obj.magic (Parray.unsafe_of_obj (Obj.repr t) def) : t)
 
 let arrayinit n (f:t->t) def =
   of_parray (Parray.init (to_uint n) (Obj.magic f) def)

--- a/kernel/nativevalues.mli
+++ b/kernel/nativevalues.mli
@@ -359,7 +359,7 @@ val no_check_next_down : t -> t
 
 (** Support for arrays *)
 
-val parray_of_array : t array -> t -> t
+val parray_of_array : t -> t -> t
 val is_parray : t -> bool
 
 val arraymake : t -> t -> t -> t -> t (* accu A n def *)

--- a/kernel/parray.ml
+++ b/kernel/parray.ml
@@ -8,6 +8,66 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+(** Uniform Arrays: non-flat arrays (even floats are boxed, i.e., doesn't use
+    {!Obj.double_array_tag}) *)
+module UArray :
+sig
+  type 'a t
+  val empty : 'a t
+  val unsafe_get : 'a t -> int -> 'a
+  val unsafe_set : 'a t -> int -> 'a -> unit
+  val length : 'a t -> int
+  val make : int -> 'a -> 'a t
+  val copy : 'a t -> 'a t
+  val of_array : 'a array -> 'a t
+  val to_array : 'a t -> 'a array
+  (* 'a should not be float (no Obj.double_tag) *)
+  val unsafe_of_array : 'a array -> 'a t
+end =
+struct
+  type 'a t = Obj.t array
+  (** Guaranteed to be a non-flat array and no funny business with write
+      barriers because of the opacity of Obj.t. *)
+
+  let empty = [||]
+
+  let length (v : 'a t) = Array.length v
+
+  let of_array v =
+    if (Obj.tag (Obj.repr v) == Obj.double_array_tag) then begin
+      let n = Array.length v in
+      (* Ensure that we initialize it with a non-float *)
+      let ans = Array.make n (Obj.repr ()) in
+      for i = 0 to n - 1 do
+        Array.unsafe_set ans i (Obj.repr (Array.unsafe_get v i))
+      done;
+      ans
+    end else
+      (Obj.magic (Array.copy v))
+
+  let obj_is_float x = Obj.tag x == Obj.double_tag
+
+  let to_array (type a) (v : a t) : a array =
+    let () = assert (not (Array.exists obj_is_float v)) in
+    Obj.magic (Array.copy v)
+
+  let unsafe_of_array (type a) (v : a array) =
+    let () = assert (Obj.tag (Obj.repr v) != Obj.double_array_tag) in
+    (Obj.magic v : a t)
+
+  let unsafe_get = Obj.magic Array.unsafe_get
+  let unsafe_set = Obj.magic Array.unsafe_set
+
+  let make (type a) n (x : a) : a t =
+    (* Ensure that we initialize it with a non-float *)
+    let ans = Array.make n (Obj.repr ()) in
+    let () = Array.fill ans 0 n (Obj.repr x) in
+    ans
+
+  let copy = Array.copy
+
+end
+
 let max_array_length32 = 4194303
 
 let max_length = Uint63.of_int max_array_length32
@@ -21,19 +81,19 @@ let trunc_size n =
 
 type 'a t = ('a kind) ref
 and 'a kind =
-  | Array of 'a array * 'a
+  | Array of 'a UArray.t * 'a
   | Updated of int * 'a * 'a t
 
-let unsafe_of_array t def = ref (Array (t,def))
-let of_array t def = unsafe_of_array (Array.copy t) def
+let unsafe_of_array t def = ref (Array (UArray.unsafe_of_array t, def))
+let of_array t def = ref (Array (UArray.of_array t, def))
 
 let rec rerootk t k =
   match !t with
   | Array (a, _) -> k a
   | Updated (i, v, p) ->
       let k' a =
-        let v' = Array.unsafe_get a i in
-        Array.unsafe_set a i v;
+        let v' = UArray.unsafe_get a i in
+        UArray.unsafe_set a i v;
         t := !p; (* i.e., Array (a, def) *)
         p := Updated (i, v', t);
         k a in
@@ -42,15 +102,15 @@ let rec rerootk t k =
 let reroot t = rerootk t (fun a -> a)
 
 let length_int p =
-  Array.length (reroot p)
+  UArray.length (reroot p)
 
 let length p = Uint63.of_int @@ length_int p
 
 let get p n =
   let t = reroot p in
-  let l = Array.length t in
+  let l = UArray.length t in
   if Uint63.le Uint63.zero n && Uint63.lt n (Uint63.of_int l) then
-    Array.unsafe_get t (length_to_int n)
+    UArray.unsafe_get t (length_to_int n)
   else
     match !p with
     | Array (_, def) -> def
@@ -58,11 +118,11 @@ let get p n =
 
 let set p n e =
   let a = reroot p in
-  let l = Uint63.of_int (Array.length a) in
+  let l = Uint63.of_int (UArray.length a) in
   if Uint63.le Uint63.zero n && Uint63.lt n l then
     let i = length_to_int n in
-    let v' = Array.unsafe_get a i in
-    Array.unsafe_set a i e;
+    let v' = UArray.unsafe_get a i in
+    UArray.unsafe_set a i e;
     let t = ref !p in (* i.e., Array (a, def) *)
     p := Updated (i, v', t);
     t
@@ -75,22 +135,34 @@ let default p =
   | Updated _ -> assert false
 
 let make n def =
-  ref (Array (Array.make (trunc_size n) def, def))
+  ref (Array (UArray.make (trunc_size n) def, def))
+
+let uinit n f =
+  if Int.equal n 0 then UArray.empty
+  else begin
+    let t = UArray.make n (f 0) in
+    for i = 1 to n - 1 do
+      UArray.unsafe_set t i (f i)
+    done;
+    t
+  end
 
 let init n f def =
   let n = trunc_size n in
-  let t = Array.init n f in
+  let t = uinit n f in
   ref (Array (t, def))
 
 let to_array p =
   let _ = reroot p in
   match !p with
-  | Array (t,def) -> Array.copy t, def
+  | Array (t,def) -> UArray.to_array t, def
   | Updated _ -> assert false
 
 let copy p =
-  let (t,def) = to_array p in
-  ref (Array (t,def))
+  let _ = reroot p in
+  match !p with
+  | Array (t, def) -> ref (Array (UArray.copy t, def))
+  | Updated _ -> assert false
 
 let reroot t =
   let _ = reroot t in
@@ -99,13 +171,20 @@ let reroot t =
 let map f p =
   let p = reroot p in
   match !p with
-  | Array (t,def) -> ref (Array (Array.map f t, f def))
+  | Array (t,def) ->
+    let t = uinit (UArray.length t) (fun i -> f (UArray.unsafe_get t i)) in
+    ref (Array (t, f def))
   | Updated _ -> assert false
 
 let fold_left f x p =
   let p = reroot p in
   match !p with
-  | Array (t,def) -> f (Array.fold_left f x t) def
+  | Array (t,def) ->
+    let r = ref x in
+    for i = 0 to UArray.length t - 1 do
+      r := f !r (UArray.unsafe_get t i)
+    done;
+    f !r def
   | Updated _ -> assert false
 
 let fold_left2 f a p1 p2 =
@@ -113,5 +192,10 @@ let fold_left2 f a p1 p2 =
   let p2 = reroot p2 in
   match !p1, !p2 with
   | Array (t1, def1), Array (t2, def2) ->
-    f (CArray.fold_left2 f a t1 t2) def1 def2
+    if UArray.length t1 <> UArray.length t2 then invalid_arg "Array.fold_left2";
+    let r = ref a in
+    for i = 0 to UArray.length t1 - 1 do
+      r := f !r (UArray.unsafe_get t1 i) (UArray.unsafe_get t2 i)
+    done;
+    f !r def1 def2
   | _ -> assert false

--- a/kernel/parray.ml
+++ b/kernel/parray.ml
@@ -22,7 +22,7 @@ sig
   val of_array : 'a array -> 'a t
   val to_array : 'a t -> 'a array
   (* 'a should not be float (no Obj.double_tag) *)
-  val unsafe_of_array : 'a array -> 'a t
+  val unsafe_of_obj : Obj.t -> 'a t
 end =
 struct
   type 'a t = Obj.t array
@@ -51,9 +51,9 @@ struct
     let () = assert (not (Array.exists obj_is_float v)) in
     Obj.magic (Array.copy v)
 
-  let unsafe_of_array (type a) (v : a array) =
-    let () = assert (Obj.tag (Obj.repr v) != Obj.double_array_tag) in
-    (Obj.magic v : a t)
+  let unsafe_of_obj (type a) (v : Obj.t) =
+    let () = assert (Obj.tag v == 0) in
+    (Obj.obj v : a t)
 
   let unsafe_get = Obj.magic Array.unsafe_get
   let unsafe_set = Obj.magic Array.unsafe_set
@@ -84,7 +84,7 @@ and 'a kind =
   | Array of 'a UArray.t * 'a
   | Updated of int * 'a * 'a t
 
-let unsafe_of_array t def = ref (Array (UArray.unsafe_of_array t, def))
+let unsafe_of_obj t def = ref (Array (UArray.unsafe_of_obj t, def))
 let of_array t def = ref (Array (UArray.of_array t, def))
 
 let rec rerootk t k =

--- a/kernel/parray.mli
+++ b/kernel/parray.mli
@@ -23,6 +23,7 @@ val copy    : 'a t -> 'a t
 val map : ('a -> 'b) -> 'a t -> 'b t
 
 val to_array : 'a t -> 'a array * 'a (* default *)
+(* 'a should not be float (no Obj.double_tag) *)
 
 val of_array : 'a array -> 'a (* default *) -> 'a t
 

--- a/kernel/parray.mli
+++ b/kernel/parray.mli
@@ -27,10 +27,10 @@ val to_array : 'a t -> 'a array * 'a (* default *)
 
 val of_array : 'a array -> 'a (* default *) -> 'a t
 
-val unsafe_of_array : 'a array -> 'a -> 'a t
-(* [unsafe_of_array] injects a mutable array into a persistent one, but does
-   not perform a copy. This means that if the persistent array is mutated, the
-   original one will be too. *)
+val unsafe_of_obj : Obj.t -> 'a -> 'a t
+(* [unsafe_of_obj] injects an untyped mutable array into a persistent one, but
+   does not perform a copy. This means that if the persistent array is mutated,
+   the original one will be too. The array must be a non-flat array. *)
 
 val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b t -> 'a
 val fold_left2 : ('a -> 'b -> 'c -> 'a) -> 'a -> 'b t -> 'c t -> 'a

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -446,8 +446,10 @@ and nf_evar env sigma evk args =
 and nf_array env sigma t typ =
   let ty, allargs = app_type env sigma (EConstr.of_constr typ) in
   let typ_elem = allargs.(0) in
-  let t, vdef = Parray.to_array t in
-  let t = Array.map (fun v -> nf_val env sigma v typ_elem) t in
+  let vdef = Parray.default t in
+  (* Do not cast into an array out of fear that floats may sneak in *)
+  let init i = nf_val env sigma (Parray.get t (Uint63.of_int i)) typ_elem in
+  let t = Array.init (Parray.length_int t) init in
   let u = snd (destConst ty) in
   mkArray(u, t, nf_val env sigma vdef typ_elem, typ_elem)
 

--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -408,8 +408,10 @@ and nf_cofix env sigma cf =
 and nf_array env sigma t typ =
   let ty, allargs = app_type env sigma (EConstr.of_constr typ) in
   let typ_elem = allargs.(0) in
-  let t, vdef = Parray.to_array t in
-  let t = Array.map (fun v -> nf_val env sigma v typ_elem) t in
+  let vdef = Parray.default t in
+  (* Do not cast into an array out of fear that floats may sneak in *)
+  let init i = nf_val env sigma (Parray.get t (Uint63.of_int i)) typ_elem in
+  let t = Array.init (Parray.length_int t) init in
   let u = snd (destConst ty) in
   mkArray(u, t, nf_val env sigma vdef typ_elem, typ_elem)
 

--- a/test-suite/bugs/closed/bug_15070.v
+++ b/test-suite/bugs/closed/bug_15070.v
@@ -1,0 +1,22 @@
+Require Import PArray PrimFloat Int63.
+
+Goal False.
+Proof.
+set (f := fun x => get (set (make 2 one) 1 x) 1).
+generalize (eq_refl (f zero)).
+change (f zero = zero -> False).
+intros H0.
+generalize (eq_refl f) (eq_refl f).
+generalize f at 1 3.
+intros g H1.
+vm_compute.
+rewrite H1.
+intros H2.
+revert H0.
+rewrite H2.
+intros H3.
+apply (f_equal classify) in H3.
+revert H3.
+vm_compute.
+Fail discriminate.
+Abort.


### PR DESCRIPTION
We provide a low-level API that statically ensures that the arrays we manipulate never use the flat-float representation, regardless of the OCaml compiler flags. Hopefully this is designed carefully enough that this invariant is really respected so that the VM and native do not break the OCaml runtime semantics.

See also #15079. It's a strongest form of it, since we have a safe abstraction barrier between OCaml arrays (which may be flat) and our own implementation (which rules this out).

Fixes #15070: Memory corruption when mixing primitive floats and arrays.

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.