### PR TITLE
Fix #14577: always include every new line ident when diffing hypothesis lines

### DIFF
--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -197,7 +197,8 @@ let process_goal_diffs diff_goal_map oldp nsigma ng =
     | None -> None
   in
   let (hyps_pp_list, concl_pp) = Proof_diffs.diff_goal_ide og_s ng nsigma in
-  { Interface.goal_hyp = hyps_pp_list; Interface.goal_ccl = concl_pp; Interface.goal_id = Goal.uid ng; Interface.goal_name = name }
+  { Interface.goal_hyp = hyps_pp_list; Interface.goal_ccl = concl_pp;
+    Interface.goal_id = Goal.uid ng; Interface.goal_name = name }
 
 let export_pre_goals Proof.{ sigma; goals; stack } process =
   let process = List.map (process sigma) in

--- a/lib/pp_diff.ml
+++ b/lib/pp_diff.ml
@@ -125,7 +125,7 @@ let diff_strs old_strs new_strs =
   let diffs = List.rev (StringDiff.diff old_strs new_strs) in
   shorten_diff_span `Removed (shorten_diff_span `Added diffs)
 
-(* Default string tokenizer.  Makes each character a separate strin.
+(* Default string tokenizer.  Makes each character a separate string.
 Whitespace is not ignored.  Doesn't handle UTF-8 differences well. *)
 let def_tokenize_string s =
   let limit = (String.length s) - 1 in

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -1043,7 +1043,7 @@ let print_and_diff oldp newp =
       else
         pr_open_subgoals ~proof
     in
-    Feedback.msg_notice output;;
+    Feedback.msg_notice output
 
 let pr_typing_flags flags =
   str "check_guarded: " ++ bool flags.check_guarded ++ fnl ()

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -111,106 +111,123 @@ let tokenize_string s =
 type hyp_info = {
   idents: string list;
   rhs_pp: Pp.t;
-  mutable done_: bool;
 }
 
-(* Generate the diffs between the old and new hyps.
-   This works by matching lines with the hypothesis name and diffing the right-hand side.
-   Lines that have multiple names such as "n, m : nat" are handled specially to account
-   for, say, the addition of m to a pre-existing "n : nat".
+(* Diff the old and new hypotheses.  The RHS (starting at ":" or ":=") is diffed with
+   the same token-based diff used for goal conclusions.  Identifiers in the LHS are
+   handled differently:
+
+   The order and grouping of LHS identifiers in the added/unchanged lines is always
+   the same as when diff is not enabled.  Identifiers existing in the old context
+   that are present in the new context with the same RHS are not highlighted.  New
+   identifiers are always highlighted.
+
+   If all the existing identifiers in a line have a new RHS, those identifiers are
+   not highlighted (in this case, the RHS will be highlighted, making the change clear).
+
+   Removed and added lines are generated in separate passes.  Removed lines appear
+   before the added line that has most identifiers in common with the old.  (For
+   a tie, use the first one found.  For zero in common, put the removal before
+   the first addition/common line.)  This should be a good but not perfect
+   approximation to what a human might do.
  *)
-let diff_hyps o_line_idents o_map n_line_idents n_map =
+let diff_hyps o_idents_in_lines o_map n_idents_in_lines n_map =
   let rv : Pp.t list ref = ref [] in
+  let removals = ref CString.Map.empty in
 
-  let is_done ident map = (CString.Map.find ident map).done_ in
-  let exists ident map =
-    try let _ = CString.Map.find ident map in true
-    with Not_found -> false in
-  let contains l ident = try [List.find (fun x  -> x = ident) l] with Not_found -> [] in
+  (* get the first identifier on the new line with the most ids in common
+     with the given old idents *)
+  let best_match old_ids =
+    let rec aux best best_score = function
+      | [] -> best
+      | nl_idents :: tl ->
+        let score = List.fold_left (fun rv ident ->
+            if List.mem ident nl_idents then rv+1 else rv) 0 old_ids in
+        if score > best_score then
+          aux (List.hd nl_idents) score tl
+        else
+          aux best best_score tl
+    in
+    aux "" 0 n_idents_in_lines
+  in
 
-  let output old_ids_uo new_ids =
-    (* use the order from the old line in case it's changed in the new *)
-    let old_ids = if old_ids_uo = [] then [] else
-      let orig = (CString.Map.find (List.hd old_ids_uo) o_map).idents in
-      List.concat (List.map (contains orig) old_ids_uo)
+  (* generate the Pp.t for a single line of the hypotheses *)
+  let gen_line old_ids old_rhs new_ids new_rhs otype =
+    let gen_pp ids map hyp =
+      if ids = [] then ("", Pp.mt ()) else begin
+        let open Pp in
+        let pp_ids = List.map (fun x -> str x) ids in
+        let hyp_pp = List.fold_left (fun l1 l2 -> l1 ++ str ", " ++ l2) (List.hd pp_ids) (List.tl pp_ids) ++ hyp in
+        (string_of_ppcmds hyp_pp, hyp_pp)
+      end;
     in
 
-    let setup ids map = if ids = [] then ("", Pp.mt ()) else
-      let open Pp in
-      let rhs_pp = (CString.Map.find (List.hd ids) map).rhs_pp in
-      let pp_ids = List.map (fun x -> str x) ids in
-      let hyp_pp = List.fold_left (fun l1 l2 -> l1 ++ str ", " ++ l2) (List.hd pp_ids) (List.tl pp_ids) ++ rhs_pp in
-      (string_of_ppcmds hyp_pp, hyp_pp)
-    in
-
-    let (o_line, o_pp) = setup old_ids o_map in
-    let (n_line, n_pp) = setup new_ids n_map in
+    let (o_line, o_pp) = gen_pp old_ids o_map old_rhs in
+    let (n_line, n_pp) = gen_pp new_ids n_map new_rhs in
 
     let hyp_diffs = diff_str ~tokenize_string o_line n_line in
-    let (has_added, has_removed) = has_changes hyp_diffs in
-    if show_removed () && has_removed then begin
-      List.iter (fun x -> (CString.Map.find x o_map).done_ <- true) old_ids;
-      rv := (add_diff_tags `Removed o_pp hyp_diffs) :: !rv;
-    end;
-    if n_line <> "" then begin
-      List.iter (fun x -> (CString.Map.find x n_map).done_ <- true) new_ids;
-      rv := (add_diff_tags `Added n_pp hyp_diffs) :: !rv
+    if otype = `Added then begin
+      let rems = try CString.Map.find (List.hd new_ids) !removals with Not_found -> [] in
+      rv := add_diff_tags otype n_pp hyp_diffs :: (rems @ !rv)
+    end else begin
+      let (has_added, has_removed) = has_changes hyp_diffs in
+      if has_removed then begin
+        let d_line = add_diff_tags otype o_pp hyp_diffs in
+        let best = best_match old_ids in
+        if best = "" then
+          rv := d_line :: !rv
+        else begin
+          let ent = try CString.Map.find best !removals with Not_found -> [] in
+          removals := CString.Map.add best (d_line :: ent) !removals
+        end
+      end
     end
   in
 
-  (* process identifier level diff *)
-  let process_ident_diff diff =
-    let (dtype, ident) = get_dinfo diff in
-    match dtype with
-    | `Removed ->
-      if dtype = `Removed then begin
-        let o_idents = (CString.Map.find ident o_map).idents in
-        (* only show lines that have all idents removed here; other removed idents appear later *)
-        if show_removed () && not (is_done ident o_map) &&
-            List.for_all (fun x -> not (exists x n_map)) o_idents then
-          output (List.rev o_idents) []
-      end
-    | _ -> begin (* Added or Common case *)
-      let n_idents = (CString.Map.find ident n_map).idents in
+  (* generate only the removals or only the additions for all hypotheses *)
+  let half_diff old_ids o_map n_idents_in_lines n_map otype =
+    let rec do_lines = function
+      | [] -> ()
+      | ids_in_line :: tl ->
+        let nl_idents, new_rhs =
+          try let ent = CString.Map.find (List.hd ids_in_line) n_map in
+            ent.idents, ent.rhs_pp
+          with Not_found -> [], (Pp.mt ()) in
 
-      (* Process a new hyp line, possibly splitting it.  Duplicates some of
-         process_ident iteration, but easier to understand this way *)
-      let process_line ident2 =
-        if not (is_done ident2 n_map) then begin
-          let n_ids_list : string list ref = ref [] in
-          let o_ids_list : string list ref = ref [] in
-          let fst_omap_idents = ref None in
-          let add ids id map =
-            ids := id :: !ids;
-            (CString.Map.find id map).done_ <- true in
+        let rec get_ol_idents ol_idents old_rhs = function
+          | [] -> List.rev ol_idents, old_rhs
+          | ident :: tl ->
+            try
+              let o_ent = CString.Map.find ident o_map in
+              let eq = (o_ent.rhs_pp = new_rhs) in
+              let ol_idents = if eq then ident :: ol_idents else ol_idents in
+              let old_rhs = if eq || old_rhs = None then Some o_ent.rhs_pp else old_rhs in
+              get_ol_idents ol_idents old_rhs tl
+            with Not_found -> get_ol_idents ol_idents old_rhs tl
+        in
 
-          (* get identifiers shared by one old and one new line, plus
-             other Added in new and other Removed in old *)
-          let process_split ident3 =
-            if not (is_done ident3 n_map) then begin
-              let this_omap_idents = try Some (CString.Map.find ident3 o_map).idents
-                                    with Not_found -> None in
-              if !fst_omap_idents = None then
-                fst_omap_idents := this_omap_idents;
-              match (!fst_omap_idents, this_omap_idents) with
-              | (Some fst, Some this) when fst == this ->  (* yes, == *)
-                add n_ids_list ident3 n_map;
-                (* include, in old order, all undone Removed idents in old *)
-                List.iter (fun x -> if x = ident3 || not (is_done x o_map) && not (exists x n_map) then
-                                    (add o_ids_list x o_map)) fst
-              | (_, None) ->
-                add n_ids_list ident3 n_map (* include all undone Added idents in new *)
-              | _ -> ()
-            end in
-          List.iter process_split n_idents;
-          output (List.rev !o_ids_list) (List.rev !n_ids_list)
-        end in
-      List.iter process_line n_idents (* O(n^2), so sue me *)
-    end in
+        let (ol_idents, old_rhs) = get_ol_idents [] None nl_idents in
+        let old_rhs = Option.default (Pp.mt ()) old_rhs in
 
-  let cvt s = Array.of_list (List.concat s) in
-  let ident_diffs = diff_strs (cvt o_line_idents) (cvt n_line_idents) in
-  List.iter process_ident_diff ident_diffs;
+        let rhs_eq = old_rhs = new_rhs in
+        (* if RHS differs, only highlight idents new to the context *)
+        let filter_ol () = if rhs_eq then ol_idents else
+          List.filter (fun ident -> CString.Map.mem ident o_map) nl_idents in
+        if otype = `Added then begin
+          let ol_idents = filter_ol () in
+          gen_line ol_idents old_rhs  nl_idents new_rhs otype
+        end else if not rhs_eq || List.length nl_idents <> List.length ol_idents then begin
+          let ol_idents = filter_ol () in
+          gen_line nl_idents new_rhs  ol_idents old_rhs otype
+        end;
+        do_lines tl
+    in
+    do_lines n_idents_in_lines
+  in
+  if show_removed () then
+    (* note reversal of new and old *)
+    half_diff (List.flatten n_idents_in_lines) n_map  o_idents_in_lines o_map `Removed;
+  half_diff (List.flatten o_idents_in_lines) o_map  n_idents_in_lines n_map `Added;
   List.rev !rv
 
 
@@ -312,7 +329,7 @@ let goal_info goal sigma =
     let ts = pp_of_type env sigma ty in
     let rhs_pp = mid ++ str " : " ++ ts in
 
-    let make_entry () = { idents; rhs_pp; done_ = false } in
+    let make_entry () = { idents; rhs_pp } in
     List.iter (fun ident -> map := (CString.Map.add ident (make_entry ()) !map); ()) idents
   in
 
@@ -324,12 +341,12 @@ let goal_info goal sigma =
   with _ -> ([], !map, Pp.mt ())
 
 let diff_goal_info o_info n_info =
-  let (o_line_idents, o_hyp_map, o_concl_pp) = o_info in
-  let (n_line_idents, n_hyp_map, n_concl_pp) = n_info in
+  let (o_idents_in_lines, o_hyp_map, o_concl_pp) = o_info in
+  let (n_idents_in_lines, n_hyp_map, n_concl_pp) = n_info in
   let show_removed = Some (show_removed ()) in
   let concl_pp = diff_pp_combined ~tokenize_string ?show_removed o_concl_pp n_concl_pp in
 
-  let hyp_diffs_list = diff_hyps o_line_idents o_hyp_map n_line_idents n_hyp_map in
+  let hyp_diffs_list = diff_hyps o_idents_in_lines o_hyp_map n_idents_in_lines n_hyp_map in
   (hyp_diffs_list, concl_pp)
 
 let hyp_list_to_pp hyps =

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -106,7 +106,7 @@ let tokenize_string s =
     toks
   with exn ->
     CLexer.Lexer.State.set st;
-    raise (Diff_Failure "Input string is not lexable");;
+    raise (Diff_Failure "Input string is not lexable")
 
 type hyp_info = {
   idents: string list;
@@ -211,7 +211,7 @@ let diff_hyps o_line_idents o_map n_line_idents n_map =
   let cvt s = Array.of_list (List.concat s) in
   let ident_diffs = diff_strs (cvt o_line_idents) (cvt n_line_idents) in
   List.iter process_ident_diff ident_diffs;
-  List.rev !rv;;
+  List.rev !rv
 
 
 type 'a hyp = (Names.Id.t Context.binder_annot list * 'a option * 'a)
@@ -224,7 +224,7 @@ module CDC = Context.Compacted.Declaration
 let to_tuple : Constr.compacted_declaration -> (Names.Id.t Context.binder_annot list * 'pc option * 'pc) =
   let open CDC in function
     | LocalAssum(idl, tm)   -> (idl, None, EConstr.of_constr tm)
-    | LocalDef(idl,tdef,tm) -> (idl, Some (EConstr.of_constr tdef), EConstr.of_constr tm);;
+    | LocalDef(idl,tdef,tm) -> (idl, Some (EConstr.of_constr tdef), EConstr.of_constr tm)
 
 let goal_repr sigma g =
   let evi = Evd.find sigma g in
@@ -244,7 +244,7 @@ let process_goal sigma g : EConstr.t reified_goal =
   (* compaction is usually desired [eg for better display] *)
   let hyps      = Termops.compact_named_context (Environ.named_context env) in
   let hyps      = List.map to_tuple hyps in
-  { name; ty; hyps; env; sigma };;
+  { name; ty; hyps; env; sigma }
 
 let pr_letype_env ?lax ?goal_concl_style env sigma ?impargs t =
   Ppconstr.pr_lconstr_expr env sigma
@@ -321,7 +321,7 @@ let goal_info goal sigma =
     List.iter (build_hyp_info env sigma) (List.rev hyps);
     let concl_pp = pp_of_type env sigma ty in
     ( List.rev !line_idents, !map, concl_pp )
-  with _ -> ([], !map, Pp.mt ());;
+  with _ -> ([], !map, Pp.mt ())
 
 let diff_goal_info o_info n_info =
   let (o_line_idents, o_hyp_map, o_concl_pp) = o_info in
@@ -336,7 +336,7 @@ let hyp_list_to_pp hyps =
   let open Pp in
   match hyps with
   | h :: tl -> List.fold_left (fun x y -> x ++ cut () ++ y) h tl
-  | [] -> mt ();;
+  | [] -> mt ()
 
 let unwrap g_s =
   match g_s with
@@ -355,7 +355,7 @@ let diff_goal ?og_s ng ns =
   v 0 (
     (hyp_list_to_pp hyps_pp_list) ++ cut () ++
     str "============================" ++ cut () ++
-    concl_pp);;
+    concl_pp)
 
 
 (*** Code to determine which calls to compare between the old and new proofs ***)

--- a/printing/proof_diffs.mli
+++ b/printing/proof_diffs.mli
@@ -84,7 +84,6 @@ val log_out_ch : out_channel ref
 type hyp_info = {
   idents: string list;
   rhs_pp: Pp.t;
-  mutable done_: bool;
 }
 
 val diff_hyps : string list list -> hyp_info CString.Map.t -> string list list -> hyp_info CString.Map.t -> Pp.t list

--- a/test-suite/unit-tests/printing/proof_diffs_test.ml
+++ b/test-suite/unit-tests/printing/proof_diffs_test.ml
@@ -113,7 +113,7 @@ let t () =
       ])) in
   let (_, n_diff) = diff_pp o_pp n_pp in
 
-  assert_equal ~msg:"added"   ~printer:db_string_of_pp n_exp (flatten n_diff);;
+  assert_equal ~msg:"added"   ~printer:db_string_of_pp n_exp (flatten n_diff)
 let _ = add_test "diff_pp/add_diff_tags a span with spaces" t
 
 
@@ -184,7 +184,7 @@ let _ = if false then add_test "diff_pp/add_diff_tags token containing white spa
 
 let add_entries map idents rhs_pp =
   let make_entry() = { idents; rhs_pp; done_ = false } in
-  List.iter (fun ident -> map := (CString.Map.add ident (make_entry ()) !map); ()) idents;;
+  List.iter (fun ident -> map := CString.Map.add ident (make_entry ()) !map) idents
 
 let print_list hyps = List.iter (fun x -> cprintf "%s\n" (string_of_ppcmds (flatten x))) hyps
 let db_print_list hyps = List.iter (fun x -> cprintf "%s\n" (db_string_of_pp (flatten x))) hyps

--- a/test-suite/unit-tests/printing/proof_diffs_test.ml
+++ b/test-suite/unit-tests/printing/proof_diffs_test.ml
@@ -183,30 +183,37 @@ let t () =
 let _ = if false then add_test "diff_pp/add_diff_tags token containing white space" t
 
 let add_entries map idents rhs_pp =
-  let make_entry() = { idents; rhs_pp; done_ = false } in
+  let make_entry() = { idents; rhs_pp } in
   List.iter (fun ident -> map := CString.Map.add ident (make_entry ()) !map) idents
 
 let print_list hyps = List.iter (fun x -> cprintf "%s\n" (string_of_ppcmds (flatten x))) hyps
 let db_print_list hyps = List.iter (fun x -> cprintf "%s\n" (db_string_of_pp (flatten x))) hyps
 
 
-(* a : foo
-   b : bar car ->
+(* a : uint
+   b : int car ->
    b : car
-   a : foo bar *)
+   a : uint int
+DIFFS
+   b : car   (remove int)
+   b : car   (added bg only)
+   a: uint int (add int)
+*)
 let t () =
   write_diffs_option "removed";   (* turn on "removed" option *)
   let o_line_idents = [ ["a"]; ["b"]] in
   let o_hyp_map = ref CString.Map.empty in
-  add_entries o_hyp_map ["a"] (str " : foo");
-  add_entries o_hyp_map ["b"] (str " : bar car");
+  add_entries o_hyp_map ["a"] (str " : uint");
+  add_entries o_hyp_map ["b"] (str " : int car");
   let n_line_idents = [ ["b"]; ["a"]] in
   let n_hyp_map = ref CString.Map.empty in
   add_entries n_hyp_map ["b"] (str " : car");
-  add_entries n_hyp_map ["a"] (str " : foo bar");
-  let expected = [flatten (wrap_in_bg "diff.removed" (seq [str "b"; str " : "; (tag "diff.removed" (str "bar")); str " car" ]));
-                  flatten (wrap_in_bg "diff.added" (seq [str "b"; str " : car" ]));
-                  flatten (wrap_in_bg "diff.added" (seq [str "a"; str " : foo "; (tag "diff.added" (str "bar")) ]))
+  add_entries n_hyp_map ["a"] (str " : uint int");
+  let expected = [flatten (wrap_in_bg "diff.removed" (seq [str "b"; str " : ";
+                      (tag "diff.removed" (str "int")); str " car" ]));
+                  flatten (wrap_in_bg "diff.added" (seq [str "b"; str " : car"]));
+                  flatten (wrap_in_bg "diff.added" (seq [str "a";
+                      str " : uint "; (tag "diff.added" (str "int")) ]))
   ] in
 
   let hyps_diff_list = diff_hyps o_line_idents !o_hyp_map n_line_idents !n_hyp_map in
@@ -223,7 +230,10 @@ let _ = add_test "diff_hyps simple diffs" t
   c, d : int ->
   a, b : nat
   d : int
- and keeps old order *)
+DIFFS
+ c, d : int (remove c,)
+ a, b : nat (add ,b)
+ d : int *)
 let t () =
   write_diffs_option "removed";   (* turn on "removed" option *)
   let o_line_idents = [ ["a"]; ["c"; "d"]] in
@@ -234,9 +244,11 @@ let t () =
   let n_hyp_map = ref CString.Map.empty in
   add_entries n_hyp_map ["a"; "b"] (str " : nat");
   add_entries n_hyp_map ["d"] (str " : int");
-  let expected = [flatten (wrap_in_bg "diff.added" (seq [str "a"; (tag "start.diff.added" (str ", ")); (tag "end.diff.added" (str "b")); str " : nat" ]));
-                  flatten (wrap_in_bg "diff.removed" (seq [(tag "start.diff.removed" (str "c"));  (tag "end.diff.removed" (str ",")); str " "; str "d";  str " : int" ]));
-                  flatten (wrap_in_bg "diff.added" (seq [str "d"; str " : int" ]))
+  let expected = [flatten (wrap_in_bg "diff.added" (seq [str "a"; (tag "start.diff.added"
+                      (str ", ")); (tag "end.diff.added" (str "b")); str " : nat" ]));
+                  flatten (wrap_in_bg "diff.removed" (seq [(tag "start.diff.removed"
+                      (str "c")); (tag "end.diff.removed" (str ",")); str " "; str "d";  str " : int" ]));
+                  flatten (seq [str "d"; str " : int" ])
   ] in
 
   let hyps_diff_list = diff_hyps o_line_idents !o_hyp_map n_line_idents !n_hyp_map in
@@ -252,33 +264,33 @@ let t () =
       expected hyps_diff_list
 let _ = add_test "diff_hyps compacted" t
 
-(* a : foo
-   b : bar
+(* a : uint
+   b : int
    c : nat ->
    b, a, c : nat
 DIFFS
-   b : bar (remove bar)
-   b : nat (add nat)
-   a : foo (remove foo)
-   a : nat (add nat)
-   c : nat
+   a : uint (remove)
+   b : int (remove)
+   b, a, c : nat (add b, a,)
  is this a realistic use case?
 *)
 let t () =
   write_diffs_option "removed";   (* turn on "removed" option *)
   let o_line_idents = [ ["a"]; ["b"]; ["c"]] in
   let o_hyp_map = ref CString.Map.empty in
-  add_entries o_hyp_map ["a"] (str " : foo");
-  add_entries o_hyp_map ["b"] (str " : bar");
+  add_entries o_hyp_map ["a"] (str " : uint");
+  add_entries o_hyp_map ["b"] (str " : int");
   add_entries o_hyp_map ["c"] (str " : nat");
   let n_line_idents = [ ["b"; "a"; "c"] ] in
   let n_hyp_map = ref CString.Map.empty in
   add_entries n_hyp_map ["b"; "a"; "c"] (str " : nat");
-  let expected = [flatten (wrap_in_bg "diff.removed" (seq [str "b"; str " : "; (tag "diff.removed" (str "bar"))]));
-                  flatten (wrap_in_bg "diff.added" (seq [str "b"; str " : "; (tag "diff.added" (str "nat"))]));
-                  flatten (wrap_in_bg "diff.removed" (seq [str "a"; str " : "; (tag "diff.removed" (str "foo"))]));
-                  flatten (wrap_in_bg "diff.added" (seq [str "a"; str " : "; (tag "diff.added" (str "nat"))]));
-                  flatten (seq [str "c"; str " : nat"])
+  let expected = [flatten (wrap_in_bg "diff.removed" (seq [str "a"; str " : ";
+                      (tag "diff.removed" (str "uint"))]));
+                  flatten (wrap_in_bg "diff.removed" (seq [str "b"; str " : ";
+                      (tag "diff.removed" (str "int"))]));
+                  flatten (wrap_in_bg "diff.added" (seq [(tag "start.diff.added"
+                      (str "b")); str ", "; str "a"; (tag "end.diff.added" (str ","));
+                      str " "; str "c"; str " : nat"]))
   ] in
 
   let hyps_diff_list = diff_hyps o_line_idents !o_hyp_map n_line_idents !n_hyp_map in
@@ -292,14 +304,13 @@ let t () =
 let _ = add_test "diff_hyps compacted with join" t
 
 (* b, a, c : nat ->
-   a : foo
-   b : bar
+   a : uint
+   b : int
    c : nat
 DIFFS
-   a : nat (remove nat)
-   a : foo (add foo)
-   b : nat (remove nat)
-   b : bar (add bar)
+   b, a, c : nat (remove b,a,)
+   a : uint (add uint)
+   b : int (add int)
    c : nat
  is this a realistic use case? *)
 let t () =
@@ -309,13 +320,14 @@ let t () =
   add_entries o_hyp_map ["b"; "a"; "c"] (str " : nat");
   let n_line_idents = [ ["a"]; ["b"]; ["c"]] in
   let n_hyp_map = ref CString.Map.empty in
-  add_entries n_hyp_map ["a"] (str " : foo");
-  add_entries n_hyp_map ["b"] (str " : bar");
+  add_entries n_hyp_map ["a"] (str " : uint");
+  add_entries n_hyp_map ["b"] (str " : int");
   add_entries n_hyp_map ["c"] (str " : nat");
-  let expected = [flatten (wrap_in_bg "diff.removed" (seq [str "a"; str " : "; (tag "diff.removed" (str "nat"))]));
-                  flatten (wrap_in_bg "diff.added" (seq [str "a"; str " : "; (tag "diff.added" (str "foo"))]));
-                  flatten (wrap_in_bg "diff.removed" (seq [str "b"; str " : "; (tag "diff.removed" (str "nat"))]));
-                  flatten (wrap_in_bg "diff.added" (seq [str "b"; str " : "; (tag "diff.added" (str "bar"))]));
+  let expected = [flatten (wrap_in_bg "diff.removed" (seq [(tag "start.diff.removed"
+                      (str "b")); str ", "; str "a"; (tag "end.diff.removed" (str ","));
+                      str " "; str "c"; str " : nat"]));
+                  flatten (wrap_in_bg "diff.added" (seq [str "a"; str " : "; (tag "diff.added" (str "uint"))]));
+                  flatten (wrap_in_bg "diff.added" (seq [str "b"; str " : "; (tag "diff.added" (str "int"))]));
                   flatten (seq [str "c"; str " : nat"])
   ] in
 
@@ -329,6 +341,38 @@ let t () =
       expected hyps_diff_list
 let _ = add_test "diff_hyps compacted with split" t
 
+(* i : nat
+   b : bool
+   j : nat ->
+   i, j : nat
+DIFFS
+   b : bool (removed)
+   i, j : nat
+*)
+let t () =
+  write_diffs_option "removed";   (* turn on "removed" option *)
+  let o_line_idents = [ ["i"]; ["b"]; ["j"] ] in
+  let o_hyp_map = ref CString.Map.empty in
+  add_entries o_hyp_map ["i"] (str " : nat");
+  add_entries o_hyp_map ["b"] (str " : bool");
+  add_entries o_hyp_map ["j"] (str " : nat");
+  let n_line_idents = [ ["i"; "j"]] in
+  let n_hyp_map = ref CString.Map.empty in
+  add_entries n_hyp_map ["i"; "j"] (str " : nat");
+  let expected = [flatten (wrap_in_bg "diff.removed"
+                      (seq [tag "start.diff.removed" (str "b"); tag "end.diff.removed" (str " : bool")]));
+                  flatten (seq [str "i"; str ", "; str "j"; str " : nat"])
+  ] in
+
+  let hyps_diff_list = diff_hyps o_line_idents !o_hyp_map n_line_idents !n_hyp_map in
+
+  (* print_list hyps_diff_list; *)
+  (* db_print_list hyps_diff_list; *)
+
+  List.iter2 (fun exp act ->
+      assert_equal ~msg:"added"   ~printer:db_string_of_pp exp (flatten act))
+      expected hyps_diff_list
+let _ = add_test "diff_hyps removal causes compaction from #14577" t
 
 (* other potential tests
 coqtop/terminal formatting BLOCKED: CAN'T GET TAGS IN FORMATTER

--- a/test-suite/unit-tests/printing/proof_diffs_test_cases.v
+++ b/test-suite/unit-tests/printing/proof_diffs_test_cases.v
@@ -1,0 +1,43 @@
+(* additional test cases for manual testing *)
+Goal 1 + 1 = 3 -> False -> True.
+intro. clear H; intro.
+Abort.
+
+Goal nat -> bool -> nat -> True.
+intros i b j.
+revert b.
+cbn.
+Abort.
+
+Require Import Coq.Init.Number.
+
+Goal int -> uint -> nat -> nat -> nat -> nat ->True.
+  intros a b c.
+clear a b c; intros b a c.
+Abort.
+
+Goal int -> nat -> uint -> nat -> nat -> nat -> True.
+  intros a b c.
+clear a b c; intros c a b.
+Abort.
+
+Goal uint -> int -> nat -> nat -> nat -> nat -> True.
+intros a b c. clear a b c; intros b a c.
+Abort.
+
+Goal nat -> int -> int -> nat -> nat -> int -> True.
+intros a c d. clear a c d; intros a b d.
+Abort.
+
+Goal 1 = 0 -> True -> False -> True.
+intros X H. clear H; intro.
+Abort.
+
+Goal True -> True -> False -> False -> True.
+intros H H0. clear H H0; intros H H0.
+Abort.
+
+Goal True -> True -> False -> False -> False
+  -> True.
+intros H H0. clear H H0; intros H H0 H1.
+Abort.


### PR DESCRIPTION
~~Always Include every new line ident when diffing hypotheses lines so it looks similar to the undiffed hypotheses.~~

~~Spent an hour or two trying to add a test for this but couldn't get the test to work.  That's difficult to debug when print statements added in the Coq code for debugging don't show anything on the console or in the test log--there used to be a way to do that.  :-(~~

After looking at more test cases, I decided to rewrite the algorithm completely based on some better ideas.  The behavior of the new algorithm is easy to describe and the new code is fairly easy to follow.  I can't say that about the original algorithm.  The description is just before `Proof_diffs.diff_hyps`.

Fixes / closes #14577
