### PR TITLE
Check guardedness of fixpoints also in erasable subterms

### DIFF
--- a/clib/cList.ml
+++ b/clib/cList.ml
@@ -81,6 +81,7 @@ sig
   exception IndexOutOfRange
   val goto : int -> 'a list -> 'a list * 'a list
   val split_when : ('a -> bool) -> 'a list -> 'a list * 'a list
+  val sep_first : 'a list -> 'a * 'a list
   val sep_last : 'a list -> 'a * 'a list
   val drop_last : 'a list -> 'a list
   val last : 'a list -> 'a
@@ -746,6 +747,10 @@ let firstn n l =
     | _ -> failwith "firstn"
   in
   aux [] n l
+
+let sep_first = function
+  | [] -> failwith "sep_first"
+  | hd :: tl -> (hd, tl)
 
 let rec sep_last = function
   | [] -> failwith "sep_last"

--- a/clib/cList.mli
+++ b/clib/cList.mli
@@ -239,6 +239,10 @@ sig
       [l1++(a::l2)=l], [p a=true] and [p b = false] for every element [b] of [l1].
       if there is no such [a], then it returns [(l,[])] instead. *)
 
+  val sep_first : 'a list -> 'a * 'a list
+  (** [sep_first l] returns [(a,l')] such that [l] is [a::l'].
+      It raises [Failure _] if the list is empty. *)
+
   val sep_last : 'a list -> 'a * 'a list
   (** [sep_last l] returns [(a,l')] such that [l] is [l'@[a]].
       It raises [Failure _] if the list is empty. *)

--- a/doc/changelog/01-kernel/15434-master+check-guard-also-erasable-subterms.rst
+++ b/doc/changelog/01-kernel/15434-master+check-guard-also-erasable-subterms.rst
@@ -1,0 +1,14 @@
+- **Changed:**
+  Fixpoints are now expected to be guarded even in subterms erasable
+  by reduction, thus getting rid from an artificial obstacle
+  preventing to lift the assumption of weak normalization of Coq to an
+  assumption of strong normalization; for instance (barring
+  implementation bugs) termination of the type-checking algorithm of
+  Coq is now restored (of course, as usual, up to the assumption of
+  the consistency of set theory and type theory, i.e., equivalently,
+  up to the weak normalization of type theory, a "physical"
+  assumption, which has not been contradicted for decades and which
+  specialists commonly believe to be a truth)
+  (`#15434 <https://github.com/coq/coq/pull/15434>`_, incidentally
+  fixes the complexity issue `#5702
+  <https://github.com/coq/coq/issues/5702>`_, by Hugo Herbelin).

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -1020,7 +1020,7 @@ let check_is_subterm x tree =
 
 (************************************************************************)
 
-exception FixGuardError of env * guard_error
+exception FixGuardError of env * fix_guard_error
 
 let error_illegal_rec_call renv fx (arg_renv,arg) =
   let le_lt_vars =
@@ -1177,7 +1177,7 @@ let check_one_fix renv recpos trees def =
                   let recArg = List.nth stack' decrArg in
                   let arg_sp = stack_element_specif recArg in
                   let illformed () =
-                    error_ill_formed_rec_body renv.env NotEnoughAbstractionInFixBody
+                    error_ill_formed_rec_body renv.env (Type_errors.FixGuardError NotEnoughAbstractionInFixBody)
                       (pi1 recdef) i (push_rec_types recdef renv.env)
                       (judgment_of_fixpoint recdef)
                   in
@@ -1300,7 +1300,7 @@ let inductive_of_mutfix env ((nvect,bodynum),(names,types,bodies as recdef)) =
   let fixenv = push_rec_types recdef env in
   let vdefj = judgment_of_fixpoint recdef in
   let raise_err env i err =
-    error_ill_formed_rec_body env err names i fixenv vdefj in
+    error_ill_formed_rec_body env (Type_errors.FixGuardError err) names i fixenv vdefj in
   (* Check the i-th definition with recarg k *)
   let find_ind i k def =
     (* check fi does not appear in the k+1 first abstractions,
@@ -1355,7 +1355,7 @@ let check_fix env ((nvect,_),(names,_,bodies as recdef) as fix) =
       let renv = make_renv fenv nvect.(i) trees.(i) in
       try check_one_fix renv nvect trees body
       with FixGuardError (fixenv,err) ->
-        error_ill_formed_rec_body fixenv err names i
+        error_ill_formed_rec_body fixenv (Type_errors.FixGuardError err) names i
           (push_rec_types recdef env) (judgment_of_fixpoint recdef)
     done
   else
@@ -1364,7 +1364,7 @@ let check_fix env ((nvect,_),(names,_,bodies as recdef) as fix) =
 (************************************************************************)
 (* Co-fixpoints. *)
 
-exception CoFixGuardError of env * guard_error
+exception CoFixGuardError of env * cofix_guard_error
 
 let anomaly_ill_typed () =
   anomaly ~label:"check_one_cofix" (Pp.str "too many arguments applied to constructor.")
@@ -1475,7 +1475,7 @@ let check_cofix env (_bodynum,(names,types,bodies as recdef)) =
       let fixenv = push_rec_types recdef env in
       try check_one_cofix fixenv nbfix bodies.(i) types.(i)
       with CoFixGuardError (errenv,err) ->
-        error_ill_formed_rec_body errenv err names i
+        error_ill_formed_rec_body errenv (Type_errors.CoFixGuardError err) names i
           fixenv (judgment_of_fixpoint recdef)
     done
   else

--- a/kernel/inductive.mli
+++ b/kernel/inductive.mli
@@ -158,11 +158,12 @@ exception SingletonInductiveBecomesProp of Id.t
 (** {6 Debug} *)
 
 type size = Large | Strict
+type internal_subterm_source = IotaTerm | LamTerm
 type subterm_spec =
-    Subterm of (int list * size * wf_paths)
+    Subterm of (internal_subterm_source Int.Map.t * size * wf_paths)
   | Dead_code
   | Not_subterm
-  | Internally_bound_subterm of int list
+  | Internally_bound_subterm of internal_subterm_source Int.Map.t
 type guard_env =
   { env     : env;
     (** dB of last fixpoint *)

--- a/kernel/inductive.mli
+++ b/kernel/inductive.mli
@@ -159,9 +159,10 @@ exception SingletonInductiveBecomesProp of Id.t
 
 type size = Large | Strict
 type subterm_spec =
-    Subterm of (size * wf_paths)
+    Subterm of (int list * size * wf_paths)
   | Dead_code
   | Not_subterm
+  | Internally_bound_subterm of int list
 type guard_env =
   { env     : env;
     (** dB of last fixpoint *)

--- a/kernel/inductive.mli
+++ b/kernel/inductive.mli
@@ -155,25 +155,4 @@ val check_cofix : env -> cofixpoint -> unit
 
 exception SingletonInductiveBecomesProp of Id.t
 
-(** {6 Debug} *)
-
-type size = Large | Strict
-type internal_subterm_source = IotaTerm | LamTerm
-type subterm_spec =
-    Subterm of (internal_subterm_source Int.Map.t * size * wf_paths)
-  | Dead_code
-  | Not_subterm
-  | Internally_bound_subterm of internal_subterm_source Int.Map.t
-type guard_env =
-  { env     : env;
-    (** dB of last fixpoint *)
-    rel_min : int;
-    (** dB of variables denoting subterms *)
-    genv    : subterm_spec Lazy.t list;
-  }
-
-type stack_element = |SClosure of guard_env*constr |SArg of subterm_spec Lazy.t
-
-val subterm_specif : guard_env -> stack_element list -> constr -> subterm_spec
-
 val abstract_mind_lc : int -> int -> MutInd.t -> (rel_context * constr) array -> constr array

--- a/kernel/type_errors.mli
+++ b/kernel/type_errors.mli
@@ -17,13 +17,16 @@ open Univ
 
 (*i Rem: NotEnoughAbstractionInFixBody should only occur with "/i" Fix
     notation i*)
-type 'constr pguard_error =
-  (** Fixpoints *)
+type 'constr pfix_guard_error =
+  (* Fixpoints *)
   | NotEnoughAbstractionInFixBody
   | RecursionNotOnInductiveType of 'constr
   | RecursionOnIllegalTerm of int * (env * 'constr) * (int list * int list) Lazy.t
   | NotEnoughArgumentsForFixCall of int
-  (** CoFixpoints *)
+  | FixpointOnIrrelevantInductive
+
+type 'constr pcofix_guard_error =
+  (* CoFixpoints *)
   | CodomainNotInductiveType of 'constr
   | NestedRecursiveOccurrences
   | UnguardedRecursiveCall of 'constr
@@ -35,8 +38,13 @@ type 'constr pguard_error =
   | RecCallInCasePred of 'constr
   | NotGuardedForm of 'constr
   | ReturnPredicateNotCoInductive of 'constr
-  | FixpointOnIrrelevantInductive
 
+type 'constr pguard_error =
+  | FixGuardError of 'constr pfix_guard_error
+  | CoFixGuardError of 'constr pcofix_guard_error
+
+type fix_guard_error = constr pfix_guard_error
+type cofix_guard_error = constr pcofix_guard_error
 type guard_error = constr pguard_error
 
 type arity_error =

--- a/test-suite/bugs/bug_14057.v
+++ b/test-suite/bugs/bug_14057.v
@@ -3,7 +3,7 @@ Module Mono.
     Fixpoint F (n : nat) (A : Type) {struct n} : nat
     with G (n : nat) (A:Type@{_})  {struct n} : nat.
     Proof.
-      1: pose (G n A).
+      1: pose (match n with S n => G n A | 0 => 0 end).
       all: exact 0.
     Defined.
   End Transparent.
@@ -12,7 +12,7 @@ Module Mono.
     Fixpoint F (n : nat) (A : Type) {struct n} : nat
     with G (n : nat) (A:Type@{_})  {struct n} : nat.
     Proof.
-      1: pose (G n A).
+      1: pose (match n with S n => G n A | 0 => 0 end).
       all: exact 0.
     Qed.
   End Opaque.
@@ -24,7 +24,7 @@ Module Poly.
     Fixpoint F (n : nat) (A : Type) {struct n} : nat
     with G (n : nat) (A:Type@{_})  {struct n} : nat.
     Proof.
-      1: pose (G n A).
+      1: pose (match n with S n => G n A | 0 => 0 end).
       all: exact 0.
     Defined.
     Check F@{_}. Check G@{_}.
@@ -34,7 +34,7 @@ Module Poly.
     Fixpoint F (n : nat) (A : Type) {struct n} : nat
     with G (n : nat) (A:Type@{_})  {struct n} : nat.
     Proof.
-      1: pose (G n A).
+      1: pose (match n with S n => G n A | 0 => 0 end).
       all: exact 0.
     Qed.
     Check F@{_}. Check G@{_}.

--- a/test-suite/bugs/bug_7061.v
+++ b/test-suite/bugs/bug_7061.v
@@ -1,0 +1,25 @@
+(* A few examples of non strongly normalizing fixpoints *)
+
+Fail Fixpoint beta_erase (v:bool) := (fun x y => x) 0 (beta_erase v).
+
+Fail Fixpoint zeta_erase (v:bool) := let _ := zeta_erase v in 0.
+
+Fail Fixpoint iota_case_erase (v:bool) :=
+  match true with
+  | true => 0
+  | false => iota_case_erase v
+  end.
+
+Fail Fixpoint iota_fix_erase (v:bool) :=
+  let g1 := fix g1 (x : nat) := x
+            with g2 (x : nat) := iota_fix_erase v
+            for g1
+  in
+  g1 0.
+
+Fail Fixpoint f (x : bool) :=
+  let y := f x in
+  match true with
+  | true => true
+  | false => y
+  end.

--- a/test-suite/bugs/bug_9598.v
+++ b/test-suite/bugs/bug_9598.v
@@ -1,24 +1,24 @@
 Module case.
 
-  Inductive pair := K (n1 : nat) (n2 : nat).
-  Definition fst (p : pair) : nat := match p with K n _ => n end.
+  Inductive pair := K (n1 : nat) (n2 : nat -> nat).
+  Definition snd (p : pair) : nat -> nat := match p with K _ f => f end.
 
   Definition alias_K a b := K a b.
 
-  Fixpoint rec (x : nat) : nat := fst (K 0 (rec x)).
-  Fixpoint rec_ko (x : nat) : nat := fst (alias_K 0 (rec_ko x)).
+  Fixpoint rec (x : nat) : nat := match x with 0 => 0 | S x => snd (K 0 rec) x end.
+  Fixpoint rec_ko (x : nat) : nat := match x with 0 => 0 | S x => snd (alias_K 0 rec_ko) x end.
 
 End case.
 
 Module fixpoint.
 
-  Inductive pair := K (n1 : nat) (n2 : nat).
-  Fixpoint fst (p : pair) : nat := match p with K n _ => n end.
+  Inductive pair := K (n1 : nat) (n2 : nat -> nat).
+  Definition snd (p : pair) : nat -> nat := match p with K _ f => f end.
 
   Definition alias_K a b := K a b.
 
-  Fixpoint rec (x : nat) : nat := fst (K 0 (rec x)).
-  Fixpoint rec_ko (x : nat) : nat := fst (alias_K 0 (rec_ko x)).
+  Fixpoint rec (x : nat) : nat := match x with 0 => 0 | S x => snd (K 0 rec) x end.
+  Fixpoint rec_ko (x : nat) : nat := match x with 0 => 0 | S x => snd (alias_K 0 rec_ko) x end.
 
 End fixpoint.
 
@@ -26,11 +26,11 @@ Module primproj.
 
   Set Primitive Projections.
 
-  Inductive pair := K { fst : nat; snd : nat }.
+  Inductive pair := K { fst : nat; snd : nat -> nat }.
 
   Definition alias_K a b := K a b.
 
-  Fixpoint rec (x : nat) : nat := fst (K 0 (rec x)).
-  Fixpoint rec_ko (x : nat) : nat := fst (alias_K 0 (rec_ko x)).
+  Fixpoint rec (x : nat) : nat := match x with 0 => 0 | S x => snd (K 0 rec) x end.
+  Fixpoint rec_ko (x : nat) : nat := match x with 0 => 0 | S x => snd (alias_K 0 rec_ko) x end.
 
 End primproj.

--- a/test-suite/complexity/bug_5702_guard.v
+++ b/test-suite/complexity/bug_5702_guard.v
@@ -1,0 +1,17 @@
+(* Examples of strong guard condition failures not requiring backtracking *)
+(* Expected time < 1.00s *)
+
+Fixpoint f (n : nat) {struct n} : nat.
+Proof.
+  do 21 (refine (id _)).
+  exact (f n).
+Timeout 5 Time Fail Defined. (* Slow. *)
+Abort.
+
+Fixpoint f (n m : nat) : nat.
+Proof.
+  do 20 (refine (id _)).
+  destruct m.
+  - exact O.
+  - exact (f n m).
+Timeout 5 Time Defined. (* Slow. *)

--- a/test-suite/success/FixStronglyWf.v
+++ b/test-suite/success/FixStronglyWf.v
@@ -89,3 +89,8 @@ Fail Fixpoint foo n :=
        | S n => aux n
        end) (S n)
   end.
+
+(* Loop in inert erasable subterm *)
+
+Fail Fixpoint g (n:nat) : Prop :=
+  (fun x : g n -> True => True) (fun y : g n => I).

--- a/test-suite/success/FixStronglyWf.v
+++ b/test-suite/success/FixStronglyWf.v
@@ -1,0 +1,91 @@
+(* Examples of fixpoints with loops in erasable subterms *)
+
+(* Loop in erasable local definition *)
+Fail Fixpoint foo (n : nat) :=
+  let g := foo n in
+  0.
+
+(* Loop in erasable branch *)
+Fail Fixpoint foo (n : nat) :=
+  match 0 with
+  | 0 => 0
+  | S x => foo n
+  end.
+
+(* Loop in inert type *)
+Fail Fixpoint foo (n : nat) :=
+  forall x : foo n, True.
+
+(* Loop in erasable (and inert) types *)
+
+Fail Fixpoint foo (n : nat) :=
+  let _ := fun x : foo n => 0 in True.
+
+Fail Fixpoint foo (n : nat) :=
+  (fun _ : foo n = foo n => True) eq_refl.
+
+Fail Fixpoint foo (n : nat) :=
+  0 : id (fun _ => nat) (foo n).
+
+(* Competition between an internally bound recursive argument and an
+   invalid argument; also checks that it does not depend on order *)
+
+Fail Fixpoint foo p (n : nat) :=
+  match n with
+  | 0 => 0
+  | S x =>
+    foo p (id (fun y =>
+      match p with
+      | true => y
+      | false => n
+      end) x)
+  end.
+
+Fail Fixpoint foo p (n : nat) :=
+  match n with
+  | 0 => 0
+  | S x =>
+    foo p (id (fun y =>
+      match p with
+      | true => n
+      | false => y
+      end) x)
+  end.
+
+(* These one are presumably inoffensive but we continue to reject them *)
+
+Fail Fixpoint foo1 (n : nat) :=
+  forall x : foo1 = foo1, True.
+
+Fail Fixpoint foo2 (n : nat) :=
+  eq foo2 foo2.
+
+(* Should we allow the following? This is practically uninteresting but a priori ok *)
+
+Fail Fixpoint foo (n : nat) :=
+  forall n, forall x : foo n = foo n, True.
+
+Fail Fixpoint foo (n : nat) :=
+  forall n, eq (foo n) (foo n).
+
+(* Loop after one step of reduction *)
+
+Fail Fixpoint foo (n : nat) :=
+  (fun f p => (fun _ => True) (foo p)) n.
+
+Fail Fixpoint foo (n : nat) :=
+  (if true then fun p => if true then True else foo n
+   else fun p => True) n.
+
+(* Loop in dead branch *)
+
+Fail Fixpoint foo n :=
+  match n with
+  | 0 => 0
+  | S n =>
+      (fix aux n :=
+       match n with
+       | 0 => foo n
+       | S n => aux n
+       end) (S n)
+  end.

--- a/test-suite/success/Fixpoint.v
+++ b/test-suite/success/Fixpoint.v
@@ -224,3 +224,185 @@ Fixpoint f n :=
   end.
 
 End CofixRedexPrimProj.
+
+Module ArgumentsAcrossMatch.
+
+(* large subterm passed across match *)
+Fail Fixpoint f n p {struct n} :=
+  match n with
+  | 0 => fun _ => 0
+  | S q => fun r => f q (f r 0)
+  end n.
+
+(* strict subterm passed across match *)
+Fixpoint f n p {struct n} :=
+  match n with
+  | 0 => 0
+  | S q =>
+     match q with
+     | 0 => fun _ => 0
+     | S q' => fun r => f q (f r 0)
+     end q
+  end.
+
+End ArgumentsAcrossMatch.
+
+Module LetToExpand.
+
+Fixpoint h n :=
+  let f n := (fun x : h n -> True => True) (fun y : h n => I) in
+  match n with
+  | 0 => True
+  | S n => f n
+  end.
+
+End LetToExpand.
+
+Module RecursiveCallInsideCoFix.
+
+CoInductive I := { field : I }.
+
+Fail Fixpoint f (n:nat) :=
+  (cofix g n := {| field := f n |}) 0.
+
+End RecursiveCallInsideCoFix.
+
+Module NestedRedexes.
+
+Fixpoint f n :=
+  match n with
+  | 0 => 0
+  | S n => id (fun x => id (fun _ => id (f x)) 0) n
+  end.
+
+End NestedRedexes.
+
+Module NestedRedexesWithCofix.
+
+CoInductive I := { field : nat -> nat }.
+
+Fail Fixpoint f n :=
+  ((cofix g h := {| field := h |}) f).(field) n.
+
+Fixpoint f n :=
+  match n with
+  | 0 => 0
+  | S p => ((cofix g h := {| field := h |}) f).(field) p
+  end.
+
+End NestedRedexesWithCofix.
+
+Module NestedApplicationsWithVariables.
+
+Section S.
+Variable h : (nat -> nat) -> nat.
+Fixpoint f n :=
+  match n with
+  | 0 => 0
+  | S p => (fun _ => 0) (h f)
+  end.
+End S.
+
+End NestedApplicationsWithVariables.
+
+Module NestedApplicationsWithParameters.
+
+Parameter h : (nat -> nat) -> nat.
+Fixpoint f n :=
+  match n with
+  | 0 => 0
+  | S p => (fun _ => 0) (h f)
+  end.
+
+End NestedApplicationsWithParameters.
+
+Module NestedApplicationsWithLocalVariables.
+
+Fixpoint f (h:(nat->nat)->nat) n :=
+  match n with
+  | 0 => 0
+  | S p => (fun _ => 0) (h (f h))
+  end.
+
+End NestedApplicationsWithLocalVariables.
+
+Module NestedApplicationsWithProjections.
+
+Set Primitive Projections.
+Record R := { field : (nat -> nat) -> nat }.
+
+Fixpoint f x n :=
+  match n with
+  | 0 => 0
+  | S p => (fun _ => 0) (x.(field) (f x))
+  end.
+
+End NestedApplicationsWithProjections.
+
+Module NestedRedexesWithFix.
+
+Fixpoint f n :=
+  match n with
+  | 0 => 0
+  | S p => (fun _ => 0) ((fix h k (q:nat) {struct q} := k) f)
+  end.
+
+(* inner fix fully applied with a match subterm *)
+Fixpoint f' n :=
+  match n with
+  | 0 => 0
+  | S p => (fun _ => 0) ((fix h k (q:nat) {struct q} := k) f' p)
+  end.
+
+(* inner fix fully applied with an arbitrary term *)
+Fixpoint f'' o n :=
+  match n with
+  | 0 => 0
+  | S p => (fun _ => 0) ((fix h k (q:nat) {struct q} := k o) f'' o)
+  end.
+
+End NestedRedexesWithFix.
+
+Module NestedRedexesWithMatch.
+
+Fixpoint f o n :=
+  match n with
+  | 0 => 0
+  | S p => (fun _ => 0) (match o with tt => f o end)
+  end.
+
+Fixpoint f' o n :=
+  match n with
+  | 0 => 0
+  | S p => (fun _ => 0) ((match o with tt => fun x => x o end) f')
+  end.
+
+End NestedRedexesWithMatch.
+
+Module ErasableInertSubterm.
+
+Fixpoint P (n:nat) :=
+  (fun _ => True) (forall a : (forall p, P p), True).
+
+End ErasableInertSubterm.
+
+Module WithLetInLift.
+
+Fixpoint f (n : nat) : nat :=
+  match n with
+  | 0 => 0
+  | S n => (let x := 0 in fun n => f n) n
+  end.
+
+End WithLetInLift.
+
+Module WithLateCaseReduction.
+
+Definition B := true.
+Fixpoint f (n : nat) :=
+  match n with
+  | 0 => 0
+  | S n => (if B as b return if b then nat -> nat else unit then fun n => f n else tt) n
+  end.
+
+End WithLateCaseReduction.


### PR DESCRIPTION
**Kind:** Enhancement

Includes #15451 and #15453.

We do that by splitting guard errors into two categories:
- fatal recursive calls to non guarded arguments
- recursive calls on descendants of variables bound in subterms of a redex and thus liable to be instantiated by reduction of the redex + not applied enough recursive calls which also may become enough applied after reduction.

We also maintain a stack of redexes so that when a variable is bound in the subterm of a redex, we directly know which redex needs to be reduced to trigger the instantiation of the variable.

In situations of the form `C(if c then x else y)` where `x` is a recursion variable, `y` needs the unfolding of a redex `C[]`, we use a rich notion of subterm which remembers both that we need to reduce the redex to check a possible recursive call on `y`, but that we need to check that we don't also make a recursive call on x even w/o reducing the redex. So, the union of specifications of subterms of a `match`/`if` is now a set.

We are also more tolerant in subterms with recursive calls on internal uninstantiatable variables and on not applied enough recursive calls which cannot be applied more (e.g.  `Fixpoint foo (n : nat) := forall x : foo = foo, True`).

For the beta and zeta-redex cases, we choose to check the argument for possibly fatal non guarded calls and reduce anyway. Another strategy could have been to reduce only when a subterm of the redex needs a reduction (but the stack call is then a bit complicated to manage).

Fixes #6487
Fixes #7061
Incidentally also fixes #5702 (reporting about a non-guarded fixpoint is exponential in the number of unfoldable constants encapsulating the illegal recursive call).

See examples in file `test-suite/success/FixStronglyWf.v`.

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
