### PR TITLE
Add missing zify class instances

### DIFF
--- a/dev/ci/user-overlays/15101-pi8027-zify-instances.sh
+++ b/dev/ci/user-overlays/15101-pi8027-zify-instances.sh
@@ -1,0 +1,1 @@
+overlay flocq https://github.com/pi8027/flocq coq-pr15101 15101

--- a/doc/changelog/04-tactics/10998-zify-instances.rst
+++ b/doc/changelog/04-tactics/10998-zify-instances.rst
@@ -1,0 +1,7 @@
+- **Added:**
+  The :tacn:`zify` tactic can now recognize `Pos.Nsucc_double`, `Pos.Ndouble`,
+  `N.succ_double`, `N.double`, `N.succ_pos`, `N.div2`, `N.pow`, `N.square`, and
+  `Z.to_pos`. Moreover, importing module `ZifyBool` lets it recognize `Pos.eqb`,
+  `Pos.leb`, `Pos.ltb`, `N.eqb`, `N.leb`, and `N.ltb`
+  (`#10998 <https://github.com/coq/coq/pull/10998>`_,
+  by Kazuhiko Sakaguchi).

--- a/test-suite/micromega/zify.v
+++ b/test-suite/micromega/zify.v
@@ -1,4 +1,4 @@
-Require Import BinNums BinInt ZifyInst Zify.
+Require Import BinNums BinInt BinNat ZifyInst Zify.
 
 Definition pos := positive.
 
@@ -89,6 +89,51 @@ Proof.
   reflexivity.
 Qed.
 
+Goal forall x, Z.of_N (Pos.Nsucc_double x) = (2 * Z.of_N x + 1)%Z.
+Proof.
+  intros; zify_op; reflexivity.
+Qed.
+
+Goal forall x, Z.of_N (Pos.Ndouble x) = (2 * Z.of_N x)%Z.
+Proof.
+  intros; zify_op; reflexivity.
+Qed.
+
+Goal forall x, Z.of_N (N.succ_double x) = (2 * Z.of_N x + 1)%Z.
+Proof.
+  intros; zify_op; reflexivity.
+Qed.
+
+Goal forall x, Z.of_N (N.double x) = (2 * Z.of_N x)%Z.
+Proof.
+  intros; zify_op; reflexivity.
+Qed.
+
+Goal forall x, Z.pos (N.succ_pos x) = (Z.of_N x + 1)%Z.
+Proof.
+  intros; zify_op; reflexivity.
+Qed.
+
+Goal forall x, Z.of_N (N.div2 x) = (Z.of_N x / 2)%Z.
+Proof.
+  intros; zify_op; reflexivity.
+Qed.
+
+Goal forall x y, Z.of_N (N.pow x y) = (Z.pow (Z.of_N x) (Z.of_N y))%Z.
+Proof.
+  intros; zify_op; reflexivity.
+Qed.
+
+Goal forall x, Z.of_N (N.square x) = (Z.of_N x * Z.of_N x)%Z.
+Proof.
+  intros; zify_op; reflexivity.
+Qed.
+
+Goal forall x, Z.pos (Z.to_pos x) = Z.max 1 x.
+Proof.
+  intros; zify_op; reflexivity.
+Qed.
+
 Require Import Lia.
 
 Goal forall n n3,
@@ -167,12 +212,6 @@ Goal  @zero znat = 0%nat.
   reflexivity.
 Qed.
 
-Require Import ZifyBool.
-Instance Op_bool_inj : UnOp (inj : bool -> bool) :=
-  { TUOp := id; TUOpInj := fun _ => eq_refl }.
-Add Zify UnOp Op_bool_inj.
-
-
 Goal forall (x y : positive) (F : forall (P: Pos.le x y) , positive) (P : Pos.le x y),
     (F P + 1 = 1 + F P)%positive.
 Proof.
@@ -221,6 +260,10 @@ Qed.
 
 Require Import ZifyBool.
 
+Instance Op_bool_inj : UnOp (inj : bool -> bool) :=
+  { TUOp := id; TUOpInj := fun _ => eq_refl }.
+Add Zify UnOp Op_bool_inj.
+
 Goal forall x y : nat, Nat.eqb x 1 = true ->
                        Nat.eqb y 0 = true ->
                        Nat.eqb (x + y) 1 = true.
@@ -242,4 +285,34 @@ Goal forall x y : nat, is_true (Nat.eqb x 1) ->
                        is_true (Nat.eqb (x + y) 1).
 Proof.
 lia.
+Qed.
+
+Goal forall x y, Pos.eqb x y = Z.eqb (Z.pos x) (Z.pos y).
+Proof.
+  intros; zify_op; reflexivity.
+Qed.
+
+Goal forall x y, Pos.leb x y = Z.leb (Z.pos x) (Z.pos y).
+Proof.
+  intros; zify_op; reflexivity.
+Qed.
+
+Goal forall x y, Pos.ltb x y = Z.ltb (Z.pos x) (Z.pos y).
+Proof.
+  intros; zify_op; reflexivity.
+Qed.
+
+Goal forall x y, N.eqb x y = Z.eqb (Z.of_N x) (Z.of_N y).
+Proof.
+  intros; zify_op; reflexivity.
+Qed.
+
+Goal forall x y, N.leb x y = Z.leb (Z.of_N x) (Z.of_N y).
+Proof.
+  intros; zify_op; reflexivity.
+Qed.
+
+Goal forall x y, N.ltb x y = Z.ltb (Z.of_N x) (Z.of_N y).
+Proof.
+  intros; zify_op; reflexivity.
 Qed.

--- a/theories/micromega/ZifyBool.v
+++ b/theories/micromega/ZifyBool.v
@@ -99,6 +99,40 @@ Instance Op_Zgtb : BinOp Z.gtb :=
   { TBOp := Z.gtb; TBOpInj := fun _ _  => eq_refl }.
 Add Zify BinOp Op_Zgtb.
 
+(** Comparison over N *)
+
+#[global]
+Instance Op_Neqb : BinOp N.eqb :=
+  { TBOp := Z.eqb; TBOpInj n m := ltac:(now destruct n, m) }.
+Add Zify BinOp Op_Neqb.
+
+#[global]
+Instance Op_Nleb : BinOp N.leb :=
+  { TBOp := Z.leb; TBOpInj n m := ltac:(now destruct n, m) }.
+Add Zify BinOp Op_Nleb.
+
+#[global]
+Instance Op_Nltb : BinOp N.ltb :=
+  { TBOp := Z.ltb; TBOpInj n m := ltac:(now destruct n, m) }.
+Add Zify BinOp Op_Nltb.
+
+(** Comparison over positive *)
+
+#[global]
+Instance Op_Pos_eqb : BinOp Pos.eqb :=
+  { TBOp := Z.eqb; TBOpInj _ _ := eq_refl }.
+Add Zify BinOp Op_Pos_eqb.
+
+#[global]
+Instance Op_Pos_leb : BinOp Pos.leb :=
+  { TBOp := Z.leb; TBOpInj _ _ := eq_refl }.
+Add Zify BinOp Op_Pos_leb.
+
+#[global]
+Instance Op_Pos_ltb : BinOp Pos.ltb :=
+  { TBOp := Z.ltb; TBOpInj _ _ := eq_refl }.
+Add Zify BinOp Op_Pos_ltb.
+
 (** Comparison over nat *)
 
 Lemma Z_of_nat_eqb_iff : forall n m,

--- a/theories/micromega/ZifyBool.v
+++ b/theories/micromega/ZifyBool.v
@@ -15,51 +15,50 @@ Local Open Scope Z_scope.
 
 #[global]
 Instance Inj_bool_bool : InjTyp bool bool :=
-  { inj := (fun x => x) ; pred := (fun b => b = true \/ b = false) ;
-    cstr := (ltac:(intro b; destruct b; tauto))}.
+  { inj b := b ; pred b := b = true \/ b = false ;
+    cstr b := ltac:(destruct b; tauto) }.
 Add Zify InjTyp Inj_bool_bool.
 
 (** Boolean operators *)
 
 #[global]
 Instance Op_andb : BinOp andb :=
-  { TBOp := andb ; TBOpInj := fun _ _  => eq_refl}.
+  { TBOp := andb ; TBOpInj _ _ := eq_refl}.
 Add Zify BinOp Op_andb.
 
 #[global]
 Instance Op_orb : BinOp orb :=
-  { TBOp := orb ; TBOpInj := fun _ _ => eq_refl}.
+  { TBOp := orb ; TBOpInj _ _ := eq_refl}.
 Add Zify BinOp Op_orb.
 
 #[global]
 Instance Op_implb : BinOp implb :=
-  { TBOp := implb; TBOpInj := fun _ _ => eq_refl }.
+  { TBOp := implb; TBOpInj _ _ := eq_refl }.
 Add Zify BinOp Op_implb.
 
-Definition xorb_eq : forall b1 b2,
-    xorb b1 b2 = andb (orb b1 b2) (negb (eqb b1 b2)).
+Definition xorb_eq b1 b2 : xorb b1 b2 = andb (orb b1 b2) (negb (eqb b1 b2)).
 Proof.
-  destruct b1,b2 ; reflexivity.
+  destruct b1, b2 ; reflexivity.
 Qed.
 
 #[global]
 Instance Op_xorb : BinOp xorb :=
-  { TBOp := fun x y => andb (orb x y) (negb (eqb x y)); TBOpInj := xorb_eq }.
+  { TBOp x y := andb (orb x y) (negb (eqb x y)); TBOpInj := xorb_eq }.
 Add Zify BinOp Op_xorb.
 
 #[global]
 Instance Op_eqb : BinOp eqb :=
-  { TBOp := eqb; TBOpInj := fun _ _ => eq_refl }.
+  { TBOp := eqb; TBOpInj _ _ := eq_refl }.
 Add Zify BinOp Op_eqb.
 
 #[global]
 Instance Op_negb : UnOp negb :=
-  { TUOp := negb ; TUOpInj := fun _ => eq_refl}.
+  { TUOp := negb ; TUOpInj _ := eq_refl}.
 Add Zify UnOp Op_negb.
 
 #[global]
 Instance Op_eq_bool : BinRel (@eq bool) :=
-  {TR := @eq bool ; TRInj := ltac:(reflexivity) }.
+  {TR := @eq bool ; TRInj b1 b2 := iff_refl (b1 = b2) }.
 Add Zify BinRel Op_eq_bool.
 
 #[global]
@@ -76,27 +75,27 @@ Add Zify CstOp Op_false.
 
 #[global]
 Instance Op_Zeqb : BinOp Z.eqb :=
-  { TBOp := Z.eqb ; TBOpInj := fun _ _ => eq_refl }.
+  { TBOp := Z.eqb ; TBOpInj _ _ := eq_refl }.
 Add Zify BinOp Op_Zeqb.
 
 #[global]
 Instance Op_Zleb : BinOp Z.leb :=
-  { TBOp := Z.leb; TBOpInj :=  fun _ _ => eq_refl }.
+  { TBOp := Z.leb; TBOpInj _ _ := eq_refl }.
 Add Zify BinOp Op_Zleb.
 
 #[global]
 Instance Op_Zgeb : BinOp Z.geb :=
-  { TBOp := Z.geb; TBOpInj := fun _ _ => eq_refl }.
+  { TBOp := Z.geb; TBOpInj _ _ := eq_refl }.
 Add Zify BinOp Op_Zgeb.
 
 #[global]
 Instance Op_Zltb : BinOp Z.ltb :=
-  { TBOp := Z.ltb ; TBOpInj := fun _ _ => eq_refl }.
+  { TBOp := Z.ltb ; TBOpInj _ _ := eq_refl }.
 Add Zify BinOp Op_Zltb.
 
 #[global]
 Instance Op_Zgtb : BinOp Z.gtb :=
-  { TBOp := Z.gtb; TBOpInj := fun _ _  => eq_refl }.
+  { TBOp := Z.gtb; TBOpInj _ _ := eq_refl }.
 Add Zify BinOp Op_Zgtb.
 
 (** Comparison over N *)
@@ -135,30 +134,24 @@ Add Zify BinOp Op_Pos_ltb.
 
 (** Comparison over nat *)
 
-Lemma Z_of_nat_eqb_iff : forall n m,
-    (n =? m)%nat = (Z.of_nat n =? Z.of_nat m).
+Lemma Z_of_nat_eqb_iff n m : (n =? m)%nat = (Z.of_nat n =? Z.of_nat m).
 Proof.
-  intros.
   rewrite Nat.eqb_compare.
   rewrite Z.eqb_compare.
   rewrite Nat2Z.inj_compare.
   reflexivity.
 Qed.
 
-Lemma Z_of_nat_leb_iff : forall n m,
-    (n <=? m)%nat = (Z.of_nat n <=? Z.of_nat m).
+Lemma Z_of_nat_leb_iff n m : (n <=? m)%nat = (Z.of_nat n <=? Z.of_nat m).
 Proof.
-  intros.
   rewrite Nat.leb_compare.
   rewrite Z.leb_compare.
   rewrite Nat2Z.inj_compare.
   reflexivity.
 Qed.
 
-Lemma Z_of_nat_ltb_iff : forall n m,
-    (n <? m)%nat = (Z.of_nat n <? Z.of_nat m).
+Lemma Z_of_nat_ltb_iff n m : (n <? m)%nat = (Z.of_nat n <? Z.of_nat m).
 Proof.
-  intros.
   rewrite Nat.ltb_compare.
   rewrite Z.ltb_compare.
   rewrite Nat2Z.inj_compare.
@@ -180,9 +173,9 @@ Instance Op_nat_ltb : BinOp Nat.ltb :=
   { TBOp := Z.ltb; TBOpInj := Z_of_nat_ltb_iff }.
 Add Zify BinOp Op_nat_ltb.
 
-Lemma b2n_b2z :  forall x,  Z.of_nat (Nat.b2n x) = Z.b2z x.
+Lemma b2n_b2z x : Z.of_nat (Nat.b2n x) = Z.b2z x.
 Proof.
-  intro. destruct x ; reflexivity.
+destruct x ; reflexivity.
 Qed.
 
 #[global]
@@ -192,19 +185,18 @@ Add Zify UnOp Op_b2n.
 
 #[global]
 Instance Op_b2z : UnOp Z.b2z :=
-  { TUOp := Z.b2z; TUOpInj := fun _ => eq_refl }.
+  { TUOp := Z.b2z; TUOpInj _ := eq_refl }.
 Add Zify UnOp Op_b2z.
 
-Lemma b2z_spec : forall b, (b = true /\ Z.b2z b = 1) \/ (b = false /\ Z.b2z b = 0).
+Lemma b2z_spec b : (b = true /\ Z.b2z b = 1) \/ (b = false /\ Z.b2z b = 0).
 Proof.
-  destruct b ; simpl; intuition congruence.
+  destruct b ; simpl; tauto.
 Qed.
 
 #[global]
 Instance b2zSpec : UnOpSpec Z.b2z :=
-  { UPred := fun b r => (b = true /\ r = 1) \/ (b = false /\ r = 0);
-    USpec := b2z_spec
-  }.
+  { UPred b r := (b = true /\ r = 1) \/ (b = false /\ r = 0);
+    USpec := b2z_spec }.
 Add Zify UnOpSpec b2zSpec.
 
 Ltac elim_bool_cstr :=

--- a/theories/micromega/ZifyInst.v
+++ b/theories/micromega/ZifyInst.v
@@ -38,12 +38,12 @@ Add Zify InjTyp Inj_nat_Z.
 (* zify_nat_rel *)
 #[global]
 Instance Op_ge : BinRel ge :=
-  {| TR := Z.ge; TRInj := Nat2Z.inj_ge |}.
+  { TR := Z.ge; TRInj := Nat2Z.inj_ge }.
 Add Zify BinRel Op_ge.
 
 #[global]
 Instance Op_lt : BinRel lt :=
-  {| TR := Z.lt; TRInj := Nat2Z.inj_lt |}.
+  { TR := Z.lt; TRInj := Nat2Z.inj_lt }.
 Add Zify BinRel Op_lt.
 
 #[global]
@@ -52,12 +52,12 @@ Add Zify BinRel Op_Nat_lt.
 
 #[global]
 Instance Op_gt : BinRel gt :=
-  {| TR := Z.gt; TRInj := Nat2Z.inj_gt |}.
+  { TR := Z.gt; TRInj := Nat2Z.inj_gt }.
 Add Zify BinRel Op_gt.
 
 #[global]
 Instance Op_le : BinRel le :=
-  {| TR := Z.le; TRInj := Nat2Z.inj_le |}.
+  { TR := Z.le; TRInj := Nat2Z.inj_le }.
 Add Zify BinRel Op_le.
 
 #[global]
@@ -66,7 +66,7 @@ Add Zify BinRel Op_Nat_le.
 
 #[global]
 Instance Op_eq_nat : BinRel (@eq nat) :=
-  {| TR := @eq Z ; TRInj := fun x y : nat => iff_sym (Nat2Z.inj_iff x y) |}.
+  { TR := @eq Z ; TRInj x y := iff_sym (Nat2Z.inj_iff x y) }.
 Add Zify BinRel Op_eq_nat.
 
 #[global]
@@ -76,42 +76,42 @@ Add Zify BinRel Op_Nat_eq.
 (* zify_nat_op *)
 #[global]
 Instance Op_plus : BinOp Nat.add :=
-  {| TBOp := Z.add; TBOpInj := Nat2Z.inj_add |}.
+  { TBOp := Z.add; TBOpInj := Nat2Z.inj_add }.
 Add Zify BinOp Op_plus.
 
 #[global]
 Instance Op_sub : BinOp Nat.sub :=
-  {| TBOp := fun n m => Z.max 0 (n - m) ; TBOpInj := Nat2Z.inj_sub_max |}.
+  { TBOp n m := Z.max 0 (n - m) ; TBOpInj := Nat2Z.inj_sub_max }.
 Add Zify BinOp Op_sub.
 
 #[global]
 Instance Op_mul : BinOp Nat.mul :=
-  {| TBOp := Z.mul ; TBOpInj := Nat2Z.inj_mul |}.
+  { TBOp := Z.mul ; TBOpInj := Nat2Z.inj_mul }.
 Add Zify BinOp Op_mul.
 
 #[global]
 Instance Op_min : BinOp Nat.min :=
-  {| TBOp := Z.min ; TBOpInj := Nat2Z.inj_min |}.
+  { TBOp := Z.min ; TBOpInj := Nat2Z.inj_min }.
 Add Zify BinOp Op_min.
 
 #[global]
 Instance Op_max : BinOp Nat.max :=
-  {| TBOp := Z.max ; TBOpInj := Nat2Z.inj_max |}.
+  { TBOp := Z.max ; TBOpInj := Nat2Z.inj_max }.
 Add Zify BinOp Op_max.
 
 #[global]
 Instance Op_pred : UnOp Nat.pred :=
-  {| TUOp := fun n => Z.max 0 (n - 1) ; TUOpInj := Nat2Z.inj_pred_max |}.
+  { TUOp n := Z.max 0 (n - 1) ; TUOpInj := Nat2Z.inj_pred_max }.
 Add Zify UnOp Op_pred.
 
 #[global]
 Instance Op_S : UnOp S :=
-  {| TUOp := fun x => Z.add x 1 ; TUOpInj := Nat2Z.inj_succ |}.
+  { TUOp x := Z.add x 1 ; TUOpInj := Nat2Z.inj_succ }.
 Add Zify UnOp Op_S.
 
 #[global]
 Instance Op_O : CstOp O :=
-  {| TCst := Z0 ; TCstInj := eq_refl (Z.of_nat 0) |}.
+  { TCst := Z0 ; TCstInj := eq_refl (Z.of_nat 0) }.
 Add Zify CstOp Op_O.
 
 #[global]
@@ -123,12 +123,12 @@ Add Zify UnOp Op_Z_abs_nat.
 
 #[global]
 Instance Inj_pos_Z : InjTyp positive Z :=
-  {| inj := Zpos ; pred := (fun x =>  0 < x ) ; cstr := Pos2Z.pos_is_pos |}.
+  { inj := Zpos ; pred x := 0 < x ; cstr := Pos2Z.pos_is_pos }.
 Add Zify InjTyp Inj_pos_Z.
 
 #[global]
 Instance Op_pos_to_nat : UnOp  Pos.to_nat :=
-  {TUOp := (fun x => x); TUOpInj := positive_nat_Z}.
+  {TUOp x := x ; TUOpInj := positive_nat_Z}.
 Add Zify UnOp Op_pos_to_nat.
 
 #[global]
@@ -139,34 +139,33 @@ Add Zify InjTyp Inj_N_Z.
 
 #[global]
 Instance Op_N_to_nat : UnOp  N.to_nat :=
-  { TUOp := fun x => x ; TUOpInj := N_nat_Z }.
+  { TUOp x := x ; TUOpInj := N_nat_Z }.
 Add Zify UnOp Op_N_to_nat.
 
 (* zify_positive_rel *)
 
 #[global]
 Instance Op_pos_ge : BinRel Pos.ge :=
-  {| TR := Z.ge; TRInj := fun x y => iff_refl (Z.pos x >= Z.pos y) |}.
+  { TR := Z.ge; TRInj x y := iff_refl (Z.pos x >= Z.pos y) }.
 Add Zify BinRel Op_pos_ge.
 
 #[global]
 Instance Op_pos_lt : BinRel Pos.lt :=
-  {| TR := Z.lt; TRInj := fun x y => iff_refl (Z.pos x < Z.pos y) |}.
+  { TR := Z.lt; TRInj x y := iff_refl (Z.pos x < Z.pos y) }.
 Add Zify BinRel Op_pos_lt.
 
 #[global]
 Instance Op_pos_gt : BinRel Pos.gt :=
-  {| TR := Z.gt; TRInj := fun x y => iff_refl (Z.pos x > Z.pos y)  |}.
+  { TR := Z.gt; TRInj x y := iff_refl (Z.pos x > Z.pos y) }.
 Add Zify BinRel Op_pos_gt.
 
 #[global]
 Instance Op_pos_le : BinRel Pos.le :=
-  {| TR := Z.le; TRInj := fun x y => iff_refl (Z.pos x <= Z.pos y) |}.
+  { TR := Z.le; TRInj x y := iff_refl (Z.pos x <= Z.pos y) }.
 Add Zify BinRel Op_pos_le.
 
-Lemma eq_pos_inj : forall (x y:positive), x = y <-> Z.pos x = Z.pos y.
+Lemma eq_pos_inj x y : x = y <-> Z.pos x = Z.pos y.
 Proof.
-  intros x y.
   apply (iff_sym (Pos2Z.inj_iff x y)).
 Qed.
 
@@ -179,80 +178,77 @@ Add Zify BinRel Op_eq_pos.
 
 #[global]
 Instance Op_Z_of_N : UnOp Z.of_N :=
-  { TUOp := (fun x => x) ; TUOpInj := fun x => eq_refl (Z.of_N x) }.
+  { TUOp x := x ; TUOpInj x := eq_refl (Z.of_N x) }.
 Add Zify UnOp Op_Z_of_N.
 
 #[global]
 Instance Op_Z_to_N : UnOp Z.to_N :=
-  { TUOp := fun x => Z.max 0 x ; TUOpInj := ltac:(now intro x; destruct x) }.
+  { TUOp x := Z.max 0 x ; TUOpInj x := ltac:(now destruct x) }.
 Add Zify UnOp Op_Z_to_N.
 
 #[global]
 Instance Op_Z_neg : UnOp Z.neg :=
-  { TUOp :=  Z.opp ; TUOpInj := (fun x => eq_refl (Zneg x))}.
+  { TUOp := Z.opp ; TUOpInj x := eq_refl (Zneg x) }.
 Add Zify UnOp Op_Z_neg.
 
 #[global]
 Instance Op_Z_pos : UnOp Z.pos :=
-  { TUOp := (fun x =>  x) ; TUOpInj := (fun x => eq_refl (Z.pos x))}.
+  { TUOp x := x ; TUOpInj x := eq_refl (Z.pos x) }.
 Add Zify UnOp Op_Z_pos.
 
 #[global]
 Instance Op_pos_succ : UnOp Pos.succ :=
-  { TUOp := fun x => x + 1; TUOpInj := Pos2Z.inj_succ  }.
+  { TUOp x := x + 1 ; TUOpInj := Pos2Z.inj_succ }.
 Add Zify UnOp Op_pos_succ.
 
 #[global]
 Instance Op_pos_pred_double : UnOp Pos.pred_double :=
-{ TUOp := fun x => 2 * x - 1; TUOpInj := ltac:(refl) }.
+{ TUOp x := 2 * x - 1 ; TUOpInj _ := eq_refl }.
 Add Zify UnOp Op_pos_pred_double.
 
 #[global]
 Instance Op_pos_pred : UnOp Pos.pred :=
-  { TUOp := fun x => Z.max 1 (x - 1) ;
-    TUOpInj := ltac :
-                 (intros;
-                    rewrite <- Pos.sub_1_r;
-                    apply Pos2Z.inj_sub_max) }.
+  { TUOp x := Z.max 1 (x - 1) ;
+    TUOpInj x := ltac:(rewrite <- Pos.sub_1_r; apply Pos2Z.inj_sub_max) }.
 Add Zify UnOp Op_pos_pred.
 
 #[global]
 Instance Op_pos_predN : UnOp Pos.pred_N :=
-  { TUOp := fun x => x - 1 ;
+  { TUOp x := x - 1 ;
     TUOpInj x := ltac: (now destruct x; rewrite N.pos_pred_spec) }.
 Add Zify UnOp Op_pos_predN.
 
 #[global]
 Instance Op_pos_of_succ_nat : UnOp Pos.of_succ_nat :=
-  { TUOp := fun x => x + 1 ; TUOpInj := Zpos_P_of_succ_nat }.
+  { TUOp x := x + 1 ; TUOpInj := Zpos_P_of_succ_nat }.
 Add Zify UnOp Op_pos_of_succ_nat.
 
 #[global]
 Instance Op_pos_of_nat : UnOp Pos.of_nat :=
-  { TUOp := fun x => Z.max 1 x ;
+  { TUOp x := Z.max 1 x ;
     TUOpInj x := ltac: (now destruct x;
                         [|rewrite <- Pos.of_nat_succ, <- (Nat2Z.inj_max 1)]) }.
 Add Zify UnOp Op_pos_of_nat.
 
 #[global]
 Instance Op_pos_add : BinOp Pos.add :=
-  { TBOp := Z.add ; TBOpInj := ltac: (refl) }.
+  { TBOp := Z.add ; TBOpInj _ _ := eq_refl }.
 Add Zify BinOp Op_pos_add.
 
 #[global]
 Instance Op_pos_add_carry : BinOp Pos.add_carry :=
-  { TBOp := fun x y => x + y + 1 ;
+  { TBOp x y := x + y + 1 ;
     TBOpInj := ltac:(now intros; rewrite Pos.add_carry_spec, Pos2Z.inj_succ) }.
 Add Zify BinOp Op_pos_add_carry.
 
 #[global]
 Instance Op_pos_sub : BinOp Pos.sub :=
-  { TBOp := fun n m => Z.max 1 (n - m) ;TBOpInj := Pos2Z.inj_sub_max }.
+  { TBOp n m := Z.max 1 (n - m) ; TBOpInj := Pos2Z.inj_sub_max }.
 Add Zify BinOp Op_pos_sub.
 
 #[global]
 Instance Op_pos_mul : BinOp Pos.mul :=
-  { TBOp :=  Z.mul ; TBOpInj := ltac: (refl) }.
+  { TBOp := Z.mul ; TBOpInj _ _ := eq_refl }.
 Add Zify BinOp Op_pos_mul.
 
 #[global]
@@ -287,48 +283,48 @@ Add Zify UnOp Op_Pos_Ndouble.
 
 #[global]
 Instance Op_xO : UnOp xO :=
-  { TUOp := fun x => 2 * x ; TUOpInj := ltac: (refl) }.
+  { TUOp x := 2 * x ; TUOpInj _ := eq_refl }.
 Add Zify UnOp Op_xO.
 
 #[global]
 Instance Op_xI : UnOp xI :=
-  { TUOp := fun x => 2 * x + 1 ; TUOpInj := ltac: (refl) }.
+  { TUOp x := 2 * x + 1 ; TUOpInj _ := eq_refl }.
 Add Zify UnOp Op_xI.
 
 #[global]
 Instance Op_xH : CstOp xH :=
-  { TCst := 1%Z ; TCstInj := ltac:(refl)}.
+  { TCst := 1%Z ; TCstInj := eq_refl }.
 Add Zify CstOp Op_xH.
 
 #[global]
 Instance Op_Z_of_nat : UnOp Z.of_nat:=
-  { TUOp := fun x => x ; TUOpInj := (fun x : nat => @eq_refl Z (Z.of_nat x)) }.
+  { TUOp x := x ; TUOpInj x := eq_refl (Z.of_nat x) }.
 Add Zify UnOp Op_Z_of_nat.
 
 (* zify_N_rel *)
 #[global]
 Instance Op_N_ge : BinRel N.ge :=
-  {| TR := Z.ge ; TRInj := N2Z.inj_ge |}.
+  { TR := Z.ge ; TRInj := N2Z.inj_ge }.
 Add Zify BinRel Op_N_ge.
 
 #[global]
 Instance Op_N_lt : BinRel N.lt :=
-  {| TR := Z.lt ; TRInj := N2Z.inj_lt |}.
+  { TR := Z.lt ; TRInj := N2Z.inj_lt }.
 Add Zify BinRel Op_N_lt.
 
 #[global]
 Instance Op_N_gt : BinRel N.gt :=
-  {| TR := Z.gt ; TRInj := N2Z.inj_gt |}.
+  { TR := Z.gt ; TRInj := N2Z.inj_gt }.
 Add Zify BinRel Op_N_gt.
 
 #[global]
 Instance Op_N_le : BinRel N.le :=
-  {| TR := Z.le ; TRInj := N2Z.inj_le |}.
+  { TR := Z.le ; TRInj := N2Z.inj_le }.
 Add Zify BinRel Op_N_le.
 
 #[global]
 Instance Op_eq_N : BinRel (@eq N) :=
-  {| TR := @eq Z ; TRInj := fun x y : N => iff_sym (N2Z.inj_iff x y) |}.
+  { TR := @eq Z ; TRInj x y := iff_sym (N2Z.inj_iff x y) }.
 Add Zify BinRel Op_eq_N.
 
 (* zify_N_op *)
@@ -339,12 +335,12 @@ Add Zify CstOp Op_N_N0.
 
 #[global]
 Instance Op_N_Npos : UnOp  Npos :=
-  { TUOp := (fun x => x) ; TUOpInj := ltac:(refl) }.
+  { TUOp x := x ; TUOpInj _ := eq_refl }.
 Add Zify UnOp Op_N_Npos.
 
 #[global]
 Instance Op_N_of_nat : UnOp  N.of_nat :=
-  { TUOp := fun x => x ; TUOpInj := nat_N_Z }.
+  { TUOp x := x ; TUOpInj := nat_N_Z }.
 Add Zify UnOp Op_N_of_nat.
 
 #[global]
@@ -354,54 +350,53 @@ Add Zify UnOp Op_Z_abs_N.
 
 #[global]
 Instance Op_N_pos : UnOp N.pos :=
-  { TUOp := fun x => x ; TUOpInj := ltac:(refl)}.
+  { TUOp x := x ; TUOpInj _ := eq_refl }.
 Add Zify UnOp Op_N_pos.
 
 #[global]
 Instance Op_N_add : BinOp N.add :=
-  {| TBOp := Z.add ; TBOpInj := N2Z.inj_add |}.
+  { TBOp := Z.add ; TBOpInj := N2Z.inj_add }.
 Add Zify BinOp Op_N_add.
 
 #[global]
 Instance Op_N_min : BinOp N.min :=
-  {| TBOp := Z.min ; TBOpInj := N2Z.inj_min |}.
+  { TBOp := Z.min ; TBOpInj := N2Z.inj_min }.
 Add Zify BinOp Op_N_min.
 
 #[global]
 Instance Op_N_max : BinOp N.max :=
-  {| TBOp := Z.max ; TBOpInj := N2Z.inj_max |}.
+  { TBOp := Z.max ; TBOpInj := N2Z.inj_max }.
 Add Zify BinOp Op_N_max.
 
 #[global]
 Instance Op_N_mul : BinOp N.mul :=
-  {| TBOp := Z.mul ; TBOpInj := N2Z.inj_mul |}.
+  { TBOp := Z.mul ; TBOpInj := N2Z.inj_mul }.
 Add Zify BinOp Op_N_mul.
 
 #[global]
 Instance Op_N_sub : BinOp N.sub :=
-  {| TBOp := fun x y => Z.max 0 (x - y) ; TBOpInj := N2Z.inj_sub_max |}.
+  { TBOp x y := Z.max 0 (x - y) ; TBOpInj := N2Z.inj_sub_max }.
 Add Zify BinOp Op_N_sub.
 
 #[global]
 Instance Op_N_div : BinOp N.div :=
-  {| TBOp := Z.div ; TBOpInj := N2Z.inj_div |}.
+  { TBOp := Z.div ; TBOpInj := N2Z.inj_div }.
 Add Zify BinOp Op_N_div.
 
 #[global]
 Instance Op_N_mod : BinOp N.modulo :=
-  {| TBOp := Z.rem ; TBOpInj := N2Z.inj_rem |}.
+  { TBOp := Z.rem ; TBOpInj := N2Z.inj_rem }.
 Add Zify BinOp Op_N_mod.
 
 #[global]
 Instance Op_N_pred : UnOp N.pred :=
-  { TUOp := fun x  => Z.max 0 (x - 1) ;
-    TUOpInj :=
-      ltac:(intros; rewrite N.pred_sub; apply N2Z.inj_sub_max) }.
+  { TUOp x := Z.max 0 (x - 1) ;
+    TUOpInj x := ltac:(rewrite N.pred_sub; apply N2Z.inj_sub_max) }.
 Add Zify UnOp Op_N_pred.
 
 #[global]
 Instance Op_N_succ : UnOp N.succ :=
-  {| TUOp := fun x => x + 1 ; TUOpInj := N2Z.inj_succ |}.
+  { TUOp x := x + 1 ; TUOpInj := N2Z.inj_succ }.
 Add Zify UnOp Op_N_succ.
 
 #[global]
@@ -442,27 +437,27 @@ Add Zify UnOp Op_N_square.
 (* zify_Z_rel *)
 #[global]
 Instance Op_Z_ge : BinRel Z.ge :=
-  {| TR := Z.ge ; TRInj := fun x y  => iff_refl (x>= y) |}.
+  { TR := Z.ge ; TRInj x y := iff_refl (x>= y) }.
 Add Zify BinRel Op_Z_ge.
 
 #[global]
 Instance Op_Z_lt : BinRel Z.lt :=
-  {| TR := Z.lt ;  TRInj := fun x y  => iff_refl (x < y) |}.
+  { TR := Z.lt ; TRInj x y := iff_refl (x < y) }.
 Add Zify BinRel Op_Z_lt.
 
 #[global]
 Instance Op_Z_gt : BinRel Z.gt :=
-  {| TR := Z.gt ;TRInj := fun x y  => iff_refl (x > y) |}.
+  { TR := Z.gt ;TRInj x y := iff_refl (x > y) }.
 Add Zify BinRel Op_Z_gt.
 
 #[global]
 Instance Op_Z_le : BinRel Z.le :=
-  {| TR := Z.le ;TRInj := fun x y  => iff_refl (x <= y) |}.
+  { TR := Z.le ;TRInj x y := iff_refl (x <= y) }.
 Add Zify BinRel Op_Z_le.
 
 #[global]
 Instance Op_eqZ : BinRel (@eq Z) :=
-  { TR := @eq Z ; TRInj := fun x y  => iff_refl (x = y) }.
+  { TR := @eq Z ; TRInj x y := iff_refl (x = y) }.
 Add Zify BinRel Op_eqZ.
 
 #[global]
@@ -472,82 +467,82 @@ Add Zify CstOp Op_Z_Z0.
 
 #[global]
 Instance Op_Z_add : BinOp Z.add :=
-  { TBOp := Z.add  ; TBOpInj := ltac:(refl) }.
+  { TBOp := Z.add  ; TBOpInj _ _ := eq_refl }.
 Add Zify BinOp Op_Z_add.
 
 #[global]
 Instance Op_Z_min : BinOp Z.min :=
-  { TBOp := Z.min ; TBOpInj := ltac:(refl) }.
+  { TBOp := Z.min ; TBOpInj _ _ := eq_refl }.
 Add Zify BinOp Op_Z_min.
 
 #[global]
 Instance Op_Z_max : BinOp Z.max :=
-  { TBOp := Z.max ; TBOpInj := ltac:(refl) }.
+  { TBOp := Z.max ; TBOpInj _ _ := eq_refl }.
 Add Zify BinOp Op_Z_max.
 
 #[global]
 Instance Op_Z_mul : BinOp Z.mul :=
-  { TBOp := Z.mul ; TBOpInj := ltac:(refl) }.
+  { TBOp := Z.mul ; TBOpInj _ _ := eq_refl }.
 Add Zify BinOp Op_Z_mul.
 
 #[global]
 Instance Op_Z_sub : BinOp Z.sub :=
-  { TBOp := Z.sub ; TBOpInj := ltac:(refl) }.
+  { TBOp := Z.sub ; TBOpInj _ _ := eq_refl }.
 Add Zify BinOp Op_Z_sub.
 
 #[global]
 Instance Op_Z_div : BinOp Z.div :=
-  { TBOp := Z.div ; TBOpInj := ltac:(refl) }.
+  { TBOp := Z.div ; TBOpInj _ _ := eq_refl }.
 Add Zify BinOp Op_Z_div.
 
 #[global]
 Instance Op_Z_mod : BinOp Z.modulo :=
-  { TBOp := Z.modulo ; TBOpInj := ltac:(refl) }.
+  { TBOp := Z.modulo ; TBOpInj _ _ := eq_refl }.
 Add Zify BinOp Op_Z_mod.
 
 #[global]
 Instance Op_Z_rem : BinOp Z.rem :=
-  { TBOp := Z.rem ; TBOpInj := ltac:(refl) }.
+  { TBOp := Z.rem ; TBOpInj _ _ := eq_refl }.
 Add Zify BinOp Op_Z_rem.
 
 #[global]
 Instance Op_Z_quot : BinOp Z.quot :=
-  { TBOp := Z.quot ; TBOpInj := ltac:(refl) }.
+  { TBOp := Z.quot ; TBOpInj _ _ := eq_refl }.
 Add Zify BinOp Op_Z_quot.
 
 #[global]
 Instance Op_Z_succ : UnOp Z.succ :=
-  { TUOp := fun x => x + 1 ; TUOpInj := ltac:(refl) }.
+  { TUOp x := x + 1 ; TUOpInj _ := eq_refl }.
 Add Zify UnOp Op_Z_succ.
 
 #[global]
 Instance Op_Z_pred : UnOp Z.pred :=
-  { TUOp := fun x => x - 1 ; TUOpInj := ltac:(refl) }.
+  { TUOp x := x - 1 ; TUOpInj _ := eq_refl }.
 Add Zify UnOp Op_Z_pred.
 
 #[global]
 Instance Op_Z_opp : UnOp Z.opp :=
-  { TUOp := Z.opp ; TUOpInj := ltac:(refl) }.
+  { TUOp := Z.opp ; TUOpInj _ := eq_refl }.
 Add Zify UnOp Op_Z_opp.
 
 #[global]
 Instance Op_Z_abs : UnOp Z.abs :=
-  { TUOp := Z.abs ; TUOpInj := ltac:(refl) }.
+  { TUOp := Z.abs ; TUOpInj _ := eq_refl }.
 Add Zify UnOp Op_Z_abs.
 
 #[global]
 Instance Op_Z_sgn : UnOp Z.sgn :=
-  { TUOp := Z.sgn ; TUOpInj := ltac:(refl) }.
+  { TUOp := Z.sgn ; TUOpInj _ := eq_refl }.
 Add Zify UnOp Op_Z_sgn.
 
 #[global]
 Instance Op_Z_pow : BinOp Z.pow :=
-  { TBOp := Z.pow ; TBOpInj := ltac:(refl) }.
+  { TBOp := Z.pow ; TBOpInj _ _ := eq_refl }.
 Add Zify BinOp Op_Z_pow.
 
 #[global]
 Instance Op_Z_pow_pos : BinOp Z.pow_pos :=
-  { TBOp := Z.pow ; TBOpInj := ltac:(refl) }.
+  { TBOp := Z.pow ; TBOpInj _ _ := eq_refl }.
 Add Zify BinOp Op_Z_pow_pos.
 
 #[global]
@@ -557,32 +552,32 @@ Add Zify UnOp Op_Z_double.
 
 #[global]
 Instance Op_Z_pred_double : UnOp Z.pred_double :=
-  { TUOp := fun x => 2 * x - 1 ; TUOpInj := Z.pred_double_spec }.
+  { TUOp x := 2 * x - 1 ; TUOpInj := Z.pred_double_spec }.
 Add Zify UnOp Op_Z_pred_double.
 
 #[global]
 Instance Op_Z_succ_double : UnOp Z.succ_double :=
-  { TUOp := fun x => 2 * x + 1 ; TUOpInj := Z.succ_double_spec }.
+  { TUOp x := 2 * x + 1 ; TUOpInj := Z.succ_double_spec }.
 Add Zify UnOp Op_Z_succ_double.
 
 #[global]
 Instance Op_Z_square : UnOp Z.square :=
-  { TUOp := fun x => x * x ; TUOpInj := Z.square_spec }.
+  { TUOp x := x * x ; TUOpInj := Z.square_spec }.
 Add Zify UnOp Op_Z_square.
 
 #[global]
 Instance Op_Z_div2 : UnOp Z.div2 :=
-  { TUOp := fun x => x / 2 ; TUOpInj := Z.div2_div }.
+  { TUOp x := x / 2 ; TUOpInj := Z.div2_div }.
 Add Zify UnOp Op_Z_div2.
 
 #[global]
 Instance Op_Z_quot2 : UnOp Z.quot2 :=
-  { TUOp := fun x => Z.quot x 2 ; TUOpInj := Zeven.Zquot2_quot }.
+  { TUOp x := Z.quot x 2 ; TUOpInj := Zeven.Zquot2_quot }.
 Add Zify UnOp Op_Z_quot2.
 
-Lemma of_nat_to_nat_eq : forall x,  Z.of_nat (Z.to_nat x) = Z.max 0 x.
+Lemma of_nat_to_nat_eq x : Z.of_nat (Z.to_nat x) = Z.max 0 x.
 Proof.
-  intros x; destruct x; simpl.
+  destruct x; simpl.
   - reflexivity.
   - now rewrite positive_nat_Z.
   - reflexivity.
@@ -590,7 +585,7 @@ Qed.
 
 #[global]
 Instance Op_Z_to_nat : UnOp Z.to_nat :=
-  { TUOp := fun x => Z.max 0 x ; TUOpInj := of_nat_to_nat_eq }.
+  { TUOp x := Z.max 0 x ; TUOpInj := of_nat_to_nat_eq }.
 Add Zify UnOp Op_Z_to_nat.
 
 #[global]
@@ -604,45 +599,39 @@ Add Zify UnOp Op_Z_to_pos.
 
 #[global]
 Instance ZmaxSpec : BinOpSpec Z.max :=
-  {| BPred := fun n m r => n < m /\ r = m \/ m <= n /\ r = n ; BSpec := Z.max_spec |}.
+  { BPred n m r := n < m /\ r = m \/ m <= n /\ r = n ; BSpec := Z.max_spec }.
 Add Zify BinOpSpec ZmaxSpec.
 
 #[global]
 Instance ZminSpec : BinOpSpec Z.min :=
-  {| BPred := fun n m r => n < m /\ r = n \/ m <= n /\ r = m ;
-     BSpec := Z.min_spec |}.
+  { BPred n m r := n < m /\ r = n \/ m <= n /\ r = m ; BSpec := Z.min_spec }.
 Add Zify BinOpSpec ZminSpec.
 
 #[global]
 Instance ZsgnSpec : UnOpSpec Z.sgn :=
-  {| UPred := fun n r : Z => 0 < n /\ r = 1 \/ 0 = n /\ r = 0 \/ n < 0 /\ r = - (1) ;
-     USpec := Z.sgn_spec |}.
+  { UPred n r := 0 < n /\ r = 1 \/ 0 = n /\ r = 0 \/ n < 0 /\ r = - 1 ;
+    USpec := Z.sgn_spec }.
 Add Zify UnOpSpec ZsgnSpec.
 
 #[global]
 Instance ZabsSpec : UnOpSpec Z.abs :=
-  {| UPred := fun n r: Z =>  0 <= n /\ r = n \/ n < 0 /\ r = - n ;
-     USpec := Z.abs_spec |}.
+  { UPred n r := 0 <= n /\ r = n \/ n < 0 /\ r = - n ; USpec := Z.abs_spec }.
 Add Zify UnOpSpec ZabsSpec.
 
 (** Saturate positivity constraints *)
 
 #[global]
 Instance SatPowPos : Saturate Z.pow :=
-  {|
-    PArg1 := fun x => 0 < x;
-    PArg2 := fun y => 0 <= y;
-    PRes  := fun r => 0 < r;
-    SatOk := Z.pow_pos_nonneg
-  |}.
+  { PArg1 x := 0 < x;
+    PArg2 y := 0 <= y;
+    PRes r := 0 < r;
+    SatOk := Z.pow_pos_nonneg }.
 Add Zify Saturate SatPowPos.
 
 #[global]
 Instance SatPowNonneg : Saturate Z.pow :=
-  {|
-    PArg1 := fun x => 0 <= x;
-    PArg2 := fun y => True;
-    PRes  := fun r => 0 <= r;
-    SatOk := fun a b Ha _ => @Z.pow_nonneg a b Ha
-  |}.
+  { PArg1 x := 0 <= x;
+    PArg2 y := True;
+    PRes r := 0 <= r;
+    SatOk a b Ha _ := @Z.pow_nonneg a b Ha }.
 Add Zify Saturate SatPowNonneg.

--- a/theories/micromega/ZifyInst.v
+++ b/theories/micromega/ZifyInst.v
@@ -276,6 +276,16 @@ Instance Op_pos_square : UnOp Pos.square :=
 Add Zify UnOp Op_pos_square.
 
 #[global]
+Instance Op_Pos_Nsucc_double : UnOp Pos.Nsucc_double :=
+  { TUOp x := 2 * x + 1 ; TUOpInj x := ltac:(now destruct x) }.
+Add Zify UnOp Op_Pos_Nsucc_double.
+
+#[global]
+Instance Op_Pos_Ndouble : UnOp Pos.Ndouble :=
+  { TUOp x := 2 * x ; TUOpInj x := ltac:(now destruct x) }.
+Add Zify UnOp Op_Pos_Ndouble.
+
+#[global]
 Instance Op_xO : UnOp xO :=
   { TUOp := fun x => 2 * x ; TUOpInj := ltac: (refl) }.
 Add Zify UnOp Op_xO.
@@ -393,6 +403,39 @@ Add Zify UnOp Op_N_pred.
 Instance Op_N_succ : UnOp N.succ :=
   {| TUOp := fun x => x + 1 ; TUOpInj := N2Z.inj_succ |}.
 Add Zify UnOp Op_N_succ.
+
+#[global]
+Instance Op_N_succ_double : UnOp N.succ_double :=
+  { TUOp x := 2 * x + 1 ; TUOpInj x := ltac:(now destruct x) }.
+Add Zify UnOp Op_N_succ_double.
+
+#[global]
+Instance Op_N_double : UnOp N.double :=
+  { TUOp x := 2 * x ; TUOpInj x := ltac:(now destruct x) }.
+Add Zify UnOp Op_N_double.
+
+#[global]
+Instance Op_N_succ_pos : UnOp N.succ_pos :=
+  { TUOp x := x + 1 ;
+    TUOpInj x := ltac:(now destruct x; simpl; [| rewrite Pplus_one_succ_r]) }.
+Add Zify UnOp Op_N_succ_pos.
+
+#[global]
+Instance Op_N_div2 : UnOp N.div2 :=
+  { TUOp x := x / 2 ;
+    TUOpInj x := ltac:(now rewrite N2Z.inj_div2, Z.div2_div) }.
+Add Zify UnOp Op_N_div2.
+
+#[global]
+Instance Op_N_pow : BinOp N.pow :=
+  { TBOp := Z.pow ; TBOpInj := N2Z.inj_pow }.
+Add Zify BinOp Op_N_pow.
+
+#[global]
+Instance Op_N_square : UnOp N.square :=
+  { TUOp x := x * x ;
+    TUOpInj x := ltac:(now rewrite N.square_spec, N2Z.inj_mul) }.
+Add Zify UnOp Op_N_square.
 
 (** Support for Z - injected to itself *)
 
@@ -539,11 +582,9 @@ Add Zify UnOp Op_Z_quot2.
 
 Lemma of_nat_to_nat_eq : forall x,  Z.of_nat (Z.to_nat x) = Z.max 0 x.
 Proof.
-  intros x; destruct x.
+  intros x; destruct x; simpl.
   - reflexivity.
-  - rewrite Z2Nat.id.
-    reflexivity.
-    compute. congruence.
+  - now rewrite positive_nat_Z.
   - reflexivity.
 Qed.
 
@@ -551,6 +592,13 @@ Qed.
 Instance Op_Z_to_nat : UnOp Z.to_nat :=
   { TUOp := fun x => Z.max 0 x ; TUOpInj := of_nat_to_nat_eq }.
 Add Zify UnOp Op_Z_to_nat.
+
+#[global]
+Instance Op_Z_to_pos : UnOp Z.to_pos :=
+  { TUOp x := Z.max 1 x ;
+    TUOpInj x := ltac:(now simpl; destruct x;
+                       [| rewrite <- Pos2Z.inj_max; rewrite Pos.max_1_l |]) }.
+Add Zify UnOp Op_Z_to_pos.
 
 (** Specification of derived operators over Z *)
 


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

This PR adds missing zify class instances for `Pos.eqb`, `Pos.leb`, `Pos.ltb`, `N.eqb`, `N.leb`, `N.ltb`, `Pos.Nsucc_double`, `Pos.Ndouble`, `N.succ_double`, `N.double`, `N.succ_pos`, `N.div2`, `N.pow`, `N.square`, and `Z.to_pos`. This PR also suggests some possible cleanups of `ZifyInst.v` and `ZifyBool.v`.

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.

<!-- If this breaks external libraries or plugins in CI: -->
- [x] Opened **overlay** pull requests.
  - ci-flocq: see https://github.com/coq/coq/pull/15101#issuecomment-957081086 

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
