### PR TITLE
Stronger invariants on the syntax of records and variants

### DIFF
--- a/doc/sphinx/language/core/records.rst
+++ b/doc/sphinx/language/core/records.rst
@@ -11,7 +11,7 @@ sense, the :cmd:`Record` construction allows defining“signatures”.
 
 .. _record_grammar:
 
-.. cmd:: {| Record | Structure } @record_definition {* with @record_definition }
+.. cmd:: {| Record | Structure } @record_definition
    :name: Record; Structure
 
    .. insertprodn record_definition field_def

--- a/doc/sphinx/language/core/variants.rst
+++ b/doc/sphinx/language/core/variants.rst
@@ -6,7 +6,7 @@ Variants and the `match` construct
 Variants
 --------
 
-.. cmd:: Variant @variant_definition {* with @variant_definition }
+.. cmd:: Variant @variant_definition
 
    .. insertprodn variant_definition variant_definition
 

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -577,11 +577,12 @@ gallina: [
 | REPLACE thm_token ident_decl binders ":" lconstr LIST0 [ "with" ident_decl binders ":" lconstr ]
 | WITH thm_token ident_decl binders ":" type LIST0 [ "with" ident_decl binders ":" type ]
 | DELETE assumptions_token inline assum_list
-| REPLACE finite_token LIST1 inductive_definition SEP "with"
+| REPLACE inductive_token LIST1 inductive_definition SEP "with"
 | WITH "Inductive" inductive_definition LIST0 ( "with" inductive_definition )
 |   "CoInductive" inductive_definition LIST0 ( "with" inductive_definition )
-|   "Variant" variant_definition LIST0 ( "with" variant_definition )
-|   [ "Record" | "Structure" ] record_definition LIST0 ( "with" record_definition )
+| REPLACE finite_token inductive_definition
+| WITH "Variant" variant_definition
+|   [ "Record" | "Structure" ] record_definition
 |   "Class" record_definition
 |   "Class" singleton_class_definition
 | REPLACE "Fixpoint" LIST1 fix_definition SEP "with"
@@ -597,6 +598,10 @@ gallina: [
 ]
 
 finite_token: [
+| DELETENT
+]
+
+inductive_token: [
 | DELETENT
 ]
 

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -808,7 +808,8 @@ gallina: [
 | assumptions_token inline assum_list
 | def_token ident_decl def_body
 | "Let" ident_decl def_body
-| finite_token LIST1 inductive_definition SEP "with"
+| finite_token inductive_definition
+| inductive_token LIST1 inductive_definition SEP "with"
 | "Fixpoint" LIST1 fix_definition SEP "with"
 | "Let" "Fixpoint" LIST1 fix_definition SEP "with"
 | "CoFixpoint" LIST1 cofix_definition SEP "with"
@@ -896,9 +897,12 @@ cumul_ident_decl: [
 | identref OPT cumul_univ_decl
 ]
 
-finite_token: [
+inductive_token: [
 | "Inductive"
 | "CoInductive"
+]
+
+finite_token: [
 | "Variant"
 | "Record"
 | "Structure"

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1053,8 +1053,8 @@ command: [
 | "Universes" LIST1 ident
 | "Constraint" LIST1 univ_constraint SEP ","
 | "CoInductive" inductive_definition LIST0 ( "with" inductive_definition )
-| "Variant" variant_definition LIST0 ( "with" variant_definition )
-| [ "Record" | "Structure" ] record_definition LIST0 ( "with" record_definition )
+| "Variant" variant_definition
+| [ "Record" | "Structure" ] record_definition
 | "Class" record_definition
 | "Class" singleton_class_definition
 | "Module" OPT [ "Import" | "Export" ] ident LIST0 module_binder OPT of_module_type OPT ( ":=" LIST1 module_expr_inl SEP "<+" )

--- a/kernel/indtypes.ml
+++ b/kernel/indtypes.ml
@@ -371,6 +371,7 @@ let check_positivity_one ~chkpos recursive (env,_,ntypes,_ as ienv) paramsctxt (
 let check_positivity ~chkpos kn names env_ar_par paramsctxt finite inds =
   let ntypes = Array.length inds in
   let recursive = finite != BiFinite in
+  if not recursive && Array.length inds <> 1 then raise (InductiveError Type_errors.BadEntry);
   let rc = Array.mapi (fun j t -> (Mrec (kn,j),t)) (Rtree.mk_rec_calls ntypes) in
   let ra_env_ar = Array.rev_to_list rc in
   let nparamsctxt = Context.Rel.length paramsctxt in

--- a/test-suite/success/Record.v
+++ b/test-suite/success/Record.v
@@ -121,5 +121,6 @@ Module NoRecursiveOrMutualRecord.
 
 Fail Record t := {a:t}.
 Fail Record t := {a:u} with u := {c:t}.
+Fail Record t := {a:nat} with u := {c:nat}.
 
 End NoRecursiveOrMutualRecord.

--- a/test-suite/success/Record.v
+++ b/test-suite/success/Record.v
@@ -116,3 +116,10 @@ Arguments f _ {a}.
 Check fun x => x.(f) : 0 = 0.
 
 End MaximalImplicit.
+
+Module NoRecursiveOrMutualRecord.
+
+Fail Record t := {a:t}.
+Fail Record t := {a:u} with u := {c:t}.
+
+End NoRecursiveOrMutualRecord.

--- a/test-suite/success/Record.v
+++ b/test-suite/success/Record.v
@@ -117,10 +117,9 @@ Check fun x => x.(f) : 0 = 0.
 
 End MaximalImplicit.
 
-Module NoRecursiveOrMutualRecord.
+Module NoRecursiveRecordVariant.
 
 Fail Record t := {a:t}.
-Fail Record t := {a:u} with u := {c:t}.
-Fail Record t := {a:nat} with u := {c:nat}.
+Fail Variant t := C : t -> t.
 
-End NoRecursiveOrMutualRecord.
+End NoRecursiveRecordVariant.

--- a/vernac/declareInd.ml
+++ b/vernac/declareInd.ml
@@ -149,11 +149,17 @@ let declare_mutual_inductive_with_eliminations ?(primitive_expected=false) ?typi
   (* spiwack: raises an error if the structure is supposed to be non-recursive,
         but isn't *)
   begin match mie.mind_entry_finite with
-    | Declarations.BiFinite when is_recursive mie ->
+  | Declarations.BiFinite ->
+    if is_recursive mie then
       if Option.has_some mie.mind_entry_record then
         CErrors.user_err Pp.(strbrk "Records declared with the keywords Record or Structure cannot be recursive. You can, however, define recursive records using the Inductive or CoInductive command.")
       else
-        CErrors.user_err Pp.(strbrk "Types declared with the keyword Variant cannot be recursive. Recursive types are defined with the Inductive and CoInductive command.")
+        CErrors.user_err Pp.(strbrk "Types declared with the keyword Variant cannot be recursive. Recursive types are defined with the Inductive and CoInductive command.");
+    if not (Int.equal (List.length mie.mind_entry_inds) 1) then
+      if Option.has_some mie.mind_entry_record then
+        CErrors.user_err Pp.(strbrk "Keywords Record and Structure are to define a single type at once.")
+      else
+        CErrors.user_err Pp.(strbrk "Keyword Variant is to define a single type at once.")
     | _ -> ()
   end;
   let names = List.map (fun e -> e.mind_entry_typename) mie.mind_entry_inds in

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -229,7 +229,9 @@ GRAMMAR EXTEND Gram
       | IDENT "Let"; id = ident_decl; b = def_body ->
           { VernacDefinition ((DoDischarge, Let), name_of_ident_decl id, b) }
       (* Gallina inductive declarations *)
-      | f = finite_token; indl = LIST1 inductive_definition SEP "with" ->
+      | f = finite_token; ind = inductive_definition ->
+          { VernacInductive (f, [ind]) }
+      | f = inductive_token; indl = LIST1 inductive_definition SEP "with" ->
           { VernacInductive (f, indl) }
       | "Fixpoint"; recs = LIST1 fix_definition SEP "with" ->
           { VernacFixpoint (NoDischarge, recs) }
@@ -340,10 +342,12 @@ GRAMMAR EXTEND Gram
     [ [ i = identref; l = OPT cumul_univ_decl -> { (i, l) }
   ] ]
   ;
-  finite_token:
+  inductive_token:
     [ [ IDENT "Inductive" -> { Inductive_kw }
-      | IDENT "CoInductive" -> { CoInductive }
-      | IDENT "Variant" -> { Variant }
+      | IDENT "CoInductive" -> { CoInductive } ] ]
+  ;
+  finite_token:
+    [ [ IDENT "Variant" -> { Variant }
       | IDENT "Record" -> { Record }
       | IDENT "Structure" -> { Structure }
       | IDENT "Class" -> { Class true } ] ]

--- a/vernac/printmod.ml
+++ b/vernac/printmod.ml
@@ -142,6 +142,7 @@ let get_fields =
 
 let print_record env mind mib udecl =
   let u = Univ.make_abstract_instance (Declareops.inductive_polymorphic_context mib) in
+  assert (Array.length mib.mind_packets = 1);
   let mip = mib.mind_packets.(0) in
   let params = Inductive.inductive_paramdecls (mib,u) in
   let nparamdecls = Context.Rel.length params in


### PR DESCRIPTION
**Kind:** Enhancement

The vernac, kernel and documentation layers were not so clear about whether a `Record` or `Variant` type could be recursive and/or mutually defined, leading e.g. to errors such as:

```coq
Record t := { a : nat } with u := { b : nat }.
Print u.
(* Record t : Set := Build_t { a : nat }. *)
```
We make it more robust, to the point of disallowing using `with` in the `Record` and `Variant` syntax. This will also hopefully make the doc about `Record` and `Variant` less confusing with this regard.

- [x] Added / updated **test-suite**.
- [x] Added / updated **documentation**.
- [x] Updated **documented syntax** by running `make -f Makefile.dune doc_gram_rsts`.
