### PR TITLE
[experiment] typeclasses caching

### DIFF
--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -763,7 +763,7 @@ module Search = struct
                   str "Goal " ++ int glid ++ str" has no more solutions, returning exception: "
                   ++ CErrors.iprint (e, info))
               in
-              if not progress then
+              if not progress && not (e == ReachedLimit) then
                 tclENV >>= fun env ->
                 tclEVARMAP >>= fun sigma ->
                 let cache = cache_goal env sigma ev cache (Failure (e, info)) in

--- a/test-suite/success/Typeclasses.v
+++ b/test-suite/success/Typeclasses.v
@@ -20,7 +20,7 @@ Module Cache.
   Proof.
     intros. split.
     all:typeclasses eauto.
-
+  Qed.
 
 End Cache.
 

--- a/test-suite/success/Typeclasses.v
+++ b/test-suite/success/Typeclasses.v
@@ -1,3 +1,31 @@
+Module Cache.
+  Class A (X : Type) := {}.
+
+  Parameter foo : forall {T} {x y : A T}, True.
+  Set Typeclasses Debug Verbosity 1.
+
+  Goal forall x : A nat, True.
+    intros.
+    unshelve eapply foo.
+  Qed.
+
+  Class B (X : Type) := {}.
+
+  Class C (X : Type) := {}.
+
+  Local Instance ac : forall {X}, C X -> A X := {}.
+  Local Instance ab : forall {X}, B X -> A X := {}.
+
+  Example cache_failure : C nat -> A nat * A nat.
+  Proof.
+    intros. split.
+    all:typeclasses eauto.
+
+
+End Cache.
+
+
+
 (* coq-prog-args: ("-async-proofs" "off") *)
 Module applydestruct.
   Class Foo (A : Type) :=
@@ -301,6 +329,7 @@ Module IterativeDeepening.
     Fail Timeout 1 typeclasses eauto.
     Set Typeclasses Iterative Deepening.
     Fail typeclasses eauto 1.
+    Set Typeclasses Debug.
     typeclasses eauto 2.
     Undo.
     Unset Typeclasses Iterative Deepening.


### PR DESCRIPTION
This is an experiment to cache failures and successes during typeclass resolution.
This currently applies only to evar-free goals, and the maintainance of the cache throughout resolution is not perfect.
I'm mainly curious to see if this has an impact and if it's worth pursuing further.

- [ ] Added / updated **test-suite**

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
