### PR TITLE
[CoqIDE] Do not scroll to start of input in navigation commands.

### DIFF
--- a/ide/coqide/coqOps.ml
+++ b/ide/coqide/coqOps.ml
@@ -628,7 +628,6 @@ object(self)
   method private fill_command_queue until queue =
     let topstack =
       if Doc.focused document then fst (Doc.context document) else [] in
-    self#scroll_to_start_of_input ();
     let rec loop n iter =
       match Sentence.find buffer iter with
       | None -> ()
@@ -903,12 +902,9 @@ object(self)
     Coq.bind (Coq.return ()) (fun () ->
     messages#default_route#clear;
     let point = self#get_insert in
-    if point#compare self#get_start_of_input >= 0 then
-      self#process_until_iter point
-    else begin
-      self#scroll_to_start_of_input ();
-      self#backtrack_to_iter ~move_insert:false point
-    end)
+    if point#compare self#get_start_of_input >= 0
+    then self#process_until_iter point
+    else self#backtrack_to_iter ~move_insert:false point)
 
   method go_to_mark m =
     Coq.bind (Coq.return ()) (fun () ->

--- a/ide/coqide/coqide.ml
+++ b/ide/coqide/coqide.ml
@@ -838,8 +838,7 @@ module Nav = struct
     maybe_update_breakpoints ();
     if notebook#pages <> [] then begin
       let sn = notebook#current_term in
-      Coq.reset_coqtop sn.coqtop; (* calls init_bpts *)
-      sn.coqops#scroll_to_start_of_input ()
+      Coq.reset_coqtop sn.coqtop (* calls init_bpts *)
     end
   let interrupt _ =  (* terminate computation *)
     Minilib.log "User interrupt received";


### PR DESCRIPTION
This restores the behaviour from before #14644.

Fixes #15230.
