### PR TITLE
Deprecate Universal Lemma Under Conjunction flag.

### DIFF
--- a/doc/changelog/07-vernac-commands-and-options/15272-deprecate-universal-lemma-under-conj.rst
+++ b/doc/changelog/07-vernac-commands-and-options/15272-deprecate-universal-lemma-under-conj.rst
@@ -1,0 +1,4 @@
+- **Deprecated:**
+  `Universal Lemma Under Conjunction` flag that was introduced for
+  compatibility with Coq versions prior to 8.4 (`#15272
+  <https://github.com/coq/coq/pull/15272>`_, by Théo Zimmermann).

--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -904,6 +904,8 @@ Applying theorems
    This :term:`flag`, which preserves compatibility with versions of Coq prior to
    8.4 is also available for :n:`apply @term in @ident` (see :tacn:`apply … in`).
 
+   .. deprecated:: 8.15
+
 .. tacn:: apply @term in @ident
    :name: apply … in
 

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -80,7 +80,7 @@ let accept_universal_lemma_under_conjunctions () =
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optdepr  = true;
       optkey   = ["Universal";"Lemma";"Under";"Conjunction"];
       optread  = (fun () -> !universal_lemma_under_conjunctions) ;
       optwrite = (fun b -> universal_lemma_under_conjunctions := b) }


### PR DESCRIPTION
This is a pre-8.4 compatibility flag that has never been deprecated.
I tested in #15268 that it is not used anywhere in our CI (a search in Coq files in GitHub also gives no result).
I propose to deprecate it in 8.15 to be able to remove it in master now. (Needs approval from @SkySkimmer.)

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
