### PR TITLE
Turn the ProofGeneral-specific infoH tactic into a command.

### DIFF
--- a/doc/changelog/07-vernac-commands-and-options/15116-make-infoH-a-command.rst
+++ b/doc/changelog/07-vernac-commands-and-options/15116-make-infoH-a-command.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  The ProofGeneral specific tactical infoH was turned into
+  a vernacular command
+  (`#15116 <https://github.com/coq/coq/pull/15116>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/changelog/07-vernac-commands-and-options/15116-make-infoH-a-command.rst
+++ b/doc/changelog/07-vernac-commands-and-options/15116-make-infoH-a-command.rst
@@ -1,5 +1,0 @@
-- **Changed:**
-  The ProofGeneral specific tactical infoH was turned into
-  a vernacular command
-  (`#15116 <https://github.com/coq/coq/pull/15116>`_,
-  by Pierre-Marie Pédrot).

--- a/doc/sphinx/proof-engine/ltac.rst
+++ b/doc/sphinx/proof-engine/ltac.rst
@@ -2400,7 +2400,7 @@ Run-time optimization tactic
    heap in the OCaml run-time system. It is analogous to the
    :cmd:`Optimize Heap` command.
 
-.. cmd:: infoH @ltac_expr3
+.. cmd:: infoH @ltac_expr
 
    Used internally by Proof General.  See `#12423 <https://github.com/coq/coq/issues/12423>`_ for
    some background.

--- a/doc/sphinx/proof-engine/ltac.rst
+++ b/doc/sphinx/proof-engine/ltac.rst
@@ -2400,9 +2400,7 @@ Run-time optimization tactic
    heap in the OCaml run-time system. It is analogous to the
    :cmd:`Optimize Heap` command.
 
-.. tacn:: infoH @ltac_expr3
+.. cmd:: infoH @ltac_expr3
 
    Used internally by Proof General.  See `#12423 <https://github.com/coq/coq/issues/12423>`_ for
    some background.
-
-   :tacn:`infoH` is an :token:`l3_tactic`.

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -609,6 +609,7 @@ command: [
 | "Print" "Equivalent" "Keys"
 | "Optimize" "Proof"
 | "Optimize" "Heap"
+| "infoH" tactic
 | "Hint" "Cut" "[" hints_path "]" opthints
 | "Typeclasses" "Transparent" LIST1 reference
 | "Typeclasses" "Opaque" LIST1 reference
@@ -2046,7 +2047,6 @@ ltac_expr3: [
 | "progress" ltac_expr3
 | "once" ltac_expr3
 | "exactly_once" ltac_expr3
-| "infoH" ltac_expr3
 | "abstract" ltac_expr2
 | "abstract" ltac_expr2 "using" ident
 | "only" selector ":" ltac_expr3

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -996,6 +996,7 @@ command: [
 | "Print" "Equivalent" "Keys"
 | "Optimize" "Proof"
 | "Optimize" "Heap"
+| "infoH" ltac_expr
 | "Reset" "Ltac" "Profile"
 | "Show" "Ltac" "Profile" OPT [ "CutOff" integer | string ]
 | "Show" "Lia" "Profile"      (* micromega plugin *)
@@ -1636,7 +1637,6 @@ simple_tactic: [
 | "progress" ltac_expr3
 | "once" ltac_expr3
 | "exactly_once" ltac_expr3
-| "infoH" ltac_expr3
 | "abstract" ltac_expr2 OPT ( "using" ident )
 | "only" selector ":" ltac_expr3
 | "tryif" ltac_expr "then" ltac_expr "else" ltac_expr2

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -1110,6 +1110,57 @@ TACTIC EXTEND optimize_heap
 | [ "optimize_heap" ] -> { tclOPTIMIZE_HEAP }
 END
 
+(** ProofGeneral specific command *)
+
+{
+
+(* Execute tac, show the names of new hypothesis names created by tac
+   in the "as" format and then forget everything. From the logical
+   point of view [infoH tac] is therefore equivalent to idtac,
+   except that it takes the time and memory of tac and prints "as"
+   information. The resulting (unchanged) goals are printed *after*
+   the as-expression, which forces pg to some gymnastic.
+   TODO: Have something similar (better?) in the xml protocol.
+   NOTE: some tactics delete hypothesis and reuse names (induction,
+   destruct), this is not detected by this tactical. *)
+let infoH (tac : raw_tactic_expr) ~pstate : unit =
+  let (_, oldhyps) = Declare.Proof.get_current_goal_context pstate in
+  let oldhyps = List.map Context.Named.Declaration.get_id @@ Environ.named_context oldhyps in
+  let tac = Tacinterp.interp tac in
+  let tac =
+    let open Proofview.Notations in
+    tac <*>
+    Proofview.Unsafe.tclGETGOALS >>= fun gls ->
+    Proofview.tclEVARMAP >>= fun sigma ->
+    let map gl =
+      let gl = Proofview_monad.drop_state gl in
+      let hyps = Evd.evar_filtered_context (Evd.find sigma gl) in
+      List.map Context.Named.Declaration.get_id @@ hyps
+    in
+    let hyps = List.map map gls in
+    let newhyps = List.map (fun hypl -> List.subtract Names.Id.equal hypl oldhyps) hyps in
+    let s =
+      let frst = ref true in
+      List.fold_left
+      (fun acc lh -> acc ^ (if !frst then (frst:=false;"") else " | ")
+        ^ (List.fold_left
+            (fun acc d -> (Names.Id.to_string d) ^ " " ^ acc)
+            "" lh))
+      "" newhyps in
+    let () = Feedback.msg_notice
+      (str "<infoH>"
+        ++  (hov 0 (str s))
+        ++  (str "</infoH>")) in
+    Proofview.tclUNIT ()
+  in
+  ignore (Declare.Proof.by tac pstate)
+
+}
+
+VERNAC COMMAND EXTEND infoH CLASSIFIED AS QUERY
+| ![ proof_query ] [ "infoH" tactic(tac) ] -> { infoH tac }
+END
+
 (** Tactic analogous to [Strategy] vernacular *)
 
 TACTIC EXTEND with_strategy

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -1110,55 +1110,8 @@ TACTIC EXTEND optimize_heap
 | [ "optimize_heap" ] -> { tclOPTIMIZE_HEAP }
 END
 
-(** ProofGeneral specific command *)
-
-{
-
-(* Execute tac, show the names of new hypothesis names created by tac
-   in the "as" format and then forget everything. From the logical
-   point of view [infoH tac] is therefore equivalent to idtac,
-   except that it takes the time and memory of tac and prints "as"
-   information. The resulting (unchanged) goals are printed *after*
-   the as-expression, which forces pg to some gymnastic.
-   TODO: Have something similar (better?) in the xml protocol.
-   NOTE: some tactics delete hypothesis and reuse names (induction,
-   destruct), this is not detected by this tactical. *)
-let infoH (tac : raw_tactic_expr) ~pstate : unit =
-  let (_, oldhyps) = Declare.Proof.get_current_goal_context pstate in
-  let oldhyps = List.map Context.Named.Declaration.get_id @@ Environ.named_context oldhyps in
-  let tac = Tacinterp.interp tac in
-  let tac =
-    let open Proofview.Notations in
-    tac <*>
-    Proofview.Unsafe.tclGETGOALS >>= fun gls ->
-    Proofview.tclEVARMAP >>= fun sigma ->
-    let map gl =
-      let gl = Proofview_monad.drop_state gl in
-      let hyps = Evd.evar_filtered_context (Evd.find sigma gl) in
-      List.map Context.Named.Declaration.get_id @@ hyps
-    in
-    let hyps = List.map map gls in
-    let newhyps = List.map (fun hypl -> List.subtract Names.Id.equal hypl oldhyps) hyps in
-    let s =
-      let frst = ref true in
-      List.fold_left
-      (fun acc lh -> acc ^ (if !frst then (frst:=false;"") else " | ")
-        ^ (List.fold_left
-            (fun acc d -> (Names.Id.to_string d) ^ " " ^ acc)
-            "" lh))
-      "" newhyps in
-    let () = Feedback.msg_notice
-      (str "<infoH>"
-        ++  (hov 0 (str s))
-        ++  (str "</infoH>")) in
-    Proofview.tclUNIT ()
-  in
-  ignore (Declare.Proof.by tac pstate)
-
-}
-
 VERNAC COMMAND EXTEND infoH CLASSIFIED AS QUERY
-| ![ proof_query ] [ "infoH" tactic(tac) ] -> { infoH tac }
+| ![ proof_query ] [ "infoH" tactic(tac) ] -> { fun ~pstate -> Internals.infoH ~pstate tac }
 END
 
 (** Tactic analogous to [Strategy] vernacular *)

--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -119,7 +119,6 @@ GRAMMAR EXTEND Gram
       | IDENT "progress"; ta = ltac_expr -> { CAst.make ~loc (TacProgress ta) }
       | IDENT "once"; ta = ltac_expr -> { CAst.make ~loc (TacOnce  ta) }
       | IDENT "exactly_once"; ta = ltac_expr -> { CAst.make ~loc (TacExactlyOnce ta) }
-      | IDENT "infoH"; ta = ltac_expr -> { CAst.make ~loc (TacShowHyps ta) }
 (*To do: put Abstract in Refiner*)
       | IDENT "abstract"; tc = NEXT -> { CAst.make ~loc (TacAbstract (tc,None)) }
       | IDENT "abstract"; tc = NEXT; "using";  s = ident ->

--- a/plugins/ltac/internals.ml
+++ b/plugins/ltac/internals.ml
@@ -1,0 +1,55 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Util
+open Tacexpr
+
+(** ProofGeneral specific command *)
+
+(* Execute tac, show the names of new hypothesis names created by tac
+   in the "as" format and then forget everything. From the logical
+   point of view [infoH tac] is therefore equivalent to idtac,
+   except that it takes the time and memory of tac and prints "as"
+   information. The resulting (unchanged) goals are printed *after*
+   the as-expression, which forces pg to some gymnastic.
+   TODO: Have something similar (better?) in the xml protocol.
+   NOTE: some tactics delete hypothesis and reuse names (induction,
+   destruct), this is not detected by this tactical. *)
+let infoH ~pstate (tac : raw_tactic_expr) : unit =
+  let (_, oldhyps) = Declare.Proof.get_current_goal_context pstate in
+  let oldhyps = List.map Context.Named.Declaration.get_id @@ Environ.named_context oldhyps in
+  let tac = Tacinterp.interp tac in
+  let tac =
+    let open Proofview.Notations in
+    tac <*>
+    Proofview.Unsafe.tclGETGOALS >>= fun gls ->
+    Proofview.tclEVARMAP >>= fun sigma ->
+    let map gl =
+      let gl = Proofview_monad.drop_state gl in
+      let hyps = Evd.evar_filtered_context (Evd.find sigma gl) in
+      List.map Context.Named.Declaration.get_id @@ hyps
+    in
+    let hyps = List.map map gls in
+    let newhyps = List.map (fun hypl -> List.subtract Names.Id.equal hypl oldhyps) hyps in
+    let s =
+      let frst = ref true in
+      List.fold_left
+      (fun acc lh -> acc ^ (if !frst then (frst:=false;"") else " | ")
+        ^ (List.fold_left
+            (fun acc d -> (Names.Id.to_string d) ^ " " ^ acc)
+            "" lh))
+      "" newhyps in
+    let () = Feedback.msg_notice
+      Pp.(str "<infoH>"
+        ++  (hov 0 (str s))
+        ++  (str "</infoH>")) in
+    Proofview.tclUNIT ()
+  in
+  ignore (Declare.Proof.by tac pstate)

--- a/plugins/ltac/internals.mli
+++ b/plugins/ltac/internals.mli
@@ -1,0 +1,14 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** Implementation of Ltac-specific code to be exported in mlg files *)
+
+val infoH : pstate:Declare.Proof.t -> Tacexpr.raw_tactic_expr -> unit
+(** ProofGeneral command *)

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -982,11 +982,6 @@ let pr_goal_selector ~toplevel s =
                 keyword "progress" ++ spc ()
                 ++ pr_tac (LevelLe ltactical) t),
               ltactical
-            | TacShowHyps t ->
-              hov 1 (
-                keyword "infoH" ++ spc ()
-                ++ pr_tac (LevelLe ltactical) t),
-              ltactical
             | TacOr (t1,t2) ->
               hov 1 (
                 pr_tac (LevelLt lorelse) t1 ++ spc ()

--- a/plugins/ltac/tacexpr.ml
+++ b/plugins/ltac/tacexpr.ml
@@ -220,7 +220,6 @@ and 'a gen_tactic_expr_r =
   | TacTime of string option * 'a gen_tactic_expr
   | TacRepeat of 'a gen_tactic_expr
   | TacProgress of 'a gen_tactic_expr
-  | TacShowHyps of 'a gen_tactic_expr
   | TacAbstract of
       'a gen_tactic_expr * Id.t option
   | TacId of 'n message_token list

--- a/plugins/ltac/tacexpr.mli
+++ b/plugins/ltac/tacexpr.mli
@@ -219,7 +219,6 @@ and 'a gen_tactic_expr_r =
   | TacTime of string option * 'a gen_tactic_expr
   | TacRepeat of 'a gen_tactic_expr
   | TacProgress of 'a gen_tactic_expr
-  | TacShowHyps of 'a gen_tactic_expr
   | TacAbstract of
       'a gen_tactic_expr * Id.t option
   | TacId of 'n message_token list

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -623,7 +623,6 @@ and intern_tactic_seq onlytac ist tac =
   | TacFail (g,n,l) ->
       ist.ltacvars, CAst.make ?loc (TacFail (g,intern_int_or_var ist n,intern_message ist l))
   | TacProgress tac -> ist.ltacvars, CAst.make ?loc (TacProgress (intern_pure_tactic ist tac))
-  | TacShowHyps tac -> ist.ltacvars, CAst.make ?loc (TacShowHyps (intern_pure_tactic ist tac))
   | TacAbstract (tac,s) ->
       ist.ltacvars, CAst.make ?loc (TacAbstract (intern_pure_tactic ist tac,s))
   | TacThen (t1,t2) ->

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -1155,10 +1155,6 @@ and eval_tactic_ist ist tac : unit Proofview.tactic =
       in
       Ftactic.run msg tac
   | TacProgress tac -> Tacticals.New.tclPROGRESS (interp_tactic ist tac)
-  | TacShowHyps tac ->
-         Proofview.V82.tactic begin
-           Tacticals.tclSHOWHYPS (Proofview.V82.of_tactic (interp_tactic ist tac))
-         end
   | TacAbstract (t,ido) ->
       let call = LtacMLCall tac in
       let trace = push_trace(None,call) ist in

--- a/plugins/ltac/tacsubst.ml
+++ b/plugins/ltac/tacsubst.ml
@@ -183,7 +183,6 @@ and subst_tactic subst = CAst.map (function
       TacMatch (lz,subst_tactic subst c,subst_match_rule subst lmr)
   | TacId _ | TacFail _ as x -> x
   | TacProgress tac -> TacProgress (subst_tactic subst tac:glob_tactic_expr)
-  | TacShowHyps tac -> TacShowHyps (subst_tactic subst tac:glob_tactic_expr)
   | TacAbstract (tac,s) -> TacAbstract (subst_tactic subst tac,s)
   | TacThen (t1,t2) ->
       TacThen (subst_tactic subst t1, subst_tactic subst t2)

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -158,42 +158,6 @@ let tclPROGRESS tac ptree =
   if Goal.V82.progress rslt ptree then rslt
   else user_err (str"Failed to progress.")
 
-(* Execute tac, show the names of new hypothesis names created by tac
-   in the "as" format and then forget everything. From the logical
-   point of view [tclSHOWHYPS tac] is therefore equivalent to idtac,
-   except that it takes the time and memory of tac and prints "as"
-   information). The resulting (unchanged) goals are printed *after*
-   the as-expression, which forces pg to some gymnastic.
-   TODO: Have something similar (better?) in the xml protocol.
-   NOTE: some tactics delete hypothesis and reuse names (induction,
-   destruct), this is not detected by this tactical. *)
-let tclSHOWHYPS (tac : tactic) (goal: Goal.goal Evd.sigma)
-    : Goal.goal list Evd.sigma =
-  let oldhyps = pf_hyps goal in
-  let rslt:Goal.goal list Evd.sigma = tac goal in
-  let { it = gls; sigma = sigma; } = rslt in
-  let hyps =
-    List.map (fun gl -> pf_hyps { it = gl; sigma=sigma; }) gls in
-  let cmp d1 d2 = Names.Id.equal (NamedDecl.get_id d1) (NamedDecl.get_id d2) in
-  let newhyps =
-    List.map
-      (fun hypl -> List.subtract cmp hypl oldhyps)
-      hyps
-  in
-  let s =
-    let frst = ref true in
-    List.fold_left
-    (fun acc lh -> acc ^ (if !frst then (frst:=false;"") else " | ")
-      ^ (List.fold_left
-           (fun acc d -> (Names.Id.to_string (NamedDecl.get_id d)) ^ " " ^ acc)
-           "" lh))
-    "" newhyps in
-  Feedback.msg_notice
-    (str "<infoH>"
-      ++  (hov 0 (str s))
-      ++  (str "</infoH>"));
-  tclIDTAC goal;;
-
 (* ORELSE0 t1 t2 tries to apply t1 and if it fails, applies t2 *)
 let tclORELSE0 t1 t2 g =
   try

--- a/tactics/tacticals.mli
+++ b/tactics/tacticals.mli
@@ -47,7 +47,6 @@ val tclFAIL          : int -> Pp.t -> tactic
 val tclFAIL_lazy     : int -> Pp.t Lazy.t -> tactic
 val tclDO            : int -> tactic -> tactic
 val tclPROGRESS      : tactic -> tactic
-val tclSHOWHYPS      : tactic -> tactic
 val tclTHENTRY       : tactic -> tactic -> tactic
 val tclMAP           : ('a -> tactic) -> 'a list -> tactic
 


### PR DESCRIPTION
As argued in #12423 this tactic is better defined as a toplevel command. The only user in the wild seems to be a fairly specific feature of ProofGeneral allowing to autofill the names that will be introduced by a tactic, and even there it's fairly buggy.

I'd like some confirmation that it works as intended by the PG people (@Matafou, @cpitclaudel ?)

- <s>[x] Added **changelog**.</s> Removed
- [x] Added / updated **documentation**.
- [x] Updated **documented syntax** by running `make -f Makefile.make doc_gram_rsts`.
