### PR TITLE
Fix STM classification of Ltac2 Eval: should be query

### DIFF
--- a/plugins/ltac2/g_ltac2.mlg
+++ b/plugins/ltac2/g_ltac2.mlg
@@ -918,7 +918,7 @@ VERNAC COMMAND EXTEND VernacDeclareTactic2Definition
 | #[ raw_attributes ] [ "Ltac2" ltac2_entry(e) ] => { classify_ltac2 e } -> {
   Tac2entries.register_struct raw_attributes e
   }
-| ![proof_opt_query] [ "Ltac2" "Eval" ltac2_expr(e) ] => { Vernacextend.classify_as_sideeff } -> {
+| ![proof_opt_query] [ "Ltac2" "Eval" ltac2_expr(e) ] => { Vernacextend.classify_as_query } -> {
   fun ~pstate -> Tac2entries.perform_eval ~pstate e
   }
 END

--- a/test-suite/bugs/bug_15569.v
+++ b/test-suite/bugs/bug_15569.v
@@ -1,0 +1,7 @@
+Require Import Ltac2.Ltac2.
+
+Example Ex1: forall a : nat, True.
+  intros a.
+  Ltac2 Eval 'a.
+  exact I.
+Qed.


### PR DESCRIPTION
Fix #15569 (caused by the replay of side effect commands at the end of
the proof)
