### PR TITLE
[stdlib] [Arith] Integrate deprecated results from Arith.Even and Arith.Div2

### DIFF
--- a/doc/changelog/10-standard-library/14736-Arith2.rst
+++ b/doc/changelog/10-standard-library/14736-Arith2.rst
@@ -3,10 +3,13 @@
   (``Div2``, ``Even``, ``Gt``, ``Le``, ``Lt``, ``Max``, ``Min``, ``Minus``, ``Mult``, ``NPeano``, ``Plus``).
   Import ``Arith_base`` instead of these files.  References to items in the deprecated files should be replaced
   with references to ``PeanoNat.Nat`` as suggested by the warning messages.
+  Concerning the definitions of parity properties (even and odd), it is recommended to use ``Nat.Even`` and ``Nat.Odd``.
+  If an inductive definition of parity is required, the mutually inductive ``Nat.Even_alt`` and ``Nat.Odd_alt`` can be used. However, induction principles for ``Nat.Odd`` and ``Nat.Even`` are available as ``Nat.Even_Odd_ind`` and ``Nat.Odd_Even_ind``.
+  The equivalence between the non-inductive and mutually inductive definitions of parity can be found in ``Nat.Even_alt_Even`` and ``Nat.Odd_alt_Odd``.
   All ``Hint`` declarations in the ``arith`` database have been moved to ``Arith_prebase`` and
   ``Arith_base``.  To use the results about Peano arithmetic, we recommend importing
   ``PeanoNat`` (or ``Arith_base`` to base it on the ``arith`` hint database) and using the ``Nat`` module.
   ``Arith_prebase`` has been introduced temporarily to ensure compatibility, but it will be removed at the end of the
   deprecation phase, e.g. in 8.18.  Its use is thus discouraged.
-  (`#14736 <https://github.com/coq/coq/pull/14736>`_,
-  by Olivier Laurent).
+  (`#14736 <https://github.com/coq/coq/pull/14736>`_, `#15411 <https://github.com/coq/coq/pull/15411>`_,
+  by Olivier Laurent, with help of Karl Palmskog).

--- a/theories/Arith/Arith_prebase.v
+++ b/theories/Arith/Arith_prebase.v
@@ -307,6 +307,12 @@ Hint Resolve Nat.max_l Nat.max_r Nat.le_max_l Nat.le_max_r: arith.
 #[global]
 Hint Resolve Nat.min_l Nat.min_r Nat.le_min_l Nat.le_min_r: arith.
 
+(* ** [Even_alt] and [Odd_alt] *)
+#[global]
+Hint Constructors Nat.Even_alt: arith.
+#[global]
+Hint Constructors Nat.Odd_alt: arith.
+
 
 (* Register *)
 #[local]

--- a/theories/Arith/Div2.v
+++ b/theories/Arith/Div2.v
@@ -12,7 +12,7 @@
     Please consider using [Nat.div2] directly, and results about it
     (see file PeanoNat). *)
 
-Require Import PeanoNat Even.
+Require Import PeanoNat.
 
 Local Open Scope nat_scope.
 
@@ -52,42 +52,38 @@ Hint Resolve Nat.lt_div2: arith.
 (** Properties related to the parity *)
 
 #[local]
-Definition even_div2_stt n : even n -> Nat.div2 n = Nat.div2 (S n).
+Definition even_div2_stt n : Nat.Even_alt n -> Nat.div2 n = Nat.div2 (S n).
 Proof.
- rewrite Even.even_equiv_stt. intros (p,->).
+ rewrite Nat.Even_alt_Even. intros (p,->).
  rewrite Nat.div2_succ_double. apply Nat.div2_double.
 Qed.
-#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete. Use Nat.Even_div2 instead.")]
 Notation even_div2 := even_div2_stt.
 
 #[local]
-Definition odd_div2_stt n : odd n -> S (Nat.div2 n) = Nat.div2 (S n).
+Definition odd_div2_stt n : Nat.Odd_alt n -> S (Nat.div2 n) = Nat.div2 (S n).
 Proof.
- rewrite Even.odd_equiv_stt. intros (p,->).
+ rewrite Nat.Odd_alt_Odd. intros (p,->).
  rewrite Nat.add_1_r, Nat.div2_succ_double.
  simpl. f_equal. symmetry. apply Nat.div2_double.
 Qed.
-#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete. Use Nat.Odd_div2 instead.")]
 Notation odd_div2 := odd_div2_stt.
 
 #[local]
-Definition div2_even_stt n : Nat.div2 n = Nat.div2 (S n) -> even n.
+Definition div2_even_stt n : Nat.div2 n = Nat.div2 (S n) -> Nat.Even_alt n.
 Proof.
- destruct (Even.even_or_odd_stt n) as [Ev|Od]; trivial.
- apply odd_div2_stt in Od. rewrite <- Od. intro Od'.
- elim (n_Sn _ Od').
+ rewrite Nat.Even_alt_Even; apply Nat.div2_Even.
 Qed.
-#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete. Use Nat.div2_Even instead.")]
 Notation div2_even := div2_even_stt.
 
 #[local]
-Definition div2_odd_stt n : S (Nat.div2 n) = Nat.div2 (S n) -> odd n.
+Definition div2_odd_stt n : S (Nat.div2 n) = Nat.div2 (S n) -> Nat.Odd_alt n.
 Proof.
- destruct (Even.even_or_odd_stt n) as [Ev|Od]; trivial.
- apply even_div2_stt in Ev. rewrite <- Ev. intro Ev'.
- symmetry in Ev'. elim (n_Sn _ Ev').
+ rewrite Nat.Odd_alt_Odd; apply Nat.div2_Odd.
 Qed.
-#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete. Use Nat.div2_Odd instead.")]
 Notation div2_odd := div2_odd_stt.
 
 #[global]
@@ -95,12 +91,12 @@ Hint Resolve even_div2_stt div2_even_stt odd_div2_stt div2_odd_stt: arith.
 
 #[local]
 Definition even_odd_div2_stt n :
- (even n <-> Nat.div2 n = Nat.div2 (S n)) /\
- (odd n <-> S (Nat.div2 n) = Nat.div2 (S n)).
+ (Nat.Even_alt n <-> Nat.div2 n = Nat.div2 (S n)) /\
+ (Nat.Odd_alt n <-> S (Nat.div2 n) = Nat.div2 (S n)).
 Proof.
  split; split; auto using div2_odd_stt, div2_even_stt, odd_div2_stt, even_div2_stt.
 Qed.
-#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete. Use Nat.Even_Odd_div2 instead.")]
 Notation even_odd_div2 := even_odd_div2_stt.
 
 
@@ -113,67 +109,48 @@ Notation double := Nat.double (only parsing).
 #[global]
 Hint Unfold Nat.double: arith.
 
-#[local]
-Definition double_S_stt : forall n, Nat.double (S n) = S (S (Nat.double n))
-                        := fun n => Nat.add_succ_r (S n) n.
-Opaque double_S_stt.
-#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete. Use Nat.add_succ_r instead.")]
-Notation double_S := double_S_stt.
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete. Use Nat.double_S instead.")]
+Notation double_S := Nat.double_S.
 
-#[local]
-Definition double_plus_stt : forall n m, Nat.double (n + m) = Nat.double n + Nat.double m
-                           := fun n m => Nat.add_shuffle1 n m n m.
-Opaque double_plus_stt.
-#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete. Use Nat.add_shuffle1 instead.")]
-Notation double_plus := double_plus_stt.
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete. Use Nat.double_add instead.")]
+Notation double_plus := Nat.double_add.
 
 #[global]
-Hint Resolve double_S_stt: arith.
+Hint Resolve Nat.double_S: arith.
 
 #[local]
 Definition even_odd_double_stt n :
-  (even n <-> n = Nat.double (Nat.div2 n)) /\ (odd n <-> n = S (Nat.double (Nat.div2 n))).
+ (Nat.Even_alt n <-> n = Nat.double (Nat.div2 n)) /\ (Nat.Odd_alt n <-> n = S (Nat.double (Nat.div2 n))).
 Proof.
-  revert n. fix even_odd_double 1. intros n; destruct n as [|[|n]].
-  - (* n = 0 *)
-    split; split; auto with arith. inversion 1.
-  - (* n = 1 *)
-    split; split; auto with arith. inversion_clear 1 as [|? H0]. inversion H0.
-  - (* n = (S (S n')) *)
-    destruct (even_odd_double n) as ((Ev,Ev'),(Od,Od')).
-    split; split; simpl Nat.div2; rewrite ?double_S_stt.
-    + inversion_clear 1 as [|? H0]. inversion_clear H0. auto.
-    + injection 1. auto with arith.
-    + inversion_clear 1 as [? H0]. inversion_clear H0. auto.
-    + injection 1. auto with arith.
+ rewrite Nat.Even_alt_Even, Nat.Odd_alt_Odd; apply Nat.Even_Odd_double.
 Qed.
-#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete. Use Even_Odd_double instead.")]
 Notation even_odd_double := even_odd_double_stt.
 
 (** Specializations *)
 
 #[local]
-Definition even_double_stt n : even n -> n = Nat.double (Nat.div2 n).
+Definition even_double_stt n : Nat.Even_alt n -> n = Nat.double (Nat.div2 n).
 Proof proj1 (proj1 (even_odd_double_stt n)).
-#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete. Use Even_double instead.")]
 Notation even_double := even_double_stt.
 
 #[local]
-Definition double_even_stt n : n = Nat.double (Nat.div2 n) -> even n.
+Definition double_even_stt n : n = Nat.double (Nat.div2 n) -> Nat.Even_alt n.
 Proof proj2 (proj1 (even_odd_double_stt n)).
-#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete. Use double_Even instead.")]
 Notation double_even := double_even_stt.
 
 #[local]
-Definition odd_double_stt n : odd n -> n = S (Nat.double (Nat.div2 n)).
+Definition odd_double_stt n : Nat.Odd_alt n -> n = S (Nat.double (Nat.div2 n)).
 Proof proj1 (proj2 (even_odd_double_stt n)).
-#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete. Use Odd_double instead.")]
 Notation odd_double := odd_double_stt.
 
 #[local]
-Definition double_odd_stt n : n = S (Nat.double (Nat.div2 n)) -> odd n.
+Definition double_odd_stt n : n = S (Nat.double (Nat.div2 n)) -> Nat.Odd_alt n.
 Proof proj2 (proj2 (even_odd_double_stt n)).
-#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete. Use double_Odd instead.")]
 Notation double_odd := double_odd_stt.
 
 #[global]
@@ -186,19 +163,19 @@ Hint Resolve even_double_stt double_even_stt odd_double_stt double_odd_stt: arit
     (Immediate: it is [n/2]) *)
 
 #[local]
-Definition even_2n_stt : forall n, even n -> {p : nat | n = Nat.double p}.
+Definition even_2n_stt : forall n, Nat.Even_alt n -> {p : nat | n = Nat.double p}.
 Proof.
   intros n H. exists (Nat.div2 n). auto with arith.
 Defined.
-#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete. Use Nat.Even_alt_Even instead.")]
 Notation even_2n := even_2n_stt.
 
 #[local]
-Definition odd_S2n_stt : forall n, odd n -> {p : nat | n = S (Nat.double p)}.
+Definition odd_S2n_stt : forall n, Nat.Odd_alt n -> {p : nat | n = S (Nat.double p)}.
 Proof.
   intros n H. exists (Nat.div2 n). auto with arith.
 Defined.
-#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Div2 file is obsolete. Use Nat.Odd_alt_Odd instead.")]
 Notation odd_S2n := odd_S2n_stt.
 
 (** Doubling before dividing by two brings back to the initial number. *)
@@ -214,3 +191,6 @@ Definition div2_double_plus_one_stt n : Nat.div2 (S (2*n)) = n.
 Proof. apply Nat.div2_succ_double. Qed.
 #[deprecated(since="8.16",note="The Arith.Div2 file is obsolete. Use Nat.div2_succ_double instead.")]
 Notation div2_double_plus_one := div2_double_plus_one_stt.
+
+(* TODO #15411 for compatibility only, should be removed after deprecation *)
+Require Import Even.

--- a/theories/Arith/Even.v
+++ b/theories/Arith/Even.v
@@ -25,57 +25,42 @@ Implicit Types m n : nat.
 
 (** * Inductive definition of [even] and [odd] *)
 
-Inductive even : nat -> Prop :=
-  | even_O : even 0
-  | even_S : forall n, odd n -> even (S n)
-with odd : nat -> Prop :=
-    odd_S : forall n, even n -> odd (S n).
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Even or Nat.Even_alt instead.")]
+Notation even := Nat.Even_alt.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Even or Nat.Even_alt instead.")]
+Notation odd := Nat.Odd_alt.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Even or Nat.Even_alt_O instead.")]
+Notation even_O := Nat.Even_alt_O.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Even or Nat.Even_alt_S instead.")]
+Notation even_S := Nat.Even_alt_S.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Even or Nat.Odd_alt_S instead.")]
+Notation odd_S := Nat.Odd_alt_S.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Even or Nat.Even_alt_ind instead.")]
+Notation even_ind := Nat.Even_alt_ind.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Even or Nat.Even_alt_sind instead.")]
+Notation even_sind := Nat.Even_alt_sind.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Even or Nat.Odd_alt_ind instead.")]
+Notation odd_ind := Nat.Odd_alt_ind.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Even or Nat.Odd_alt_ind instead.")]
+Notation odd_sind := Nat.Odd_alt_sind.
 
 #[global]
-Hint Constructors even: arith.
+Hint Constructors Nat.Even_alt: arith.
 #[global]
-Hint Constructors odd: arith.
+Hint Constructors Nat.Odd_alt: arith.
 
 (** * Equivalence with predicates [Nat.Even] and [Nat.odd] *)
 
-#[local]
-Definition even_equiv_stt : forall n, even n <-> Nat.Even n.
-Proof.
- fix even_equiv 1.
- intros n; destruct n as [|[|n]]; simpl.
- - split; [now exists 0 | constructor].
- - split.
-   + inversion_clear 1 as [|? H0]. inversion_clear H0.
-   + now rewrite <- Nat.even_spec.
- - rewrite Nat.Even_succ_succ, <- even_equiv.
-   split.
-   + inversion_clear 1 as [|? H0]. now inversion_clear H0.
-   + now do 2 constructor.
-Qed.
-#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
-Notation even_equiv := even_equiv_stt.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Even_alt_Even instead.")]
+Notation even_equiv := Nat.Even_alt_Even.
 
-#[local]
-Definition odd_equiv_stt : forall n, odd n <-> Nat.Odd n.
-Proof.
- fix odd_equiv 1.
- intros n; destruct n as [|[|n]]; simpl.
- - split.
-   + inversion_clear 1.
-   + now rewrite <- Nat.odd_spec.
- - split; [ now exists 0 | do 2 constructor ].
- - rewrite Nat.Odd_succ_succ, <- odd_equiv.
-   split.
-   + inversion_clear 1 as [? H0]. now inversion_clear H0.
-   + now do 2 constructor.
-Qed.
-#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
-Notation odd_equiv := odd_equiv_stt.
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Odd_alt_Odd instead")]
+Notation odd_equiv := Nat.Odd_alt_Odd.
 
 (** Basic facts *)
 
 #[local]
-Definition even_or_odd_stt n : even n \/ odd n.
+Definition even_or_odd_stt n : Nat.Even_alt n \/ Nat.Odd_alt n.
 Proof.
   induction n as [|n IHn].
   - auto with arith.
@@ -85,17 +70,17 @@ Qed.
 Notation even_or_odd := even_or_odd_stt.
 
 #[local]
-Definition even_odd_dec_stt n : {even n} + {odd n}.
+Definition even_odd_dec_stt n : {Nat.Even_alt n} + {Nat.Odd_alt n}.
 Proof.
   induction n as [|n IHn].
   - auto with arith.
   - elim IHn; auto with arith.
 Defined.
-#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Even_Odd_dec instead")]
 Notation even_odd_dec := even_odd_dec_stt.
 
 #[local]
-Definition not_even_and_odd_stt n : even n -> odd n -> False.
+Definition not_even_and_odd_stt n : Nat.Even_alt n -> Nat.Odd_alt n -> False.
 Proof.
   induction n.
   - intros Ev Od. inversion Od.
@@ -109,11 +94,11 @@ Notation not_even_and_odd := not_even_and_odd_stt (only parsing).
 
 #[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
 Ltac parity2bool :=
- rewrite ?even_equiv_stt, ?odd_equiv_stt, <- ?Nat.even_spec, <- ?Nat.odd_spec.
+ rewrite ?Nat.Even_alt_Even, ?Nat.Odd_alt_Odd, <- ?Nat.even_spec, <- ?Nat.odd_spec.
 
 #[local]
 Ltac parity2bool_dep :=
- rewrite ?even_equiv_stt, ?odd_equiv_stt, <- ?Nat.even_spec, <- ?Nat.odd_spec.
+ rewrite ?Nat.Even_alt_Even, ?Nat.Odd_alt_Odd, <- ?Nat.even_spec, <- ?Nat.odd_spec.
 
 #[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
 Ltac parity_binop_spec :=
@@ -135,96 +120,96 @@ Ltac parity_binop_dep :=
 
 #[local]
 Definition even_plus_split_stt n m :
-  even (n + m) -> even n /\ even m \/ odd n /\ odd m.
+  Nat.Even_alt (n + m) -> Nat.Even_alt n /\ Nat.Even_alt m \/ Nat.Odd_alt n /\ Nat.Odd_alt m.
 Proof. parity_binop_dep. Qed.
-#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Even_add_split instead.")]
 Notation even_plus_split := even_plus_split_stt.
 
 #[local]
 Definition odd_plus_split_stt n m :
-  odd (n + m) -> odd n /\ even m \/ even n /\ odd m.
+  Nat.Odd_alt (n + m) -> Nat.Odd_alt n /\ Nat.Even_alt m \/ Nat.Even_alt n /\ Nat.Odd_alt m.
 Proof. parity_binop_dep. Qed.
-#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Odd_add_split instead.")]
 Notation odd_plus_split := odd_plus_split_stt.
 
 #[local]
-Definition even_even_plus_stt n m: even n -> even m -> even (n + m).
+Definition even_even_plus_stt n m: Nat.Even_alt n -> Nat.Even_alt m -> Nat.Even_alt (n + m).
 Proof. parity_binop_dep. Qed.
-#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Even_Even_add instead.")]
 Notation even_even_plus := even_even_plus_stt.
 
 #[local]
-Definition odd_plus_l_stt n m : odd n -> even m -> odd (n + m).
+Definition odd_plus_l_stt n m : Nat.Odd_alt n -> Nat.Even_alt m -> Nat.Odd_alt (n + m).
 Proof. parity_binop_dep. Qed.
-#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Odd_add_l instead.")]
 Notation odd_plus_l := odd_plus_l_stt.
 
 #[local]
-Definition odd_plus_r_stt n m : even n -> odd m -> odd (n + m).
+Definition odd_plus_r_stt n m : Nat.Even_alt n -> Nat.Odd_alt m -> Nat.Odd_alt (n + m).
 Proof. parity_binop_dep. Qed.
-#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Odd_add_r instead.")]
 Notation odd_plus_r := odd_plus_r_stt.
 
 #[local]
-Definition odd_even_plus_stt n m : odd n -> odd m -> even (n + m).
+Definition odd_even_plus_stt n m : Nat.Odd_alt n -> Nat.Odd_alt m -> Nat.Even_alt (n + m).
 Proof. parity_binop_dep. Qed.
-#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Odd_Odd_add instead.")]
 Notation odd_even_plus := odd_even_plus_stt.
 
 #[local]
 Definition even_plus_aux_stt n m :
-    (odd (n + m) <-> odd n /\ even m \/ even n /\ odd m) /\
-    (even (n + m) <-> even n /\ even m \/ odd n /\ odd m).
+    (Nat.Odd_alt (n + m) <-> Nat.Odd_alt n /\ Nat.Even_alt m \/ Nat.Even_alt n /\ Nat.Odd_alt m) /\
+    (Nat.Even_alt (n + m) <-> Nat.Even_alt n /\ Nat.Even_alt m \/ Nat.Odd_alt n /\ Nat.Odd_alt m).
 Proof. parity_binop_dep. Qed.
-#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Even_add_aux instead.")]
 Notation even_plus_aux := even_plus_aux_stt.
 
 #[local]
-Definition even_plus_even_inv_r_stt n m : even (n + m) -> even n -> even m.
+Definition even_plus_even_inv_r_stt n m : Nat.Even_alt (n + m) -> Nat.Even_alt n -> Nat.Even_alt m.
 Proof. parity_binop_dep. Qed.
-#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Even_add_Even_inv_r instead.")]
 Notation even_plus_even_inv_r := even_plus_even_inv_r_stt.
 
 #[local]
-Definition even_plus_even_inv_l_stt n m : even (n + m) -> even m -> even n.
+Definition even_plus_even_inv_l_stt n m : Nat.Even_alt (n + m) -> Nat.Even_alt m -> Nat.Even_alt n.
 Proof. parity_binop_dep. Qed.
-#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Even_add_Even_inv_l instead.")]
 Notation even_plus_even_inv_l := even_plus_even_inv_l_stt.
 
 #[local]
-Definition even_plus_odd_inv_r_stt n m : even (n + m) -> odd n -> odd m.
+Definition even_plus_odd_inv_r_stt n m : Nat.Even_alt (n + m) -> Nat.Odd_alt n -> Nat.Odd_alt m.
 Proof. parity_binop_dep. Qed.
-#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Even_add_Odd_inv_r instead.")]
 Notation even_plus_odd_inv_r := even_plus_odd_inv_r_stt.
 
 #[local]
-Definition even_plus_odd_inv_l_stt n m : even (n + m) -> odd m -> odd n.
+Definition even_plus_odd_inv_l_stt n m : Nat.Even_alt (n + m) -> Nat.Odd_alt m -> Nat.Odd_alt n.
 Proof. parity_binop_dep. Qed.
-#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Even_add_Even_inv_l instead.")]
 Notation even_plus_odd_inv_l := even_plus_odd_inv_l_stt.
 
 #[local]
-Definition odd_plus_even_inv_l_stt n m : odd (n + m) -> odd m -> even n.
+Definition odd_plus_even_inv_l_stt n m : Nat.Odd_alt (n + m) -> Nat.Odd_alt m -> Nat.Even_alt n.
 Proof. parity_binop_dep. Qed.
-#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Odd_add_Even_inv_l instead.")]
 Notation odd_plus_even_inv_l := odd_plus_even_inv_l_stt.
 
 #[local]
-Definition odd_plus_even_inv_r_stt n m : odd (n + m) -> odd n -> even m.
+Definition odd_plus_even_inv_r_stt n m : Nat.Odd_alt (n + m) -> Nat.Odd_alt n -> Nat.Even_alt m.
 Proof. parity_binop_dep. Qed.
-#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Odd_add_Even_inv_r instead.")]
 Notation odd_plus_even_inv_r := odd_plus_even_inv_r_stt.
 
 #[local]
-Definition odd_plus_odd_inv_l_stt n m : odd (n + m) -> even m -> odd n.
+Definition odd_plus_odd_inv_l_stt n m : Nat.Odd_alt (n + m) -> Nat.Even_alt m -> Nat.Odd_alt n.
 Proof. parity_binop_dep. Qed.
-#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Odd_add_Odd_inv_l instead.")]
 Notation odd_plus_odd_inv_l := odd_plus_odd_inv_l_stt.
 
 #[local]
-Definition odd_plus_odd_inv_r_stt n m : odd (n + m) -> even n -> odd m.
+Definition odd_plus_odd_inv_r_stt n m : Nat.Odd_alt (n + m) -> Nat.Even_alt n -> Nat.Odd_alt m.
 Proof. parity_binop_dep. Qed.
-#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Odd_add_Odd_inv_r instead.")]
 Notation odd_plus_odd_inv_r := odd_plus_odd_inv_r_stt.
 
 
@@ -232,51 +217,51 @@ Notation odd_plus_odd_inv_r := odd_plus_odd_inv_r_stt.
 
 #[local]
 Definition even_mult_aux_stt n m :
-  (odd (n * m) <-> odd n /\ odd m) /\ (even (n * m) <-> even n \/ even m).
+  (Nat.Odd_alt (n * m) <-> Nat.Odd_alt n /\ Nat.Odd_alt m) /\ (Nat.Even_alt (n * m) <-> Nat.Even_alt n \/ Nat.Even_alt m).
 Proof. parity_binop_dep. Qed.
-#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Even_mul_aux instead.")]
 Notation even_mult_aux := even_mult_aux_stt.
 
 #[local]
-Definition even_mult_l_stt n m : even n -> even (n * m).
+Definition even_mult_l_stt n m : Nat.Even_alt n -> Nat.Even_alt (n * m).
 Proof. parity_binop_dep. Qed.
-#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Even_mul_l instead.")]
 Notation even_mult_l := even_mult_l_stt.
 
 #[local]
-Definition even_mult_r_stt n m : even m -> even (n * m).
+Definition even_mult_r_stt n m : Nat.Even_alt m -> Nat.Even_alt (n * m).
 Proof. parity_binop_dep. Qed.
-#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Even_mul_r instead.")]
 Notation even_mult_r := even_mult_r_stt.
 
 #[local]
-Definition even_mult_inv_r_stt n m : even (n * m) -> odd n -> even m.
+Definition even_mult_inv_r_stt n m : Nat.Even_alt (n * m) -> Nat.Odd_alt n -> Nat.Even_alt m.
 Proof. parity_binop_dep. Qed.
-#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Even_mul_inv_r instead.")]
 Notation even_mult_inv_r := even_mult_inv_r_stt.
 
 #[local]
-Definition even_mult_inv_l_stt n m : even (n * m) -> odd m -> even n.
+Definition even_mult_inv_l_stt n m : Nat.Even_alt (n * m) -> Nat.Odd_alt m -> Nat.Even_alt n.
 Proof. parity_binop_dep. Qed.
-#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Even_mul_inv_l instead.")]
 Notation even_mult_inv_l := even_mult_inv_l_stt.
 
 #[local]
-Definition odd_mult_stt n m : odd n -> odd m -> odd (n * m).
+Definition odd_mult_stt n m : Nat.Odd_alt n -> Nat.Odd_alt m -> Nat.Odd_alt (n * m).
 Proof. parity_binop_dep. Qed.
-#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Odd_mul instead.")]
 Notation odd_mult := odd_mult_stt.
 
 #[local]
-Definition odd_mult_inv_l_stt n m : odd (n * m) -> odd n.
+Definition odd_mult_inv_l_stt n m : Nat.Odd_alt (n * m) -> Nat.Odd_alt n.
 Proof. parity_binop_dep. Qed.
-#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Odd_mul_inv_l instead.")]
 Notation odd_mult_inv_l := odd_mult_inv_l_stt.
 
 #[local]
-Definition odd_mult_inv_r_stt n m : odd (n * m) -> odd m.
+Definition odd_mult_inv_r_stt n m : Nat.Odd_alt (n * m) -> Nat.Odd_alt m.
 Proof. parity_binop_dep. Qed.
-#[deprecated(since="8.16",note="The Arith.Even file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Even file is obsolete. Use Nat.Odd_mul_inv_r instead.")]
 Notation odd_mult_inv_r := odd_mult_inv_r_stt.
 
 #[global]

--- a/theories/Arith/Gt.v
+++ b/theories/Arith/Gt.v
@@ -78,13 +78,11 @@ Notation gt_trans_S := Arith_prebase.gt_trans_S_stt.
 
 #[local]
 Definition gt_0_eq_stt n : n > 0 \/ 0 = n.
-Proof.
- destruct n; [now right | left; apply Nat.lt_0_succ].
-Qed.
-#[deprecated(since="8.16",note="The Arith.Gt file is obsolete.")]
+Proof. destruct (Nat.eq_0_gt_0_cases n); auto. Qed.
+#[deprecated(since="8.16",note="The Arith.Gt file is obsolete. Use Nat.eq_0_gt_0_cases instead.")]
 Notation gt_0_eq := gt_0_eq_stt.
 (* begin hide *)
-#[deprecated(since="8.16",note="The Arith.Gt file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Gt file is obsolete. Use Nat.eq_0_gt_0_cases instead.")]
 Notation gt_O_eq := gt_0_eq_stt (only parsing).
 (* end hide *)
 

--- a/theories/Arith/Le.v
+++ b/theories/Arith/Le.v
@@ -21,7 +21,7 @@ Require Export Arith_prebase.
 Notation le_refl := Nat.le_refl (only parsing).
 #[deprecated(since="8.16",note="The Arith.Le file is obsolete. Use Nat.le_trans instead.")]
 Notation le_trans := Nat.le_trans (only parsing).
-#[deprecated(since="8.16",note="The Arith.Le file is obsolete. Use Nat.le_antisym instead.")]
+#[deprecated(since="8.16",note="The Arith.Le file is obsolete. Use Nat.le_antisymm instead.")]
 Notation le_antisym := Nat.le_antisymm (only parsing).
 
 (** * Properties of [le] w.r.t 0 *)

--- a/theories/Arith/Mult.v
+++ b/theories/Arith/Mult.v
@@ -117,7 +117,7 @@ Proof.
  - now exists q.
  - now exists p.
 Qed.
-#[deprecated(since="8.16",note="The Arith.Mult file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Mult file is obsolete. Use Nat.Even_Odd_False instead.")]
 Notation odd_even_lem := odd_even_lem_stt.
 
 (** * Tail-recursive [mult] *)

--- a/theories/Arith/PeanoNat.v
+++ b/theories/Arith/PeanoNat.v
@@ -15,10 +15,10 @@ Require Import NAxioms NProperties OrdersFacts.
 (** Implementation of [NAxiomsSig] by [nat] *)
 
 Module Nat
- <: NAxiomsSig
- <: UsualDecidableTypeFull
- <: OrderedTypeFull
- <: TotalOrder.
+  <: NAxiomsSig
+  <: UsualDecidableTypeFull
+  <: OrderedTypeFull
+  <: TotalOrder.
 
 (** Operations over [nat] are defined in a separate module *)
 
@@ -32,26 +32,16 @@ Set Inline Level 50.
 
 Definition eq_equiv : Equivalence (@eq nat) := eq_equivalence.
 Local Obligation Tactic := simpl_relation.
-#[global]
-Program Instance succ_wd : Proper (eq==>eq) S.
-#[global]
-Program Instance pred_wd : Proper (eq==>eq) pred.
-#[global]
-Program Instance add_wd : Proper (eq==>eq==>eq) plus.
-#[global]
-Program Instance sub_wd : Proper (eq==>eq==>eq) minus.
-#[global]
-Program Instance mul_wd : Proper (eq==>eq==>eq) mult.
-#[global]
-Program Instance pow_wd : Proper (eq==>eq==>eq) pow.
-#[global]
-Program Instance div_wd : Proper (eq==>eq==>eq) div.
-#[global]
-Program Instance mod_wd : Proper (eq==>eq==>eq) modulo.
-#[global]
-Program Instance lt_wd : Proper (eq==>eq==>iff) lt.
-#[global]
-Program Instance testbit_wd : Proper (eq==>eq==>eq) testbit.
+#[global] Program Instance succ_wd : Proper (eq==>eq) S.
+#[global] Program Instance pred_wd : Proper (eq==>eq) pred.
+#[global] Program Instance add_wd : Proper (eq==>eq==>eq) plus.
+#[global] Program Instance sub_wd : Proper (eq==>eq==>eq) minus.
+#[global] Program Instance mul_wd : Proper (eq==>eq==>eq) mult.
+#[global] Program Instance pow_wd : Proper (eq==>eq==>eq) pow.
+#[global] Program Instance div_wd : Proper (eq==>eq==>eq) div.
+#[global] Program Instance mod_wd : Proper (eq==>eq==>eq) modulo.
+#[global] Program Instance lt_wd : Proper (eq==>eq==>iff) lt.
+#[global] Program Instance testbit_wd : Proper (eq==>eq==>eq) testbit.
 
 (** Bi-directional induction. *)
 
@@ -59,7 +49,9 @@ Theorem bi_induction :
   forall A : nat -> Prop, Proper (eq==>iff) A ->
     A 0 -> (forall n : nat, A n <-> A (S n)) -> forall n : nat, A n.
 Proof.
-intros A A_wd A0 AS. apply nat_ind. assumption. intros; now apply -> AS.
+  intros A A_wd A0 AS; apply nat_ind.
+  - assumption.
+  - intros; now apply -> AS.
 Qed.
 
 (** Recursion function *)
@@ -67,28 +59,26 @@ Qed.
 Definition recursion {A} : A -> (nat -> A -> A) -> nat -> A :=
   nat_rect (fun _ => A).
 
-#[global]
-Instance recursion_wd {A} (Aeq : relation A) :
- Proper (Aeq ==> (eq==>Aeq==>Aeq) ==> eq ==> Aeq) recursion.
+#[global] Instance recursion_wd {A} (Aeq : relation A) :
+  Proper (Aeq ==> (eq==>Aeq==>Aeq) ==> eq ==> Aeq) recursion.
 Proof.
-intros a a' Ha f f' Hf n n' Hn. subst n'.
-induction n; simpl; auto. apply Hf; auto.
+  intros a a' Ha f f' Hf n n' <-.
+  induction n; simpl; auto.
+  apply Hf; auto.
 Qed.
 
 Theorem recursion_0 :
   forall {A} (a : A) (f : nat -> A -> A), recursion a f 0 = a.
-Proof.
-reflexivity.
-Qed.
+Proof. reflexivity. Qed.
 
 Theorem recursion_succ :
   forall {A} (Aeq : relation A) (a : A) (f : nat -> A -> A),
     Aeq a a -> Proper (eq==>Aeq==>Aeq) f ->
       forall n : nat, Aeq (recursion a f (S n)) (f n (recursion a f n)).
 Proof.
-unfold Proper, respectful in *.
-intros A Aeq a f ? ? n.
-induction n; simpl; auto.
+  unfold Proper, respectful in *.
+  intros A Aeq a f ? ? n.
+  induction n; simpl; auto.
 Qed.
 
 (** ** Remaining constants not defined in Coq.Init.Nat *)
@@ -103,89 +93,76 @@ Definition lt := Peano.lt.
 (** ** Basic specifications : pred add sub mul *)
 
 Lemma pred_succ n : pred (S n) = n.
-Proof.
-reflexivity.
-Qed.
+Proof. reflexivity. Qed.
 
 Lemma pred_0 : pred 0 = 0.
-Proof.
-reflexivity.
-Qed.
+Proof. reflexivity. Qed.
 
 Lemma one_succ : 1 = S 0.
-Proof.
-reflexivity.
-Qed.
+Proof. reflexivity. Qed.
 
 Lemma two_succ : 2 = S 1.
-Proof.
-reflexivity.
-Qed.
+Proof. reflexivity. Qed.
 
 Lemma add_0_l n : 0 + n = n.
-Proof.
-reflexivity.
-Qed.
+Proof. reflexivity. Qed.
 
 Lemma add_succ_l n m : (S n) + m = S (n + m).
-Proof.
-reflexivity.
-Qed.
+Proof. reflexivity. Qed.
 
 Lemma sub_0_r n : n - 0 = n.
-Proof.
-now destruct n.
-Qed.
+Proof. now destruct n. Qed.
 
 Lemma sub_succ_r n m : n - (S m) = pred (n - m).
 Proof.
-revert m. induction n; intro m; destruct m; simpl; auto. apply sub_0_r.
+  revert m; induction n; intro m; destruct m; simpl; auto.
+  apply sub_0_r.
 Qed.
 
 Lemma mul_0_l n : 0 * n = 0.
-Proof.
-reflexivity.
-Qed.
+Proof. reflexivity. Qed.
 
 Lemma mul_succ_l n m : S n * m = n * m + m.
 Proof.
-assert (succ_r : forall x y, x+S y = S(x+y)) by now intro x; induction x.
-assert (comm : forall x y, x+y = y+x).
-{ intro x; induction x; simpl; auto. intros; rewrite succ_r; now f_equal. }
-now rewrite comm.
+  assert (succ_r : forall x y, x+S y = S(x+y)) by now intro x; induction x.
+  assert (comm : forall x y, x+y = y+x).
+  { intro x; induction x; simpl; auto.
+    intros; rewrite succ_r; now f_equal. }
+  now rewrite comm.
 Qed.
 
 Lemma lt_succ_r n m : n < S m <-> n <= m.
 Proof.
-split. apply Peano.le_S_n. induction 1; auto.
+  split.
+  - apply Peano.le_S_n.
+  - induction 1; auto.
 Qed.
 
 (** ** Boolean comparisons *)
 
 Lemma eqb_eq n m : eqb n m = true <-> n = m.
 Proof.
- revert m.
- induction n as [|n IHn]; intro m; destruct m; simpl; rewrite ?IHn; split; try easy.
- - now intros ->.
- - now injection 1.
+  revert m.
+  induction n as [|n IHn]; intro m; destruct m; simpl; rewrite ?IHn; split; try easy.
+  - now intros ->.
+  - now injection 1.
 Qed.
 
 Lemma leb_le n m : (n <=? m) = true <-> n <= m.
 Proof.
- revert m.
- induction n as [|n IHn]; intro m; destruct m; simpl.
- - now split.
- - split; trivial. intros; apply Peano.le_0_n.
- - now split.
- - rewrite IHn; split.
-   + apply Peano.le_n_S.
-   + apply Peano.le_S_n.
+  revert m.
+  induction n as [|n IHn]; intro m; destruct m; simpl.
+  - now split.
+  - split; trivial.
+    intros; apply Peano.le_0_n.
+  - now split.
+  - rewrite IHn; split.
+    + apply Peano.le_n_S.
+    + apply Peano.le_S_n.
 Qed.
 
 Lemma ltb_lt n m : (n <? m) = true <-> n < m.
-Proof.
- apply leb_le.
-Qed.
+Proof. apply leb_le. Qed.
 
 (** ** Decidability of equality over [nat]. *)
 
@@ -206,63 +183,54 @@ Defined.
 
 Lemma compare_eq_iff n m : (n ?= m) = Eq <-> n = m.
 Proof.
- revert m; induction n as [|n IHn]; intro m; destruct m;
- simpl; rewrite ?IHn; split; auto; easy.
+  revert m; induction n as [|n IHn]; intro m; destruct m;
+  simpl; rewrite ?IHn; split; auto; easy.
 Qed.
 
 Lemma compare_lt_iff n m : (n ?= m) = Lt <-> n < m.
 Proof.
- revert m; induction n as [|n IHn]; intro m; destruct m;
- simpl; rewrite ?IHn; split; try easy.
- - intros _. apply Peano.le_n_S, Peano.le_0_n.
- - apply Peano.le_n_S.
- - apply Peano.le_S_n.
+  revert m; induction n as [|n IHn]; intro m; destruct m;
+  simpl; rewrite ?IHn; split; try easy.
+  - intros _; apply Peano.le_n_S, Peano.le_0_n.
+  - apply Peano.le_n_S.
+  - apply Peano.le_S_n.
 Qed.
 
 Lemma compare_le_iff n m : (n ?= m) <> Gt <-> n <= m.
 Proof.
- revert m; induction n as [|n IHn]; intro m; destruct m; simpl; rewrite ?IHn.
- - now split.
- - split; intros. apply Peano.le_0_n. easy.
- - split. now destruct 1. inversion 1.
- - split; intros. now apply Peano.le_n_S. now apply Peano.le_S_n.
+  revert m; induction n as [|n IHn]; intro m; destruct m; simpl; rewrite ?IHn.
+  - now split.
+  - split; intros.
+    + apply Peano.le_0_n.
+    + easy.
+  - split.
+    + now destruct 1.
+    + inversion 1.
+  - split; intros.
+    + now apply Peano.le_n_S.
+    + now apply Peano.le_S_n.
 Qed.
 
 Lemma compare_antisym n m : (m ?= n) = CompOpp (n ?= m).
-Proof.
- revert m; induction n; intro m; destruct m; simpl; trivial.
-Qed.
+Proof. revert m; induction n; intro m; destruct m; simpl; trivial. Qed.
 
 Lemma compare_succ n m : (S n ?= S m) = (n ?= m).
-Proof.
- reflexivity.
-Qed.
+Proof. reflexivity. Qed.
 
-
-(* BUG: Ajout d'un cas * après preuve finie (deuxième niveau +++*** ) :
-    *  --->   Anomaly: Uncaught exception Proofview.IndexOutOfRange(_). Please report. *)
 
 (** ** Minimum, maximum *)
 
 Lemma max_l : forall n m, m <= n -> max n m = n.
-Proof.
- exact Peano.max_l.
-Qed.
+Proof. exact Peano.max_l. Qed.
 
 Lemma max_r : forall n m, n <= m -> max n m = m.
-Proof.
- exact Peano.max_r.
-Qed.
+Proof. exact Peano.max_r. Qed.
 
 Lemma min_l : forall n m, n <= m -> min n m = n.
-Proof.
- exact Peano.min_l.
-Qed.
+Proof. exact Peano.min_l. Qed.
 
 Lemma min_r : forall n m, m <= n -> min n m = m.
-Proof.
- exact Peano.min_r.
-Qed.
+Proof. exact Peano.min_r. Qed.
 
 (** Some more advanced properties of comparison and orders,
     including [compare_spec] and [lt_irrefl] and [lt_eq_cases]. *)
@@ -277,7 +245,8 @@ Include NBasicProp <+ UsualMinMaxLogicalProperties <+ UsualMinMaxDecProperties.
 
 (** ** Power *)
 
-Lemma pow_neg_r a b : b<0 -> a^b = 0. inversion 1. Qed.
+Lemma pow_neg_r a b : b<0 -> a^b = 0.
+Proof. inversion 1. Qed.
 
 Lemma pow_0_r a : a^0 = 1.
 Proof. reflexivity. Qed.
@@ -298,41 +267,44 @@ Definition Odd n := exists m, n = 2*m+1.
 Module Private_Parity.
 
 Lemma Even_0 : Even 0.
-Proof.
- exists 0; reflexivity.
-Qed.
+Proof. exists 0; reflexivity. Qed.
 
 Lemma Even_1 : ~ Even 1.
 Proof.
- intros ([|], H); try discriminate.
- simpl in H. now rewrite <- plus_n_Sm in H.
+  intros ([|], H); try discriminate.
+  simpl in H.
+  now rewrite <- plus_n_Sm in H.
 Qed.
 
 Lemma Even_2 n : Even n <-> Even (S (S n)).
 Proof.
- split; intros (m,H).
- - exists (S m). rewrite H. simpl. now rewrite plus_n_Sm.
- - destruct m as [|m]; try discriminate.
-   exists m. simpl in H. rewrite <- plus_n_Sm in H. now inversion H.
+  split; intros (m,H).
+  - exists (S m).
+    rewrite H; simpl.
+    now rewrite plus_n_Sm.
+  - destruct m as [|m]; try discriminate.
+    exists m.
+    simpl in H; rewrite <- plus_n_Sm in H.
+    now inversion H.
 Qed.
 
 Lemma Odd_0 : ~ Odd 0.
-Proof.
- now intros ([|], H).
-Qed.
+Proof. now intros ([|], H). Qed.
 
 Lemma Odd_1 : Odd 1.
-Proof.
- exists 0; reflexivity.
-Qed.
+Proof. exists 0; reflexivity. Qed.
 
 Lemma Odd_2 n : Odd n <-> Odd (S (S n)).
 Proof.
- split; intros (m,H).
- - exists (S m). rewrite H. simpl. now rewrite <- (plus_n_Sm m).
- - destruct m as [|m]; try discriminate.
-   exists m. simpl in H. rewrite <- plus_n_Sm in H. inversion H.
-   simpl. now rewrite <- !plus_n_Sm, <- !plus_n_O.
+  split; intros (m,H).
+  - exists (S m).
+    rewrite H. simpl.
+    now rewrite <- (plus_n_Sm m).
+  - destruct m as [|m]; try discriminate.
+    exists m.
+    simpl in H; rewrite <- plus_n_Sm in H.
+    inversion H; simpl.
+    now rewrite <- !plus_n_Sm, <- !plus_n_O.
 Qed.
 
 End Private_Parity.
@@ -340,109 +312,119 @@ Import Private_Parity.
 
 Lemma even_spec : forall n, even n = true <-> Even n.
 Proof.
- fix even_spec 1.
-  intro n; destruct n as [|[|n]]; simpl.
-  - split; [ intros; apply Even_0  | trivial ].
-  - split; [ discriminate | intro H; elim (Even_1 H) ].
-  - rewrite even_spec. apply Even_2.
+  fix even_spec 1.
+    intro n; destruct n as [|[|n]]; simpl.
+    - split; [ intros; apply Even_0  | trivial ].
+    - split; [ discriminate | intro H; elim (Even_1 H) ].
+    - rewrite even_spec.
+      apply Even_2.
 Qed.
 
 Lemma odd_spec : forall n, odd n = true <-> Odd n.
 Proof.
- unfold odd.
- fix odd_spec 1.
-  intro n; destruct n as [|[|n]]; simpl.
-  - split; [ discriminate | intro H; elim (Odd_0 H) ].
-  - split; [ intros; apply Odd_1 | trivial ].
-  - rewrite odd_spec. apply Odd_2.
+  unfold odd.
+  fix odd_spec 1.
+    intro n; destruct n as [|[|n]]; simpl.
+    - split; [ discriminate | intro H; elim (Odd_0 H) ].
+    - split; [ intros; apply Odd_1 | trivial ].
+    - rewrite odd_spec.
+      apply Odd_2.
 Qed.
 
 (** ** Division *)
 
 Lemma divmod_spec : forall x y q u, u <= y ->
- let (q',u') := divmod x y q u in
- x + (S y)*q + (y-u) = (S y)*q' + (y-u') /\ u' <= y.
+  let (q',u') := divmod x y q u in
+  x + (S y)*q + (y-u) = (S y)*q' + (y-u') /\ u' <= y.
 Proof.
- intro x; induction x as [|x IHx].
- - simpl; intuition.
- - intros y q u H. destruct u as [|u]; simpl divmod.
-   + generalize (IHx y (S q) y (le_n y)). destruct divmod as (q',u').
-     intros (EQ,LE); split; trivial.
-     rewrite <- EQ, sub_0_r, sub_diag, add_0_r.
-     now rewrite !add_succ_l, <- add_succ_r, <- add_assoc, mul_succ_r.
-   + assert (H' : u <= y).
-     { apply le_trans with (S u); trivial. do 2 constructor. }
-     generalize (IHx y q u H'). destruct divmod as (q',u').
-     intros (EQ,LE); split; trivial.
-     rewrite <- EQ.
-     rewrite !add_succ_l, <- add_succ_r. f_equal. now rewrite <- sub_succ_l.
+  intro x; induction x as [|x IHx].
+  - simpl; intuition.
+  - intros y q u H.
+    destruct u as [|u]; simpl divmod.
+    + generalize (IHx y (S q) y (le_n y)).
+      destruct divmod as (q',u').
+      intros (EQ,LE); split; trivial.
+      rewrite <- EQ, sub_0_r, sub_diag, add_0_r.
+      now rewrite !add_succ_l, <- add_succ_r, <- add_assoc, mul_succ_r.
+    + assert (H' : u <= y).
+      { apply le_trans with (S u); trivial.
+        do 2 constructor. }
+      generalize (IHx y q u H').
+      destruct divmod as (q',u').
+      intros (EQ,LE); split; trivial.
+      rewrite <- EQ, !add_succ_l, <- add_succ_r; f_equal.
+      now rewrite <- sub_succ_l.
 Qed.
 
 Lemma div_mod x y : y<>0 -> x = y*(x/y) + x mod y.
 Proof.
- intros Hy.
- destruct y as [|y]; [ now elim Hy | clear Hy ].
- unfold div, modulo.
- generalize (divmod_spec x y 0 y (le_n y)).
- destruct divmod as (q,u).
- intros (U,V).
- simpl in *.
- now rewrite mul_0_r, sub_diag, !add_0_r in U.
+  intros Hy.
+  destruct y as [|y]; [ now elim Hy | clear Hy ].
+  unfold div, modulo.
+  generalize (divmod_spec x y 0 y (le_n y)).
+  destruct divmod as (q,u).
+  intros (U,V).
+  simpl in *.
+  now rewrite mul_0_r, sub_diag, !add_0_r in U.
 Qed.
 
 Lemma div_mod_eq x y : x = y*(x/y) + x mod y.
-Proof.
-  destruct y as [|y]; [reflexivity|now apply div_mod].
-Qed.
+Proof. destruct y as [|y]; [reflexivity|now apply div_mod]. Qed.
 
 Lemma mod_bound_pos x y : 0<=x -> 0<y -> 0 <= x mod y < y.
 Proof.
- intros Hx Hy. split. apply le_0_l.
- destruct y; [ now elim Hy | clear Hy ].
- unfold modulo.
- apply lt_succ_r, le_sub_l.
+  intros Hx Hy.
+  split.
+  - apply le_0_l.
+  - destruct y; [ now elim Hy | clear Hy ].
+    unfold modulo.
+    apply lt_succ_r, le_sub_l.
 Qed.
 
 (** ** Square root *)
 
 Lemma sqrt_iter_spec : forall k p q r,
- q = p+p -> r<=q ->
- let s := sqrt_iter k p q r in
- s*s <= k + p*p + (q - r) < (S s)*(S s).
+  q = p+p -> r<=q ->
+  let s := sqrt_iter k p q r in
+  s*s <= k + p*p + (q - r) < (S s)*(S s).
 Proof.
- intro k; induction k as [|k IHk].
- - (* k = 0 *)
-   simpl; intros p q r Hq Hr.
-   split.
-   + apply le_add_r.
-   + apply lt_succ_r.
-     rewrite mul_succ_r.
-     rewrite add_assoc, (add_comm p), <- add_assoc.
-     apply add_le_mono_l.
-     rewrite <- Hq. apply le_sub_l.
- - (* k = S k' *)
-   intros p q r; destruct r as [|r].
-   + (* r = 0 *)
-     intros Hq _.
-     replace (S k + p*p + (q-0)) with (k + (S p)*(S p) + (S (S q) - S (S q))).
-     * apply IHk.
-       simpl. now rewrite add_succ_r, Hq. apply le_n.
-     * rewrite sub_diag, sub_0_r, add_0_r. simpl.
-       rewrite add_succ_r; f_equal. rewrite <- add_assoc; f_equal.
-       rewrite mul_succ_r, (add_comm p), <- add_assoc. now f_equal.
-   + (* r = S r' *)
-     intros Hq Hr.
-     replace (S k + p*p + (q-S r)) with (k + p*p + (q - r)).
-     * apply IHk; trivial. apply le_trans with (S r); trivial. do 2 constructor.
-     * simpl. rewrite <- add_succ_r. f_equal. rewrite <- sub_succ_l; trivial.
+  intro k; induction k as [|k IHk].
+  - (* k = 0 *)
+    simpl; intros p q r Hq Hr.
+    split.
+    + apply le_add_r.
+    + apply lt_succ_r.
+      rewrite mul_succ_r, add_assoc, (add_comm p), <- add_assoc.
+      apply add_le_mono_l.
+      rewrite <- Hq.
+      apply le_sub_l.
+  - (* k = S k' *)
+    intros p q r; destruct r as [|r].
+    + (* r = 0 *)
+      intros Hq _.
+      replace (S k + p*p + (q-0)) with (k + (S p)*(S p) + (S (S q) - S (S q))).
+      2:{ rewrite sub_diag, sub_0_r, add_0_r. simpl.
+          rewrite add_succ_r; f_equal. rewrite <- add_assoc; f_equal.
+          rewrite mul_succ_r, (add_comm p), <- add_assoc. now f_equal. }
+      apply IHk; simpl.
+      * now rewrite add_succ_r, Hq.
+      * apply le_n.
+    + (* r = S r' *)
+      intros Hq Hr.
+      replace (S k + p*p + (q-S r)) with (k + p*p + (q - r))
+        by (simpl; rewrite <- add_succ_r; f_equal; rewrite <- sub_succ_l; trivial).
+      apply IHk; trivial.
+      apply le_trans with (S r); trivial.
+      do 2 constructor.
 Qed.
 
 Lemma sqrt_specif n : (sqrt n)*(sqrt n) <= n < S (sqrt n) * S (sqrt n).
 Proof.
- set (s:=sqrt n).
- replace n with (n + 0*0 + (0-0)).
- apply sqrt_iter_spec; auto.
- simpl. now rewrite !add_0_r.
+  set (s:=sqrt n).
+  replace n with (n + 0*0 + (0-0)).
+  apply sqrt_iter_spec; auto.
+  simpl.
+  now rewrite !add_0_r.
 Qed.
 
 Definition sqrt_spec a (Ha:0<=a) := sqrt_specif a.
@@ -453,48 +435,55 @@ Proof. inversion 1. Qed.
 (** ** Logarithm *)
 
 Lemma log2_iter_spec : forall k p q r,
- 2^(S p) = q + S r -> r < 2^p ->
- let s := log2_iter k p q r in
- 2^s <= k + q < 2^(S s).
+  2^(S p) = q + S r -> r < 2^p ->
+  let s := log2_iter k p q r in
+  2^s <= k + q < 2^(S s).
 Proof.
- intro k; induction k as [|k IHk].
- - (* k = 0 *)
-   intros p q r EQ LT. simpl log2_iter. cbv zeta.
-   split.
-   + rewrite add_0_l.
-     rewrite (add_le_mono_l _ _ (2^p)).
-     simpl pow in EQ. rewrite add_0_r in EQ. rewrite EQ.
-     rewrite add_comm. apply add_le_mono_r. apply LT.
-   + rewrite EQ, add_comm. apply add_lt_mono_l.
-     apply lt_succ_r, le_0_l.
- - (* k = S k' *)
-   intros p q r EQ LT. destruct r as [|r].
-   + (* r = 0 *)
-     rewrite add_succ_r, add_0_r in EQ.
-     rewrite add_succ_l, <- add_succ_r. apply IHk.
-     * rewrite <- EQ. remember (S p) as p'; simpl. now rewrite add_0_r.
-     * rewrite EQ. constructor.
-   + (* r = S r' *)
-     rewrite add_succ_l, <- add_succ_r. apply IHk.
-     * now rewrite add_succ_l, <- add_succ_r.
-     * apply le_lt_trans with (S r); trivial. do 2 constructor.
+  intro k; induction k as [|k IHk].
+  - (* k = 0 *)
+    intros p q r EQ LT.
+    simpl log2_iter; cbv zeta.
+    split.
+    + rewrite add_0_l, (add_le_mono_l _ _ (2^p)).
+      simpl pow in EQ.
+      rewrite add_0_r in EQ; rewrite EQ, add_comm.
+      apply add_le_mono_r, LT.
+    + rewrite EQ, add_comm.
+      apply add_lt_mono_l.
+      apply lt_succ_r, le_0_l.
+  - (* k = S k' *)
+    intros p q r EQ LT.
+    destruct r as [|r].
+    + (* r = 0 *)
+      rewrite add_succ_r, add_0_r in EQ.
+      rewrite add_succ_l, <- add_succ_r.
+      apply IHk.
+      * rewrite <- EQ.
+        remember (S p) as p'; simpl.
+        now rewrite add_0_r.
+      * rewrite EQ; constructor.
+    + (* r = S r' *)
+      rewrite add_succ_l, <- add_succ_r.
+      apply IHk.
+      * now rewrite add_succ_l, <- add_succ_r.
+      * apply le_lt_trans with (S r); trivial.
+        do 2 constructor.
 Qed.
 
 Lemma log2_spec n : 0<n ->
- 2^(log2 n) <= n < 2^(S (log2 n)).
+  2^(log2 n) <= n < 2^(S (log2 n)).
 Proof.
- intros.
- set (s:=log2 n).
- replace n with (pred n + 1).
- apply log2_iter_spec; auto.
- rewrite add_1_r.
- apply succ_pred. now apply neq_sym, lt_neq.
+  intros.
+  set (s:=log2 n).
+  replace n with (pred n + 1).
+  - apply log2_iter_spec; auto.
+  - rewrite add_1_r.
+    apply succ_pred.
+    now apply neq_sym, lt_neq.
 Qed.
 
 Lemma log2_nonpos n : n<=0 -> log2 n = 0.
-Proof.
- inversion 1; now subst.
-Qed.
+Proof. inversion 1; now subst. Qed.
 
 (** ** Gcd *)
 
@@ -503,46 +492,44 @@ Notation "( x | y )" := (divide x y) (at level 0) : nat_scope.
 
 Lemma gcd_divide : forall a b, (gcd a b | a) /\ (gcd a b | b).
 Proof.
- fix gcd_divide 1.
- intros [|a] b; simpl.
- - split.
-   + now exists 0.
-   + exists 1. simpl. now rewrite <- plus_n_O.
- - fold (b mod (S a)).
-   destruct (gcd_divide (b mod (S a)) (S a)) as (H,H').
-   set (a':=S a) in *.
-   split; auto.
-   rewrite (div_mod b a') at 2 by discriminate.
-   destruct H as (u,Hu), H' as (v,Hv).
-   rewrite mul_comm.
-   exists ((b/a')*v + u).
-   rewrite mul_add_distr_r.
-   now rewrite <- mul_assoc, <- Hv, <- Hu.
+  fix gcd_divide 1.
+    intros [|a] b; simpl.
+    - split.
+      + now exists 0.
+      + exists 1; simpl.
+        now rewrite <- plus_n_O.
+    - fold (b mod (S a)).
+      destruct (gcd_divide (b mod (S a)) (S a)) as (H,H').
+      set (a':=S a) in *.
+      split; auto.
+      rewrite (div_mod b a') at 2 by discriminate.
+      destruct H as (u,Hu), H' as (v,Hv).
+      rewrite mul_comm.
+      exists ((b/a')*v + u).
+      rewrite mul_add_distr_r.
+      now rewrite <- mul_assoc, <- Hv, <- Hu.
 Qed.
 
 Lemma gcd_divide_l : forall a b, (gcd a b | a).
-Proof.
- intros. apply gcd_divide.
-Qed.
+Proof. apply gcd_divide. Qed.
 
 Lemma gcd_divide_r : forall a b, (gcd a b | b).
-Proof.
- intros. apply gcd_divide.
-Qed.
+Proof. apply gcd_divide. Qed.
 
 Lemma gcd_greatest : forall a b c, (c|a) -> (c|b) -> (c|gcd a b).
 Proof.
- fix gcd_greatest 1.
- intros [|a] b; simpl; auto.
- fold (b mod (S a)).
- intros c H H'. apply gcd_greatest; auto.
- set (a':=S a) in *.
- rewrite (div_mod b a') in H' by discriminate.
- destruct H as (u,Hu), H' as (v,Hv).
- exists (v - (b/a')*u).
- rewrite mul_comm in Hv.
- rewrite mul_sub_distr_r, <- Hv, <- mul_assoc, <-Hu.
- now rewrite add_comm, add_sub.
+  fix gcd_greatest 1.
+    intros [|a] b; simpl; auto.
+    fold (b mod (S a)).
+    intros c H H'.
+    apply gcd_greatest; auto.
+    set (a':=S a) in *.
+    rewrite (div_mod b a') in H' by discriminate.
+    destruct H as (u,Hu), H' as (v,Hv).
+    exists (v - (b/a')*u).
+    rewrite mul_comm in Hv.
+    rewrite mul_sub_distr_r, <- Hv, <- mul_assoc, <-Hu.
+    now rewrite add_comm, add_sub.
 Qed.
 
 Lemma gcd_nonneg a b : 0<=gcd a b.
@@ -553,43 +540,46 @@ Proof. apply le_0_l. Qed.
 
 Lemma div2_double n : div2 (2*n) = n.
 Proof.
- induction n; trivial.
- simpl mul. rewrite add_succ_r. simpl. now f_equal.
+  induction n; trivial.
+  simpl mul.
+  rewrite add_succ_r; simpl.
+  now f_equal.
 Qed.
 
 Lemma div2_succ_double n : div2 (S (2*n)) = n.
 Proof.
- induction n; trivial.
- simpl. f_equal. now rewrite add_succ_r.
+  induction n; trivial.
+  simpl; f_equal.
+  now rewrite add_succ_r.
 Qed.
 
 Lemma le_div2 n : div2 (S n) <= n.
 Proof.
- revert n.
- fix le_div2 1.
- intro n; destruct n as [|n]; simpl; trivial. apply lt_succ_r.
- destruct n; [simpl|]; trivial. now constructor.
+  revert n.
+  fix le_div2 1.
+    intro n; destruct n as [|n]; simpl; trivial.
+    apply lt_succ_r.
+    destruct n; [simpl|]; trivial.
+    now constructor.
 Qed.
 
 Lemma lt_div2 n : 0 < n -> div2 n < n.
 Proof.
- destruct n.
- - inversion 1.
- - intros _. apply lt_succ_r, le_div2.
+  destruct n.
+  - inversion 1.
+  - intros _; apply lt_succ_r, le_div2.
 Qed.
 
 Lemma div2_decr a n : a <= S n -> div2 a <= n.
 Proof.
- destruct a as [|a]; intros H.
- - simpl. apply le_0_l.
- - apply succ_le_mono in H.
-   apply le_trans with a; [ apply le_div2 | trivial ].
+  destruct a as [|a]; intros H.
+  - simpl; apply le_0_l.
+  - apply succ_le_mono in H.
+    apply le_trans with a; [ apply le_div2 | trivial ].
 Qed.
 
 Lemma double_twice : forall n, double n = 2*n.
-Proof.
- simpl; intros. now rewrite add_0_r.
-Qed.
+Proof. simpl; intros; now rewrite add_0_r. Qed.
 
 Definition double_S : forall n, double (S n) = S (S (double n))
                     := fun n => add_succ_r (S n) n.
@@ -598,155 +588,152 @@ Definition double_add : forall n m, double (n + m) = double n + double m
                       := fun n m => add_shuffle1 n m n m.
 
 Lemma testbit_0_l : forall n, testbit 0 n = false.
-Proof.
- now intro n; induction n.
-Qed.
+Proof. now intro n; induction n. Qed.
 
 Lemma testbit_odd_0 a : testbit (2*a+1) 0 = true.
-Proof.
- unfold testbit. rewrite odd_spec. now exists a.
-Qed.
+Proof. unfold testbit; rewrite odd_spec; now exists a. Qed.
 
 Lemma testbit_even_0 a : testbit (2*a) 0 = false.
 Proof.
- unfold testbit, odd. rewrite (proj2 (even_spec _)); trivial.
- now exists a.
+  unfold testbit, odd.
+  rewrite (proj2 (even_spec _)); trivial.
+  now exists a.
 Qed.
 
 Lemma testbit_odd_succ' a n : testbit (2*a+1) (S n) = testbit a n.
 Proof.
- unfold testbit; fold testbit.
- rewrite add_1_r. f_equal.
- apply div2_succ_double.
+  unfold testbit; fold testbit.
+  rewrite add_1_r; f_equal.
+  apply div2_succ_double.
 Qed.
 
 Lemma testbit_even_succ' a n : testbit (2*a) (S n) = testbit a n.
-Proof.
- unfold testbit; fold testbit. f_equal. apply div2_double.
-Qed.
+Proof. unfold testbit; fold testbit; f_equal; apply div2_double. Qed.
 
 Lemma shiftr_specif : forall a n m,
- testbit (shiftr a n) m = testbit a (m+n).
+  testbit (shiftr a n) m = testbit a (m+n).
 Proof.
- intros a n; induction n as [|n IHn]; intros m. trivial.
- now rewrite add_0_r.
- now rewrite add_succ_r, <- add_succ_l, <- IHn.
+  intros a n; induction n as [|n IHn]; intros m. trivial.
+  - now rewrite add_0_r.
+  - now rewrite add_succ_r, <- add_succ_l, <- IHn.
 Qed.
 
 Lemma shiftl_specif_high : forall a n m, n<=m ->
- testbit (shiftl a n) m = testbit a (m-n).
+  testbit (shiftl a n) m = testbit a (m-n).
 Proof.
- intros a n; induction n as [|n IHn]; intros m H. trivial.
- now rewrite sub_0_r.
- destruct m. inversion H.
- simpl. apply succ_le_mono in H.
- change (shiftl a (S n)) with (double (shiftl a n)).
- rewrite double_twice, div2_double. now apply IHn.
+  intros a n; induction n as [|n IHn]; intros m H; [ trivial | ].
+  - now rewrite sub_0_r.
+  - destruct m; [ inversion H | ].
+    simpl; apply succ_le_mono in H.
+    change (shiftl a (S n)) with (double (shiftl a n)).
+    rewrite double_twice, div2_double.
+    now apply IHn.
 Qed.
 
 Lemma shiftl_spec_low : forall a n m, m<n ->
- testbit (shiftl a n) m = false.
+  testbit (shiftl a n) m = false.
 Proof.
- intros a n; induction n as [|n IHn]; intros m H. inversion H.
- change (shiftl a (S n)) with (double (shiftl a n)).
- destruct m; simpl.
- unfold odd. apply negb_false_iff.
- apply even_spec. exists (shiftl a n). apply double_twice.
- rewrite double_twice, div2_double. apply IHn.
- now apply succ_le_mono.
+  intros a n; induction n as [|n IHn]; intros m H; [ inversion H | ].
+  change (shiftl a (S n)) with (double (shiftl a n)).
+  destruct m; simpl.
+  unfold odd; apply negb_false_iff.
+  apply even_spec.
+  exists (shiftl a n).
+  apply double_twice.
+  rewrite double_twice, div2_double.
+  apply IHn.
+  now apply succ_le_mono.
 Qed.
 
 Lemma div2_bitwise : forall op n a b,
- div2 (bitwise op (S n) a b) = bitwise op n (div2 a) (div2 b).
+  div2 (bitwise op (S n) a b) = bitwise op n (div2 a) (div2 b).
 Proof.
- intros op n a b. unfold bitwise; fold bitwise.
- destruct (op (odd a) (odd b)).
- now rewrite div2_succ_double.
- now rewrite add_0_l, div2_double.
+  intros op n a b; unfold bitwise; fold bitwise.
+  destruct (op (odd a) (odd b)).
+  - now rewrite div2_succ_double.
+  - now rewrite add_0_l, div2_double.
 Qed.
 
 Lemma odd_bitwise : forall op n a b,
- odd (bitwise op (S n) a b) = op (odd a) (odd b).
+  odd (bitwise op (S n) a b) = op (odd a) (odd b).
 Proof.
- intros op n a b. unfold bitwise; fold bitwise.
- destruct (op (odd a) (odd b)).
- apply odd_spec. rewrite add_comm. eexists; eauto.
- unfold odd. apply negb_false_iff. apply even_spec.
- rewrite add_0_l; eexists; eauto.
+  intros op n a b; unfold bitwise; fold bitwise.
+  destruct (op (odd a) (odd b)).
+  - apply odd_spec.
+    rewrite add_comm; eexists; eauto.
+  - unfold odd; apply negb_false_iff.
+    apply even_spec.
+    rewrite add_0_l; eexists; eauto.
 Qed.
 
 Lemma testbit_bitwise_1 : forall op, (forall b, op false b = false) ->
- forall n m a b, a<=n ->
- testbit (bitwise op n a b) m = op (testbit a m) (testbit b m).
+  forall n m a b, a<=n ->
+  testbit (bitwise op n a b) m = op (testbit a m) (testbit b m).
 Proof.
- intros op Hop.
- intro n; induction n as [|n IHn]; intros m a b Ha.
- simpl. inversion Ha; subst. now rewrite testbit_0_l.
- destruct m.
- apply odd_bitwise.
- unfold testbit; fold testbit. rewrite div2_bitwise.
- apply IHn. now apply div2_decr.
+  intros op Hop.
+  intro n; induction n as [|n IHn]; intros m a b Ha.
+  - simpl; inversion Ha; subst.
+    now rewrite testbit_0_l.
+  - destruct m.
+    + apply odd_bitwise.
+    + unfold testbit; fold testbit; rewrite div2_bitwise.
+      apply IHn; now apply div2_decr.
 Qed.
 
 Lemma testbit_bitwise_2 : forall op, op false false = false ->
- forall n m a b, a<=n -> b<=n ->
- testbit (bitwise op n a b) m = op (testbit a m) (testbit b m).
+  forall n m a b, a<=n -> b<=n ->
+  testbit (bitwise op n a b) m = op (testbit a m) (testbit b m).
 Proof.
- intros op Hop.
- intro n; induction n as [|n IHn]; intros m a b Ha Hb.
- simpl. inversion Ha; inversion Hb; subst. now rewrite testbit_0_l.
- destruct m.
- apply odd_bitwise.
- unfold testbit; fold testbit. rewrite div2_bitwise.
- apply IHn; now apply div2_decr.
+  intros op Hop.
+  intro n; induction n as [|n IHn]; intros m a b Ha Hb.
+  - simpl; inversion Ha; inversion Hb; subst.
+    now rewrite testbit_0_l.
+  - destruct m.
+    + apply odd_bitwise.
+    + unfold testbit; fold testbit; rewrite div2_bitwise.
+      apply IHn; now apply div2_decr.
 Qed.
 
 Lemma land_spec a b n :
- testbit (land a b) n = testbit a n && testbit b n.
-Proof.
- unfold land. apply testbit_bitwise_1; trivial.
-Qed.
+  testbit (land a b) n = testbit a n && testbit b n.
+Proof. unfold land; apply testbit_bitwise_1; trivial. Qed.
 
 Lemma ldiff_spec a b n :
- testbit (ldiff a b) n = testbit a n && negb (testbit b n).
-Proof.
- unfold ldiff. apply testbit_bitwise_1; trivial.
-Qed.
+  testbit (ldiff a b) n = testbit a n && negb (testbit b n).
+Proof. unfold ldiff; apply testbit_bitwise_1; trivial. Qed.
 
 Lemma lor_spec a b n :
- testbit (lor a b) n = testbit a n || testbit b n.
+  testbit (lor a b) n = testbit a n || testbit b n.
 Proof.
- unfold lor. apply testbit_bitwise_2.
- - trivial.
- - destruct (compare_spec a b) as [H|H|H].
-   + rewrite max_l; subst; trivial.
-   + apply lt_le_incl in H. now rewrite max_r.
-   + apply lt_le_incl in H. now rewrite max_l.
- - destruct (compare_spec a b) as [H|H|H].
-   + rewrite max_r; subst; trivial.
-   + apply lt_le_incl in H. now rewrite max_r.
-   + apply lt_le_incl in H. now rewrite max_l.
+  unfold lor; apply testbit_bitwise_2.
+  - trivial.
+  - destruct (compare_spec a b) as [H|H|H].
+    + rewrite max_l; subst; trivial.
+    + now apply lt_le_incl in H; rewrite max_r.
+    + now apply lt_le_incl in H; rewrite max_l.
+  - destruct (compare_spec a b) as [H|H|H].
+    + rewrite max_r; subst; trivial.
+    + now apply lt_le_incl in H; rewrite max_r.
+    + now apply lt_le_incl in H; rewrite max_l.
 Qed.
 
 Lemma lxor_spec a b n :
- testbit (lxor a b) n = xorb (testbit a n) (testbit b n).
+  testbit (lxor a b) n = xorb (testbit a n) (testbit b n).
 Proof.
- unfold lxor. apply testbit_bitwise_2.
- - trivial.
- - destruct (compare_spec a b) as [H|H|H].
-   + rewrite max_l; subst; trivial.
-   + apply lt_le_incl in H. now rewrite max_r.
-   + apply lt_le_incl in H. now rewrite max_l.
- - destruct (compare_spec a b) as [H|H|H].
-   + rewrite max_r; subst; trivial.
-   + apply lt_le_incl in H. now rewrite max_r.
-   + apply lt_le_incl in H. now rewrite max_l.
+  unfold lxor; apply testbit_bitwise_2.
+  - trivial.
+  - destruct (compare_spec a b) as [H|H|H].
+    + rewrite max_l; subst; trivial.
+    + now apply lt_le_incl in H; rewrite max_r.
+    + now apply lt_le_incl in H; rewrite max_l.
+  - destruct (compare_spec a b) as [H|H|H].
+    + rewrite max_r; subst; trivial.
+    + now apply lt_le_incl in H; rewrite max_r.
+    + now apply lt_le_incl in H; rewrite max_l.
 Qed.
 
 Lemma div2_spec a : div2 a = shiftr a 1.
-Proof.
- reflexivity.
-Qed.
+Proof. reflexivity. Qed.
 
 (** Aliases with extra dummy hypothesis, to fulfil the interface *)
 
@@ -766,203 +753,186 @@ Include NExtraProp.
 
 Lemma tail_add_spec n m : tail_add n m = n + m.
 Proof.
- revert m. induction n as [|n IH]; simpl; trivial.
- intros. now rewrite IH, add_succ_r.
+  revert m; induction n as [|n IH]; simpl; trivial; intros.
+  now rewrite IH, add_succ_r.
 Qed.
 
 Lemma tail_addmul_spec r n m : tail_addmul r n m = r + n * m.
 Proof.
- revert m r. induction n as [| n IH]; simpl; trivial.
- intros. rewrite IH, tail_add_spec.
- rewrite add_assoc. f_equal. apply add_comm.
+  revert m r; induction n as [| n IH]; simpl; trivial; intros.
+  rewrite IH, tail_add_spec.
+  rewrite add_assoc.
+  f_equal; apply add_comm.
 Qed.
 
 Lemma tail_mul_spec n m : tail_mul n m = n * m.
-Proof.
- unfold tail_mul. now rewrite tail_addmul_spec.
-Qed.
+Proof. unfold tail_mul; now rewrite tail_addmul_spec. Qed.
 
 (** Additional results about [Even] and [Odd] *)
 
 Definition Even_Odd_dec n : {Even n} + {Odd n}.
 Proof.
- induction n as [|n IHn].
- - left; apply Even_0.
- - elim IHn; intros.
-   + right; apply Even_succ, Even_succ_succ; assumption.
-   + left; apply Odd_succ, Odd_succ_succ; assumption.
+  induction n as [|n IHn].
+  - left; apply Even_0.
+  - elim IHn; intros.
+    + right; apply Even_succ, Even_succ_succ; assumption.
+    + left; apply Odd_succ, Odd_succ_succ; assumption.
 Defined.
 
 Definition Even_add_split n m :
- Even (n + m) -> Even n /\ Even m \/ Odd n /\ Odd m.
+  Even (n + m) -> Even n /\ Even m \/ Odd n /\ Odd m.
 Proof.
- rewrite <- ? even_spec, <- ? odd_spec, even_add; unfold odd; do 2 destruct even; auto.
+  rewrite <- ? even_spec, <- ? odd_spec, even_add; unfold odd; do 2 destruct even; auto.
 Qed.
 
 Definition Odd_add_split n m :
- Odd (n + m) -> Odd n /\ Even m \/ Even n /\ Odd m.
+  Odd (n + m) -> Odd n /\ Even m \/ Even n /\ Odd m.
 Proof.
- rewrite <- ? even_spec, <- ? odd_spec, odd_add; unfold odd; do 2 destruct even; auto.
+  rewrite <- ? even_spec, <- ? odd_spec, odd_add; unfold odd; do 2 destruct even; auto.
 Qed.
 
 Definition Even_Even_add n m: Even n -> Even m -> Even (n + m).
-Proof.
- rewrite <- ? even_spec, even_add; do 2 destruct even; auto.
-Qed.
+Proof. rewrite <- ? even_spec, even_add; do 2 destruct even; auto. Qed.
 
 Definition Odd_add_l n m : Odd n -> Even m -> Odd (n + m).
 Proof.
- rewrite <- ? even_spec, <- ? odd_spec, odd_add; unfold odd; do 2 destruct even; auto.
+  rewrite <- ? even_spec, <- ? odd_spec, odd_add; unfold odd; do 2 destruct even; auto.
 Qed.
 
 Definition Odd_add_r n m : Even n -> Odd m -> Odd (n + m).
 Proof.
- rewrite <- ? even_spec, <- ? odd_spec, odd_add; unfold odd; do 2 destruct even; auto.
+  rewrite <- ? even_spec, <- ? odd_spec, odd_add; unfold odd; do 2 destruct even; auto.
 Qed.
 
 Definition Odd_Odd_add n m : Odd n -> Odd m -> Even (n + m).
 Proof.
- rewrite <- ? even_spec, <- ? odd_spec, even_add; unfold odd; do 2 destruct even; auto.
+  rewrite <- ? even_spec, <- ? odd_spec, even_add; unfold odd; do 2 destruct even; auto.
 Qed.
 
 Definition Even_add_aux n m :
- (Odd (n + m) <-> Odd n /\ Even m \/ Even n /\ Odd m) /\
- (Even (n + m) <-> Even n /\ Even m \/ Odd n /\ Odd m).
+  (Odd (n + m) <-> Odd n /\ Even m \/ Even n /\ Odd m) /\
+  (Even (n + m) <-> Even n /\ Even m \/ Odd n /\ Odd m).
 Proof.
- split; split.
- - apply Odd_add_split.
- - intros [[HO HE]|[HE HO]]; [ apply Odd_add_l | apply Odd_add_r ]; assumption.
- - apply Even_add_split.
- - intros [[HO HE]|[HE HO]]; [ apply Even_Even_add | apply Odd_Odd_add ]; assumption.
+  split; split.
+  - apply Odd_add_split.
+  - intros [[HO HE]|[HE HO]]; [ apply Odd_add_l | apply Odd_add_r ]; assumption.
+  - apply Even_add_split.
+  - intros [[HO HE]|[HE HO]]; [ apply Even_Even_add | apply Odd_Odd_add ]; assumption.
 Qed.
 
 Definition Even_add_Even_inv_r n m : Even (n + m) -> Even n -> Even m.
-Proof.
- rewrite <- ? even_spec, even_add; do 2 destruct even; auto.
-Qed.
+Proof. rewrite <- ? even_spec, even_add; do 2 destruct even; auto. Qed.
 
 Definition Even_add_Even_inv_l n m : Even (n + m) -> Even m -> Even n.
-Proof.
- rewrite <- ? even_spec, even_add; do 2 destruct even; auto.
-Qed.
+Proof. rewrite <- ? even_spec, even_add; do 2 destruct even; auto. Qed.
 
 Definition Even_add_Odd_inv_r n m : Even (n + m) -> Odd n -> Odd m.
 Proof.
- rewrite <- ? even_spec, <- ? odd_spec, even_add; unfold odd; do 2 destruct even; auto.
+  rewrite <- ? even_spec, <- ? odd_spec, even_add; unfold odd; do 2 destruct even; auto.
 Qed.
 
 Definition Even_add_Odd_inv_l n m : Even (n + m) -> Odd m -> Odd n.
 Proof.
- rewrite <- ? even_spec, <- ? odd_spec, even_add; unfold odd; do 2 destruct even; auto.
+  rewrite <- ? even_spec, <- ? odd_spec, even_add; unfold odd; do 2 destruct even; auto.
 Qed.
 
 Definition Odd_add_Even_inv_l n m : Odd (n + m) -> Odd m -> Even n.
 Proof.
- rewrite <- ? even_spec, <- ? odd_spec, odd_add; unfold odd; do 2 destruct even; auto.
+  rewrite <- ? even_spec, <- ? odd_spec, odd_add; unfold odd; do 2 destruct even; auto.
 Qed.
 
 Definition Odd_add_Even_inv_r n m : Odd (n + m) -> Odd n -> Even m.
 Proof.
- rewrite <- ? even_spec, <- ? odd_spec, odd_add; unfold odd; do 2 destruct even; auto.
+  rewrite <- ? even_spec, <- ? odd_spec, odd_add; unfold odd; do 2 destruct even; auto.
 Qed.
 
 Definition Odd_add_Odd_inv_l n m : Odd (n + m) -> Even m -> Odd n.
 Proof.
- rewrite <- ? even_spec, <- ? odd_spec, odd_add; unfold odd; do 2 destruct even; auto.
+  rewrite <- ? even_spec, <- ? odd_spec, odd_add; unfold odd; do 2 destruct even; auto.
 Qed.
 
 Definition Odd_add_Odd_inv_r n m : Odd (n + m) -> Even n -> Odd m.
 Proof.
- rewrite <- ? even_spec, <- ? odd_spec, odd_add; unfold odd; do 2 destruct even; auto.
+  rewrite <- ? even_spec, <- ? odd_spec, odd_add; unfold odd; do 2 destruct even; auto.
 Qed.
 
 Definition Even_mul_aux n m :
- (Odd (n * m) <-> Odd n /\ Odd m) /\ (Even (n * m) <-> Even n \/ Even m).
+  (Odd (n * m) <-> Odd n /\ Odd m) /\ (Even (n * m) <-> Even n \/ Even m).
 Proof.
- rewrite <- ? even_spec, <- ? odd_spec, odd_mul, even_mul; unfold odd; do 2 destruct even; tauto.
+  rewrite <- ? even_spec, <- ? odd_spec, odd_mul, even_mul; unfold odd; do 2 destruct even; tauto.
 Qed.
 
 Definition Even_mul_l n m : Even n -> Even (n * m).
-Proof.
- rewrite <- ? even_spec, even_mul; do 2 destruct even; auto.
-Qed.
+Proof. rewrite <- ? even_spec, even_mul; do 2 destruct even; auto. Qed.
 
 Definition Even_mul_r n m : Even m -> Even (n * m).
-Proof.
- rewrite <- ? even_spec, even_mul; do 2 destruct even; auto.
-Qed.
+Proof. rewrite <- ? even_spec, even_mul; do 2 destruct even; auto. Qed.
 
 Definition Even_mul_inv_r n m : Even (n * m) -> Odd n -> Even m.
 Proof.
- rewrite <- ? even_spec, <- ? odd_spec, even_mul; unfold odd; do 2 destruct even; auto.
+  rewrite <- ? even_spec, <- ? odd_spec, even_mul; unfold odd; do 2 destruct even; auto.
 Qed.
 
 Definition Even_mul_inv_l n m : Even (n * m) -> Odd m -> Even n.
 Proof.
- rewrite <- ? even_spec, <- ? odd_spec, even_mul; unfold odd; do 2 destruct even; auto.
+  rewrite <- ? even_spec, <- ? odd_spec, even_mul; unfold odd; do 2 destruct even; auto.
 Qed.
 
 Definition Odd_mul n m : Odd n -> Odd m -> Odd (n * m).
-Proof.
- rewrite <- ? odd_spec, odd_mul; unfold odd; do 2 destruct even; auto.
-Qed.
+Proof. rewrite <- ? odd_spec, odd_mul; unfold odd; do 2 destruct even; auto. Qed.
 
 Definition Odd_mul_inv_l n m : Odd (n * m) -> Odd n.
-Proof.
- rewrite <- ? odd_spec, odd_mul; unfold odd; do 2 destruct even; auto.
-Qed.
+Proof. rewrite <- ? odd_spec, odd_mul; unfold odd; do 2 destruct even; auto. Qed.
 
 Definition Odd_mul_inv_r n m : Odd (n * m) -> Odd m.
-Proof.
- rewrite <- ? odd_spec, odd_mul; unfold odd; do 2 destruct even; auto.
-Qed.
+Proof. rewrite <- ? odd_spec, odd_mul; unfold odd; do 2 destruct even; auto. Qed.
 
 Definition Even_div2 n : Even n -> div2 n = div2 (S n).
-Proof.
- intros [p ->]; rewrite div2_succ_double; apply div2_double.
-Qed.
+Proof. intros [p ->]; rewrite div2_succ_double; apply div2_double. Qed.
 
 Definition Odd_div2 n : Odd n -> S (div2 n) = div2 (S n).
 Proof.
- intros [p ->]; rewrite add_1_r, div2_succ_double; cbn.
- f_equal; symmetry; apply div2_double.
+  intros [p ->]; rewrite add_1_r, div2_succ_double; cbn.
+  f_equal; symmetry; apply div2_double.
 Qed.
 
 Definition div2_Even n : div2 n = div2 (S n) -> Even n.
 Proof.
- destruct (Even_or_Odd n) as [Ev|Od]; trivial.
- apply Odd_div2 in Od; rewrite <- Od.
- intro Od'; destruct (neq_succ_diag_r _ Od').
+  destruct (Even_or_Odd n) as [Ev|Od]; trivial.
+  apply Odd_div2 in Od; rewrite <- Od.
+  intro Od'; destruct (neq_succ_diag_r _ Od').
 Qed.
 
 Definition div2_Odd n : S (div2 n) = div2 (S n) -> Odd n.
 Proof.
- destruct (Even_or_Odd n) as [Ev|Od]; trivial.
- apply Even_div2 in Ev; rewrite <- Ev.
- intro Ev'; symmetry in Ev'; destruct (neq_succ_diag_r _ Ev').
+  destruct (Even_or_Odd n) as [Ev|Od]; trivial.
+  apply Even_div2 in Ev; rewrite <- Ev.
+  intro Ev'; symmetry in Ev'; destruct (neq_succ_diag_r _ Ev').
 Qed.
 
 Definition Even_Odd_div2 n :
- (Even n <-> div2 n = div2 (S n)) /\ (Odd n <-> S (div2 n) = div2 (S n)).
+  (Even n <-> div2 n = div2 (S n)) /\ (Odd n <-> S (div2 n) = div2 (S n)).
 Proof.
-split; split; [ apply Even_div2 | apply div2_Even | apply Odd_div2 | apply div2_Odd ].
+  split; split; [ apply Even_div2 | apply div2_Even | apply Odd_div2 | apply div2_Odd ].
 Qed.
 
 Definition Even_Odd_double n :
   (Even n <-> n = double (div2 n)) /\ (Odd n <-> n = S (double (div2 n))).
 Proof.
-  revert n. fix Even_Odd_double 1. intros n; destruct n as [|[|n]].
-  - (* n = 0 *)
-    split; split; intros H; [ reflexivity | apply Even_0 | apply Odd_0 in H as [] | inversion H ].
-  - (* n = 1 *)
-    split; split; intros H; [ apply Even_1 in H as [] | inversion H | reflexivity | apply Odd_1 ].
-  - (* n = (S (S n')) *)
-    destruct (Even_Odd_double n) as ((Ev,Ev'),(Od,Od')).
-    split; split; simpl div2; rewrite ? double_S, ? Even_succ_succ, ? Odd_succ_succ.
-    + intros; do 2 f_equal; auto.
-    + injection 1; auto.
-    + intros; do 2 f_equal; auto.
-    + injection 1; auto.
+  revert n.
+  fix Even_Odd_double 1.
+    intros n; destruct n as [|[|n]].
+    - (* n = 0 *)
+      split; split; intros H; [ reflexivity | apply Even_0 | apply Odd_0 in H as [] | inversion H ].
+    - (* n = 1 *)
+      split; split; intros H; [ apply Even_1 in H as [] | inversion H | reflexivity | apply Odd_1 ].
+    - (* n = (S (S n')) *)
+      destruct (Even_Odd_double n) as ((Ev,Ev'),(Od,Od')).
+      split; split; simpl div2; rewrite ? double_S, ? Even_succ_succ, ? Odd_succ_succ.
+      + intros; do 2 f_equal; auto.
+      + injection 1; auto.
+      + intros; do 2 f_equal; auto.
+      + injection 1; auto.
 Qed.
 
 Definition Even_double n : Even n -> n = double (div2 n).
@@ -979,37 +949,40 @@ Proof proj2 (proj2 (Even_Odd_double n)).
 
 (** Inductive definition of even and odd *)
 Inductive Even_alt : nat -> Prop :=
- | Even_alt_O : Even_alt 0
- | Even_alt_S : forall n, Odd_alt n -> Even_alt (S n)
+| Even_alt_O : Even_alt 0
+| Even_alt_S : forall n, Odd_alt n -> Even_alt (S n)
 with Odd_alt : nat -> Prop :=
- | Odd_alt_S : forall n, Even_alt n -> Odd_alt (S n).
+| Odd_alt_S : forall n, Even_alt n -> Odd_alt (S n).
 
 Definition Even_alt_Even : forall n, Even_alt n <-> Even n.
 Proof.
- fix Even_alt_Even 1.
- intros n; destruct n as [|[|n]]; simpl.
- - split; [now exists 0 | constructor].
- - split.
-   + inversion_clear 1 as [|? H0]. inversion_clear H0.
-   + now rewrite <- Nat.even_spec.
- - rewrite Nat.Even_succ_succ, <- Even_alt_Even.
-   split.
-   + inversion_clear 1 as [|? H0]. now inversion_clear H0.
-   + now do 2 constructor.
+  fix Even_alt_Even 1.
+    intros n; destruct n as [|[|n]]; simpl.
+    - split; [now exists 0 | constructor].
+    - split.
+      + inversion_clear 1 as [|? H0].
+        inversion_clear H0.
+      + now rewrite <- Nat.even_spec.
+    - rewrite Nat.Even_succ_succ, <- Even_alt_Even.
+      split.
+      + inversion_clear 1 as [|? H0].
+        now inversion_clear H0.
+      + now do 2 constructor.
 Qed.
 
 Definition Odd_alt_Odd : forall n, Odd_alt n <-> Odd n.
 Proof.
- fix Odd_alt_Odd 1.
- intros n; destruct n as [|[|n]]; simpl.
- - split.
-   + inversion_clear 1.
-   + now rewrite <- Nat.odd_spec.
- - split; [ now exists 0 | do 2 constructor ].
- - rewrite Nat.Odd_succ_succ, <- Odd_alt_Odd.
-   split.
-   + inversion_clear 1 as [? H0]. now inversion_clear H0.
-   + now do 2 constructor.
+  fix Odd_alt_Odd 1.
+    intros n; destruct n as [|[|n]]; simpl.
+    - split.
+      + inversion_clear 1.
+      + now rewrite <- Nat.odd_spec.
+    - split; [ now exists 0 | do 2 constructor ].
+    - rewrite Nat.Odd_succ_succ, <- Odd_alt_Odd.
+      split.
+      + inversion_clear 1 as [? H0].
+        now inversion_clear H0.
+      + now do 2 constructor.
 Qed.
 
 Scheme Odd_alt_Even_alt_ind := Minimality for Odd_alt Sort Prop
@@ -1019,20 +992,20 @@ Lemma Odd_Even_ind (P Q : nat -> Prop) :
   (forall n, Even n -> Q n -> P (S n)) ->
   Q 0 -> (forall n, Odd n -> P n -> Q (S n)) -> forall n, Odd n -> P n.
 Proof.
-intros HSE H0 HSO n HO%Odd_alt_Odd.
-apply Odd_alt_Even_alt_ind with Q; try assumption.
-- intros m HSE'%Even_alt_Even; auto.
-- intros m HSO'%Odd_alt_Odd; auto.
+  intros HSE H0 HSO n HO%Odd_alt_Odd.
+  apply Odd_alt_Even_alt_ind with Q; try assumption.
+  - intros m HSE'%Even_alt_Even; auto.
+  - intros m HSO'%Odd_alt_Odd; auto.
 Qed.
 
 Lemma Even_Odd_ind (P Q : nat -> Prop) :
   (forall n, Even n -> Q n -> P (S n)) ->
   Q 0 -> (forall n, Odd n -> P n -> Q (S n)) -> forall n, Even n -> Q n.
 Proof.
-intros HSE H0 HSO n HE%Even_alt_Even.
-apply Even_alt_Odd_alt_ind with P; try assumption.
-- intros m HSE'%Even_alt_Even; auto.
-- intros m HSO'%Odd_alt_Odd; auto.
+  intros HSE H0 HSO n HE%Even_alt_Even.
+  apply Even_alt_Odd_alt_ind with P; try assumption.
+  - intros m HSE'%Even_alt_Even; auto.
+  - intros m HSO'%Odd_alt_Odd; auto.
 Qed.
 
 (* Anomaly see Issue #15413
@@ -1046,20 +1019,20 @@ Lemma Odd_Even_sind (P Q : nat -> SProp) :
   (forall n, Even n -> Q n -> P (S n)) ->
   Q 0 -> (forall n, Odd n -> P n -> Q (S n)) -> forall n, Odd n -> P n.
 Proof.
-intros HSE H0 HSO n HO%Odd_alt_Odd.
-apply Odd_alt_Even_alt_sind with Q; try assumption.
-- intros m HSE'%Even_alt_Even; auto.
-- intros m HSO'%Odd_alt_Odd; auto.
+  intros HSE H0 HSO n HO%Odd_alt_Odd.
+  apply Odd_alt_Even_alt_sind with Q; try assumption.
+  - intros m HSE'%Even_alt_Even; auto.
+  - intros m HSO'%Odd_alt_Odd; auto.
 Qed.
 
 Lemma Even_Odd_sind (P Q : nat -> SProp) :
   (forall n, Even n -> Q n -> P (S n)) ->
   Q 0 -> (forall n, Odd n -> P n -> Q (S n)) -> forall n, Even n -> Q n.
 Proof.
-intros HSE H0 HSO n HE%Even_alt_Even.
-apply Even_alt_Odd_alt_sind with P; try assumption.
-- intros m HSE'%Even_alt_Even; auto.
-- intros m HSO'%Odd_alt_Odd; auto.
+  intros HSE H0 HSO n HE%Even_alt_Even.
+  apply Even_alt_Odd_alt_sind with P; try assumption.
+  - intros m HSE'%Even_alt_Even; auto.
+  - intros m HSO'%Odd_alt_Odd; auto.
 Qed.
 
 (* Anomaly see Issue #15413
@@ -1081,10 +1054,8 @@ Infix "?=" := Nat.compare (at level 70) : nat_scope.
 Infix "/" := Nat.div : nat_scope.
 Infix "mod" := Nat.modulo (at level 40, no associativity) : nat_scope.
 
-#[global]
-Hint Unfold Nat.le : core.
-#[global]
-Hint Unfold Nat.lt : core.
+#[global] Hint Unfold Nat.le : core.
+#[global] Hint Unfold Nat.lt : core.
 
 Register Nat.le_trans as num.nat.le_trans.
 Register Nat.nlt_0_r as num.nat.nlt_0_r.
@@ -1095,8 +1066,6 @@ Register Nat.nlt_0_r as num.nat.nlt_0_r.
     [1<=2] or [x<=x+x], but rather things like [x<=y -> y<=x -> x=y]. *)
 
 Section TestOrder.
- Let test : forall x y, x<=y -> y<=x -> x=y.
- Proof.
- Nat.order.
- Qed.
+  Let test : forall x y, x<=y -> y<=x -> x=y.
+  Proof. Nat.order. Qed.
 End TestOrder.

--- a/theories/Arith/Plus.v
+++ b/theories/Arith/Plus.v
@@ -98,11 +98,8 @@ Notation lt_plus_trans := Arith_prebase.lt_plus_trans_stt.
 (** * Inversion lemmas *)
 
 #[local]
-Definition plus_is_O_stt n m : n + m = 0 -> n = 0 /\ m = 0.
-Proof.
-  destruct n; now split.
-Qed.
-#[deprecated(since="8.16",note="The Arith.Plus file is obsolete.")]
+Definition plus_is_O_stt := fun n m => proj1 (Nat.eq_add_0 n m).
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.eq_add_0 instead.")]
 Notation plus_is_O := plus_is_O_stt.
 
 #[local]
@@ -113,7 +110,7 @@ Proof.
   destruct m; auto.
   discriminate.
 Defined.
-#[deprecated(since="8.16",note="The Arith.Plus file is obsolete.")]
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.eq_add_1 instead.")]
 Notation plus_is_one := plus_is_one_stt.
 
 (** * Derived properties *)


### PR DESCRIPTION
Following #14736, deprecated results not already available in `Arith.PeanoNat` are integrated in `PeanoNat.Nat`.
Results about `Even.even` are integrated as results about `Nat.Even`.
The inductive definition `Even.even` is integrated as the new `Nat.Even_alt`.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
