### PR TITLE
Inline variant definition in the documentation after #15484.

### DIFF
--- a/doc/sphinx/language/core/variants.rst
+++ b/doc/sphinx/language/core/variants.rst
@@ -6,12 +6,7 @@ Variants and the `match` construct
 Variants
 --------
 
-.. cmd:: Variant @variant_definition
-
-   .. insertprodn variant_definition variant_definition
-
-   .. prodn::
-      variant_definition ::= @ident_decl {* @binder } {? %| {* @binder } } {? : @type } := {? %| } {+| @constructor } {? @decl_notations }
+.. cmd:: Variant @ident_decl {* @binder } {? %| {* @binder } } {? : @type } := {? %| } {+| @constructor } {? @decl_notations }
 
    The :cmd:`Variant` command is similar to the :cmd:`Inductive` command, except
    that it disallows recursive definition of types (for instance, lists cannot

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -607,6 +607,10 @@ gallina: [
 | "Scheme" OPT "Boolean" "Equality" "for" smart_global
 ]
 
+SPLICE: [
+| variant_definition
+]
+
 finite_token: [
 | DELETENT
 ]

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -669,10 +669,6 @@ pattern_occs: [
 | one_term OPT ( "at" occs_nums )
 ]
 
-variant_definition: [
-| ident_decl LIST0 binder OPT [ "|" LIST0 binder ] OPT [ ":" type ] ":=" OPT "|" LIST1 constructor SEP "|" OPT decl_notations
-]
-
 record_definition: [
 | OPT ">" ident_decl LIST0 binder OPT [ ":" sort ] OPT ( ":=" OPT ident "{" LIST0 record_field SEP ";" OPT ";" "}" OPT [ "as" ident ] )
 ]
@@ -1063,7 +1059,7 @@ command: [
 | "Constraint" LIST1 univ_constraint SEP ","
 | "CoInductive" inductive_definition LIST0 ( "with" inductive_definition )
 | "CoInductive" record_definition LIST0 ( "with" record_definition )
-| "Variant" variant_definition
+| "Variant" ident_decl LIST0 binder OPT [ "|" LIST0 binder ] OPT [ ":" type ] ":=" OPT "|" LIST1 constructor SEP "|" OPT decl_notations
 | [ "Record" | "Structure" ] record_definition
 | "Class" record_definition
 | "Class" ident_decl LIST0 binder OPT [ ":" sort ] ":=" constructor


### PR DESCRIPTION
If someone is motivated, it would be really nice to improve the description of `Variant` and `Record`. The former should be presented directly, not primarily as a restricted `Inductive`, because we have put the section about variants and the match construct before the one of inductive types and fixpoints.