### PR TITLE
Make Scheme Equality compatible with universe polymorphism

### DIFF
--- a/engine/termops.mli
+++ b/engine/termops.mli
@@ -214,6 +214,7 @@ val names_of_rel_context : env -> names_context
    [n] hypotheses, excluding local definitions, and [Γ₁], if not empty,
    starts with an hypothesis (i.e. [Γ₁] has the form empty or [x:A;Γ₁'] *)
 val context_chop : int -> Constr.rel_context -> Constr.rel_context * Constr.rel_context
+  [@@ocaml.deprecated "Use synonymous [Context.Rel.chop_nhyps]."]
 
 (* [env_rel_context_chop n env] extracts out the [n] top declarations
    of the rel_context part of [env], counting both local definitions and

--- a/kernel/context.ml
+++ b/kernel/context.ml
@@ -256,6 +256,16 @@ struct
 
   let drop_bodies l = List.Smart.map Declaration.drop_body l
 
+  (** Split a context so that the second part contains [n]
+      [LocalAssum], keeping all [LocalDef] in the middle in the first part *)
+  let chop_nhyps n l =
+    let rec aux l' = function
+      | (0, l) -> (List.rev l', l)
+      | (n, (Declaration.LocalDef _ as h) :: l) -> aux (h::l') (n, l)
+      | (n, (Declaration.LocalAssum _ as h) :: l) -> aux (h::l') (n-1, l)
+      | (_, []) -> CErrors.anomaly (Pp.str "chop_nhyps: not enough hypotheses.")
+    in aux [] (n,l)
+
   (** [extended_list n Γ] builds an instance [args] such that [Γ,Δ ⊢ args:Γ]
       with n = |Δ| and with the {e local definitions} of [Γ] skipped in
       [args]. Example: for [x:T, y:=c, z:U] and [n]=2, it gives [Rel 5, Rel 3]. *)

--- a/kernel/context.mli
+++ b/kernel/context.mli
@@ -169,6 +169,14 @@ sig
   (** Turn all [LocalDef] into [LocalAssum], leave [LocalAssum] unchanged. *)
   val drop_bodies : ('c, 't) pt -> ('c, 't) pt
 
+  (** [chop_nhyps n Γ] returns [Γ'',Γ'] such that [Γ]=[Γ'Γ''], [Γ''] has
+      [n] hypotheses (i.e. [LocalAssum]), excluding local definitions
+      (i.e. [LocalDef]), and [Γ''], if [n] non zero, starts with an
+      hypothesis (i.e., [Γ''] has the form [x:A;Γ'''], i.e., local
+      definitions at the junction of the [n] hypotheses are put in
+      [Γ'] rather than in [Γ''] *)
+  val chop_nhyps : int -> ('c, 't) pt -> ('c, 't) pt * ('c, 't) pt
+
   (** [instance mk n Γ] builds an instance [args] such that [Γ,Δ ⊢ args:Γ]
       with n = |Δ| and with the {e local definitions} of [Γ] skipped in
       [args] where [mk] is used to build the corresponding variables.

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -55,6 +55,11 @@ let inductive_params (mib,_) = mib.mind_nparams
 let inductive_paramdecls (mib,u) =
   Vars.subst_instance_context u mib.mind_params_ctxt
 
+let inductive_nonrec_rec_paramdecls (mib,u) =
+  let nnonrecparamdecls = mib.mind_nparams - mib.mind_nparams_rec in
+  let paramdecls = inductive_paramdecls (mib,u) in
+  Context.Rel.chop_nhyps nnonrecparamdecls paramdecls
+
 let instantiate_inductive_constraints mib u =
   Univ.AbstractContext.instantiate u (Declareops.inductive_polymorphic_context mib)
 

--- a/kernel/inductive.mli
+++ b/kernel/inductive.mli
@@ -34,7 +34,14 @@ type mind_specif = mutual_inductive_body * one_inductive_body
 val lookup_mind_specif : env -> inductive -> mind_specif
 
 (** {6 Functions to build standard types related to inductive } *)
+
+(** Returns the parameters of an inductive type with universes instantiated *)
 val inductive_paramdecls : mutual_inductive_body puniverses -> Constr.rel_context
+
+(** Returns the parameters of an inductive type with universes
+    instantiated, splitting it into the contexts of recursively
+    uniform and recursively non-uniform parameters *)
+val inductive_nonrec_rec_paramdecls : mutual_inductive_body puniverses -> Constr.rel_context * Constr.rel_context
 
 val instantiate_inductive_constraints :
   mutual_inductive_body -> Instance.t -> Constraints.t

--- a/pretyping/indrec.ml
+++ b/pretyping/indrec.ml
@@ -326,8 +326,7 @@ let mis_make_indrec env sigma ?(force_mutual=false) listdepkind mib u =
   let nparams = mib.mind_nparams in
   let nparrec = mib.mind_nparams_rec in
   let evdref = ref sigma in
-  let lnonparrec,lnamesparrec =
-    Termops.context_chop (nparams-nparrec) (Vars.subst_instance_context u mib.mind_params_ctxt) in
+  let lnonparrec,lnamesparrec = Inductive.inductive_nonrec_rec_paramdecls (mib,u) in
   let nrec = List.length listdepkind in
   let depPvec =
     Array.make mib.mind_ntypes (None : (bool * constr) option) in

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -313,7 +313,7 @@ let lift_constructor n cs = {
 let instantiate_params t params sign =
   let nnonrecpar = Context.Rel.nhyps sign - List.length params in
   (* Adjust the signature if recursively non-uniform parameters are not here *)
-  let _,sign = context_chop nnonrecpar sign in
+  let _,sign = Context.Rel.chop_nhyps nnonrecpar sign in
   let _,t = decompose_prod_n_assum (Context.Rel.length sign) t in
   let subst = subst_of_rel_context_instance_list sign params in
   substl subst t
@@ -407,13 +407,11 @@ let get_arity env ((ind,u),params) =
        parameters *)
     let nparams = List.length params in
     if Int.equal nparams mib.mind_nparams then
-      mib.mind_params_ctxt
+      Inductive.inductive_paramdecls (mib,u)
     else begin
       assert (Int.equal nparams mib.mind_nparams_rec);
-      let nnonrecparamdecls = mib.mind_nparams - mib.mind_nparams_rec in
-      snd (Termops.context_chop nnonrecparamdecls mib.mind_params_ctxt)
+      snd (Inductive.inductive_nonrec_rec_paramdecls (mib,u))
     end in
-  let parsign = Vars.subst_instance_context u parsign in
   let arproperlength = List.length mip.mind_arity_ctxt - List.length parsign in
   let arsign,_ = List.chop arproperlength mip.mind_arity_ctxt in
   let subst = subst_of_rel_context_instance_list parsign params in

--- a/test-suite/success/SchemeEquality.v
+++ b/test-suite/success/SchemeEquality.v
@@ -27,3 +27,15 @@ Module C.
   Inductive J := D : list A -> J.
   Scheme Equality for J.
 End C.
+
+(* Universe polymorphism *)
+Module D.
+  Set Universe Polymorphism.
+  Inductive prod (A B:Type) := pair : A -> B -> prod A B.
+  Scheme Equality for prod.
+
+  (* With an indirection *)
+  Inductive box A := c : A -> box A.
+  Inductive prodbox (A B:Type) := pairbox : box A -> box B -> prodbox A B.
+  Scheme Equality for prodbox.
+End D.


### PR DESCRIPTION
**Kind:** enhancement/fix

We address the `FIXME` remaining in the code of `Scheme Equality` wrt universe polymorphism support.

Incidentally, we introduce an intermediary level of abstraction for instantiating inductive parameters with universes.

- [x] Added / updated **test-suite**.