### PR TITLE
Remove V82 compatibility layer used in printing.

### DIFF
--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -187,12 +187,11 @@ let process_goal sigma g =
   { Interface.goal_hyp = List.rev hyps; Interface.goal_ccl = ccl; Interface.goal_id = Goal.uid g; Interface.goal_name = name }
 
 let process_goal_diffs diff_goal_map oldp nsigma ng =
-  let open Evd in
   let name = if Printer.print_goal_names () then Some (Names.Id.to_string (Termops.evar_suggested_name (Global.env ()) nsigma ng)) else None in
   let og_s = match oldp with
     | Some oldp ->
       let Proof.{ sigma=osigma } = Proof.data oldp in
-      (try Some { it = Evar.Map.find ng diff_goal_map; sigma = osigma }
+      (try Some (Evar.Map.find ng diff_goal_map, osigma)
        with Not_found -> None)
     | None -> None
   in

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -725,7 +725,7 @@ let pr_subgoals ?(pr_first=true) ?(diffs=false) ?os_map
       (* if Not_found, returning None treats the goal as new and it will be diff highlighted;
          returning Some { it = g; sigma = sigma } will compare the new goal
          to itself and it won't be highlighted *)
-      (try Some { it = GoalMap.find g diff_goal_map; sigma = osigma }
+      (try Some (GoalMap.find g diff_goal_map, osigma)
       with Not_found -> None)
     | None -> None
   in

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -194,7 +194,7 @@ val pr_transparent_state   : TransparentState.t -> Pp.t
     records containing the goal and sigma for, respectively, the new and old proof steps,
     e.g. [{ it = g ; sigma = sigma }].
 *)
-val pr_goal                : ?diffs:bool -> ?og_s:(Goal.goal sigma) -> Goal.goal sigma -> Pp.t
+val pr_goal                : ?diffs:bool -> ?og_s:(Goal.goal * Evd.evar_map) -> Goal.goal sigma -> Pp.t
 
 (** [pr_subgoals ~pr_first ~diffs ~os_map close_cmd sigma ~seeds ~shelf ~stack ~unfocused ~goals]
    prints the goals in [goals] followed by the goals in [unfocused] in a compact form
@@ -221,7 +221,7 @@ val pr_subgoal             : int -> evar_map -> Goal.goal list -> Pp.t
     is labelled "subgoal [n]".  If [diffs] is true, highlight the differences between the old conclusion,
     [og_s], and [g]+[sigma].  [og_s] is a record containing the old goal and sigma, e.g. [{ it = g ; sigma = sigma }].
 *)
-val pr_concl               : int -> ?diffs:bool -> ?og_s:(Goal.goal sigma) -> evar_map -> Goal.goal -> Pp.t
+val pr_concl               : int -> ?diffs:bool -> ?og_s:(Goal.goal * Evd.evar_map) -> evar_map -> Goal.goal -> Pp.t
 
 (** [pr_open_subgoals_diff ~quiet ~diffs ~oproof proof] shows the context for [proof] as used by, for example, coqtop.
     The first active goal is printed with all its antecedents and the conclusion.  The other active goals only show their

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -232,8 +232,6 @@ let goal_repr sigma g =
   let ty  = Evd.evar_concl evi in
   (env, ty)
 
-(* XXX: Very unfortunately we cannot use the Proofview interface as
-   Proof is still using the "legacy" one. *)
 let process_goal_concl sigma g : EConstr.t * Environ.env =
   let (env, ty) = goal_repr sigma g in
   (ty, env)
@@ -263,9 +261,8 @@ let pr_lconstr_env ?lax ?inctx ?scope env sigma c =
   pr_leconstr_env ?lax ?inctx ?scope env sigma (EConstr.of_constr c)
 
 let diff_concl ?og_s nsigma ng =
-  let open Evd in
   let o_concl_pp = match og_s with
-    | Some { it=og; sigma=osigma } ->
+    | Some (og, osigma) ->
       let (oty, oenv) = process_goal_concl osigma og in
       pp_of_type oenv osigma oty
     | None -> Pp.mt()
@@ -340,10 +337,7 @@ let hyp_list_to_pp hyps =
 
 let unwrap g_s =
   match g_s with
-  | Some g_s ->
-    let goal = Evd.sig_it g_s in
-    let sigma = Tacmach.Old.project g_s in
-    goal_info goal sigma
+  | Some (goal, sigma) -> goal_info goal sigma
   | None -> ([], CString.Map.empty, Pp.mt ())
 
 let diff_goal_ide og_s ng nsigma =
@@ -566,7 +560,8 @@ let match_goals ot nt =
 
 let get_proof_context (p : Proof.t) =
   let Proof.{goals; sigma} = Proof.data p in
-  sigma, Tacmach.Old.pf_env { Evd.it = List.(hd goals); sigma }
+  let env = Evd.evar_filtered_env (Global.env ()) (Evd.find sigma (List.hd goals)) in
+  sigma, env
 
 let to_constr pf =
   let open CAst in

--- a/printing/proof_diffs.mli
+++ b/printing/proof_diffs.mli
@@ -44,7 +44,7 @@ If you want to make your call especially bulletproof, catch these
 exceptions, print a user-visible message, then recall this routine with
 the first argument set to None, which will skip the diff.
 *)
-val diff_goal_ide : Goal.goal sigma option -> Goal.goal -> Evd.evar_map -> Pp.t list * Pp.t
+val diff_goal_ide : (Goal.goal * Evd.evar_map) option -> Goal.goal -> Evd.evar_map -> Pp.t list * Pp.t
 
 (** Computes the diff between two goals
 
@@ -56,7 +56,7 @@ If you want to make your call especially bulletproof, catch these
 exceptions, print a user-visible message, then recall this routine with
 the first argument set to None, which will skip the diff.
 *)
-val diff_goal : ?og_s:(Goal.goal sigma) -> Goal.goal -> Evd.evar_map -> Pp.t
+val diff_goal : ?og_s:(Goal.goal * Evd.evar_map) -> Goal.goal -> Evd.evar_map -> Pp.t
 
 (** Convert a string to a list of token strings using the lexer *)
 val tokenize_string : string -> string list
@@ -66,7 +66,7 @@ val pr_leconstr_env        : ?lax:bool -> ?inctx:bool -> ?scope:Notation_term.sc
 val pr_lconstr_env         : ?lax:bool -> ?inctx:bool -> ?scope:Notation_term.scope_name -> env -> evar_map -> constr -> Pp.t
 
 (** Computes diffs for a single conclusion *)
-val diff_concl : ?og_s:Goal.goal sigma -> Evd.evar_map -> Goal.goal -> Pp.t
+val diff_concl : ?og_s:(Goal.goal * Evd.evar_map) -> Evd.evar_map -> Goal.goal -> Pp.t
 
 (** Generates a map from [np] to [op] that maps changed goals to their prior
 forms.  The map doesn't include entries for unchanged goals; unchanged goals


### PR DESCRIPTION
There are very weird things going on with the diff API, I suspect it should not be written the way it is, but rely on more algebraic inputs enforcing more invariants. I do not have time to fix this right now, so for the time being this trivial patch should be enough.
