### PR TITLE
Fixes #15451: incompletenesses in guard condition regarding cofix and primitive projections

### DIFF
--- a/doc/changelog/01-kernel/15498-master+fix15451-incompleteness-guard-condition.rst
+++ b/doc/changelog/01-kernel/15498-master+fix15451-incompleteness-guard-condition.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  cases of incompletenesses in the guard condition for fixpoints in
+  the presence of cofixpoints or primitive projections
+  (`#15498 <https://github.com/coq/coq/pull/15498>`_,
+  fixes `#15451 <https://github.com/coq/coq/issues/15451>`_,
+  by Hugo Herbelin).

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -1116,12 +1116,14 @@ let check_one_fix renv recpos trees def =
               let c_0 = whd_all renv.env c_0 in
               let hd, _ = decompose_app c_0 in
               match kind hd with
-              | Construct _ ->
+              | Construct _ | CoFix _ ->
                   (* the call to whd_betaiotazeta will reduce the
                      apparent iota redex away *)
                   check_rec_call renv []
                     (Term.applist (mkCase (ci, u, pms, ret, iv, c_0, br), l))
-              | _ -> Exninfo.iraise exn
+              | Rel _ | Var _ | Const _ | App _ | Lambda _ | Prod _ | LetIn _
+              | Ind _ | Case _ | Fix _ | Proj _ | Sort _ | Cast _
+              | Int _ | Float _ | Array _ | Meta _ | Evar _ -> Exninfo.iraise exn
             end
 
         (* Enables to traverse Fixpoint definitions in a more intelligent
@@ -1167,7 +1169,9 @@ let check_one_fix renv recpos trees def =
                   let before, after = CList.(firstn decrArg l, skipn (decrArg+1) l) in
                   check_rec_call renv []
                     (Term.applist (mkFix ((recindxs,i),recdef), (before @ recArg :: after)))
-              | _ -> Exninfo.iraise exn
+              | Rel _ | Var _ | Const _ | App _ | Lambda _ | Prod _ | LetIn _
+              | Ind _ | Case _ | Fix _ | CoFix _ | Proj _ | Sort _ | Cast _
+              | Int _ | Float _ | Array _ | Meta _ | Evar _ -> Exninfo.iraise exn
             end
 
         | Const (kn,_u as cu) ->
@@ -1209,10 +1213,12 @@ let check_one_fix renv recpos trees def =
               let c = whd_all renv.env c in
               let hd, _ = decompose_app c in
               match kind hd with
-              | Construct _ ->
+              | Construct _ | CoFix _ ->
                   check_rec_call renv []
                     (Term.applist (mkProj(Projection.unfold p,c), l))
-              | _ -> Exninfo.iraise exn
+              | Rel _ | Var _ | Const _ | App _ | Lambda _ | Prod _ | LetIn _
+              | Ind _ | Case _ | Fix _ | Proj _ | Sort _ | Cast _
+              | Int _ | Float _ | Array _ | Meta _ | Evar _ -> Exninfo.iraise exn
             end
 
         | Var id ->

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -1214,7 +1214,7 @@ let check_one_fix renv recpos trees def =
               let hd, _ = decompose_app c in
               match kind hd with
               | Construct _ | CoFix _ ->
-                  check_rec_call renv []
+                  check_rec_call renv stack
                     (Term.applist (mkProj(Projection.unfold p,c), l))
               | Rel _ | Var _ | Const _ | App _ | Lambda _ | Prod _ | LetIn _
               | Ind _ | Case _ | Fix _ | Proj _ | Sort _ | Cast _

--- a/test-suite/bugs/bug_15451.v
+++ b/test-suite/bugs/bug_15451.v
@@ -1,0 +1,31 @@
+(* Treat "match" on a "cofix" like "match" on a constructor in guard condition *)
+
+Module CofixRedex.
+
+CoInductive Stream := {hd : nat; tl : Stream}.
+Definition zeros := cofix zeros := {|hd := 0; tl := zeros|}.
+
+Fixpoint f n :=
+  match n with
+  | 0 => 0
+  | S n =>
+    match zeros with
+    | {|hd:=_|} => fun f => f n
+    end f
+  end.
+
+End CofixRedex.
+
+Module CofixRedexPrimProj.
+
+Set Primitive Projections.
+CoInductive Stream A := {hd : A; tl : Stream A}.
+Arguments hd {A} s.
+
+Fixpoint f n :=
+  match n with
+  | 0 => 0
+  | S n => (cofix cst := {|hd := (fun f => f n); tl := cst|}).(hd) f
+  end.
+
+End CofixRedexPrimProj.

--- a/test-suite/bugs/bug_15451.v
+++ b/test-suite/bugs/bug_15451.v
@@ -29,3 +29,19 @@ Fixpoint f n :=
   end.
 
 End CofixRedexPrimProj.
+
+(* Stack was missing when unfolding primitive projection in guard condition *)
+
+Module ProjectionStack.
+
+Set Primitive Projections.
+
+Record T := { a : nat -> nat }.
+
+Check fix f (b:bool) n : nat :=
+  match n with
+  | 0 => 0
+  | S n => (if b then {| a := f b |}.(a) else f b) n
+  end.
+
+End ProjectionStack.


### PR DESCRIPTION
**Kind:** Fix

Two issues:
- the case of a `cofix` was missing when detecting the presence of a potential iota-redex to reduce
- the stack was discarded when reducing a primitive projection

Fixes #15451

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
