### PR TITLE
In "rewrite in hyps", restrict term to rewrite to avoid hyps.

### DIFF
--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -638,6 +638,12 @@ let clear_hyps_in_evi_main env sigma hyps terms ids =
   in
   (!evdref, nhyps,List.map EConstr.of_constr terms)
 
+let check_and_clear_in_constr ~is_section_variable env evd err ids global c =
+  let evdref = ref evd in
+  let c = EConstr.Unsafe.to_constr c in
+  let c = check_and_clear_in_constr ~is_section_variable env evdref err ids global c in
+  !evdref, EConstr.of_constr c
+
 let clear_hyps_in_evi env sigma hyps concl ids =
   match clear_hyps_in_evi_main env sigma hyps [concl] ids with
   | (sigma,nhyps,[nconcl]) -> (sigma,nhyps,nconcl)

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -252,6 +252,16 @@ val clear_hyps_in_evi : env -> evar_map -> named_context_val -> types ->
 val clear_hyps2_in_evi : env -> evar_map -> named_context_val -> types -> types ->
   Id.Set.t -> evar_map * named_context_val * types * types
 
+val check_and_clear_in_constr
+  : is_section_variable:(Names.Id.Set.elt -> bool)
+  -> Environ.env
+  -> Evd.evar_map
+  -> clear_dependency_error
+  -> Names.Id.Set.t
+  -> bool
+  -> EConstr.constr
+  -> Evd.evar_map * EConstr.constr
+
 type csubst
 
 val empty_csubst : csubst

--- a/test-suite/bugs/bug_15448.v
+++ b/test-suite/bugs/bug_15448.v
@@ -1,0 +1,24 @@
+Lemma bar (a b:unit) (H0: a = b) (H: a = b) : a = b.
+Proof.
+  Fail rewrite (match a,b return _ -> a = b with tt, tt => fun _ => eq_refl end H) in H,H0.
+  Fail rewrite (match a,b return _ -> a = b with tt, tt => fun _ => eq_refl end H0) in H,H0.
+  rewrite (match a,b return _ -> a = b with tt, tt => fun _ => eq_refl end H) in H0.
+  Check H0 : b = b.
+  Check H : a = b.
+  destruct a,b;reflexivity.
+Defined.
+
+Lemma bar' (a b:unit) (H0: a = b) (H: a = b) : a = b.
+Proof.
+  rewrite (match a,b return _ -> a = b with tt, tt => fun _ => eq_refl end H) in *.
+  Check H0 : b = b.
+  Check H : a = b.
+  destruct a,b;reflexivity.
+Defined.
+
+Lemma bar'' (a b:unit) (H0: a = b) (H: a = b) : a = b.
+Proof.
+  unshelve erewrite (_: a = b) in *.
+  { revert H; destruct a,b;reflexivity. }
+  destruct a,b;reflexivity.
+Defined.


### PR DESCRIPTION
Fix #15448
