### PR TITLE
Implement our own cache for is_ground_env in Evarconv.

### DIFF
--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -117,17 +117,6 @@ let is_ground_env evd env =
   List.for_all is_ground_rel_decl (rel_context env) &&
   List.for_all is_ground_named_decl (named_context env)
 
-(* Memoization is safe since evar_map and environ are applicative
-   structures *)
-let memo f =
-  let module E = Ephemeron.K2 in
-  let m = E.create () in
-  fun x y -> match E.get_key1 m, E.get_key2 m with
-  | Some x', Some y' when x == x' && y == y' -> Option.get (E.get_data m)
-  | _ -> let r = f x y in E.set_key1 m x; E.set_key2 m y; E.set_data m r; r
-
-let is_ground_env = memo is_ground_env
-
 (* Return the head evar if any *)
 
 exception NoHeadEvar

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -541,6 +541,17 @@ let conv_fun f flags on_types =
     | TypeUnification -> typefn
     | TermUnification -> termfn
 
+let evar_conv_x flags env evd pbty term1 term2 =
+
+let cache = ref None in
+let is_ground_env env sigma = match !cache with
+| Some (sigma', env', v) when sigma == sigma' && env == env' -> v
+| None | Some _ ->
+  let v = is_ground_env env sigma in
+  let () = cache := Some (sigma, env, v) in
+  v
+in
+
 let rec evar_conv_x flags env evd pbty term1 term2 =
   let term1 = whd_head_evar evd term1 in
   let term2 = whd_head_evar evd term2 in
@@ -1223,6 +1234,8 @@ and eta_constructor flags env evd ((ind, i), u) sk1 (term2,sk2) =
            UnifFailure(evd,NotSameHead))
       end
     | _ -> UnifFailure (evd,NotSameHead)
+in
+evar_conv_x flags env evd pbty term1 term2
 
 let evar_conv_x flags = evar_conv_x flags
 

--- a/pretyping/evarconv.mli
+++ b/pretyping/evarconv.mli
@@ -135,11 +135,6 @@ val evar_unify : Evarsolve.unifier
 
 (**/**)
 (* For debugging *)
-val evar_eqappr_x : ?rhs_is_already_stuck:bool -> unify_flags ->
-  env -> evar_map ->
-    conv_pb -> state -> state ->
-      Evarsolve.unification_result
-
 val occur_rigidly : Evarsolve.unify_flags ->
   'a -> Evd.evar_map -> Evar.t * 'b -> EConstr.t -> bool
 (**/**)


### PR DESCRIPTION
We remove the one from Evarutil since it relies on a deprecated OCaml API. Alternative to #15492.