### PR TITLE
Refine phase separation in module internalization

### DIFF
--- a/interp/modintern.mli
+++ b/interp/modintern.mli
@@ -8,6 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+open Names
 open Environ
 open Entries
 open Constrexpr
@@ -33,5 +34,10 @@ exception ModuleInternalizationError of module_internalization_error
 
 type module_kind = Module | ModType | ModAny
 
+(** Module internalization, i.e. from AST to module expression *)
+val intern_module_ast :
+  module_kind -> module_ast -> (universe_decl_expr option * constr_expr) Declarations.module_alg_expr * ModPath.t * module_kind
+
+(** Module interpretation, i.e. from module expression to typed module entry *)
 val interp_module_ast :
-  env -> module_kind -> module_ast -> module_struct_entry * module_kind * Univ.ContextSet.t
+  env -> module_kind -> ModPath.t -> (universe_decl_expr option * constr_expr) Declarations.module_alg_expr -> module_struct_entry * Univ.ContextSet.t

--- a/kernel/declarations.ml
+++ b/kernel/declarations.ml
@@ -289,14 +289,14 @@ type ('ty,'a) functorize =
     and won't play any role into the kernel after that : they are kept
     only for short module printing and for extraction. *)
 
-type with_declaration =
+type 'uconstr with_declaration =
   | WithMod of Id.t list * ModPath.t
-  | WithDef of Id.t list * (constr * Univ.AbstractContext.t option)
+  | WithDef of Id.t list * 'uconstr
 
-type module_alg_expr =
+type 'uconstr module_alg_expr =
   | MEident of ModPath.t
-  | MEapply of module_alg_expr * ModPath.t
-  | MEwith of module_alg_expr * with_declaration
+  | MEapply of 'uconstr module_alg_expr * ModPath.t
+  | MEwith of 'uconstr module_alg_expr * 'uconstr with_declaration
 
 (** A component of a module structure *)
 
@@ -320,7 +320,7 @@ and module_signature = (module_type_body,structure_body) functorize
 
 (** A module expression is an algebraic expression, possibly functorized. *)
 
-and module_expression = (module_type_body,module_alg_expr) functorize
+and module_expression = (module_type_body, (constr * Univ.AbstractContext.t option) module_alg_expr) functorize
 
 and module_implementation =
   | Abstract (** no accessible implementation *)

--- a/kernel/entries.ml
+++ b/kernel/entries.ml
@@ -112,7 +112,7 @@ type constant_entry =
 
 (** {6 Modules } *)
 
-type module_struct_entry = Declarations.module_alg_expr
+type module_struct_entry = (constr * Univ.AbstractContext.t option) Declarations.module_alg_expr
 
 type module_params_entry =
   (MBId.t * module_struct_entry * inline) list (** older first *)

--- a/kernel/mod_typing.mli
+++ b/kernel/mod_typing.mli
@@ -43,7 +43,7 @@ type 'alg translation =
 
 val translate_mse :
   env -> ModPath.t option -> inline -> module_struct_entry ->
-    module_alg_expr translation
+    (Constr.t * Univ.AbstractContext.t option) module_alg_expr translation
 
 (** From an already-translated (or interactive) implementation and
     an (optional) signature entry, produces a final [module_body] *)

--- a/vernac/declaremods.mli
+++ b/vernac/declaremods.mli
@@ -125,4 +125,4 @@ val debug_print_modtab : unit -> Pp.t
     bound module hasn't an atomic type. *)
 
 val process_module_binding :
-  MBId.t -> Declarations.module_alg_expr -> unit
+  MBId.t -> (Constr.t * Univ.AbstractContext.t option) Declarations.module_alg_expr -> unit


### PR DESCRIPTION
For #15409, we need a module internalization phase that does not require term typing.

This PR splits this internalization in two phases.