### PR TITLE
Print all goals in debugger (quick fix)

### DIFF
--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -590,7 +590,7 @@ let loop ( { Coqtop.run_mode; color_mode },_) ~opts:_ state =
     let open Xmlprotocol in
     let xml = match ans with
       | Prompt msg -> of_ltac_debug_answer ~tag:"prompt" msg
-      | Goal msg -> of_ltac_debug_answer ~tag:"goal" (str "Goal:" ++ fnl () ++ msg)
+      | Goal msg -> of_ltac_debug_answer ~tag:"goal" msg
       | Output msg -> of_ltac_debug_answer ~tag:"output" msg
       | Init -> of_ltac_debug_answer ~tag:"init" (str "")
       | Vars vars -> of_vars vars;

--- a/plugins/ltac/tactic_debug.ml
+++ b/plugins/ltac/tactic_debug.ml
@@ -326,13 +326,16 @@ let db_pr_goal gl =
   let pc = Printer.pr_econstr_env env (Tacmach.project gl) concl in
     str"  " ++ hv 0 (penv ++ fnl () ++
                    str "============================" ++ fnl ()  ++
-                   str" "  ++ pc) ++ fnl ()
+                   str" "  ++ pc) ++ fnl () ++ fnl ()
 
 let db_pr_goal =
-  Proofview.Goal.enter begin fun gl ->
-  let pg = db_pr_goal gl in
+  let open Proofview in
+  let open Notations in
+  Goal.goals >>= fun gl ->
+  Monad.List.map (fun x -> x) gl >>= fun gls ->
+  let pg = str (CString.plural (List.length gls) "Goal") ++ str ":" ++ fnl () ++
+      Pp.seq (List.map db_pr_goal gls) in
   Proofview.tclLIFT (Comm.goal pg)
-  end
 
 (* Prints the commands *)
 let help () =

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -136,7 +136,7 @@ let ltac_debug_answer = let open DebugHook.Answer in function
       (* No newline *)
       Format.fprintf !Topfmt.err_ft "@[%a@]%!" Pp.pp_with prompt
     | Goal g ->
-      Format.fprintf !Topfmt.err_ft "@[%a@]@\n%!" Pp.pp_with (str "Goal:" ++ fnl () ++ g)
+      Format.fprintf !Topfmt.err_ft "@[%a@]@\n%!" Pp.pp_with g
     | Output o ->
       Format.fprintf !Topfmt.err_ft "@[%a@]@\n%!" Pp.pp_with o
     | Init ->


### PR DESCRIPTION
This is a quick fix for #15345, which makes the debugger much less useful in certain cases.  I hope it's not too late to get this into 8.15.  In the meantime I'm working on a much better fix.

Here's an example of what you see in the debugger's proof panel if there are multiple goals:

```
Goal(s):
    H : False
  ============================
   False

    H : False
  ============================
   True
```