### PR TITLE
Re-implementing the disjunctive-conjunctive introduction pattern on top of "destruct" rather than "case" (reopened)

### DIFF
--- a/dev/ci/user-overlays/13513-herbelin-master+disjunctive-intro-pattern-on-top-of-destruct.sh
+++ b/dev/ci/user-overlays/13513-herbelin-master+disjunctive-intro-pattern-on-top-of-destruct.sh
@@ -1,0 +1,7 @@
+if [ "$CI_PULL_REQUEST" = "13513" ] || [ "$CI_BRANCH" = "master+disjunctive-intro-pattern-on-top-of-destruct" ]; then
+
+    overlay flocq git@gitlab.inria.fr:herbelin/flocq.git master+adapt-coq-pr13513-disjunctive-intro-pattern-is-destruct
+    overlay hott https://github.com/herbelin/HoTT master+adapt-coq-pr13513-disjunctive-intro-pattern-is-destruct
+    overlay unimath https://github.com/herbelin/UniMath master+adapt-coq-pr13513-disjunctive-intro-pattern-is-destruct
+
+fi

--- a/dev/ci/user-overlays/13521-herbelin-master+disjunctive-intro-pattern-on-top-of-destruct
+++ b/dev/ci/user-overlays/13521-herbelin-master+disjunctive-intro-pattern-on-top-of-destruct
@@ -1,0 +1,11 @@
+if [ "$CI_PULL_REQUEST" = "13415" ] || [ "$CI_BRANCH" = "intern-univs" ]; then
+
+    overlay argosy https://github.com/herbelin/argosy master+adapt-coq-pr13521-edestruct-clear-variables-like-destruct
+    overlay cross-crypto https://github.com/herbelin/cross-crypto master+adapt-coq-pr13521-edestruct-clear-variables-like-destruct
+    overlay stdpp https://github.com/herbelin/stdpp master+adapt-coq-pr13521-edestruct-clear-variables-like-destruct
+    overlay sf https://github.com/herbelin/sf master+adapt-coq-pr13521-edestruct-clear-variables-like-destruct
+    overlay fiat-parsers https://github.com/herbelin/fiat-parsers master+adapt-coq-pr13521-edestruct-clear-variables-like-destruct
+    overlay metacoq https://github.com/herbelin/metacoq master+adapt-coq-pr13521-edestruct-clear-variables-like-destruct
+    overlay quickchick https://github.com/herbelin/QuickChick master+adapt-coq-pr13521-edestruct-clear-variables-like-destruct
+
+fi

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1582,7 +1582,6 @@ let general_case_analysis with_evars clear_flag (c,lbindc as cx) =
         general_case_analysis_in_context with_evars clear_flag cx
 
 let simplest_case c = general_case_analysis false None (c,NoBindings)
-let simplest_ecase c = general_case_analysis true None (c,NoBindings)
 
 (* Elimination tactic with bindings but using the default elimination
  * constant associated with the type. *)
@@ -2346,22 +2345,17 @@ let intro_decomp_eq ?loc l thin tac id =
     Tacticals.tclZEROMSG ~info (str "Not a primitive equality here.")
   end
 
-let intro_or_and_pattern ?loc with_evars ll thin tac id =
+let destruct_function = ref (fun _ -> failwith "Not implemented")
+
+let intro_or_and_pattern ?loc with_evars ll tac id =
   Proofview.Goal.enter begin fun gl ->
   let c = mkVar id in
   let env = Proofview.Goal.env gl in
   let sigma = Proofview.Goal.sigma gl in
   let sigma, t = Typing.type_of env sigma c in
-  let (ind,t) = reduce_to_quantified_ind env sigma t in
-  let branchsigns = compute_constructor_signatures env ~rec_flag:false ind in
-  let nv_with_let = Array.map List.length branchsigns in
-  let ll = fix_empty_or_and_pattern (Array.length branchsigns) ll in
-  let ll = get_and_check_or_and_pattern ?loc ll branchsigns in
-  Proofview.tclTHEN (Proofview.Unsafe.tclEVARS sigma)
-    (Tacticals.tclTHENLASTn
-       (Tacticals.tclTHEN (simplest_ecase c) (clear [id]))
-       (Array.map2 (fun n l -> tac thin (Some n) l)
-          nv_with_let ll))
+  Proofview.tclTHEN
+    (Proofview.Unsafe.tclEVARS sigma)
+    (!destruct_function id ll (fun thin -> Proofview.tclTHEN (clear []) (tac thin)))
   end
 
 let rewrite_hyp_then with_evars thin l2r id tac =
@@ -2540,7 +2534,7 @@ and intro_pattern_action ?loc with_evars pat thin destopt tac id =
   | IntroWildcard ->
       tac (CAst.(make ?loc id)::thin) None []
   | IntroOrAndPattern ll ->
-      intro_or_and_pattern ?loc with_evars ll thin tac id
+      intro_or_and_pattern ?loc with_evars ll (fun thin' -> tac (thin'@thin) None []) id
   | IntroInjection l' ->
       intro_decomp_eq ?loc l' thin tac id
   | IntroRewrite l2r ->
@@ -3375,7 +3369,7 @@ let induct_discharge with_evars dests avoid' tac (avoid,ra) names =
         let env = Proofview.Goal.env gl in
         let sigma = Proofview.Goal.sigma gl in
         check_unused_names env sigma names;
-        Tacticals.tclTHEN (clear_wildcards thin) (tac dests)
+        tac thin dests
         end
   in
   peel_tac ra dests names []
@@ -4376,7 +4370,7 @@ let induction_tac with_evars params indvars (elim, elimt) =
    hypotheses from the context, replacing the main hypothesis on which
    induction applies with the induction hypotheses *)
 
-let apply_induction_in_context with_evars hyp0 inhyps elim indvars names induct_tac =
+let apply_induction_in_context with_evars hyp0 inhyps elim indvars names induct_tac tac =
   Proofview.Goal.enter begin fun gl ->
     let sigma = Proofview.Goal.sigma gl in
     let env = Proofview.Goal.env gl in
@@ -4406,19 +4400,20 @@ let apply_induction_in_context with_evars hyp0 inhyps elim indvars names induct_
       ])
       (Array.map2
          (induct_discharge with_evars lhyp0 avoid
-            (re_intro_dependent_hypotheses statuslists))
+            (fun thin dest ->
+              Tacticals.tclTHEN (re_intro_dependent_hypotheses statuslists dest) (tac thin)))
          indsign names)
     in
     Proofview.tclTHEN (Proofview.Unsafe.tclEVARS sigma) tac
   end
 
-let induction_with_atomization_of_ind_arg isrec with_evars elim names hyp0 inhyps =
+let induction_with_atomization_of_ind_arg isrec with_evars elim names hyp0 tac inhyps =
   Proofview.Goal.enter begin fun gl ->
   let sigma, elim_info = find_induction_type isrec elim hyp0 gl in
   tclEVARSTHEN sigma
     (atomize_param_of_ind_then elim_info hyp0 (fun indvars ->
          apply_induction_in_context with_evars (Some hyp0) inhyps (pi3 elim_info) indvars names
-           (fun elim -> induction_tac with_evars [] [hyp0] elim)))
+           (fun elim -> induction_tac with_evars [] [hyp0] elim) tac))
   end
 
 let msg_not_right_number_induction_arguments scheme =
@@ -4477,7 +4472,7 @@ let induction_without_atomization isrec with_evars elim names lid =
     induction_tac with_evars params realindvars elim;
   ] in
   let elim = ElimUsing ((ElimClause elimc, scheme.elimt), indsign) in
-  apply_induction_in_context with_evars None [] elim indvars names induct_tac
+  apply_induction_in_context with_evars None [] elim indvars names induct_tac clear_wildcards
   end
 
 (* assume that no occurrences are selected *)
@@ -4634,8 +4629,8 @@ let has_generic_occurrences_but_goal cls id env sigma ccl =
   (* TODO: whd_evar of goal *)
   (cls.concl_occs != NoOccurrences || not (occur_var env sigma id ccl))
 
-let induction_gen clear_flag isrec with_evars elim
-    ((_pending,(c,lbind)),(eqname,names) as arg) cls =
+let induction_gen clear_flag isrec with_evars no_clear_with_evars elim
+    ((_pending,(c,lbind)),(eqname,names) as arg) cls tac =
   let inhyps = match cls with
   | Some {onhyps=Some hyps} -> List.map (fun ((_,id),_) -> id) hyps
   | _ -> [] in
@@ -4647,7 +4642,7 @@ let induction_gen clear_flag isrec with_evars elim
   let t = typ_of env evd c in
   let is_arg_pure_hyp =
     isVar evd c && not (mem_named_context_val (destVar evd c) (Global.named_context_val ()))
-    && lbind == NoBindings && not with_evars && Option.is_empty eqname
+    && lbind == NoBindings && not no_clear_with_evars && Option.is_empty eqname
     && clear_flag == None
     && has_generic_occurrences_but_goal cls (destVar evd c) env evd ccl in
   let enough_applied = check_enough_applied env evd elim t in
@@ -4661,7 +4656,7 @@ let induction_gen clear_flag isrec with_evars elim
     Tacticals.tclTHEN
       (clear_unselected_context id inhyps cls)
       (induction_with_atomization_of_ind_arg
-         isrec with_evars elim names id inhyps)
+         isrec with_evars elim names id tac inhyps)
   else
   (* Otherwise, we look for the pattern, possibly adding missing arguments and
      declaring the induction argument as a new local variable *)
@@ -4676,8 +4671,16 @@ let induction_gen clear_flag isrec with_evars elim
     pose_induction_arg_then
       isrec with_evars info_arg elim id arg t inhyps cls
     (induction_with_atomization_of_ind_arg
-       isrec with_evars elim names id)
+       isrec with_evars elim names id tac)
   end
+
+let () =
+  destruct_function :=
+    (fun id names tac ->
+      Proofview.Goal.enter begin fun gl ->
+        let sigma = Proofview.Goal.sigma gl in
+        induction_gen None false true false None ((sigma,(mkVar id,NoBindings)),(None,Some (CAst.make names))) None tac
+        end)
 
 (* Induction on a list of arguments. First make induction arguments
    atomic (using letins), then do induction. The specificity here is
@@ -4746,7 +4749,7 @@ let induction_destruct isrec with_evars (lc,elim) =
     | _ ->
       (* standard induction *)
       onOpenInductionArg env sigma
-      (fun clear_flag c -> induction_gen clear_flag isrec with_evars elim (c,allnames) cls) c
+      (fun clear_flag c -> induction_gen clear_flag isrec with_evars with_evars elim (c,allnames) cls clear_wildcards) c
     end
   | _ ->
     Proofview.Goal.enter begin fun gl ->
@@ -4763,13 +4766,13 @@ let induction_destruct isrec with_evars (lc,elim) =
       (* TODO *)
       Tacticals.tclTHEN
         (onOpenInductionArg env sigma (fun clear_flag a ->
-          induction_gen clear_flag isrec with_evars None (a,b) cl) a)
+          induction_gen clear_flag isrec with_evars with_evars None (a,b) cl clear_wildcards) a)
         (Tacticals.tclMAP (fun (a,b,cl) ->
           Proofview.Goal.enter begin fun gl ->
           let env = Proofview.Goal.env gl in
           let sigma = Tacmach.project gl in
           onOpenInductionArg env sigma (fun clear_flag a ->
-            induction_gen clear_flag false with_evars None (a,b) cl) a
+            induction_gen clear_flag false with_evars with_evars None (a,b) cl clear_wildcards) a
           end) l)
     | Some elim ->
       (* Several induction hyps with induction scheme *)
@@ -4792,12 +4795,12 @@ let induction_destruct isrec with_evars (lc,elim) =
     end
 
 let induction ev clr c l e =
-  induction_gen clr true ev e
-    ((Evd.empty,(c,NoBindings)),(None,l)) None
+  induction_gen clr true ev ev e
+    ((Evd.empty,(c,NoBindings)),(None,l)) None clear_wildcards
 
 let destruct ev clr c l e =
-  induction_gen clr false ev e
-    ((Evd.empty,(c,NoBindings)),(None,l)) None
+  induction_gen clr false ev ev e
+    ((Evd.empty,(c,NoBindings)),(None,l)) None clear_wildcards
 
 (*
  *  Eliminations giving the type instead of the proof.

--- a/test-suite/bugs/closed/bug_3045.v
+++ b/test-suite/bugs/closed/bug_3045.v
@@ -31,5 +31,5 @@ refine match m with
 (* This fails with an error rather than an anomaly, but morally
    it should work, if destruct were able to do the good generalization
    in advance, before doing the "intros []". *)
-Fail destruct (@ReifiedMorphismSimplifyWithProof T s1 d0 d0' m1) as [ [] ? ].
+destruct (@ReifiedMorphismSimplifyWithProof T s1 d0 d0' m1) as [ [] ? ].
 Abort.

--- a/test-suite/bugs/closed/bug_7972.v
+++ b/test-suite/bugs/closed/bug_7972.v
@@ -1,0 +1,6 @@
+Inductive foo : Set -> Type := Foo : foo unit.
+
+Lemma bar U (pf : unit = U) : forall (x : foo U), x = eq_rect unit foo Foo U pf.
+Proof.
+  intros [].
+Abort.


### PR DESCRIPTION
**Kind:** feature

Reopening of #13513.

First attempt at using `destruct` rather than `case` in disjunctive introduction patterns. 

It is surprisingly backward-compatible in the standard library and test-suite. It is probably a bit slower though since it looks for occurrences in the whole context. If significant, some fine-tuning may be needed.

This is also a step in the direction of a better compatibility with #9710 (compact representation of pattern-matching).

In particular, closes #7972 and answer a [comment](https://github.com/coq/coq/issues/3045#issuecomment-337514632) of #3045.

- [X] Added / updated test-suite
- [ ] Corresponding documentation was added / updated
- [ ] Entry added in the changelog
