### PR TITLE
Deprecate the Evd.sigma wrapper

### DIFF
--- a/dev/ci/user-overlays/15393-ppedrot-deprecate-sigma-wrapper.sh
+++ b/dev/ci/user-overlays/15393-ppedrot-deprecate-sigma-wrapper.sh
@@ -1,0 +1,5 @@
+overlay equations https://github.com/ppedrot/Coq-Equations deprecate-sigma-wrapper 15393
+
+overlay aac_tactics https://github.com/ppedrot/aac-tactics deprecate-sigma-wrapper 15393
+
+overlay itauto https://gitlab.inria.fr/pedrot/itauto deprecate-sigma-wrapper 15393

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -195,8 +195,7 @@ let ppexistentialfilter filter = match Evd.Filter.repr filter with
 | Some f -> pp (prlist_with_sep spc bool f)
 let pr_goal e = Pp.(str "GOAL:" ++ int (Evar.repr e))
 let ppclenv clenv = pp(pr_clenv clenv)
-let ppgoal g = pp(Printer.pr_goal g)
-let ppgoalsigma g = pp(Printer.pr_goal g ++ Termops.pr_evar_map None (Global.env ()) g.Evd.sigma)
+let ppgoal g = pp(Printer.Debug.pr_goal g)
 let pphintdb db = pp(envpp Hints.pr_hint_db_env db)
 let ppproofview p =
   let gls,sigma = Proofview.proofview p in

--- a/dev/top_printers.mli
+++ b/dev/top_printers.mli
@@ -120,9 +120,7 @@ val ppexistentialfilter : Evd.Filter.t -> unit
 
 val ppclenv : Clenv.clausenv -> unit
 
-val ppgoal : Evar.t Evd.sigma -> unit
-(* also print evar map *)
-val ppgoalsigma : Evar.t Evd.sigma -> unit
+val ppgoal : Proofview.Goal.t -> unit
 
 val pphintdb : Hints.Hint_db.t -> unit
 val ppproofview : Proofview.proofview -> unit

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -458,13 +458,13 @@ type 'a sigma = {
   (** The base object. *)
   sigma : evar_map
   (** The added unification state. *)
-}
+} [@@ocaml.deprecated]
 (** The type constructor ['a sigma] adds an evar map to an object of type
     ['a]. *)
 
-val sig_it  : 'a sigma -> 'a
-val sig_sig : 'a sigma -> evar_map
-val on_sig : 'a sigma -> (evar_map -> evar_map * 'b) -> 'a sigma * 'b
+val sig_it  : 'a sigma -> 'a  [@@ocaml.warning "-3"] [@@ocaml.deprecated]
+val sig_sig : 'a sigma -> evar_map [@@ocaml.warning "-3"] [@@ocaml.deprecated]
+val on_sig : 'a sigma -> (evar_map -> evar_map * 'b) -> 'a sigma * 'b [@@ocaml.warning "-3"] [@@ocaml.deprecated]
 
 (** {5 The state monad with state an evar map} *)
 

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -1203,6 +1203,8 @@ let wrap_exceptions f =
 
 (*** Compatibility layer with <= 8.2 tactics ***)
 module V82 = struct
+[@@@ocaml.warning "-3"]
+
   type tac = Evar.t Evd.sigma -> Evar.t list Evd.sigma
 
   let tactic ?(nf_evars=true) tac =
@@ -1247,6 +1249,7 @@ module V82 = struct
       let (_, info) = Exninfo.capture src in
       Exninfo.iraise (e, info)
 
+[@@@ocaml.warning "-3"]
 end
 
 (** {7 Notations} *)

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -1076,8 +1076,6 @@ module Goal = struct
     self : Evar.t ; (* for compatibility with old-style definitions *)
   }
 
-  let print { sigma; self } = { Evd.it = self; sigma }
-
   let state { state=state } = state
 
   let env {env} = env

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -553,7 +553,6 @@ module Goal : sig
 
   (** Compatibility: avoid if possible *)
   val goal : t -> Evar.t
-  val print : t -> Evar.t Evd.sigma
 
 end
 

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -591,7 +591,9 @@ val wrap_exceptions : (unit -> 'a tactic) -> 'a tactic
 
 (*** Compatibility layer with <= 8.2 tactics ***)
 module V82 : sig
+  [@@@ocaml.warning "-3"]
   type tac = Evar.t Evd.sigma -> Evar.t list Evd.sigma
+  [@@@ocaml.warning "+3"]
 
   (* [nf_evars=true] applies the evar (assignment) map to the goals
    * (conclusion and context) before calling the tactic *)

--- a/plugins/firstorder/ground.ml
+++ b/plugins/firstorder/ground.ml
@@ -36,8 +36,7 @@ let ground_tac solver startseq =
     let () =
       if Tacinterp.get_debug()=Tactic_debug.DebugOn 0
       then
-        let gl = { Evd.it = Proofview.Goal.goal gl; sigma = project gl } in
-        Feedback.msg_debug (Printer.pr_goal gl)
+        Feedback.msg_debug (Printer.Debug.pr_goal gl)
     in
     tclORELSE (axiom_tac seq.gl seq)
       begin

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -333,7 +333,7 @@ module New = struct
     let open Proofview.Notations in
     let open Proofview in
     Goal.enter (fun gl ->
-        let goal = Printer.pr_goal (Goal.print gl) in
+        let goal = Printer.Debug.pr_goal gl in
         let env, sigma = (Goal.env gl, Goal.sigma gl) in
         let s = s env sigma in
         let lmsg = seq [header; str " : " ++ s] in

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -570,7 +570,7 @@ let rec prove_lt hyple =
           ; New.observe_tac
               (fun _ _ ->
                 str "assumption: "
-                ++ Printer.pr_goal Evd.{it = Proofview.Goal.goal g; sigma})
+                ++ Printer.Debug.pr_goal g)
               assumption ])
 
 let rec destruct_bounds_aux infos (bound, hyple, rechyps) lbounds =

--- a/plugins/ssr/ssrast.mli
+++ b/plugins/ssr/ssrast.mli
@@ -181,4 +181,3 @@ type ssrapplyarg = ssrterm list * (ssrterm ssragens * ssripats)
 type gist = Tacintern.glob_sign
 type ist = Tacinterp.interp_sign
 type goal = Evar.t
-type 'a sigma = 'a Evd.sigma

--- a/plugins/ssr/ssripats.ml
+++ b/plugins/ssr/ssripats.ml
@@ -422,7 +422,7 @@ let tclLOG p t =
   Goal.enter begin fun g ->
     Ssrprinters.debug_ssr (fun () -> Pp.(str" on state:" ++ spc () ++
       isPRINT g ++
-      str" goal:" ++ spc () ++ Printer.pr_goal (Goal.print g)));
+      str" goal:" ++ spc () ++ Printer.Debug.pr_goal g));
     tclUNIT ()
   end
   <*>

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -491,6 +491,7 @@ let pr_goal ?diffs g_s =
         hov 0 (pr_letype_env ~goal_concl_style:true env sigma concl)
   in
   str "  " ++ v 0 goal
+  [@@ocaml.warning "-3"]
 
 (* display a goal tag *)
 let pr_goal_tag g =

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -1046,3 +1046,12 @@ let pr_typing_flags flags =
   ++ str "check_universes: " ++ bool flags.check_universes ++ fnl ()
   ++ str "cumulative sprop: " ++ bool flags.cumulative_sprop ++ fnl ()
   ++ str "definitional uip: " ++ bool flags.allow_uip
+
+module Debug =
+struct
+
+let pr_goal gl =
+  let g = Proofview.Goal.goal gl in
+  pr_goal { Evd.it = g; Evd.sigma = Proofview.Goal.sigma gl }
+
+end

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -816,18 +816,18 @@ let pr_open_subgoals ?(quiet=false) ?diffs proof =
   let given_up = Evd.given_up sigma in
   let stack = List.map (fun (l,r) -> List.length l + List.length r) stack in
   begin match goals with
-  | [] -> let { Evd.it = bgoals ; sigma = bsigma } = Proof.V82.background_subgoals p in
+  | [] -> let bgoals = Proof.background_subgoals p in
           begin match bgoals,shelf,given_up with
           | [] , [] , g when Evar.Set.is_empty g -> pr_subgoals None sigma ~entry ~shelf ~stack ~unfocused:[] ~goals
           | [] , [] , _ ->
              Feedback.msg_info (str "No more goals, but there are some goals you gave up:");
              fnl ()
-            ++ pr_subgoals ~pr_first:false None bsigma ~entry ~shelf:[] ~stack:[] ~unfocused:[] ~goals:(Evar.Set.elements given_up)
+            ++ pr_subgoals ~pr_first:false None sigma ~entry ~shelf:[] ~stack:[] ~unfocused:[] ~goals:(Evar.Set.elements given_up)
             ++ fnl () ++ str "You need to go back and solve them."
           | [] , _ , _ ->
             Feedback.msg_info (str "All the remaining goals are on the shelf.");
             fnl ()
-            ++ pr_subgoals ~pr_first:false None bsigma ~entry ~shelf:[] ~stack:[] ~unfocused:[] ~goals:shelf
+            ++ pr_subgoals ~pr_first:false None sigma ~entry ~shelf:[] ~stack:[] ~unfocused:[] ~goals:shelf
           | _ , _, _ ->
             let cmd = if quiet then None else
               Some
@@ -836,10 +836,10 @@ let pr_open_subgoals ?(quiet=false) ?diffs proof =
                  if Pp.ismt s then s else fnl () ++ s) ++
                 fnl ())
             in
-            pr_subgoals ~pr_first:false cmd bsigma ~entry ~shelf ~stack:[] ~unfocused:[] ~goals:bgoals
+            pr_subgoals ~pr_first:false cmd sigma ~entry ~shelf ~stack:[] ~unfocused:[] ~goals:bgoals
           end
   | _ ->
-     let { Evd.it = bgoals ; sigma = bsigma } = Proof.V82.background_subgoals p in
+     let bgoals = Proof.background_subgoals p in
      let bgoals_focused, bgoals_unfocused = List.partition (fun x -> List.mem x goals) bgoals in
      let unfocused_if_needed = if should_unfoc() then bgoals_unfocused else [] in
      let diffs = match diffs with
@@ -851,7 +851,7 @@ let pr_open_subgoals ?(quiet=false) ?diffs proof =
        | Some None -> Some None
        | None -> None
      in
-     pr_subgoals ~pr_first:true ?diffs None bsigma ~entry ~shelf ~stack:[]
+     pr_subgoals ~pr_first:true ?diffs None sigma ~entry ~shelf ~stack:[]
         ~unfocused:unfocused_if_needed ~goals:bgoals_focused
   end
 

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -189,12 +189,6 @@ val pr_transparent_state   : TransparentState.t -> Pp.t
 
 (** Proofs, these functions obey [Hyps Limit] and [Compact contexts]. *)
 
-(** [pr_goal ?diffs g_s] prints the goal specified by [g_s].  If [diffs] is [Some og_s],
-    highlight the differences between the (optional) old goal [og_s] and [g_s].
-    This is a UI-facing function, you should not use that for debug printing.
-*)
-val pr_goal : ?diffs:Proof_diffs.goal option -> Evar.t sigma -> Pp.t
-
 (** [pr_open_subgoals ~quiet ?diffs proof] shows the context for [proof] as used by, for example, coqtop.
     The first active goal is printed with all its antecedents and the conclusion.  The other active goals only show their
      conclusions.  If [diffs] is [Some oproof], highlight the differences between the old proof [oproof], and [proof].  [quiet]
@@ -236,3 +230,11 @@ val pr_typing_flags : Declarations.typing_flags -> Pp.t
 
 (** Tells if flag "Printing Goal Names" is activated *)
 val print_goal_names : unit -> bool
+
+module Debug :
+sig
+
+val pr_goal : Proofview.Goal.t -> Pp.t
+
+end
+(** Debug printers *)

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -396,14 +396,9 @@ let unshelve p =
   let proofview = Proofview.unshelve shelf p.proofview in
   { p with proofview }
 
-(*** Compatibility layer with <=v8.2 ***)
-module V82 = struct
-
-  let background_subgoals p =
-    let it, sigma = Proofview.proofview (unroll_focus p.proofview p.focus_stack) in
-    Evd.{ it; sigma }
-
-end
+let background_subgoals p =
+  let it, _ = Proofview.proofview (unroll_focus p.proofview p.focus_stack) in
+  it
 
 let all_goals p =
   let add gs set =
@@ -413,7 +408,7 @@ let all_goals p =
     let set = List.fold_left (fun s gs -> let (g1, g2) = gs in add g1 (add g2 set)) set stack in
     let set = add (Evd.shelf sigma) set in
     let set = Evar.Set.union (Evd.given_up sigma) set in
-    let { Evd.it = bgoals ; sigma = bsigma } = V82.background_subgoals p in
+    let bgoals = background_subgoals p in
     add bgoals set
 
 type data =

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -545,13 +545,9 @@ let refine_by_tactic ~name ~poly env sigma ty tac =
   let (ans, _) = Safe_typing.inline_private_constants env ((ans, Univ.ContextSet.empty), neff) in
   ans, sigma
 
-let get_nth_V82_goal p i =
-  let { sigma; goals } = data p in
-  try { Evd.it = List.nth goals (i-1) ; sigma }
-  with Failure _ -> raise (NoSuchGoal None)
-
 let get_goal_context_gen pf i =
-  let { Evd.it=goal ; sigma=sigma; } = get_nth_V82_goal pf i in
+  let { sigma; goals } = data pf in
+  let goal = try List.nth goals (i-1) with Failure _ -> raise (NoSuchGoal None) in
   let env = Evd.evar_filtered_env (Global.env ()) (Evd.find sigma goal) in
   (sigma, env)
 

--- a/proofs/proof.mli
+++ b/proofs/proof.mli
@@ -189,13 +189,8 @@ val goal_uid : Evar.t -> string
 
 val pr_proof : t -> Pp.t
 
-(*** Compatibility layer with <=v8.2 ***)
-module V82 : sig
-
-  (* All the subgoals of the proof, including those which are not focused. *)
-  val background_subgoals : t -> Evar.t list Evd.sigma
-
-end
+(* All the subgoals of the proof, including those which are not focused. *)
+val background_subgoals : t -> Evar.t list
 
 (* returns the set of all goals in the proof *)
 val all_goals : t -> Evar.Set.t

--- a/proofs/tacmach.ml
+++ b/proofs/tacmach.ml
@@ -24,15 +24,15 @@ module NamedDecl = Context.Named.Declaration
 module Old =
 struct
 
+[@@@ocaml.warning "-3"]
+
 let re_sig it  gc = { it = it; sigma = gc; }
 
 (**************************************************************)
 (* Operations for handling terms under a local typing context *)
 (**************************************************************)
 
-[@@@ocaml.warning "-3"]
 type tactic = Proofview.V82.tac
-[@@@ocaml.warning "+3"]
 
 let sig_it x = x.it
 let project x = x.sigma
@@ -106,6 +106,8 @@ let db_pr_goal sigma g =
 
 let pr_gls gls =
   hov 0 (pr_evar_map (Some 2) (pf_env gls) (project gls) ++ fnl () ++ db_pr_goal (project gls) (sig_it gls))
+
+[@@@ocaml.warning "+3"]
 
 end
 

--- a/proofs/tacmach.mli
+++ b/proofs/tacmach.mli
@@ -23,7 +23,6 @@ sig
 
 [@@@ocaml.warning "-3"]
 type tactic = Proofview.V82.tac
-[@@@ocaml.warning "+3"]
 
 val sig_it  : 'a sigma   -> 'a
 val project : Evar.t sigma -> evar_map
@@ -84,6 +83,7 @@ val pf_conv_x      : Evar.t sigma -> constr -> constr -> bool
 (** {6 Pretty-printing functions (debug only). } *)
 val pr_gls    : Evar.t sigma -> Pp.t
 
+[@@@ocaml.warning "+3"]
 end
 [@@ocaml.deprecated "Use the new engine"]
 
@@ -92,7 +92,7 @@ end
 val pf_apply : (env -> evar_map -> 'a) -> Proofview.Goal.t -> 'a
 
 val of_old : (Goal.goal Evd.sigma -> 'a) -> Proofview.Goal.t -> 'a
-[@@ocaml.deprecated "Use the new engine"]
+[@@ocaml.warning "-3"] [@@ocaml.deprecated "Use the new engine"]
 
 val project : Proofview.Goal.t -> Evd.evar_map
 val pf_env : Proofview.Goal.t -> Environ.env

--- a/tactics/tacticals.mli
+++ b/tactics/tacticals.mli
@@ -20,15 +20,15 @@ exception FailError of int * Pp.t Lazy.t
 module Old :
 sig
 
+[@@@ocaml.warning "-3"]
+
 (** Takes an exception and either raise it at the next
    level or do nothing. *)
 val catch_failerror  : Exninfo.iexn -> unit
 
 (** Tacticals i.e. functions from tactics to tactics. *)
 
-[@@@ocaml.warning "-3"]
 type tactic = Proofview.V82.tac
-[@@@ocaml.warning "+3"]
 
 val tclIDTAC         : tactic
 val tclIDTAC_MESSAGE : Pp.t -> tactic
@@ -101,6 +101,8 @@ val elimination_sort_of_clause : Id.t option -> Evar.t sigma -> Sorts.family
 
 val pf_with_evars :  (Goal.goal sigma -> Evd.evar_map * 'a) -> ('a -> tactic) -> tactic
 val pf_constr_of_global : GlobRef.t -> (constr -> tactic) -> tactic
+
+[@@@ocaml.warning "+3"]
 
 end
 [@@ocaml.deprecated "Use the new engine"]


### PR DESCRIPTION
A landmark of the old proof engine, this was only used in a few rare places. We port the leftover non-deprecated APIs to the new interface and deprecate the type for good.

Overlays:
- https://github.com/mattam82/Coq-Equations/pull/469
- https://github.com/coq-community/aac-tactics/pull/107
- https://gitlab.inria.fr/fbesson/itauto/-/merge_requests/4