### PR TITLE
Improve output tests

### DIFF
--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -461,8 +461,10 @@ $(addsuffix .log,$(wildcard output/*.v)): %.v.log: %.v %.out $(PREREQUISITELOG)
 	  output=$*.out.real; \
 	  export LC_CTYPE=C; \
 	  export LANG=C; \
-	  $(coqc_interactive) "$<" $(call get_coq_prog_args,"$<") 2>&1 \
-	    | grep -a -v "Welcome to Coq" \
+	  { $(coqc_interactive) "$<" $(call get_coq_prog_args,"$<") 2>&1; \
+	      R=$$?; \
+	      if ! [ $$R = 0 ]; then printf '\ncoqc exited with code %s\n' "$$R"; fi; \
+	  } | grep -a -v "Welcome to Coq" \
 	    | grep -a -v "\[Loading ML file" \
 	    | grep -a -v "Skipping rcfile loading" \
 	    | grep -a -v "^<W>" \

--- a/test-suite/output/Arguments.out
+++ b/test-suite/output/Arguments.out
@@ -105,6 +105,7 @@ f is transparent
 Expands to: Constant Arguments.f
 forall w : r, w 3 true = tt
      : Prop
+File "./output/Arguments.v", line 52, characters 28-29:
 The command has indeed failed with message:
 Unknown interpretation for notation "$".
 w 3 true = tt

--- a/test-suite/output/Cases.out
+++ b/test-suite/output/Cases.out
@@ -60,6 +60,7 @@ end
 The command has indeed failed with message:
 Non exhaustive pattern-matching: no clause found for pattern 
 gadtTy _ _
+File "./output/Cases.v", line 108, characters 17-18:
 The command has indeed failed with message:
 In environment
 texpDenote : forall t : type, texp t -> typeDenote t
@@ -74,6 +75,7 @@ fun '{{n, m, p}} => n + m + p
      : J -> nat
 fun '(D n m p q) => n + m + p + q
      : J -> nat
+File "./output/Cases.v", line 126, characters 29-42:
 The command has indeed failed with message:
 Once notations are expanded, the resulting constructor D (in type J) is
 expected to be applied to no arguments while it is actually applied to
@@ -171,6 +173,7 @@ fun x : K => match x with
              | _ => 2
              end
      : K -> nat
+File "./output/Cases.v", line 224, characters 38-86:
 The command has indeed failed with message:
 Pattern "S _, _" is redundant in this clause.
 stray = 
@@ -190,14 +193,18 @@ Arguments stray N
 File "./output/Cases.v", line 253, characters 4-5:
 Warning: Unused variable B catches more than one case.
 [unused-pattern-matching-variable,pattern-matching]
+File "./output/Cases.v", line 266, characters 33-40:
 The command has indeed failed with message:
 Application of arguments to a recursive notation not supported in patterns.
+File "./output/Cases.v", line 267, characters 33-43:
 The command has indeed failed with message:
 The constructor cons (in type list) is expected to be applied to 2 arguments
 while it is actually applied to 3 arguments.
+File "./output/Cases.v", line 268, characters 33-39:
 The command has indeed failed with message:
 The constructor cons (in type list) is expected to be applied to 2 arguments
 while it is actually applied to 1 argument.
+File "./output/Cases.v", line 271, characters 33-45:
 The command has indeed failed with message:
 The constructor D' (in type J') is expected to be applied to 4 arguments (or
 6 arguments when including variables for local definitions) while it is
@@ -212,18 +219,23 @@ match x with
 | @D' _ _ _ _ n _ p _ => n + p
 end
      : J' bool (true, true) -> nat
+File "./output/Cases.v", line 277, characters 33-40:
 The command has indeed failed with message:
 Application of arguments to a recursive notation not supported in patterns.
+File "./output/Cases.v", line 278, characters 33-43:
 The command has indeed failed with message:
 The constructor cons (in type list) is expected to be applied to 2 arguments
 while it is actually applied to 3 arguments.
+File "./output/Cases.v", line 279, characters 33-39:
 The command has indeed failed with message:
 The constructor cons (in type list) is expected to be applied to 2 arguments
 while it is actually applied to 1 argument.
+File "./output/Cases.v", line 281, characters 33-39:
 The command has indeed failed with message:
 The constructor D' (in type J') is expected to be applied to 3 arguments (or
 4 arguments when including variables for local definitions) while it is
 actually applied to 2 arguments.
+File "./output/Cases.v", line 282, characters 33-45:
 The command has indeed failed with message:
 The constructor D' (in type J') is expected to be applied to 3 arguments (or
 4 arguments when including variables for local definitions) while it is

--- a/test-suite/output/CoercionOnHole.out
+++ b/test-suite/output/CoercionOnHole.out
@@ -1,9 +1,8 @@
-File "./output/CoercionOnHole.v", line 23, characters 12-15:
-Error:
+File "./output/CoercionOnHole.v", line 23, characters 17-20:
+The command has indeed failed with message:
 In environment
 e1, e2, v1 : expr
 IH1 : eval e1 v1
 IHe2 : exists v : expr, eval e2 v
 The term "IH1" has type "eval e1 v1" while it is expected to have type
  "eval e1 (Const ?v1)".
-

--- a/test-suite/output/CoercionOnHole.v
+++ b/test-suite/output/CoercionOnHole.v
@@ -20,5 +20,5 @@ Proof.
   - destruct IHe1 as [v1 IH1].
     eexists.
     eapply EAdd.
-    + exact IH1.
+    + Fail exact IH1.
 Abort.

--- a/test-suite/output/DependentInductionErrors.out
+++ b/test-suite/output/DependentInductionErrors.out
@@ -1,4 +1,6 @@
+File "./output/DependentInductionErrors.v", line 3, characters 7-30:
 The command has indeed failed with message:
 Tactic failure: To use dependent destruction, first [Require Import Coq.Program.Equality.].
+File "./output/DependentInductionErrors.v", line 4, characters 7-28:
 The command has indeed failed with message:
 Tactic failure: To use dependent induction, first [Require Import Coq.Program.Equality.].

--- a/test-suite/output/EqNotation.out
+++ b/test-suite/output/EqNotation.out
@@ -1,3 +1,4 @@
+File "./output/EqNotation.v", line 2, characters 21-26:
 The command has indeed failed with message:
 Cannot infer the implicit parameter A of eq whose type is 
 "Type".

--- a/test-suite/output/ErrorInCanonicalStructures.out
+++ b/test-suite/output/ErrorInCanonicalStructures.out
@@ -1,4 +1,6 @@
-File "./output/ErrorInCanonicalStructures.v", line 3, characters 0-24:
-Error: Could not declare a canonical structure Foo.
+The command has indeed failed with message:
+Could not declare a canonical structure Foo.
 Expected an instance of a record or structure.
-
+The command has indeed failed with message:
+Could not declare a canonical structure bar.
+Expected an instance of a record or structure.

--- a/test-suite/output/ErrorInCanonicalStructures.v
+++ b/test-suite/output/ErrorInCanonicalStructures.v
@@ -1,3 +1,7 @@
 Record Foo := MkFoo { field1 : nat; field2 : nat -> nat }.
 
-Canonical Structure Foo.
+Definition bar := 99.
+
+Fail Canonical Structure Foo.
+
+Fail Canonical Structure bar.

--- a/test-suite/output/ErrorInCanonicalStructures2.out
+++ b/test-suite/output/ErrorInCanonicalStructures2.out
@@ -1,4 +1,0 @@
-File "./output/ErrorInCanonicalStructures2.v", line 3, characters 0-24:
-Error: Could not declare a canonical structure bar.
-Expected an instance of a record or structure.
-

--- a/test-suite/output/ErrorInCanonicalStructures2.v
+++ b/test-suite/output/ErrorInCanonicalStructures2.v
@@ -1,3 +1,0 @@
-Definition bar := 99.
-
-Canonical Structure bar.

--- a/test-suite/output/ErrorInModule.out
+++ b/test-suite/output/ErrorInModule.out
@@ -1,3 +1,3 @@
-File "./output/ErrorInModule.v", line 3, characters 20-31:
-Error: The reference nonexistent was not found in the current environment.
-
+File "./output/ErrorInModule.v", line 3, characters 25-36:
+The command has indeed failed with message:
+The reference nonexistent was not found in the current environment.

--- a/test-suite/output/ErrorInModule.v
+++ b/test-suite/output/ErrorInModule.v
@@ -1,4 +1,4 @@
 (* -*- mode: coq; coq-prog-args: ("-vio") -*- *)
 Module M.
-  Definition foo := nonexistent.
+  Fail Definition foo := nonexistent.
 End M.

--- a/test-suite/output/ErrorInSection.out
+++ b/test-suite/output/ErrorInSection.out
@@ -1,3 +1,3 @@
-File "./output/ErrorInSection.v", line 3, characters 20-31:
-Error: The reference nonexistent was not found in the current environment.
-
+File "./output/ErrorInSection.v", line 3, characters 25-36:
+The command has indeed failed with message:
+The reference nonexistent was not found in the current environment.

--- a/test-suite/output/ErrorInSection.v
+++ b/test-suite/output/ErrorInSection.v
@@ -1,4 +1,4 @@
 (* -*- mode: coq; coq-prog-args: ("-vio") -*- *)
 Section S.
-  Definition foo := nonexistent.
+  Fail Definition foo := nonexistent.
 End S.

--- a/test-suite/output/ErrorLocation_12152.out
+++ b/test-suite/output/ErrorLocation_12152.out
@@ -1,0 +1,6 @@
+File "./output/ErrorLocation_12152.v", line 3, characters 5-12:
+The command has indeed failed with message:
+No product even after head-reduction.
+File "./output/ErrorLocation_12152.v", line 4, characters 5-13:
+The command has indeed failed with message:
+No product even after head-reduction.

--- a/test-suite/output/ErrorLocation_12152.v
+++ b/test-suite/output/ErrorLocation_12152.v
@@ -1,4 +1,5 @@
 (* Reported in #12152 *)
 Goal True.
-intros H; auto.
+Fail intro H; auto.
+Fail intros H; auto.
 Abort.

--- a/test-suite/output/ErrorLocation_12152_1.out
+++ b/test-suite/output/ErrorLocation_12152_1.out
@@ -1,3 +1,0 @@
-File "./output/ErrorLocation_12152_1.v", line 3, characters 0-7:
-Error: No product even after head-reduction.
-

--- a/test-suite/output/ErrorLocation_12152_1.v
+++ b/test-suite/output/ErrorLocation_12152_1.v
@@ -1,4 +1,0 @@
-(* Reported in #12152 *)
-Goal True.
-intro H; auto.
-Abort.

--- a/test-suite/output/ErrorLocation_12152_2.out
+++ b/test-suite/output/ErrorLocation_12152_2.out
@@ -1,3 +1,0 @@
-File "./output/ErrorLocation_12152_2.v", line 3, characters 0-8:
-Error: No product even after head-reduction.
-

--- a/test-suite/output/ErrorLocation_12255.out
+++ b/test-suite/output/ErrorLocation_12255.out
@@ -1,4 +1,4 @@
-File "./output/ErrorLocation_12255.v", line 4, characters 0-16:
-Error: Ltac variable x is bound to i > 0 which cannot be coerced to
+File "./output/ErrorLocation_12255.v", line 4, characters 5-21:
+The command has indeed failed with message:
+Ltac variable x is bound to i > 0 which cannot be coerced to
 an evaluable reference.
-

--- a/test-suite/output/ErrorLocation_12255.v
+++ b/test-suite/output/ErrorLocation_12255.v
@@ -1,5 +1,5 @@
 Ltac can_unfold x := let b := eval cbv delta [x] in x in idtac.
 Definition i := O.
 Goal False.
-can_unfold (i>0).
+Fail can_unfold (i>0).
 Abort.

--- a/test-suite/output/ErrorLocation_12774.out
+++ b/test-suite/output/ErrorLocation_12774.out
@@ -1,0 +1,9 @@
+File "./output/ErrorLocation_12774.v", line 5, characters 18-19:
+The command has indeed failed with message:
+The term "0" has type "nat" while it is expected to have type "Type".
+File "./output/ErrorLocation_12774.v", line 6, characters 14-15:
+The command has indeed failed with message:
+The term "0" has type "nat" while it is expected to have type "Type".
+File "./output/ErrorLocation_12774.v", line 7, characters 5-6:
+The command has indeed failed with message:
+No product even after head-reduction.

--- a/test-suite/output/ErrorLocation_12774.v
+++ b/test-suite/output/ErrorLocation_12774.v
@@ -1,0 +1,8 @@
+Ltac f := simpl.
+Ltac g := auto; intro.
+
+Goal Type.
+Fail simpl; exact 0.
+Fail f; exact 0.
+Fail g.
+Abort.

--- a/test-suite/output/ErrorLocation_12774_1.out
+++ b/test-suite/output/ErrorLocation_12774_1.out
@@ -1,3 +1,0 @@
-File "./output/ErrorLocation_12774_1.v", line 2, characters 13-14:
-Error: The term "0" has type "nat" while it is expected to have type "Type".
-

--- a/test-suite/output/ErrorLocation_12774_1.v
+++ b/test-suite/output/ErrorLocation_12774_1.v
@@ -1,3 +1,0 @@
-Goal Type.
-simpl; exact 0.
-Abort.

--- a/test-suite/output/ErrorLocation_12774_2.out
+++ b/test-suite/output/ErrorLocation_12774_2.out
@@ -1,3 +1,0 @@
-File "./output/ErrorLocation_12774_2.v", line 3, characters 9-10:
-Error: The term "0" has type "nat" while it is expected to have type "Type".
-

--- a/test-suite/output/ErrorLocation_12774_2.v
+++ b/test-suite/output/ErrorLocation_12774_2.v
@@ -1,4 +1,0 @@
-Ltac f := simpl.
-Goal Type.
-f; exact 0.
-Abort.

--- a/test-suite/output/ErrorLocation_12774_3.out
+++ b/test-suite/output/ErrorLocation_12774_3.out
@@ -1,3 +1,0 @@
-File "./output/ErrorLocation_12774_3.v", line 3, characters 0-1:
-Error: No product even after head-reduction.
-

--- a/test-suite/output/ErrorLocation_12774_3.v
+++ b/test-suite/output/ErrorLocation_12774_3.v
@@ -1,4 +1,0 @@
-Ltac f := auto; intro.
-Goal False.
-f.
-Abort.

--- a/test-suite/output/ErrorLocation_13241.out
+++ b/test-suite/output/ErrorLocation_13241.out
@@ -1,0 +1,6 @@
+File "./output/ErrorLocation_13241.v", line 5, characters 5-6:
+The command has indeed failed with message:
+No product even after head-reduction.
+File "./output/ErrorLocation_13241.v", line 13, characters 5-6:
+The command has indeed failed with message:
+No product even after head-reduction.

--- a/test-suite/output/ErrorLocation_13241.v
+++ b/test-suite/output/ErrorLocation_13241.v
@@ -1,0 +1,15 @@
+Module Direct.
+Ltac a := intro.
+Ltac b := a.
+Goal True.
+Fail b.
+Abort.
+End Direct.
+
+Module Thunked.
+Ltac a _ := intro.
+Ltac b := a ().
+Goal True.
+Fail b.
+Abort.
+End Thunked.

--- a/test-suite/output/ErrorLocation_13241_1.out
+++ b/test-suite/output/ErrorLocation_13241_1.out
@@ -1,3 +1,0 @@
-File "./output/ErrorLocation_13241_1.v", line 4, characters 0-1:
-Error: No product even after head-reduction.
-

--- a/test-suite/output/ErrorLocation_13241_1.v
+++ b/test-suite/output/ErrorLocation_13241_1.v
@@ -1,5 +1,0 @@
-Ltac a := intro.
-Ltac b := a.
-Goal True.
-b.
-Abort.

--- a/test-suite/output/ErrorLocation_13241_2.out
+++ b/test-suite/output/ErrorLocation_13241_2.out
@@ -1,3 +1,0 @@
-File "./output/ErrorLocation_13241_2.v", line 4, characters 0-1:
-Error: No product even after head-reduction.
-

--- a/test-suite/output/ErrorLocation_13241_2.v
+++ b/test-suite/output/ErrorLocation_13241_2.v
@@ -1,5 +1,0 @@
-Ltac a _ := intro.
-Ltac b := a ().
-Goal True.
-b.
-Abort.

--- a/test-suite/output/ErrorLocation_ltac.out
+++ b/test-suite/output/ErrorLocation_ltac.out
@@ -1,0 +1,12 @@
+File "./output/ErrorLocation_ltac.v", line 5, characters 12-16:
+The command has indeed failed with message:
+Tactic failure: Cannot solve this goal.
+File "./output/ErrorLocation_ltac.v", line 6, characters 12-13:
+The command has indeed failed with message:
+Tactic failure.
+File "./output/ErrorLocation_ltac.v", line 7, characters 12-15:
+The command has indeed failed with message:
+Not a negated primitive equality.
+File "./output/ErrorLocation_ltac.v", line 8, characters 27-28:
+The command has indeed failed with message:
+Tactic failure.

--- a/test-suite/output/ErrorLocation_ltac.v
+++ b/test-suite/output/ErrorLocation_ltac.v
@@ -1,0 +1,9 @@
+Ltac f := fail.
+Ltac inj := injection.
+
+Goal False.
+Fail idtac; easy.
+Fail idtac; f.
+Fail idtac; inj.
+Fail let x := fail in x || x.
+Abort.

--- a/test-suite/output/ErrorLocation_ltac_1.out
+++ b/test-suite/output/ErrorLocation_ltac_1.out
@@ -1,3 +1,0 @@
-File "./output/ErrorLocation_ltac_1.v", line 2, characters 7-11:
-Error: Tactic failure: Cannot solve this goal.
-

--- a/test-suite/output/ErrorLocation_ltac_1.v
+++ b/test-suite/output/ErrorLocation_ltac_1.v
@@ -1,3 +1,0 @@
-Goal False.
-idtac; easy.
-Abort.

--- a/test-suite/output/ErrorLocation_ltac_2.out
+++ b/test-suite/output/ErrorLocation_ltac_2.out
@@ -1,3 +1,0 @@
-File "./output/ErrorLocation_ltac_2.v", line 3, characters 7-8:
-Error: Tactic failure.
-

--- a/test-suite/output/ErrorLocation_ltac_2.v
+++ b/test-suite/output/ErrorLocation_ltac_2.v
@@ -1,4 +1,0 @@
-Ltac f := fail.
-Goal False.
-idtac; f.
-Abort.

--- a/test-suite/output/ErrorLocation_ltac_3.out
+++ b/test-suite/output/ErrorLocation_ltac_3.out
@@ -1,3 +1,0 @@
-File "./output/ErrorLocation_ltac_3.v", line 3, characters 7-10:
-Error: Not a negated primitive equality.
-

--- a/test-suite/output/ErrorLocation_ltac_3.v
+++ b/test-suite/output/ErrorLocation_ltac_3.v
@@ -1,4 +1,0 @@
-Ltac inj := injection.
-Goal False.
-idtac; inj.
-Abort.

--- a/test-suite/output/ErrorLocation_ltac_4.out
+++ b/test-suite/output/ErrorLocation_ltac_4.out
@@ -1,3 +1,0 @@
-File "./output/ErrorLocation_ltac_4.v", line 2, characters 22-23:
-Error: Tactic failure.
-

--- a/test-suite/output/ErrorLocation_ltac_4.v
+++ b/test-suite/output/ErrorLocation_ltac_4.v
@@ -1,3 +1,0 @@
-Goal False.
-let x := fail in x || x.
-Abort.

--- a/test-suite/output/ErrorLocation_tac_in_term.out
+++ b/test-suite/output/ErrorLocation_tac_in_term.out
@@ -1,0 +1,6 @@
+File "./output/ErrorLocation_tac_in_term.v", line 4, characters 26-30:
+The command has indeed failed with message:
+The term "true" has type "bool" while it is expected to have type "nat".
+File "./output/ErrorLocation_tac_in_term.v", line 5, characters 17-25:
+The command has indeed failed with message:
+The term "true" has type "bool" while it is expected to have type "nat".

--- a/test-suite/output/ErrorLocation_tac_in_term.v
+++ b/test-suite/output/ErrorLocation_tac_in_term.v
@@ -1,0 +1,6 @@
+Ltac f x y := apply (x y).
+
+Goal True.
+Fail apply ltac:(apply (S true)).
+Fail apply ltac:(f S true).
+Abort.

--- a/test-suite/output/ErrorLocation_tac_in_term_1.out
+++ b/test-suite/output/ErrorLocation_tac_in_term_1.out
@@ -1,4 +1,0 @@
-File "./output/ErrorLocation_tac_in_term_1.v", line 2, characters 21-25:
-Error:
-The term "true" has type "bool" while it is expected to have type "nat".
-

--- a/test-suite/output/ErrorLocation_tac_in_term_1.v
+++ b/test-suite/output/ErrorLocation_tac_in_term_1.v
@@ -1,3 +1,0 @@
-Goal True.
-apply ltac:(apply (S true)).
-Abort.

--- a/test-suite/output/ErrorLocation_tac_in_term_2.out
+++ b/test-suite/output/ErrorLocation_tac_in_term_2.out
@@ -1,4 +1,0 @@
-File "./output/ErrorLocation_tac_in_term_2.v", line 4, characters 12-20:
-Error:
-The term "true" has type "bool" while it is expected to have type "nat".
-

--- a/test-suite/output/ErrorLocation_tac_in_term_2.v
+++ b/test-suite/output/ErrorLocation_tac_in_term_2.v
@@ -1,5 +1,0 @@
-Ltac f x y := apply (x y).
-
-Goal True.
-apply ltac:(f S true).
-Abort.

--- a/test-suite/output/Error_msg_diffs.out
+++ b/test-suite/output/Error_msg_diffs.out
@@ -1,5 +1,5 @@
-File "./output/Error_msg_diffs.v", line 32, characters 0-11:
-[37;41;1mError:[0m
+File "./output/Error_msg_diffs.v", line 32, characters 5-16:
+The command has indeed failed with message:
 In environment
 T : [33;1mType[0m
 p : T[37m ->[0m bool
@@ -9,4 +9,3 @@ IH1 : count p (rev_tree t1)[37m =[0m count p t1
 IH2 : count p (rev_tree t2)[37m =[0m count p t2
 Unable to unify "[48;2;91;0;0m([1mif[22m p a [1mthen[22m 1 [1melse[22m 0)[37m +[39m (count p [48;2;170;0;0;4mt1[48;2;91;0;0;24m[37m +[39m count p [48;2;170;0;0;4mt2[48;2;91;0;0;24m)[0m" with
  "[48;2;0;91;0m([1mif[22m p a [1mthen[22m 1 [1melse[22m 0)[37m +[39m (count p [48;2;0;141;0;4mt2[48;2;0;91;0;24m[37m +[39m count p [48;2;0;141;0;4mt1[48;2;0;91;0;24m)[0m".
-

--- a/test-suite/output/Error_msg_diffs.v
+++ b/test-suite/output/Error_msg_diffs.v
@@ -29,7 +29,7 @@ induction t as [ | a t1 IH1 t2 IH2].
 simpl.
 rewrite IH1.
 rewrite IH2.
-reflexivity.
+Fail reflexivity.
 rewrite (Nat.add_comm (count p t2)).
 easy.
 Qed.

--- a/test-suite/output/Errors.out
+++ b/test-suite/output/Errors.out
@@ -1,18 +1,24 @@
 The command has indeed failed with message:
 The field t is missing in Errors.M.
+File "./output/Errors.v", line 19, characters 18-19:
 The command has indeed failed with message:
 Unable to unify "nat" with "True".
+File "./output/Errors.v", line 17, characters 18-19:
 The command has indeed failed with message:
 In nested Ltac calls to "f" and "apply x", last call failed.
 Unable to unify "nat" with "True".
+File "./output/Errors.v", line 29, characters 21-30:
 The command has indeed failed with message:
 Ltac call to "instantiate ( (ident) := (lglob) )" failed.
 Instance is not well-typed in the environment of ?x.
+File "./output/Errors.v", line 34, characters 19-20:
 The command has indeed failed with message:
 Cannot infer ?T in the partial instance "?T -> nat" found for the type of f.
+File "./output/Errors.v", line 35, characters 22-24:
 The command has indeed failed with message:
 Cannot infer ?T in the partial instance "?T -> nat" found for the implicit
 parameter A of id whose type is "Type".
+File "./output/Errors.v", line 36, characters 17-18:
 The command has indeed failed with message:
 Cannot infer ?T in the partial instance "forall x : nat, ?T" found for the
 type of f in environment:

--- a/test-suite/output/FunExt.out
+++ b/test-suite/output/FunExt.out
@@ -1,12 +1,18 @@
+File "./output/FunExt.v", line 15, characters 5-24:
 The command has indeed failed with message:
 Tactic failure: Not an extensional equality.
+File "./output/FunExt.v", line 17, characters 5-24:
 The command has indeed failed with message:
 Tactic failure: Not an extensional equality.
+File "./output/FunExt.v", line 18, characters 5-26:
 The command has indeed failed with message:
 Tactic failure: Not an extensional equality.
+File "./output/FunExt.v", line 93, characters 9-28:
 The command has indeed failed with message:
 Tactic failure: Not an extensional equality.
+File "./output/FunExt.v", line 149, characters 9-28:
 The command has indeed failed with message:
 Tactic failure: Already an intensional equality.
+File "./output/FunExt.v", line 162, characters 9-29:
 The command has indeed failed with message:
 Hypothesis e depends on the body of H'

--- a/test-suite/output/Int31NumberSyntax.out
+++ b/test-suite/output/Int31NumberSyntax.out
@@ -12,5 +12,6 @@ I31
      : int31
      = 710436486
      : int31
+File "./output/Int31NumberSyntax.v", line 13, characters 11-13:
 The command has indeed failed with message:
 Cannot interpret this number as a value of type int31

--- a/test-suite/output/Int63NumberSyntax.out
+++ b/test-suite/output/Int63NumberSyntax.out
@@ -14,26 +14,34 @@
      : int
 427
      : int
+File "./output/Int63NumberSyntax.v", line 12, characters 11-17:
 The command has indeed failed with message:
 Cannot interpret this number as a value of type int
+File "./output/Int63NumberSyntax.v", line 13, characters 11-17:
 The command has indeed failed with message:
 Cannot interpret this number as a value of type int
 0
      : int
 0
      : int
+File "./output/Int63NumberSyntax.v", line 16, characters 12-14:
 The command has indeed failed with message:
 The reference xg was not found in the current environment.
+File "./output/Int63NumberSyntax.v", line 17, characters 12-14:
 The command has indeed failed with message:
 The reference xG was not found in the current environment.
+File "./output/Int63NumberSyntax.v", line 18, characters 13-15:
 The command has indeed failed with message:
 The reference x1 was not found in the current environment.
+File "./output/Int63NumberSyntax.v", line 19, characters 12-13:
 The command has indeed failed with message:
 The reference x was not found in the current environment.
 add 2 2
      : int
+File "./output/Int63NumberSyntax.v", line 21, characters 11-13:
 The command has indeed failed with message:
 Cannot interpret this number as a value of type int
+File "./output/Int63NumberSyntax.v", line 22, characters 11-30:
 The command has indeed failed with message:
 Overflow in int63 literal: 9223372036854775808.
 0x1

--- a/test-suite/output/InvalidDisjunctiveIntro.out
+++ b/test-suite/output/InvalidDisjunctiveIntro.out
@@ -1,16 +1,21 @@
+File "./output/InvalidDisjunctiveIntro.v", line 2, characters 31-32:
 The command has indeed failed with message:
 Cannot coerce to a disjunctive/conjunctive pattern.
 The command has indeed failed with message:
 Disjunctive/conjunctive introduction pattern expected.
+File "./output/InvalidDisjunctiveIntro.v", line 6, characters 48-49:
 The command has indeed failed with message:
 Cannot coerce to a disjunctive/conjunctive pattern.
+File "./output/InvalidDisjunctiveIntro.v", line 8, characters 49-50:
 The command has indeed failed with message:
 Cannot coerce to a disjunctive/conjunctive pattern.
+File "./output/InvalidDisjunctiveIntro.v", line 10, characters 32-33:
 The command has indeed failed with message:
 Ltac variable H is bound to <tactic closure> which cannot be coerced to
 an introduction pattern.
 The command has indeed failed with message:
 Disjunctive/conjunctive introduction pattern expected.
+File "./output/InvalidDisjunctiveIntro.v", line 15, characters 50-52:
 The command has indeed failed with message:
 Ltac variable H' is bound to <tactic closure> which cannot be coerced to
 an introduction pattern.

--- a/test-suite/output/NatSyntax.out
+++ b/test-suite/output/NatSyntax.out
@@ -14,20 +14,26 @@
      : nat
 427
      : nat
+File "./output/NatSyntax.v", line 9, characters 11-17:
 The command has indeed failed with message:
 Cannot interpret this number as a value of type nat
+File "./output/NatSyntax.v", line 10, characters 11-17:
 The command has indeed failed with message:
 Cannot interpret this number as a value of type nat
 0
      : nat
 0
      : nat
+File "./output/NatSyntax.v", line 13, characters 12-14:
 The command has indeed failed with message:
 The reference xg was not found in the current environment.
+File "./output/NatSyntax.v", line 14, characters 12-14:
 The command has indeed failed with message:
 The reference xG was not found in the current environment.
+File "./output/NatSyntax.v", line 15, characters 13-15:
 The command has indeed failed with message:
 The reference x1 was not found in the current environment.
+File "./output/NatSyntax.v", line 16, characters 12-13:
 The command has indeed failed with message:
 The reference x was not found in the current environment.
 0x2a

--- a/test-suite/output/NotationSyntax.out
+++ b/test-suite/output/NotationSyntax.out
@@ -1,7 +1,10 @@
+File "./output/NotationSyntax.v", line 2, characters 38-50:
 The command has indeed failed with message:
 "only parsing" is given more than once.
+File "./output/NotationSyntax.v", line 3, characters 38-51:
 The command has indeed failed with message:
 A notation cannot be both "only printing" and "only parsing".
+File "./output/NotationSyntax.v", line 4, characters 39-52:
 The command has indeed failed with message:
 "only printing" is given more than once.
 File "./output/NotationSyntax.v", line 5, characters 33-43:
@@ -12,5 +15,6 @@ Warning: Notations for numbers are primitive; skipping this modifier.
 [primitive-token-modifier,parsing]
 1%nat
      : nat
+File "./output/NotationSyntax.v", line 10, characters 23-26:
 The command has indeed failed with message:
 Notations for numbers are primitive and need not be reserved.

--- a/test-suite/output/Notations.out
+++ b/test-suite/output/Notations.out
@@ -40,28 +40,36 @@ fun x : nat => ifn x is succ n then n else 0
      : bool
 -4
      : Z
+File "./output/Notations.v", line 139, characters 46-62:
 The command has indeed failed with message:
 Cannot find where the recursive pattern starts.
 The command has indeed failed with message:
 in the right-hand side, y and z should appear in
 term position as part of a recursive pattern.
+File "./output/Notations.v", line 145, characters 57-58:
 The command has indeed failed with message:
 The reference w was not found in the current environment.
 The command has indeed failed with message:
 in the right-hand side, y and z should appear in
 term position as part of a recursive pattern.
+File "./output/Notations.v", line 152, characters 56-57:
 The command has indeed failed with message:
 z is expected to occur in binding position in the right-hand side.
 The command has indeed failed with message:
 as y is a non-closed binder, no such "," is allowed to occur.
+File "./output/Notations.v", line 160, characters 46-69:
 The command has indeed failed with message:
 Cannot find where the recursive pattern starts.
+File "./output/Notations.v", line 161, characters 46-62:
 The command has indeed failed with message:
 Cannot find where the recursive pattern starts.
+File "./output/Notations.v", line 162, characters 49-63:
 The command has indeed failed with message:
 Cannot find where the recursive pattern starts.
+File "./output/Notations.v", line 163, characters 50-64:
 The command has indeed failed with message:
 Cannot find where the recursive pattern starts.
+Toplevel input, characters 4941-4955:
 The command has indeed failed with message:
 Both ends of the recursive pattern are the same.
 SUM (nat * nat) nat

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -59,12 +59,16 @@ where
       |- Type] (pat, p0, p cannot be used)
 fun '{| |} => true
      : R -> bool
+File "./output/Notations4.v", line 139, characters 82-85:
 The command has indeed failed with message:
 The format is not the same on the right- and left-hand sides of the special token "..".
+File "./output/Notations4.v", line 143, characters 76-78:
 The command has indeed failed with message:
 The format is not the same on the right- and left-hand sides of the special token "..".
+File "./output/Notations4.v", line 147, characters 78-81:
 The command has indeed failed with message:
 The format is not the same on the right- and left-hand sides of the special token "..".
+File "./output/Notations4.v", line 151, characters 52-55:
 The command has indeed failed with message:
 The format is not the same on the right- and left-hand sides of the special token "..".
 Entry custom:expr is
@@ -123,40 +127,49 @@ exists p : nat, ▢_p (p >= 1)
      : Prop
 ▢_n (n >= 1)
      : Prop
+File "./output/Notations4.v", line 297, characters 17-20:
 The command has indeed failed with message:
 Found an inductive type while a variable name was expected.
+File "./output/Notations4.v", line 298, characters 17-18:
 The command has indeed failed with message:
 Found a constructor while a variable name was expected.
+File "./output/Notations4.v", line 300, characters 17-18:
 The command has indeed failed with message:
 Found a constant while a variable name was expected.
 exists x y : nat, ▢_(x, y) (x >= 1 /\ y >= 2)
      : Prop
 ▢_n (n >= 1)
      : Prop
+File "./output/Notations4.v", line 313, characters 17-20:
 The command has indeed failed with message:
 Found an inductive type while a pattern was expected.
 ▢_tt (tt = tt)
      : Prop
+File "./output/Notations4.v", line 316, characters 17-18:
 The command has indeed failed with message:
 Found a constant while a pattern was expected.
 exists x y : nat, ▢_(x, y) (x >= 1 /\ y >= 2)
      : Prop
 pseudo_force n (fun n : nat => n >= 1)
      : Prop
+File "./output/Notations4.v", line 329, characters 17-20:
 The command has indeed failed with message:
 Found an inductive type while a pattern was expected.
 ▢_tt (tt = tt)
      : Prop
+File "./output/Notations4.v", line 332, characters 17-18:
 The command has indeed failed with message:
 Found a constant while a pattern was expected.
 exists x y : nat, myforce (x, y) (x >= 1 /\ y >= 2)
      : Prop
 myforce n (n >= 1)
      : Prop
+File "./output/Notations4.v", line 344, characters 21-24:
 The command has indeed failed with message:
 Found an inductive type while a pattern was expected.
 myforce tt (tt = tt)
      : Prop
+File "./output/Notations4.v", line 347, characters 21-22:
 The command has indeed failed with message:
 Found a constant while a pattern was expected.
 id nat
@@ -165,6 +178,7 @@ fun a : bool => id a
      : bool -> bool
 fun nat : bool => id nat
      : bool -> bool
+File "./output/Notations4.v", line 359, characters 17-20:
 The command has indeed failed with message:
 Found an inductive type while a pattern was expected.
 !! nat, nat = true
@@ -193,6 +207,7 @@ Found an inductive type while a pattern was expected.
      : Type
 ## (x, _) (x = 0)
      : Prop
+File "./output/Notations4.v", line 455, characters 21-30:
 The command has indeed failed with message:
 Unexpected type constraint in notation already providing a type constraint.
 ## '(x, y) (x + y = 0)

--- a/test-suite/output/NumberNotations.out
+++ b/test-suite/output/NumberNotations.out
@@ -1,7 +1,10 @@
+File "./output/NumberNotations.v", line 11, characters 13-14:
 The command has indeed failed with message:
 Unexpected term (nat -> nat) while parsing a number notation.
+File "./output/NumberNotations.v", line 21, characters 13-14:
 The command has indeed failed with message:
 Unexpected non-option term opaque4 while parsing a number notation.
+File "./output/NumberNotations.v", line 32, characters 13-14:
 The command has indeed failed with message:
 Unexpected term (fun (A : Type) (x : A) => x) while parsing a number
 notation.
@@ -15,8 +18,10 @@ let v := 0%ppp in v : punit
      : punit
 let v := 0%uto in v : unit
      : unit
+File "./output/NumberNotations.v", line 72, characters 13-14:
 The command has indeed failed with message:
 Cannot interpret this number as a value of type unit
+File "./output/NumberNotations.v", line 73, characters 14-16:
 The command has indeed failed with message:
 Cannot interpret this number as a value of type unit
 let v := 0%upp in v : unit
@@ -30,6 +35,7 @@ let v := 0%ppps in v : punit
 File "./output/NumberNotations.v", line 91, characters 2-46:
 Warning: To avoid stack overflow, large numbers in punit are interpreted as
 applications of pto_punits. [abstract-large-number,numbers]
+File "./output/NumberNotations.v", line 91, characters 32-33:
 The command has indeed failed with message:
 In environment
 v := pto_punits (Number.UIntDecimal (Decimal.D1 Decimal.Nil)) : punit
@@ -57,6 +63,7 @@ let v := 0%wuint8 in v : wuint
      : wuint
 let v := 0 in v : nat
      : nat
+File "./output/NumberNotations.v", line 164, characters 34-35:
 The command has indeed failed with message:
 In environment
 v := 0 : nat
@@ -71,6 +78,7 @@ let v := 0%wuint9' in v : wuint
      : wuint
 let v := 0 in v : nat
      : nat
+File "./output/NumberNotations.v", line 191, characters 34-35:
 The command has indeed failed with message:
 In environment
 v := 0 : nat
@@ -86,14 +94,18 @@ let v := of_uint (Number.UIntDecimal (Decimal.D1 Decimal.Nil)) in v : unit
      : unit
 let v := 0%test13 in v : unit
      : unit
+File "./output/NumberNotations.v", line 238, characters 36-44:
 The command has indeed failed with message:
 to_uint' is bound to a notation that does not denote a reference.
+File "./output/NumberNotations.v", line 239, characters 35-36:
 The command has indeed failed with message:
 In environment
 v := 0 : nat
 The term "v" has type "nat" while it is expected to have type "unit".
+File "./output/NumberNotations.v", line 240, characters 36-45:
 The command has indeed failed with message:
 to_uint'' is bound to a notation that does not denote a reference.
+File "./output/NumberNotations.v", line 241, characters 36-37:
 The command has indeed failed with message:
 In environment
 v := 0 : nat
@@ -102,14 +114,17 @@ let v := 0%test14' in v : unit
      : unit
 let v := 0%test14' in v : unit
      : unit
+File "./output/NumberNotations.v", line 264, characters 34-35:
 The command has indeed failed with message:
 In environment
 v := 0 : nat
 The term "v" has type "nat" while it is expected to have type "unit".
+File "./output/NumberNotations.v", line 265, characters 35-36:
 The command has indeed failed with message:
 In environment
 v := 0 : nat
 The term "v" has type "nat" while it is expected to have type "unit".
+File "./output/NumberNotations.v", line 267, characters 34-35:
 The command has indeed failed with message:
 In environment
 v := 0 : nat
@@ -120,14 +135,17 @@ The command has indeed failed with message:
 This command does not support the Global option in sections.
 let v := 0%test14'' in v : unit
      : unit
+File "./output/NumberNotations.v", line 275, characters 39-40:
 The command has indeed failed with message:
 In environment
 v := 0 : nat
 The term "v" has type "nat" while it is expected to have type "unit".
+File "./output/NumberNotations.v", line 277, characters 36-37:
 The command has indeed failed with message:
 In environment
 v := 0 : nat
 The term "v" has type "nat" while it is expected to have type "unit".
+File "./output/NumberNotations.v", line 278, characters 37-38:
 The command has indeed failed with message:
 In environment
 v := 0 : nat
@@ -140,6 +158,7 @@ let v := 0%test15 in v : unit
      : unit
 let v := foo a.t in v : Foo
      : Foo
+File "./output/NumberNotations.v", line 320, characters 22-23:
 The command has indeed failed with message:
 Cannot interpret in test16_scope because NumberNotations.Test16.F.Foo could not be found in the current environment.
 let v := 0%test17 in v : myint63
@@ -192,6 +211,7 @@ let v := 4%kt in v : ty
      : ty
 let v := 5%kt in v : ty
      : ty
+File "./output/NumberNotations.v", line 451, characters 22-23:
 The command has indeed failed with message:
 Cannot interpret this number as a value of type ty
      = 0%kt
@@ -252,10 +272,13 @@ sum unit (sum unit unit)
      : Set
 The command has indeed failed with message:
 Missing mapping for constructor Isum.
+File "./output/NumberNotations.v", line 552, characters 68-73:
 The command has indeed failed with message:
 Iunit was already mapped to unit and cannot be remapped to unit.
+File "./output/NumberNotations.v", line 556, characters 47-50:
 The command has indeed failed with message:
 add is not an inductive type.
+File "./output/NumberNotations.v", line 562, characters 40-43:
 The command has indeed failed with message:
 add is not a constructor of an inductive type.
 The command has indeed failed with message:
@@ -286,6 +309,7 @@ Warning: Type of IS seems incompatible with the type of Fin.FS.
 Expected type is: (nat -> I -> I) instead of (I -> I).
 This might yield ill typed terms when using the notation.
 [via-type-mismatch,numbers]
+File "./output/NumberNotations.v", line 668, characters 11-12:
 The command has indeed failed with message:
 The term "0" has type "forall n : nat, Fin.t (S n)"
 while it is expected to have type "nat".
@@ -311,6 +335,7 @@ where
      : Fin.t 3
 2 : Fin.t 3
      : Fin.t 3
+File "./output/NumberNotations.v", line 681, characters 11-42:
 The command has indeed failed with message:
 The term "3" has type "Fin.t (S (S (S (S ?n))))"
 while it is expected to have type "Fin.t 3".
@@ -336,6 +361,7 @@ where
      : Fin.t (S (S (S O)))
 @Fin.FS (S (S O)) (@Fin.FS (S O) (@Fin.F1 O)) : Fin.t (S (S (S O)))
      : Fin.t (S (S (S O)))
+File "./output/NumberNotations.v", line 690, characters 11-12:
 The command has indeed failed with message:
 The term
  "@Fin.FS (S (S (S ?n))) (@Fin.FS (S (S ?n)) (@Fin.FS (S ?n) (@Fin.F1 ?n)))"
@@ -431,6 +457,7 @@ where
      : Fin.t 3
 2 : Fin.t 3
      : Fin.t 3
+File "./output/NumberNotations.v", line 914, characters 11-42:
 The command has indeed failed with message:
 The term "3" has type "Fin.t (S (S (S (S ?n))))"
 while it is expected to have type "Fin.t 3".
@@ -456,6 +483,7 @@ where
      : Fin.t (S (S (S O)))
 @Fin.FS (S (S O)) (@Fin.FS (S O) (@Fin.F1 O)) : Fin.t (S (S (S O)))
      : Fin.t (S (S (S O)))
+File "./output/NumberNotations.v", line 923, characters 11-12:
 The command has indeed failed with message:
 The term
  "@Fin.FS (S (S (S ?n))) (@Fin.FS (S (S ?n)) (@Fin.FS (S ?n) (@Fin.F1 ?n)))"
@@ -483,6 +511,7 @@ where
      : Fin.t 3
 2 : Fin.t 3
      : Fin.t 3
+File "./output/NumberNotations.v", line 968, characters 11-42:
 The command has indeed failed with message:
 The term "3" has type "Fin.t (S (S (S (S ?n))))"
 while it is expected to have type "Fin.t 3".
@@ -508,6 +537,7 @@ where
      : Fin.t (S (S (S O)))
 @Fin.FS (S (S O)) (@Fin.FS (S O) (@Fin.F1 O)) : Fin.t (S (S (S O)))
      : Fin.t (S (S (S O)))
+File "./output/NumberNotations.v", line 977, characters 11-12:
 The command has indeed failed with message:
 The term
  "@Fin.FS (S (S (S ?n))) (@Fin.FS (S (S ?n)) (@Fin.FS (S ?n) (@Fin.F1 ?n)))"

--- a/test-suite/output/PosSyntax.out
+++ b/test-suite/output/PosSyntax.out
@@ -20,10 +20,13 @@ fun x : positive => (x~0 + 1)%positive
      : positive
 Pos.of_nat 1 = 1%positive
      : Prop
+File "./output/PosSyntax.v", line 13, characters 11-12:
 The command has indeed failed with message:
 Cannot interpret this number as a value of type positive
+File "./output/PosSyntax.v", line 14, characters 11-14:
 The command has indeed failed with message:
 Cannot interpret this number as a value of type positive
+File "./output/PosSyntax.v", line 15, characters 11-15:
 The command has indeed failed with message:
 Cannot interpret this number as a value of type positive
 1%positive : positive
@@ -46,20 +49,10 @@ Cannot interpret this number as a value of type positive
      : positive
 0x1
      : positive
+File "./output/PosSyntax.v", line 29, characters 11-14:
 The command has indeed failed with message:
 Cannot interpret this number as a value of type positive
-The command has indeed failed with message:
-Cannot interpret this number as a value of type positive
-0x1 : positive
-     : positive
-0x2 : positive
-     : positive
-0xff : positive
-     : positive
-0xff : positive
-     : positive
-The command has indeed failed with message:
-Cannot interpret this number as a value of type positive
+File "./output/PosSyntax.v", line 30, characters 11-15:
 The command has indeed failed with message:
 Cannot interpret this number as a value of type positive
 0x1 : positive
@@ -70,8 +63,24 @@ Cannot interpret this number as a value of type positive
      : positive
 0xff : positive
      : positive
+File "./output/PosSyntax.v", line 35, characters 11-14:
 The command has indeed failed with message:
 Cannot interpret this number as a value of type positive
+File "./output/PosSyntax.v", line 36, characters 11-15:
+The command has indeed failed with message:
+Cannot interpret this number as a value of type positive
+0x1 : positive
+     : positive
+0x2 : positive
+     : positive
+0xff : positive
+     : positive
+0xff : positive
+     : positive
+File "./output/PosSyntax.v", line 41, characters 11-14:
+The command has indeed failed with message:
+Cannot interpret this number as a value of type positive
+File "./output/PosSyntax.v", line 42, characters 11-15:
 The command has indeed failed with message:
 Cannot interpret this number as a value of type positive
 0x1 : positive

--- a/test-suite/output/Record.out
+++ b/test-suite/output/Record.out
@@ -74,5 +74,6 @@ fun x : R => 0
              +++
              x.(field) 0
      : R -> nat
+File "./output/Record.v", line 85, characters 23-24:
 The command has indeed failed with message:
 Projection f expected 1 explicit parameter.

--- a/test-suite/output/RecordFieldErrors.out
+++ b/test-suite/output/RecordFieldErrors.out
@@ -1,14 +1,21 @@
+File "./output/RecordFieldErrors.v", line 10, characters 14-18:
 The command has indeed failed with message:
 unit: Not a projection.
+File "./output/RecordFieldErrors.v", line 13, characters 14-18:
 The command has indeed failed with message:
 unit: Not a projection.
+File "./output/RecordFieldErrors.v", line 17, characters 14-48:
 The command has indeed failed with message:
 This record contains fields of both t and t'.
+File "./output/RecordFieldErrors.v", line 21, characters 14-18:
 The command has indeed failed with message:
 unit: Not a projection.
+File "./output/RecordFieldErrors.v", line 25, characters 14-48:
 The command has indeed failed with message:
 This record defines several times the field foo.
+File "./output/RecordFieldErrors.v", line 29, characters 14-75:
 The command has indeed failed with message:
 This record defines several times the field unit.
+File "./output/RecordFieldErrors.v", line 37, characters 14-18:
 The command has indeed failed with message:
 unit: Not a projection.

--- a/test-suite/output/Sint63NumberSyntax.out
+++ b/test-suite/output/Sint63NumberSyntax.out
@@ -18,26 +18,34 @@
      : int
 427
      : int
+File "./output/Sint63NumberSyntax.v", line 14, characters 11-17:
 The command has indeed failed with message:
 Cannot interpret this number as a value of type int
+File "./output/Sint63NumberSyntax.v", line 15, characters 11-17:
 The command has indeed failed with message:
 Cannot interpret this number as a value of type int
 0
      : int
 0
      : int
+File "./output/Sint63NumberSyntax.v", line 18, characters 12-14:
 The command has indeed failed with message:
 The reference xg was not found in the current environment.
+File "./output/Sint63NumberSyntax.v", line 19, characters 12-14:
 The command has indeed failed with message:
 The reference xG was not found in the current environment.
+File "./output/Sint63NumberSyntax.v", line 20, characters 13-15:
 The command has indeed failed with message:
 The reference x1 was not found in the current environment.
+File "./output/Sint63NumberSyntax.v", line 21, characters 12-13:
 The command has indeed failed with message:
 The reference x was not found in the current environment.
 2 + 2
      : int
+File "./output/Sint63NumberSyntax.v", line 23, characters 11-30:
 The command has indeed failed with message:
 Cannot interpret this number as a value of type int
+File "./output/Sint63NumberSyntax.v", line 24, characters 11-31:
 The command has indeed failed with message:
 Cannot interpret this number as a value of type int
 0x1%uint63

--- a/test-suite/output/StringSyntax.out
+++ b/test-suite/output/StringSyntax.out
@@ -1050,6 +1050,7 @@ Arguments byte_ind P%function_scope f f f f f f f f f f f f f f f f f f f f f f 
      : byte
 "127"
      : byte
+File "./output/StringSyntax.v", line 18, characters 11-16:
 The command has indeed failed with message:
 Expects a single character or a three-digit ASCII code.
 "000"
@@ -1058,6 +1059,7 @@ Expects a single character or a three-digit ASCII code.
      : ascii
 "127"
      : ascii
+File "./output/StringSyntax.v", line 25, characters 11-16:
 The command has indeed failed with message:
 Expects a single character or a three-digit ASCII code.
 "000"
@@ -1094,6 +1096,7 @@ Expects a single character or a three-digit ASCII code.
      : nat
 "255"
      : nat
+File "./output/StringSyntax.v", line 95, characters 11-16:
 The command has indeed failed with message:
 Expects a single character or a three-digit ASCII code.
 "abc"

--- a/test-suite/output/Succeed.out
+++ b/test-suite/output/Succeed.out
@@ -3,8 +3,7 @@
 File "./output/Succeed.v", line 5, characters 11-12:
 The command has indeed failed with message:
 The reference x was not found in the current environment.
-File "./output/Succeed.v", line 7, characters 14-18:
-Error:
+File "./output/Succeed.v", line 7, characters 19-23:
+The command has indeed failed with message:
 The term "Prop" has type "Type" while it is expected to have type 
 "Prop" (universe inconsistency: Cannot enforce Set+1 <= Prop).
-

--- a/test-suite/output/Succeed.out
+++ b/test-suite/output/Succeed.out
@@ -1,5 +1,6 @@
 0
      : nat
+File "./output/Succeed.v", line 5, characters 11-12:
 The command has indeed failed with message:
 The reference x was not found in the current environment.
 File "./output/Succeed.v", line 7, characters 14-18:

--- a/test-suite/output/Succeed.v
+++ b/test-suite/output/Succeed.v
@@ -4,4 +4,4 @@ Succeed Check 0.
 Succeed Definition x := 0.
 Fail Check x.
 
-Succeed Check Prop : Prop.
+Fail Succeed Check Prop : Prop.

--- a/test-suite/output/Tactics.out
+++ b/test-suite/output/Tactics.out
@@ -2,11 +2,14 @@ Ltac f H := split; [ a H | e H ]
 Ltac g := match goal with
           | |- context [ if ?X then _ else _ ] => case X
           end
+File "./output/Tactics.v", line 22, characters 13-19:
 The command has indeed failed with message:
 H is already used.
+File "./output/Tactics.v", line 23, characters 20-26:
 The command has indeed failed with message:
 H is already used.
 a
+File "./output/Tactics.v", line 37, characters 16-17:
 The command has indeed failed with message:
 This variable is used in hypothesis H.
 Ltac test a b c d e := apply a, b in c as [], d, e as ->

--- a/test-suite/output/TypeclassDebug.out
+++ b/test-suite/output/TypeclassDebug.out
@@ -13,5 +13,6 @@ Debug: 1.1-1.1-1.1-1.1-1 : foo
 Debug: 1.1-1.1-1.1-1.1-1: looking for foo without backtracking
 Debug: 1.1-1.1-1.1-1.1-1.1: simple apply H on foo, 1 subgoal(s)
 Debug: 1.1-1.1-1.1-1.1-1.1-1 : foo
+File "./output/TypeclassDebug.v", line 9, characters 5-33:
 The command has indeed failed with message:
 Tactic failure: Proof search reached its limit.

--- a/test-suite/output/UnboundRef.out
+++ b/test-suite/output/UnboundRef.out
@@ -1,3 +1,3 @@
-File "./output/UnboundRef.v", line 1, characters 11-12:
-Error: The reference a was not found in the current environment.
-
+File "./output/UnboundRef.v", line 1, characters 16-17:
+The command has indeed failed with message:
+The reference a was not found in the current environment.

--- a/test-suite/output/UnboundRef.v
+++ b/test-suite/output/UnboundRef.v
@@ -1,2 +1,2 @@
-Check Prop a b.
+Fail Check Prop a b.
 (* Prop is because we need a real head for the application *)

--- a/test-suite/output/UnclosedBlocks.out
+++ b/test-suite/output/UnclosedBlocks.out
@@ -1,2 +1,4 @@
 Error: The section Baz, module type Bar and module Foo need to be closed.
 
+
+coqc exited with code 1

--- a/test-suite/output/UnivBinders.out
+++ b/test-suite/output/UnivBinders.out
@@ -71,6 +71,7 @@ bobmorane =
 let tt := Type@{UnivBinders.32} in
 let ff := Type@{UnivBinders.34} in tt -> ff
      : Type@{max(UnivBinders.31,UnivBinders.33)}
+File "./output/UnivBinders.v", line 85, characters 23-25:
 The command has indeed failed with message:
 Universe uu already bound.
 foo@{E M N} = 
@@ -158,6 +159,7 @@ axbar' : Type@{axfoo'.u0} -> Type@{axfoo'.i}
 axbar' is not universe polymorphic
 Arguments axbar' _%type_scope
 Expands to: Constant UnivBinders.axbar'
+File "./output/UnivBinders.v", line 153, characters 19-26:
 The command has indeed failed with message:
 When declaring multiple axioms in one command, only the first is allowed a universe binder (which will be shared by the whole block).
 foo@{i} = Type@{M.i} -> Type@{i}

--- a/test-suite/output/bug12442.out
+++ b/test-suite/output/bug12442.out
@@ -1,6 +1,9 @@
+File "./output/bug12442.v", line 6, characters 7-19:
 The command has indeed failed with message:
 No product even after head-reduction.
+File "./output/bug12442.v", line 7, characters 7-18:
 The command has indeed failed with message:
 Not an inductive product.
+File "./output/bug12442.v", line 9, characters 7-25:
 The command has indeed failed with message:
 Not an inductive product.

--- a/test-suite/output/bug5778.out
+++ b/test-suite/output/bug5778.out
@@ -1,3 +1,4 @@
+File "./output/bug5778.v", line 2, characters 22-23:
 The command has indeed failed with message:
 In nested Ltac calls to "c", "abs", "abstract b ltac:(())", 
 "b", "a", "pose (I : I)" and "(I : I)", last term evaluation failed.

--- a/test-suite/output/bug6404.out
+++ b/test-suite/output/bug6404.out
@@ -1,3 +1,4 @@
+File "./output/bug6404.v", line 2, characters 22-23:
 The command has indeed failed with message:
 In nested Ltac calls to "c", "abs", "transparent_abstract (tactic3)", 
 "b", "a", "pose (I : I)" and "(I : I)", last term evaluation failed.

--- a/test-suite/output/bug_12887.out
+++ b/test-suite/output/bug_12887.out
@@ -1,3 +1,4 @@
+File "./output/bug_12887.v", line 5, characters 25-26:
 The command has indeed failed with message:
 Cannot infer this placeholder of type "Type" in
 environment:

--- a/test-suite/output/bug_13266.out
+++ b/test-suite/output/bug_13266.out
@@ -1,3 +1,4 @@
+File "./output/bug_13266.v", line 17, characters 7-18:
 The command has indeed failed with message:
 Abstracting over the terms "S", "p" and "u" leads to a term
 fun (S0 : Type) (p0 : proc S0) (_ : S0) => p0 = Tick -> True

--- a/test-suite/output/bug_13595.out
+++ b/test-suite/output/bug_13595.out
@@ -1,3 +1,4 @@
+File "./output/bug_13595.v", line 5, characters 7-17:
 The command has indeed failed with message:
 Tactic failure: Goal is solvable by congruence but some arguments are missing.
   Try "congruence with ((Triple a _ _)) ((Triple d c _))",

--- a/test-suite/output/bug_13857.out
+++ b/test-suite/output/bug_13857.out
@@ -1,6 +1,9 @@
+File "./output/bug_13857.v", line 6, characters 13-16:
 The command has indeed failed with message:
 Unable to find an instance for the variable x.
+File "./output/bug_13857.v", line 7, characters 13-17:
 The command has indeed failed with message:
 Unable to unify "foo2" with "foo".
+File "./output/bug_13857.v", line 8, characters 13-17:
 The command has indeed failed with message:
 Unable to unify "foo3" with "foo".

--- a/test-suite/output/bug_15106.out
+++ b/test-suite/output/bug_15106.out
@@ -1,3 +1,2 @@
-File "./output/bug_15106.v", line 4, characters 0-13:
-Error: Obligation 2 already solved.
-
+The command has indeed failed with message:
+Obligation 2 already solved.

--- a/test-suite/output/bug_15106.v
+++ b/test-suite/output/bug_15106.v
@@ -1,4 +1,9 @@
 Require Import Coq.Program.Tactics.
 Obligation Tactic := try constructor.
-Program Definition foo := (fun (x : False) (y : True) => I) _ _.
-Obligation 2.
+
+Axiom P : Prop. Axiom p : P.
+
+Program Definition foo := (fun (x : P) (y : True) => I) _ _.
+Fail Obligation 2.
+
+Obligation 1. exact p. Qed.

--- a/test-suite/output/bug_4337.out
+++ b/test-suite/output/bug_4337.out
@@ -1,8 +1,7 @@
 File "./output/bug_4337.v", line 4, characters 35-36:
-Error:
+The command has indeed failed with message:
 In environment
 Foo : list var -> term -> Prop
 l : list var
 x : var
 The term "x" has type "var" while it is expected to have type "term".
-

--- a/test-suite/output/bug_4337.v
+++ b/test-suite/output/bug_4337.v
@@ -1,4 +1,4 @@
 Axiom var term : Type.
 
-Inductive Foo : list var -> term -> Prop :=
+Fail Inductive Foo : list var -> term -> Prop :=
 | foo : forall l x, Foo (cons x l) x.

--- a/test-suite/output/bug_7443.out
+++ b/test-suite/output/bug_7443.out
@@ -6,6 +6,7 @@ Literal 1
      : Type
 [1]
      : Type
+File "./output/bug_7443.v", line 30, characters 14-15:
 The command has indeed failed with message:
 The term "1" has type "Datatypes.nat" while it is expected to have type
  "denote ?t".

--- a/test-suite/output/bug_8206.out
+++ b/test-suite/output/bug_8206.out
@@ -1,5 +1,4 @@
-File "./output/bug_8206.v", line 11, characters 0-23:
-Error: Signature components for label homework do not match: expected type
+The command has indeed failed with message:
+Signature components for label homework do not match: expected type
 "forall a b : nat, bug_8206.M.add a b = bug_8206.M.add b a" but found type
 "nat -> forall b : nat, bug_8206.M.add 0 b = bug_8206.M.add b 0".
-

--- a/test-suite/output/bug_8206.v
+++ b/test-suite/output/bug_8206.v
@@ -8,4 +8,4 @@ Module Impl.
   Axiom homework: forall (a b: nat), add 0 b = add b 0.
 End Impl.
 
-Module M : Sig := Impl.
+Fail Module M : Sig := Impl.

--- a/test-suite/output/injection.out
+++ b/test-suite/output/injection.out
@@ -1,4 +1,6 @@
+File "./output/injection.v", line 4, characters 39-42:
 The command has indeed failed with message:
 Unexpected pattern.
+File "./output/injection.v", line 5, characters 35-42:
 The command has indeed failed with message:
 Unexpected injection pattern.

--- a/test-suite/output/ltac.out
+++ b/test-suite/output/ltac.out
@@ -1,19 +1,24 @@
+File "./output/ltac.v", line 8, characters 13-31:
 The command has indeed failed with message:
 Ltac variable y depends on pattern variable name z which is not bound in current context.
 Ltac f x y z :=
   symmetry in x, y; auto with z; auto; intros; clearbody x; generalize
    dependent z
+File "./output/ltac.v", line 33, characters 20-21:
 The command has indeed failed with message:
 In nested Ltac calls to "g1" and "refine (uconstr)", last call failed.
 The term "I" has type "True" while it is expected to have type "False".
+File "./output/ltac.v", line 35, characters 41-42:
 The command has indeed failed with message:
 In nested Ltac calls to "f1 (constr)" and "refine (uconstr)", last call
 failed.
 The term "I" has type "True" while it is expected to have type "False".
+File "./output/ltac.v", line 33, characters 20-21:
 The command has indeed failed with message:
 In nested Ltac calls to "g2 (constr)", "g1" and "refine (uconstr)", last call
 failed.
 The term "I" has type "True" while it is expected to have type "False".
+File "./output/ltac.v", line 35, characters 41-42:
 The command has indeed failed with message:
 In nested Ltac calls to "f2", "f1 (constr)" and "refine (uconstr)", last call
 failed.

--- a/test-suite/output/names.out
+++ b/test-suite/output/names.out
@@ -1,3 +1,4 @@
+File "./output/names.v", line 5, characters 37-40:
 The command has indeed failed with message:
 In environment
 y : nat

--- a/test-suite/output/notation_principal_scope.out
+++ b/test-suite/output/notation_principal_scope.out
@@ -1,16 +1,21 @@
+File "./output/notation_principal_scope.v", line 4, characters 28-29:
 The command has indeed failed with message:
 Argument X was previously inferred to be in scope function_scope but is here
 used in the empty scope stack. Scope function_scope will be used at parsing
 time unless you override it by annotating the argument with an explicit scope
 of choice. [inconsistent-scopes,syntax]
+File "./output/notation_principal_scope.v", line 6, characters 23-36:
 The command has indeed failed with message:
 Abbreviations don't support only printing
+File "./output/notation_principal_scope.v", line 8, characters 22-33:
 The command has indeed failed with message:
 The reference nonexisting was not found in the current environment.
+File "./output/notation_principal_scope.v", line 10, characters 34-57:
 The command has indeed failed with message:
 Notation scope for argument X can be specified only once.
 pp I
      : True /\ True
+File "./output/notation_principal_scope.v", line 19, characters 18-19:
 The command has indeed failed with message:
 Illegal application (Non-functional construction): 
 The expression "I" of type "True" cannot be applied to the term

--- a/test-suite/output/print_ltac.out
+++ b/test-suite/output/print_ltac.out
@@ -6,6 +6,7 @@ Ltac t3 := idtacstr "my tactic"
 Ltac t4 x := match x with
              | ?A => constr:((A, A))
              end
+File "./output/print_ltac.v", line 17, characters 27-32:
 The command has indeed failed with message:
 idnat is bound to a notation that does not denote a reference.
 Ltac withstrategy l x :=
@@ -119,6 +120,7 @@ Ltac withstrategy l x :=
   x
   ]
   idtac
+File "./output/print_ltac.v", line 52, characters 29-34:
 The command has indeed failed with message:
 idnat is bound to a notation that does not denote a reference.
 Ltac withstrategy l x :=

--- a/test-suite/output/qualification.out
+++ b/test-suite/output/qualification.out
@@ -3,3 +3,5 @@ Error: Signature components for label test do not match: expected type
 "qualification.M2.t = qualification.M2.M.t" but found type
 "qualification.M2.t = qualification.M2.t".
 
+
+coqc exited with code 1

--- a/test-suite/output/rewrite_2172.out
+++ b/test-suite/output/rewrite_2172.out
@@ -1,2 +1,3 @@
+File "./output/rewrite_2172.v", line 21, characters 7-23:
 The command has indeed failed with message:
 Unable to find an instance for the variable E.

--- a/test-suite/output/ssr_clear.out
+++ b/test-suite/output/ssr_clear.out
@@ -1,2 +1,3 @@
+File "./output/ssr_clear.v", line 5, characters 5-26:
 The command has indeed failed with message:
 No assumption is named NO_SUCH_NAME

--- a/test-suite/output/ssr_error_multiple_intro_after_case.out
+++ b/test-suite/output/ssr_error_multiple_intro_after_case.out
@@ -1,3 +1,3 @@
-File "./output/ssr_error_multiple_intro_after_case.v", line 3, characters 0-11:
-Error: x already used
-
+File "./output/ssr_error_multiple_intro_after_case.v", line 3, characters 5-16:
+The command has indeed failed with message:
+x already used

--- a/test-suite/output/ssr_error_multiple_intro_after_case.v
+++ b/test-suite/output/ssr_error_multiple_intro_after_case.v
@@ -1,4 +1,4 @@
 Require Import ssreflect.
 Goal forall p : nat * nat , True.
-case => x x.
+Fail case => x x.
 Abort.

--- a/test-suite/output/ssr_explain_match.out
+++ b/test-suite/output/ssr_explain_match.out
@@ -50,5 +50,6 @@ instance: (addnC z (x + y)) matches: (x + y + z)
 instance: (addnC y x) matches: (x + y)
 instance: (addnC y x) matches: (x + y)
 END INSTANCES
+File "./output/ssr_explain_match.v", line 22, characters 5-38:
 The command has indeed failed with message:
 Not supported

--- a/test-suite/output/unifconstraints.out
+++ b/test-suite/output/unifconstraints.out
@@ -59,6 +59,7 @@ unification constraint:
    True /\ True /\ True \/
    veeryyyyyyyyyyyyloooooooooooooonggidentifier =
    veeryyyyyyyyyyyyloooooooooooooonggidentifier
+File "./output/unifconstraints.v", line 29, characters 42-43:
 The command has indeed failed with message:
 In environment
 P : nat -> Type

--- a/test-suite/output/unification.out
+++ b/test-suite/output/unification.out
@@ -1,3 +1,4 @@
+File "./output/unification.v", line 9, characters 35-39:
 The command has indeed failed with message:
 In environment
 x : T
@@ -6,6 +7,7 @@ a : T
 Unable to unify "T" with "?X@{x0:=x; x:=C a}" (cannot instantiate 
 "?X" because "T" is not in its scope: available arguments are 
 "x" "C a").
+File "./output/unification.v", line 12, characters 12-14:
 The command has indeed failed with message:
 The term "id" has type "ID" while it is expected to have type 
 "Type -> ?T" (cannot instantiate "?T" because "A" is not in its scope).


### PR DESCRIPTION
- Fail prints locations in test-mode
- exit code of coqc is included in the output/ expected output

This allows to test multiple error locations in 1 file.
We also avoid having coqc stealthily fail (a couple tests expect it to fail).

Overlays
- https://github.com/mit-plv/bedrock2/pull/202
- https://github.com/tchajed/coq-record-update/pull/28