### PR TITLE
Forbidding to use twice the same name in the same block of binders

### DIFF
--- a/test-suite/bugs/bug_10197.v
+++ b/test-suite/bugs/bug_10197.v
@@ -9,8 +9,14 @@ Check cofix f {f:nat} := {| this := f ; next := None |}.
 (* The following was ok from 8.4, just checking that the order is not
    mixed up accidentally *)
 
-Check fix f (x : nat) (x : forall {a:nat}, a = 0 -> nat) :=
+Fail Check fix f (x : nat) (x : forall {a:nat}, a = 0 -> nat) :=
    match x eq_refl with 0 => true | _ => false end.
 
-Check fix f (x : forall {a:nat}, a = 0 -> bool) (x : nat) :=
+Check fix f (_ : nat) (x : forall {a:nat}, a = 0 -> nat) :=
+   match x eq_refl with 0 => true | _ => false end.
+
+Fail Check fix f (x : forall {a:nat}, a = 0 -> bool) (x : nat) :=
+   match x with 0 => true | _ => false end.
+
+Check fix f (_ : forall {a:nat}, a = 0 -> bool) (x : nat) :=
    match x with 0 => true | _ => false end.

--- a/test-suite/bugs/bug_12001.v
+++ b/test-suite/bugs/bug_12001.v
@@ -6,9 +6,10 @@ Check leibniz_equiv_iff (A := nat) 2 3 : True.
 Unset Mangle Names.
 
 (* Coq doesn't make up names for arguments *)
-Definition bar (a a : nat) : nat := 3.
+Fail Definition bar (a a : nat) : nat := 3.
+Definition bar (a a0 : nat) : nat := 3.
 Arguments bar _ _ : assert.
-Fail Arguments bar a a0 : assert.
+Fail Arguments bar a a1 : assert.
 
 (* This definition caused an anomaly in a version of this PR
 without the change to prepare_implicits *)

--- a/test-suite/bugs/bug_1414.v
+++ b/test-suite/bugs/bug_1414.v
@@ -18,7 +18,7 @@ Parameter add : data -> t -> t.
 
 Program Fixpoint union
   (s u:t)
-  (hb1: bst s)(ha1: avl s)(hb2: bst u)(hb2: avl u)
+  (hb1: bst s)(ha1: avl s)(hb2: bst u)(hb3: avl u)
   { measure (cardinal s + cardinal u) } :
   {s' : t | bst s' /\ avl s' /\ forall x, In x s' <-> In x s \/ In x u} :=
   match s, u with

--- a/test-suite/bugs/bug_5755.v
+++ b/test-suite/bugs/bug_5755.v
@@ -2,7 +2,8 @@
 
 Section Foo.
 
-Inductive foo (A : Type) (x : A) (y := x) (y : A) := Foo.
+Fail Inductive foo (A : Type) (x : A) (y := x) (y : A) := Foo.
+Inductive foo (A : Type) (x : A) (y := x) (y' : A) := Foo.
 
 End Foo.
 
@@ -11,6 +12,7 @@ Section Foo2.
 Variable B : Type.
 Variable b : B.
 Let c := b.
-Inductive foo2 (A : Type) (x : A) (y := x) (y : A) := Foo2 : c=c -> foo2 A x y.
+Fail Inductive foo2 (A : Type) (x : A) (y := x) (y : A) := Foo2 : c=c -> foo2 A x y.
+Inductive foo2 (A : Type) (x : A) (y' := x) (y : A) := Foo2 : c=c -> foo2 A x y.
 
 End Foo2.


### PR DESCRIPTION
**Kind:** design

This is a natural and safe expectation, liable to remove various implicit alpha-conversion problems. See #6786.

Let's see what CI says.

Fixes / closes #6786

- [x] Added / updated **test-suite**.
- [ ] Added **changelog**.
