### PR TITLE
Deprecate "dfs eauto" tactic

### DIFF
--- a/doc/sphinx/proofs/automatic-tactics/auto.rst
+++ b/doc/sphinx/proofs/automatic-tactics/auto.rst
@@ -134,6 +134,12 @@ Programmable proof search
       Behaves like :tacn:`eauto` but shows the tactics it tries to solve the goal,
       including failing paths.
 
+   .. tacn:: dfs eauto {? @nat_or_var } {? @auto_using } {? @hintbases }
+
+      .. deprecated:: 8.16
+
+      An alias for :tacn:`eauto`.
+
 .. tacn:: autounfold {? @hintbases } {? @simple_occurrences }
 
    Unfolds constants that were declared through a :cmd:`Hint Unfold`

--- a/plugins/ltac/g_auto.mlg
+++ b/plugins/ltac/g_auto.mlg
@@ -126,7 +126,7 @@ TACTIC EXTEND info_eauto
   { Eauto.gen_eauto ~debug:Info ?depth (eval_uconstrs ist lems) db }
 END
 
-TACTIC EXTEND dfs_eauto
+TACTIC EXTEND dfs_eauto DEPRECATED { Deprecation.make ~since:"8.16" ~note:"Use [eauto] instead." () }
 | [ "dfs" "eauto" nat_or_var_opt(depth) auto_using(lems) hintbases(db) ] ->
   { Eauto.gen_eauto ?depth (eval_uconstrs ist lems) db }
 END


### PR DESCRIPTION
No longer needed because `bfs eauto` was removed.