### PR TITLE
Stop caring about unfolding state of primproj in constr_matching

### DIFF
--- a/doc/changelog/05-tactic-language/15559-constr-match-unfold-proj.rst
+++ b/doc/changelog/05-tactic-language/15559-constr-match-unfold-proj.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  Ltac `match` does not fail when the term to match contains an unfolded primitive projection
+  (`#15559 <https://github.com/coq/coq/pull/15559>`_,
+  fixes `#15554 <https://github.com/coq/coq/issues/15554>`_,
+  by Gaëtan Gilbert).

--- a/pretyping/constr_matching.ml
+++ b/pretyping/constr_matching.ml
@@ -299,7 +299,7 @@ let matches_core env sigma allow_bound_rels
             Array.fold_left2 (sorec ctx env) subst args1 args22
           else (* Might be a projection on the right *)
             match EConstr.kind sigma c2 with
-            | Proj (pr, c) when not (Projection.unfolded pr) ->
+            | Proj (pr, c) ->
               (try let term = Retyping.expand_projection env sigma pr c (Array.to_list args2) in
                      sorec ctx env subst p term
                with Retyping.RetypeError _ -> raise PatternMatchingFailure)
@@ -307,15 +307,15 @@ let matches_core env sigma allow_bound_rels
 
       | PApp (c1,arg1), App (c2,arg2) ->
         (match c1, EConstr.kind sigma c2 with
-        | PRef (GlobRef.ConstRef r), Proj (pr,c) when not (Environ.QConstant.equal env r (Projection.constant pr))
-            || Projection.unfolded pr ->
-          raise PatternMatchingFailure
+         | PRef (GlobRef.ConstRef r), Proj (pr,c)
+           when not (Environ.QConstant.equal env r (Projection.constant pr)) ->
+           raise PatternMatchingFailure
         | PProj (pr1,c1), Proj (pr,c) ->
           if Environ.QProjection.equal env pr1 pr then
             try Array.fold_left2 (sorec ctx env) (sorec ctx env subst c1 c) arg1 arg2
             with Invalid_argument _ -> raise PatternMatchingFailure
           else raise PatternMatchingFailure
-        | _, Proj (pr,c) when not (Projection.unfolded pr) ->
+        | _, Proj (pr,c) ->
           (try let term = Retyping.expand_projection env sigma pr c (Array.to_list arg2) in
                  sorec ctx env subst p term
            with Retyping.RetypeError _ -> raise PatternMatchingFailure)
@@ -324,7 +324,7 @@ let matches_core env sigma allow_bound_rels
           with Invalid_argument _ -> raise PatternMatchingFailure)
 
       | PApp (PRef (GlobRef.ConstRef c1), _), Proj (pr, c2)
-        when Projection.unfolded pr || not (Environ.QConstant.equal env c1 (Projection.constant pr)) ->
+        when not (Environ.QConstant.equal env c1 (Projection.constant pr)) ->
         raise PatternMatchingFailure
 
       | PApp (c, args), Proj (pr, c2) ->

--- a/test-suite/bugs/bug_15554.v
+++ b/test-suite/bugs/bug_15554.v
@@ -1,0 +1,27 @@
+Set Primitive Projections.
+Record Box {T} := box { unbox : T }.
+Arguments Box : clear implicits.
+Definition indirect := @unbox.
+Goal forall T : @Box Set, unbox T -> False.
+  intros T x.
+  let Tindirect := constr:(indirect _ T) in
+  let Tdefined := eval cbv [indirect] in Tindirect in
+  let Tfolded := type of x in
+  cbv [unbox] in x;
+  let Tunfolded := type of x in
+  match Tdefined with Tdefined => idtac end;
+  match Tfolded with Tfolded => idtac end;
+  match Tfolded with Tunfolded => idtac end;
+  match Tdefined with Tfolded => idtac end;
+  match Tdefined with Tunfolded => idtac end;
+  match Tfolded with Tdefined => idtac end;
+  (* matches above have passed for a while
+     matches below used to fail with "Error: No matching clauses for match." *)
+  match Tunfolded with Tunfolded => idtac end;
+  match Tunfolded with Tfolded => idtac end;
+  match Tunfolded with Tdefined => idtac end;
+  assert_fails (constr_eq Tdefined Tfolded);
+  assert_fails (constr_eq Tdefined Tunfolded);
+  assert_fails (constr_eq Tfolded Tunfolded);
+  idtac Tdefined Tfolded Tunfolded.
+Abort.

--- a/test-suite/bugs/bug_3656.v
+++ b/test-suite/bugs/bug_3656.v
@@ -32,23 +32,3 @@ let x := head_hnf_under_binders setT in pose x.
 set (foo := eq_refl (@setT nat)). generalize foo. simpl. cbn.
 Abort.
 End A'.
-
-Set Primitive Projections.
-Record hSet : Type := BuildhSet { setT : Type;  iss : True }.
-Ltac head_hnf_under_binders x :=
-  match eval hnf in x with
-    | ?f _ => head_hnf_under_binders f
-    | (fun y => ?f y) => head_hnf_under_binders f
-    | ?y => y
-  end.
-Goal setT = setT.
- progress unfold setT. (* should not succeed *)
- match goal with
-    | |- (fun h => setT h) = (fun h => setT h) => fail 1 "should not eta-expand"
-    | _ => idtac
-  end. (* should not fail *)
-Abort.
-
-Goal forall h, setT h = setT h.
-Proof. intro. progress unfold setT.
-Abort.

--- a/test-suite/bugs/bug_3662.v
+++ b/test-suite/bugs/bug_3662.v
@@ -37,10 +37,3 @@ Goal fst (pair nat nat) = nat.
 Defined.
 
 Lemma eta A B : forall x : prod A B, x = pair (fst x) (snd x). reflexivity. Qed.
-
-Goal forall x : prod nat nat, fst x = 0.
-  intros. unfold fst.
-  Fail match goal with
-    | [ |- fst ?x = 0 ] => idtac
-  end.
-Abort.


### PR DESCRIPTION
Fix #15554
