### PR TITLE
Use uconstr instead of the ad-hoc casted_constr in the exact tactic.

### DIFF
--- a/doc/changelog/04-tactics/15171-tactic-exact-use-uconstr.rst
+++ b/doc/changelog/04-tactics/15171-tactic-exact-use-uconstr.rst
@@ -1,0 +1,7 @@
+- **Changed:**
+  The :tacn:`exact` tactic now takes a :g:`uconstr` as argument
+  instead of an ad-hoc one. In very rare cases, this can change
+  the order of resolution of dependent evars when used over
+  several goals at once
+  (`#15171 <https://github.com/coq/coq/pull/15171>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -2617,7 +2617,6 @@ SPLICE: [
 | preident
 | lpar_id_coloneq
 | binders
-| casted_constr
 | check_module_types
 | decl_sep
 | function_fix_definition (* loses funind annotation *)

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1477,7 +1477,7 @@ simple_tactic: [
 | "functional" "induction" lconstr fun_ind_using with_names      (* funind plugin *)
 | "soft" "functional" "induction" LIST1 constr fun_ind_using with_names      (* funind plugin *)
 | "reflexivity"
-| "exact" casted_constr
+| "exact" uconstr
 | "assumption"
 | "etransitivity"
 | "cut" constr
@@ -1902,10 +1902,6 @@ EXTRAARGS_lconstr: [
 
 lglob: [
 | EXTRAARGS_lconstr
-]
-
-casted_constr: [
-| constr
 ]
 
 hloc: [

--- a/plugins/ltac/coretactics.mlg
+++ b/plugins/ltac/coretactics.mlg
@@ -31,7 +31,7 @@ TACTIC EXTEND reflexivity
 END
 
 TACTIC EXTEND exact
-| [ "exact" casted_constr(c) ] -> { Tactics.exact_no_check c }
+| [ "exact" uconstr(c) ] -> { Internals.exact ist c }
 END
 
 TACTIC EXTEND assumption

--- a/plugins/ltac/extraargs.mlg
+++ b/plugins/ltac/extraargs.mlg
@@ -16,7 +16,6 @@ open Tacarg
 open Pcoq.Prim
 open Pcoq.Constr
 open Names
-open Tacmach.Old
 open Tacexpr
 open Taccoerce
 open Tacinterp
@@ -189,20 +188,6 @@ ARGUMENT EXTEND lglob
      RAW_PRINTED BY { pr_gen env sigma }
      GLOB_PRINTED BY { pr_gen env sigma }
 | [ lconstr(c) ] -> { c }
-END
-
-{
-
-let interp_casted_constr ist gl c =
-  interp_constr_gen (Pretyping.OfType (pf_concl gl)) ist (pf_env gl) (project gl) c
-
-}
-
-ARGUMENT EXTEND casted_constr
-  TYPED AS constr
-  PRINTED BY { pr_gen env sigma }
-  INTERPRETED [ legacy ] BY { interp_casted_constr }
-| [ constr(c) ] -> { c }
 END
 
 {

--- a/plugins/ltac/extraargs.mli
+++ b/plugins/ltac/extraargs.mli
@@ -42,11 +42,6 @@ val wit_lconstr :
   glob_constr_and_expr,
   EConstr.t) Genarg.genarg_type
 
-val wit_casted_constr :
-  (constr_expr,
-  glob_constr_and_expr,
-  EConstr.t) Genarg.genarg_type
-
 val glob : constr_expr Pcoq.Entry.t
 val lglob : constr_expr Pcoq.Entry.t
 

--- a/plugins/ltac/internals.ml
+++ b/plugins/ltac/internals.ml
@@ -370,6 +370,14 @@ let decompose l c =
     Elim.h_decompose l c
   end
 
+let exact ist (c : Ltac_pretype.closed_glob_constr) =
+  let open Tacmach in
+  Proofview.Goal.enter begin fun gl ->
+  let expected_type = Pretyping.OfType (pf_concl gl) in
+  let sigma, c = Tacinterp.type_uconstr ~expected_type ist c (pf_env gl) (project gl) in
+  Proofview.tclTHEN (Proofview.Unsafe.tclEVARS sigma) (Tactics.exact_no_check c)
+  end
+
 (** ProofGeneral specific command *)
 
 (* Execute tac, show the names of new hypothesis names created by tac

--- a/plugins/ltac/internals.mli
+++ b/plugins/ltac/internals.mli
@@ -64,6 +64,8 @@ val tclOPTIMIZE_HEAP : unit tactic
 
 val onSomeWithHoles : ('a option -> unit tactic) -> 'a Tactypes.delayed_open option -> unit tactic
 
+val exact : Geninterp.interp_sign -> Ltac_pretype.closed_glob_constr -> unit Proofview.tactic
+
 (** {5 Commands} *)
 
 val declare_equivalent_keys : Constrexpr.constr_expr -> Constrexpr.constr_expr -> unit


### PR DESCRIPTION
This was the last `legacy` genarg, and it has been removed in this PR.

Depends on:
- #15170
- #15178

Overlays:
- https://github.com/HoTT/HoTT/pull/1596 (backwards compatible)