### PR TITLE
Fixes #15403: inlining not propagated along aliases of module paths in delta-resolver

### DIFF
--- a/doc/changelog/01-kernel/15412-master+fix15403-missing-inlining-resolver-composition.rst
+++ b/doc/changelog/01-kernel/15412-master+fix15403-missing-inlining-resolver-composition.rst
@@ -1,0 +1,7 @@
+- **Fixed:**
+  Inlining of non-logical objects (notations, hints, ...) was missing
+  when applying a functor returning one of its arguments as e.g. in
+  :n:`Module F (E:T) := E`
+  (`#15412 <https://github.com/coq/coq/pull/15412>`_,
+  fixes `#15403 <https://github.com/coq/coq/issues/15403>`_,
+  by Hugo Herbelin).

--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -459,8 +459,8 @@ let subset_prefixed_by mp resolver =
   in
   let kn_prefix kn hint rslv =
     match hint with
-      | Inline _ -> rslv
-      | Equiv _ ->
+      | Inline (_,None) -> rslv
+      | Equiv _ | Inline (_,Some _) ->
         if mp_in_mp mp (KerName.modpath kn) then Deltamap.add_kn kn hint rslv else rslv
   in
   Deltamap.fold mp_prefix kn_prefix resolver empty_delta_resolver

--- a/test-suite/bugs/bug_15403.v
+++ b/test-suite/bugs/bug_15403.v
@@ -1,0 +1,18 @@
+Module Type EqType.
+   Parameter Inline t : Type.
+   Parameter eq : t -> t -> Prop.
+End EqType.
+
+Module NAT.
+   Definition t := nat.
+   Definition eq := @eq nat.
+End NAT.
+
+Module F (E:EqType) :=
+  E.
+
+Module Import NAT' := F NAT.
+
+(* NAT'.eq should declared arguments in nat_scope *)
+Notation "1" := true.
+Check NAT'.eq 1 1.


### PR DESCRIPTION
**Kind:** fix

The invariants of the code for delta-resolver composition are complex and I don't understand them well. At least, there was a discrepancy when composing either a delta-resolver `[Top.NAT'=>Top.E]` or delta-resolver `[Top.NAT'.t=>Top.E.t]` with a substitution `{Top.E |-> Top.NAT [Top.NAT.t=>inline(Some _)]}`: the second case was adding `[Top.NAT'.t=>inline(Some _)]` but not the first case. The discrepancy was in `Mod_subst.gen_subst_delta_resolver`, which `subst_codom_delta_resolver` was calling and we fix the first case.

Fixes / closes #15403

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
