### PR TITLE
Drop backtrace when raising Exit

### DIFF
--- a/checker/check.ml
+++ b/checker/check.ml
@@ -309,7 +309,7 @@ let marshal_in_segment ~validate ~value ~segment f ch =
       try
         let v = Analyze.parse_channel ch in
         let digest = Digest.input ch in
-        let () = if not (String.equal digest segment.ObjFile.hash) then raise Exit in
+        let () = if not (String.equal digest segment.ObjFile.hash) then raise_notrace Exit in
         v
       with _ ->
         user_err (str "Corrupted file " ++ quote (str f))

--- a/checker/checker.ml
+++ b/checker/checker.ml
@@ -75,7 +75,7 @@ let convert_string d =
   with CErrors.UserError _ ->
     Flags.if_verbose Feedback.msg_warning
       (str "Directory " ++ str d ++ str " cannot be used as a Coq identifier (skipped)");
-    raise Exit
+    raise_notrace Exit
 
 let add_rec_path ~unix_path ~coq_root =
   if exists_dir unix_path then

--- a/checker/votour.ml
+++ b/checker/votour.ml
@@ -205,20 +205,20 @@ let node_info (v,o,p) =
 let access_children vs os pos =
   if Array.length os = Array.length vs then
     Array.mapi (fun i v -> v, os.(i), i::pos) vs
-  else raise Exit
+  else raise_notrace Exit
 
 let access_list v o pos =
   let rec loop o pos accu = match Repr.repr o with
   | INT 0 -> List.rev accu
   | BLOCK (0, [|hd; tl|]) ->
     loop tl (1 :: pos) ((v, hd, 0 :: pos) :: accu)
-  | _ -> raise Exit
+  | _ -> raise_notrace Exit
   in
   Array.of_list (loop o pos [])
 
 let access_block o = match Repr.repr o with
 | BLOCK (tag, os) -> (tag, os)
-| _ -> raise Exit
+| _ -> raise_notrace Exit
 
 (** raises Exit if the object has not the expected structure *)
 exception Forbidden
@@ -230,7 +230,7 @@ let rec get_children v o pos = match v with
     begin match Repr.repr o with
     | BLOCK (tag, os) -> access_children vv.(tag) os pos
     | INT _ -> [||]
-    | _ -> raise Exit
+    | _ -> raise_notrace Exit
     end
   |Array v ->
     let (_, os) = access_block o in
@@ -240,31 +240,31 @@ let rec get_children v o pos = match v with
     begin match Repr.repr o with
     | INT 0 -> [||]
     | BLOCK (0, [|x|]) -> [|(v, x, 0 :: pos)|]
-    | _ -> raise Exit
+    | _ -> raise_notrace Exit
     end
   | String ->
     begin match Repr.repr o with
     | STRING _ -> [||]
-    | _ -> raise Exit
+    | _ -> raise_notrace Exit
     end
   | Int ->
     begin match Repr.repr o with
     | INT _ -> [||]
-    | _ -> raise Exit
+    | _ -> raise_notrace Exit
     end
   |Annot (s,v) -> get_children v o pos
-  |Any -> raise Exit
+  |Any -> raise_notrace Exit
   |Dyn ->
     begin match Repr.repr o with
     | BLOCK (0, [|id; o|]) ->
       let tpe = Any in
       [|(Int, id, 0 :: pos); (tpe, o, 1 :: pos)|]
-    | _ -> raise Exit
+    | _ -> raise_notrace Exit
     end
   |Fail s -> raise Forbidden
   | Proxy v -> get_children !v o pos
-  | Int64 -> raise Exit
-  | Float64 -> raise Exit
+  | Int64 -> raise_notrace Exit
+  | Float64 -> raise_notrace Exit
 
 let get_children v o pos =
   try get_children v o pos

--- a/clib/cArray.ml
+++ b/clib/cArray.ml
@@ -457,7 +457,7 @@ let distinct v =
   try
     Array.iter
       (fun x ->
-        if Hashtbl.mem visited x then raise Exit
+        if Hashtbl.mem visited x then raise_notrace Exit
         else Hashtbl.add visited x x)
       v;
     true

--- a/clib/option.ml
+++ b/clib/option.ml
@@ -210,7 +210,7 @@ module List =
     | [] -> []
     | x :: l ->
       match f x with
-      | None -> raise Exit
+      | None -> raise_notrace Exit
       | Some y -> y :: aux f l
     in
     try Some (aux f l) with Exit -> None

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -228,7 +228,7 @@ let evar_dependency_closure n sigma =
   EvMap.bindings map
 
 let has_no_evar sigma =
-  try let () = Evd.fold (fun _ _ () -> raise Exit) sigma () in true
+  try let () = Evd.fold (fun _ _ () -> raise_notrace Exit) sigma () in true
   with Exit -> false
 
 let pr_evd_level sigma = UState.pr_uctx_level (Evd.evar_universe_context sigma)

--- a/ide/coqide/ideutils.ml
+++ b/ide/coqide/ideutils.ml
@@ -527,7 +527,7 @@ let url_for_keyword =
             (fun x -> Sys.file_exists (Filename.concat x "index_urls.txt"))
             (Minilib.coqide_data_dirs ())) "index_urls.txt" in
             open_in index_urls
-          with Not_found -> raise Exit
+          with Not_found -> raise_notrace Exit
         in
           try while true do
             let s = input_line cin in

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -428,14 +428,14 @@ let pattern_printable_in_both_syntax (ind,_ as c) =
 
 let extern_record_pattern cstrsp args =
   try
-    if !Flags.raw_print then raise Exit;
+    if !Flags.raw_print then raise_notrace Exit;
     let projs = Structure.find_projections (fst cstrsp) in
     if PrintingRecord.active (fst cstrsp) then
       ()
     else if PrintingConstructor.active (fst cstrsp) then
-      raise Exit
+      raise_notrace Exit
     else if not (get_record_print ()) then
-      raise Exit;
+      raise_notrace Exit;
     let rec ip projs args acc =
       match projs, args with
       | [], [] -> acc
@@ -706,15 +706,15 @@ let is_start_implicit = function
 
 let extern_record ref args =
   try
-    if !Flags.raw_print then raise Exit;
+    if !Flags.raw_print then raise_notrace Exit;
     let cstrsp = match ref with GlobRef.ConstructRef c -> c | _ -> raise Not_found in
     let struc = Structure.find (fst cstrsp) in
     if PrintingRecord.active (fst cstrsp) then
       ()
     else if PrintingConstructor.active (fst cstrsp) then
-      raise Exit
+      raise_notrace Exit
     else if not (get_record_print ()) then
-      raise Exit;
+      raise_notrace Exit;
     let projs = struc.Structure.projections in
     let rec cut args n =
       if Int.equal n 0 then args

--- a/plugins/micromega/polynomial.ml
+++ b/plugins/micromega/polynomial.ml
@@ -155,7 +155,7 @@ struct
       if Int.equal i len then ()
       else
         let v = m.(i + 1) in
-        let () = if v mod 2 = 0 then m.(i + 1) <- v / 2 else raise Exit in
+        let () = if v mod 2 = 0 then m.(i + 1) <- v / 2 else raise_notrace Exit in
         set (i + 2)
     in
     try let () = set 1 in Some m with Exit -> None

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -62,14 +62,14 @@ let instantiate_context u subst nas ctx =
     let bdy = substnl subst i (subst_instance_constr u bdy) in
     LocalDef (nas.(i), ty, bdy) :: ctx
   in
-  let () = if not (Int.equal (Array.length nas) (List.length ctx)) then raise Exit in
+  let () = if not (Int.equal (Array.length nas) (List.length ctx)) then raise_notrace Exit in
   instantiate (Array.length nas - 1) ctx
 
 let return_clause env sigma ind u params (nas, p) =
   try
     let u = EConstr.Unsafe.to_instance u in
     let params = EConstr.Unsafe.to_constr_array params in
-    let () = if not @@ Environ.mem_mind (fst ind) env then raise Exit in
+    let () = if not @@ Environ.mem_mind (fst ind) env then raise_notrace Exit in
     let mib = Environ.lookup_mind (fst ind) env in
     let mip = mib.mind_packets.(snd ind) in
     let paramdecl = subst_instance_context u mib.mind_params_ctxt in
@@ -91,7 +91,7 @@ let branch env sigma (ind, i) u params (nas, br) =
   try
     let u = EConstr.Unsafe.to_instance u in
     let params = EConstr.Unsafe.to_constr_array params in
-    let () = if not @@ Environ.mem_mind (fst ind) env then raise Exit in
+    let () = if not @@ Environ.mem_mind (fst ind) env then raise_notrace Exit in
     let mib = Environ.lookup_mind (fst ind) env in
     let mip = mib.mind_packets.(snd ind) in
     let paramdecl = subst_instance_context u mib.mind_params_ctxt in
@@ -868,7 +868,7 @@ and detype_r d flags avoid env sigma t =
 
 and detype_eqns d flags avoid env sigma computable constructs consnargsl bl =
   try
-    if !Flags.raw_print || not (reverse_matching ()) then raise Exit;
+    if !Flags.raw_print || not (reverse_matching ()) then raise_notrace Exit;
     let mat = build_tree Anonymous flags (avoid,env) sigma bl in
     List.map (fun (ids,pat,((avoid,env),c)) ->
         CAst.make (Id.Set.elements ids,[pat],detype d flags avoid env sigma c))

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -1065,7 +1065,7 @@ let extract_unique_projection = function
 let extract_candidates sols =
   try
     UpdateWith
-      (List.map (function (id,ProjectVar) -> mkVar id | _ -> raise Exit) sols)
+      (List.map (function (id,ProjectVar) -> mkVar id | _ -> raise_notrace Exit) sols)
   with Exit ->
     NoUpdate
 

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -1351,18 +1351,18 @@ let inject_if_homogenous_dependent_pair ty =
     let existTconstr = Coqlib.lib_ref    "core.sigT.intro" in
     (* check whether the equality deals with dep pairs or not *)
     let eqTypeDest = fst (decompose_app sigma t) in
-    if not (isRefX sigma sigTconstr eqTypeDest) then raise Exit;
+    if not (isRefX sigma sigTconstr eqTypeDest) then raise_notrace Exit;
     let hd1,ar1 = decompose_app_vect sigma t1 and
         hd2,ar2 = decompose_app_vect sigma t2 in
-    if not (isRefX sigma existTconstr hd1) then raise Exit;
-    if not (isRefX sigma existTconstr hd2) then raise Exit;
-    let (ind, _), _ = try pf_apply find_mrectype gl ar1.(0) with Not_found -> raise Exit in
+    if not (isRefX sigma existTconstr hd1) then raise_notrace Exit;
+    if not (isRefX sigma existTconstr hd2) then raise_notrace Exit;
+    let (ind, _), _ = try pf_apply find_mrectype gl ar1.(0) with Not_found -> raise_notrace Exit in
     (* check if the user has declared the dec principle *)
     (* and compare the fst arguments of the dep pair *)
     (* Note: should work even if not an inductive type, but the table only *)
     (* knows inductive types *)
     if not (Option.has_some (Ind_tables.lookup_scheme (!eq_dec_scheme_kind_name()) ind) &&
-      pf_apply is_conv gl ar1.(2) ar2.(2)) then raise Exit;
+      pf_apply is_conv gl ar1.(2) ar2.(2)) then raise_notrace Exit;
     check_required_library ["Coq";"Logic";"Eqdep_dec"];
     let new_eq_args = [|pf_get_type_of gl ar1.(3);ar1.(3);ar2.(3)|] in
     let inj2 = lib_ref "core.eqdep_dec.inj_pair2" in

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -4146,10 +4146,10 @@ let compute_elim_sig sigma elimt =
       res := { !res with
         indarg = None;
         indarg_in_concl = false; farg_in_concl = true };
-      raise Exit
+      raise_notrace Exit
     end;
     (* 2- If no args_indargs (=!res.nargs at this point) then no indarg *)
-    if Int.equal !res.nargs 0 then raise Exit;
+    if Int.equal !res.nargs 0 then raise_notrace Exit;
     (* 3- Look at last arg: is it the indarg? *)
     ignore (
       match List.hd args_indargs with
@@ -4166,15 +4166,15 @@ let compute_elim_sig sigma elimt =
             let hi_args_enough = (* hi a le bon nbre d'arguments *)
               Int.equal (List.length hi_args) (List.length params + !res.nargs -1) in
             (* FIXME: Ces deux tests ne sont pas suffisants. *)
-            if not (hi_is_ind && hi_args_enough) then raise Exit (* No indarg *)
+            if not (hi_is_ind && hi_args_enough) then raise_notrace Exit (* No indarg *)
             else (* Last arg is the indarg *)
               res := {!res with
                 indarg = Some (List.hd !res.args);
                 indarg_in_concl = occur_rel sigma 1 ccl;
                 args = List.tl !res.args; nargs = !res.nargs - 1;
               };
-            raise Exit);
-    raise Exit(* exit anyway *)
+            raise_notrace Exit);
+    raise_notrace Exit(* exit anyway *)
   with Exit -> (* Ending by computing indref: *)
     match !res.indarg with
       | None -> !res (* No indref *)
@@ -4223,7 +4223,7 @@ let compute_scheme_signature evd scheme names_info ind_type_guess =
       | LetIn (_,_,_,c) ->
         (OtherArg, false, not (Vars.noccurn evd 1 c)) :: check_branch (p+1) c
       | _ when is_pred p c == IndArg -> []
-      | _ -> raise Exit
+      | _ -> raise_notrace Exit
   in
   let rec find_branches p lbrch =
     match lbrch with

--- a/topbin/coqnative_bin.ml
+++ b/topbin/coqnative_bin.ml
@@ -207,7 +207,7 @@ let convert_string d =
   with CErrors.UserError _ ->
     Flags.if_verbose Feedback.msg_warning
       (str "Directory " ++ str d ++ str " cannot be used as a Coq identifier (skipped)");
-    raise Exit
+    raise_notrace Exit
 
 let coq_root = Id.of_string "Coq"
 

--- a/vernac/egramcoq.ml
+++ b/vernac/egramcoq.ml
@@ -109,7 +109,7 @@ let find_position_gen current ensure assoc lev =
           let a' = create_assoc assoc in
           (init := Some (a', q); (p,a',false)::l)
         else if admissible_assoc (a,assoc) then
-          raise Exit
+          raise_notrace Exit
         else
           error_level_assoc p a (Option.get assoc)
       | l -> after := q; (n,create_assoc assoc,ensure)::l

--- a/vernac/loadpath.ml
+++ b/vernac/loadpath.ml
@@ -295,7 +295,7 @@ let convert_string d =
   | CErrors.UserError _ ->
     let d = Unicode.escaped_if_non_utf8 d in
     warn_cannot_use_directory d;
-    raise Exit
+    raise_notrace Exit
 
 let add_vo_path lp =
   let unix_path = lp.unix_path in

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -468,7 +468,7 @@ let rec split_format_at_ldots hd = function
   | u :: fmt ->
       check_no_ldots_in_box u;
       split_format_at_ldots (u::hd) fmt
-  | [] -> raise Exit
+  | [] -> raise_notrace Exit
 
 and check_no_ldots_in_box = function
   | (_,UnpBox (_,fmt)) ->
@@ -628,7 +628,7 @@ let include_possible_similar_trailing_pattern typ etyps sl l =
   | [], NonTerminal x ::l' when is_constr_typ typ x etyps -> try_aux n l'
   | Break _ :: sl, l -> aux n (sl,l)
   | sl, Break _ :: l -> aux n (sl,l)
-  | _ -> raise Exit
+  | _ -> raise_notrace Exit
   and try_aux n l =
     try aux (n+1) (sl,l)
     with Exit -> n,l in


### PR DESCRIPTION
The backtrace isn't useful as the `Exit` exception is always caught.

I suspect there's many other cases where the backtrace is needlessly created, but they require some inspection unlike Exit.