### PR TITLE
Fixes #15334: anomaly on parsing error due to empty entry (8.14 regression)

### DIFF
--- a/doc/changelog/03-notations/15338-master+fix15334-parsing-failure-on-empty-grammar.rst
+++ b/doc/changelog/03-notations/15338-master+fix15334-parsing-failure-on-empty-grammar.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Regression in parsing error reporting in case of empty custom entry
+  (`#15338 <https://github.com/coq/coq/pull/15338>`_,
+  fixes `#15334 <https://github.com/coq/coq/issues/15334>`_,
+  by Hugo Herbelin).

--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -1608,8 +1608,12 @@ module Parsable = struct
     let get_parsing_loc () =
       (* Build the loc spanning from just after what is consumed (count)
          up to the further token known to have been read (max_peek).
-         Being a parsing error, there needs
-         to be a next token that caused the failure. *)
+         Being a parsing error, there needs to be a next token that
+         caused the failure, except when the rule is empty (e.g. an
+         empty custom entry); thus, we need to ensure that the token
+         at location cnt has been peeked (which in turn ensures that
+         the max peek is at least the current position) *)
+      let _ = LStream.peek ts in
       let loc' = LStream.max_peek_loc ts in
       let loc = LStream.get_loc (LStream.count ts) ts in
       Loc.merge loc loc'

--- a/test-suite/output/bug_15334.out
+++ b/test-suite/output/bug_15334.out
@@ -1,0 +1,5 @@
+File "./output/bug_15334.v", line 4, characters 11-12:
+Error: Syntax error: [custom:ent] expected after 'ent:(' (in [term]).
+
+
+coqc exited with code 1

--- a/test-suite/output/bug_15334.v
+++ b/test-suite/output/bug_15334.v
@@ -1,0 +1,4 @@
+Declare Custom Entry ent.
+Notation "ent:( x )" := x (x custom ent).
+Notation "a ; b" := (pair a b) (in custom ent at level 50).
+Check ent:(_ ; _).


### PR DESCRIPTION
**Kind:** fix

#14532 was not yet the last word about locating parsing errors. The case of a parsing failure due to an empty entry was not treated.

Fixes / closes #15334

- [x] Added **changelog**.
