### PR TITLE
Move tactic code out of Extratactics into Internals.

### DIFF
--- a/plugins/funind/g_indfun.mlg
+++ b/plugins/funind/g_indfun.mlg
@@ -99,7 +99,7 @@ let functional_induction b c x pat =
 TACTIC EXTEND newfunind
 | ["functional" "induction" lconstr(c) fun_ind_using(princl) with_names(pat)] ->
    {
-     (Extratactics.onSomeWithHoles
+     (Ltac_plugin.Internals.onSomeWithHoles
           (fun x -> functional_induction true c x pat) princl)
    }
 
@@ -113,7 +113,7 @@ TACTIC EXTEND snewfunind
          | [c] -> c
          | c::cl -> EConstr.applist(c,cl)
        in
-       Extratactics.onSomeWithHoles (fun x -> functional_induction false c x pat) princl }
+       Ltac_plugin.Internals.onSomeWithHoles (fun x -> functional_induction false c x pat) princl }
 END
 
 {

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -11,8 +11,6 @@
 {
 
 open Pp
-open Constr
-open Context
 open Genarg
 open Stdarg
 open Tacarg
@@ -20,15 +18,10 @@ open Extraargs
 open Pltac
 open Mod_subst
 open Names
-open Tacexpr
-open Glob_ops
 open CErrors
 open Util
-open Termops
 open Equality
-open Namegen
 open Tactypes
-open Tactics
 open Proofview.Notations
 open Attributes
 open Vernacextend
@@ -37,111 +30,47 @@ open Vernacextend
 
 DECLARE PLUGIN "ltac_plugin"
 
-{
-
-(**********************************************************************)
-(* replace, discriminate, injection, simplify_eq                      *)
-(* cutrewrite, dependent rewrite                                      *)
-
-let with_delayed_uconstr ist c tac =
-  let flags = {
-    Pretyping.use_typeclasses = Pretyping.NoUseTC;
-    solve_unification_constraints = true;
-    fail_evar = false;
-    expand_evars = true;
-    program_mode = false;
-    polymorphic = false;
- } in
-  let c = Tacinterp.type_uconstr ~flags ist c in
-  Tacticals.New.tclDELAYEDWITHHOLES false c tac
-
-let replace_in_clause_maybe_by ist c1 c2 cl tac =
-  with_delayed_uconstr ist c1
-  (fun c1 -> replace_in_clause_maybe_by c1 c2 cl (Option.map (Tacinterp.tactic_of_value ist) tac))
-
-let replace_term ist dir_opt c cl =
-  with_delayed_uconstr ist c (fun c -> replace_term dir_opt c cl)
-
-}
-
 TACTIC EXTEND replace
 | ["replace" uconstr(c1) "with" constr(c2) clause(cl) by_arg_tac(tac) ]
--> { replace_in_clause_maybe_by ist c1 c2 cl tac }
+-> { Internals.replace_in_clause_maybe_by ist c1 c2 cl tac }
 END
 
 TACTIC EXTEND replace_term_left
 | [ "replace"  "->" uconstr(c) clause(cl) ]
-  -> { replace_term ist (Some true) c cl }
+  -> { Internals.replace_term ist (Some true) c cl }
 END
 
 TACTIC EXTEND replace_term_right
 | [ "replace"  "<-" uconstr(c) clause(cl) ]
-  -> { replace_term ist (Some false) c cl }
+  -> { Internals.replace_term ist (Some false) c cl }
 END
 
 TACTIC EXTEND replace_term
 | [ "replace" uconstr(c) clause(cl) ]
-  -> { replace_term ist None c cl }
+  -> { Internals.replace_term ist None c cl }
 END
-
-{
-
-let induction_arg_of_quantified_hyp = function
-  | AnonHyp n -> None,ElimOnAnonHyp n
-  | NamedHyp id -> None,ElimOnIdent id
-
-(* Versions *_main must come first!! so that "1" is interpreted as a
-   ElimOnAnonHyp and not as a "constr", and "id" is interpreted as a
-   ElimOnIdent and not as "constr" *)
-
-let mytclWithHoles tac with_evars c =
-  Proofview.Goal.enter begin fun gl ->
-    let env = Tacmach.New.pf_env gl in
-    let sigma = Tacmach.New.project gl in
-    let sigma',c = Tactics.force_destruction_arg with_evars env sigma c in
-    Tacticals.New.tclWITHHOLES with_evars (tac with_evars (Some c)) sigma'
-  end
-
-let elimOnConstrWithHoles tac with_evars c =
-  Tacticals.New.tclDELAYEDWITHHOLES with_evars c
-    (fun c -> tac with_evars (Some (None,ElimOnConstr c)))
-
-}
 
 TACTIC EXTEND simplify_eq
 | [ "simplify_eq" ] -> { dEq ~keep_proofs:None false None }
-| [ "simplify_eq" destruction_arg(c) ] -> { mytclWithHoles (dEq ~keep_proofs:None) false c }
+| [ "simplify_eq" destruction_arg(c) ] -> { Internals.mytclWithHoles (dEq ~keep_proofs:None) false c }
 END
 TACTIC EXTEND esimplify_eq
 | [ "esimplify_eq" ] -> { dEq ~keep_proofs:None true None }
-| [ "esimplify_eq" destruction_arg(c) ] -> { mytclWithHoles (dEq ~keep_proofs:None) true c }
+| [ "esimplify_eq" destruction_arg(c) ] -> { Internals.mytclWithHoles (dEq ~keep_proofs:None) true c }
 END
-
-{
-
-let discr_main c = elimOnConstrWithHoles discr_tac false c
-
-}
 
 TACTIC EXTEND discriminate
 | [ "discriminate" ] -> { discr_tac false None }
 | [ "discriminate" destruction_arg(c) ] ->
-    { mytclWithHoles discr_tac false c }
+    { Internals.mytclWithHoles discr_tac false c }
 END
 TACTIC EXTEND ediscriminate
 | [ "ediscriminate" ] -> { discr_tac true None }
 | [ "ediscriminate" destruction_arg(c) ] ->
-    { mytclWithHoles discr_tac true c }
+    { Internals.mytclWithHoles discr_tac true c }
 END
 
 {
-
-let discrHyp id =
-  Proofview.tclEVARMAP >>= fun sigma ->
-  discr_main (fun env sigma -> (sigma, (EConstr.mkVar id, NoBindings)))
-
-let injection_main with_evars c =
- elimOnConstrWithHoles (injClause None None) with_evars c
 
 let isInjPat pat = match pat.CAst.v with IntroAction (IntroInjection _) -> Some pat.CAst.loc | _ -> None
 
@@ -164,36 +93,28 @@ let decode_inj_ipat ?loc = function
 
 TACTIC EXTEND injection
 | [ "injection" ] -> { injClause None None false None }
-| [ "injection" destruction_arg(c) ] -> { mytclWithHoles (injClause None None) false c }
+| [ "injection" destruction_arg(c) ] -> { Internals.mytclWithHoles (injClause None None) false c }
 END
 TACTIC EXTEND einjection
 | [ "einjection" ] -> { injClause None None true None }
-| [ "einjection" destruction_arg(c) ] -> { mytclWithHoles (injClause None None) true c }
+| [ "einjection" destruction_arg(c) ] -> { Internals.mytclWithHoles (injClause None None) true c }
 END
 TACTIC EXTEND injection_as
 | [ "injection" "as" simple_intropattern_list(ipat)] ->
     { injClause None (Some (decode_inj_ipat ipat)) false None }
 | [ "injection" destruction_arg(c) "as" simple_intropattern_list(ipat)] ->
-    { mytclWithHoles (injClause None (Some (decode_inj_ipat ipat))) false c }
+    { Internals.mytclWithHoles (injClause None (Some (decode_inj_ipat ipat))) false c }
 END
 TACTIC EXTEND einjection_as
 | [ "einjection" "as" simple_intropattern_list(ipat)] ->
     { injClause None (Some (decode_inj_ipat ipat)) true None }
 | [ "einjection" destruction_arg(c) "as" simple_intropattern_list(ipat)] ->
-    { mytclWithHoles (injClause None (Some (decode_inj_ipat ipat))) true c }
+    { Internals.mytclWithHoles (injClause None (Some (decode_inj_ipat ipat))) true c }
 END
 TACTIC EXTEND simple_injection
 | [ "simple" "injection" ] -> { simpleInjClause None false None }
-| [ "simple" "injection" destruction_arg(c) ] -> { mytclWithHoles (simpleInjClause None) false c }
+| [ "simple" "injection" destruction_arg(c) ] -> { Internals.mytclWithHoles (simpleInjClause None) false c }
 END
-
-{
-
-let injHyp id =
-  Proofview.tclEVARMAP >>= fun sigma ->
-  injection_main false (fun env sigma -> (sigma, (EConstr.mkVar id, NoBindings)))
-
-}
 
 TACTIC EXTEND dependent_rewrite
 | [ "dependent" "rewrite" orient(b) constr(c) ] -> { rewriteInConcl b c }
@@ -231,17 +152,9 @@ TACTIC EXTEND absurd
 | [ "absurd" constr(c) ] -> { absurd c }
 END
 
-{
-
-let onSomeWithHoles tac = function
-  | None -> tac None
-  | Some c -> Tacticals.New.tclDELAYEDWITHHOLES false c (fun c -> tac (Some c))
-
-}
-
 TACTIC EXTEND contradiction
 | [ "contradiction" constr_with_bindings_opt(c) ] ->
-    { onSomeWithHoles contradiction c }
+    { Internals.onSomeWithHoles contradiction c }
 END
 
 (**********************************************************************)
@@ -276,7 +189,7 @@ END
 
 let rewrite_star ist clause orient occs c (tac : Geninterp.Val.t option) =
   let tac' = Option.map (fun t -> Tacinterp.tactic_of_value ist t, FirstSolved) tac in
-  with_delayed_uconstr ist c
+  Internals.with_delayed_uconstr ist c
     (fun c -> general_rewrite ~where:clause ~l2r:orient occs ?tac:tac' ~freeze:true ~dep:true ~with_evars:true (c,NoBindings))
 
 }
@@ -339,58 +252,24 @@ END
 (**********************************************************************)
 (* Refine                                                             *)
 
-{
-
-open EConstr
-open Vars
-
-let constr_flags () = {
-  Pretyping.use_typeclasses = Pretyping.UseTC;
-  Pretyping.solve_unification_constraints = Proof.use_unification_heuristics ();
-  Pretyping.fail_evar = false;
-  Pretyping.expand_evars = true;
-  Pretyping.program_mode = false;
-  Pretyping.polymorphic = false;
-}
-
-let refine_tac ist simple with_classes c =
-  Proofview.Goal.enter begin fun gl ->
-    let concl = Proofview.Goal.concl gl in
-    let env = Proofview.Goal.env gl in
-    let flags =
-      { (constr_flags ()) with Pretyping.use_typeclasses = with_classes } in
-    let expected_type = Pretyping.OfType concl in
-    let c = Tacinterp.type_uconstr ~flags ~expected_type ist c in
-    let update = begin fun sigma ->
-      c env sigma
-    end in
-    let refine = Refine.refine ~typecheck:false update in
-    if simple then refine
-    else refine <*>
-           Tactics.New.reduce_after_refine <*>
-           Proofview.shelve_unifiable
-  end
-
-}
-
 TACTIC EXTEND refine
 | [ "refine" uconstr(c) ] ->
-   { refine_tac ist false Pretyping.UseTC c }
+   { Internals.refine_tac ist ~simple:false ~with_classes:true c }
 END
 
 TACTIC EXTEND simple_refine
 | [ "simple" "refine" uconstr(c) ] ->
-   { refine_tac ist true Pretyping.UseTC c }
+   { Internals.refine_tac ist ~simple:true ~with_classes:true c }
 END
 
 TACTIC EXTEND notcs_refine
 | [ "notypeclasses" "refine" uconstr(c) ] ->
-   { refine_tac ist false Pretyping.NoUseTC c }
+   { Internals.refine_tac ist ~simple:false ~with_classes:false c }
 END
 
 TACTIC EXTEND notcs_simple_refine
 | [ "simple" "notypeclasses" "refine" uconstr(c) ] ->
-   { refine_tac ist true Pretyping.NoUseTC c }
+   { Internals.refine_tac ist ~simple:true ~with_classes:false c }
 END
 
 (* Solve unification constraints using heuristics or fail if any remain *)
@@ -501,7 +380,6 @@ END
 {
 
 open Tactics
-open Glob_term
 open Libobject
 open Lib
 
@@ -599,101 +477,9 @@ TACTIC EXTEND specialize_eqs
 | [ "specialize_eqs" hyp(id) ] -> { specialize_eqs id }
 END
 
-(**********************************************************************)
-(* A tactic that considers a given occurrence of [c] in [t] and       *)
-(* abstract the minimal set of all the occurrences of [c] so that the *)
-(* abstraction [fun x -> t[x/c]] is well-typed                        *)
-(*                                                                    *)
-(* Contributed by Chung-Kil Hur (Winter 2009)                         *)
-(**********************************************************************)
-
-{
-
-let subst_var_with_hole occ tid t =
-  let occref = if occ > 0 then ref occ else Locusops.error_invalid_occurrence [occ] in
-  let locref = ref 0 in
-  let rec substrec x = match DAst.get x with
-    | GVar id ->
-        if Id.equal id tid
-        then
-          (decr occref;
-           if Int.equal !occref 0 then x
-           else
-             (incr locref;
-              DAst.make ~loc:(Loc.make_loc (!locref,0)) @@
-              GHole (Evar_kinds.QuestionMark {
-                  Evar_kinds.qm_obligation=Evar_kinds.Define true;
-                  Evar_kinds.qm_name=Anonymous;
-                  Evar_kinds.qm_record_field=None;
-             }, IntroAnonymous, None)))
-        else x
-    | _ -> map_glob_constr_left_to_right substrec x in
-  let t' = substrec t
-  in
-  if !occref > 0 then Locusops.error_invalid_occurrence [occ] else t'
-
-let subst_hole_with_term occ tc t =
-  let locref = ref 0 in
-  let occref = ref occ in
-  let rec substrec c = match DAst.get c with
-    | GHole (Evar_kinds.QuestionMark {
-                Evar_kinds.qm_obligation=Evar_kinds.Define true;
-                Evar_kinds.qm_name=Anonymous;
-                Evar_kinds.qm_record_field=None;
-           }, IntroAnonymous, s) ->
-        decr occref;
-        if Int.equal !occref 0 then tc
-        else
-          (incr locref;
-           DAst.make ~loc:(Loc.make_loc (!locref,0)) @@
-           GHole (Evar_kinds.QuestionMark {
-               Evar_kinds.qm_obligation=Evar_kinds.Define true;
-               Evar_kinds.qm_name=Anonymous;
-               Evar_kinds.qm_record_field=None;
-          },IntroAnonymous,s))
-    | _ -> map_glob_constr_left_to_right substrec c
-  in
-  substrec t
-
-let hResolve id c occ t =
-  Proofview.Goal.enter begin fun gl ->
-  let sigma = Proofview.Goal.sigma gl in
-  let env = Termops.clear_named_body id (Proofview.Goal.env gl) in
-  let concl = Proofview.Goal.concl gl in
-  let env_ids = Termops.vars_of_env env in
-  let c_raw = Detyping.detype Detyping.Now true env_ids env sigma c in
-  let t_raw = Detyping.detype Detyping.Now true env_ids env sigma t in
-  let rec resolve_hole t_hole =
-    try
-      Pretyping.understand env sigma t_hole
-    with
-      | Pretype_errors.PretypeError (_,_,Pretype_errors.UnsolvableImplicit _) as e ->
-          let (e, info) = Exninfo.capture e in
-          let loc_begin = Option.cata (fun l -> fst (Loc.unloc l)) 0 (Loc.get_loc info) in
-          resolve_hole (subst_hole_with_term loc_begin c_raw t_hole)
-  in
-  let t_constr,ctx = resolve_hole (subst_var_with_hole occ id t_raw) in
-  let sigma = Evd.merge_universe_context sigma ctx in
-  let t_constr_type = Retyping.get_type_of env sigma t_constr in
-  Proofview.tclTHEN (Proofview.Unsafe.tclEVARS sigma)
-    (change_concl (mkLetIn (make_annot Name.Anonymous Sorts.Relevant,t_constr,t_constr_type,concl)))
-  end
-
-let hResolve_auto id c t =
-  let rec resolve_auto n =
-    try
-      hResolve id c n t
-    with
-    | UserError _ as e -> raise e
-    | e when CErrors.noncritical e -> resolve_auto (n+1)
-  in
-  resolve_auto 1
-
-}
-
 TACTIC EXTEND hresolve_core
-| [ "hresolve_core" "(" ident(id) ":=" constr(c) ")" "at" nat_or_var(occ) "in" constr(t) ] -> { hResolve id c occ t }
-| [ "hresolve_core" "(" ident(id) ":=" constr(c) ")" "in" constr(t) ] -> { hResolve_auto id c t }
+| [ "hresolve_core" "(" ident(id) ":=" constr(c) ")" "at" nat_or_var(occ) "in" constr(t) ] -> { Internals.hResolve id c occ t }
+| [ "hresolve_core" "(" ident(id) ":=" constr(c) ")" "in" constr(t) ] -> { Internals.hResolve_auto id c t }
 END
 
 (**
@@ -704,105 +490,9 @@ TACTIC EXTEND hget_evar
 | [ "hget_evar" nat_or_var(n) ] -> { Evar_tactics.hget_evar n }
 END
 
-(**********************************************************************)
-
-(**********************************************************************)
-(* A tactic that reduces one match t with ... by doing destruct t.    *)
-(* if t is not a variable, the tactic does                            *)
-(* case_eq t;intros ... heq;rewrite heq in *|-. (but heq itself is    *)
-(* preserved).                                                        *)
-(* Contributed by Julien Forest and Pierre Courtieu (july 2010)       *)
-(**********************************************************************)
-
-{
-
-exception Found of unit Proofview.tactic
-
-let rewrite_except h =
-  Proofview.Goal.enter begin fun gl ->
-  let hyps = Tacmach.New.pf_ids_of_hyps gl in
-  Tacticals.New.tclMAP (fun id -> if Id.equal id h then Proofview.tclUNIT () else
-      Tacticals.New.tclTRY (Equality.general_rewrite ~where:(Some id) ~l2r:true Locus.AllOccurrences ~freeze:true ~dep:true ~with_evars:false (mkVar h, NoBindings)))
-    hyps
-  end
-
-
-let refl_equal () = Coqlib.lib_ref "core.eq.type"
-
-(* This is simply an implementation of the case_eq tactic.  this code
-  should be replaced by a call to the tactic but I don't know how to
-  call it before it is defined. *)
-let  mkCaseEq a  : unit Proofview.tactic =
-  Proofview.Goal.enter begin fun gl ->
-    let type_of_a = Tacmach.New.pf_get_type_of gl a in
-    Tacticals.New.pf_constr_of_global (delayed_force refl_equal) >>= fun req ->
-    Tacticals.New.tclTHENLIST
-         [Tactics.generalize [(mkApp(req, [| type_of_a; a|]))];
-          Proofview.Goal.enter begin fun gl ->
-            let concl = Proofview.Goal.concl gl in
-            let env = Proofview.Goal.env gl in
-            (* FIXME: this looks really wrong. Does anybody really use
-               this tactic? *)
-            let (_, c) = Tacred.pattern_occs [Locus.OnlyOccurrences [1], a] env (Evd.from_env env) concl in
-            change_concl c
-          end;
-          simplest_case a]
-  end
-
-
-let case_eq_intros_rewrite x =
-  Proofview.Goal.enter begin fun gl ->
-  let n = nb_prod (Tacmach.New.project gl) (Proofview.Goal.concl gl) in
-  (* Pp.msgnl (Printer.pr_lconstr x); *)
-  Tacticals.New.tclTHENLIST [
-      mkCaseEq x;
-    Proofview.Goal.enter begin fun gl ->
-      let concl = Proofview.Goal.concl gl in
-      let hyps = Tacmach.New.pf_ids_set_of_hyps gl in
-      let n' = nb_prod (Tacmach.New.project gl) concl in
-      let h = fresh_id_in_env hyps (Id.of_string "heq") (Proofview.Goal.env gl)  in
-      Tacticals.New.tclTHENLIST [
-                    Tacticals.New.tclDO (n'-n-1) intro;
-                    introduction h;
-                    rewrite_except h]
-    end
-  ]
-  end
-
-let rec find_a_destructable_match sigma t =
-  let cl = induction_arg_of_quantified_hyp (NamedHyp (CAst.make @@ Id.of_string "x")) in
-  let cl = [cl, (None, None), None], None in
-  let dest = CAst.make @@ TacAtom (TacInductionDestruct(false, false, cl)) in
-  match EConstr.kind sigma t with
-    | Case (_,_,_,_,_,x,_) when closed0 sigma x ->
-        if isVar sigma x then
-          (* TODO check there is no rel n. *)
-          raise (Found (Tacinterp.eval_tactic dest))
-        else
-          (* let _ = Pp.msgnl (Printer.pr_lconstr x)  in *)
-          raise (Found (case_eq_intros_rewrite x))
-    | _ -> EConstr.iter sigma (fun c -> find_a_destructable_match sigma c) t
-
-
-let destauto t =
-  Proofview.tclEVARMAP >>= fun sigma ->
-  try find_a_destructable_match sigma t;
-    Tacticals.New.tclZEROMSG (str "No destructable match found")
-  with Found tac -> tac
-
-let destauto_in id =
-  Proofview.Goal.enter begin fun gl ->
-  let ctype = Tacmach.New.pf_get_type_of gl (mkVar id) in
-(*  Pp.msgnl (Printer.pr_lconstr (mkVar id)); *)
-(*  Pp.msgnl (Printer.pr_lconstr (ctype)); *)
-  destauto ctype
-  end
-
-}
-
 TACTIC EXTEND destauto
-| [ "destauto" ] -> { Proofview.Goal.enter begin fun gl -> destauto (Proofview.Goal.concl gl) end }
-| [ "destauto" "in" hyp(id) ] -> { destauto_in id }
+| [ "destauto" ] -> { Internals.destauto }
+| [ "destauto" "in" hyp(id) ] -> { Internals.destauto_in id }
 END
 
 (**********************************************************************)
@@ -832,106 +522,60 @@ END
 TACTIC EXTEND constr_eq_nounivs
 | [ "constr_eq_nounivs" constr(x) constr(y) ] -> {
     Proofview.tclEVARMAP >>= fun sigma ->
-    if eq_constr_nounivs sigma x y then Proofview.tclUNIT () else Tacticals.New.tclFAIL 0 (str "Not equal") }
+    if EConstr.eq_constr_nounivs sigma x y then Proofview.tclUNIT () else Tacticals.New.tclFAIL 0 (str "Not equal") }
 END
 
 TACTIC EXTEND is_evar
-| [ "is_evar" constr(x) ] -> {
-    Proofview.tclEVARMAP >>= fun sigma ->
-    match EConstr.kind sigma x with
-      | Evar _ -> Proofview.tclUNIT ()
-      | _ -> Tacticals.New.tclFAIL 0 (str "Not an evar")
-   }
+| [ "is_evar" constr(x) ] -> { Internals.is_evar x }
 END
 
 TACTIC EXTEND has_evar
-| [ "has_evar" constr(x) ] -> {
-  Proofview.tclEVARMAP >>= fun sigma ->
-  if Evarutil.has_undefined_evars sigma x
-  then Proofview.tclUNIT ()
-  else Tacticals.New.tclFAIL 0 (str "No evars")
-}
+| [ "has_evar" constr(x) ] -> { Internals.has_evar x }
 END
 
 TACTIC EXTEND is_hyp
-| [ "is_var" constr(x) ] -> {
-  Proofview.tclEVARMAP >>= fun sigma ->
-  match EConstr.kind sigma x with
-    | Var _ ->  Proofview.tclUNIT ()
-    | _ -> Tacticals.New.tclFAIL 0 (str "Not a variable or hypothesis") }
+| [ "is_var" constr(x) ] -> { Internals.is_var x }
 END
 
 TACTIC EXTEND is_fix
-| [ "is_fix" constr(x) ] -> {
-  Proofview.tclEVARMAP >>= fun sigma ->
-  match EConstr.kind sigma x with
-    | Fix _ -> Proofview.tclUNIT ()
-    | _ -> Tacticals.New.tclFAIL 0 (Pp.str "not a fix definition") }
+| [ "is_fix" constr(x) ] -> { Internals.is_fix x }
 END
 
 TACTIC EXTEND is_cofix
-| [ "is_cofix" constr(x) ] -> {
-  Proofview.tclEVARMAP >>= fun sigma ->
-  match EConstr.kind sigma x with
-    | CoFix _ -> Proofview.tclUNIT ()
-    | _ -> Tacticals.New.tclFAIL 0 (Pp.str "not a cofix definition") }
+| [ "is_cofix" constr(x) ] -> { Internals.is_cofix x }
 END
 
 TACTIC EXTEND is_ind
-| [ "is_ind" constr(x) ] -> {
-  Proofview.tclEVARMAP >>= fun sigma ->
-  match EConstr.kind sigma x with
-    | Ind _ -> Proofview.tclUNIT ()
-    | _ -> Tacticals.New.tclFAIL 0 (Pp.str "not an (co)inductive datatype") }
+| [ "is_ind" constr(x) ] -> { Internals.is_ind x }
 END
 
 TACTIC EXTEND is_constructor
-| [ "is_constructor" constr(x) ] -> {
-  Proofview.tclEVARMAP >>= fun sigma ->
-  match EConstr.kind sigma x with
-    | Construct _ -> Proofview.tclUNIT ()
-    | _ -> Tacticals.New.tclFAIL 0 (Pp.str "not a constructor") }
+| [ "is_constructor" constr(x) ] -> { Internals.is_constructor x }
 END
 
 TACTIC EXTEND is_proj
-| [ "is_proj" constr(x) ] -> {
-  Proofview.tclEVARMAP >>= fun sigma ->
-  match EConstr.kind sigma x with
-    | Proj _ -> Proofview.tclUNIT ()
-    | _ -> Tacticals.New.tclFAIL 0 (Pp.str "not a primitive projection") }
+| [ "is_proj" constr(x) ] -> { Internals.is_proj x }
 END
 
 TACTIC EXTEND is_const
-| [ "is_const" constr(x) ] -> {
-  Proofview.tclEVARMAP >>= fun sigma ->
-  match EConstr.kind sigma x with
-    | Const _ -> Proofview.tclUNIT ()
-    | _ -> Tacticals.New.tclFAIL 0 (Pp.str "not a constant") }
+| [ "is_const" constr(x) ] -> { Internals.is_const x }
 END
 
 (* Shelves all the goals under focus. *)
 TACTIC EXTEND shelve
-| [ "shelve" ] ->
-    { Proofview.shelve }
+| [ "shelve" ] -> { Proofview.shelve }
 END
 
 (* Shelves the unifiable goals under focus, i.e. the goals which
    appear in other goals under focus (the unfocused goals are not
    considered). *)
 TACTIC EXTEND shelve_unifiable
-| [ "shelve_unifiable" ] ->
-    { Proofview.shelve_unifiable }
+| [ "shelve_unifiable" ] -> { Proofview.shelve_unifiable }
 END
 
 (* Unshelves the goal shelved by the tactic. *)
 TACTIC EXTEND unshelve
-| [ "unshelve" tactic1(t) ] ->
-    {
-      Proofview.with_shelf (Tacinterp.tactic_of_value ist t) >>= fun (gls, ()) ->
-      let gls = List.map Proofview.with_empty_state gls in
-      Proofview.Unsafe.tclGETGOALS >>= fun ogls ->
-      Proofview.Unsafe.tclSETGOALS (gls @ ogls)
-   }
+| [ "unshelve" tactic1(t) ] -> { Internals.unshelve ist t }
 END
 
 (* Command to add every unshelved variables to the focus *)
@@ -1045,47 +689,19 @@ TACTIC EXTEND guard
 | [ "guard" test(tst) ] -> { guard tst }
 END
 
-{
-
-let decompose l c =
-  Proofview.Goal.enter begin fun gl ->
-    let sigma = Tacmach.New.project gl in
-    let to_ind c =
-      if isInd sigma c then fst (destInd sigma c)
-      else user_err Pp.(str "not an inductive type")
-    in
-    let l = List.map to_ind l in
-    Elim.h_decompose l c
-  end
-
-}
-
 TACTIC EXTEND decompose
-| [ "decompose" "[" ne_constr_list(l) "]" constr(c) ] -> { decompose l c }
+| [ "decompose" "[" ne_constr_list(l) "]" constr(c) ] -> { Internals.decompose l c }
 END
 
 (** library/keys *)
 
 VERNAC COMMAND EXTEND Declare_keys CLASSIFIED AS SIDEFF
-| [ "Declare" "Equivalent" "Keys" constr(c) constr(c') ] -> {
-  let get_key c =
-    let env = Global.env () in
-    let evd = Evd.from_env env in
-    let (evd, c) = Constrintern.interp_open_constr env evd c in
-    let kind c = EConstr.kind evd c in
-    Keys.constr_key kind c
-  in
-  let k1 = get_key c in
-  let k2 = get_key c' in
-    match k1, k2 with
-    | Some k1, Some k2 -> Keys.declare_equiv_keys k1 k2
-    | _ -> () }
+| [ "Declare" "Equivalent" "Keys" constr(c) constr(c') ] -> { Internals.declare_equivalent_keys c c' }
 END
 
 VERNAC COMMAND EXTEND Print_keys CLASSIFIED AS QUERY
 | [ "Print" "Equivalent" "Keys" ] -> { Feedback.msg_notice (Keys.pr_keys Printer.pr_global) }
 END
-
 
 VERNAC COMMAND EXTEND OptimizeProof
 | ![ proof ] [ "Optimize" "Proof" ] => { classify_as_proofstep } ->
@@ -1094,21 +710,12 @@ VERNAC COMMAND EXTEND OptimizeProof
   { Gc.compact () }
 END
 
-(** tactic analogous to "OPTIMIZE HEAP" *)
-
-{
-
-let tclOPTIMIZE_HEAP =
-  Proofview.tclLIFT (Proofview.NonLogical.make (fun () -> Gc.compact ()))
-
-}
-
 TACTIC EXTEND optimize_heap
-| [ "optimize_heap" ] -> { tclOPTIMIZE_HEAP }
+| [ "optimize_heap" ] -> { Internals.tclOPTIMIZE_HEAP }
 END
 
 VERNAC COMMAND EXTEND infoH CLASSIFIED AS QUERY
-| ![ proof_query ] [ "infoH" tactic(tac) ] -> { fun ~pstate -> Internals.infoH ~pstate tac }
+| ![ proof_query ] [ "infoH" tactic(tac) ] -> { Internals.infoH tac }
 END
 
 (** Tactic analogous to [Strategy] vernacular *)

--- a/plugins/ltac/extratactics.mli
+++ b/plugins/ltac/extratactics.mli
@@ -7,11 +7,3 @@
 (*         *     GNU Lesser General Public License Version 2.1          *)
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
-
-
-val discrHyp : Names.Id.t -> unit Proofview.tactic
-val injHyp : Names.Id.t -> unit Proofview.tactic
-
-(* val refine_tac : Evd.open_constr -> unit Proofview.tactic *)
-
-val onSomeWithHoles : ('a option -> unit Proofview.tactic) -> 'a Tactypes.delayed_open option -> unit Proofview.tactic

--- a/plugins/ltac/internals.mli
+++ b/plugins/ltac/internals.mli
@@ -8,7 +8,65 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(** Implementation of Ltac-specific code to be exported in mlg files *)
+open Names
+open Proofview
+open Ltac_pretype
+
+(** Implementation of Ltac-specific code to be exported in mlg files.
+
+    This is voluntarily undocumented. Please do not use in plugin code. *)
+
+(** {5 Tactics} *)
+
+val mytclWithHoles : (Tactics.evars_flag ->
+  EConstr.constr Tactypes.with_bindings Tactics.destruction_arg option ->
+    unit Proofview.tactic) ->
+  Tactics.evars_flag ->
+  Tactypes.delayed_open_constr_with_bindings Tactics.destruction_arg ->
+  unit Proofview.tactic
+
+val with_delayed_uconstr : Tacinterp.interp_sign ->
+  closed_glob_constr -> (EConstr.constr -> unit tactic) -> unit tactic
+val replace_in_clause_maybe_by : Tacinterp.interp_sign ->
+  closed_glob_constr -> EConstr.constr ->
+  Locus.clause -> Tacinterp.Value.t option -> unit tactic
+val replace_term : Geninterp.interp_sign -> bool option -> closed_glob_constr ->
+  Locus.clause -> unit tactic
+
+val discrHyp : Names.Id.t -> unit tactic
+val injHyp : Names.Id.t -> unit tactic
+(* TODO: remove these, they are not used from within Coq *)
+
+val refine_tac : Tacinterp.interp_sign -> simple:bool -> with_classes:bool ->
+  closed_glob_constr -> unit tactic
+
+val hResolve : Id.t -> EConstr.t -> int -> EConstr.t -> unit tactic
+val hResolve_auto : Id.t -> EConstr.t -> EConstr.t -> unit tactic
+
+val destauto : unit tactic
+val destauto_in : Id.t -> unit tactic
+
+val has_evar : EConstr.t -> unit tactic
+val is_evar : EConstr.t -> unit tactic
+val is_var : EConstr.t -> unit tactic
+val is_fix : EConstr.t -> unit tactic
+val is_cofix : EConstr.t -> unit tactic
+val is_ind : EConstr.t -> unit tactic
+val is_constructor : EConstr.t -> unit tactic
+val is_proj : EConstr.t -> unit tactic
+val is_const : EConstr.t -> unit tactic
+
+val unshelve : Tacinterp.interp_sign -> Tacinterp.Value.t -> unit tactic
+
+val decompose : EConstr.t list -> EConstr.t -> unit tactic
+
+val tclOPTIMIZE_HEAP : unit tactic
+
+val onSomeWithHoles : ('a option -> unit tactic) -> 'a Tactypes.delayed_open option -> unit tactic
+
+(** {5 Commands} *)
+
+val declare_equivalent_keys : Constrexpr.constr_expr -> Constrexpr.constr_expr -> unit
 
 val infoH : pstate:Declare.Proof.t -> Tacexpr.raw_tactic_expr -> unit
 (** ProofGeneral command *)


### PR DESCRIPTION
It is very bad practice to keep non-trivial code in mlg files, whose sole purpose is to declare grammar rules with syntactic sugar. We can probably even clean that up further but it is a good first step.
