### PR TITLE
[CI] [flocq] Also install glob files

### DIFF
--- a/dev/ci/ci-flocq.sh
+++ b/dev/ci/ci-flocq.sh
@@ -15,5 +15,5 @@ if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
       ./configure COQEXTRAFLAGS="-compat 8.13";
   fi
   ./remake "-j${NJOBS}"
-  ./remake install
+  ./remake install install-glob
 )


### PR DESCRIPTION
This is required to minimize CI jobs that depend on flocq.  Otherwise
the minimization is incomplete as in
https://github.com/coq/coq/pull/15501#issuecomment-1015412511

Fixes #15074