### PR TITLE
Better control of the domain of module substitution and related optimizations

### DIFF
--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -556,5 +556,3 @@ let compose subst1 subst2 =
   in
   let mp_apply_subst mp = apply_subst mp (Umap.add_mp mp) in
   Umap.fold mp_apply_subst subst1 empty_subst
-
-let join subst1 subst2 = Umap.join subst2 (compose subst1 subst2)

--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -537,7 +537,7 @@ let substition_prefixed_by k mp subst =
   in
   Umap.fold mp_prefixmp subst empty_subst
 
-let join subst1 subst2 =
+let compose subst1 subst2 =
   let apply_subst mpk add (mp,resolve) res =
     let mp',resolve' =
       match subst_mp0 subst2 mp with
@@ -555,5 +555,6 @@ let join subst1 subst2 =
     Umap.join prefixed_subst (add (mp',resolve'') res)
   in
   let mp_apply_subst mp = apply_subst mp (Umap.add_mp mp) in
-  let subst = Umap.fold mp_apply_subst subst1 empty_subst in
-  Umap.join subst2 subst
+  Umap.fold mp_apply_subst subst1 empty_subst
+
+let join subst1 subst2 = Umap.join subst2 (compose subst1 subst2)

--- a/kernel/mod_subst.mli
+++ b/kernel/mod_subst.mli
@@ -84,13 +84,8 @@ val map_mbid :
 val map_mp :
   ModPath.t -> ModPath.t -> delta_resolver -> substitution
 
-(** sequential composition:
-   [substitute (join sub1 sub2) t = substitute sub2 (substitute sub1 t)]
-*)
-val join : substitution -> substitution -> substitution
-
-(** sequential composition when [sub2] applies only to [sub1],
-    i.e. when [t[sub1]] is already a closure
+(** sequential composition when [sub1] binds all free variables of [t]:
+   [substitute (compose sub1 sub2) t = substitute sub2 (substitute sub1 t)]
 *)
 val compose : substitution -> substitution -> substitution
 

--- a/kernel/mod_subst.mli
+++ b/kernel/mod_subst.mli
@@ -89,6 +89,11 @@ val map_mp :
 *)
 val join : substitution -> substitution -> substitution
 
+(** sequential composition when [sub2] applies only to [sub1],
+    i.e. when [t[sub1]] is already a closure
+*)
+val compose : substitution -> substitution -> substitution
+
 
 (** Apply the substitution on the domain of the resolver  *)
 val subst_dom_delta_resolver : substitution -> delta_resolver -> delta_resolver

--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -479,11 +479,8 @@ and strengthen_and_subst_struct str subst mp_from mp_to alias incl reso =
         else
           add_delta_resolver reso' mb'.mod_delta, str'
     | (l,SFBmodtype mty) as item :: rest ->
-        let mp_from' = MPdot (mp_from,l) in
-        let mp_to' = MPdot(mp_to,l) in
-        let subst' = add_mp mp_from' mp_to' empty_delta_resolver subst in
-        let mty' = subst_modtype subst'
-          (fun resolver _ -> subst_dom_codom_delta_resolver subst' resolver)
+        let mty' = subst_modtype subst
+          (fun resolver _ -> subst_dom_codom_delta_resolver subst resolver)
           mty
         in
         let item' = if mty' == mty then item else (l, SFBmodtype mty') in
@@ -494,6 +491,7 @@ and strengthen_and_subst_struct str subst mp_from mp_to alias incl reso =
           if rest' == rest && item' == item then str
           else item' :: rest'
         in
+        let mp_to' = MPdot(mp_to,l) in
         add_mp_delta_resolver mp_to' mp_to' reso', str'
 
 

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -313,7 +313,7 @@ and check_modtypes cst env mtb1 mtb2 subst1 subst2 equiv =
       |MoreFunctor (arg_id1,arg_t1,body_t1),
        MoreFunctor (arg_id2,arg_t2,body_t2) ->
         let mp2 = MPbound arg_id2 in
-        let subst1 = join (map_mbid arg_id1 mp2 arg_t2.mod_delta) subst1 in
+        let subst1 = add_mbid arg_id1 mp2 arg_t2.mod_delta subst1 in
         let cst = check_modtypes cst env arg_t2 arg_t1 subst2 subst1 equiv in
         (* contravariant *)
         let env = add_module_type mp2 arg_t2 env in

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -64,7 +64,7 @@ let rec fields_of_functor f subs mp0 args = function
     match args with
     | [] -> assert false (* we should only encounter applied functors *)
     | mpa :: args ->
-      let subs = join (map_mbid mbid mpa empty_delta_resolver (*TODO*)) subs in
+      let subs = add_mbid mbid mpa empty_delta_resolver (*TODO*) subs in
       fields_of_functor f subs mp0 args e
 
 let rec lookup_module_in_impl mp =

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -489,7 +489,7 @@ let rec compute_subst env mbids sign mp_l inl =
           else
             Modops.inline_delta_resolver env inl mp farg_id farg_b mb.mod_delta
         in
-        mbid_left,join (map_mbid mbid mp resolver) subst
+        mbid_left,add_mbid mbid mp resolver subst
 
 (** Create the objects of a "with Module" structure. *)
 
@@ -917,7 +917,7 @@ let rec include_subst env mp reso mbids sign inline = match mbids with
     let mp_delta =
       Modops.inline_delta_resolver env inline mp farg_id farg_b reso
     in
-    join (map_mbid mbid mp mp_delta) subst
+    add_mbid mbid mp mp_delta subst
 
 let rec decompose_functor mpl typ =
   match mpl, typ with
@@ -953,7 +953,7 @@ let declare_one_include (me_ast,annot) =
   in
   let base_mp = get_module_path me in
   let resolver = Global.add_include me is_mod inl in
-  let subst = join subst_self (map_mp base_mp cur_mp resolver) in
+  let subst = add_mp base_mp cur_mp resolver subst_self in
   let aobjs = subst_aobjs subst aobjs in
   cache_include (Lib.prefix(), aobjs);
   Lib.add_leaf_entry (IncludeObject aobjs)


### PR DESCRIPTION
**Kind:** cleanup

By a better control of when a module substitution is in parallel (substitutions of the different parameters or of the name of the module it self) or sequential (sequence of inclusion), we can correspondently use `Mod_subst.add_mp` or a new `compose` instead of `Mod_subst.join` which assumes the worth and compose both in parallel and sequentially to the risk of proliferation of useless binders (fortunately all on distinct names though, since even bound variables have distinct names). This should reduce a bit the size of module substitutions.

An additional commit independently removes a redundant binding in a substitution.