### PR TITLE
Support for inductive with defined parameters in native_compute

### DIFF
--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -103,7 +103,7 @@ let mis_is_recursive (ind,mib,mip) =
   mis_is_recursive_subset (List.interval 0 (mib.mind_ntypes - 1))
     mip.mind_recargs
 
-let mis_nf_constructor_type ((ind,u),mib,mip) j =
+let mis_nf_constructor_type ((_,j),u) (mib,mip) =
   let nconstr = Array.length mip.mind_consnames in
   if j > nconstr then user_err Pp.(str "Not enough constructors in the type.");
   let (ctx, cty) = mip.mind_nf_lc.(j - 1) in
@@ -318,11 +318,14 @@ let instantiate_params t params sign =
   let subst = subst_of_rel_context_instance_list sign params in
   substl subst t
 
-let get_constructor ((ind,u as indu),mib,mip,params) j =
-  assert (j <= Array.length mip.mind_consnames);
-  let typi = mis_nf_constructor_type (indu,mib,mip) j in
+let instantiate_constructor_params (_,u as cstru) (mib,_ as mind_specif) params =
+  let typi = mis_nf_constructor_type cstru mind_specif in
   let ctx = Vars.subst_instance_context u mib.mind_params_ctxt in
-  let typi = instantiate_params typi params ctx in
+  instantiate_params typi params ctx
+
+let get_constructor ((ind,u),mib,mip,params) j =
+  assert (j <= Array.length mip.mind_consnames);
+  let typi = instantiate_constructor_params ((ind,j),u) (mib,mip) params in
   let (args,ccl) = decompose_prod_assum typi in
   let (_,allargs) = decompose_app ccl in
   let vargs = List.skipn (List.length params) allargs in

--- a/pretyping/inductiveops.mli
+++ b/pretyping/inductiveops.mli
@@ -57,7 +57,7 @@ val mis_is_recursive_subset : int list -> wf_paths -> bool
 val mis_is_recursive :
   inductive * mutual_inductive_body * one_inductive_body -> bool
 val mis_nf_constructor_type :
-  pinductive * mutual_inductive_body * one_inductive_body -> int -> constr
+  pconstructor -> mutual_inductive_body * one_inductive_body -> constr
 
 (** {6 Extract information from an inductive name} *)
 
@@ -191,6 +191,10 @@ val find_mrectype_vect : env -> evar_map -> EConstr.types -> (inductive * EConst
 val find_rectype     : env -> evar_map -> EConstr.types -> inductive_type
 val find_inductive   : env -> evar_map -> EConstr.types -> (inductive * EConstr.EInstance.t) * constr list
 val find_coinductive : env -> evar_map -> EConstr.types -> (inductive * EConstr.EInstance.t) * constr list
+
+(** [instantiate_constructor_params cstr mind params] instantiates the
+    type of the given constructor with parameters [params] *)
+val instantiate_constructor_params : pconstructor -> Inductive.mind_specif -> constr list -> constr
 
 (********************)
 

--- a/test-suite/success/nativecompute.v
+++ b/test-suite/success/nativecompute.v
@@ -1,0 +1,5 @@
+(* An example with local definitions *)
+
+Inductive I (a:=0) (b:nat) (c:=1) := C : I b.
+
+Eval native_compute in (fun x => C) 0.


### PR DESCRIPTION
**Kind:** Mini-fix

The interest for local definitions in parameters is not very clear in practice,  but, from an implementation point of view, it is still easier to generically treat parameters as contexts, thus possibly including let-ins.

This PR adds supports for let-ins in parameters for `native_compute`.

It is part of a general double-check at the uses of `decompose_prod_n` and variants in the implementation, following a remark from @mattam82 at [#15453](https://github.com/coq/coq/pull/15453#discussion_r786644710).

- [x] Added / updated **test-suite**.
