### PR TITLE
Remove some compat layer in ssreflect, take two

### DIFF
--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -658,9 +658,6 @@ let abs_evars_pirrel env sigma0 (sigma, c0) =
   pp(lazy(str"res= " ++ pr_constr res));
   List.length evlist, res
 
-let pf_abs_evars_pirrel gl c =
-  abs_evars_pirrel (pf_env gl) (project gl) c
-
 (* Strip all non-essential dependencies from an abstracted term, generating *)
 (* standard names for the abstracted holes.                                 *)
 
@@ -684,9 +681,6 @@ let pfe_new_type gl =
 let pfe_type_relevance_of env sigma t =
   let sigma, ty = Typing.type_of env sigma t in
   sigma, ty, Retyping.relevance_of_term env sigma t
-let pf_type_of gl t =
-  let sigma, ty = pf_type_of gl (EConstr.of_constr t) in
-  re_sig (sig_it gl)  sigma, EConstr.Unsafe.to_constr ty
 
 let abs_cterm env sigma n c0 =
   if n <= 0 then c0 else
@@ -756,8 +750,6 @@ let pf_mkprod gl c ?(name=constr_name (project gl) c) cl =
   let gl = re_sig (sig_it gl) sigma in
   if name <> Anonymous || EConstr.Vars.noccurn (project gl) 1 cl then gl, EConstr.mkProd (make_annot name r, t, cl) else
   gl, EConstr.mkProd (make_annot (Name (pf_type_id gl t)) r, t, cl)
-
-let pf_abs_prod name gl c cl = pf_mkprod gl c ~name (Termops.subst_term (project gl) c cl)
 
 (** look up a name in the ssreflect internals module *)
 let ssrdirpath = DirPath.make [Id.of_string "ssreflect"]
@@ -1165,8 +1157,6 @@ let pf_interp_gen_aux gl to_ind ((oclr, occ), t) =
     let gl = re_sig (sig_it gl) sigma in
     false, pat, EConstr.mkProd (make_annot (constr_name (project gl) c) rp, pty, Tacmach.Old.pf_concl gl), p, clr,ucst,gl
   else CErrors.user_err ?loc:(loc_of_cpattern t) (str "generalized term didn't match")
-
-let apply_type x xs = Proofview.V82.of_tactic (Tactics.apply_type ~typecheck:true x xs)
 
 let genclrtac cl cs clr =
   let open Proofview.Notations in

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -270,9 +270,9 @@ let interp_hyp ist env sigma (SsrHyp (loc, id)) =
   if not_section_id id' then SsrHyp (loc, id') else
   hyp_err ?loc "Can't clear section hypothesis " id'
 
-let interp_hyps ist gl ghyps =
-  let hyps = List.map (interp_hyp ist (pf_env gl) (project gl)) ghyps in
-  check_hyps_uniq [] hyps; Tacmach.Old.project gl, hyps
+let interp_hyps ist env sigma ghyps =
+  let hyps = List.map (interp_hyp ist env sigma) ghyps in
+  check_hyps_uniq [] hyps; hyps
 
 (* Old terms *)
 let mk_term k c = k, (mkRHole, Some c)

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -255,10 +255,6 @@ val pf_abs_evars_pirrel :
            evar_map * Constr.constr -> int * Constr.constr
 val nbargs_open_constr : Environ.env -> Evd.evar_map * EConstr.t -> int
 val pf_nbargs : Environ.env -> Evd.evar_map -> EConstr.t -> int
-val gen_tmp_ids :
-           ?ist:Geninterp.interp_sign ->
-           (Goal.goal * tac_ctx) Evd.sigma ->
-           (Goal.goal * tac_ctx) list Evd.sigma
 
 val ssrevaltac :
   Tacinterp.interp_sign -> Tacinterp.Value.t -> unit Proofview.tactic

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -393,7 +393,7 @@ val interp_clr :
 
 val genclrtac :
   EConstr.constr ->
-  EConstr.constr list -> Ssrast.ssrhyp list -> Tacmach.Old.tactic
+  EConstr.constr list -> Ssrast.ssrhyp list -> unit Proofview.tactic
 val cleartac : ssrhyps -> unit Proofview.tactic
 
 val tclMULT : int * ssrmmod -> unit Proofview.tactic -> unit Proofview.tactic

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -135,7 +135,7 @@ val interp_term :
     ssrterm -> evar_map * EConstr.t
 
 val interp_hyp : ist -> env -> evar_map -> ssrhyp -> ssrhyp
-val interp_hyps : ist -> goal sigma -> ssrhyps -> evar_map * ssrhyps
+val interp_hyps : ist -> env -> evar_map -> ssrhyps -> ssrhyps
 
 val interp_refine :
   Environ.env -> Evd.evar_map -> Tacinterp.interp_sign -> concl:EConstr.constr ->

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -212,18 +212,10 @@ val pf_merge_uc :
 val pf_merge_uc_of :
            evar_map -> 'a Evd.sigma -> 'a Evd.sigma
 val constr_name : evar_map -> EConstr.t -> Name.t
-val pf_type_of :
-           Goal.goal Evd.sigma ->
-           Constr.constr -> Goal.goal Evd.sigma * Constr.types
 val pfe_type_of :
            Goal.goal Evd.sigma ->
            EConstr.t -> Goal.goal Evd.sigma * EConstr.types
 val pfe_new_type : Goal.goal Evd.sigma -> Goal.goal Evd.sigma * EConstr.types
-val pf_abs_prod :
-           Name.t ->
-           Goal.goal Evd.sigma ->
-           EConstr.t ->
-           EConstr.t -> Goal.goal Evd.sigma * EConstr.types
 
 val mkSsrRef : string -> GlobRef.t
 val mkSsrRRef : string -> Glob_term.glob_constr * 'a option
@@ -246,9 +238,6 @@ val new_tmp_id :
 val mk_anon_id : string -> Id.t list -> Id.t
 val abs_evars_pirrel :
            Environ.env -> Evd.evar_map ->
-           evar_map * Constr.constr -> int * Constr.constr
-val pf_abs_evars_pirrel :
-           Goal.goal Evd.sigma ->
            evar_map * Constr.constr -> int * Constr.constr
 val nbargs_open_constr : Environ.env -> Evd.evar_map * EConstr.t -> int
 val pf_nbargs : Environ.env -> Evd.evar_map -> EConstr.t -> int
@@ -412,8 +401,6 @@ val clr_of_wgen :
 
 
 val unfold : EConstr.t list -> unit Proofview.tactic
-
-val apply_type : EConstr.types -> EConstr.t list -> Proofview.V82.tac
 
 (* New code ****************************************************************)
 

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -219,9 +219,6 @@ val pfe_type_of :
            Goal.goal Evd.sigma ->
            EConstr.t -> Goal.goal Evd.sigma * EConstr.types
 val pfe_new_type : Goal.goal Evd.sigma -> Goal.goal Evd.sigma * EConstr.types
-val pfe_type_relevance_of :
-           Goal.goal Evd.sigma ->
-           EConstr.t -> Goal.goal Evd.sigma * EConstr.types * Sorts.relevance
 val pf_abs_prod :
            Name.t ->
            Goal.goal Evd.sigma ->
@@ -398,14 +395,16 @@ val unprotecttac : unit Proofview.tactic
 val is_protect : EConstr.t -> Environ.env -> Evd.evar_map -> bool
 
 val abs_wgen :
+  Environ.env ->
+  Evd.evar_map ->
   bool ->
   (Id.t -> Id.t) ->
   'a *
     ((Ssrast.ssrhyp_or_id * string) *
        Ssrmatching.cpattern option)
       option ->
-  Goal.goal Evd.sigma * EConstr.t list * EConstr.t ->
-  Goal.goal Evd.sigma * EConstr.t list * EConstr.t
+  EConstr.t list * EConstr.t ->
+  Evd.evar_map * EConstr.t list * EConstr.t
 
 val clr_of_wgen :
   ssrhyps * ((ssrhyp_or_id * 'a) * 'b option) option ->

--- a/plugins/ssr/ssrfwd.ml
+++ b/plugins/ssr/ssrfwd.ml
@@ -262,7 +262,11 @@ let wlogtac ist (((clr0, pats),_),_) (gens, ((_, ct))) hint suff ghave =
   Proofview.V82.tactic begin fun gl ->
   let clr0 = Option.default [] clr0 in
   let pats = tclCompileIPats pats in
-  let mkabs gen = abs_wgen false (fun x -> x) gen in
+  let mkabs gen (gl, args, c) =
+    let sigma, args, c = abs_wgen (pf_env gl) (project gl) false (fun x -> x) gen (args, c) in
+    let gl = re_sig (sig_it gl) sigma in
+    gl, args, c
+  in
   let mkclr gen clrs = clr_of_wgen gen clrs in
   let mkpats = function
   | _, Some ((x, _), _) -> fun pats -> IOpId (hoi_id x) :: pats


### PR DESCRIPTION
Small progress towards the goal (or removal thereof, pun intended).

@gares FTR I am encountering fancy bugs with later patches due to the fact that the V82 compat functions silently erase the ssr goal state. This (arguably) buggy behaviour turns out to be necessary to make the move pattern compilation work correctly and it is a hell to debug, so let stick to this partial PR for now. I think I'll need a bit of help to understand the expected invariants before losing my mental sanity.