### PR TITLE
docs: Add new shields.io badge for `coqorg/coq:latest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ environment for semi-interactive development of machine-checked proofs.
 [![nixpkgs unstable package][nixpkgs-badge]][nixpkgs-link]
 
 [![Docker Hub package][dockerhub-badge]][dockerhub-link]
+[![latest dockerized version][coqorg-badge]][coqorg-link]
 
 [repology-badge]: https://repology.org/badge/latest-versions/coq.svg
 [repology-link]: https://repology.org/metapackage/coq/versions
@@ -60,6 +61,9 @@ environment for semi-interactive development of machine-checked proofs.
 
 [dockerhub-badge]: https://img.shields.io/badge/images%20on-Docker%20Hub-blue.svg
 [dockerhub-link]: https://hub.docker.com/r/coqorg/coq#supported-tags "Supported tags on Docker Hub"
+
+[coqorg-badge]: https://img.shields.io/docker/v/coqorg/coq/latest
+[coqorg-link]: https://github.com/coq-community/docker-coq/wiki#docker-coq-images "coqorg/coq:latest"
 
 Please see https://coq.inria.fr/download.
 Information on how to build and install from sources can be found in


### PR DESCRIPTION
* This patch subsumes PR https://github.com/coq/coq/pull/15001

(at the time we did use `https://images.microbadger.com/badges/version/coqorg/coq.svg` badges,
this [shields.io](https://shields.io) badge used in this PR was not available in <https://shields.io/category/version>; fortunately this is now the case :)