### PR TITLE
Make the transparent state of setoid_rewrite through rewrite configurable

### DIFF
--- a/theories/Init/Tactics.v
+++ b/theories/Init/Tactics.v
@@ -347,7 +347,22 @@ Tactic Notation "assert_succeeds" tactic3(tac) :=
 Tactic Notation "assert_fails" tactic3(tac) :=
   assert_fails tac.
 
+(** Standard library databases *)
+
+(** The global typeclass instances database. *)
+Create HintDb typeclass_instances discriminated.
+
+(** This hint database's transparent state controls
+  the delta-reduction happening during subterm selection in
+  setoid-rewrite. *)
 Create HintDb rewrite discriminated.
 #[global]
 Hint Variables Opaque : rewrite.
-Create HintDb typeclass_instances discriminated.
+
+(** This hint database's transparent state controls
+  the delta-reduction happening during subterm selection in
+  setoid-rewrite called through rewrite *on closed terms* only.
+  No delta-reduction is used on open terms. *)
+Create HintDb rewrite_conv discriminated.
+#[global]
+Hint Variables Opaque : rewrite_conv.


### PR DESCRIPTION
This declares a new `rewrite_conv` hint database in Init/Tactics.v that can be user-configured to control the amount of delta-reduction that can be performed during unification (subterm selection) of setoid-rewrite called through the rewrite tactic. Note that this configuration applies only when unification faces unification problems that are evar-free and hence calls conversion, no delta reduction is allowed otherwise during these unifications. This PR should be entirely backwards compatible, it just makes this transparent state configurable by the user. Changing the default might help speed up user developments significantly. 

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
