### PR TITLE
Simplify the internal state of eauto

### DIFF
--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -240,7 +240,7 @@ module SearchProblem = struct
           prev = ps; dblist = s.dblist;
           local_lemmas = s.local_lemmas }
       in
-      List.sort compare (List.map map (assumption_tacs @ intro_tac @ rec_tacs))
+      List.map map (assumption_tacs @ intro_tac) @ (List.sort compare (List.map map rec_tacs))
 
   let pp s = hov 0 (str " depth=" ++ int s.depth ++ spc () ++
                       (Lazy.force s.last_tactic))


### PR DESCRIPTION
This is the backwards compatible prefix of #15390. Since it's a net clean up, it is worthy to be merged as a standalone PR.

- We stop sorting a list that is known to be already sorted.
- We pass a scoped state as a reader rather than inside the full-blown eauto proof state.