### PR TITLE
Introduce a new directive to document known issues.

### DIFF
--- a/doc/sphinx/README.rst
+++ b/doc/sphinx/README.rst
@@ -292,6 +292,58 @@ In addition to the objects above, the ``coqrst`` Sphinx plugin defines the follo
 
              Hint Resolve plus_comm : plu.
 
+``.. knownissue::`` A reST directive for known issues.
+    This directive is used to document known issues (confirmed bugs or
+    limitations) that do not look like they will be fixed in time for
+    the next release.
+
+    When a known issue is documented, a link to the Coq bug tracker
+    should always be provided so that interested parties know where to
+    discuss the issue (and what is the canonical reference in case
+    duplicate reports need to be closed).
+
+    The directive behaves like an error admonition; see
+    https://docutils.sourceforge.io/docs/ref/rst/directives.html#specific-admonitions
+    for more details.
+
+    Optionally, any text immediately following the ``.. knownissue::`` header is
+    used as the known issue's title. It is strongly recommended to provide one.
+
+    Example::
+
+      .. knownissue:: Hint Cut regexp precedence
+
+         :cmd:`Hint Cut` doesn't apply any operator precedence when
+         parsing regular expressions.  You can check how the cut
+         expression has been parsed with :cmd:`Print HintDb`.
+
+         .. coqtop:: none reset
+
+            Class foo.
+            #[ local ] Instance bar : foo -> foo := {}.
+
+         In the following example, one would expect the `*` to only
+         apply to the `_`, but that's not the case:
+
+         .. coqtop:: all
+
+            #[ local ] Hint Cut [_* bar _* bar] : typeclass_instances.
+            Print HintDb typeclass_instances.
+
+         To get the expected behavior, one should put additional parentheses.
+
+         .. coqtop:: none reset
+
+            Class foo.
+            #[ local ] Instance bar : foo -> foo := {}.
+
+         .. coqtop:: all
+
+            #[ local ] Hint Cut [(_*) bar (_*) bar] : typeclass_instances.
+            Print HintDb typeclass_instances.
+
+         The issue is tracked in `#5206 <https://github.com/coq/coq/issues/5206>`_.
+
 ``.. inference::`` A reST directive to format inference rules.
     This also serves as a small illustration of the way to create new Sphinx
     directives.

--- a/doc/sphinx/proofs/automatic-tactics/auto.rst
+++ b/doc/sphinx/proofs/automatic-tactics/auto.rst
@@ -548,19 +548,46 @@ Creating Hints
 
       .. warning::
 
-         The regexp matches the entire path. Most hints will start with a
-         leading `( _* )` to match the tail of the path. (Note that `(_*)`
-         misparses since `*)` would end a comment.)
-
-      .. warning::
-
-         There is no operator precedence during parsing, one can
-         check with :cmd:`Print HintDb` to verify the current cut expression.
-
-      .. warning::
-
          These hints currently only apply to typeclass proof search and the
          :tacn:`typeclasses eauto` tactic.
+
+      .. warning::
+
+         The regexp matches the entire path. Most hints will start with a
+         leading `( _* )` to match the tail of the path.
+
+      .. knownissue:: Hint Cut regexp precedence
+
+         :cmd:`Hint Cut` doesn't apply any operator precedence when
+         parsing regular expressions.  You can check how the cut
+         expression has been parsed with :cmd:`Print HintDb`.
+
+         .. coqtop:: none reset
+
+            Class foo.
+            #[ local ] Instance bar : foo -> foo := {}.
+
+         In the following example, one would expect the `*` to only
+         apply to the `_`, but that's not the case:
+
+         .. coqtop:: all
+
+            #[ local ] Hint Cut [_* bar _* bar] : typeclass_instances.
+            Print HintDb typeclass_instances.
+
+         To get the expected behavior, one should put additional parentheses.
+
+         .. coqtop:: none reset
+
+            Class foo.
+            #[ local ] Instance bar : foo -> foo := {}.
+
+         .. coqtop:: all
+
+            #[ local ] Hint Cut [(_*) bar (_*) bar] : typeclass_instances.
+            Print HintDb typeclass_instances.
+
+         The issue is tracked in `#5206 <https://github.com/coq/coq/issues/5206>`_.
 
    .. cmd:: Hint Mode @qualid {+ {| + | ! | - } } {? : {+ @ident } }
 


### PR DESCRIPTION
This is a follow-up to https://github.com/coq/coq/wiki/Coq-Call-2021-10-13 and a first step toward closing #12665. This introduces a new Sphinx directive, similar to a warning, to document known issues (but there is no index of known issues yet).

@coq/doc-maintainers Any idea how to introduce an anchor so that we can directly link to these known issues? Do you think that adding an index would be easy?