### PR TITLE
Last round of compatibility removal in ssreflect

### DIFF
--- a/plugins/ssr/ssrast.mli
+++ b/plugins/ssr/ssrast.mli
@@ -182,4 +182,3 @@ type gist = Tacintern.glob_sign
 type ist = Tacinterp.interp_sign
 type goal = Goal.goal
 type 'a sigma = 'a Evd.sigma
-type v82tac = Tacmach.Old.tactic

--- a/plugins/ssr/ssrbwd.ml
+++ b/plugins/ssr/ssrbwd.ml
@@ -102,7 +102,7 @@ let refine_interp_apply_view dbl ist gv =
   | [] -> Proofview.tclORELSE (apply_rconstr ~ist rv) (fun _ -> view_error "apply" gv)
   | h :: hs ->
     match interp_with h with
-    | (_, t) -> Proofview.tclORELSE (refine_with t) (fun _ -> loop hs)
+    | t -> Proofview.tclORELSE (refine_with t) (fun _ -> loop hs)
     | exception e -> loop hs
   in
   loop (pair dbl (Ssrview.AdaptorDb.get dbl) @
@@ -146,8 +146,8 @@ let inner_ssrapplytac gviews (ggenl, gclr) ist =
       (cleartac clr)
   | [], [agens] ->
     let sigma = Proofview.Goal.sigma gl in
-    let clr', (nsigma, lemma) = interp_agens ist (pf_env gl) sigma ~concl:(pf_concl gl) agens in
-    let sigma = Evd.merge_universe_context sigma (Evd.evar_universe_context nsigma) in
+    let clr', lemma = interp_agens ist (pf_env gl) sigma ~concl:(pf_concl gl) agens in
+    let sigma = Evd.merge_universe_context sigma (Evd.evar_universe_context (fst lemma)) in
     Tacticals.tclTHENLIST [Proofview.Unsafe.tclEVARS sigma; cleartac clr; refine_with ~beta:true lemma; cleartac clr']
   | _, _ ->
     Tacticals.tclTHENLIST [apply_top_tac; cleartac clr]))

--- a/plugins/ssr/ssrbwd.ml
+++ b/plugins/ssr/ssrbwd.ml
@@ -43,13 +43,13 @@ let interp_agen ist env sigma ((goclr, _), (k, gc as c)) (clr, rcs) =
 let interp_nbargs ist env sigma rc =
   try
     let rc6 = mkRApp rc (mkRHoles 6) in
-    let sigma, t = interp_open_constr env sigma ist (rc6, None) in
+    let t = interp_open_constr env sigma ist (rc6, None) in
     6 + Ssrcommon.nbargs_open_constr env t
   with _ -> 5
 
 let interp_view_nbimps ist env sigma rc =
   try
-    let sigma, t = interp_open_constr env sigma ist (rc, None) in
+    let t = interp_open_constr env sigma ist (rc, None) in
     let pl, c = splay_open_constr env t in
     if Ssrcommon.isAppInd env sigma c then List.length pl else (-(List.length pl))
   with _ -> 0

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -449,13 +449,7 @@ let abs_evars2 env sigma0 rigid (sigma, c0) =
   | [] -> c in
   List.length evlist, EConstr.of_constr (loop (get 1 c0) 1 evlist), List.map fst evlist, ucst
 
-let pf_abs_evars2 gl rigid c =
-  abs_evars2 (pf_env gl) (project gl) rigid c
-
 let abs_evars env sigma t = abs_evars2 env sigma [] t
-
-let pf_abs_evars gl t = pf_abs_evars2 gl [] t
-
 
 (* As before but if (?i : T(?j)) and (?j : P : Prop), then the lambda for i
  * looks like (fun evar_i : (forall pi : P. T(pi))) thanks to "loopP" and all
@@ -574,13 +568,6 @@ let nb_evar_deps = function
   | _ -> 0
 
 let type_id env sigma t = Id.of_string (Namegen.hdchar env sigma t)
-let pfe_type_of gl t =
-  let sigma, ty = pf_type_of gl t in
-  re_sig (sig_it gl) sigma, ty
-let pfe_new_type gl =
-  let sigma, env, it = project gl, pf_env gl, sig_it gl in
-  let sigma,t  = Evarutil.new_Type sigma in
-  re_sig it sigma, t
 let pfe_type_relevance_of env sigma t =
   let sigma, ty = Typing.type_of env sigma t in
   sigma, ty, Retyping.relevance_of_term env sigma t
@@ -624,8 +611,6 @@ let abs_cterm env sigma n c0 =
     | _ -> strip i c in
   EConstr.of_constr (strip_evars 0 c0)
 
-let pf_abs_cterm gl n c0 = abs_cterm (pf_env gl) (project gl) n c0
-
 (* }}} *)
 
 let merge_uc uc =
@@ -665,10 +650,6 @@ let mkSsrRef name =
 let mkSsrRRef name = (DAst.make @@ GRef (mkSsrRef name,None)), None
 let mkSsrConst env sigma name =
   EConstr.fresh_global env sigma (mkSsrRef name)
-let pf_fresh_global name gl =
-  let sigma, env, it = project gl, pf_env gl, sig_it gl in
-  let sigma,t  = Evd.fresh_global env sigma name in
-  EConstr.Unsafe.to_constr t, re_sig it sigma
 
 let mkProt env sigma t c =
   let sigma, prot = mkSsrConst env sigma "protect_term" in

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -836,11 +836,6 @@ let saturate ?(beta=false) ?(bi_types=false) env sigma c ?(ty=Retyping.get_type_
   in
    loop ty [] sigma m
 
-let pf_saturate ?beta ?bi_types gl c ?ty m =
-  let env, sigma, si = pf_env gl, project gl, sig_it gl in
-  let t, ty, args, sigma = saturate ?beta ?bi_types env sigma c ?ty m in
-  t, ty, args, re_sig si sigma
-
 let dependent_apply_error =
   try CErrors.user_err (Pp.str "Could not fill dependent hole in \"apply\"")
   with err -> err

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -187,7 +187,7 @@ let interp_refine env sigma ist ~concl rc =
   let sigma, c = Pretyping.understand_ltac flags env sigma vars kind rc in
 (*   ppdebug(lazy(str"sigma@interp_refine=" ++ pr_evar_map None sigma)); *)
   debug_ssr (fun () -> str"c@interp_refine=" ++ Printer.pr_econstr_env env sigma c);
-  (sigma, (sigma, c))
+  (sigma, c)
 
 
 let interp_open_constr env sigma0 ist gc =

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -190,11 +190,11 @@ let interp_refine env sigma ist ~concl rc =
   (sigma, c)
 
 
-let interp_open_constr env sigma0 ist gc =
-  let (sigma, (c, _)) = Tacinterp.interp_open_constr_with_bindings ist env sigma0 (gc, Tactypes.NoBindings) in
-  (sigma0, (sigma, c))
+let interp_open_constr env sigma ist gc =
+  let (sigma, (c, _)) = Tacinterp.interp_open_constr_with_bindings ist env sigma (gc, Tactypes.NoBindings) in
+  (sigma, c)
 
-let interp_term env sigma ist (_, c) = snd (interp_open_constr env sigma ist c)
+let interp_term env sigma ist (_, c) = interp_open_constr env sigma ist c
 
 let interp_hyp ist env sigma (SsrHyp (loc, id)) =
   let id' = Tacinterp.interp_hyp ist env sigma CAst.(make ?loc id) in
@@ -722,9 +722,9 @@ type name_hint = (int * EConstr.types array) option ref
 
 let abs_ssrterm ?(resolve_typeclasses=false) ist env sigma t =
   let sigma0 = sigma in
-  let sigma, ct as t = interp_term env sigma ist t in
-  let sigma, _ as t =
-    if not resolve_typeclasses then t
+  let sigma, ct = interp_term env sigma ist t in
+  let t =
+    if not resolve_typeclasses then (sigma, ct)
     else
        let sigma = Typeclasses.resolve_typeclasses ~fail:false env sigma in
        sigma, Evarutil.nf_evar sigma ct in

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -85,7 +85,6 @@ let mk_orhint tacs = true, tacs
 let nullhint = true, []
 let nohint = false, []
 
-let project gl = gl.Evd.sigma
 let re_sig it sigma = { Evd.it = it; Evd.sigma = sigma }
 
 open Pp
@@ -397,11 +396,6 @@ let env_size env = List.length (Environ.named_context env)
 
 let pf_concl gl = EConstr.Unsafe.to_constr (Tacmach.pf_concl gl)
 let pf_get_hyp gl x = EConstr.Unsafe.to_named_decl (Tacmach.pf_get_hyp x gl)
-
-let pf_e_type_of gl t =
-  let sigma, env, it = project gl, pf_env gl, sig_it gl in
-  let sigma, ty = Typing.type_of env sigma t in
-  re_sig it sigma, ty
 
 let resolve_typeclasses env sigma ~where ~fail =
   let filter =

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -263,15 +263,6 @@ val applyn :
            int ->
            EConstr.t -> unit Proofview.tactic
 exception NotEnoughProducts
-val pf_saturate :
-           ?beta:bool ->
-           ?bi_types:bool ->
-           Goal.goal Evd.sigma ->
-           EConstr.constr ->
-           ?ty:EConstr.types ->
-           int ->
-           EConstr.constr * EConstr.types * (int * EConstr.constr) list *
-           Goal.goal Evd.sigma
 val saturate :
            ?beta:bool ->
            ?bi_types:bool ->

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -105,10 +105,6 @@ val interp_open_constr :
   Tacinterp.interp_sign ->
     Genintern.glob_constr_and_expr -> evar_map * EConstr.t
 
-val pf_e_type_of :
-  Goal.goal Evd.sigma ->
-  EConstr.constr -> Goal.goal Evd.sigma * EConstr.types
-
 val splay_open_constr :
            Environ.env ->
            evar_map * EConstr.t ->

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -150,39 +150,16 @@ val abs_evars2 : (* ssr2 *)
 val abs_cterm :
            Environ.env -> Evd.evar_map -> int -> EConstr.t -> EConstr.t
 
-
-val pf_abs_evars :
-           Goal.goal Evd.sigma ->
-           evar_map * EConstr.t ->
-           int * EConstr.t * Evar.t list *
-           UState.t
-val pf_abs_evars2 : (* ssr2 *)
-           Goal.goal Evd.sigma -> Evar.t list ->
-           evar_map * EConstr.t ->
-           int * EConstr.t * Evar.t list *
-           UState.t
-val pf_abs_cterm :
-           Goal.goal Evd.sigma -> int -> EConstr.t -> EConstr.t
-
 val merge_uc : UState.t -> unit Proofview.tactic
 val pf_merge_uc :
            UState.t -> 'a Evd.sigma -> 'a Evd.sigma
 val pf_merge_uc_of :
            evar_map -> 'a Evd.sigma -> 'a Evd.sigma
 val constr_name : evar_map -> EConstr.t -> Name.t
-val pfe_type_of :
-           Goal.goal Evd.sigma ->
-           EConstr.t -> Goal.goal Evd.sigma * EConstr.types
-val pfe_new_type : Goal.goal Evd.sigma -> Goal.goal Evd.sigma * EConstr.types
 
 val mkSsrRef : string -> GlobRef.t
 val mkSsrRRef : string -> Glob_term.glob_constr * 'a option
 val mkSsrConst : Environ.env -> Evd.evar_map -> string -> Evd.evar_map * EConstr.t
-
-val pf_fresh_global :
-           GlobRef.t ->
-           Goal.goal Evd.sigma ->
-           Constr.constr * Goal.goal Evd.sigma
 
 val is_discharged_id : Id.t -> bool
 val mk_discharged_id : Id.t -> Id.t

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -103,7 +103,7 @@ val interp_refine :
 val interp_open_constr :
   Environ.env -> Evd.evar_map ->
   Tacinterp.interp_sign ->
-    Genintern.glob_constr_and_expr -> evar_map * (evar_map * EConstr.t)
+    Genintern.glob_constr_and_expr -> evar_map * EConstr.t
 
 val pf_e_type_of :
   Goal.goal Evd.sigma ->

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -98,7 +98,7 @@ val interp_hyps : ist -> env -> evar_map -> ssrhyps -> ssrhyps
 
 val interp_refine :
   Environ.env -> Evd.evar_map -> Tacinterp.interp_sign -> concl:EConstr.constr ->
-    Glob_term.glob_constr -> evar_map * (evar_map * EConstr.constr)
+    Glob_term.glob_constr -> evar_map * EConstr.constr
 
 val interp_open_constr :
   Environ.env -> Evd.evar_map ->

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -307,18 +307,14 @@ val genstac :
     list * Ssrast.ssrhyp list ->
   unit Proofview.tactic
 
-val pf_interp_gen :
+val interp_gen :
+  Environ.env ->
+  Evd.evar_map ->
+  concl:EConstr.t ->
   bool ->
   (Ssrast.ssrhyp list option * Ssrmatching.occ) *
     Ssrmatching.cpattern ->
-  Goal.goal Evd.sigma ->
-  (EConstr.t * EConstr.t * Ssrast.ssrhyp list) *
-    Goal.goal Evd.sigma
-
-(* HACK: use to put old pf_code in the tactic monad *)
-val pfLIFT
-  :  (Goal.goal Evd.sigma -> 'a * Goal.goal Evd.sigma)
-  -> 'a Proofview.tactic
+  Evd.evar_map * (EConstr.t * EConstr.t * Ssrast.ssrhyp list)
 
 (** Basic tactics *)
 

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -359,9 +359,6 @@ val unfold : EConstr.t list -> unit Proofview.tactic
 
 (* New code ****************************************************************)
 
-(* To call old code *)
-val tacSIGMA : Goal.goal Evd.sigma Proofview.tactic
-
 val tclINTERP_AST_CLOSURE_TERM_AS_CONSTR :
   ast_closure_term -> EConstr.t list Proofview.tactic
 

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -52,39 +52,6 @@ val array_fold_right_from : int -> ('a -> 'b -> 'b) -> 'a array -> 'b -> 'b
 
 val option_assert_get : 'a option -> Pp.t -> 'a
 
-(**************************** lifted tactics ******************************)
-
-(* tactics with extra data attached to each goals, e.g. the list of
- * temporary variables to be cleared *)
-type 'a tac_a = (goal * 'a) sigma -> (goal * 'a) list sigma
-
-(* Thread around names to be cleared or generalized back, and the speed *)
-type tac_ctx = {
-  tmp_ids : (Id.t * Name.t ref) list;
-  wild_ids : Id.t list;
-  (* List of variables to be cleared at the end of the sentence *)
-  delayed_clears : Id.t list;
-}
-
-val new_ctx : unit -> tac_ctx (* REMOVE *)
-val pull_ctxs : ('a * tac_ctx) list  sigma -> 'a list sigma * tac_ctx list (* REMOVE *)
-
-val pull_ctx : ('a * tac_ctx) sigma -> 'a sigma * tac_ctx
-val push_ctx : tac_ctx -> 'a sigma -> ('a * tac_ctx) sigma
-val push_ctxs : tac_ctx -> 'a list sigma -> ('a * tac_ctx) list sigma
-val with_ctx :
-  (tac_ctx -> 'b * tac_ctx) -> ('a * tac_ctx) sigma -> 'b * ('a * tac_ctx) sigma
-val without_ctx : ('a sigma -> 'b) -> ('a * tac_ctx) sigma -> 'b
-
-(* Standard tacticals lifted to the tac_a type *)
-val tclTHENLIST_a : tac_ctx tac_a list -> tac_ctx tac_a
-val tclTHEN_i_max :
-  tac_ctx tac_a -> (int -> int -> tac_ctx tac_a) -> tac_ctx tac_a
-val tclTHEN_a : tac_ctx tac_a -> tac_ctx tac_a -> tac_ctx tac_a
-val tclTHENS_a : tac_ctx tac_a -> tac_ctx tac_a list -> tac_ctx tac_a
-
-val tac_on_all :
-  (goal * tac_ctx) list sigma -> tac_ctx tac_a -> (goal * tac_ctx) list sigma
 (************************ ssr tactic arguments ******************************)
 
 
@@ -212,8 +179,6 @@ val mkSsrRef : string -> GlobRef.t
 val mkSsrRRef : string -> Glob_term.glob_constr * 'a option
 val mkSsrConst : Environ.env -> Evd.evar_map -> string -> Evd.evar_map * EConstr.t
 
-val new_wild_id : tac_ctx -> Names.Id.t * tac_ctx
-
 val pf_fresh_global :
            GlobRef.t ->
            Goal.goal Evd.sigma ->
@@ -224,8 +189,6 @@ val mk_discharged_id : Id.t -> Id.t
 val is_tagged : string -> string -> bool
 val has_discharged_tag : string -> bool
 val ssrqid : string -> Libnames.qualid
-val new_tmp_id :
-  tac_ctx -> (Names.Id.t * Name.t ref) * tac_ctx
 val mk_anon_id : string -> Id.t list -> Id.t
 val abs_evars_pirrel :
            Environ.env -> Evd.evar_map ->

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -128,7 +128,7 @@ let tclMATCH_GOAL env sigma c t_ok t_fail =
   Proofview.Goal.enter begin fun gl ->
   match unify_HO env sigma (Proofview.Goal.concl gl) c with
   | sigma ->
-    (* FIXME: why do we drop the evarmap? *)
+    Proofview.Unsafe.tclEVARS sigma <*>
     convert_concl ~check:true (Reductionops.nf_evar sigma c) <*> t_ok sigma
   | exception exn when CErrors.noncritical exn -> t_fail ()
   end

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -104,7 +104,7 @@ let congrtac ((n, t), ty) ist =
     Id.Map.add pattern_id (Tacinterp.Value.of_constr f) Id.Map.empty } in
   let rf = mkRltacVar pattern_id in
   let m = pf_nbargs env sigma f in
-  let _, cf = if n > 0 then
+  let cf = if n > 0 then
     match interp_congrarg_at env sigma ist' ~concl n rf ty m with
     | Some cf -> cf
     | None -> errorstrm Pp.(str "No " ++ int n ++ str "-congruence with "

--- a/plugins/ssr/ssrfwd.ml
+++ b/plugins/ssr/ssrfwd.ml
@@ -205,7 +205,7 @@ let havetac ist
    | FwdHave, false, true ->
      let cty = combineCG cty hole (mkCArrow ?loc) mkRArrow in
      let gl, t, _ = interp gl false (combineCG ct cty (mkCCast ?loc) mkRCast) in
-     let gl, ty = pfe_type_of gl t in
+     let gl, ty = pf_e_type_of gl t in
      let ctx, _ = EConstr.decompose_prod_n_assum (project gl) 1 ty in
      let assert_is_conv gl =
        try Proofview.V82.of_tactic (convert_concl ~check:true (EConstr.it_mkProd_or_LetIn concl ctx)) gl

--- a/plugins/ssr/ssripats.ml
+++ b/plugins/ssr/ssripats.ml
@@ -846,9 +846,13 @@ let pushmoveeqtac cl c = Goal.enter begin fun g ->
 end
 
 let eqmovetac _ gen =
-  Ssrcommon.pfLIFT (Ssrcommon.pf_interp_gen false gen) >>=
-  fun (cl, c, _) -> pushmoveeqtac cl c
-;;
+  Proofview.Goal.enter begin fun gl ->
+    let env = Proofview.Goal.env gl in
+    let sigma = Proofview.Goal.sigma gl in
+    let concl = Proofview.Goal.concl gl in
+    let (sigma, (cl, c, _)) = Ssrcommon.interp_gen env sigma ~concl false gen in
+    Proofview.Unsafe.tclEVARS sigma <*> pushmoveeqtac cl c
+  end
 
 let rec eqmoveipats eqpat = function
   | (IOpSimpl _ | IOpClear _ as ipat) :: ipats ->

--- a/plugins/ssr/ssripats.mli
+++ b/plugins/ssr/ssripats.mli
@@ -76,8 +76,6 @@ val ssrscasetoptac : unit Proofview.tactic
  * ipat, and in ssrfwd for the integration with [have] *)
 val ssrabstract : ssrdgens -> unit Proofview.tactic
 
-(* Handling of [[:var]], needed in ssrfwd. Since ssrfwd is still outside the
- * tactic monad we export code with the V82 interface *)
 module Internal : sig
 val examine_abstract :
   Environ.env -> Evd.evar_map -> EConstr.t -> Evd.evar_map * (EConstr.types * EConstr.t array)

--- a/plugins/ssr/ssrtacticals.ml
+++ b/plugins/ssr/ssrtacticals.ml
@@ -14,7 +14,8 @@ open Names
 open Constr
 open Context
 open Termops
-open Tacmach.Old
+
+open Proofview.Notations
 
 open Ssrast
 open Ssrcommon
@@ -31,10 +32,8 @@ let get_index = function Locus.ArgArg i -> i | _ ->
 (** The "first" and "last" tacticals. *)
 
 let tclPERM perm tac =
-  Proofview.V82.tactic begin fun gls ->
-  let subgls = Proofview.V82.of_tactic tac gls in
-  let subgll' = perm subgls.Evd.it in
-  re_sig subgll' subgls.Evd.sigma
+  Proofview.Goal.enter begin fun gls ->
+    tac <*> (Proofview.Unsafe.tclGETGOALS >>= fun gls -> Proofview.Unsafe.tclSETGOALS (perm gls))
   end
 
 let rot_hyps dir i hyps =

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -268,12 +268,6 @@ let unify_HO env sigma0 t1 t2 =
   let sigma, uc, _ = unif_end ~solve_TC:false env sigma0 sigma t2 (fun _ -> true) in
   Evd.set_universe_context sigma uc
 
-let pf_unify_HO gl t1 t2 =
-  let open Tacmach.Old in
-  let env, sigma0, si = pf_env gl, project gl, sig_it gl in
-  let sigma = unify_HO env sigma0 t1 t2 in
-  re_sig si sigma
-
 (* This is what the definition of iter_constr should be... *)
 let iter_constr_LR f c = match kind c with
   | Evar (k, a) -> List.iter f a

--- a/plugins/ssrmatching/ssrmatching.mli
+++ b/plugins/ssrmatching/ssrmatching.mli
@@ -10,7 +10,6 @@
 
 (* (c) Copyright 2006-2015 Microsoft Corporation and Inria.                  *)
 
-open Goal
 open Environ
 open Evd
 open Constr
@@ -216,7 +215,6 @@ val assert_done : 'a option ref -> 'a
     In case of failure they raise [NoMatch] *)
 
 val unify_HO : env -> evar_map -> EConstr.constr -> EConstr.constr -> evar_map
-val pf_unify_HO : goal sigma -> EConstr.constr -> EConstr.constr -> goal sigma
 
 (** Some more low level functions needed to implement the full SSR language
     on top of the former APIs *)


### PR DESCRIPTION
There are still a lot of suspicious things going on like evarmap mangling, evar leaks, mysterious goal state appearances and the truth is definitely out there. But at least we're not relying anymore on the legacy engine.

The legitimacy of the remaining paranormal ssr activity will be assessed in later PRs. One thing at a time.