### PR TITLE
Delay removing native_compute .ml files until exit

### DIFF
--- a/kernel/nativelib.ml
+++ b/kernel/nativelib.ml
@@ -48,6 +48,11 @@ let () = at_exit (fun () ->
           Pp.(str "Native compile: failed to cleanup: " ++
               str(Printexc.to_string e) ++ fnl()))
 
+let delay_cleanup_file =
+  let toclean = ref [] in
+  let () = at_exit (fun () -> List.iter (fun f -> if Sys.file_exists f then Sys.remove f) !toclean) in
+  fun f -> if not (keep_debug_files()) then toclean := f :: !toclean
+
 (* We have to delay evaluation of include_dirs because coqlib cannot
    be guessed until flags have been properly initialized. It also lets
    us avoid forcing [my_temp_dir] if we don't need it (eg stdlib file
@@ -148,7 +153,9 @@ let call_compiler ?profile:(profile=false) ml_filename =
 let compile fn code ~profile:profile =
   write_ml_code fn code;
   let r = call_compiler ~profile fn in
-  if (not (keep_debug_files ())) && Sys.file_exists fn then Sys.remove fn;
+  (* NB: to prevent reusing the same filename we MUST NOT remove the file until exit
+     cf #15263 *)
+  delay_cleanup_file fn;
   r
 
 type native_library = Nativecode.global list * Nativevalues.symbols
@@ -166,7 +173,7 @@ let compile_library (code, symb) fn =
   let fn = dirname / basename in
   write_ml_code fn ~header code;
   let _ = call_compiler fn in
-  if (not (keep_debug_files ())) && Sys.file_exists fn then Sys.remove fn
+  delay_cleanup_file fn
 
 let execute_library ~prefix f upds =
   rt1 := dummy_value ();


### PR DESCRIPTION
Fix #15263 (assuming it was correctly diagnosed)
