### PR TITLE
Don't handle CAMLFLAGS in configure

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -58,11 +58,13 @@ VO_OUT_DIR=$(BUILD_OUT_DIR)/lib/coq/
 
 LEGACY_BIN_DIR=bin
 
+MKDIR:=mkdir -p
+
 $(BUILD_OUT_DIR) $(VO_OUT_DIR):
 	$(SHOW)'MKDIR     BUILD_OUT'
-	$(HIDE)mkdir -p $(BUILD_OUT_DIR)
-	$(HIDE)mkdir -p $(BUILD_OUT_DIR)/lib/coq
-	$(HIDE)mkdir -p $(BUILD_OUT_DIR)/lib/coq-core
+	$(HIDE)$(MKDIR) $(BUILD_OUT_DIR)
+	$(HIDE)$(MKDIR) $(BUILD_OUT_DIR)/lib/coq
+	$(HIDE)$(MKDIR) $(BUILD_OUT_DIR)/lib/coq-core
 	$(HIDE)ln -s $(shell pwd)/_build/install/default/bin/ $(LEGACY_BIN_DIR)
 	$(HIDE)ln -s $(shell pwd)/_build/install/default/bin/ $(BUILD_OUT_DIR)/bin
 	$(HIDE)ln -s $(shell pwd)/_build/default/plugins/ $(BUILD_OUT_DIR)/lib/coq-core

--- a/config/coq_config.mli
+++ b/config/coq_config.mli
@@ -23,8 +23,6 @@ val docdirsuffix : string    (* doc directory relative to installation prefix *)
 
 val ocamlfind : string
 
-val caml_flags : string     (* arguments passed to ocamlc (ie. CAMLFLAGS) *)
-
 val arch : string       (* architecture *)
 val arch_is_win32 : bool
 

--- a/config/dune
+++ b/config/dune
@@ -21,4 +21,4 @@
    ; Needed to generate include lists for coq_makefile
    plugin_list
   (env_var COQ_CONFIGURE_PREFIX))
- (action (chdir %{project_root} (run %{project_root}/tools/configure/configure.exe -no-ask -native-compiler no -bin-annot))))
+ (action (chdir %{project_root} (run %{project_root}/tools/configure/configure.exe -no-ask -native-compiler no))))

--- a/lib/envars.ml
+++ b/lib/envars.ml
@@ -176,8 +176,6 @@ let print_config ?(prefix_var_name="") f =
   fprintf f "%sCOQCORELIB=%s/\n" prefix_var_name corelib;
   fprintf f "%sDOCDIR=%s/\n" prefix_var_name (docdir ());
   fprintf f "%sOCAMLFIND=%s\n" prefix_var_name (ocamlfind ());
-  fprintf f "%sCAMLFLAGS=%s\n" prefix_var_name Coq_config.caml_flags;
-  fprintf f "%sWARN=%s\n" prefix_var_name "-warn-error +a-3";
   fprintf f "%sHASNATDYNLINK=%s\n" prefix_var_name
     (if Coq_config.has_natdynlink then "true" else "false");
   fprintf f "%sCOQ_SRC_SUBDIRS=%s\n" prefix_var_name (String.concat " " Coq_config.all_src_dirs);

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -70,6 +70,22 @@ ifeq ($(wildcard $(COQLIB)/theories/Reals/Reals.vo),)
 	COQLIB_NOT_FOUND:=true
 endif
 
+# TODO use dune instead
+# Explanation of enabled/disabled warnings:
+# 4: fragile pattern matching: too common in the code and too annoying to avoid in general
+# 9: missing fields in a record pattern: too common in the code and not worth the bother
+# 27: innocuous unused variable: innocuous
+# 41: ambiguous constructor or label: too common
+# 42: disambiguated counstructor or label: too common
+# 44: "open" shadowing already defined identifier: too common, especially when some are aliases
+# 45: "open" shadowing a label or constructor: see 44
+# 48: implicit elimination of optional arguments: too common
+# 58: "no cmx file was found in path": See https://github.com/ocaml/num/issues/9
+# 67: "unused functor parameter" seems totally bogus
+# 68: "This pattern depends on mutable state" no idea what it means, dune builds don't display it
+# 70: ".ml file without .mli file" bogus warning when used generally
+CAMLFLAGS:=-thread -rectypes -w -a+1..3-4+5..8-9+10..26-27+28..40-41-42+43-44-45+46..47-48+49..57-58+59..66-67-68+69-70  -bin-annot -safe-string -strict-sequence
+
 COQEXTRAFLAGS?=
 COQFLAGS?=$(COQEXTRAFLAGS)
 

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -39,9 +39,7 @@ COQLIB            := $(COQMF_COQLIB)
 COQCORELIB        := $(COQMF_COQCORELIB)
 DOCDIR            := $(COQMF_DOCDIR)
 OCAMLFIND         := $(COQMF_OCAMLFIND)
-CAMLFLAGS         := $(COQMF_CAMLFLAGS)
 HASNATDYNLINK     := $(COQMF_HASNATDYNLINK)
-OCAMLWARN         := $(COQMF_WARN)
 
 @CONF_FILE@: @PROJECT_FILE@
 	@COQ_MAKEFILE_INVOCATION@
@@ -266,9 +264,28 @@ COQMAKEFILE_VERSION:=@COQ_VERSION@
 COQ_SRC_SUBDIRS?=
 COQSRCLIBS?= $(foreach d,$(COQCORE_SRC_SUBDIRS), -I "$(COQCORELIB)/$(d)") $(foreach d,$(COQ_SRC_SUBDIRS), -I "$(COQLIB)/$(d)")
 
-CAMLFLAGS+=$(OCAMLLIBS) $(COQSRCLIBS)
+# Explanation of enabled/disabled warnings:
+# 4: fragile pattern matching: too common in the code and too annoying to avoid in general
+# 9: missing fields in a record pattern: too common in the code and not worth the bother
+# 27: innocuous unused variable: innocuous
+# 41: ambiguous constructor or label: too common
+# 42: disambiguated counstructor or label: too common
+# 44: "open" shadowing already defined identifier: too common, especially when some are aliases
+# 45: "open" shadowing a label or constructor: see 44
+# 48: implicit elimination of optional arguments: too common
+# 58: "no cmx file was found in path": See https://github.com/ocaml/num/issues/9
+# 67: "unused functor parameter" seems totally bogus
+# 68: "This pattern depends on mutable state" no idea what it means, dune builds don't display it
+# 70: ".ml file without .mli file" bogus warning when used generally
+
+# Note, we list all warnings to be complete
+BASE_CAMLFLAGS:=-thread -rectypes -w -a+1..3-4+5..8-9+10..26-27+28..40-41-42+43-44-45+46..47-48+49..57-58+59..66-67-68+69-70  -bin-annot -safe-string -strict-sequence
+
+CAMLFLAGS:=$(BASE_CAMLFLAGS) $(OCAMLLIBS) $(COQSRCLIBS)
 # ocamldoc fails with unknown argument otherwise
 CAMLDOCFLAGS:=$(filter-out -annot, $(filter-out -bin-annot, $(CAMLFLAGS)))
+
+OCAMLWARN:=-warn-error +a-3
 CAMLFLAGS+=$(OCAMLWARN)
 
 ifneq (,$(TIMING))
@@ -888,7 +905,7 @@ printenv::
 # file you can extend the merlin-hook target in @LOCAL_FILE@
 .merlin:
 	$(SHOW)'FILL .merlin'
-	$(HIDE)echo 'FLG $(COQMF_CAMLFLAGS)' > .merlin
+	$(HIDE)echo 'FLG $(BASE_CAMLFLAGS)' > .merlin
 	$(HIDE)echo 'B $(COQCORELIB)' >> .merlin
 	$(HIDE)echo 'S $(COQCORELIB)' >> .merlin
 	$(HIDE)$(foreach d,$(COQCORE_SRC_SUBDIRS), \

--- a/tools/configure/cmdArgs.ml
+++ b/tools/configure/cmdArgs.ml
@@ -33,8 +33,6 @@ type t = {
   browser : string option;
   withdoc : bool;
   byteonly : bool;
-  bin_annot : bool;
-  annot : bool;
   bytecodecompiler : bool;
   nativecompiler : nativecompiler;
   coqwebsite : string;
@@ -65,8 +63,6 @@ let default = {
   browser = None;
   withdoc = false;
   byteonly = false;
-  bin_annot = false;
-  annot = false;
   bytecodecompiler = true;
   nativecompiler =
     if os_type_win32 || os_type_cygwin then NativeNo else NativeOndemand;
@@ -78,8 +74,6 @@ let default = {
 }
 
 let devel state = { state with
-  bin_annot = true;
-  annot = true;
   warn_error = true;
   dune_profile = "--profile=dev";
   interactive = true;
@@ -169,10 +163,6 @@ let args_options = Arg.align [
     "(yes|no) Compile the documentation or not";
   "-byte-only", arg_set (fun p -> { p with byteonly = true }),
     " Compiles only bytecode version of Coq";
-  "-annot", arg_set (fun p -> { p with annot = true }),
-    " Dumps ml text annotation files while compiling Coq (e.g. for Tuareg)";
-  "-bin-annot", arg_set (fun p -> { p with bin_annot = true }),
-    " Dumps ml binary annotation files while compiling Coq (e.g. for Merlin)";
   "-bytecode-compiler", arg_bool (fun p bytecodecompiler -> { p with bytecodecompiler }),
     "(yes|no) Enable Coq's bytecode reduction machine (VM)";
   "-native-compiler", arg_native (fun p nativecompiler -> { p with nativecompiler }),

--- a/tools/configure/cmdArgs.mli
+++ b/tools/configure/cmdArgs.mli
@@ -45,9 +45,6 @@ type t =
   (** Build documentation [controls makefile variable]  *)
   ; byteonly : bool
   (** Whether to build a byte-only version of Coq *)
-  ; bin_annot : bool
-  ; annot : bool
-  (** OCaml annot options [only relevant to coq_makefile] *)
   ; bytecodecompiler : bool
   (** Enable/disable Coq's VM *)
   ; nativecompiler : nativecompiler


### PR DESCRIPTION
- inline disabled warnings in test-suite/Makefile and CoqMakefile.in
- unconditionally -bin-annot
- also move MKDIR definition to Makefile.common
