### PR TITLE
[experiment] Do not return the argument constr in check_and_clear functions.

### DIFF
--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -233,7 +233,7 @@ raise OccurHypInSimpleClause if the removal breaks dependencies *)
 
 type clear_dependency_error =
 | OccurHypInSimpleClause of Id.t option
-| EvarTypingBreak of Constr.existential
+| EvarTypingBreak of EConstr.existential
 | NoCandidatesLeft of Evar.t
 
 exception ClearDependencyError of Id.t * clear_dependency_error * GlobRef.t option
@@ -247,10 +247,10 @@ val restrict_evar : evar_map -> Evar.t -> Filter.t ->
   ?src:Evar_kinds.t Loc.located -> constr list option -> evar_map * Evar.t
 
 val clear_hyps_in_evi : env -> evar_map -> named_context_val -> types ->
-  Id.Set.t -> evar_map * named_context_val * types
+  Id.Set.t -> evar_map * named_context_val
 
 val clear_hyps2_in_evi : env -> evar_map -> named_context_val -> types -> types ->
-  Id.Set.t -> evar_map * named_context_val * types * types
+  Id.Set.t -> evar_map * named_context_val
 
 type csubst
 

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -955,9 +955,9 @@ let thin id sigma goal =
   in
   match ans with
   | None -> sigma
-  | Some (sigma, hyps, concl) ->
+  | Some (sigma, hyps) ->
     let (sigma, evk) =
-      Evarutil.new_pure_evar ~src:(Loc.tag Evar_kinds.GoalEvar) ~typeclass_candidate:false hyps sigma concl
+      Evarutil.new_pure_evar ~src:(Loc.tag Evar_kinds.GoalEvar) ~typeclass_candidate:false hyps sigma cl
     in
     let sigma = Evd.remove_future_goal sigma evk in
     let id = Evd.evar_ident goal sigma in

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -265,7 +265,7 @@ let pr_puniverses f env sigma (c,u) =
   else f env c
 
 let pr_existential_key = Termops.pr_existential_key
-let pr_existential env sigma ev = pr_lconstr_env env sigma (mkEvar ev)
+let pr_existential env sigma ev = pr_leconstr_env env sigma (EConstr.mkEvar ev)
 
 let pr_constant env cst = pr_global_env (Termops.vars_of_env env) (GlobRef.ConstRef cst)
 let pr_inductive env ind = pr_global_env (Termops.vars_of_env env) (GlobRef.IndRef ind)

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -151,7 +151,7 @@ val pr_global              : GlobRef.t -> Pp.t
 
 val pr_constant            : env -> Constant.t -> Pp.t
 val pr_existential_key     : env -> evar_map -> Evar.t -> Pp.t
-val pr_existential         : env -> evar_map -> existential -> Pp.t
+val pr_existential         : env -> evar_map -> EConstr.existential -> Pp.t
 val pr_constructor         : env -> constructor -> Pp.t
 val pr_inductive           : env -> inductive -> Pp.t
 val pr_evaluable_reference : Tacred.evaluable_global_reference -> Pp.t

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -389,7 +389,7 @@ let clear_gen fail = function
     let env = Proofview.Goal.env gl in
     let sigma = Tacmach.project gl in
     let concl = Proofview.Goal.concl gl in
-    let (sigma, hyps, concl) =
+    let (sigma, hyps) =
       try clear_hyps_in_evi env sigma (named_context_val env) concl ids
       with Evarutil.ClearDependencyError (id,err,inglobal) -> fail env sigma id err inglobal
     in
@@ -579,16 +579,16 @@ let internal_cut ?(check=true) replace id t =
     let concl = Proofview.Goal.concl gl in
     let sign = named_context_val env in
     let r = Retyping.relevance_of_type env sigma t in
-    let env',t,concl,sigma =
+    let env', t, sigma =
       if replace then
         let nexthyp = get_next_hyp_position env sigma id (named_context_of_val sign) in
-        let sigma,sign',t,concl = clear_hyps2 env sigma (Id.Set.singleton id) sign t concl in
+        let sigma, sign' = clear_hyps2 env sigma (Id.Set.singleton id) sign t concl in
         let sign' = insert_decl_in_named_context env sigma (LocalAssum (make_annot id r,t)) nexthyp sign' in
-        Environ.reset_with_named_context sign' env,t,concl,sigma
+        Environ.reset_with_named_context sign' env, t, sigma
       else
         (if check && mem_named_context_val id sign then
            error (IntroAlreadyDeclared id);
-         push_named (LocalAssum (make_annot id r,t)) env,t,concl,sigma) in
+         push_named (LocalAssum (make_annot id r,t)) env, t, sigma) in
     let nf_t = nf_betaiota env sigma t in
     Proofview.tclTHEN
       (Proofview.Unsafe.tclEVARS sigma)


### PR DESCRIPTION
It was statically known to be the evar-expanded form of the argument. We also clean up the implementation and rely on the EConstr API.