### PR TITLE
Fixes #9555: expansion of self in functorial module types wrongly extend over the type of parameters, impacting the correctness of the algebraic form of the type of parameters

### DIFF
--- a/doc/changelog/01-kernel/15385-master+fix-bug9555-subst-module-type-wrongly-over-functor.rst
+++ b/doc/changelog/01-kernel/15385-master+fix-bug9555-subst-module-type-wrongly-over-functor.rst
@@ -1,0 +1,8 @@
+- **Fixed:**
+  Name clash in a computation of the type of parameters of functorial
+  module types; this computation was provided for the purpose of
+  clients using the algebraic form of module types such as :cmd:`Print
+  Module Type`
+  (`#15385 <https://github.com/coq/coq/pull/15385>`_,
+  fixes `#9555 <https://github.com/coq/coq/issues/9555>`_,
+  by Hugo Herbelin).

--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -260,6 +260,7 @@ let do_delta_dom reso sub = subst_dom_delta_resolver sub reso
 let do_delta_codom reso sub = subst_codom_delta_resolver sub reso
 let do_delta_dom_codom reso sub = subst_dom_codom_delta_resolver sub reso
 
+let subst_dom_codom_signature subst = subst_signature subst do_delta_dom_codom
 let subst_signature subst = subst_signature subst do_delta_codom
 let subst_structure subst = subst_structure subst do_delta_codom
 
@@ -532,11 +533,9 @@ let strengthen_and_subst_mb mb mp include_b = match mb.mod_type with
     let subst = map_mp mb.mod_mp mp empty_delta_resolver in
     subst_module subst do_delta_dom_codom mb
 
-let subst_modtype_and_resolver mtb mp =
-  let subst = map_mp mtb.mod_mp mp empty_delta_resolver in
-  let new_delta = subst_dom_codom_delta_resolver subst mtb.mod_delta in
-  let full_subst = map_mp mtb.mod_mp mp new_delta in
-  subst_modtype full_subst do_delta_dom_codom mtb
+let subst_modtype_signature_and_resolver mp_from mp_to sign reso =
+  let subst = map_mp mp_from mp_to empty_delta_resolver in
+  subst_dom_codom_signature subst sign, subst_dom_codom_delta_resolver subst reso
 
 (** {6 Cleaning a module expression from bounded parts }
 

--- a/kernel/modops.mli
+++ b/kernel/modops.mli
@@ -69,8 +69,8 @@ val inline_delta_resolver :
 
 val strengthen_and_subst_mb : module_body -> ModPath.t -> bool -> module_body
 
-val subst_modtype_and_resolver : module_type_body -> ModPath.t ->
-  module_type_body
+val subst_modtype_signature_and_resolver : ModPath.t -> ModPath.t ->
+  module_signature -> delta_resolver -> module_signature * delta_resolver
 
 (** {6 Cleaning a module expression from bounded parts }
 

--- a/test-suite/output/bug_9555.out
+++ b/test-suite/output/bug_9555.out
@@ -1,0 +1,1 @@
+Module Type F = Funsig (X:S) Sig Parameter T : Type. Parameter a : T. End

--- a/test-suite/output/bug_9555.v
+++ b/test-suite/output/bug_9555.v
@@ -1,0 +1,3 @@
+Module Type S. Axiom T : Type. Axiom a : T. End S.
+Module Type F (X : S) := S.
+Print Module Type F.


### PR DESCRIPTION
**Kind:** kernel fix

This is a typing bug in the kernel which affects the algebraic part of the type of parameters of functorial types. The kernel provides this part for printing, or for the extraction, or for other clients. However, I don't see how to exploit the problem from the kernel itself. For instance, even though `Print Module F` below is wrong, we can correctly apply arguments to `F`:
```
Module Type S. Axiom T : Type. Axiom a : T. End S.
Module Type F (X : S) := S.

Print Module Type F. (* Funsig (X:F) Sig Parameter T : Type. Parameter a : T. End *)

Module N : S. Definition T := nat. Definition a := 0. End N.
Module A : F N. Include N. End A.
```

The problem comes from that when defining a module type `F` using an expression `M` with params `X:T`, the self-reference to `M` in `M` must be replaced by `F` (i.e. implicitly by `F X`) but no substitution should be done in the parameters as was done before the PR, resulting in bug #9555.

We fix it by moving the substitution on the body of the functor.

Fixes / closes #9555

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
