### PR TITLE
Hide the instantiation of patterns with constr variables under an API.

### DIFF
--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -1037,14 +1037,8 @@ let head_with_value (lvar,lval) =
     {!Matching.matching_result}) into a context value of Ltac.  *)
 let interp_context ctxt = in_gen (topwit wit_constr_context) ctxt
 
-(* Reads a pattern by substituting vars of lfun *)
-let use_types = false
-
-let eval_pattern lfun ist env sigma (bvars,(glob,_),pat as c) =
-  if use_types then
-    (bvars,interp_typed_pattern ist env sigma c)
-  else
-    (bvars,instantiate_pattern env sigma lfun pat)
+let eval_pattern lfun ist env sigma (bvars, _, pat) =
+  (bvars,Constr_matching.instantiate_pattern env sigma lfun pat)
 
 let read_pattern lfun ist env sigma = function
   | Subterm (ido,c) -> Subterm (ido,eval_pattern lfun ist env sigma c)

--- a/plugins/ltac/tactic_matching.mli
+++ b/plugins/ltac/tactic_matching.mli
@@ -35,7 +35,7 @@ val match_term :
   Environ.env ->
   Evd.evar_map ->
   EConstr.constr ->
-  (Constr_matching.binding_bound_vars * Pattern.constr_pattern, Tacexpr.glob_tactic_expr) Tacexpr.match_rule list ->
+  (Constr_matching.binding_bound_vars * Constr_matching.instantiated_pattern, Tacexpr.glob_tactic_expr) Tacexpr.match_rule list ->
   Tacexpr.glob_tactic_expr t Proofview.tactic
 
 (** [match_goal env sigma hyps concl rules] matches the goal
@@ -48,5 +48,5 @@ val match_goal:
   Evd.evar_map ->
   EConstr.named_context ->
   EConstr.constr ->
-  (Constr_matching.binding_bound_vars * Pattern.constr_pattern, Tacexpr.glob_tactic_expr) Tacexpr.match_rule list ->
+  (Constr_matching.binding_bound_vars * Constr_matching.instantiated_pattern, Tacexpr.glob_tactic_expr) Tacexpr.match_rule list ->
   Tacexpr.glob_tactic_expr t Proofview.tactic

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -796,6 +796,7 @@ let () = define2 "pattern_matches_subterm" pattern constr begin fun pat c ->
     Proofview.tclOR (return ans) (fun _ -> of_ans s)
   in
   pf_apply begin fun env sigma ->
+    let pat = Constr_matching.instantiate_pattern env sigma Id.Map.empty pat in
     let ans = Constr_matching.match_subterm env sigma (Id.Set.empty,pat) c in
     of_ans ans
   end
@@ -828,6 +829,7 @@ let () = define2 "pattern_matches_subterm_vect" pattern constr begin fun pat c -
     Proofview.tclOR (return ans) (fun _ -> of_ans s)
   in
   pf_apply begin fun env sigma ->
+    let pat = Constr_matching.instantiate_pattern env sigma Id.Map.empty pat in
     let ans = Constr_matching.match_subterm env sigma (Id.Set.empty,pat) c in
     of_ans ans
   end

--- a/plugins/ltac2/tac2match.ml
+++ b/plugins/ltac2/tac2match.ml
@@ -181,6 +181,7 @@ module PatternMatching (E:StaticEnvironment) = struct
             | Some nctx -> Proofview.tclOR (k (Some (Lazy.force m_ctx)) nctx) (fun e -> (map s e).stream k ctx)
         }
       in
+      let p = Constr_matching.instantiate_pattern E.env E.sigma Id.Map.empty p in
       map (Constr_matching.match_subterm E.env E.sigma (Id.Set.empty,p) term) imatching_error
 
   let hyp_match_type pat hyps =

--- a/pretyping/constr_matching.mli
+++ b/pretyping/constr_matching.mli
@@ -17,6 +17,12 @@ open Environ
 open Pattern
 open Ltac_pretype
 
+type instantiated_pattern
+
+val instantiate_pattern : Environ.env ->
+  Evd.evar_map -> extended_patvar_map ->
+  constr_pattern -> instantiated_pattern
+
 type binding_bound_vars = Id.Set.t
 
 (** [PatternMatchingFailure] is the exception raised when pattern
@@ -47,7 +53,7 @@ val matches_head : env -> Evd.evar_map -> constr_pattern -> constr -> patvar_map
    variables or metavariables have the same name, the metavariable,
    or else the rightmost bound variable, takes precedence *)
 val extended_matches :
-  env -> Evd.evar_map -> binding_bound_vars * constr_pattern ->
+  env -> Evd.evar_map -> binding_bound_vars * instantiated_pattern ->
   constr -> bound_ident_map * extended_patvar_map
 
 (** [is_matching pat c] just tells if [c] matches against [pat] *)
@@ -67,7 +73,7 @@ type matching_result =
    corresponding to each **closed** subterm of [c] matching [pat],
    considering application contexts as well. *)
 val match_subterm : env -> Evd.evar_map ->
-  binding_bound_vars * constr_pattern -> constr ->
+  binding_bound_vars * instantiated_pattern -> constr ->
   matching_result IStream.t
 
 (** [is_matching_appsubterm pat c] tells if a subterm of [c] matches

--- a/pretyping/patternops.ml
+++ b/pretyping/patternops.ml
@@ -264,42 +264,6 @@ let map_pattern_with_binders g f l = function
   | (PVar _ | PEvar _ | PRel _ | PRef _  | PSort _  | PMeta _ | PInt _
      | PFloat _ as x) -> x
 
-let error_instantiate_pattern id l =
-  let is = match l with
-  | [_] -> "is"
-  | _ -> "are"
-  in
-  user_err  (str "Cannot substitute the term bound to " ++ Id.print id
-    ++ strbrk " in pattern because the term refers to " ++ pr_enum Id.print l
-    ++ strbrk " which " ++ str is ++ strbrk " not bound in the pattern.")
-
-let instantiate_pattern env sigma lvar c =
-  let open EConstr in
-  let open Vars in
-  let rec aux vars = function
-  | PVar id as x ->
-      (try
-        let ctx,c = Id.Map.find id lvar in
-        try
-          let inst =
-            List.map
-              (fun id -> mkRel (List.index Name.equal (Name id) vars))
-              ctx
-          in
-          let c = substl inst c in
-          (* FIXME: Stupid workaround to pattern_of_constr being evar sensitive *)
-          let c = Evarutil.nf_evar sigma c in
-          pattern_of_constr env sigma (EConstr.Unsafe.to_constr c)
-        with Not_found (* List.index failed *) ->
-          let vars =
-            List.map_filter (function Name id -> Some id | _ -> None) vars in
-          error_instantiate_pattern id (List.subtract Id.equal ctx vars)
-       with Not_found (* Map.find failed *) ->
-         x)
-  | c ->
-      map_pattern_with_binders (fun id vars -> id::vars) aux vars c in
-  aux [] c
-
 let rec liftn_pattern k n = function
   | PRel i as x -> if i >= n then PRel (i+k) else x
   | c -> map_pattern_with_binders (fun _ -> succ) (liftn_pattern k) n c

--- a/pretyping/patternops.mli
+++ b/pretyping/patternops.mli
@@ -13,7 +13,6 @@ open Mod_subst
 open Glob_term
 open Pattern
 open EConstr
-open Ltac_pretype
 
 (** {5 Functions on patterns} *)
 
@@ -52,8 +51,7 @@ val pattern_of_constr : Environ.env -> Evd.evar_map -> Constr.constr -> constr_p
 val pattern_of_glob_constr : glob_constr ->
       patvar list * constr_pattern
 
-val instantiate_pattern : Environ.env ->
-  Evd.evar_map -> extended_patvar_map ->
-  constr_pattern -> constr_pattern
+val map_pattern_with_binders : (Name.t -> 'a -> 'a) ->
+  ('a -> constr_pattern -> constr_pattern) -> 'a -> constr_pattern -> constr_pattern
 
 val lift_pattern : int -> constr_pattern -> constr_pattern


### PR DESCRIPTION
This makes internal one critical call to the dreaded pattern_of_constr function. As a nice bonus, this also enforces statically that we never perform compositions of pattern_of_constr calls. Instantiating a pattern is just mapping a given set of variables to specific constr that are turned into constr_patterns, where the instantiation is not recursive.