### PR TITLE
Statically ensure that some universe constraints are merged in ssrmatching

### DIFF
--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -652,11 +652,11 @@ let rwrxtac ?under ?map_redex occ rdx_pat dir rule =
       let r = ref None in
       (fun env c _ h -> do_once r (fun () -> find_rule c, c); EConstr.mkRel h),
       (fun concl -> closed0_check env0 sigma0 concl e;
-        let (d,(ev,ctx,c)) , x = assert_done r in (d,(ev,ctx, Reductionops.nf_evar ev c)) , x) in
+        let (d,(ev,ctx,c)) , x = assert_done r in (d,(true, ev,ctx, Reductionops.nf_evar ev c)) , x) in
   let concl0 = Reductionops.nf_evar sigma0 concl0 in
   let concl = eval_pattern env0 sigma0 concl0 rdx_pat occ find_R in
-  let (d, r), rdx = conclude concl in
-  let r = Evd.merge_universe_context (pi1 r) (pi2 r), (pi3 r) in
+  let (d, (_, sigma, uc, t)), rdx = conclude concl in
+  let r = Evd.merge_universe_context sigma uc, t in
   rwcltac ?under ?map_redex concl rdx d r
   end
 

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -278,7 +278,8 @@ let unfoldintac occ rdx t (kt,_) =
   let unfold, conclude = match classify_pattern rdx with
   | None ->
     let ise = Evd.create_evar_defs sigma in
-    let ise, u = mk_tpattern env0 sigma0 (ise, t) L2R t in
+    let rigid ev = Evd.mem sigma0 ev in
+    let ise, u = mk_tpattern env0 ~rigid (ise, t) L2R t in
     let find_T, end_T =
       mk_tpattern_matcher ~raise_NoMatch:true sigma0 occ (ise,[u]) in
     (fun env c _ h ->
@@ -331,7 +332,8 @@ let foldtac occ rdx ft =
   | None ->
     let ise = Evd.create_evar_defs sigma in
     let ut = red_product_skip_id env0 sigma t in
-    let ise, ut = mk_tpattern env0 sigma0 (ise,t) L2R ut in
+    let rigid ev = Evd.mem sigma0 ev in
+    let ise, ut = mk_tpattern ~rigid env0 (ise,t) L2R ut in
     let find_T, end_T =
       mk_tpattern_matcher ~raise_NoMatch:true sigma0 occ (ise,[ut]) in
     (fun env c _ h -> try find_T env c h ~k:(fun env t _ _ -> t) with NoMatch ->c),
@@ -634,14 +636,15 @@ let rwrxtac ?under ?map_redex occ rdx_pat dir rule =
      rwtac rules in
   let env0 = env in
   let concl0 = Proofview.Goal.concl gl in
+  let rigid ev = Evd.mem sigma0 ev in
   let find_R, conclude = match classify_pattern rdx_pat with
   | None ->
       let upats_origin = dir, (snd rule) in
-      let rpat env sigma0 (sigma, pats) (d, r, lhs, rhs) =
+      let rpat (sigma, pats) (d, r, lhs, rhs) =
         let sigma, pat =
-          mk_tpattern ~ok:(rw_progress rhs) env sigma0 (sigma, Reductionops.nf_evar sigma r) d (Reductionops.nf_evar sigma lhs) in
+          mk_tpattern ~ok:(rw_progress rhs) ~rigid env0 (sigma, Reductionops.nf_evar sigma r) d (Reductionops.nf_evar sigma lhs) in
         sigma, pats @ [pat] in
-      let rpats = List.fold_left (rpat env0 sigma0) (r_sigma,[]) rules in
+      let rpats = List.fold_left rpat (r_sigma,[]) rules in
       let find_R, end_R = mk_tpattern_matcher sigma0 occ ~upats_origin rpats in
       (fun e c _ i -> find_R ~k:(fun _ _ _ h -> EConstr.mkRel h) e c i),
       fun cl -> let rdx,d,r = end_R () in closed0_check env0 sigma0 cl rdx; (d,r),rdx
@@ -662,18 +665,19 @@ let ssrinstancesofrule ist dir arg =
   let env0 = Proofview.Goal.env gl in
   let sigma0 = Proofview.Goal.sigma gl in
   let concl0 = Proofview.Goal.concl gl in
+  let rigid ev = Evd.mem sigma0 ev in
   let rule = interp_term env0 sigma0 ist arg in
   let r_sigma, rules = rwprocess_rule env0 dir rule in
   let find, conclude =
     let upats_origin = dir, (snd rule) in
-    let rpat env sigma0 (sigma, pats) (d, r, lhs, rhs) =
+    let rpat (sigma, pats) (d, r, lhs, rhs) =
       let sigma, pat =
-        mk_tpattern ~ok:(rw_progress rhs) env sigma0
+        mk_tpattern ~ok:(rw_progress rhs) ~rigid env0
           (sigma, Reductionops.nf_evar sigma r)
           d
           (Reductionops.nf_evar sigma lhs) in
       sigma, pats @ [pat] in
-    let rpats = List.fold_left (rpat env0 sigma0) (r_sigma,[]) rules in
+    let rpats = List.fold_left rpat (r_sigma,[]) rules in
     mk_tpattern_matcher ~all_instances:true ~raise_NoMatch:true sigma0 None ~upats_origin rpats in
   let print env p c _ = Feedback.msg_info Pp.(hov 1 (str"instance:" ++ spc() ++ pr_econstr_env env r_sigma p ++ spc() ++ str "matches:" ++ spc() ++ pr_econstr_env env r_sigma c)); c in
   Feedback.msg_info Pp.(str"BEGIN INSTANCES");

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -632,7 +632,7 @@ let rwrxtac ?under ?map_redex occ rdx_pat dir rule =
         try
           let ise = unify_HO env (Evd.create_evar_defs r_sigma) lhs rdx in
           if not (rw_progress rhs rdx ise) then raise NoMatch else
-          d, (ise, Evd.evar_universe_context ise, Reductionops.nf_evar ise r)
+          d, (ise, Reductionops.nf_evar ise r)
         with _ -> rwtac rs in
      rwtac rules in
   let env0 = env in
@@ -653,11 +653,11 @@ let rwrxtac ?under ?map_redex occ rdx_pat dir rule =
       let r = ref None in
       (fun env c _ h -> do_once r (fun () -> find_rule c, c); EConstr.mkRel h),
       (fun concl -> closed0_check env0 sigma0 concl e;
-        let (d,(ev,ctx,c)) , x = assert_done r in (d,(true, ev,ctx, Reductionops.nf_evar ev c)) , x) in
+        let (d, (ev, c)), x = assert_done r in (d, (true, ev, Reductionops.nf_evar ev c)), x) in
   let concl0 = Reductionops.nf_evar sigma0 concl0 in
   let concl = eval_pattern ~rigid env0 concl0 rdx_pat occ find_R in
-  let (d, (_, sigma, uc, t)), rdx = conclude concl in
-  let r = Evd.merge_universe_context sigma uc, t in
+  let (d, (_, sigma, t)), rdx = conclude concl in
+  let r = sigma, t in
   rwcltac ?under ?map_redex concl rdx d r
   end
 

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -220,23 +220,22 @@ let unif_FO env ise p c =
 (* Perform evar substitution in main term and prune substitution. *)
 let nf_open_term sigma0 ise c =
   let open EConstr in
-  let s = ise and s' = ref sigma0 in
-  let rec nf c' = match EConstr.kind s c' with
+  let s' = ref sigma0 in
+  let rec nf c' = match EConstr.kind ise c' with
   | Evar ex ->
     let k, a = ex in let a' = List.map nf a in
     if not (Evd.mem !s' k) then
-      s' := Evd.add !s' k (Evarutil.nf_evar_info s (Evd.find s k));
+      s' := Evd.add !s' k (Evarutil.nf_evar_info ise (Evd.find ise k));
     mkEvar (k, a')
-  | _ -> map s nf c' in
-  let copy_def k evi () =
-    if evar_body evi != Evd.Evar_empty then () else
-    match Evd.evar_body (Evd.find s k) with
-      | Evar_defined c' ->
-        let c' = nf c' in
-        s' := Evd.define k c' !s'
-    | _ -> () in
-  let c' = nf c in let _ = Evd.fold copy_def sigma0 () in
-  !s', Evd.evar_universe_context s, c'
+  | _ -> map ise nf c' in
+  let copy_def k _ () = match Evd.evar_body (Evd.find ise k) with
+  | Evar_defined c' ->
+    let c' = nf c' in
+    s' := Evd.define k c' !s'
+  | _ -> () in
+  let c' = nf c in
+  let _ = Evd.fold_undefined copy_def sigma0 () in
+  !s', Evd.evar_universe_context ise, c'
 
 let unif_end ?(solve_TC=true) env sigma0 ise0 pt ok =
   let ise = Evarconv.solve_unif_constraints_with_heuristics env ise0 in

--- a/plugins/ssrmatching/ssrmatching.mli
+++ b/plugins/ssrmatching/ssrmatching.mli
@@ -159,7 +159,7 @@ type find_P =
     instantiation, the proof term and the ssrdit stored in the tpattern
   @raise UserEerror if too many occurrences were specified *)
 type conclude =
-  unit -> EConstr.t * ssrdir * (bool * evar_map * UState.t * EConstr.t)
+  unit -> EConstr.t * ssrdir * (bool * evar_map * EConstr.t)
 
 (** [mk_tpattern_matcher b o sigma0 occ sigma_tplist] creates a pair
     a function [find_P] and [conclude] with the behaviour explained above.

--- a/plugins/ssrmatching/ssrmatching.mli
+++ b/plugins/ssrmatching/ssrmatching.mli
@@ -134,7 +134,8 @@ type tpattern
 val mk_tpattern :
   ?p_origin:ssrdir * EConstr.t ->
   ?ok:(EConstr.t -> evar_map -> bool) ->
-  env -> evar_map ->
+  rigid:(Evar.t -> bool) ->
+  env ->
   evar_map * EConstr.t ->
   ssrdir -> EConstr.t ->
     evar_map * tpattern

--- a/plugins/ssrmatching/ssrmatching.mli
+++ b/plugins/ssrmatching/ssrmatching.mli
@@ -158,7 +158,7 @@ type find_P =
     instantiation, the proof term and the ssrdit stored in the tpattern
   @raise UserEerror if too many occurrences were specified *)
 type conclude =
-  unit -> EConstr.t * ssrdir * (evar_map * UState.t * EConstr.t)
+  unit -> EConstr.t * ssrdir * (bool * evar_map * UState.t * EConstr.t)
 
 (** [mk_tpattern_matcher b o sigma0 occ sigma_tplist] creates a pair
     a function [find_P] and [conclude] with the behaviour explained above.

--- a/plugins/ssrmatching/ssrmatching.mli
+++ b/plugins/ssrmatching/ssrmatching.mli
@@ -171,7 +171,6 @@ val mk_tpattern_matcher :
   ?all_instances:bool ->
   ?raise_NoMatch:bool ->
   ?upats_origin:ssrdir * EConstr.t ->
-  fresh:(Evar.t -> bool) ->
   occ -> evar_map * tpattern list ->
     find_P * conclude
 
@@ -202,7 +201,7 @@ val mk_tpattern_matcher :
  * [concl] where [occ] occurrences of [t] have been replaced
  * by [Rel 1] and the instance of [t] *)
 
-val fill_occ_term : Environ.env -> Evd.evar_map -> EConstr.t -> occ -> evar_map * EConstr.t -> EConstr.t * EConstr.t
+val fill_occ_term : rigid:(Evar.t -> bool) -> Environ.env -> EConstr.t -> occ -> evar_map * EConstr.t -> EConstr.t * EConstr.t
 
 (** Helpers to make stateful closures. Example: a [find_P] function may be
     called many times, but the pattern instantiation phase is performed only the

--- a/plugins/ssrmatching/ssrmatching.mli
+++ b/plugins/ssrmatching/ssrmatching.mli
@@ -133,9 +133,9 @@ type tpattern
   @raise UserEerror is the pattern is a wildcard *)
 val mk_tpattern :
   ?p_origin:ssrdir * EConstr.t ->
+  ?ok:(EConstr.t -> evar_map -> bool) ->
   env -> evar_map ->
   evar_map * EConstr.t ->
-  (EConstr.t -> evar_map -> bool) ->
   ssrdir -> EConstr.t ->
     evar_map * tpattern
 

--- a/plugins/ssrmatching/ssrmatching.mli
+++ b/plugins/ssrmatching/ssrmatching.mli
@@ -90,7 +90,8 @@ type subst = Environ.env -> EConstr.t -> EConstr.t -> int -> EConstr.t
     [subst] *)
 val eval_pattern :
   ?raise_NoMatch:bool ->
-  env -> evar_map -> EConstr.t ->
+  rigid:(Evar.t -> bool) ->
+  env -> EConstr.t ->
   pattern option -> occ -> subst ->
     EConstr.t
 
@@ -170,7 +171,8 @@ val mk_tpattern_matcher :
   ?all_instances:bool ->
   ?raise_NoMatch:bool ->
   ?upats_origin:ssrdir * EConstr.t ->
-  evar_map -> occ -> evar_map * tpattern list ->
+  fresh:(Evar.t -> bool) ->
+  occ -> evar_map * tpattern list ->
     find_P * conclude
 
 (** Example of [mk_tpattern_matcher] to implement


### PR DESCRIPTION
This saves a lot of useless splitting-then-merging of universes.