### PR TITLE
Fixing regression in reporting incompatible notations

### DIFF
--- a/parsing/extend.ml
+++ b/parsing/extend.ml
@@ -39,6 +39,17 @@ type 'a constr_entry_key_gen =
   | ETConstr of Constrexpr.notation_entry * Notation_term.constr_as_binder_kind option * 'a
   | ETPattern of bool * int option (* true = strict pattern, i.e. not a single variable *)
 
+let constr_entry_key_eq v1 v2 = match v1, v2 with
+  | ETIdent, ETIdent -> true
+  | ETName _, ETName _ -> true
+  | ETGlobal, ETGlobal -> true
+  | ETBigint, ETBigint -> true
+  | ETBinder b1, ETBinder b2 -> b1 == b2
+  | ETConstr (s1,bko1,_lev1), ETConstr (s2,bko2,_lev2) ->
+    Notation.notation_entry_eq s1 s2 && Option.equal (=) bko1 bko2
+  | ETPattern (b1,n1), ETPattern (b2,n2) -> b1 = b2 && Option.equal Int.equal n1 n2
+  | (ETIdent | ETName _ | ETGlobal | ETBigint | ETBinder _ | ETConstr _ | ETPattern _), _ -> false
+
 (** Entries level (left-hand side of grammar rules) *)
 
 type constr_entry_key =

--- a/parsing/extend.mli
+++ b/parsing/extend.mli
@@ -39,6 +39,8 @@ type 'a constr_entry_key_gen =
 type constr_entry_key =
     (production_level * production_position) constr_entry_key_gen
 
+val constr_entry_key_eq : constr_entry_key -> constr_entry_key -> bool
+
 (** Entries used in productions, vernac side (e.g. "x bigint" or "x ident") *)
 
 type simple_constr_prod_entry_key =

--- a/test-suite/bugs/closed/bug_13966.v
+++ b/test-suite/bugs/closed/bug_13966.v
@@ -3,4 +3,4 @@ Inductive expr  := Const : nat -> expr.
 Declare Custom Entry expr.
 Notation "'[' e ']'" := e (e custom expr at level 0).
 Notation "x" := (Const x) (in custom expr at level 0, x bigint).
-Notation "x" := x (in custom expr at level 0, x ident).
+Fail Notation "x" := x (in custom expr at level 0, x ident).

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -240,3 +240,12 @@ where
 ?A : [ |- Type]
 0
      : nat
+File "./output/Notations4.v", line 505, characters 0-78:
+The command has indeed failed with message:
+Notation "func _ .. _ , _" is already defined at level 200 with arguments
+binder, constr at next level while it is now required to be at level 200
+with arguments constr, constr at next level.
+File "./output/Notations4.v", line 510, characters 0-57:
+The command has indeed failed with message:
+Notation "[[ _ ]]" is already defined at level 0 with arguments custom foo
+while it is now required to be at level 0 with arguments custom bar.

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -498,3 +498,15 @@ Check 0+.
 Check 0.
 
 End LeadingNumber.
+
+Module Incompatibility.
+
+Notation "'func' x .. y , P" := (fun x => .. (fun y => P) ..) (x binder, y binder, at level 200).
+Fail Notation "'func' x .. y , P" := (pair x .. (pair y P) ..) (at level 200).
+
+Declare Custom Entry foo.
+Declare Custom Entry bar.
+Notation "[[ x ]]" := x (x custom foo) : nat_scope.
+Fail Notation "[[ x ]]" := x (x custom bar) : type_scope.
+
+End Incompatibility.

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -819,7 +819,8 @@ let cache_one_syntax_extension (ntn,synext) =
         with Not_found -> None
       in
       let oldtyps = Notgram_ops.subentries_of_notation ntn in
-      if not (Notation.level_eq prec oldprec) && (oldparsing <> None || synext.synext_notgram = None) then
+      if not (Notation.level_eq prec oldprec && List.for_all2 Extend.constr_entry_key_eq synext.synext_nottyps oldtyps) &&
+         (oldparsing <> None || synext.synext_notgram = None) then
         error_incompatible_level ntn oldprec oldtyps prec synext.synext_nottyps;
       oldparsing
     with Not_found ->


### PR DESCRIPTION
**Kind:** fix

Apparently accidentally removed in #12523 (53e19f76, c9f7441c, July 2020, 8.12.0). Thanks to @gares for reporting.

- [x] Added / updated **test-suite**.
