### PR TITLE
Don't gitignore user-contrib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,9 +134,6 @@ ide/coqide/index_urls.txt
 # coqide generated files (when testing)
 *.crashcoqide
 
-/user-contrib/*
-!/user-contrib/Ltac2
-
 .*.sw*
 .#*
 


### PR DESCRIPTION
CI scripts used to install into it, but now they install in _build or _build_vo
