### PR TITLE
Fix anomaly when Ltac2 "unfold" uses undefined varaible

### DIFF
--- a/doc/changelog/04-tactics/15175-undefined-variable-unfold-anomaly.rst
+++ b/doc/changelog/04-tactics/15175-undefined-variable-unfold-anomaly.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Display proper error messages for Ltac2 "unfold" tactic
+  when invoked with an undefined variable name
+  (`#15175 <https://github.com/coq/coq/pull/15175>`_,
+  fixes `#14485 <https://github.com/coq/coq/issues/14485>`_,
+  by Wojciech Karpiel).

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -1184,10 +1184,9 @@ let unfold env sigma name c =
  * Performs a betaiota reduction after unfolding. *)
 let unfoldoccs env sigma (occs,name) c =
   begin match name with
-    | EvalVarRef id -> begin try ignore (lookup_named id env) with Not_found as exn ->
-        let _, info = Exninfo.capture exn in
-        Nametab.error_global_not_found ~info (qualid_of_evaluable_ref env name)
-      end
+    | EvalVarRef id ->
+      begin try ignore (lookup_named id env) with Not_found ->
+        Nametab.error_global_not_found ~info:Exninfo.null (qualid_of_evaluable_ref env name) end
     | EvalConstRef _ -> () (* No checks necessary *)
   end;
   match occs with

--- a/test-suite/output/bug_14485.out
+++ b/test-suite/output/bug_14485.out
@@ -1,0 +1,4 @@
+The command has indeed failed with message:
+The reference unknown_identifier was not found in the current environment.
+The command has indeed failed with message:
+The reference unknown_identifier was not found in the current environment.

--- a/test-suite/output/bug_14485.v
+++ b/test-suite/output/bug_14485.v
@@ -1,0 +1,6 @@
+From Ltac2 Require Import Ltac2.
+Goal True.
+  Fail unfold &unknown_identifier.
+  Fail unfold &unknown_identifier at 1.
+  exact I.
+Qed.


### PR DESCRIPTION
Hello!

There are two issues that I want to solve with this PR

1. First one is #14485

    I made error message to be the same as for Ltac1 ("The reference unknown_identifier was not found in the current environment."), but it can be misleading in some cases. For example, if someone tries to use a global reference as a variable name, then the error might seem wrong.

        From Ltac2 Require Import Ltac2.
        Goal  (True).
          unfold id. (* OK *)
          unfold &id. (* Error which makes it look like 'id' was never defined, while it is not a variable *)
        Qed.
        
    WDYT?

1. Second one is `unfold` in Ltac2 providing misleading error message when an unknown identifier is used (in cases when it doesn't crash like in #14485)

    Ltac1:

        Goal True.
          unfold unknown_identifier at 1.  -> The reference unknown_identifier was not found in the current environment.

    Ltac2:

        From Ltac2 Require Import Ltac2.
        Goal True.
          unfold &unknown_identifier at 1.  -> unknown_identifier does not occur. (ignoring the fact that name is not tied to any existing thing)




<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
