### PR TITLE
[CI] [fiat-crypto] Fix fiat-crypto CI

### DIFF
--- a/dev/ci/ci-fiat_crypto.sh
+++ b/dev/ci/ci-fiat_crypto.sh
@@ -13,7 +13,8 @@ if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
 # We need a larger stack size to not overflow ocamlopt+flambda when
 # building the executables.
 # c.f. https://github.com/coq/coq/pull/8313#issuecomment-416650241
-stacksize=32768
+# c.f. https://coq.zulipchat.com/#narrow/stream/237656-Coq-devs.20.26.20plugin.20devs/topic/fiat.20crypto.20broken/near/263463085
+stacksize=65536
 
 # fiat-crypto is not guaranteed to build with the latest version of
 # bedrock2, so we use the pinned version of bedrock2, but the external


### PR DESCRIPTION
The native compiler runs out of stack, it seems? c.f.
https://github.com/mit-plv/bedrock2/issues/205

