### PR TITLE
Remove the legacy qualifier for ARGUMENT EXTEND

### DIFF
--- a/coqpp/coqpp_main.ml
+++ b/coqpp/coqpp_main.ml
@@ -578,8 +578,6 @@ let print_ast fmt arg =
   let interp fmt () = match arg.argext_interp, arg.argext_type with
   | Some (None, f), (None | Some _) ->
     fprintf fmt "@[Tacentries.ArgInterpSimple (%a)@]" print_code f
-  | Some (Some "legacy", f), (None | Some _) ->
-    fprintf fmt "@[Tacentries.ArgInterpLegacy (%a)@]" print_code f
   | Some (Some kind, f), (None | Some _) ->
     fatal (Printf.sprintf "Unknown kind %s of interpretation function" kind)
   | None, Some t ->

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -849,8 +849,6 @@ type ('b, 'c) argument_interp =
 | ArgInterpWit : ('a, 'b, 'r) Genarg.genarg_type -> ('b, 'c) argument_interp
 | ArgInterpSimple :
   (Geninterp.interp_sign -> Environ.env -> Evd.evar_map -> 'b -> 'c) -> ('b, 'c) argument_interp
-| ArgInterpLegacy :
-  (Geninterp.interp_sign -> Goal.goal Evd.sigma -> 'b -> Evd.evar_map * 'c) -> ('b, 'c) argument_interp
 
 type ('a, 'b, 'c) tactic_argument = {
   arg_parsing : 'a Vernacextend.argument_rule;
@@ -890,12 +888,6 @@ match arg.arg_interp with
     let v = f ist env sigma v in
     Ftactic.return (Geninterp.Val.inject tag v)
   end)
-| ArgInterpLegacy f ->
-  (fun ist v -> Ftactic.enter (fun gl ->
-    let (sigma, v) = Tacmach.of_old (fun gl -> f ist gl v) gl in
-    let v = Geninterp.Val.inject tag v in
-    Proofview.tclTHEN (Proofview.Unsafe.tclEVARS sigma) (Ftactic.return v)
-  ))
 
 let argument_extend (type a b c) ~name (arg : (a, b, c) tactic_argument) =
   let wit = Genarg.create_arg name in

--- a/plugins/ltac/tacentries.mli
+++ b/plugins/ltac/tacentries.mli
@@ -158,8 +158,6 @@ type ('b, 'c) argument_interp =
 | ArgInterpWit : ('a, 'b, 'r) Genarg.genarg_type -> ('b, 'c) argument_interp
 | ArgInterpSimple :
   (Geninterp.interp_sign -> Environ.env -> Evd.evar_map -> 'b -> 'c) -> ('b, 'c) argument_interp
-| ArgInterpLegacy :
-  (Geninterp.interp_sign -> Goal.goal Evd.sigma -> 'b -> Evd.evar_map * 'c) -> ('b, 'c) argument_interp
 
 type ('a, 'b, 'c) tactic_argument = {
   arg_parsing : 'a Vernacextend.argument_rule;

--- a/proofs/tacmach.mli
+++ b/proofs/tacmach.mli
@@ -89,8 +89,8 @@ end
 
 val pf_apply : (env -> evar_map -> 'a) -> Proofview.Goal.t -> 'a
 
-(** FIXME: encapsulate the level in an existential type. *)
 val of_old : (Goal.goal Evd.sigma -> 'a) -> Proofview.Goal.t -> 'a
+[@@ocaml.deprecated "Use the new engine"]
 
 val project : Proofview.Goal.t -> Evd.evar_map
 val pf_env : Proofview.Goal.t -> Environ.env


### PR DESCRIPTION
The only user recently was casted_constr, which was removed in favour of uconstr. So there is literally nobody out there relying on this API.

We also deprecate `Tacmach.of_old` which was only used by this piece of code.