### PR TITLE
[CI] Add a CI job to test the MetaCoq artifact

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -819,6 +819,13 @@ plugin:ci-metacoq:
   - build:base
   - plugin:ci-equations
 
+plugin:ci-metacoq_test_artifact:
+  extends: .ci-template
+  needs:
+  - build:base
+  - plugin:ci-equations
+  - plugin:ci-metacoq
+
 plugin:ci-mtac2:
   extends: .ci-template
 

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -48,6 +48,7 @@ CI_TARGETS= \
     ci-mczify \
     ci-menhir \
     ci-metacoq \
+    ci-metacoq_test_artifact \
     ci-mtac2 \
     ci-oddorder \
     ci-paramcoq \
@@ -103,6 +104,7 @@ ci-simple_io: ci-ext_lib
 ci-quickchick: ci-ext_lib ci-simple_io ci-mathcomp
 
 ci-metacoq: ci-equations
+ci-metacoq_test_artifact: ci-metacoq
 
 ci-vst: ci-flocq
 

--- a/dev/ci/ci-metacoq_test_artifact.sh
+++ b/dev/ci/ci-metacoq_test_artifact.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+# this dummy file exists only so that we have a script to run for
+# ci-metacoq_test_artifact.  This CI target is really only present to
+# ensure that running the ci-metacoq script again in the artifact in
+# fact installs the code, ideally without rebuilding it, which is
+# necessary for the bug minimizer to be able to minimize metacoq


### PR DESCRIPTION
This will ensure that the MetaCoq CI job continues to be minimizable,
and will catch issues like https://github.com/MetaCoq/metacoq/issues/605
earlier.  It's plausible that we should instead have a general CI target
that is dependent on all successful CI targets (perhaps split amongst
the various base Coq jobs), to test this everywhere.  Or perhaps the CI
should run each ci-script.sh twice, which might be a good enough
approximation.

