### PR TITLE
Mostly cosmetic changes to hopefully make kernel code on modules easier to read

### DIFF
--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -116,16 +116,16 @@ let rec check_module env opac mp mb opacify =
     check_signature env opac mb.mod_type mb.mod_mp mb.mod_delta opacify
   in
   let optsign, opac = match mb.mod_expr with
-    |Struct sign_struct ->
+    | Struct sign_struct ->
       let opacify = collect_constants_without_body sign mb.mod_mp opacify in
       let sign, opac = check_signature env opac sign_struct mb.mod_mp mb.mod_delta opacify in
       Some (sign, mb.mod_delta), opac
-    |Algebraic me -> Some (check_mexpression env opac me mb.mod_mp mb.mod_delta), opac
-    |Abstract|FullStruct -> None, opac
+    | Algebraic me -> Some (check_mexpression env opac me mb.mod_mp mb.mod_delta), opac
+    | Abstract|FullStruct -> None, opac
   in
   let () = match optsign with
-  |None -> ()
-  |Some (sign,delta) ->
+  | None -> ()
+  | Some (sign,delta) ->
     let mtb1 = mk_mtb mp sign delta
     and mtb2 = mk_mtb mp mb.mod_type mb.mod_delta in
     let env = Modops.add_module_type mp mtb1 env in

--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -159,7 +159,7 @@ and check_structure_field env opac mp lab res opacify = function
 and check_mexpr env opac mse mp_mse res = match mse with
   | MEident mp ->
       let mb = lookup_module mp env in
-      let mb = Modops.strengthen_and_subst_mb mb mp_mse false in
+      let mb = Modops.strengthen_and_subst_module_body mb mp_mse false in
       mb.mod_type, mb.mod_delta
   | MEapply (f,mp) ->
       let sign, delta = check_mexpr env opac f mp_mse res in

--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -98,7 +98,7 @@ let mk_mtb mp sign delta =
     mod_retroknowledge = ModTypeRK; }
 
 let rec collect_constants_without_body sign mp accu =
-  let collect_sf s lab = function
+  let collect_field s lab = function
   | SFBconst cb ->
      let c = Constant.make2 mp lab in
      if Declareops.constant_has_body cb then s else Cset.add c s
@@ -107,7 +107,7 @@ let rec collect_constants_without_body sign mp accu =
   match sign with
   | MoreFunctor _ -> Cset.empty  (* currently ignored *)
   | NoFunctor struc ->
-     List.fold_left (fun s (lab,mb) -> collect_sf s lab mb) accu struc
+     List.fold_left (fun s (lab,mb) -> collect_field s lab mb) accu struc
 
 let rec check_module env opac mp mb opacify =
   Flags.if_verbose Feedback.msg_notice (str "  checking module: " ++ str (ModPath.to_string mp));

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -601,14 +601,14 @@ let encode_path ?loc prefix mpdir suffix id =
 
 let raw_string_of_ref ?loc _ = let open GlobRef in function
   | ConstRef cst ->
-      let (mp,id) = Constant.repr2 cst in
+      let (mp,id) = KerName.repr (Constant.user cst) in
       encode_path ?loc "CST" (Some mp) [] (Label.to_id id)
   | IndRef (kn,i) ->
-      let (mp,id) = MutInd.repr2 kn in
+      let (mp,id) = KerName.repr (MutInd.user kn) in
       encode_path ?loc "IND" (Some mp) [Label.to_id id]
         (Id.of_string ("_"^string_of_int i))
   | ConstructRef ((kn,i),j) ->
-      let (mp,id) = MutInd.repr2 kn in
+      let (mp,id) = KerName.repr (MutInd.user kn) in
       encode_path ?loc "CSTR" (Some mp)
         [Label.to_id id;Id.of_string ("_"^string_of_int i)]
         (Id.of_string ("_"^string_of_int j))

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -623,7 +623,7 @@ let push_fix_renv renv (_,v,_ as recdef) =
     genv = iterate (fun ge -> lazy Not_subterm::ge) n renv.genv }
 
 (* Definition and manipulation of the stack *)
-type stack_element = |SClosure of guard_env*constr |SArg of subterm_spec Lazy.t
+type stack_element = SClosure of guard_env*constr | SArg of subterm_spec Lazy.t
 
 let push_stack_closures renv l stack =
   List.fold_right (fun h b -> (SClosure (renv,h))::b) l stack
@@ -644,7 +644,7 @@ let match_inductive ind ra =
     | Mrec i | Nested (NestedInd i) -> Ind.CanOrd.equal ind i
     | Norec | Nested (NestedPrimitive _) -> false
 
-(* In {match c as z in ci y_s return P with |C_i x_s => t end}
+(* In {match c as z in ci y_s return P with | C_i x_s => t end}
    [branches_specif renv c_spec ci] returns an array of x_s specs knowing
    c_spec. *)
 let branches_specif renv c_spec ci =
@@ -964,8 +964,8 @@ and lazy_subterm_specif renv stack t =
   lazy (subterm_specif renv stack t)
 
 and stack_element_specif = function
-  |SClosure (h_renv,h) -> lazy_subterm_specif h_renv [] h
-  |SArg x -> x
+  | SClosure (h_renv,h) -> lazy_subterm_specif h_renv [] h
+  | SArg x -> x
 
 and extract_stack = function
    | [] -> Lazy.from_val Not_subterm , []
@@ -1082,8 +1082,8 @@ let check_one_fix renv recpos trees def =
                   let z = List.nth stack' np in
                   if not (check_is_subterm (stack_element_specif z) trees.(glob)) then
                     begin match z with
-                      |SClosure (z,z') -> error_illegal_rec_call renv glob (z,z')
-                      |SArg _ -> error_partial_apply renv glob
+                      | SClosure (z,z') -> error_illegal_rec_call renv glob (z,z')
+                      | SArg _ -> error_partial_apply renv glob
                     end
               end
             else

--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -528,7 +528,7 @@ let add_delta_resolver resolver1 resolver2 =
   else
     update_delta_resolver resolver1 resolver2
 
-let substition_prefixed_by k mp subst =
+let substitution_prefixed_by k mp subst =
   let mp_prefixmp kmp (mp_to,reso) sub =
     if mp_in_mp mp kmp && not (ModPath.equal mp kmp) then
       let new_key = replace_mp_in_mp mp k kmp in
@@ -551,7 +551,7 @@ let join subst1 subst2 =
         | None ->
             subst_codom_delta_resolver subst2 resolve
     in
-    let prefixed_subst = substition_prefixed_by mpk mp' subst2 in
+    let prefixed_subst = substitution_prefixed_by mpk mp' subst2 in
     Umap.join prefixed_subst (add (mp',resolve'') res)
   in
   let mp_apply_subst mp = apply_subst mp (Umap.add_mp mp) in

--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -97,22 +97,22 @@ let debug_string_of_delta resolve =
   let l = Deltamap.fold mp_to_string kn_to_string resolve [] in
   String.concat ", " (List.rev l)
 
-let list_contents sub =
+let list_contents subst =
   let one_pair (mp,reso) = (ModPath.to_string mp,debug_string_of_delta reso) in
   let mp_one_pair mp0 p l = (ModPath.to_string mp0, one_pair p)::l in
-  Umap.fold mp_one_pair sub []
+  Umap.fold mp_one_pair subst []
 
-let debug_string_of_subst sub =
+let debug_string_of_subst subst =
   let l = List.map (fun (s1,(s2,s3)) -> s1^"|->"^s2^"["^s3^"]")
-    (list_contents sub)
+    (list_contents subst)
   in
   "{" ^ String.concat "; " l ^ "}"
 
 let debug_pr_delta resolve =
   str (debug_string_of_delta resolve)
 
-let debug_pr_subst sub =
-  let l = list_contents sub in
+let debug_pr_subst subst =
+  let l = list_contents subst in
   let f (s1,(s2,s3)) = hov 2 (str s1 ++ spc () ++ str "|-> " ++ str s2 ++
                               spc () ++ str "[" ++ str s3 ++ str "]")
   in
@@ -225,13 +225,13 @@ let search_delta_inline resolve kn1 kn2 =
       try find kn2
       with Not_found -> None
 
-let subst_mp0 sub mp = (* 's like subst *)
+let subst_mp_opt subst mp = (* 's like subst *)
  let rec aux mp =
   match mp with
-    | MPfile _ | MPbound _ -> Umap.find mp sub
+    | MPfile _ | MPbound _ -> Umap.find mp subst
     | MPdot (mp1,l) as mp2 ->
         begin
-          try Umap.find mp2 sub
+          try Umap.find mp2 subst
           with Not_found ->
             let mp1',resolve = aux mp1 in
             MPdot (mp1',l),resolve
@@ -239,31 +239,31 @@ let subst_mp0 sub mp = (* 's like subst *)
  in
  try Some (aux mp) with Not_found -> None
 
-let subst_mp sub mp =
- match subst_mp0 sub mp with
+let subst_mp subst mp =
+ match subst_mp_opt subst mp with
     None -> mp
   | Some (mp',_) -> mp'
 
-let subst_kn_delta sub kn =
+let subst_kn_delta subst kn =
  let mp,l = KerName.repr kn in
-  match subst_mp0 sub mp with
+  match subst_mp_opt subst mp with
      Some (mp',resolve) ->
       solve_delta_kn resolve (KerName.make mp' l)
    | None -> kn
 
 
-let subst_kn sub kn =
+let subst_kn subst kn =
  let mp,l = KerName.repr kn in
-  match subst_mp0 sub mp with
+  match subst_mp_opt subst mp with
      Some (mp',_) ->
       (KerName.make mp' l)
    | None -> kn
 
 exception No_subst
 
-let subst_dual_mp sub mp1 mp2 =
-  let o1 = subst_mp0 sub mp1 in
-  let o2 = if mp1 == mp2 then o1 else subst_mp0 sub mp2 in
+let subst_dual_mp subst mp1 mp2 =
+  let o1 = subst_mp_opt subst mp1 in
+  let o2 = if mp1 == mp2 then o1 else subst_mp_opt subst mp2 in
   match o1, o2 with
     | None, None -> raise No_subst
     | Some (mp1',resolve), None -> mp1', mp2, resolve, true
@@ -274,11 +274,11 @@ let progress f x ~orelse =
   let y = f x in
   if y != x then y else orelse
 
-let subst_mind sub mind =
+let subst_mind subst mind =
   let mpu,l = KerName.repr (MutInd.user mind) in
   let mpc = KerName.modpath (MutInd.canonical mind) in
   try
-    let mpu,mpc,resolve,user = subst_dual_mp sub mpu mpc in
+    let mpu,mpc,resolve,user = subst_dual_mp subst mpu mpc in
     let knu = KerName.make mpu l in
     let knc = if mpu == mpc then knu else KerName.make mpc l in
     let knc' =
@@ -287,8 +287,8 @@ let subst_mind sub mind =
     MutInd.make knu knc'
   with No_subst -> mind
 
-let subst_ind sub (ind,i as indi) =
-  let ind' = subst_mind sub ind in
+let subst_ind subst (ind,i as indi) =
+  let ind' = subst_mind subst ind in
     if ind' == ind then indi else ind',i
 
 let subst_constructor subst (ind,j as ref) =
@@ -296,13 +296,13 @@ let subst_constructor subst (ind,j as ref) =
   if ind==ind' then ref
   else (ind',j)
 
-let subst_pind sub (ind,u) =
-  (subst_ind sub ind, u)
+let subst_pind subst (ind,u) =
+  (subst_ind subst ind, u)
 
-let subst_con0 sub cst =
+let subst_con0 subst cst =
   let mpu,l = KerName.repr (Constant.user cst) in
   let mpc = KerName.modpath (Constant.canonical cst) in
-  let mpu,mpc,resolve,user = subst_dual_mp sub mpu mpc in
+  let mpu,mpc,resolve,user = subst_dual_mp subst mpu mpc in
   let knu = KerName.make mpu l in
   let knc = if mpu == mpc then knu else KerName.make mpc l in
   match search_delta_inline resolve knu knc with
@@ -316,24 +316,24 @@ let subst_con0 sub cst =
       let cst' = Constant.make knu knc' in
       cst', None
 
-let subst_con sub cst =
-  try subst_con0 sub cst
+let subst_con subst cst =
+  try subst_con0 subst cst
   with No_subst -> cst, None
 
-let subst_pcon sub (con,u as pcon) =
-  try let con', _can = subst_con0 sub con in
+let subst_pcon subst (con,u as pcon) =
+  try let con', _can = subst_con0 subst con in
         con',u
   with No_subst -> pcon
 
-let subst_constant sub con =
-  try fst (subst_con0 sub con)
+let subst_constant subst con =
+  try fst (subst_con0 subst con)
   with No_subst -> con
 
-let subst_proj_repr sub p =
-  Projection.Repr.map (subst_mind sub) p
+let subst_proj_repr subst p =
+  Projection.Repr.map (subst_mind subst) p
 
-let subst_proj sub p =
-  Projection.map (subst_mind sub) p
+let subst_proj subst p =
+  Projection.map (subst_mind subst) p
 
 let subst_retro_action subst action =
   let open Retroknowledge in
@@ -422,15 +422,15 @@ let rec map_kn f f' c =
             else mkCoFix (ln,(lna,tl',bl'))
       | _ -> c
 
-let subst_mps sub c =
-  let subst_pcon_term sub (con,u) =
-    let con', can = subst_con0 sub con in
+let subst_mps subst c =
+  let subst_pcon_term subst (con,u) =
+    let con', can = subst_con0 subst con in
     match can with
     | None -> mkConstU (con',u)
     | Some t -> Vars.univ_instantiate_constr u t
   in
-  if is_empty_subst sub then c
-  else map_kn (subst_mind sub) (subst_pcon_term sub) c
+  if is_empty_subst subst then c
+  else map_kn (subst_mind subst) (subst_pcon_term subst) c
 
 let rec replace_mp_in_mp mpfrom mpto mp =
   match mp with
@@ -474,8 +474,8 @@ let subst_dom_delta_resolver subst resolver =
   in
   Deltamap.fold mp_apply_subst kn_apply_subst resolver empty_delta_resolver
 
-let subst_mp_delta sub mp mkey =
- match subst_mp0 sub mp with
+let subst_mp_delta subst mp mkey =
+ match subst_mp_opt subst mp with
     None -> empty_delta_resolver,mp
   | Some (mp',resolve) ->
       let mp1 = find_prefix resolve mp' in
@@ -529,18 +529,18 @@ let add_delta_resolver resolver1 resolver2 =
     update_delta_resolver resolver1 resolver2
 
 let substitution_prefixed_by k mp subst =
-  let mp_prefixmp kmp (mp_to,reso) sub =
+  let mp_prefixmp kmp (mp_to,reso) subst =
     if mp_in_mp mp kmp && not (ModPath.equal mp kmp) then
       let new_key = replace_mp_in_mp mp k kmp in
-      Umap.add_mp new_key (mp_to,reso) sub
-    else sub
+      Umap.add_mp new_key (mp_to,reso) subst
+    else subst
   in
   Umap.fold mp_prefixmp subst empty_subst
 
 let join subst1 subst2 =
   let apply_subst mpk add (mp,resolve) res =
     let mp',resolve' =
-      match subst_mp0 subst2 mp with
+      match subst_mp_opt subst2 mp with
         | None -> mp, None
         | Some (mp',resolve') ->  mp', Some resolve' in
     let resolve'' =

--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -275,7 +275,7 @@ let progress f x ~orelse =
   if y != x then y else orelse
 
 let subst_mind sub mind =
-  let mpu,l = MutInd.repr2 mind in
+  let mpu,l = KerName.repr (MutInd.user mind) in
   let mpc = KerName.modpath (MutInd.canonical mind) in
   try
     let mpu,mpc,resolve,user = subst_dual_mp sub mpu mpc in
@@ -300,7 +300,7 @@ let subst_pind sub (ind,u) =
   (subst_ind sub ind, u)
 
 let subst_con0 sub cst =
-  let mpu,l = Constant.repr2 cst in
+  let mpu,l = KerName.repr (Constant.user cst) in
   let mpc = KerName.modpath (Constant.canonical cst) in
   let mpu,mpc,resolve,user = subst_dual_mp sub mpu mpc in
   let knu = KerName.make mpu l in

--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -21,7 +21,8 @@ open Names
 open Constr
 
 (* For Inline, the int is an inlining level, and the constr (if present)
-   is the term into which we should inline. *)
+   is the term into which we should inline.
+   Equiv gives the canonical name in the given context. *)
 
 type delta_hint =
   | Inline of int * constr Univ.univ_abstracted option

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -221,12 +221,12 @@ let rec check_with_mod env struc (idl,mp1) mp equiv =
   | Reduction.NotConvertible -> error_incorrect_with_constraint lab
 
 let check_with env mp (sign,alg,reso,cst) = function
-  |WithDef(idl, (c, ctx)) ->
+  | WithDef(idl, (c, ctx)) ->
     let struc = destr_nofunctor mp sign in
     let struc', c', cst' = check_with_def env struc (idl, (c, ctx)) mp reso in
     let wd' = WithDef (idl, (c', ctx)) in
     NoFunctor struc', MEwith (alg,wd'), reso, Univ.Constraints.union cst' cst
-  |WithMod(idl,mp1) as wd ->
+  | WithMod(idl,mp1) as wd ->
     let struc = destr_nofunctor mp sign in
     let struc',reso',cst' = check_with_mod env struc (idl,mp1) mp reso in
     NoFunctor struc', MEwith (alg,wd), reso', Univ.Constraints.union cst' cst
@@ -253,15 +253,15 @@ let translate_apply env inl (sign,alg,reso,cst1) mp1 mkalg =
 let mk_alg_app alg arg = MEapply (alg,arg)
 
 let rec translate_mse env mpo inl = function
-  |MEident mp1 as me ->
+  | MEident mp1 as me ->
     let mb = match mpo with
-      |Some mp -> strengthen_and_subst_mb (lookup_module mp1 env) mp false
-      |None ->
+      | Some mp -> strengthen_and_subst_mb (lookup_module mp1 env) mp false
+      | None ->
         let mt = lookup_modtype mp1 env in
         module_body_of_type mt.mod_mp mt
     in
     mb.mod_type, me, mb.mod_delta, Univ.Constraints.empty
-  |MEapply (fe,mp1) ->
+  | MEapply (fe,mp1) ->
     translate_apply env inl (translate_mse env mpo inl fe) mp1 mk_alg_app
   |MEwith(me, with_decl) ->
     assert (Option.is_empty mpo); (* No 'with' syntax for modules *)
@@ -324,7 +324,7 @@ let finalize_module env mp (sign,alg,reso,cst1) restype = match restype with
     Univ.Constraints.(union cst1 (union cst2 cst3))
 
 let translate_module env mp inl = function
-  |MType (params,ty) ->
+  | MType (params,ty) ->
     let mtb, cst = translate_modtype env mp inl (params,ty) in
     module_body_of_type mp mtb, cst
   |MExpr (params,mse,oty) ->
@@ -338,32 +338,32 @@ let translate_module env mp inl = function
     thanks to strengthening. *)
 
 let rec unfunct = function
-  |NoFunctor me -> me
-  |MoreFunctor(_,_,me) -> unfunct me
+  | NoFunctor me -> me
+  | MoreFunctor(_,_,me) -> unfunct me
 
 let rec forbid_incl_signed_functor env = function
-  |MEapply(fe,_) -> forbid_incl_signed_functor env fe
-  |MEwith _ -> assert false (* No 'with' syntax for modules *)
-  |MEident mp1 ->
+  | MEapply(fe,_) -> forbid_incl_signed_functor env fe
+  | MEwith _ -> assert false (* No 'with' syntax for modules *)
+  | MEident mp1 ->
     let mb = lookup_module mp1 env in
     match mb.mod_type, mb.mod_type_alg, mb.mod_expr with
-    |MoreFunctor _, Some _, _ ->
+    | MoreFunctor _, Some _, _ ->
       (* functor + restricted signature = error *)
       error_include_restricted_functor mp1
-    |MoreFunctor _, None, Algebraic me ->
+    | MoreFunctor _, None, Algebraic me ->
       (* functor, no signature yet, a definition which may be restricted *)
       forbid_incl_signed_functor env (unfunct me)
     |_ -> ()
 
 let rec translate_mse_inclmod env mp inl = function
-  |MEident mp1 ->
+  | MEident mp1 ->
     let mb = strengthen_and_subst_mb (lookup_module mp1 env) mp true in
     let sign = clean_bounded_mod_expr mb.mod_type in
     sign,(),mb.mod_delta,Univ.Constraints.empty
-  |MEapply (fe,arg) ->
+  | MEapply (fe,arg) ->
     let ftrans = translate_mse_inclmod env mp inl fe in
     translate_apply env inl ftrans arg (fun _ _ -> ())
-  |MEwith _ -> assert false (* No 'with' syntax for modules *)
+  | MEwith _ -> assert false (* No 'with' syntax for modules *)
 
 let translate_mse_incl is_mod env mp inl me =
   if is_mod then

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -70,7 +70,7 @@ let rec check_with_def env struc (idl,(c,ctx)) mp equiv =
         | _ -> error_not_a_constant lab
       in
       (* In the spirit of subtyping.check_constant, we accept
-         any implementations of parameters and opaques terms,
+         any implementations of parameters and opaque terms,
          as long as they have the right type *)
       let c', univs, ctx' =
         match cb.const_universes, ctx with

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -174,7 +174,7 @@ let rec check_with_mod env struc (idl,mp1) mp equiv =
         | _ -> error_generative_module_expected lab
       in
       let mp' = MPdot (mp,lab) in
-      let new_mb = strengthen_and_subst_mb mb_mp1 mp' false in
+      let new_mb = strengthen_and_subst_module_body mb_mp1 mp' false in
       let new_mb' =
         { new_mb with
           mod_mp = mp';
@@ -255,7 +255,7 @@ let mk_alg_app alg arg = MEapply (alg,arg)
 let rec translate_mse env mpo inl = function
   | MEident mp1 as me ->
     let mb = match mpo with
-      | Some mp -> strengthen_and_subst_mb (lookup_module mp1 env) mp false
+      | Some mp -> strengthen_and_subst_module_body (lookup_module mp1 env) mp false
       | None ->
         let mt = lookup_modtype mp1 env in
         module_body_of_type mt.mod_mp mt
@@ -355,20 +355,20 @@ let rec forbid_incl_signed_functor env = function
       forbid_incl_signed_functor env (unfunct me)
     |_ -> ()
 
-let rec translate_mse_inclmod env mp inl = function
+let rec translate_mse_include_module env mp inl = function
   | MEident mp1 ->
-    let mb = strengthen_and_subst_mb (lookup_module mp1 env) mp true in
+    let mb = strengthen_and_subst_module_body (lookup_module mp1 env) mp true in
     let sign = clean_bounded_mod_expr mb.mod_type in
     sign,(),mb.mod_delta,Univ.Constraints.empty
   | MEapply (fe,arg) ->
-    let ftrans = translate_mse_inclmod env mp inl fe in
+    let ftrans = translate_mse_include_module env mp inl fe in
     translate_apply env inl ftrans arg (fun _ _ -> ())
   | MEwith _ -> assert false (* No 'with' syntax for modules *)
 
-let translate_mse_incl is_mod env mp inl me =
+let translate_mse_include is_mod env mp inl me =
   if is_mod then
     let () = forbid_incl_signed_functor env me in
-    translate_mse_inclmod env mp inl me
+    translate_mse_include_module env mp inl me
   else
     let mtb, cst = translate_modtype env mp inl ([],me) in
     let sign = clean_bounded_mod_expr mtb.mod_type in

--- a/kernel/mod_typing.mli
+++ b/kernel/mod_typing.mli
@@ -56,6 +56,6 @@ val finalize_module :
 (** [translate_mse_incl] translate the mse of a module or
     module type given to an Include *)
 
-val translate_mse_incl :
+val translate_mse_include :
   bool -> env -> ModPath.t -> inline -> module_struct_entry ->
     unit translation

--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -302,7 +302,7 @@ let add_module mb env =
 let add_module_type mp mtb env =
   add_module (module_body_of_type mp mtb) env
 
-(** {6 Strengtening } *)
+(** {6 Strengthening } *)
 
 let strengthen_const mp_from l cb resolver =
   match cb.const_body with

--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -499,7 +499,7 @@ and strengthen_and_subst_struct str subst mp_from mp_to alias incl reso =
     - The first one is applying the substitution {P <- M} on the type of P
     - The second one is strengthening. *)
 
-let strengthen_and_subst_mb mb mp include_b = match mb.mod_type with
+let strengthen_and_subst_module_body mb mp include_b = match mb.mod_type with
   | NoFunctor struc ->
     let mb_is_an_alias = mp_in_delta mb.mod_mp mb.mod_delta in
     (* if mb.mod_mp is an alias then the strengthening is useless

--- a/kernel/modops.mli
+++ b/kernel/modops.mli
@@ -32,7 +32,7 @@ val module_body_of_type : ModPath.t -> module_type_body -> module_body
 
 val check_modpath_equiv : env -> ModPath.t -> ModPath.t -> unit
 
-val implem_smartmap :
+val implem_smart_map :
   (module_signature -> module_signature) ->
   (module_expression -> module_expression) ->
   (module_implementation -> module_implementation)

--- a/kernel/modops.mli
+++ b/kernel/modops.mli
@@ -67,7 +67,7 @@ val inline_delta_resolver :
   env -> inline -> ModPath.t -> MBId.t -> module_type_body ->
   delta_resolver -> delta_resolver
 
-val strengthen_and_subst_mb : module_body -> ModPath.t -> bool -> module_body
+val strengthen_and_subst_module_body : module_body -> ModPath.t -> bool -> module_body
 
 val subst_modtype_signature_and_resolver : ModPath.t -> ModPath.t ->
   module_signature -> delta_resolver -> module_signature * delta_resolver

--- a/kernel/modops.mli
+++ b/kernel/modops.mli
@@ -63,14 +63,16 @@ val add_retroknowledge : module_implementation module_retroknowledge -> env -> e
 
 val strengthen : module_type_body -> ModPath.t -> module_type_body
 
-val inline_delta_resolver :
-  env -> inline -> ModPath.t -> MBId.t -> module_type_body ->
-  delta_resolver -> delta_resolver
-
 val strengthen_and_subst_module_body : module_body -> ModPath.t -> bool -> module_body
 
 val subst_modtype_signature_and_resolver : ModPath.t -> ModPath.t ->
   module_signature -> delta_resolver -> module_signature * delta_resolver
+
+(** {6 Building map of constants to inline } *)
+
+val inline_delta_resolver :
+  env -> inline -> ModPath.t -> MBId.t -> module_type_body ->
+  delta_resolver -> delta_resolver
 
 (** {6 Cleaning a module expression from bounded parts }
 

--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -499,7 +499,6 @@ module KerPair = struct
 
   let make1 = same
   let make2 mp l = same (KerName.make mp l)
-  let repr2 kp = KerName.repr (user kp)
   let label kp = KerName.label (user kp)
   let modpath kp = KerName.modpath (user kp)
 

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -386,9 +386,6 @@ sig
   val user : t -> KerName.t
   val canonical : t -> KerName.t
 
-  val repr2 : t -> ModPath.t * Label.t
-  (** Shortcut for [KerName.repr (user ...)] *)
-
   val modpath : t -> ModPath.t
   (** Shortcut for [KerName.modpath (user ...)] *)
 
@@ -459,9 +456,6 @@ sig
 
   val user : t -> KerName.t
   val canonical : t -> KerName.t
-
-  val repr2 : t -> ModPath.t * Label.t
-  (** Shortcut for [KerName.repr (user ...)] *)
 
   val modpath : t -> ModPath.t
   (** Shortcut for [KerName.modpath (user ...)] *)

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1215,7 +1215,7 @@ let add_include me is_module inl senv =
   let open Mod_typing in
   let mp_sup = senv.modpath in
   let sign,(),resolver,cst =
-    translate_mse_incl is_module senv.env mp_sup inl me
+    translate_mse_include is_module senv.env mp_sup inl me
   in
   let senv = push_context_set ~strict:true (Univ.Level.Set.empty,cst) senv in
   (* Include Self support  *)

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1127,7 +1127,7 @@ let propagate_loads senv =
 let functorize_module params mb =
   let f x = functorize params x in
   { mb with
-    mod_expr = Modops.implem_smartmap f f mb.mod_expr;
+    mod_expr = Modops.implem_smart_map f f mb.mod_expr;
     mod_type = f mb.mod_type;
     mod_type_alg = Option.map f mb.mod_type_alg }
 

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -293,8 +293,8 @@ and check_modtypes cst env mtb1 mtb2 subst1 subst2 equiv =
   else
     let rec check_structure cst env str1 str2 equiv subst1 subst2 =
       match str1,str2 with
-      |NoFunctor list1,
-       NoFunctor list2 ->
+      | NoFunctor list1,
+        NoFunctor list2 ->
         if equiv then
           let subst2 = add_mp mtb2.mod_mp mtb1.mod_mp mtb1.mod_delta subst2 in
           let cst1 = check_signatures cst env
@@ -310,8 +310,8 @@ and check_modtypes cst env mtb1 mtb2 subst1 subst2 equiv =
           check_signatures cst env
             mtb1.mod_mp list1 mtb2.mod_mp list2 subst1 subst2
             mtb1.mod_delta  mtb2.mod_delta
-      |MoreFunctor (arg_id1,arg_t1,body_t1),
-       MoreFunctor (arg_id2,arg_t2,body_t2) ->
+      | MoreFunctor (arg_id1,arg_t1,body_t1),
+        MoreFunctor (arg_id2,arg_t2,body_t2) ->
         let mp2 = MPbound arg_id2 in
         let subst1 = join (map_mbid arg_id1 mp2 arg_t2.mod_delta) subst1 in
         let cst = check_modtypes cst env arg_t2 arg_t1 subst2 subst1 equiv in

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -260,7 +260,7 @@ let rec check_modules cst env msb1 msb2 subst1 subst2 =
   let mty2 =  module_type_of_module msb2 in
   check_modtypes cst env mty1 mty2 subst1 subst2 false
 
-and check_signatures cst env mp1 sig1 mp2 sig2 subst1 subst2 reso1 reso2=
+and check_signatures cst env mp1 sig1 mp2 sig2 subst1 subst2 reso1 reso2 =
   let map1 = make_labmap mp1 sig1 in
   let check_one_body cst (l,spec2) =
     match spec2 with
@@ -303,7 +303,7 @@ and check_modtypes cst env mtb1 mtb2 subst1 subst2 equiv =
           in
           let cst2 = check_signatures cst env
             mtb2.mod_mp list2 mtb1.mod_mp list1 subst2 subst1
-            mtb2.mod_delta  mtb1.mod_delta
+            mtb2.mod_delta mtb1.mod_delta
           in
           Univ.Constraints.union cst1 cst2
         else

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -291,8 +291,8 @@ and check_signatures cst env mp1 sig1 mp2 sig2 subst1 subst2 reso1 reso2 =
 and check_modtypes cst env mtb1 mtb2 subst1 subst2 equiv =
   if mtb1==mtb2 || mtb1.mod_type == mtb2.mod_type then cst
   else
-    let rec check_structure cst env str1 str2 equiv subst1 subst2 =
-      match str1,str2 with
+    let rec check_structure cst env struc1 struc2 equiv subst1 subst2 =
+      match struc1,struc2 with
       | NoFunctor list1,
         NoFunctor list2 ->
         if equiv then

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -36,9 +36,9 @@ let occur_kn_in_ref kn = let open GlobRef in function
   | ConstRef _ | VarRef _ -> false
 
 let repr_of_r = let open GlobRef in function
-  | ConstRef kn -> Constant.repr2 kn
+  | ConstRef kn -> KerName.repr (Constant.user kn)
   | IndRef (kn,_)
-  | ConstructRef ((kn,_),_) -> MutInd.repr2 kn
+  | ConstructRef ((kn,_),_) -> KerName.repr (MutInd.user kn)
   | VarRef v -> KerName.repr (Lib.make_kn v)
 
 let modpath_of_r r =
@@ -288,7 +288,7 @@ let safe_pr_long_global r =
   try Printer.pr_global r
   with Not_found -> match r with
     | GlobRef.ConstRef kn ->
-        let mp,l = Constant.repr2 kn in
+        let mp,l = KerName.repr (Constant.user kn) in
         str ((ModPath.to_string mp)^"."^(Label.to_string l))
     | _ -> assert false
 

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -394,7 +394,7 @@ let pirrel_rewrite ?(under=false) ?(map_redex=id_map_redex) pred rdx rdx_ty new_
       let sigma, elim = Evd.fresh_global env sigma (Indrec.lookup_eliminator env ind sort) in
       if dir = R2L then sigma, elim else
       let elim, _ = EConstr.destConst sigma elim in
-      let mp,l = Constant.repr2 (Constant.make1 (Constant.canonical elim)) in
+      let mp,l = KerName.repr (Constant.canonical elim) in
       let l' = Label.of_id (Nameops.add_suffix (Label.to_id l) "_r")  in
       let c1' = Global.constant_of_delta_kn (Constant.canonical (Constant.make2 mp l')) in
       sigma, EConstr.of_constr (mkConst c1')

--- a/tactics/cbn.ml
+++ b/tactics/cbn.ml
@@ -440,7 +440,7 @@ let magically_constant_of_fixbody env sigma reference bd = function
   | Name.Anonymous -> bd
   | Name.Name id ->
     let open UnivProblem in
-    let (cst_mod,_) = Constant.repr2 reference in
+    let cst_mod = KerName.modpath (Constant.user reference) in
     let cst = Constant.make2 cst_mod (Label.of_id id) in
     if not (Environ.mem_constant cst env) then bd
     else

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -369,7 +369,7 @@ let find_elim hdcncl lft2rgt dep cls ot =
           | Some r -> destConstRef r
           | None ->
             let c1 = destConstRef (lookup_eliminator env ind_sp sort) in
-            let mp,l = Constant.repr2 (Constant.make1 (Constant.canonical c1)) in
+            let mp,l = KerName.repr (Constant.canonical c1) in
             let l' = Label.of_id (add_suffix (Label.to_id l) "_r")  in
             let c1' = Global.constant_of_delta_kn (KerName.make mp l') in
             if not (Environ.mem_constant c1' (Global.env ())) then

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -59,8 +59,8 @@ let rec search_mind_label lab = function
 *)
 
 let rec fields_of_functor f subs mp0 args = function
-  |NoFunctor a -> f subs mp0 args a
-  |MoreFunctor (mbid,_,e) ->
+  | NoFunctor a -> f subs mp0 args a
+  | MoreFunctor (mbid,_,e) ->
     match args with
     | [] -> assert false (* we should only encounter applied functors *)
     | mpa :: args ->
@@ -95,9 +95,9 @@ and fields_of_mp mp =
   Modops.subst_structure subs fields
 
 and fields_of_mb subs mb args = match mb.mod_expr with
-  |Algebraic expr -> fields_of_expression subs mb.mod_mp args expr
-  |Struct sign -> fields_of_signature subs mb.mod_mp args sign
-  |Abstract|FullStruct -> fields_of_signature subs mb.mod_mp args mb.mod_type
+  | Algebraic expr -> fields_of_expression subs mb.mod_mp args expr
+  | Struct sign -> fields_of_signature subs mb.mod_mp args sign
+  | Abstract|FullStruct -> fields_of_signature subs mb.mod_mp args mb.mod_type
 
 (** The Abstract case above corresponds to [Declare Module] *)
 
@@ -108,11 +108,11 @@ and fields_of_signature x =
       (struc, mp0, subs)) x
 
 and fields_of_expr subs mp0 args = function
-  |MEident mp ->
+  | MEident mp ->
     let mb = lookup_module_in_impl (subst_mp subs mp) in
     fields_of_mb subs mb args
-  |MEapply (me1,mp2) -> fields_of_expr subs mp0 (mp2::args) me1
-  |MEwith _ -> assert false (* no 'with' in [mod_expr] *)
+  | MEapply (me1,mp2) -> fields_of_expr subs mp0 (mp2::args) me1
+  | MEwith _ -> assert false (* no 'with' in [mod_expr] *)
 
 and fields_of_expression x = fields_of_functor fields_of_expr x
 

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -911,6 +911,10 @@ let type_of_incl env is_mod = function
     decompose_functor mp_l (type_of_mod mp0 env is_mod)
   | MEwith _ -> raise NoIncludeSelf
 
+(** Implements [Include F] where [F] has parameters [mbids] to be
+    instantiated by fields of the current "self" module, i.e. using
+    subtyping, by the current module itself. *)
+
 let declare_one_include (me_ast,annot) =
   let env = Global.env() in
   let me, kind, cst = Modintern.interp_module_ast env Modintern.ModAny me_ast in

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -532,7 +532,7 @@ let rec get_module_sobjs is_mod env inl = function
     assert (not is_mod);
     let sobjs0 = get_module_sobjs is_mod env inl mty in
     assert (sobjs_no_functor sobjs0);
-    (* For now, we expanse everything, to be safe *)
+    (* For now, we expand everything, to be safe *)
     let mp0 = get_module_path mty in
     let objs0 = expand_sobjs sobjs0 in
     let objs1 = expand_sobjs (ModSubstObjs.get mp1) in

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -510,25 +510,25 @@ let rec replace_module_object idl mp0 objs0 mp1 objs1 =
   | idl,lobj::tail -> lobj::replace_module_object idl mp0 tail mp1 objs1
 
 let type_of_mod mp env = function
-  |true -> (Environ.lookup_module mp env).mod_type
-  |false -> (Environ.lookup_modtype mp env).mod_type
+  | true -> (Environ.lookup_module mp env).mod_type
+  | false -> (Environ.lookup_modtype mp env).mod_type
 
 let rec get_module_path = function
-  |MEident mp -> mp
-  |MEwith (me,_) -> get_module_path me
-  |MEapply (me,_) -> get_module_path me
+  | MEident mp -> mp
+  | MEwith (me,_) -> get_module_path me
+  | MEapply (me,_) -> get_module_path me
 
 (** Substitutive objects of a module expression (or module type) *)
 
 let rec get_module_sobjs is_mod env inl = function
-  |MEident mp ->
+  | MEident mp ->
     begin match ModSubstObjs.get mp with
-    |(mbids,Objs _) when not (ModPath.is_bound mp) ->
+    | (mbids,Objs _) when not (ModPath.is_bound mp) ->
       (mbids,Ref (mp, empty_subst)) (* we create an alias *)
-    |sobjs -> sobjs
+    | sobjs -> sobjs
     end
-  |MEwith (mty, WithDef _) -> get_module_sobjs is_mod env inl mty
-  |MEwith (mty, WithMod (idl,mp1)) ->
+  | MEwith (mty, WithDef _) -> get_module_sobjs is_mod env inl mty
+  | MEwith (mty, WithMod (idl,mp1)) ->
     assert (not is_mod);
     let sobjs0 = get_module_sobjs is_mod env inl mty in
     assert (sobjs_no_functor sobjs0);
@@ -537,7 +537,7 @@ let rec get_module_sobjs is_mod env inl = function
     let objs0 = expand_sobjs sobjs0 in
     let objs1 = expand_sobjs (ModSubstObjs.get mp1) in
     ([], Objs (replace_module_object idl mp0 objs0 mp1 objs1))
-  |MEapply _ as me ->
+  | MEapply _ as me ->
     let mp1, mp_l = get_applications me in
     let mbids, aobjs = get_module_sobjs is_mod env inl (MEident mp1) in
     let typ = type_of_mod mp1 env is_mod in
@@ -905,11 +905,11 @@ let rec decompose_functor mpl typ =
 exception NoIncludeSelf
 
 let type_of_incl env is_mod = function
-  |MEident mp -> type_of_mod mp env is_mod
-  |MEapply _ as me ->
+  | MEident mp -> type_of_mod mp env is_mod
+  | MEapply _ as me ->
     let mp0, mp_l = get_applications me in
     decompose_functor mp_l (type_of_mod mp0 env is_mod)
-  |MEwith _ -> raise NoIncludeSelf
+  | MEwith _ -> raise NoIncludeSelf
 
 let declare_one_include (me_ast,annot) =
   let env = Global.env() in


### PR DESCRIPTION
**Kind:** cleanup

This is mostly cosmetic internal changes + a few API renaming.

Cosmetic internal changes:
- expanding/unifying terminology to make it easier to read from outside: mod -> module, incl -> include, sub -> subst, ...
- standardizing use of a space after `|` in pattern-matching
- a bit of comments on the code
- a bit of code factorization
- typos

API renaming:
- most importantly: cryptic `subst_mps` renamed to `subst_constr` to follow the standard pattern for `subst_` functions
- more confidentially: expanding `mb` and `incl` in `strengthen_and_subst_mb` and `translate_mse_incl`

[ ] document the `subst_mps` change