### PR TITLE
cbn: do not refold constants with ! and / when the ! matched.

### DIFF
--- a/doc/changelog/04-tactics/15204-cbn-volatile.rst
+++ b/doc/changelog/04-tactics/15204-cbn-volatile.rst
@@ -1,0 +1,13 @@
+- **Changed:** :tacn:`cbn` interprets the combination of the ``!`` and
+  ``/`` modifiers (from :cmd:`Arguments`) to mean "unfold as soon as
+  all arguments before the ``/`` are provided and all arguments marked
+  with ``!`` reduce to a constructor". This makes it unfold more often
+  than without the ``/`` when all arguments are provided. Previously
+  adding ``/`` would only prevent unfolding when insufficient
+  arguments are provided without adding new unfoldings.
+
+  Note that this change only takes effect in default mode (as opposed
+  to when ``simpl nomatch`` was used) (`#15204
+  <https://github.com/coq/coq/pull/15204>`_, fixes `#4555
+  <https://github.com/coq/coq/issues/4555>`_ and `#7674
+  <https://github.com/coq/coq/issues/7674>`_, by Gaëtan Gilbert).

--- a/test-suite/bugs/closed/bug_4555.v
+++ b/test-suite/bugs/closed/bug_4555.v
@@ -1,0 +1,29 @@
+Definition prod_map {A A' B B'} (f : A -> A') (g : B -> B')
+           (p : A * B) : A' * B'
+  := (f (fst p), g (snd p)).
+Arguments prod_map {_ _ _ _} _ _ !_ /.
+
+Lemma test1 {A A' B B'} (f : A -> A') (g : B -> B') x y :
+  prod_map f g (x,y) = (f x, g y).
+Proof.
+  Succeed progress simpl; match goal with |- ?x = ?x => idtac end. (* LHS becomes (f x, g y) *)
+
+  Succeed progress cbn; match goal with |- ?x = ?x => idtac end. (* LHS is not simplified *)
+Admitted.
+
+
+Axiom n : nat.
+Arguments Nat.add _ !_.
+
+Goal n + S n = 0.
+  Fail progress cbn.
+Abort.
+
+Goal S n + S n = 0.
+  progress cbn.
+  match goal with |- S (n + S n) = 0 => idtac end.
+Abort.
+
+Goal S n + n = 0.
+  Fail progress cbn.
+Abort.

--- a/test-suite/bugs/closed/bug_7674.v
+++ b/test-suite/bugs/closed/bug_7674.v
@@ -1,0 +1,30 @@
+Definition foo (n : option nat) : nat := 0.
+Arguments foo !_ /.
+
+Goal forall n, foo (Some n) = 1.
+  intros.
+  progress cbn.
+Abort.
+
+Goal forall n, foo n = 1.
+  intros.
+  Fail progress cbn.
+Abort.
+
+Require Bool.
+
+Definition do_something (p q : bool) (a b : nat) : option nat :=
+  if Bool.eqb p q then Some a else Some b.
+Arguments do_something !_ !_ _ _ /.
+
+Lemma test a b :
+  exists x, do_something false true a b = x.
+Proof.
+  intros. eexists.
+
+  progress cbn [do_something].
+  match goal with |- (if Bool.eqb false true then Some a else Some b) = _ => idtac end.
+
+  progress cbn [Bool.eqb].
+  reflexivity.
+Qed.


### PR DESCRIPTION
Fix #4555
Fix #7674
