### PR TITLE
add a test for #9633 after fixed by #14562

### DIFF
--- a/test-suite/bugs/closed/bug_9633.v
+++ b/test-suite/bugs/closed/bug_9633.v
@@ -1,0 +1,36 @@
+Declare Custom Entry expr.
+
+Check fun expr => expr.
+Check fun constr => constr.
+Goal True.
+  let x := open_constr:(1+1) in pose x.
+  let x := constr:(1+1) in pose x.
+Abort.
+
+Module A.
+  Notation "'constr' : ( e )" := e (in custom expr, e constr).
+  Notation "'expr' : ( e )" := e (e custom expr).
+
+  Check expr:( constr:( 1 )).
+
+  Check fun expr => expr.
+  Check fun constr => constr.
+  Goal True.
+    let x := open_constr:(1+1) in pose x.
+    let x := constr:(1+1) in pose x.
+  Abort.
+End A.
+
+Module B.
+  Notation "'expr' : ( e )" := e (e custom expr).
+  Notation "'constr' : ( e )" := e (in custom expr, e constr).
+
+  Check expr:( constr:( 1 )).
+
+  Check fun expr => expr.
+  Check fun constr => constr.
+  Goal True.
+    let x := open_constr:(1+1) in pose x.
+    let x := constr:(1+1) in pose x.
+  Abort.
+End B.


### PR DESCRIPTION
Closes #9633 (already fixed in #14562 :tada:)

- [x] Added / updated **test-suite**.

I confirmed that the added file passes on master but fails on 8.14.1.