### PR TITLE
Update locations of ltac errors based on Loc.finer

### DIFF
--- a/test-suite/output/UpdateLoc.out
+++ b/test-suite/output/UpdateLoc.out
@@ -1,0 +1,6 @@
+File "./output/UpdateLoc.v", line 5, characters 14-15:
+The command has indeed failed with message:
+The term "0" has type "nat" while it is expected to have type "False".
+File "./output/UpdateLoc.v", line 6, characters 7-9:
+The command has indeed failed with message:
+The term "0" has type "nat" while it is expected to have type "False".

--- a/test-suite/output/UpdateLoc.v
+++ b/test-suite/output/UpdateLoc.v
@@ -1,0 +1,7 @@
+Ltac r0 := refine 0.
+
+Goal False.
+Proof.
+  Fail refine 0. (* before: whole tactic, after: just 0 *)
+  Fail r0. (* before: "refine 0" in the ltac definition, after: r0 in this line *)
+Abort.


### PR DESCRIPTION
~~~coq
Ltac r0 := refine 0.

Goal False.
Proof.
  Fail refine 0. (* before: whole tactic, after: just 0 *)
  Fail r0. (* before: "refine 0" in the ltac definition, after: r0 in this line *)
Abort.
~~~

Based on #15174 to be able to write the test in a sane way.