### PR TITLE
WIP: Rewrite prod to be a Record

### DIFF
--- a/theories/Init/Datatypes.v
+++ b/theories/Init/Datatypes.v
@@ -221,31 +221,26 @@ Register inr as core.sum.inr.
     the pair [pair A B a b] of [a] and [b] is abbreviated [(a,b)] *)
 
 #[universes(template)]
-Inductive prod (A B:Type) : Type :=
-  pair : A -> B -> A * B
+Record prod (A B:Type) : Type := pair { fst: A ; snd: B }.
 
-where "x * y" := (prod x y) : type_scope.
+Notation "x * y" := (prod x y) : type_scope.
 
 Add Printing Let prod.
 
+Arguments pair {A B} _ _.
+Arguments fst {A B} _.
+Arguments snd {A B} _.
+
 Notation "( x , y , .. , z )" := (pair .. (pair x y) .. z) : core_scope.
 
-Arguments pair {A B} _ _.
+Scheme prod_rect := Induction for prod Sort Type.
 
 Register prod as core.prod.type.
 Register pair as core.prod.intro.
 Register prod_rect as core.prod.rect.
 
-Section projections.
-  Context {A : Type} {B : Type}.
-
-  Definition fst (p:A * B) := match p with (x, y) => x end.
-  Definition snd (p:A * B) := match p with (x, y) => y end.
-
-  Register fst as core.prod.proj1.
-  Register snd as core.prod.proj2.
-
-End projections.
+Register fst as core.prod.proj1.
+Register snd as core.prod.proj2.
 
 #[global]
 Hint Resolve pair inl inr: core.

--- a/theories/Init/Datatypes.v
+++ b/theories/Init/Datatypes.v
@@ -218,6 +218,7 @@ Register inl as core.sum.inl.
 Register inr as core.sum.inr.
 
 Local Set Primitive Projections.
+Local Set Nonrecursive Elimination Schemes.
 
 (** [prod A B], written [A * B], is the product of [A] and [B];
     the pair [pair A B a b] of [a] and [b] is abbreviated [(a,b)] *)
@@ -226,6 +227,7 @@ Local Set Primitive Projections.
 Record prod (A B:Type) : Type := pair { fst: A ; snd: B }.
 
 Local Unset Primitive Projections.
+Local Unset Nonrecursive Elimination Schemes.
 
 Notation "x * y" := (prod x y) : type_scope.
 
@@ -236,10 +238,6 @@ Arguments fst {A B} _.
 Arguments snd {A B} _.
 
 Notation "( x , y , .. , z )" := (pair .. (pair x y) .. z) : core_scope.
-
-Scheme prod_ind := Induction for prod Sort Prop.
-Scheme prod_rec := Induction for prod Sort Set.
-Scheme prod_rect := Induction for prod Sort Type.
 
 Register prod as core.prod.type.
 Register pair as core.prod.intro.

--- a/theories/Init/Datatypes.v
+++ b/theories/Init/Datatypes.v
@@ -223,7 +223,7 @@ Local Set Primitive Projections.
     the pair [pair A B a b] of [a] and [b] is abbreviated [(a,b)] *)
 
 #[universes(template)]
-Inductive prod (A B:Type) : Type := pair { fst: A ; snd: B }.
+Record prod (A B:Type) : Type := pair { fst: A ; snd: B }.
 
 Local Unset Primitive Projections.
 
@@ -236,6 +236,10 @@ Arguments fst {A B} _.
 Arguments snd {A B} _.
 
 Notation "( x , y , .. , z )" := (pair .. (pair x y) .. z) : core_scope.
+
+Scheme prod_ind := Induction for prod Sort Prop.
+Scheme prod_rec := Induction for prod Sort Set.
+Scheme prod_rect := Induction for prod Sort Type.
 
 Register prod as core.prod.type.
 Register pair as core.prod.intro.

--- a/theories/Init/Datatypes.v
+++ b/theories/Init/Datatypes.v
@@ -217,11 +217,15 @@ Register sum as core.sum.type.
 Register inl as core.sum.inl.
 Register inr as core.sum.inr.
 
+Local Set Primitive Projections.
+
 (** [prod A B], written [A * B], is the product of [A] and [B];
     the pair [pair A B a b] of [a] and [b] is abbreviated [(a,b)] *)
 
 #[universes(template)]
 Record prod (A B:Type) : Type := pair { fst: A ; snd: B }.
+
+Local Unset Primitive Projections.
 
 Notation "x * y" := (prod x y) : type_scope.
 

--- a/theories/Init/Datatypes.v
+++ b/theories/Init/Datatypes.v
@@ -223,7 +223,7 @@ Local Set Primitive Projections.
     the pair [pair A B a b] of [a] and [b] is abbreviated [(a,b)] *)
 
 #[universes(template)]
-Record prod (A B:Type) : Type := pair { fst: A ; snd: B }.
+Inductive prod (A B:Type) : Type := pair { fst: A ; snd: B }.
 
 Local Unset Primitive Projections.
 
@@ -236,8 +236,6 @@ Arguments fst {A B} _.
 Arguments snd {A B} _.
 
 Notation "( x , y , .. , z )" := (pair .. (pair x y) .. z) : core_scope.
-
-Scheme prod_rect := Induction for prod Sort Type.
 
 Register prod as core.prod.type.
 Register pair as core.prod.intro.


### PR DESCRIPTION
This has slightly nicer typechecking behaviour under primitive projections.
In brief 'let (a, b) := p in f a b' does not simplify to
 'f (let (a, _) := p in a) (let (_, b) := p in b).'

This is a WIP.

See also https://coq.discourse.group/t/redefining-prod-as-a-record/1365

Not really sure how to redefine prod as a record without breaking lots of stuff.

It was suggested uploading here and seeing what it breaks in CI.

Not quite sure about the behavior of records without primitive projections. Maybe one could set primitive projections for prod without enabling it else where?