### PR TITLE
Parameterize the Evarutil naming flag with the rigid set of identifiers.

### DIFF
--- a/dev/ci/user-overlays/15407-ppedrot-evarutil-precise-naming-mode.sh
+++ b/dev/ci/user-overlays/15407-ppedrot-evarutil-precise-naming-mode.sh
@@ -1,0 +1,1 @@
+overlay equations https://github.com/ppedrot/Coq-Equations evarutil-precise-naming-mode 15407

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -24,12 +24,18 @@ val new_meta : unit -> metavariable
 
 (** {6 Creating a fresh evar given their type and context} *)
 
+module VarSet :
+sig
+  type t
+  val empty : t
+  val full : t
+  val variables : Environ.env -> t
+end
+
 type naming_mode =
-  | KeepUserNameAndRenameExistingButSectionNames
-  | KeepUserNameAndRenameExistingEvenSectionNames
-  | KeepExistingNames
+  | RenameExistingBut of VarSet.t
   | FailIfConflict
-  | ProgramNaming
+  | ProgramNaming of VarSet.t
 
 val new_evar :
   ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
@@ -254,10 +260,10 @@ val csubst_subst : csubst -> constr -> constr
 type ext_named_context =
   csubst * Id.Set.t * named_context_val
 
-val push_rel_decl_to_named_context : ?hypnaming:naming_mode ->
+val push_rel_decl_to_named_context : hypnaming:naming_mode ->
   evar_map -> rel_declaration -> ext_named_context -> ext_named_context
 
-val push_rel_context_to_named_context : ?hypnaming:naming_mode ->
+val push_rel_context_to_named_context : hypnaming:naming_mode ->
   Environ.env -> evar_map -> types ->
   named_context_val * types * constr list * csubst
 

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -764,7 +764,8 @@ let make_evar_clause env sigma ?len t =
       let inst, ctx, args, identity, subst = match inst with
       | None ->
         (* Dummy type *)
-        let ctx, _, args, subst = push_rel_context_to_named_context env sigma mkProp in
+        let hypnaming = RenameExistingBut (VarSet.variables (Global.env ())) in
+        let ctx, _, args, subst = push_rel_context_to_named_context ~hypnaming env sigma mkProp in
         let id = if Int.equal (Environ.nb_rel env) 0 then Identity.make args else Identity.none () in
         Some (ctx, args, id, subst), ctx, args, id, subst
       | Some (ctx, args, id, subst) -> inst, ctx, args, id, subst


### PR DESCRIPTION
In addition to merging three constructors and making the system more general, it allows pushing a call to Global.env further up.

Overlays:
- https://github.com/mattam82/Coq-Equations/pull/470
