### PR TITLE
Wish #7911: support for recursively using "x .. y" in recursive notations

### DIFF
--- a/doc/changelog/03-notations/15291-master+wish-recursive-patterns-in-argument-of-recursive-notations.rst
+++ b/doc/changelog/03-notations/15291-master+wish-recursive-patterns-in-argument-of-recursive-notations.rst
@@ -1,0 +1,7 @@
+- **Added:**
+  When defining a recursive notation referring to another recursive
+  notation, expressions of the form :n:`x .. y` can be used where a
+  sequence of binders is expected
+  (`#15291 <https://github.com/coq/coq/pull/15291>`_,
+  grants `#7911 <https://github.com/coq/coq/issues/7911>`_,
+  by Hugo Herbelin).

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -255,3 +255,5 @@ File "./output/Notations4.v", line 540, characters 0-57:
 The command has indeed failed with message:
 Notation "[[ _ ]]" is already defined at level 0 with arguments custom foo
 while it is now required to be at level 0 with arguments custom bar.
+lambda x y : nat, x + y = 0
+     : nat -> nat -> Prop

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -540,3 +540,15 @@ Notation "[[ x ]]" := x (x custom foo) : nat_scope.
 Fail Notation "[[ x ]]" := x (x custom bar) : type_scope.
 
 End Incompatibility.
+
+Module RecursivePatternsArgumentsInRecursiveNotations.
+
+Notation "'λ' x .. y , t" := (fun x => .. (fun y => t) ..)
+  (at level 200, x binder, y binder, right associativity,
+  format "'[  ' '[  ' 'λ'  x  ..  y ']' ,  '/' t ']'").
+
+Notation "'lambda' x .. y , t" := (λ x .. y, t) (at level 200, x binder, y binder).
+
+Check lambda x y, x+y=0.
+
+End RecursivePatternsArgumentsInRecursiveNotations.


### PR DESCRIPTION
**Kind:** Enhancement

We simply interpret `..` in a list of arguments for a recursive notations as an iterator producting `.. a ..` from `a`.

For terms, we additionally need to extend the parser of arguments of recursive notations. A conflict between `..` alone and `.. term ..` can happen if ever some code already use `.. term ..` as argument of a recursive notation which has no separator. To be investigated.

Closes #7911

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
