### PR TITLE
Fixes #15335: let entry coercions in notations and custom ident/global notations respect "only parsing"

### DIFF
--- a/doc/changelog/03-notations/15340-master+fix15335-entry-coercions-respect-only-parsing.rst
+++ b/doc/changelog/03-notations/15340-master+fix15335-entry-coercions-respect-only-parsing.rst
@@ -1,0 +1,6 @@
+- **Added:**
+  Coercion entries and :n:`ident`/:n:`global` entries in custom notations now
+  respect the :n:`only parsing` modifier
+  (`#15340 <https://github.com/coq/coq/pull/15340>`_,
+  fixes `#15335 <https://github.com/coq/coq/issues/15335>`_,
+  by Hugo Herbelin).

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -123,53 +123,59 @@ Warning: Notation "_ :=: _" was already used. [notation-overridden,parsing]
      : Prop
 fun x : nat => <{ x; (S x) }>
      : nat -> nat
+Set
+     : Type
+fun x : nat => S x
+     : nat -> nat
+True
+     : Prop
 exists p : nat, ▢_p (p >= 1)
      : Prop
 ▢_n (n >= 1)
      : Prop
-File "./output/Notations4.v", line 297, characters 17-20:
+File "./output/Notations4.v", line 327, characters 17-20:
 The command has indeed failed with message:
 Found an inductive type while a variable name was expected.
-File "./output/Notations4.v", line 298, characters 17-18:
+File "./output/Notations4.v", line 328, characters 17-18:
 The command has indeed failed with message:
 Found a constructor while a variable name was expected.
-File "./output/Notations4.v", line 300, characters 17-18:
+File "./output/Notations4.v", line 330, characters 17-18:
 The command has indeed failed with message:
 Found a constant while a variable name was expected.
 exists x y : nat, ▢_(x, y) (x >= 1 /\ y >= 2)
      : Prop
 ▢_n (n >= 1)
      : Prop
-File "./output/Notations4.v", line 313, characters 17-20:
+File "./output/Notations4.v", line 343, characters 17-20:
 The command has indeed failed with message:
 Found an inductive type while a pattern was expected.
 ▢_tt (tt = tt)
      : Prop
-File "./output/Notations4.v", line 316, characters 17-18:
+File "./output/Notations4.v", line 346, characters 17-18:
 The command has indeed failed with message:
 Found a constant while a pattern was expected.
 exists x y : nat, ▢_(x, y) (x >= 1 /\ y >= 2)
      : Prop
 pseudo_force n (fun n : nat => n >= 1)
      : Prop
-File "./output/Notations4.v", line 329, characters 17-20:
+File "./output/Notations4.v", line 359, characters 17-20:
 The command has indeed failed with message:
 Found an inductive type while a pattern was expected.
 ▢_tt (tt = tt)
      : Prop
-File "./output/Notations4.v", line 332, characters 17-18:
+File "./output/Notations4.v", line 362, characters 17-18:
 The command has indeed failed with message:
 Found a constant while a pattern was expected.
 exists x y : nat, myforce (x, y) (x >= 1 /\ y >= 2)
      : Prop
 myforce n (n >= 1)
      : Prop
-File "./output/Notations4.v", line 344, characters 21-24:
+File "./output/Notations4.v", line 374, characters 21-24:
 The command has indeed failed with message:
 Found an inductive type while a pattern was expected.
 myforce tt (tt = tt)
      : Prop
-File "./output/Notations4.v", line 347, characters 21-22:
+File "./output/Notations4.v", line 377, characters 21-22:
 The command has indeed failed with message:
 Found a constant while a pattern was expected.
 id nat
@@ -178,7 +184,7 @@ fun a : bool => id a
      : bool -> bool
 fun nat : bool => id nat
      : bool -> bool
-File "./output/Notations4.v", line 359, characters 17-20:
+File "./output/Notations4.v", line 389, characters 17-20:
 The command has indeed failed with message:
 Found an inductive type while a pattern was expected.
 !! nat, nat = true
@@ -207,7 +213,7 @@ Found an inductive type while a pattern was expected.
      : Type
 ## (x, _) (x = 0)
      : Prop
-File "./output/Notations4.v", line 455, characters 21-30:
+File "./output/Notations4.v", line 485, characters 21-30:
 The command has indeed failed with message:
 Unexpected type constraint in notation already providing a type constraint.
 ## '(x, y) (x + y = 0)

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -273,6 +273,36 @@ Check fun x => <{ x ; (S x) }>.
 
 End CoercionEntryTransitivity.
 
+Module CoercionEntryOnlyParsing.
+
+(* bug #15335 *)
+Declare Custom Entry ent.
+Notation "ent:( x )" := x (x custom ent, only parsing).
+Notation "!" := Set (in custom ent at level 0).
+Check ent:( ! ).
+
+End CoercionEntryOnlyParsing.
+
+Module CustomIdentOnlyParsing.
+
+Declare Custom Entry ent2.
+Notation "ent:( x )" := x (x custom ent2, format "ent:( x )").
+Notation "# x" := (S x) (in custom ent2 at level 0, x at level 0).
+Notation "x" := x (in custom ent2 at level 0, x ident, only parsing).
+Check fun x : nat => ent:(# x).
+
+End CustomIdentOnlyParsing.
+
+Module CustomGlobalOnlyParsing.
+
+Declare Custom Entry ent3.
+Notation "ent:( x )" := x (x custom ent3, format "ent:( x )").
+Notation "# x" := (S x) (in custom ent3 at level 0, x at level 0).
+Notation "x" := x (in custom ent3 at level 0, x global, only parsing).
+Check ent:(True).
+
+End CustomGlobalOnlyParsing.
+
 (* Some corner cases *)
 
 Module P.

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1183,9 +1183,12 @@ let is_coercion level typs =
 let printability level typs onlyparsing reversibility = function
 | NVar _ when reversibility = APrioriReversible ->
   let coe = is_coercion level typs in
-  if not onlyparsing && coe = None then
-    warn_notation_bound_to_variable ();
-  true, coe
+  let onlyparsing =
+    if not onlyparsing && Option.is_empty coe then
+      (warn_notation_bound_to_variable (); true)
+    else
+      onlyparsing in
+  onlyparsing, coe
 | _ ->
    (if not onlyparsing && reversibility <> APrioriReversible then
      (warn_non_reversible_notation reversibility; true)


### PR DESCRIPTION
**Kind:** fix/enhancement

Entries of the form
```
Notation "[ x ]" := x (x custom expr at level 100).
Notation "x" := x (in custom expr at level 0, x ident).
Notation "x" := x (in custom expr at level 0, x global).
```
were not respecting the `only parsing` flag.

Fixes #15335.

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
