### PR TITLE
Clean the Printer API

### DIFF
--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -197,7 +197,7 @@ let process_goal_diffs diff_goal_map oldp nsigma ng =
   | Some oldp, Some diff_goal_map -> Proof_diffs.map_goal ng diff_goal_map
   | None, _ | _, None -> None
   in
-  let (hyps_pp_list, concl_pp) = Proof_diffs.diff_goal_ide og_s (Proof_diffs.make_goal env nsigma ng) in
+  let (hyps_pp_list, concl_pp) = Proof_diffs.diff_goal ?og_s (Proof_diffs.make_goal env nsigma ng) in
   { Interface.goal_hyp = hyps_pp_list; Interface.goal_ccl = concl_pp;
     Interface.goal_id = Proof.goal_uid ng; Interface.goal_name = name }
 

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -793,7 +793,7 @@ let pr_subgoals ?(pr_first=true) ?diffs ?entry
         ++ pr_evar_info (Some g1)
       )
 
-let pr_open_subgoals_diff ?(quiet=false) ?diffs proof =
+let pr_open_subgoals ?(quiet=false) ?diffs proof =
   (* spiwack: it shouldn't be the job of the printer to look up stuff
      in the [evar_map], I did stuff that way because it was more
      straightforward, but seriously, [Proof.proof] should return
@@ -842,9 +842,6 @@ let pr_open_subgoals_diff ?(quiet=false) ?diffs proof =
      pr_subgoals ~pr_first:true ?diffs None bsigma ~entry ~shelf ~stack:[]
         ~unfocused:unfocused_if_needed ~goals:bgoals_focused
   end
-
-let pr_open_subgoals ~proof =
-  pr_open_subgoals_diff proof
 
 let pr_nth_open_subgoal ~proof n =
   let Proof.{goals;sigma} = Proof.data proof in
@@ -1035,15 +1032,15 @@ let pr_assumptionset env sigma s =
 let print_and_diff oldp proof =
   let output =
     if Proof_diffs.show_diffs () then
-      try pr_open_subgoals_diff ~diffs:oldp proof
+      try pr_open_subgoals ~diffs:oldp proof
       with Pp_diff.Diff_Failure msg -> begin
         (* todo: print the unparsable string (if we know it) *)
         Feedback.msg_warning Pp.(str ("Diff failure: " ^ msg) ++ cut()
             ++ str "Showing results without diff highlighting" );
-        pr_open_subgoals ~proof
+        pr_open_subgoals proof
       end
     else
-      pr_open_subgoals ~proof
+      pr_open_subgoals proof
   in
   Feedback.msg_notice output
 

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -62,13 +62,15 @@ let pr_econstr_n_env ?lax ?inctx ?scope env sigma n t =
   pr_constr_expr_n env sigma n (extern_constr ?lax ?inctx ?scope env sigma t)
 let pr_econstr_env ?lax ?inctx ?scope env sigma t =
   pr_constr_expr env sigma (extern_constr ?lax ?inctx ?scope env sigma t)
-let pr_leconstr_env = Proof_diffs.pr_leconstr_env
+let pr_leconstr_env ?lax ?inctx ?scope env sigma t =
+  Ppconstr.pr_lconstr_expr env sigma (extern_constr ?lax ?inctx ?scope env sigma t)
 
 let pr_constr_n_env ?lax ?inctx ?scope env sigma n c =
   pr_econstr_n_env ?lax ?inctx ?scope env sigma n (EConstr.of_constr c)
 let pr_constr_env ?lax ?inctx ?scope env sigma c =
   pr_econstr_env ?lax ?inctx ?scope env sigma (EConstr.of_constr c)
-let pr_lconstr_env = Proof_diffs.pr_lconstr_env
+let pr_lconstr_env ?lax ?inctx ?scope env sigma c =
+  pr_leconstr_env ?lax ?inctx ?scope env sigma (EConstr.of_constr c)
 
 let pr_open_lconstr_env ?lax ?inctx ?scope env sigma (_,c) =
   pr_leconstr_env ?lax ?inctx ?scope env sigma c
@@ -87,7 +89,8 @@ let pr_lconstr_under_binders_env = pr_constr_under_binders_env_gen pr_leconstr_e
 
 let pr_etype_env ?lax ?goal_concl_style env sigma t =
   pr_constr_expr env sigma (extern_type ?lax ?goal_concl_style env sigma t)
-let pr_letype_env = Proof_diffs.pr_letype_env
+let pr_letype_env ?lax ?goal_concl_style env sigma ?impargs t =
+  pr_lconstr_expr env sigma (extern_type ?lax ?goal_concl_style env sigma ?impargs t)
 
 let pr_type_env ?lax ?goal_concl_style env sigma c =
   pr_etype_env ?lax ?goal_concl_style env sigma (EConstr.of_constr c)

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -1037,22 +1037,6 @@ let pr_assumptionset env sigma s =
     ] in
     prlist_with_sep fnl (fun x -> x) (Option.List.flatten assums)
 
-(* print the proof step, possibly with diffs highlighted, *)
-let print_and_diff oldp proof =
-  let output =
-    if Proof_diffs.show_diffs () then
-      try pr_open_subgoals ~diffs:oldp proof
-      with Pp_diff.Diff_Failure msg -> begin
-        (* todo: print the unparsable string (if we know it) *)
-        Feedback.msg_warning Pp.(str ("Diff failure: " ^ msg) ++ cut()
-            ++ str "Showing results without diff highlighting" );
-        pr_open_subgoals proof
-      end
-    else
-      pr_open_subgoals proof
-  in
-  Feedback.msg_notice output
-
 let pr_typing_flags flags =
   str "check_guarded: " ++ bool flags.check_guarded ++ fnl ()
   ++ str "check_positive: " ++ bool flags.check_positive ++ fnl ()

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -468,12 +468,21 @@ let goal_repr sigma g =
 let pr_goal ?diffs g_s =
   let g = sig_it g_s in
   let sigma = g_s.Evd.sigma in
-  let env, concl = goal_repr sigma g in
   let goal = match diffs with
   | Some og_s ->
     let g = Proof_diffs.make_goal (Global.env ()) sigma g in
-    Proof_diffs.diff_goal ?og_s g
+    let (hyps_pp_list, concl_pp) = Proof_diffs.diff_goal ?og_s g in
+    let hyp_list_to_pp hyps =
+      match hyps with
+      | h :: tl -> List.fold_left (fun x y -> x ++ cut () ++ y) h tl
+      | [] -> mt ()
+    in
+    v 0 (
+      (hyp_list_to_pp hyps_pp_list) ++ cut () ++
+      str "============================" ++ cut () ++
+      concl_pp)
   | None ->
+    let env, concl = goal_repr sigma g in
       pr_context_of env sigma ++ cut () ++
         str "============================" ++ cut ()  ++
         hov 0 (pr_letype_env ~goal_concl_style:true env sigma concl)

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -1032,23 +1032,20 @@ let pr_assumptionset env sigma s =
     prlist_with_sep fnl (fun x -> x) (Option.List.flatten assums)
 
 (* print the proof step, possibly with diffs highlighted, *)
-let print_and_diff oldp newp =
-  match newp with
-  | None -> ()
-  | Some proof ->
-    let output =
-      if Proof_diffs.show_diffs () then
-        try pr_open_subgoals_diff ~diffs:oldp proof
-        with Pp_diff.Diff_Failure msg -> begin
-          (* todo: print the unparsable string (if we know it) *)
-          Feedback.msg_warning Pp.(str ("Diff failure: " ^ msg) ++ cut()
-              ++ str "Showing results without diff highlighting" );
-          pr_open_subgoals ~proof
-        end
-      else
+let print_and_diff oldp proof =
+  let output =
+    if Proof_diffs.show_diffs () then
+      try pr_open_subgoals_diff ~diffs:oldp proof
+      with Pp_diff.Diff_Failure msg -> begin
+        (* todo: print the unparsable string (if we know it) *)
+        Feedback.msg_warning Pp.(str ("Diff failure: " ^ msg) ++ cut()
+            ++ str "Showing results without diff highlighting" );
         pr_open_subgoals ~proof
-    in
-    Feedback.msg_notice output
+      end
+    else
+      pr_open_subgoals ~proof
+  in
+  Feedback.msg_notice output
 
 let pr_typing_flags flags =
   str "check_guarded: " ++ bool flags.check_guarded ++ fnl ()

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -241,7 +241,7 @@ val pr_evars               : evar_map -> evar_info Evar.Map.t -> Pp.t
 val pr_ne_evar_set         : Pp.t -> Pp.t -> evar_map ->
   Evar.Set.t -> Pp.t
 
-val print_and_diff : Proof.t option -> Proof.t option -> unit
+val print_and_diff : Proof.t option -> Proof.t -> unit
 val print_dependent_evars : Evar.t option -> evar_map -> Evar.t list -> Pp.t
 
 (** Declarations for the "Print Assumption" command *)

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -189,19 +189,17 @@ val pr_transparent_state   : TransparentState.t -> Pp.t
 
 (** Proofs, these functions obey [Hyps Limit] and [Compact contexts]. *)
 
-(** [pr_goal ~diffs ~og_s g_s] prints the goal specified by [g_s].  If [diffs] is true,
-    highlight the differences between the old goal, [og_s], and [g_s].  [g_s] and [og_s] are
-    records containing the goal and sigma for, respectively, the new and old proof steps,
-    e.g. [{ it = g ; sigma = sigma }].
+(** [pr_goal ?diffs g_s] prints the goal specified by [g_s].  If [diffs] is [Some og_s],
+    highlight the differences between the (optional) old goal [og_s] and [g_s].
 *)
-val pr_goal : ?diffs:bool -> ?og_s:Proof_diffs.goal -> Evar.t sigma -> Pp.t
+val pr_goal : ?diffs:Proof_diffs.goal option -> Evar.t sigma -> Pp.t
 
-(** [pr_subgoals ~pr_first ~diffs ~os_map close_cmd sigma ~seeds ~shelf ~stack ~unfocused ~goals]
+(** [pr_subgoals ~pr_first ?diffs close_cmd sigma ~seeds ~shelf ~stack ~unfocused ~goals]
    prints the goals in [goals] followed by the goals in [unfocused] in a compact form
    (typically only the conclusion).  If [pr_first] is true, print the first goal in full.
    [close_cmd] is printed afterwards verbatim.
 
-   If [diffs] is true, then highlight diffs relative to [os_map] in the output for first goal.
+   If [diffs] is [Some os_map], then highlight diffs relative to [os_map] in the output for first goal.
    [os_map] contains sigma for the old proof step and the goal map created by
    [Proof_diffs.make_goal_map].
 
@@ -213,8 +211,7 @@ val pr_goal : ?diffs:bool -> ?og_s:Proof_diffs.goal -> Evar.t sigma -> Pp.t
 *)
 val pr_subgoals
   : ?pr_first:bool
-  -> ?diffs:bool
-  -> ?os_map:Proof_diffs.goal_map
+  -> ?diffs:Proof_diffs.goal_map option
   -> ?entry:Proofview.entry
   -> Pp.t option -> evar_map
   -> shelf:Evar.t list
@@ -225,18 +222,17 @@ val pr_subgoals
 
 val pr_subgoal : int -> evar_map -> Evar.t list -> Pp.t
 
-(** [pr_concl n ~diffs ~og_s sigma g] prints the conclusion of the goal [g] using [sigma].  The output
-    is labelled "subgoal [n]".  If [diffs] is true, highlight the differences between the old conclusion,
-    [og_s], and [g]+[sigma].  [og_s] is a record containing the old goal and sigma, e.g. [{ it = g ; sigma = sigma }].
-*)
-val pr_concl : int -> ?diffs:bool -> ?og_s:Proof_diffs.goal -> evar_map -> Evar.t -> Pp.t
+(** [pr_concl n ?diffs sigma g] prints the conclusion of the goal [g] using [sigma].  The output
+    is labelled "subgoal [n]".  If [diffs] is [Some og_s], highlight the differences between the old conclusion,
+    [og_s], and [g, sigma]. *)
+val pr_concl : int -> ?diffs:Proof_diffs.goal option -> evar_map -> Evar.t -> Pp.t
 
-(** [pr_open_subgoals_diff ~quiet ~diffs ~oproof proof] shows the context for [proof] as used by, for example, coqtop.
+(** [pr_open_subgoals_diff ~quiet ?diffs proof] shows the context for [proof] as used by, for example, coqtop.
     The first active goal is printed with all its antecedents and the conclusion.  The other active goals only show their
-     conclusions.  If [diffs] is true, highlight the differences between the old proof, [oproof], and [proof].  [quiet]
+     conclusions.  If [diffs] is [Some oproof], highlight the differences between the old proof [oproof], and [proof].  [quiet]
      disables printing messages as Feedback.
 *)
-val pr_open_subgoals_diff  : ?quiet:bool -> ?diffs:bool -> ?oproof:Proof.t -> Proof.t -> Pp.t
+val pr_open_subgoals_diff  : ?quiet:bool -> ?diffs:Proof.t option -> Proof.t -> Pp.t
 val pr_open_subgoals       : proof:Proof.t -> Pp.t
 val pr_nth_open_subgoal    : proof:Proof.t -> int -> Pp.t
 val pr_evar                : evar_map -> (Evar.t * evar_info) -> Pp.t

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -240,7 +240,6 @@ val pr_evars               : evar_map -> evar_info Evar.Map.t -> Pp.t
 val pr_ne_evar_set         : Pp.t -> Pp.t -> evar_map ->
   Evar.Set.t -> Pp.t
 
-val print_and_diff : Proof.t option -> Proof.t -> unit
 val print_dependent_evars : Evar.t option -> evar_map -> Evar.t list -> Pp.t
 
 (** Declarations for the "Print Assumption" command *)

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -191,41 +191,9 @@ val pr_transparent_state   : TransparentState.t -> Pp.t
 
 (** [pr_goal ?diffs g_s] prints the goal specified by [g_s].  If [diffs] is [Some og_s],
     highlight the differences between the (optional) old goal [og_s] and [g_s].
+    This is a UI-facing function, you should not use that for debug printing.
 *)
 val pr_goal : ?diffs:Proof_diffs.goal option -> Evar.t sigma -> Pp.t
-
-(** [pr_subgoals ~pr_first ?diffs close_cmd sigma ~seeds ~shelf ~stack ~unfocused ~goals]
-   prints the goals in [goals] followed by the goals in [unfocused] in a compact form
-   (typically only the conclusion).  If [pr_first] is true, print the first goal in full.
-   [close_cmd] is printed afterwards verbatim.
-
-   If [diffs] is [Some os_map], then highlight diffs relative to [os_map] in the output for first goal.
-   [os_map] contains sigma for the old proof step and the goal map created by
-   [Proof_diffs.make_goal_map].
-
-   This function prints only the focused goals unless the corresponding option [enable_unfocused_goal_printing] is set.
-   [seeds] is for printing dependent evars (mainly for emacs proof tree mode).  [shelf] is from
-   Proof.proof and is used to identify shelved goals in a message if there are no more subgoals but
-   there are non-instantiated existential variables.  [stack] is used to print summary info on unfocused
-   goals.
-*)
-val pr_subgoals
-  : ?pr_first:bool
-  -> ?diffs:Proof_diffs.goal_map option
-  -> ?entry:Proofview.entry
-  -> Pp.t option -> evar_map
-  -> shelf:Evar.t list
-  -> stack:int list
-  -> unfocused:Evar.t list
-  -> goals:Evar.t list
-  -> Pp.t
-
-val pr_subgoal : int -> evar_map -> Evar.t list -> Pp.t
-
-(** [pr_concl n ?diffs sigma g] prints the conclusion of the goal [g] using [sigma].  The output
-    is labelled "subgoal [n]".  If [diffs] is [Some og_s], highlight the differences between the old conclusion,
-    [og_s], and [g, sigma]. *)
-val pr_concl : int -> ?diffs:Proof_diffs.goal option -> evar_map -> Evar.t -> Pp.t
 
 (** [pr_open_subgoals ~quiet ?diffs proof] shows the context for [proof] as used by, for example, coqtop.
     The first active goal is printed with all its antecedents and the conclusion.  The other active goals only show their
@@ -236,7 +204,6 @@ val pr_open_subgoals       : ?quiet:bool -> ?diffs:Proof.t option -> Proof.t -> 
 val pr_nth_open_subgoal    : proof:Proof.t -> int -> Pp.t
 val pr_evar                : evar_map -> (Evar.t * evar_info) -> Pp.t
 val pr_evars_int           : evar_map -> shelf:Evar.t list -> given_up:Evar.t list -> int -> evar_info Evar.Map.t -> Pp.t
-val pr_evars               : evar_map -> evar_info Evar.Map.t -> Pp.t
 val pr_ne_evar_set         : Pp.t -> Pp.t -> evar_map ->
   Evar.Set.t -> Pp.t
 

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -227,13 +227,12 @@ val pr_subgoal : int -> evar_map -> Evar.t list -> Pp.t
     [og_s], and [g, sigma]. *)
 val pr_concl : int -> ?diffs:Proof_diffs.goal option -> evar_map -> Evar.t -> Pp.t
 
-(** [pr_open_subgoals_diff ~quiet ?diffs proof] shows the context for [proof] as used by, for example, coqtop.
+(** [pr_open_subgoals ~quiet ?diffs proof] shows the context for [proof] as used by, for example, coqtop.
     The first active goal is printed with all its antecedents and the conclusion.  The other active goals only show their
      conclusions.  If [diffs] is [Some oproof], highlight the differences between the old proof [oproof], and [proof].  [quiet]
      disables printing messages as Feedback.
 *)
-val pr_open_subgoals_diff  : ?quiet:bool -> ?diffs:Proof.t option -> Proof.t -> Pp.t
-val pr_open_subgoals       : proof:Proof.t -> Pp.t
+val pr_open_subgoals       : ?quiet:bool -> ?diffs:Proof.t option -> Proof.t -> Pp.t
 val pr_nth_open_subgoal    : proof:Proof.t -> int -> Pp.t
 val pr_evar                : evar_map -> (Evar.t * evar_info) -> Pp.t
 val pr_evars_int           : evar_map -> shelf:Evar.t list -> given_up:Evar.t list -> int -> evar_info Evar.Map.t -> Pp.t

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -332,28 +332,13 @@ let diff_goal_info o_info n_info =
   let hyp_diffs_list = diff_hyps o_idents_in_lines o_hyp_map n_idents_in_lines n_hyp_map in
   (hyp_diffs_list, concl_pp)
 
-let hyp_list_to_pp hyps =
-  let open Pp in
-  match hyps with
-  | h :: tl -> List.fold_left (fun x y -> x ++ cut () ++ y) h tl
-  | [] -> mt ()
-
 let unwrap g_s =
   match g_s with
   | Some g_s -> goal_info g_s
   | None -> ([], CString.Map.empty, Pp.mt ())
 
-let diff_goal_ide og_s ng =
-  diff_goal_info (unwrap og_s) (goal_info ng)
-
 let diff_goal ?og_s ng =
-  let (hyps_pp_list, concl_pp) = diff_goal_info (unwrap og_s) (goal_info ng) in
-  let open Pp in
-  v 0 (
-    (hyp_list_to_pp hyps_pp_list) ++ cut () ++
-    str "============================" ++ cut () ++
-    concl_pp)
-
+  diff_goal_info (unwrap og_s) (goal_info ng)
 
 (*** Code to determine which calls to compare between the old and new proofs ***)
 

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -260,9 +260,6 @@ let pr_leconstr_env ?lax ?inctx ?scope env sigma t =
 let pr_econstr_env ?lax ?inctx ?scope env sigma t =
   Ppconstr.pr_constr_expr env sigma (Constrextern.extern_constr ?lax ?inctx ?scope env sigma t)
 
-let pr_lconstr_env ?lax ?inctx ?scope env sigma c =
-  pr_leconstr_env ?lax ?inctx ?scope env sigma (EConstr.of_constr c)
-
 let diff_concl ?og_s ng =
   let o_concl_pp = match og_s with
   | Some { ty = oty; env = oenv; sigma = osigma } -> pp_of_type oenv osigma oty

--- a/printing/proof_diffs.mli
+++ b/printing/proof_diffs.mli
@@ -29,10 +29,6 @@ type diffOpt = DiffOff | DiffOn | DiffRemoved
 
 val string_to_diffs : string -> diffOpt
 
-open Evd
-open Environ
-open Constr
-
 type goal
 
 val make_goal : Environ.env -> Evd.evar_map -> Evar.t -> goal
@@ -52,10 +48,6 @@ val diff_goal : ?og_s:goal -> goal -> Pp.t list * Pp.t
 
 (** Convert a string to a list of token strings using the lexer *)
 val tokenize_string : string -> string list
-
-val pr_letype_env          : ?lax:bool -> ?goal_concl_style:bool -> Environ.env -> Evd.evar_map -> ?impargs:Glob_term.binding_kind list -> EConstr.types -> Pp.t
-val pr_leconstr_env        : ?lax:bool -> ?inctx:bool -> ?scope:Notation_term.scope_name -> Environ.env -> Evd.evar_map -> EConstr.constr -> Pp.t
-val pr_lconstr_env         : ?lax:bool -> ?inctx:bool -> ?scope:Notation_term.scope_name -> env -> evar_map -> constr -> Pp.t
 
 (** Computes diffs for a single conclusion *)
 val diff_concl : ?og_s:goal -> goal -> Pp.t

--- a/printing/proof_diffs.mli
+++ b/printing/proof_diffs.mli
@@ -48,19 +48,7 @@ If you want to make your call especially bulletproof, catch these
 exceptions, print a user-visible message, then recall this routine with
 the first argument set to None, which will skip the diff.
 *)
-val diff_goal_ide : goal option -> goal -> Pp.t list * Pp.t
-
-(** Computes the diff between two goals
-
-If the strings used to display the goal are not lexable (this is believed
-unlikely), this routine will generate a Diff_Failure.  This routine may also
-raise Diff_Failure under some "impossible" conditions.
-
-If you want to make your call especially bulletproof, catch these
-exceptions, print a user-visible message, then recall this routine with
-the first argument set to None, which will skip the diff.
-*)
-val diff_goal : ?og_s:goal -> goal -> Pp.t
+val diff_goal : ?og_s:goal -> goal -> Pp.t list * Pp.t
 
 (** Convert a string to a list of token strings using the lexer *)
 val tokenize_string : string -> string list

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -366,7 +366,7 @@ let print_anyway c =
    generic way, but that'll do for now *)
 let top_goal_print ~doc c oldp newp =
   try
-    let proof_changed = not (Option.equal cproof oldp newp) in
+    let proof_changed = not (Option.equal cproof oldp (Some newp)) in
     let print_goals = proof_changed && Vernacstate.Declare.there_are_pending_proofs () ||
                       print_anyway c in
     if not !Flags.quiet && print_goals then begin
@@ -413,7 +413,10 @@ let process_toplevel_command ~state stm =
 
   | VernacControl { CAst.loc; v=c } ->
     let nstate = Vernac.process_expr ~state (CAst.make ?loc c) in
-    top_goal_print ~doc:state.doc c state.proof nstate.proof;
+    let () = match nstate.proof with
+    | None -> ()
+    | Some proof -> top_goal_print ~doc:state.doc c state.proof proof
+    in
     nstate
 
   | VernacShowGoal { gid; sid } ->

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2121,7 +2121,7 @@ let vernac_show ~pstate =
     begin function
     | ShowGoal goalref ->
       begin match goalref with
-        | OpenSubgoals -> pr_open_subgoals ~proof
+        | OpenSubgoals -> pr_open_subgoals proof
         | NthGoal n -> pr_nth_open_subgoal ~proof n
         | GoalId id -> pr_goal_by_id ~proof id
       end


### PR DESCRIPTION
This PR is a series of cleanups around the Printer API. High-level list of change:
- Merging of a few similar exported functions
- Static invariants enforced by typing (notably moving `diffs` arguments from a boolean to an option)
- Removal of internal printing functions that are only used for coqtop UI printing.