### PR TITLE
A pass on error messages related to the "with" clause of module types

### DIFF
--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -137,10 +137,7 @@ matches the module type.  If the module is not a
 functor, its components (:term:`constants <constant>`, inductive types, submodules etc.)
 are now available through the dot notation.
 
-.. exn:: No such label @ident.
-    :undocumented:
-
-.. exn:: Signature components for label @ident do not match.
+.. exn:: Signature components for field @ident do not match.
     :undocumented:
 
 .. exn:: The field @ident is missing in @qualid.
@@ -421,6 +418,12 @@ The definition of :g:`N` using the module type expression :g:`SIG` with
    End SIG'.
 
    Module N : SIG' := M.
+
+.. exn:: No field named @ident in @qualid.
+
+   Raised when the final :n:`@ident` in the left-hand side :n:`@qualid` of
+   a :n:`@with_declaration` is applied to a module type :n:`@qualid` that
+   has no field named this :n:`@ident`.
 
 If we just want to be sure that our implementation satisfies a
 given module type without restricting the interface, we can use a

--- a/interp/modintern.ml
+++ b/interp/modintern.ml
@@ -14,7 +14,9 @@ open Constrexpr
 open Constrintern
 
 type module_internalization_error =
-  | NotAModuleNorModtype of string
+  | NotAModuleNorModtype of qualid
+  | NotAModuleType of qualid
+  | NotAModule of qualid
   | IncorrectWithInModule
   | IncorrectModuleApplication
 
@@ -23,14 +25,13 @@ exception ModuleInternalizationError of module_internalization_error
 type module_kind = Module | ModType | ModAny
 
 let error_not_a_module_loc ~info kind loc qid =
-  let s = string_of_qualid qid in
   let e = match kind with
-    | Module -> Modops.ModuleTypingError (Modops.NotAModule s)
-    | ModType -> Modops.ModuleTypingError (Modops.NotAModuleType s)
-    | ModAny -> ModuleInternalizationError (NotAModuleNorModtype s)
+    | Module -> NotAModule qid
+    | ModType -> NotAModuleType qid
+    | ModAny -> NotAModuleNorModtype qid
   in
   let info = Option.cata (Loc.add_loc info) info loc in
-  Exninfo.iraise (e,info)
+  Exninfo.iraise (ModuleInternalizationError e,info)
 
 let error_incorrect_with_in_module loc =
   Loc.raise ?loc (ModuleInternalizationError IncorrectWithInModule)

--- a/interp/modintern.mli
+++ b/interp/modintern.mli
@@ -11,11 +11,14 @@
 open Environ
 open Entries
 open Constrexpr
+open Libnames
 
 (** Module internalization errors *)
 
 type module_internalization_error =
-  | NotAModuleNorModtype of string
+  | NotAModuleNorModtype of qualid
+  | NotAModuleType of qualid
+  | NotAModule of qualid
   | IncorrectWithInModule
   | IncorrectModuleApplication
 

--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -56,13 +56,11 @@ type module_typing_error =
       Label.t * structure_field_body * signature_mismatch_error
   | LabelAlreadyDeclared of Label.t
   | NotAFunctor
-  | IsAFunctor
+  | IsAFunctor of ModPath.t
   | IncompatibleModuleTypes of module_type_body * module_type_body
   | NotEqualModulePaths of ModPath.t * ModPath.t
-  | NoSuchLabel of Label.t
-  | IncompatibleLabels of Label.t * Label.t
-  | NotAModule of string
-  | NotAModuleType of string
+  | NoSuchLabel of Label.t * ModPath.t
+  | NotAModuleLabel of Label.t
   | NotAConstant of Label.t
   | IncorrectWithConstraint of Label.t
   | GenerativeModuleExpected of Label.t
@@ -77,8 +75,8 @@ let error_existing_label l =
 let error_not_a_functor () =
   raise (ModuleTypingError NotAFunctor)
 
-let error_is_a_functor () =
-  raise (ModuleTypingError IsAFunctor)
+let error_is_a_functor mp =
+  raise (ModuleTypingError (IsAFunctor mp))
 
 let error_incompatible_modtypes mexpr1 mexpr2 =
   raise (ModuleTypingError (IncompatibleModuleTypes (mexpr1,mexpr2)))
@@ -89,14 +87,11 @@ let error_not_equal_modpaths mp1 mp2 =
 let error_signature_mismatch l spec why =
   raise (ModuleTypingError (SignatureMismatch (l,spec,why)))
 
-let error_no_such_label l =
-  raise (ModuleTypingError (NoSuchLabel l))
+let error_no_such_label l mp =
+  raise (ModuleTypingError (NoSuchLabel (l,mp)))
 
-let error_incompatible_labels l l' =
-  raise (ModuleTypingError (IncompatibleLabels (l,l')))
-
-let error_not_a_module s =
-  raise (ModuleTypingError (NotAModule s))
+let error_not_a_module_label s =
+  raise (ModuleTypingError (NotAModuleLabel s))
 
 let error_not_a_constant l =
   raise (ModuleTypingError (NotAConstant l))
@@ -123,9 +118,9 @@ let destr_functor = function
   |NoFunctor _ -> error_not_a_functor ()
   |MoreFunctor (mbid,ty,x) -> (mbid,ty,x)
 
-let destr_nofunctor = function
+let destr_nofunctor mp = function
   |NoFunctor a -> a
-  |MoreFunctor _ -> error_is_a_functor ()
+  |MoreFunctor _ -> error_is_a_functor mp
 
 let rec functor_smart_map fty f0 funct = match funct with
   |MoreFunctor (mbid,ty,e) ->

--- a/kernel/modops.mli
+++ b/kernel/modops.mli
@@ -23,7 +23,7 @@ val is_functor : ('ty,'a) functorize -> bool
 
 val destr_functor : ('ty,'a) functorize -> MBId.t * 'ty * ('ty,'a) functorize
 
-val destr_nofunctor : ('ty,'a) functorize -> 'a
+val destr_nofunctor : ModPath.t -> ('ty,'a) functorize -> 'a
 
 (** Conversions between [module_body] and [module_type_body] *)
 
@@ -113,13 +113,11 @@ type module_typing_error =
       Label.t * structure_field_body * signature_mismatch_error
   | LabelAlreadyDeclared of Label.t
   | NotAFunctor
-  | IsAFunctor
+  | IsAFunctor of ModPath.t
   | IncompatibleModuleTypes of module_type_body * module_type_body
   | NotEqualModulePaths of ModPath.t * ModPath.t
-  | NoSuchLabel of Label.t
-  | IncompatibleLabels of Label.t * Label.t
-  | NotAModule of string
-  | NotAModuleType of string
+  | NoSuchLabel of Label.t * ModPath.t
+  | NotAModuleLabel of Label.t
   | NotAConstant of Label.t
   | IncorrectWithConstraint of Label.t
   | GenerativeModuleExpected of Label.t
@@ -136,11 +134,9 @@ val error_incompatible_modtypes :
 val error_signature_mismatch :
   Label.t -> structure_field_body -> signature_mismatch_error -> 'a
 
-val error_incompatible_labels : Label.t -> Label.t -> 'a
+val error_no_such_label : Label.t -> ModPath.t -> 'a
 
-val error_no_such_label : Label.t -> 'a
-
-val error_not_a_module : string -> 'a
+val error_not_a_module_label : Label.t -> 'a
 
 val error_not_a_constant : Label.t -> 'a
 

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -35,7 +35,7 @@ let environment_until dir_opt =
     | [] -> []
     | d :: l ->
       let meb =
-        Modops.destr_nofunctor (Global.lookup_module (MPfile d)).mod_type
+        Modops.destr_nofunctor (MPfile d) (Global.lookup_module (MPfile d)).mod_type
       in
       match dir_opt with
       | Some d' when DirPath.equal d d' -> [MPfile d, meb]
@@ -179,7 +179,7 @@ let flatten_modtype env mp me_alg struc_opt =
 *)
 
 let env_for_mtb_with_def env mp me reso idl =
-  let struc = Modops.destr_nofunctor me in
+  let struc = Modops.destr_nofunctor mp me in
   let l = Label.of_id (List.hd idl) in
   let spot = function (l',SFBconst _) -> Label.equal l l' | _ -> false in
   let before = fst (List.split_when spot struc) in

--- a/test-suite/output/ErrorModuleWith.out
+++ b/test-suite/output/ErrorModuleWith.out
@@ -1,0 +1,15 @@
+File "./output/ErrorModuleWith.v", line 5, characters 0-53:
+The command has indeed failed with message:
+No field named V in module A.B of M.
+File "./output/ErrorModuleWith.v", line 6, characters 0-53:
+The command has indeed failed with message:
+No field named C in module A of M.
+File "./output/ErrorModuleWith.v", line 7, characters 0-49:
+The command has indeed failed with message:
+No field named V in M.
+File "./output/ErrorModuleWith.v", line 8, characters 0-53:
+The command has indeed failed with message:
+Module A' of M not expected to be a functor.
+File "./output/ErrorModuleWith.v", line 13, characters 0-38:
+The command has indeed failed with message:
+Module M2 is not equal to M1.

--- a/test-suite/output/ErrorModuleWith.v
+++ b/test-suite/output/ErrorModuleWith.v
@@ -1,0 +1,13 @@
+Module Type T. Axiom U : Type. End T.
+Module Type S. Declare Module B : T. End S.
+Module Type S' (X : T). Axiom U' : Type. End S'.
+Module Type M. Declare Module A : S. Declare Module A' : S'. End M.
+Fail Module Type N := M with Definition A.B.V := nat.
+Fail Module Type N := M with Definition A.C.U := nat.
+Fail Module Type N := M with Definition V := nat.
+Fail Module Type N := M with Definition A'.U' := nat.
+
+Module M1. Axiom T : Type. End M1.
+Module M2. Axiom T : Type. End M2.
+Module Type V. Module N := M1. End V.
+Fail Module Q : V with Module N := M2.

--- a/test-suite/output/bug_8206.out
+++ b/test-suite/output/bug_8206.out
@@ -1,5 +1,5 @@
 File "./output/bug_8206.v", line 11, characters 0-28:
 The command has indeed failed with message:
-Signature components for label homework do not match: expected type
+Signature components for field homework do not match: expected type
 "forall a b : nat, bug_8206.M.add a b = bug_8206.M.add b a" but found type
 "nat -> forall b : nat, bug_8206.M.add 0 b = bug_8206.M.add b 0".

--- a/test-suite/output/qualification.out
+++ b/test-suite/output/qualification.out
@@ -1,5 +1,5 @@
 File "./output/qualification.v", line 20, characters 0-7:
-Error: Signature components for label test do not match: expected type
+Error: Signature components for field test do not match: expected type
 "qualification.M2.t = qualification.M2.M.t" but found type
 "qualification.M2.t = qualification.M2.t".
 


### PR DESCRIPTION
**Kind:** Cleanup, enhancements

The PR cleans a few error messages:
- `IncompatibleLabels` was dead code
- `NotAModule` had two roles, one in kernel, one in interning: we split the roles
- `NotAModuleType` was relevant only for interning: we move it out of kernel

It also tries to improve some error messages:
- The word "label" is internal to the implementation and was not used in the reference manual: we replace it in error messages by "field" or "name of field"
- We build more detailed error messages when a field is incorrect (see test-suite)

- [x] Added / updated **test-suite**.
- [x] Documented any new / changed **user messages**.

