### PR TITLE
Forbid non extensible univ decls for Program Definition

### DIFF
--- a/doc/changelog/07-vernac-commands-and-options/15424-progdef-no-udecl.rst
+++ b/doc/changelog/07-vernac-commands-and-options/15424-progdef-no-udecl.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  :ref:`program_definition` in universe monomorphic mode does not accept non-extensible universe declarations
+  (`#15424 <https://github.com/coq/coq/pull/15424>`_,
+  fixes `#15410 <https://github.com/coq/coq/issues/15410>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/addendum/program.rst
+++ b/doc/sphinx/addendum/program.rst
@@ -159,7 +159,7 @@ the value term in Russell and generates proof
 obligations. Once solved using the commands shown below, it binds the
 final Coq term to the name :n:`@ident` in the global environment.
 
-:n:`Program Definition @ident : @type := @term`
+:n:`Program Definition @ident_decl : @type := @term`
 
 Interprets the type :n:`@type`, potentially generating proof
 obligations to be resolved. Once done with them, we have a Coq
@@ -168,6 +168,10 @@ term :n:`@term__0`, checking that the type of :n:`@term__0` is coercible to
 :n:`@type__0`, and registers :n:`@ident` as being of type :n:`@type__0` once the
 set of obligations generated during the interpretation of :n:`@term__0`
 and the aforementioned coercion derivation are solved.
+
+.. exn:: Non extensible universe declaration not supported with monomorphic Program Definition.
+
+   The absence of additional universes or constraints cannot be properly enforced even without Program.
 
 .. seealso:: Sections :ref:`controlling-the-reduction-strategies`, :tacn:`unfold`
 

--- a/test-suite/bugs/bug_15410.v
+++ b/test-suite/bugs/bug_15410.v
@@ -1,0 +1,3 @@
+Require Program.Tactics.
+
+Fail Program Definition foo@{u} : Type@{u} := _.


### PR DESCRIPTION
Fix #15410 (turning assert false into a regular error).

In general non extensible udecls cannot be enforced for monomorphic
definitions, so maybe the error should be regardless of program mode.

TODO also error for program fixpoint and whatever else uses program.
