### PR TITLE
Use anonymous primitive projections in the VM.

### DIFF
--- a/dev/vm_printers.ml
+++ b/dev/vm_printers.ml
@@ -12,8 +12,6 @@ let ppripos (ri,pos) =
       print_string "structured constant\n"
   | Reloc_getglobal kn ->
     print_string ("getglob "^(Constant.to_string kn)^"\n")
-  | Reloc_proj_name p ->
-    print_string ("proj "^(Projection.Repr.to_string p)^"\n")
   | Reloc_caml_prim op ->
     print_string ("caml primitive "^CPrimitives.to_string op)
   );

--- a/kernel/byterun/coq_interp.c
+++ b/kernel/byterun/coq_interp.c
@@ -1061,11 +1061,10 @@ value coq_interprete
           default:
             {
               value block;
-              /* Skip over the index of projected field */
-              ++pc;
+              int index = *pc++;
               /* Create atom */
               Alloc_small(accu, 2, ATOM_PROJ_TAG);
-              Field(accu, 0) = Field(coq_global_data, *pc++);
+              Field(accu, 0) = Val_int(index);
               Field(accu, 1) = *sp++;
               /* Create accumulator */
               Alloc_small(block, 3, Closure_tag);
@@ -1077,7 +1076,7 @@ value coq_interprete
           }
         } else {
           accu = Field(accu, *pc);
-          pc += 2;
+          pc++;
         }
         Next;
       }

--- a/kernel/genOpcodeFiles.ml
+++ b/kernel/genOpcodeFiles.ml
@@ -84,7 +84,7 @@ let opcodes =
     "GETFIELD1", 0;
     "GETFIELD", 1;
     "SETFIELD", 1;
-    "PROJ", 2;
+    "PROJ", 1;
     "ENSURESTACKCAPACITY", 1;
     "CONST0", 0;
     "CONST1", 0;

--- a/kernel/vconv.ml
+++ b/kernel/vconv.ml
@@ -141,7 +141,7 @@ and conv_stack env k stk1 stk2 cu =
         conv_stack env k stk1 stk2 !rcu
       else raise NotConvertible
   | Zproj p1 :: stk1, Zproj p2 :: stk2 ->
-    if Projection.Repr.CanOrd.equal p1 p2 then conv_stack env k stk1 stk2 cu
+    if Int.equal p1 p2 then conv_stack env k stk1 stk2 cu
     else raise NotConvertible
   | [], _ | Zapp _ :: _, _ | Zfix _ :: _, _ | Zswitch _ :: _, _
   | Zproj _ :: _, _ -> raise NotConvertible

--- a/kernel/vmemitcodes.mli
+++ b/kernel/vmemitcodes.mli
@@ -15,7 +15,6 @@ type reloc_info =
   | Reloc_annot of annot_switch
   | Reloc_const of structured_constant
   | Reloc_getglobal of Constant.t
-  | Reloc_proj_name of Projection.Repr.t
   | Reloc_caml_prim of CPrimitives.t
 
 type patches

--- a/kernel/vmsymtable.ml
+++ b/kernel/vmsymtable.ml
@@ -85,14 +85,10 @@ module AnnotTable = Hashtbl.Make (struct
   let hash = hash_annot_switch
 end)
 
-module ProjNameTable = Hashtbl.Make (Projection.Repr.CanOrd)
-
 let str_cst_tbl : int SConstTable.t = SConstTable.create 31
 
 let annot_tbl : int AnnotTable.t = AnnotTable.create 31
     (* (annot_switch * int) Hashtbl.t  *)
-
-let proj_name_tbl : int ProjNameTable.t = ProjNameTable.create 31
 
 (*************************************************************)
 (*** Mise a jour des valeurs des variables et des constantes *)
@@ -136,13 +132,6 @@ let slot_for_caml_prim =
   | Arraycopy -> parray_copy
   | Arraylength -> parray_length
   | _ -> assert false
-
-let slot_for_proj_name key =
-  try ProjNameTable.find proj_name_tbl key
-  with Not_found ->
-    let n =  set_global (val_of_proj_name key) in
-    ProjNameTable.add proj_name_tbl key n;
-    n
 
 let rec slot_for_getglobal env sigma kn =
   let (cb,(_,rk)) = lookup_constant_key kn env in
@@ -199,7 +188,6 @@ and eval_to_patch env sigma (buff,pl,fv) =
     | Reloc_annot a -> slot_for_annot a
     | Reloc_const sc -> slot_for_str_cst sc
     | Reloc_getglobal kn -> slot_for_getglobal env sigma kn
-    | Reloc_proj_name p -> slot_for_proj_name p
     | Reloc_caml_prim op -> slot_for_caml_prim op
   in
   let tc = patch buff pl slots in

--- a/kernel/vmvalues.ml
+++ b/kernel/vmvalues.ml
@@ -267,7 +267,7 @@ type zipper =
   | Zapp of arguments
   | Zfix of vfix*arguments  (* Possibly empty *)
   | Zswitch of vswitch
-  | Zproj of Projection.Repr.t (* name of the projection *)
+  | Zproj of int (* index of the projection as in Projection.Repr *)
 
 type stack = zipper list
 
@@ -500,7 +500,6 @@ let val_of_constant c = val_of_idkey (ConstKey c)
 let val_of_evar evk = val_of_idkey (EvarKey evk)
 
 external val_of_annot_switch : annot_switch -> values = "%identity"
-external val_of_proj_name : Projection.Repr.t -> values = "%identity"
 
 (*************************************************)
 (** Operations manipulating data types ***********)
@@ -696,7 +695,7 @@ and pr_zipper z =
   | Zapp args -> str "Zapp(len = " ++ int (nargs args) ++ str ")"
   | Zfix (_f,args) -> str "Zfix(..., len=" ++ int (nargs args) ++ str ")"
   | Zswitch _s -> str "Zswitch(...)"
-  | Zproj c -> str "Zproj(" ++ Projection.Repr.print c ++ str ")")
+  | Zproj n -> str "Zproj(" ++ int n ++ str ")")
 
 (** Primitives implemented in OCaml *)
 

--- a/kernel/vmvalues.mli
+++ b/kernel/vmvalues.mli
@@ -113,7 +113,7 @@ type zipper =
   | Zapp of arguments
   | Zfix of vfix * arguments  (** might be empty *)
   | Zswitch of vswitch
-  | Zproj of Projection.Repr.t (* name of the projection *)
+  | Zproj of int (* index of the projection as in Projection.Repr *)
 
 type stack = zipper list
 
@@ -143,14 +143,13 @@ val val_of_rel : int -> values
 val val_of_named : Id.t -> values
 val val_of_constant : Constant.t -> values
 val val_of_evar : Evar.t -> values
-val val_of_proj : Projection.Repr.t -> values -> values
+val val_of_proj : int -> values -> values
 val val_of_atom : atom -> values
 val val_of_int : int -> structured_values
 val val_of_block : tag -> structured_values array -> structured_values
 val val_of_uint : Uint63.t -> structured_values
 
 external val_of_annot_switch : annot_switch -> values = "%identity"
-external val_of_proj_name : Projection.Repr.t -> values = "%identity"
 
 (** Destructors *)
 

--- a/test-suite/vm_norm_records.v
+++ b/test-suite/vm_norm_records.v
@@ -1,0 +1,75 @@
+Set Primitive Projections.
+
+(** Variant of VM conversion that exercises the reification part of the VM *)
+Ltac norm := match goal with [ |- ?P ] => let Q := eval vm_compute in P in change Q end.
+
+Module T.
+
+Record prod (A : Type) (B : A -> Type) := pair { fst : A; snd : B fst }.
+
+Arguments fst {_ _}.
+Arguments snd {_ _}.
+
+Goal forall (p : prod nat (fun n => n = 0)), fst p = 0.
+Proof.
+intros p.
+norm.
+apply (snd p).
+Qed.
+
+End T.
+
+Module M.
+
+CoInductive foo := Foo {
+  foo0 : foo;
+  foo1 : bar;
+}
+with bar := Bar {
+  bar0 : foo;
+  bar1 : bar;
+}.
+
+CoFixpoint f : foo := Foo f g
+with g : bar := Bar f g.
+
+Goal f.(foo0).(foo0) = g.(bar0).
+Proof.
+norm.
+match goal with [ |- ?t = ?t ] => idtac end.
+reflexivity.
+Qed.
+
+Goal g.(bar1).(bar0).(foo1) = g.
+Proof.
+norm.
+match goal with [ |- ?t = ?t ] => idtac end.
+reflexivity.
+Qed.
+
+End M.
+
+Module N.
+
+Inductive foo := Foo {
+  foo0 : option foo;
+  foo1 : list bar;
+}
+with bar := Bar {
+  bar0 : option bar;
+  bar1 : list foo;
+}.
+
+Definition f_0 := Foo None nil.
+Definition g_0 := Bar None nil.
+
+Definition f := Foo (Some f_0) (cons g_0 nil).
+
+Goal f.(foo1) = cons g_0 nil.
+Proof.
+norm.
+match goal with [ |- ?t = ?t ] => idtac end.
+reflexivity.
+Qed.
+
+End N.


### PR DESCRIPTION
This patch changes the PROJ VM opcode to only take the projection index as argument, rather than both the index and the high-level Projection.Repr.t representation. This allows removing the code for global registering of projections in the VM, thus reducing the size of relocations. Since this also makes the bytecode slightly shorter, this is a net gain in memory and vo size.

The only place where this has an effect is during reification of accumulated projections. One could think that this makes the process more expensive since we now have to reconstruct the projection, but in reality we were already accessing the environment there to fetch the inductive block (and doing so several times, actually). The new code only accesses the environment once, so even there this should be faster on average.