### PR TITLE
Use evar map when calling vm_conv from outside the kernel.

### DIFF
--- a/kernel/nativeconv.ml
+++ b/kernel/nativeconv.ml
@@ -166,7 +166,7 @@ let native_conv_gen pb sigma env univs t1 t2 =
 let native_conv_gen pb sigma env univs t1 t2 =
   if not (typing_flags env).Declarations.enable_native_compiler then begin
     warn_no_native_compiler ();
-    Vconv.vm_conv_gen pb env univs t1 t2
+    Vconv.vm_conv_gen pb sigma.Nativelambda.evars_val env univs t1 t2
   end
   else native_conv_gen pb sigma env univs t1 t2
 

--- a/kernel/vconv.ml
+++ b/kernel/vconv.ml
@@ -190,19 +190,18 @@ let warn_bytecode_compiler_failed =
          (fun () -> strbrk "Bytecode compiler failed, " ++
                       strbrk "falling back to standard conversion")
 
-let vm_conv_gen cv_pb env univs t1 t2 =
+let vm_conv_gen cv_pb sigma env univs t1 t2 =
   if not (typing_flags env).Declarations.enable_VM then
-    Reduction.generic_conv cv_pb ~l2r:false (fun _ -> None)
+    Reduction.generic_conv cv_pb ~l2r:false sigma
       TransparentState.full env univs t1 t2
   else
   try
-    let sigma _ = assert false in
     let v1 = val_of_constr env sigma t1 in
     let v2 = val_of_constr env sigma t2 in
     fst (conv_val env cv_pb (nb_rel env) v1 v2 univs)
   with Not_found | Invalid_argument _ ->
     warn_bytecode_compiler_failed ();
-    Reduction.generic_conv cv_pb ~l2r:false (fun _ -> None)
+    Reduction.generic_conv cv_pb ~l2r:false sigma
       TransparentState.full env univs t1 t2
 
 let vm_conv cv_pb env t1 t2 =
@@ -213,4 +212,4 @@ let vm_conv cv_pb env t1 t2 =
   in
   if not b then
     let state = (univs, checked_universes) in
-    let _ = vm_conv_gen cv_pb env state t1 t2 in ()
+    let _ = vm_conv_gen cv_pb (fun _ -> None) env state t1 t2 in ()

--- a/kernel/vconv.mli
+++ b/kernel/vconv.mli
@@ -15,6 +15,6 @@ open Reduction
   s conversion functions *)
 val vm_conv : conv_pb -> types kernel_conversion_function
 
-(** A conversion function parametrized by a universe comparator. Used outside of
-    the kernel. *)
-val vm_conv_gen : conv_pb -> (types, 'a) generic_conversion_function
+(** A conversion function parametrized by a universe comparator and
+   evar normalizer. Used outside of the kernel. *)
+val vm_conv_gen : conv_pb -> (existential -> constr option) -> (types, 'a) generic_conversion_function

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -1191,14 +1191,12 @@ struct
         | VMcast ->
           let sigma, cj = pretype empty_tycon env sigma c in
           let cty = nf_evar sigma cj.uj_type and tval = nf_evar sigma tval in
-          if not (occur_existential sigma cty || occur_existential sigma tval) then
-            match Reductionops.vm_infer_conv !!env sigma cty tval with
+          begin match Reductionops.vm_infer_conv !!env sigma cty tval with
             | Some sigma -> (sigma, cj), tval
             | None ->
               error_actual_type ?loc !!env sigma cj tval
                 (ConversionFailed (!!env,cty,tval))
-          else user_err ?loc  (str "Cannot check cast with vm: " ++
-                               str "unresolved arguments remain.")
+          end
         | NATIVEcast ->
           let sigma, cj = pretype empty_tycon env sigma c in
           let cty = nf_evar sigma cj.uj_type and tval = nf_evar sigma tval in

--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -425,7 +425,8 @@ let cbv_vm env sigma c t  =
   EConstr.of_constr (nf_val env sigma v t)
 
 let vm_infer_conv ?(pb=Reduction.CUMUL) env sigma t1 t2 =
-  Reductionops.infer_conv_gen (fun pb ~l2r sigma ts -> Vconv.vm_conv_gen pb)
+  Reductionops.infer_conv_gen (fun pb ~l2r sigma ts ->
+      Vconv.vm_conv_gen pb (Evd.existential_opt_value0 sigma))
     ~catch_incon:true ~pb env sigma t1 t2
 
 let _ = if Coq_config.bytecode_compiler then Reductionops.set_vm_infer_conv vm_infer_conv


### PR DESCRIPTION
The "Cannot check cast with vm: unresolved arguments remain." error
from #14745 is now
~~~
The term "eq_refl" has type "?x = ?x" while it is expected to have type
 "ZMicromega.ZTautoChecker __ff __wit = true".
~~~

Also fixes an anomaly when doing `Check (eq_refl <<: 0 = 0).` with
native configured off (for some reason I get the anomaly on master but
not 8.11).
