### PR TITLE
Ignore failures with with a level > 0 in eauto runs.

### DIFF
--- a/doc/changelog/04-tactics/15215-eauto-ignore-higher-failures.rst
+++ b/doc/changelog/04-tactics/15215-eauto-ignore-higher-failures.rst
@@ -1,0 +1,7 @@
+- **Changed:**
+  The :tacn:`eauto` tactic does not propagate internal Ltac failures
+  with level > 0 anymore. Any failure caused by a hint now behaves as if it
+  were a level 0 error
+  (`#15215 <https://github.com/coq/coq/pull/15215>`_,
+  fixes `#15214 <https://github.com/coq/coq/issues/15214>`_,
+  by Pierre-Marie Pédrot).

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -185,8 +185,6 @@ module SearchProblem = struct
         let is_done = is_done || List.is_empty ngls in
         Some (sigma, is_done, ngls, cost, pptac)
       with e when CErrors.noncritical e ->
-        let e = Exninfo.capture e in
-        let () = Tacticals.Old.catch_failerror e in
         None
     in
     List.map_filter map l

--- a/test-suite/bugs/closed/bug_15214.v
+++ b/test-suite/bugs/closed/bug_15214.v
@@ -1,0 +1,6 @@
+#[local] Hint Extern 0 => fail 1 : foo.
+
+Goal False.
+Proof.
+eauto with foo.
+Abort.


### PR DESCRIPTION
Fixes #15214.

Let's pray that nobody relies on this in the CI. I am looking at you fcl.