### PR TITLE
Finer types for the INTERPRETED BY macro 

### DIFF
--- a/coqpp/coqpp_ast.mli
+++ b/coqpp/coqpp_ast.mli
@@ -138,7 +138,7 @@ type argument_ext = {
   argext_name : string;
   argext_rules : tactic_rule list;
   argext_type : argument_type option;
-  argext_interp : code option;
+  argext_interp : (string option * code) option;
   argext_glob : code option;
   argext_subst : code option;
   argext_rprinter : code option;

--- a/coqpp/coqpp_main.ml
+++ b/coqpp/coqpp_main.ml
@@ -576,8 +576,10 @@ let print_ast fmt arg =
     fprintf fmt "@[Tacentries.ArgSubstFun (fun s v -> v)@]"
   in
   let interp fmt () = match arg.argext_interp, arg.argext_type with
-  | Some f, (None | Some _) ->
+  | Some (None, f), (None | Some _) ->
     fprintf fmt "@[Tacentries.ArgInterpLegacy (%a)@]" print_code f
+  | Some (Some kind, f), (None | Some _) ->
+    fatal (Printf.sprintf "Unknown kind %s of interpretation function" kind)
   | None, Some t ->
     fprintf fmt "@[Tacentries.ArgInterpWit (%a)@]" print_wit t
   | None, None ->

--- a/coqpp/coqpp_main.ml
+++ b/coqpp/coqpp_main.ml
@@ -577,6 +577,8 @@ let print_ast fmt arg =
   in
   let interp fmt () = match arg.argext_interp, arg.argext_type with
   | Some (None, f), (None | Some _) ->
+    fprintf fmt "@[Tacentries.ArgInterpSimple (%a)@]" print_code f
+  | Some (Some "legacy", f), (None | Some _) ->
     fprintf fmt "@[Tacentries.ArgInterpLegacy (%a)@]" print_code f
   | Some (Some kind, f), (None | Some _) ->
     fatal (Printf.sprintf "Unknown kind %s of interpretation function" kind)

--- a/coqpp/coqpp_parse.mly
+++ b/coqpp/coqpp_parse.mly
@@ -156,9 +156,14 @@ glob_printed_opt:
 | GLOB_PRINTED BY CODE { Some $3 }
 ;
 
+interpreted_modifier_opt:
+| { None }
+| LBRACKET IDENT RBRACKET { Some $2 }
+;
+
 interpreted_opt:
 | { None }
-| INTERPRETED BY CODE { Some $3 }
+| INTERPRETED interpreted_modifier_opt BY CODE { Some ($2,$4) }
 ;
 
 globalized_opt:

--- a/dev/ci/user-overlays/15119-ppedrot-vernac-arg-finer-interp-type.sh
+++ b/dev/ci/user-overlays/15119-ppedrot-vernac-arg-finer-interp-type.sh
@@ -1,0 +1,5 @@
+overlay elpi https://github.com/ppedrot/coq-elpi vernac-arg-finer-interp-type 15119
+
+overlay equations https://github.com/ppedrot/Coq-Equations vernac-arg-finer-interp-type 15119
+
+overlay mtac2 https://github.com/ppedrot/Mtac2 vernac-arg-finer-interp-type 15119

--- a/plugins/ltac/extraargs.mlg
+++ b/plugins/ltac/extraargs.mlg
@@ -107,14 +107,12 @@ let int_list_of_VList v = match Value.to_list v with
 | Some l -> List.map (fun n -> coerce_to_int n) l
 | _ -> raise (CannotCoerceTo "an integer")
 
-let interp_occs ist gl l =
+let interp_occs ist env sigma l =
   match l with
     | ArgArg x -> x
     | ArgVar ({ CAst.v = id } as locid) ->
         (try int_list_of_VList (Id.Map.find id ist.lfun)
           with Not_found | CannotCoerceTo _ -> [interp_int ist locid])
-let interp_occs ist gl l =
-  Tacmach.project gl , interp_occs ist gl l
 
 let glob_occs ist l = l
 
@@ -146,7 +144,7 @@ let pr_gen env sigma prc _prlc _prtac x = prc env sigma x
 let pr_globc env sigma _prc _prlc _prtac (_,glob) =
   Printer.pr_glob_constr_env env sigma glob
 
-let interp_glob ist gl (t,_) = Tacmach.project gl , (ist,t)
+let interp_glob ist env sigma (t,_) = (ist,t)
 
 let glob_glob = Tacintern.intern_constr
 
@@ -203,7 +201,7 @@ let interp_casted_constr ist gl c =
 ARGUMENT EXTEND casted_constr
   TYPED AS constr
   PRINTED BY { pr_gen env sigma }
-  INTERPRETED BY { interp_casted_constr }
+  INTERPRETED [ legacy ] BY { interp_casted_constr }
 | [ constr(c) ] -> { c }
 END
 
@@ -233,9 +231,6 @@ let intern_place ist = function
 let interp_place ist env sigma = function
     ConclLocation () -> ConclLocation ()
   | HypLocation (id,hl) -> HypLocation (Tacinterp.interp_hyp ist env sigma id,hl)
-
-let interp_place ist gl p =
-  Tacmach.project gl , interp_place ist (Tacmach.pf_env gl) (Tacmach.project gl) p
 
 let subst_place subst pl = pl
 
@@ -360,8 +355,8 @@ let intern_strategy ist v = match v with
 
 let subst_strategy _ v = v
 
-let interp_strategy ist gl = function
-| ArgArg n -> gl.Evd.sigma, n
+let interp_strategy ist env sigma = function
+| ArgArg n -> n
 | ArgVar { CAst.v = id; CAst.loc } ->
   let v =
     try Id.Map.find id ist.lfun
@@ -373,7 +368,7 @@ let interp_strategy ist gl = function
     try Tacinterp.Value.cast (Genarg.topwit wit_strategy_level) v
     with CErrors.UserError _ -> Taccoerce.error_ltac_variable ?loc id None v "a strategy_level"
   in
-  gl.Evd.sigma, v
+  v
 
 let pr_loc_strategy _ _ _ v = Pputils.pr_or_var Conv_oracle.pr_level v
 

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -655,8 +655,6 @@ let subst_hole_with_term occ tc t =
   in
   substrec t
 
-open Tacmach
-
 let hResolve id c occ t =
   Proofview.Goal.enter begin fun gl ->
   let sigma = Proofview.Goal.sigma gl in
@@ -1008,9 +1006,8 @@ ARGUMENT EXTEND comparison PRINTED BY { pr_cmp' }
 
 {
 
-let interp_test ist gls = function
+let interp_test ist env sigma = function
   | Test (c,x,y) ->
-      project gls ,
       Test(c,Tacinterp.interp_int_or_var ist x,Tacinterp.interp_int_or_var ist y)
 
 }

--- a/plugins/ltac/g_rewrite.mlg
+++ b/plugins/ltac/g_rewrite.mlg
@@ -19,7 +19,6 @@ open Glob_term
 open Genintern
 open Geninterp
 open Extraargs
-open Tacmach
 open Rewrite
 open Stdarg
 open Tactypes
@@ -44,7 +43,7 @@ let pr_glob_constr_with_bindings_sign env sigma _ _ _ (ge : glob_constr_with_bin
 let pr_glob_constr_with_bindings env sigma _ _ _ (ge : glob_constr_with_bindings) =
   Printer.pr_glob_constr_env env sigma (fst (fst ge))
 let pr_constr_expr_with_bindings env sigma prc _ _ (ge : constr_expr_with_bindings) = prc env sigma (fst ge)
-let interp_glob_constr_with_bindings ist gl c = Tacmach.project gl , (ist, c)
+let interp_glob_constr_with_bindings ist _ _ c = (ist, c)
 let glob_glob_constr_with_bindings ist l = Tacintern.intern_constr_with_bindings ist l
 let subst_glob_constr_with_bindings s c =
   Tacsubst.subst_glob_with_bindings s c
@@ -69,9 +68,8 @@ END
 type raw_strategy = (constr_expr, Tacexpr.raw_red_expr) strategy_ast
 type glob_strategy = (glob_constr_and_expr, Tacexpr.glob_red_expr) strategy_ast
 
-let interp_strategy ist gl s =
-  let sigma = project gl in
-    sigma, strategy_of_ast ist s
+let interp_strategy ist env sigma s =
+    strategy_of_ast ist s
 let glob_strategy ist s = map_strategy (Tacintern.intern_constr ist) (Tacintern.intern_red_expr ist) s
 let subst_strategy s str = str
 

--- a/plugins/ltac/tacentries.mli
+++ b/plugins/ltac/tacentries.mli
@@ -156,6 +156,8 @@ type ('b, 'c) argument_interp =
 | ArgInterpRet : ('c, 'c) argument_interp
 | ArgInterpFun : ('b, Geninterp.Val.t) Geninterp.interp_fun -> ('b, 'c) argument_interp
 | ArgInterpWit : ('a, 'b, 'r) Genarg.genarg_type -> ('b, 'c) argument_interp
+| ArgInterpSimple :
+  (Geninterp.interp_sign -> Environ.env -> Evd.evar_map -> 'b -> 'c) -> ('b, 'c) argument_interp
 | ArgInterpLegacy :
   (Geninterp.interp_sign -> Goal.goal Evd.sigma -> 'b -> Evd.evar_map * 'c) -> ('b, 'c) argument_interp
 

--- a/plugins/ltac/tacinterp.mli
+++ b/plugins/ltac/tacinterp.mli
@@ -145,5 +145,10 @@ val interp_int : interp_sign -> lident -> int
 
 val interp_int_or_var : interp_sign -> int Locus.or_var -> int
 
+val interp_ident : interp_sign -> Environ.env -> Evd.evar_map -> Id.t -> Id.t
+
+val interp_intro_pattern : interp_sign -> Environ.env -> Evd.evar_map ->
+  glob_constr_and_expr intro_pattern_expr CAst.t -> intro_pattern
+
 val default_ist : unit -> Geninterp.interp_sign
 (** Empty ist with debug set on the current value. *)

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -138,7 +138,7 @@ val interp_term :
 val interp_wit :
   ('a, 'b, 'c) genarg_type -> ist -> goal sigma -> 'b -> evar_map * 'c
 
-val interp_hyp : ist -> goal sigma -> ssrhyp -> evar_map * ssrhyp
+val interp_hyp : ist -> env -> evar_map -> ssrhyp -> ssrhyp
 val interp_hyps : ist -> goal sigma -> ssrhyps -> evar_map * ssrhyps
 
 val interp_refine :
@@ -166,8 +166,7 @@ val mk_lterm : constr_expr -> ssrterm
 val mk_ast_closure_term :
   [ `None | `Parens | `DoubleParens | `At ] ->
   Constrexpr.constr_expr -> ast_closure_term
-val interp_ast_closure_term : Geninterp.interp_sign -> Goal.goal
-Evd.sigma -> ast_closure_term -> Evd.evar_map * ast_closure_term
+val interp_ast_closure_term : Geninterp.interp_sign -> env -> evar_map -> ast_closure_term -> ast_closure_term
 val subst_ast_closure_term : Mod_subst.substitution -> ast_closure_term -> ast_closure_term
 val glob_ast_closure_term : Genintern.glob_sign -> ast_closure_term -> ast_closure_term
 val ssrterm_of_ast_closure_term : ast_closure_term -> ssrterm

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -22,7 +22,6 @@ open Stdarg
 open Tacarg
 open Libnames
 open Tactics
-open Tacmach
 open Util
 open Locus
 open Tacexpr
@@ -217,11 +216,11 @@ let intern_ssrhoi ist = function
     let _ = Tacintern.intern_genarg ist (in_gen (rawwit wit_ident) id) in
     hyp
 
-let interp_ssrhoi ist gl = function
-  | Hyp h -> let s, h' = interp_hyp ist gl h in s, Hyp h'
+let interp_ssrhoi ist env sigma = function
+  | Hyp h -> let h' = interp_hyp ist env sigma h in Hyp h'
   | Id (SsrHyp (loc, id)) ->
-    let s, id' = interp_wit wit_ident ist gl id in
-    s, Id (SsrHyp (loc, id'))
+    let id' = Tacinterp.interp_ident ist env sigma id in
+    Id (SsrHyp (loc, id'))
 
 }
 
@@ -370,8 +369,7 @@ let mk_index ?loc = function
   | ArgArg i -> ArgArg (check_index ?loc i)
   | iv -> iv
 
-let interp_index ist gl idx =
-  Tacmach.project gl,
+let interp_index ist env sigma idx =
   match idx with
   | ArgArg _ -> idx
   | ArgVar id ->
@@ -383,7 +381,7 @@ let interp_index ist gl idx =
         | None ->
         begin match Tacinterp.Value.to_constr v with
         | Some c ->
-          let rc = Detyping.detype Detyping.Now false Id.Set.empty (pf_env gl) (project gl) c in
+          let rc = Detyping.detype Detyping.Now false Id.Set.empty env sigma c in
           begin match Notation.uninterp_prim_token rc (None, []) with
           | Constrexpr.Number n, _ when NumTok.Signed.is_int n ->
             int_of_string (NumTok.Signed.to_string n)
@@ -525,7 +523,7 @@ let glob_ssrterm gs = function
   | k, (_, Some c) -> k, Tacintern.intern_constr gs c
   | ct -> ct
 let subst_ssrterm s (k, c) = k, Tacsubst.subst_glob_constr_and_expr s c
-let interp_ssrterm _ gl t = Tacmach.project gl, t
+let interp_ssrterm _ _ _ t = t
 
 open Pcoq.Constr
 
@@ -678,11 +676,11 @@ let intern_ipat ist =
 
 let intern_ipats ist = List.map (intern_ipat ist)
 
-let interp_intro_pattern = interp_wit wit_intro_pattern
+let interp_intro_pattern = Tacinterp.interp_intro_pattern
 
-let interp_introid ist gl id =
- try IntroNaming (IntroIdentifier (hyp_id (snd (interp_hyp ist gl (SsrHyp (Loc.tag id))))))
- with _ -> (snd (interp_intro_pattern ist gl (CAst.make @@ IntroNaming (IntroIdentifier id)))).CAst.v
+let interp_introid ist env sigma id =
+ try IntroNaming (IntroIdentifier (hyp_id (interp_hyp ist env sigma (SsrHyp (Loc.tag id)))))
+ with _ -> (interp_intro_pattern ist env sigma (CAst.make @@ IntroNaming (IntroIdentifier id))).CAst.v
 
 let get_intro_id = function
   | IntroNaming (IntroIdentifier id) -> id
@@ -710,28 +708,28 @@ let rec add_intro_pattern_hyps ipat hyps =
 
 (* We interp the ipat using the standard ltac machinery for ids, since
  * we have no clue what a name could be bound to (maybe another ipat) *)
-let interp_ipat ist gl =
+let interp_ipat ist env sigma =
   let ltacvar id = Id.Map.mem id ist.Tacinterp.lfun in
   let interp_block = function
     | Prefix id when ltacvar id ->
-        begin match interp_introid ist gl id with
+        begin match interp_introid ist env sigma id with
         | IntroNaming (IntroIdentifier id) -> Prefix id
         | _ -> Ssrcommon.errorstrm Pp.(str"Variable " ++ Id.print id ++ str" in block intro pattern should be bound to an identifier.")
         end
     | SuffixId id when ltacvar id ->
-        begin match interp_introid ist gl id with
+        begin match interp_introid ist env sigma id with
         | IntroNaming (IntroIdentifier id) -> SuffixId id
         | _ -> Ssrcommon.errorstrm Pp.(str"Variable " ++ Id.print id ++ str" in block intro pattern should be bound to an identifier.")
         end
     | x -> x in
   let rec interp = function
   | IPatId id when ltacvar id ->
-    ipat_of_intro_pattern (interp_introid ist gl id)
+    ipat_of_intro_pattern (interp_introid ist env sigma id)
   | IPatId _ as x -> x
   | IPatClear clr ->
     let add_hyps (SsrHyp (loc, id) as hyp) hyps =
       if not (ltacvar id) then hyp :: hyps else
-      add_intro_pattern_hyps CAst.(make ?loc (interp_introid ist gl id)) hyps in
+      add_intro_pattern_hyps CAst.(make ?loc (interp_introid ist env sigma id)) hyps in
     let clr' = List.fold_right add_hyps clr [] in
     check_hyps_uniq [] clr';
     IPatClear clr'
@@ -745,14 +743,14 @@ let interp_ipat ist gl =
 
   | IPatInj iorpat -> IPatInj (List.map (List.map interp) iorpat)
   | IPatAbstractVars l ->
-     IPatAbstractVars (List.map get_intro_id (List.map (interp_introid ist gl) l))
-  | IPatView l -> IPatView (List.map (fun x -> snd(interp_ast_closure_term ist
-     gl x)) l)
+     IPatAbstractVars (List.map get_intro_id (List.map (interp_introid ist env sigma) l))
+  | IPatView l -> IPatView (List.map (fun x -> interp_ast_closure_term ist
+     env sigma x) l)
   | (IPatSimpl _ | IPatAnon _ | IPatRewrite _ | IPatNoop | IPatFastNondep) as x -> x
     in
   interp
 
-let interp_ipats ist gl l = project gl, List.map (interp_ipat ist gl) l
+let interp_ipats ist env sigma l = List.map (interp_ipat ist env sigma) l
 
 let pushIPatRewrite = function
   | pats :: orpat -> (IPatRewrite (allocc, L2R) :: pats) :: orpat

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -919,7 +919,7 @@ let interp_rpattern s = function
   | E_As_X_In_T(e,x,t) ->
     E_As_X_In_T (interp_ssrterm s e,interp_ssrterm s x,interp_ssrterm s t)
 
-let interp_rpattern0 ist gl t = Tacmach.project gl, interp_rpattern ist t
+let interp_rpattern0 ist _ _ t = interp_rpattern ist t
 
 let tag_of_cpattern p = p.kind
 let loc_of_cpattern = loc_ofCG
@@ -949,7 +949,7 @@ let interp_open_constr ist env sigma gc =
   Tacinterp.interp_open_constr ist env sigma gc
 let pf_intern_term env sigma {pattern = c; interpretation = ist; _} = glob_constr ist env sigma c
 
-let interp_ssrterm ist gl t = Tacmach.project gl, interp_ssrterm ist t
+let interp_ssrterm ist env sigma t = interp_ssrterm ist t
 
 let interp_term env sigma = function
   | {pattern = c; interpretation = Some ist; _} ->

--- a/plugins/ssrmatching/ssrmatching.mli
+++ b/plugins/ssrmatching/ssrmatching.mli
@@ -243,7 +243,7 @@ sig
   val wit_rpatternty : (rpattern, rpattern, rpattern) Genarg.genarg_type
   val glob_rpattern : Genintern.glob_sign -> rpattern -> rpattern
   val subst_rpattern : Mod_subst.substitution -> rpattern -> rpattern
-  val interp_rpattern : Geninterp.interp_sign -> Goal.goal Evd.sigma -> rpattern -> Evd.evar_map * rpattern
+  val interp_rpattern : Geninterp.interp_sign -> env -> evar_map -> rpattern -> rpattern
   val pr_rpattern : rpattern -> Pp.t
   val mk_rpattern : (cpattern, cpattern) ssrpattern -> rpattern
   val mk_lterm : Constrexpr.constr_expr -> Geninterp.interp_sign option -> cpattern
@@ -251,7 +251,7 @@ sig
 
   val glob_cpattern : Genintern.glob_sign -> cpattern -> cpattern
   val subst_ssrterm : Mod_subst.substitution -> cpattern -> cpattern
-  val interp_ssrterm : Geninterp.interp_sign -> Goal.goal Evd.sigma -> cpattern -> Evd.evar_map * cpattern
+  val interp_ssrterm : Geninterp.interp_sign -> env -> evar_map -> cpattern -> cpattern
   val pr_ssrterm : cpattern -> Pp.t
 end
 


### PR DESCRIPTION
In order to make progress on the deprecation of legacy API, we introduce a new modifier syntax for the `INTERPRETED BY` macro. The type of the block depends on the optional modifier.

We also change the default interpretation to a simpler one where instead of taking a goal and an evarmap and returning a modified evarmap, we simply read the environment and the evarmap. The old behaviour is available via the `[legacy]` modifier. As witnessed by the PR, there is only a single argument in the whole Coq codebase where we actually need the additional power provided by the legacy interpretation. (For the curious, it's for `exact t` where `t` is type-checked against the conclusion).

Let's see what the CI gives.

Overlays
- https://github.com/LPCIC/coq-elpi/pull/303
- https://github.com/mattam82/Coq-Equations/pull/443
- https://github.com/Mtac2/Mtac2/pull/348