### PR TITLE
Adding Scheme Boolean Equality to produce Boolean equality w/o full decidability

### DIFF
--- a/doc/changelog/07-vernac-commands-and-options/15526-master+adding-specific-scheme-boolean-equality.rst
+++ b/doc/changelog/07-vernac-commands-and-options/15526-master+adding-specific-scheme-boolean-equality.rst
@@ -1,0 +1,9 @@
+- **Added:**
+  :cmd:`Scheme Boolean Equality` command to generate the boolean
+  equality for an inductive type whose equality is
+  decidable.  It is useful when Coq is able to generate the boolean
+  equality but isn't powerful enough to prove the decidability of
+  equality (unlike :cmd:`Scheme Equality`, which tries to
+  prove the decidability of the type)
+  (`#15526 <https://github.com/coq/coq/pull/15526>`_,
+  by Hugo Herbelin).

--- a/doc/sphinx/proofs/writing-proofs/reasoning-inductives.rst
+++ b/doc/sphinx/proofs/writing-proofs/reasoning-inductives.rst
@@ -1008,12 +1008,15 @@ Generation of induction principles with ``Scheme``
 
    See examples of the :n:`@scheme_type`\s :ref:`here <scheme_example>`.
 
-.. cmd:: Scheme Equality for @reference
-   :name: Scheme Equality
+.. cmd:: Scheme {? Boolean } Equality for @reference
+   :name: Scheme Equality; Scheme Boolean Equality
 
-   Generates a Boolean equality and a proof of the decidability of the usual
-   equality. If :token:`reference` refers to other inductive types, their
-   equality must already be defined.
+   Tries to generate a Boolean equality for :n:`@reference`. If
+   :n:`Boolean` is not specified, the command also tries to generate
+   a proof of the decidability of propositional equality over
+   :n:`@reference`.
+   If :token:`reference` involves independent constants or other
+   inductive types, we recommend defining their equality first.
 
 .. example:: Induction scheme for tree and forest
 

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -595,6 +595,9 @@ gallina: [
 | WITH "Let" "CoFixpoint" cofix_definition LIST0 ( "with" cofix_definition )
 | REPLACE "Scheme" LIST1 scheme SEP "with"
 | WITH "Scheme" scheme LIST0 ( "with" scheme )
+| DELETE "Scheme" "Boolean" "Equality" "for" smart_global
+| DELETE "Scheme" "Equality" "for" smart_global
+| "Scheme" OPT "Boolean" "Equality" "for" smart_global
 ]
 
 finite_token: [

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -816,6 +816,7 @@ gallina: [
 | "Let" "CoFixpoint" LIST1 cofix_definition SEP "with"
 | "Scheme" LIST1 scheme SEP "with"
 | "Scheme" "Equality" "for" smart_global
+| "Scheme" "Boolean" "Equality" "for" smart_global
 | "Combined" "Scheme" identref "from" LIST1 identref SEP ","
 | "Register" global "as" qualid
 | "Register" "Inline" global

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1051,7 +1051,7 @@ command: [
 | "CoFixpoint" cofix_definition LIST0 ( "with" cofix_definition )
 | "Let" "CoFixpoint" cofix_definition LIST0 ( "with" cofix_definition )
 | "Scheme" OPT ( ident ":=" ) scheme_kind LIST0 ( "with" OPT ( ident ":=" ) scheme_kind )
-| "Scheme" "Equality" "for" reference
+| "Scheme" OPT "Boolean" "Equality" "for" reference
 | "Combined" "Scheme" ident "from" LIST1 ident SEP ","
 | "Register" qualid "as" qualid
 | "Register" "Inline" qualid

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -242,7 +242,10 @@ GRAMMAR EXTEND Gram
       | IDENT "Let"; "CoFixpoint"; corecs = LIST1 cofix_definition SEP "with" ->
           { VernacCoFixpoint (DoDischarge, corecs) }
       | IDENT "Scheme"; l = LIST1 scheme SEP "with" -> { VernacScheme l }
-      | IDENT "Scheme"; IDENT "Equality"; IDENT "for" ; id = smart_global -> { VernacSchemeEquality id }
+      | IDENT "Scheme"; IDENT "Equality"; IDENT "for" ; id = smart_global ->
+          { VernacSchemeEquality (SchemeEquality,id) }
+      | IDENT "Scheme"; IDENT "Boolean"; IDENT "Equality"; IDENT "for" ; id = smart_global ->
+          { VernacSchemeEquality (SchemeBooleanEquality,id) }
       | IDENT "Combined"; IDENT "Scheme"; id = identref; IDENT "from";
               l = LIST1 identref SEP "," -> { VernacCombinedScheme (id, l) }
       | IDENT "Register"; g = global; "as"; quid = qualid ->

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -400,10 +400,11 @@ let do_scheme env l =
   let lnamedepindsort = name_and_process_schemes env l in
   do_mutual_induction_scheme env lnamedepindsort
 
-let do_scheme_equality id =
+let do_scheme_equality sch id =
   let mind,_ = Smartlocate.smart_global_inductive id in
+  let dec = match sch with SchemeBooleanEquality -> false | SchemeEquality -> true in
   declare_beq_scheme mind;
-  declare_eq_decidability mind
+  if dec then declare_eq_decidability mind
 
 (**********************************************************************)
 (* Combined scheme *)

--- a/vernac/indschemes.mli
+++ b/vernac/indschemes.mli
@@ -51,7 +51,7 @@ val do_scheme : Environ.env -> (Names.Id.t CAst.t option * Vernacexpr.scheme) li
 
 (** Main call to Scheme Equality command *)
 
-val do_scheme_equality : Libnames.qualid Constrexpr.or_by_notation -> unit
+val do_scheme_equality : Vernacexpr.equality_scheme_type -> Libnames.qualid Constrexpr.or_by_notation -> unit
 
 (** Combine a list of schemes into a conjunction of them *)
 

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -402,6 +402,12 @@ let pr_onescheme (idop, {sch_type; sch_qualid; sch_sort}) =
   hov 0 str_identifier ++ spc () ++ hov 0 (str_scheme ++ spc() ++ pr_smart_global sch_qualid)
     ++ spc () ++ hov 0 (keyword "Sort" ++ spc() ++ Sorts.pr_sort_family sch_sort)
 
+let pr_equality_scheme_type sch id =
+  let str_scheme = match sch with
+  | SchemeBooleanEquality -> keyword "Boolean Equality for"
+  | SchemeEquality -> keyword "Equality for" in
+  hov 0 (str_scheme ++ spc() ++ pr_smart_global id)
+
 let begin_of_inductive = function
   | [] -> 0
   | (_,({loc},_))::_ -> Option.cata (fun loc -> fst (Loc.unloc loc)) 0 loc
@@ -895,9 +901,9 @@ let pr_vernac_expr v =
       hov 2 (keyword "Scheme" ++ spc() ++
              prlist_with_sep (fun _ -> fnl() ++ keyword "with" ++ spc ()) pr_onescheme l)
     )
-  | VernacSchemeEquality id ->
+  | VernacSchemeEquality (sch,id) ->
     return (
-      hov 2 (keyword "Scheme Equality for" ++ spc() ++ pr_or_by_notation pr_qualid id)
+      hov 2 (keyword "Scheme " ++ pr_equality_scheme_type sch id)
     )
   | VernacCombinedScheme (id, l) ->
     return (

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1021,10 +1021,10 @@ let vernac_scheme l =
       dump_global sch.sch_qualid) l;
   Indschemes.do_scheme (Global.env ()) l
 
-let vernac_scheme_equality id =
+let vernac_scheme_equality sch id =
   if Dumpglob.dump () then
     dump_global id;
-  Indschemes.do_scheme_equality id
+  Indschemes.do_scheme_equality sch id
 
 let vernac_combined_scheme lid l =
   if Dumpglob.dump () then
@@ -2233,10 +2233,10 @@ let translate_vernac ?loc ~atts v = let open Vernacextend in match v with
     vtdefault(fun () ->
         unsupported_attributes atts;
         vernac_scheme l)
-  | VernacSchemeEquality id ->
+  | VernacSchemeEquality (sch,id) ->
     vtdefault(fun () ->
         unsupported_attributes atts;
-        vernac_scheme_equality id)
+        vernac_scheme_equality sch id)
   | VernacCombinedScheme (id, l) ->
     vtdefault(fun () ->
         unsupported_attributes atts;

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -220,6 +220,10 @@ type scheme_type =
   | SchemeElimination
   | SchemeCase
 
+type equality_scheme_type =
+  | SchemeBooleanEquality
+  | SchemeEquality
+
   (* The data of a Scheme decleration *)
 type scheme = {
   sch_type : scheme_type ;
@@ -350,7 +354,7 @@ type nonrec vernac_expr =
   | VernacFixpoint of discharge * fixpoint_expr list
   | VernacCoFixpoint of discharge * cofixpoint_expr list
   | VernacScheme of (lident option * scheme) list
-  | VernacSchemeEquality of Libnames.qualid Constrexpr.or_by_notation
+  | VernacSchemeEquality of equality_scheme_type * Libnames.qualid Constrexpr.or_by_notation
   | VernacCombinedScheme of lident * lident list
   | VernacUniverse of lident list
   | VernacConstraint of univ_constraint_expr list


### PR DESCRIPTION
**Kind:** Small feature / enhancement

It happens that building a Boolean equality works while building decidability of equality does not work. Consistently with the presence of a flag `Set Boolean Equality` to tell to synthesize only a Boolean equality, we add a `Scheme Boolean Equality for reference` to specifically target Boolean equalities only.

- [x] Added **changelog**.
- [x] Added / updated **documentation**.
- [x] Updated **documented syntax** by running `make -f Makefile.dune doc_gram_rsts`.
