### PR TITLE
When "change" is applied to terms of incompatible types, tell which they are

### DIFF
--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -80,7 +80,7 @@ exception ReplacingDependency of env * evar_map * Id.t * Evarutil.clear_dependen
 exception AlreadyUsed of Id.t
 exception UsedTwice of Id.t
 exception VariableHasNoValue of Id.t
-exception ConvertIncompatibleTypes
+exception ConvertIncompatibleTypes of env * evar_map * constr * constr
 exception ConvertNotAType
 exception NotConvertible
 exception NotUnfoldable
@@ -199,8 +199,11 @@ let tactic_interp_error_handler = function
       Id.print id ++ str" is used twice."
   | VariableHasNoValue id ->
       Id.print id ++ str" is not a defined hypothesis."
-  | ConvertIncompatibleTypes ->
-      str "Types are incompatible."
+  | ConvertIncompatibleTypes (env,sigma,t1,t2) ->
+      str "The first term has type" ++ spc () ++
+      quote (Termops.Internal.print_constr_env env sigma t1) ++ spc () ++
+      strbrk "while the second term has incompatible type" ++ spc () ++
+      quote (Termops.Internal.print_constr_env env sigma t2) ++ str "."
   | ConvertNotAType ->
       str "Not a type."
   | NotConvertible ->
@@ -889,7 +892,7 @@ let check_types env sigma mayneedglobalcheck deep newc origc =
         isSort sigma (whd_all env sigma t2)
       then (mayneedglobalcheck := true; sigma)
       else
-        error ConvertIncompatibleTypes
+        error (ConvertIncompatibleTypes (env,sigma,t2,t1))
     | Some sigma -> sigma
   end
   else

--- a/test-suite/output/Errors.out
+++ b/test-suite/output/Errors.out
@@ -23,3 +23,6 @@ The command has indeed failed with message:
 Cannot infer ?T in the partial instance "forall x : nat, ?T" found for the
 type of f in environment:
 x : nat
+The command has indeed failed with message:
+The first term has type "nat" while the second term has incompatible type
+"bool".

--- a/test-suite/output/Errors.v
+++ b/test-suite/output/Errors.v
@@ -37,3 +37,11 @@ Fail Goal forall f P,  P (f 0).
 
 Definition t := unit.
 End M.
+
+Module Change.
+
+Goal 0 = 0.
+Fail change 0 with true.
+Abort.
+
+End Change.


### PR DESCRIPTION
**Kind:** Enhancement

(Thanks to tactic errors being in an algebraic type, printing of the terms is done only when really needed.)

Short example:
```
Goal 0 = 0.
Fail change 0 with true.
(* The first term has type "nat" while the second term has incompatible type "bool". *)
```

- [x] Added / updated **test-suite**.
