### PR TITLE
Clean up the Proof_diffs API

### DIFF
--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -191,15 +191,16 @@ let process_goal sigma g =
   { Interface.goal_hyp = List.rev hyps; Interface.goal_ccl = ccl; Interface.goal_id = Proof.goal_uid g; Interface.goal_name = name }
 
 let process_goal_diffs diff_goal_map oldp nsigma ng =
-  let name = if Printer.print_goal_names () then Some (Names.Id.to_string (Termops.evar_suggested_name (Global.env ()) nsigma ng)) else None in
+  let env = Global.env () in
+  let name = if Printer.print_goal_names () then Some (Names.Id.to_string (Termops.evar_suggested_name env nsigma ng)) else None in
   let og_s = match oldp with
     | Some oldp ->
       let Proof.{ sigma=osigma } = Proof.data oldp in
-      (try Some (Evar.Map.find ng diff_goal_map, osigma)
+      (try Some (Proof_diffs.make_goal env osigma (Evar.Map.find ng diff_goal_map))
        with Not_found -> None)
     | None -> None
   in
-  let (hyps_pp_list, concl_pp) = Proof_diffs.diff_goal_ide og_s ng nsigma in
+  let (hyps_pp_list, concl_pp) = Proof_diffs.diff_goal_ide og_s (Proof_diffs.make_goal env nsigma ng) in
   { Interface.goal_hyp = hyps_pp_list; Interface.goal_ccl = concl_pp;
     Interface.goal_id = Proof.goal_uid ng; Interface.goal_name = name }
 

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -193,12 +193,9 @@ let process_goal sigma g =
 let process_goal_diffs diff_goal_map oldp nsigma ng =
   let env = Global.env () in
   let name = if Printer.print_goal_names () then Some (Names.Id.to_string (Termops.evar_suggested_name env nsigma ng)) else None in
-  let og_s = match oldp with
-    | Some oldp ->
-      let Proof.{ sigma=osigma } = Proof.data oldp in
-      (try Some (Proof_diffs.make_goal env osigma (Evar.Map.find ng diff_goal_map))
-       with Not_found -> None)
-    | None -> None
+  let og_s = match oldp, diff_goal_map with
+  | Some oldp, Some diff_goal_map -> Proof_diffs.map_goal ng diff_goal_map
+  | None, _ | _, None -> None
   in
   let (hyps_pp_list, concl_pp) = Proof_diffs.diff_goal_ide og_s (Proof_diffs.make_goal env nsigma ng) in
   { Interface.goal_hyp = hyps_pp_list; Interface.goal_ccl = concl_pp;
@@ -221,8 +218,8 @@ let goals () =
       let oldp = Stm.get_prev_proof ~doc (Stm.get_current_state ~doc) in
       (try
         let diff_goal_map = match oldp with
-        | None -> Evar.Map.empty
-        | Some oldp -> Proof_diffs.make_goal_map oldp newp
+        | None -> None
+        | Some oldp -> Some (Proof_diffs.make_goal_map oldp newp)
         in
         Some (export_pre_goals Proof.(data newp) (process_goal_diffs diff_goal_map oldp))
        with Pp_diff.Diff_Failure msg ->

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -220,7 +220,10 @@ let goals () =
     if Proof_diffs.show_diffs () then begin
       let oldp = Stm.get_prev_proof ~doc (Stm.get_current_state ~doc) in
       (try
-        let diff_goal_map = Proof_diffs.make_goal_map oldp newp in
+        let diff_goal_map = match oldp with
+        | None -> Evar.Map.empty
+        | Some oldp -> Proof_diffs.make_goal_map oldp newp
+        in
         Some (export_pre_goals Proof.(data newp) (process_goal_diffs diff_goal_map oldp))
        with Pp_diff.Diff_Failure msg ->
          Proof_diffs.notify_proof_diff_failure msg;

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -844,7 +844,7 @@ let pr_open_subgoals_diff ?(quiet=false) ?(diffs=false) ?oproof proof =
        | Some op when diffs ->
          (try
            let Proof.{sigma=osigma} = Proof.data op in
-           let diff_goal_map = Proof_diffs.make_goal_map oproof proof in
+           let diff_goal_map = Proof_diffs.make_goal_map op proof in
            Some (osigma, diff_goal_map)
          with Pp_diff.Diff_Failure msg ->
            Proof_diffs.notify_proof_diff_failure msg;

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -194,7 +194,7 @@ val pr_transparent_state   : TransparentState.t -> Pp.t
     records containing the goal and sigma for, respectively, the new and old proof steps,
     e.g. [{ it = g ; sigma = sigma }].
 *)
-val pr_goal : ?diffs:bool -> ?og_s:(Goal.goal * Evd.evar_map) -> Goal.goal sigma -> Pp.t
+val pr_goal : ?diffs:bool -> ?og_s:Proof_diffs.goal -> Goal.goal sigma -> Pp.t
 
 (** [pr_subgoals ~pr_first ~diffs ~os_map close_cmd sigma ~seeds ~shelf ~stack ~unfocused ~goals]
    prints the goals in [goals] followed by the goals in [unfocused] in a compact form
@@ -229,7 +229,7 @@ val pr_subgoal : int -> evar_map -> Goal.goal list -> Pp.t
     is labelled "subgoal [n]".  If [diffs] is true, highlight the differences between the old conclusion,
     [og_s], and [g]+[sigma].  [og_s] is a record containing the old goal and sigma, e.g. [{ it = g ; sigma = sigma }].
 *)
-val pr_concl : int -> ?diffs:bool -> ?og_s:(Goal.goal * Evd.evar_map) -> evar_map -> Goal.goal -> Pp.t
+val pr_concl : int -> ?diffs:bool -> ?og_s:Proof_diffs.goal -> evar_map -> Goal.goal -> Pp.t
 
 (** [pr_open_subgoals_diff ~quiet ~diffs ~oproof proof] shows the context for [proof] as used by, for example, coqtop.
     The first active goal is printed with all its antecedents and the conclusion.  The other active goals only show their

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -214,7 +214,7 @@ val pr_goal : ?diffs:bool -> ?og_s:Proof_diffs.goal -> Goal.goal sigma -> Pp.t
 val pr_subgoals
   : ?pr_first:bool
   -> ?diffs:bool
-  -> ?os_map:(evar_map * Goal.goal Evar.Map.t)
+  -> ?os_map:Proof_diffs.goal_map
   -> ?entry:Proofview.entry
   -> Pp.t option -> evar_map
   -> shelf:Goal.goal list

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -628,47 +628,39 @@ let db_goal_map op np ng_to_og =
    to create the map from new goal ids to old goal ids.
 *)
 let make_goal_map op np =
-  let ng_to_og = ref GoalMap.empty in
   let open Evar.Set in
   let ogs = Proof.all_goals op in
   let ngs = Proof.all_goals np in
   let rem_gs = diff ogs ngs in
-  let num_rems = cardinal rem_gs in
   let add_gs = diff ngs ogs in
-  let num_adds = cardinal add_gs in
 
   (* add common goals *)
-  Evar.Set.iter (fun x -> ng_to_og := GoalMap.add x x !ng_to_og) (inter ogs ngs);
+  let ng_to_og = Evar.Set.fold (fun x accu -> GoalMap.add x x accu) (inter ogs ngs) GoalMap.empty in
 
-  if num_rems = 0 then
-    !ng_to_og (* proofs are the same *)
-  else if num_adds = 0 then
-    !ng_to_og (* only removals *)
-  else if num_rems = 1 then begin
+  match Evar.Set.elements rem_gs with
+  | [] -> ng_to_og (* proofs are the same *)
+  | [hd] ->
     (* only 1 removal, some additions *)
-    let removed_g = List.hd (elements rem_gs) in
-    Evar.Set.iter (fun x -> ng_to_og := GoalMap.add x removed_g !ng_to_og) add_gs;
-    !ng_to_og
-  end else begin
-    (* >= 2 removals, >= 1 addition, need to match *)
-    let nevar_to_oevar = match_goals (to_constr op) (to_constr np) in
+    Evar.Set.fold (fun x accu -> GoalMap.add x hd accu) add_gs ng_to_og
+  | elts ->
+    if Evar.Set.is_empty add_gs then ng_to_og (* only removals *)
+    else
+      (* >= 2 removals, >= 1 addition, need to match *)
+      let nevar_to_oevar = match_goals (to_constr op) (to_constr np) in
 
-    let oevar_to_og = ref CString.Map.empty in
-    let Proof.{sigma=osigma} = Proof.data op in
-    List.iter (fun og -> oevar_to_og := CString.Map.add (goal_to_evar og osigma) og !oevar_to_og)
-        (Evar.Set.elements rem_gs);
+      let Proof.{sigma=osigma} = Proof.data op in
+      let fold accu og = CString.Map.add (goal_to_evar og osigma) og accu in
+      let oevar_to_og = List.fold_left fold CString.Map.empty elts in
 
-    let Proof.{sigma=nsigma} = Proof.data np in
-    let get_og ng =
-      let nevar = goal_to_evar ng nsigma in
-      let oevar = CString.Map.find nevar nevar_to_oevar in
-      let og = CString.Map.find oevar !oevar_to_og in
-      og
-    in
-    Evar.Set.iter (fun ng ->
-        try ng_to_og := GoalMap.add ng (get_og ng) !ng_to_og with Not_found -> ())  add_gs;
-    !ng_to_og
-  end
+      let Proof.{sigma=nsigma} = Proof.data np in
+      let get_og ng =
+        let nevar = goal_to_evar ng nsigma in
+        let oevar = CString.Map.find nevar nevar_to_oevar in
+        let og = CString.Map.find oevar oevar_to_og in
+        og
+      in
+      let fold ng accu = try GoalMap.add ng (get_og ng) accu with Not_found -> accu in
+      Evar.Set.fold fold add_gs ng_to_og
 
 let notify_proof_diff_failure msg =
   Feedback.msg_notice Pp.(str "Unable to compute diffs: " ++ str msg)

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -606,6 +606,15 @@ let db_goal_map op np ng_to_og =
   Printf.printf "\n"
 [@@@ocaml.warning "+32"]
 
+type goal_map = Evd.evar_map * Goal.goal Evar.Map.t
+
+let map_goal g (osigma, map) = match GoalMap.find_opt g map with
+| None -> None
+| Some g -> Some (make_goal (Global.env ()) osigma g)
+(* if not found, returning None treats the goal as new and it will be diff highlighted;
+    returning Some { it = g; sigma = sigma } will compare the new goal
+    to itself and it won't be highlighted *)
+
 (* Create a map from new goals to old goals for proof diff.  New goals
  that are evars not appearing in the proof will not have a mapping.
 
@@ -661,6 +670,10 @@ let make_goal_map op np =
       in
       let fold ng accu = try GoalMap.add ng (get_og ng) accu with Not_found -> accu in
       Evar.Set.fold fold add_gs ng_to_og
+
+let make_goal_map op np =
+  let map = make_goal_map op np in
+  ((Proof.data op).Proof.sigma, map)
 
 let notify_proof_diff_failure msg =
   Feedback.msg_notice Pp.(str "Unable to compute diffs: " ++ str msg)

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -556,9 +556,7 @@ let match_goals ot nt =
     end
   in
 
-  (match ot with
-  | Some ot -> match_goals_r "" ot nt
-  | None -> ());
+  let () = match_goals_r "" ot nt in
   !nevar_to_oevar
 
 let get_proof_context (p : Proof.t) =
@@ -656,7 +654,7 @@ let make_goal_map_i op np =
       !ng_to_og
     end else begin
       (* >= 2 removals, >= 1 addition, need to match *)
-      let nevar_to_oevar = match_goals (Some (to_constr op)) (to_constr np) in
+      let nevar_to_oevar = match_goals (to_constr op) (to_constr np) in
 
       let oevar_to_og = ref CString.Map.empty in
       let Proof.{sigma=osigma} = Proof.data op in

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -231,8 +231,8 @@ let diff_hyps o_idents_in_lines o_map n_idents_in_lines n_map =
   List.rev !rv
 
 
-type 'a hyp = (Names.Id.t Context.binder_annot list * 'a option * 'a)
-type 'a reified_goal = { name: string; ty: 'a; hyps: 'a hyp list; env : Environ.env; sigma: Evd.evar_map }
+type hyp = (Names.Id.t Context.binder_annot list * EConstr.t option * EConstr.t)
+type reified_goal = { name: string; ty: EConstr.t; hyps: hyp list; env : Environ.env; sigma: Evd.evar_map }
 
 (* XXX: Port to proofview, one day. *)
 (* open Proofview *)
@@ -253,7 +253,7 @@ let process_goal_concl sigma g : EConstr.t * Environ.env =
   let (env, ty) = goal_repr sigma g in
   (ty, env)
 
-let process_goal sigma g : EConstr.t reified_goal =
+let process_goal sigma g : reified_goal =
   let (env, ty) = goal_repr sigma g in
   let name = Proof.goal_uid g             in
   (* compaction is usually desired [eg for better display] *)

--- a/printing/proof_diffs.mli
+++ b/printing/proof_diffs.mli
@@ -33,6 +33,10 @@ open Evd
 open Environ
 open Constr
 
+type goal
+
+val make_goal : Environ.env -> Evd.evar_map -> Evar.t -> goal
+
 (** Computes the diff between the goals of two Proofs and returns
 the highlighted lists of hypotheses and conclusions.
 
@@ -44,7 +48,7 @@ If you want to make your call especially bulletproof, catch these
 exceptions, print a user-visible message, then recall this routine with
 the first argument set to None, which will skip the diff.
 *)
-val diff_goal_ide : (Goal.goal * Evd.evar_map) option -> Goal.goal -> Evd.evar_map -> Pp.t list * Pp.t
+val diff_goal_ide : goal option -> goal -> Pp.t list * Pp.t
 
 (** Computes the diff between two goals
 
@@ -56,7 +60,7 @@ If you want to make your call especially bulletproof, catch these
 exceptions, print a user-visible message, then recall this routine with
 the first argument set to None, which will skip the diff.
 *)
-val diff_goal : ?og_s:(Goal.goal * Evd.evar_map) -> Goal.goal -> Evd.evar_map -> Pp.t
+val diff_goal : ?og_s:goal -> goal -> Pp.t
 
 (** Convert a string to a list of token strings using the lexer *)
 val tokenize_string : string -> string list
@@ -66,7 +70,7 @@ val pr_leconstr_env        : ?lax:bool -> ?inctx:bool -> ?scope:Notation_term.sc
 val pr_lconstr_env         : ?lax:bool -> ?inctx:bool -> ?scope:Notation_term.scope_name -> env -> evar_map -> constr -> Pp.t
 
 (** Computes diffs for a single conclusion *)
-val diff_concl : ?og_s:(Goal.goal * Evd.evar_map) -> Evd.evar_map -> Goal.goal -> Pp.t
+val diff_concl : ?og_s:goal -> goal -> Pp.t
 
 (** Generates a map from [np] to [op] that maps changed goals to their prior
 forms.  The map doesn't include entries for unchanged goals; unchanged goals

--- a/printing/proof_diffs.mli
+++ b/printing/proof_diffs.mli
@@ -78,7 +78,7 @@ will have the same goal id in both versions.
 
 [op] and [np] must be from the same proof document and [op] must be for a state
 before [np]. *)
-val make_goal_map : Proof.t option -> Proof.t -> Goal.goal Evar.Map.t
+val make_goal_map : Proof.t -> Proof.t -> Goal.goal Evar.Map.t
 
 (* Exposed for unit test, don't use these otherwise *)
 (* output channel for the test log file *)

--- a/printing/proof_diffs.mli
+++ b/printing/proof_diffs.mli
@@ -72,13 +72,17 @@ val pr_lconstr_env         : ?lax:bool -> ?inctx:bool -> ?scope:Notation_term.sc
 (** Computes diffs for a single conclusion *)
 val diff_concl : ?og_s:goal -> goal -> Pp.t
 
+type goal_map
+
 (** Generates a map from [np] to [op] that maps changed goals to their prior
 forms.  The map doesn't include entries for unchanged goals; unchanged goals
 will have the same goal id in both versions.
 
 [op] and [np] must be from the same proof document and [op] must be for a state
 before [np]. *)
-val make_goal_map : Proof.t -> Proof.t -> Goal.goal Evar.Map.t
+val make_goal_map : Proof.t -> Proof.t -> goal_map
+
+val map_goal : Evar.t -> goal_map -> goal option
 
 (* Exposed for unit test, don't use these otherwise *)
 (* output channel for the test log file *)


### PR DESCRIPTION
We abstract away a few types and stop relying on deprecated APIs. Minor static invariants are also enforced though there is still a lot of room for improvement.
