### PR TITLE
A pass on the documentation of records

### DIFF
--- a/doc/sphinx/addendum/implicit-coercions.rst
+++ b/doc/sphinx/addendum/implicit-coercions.rst
@@ -127,7 +127,6 @@ Declaring Coercions
 
 .. cmd:: Coercion @reference : @class >-> @class
          Coercion @ident {? @univ_decl } @def_body
-   :name: Coercion; _
 
   The first form declares the construction denoted by :token:`reference` as a coercion between
   the two given classes.  The second form defines :token:`ident`

--- a/doc/sphinx/addendum/type-classes.rst
+++ b/doc/sphinx/addendum/type-classes.rst
@@ -300,12 +300,7 @@ Summary of the commands
 -----------------------
 
 .. cmd:: Class @record_definition
-         Class @singleton_class_definition
-
-   .. insertprodn singleton_class_definition singleton_class_definition
-
-   .. prodn::
-      singleton_class_definition ::= {? > } @ident_decl {* @binder } {? : @sort } := @constructor
+         Class {? > } @ident_decl {* @binder } {? : @sort } := @constructor
 
    The first form declares a record and makes the record a typeclass with parameters
    :n:`{* @binder }` and the listed record fields.
@@ -339,11 +334,11 @@ Summary of the commands
 
          This command has no effect when used on a typeclass.
 
-.. cmd:: Instance {? @ident_decl {* @binder } } : @type {? @hint_info } {? {| := %{ {* @field_def } %} | := @term } }
+.. cmd:: Instance {? @ident_decl {* @binder } } : @type {? @hint_info } {? {| := %{ {* @field_val } %} | := @term } }
 
    Declares a typeclass instance named
    :token:`ident_decl` of the class :n:`@type` with the specified parameters and with
-   fields defined by :token:`field_def`, where each field must be a declared field of
+   fields defined by :token:`field_val`, where each field must be a declared field of
    the class.
 
    Adds one or more :token:`binder`\s to declare a parameterized instance. :token:`hint_info`

--- a/doc/sphinx/language/core/assumptions.rst
+++ b/doc/sphinx/language/core/assumptions.rst
@@ -115,16 +115,20 @@ Function application
    | ( @natural := @term )
    | @term1
 
-:n:`@term__fun @term` denotes applying the function :n:`@term__fun` to :token:`term`.
+:n:`@term1__fun @term1` denotes applying the function :n:`@term1__fun` to :token:`term1`.
 
-:n:`@term__fun {+ @term__i }` denotes applying
-:n:`@term__fun` to the arguments :n:`@term__i`.  It is
-equivalent to :n:`( … ( @term__fun @term__1 ) … ) @term__n`:
+:n:`@term1__fun {+ @term1__i }` denotes applying
+:n:`@term1__fun` to the arguments :n:`@term1__i`.  It is
+equivalent to :n:`( … ( @term1__fun @term1__1 ) … ) @term1__n`:
 associativity is to the left.
 
+The :n:`@ @qualid_annotated {+ @term1 }` form requires specifying all arguments,
+including implicit ones.  Otherwise, implicit arguments need
+not be given.  See :ref:`ImplicitArguments`.
+
 The notations :n:`(@ident := @term)` and :n:`(@natural := @term)`
-for arguments are used for making explicit the value of implicit arguments (see
-Section :ref:`explicit-applications`).
+for arguments are used for making explicit the value of implicit arguments.
+See :ref:`explicit-applications`.
 
 .. _gallina-assumptions:
 

--- a/doc/sphinx/language/core/inductive.rst
+++ b/doc/sphinx/language/core/inductive.rst
@@ -48,7 +48,8 @@ Inductive types
    such types are not useful.  Use the :cmd:`Scheme` command to generate useful
    induction principles.  See :ref:`mutually_inductive_types`.
 
-   If the entire inductive definition is parameterized with :n:`@binder`\s, the parameters correspond
+   If the entire inductive definition is parameterized with :n:`@binder`\s, those
+   :gdef:`inductive parameters <inductive parameter>` correspond
    to a local context in which the entire set of inductive declarations is interpreted.
    For this reason, the parameters must be strictly the same for each inductive type.
    See :ref:`parametrized-inductive-types`.

--- a/doc/sphinx/language/extensions/implicit-arguments.rst
+++ b/doc/sphinx/language/extensions/implicit-arguments.rst
@@ -3,7 +3,7 @@
 Implicit arguments
 ------------------
 
-An implicit argument of a function is an argument which can be
+An :gdef:`implicit argument` of a function is an argument which can be
 inferred from contextual knowledge. There are different kinds of
 implicit arguments that can be considered implicit in different ways.
 There are also various commands to control the setting or the

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -605,6 +605,12 @@ inductive_token: [
 | DELETENT
 ]
 
+(* decl_notations not allowed for Record, Structure or Class *)
+record_field: [
+| REPLACE LIST0 quoted_attributes record_binder OPT [ "|" natural ] decl_notations
+| WITH LIST0 quoted_attributes record_binder OPT [ "|" natural ]
+]
+
 record_fields: [
 | REPLACE record_field ";" record_fields
 | WITH LIST0 record_field SEP ";" OPT ";"
@@ -2761,6 +2767,7 @@ SPLICE: [
 | cofixdecl
 | induction_clause_list
 | as_or_and_ipat
+| singleton_class_definition
 ] (* end SPLICE *)
 
 RENAME: [
@@ -2824,6 +2831,8 @@ RENAME: [
 | delta_flag delta_reductions
 | q_strategy_flag q_reductions
 | destruction_arg induction_arg
+| field_body field_spec
+| field_def field_val
 ]
 
 simple_tactic: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -673,29 +673,25 @@ variant_definition: [
 | ident_decl LIST0 binder OPT [ "|" LIST0 binder ] OPT [ ":" type ] ":=" OPT "|" LIST1 constructor SEP "|" OPT decl_notations
 ]
 
-singleton_class_definition: [
-| OPT ">" ident_decl LIST0 binder OPT [ ":" sort ] ":=" constructor
-]
-
 record_definition: [
 | OPT ">" ident_decl LIST0 binder OPT [ ":" sort ] OPT ( ":=" OPT ident "{" LIST0 record_field SEP ";" OPT ";" "}" OPT [ "as" ident ] )
 ]
 
 record_field: [
-| LIST0 ( "#[" LIST0 attribute SEP "," "]" ) name OPT field_body OPT [ "|" natural ] OPT decl_notations
+| LIST0 ( "#[" LIST0 attribute SEP "," "]" ) name OPT field_spec OPT [ "|" natural ]
 ]
 
-field_body: [
+field_spec: [
 | LIST0 binder of_type
-| LIST0 binder of_type ":=" term
 | LIST0 binder ":=" term
+| LIST0 binder of_type ":=" term
 ]
 
 term_record: [
-| "{|" LIST0 field_def SEP ";" OPT ";" "|}"
+| "{|" LIST0 field_val SEP ";" OPT ";" "|}"
 ]
 
-field_def: [
+field_val: [
 | qualid LIST0 binder ":=" term
 ]
 
@@ -1056,7 +1052,7 @@ command: [
 | "Variant" variant_definition
 | [ "Record" | "Structure" ] record_definition
 | "Class" record_definition
-| "Class" singleton_class_definition
+| "Class" OPT ">" ident_decl LIST0 binder OPT [ ":" sort ] ":=" constructor
 | "Module" OPT [ "Import" | "Export" ] ident LIST0 module_binder OPT of_module_type OPT ( ":=" LIST1 module_expr_inl SEP "<+" )
 | "Module" "Type" ident LIST0 module_binder LIST0 ( "<:" module_type_inl ) OPT ( ":=" LIST1 module_type_inl SEP "<+" )
 | "Declare" "Module" OPT [ "Import" | "Export" ] ident LIST0 module_binder ":" module_type_inl
@@ -1077,7 +1073,7 @@ command: [
 | "Identity" "Coercion" ident ":" class ">->" class
 | "Coercion" reference ":" class ">->" class
 | "Context" LIST1 binder
-| "Instance" OPT ( ident_decl LIST0 binder ) ":" type OPT hint_info OPT [ ":=" "{" LIST0 field_def "}" | ":=" term ]
+| "Instance" OPT ( ident_decl LIST0 binder ) ":" type OPT hint_info OPT [ ":=" "{" LIST0 field_val "}" | ":=" term ]
 | "Existing" "Instance" qualid OPT hint_info
 | "Existing" "Instances" LIST1 qualid OPT [ "|" natural ]
 | "Existing" "Class" qualid


### PR DESCRIPTION
**Kind:** Doc cleanup

Mostly, we gather things that go together and balance the different parts of the explanation. We also put more emphasis on the `{| f := t |}` and `t.(f)` syntax.

This is on top of #14563.

- [x] Added / updated **documentation**.
