### PR TITLE
Pass the genargs from the tactic closure to uconstr interpretation.

### DIFF
--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -558,13 +558,13 @@ let extract_ltac_constr_context ist env sigma =
     try Id.Map.add id (coerce_var_to_ident false env sigma v) map
     with CannotCoerceTo _ -> map
   in
-  let fold id v {idents;typed;untyped} =
+  let fold id v {idents;typed;untyped;genargs} =
     let idents = add_ident id v idents in
     let typed = add_constr id v typed in
     let untyped = add_uconstr id v untyped in
-    { idents ; typed ; untyped }
+    { idents ; typed ; untyped; genargs }
   in
-  let empty =  { idents = Id.Map.empty ;typed = Id.Map.empty ; untyped = Id.Map.empty } in
+  let empty = { idents = Id.Map.empty ;typed = Id.Map.empty ; untyped = Id.Map.empty; genargs = ist.lfun } in
   Id.Map.fold fold ist.lfun empty
 
 (** Significantly simpler than [interp_constr], to interpret an
@@ -1079,7 +1079,7 @@ let type_uconstr ?(flags = (constr_flags ()))
     ltac_constrs = closure.typed;
     ltac_uconstrs = closure.untyped;
     ltac_idents = closure.idents;
-    ltac_genargs = Id.Map.empty;
+    ltac_genargs = closure.genargs;
   } in
   let flags = { flags with polymorphic = ist.Geninterp.poly } in
   understand_ltac flags env sigma vars expected_type term

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -1308,6 +1308,7 @@ let () =
       idents = Id.Map.empty;
       typed = Id.Map.empty;
       untyped = Id.Map.empty;
+      genargs = Id.Map.empty;
     } in
     let c = { closure; term = c } in
     return (Value.of_ext val_preterm c)

--- a/pretyping/ltac_pretype.ml
+++ b/pretyping/ltac_pretype.ml
@@ -46,7 +46,8 @@ type extended_patvar_map = constr_under_binders Id.Map.t
 type closure = {
   idents:Id.t Id.Map.t;
   typed: constr_under_binders Id.Map.t ;
-  untyped:closed_glob_constr Id.Map.t }
+  untyped:closed_glob_constr Id.Map.t;
+  genargs : Geninterp.Val.t Id.Map.t; }
 and closed_glob_constr = {
   closure: closure;
   term: glob_constr }

--- a/test-suite/bugs/closed/bug_15177.v
+++ b/test-suite/bugs/closed/bug_15177.v
@@ -1,0 +1,10 @@
+Ltac foo :=
+match goal with
+| [ x : ?T |- _ ] => refine (ltac:(exact x))
+end.
+
+Goal nat -> nat.
+Proof.
+intros n.
+foo.
+Qed.


### PR DESCRIPTION
Fixes #15177: Incorrect closure of uconstr.