### PR TITLE
Mention Coqtail in refman

### DIFF
--- a/doc/sphinx/practical-tools/utilities.rst
+++ b/doc/sphinx/practical-tools/utilities.rst
@@ -91,7 +91,7 @@ generate object files that are not usable except for expert cases.
 The ``-native-compiler`` option given in the ``_CoqProject`` file will override
 the global one passed at configure time.
 
-CoqIDE, Proof-General and VSCoq all
+CoqIDE, Proof-General, VSCoq and Coqtail all
 understand ``_CoqProject`` files and can be used to invoke Coq with the desired options.
 
 The ``coq_makefile`` utility can be used to set up a build infrastructure

--- a/doc/sphinx/practical-tools/utilities.rst
+++ b/doc/sphinx/practical-tools/utilities.rst
@@ -91,7 +91,7 @@ generate object files that are not usable except for expert cases.
 The ``-native-compiler`` option given in the ``_CoqProject`` file will override
 the global one passed at configure time.
 
-CoqIDE, Proof-General, VSCoq and Coqtail all
+CoqIDE, Proof General, VsCoq and Coqtail all
 understand ``_CoqProject`` files and can be used to invoke Coq with the desired options.
 
 The ``coq_makefile`` utility can be used to set up a build infrastructure

--- a/doc/sphinx/proofs/writing-proofs/proof-mode.rst
+++ b/doc/sphinx/proofs/writing-proofs/proof-mode.rst
@@ -994,7 +994,7 @@ command in CoqIDE.  You can change the background colors shown for diffs from th
 lets you control other attributes of the highlights, such as the foreground
 color, bold, italic, underline and strikeout.
 
-Proof General and Coqtail can also display Coq-generated proof diffs automatically.
+Proof General, VsCoq and Coqtail can also display Coq-generated proof diffs automatically.
 Please see the PG documentation section
 `"Showing Proof Diffs" <https://proofgeneral.github.io/doc/master/userman/Coq-Proof-General#Showing-Proof-Diffs>`_
 and Coqtail's `"Proof Diffs" <https://github.com/whonore/Coqtail#proof-diffs>`_

--- a/doc/sphinx/proofs/writing-proofs/proof-mode.rst
+++ b/doc/sphinx/proofs/writing-proofs/proof-mode.rst
@@ -994,9 +994,10 @@ command in CoqIDE.  You can change the background colors shown for diffs from th
 lets you control other attributes of the highlights, such as the foreground
 color, bold, italic, underline and strikeout.
 
-Proof General can also display Coq-generated proof diffs automatically.
+Proof General and Coqtail can also display Coq-generated proof diffs automatically.
 Please see the PG documentation section
-"`Showing Proof Diffs" <https://proofgeneral.github.io/doc/master/userman/Coq-Proof-General#Showing-Proof-Diffs>`_)
+`"Showing Proof Diffs" <https://proofgeneral.github.io/doc/master/userman/Coq-Proof-General#Showing-Proof-Diffs>`_
+and Coqtail's `"Proof Diffs" <https://github.com/whonore/Coqtail#proof-diffs>`_
 for details.
 
 How diffs are calculated


### PR DESCRIPTION
I added Coqtail to parts of the manual that talk about IDE support for various features. Given the number of Coq IDEs and their varying levels of support for different features, it might be useful to have a table somewhere summarizing the differences. That would help users decide if a particular IDE suits their needs, it would be easier for documentation writers to keep up-to-date instead of updating each page individually, and it could help IDE developers prioritize which features to support next.
