### PR TITLE
Updating the list of keywords to avoid in extraction to Haskell and OCaml

### DIFF
--- a/plugins/extraction/haskell.ml
+++ b/plugins/extraction/haskell.ml
@@ -26,8 +26,8 @@ let pr_upper_id id = str (String.capitalize_ascii (Id.to_string id))
 let keywords =
   List.fold_right (fun s -> Id.Set.add (Id.of_string s))
   [ "Any"; "case"; "class"; "data"; "default"; "deriving"; "do"; "else";
-    "if"; "import"; "in"; "infix"; "infixl"; "infixr"; "instance";
-    "let"; "module"; "newtype"; "of"; "then"; "type"; "where"; "_"; "__";
+    "family"; "forall"; "foreign"; "if"; "import"; "in"; "infix"; "infixl"; "infixr"; "instance";
+    "let"; "mdo"; "module"; "newtype"; "of"; "proc"; "rec"; "then"; "type"; "where"; "_"; "__";
     "as"; "qualified"; "hiding" ; "unit" ; "unsafeCoerce" ]
   Id.Set.empty
 

--- a/plugins/extraction/ocaml.ml
+++ b/plugins/extraction/ocaml.ml
@@ -50,7 +50,7 @@ let keywords =
     "done"; "downto"; "else"; "end"; "exception"; "external"; "false";
     "for"; "fun"; "function"; "functor"; "if"; "in"; "include";
     "inherit"; "initializer"; "lazy"; "let"; "match"; "method";
-    "module"; "mutable"; "new"; "object"; "of"; "open"; "or";
+    "module"; "mutable"; "new"; "nonrec"; "object"; "of"; "open"; "or";
     "parser"; "private"; "rec"; "sig"; "struct"; "then"; "to"; "true";
     "try"; "type"; "val"; "virtual"; "when"; "while"; "with"; "mod";
     "land"; "lor"; "lxor"; "lsl"; "lsr"; "asr" ; "unit" ; "_" ; "__" ]


### PR DESCRIPTION
**Kind:** Enhancement

Courtesy of @JasonGross, extracted from his branch [extraction-blacklist-ident](https://github.com/JasonGross/coq/tree/extraction-blacklist-ident).

For Haskell, see https://wiki.haskell.org/Keywords.