### PR TITLE
Delay the merging of universes for type compatibility in old unification.

### DIFF
--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -232,6 +232,9 @@ val check_conv : ?pb:conv_pb -> ?ts:TransparentState.t -> env ->  evar_map -> co
 val infer_conv : ?catch_incon:bool -> ?pb:conv_pb -> ?ts:TransparentState.t ->
   env -> evar_map -> constr -> constr -> evar_map option
 
+val infer_conv_ustate : ?catch_incon:bool -> ?pb:conv_pb -> ?ts:TransparentState.t ->
+  env -> evar_map -> constr -> constr -> UnivProblem.Set.t option
+
 (** Conversion with inference of universe constraints *)
 val vm_infer_conv : ?pb:conv_pb -> env -> evar_map -> constr -> constr ->
   evar_map option


### PR DESCRIPTION
This seems to be critical for the pattern selection algorithm used by setoid rewrite, which activates full-blown conversion on closed terms. In this situation, the previous code was first checking that the types of the subterms were unifiable and then that the terms themselves were. Now, we do the same thing except that we delay the processing of universe constraints resulting from the first check after the second one. In most cases, unification would fail on pattern selection, so the first constraint merging was costly for no reason. Postponing it makes the whole check faster, with no observable change in the CI.

A good question is why on earth setoid rewrite uses full blown conversion flags but it is too late to change.
