### PR TITLE
[primitive floats] Deprecate frexp and ldexp

### DIFF
--- a/doc/changelog/10-standard-library/15085-deprecate-frexp.rst
+++ b/doc/changelog/10-standard-library/15085-deprecate-frexp.rst
@@ -1,0 +1,4 @@
+- **Deprecated:**
+  ``frexp`` and ``ldexp`` in `FloatOps.v`, renamed ``Z.frexp`` and ``Z.ldexp``
+  (`#15085 <https://github.com/coq/coq/pull/15085>`_,
+  by Pierre Roux).

--- a/test-suite/primitive/float/add.v
+++ b/test-suite/primitive/float/add.v
@@ -12,8 +12,8 @@ Check (eq_refl five <<: two + three = five).
 Definition compute1 := Eval compute in two + three.
 Check (eq_refl compute1 : five = five).
 
-Definition huge := Eval compute in ldexp one 1023%Z.
-Definition tiny := Eval compute in ldexp one (-1023)%Z.
+Definition huge := Eval compute in Z.ldexp one 1023%Z.
+Definition tiny := Eval compute in Z.ldexp one (-1023)%Z.
 
 Check (eq_refl : huge + tiny = huge).
 Check (eq_refl huge <: huge + tiny = huge).

--- a/test-suite/primitive/float/classify.v
+++ b/test-suite/primitive/float/classify.v
@@ -1,6 +1,6 @@
 Require Import ZArith Floats.
 
-Definition epsilon := Eval compute in ldexp one (-1024)%Z.
+Definition epsilon := Eval compute in Z.ldexp one (-1024)%Z.
 
 Check (eq_refl : classify one = PNormal).
 Check (eq_refl : classify (- one)%float = NNormal).

--- a/test-suite/primitive/float/compare.v
+++ b/test-suite/primitive/float/compare.v
@@ -2,9 +2,9 @@
 Require Import ZArith Floats.
 Local Open Scope float_scope.
 
-Definition min_denorm := Eval compute in ldexp one (-1074)%Z.
+Definition min_denorm := Eval compute in Z.ldexp one (-1074)%Z.
 
-Definition min_norm := Eval compute in ldexp one (-1024)%Z.
+Definition min_norm := Eval compute in Z.ldexp one (-1024)%Z.
 
 Check (eq_refl false : nan =? nan = false).
 Check (eq_refl false : nan =? nan = false).

--- a/test-suite/primitive/float/div.v
+++ b/test-suite/primitive/float/div.v
@@ -12,8 +12,8 @@ Check (eq_refl two <<: six / three = two).
 Definition compute1 := Eval compute in six / three.
 Check (eq_refl compute1 : two = two).
 
-Definition huge := Eval compute in ldexp one 1023%Z.
-Definition tiny := Eval compute in ldexp one (-1023)%Z.
+Definition huge := Eval compute in Z.ldexp one 1023%Z.
+Definition tiny := Eval compute in Z.ldexp one (-1023)%Z.
 
 Check (eq_refl : huge / tiny = infinity).
 Check (eq_refl infinity <: huge / tiny = infinity).

--- a/test-suite/primitive/float/double_rounding.v
+++ b/test-suite/primitive/float/double_rounding.v
@@ -2,8 +2,8 @@ Require Import Floats ZArith.
 
 (* This test check that there is no double rounding with 80 bits registers inside float computations *)
 
-Definition big_cbn := Eval cbn in ldexp one (53)%Z.
-Definition small_cbn := Eval cbn in (one + ldexp one (-52)%Z)%float.
+Definition big_cbn := Eval cbn in Z.ldexp one (53)%Z.
+Definition small_cbn := Eval cbn in (one + Z.ldexp one (-52)%Z)%float.
 Definition result_cbn := Eval cbn in (big_cbn + small_cbn)%float.
 Definition check_cbn := Eval cbn in (big_cbn + one)%float.
 
@@ -11,8 +11,8 @@ Check (eq_refl : (result_cbn ?= big_cbn)%float = FGt).
 Check (eq_refl : (check_cbn ?= big_cbn)%float = FEq).
 
 
-Definition big_cbv := Eval cbv in ldexp one (53)%Z.
-Definition small_cbv := Eval cbv in (one + ldexp one (-52)%Z)%float.
+Definition big_cbv := Eval cbv in Z.ldexp one (53)%Z.
+Definition small_cbv := Eval cbv in (one + Z.ldexp one (-52)%Z)%float.
 Definition result_cbv := Eval cbv in (big_cbv + small_cbv)%float.
 Definition check_cbv := Eval cbv in (big_cbv + one)%float.
 
@@ -20,8 +20,8 @@ Check (eq_refl : (result_cbv ?= big_cbv)%float = FGt).
 Check (eq_refl : (check_cbv ?= big_cbv)%float = FEq).
 
 
-Definition big_vm := Eval vm_compute in ldexp one (53)%Z.
-Definition small_vm := Eval vm_compute in (one + ldexp one (-52)%Z)%float.
+Definition big_vm := Eval vm_compute in Z.ldexp one (53)%Z.
+Definition small_vm := Eval vm_compute in (one + Z.ldexp one (-52)%Z)%float.
 Definition result_vm := Eval vm_compute in (big_vm + small_vm)%float.
 Definition check_vm := Eval vm_compute in (big_vm + one)%float.
 
@@ -29,8 +29,8 @@ Check (eq_refl : (result_vm ?= big_vm)%float = FGt).
 Check (eq_refl : (check_vm ?= big_vm)%float = FEq).
 
 
-Definition big_native := Eval native_compute in ldexp one (53)%Z.
-Definition small_native := Eval native_compute in (one + ldexp one (-52)%Z)%float.
+Definition big_native := Eval native_compute in Z.ldexp one (53)%Z.
+Definition small_native := Eval native_compute in (one + Z.ldexp one (-52)%Z)%float.
 Definition result_native := Eval native_compute in (big_native + small_native)%float.
 Definition check_native := Eval native_compute in (big_native + one)%float.
 

--- a/test-suite/primitive/float/frexp.v
+++ b/test-suite/primitive/float/frexp.v
@@ -1,28 +1,28 @@
 Require Import ZArith Floats.
 
-Definition denorm := Eval compute in ldexp one (-1074)%Z.
+Definition denorm := Eval compute in Z.ldexp one (-1074)%Z.
 Definition neg_one := Eval compute in (-one)%float.
 
-Check (eq_refl : let (m,e) := frexp infinity in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF infinity)).
-Check (eq_refl (SFfrexp prec emax (Prim2SF infinity)) <: let (m,e) := frexp infinity in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF infinity)).
-Check (eq_refl (SFfrexp prec emax (Prim2SF infinity)) <<: let (m,e) := frexp infinity in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF infinity)).
+Check (eq_refl : let (m,e) := Z.frexp infinity in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF infinity)).
+Check (eq_refl (SFfrexp prec emax (Prim2SF infinity)) <: let (m,e) := Z.frexp infinity in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF infinity)).
+Check (eq_refl (SFfrexp prec emax (Prim2SF infinity)) <<: let (m,e) := Z.frexp infinity in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF infinity)).
 
-Check (eq_refl : let (m,e) := frexp nan in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF nan)).
-Check (eq_refl (SFfrexp prec emax (Prim2SF nan)) <: let (m,e) := frexp nan in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF nan)).
-Check (eq_refl (SFfrexp prec emax (Prim2SF nan)) <<: let (m,e) := frexp nan in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF nan)).
+Check (eq_refl : let (m,e) := Z.frexp nan in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF nan)).
+Check (eq_refl (SFfrexp prec emax (Prim2SF nan)) <: let (m,e) := Z.frexp nan in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF nan)).
+Check (eq_refl (SFfrexp prec emax (Prim2SF nan)) <<: let (m,e) := Z.frexp nan in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF nan)).
 
-Check (eq_refl : let (m,e) := frexp zero in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF zero)).
-Check (eq_refl (SFfrexp prec emax (Prim2SF zero)) <: let (m,e) := frexp zero in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF zero)).
-Check (eq_refl (SFfrexp prec emax (Prim2SF zero)) <<: let (m,e) := frexp zero in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF zero)).
+Check (eq_refl : let (m,e) := Z.frexp zero in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF zero)).
+Check (eq_refl (SFfrexp prec emax (Prim2SF zero)) <: let (m,e) := Z.frexp zero in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF zero)).
+Check (eq_refl (SFfrexp prec emax (Prim2SF zero)) <<: let (m,e) := Z.frexp zero in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF zero)).
 
-Check (eq_refl : let (m,e) := frexp one in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF one)).
-Check (eq_refl (SFfrexp prec emax (Prim2SF one)) <: let (m,e) := frexp one in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF one)).
-Check (eq_refl (SFfrexp prec emax (Prim2SF one)) <<: let (m,e) := frexp one in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF one)).
+Check (eq_refl : let (m,e) := Z.frexp one in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF one)).
+Check (eq_refl (SFfrexp prec emax (Prim2SF one)) <: let (m,e) := Z.frexp one in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF one)).
+Check (eq_refl (SFfrexp prec emax (Prim2SF one)) <<: let (m,e) := Z.frexp one in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF one)).
 
-Check (eq_refl : let (m,e) := frexp neg_one in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF neg_one)).
-Check (eq_refl (SFfrexp prec emax (Prim2SF neg_one)) <: let (m,e) := frexp neg_one in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF neg_one)).
-Check (eq_refl (SFfrexp prec emax (Prim2SF neg_one)) <<: let (m,e) := frexp neg_one in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF neg_one)).
+Check (eq_refl : let (m,e) := Z.frexp neg_one in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF neg_one)).
+Check (eq_refl (SFfrexp prec emax (Prim2SF neg_one)) <: let (m,e) := Z.frexp neg_one in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF neg_one)).
+Check (eq_refl (SFfrexp prec emax (Prim2SF neg_one)) <<: let (m,e) := Z.frexp neg_one in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF neg_one)).
 
-Check (eq_refl : let (m,e) := frexp denorm in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF denorm)).
-Check (eq_refl (SFfrexp prec emax (Prim2SF denorm)) <: let (m,e) := frexp denorm in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF denorm)).
-Check (eq_refl (SFfrexp prec emax (Prim2SF denorm)) <<: let (m,e) := frexp denorm in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF denorm)).
+Check (eq_refl : let (m,e) := Z.frexp denorm in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF denorm)).
+Check (eq_refl (SFfrexp prec emax (Prim2SF denorm)) <: let (m,e) := Z.frexp denorm in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF denorm)).
+Check (eq_refl (SFfrexp prec emax (Prim2SF denorm)) <<: let (m,e) := Z.frexp denorm in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF denorm)).

--- a/test-suite/primitive/float/gen_compare.sh
+++ b/test-suite/primitive/float/gen_compare.sh
@@ -9,9 +9,9 @@ cat <<EOF
 Require Import ZArith Floats.
 Local Open Scope float_scope.
 
-Definition min_denorm := Eval compute in ldexp one (-1074)%Z.
+Definition min_denorm := Eval compute in Z.ldexp one (-1074)%Z.
 
-Definition min_norm := Eval compute in ldexp one (-1024)%Z.
+Definition min_norm := Eval compute in Z.ldexp one (-1024)%Z.
 
 EOF
 

--- a/test-suite/primitive/float/ldexp.v
+++ b/test-suite/primitive/float/ldexp.v
@@ -1,21 +1,21 @@
 Require Import ZArith Uint63 Floats.
 
-Check (eq_refl : ldexp one 9223372036854773807%Z = infinity).
-Check (eq_refl infinity <: ldexp one 9223372036854773807%Z = infinity).
-Check (eq_refl infinity <<: ldexp one 9223372036854773807%Z = infinity).
+Check (eq_refl : Z.ldexp one 9223372036854773807%Z = infinity).
+Check (eq_refl infinity <: Z.ldexp one 9223372036854773807%Z = infinity).
+Check (eq_refl infinity <<: Z.ldexp one 9223372036854773807%Z = infinity).
 
 Check (eq_refl : ldshiftexp one 9223372036854775807 = infinity).
 Check (eq_refl infinity <: ldshiftexp one 9223372036854775807 = infinity).
 Check (eq_refl infinity <<: ldshiftexp one 9223372036854775807 = infinity).
 
-Check (eq_refl : ldexp one (-2102) = 0%float).
-Check (eq_refl 0%float <: ldexp one (-2102) = 0%float).
-Check (eq_refl 0%float <<: ldexp one (-2102) = 0%float).
+Check (eq_refl : Z.ldexp one (-2102) = 0%float).
+Check (eq_refl 0%float <: Z.ldexp one (-2102) = 0%float).
+Check (eq_refl 0%float <<: Z.ldexp one (-2102) = 0%float).
 
-Check (eq_refl : ldexp one (-3) = 0.125%float).
-Check (eq_refl 0.125%float <: ldexp one (-3) = 0.125%float).
-Check (eq_refl 0.125%float <<: ldexp one (-3) = 0.125%float).
+Check (eq_refl : Z.ldexp one (-3) = 0.125%float).
+Check (eq_refl 0.125%float <: Z.ldexp one (-3) = 0.125%float).
+Check (eq_refl 0.125%float <<: Z.ldexp one (-3) = 0.125%float).
 
-Check (eq_refl : ldexp one 3 = 8%float).
-Check (eq_refl 8%float <: ldexp one 3 = 8%float).
-Check (eq_refl 8%float <<: ldexp one 3 = 8%float).
+Check (eq_refl : Z.ldexp one 3 = 8%float).
+Check (eq_refl 8%float <: Z.ldexp one 3 = 8%float).
+Check (eq_refl 8%float <<: Z.ldexp one 3 = 8%float).

--- a/test-suite/primitive/float/mul.v
+++ b/test-suite/primitive/float/mul.v
@@ -12,8 +12,8 @@ Check (eq_refl six <<: three * two = six).
 Definition compute1 := Eval compute in three * two.
 Check (eq_refl compute1 : six = six).
 
-Definition huge := Eval compute in ldexp one 1023%Z.
-Definition tiny := Eval compute in ldexp one (-1023)%Z.
+Definition huge := Eval compute in Z.ldexp one 1023%Z.
+Definition tiny := Eval compute in Z.ldexp one (-1023)%Z.
 
 Check (eq_refl : huge * tiny = one).
 Check (eq_refl one <: huge * tiny = one).

--- a/test-suite/primitive/float/next_up_down.v
+++ b/test-suite/primitive/float/next_up_down.v
@@ -4,22 +4,22 @@ Open Scope float_scope.
 
 Definition f0 := zero.
 Definition f1 := neg_zero.
-Definition f2 := Eval compute in ldexp one 0.
+Definition f2 := Eval compute in Z.ldexp one 0.
 Definition f3 := Eval compute in -f1.
 (* smallest positive float *)
-Definition f4 := Eval compute in ldexp one (-1074).
+Definition f4 := Eval compute in Z.ldexp one (-1074).
 Definition f5 := Eval compute in -f3.
 Definition f6 := infinity.
 Definition f7 := neg_infinity.
-Definition f8 := Eval compute in ldexp one (-1).
+Definition f8 := Eval compute in Z.ldexp one (-1).
 Definition f9 := Eval compute in -f8.
 Definition f10 := Eval compute in of_int63 42.
 Definition f11 := Eval compute in -f10.
 (* max float *)
-Definition f12 := Eval compute in ldexp (of_int63 9007199254740991) 1024.
+Definition f12 := Eval compute in Z.ldexp (of_int63 9007199254740991) 1024.
 Definition f13 := Eval compute in -f12.
 (* smallest positive normalized float *)
-Definition f14 := Eval compute in ldexp one (-1022).
+Definition f14 := Eval compute in Z.ldexp one (-1022).
 Definition f15 := Eval compute in -f14.
 
 Check (eq_refl : Prim2SF (next_up f0) = SF64succ (Prim2SF f0)).

--- a/test-suite/primitive/float/normfr_mantissa.v
+++ b/test-suite/primitive/float/normfr_mantissa.v
@@ -1,7 +1,7 @@
 Require Import Uint63 ZArith Floats.
 
-Definition half := ldexp one (-1)%Z.
-Definition three_quarters := (half + (ldexp one (-2)%Z))%float.
+Definition half := Z.ldexp one (-1)%Z.
+Definition three_quarters := (half + (Z.ldexp one (-2)%Z))%float.
 
 Check (eq_refl : normfr_mantissa one = 0%uint63).
 Check (eq_refl : normfr_mantissa half = (1 << 52)%uint63).

--- a/test-suite/primitive/float/spec_conv.v
+++ b/test-suite/primitive/float/spec_conv.v
@@ -2,9 +2,9 @@ Require Import ZArith Floats.
 
 Definition two := Eval compute in (one + one)%float.
 Definition half := Eval compute in (one / two)%float.
-Definition huge := Eval compute in ldexp one (1023)%Z.
-Definition tiny := Eval compute in ldexp one (-1023)%Z.
-Definition denorm := Eval compute in ldexp one (-1074)%Z.
+Definition huge := Eval compute in Z.ldexp one (1023)%Z.
+Definition tiny := Eval compute in Z.ldexp one (-1023)%Z.
+Definition denorm := Eval compute in Z.ldexp one (-1074)%Z.
 
 Check (eq_refl : SF2Prim (Prim2SF zero) = zero).
 Check (eq_refl : SF2Prim (Prim2SF neg_zero) = neg_zero).

--- a/test-suite/primitive/float/sqrt.v
+++ b/test-suite/primitive/float/sqrt.v
@@ -10,9 +10,9 @@ Check (eq_refl three <: sqrt nine = three).
 Definition compute1 := Eval compute in sqrt nine.
 Check (eq_refl : three = three).
 
-Definition huge := Eval compute in ldexp one (1023)%Z.
-Definition tiny := Eval compute in ldexp one (-1023)%Z.
-Definition denorm := Eval compute in ldexp one (-1074)%Z.
+Definition huge := Eval compute in Z.ldexp one (1023)%Z.
+Definition tiny := Eval compute in Z.ldexp one (-1023)%Z.
+Definition denorm := Eval compute in Z.ldexp one (-1074)%Z.
 
 Goal (Prim2SF (sqrt huge) = SF64sqrt (Prim2SF huge)).
   now compute. Undo. now vm_compute.

--- a/test-suite/primitive/float/sub.v
+++ b/test-suite/primitive/float/sub.v
@@ -11,8 +11,8 @@ Check (eq_refl one <<: three - two = one).
 Definition compute1 := Eval compute in three - two.
 Check (eq_refl compute1 : one = one).
 
-Definition huge := Eval compute in ldexp one 1023%Z.
-Definition tiny := Eval compute in ldexp one (-1023)%Z.
+Definition huge := Eval compute in Z.ldexp one 1023%Z.
+Definition tiny := Eval compute in Z.ldexp one (-1023)%Z.
 
 Check (eq_refl : huge - tiny = huge).
 Check (eq_refl huge <: huge - tiny = huge).

--- a/test-suite/primitive/float/valid_binary_conv.v
+++ b/test-suite/primitive/float/valid_binary_conv.v
@@ -2,9 +2,9 @@ Require Import ZArith Floats.
 
 Definition two := Eval compute in (one + one)%float.
 Definition half := Eval compute in (one / two)%float.
-Definition huge := Eval compute in ldexp one (1023)%Z.
-Definition tiny := Eval compute in ldexp one (-1022)%Z.
-Definition denorm := Eval compute in ldexp one (-1074)%Z.
+Definition huge := Eval compute in Z.ldexp one (1023)%Z.
+Definition tiny := Eval compute in Z.ldexp one (-1022)%Z.
+Definition denorm := Eval compute in Z.ldexp one (-1074)%Z.
 
 Check (eq_refl : valid_binary (Prim2SF zero) = true).
 Check (eq_refl : valid_binary (Prim2SF neg_zero) = true).

--- a/theories/Floats/FloatLemmas.v
+++ b/theories/Floats/FloatLemmas.v
@@ -17,18 +17,20 @@ Lemma shift_value : shift = (2*emax + prec)%Z.
   reflexivity.
 Qed.
 
-Theorem frexp_spec : forall f, let (m,e) := frexp f in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF f).
+Theorem Z_frexp_spec : forall f, let (m,e) := Z.frexp f in (Prim2SF m, e) = SFfrexp prec emax (Prim2SF f).
   intro.
-  unfold frexp.
+  unfold Z.frexp.
   case_eq (frshiftexp f).
   intros.
   assert (H' := frshiftexp_spec f).
   now rewrite H in H'.
 Qed.
+#[deprecated(since = "8.15.0", note = "Use Z_frexp_spec instead.")]
+Notation frexp_spec := Z_frexp_spec (only parsing).
 
-Theorem ldexp_spec : forall f e, Prim2SF (ldexp f e) = SFldexp prec emax (Prim2SF f) e.
+Theorem Z_ldexp_spec : forall f e, Prim2SF (Z.ldexp f e) = SFldexp prec emax (Prim2SF f) e.
   intros.
-  unfold ldexp.
+  unfold Z.ldexp.
   rewrite (ldshiftexp_spec f _).
   assert (Hv := Prim2SF_valid f).
   destruct (Prim2SF f); auto.
@@ -327,3 +329,5 @@ Theorem ldexp_spec : forall f e, Prim2SF (ldexp f e) = SFldexp prec emax (Prim2S
       reflexivity.
     + exfalso; lia.
 Qed.
+#[deprecated(since = "8.15.0", note = "Use Z_ldexp_spec instead.")]
+Notation ldexp_spec := Z_ldexp_spec (only parsing).

--- a/theories/Floats/Floats.v
+++ b/theories/Floats/Floats.v
@@ -14,7 +14,7 @@
 - SpecFloat: specify the floating-point operators with binary integers
 - FloatOps: define conversion functions between [spec_float] and [float]
 - FloatAxioms: state properties of the primitive operators w.r.t. [spec_float]
-- FloatLemmas: prove a few results involving frexp and ldexp
+- FloatLemmas: prove a few results involving Z.frexp and Z.ldexp
 
 For a brief overview of the Floats library,
 see {{https://coq.inria.fr/distrib/current/refman/language/coq-library.html#floats-library}} *)


### PR DESCRIPTION
Now that we have signed primitive integers, we would like to use them
in frexp and ldexp but the name was taken by functions with exponent
in Z. These functions are renamed Z.frexp and Z.ldexp so that frexp and
ldexp could later be added with signed primitive integer exponent.

- [x] Added **changelog**.
