### PR TITLE
Move `Export` support outside of `Require` libobject

### DIFF
--- a/doc/changelog/07-vernac-commands-and-options/15347-require-no-export.rst
+++ b/doc/changelog/07-vernac-commands-and-options/15347-require-no-export.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Make `Require Import M.` equivalent to `Require M. Import M.`
+  (`#15347 <https://github.com/coq/coq/pull/15347>`_,
+  fixes `#3556 <https://github.com/coq/coq/issues/3556>`_,
+  by Maxime Dénès).

--- a/test-suite/bugs/bug_3556.v
+++ b/test-suite/bugs/bug_3556.v
@@ -1,0 +1,9 @@
+Section S.
+Require Hurkens. Import Hurkens.
+End S.
+Fail Check Generic.paradox.
+
+Section S.
+  Require Import Hurkens.
+End S.
+Fail Check Generic.paradox.


### PR DESCRIPTION
We unify the way actions are handled inside and outside of modules. Calling
`Export` handling code from the `Require` libobject was a bit of a hack, since
the `open` function is never called on such an `Anticipate` object.