### PR TITLE
Clean up the ssr implementation

### DIFF
--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -84,8 +84,6 @@ let mk_orhint tacs = true, tacs
 let nullhint = true, []
 let nohint = false, []
 
-let re_sig it sigma = { Evd.it = it; Evd.sigma = sigma }
-
 open Pp
 
 let errorstrm x = CErrors.user_err x
@@ -614,19 +612,6 @@ let abs_cterm env sigma n c0 =
   EConstr.of_constr (strip_evars 0 c0)
 
 (* }}} *)
-
-let merge_uc uc =
-  let open Proofview.Notations in
-  Proofview.tclEVARMAP >>= fun sigma ->
-  try Proofview.Unsafe.tclEVARS (Evd.merge_universe_context sigma uc)
-  with e when CErrors.noncritical e -> Proofview.tclZERO e
-
-let pf_merge_uc uc gl =
-  re_sig (sig_it gl) (Evd.merge_universe_context gl.Evd.sigma uc)
-let pf_merge_uc_of sigma gl =
-  let ucst = Evd.evar_universe_context sigma in
-  pf_merge_uc ucst gl
-
 
 let rec constr_name sigma c = match EConstr.kind sigma c with
   | Var id -> Name id

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -1004,10 +1004,8 @@ let pf_interp_gen_aux env sigma ~concl to_ind ((oclr, occ), t) =
   let sigma = Evd.merge_universe_context sigma (Evd.evar_universe_context @@ fst pat) in
   let (c, ucst), cl =
     try fill_occ_pattern ~raise_NoMatch:true env sigma (EConstr.Unsafe.to_constr concl) pat occ 1
-    with NoMatch -> redex_of_pattern env pat, (EConstr.Unsafe.to_constr concl) in
+    with NoMatch -> redex_of_pattern env pat, concl in
   let sigma = Evd.merge_universe_context sigma ucst in
-  let c = EConstr.of_constr c in
-  let cl = EConstr.of_constr cl in
   let clr = interp_clr sigma (oclr, (tag_of_cpattern t, c)) in
   if not(occur_existential sigma c) then
     if tag_of_cpattern t = WithAt then
@@ -1094,9 +1092,7 @@ let abs_wgen env sigma keep_let f gen (args,c) =
      let sigma = Evd.merge_universe_context sigma (Evd.evar_universe_context (fst cp)) in
      let (t, ucst), c =
        try fill_occ_pattern ~raise_NoMatch:true env sigma (EConstr.Unsafe.to_constr c) cp None 1
-       with NoMatch -> redex_of_pattern env cp, (EConstr.Unsafe.to_constr c) in
-     let c = EConstr.of_constr c in
-     let t = EConstr.of_constr t in
+       with NoMatch -> redex_of_pattern env cp, c in
      evar_closed t p;
      let ut = red_product_skip_id env sigma t in
      let sigma, ty, r = pfe_type_relevance_of env sigma t in
@@ -1108,9 +1104,7 @@ let abs_wgen env sigma keep_let f gen (args,c) =
      let sigma = Evd.merge_universe_context sigma (Evd.evar_universe_context (fst cp)) in
      let (t, ucst), c =
        try fill_occ_pattern ~raise_NoMatch:true env sigma (EConstr.Unsafe.to_constr c) cp None 1
-       with NoMatch -> redex_of_pattern env cp, (EConstr.Unsafe.to_constr c) in
-     let c = EConstr.of_constr c in
-     let t = EConstr.of_constr t in
+       with NoMatch -> redex_of_pattern env cp, c in
      evar_closed t p;
      let sigma, ty, r = pfe_type_relevance_of env sigma t in
      let sigma = Evd.merge_universe_context sigma ucst in

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -789,8 +789,8 @@ let pf_interp_ty ?(resolve_typeclasses=false) env sigma0 ist ty =
    let n = List.length evs in
    let lam_c = abs_cterm env sigma0 n c in
    let ctx, c = EConstr.decompose_lam_n_assum sigma n lam_c in
-   n, EConstr.it_mkProd_or_LetIn c ctx, lam_c, ucst
-;;
+   let sigma0 = Evd.merge_universe_context sigma0 ucst in
+   sigma0, n, EConstr.it_mkProd_or_LetIn c ctx, lam_c
 
 (* TASSI: given (c : ty), generates (c ??? : ty[???/...]) with m evars *)
 exception NotEnoughProducts

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -1003,7 +1003,7 @@ let pf_interp_gen_aux env sigma ~concl to_ind ((oclr, occ), t) =
   let pat = interp_cpattern env sigma t None in (* UGLY API *)
   let sigma = Evd.merge_universe_context sigma (Evd.evar_universe_context @@ fst pat) in
   let (c, ucst), cl =
-    try fill_occ_pattern ~raise_NoMatch:true env sigma (EConstr.Unsafe.to_constr concl) pat occ 1
+    try fill_occ_pattern ~raise_NoMatch:true env sigma concl pat occ 1
     with NoMatch -> redex_of_pattern env pat, concl in
   let sigma = Evd.merge_universe_context sigma ucst in
   let clr = interp_clr sigma (oclr, (tag_of_cpattern t, c)) in
@@ -1091,7 +1091,7 @@ let abs_wgen env sigma keep_let f gen (args,c) =
      let cp = interp_cpattern env sigma p None in
      let sigma = Evd.merge_universe_context sigma (Evd.evar_universe_context (fst cp)) in
      let (t, ucst), c =
-       try fill_occ_pattern ~raise_NoMatch:true env sigma (EConstr.Unsafe.to_constr c) cp None 1
+       try fill_occ_pattern ~raise_NoMatch:true env sigma c cp None 1
        with NoMatch -> redex_of_pattern env cp, c in
      evar_closed t p;
      let ut = red_product_skip_id env sigma t in
@@ -1103,7 +1103,7 @@ let abs_wgen env sigma keep_let f gen (args,c) =
      let cp = interp_cpattern env sigma p None in
      let sigma = Evd.merge_universe_context sigma (Evd.evar_universe_context (fst cp)) in
      let (t, ucst), c =
-       try fill_occ_pattern ~raise_NoMatch:true env sigma (EConstr.Unsafe.to_constr c) cp None 1
+       try fill_occ_pattern ~raise_NoMatch:true env sigma c cp None 1
        with NoMatch -> redex_of_pattern env cp, c in
      evar_closed t p;
      let sigma, ty, r = pfe_type_relevance_of env sigma t in

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -403,7 +403,7 @@ let resolve_typeclasses env sigma ~where ~fail =
 let nf_evar sigma t =
   EConstr.Unsafe.to_constr (Evarutil.nf_evar sigma (EConstr.of_constr t))
 
-let abs_evars2 env sigma0 rigid (sigma, c0) =
+let abs_evars env sigma0 ?(rigid = []) (sigma, c0) =
   let c0 = EConstr.to_constr ~abort_on_undefined_evars:false sigma c0 in
   let sigma0, ucst = sigma0, Evd.evar_universe_context sigma in
   let nenv = env_size env in
@@ -441,8 +441,6 @@ let abs_evars2 env sigma0 rigid (sigma, c0) =
       loop (mkLambda (make_annot (mk_evar_name n) Sorts.Relevant, get (i - 1) t, c)) (i - 1) evl
     | [] -> c in
     EConstr.of_constr (loop (get 1 c0) 1 evlist), List.map fst evlist, ucst
-
-let abs_evars env sigma t = abs_evars2 env sigma [] t
 
 (* As before but if (?i : T(?j)) and (?j : P : Prop), then the lambda for i
  * looks like (fun evar_i : (forall pi : P. T(pi))) thanks to "loopP" and all

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -153,9 +153,6 @@ val is_tagged : string -> string -> bool
 val has_discharged_tag : string -> bool
 val ssrqid : string -> Libnames.qualid
 val mk_anon_id : string -> Id.t list -> Id.t
-val abs_evars_pirrel :
-           Environ.env -> Evd.evar_map ->
-           evar_map * Constr.constr -> int * Constr.constr
 val nbargs_open_constr : Environ.env -> Evd.evar_map * EConstr.t -> int
 val pf_nbargs : Environ.env -> Evd.evar_map -> EConstr.t -> int
 

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -223,7 +223,7 @@ val pf_interp_ty :
            Tacinterp.interp_sign ->
            Ssrast.ssrtermkind *
            (Glob_term.glob_constr * Constrexpr.constr_expr option) ->
-           int * EConstr.t * EConstr.t * UState.t
+           Evd.evar_map * int * EConstr.t * EConstr.t
 
 val ssr_n_tac : string -> int -> unit Proofview.tactic
 val donetac : int -> unit Proofview.tactic

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -146,11 +146,6 @@ val abs_evars2 : (* ssr2 *)
 val abs_cterm :
            Environ.env -> Evd.evar_map -> int -> EConstr.t -> EConstr.t
 
-val merge_uc : UState.t -> unit Proofview.tactic
-val pf_merge_uc :
-           UState.t -> 'a Evd.sigma -> 'a Evd.sigma
-val pf_merge_uc_of :
-           evar_map -> 'a Evd.sigma -> 'a Evd.sigma
 val constr_name : evar_map -> EConstr.t -> Name.t
 
 val mkSsrRef : string -> GlobRef.t

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -136,12 +136,12 @@ val type_id : Environ.env -> Evd.evar_map -> EConstr.types -> Id.t
 val abs_evars :
            Environ.env -> Evd.evar_map ->
            evar_map * EConstr.t ->
-           int * EConstr.t * Evar.t list *
+           EConstr.t * Evar.t list *
            UState.t
 val abs_evars2 : (* ssr2 *)
            Environ.env -> Evd.evar_map -> Evar.t list ->
            evar_map * EConstr.t ->
-           int * EConstr.t * Evar.t list *
+           EConstr.t * Evar.t list *
            UState.t
 val abs_cterm :
            Environ.env -> Evd.evar_map -> int -> EConstr.t -> EConstr.t

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -134,12 +134,7 @@ val ssr_anon_hyp : string
 val type_id : Environ.env -> Evd.evar_map -> EConstr.types -> Id.t
 
 val abs_evars :
-           Environ.env -> Evd.evar_map ->
-           evar_map * EConstr.t ->
-           EConstr.t * Evar.t list *
-           UState.t
-val abs_evars2 : (* ssr2 *)
-           Environ.env -> Evd.evar_map -> Evar.t list ->
+           Environ.env -> Evd.evar_map -> ?rigid:Evar.t list ->
            evar_map * EConstr.t ->
            EConstr.t * Evar.t list *
            UState.t

--- a/plugins/ssr/ssrelim.ml
+++ b/plugins/ssr/ssrelim.ml
@@ -144,14 +144,14 @@ let fire_subst sigma t = Reductionops.nf_evar sigma t
 let mkTpat env sigma0 (sigma, t) = (* takes a term, refreshes it and makes a T pattern *)
   let t, evs, ucst = abs_evars env sigma0 (sigma, fire_subst sigma t) in
   let t, _, _, sigma = saturate ~beta:true env sigma t (List.length evs) in
-  Evd.merge_universe_context sigma ucst, T (EConstr.Unsafe.to_constr t)
+  Evd.merge_universe_context sigma ucst, T t
 
 let unif_redex env sigma0 nsigma (sigma, r as p) t = (* t is a hint for the redex of p *)
   let t, evs, ucst = abs_evars env sigma0 (nsigma, fire_subst nsigma t) in
   let t, _, _, sigma = saturate ~beta:true env sigma t (List.length evs) in
   let sigma = Evd.merge_universe_context sigma ucst in
   match r with
-  | X_In_T (e, p) -> sigma, E_As_X_In_T (EConstr.Unsafe.to_constr t, e, p)
+  | X_In_T (e, p) -> sigma, E_As_X_In_T (t, e, p)
   | _ ->
       try unify_HO env sigma t (fst (redex_of_pattern env p)), r
       with e when CErrors.noncritical e -> p
@@ -311,7 +311,7 @@ let check_pattern_instantiated env sigma patterns =
   end
 
 let is_undef_pat = function
-| sigma, T t -> EConstr.isEvar sigma (EConstr.of_constr t)
+| sigma, T t -> EConstr.isEvar sigma t
 | _ -> false
 
 let generate_pred env sigma0 ~concl patterns predty eqid is_rec deps elim_args n_elim_args c_is_head_p clr sigma =

--- a/plugins/ssr/ssrelim.ml
+++ b/plugins/ssr/ssrelim.ml
@@ -142,13 +142,13 @@ let match_pat env sigma0 p occ h cl =
 let fire_subst sigma t = Reductionops.nf_evar sigma t
 
 let mkTpat env sigma0 (sigma, t) = (* takes a term, refreshes it and makes a T pattern *)
-  let n, t, _, ucst = abs_evars env sigma0 (sigma, fire_subst sigma t) in
-  let t, _, _, sigma = saturate ~beta:true env sigma t n in
+  let t, evs, ucst = abs_evars env sigma0 (sigma, fire_subst sigma t) in
+  let t, _, _, sigma = saturate ~beta:true env sigma t (List.length evs) in
   Evd.merge_universe_context sigma ucst, T (EConstr.Unsafe.to_constr t)
 
 let unif_redex env sigma0 nsigma (sigma, r as p) t = (* t is a hint for the redex of p *)
-  let n, t, _, ucst = abs_evars env sigma0 (nsigma, fire_subst nsigma t) in
-  let t, _, _, sigma = saturate ~beta:true env sigma t n in
+  let t, evs, ucst = abs_evars env sigma0 (nsigma, fire_subst nsigma t) in
+  let t, _, _, sigma = saturate ~beta:true env sigma t (List.length evs) in
   let sigma = Evd.merge_universe_context sigma ucst in
   match r with
   | X_In_T (e, p) -> sigma, E_As_X_In_T (EConstr.Unsafe.to_constr t, e, p)
@@ -335,8 +335,8 @@ let generate_pred env sigma0 ~concl patterns predty eqid is_rec deps elim_args n
         let e, ucst = redex_of_pattern env p in
         let sigma = Evd.merge_universe_context sigma ucst in
         let e = EConstr.of_constr e in
-        let n, e, _, _ucst =  abs_evars env sigma (fst p, e) in
-        let e, _, _, sigma = saturate ~beta:true env sigma e n in
+        let e, evs, _ucst = abs_evars env sigma (fst p, e) in
+        let e, _, _, sigma = saturate ~beta:true env sigma e (List.length evs) in
         let sigma = try unify_HO env sigma inf_t e
                   with exn when CErrors.noncritical exn -> error sigma e inf_t in
         cl, sigma, post

--- a/plugins/ssr/ssrelim.ml
+++ b/plugins/ssr/ssrelim.ml
@@ -136,8 +136,8 @@ let match_pat env sigma0 p occ h cl =
   debug_ssr (fun () -> Pp.(str"matching: " ++ pr_occ occ ++ pp_pattern env p));
   let (c,ucst), cl =
     fill_occ_pattern ~raise_NoMatch:true env sigma0 (EConstr.Unsafe.to_constr cl) p occ h in
-  debug_ssr (fun () -> Pp.(str"     got: " ++ pr_constr_env env sigma0 c));
-  EConstr.of_constr c, EConstr.of_constr cl, ucst
+  debug_ssr (fun () -> Pp.(str"     got: " ++ pr_econstr_env env sigma0 c));
+  c, cl, ucst
 
 let fire_subst sigma t = Reductionops.nf_evar sigma t
 
@@ -153,7 +153,7 @@ let unif_redex env sigma0 nsigma (sigma, r as p) t = (* t is a hint for the rede
   match r with
   | X_In_T (e, p) -> sigma, E_As_X_In_T (EConstr.Unsafe.to_constr t, e, p)
   | _ ->
-      try unify_HO env sigma t (EConstr.of_constr (fst (redex_of_pattern env p))), r
+      try unify_HO env sigma t (fst (redex_of_pattern env p)), r
       with e when CErrors.noncritical e -> p
 
 let find_eliminator env sigma ~concl ~is_case ?elim oc c_gen =
@@ -334,7 +334,6 @@ let generate_pred env sigma0 ~concl patterns predty eqid is_rec deps elim_args n
     | NoMatch | NoProgress ->
         let e, ucst = redex_of_pattern env p in
         let sigma = Evd.merge_universe_context sigma ucst in
-        let e = EConstr.of_constr e in
         let e, evs, _ucst = abs_evars env sigma (fst p, e) in
         let e, _, _, sigma = saturate ~beta:true env sigma e (List.length evs) in
         let sigma = try unify_HO env sigma inf_t e
@@ -400,7 +399,7 @@ let compute_patterns env sigma0 what c_is_head_p cty deps inf_deps_r occ orig_cl
     | ((oclr, occ), t):: deps, inf_t :: inf_deps ->
         let p = interp_cpattern env sigma0 t None in
         let clr_t =
-          interp_clr sigma (oclr,(tag_of_cpattern t,EConstr.of_constr (fst (redex_of_pattern env p)))) in
+          interp_clr sigma (oclr,(tag_of_cpattern t, fst (redex_of_pattern env p))) in
         (* if we are the index for the equation we do not clear *)
         let clr_t = if deps = [] && eqid <> None then [] else clr_t in
         let p = if is_undef_pat p then mkTpat env sigma0 (sigma, inf_t) else p in

--- a/plugins/ssr/ssrelim.ml
+++ b/plugins/ssr/ssrelim.ml
@@ -135,7 +135,7 @@ let check_elim sigma has_elim = function
 let match_pat env sigma0 p occ h cl =
   debug_ssr (fun () -> Pp.(str"matching: " ++ pr_occ occ ++ pp_pattern env p));
   let (c,ucst), cl =
-    fill_occ_pattern ~raise_NoMatch:true env sigma0 (EConstr.Unsafe.to_constr cl) p occ h in
+    fill_occ_pattern ~raise_NoMatch:true env sigma0 cl p occ h in
   debug_ssr (fun () -> Pp.(str"     got: " ++ pr_econstr_env env sigma0 c));
   c, cl, ucst
 

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -227,7 +227,7 @@ let simplintac occ rdx sim =
     end else
       let sigma0, concl0, env0 = Proofview.Goal.(sigma gl, concl gl, env gl) in
       let simp env c _ _ = red_safe Tacred.simpl env sigma0 c in
-      convert_concl_no_check (EConstr.of_constr (eval_pattern env0 sigma0 (EConstr.to_constr ~abort_on_undefined_evars:false sigma0 concl0) rdx occ simp))
+      convert_concl_no_check (eval_pattern env0 sigma0 (EConstr.to_constr ~abort_on_undefined_evars:false sigma0 concl0) rdx occ simp)
     end
   in
   let open Tacticals in
@@ -316,7 +316,7 @@ let unfoldintac occ rdx t (kt,_) =
     fake_pmatcher_end in
   let concl =
     let concl0 = EConstr.Unsafe.to_constr concl0 in
-    try beta env0 (EConstr.of_constr (eval_pattern env0 sigma0 concl0 rdx occ unfold))
+    try beta env0 (eval_pattern env0 sigma0 concl0 rdx occ unfold)
     with Option.IsNone -> errorstrm Pp.(str"Failed to unfold " ++ pr_econstr_pat env0 sigma t) in
   let _ = conclude () in
   convert_concl ~check:true concl
@@ -349,7 +349,7 @@ let foldtac occ rdx ft =
   let concl0 = EConstr.Unsafe.to_constr concl0 in
   let concl = eval_pattern env0 sigma0 concl0 rdx occ fold in
   let _ = conclude () in
-  convert_concl ~check:true (EConstr.of_constr concl)
+  convert_concl ~check:true concl
   end
 
 let converse_dir = function L2R -> R2L | R2L -> L2R
@@ -535,7 +535,7 @@ let ssr_is_setoid env =
       sigma [] (EConstr.mkApp (r, args)) <> None
 
 let closed0_check env sigma cl p =
-  if closed0 cl then
+  if closed0 (EConstr.Unsafe.to_constr cl) then
     errorstrm Pp.(str"No occurrence of redex "++ pr_constr_env env sigma p)
 
 let dir_org = function L2R -> 1 | R2L -> 2
@@ -658,7 +658,7 @@ let rwrxtac ?under ?map_redex occ rdx_pat dir rule =
   let concl = eval_pattern env0 sigma0 concl0 rdx_pat occ find_R in
   let (d, r), rdx = conclude concl in
   let r = Evd.merge_universe_context (pi1 r) (pi2 r), (pi3 r) in
-  rwcltac ?under ?map_redex (EConstr.of_constr concl) rdx d r
+  rwcltac ?under ?map_redex concl rdx d r
   end
 
 let ssrinstancesofrule ist dir arg =

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -99,7 +99,7 @@ let congrtac ((n, t), ty) ist =
   debug_ssr (fun () -> Pp.(str"concl=" ++ Printer.pr_econstr_env env sigma concl));
   let nsigma, _ as it = interp_term env sigma ist t in
   let sigma = Evd.merge_universe_context sigma (Evd.evar_universe_context nsigma) in
-  let _, f, _, _ucst = abs_evars2 env sigma [] it in
+  let f, _, _ucst = abs_evars2 env sigma [] it in
   let ist' = {ist with lfun =
     Id.Map.add pattern_id (Tacinterp.Value.of_constr f) Id.Map.empty } in
   let rf = mkRltacVar pattern_id in
@@ -451,7 +451,8 @@ let rwcltac ?under ?map_redex cl rdx dir sr =
     let sigma, r = sr in
     let sigma = resolve_typeclasses ~where:r ~fail:false env sigma in
     sigma, r in
-  let n, r_n,_, ucst = abs_evars env sigma0 sr in
+  let r_n, evs, ucst = abs_evars env sigma0 sr in
+  let n = List.length evs in
   let r_n' = abs_cterm env sigma0 n r_n in
   let r' = EConstr.Vars.subst_var pattern_id r_n' in
   let sigma0 = Evd.set_universe_context sigma0 ucst in

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -648,6 +648,7 @@ let rwrxtac ?under ?map_redex occ rdx_pat dir rule =
       (fun e c _ i -> find_R ~k:(fun _ _ _ h -> EConstr.mkRel h) e c i),
       fun cl -> let rdx,d,r = end_R () in closed0_check env0 sigma0 cl (EConstr.Unsafe.to_constr rdx); (d,r),rdx
   | Some(_, (T e | X_In_T (_,e) | E_As_X_In_T (e,_,_) | E_In_X_In_T (e,_,_))) ->
+      let e = EConstr.Unsafe.to_constr e in
       let r = ref None in
       (fun env c _ h -> do_once r (fun () -> find_rule c, c); EConstr.mkRel h),
       (fun concl -> closed0_check env0 sigma0 concl e;
@@ -699,7 +700,7 @@ let rwargtac ?under ?map_redex ist ((dir, mult), (((oclr, occ), grx), (kind, gt)
   let fail = ref false in
   let interp_rpattern env sigma gc =
     try interp_rpattern env sigma gc
-    with _ when snd mult = May -> fail := true; sigma, T mkProp in
+    with _ when snd mult = May -> fail := true; sigma, T EConstr.mkProp in
   let interp env sigma gc =
     try interp_term env sigma ist gc
     with _ when snd mult = May -> fail := true; (sigma, EConstr.mkProp) in

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -533,8 +533,8 @@ let ssr_is_setoid env =
       sigma [] (EConstr.mkApp (r, args)) <> None
 
 let closed0_check env sigma cl p =
-  if closed0 (EConstr.Unsafe.to_constr cl) then
-    errorstrm Pp.(str"No occurrence of redex "++ pr_constr_env env sigma p)
+  if EConstr.Vars.closed0 sigma cl then
+    errorstrm Pp.(str"No occurrence of redex "++ pr_econstr_env env sigma p)
 
 let dir_org = function L2R -> 1 | R2L -> 2
 
@@ -646,9 +646,8 @@ let rwrxtac ?under ?map_redex occ rdx_pat dir rule =
       let rpats = List.fold_left (rpat env0 sigma0) (r_sigma,[]) rules in
       let find_R, end_R = mk_tpattern_matcher sigma0 occ ~upats_origin rpats in
       (fun e c _ i -> find_R ~k:(fun _ _ _ h -> EConstr.mkRel h) e c i),
-      fun cl -> let rdx,d,r = end_R () in closed0_check env0 sigma0 cl (EConstr.Unsafe.to_constr rdx); (d,r),rdx
+      fun cl -> let rdx,d,r = end_R () in closed0_check env0 sigma0 cl rdx; (d,r),rdx
   | Some(_, (T e | X_In_T (_,e) | E_As_X_In_T (e,_,_) | E_In_X_In_T (e,_,_))) ->
-      let e = EConstr.Unsafe.to_constr e in
       let r = ref None in
       (fun env c _ h -> do_once r (fun () -> find_rule c, c); EConstr.mkRel h),
       (fun concl -> closed0_check env0 sigma0 concl e;

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -283,7 +283,7 @@ let unfoldintac occ rdx t (kt,_) =
     let find_T, end_T =
       mk_tpattern_matcher ~raise_NoMatch:true sigma0 occ (ise,[u]) in
     (fun env c _ h ->
-      try EConstr.of_constr @@ find_T env (EConstr.Unsafe.to_constr c) h ~k:(fun env c _ _ -> body env t c)
+      try find_T env c h ~k:(fun env c _ _ -> body env t c)
       with NoMatch when easy -> c
       | NoMatch | NoProgress -> errorstrm Pp.(str"No occurrence of "
         ++ pr_econstr_pat env sigma0 t ++ spc() ++ str "in " ++ Printer.pr_econstr_env env sigma c)),
@@ -336,7 +336,7 @@ let foldtac occ rdx ft =
     let ise, ut = mk_tpattern env0 sigma0 (ise,t) all_ok L2R ut in
     let find_T, end_T =
       mk_tpattern_matcher ~raise_NoMatch:true sigma0 occ (ise,[ut]) in
-    (fun env c _ h -> try EConstr.of_constr @@ find_T env (EConstr.Unsafe.to_constr c) h ~k:(fun env t _ _ -> t) with NoMatch ->c),
+    (fun env c _ h -> try find_T env c h ~k:(fun env t _ _ -> t) with NoMatch ->c),
     (fun () -> try end_T () with NoMatch -> fake_pmatcher_end ())
   | _ ->
     (fun env c _ h ->
@@ -647,7 +647,7 @@ let rwrxtac ?under ?map_redex occ rdx_pat dir rule =
         sigma, pats @ [pat] in
       let rpats = List.fold_left (rpat env0 sigma0) (r_sigma,[]) rules in
       let find_R, end_R = mk_tpattern_matcher sigma0 occ ~upats_origin rpats in
-      (fun e c _ i -> EConstr.of_constr @@ find_R ~k:(fun _ _ _ h -> EConstr.mkRel h) e (EConstr.Unsafe.to_constr c) i),
+      (fun e c _ i -> find_R ~k:(fun _ _ _ h -> EConstr.mkRel h) e c i),
       fun cl -> let rdx,d,r = end_R () in closed0_check env0 sigma0 cl rdx; (d,r),rdx
   | Some(_, (T e | X_In_T (_,e) | E_As_X_In_T (e,_,_) | E_In_X_In_T (e,_,_))) ->
       let r = ref None in
@@ -684,7 +684,7 @@ let ssrinstancesofrule ist dir arg =
   Feedback.msg_info Pp.(str"BEGIN INSTANCES");
   try
     while true do
-      ignore(find env0 (EConstr.to_constr ~abort_on_undefined_evars:false sigma0 concl0) 1 ~k:print)
+      ignore(find env0 (Reductionops.nf_evar sigma0 concl0) 1 ~k:print)
     done; raise NoMatch
   with NoMatch -> Feedback.msg_info Pp.(str"END INSTANCES"); Tacticals.tclIDTAC
   end

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -99,7 +99,7 @@ let congrtac ((n, t), ty) ist =
   debug_ssr (fun () -> Pp.(str"concl=" ++ Printer.pr_econstr_env env sigma concl));
   let nsigma, _ as it = interp_term env sigma ist t in
   let sigma = Evd.merge_universe_context sigma (Evd.evar_universe_context nsigma) in
-  let f, _, _ucst = abs_evars2 env sigma [] it in
+  let f, _, _ucst = abs_evars env sigma it in
   let ist' = {ist with lfun =
     Id.Map.add pattern_id (Tacinterp.Value.of_constr f) Id.Map.empty } in
   let rf = mkRltacVar pattern_id in

--- a/plugins/ssr/ssrfwd.ml
+++ b/plugins/ssr/ssrfwd.ml
@@ -262,16 +262,13 @@ let havetac ist
      sigma, ty, Tactics.apply t,
        itac_c <*> simpltac <*> tacopen_skols <*> unfold [abstract; abstract_key]
    | _,true,true  ->
-     let _, ty, _, uc = pf_interp_ty ~resolve_typeclasses:fixtc env sigma ist cty in
-     let sigma = Evd.merge_universe_context sigma uc in
+     let sigma, _, ty, _ = pf_interp_ty ~resolve_typeclasses:fixtc env sigma ist cty in
      sigma, EConstr.mkArrow ty Sorts.Relevant concl, hint <*> itac, clr
    | _,false,true ->
-     let _, ty, _, uc = pf_interp_ty ~resolve_typeclasses:fixtc env sigma ist cty in
-     let sigma = Evd.merge_universe_context sigma uc in
+     let sigma, _, ty, _ = pf_interp_ty ~resolve_typeclasses:fixtc env sigma ist cty in
      sigma, EConstr.mkArrow ty Sorts.Relevant concl, hint, itac_c
    | _, false, false ->
-     let n, cty, _ , uc = pf_interp_ty ~resolve_typeclasses:fixtc env sigma ist cty in
-     let sigma = Evd.merge_universe_context sigma uc in
+     let sigma, n, cty, _  = pf_interp_ty ~resolve_typeclasses:fixtc env sigma ist cty in
      sigma, cty, (binderstac n) <*> hint, Tacticals.tclTHEN itac_c simpltac
    | _, true, false -> assert false in
   Proofview.Unsafe.tclEVARS sigma <*>
@@ -321,7 +318,7 @@ let wlogtac ist (((clr0, pats),_),_) (gens, ((_, ct))) hint suff ghave =
       List.fold_left (fun (env, c) _ ->
         let rd, c = destProd_or_LetIn sigma c in
         EConstr.push_rel rd env, c) (env, c) gens in
-    let _, ct, _, uc = pf_interp_ty env sigma ist ct in
+    let sigma, _, ct, _ = pf_interp_ty env sigma ist ct in
     let rec var2rel c g s = match EConstr.kind sigma c, g with
       | Prod({binder_name=Anonymous} as x,_,c), [] -> EConstr.mkProd(x, EConstr.Vars.subst_vars s ct, c)
       | Sort _, [] -> EConstr.Vars.subst_vars s ct
@@ -335,7 +332,6 @@ let wlogtac ist (((clr0, pats),_),_) (gens, ((_, ct))) hint suff ghave =
          | Prod(_,_,c) -> pired (EConstr.Vars.subst1 t c) ts
          | LetIn(id,b,ty,c) -> EConstr.mkLetIn (id,b,ty,pired c args)
          | _ -> CErrors.anomaly(str"SSR: wlog: pired: " ++ pr_econstr_env env sigma c) in
-    let sigma = Evd.merge_universe_context sigma uc in
     c, args, pired c args, sigma
   in
   let tacipat pats = introstac pats in
@@ -401,8 +397,8 @@ let sufftac ist ((((clr, pats),binders),simpl), ((_, c), hint)) =
   let ctac =
     let open Tacmach in
     Proofview.Goal.enter begin fun gl ->
-    let _,ty,_,uc = pf_interp_ty (pf_env gl) (project gl) ist c in
-    merge_uc uc <*> basesufftac ty
+    let sigma, _, ty, _ = pf_interp_ty (pf_env gl) (project gl) ist c in
+    Proofview.Unsafe.tclEVARS sigma <*> basesufftac ty
   end in
   Tacticals.tclTHENS ctac [htac; Tacticals.tclTHEN (cleartac clr) (introstac (binders@simpl))]
 

--- a/plugins/ssr/ssrfwd.ml
+++ b/plugins/ssr/ssrfwd.ml
@@ -52,7 +52,7 @@ let ssrsettac id ((_, (pat, pty)), (_, occ)) =
     (mkRHole, Some body), ist) pty in
   let pat = interp_cpattern env sigma pat pty in
   let (c, ucst), cl =
-    try fill_occ_pattern ~raise_NoMatch:true env sigma (EConstr.Unsafe.to_constr cl) pat occ 1
+    try fill_occ_pattern ~raise_NoMatch:true env sigma cl pat occ 1
     with NoMatch -> redex_of_pattern ~resolve_typeclasses:true env pat, cl in
   let sigma = Evd.merge_universe_context sigma ucst in
   if Termops.occur_existential sigma c then errorstrm(str"The pattern"++spc()++

--- a/plugins/ssr/ssrfwd.ml
+++ b/plugins/ssr/ssrfwd.ml
@@ -52,12 +52,9 @@ let ssrsettac id ((_, (pat, pty)), (_, occ)) =
     (mkRHole, Some body), ist) pty in
   let pat = interp_cpattern env sigma pat pty in
   let (c, ucst), cl =
-    let cl = EConstr.Unsafe.to_constr cl in
-    try fill_occ_pattern ~raise_NoMatch:true env sigma cl pat occ 1
+    try fill_occ_pattern ~raise_NoMatch:true env sigma (EConstr.Unsafe.to_constr cl) pat occ 1
     with NoMatch -> redex_of_pattern ~resolve_typeclasses:true env pat, cl in
   let sigma = Evd.merge_universe_context sigma ucst in
-  let c = EConstr.of_constr c in
-  let cl = EConstr.of_constr cl in
   if Termops.occur_existential sigma c then errorstrm(str"The pattern"++spc()++
     pr_econstr_pat env sigma c++spc()++str"did not match and has holes."++spc()++
     str"Did you mean pose?") else

--- a/plugins/ssr/ssripats.ml
+++ b/plugins/ssr/ssripats.ml
@@ -756,9 +756,7 @@ let tclLAST_GEN ~to_ind ((oclr, occ), t) conclusion = tclINDEPENDENTL begin
       tclUNIT (false, ccl, c, clr)
   else
     if to_ind && occ = None then
-      let p, _, ucst' =
-        (* TODO: use abs_evars2 *)
-        Ssrcommon.abs_evars env sigma0 (fst pat, c) in
+      let p, _, ucst' = Ssrcommon.abs_evars env sigma0 (fst pat, c) in
       let sigma = Evd.merge_universe_context sigma ucst' in
       Unsafe.tclEVARS sigma <*>
       Ssrcommon.tacTYPEOF p >>= fun pty ->

--- a/plugins/ssr/ssripats.ml
+++ b/plugins/ssr/ssripats.ml
@@ -731,7 +731,7 @@ let tclLAST_GEN ~to_ind ((oclr, occ), t) conclusion = tclINDEPENDENTL begin
   let pat = Ssrmatching.interp_cpattern env sigma t None in
   let cl = Reductionops.nf_evar sigma cl0 in
   let (c, ucst), cl =
-    try Ssrmatching.fill_occ_pattern ~raise_NoMatch:true env sigma (EConstr.Unsafe.to_constr cl) pat occ 1
+    try Ssrmatching.fill_occ_pattern ~raise_NoMatch:true env sigma cl pat occ 1
     with Ssrmatching.NoMatch -> Ssrmatching.redex_of_pattern env pat, cl in
   let sigma = Evd.merge_universe_context sigma ucst in
   let clr =

--- a/plugins/ssr/ssripats.ml
+++ b/plugins/ssr/ssripats.ml
@@ -729,12 +729,11 @@ let tclLAST_GEN ~to_ind ((oclr, occ), t) conclusion = tclINDEPENDENTL begin
   let cl0, env, sigma, hyps = Goal.(concl gl, env gl, sigma gl, hyps gl) in
   let sigma0 = sigma in
   let pat = Ssrmatching.interp_cpattern env sigma t None in
-  let cl = EConstr.to_constr ~abort_on_undefined_evars:false sigma cl0 in
+  let cl = Reductionops.nf_evar sigma cl0 in
   let (c, ucst), cl =
-    try Ssrmatching.fill_occ_pattern ~raise_NoMatch:true env sigma cl pat occ 1
+    try Ssrmatching.fill_occ_pattern ~raise_NoMatch:true env sigma (EConstr.Unsafe.to_constr cl) pat occ 1
     with Ssrmatching.NoMatch -> Ssrmatching.redex_of_pattern env pat, cl in
   let sigma = Evd.merge_universe_context sigma ucst in
-  let c, cl = EConstr.of_constr c, EConstr.of_constr cl in
   let clr =
     Ssrcommon.interp_clr sigma (oclr, (Ssrmatching.tag_of_cpattern t,c)) in
   (* Historically in Coq, and hence in ssr, [case t] accepts [t] of type

--- a/plugins/ssr/ssripats.ml
+++ b/plugins/ssr/ssripats.ml
@@ -959,7 +959,7 @@ let ssrabstract dgens =
     Ssrcommon.tacMK_SSR_CONST "abstract" >>= fun abstract ->
     Ssrcommon.tacMK_SSR_CONST "abstract_key" >>= fun abstract_key ->
     Ssrcommon.tacINTERP_CPATTERN cid >>= fun cid ->
-    let id = EConstr.mkVar (Option.get (Ssrmatching.id_of_pattern cid)) in
+    let id = EConstr.mkVar (Option.get (Ssrmatching.id_of_pattern (Goal.sigma g) cid)) in
     tacEXAMINE_ABSTRACT id >>= fun (idty, args_id) ->
     let abstract_n = args_id.(1) in
     tacFIND_ABSTRACT_PROOF true abstract_n >>= fun abstract_proof ->
@@ -994,7 +994,7 @@ let ssrabstract dgens =
      let open Ssrmatching in
      let open Tacmach in
      let ipats = List.map (fun (_,cp) ->
-       match id_of_pattern (interp_cpattern (pf_env gl) (project gl) cp None) with
+       match id_of_pattern (project gl) (interp_cpattern (pf_env gl) (project gl) cp None) with
        | None -> IPatAnon (One None)
        | Some id -> IPatId id)
        (List.tl gens) in

--- a/plugins/ssr/ssripats.ml
+++ b/plugins/ssr/ssripats.ml
@@ -756,7 +756,7 @@ let tclLAST_GEN ~to_ind ((oclr, occ), t) conclusion = tclINDEPENDENTL begin
       tclUNIT (false, ccl, c, clr)
   else
     if to_ind && occ = None then
-      let _, p, _, ucst' =
+      let p, _, ucst' =
         (* TODO: use abs_evars2 *)
         Ssrcommon.abs_evars env sigma0 (fst pat, c) in
       let sigma = Evd.merge_universe_context sigma ucst' in

--- a/plugins/ssr/ssrview.ml
+++ b/plugins/ssr/ssrview.ml
@@ -323,8 +323,8 @@ Goal.enter_one ~__LOC__ begin fun g ->
     List.filter (fun k -> Evar.Set.mem k g0)
       (List.map fst (Evar.Map.bindings (Evd.undefined_map sigma0))) in
   let rigid = rigid_of und0 in
-  let n, p, to_prune, _ucst = abs_evars2 env0 sigma0 rigid (sigma, p) in
-  let p = if simple_types then abs_cterm env0 sigma0 n p else p in
+  let p, to_prune, _ucst = abs_evars2 env0 sigma0 rigid (sigma, p) in
+  let p = if simple_types then abs_cterm env0 sigma0 (List.length to_prune) p else p in
   Ssrprinters.debug_ssr (fun () -> Pp.(str"view@finalized: " ++
     Printer.pr_econstr_env env sigma p));
   let sigma = List.fold_left Evd.remove sigma to_prune in

--- a/plugins/ssr/ssrview.ml
+++ b/plugins/ssr/ssrview.ml
@@ -323,7 +323,7 @@ Goal.enter_one ~__LOC__ begin fun g ->
     List.filter (fun k -> Evar.Set.mem k g0)
       (List.map fst (Evar.Map.bindings (Evd.undefined_map sigma0))) in
   let rigid = rigid_of und0 in
-  let p, to_prune, _ucst = abs_evars2 env0 sigma0 rigid (sigma, p) in
+  let p, to_prune, _ucst = abs_evars env0 sigma0 ~rigid (sigma, p) in
   let p = if simple_types then abs_cterm env0 sigma0 (List.length to_prune) p else p in
   Ssrprinters.debug_ssr (fun () -> Pp.(str"view@finalized: " ++
     Printer.pr_econstr_env env sigma p));

--- a/plugins/ssr/ssrview.ml
+++ b/plugins/ssr/ssrview.ml
@@ -307,12 +307,12 @@ Goal.enter_one ~__LOC__ begin fun g ->
   let p = Reductionops.nf_evar sigma p in
   let get_body = function Evd.Evar_defined x -> x | _ -> assert false in
   let evars_of_econstr sigma t =
-    Evarutil.undefined_evars_of_term sigma (EConstr.of_constr t) in
+    Evarutil.undefined_evars_of_term sigma t in
   let rigid_of s =
     List.fold_left (fun l k ->
       if Evd.is_defined sigma k then
         let bo = get_body Evd.(evar_body (find sigma k)) in
-          k :: l @ Evar.Set.elements (evars_of_econstr sigma (EConstr.Unsafe.to_constr bo))
+          k :: l @ Evar.Set.elements (evars_of_econstr sigma bo)
       else l
     ) [] s in
   let env0 = Proofview.Goal.env s0 in

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -637,7 +637,7 @@ type find_P =
   k:subst ->
      EConstr.t
 type conclude = unit ->
-  constr * ssrdir * (Evd.evar_map * UState.t * constr)
+  EConstr.t * ssrdir * (Evd.evar_map * UState.t * EConstr.t)
 
 let apply_subst (k : subst) env (c : constr) (t : constr) n =
   EConstr.Unsafe.to_constr (k env (EConstr.of_constr c) (EConstr.of_constr t) n)
@@ -767,7 +767,7 @@ let rec uniquize = function
     | Some (env,_,x) -> env,List.hd x | None when raise_NoMatch -> raise NoMatch
     | None -> CErrors.anomaly (str"companion function never called.") in
   let p' = mkApp (pf, pa) in
-  if max_occ <= !nocc then p', u.up_dir, (sigma, uc, u.up_t)
+  if max_occ <= !nocc then EConstr.of_constr p', u.up_dir, (sigma, uc, EConstr.of_constr u.up_t)
   else errorstrm (str"Only " ++ int !nocc ++ str" < " ++ int max_occ ++
         str(String.plural !nocc " occurrence") ++ match upats_origin with
         | None -> str" of" ++ spc() ++ pr_constr_pat env sigma p'
@@ -1252,7 +1252,7 @@ let pf_fill_occ env concl occ sigma0 p (sigma, t) ok h =
    mk_tpattern_matcher ~raise_NoMatch:true sigma0 occ (ise,[u]) in
  let concl = apply_find_P find_U env concl h ~k:(fun _ _ _ n -> EConstr.mkRel n) in
  let rdx, _, (sigma, uc, p) = end_U () in
- sigma, uc, EConstr.of_constr p, EConstr.of_constr concl, EConstr.of_constr rdx
+ sigma, uc, p, EConstr.of_constr concl, rdx
 
 let fill_occ_term env sigma0 cl occ (sigma, t) =
   try

--- a/plugins/ssrmatching/ssrmatching.mli
+++ b/plugins/ssrmatching/ssrmatching.mli
@@ -152,7 +152,7 @@ type find_P =
     instantiation, the proof term and the ssrdit stored in the tpattern
   @raise UserEerror if too many occurrences were specified *)
 type conclude =
-  unit -> constr * ssrdir * (evar_map * UState.t * constr)
+  unit -> EConstr.t * ssrdir * (evar_map * UState.t * EConstr.t)
 
 (** [mk_tpattern_matcher b o sigma0 occ sigma_tplist] creates a pair
     a function [find_P] and [conclude] with the behaviour explained above.

--- a/plugins/ssrmatching/ssrmatching.mli
+++ b/plugins/ssrmatching/ssrmatching.mli
@@ -91,7 +91,7 @@ type subst = Environ.env -> EConstr.t -> EConstr.t -> int -> EConstr.t
     [subst] *)
 val eval_pattern :
   ?raise_NoMatch:bool ->
-  env -> evar_map -> constr ->
+  env -> evar_map -> EConstr.t ->
   pattern option -> occ -> subst ->
     EConstr.t
 
@@ -105,7 +105,7 @@ val eval_pattern :
     transformed as described above. *)
 val fill_occ_pattern :
   ?raise_NoMatch:bool ->
-  env -> evar_map -> constr ->
+  env -> evar_map -> EConstr.t ->
   pattern -> occ -> int ->
     EConstr.t Evd.in_evar_universe_context * EConstr.t
 

--- a/plugins/ssrmatching/ssrmatching.mli
+++ b/plugins/ssrmatching/ssrmatching.mli
@@ -56,7 +56,7 @@ val pr_rpattern : rpattern -> Pp.t
   @raise Anomaly if called on [In_T] or [In_X_In_T] *)
 val redex_of_pattern :
   ?resolve_typeclasses:bool -> env -> pattern ->
-     constr Evd.in_evar_universe_context
+     EConstr.t Evd.in_evar_universe_context
 
 (** [interp_rpattern ise gl rpat] "internalizes" and "interprets" [rpat]
     in the current [Ltac] interpretation signature [ise] and tactic input [gl]*)
@@ -93,7 +93,7 @@ val eval_pattern :
   ?raise_NoMatch:bool ->
   env -> evar_map -> constr ->
   pattern option -> occ -> subst ->
-    constr
+    EConstr.t
 
 (** [fill_occ_pattern b env sigma t pat occ h] is a simplified version of
     [eval_pattern].
@@ -107,7 +107,7 @@ val fill_occ_pattern :
   ?raise_NoMatch:bool ->
   env -> evar_map -> constr ->
   pattern -> occ -> int ->
-    constr Evd.in_evar_universe_context * constr
+    EConstr.t Evd.in_evar_universe_context * EConstr.t
 
 (** *************************** Low level APIs ****************************** *)
 

--- a/plugins/ssrmatching/ssrmatching.mli
+++ b/plugins/ssrmatching/ssrmatching.mli
@@ -127,11 +127,11 @@ type tpattern
   @return the compiled [tpattern] and its [evar_map]
   @raise UserEerror is the pattern is a wildcard *)
 val mk_tpattern :
-  ?p_origin:ssrdir * constr ->
+  ?p_origin:ssrdir * EConstr.t ->
   env -> evar_map ->
-  evar_map * constr ->
-  (constr -> evar_map -> bool) ->
-  ssrdir -> constr ->
+  evar_map * EConstr.t ->
+  (EConstr.t -> evar_map -> bool) ->
+  ssrdir -> EConstr.t ->
     evar_map * tpattern
 
 (** [findP env t i k] is a stateful function that finds the next occurrence
@@ -163,7 +163,7 @@ type conclude =
 val mk_tpattern_matcher :
   ?all_instances:bool ->
   ?raise_NoMatch:bool ->
-  ?upats_origin:ssrdir * constr ->
+  ?upats_origin:ssrdir * EConstr.t ->
   evar_map -> occ -> evar_map * tpattern list ->
     find_P * conclude
 

--- a/plugins/ssrmatching/ssrmatching.mli
+++ b/plugins/ssrmatching/ssrmatching.mli
@@ -43,7 +43,7 @@ type ('ident, 'term) ssrpattern =
   | E_In_X_In_T of 'term * 'ident * 'term
   | E_As_X_In_T of 'term * 'ident * 'term
 
-type pattern = evar_map * (constr, constr) ssrpattern
+type pattern = Evd.evar_map * (EConstr.t, EConstr.t) ssrpattern
 val pp_pattern : env -> pattern -> Pp.t
 
 (** The type of rewrite patterns, the patterns of the [rewrite] tactic.
@@ -220,7 +220,7 @@ val unify_HO : env -> evar_map -> EConstr.constr -> EConstr.constr -> evar_map
     on top of the former APIs *)
 val tag_of_cpattern : cpattern -> ssrtermkind
 val loc_of_cpattern : cpattern -> Loc.t option
-val id_of_pattern : pattern -> Names.Id.t option
+val id_of_pattern : evar_map -> pattern -> Names.Id.t option
 val is_wildcard : cpattern -> bool
 val cpattern_of_id : Names.Id.t -> cpattern
 val pr_constr_pat : env -> evar_map -> constr -> Pp.t

--- a/plugins/ssrmatching/ssrmatching.mli
+++ b/plugins/ssrmatching/ssrmatching.mli
@@ -145,7 +145,7 @@ val mk_tpattern :
   @raise UserEerror if the raise_NoMatch flag given to [mk_tpattern_matcher] is
     [false] and if the pattern did not match *)
 type find_P =
-  env -> constr -> int -> k:subst -> constr
+  Environ.env -> EConstr.t -> int -> k:subst -> EConstr.t
 
 (** [conclude ()] asserts that all mentioned occurrences have been visited.
   @return the instance of the pattern, the evarmap after the pattern

--- a/plugins/ssrmatching/ssrmatching.mli
+++ b/plugins/ssrmatching/ssrmatching.mli
@@ -79,7 +79,7 @@ type occ = (bool * int list) option
 
 (** [subst e p t i]. [i] is the number of binders
     traversed so far, [p] the term from the pattern, [t] the matched one *)
-type subst = env -> constr -> constr -> int -> constr
+type subst = Environ.env -> EConstr.t -> EConstr.t -> int -> EConstr.t
 
 (** [eval_pattern b env sigma t pat occ subst] maps [t] calling [subst] on every
     [occ] occurrence of [pat]. The [int] argument is the number of


### PR DESCRIPTION
This PR performs a bit of cleanup of the ssr and ssrmatching plugins. In addition to minute API tweaks, the major change introduced is that most of the code has been ported to EConstr. As usual, since this is easy to introduce nasty bugs when performing this change, I've cut the PR in small self-contained patches.