### PR TITLE
Tactic_option supports export

### DIFF
--- a/dev/ci/user-overlays/15274-SkySkimmer-tacopt.sh
+++ b/dev/ci/user-overlays/15274-SkySkimmer-tacopt.sh
@@ -1,0 +1,1 @@
+overlay paramcoq https://github.com/SkySkimmer/paramcoq tacopt 15274

--- a/doc/changelog/07-vernac-commands-and-options/15274-tacopt.rst
+++ b/doc/changelog/07-vernac-commands-and-options/15274-tacopt.rst
@@ -1,8 +1,9 @@
-- **Changed:** commands setting tactic options (currently
+- **Changed:** commands which set tactic options (currently
   :opt:`Firstorder Solver` and :cmd:`Obligation Tactic`, as well as any
   defined by third party plugins) now support :attr:`export` locality.
-  Note that the meaning of :attr:`global` and the default outside
-  sections currently also set the option when importing any
-  surrounding module. This will change in a future version. (`#15274
+  Note that such commands using :attr:`global` without :attr:`export`
+  or using no explicit locality outside sections apply their effects
+  when any module containing it (recursively) is imported. This will
+  change in a future version. (`#15274
   <https://github.com/coq/coq/pull/15274>`_, fixes `#15072
   <https://github.com/coq/coq/issues/15072>`_, by Gaëtan Gilbert).

--- a/doc/changelog/07-vernac-commands-and-options/15274-tacopt.rst
+++ b/doc/changelog/07-vernac-commands-and-options/15274-tacopt.rst
@@ -1,0 +1,8 @@
+- **Changed:** commands setting tactic options (currently
+  :opt:`Firstorder Solver` and :cmd:`Obligation Tactic`, as well as any
+  defined by third party plugins) now support :attr:`export` locality.
+  Note that the meaning of :attr:`global` and the default outside
+  sections currently also set the option when importing any
+  surrounding module. This will change in a future version. (`#15274
+  <https://github.com/coq/coq/pull/15274>`_, fixes `#15072
+  <https://github.com/coq/coq/issues/15072>`_, by Gaëtan Gilbert).

--- a/doc/sphinx/addendum/program.rst
+++ b/doc/sphinx/addendum/program.rst
@@ -273,10 +273,18 @@ optional tactic is replaced by the default one if not specified.
    automatically, whether to solve them or when starting to prove one,
    e.g. using :cmd:`Next Obligation`.
 
-   This command supports the :attr:`local` and :attr:`global` attributes.
+   This command supports the :attr:`local`, :attr:`export` and :attr:`global` attributes.
    :attr:`local` makes the setting last only for the current
    module. :attr:`local` is the default inside sections while :attr:`global`
-   otherwise.
+   otherwise. :attr:`export` and :attr:`global` may be used together.
+
+   When :attr:`global` is used without :attr:`export` and when no
+   explicit locality is used outside sections, the meaning is
+   different from the usual meaning of :attr:`global`: the command's
+   effect persists after the current module is closed (as with the
+   usual :attr:`global`), but it is also reapplied when the module or
+   any of its parents is imported. This will change in a future
+   version.
 
 .. cmd:: Show Obligation Tactic
 

--- a/doc/sphinx/proofs/automatic-tactics/logic.rst
+++ b/doc/sphinx/proofs/automatic-tactics/logic.rst
@@ -124,8 +124,9 @@ Solvers for logic and equality
 
    .. opt:: Firstorder Solver @ltac_expr
 
-      The default tactic used by :tacn:`firstorder` when no rule applies in
-      :g:`auto with core`.  It can be set locally or globally using this :term:`option`.
+      The default tactic used by :tacn:`firstorder` when no rule
+      applies in :g:`auto with core`. This command supports the same
+      locality attributes as :cmd:`Obligation Tactic`.
 
    .. cmd:: Print Firstorder Solver
 

--- a/plugins/firstorder/g_ground.mlg
+++ b/plugins/firstorder/g_ground.mlg
@@ -69,8 +69,9 @@ let gen_ground_tac flag taco ids bases =
       qflag:=flag;
       let solver=
         match taco with
-            Some tac-> tac
-          | None-> snd (default_solver ()) in
+        | Some tac -> tac
+        | None-> default_solver ()
+      in
       let startseq k =
         Proofview.Goal.enter begin fun gl ->
         let seq=empty_seq (ground_depth ()) in

--- a/plugins/firstorder/g_ground.mlg
+++ b/plugins/firstorder/g_ground.mlg
@@ -20,7 +20,6 @@ open Tacticals
 open Tacinterp
 open Stdarg
 open Tacarg
-open Attributes
 open Pcoq.Prim
 
 }
@@ -47,9 +46,9 @@ let (set_default_solver, default_solver, print_default_solver) =
 }
 
 VERNAC COMMAND EXTEND Firstorder_Set_Solver CLASSIFIED AS SIDEFF
-| #[ locality; ] [ "Set" "Firstorder" "Solver" tactic(t) ] -> {
+| #[ locality = Tactic_option.tac_option_locality; ] [ "Set" "Firstorder" "Solver" tactic(t) ] -> {
       set_default_solver
-        (Locality.make_section_locality locality)
+        locality
         (Tacintern.glob_tactic t)
   }
 END

--- a/plugins/ltac/g_obligations.mlg
+++ b/plugins/ltac/g_obligations.mlg
@@ -26,8 +26,9 @@ let (set_default_tactic, get_default_tactic, print_default_tactic) =
 let () =
   (* Delay to recover the tactic imperatively *)
   let tac = Proofview.tclBIND (Proofview.tclUNIT ()) begin fun () ->
-    snd (get_default_tactic ())
-  end in
+      get_default_tactic ()
+    end
+  in
   Declare.Obls.default_tactic := tac
 
 let with_tac f tac =

--- a/plugins/ltac/g_obligations.mlg
+++ b/plugins/ltac/g_obligations.mlg
@@ -133,9 +133,9 @@ VERNAC COMMAND EXTEND Admit_Obligations CLASSIFIED AS SIDEFF STATE program
 END
 
 VERNAC COMMAND EXTEND Set_Solver CLASSIFIED AS SIDEFF
-| #[ locality = Attributes.locality; ] [ "Obligation" "Tactic" ":=" tactic(t) ] -> {
+| #[ locality = Tactic_option.tac_option_locality; ] [ "Obligation" "Tactic" ":=" tactic(t) ] -> {
         set_default_tactic
-          (Locality.make_section_locality locality)
+          locality
           (Tacintern.glob_tactic t);
   }
 END

--- a/plugins/ltac/tactic_option.ml
+++ b/plugins/ltac/tactic_option.ml
@@ -9,20 +9,17 @@
 (************************************************************************)
 
 open Libobject
-open Pp
 
 let declare_tactic_option ?(default=CAst.make (Tacexpr.TacId[])) name =
-  let locality = Summary.ref false ~name:(name^"-locality") in
   let default_tactic : Tacexpr.glob_tactic_expr ref =
     Summary.ref default ~name:(name^"-default-tactic")
   in
-  let set_default_tactic local t =
-    locality := local;
+  let set_default_tactic t =
     default_tactic := t
   in
-  let cache (local, tac) = set_default_tactic local tac in
+  let cache (local, tac) = set_default_tactic tac in
   let load (local, tac) =
-    if not local then set_default_tactic local tac
+    if not local then set_default_tactic tac
   in
   let subst (s, (local, tac)) =
     (local, Tacsubst.subst_tactic s tac)
@@ -39,9 +36,6 @@ let declare_tactic_option ?(default=CAst.make (Tacexpr.TacId[])) name =
   let put local tac =
     Lib.add_leaf (input (local, tac))
   in
-  let get () = !locality, Tacinterp.eval_tactic !default_tactic in
-  let print () =
-    Pptactic.pr_glob_tactic (Global.env ()) !default_tactic ++
-      (if !locality then str" (locally defined)" else str" (globally defined)")
-  in
+  let get () = Tacinterp.eval_tactic !default_tactic in
+  let print () = Pptactic.pr_glob_tactic (Global.env ()) !default_tactic in
   put, get, print

--- a/plugins/ltac/tactic_option.ml
+++ b/plugins/ltac/tactic_option.ml
@@ -10,6 +10,44 @@
 
 open Libobject
 
+type tac_option_locality =
+  | Default
+  | Global
+  | Local
+  | Export
+  | GlobalAndExport
+
+let tac_option_locality =
+  let open Attributes in
+  let open Attributes.Notations in
+  let one x = attribute_of_list [x,single_key_parser ~name:"Locality" ~key:x ()] in
+  one "local" ++ one "global" ++ one "export" >>= fun ((local,global),export) ->
+  match local, global, export with
+  | None, None, None -> return Default
+
+  | Some (), Some (), _ -> CErrors.user_err Pp.(str "Cannot combine local and global.")
+  | Some (), _, Some () -> CErrors.user_err Pp.(str "Cannot combine local and export.")
+
+  | Some (), None, None -> return Local
+  | None, Some (), None -> return Global
+  | None, None, Some () -> return Export
+  | None, Some (), Some () -> return GlobalAndExport
+
+let warn_default_locality =
+  CWarnings.create ~name:"deprecated-tacopt-without-locality" ~category:"deprecated" Pp.(fun () ->
+      strbrk
+        "The default and global localities for this command outside \
+         sections are currently equivalent to the combination of the \
+         standard meaning of \"global\" (as described in the reference \
+         manual), \"export\" and re-exporting for every surrounding \
+         module. It will change to just \"global\" (with the meaning \
+         used by the \"Set\" command) in a future release." ++ fnl() ++
+      strbrk
+        "To preserve the current meaning in a forward compatible way, \
+         use the attribute \"#[global,export]\" and repeat the command \
+         with just \"#[export]\" in any surrounding modules. If you \
+         are fine with the change of semantics, disable this warning.")
+
 let declare_tactic_option ?(default=CAst.make (Tacexpr.TacId[])) name =
   let default_tactic : Tacexpr.glob_tactic_expr ref =
     Summary.ref default ~name:(name^"-default-tactic")
@@ -17,23 +55,42 @@ let declare_tactic_option ?(default=CAst.make (Tacexpr.TacId[])) name =
   let set_default_tactic t =
     default_tactic := t
   in
-  let cache (local, tac) = set_default_tactic tac in
-  let load (local, tac) =
-    if not local then set_default_tactic tac
+  let cache (_, tac) = set_default_tactic tac in
+  let load _ (local, tac) = match local with
+    | Default | Global | GlobalAndExport -> set_default_tactic tac
+    | Export -> ()
+    | Local -> assert false (* not allowed by classify *)
+  in
+  let import i (local, tac) = match local with
+    | GlobalAndExport | Export -> if Int.equal i 1 then set_default_tactic tac
+    | Default | Global -> set_default_tactic tac
+    | Local -> assert false (* not allowed by classify *)
+  in
+  let classify (local, _) = match local with
+    | Local -> Dispose
+    | Default | Global | Export | GlobalAndExport -> Substitute
   in
   let subst (s, (local, tac)) =
     (local, Tacsubst.subst_tactic s tac)
   in
-  let input : bool * Tacexpr.glob_tactic_expr -> obj =
+  let input : tac_option_locality * Tacexpr.glob_tactic_expr -> obj =
     declare_object
       { (default_object name) with
         cache_function = cache;
-        load_function = (fun _ -> load);
-        open_function = simple_open (fun _ -> load);
-        classify_function = (fun (local, _) -> if local then Dispose else Substitute);
+        load_function = load;
+        open_function = simple_open import;
+        classify_function = classify;
         subst_function = subst}
   in
-  let put local tac =
+  let put ?loc local tac =
+    let () = match local with
+      | Default -> if not (Global.sections_are_opened()) then warn_default_locality ?loc ()
+      | Local -> ()
+      | Export | Global | GlobalAndExport ->
+        if Global.sections_are_opened()
+        then CErrors.user_err ?loc
+            Pp.(str "This locality is not supported inside sections by this command.")
+    in
     Lib.add_leaf (input (local, tac))
   in
   let get () = Tacinterp.eval_tactic !default_tactic in

--- a/plugins/ltac/tactic_option.mli
+++ b/plugins/ltac/tactic_option.mli
@@ -13,5 +13,5 @@ open Vernacexpr
 
 val declare_tactic_option : ?default:Tacexpr.glob_tactic_expr -> string ->
   (* put *) (locality_flag -> glob_tactic_expr -> unit) *
-  (* get *) (unit -> locality_flag * unit Proofview.tactic) *
+  (* get *) (unit -> unit Proofview.tactic) *
   (* print *) (unit -> Pp.t)

--- a/plugins/ltac/tactic_option.mli
+++ b/plugins/ltac/tactic_option.mli
@@ -8,10 +8,11 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open Tacexpr
-open Vernacexpr
+type tac_option_locality
+
+val tac_option_locality : tac_option_locality Attributes.attribute
 
 val declare_tactic_option : ?default:Tacexpr.glob_tactic_expr -> string ->
-  (* put *) (locality_flag -> glob_tactic_expr -> unit) *
+  (* put *) (?loc:Loc.t -> tac_option_locality -> Tacexpr.glob_tactic_expr -> unit) *
   (* get *) (unit -> unit Proofview.tactic) *
   (* print *) (unit -> Pp.t)

--- a/test-suite/output/bug_15106.v
+++ b/test-suite/output/bug_15106.v
@@ -1,5 +1,5 @@
 Require Import Coq.Program.Tactics.
-Obligation Tactic := try constructor.
+Local Obligation Tactic := try constructor.
 
 Axiom P : Prop. Axiom p : P.
 

--- a/theories/Classes/EquivDec.v
+++ b/theories/Classes/EquivDec.v
@@ -94,7 +94,8 @@ Program Instance unit_eqdec : EqDec unit eq := fun x y => in_left.
     reflexivity.
   Qed.
 
-Obligation Tactic := unfold complement, equiv ; program_simpl.
+#[global] Obligation Tactic := unfold complement, equiv ; program_simpl.
+#[export] Obligation Tactic := unfold complement, equiv ; program_simpl.
 
 #[global]
 Program Instance prod_eqdec `(EqDec A eq, EqDec B eq) :

--- a/theories/Classes/SetoidClass.v
+++ b/theories/Classes/SetoidClass.v
@@ -145,4 +145,5 @@ Infix "=~=" := pequiv (at level 70, no associativity) : type_scope.
 
 (** Reset the default Program tactic. *)
 
-Obligation Tactic := program_simpl.
+#[global] Obligation Tactic := program_simpl.
+#[export] Obligation Tactic := program_simpl.

--- a/theories/Classes/SetoidTactics.v
+++ b/theories/Classes/SetoidTactics.v
@@ -183,6 +183,7 @@ Ltac default_add_morphism_tactic :=
 
 Ltac add_morphism_tactic := default_add_morphism_tactic.
 
-Obligation Tactic := program_simpl.
+#[global] Obligation Tactic := program_simpl.
+#[export] Obligation Tactic := program_simpl.
 
 (* Notation "'Morphism' s t " := (@Proper _ (s%signature) t) (at level 10, s at next level, t at next level). *)

--- a/theories/Program/Tactics.v
+++ b/theories/Program/Tactics.v
@@ -318,4 +318,5 @@ Create HintDb program discriminated.
 
 Ltac program_simpl := program_simplify ; try typeclasses eauto 10 with program ; try program_solve_wf.
 
-Obligation Tactic := program_simpl.
+#[global] Obligation Tactic := program_simpl.
+#[export] Obligation Tactic := program_simpl.


### PR DESCRIPTION
Fix #15072

Overlays:
- https://github.com/coq-community/paramcoq/pull/95


OUTDATED default is now a special backwards compatible locality
Note that there is no way to get a backwards compatible declaration
because of the following behaviour:

~~~coq
Module M.
  Module N.
    Obligation Tactic := idtac 1.
  End N.
End M.

Obligation Tactic := idtac 2.

Import M.

Show Obligation Tactic. (* "idtac 1" !!! *)
~~~

In other words, duplication to have both `#[global]` and `#[export]`
is as close as we can get but not backwards compatible.
