### PR TITLE
Deprecate the Goal.V82 API

### DIFF
--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -170,7 +170,7 @@ let concl_next_tac =
   ])
 
 let process_goal sigma g =
-  let env = Goal.V82.env sigma g in
+  let env = Evd.evar_filtered_env (Global.env ()) (Evd.find sigma g) in
   let min_env = Environ.reset_context env in
   let name = if Printer.print_goal_names () then Some (Names.Id.to_string (Termops.evar_suggested_name env sigma g)) else None in
   let ccl =
@@ -244,7 +244,7 @@ let hints () =
     match goals with
     | [] -> None
     | g :: _ ->
-      let env = Goal.V82.env sigma g in
+      let env = Evd.evar_filtered_env (Global.env ()) (Evd.find sigma g) in
       let get_hint_hyp env d accu = hyp_next_tac sigma env d :: accu in
       let hint_hyps = List.rev (Environ.fold_named_context get_hint_hyp env ~init: []) in
       Some (hint_hyps, concl_next_tac)

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -170,11 +170,12 @@ let concl_next_tac =
   ])
 
 let process_goal sigma g =
-  let env = Evd.evar_filtered_env (Global.env ()) (Evd.find sigma g) in
+  let evi = Evd.find sigma g in
+  let env = Evd.evar_filtered_env (Global.env ()) evi in
   let min_env = Environ.reset_context env in
   let name = if Printer.print_goal_names () then Some (Names.Id.to_string (Termops.evar_suggested_name env sigma g)) else None in
   let ccl =
-    pr_letype_env ~goal_concl_style:true env sigma (Goal.V82.concl sigma g)
+    pr_letype_env ~goal_concl_style:true env sigma (Evd.evar_concl evi)
   in
   let process_hyp d (env,l) =
     let d' = CompactedDecl.to_named_context d in

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -1334,7 +1334,8 @@ let whole_start concl_tac nb_args is_mes func input_type relation rec_arg_num :
 let abstract_type sigma gl =
   let open EConstr in
   let genv = Global.env () in
-  let env = Evd.evar_filtered_env genv (Evd.find sigma gl) in
+  let evi = Evd.find sigma gl in
+  let env = Evd.evar_filtered_env genv evi in
   let is_proof_var decl =
     try ignore (Environ.lookup_named (Context.Named.Declaration.get_id decl) genv); false
     with Not_found -> true in
@@ -1344,7 +1345,7 @@ let abstract_type sigma gl =
                                           mkNamedProd_or_LetIn decl t
                                         else
                                           t
-                                      ) ~init:(Goal.V82.concl sigma gl) env
+                                      ) ~init:(Evd.evar_concl evi) env
 
 let get_current_subgoals_types pstate =
   let p = Declare.Proof.get pstate in

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -958,7 +958,7 @@ let interp_term env sigma = function
 
 let thin id sigma goal =
   let ids = Id.Set.singleton id in
-  let env = Goal.V82.env sigma goal in
+  let env = Evd.evar_filtered_env (Global.env ()) (Evd.find sigma goal) in
   let cl = Goal.V82.concl sigma goal in
   let sigma = Evd.clear_metas sigma in
   let ans =

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -958,8 +958,9 @@ let interp_term env sigma = function
 
 let thin id sigma goal =
   let ids = Id.Set.singleton id in
-  let env = Evd.evar_filtered_env (Global.env ()) (Evd.find sigma goal) in
-  let cl = Goal.V82.concl sigma goal in
+  let evi = Evd.find sigma goal in
+  let env = Evd.evar_filtered_env (Global.env ()) evi in
+  let cl = Evd.evar_concl evi in
   let sigma = Evd.clear_metas sigma in
   let ans =
     try Some (Evarutil.clear_hyps_in_evi env sigma (Environ.named_context_val env) cl ids)

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -956,6 +956,13 @@ let interp_term env sigma = function
       on_snd EConstr.Unsafe.to_constr (interp_open_constr ist env sigma c)
   | _ -> errorstrm (str"interpreting a term with no ist")
 
+let partial_solution_to env sigma evk evk' c =
+  let id = Evd.evar_ident evk sigma in
+  let sigma = Goal.V82.partial_solution env sigma evk c in
+  match id with
+  | None -> sigma
+  | Some id -> Evd.rename evk' id sigma
+
 let thin id sigma goal =
   let ids = Id.Set.singleton id in
   let env = Evd.evar_filtered_env (Global.env ()) (Evd.find sigma goal) in
@@ -969,7 +976,7 @@ let thin id sigma goal =
   | None -> sigma
   | Some (sigma, hyps, concl) ->
     let (gl,ev,sigma) = Goal.V82.mk_goal sigma hyps concl in
-    let sigma = Goal.V82.partial_solution_to env sigma goal gl ev in
+    let sigma = partial_solution_to env sigma goal gl ev in
     sigma
 
 (*

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -457,8 +457,9 @@ let pr_transparent_state ts =
   hv 0 (str"VARIABLES: " ++ pr_idpred ts.TransparentState.tr_var ++ fnl () ++
         str"CONSTANTS: " ++ pr_cpred ts.TransparentState.tr_cst ++ fnl ())
 
-let goal_env sigma g =
-  Evd.evar_filtered_env (Global.env ()) (Evd.find sigma g)
+let goal_repr sigma g =
+  let evi = Evd.find sigma g in
+  Evd.evar_filtered_env (Global.env ()) evi, Evd.evar_concl evi
 
 (* display complete goal
  og_s has goal+sigma on the previous proof step for diffs
@@ -467,8 +468,7 @@ let goal_env sigma g =
 let pr_goal ?(diffs=false) ?og_s g_s =
   let g = sig_it g_s in
   let sigma = Tacmach.project g_s in
-  let env = goal_env sigma g in
-  let concl = Goal.V82.concl sigma g in
+  let env, concl = goal_repr sigma g in
   let goal =
     if diffs then
       Proof_diffs.diff_goal ?og_s g sigma
@@ -495,12 +495,12 @@ let pr_goal_header nme sigma g =
 
 (* display the conclusion of a goal *)
 let pr_concl n ?(diffs=false) ?og_s sigma g =
-  let env = goal_env sigma g in
+  let env, concl = goal_repr sigma g in
   let pc =
     if diffs then
       Proof_diffs.diff_concl ?og_s sigma g
     else
-      pr_letype_env ~goal_concl_style:true env sigma (Goal.V82.concl sigma g)
+      pr_letype_env ~goal_concl_style:true env sigma concl
   in
   let header = pr_goal_header (int n) sigma g in
   header ++ str " is:" ++ cut () ++ str" "  ++ pc
@@ -591,7 +591,7 @@ let print_evar_constraints gl sigma =
     match gl with
     | None -> fun e' -> pr_context_of e' sigma
     | Some g ->
-       let env = goal_env sigma g in fun e' ->
+       let env, _ = goal_repr sigma g in fun e' ->
        begin
          if Context.Named.equal Constr.equal (named_context env) (named_context e') then
            if Context.Rel.equal Constr.equal (rel_context env) (rel_context e') then mt ()

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -490,13 +490,11 @@ let pr_goal_name sigma g =
   else mt ()
 
 let pr_goal_header nme sigma g =
-  let (g,sigma) = Goal.V82.nf_evar sigma g in
   str "goal " ++ nme ++ (if should_tag() then pr_goal_tag g else str"")
   ++ (if should_gname() then str " " ++ Pp.surround (pr_existential_key (Global.env ()) sigma g) else mt ())
 
 (* display the conclusion of a goal *)
 let pr_concl n ?(diffs=false) ?og_s sigma g =
-  let (g,sigma) = Goal.V82.nf_evar sigma g in
   let env = goal_env sigma g in
   let pc =
     if diffs then

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -457,6 +457,9 @@ let pr_transparent_state ts =
   hv 0 (str"VARIABLES: " ++ pr_idpred ts.TransparentState.tr_var ++ fnl () ++
         str"CONSTANTS: " ++ pr_cpred ts.TransparentState.tr_cst ++ fnl ())
 
+let goal_env sigma g =
+  Evd.evar_filtered_env (Global.env ()) (Evd.find sigma g)
+
 (* display complete goal
  og_s has goal+sigma on the previous proof step for diffs
  g_s has goal+sigma on the current proof step
@@ -464,7 +467,7 @@ let pr_transparent_state ts =
 let pr_goal ?(diffs=false) ?og_s g_s =
   let g = sig_it g_s in
   let sigma = Tacmach.project g_s in
-  let env = Goal.V82.env sigma g in
+  let env = goal_env sigma g in
   let concl = Goal.V82.concl sigma g in
   let goal =
     if diffs then
@@ -494,7 +497,7 @@ let pr_goal_header nme sigma g =
 (* display the conclusion of a goal *)
 let pr_concl n ?(diffs=false) ?og_s sigma g =
   let (g,sigma) = Goal.V82.nf_evar sigma g in
-  let env = Goal.V82.env sigma g in
+  let env = goal_env sigma g in
   let pc =
     if diffs then
       Proof_diffs.diff_concl ?og_s sigma g
@@ -590,7 +593,7 @@ let print_evar_constraints gl sigma =
     match gl with
     | None -> fun e' -> pr_context_of e' sigma
     | Some g ->
-       let env = Goal.V82.env sigma g in fun e' ->
+       let env = goal_env sigma g in fun e' ->
        begin
          if Context.Named.equal Constr.equal (named_context env) (named_context e') then
            if Context.Rel.equal Constr.equal (rel_context env) (rel_context e') then mt ()

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -226,16 +226,20 @@ let to_tuple : Constr.compacted_declaration -> (Names.Id.t Context.binder_annot 
     | LocalAssum(idl, tm)   -> (idl, None, EConstr.of_constr tm)
     | LocalDef(idl,tdef,tm) -> (idl, Some (EConstr.of_constr tdef), EConstr.of_constr tm);;
 
+let goal_repr sigma g =
+  let evi = Evd.find sigma g in
+  let env = Evd.evar_filtered_env (Global.env ()) evi in
+  let ty  = Evd.evar_concl evi in
+  (env, ty)
+
 (* XXX: Very unfortunately we cannot use the Proofview interface as
    Proof is still using the "legacy" one. *)
 let process_goal_concl sigma g : EConstr.t * Environ.env =
-  let env = Evd.evar_filtered_env (Global.env ()) (Evd.find sigma g) in
-  let ty   = Goal.V82.concl sigma g in
+  let (env, ty) = goal_repr sigma g in
   (ty, env)
 
 let process_goal sigma g : EConstr.t reified_goal =
-  let env = Evd.evar_filtered_env (Global.env ()) (Evd.find sigma g) in
-  let ty   = Goal.V82.concl sigma g in
+  let (env, ty) = goal_repr sigma g in
   let name = Goal.uid g             in
   (* compaction is usually desired [eg for better display] *)
   let hyps      = Termops.compact_named_context (Environ.named_context env) in

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -229,12 +229,12 @@ let to_tuple : Constr.compacted_declaration -> (Names.Id.t Context.binder_annot 
 (* XXX: Very unfortunately we cannot use the Proofview interface as
    Proof is still using the "legacy" one. *)
 let process_goal_concl sigma g : EConstr.t * Environ.env =
-  let env  = Goal.V82.env   sigma g in
+  let env = Evd.evar_filtered_env (Global.env ()) (Evd.find sigma g) in
   let ty   = Goal.V82.concl sigma g in
   (ty, env)
 
 let process_goal sigma g : EConstr.t reified_goal =
-  let env  = Goal.V82.env   sigma g in
+  let env = Evd.evar_filtered_env (Global.env ()) (Evd.find sigma g) in
   let ty   = Goal.V82.concl sigma g in
   let name = Goal.uid g             in
   (* compaction is usually desired [eg for better display] *)

--- a/proofs/goal.ml
+++ b/proofs/goal.ml
@@ -75,21 +75,6 @@ module V82 = struct
     in
     Evd.define evk c sigma
 
-  let weak_progress glss gls =
-    match glss.Evd.it with
-    | [ g ] -> not (Proofview.Progress.goal_equal ~evd:gls.Evd.sigma
-                      ~extended_evd:glss.Evd.sigma gls.Evd.it g)
-    | _ -> true
-
-  let progress glss gls =
-    weak_progress glss gls
-    (* spiwack: progress normally goes like this:
-    (Evd.progress_evar_map gls.Evd.sigma glss.Evd.sigma) || (weak_progress glss gls)
-       This is immensly slow in the current implementation. Maybe we could
-       reimplement progress_evar_map with restricted folds like "fold_undefined",
-       with a good implementation of them.
-    *)
-
   (* Used by the compatibility layer and typeclasses *)
   let nf_evar sigma gl =
     let evi = Evd.find sigma gl in

--- a/proofs/goal.ml
+++ b/proofs/goal.ml
@@ -75,14 +75,6 @@ module V82 = struct
     in
     Evd.define evk c sigma
 
-  (* Instantiates a goal with an open term, using name of goal for evk' *)
-  let partial_solution_to env sigma evk evk' c =
-    let id = Evd.evar_ident evk sigma in
-    let sigma = partial_solution env sigma evk c in
-    match id with
-    | None -> sigma
-    | Some id -> Evd.rename evk' id sigma
-
   let weak_progress glss gls =
     match glss.Evd.it with
     | [ g ] -> not (Proofview.Progress.goal_equal ~evd:gls.Evd.sigma

--- a/proofs/goal.ml
+++ b/proofs/goal.ml
@@ -10,8 +10,6 @@
 
 open Pp
 
-module NamedDecl = Context.Named.Declaration
-
 (* This module implements the abstract interface to goals *)
 (* A general invariant of the module, is that a goal whose associated
    evar is defined in the current evar_map, should not be accessed. *)
@@ -81,23 +79,6 @@ module V82 = struct
     let evi = Evarutil.nf_evar_info sigma evi in
     let sigma = Evd.add sigma gl evi in
     (gl, sigma)
-
-  (* Goal represented as a type, doesn't take into account section variables *)
-  let abstract_type sigma gl =
-    let open EConstr in
-    let (gl,sigma) = nf_evar sigma gl in
-    let env = env sigma gl in
-    let genv = Global.env () in
-    let is_proof_var decl =
-      try ignore (Environ.lookup_named (NamedDecl.get_id decl) genv); false
-      with Not_found -> true in
-    Environ.fold_named_context_reverse (fun t decl ->
-                                          if is_proof_var decl then
-                                            let decl = Termops.map_named_decl EConstr.of_constr decl in
-                                            mkNamedProd_or_LetIn decl t
-                                          else
-                                            t
-                                       ) ~init:(concl sigma gl) env
 
 end
 

--- a/proofs/goal.mli
+++ b/proofs/goal.mli
@@ -49,6 +49,7 @@ module V82 : sig
                          Environ.named_context_val ->
                          EConstr.constr ->
                          goal * EConstr.constr * Evd.evar_map
+  [@@ocaml.deprecated "Use the Refine.refine primitive and related API"]
 
   (* Instantiates a goal with an open term *)
   val partial_solution : Environ.env -> Evd.evar_map -> goal -> EConstr.constr -> Evd.evar_map

--- a/proofs/goal.mli
+++ b/proofs/goal.mli
@@ -28,6 +28,7 @@ module V82 : sig
 
   (* Old style env primitive *)
   val env : Evd.evar_map -> goal -> Environ.env
+  [@@ocaml.deprecated "Use Evd.evar_filtered_env"]
 
   (* Old style hyps primitive *)
   val hyps : Evd.evar_map -> goal -> Environ.named_context_val

--- a/proofs/goal.mli
+++ b/proofs/goal.mli
@@ -53,10 +53,6 @@ module V82 : sig
   (* Instantiates a goal with an open term *)
   val partial_solution : Environ.env -> Evd.evar_map -> goal -> EConstr.constr -> Evd.evar_map
 
-  (* Instantiates a goal with an open term, reusing name of goal for
-     second goal *)
-  val partial_solution_to : Environ.env -> Evd.evar_map -> goal -> goal -> EConstr.constr -> Evd.evar_map
-
   (* Principal part of the progress tactical *)
   val progress : goal list Evd.sigma -> goal Evd.sigma -> bool
 

--- a/proofs/goal.mli
+++ b/proofs/goal.mli
@@ -53,9 +53,6 @@ module V82 : sig
   (* Instantiates a goal with an open term *)
   val partial_solution : Environ.env -> Evd.evar_map -> goal -> EConstr.constr -> Evd.evar_map
 
-  (* Principal part of the progress tactical *)
-  val progress : goal list Evd.sigma -> goal Evd.sigma -> bool
-
   (* Used by the compatibility layer and typeclasses *)
   val nf_evar : Evd.evar_map -> goal -> goal * Evd.evar_map
   [@@ocaml.deprecated "This should be the identity now"]

--- a/proofs/goal.mli
+++ b/proofs/goal.mli
@@ -57,9 +57,6 @@ module V82 : sig
   val nf_evar : Evd.evar_map -> goal -> goal * Evd.evar_map
   [@@ocaml.deprecated "This should be the identity now"]
 
-  (* Goal represented as a type, doesn't take into account section variables *)
-  val abstract_type : Evd.evar_map -> goal -> EConstr.types
-
 end
 
 module Set = Evar.Set

--- a/proofs/goal.mli
+++ b/proofs/goal.mli
@@ -61,6 +61,7 @@ module V82 : sig
 
   (* Used by the compatibility layer and typeclasses *)
   val nf_evar : Evd.evar_map -> goal -> goal * Evd.evar_map
+  [@@ocaml.deprecated "This should be the identity now"]
 
   (* Goal represented as a type, doesn't take into account section variables *)
   val abstract_type : Evd.evar_map -> goal -> EConstr.types

--- a/proofs/goal.mli
+++ b/proofs/goal.mli
@@ -37,6 +37,7 @@ module V82 : sig
   (* same as [hyps], but ensures that existential variables are
      normalised. *)
   val nf_hyps : Evd.evar_map -> goal -> Environ.named_context_val
+  [@@ocaml.deprecated "Use Evd.evar_filtered_hyps"]
 
   (* Access to ".evar_concl" *)
   val concl : Evd.evar_map -> goal -> EConstr.constr

--- a/proofs/goal.mli
+++ b/proofs/goal.mli
@@ -52,6 +52,7 @@ module V82 : sig
 
   (* Instantiates a goal with an open term *)
   val partial_solution : Environ.env -> Evd.evar_map -> goal -> EConstr.constr -> Evd.evar_map
+  [@@ocaml.deprecated "Use Refine.refine"]
 
   (* Used by the compatibility layer and typeclasses *)
   val nf_evar : Evd.evar_map -> goal -> goal * Evd.evar_map

--- a/proofs/goal.mli
+++ b/proofs/goal.mli
@@ -41,6 +41,7 @@ module V82 : sig
 
   (* Access to ".evar_concl" *)
   val concl : Evd.evar_map -> goal -> EConstr.constr
+  [@@ocaml.deprecated "Use Evd.evar_concl"]
 
   (* Old style mk_goal primitive, returns a new goal with corresponding
        hypotheses and conclusion, together with a term which is precisely

--- a/proofs/goal.mli
+++ b/proofs/goal.mli
@@ -32,6 +32,7 @@ module V82 : sig
 
   (* Old style hyps primitive *)
   val hyps : Evd.evar_map -> goal -> Environ.named_context_val
+  [@@ocaml.deprecated "Use Evd.evar_filtered_hyps"]
 
   (* same as [hyps], but ensures that existential variables are
      normalised. *)

--- a/proofs/logic.ml
+++ b/proofs/logic.ml
@@ -320,11 +320,11 @@ let goal_type_of ~check env sigma c =
     (sigma, EConstr.Unsafe.to_constr t)
   else (sigma, EConstr.Unsafe.to_constr (Retyping.get_type_of env sigma (EConstr.of_constr c)))
 
+let mk_goal = Goal.V82.mk_goal [@ocaml.warning "-3"]
+(* TODO: inline when the Goal.V82 module is removed *)
+
 let rec mk_refgoals ~check env sigma goalacc conclty trm =
   let hyps = Environ.named_context_val env in
-  let mk_goal hyps concl =
-    Goal.V82.mk_goal sigma hyps concl
-  in
     if (not check) && not (occur_meta sigma (EConstr.of_constr trm)) then
       let t'ty = Retyping.get_type_of env sigma (EConstr.of_constr trm) in
       let t'ty = EConstr.Unsafe.to_constr t'ty in
@@ -336,7 +336,7 @@ let rec mk_refgoals ~check env sigma goalacc conclty trm =
         let conclty = nf_betaiota env sigma conclty in
           if check && occur_meta sigma conclty then
             raise (RefinerError (env, sigma, MetaInType conclty));
-          let (gl,ev,sigma) = mk_goal hyps conclty in
+          let (gl,ev,sigma) = mk_goal sigma hyps conclty in
           let ev = EConstr.Unsafe.to_constr ev in
           let conclty = EConstr.Unsafe.to_constr conclty in
           gl::goalacc, conclty, sigma, ev
@@ -406,12 +406,10 @@ let rec mk_refgoals ~check env sigma goalacc conclty trm =
 
 and mk_hdgoals ~check env sigma goalacc trm =
   let hyps = Environ.named_context_val env in
-  let mk_goal hyps concl =
-    Goal.V82.mk_goal sigma hyps concl in
   match kind trm with
     | Cast (c,_, ty) when isMeta c ->
         let sigma = check_typability ~check env sigma ty in
-        let (gl,ev,sigma) = mk_goal hyps (nf_betaiota env sigma (EConstr.of_constr ty)) in
+        let (gl,ev,sigma) = mk_goal sigma hyps (nf_betaiota env sigma (EConstr.of_constr ty)) in
         let ev = EConstr.Unsafe.to_constr ev in
         gl::goalacc,ty,sigma,ev
 

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -562,7 +562,8 @@ let get_nth_V82_goal p i =
 
 let get_goal_context_gen pf i =
   let { Evd.it=goal ; sigma=sigma; } = get_nth_V82_goal pf i in
-  (sigma, Global.env_of_context (Goal.V82.hyps sigma goal))
+  let env = Evd.evar_filtered_env (Global.env ()) (Evd.find sigma goal) in
+  (sigma, env)
 
 let get_proof_context p =
   try get_goal_context_gen p 1

--- a/proofs/tacmach.ml
+++ b/proofs/tacmach.ml
@@ -31,8 +31,8 @@ type tactic = Proofview.V82.tac
 
 let sig_it x = x.it
 let project x = x.sigma
-let pf_env gls = Global.env_of_context (Goal.V82.hyps (project gls) (sig_it gls))
-let pf_hyps gls = EConstr.named_context_of_val (Goal.V82.hyps (project gls) (sig_it gls))
+let pf_env { it; sigma } = Evd.evar_filtered_env (Global.env ()) (Evd.find sigma it)
+let pf_hyps { it; sigma } = Evd.evar_filtered_context (Evd.find sigma it)
 
 let test_conversion env sigma pb c1 c2 =
   Reductionops.check_conv ~pb env sigma c1 c2

--- a/proofs/tacmach.ml
+++ b/proofs/tacmach.ml
@@ -37,7 +37,7 @@ let pf_hyps { it; sigma } = Evd.evar_filtered_context (Evd.find sigma it)
 let test_conversion env sigma pb c1 c2 =
   Reductionops.check_conv ~pb env sigma c1 c2
 
-let pf_concl gls = Goal.V82.concl (project gls) (sig_it gls)
+let pf_concl gls = Evd.evar_concl (Evd.find (project gls) (sig_it gls))
 let pf_hyps_types gls  =
   let sign = Environ.named_context (pf_env gls) in
   List.map (function LocalAssum (id,x)
@@ -91,9 +91,10 @@ let pf_hnf_type_of gls          = pf_get_type_of gls %> pf_whd_all gls
 open Pp
 
 let db_pr_goal sigma g =
-  let env = Evd.evar_filtered_env (Global.env ()) (Evd.find sigma g) in
+  let evi = Evd.find sigma g in
+  let env = Evd.evar_filtered_env (Global.env ()) evi in
   let penv = Termops.Internal.print_named_context env in
-  let pc = Termops.Internal.print_constr_env env sigma (Goal.V82.concl sigma g) in
+  let pc = Termops.Internal.print_constr_env env sigma (Evd.evar_concl evi) in
   str"  " ++ hv 0 (penv ++ fnl () ++
                    str "============================" ++ fnl ()  ++
                    str" "  ++ pc) ++ fnl ()

--- a/proofs/tacmach.ml
+++ b/proofs/tacmach.ml
@@ -91,7 +91,7 @@ let pf_hnf_type_of gls          = pf_get_type_of gls %> pf_whd_all gls
 open Pp
 
 let db_pr_goal sigma g =
-  let env = Goal.V82.env sigma g in
+  let env = Evd.evar_filtered_env (Global.env ()) (Evd.find sigma g) in
   let penv = Termops.Internal.print_named_context env in
   let pc = Termops.Internal.print_constr_env env sigma (Goal.V82.concl sigma g) in
   str"  " ++ hv 0 (penv ++ fnl () ++

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -112,8 +112,9 @@ let set_typeclasses_strategy = function
   | Bfs -> Goptions.set_bool_option_value iterative_deepening_opt_name true
 
 let pr_ev evs ev =
-  let env = Evd.evar_filtered_env (Global.env ()) (Evd.find evs ev) in
-  Printer.pr_econstr_env env evs (Goal.V82.concl evs ev)
+  let evi = Evd.find evs ev in
+  let env = Evd.evar_filtered_env (Global.env ()) evi in
+  Printer.pr_econstr_env env evs (Evd.evar_concl evi)
 
 (** Typeclasses instance search tactic / eauto *)
 

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -1125,25 +1125,23 @@ let solve_inst env evd filter unique split fail =
 let () =
   Hook.set Typeclasses.solve_all_instances_hook solve_inst
 
-let resolve_one_typeclass env ?(sigma=Evd.from_env env) gl unique =
+let resolve_one_typeclass env ?(sigma=Evd.from_env env) concl unique =
   let (term, sigma) = Hints.wrap_hint_warning_fun env sigma begin fun sigma ->
-  let nc, gl, subst, _ = Evarutil.push_rel_context_to_named_context env sigma gl in
-  let (gl,t,sigma) = Goal.V82.mk_goal sigma nc gl in
-  let (ev, _) = destEvar sigma t in
-  let gls = { it = gl ; sigma = sigma; } in
   let hints = searchtable_map typeclasses_db in
   let st = Hint_db.transparent_state hints in
   let modes = Hint_db.modes hints in
   let depth = get_typeclasses_depth () in
-  let gls' =
-      try
-        Proofview.V82.of_tactic
-        (Search.eauto_tac (modes,st) ~only_classes:true ~depth [hints] ~dep:true) gls
-      with Tacticals.FailError _ -> raise Not_found
+  let tac = Search.eauto_tac (modes,st) ~only_classes:true ~depth [hints] ~dep:true in
+  let entry, pv = Proofview.init sigma [env, concl] in
+  let pv =
+    let name = Names.Id.of_string "legacy_pe" in
+    match Proofview.apply ~name ~poly:false (Global.env ()) tac pv with
+    | (_, final, _, _) -> final
+    | exception (Logic_monad.TacticFailure (Tacticals.FailError _)) ->
+      raise Not_found
   in
-  let evd = sig_sig gls' in
-  let t' = mkEvar (ev, subst) in
-  let term = Evarutil.nf_evar evd t' in
+  let evd = Proofview.return pv in
+  let term = match Proofview.partial_proof entry pv with [t] -> t | _ -> assert false in
   term, evd
   end in
   (sigma, term)

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -112,7 +112,8 @@ let set_typeclasses_strategy = function
   | Bfs -> Goptions.set_bool_option_value iterative_deepening_opt_name true
 
 let pr_ev evs ev =
-  Printer.pr_econstr_env (Goal.V82.env evs ev) evs (Goal.V82.concl evs ev)
+  let env = Evd.evar_filtered_env (Global.env ()) (Evd.find evs ev) in
+  Printer.pr_econstr_env env evs (Goal.V82.concl evs ev)
 
 (** Typeclasses instance search tactic / eauto *)
 

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1593,7 +1593,7 @@ let pr_applicable_hint pf =
   match goals with
   | [] -> CErrors.user_err Pp.(str "No focused goal.")
   | g::_ ->
-    pr_hint_term env sigma (Goal.V82.concl sigma g)
+    pr_hint_term env sigma (Evd.evar_concl (Evd.find sigma g))
 
 let pp_hint_mode = function
   | ModeInput -> str"+"

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2138,7 +2138,8 @@ let vernac_check_guard ~pstate =
   let message =
     try
       let { Evd.it=gl ; sigma=sigma } = Proof.V82.top_goal pts in
-      Inductiveops.control_only_guard (Goal.V82.env sigma gl) sigma pfterm;
+      let env = Evd.evar_filtered_env (Global.env ()) (Evd.find sigma gl) in
+      Inductiveops.control_only_guard env sigma pfterm;
       (str "The condition holds up to here")
     with UserError s ->
       (str ("Condition violated: ") ++ s ++ str ".")


### PR DESCRIPTION
Some of the exposed functions were so specific that they were simply removed and inlined in their only caller. Most of the calls are trivial wrappers around the Evd API that shouldn't even have been introduced in the first place, and were there just to tempt people into using a discouraged API.