### PR TITLE
Set the level of the Ltac2 "now" notation to 6.

### DIFF
--- a/doc/changelog/05-tactic-language/15250-ltac2-fix-now-precedence.rst
+++ b/doc/changelog/05-tactic-language/15250-ltac2-fix-now-precedence.rst
@@ -1,0 +1,7 @@
+- **Fixed:**
+  the parsing level of the Ltac2 tactic :tacn:`now`
+  was set to level 6 in order to behave as it did before
+  8.14
+  (`#15250 <https://github.com/coq/coq/pull/15250>`_,
+  fixes `#15122 <https://github.com/coq/coq/issues/15122>`_,
+  by Pierre-Marie Pédrot).

--- a/test-suite/bugs/closed/bug_15122.v
+++ b/test-suite/bugs/closed/bug_15122.v
@@ -1,0 +1,10 @@
+Require Import Ltac2.Ltac2.
+
+Axiom P : Prop.
+Axiom p : P.
+
+Goal P.
+Proof.
+now (); apply p.
+(* This should parse as (now ((); apply p)) *)
+Qed.

--- a/user-contrib/Ltac2/Notations.v
+++ b/user-contrib/Ltac2/Notations.v
@@ -594,4 +594,4 @@ Ltac2 Notation f_equal := f_equal0 ().
 (** now *)
 
 Ltac2 now0 t := t (); ltac1:(easy).
-Ltac2 Notation "now" t(thunk(self)) := now0 t.
+Ltac2 Notation "now" t(thunk(self)) : 6 := now0 t.


### PR DESCRIPTION
Fixes #15122: Ltac2: "now" tactic does not work in 8.14.0.
