### PR TITLE
[stdlib] [PeanoNat] Add EvenT and OddT (Even and Odd in Type)

### DIFF
--- a/doc/changelog/10-standard-library/15427-Arith3.rst
+++ b/doc/changelog/10-standard-library/15427-Arith3.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  ``Nat.EvenT`` and ``Nat.OddT`` (almost the same as ``Nat.Even`` and ``Nat.Odd`` but with output in ``Type``.
+  Decidability of parity (with output ``Type``) is provided ``EvenT_OddT_dec`` as well as induction principles ``Nat.EvenT_OddT_rect`` and ``Nat.OddT_EvenT_rect`` (with output ``Type``)
+  (`#15427 <https://github.com/coq/coq/pull/15427>`_,
+  by Olivier Laurent).


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

Versions of `Nat.Even` and `Nat.Odd` with type `Type`.
Decision and induction principles in `Type` are defined: `EvenT_OddT_dec` and `EvenT_OddT_rect`.



<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
