### PR TITLE
[CI] Add MathComp Analysis

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -763,6 +763,31 @@ library:ci-mczify:
   - build:edge+flambda
   - library:ci-mathcomp
 
+library:ci-mathcomp_base:
+  extends: .ci-template
+
+library:ci-finmap:
+  extends: .ci-template
+  needs:
+  - build:base
+  - library:ci-mathcomp_base
+
+library:ci-bigenough:
+  extends: .ci-template
+  needs:
+  - build:base
+  - library:ci-mathcomp_base
+
+library:ci-analysis:
+  extends: .ci-template
+  needs:
+  - build:base
+  - library:ci-mathcomp_base
+  - library:ci-finmap
+  - library:ci-bigenough
+  - plugin:ci-elpi  # for Hierarchy Builder
+  # we need a mathcomp_base here as elpi requires OCaml < 4.13
+
 library:ci-sf:
   extends: .ci-template
 

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -47,6 +47,10 @@ CI_TARGETS= \
     ci-math_classes \
     ci-mathcomp \
     ci-mczify \
+    ci-mathcomp_base \
+    ci-finmap \
+    ci-bigenough \
+    ci-analysis \
     ci-menhir \
     ci-metacoq \
     ci-mtac2 \
@@ -95,6 +99,9 @@ ci-fourcolor: ci-mathcomp
 ci-oddorder: ci-mathcomp
 ci-fcsl_pcm: ci-mathcomp
 ci-mczify: ci-mathcomp
+ci-finmap: ci-mathcomp_base
+ci-bigenough: ci-mathcomp_base
+ci-analysis: ci-elpi ci-finmap ci-bigenough
 
 ci-iris: ci-autosubst
 

--- a/dev/ci/ci-analysis.sh
+++ b/dev/ci/ci-analysis.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+git_download analysis
+
+if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
+
+( cd "${CI_BUILD_DIR}/analysis"
+  make
+  make install
+)

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -50,6 +50,12 @@ project oddorder "https://github.com/math-comp/odd-order" "master"
 
 project mczify "https://github.com/math-comp/mczify" "master"
 
+project finmap "https://github.com/math-comp/finmap" "master"
+
+project bigenough "https://github.com/math-comp/bigenough" "master"
+
+project analysis "https://github.com/math-comp/analysis" "master"
+
 ########################################################################
 # UniMath
 ########################################################################

--- a/dev/ci/ci-bigenough.sh
+++ b/dev/ci/ci-bigenough.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+git_download bigenough
+
+if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
+
+( cd "${CI_BUILD_DIR}/bigenough"
+  make
+  make install
+)

--- a/dev/ci/ci-finmap.sh
+++ b/dev/ci/ci-finmap.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+git_download finmap
+
+if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
+
+( cd "${CI_BUILD_DIR}/finmap"
+  make
+  make install
+)

--- a/dev/ci/ci-mathcomp_base.sh
+++ b/dev/ci/ci-mathcomp_base.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+git_download mathcomp
+
+if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
+
+( cd "${CI_BUILD_DIR}/mathcomp/mathcomp"
+  make
+  # don't run the test suite as hierarchy.ml requires a newer OCaml version
+  # make test-suite
+  make install
+)


### PR DESCRIPTION
A bug in ssr was recently catched in MathComp Analysis but not in
MathComp itself: https://github.com/coq/coq/issues/15325
so it seems interesting to add Analysis to the CI.

Pinging @affeldt-aist @spitters who proposed this addition