### PR TITLE
Computation of the guardedness of a subterm assumes too strong invariants on the internal form of fixpoints

### DIFF
--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -918,7 +918,7 @@ let rec subterm_specif renv stack t =
         let decrArg = recindxs.(i) in
         let theBody = bodies.(i)   in
         let nbOfAbst = decrArg+1 in
-        let sign,strippedBody = Term.decompose_lam_n_assum nbOfAbst theBody in
+        let sign,strippedBody = dest_lam_n_assum renv.env nbOfAbst theBody in
                    (* pushing the fix parameters *)
         let stack' = push_stack_closures renv l stack in
         let renv'' = push_ctxt_renv renv' sign in

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -1061,6 +1061,22 @@ let dest_lam_assum env =
   in
   lamec_rec env Context.Rel.empty
 
+let dest_lam_n_assum env n =
+  let rec lamec_rec env n l c =
+    if Int.equal n 0 then l,c
+    else
+    let rc = whd_allnolet env c in
+    match kind rc with
+    | Lambda (x,t,c)  ->
+        let d = LocalAssum (x,t) in
+        lamec_rec (push_rel d env) (n-1) (Context.Rel.add d l) c
+    | LetIn (x,b,t,c) ->
+        let d = LocalDef (x,b,t) in
+        lamec_rec (push_rel d env) n (Context.Rel.add d l) c
+    | _ -> anomaly (Pp.str "dest_lam_n_assum: not enough abstractions")
+  in
+  lamec_rec env n Context.Rel.empty
+
 exception NotArity
 
 let dest_arity env c =

--- a/kernel/reduction.mli
+++ b/kernel/reduction.mli
@@ -120,6 +120,7 @@ val dest_prod       : env -> types -> Constr.rel_context * types
 val dest_prod_assum : env -> types -> Constr.rel_context * types
 val dest_lam        : env -> constr -> Constr.rel_context * constr
 val dest_lam_assum  : env -> constr -> Constr.rel_context * constr
+val dest_lam_n_assum : env -> int -> constr -> Constr.rel_context * constr
 
 exception NotArity
 


### PR DESCRIPTION
**Kind:** mini-fix

The computation of the guardedness of a subterm assumed the body of a fix to start with a context of sufficient length, but, e.g., `Theorem with` does not ensure that.

The PR takes into account the possible need for reduction to reveal the context of the fixpoint.

No test, but using a fixpoint built with`Theorem with` as argument of another fix would probably trigger the problem (which I found while working on #15434, with `decompose_lam_n_assum` eventually raising an error).

The PR also moves the error in `decompose_{lam,prod}_n_{assum,decls}` into an anomaly.

-------
More generally, I wonder whether we should not instead change the representation of fix/cofix to ensure the presence of such context, as in:
```ocaml
type fixpoint = int * (Name.t binder_annot array * types array * (rel_context * constr) array)
type cofixpoint = int * (Name.t binder_annot array * types array * (rel_context * constr) array)
```
where the context goes until the recursive argument for fix and contains all the arguments for cofix.
