### PR TITLE
Libobject/Lib name handling refactor

### DIFF
--- a/checker/values.ml
+++ b/checker/values.ml
@@ -390,7 +390,7 @@ and v_libobjt = Sum("Libobject.t",0,
      [| v_aobjs |];
      [| v_id; v_libobjs |];
      [| List (v_pair v_open_filter v_mp)|];
-     [| v_id; v_obj |]
+     [| v_obj |]
   |])
 
 and v_libobjs = List v_libobjt

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -387,7 +387,7 @@ and v_substobjs =
 and v_libobjt = Sum("Libobject.t",0,
   [| [| v_id; v_substobjs |];
      [| v_id; v_substobjs |];
-     [| v_id; v_aobjs |];
+     [| v_aobjs |];
      [| v_id; v_libobjs |];
      [| List (v_pair v_open_filter v_mp)|];
      [| v_id; v_obj |]

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -385,17 +385,15 @@ let rec v_aobjs = Sum("algebraic_objects", 0,
 and v_substobjs =
   Tuple("*", [|List v_uid;v_aobjs|])
 and v_libobjt = Sum("Libobject.t",0,
-  [| [| v_substobjs |];
-     [| v_substobjs |];
-     [| v_aobjs |];
-     [| v_libobjs |];
+  [| [| v_id; v_substobjs |];
+     [| v_id; v_substobjs |];
+     [| v_id; v_aobjs |];
+     [| v_id; v_libobjs |];
      [| List (v_pair v_open_filter v_mp)|];
-     [| v_obj |]
+     [| v_id; v_obj |]
   |])
 
-and v_libobj = Tuple ("libobj", [|v_id;v_libobjt|])
-
-and v_libobjs = List v_libobj
+and v_libobjs = List v_libobjt
 
 let v_libraryobjs = Tuple ("library_objects",[|v_libobjs;v_libobjs|])
 

--- a/dev/ci/ci-quickchick.sh
+++ b/dev/ci/ci-quickchick.sh
@@ -11,6 +11,7 @@ if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
 
 ( cd "${CI_BUILD_DIR}/quickchick"
   make
-  make install INSTALLDIR=$CI_INSTALL_DIR/bin
+  mkdir -p "$CI_INSTALL_DIR/bin"
+  make install INSTALLDIR="$CI_INSTALL_DIR/bin"
   make tests
 )

--- a/dev/ci/user-overlays/15317-SkySkimmer-libobject-names.sh
+++ b/dev/ci/user-overlays/15317-SkySkimmer-libobject-names.sh
@@ -1,0 +1,7 @@
+overlay elpi https://github.com/SkySkimmer/coq-elpi libobject-names 15317
+
+overlay equations https://github.com/SkySkimmer/Coq-Equations libobject-names 15317
+
+overlay paramcoq https://github.com/SkySkimmer/paramcoq libobject-names 15317
+
+overlay quickchick https://github.com/SkySkimmer/QuickChick libobject-names 15317

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -23,6 +23,7 @@ open Context
 open Genarg
 open Clenv
 
+let _ = Flags.in_debugger := true
 let _ = Detyping.print_evar_arguments := true
 let _ = Detyping.print_universes := true
 let _ = Goptions.set_bool_option_value ["Printing";"Matching"] false
@@ -631,6 +632,5 @@ let short_string_of_ref ?loc _ = let open GlobRef in function
 (* Anticipate that printers can be used from ocamldebug and that
    pretty-printer should not make calls to the global env since ocamldebug
    runs in a different process and does not have the proper env at hand *)
-let _ = Flags.in_debugger := true
 let _ = Constrextern.set_extern_reference
   (if !rawdebug then raw_string_of_ref else short_string_of_ref)

--- a/doc/plugin_tutorial/tuto2/src/persistent_counter.ml
+++ b/doc/plugin_tutorial/tuto2/src/persistent_counter.ml
@@ -14,7 +14,7 @@ let counter = Summary.ref ~name:"persistent_counter" 0
  * using Libobject.declare_object. To do that, we define a function that
  * saves the value that is passed to it into the reference we have just defined:
  *)
-let cache_count (_, v) =
+let cache_count v =
   counter := v
 
 (*

--- a/doc/plugin_tutorial/tuto2/src/persistent_counter.ml
+++ b/doc/plugin_tutorial/tuto2/src/persistent_counter.ml
@@ -43,10 +43,10 @@ let declare_counter : int -> Libobject.obj =
  * Incrementing our counter looks almost identical:
  *)
 let increment () =
-  Lib.add_anonymous_leaf (declare_counter (succ !counter))
+  Lib.add_leaf (declare_counter (succ !counter))
 (*
  * except that we must call our declare_counter function to get a persistent
- * object. We then pass this object to Lib.add_anonymous_leaf.
+ * object. We then pass this object to Lib.add_leaf.
  *)
 
 (*

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -733,9 +733,6 @@ interactively, they cannot be part of a Coq file loaded via
    declared object as well as the name of a section. One cannot reset
    over the name of a module or of an object inside a module.
 
-   .. exn:: @ident: no such entry.
-      :undocumented:
-
 .. cmd:: Reset Initial
 
    Goes back to the initial state, just after the start

--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -525,7 +525,7 @@ let implicits_of_global ref =
 let cache_implicits_decl (ref,imps) =
   implicits_table := GlobRef.Map.add ref imps !implicits_table
 
-let load_implicits _ (_,(_,l)) = List.iter cache_implicits_decl l
+let load_implicits _ (_,l) = List.iter cache_implicits_decl l
 
 let cache_implicits o =
   load_implicits 1 o

--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -16,7 +16,6 @@ open Constr
 open Globnames
 open Glob_term
 open Declarations
-open Lib
 open Libobject
 open EConstr
 open Reductionops
@@ -579,7 +578,7 @@ let discharge_implicits (req,l) =
      let l' =
        try
          List.map (fun (gr, l) ->
-             let vars = variable_section_segment_of_reference gr in
+             let vars = Lib.variable_section_segment_of_reference gr in
              let extra_impls = impls_of_context vars in
              let newimpls = List.map (add_section_impls vars extra_impls) l in
              (gr, newimpls)) l
@@ -605,7 +604,7 @@ let rebuild_implicits (req,l) =
 
   | ImplInteractive (flags,o) ->
       let ref,oldimpls = List.hd l in
-      (if isVarRef ref && is_in_section ref then ImplLocal else req),
+      (if isVarRef ref && Lib.is_in_section ref then ImplLocal else req),
       match o with
       | ImplAuto ->
          let newimpls = compute_global_implicits flags ref in
@@ -636,11 +635,11 @@ let inImplicits : implicits_obj -> obj =
     discharge_function = discharge_implicits;
     rebuild_function = rebuild_implicits }
 
-let is_local local ref = local || isVarRef ref && is_in_section ref
+let is_local local ref = local || isVarRef ref && Lib.is_in_section ref
 
 let declare_implicits_gen req flags ref =
   let imps = compute_global_implicits flags ref in
-  add_anonymous_leaf (inImplicits (req,[ref,imps]))
+  Lib.add_anonymous_leaf (inImplicits (req,[ref,imps]))
 
 let declare_implicits local ref =
   let flags = { !implicit_args with auto = true } in
@@ -662,7 +661,7 @@ let declare_mib_implicits kn =
   let imps = Array.map_to_list
     (fun (ind,cstrs) -> ind::(Array.to_list cstrs))
     (compute_mib_implicits flags kn) in
-    add_anonymous_leaf
+    Lib.add_anonymous_leaf
       (inImplicits (ImplMutualInductive (kn,flags),List.flatten imps))
 
 (* Declare manual implicits *)
@@ -702,7 +701,8 @@ let declare_manual_implicits local ref ?enriching l =
   let req =
     if is_local local ref then ImplLocal
     else ImplInteractive(flags,ImplManual (List.length autoimpls))
-  in add_anonymous_leaf (inImplicits (req,[ref,l]))
+  in
+  Lib.add_anonymous_leaf (inImplicits (req,[ref,l]))
 
 let maybe_declare_manual_implicits local ref ?enriching l =
   if List.exists (fun x -> x.CAst.v <> None) l then
@@ -752,7 +752,8 @@ let set_implicits local ref l =
   let req =
     if is_local local ref then ImplLocal
     else ImplInteractive(flags,ImplManual (List.length autoimpls))
-  in add_anonymous_leaf (inImplicits (req,[ref,l']))
+  in
+  Lib.add_anonymous_leaf (inImplicits (req,[ref,l']))
 
 let extract_impargs_data impls =
   let rec aux p = function

--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -618,9 +618,9 @@ let rebuild_implicits (req,l) =
          else
            [ref,oldimpls]
 
-let classify_implicits (req,_ as obj) = match req with
+let classify_implicits (req,_) = match req with
 | ImplLocal -> Dispose
-| _ -> Substitute obj
+| _ -> Substitute
 
 type implicits_obj =
     implicit_discharge_request *

--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -572,7 +572,7 @@ let add_section_impls vars extra_impls (cond,impls) =
   let p = List.length vars - List.length extra_impls in
   adjust_side_condition p cond, extra_impls @ List.map (Option.map (lift_implicits p)) impls
 
-let discharge_implicits (_,(req,l)) =
+let discharge_implicits (req,l) =
   match req with
   | ImplLocal -> None
   | ImplMutualInductive _ | ImplInteractive _ | ImplConstant _ ->

--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -639,7 +639,7 @@ let is_local local ref = local || isVarRef ref && Lib.is_in_section ref
 
 let declare_implicits_gen req flags ref =
   let imps = compute_global_implicits flags ref in
-  Lib.add_anonymous_leaf (inImplicits (req,[ref,imps]))
+  Lib.add_leaf (inImplicits (req,[ref,imps]))
 
 let declare_implicits local ref =
   let flags = { !implicit_args with auto = true } in
@@ -661,7 +661,7 @@ let declare_mib_implicits kn =
   let imps = Array.map_to_list
     (fun (ind,cstrs) -> ind::(Array.to_list cstrs))
     (compute_mib_implicits flags kn) in
-    Lib.add_anonymous_leaf
+    Lib.add_leaf
       (inImplicits (ImplMutualInductive (kn,flags),List.flatten imps))
 
 (* Declare manual implicits *)
@@ -702,7 +702,7 @@ let declare_manual_implicits local ref ?enriching l =
     if is_local local ref then ImplLocal
     else ImplInteractive(flags,ImplManual (List.length autoimpls))
   in
-  Lib.add_anonymous_leaf (inImplicits (req,[ref,l]))
+  Lib.add_leaf (inImplicits (req,[ref,l]))
 
 let maybe_declare_manual_implicits local ref ?enriching l =
   if List.exists (fun x -> x.CAst.v <> None) l then
@@ -753,7 +753,7 @@ let set_implicits local ref l =
     if is_local local ref then ImplLocal
     else ImplInteractive(flags,ImplManual (List.length autoimpls))
   in
-  Lib.add_anonymous_leaf (inImplicits (req,[ref,l']))
+  Lib.add_leaf (inImplicits (req,[ref,l']))
 
 let extract_impargs_data impls =
   let rec aux p = function

--- a/interp/implicit_quantifiers.ml
+++ b/interp/implicit_quantifiers.ml
@@ -58,7 +58,7 @@ let in_generalizable : bool * lident list option -> obj =
   }
 
 let declare_generalizable ~local gen =
- Lib.add_anonymous_leaf (in_generalizable (local, gen))
+ Lib.add_leaf (in_generalizable (local, gen))
 
 let find_generalizable_ident id = Id.Pred.mem (root_of_id id) !generalizable_table
 

--- a/interp/implicit_quantifiers.ml
+++ b/interp/implicit_quantifiers.ml
@@ -44,10 +44,10 @@ let add_generalizable gen table =
   | Some l -> List.fold_left (fun table lid -> declare_generalizable_ident table lid)
       table l
 
-let cache_generalizable_type (_,(local,cmd)) =
+let cache_generalizable_type (local,cmd) =
   generalizable_table := add_generalizable cmd !generalizable_table
 
-let load_generalizable_type _ (_,(local,cmd)) =
+let load_generalizable_type _ (local,cmd) =
   generalizable_table := add_generalizable cmd !generalizable_table
 
 let in_generalizable : bool * lident list option -> obj =

--- a/interp/implicit_quantifiers.ml
+++ b/interp/implicit_quantifiers.ml
@@ -54,7 +54,7 @@ let in_generalizable : bool * lident list option -> obj =
   declare_object {(default_object "GENERALIZED-IDENT") with
     load_function = load_generalizable_type;
     cache_function = cache_generalizable_type;
-    classify_function = (fun (local, _ as obj) -> if local then Dispose else Keep obj)
+    classify_function = (fun (local, _) -> if local then Dispose else Keep)
   }
 
 let declare_generalizable ~local gen =

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -243,7 +243,7 @@ let subst_scope (subst,sc) = sc
 
 open Libobject
 
-let discharge_scope (_,(local,_,_ as o)) =
+let discharge_scope (local,_,_ as o) =
   if local then None else Some o
 
 let classify_scope (local,_,_ as o) =
@@ -2046,7 +2046,7 @@ let subst_arguments_scope (subst,(req,r,n,scl,cls)) =
   let cls' = List.Smart.map subst_cl cls in
   (ArgsScopeNoDischarge,r',n,scl,cls')
 
-let discharge_arguments_scope (_,(req,r,n,l,_)) =
+let discharge_arguments_scope (req,r,n,l,_) =
   if req == ArgsScopeNoDischarge || (isVarRef r && Lib.is_in_section r) then None
   else
     let n =

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -246,8 +246,8 @@ open Libobject
 let discharge_scope (local,_,_ as o) =
   if local then None else Some o
 
-let classify_scope (local,_,_ as o) =
-  if local then Dispose else Substitute o
+let classify_scope (local,_,_) =
+  if local then Dispose else Substitute
 
 let inScope : bool * bool * scope_item -> obj =
   declare_object {(default_object "SCOPE") with
@@ -1360,7 +1360,7 @@ let subst_prim_token_interpretation (subs,infos) =
     pt_refs = List.map (subst_global_reference subs) infos.pt_refs }
 
 let classify_prim_token_interpretation infos =
-    if infos.pt_local then Dispose else Substitute infos
+    if infos.pt_local then Dispose else Substitute
 
 let open_prim_token_interpretation i o =
   if Int.equal i 1 then cache_prim_token_interpretation o
@@ -2057,8 +2057,8 @@ let discharge_arguments_scope (req,r,n,l,_) =
         Not_found (* Not a ref defined in this section *) -> 0 in
     Some (req,r,n,l,[])
 
-let classify_arguments_scope (req,_,_,_,_ as obj) =
-  if req == ArgsScopeNoDischarge then Dispose else Substitute obj
+let classify_arguments_scope (req,_,_,_,_) =
+  if req == ArgsScopeNoDischarge then Dispose else Substitute
 
 let rebuild_arguments_scope sigma (req,r,n,l,_) =
   match req with

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -230,7 +230,7 @@ let scope_is_open sc = scope_is_open_in_scopes sc (!scope_stack)
 (* TODO: push nat_scope, z_scope, ... in scopes summary *)
 
 (* Exportation of scopes *)
-let open_scope i (_,(local,op,sc)) =
+let open_scope i (local,op,sc) =
   if Int.equal i 1 then
     scope_stack :=
       if op then sc :: !scope_stack
@@ -1342,7 +1342,7 @@ let register_string_interpretation ?(allow_overwrite=false) uid (interp, uninter
   register_gen_interpretation allow_overwrite uid
     (InnerPrimToken.StringInterp interp, InnerPrimToken.StringUninterp uninterp)
 
-let cache_prim_token_interpretation (_,infos) =
+let cache_prim_token_interpretation infos =
   let ptii = infos.pt_interp_info in
   let sc = infos.pt_scope in
   check_scope ~tolerant:true sc;
@@ -2023,7 +2023,7 @@ type arguments_scope_discharge_request =
   | ArgsScopeManual
   | ArgsScopeNoDischarge
 
-let load_arguments_scope _ (_,(_,r,n,scl,cls)) =
+let load_arguments_scope _ (_,r,n,scl,cls) =
   List.iter (Option.iter check_scope) scl;
   let initial_stamp = ScopeClassMap.empty in
   arguments_scope := GlobRef.Map.add r (scl,cls,initial_stamp) !arguments_scope

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -258,7 +258,7 @@ let inScope : bool * bool * scope_item -> obj =
       classify_function = classify_scope }
 
 let open_close_scope (local,opening,sc) =
-  Lib.add_anonymous_leaf (inScope (local,opening,OpenScopeItem (normalize_scope sc)))
+  Lib.add_leaf (inScope (local,opening,OpenScopeItem (normalize_scope sc)))
 
 let empty_scope_stack = []
 
@@ -1373,7 +1373,7 @@ let inPrimTokenInterp : prim_token_infos -> obj =
      classify_function = classify_prim_token_interpretation}
 
 let enable_prim_token_interpretation infos =
-  Lib.add_anonymous_leaf (inPrimTokenInterp infos)
+  Lib.add_leaf (inPrimTokenInterp infos)
 
 (** Compatibility.
     Avoid the next two functions, they will now store unnecessary
@@ -2098,7 +2098,7 @@ let inArgumentsScope : arguments_scope_obj -> obj =
 let is_local local ref = local || isVarRef ref && Lib.is_in_section ref
 
 let declare_arguments_scope_gen req r n (scl,cls) =
-  Lib.add_anonymous_leaf (inArgumentsScope (req,r,n,scl,cls))
+  Lib.add_leaf (inArgumentsScope (req,r,n,scl,cls))
 
 let declare_arguments_scope local r scl =
   let req = if is_local local r then ArgsScopeNoDischarge else ArgsScopeManual in

--- a/interp/syntax_def.ml
+++ b/interp/syntax_def.ml
@@ -70,7 +70,7 @@ let subst_syntax_constant (subst,(local,syndef)) =
 let classify_syntax_constant (local,_) =
   if local then Dispose else Substitute
 
-let in_syntax_constant : (bool * syndef) -> obj =
+let in_syntax_constant : Id.t -> (bool * syndef) -> obj =
   declare_named_object {(default_object "SYNDEF") with
     cache_function = cache_syntax_constant;
     load_function = load_syntax_constant;
@@ -86,7 +86,7 @@ let declare_syntactic_definition ~local ?(also_in_cases_pattern=true) deprecatio
       syndef_also_in_cases_pattern = also_in_cases_pattern;
     }
   in
-  Lib.add_leaf id (in_syntax_constant (local,syndef))
+  Lib.add_leaf (in_syntax_constant id (local,syndef))
 
 let pr_syndef kn = pr_qualid (Nametab.shortest_qualid_of_syndef Id.Set.empty kn)
 

--- a/interp/syntax_def.ml
+++ b/interp/syntax_def.ml
@@ -87,7 +87,7 @@ let declare_syntactic_definition ~local ?(also_in_cases_pattern=true) deprecatio
       syndef_also_in_cases_pattern = also_in_cases_pattern;
     }
   in
-  let _ = add_leaf id (in_syntax_constant (local,syndef)) in ()
+  add_leaf id (in_syntax_constant (local,syndef))
 
 let pr_syndef kn = pr_qualid (Nametab.shortest_qualid_of_syndef Id.Set.empty kn)
 

--- a/interp/syntax_def.ml
+++ b/interp/syntax_def.ml
@@ -67,8 +67,8 @@ let subst_syntax_constant (subst,(local,syndef)) =
   let syndef_pattern = Notation_ops.subst_interpretation subst syndef.syndef_pattern in
   (local, { syndef with syndef_pattern })
 
-let classify_syntax_constant (local,_ as o) =
-  if local then Dispose else Substitute o
+let classify_syntax_constant (local,_) =
+  if local then Dispose else Substitute
 
 let in_syntax_constant : (bool * syndef) -> obj =
   declare_named_object {(default_object "SYNDEF") with

--- a/interp/syntax_def.ml
+++ b/interp/syntax_def.ml
@@ -71,7 +71,7 @@ let classify_syntax_constant (local,_ as o) =
   if local then Dispose else Substitute o
 
 let in_syntax_constant : (bool * syndef) -> obj =
-  declare_object {(default_object "SYNDEF") with
+  declare_named_object {(default_object "SYNDEF") with
     cache_function = cache_syntax_constant;
     load_function = load_syntax_constant;
     open_function = simple_open open_syntax_constant;

--- a/interp/syntax_def.ml
+++ b/interp/syntax_def.ml
@@ -13,7 +13,6 @@ open CErrors
 open Names
 open Libnames
 open Libobject
-open Lib
 open Notation_term
 
 (* Syntactic definitions. *)
@@ -87,7 +86,7 @@ let declare_syntactic_definition ~local ?(also_in_cases_pattern=true) deprecatio
       syndef_also_in_cases_pattern = also_in_cases_pattern;
     }
   in
-  add_leaf id (in_syntax_constant (local,syndef))
+  Lib.add_leaf id (in_syntax_constant (local,syndef))
 
 let pr_syndef kn = pr_qualid (Nametab.shortest_qualid_of_syndef Id.Set.empty kn)
 

--- a/library/coqlib.ml
+++ b/library/coqlib.ml
@@ -57,7 +57,7 @@ let lib_ref s =
 let add_ref s c =
   table := CString.Map.add s c !table
 
-let cache_ref (_,(s,c)) =
+let cache_ref (s,c) =
   add_ref s c
 
 let (inCoqlibRef : string * GlobRef.t -> Libobject.obj) =

--- a/library/coqlib.ml
+++ b/library/coqlib.ml
@@ -71,7 +71,7 @@ let (inCoqlibRef : string * GlobRef.t -> Libobject.obj) =
 
 (** Replaces a binding ! *)
 let register_ref s c =
-  Lib.add_anonymous_leaf @@ inCoqlibRef (s,c)
+  Lib.add_leaf @@ inCoqlibRef (s,c)
 
 (************************************************************************)
 (* Generic functions to find Coq objects *)

--- a/library/coqlib.ml
+++ b/library/coqlib.ml
@@ -65,7 +65,7 @@ let (inCoqlibRef : string * GlobRef.t -> Libobject.obj) =
   declare_object { (default_object "COQLIBREF") with
     cache_function = cache_ref;
     load_function = (fun _ x -> cache_ref x);
-    classify_function = (fun o -> Substitute o);
+    classify_function = (fun _ -> Substitute);
     subst_function = ident_subst_function;
     discharge_function = (fun sc -> Some sc); }
 

--- a/library/coqlib.ml
+++ b/library/coqlib.ml
@@ -67,7 +67,7 @@ let (inCoqlibRef : string * GlobRef.t -> Libobject.obj) =
     load_function = (fun _ x -> cache_ref x);
     classify_function = (fun o -> Substitute o);
     subst_function = ident_subst_function;
-    discharge_function = fun (_, sc) -> Some sc }
+    discharge_function = (fun sc -> Some sc); }
 
 (** Replaces a binding ! *)
 let register_ref s c =

--- a/library/goptions.ml
+++ b/library/goptions.ml
@@ -281,7 +281,7 @@ let declare_option cast uncast append ?(preprocess = fun x -> x)
         assert false
       in
       let subst_options (subst,obj) = obj in
-      let discharge_options (_,(l,_,_ as o)) =
+      let discharge_options (l,_,_ as o) =
         match l with OptLocal -> None | (OptExport | OptGlobal | OptDefault) -> Some o in
       let classify_options (l,_,_ as o) =
         match l with (OptExport | OptGlobal) -> Substitute o | (OptLocal | OptDefault) -> Dispose in

--- a/library/goptions.ml
+++ b/library/goptions.ml
@@ -102,7 +102,7 @@ module MakeTable =
                 Libobject.open_function = simple_open load_options;
                 Libobject.cache_function = cache_options;
                 Libobject.subst_function = subst_options;
-                Libobject.classify_function = (fun x -> Substitute x)}
+                Libobject.classify_function = (fun x -> Substitute)}
         in
         ((fun c -> Lib.add_anonymous_leaf (inGo (GOadd, c))),
          (fun c -> Lib.add_anonymous_leaf (inGo (GOrmv, c))))
@@ -283,8 +283,8 @@ let declare_option cast uncast append ?(preprocess = fun x -> x)
       let subst_options (subst,obj) = obj in
       let discharge_options (l,_,_ as o) =
         match l with OptLocal -> None | (OptExport | OptGlobal | OptDefault) -> Some o in
-      let classify_options (l,_,_ as o) =
-        match l with (OptExport | OptGlobal) -> Substitute o | (OptLocal | OptDefault) -> Dispose in
+      let classify_options (l,_,_) =
+        match l with (OptExport | OptGlobal) -> Substitute | (OptLocal | OptDefault) -> Dispose in
       let options : option_locality * option_mod * _ -> obj =
         declare_object
           { (default_object (nickname key)) with

--- a/library/goptions.ml
+++ b/library/goptions.ml
@@ -87,7 +87,7 @@ module MakeTable =
     let t = Summary.ref MySet.empty ~name:nick
 
     let (add_option,remove_option) =
-        let cache_options (_,(f,p)) = match f with
+        let cache_options (f,p) = match f with
           | GOadd -> t := MySet.add p !t
           | GOrmv -> t := MySet.remove p !t in
         let load_options i o = if Int.equal i 1 then cache_options o in
@@ -262,18 +262,18 @@ let declare_option cast uncast append ?(preprocess = fun x -> x)
         { Summary.freeze_function = (fun ~marshallable -> read ());
           Summary.unfreeze_function = write;
           Summary.init_function = (fun () -> write default) } in
-      let cache_options (_,(l,m,v)) =
+      let cache_options (l,m,v) =
         match m with
         | OptSet -> write v
         | OptAppend -> write (append (read ()) v) in
-      let load_options i (_, (l, _, _) as o) = match l with
+      let load_options i (l, _, _ as o) = match l with
       | OptGlobal -> cache_options o
       | OptExport -> ()
       | OptLocal | OptDefault ->
         (* Ruled out by classify_function *)
         assert false
       in
-      let open_options i  (_, (l, _, _) as o) = match l with
+      let open_options i  (l, _, _ as o) = match l with
       | OptExport -> if Int.equal i 1 then cache_options o
       | OptGlobal -> ()
       | OptLocal | OptDefault ->

--- a/library/goptions.ml
+++ b/library/goptions.ml
@@ -104,8 +104,8 @@ module MakeTable =
                 Libobject.subst_function = subst_options;
                 Libobject.classify_function = (fun x -> Substitute)}
         in
-        ((fun c -> Lib.add_anonymous_leaf (inGo (GOadd, c))),
-         (fun c -> Lib.add_anonymous_leaf (inGo (GOrmv, c))))
+        ((fun c -> Lib.add_leaf (inGo (GOadd, c))),
+         (fun c -> Lib.add_leaf (inGo (GOrmv, c))))
 
     let print_table table_name printer table =
       Feedback.msg_notice
@@ -294,7 +294,7 @@ let declare_option cast uncast append ?(preprocess = fun x -> x)
             subst_function = subst_options;
             discharge_function = discharge_options;
             classify_function = classify_options } in
-      (fun l m v -> let v = preprocess v in Lib.add_anonymous_leaf (options (l, m, v)))
+      (fun l m v -> let v = preprocess v in Lib.add_leaf (options (l, m, v)))
   in
   let warn () = if depr then warn_deprecated_option key in
   let cread () = cast (read ()) in

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -455,14 +455,14 @@ let open_section id =
 (* Restore lib_stk and summaries as before the section opening, and
    add a ClosedSection object. *)
 
-let discharge_item ((sp,_ as oname),e) =
+let discharge_item ((sp,_),e) =
   match e with
   | Leaf lobj ->
     begin match lobj with
     | ModuleObject _ | ModuleTypeObject _ | IncludeObject _ | KeepObject _
     | ExportObject _ -> None
     | AtomicObject obj ->
-      Option.map (fun o -> (basename sp,o)) (discharge_object (oname,obj))
+      Option.map (fun o -> (basename sp,o)) (discharge_object obj)
     end
   | OpenedSection _ | OpenedModule _ | CompilingLibrary _ ->
       anomaly (Pp.str "discharge_item.")

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -64,7 +64,7 @@ let classify_segment seg =
           clean (substl, o::keepl, anticipl) stk
         | ExportObject _ ->
           clean (o::substl, keepl, anticipl) stk
-        | AtomicObject (id, obj) as o ->
+        | AtomicObject obj as o ->
           begin match classify_object obj with
             | Dispose -> clean acc stk
             | Keep ->
@@ -193,13 +193,13 @@ let add_discharged_leaf id obj =
   let oname = make_foname id in
   let newobj = rebuild_object obj in
   cache_object (prefix(),newobj);
-  add_entry oname (Leaf (AtomicObject (id, newobj)))
+  add_entry oname (Leaf (AtomicObject newobj))
 
 let add_leaf obj =
   let id = anonymous_id () in
   let oname = make_foname id in
   cache_object (prefix(),obj);
-  add_entry oname (Leaf (AtomicObject (id, obj)))
+  add_entry oname (Leaf (AtomicObject obj))
 
 (* Modules. *)
 
@@ -415,8 +415,7 @@ let discharge_item ((sp,_),e) =
     begin match lobj with
     | ModuleObject _ | ModuleTypeObject _ | IncludeObject _ | KeepObject _
     | ExportObject _ -> None
-    | AtomicObject (id,obj) ->
-      Option.map (fun o -> (basename sp,o)) (discharge_object obj)
+    | AtomicObject obj -> Option.map (fun o -> Libnames.basename sp, o) (discharge_object obj)
     end
   | OpenedSection _ | OpenedModule _ | CompilingLibrary _ ->
       anomaly (Pp.str "discharge_item.")

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -37,25 +37,10 @@ type library_entry = object_name * node
 
 type library_segment = library_entry list
 
-type lib_atomic_objects = (Id.t * Libobject.obj) list
 type lib_objects =  (Names.Id.t * Libobject.t) list
 
 let module_kind is_type =
   if is_type then "module type" else "module"
-
-let iter_objects f i prefix =
-  List.iter (fun (id,obj) -> f i (prefix, obj))
-
-let load_atomic_objects i pr = iter_objects load_object i pr
-let open_atomic_objects f i pr = iter_objects (open_object f) i pr
-
-let subst_atomic_objects subst seg =
-  let subst_one = fun (id,obj as node) ->
-    let obj' = subst_object (subst,obj) in
-      if obj' == obj then node else
-        (id, obj')
-  in
-    List.Smart.map subst_one seg
 
 (*let load_and_subst_objects i prefix subst seg =
   List.rev (List.fold_left (fun seg (id,obj as node) ->

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -202,10 +202,6 @@ let split_lib_gen test =
 let eq_object_name (fp1, kn1) (fp2, kn2) =
   eq_full_path fp1 fp2 && Names.KerName.equal kn1 kn2
 
-let split_lib sp =
-  let is_sp (nsp, _) = eq_object_name sp nsp in
-  split_lib_gen is_sp
-
 let split_lib_at_opening sp =
   let is_sp (nsp, obj) = match obj with
     | OpenedSection _ | OpenedModule _ | CompilingLibrary _ ->
@@ -308,8 +304,6 @@ let end_module () = end_mod false
 let end_modtype () = end_mod true
 
 let contents () = !lib_state.lib_stk
-
-let contents_after sp = let (after,_,_) = split_lib sp in after
 
 (* Modules. *)
 

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -211,14 +211,6 @@ let is_opening_node_or_lib = function
   | _,(CompilingLibrary _ | OpenedSection _ | OpenedModule _) -> true
   | _ -> false
 
-let current_mod_id () =
-  try match find_entry_p is_opening_node_or_lib with
-    | oname,OpenedModule (_,_,_,fs) -> basename (fst oname)
-    | oname,CompilingLibrary _ -> basename (fst oname)
-    | _ -> user_err Pp.(str "you are not in a module")
-  with Not_found -> user_err Pp.(str "no opened modules")
-
-
 let start_mod is_type export id mp fs =
   let dir = add_dirpath_suffix (!lib_state.path_prefix.Nametab.obj_dir) id in
   let prefix = Nametab.{ obj_dir = dir; obj_mp = mp; } in

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -235,7 +235,7 @@ let add_leaf id obj =
   let oname = make_foname id in
   cache_object (oname,obj);
   add_entry oname (Leaf (AtomicObject obj));
-  oname
+  ()
 
 let add_discharged_leaf id obj =
   let oname = make_foname id in

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -67,31 +67,31 @@ let classify_segment seg =
   let rec clean ((substl,keepl,anticipl) as acc) = function
     | (_,CompilingLibrary _) :: _ | [] -> acc
     | ((sp,kn),Leaf o) :: stk ->
-          let id = Names.Label.to_id (Names.KerName.label kn) in
-    begin match o with
-    | ModuleObject _ | ModuleTypeObject _ | IncludeObject _ ->
-      clean ((id,o)::substl, keepl, anticipl) stk
-    | KeepObject _ ->
-      clean (substl, (id,o)::keepl, anticipl) stk
-    | ExportObject _ ->
-      clean ((id,o)::substl, keepl, anticipl) stk
-    | AtomicObject obj ->
-      begin match classify_object obj with
-        | Dispose -> clean acc stk
-        | Keep o' ->
-          clean (substl, (id,AtomicObject o')::keepl, anticipl) stk
-        | Substitute o' ->
-          clean ((id,AtomicObject o')::substl, keepl, anticipl) stk
-        | Anticipate o' ->
-          clean (substl, keepl, AtomicObject o'::anticipl) stk
+      let id = Names.Label.to_id (Names.KerName.label kn) in
+      begin match o with
+        | ModuleObject _ | ModuleTypeObject _ | IncludeObject _ ->
+          clean ((id,o)::substl, keepl, anticipl) stk
+        | KeepObject _ ->
+          clean (substl, (id,o)::keepl, anticipl) stk
+        | ExportObject _ ->
+          clean ((id,o)::substl, keepl, anticipl) stk
+        | AtomicObject obj ->
+          begin match classify_object obj with
+            | Dispose -> clean acc stk
+            | Keep o' ->
+              clean (substl, (id,AtomicObject o')::keepl, anticipl) stk
+            | Substitute o' ->
+              clean ((id,AtomicObject o')::substl, keepl, anticipl) stk
+            | Anticipate o' ->
+              clean (substl, keepl, AtomicObject o'::anticipl) stk
+          end
       end
-    end
     | (_,OpenedSection _) :: _ -> user_err Pp.(str "there are still opened sections")
     | (_,OpenedModule (ty,_,_,_)) :: _ ->
       user_err
         (str "there are still opened " ++ str (module_kind ty) ++ str "s.")
   in
-    clean ([],[],[]) (List.rev seg)
+  clean ([],[],[]) (List.rev seg)
 
 (* We keep trace of operations in the stack [lib_stk].
    [path_prefix] is the current path of sections, where sections are stored in

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -286,9 +286,8 @@ let end_mod is_type =
   in
   let (after,mark,before) = split_lib_at_opening oname in
   lib_state := { !lib_state with lib_stk = before };
-  let prefix = !lib_state.path_prefix in
   recalc_path_prefix ();
-  (oname, prefix, fs, after)
+  (oname, fs, after)
 
 let end_module () = end_mod false
 let end_modtype () = end_mod true

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -78,12 +78,12 @@ let classify_segment seg =
         | AtomicObject obj ->
           begin match classify_object obj with
             | Dispose -> clean acc stk
-            | Keep o' ->
-              clean (substl, (id,AtomicObject o')::keepl, anticipl) stk
-            | Substitute o' ->
-              clean ((id,AtomicObject o')::substl, keepl, anticipl) stk
-            | Anticipate o' ->
-              clean (substl, keepl, AtomicObject o'::anticipl) stk
+            | Keep ->
+              clean (substl, (id,AtomicObject obj)::keepl, anticipl) stk
+            | Substitute ->
+              clean ((id,AtomicObject obj)::substl, keepl, anticipl) stk
+            | Anticipate ->
+              clean (substl, keepl, AtomicObject obj::anticipl) stk
           end
       end
     | (_,OpenedSection _) :: _ -> user_err Pp.(str "there are still opened sections")

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -170,32 +170,6 @@ let find_entries_p p =
   in
   find !lib_state.lib_stk
 
-let split_lib_gen test =
-  let rec collect after equal = function
-    | hd::before when test hd -> collect after (hd::equal) before
-    | before -> after,equal,before
-  in
-  let rec findeq after = function
-    | hd :: before when test hd -> collect after [hd] before
-    | hd :: before -> findeq (hd::after) before
-    | [] -> user_err Pp.(str "no such entry")
-  in
-  findeq [] !lib_state.lib_stk
-
-let eq_object_name (fp1, kn1) (fp2, kn2) =
-  eq_full_path fp1 fp2 && Names.KerName.equal kn1 kn2
-
-let split_lib_at_opening sp =
-  let is_sp (nsp, obj) = match obj with
-    | OpenedSection _ | OpenedModule _ | CompilingLibrary _ ->
-      eq_object_name nsp sp
-    | _ -> false
-  in
-  let a, s, b = split_lib_gen is_sp in
-  match s with
-  | [obj] -> (a, obj, b)
-  | _ -> assert false
-
 (* Adding operations. *)
 
 let add_entry sp node =
@@ -254,22 +228,30 @@ let start_mod is_type export id mp fs =
 let start_module = start_mod false
 let start_modtype = start_mod true None
 
+let split_lib_at_opening () =
+  let rec findeq after = function
+    | hd :: before when is_opening_node_or_lib hd -> after, hd, before
+    | hd :: before -> findeq (hd::after) before
+    | [] -> anomaly Pp.(str "No opening entry.")
+  in
+  findeq [] !lib_state.lib_stk
+
 let error_still_opened string oname =
   let id = basename (fst oname) in
   user_err
     (str "The " ++ str string ++ str " " ++ Id.print id ++ str " is still opened.")
 
 let end_mod is_type =
-  let oname,fs =
-    try match find_entry_p is_opening_node with
-      | oname,OpenedModule (ty,_,_,fs) ->
-        if ty == is_type then oname, fs
-        else error_still_opened (module_kind ty) oname
-      | oname,OpenedSection _ -> error_still_opened "section" oname
-      | _ -> assert false
-    with Not_found -> user_err (Pp.str "No opened modules.")
+  let (after,mark,before) = split_lib_at_opening () in
+  (* The errors here should not happen because we checked in the upper layers *)
+  let oname, fs = match mark with
+    | oname,OpenedModule (ty,_,_,fs) ->
+      if ty == is_type then oname, fs
+      else error_still_opened (module_kind ty) oname
+    | oname,OpenedSection _ -> error_still_opened "section" oname
+    | _, CompilingLibrary _ -> user_err (Pp.str "No opened modules.")
+    | _, Leaf _ -> assert false
   in
-  let (after,mark,before) = split_lib_at_opening oname in
   lib_state := { !lib_state with lib_stk = before };
   recalc_path_prefix ();
   (oname, fs, after)
@@ -301,18 +283,10 @@ let open_blocks_message es =
   str "need" ++ str (if List.length es == 1 then "s" else "") ++ str " to be closed."
 
 let end_compilation_checks dir =
-  let _ = match find_entries_p is_opening_node with
+  let () = match find_entries_p is_opening_node with
     | [] -> ()
     | es -> user_err (open_blocks_message es) in
-  let is_opening_lib = function _,CompilingLibrary _ -> true | _ -> false
-  in
-  let oname =
-    try match find_entry_p is_opening_lib with
-      |	(oname, CompilingLibrary prefix) -> oname
-      | _ -> assert false
-    with Not_found -> anomaly (Pp.str "No module declared.")
-  in
-  let _ =
+  let () =
     match !lib_state.comp_name with
       | None -> anomaly (Pp.str "There should be a module name...")
       | Some m ->
@@ -320,10 +294,11 @@ let end_compilation_checks dir =
            (str "The current open module has name" ++ spc () ++ DirPath.print m ++
              spc () ++ str "and not" ++ spc () ++ DirPath.print m ++ str ".");
   in
-  oname
+  ()
 
-let end_compilation oname =
-  let (after,mark,before) = split_lib_at_opening oname in
+let end_compilation dir =
+  end_compilation_checks dir;
+  let (after,mark,before) = split_lib_at_opening () in
   lib_state := { !lib_state with comp_name = None };
   !lib_state.path_prefix,after
 
@@ -446,14 +421,11 @@ let discharge_item ((sp,_),e) =
       anomaly (Pp.str "discharge_item.")
 
 let close_section () =
-  let oname,fs =
-    try match find_entry_p is_opening_node with
-      | oname,OpenedSection (_,fs) -> oname,fs
-      | _ -> assert false
-    with Not_found ->
-      user_err Pp.(str  "No opened section.")
+  let (secdecls,mark,before) = split_lib_at_opening () in
+  let oname, fs = match mark with
+    | oname,OpenedSection (_,fs) -> oname,fs
+    | _ -> user_err Pp.(str "No opened section.")
   in
-  let (secdecls,mark,before) = split_lib_at_opening oname in
   lib_state := { !lib_state with lib_stk = before };
   pop_path_prefix ();
   let newdecls = List.map discharge_item secdecls in

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -93,10 +93,6 @@ let classify_segment seg =
   in
     clean ([],[],[]) (List.rev seg)
 
-
-let segment_of_objects prefix =
-  List.map (fun (id,obj) -> (make_oname prefix id, Leaf obj))
-
 (* We keep trace of operations in the stack [lib_stk].
    [path_prefix] is the current path of sections, where sections are stored in
    ``correct'' order, the oldest coming first in the list. It may seems

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -243,16 +243,11 @@ let add_discharged_leaf id obj =
   cache_object (oname,newobj);
   add_entry oname (Leaf (AtomicObject newobj))
 
-let add_anonymous_leaf ?(cache_first = true) obj =
+let add_anonymous_leaf obj =
   let id = anonymous_id () in
   let oname = make_foname id in
-  if cache_first then begin
-    cache_object (oname,obj);
-    add_entry oname (Leaf (AtomicObject obj))
-  end else begin
-    add_entry oname (Leaf (AtomicObject obj));
-    cache_object (oname,obj)
-  end
+  cache_object (oname,obj);
+  add_entry oname (Leaf (AtomicObject obj))
 
 (* Modules. *)
 

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -110,13 +110,11 @@ val start_modtype :
 
 val end_module :
   unit ->
-  Libobject.object_name * Nametab.object_prefix *
-    Summary.frozen * library_segment
+  Libobject.object_name * Summary.frozen * library_segment
 
 val end_modtype :
   unit ->
-  Libobject.object_name * Nametab.object_prefix *
-    Summary.frozen * library_segment
+  Libobject.object_name * Summary.frozen * library_segment
 
 (** {6 Compilation units } *)
 

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -72,11 +72,6 @@ val add_anonymous_leaf : Libobject.obj -> unit
 
 val contents : unit -> library_segment
 
-(** The function [contents_after] returns the current library segment,
-  starting from a given section path. *)
-
-val contents_after : Libobject.object_name -> library_segment
-
 (** {6 Functions relative to current path } *)
 
 (** User-side names *)

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -64,7 +64,7 @@ val add_anonymous_entry : node -> unit
   current list of operations (most recent ones coming first). *)
 
 val add_leaf : Id.t -> Libobject.obj -> unit
-val add_anonymous_leaf : ?cache_first:bool -> Libobject.obj -> unit
+val add_anonymous_leaf : Libobject.obj -> unit
 
 (** {6 ... } *)
 

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -24,12 +24,16 @@ val make_foname : Names.Id.t -> Libobject.object_name
 val oname_prefix : Libobject.object_name -> Nametab.object_prefix
 
 type node =
-  | Leaf of Libobject.t
   | CompilingLibrary of Nametab.object_prefix
   | OpenedModule of is_type * export * Nametab.object_prefix * Summary.frozen
   | OpenedSection of Nametab.object_prefix * Summary.frozen
 
-type library_segment = (Libobject.object_name * node) list
+(** Extract the [object_prefix] component. Note that it is the prefix
+   of the objects *inside* this node, eg in [Module M.] we have
+   [OpenedModule] with prefix containing [M]. *)
+val node_prefix : node -> Nametab.object_prefix
+
+type library_segment = (node * Libobject.t list) list
 
 type classified_objects = {
   substobjs : Libobject.t list;
@@ -38,10 +42,10 @@ type classified_objects = {
 }
 
 (** {6 ... } *)
-(** Low-level adding operations *)
+(** Low-level adding operations (does not cache) *)
 
-val add_entry : Libobject.object_name -> node -> unit
-val add_anonymous_entry : node -> unit
+val add_entry : node -> unit
+val add_leaf_entry : Libobject.t -> unit
 
 (** {6 ... } *)
 (** Adding operations (which call the [cache] method, and getting the
@@ -97,11 +101,11 @@ val start_modtype :
 
 val end_module :
   unit ->
-  Libobject.object_name * Summary.frozen * classified_objects
+  Nametab.object_prefix * Summary.frozen * classified_objects
 
 val end_modtype :
   unit ->
-  Libobject.object_name * Summary.frozen * classified_objects
+  Nametab.object_prefix * Summary.frozen * classified_objects
 
 (** {6 Compilation units } *)
 

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -20,7 +20,7 @@ type is_type = bool (* Module Type or just Module *)
 type export = bool option (* None for a Module Type *)
 
 val make_oname : Nametab.object_prefix -> Names.Id.t -> Libobject.object_name
-val make_foname : Names.Id.t -> Libnames.full_path * Names.KerName.t
+val make_foname : Names.Id.t -> Libobject.object_name
 
 type node =
   | Leaf of Libobject.t
@@ -123,7 +123,7 @@ val end_modtype :
 val start_compilation : DirPath.t -> ModPath.t -> unit
 val end_compilation_checks : DirPath.t -> Libobject.object_name
 val end_compilation :
-  Libobject.object_name-> Nametab.object_prefix * library_segment
+  Libobject.object_name -> Nametab.object_prefix * library_segment
 
 (** The function [library_dp] returns the [DirPath.t] of the current
    compiling library (or [default_library]) *)

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -110,9 +110,7 @@ val end_modtype :
 (** {6 Compilation units } *)
 
 val start_compilation : DirPath.t -> ModPath.t -> unit
-val end_compilation_checks : DirPath.t -> Libobject.object_name
-val end_compilation :
-  Libobject.object_name -> Nametab.object_prefix * library_segment
+val end_compilation : DirPath.t -> Nametab.object_prefix * library_segment
 
 (** The function [library_dp] returns the [DirPath.t] of the current
    compiling library (or [default_library]) *)

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -58,6 +58,7 @@ val contents : unit -> library_segment
 (** {6 Functions relative to current path } *)
 
 (** User-side names *)
+val prefix : unit -> Nametab.object_prefix
 val cwd : unit -> DirPath.t
 val cwd_except_section : unit -> DirPath.t
 val current_dirpath : bool -> DirPath.t (* false = except sections *)
@@ -80,7 +81,6 @@ val is_modtype : unit -> bool
    if the latest module started is a module type.  *)
 val is_modtype_strict : unit -> bool
 val is_module : unit -> bool
-val current_mod_id : unit -> module_ident
 
 (** Returns the opening node of a given name *)
 val find_opening_node : Id.t -> node

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -49,10 +49,6 @@ val subst_atomic_objects : Mod_subst.substitution -> lib_atomic_objects -> lib_a
 val classify_segment :
   library_segment -> lib_objects * lib_objects * Libobject.t list
 
-(** [segment_of_objects prefix objs] forms a list of Leafs *)
-val segment_of_objects :
-  Nametab.object_prefix -> lib_objects -> library_segment
-
 (** {6 ... } *)
 (** Low-level adding operations *)
 

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -21,6 +21,7 @@ type export = bool option (* None for a Module Type *)
 
 val make_oname : Nametab.object_prefix -> Names.Id.t -> Libobject.object_name
 val make_foname : Names.Id.t -> Libobject.object_name
+val oname_prefix : Libobject.object_name -> Nametab.object_prefix
 
 type node =
   | Leaf of Libobject.t
@@ -59,8 +60,7 @@ val add_anonymous_entry : node -> unit
 (** Adding operations (which call the [cache] method, and getting the
   current list of operations (most recent ones coming first). *)
 
-val add_leaf : Id.t -> Libobject.obj -> unit
-val add_anonymous_leaf : Libobject.obj -> unit
+val add_leaf : Libobject.obj -> unit
 
 (** {6 ... } *)
 

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -63,7 +63,7 @@ val add_anonymous_entry : node -> unit
 (** Adding operations (which call the [cache] method, and getting the
   current list of operations (most recent ones coming first). *)
 
-val add_leaf : Id.t -> Libobject.obj -> Libobject.object_name
+val add_leaf : Id.t -> Libobject.obj -> unit
 val add_anonymous_leaf : ?cache_first:bool -> Libobject.obj -> unit
 
 (** {6 ... } *)

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -31,11 +31,9 @@ type node =
 
 type library_segment = (Libobject.object_name * node) list
 
-type lib_objects = (Id.t * Libobject.t) list
-
 type classified_objects = {
-  substobjs : lib_objects;
-  keepobjs : lib_objects;
+  substobjs : Libobject.t list;
+  keepobjs : Libobject.t list;
   anticipateobjs : Libobject.t list;
 }
 

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -31,16 +31,7 @@ type node =
 
 type library_segment = (Libobject.object_name * node) list
 
-type lib_atomic_objects = (Id.t * Libobject.obj) list
 type lib_objects = (Id.t * Libobject.t) list
-
-(** {6 Object iteration functions. } *)
-
-val open_atomic_objects : Libobject.open_filter
-  -> int -> Nametab.object_prefix -> lib_atomic_objects -> unit
-val load_atomic_objects : int -> Nametab.object_prefix -> lib_atomic_objects -> unit
-val subst_atomic_objects : Mod_subst.substitution -> lib_atomic_objects -> lib_atomic_objects
-(*val load_and_subst_objects : int -> Libnames.Nametab.object_prefix -> Mod_subst.substitution -> lib_objects -> lib_objects*)
 
 (** [classify_segment seg] verifies that there are no OpenedThings,
    clears ClosedSections and FrozenStates and divides Leafs according

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -33,13 +33,11 @@ type library_segment = (Libobject.object_name * node) list
 
 type lib_objects = (Id.t * Libobject.t) list
 
-(** [classify_segment seg] verifies that there are no OpenedThings,
-   clears ClosedSections and FrozenStates and divides Leafs according
-   to their answers to the [classify_object] function in three groups:
-   [Substitute], [Keep], [Anticipate] respectively.  The order of each
-   returned list is the same as in the input list. *)
-val classify_segment :
-  library_segment -> lib_objects * lib_objects * Libobject.t list
+type classified_objects = {
+  substobjs : lib_objects;
+  keepobjs : lib_objects;
+  anticipateobjs : Libobject.t list;
+}
 
 (** {6 ... } *)
 (** Low-level adding operations *)
@@ -101,16 +99,16 @@ val start_modtype :
 
 val end_module :
   unit ->
-  Libobject.object_name * Summary.frozen * library_segment
+  Libobject.object_name * Summary.frozen * classified_objects
 
 val end_modtype :
   unit ->
-  Libobject.object_name * Summary.frozen * library_segment
+  Libobject.object_name * Summary.frozen * classified_objects
 
 (** {6 Compilation units } *)
 
 val start_compilation : DirPath.t -> ModPath.t -> unit
-val end_compilation : DirPath.t -> Nametab.object_prefix * library_segment
+val end_compilation : DirPath.t -> Nametab.object_prefix * classified_objects
 
 (** The function [library_dp] returns the [DirPath.t] of the current
    compiling library (or [default_library]) *)

--- a/library/libobject.ml
+++ b/library/libobject.ml
@@ -115,18 +115,16 @@ type obj = Dyn.t (* persistent dynamic objects *)
 *)
 
 type algebraic_objects =
-  | Objs of objects
-  | Ref of Names.ModPath.t * Mod_subst.substitution
+  | Objs of t list
+  | Ref of ModPath.t * Mod_subst.substitution
 
 and t =
-  | ModuleObject of substitutive_objects
-  | ModuleTypeObject of substitutive_objects
-  | IncludeObject of algebraic_objects
-  | KeepObject of objects
+  | ModuleObject of Id.t * substitutive_objects
+  | ModuleTypeObject of Id.t * substitutive_objects
+  | IncludeObject of Id.t * algebraic_objects
+  | KeepObject of Id.t * t list
   | ExportObject of { mpl : (open_filter * ModPath.t) list }
-  | AtomicObject of obj
-
-and objects = (Names.Id.t * t) list
+  | AtomicObject of Id.t * obj
 
 and substitutive_objects = MBId.t list * algebraic_objects
 

--- a/library/libobject.ml
+++ b/library/libobject.ml
@@ -124,7 +124,7 @@ and t =
   | IncludeObject of algebraic_objects
   | KeepObject of Id.t * t list
   | ExportObject of { mpl : (open_filter * ModPath.t) list }
-  | AtomicObject of Id.t * obj
+  | AtomicObject of obj
 
 and substitutive_objects = MBId.t list * algebraic_objects
 

--- a/library/libobject.ml
+++ b/library/libobject.ml
@@ -132,7 +132,7 @@ module DynMap = Dyn.Map (struct type 'a t = ('a, Nametab.object_prefix * 'a) obj
 
 let cache_tab = ref DynMap.empty
 
-let declare_object_gen odecl =
+let declare_object_full odecl =
   let na = odecl.object_name in
   let tag = Dyn.create na in
   let () = cache_tab := DynMap.add tag odecl !cache_tab in
@@ -141,7 +141,7 @@ let declare_object_gen odecl =
 let make_oname Nametab.{ obj_dir; obj_mp } id =
   Libnames.make_path obj_dir id, KerName.make obj_mp (Label.of_id id)
 
-let declare_object_full odecl =
+let declare_named_object_full odecl =
   let odecl =
     let oname = make_oname in
     { object_name = odecl.object_name;
@@ -154,15 +154,15 @@ let declare_object_full odecl =
       rebuild_function = Util.on_snd odecl.rebuild_function;
     }
   in
-  declare_object_gen odecl
+  declare_object_full odecl
 
 let declare_named_object odecl =
-  let tag = declare_object_full odecl in
+  let tag = declare_named_object_full odecl in
   let infun id v = Dyn.Dyn (tag, (id, v)) in
   infun
 
-let declare_named_object0 odecl =
-  let tag = declare_object_gen odecl in
+let declare_named_object_gen odecl =
+  let tag = declare_object_full odecl in
   let infun v = Dyn.Dyn (tag, v) in
   infun
 
@@ -174,7 +174,7 @@ let declare_object odecl =
       open_function = (fun f i (_,o) -> odecl.open_function f i o);
     }
   in
-  let tag = declare_object_gen odecl in
+  let tag = declare_object_full odecl in
   let infun v = Dyn.Dyn (tag, v) in
   infun
 

--- a/library/libobject.ml
+++ b/library/libobject.ml
@@ -180,20 +180,23 @@ let rebuild_object (Dyn.Dyn (tag, v)) =
 
 let dump = Dyn.dump
 
+let forget_names f = (); fun (_,o) -> f o
+
 let local_object_nodischarge s ~cache =
   { (default_object s) with
-    cache_function = cache;
+    cache_function = forget_names cache;
     classify_function = (fun _ -> Dispose);
   }
 
 let local_object s ~cache ~discharge =
   { (local_object_nodischarge s ~cache) with
-    discharge_function = discharge }
+    discharge_function = forget_names discharge;
+  }
 
 let global_object_nodischarge ?cat s ~cache ~subst =
-  let import i o = if Int.equal i 1 then cache o in
+  let import i o = if Int.equal i 1 then forget_names cache o in
   { (default_object s) with
-    cache_function = cache;
+    cache_function = forget_names cache;
     open_function = simple_open ?cat import;
     subst_function = (match subst with
         | None -> fun _ -> CErrors.anomaly (str "The object " ++ str s ++ str " does not know how to substitute!")
@@ -205,12 +208,12 @@ let global_object_nodischarge ?cat s ~cache ~subst =
 
 let global_object ?cat s ~cache ~subst ~discharge =
   { (global_object_nodischarge ?cat s ~cache ~subst) with
-    discharge_function = discharge }
+    discharge_function = forget_names discharge }
 
 let superglobal_object_nodischarge s ~cache ~subst =
   { (default_object s) with
-    load_function = (fun _ x -> cache x);
-    cache_function = cache;
+    load_function = (fun _ x -> forget_names cache x);
+    cache_function = forget_names cache;
     subst_function = (match subst with
         | None -> fun _ -> CErrors.anomaly (str "The object " ++ str s ++ str " does not know how to substitute!")
         | Some subst -> subst;
@@ -221,4 +224,4 @@ let superglobal_object_nodischarge s ~cache ~subst =
 
 let superglobal_object s ~cache ~subst ~discharge =
   { (superglobal_object_nodischarge s ~cache ~subst) with
-    discharge_function = discharge }
+    discharge_function = forget_names discharge }

--- a/library/libobject.ml
+++ b/library/libobject.ml
@@ -72,7 +72,7 @@ type 'a object_declaration = {
   open_function : open_filter -> int -> object_name * 'a -> unit;
   classify_function : 'a -> 'a substitutivity;
   subst_function : Mod_subst.substitution * 'a -> 'a;
-  discharge_function : object_name * 'a -> 'a option;
+  discharge_function : 'a -> 'a option;
   rebuild_function : 'a -> 'a }
 
 let default_object s = {
@@ -168,9 +168,9 @@ let classify_object (Dyn.Dyn (tag, v)) =
   | Keep v -> Keep (Dyn.Dyn (tag, v))
   | Anticipate v -> Anticipate (Dyn.Dyn (tag, v))
 
-let discharge_object (sp, Dyn.Dyn (tag, v)) =
+let discharge_object (Dyn.Dyn (tag, v)) =
   let decl = DynMap.find tag !cache_tab in
-  match decl.discharge_function (sp, v) with
+  match decl.discharge_function v with
   | None -> None
   | Some v -> Some (Dyn.Dyn (tag, v))
 
@@ -190,7 +190,7 @@ let local_object_nodischarge s ~cache =
 
 let local_object s ~cache ~discharge =
   { (local_object_nodischarge s ~cache) with
-    discharge_function = forget_names discharge;
+    discharge_function = discharge;
   }
 
 let global_object_nodischarge ?cat s ~cache ~subst =
@@ -208,7 +208,7 @@ let global_object_nodischarge ?cat s ~cache ~subst =
 
 let global_object ?cat s ~cache ~subst ~discharge =
   { (global_object_nodischarge ?cat s ~cache ~subst) with
-    discharge_function = forget_names discharge }
+    discharge_function = discharge }
 
 let superglobal_object_nodischarge s ~cache ~subst =
   { (default_object s) with
@@ -224,4 +224,4 @@ let superglobal_object_nodischarge s ~cache ~subst =
 
 let superglobal_object s ~cache ~subst ~discharge =
   { (superglobal_object_nodischarge s ~cache ~subst) with
-    discharge_function = forget_names discharge }
+    discharge_function = discharge }

--- a/library/libobject.ml
+++ b/library/libobject.ml
@@ -121,7 +121,7 @@ type algebraic_objects =
 and t =
   | ModuleObject of Id.t * substitutive_objects
   | ModuleTypeObject of Id.t * substitutive_objects
-  | IncludeObject of Id.t * algebraic_objects
+  | IncludeObject of algebraic_objects
   | KeepObject of Id.t * t list
   | ExportObject of { mpl : (open_filter * ModPath.t) list }
   | AtomicObject of Id.t * obj

--- a/library/libobject.mli
+++ b/library/libobject.mli
@@ -81,7 +81,7 @@ type 'a object_declaration = {
   open_function : open_filter -> int -> object_name * 'a -> unit;
   classify_function : 'a -> 'a substitutivity;
   subst_function :  substitution * 'a -> 'a;
-  discharge_function : object_name * 'a -> 'a option;
+  discharge_function : 'a -> 'a option;
   rebuild_function : 'a -> 'a;
 }
 
@@ -163,7 +163,7 @@ val load_object : int -> object_name * obj -> unit
 val open_object : open_filter -> int -> object_name * obj -> unit
 val subst_object : substitution * obj -> obj
 val classify_object : obj -> obj substitutivity
-val discharge_object : object_name * obj -> obj option
+val discharge_object : obj -> obj option
 val rebuild_object : obj -> obj
 
 (** Higher-level API for objects with fixed scope.

--- a/library/libobject.mli
+++ b/library/libobject.mli
@@ -82,7 +82,8 @@ type 'a object_declaration = {
   classify_function : 'a -> 'a substitutivity;
   subst_function :  substitution * 'a -> 'a;
   discharge_function : object_name * 'a -> 'a option;
-  rebuild_function : 'a -> 'a }
+  rebuild_function : 'a -> 'a;
+}
 
 val unfiltered : open_filter
 
@@ -180,33 +181,33 @@ variants.
 *)
 
 val local_object : string ->
-  cache:(object_name * 'a -> unit) ->
-  discharge:(object_name * 'a -> 'a option) ->
+  cache:('a -> unit) ->
+  discharge:('a -> 'a option) ->
   'a object_declaration
 
 val local_object_nodischarge : string ->
-  cache:(object_name * 'a -> unit) ->
+  cache:('a -> unit) ->
   'a object_declaration
 
 val global_object : ?cat:category -> string ->
-  cache:(object_name * 'a -> unit) ->
+  cache:('a -> unit) ->
   subst:(Mod_subst.substitution * 'a -> 'a) option ->
-  discharge:(object_name * 'a -> 'a option) ->
+  discharge:('a -> 'a option) ->
   'a object_declaration
 
 val global_object_nodischarge : ?cat:category -> string ->
-  cache:(object_name * 'a -> unit) ->
+  cache:('a -> unit) ->
   subst:(Mod_subst.substitution * 'a -> 'a) option ->
   'a object_declaration
 
 val superglobal_object : string ->
-  cache:(object_name * 'a -> unit) ->
+  cache:('a -> unit) ->
   subst:(Mod_subst.substitution * 'a -> 'a) option ->
-  discharge:(object_name * 'a -> 'a option) ->
+  discharge:('a -> 'a option) ->
   'a object_declaration
 
 val superglobal_object_nodischarge : string ->
-  cache:(object_name * 'a -> unit) ->
+  cache:('a -> unit) ->
   subst:(Mod_subst.substitution * 'a -> 'a) option ->
   'a object_declaration
 

--- a/library/libobject.mli
+++ b/library/libobject.mli
@@ -8,7 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open Libnames
+open Nametab
 open Mod_subst
 
 (** [Libobject] declares persistent objects, given with methods:
@@ -69,7 +69,7 @@ type substitutivity = Dispose | Substitute | Keep | Anticipate
    can be substituted and a "syntactic" [full_path] which can be printed
 *)
 
-type object_name = full_path * Names.KerName.t
+type object_name = Libnames.full_path * Names.KerName.t
 
 type open_filter
 
@@ -152,17 +152,20 @@ and objects = (Names.Id.t * t) list
 and substitutive_objects = Names.MBId.t list * algebraic_objects
 
 val declare_object_full :
-  ('a,object_name * 'a) object_declaration -> 'a Dyn.tag
+  ('a,object_name * 'a) object_declaration -> (Names.Id.t * 'a) Dyn.tag
 
 val declare_named_object :
-  ('a,object_name * 'a) object_declaration -> ('a -> obj)
+  ('a,object_name * 'a) object_declaration -> (Names.Id.t -> 'a -> obj)
+
+val declare_named_object0 :
+  ('a,object_prefix * 'a) object_declaration -> ('a -> obj)
 
 val declare_object :
   ('a,'a) object_declaration -> ('a -> obj)
 
-val cache_object : object_name * obj -> unit
-val load_object : int -> object_name * obj -> unit
-val open_object : open_filter -> int -> object_name * obj -> unit
+val cache_object : object_prefix * obj -> unit
+val load_object : int -> object_prefix * obj -> unit
+val open_object : open_filter -> int -> object_prefix * obj -> unit
 val subst_object : substitution * obj -> obj
 val classify_object : obj -> substitutivity
 val discharge_object : obj -> obj option

--- a/library/libobject.mli
+++ b/library/libobject.mli
@@ -143,7 +143,7 @@ type algebraic_objects =
 and t =
   | ModuleObject of Id.t * substitutive_objects
   | ModuleTypeObject of Id.t * substitutive_objects
-  | IncludeObject of Id.t * algebraic_objects
+  | IncludeObject of algebraic_objects
   | KeepObject of Id.t * t list
   | ExportObject of { mpl : (open_filter * ModPath.t) list }
   | AtomicObject of Id.t * obj

--- a/library/libobject.mli
+++ b/library/libobject.mli
@@ -8,6 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+open Names
 open Nametab
 open Mod_subst
 
@@ -69,7 +70,7 @@ type substitutivity = Dispose | Substitute | Keep | Anticipate
    can be substituted and a "syntactic" [full_path] which can be printed
 *)
 
-type object_name = Libnames.full_path * Names.KerName.t
+type object_name = Libnames.full_path * KerName.t
 
 type open_filter
 
@@ -136,26 +137,24 @@ module Dyn : Dyn.S
 type obj = Dyn.t
 
 type algebraic_objects =
-  | Objs of objects
-  | Ref of Names.ModPath.t * Mod_subst.substitution
+  | Objs of t list
+  | Ref of ModPath.t * Mod_subst.substitution
 
 and t =
-  | ModuleObject of substitutive_objects
-  | ModuleTypeObject of substitutive_objects
-  | IncludeObject of algebraic_objects
-  | KeepObject of objects
-  | ExportObject of { mpl : (open_filter * Names.ModPath.t) list }
-  | AtomicObject of obj
+  | ModuleObject of Id.t * substitutive_objects
+  | ModuleTypeObject of Id.t * substitutive_objects
+  | IncludeObject of Id.t * algebraic_objects
+  | KeepObject of Id.t * t list
+  | ExportObject of { mpl : (open_filter * ModPath.t) list }
+  | AtomicObject of Id.t * obj
 
-and objects = (Names.Id.t * t) list
-
-and substitutive_objects = Names.MBId.t list * algebraic_objects
+and substitutive_objects = MBId.t list * algebraic_objects
 
 val declare_object_full :
-  ('a,object_name * 'a) object_declaration -> (Names.Id.t * 'a) Dyn.tag
+  ('a,object_name * 'a) object_declaration -> (Id.t * 'a) Dyn.tag
 
 val declare_named_object :
-  ('a,object_name * 'a) object_declaration -> (Names.Id.t -> 'a -> obj)
+  ('a,object_name * 'a) object_declaration -> (Id.t -> 'a -> obj)
 
 val declare_named_object0 :
   ('a,object_prefix * 'a) object_declaration -> ('a -> obj)

--- a/library/libobject.mli
+++ b/library/libobject.mli
@@ -63,8 +63,7 @@ open Mod_subst
 
 *)
 
-type 'a substitutivity =
-    Dispose | Substitute of 'a | Keep of 'a | Anticipate of 'a
+type substitutivity = Dispose | Substitute | Keep | Anticipate
 
 (** Both names are passed to objects: a "semantic" [kernel_name], which
    can be substituted and a "syntactic" [full_path] which can be printed
@@ -79,7 +78,7 @@ type ('a,'b) object_declaration = {
   cache_function : 'b -> unit;
   load_function : int -> 'b -> unit;
   open_function : open_filter -> int -> 'b -> unit;
-  classify_function : 'a -> 'a substitutivity;
+  classify_function : 'a -> substitutivity;
   subst_function :  substitution * 'a -> 'a;
   discharge_function : 'a -> 'a option;
   rebuild_function : 'a -> 'a;
@@ -165,7 +164,7 @@ val cache_object : object_name * obj -> unit
 val load_object : int -> object_name * obj -> unit
 val open_object : open_filter -> int -> object_name * obj -> unit
 val subst_object : substitution * obj -> obj
-val classify_object : obj -> obj substitutivity
+val classify_object : obj -> substitutivity
 val discharge_object : obj -> obj option
 val rebuild_object : obj -> obj
 

--- a/library/libobject.mli
+++ b/library/libobject.mli
@@ -102,8 +102,8 @@ val in_filter : cat:category option -> open_filter -> bool
     On [cat:(Some category)], returns whether the filter allows
    opening objects in the given [category]. *)
 
-val simple_open : ?cat:category -> (int -> object_name * 'a -> unit) ->
-  open_filter -> int -> object_name * 'a -> unit
+val simple_open : ?cat:category -> ('i -> 'a -> unit) ->
+  open_filter -> 'i -> 'a -> unit
 (** Combinator for making objects with simple category-based open
    behaviour. When [cat:None], can be opened by Unfiltered, but also
    by Filtered with a negative set. *)

--- a/library/libobject.mli
+++ b/library/libobject.mli
@@ -74,11 +74,11 @@ type object_name = full_path * Names.KerName.t
 
 type open_filter
 
-type 'a object_declaration = {
+type ('a,'b) object_declaration = {
   object_name : string;
-  cache_function : object_name * 'a -> unit;
-  load_function : int -> object_name * 'a -> unit;
-  open_function : open_filter -> int -> object_name * 'a -> unit;
+  cache_function : 'b -> unit;
+  load_function : int -> 'b -> unit;
+  open_function : open_filter -> int -> 'b -> unit;
   classify_function : 'a -> 'a substitutivity;
   subst_function :  substitution * 'a -> 'a;
   discharge_function : 'a -> 'a option;
@@ -122,7 +122,7 @@ val filter_or :  open_filter -> open_filter -> open_filter
 
 *)
 
-val default_object : string -> 'a object_declaration
+val default_object : string -> ('a,'b) object_declaration
 
 (** the identity substitution function *)
 val ident_subst_function : substitution * 'a -> 'a
@@ -153,10 +153,13 @@ and objects = (Names.Id.t * t) list
 and substitutive_objects = Names.MBId.t list * algebraic_objects
 
 val declare_object_full :
-  'a object_declaration -> 'a Dyn.tag
+  ('a,object_name * 'a) object_declaration -> 'a Dyn.tag
+
+val declare_named_object :
+  ('a,object_name * 'a) object_declaration -> ('a -> obj)
 
 val declare_object :
-  'a object_declaration -> ('a -> obj)
+  ('a,'a) object_declaration -> ('a -> obj)
 
 val cache_object : object_name * obj -> unit
 val load_object : int -> object_name * obj -> unit
@@ -183,33 +186,33 @@ variants.
 val local_object : string ->
   cache:('a -> unit) ->
   discharge:('a -> 'a option) ->
-  'a object_declaration
+  ('a,'a) object_declaration
 
 val local_object_nodischarge : string ->
   cache:('a -> unit) ->
-  'a object_declaration
+  ('a,'a) object_declaration
 
 val global_object : ?cat:category -> string ->
   cache:('a -> unit) ->
   subst:(Mod_subst.substitution * 'a -> 'a) option ->
   discharge:('a -> 'a option) ->
-  'a object_declaration
+  ('a,'a) object_declaration
 
 val global_object_nodischarge : ?cat:category -> string ->
   cache:('a -> unit) ->
   subst:(Mod_subst.substitution * 'a -> 'a) option ->
-  'a object_declaration
+  ('a,'a) object_declaration
 
 val superglobal_object : string ->
   cache:('a -> unit) ->
   subst:(Mod_subst.substitution * 'a -> 'a) option ->
   discharge:('a -> 'a option) ->
-  'a object_declaration
+  ('a,'a) object_declaration
 
 val superglobal_object_nodischarge : string ->
   cache:('a -> unit) ->
   subst:(Mod_subst.substitution * 'a -> 'a) option ->
-  'a object_declaration
+  ('a,'a) object_declaration
 
 (** {6 Debug} *)
 

--- a/library/libobject.mli
+++ b/library/libobject.mli
@@ -150,17 +150,33 @@ and t =
 
 and substitutive_objects = MBId.t list * algebraic_objects
 
+(** Object declaration and names: if you need the current prefix
+   (typically to interact with the nametab), you need to have it
+   passed to you.
+
+    - [declare_object_full] and [declare_named_object_gen] pass the
+   raw prefix which you can manipulate as you wish.
+
+    - [declare_named_object_full] and [declare_named_object] provide
+   the convenience of packaging it with the provided [Id.t] into a
+   [object_name].
+
+    - [declare_object] ignores the prefix for you. *)
+
+val declare_object :
+  ('a,'a) object_declaration -> ('a -> obj)
+
 val declare_object_full :
+  ('a,object_prefix * 'a) object_declaration -> 'a Dyn.tag
+
+val declare_named_object_full :
   ('a,object_name * 'a) object_declaration -> (Id.t * 'a) Dyn.tag
 
 val declare_named_object :
   ('a,object_name * 'a) object_declaration -> (Id.t -> 'a -> obj)
 
-val declare_named_object0 :
+val declare_named_object_gen :
   ('a,object_prefix * 'a) object_declaration -> ('a -> obj)
-
-val declare_object :
-  ('a,'a) object_declaration -> ('a -> obj)
 
 val cache_object : object_prefix * obj -> unit
 val load_object : int -> object_prefix * obj -> unit

--- a/library/libobject.mli
+++ b/library/libobject.mli
@@ -146,7 +146,7 @@ and t =
   | IncludeObject of algebraic_objects
   | KeepObject of Id.t * t list
   | ExportObject of { mpl : (open_filter * ModPath.t) list }
-  | AtomicObject of Id.t * obj
+  | AtomicObject of obj
 
 and substitutive_objects = MBId.t list * algebraic_objects
 

--- a/library/nametab.mli
+++ b/library/nametab.mli
@@ -58,16 +58,15 @@ open Globnames
 *)
 
 (** Object prefix morally contains the "prefix" naming of an object to
-   be stored by [library], where [obj_dir] is the "absolute" path,
-   [obj_mp] is the current "module" prefix and [obj_sec] is the
-   "section" prefix.
+   be stored by [library], where [obj_dir] is the "absolute" path and
+   [obj_mp] is the current "module" prefix.
 
     Thus, for an object living inside [Module A. Section B.] the
    prefix would be:
 
-    [ { obj_dir = "A.B"; obj_mp = "A"; obj_sec = "B" } ]
+    [ { obj_dir = "A.B"; obj_mp = "A"; } ]
 
-    Note that both [obj_dir] and [obj_sec] are "paths" that is to say,
+    Note that [obj_dir] is a "path" that is to say,
    as opposed to [obj_mp] which is a single module name.
 
  *)

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -603,7 +603,7 @@ let lang () = !lang_ref
 
 let extr_lang : lang -> obj =
   declare_object @@ superglobal_object_nodischarge "Extraction Lang"
-    ~cache:(fun (_,l) -> lang_ref := l)
+    ~cache:(fun l -> lang_ref := l)
     ~subst:None
 
 let extraction_language x = Lib.add_anonymous_leaf (extr_lang x)
@@ -629,9 +629,9 @@ let add_inline_entries b l =
 
 let inline_extraction : bool * GlobRef.t list -> obj =
   declare_object @@ superglobal_object "Extraction Inline"
-    ~cache:(fun (_,(b,l)) -> add_inline_entries b l)
+    ~cache:(fun (b,l) -> add_inline_entries b l)
     ~subst:(Some (fun (s,(b,l)) -> (b,(List.map (fun x -> fst (subst_global s x)) l))))
-    ~discharge:(fun (_,x) -> Some x)
+    ~discharge:(fun x -> Some x)
 
 (* Grammar entries. *)
 
@@ -661,7 +661,7 @@ let print_extraction_inline () =
 
 let reset_inline : unit -> obj =
   declare_object @@ superglobal_object_nodischarge "Reset Extraction Inline"
-    ~cache:(fun (_,_)-> inline_table :=  empty_inline_table)
+    ~cache:(fun () -> inline_table := empty_inline_table)
     ~subst:None
 
 let reset_extraction_inline () = Lib.add_anonymous_leaf (reset_inline ())
@@ -706,7 +706,7 @@ let add_implicits r l =
 
 let implicit_extraction : GlobRef.t * int_or_id list -> obj =
   declare_object @@ superglobal_object_nodischarge "Extraction Implicit"
-    ~cache:(fun (_,(r,l)) -> add_implicits r l)
+    ~cache:(fun (r,l) -> add_implicits r l)
     ~subst:(Some (fun (s,(r,l)) -> (fst (subst_global s r), l)))
 
 (* Grammar entries. *)
@@ -755,7 +755,7 @@ let add_blacklist_entries l =
 
 let blacklist_extraction : string list -> obj =
   declare_object @@ superglobal_object_nodischarge "Extraction Blacklist"
-    ~cache:(fun (_,l) -> add_blacklist_entries l)
+    ~cache:add_blacklist_entries
     ~subst:None
 
 (* Grammar entries. *)
@@ -773,7 +773,7 @@ let print_extraction_blacklist () =
 
 let reset_blacklist : unit -> obj =
   declare_object @@ superglobal_object_nodischarge "Reset Extraction Blacklist"
-    ~cache:(fun (_,_)-> blacklist_table := Id.Set.empty)
+    ~cache:(fun ()-> blacklist_table := Id.Set.empty)
     ~subst:None
 
 let reset_extraction_blacklist () = Lib.add_anonymous_leaf (reset_blacklist ())
@@ -819,12 +819,12 @@ let find_custom_match pv =
 
 let in_customs : GlobRef.t * string list * string -> obj =
   declare_object @@ superglobal_object_nodischarge "ML extractions"
-    ~cache:(fun (_,(r,ids,s)) -> add_custom r ids s)
+    ~cache:(fun (r,ids,s) -> add_custom r ids s)
     ~subst:(Some (fun (s,(r,ids,str)) -> (fst (subst_global s r), ids, str)))
 
 let in_custom_matchs : GlobRef.t * string -> obj =
   declare_object @@ superglobal_object_nodischarge "ML extractions custom matches"
-    ~cache:(fun (_,(r,s)) -> add_custom_match r s)
+    ~cache:(fun (r,s) -> add_custom_match r s)
     ~subst:(Some (fun (subs,(r,s)) -> (fst (subst_global subs r), s)))
 
 (* Grammar entries. *)

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -606,7 +606,7 @@ let extr_lang : lang -> obj =
     ~cache:(fun l -> lang_ref := l)
     ~subst:None
 
-let extraction_language x = Lib.add_anonymous_leaf (extr_lang x)
+let extraction_language x = Lib.add_leaf (extr_lang x)
 
 (*s Extraction Inline/NoInline *)
 
@@ -641,7 +641,7 @@ let extraction_inline b l =
     (fun r -> match r with
        | GlobRef.ConstRef _ -> ()
        | _ -> error_constant r) refs;
-  Lib.add_anonymous_leaf (inline_extraction (b,refs))
+  Lib.add_leaf (inline_extraction (b,refs))
 
 (* Printing part *)
 
@@ -664,7 +664,7 @@ let reset_inline : unit -> obj =
     ~cache:(fun () -> inline_table := empty_inline_table)
     ~subst:None
 
-let reset_extraction_inline () = Lib.add_anonymous_leaf (reset_inline ())
+let reset_extraction_inline () = Lib.add_leaf (reset_inline ())
 
 (*s Extraction Implicit *)
 
@@ -713,7 +713,7 @@ let implicit_extraction : GlobRef.t * int_or_id list -> obj =
 
 let extraction_implicit r l =
   check_inside_section ();
-  Lib.add_anonymous_leaf (implicit_extraction (Smartlocate.global_with_alias r,l))
+  Lib.add_leaf (implicit_extraction (Smartlocate.global_with_alias r,l))
 
 
 (*s Extraction Blacklist of filenames not to use while extracting *)
@@ -762,7 +762,7 @@ let blacklist_extraction : string list -> obj =
 
 let extraction_blacklist l =
   let l = List.rev l in
-  Lib.add_anonymous_leaf (blacklist_extraction l)
+  Lib.add_leaf (blacklist_extraction l)
 
 (* Printing part *)
 
@@ -776,7 +776,7 @@ let reset_blacklist : unit -> obj =
     ~cache:(fun ()-> blacklist_table := Id.Set.empty)
     ~subst:None
 
-let reset_extraction_blacklist () = Lib.add_anonymous_leaf (reset_blacklist ())
+let reset_extraction_blacklist () = Lib.add_leaf (reset_blacklist ())
 
 (*s Extract Constant/Inductive. *)
 
@@ -842,8 +842,8 @@ let extract_constant_inline inline r ids s =
             let nargs = Hook.get use_type_scheme_nb_args env typ in
             if not (Int.equal (List.length ids) nargs) then error_axiom_scheme ?loc:r.CAst.loc g nargs
           end;
-        Lib.add_anonymous_leaf (inline_extraction (inline,[g]));
-        Lib.add_anonymous_leaf (in_customs (g,ids,s))
+        Lib.add_leaf (inline_extraction (inline,[g]));
+        Lib.add_leaf (in_customs (g,ids,s))
     | _ -> error_constant ?loc:r.CAst.loc g
 
 
@@ -856,15 +856,15 @@ let extract_inductive r s l optstr =
         let mib = Global.lookup_mind kn in
         let n = Array.length mib.mind_packets.(i).mind_consnames in
         if not (Int.equal n (List.length l)) then error_nb_cons ();
-        Lib.add_anonymous_leaf (inline_extraction (true,[g]));
-        Lib.add_anonymous_leaf (in_customs (g,[],s));
-        Option.iter (fun s -> Lib.add_anonymous_leaf (in_custom_matchs (g,s)))
+        Lib.add_leaf (inline_extraction (true,[g]));
+        Lib.add_leaf (in_customs (g,[],s));
+        Option.iter (fun s -> Lib.add_leaf (in_custom_matchs (g,s)))
           optstr;
         List.iteri
           (fun j s ->
              let g = GlobRef.ConstructRef (ip,succ j) in
-             Lib.add_anonymous_leaf (inline_extraction (true,[g]));
-             Lib.add_anonymous_leaf (in_customs (g,[],s))) l
+             Lib.add_leaf (inline_extraction (true,[g]));
+             Lib.add_leaf (in_customs (g,[],s))) l
     | _ -> error_inductive ?loc:r.CAst.loc g
 
 

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -164,7 +164,7 @@ let cache_Function (_,(finfos)) =
   then function_table := new_tbl
 *)
 
-let cache_Function (_, finfos) =
+let cache_Function finfos =
   from_function := Cmap_env.add finfos.function_constant finfos !from_function;
   from_graph := Indmap.add finfos.graph_ind finfos !from_graph
 
@@ -207,7 +207,7 @@ let subst_Function (subst, finfos) =
     ; sprop_lemma = sprop_lemma'
     ; is_general = finfos.is_general }
 
-let discharge_Function (_, finfos) = Some finfos
+let discharge_Function finfos = Some finfos
 
 let pr_ocst env sigma c =
   Option.fold_right

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -266,7 +266,7 @@ let find_Function_of_graph ind = Indmap.find_opt ind !from_graph
 
 let update_Function finfo =
   (* Pp.msgnl (pr_info finfo); *)
-  Lib.add_anonymous_leaf (in_Function finfo)
+  Lib.add_leaf (in_Function finfo)
 
 let add_Function is_general f =
   let f_id = Label.to_id (Constant.label f) in

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -429,7 +429,7 @@ let add_transitivity_lemma left lem =
   let sigma = Evd.from_env env in
   let lem',ctx (*FIXME*) = Constrintern.interp_constr env sigma lem in
   let lem' = EConstr.to_constr sigma lem' in
-  Lib.add_anonymous_leaf (inTransitivity (left,lem'))
+  Lib.add_leaf (inTransitivity (left,lem'))
 
 }
 

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -410,7 +410,7 @@ let step left x tac =
 
 (* Main function to push lemmas in persistent environment *)
 
-let cache_transitivity_lemma (_,(left,lem)) =
+let cache_transitivity_lemma (left,lem) =
   if left then
     transitivity_left_table  := lem :: !transitivity_left_table
   else

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -384,7 +384,6 @@ END
 
 open Tactics
 open Libobject
-open Lib
 
 (* Registered lemmas are expected to be of the form
      x R y -> y == z -> x R z    (in the right table)
@@ -430,7 +429,7 @@ let add_transitivity_lemma left lem =
   let sigma = Evd.from_env env in
   let lem',ctx (*FIXME*) = Constrintern.interp_constr env sigma lem in
   let lem' = EConstr.to_constr sigma lem' in
-  add_anonymous_leaf (inTransitivity (left,lem'))
+  Lib.add_anonymous_leaf (inTransitivity (left,lem'))
 
 }
 

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -323,7 +323,7 @@ let add_glob_tactic_notation local ~level ?deprecation prods forml ids tac =
     tacobj_body = { alias_args = ids; alias_body = tac; alias_deprecation = deprecation };
     tacobj_forml = forml;
   } in
-  Lib.add_anonymous_leaf (inTacticGrammar tacobj)
+  Lib.add_leaf (inTacticGrammar tacobj)
 
 let add_tactic_notation local n ?deprecation prods e =
   let ids = List.map_filter cons_production_parameter prods in

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -294,7 +294,7 @@ let subst_tactic_notation (subst, tobj) =
     tacobj_body = { alias with alias_body = Tacsubst.subst_tactic subst alias.alias_body };
   }
 
-let classify_tactic_notation tacobj = Substitute tacobj
+let classify_tactic_notation tacobj = Substitute
 
 let ltac_notation_cat = Libobject.create_category "ltac.notations"
 

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -265,19 +265,19 @@ let check_key key =
     user_err Pp.(str "Conflicting tactic notations keys. This can happen when including \
     twice the same module.")
 
-let cache_tactic_notation (_, tobj) =
+let cache_tactic_notation tobj =
   let key = tobj.tacobj_key in
   let () = check_key key in
   Tacenv.register_alias key tobj.tacobj_body;
   extend_tactic_grammar key tobj.tacobj_forml tobj.tacobj_tacgram;
   Pptactic.declare_notation_tactic_pprule key (pprule tobj.tacobj_tacgram)
 
-let open_tactic_notation i (_, tobj) =
+let open_tactic_notation i tobj =
   let key = tobj.tacobj_key in
   if Int.equal i 1 && not tobj.tacobj_local then
     extend_tactic_grammar key tobj.tacobj_forml tobj.tacobj_tacgram
 
-let load_tactic_notation i (_, tobj) =
+let load_tactic_notation i tobj =
   let key = tobj.tacobj_key in
   let () = check_key key in
   (* Only add the printing and interpretation rules. *)

--- a/plugins/ltac/tacenv.ml
+++ b/plugins/ltac/tacenv.ml
@@ -195,7 +195,7 @@ let subst_md (subst, {local; replace=repl; for_ml; expr=t; depr}) =
 let classify_md o = Substitute
 
 let inMD : tacdef -> obj =
-  declare_named_object0 {(default_object "TAC-DEFINITION") with
+  declare_named_object_gen {(default_object "TAC-DEFINITION") with
      cache_function = cache_md;
      load_function = load_md;
      open_function = simple_open open_md;

--- a/plugins/ltac/tacenv.ml
+++ b/plugins/ltac/tacenv.ml
@@ -186,7 +186,7 @@ let subst_kind subst id = match id with
 let subst_md (subst, {local; replace=id; for_ml; expr=t; depr}) =
   {local; replace=subst_kind subst id; for_ml; expr=Tacsubst.subst_tactic subst t; depr}
 
-let classify_md o = Substitute o
+let classify_md o = Substitute
 
 let inMD : tacdef -> obj =
   declare_named_object {(default_object "TAC-DEFINITION") with

--- a/plugins/ltac/tacenv.ml
+++ b/plugins/ltac/tacenv.ml
@@ -188,7 +188,7 @@ let inMD : bool * ltac_constant option * bool * glob_tactic_expr *
      classify_function = classify_md}
 
 let register_ltac for_ml local ?deprecation id tac =
-  ignore (Lib.add_leaf id (inMD (local, None, for_ml, tac, deprecation)))
+  Lib.add_leaf id (inMD (local, None, for_ml, tac, deprecation))
 
 let redefine_ltac local ?deprecation kn tac =
   Lib.add_anonymous_leaf (inMD (local, Some kn, false, tac, deprecation))

--- a/plugins/ltac/tacenv.ml
+++ b/plugins/ltac/tacenv.ml
@@ -180,10 +180,10 @@ let classify_md (local, _, _, _, _ as o) = Substitute o
 
 let inMD : bool * ltac_constant option * bool * glob_tactic_expr *
            Deprecation.t option -> obj =
-  declare_object {(default_object "TAC-DEFINITION") with
-     cache_function  = cache_md;
-     load_function   = load_md;
-     open_function   = simple_open open_md;
+  declare_named_object {(default_object "TAC-DEFINITION") with
+     cache_function = cache_md;
+     load_function = load_md;
+     open_function = simple_open open_md;
      subst_function = subst_md;
      classify_function = classify_md}
 

--- a/plugins/ltac/tactic_option.ml
+++ b/plugins/ltac/tactic_option.ml
@@ -20,8 +20,8 @@ let declare_tactic_option ?(default=CAst.make (Tacexpr.TacId[])) name =
     locality := local;
     default_tactic := t
   in
-  let cache (_, (local, tac)) = set_default_tactic local tac in
-  let load (_, (local, tac)) =
+  let cache (local, tac) = set_default_tactic local tac in
+  let load (local, tac) =
     if not local then set_default_tactic local tac
   in
   let subst (s, (local, tac)) =

--- a/plugins/ltac/tactic_option.ml
+++ b/plugins/ltac/tactic_option.ml
@@ -33,8 +33,7 @@ let declare_tactic_option ?(default=CAst.make (Tacexpr.TacId[])) name =
         cache_function = cache;
         load_function = (fun _ -> load);
         open_function = simple_open (fun _ -> load);
-        classify_function = (fun (local, tac) ->
-          if local then Dispose else Substitute (local, tac));
+        classify_function = (fun (local, _) -> if local then Dispose else Substitute);
         subst_function = subst}
   in
   let put local tac =

--- a/plugins/ltac/tactic_option.ml
+++ b/plugins/ltac/tactic_option.ml
@@ -37,7 +37,7 @@ let declare_tactic_option ?(default=CAst.make (Tacexpr.TacId[])) name =
         subst_function = subst}
   in
   let put local tac =
-    Lib.add_anonymous_leaf (input (local, tac))
+    Lib.add_leaf (input (local, tac))
   in
   let get () = !locality, Tacinterp.eval_tactic !default_tactic in
   let print () =

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -94,7 +94,7 @@ let subst_tacdef (subst, def) =
   if expr' == def.tacdef_expr && type' == def.tacdef_type then def
   else { def with tacdef_expr = expr'; tacdef_type = type' }
 
-let classify_tacdef o = Substitute o
+let classify_tacdef o = Substitute
 
 let inTacDef : tacdef -> obj =
   declare_named_object {(default_object "TAC2-DEFINITION") with
@@ -201,7 +201,7 @@ let subst_typdef (subst, def) =
   let expr' = subst_quant_typedef subst def.typdef_expr in
   if expr' == def.typdef_expr then def else { def with typdef_expr = expr' }
 
-let classify_typdef o = Substitute o
+let classify_typdef o = Substitute
 
 let inTypDef : typdef -> obj =
   declare_named_object {(default_object "TAC2-TYPE-DEFINITION") with
@@ -271,7 +271,7 @@ let subst_typext (subst, e) =
   else
     { e with typext_type; typext_expr }
 
-let classify_typext o = Substitute o
+let classify_typext o = Substitute
 
 let inTypExt : typext -> obj =
   declare_named_object {(default_object "TAC2-TYPE-EXTENSION") with
@@ -704,7 +704,7 @@ let subst_synext (subst, syn) =
   if e == syn.synext_exp then syn else { syn with synext_exp = e }
 
 let classify_synext o =
-  if o.synext_loc then Dispose else Substitute o
+  if o.synext_loc then Dispose else Substitute
 
 let ltac2_notation_cat = Libobject.create_category "ltac2.notations"
 
@@ -736,7 +736,7 @@ let subst_abbreviation (subst, abbr) =
   if body' == abbr.abbr_body then abbr
   else { abbr_body = body'; abbr_depr = abbr.abbr_depr }
 
-let classify_abbreviation o = Substitute o
+let classify_abbreviation o = Substitute
 
 let inTac2Abbreviation : abbreviation -> obj =
   declare_named_object {(default_object "TAC2-ABBREVIATION") with
@@ -806,7 +806,7 @@ let subst_redefinition (subst, redef) =
   if kn == redef.redef_kn && body == redef.redef_body then redef
   else { redef_kn = kn; redef_body = body; redef_old = redef.redef_old }
 
-let classify_redefinition o = Substitute o
+let classify_redefinition o = Substitute
 
 let inTac2Redefinition : redefinition -> obj =
   declare_object

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -97,7 +97,7 @@ let subst_tacdef (subst, def) =
 let classify_tacdef o = Substitute o
 
 let inTacDef : tacdef -> obj =
-  declare_object {(default_object "TAC2-DEFINITION") with
+  declare_named_object {(default_object "TAC2-DEFINITION") with
      cache_function  = cache_tacdef;
      load_function   = load_tacdef;
      open_function   = simple_open open_tacdef;
@@ -204,7 +204,7 @@ let subst_typdef (subst, def) =
 let classify_typdef o = Substitute o
 
 let inTypDef : typdef -> obj =
-  declare_object {(default_object "TAC2-TYPE-DEFINITION") with
+  declare_named_object {(default_object "TAC2-TYPE-DEFINITION") with
      cache_function  = cache_typdef;
      load_function   = load_typdef;
      open_function   = simple_open open_typdef;
@@ -274,7 +274,7 @@ let subst_typext (subst, e) =
 let classify_typext o = Substitute o
 
 let inTypExt : typext -> obj =
-  declare_object {(default_object "TAC2-TYPE-EXTENSION") with
+  declare_named_object {(default_object "TAC2-TYPE-EXTENSION") with
      cache_function  = cache_typext;
      load_function   = load_typext;
      open_function   = simple_open open_typext;
@@ -693,10 +693,10 @@ let perform_notation syn st =
 let ltac2_notation =
   Pcoq.create_grammar_command "ltac2-notation" perform_notation
 
-let cache_synext (_, syn) =
+let cache_synext syn =
   Pcoq.extend_grammar_command ltac2_notation syn
 
-let open_synext i (_, syn) =
+let open_synext i syn =
   if Int.equal i 1 then Pcoq.extend_grammar_command ltac2_notation syn
 
 let subst_synext (subst, syn) =
@@ -739,7 +739,7 @@ let subst_abbreviation (subst, abbr) =
 let classify_abbreviation o = Substitute o
 
 let inTac2Abbreviation : abbreviation -> obj =
-  declare_object {(default_object "TAC2-ABBREVIATION") with
+  declare_named_object {(default_object "TAC2-ABBREVIATION") with
      cache_function  = cache_abbreviation;
      load_function   = load_abbreviation;
      open_function   = simple_open ~cat:ltac2_notation_cat open_abbreviation;
@@ -788,7 +788,7 @@ type redefinition = {
   redef_old : Id.t option;
 }
 
-let perform_redefinition (_, redef) =
+let perform_redefinition redef =
   let kn = redef.redef_kn in
   let data = Tac2env.interp_global kn in
   let body = match redef.redef_old with
@@ -809,11 +809,13 @@ let subst_redefinition (subst, redef) =
 let classify_redefinition o = Substitute o
 
 let inTac2Redefinition : redefinition -> obj =
-  declare_object {(default_object "TAC2-REDEFINITION") with
+  declare_object
+    {(default_object "TAC2-REDEFINITION") with
      cache_function  = perform_redefinition;
      open_function   = simple_open (fun _ -> perform_redefinition);
      subst_function = subst_redefinition;
-     classify_function = classify_redefinition }
+     classify_function = classify_redefinition;
+    }
 
 let register_redefinition qid old e =
   let kn =
@@ -1022,13 +1024,13 @@ let t_list = coq_def "list"
 
 let (f_register_constr_quotations, register_constr_quotations) = Hook.make ()
 
-let cache_ltac2_init (_, ()) =
+let cache_ltac2_init () =
   Hook.get f_register_constr_quotations ()
 
-let load_ltac2_init _ (_, ()) =
+let load_ltac2_init _ () =
   Hook.get f_register_constr_quotations ()
 
-let open_ltac2_init _ (_, ()) =
+let open_ltac2_init _ () =
   Goptions.set_string_option_value_gen ["Default"; "Proof"; "Mode"] "Ltac2"
 
 (** Dummy object that register global rules when Require is called *)

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -274,7 +274,7 @@ let subst_typext (subst, e) =
 let classify_typext o = Substitute
 
 let inTypExt : typext -> obj =
-  declare_named_object0 {(default_object "TAC2-TYPE-EXTENSION") with
+  declare_named_object_gen {(default_object "TAC2-TYPE-EXTENSION") with
      cache_function  = cache_typext;
      load_function   = load_typext;
      open_function   = simple_open open_typext;

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -96,7 +96,7 @@ let subst_tacdef (subst, def) =
 
 let classify_tacdef o = Substitute
 
-let inTacDef : tacdef -> obj =
+let inTacDef : Id.t -> tacdef -> obj =
   declare_named_object {(default_object "TAC2-DEFINITION") with
      cache_function  = cache_tacdef;
      load_function   = load_tacdef;
@@ -203,7 +203,7 @@ let subst_typdef (subst, def) =
 
 let classify_typdef o = Substitute
 
-let inTypDef : typdef -> obj =
+let inTypDef : Id.t -> typdef -> obj =
   declare_named_object {(default_object "TAC2-TYPE-DEFINITION") with
      cache_function  = cache_typdef;
      load_function   = load_typdef;
@@ -225,17 +225,17 @@ type typext = {
   typext_expr : extension_data list;
 }
 
-let push_typext vis sp kn def =
+let push_typext vis prefix def =
   let iter data =
-    let spc = change_sp_label sp data.edata_name in
-    let knc = change_kn_label kn data.edata_name in
+    let spc = Libnames.make_path prefix.obj_dir data.edata_name in
+    let knc = KerName.make prefix.obj_mp (Label.of_id data.edata_name) in
     Tac2env.push_constructor vis spc knc
   in
   List.iter iter def.typext_expr
 
-let define_typext kn def =
+let define_typext mp def =
   let iter data =
-    let knc = change_kn_label kn data.edata_name in
+    let knc = KerName.make mp (Label.of_id data.edata_name) in
     let cdata = {
       Tac2env.cdata_prms = def.typext_prms;
       cdata_type = def.typext_type;
@@ -246,13 +246,13 @@ let define_typext kn def =
   in
   List.iter iter def.typext_expr
 
-let cache_typext ((sp, kn), def) =
-  let () = define_typext kn def in
-  push_typext (Until 1) sp kn def
+let cache_typext (prefix, def) =
+  let () = define_typext prefix.obj_mp def in
+  push_typext (Until 1) prefix def
 
-let perform_typext vs ((sp, kn), def) =
-  let () = if not def.typext_local then push_typext vs sp kn def in
-  define_typext kn def
+let perform_typext vs (prefix, def) =
+  let () = if not def.typext_local then push_typext vs prefix def in
+  define_typext prefix.obj_mp def
 
 let load_typext i obj = perform_typext (Until i) obj
 let open_typext i obj = perform_typext (Exactly i) obj
@@ -274,7 +274,7 @@ let subst_typext (subst, e) =
 let classify_typext o = Substitute
 
 let inTypExt : typext -> obj =
-  declare_named_object {(default_object "TAC2-TYPE-EXTENSION") with
+  declare_named_object0 {(default_object "TAC2-TYPE-EXTENSION") with
      cache_function  = cache_typext;
      load_function   = load_typext;
      open_function   = simple_open open_typext;
@@ -369,7 +369,7 @@ let register_ltac ?deprecation ?(local = false) ?(mut = false) isrec tactics =
       tacdef_type = t;
       tacdef_deprecation = deprecation;
     } in
-    Lib.add_leaf id (inTacDef def)
+    Lib.add_leaf (inTacDef id def)
   in
   List.iter iter defs
 
@@ -460,7 +460,7 @@ let register_typedef ?(local = false) isrec types =
     (id, typdef)
   in
   let types = List.map map types in
-  let iter (id, def) = Lib.add_leaf id (inTypDef def) in
+  let iter (id, def) = Lib.add_leaf (inTypDef id def) in
   List.iter iter types
 
 let register_primitive ?deprecation ?(local = false) {loc;v=id} t ml =
@@ -489,7 +489,7 @@ let register_primitive ?deprecation ?(local = false) {loc;v=id} t ml =
     tacdef_type = t;
     tacdef_deprecation = deprecation;
   } in
-  Lib.add_leaf id (inTacDef def)
+  Lib.add_leaf (inTacDef id def)
 
 let register_open ?(local = false) qid (params, def) =
   let kn =
@@ -546,7 +546,7 @@ let register_open ?(local = false) qid (params, def) =
       typext_prms = tparams;
       typext_expr = def;
     } in
-    Lib.add_anonymous_leaf (inTypExt def)
+    Lib.add_leaf (inTypExt def)
   | CTydRec _ | CTydDef _ ->
     user_err ?loc:qid.CAst.loc (str "Extensions only accept inductive constructors")
 
@@ -738,7 +738,7 @@ let subst_abbreviation (subst, abbr) =
 
 let classify_abbreviation o = Substitute
 
-let inTac2Abbreviation : abbreviation -> obj =
+let inTac2Abbreviation : Id.t -> abbreviation -> obj =
   declare_named_object {(default_object "TAC2-ABBREVIATION") with
      cache_function  = cache_abbreviation;
      load_function   = load_abbreviation;
@@ -752,7 +752,7 @@ let register_notation ?deprecation ?(local = false) tkn lev body = match tkn, le
   let () = check_lowercase CAst.(make ?loc id) in
   let body = Tac2intern.globalize Id.Set.empty body in
   let abbr = { abbr_body = body; abbr_depr = deprecation } in
-  Lib.add_leaf id (inTac2Abbreviation abbr)
+  Lib.add_leaf (inTac2Abbreviation id abbr)
 | _ ->
   (* Check that the tokens make sense *)
   let entries = List.map ParseToken.parse_token tkn in
@@ -780,7 +780,7 @@ let register_notation ?deprecation ?(local = false) tkn lev body = match tkn, le
     synext_loc = local;
     synext_depr = deprecation;
   } in
-  Lib.add_anonymous_leaf (inTac2Notation ext)
+  Lib.add_leaf (inTac2Notation ext)
 
 type redefinition = {
   redef_kn : ltac_constant;
@@ -853,7 +853,7 @@ let register_redefinition qid old e =
     redef_body = e;
     redef_old = old;
   } in
-  Lib.add_anonymous_leaf (inTac2Redefinition def)
+  Lib.add_leaf (inTac2Redefinition def)
 
 let perform_eval ~pstate e =
   let env = Global.env () in
@@ -1011,7 +1011,7 @@ let register_prim_alg name params def =
   } in
   let def = (params, GTydAlg alg) in
   let def = { typdef_local = false; typdef_expr = def } in
-  Lib.add_leaf id (inTypDef def)
+  Lib.add_leaf (inTypDef id def)
 
 let coq_def n = KerName.make Tac2env.coq_prefix (Label.make n)
 
@@ -1042,10 +1042,11 @@ let inTac2Init : unit -> obj =
   }
 
 let _ = Mltop.declare_cache_obj begin fun () ->
-  Lib.add_leaf (Id.of_string "unit") (inTypDef def_unit);
+  let unit = Id.of_string "unit" in
+  Lib.add_leaf (inTypDef unit def_unit);
   register_prim_alg "list" 1 [
     ("[]", []);
     ("::", [GTypVar 0; GTypRef (Other t_list, [GTypVar 0])]);
   ];
-  Lib.add_anonymous_leaf (inTac2Init ());
+  Lib.add_leaf (inTac2Init ());
 end "ltac2_plugin"

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -369,7 +369,7 @@ let register_ltac ?deprecation ?(local = false) ?(mut = false) isrec tactics =
       tacdef_type = t;
       tacdef_deprecation = deprecation;
     } in
-    ignore (Lib.add_leaf id (inTacDef def))
+    Lib.add_leaf id (inTacDef def)
   in
   List.iter iter defs
 
@@ -460,7 +460,7 @@ let register_typedef ?(local = false) isrec types =
     (id, typdef)
   in
   let types = List.map map types in
-  let iter (id, def) = ignore (Lib.add_leaf id (inTypDef def)) in
+  let iter (id, def) = Lib.add_leaf id (inTypDef def) in
   List.iter iter types
 
 let register_primitive ?deprecation ?(local = false) {loc;v=id} t ml =
@@ -489,7 +489,7 @@ let register_primitive ?deprecation ?(local = false) {loc;v=id} t ml =
     tacdef_type = t;
     tacdef_deprecation = deprecation;
   } in
-  ignore (Lib.add_leaf id (inTacDef def))
+  Lib.add_leaf id (inTacDef def)
 
 let register_open ?(local = false) qid (params, def) =
   let kn =
@@ -752,7 +752,7 @@ let register_notation ?deprecation ?(local = false) tkn lev body = match tkn, le
   let () = check_lowercase CAst.(make ?loc id) in
   let body = Tac2intern.globalize Id.Set.empty body in
   let abbr = { abbr_body = body; abbr_depr = deprecation } in
-  ignore (Lib.add_leaf id (inTac2Abbreviation abbr))
+  Lib.add_leaf id (inTac2Abbreviation abbr)
 | _ ->
   (* Check that the tokens make sense *)
   let entries = List.map ParseToken.parse_token tkn in
@@ -1009,7 +1009,7 @@ let register_prim_alg name params def =
   } in
   let def = (params, GTydAlg alg) in
   let def = { typdef_local = false; typdef_expr = def } in
-  ignore (Lib.add_leaf id (inTypDef def))
+  Lib.add_leaf id (inTypDef def)
 
 let coq_def n = KerName.make Tac2env.coq_prefix (Label.make n)
 
@@ -1040,7 +1040,7 @@ let inTac2Init : unit -> obj =
   }
 
 let _ = Mltop.declare_cache_obj begin fun () ->
-  ignore (Lib.add_leaf (Id.of_string "unit") (inTypDef def_unit));
+  Lib.add_leaf (Id.of_string "unit") (inTypDef def_unit);
   register_prim_alg "list" 1 [
     ("[]", []);
     ("::", [GTypVar 0; GTypRef (Other t_list, [GTypVar 0])]);

--- a/plugins/micromega/zify.ml
+++ b/plugins/micromega/zify.ml
@@ -676,7 +676,7 @@ module MakeTable (E : Elt) = struct
   let register c =
     try
       let c = UnivGen.constr_of_monomorphic_global (Global.env ()) (Nametab.locate c) in
-      let _ = Lib.add_anonymous_leaf (register_obj c) in
+      let _ = Lib.add_leaf (register_obj c) in
       ()
     with Not_found ->
       raise

--- a/plugins/micromega/zify.ml
+++ b/plugins/micromega/zify.ml
@@ -657,7 +657,7 @@ module MakeTable (E : Elt) = struct
              ++ str " X1 ... Xn"))
 
   let register_obj : Constr.constr -> Libobject.obj =
-    let cache_constr (_, c) =
+    let cache_constr c =
       let env = Global.env () in
       let evd = Evd.from_env env in
       register_constr env evd c

--- a/plugins/ring/ring.ml
+++ b/plugins/ring/ring.ml
@@ -396,9 +396,8 @@ let subst_th (subst,th) =
 
 
 let theory_to_obj : ring_info -> obj =
-  let cache_th (_, th) = add_entry th in
   declare_object @@ global_object_nodischarge "tactic-new-ring-theory"
-    ~cache:cache_th
+    ~cache:add_entry
     ~subst:(Some subst_th)
 
 let setoid_of_relation env sigma a r =
@@ -841,9 +840,8 @@ let subst_th (subst,th) =
       field_post_tac = posttac' }
 
 let ftheory_to_obj : field_info -> obj =
-  let cache_th (_, th) = add_field_entry th in
   declare_object @@ global_object_nodischarge "tactic-new-field-theory"
-    ~cache:cache_th
+    ~cache:add_field_entry
     ~subst:(Some subst_th)
 
 let field_equality env sigma r inv req =

--- a/plugins/ring/ring.ml
+++ b/plugins/ring/ring.ml
@@ -585,7 +585,7 @@ let add_theory0 env sigma name rth eqth morphth cst_tac (pre,post) power sign di
   let req = EConstr.to_constr sigma req in
   let sth = EConstr.to_constr sigma sth in
   let _ =
-    Lib.add_anonymous_leaf
+    Lib.add_leaf
       (theory_to_obj
         { ring_name = name;
           ring_carrier = r;
@@ -907,7 +907,7 @@ let add_field_theory0 env sigma name fth eqth morphth cst_tac inj (pre,post) pow
   let r = EConstr.to_constr sigma r in
   let req = EConstr.to_constr sigma req in
   let _ =
-    Lib.add_anonymous_leaf
+    Lib.add_leaf
       (ftheory_to_obj
         { field_name = name;
           field_carrier = r;

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -80,7 +80,7 @@ let ssrtac_entry name = {
   mltac_index = 0;
 }
 
-let cache_tactic_notation (_, (key, body, parule)) =
+let cache_tactic_notation (key, body, parule) =
   Tacenv.register_alias key body;
   Pptactic.declare_notation_tactic_pprule key parule
 

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -90,7 +90,7 @@ let inSsrGrammar : tactic_grammar_obj -> obj =
   declare_object {(default_object "SsrGrammar") with
                   load_function = (fun _ -> cache_tactic_notation);
                   cache_function = cache_tactic_notation;
-                  classify_function = (fun x -> Keep x)}
+                  classify_function = (fun x -> Keep)}
 
 let path = MPfile (DirPath.make @@ List.map Id.of_string ["ssreflect"; "ssr"; "Coq"])
 

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -110,7 +110,7 @@ let register_ssrtac name f prods =
     pptac_prods = prods
   } in
   let obj () =
-    Lib.add_anonymous_leaf (inSsrGrammar (key, body, parule)) in
+    Lib.add_leaf (inSsrGrammar (key, body, parule)) in
   Mltop.declare_cache_obj obj __coq_plugin_name;
   key
 

--- a/plugins/ssr/ssrview.ml
+++ b/plugins/ssr/ssrview.ml
@@ -37,12 +37,12 @@ module AdaptorDb = struct
     try AdaptorMap.find k !term_view_adaptor_db
     with Not_found -> []
 
-  let cache_adaptor (_, (k, t)) =
+  let cache_adaptor (k, t) =
     let lk = get k in
     if not (List.exists (Glob_ops.glob_constr_eq t) lk) then
       term_view_adaptor_db := AdaptorMap.add k (t :: lk) !term_view_adaptor_db
 
-  let subst_adaptor ( subst, (k, t as a)) =
+  let subst_adaptor (subst, (k, t as a)) =
     let t' = Detyping.subst_glob_constr (Global.env()) subst t in
     if t' == t then a else k, t'
 

--- a/plugins/ssr/ssrview.ml
+++ b/plugins/ssr/ssrview.ml
@@ -53,7 +53,7 @@ module AdaptorDb = struct
       ~subst:(Some subst_adaptor)
 
   let declare kind terms =
-    List.iter (fun term -> Lib.add_anonymous_leaf (in_db (kind,term)))
+    List.iter (fun term -> Lib.add_leaf (in_db (kind,term)))
       (List.rev terms)
 
 end

--- a/pretyping/arguments_renaming.ml
+++ b/pretyping/arguments_renaming.ml
@@ -28,7 +28,7 @@ type req =
   | ReqLocal
   | ReqGlobal of GlobRef.t * Name.t list
 
-let load_rename_args _ (_, (_, (r, names))) =
+let load_rename_args _ (_, (r, names)) =
   name_table := GlobRef.Map.add r names !name_table
 
 let cache_rename_args o = load_rename_args 1 o

--- a/pretyping/arguments_renaming.ml
+++ b/pretyping/arguments_renaming.ml
@@ -43,7 +43,7 @@ let subst_rename_args (subst, (_, (r, names as orig))) =
   if r==r' then orig else (r', names)
 
 let discharge_rename_args = function
-  | _, (ReqGlobal (c, names), _ as req) when not (isVarRef c && Lib.is_in_section c) ->
+  | ReqGlobal (c, names), _ as req when not (isVarRef c && Lib.is_in_section c) ->
      (try
        let vars = Lib.variable_section_segment_of_reference c in
        let var_names = List.map (NamedDecl.get_id %> Name.mk_name) vars in

--- a/pretyping/arguments_renaming.ml
+++ b/pretyping/arguments_renaming.ml
@@ -35,7 +35,7 @@ let cache_rename_args o = load_rename_args 1 o
 
 let classify_rename_args = function
   | ReqLocal, _ -> Dispose
-  | ReqGlobal _, _ as o -> Substitute o
+  | ReqGlobal _, _ -> Substitute
 
 let subst_rename_args (subst, (_, (r, names as orig))) =
   ReqLocal,

--- a/pretyping/arguments_renaming.ml
+++ b/pretyping/arguments_renaming.ml
@@ -73,7 +73,7 @@ let rename_arguments local r names =
     | _ -> ()
   in
   let req = if local then ReqLocal else ReqGlobal (r, names) in
-  Lib.add_anonymous_leaf (inRenameArgs (req, (r, names)))
+  Lib.add_leaf (inRenameArgs (req, (r, names)))
 
 let arguments_names r = GlobRef.Map.find r !name_table
 

--- a/pretyping/keys.ml
+++ b/pretyping/keys.ml
@@ -115,7 +115,7 @@ let inKeys : key_obj -> obj =
     ~discharge:discharge_keys
 
 let declare_equiv_keys ref ref' =
-  Lib.add_anonymous_leaf (inKeys (ref,ref'))
+  Lib.add_leaf (inKeys (ref,ref'))
 
 let constr_key kind c =
   try

--- a/pretyping/keys.ml
+++ b/pretyping/keys.ml
@@ -83,7 +83,7 @@ let equiv_keys k k' =
 
 (** Registration of keys as an object *)
 
-let load_keys _ (_,(ref,ref')) =
+let load_keys _ (ref,ref') =
   add_keys ref ref'
 
 let cache_keys o =
@@ -101,7 +101,7 @@ let discharge_key = function
   | KGlob (GlobRef.VarRef _ as g) when Lib.is_in_section g -> None
   | x -> Some x
 
-let discharge_keys (_,(k,k')) =
+let discharge_keys (k,k') =
   match discharge_key k, discharge_key k' with
   | Some x, Some y -> Some (x, y)
   | _ -> None

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -49,7 +49,7 @@ let reduction_effect_hook env sigma con c =
     effect env sigma (Lazy.force c)
   with Not_found -> ()
 
-let cache_reduction_effect (_,(con,funkey)) =
+let cache_reduction_effect (con,funkey) =
   constant_effect_table := Cmap.add con funkey !constant_effect_table
 
 let subst_reduction_effect (subst,(con,funkey)) =

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -92,7 +92,7 @@ module ReductionBehaviour = struct
   let table =
     Summary.ref (GlobRef.Map.empty : t GlobRef.Map.t) ~name:"reductionbehaviour"
 
-  let load _ (_,(_,(r, b))) =
+  let load _ (_,(r, b)) =
     table := GlobRef.Map.add r b !table
 
   let cache o = load 1 o
@@ -120,14 +120,14 @@ module ReductionBehaviour = struct
     | _ -> assert false
 
   let inRedBehaviour = declare_object {
-                        (default_object "REDUCTIONBEHAVIOUR") with
-                        load_function = load;
-                        cache_function = cache;
-                        classify_function = classify;
-                        subst_function = subst;
-                        discharge_function = discharge;
-                        rebuild_function = rebuild;
-                      }
+      (default_object "REDUCTIONBEHAVIOUR") with
+      load_function = load;
+      cache_function = cache;
+      classify_function = classify;
+      subst_function = subst;
+      discharge_function = discharge;
+      rebuild_function = rebuild;
+    }
 
   let set ~local r b =
     Lib.add_anonymous_leaf (inRedBehaviour (local, (r, b)))

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -104,7 +104,7 @@ module ReductionBehaviour = struct
     else (local,(r',o))
 
   let discharge = function
-    | _,(false, (gr, b)) ->
+    | false, (gr, b) ->
       let b =
         if Lib.is_in_section gr then
           let vars = Lib.variable_section_segment_of_reference gr in
@@ -113,7 +113,7 @@ module ReductionBehaviour = struct
         else b
       in
       Some (false, (gr, b))
-    | _ -> None
+    | true, _ -> None
 
   let rebuild = function
     | req, (GlobRef.ConstRef c, _ as x) -> req, x

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -67,7 +67,7 @@ let declare_reduction_effect funkey f =
 
 (** A function to set the value of the print function *)
 let set_reduction_effect x funkey =
-  Lib.add_anonymous_leaf (inReductionEffect (x,funkey))
+  Lib.add_leaf (inReductionEffect (x,funkey))
 
 
 (** Machinery to custom the behavior of the reduction *)
@@ -130,7 +130,7 @@ module ReductionBehaviour = struct
     }
 
   let set ~local r b =
-    Lib.add_anonymous_leaf (inRedBehaviour (local, (r, b)))
+    Lib.add_leaf (inRedBehaviour (local, (r, b)))
 
   let get r = GlobRef.Map.find_opt r !table
 

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -97,7 +97,7 @@ module ReductionBehaviour = struct
 
   let cache o = load 1 o
 
-  let classify (local,_ as o) = if local then Dispose else Substitute o
+  let classify (local,_) = if local then Dispose else Substitute
 
   let subst (subst, (local, (r,o) as orig)) =
     let r' = subst_global_reference subst r in if r==r' then orig

--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -299,11 +299,11 @@ let add_rew_rules ~locality base lrul =
       CErrors.user_err Pp.(str
         "This command does not support the global attribute in sections.");
     in
-    Lib.add_anonymous_leaf (inGlobalHintRewrite (base,lrul))
+    Lib.add_leaf (inGlobalHintRewrite (base,lrul))
   | Export ->
     let () =
       if Global.sections_are_opened () then
         CErrors.user_err Pp.(str
           "This command does not support the export attribute in sections.");
     in
-    Lib.add_anonymous_leaf (inExportHintRewrite (base,lrul))
+    Lib.add_leaf (inExportHintRewrite (base,lrul))

--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -191,7 +191,7 @@ let auto_multi_rewrite_with ?(conds=Naive) tac_main lbas cl =
         (strbrk "autorewrite .. in .. using can only be used either with a unique hypothesis or on the conclusion.")
 
 (* Functions necessary to the library object declaration *)
-let cache_hintrewrite (_,(rbase,lrl)) =
+let cache_hintrewrite (rbase,lrl) =
   let base = try raw_find_base rbase with Not_found -> HintDN.empty in
   let max = try fst (Util.List.last (HintDN.find_all base)) with Failure _ -> 0
   in
@@ -292,7 +292,7 @@ let add_rew_rules ~locality base lrul =
   in
   let open Hints in
   match locality with
-  | Local -> cache_hintrewrite ((),(base,lrul))
+  | Local -> cache_hintrewrite (base,lrul)
   | SuperGlobal ->
     let () =
       if Global.sections_are_opened () then

--- a/tactics/declareScheme.ml
+++ b/tactics/declareScheme.ml
@@ -37,7 +37,7 @@ let inScheme : string * (inductive * Constant.t) array -> Libobject.obj =
     ~discharge:discharge_scheme
 
 let declare_scheme kind indcl =
-  Lib.add_anonymous_leaf (inScheme (kind,indcl))
+  Lib.add_leaf (inScheme (kind,indcl))
 
 let lookup_scheme kind ind = CString.Map.find kind (Indmap.find ind !scheme_map)
 

--- a/tactics/declareScheme.ml
+++ b/tactics/declareScheme.ml
@@ -16,7 +16,7 @@ let cache_one_scheme kind (ind,const) =
   let map = try Indmap.find ind !scheme_map with Not_found -> CString.Map.empty in
   scheme_map := Indmap.add ind (CString.Map.add kind const map) !scheme_map
 
-let cache_scheme (_,(kind,l)) =
+let cache_scheme (kind,l) =
   Array.iter (cache_one_scheme kind) l
 
 let subst_one_scheme subst (ind,const) =
@@ -26,7 +26,7 @@ let subst_one_scheme subst (ind,const) =
 let subst_scheme (subst,(kind,l)) =
   (kind, CArray.Smart.map (subst_one_scheme subst) l)
 
-let discharge_scheme (_,(kind,l)) =
+let discharge_scheme (kind,l) =
   Some (kind, l)
 
 let inScheme : string * (inductive * Constant.t) array -> Libobject.obj =

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1200,7 +1200,7 @@ let classify_autohint obj =
   if is_hint_local obj.hint_local || is_trivial_action obj.hint_action then Dispose
   else Substitute obj
 
-let discharge_autohint (_, obj) =
+let discharge_autohint obj =
   if is_hint_local obj.hint_local then None
   else
     let action = match obj.hint_action with

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1019,7 +1019,7 @@ type db_obj = {
   db_ts : TransparentState.t;
 }
 
-let cache_db (_, {db_name=name; db_use_dn=b; db_ts=ts}) =
+let cache_db {db_name=name; db_use_dn=b; db_ts=ts} =
   searchtable_add (name, Hint_db.empty ~name ts b)
 
 let load_db _ x = cache_db x
@@ -1078,7 +1078,7 @@ let superglobal h = match h.hint_local with
   | SuperGlobal -> true
   | Local | Export -> false
 
-let load_autohint _ (kn, h) =
+let load_autohint _ h =
   let name = h.hint_name in
   let superglobal = superglobal h in
   match h.hint_action with
@@ -1093,7 +1093,7 @@ let load_autohint _ (kn, h) =
   | AddMode { gref; mode } ->
     if superglobal then add_mode name gref mode
 
-let open_autohint i (kn, h) =
+let open_autohint i h =
   let superglobal = superglobal h in
   if Int.equal i 1 then match h.hint_action with
   | AddHints hints ->
@@ -1114,8 +1114,8 @@ let open_autohint i (kn, h) =
   | AddMode { gref; mode } ->
     if not superglobal then add_mode h.hint_name gref mode
 
-let cache_autohint (kn, obj) =
-  load_autohint 1 (kn, obj); open_autohint 1 (kn, obj)
+let cache_autohint o =
+  load_autohint 1 o; open_autohint 1 o
 
 let subst_autohint (subst, obj) =
   let subst_key gr =
@@ -1237,14 +1237,15 @@ let discharge_autohint obj =
 let hint_cat = create_category "hints"
 
 let inAutoHint : hint_obj -> obj =
-  declare_object {(default_object "AUTOHINT") with
-                    cache_function = cache_autohint;
-                    load_function = load_autohint;
-                    open_function = simple_open ~cat:hint_cat open_autohint;
-                    subst_function = subst_autohint;
-                    classify_function = classify_autohint;
-                    discharge_function = discharge_autohint;
-                  }
+  declare_object
+    {(default_object "AUTOHINT") with
+     cache_function = cache_autohint;
+     load_function = load_autohint;
+     open_function = simple_open ~cat:hint_cat open_autohint;
+     subst_function = subst_autohint;
+     classify_function = classify_autohint;
+     discharge_function = discharge_autohint;
+    }
 
 let check_locality locality =
   let not_local what =

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1024,7 +1024,7 @@ let cache_db {db_name=name; db_use_dn=b; db_ts=ts} =
 
 let load_db _ x = cache_db x
 
-let classify_db db = if db.db_local then Dispose else Substitute db
+let classify_db db = if db.db_local then Dispose else Substitute
 
 let inDB : db_obj -> obj =
   declare_object {(default_object "AUTOHINT_DB") with
@@ -1198,7 +1198,7 @@ let is_hint_local = function Local -> true | Export | SuperGlobal -> false
 
 let classify_autohint obj =
   if is_hint_local obj.hint_local || is_trivial_action obj.hint_action then Dispose
-  else Substitute obj
+  else Substitute
 
 let discharge_autohint obj =
   if is_hint_local obj.hint_local then None

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1035,7 +1035,7 @@ let inDB : db_obj -> obj =
 
 let create_hint_db l n ts b =
   let hint = {db_local=l; db_name=n; db_use_dn=b; db_ts=ts} in
-  Lib.add_anonymous_leaf (inDB hint)
+  Lib.add_leaf (inDB hint)
 
 type hint_action =
   | AddTransparency of {
@@ -1287,7 +1287,7 @@ let remove_hints ~locality dbnames grs =
     List.iter
       (fun dbname ->
         let hint = make_hint ~locality dbname (RemoveHints grs) in
-        Lib.add_anonymous_leaf (inAutoHint hint))
+        Lib.add_leaf (inAutoHint hint))
       dbnames
 
 (**************************************************************************)
@@ -1322,21 +1322,21 @@ let add_resolves env sigma clist ~locality dbnames =
       in
       let () = if not !Flags.quiet then List.iter check r in
       let hint = make_hint ~locality dbname (AddHints r) in
-      Lib.add_anonymous_leaf (inAutoHint hint))
+      Lib.add_leaf (inAutoHint hint))
     dbnames
 
 let add_unfolds l ~locality dbnames =
   List.iter
     (fun dbname ->
       let hint = make_hint ~locality dbname (AddHints (List.map make_unfold l)) in
-      Lib.add_anonymous_leaf (inAutoHint hint))
+      Lib.add_leaf (inAutoHint hint))
     dbnames
 
 let add_cuts l ~locality dbnames =
   List.iter
     (fun dbname ->
       let hint = make_hint ~locality dbname (AddCut l) in
-      Lib.add_anonymous_leaf (inAutoHint hint))
+      Lib.add_leaf (inAutoHint hint))
     dbnames
 
 let add_mode l m ~locality dbnames =
@@ -1344,14 +1344,14 @@ let add_mode l m ~locality dbnames =
     (fun dbname ->
       let m' = make_mode l m in
       let hint = make_hint ~locality dbname (AddMode { gref = l; mode = m' }) in
-      Lib.add_anonymous_leaf (inAutoHint hint))
+      Lib.add_leaf (inAutoHint hint))
     dbnames
 
 let add_transparency l b ~locality dbnames =
   List.iter
     (fun dbname ->
       let hint = make_hint ~locality dbname (AddTransparency { grefs = l; state = b }) in
-      Lib.add_anonymous_leaf (inAutoHint hint))
+      Lib.add_leaf (inAutoHint hint))
     dbnames
 
 let add_extern info tacast ~locality dbname =
@@ -1361,7 +1361,7 @@ let add_extern info tacast ~locality dbname =
   in
   let hint = make_hint ~locality dbname
                        (AddHints [make_extern (Option.get info.hint_priority) pat tacast]) in
-  Lib.add_anonymous_leaf (inAutoHint hint)
+  Lib.add_leaf (inAutoHint hint)
 
 let add_externs info tacast ~locality dbnames =
   List.iter (add_extern info tacast ~locality) dbnames
@@ -1371,7 +1371,7 @@ let add_trivials env sigma l ~locality dbnames =
     (fun dbname ->
       let l = List.map (fun (name, c) -> make_trivial env sigma ~name c) l in
       let hint = make_hint ~locality dbname (AddHints l) in
-      Lib.add_anonymous_leaf (inAutoHint hint))
+      Lib.add_leaf (inAutoHint hint))
     dbnames
 
 type hnf = bool

--- a/tactics/redexpr.ml
+++ b/tactics/redexpr.ml
@@ -121,7 +121,7 @@ let inStrategy : strategy_obj -> obj =
 
 
 let set_strategy local str =
-  Lib.add_anonymous_leaf (inStrategy (local,str))
+  Lib.add_leaf (inStrategy (local,str))
 
 (* Generic reduction: reduction functions used in reduction tactics *)
 
@@ -360,4 +360,4 @@ let inReduction : bool * string * red_expr -> obj =
        (fun ((b,_,_)) -> if b then Dispose else Substitute) }
 
 let declare_red_expr locality s expr =
-    Lib.add_anonymous_leaf (inReduction (locality,s,expr))
+    Lib.add_leaf (inReduction (locality,s,expr))

--- a/tactics/redexpr.ml
+++ b/tactics/redexpr.ml
@@ -102,7 +102,7 @@ let disch_ref ref =
       EvalConstRef c -> Some ref
     | EvalVarRef id -> if Lib.is_in_section (GlobRef.VarRef id) then None else Some ref
 
-let discharge_strategy (_,(local,obj)) =
+let discharge_strategy (local,obj) =
   if local then None else
   map_strategy disch_ref obj
 

--- a/tactics/redexpr.ml
+++ b/tactics/redexpr.ml
@@ -94,8 +94,8 @@ let map_strategy f l =
       if List.is_empty ql' then str else (lev,ql')::str) l [] in
   if List.is_empty l' then None else Some (false,l')
 
-let classify_strategy (local,_ as obj) =
-  if local then Dispose else Substitute obj
+let classify_strategy (local,_) =
+  if local then Dispose else Substitute
 
 let disch_ref ref =
   match ref with
@@ -357,7 +357,7 @@ let inReduction : bool * string * red_expr -> obj =
      subst_function =
        (fun (subs,(b,s,e)) -> b,s,subst_red_expr subs e);
      classify_function =
-       (fun ((b,_,_) as obj) -> if b then Dispose else Substitute obj) }
+       (fun ((b,_,_)) -> if b then Dispose else Substitute) }
 
 let declare_red_expr locality s expr =
     Lib.add_anonymous_leaf (inReduction (locality,s,expr))

--- a/tactics/redexpr.ml
+++ b/tactics/redexpr.ml
@@ -110,12 +110,14 @@ type strategy_obj =
     bool * (Conv_oracle.level * evaluable_global_reference list) list
 
 let inStrategy : strategy_obj -> obj =
-  declare_object {(default_object "STRATEGY") with
-                    cache_function = (fun (_,obj) -> cache_strategy obj);
-                    load_function = (fun _ (_,obj) -> cache_strategy obj);
-                    subst_function = subst_strategy;
-                    discharge_function = discharge_strategy;
-                    classify_function = classify_strategy }
+  declare_object
+    {(default_object "STRATEGY") with
+     cache_function = cache_strategy;
+     load_function = (fun _ obj -> cache_strategy obj);
+     subst_function = subst_strategy;
+     discharge_function = discharge_strategy;
+     classify_function = classify_strategy;
+    }
 
 
 let set_strategy local str =
@@ -350,12 +352,12 @@ let subst_red_expr subs =
 let inReduction : bool * string * red_expr -> obj =
   declare_object
     {(default_object "REDUCTION") with
-       cache_function = (fun (_,(_,s,e)) -> decl_red_expr s e);
-       load_function = (fun _ (_,(_,s,e)) -> decl_red_expr s e);
-       subst_function =
-        (fun (subs,(b,s,e)) -> b,s,subst_red_expr subs e);
-       classify_function =
-        (fun ((b,_,_) as obj) -> if b then Dispose else Substitute obj) }
+     cache_function = (fun (_,s,e) -> decl_red_expr s e);
+     load_function = (fun _ (_,s,e) -> decl_red_expr s e);
+     subst_function =
+       (fun (subs,(b,s,e)) -> b,s,subst_red_expr subs e);
+     classify_function =
+       (fun ((b,_,_) as obj) -> if b then Dispose else Substitute obj) }
 
 let declare_red_expr locality s expr =
     Lib.add_anonymous_leaf (inReduction (locality,s,expr))

--- a/test-suite/unit-tests/printing/proof_diffs_test.ml
+++ b/test-suite/unit-tests/printing/proof_diffs_test.ml
@@ -3,6 +3,11 @@ open Utest
 open Pp_diff
 open Proof_diffs
 
+(* Needed to be able to set through goptions *)
+let () =
+  let open Names in
+  Lib.start_compilation DirPath.initial (ModPath.MPfile DirPath.initial)
+
 let tokenize_string = Proof_diffs.tokenize_string
 let diff_pp = diff_pp ~tokenize_string
 let diff_str = diff_str ~tokenize_string

--- a/vernac/canonical.ml
+++ b/vernac/canonical.ml
@@ -20,7 +20,7 @@ let cache_canonical_structure (_, (o,_)) =
   let sigma = Evd.from_env env in
   Instance.register ~warn:true env sigma o
 
-let discharge_canonical_structure (_,(x, local)) =
+let discharge_canonical_structure (x, local) =
   let gref = Instance.repr x in
   if local || (Globnames.isVarRef gref && Lib.is_in_section gref) then None
   else Some (x, local)

--- a/vernac/canonical.ml
+++ b/vernac/canonical.ml
@@ -32,7 +32,7 @@ let inCanonStruc : Instance.t * bool -> obj =
                   open_function = simple_open ~cat:canon_cat open_canonical_structure;
                   cache_function = cache_canonical_structure;
                   subst_function = (fun (subst,(c,local)) -> Instance.subst subst c, local);
-                  classify_function = (fun x -> Substitute x);
+                  classify_function = (fun x -> Substitute);
                   discharge_function = discharge_canonical_structure }
 
 let add_canonical_structure x = Lib.add_anonymous_leaf (inCanonStruc x)

--- a/vernac/canonical.ml
+++ b/vernac/canonical.ml
@@ -10,12 +10,12 @@
 open Libobject
 open Structures
 
-let open_canonical_structure i (_, (o,_)) =
+let open_canonical_structure i (o,_) =
   let env = Global.env () in
   let sigma = Evd.from_env env in
   if Int.equal i 1 then Instance.register env sigma ~warn:false o
 
-let cache_canonical_structure (_, (o,_)) =
+let cache_canonical_structure (o,_) =
   let env = Global.env () in
   let sigma = Evd.from_env env in
   Instance.register ~warn:true env sigma o

--- a/vernac/canonical.ml
+++ b/vernac/canonical.ml
@@ -35,7 +35,7 @@ let inCanonStruc : Instance.t * bool -> obj =
                   classify_function = (fun x -> Substitute);
                   discharge_function = discharge_canonical_structure }
 
-let add_canonical_structure x = Lib.add_anonymous_leaf (inCanonStruc x)
+let add_canonical_structure x = Lib.add_leaf (inCanonStruc x)
 
 let declare_canonical_structure ?(local=false) ref =
   let env = Global.env () in

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -103,14 +103,14 @@ let perform_instance i =
   let i = { is_class = i.inst_class; is_info = i.inst_info; is_impl = i.inst_impl } in
   Typeclasses.load_instance i
 
-let cache_instance (_, inst) = perform_instance inst
+let cache_instance inst = perform_instance inst
 
-let load_instance _ (_, inst) = match inst.inst_global with
+let load_instance _ inst = match inst.inst_global with
 | Local -> assert false
 | SuperGlobal -> perform_instance inst
 | Export -> ()
 
-let open_instance i (_, inst) = match inst.inst_global with
+let open_instance i inst = match inst.inst_global with
 | Local -> assert false
 | SuperGlobal -> perform_instance inst
 | Export -> if Int.equal i 1 then perform_instance inst
@@ -210,7 +210,7 @@ let declare_instance ?(warn = false) env sigma info local glob =
  * classes persistent object
  *)
 
-let cache_class (_,c) = load_class c
+let cache_class c = load_class c
 
 let subst_class (subst,cl) =
   let do_subst_con c = Mod_subst.subst_constant subst c

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -120,7 +120,7 @@ let subst_instance (subst, inst) =
       inst_class = fst (subst_global subst inst.inst_class);
       inst_impl = fst (subst_global subst inst.inst_impl) }
 
-let discharge_instance (_, inst) =
+let discharge_instance inst =
   match inst.inst_global with
   | Local -> None
   | SuperGlobal | Export ->
@@ -236,7 +236,7 @@ let subst_class (subst,cl) =
     cl_strict = cl.cl_strict;
     cl_unique = cl.cl_unique }
 
-let discharge_class (_,cl) =
+let discharge_class cl =
   let open CVars in
   let repl = Lib.replacement_context () in
   let rel_of_variable_context ctx = List.fold_right

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -182,7 +182,7 @@ let add_instance cl info global impl =
     inst_global = global ;
     inst_impl = impl;
   } in
-  Lib.add_anonymous_leaf (instance_input i);
+  Lib.add_leaf (instance_input i);
   add_instance_base i
 
 let warning_not_a_class =
@@ -298,7 +298,7 @@ let class_input : typeclass -> obj =
       subst_function = subst_class }
 
 let add_class cl =
-  Lib.add_anonymous_leaf (class_input cl)
+  Lib.add_leaf (class_input cl)
 
 let add_class env sigma cl =
   add_class cl;

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -133,7 +133,7 @@ let rebuild_instance inst =
 
 let classify_instance inst = match inst.inst_global with
 | Local -> Dispose
-| SuperGlobal | Export -> Substitute inst
+| SuperGlobal | Export -> Substitute
 
 let instance_input : instance_obj -> obj =
   declare_object
@@ -292,7 +292,7 @@ let class_input : typeclass -> obj =
     { (default_object "type classes state") with
       cache_function = cache_class;
       load_function = (fun _ -> cache_class);
-      classify_function = (fun x -> Substitute x);
+      classify_function = (fun x -> Substitute);
       discharge_function = (fun a -> Some (discharge_class a));
       rebuild_function = rebuild_class;
       subst_function = subst_class }

--- a/vernac/comArguments.ml
+++ b/vernac/comArguments.ml
@@ -296,14 +296,14 @@ let vernac_arguments ~section_local reference args more_implicits flags =
     if section_local then
       Pretyping.add_bidirectionality_hint sr n
     else
-      Lib.add_anonymous_leaf (inBidiHints (sr, Some n))
+      Lib.add_leaf (inBidiHints (sr, Some n))
   end;
 
   if clear_bidi_hint then begin
     if section_local then
       Pretyping.clear_bidirectionality_hint sr
     else
-      Lib.add_anonymous_leaf (inBidiHints (sr, None))
+      Lib.add_leaf (inBidiHints (sr, None))
   end;
 
   if not (renaming_specified ||

--- a/vernac/comArguments.ml
+++ b/vernac/comArguments.ml
@@ -42,7 +42,7 @@ let inBidiHints =
   declare_object { (default_object "BIDIRECTIONALITY-HINTS" ) with
                    load_function = load_bidi_hints;
                    cache_function = cache_bidi_hints;
-                   classify_function = (fun o -> Substitute o);
+                   classify_function = (fun o -> Substitute);
                    subst_function = subst_bidi_hints;
                    discharge_function = discharge_bidi_hints;
                  }

--- a/vernac/comArguments.ml
+++ b/vernac/comArguments.ml
@@ -18,7 +18,7 @@ let smart_global r =
   Dumpglob.add_glob ?loc:r.loc gr;
   gr
 
-let cache_bidi_hints (_name, (gr, ohint)) =
+let cache_bidi_hints (gr, ohint) =
   match ohint with
   | None -> Pretyping.clear_bidirectionality_hint gr
   | Some nargs -> Pretyping.add_bidirectionality_hint gr nargs

--- a/vernac/comArguments.ml
+++ b/vernac/comArguments.ml
@@ -30,7 +30,7 @@ let subst_bidi_hints (subst, (gr, ohint as orig)) =
   let gr' = Globnames.subst_global_reference subst gr in
   if gr == gr' then orig else (gr', ohint)
 
-let discharge_bidi_hints (_name, (gr, ohint)) =
+let discharge_bidi_hints (gr, ohint) =
   if Globnames.isVarRef gr && Lib.is_in_section gr then None
   else
     let vars = Lib.variable_section_segment_of_reference gr in

--- a/vernac/comCoercion.ml
+++ b/vernac/comCoercion.ml
@@ -255,7 +255,7 @@ let rebuild_coercion c =
   { c with coe_typ = fst (Typeops.type_of_global_in_context (Global.env ()) c.coe_value) }
 
 let classify_coercion obj =
-  if obj.coe_local then Dispose else Substitute obj
+  if obj.coe_local then Dispose else Substitute
 
 let coe_cat = create_category "coercions"
 

--- a/vernac/comCoercion.ml
+++ b/vernac/comCoercion.ml
@@ -227,7 +227,7 @@ let check_source = function
 | Some (CL_FUN as s) -> raise (CoercionError (ForbiddenSourceClass s))
 | _ -> ()
 
-let cache_coercion (_,c) =
+let cache_coercion c =
   let env = Global.env () in
   let sigma = Evd.from_env env in
   Coercionops.declare_coercion env sigma c

--- a/vernac/comCoercion.ml
+++ b/vernac/comCoercion.ml
@@ -236,7 +236,7 @@ let open_coercion i o =
   if Int.equal i 1 then
     cache_coercion o
 
-let discharge_coercion (_, c) =
+let discharge_coercion c =
   if c.coe_local then None
   else
     let n =

--- a/vernac/comCoercion.ml
+++ b/vernac/comCoercion.ml
@@ -284,7 +284,7 @@ let declare_coercion coef typ ?(local = false) ~isid ~src:cls ~target:clt ~param
     coe_target = clt;
     coe_param = ps;
   } in
-  Lib.add_anonymous_leaf (inCoercion c)
+  Lib.add_leaf (inCoercion c)
 
 (*
 nom de la fonction coercion

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -201,7 +201,7 @@ let cache_constant ((sp,kn), obj) =
 
 let discharge_constant obj = Some obj
 
-let classify_constant cst = Libobject.Substitute cst
+let classify_constant cst = Libobject.Substitute
 
 let (objConstant : constant_obj Libobject.Dyn.tag) =
   let open Libobject in

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -232,7 +232,7 @@ let register_constant kn kind local =
     cst_locl = local;
   } in
   let id = Label.to_id (Constant.label kn) in
-  let _ = Lib.add_leaf id o in
+  let () = Lib.add_leaf id o in
   update_tables kn
 
 let register_side_effect (c, body, role) =

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -486,10 +486,10 @@ type variable_declaration =
 
 (* This object is only for things which iterate over objects to find
    variables (only Prettyp.print_context AFAICT) *)
-let objVariable : unit Libobject.Dyn.tag =
+let objVariable : Id.t Libobject.Dyn.tag =
   let open Libobject in
   declare_object_full { (default_object "VARIABLE") with
-    classify_function = (fun () -> Dispose)}
+    classify_function = (fun _ -> Dispose)}
 
 let inVariable v = Libobject.Dyn.Easy.inj v objVariable
 
@@ -530,7 +530,7 @@ let declare_variable_core ~name ~kind d =
   in
   Nametab.push (Nametab.Until 1) (Libnames.make_path DirPath.empty name) (GlobRef.VarRef name);
   Decls.(add_variable_data name {opaque;kind});
-  ignore(Lib.add_leaf name (inVariable ()) : Libobject.object_name);
+  Lib.add_anonymous_leaf (inVariable name);
   Impargs.declare_var_implicits ~impl name;
   Notation.declare_ref_arguments_scope Evd.empty (GlobRef.VarRef name)
 

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -205,7 +205,7 @@ let classify_constant cst = Libobject.Substitute
 
 let (objConstant : (Id.t * constant_obj) Libobject.Dyn.tag) =
   let open Libobject in
-  declare_object_full { (default_object "CONSTANT") with
+  declare_named_object_full { (default_object "CONSTANT") with
     cache_function = cache_constant;
     load_function = load_constant;
     open_function = simple_open open_constant;
@@ -476,10 +476,10 @@ type variable_declaration =
 
 (* This object is only for things which iterate over objects to find
    variables (only Prettyp.print_context AFAICT) *)
-let objVariable : (Id.t * unit) Libobject.Dyn.tag =
+let objVariable : Id.t Libobject.Dyn.tag =
   let open Libobject in
   declare_object_full { (default_object "VARIABLE") with
-    classify_function = (fun () -> Dispose)}
+    classify_function = (fun _ -> Dispose)}
 
 let inVariable v = Libobject.Dyn.Easy.inj v objVariable
 
@@ -520,7 +520,7 @@ let declare_variable_core ~name ~kind d =
   in
   Nametab.push (Nametab.Until 1) (Libnames.make_path DirPath.empty name) (GlobRef.VarRef name);
   Decls.(add_variable_data name {opaque;kind});
-  Lib.add_leaf (inVariable (name,()));
+  Lib.add_leaf (inVariable name);
   Impargs.declare_var_implicits ~impl name;
   Notation.declare_ref_arguments_scope Evd.empty (GlobRef.VarRef name)
 

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -195,15 +195,9 @@ let check_exists id =
     raise (DeclareUniv.AlreadyDeclared (None, id))
 
 let cache_constant ((sp,kn), obj) =
-  (* Invariant: the constant must exist in the logical environment *)
-  let kn' =
-    if Global.exists_objlabel (Label.of_id (Libnames.basename sp))
-    then Constant.make1 kn
-    else CErrors.anomaly Pp.(str"Missing constant " ++ Id.print(Libnames.basename sp) ++ str".")
-  in
-  assert (Environ.QConstant.equal (Global.env ()) kn' (Constant.make1 kn));
-  Nametab.push (Nametab.Until 1) sp (GlobRef.ConstRef (Constant.make1 kn));
-  Dumpglob.add_constant_kind (Constant.make1 kn) obj.cst_kind
+  let kn = Global.constant_of_delta_kn kn in
+  Nametab.push (Nametab.Until 1) sp (GlobRef.ConstRef kn);
+  Dumpglob.add_constant_kind kn obj.cst_kind
 
 let discharge_constant obj = Some obj
 

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -205,8 +205,7 @@ let cache_constant ((sp,kn), obj) =
   Nametab.push (Nametab.Until 1) sp (GlobRef.ConstRef (Constant.make1 kn));
   Dumpglob.add_constant_kind (Constant.make1 kn) obj.cst_kind
 
-let discharge_constant ((sp, kn), obj) =
-  Some obj
+let discharge_constant obj = Some obj
 
 let classify_constant cst = Libobject.Substitute cst
 

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -569,6 +569,6 @@ module Internal : sig
     val kind : t -> Decls.logical_kind
   end
 
-  val objVariable : unit Libobject.Dyn.tag
+  val objVariable : Id.t Libobject.Dyn.tag
 
 end

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -569,6 +569,6 @@ module Internal : sig
     val kind : t -> Decls.logical_kind
   end
 
-  val objVariable : (Id.t * unit) Libobject.Dyn.tag
+  val objVariable : Id.t Libobject.Dyn.tag
 
 end

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -565,10 +565,10 @@ module Internal : sig
   (* Liboject exports *)
   module Constant : sig
     type t
-    val tag : t Libobject.Dyn.tag
+    val tag : (Id.t * t) Libobject.Dyn.tag
     val kind : t -> Decls.logical_kind
   end
 
-  val objVariable : Id.t Libobject.Dyn.tag
+  val objVariable : (Id.t * unit) Libobject.Dyn.tag
 
 end

--- a/vernac/declareInd.ml
+++ b/vernac/declareInd.ml
@@ -57,7 +57,7 @@ let cache_inductive ((sp, kn), names) =
 let discharge_inductive names =
   Some names
 
-let objInductive : inductive_obj Libobject.Dyn.tag =
+let objInductive : (Id.t * inductive_obj) Libobject.Dyn.tag =
   let open Libobject in
   declare_object_full {(default_object "INDUCTIVE") with
     cache_function = cache_inductive;
@@ -88,7 +88,7 @@ let inPrim : (Projection.Repr.t * Constant.t) -> Libobject.obj =
     classify_function = (fun x -> Substitute);
     discharge_function = discharge_prim }
 
-let declare_primitive_projection p c = Lib.add_anonymous_leaf (inPrim (p,c))
+let declare_primitive_projection p c = Lib.add_leaf (inPrim (p,c))
 
 let feedback_axiom () = Feedback.(feedback AddedAxiom)
 
@@ -108,7 +108,7 @@ let declare_mind ?typing_flags mie =
       Declare.check_exists typ;
       List.iter Declare.check_exists cons) names;
   let mind = Global.add_mind ?typing_flags id mie in
-  let () = Lib.add_leaf id (inInductive { ind_names = names }) in
+  let () = Lib.add_leaf (inInductive (id, { ind_names = names })) in
   if is_unsafe_typing_flags() then feedback_axiom ();
   let isprim = Inductive.is_primitive_record (Inductive.lookup_mind_specif (Global.env()) (mind,0)) in
   Impargs.declare_mib_implicits mind;

--- a/vernac/declareInd.ml
+++ b/vernac/declareInd.ml
@@ -63,7 +63,7 @@ let objInductive : inductive_obj Libobject.Dyn.tag =
     cache_function = cache_inductive;
     load_function = load_inductive;
     open_function = simple_open open_inductive;
-    classify_function = (fun a -> Substitute a);
+    classify_function = (fun a -> Substitute);
     subst_function = ident_subst_function;
     discharge_function = discharge_inductive;
   }
@@ -85,7 +85,7 @@ let inPrim : (Projection.Repr.t * Constant.t) -> Libobject.obj =
     cache_function = cache_prim ;
     load_function = load_prim;
     subst_function = subst_prim;
-    classify_function = (fun x -> Substitute x);
+    classify_function = (fun x -> Substitute);
     discharge_function = discharge_prim }
 
 let declare_primitive_projection p c = Lib.add_anonymous_leaf (inPrim (p,c))

--- a/vernac/declareInd.ml
+++ b/vernac/declareInd.ml
@@ -57,7 +57,7 @@ let cache_inductive ((sp, kn), names) =
   let names = inductive_names sp kn names in
   List.iter (fun (sp, ref) -> Nametab.push (Nametab.Until 1) sp ref) names
 
-let discharge_inductive ((sp, kn), names) =
+let discharge_inductive names =
   Some names
 
 let objInductive : inductive_obj Libobject.Dyn.tag =
@@ -79,7 +79,7 @@ let load_prim _ p = cache_prim p
 
 let subst_prim (subst,(p,c)) = Mod_subst.subst_proj_repr subst p, Mod_subst.subst_constant subst c
 
-let discharge_prim (_,(p,c)) = Some (Lib.discharge_proj_repr p, c)
+let discharge_prim (p,c) = Some (Lib.discharge_proj_repr p, c)
 
 let inPrim : (Projection.Repr.t * Constant.t) -> Libobject.obj =
   let open Libobject in

--- a/vernac/declareInd.ml
+++ b/vernac/declareInd.ml
@@ -111,7 +111,7 @@ let declare_mind ?typing_flags mie =
       Declare.check_exists typ;
       List.iter Declare.check_exists cons) names;
   let mind = Global.add_mind ?typing_flags id mie in
-  let (_,_) : Libobject.object_name = Lib.add_leaf id (inInductive { ind_names = names }) in
+  let () = Lib.add_leaf id (inInductive { ind_names = names }) in
   if is_unsafe_typing_flags() then feedback_axiom ();
   let isprim = Inductive.is_primitive_record (Inductive.lookup_mind_specif (Global.env()) (mind,0)) in
   Impargs.declare_mib_implicits mind;

--- a/vernac/declareInd.ml
+++ b/vernac/declareInd.ml
@@ -34,14 +34,11 @@ let inductive_names sp kn obj =
          let names, _ =
            List.fold_left
              (fun (names, p) l ->
-                let sp =
-                  Libnames.make_path dp l
-                in
-                  ((sp, GlobRef.ConstructRef (ind_p,p)) :: names, p+1))
+                let sp = Libnames.make_path dp l in
+                ((sp, GlobRef.ConstructRef (ind_p,p)) :: names, p+1))
              (names, 1) consnames in
-         let sp = Libnames.make_path dp typename
-         in
-           ((sp, GlobRef.IndRef ind_p) :: names, n+1))
+         let sp = Libnames.make_path dp typename in
+         ((sp, GlobRef.IndRef ind_p) :: names, n+1))
       ([], 0) obj.ind_names
   in names
 
@@ -73,7 +70,7 @@ let objInductive : inductive_obj Libobject.Dyn.tag =
 
 let inInductive v = Libobject.Dyn.Easy.inj v objInductive
 
-let cache_prim (_,(p,c)) = Structures.PrimitiveProjections.register p c
+let cache_prim (p,c) = Structures.PrimitiveProjections.register p c
 
 let load_prim _ p = cache_prim p
 

--- a/vernac/declareInd.ml
+++ b/vernac/declareInd.ml
@@ -59,7 +59,7 @@ let discharge_inductive names =
 
 let objInductive : (Id.t * inductive_obj) Libobject.Dyn.tag =
   let open Libobject in
-  declare_object_full {(default_object "INDUCTIVE") with
+  declare_named_object_full {(default_object "INDUCTIVE") with
     cache_function = cache_inductive;
     load_function = load_inductive;
     open_function = simple_open open_inductive;

--- a/vernac/declareInd.ml
+++ b/vernac/declareInd.ml
@@ -110,14 +110,13 @@ let declare_mind ?typing_flags mie =
   List.iter (fun (typ, cons) ->
       Declare.check_exists typ;
       List.iter Declare.check_exists cons) names;
-  let _kn' = Global.add_mind ?typing_flags id mie in
-  let (sp,kn as oname) = Lib.add_leaf id (inInductive { ind_names = names }) in
+  let mind = Global.add_mind ?typing_flags id mie in
+  let (_,_) : Libobject.object_name = Lib.add_leaf id (inInductive { ind_names = names }) in
   if is_unsafe_typing_flags() then feedback_axiom ();
-  let mind = Global.mind_of_delta_kn kn in
   let isprim = Inductive.is_primitive_record (Inductive.lookup_mind_specif (Global.env()) (mind,0)) in
   Impargs.declare_mib_implicits mind;
   declare_inductive_argument_scopes mind mie;
-  oname, isprim
+  mind, isprim
 
 let is_recursive mie =
   let open Constr in
@@ -163,8 +162,7 @@ let declare_mutual_inductive_with_eliminations ?(primitive_expected=false) ?typi
     | _ -> ()
   end;
   let names = List.map (fun e -> e.mind_entry_typename) mie.mind_entry_inds in
-  let (_, kn), prim = declare_mind ?typing_flags mie in
-  let mind = Global.mind_of_delta_kn kn in
+  let mind, prim = declare_mind ?typing_flags mie in
   let is_template = match mie.mind_entry_universes with Template_ind_entry _ -> true | _ -> false in
   if primitive_expected && not prim then warn_non_primitive_record (mind,0);
   DeclareUniv.declare_univ_binders (GlobRef.IndRef (mind,0)) ubinders;

--- a/vernac/declareInd.mli
+++ b/vernac/declareInd.mli
@@ -28,7 +28,7 @@ module Internal :
 sig
 
 type inductive_obj
-val objInductive : inductive_obj Libobject.Dyn.tag
+val objInductive : (Names.Id.t * inductive_obj) Libobject.Dyn.tag
 
 end
 

--- a/vernac/declareUniv.ml
+++ b/vernac/declareUniv.ml
@@ -64,7 +64,7 @@ let discharge_univ_names = function
 
 let input_univ_names : universe_name_decl -> Libobject.obj =
   let open Libobject in
-  declare_named_object0
+  declare_named_object_gen
     { (default_object "Global universe name state") with
       cache_function = cache_univ_names;
       load_function = load_univ_names;

--- a/vernac/declareUniv.ml
+++ b/vernac/declareUniv.ml
@@ -47,16 +47,16 @@ let do_univ_name ~check i dp src (id,univ) =
   if check then check_exists_universe sp;
   Nametab.push_universe i sp univ
 
-let cache_univ_names ((sp, _), (src, univs)) =
+let cache_univ_names (prefix, (src, univs)) =
   let depth = Lib.sections_depth () in
-  let dp = Libnames.pop_dirpath_n depth (Libnames.dirpath sp) in
+  let dp = Libnames.pop_dirpath_n depth prefix.Nametab.obj_dir in
   List.iter (do_univ_name ~check:true (Nametab.Until 1) dp src) univs
 
-let load_univ_names i ((sp, _), (src, univs)) =
-  List.iter (do_univ_name ~check:false (Nametab.Until i) (Libnames.dirpath sp) src) univs
+let load_univ_names i (prefix, (src, univs)) =
+  List.iter (do_univ_name ~check:false (Nametab.Until i) prefix.Nametab.obj_dir src) univs
 
-let open_univ_names i ((sp, _), (src, univs)) =
-  List.iter (do_univ_name ~check:false (Nametab.Exactly i) (Libnames.dirpath sp) src) univs
+let open_univ_names i (prefix, (src, univs)) =
+  List.iter (do_univ_name ~check:false (Nametab.Exactly i) prefix.Nametab.obj_dir src) univs
 
 let discharge_univ_names = function
   | BoundUniv, _ -> None
@@ -64,7 +64,7 @@ let discharge_univ_names = function
 
 let input_univ_names : universe_name_decl -> Libobject.obj =
   let open Libobject in
-  declare_named_object
+  declare_named_object0
     { (default_object "Global universe name state") with
       cache_function = cache_univ_names;
       load_function = load_univ_names;
@@ -75,7 +75,7 @@ let input_univ_names : universe_name_decl -> Libobject.obj =
 
 let input_univ_names (src, l) =
   if CList.is_empty l then ()
-  else Lib.add_anonymous_leaf (input_univ_names (src, l))
+  else Lib.add_leaf (input_univ_names (src, l))
 
 let invent_name (named,cnt) u =
   let rec aux i =

--- a/vernac/declareUniv.ml
+++ b/vernac/declareUniv.ml
@@ -59,8 +59,8 @@ let open_univ_names i ((sp, _), (src, univs)) =
   List.iter (do_univ_name ~check:false (Nametab.Exactly i) (Libnames.dirpath sp) src) univs
 
 let discharge_univ_names = function
-  | _, (BoundUniv, _) -> None
-  | _, ((QualifiedUniv _ | UnqualifiedUniv), _ as x) -> Some x
+  | BoundUniv, _ -> None
+  | (QualifiedUniv _ | UnqualifiedUniv), _ as x -> Some x
 
 let input_univ_names : universe_name_decl -> Libobject.obj =
   let open Libobject in

--- a/vernac/declareUniv.ml
+++ b/vernac/declareUniv.ml
@@ -64,7 +64,7 @@ let discharge_univ_names = function
 
 let input_univ_names : universe_name_decl -> Libobject.obj =
   let open Libobject in
-  declare_object
+  declare_named_object
     { (default_object "Global universe name state") with
       cache_function = cache_univ_names;
       load_function = load_univ_names;

--- a/vernac/declareUniv.ml
+++ b/vernac/declareUniv.ml
@@ -71,7 +71,7 @@ let input_univ_names : universe_name_decl -> Libobject.obj =
       open_function = simple_open open_univ_names;
       discharge_function = discharge_univ_names;
       subst_function = (fun (subst, a) -> (* Actually the name is generated once and for all. *) a);
-      classify_function = (fun a -> Substitute a) }
+      classify_function = (fun a -> Substitute) }
 
 let input_univ_names (src, l) =
   if CList.is_empty l then ()

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -101,9 +101,9 @@ and subst_sobjs sub (mbids,aobjs as sobjs) =
 and subst_objects subst seg =
   let subst_one node =
     match node with
-    | AtomicObject (id, obj) ->
+    | AtomicObject obj ->
       let obj' = Libobject.subst_object (subst,obj) in
-      if obj' == obj then node else AtomicObject (id, obj')
+      if obj' == obj then node else AtomicObject obj'
     | ModuleObject (id, sobjs) ->
       let sobjs' = subst_sobjs subst sobjs in
       if sobjs' == sobjs then node else ModuleObject (id, sobjs')
@@ -255,7 +255,7 @@ let load_modtype i sp mp sobjs =
 
 let rec load_object i (prefix, obj) =
   match obj with
-  | AtomicObject (_,o) -> Libobject.load_object i (prefix, o)
+  | AtomicObject o -> Libobject.load_object i (prefix, o)
   | ModuleObject (id,sobjs) ->
     let name = Lib.make_oname prefix id in
     do_module' false load_objects i (name, sobjs)
@@ -353,7 +353,7 @@ let open_modtype i ((sp,kn),_) =
 
 let rec open_object f i (prefix, obj) =
   match obj with
-  | AtomicObject (_,o) -> Libobject.open_object f i (prefix, o)
+  | AtomicObject o -> Libobject.open_object f i (prefix, o)
   | ModuleObject (id,sobjs) ->
     let name = Lib.make_oname prefix id in
     let dir = dir_of_sp (fst name) in
@@ -396,7 +396,7 @@ and open_keep f i ((sp,kn),kobjs) =
 
 let rec cache_object (prefix, obj) =
   match obj with
-  | AtomicObject (_,o) -> Libobject.cache_object (prefix, o)
+  | AtomicObject o -> Libobject.cache_object (prefix, o)
   | ModuleObject (id,sobjs) ->
     let name = Lib.make_oname prefix id in
     do_module' false load_objects 1 (name, sobjs)

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -719,7 +719,7 @@ let start_module export id args res fs =
 
 let end_module () =
   let oldoname,fs,lib_stack = Lib.end_module () in
-  let substitute, keep, special = Lib.classify_segment lib_stack in
+  let {Lib.substobjs = substitute; keepobjs = keep; anticipateobjs = special; } = lib_stack in
   let m_info = !openmod_info in
 
   (* For sealed modules, we use the substitutive objects of their signatures *)
@@ -839,7 +839,7 @@ let start_modtype id args mtys fs =
 let end_modtype () =
   let oldoname,fs,lib_stack = Lib.end_modtype () in
   let id = basename (fst oldoname) in
-  let substitute, _, special = Lib.classify_segment lib_stack in
+  let {Lib.substobjs = substitute; keepobjs = _; anticipateobjs = special; } = lib_stack in
   let sub_mty_l = !openmodtype_info in
   let mp, mbids = Global.end_modtype fs id in
   let modtypeobjs = (mbids, Objs substitute) in
@@ -1045,7 +1045,7 @@ let end_library ~output_native_objects dir =
   let prefix, lib_stack = Lib.end_compilation dir in
   let mp,cenv,ast = Global.export ~output_native_objects dir in
   assert (ModPath.equal mp (MPfile dir));
-  let substitute, keep, _ = Lib.classify_segment lib_stack in
+  let {Lib.substobjs = substitute; keepobjs = keep; anticipateobjs = _; } = lib_stack in
   cenv,(substitute,keep),ast
 
 let import_modules ~export mpl =

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -418,7 +418,7 @@ let add_leaf id obj =
   let oname = Lib.make_foname id in
   cache_object (oname,obj);
   Lib.add_entry oname (Lib.Leaf obj);
-  oname
+  ()
 
 let add_leaves id objs =
   let oname = Lib.make_foname id in
@@ -817,7 +817,7 @@ let declare_module id args res mexpr_o fs =
   check_subtypes mp subs;
 
   let sobjs = subst_sobjs (map_mp mp0 mp resolver) sobjs in
-  ignore (add_leaf id (ModuleObject sobjs));
+  add_leaf id (ModuleObject sobjs);
   mp
 
 end
@@ -895,7 +895,7 @@ let declare_modtype id args mtys (mty,ann) fs =
   (* Subtyping checks *)
   check_subtypes_mt mp sub_mty_l;
 
-  ignore (add_leaf id (ModuleTypeObject sobjs));
+  add_leaf id (ModuleTypeObject sobjs);
   mp
 
 end
@@ -950,7 +950,7 @@ let declare_one_include (me_ast,annot) =
   let resolver = Global.add_include me is_mod inl in
   let subst = join subst_self (map_mp base_mp cur_mp resolver) in
   let aobjs = subst_aobjs subst aobjs in
-  ignore (add_leaf (Lib.current_mod_id ()) (IncludeObject aobjs))
+  add_leaf (Lib.current_mod_id ()) (IncludeObject aobjs)
 
 let declare_include me_asts = List.iter declare_one_include me_asts
 

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -1094,8 +1094,7 @@ let debug_print_modtab _ =
   in
   let pr_modinfo mp modobjs s =
     let objs = modobjs.module_substituted_objects @ modobjs.module_keep_objects in
-    s ++ str (ModPath.to_string mp) ++ (spc ())
-    ++ (pr_seg (Lib.segment_of_objects modobjs.module_prefix objs))
+    s ++ str (ModPath.to_string mp) ++ spc () ++ pr_seg objs
   in
   let modules = MPmap.fold pr_modinfo (ModObjs.all ()) (mt ()) in
   hov 0 modules

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -1042,9 +1042,8 @@ let append_end_library_hook f =
 
 let end_library ~output_native_objects dir =
   !end_library_hook();
-  let oname = Lib.end_compilation_checks dir in
+  let prefix, lib_stack = Lib.end_compilation dir in
   let mp,cenv,ast = Global.export ~output_native_objects dir in
-  let prefix, lib_stack = Lib.end_compilation oname in
   assert (ModPath.equal mp (MPfile dir));
   let substitute, keep, _ = Lib.classify_segment lib_stack in
   cenv,(substitute,keep),ast

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -255,7 +255,7 @@ let load_modtype i sp mp sobjs =
 
 let rec load_object i (name, obj) =
   match obj with
-  | AtomicObject o -> Libobject.load_object i (name, o)
+  | AtomicObject o -> Libobject.load_object i (Lib.oname_prefix name, o)
   | ModuleObject sobjs -> do_module' false load_objects i (name, sobjs)
   | ModuleTypeObject sobjs ->
     let (sp,kn) = name in
@@ -350,7 +350,7 @@ let open_modtype i ((sp,kn),_) =
 
 let rec open_object f i (name, obj) =
   match obj with
-  | AtomicObject o -> Libobject.open_object f i (name, o)
+  | AtomicObject o -> Libobject.open_object f i (Lib.oname_prefix name, o)
   | ModuleObject sobjs ->
     let dir = dir_of_sp (fst name) in
     let mp = mp_of_kn (snd name) in
@@ -390,7 +390,7 @@ and open_keep f i ((sp,kn),kobjs) =
 
 let rec cache_object (name, obj) =
   match obj with
-  | AtomicObject o -> Libobject.cache_object (name, o)
+  | AtomicObject o -> Libobject.cache_object (Lib.oname_prefix name, o)
   | ModuleObject sobjs -> do_module' false load_objects 1 (name, sobjs)
   | ModuleTypeObject sobjs ->
     let (sp,kn) = name in

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -718,7 +718,7 @@ let start_module export id args res fs =
   mp
 
 let end_module () =
-  let oldoname,oldprefix,fs,lib_stack = Lib.end_module () in
+  let oldoname,fs,lib_stack = Lib.end_module () in
   let substitute, keep, special = Lib.classify_segment lib_stack in
   let m_info = !openmod_info in
 
@@ -837,7 +837,7 @@ let start_modtype id args mtys fs =
   mp
 
 let end_modtype () =
-  let oldoname,prefix,fs,lib_stack = Lib.end_modtype () in
+  let oldoname,fs,lib_stack = Lib.end_modtype () in
   let id = basename (fst oldoname) in
   let substitute, _, special = Lib.classify_segment lib_stack in
   let sub_mty_l = !openmodtype_info in

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -413,8 +413,6 @@ and cache_keep ((sp,kn),kobjs) =
 (* Adding operations with containers *)
 
 let add_leaf id obj =
-  if ModPath.equal (Lib.current_mp ()) ModPath.initial then
-    user_err Pp.(str "No session module started (use -top dir)");
   let oname = Lib.make_foname id in
   cache_object (oname,obj);
   Lib.add_entry oname (Lib.Leaf obj);

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -99,23 +99,23 @@ and subst_sobjs sub (mbids,aobjs as sobjs) =
   if aobjs' == aobjs then sobjs else (mbids, aobjs')
 
 and subst_objects subst seg =
-  let subst_one (id,obj as node) =
-    match obj with
-    | AtomicObject obj ->
+  let subst_one node =
+    match node with
+    | AtomicObject (id, obj) ->
       let obj' = Libobject.subst_object (subst,obj) in
-      if obj' == obj then node else (id, AtomicObject obj')
-    | ModuleObject sobjs ->
+      if obj' == obj then node else AtomicObject (id, obj')
+    | ModuleObject (id, sobjs) ->
       let sobjs' = subst_sobjs subst sobjs in
-      if sobjs' == sobjs then node else (id, ModuleObject sobjs')
-    | ModuleTypeObject sobjs ->
+      if sobjs' == sobjs then node else ModuleObject (id, sobjs')
+    | ModuleTypeObject (id, sobjs) ->
       let sobjs' = subst_sobjs subst sobjs in
-      if sobjs' == sobjs then node else (id, ModuleTypeObject sobjs')
-    | IncludeObject aobjs ->
+      if sobjs' == sobjs then node else ModuleTypeObject (id, sobjs')
+    | IncludeObject (id, aobjs) ->
       let aobjs' = subst_aobjs subst aobjs in
-      if aobjs' == aobjs then node else (id, IncludeObject aobjs')
+      if aobjs' == aobjs then node else IncludeObject (id, aobjs')
     | ExportObject { mpl } ->
       let mpl' = List.Smart.map (subst_filtered subst) mpl in
-      if mpl'==mpl then node else (id, ExportObject { mpl = mpl' })
+      if mpl'==mpl then node else ExportObject { mpl = mpl' }
     | KeepObject _ -> assert false
   in
   List.Smart.map subst_one seg
@@ -156,8 +156,8 @@ let expand_sobjs (_,aobjs) = expand_aobjs aobjs
 
 type module_objects =
   { module_prefix : Nametab.object_prefix;
-    module_substituted_objects : Lib.lib_objects;
-    module_keep_objects : Lib.lib_objects;
+    module_substituted_objects : Libobject.t list;
+    module_keep_objects : Libobject.t list;
   }
 
 module ModObjs :
@@ -253,19 +253,26 @@ let load_modtype i sp mp sobjs =
 
 (** {6 Declaration of substitutive objects for Include} *)
 
-let rec load_object i (name, obj) =
+let rec load_object i (prefix, obj) =
   match obj with
-  | AtomicObject o -> Libobject.load_object i (Lib.oname_prefix name, o)
-  | ModuleObject sobjs -> do_module' false load_objects i (name, sobjs)
-  | ModuleTypeObject sobjs ->
+  | AtomicObject (_,o) -> Libobject.load_object i (prefix, o)
+  | ModuleObject (id,sobjs) ->
+    let name = Lib.make_oname prefix id in
+    do_module' false load_objects i (name, sobjs)
+  | ModuleTypeObject (id,sobjs) ->
+    let name = Lib.make_oname prefix id in
     let (sp,kn) = name in
     load_modtype i sp (mp_of_kn kn) sobjs
-  | IncludeObject aobjs -> load_include i (name, aobjs)
+  | IncludeObject (id,aobjs) ->
+    let name = Lib.make_oname prefix id in
+    load_include i (name, aobjs)
   | ExportObject _ -> ()
-  | KeepObject objs -> load_keep i (name, objs)
+  | KeepObject (id,objs) ->
+    let name = Lib.make_oname prefix id in
+    load_keep i (name, objs)
 
 and load_objects i prefix objs =
-  List.iter (fun (id, obj) -> load_object i (Lib.make_oname prefix id, obj)) objs
+  List.iter (fun obj -> load_object i (prefix, obj)) objs
 
 and load_include i ((sp,kn), aobjs) =
   let obj_dir = Libnames.dirpath sp in
@@ -302,16 +309,16 @@ and collect_module (f,mp) acc =
   let acc = collect_objects f 1 prefix modobjs.module_keep_objects acc in
   collect_objects f 1 prefix modobjs.module_substituted_objects acc
 
-and collect_object f i (name, obj as o) acc =
+and collect_object f i prefix obj acc =
   match obj with
   | ExportObject { mpl } -> collect_exports f i mpl acc
   | AtomicObject _ | IncludeObject _ | KeepObject _
-  | ModuleObject _ | ModuleTypeObject _ -> mark_object f o acc
+  | ModuleObject _ | ModuleTypeObject _ -> mark_object f (prefix,obj) acc
 
 and collect_objects f i prefix objs acc =
-  List.fold_left (fun acc (id, obj) ->
-    collect_object f i (Lib.make_oname prefix id, obj) acc
-  ) acc (List.rev objs)
+  List.fold_left (fun acc obj -> collect_object f i prefix obj acc)
+    acc
+    (List.rev objs)
 
 and collect_export f (f',mp) (exports,objs as acc) =
   match filter_and f f' with
@@ -348,17 +355,24 @@ let open_modtype i ((sp,kn),_) =
   assert (ModPath.equal mp mp');
   Nametab.push_modtype (Nametab.Exactly i) sp mp
 
-let rec open_object f i (name, obj) =
+let rec open_object f i (prefix, obj) =
   match obj with
-  | AtomicObject o -> Libobject.open_object f i (Lib.oname_prefix name, o)
-  | ModuleObject sobjs ->
+  | AtomicObject (_,o) -> Libobject.open_object f i (prefix, o)
+  | ModuleObject (id,sobjs) ->
+    let name = Lib.make_oname prefix id in
     let dir = dir_of_sp (fst name) in
     let mp = mp_of_kn (snd name) in
     open_module f i dir mp sobjs
-  | ModuleTypeObject sobjs -> open_modtype i (name, sobjs)
-  | IncludeObject aobjs -> open_include f i (name, aobjs)
+  | ModuleTypeObject (id,sobjs) ->
+    let name = Lib.make_oname prefix id in
+    open_modtype i (name, sobjs)
+  | IncludeObject (id,aobjs) ->
+    let name = Lib.make_oname prefix id in
+    open_include f i (name, aobjs)
   | ExportObject { mpl } -> open_export f i mpl
-  | KeepObject objs -> open_keep f i (name, objs)
+  | KeepObject (id,objs) ->
+    let name = Lib.make_oname prefix id in
+    open_keep f i (name, objs)
 
 and open_module f i obj_dir obj_mp sobjs =
   consistency_checks true obj_dir;
@@ -370,7 +384,7 @@ and open_module f i obj_dir obj_mp sobjs =
   end
 
 and open_objects f i prefix objs =
-  List.iter (fun (id, obj) -> open_object f i (Lib.make_oname prefix id, obj)) objs
+  List.iter (fun obj -> open_object f i (prefix, obj)) objs
 
 and open_include f i ((sp,kn), aobjs) =
   let obj_dir = Libnames.dirpath sp in
@@ -388,16 +402,23 @@ and open_keep f i ((sp,kn),kobjs) =
   let prefix = Nametab.{ obj_dir; obj_mp; } in
   open_objects f i prefix kobjs
 
-let rec cache_object (name, obj) =
+let rec cache_object (prefix, obj) =
   match obj with
-  | AtomicObject o -> Libobject.cache_object (Lib.oname_prefix name, o)
-  | ModuleObject sobjs -> do_module' false load_objects 1 (name, sobjs)
-  | ModuleTypeObject sobjs ->
+  | AtomicObject (_,o) -> Libobject.cache_object (prefix, o)
+  | ModuleObject (id,sobjs) ->
+    let name = Lib.make_oname prefix id in
+    do_module' false load_objects 1 (name, sobjs)
+  | ModuleTypeObject (id,sobjs) ->
+    let name = Lib.make_oname prefix id in
     let (sp,kn) = name in
     load_modtype 0 sp (mp_of_kn kn) sobjs
-  | IncludeObject aobjs -> cache_include (name, aobjs)
+  | IncludeObject (id,aobjs) ->
+    let name = Lib.make_oname prefix id in
+    cache_include (name, aobjs)
   | ExportObject { mpl } -> anomaly Pp.(str "Export should not be cached")
-  | KeepObject objs -> cache_keep (name, objs)
+  | KeepObject (id,objs) ->
+    let name = Lib.make_oname prefix id in
+    cache_keep (name, objs)
 
 and cache_include ((sp,kn), aobjs) =
   let obj_dir = Libnames.dirpath sp in
@@ -414,7 +435,7 @@ and cache_keep ((sp,kn),kobjs) =
 
 let add_leaf id obj =
   let oname = Lib.make_foname id in
-  cache_object (oname,obj);
+  cache_object (Lib.oname_prefix oname,obj);
   Lib.add_entry oname (Lib.Leaf obj);
   ()
 
@@ -422,7 +443,7 @@ let add_leaves id objs =
   let oname = Lib.make_foname id in
   let add_obj obj =
     Lib.add_entry oname (Lib.Leaf obj);
-    load_object 1 (oname,obj)
+    load_object 1 (Lib.oname_prefix oname,obj)
   in
   List.iter add_obj objs;
   oname
@@ -435,10 +456,10 @@ let add_leaves id objs =
 
 let mp_id mp id = MPdot (mp, Label.of_id id)
 
-let rec register_mod_objs mp (id,obj) = match obj with
-  | ModuleObject sobjs -> ModSubstObjs.set (mp_id mp id) sobjs
-  | ModuleTypeObject sobjs -> ModSubstObjs.set (mp_id mp id) sobjs
-  | IncludeObject aobjs ->
+let rec register_mod_objs mp obj = match obj with
+  | ModuleObject (id,sobjs) -> ModSubstObjs.set (mp_id mp id) sobjs
+  | ModuleTypeObject (id,sobjs) -> ModSubstObjs.set (mp_id mp id) sobjs
+  | IncludeObject (id,aobjs) ->
     List.iter (register_mod_objs mp) (expand_aobjs aobjs)
   | _ -> ()
 
@@ -490,9 +511,8 @@ let rec compute_subst env mbids sign mp_l inl =
 let rec replace_module_object idl mp0 objs0 mp1 objs1 =
   match idl, objs0 with
   | _,[] -> []
-  | id::idl,(id',obj)::tail when Id.equal id id' ->
-    begin match obj with
-    | ModuleObject sobjs ->
+  | id::idl,(ModuleObject (id', sobjs))::tail when Id.equal id id' ->
+    begin
       let mp_id = MPdot(mp0, Label.of_id id) in
       let objs = match idl with
         | [] -> subst_objects (map_mp mp1 mp_id empty_delta_resolver) objs1
@@ -500,8 +520,7 @@ let rec replace_module_object idl mp0 objs0 mp1 objs1 =
           let objs_id = expand_sobjs sobjs in
           replace_module_object idl mp_id objs_id mp1 objs1
       in
-      (id, ModuleObject ([], Objs objs))::tail
-    | _ -> assert false
+      (ModuleObject (id, ([], Objs objs)))::tail
     end
   | idl,lobj::tail -> lobj::replace_module_object idl mp0 tail mp1 objs1
 
@@ -741,11 +760,11 @@ let end_module () =
       | Some (mty, _) ->
         subst_sobjs (map_mp (get_module_path mty) mp resolver) sobjs
   in
-  let node = ModuleObject sobjs in
+  let node = ModuleObject (id,sobjs) in
   (* We add the keep objects, if any, and if this isn't a functor *)
   let objects = match keep, mbids with
     | [], _ | _, _ :: _ -> special@[node]
-    | _ -> special@[node;KeepObject keep]
+    | _ -> special@[node;KeepObject (id,keep)]
   in
   let newoname = add_leaves id objects in
 
@@ -815,7 +834,7 @@ let declare_module id args res mexpr_o fs =
   check_subtypes mp subs;
 
   let sobjs = subst_sobjs (map_mp mp0 mp resolver) sobjs in
-  add_leaf id (ModuleObject sobjs);
+  add_leaf id (ModuleObject (id,sobjs));
   mp
 
 end
@@ -844,7 +863,7 @@ let end_modtype () =
   let mp, mbids = Global.end_modtype fs id in
   let modtypeobjs = (mbids, Objs substitute) in
   check_subtypes_mt mp sub_mty_l;
-  let oname = add_leaves id (special@[ModuleTypeObject modtypeobjs])
+  let oname = add_leaves id (special@[ModuleTypeObject (id,modtypeobjs)])
   in
   (* Check name consistence : start_ vs. end_modtype, kernel vs. library *)
   assert (eq_full_path (fst oname) (fst oldoname));
@@ -893,7 +912,7 @@ let declare_modtype id args mtys (mty,ann) fs =
   (* Subtyping checks *)
   check_subtypes_mt mp sub_mty_l;
 
-  add_leaf id (ModuleTypeObject sobjs);
+  add_leaf id (ModuleTypeObject (id, sobjs));
   mp
 
 end
@@ -948,7 +967,8 @@ let declare_one_include (me_ast,annot) =
   let resolver = Global.add_include me is_mod inl in
   let subst = join subst_self (map_mp base_mp cur_mp resolver) in
   let aobjs = subst_aobjs subst aobjs in
-  add_leaf (Lib.current_mod_id ()) (IncludeObject aobjs)
+  let id = Lib.current_mod_id () in
+  add_leaf id (IncludeObject (id, aobjs))
 
 let declare_include me_asts = List.iter declare_one_include me_asts
 
@@ -1011,7 +1031,7 @@ type library_name = DirPath.t
 (** A library object is made of some substitutive objects
     and some "keep" objects. *)
 
-type library_objects = Lib.lib_objects * Lib.lib_objects
+type library_objects = Libobject.t list * Libobject.t list
 
 (** For the native compiler, we cache the library values *)
 
@@ -1059,11 +1079,11 @@ let import_module f ~export mp =
 (** {6 Iterators} *)
 
 let iter_all_segments f =
-  let rec apply_obj prefix (id,obj) = match obj with
-    | IncludeObject aobjs ->
+  let rec apply_obj prefix obj = match obj with
+    | IncludeObject (id, aobjs) ->
       let objs = expand_aobjs aobjs in
       List.iter (apply_obj prefix) objs
-    | _ -> f (Lib.make_oname prefix id) obj
+    | _ -> f prefix obj
   in
   let apply_mod_obj _ modobjs =
     let prefix = modobjs.module_prefix in
@@ -1071,7 +1091,7 @@ let iter_all_segments f =
     List.iter (apply_obj prefix) modobjs.module_keep_objects
   in
   let apply_node = function
-    | sp, Lib.Leaf o -> f sp o
+    | sp, Lib.Leaf o -> f (Lib.oname_prefix sp) o
     | _ -> ()
   in
   MPmap.iter apply_mod_obj (ModObjs.all ());

--- a/vernac/declaremods.mli
+++ b/vernac/declaremods.mli
@@ -114,7 +114,7 @@ val declare_include : (Constrexpr.module_ast * inline) list -> unit
     (together with their section path). *)
 
 val iter_all_segments :
-  (Libobject.object_name -> Libobject.t -> unit) -> unit
+  (Nametab.object_prefix -> Libobject.t -> unit) -> unit
 
 
 val debug_print_modtab : unit -> Pp.t

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -363,7 +363,7 @@ let in_require : require_obj -> obj =
      load_function = load_require;
      open_function = (fun _ _ -> assert false);
      discharge_function = discharge_require;
-     classify_function = (fun o -> Anticipate o) }
+     classify_function = (fun o -> Anticipate) }
 
 (* Require libraries, import them if [export <> None], mark them for export
    if [export = Some true] *)

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -380,14 +380,14 @@ let require_library_from_dirpath ~lib_resolver modrefl export =
   if Lib.is_module_or_modtype () then
     begin
       warn_require_in_module ();
-      Lib.add_anonymous_leaf (in_require (needed,modrefl,None));
+      Lib.add_leaf (in_require (needed,modrefl,None));
       Option.iter (fun export ->
           (* TODO import filters *)
           List.iter (fun m -> Declaremods.import_module unfiltered ~export (MPfile m)) modrefl)
         export
     end
   else
-    Lib.add_anonymous_leaf (in_require (needed,modrefl,export))
+    Lib.add_leaf (in_require (needed,modrefl,export))
 
 (************************************************************************)
 (*s Initializing the compilation of a library. *)

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -13,7 +13,6 @@ open CErrors
 open Util
 
 open Names
-open Lib
 open Libobject
 
 (************************************************************************)
@@ -380,15 +379,14 @@ let require_library_from_dirpath ~lib_resolver modrefl export =
   if Lib.is_module_or_modtype () then
     begin
       warn_require_in_module ();
-      add_anonymous_leaf (in_require (needed,modrefl,None));
+      Lib.add_anonymous_leaf (in_require (needed,modrefl,None));
       Option.iter (fun export ->
           (* TODO import filters *)
           List.iter (fun m -> Declaremods.import_module unfiltered ~export (MPfile m)) modrefl)
         export
     end
   else
-    add_anonymous_leaf (in_require (needed,modrefl,export));
-  ()
+    Lib.add_anonymous_leaf (in_require (needed,modrefl,export))
 
 (************************************************************************)
 (*s Initializing the compilation of a library. *)

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -351,7 +351,7 @@ let cache_require o =
   load_require 1 o;
   open_require 1 o
 
-let discharge_require (_,o) = Some o
+let discharge_require o = Some o
 
 (* open_function is never called from here because an Anticipate object *)
 

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -335,10 +335,10 @@ let register_library m =
    - called at module or module type closing when a Require occurs in
      the module or module type
    - not called from a library (i.e. a module identified with a file) *)
-let load_require _ (_,(needed,modl,_)) =
+let load_require _ (needed,modl,_) =
   List.iter register_library needed
 
-let open_require i (_,(_,modl,export)) =
+let open_require i (_,modl,export) =
   Option.iter (fun export ->
       let mpl = List.map (fun m -> unfiltered, MPfile m) modl in
       (* TODO support filters in Require *)
@@ -357,12 +357,13 @@ let discharge_require o = Some o
 type require_obj = library_t list * DirPath.t list * bool option
 
 let in_require : require_obj -> obj =
-  declare_object {(default_object "REQUIRE") with
-       cache_function = cache_require;
-       load_function = load_require;
-       open_function = (fun _ _ -> assert false);
-       discharge_function = discharge_require;
-       classify_function = (fun o -> Anticipate o) }
+  declare_object
+    {(default_object "REQUIRE") with
+     cache_function = cache_require;
+     load_function = load_require;
+     open_function = (fun _ _ -> assert false);
+     discharge_function = discharge_require;
+     classify_function = (fun o -> Anticipate o) }
 
 (* Require libraries, import them if [export <> None], mark them for export
    if [export = Some true] *)

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -842,8 +842,8 @@ let cache_syntax_extension (_, sy) =
 let subst_syntax_extension (subst, (local, (ntn, synext))) =
   (local, (ntn, synext))
 
-let classify_syntax_definition (local, _ as o) =
-  if local then Dispose else Substitute o
+let classify_syntax_definition (local, _) =
+  if local then Dispose else Substitute
 
 let open_syntax_extension i o =
   if Int.equal i 1 then cache_syntax_extension o
@@ -1430,7 +1430,7 @@ let subst_notation (subst, nobj) =
   { nobj with notobj_interp = subst_interpretation subst nobj.notobj_interp; }
 
 let classify_notation nobj =
-  if nobj.notobj_local then Dispose else Substitute nobj
+  if nobj.notobj_local then Dispose else Substitute
 
 let inNotation : notation_obj -> obj =
   declare_object {(default_object "NOTATION") with
@@ -1789,8 +1789,8 @@ let subst_scope_command (subst,(local,scope,o as x)) = match o with
       local, scope, ScopeClasses cl'
   | _ -> x
 
-let classify_scope_command (local, _, _ as o) =
-  if local then Dispose else Substitute o
+let classify_scope_command (local, _, _) =
+  if local then Dispose else Substitute
 
 let inScopeCommand : locality_flag * scope_name * scope_command -> obj =
   declare_object {(default_object "DELIMITERS") with
@@ -1860,8 +1860,8 @@ let cache_custom_entry o = load_custom_entry 1 o
 
 let subst_custom_entry (subst,x) = x
 
-let classify_custom_entry (local,s as o) =
-  if local then Dispose else Substitute o
+let classify_custom_entry (local,s) =
+  if local then Dispose else Substitute
 
 let inCustomEntry : locality_flag * string -> obj =
   declare_object {(default_object "CUSTOM-ENTRIES") with

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -836,7 +836,7 @@ let cache_one_syntax_extension (ntn,synext) =
   (* Printing *)
   Option.iter (declare_generic_notation_printing_rules ntn) synext.synext_notprint
 
-let cache_syntax_extension (_, (_, sy)) =
+let cache_syntax_extension (_, sy) =
   cache_one_syntax_extension sy
 
 let subst_syntax_extension (subst, (local, (ntn, synext))) =
@@ -849,11 +849,12 @@ let open_syntax_extension i o =
   if Int.equal i 1 then cache_syntax_extension o
 
 let inSyntaxExtension : syntax_extension_obj -> obj =
-  declare_object {(default_object "SYNTAX-EXTENSION") with
-       open_function = simple_open ~cat:notation_cat open_syntax_extension;
-       cache_function = cache_syntax_extension;
-       subst_function = subst_syntax_extension;
-       classify_function = classify_syntax_definition}
+  declare_object
+    {(default_object "SYNTAX-EXTENSION") with
+     open_function = simple_open ~cat:notation_cat open_syntax_extension;
+     cache_function = cache_syntax_extension;
+     subst_function = subst_syntax_extension;
+     classify_function = classify_syntax_definition}
 
 (**************************************************************************)
 (* Precedences                                                            *)
@@ -1388,7 +1389,7 @@ type notation_obj = {
   notobj_also_in_cases_pattern : bool;
 }
 
-let load_notation_common silently_define_scope_if_undefined _ (_, nobj) =
+let load_notation_common silently_define_scope_if_undefined _ nobj =
   (* When the default shall be to require that a scope already exists *)
   (* the call to ensure_scope will have to be removed *)
   if silently_define_scope_if_undefined then
@@ -1401,7 +1402,7 @@ let load_notation_common silently_define_scope_if_undefined _ (_, nobj) =
 let load_notation =
   load_notation_common true
 
-let open_notation i (_, nobj) =
+let open_notation i nobj =
   if Int.equal i 1 then begin
     let scope = nobj.notobj_scope in
     let (ntn, df) = nobj.notobj_notation in
@@ -1751,7 +1752,7 @@ type scope_command =
   | ScopeDelimRemove
   | ScopeClasses of scope_class list
 
-let load_scope_command_common silently_define_scope_if_undefined _ (_,(local,scope,o)) =
+let load_scope_command_common silently_define_scope_if_undefined _ (local,scope,o) =
   let declare_scope_if_needed =
     if silently_define_scope_if_undefined then Notation.declare_scope
     else Notation.ensure_scope in
@@ -1766,7 +1767,7 @@ let load_scope_command_common silently_define_scope_if_undefined _ (_,(local,sco
 let load_scope_command =
   load_scope_command_common true
 
-let open_scope_command i (_,(local,scope,o)) =
+let open_scope_command i (local,scope,o) =
   if Int.equal i 1 then
     match o with
     | ScopeDeclare -> ()
@@ -1851,7 +1852,7 @@ let warn_custom_entry =
          (fun s ->
           strbrk "Custom entry " ++ str s ++ strbrk " has been overridden.")
 
-let load_custom_entry _ (_,(local,s)) =
+let load_custom_entry _ (local,s) =
   if Egramcoq.exists_custom_entry s then warn_custom_entry s
   else Egramcoq.create_custom_entry ~local s
 

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1656,7 +1656,7 @@ let add_reserved_notation ~local ~infix ({CAst.loc;v=df},mods) =
   let sd = compute_syntax_data ~local main_data notation_symbols ntn mods in
   let synext = make_syntax_rules true main_data ntn sd in
   List.iter (fun f -> f ()) sd.msgs;
-  Lib.add_anonymous_leaf (inSyntaxExtension(local,(ntn,synext)))
+  Lib.add_leaf (inSyntaxExtension(local,(ntn,synext)))
 
 (* Notations associated to a where clause *)
 
@@ -1686,16 +1686,16 @@ let prepare_where_notation decl_ntn =
 let add_notation_interpretation ~local env (decl_ntn, main_data, notation_symbols, ntn, syntax_rules) =
   let { decl_ntn_string = { CAst.loc ; v = df }; decl_ntn_interp = c; decl_ntn_scope = sc } = decl_ntn in
   let notation = make_notation_interpretation ~local main_data notation_symbols ntn syntax_rules df env c sc in
-  syntax_rules_iter (fun sy -> Lib.add_anonymous_leaf (inSyntaxExtension (local,(ntn,sy)))) syntax_rules;
-  Lib.add_anonymous_leaf (inNotation notation);
+  syntax_rules_iter (fun sy -> Lib.add_leaf (inSyntaxExtension (local,(ntn,sy)))) syntax_rules;
+  Lib.add_leaf (inNotation notation);
   Dumpglob.dump_notation (CAst.make ?loc ntn) sc true
 
 (* interpreting a where clause *)
 let set_notation_for_interpretation env impls (decl_ntn, main_data, notation_symbols, ntn, syntax_rules) =
   let { decl_ntn_string = { CAst.loc ; v = df }; decl_ntn_interp = c; decl_ntn_scope = sc } = decl_ntn in
   let notation = make_notation_interpretation ~local:true main_data notation_symbols ntn syntax_rules df env ~impls c sc in
-  syntax_rules_iter (fun sy -> Lib.add_anonymous_leaf (inSyntaxExtension (true,(ntn,sy)))) syntax_rules;
-  Lib.add_anonymous_leaf (inNotation notation);
+  syntax_rules_iter (fun sy -> Lib.add_leaf (inSyntaxExtension (true,(ntn,sy)))) syntax_rules;
+  Lib.add_leaf (inNotation notation);
   Option.iter (fun sc -> Notation.open_close_scope (false,true,sc)) sc
 
 (* Main entry point for command Notation *)
@@ -1729,8 +1729,8 @@ let add_notation ~local ~infix deprecation env c ({CAst.loc;v=df},modifiers) sc 
   (* Build the interpretation *)
   let notation = make_notation_interpretation ~local main_data notation_symbols ntn syntax_rules df env c sc in
   (* Declare both syntax and interpretation *)
-  syntax_rules_iter (fun sy -> Lib.add_anonymous_leaf (inSyntaxExtension (local,(ntn,sy)))) syntax_rules;
-  Lib.add_anonymous_leaf (inNotation notation);
+  syntax_rules_iter (fun sy -> Lib.add_leaf (inSyntaxExtension (local,(ntn,sy)))) syntax_rules;
+  Lib.add_leaf (inNotation notation);
   (* Dump the location of the notation for coqdoc *)
   Dumpglob.dump_notation (CAst.make ?loc ntn) sc true
 
@@ -1801,16 +1801,16 @@ let inScopeCommand : locality_flag * scope_name * scope_command -> obj =
       classify_function = classify_scope_command}
 
 let declare_scope local scope =
-  Lib.add_anonymous_leaf (inScopeCommand(local,scope,ScopeDeclare))
+  Lib.add_leaf (inScopeCommand(local,scope,ScopeDeclare))
 
 let add_delimiters local scope key =
-  Lib.add_anonymous_leaf (inScopeCommand(local,scope,ScopeDelimAdd key))
+  Lib.add_leaf (inScopeCommand(local,scope,ScopeDelimAdd key))
 
 let remove_delimiters local scope =
-  Lib.add_anonymous_leaf (inScopeCommand(local,scope,ScopeDelimRemove))
+  Lib.add_leaf (inScopeCommand(local,scope,ScopeDelimRemove))
 
 let add_class_scope local scope cl =
-  Lib.add_anonymous_leaf (inScopeCommand(local,scope,ScopeClasses cl))
+  Lib.add_leaf (inScopeCommand(local,scope,ScopeClasses cl))
 
 let interp_syndef_modifiers deprecation modl =
   let mods, skipped = interp_non_syntax_modifiers ~reserved:false ~infix:false ~syndef:true deprecation modl in
@@ -1874,4 +1874,4 @@ let declare_custom_entry local s =
   if Egramcoq.exists_custom_entry s then
     user_err Pp.(str "Custom entry " ++ str s ++ str " already exists.")
   else
-    Lib.add_anonymous_leaf (inCustomEntry (local,s))
+    Lib.add_leaf (inCustomEntry (local,s))

--- a/vernac/mltop.ml
+++ b/vernac/mltop.ml
@@ -345,7 +345,7 @@ let declare_ml_modules local l =
   then user_err Pp.(str "Cannot Declare ML Module while sections are opened.");
   let l = List.map mod_of_name l in
   let l = List.map add_module_digest l in
-  Lib.add_anonymous_leaf (inMLModule {mlocal=local; mnames=l});
+  Lib.add_leaf (inMLModule {mlocal=local; mnames=l});
   (* We can't put this in cache_function: it may declare other
      objects, and when the current module is required we want to run
      the ML-MODULE object before them. *)

--- a/vernac/mltop.ml
+++ b/vernac/mltop.ml
@@ -324,7 +324,7 @@ let cache_ml_objects mnames =
   let iter (obj, _) = trigger_ml_object true true true obj in
   List.iter iter mnames
 
-let load_ml_objects _ (_,{mnames=mnames}) =
+let load_ml_objects _ {mnames=mnames} =
   let iter (obj, _) = trigger_ml_object true false true obj in
   List.iter iter mnames
 

--- a/vernac/mltop.ml
+++ b/vernac/mltop.ml
@@ -328,8 +328,8 @@ let load_ml_objects _ {mnames=mnames} =
   let iter (obj, _) = trigger_ml_object true false true obj in
   List.iter iter mnames
 
-let classify_ml_objects ({mlocal=mlocal} as o) =
-  if mlocal then Libobject.Dispose else Libobject.Substitute o
+let classify_ml_objects {mlocal=mlocal} =
+  if mlocal then Libobject.Dispose else Libobject.Substitute
 
 let inMLModule : ml_module_object -> Libobject.obj =
   let open Libobject in

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -677,7 +677,7 @@ let handle h (Libobject.Dyn.Dyn (tag, o)) = match DynHandle.find tag h with
 let gallina_print_leaf_entry env sigma with_values ((_, kn),lobj) =
   let sep = if with_values then " = " else " : " in
   match lobj with
-  | AtomicObject (_,o) ->
+  | AtomicObject o ->
     let handler =
       DynHandle.add Declare.Internal.objVariable begin fun (id,()) ->
           (* Outside sections, VARIABLES still exist but only with universes
@@ -792,7 +792,7 @@ let handleF h (Libobject.Dyn.Dyn (tag, o)) = match DynHandleF.find tag h with
 (* TODO: see the comment for {!gallina_print_leaf_entry} *)
 let print_full_pure_context env sigma =
   let rec prec = function
-  | ((_,kn),Lib.Leaf AtomicObject (_, lobj))::rest ->
+  | ((_,kn),Lib.Leaf AtomicObject lobj)::rest ->
     let handler =
       DynHandleF.add Declare.Internal.Constant.tag begin fun (id,_) ->
           let kn = KerName.make (KerName.modpath kn) (Label.of_id id) in

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -677,7 +677,7 @@ let handle h (Libobject.Dyn.Dyn (tag, o)) = match DynHandle.find tag h with
 let gallina_print_leaf_entry env sigma with_values ((_, kn),lobj) =
   let sep = if with_values then " = " else " : " in
   match lobj with
-  | AtomicObject o ->
+  | AtomicObject (_,o) ->
     let handler =
       DynHandle.add Declare.Internal.objVariable begin fun (id,()) ->
           (* Outside sections, VARIABLES still exist but only with universes
@@ -792,7 +792,7 @@ let handleF h (Libobject.Dyn.Dyn (tag, o)) = match DynHandleF.find tag h with
 (* TODO: see the comment for {!gallina_print_leaf_entry} *)
 let print_full_pure_context env sigma =
   let rec prec = function
-  | ((_,kn),Lib.Leaf AtomicObject lobj)::rest ->
+  | ((_,kn),Lib.Leaf AtomicObject (_, lobj))::rest ->
     let handler =
       DynHandleF.add Declare.Internal.Constant.tag begin fun (id,_) ->
           let kn = KerName.make (KerName.modpath kn) (Label.of_id id) in

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -679,7 +679,7 @@ let gallina_print_library_leaf env sigma with_values mp lobj =
   match lobj with
   | AtomicObject o ->
     let handler =
-      DynHandle.add Declare.Internal.objVariable begin fun (id,()) ->
+      DynHandle.add Declare.Internal.objVariable begin fun id ->
           (* Outside sections, VARIABLES still exist but only with universes
              constraints *)
           (try Some(print_named_decl env sigma id) with Not_found -> None)

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -39,7 +39,7 @@ type object_pr = {
   print_module              : ModPath.t -> Pp.t;
   print_modtype             : ModPath.t -> Pp.t;
   print_named_decl          : env -> Evd.evar_map -> Constr.named_declaration -> Pp.t;
-  print_library_entry       : env -> Evd.evar_map -> bool -> (object_name * Lib.node) -> Pp.t option;
+  print_library_leaf       : env -> Evd.evar_map -> bool -> ModPath.t -> Libobject.t -> Pp.t option;
   print_context             : env -> Evd.evar_map -> bool -> int option -> Lib.library_segment -> Pp.t;
   print_typed_value_in_env  : Environ.env -> Evd.evar_map -> EConstr.constr * EConstr.types -> Pp.t;
   print_eval                : Reductionops.reduction_function -> env -> Evd.evar_map -> Constrexpr.constr_expr -> EConstr.unsafe_judgment -> Pp.t;
@@ -674,7 +674,7 @@ let handle h (Libobject.Dyn.Dyn (tag, o)) = match DynHandle.find tag h with
    no reason that an object in the stack corresponds to a user-facing
    declaration. It may have been so at the time this was written, but this
    needs to be done in a more principled way. *)
-let gallina_print_leaf_entry env sigma with_values ((_, kn),lobj) =
+let gallina_print_library_leaf env sigma with_values mp lobj =
   let sep = if with_values then " = " else " : " in
   match lobj with
   | AtomicObject o ->
@@ -685,45 +685,62 @@ let gallina_print_leaf_entry env sigma with_values ((_, kn),lobj) =
           (try Some(print_named_decl env sigma id) with Not_found -> None)
       end @@
       DynHandle.add Declare.Internal.Constant.tag begin fun (id,_) ->
-        let kn = Constant.make2 (KerName.modpath kn) (Label.of_id id) in
+        let kn = Constant.make2 mp (Label.of_id id) in
         Some (print_constant with_values sep kn None)
       end @@
       DynHandle.add DeclareInd.Internal.objInductive begin fun (id,_) ->
-        let kn = MutInd.make2 (KerName.modpath kn) (Label.of_id id) in
+        let kn = MutInd.make2 mp (Label.of_id id) in
         Some (gallina_print_inductive kn None)
       end @@
       DynHandle.empty
     in
     handle handler o
   | ModuleObject (id,_) ->
-    let mp = KerName.modpath kn in
     Some (print_module ~with_body:with_values (MPdot (mp,Label.of_id id)))
   | ModuleTypeObject (id,_) ->
-    let mp = KerName.modpath kn in
     Some (print_modtype (MPdot (mp, Label.of_id id)))
-  | _ -> None
+  | IncludeObject _ | KeepObject _ | ExportObject _ -> None
 
-let gallina_print_library_entry env sigma with_values ent =
-  let pr_name (sp,_) = Id.print (basename sp) in
-  match ent with
-    | (oname,Lib.Leaf lobj) ->
-      gallina_print_leaf_entry env sigma with_values (oname,lobj)
-    | (oname,Lib.OpenedSection (dir,_)) ->
-      Some (str " >>>>>>> Section " ++ pr_name oname)
-    | (_,Lib.CompilingLibrary { Nametab.obj_dir; _ }) ->
-      Some (str " >>>>>>> Library " ++ DirPath.print obj_dir)
-    | (oname,Lib.OpenedModule _) ->
-      Some (str " >>>>>>> Module " ++ pr_name oname)
+let decr = Option.map ((+) (-1))
+
+let is_done = Option.equal Int.equal (Some 0)
+
+let print_leaves env sigma with_values mp =
+  let rec prec n = function
+    | [] -> n, mt()
+    | o :: rest ->
+      if is_done n then n, mt()
+      else begin match gallina_print_library_leaf env sigma with_values mp o with
+        | Some pp ->
+          let n, prest = prec (decr n) rest in
+          n, prest ++ pp
+        | None -> prec n rest
+      end
+  in
+  prec
 
 let gallina_print_context env sigma with_values =
   let rec prec n = function
-    | h::rest when Option.is_empty n || Option.get n > 0 ->
-      (match gallina_print_library_entry env sigma with_values h with
-       | None -> prec n rest
-       | Some pp -> prec (Option.map ((+) (-1)) n) rest ++ pp ++ fnl ())
-    | _ -> mt ()
+    | [] -> mt()
+    | (node, leaves) :: rest ->
+      if is_done n then mt()
+      else
+        let mp = (Lib.node_prefix node).Nametab.obj_mp in
+        let n, pleaves = print_leaves env sigma with_values mp n leaves in
+        if is_done n then pleaves
+        else prec n rest ++ pleaves
   in
   prec
+
+let pr_prefix_name prefix = Id.print (snd (split_dirpath prefix.Nametab.obj_dir))
+
+let print_library_node = function
+  | Lib.OpenedSection (prefix, _) ->
+    str " >>>>>>> Section " ++ pr_prefix_name prefix
+  | Lib.OpenedModule (_,_,prefix,_) ->
+    str " >>>>>>> Module " ++ pr_prefix_name prefix
+  | Lib.CompilingLibrary { Nametab.obj_dir; _ } ->
+    str " >>>>>>> Library " ++ DirPath.print obj_dir
 
 let gallina_print_eval red_fun env sigma _ {uj_val=trm;uj_type=typ} =
   let ntrm = red_fun env sigma trm in
@@ -740,7 +757,7 @@ let default_object_pr = {
   print_module              = gallina_print_module;
   print_modtype             = gallina_print_modtype;
   print_named_decl          = gallina_print_named_decl;
-  print_library_entry       = gallina_print_library_entry;
+  print_library_leaf        = gallina_print_library_leaf;
   print_context             = gallina_print_context;
   print_typed_value_in_env  = gallina_print_typed_value_in_env;
   print_eval                = gallina_print_eval;
@@ -756,7 +773,7 @@ let print_syntactic_def x = !object_pr.print_syntactic_def x
 let print_module x  = !object_pr.print_module  x
 let print_modtype x = !object_pr.print_modtype x
 let print_named_decl x = !object_pr.print_named_decl x
-let print_library_entry x = !object_pr.print_library_entry x
+let print_library_leaf x = !object_pr.print_library_leaf x
 let print_context x = !object_pr.print_context x
 let print_typed_value_in_env x = !object_pr.print_typed_value_in_env x
 let print_eval x = !object_pr.print_eval x
@@ -790,55 +807,61 @@ let handleF h (Libobject.Dyn.Dyn (tag, o)) = match DynHandleF.find tag h with
 | exception Not_found -> mt ()
 
 (* TODO: see the comment for {!gallina_print_leaf_entry} *)
+let print_full_pure_atomic env sigma mp lobj =
+  let handler =
+    DynHandleF.add Declare.Internal.Constant.tag begin fun (id,_) ->
+      let kn = KerName.make mp (Label.of_id id) in
+      let con = Global.constant_of_delta_kn kn in
+      let cb = Global.lookup_constant con in
+      let typ = cb.const_type in
+      hov 0 (
+        match cb.const_body with
+        | Undef _ ->
+          str "Parameter " ++
+          print_basename con ++ str " : " ++ cut () ++ pr_ltype_env env sigma typ
+        | OpaqueDef lc ->
+          str "Theorem " ++ print_basename con ++ cut () ++
+          str " : " ++ pr_ltype_env env sigma typ ++ str "." ++ fnl () ++
+          str "Proof " ++ pr_lconstr_env env sigma
+            (fst (Global.force_proof Library.indirect_accessor lc))
+        | Def c ->
+          str "Definition " ++ print_basename con ++ cut () ++
+          str "  : " ++ pr_ltype_env env sigma typ ++ cut () ++ str " := " ++
+          pr_lconstr_env env sigma c
+        | Primitive _ ->
+          str "Primitive " ++
+          print_basename con ++ str " : " ++ cut () ++ pr_ltype_env env sigma typ)
+      ++ str "." ++ fnl () ++ fnl ()
+    end @@
+    DynHandleF.add DeclareInd.Internal.objInductive begin fun (id,_) ->
+      let kn = KerName.make mp (Label.of_id id) in
+      let mind = Global.mind_of_delta_kn kn in
+      let mib = Global.lookup_mind mind in
+      pr_mutual_inductive_body (Global.env()) mind mib None ++
+      str "." ++ fnl () ++ fnl ()
+    end @@
+    DynHandleF.empty
+  in
+  handleF handler lobj
+
+let print_full_pure_leaf env sigma mp = function
+  | AtomicObject lobj -> print_full_pure_atomic env sigma mp lobj
+  | ModuleObject (id, _) ->
+    (* TODO: make it reparsable *)
+    print_module (MPdot (mp,Label.of_id id)) ++ str "." ++ fnl () ++ fnl ()
+  | ModuleTypeObject (id, _) ->
+    (* TODO: make it reparsable *)
+    print_modtype (MPdot (mp,Label.of_id id)) ++ str "." ++ fnl () ++ fnl ()
+  | _ -> mt()
+
 let print_full_pure_context env sigma =
   let rec prec = function
-  | ((_,kn),Lib.Leaf AtomicObject lobj)::rest ->
-    let handler =
-      DynHandleF.add Declare.Internal.Constant.tag begin fun (id,_) ->
-          let kn = KerName.make (KerName.modpath kn) (Label.of_id id) in
-          let con = Global.constant_of_delta_kn kn in
-          let cb = Global.lookup_constant con in
-          let typ = cb.const_type in
-          hov 0 (
-            match cb.const_body with
-              | Undef _ ->
-                str "Parameter " ++
-                print_basename con ++ str " : " ++ cut () ++ pr_ltype_env env sigma typ
-              | OpaqueDef lc ->
-                str "Theorem " ++ print_basename con ++ cut () ++
-                str " : " ++ pr_ltype_env env sigma typ ++ str "." ++ fnl () ++
-                str "Proof " ++ pr_lconstr_env env sigma
-                  (fst (Global.force_proof Library.indirect_accessor lc))
-              | Def c ->
-                str "Definition " ++ print_basename con ++ cut () ++
-                str "  : " ++ pr_ltype_env env sigma typ ++ cut () ++ str " := " ++
-                pr_lconstr_env env sigma c
-              | Primitive _ ->
-                 str "Primitive " ++
-                   print_basename con ++ str " : " ++ cut () ++ pr_ltype_env env sigma typ)
-          ++ str "." ++ fnl () ++ fnl ()
-      end @@
-      DynHandleF.add DeclareInd.Internal.objInductive begin fun (id,_) ->
-          let kn = KerName.make (KerName.modpath kn) (Label.of_id id) in
-          let mind = Global.mind_of_delta_kn kn in
-          let mib = Global.lookup_mind mind in
-          pr_mutual_inductive_body (Global.env()) mind mib None ++
-            str "." ++ fnl () ++ fnl ()
-      end @@
-      DynHandleF.empty
-    in
-    let pp = handleF handler lobj in
+    | (node,leaves)::rest ->
+      let mp = (Lib.node_prefix node).Nametab.obj_mp in
+      let pp = Pp.prlist (print_full_pure_leaf env sigma mp) leaves in
       prec rest ++ pp
-  | ((_,kn),Lib.Leaf ModuleObject (id,_))::rest ->
-    (* TODO: make it reparsable *)
-    let mp = KerName.modpath kn in
-    prec rest ++ print_module (MPdot (mp,Label.of_id id)) ++ str "." ++ fnl () ++ fnl ()
-  | ((_,kn),Lib.Leaf ModuleTypeObject (id,_))::rest ->
-    (* TODO: make it reparsable *)
-    let mp = KerName.modpath kn in
-    prec rest ++ print_modtype (MPdot (mp,Label.of_id id)) ++ str "." ++ fnl () ++ fnl ()
-  | _::rest -> prec rest
-  | _ -> mt () in
+  | [] -> mt ()
+  in
   prec (Lib.contents ())
 
 (* For printing an inductive definition with
@@ -853,7 +876,7 @@ let read_sec_context qid =
     with Not_found ->
       user_err ?loc:qid.loc (str "Unknown section.") in
   let rec get_cxt in_cxt = function
-    | (_,Lib.OpenedSection ({Nametab.obj_dir;_},_) as hd)::rest ->
+    | (Lib.OpenedSection ({Nametab.obj_dir;_},_), _ as hd)::rest ->
         if DirPath.equal dir obj_dir then (hd::in_cxt) else get_cxt (hd::in_cxt) rest
     | [] -> []
     | hd::rest -> get_cxt (hd::in_cxt) rest

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -679,10 +679,10 @@ let gallina_print_leaf_entry env sigma with_values ((sp, kn),lobj) =
   match lobj with
   | AtomicObject o ->
     let handler =
-      DynHandle.add Declare.Internal.objVariable begin fun _ ->
+      DynHandle.add Declare.Internal.objVariable begin fun id ->
           (* Outside sections, VARIABLES still exist but only with universes
              constraints *)
-          (try Some(print_named_decl env sigma (basename sp)) with Not_found -> None)
+          (try Some(print_named_decl env sigma id) with Not_found -> None)
       end @@
       DynHandle.add Declare.Internal.Constant.tag begin fun _ ->
           Some (print_constant with_values sep (Constant.make1 kn) None)

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -695,12 +695,12 @@ let gallina_print_leaf_entry env sigma with_values ((_, kn),lobj) =
       DynHandle.empty
     in
     handle handler o
-  | ModuleObject _ ->
-    let (mp,l) = KerName.repr kn in
-    Some (print_module ~with_body:with_values (MPdot (mp,l)))
-  | ModuleTypeObject _ ->
-    let (mp,l) = KerName.repr kn in
-          Some (print_modtype (MPdot (mp,l)))
+  | ModuleObject (id,_) ->
+    let mp = KerName.modpath kn in
+    Some (print_module ~with_body:with_values (MPdot (mp,Label.of_id id)))
+  | ModuleTypeObject (id,_) ->
+    let mp = KerName.modpath kn in
+    Some (print_modtype (MPdot (mp, Label.of_id id)))
   | _ -> None
 
 let gallina_print_library_entry env sigma with_values ent =
@@ -829,14 +829,14 @@ let print_full_pure_context env sigma =
     in
     let pp = handleF handler lobj in
       prec rest ++ pp
-  | ((_,kn),Lib.Leaf ModuleObject _)::rest ->
-          (* TODO: make it reparsable *)
-    let (mp,l) = KerName.repr kn in
-          prec rest ++ print_module (MPdot (mp,l)) ++ str "." ++ fnl () ++ fnl ()
-  | ((_,kn),Lib.Leaf ModuleTypeObject _)::rest ->
-          (* TODO: make it reparsable *)
-    let (mp,l) = KerName.repr kn in
-          prec rest ++ print_modtype (MPdot (mp,l)) ++ str "." ++ fnl () ++ fnl ()
+  | ((_,kn),Lib.Leaf ModuleObject (id,_))::rest ->
+    (* TODO: make it reparsable *)
+    let mp = KerName.modpath kn in
+    prec rest ++ print_module (MPdot (mp,Label.of_id id)) ++ str "." ++ fnl () ++ fnl ()
+  | ((_,kn),Lib.Leaf ModuleTypeObject (id,_))::rest ->
+    (* TODO: make it reparsable *)
+    let mp = KerName.modpath kn in
+    prec rest ++ print_modtype (MPdot (mp,Label.of_id id)) ++ str "." ++ fnl () ++ fnl ()
   | _::rest -> prec rest
   | _ -> mt () in
   prec (Lib.contents ())

--- a/vernac/prettyp.mli
+++ b/vernac/prettyp.mli
@@ -22,10 +22,14 @@ val print_context
   : env
   -> Evd.evar_map
   -> bool -> int option -> Lib.library_segment -> Pp.t
-val print_library_entry
+val print_library_leaf
   : env
   -> Evd.evar_map
-  -> bool -> (Libobject.object_name * Lib.node) -> Pp.t option
+  -> bool
+  -> ModPath.t
+  -> Libobject.t
+  -> Pp.t option
+val print_library_node : Lib.node -> Pp.t
 val print_full_context : env -> Evd.evar_map -> Pp.t
 val print_full_context_typ : env -> Evd.evar_map -> Pp.t
 
@@ -99,7 +103,7 @@ type object_pr = {
   print_module              : ModPath.t -> Pp.t;
   print_modtype             : ModPath.t -> Pp.t;
   print_named_decl          : env -> Evd.evar_map -> Constr.named_declaration -> Pp.t;
-  print_library_entry       : env -> Evd.evar_map -> bool -> (Libobject.object_name * Lib.node) -> Pp.t option;
+  print_library_leaf       : env -> Evd.evar_map -> bool -> ModPath.t -> Libobject.t -> Pp.t option;
   print_context             : env -> Evd.evar_map -> bool -> int option -> Lib.library_segment -> Pp.t;
   print_typed_value_in_env  : Environ.env -> Evd.evar_map -> EConstr.constr * EConstr.types -> Pp.t;
   print_eval                : Reductionops.reduction_function -> env -> Evd.evar_map -> Constrexpr.constr_expr -> EConstr.unsafe_judgment -> Pp.t;

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -489,7 +489,7 @@ let cache_structure o = load_structure 1 o
 
 let subst_structure (subst, obj) = Structure.subst subst obj
 
-let discharge_structure (_, x) = Some x
+let discharge_structure x = Some x
 
 let rebuild_structure s = Structure.rebuild (Global.env()) s
 

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -499,7 +499,7 @@ let inStruc : Structure.t -> Libobject.obj =
     cache_function = cache_structure;
     load_function = load_structure;
     subst_function = subst_structure;
-    classify_function = (fun x -> Substitute x);
+    classify_function = (fun x -> Substitute);
     discharge_function = discharge_structure;
     rebuild_function = rebuild_structure; }
 

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -504,7 +504,7 @@ let inStruc : Structure.t -> Libobject.obj =
     rebuild_function = rebuild_structure; }
 
 let declare_structure_entry o =
-  Lib.add_anonymous_leaf (inStruc o)
+  Lib.add_leaf (inStruc o)
 
 (** In the type of every projection, the record is bound to a variable named
   using the first character of the record type. We rename it to avoid

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -483,7 +483,7 @@ let check_template ~template ~poly ~univs ~params { Data.id; rdata = { DataR.min
     (* auto detect template *)
     ComInductive.should_auto_template id (template && template_candidate ())
 
-let load_structure i (_, structure) = Structure.register structure
+let load_structure i structure = Structure.register structure
 
 let cache_structure o = load_structure 1 o
 

--- a/vernac/search.ml
+++ b/vernac/search.ml
@@ -76,11 +76,11 @@ let handle h (Libobject.Dyn.Dyn (tag, o)) = match DynHandle.find tag h with
 let generic_search env (fn : GlobRef.t -> Decls.logical_kind option -> env -> constr -> unit) =
   List.iter (fun d -> fn (GlobRef.VarRef (NamedDecl.get_id d)) None env (NamedDecl.get_type d))
     (Environ.named_context env);
-  let iter_obj (_, kn) lobj = match lobj with
-    | AtomicObject o ->
+  let iter_obj prefix lobj = match lobj with
+    | AtomicObject (_,o) ->
       let handler =
         DynHandle.add Declare.Internal.Constant.tag begin fun (id,obj) ->
-          let kn = KerName.make (KerName.modpath kn) (Label.of_id id) in
+          let kn = KerName.make prefix.Nametab.obj_mp (Label.of_id id) in
           let cst = Global.constant_of_delta_kn kn in
           let gr = GlobRef.ConstRef cst in
           let (typ, _) = Typeops.type_of_global_in_context (Global.env ()) gr in
@@ -88,7 +88,7 @@ let generic_search env (fn : GlobRef.t -> Decls.logical_kind option -> env -> co
           fn gr (Some kind) env typ
         end @@
         DynHandle.add DeclareInd.Internal.objInductive begin fun (id,_) ->
-          let kn = KerName.make (KerName.modpath kn) (Label.of_id id) in
+          let kn = KerName.make prefix.Nametab.obj_mp (Label.of_id id) in
           let mind = Global.mind_of_delta_kn kn in
           let mib = Global.lookup_mind mind in
           let iter_packet i mip =

--- a/vernac/search.ml
+++ b/vernac/search.ml
@@ -76,17 +76,19 @@ let handle h (Libobject.Dyn.Dyn (tag, o)) = match DynHandle.find tag h with
 let generic_search env (fn : GlobRef.t -> Decls.logical_kind option -> env -> constr -> unit) =
   List.iter (fun d -> fn (GlobRef.VarRef (NamedDecl.get_id d)) None env (NamedDecl.get_type d))
     (Environ.named_context env);
-  let iter_obj (sp, kn) lobj = match lobj with
+  let iter_obj (_, kn) lobj = match lobj with
     | AtomicObject o ->
       let handler =
-        DynHandle.add Declare.Internal.Constant.tag begin fun obj ->
+        DynHandle.add Declare.Internal.Constant.tag begin fun (id,obj) ->
+          let kn = KerName.make (KerName.modpath kn) (Label.of_id id) in
           let cst = Global.constant_of_delta_kn kn in
           let gr = GlobRef.ConstRef cst in
           let (typ, _) = Typeops.type_of_global_in_context (Global.env ()) gr in
           let kind = Declare.Internal.Constant.kind obj in
           fn gr (Some kind) env typ
         end @@
-        DynHandle.add DeclareInd.Internal.objInductive begin fun _ ->
+        DynHandle.add DeclareInd.Internal.objInductive begin fun (id,_) ->
+          let kn = KerName.make (KerName.modpath kn) (Label.of_id id) in
           let mind = Global.mind_of_delta_kn kn in
           let mib = Global.lookup_mind mind in
           let iter_packet i mip =

--- a/vernac/search.ml
+++ b/vernac/search.ml
@@ -77,7 +77,7 @@ let generic_search env (fn : GlobRef.t -> Decls.logical_kind option -> env -> co
   List.iter (fun d -> fn (GlobRef.VarRef (NamedDecl.get_id d)) None env (NamedDecl.get_type d))
     (Environ.named_context env);
   let iter_obj prefix lobj = match lobj with
-    | AtomicObject (_,o) ->
+    | AtomicObject o ->
       let handler =
         DynHandle.add Declare.Internal.Constant.tag begin fun (id,obj) ->
           let kn = KerName.make prefix.Nametab.obj_mp (Label.of_id id) in

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1121,19 +1121,19 @@ let cache_name (len,n) =
   | TrueGlobal gr ->
     Nametab.(push (Exactly (len+1)) (path_of_global gr) gr)
 
-let cache_names (_,ns) = List.iter cache_name ns
+let cache_names ns = List.iter cache_name ns
 
 let subst_names (subst,ns) = List.Smart.map (on_snd (Globnames.subst_extended_reference subst)) ns
 
 let inExportNames = Libobject.declare_object
     (Libobject.global_object "EXPORTNAMES"
        ~cache:cache_names ~subst:(Some subst_names)
-       ~discharge:(fun (_,x) -> Some x))
+       ~discharge:(fun x -> Some x))
 
 let import_names ~export m ns =
   let ns = interp_names m ns in
   if export then Lib.add_anonymous_leaf (inExportNames ns)
-  else cache_names ((),ns)
+  else cache_names ns
 
 let vernac_import export cats refl =
   if Option.has_some cats then

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1132,7 +1132,7 @@ let inExportNames = Libobject.declare_object
 
 let import_names ~export m ns =
   let ns = interp_names m ns in
-  if export then Lib.add_anonymous_leaf (inExportNames ns)
+  if export then Lib.add_leaf (inExportNames ns)
   else cache_names ns
 
 let vernac_import export cats refl =


### PR DESCRIPTION
Only objects which actually need one get an object_name. It is constructed on the fly from the object_prefix and the object's explicitly provided id.

In short:

- instead of `Lib.add_leaf id (inObj bla)` we do `Lib.add_leaf (inObj (id,bla))`
- `Lib.add_leaf` is the renamed `Lib.add_anonymous_leaf`, ie `Lib.add_anonymous_leaf (inObj bla)` becomes `Lib.add_leaf (inObj bla)`. It does not invent and risk leaking a garbage id anymore.
- the non-atomic leaf objects (eg ModuleObject, IncludeObject etc) also explicitly manage their ids. Notably IncludeObject stops using `current_mod_id` for its `add_entry`, which is good as `current_mod_id` outside a module produces a garbage id.
- the library segment has been changed from `` (object_name * [ `Leaf of Libobject.t | `OpenModule of ... | ... ]) list `` to `` ([ `OpenModule of ... | ... ] * Libobject.t list) list ``. Notably the garbage object_name `If you see this, it's a bug` is not paired with the CompiledLibrary element anymore. The object_prefix for the Libobject.t is trivially gotten from OpenModule & co, and they turn it into object_name using their explicit id if needed.

See individual commits for details, especially about additionnaly supporting changes.

Further cleanups may be possible, but I think the libobject / Lib.add_leaf API should be at a stable point so we won't rebreak all object using plugins.

Overlays:
- https://github.com/mattam82/Coq-Equations/pull/465
- https://github.com/coq-community/paramcoq/pull/89
- https://github.com/QuickChick/QuickChick/pull/260
- https://github.com/LPCIC/coq-elpi/pull/314