### PR TITLE
Remove most of the Goal module.

### DIFF
--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -192,14 +192,15 @@ let ppexistentialset evars =
 let ppexistentialfilter filter = match Evd.Filter.repr filter with
 | None -> pp (Pp.str "ø")
 | Some f -> pp (prlist_with_sep spc bool f)
+let pr_goal e = Pp.(str "GOAL:" ++ int (Evar.repr e))
 let ppclenv clenv = pp(pr_clenv clenv)
-let ppgoalgoal gl = pp(Goal.pr_goal gl)
+let ppgoalgoal gl = pp(pr_goal gl)
 let ppgoal g = pp(Printer.pr_goal g)
 let ppgoalsigma g = pp(Printer.pr_goal g ++ Termops.pr_evar_map None (Global.env ()) g.Evd.sigma)
 let pphintdb db = pp(envpp Hints.pr_hint_db_env db)
 let ppproofview p =
   let gls,sigma = Proofview.proofview p in
-  pp(pr_enum Goal.pr_goal gls ++ fnl () ++ Termops.pr_evar_map (Some 1) (Global.env ()) sigma)
+  pp(pr_enum pr_goal gls ++ fnl () ++ Termops.pr_evar_map (Some 1) (Global.env ()) sigma)
 
 let ppopenconstr (x : Evd.open_constr) =
   let (evd,c) = x in pp (Termops.pr_evar_map (Some 2) (Global.env ()) evd ++ envpp pr_econstr_env c)

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -188,7 +188,7 @@ let process_goal sigma g =
   let (_env, hyps) =
     Context.Compacted.fold process_hyp
       (Termops.compact_named_context (Environ.named_context env)) ~init:(min_env,[]) in
-  { Interface.goal_hyp = List.rev hyps; Interface.goal_ccl = ccl; Interface.goal_id = Goal.uid g; Interface.goal_name = name }
+  { Interface.goal_hyp = List.rev hyps; Interface.goal_ccl = ccl; Interface.goal_id = Proof.goal_uid g; Interface.goal_name = name }
 
 let process_goal_diffs diff_goal_map oldp nsigma ng =
   let name = if Printer.print_goal_names () then Some (Names.Id.to_string (Termops.evar_suggested_name (Global.env ()) nsigma ng)) else None in
@@ -201,7 +201,7 @@ let process_goal_diffs diff_goal_map oldp nsigma ng =
   in
   let (hyps_pp_list, concl_pp) = Proof_diffs.diff_goal_ide og_s ng nsigma in
   { Interface.goal_hyp = hyps_pp_list; Interface.goal_ccl = concl_pp;
-    Interface.goal_id = Goal.uid ng; Interface.goal_name = name }
+    Interface.goal_id = Proof.goal_uid ng; Interface.goal_name = name }
 
 let export_pre_goals Proof.{ sigma; goals; stack } process =
   let process = List.map (process sigma) in

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -481,7 +481,7 @@ let pr_goal ?(diffs=false) ?og_s g_s =
 
 (* display a goal tag *)
 let pr_goal_tag g =
-  let s = " (ID " ^ Goal.uid g ^ ")" in
+  let s = " (ID " ^ Proof.goal_uid g ^ ")" in
   str s
 
 (* display a goal name *)

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -594,7 +594,7 @@ module GoalMap = Evar.Map
 
 let goal_to_evar g sigma = Id.to_string (Termops.evar_suggested_name (Global.env ()) sigma g)
 
-open Goal.Set
+open Evar.Set
 
 [@@@ocaml.warning "-32"]
 let db_goal_map op np ng_to_og =
@@ -614,10 +614,10 @@ let db_goal_map op np ng_to_og =
   Printf.printf "\nGoal map: ";
   GoalMap.iter (fun ng og -> Printf.printf "%d -> %d  " (Evar.repr ng) (Evar.repr og)) ng_to_og;
   let unmapped = ref (Proof.all_goals np) in
-  GoalMap.iter (fun ng _ -> unmapped := Goal.Set.remove ng !unmapped) ng_to_og;
-  if Goal.Set.cardinal !unmapped > 0 then begin
+  GoalMap.iter (fun ng _ -> unmapped := Evar.Set.remove ng !unmapped) ng_to_og;
+  if Evar.Set.cardinal !unmapped > 0 then begin
     Printf.printf "\nUnmapped goals: ";
-    Goal.Set.iter (fun ng -> Printf.printf "%d  " (Evar.repr ng)) !unmapped
+    Evar.Set.iter (fun ng -> Printf.printf "%d  " (Evar.repr ng)) !unmapped
   end;
   Printf.printf "\n"
 [@@@ocaml.warning "+32"]
@@ -648,7 +648,7 @@ let make_goal_map_i op np =
   match op with
   | None -> !ng_to_og
   | Some op ->
-    let open Goal.Set in
+    let open Evar.Set in
     let ogs = Proof.all_goals op in
     let ngs = Proof.all_goals np in
     let rem_gs = diff ogs ngs in
@@ -657,7 +657,7 @@ let make_goal_map_i op np =
     let num_adds = cardinal add_gs in
 
     (* add common goals *)
-    Goal.Set.iter (fun x -> ng_to_og := GoalMap.add x x !ng_to_og) (inter ogs ngs);
+    Evar.Set.iter (fun x -> ng_to_og := GoalMap.add x x !ng_to_og) (inter ogs ngs);
 
     if num_rems = 0 then
       !ng_to_og (* proofs are the same *)
@@ -666,7 +666,7 @@ let make_goal_map_i op np =
     else if num_rems = 1 then begin
       (* only 1 removal, some additions *)
       let removed_g = List.hd (elements rem_gs) in
-      Goal.Set.iter (fun x -> ng_to_og := GoalMap.add x removed_g !ng_to_og) add_gs;
+      Evar.Set.iter (fun x -> ng_to_og := GoalMap.add x removed_g !ng_to_og) add_gs;
       !ng_to_og
     end else begin
       (* >= 2 removals, >= 1 addition, need to match *)
@@ -675,7 +675,7 @@ let make_goal_map_i op np =
       let oevar_to_og = ref CString.Map.empty in
       let Proof.{sigma=osigma} = Proof.data op in
       List.iter (fun og -> oevar_to_og := CString.Map.add (goal_to_evar og osigma) og !oevar_to_og)
-          (Goal.Set.elements rem_gs);
+          (Evar.Set.elements rem_gs);
 
       let Proof.{sigma=nsigma} = Proof.data np in
       let get_og ng =
@@ -684,7 +684,7 @@ let make_goal_map_i op np =
         let og = CString.Map.find oevar !oevar_to_og in
         og
       in
-      Goal.Set.iter (fun ng ->
+      Evar.Set.iter (fun ng ->
           try ng_to_og := GoalMap.add ng (get_og ng) !ng_to_og with Not_found -> ())  add_gs;
       !ng_to_og
     end

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -255,7 +255,7 @@ let process_goal_concl sigma g : EConstr.t * Environ.env =
 
 let process_goal sigma g : EConstr.t reified_goal =
   let (env, ty) = goal_repr sigma g in
-  let name = Goal.uid g             in
+  let name = Proof.goal_uid g             in
   (* compaction is usually desired [eg for better display] *)
   let hyps      = Termops.compact_named_context (Environ.named_context env) in
   let hyps      = List.map to_tuple hyps in

--- a/proofs/goal.ml
+++ b/proofs/goal.ml
@@ -8,13 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open Pp
-
 (** Don't use this module. *)
 
 (* type of the goals *)
 type goal = Evar.t
-
-let pr_goal e = str "GOAL:" ++ Pp.int (Evar.repr e)
-
-let uid e = string_of_int (Evar.repr e)

--- a/proofs/goal.mli
+++ b/proofs/goal.mli
@@ -11,10 +11,3 @@
 (** Don't use this module. *)
 
 type goal = Evar.t
-
-(* Gives a unique identifier to each goal. The identifier is
-   guaranteed to contain no space. *)
-val uid : goal -> string
-
-(* Debugging help *)
-val pr_goal : goal -> Pp.t

--- a/proofs/goal.mli
+++ b/proofs/goal.mli
@@ -8,9 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(** This module implements the abstract interface to goals. Most of the code
-    here is useless and should be eventually removed. Consider using
-    {!Proofview.Goal} instead. *)
+(** Don't use this module. *)
 
 type goal = Evar.t
 
@@ -20,46 +18,3 @@ val uid : goal -> string
 
 (* Debugging help *)
 val pr_goal : goal -> Pp.t
-
-(* Layer to implement v8.2 tactic engine ontop of the new architecture.
-   Types are different from what they used to be due to a change of the
-   internal types. *)
-module V82 : sig
-
-  (* Old style env primitive *)
-  val env : Evd.evar_map -> goal -> Environ.env
-  [@@ocaml.deprecated "Use Evd.evar_filtered_env"]
-
-  (* Old style hyps primitive *)
-  val hyps : Evd.evar_map -> goal -> Environ.named_context_val
-  [@@ocaml.deprecated "Use Evd.evar_filtered_hyps"]
-
-  (* same as [hyps], but ensures that existential variables are
-     normalised. *)
-  val nf_hyps : Evd.evar_map -> goal -> Environ.named_context_val
-  [@@ocaml.deprecated "Use Evd.evar_filtered_hyps"]
-
-  (* Access to ".evar_concl" *)
-  val concl : Evd.evar_map -> goal -> EConstr.constr
-  [@@ocaml.deprecated "Use Evd.evar_concl"]
-
-  (* Old style mk_goal primitive, returns a new goal with corresponding
-       hypotheses and conclusion, together with a term which is precisely
-       the evar corresponding to the goal, and an updated evar_map. *)
-  val mk_goal : Evd.evar_map ->
-                         Environ.named_context_val ->
-                         EConstr.constr ->
-                         goal * EConstr.constr * Evd.evar_map
-  [@@ocaml.deprecated "Use the Refine.refine primitive and related API"]
-
-  (* Instantiates a goal with an open term *)
-  val partial_solution : Environ.env -> Evd.evar_map -> goal -> EConstr.constr -> Evd.evar_map
-  [@@ocaml.deprecated "Use Refine.refine"]
-
-  (* Used by the compatibility layer and typeclasses *)
-  val nf_evar : Evd.evar_map -> goal -> goal * Evd.evar_map
-  [@@ocaml.deprecated "This should be the identity now"]
-
-end
-
-module Set = Evar.Set

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -416,12 +416,12 @@ end
 
 let all_goals p =
   let add gs set =
-    List.fold_left (fun s g -> Goal.Set.add g s) set gs in
+    List.fold_left (fun s g -> Evar.Set.add g s) set gs in
   let (goals,stack,sigma) = proof p in
-    let set = add goals Goal.Set.empty in
+    let set = add goals Evar.Set.empty in
     let set = List.fold_left (fun s gs -> let (g1, g2) = gs in add g1 (add g2 set)) set stack in
     let set = add (Evd.shelf sigma) set in
-    let set = Goal.Set.union (Evd.given_up sigma) set in
+    let set = Evar.Set.union (Evd.given_up sigma) set in
     let { Evd.it = bgoals ; sigma = bsigma } = V82.background_subgoals p in
     add bgoals set
 

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -453,10 +453,14 @@ let data { proofview; focus_stack; entry; name; poly } =
     map_minus_one (fun (_,_,c) -> Proofview.focus_context c) focus_stack in
   { sigma; goals; entry; stack; name; poly }
 
+let pr_goal e = Pp.(str "GOAL:" ++ int (Evar.repr e))
+
+let goal_uid e = string_of_int (Evar.repr e)
+
 let pr_proof p =
   let { goals=fg_goals; stack=bg_goals; sigma } = data p in
   Pp.(
-    let pr_goal_list = prlist_with_sep spc Goal.pr_goal in
+    let pr_goal_list = prlist_with_sep spc pr_goal in
     let rec aux acc = function
       | [] -> acc
       | (before,after)::stack ->

--- a/proofs/proof.mli
+++ b/proofs/proof.mli
@@ -183,6 +183,10 @@ val maximal_unfocus : 'a focus_kind -> t -> t
    focused goals. *)
 val unshelve : t -> t
 
+(* Gives a unique identifier to each goal. The identifier is
+   guaranteed to contain no space. *)
+val goal_uid : Evar.t -> string
+
 val pr_proof : t -> Pp.t
 
 (*** Compatibility layer with <=v8.2 ***)

--- a/proofs/proof.mli
+++ b/proofs/proof.mli
@@ -199,7 +199,7 @@ module V82 : sig
 end
 
 (* returns the set of all goals in the proof *)
-val all_goals : t -> Goal.Set.t
+val all_goals : t -> Evar.Set.t
 
 (** [solve (SelectNth n) tac] applies tactic [tac] to the [n]th
     subgoal of the current focused proof. [solve SelectAll

--- a/stm/partac.ml
+++ b/stm/partac.ml
@@ -171,7 +171,7 @@ let enable_par ~nworkers = ComTactic.set_par_implementation
       TaskQueue.enqueue_task queue
       ~cancel_switch:(ref false)
       { t_state; t_assign = ans; t_ast;
-          t_goalno = i; t_goal = g; t_name = Goal.uid g;
+          t_goalno = i; t_goal = g; t_name = Proof.goal_uid g;
           t_kill = (fun () -> TaskQueue.cancel_all queue) };
       g, ans) 1 in
     TaskQueue.join queue;

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -1195,7 +1195,7 @@ end = struct (* {{{ *)
           did := fold_until back_tactic 1 !did;
           rv := get_proof ~doc !did;
           done_ := match !rv with
-            | Some rv -> not (Goal.Set.equal (Proof.all_goals rv) (Proof.all_goals cp))
+            | Some rv -> not (Evar.Set.equal (Proof.all_goals rv) (Proof.all_goals cp))
             | None -> true
         done;
         !rv


### PR DESCRIPTION
It was deprecated in 8.15. The only use of this module is now to declare an alias type name for `Evar.t`.
