### PR TITLE
Granting wish part of #15497: link the source file loaded by "Load" in coqdoc when this file is referred by qualid

### DIFF
--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -479,19 +479,21 @@ toplevel. This kind of file is called a *script* for Coq. The standard
 (and default) extension of Coq’s script files is .v.
 
 
-.. cmd:: Load {? Verbose } {| @string | @ident }
+.. cmd:: Load {? Verbose } {| @string | @qualid }
 
-   Loads a file.  If :n:`@ident` is specified, the command loads a file
-   named :n:`@ident.v`, searching successively in
-   each of the directories specified in the *loadpath*. (see Section
-   :ref:`libraries-and-filesystem`)
+   Executes the commands of a file in the current context.
+
+   If :n:`@qualid` is specified, :n:`Load` searches
+   in the *loadpath* (see Section :ref:`libraries-and-filesystem`)
+   for a file with suffix :n:`.v` whose logical name is :n:`@qualid`.
 
    If :n:`@string` is specified, it must specify a complete filename.
    `~` and .. abbreviations are
    allowed as well as shell variables. If no extension is specified, Coq
-   will use the default extension ``.v``.
+   will use the default extension ``.v``. If the filename is relative,
+   it is searched in the loadpath, ignoring the logical part.
 
-   Files loaded this way can't leave proofs open, nor can :cmd:`Load`
+   Files included this way can't leave proofs open, nor can :cmd:`Load`
    be used inside a proof.
 
    We discourage the use of :cmd:`Load`; use :cmd:`Require` instead.
@@ -501,7 +503,7 @@ toplevel. This kind of file is called a *script* for Coq. The standard
    :n:`Verbose` displays the Coq output for each command and tactic
    in the loaded file, as if the commands and tactics were entered interactively.
 
-   .. exn:: Can’t find file @ident on loadpath.
+   .. exn:: Can’t find file @qualid on loadpath.
       :undocumented:
 
    .. exn:: Load is not supported inside proofs.

--- a/test-suite/misc/15497.sh
+++ b/test-suite/misc/15497.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+export COQBIN=$BIN
+export PATH=$COQBIN:$PATH
+
+(cd misc/15497; coq_makefile -R . Top A.v B.v -o Makefile; make all html)
+diff -u --strip-trailing-cr misc/15497/B.glob.out misc/15497/B.glob
+R=$?
+if [ $R == 0 ]; then
+  exit 0
+else
+  exit 1
+fi
+

--- a/test-suite/misc/15497/A.v
+++ b/test-suite/misc/15497/A.v
@@ -1,0 +1,2 @@
+Require Import Init.
+Require Import Init.

--- a/test-suite/misc/15497/B.glob.out
+++ b/test-suite/misc/15497/B.glob.out
@@ -1,0 +1,6 @@
+DIGEST 4f20981d9fdb7f179fb549820cab8dea
+FTop.B
+R15:18 Coq.Classes.Init <> <> lib
+R64:67 Coq.Classes.Init <> <> lib
+R75:75 Top.A <> <> lib
+R84:86 Coq.Init.Datatypes <> nat ind

--- a/test-suite/misc/15497/B.v
+++ b/test-suite/misc/15497/B.v
@@ -1,0 +1,4 @@
+Require Import Init. Local Open Scope nat_scope.
+Require Import Init.
+Load A.
+Check nat.

--- a/tools/coqdep_common.ml
+++ b/tools/coqdep_common.ml
@@ -379,9 +379,12 @@ let rec find_dependencies basename =
             let canon =
               match file with
               | Logical str ->
-                if should_visit_v_and_mark None [str] then safe_assoc None verbose f [str]
+                if should_visit_v_and_mark None str then
+                  Option.map (List.map canonize) (safe_assoc None verbose f str)
                 else None
               | Physical str ->
+                (* TODO: look in the physical part of the path even
+                   when str contains "/", as coqc does *)
                 if String.equal (Filename.basename str) str then
                   if should_visit_v_and_mark None [str] then safe_assoc None verbose f [str]
                   else None

--- a/tools/coqdep_lexer.mli
+++ b/tools/coqdep_lexer.mli
@@ -10,7 +10,7 @@
 
 type qualid = string list
 
-type load = Logical of string | Physical of string
+type load = Logical of qualid | Physical of string
 
 type coq_token =
   | Require of qualid option * qualid list

--- a/tools/coqdep_lexer.mll
+++ b/tools/coqdep_lexer.mll
@@ -15,7 +15,7 @@
 
   type qualid = string list
 
-  type load = Logical of string | Physical of string
+  type load = Logical of qualid | Physical of string
 
   type coq_token =
     | Require of qualid option * qualid list
@@ -174,7 +174,9 @@ and load_file = parse
 	parse_dot lexbuf;
         Load (Physical (unquote_vfile_string s)) }
   | coq_ident
-      { let s = get_ident lexbuf in skip_to_dot lexbuf; Load (Logical s) }
+      { let name = coq_qual_id_tail [get_ident lexbuf] lexbuf in
+        parse_dot lexbuf;
+        Load (Logical name) }
   | eof
       { syntax_error lexbuf }
   | _
@@ -203,6 +205,8 @@ and skip_to_dot = parse
   | _   { skip_to_dot lexbuf }
 
 and parse_dot = parse
+  | "(*"
+      { comment lexbuf; parse_dot lexbuf }
   | dot { () }
   | eof { syntax_error lexbuf }
   | _ { syntax_error lexbuf }

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -914,7 +914,7 @@ GRAMMAR EXTEND Gram
       | IDENT "Cd"; dir = ne_string -> { VernacChdir (Some dir) }
 
       | IDENT "Load"; verbosely = [ IDENT "Verbose" -> { true } | -> { false } ];
-        s = [ s = ne_string -> { s } | s = IDENT -> { s } ] ->
+        s = [ s = ne_lstring -> { LoadByFilename s } | qid = global -> { LoadByQualid qid } ] ->
           { VernacLoad (verbosely, s) }
       | IDENT "Declare"; IDENT "ML"; IDENT "Module"; l = LIST1 ne_string ->
           { VernacDeclareMLModule l }

--- a/vernac/loadpath.mli
+++ b/vernac/loadpath.mli
@@ -52,10 +52,19 @@ type library_location = LibLoaded | LibInPath
 type locate_error = LibUnmappedDir | LibNotFound
 type 'a locate_result = ('a, locate_error) result
 
-val locate_qualified_library
+val try_locate_qualified_library_status
   :  ?root:DirPath.t
   -> Libnames.qualid
-  -> (library_location * DirPath.t * CUnix.physical_path) locate_result
+  -> library_location * DirPath.t * CUnix.physical_path
+
+val try_locate_qualified_library
+  :  ?root:DirPath.t
+  -> Libnames.qualid
+  -> DirPath.t * CUnix.physical_path
+
+val try_locate_qualified_library_source
+  :  Libnames.qualid
+  -> DirPath.t * CUnix.physical_path
 
 (** Locates a library by implicit name.
 

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -678,11 +678,9 @@ let pr_vernac_expr v =
   match v with
   | VernacLoad (f,s) ->
     return (
-      keyword "Load"
-      ++ if f then
-        (spc() ++ keyword "Verbose" ++ spc())
-      else
-        spc() ++ qs s
+      keyword "Load" ++ spc() ++
+      (if f then keyword "Verbose" ++ spc() else mt()) ++
+      (match s with LoadByQualid qid -> pr_qualid qid | LoadByFilename s -> qs s.CAst.v)
     )
 
   (* Proof management *)

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -316,9 +316,13 @@ type hints_expr =
   | HintsConstructors of Libnames.qualid list
   | HintsExtern of int * Constrexpr.constr_expr option * Genarg.raw_generic_argument
 
+type load_name =
+  | LoadByQualid of qualid
+  | LoadByFilename of lstring
+
 type nonrec vernac_expr =
 
-  | VernacLoad of verbose_flag * string
+  | VernacLoad of verbose_flag * load_name
   (* Syntax *)
   | VernacReservedNotation of infix_flag * (lstring * syntax_modifier CAst.t list)
   | VernacOpenCloseScope of bool * scope_name

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -195,7 +195,9 @@ and vernac_load ~verbosely fname =
       let stack, pm = v_mod (interp_control ~st:{ st with Vernacstate.lemmas = stack; program = pm }) stm in
       (load_loop [@ocaml.tailcall]) ~stack ~pm
   in
+  let () = Dumpglob.(push_output NoGlob) in
   let stack, pm = load_loop ~pm:st.Vernacstate.program ~stack:st.Vernacstate.lemmas in
+  let () = Dumpglob.pop_output () in
   (* If Load left a proof open, we fail too. *)
   if Option.has_some stack then
     CErrors.user_err Pp.(str "Files processed by Load cannot leave open proofs.");

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -173,6 +173,7 @@ and vernac_load ~verbosely fname =
       match fname with
         | LoadByQualid qid ->
           let dp, longfname = Loadpath.try_locate_qualified_library_source qid in
+          Dumpglob.dump_libref ?loc:qid.CAst.loc dp "lib";
           longfname
         | LoadByFilename (CAst.{v=fname}) ->
           let fname =


### PR DESCRIPTION
**Kind:** enhancement

Depends on #15511 and #15512.

Closes #15497 (wish part)

For each `Load qualid.` line in a file, we add a line of the form `Rloc1:loc2 fullqualid <> <> lib` in the glob file so that it is hyperlinked by coqdoc.

- [x] Added / updated **test-suite**.
- [ ] Added **changelog**.