### PR TITLE
`add_notation_interpretation` should not add syntax rules

### DIFF
--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1690,7 +1690,6 @@ let prepare_where_notation decl_ntn =
 let add_notation_interpretation ~local env (decl_ntn, main_data, notation_symbols, ntn, syntax_rules) =
   let { decl_ntn_string = { CAst.loc ; v = df }; decl_ntn_interp = c; decl_ntn_scope = sc } = decl_ntn in
   let notation = make_notation_interpretation ~local main_data notation_symbols ntn syntax_rules df env c sc in
-  syntax_rules_iter (fun sy -> Lib.add_leaf (inSyntaxExtension (local,(ntn,sy)))) syntax_rules;
   Lib.add_leaf (inNotation notation);
   Dumpglob.dump_notation (CAst.make ?loc ntn) sc true
 


### PR DESCRIPTION
This is necessary for #15409. I don't know why this call was there.