### PR TITLE
Add a trivial test to pkg:opam CI job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -347,6 +347,7 @@ pkg:opam:
     - opam pin add --kind=path coq-stdlib.dev .
     - opam pin add --kind=path coqide-server.dev .
     - opam pin add --kind=path coqide.dev .
+    - coqc -config
     - set +e
   variables:
     OPAM_SWITCH: "edge"


### PR DESCRIPTION
The current system to set -prefix for configure has never worked,
let's see if this is enough to detect it.