### PR TITLE
Add mandatory arguments for setting transparency when creating hint databases.

### DIFF
--- a/theories/Init/Logic.v
+++ b/theories/Init/Logic.v
@@ -44,11 +44,7 @@ Definition notT (A:Type) := A -> False.
 (** Create the "core" hint database, and set its transparent state for
   variables and constants explicitly. *)
 
-Create HintDb core.
-#[global]
-Hint Variables Opaque : core.
-#[global]
-Hint Constants Opaque : core.
+Create HintDb core Variables(Opaque) Constants(Opaque).
 
 #[global]
 Hint Unfold not: core.

--- a/theories/Init/Tactics.v
+++ b/theories/Init/Tactics.v
@@ -347,7 +347,5 @@ Tactic Notation "assert_succeeds" tactic3(tac) :=
 Tactic Notation "assert_fails" tactic3(tac) :=
   assert_fails tac.
 
-Create HintDb rewrite discriminated.
-#[global]
-Hint Variables Opaque : rewrite.
-Create HintDb typeclass_instances discriminated.
+Create HintDb rewrite Variables(Opaque) Constants(Transparent) discriminated.
+Create HintDb typeclass_instances Variables(Transparent) Constants(Transparent) discriminated.

--- a/theories/Program/Tactics.v
+++ b/theories/Program/Tactics.v
@@ -314,7 +314,7 @@ Ltac program_solve_wf :=
     | |- ?T => match type of T with Prop => auto end
   end.
 
-Create HintDb program discriminated.
+Create HintDb program Variables(Transparent) Constants(Transparent) discriminated.
 
 Ltac program_simpl := program_simplify ; try typeclasses eauto 10 with program ; try program_solve_wf.
 

--- a/theories/Structures/OrderedType.v
+++ b/theories/Structures/OrderedType.v
@@ -26,7 +26,7 @@ Arguments LT [X lt eq x y] _.
 Arguments EQ [X lt eq x y] _.
 Arguments GT [X lt eq x y] _.
 
-Create HintDb ordered_type.
+Create HintDb ordered_type Variables(Transparent) Constants(Transparent).
 
 Module Type MiniOrderedType.
 

--- a/vernac/g_proofs.mlg
+++ b/vernac/g_proofs.mlg
@@ -98,13 +98,23 @@ GRAMMAR EXTEND Gram
       | IDENT "Guarded" -> { VernacCheckGuard }
       (* Hints for Auto and EAuto *)
       | IDENT "Create"; IDENT "HintDb" ;
-          id = IDENT ; b = [ IDENT "discriminated" -> { true } | -> { false } ] ->
-            { VernacCreateHintDb (id, b) }
+          id = IDENT ; args = LIST0 create_hintdb_arg ->
+            { VernacCreateHintDb (id, args) }
       | IDENT "Remove"; IDENT "Hints"; ids = LIST1 global; dbnames = opt_hintbases ->
           { VernacRemoveHints (dbnames, ids) }
       | IDENT "Hint"; h = hint; dbnames = opt_hintbases ->
           { VernacHints (dbnames, h) }
-      ] ];
+      ] ]
+  ;
+  create_hintdb_arg:
+  [ [ IDENT "discriminated" -> { Discriminated }
+    | IDENT "Variables"; "(" ; o = opacity_flag; ")" -> { Variables o }
+    | IDENT "Constants"; "(" ; o = opacity_flag; ")" -> { Constants o } ] ]
+  ;
+  opacity_flag:
+  [ [ IDENT "Opaque" -> { Opaque }
+    | IDENT "Transparent" -> { Transparent } ] ]
+  ;
   reference_or_constr:
    [ [ r = global -> { HintsReference r }
      | c = constr -> { HintsConstr c } ] ]

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -1073,10 +1073,19 @@ let pr_vernac_expr v =
     return (keyword "Cd" ++ pr_opt qs s)
 
   (* Commands *)
-  | VernacCreateHintDb (dbname,b) ->
-    return (
-      hov 1 (keyword "Create HintDb" ++ spc () ++
-             str dbname ++ (if b then str" discriminated" else mt ()))
+  | VernacCreateHintDb (dbname,flags) ->
+    let pr_opacity_flag = function
+      | Opaque -> str"Opaque"
+      | Transparent -> str"Transparent"
+    in
+    let pr_create_hintdb_flag = function
+      | Discriminated -> str" discriminated"
+      | Variables o -> str" Variables(" ++ pr_opacity_flag o ++ str")"
+      | Constants o -> str" Constants(" ++ pr_opacity_flag o ++ str")"
+    in
+      return (
+        hov 1 (keyword "Create HintDb" ++ spc () ++
+             str dbname ++ prlist_with_sep (fun _ -> mt ()) pr_create_hintdb_flag flags)
     )
   | VernacRemoveHints (dbnames, ids) ->
     return (

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1475,7 +1475,7 @@ let warn_create_hint_db_no_transparent_state =
 let vernac_create_hintdb ~module_local id flags =
   let interp_var_opacity opt o =
     match opt with
-    | Some o -> user_err Pp.(str"Multiple specifications of the 'Variables' flag")
+    | Some o -> user_err Pp.(str"Multiple specifications of the 'Variables' flag.")
     | None ->
       match o with
       | Opaque -> Names.Id.Pred.empty
@@ -1483,7 +1483,7 @@ let vernac_create_hintdb ~module_local id flags =
   in
   let interp_cst_opacity opt o =
     match opt with
-    | Some o -> user_err Pp.(str"Multiple specifications of the 'Constants' flag")
+    | Some o -> user_err Pp.(str"Multiple specifications of the 'Constants' flag.")
     | None ->
       match o with
       | Opaque -> Names.Cpred.empty
@@ -1501,7 +1501,7 @@ let vernac_create_hintdb ~module_local id flags =
         Option.default false discriminated, vars, csts)
     | Discriminated :: flags ->
       begin match discriminated with
-      | Some _ -> user_err Pp.(str"Multiple specifications of the 'discriminated' flag")
+      | Some _ -> user_err Pp.(str"Multiple specifications of the 'discriminated' flag.")
       | None -> interp_flags (Some true, vars, csts) flags
       end
     | Variables o :: flags ->

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -302,6 +302,9 @@ type discharge = DoDischarge | NoDischarge
 
 type hint_info_expr = Constrexpr.constr_pattern_expr Typeclasses.hint_info_gen
 
+type create_hintdb_arg =
+  Discriminated | Variables of opacity_flag | Constants of opacity_flag
+
 type reference_or_constr =
   | HintsReference of Libnames.qualid
   | HintsConstr of Constrexpr.constr_expr
@@ -405,7 +408,7 @@ type nonrec vernac_expr =
   | VernacBack of int
 
   (* Commands *)
-  | VernacCreateHintDb of string * bool
+  | VernacCreateHintDb of string * create_hintdb_arg list
   | VernacRemoveHints of string list * qualid list
   | VernacHints of string list * hints_expr
   | VernacSyntacticDefinition of


### PR DESCRIPTION
Deprecate the version without transparency arguments.
This is backwards compatible, but will warn about the deprecation in 8.16.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #5381

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make -f Makefile.dune doc_gram_rsts`.

