### PR TITLE
Tentative mini-update of API for construction/analysis of canonical/user names

### DIFF
--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -100,7 +100,7 @@ let mk_mtb mp sign delta =
 let rec collect_constants_without_body sign mp accu =
   let collect_sf s lab = function
   | SFBconst cb ->
-     let c = Constant.make2 mp lab in
+     let c = Constant.make mp lab in
      if Declareops.constant_has_body cb then s else Cset.add c s
   | SFBmodule msb -> collect_constants_without_body msb.mod_type (MPdot(mp,lab)) s
   | SFBmind _ | SFBmodtype _ -> s in
@@ -143,7 +143,7 @@ and check_module_type env mty =
 
 and check_structure_field env opac mp lab res opacify = function
   | SFBconst cb ->
-      let c = Constant.make2 mp lab in
+      let c = Constant.make mp lab in
       check_constant_declaration env opac c cb (Cset.mem c opacify)
   | SFBmind mib ->
       let kn = KerName.make mp lab in

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -602,14 +602,14 @@ let encode_path ?loc prefix mpdir suffix id =
 
 let raw_string_of_ref ?loc _ = let open GlobRef in function
   | ConstRef cst ->
-      let (mp,id) = Constant.repr2 cst in
+      let (mp,id) = KerName.repr (Constant.user cst) in
       encode_path ?loc "CST" (Some mp) [] (Label.to_id id)
   | IndRef (kn,i) ->
-      let (mp,id) = MutInd.repr2 kn in
+      let (mp,id) = KerName.repr (MutInd.user kn) in
       encode_path ?loc "IND" (Some mp) [Label.to_id id]
         (Id.of_string ("_"^string_of_int i))
   | ConstructRef ((kn,i),j) ->
-      let (mp,id) = MutInd.repr2 kn in
+      let (mp,id) = KerName.repr (MutInd.user kn) in
       encode_path ?loc "CSTR" (Some mp)
         [Label.to_id id;Id.of_string ("_"^string_of_int i)]
         (Id.of_string ("_"^string_of_int j))

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -1445,4 +1445,16 @@ let env_rel_context_chop k env =
   ctx1
 end
 
+let rec canonize_globals c =
+  match Constr.kind c with
+  | Const (cst,u) -> mkConstU (Constant.canonize cst,u)
+  | Ind ((mind,i),u) -> mkIndU ((MutInd.canonize mind,i),u)
+  | Construct (((mind,i),j),u) -> mkConstructU (((MutInd.canonize mind,i),j),u)
+  | Prod (na,t,ct) -> mkProd (na,canonize_globals t, canonize_globals ct)
+  | Lambda (na,t,ct) -> mkLambda (na, canonize_globals t, canonize_globals ct)
+  | LetIn (na,b,t,ct) -> mkLetIn (na, canonize_globals b, canonize_globals t, canonize_globals ct)
+  | App (ct,l) -> mkApp (canonize_globals ct,Array.Smart.map canonize_globals l)
+  | Proj(p,c) -> mkProj (Projection.map MutInd.canonize p, canonize_globals c)
+  | _ -> c
+
 include Internal

--- a/engine/termops.mli
+++ b/engine/termops.mli
@@ -199,6 +199,9 @@ val adjust_app_list_size : constr -> constr list -> constr -> constr list ->
 val adjust_app_array_size : constr -> constr array -> constr -> constr array ->
   (constr * constr array * constr * constr array)
 
+(** Replace the global references of a term by their canonical form *)
+val canonize_globals : Constr.t -> Constr.t
+
 (** name contexts *)
 type names_context = Name.t list
 val add_name : Name.t -> names_context -> names_context

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -377,38 +377,38 @@ let keymap_find key map =
 let notations_key_table = ref (KeyMap.empty : (bool * notation_rule) list KeyMap.t)
 
 let glob_prim_constr_key c = match DAst.get c with
-  | GRef (ref, _) -> Some (canonical_gr ref)
+  | GRef (ref, _) -> Some (canonize_global ref)
   | GApp (c, _) ->
     begin match DAst.get c with
-    | GRef (ref, _) -> Some (canonical_gr ref)
+    | GRef (ref, _) -> Some (canonize_global ref)
     | _ -> None
     end
-  | GProj ((cst,_), _, _) -> Some (canonical_gr (GlobRef.ConstRef cst))
+  | GProj ((cst,_), _, _) -> Some (canonize_global (GlobRef.ConstRef cst))
   | _ -> None
 
 let glob_constr_keys c = match DAst.get c with
   | GApp (c, _) ->
     begin match DAst.get c with
-    | GRef (ref, _) -> [RefKey (canonical_gr ref); Oth]
+    | GRef (ref, _) -> [RefKey (canonize_global ref); Oth]
     | _ -> [Oth]
     end
-  | GProj ((cst,_), _, _) -> [RefKey (canonical_gr (GlobRef.ConstRef cst))]
-  | GRef (ref,_) -> [RefKey (canonical_gr ref)]
+  | GProj ((cst,_), _, _) -> [RefKey (canonize_global (GlobRef.ConstRef cst))]
+  | GRef (ref,_) -> [RefKey (canonize_global ref)]
   | _ -> [Oth]
 
 let cases_pattern_key c = match DAst.get c with
-  | PatCstr (ref,_,_) -> RefKey (canonical_gr (GlobRef.ConstructRef ref))
+  | PatCstr (ref,_,_) -> RefKey (canonize_global (GlobRef.ConstructRef ref))
   | _ -> Oth
 
 let notation_constr_key = function (* Rem: NApp(NRef ref,[]) stands for @ref *)
-  | NApp (NRef (ref,_),args) -> RefKey(canonical_gr ref), AppBoundedNotation (List.length args)
-  | NProj ((cst,_),args,_) -> RefKey(canonical_gr (GlobRef.ConstRef cst)), AppBoundedNotation (List.length args + 1)
+  | NApp (NRef (ref,_),args) -> RefKey(canonize_global ref), AppBoundedNotation (List.length args)
+  | NProj ((cst,_),args,_) -> RefKey(canonize_global (GlobRef.ConstRef cst)), AppBoundedNotation (List.length args + 1)
   | NList (_,_,NApp (NRef (ref,_),args),_,_)
   | NBinderList (_,_,NApp (NRef (ref,_),args),_,_) ->
-      RefKey (canonical_gr ref), AppBoundedNotation (List.length args)
-  | NRef (ref,_) -> RefKey(canonical_gr ref), NotAppNotation
+      RefKey (canonize_global ref), AppBoundedNotation (List.length args)
+  | NRef (ref,_) -> RefKey(canonize_global ref), NotAppNotation
   | NApp (NList (_,_,NApp (NRef (ref,_),args),_,_), args') ->
-      RefKey (canonical_gr ref), AppBoundedNotation (List.length args + List.length args')
+      RefKey (canonize_global ref), AppBoundedNotation (List.length args + List.length args')
   | NApp (NList (_,_,NApp (_,args),_,_), args') ->
       Oth, AppBoundedNotation (List.length args + List.length args')
   | NApp (_,args) -> Oth, AppBoundedNotation (List.length args)
@@ -1661,7 +1661,7 @@ let uninterp_cases_pattern_notations c =
   filter_also_for_pattern (keymap_find (cases_pattern_key c) !notations_key_table)
 
 let uninterp_ind_pattern_notations ind =
-  filter_also_for_pattern (keymap_find (RefKey (canonical_gr (GlobRef.IndRef ind))) !notations_key_table)
+  filter_also_for_pattern (keymap_find (RefKey (canonize_global (GlobRef.IndRef ind))) !notations_key_table)
 
 let has_active_parsing_rule_in_scope ntn sc =
   try

--- a/interp/reserve.ml
+++ b/interp/reserve.ml
@@ -69,10 +69,10 @@ let reserve_table = Summary.ref Id.Map.empty ~name:"reserved-type"
 let reserve_revtable = Summary.ref KeyMap.empty ~name:"reserved-type-rev"
 
 let notation_constr_key = function (* Rem: NApp(NRef ref,[]) stands for @ref *)
-  | NApp (NRef (ref,_),args) -> RefKey(canonical_gr ref), Some (List.length args)
+  | NApp (NRef (ref,_),args) -> RefKey(canonize_global ref), Some (List.length args)
   | NList (_,_,NApp (NRef (ref,_),args),_,_)
-  | NBinderList (_,_,NApp (NRef (ref,_),args),_,_) -> RefKey (canonical_gr ref), Some (List.length args)
-  | NRef (ref,_) -> RefKey(canonical_gr ref), None
+  | NBinderList (_,_,NApp (NRef (ref,_),args),_,_) -> RefKey (canonize_global ref), Some (List.length args)
+  | NRef (ref,_) -> RefKey(canonize_global ref), None
   | _ -> Oth, None
 
 let add_reserved_type (id,t) =
@@ -98,7 +98,7 @@ let declare_reserved_type idl t =
 let find_reserved_type id = Id.Map.find (root_of_id id) !reserve_table
 
 let constr_key c =
-  try RefKey (canonical_gr (fst @@ Constr.destRef (fst (Constr.decompose_app c))))
+  try RefKey (canonize_global (fst @@ Constr.destRef (fst (Constr.decompose_app c))))
   with Constr.DestKO -> Oth
 
 let revert_reserved_type t =

--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -191,16 +191,16 @@ let kn_of_deltas resolve1 resolve2 kn =
   if kn' == kn then kn_of_delta resolve2 kn else kn'
 
 let constant_of_delta_kn resolve kn =
-  Constant.make kn (kn_of_delta resolve kn)
+  Constant.of_kn ~user:kn (kn_of_delta resolve kn)
 
 let constant_of_deltas_kn resolve1 resolve2 kn =
-  Constant.make kn (kn_of_deltas resolve1 resolve2 kn)
+  Constant.of_kn ~user:kn (kn_of_deltas resolve1 resolve2 kn)
 
 let mind_of_delta_kn resolve kn =
-  MutInd.make kn (kn_of_delta resolve kn)
+  MutInd.of_kn ~user:kn (kn_of_delta resolve kn)
 
 let mind_of_deltas_kn resolve1 resolve2 kn =
-  MutInd.make kn (kn_of_deltas resolve1 resolve2 kn)
+  MutInd.of_kn ~user:kn (kn_of_deltas resolve1 resolve2 kn)
 
 let inline_of_delta inline resolver =
   match inline with
@@ -284,7 +284,7 @@ let subst_mind sub mind =
     let knc' =
       progress (kn_of_delta resolve) (if user then knu else knc) ~orelse:knc
     in
-    MutInd.make knu knc'
+    MutInd.of_kn ~user:knu knc'
   with No_subst -> mind
 
 let subst_ind sub (ind,i as indi) =
@@ -308,12 +308,12 @@ let subst_con0 sub cst =
   match search_delta_inline resolve knu knc with
     | Some t ->
       (* In case of inlining, discard the canonical part (cf #2608) *)
-      Constant.make1 knu, Some t
+      Constant.of_kn knu, Some t
     | None ->
       let knc' =
         progress (kn_of_delta resolve) (if user then knu else knc) ~orelse:knc
       in
-      let cst' = Constant.make knu knc' in
+      let cst' = Constant.of_kn ~user:knu knc' in
       cst', None
 
 let subst_con sub cst =

--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -275,7 +275,7 @@ let progress f x ~orelse =
   if y != x then y else orelse
 
 let subst_mind sub mind =
-  let mpu,l = MutInd.repr2 mind in
+  let mpu,l = KerName.repr (MutInd.user mind) in
   let mpc = KerName.modpath (MutInd.canonical mind) in
   try
     let mpu,mpc,resolve,user = subst_dual_mp sub mpu mpc in
@@ -300,7 +300,7 @@ let subst_pind sub (ind,u) =
   (subst_ind sub ind, u)
 
 let subst_con0 sub cst =
-  let mpu,l = Constant.repr2 cst in
+  let mpu,l = KerName.repr (Constant.user cst) in
   let mpc = KerName.modpath (Constant.canonical cst) in
   let mpu,mpc,resolve,user = subst_dual_mp sub mpu mpc in
   let knu = KerName.make mpu l in

--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -502,6 +502,8 @@ module KerPair = struct
   let label kp = KerName.label (user kp)
   let modpath kp = KerName.modpath (user kp)
 
+  let canonize kp = Same (canonical kp)
+
   let change_label kp lbl =
     let (mp1,l1) = KerName.repr (user kp)
     and (mp2,l2) = KerName.repr (canonical kp) in

--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -495,10 +495,13 @@ module KerPair = struct
     | Dual (kn,_) -> kn
 
   let same kn = Same kn
-  let make knu knc = if KerName.equal knu knc then Same knc else Dual (knu,knc)
+  let make_pair knu knc = if KerName.equal knu knc then Same knc else Dual (knu,knc)
 
-  let make1 = same
-  let make2 mp l = same (KerName.make mp l)
+  let of_kn ?user knc = match user with None -> same knc | Some knu -> make_pair knu knc
+  let make ?user mpc l =
+    let knc = KerName.make mpc l in
+    match user with None -> same knc | Some mpu -> make_pair (KerName.make mpu l) knc
+
   let label kp = KerName.label (user kp)
   let modpath kp = KerName.modpath (user kp)
 
@@ -513,7 +516,7 @@ module KerPair = struct
     else
       let kn = KerName.make mp1 lbl in
       if mp1 == mp2 then same kn
-      else make kn (KerName.make mp2 lbl)
+      else Dual (kn, KerName.make mp2 lbl)
 
   let to_string kp = KerName.to_string (user kp)
   let print kp = str (to_string kp)
@@ -570,7 +573,7 @@ module KerPair = struct
       type u = KerName.t -> KerName.t
       let hashcons hkn = function
         | Same kn -> Same (hkn kn)
-        | Dual (knu,knc) -> make (hkn knu) (hkn knc)
+        | Dual (knu,knc) -> Dual (hkn knu, hkn knc)
       let eq x y = (* physical comparison on subterms *)
         x == y ||
         match x,y with

--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -503,6 +503,7 @@ module KerPair = struct
   let modpath kp = KerName.modpath (user kp)
 
   let canonize kp = Same (canonical kp)
+  let is_canonical = function Same _ -> true | Dual _ -> false
 
   let change_label kp lbl =
     let (mp1,l1) = KerName.repr (user kp)

--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -499,7 +499,6 @@ module KerPair = struct
 
   let make1 = same
   let make2 mp l = same (KerName.make mp l)
-  let repr2 kp = KerName.repr (user kp)
   let label kp = KerName.label (user kp)
   let modpath kp = KerName.modpath (user kp)
 

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -392,9 +392,10 @@ sig
   val label : t -> Label.t
   (** Shortcut for [KerName.label (user ...)] *)
 
-  (** Normalization *)
+  (** Normalization, queries *)
 
   val canonize : t -> t
+  val is_canonical : t -> bool
 
   (** Comparisons *)
 
@@ -467,9 +468,10 @@ sig
   val label : t -> Label.t
   (** Shortcut for [KerName.label (user ...)] *)
 
-  (** Normalization *)
+  (** Normalization, queries *)
 
   val canonize : t -> t
+  val is_canonical : t -> bool
 
   (** Comparisons *)
 

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -392,6 +392,10 @@ sig
   val label : t -> Label.t
   (** Shortcut for [KerName.label (user ...)] *)
 
+  (** Normalization *)
+
+  val canonize : t -> t
+
   (** Comparisons *)
 
   include QNameS with type t := t
@@ -462,6 +466,10 @@ sig
 
   val label : t -> Label.t
   (** Shortcut for [KerName.label (user ...)] *)
+
+  (** Normalization *)
+
+  val canonize : t -> t
 
   (** Comparisons *)
 

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -386,9 +386,6 @@ sig
   val user : t -> KerName.t
   val canonical : t -> KerName.t
 
-  val repr2 : t -> ModPath.t * Label.t
-  (** Shortcut for [KerName.repr (user ...)] *)
-
   val modpath : t -> ModPath.t
   (** Shortcut for [KerName.modpath (user ...)] *)
 
@@ -459,9 +456,6 @@ sig
 
   val user : t -> KerName.t
   val canonical : t -> KerName.t
-
-  val repr2 : t -> ModPath.t * Label.t
-  (** Shortcut for [KerName.repr (user ...)] *)
 
   val modpath : t -> ModPath.t
   (** Shortcut for [KerName.modpath (user ...)] *)

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -372,14 +372,15 @@ sig
 
   (** Constructors *)
 
-  val make : KerName.t -> KerName.t -> t
-  (** Builds a constant name from a user and a canonical kernel name. *)
+  val make : ?user:ModPath.t -> ModPath.t -> Label.t -> t
+  (** Builds a constant name from a user and canonical module
+      paths and from a label. If the user path is not provided, it is
+      taken to be the same as the canonical one. *)
 
-  val make1 : KerName.t -> t
-  (** Special case of [make] where the user name is canonical.  *)
-
-  val make2 : ModPath.t -> Label.t -> t
-  (** Shortcut for [(make1 (KerName.make2 ...))] *)
+  val of_kn : ?user:KerName.t -> KerName.t -> t
+  (** Builds a constant name from a user and canonical kernel
+      name. If the user name is not provided, it is taken to be the
+      same as the canonical one. *)
 
   (** Projections *)
 
@@ -448,14 +449,15 @@ sig
 
   (** Constructors *)
 
-  val make : KerName.t -> KerName.t -> t
-  (** Builds a mutual inductive name from a user and a canonical kernel name. *)
+  val make : ?user:ModPath.t -> ModPath.t -> Label.t -> t
+  (** Builds a mutual inductive name from a user and canonical module
+      paths and from a label. If the user path is not provided, it is
+      taken to be the same as the canonical one. *)
 
-  val make1 : KerName.t -> t
-  (** Special case of [make] where the user name is canonical.  *)
-
-  val make2 : ModPath.t -> Label.t -> t
-  (** Shortcut for [(make1 (KerName.make2 ...))] *)
+  val of_kn : ?user:KerName.t -> KerName.t -> t
+  (** Builds a mutual inductive name from a user and canonical kernel
+      name. If the user name is not provided, it is taken to be the
+      same as the canonical one. *)
 
   (** Projections *)
 

--- a/kernel/nativecode.ml
+++ b/kernel/nativecode.ml
@@ -2140,7 +2140,7 @@ let compile_constant_field env con acc cb =
     gl@acc
 
 let compile_mind_field mp l acc mb =
-  let mind = MutInd.make2 mp l in
+  let mind = MutInd.make mp l in
   compile_mind mb mind acc
 
 let mk_open s = Gopen s

--- a/kernel/nativelibrary.ml
+++ b/kernel/nativelibrary.ml
@@ -27,7 +27,7 @@ let rec translate_mod mp env mod_expr acc =
 and translate_field mp env acc (l,x) =
   match x with
   | SFBconst cb ->
-     let con = Constant.make2 mp l in
+     let con = Constant.make mp l in
      (debug_native_compiler (fun () ->
         let msg = Printf.sprintf "Compiling constant %s..." (Constant.to_string con) in
         Pp.str msg));

--- a/kernel/primred.ml
+++ b/kernel/primred.ml
@@ -98,7 +98,7 @@ let get_float_type env =
 let get_cmp_type env =
   match env.retroknowledge.retro_cmp with
   | Some (((mindcmp,_),_),_,_) ->
-     Constant.make (MutInd.user mindcmp) (MutInd.canonical mindcmp)
+     Constant.of_kn ~user:(MutInd.user mindcmp) (MutInd.canonical mindcmp)
   | None -> anomaly Pp.(str"Reduction of primitive: comparison not registered")
 
 let get_bool_constructors env =

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -852,7 +852,7 @@ let export_private_constants eff senv =
   exported, senv
 
 let add_constant l decl senv =
-  let kn = Constant.make2 senv.modpath l in
+  let kn = Constant.make senv.modpath l in
   let senv, cb =
       match decl with
       | OpaqueEntry ce ->
@@ -943,7 +943,7 @@ let check_constraints uctx = function
 | Entries.Monomorphic_entry -> true
 
 let add_private_constant l uctx decl senv : (Constant.t * private_constants) * safe_environment =
-  let kn = Constant.make2 senv.modpath l in
+  let kn = Constant.make senv.modpath l in
   let senv = push_context_set ~strict:true uctx senv in
     let cb =
       match decl with
@@ -995,7 +995,7 @@ let add_checked_mind kn mib senv =
 
 let add_mind l mie senv =
   let () = check_mind mie l in
-  let kn = MutInd.make2 senv.modpath l in
+  let kn = MutInd.make senv.modpath l in
   let sec_univs = Option.map Section.all_poly_univs  senv.sections
   in
   let mib = Indtypes.check_inductive senv.env ~sec_univs kn mie in

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -43,7 +43,7 @@ type namedmodule =
    constructors *)
 
 let add_mib_nameobjects mp l mib map =
-  let ind = MutInd.make2 mp l in
+  let ind = MutInd.make mp l in
   let add_mip_nameobjects j oib map =
     let ip = (ind,j) in
     let map =
@@ -155,7 +155,7 @@ let check_inductive cst env mp1 l info1 mp2 mib2 spec2 subst1 subst2 reso1 reso2
       let cst = check_inductive_type cst p2.mind_typename ty1 ty2 in
         cst
   in
-  let mind = MutInd.make1 kn1 in
+  let mind = MutInd.of_kn kn1 in
   let check_cons_types i cst p1 p2 =
     Array.fold_left3
       (fun cst id t1 t2 -> check_conv (NotConvertibleConstructorField id) cst
@@ -183,7 +183,7 @@ let check_inductive cst env mp1 l info1 mp2 mib2 spec2 subst1 subst2 reso1 reso2
     let kn2' = kn_of_delta reso2 kn2 in
     if KerName.equal kn2 kn2' ||
        MutInd.CanOrd.equal (mind_of_delta_kn reso1 kn1)
-                    (subst_mind subst2 (MutInd.make kn2 kn2'))
+                    (subst_mind subst2 (MutInd.of_kn ~user:kn2 kn2'))
     then ()
     else error NotEqualInductiveAliases
   end;

--- a/kernel/vmbytegen.ml
+++ b/kernel/vmbytegen.ml
@@ -889,9 +889,9 @@ let compile_constant_body ~fail_on_error env univs = function
   | Def body ->
       let instance_size = Univ.AbstractContext.size (Declareops.universes_context univs) in
       match kind body with
-        | Const (kn',u) when is_univ_copy instance_size u ->
+        | Const (cst,u) when is_univ_copy instance_size u ->
             (* we use the canonical name of the constant*)
-            let con= Constant.make1 (Constant.canonical kn') in
+            let con = Constant.canonize cst in
               Some (BCalias (get_alias env con))
         | _ ->
             let sigma _ = assert false in
@@ -900,4 +900,4 @@ let compile_constant_body ~fail_on_error env univs = function
 
 (* Shortcut of the previous function used during module strengthening *)
 
-let compile_alias kn = BCalias (Constant.make1 (Constant.canonical kn))
+let compile_alias cst = BCalias (Constant.canonize cst)

--- a/library/coqlib.ml
+++ b/library/coqlib.ml
@@ -151,11 +151,11 @@ let datatypes_module = MPfile (make_dir datatypes_module_name)
 
 (** Identity *)
 
-let id = Constant.make2 datatypes_module @@ Label.make "idProp"
-let type_of_id = Constant.make2 datatypes_module @@ Label.make "IDProp"
+let id = Constant.make datatypes_module @@ Label.make "idProp"
+let type_of_id = Constant.make datatypes_module @@ Label.make "IDProp"
 
 (** Natural numbers *)
-let nat_kn = MutInd.make2 datatypes_module @@ Label.make "nat"
+let nat_kn = MutInd.make datatypes_module @@ Label.make "nat"
 let nat_path = Libnames.make_path (make_dir datatypes_module_name) (Id.of_string "nat")
 
 let glob_nat = GlobRef.IndRef (nat_kn,0)
@@ -166,7 +166,7 @@ let glob_O = GlobRef.ConstructRef path_of_O
 let glob_S = GlobRef.ConstructRef path_of_S
 
 (** Booleans *)
-let bool_kn = MutInd.make2 datatypes_module @@ Label.make "bool"
+let bool_kn = MutInd.make datatypes_module @@ Label.make "bool"
 
 let glob_bool = GlobRef.IndRef (bool_kn,0)
 
@@ -176,13 +176,13 @@ let glob_true  = GlobRef.ConstructRef path_of_true
 let glob_false  = GlobRef.ConstructRef path_of_false
 
 (** Equality *)
-let eq_kn = MutInd.make2 logic_module @@ Label.make "eq"
+let eq_kn = MutInd.make logic_module @@ Label.make "eq"
 let glob_eq = GlobRef.IndRef (eq_kn,0)
 
-let identity_kn = MutInd.make2 datatypes_module @@ Label.make "identity"
+let identity_kn = MutInd.make datatypes_module @@ Label.make "identity"
 let glob_identity = GlobRef.IndRef (identity_kn,0)
 
-let jmeq_kn = MutInd.make2 jmeq_module @@ Label.make "JMeq"
+let jmeq_kn = MutInd.make jmeq_module @@ Label.make "JMeq"
 let glob_jmeq = GlobRef.IndRef (jmeq_kn,0)
 
 (* Sigma data *)

--- a/library/globnames.ml
+++ b/library/globnames.ml
@@ -56,11 +56,23 @@ let subst_global subst ref = match ref with
       let c' = subst_constructor subst c in
       if c'==c then ref,None else ConstructRef c', None
 
-let canonical_gr = function
+let canonize_global = function
   | ConstRef con -> ConstRef(Constant.canonize con)
   | IndRef (mind,i) -> IndRef(MutInd.canonize mind,i)
   | ConstructRef ((mind,i),j )-> ConstructRef((MutInd.canonize mind,i),j)
   | VarRef id -> VarRef id
+
+let canonize_global_opt = function
+  | ConstRef cst ->
+    if Constant.is_canonical cst then None
+    else Some (ConstRef (Constant.canonize cst))
+  | IndRef (mind,i) ->
+    if MutInd.is_canonical mind then None
+    else Some (IndRef (MutInd.canonize mind, i))
+  | ConstructRef ((mind,i),j) ->
+    if MutInd.is_canonical mind then None
+    else Some (ConstructRef ((MutInd.canonize mind, i),j))
+  | VarRef _ -> None
 
 let global_of_constr c = match kind c with
   | Const (sp,u) -> ConstRef sp

--- a/library/globnames.ml
+++ b/library/globnames.ml
@@ -57,9 +57,9 @@ let subst_global subst ref = match ref with
       if c'==c then ref,None else ConstructRef c', None
 
 let canonical_gr = function
-  | ConstRef con -> ConstRef(Constant.make1 (Constant.canonical con))
-  | IndRef (kn,i) -> IndRef(MutInd.make1(MutInd.canonical kn),i)
-  | ConstructRef ((kn,i),j )-> ConstructRef((MutInd.make1(MutInd.canonical kn),i),j)
+  | ConstRef con -> ConstRef(Constant.canonize con)
+  | IndRef (mind,i) -> IndRef(MutInd.canonize mind,i)
+  | ConstructRef ((mind,i),j )-> ConstructRef((MutInd.canonize mind,i),j)
   | VarRef id -> VarRef id
 
 let global_of_constr c = match kind c with

--- a/library/globnames.mli
+++ b/library/globnames.mli
@@ -24,7 +24,11 @@ val isConstRef : GlobRef.t -> bool
 val isIndRef : GlobRef.t -> bool
 val isConstructRef : GlobRef.t -> bool
 
-val canonical_gr : GlobRef.t -> GlobRef.t
+val canonize_global : GlobRef.t -> GlobRef.t
+(** Turn a global reference into its canonical representative *)
+
+val canonize_global_opt : GlobRef.t -> GlobRef.t option
+(** Returns the canonical representative of a global reference if not already canonical *)
 
 val destVarRef : GlobRef.t -> variable
 val destConstRef : GlobRef.t -> Constant.t

--- a/plugins/cc/ccalgo.ml
+++ b/plugins/cc/ccalgo.ml
@@ -482,14 +482,14 @@ let rec canonize_name c =
   let c = EConstr.Unsafe.to_constr c in
   let func c = canonize_name (EConstr.of_constr c) in
     match Constr.kind c with
-      | Const (kn,u) ->
-          let canon_const = Constant.make1 (Constant.canonical kn) in
+      | Const (cst,u) ->
+          let canon_const = Constant.canonize cst in
             (mkConstU (canon_const,u))
-      | Ind ((kn,i),u) ->
-          let canon_mind = MutInd.make1 (MutInd.canonical kn) in
+      | Ind ((mind,i),u) ->
+          let canon_mind = MutInd.canonize mind in
             (mkIndU ((canon_mind,i),u))
-      | Construct (((kn,i),j),u) ->
-          let canon_mind = MutInd.make1 (MutInd.canonical kn) in
+      | Construct (((mind,i),j),u) ->
+          let canon_mind = MutInd.canonize mind in
             mkConstructU (((canon_mind,i),j),u)
       | Prod (na,t,ct) ->
           mkProd (na,func t, func ct)
@@ -500,8 +500,7 @@ let rec canonize_name c =
       | App (ct,l) ->
           mkApp (func ct,Array.Smart.map func l)
       | Proj(p,c) ->
-        let p' = Projection.map (fun kn ->
-          MutInd.make1 (MutInd.canonical kn)) p in
+        let p' = Projection.map MutInd.canonize p in
           (mkProj (p', func c))
       | _ -> c
 

--- a/plugins/cc/ccalgo.ml
+++ b/plugins/cc/ccalgo.ml
@@ -477,32 +477,8 @@ let new_representative typ =
    class_type=typ;
    functions=PafMap.empty}
 
-
-let rec canonize_name c =
-  let c = EConstr.Unsafe.to_constr c in
-  let func c = canonize_name (EConstr.of_constr c) in
-    match Constr.kind c with
-      | Const (cst,u) ->
-          let canon_const = Constant.canonize cst in
-            (mkConstU (canon_const,u))
-      | Ind ((mind,i),u) ->
-          let canon_mind = MutInd.canonize mind in
-            (mkIndU ((canon_mind,i),u))
-      | Construct (((mind,i),j),u) ->
-          let canon_mind = MutInd.canonize mind in
-            mkConstructU (((canon_mind,i),j),u)
-      | Prod (na,t,ct) ->
-          mkProd (na,func t, func ct)
-      | Lambda (na,t,ct) ->
-          mkLambda (na, func t,func ct)
-      | LetIn (na,b,t,ct) ->
-          mkLetIn (na, func b,func t,func ct)
-      | App (ct,l) ->
-          mkApp (func ct,Array.Smart.map func l)
-      | Proj(p,c) ->
-        let p' = Projection.map MutInd.canonize p in
-          (mkProj (p', func c))
-      | _ -> c
+let canonize_name c =
+  Termops.canonize_globals (EConstr.Unsafe.to_constr c)
 
 (* rebuild a term from a pattern and a substitution *)
 

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -67,7 +67,7 @@ let rec decompose_term env sigma t =
     | Construct c ->
         let (((mind,i_ind),i_con),u)= c in
         let u = EInstance.kind sigma u in
-        let canon_mind = MutInd.make1 (MutInd.canonical mind) in
+        let canon_mind = MutInd.canonize mind in
         let canon_ind = canon_mind,i_ind in
         let (oib,_)=Global.lookup_inductive (canon_ind) in
         let nargs=constructor_nallargs env (canon_ind,i_con) in
@@ -77,15 +77,14 @@ let rec decompose_term env sigma t =
     | Ind c ->
         let (mind,i_ind),u = c in
         let u = EInstance.kind sigma u in
-        let canon_mind = MutInd.make1 (MutInd.canonical mind) in
+        let canon_mind = MutInd.canonize mind in
         let canon_ind = canon_mind,i_ind in ATerm.mkSymb (Constr.mkIndU (canon_ind,u))
-    | Const (c,u) ->
+    | Const (cst,u) ->
         let u = EInstance.kind sigma u in
-        let canon_const = Constant.make1 (Constant.canonical c) in
+        let canon_const = Constant.canonize cst in
           ATerm.mkSymb (Constr.mkConstU (canon_const,u))
     | Proj (p, c) ->
-        let canon_mind kn = MutInd.make1 (MutInd.canonical kn) in
-        let p' = Projection.map canon_mind p in
+        let p' = Projection.map MutInd.canonize p in
         let c = Retyping.expand_projection env sigma p' c [] in
         decompose_term env sigma c
     | _ ->

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -747,7 +747,7 @@ let show_extraction ~pstate =
     let ast, ty = extract_constr env sigma t in
     let mp = Lib.current_mp () in
     let l = Label.of_id (Declare.Proof.get_name pstate) in
-    let fake_ref = GlobRef.ConstRef (Constant.make2 mp l) in
+    let fake_ref = GlobRef.ConstRef (Constant.make mp l) in
     let decl = Dterm (fake_ref, ast, ty) in
     print_one_decl [] mp decl
   in

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -515,7 +515,7 @@ and extract_really_ind env kn mib =
           | {binder_name=Anonymous}::l, typ::typs ->
               None :: (select_fields (i+1) l typs)
           | {binder_name=Name id}::l, typ::typs ->
-              let knp = Constant.make2 mp (Label.of_id id) in
+              let knp = Constant.make mp (Label.of_id id) in
               (* Is it safe to use [id] for projections [foo.id] ? *)
               if List.for_all ((==) Keep) (type2signature env typ)
               then projs := Cset.add knp !projs;

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -415,12 +415,12 @@ and extract_really_ind env kn mib =
     let equiv =
       if lang () != Ocaml ||
          (not (modular ()) && at_toplevel (MutInd.modpath kn)) ||
-         KerName.equal (MutInd.canonical kn) (MutInd.user kn)
+         MutInd.is_canonical kn
       then
         NoEquiv
       else
         begin
-          ignore (extract_ind env (MutInd.make1 (MutInd.canonical kn)));
+          ignore (extract_ind env (MutInd.canonize kn));
           Equiv (MutInd.canonical kn)
         end
     in

--- a/plugins/extraction/mlutil.ml
+++ b/plugins/extraction/mlutil.ml
@@ -1534,7 +1534,7 @@ let inline_test r t =
 
 let con_of_string s =
   let d, id = Libnames.split_dirpath (dirpath_of_string s) in
-  Constant.make2 (ModPath.MPfile d) (Label.of_id id)
+  Constant.make (ModPath.MPfile d) (Label.of_id id)
 
 let manual_inline_set =
   List.fold_right (fun x -> Cset_env.add (con_of_string x))

--- a/plugins/extraction/modutil.ml
+++ b/plugins/extraction/modutil.ml
@@ -41,7 +41,7 @@ let se_iter do_decl do_spec do_mp =
         let mp_w =
           List.fold_left (fun mp l -> MPdot(mp,Label.of_id l)) mp_mt idl'
         in
-        let r = GlobRef.ConstRef (Constant.make2 mp_w (Label.of_id l')) in
+        let r = GlobRef.ConstRef (Constant.make mp_w (Label.of_id l')) in
         mt_iter mt; do_spec (Stype(r,l,Some t))
     | MTwith (mt,ML_With_module(idl,mp))->
         let mp_mt = msid_of_mt mt in
@@ -117,7 +117,7 @@ let ind_iter_references do_term do_cons do_type kn ind =
     do_type (GlobRef.IndRef ip);
     if lang () == Ocaml then
       (match ind.ind_equiv with
-         | Miniml.Equiv kne -> do_type (GlobRef.IndRef (MutInd.make1 kne, snd ip));
+         | Miniml.Equiv kne -> do_type (GlobRef.IndRef (MutInd.of_kn kne, snd ip));
          | _ -> ());
     Array.iteri (fun j -> cons_iter (ip,j+1)) p.ip_types
   in

--- a/plugins/extraction/ocaml.ml
+++ b/plugins/extraction/ocaml.ml
@@ -479,7 +479,7 @@ let pp_Dfix (rv,c,t) =
 let pp_equiv param_list name = function
   | NoEquiv, _ -> mt ()
   | Equiv kn, i ->
-      str " = " ++ pp_parameters param_list ++ pp_global Type (GlobRef.IndRef (MutInd.make1 kn,i))
+      str " = " ++ pp_parameters param_list ++ pp_global Type (GlobRef.IndRef (MutInd.of_kn kn,i))
   | RenEquiv ren, _  ->
       str " = " ++ pp_parameters param_list ++ str (ren^".") ++ name
 
@@ -680,7 +680,7 @@ and pp_module_type params = function
       let mp_w =
         List.fold_left (fun mp l -> MPdot(mp,Label.of_id l)) mp_mt idl'
       in
-      let r = GlobRef.ConstRef (Constant.make2 mp_w (Label.of_id l)) in
+      let r = GlobRef.ConstRef (Constant.make mp_w (Label.of_id l)) in
       push_visible mp_mt [];
       let pp_w = str " with type " ++ ids ++ pp_global Type r in
       pop_visible();

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -36,9 +36,9 @@ let occur_kn_in_ref kn = let open GlobRef in function
   | ConstRef _ | VarRef _ -> false
 
 let repr_of_r = let open GlobRef in function
-  | ConstRef kn -> Constant.repr2 kn
+  | ConstRef kn -> KerName.repr (Constant.user kn)
   | IndRef (kn,_)
-  | ConstructRef ((kn,_),_) -> MutInd.repr2 kn
+  | ConstructRef ((kn,_),_) -> KerName.repr (MutInd.user kn)
   | VarRef v -> KerName.repr (Lib.make_kn v)
 
 let modpath_of_r r =
@@ -288,7 +288,7 @@ let safe_pr_long_global r =
   try Printer.pr_global r
   with Not_found -> match r with
     | GlobRef.ConstRef kn ->
-        let mp,l = Constant.repr2 kn in
+        let mp,l = KerName.repr (Constant.user kn) in
         str ((ModPath.to_string mp)^"."^(Label.to_string l))
     | _ -> assert false
 

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -1215,7 +1215,7 @@ let get_funs_constant mp =
         (fun i na ->
           match na.Context.binder_name with
           | Name id ->
-            let const = Constant.make2 mp (Label.of_id id) in
+            let const = Constant.make mp (Label.of_id id) in
             (const, i)
           | Anonymous -> CErrors.anomaly (Pp.str "Anonymous fix."))
         na
@@ -2134,7 +2134,7 @@ let make_graph (f_ref : GlobRef.t) =
     (* We register the infos *)
     List.iter
       (fun {Vernacexpr.fname = {CAst.v = id}} ->
-        add_Function false (Constant.make2 mp (Label.of_id id)))
+        add_Function false (Constant.make mp (Label.of_id id)))
       expr_list
 
 (* *************** statically typed entrypoints ************************* *)

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -1447,7 +1447,7 @@ let open_new_goal ~lemma build_proof sigma using_lemmas ref_ goal_name
       | GlobRef.ConstRef c -> is_opaque_constant c
       | _ -> anomaly ~label:"equation_lemma" (Pp.str "not a constant.")
     in
-    let lemma = mkConst (Names.Constant.make1 (Lib.make_kn na)) in
+    let lemma = mkConst (Names.Constant.of_kn (Lib.make_kn na)) in
     ref_ := Value (EConstr.Unsafe.to_constr lemma);
     let lid = ref [] in
     let h_num = ref (-1) in

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -395,7 +395,7 @@ let pirrel_rewrite ?(under=false) ?(map_redex=id_map_redex) pred rdx rdx_ty new_
       let elim, _ = EConstr.destConst sigma elim in
       let mp,l = KerName.repr (Constant.canonical elim) in
       let l' = Label.of_id (Nameops.add_suffix (Label.to_id l) "_r")  in
-      let c1' = Global.constant_of_delta_kn (Constant.canonical (Constant.make2 mp l')) in
+      let c1' = Global.constant_of_delta_kn (KerName.make mp l') in
       sigma, EConstr.of_constr (mkConst c1')
   in
   let proof = EConstr.mkApp (elim, [| rdx_ty; new_rdx; pred; p; rdx; c |]) in

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -393,7 +393,7 @@ let pirrel_rewrite ?(under=false) ?(map_redex=id_map_redex) pred rdx rdx_ty new_
       let sigma, elim = Evd.fresh_global env sigma (Indrec.lookup_eliminator env ind sort) in
       if dir = R2L then sigma, elim else
       let elim, _ = EConstr.destConst sigma elim in
-      let mp,l = Constant.repr2 (Constant.make1 (Constant.canonical elim)) in
+      let mp,l = KerName.repr (Constant.canonical elim) in
       let l' = Label.of_id (Nameops.add_suffix (Label.to_id l) "_r")  in
       let c1' = Global.constant_of_delta_kn (Constant.canonical (Constant.make2 mp l')) in
       sigma, EConstr.of_constr (mkConst c1')

--- a/pretyping/indrec.ml
+++ b/pretyping/indrec.ml
@@ -639,7 +639,7 @@ let lookup_eliminator env ind_sp s =
   let knc = KerName.make mpc l in
   (* Try first to get an eliminator defined in the same section as the *)
   (* inductive type *)
-  let cst = Constant.make knu knc in
+  let cst = Constant.of_kn ~user:knu knc in
   if mem_constant cst env then GlobRef.ConstRef cst
   else
     (* Then try to get a user-defined eliminator in some other places *)

--- a/pretyping/patternops.ml
+++ b/pretyping/patternops.ml
@@ -184,9 +184,9 @@ let pattern_of_constr env sigma t =
          with
          | Some n -> PSoApp (n,Array.to_list (Array.map (pattern_of_constr env) a))
          | None -> PApp (pattern_of_constr env f,Array.map (pattern_of_constr env) a))
-    | Const (con,u)  -> PRef (canonical_gr (GlobRef.ConstRef con))
-    | Ind (ind,u)    -> PRef (canonical_gr (GlobRef.IndRef ind))
-    | Construct (cstr,u) -> PRef (canonical_gr (GlobRef.ConstructRef cstr))
+    | Const (con,u)  -> PRef (canonize_global (GlobRef.ConstRef con))
+    | Ind (ind,u)    -> PRef (canonize_global (GlobRef.IndRef ind))
+    | Construct (cstr,u) -> PRef (canonize_global (GlobRef.ConstructRef cstr))
     | Proj (p, c) ->
       pattern_of_constr env (EConstr.Unsafe.to_constr (Retyping.expand_projection env sigma p (EConstr.of_constr c) []))
     | Evar (evk,ctxt as ev) ->
@@ -422,7 +422,7 @@ let rec pat_of_raw metas vars = DAst.with_loc_val (fun ?loc -> function
   | GPatVar (Evar_kinds.FirstOrderPatVar n) ->
       metas := n::!metas; PMeta (Some n)
   | GRef (gr,_) ->
-      PRef (canonical_gr gr)
+      PRef (canonize_global gr)
   (* Hack to avoid rewriting a complete interpretation of patterns *)
   | GApp (c, cl) ->
     begin match DAst.get c with

--- a/pretyping/patternops.ml
+++ b/pretyping/patternops.ml
@@ -184,9 +184,9 @@ let pattern_of_constr env sigma t =
          with
          | Some n -> PSoApp (n,Array.to_list (Array.map (pattern_of_constr env) a))
          | None -> PApp (pattern_of_constr env f,Array.map (pattern_of_constr env) a))
-    | Const (sp,u)  -> PRef (GlobRef.ConstRef (Constant.make1 (Constant.canonical sp)))
-    | Ind (sp,u)    -> PRef (canonical_gr (GlobRef.IndRef sp))
-    | Construct (sp,u) -> PRef (canonical_gr (GlobRef.ConstructRef sp))
+    | Const (con,u)  -> PRef (canonical_gr (GlobRef.ConstRef con))
+    | Ind (ind,u)    -> PRef (canonical_gr (GlobRef.IndRef ind))
+    | Construct (cstr,u) -> PRef (canonical_gr (GlobRef.ConstructRef cstr))
     | Proj (p, c) ->
       pattern_of_constr env (EConstr.Unsafe.to_constr (Retyping.expand_projection env sigma p (EConstr.of_constr c) []))
     | Evar (evk,ctxt as ev) ->

--- a/tactics/cbn.ml
+++ b/tactics/cbn.ml
@@ -440,7 +440,7 @@ let magically_constant_of_fixbody env sigma reference bd = function
   | Name.Anonymous -> bd
   | Name.Name id ->
     let open UnivProblem in
-    let (cst_mod,_) = Constant.repr2 reference in
+    let cst_mod = KerName.modpath (Constant.user reference) in
     let cst = Constant.make2 cst_mod (Label.of_id id) in
     if not (Environ.mem_constant cst env) then bd
     else

--- a/tactics/cbn.ml
+++ b/tactics/cbn.ml
@@ -441,7 +441,7 @@ let magically_constant_of_fixbody env sigma reference bd = function
   | Name.Name id ->
     let open UnivProblem in
     let cst_mod = KerName.modpath (Constant.user reference) in
-    let cst = Constant.make2 cst_mod (Label.of_id id) in
+    let cst = Constant.make cst_mod (Label.of_id id) in
     if not (Environ.mem_constant cst env) then bd
     else
       let (cst, u), ctx = UnivGen.fresh_constant_instance env cst in

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -369,7 +369,7 @@ let find_elim hdcncl lft2rgt dep cls ot =
           | Some r -> destConstRef r
           | None ->
             let c1 = destConstRef (lookup_eliminator env ind_sp sort) in
-            let mp,l = Constant.repr2 (Constant.make1 (Constant.canonical c1)) in
+            let mp,l = KerName.repr (Constant.canonical c1) in
             let l' = Label.of_id (add_suffix (Label.to_id l) "_r")  in
             let c1' = Global.constant_of_delta_kn (KerName.make mp l') in
             if not (Environ.mem_constant c1' (Global.env ())) then

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -682,11 +682,11 @@ let gallina_print_library_leaf env sigma with_values mp lobj =
           (try Some(print_named_decl env sigma id) with Not_found -> None)
       end @@
       DynHandle.add Declare.Internal.Constant.tag begin fun (id,_) ->
-        let kn = Constant.make2 mp (Label.of_id id) in
+        let kn = Constant.make mp (Label.of_id id) in
         Some (print_constant with_values sep kn None)
       end @@
       DynHandle.add DeclareInd.Internal.objInductive begin fun (id,_) ->
-        let kn = MutInd.make2 mp (Label.of_id id) in
+        let kn = MutInd.make mp (Label.of_id id) in
         Some (gallina_print_inductive kn None)
       end @@
       DynHandle.empty

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -449,18 +449,15 @@ let pr_located_qualid = function
       pr_qualid qid ++ spc () ++ str "not a defined object."
 
 let canonize_ref = let open GlobRef in function
-  | ConstRef c ->
-    let kn = Constant.canonical c in
-    if KerName.equal (Constant.user c) kn then None
-    else Some (ConstRef (Constant.make1 kn))
-  | IndRef (ind,i) ->
-    let kn = MutInd.canonical ind in
-    if KerName.equal (MutInd.user ind) kn then None
-    else Some (IndRef (MutInd.make1 kn, i))
-  | ConstructRef ((ind,i),j) ->
-    let kn = MutInd.canonical ind in
-    if KerName.equal (MutInd.user ind) kn then None
-    else Some (ConstructRef ((MutInd.make1 kn, i),j))
+  | ConstRef cst ->
+    if Constant.is_canonical cst then None
+    else Some (ConstRef (Constant.canonize cst))
+  | IndRef (mind,i) ->
+    if MutInd.is_canonical mind then None
+    else Some (IndRef (MutInd.canonize mind, i))
+  | ConstructRef ((mind,i),j) ->
+    if MutInd.is_canonical mind then None
+    else Some (ConstructRef ((MutInd.canonize mind, i),j))
   | VarRef _ -> None
 
 let display_alias = function

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -448,21 +448,9 @@ let pr_located_qualid = function
   | Undefined qid ->
       pr_qualid qid ++ spc () ++ str "not a defined object."
 
-let canonize_ref = let open GlobRef in function
-  | ConstRef cst ->
-    if Constant.is_canonical cst then None
-    else Some (ConstRef (Constant.canonize cst))
-  | IndRef (mind,i) ->
-    if MutInd.is_canonical mind then None
-    else Some (IndRef (MutInd.canonize mind, i))
-  | ConstructRef ((mind,i),j) ->
-    if MutInd.is_canonical mind then None
-    else Some (ConstructRef ((MutInd.canonize mind, i),j))
-  | VarRef _ -> None
-
 let display_alias = function
   | Term r ->
-    begin match canonize_ref r with
+    begin match Globnames.canonize_global_opt r with
     | None -> mt ()
     | Some r' ->
       let q' = Nametab.shortest_qualid_of_global Id.Set.empty r' in

--- a/vernac/printmod.ml
+++ b/vernac/printmod.ml
@@ -229,9 +229,9 @@ let nametab_register_body mp dir (l,body) =
     | SFBmodule _ -> () (* TODO *)
     | SFBmodtype _ -> () (* TODO *)
     | SFBconst _ ->
-      push (Label.to_id l) (GlobRef.ConstRef (Constant.make2 mp l))
+      push (Label.to_id l) (GlobRef.ConstRef (Constant.make mp l))
     | SFBmind mib ->
-      let mind = MutInd.make2 mp l in
+      let mind = MutInd.make mp l in
       Array.iteri
         (fun i mip ->
           push mip.mind_typename (GlobRef.IndRef (mind,i));
@@ -303,7 +303,7 @@ let print_body is_impl extent env mp (l,body) =
     | SFBmind mib ->
       match extent with
       | WithContents ->
-        pr_mutual_inductive_body env (MutInd.make2 mp l) mib None
+        pr_mutual_inductive_body env (MutInd.make mp l) mib None
       | OnlyNames ->
         let keyword =
           let open Declarations in


### PR DESCRIPTION
**Kind:** Cleanup

We experiment the following renaming scheme for `Names.Constant` and `Names.MutInd`:
- `make2` -> `make`, with an optional `~user:modpath`
- `make1` -> `of_kn`, with an optional `~user:kn`
- `make` -> subsumed by `of_kn ~user:kn`

We remove:
- `repr2`

We add higher-level API:
- `canonize : t -> t`
- `is_canonical : t -> bool`

We centralize and standardize `canonize` for global reference in `Globnames`.

We move `Ccalgo.canonize_name` (canonizing globals in a term) to a function of general interest `Termops.canonical_globals`.

This could possibly be several PRs if needed.

- [ ] Decision to take for deprecation strategy or not
- [ ] Documentation in `dev/doc/changes.md`
