### PR TITLE
Concentrate the Clenv code in Equality.

### DIFF
--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1355,13 +1355,9 @@ let meta_reassign mv (v, pb) evd =
 
 let clear_metas evd = {evd with metas = Metamap.empty}
 
-let meta_merge ?(with_univs = true) evd1 evd2 =
+let meta_merge evd1 evd2 =
   let metas = Metamap.fold Metamap.add evd1.metas evd2.metas in
-  let universes =
-    if with_univs then UState.union evd2.universes evd1.universes
-    else evd2.universes
-  in
-  {evd2 with universes; metas; }
+  { evd2 with metas }
 
 type metabinding = metavariable * constr * instance_status
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -574,7 +574,7 @@ val meta_reassign  : metavariable -> econstr * instance_status -> evar_map -> ev
 val clear_metas : evar_map -> evar_map
 
 (** [meta_merge evd1 evd2] returns [evd2] extended with the metas of [evd1] *)
-val meta_merge : ?with_univs:bool -> evar_map -> evar_map -> evar_map
+val meta_merge : evar_map -> evar_map -> evar_map
 
 val undefined_metas : evar_map -> metavariable list
 val map_metas_fvalue : (econstr -> econstr) -> evar_map -> evar_map

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -2083,7 +2083,8 @@ let w_unify_to_subterm_all env evd ?(flags=default_unify_flags ()) (op,cl) =
   match res with
   | [] ->
     raise (PretypeError (env,evd,NoOccurrenceFound (op, None)))
-  | _ -> res
+  | _ ->
+    List.map fst res
 
 let w_unify_to_subterm_list env evd flags hdmeta oplist t =
   List.fold_right

--- a/pretyping/unification.mli
+++ b/pretyping/unification.mli
@@ -58,7 +58,7 @@ val w_unify_to_subterm :
   env -> evar_map -> ?flags:unify_flags -> constr * constr -> evar_map * constr
 
 val w_unify_to_subterm_all :
-  env -> evar_map -> ?flags:unify_flags -> constr * constr -> (evar_map * constr) list
+  env -> evar_map -> ?flags:unify_flags -> constr * constr -> evar_map list
 
 val w_unify_meta_types : env -> ?flags:unify_flags -> evar_map -> evar_map
 

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -422,9 +422,9 @@ let clenv_instantiate ?(flags=fchain_flags ()) mv clenv (c, ty) =
   let clenv = clenv_unify ~flags CUMUL ty (clenv_meta_type clenv mv) clenv in
   clenv_assign mv c clenv
 
-let clenv_fchain ?with_univs ?(flags=fchain_flags ()) mv clenv nextclenv =
+let clenv_fchain ?(flags=fchain_flags ()) mv clenv nextclenv =
   (* Add the metavars of [nextclenv] to [clenv], with their name-environment *)
-  let evd = meta_merge ?with_univs nextclenv.evd clenv.evd in
+  let evd = meta_merge nextclenv.evd clenv.evd in
   let clenv' =
     { templval = clenv.templval;
       templtyp = clenv.templtyp;

--- a/proofs/clenv.mli
+++ b/proofs/clenv.mli
@@ -52,7 +52,7 @@ val mk_clenv_from_n : env -> evar_map -> int -> EConstr.constr * EConstr.types -
 val clenv_instantiate : ?flags:unify_flags -> metavariable -> clausenv -> (constr * types) -> clausenv
 
 val clenv_fchain :
-  ?with_univs:bool -> ?flags:unify_flags -> metavariable -> clausenv -> clausenv -> clausenv
+  ?flags:unify_flags -> metavariable -> clausenv -> clausenv -> clausenv
 
 (** {6 Unification with clenvs } *)
 

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -259,9 +259,10 @@ let general_elim_clause with_evars frzevars tac cls c t l l2r elim =
       (* we would have to take the clenv_value *)
       let newevars = lazy (Evarutil.undefined_evars_of_term sigma (Clenv.clenv_type rew)) in
       let flags = make_flags frzevars sigma flags newevars in
-      general_elim_clause with_evars flags cls rew elim
+      general_elim_clause with_evars flags cls (Clenv.clenv_value rew, Clenv.clenv_type rew) elim
       end
     in
+    Proofview.Unsafe.tclEVARS rew.Clenv.evd <*>
     elim_wrapper cls rewrite_elim
   in
   let strat, tac =
@@ -286,15 +287,10 @@ let general_elim_clause with_evars frzevars tac cls c t l l2r elim =
     let try_clause evd' =
       let clenv = Clenv.update_clenv_evd eqclause evd' in
       let clenv = Clenv.clenv_pose_dependent_evars ~with_evars:true clenv in
-      side_tac
-        (tclTHEN
-          (Proofview.Unsafe.tclEVARS clenv.Clenv.evd)
-          (general_elim_clause0 clenv))
-        tac
+      side_tac (general_elim_clause0 clenv) tac
     in
     match strat with
     | Naive ->
-      Proofview.Unsafe.tclEVARS eqclause.Clenv.evd <*>
       side_tac (general_elim_clause0 eqclause) tac
     | FirstSolved ->
       let flags = make_flags frzevars sigma rewrite_unif_flags (lazy Evar.Set.empty) in

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -143,7 +143,7 @@ let instantiate_lemma_all frzevars gl c ty l l2r concl =
   let () = if arglen < 2 then user_err Pp.(str "The term provided is not an applied relation.") in
   let c1 = args.(arglen - 2) in
   let c2 = args.(arglen - 1) in
-  let try_occ (evd', c') =
+  let try_occ evd' =
     let clenv = Clenv.update_clenv_evd eqclause evd' in
     Clenv.clenv_pose_dependent_evars ~with_evars:true clenv
   in

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1531,7 +1531,7 @@ let general_elim_clause with_evars flags where (c, ty) elim =
        | _  -> error IllFormedEliminationType)
   in
   (* Assumes that the metas of [c] are part of [sigma] already *)
-  let elimclause = Clenv.update_clenv_evd elimclause (meta_merge ~with_univs:false sigma elimclause.Clenv.evd) in
+  let elimclause = Clenv.update_clenv_evd elimclause (meta_merge sigma elimclause.Clenv.evd) in
   match where with
   | None ->
     let elimclause = clenv_instantiate ~flags indmv elimclause (c, ty) in
@@ -1553,7 +1553,7 @@ let general_elim with_evars clear_flag (c, lbindc) elim =
   let ct = Retyping.get_type_of env sigma c in
   let t = try snd (reduce_to_quantified_ind env sigma ct) with UserError _ -> ct in
   let indclause  = make_clenv_binding env sigma (c, t) lbindc in
-  let sigma = meta_merge ~with_univs:false sigma indclause.evd in
+  let sigma = meta_merge sigma indclause.evd in
   let flags = elim_flags () in
   Proofview.Unsafe.tclEVARS sigma <*>
   Tacticals.tclTHEN
@@ -1886,7 +1886,7 @@ let progress_with_clause flags (id, t) clause mvs =
   if List.is_empty mvs then raise UnableToApply;
   let f mv =
     let rec find innerclause =
-      try Some (clenv_fchain ~with_univs:false mv ~flags clause innerclause)
+      try Some (clenv_fchain mv ~flags clause innerclause)
       with e when noncritical e ->
       match clenv_push_prod innerclause with
       | Some (_, _, innerclause) -> find innerclause

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -13,7 +13,6 @@ open Constr
 open EConstr
 open Environ
 open Evd
-open Clenv
 open Redexpr
 open Pattern
 open Unification
@@ -284,7 +283,7 @@ val general_elim  : evars_flag -> clear_flag ->
   constr with_bindings -> eliminator -> unit Proofview.tactic
 
 val general_elim_clause : evars_flag -> unify_flags -> Id.t option ->
-  clausenv -> eliminator -> unit Proofview.tactic
+  (EConstr.t * EConstr.t) -> eliminator -> unit Proofview.tactic
 
 val default_elim  : evars_flag -> clear_flag -> constr with_bindings ->
   unit Proofview.tactic

--- a/test-suite/bugs/bug_15501.v
+++ b/test-suite/bugs/bug_15501.v
@@ -1,0 +1,13 @@
+Axiom word : nat -> Set.
+Axiom wones : forall (sz : nat), word sz.
+
+Axiom combine : forall (sz1 : nat) (w : word sz1), forall sz2, word sz2 -> word (sz1 + sz2).
+Axiom split1 : forall (sz1 sz2 : nat), word (sz1 + sz2) -> word sz1.
+Axiom bitwp : forall (f : bool -> bool -> bool) sz (w1 : word sz), word sz -> word sz.
+Axiom split1_combine : forall sz1 sz2 (w : word sz1) (z : word sz2), split1 sz1 sz2 (combine _ w _ z) = w.
+
+Theorem wnot_split1 : forall sz1 sz2 w w', w' = split1 sz1 sz2 (bitwp xorb _ (wones (sz1 + sz2)) w).
+Proof.
+intros.
+erewrite <- split1_combine with (w := wones _).
+Abort.


### PR DESCRIPTION
This PR makes it easier to track the use of clausenvs in the Equality module. The various parts using them have been brought closer together and some invariants are now clearer from the code.