### PR TITLE
Correctly pass the genarg map to uconstr pretyping.

### DIFF
--- a/pretyping/globEnv.ml
+++ b/pretyping/globEnv.ml
@@ -165,7 +165,7 @@ let interp_ltac_variable ?loc typing_fun env sigma id : Evd.evar_map * unsafe_ju
       ltac_constrs = closure.typed;
       ltac_uconstrs = closure.untyped;
       ltac_idents = closure.idents;
-      ltac_genargs = Id.Map.empty; }
+      ltac_genargs = closure.genargs; }
     in
     (* spiwack: I'm catching [Not_found] potentially too eagerly
        here, as the call to the main pretyping function is caught

--- a/test-suite/bugs/closed/bug_15197.v
+++ b/test-suite/bugs/closed/bug_15197.v
@@ -1,0 +1,7 @@
+Goal nat.
+Proof.
+let x := constr:(0) in
+let y := uconstr:(ltac:(exact x)) in
+refine (ltac:(exact y)).
+(* The reference x was not found in the current environment. *)
+Qed.


### PR DESCRIPTION
Fixes #15197: Incorrect closure of uconstr (variation on a theme).

Overlays:
- https://github.com/HoTT/HoTT/pull/1595 (since it's backwards compatible, let's wait for it to be merged instead of adding an overlay)