### PR TITLE
Make our only use of the OCaml Ephemeron API compatible with OCaml 5.0.

### DIFF
--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -93,7 +93,7 @@ val whd_head_evar :  evar_map -> constr -> constr
 val has_undefined_evars : evar_map -> constr -> bool
 
 val is_ground_term :  evar_map -> constr -> bool
-val is_ground_env  :  evar_map -> env -> bool
+val is_ground_env  :  env -> evar_map -> bool
 
 (** [gather_dependent_evars evm seeds] classifies the evars in [evm]
     as dependent_evars and goals (these may overlap). A goal is an evar

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -556,7 +556,7 @@ let rec evar_conv_x flags env evd pbty term1 term2 =
           | exception Univ.UniverseInconsistency e -> UnifFailure (evd, UnifUnivInconsistency e)
       in
         match e with
-        | UnifFailure (evd, e) when not (is_ground_env evd env) -> None
+        | UnifFailure (evd, e) when not (is_ground_env env evd) -> None
         | _ -> Some e)
     else None
   in

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -548,7 +548,7 @@ let program_inference_hook env sigma ev =
   let env = Evd.evar_filtered_env env evi in
   try
     let concl = evi.Evd.evar_concl in
-    if not (Evarutil.is_ground_env sigma env &&
+    if not (Evarutil.is_ground_env env sigma &&
             Evarutil.is_ground_term sigma concl)
     then None
     else


### PR DESCRIPTION
Instead of using the low-level Ephemeron API, we simply use a dummy weak hash table where the key structure is trivial. This might be marginally more costly but it is unlikely to make any difference in practice.

We also seize the opportunity to put the arguments of is_ground_env in the standard order, i.e. the environment before the evarmap.