### PR TITLE
Docker image: Bump lablgtk to 3.1.2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ variables:
   # Format: $IMAGE-V$DATE-$hash
   # The $hash is the first 10 characters of the md5 of the Dockerfile. e.g.
   # echo $(md5sum dev/ci/docker/bionic_coq/Dockerfile | head -c 10)
-  CACHEKEY: "bionic_coq-V2021-10-01-7c5b78d50f"
+  CACHEKEY: "bionic_coq-V2021-12-25-b045733961"
   IMAGE: "$CI_REGISTRY_IMAGE:$CACHEKEY"
   # By default, jobs run in the base switch; override to select another switch
   OPAM_SWITCH: "base"

--- a/dev/ci/docker/bionic_coq/Dockerfile
+++ b/dev/ci/docker/bionic_coq/Dockerfile
@@ -47,7 +47,7 @@ ENV BASE_OPAM="zarith.1.10 ocamlfind.1.9.1 ounit2.2.2.3 odoc.1.5.3" \
     BASE_ONLY_OPAM="dune.2.7.1 elpi.1.13.6 stdlib-shims.0.1.0"
 
 # BASE switch; CI_OPAM contains Coq's CI dependencies.
-ENV COQIDE_OPAM="cairo2.0.6.1 lablgtk3-sourceview3.3.1.0"
+ENV COQIDE_OPAM="cairo2.0.6.1 lablgtk3-sourceview3.3.1.2"
 
 # Must add this to COQIDE_OPAM{,_EDGE} when we update the opam
 # packages "lablgtk3-gtksourceview3"


### PR DESCRIPTION
Enables PR #15399 which addresses #12779.

Waiting for https://github.com/ocaml/opam-repository/pull/20323