### PR TITLE
Dispatch consistently it_mkLambda and cie between econstr.ml and termops.ml

### DIFF
--- a/dev/ci/user-overlays/15565-herbelin-master+it_mkLambda-and-cie-econstr-termops-dispatch.sh
+++ b/dev/ci/user-overlays/15565-herbelin-master+it_mkLambda-and-cie-econstr-termops-dispatch.sh
@@ -1,0 +1,1 @@
+overlay equations https://github.com/herbelin/Coq-Equations master+adapt-coq-pr15565-it_mkLambda-constr-econstr 15565

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -906,6 +906,9 @@ let mkNamedLambda_or_LetIn sigma decl c =
     | LocalAssum (id,t) -> mkNamedLambda sigma id t c
     | LocalDef (id,b,t) -> mkNamedLetIn sigma id b t c
 
+let it_mkProd init = List.fold_left (fun c (n,t)  -> mkProd (n, t, c)) init
+let it_mkLambda init = List.fold_left (fun c (n,t)  -> mkLambda (n, t, c)) init
+
 let it_mkProd_or_LetIn t ctx = List.fold_left (fun c d -> mkProd_or_LetIn d c) t ctx
 let it_mkLambda_or_LetIn t ctx = List.fold_left (fun c d -> mkLambda_or_LetIn d c) t ctx
 

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -271,16 +271,6 @@ let decompose_lam_n_decls sigma n =
   in
   lamdec_rec Context.Rel.empty n
 
-let lamn n env b =
-  let rec lamrec = function
-    | (0, env, b)        -> b
-    | (n, ((v,t)::l), b) -> lamrec (n-1,  l, mkLambda (v,t,b))
-    | _ -> assert false
-  in
-  lamrec (n,env,b)
-
-let compose_lam l b = lamn (List.length l) l b
-
 let rec to_lambda sigma n prod =
   if Int.equal n 0 then
     prod
@@ -908,6 +898,8 @@ let mkNamedLambda_or_LetIn sigma decl c =
 
 let it_mkProd init = List.fold_left (fun c (n,t)  -> mkProd (n, t, c)) init
 let it_mkLambda init = List.fold_left (fun c (n,t)  -> mkLambda (n, t, c)) init
+
+let compose_lam l b = it_mkLambda b l
 
 let it_mkProd_or_LetIn t ctx = List.fold_left (fun c d -> mkProd_or_LetIn d c) t ctx
 let it_mkLambda_or_LetIn t ctx = List.fold_left (fun c d -> mkLambda_or_LetIn d c) t ctx

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -149,6 +149,9 @@ val type1 : t
 val applist : t * t list -> t
 val applistc : t -> t list -> t
 
+val it_mkProd : t -> (Name.t Context.binder_annot * t) list -> t
+val it_mkLambda : t -> (Name.t Context.binder_annot * t) list -> t
+
 val mkProd_or_LetIn : rel_declaration -> t -> t
 val mkLambda_or_LetIn : rel_declaration -> t -> t
 val it_mkProd_or_LetIn : t -> rel_context -> t

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -149,6 +149,14 @@ val type1 : t
 val applist : t * t list -> t
 val applistc : t -> t list -> t
 
+(** { Abstracting/generalizing over binders } *)
+
+(** it = iterated
+    or_LetIn = turn a local definition into a LetIn
+    wo_LetIn = inlines local definitions (i.e. substitute them in the body)
+    Named = binding is by name and the combinators turn it into a
+            binding by index (complexity is nb(binders) * size(term)) *)
+
 val it_mkProd : t -> (Name.t Context.binder_annot * t) list -> t
 val it_mkLambda : t -> (Name.t Context.binder_annot * t) list -> t
 
@@ -157,11 +165,22 @@ val mkLambda_or_LetIn : rel_declaration -> t -> t
 val it_mkProd_or_LetIn : t -> rel_context -> t
 val it_mkLambda_or_LetIn : t -> rel_context -> t
 
+val mkProd_wo_LetIn : rel_declaration -> t -> t
+val mkLambda_wo_LetIn : rel_declaration -> t -> t
+val it_mkProd_wo_LetIn : t -> rel_context -> t
+val it_mkLambda_wo_LetIn : t -> rel_context -> t
+
+val mkNamedProd : Evd.evar_map -> Id.t Context.binder_annot -> types -> types -> types
 val mkNamedLambda : Evd.evar_map -> Id.t Context.binder_annot -> types -> constr -> constr
 val mkNamedLetIn : Evd.evar_map -> Id.t Context.binder_annot -> constr -> types -> constr -> constr
-val mkNamedProd : Evd.evar_map -> Id.t Context.binder_annot -> types -> types -> types
-val mkNamedLambda_or_LetIn : Evd.evar_map -> named_declaration -> types -> types
+
 val mkNamedProd_or_LetIn : Evd.evar_map -> named_declaration -> types -> types
+val mkNamedLambda_or_LetIn : Evd.evar_map -> named_declaration -> types -> types
+val it_mkNamedProd_or_LetIn : Evd.evar_map -> t -> named_context -> t
+val it_mkNamedLambda_or_LetIn : Evd.evar_map -> t -> named_context -> t
+
+val mkNamedProd_wo_LetIn : Evd.evar_map -> named_declaration -> t -> t
+val it_mkNamedProd_wo_LetIn : Evd.evar_map -> t -> named_context -> t
 
 val mkLEvar : Evd.evar_map -> Evar.t * t list -> t
 (** Variant of {!mkEvar} that removes identity variable instances from its argument. *)

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -237,6 +237,8 @@ val decompose_lam_n_assum : Evd.evar_map -> int -> t -> rel_context * t
 val decompose_lam_n_decls : Evd.evar_map -> int -> t -> rel_context * t
 
 val compose_lam : (Name.t Context.binder_annot * t) list -> t -> t
+[@@ocaml.deprecated "Use [it_mkLambda] instead."]
+
 val to_lambda : Evd.evar_map -> int -> t -> t
 
 val decompose_prod : Evd.evar_map -> t -> (Name.t Context.binder_annot * t) list * t

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -491,28 +491,21 @@ let lookup_rel_id id sign =
   in
   lookrec 1 sign
 
-(* Constructs either [forall x:t, c] or [let x:=b:t in c] *)
 let mkProd_or_LetIn = EConstr.mkProd_or_LetIn
-(* Constructs either [forall x:t, c] or [c] in which [x] is replaced by [b] *)
-let mkProd_wo_LetIn decl c =
-  let open EConstr in
-  let open RelDecl in
-  match decl with
-    | LocalAssum (na,t) -> mkProd (na, t, c)
-    | LocalDef (_,b,_) -> Vars.subst1 b c
+let mkProd_wo_LetIn = EConstr.mkProd_wo_LetIn
 
-let it_mkProd init = List.fold_left (fun c (n,t)  -> EConstr.mkProd (n, t, c)) init
-let it_mkLambda init = List.fold_left (fun c (n,t)  -> EConstr.mkLambda (n, t, c)) init
+let it_mkProd = EConstr.it_mkProd
+let it_mkLambda = EConstr.it_mkLambda
 
-let it_named_context_quantifier f ~init =
-  List.fold_left (fun c d -> f d c) init
+let it_mkProd_or_LetIn = EConstr.it_mkProd_or_LetIn
+let it_mkProd_wo_LetIn = EConstr.it_mkProd_wo_LetIn
+let it_mkLambda_or_LetIn = Term.it_mkLambda_or_LetIn
+let it_mkNamedProd_or_LetIn = EConstr.it_mkNamedProd_or_LetIn
+let it_mkNamedLambda_or_LetIn = EConstr.it_mkNamedLambda_or_LetIn
 
-let it_mkProd_or_LetIn init = it_named_context_quantifier mkProd_or_LetIn ~init
-let it_mkProd_wo_LetIn init = it_named_context_quantifier mkProd_wo_LetIn ~init
-let it_mkLambda_or_LetIn init = it_named_context_quantifier mkLambda_or_LetIn ~init
-let it_mkNamedProd_or_LetIn sigma init = it_named_context_quantifier (EConstr.mkNamedProd_or_LetIn sigma) ~init
+(* On Constr *)
+let it_named_context_quantifier f ~init = List.fold_left (fun c d -> f d c) init
 let it_mkNamedProd_wo_LetIn init = it_named_context_quantifier mkNamedProd_wo_LetIn ~init
-let it_mkNamedLambda_or_LetIn sigma init = it_named_context_quantifier (EConstr.mkNamedLambda_or_LetIn sigma) ~init
 
 let it_mkLambda_or_LetIn_from_no_LetIn c decls =
   let open RelDecl in

--- a/engine/termops.mli
+++ b/engine/termops.mli
@@ -31,17 +31,38 @@ val lookup_rel_id : Id.t -> ('c, 't) Context.Rel.pt -> int * 'c option * 't
 val rel_vect : int -> int -> Constr.constr array
 val rel_list : int -> int -> constr list
 
-(** iterators/destructors on terms *)
+(** Prod/Lambda/LetIn destructors on econstr *)
+
 val mkProd_or_LetIn : rel_declaration -> types -> types
+  [@@ocaml.deprecated "Use synonymous [EConstr.mkProd_or_LetIn]."]
+
 val mkProd_wo_LetIn : rel_declaration -> types -> types
+  [@@ocaml.deprecated "Use synonymous [EConstr.mkProd_wo_LetIn]."]
+
 val it_mkProd : types -> (Name.t Context.binder_annot * types) list -> types
+  [@@ocaml.deprecated "Use synonymous [EConstr.it_mkProd]."]
+
 val it_mkLambda : constr -> (Name.t Context.binder_annot * types) list -> constr
+  [@@ocaml.deprecated "Use synonymous [EConstr.it_mkLambda]."]
+
 val it_mkProd_or_LetIn : types -> rel_context -> types
+  [@@ocaml.deprecated "Use synonymous [EConstr.it_mkProd_or_LetIn]."]
+
 val it_mkProd_wo_LetIn : types -> rel_context -> types
+  [@@ocaml.deprecated "Use synonymous [EConstr.it_mkProd_wo_LetIn]."]
+
 val it_mkLambda_or_LetIn : Constr.constr -> Constr.rel_context -> Constr.constr
+  [@@ocaml.deprecated "Use synonymous [Term.it_mkLambda_or_LetIn]."]
+
 val it_mkNamedProd_or_LetIn : Evd.evar_map -> types -> named_context -> types
-val it_mkNamedProd_wo_LetIn : Constr.types -> Constr.named_context -> Constr.types
+  [@@ocaml.deprecated "Use synonymous [EConstr.it_mkNamedProd_or_LetIn]."]
+
 val it_mkNamedLambda_or_LetIn : Evd.evar_map -> constr -> named_context -> constr
+  [@@ocaml.deprecated "Use synonymous [EConstr.it_mkNamedLambda_or_LetIn]."]
+
+(** Prod/Lambda/LetIn destructors on constr *)
+
+val it_mkNamedProd_wo_LetIn : Constr.types -> Constr.named_context -> Constr.types
 
 (* Ad hoc version reinserting letin, assuming the body is defined in
    the context where the letins are expanded *)

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -20,7 +20,6 @@ open Environ
 open Reduction
 open Reductionops
 open Inductive
-open Termops
 open Inductiveops
 open Namegen
 open Miniml
@@ -41,11 +40,11 @@ let current_fixpoints = ref ([] : Constant.t list)
 
 let type_of env sg c =
   let polyprop = (lang() == Haskell) in
-  Retyping.get_type_of ~polyprop env sg (strip_outer_cast sg c)
+  Retyping.get_type_of ~polyprop env sg (Termops.strip_outer_cast sg c)
 
 let sort_of env sg c =
   let polyprop = (lang() == Haskell) in
-  Retyping.get_sort_family_of ~polyprop env sg (strip_outer_cast sg c)
+  Retyping.get_sort_family_of ~polyprop env sg (Termops.strip_outer_cast sg c)
 
 (*S Generation of flags and signatures. *)
 

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -13,12 +13,12 @@ open CErrors
 open Util
 open Constr
 open Context
+open Termops
 open EConstr
 open Vars
 open Namegen
 open Names
 open Pp
-open Termops
 open Tactics
 open Indfun_common
 open Libnames

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -1418,7 +1418,7 @@ let make_scheme evd (fas : (Constr.pconstant * Sorts.family) list) : _ list =
             (body, typ, univs, opaque)
           with Found_type i ->
             let princ_body =
-              Termops.it_mkLambda_or_LetIn (Constr.mkFix ((idxs, i), decl)) ctxt
+              Term.it_mkLambda_or_LetIn (Constr.mkFix ((idxs, i), decl)) ctxt
             in
             (princ_body, Some scheme_type, univs, opaque))
         other_fun_princ_types

--- a/plugins/ssr/ssrelim.ml
+++ b/plugins/ssr/ssrelim.ml
@@ -592,7 +592,7 @@ let perform_injection c =
   let id_with_ebind = (EConstr.mkVar id, NoBindings) in
   let injtac = Tacticals.tclTHEN (introid id) (injectidl2rtac id id_with_ebind) in
   Proofview.Unsafe.tclEVARS sigma <*>
-  Tacticals.tclTHENLAST (Tactics.apply (Termops.it_mkLambda cl1 dc)) injtac
+  Tacticals.tclTHENLAST (Tactics.apply (EConstr.it_mkLambda cl1 dc)) injtac
   end
 
 let ssrscase_or_inj_tac c =

--- a/plugins/ssr/ssrelim.ml
+++ b/plugins/ssr/ssrelim.ml
@@ -592,7 +592,7 @@ let perform_injection c =
   let id_with_ebind = (EConstr.mkVar id, NoBindings) in
   let injtac = Tacticals.tclTHEN (introid id) (injectidl2rtac id id_with_ebind) in
   Proofview.Unsafe.tclEVARS sigma <*>
-  Tacticals.tclTHENLAST (Tactics.apply (EConstr.compose_lam dc cl1)) injtac
+  Tacticals.tclTHENLAST (Tactics.apply (Termops.it_mkLambda cl1 dc)) injtac
   end
 
 let ssrscase_or_inj_tac c =

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -852,7 +852,7 @@ and treat_case env sigma ci lbrty lf acc' =
         if isMeta head then begin
           assert (args = Context.Rel.instance mkRel 0 ctx);
           let (r,_,s,head'') = mk_refgoals env sigma lacc ty head in
-          let fi' = it_mkLambda_or_LetIn (mkApp (head'',args)) ctx in
+          let fi' = Term.it_mkLambda_or_LetIn (mkApp (head'',args)) ctx in
           (r,s,fi'::bacc)
         end
         else

--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -12,7 +12,6 @@ open Equality
 open Names
 open Pp
 open Constr
-open Termops
 open CErrors
 open Util
 open Mod_subst
@@ -273,14 +272,13 @@ let filtering env sigma cv_pb c1 c2 =
   try let () = aux env cv_pb c1 c2 in true with CannotFilter -> false
 
 let align_prod_letin sigma c a =
-  let open Termops in
   let (lc,_) = EConstr.decompose_prod_assum sigma c in
   let (l,a) = EConstr.decompose_prod_assum sigma a in
   let lc = List.length lc in
   let n = List.length l in
   if n < lc then invalid_arg "align_prod_letin";
   let l1 = CList.firstn lc l in
-  n - lc, it_mkProd_or_LetIn a l1
+  n - lc, EConstr.it_mkProd_or_LetIn a l1
 
   let decomp pat = match pat_of_constr pat with
   | None -> Dn.Everything
@@ -524,7 +522,7 @@ let decompose_applied_relation env sigma c ctype left2right =
     | Some c -> Some { hyp_pat = c; hyp_ty = ctype }
     | None ->
         let ctx,t' = Reductionops.splay_prod_assum env sigma ctype in (* Search for underlying eq *)
-        let ctype = it_mkProd_or_LetIn t' ctx in
+        let ctype = EConstr.it_mkProd_or_LetIn t' ctx in
         match find_rel ctype with
         | Some c -> Some { hyp_pat = c; hyp_ty = ctype }
         | None -> None

--- a/tactics/eqschemes.ml
+++ b/tactics/eqschemes.ml
@@ -93,7 +93,7 @@ let name_context env hyps =
           let d' = name_assumption env d in (push_rel d' env, d' :: hyps))
        (env,[]) (List.rev hyps))
 
-let my_it_mkLambda_or_LetIn s c = it_mkLambda_or_LetIn c s
+let my_it_mkLambda_or_LetIn s c = Term.it_mkLambda_or_LetIn c s
 let my_it_mkProd_or_LetIn s c = Term.it_mkProd_or_LetIn c s
 let my_it_mkLambda_or_LetIn_name env s c =
   let mkLambda_or_LetIn_name d b = mkLambda_or_LetIn (name_assumption env d) b in

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -13,6 +13,7 @@
 
 open Util
 open Constr
+open Vars
 open Declarations
 open Names
 
@@ -522,7 +523,7 @@ let build_beq_scheme env handle kn =
     | Ind (ind',u) ->
       begin
         match find_ind_env_lift env_lift ind' with
-        | Some (_,recparamsctx,n) -> Some (Termops.it_mkLambda_or_LetIn (mkRel n) (translate_context env_lift recparamsctx))
+        | Some (_,recparamsctx,n) -> Some (Term.it_mkLambda_or_LetIn (mkRel n) (translate_context env_lift recparamsctx))
         | None ->
             try Some (mkConstU (get_scheme handle (!beq_scheme_kind_aux()) ind',u))
             with Not_found -> raise(EqNotFound ind')
@@ -837,14 +838,14 @@ let build_beq_scheme env handle kn =
               raise (NonSingletonProp (kn,i));
             let decrArg = Context.Rel.length nonrecparams_ctx_with_eqs in
             let fix = mkFix (((Array.make nb_ind decrArg),i),(names,types,cores)) in
-            Termops.it_mkLambda_or_LetIn fix recparams_ctx_with_eqs)
+            Term.it_mkLambda_or_LetIn fix recparams_ctx_with_eqs)
       | Finite | BiFinite ->
          assert (Int.equal nb_ind 1);
          (* If the inductive type is not recursive, the fixpoint is
              not used, so let's replace it with garbage *)
          let kelim = Inductive.elim_sort (mib,mib.mind_packets.(0)) in
          if not (Sorts.family_leq InSet kelim) then raise (NonSingletonProp (kn,0));
-         [|Termops.it_mkLambda_or_LetIn (make_one_eq 0) recparams_ctx_with_eqs|]
+         [|Term.it_mkLambda_or_LetIn (make_one_eq 0) recparams_ctx_with_eqs|]
   in
   res, uctx
 

--- a/vernac/comCoercion.ml
+++ b/vernac/comCoercion.ml
@@ -16,7 +16,6 @@ open Term
 open Constr
 open Context
 open Vars
-open Termops
 open Environ
 open Coercionops
 open Declare
@@ -186,7 +185,7 @@ let build_id_coercion idf_opt source poly =
     | None -> error_not_transparent source in
   let lams,t = decompose_lam_assum c in
   let val_f =
-    it_mkLambda_or_LetIn
+    Term.it_mkLambda_or_LetIn
       (mkLambda (make_annot (Name Namegen.default_dependent_ident) Sorts.Relevant,
                  applistc vs (Context.Rel.instance_list mkRel 0 lams),
                  mkRel 1))

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -292,8 +292,8 @@ let do_program_recursive ~pm ~scope ~poly ?typing_flags ?using fixkind fixl =
     (* Generalize by the recursive prototypes  *)
     let terms = [def; typ] in
     let using = Option.map (fun using -> Proof_using.definition_using env evd ~using ~terms) using in
-    let def = nf_evar evd (Termops.it_mkNamedLambda_or_LetIn evd def rec_sign) in
-    let typ = nf_evar evd (Termops.it_mkNamedProd_or_LetIn evd typ rec_sign) in
+    let def = nf_evar evd (EConstr.it_mkNamedLambda_or_LetIn evd def rec_sign) in
+    let typ = nf_evar evd (EConstr.it_mkNamedProd_or_LetIn evd typ rec_sign) in
     let evm = collect_evars_of_term evd def typ in
     let evars, _, def, typ =
       RetrieveObl.retrieve_obligations env name evm


### PR DESCRIPTION
**Kind:** cleanup

This is part 2 of proposal at #15562. It includes:
- removal redundancy between termops and econstr
- move of `it_mkLambda`/`it_mkProd` combinators from `termops.ml` to `eConstr.ml` when on `EConstr.t`
- keep them in `termops.ml` otherwise
- deprecation of the redundant copies
- a bit of documentation of the function

This includes adding a few other combinators to complete the picture.

Only pending question I see is whether we extract something like `eConstrops.ml` out of `eConstr.ml` or if we keep things as they are, but this can anyway be the purpose of subsequent PRs.