### PR TITLE
Use the new representation in old unification on Case / Case problems.

### DIFF
--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -863,15 +863,18 @@ let rec unify_0_with_initial_metas (sigma,ms,es as subst : subst0) conv_at_top e
              | _ -> raise ex)
 
         | Case (ci1, u1, pms1, p1, iv1, c1, cl1), Case (ci2, u2, pms2, p2, iv2, c2, cl2) ->
-          let (ci1, p1, iv1, c1, cl1) = EConstr.expand_case env sigma (ci1, u1, pms1, p1, iv1, c1, cl1) in
-          let (ci2, p2, iv2, c2, cl2) = EConstr.expand_case env sigma (ci2, u2, pms2, p2, iv2, c2, cl2) in
             (try
-             if not (Ind.CanOrd.equal ci1.ci_ind ci2.ci_ind) then error_cannot_unify curenv sigma (cM,cN);
+             let () = if not (Ind.CanOrd.equal ci1.ci_ind ci2.ci_ind) then error_cannot_unify curenv sigma (cM,cN) in
              let opt' = {opt with at_top = true; with_types = false} in
-               Array.fold_left2 (unirec_rec curenvnb CONV {opt with at_top = true} ~nargs:0)
-               (unirec_rec curenvnb CONV opt'
-                (unirec_rec curenvnb CONV opt' substn p1 p2) c1 c2)
-                 cl1 cl2
+             let substn = Array.fold_left2 (unirec_rec curenvnb CONV ~nargs:0 opt') substn pms1 pms2 in
+             let (ci1, _, _, p1, _, c1, cl1) = EConstr.annotate_case env sigma (ci1, u1, pms1, p1, iv1, c1, cl1) in
+             let unif opt substn (ctx1, c1) (_, c2) =
+               let curenvnb' = List.fold_right (fun decl (env, n) -> push_rel decl env, n + 1) ctx1 curenvnb in
+               unirec_rec curenvnb' CONV opt' substn c1 c2
+             in
+             let substn = unif opt' substn p1 p2 in
+             let substn = unirec_rec curenvnb CONV opt' substn c1 c2 in
+             Array.fold_left2 (unif {opt with at_top = true}) substn cl1 cl2
              with ex when precatchable_exception ex ->
                reduce curenvnb pb opt substn cM cN)
 


### PR DESCRIPTION
We do not check for convertibility of the variable types in the return clause and in the branches, and we delay the expansion after the check that the inductive types coincide.

I had this sitting on my drive for more than a year for some reason, but I don't remember why I did not submit it. I do remember that VST was quite sensitive to the unfolding heuristics of Reductionops, but it's not clear that this patch would reintroduce the same kind of problem. In any case let's bench it.