### PR TITLE
Fixes #9579 about locally corrupted functorial algebraic form of module type + inconsistencies in taking inline levels into account

### DIFF
--- a/kernel/entries.ml
+++ b/kernel/entries.ml
@@ -115,7 +115,7 @@ type constant_entry =
 type module_struct_entry = Declarations.module_alg_expr
 
 type module_params_entry =
-  (MBId.t * module_struct_entry) list (** older first *)
+  (MBId.t * module_struct_entry * inline) list (** older first *)
 
 type module_type_entry = module_params_entry * module_struct_entry
 

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -287,9 +287,9 @@ let rec translate_mse_funct env ~is_mod mp inl mse = function
       if is_mod then sign,reso
       else subst_modtype_signature_and_resolver (mp_from_mexpr mse) mp sign reso in
     sign, NoFunctor alg, reso, cst
-  |(mbid, ty) :: params ->
+  |(mbid, ty, ty_inl) :: params ->
     let mp_id = MPbound mbid in
-    let mtb, cst = translate_modtype env mp_id inl ([],ty) in
+    let mtb, cst = translate_modtype env mp_id ty_inl ([],ty) in
     let env' = add_module_type mp_id mtb env in
     let sign,alg,reso,cst' = translate_mse_funct env' ~is_mod mp inl mse params in
     let alg' = MoreFunctor (mbid,mtb,alg) in

--- a/test-suite/modules/inlining.v
+++ b/test-suite/modules/inlining.v
@@ -1,0 +1,101 @@
+Module Type T. Parameter Inline(50) t : Type. End T.
+
+Module Type F (X : T). Parameter p : X.t. End F.
+
+Module M. Definition t := nat. End M.
+
+Set Inline Level 49.
+
+Module G
+  (X : F M [inline at level 49])
+  (Y : F M [inline at level 50])
+  (Z : F M) : F M [inline at level 50].
+
+(* M.t should not be inlined in the type of X.p, because 49 < 50 *)
+Goal X.p = X.p.
+match goal with |- _ = _ :> M.t => idtac | _ => fail end.
+Fail match goal with |- _ = _ :> nat => idtac | _ => fail end.
+Abort.
+
+(* M.t should be inlined in the type of Y.p, because 50 >= 50 *)
+Goal Y.p = Y.p.
+Fail match goal with |- _ = _ :> M.t => idtac | _ => fail end.
+match goal with |- _ = _ :> nat => idtac | _ => fail end.
+Abort.
+
+(* M.t should not be inlined in the type of Z.p, because default level < 50 *)
+Goal Z.p = Z.p.
+match goal with |- _ = _ :> M.t => idtac | _ => fail end.
+Fail match goal with |- _ = _ :> nat => idtac | _ => fail end.
+Abort.
+
+Definition p := X.p.
+End G.
+
+Module N. Definition p := 0. End N.
+
+Module P := G N N N.
+
+(* M.t should be inlined in the type of P.p, because 50 >= 50 *)
+Goal P.p = P.p.
+Fail match goal with |- _ = _ :> M.t => idtac | _ => fail end.
+match goal with |- _ = _ :> nat => idtac | _ => fail end.
+Abort.
+
+Set Inline Level 50.
+
+Module G'
+  (X : F M [inline at level 49])
+  (Y : F M [inline at level 50])
+  (Z : F M) : F M [inline at level 49].
+
+(* M.t should be inlined in the type of Z.p, because default level >= 50 *)
+Goal Z.p = Z.p.
+Fail match goal with |- _ = _ :> M.t => idtac | _ => fail end.
+match goal with |- _ = _ :> nat => idtac | _ => fail end.
+Abort.
+
+Definition p := X.p.
+End G'.
+
+Module P' := G' N N N.
+
+(* M.t should not be inlined in the type of P'.p, because 49 < 50 *)
+Goal P'.p = P'.p.
+match goal with |- _ = _ :> M.t => idtac | _ => fail end.
+Fail match goal with |- _ = _ :> nat => idtac | _ => fail end.
+Abort.
+
+Set Inline Level 50.
+
+Module G''
+  (X : F M [inline at level 49])
+  (Y : F M [inline at level 50])
+  (Z : F M) : F M.
+Definition p := X.p.
+End G''.
+
+Module P'' := G'' N N N.
+
+(* M.t should not be inlined in the type of P''.p, because default level >= 50 *)
+Goal P''.p = P''.p.
+Fail match goal with |- _ = _ :> M.t => idtac | _ => fail end.
+match goal with |- _ = _ :> nat => idtac | _ => fail end.
+Abort.
+
+Set Inline Level 49.
+
+Module G'''
+  (X : F M [inline at level 49])
+  (Y : F M [inline at level 50])
+  (Z : F M) : F M.
+Definition p := X.p.
+End G'''.
+
+Module P''' := G''' N N N.
+
+(* M.t should not be inlined in the type of P'.p, because default level < 50 *)
+Goal P'''.p = P'''.p.
+match goal with |- _ = _ :> M.t => idtac | _ => fail end.
+Fail match goal with |- _ = _ :> nat => idtac | _ => fail end.
+Abort.


### PR DESCRIPTION
**Kind:** fix

Depends on #15385 (merged).

Issue #9579 was about a wrong representation of the algebraic form of functors and functorial types, locally in `declaremods.ml`.
    
In related code, inlining levels in module parameters were otherwise treated inconsistently:
- In `Module F (X:T [at inline level 10]) := ...`, the level was discarded (before calling `Mod_typing.translate_module`) except to check possible `<:` constraints (in `Declaremods.check_subtypes`).
 - In `Module F (X:T [at inline level 10]). ... End F.`, the level was taken into account (via `Safe_typing.add_module_parameter`).
    
For the purpose of documentation, note that the `inline level` (or `!`, or `no inline`) has an effect on the immediate module type it is attached to. The effect is visible only if the type is an applied functorial type and, if so, it tells how to inline the argument of the application.

Fixes / closes #9579

- [ ] Added **changelog** (the module type bug is not observable, so probably not needed; as for the inline levels, they are not really documented anyway) 
