### PR TITLE
Avoid bound names in instantiate_notation_constr

### DIFF
--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -773,10 +773,8 @@ let traverse_binder intern_pat ntnvars (terms,_,binders,_ as subst) avoid (renam
     (* Binders not bound in the notation do not capture variables *)
     (* outside the notation (i.e. in the substitution) *)
     let id' = find_fresh_name renaming subst avoid id in
-    let renaming' =
-      if Id.equal id id' then renaming else Id.Map.add id id' renaming
-    in
-    (renaming',env), None, Name id', Explicit, set_type ty None
+    let renaming = Id.Map.add id id' renaming in
+    (renaming,env), None, Name id', Explicit, set_type ty None
 
 type binder_action =
   | AddLetIn of lname * constr_expr * constr_expr option

--- a/test-suite/bugs/bug_15356.v
+++ b/test-suite/bugs/bug_15356.v
@@ -1,0 +1,6 @@
+Local Notation foo := (forall x y:Type , x * y).
+
+Set Mangle Names.
+Local Notation goal  := foo.
+
+Check eq_refl : eq foo goal.


### PR DESCRIPTION
Fix #15356

Not sure if this is the correct way to fix this but it seems to work.
