### PR TITLE
Provide an explicit primitive to raise non-zero Ltac failures.

### DIFF
--- a/dev/ci/user-overlays/15327-ppedrot-split-tclfail-level.sh
+++ b/dev/ci/user-overlays/15327-ppedrot-split-tclfail-level.sh
@@ -1,0 +1,15 @@
+overlay aac_tactics https://github.com/ppedrot/aac-tactics split-tclfail-level 15327
+
+overlay coqhammer https://github.com/ppedrot/coqhammer split-tclfail-level 15327
+
+overlay elpi https://github.com/ppedrot/coq-elpi split-tclfail-level 15327
+
+overlay equations https://github.com/ppedrot/Coq-Equations split-tclfail-level 15327
+
+overlay fiat_parsers https://github.com/ppedrot/fiat split-tclfail-level 15327
+
+overlay itauto https://gitlab.inria.fr/pedrot/itauto split-tclfail-level 15327
+
+overlay unicoq https://github.com/ppedrot/unicoq split-tclfail-level 15327
+
+overlay relation_algebra https://github.com/ppedrot/relation-algebra split-tclfail-level 15327

--- a/plugins/btauto/refl_btauto.ml
+++ b/plugins/btauto/refl_btauto.ml
@@ -207,7 +207,7 @@ module Btauto = struct
         str "Not a tautology:" ++ spc () ++ l
       with e when CErrors.noncritical e -> (str "Not a tautology")
     in
-    Tacticals.tclFAIL 0 msg
+    Tacticals.tclFAIL msg
   end
 
   let try_unification env =
@@ -223,7 +223,7 @@ module Btauto = struct
           tac
       | _ ->
           let msg = str "Btauto: Internal error" in
-          Tacticals.tclFAIL 0 msg
+          Tacticals.tclFAIL msg
     end
 
   let tac =
@@ -253,7 +253,7 @@ module Btauto = struct
           ]
       | _ ->
           let msg = str "Cannot recognize a boolean equality" in
-          Tacticals.tclFAIL 0 msg
+          Tacticals.tclFAIL msg
     end
 
 end

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -451,7 +451,7 @@ let cc_tactic depth additional_terms b =
     let _ = debug_congruence (fun () -> Pp.str "Computation completed.") in
     let uf=forest state in
     match sol with
-      None -> Tacticals.tclFAIL 0 (str (if b then "simple congruence failed" else "congruence failed"))
+      None -> Tacticals.tclFAIL (str (if b then "simple congruence failed" else "congruence failed"))
     | Some reason ->
       debug_congruence (fun () -> Pp.str "Goal solved, generating proof ...");
       match reason with
@@ -482,7 +482,7 @@ let cc_tactic depth additional_terms b =
                         end ++
                       fnl() ++ str "  replacing metavariables by arbitrary terms")
         in
-        Tacticals.tclFAIL 0 msg
+        Tacticals.tclFAIL msg
       | Contradiction dis ->
         let env = Proofview.Goal.env gl in
         let p=build_proof env sigma uf (`Prove (dis.lhs,dis.rhs)) in

--- a/plugins/firstorder/ground.ml
+++ b/plugins/firstorder/ground.ml
@@ -55,7 +55,7 @@ let ground_tac solver startseq =
                       | Rforall->
                           let backtrack1=
                             if !qflag then
-                              tclFAIL 0 (Pp.str "reversible in 1st order mode")
+                              tclFAIL (Pp.str "reversible in 1st order mode")
                             else
                               backtrack in
                             forall_tac backtrack1 continue (re_add seq1)

--- a/plugins/firstorder/instances.ml
+++ b/plugins/firstorder/instances.ml
@@ -133,7 +133,7 @@ let left_instance_tac (inst,id) continue seq=
   match inst with
       Phantom dom->
         if lookup env sigma (id,None) seq then
-          tclFAIL 0 (Pp.str "already done")
+          tclFAIL (Pp.str "already done")
         else
           tclTHENS (cut dom)
             [tclTHENLIST
@@ -150,7 +150,7 @@ let left_instance_tac (inst,id) continue seq=
     | Real((m,t),_)->
         let c = (m, EConstr.to_constr ~abort_on_undefined_evars:false sigma t) in
         if lookup env sigma (id,Some c) seq then
-          tclFAIL 0 (Pp.str "already done")
+          tclFAIL (Pp.str "already done")
         else
           let special_generalize=
             if m>0 then
@@ -195,7 +195,7 @@ let right_instance_tac inst continue seq=
         (tclTHEN (split (Tactypes.ImplicitBindings [t]))
            (tclSOLVE [wrap 0 true continue (deepen seq)]))
     | Real ((m,t),_) ->
-        tclFAIL 0 (Pp.str "not implemented ... yet")
+        tclFAIL (Pp.str "not implemented ... yet")
   end
 
 let instance_tac inst=

--- a/plugins/firstorder/rules.ml
+++ b/plugins/firstorder/rules.ml
@@ -65,7 +65,7 @@ let axiom_tac t seq =
   try
     pf_constr_of_global (find_left (project gl) t seq) >>= fun c ->
     exact_no_check c
-  with Not_found -> tclFAIL 0 (Pp.str "No axiom link")
+  with Not_found -> tclFAIL (Pp.str "No axiom link")
   end
 
 let ll_atom_tac a backtrack id continue seq =
@@ -75,7 +75,7 @@ let ll_atom_tac a backtrack id continue seq =
         [(Proofview.tclEVARMAP >>= fun sigma ->
           let gr =
             try Proofview.tclUNIT (find_left sigma a seq)
-            with Not_found -> tclFAIL 0 (Pp.str "No link")
+            with Not_found -> tclFAIL (Pp.str "No link")
           in
           gr >>= fun gr ->
           pf_constr_of_global gr >>= fun left ->
@@ -190,7 +190,7 @@ let forall_tac backtrack continue seq=
           (tclTHEN introf (tclCOMPLETE (wrap 0 true continue seq)))
           backtrack))
     (if !qflag then
-       tclFAIL 0 (Pp.str "reversible in 1st order mode")
+       tclFAIL (Pp.str "reversible in 1st order mode")
      else
        backtrack)
 

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -415,7 +415,7 @@ let list_rewrite (rev : bool) (eqs : (EConstr.constr * bool) list) =
             ((if b then Equality.rewriteLR else Equality.rewriteRL) eq)
             i)
         (if rev then List.rev eqs else eqs)
-        (tclFAIL 0 (mt ()))) [@ocaml.warning "-3"])
+        (tclFAIL (mt ()))) [@ocaml.warning "-3"])
 
 let decompose_lam_n sigma n =
   if n < 0 then

--- a/plugins/funind/invfun.ml
+++ b/plugins/funind/invfun.ml
@@ -93,7 +93,7 @@ let functional_inversion kn hid fconst f_correct =
             ((fun hid -> intros_symmetry (Locusops.onHyp hid)), f_args, args.(2))
           | _, App (f, f_args) when EConstr.eq_constr sigma f fconst ->
             ((fun hid -> tclIDTAC), f_args, args.(1))
-          | _ -> ((fun hid -> tclFAIL 1 Pp.(mt ())), [||], args.(2))
+          | _ -> ((fun hid -> tclFAILn 1 Pp.(mt ())), [||], args.(2))
         in
         tclTHENLIST
           [ pre_tac hid
@@ -109,7 +109,7 @@ let functional_inversion kn hid fconst f_correct =
                     (pf_ids_of_hyps gl)
                 in
                 tclMAP (revert_graph kn pre_tac) (hid :: new_ids)) ]
-      | _ -> tclFAIL 1 Pp.(mt ()))
+      | _ -> tclFAILn 1 Pp.(mt ()))
 
 let invfun qhyp f =
   let f =

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -946,7 +946,7 @@ let rec prove_le () =
                 ; New.observe_tac
                     (fun _ _ -> str "prove_le (rec)")
                     (prove_le ()) ]
-            with Not_found -> Tacticals.tclFAIL 0 (mt ())
+            with Not_found -> Tacticals.tclFAIL (mt ())
           end ])
 
 let rec make_rewrite_list expr_info max = function

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -525,7 +525,7 @@ END
 TACTIC EXTEND constr_eq_nounivs
 | [ "constr_eq_nounivs" constr(x) constr(y) ] -> {
     Proofview.tclEVARMAP >>= fun sigma ->
-    if EConstr.eq_constr_nounivs sigma x y then Proofview.tclUNIT () else Tacticals.tclFAIL 0 (str "Not equal") }
+    if EConstr.eq_constr_nounivs sigma x y then Proofview.tclUNIT () else Tacticals.tclFAIL (str "Not equal") }
 END
 
 TACTIC EXTEND is_evar

--- a/plugins/ltac/g_class.mlg
+++ b/plugins/ltac/g_class.mlg
@@ -137,7 +137,7 @@ let progress_evars t =
         if eq_constr_mod_evars sigma concl newconcl
         then
           let info = Exninfo.reify () in
-          Tacticals.tclFAIL ~info 0 (Pp.str"No progress made (modulo evars)")
+          Tacticals.tclFAIL ~info (Pp.str"No progress made (modulo evars)")
         else Proofview.tclUNIT ()
       end
     in t <*> check

--- a/plugins/ltac/internals.ml
+++ b/plugins/ltac/internals.ml
@@ -294,55 +294,55 @@ let is_evar x =
   Proofview.tclEVARMAP >>= fun sigma ->
   match EConstr.kind sigma x with
     | Evar _ -> Proofview.tclUNIT ()
-    | _ -> Tacticals.tclFAIL 0 (Pp.str "Not an evar")
+    | _ -> Tacticals.tclFAIL (Pp.str "Not an evar")
 
 let has_evar x =
   Proofview.tclEVARMAP >>= fun sigma ->
   if Evarutil.has_undefined_evars sigma x
   then Proofview.tclUNIT ()
-  else Tacticals.tclFAIL 0 (Pp.str "No evars")
+  else Tacticals.tclFAIL (Pp.str "No evars")
 
 let is_var x =
   Proofview.tclEVARMAP >>= fun sigma ->
   match EConstr.kind sigma x with
     | Var _ ->  Proofview.tclUNIT ()
-    | _ -> Tacticals.tclFAIL 0 (Pp.str "Not a variable or hypothesis")
+    | _ -> Tacticals.tclFAIL (Pp.str "Not a variable or hypothesis")
 
 let is_fix x =
   Proofview.tclEVARMAP >>= fun sigma ->
   match EConstr.kind sigma x with
     | Fix _ -> Proofview.tclUNIT ()
-    | _ -> Tacticals.tclFAIL 0 (Pp.str "not a fix definition")
+    | _ -> Tacticals.tclFAIL (Pp.str "not a fix definition")
 
 let is_cofix x =
   Proofview.tclEVARMAP >>= fun sigma ->
   match EConstr.kind sigma x with
     | CoFix _ -> Proofview.tclUNIT ()
-    | _ -> Tacticals.tclFAIL 0 (Pp.str "not a cofix definition")
+    | _ -> Tacticals.tclFAIL (Pp.str "not a cofix definition")
 
 let is_ind x =
   Proofview.tclEVARMAP >>= fun sigma ->
   match EConstr.kind sigma x with
     | Ind _ -> Proofview.tclUNIT ()
-    | _ -> Tacticals.tclFAIL 0 (Pp.str "not an (co)inductive datatype")
+    | _ -> Tacticals.tclFAIL (Pp.str "not an (co)inductive datatype")
 
 let is_constructor x =
   Proofview.tclEVARMAP >>= fun sigma ->
   match EConstr.kind sigma x with
     | Construct _ -> Proofview.tclUNIT ()
-    | _ -> Tacticals.tclFAIL 0 (Pp.str "not a constructor")
+    | _ -> Tacticals.tclFAIL (Pp.str "not a constructor")
 
 let is_proj x =
   Proofview.tclEVARMAP >>= fun sigma ->
   match EConstr.kind sigma x with
     | Proj _ -> Proofview.tclUNIT ()
-    | _ -> Tacticals.tclFAIL 0 (Pp.str "not a primitive projection")
+    | _ -> Tacticals.tclFAIL (Pp.str "not a primitive projection")
 
 let is_const x =
   Proofview.tclEVARMAP >>= fun sigma ->
   match EConstr.kind sigma x with
     | Const _ -> Proofview.tclUNIT ()
-    | _ -> Tacticals.tclFAIL 0 (Pp.str "not a constant")
+    | _ -> Tacticals.tclFAIL (Pp.str "not a constant")
 
 let unshelve ist t =
   Proofview.with_shelf (Tacinterp.tactic_of_value ist t) >>= fun (gls, ()) ->

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -1614,7 +1614,7 @@ let tactic_init_setoid () =
   try init_setoid (); Proofview.tclUNIT ()
   with e when CErrors.noncritical e ->
     let _, info = Exninfo.capture e in
-    Tacticals.tclFAIL ~info 0 (str"Setoid library not loaded")
+    Tacticals.tclFAIL ~info (str"Setoid library not loaded")
 
 let cl_rewrite_clause_strat progress strat clause =
   tactic_init_setoid () <*>
@@ -1625,7 +1625,7 @@ let cl_rewrite_clause_strat progress strat clause =
        | RewriteFailure e ->
          tclZEROMSG ~info (str"setoid rewrite failed: " ++ e)
        | Tacticals.FailError (n, pp) ->
-         tclFAIL ~info n (str"setoid rewrite failed: " ++ Lazy.force pp)
+         tclFAILn ~info n (str"setoid rewrite failed: " ++ Lazy.force pp)
        | e ->
          Proofview.tclZERO ~info e))
 
@@ -2094,7 +2094,7 @@ let general_s_rewrite cl l2r occs (c,l) ~new_goals =
             (cl_rewrite_clause_newtac ~progress:true ~abs:(Some abs) ~origsigma strat cl)))
     (fun (e, info) -> match e with
     | RewriteFailure e ->
-      tclFAIL ~info 0 (str"setoid rewrite failed: " ++ e)
+      tclFAIL ~info (str"setoid rewrite failed: " ++ e)
     | e -> Proofview.tclZERO ~info e)
   end
 
@@ -2103,7 +2103,7 @@ let _ = Hook.set Equality.general_setoid_rewrite_clause general_s_rewrite
 (** [setoid_]{reflexivity,symmetry,transitivity} tactics *)
 
 let not_declared ~info env sigma ty rel =
-  tclFAIL ~info 0
+  tclFAIL ~info
     (str" The relation " ++ Printer.pr_econstr_env env sigma rel ++ str" is not a declared " ++
      str ty ++ str" relation. Maybe you need to require the Coq.Classes.RelationClasses library")
 

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -1150,7 +1150,7 @@ and eval_tactic_ist ist tac : unit Proofview.tactic =
       end
   | TacFail (g,n,s) ->
       let msg = interp_message ist s in
-      let tac ~info l = Tacticals.tclFAIL ~info (interp_int_or_var ist n) l in
+      let tac ~info l = Tacticals.tclFAILn ~info (interp_int_or_var ist n) l in
       let tac =
         match g with
         | TacLocal ->

--- a/plugins/ltac/tauto.ml
+++ b/plugins/ltac/tauto.ml
@@ -75,7 +75,7 @@ let () =
 (** Base tactics *)
 
 let idtac = Proofview.tclUNIT ()
-let fail = Proofview.tclINDEPENDENT (tclFAIL 0 (Pp.mt ()))
+let fail = Proofview.tclINDEPENDENT (tclFAIL (Pp.mt ()))
 
 let intro = Tactics.intro
 
@@ -214,7 +214,7 @@ let apply_nnpp _ ist =
     begin fun () ->
       if Coqlib.has_ref nnpp
       then Tacticals.pf_constr_of_global (Coqlib.lib_ref nnpp) >>= apply
-      else tclFAIL 0 (Pp.mt ())
+      else tclFAIL (Pp.mt ())
     end
 
 (* This is the uniform mode dealing with ->, not, iff and types isomorphic to

--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -1858,9 +1858,9 @@ let micromega_gen parse_arith pre_process cnf spec dumpexpr prover tac =
         with
         | Unknown ->
           flush stdout;
-          Tacticals.tclFAIL 0 (Pp.str " Cannot find witness")
+          Tacticals.tclFAIL (Pp.str " Cannot find witness")
         | Model (m, e) ->
-          Tacticals.tclFAIL 0 (Pp.str " Cannot find witness")
+          Tacticals.tclFAIL (Pp.str " Cannot find witness")
         | Prf (ids, ff', res') ->
           let arith_goal, props, vars, ff_arith =
             make_goal_of_formula (genv, sigma) dumpexpr ff'
@@ -1906,10 +1906,10 @@ Tacticals.tclTHEN
                   ( EConstr.mkVar goal_name
                   , arith_args @ List.map EConstr.mkVar ids )))
       with
-      | Mfourier.TimeOut -> Tacticals.tclFAIL 0 (Pp.str "Timeout")
+      | Mfourier.TimeOut -> Tacticals.tclFAIL (Pp.str "Timeout")
       | CsdpNotFound ->
         flush stdout;
-        Tacticals.tclFAIL 0
+        Tacticals.tclFAIL
           (Pp.str
              ( " Skipping what remains of this tactic: the complexity of the \
                 goal requires "
@@ -1921,7 +1921,7 @@ Tacticals.tclTHEN
                 https://projects.coin-or.org/Csdp" ))
       | x ->
         if debug then
-          Tacticals.tclFAIL 0 (Pp.str (Printexc.get_backtrace ()))
+          Tacticals.tclFAIL (Pp.str (Printexc.get_backtrace ()))
         else raise x)
 
 let micromega_order_changer cert env ff =
@@ -1995,7 +1995,7 @@ let micromega_genr prover tac =
         with
         | Unknown | Model _ ->
           flush stdout;
-          Tacticals.tclFAIL 0 (Pp.str " Cannot find witness")
+          Tacticals.tclFAIL (Pp.str " Cannot find witness")
         | Prf (ids, ff', res') ->
           let ff, ids =
             formula_hyps_concl
@@ -2045,10 +2045,10 @@ let micromega_genr prover tac =
                 ; Tactics.exact_check
                     (EConstr.applist (EConstr.mkVar goal_name, arith_args)) ] ]
       with
-      | Mfourier.TimeOut -> Tacticals.tclFAIL 0 (Pp.str "Timeout")
+      | Mfourier.TimeOut -> Tacticals.tclFAIL (Pp.str "Timeout")
       | CsdpNotFound ->
         flush stdout;
-        Tacticals.tclFAIL 0
+        Tacticals.tclFAIL
           (Pp.str
              ( " Skipping what remains of this tactic: the complexity of the \
                 goal requires "

--- a/plugins/micromega/zify.ml
+++ b/plugins/micromega/zify.ml
@@ -1394,7 +1394,7 @@ let assert_inj t =
         ignore (get_injection env evd t);
         Tacticals.tclIDTAC
       with Not_found ->
-        Tacticals.tclFAIL 0 (Pp.str " InjTyp does not exist"))
+        Tacticals.tclFAIL (Pp.str " InjTyp does not exist"))
 
 let elim_binding x t ty =
   Proofview.Goal.enter (fun gl ->

--- a/plugins/ring/ring.ml
+++ b/plugins/ring/ring.ml
@@ -108,7 +108,7 @@ let closed_term args _ = match args with
   let l = List.map (fun c -> Value.cast (Genarg.topwit Stdarg.wit_ref) c) (Option.get (Value.to_list l)) in
   Proofview.tclEVARMAP >>= fun sigma ->
   let cs = List.fold_right GlobRef.Set_env.add l GlobRef.Set_env.empty in
-  if closed_under sigma cs t then Proofview.tclUNIT () else Tacticals.tclFAIL 0 (mt())
+  if closed_under sigma cs t then Proofview.tclUNIT () else Tacticals.tclFAIL (mt())
 | _ -> assert false
 
 let closed_term_ast =

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -320,7 +320,7 @@ and tac_of_hint dbg db_list local_db concl h =
          Tacticals.tclPROGRESS (reduce (Unfold [AllOccurrences,c]) Locusops.onConcl)
        else
          let info = Exninfo.reify () in
-         Tacticals.tclFAIL ~info 0 (str"Unbound reference")
+         Tacticals.tclFAIL ~info (str"Unbound reference")
        end
     | Extern (p, tacast) ->
       conclPattern concl p tacast

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -1031,13 +1031,13 @@ module Search = struct
     let error (e, info) =
       match e with
       | ReachedLimit ->
-        Tacticals.tclFAIL ~info 0 (str"Proof search reached its limit")
+        Tacticals.tclFAIL ~info (str"Proof search reached its limit")
       | NoApplicableHint ->
-        Tacticals.tclFAIL ~info 0 (str"Proof search failed" ++
+        Tacticals.tclFAIL ~info (str"Proof search failed" ++
                                     (if Option.is_empty depth then mt()
                                      else str" without reaching its limit"))
       | Proofview.MoreThanOneSuccess ->
-        Tacticals.tclFAIL ~info 0 (str"Proof search failed: " ++
+        Tacticals.tclFAIL ~info (str"Proof search failed: " ++
                                        str"more than one success found")
       | e -> Proofview.tclZERO ~info e
     in
@@ -1392,14 +1392,14 @@ let head_of_constr h c =
 let not_evar c =
   Proofview.tclEVARMAP >>= fun sigma ->
   match EConstr.kind sigma c with
-  | Evar _ -> Tacticals.tclFAIL 0 (str"Evar")
+  | Evar _ -> Tacticals.tclFAIL (str"Evar")
   | _ -> Proofview.tclUNIT ()
 
 let is_ground c =
   let open Tacticals in
   Proofview.tclEVARMAP >>= fun sigma ->
   if Evarutil.is_ground_term sigma c then tclIDTAC
-  else tclFAIL 0 (str"Not ground")
+  else tclFAIL (str"Not ground")
 
 let autoapply c i =
   let open Proofview.Notations in

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -459,5 +459,5 @@ let autounfold_one db cl =
       | None -> convert_concl ~cast:false ~check:false c' DEFAULTcast
     else
       let info = Exninfo.reify () in
-      Tacticals.tclFAIL ~info 0 (str "Nothing to unfold")
+      Tacticals.tclFAIL ~info (str "Nothing to unfold")
   end

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -629,7 +629,7 @@ let replace_using_leibniz clause c1 c2 l2r unsafe try_prove_eq_opt =
   in
   match evd with
   | None ->
-    tclFAIL 0 (str"Terms do not have convertible types")
+    tclFAIL (str"Terms do not have convertible types")
   | Some evd ->
     let e,sym =
       try lib_ref "core.eq.type", lib_ref "core.eq.sym"

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -431,7 +431,7 @@ let tclIDTAC = tclUNIT ()
 let tclTHEN t1 t2 =
   t1 <*> t2
 
-let tclFAIL ?info lvl msg =
+let tclFAILn ?info lvl msg =
   let info = match info with
     (* If the backtrace points here it means the caller didn't save
         the backtrace correctly *)
@@ -439,6 +439,8 @@ let tclFAIL ?info lvl msg =
     | Some info -> info
   in
   tclZERO ~info (FailError (lvl,lazy msg))
+
+let tclFAIL ?info msg = tclFAILn ?info 0 msg
 
 let tclZEROMSG ?info ?loc msg =
   let info = match info with
@@ -528,7 +530,7 @@ let tclTHENS3PARTS t1 l1 repeat l2 =
                 str"Incorrect number of goals" ++ spc() ++
                 str"(expected "++int i++str(String.plural i " tactic") ++ str")"
               in
-              tclFAIL 0 errmsg
+              tclFAIL errmsg
           | reraise -> tclZERO ~info reraise
         end
   end
@@ -543,7 +545,7 @@ let tclBINDFIRST t1 t2 =
   t1 >>= fun ans ->
   Proofview.Unsafe.tclGETGOALS >>= fun gls ->
   match gls with
-  | [] -> tclFAIL 0 (str "Expect at least one goal.")
+  | [] -> tclFAIL (str "Expect at least one goal.")
   | hd::tl ->
   Proofview.Unsafe.tclSETGOALS [hd] <*> t2 ans >>= fun ans ->
   Proofview.Unsafe.tclNEWGOALS tl <*>
@@ -562,7 +564,7 @@ let tclBINDLAST t1 t2 =
   t1 >>= fun ans ->
   Proofview.Unsafe.tclGETGOALS >>= fun gls ->
   match option_of_failure List.sep_last gls with
-  | None -> tclFAIL 0 (str "Expect at least one goal.")
+  | None -> tclFAIL (str "Expect at least one goal.")
   | Some (last,firstn) ->
   Proofview.Unsafe.tclSETGOALS [last] <*> t2 ans >>= fun ans ->
   Proofview.Unsafe.tclGETGOALS >>= fun newgls ->
@@ -581,7 +583,7 @@ let tclTHENS t l =
                 str"Incorrect number of goals" ++ spc() ++
                 str"(expected "++int i++str(String.plural i " tactic") ++ str")"
               in
-              tclFAIL 0 errmsg
+              tclFAIL errmsg
           | reraise -> tclZERO ~info reraise
         end
   end
@@ -626,7 +628,7 @@ let rec tclFIRST = function
   | t::rest -> tclORELSE0 t (tclFIRST rest)
 
 let rec tclFIRST_PROGRESS_ON tac = function
-  | []    -> tclFAIL 0 (str "No applicable tactic")
+  | []    -> tclFAIL (str "No applicable tactic")
   | [a]   -> tac a (* so that returned failure is the one from last item *)
   | a::tl -> tclORELSE (tac a) (tclFIRST_PROGRESS_ON tac tl)
 

--- a/tactics/tacticals.mli
+++ b/tactics/tacticals.mli
@@ -125,10 +125,13 @@ val catch_failerror : Exninfo.iexn -> unit tactic
 
 val tclIDTAC : unit tactic
 val tclTHEN : unit tactic -> unit tactic -> unit tactic
-(* [tclFAIL n msg] fails with [msg] as an error message at level [n]
+(* [tclFAILn n msg] fails with [msg] as an error message at level [n]
     (meaning that it will jump over [n] error catching tacticals FROM
     THIS MODULE. *)
-val tclFAIL : ?info:Exninfo.info -> int -> Pp.t -> 'a tactic
+val tclFAILn : ?info:Exninfo.info -> int -> Pp.t -> 'a tactic
+
+val tclFAIL : ?info:Exninfo.info -> Pp.t -> 'a tactic
+(** Same as above with level set to 0. *)
 
 val tclZEROMSG : ?info:Exninfo.info -> ?loc:Loc.t -> Pp.t -> 'a tactic
 (** Fail with a [User_Error] containing the given message. *)

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -365,11 +365,11 @@ let convert_gen pb x y =
     | Some sigma -> Proofview.Unsafe.tclEVARS sigma
     | None ->
       let info = Exninfo.reify () in
-      Tacticals.tclFAIL ~info 0 (str "Not convertible")
+      Tacticals.tclFAIL ~info (str "Not convertible")
     | exception e ->
       let _, info = Exninfo.capture e in
       (* FIXME: Sometimes an anomaly is raised from conversion *)
-      Tacticals.tclFAIL ~info 0 (str "Not convertible")
+      Tacticals.tclFAIL ~info (str "Not convertible")
 end
 
 let convert x y = convert_gen Reduction.CONV x y
@@ -4043,7 +4043,7 @@ let specialize_eqs id =
         (exact_no_check ((* refresh_universes_strict *) acc'))
     else
       let info = Exninfo.reify () in
-      Tacticals.tclFAIL ~info 0 (str "Nothing to do in hypothesis " ++ Id.print id)
+      Tacticals.tclFAIL ~info (str "Nothing to do in hypothesis " ++ Id.print id)
   end
 
 let specialize_eqs id = Proofview.Goal.enter begin fun gl ->
@@ -5056,8 +5056,8 @@ let transitivity t = transitivity_gen (Some t)
 let intros_transitivity  n  = Tacticals.tclTHEN intros (transitivity_gen n)
 
 let constr_eq ~strict x y =
-  let fail ~info = Tacticals.tclFAIL ~info 0 (str "Not equal") in
-  let fail_universes ~info = Tacticals.tclFAIL ~info 0 (str "Not equal (due to universes)") in
+  let fail ~info = Tacticals.tclFAIL ~info (str "Not equal") in
+  let fail_universes ~info = Tacticals.tclFAIL ~info (str "Not equal (due to universes)") in
   Proofview.Goal.enter begin fun gl ->
     let env = Tacmach.pf_env gl in
     let evd = Tacmach.project gl in


### PR DESCRIPTION
The rationale is that non-zero level failing is an Ltac-specific feature. We have a few tacticals around that try to catch this level and reraise it with a lower level, but this hardly makes sense for ML tactics. Only Ltac programs should ever observe the level, and even there this feature is often used to work around deficiencies of the expressivity of Ltac.

As a matter of fact, most ML callers of the tclFAIL primitive call it with a level set to 0, which clearly indicates an API issue.

This PR removes the tclFAIL level argument, and provides a tclFAILn function to pass an arbitrary number when needed.

Overlays:
- https://github.com/coq-community/aac-tactics/pull/106
- https://github.com/LPCIC/coq-elpi/pull/317
- https://github.com/mattam82/Coq-Equations/pull/466
- https://github.com/lukaszcz/coqhammer/pull/116
- https://github.com/mit-plv/fiat/pull/63
- https://gitlab.inria.fr/fbesson/itauto/-/merge_requests/3
- https://github.com/unicoq/unicoq/pull/65
- https://github.com/damien-pous/relation-algebra/pull/31