### PR TITLE
Ensure that errors are located in the current command.

### DIFF
--- a/test-suite/output/Arguments.out
+++ b/test-suite/output/Arguments.out
@@ -110,6 +110,7 @@ The command has indeed failed with message:
 Unknown interpretation for notation "$".
 w 3 true = tt
      : Prop
+File "./output/Arguments.v", line 56, characters 0-26:
 The command has indeed failed with message:
 Extra arguments: _, _.
 volatilematch : nat -> nat

--- a/test-suite/output/Arguments_renaming.out
+++ b/test-suite/output/Arguments_renaming.out
@@ -1,3 +1,4 @@
+File "./output/Arguments_renaming.v", line 2, characters 0-36:
 The command has indeed failed with message:
 Flag "rename" expected to rename A into B.
 File "./output/Arguments_renaming.v", line 3, characters 0-19:
@@ -89,19 +90,26 @@ myplus is transparent
 Expands to: Constant Arguments_renaming.myplus
 @myplus
      : forall Z : Type, Z -> nat -> nat -> nat
+File "./output/Arguments_renaming.v", line 49, characters 0-36:
 The command has indeed failed with message:
 Argument lists should agree on the names they provide.
+File "./output/Arguments_renaming.v", line 50, characters 0-41:
 The command has indeed failed with message:
 Sequences of implicit arguments must be of different lengths.
+File "./output/Arguments_renaming.v", line 51, characters 0-37:
 The command has indeed failed with message:
 Argument number 3 is a trailing implicit, so it can't be declared non
 maximal. Please use { } instead of [ ].
+File "./output/Arguments_renaming.v", line 52, characters 0-37:
 The command has indeed failed with message:
 Argument z is a trailing implicit, so it can't be declared non maximal.
 Please use { } instead of [ ].
+File "./output/Arguments_renaming.v", line 53, characters 0-28:
 The command has indeed failed with message:
 Extra arguments: y.
+File "./output/Arguments_renaming.v", line 54, characters 0-26:
 The command has indeed failed with message:
 Flag "rename" expected to rename A into R.
+File "./output/Arguments_renaming.v", line 58, characters 2-36:
 The command has indeed failed with message:
 Arguments of section variables such as allTrue may not be renamed.

--- a/test-suite/output/BadOptionValueType.out
+++ b/test-suite/output/BadOptionValueType.out
@@ -1,14 +1,21 @@
+File "./output/BadOptionValueType.v", line 1, characters 0-29:
 The command has indeed failed with message:
 Bad type of value for this option: expected int, got string.
+File "./output/BadOptionValueType.v", line 2, characters 0-25:
 The command has indeed failed with message:
 This is an option. A value must be provided.
+File "./output/BadOptionValueType.v", line 3, characters 0-27:
 The command has indeed failed with message:
 Bad type of value for this option: expected string, got int.
+File "./output/BadOptionValueType.v", line 4, characters 0-25:
 The command has indeed failed with message:
 This is an option. A value must be provided.
+File "./output/BadOptionValueType.v", line 5, characters 0-27:
 The command has indeed failed with message:
 This is a flag. It does not take a value.
+File "./output/BadOptionValueType.v", line 6, characters 0-23:
 The command has indeed failed with message:
 This is a flag. It does not take a value.
+File "./output/BadOptionValueType.v", line 7, characters 0-20:
 The command has indeed failed with message:
 This option does not support the "Unset" command.

--- a/test-suite/output/Cases.out
+++ b/test-suite/output/Cases.out
@@ -57,6 +57,7 @@ match H with
       else fun _ : P false => Logic.I) x0) x
 end
      : B -> True
+File "./output/Cases.v", line 91, characters 0-98:
 The command has indeed failed with message:
 Non exhaustive pattern-matching: no clause found for pattern 
 gadtTy _ _

--- a/test-suite/output/ErrorInCanonicalStructures.out
+++ b/test-suite/output/ErrorInCanonicalStructures.out
@@ -1,6 +1,8 @@
+File "./output/ErrorInCanonicalStructures.v", line 5, characters 0-29:
 The command has indeed failed with message:
 Could not declare a canonical structure Foo.
 Expected an instance of a record or structure.
+File "./output/ErrorInCanonicalStructures.v", line 7, characters 0-29:
 The command has indeed failed with message:
 Could not declare a canonical structure bar.
 Expected an instance of a record or structure.

--- a/test-suite/output/ErrorLocation_tac_in_term.out
+++ b/test-suite/output/ErrorLocation_tac_in_term.out
@@ -1,6 +1,21 @@
-File "./output/ErrorLocation_tac_in_term.v", line 4, characters 26-30:
+File "./output/ErrorLocation_tac_in_term.v", line 3, characters 11-14:
+The command has indeed failed with message:
+Illegal application (Non-functional construction): 
+The expression "I" of type "True" cannot be applied to the term
+ "I" : "True"
+File "./output/ErrorLocation_tac_in_term.v", line 8, characters 0-15:
+The command has indeed failed with message:
+Illegal application (Non-functional construction): 
+The expression "I" of type "True" cannot be applied to the term
+ "I" : "True"
+File "./output/ErrorLocation_tac_in_term.v", line 12, characters 16-19:
+The command has indeed failed with message:
+Illegal application (Non-functional construction): 
+The expression "I" of type "True" cannot be applied to the term
+ "I" : "True"
+File "./output/ErrorLocation_tac_in_term.v", line 17, characters 26-30:
 The command has indeed failed with message:
 The term "true" has type "bool" while it is expected to have type "nat".
-File "./output/ErrorLocation_tac_in_term.v", line 5, characters 17-25:
+File "./output/ErrorLocation_tac_in_term.v", line 18, characters 17-25:
 The command has indeed failed with message:
 The term "true" has type "bool" while it is expected to have type "nat".

--- a/test-suite/output/ErrorLocation_tac_in_term.v
+++ b/test-suite/output/ErrorLocation_tac_in_term.v
@@ -1,3 +1,16 @@
+Notation foo := (I I).
+
+Fail Check foo.
+
+Notation bar := (ltac:(exact (I I))) (only parsing).
+
+(* whole command: it would be nice to be more precise *)
+Fail Check bar.
+
+Notation baz x := (ltac:(exact x)) (only parsing).
+
+Fail Check baz (I I).
+
 Ltac f x y := apply (x y).
 
 Goal True.

--- a/test-suite/output/Errors.out
+++ b/test-suite/output/Errors.out
@@ -1,9 +1,10 @@
+File "./output/Errors.v", line 12, characters 0-11:
 The command has indeed failed with message:
 The field t is missing in Errors.M.
 File "./output/Errors.v", line 19, characters 18-19:
 The command has indeed failed with message:
 Unable to unify "nat" with "True".
-File "./output/Errors.v", line 17, characters 18-19:
+File "./output/Errors.v", line 20, characters 0-16:
 The command has indeed failed with message:
 In nested Ltac calls to "f" and "apply x", last call failed.
 Unable to unify "nat" with "True".

--- a/test-suite/output/HintLocality.out
+++ b/test-suite/output/HintLocality.out
@@ -67,6 +67,7 @@ For any goal ->
 For nat ->   
 For S (modes !) ->   
 
+File "./output/HintLocality.v", line 61, characters 0-38:
 The command has indeed failed with message:
 This command does not support the global attribute in sections.
 Non-discriminated database

--- a/test-suite/output/Inductive.out
+++ b/test-suite/output/Inductive.out
@@ -1,3 +1,4 @@
+File "./output/Inductive.v", line 1, characters 0-93:
 The command has indeed failed with message:
 In environment
 list' : Set -> Set

--- a/test-suite/output/InvalidDisjunctiveIntro.out
+++ b/test-suite/output/InvalidDisjunctiveIntro.out
@@ -1,6 +1,7 @@
 File "./output/InvalidDisjunctiveIntro.v", line 2, characters 31-32:
 The command has indeed failed with message:
 Cannot coerce to a disjunctive/conjunctive pattern.
+File "./output/InvalidDisjunctiveIntro.v", line 4, characters 2-32:
 The command has indeed failed with message:
 Disjunctive/conjunctive introduction pattern expected.
 File "./output/InvalidDisjunctiveIntro.v", line 6, characters 48-49:
@@ -13,6 +14,7 @@ File "./output/InvalidDisjunctiveIntro.v", line 10, characters 32-33:
 The command has indeed failed with message:
 Ltac variable H is bound to <tactic closure> which cannot be coerced to
 an introduction pattern.
+File "./output/InvalidDisjunctiveIntro.v", line 13, characters 2-52:
 The command has indeed failed with message:
 Disjunctive/conjunctive introduction pattern expected.
 File "./output/InvalidDisjunctiveIntro.v", line 15, characters 50-52:

--- a/test-suite/output/Load.out
+++ b/test-suite/output/Load.out
@@ -2,5 +2,6 @@ f = 2
      : nat
 u = I
      : True
+File "./output/Load.v", line 7, characters 0-41:
 The command has indeed failed with message:
 Files processed by Load cannot leave open proofs.

--- a/test-suite/output/Notations.out
+++ b/test-suite/output/Notations.out
@@ -43,18 +43,21 @@ fun x : nat => ifn x is succ n then n else 0
 File "./output/Notations.v", line 139, characters 46-62:
 The command has indeed failed with message:
 Cannot find where the recursive pattern starts.
+File "./output/Notations.v", line 142, characters 0-58:
 The command has indeed failed with message:
 in the right-hand side, y and z should appear in
 term position as part of a recursive pattern.
 File "./output/Notations.v", line 145, characters 57-58:
 The command has indeed failed with message:
 The reference w was not found in the current environment.
+File "./output/Notations.v", line 151, characters 0-78:
 The command has indeed failed with message:
 in the right-hand side, y and z should appear in
 term position as part of a recursive pattern.
 File "./output/Notations.v", line 152, characters 56-57:
 The command has indeed failed with message:
 z is expected to occur in binding position in the right-hand side.
+File "./output/Notations.v", line 156, characters 0-102:
 The command has indeed failed with message:
 as y is a non-closed binder, no such "," is allowed to occur.
 File "./output/Notations.v", line 160, characters 46-69:
@@ -69,7 +72,7 @@ Cannot find where the recursive pattern starts.
 File "./output/Notations.v", line 163, characters 50-64:
 The command has indeed failed with message:
 Cannot find where the recursive pattern starts.
-Toplevel input, characters 4941-4955:
+File "./output/Notations.v", line 166, characters 0-73:
 The command has indeed failed with message:
 Both ends of the recursive pattern are the same.
 SUM (nat * nat) nat

--- a/test-suite/output/NumberNotations.out
+++ b/test-suite/output/NumberNotations.out
@@ -87,6 +87,7 @@ File "./output/NumberNotations.v", line 203, characters 2-71:
 Warning: The 'abstract after' directive has no effect when the parsing
 function (of_uint) targets an option type.
 [abstract-large-number-no-op,numbers]
+File "./output/NumberNotations.v", line 206, characters 2-77:
 The command has indeed failed with message:
 The 'abstract after' directive has no effect when the parsing function
 (of_uint) targets an option type. [abstract-large-number-no-op,numbers]
@@ -131,6 +132,7 @@ v := 0 : nat
 The term "v" has type "nat" while it is expected to have type "unit".
 let v := 0%test14' in v : unit
      : unit
+File "./output/NumberNotations.v", line 273, characters 4-71:
 The command has indeed failed with message:
 This command does not support the Global option in sections.
 let v := 0%test14'' in v : unit
@@ -270,6 +272,7 @@ sum unit unit
      : Set
 sum unit (sum unit unit)
      : Set
+File "./output/NumberNotations.v", line 546, characters 0-112:
 The command has indeed failed with message:
 Missing mapping for constructor Isum.
 File "./output/NumberNotations.v", line 552, characters 68-73:
@@ -281,6 +284,7 @@ add is not an inductive type.
 File "./output/NumberNotations.v", line 562, characters 40-43:
 The command has indeed failed with message:
 add is not a constructor of an inductive type.
+File "./output/NumberNotations.v", line 566, characters 0-103:
 The command has indeed failed with message:
 Missing mapping for constructor Iempty.
 File "./output/NumberNotations.v", line 580, characters 56-61:
@@ -297,6 +301,7 @@ Warning: Type of Iunit seems incompatible with the type of O.
 Expected type is: I instead of I.
 This might yield ill typed terms when using the notation.
 [via-type-mismatch,numbers]
+File "./output/NumberNotations.v", line 589, characters 0-146:
 The command has indeed failed with message:
 'via' and 'abstract' cannot be used together.
 File "./output/NumberNotations.v", line 665, characters 21-23:

--- a/test-suite/output/Partac.out
+++ b/test-suite/output/Partac.out
@@ -1,6 +1,8 @@
+File "./output/Partac.v", line 4, characters 2-24:
 The command has indeed failed with message:
 The term "false" has type "bool" while it is expected to have type "nat".
 (for goal 1)
+File "./output/Partac.v", line 5, characters 2-20:
 The command has indeed failed with message:
 The term "0" has type "nat" while it is expected to have type "bool".
 (for goal 2)

--- a/test-suite/output/ProofUsingClashWarning.out
+++ b/test-suite/output/ProofUsingClashWarning.out
@@ -5,6 +5,7 @@ clashing_name was already a defined Variable, the name clashing_name will refer 
 File "./output/ProofUsingClashWarning.v", line 6, characters 2-39:
 Warning: New Collection definition of redefined_col shadows the previous one.
 [collection-redefinition,deprecated]
+File "./output/ProofUsingClashWarning.v", line 8, characters 2-34:
 The command has indeed failed with message:
 "All" is a predefined collection containing all variables. It can't be redefined.
 File "./output/ProofUsingClashWarning.v", line 11, characters 2-28:

--- a/test-suite/output/RecordMissingField.out
+++ b/test-suite/output/RecordMissingField.out
@@ -1,9 +1,11 @@
+File "./output/RecordMissingField.v", line 6, characters 0-80:
 The command has indeed failed with message:
 The following term contains unresolved implicit arguments:
   (fun p : point2d => {| x2p := x2p p + 1; y2p := ?y2p |})
 More precisely: 
 - ?y2p: Cannot infer field y2p of record point2d in environment:
   p : point2d
+File "./output/RecordMissingField.v", line 11, characters 0-93:
 The command has indeed failed with message:
 The following term contains unresolved implicit arguments:
   (fun p : point2d => {| x2p := x2p p + (fun n : nat => ?n) 1; y2p := ?y2p |})

--- a/test-suite/output/SchemeNames.out
+++ b/test-suite/output/SchemeNames.out
@@ -1,7 +1,10 @@
+File "./output/SchemeNames.v", line 14, characters 2-47:
 The command has indeed failed with message:
 Induction on sort Prop is not allowed for inductive definition fooSProp.
+File "./output/SchemeNames.v", line 15, characters 2-46:
 The command has indeed failed with message:
 Induction on sort Set is not allowed for inductive definition fooSProp.
+File "./output/SchemeNames.v", line 16, characters 2-47:
 The command has indeed failed with message:
 Induction on sort Type is not allowed for inductive definition fooSProp.
 fooSProp_inds :
@@ -11,10 +14,13 @@ fooSProp_inds is not universe polymorphic
 Arguments fooSProp_inds P%function_scope f f f
 fooSProp_inds is transparent
 Expands to: Constant SchemeNames.fooSProp_inds
+File "./output/SchemeNames.v", line 23, characters 2-48:
 The command has indeed failed with message:
 Induction on sort Prop is not allowed for inductive definition fooSProp.
+File "./output/SchemeNames.v", line 24, characters 2-47:
 The command has indeed failed with message:
 Induction on sort Set is not allowed for inductive definition fooSProp.
+File "./output/SchemeNames.v", line 25, characters 2-48:
 The command has indeed failed with message:
 Induction on sort Type is not allowed for inductive definition fooSProp.
 fooSProp_inds_nodep : forall P : SProp, P -> P -> fooSProp -> P
@@ -23,10 +29,13 @@ fooSProp_inds_nodep is not universe polymorphic
 Arguments fooSProp_inds_nodep P%type_scope f f f
 fooSProp_inds_nodep is transparent
 Expands to: Constant SchemeNames.fooSProp_inds_nodep
+File "./output/SchemeNames.v", line 32, characters 2-49:
 The command has indeed failed with message:
 Induction on sort Prop is not allowed for inductive definition fooSProp.
+File "./output/SchemeNames.v", line 33, characters 2-48:
 The command has indeed failed with message:
 Induction on sort Set is not allowed for inductive definition fooSProp.
+File "./output/SchemeNames.v", line 34, characters 2-49:
 The command has indeed failed with message:
 Induction on sort Type is not allowed for inductive definition fooSProp.
 fooSProp_cases :
@@ -36,10 +45,13 @@ fooSProp_cases is not universe polymorphic
 Arguments fooSProp_cases P%function_scope f f f
 fooSProp_cases is transparent
 Expands to: Constant SchemeNames.fooSProp_cases
+File "./output/SchemeNames.v", line 41, characters 2-42:
 The command has indeed failed with message:
 Induction on sort Prop is not allowed for inductive definition fooSProp.
+File "./output/SchemeNames.v", line 42, characters 2-41:
 The command has indeed failed with message:
 Induction on sort Set is not allowed for inductive definition fooSProp.
+File "./output/SchemeNames.v", line 43, characters 2-42:
 The command has indeed failed with message:
 Induction on sort Type is not allowed for inductive definition fooSProp.
 fooSProp_cases_nodep : forall P : SProp, P -> P -> fooSProp -> P
@@ -48,11 +60,14 @@ fooSProp_cases_nodep is not universe polymorphic
 Arguments fooSProp_cases_nodep P%type_scope f f f
 fooSProp_cases_nodep is transparent
 Expands to: Constant SchemeNames.fooSProp_cases_nodep
+File "./output/SchemeNames.v", line 49, characters 2-36:
 The command has indeed failed with message:
 Cannot extract computational content from proposition 
 "fooSProp".
+File "./output/SchemeNames.v", line 61, characters 2-45:
 The command has indeed failed with message:
 Induction on sort Set is not allowed for inductive definition fooProp.
+File "./output/SchemeNames.v", line 62, characters 2-46:
 The command has indeed failed with message:
 Induction on sort Type is not allowed for inductive definition fooProp.
 fooProp_inds_dep :
@@ -69,8 +84,10 @@ fooProp_ind_dep is not universe polymorphic
 Arguments fooProp_ind_dep P%function_scope f f f
 fooProp_ind_dep is transparent
 Expands to: Constant SchemeNames.fooProp_ind_dep
+File "./output/SchemeNames.v", line 71, characters 2-46:
 The command has indeed failed with message:
 Induction on sort Set is not allowed for inductive definition fooProp.
+File "./output/SchemeNames.v", line 72, characters 2-47:
 The command has indeed failed with message:
 Induction on sort Type is not allowed for inductive definition fooProp.
 fooProp_inds : forall P : SProp, P -> P -> fooProp -> P
@@ -85,8 +102,10 @@ fooProp_ind is not universe polymorphic
 Arguments fooProp_ind P%type_scope f f f
 fooProp_ind is transparent
 Expands to: Constant SchemeNames.fooProp_ind
+File "./output/SchemeNames.v", line 81, characters 2-47:
 The command has indeed failed with message:
 Induction on sort Set is not allowed for inductive definition fooProp.
+File "./output/SchemeNames.v", line 82, characters 2-48:
 The command has indeed failed with message:
 Induction on sort Type is not allowed for inductive definition fooProp.
 fooProp_cases_dep :
@@ -103,8 +122,10 @@ fooProp_case_dep is not universe polymorphic
 Arguments fooProp_case_dep P%function_scope f f f
 fooProp_case_dep is transparent
 Expands to: Constant SchemeNames.fooProp_case_dep
+File "./output/SchemeNames.v", line 91, characters 2-40:
 The command has indeed failed with message:
 Induction on sort Set is not allowed for inductive definition fooProp.
+File "./output/SchemeNames.v", line 92, characters 2-41:
 The command has indeed failed with message:
 Induction on sort Type is not allowed for inductive definition fooProp.
 fooProp_cases : forall P : SProp, P -> P -> fooProp -> P
@@ -119,6 +140,7 @@ fooProp_case is not universe polymorphic
 Arguments fooProp_case P%type_scope f f f
 fooProp_case is transparent
 Expands to: Constant SchemeNames.fooProp_case
+File "./output/SchemeNames.v", line 99, characters 2-35:
 The command has indeed failed with message:
 Cannot extract computational content from proposition 
 "fooProp".

--- a/test-suite/output/Search.out
+++ b/test-suite/output/Search.out
@@ -278,10 +278,13 @@ h: n <> newdef n
 h: n <> newdef n
 h: n <> newdef n
 h': newdef n <> n
+File "./output/Search.v", line 23, characters 2-23:
 The command has indeed failed with message:
 [Focus] No such goal.
+File "./output/Search.v", line 24, characters 2-25:
 The command has indeed failed with message:
 Query commands only support the single numbered goal selector.
+File "./output/Search.v", line 25, characters 2-25:
 The command has indeed failed with message:
 Query commands only support the single numbered goal selector.
 h: P n

--- a/test-suite/output/UnivBinders.out
+++ b/test-suite/output/UnivBinders.out
@@ -55,6 +55,7 @@ mono
      : Type@{mono.uu+1}
 Type@{mono.uu}
      : Type@{mono.uu+1}
+File "./output/UnivBinders.v", line 50, characters 2-31:
 The command has indeed failed with message:
 Universe uu already exists.
 monomono
@@ -65,6 +66,7 @@ monomono
      : Type@{MONOU+1}
 mono
      : Type@{mono.uu+1}
+File "./output/UnivBinders.v", line 70, characters 0-52:
 The command has indeed failed with message:
 Universe uu already exists.
 bobmorane = 
@@ -97,12 +99,16 @@ punwrap is universe polymorphic
 Arguments punwrap A%type_scope p
 punwrap is transparent
 Expands to: Constant UnivBinders.punwrap
+File "./output/UnivBinders.v", line 100, characters 0-19:
 The command has indeed failed with message:
 Universe instance length is 3 but should be 1.
+File "./output/UnivBinders.v", line 101, characters 0-20:
 The command has indeed failed with message:
 Universe instance length is 0 but should be 1.
+File "./output/UnivBinders.v", line 104, characters 0-30:
 The command has indeed failed with message:
 This object does not support universe names.
+File "./output/UnivBinders.v", line 108, characters 0-49:
 The command has indeed failed with message:
 Cannot enforce v < u because u < gU < gV < v
 insec@{v} = Type@{uu} -> Type@{v}

--- a/test-suite/output/bug5778.out
+++ b/test-suite/output/bug5778.out
@@ -1,4 +1,4 @@
-File "./output/bug5778.v", line 2, characters 22-23:
+File "./output/bug5778.v", line 7, characters 2-12:
 The command has indeed failed with message:
 In nested Ltac calls to "c", "abs", "abstract b ltac:(())", 
 "b", "a", "pose (I : I)" and "(I : I)", last term evaluation failed.

--- a/test-suite/output/bug6404.out
+++ b/test-suite/output/bug6404.out
@@ -1,4 +1,4 @@
-File "./output/bug6404.v", line 2, characters 22-23:
+File "./output/bug6404.v", line 7, characters 2-12:
 The command has indeed failed with message:
 In nested Ltac calls to "c", "abs", "transparent_abstract (tactic3)", 
 "b", "a", "pose (I : I)" and "(I : I)", last term evaluation failed.

--- a/test-suite/output/bug_12887.out
+++ b/test-suite/output/bug_12887.out
@@ -5,6 +5,7 @@ environment:
 Functor : (Type -> Type) -> Type
 F : Type -> Type
 fmap : forall A B : Type, (A -> B) -> F A -> F B
+File "./output/bug_12887.v", line 8, characters 0-53:
 The command has indeed failed with message:
 Cannot infer an existential variable of type "nat" in
 environment:

--- a/test-suite/output/bug_13320.out
+++ b/test-suite/output/bug_13320.out
@@ -1,2 +1,3 @@
+File "./output/bug_13320.v", line 2, characters 0-21:
 The command has indeed failed with message:
 No obligations remaining

--- a/test-suite/output/bug_13942.out
+++ b/test-suite/output/bug_13942.out
@@ -1,3 +1,4 @@
+File "./output/bug_13942.v", line 102, characters 2-34:
 The command has indeed failed with message:
 The following term contains unresolved implicit arguments:
   (fi fu)
@@ -35,6 +36,7 @@ More precisely:
   i : Union (M A)
   i' : Union (M B)
   fi' : Insert K B (M B)
+File "./output/bug_13942.v", line 106, characters 2-39:
 The command has indeed failed with message:
 The following term contains unresolved implicit arguments:
   (fi fu)
@@ -50,6 +52,7 @@ More precisely:
   i : Union (M A)
   i' : Union (M B)
   fi' : Insert K B (M B)
+File "./output/bug_13942.v", line 120, characters 2-34:
 The command has indeed failed with message:
 The following term contains unresolved implicit arguments:
   (fi fu)
@@ -87,6 +90,7 @@ More precisely:
   i' : Union (M B)
   fi' : Insert K B (M B)
   i : Union (M A)
+File "./output/bug_13942.v", line 124, characters 2-40:
 The command has indeed failed with message:
 The following term contains unresolved implicit arguments:
   (fi fu)
@@ -102,6 +106,7 @@ More precisely:
   i' : Union (M B)
   fi' : Insert K B (M B)
   i : Union (M A)
+File "./output/bug_13942.v", line 140, characters 2-20:
 The command has indeed failed with message:
 Unable to satisfy the following constraints:
 In environment:
@@ -119,6 +124,7 @@ i : Choose false -> Union (M A)
 
 ?hu : "Union (M ?A)"
 
+File "./output/bug_13942.v", line 145, characters 2-24:
 The command has indeed failed with message:
 Unable to satisfy the following constraints:
 In environment:
@@ -136,6 +142,7 @@ i : Choose false -> Union (M A)
 
 fi fu : B
      : B
+File "./output/bug_13942.v", line 305, characters 2-126:
 The command has indeed failed with message:
 Unable to satisfy the following constraints:
 In environment:

--- a/test-suite/output/bug_15097.out
+++ b/test-suite/output/bug_15097.out
@@ -1,5 +1,7 @@
+File "./output/bug_15097.v", line 1, characters 0-39:
 The command has indeed failed with message:
 Cannot find a physical path bound to logical path Coq.Does.Not.Exist.
+File "./output/bug_15097.v", line 2, characters 0-44:
 The command has indeed failed with message:
 Cannot find a physical path bound to logical path
 Does.Not.Exist with prefix Coq.

--- a/test-suite/output/bug_15106.out
+++ b/test-suite/output/bug_15106.out
@@ -1,2 +1,3 @@
+File "./output/bug_15106.v", line 7, characters 0-18:
 The command has indeed failed with message:
 Obligation 2 already solved.

--- a/test-suite/output/bug_8206.out
+++ b/test-suite/output/bug_8206.out
@@ -1,3 +1,4 @@
+File "./output/bug_8206.v", line 11, characters 0-28:
 The command has indeed failed with message:
 Signature components for label homework do not match: expected type
 "forall a b : nat, bug_8206.M.add a b = bug_8206.M.add b a" but found type

--- a/test-suite/output/ltac.out
+++ b/test-suite/output/ltac.out
@@ -4,29 +4,31 @@ Ltac variable y depends on pattern variable name z which is not bound in current
 Ltac f x y z :=
   symmetry in x, y; auto with z; auto; intros; clearbody x; generalize
    dependent z
-File "./output/ltac.v", line 33, characters 20-21:
+File "./output/ltac.v", line 38, characters 0-10:
 The command has indeed failed with message:
 In nested Ltac calls to "g1" and "refine (uconstr)", last call failed.
 The term "I" has type "True" while it is expected to have type "False".
-File "./output/ltac.v", line 35, characters 41-42:
+File "./output/ltac.v", line 39, characters 0-10:
 The command has indeed failed with message:
 In nested Ltac calls to "f1 (constr)" and "refine (uconstr)", last call
 failed.
 The term "I" has type "True" while it is expected to have type "False".
-File "./output/ltac.v", line 33, characters 20-21:
+File "./output/ltac.v", line 40, characters 0-10:
 The command has indeed failed with message:
 In nested Ltac calls to "g2 (constr)", "g1" and "refine (uconstr)", last call
 failed.
 The term "I" has type "True" while it is expected to have type "False".
-File "./output/ltac.v", line 35, characters 41-42:
+File "./output/ltac.v", line 41, characters 0-10:
 The command has indeed failed with message:
 In nested Ltac calls to "f2", "f1 (constr)" and "refine (uconstr)", last call
 failed.
 The term "I" has type "True" while it is expected to have type "False".
+File "./output/ltac.v", line 46, characters 0-9:
 The command has indeed failed with message:
 In nested Ltac calls to "h" and "injection (destruction_arg)", last call
 failed.
 No primitive equality found.
+File "./output/ltac.v", line 48, characters 0-9:
 The command has indeed failed with message:
 In nested Ltac calls to "h" and "injection (destruction_arg)", last call
 failed.

--- a/test-suite/output/ltac_extra_args.out
+++ b/test-suite/output/ltac_extra_args.out
@@ -1,8 +1,12 @@
+File "./output/ltac_extra_args.v", line 6, characters 2-13:
 The command has indeed failed with message:
 Illegal tactic application: got 1 extra argument.
+File "./output/ltac_extra_args.v", line 7, characters 2-16:
 The command has indeed failed with message:
 Illegal tactic application: got 2 extra arguments.
+File "./output/ltac_extra_args.v", line 8, characters 2-16:
 The command has indeed failed with message:
 Illegal tactic application: got 1 extra argument.
+File "./output/ltac_extra_args.v", line 9, characters 2-20:
 The command has indeed failed with message:
 Illegal tactic application: got 2 extra arguments.

--- a/test-suite/output/ltac_missing_args.out
+++ b/test-suite/output/ltac_missing_args.out
@@ -1,39 +1,49 @@
+File "./output/ltac_missing_args.v", line 11, characters 2-11:
 The command has indeed failed with message:
 The user-defined tactic "foo" was not fully applied:
 There is a missing argument for variable x,
 no arguments at all were provided.
+File "./output/ltac_missing_args.v", line 12, characters 2-11:
 The command has indeed failed with message:
 The user-defined tactic "bar" was not fully applied:
 There is a missing argument for variable x,
 no arguments at all were provided.
+File "./output/ltac_missing_args.v", line 13, characters 2-16:
 The command has indeed failed with message:
 The user-defined tactic "bar" was not fully applied:
 There are missing arguments for variables y and _,
 an argument was provided for variable x.
+File "./output/ltac_missing_args.v", line 14, characters 2-11:
 The command has indeed failed with message:
 The user-defined tactic "baz" was not fully applied:
 There is a missing argument for variable x,
 no arguments at all were provided.
+File "./output/ltac_missing_args.v", line 15, characters 2-11:
 The command has indeed failed with message:
 The user-defined tactic "qux" was not fully applied:
 There is a missing argument for variable x,
 no arguments at all were provided.
+File "./output/ltac_missing_args.v", line 16, characters 2-36:
 The command has indeed failed with message:
 The user-defined tactic "mydo" was not fully applied:
 There is a missing argument for variable _,
 no arguments at all were provided.
+File "./output/ltac_missing_args.v", line 17, characters 2-42:
 The command has indeed failed with message:
 An unnamed user-defined tactic was not fully applied:
 There is a missing argument for variable _,
 no arguments at all were provided.
+File "./output/ltac_missing_args.v", line 18, characters 2-24:
 The command has indeed failed with message:
 An unnamed user-defined tactic was not fully applied:
 There is a missing argument for variable _,
 no arguments at all were provided.
+File "./output/ltac_missing_args.v", line 19, characters 2-16:
 The command has indeed failed with message:
 The user-defined tactic "rec" was not fully applied:
 There is a missing argument for variable x,
 no arguments at all were provided.
+File "./output/ltac_missing_args.v", line 20, characters 2-40:
 The command has indeed failed with message:
 An unnamed user-defined tactic was not fully applied:
 There is a missing argument for variable x,

--- a/test-suite/output/undeclared_key.out
+++ b/test-suite/output/undeclared_key.out
@@ -1,13 +1,18 @@
+File "./output/undeclared_key.v", line 1, characters 0-28:
 The command has indeed failed with message:
 There is no flag, option or table with this name: "Search Blacklists".
+File "./output/undeclared_key.v", line 2, characters 0-35:
 The command has indeed failed with message:
 There is no qualid-valued table with this name: "Search Blacklist".
 File "./output/undeclared_key.v", line 3, characters 0-22:
 Warning: There is no flag or option with this name: "Search Blacklists".
 [unknown-option,option]
+File "./output/undeclared_key.v", line 4, characters 0-40:
 The command has indeed failed with message:
 There is no string-valued table with this name: "Search Blacklists".
+File "./output/undeclared_key.v", line 5, characters 0-39:
 The command has indeed failed with message:
 There is no qualid-valued table with this name: "Search Blacklist".
+File "./output/undeclared_key.v", line 6, characters 0-36:
 The command has indeed failed with message:
 There is no qualid-valued table with this name: "Search Blacklist".

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -76,16 +76,20 @@ let with_fail f : (Loc.t option * Pp.t, unit) result =
     let _, info as e = Exninfo.capture e in
     Ok (Loc.get_loc info, CErrors.iprint e)
 
+let real_error_loc ~cmdloc ~eloc =
+  if Loc.finer eloc cmdloc then eloc
+  else cmdloc
+
 (* We restore the state always *)
-let with_fail ~st f =
+let with_fail ~loc ~st f =
   let res = with_fail f in
   Vernacstate.invalidate_cache ();
   Vernacstate.unfreeze_interp_state st;
   match res with
   | Error () ->
     CErrors.user_err (Pp.str "The command has not failed!")
-  | Ok (loc, msg) ->
-    let loc = if !test_mode then loc else None in
+  | Ok (eloc, msg) ->
+    let loc = if !test_mode then real_error_loc ~cmdloc:loc ~eloc else None in
     if not !Flags.quiet || !test_mode
     then Feedback.msg_notice ?loc Pp.(str "The command has indeed failed with message:" ++ fnl () ++ msg)
 
@@ -97,9 +101,7 @@ let with_succeed ~st f =
   then Feedback.msg_notice Pp.(str "The command has succeeded and its effects have been reverted.")
 
 let locate_if_not_already ?loc (e, info) =
-  match Loc.get_loc info with
-  | None   -> (e, Option.cata (Loc.add_loc info) info loc)
-  | Some l -> (e, info)
+  (e, Option.cata (Loc.add_loc info) info (real_error_loc ~cmdloc:loc ~eloc:(Loc.get_loc info)))
 
 let mk_time_header =
   (* Drop the time header to print the command, we should indeed use a
@@ -115,11 +117,11 @@ let mk_time_header =
   in
   fun vernac -> Lazy.from_fun (fun () -> pr_time_header vernac)
 
-let interp_control_flag ~time_header (f : control_flag) ~st
+let interp_control_flag ~loc ~time_header (f : control_flag) ~st
     (fn : st:Vernacstate.t -> Vernacstate.LemmaStack.t option * Declare.OblState.t NeList.t) =
   match f with
   | ControlFail ->
-    with_fail ~st (fun () -> fn ~st);
+    with_fail ~loc ~st (fun () -> fn ~st);
     st.Vernacstate.lemmas, st.Vernacstate.program
   | ControlSucceed ->
     with_succeed ~st (fun () -> fn ~st);
@@ -194,7 +196,7 @@ and vernac_load ~verbosely fname =
 
 and interp_control ~st ({ CAst.v = cmd; loc } as vernac) =
   let time_header = mk_time_header vernac in
-  List.fold_right (fun flag fn -> interp_control_flag ~time_header flag fn)
+  List.fold_right (fun flag fn -> interp_control_flag ~loc ~time_header flag fn)
     cmd.control
     (fun ~st ->
        let before_univs = Global.universes () in
@@ -230,7 +232,7 @@ let interp_qed_delayed ~proof ~st pe =
 
 let interp_qed_delayed_control ~proof ~st ~control { CAst.loc; v=pe } =
   let time_header = mk_time_header (CAst.make ?loc { control; attrs = []; expr = VernacEndProof pe }) in
-  List.fold_right (fun flag fn -> interp_control_flag ~time_header flag fn)
+  List.fold_right (fun flag fn -> interp_control_flag ~loc ~time_header flag fn)
     control
     (fun ~st -> interp_qed_delayed ~proof ~st pe)
     ~st

--- a/vernac/vernacinterp.mli
+++ b/vernac/vernacinterp.mli
@@ -20,9 +20,6 @@ val interp_qed_delayed_proof
   -> Vernacexpr.proof_end CAst.t
   -> Vernacstate.t
 
-(** [with_fail ~st f] runs [f ()] and expects it to fail, otherwise it fails. *)
-val with_fail : st:Vernacstate.t -> (unit -> 'a) -> unit
-
 (** Flag set when the test-suite is called. Its only effect to display
     verbose information for [Fail] *)
 val test_mode : bool ref


### PR DESCRIPTION
Fix #15298

Why did we expose Vernacinterp.with_fail?
