### PR TITLE
Reduce the use of `Global` functions

### DIFF
--- a/dev/ci/user-overlays/15414-ppedrot-reduce-global-use.sh
+++ b/dev/ci/user-overlays/15414-ppedrot-reduce-global-use.sh
@@ -1,0 +1,1 @@
+overlay paramcoq https://github.com/ppedrot/paramcoq reduce-global-use 15414

--- a/doc/plugin_tutorial/tuto3/src/construction_game.ml
+++ b/doc/plugin_tutorial/tuto3/src/construction_game.ml
@@ -11,7 +11,7 @@ let example_sort sigma =
   let new_type = EConstr.mkSort s in
   sigma, new_type
 
-let c_one sigma =
+let c_one env sigma =
 (* In the general case, global references may refer to universe polymorphic
    objects, and their universe has to be made afresh when creating an instance. *)
   let gr_S =
@@ -19,8 +19,8 @@ let c_one sigma =
 (* the long name of "S" was found with the command "About S." *)
   let gr_O =
     find_reference "Tuto3" ["Coq"; "Init"; "Datatypes"] "O" in
-  let sigma, c_O = Evd.fresh_global (Global.env ()) sigma gr_O in
-  let sigma, c_S = Evd.fresh_global (Global.env ()) sigma gr_S in
+  let sigma, c_O = Evd.fresh_global env sigma gr_O in
+  let sigma, c_S = Evd.fresh_global env sigma gr_S in
 (* Here is the construction of a new term by applying functions to argument. *)
   sigma, EConstr.mkApp (c_S, [| c_O |])
 
@@ -47,7 +47,7 @@ let dangling_identity2 env sigma =
 let example_sort_app_lambda () =
     let env = Global.env () in
     let sigma = Evd.from_env env in
-    let sigma, c_v = c_one sigma in
+    let sigma, c_v = c_one env sigma in
 (* dangling_identity and dangling_identity2 can be used interchangeably here *)
     let sigma, c_f = dangling_identity2 env sigma in
     let c_1 = EConstr.mkApp (c_f, [| c_v |]) in
@@ -65,51 +65,51 @@ let example_sort_app_lambda () =
        (Printer.pr_econstr_env env sigma the_type))
 
 
-let c_S sigma =
+let c_S env sigma =
   let gr = find_reference "Tuto3" ["Coq"; "Init"; "Datatypes"] "S" in
-  Evd.fresh_global (Global.env ()) sigma gr
+  Evd.fresh_global env sigma gr
 
-let c_O sigma =
+let c_O env sigma =
   let gr = find_reference "Tuto3" ["Coq"; "Init"; "Datatypes"] "O" in
-  Evd.fresh_global (Global.env ()) sigma gr
+  Evd.fresh_global env sigma gr
 
-let c_E sigma =
+let c_E env sigma =
   let gr = find_reference "Tuto3" ["Tuto3"; "Data"] "EvenNat" in
-  Evd.fresh_global (Global.env ()) sigma gr
+  Evd.fresh_global env sigma gr
 
-let c_D sigma =
+let c_D env sigma =
   let gr = find_reference "Tuto3" ["Tuto3"; "Data"] "tuto_div2" in
-  Evd.fresh_global (Global.env ()) sigma gr
+  Evd.fresh_global env sigma gr
 
-let c_Q sigma =
+let c_Q env sigma =
   let gr = find_reference "Tuto3" ["Coq"; "Init"; "Logic"] "eq" in
-  Evd.fresh_global (Global.env ()) sigma gr
+  Evd.fresh_global env sigma gr
 
-let c_R sigma =
+let c_R env sigma =
   let gr = find_reference "Tuto3" ["Coq"; "Init"; "Logic"] "eq_refl" in
-  Evd.fresh_global (Global.env ()) sigma gr
+  Evd.fresh_global env sigma gr
 
-let c_N sigma =
+let c_N env sigma =
   let gr = find_reference "Tuto3" ["Coq"; "Init"; "Datatypes"] "nat" in
-  Evd.fresh_global (Global.env ()) sigma gr
+  Evd.fresh_global env sigma gr
 
-let c_C sigma =
+let c_C env sigma =
   let gr = find_reference "Tuto3" ["Tuto3"; "Data"] "C" in
-  Evd.fresh_global (Global.env ()) sigma gr
+  Evd.fresh_global env sigma gr
 
-let c_F sigma =
+let c_F env sigma =
   let gr = find_reference "Tuto3" ["Tuto3"; "Data"] "S_ev" in
-  Evd.fresh_global (Global.env ()) sigma gr
+  Evd.fresh_global env sigma gr
 
-let c_P sigma =
+let c_P env sigma =
   let gr = find_reference "Tuto3" ["Tuto3"; "Data"] "s_half_proof" in
-  Evd.fresh_global (Global.env ()) sigma gr
+  Evd.fresh_global env sigma gr
 
 (* If c_S was universe polymorphic, we should have created a new constant
    at each iteration of buildup. *)
-let mk_nat sigma n =
-  let sigma, c_S = c_S sigma in
-  let sigma, c_O = c_O sigma in
+let mk_nat env sigma n =
+  let sigma, c_S = c_S env sigma in
+  let sigma, c_O = c_O env sigma in
   let rec buildup = function
     | 0 -> c_O
     | n -> EConstr.mkApp (c_S, [| buildup (n - 1) |]) in
@@ -118,13 +118,13 @@ let mk_nat sigma n =
 let example_classes n =
   let env = Global.env () in
   let sigma = Evd.from_env env in
-  let sigma, c_n = mk_nat sigma n in
-  let sigma, n_half = mk_nat sigma (n / 2) in
-  let sigma, c_N = c_N sigma in
-  let sigma, c_div = c_D sigma in
-  let sigma, c_even = c_E sigma in
-  let sigma, c_Q = c_Q sigma in
-  let sigma, c_R = c_R sigma in
+  let sigma, c_n = mk_nat env sigma n in
+  let sigma, n_half = mk_nat env sigma (n / 2) in
+  let sigma, c_N = c_N env sigma in
+  let sigma, c_div = c_D env sigma in
+  let sigma, c_even = c_E env sigma in
+  let sigma, c_Q = c_Q env sigma in
+  let sigma, c_R = c_R env sigma in
   let arg_type = EConstr.mkApp (c_even, [| c_n |]) in
   let sigma0 = sigma in
   let sigma, instance = Evarutil.new_evar env sigma arg_type in
@@ -154,13 +154,13 @@ let example_canonical n =
   let env = Global.env () in
   let sigma = Evd.from_env env in
 (* Construct a natural representation of this integer. *)
-  let sigma, c_n = mk_nat sigma n in
+  let sigma, c_n = mk_nat env sigma n in
 (* terms for "nat", "eq", "S_ev", "eq_refl", "C" *)
-  let sigma, c_N = c_N sigma in
-  let sigma, c_F = c_F sigma in
-  let sigma, c_R = c_R sigma in
-  let sigma, c_C = c_C sigma in
-  let sigma, c_P = c_P sigma in
+  let sigma, c_N = c_N env sigma in
+  let sigma, c_F = c_F env sigma in
+  let sigma, c_R = c_R env sigma in
+  let sigma, c_C = c_C env sigma in
+  let sigma, c_P = c_P env sigma in
 (* the last argument of C *)
   let refl_term = EConstr.mkApp (c_R, [|c_N; c_n |]) in
 (* Now we build two existential variables, for the value of the half and for

--- a/doc/plugin_tutorial/tuto3/src/g_tuto3.mlg
+++ b/doc/plugin_tutorial/tuto3/src/g_tuto3.mlg
@@ -18,7 +18,7 @@ VERNAC COMMAND EXTEND ShowTypeConstruction CLASSIFIED AS QUERY
     let sigma, s = Evd.new_sort_variable Evd.univ_rigid sigma in
     let new_type_2 = EConstr.mkSort s in
     let sigma, _ =
-      Typing.type_of (Global.env()) (Evd.from_env (Global.env())) new_type_2 in
+      Typing.type_of env (Evd.from_env env) new_type_2 in
     Feedback.msg_notice
       (Printer.pr_econstr_env env sigma new_type_2) }
 END

--- a/plugins/funind/functional_principles_types.ml
+++ b/plugins/funind/functional_principles_types.ml
@@ -32,10 +32,9 @@ let pop t = Vars.lift (-1) t
    Transform an inductive induction principle into
    a functional one
 *)
-let compute_new_princ_type_from_rel rel_to_fun sorts princ_type =
+let compute_new_princ_type_from_rel env rel_to_fun sorts princ_type =
   let princ_type = EConstr.of_constr princ_type in
   let princ_type_info = compute_elim_sig Evd.empty princ_type (* FIXME *) in
-  let env = Global.env () in
   let env_with_params = EConstr.push_rel_context princ_type_info.params env in
   let tbl = Hashtbl.create 792 in
   let rec change_predicates_names (avoid : Id.t list)

--- a/plugins/funind/functional_principles_types.mli
+++ b/plugins/funind/functional_principles_types.mli
@@ -9,4 +9,4 @@
 (************************************************************************)
 
 val compute_new_princ_type_from_rel :
-  Constr.constr array -> Sorts.t array -> Constr.t -> Constr.types
+  Environ.env -> Constr.constr array -> Sorts.t array -> Constr.t -> Constr.types

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -77,12 +77,12 @@ let def_of_const t =
         ++ str "." ) )
   | _ -> assert false
 
-let type_of_const sigma t =
+let type_of_const env sigma t =
   match EConstr.kind sigma t with
   | Const (sp, u) ->
     let u = EInstance.kind sigma u in
     (* FIXME discarding universe constraints *)
-    Typeops.type_of_constant_in (Global.env ()) (sp, u)
+    Typeops.type_of_constant_in env (sp, u)
   | _ -> assert false
 
 let constant sl s = UnivGen.constr_of_monomorphic_global (Global.env ()) (find_reference sl s)
@@ -1572,7 +1572,7 @@ let start_equation (f : GlobRef.t) (term_f : GlobRef.t)
       let terminate_constr = constr_of_monomorphic_global (Global.env ()) term_f in
       let terminate_constr = EConstr.of_constr terminate_constr in
       let nargs =
-        nb_prod sigma (EConstr.of_constr (type_of_const sigma terminate_constr))
+        nb_prod sigma (EConstr.of_constr (type_of_const (Global.env ()) sigma terminate_constr))
       in
       let x = n_x_id ids nargs in
       New.observe_tac

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -2188,12 +2188,12 @@ let eq_id avoid id =
   let hid' = next_ident_away hid avoid in
     hid'
 
-let mk_eq sigma typ x y = papp sigma coq_eq_ind [| typ; x ; y |]
-let mk_eq_refl sigma typ x = papp sigma coq_eq_refl [| typ; x |]
-let mk_JMeq sigma typ x typ' y =
-  papp sigma coq_JMeq_ind [| typ; x ; typ'; y |]
-let mk_JMeq_refl sigma typ x =
-  papp sigma coq_JMeq_refl [| typ; x |]
+let mk_eq env sigma typ x y = papp env sigma coq_eq_ind [| typ; x ; y |]
+let mk_eq_refl env sigma typ x = papp env sigma coq_eq_refl [| typ; x |]
+let mk_JMeq env sigma typ x typ' y =
+  papp env sigma coq_JMeq_ind [| typ; x ; typ'; y |]
+let mk_JMeq_refl env sigma typ x =
+  papp env sigma coq_JMeq_refl [| typ; x |]
 
 let hole na = DAst.make @@
   GHole (Evar_kinds.QuestionMark {
@@ -2264,7 +2264,7 @@ let constr_of_pat env sigma arsign pat avoid =
                     let env = EConstr.push_rel_context sign env in
                     let sigma = unify_leq_delay (EConstr.push_rel_context sign env) sigma
                       (lift (succ m) ty) (lift 1 apptype) in
-                    let sigma, eq_t = mk_eq sigma (lift (succ m) ty)
+                    let sigma, eq_t = mk_eq env sigma (lift (succ m) ty)
                       (mkRel 1) (* alias *)
                       (lift 1 app) (* aliased term *)
                     in
@@ -2326,7 +2326,7 @@ let rec is_included x y =
    Hence pats is already typed in its
    full signature. However prevpatterns are in the original one signature per pattern form.
  *)
-let build_ineqs sigma prevpatterns pats liftsign =
+let build_ineqs env sigma prevpatterns pats liftsign =
   let sigma, diffs =
     List.fold_left
       (fun (sigma, c) eqnpats ->
@@ -2343,7 +2343,7 @@ let build_ineqs sigma prevpatterns pats liftsign =
                       (* Accumulated length of previous pattern's signatures *)
                       let len' = lens + len in
                       let sigma, c' =
-                        papp sigma coq_eq_ind
+                        papp env sigma coq_eq_ind
                           [| lift (len' + liftsign) curpat_ty;
                             liftn (len + liftsign) (succ lens) ppat_c ;
                             lift len' curpat_c |]
@@ -2360,13 +2360,13 @@ let build_ineqs sigma prevpatterns pats liftsign =
          in match acc with
              None -> sigma, c
             | Some (sign, len, _, c') ->
-               let sigma, conj = mk_coq_and sigma c' in
-               let sigma, neg = mk_coq_not sigma conj in
+               let sigma, conj = mk_coq_and env sigma c' in
+               let sigma, neg = mk_coq_not env sigma conj in
                let conj = it_mkProd_or_LetIn neg (lift_rel_context liftsign sign) in
                sigma, conj :: c)
       (sigma, []) prevpatterns
   in match diffs with [] -> sigma, None
-    | _ -> let sigma, conj = mk_coq_and sigma diffs in sigma, Some conj
+    | _ -> let sigma, conj = mk_coq_and env sigma diffs in sigma, Some conj
 
 let constrs_of_pats typing_fun env sigma eqns tomatchs sign neqs arity =
   let i = ref 0 in
@@ -2401,7 +2401,7 @@ let constrs_of_pats typing_fun env sigma eqns tomatchs sign neqs arity =
                  (s, List.map (lift n) args), p) :: pats, len + n))
            ([], 0) pats
          in
-         let sigma, ineqs = build_ineqs sigma prevpatterns pats signlen in
+         let sigma, ineqs = build_ineqs !!env sigma prevpatterns pats signlen in
          let rhs_rels' = rels_of_patsign sigma rhs_rels in
          let _signenv,_ = push_rel_context ~hypnaming:ProgramNaming sigma rhs_rels' env in
          let arity =
@@ -2518,20 +2518,20 @@ let build_dependent_signature env sigma avoid tomatchs arsign =
                     let sigma, eq, refl_arg =
                       if Reductionops.is_conv env sigma argt t then
                         let sigma, eq =
-                          mk_eq sigma (lift (nargeqs + slift) argt)
+                          mk_eq env sigma (lift (nargeqs + slift) argt)
                             (mkRel (nargeqs + slift))
                             (lift (nargeqs + nar) arg)
                         in
-                        let sigma, refl = mk_eq_refl sigma argt arg in
+                        let sigma, refl = mk_eq_refl env sigma argt arg in
                         sigma, eq, refl
                       else
                         let sigma, eq =
-                          mk_JMeq sigma (lift (nargeqs + slift) t)
+                          mk_JMeq env sigma (lift (nargeqs + slift) t)
                             (mkRel (nargeqs + slift))
                             (lift (nargeqs + nar) argt)
                             (lift (nargeqs + nar) arg)
                         in
-                        let sigma, refl = mk_JMeq_refl sigma argt arg in
+                        let sigma, refl = mk_JMeq_refl env sigma argt arg in
                         (sigma, eq, refl)
                     in
                     let previd, id =
@@ -2550,13 +2550,13 @@ let build_dependent_signature env sigma avoid tomatchs arsign =
                  (sigma, env, neqs, [], [], slift, []) args argsign
              in
               let sigma, eq =
-                mk_JMeq sigma
+                mk_JMeq env sigma
                   (lift (nargeqs + slift) appt)
                   (mkRel (nargeqs + slift))
                   (lift (nargeqs + nar) ty)
                   (lift (nargeqs + nar) tm)
              in
-             let sigma, refl_eq = mk_JMeq_refl sigma ty tm in
+             let sigma, refl_eq = mk_JMeq_refl env sigma ty tm in
              let previd, id = make_prime avoid appn in
                (sigma, (LocalAssum (make_annot (Name (eq_id avoid previd)) Sorts.Relevant, eq) :: argeqs) :: eqs,
                 succ nargeqs,
@@ -2571,10 +2571,10 @@ let build_dependent_signature env sigma avoid tomatchs arsign =
              let arsign' = RelDecl.set_name (Name id) decl in
              let tomatch_ty = type_of_tomatch ty in
             let sigma, eq =
-              mk_eq sigma (lift nar tomatch_ty)
+              mk_eq env sigma (lift nar tomatch_ty)
                 (mkRel slift) (lift nar tm)
             in
-            let sigma, refl = mk_eq_refl sigma tomatch_ty tm in
+            let sigma, refl = mk_eq_refl env sigma tomatch_ty tm in
             let na = make_annot (Name (eq_id avoid previd)) Sorts.Relevant in
             (sigma,
             [LocalAssum (na, eq)] :: eqs, succ neqs,

--- a/pretyping/coercion.ml
+++ b/pretyping/coercion.ml
@@ -186,9 +186,9 @@ let coerce ?loc env sigma (x : EConstr.constr) (y : EConstr.constr)
             in
             let args = List.rev (restargs @ mkRel 1 :: List.map (lift 1) tele) in
             let pred = mkLambda (n, eqT, applist (lift 1 c, args)) in
-            let sigma, eq = papp sigma coq_eq_ind [| eqT; hdx; hdy |] in
+            let sigma, eq = papp env sigma coq_eq_ind [| eqT; hdx; hdy |] in
             let sigma, evar = make_existential ?loc n.binder_name env sigma eq in
-            let eq_app sigma x = papp sigma coq_eq_rect
+            let eq_app sigma x = papp env sigma coq_eq_rect
                 [| eqT; hdx; pred; x; hdy; evar|]
             in
             aux sigma (hdy :: tele) (subst1 hdx restT)
@@ -279,11 +279,11 @@ let coerce ?loc env sigma (x : EConstr.constr) (y : EConstr.constr)
                | _, _ ->
                  sigma,
                  Some (fun sigma x ->
-                     let sigma, t1 = papp sigma sigT_proj1 [| a; pb; x |] in
-                     let sigma, t2 = papp sigma sigT_proj2 [| a; pb; x |] in
+                     let sigma, t1 = papp env sigma sigT_proj1 [| a; pb; x |] in
+                     let sigma, t2 = papp env sigma sigT_proj2 [| a; pb; x |] in
                      let sigma, x =  app_opt env' sigma c1 t1 in
                      let sigma, y = app_opt env' sigma c2 t2 in
-                     papp sigma sigT_intro [| a'; pb'; x ; y |])
+                     papp env sigma sigT_intro [| a'; pb'; x ; y |])
              end
            else
              begin
@@ -297,11 +297,11 @@ let coerce ?loc env sigma (x : EConstr.constr) (y : EConstr.constr)
                | _, _ ->
                  sigma,
                  Some (fun sigma x ->
-                     let sigma, t1 = papp sigma prod_proj1 [| a; b; x |] in
-                     let sigma, t2 = papp sigma prod_proj2 [| a; b; x |] in
+                     let sigma, t1 = papp env sigma prod_proj1 [| a; b; x |] in
+                     let sigma, t2 = papp env sigma prod_proj2 [| a; b; x |] in
                      let sigma, x = app_opt env sigma c1 t1 in
                      let sigma, y = app_opt env sigma c2 t2 in
-                     papp sigma prod_intro [| a'; b'; x ; y |])
+                     papp env sigma prod_intro [| a'; b'; x ; y |])
              end
          else
          if Ind.CanOrd.equal i i' && Int.equal len (Array.length l') then
@@ -326,7 +326,7 @@ let coerce ?loc env sigma (x : EConstr.constr) (y : EConstr.constr)
       Some (u, p) ->
       let sigma, c = coerce_unify env sigma u y in
       let f sigma x =
-        let sigma, t = papp sigma sig_proj1 [| u; p; x |] in
+        let sigma, t = papp env sigma sig_proj1 [| u; p; x |] in
         app_opt env sigma c t
       in sigma, Some f
     | None ->
@@ -338,7 +338,7 @@ let coerce ?loc env sigma (x : EConstr.constr) (y : EConstr.constr)
              let sigma, cx = app_opt env sigma c x in
              let sigma, evar = make_existential ?loc Anonymous env sigma (mkApp (p, [| cx |]))
              in
-             (papp sigma sig_intro [| u; p; cx; evar |]))
+             (papp env sigma sig_intro [| u; p; cx; evar |]))
       | None ->
         raise NoSubtacCoercion
   in coerce_unify env sigma x y

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -832,7 +832,7 @@ and detype_r d flags avoid env sigma t =
       let id,l =
         try
           let id = match Evd.evar_ident evk sigma with
-          | None -> Termops.evar_suggested_name (Global.env ()) sigma evk
+          | None -> Termops.evar_suggested_name (snd env) sigma evk
           | Some id -> id
           in
           let l = Evd.evar_instance_array bound_to_itself_or_letin (Evd.find sigma evk) cl in

--- a/pretyping/program.ml
+++ b/pretyping/program.ml
@@ -11,10 +11,10 @@
 open CErrors
 open Util
 
-let papp sigma r args =
+let papp env sigma r args =
   let open EConstr in
   let gr = delayed_force r in
-  let evd, hd = Evd.fresh_global (Global.env ()) sigma gr in
+  let evd, hd = Evd.fresh_global env sigma gr in
   sigma, mkApp (hd, args)
 
 let sig_typ   () = Coqlib.lib_ref "core.sig.type"
@@ -37,8 +37,8 @@ let coq_eq_refl     () = Coqlib.lib_ref "core.eq.refl"
 let coq_eq_refl_ref () = Coqlib.lib_ref "core.eq.refl"
 let coq_eq_rect     () = Coqlib.lib_ref "core.eq.rect"
 
-let mk_coq_not sigma x =
-  let sigma, notc = Evd.fresh_global (Global.env ()) sigma Coqlib.(lib_ref "core.not.type") in
+let mk_coq_not env sigma x =
+  let sigma, notc = Evd.fresh_global env sigma Coqlib.(lib_ref "core.not.type") in
   sigma, EConstr.mkApp (notc, [| x |])
 
 let coq_JMeq_ind  () =
@@ -54,8 +54,8 @@ let unsafe_fold_right f = function
     hd :: tl -> List.fold_right f tl hd
   | [] -> invalid_arg "unsafe_fold_right"
 
-let mk_coq_and sigma l =
-  let sigma, and_typ = Evd.fresh_global (Global.env ()) sigma Coqlib.(lib_ref "core.and.type") in
+let mk_coq_and env sigma l =
+  let sigma, and_typ = Evd.fresh_global env sigma Coqlib.(lib_ref "core.and.type") in
   sigma, unsafe_fold_right
       (fun c conj ->
          EConstr.(mkApp (and_typ, [| c ; conj |])))

--- a/pretyping/program.mli
+++ b/pretyping/program.mli
@@ -35,11 +35,11 @@ val coq_eq_rect : unit -> GlobRef.t
 val coq_JMeq_ind : unit -> GlobRef.t
 val coq_JMeq_refl : unit -> GlobRef.t
 
-val mk_coq_and : Evd.evar_map -> constr list -> Evd.evar_map * constr
-val mk_coq_not : Evd.evar_map -> constr -> Evd.evar_map * constr
+val mk_coq_and : Environ.env -> Evd.evar_map -> constr list -> Evd.evar_map * constr
+val mk_coq_not : Environ.env -> Evd.evar_map -> constr -> Evd.evar_map * constr
 
 (** Polymorphic application of delayed references *)
-val papp : evar_map -> (unit -> GlobRef.t) -> constr array -> evar_map * constr
+val papp : Environ.env -> evar_map -> (unit -> GlobRef.t) -> constr array -> evar_map * constr
 
 val get_proofs_transparency : unit -> bool
 val is_program_cases : unit -> bool


### PR DESCRIPTION
A small step towards the removal of dependence on global states. As usual, it's more efficient to do this incrementally otherwise we will never make progress. We explicitly pass around environments where needed. In particular, the tutorial plugin uses a style that is preferred for global constant handling.

Overlays:
- https://github.com/coq-community/paramcoq/pull/91