### PR TITLE
Legacy build: remove nonsense `byte` target and noop `install-byte`

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -34,7 +34,6 @@ jobs:
         run: |
           eval $(opam env)
           ./configure -prefix "$(pwd)/_install_ci" -warn-error yes -native-compiler no -coqide opt
-          make -j "$NJOBS" byte
           make -j "$NJOBS"
         env:
           MACOSX_DEPLOYMENT_TARGET: "10.11"
@@ -43,7 +42,7 @@ jobs:
       - name: Install Coq
         run: |
           eval $(opam env)
-          make install install-byte
+          make install
 
       - name: Run Coq Test Suite
         run: |

--- a/Makefile.build
+++ b/Makefile.build
@@ -73,7 +73,7 @@ NJOBS ?= 2
 
 .PHONY: NOARG
 
-NOARG: world byte
+NOARG: world
 
 include Makefile.common
 include Makefile.vofiles
@@ -86,14 +86,13 @@ include Makefile.dev
 # Default starting rule
 ###########################################################################
 
-.PHONY: world byte coq world.timing.diff coq.timing.diff states
+.PHONY: world coq world.timing.diff coq.timing.diff states
 
 world: coq documentation revision
 ifneq ($(HASCOQIDE),no)
 world: coqide
 endif
 
-byte: world
 coq: coqlib coqbinaries tools $(BCONTEXT)/coq-core.install $(BCONTEXT)/coqide-server.install
 
 world.timing.diff: coq.timing.diff

--- a/Makefile.install
+++ b/Makefile.install
@@ -27,9 +27,8 @@ endif
 
 install-doc-all: install-doc
 install-doc-no:
-install-byte:
 
-.PHONY: install install-byte install-coqide install-doc-all install-doc-no
+.PHONY: install install-coqide install-doc-all install-doc-no
 
 INSTALLLIB:=install -m 644
 

--- a/Makefile.make
+++ b/Makefile.make
@@ -78,7 +78,7 @@ endef
 
 .DEFAULT_GOAL:=NOARG
 
-NOARG: world byte
+NOARG: world
 
 include Makefile.common
 

--- a/coq.opam.docker
+++ b/coq.opam.docker
@@ -40,5 +40,4 @@ build: [
 ]
 install: [
   [make "install"]
-  [make "install-byte"]
 ]

--- a/default.nix
+++ b/default.nix
@@ -90,10 +90,10 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  buildFlags = [ "world" "byte" ] ++ optional buildDoc "doc-html";
+  buildFlags = [ "world" ] ++ optional buildDoc "doc-html";
 
   installTargets =
-    [ "install" "install-byte" ] ++ optional buildDoc "install-doc-html";
+    [ "install" ] ++ optional buildDoc "install-doc-html";
 
   createFindlibDestdir = !shell;
 


### PR DESCRIPTION
`byte` was equivalent to `world`

Close #14658