### PR TITLE
Allow calling doc_gram targets through Makefile.dune

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,6 +45,7 @@
 
 /doc/                  @coq/doc-maintainers
 /Makefile.doc          @coq/doc-maintainers
+/Makefile.docgram      @coq/doc-maintainers
 
 /dev/doc/              @coq/doc-maintainers
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@ Fixes / closes #????
 - [ ] Added / updated **documentation**.
   <!-- Check if the following applies, otherwise remove these lines. -->
   - [ ] Documented any new / changed **user messages**.
-  - [ ] Updated **documented syntax** by running `make -f Makefile.make doc_gram_rsts`.
+  - [ ] Updated **documented syntax** by running `make -f Makefile.dune doc_gram_rsts`.
 
 <!-- If this breaks external libraries or plugins in CI: -->
 - [ ] Opened **overlay** pull requests.

--- a/Makefile.doc
+++ b/Makefile.doc
@@ -48,13 +48,6 @@ endif
 SPHINXBUILD= sphinx-build
 SPHINXBUILDDIR= doc/sphinx/_build
 
-DOCGRAMWARN ?= 0
-ifeq ($(DOCGRAMWARN),0)
-DOCGRAMWARNFLAG=-no-warn
-else
-DOCGRAMWARNFLAG=
-endif
-
 # Internal variables.
 ALLSPHINXOPTS= -d $(SPHINXBUILDDIR)/doctrees $(SPHINXOPTS)
 
@@ -285,60 +278,7 @@ install-doc-sphinx:
 		$(INSTALLLIB) doc/sphinx/_build/$$d/$$f $(DOCDIRDEST)/sphinx/$$d/$$f;\
 	done; done)
 
-######################################################################
-# doc_grammar tool
-######################################################################
-
-# List mlg files explicitly to avoid ordering problems (across
-# different installations / make versions).
-DOC_MLGS := \
-	parsing/g_constr.mlg parsing/g_prim.mlg \
-	toplevel/g_toplevel.mlg \
-	vernac/g_proofs.mlg  vernac/g_vernac.mlg \
-	plugins/btauto/g_btauto.mlg \
-	plugins/cc/g_congruence.mlg \
-	plugins/derive/g_derive.mlg \
-	plugins/extraction/g_extraction.mlg \
-	plugins/firstorder/g_ground.mlg \
-	plugins/funind/g_indfun.mlg \
-	plugins/ltac/coretactics.mlg plugins/ltac/extraargs.mlg plugins/ltac/extratactics.mlg \
-	plugins/ltac/g_auto.mlg plugins/ltac/g_class.mlg plugins/ltac/g_eqdecide.mlg \
-	plugins/ltac/g_ltac.mlg plugins/ltac/g_obligations.mlg plugins/ltac/g_rewrite.mlg \
-	plugins/ltac/g_tactic.mlg plugins/ltac/profile_ltac_tactics.mlg \
-	plugins/micromega/g_micromega.mlg  plugins/micromega/g_zify.mlg \
-	plugins/nsatz/g_nsatz.mlg \
-	plugins/ring/g_ring.mlg \
-	plugins/rtauto/g_rtauto.mlg \
-	plugins/ssr/ssrparser.mlg  plugins/ssr/ssrvernac.mlg \
-	plugins/ssrmatching/g_ssrmatching.mlg \
-	plugins/syntax/g_number_string.mlg \
-	plugins/ltac2/g_ltac2.mlg
-DOC_EDIT_MLGS := $(wildcard doc/tools/docgram/*.edit_mlg)
-DOC_RSTS := $(wildcard doc/sphinx/*/*.rst) $(wildcard doc/sphinx/*/*/*.rst)
-
-doc/tools/docgram/fullGrammar: $(DOC_GRAM) $(DOC_MLGS)
-	$(SHOW)'DOC_GRAM'
-	$(HIDE)$(DOC_GRAM) -short -no-warn $(DOC_MLGS)
-
-#todo: add a dependency of sphinx on updated_rsts when we're ready
-doc/tools/docgram/orderedGrammar doc/tools/docgram/updated_rsts: doc/tools/docgram/fullGrammar $(DOC_GRAM) $(DOC_EDIT_MLGS)
-	$(SHOW)'DOC_GRAM_RSTS'
-	$(HIDE)$(DOC_GRAM) $(DOCGRAMWARNFLAG) -check-cmds -check-tacs $(DOC_MLGS) $(DOC_RSTS)
-
-.PRECIOUS: doc/tools/docgram/orderedGrammar
-
-doc/tools/docgram/updated_rsts: doc/tools/docgram/orderedGrammar
-
-.PHONY: doc_gram doc_gram_verify doc_gram_rsts
-
-doc_gram: doc/tools/docgram/fullGrammar
-
-doc_gram_verify: $(DOC_GRAM) $(DOC_MLGS)
-	$(SHOW)'DOC_GRAM_VERIFY'
-	$(HIDE)$(DOC_GRAM) -no-warn -verify $(DOC_MLGS) $(DOC_RSTS)
-
-doc_gram_rsts: doc/tools/docgram/updated_rsts
-
+include Makefile.docgram
 
 # For emacs:
 # Local Variables:

--- a/Makefile.docgram
+++ b/Makefile.docgram
@@ -1,0 +1,66 @@
+######################################################################
+# doc_grammar tool
+######################################################################
+
+DOCGRAMWARN ?= 0
+ifeq ($(DOCGRAMWARN),0)
+DOCGRAMWARNFLAG=-no-warn
+else
+DOCGRAMWARNFLAG=
+endif
+
+# List mlg files explicitly to avoid ordering problems (across
+# different installations / make versions).
+DOC_MLGS := \
+	parsing/g_constr.mlg parsing/g_prim.mlg \
+	toplevel/g_toplevel.mlg \
+	vernac/g_proofs.mlg  vernac/g_vernac.mlg \
+	plugins/btauto/g_btauto.mlg \
+	plugins/cc/g_congruence.mlg \
+	plugins/derive/g_derive.mlg \
+	plugins/extraction/g_extraction.mlg \
+	plugins/firstorder/g_ground.mlg \
+	plugins/funind/g_indfun.mlg \
+	plugins/ltac/coretactics.mlg plugins/ltac/extraargs.mlg plugins/ltac/extratactics.mlg \
+	plugins/ltac/g_auto.mlg plugins/ltac/g_class.mlg plugins/ltac/g_eqdecide.mlg \
+	plugins/ltac/g_ltac.mlg plugins/ltac/g_obligations.mlg plugins/ltac/g_rewrite.mlg \
+	plugins/ltac/g_tactic.mlg plugins/ltac/profile_ltac_tactics.mlg \
+	plugins/micromega/g_micromega.mlg  plugins/micromega/g_zify.mlg \
+	plugins/nsatz/g_nsatz.mlg \
+	plugins/ring/g_ring.mlg \
+	plugins/rtauto/g_rtauto.mlg \
+	plugins/ssr/ssrparser.mlg  plugins/ssr/ssrvernac.mlg \
+	plugins/ssrmatching/g_ssrmatching.mlg \
+	plugins/syntax/g_number_string.mlg \
+	plugins/ltac2/g_ltac2.mlg
+DOC_EDIT_MLGS := $(wildcard doc/tools/docgram/*.edit_mlg)
+DOC_RSTS := $(wildcard doc/sphinx/*/*.rst) $(wildcard doc/sphinx/*/*/*.rst)
+
+doc/tools/docgram/fullGrammar: $(DOC_GRAM) $(DOC_MLGS)
+	$(SHOW)'DOC_GRAM'
+	$(HIDE)$(DOC_GRAM) -short -no-warn $(DOC_MLGS)
+
+#todo: add a dependency of sphinx on updated_rsts when we're ready
+doc/tools/docgram/orderedGrammar doc/tools/docgram/updated_rsts: doc/tools/docgram/fullGrammar $(DOC_GRAM) $(DOC_EDIT_MLGS)
+	$(SHOW)'DOC_GRAM_RSTS'
+	$(HIDE)$(DOC_GRAM) $(DOCGRAMWARNFLAG) -check-cmds -check-tacs $(DOC_MLGS) $(DOC_RSTS)
+
+.PRECIOUS: doc/tools/docgram/orderedGrammar
+
+doc/tools/docgram/updated_rsts: doc/tools/docgram/orderedGrammar
+
+.PHONY: doc_gram doc_gram_verify doc_gram_rsts
+
+doc_gram: doc/tools/docgram/fullGrammar
+
+doc_gram_verify: $(DOC_GRAM) $(DOC_MLGS)
+	$(SHOW)'DOC_GRAM_VERIFY'
+	$(HIDE)$(DOC_GRAM) -no-warn -verify $(DOC_MLGS) $(DOC_RSTS)
+
+doc_gram_rsts: doc/tools/docgram/updated_rsts
+
+
+# For emacs:
+# Local Variables:
+# mode: makefile
+# End:

--- a/Makefile.dune
+++ b/Makefile.dune
@@ -7,6 +7,17 @@
 .PHONY: fmt ocheck ireport clean                      # Maintenance targets
 .PHONY: voboot release install                        # Added just not to break old scripts
 
+
+###########################################################################
+# The SHOW and HIDE variables control whether make will echo complete commands
+# or only abbreviated versions.
+# Quiet mode is ON by default except if VERBOSE=1 option is given to make
+# Used only by targets which don't go through dune (eg doc_gram_rsts)
+
+VERBOSE ?=
+SHOW := $(if $(VERBOSE),@true "",@echo "")
+HIDE := $(if $(VERBOSE),,@)
+
 # use DUNEOPT=--display=short for a more verbose build
 # DUNEOPT=--display=short
 
@@ -139,6 +150,17 @@ ireport:
 
 clean:
 	dune clean
+
+# docgram
+
+DOC_GRAM:=_build/default/doc/tools/docgram/doc_grammar.exe
+
+# not worth figuring out dependencies, just leave it to dune
+.PHONY: $(DOC_GRAM)
+$(DOC_GRAM):
+	dune build $(DUNEOPT) $@
+
+include Makefile.docgram
 
 # ci-* targets
 

--- a/dev/lint-repository.sh
+++ b/dev/lint-repository.sh
@@ -37,7 +37,6 @@ dev/tools/check-cachekey.sh || CODE=1
 
 # Check that doc/tools/docgram/fullGrammar is up-to-date
 echo Checking grammar files
-{ ./configure -profile devel >/dev/null && \
-  make -j "$NJOBS" -f Makefile.make SHOW='@true ""' doc_gram_verify; } || CODE=1
+make -f Makefile.dune SHOW='@true ""' doc_gram_verify || CODE=1
 
 exit $CODE


### PR DESCRIPTION
Notably this allows to run them without explicit configuration.

Closes #15246