### PR TITLE
Fixes #15244: wrong choice of final name for specialize with an introduction pattern

### DIFF
--- a/doc/changelog/04-tactics/15245-master+fix15244-specialize-wrong-final-name-ipat.rst
+++ b/doc/changelog/04-tactics/15245-master+fix15244-specialize-wrong-final-name-ipat.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Regression in 8.14.0 and 8.14.1 with action pattern :n:`%` in
+  :n:`as` clause of tactic :tacn:`specialize`
+  (`#15245 <https://github.com/coq/coq/pull/15245>`_,
+  fixes `#15244 <https://github.com/coq/coq/issues/15244>`_,
+  by Hugo Herbelin).

--- a/test-suite/bugs/closed/bug_15244.v
+++ b/test-suite/bugs/closed/bug_15244.v
@@ -1,0 +1,30 @@
+Lemma test (X : nat -> Prop) (H : forall n, X n) (H' : forall n, X n -> X (S n)) : True.
+Proof.
+  specialize (H 5) as J%H'.
+  Check (J : X 6).
+  Fail Check H.
+  Undo.
+  specialize (H 5) as ?%H'.
+  Check (H0 : X 6).
+  Fail Check H.
+Abort.
+
+Lemma test2 (b : bool) (f : bool -> nat) : True.
+Proof.
+  specialize b as [|n]%f.
+  Fail Check b.
+  2:Check (n : nat).
+Abort.
+
+Lemma test3 (b : bool) (f : bool -> nat) : True.
+Proof.
+  specialize (f b) as f'.
+  Check (f : bool -> nat).
+  Undo.
+  specialize (f b) as ?f.
+  Check (f : bool -> nat).
+  Check (f0 : nat).
+  Undo.
+  specialize (f b) as f.
+  Check (f : nat).
+Abort.


### PR DESCRIPTION
**Kind:** Fix

Fixes / closes #15244

This was introduced in e56c65c which did not adapt `specialize` correctly.

- [X] Added / updated **test-suite**.
- [x] Added **changelog**.
