### PR TITLE
Remove the last call to interp_wit from ssreflect.

### DIFF
--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -18,7 +18,6 @@ open Constrexpr
 open Ssrast
 
 open Ltac_plugin
-open Genarg
 
 open Ssrmatching_plugin
 
@@ -134,9 +133,6 @@ val interp_term :
   Environ.env -> Evd.evar_map ->
   Tacinterp.interp_sign ->
     ssrterm -> evar_map * EConstr.t
-
-val interp_wit :
-  ('a, 'b, 'c) genarg_type -> ist -> goal sigma -> 'b -> evar_map * 'c
 
 val interp_hyp : ist -> env -> evar_map -> ssrhyp -> ssrhyp
 val interp_hyps : ist -> goal sigma -> ssrhyps -> evar_map * ssrhyps


### PR DESCRIPTION
This was using dubious calls to the tactic monad, or even worse, the Ltac-specific and probably quite broken Ftactic wrapper. Since this was a useless circumvolution, it is better to simply call the base API.
