### PR TITLE
Progress in removing the compatibility layer in ssreflect

### DIFF
--- a/plugins/ssr/ssrbwd.ml
+++ b/plugins/ssr/ssrbwd.ml
@@ -43,28 +43,24 @@ let interp_agen ist gl ((goclr, _), (k, gc as c)) (clr, rcs) =
 
 let pf_pr_glob_constr gl = pr_glob_constr_env (pf_env gl) (project gl)
 
-let interp_nbargs ist gl rc =
+let interp_nbargs ist env sigma rc =
   try
     let rc6 = mkRApp rc (mkRHoles 6) in
-    let sigma, t = interp_open_constr (pf_env gl) (project gl) ist (rc6, None) in
-    let si = sig_it gl in
-    let gl = re_sig si sigma in
-    6 + Ssrcommon.nbargs_open_constr (pf_env gl) t
+    let sigma, t = interp_open_constr env sigma ist (rc6, None) in
+    6 + Ssrcommon.nbargs_open_constr env t
   with _ -> 5
 
-let interp_view_nbimps ist gl rc =
+let interp_view_nbimps ist env sigma rc =
   try
-    let sigma, t = interp_open_constr (pf_env gl) (project gl) ist (rc, None) in
-    let si = sig_it gl in
-    let gl = re_sig si sigma in
-    let pl, c = splay_open_constr (pf_env gl) t in
-    if Ssrcommon.isAppInd (pf_env gl) (project gl) c then List.length pl else (-(List.length pl))
+    let sigma, t = interp_open_constr env sigma ist (rc, None) in
+    let pl, c = splay_open_constr env t in
+    if Ssrcommon.isAppInd env sigma c then List.length pl else (-(List.length pl))
   with _ -> 0
 
 let interp_agens ist gl gagens =
   match List.fold_right (interp_agen ist gl) gagens ([], []) with
   | clr, rlemma :: args ->
-    let n = interp_nbargs ist gl rlemma - List.length args in
+    let n = interp_nbargs ist (pf_env gl) (project gl) rlemma - List.length args in
     let rec loop i =
       if i > n then
          errorstrm Pp.(str "Cannot apply lemma " ++ pf_pr_glob_constr gl rlemma)
@@ -74,53 +70,57 @@ let interp_agens ist gl gagens =
     clr, loop 0
   | _ -> assert false
 
-let pf_match = pf_apply (fun e s c t -> understand_tcc e s ~expected_type:t c)
-
-let apply_rconstr ?ist t gl =
+let apply_rconstr ?ist t =
+  Proofview.Goal.enter begin fun gl ->
+  let env = Proofview.Goal.env gl in
+  let sigma = Proofview.Goal.sigma gl in
+  let cl = Proofview.Goal.concl gl in
 (* ppdebug(lazy(str"sigma@apply_rconstr=" ++ pr_evar_map None (project gl))); *)
   let n = match ist, DAst.get t with
-    | None, (GVar id | GRef (Names.GlobRef.VarRef id,_)) -> pf_nbargs (pf_env gl) (project gl) (EConstr.mkVar id)
-    | Some ist, _ -> interp_nbargs ist gl t
+    | None, (GVar id | GRef (Names.GlobRef.VarRef id,_)) -> pf_nbargs env sigma (EConstr.mkVar id)
+    | Some ist, _ -> interp_nbargs ist env sigma t
     | _ -> anomaly "apply_rconstr without ist and not RVar" in
   let mkRlemma i = mkRApp t (mkRHoles i) in
-  let cl = pf_concl gl in
   let rec loop i =
     if i > n then
-      errorstrm Pp.(str"Cannot apply lemma "++pf_pr_glob_constr gl t)
-    else try pf_match gl (mkRlemma i) (OfType cl) with _ -> loop (i + 1) in
-  Proofview.V82.of_tactic (refine_with (loop 0)) gl
+      errorstrm Pp.(str"Cannot apply lemma "++pr_glob_constr_env env sigma t)
+    else try understand_tcc env sigma ~expected_type:(OfType cl) (mkRlemma i) with _ -> loop (i + 1) in
+  refine_with (loop 0)
+  end
 
-let mkRAppView ist gl rv gv =
-  let nb_view_imps = interp_view_nbimps ist gl rv in
+let mkRAppView ist env sigma rv gv =
+  let nb_view_imps = interp_view_nbimps ist env sigma rv in
   mkRApp rv (mkRHoles (abs nb_view_imps))
 
-let refine_interp_apply_view dbl ist gl gv =
+let refine_interp_apply_view dbl ist gv =
+  Proofview.V82.tactic begin fun gl ->
   let pair i = List.map (fun x -> i, x) in
   let rv = pf_intern_term ist gl gv in
-  let v = mkRAppView ist gl rv gv in
+  let v = mkRAppView ist (pf_env gl) (project gl) rv gv in
   let interp_with (dbl, hint) =
     let i = if dbl = Ssrview.AdaptorDb.Equivalence then 2 else 1 in
     interp_refine ist gl (mkRApp hint (v :: mkRHoles i)) in
   let rec loop = function
-  | [] -> (try apply_rconstr ~ist rv gl with _ -> view_error "apply" gv)
+  | [] -> (try Proofview.V82.of_tactic (apply_rconstr ~ist rv) gl with _ -> view_error "apply" gv)
   | h :: hs -> (try Proofview.V82.of_tactic (refine_with (snd (interp_with h))) gl with _ -> loop hs) in
   loop (pair dbl (Ssrview.AdaptorDb.get dbl) @
         if dbl = Ssrview.AdaptorDb.Equivalence
         then pair Ssrview.AdaptorDb.Backward (Ssrview.AdaptorDb.(get Backward))
         else [])
+  end
 
 let apply_top_tac =
   Proofview.Goal.enter begin fun _ ->
   Tacticals.New.tclTHENLIST [
     introid top_id;
-    Proofview.V82.tactic (apply_rconstr (mkRVar top_id));
+    apply_rconstr (mkRVar top_id);
     cleartac [SsrHyp(None,top_id)]
   ]
   end
 
 let inner_ssrapplytac gviews (ggenl, gclr) ist = Proofview.V82.tactic ~nf_evars:false (fun gl ->
  let _, clr = interp_hyps ist gl gclr in
- let vtac gv i gl' = refine_interp_apply_view i ist gl' gv in
+ let vtac gv i = refine_interp_apply_view i ist gv in
  let ggenl, tclGENTAC =
    if gviews <> [] && ggenl <> [] then
      let ggenl= List.map (fun (x,(k,p)) -> x, {kind=k; pattern=p; interpretation= Some ist}) (List.hd ggenl) in
@@ -133,11 +133,11 @@ let inner_ssrapplytac gviews (ggenl, gclr) ist = Proofview.V82.tactic ~nf_evars:
       if List.length tl = 1
       then Ssrview.AdaptorDb.Equivalence
       else Ssrview.AdaptorDb.Backward in
-    Tacticals.tclTHEN
+    Proofview.V82.of_tactic (Tacticals.New.tclTHEN
       (List.fold_left (fun acc v ->
-         Tacticals.tclTHENLAST acc (vtac v dbl))
+         Tacticals.New.tclTHENLAST acc (vtac v dbl))
         (vtac v Ssrview.AdaptorDb.Backward) tl)
-      (old_cleartac clr) gl
+      (cleartac clr)) gl
   | [], [agens] ->
     let clr', (sigma, lemma) = interp_agens ist gl agens in
     let gl = pf_merge_uc_of sigma gl in

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -781,11 +781,11 @@ let mkSsrRef name =
   if Coqlib.has_ref qn then Coqlib.lib_ref qn else
   CErrors.user_err Pp.(str "Small scale reflection library not loaded (" ++ str name ++ str ")")
 let mkSsrRRef name = (DAst.make @@ GRef (mkSsrRef name,None)), None
-let mkSsrConst name env sigma =
+let mkSsrConst env sigma name =
   EConstr.fresh_global env sigma (mkSsrRef name)
 let pf_mkSsrConst name gl =
   let sigma, env, it = project gl, pf_env gl, sig_it gl in
-  let (sigma, t) = mkSsrConst name env sigma in
+  let (sigma, t) = mkSsrConst env sigma name in
   t, re_sig it sigma
 let pf_fresh_global name gl =
   let sigma, env, it = project gl, pf_env gl, sig_it gl in
@@ -1238,7 +1238,7 @@ let pfLIFT f =
 ;;
 
 let is_protect hd env sigma =
-  let _, protectC = mkSsrConst "protect_term" env sigma in
+  let _, protectC = mkSsrConst env sigma "protect_term" in
   EConstr.eq_constr_nounivs sigma hd protectC
 
 let abs_wgen keep_let f gen (gl,args,c) =
@@ -1497,7 +1497,7 @@ end
 let tacMK_SSR_CONST name =
   Proofview.tclENV >>= fun env ->
   Proofview.tclEVARMAP >>= fun sigma ->
-  match mkSsrConst name env sigma with
+  match mkSsrConst env sigma name with
   | sigma, c -> Unsafe.tclEVARS sigma <*> tclUNIT c
   | exception e when CErrors.noncritical e ->
     tclLIFT (Proofview.NonLogical.raise (e, Exninfo.null))

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -823,26 +823,6 @@ let discharge_hyp (id', (id, mode)) gl =
      Proofview.V82.of_tactic
        (convert_concl ~check:true (EConstr.of_constr (mkLetIn (id', v, t, cl')))) gl
 
-(* wildcard names *)
-let clear_wilds wilds gl =
-  Proofview.V82.of_tactic (Tactics.clear (List.filter (fun id -> List.mem id wilds) (pf_ids_of_hyps gl))) gl
-
-let clear_with_wilds wilds clr0 gl =
-  let extend_clr clr nd =
-    let id = NamedDecl.get_id nd in
-    if List.mem id clr || not (List.mem id wilds) then clr else
-    let vars = Termops.global_vars_set_of_decl (pf_env gl) (project gl) nd in
-    let occurs id' = Id.Set.mem id' vars in
-    if List.exists occurs clr then id :: clr else clr in
-  Proofview.V82.of_tactic (Tactics.clear (Context.Named.fold_inside extend_clr ~init:clr0 (Tacmach.pf_hyps gl))) gl
-
-let clear_wilds_and_tmp_and_delayed_ids gl =
-  let _, ctx = pull_ctx gl in
-  tac_ctx
-   (tclTHEN
-    (clear_with_wilds ctx.wild_ids ctx.delayed_clears)
-    (clear_wilds (List.map fst ctx.tmp_ids @ ctx.wild_ids))) gl
-
 let view_error s gv =
   errorstrm (str ("Cannot " ^ s ^ " view ") ++ pr_term gv)
 

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -752,6 +752,12 @@ let pf_abs_cterm gl n c0 = abs_cterm (pf_env gl) (project gl) n c0
 
 (* }}} *)
 
+let merge_uc uc =
+  let open Proofview.Notations in
+  Proofview.tclEVARMAP >>= fun sigma ->
+  try Proofview.Unsafe.tclEVARS (Evd.merge_universe_context sigma uc)
+  with e when CErrors.noncritical e -> Proofview.tclZERO e
+
 let pf_merge_uc uc gl =
   re_sig (sig_it gl) (Evd.merge_universe_context gl.Evd.sigma uc)
 let pf_merge_uc_of sigma gl =

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -1238,8 +1238,8 @@ let pfLIFT f =
 ;;
 
 let is_protect hd env sigma =
-  let _, protectC = mkSsrConst env sigma "protect_term" in
-  EConstr.eq_constr_nounivs sigma hd protectC
+  let protectC = mkSsrRef "protect_term" in
+  EConstr.isRefX sigma protectC hd
 
 let abs_wgen keep_let f gen (gl,args,c) =
   let sigma, env = project gl, pf_env gl in

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -235,12 +235,12 @@ let isAppInd env sigma c =
 
 (** Generic argument-based globbing/typing utilities *)
 
-let interp_refine ist gl rc =
-  let constrvars = Tacinterp.extract_ltac_constr_values ist (pf_env gl) in
+let interp_refine env sigma ist ~concl rc =
+  let constrvars = Tacinterp.extract_ltac_constr_values ist env in
   let vars = { Glob_ops.empty_lvar with
     Ltac_pretype.ltac_constrs = constrvars; ltac_genargs = ist.Tacinterp.lfun
   } in
-  let kind = Pretyping.OfType (pf_concl gl) in
+  let kind = Pretyping.OfType concl in
   let flags = {
     Pretyping.use_typeclasses = Pretyping.UseTC;
     solve_unification_constraints = true;
@@ -250,9 +250,9 @@ let interp_refine ist gl rc =
     polymorphic = false;
   }
   in
-  let sigma, c = Pretyping.understand_ltac flags (pf_env gl) (project gl) vars kind rc in
+  let sigma, c = Pretyping.understand_ltac flags env sigma vars kind rc in
 (*   ppdebug(lazy(str"sigma@interp_refine=" ++ pr_evar_map None sigma)); *)
-  debug_ssr (fun () -> str"c@interp_refine=" ++ Printer.pr_econstr_env (pf_env gl) sigma c);
+  debug_ssr (fun () -> str"c@interp_refine=" ++ Printer.pr_econstr_env env sigma c);
   (sigma, (sigma, c))
 
 
@@ -831,7 +831,7 @@ let discharge_hyp (id', (id, mode)) =
   end
 
 let view_error s gv =
-  errorstrm (str ("Cannot " ^ s ^ " view ") ++ pr_term gv)
+  Tacticals.New.tclZEROMSG (str ("Cannot " ^ s ^ " view ") ++ pr_term gv)
 
 
 open Locus

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -871,7 +871,9 @@ let pf_abs_ssrterm ?(resolve_typeclasses=false) ist gl t =
        let sigma = Typeclasses.resolve_typeclasses ~fail:false env sigma in
        sigma, Evarutil.nf_evar sigma ct in
   let n, c, abstracted_away, ucst = pf_abs_evars gl t in
-  List.fold_left Evd.remove sigma abstracted_away, pf_abs_cterm gl n c, ucst, n
+  let t = pf_abs_cterm gl n c in
+  let gl = pf_merge_uc ucst gl in
+  gl, t, n
 
 let top_id = mk_internal_id "top assumption"
 

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -842,18 +842,18 @@ let rewritetac ?(under=false) dir c =
 
 type name_hint = (int * EConstr.types array) option ref
 
-let pf_abs_ssrterm ?(resolve_typeclasses=false) ist gl t =
-  let sigma, ct as t = interp_term (pf_env gl) (project gl) ist t in
+let abs_ssrterm ?(resolve_typeclasses=false) ist env sigma t =
+  let sigma0 = sigma in
+  let sigma, ct as t = interp_term env sigma ist t in
   let sigma, _ as t =
-    let env = pf_env gl in
     if not resolve_typeclasses then t
     else
        let sigma = Typeclasses.resolve_typeclasses ~fail:false env sigma in
        sigma, Evarutil.nf_evar sigma ct in
-  let n, c, abstracted_away, ucst = pf_abs_evars gl t in
-  let t = pf_abs_cterm gl n c in
-  let gl = pf_merge_uc ucst gl in
-  gl, t, n
+  let n, c, abstracted_away, ucst = abs_evars env sigma0 t in
+  let t = abs_cterm env sigma0 n c in
+  let sigma = Evd.merge_universe_context sigma0 ucst in
+  sigma, t, n
 
 let top_id = mk_internal_id "top assumption"
 

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -292,8 +292,7 @@ val mkRefl :
   Goal.goal Evd.sigma -> EConstr.t * Goal.goal Evd.sigma
 
 val discharge_hyp :
-           Id.t * (Id.t * string) ->
-           Goal.goal Evd.sigma -> Evar.t list Evd.sigma
+           Id.t * (Id.t * string) -> unit Proofview.tactic
 
 val view_error : string -> ssrterm -> 'a
 

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -300,12 +300,12 @@ val view_error : string -> ssrterm -> 'a
 
 val top_id : Id.t
 
-val pf_abs_ssrterm :
+val abs_ssrterm :
            ?resolve_typeclasses:bool ->
            ist ->
-           Goal.goal Evd.sigma ->
+           Environ.env -> Evd.evar_map ->
            ssrterm ->
-           Goal.goal Evd.sigma * EConstr.t * int
+           Evd.evar_map * EConstr.t * int
 
 val pf_interp_ty :
            ?resolve_typeclasses:bool ->

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -295,10 +295,6 @@ val discharge_hyp :
            Id.t * (Id.t * string) ->
            Goal.goal Evd.sigma -> Evar.t list Evd.sigma
 
-val clear_wilds_and_tmp_and_delayed_ids :
-           (Goal.goal * tac_ctx) Evd.sigma ->
-           (Goal.goal * tac_ctx) list Evd.sigma
-
 val view_error : string -> ssrterm -> 'a
 
 

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -211,6 +211,7 @@ val pf_abs_evars2 : (* ssr2 *)
 val pf_abs_cterm :
            Goal.goal Evd.sigma -> int -> EConstr.t -> EConstr.t
 
+val merge_uc : UState.t -> unit Proofview.tactic
 val pf_merge_uc :
            UState.t -> 'a Evd.sigma -> 'a Evd.sigma
 val pf_merge_uc_of :

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -232,7 +232,9 @@ val pf_abs_prod :
            EConstr.t ->
            EConstr.t -> Goal.goal Evd.sigma * EConstr.types
 
+val mkSsrRef : string -> GlobRef.t
 val mkSsrRRef : string -> Glob_term.glob_constr * 'a option
+val mkSsrConst : Environ.env -> Evd.evar_map -> string -> Evd.evar_map * EConstr.t
 
 val new_wild_id : tac_ctx -> Names.Id.t * tac_ctx
 

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -396,7 +396,6 @@ val interp_clr :
 val genclrtac :
   EConstr.constr ->
   EConstr.constr list -> Ssrast.ssrhyp list -> Tacmach.tactic
-val old_cleartac : ssrhyps -> v82tac
 val cleartac : ssrhyps -> unit Proofview.tactic
 
 val tclMULT : int * ssrmmod -> unit Proofview.tactic -> unit Proofview.tactic

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -309,7 +309,7 @@ val pf_abs_ssrterm :
            ist ->
            Goal.goal Evd.sigma ->
            ssrterm ->
-           evar_map * EConstr.t * UState.t * int
+           Goal.goal Evd.sigma * EConstr.t * int
 
 val pf_interp_ty :
            ?resolve_typeclasses:bool ->

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -142,7 +142,7 @@ val interp_hyp : ist -> goal sigma -> ssrhyp -> evar_map * ssrhyp
 val interp_hyps : ist -> goal sigma -> ssrhyps -> evar_map * ssrhyps
 
 val interp_refine :
-  Tacinterp.interp_sign -> Goal.goal Evd.sigma ->
+  Environ.env -> Evd.evar_map -> Tacinterp.interp_sign -> concl:EConstr.constr ->
     Glob_term.glob_constr -> evar_map * (evar_map * EConstr.constr)
 
 val interp_open_constr :
@@ -297,7 +297,7 @@ val mkRefl :
 val discharge_hyp :
            Id.t * (Id.t * string) -> unit Proofview.tactic
 
-val view_error : string -> ssrterm -> 'a
+val view_error : string -> ssrterm -> 'a Proofview.tactic
 
 
 val top_id : Id.t

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -391,7 +391,7 @@ val pfLIFT
 (** Basic tactics *)
 
 val introid : ?orig:Name.t ref -> Id.t -> unit Proofview.tactic
-val intro_anon : v82tac
+val intro_anon : unit Proofview.tactic
 
 val interp_clr :
   evar_map -> ssrhyps option * (ssrtermkind * EConstr.t) -> ssrhyps

--- a/plugins/ssr/ssrelim.ml
+++ b/plugins/ssr/ssrelim.ml
@@ -504,7 +504,7 @@ let equality_inj l b id c = Proofview.Goal.enter begin fun gl ->
         let open Proofview.Notations in
         Ssrcommon.tacTYPEOF (EConstr.mkVar id) >>= fun ty ->
         nothing_to_inject (Proofview.Goal.sigma gl, Proofview.Goal.env gl, ty);
-        Proofview.V82.tactic (discharge_hyp (id, (id, "")))
+        discharge_hyp (id, (id, ""))
     | (e,info) -> Proofview.tclZERO ~info e)
   end
 

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -85,7 +85,7 @@ let interp_congrarg_at ist gl n rf ty m =
     try
       let rt = mkRApp congrn (args1 @  mkRApp rf (mkRHoles i) :: args2) in
       debug_ssr (fun () -> Pp.(str"rt=" ++ Printer.pr_glob_constr_env (pf_env gl) (project gl) rt));
-      Some (interp_refine ist gl rt)
+      Some (interp_refine (pf_env gl) (project gl) ist ~concl:(pf_concl gl) rt)
     with _ -> loop (i + 1) in
   loop 0
 

--- a/plugins/ssr/ssrfwd.ml
+++ b/plugins/ssr/ssrfwd.ml
@@ -320,6 +320,8 @@ let wlogtac ist (((clr0, pats),_),_) (gens, ((_, ct))) hint suff ghave =
 
 (** The "suffice" tactic *)
 
+open Proofview.Notations
+
 let sufftac ist ((((clr, pats),binders),simpl), ((_, c), hint)) =
   let clr = Option.default [] clr in
   let pats = tclCompileIPats pats in
@@ -339,13 +341,12 @@ let sufftac ist ((((clr, pats),binders),simpl), ((_, c), hint)) =
     end
   in
   let ctac =
-    Proofview.V82.tactic begin fun gl ->
-    let _,ty,_,uc = pf_interp_ty (pf_env gl) (project gl) ist c in let gl = pf_merge_uc uc gl in
-    Proofview.V82.of_tactic (basesufftac ty) gl
+    let open Tacmach.New in
+    Proofview.Goal.enter begin fun gl ->
+    let _,ty,_,uc = pf_interp_ty (pf_env gl) (project gl) ist c in
+    merge_uc uc <*> basesufftac ty
   end in
   Tacticals.New.tclTHENS ctac [htac; Tacticals.New.tclTHEN (cleartac clr) (introstac (binders@simpl))]
-
-open Proofview.Notations
 
 let is_app_evar sigma t =
   match EConstr.kind sigma t with

--- a/plugins/ssr/ssrfwd.ml
+++ b/plugins/ssr/ssrfwd.ml
@@ -192,7 +192,8 @@ let havetac ist
        | IOpAbstractVars ids -> ids
        | _ -> assert false) skols) in
      let skols_args =
-       List.map (fun id -> Ssripats.Internal.examine_abstract (EConstr.mkVar id) gl) skols in
+       List.map (fun id -> snd @@ (* FIXME: evar leak *)
+         Ssripats.Internal.examine_abstract (pf_env gl) (project gl) (EConstr.mkVar id)) skols in
      let gl = List.fold_right unlock_abs skols_args gl in
      let gl, t, n_evars =
        interp gl false (combineCG ct cty (mkCCast ?loc) mkRCast) in
@@ -202,7 +203,7 @@ let havetac ist
                      "not supported");
      let gs =
        List.map (fun (_,a) ->
-         Ssripats.Internal.pf_find_abstract_proof false gl (EConstr.Unsafe.to_constr a.(1))) skols_args in
+         Ssripats.Internal.find_abstract_proof (pf_env gl) (project gl) false a.(1)) skols_args in
      let tacopen_skols = Proofview.V82.tactic (fun gl -> re_sig (gs @ [gl.Evd.it]) gl.Evd.sigma) in
      let gl, ty = pf_e_type_of gl t in
      gl, ty, Tactics.apply t, id,

--- a/plugins/ssr/ssripats.mli
+++ b/plugins/ssr/ssripats.mli
@@ -80,7 +80,7 @@ val ssrabstract : ssrdgens -> unit Proofview.tactic
  * tactic monad we export code with the V82 interface *)
 module Internal : sig
 val examine_abstract :
-  EConstr.t -> Goal.goal Evd.sigma -> EConstr.types * EConstr.t array
-val pf_find_abstract_proof :
-  bool -> Goal.goal Evd.sigma -> Constr.constr -> Evar.t
+  Environ.env -> Evd.evar_map -> EConstr.t -> Evd.evar_map * (EConstr.types * EConstr.t array)
+val find_abstract_proof :
+  Environ.env -> Evd.evar_map -> bool -> EConstr.constr -> Evar.t
 end


### PR DESCRIPTION
I am getting tired of restarting this from scratch every six months, so let's push a bit of progress for the time being. As usual, each commit compiles separately so that it will be easier to do a post-mortem bisect if something goes wrong in released code.

(There are some real fixes in this PR, by the way.)