### PR TITLE
Fixes #15455: regression due to #14606 in computing best implicit arguments signature for projections

### DIFF
--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -792,7 +792,7 @@ let select_impargs_size_for_proj ~nexpectedparams ~ngivenparams ~nextraargs impl
     (* Force the main argument to be explicit *)
     (nimps1, imps1 @ [None], imps2)
   in
-  let nallgivenargs = ngivenparams + nextraargs in
+  let nallgivenargs = ngivenparams + nextraargs + 1 in
   let little_enough_all_implicit = function
   | (DefaultImpArgs, impls) -> Some (split_implicit_params impls)
   | (LessArgsThan r, impls) when nallgivenargs <= r -> Some (split_implicit_params impls)

--- a/test-suite/bugs/bug_15455.v
+++ b/test-suite/bugs/bug_15455.v
@@ -1,0 +1,5 @@
+(* A reduced form of bug #15455 *)
+
+Record R := { f {Hp : 0 = 0} (Hq : 0 = 0) : bool }.
+Arguments f _ Hp Hq, _ {Hp} Hq.
+Check fun x => x.(f) eq_refl eq_refl.


### PR DESCRIPTION
**Kind:** fix
 
In enhancement #14606, the main argument was forgotten in computing the number of given arguments in the case of multiple signatures for implicit arguments of a projection.

Fixes / closes #15455.

- [X] Added / updated **test-suite**.

I guess it does not need a changelog if it can go to 8.15.0.
