### PR TITLE
Do not unconditionally record backtraces in CoqIDE.

### DIFF
--- a/ide/coqide/coqOps.ml
+++ b/ide/coqide/coqOps.ml
@@ -575,7 +575,6 @@ object(self)
           Coq.set_stopped_in_debugger _ct true;
         self#debug_prompt ~tag msg2
     with e -> (Printf.printf "Exception: %s\n%!" (Printexc.to_string e);
-        Printexc.print_backtrace stdout;
         flush stdout;
         raise e)
 

--- a/ide/coqide/coqide.ml
+++ b/ide/coqide/coqide.ml
@@ -1781,7 +1781,6 @@ let make_scratch_buffer () =
   ()
 
 let main files =
-  Printexc.record_backtrace true;
   let w = build_ui () in
   reset_revert_timer ();
   reset_autosave_timer ();


### PR DESCRIPTION
This was introduced by f3f165b and is probably a remnant of debugging. We should not record backtraces in general, this can be expensive. The other removed line was broken in general since it was printing the backtrace after an arbitrary function call.
