### PR TITLE
Remove Termops.global_vars API

### DIFF
--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -1373,8 +1373,6 @@ let global_vars_set env sigma constr =
   in
   filtrec Id.Set.empty constr
 
-let global_vars env sigma ids = Id.Set.elements (global_vars_set env sigma ids)
-
 let global_vars_set_of_decl env sigma = function
   | NamedDecl.LocalAssum (_,t) -> global_vars_set env sigma t
   | NamedDecl.LocalDef (_,c,t) ->

--- a/engine/termops.mli
+++ b/engine/termops.mli
@@ -251,7 +251,6 @@ val map_named_decl : ('a -> 'b) -> ('a, 'a) Context.Named.Declaration.pt -> ('b,
 
 val clear_named_body : Id.t -> env -> env
 
-val global_vars : env -> Evd.evar_map -> constr -> Id.t list
 val global_vars_set : env -> Evd.evar_map -> constr -> Id.Set.t
 val global_vars_set_of_decl : env -> Evd.evar_map -> named_declaration -> Id.Set.t
 val global_app_of_constr : Evd.evar_map -> constr -> (GlobRef.t * EInstance.t) * constr option

--- a/plugins/ltac/leminv.ml
+++ b/plugins/ltac/leminv.ml
@@ -155,13 +155,13 @@ let compute_first_inversion_scheme env sigma ind sort dep_option =
       pty,goal
     else
       let i = mkAppliedInd ind in
-      let ivars = global_vars env sigma i in
+      let ivars = Termops.global_vars_set env sigma i in
       let revargs,ownsign =
         fold_named_context
           (fun env d (revargs,hyps) ->
             let d = map_named_decl EConstr.of_constr d in
              let id = NamedDecl.get_id d in
-             if Id.List.mem id ivars then
+             if Id.Set.mem id ivars then
                ((mkVar id)::revargs, Context.Named.add d hyps)
              else
                (revargs,hyps))
@@ -193,9 +193,9 @@ let inversion_scheme ~name ~poly env sigma t sort dep_option inv_op =
     compute_first_inversion_scheme env sigma ind sort dep_option
   in
   assert
-    (List.subset
-       (global_vars env sigma invGoal)
-       (ids_of_named_context (named_context invEnv)));
+    (Id.Set.subset
+       (Termops.global_vars_set env sigma invGoal)
+       (ids_of_named_context_val (named_context_val invEnv)));
   (*
     user_err
     (str"Computed inversion goal was not closed in initial signature.");


### PR DESCRIPTION
It uselessly does Id.Set.elements around global_vars_set
