### PR TITLE
Stepwise unfold constants until finding an appropriate scope when computing arguments scopes

### DIFF
--- a/test-suite/success/Scopes.v
+++ b/test-suite/success/Scopes.v
@@ -49,3 +49,21 @@ Arguments fst {A B} p%foo.
 Check [[2,3]].(fst).
 
 End ScopeProjNotation.
+
+Module BindScopeGranularity.
+
+Notation "0" := true.
+Definition f (a: id nat) := a.
+Check f 0.
+
+Definition g (a: fst (nat, nat)) := a.
+Check g 0.
+
+Set Primitive Projections.
+Record prod A B := {fst:A; snd:B}.
+Arguments fst {_ _}.
+
+Definition h (a: {|fst:=nat;snd:=nat|}.(fst)) := a.
+Check h 0.
+
+End BindScopeGranularity.


### PR DESCRIPTION
**Kind:** enhancement

If the type of an argument is not bound to a scope, we reduce its head constant stepwise until possibly finding a scope which matches. This is virtually more costly at definition and discharge time since it (virtually) involves arbitrary long head-reduction rather than betaiotazeta, but more natural (there are examples in MathComp), even if it makes arguments scopes even more tied to typing.

- [x] Added / updated **test-suite**.
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
