### PR TITLE
Deprecation notice of ambiguous `Proof using` and `Collection` usage

### DIFF
--- a/doc/changelog/07-vernac-commands-and-options/15056-collection-variable-clash-deprecation-notice.rst
+++ b/doc/changelog/07-vernac-commands-and-options/15056-collection-variable-clash-deprecation-notice.rst
@@ -1,0 +1,5 @@
+- **Deprecated:**
+  Deprecate ambiguous :cmd:`Proof using` and :cmd:`Collection` usage
+  (`#15056 <https://github.com/coq/coq/pull/15056>`_,
+  fixes `#13296 <https://github.com/coq/coq/issues/13296>`_,
+  by Wojciech Karpiel).

--- a/doc/sphinx/proofs/writing-proofs/proof-mode.rst
+++ b/doc/sphinx/proofs/writing-proofs/proof-mode.rst
@@ -395,9 +395,8 @@ Name a set of section hypotheses for ``Proof using``
    .. deprecated:: 8.15
 
       Redefining a collection, defining a collection with the same name as a variable,
-      and invoking the :cmd:`Proof using` command whenever names of collections and variables overlap
-      are deprecated. See the documentation of the warnings below and the warnigns
-      of the :cmd:`Proof using` command.
+      and invoking the :cmd:`Proof using` command when collection and variable names overlap
+      are deprecated. See the warnings below and in the :cmd:`Proof using` command.
 
    .. exn:: "All" is a predefined collection containing all variables. It can't be redefined.
 

--- a/doc/sphinx/proofs/writing-proofs/proof-mode.rst
+++ b/doc/sphinx/proofs/writing-proofs/proof-mode.rst
@@ -392,6 +392,13 @@ Name a set of section hypotheses for ``Proof using``
 
          Collection Many := Fewer - (x y)
 
+   .. deprecated:: 8.15
+
+      Redefining a collection, defining a collection with the same name as a variable,
+      and invoking the :cmd:`Proof using` command whenever names of collections and variables overlap
+      are deprecated. See the documentation of the warnings below and the warnigns
+      of the :cmd:`Proof using` command.
+
    .. exn:: "All" is a predefined collection containing all variables. It can't be redefined.
 
       When issuing a :cmd:`Proof using` command, **All** used as a collection name always means


### PR DESCRIPTION
This is a followup of #15056, adding missing deprecation notice and a changelog.

I feel guilty for the time it took for such simple issue to be finally closed, sorry!

- [x] Added **changelog**.