### PR TITLE
[stdlib] Make Program.Basics.arrow and Program.Basics.flip universe polymorphic

### DIFF
--- a/dev/ci/user-overlays/15440-olaure01-arrow.sh
+++ b/dev/ci/user-overlays/15440-olaure01-arrow.sh
@@ -1,0 +1,1 @@
+overlay coq_dpdgraph https://github.com/olaure01/coq-dpdgraph arrow 15440

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -485,8 +485,8 @@ module PropGlobal = struct
     let morphisms = ["Coq"; "Classes"; "Morphisms"]
     let relation = ["Coq"; "Relations";"Relation_Definitions"], "relation"
     let app_poly = app_poly_nocheck
-    let arrow = find_global ["Coq"; "Program"; "Basics"] "arrow"
-    let coq_inverse = find_global ["Coq"; "Program"; "Basics"] "flip"
+    let arrow = find_global ["Coq"; "Init"; "Datatypes"] "arrow"
+    let coq_inverse = find_global ["Coq"; "Init"; "Datatypes"] "flip"
   end
 
   module G = GlobalBindings(Consts)
@@ -506,8 +506,8 @@ module TypeGlobal = struct
       let morphisms = ["Coq"; "Classes"; "CMorphisms"]
       let relation = relation_classes, "crelation"
       let app_poly = app_poly_check
-      let arrow = find_global ["Coq"; "Classes"; "CRelationClasses"] "arrow"
-      let coq_inverse = find_global ["Coq"; "Classes"; "CRelationClasses"] "flip"
+      let arrow = find_global ["Coq"; "Init"; "Datatypes"] "arrow"
+      let coq_inverse = find_global ["Coq"; "Init"; "Datatypes"] "flip"
     end
 
   module G = GlobalBindings(Consts)

--- a/test-suite/bugs/bug_14725.v
+++ b/test-suite/bugs/bug_14725.v
@@ -5,7 +5,7 @@ Axiom Teq : relation T.
 #[local] Declare Instance Teq_Equivalence : Equivalence Teq.
 
 Axiom P : T -> Prop.
-Axiom P_Proper : Proper (Teq ==> Basics.flip Basics.impl) P.
+Axiom P_Proper : Proper (Teq ==> flip Basics.impl) P.
 
 (** This is a manually crafted hint which is essentially declaring P_Proper as
     a typeclass instance, except that it builds a proof term that captures the
@@ -13,7 +13,7 @@ Axiom P_Proper : Proper (Teq ==> Basics.flip Basics.impl) P.
     escape, the call to rewrite below would fail with a type error. *)
 Ltac manual_P_proper :=
 match goal with
-| [ H : apply_subrelation |- Proper (Teq ==> Basics.flip Basics.impl) P ] =>
+| [ H : apply_subrelation |- Proper (Teq ==> flip Basics.impl) P ] =>
   case H; apply P_Proper
 end.
 

--- a/test-suite/bugs/bug_3513.v
+++ b/test-suite/bugs/bug_3513.v
@@ -67,7 +67,7 @@ Goal forall (T : Type) (O0 : T -> OPred) (O1 : T -> PointedOPred)
          catOP_entails_m_Proper a a' H b b' H') in
     pose P;
     refine (P _ _)
-  end; unfold Basics.flip.
+  end; unfold flip.
   Focus 2.
   (* As in 8.5, allow a shelved subgoal to remain *)
   apply reflexivity.

--- a/test-suite/bugs/bug_4754.v
+++ b/test-suite/bugs/bug_4754.v
@@ -14,14 +14,14 @@ Existing Instance eq_Reflexive.
 
 Global Instance foo (A := nat)
   : Proper ((pointwise_relation _ eq)
-              ==> eq ==> forall_relation (fun _ => Basics.flip Basics.impl))
+              ==> eq ==> forall_relation (fun _ => flip Basics.impl))
            (@option_rect A (fun _ => Prop)) | 0.
 exact admit.
 Qed.
 
 Global Instance bar (A := nat)
   : Proper ((pointwise_relation _ eq)
-              ==> eq ==> eq ==> Basics.flip Basics.impl)
+              ==> eq ==> eq ==> flip Basics.impl)
            (@option_rect A (fun _ => Prop)) | 0.
 exact admit.
 Qed.

--- a/test-suite/success/rewrite_closed.v
+++ b/test-suite/success/rewrite_closed.v
@@ -8,7 +8,7 @@ forall [T : Type] (P : Type), (forall t : T, P) -> forall l : lattice_for T, P.
 
 #[local]
 Declare Instance lattice_for_rect_Proper_85 : forall {A},
-  Proper (forall_relation (fun _ => eq) ==> eq ==> Basics.flip Basics.impl)
+  Proper (forall_relation (fun _ => eq) ==> eq ==> flip Basics.impl)
            (@lattice_for_rect A Prop) | 3.
 
 Axiom lattice_rewrite :

--- a/theories/Classes/CMorphisms.v
+++ b/theories/Classes/CMorphisms.v
@@ -583,9 +583,9 @@ End Normalize.
 
 Lemma flip_arrow `(NA : Normalizes A R (flip R'''), NB : Normalizes B R' (flip R'')) :
   Normalizes (A -> B) (R ==> R') (flip (R''' ==> R'')%signatureT).
-Proof. 
+Proof.
   unfold Normalizes in *. intros.
-  rewrite NA, NB. firstorder. 
+  rewrite NA, NB. firstorder.
 Qed.
 
 Ltac normalizes :=

--- a/theories/Classes/CRelationClasses.v
+++ b/theories/Classes/CRelationClasses.v
@@ -31,8 +31,6 @@ Definition arrow (A B : Type) := A -> B.
 
 Definition flip {A B C : Type} (f : A -> B -> C) := fun x y => f y x.
 
-Definition iffT (A B : Type) := ((A -> B) * (B -> A))%type.
-
 (** We allow to unfold the [crelation] definition while doing morphism search. *)
 
 Section Defs.
@@ -48,7 +46,7 @@ Section Defs.
 
   (** Opaque for proof-search. *)
   Typeclasses Opaque complement iffT.
-  
+
   (** These are convertible. *)
   Lemma complement_inverse R : complement (flip R) = flip (complement R).
   Proof. reflexivity. Qed.
@@ -58,15 +56,15 @@ Section Defs.
 
   Class Symmetric (R : crelation A) :=
     symmetry : forall {x y}, R x y -> R y x.
-  
+
   Class Asymmetric (R : crelation A) :=
     asymmetry : forall {x y}, R x y -> (complement R y x : Type).
-  
+
   Class Transitive (R : crelation A) :=
     transitivity : forall {x y z}, R x y -> R y z -> R x z.
 
   (** Various combinations of reflexivity, symmetry and transitivity. *)
-  
+
   (** A [PreOrder] is both Reflexive and Transitive. *)
 
   Class PreOrder (R : crelation A)  := {
@@ -88,7 +86,7 @@ Section Defs.
   Proof. firstorder. Qed.
 
   (** A partial equivalence crelation is Symmetric and Transitive. *)
-  
+
   Class PER (R : crelation A)  := {
     PER_Symmetric : Symmetric R | 3 ;
     PER_Transitive : Transitive R | 3 }.
@@ -118,26 +116,26 @@ Section Defs.
 
   Class subrelation (R R' : crelation A) :=
     is_subrelation : forall {x y}, R x y -> R' x y.
-  
+
   (** Any symmetric crelation is equal to its inverse. *)
-  
+
   Lemma subrelation_symmetric R `(Symmetric R) : subrelation (flip R) R.
   Proof. hnf. intros x y H'. red in H'. apply symmetry. assumption. Qed.
 
   Section flip.
-  
+
     Lemma flip_Reflexive `{Reflexive R} : Reflexive (flip R).
     Proof. tauto. Qed.
-    
+
     Program Definition flip_Irreflexive `(Irreflexive R) : Irreflexive (flip R) :=
       irreflexivity (R:=R).
-    
+
     Program Definition flip_Symmetric `(Symmetric R) : Symmetric (flip R) :=
       fun x y H => symmetry (R:=R) H.
-    
+
     Program Definition flip_Asymmetric `(Asymmetric R) : Asymmetric (flip R) :=
       fun x y H H' => asymmetry (R:=R) H H'.
-    
+
     Program Definition flip_Transitive `(Transitive R) : Transitive (flip R) :=
       fun x y z H H' => transitivity (R:=R) H' H.
 
@@ -184,7 +182,7 @@ Section Defs.
 
   (** Any [Equivalence] declared in the context is automatically considered
    a rewrite crelation. *)
-    
+
   Global Instance equivalence_rewrite_crelation `(Equivalence eqA) : RewriteRelation eqA.
   Defined.
 
@@ -193,14 +191,14 @@ Section Defs.
     Global Instance eq_Reflexive : Reflexive (@eq A) := @eq_refl A.
     Global Instance eq_Symmetric : Symmetric (@eq A) := @eq_sym A.
     Global Instance eq_Transitive : Transitive (@eq A) := @eq_trans A.
-    
+
     (** Leibinz equality [eq] is an equivalence crelation.
         The instance has low priority as it is always applicable
         if only the type is constrained. *)
-    
+
     Global Program Instance eq_equivalence : Equivalence (@eq A) | 10.
   End Leibniz.
-  
+
 End Defs.
 
 (** Default rewrite crelations handled by [setoid_rewrite]. *)
@@ -344,7 +342,7 @@ Section Binary.
 
   Definition relation_disjunction (R : crelation A) (R' : crelation A) : crelation A :=
     fun x y => sum (R x y) (R' x y).
-  
+
   (** Relation equivalence is an equivalence, and subrelation defines a partial order. *)
 
   Global Instance relation_equivalence_equivalence :
@@ -355,7 +353,7 @@ Section Binary.
     - firstorder.
     - intros x y z X X0 x0 y0. specialize (X x0 y0). specialize (X0 x0 y0). firstorder.
   Qed.
-    
+
   Global Instance relation_implication_preorder : PreOrder (@subrelation A).
   Proof. firstorder. Qed.
 
@@ -366,7 +364,7 @@ Section Binary.
 
   Class PartialOrder eqA `{equ : Equivalence A eqA} R `{preo : PreOrder A R} :=
     partial_order_equivalence : relation_equivalence eqA (relation_conjunction R (flip R)).
-  
+
   (** The equivalence proof is sufficient for proving that [R] must be a
    morphism for equivalence (see Morphisms).  It is also sufficient to
    show that [R] is antisymmetric w.r.t. [eqA] *)
@@ -398,3 +396,6 @@ Hint Extern 3 (PartialOrder (flip _)) => class_apply PartialOrder_inverse : type
 (* Qed. *)
 
 Global Typeclasses Opaque relation_equivalence.
+
+#[deprecated(since="8.16",note="Use Init.Datatypes.iffT instead.")]
+Notation iffT := iffT.

--- a/theories/Classes/CRelationClasses.v
+++ b/theories/Classes/CRelationClasses.v
@@ -27,10 +27,6 @@ Set Universe Polymorphism.
 
 Definition crelation (A : Type) := A -> A -> Type.
 
-Definition arrow (A B : Type) := A -> B.
-
-Definition flip {A B C : Type} (f : A -> B -> C) := fun x y => f y x.
-
 (** We allow to unfold the [crelation] definition while doing morphism search. *)
 
 Section Defs.
@@ -397,5 +393,9 @@ Hint Extern 3 (PartialOrder (flip _)) => class_apply PartialOrder_inverse : type
 
 Global Typeclasses Opaque relation_equivalence.
 
+#[deprecated(since="8.16",note="Use Init.Datatypes.arrow instead.")]
+Notation arrow := arrow.
+#[deprecated(since="8.16",note="Use Init.Datatypes.flip instead.")]
+Notation flip := flip.
 #[deprecated(since="8.16",note="Use Init.Datatypes.iffT instead.")]
 Notation iffT := iffT.

--- a/theories/Classes/Morphisms.v
+++ b/theories/Classes/Morphisms.v
@@ -76,7 +76,7 @@ Section Proper.
   (** Respectful morphisms. *)
   
   (** The fully dependent version, not used yet. *)
-  
+
   Definition respectful_hetero
   (A B : Type)
   (C : A -> Type) (D : B -> Type)
@@ -86,7 +86,7 @@ Section Proper.
     fun f g => forall x y, R x y -> R' x y (f x) (g y).
 
   (** The non-dependent version is an instance where we forget dependencies. *)
-  
+
   Definition respectful (R : relation A) (R' : relation B) : relation (A -> B) :=
     Eval compute in @respectful_hetero A A (fun _ => B) (fun _ => B) R (fun _ _ => R').
 
@@ -229,11 +229,11 @@ Section Relations.
   Context {A B : U} (P : A -> U).
 
   (** [forall_def] reifies the dependent product as a definition. *)
-  
+
   Definition forall_def : Type := forall x : A, P x.
-  
+
   (** Dependent pointwise lifting of a relation on the range. *)
-  
+
   Definition forall_relation 
              (sig : forall a, relation (P a)) : relation (forall x, P x) :=
     fun f g => forall a, sig a (f a) (g a).
@@ -241,28 +241,28 @@ Section Relations.
   Lemma pointwise_pointwise (R : relation B) :
     relation_equivalence (pointwise_relation A R) (@eq A ==> R).
   Proof. intros. split; reduce; subst; firstorder. Qed.
-  
+
   (** Subrelations induce a morphism on the identity. *)
-  
+
   Global Instance subrelation_id_proper `(subrelation A RA RA') : Proper (RA ==> RA') id.
   Proof. firstorder. Qed.
 
   (** The subrelation property goes through products as usual. *)
-  
+
   Lemma subrelation_respectful `(subl : subrelation A RA' RA, subr : subrelation B RB RB') :
     subrelation (RA ==> RB) (RA' ==> RB').
   Proof. unfold subrelation in *; firstorder. Qed.
 
   (** And of course it is reflexive. *)
-  
+
   Lemma subrelation_refl R : @subrelation A R R.
   Proof. unfold subrelation; firstorder. Qed.
 
   (** [Proper] is itself a covariant morphism for [subrelation].
    We use an unconvertible premise to avoid looping.
    *)
-  
-  Lemma subrelation_proper `(mor : Proper A R' m) 
+
+  Lemma subrelation_proper `(mor : Proper A R' m)
         `(unc : Unconvertible (relation A) R R')
         `(sub : subrelation A R' R) : Proper R m.
   Proof.
@@ -276,7 +276,7 @@ Section Relations.
   Global Instance pointwise_subrelation `(sub : subrelation B R R') :
     subrelation (pointwise_relation A R) (pointwise_relation A R') | 4.
   Proof. intros x y H a. unfold pointwise_relation in *. apply sub. apply H. Qed.
-  
+
   (** For dependent function types. *)
   Lemma forall_subrelation (R S : forall x : A, relation (P x)) :
     (forall a, subrelation (R a) (S a)) -> subrelation (forall_relation R) (forall_relation S).
@@ -286,7 +286,7 @@ End Relations.
 Global Typeclasses Opaque respectful pointwise_relation forall_relation.
 Arguments forall_relation {A P}%type sig%signature _ _.
 Arguments pointwise_relation A%type {B}%type R%signature _ _.
-  
+
 #[global]
 Hint Unfold Reflexive : core.
 #[global]
@@ -336,7 +336,7 @@ Section GenericInstances.
 
   (** We can build a PER on the Coq function space if we have PERs on the domain and
    codomain. *)
-  
+
   Program Instance respectful_per `(PER A R, PER B R') : PER (R ==> R').
 
   Next Obligation.
@@ -348,11 +348,11 @@ Section GenericInstances.
   Qed.
 
   (** The complement of a relation conserves its proper elements. *)
-  
+
   Program Definition complement_proper
           `(mR : Proper (A -> A -> Prop) (RA ==> RA ==> iff) R) :
     Proper (RA ==> RA ==> iff) (complement R) := _.
-  
+
   Next Obligation.
   Proof.
     intros RA R mR x y H x0 y0 H0.
@@ -366,7 +366,7 @@ Section GenericInstances.
   Program Definition flip_proper
           `(mor : Proper (A -> B -> C) (RA ==> RB ==> RC) f) :
     Proper (RB ==> RA ==> RC) (flip f) := _.
-  
+
   Next Obligation.
   Proof.
     intros RA RB RC f mor x y H x0 y0 H0; apply mor ; auto.
@@ -375,11 +375,11 @@ Section GenericInstances.
 
   (** Every Transitive relation gives rise to a binary morphism on [impl],
    contravariant in the first argument, covariant in the second. *)
-  
+
   Global Program 
   Instance trans_contra_co_morphism
     `(Transitive A R) : Proper (R --> R ++> impl) R.
-  
+
   Next Obligation.
   Proof with auto.
     intros R H x y H0 x0 y0 H1 H2.
@@ -484,7 +484,7 @@ Section GenericInstances.
   Proof. simpl_relation. Qed.
 
   (** [respectful] is a morphism for relation equivalence. *)
-  
+
   Global Instance respectful_morphism :
     Proper (relation_equivalence ++> relation_equivalence ++> relation_equivalence) 
            (@respectful A B).
@@ -492,12 +492,10 @@ Section GenericInstances.
     intros x y H x0 y0 H0 x1 x2.
     unfold respectful, relation_equivalence, predicate_equivalence in * ; simpl in *.
     split ; intros H1 x3 y1 H2.
-    
     - rewrite <- H0.
       apply H1.
       rewrite H.
       assumption.
-
     - rewrite H0.
       apply H1.
       rewrite <- H.
@@ -509,7 +507,7 @@ Section GenericInstances.
   Lemma Reflexive_partial_app_morphism `(Proper (A -> B) (R ==> R') m, ProperProxy A R x) :
     Proper R' (m x).
   Proof. simpl_relation. Qed.
-  
+
   Lemma flip_respectful (R : relation A) (R' : relation B) :
     relation_equivalence (flip (R ==> R')) (flip R ==> flip R').
   Proof.
@@ -518,25 +516,25 @@ Section GenericInstances.
     split ; intros ; intuition.
   Qed.
 
-  
+
   (** Treating flip: can't make them direct instances as we
    need at least a [flip] present in the goal. *)
-  
+
   Lemma flip1 `(subrelation A R' R) : subrelation (flip (flip R')) R.
   Proof. firstorder. Qed.
-  
+
   Lemma flip2 `(subrelation A R R') : subrelation R (flip (flip R')).
   Proof. firstorder. Qed.
-  
+
   (** That's if and only if *)
-  
+
   Lemma eq_subrelation `(Reflexive A R) : subrelation (@eq A) R.
   Proof. simpl_relation. Qed.
 
   (** Once we have normalized, we will apply this instance to simplify the problem. *)
-  
+
   Definition proper_flip_proper `(mor : Proper A R m) : Proper (flip R) m := mor.
-  
+
   Lemma proper_eq (x : A) : Proper (@eq A) x.
   Proof. intros. reflexivity. Qed.
   

--- a/theories/Init/Datatypes.v
+++ b/theories/Init/Datatypes.v
@@ -497,6 +497,14 @@ Definition idProp : IDProp := fun A x => x.
 
 Register idProp as core.IDProp.idProp.
 
+(** The non-dependent function space between [A] and [B]. *)
+
+#[universes(polymorphic)]
+Definition arrow (A B : Type) := A -> B.
+
+#[universes(polymorphic)]
+Definition flip {A B C : Type} (f : A -> B -> C) := fun x y => f y x.
+
 (** Equivalence in [Type] *)
 #[universes(polymorphic)]
 Definition iffT (A B : Type) := ((A -> B) * (B -> A))%type.

--- a/theories/Init/Datatypes.v
+++ b/theories/Init/Datatypes.v
@@ -497,6 +497,10 @@ Definition idProp : IDProp := fun A x => x.
 
 Register idProp as core.IDProp.idProp.
 
+(** Equivalence in [Type] *)
+#[universes(polymorphic)]
+Definition iffT (A B : Type) := ((A -> B) * (B -> A))%type.
+
 (* begin hide *)
 
 (* Compatibility *)

--- a/theories/Program/Basics.v
+++ b/theories/Program/Basics.v
@@ -37,8 +37,8 @@ Notation " g ∘ f " := (compose g f)
 Local Open Scope program_scope.
 
 (** The non-dependent function space between [A] and [B]. *)
-
-Definition arrow (A B : Type) := A -> B.
+#[deprecated(since="8.16",note="Use Init.Datatypes.arrow instead.")]
+Notation arrow := arrow.
 
 (** Logical implication. *)
 
@@ -49,8 +49,8 @@ Definition impl (A B : Prop) : Prop := A -> B.
 Definition const {A B} (a : A) := fun _ : B => a.
 
 (** The [flip] combinator reverses the first two arguments of a function. *)
-
-Definition flip {A B C} (f : A -> B -> C) x y := f y x.
+#[deprecated(since="8.16",note="Use Init.Datatypes.flip instead.")]
+Notation flip := flip.
 
 (** Application as a combinator. *)
 

--- a/theories/Reals/Abstract/ConstructiveLimits.v
+++ b/theories/Reals/Abstract/ConstructiveLimits.v
@@ -179,7 +179,7 @@ Qed.
 #[global]
 Instance CR_cv_morph
   : forall {R : ConstructiveReals} (un : nat -> CRcarrier R), CMorphisms.Proper
-      (CMorphisms.respectful (CReq R) CRelationClasses.iffT) (CR_cv R un).
+      (CMorphisms.respectful (CReq R) iffT) (CR_cv R un).
 Proof.
   split. intros. apply (CR_cv_proper un x). exact H0. exact H.
   intros. apply (CR_cv_proper un y). exact H0. symmetry. exact H.

--- a/theories/Reals/Abstract/ConstructiveReals.v
+++ b/theories/Reals/Abstract/ConstructiveReals.v
@@ -240,7 +240,7 @@ Lemma CRlt_proper
   : forall R : ConstructiveReals,
     CMorphisms.Proper
       (CMorphisms.respectful (CReq R)
-                             (CMorphisms.respectful (CReq R) CRelationClasses.iffT)) (CRlt R).
+                             (CMorphisms.respectful (CReq R) iffT)) (CRlt R).
 Proof.
   intros R x y H x0 y0 H0. destruct H, H0.
   destruct (CRltLinear R). split.
@@ -330,7 +330,7 @@ Qed.
 #[global]
 Instance CRlt_morph
   : forall {R : ConstructiveReals}, CMorphisms.Proper
-      (CMorphisms.respectful (CReq R) (CMorphisms.respectful (CReq R) CRelationClasses.iffT)) (CRlt R).
+      (CMorphisms.respectful (CReq R) (CMorphisms.respectful (CReq R) iffT)) (CRlt R).
 Proof.
   intros R x y H x0 y0 H0. destruct H, H0. split.
   - intro. destruct (CRltLinear R). destruct (s x y x0). assumption.
@@ -1137,7 +1137,7 @@ Qed.
 #[global]
 Instance CRapart_morph
   : forall {R : ConstructiveReals}, CMorphisms.Proper
-      (CMorphisms.respectful (CReq R) (CMorphisms.respectful (CReq R) CRelationClasses.iffT)) (CRapart R).
+      (CMorphisms.respectful (CReq R) (CMorphisms.respectful (CReq R) iffT)) (CRapart R).
 Proof.
   intros R x y H x0 y0 H0. destruct H, H0. split.
   - intro. destruct H3.

--- a/theories/Reals/Cauchy/ConstructiveCauchyReals.v
+++ b/theories/Reals/Cauchy/ConstructiveCauchyReals.v
@@ -375,7 +375,7 @@ Qed.
 #[global]
 Instance CRealLt_morph
   : CMorphisms.Proper
-      (CMorphisms.respectful CRealEq (CMorphisms.respectful CRealEq CRelationClasses.iffT)) CRealLt.
+      (CMorphisms.respectful CRealEq (CMorphisms.respectful CRealEq iffT)) CRealLt.
 Proof.
   intros x y Hxeqy x0 y0 Hx0eqy0.
   destruct Hxeqy as [Hylex Hxley].
@@ -396,7 +396,7 @@ Qed.
 #[global]
 Instance CRealGt_morph
   : CMorphisms.Proper
-      (CMorphisms.respectful CRealEq (CMorphisms.respectful CRealEq CRelationClasses.iffT)) CRealGt.
+      (CMorphisms.respectful CRealEq (CMorphisms.respectful CRealEq iffT)) CRealGt.
 Proof.
   intros x y Hxeqy x0 y0 Hx0eqy0. apply CRealLt_morph; assumption.
 Qed.
@@ -404,7 +404,7 @@ Qed.
 #[global]
 Instance CReal_appart_morph
   : CMorphisms.Proper
-      (CMorphisms.respectful CRealEq (CMorphisms.respectful CRealEq CRelationClasses.iffT)) CReal_appart.
+      (CMorphisms.respectful CRealEq (CMorphisms.respectful CRealEq iffT)) CReal_appart.
 Proof.
   intros x y Hxeqy x0 y0 Hx0eqy0.
   split.

--- a/theories/Reals/Cauchy/ConstructiveRcomplete.v
+++ b/theories/Reals/Cauchy/ConstructiveRcomplete.v
@@ -53,7 +53,7 @@ Qed.
 #[global]
 Instance seq_cv_morph
   : forall (un : nat -> CReal), CMorphisms.Proper
-      (CMorphisms.respectful CRealEq CRelationClasses.iffT) (seq_cv un).
+      (CMorphisms.respectful CRealEq iffT) (seq_cv un).
 Proof.
   split. intros. apply (seq_cv_proper un x). exact H0. exact H.
   intros. apply (seq_cv_proper un y). exact H0. symmetry. exact H.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

The goal is to avoid having both the monomorphic definition in `Program.Basics` and the polymorphic one in `Classes.RelationClasses`.
This is mostly for benchmarking (impact on performance will certainly be rather bad).

- [x] Added / updated **test-suite**.
- [ ] Added **changelog**.
- [ ] Opened **overlay** pull requests.
<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
