### PR TITLE
Ensure at grammar level that module application is always to a qualid.

### DIFF
--- a/doc/changelog/07-vernac-commands-and-options/15355-mod-apply-ident.rst
+++ b/doc/changelog/07-vernac-commands-and-options/15355-mod-apply-ident.rst
@@ -1,0 +1,4 @@
+- **Changed:**
+  :cmd:`Module` now only allows parentheses around module arguments. For instance, ``Module M := (F X).`` is now a parsing error
+  (`#15355 <https://github.com/coq/coq/pull/15355>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -76,7 +76,7 @@ together, as well as a means of massive abstraction.
       with_declaration ::= Definition @qualid {? @univ_decl } := @term
       | Module @qualid := @qualid
       module_expr_atom ::= @qualid
-      | ( {+ @module_expr_atom } )
+      | ( @module_expr_atom )
       of_module_type ::= : @module_type_inl
       | {* <: @module_type_inl }
       module_expr_inl ::= ! {+ @module_expr_atom }

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1134,7 +1134,7 @@ module_expr: [
 
 module_expr_atom: [
 | qualid
-| "(" module_expr ")"
+| "(" module_expr_atom ")"
 ]
 
 with_declaration: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -772,7 +772,7 @@ with_declaration: [
 
 module_expr_atom: [
 | qualid
-| "(" LIST1 module_expr_atom ")"
+| "(" module_expr_atom ")"
 ]
 
 of_module_type: [

--- a/interp/constrexpr.ml
+++ b/interp/constrexpr.ml
@@ -176,6 +176,6 @@ type with_declaration_ast =
 
 type module_ast_r =
   | CMident of qualid
-  | CMapply of module_ast * module_ast
+  | CMapply of module_ast * qualid
   | CMwith  of module_ast * with_declaration_ast
 and module_ast = module_ast_r CAst.t

--- a/interp/modintern.ml
+++ b/interp/modintern.ml
@@ -32,9 +32,6 @@ let error_not_a_module_loc ~info kind loc qid =
   let info = Option.cata (Loc.add_loc info) info loc in
   Exninfo.iraise (e,info)
 
-let error_application_to_not_path loc me =
-  Loc.raise ?loc (Modops.ModuleTypingError (Modops.ApplicationToNotPath me))
-
 let error_incorrect_with_in_module loc =
   Loc.raise ?loc (ModuleInternalizationError IncorrectWithInModule)
 
@@ -131,11 +128,7 @@ let rec interp_module_ast env kind m cst = match m with
       (MEident mp, mp, kind, cst)
   | {CAst.loc;v=CMapply (me1,me2)} ->
       let me1', base, kind1, cst = interp_module_ast env kind me1 cst in
-      let me2', _, kind2, cst = interp_module_ast env ModAny me2 cst in
-      let mp2 = match me2' with
-        | MEident mp -> mp
-        | _ -> error_application_to_not_path (loc_of_module me2) me2'
-      in
+      let mp2, kind2 = lookup_module_or_modtype ModAny me2 in
       if kind2 == ModType then
         error_application_to_module_type (loc_of_module me2);
       (MEapply (me1',mp2), base, kind1, cst)

--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -23,7 +23,6 @@ open Constr
 open Declarations
 open Declareops
 open Environ
-open Entries
 open Mod_subst
 
 (** {6 Errors } *)
@@ -56,7 +55,6 @@ type module_typing_error =
   | SignatureMismatch of
       Label.t * structure_field_body * signature_mismatch_error
   | LabelAlreadyDeclared of Label.t
-  | ApplicationToNotPath of module_struct_entry
   | NotAFunctor
   | IsAFunctor
   | IncompatibleModuleTypes of module_type_body * module_type_body

--- a/kernel/modops.mli
+++ b/kernel/modops.mli
@@ -112,7 +112,6 @@ type module_typing_error =
   | SignatureMismatch of
       Label.t * structure_field_body * signature_mismatch_error
   | LabelAlreadyDeclared of Label.t
-  | ApplicationToNotPath of module_struct_entry
   | NotAFunctor
   | IsAFunctor
   | IncompatibleModuleTypes of module_type_body * module_type_body

--- a/test-suite/bugs/bug_11133.v
+++ b/test-suite/bugs/bug_11133.v
@@ -7,7 +7,7 @@ Include Univ.
 End Univ_prop.
 
 Module Monad (Univ : Universe).
-Module UP := (Univ_prop Univ).
+Module UP := Univ_prop Univ.
 End Monad.
 
 Module Rules (Univ:Universe).

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -648,12 +648,12 @@ GRAMMAR EXTEND Gram
   ;
   (* Module expressions *)
   module_expr:
-    [ [ me = module_expr_atom -> { me }
+    [ [ me = module_expr_atom -> { CAst.make ~loc @@ CMident me }
       | me1 = module_expr; me2 = module_expr_atom -> { CAst.make ~loc @@ CMapply (me1,me2) }
       ] ]
   ;
   module_expr_atom:
-    [ [ qid = qualid -> { CAst.make ~loc @@ CMident qid } | "("; me = module_expr; ")" -> { me } ] ]
+    [ [ qid = qualid -> { qid } | "("; me = module_expr_atom; ")" -> { me } ] ]
   ;
   with_declaration:
     [ [ "Definition"; fqid = fullyqualid; udecl = OPT univ_decl; ":="; c = Constr.lconstr ->

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1013,11 +1013,6 @@ let explain_signature_mismatch l spec why =
 let explain_label_already_declared l =
   str "The label " ++ Label.print l ++ str " is already declared."
 
-let explain_application_to_not_path _ =
-  strbrk "A module cannot be applied to another module application or " ++
-  strbrk "with-expression; you must give a name to the intermediate result " ++
-  strbrk "module first."
-
 let explain_not_a_functor () =
   str "Application of a non-functor."
 
@@ -1078,7 +1073,6 @@ let explain_include_restricted_functor mp =
 let explain_module_error = function
   | SignatureMismatch (l,spec,err) -> explain_signature_mismatch l spec err
   | LabelAlreadyDeclared l -> explain_label_already_declared l
-  | ApplicationToNotPath mexpr -> explain_application_to_not_path mexpr
   | NotAFunctor -> explain_not_a_functor ()
   | IsAFunctor -> explain_is_a_functor ()
   | IncompatibleModuleTypes (m1,m2) -> explain_incompatible_module_types m1 m2

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -343,11 +343,8 @@ let rec pr_module_ast leading_space pr_c = function
     let m = pr_module_ast leading_space pr_c mty in
     let p = pr_with_declaration pr_c decl in
     m ++ spc() ++ keyword "with" ++ spc() ++ p
-  | { v = CMapply (me1, ( { v = CMident _ } as me2 ) ) } ->
-    pr_module_ast leading_space pr_c me1 ++ spc() ++ pr_module_ast false pr_c me2
-  | { v = CMapply (me1,me2) } ->
-    pr_module_ast leading_space pr_c me1 ++ spc() ++
-    hov 1 (str"(" ++ pr_module_ast false pr_c me2 ++ str")")
+  | { v = CMapply (me1, me2 ) } ->
+    pr_module_ast leading_space pr_c me1 ++ spc() ++ pr_located pr_qualid (me2.loc, me2)
 
 let pr_inline = function
   | DefaultInline -> mt ()


### PR DESCRIPTION
We keep module_expr_atom to be able to use parentheses as in
~~~coq
Module M := F (X).
~~~
