### PR TITLE
Fix identifier capture in uconstr interpretation.

### DIFF
--- a/pretyping/globEnv.ml
+++ b/pretyping/globEnv.ml
@@ -181,6 +181,12 @@ let interp_ltac_variable ?loc typing_fun env sigma id : Evd.evar_map * unsafe_ju
      (str "Variable " ++ Id.print id ++ str " should be bound to a term but is \
       bound to a " ++ Geninterp.Val.pr typ ++ str ".")
   end;
+  if Id.Map.mem id env.lvar.ltac_idents then begin
+    let bnd = Id.Map.find id env.lvar.ltac_idents in
+    user_err ?loc
+     (str "Variable " ++ Id.print id ++ str " should be bound to a term but is \
+      bound to the identifier " ++ quote (Id.print bnd) ++ str ".")
+  end;
   raise Not_found
 
 let interp_ltac_id env id = ltac_interp_id env.lvar id

--- a/test-suite/bugs/closed/bug_15161.v
+++ b/test-suite/bugs/closed/bug_15161.v
@@ -1,0 +1,6 @@
+Ltac bar x := refine x.
+Goal False -> False.
+Proof.
+  intro x.
+  Fail bar doesnotexist.
+Abort.


### PR DESCRIPTION
Fixes #15161: uconstr incorrectly implements dynamic binding.

- [X] Added / updated **test-suite**.