### PR TITLE
ssr: make have-like tactics compatible with SProp

### DIFF
--- a/doc/changelog/06-ssreflect/15121-ssr-cut.rst
+++ b/doc/changelog/06-ssreflect/15121-ssr-cut.rst
@@ -1,0 +1,4 @@
+- **Fixed:**
+  :tacn:`have`, :tacn:`suff` and :tacn:`wlog` support goals in `sProp`
+  (`#15121 <https://github.com/coq/coq/pull/15121>`_,
+  by Enrico Tassi).

--- a/plugins/ssr/ssrfwd.mli
+++ b/plugins/ssr/ssrfwd.mli
@@ -29,7 +29,8 @@ val havetac : ist ->
            bool ->
            bool -> unit Proofview.tactic
 
-val basecuttac : string -> EConstr.t -> unit Proofview.tactic
+type cut_kind = Have | HaveTransp | Suff
+val basecuttac : cut_kind -> EConstr.t -> unit Proofview.tactic
 
 val basesufftac : EConstr.t -> unit Proofview.tactic
 

--- a/test-suite/output/section_have.out
+++ b/test-suite/output/section_have.out
@@ -1,0 +1,4 @@
+toto = (fun y : True => conj y y) I
+     : True /\ True
+toto = (fun y : True => conj y y) I
+     : True /\ True

--- a/test-suite/output/section_have.v
+++ b/test-suite/output/section_have.v
@@ -1,0 +1,16 @@
+Require Import ssreflect.
+
+Section Foo.
+Variable x : nat.
+
+Lemma toto : True /\ True.
+Proof.
+  have y : True by [].
+  by split.
+Qed.
+
+Print toto.
+
+End Foo.
+
+Print toto.

--- a/test-suite/ssr/have_TC.v
+++ b/test-suite/ssr/have_TC.v
@@ -48,3 +48,10 @@ have totoc (H : bar _ 5) : 3 = 3 := eq_refl.
 move/totoc: nat => _.
 exact I.
 Qed.
+
+Unset SsrHave NoTCResolution.
+
+Instance test : foo bool.
+Proof.
+  have : foo nat.
+Abort.

--- a/test-suite/ssr/have_transp.v
+++ b/test-suite/ssr/have_transp.v
@@ -46,3 +46,10 @@ Proof.
 have @h m : 'I_(n+m).+1 by apply: (Sub 0); abstract auto.
 by [].
 Qed.
+
+Lemma test5 : True.
+Proof.
+have @t : nat := 3.
+have : t = 3 by [].
+by [].
+Qed.

--- a/test-suite/ssr/ssr_sProp.v
+++ b/test-suite/ssr/ssr_sProp.v
@@ -1,0 +1,6 @@
+Require Import ssreflect StrictProp.
+
+Goal True.
+have h := (fun x : sEmpty => x).
+constructor.
+Qed.

--- a/theories/ssr/ssreflect.v
+++ b/theories/ssr/ssreflect.v
@@ -459,27 +459,6 @@ Canonical locked_with_unlockable T k x :=
 Lemma unlock_with T k x : unlocked (locked_with_unlockable k x) = x :> T.
 Proof. exact: unlock. Qed.
 
-(**  The internal lemmas for the have tactics.  **)
-
-Definition ssr_have Plemma Pgoal (step : Plemma) rest : Pgoal := rest step.
-Arguments ssr_have Plemma [Pgoal].
-
-Definition ssr_have_let Pgoal Plemma step
-  (rest : let x : Plemma := step in Pgoal) : Pgoal := rest.
-Arguments ssr_have_let [Pgoal].
-
-Register ssr_have as plugins.ssreflect.ssr_have.
-Register ssr_have_let as plugins.ssreflect.ssr_have_let.
-
-Definition ssr_suff Plemma Pgoal step (rest : Plemma) : Pgoal := step rest.
-Arguments ssr_suff Plemma [Pgoal].
-
-Definition ssr_wlog := ssr_suff.
-Arguments ssr_wlog Plemma [Pgoal].
-
-Register ssr_suff as plugins.ssreflect.ssr_suff.
-Register ssr_wlog as plugins.ssreflect.ssr_wlog.
-
 (**  Internal N-ary congruence lemmas for the congr tactic.  **)
 
 Fixpoint nary_congruence_statement (n : nat)


### PR DESCRIPTION
In this PR we replace the use of ssr_have, ssr_have_let and ssr_wlog to implement the corresponding tactics, since one would need proper sort polymorphism to use them on all current sorts at once (including `SProp`). Instead we build proof terms directly (beta redex).

CC @kyoDralliam 