### PR TITLE
Command Fail not catching anomalies

### DIFF
--- a/doc/changelog/07-vernac-commands-and-options/15366-master+Fail-not-catching-anomaly.rst
+++ b/doc/changelog/07-vernac-commands-and-options/15366-master+Fail-not-catching-anomaly.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  :cmd:`Fail` no longer catches anomalies, which it has done since Coq version 8.11.
+  Now it only catches user errors
+  (`#15366 <https://github.com/coq/coq/pull/15366>`_,
+  by Hugo Herbelin).

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -835,7 +835,7 @@ Quitting and debugging
    For debugging scripts, sometimes it is desirable to know whether a
    command or a tactic fails. If :n:`@sentence` fails, then
    :n:`Fail @sentence` succeeds (except for
-   critical errors, such as "stack overflow"), without changing the
+   anomalies or for critical failures such as "stack overflow"), without changing the
    proof state.  In interactive mode, the system prints a message
    confirming the failure.
 

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -71,10 +71,11 @@ let with_fail f : (Loc.t option * Pp.t, unit) result =
     Error ()
   with
   (* Fail Timeout is a common pattern so we need to support it. *)
-  | e when CErrors.noncritical e || e = CErrors.Timeout ->
+  | e ->
     (* The error has to be printed in the failing state *)
-    let _, info as e = Exninfo.capture e in
-    Ok (Loc.get_loc info, CErrors.iprint e)
+    let _, info as exn = Exninfo.capture e in
+    if CErrors.is_anomaly e && e != CErrors.Timeout then Exninfo.iraise exn;
+    Ok (Loc.get_loc info, CErrors.iprint exn)
 
 let real_error_loc ~cmdloc ~eloc =
   if Loc.finer eloc cmdloc then eloc


### PR DESCRIPTION
**Kind:** change of semantics

See [Zulip](https://coq.zulipchat.com/#narrow/stream/237656-Coq-devs.20.26.20plugin.20devs/topic/Testing.20that.20an.20error.20is.20not.20an.20anomaly) discussion.

In particular, as reminded by @SkySkimmer, the definition of an anomaly is by the negative: it is any exception for which there is no declared handler (excepting `Timeout`). This has a cost which however happens only once for `Fail`, so, not really a problem in this case.

See be9a1834a48 for history (anomalies started to be caught from 8.11).

Note that it revealed a `Fail` catching a `Not_found` in the test for #3209. This is fixed in #15365. on which this PR depends.

- [x] Added **changelog**.
