### PR TITLE
Use a dummy term for SProp conversion

### DIFF
--- a/doc/changelog/01-kernel/15575-sprop-dummy-cclosure-red.rst
+++ b/doc/changelog/01-kernel/15575-sprop-dummy-cclosure-red.rst
@@ -1,0 +1,9 @@
+- **Fixed:**
+  We introduce a new irrelevant term in the reduction machine.
+  It is used to shortcut computation of terms living in a strict
+  proposition, and behaves as an exception. This restores subject
+  reduction, and also makes conversion of large terms in SProp
+  cheap
+  (`#15575 <https://github.com/coq/coq/pull/15575>`_,
+  fixes `#14015 <https://github.com/coq/coq/issues/14015>`_,
+  by Pierre-Marie Pédrot).

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -1351,14 +1351,11 @@ let rec skip_irrelevant_stack stk = match stk with
   let _ = update ~share:true m mk_irrelevant.mark mk_irrelevant.term in
   skip_irrelevant_stack s
 
-let is_irrelevant_constructor infos ((mi,i),_) = match infos.i_cache.i_mode with
-| Conversion ->
-  let decl = lookup_mind mi infos.i_cache.i_env in
-  let packet = decl.mind_packets.(i) in
-  packet.mind_relevance == Sorts.Irrelevant
+let is_irrelevant_constructor infos (ind,_) = match infos.i_cache.i_mode with
+| Conversion -> Indset_env.mem ind infos.i_cache.i_env.irr_inds
 | Reduction -> false
 
-(* FIXME: cache relevance in projection like Fix / Case nodes *)
+(* FIXME: cache relevance in projection like Fix / Case nodes or in env like constants and inds *)
 let is_irrelevant_projection infos p = match infos.i_cache.i_mode with
 | Conversion ->
   let mind = Projection.mind p in

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -280,18 +280,11 @@ let neutr = function
   | Whnf|Ntrl -> Whnf
   | Red|Cstr -> Red
 
-type optrel = Unknown | KnownR | KnownI
-
-let opt_of_rel = function
-  | Sorts.Relevant -> KnownR
-  | Sorts.Irrelevant -> KnownI
-
 module Mark : sig
 
   type t
 
-  val mark : red_state -> optrel -> t
-  val relevance : t -> optrel
+  val mark : red_state -> t
   val red_state : t -> red_state
 
   val neutr : t -> t
@@ -299,34 +292,15 @@ module Mark : sig
   val set_ntrl : t -> t
 
 end = struct
-  type t = int
+  type t = red_state
 
-  let[@inline] of_state = function
-    | Ntrl -> 0b00 | Cstr -> 0b01 | Whnf -> 0b10 | Red -> 0b11
+  let[@inline] mark state = state
 
-  let[@inline] of_relevance = function
-    | Unknown -> 0
-    | KnownR -> 0b01
-    | KnownI -> 0b10
+  let[@inline] red_state x = x
 
-  let[@inline] mark state relevance = (of_state state) * 4 + (of_relevance relevance)
+  let neutr = neutr
 
-  let[@inline] relevance x = match x land 0b11 with
-    | 0b00 -> Unknown
-    | 0b01 -> KnownR
-    | 0b10 -> KnownI
-    | _ -> assert false
-
-  let[@inline] red_state x = match x land 0b1100 with
-    | 0b0000 -> Ntrl
-    | 0b0100 -> Cstr
-    | 0b1000 -> Whnf
-    | 0b1100 -> Red
-    | _ -> assert false
-
-  let[@inline] neutr x = x lor 0b1000 (* Whnf|Ntrl -> Whnf | Red|Cstr -> Red *)
-
-  let[@inline] set_ntrl x = x land 0b0011
+  let[@inline] set_ntrl _ = Ntrl
 end
 let mark = Mark.mark
 
@@ -365,8 +339,8 @@ let fterm_of v = v.term
 let set_ntrl v = v.mark <- Mark.set_ntrl v.mark
 let is_val v = match Mark.red_state v.mark with Ntrl -> true | Cstr | Whnf | Red -> false
 
-let mk_atom c = {mark=mark Ntrl Unknown;term=FAtom c}
-let mk_red f = {mark=mark Red Unknown;term=f}
+let mk_atom c = {mark=mark Ntrl;term=FAtom c}
+let mk_red f = {mark=mark Red;term=f}
 
 (* Could issue a warning if no is still Red, pointing out that we loose
    sharing. *)
@@ -450,15 +424,14 @@ let rec stack_args_size = function
    lft_fconstr always create a new cell, while lift_fconstr avoids it
    when the lift is 0. *)
 let rec lft_fconstr n ft =
-  let r = Mark.relevance ft.mark in
   match ft.term with
     | (FInd _|FConstruct _|FFlex(ConstKey _|VarKey _)|FInt _|FFloat _|FIrrelevant) -> ft
     | FRel i -> {mark=ft.mark;term=FRel(i+n)}
-    | FLambda(k,tys,f,e) -> {mark=mark Cstr r; term=FLambda(k,tys,f,subs_shft(n,e))}
+    | FLambda(k,tys,f,e) -> {mark=mark Cstr; term=FLambda(k,tys,f,subs_shft(n,e))}
     | FFix(fx,e) ->
-      {mark=mark Cstr r; term=FFix(fx,subs_shft(n,e))}
+      {mark=mark Cstr; term=FFix(fx,subs_shft(n,e))}
     | FCoFix(cfx,e) ->
-      {mark=mark Cstr r; term=FCoFix(cfx,subs_shft(n,e))}
+      {mark=mark Cstr; term=FCoFix(cfx,subs_shft(n,e))}
     | FLIFT(k,m) -> lft_fconstr (n+k) m
     | FLOCKED -> assert false
     | FFlex (RelKey _) | FAtom _ | FApp _ | FProj _ | FCaseT _ | FCaseInvert _ | FProd _
@@ -471,9 +444,9 @@ let lift_fconstr_vect k v =
 let clos_rel e i =
   match expand_rel i e with
     | Inl(n,mt) -> lift_fconstr n mt
-    | Inr(k,None) -> {mark=mark Ntrl Unknown; term= FRel k}
+    | Inr(k,None) -> {mark=mark Ntrl; term= FRel k}
     | Inr(k,Some p) ->
-        lift_fconstr (k-p) {mark=mark Red Unknown;term=FFlex(RelKey p)}
+        lift_fconstr (k-p) {mark=mark Red;term=FFlex(RelKey p)}
 
 (* since the head may be reducible, we might introduce lifts of 0 *)
 let compact_stack head stk =
@@ -517,19 +490,19 @@ let destFLambda clos_fun t =
 let mk_clos e t =
   match kind t with
     | Rel i -> clos_rel e i
-    | Var x -> {mark = mark Red Unknown; term = FFlex (VarKey x) }
-    | Const c -> {mark = mark Red Unknown; term = FFlex (ConstKey c) }
-    | Meta _ | Sort _ ->  {mark = mark Ntrl KnownR; term = FAtom t }
-    | Ind kn -> {mark = mark Ntrl KnownR; term = FInd kn }
-    | Construct kn -> {mark = mark Cstr Unknown; term = FConstruct kn }
-    | Int i -> {mark = mark Cstr Unknown; term = FInt i}
-    | Float f -> {mark = mark Cstr Unknown; term = FFloat f}
+    | Var x -> {mark = mark Red; term = FFlex (VarKey x) }
+    | Const c -> {mark = mark Red; term = FFlex (ConstKey c) }
+    | Meta _ | Sort _ ->  {mark = mark Ntrl; term = FAtom t }
+    | Ind kn -> {mark = mark Ntrl; term = FInd kn }
+    | Construct kn -> {mark = mark Cstr; term = FConstruct kn }
+    | Int i -> {mark = mark Cstr; term = FInt i}
+    | Float f -> {mark = mark Cstr; term = FFloat f}
     | (CoFix _|Lambda _|Fix _|Prod _|Evar _|App _|Case _|Cast _|LetIn _|Proj _|Array _) ->
-        {mark = mark Red Unknown; term = FCLOS(t,e)}
+        {mark = mark Red; term = FCLOS(t,e)}
 
 let inject c = mk_clos (subs_id 0) c
 
-let mk_irrelevant = { mark = mark Cstr KnownI; term = FIrrelevant }
+let mk_irrelevant = { mark = mark Cstr; term = FIrrelevant }
 
 (************************************************************************)
 
@@ -734,10 +707,10 @@ let rec zip m stk =
     | Zapp args :: s -> zip {mark=Mark.neutr m.mark; term=FApp(m, args)} s
     | ZcaseT(ci, u, pms, p, br, e)::s ->
         let t = FCaseT(ci, u, pms, p, m, br, e) in
-        let mark = mark (neutr (Mark.red_state m.mark)) Unknown  in
+        let mark = mark (neutr (Mark.red_state m.mark)) in
         zip {mark; term=t} s
     | Zproj p :: s ->
-        let mark = mark (neutr (Mark.red_state m.mark)) Unknown in
+        let mark = mark (neutr (Mark.red_state m.mark)) in
         zip {mark; term=FProj(Projection.make p true,m)} s
     | Zfix(fx,par)::s ->
         zip fx (par @ append_stack [|m|] s)
@@ -748,8 +721,8 @@ let rec zip m stk =
         zip (update ~share:true rf m.mark m.term) s
     | Zprimitive(_op,c,rargs,kargs)::s ->
       let args = List.rev_append rargs (m::List.map snd kargs) in
-      let f = {mark = mark Red Unknown;term = FFlex (ConstKey c)} in
-      zip {mark=mark (neutr (Mark.red_state m.mark)) KnownR; term = FApp (f, Array.of_list args)} s
+      let f = {mark = mark Red; term = FFlex (ConstKey c)} in
+      zip {mark=mark (neutr (Mark.red_state m.mark)); term = FApp (f, Array.of_list args)} s
 
 let fapp_stack (m,stk) = zip m stk
 
@@ -816,7 +789,7 @@ let subs_consv v s =
 let rec get_args n tys f e = function
     | Zupdate r :: s ->
         (** The stack contains [Zupdate] mark only if in sharing mode *)
-        let _hd = update ~share:true r (mark Cstr (Mark.relevance r.mark)) (FLambda(n,tys,f,e)) in
+        let _hd = update ~share:true r (mark Cstr) (FLambda(n,tys,f,e)) in
         get_args n tys f e s
     | Zshift k :: s ->
         get_args n tys f (subs_shft (k,e)) s
@@ -830,7 +803,7 @@ let rec get_args n tys f e = function
           let etys = List.skipn na tys in
           get_args (n-na) etys f (subs_consn l 0 na e) s
     | ((ZcaseT _ | Zproj _ | Zfix _ | Zprimitive _) :: _ | []) as stk ->
-      (Inr {mark=mark Cstr Unknown;term=FLambda(n,tys,f,e)}, stk)
+      (Inr {mark=mark Cstr; term=FLambda(n,tys,f,e)}, stk)
 
 (* Eta expansion: add a reference to implicit surrounding lambda at end of stack *)
 let rec eta_expand_stack na = function
@@ -839,7 +812,7 @@ let rec eta_expand_stack na = function
       e :: eta_expand_stack na s
   | [] ->
     let arg = match na.binder_relevance with
-    | Sorts.Relevant -> {mark = mark Ntrl KnownR; term = FRel 1}
+    | Sorts.Relevant -> {mark = mark Ntrl; term = FRel 1}
     | Sorts.Irrelevant -> mk_irrelevant
     in
     [Zshift 1; Zapp [|arg|]]
@@ -875,7 +848,7 @@ let get_native_args op c stk =
     | Zupdate(m) :: s ->
       strip_rec rnargs (update ~share:true m h.mark h.term) depth  kargs s
     | (Zprimitive _ | ZcaseT _ | Zproj _ | Zfix _) :: _ | [] -> assert false
-  in strip_rec [] {mark = mark Red Unknown;term = FFlex(ConstKey c)} 0 kargs stk
+  in strip_rec [] {mark = mark Red; term = FFlex(ConstKey c)} 0 kargs stk
 
 let get_native_args1 op c stk =
   match get_native_args op c stk with
@@ -1006,7 +979,7 @@ let eta_expand_ind_stack env ind m s (f, s') =
     (** Try to drop the params, might fail on partially applied constructors. *)
     let argss = try_drop_parameters depth pars args in
     let hstack = Array.map (fun p ->
-        { mark = mark Red Unknown; (* right can't be a constructor though *)
+        { mark = mark Red; (* right can't be a constructor though *)
           term = FProj (Projection.make p true, right) })
         projs
     in
@@ -1033,14 +1006,14 @@ let rec project_nth_arg n = function
 let contract_fix_vect fix =
   let (thisbody, make_body, env, nfix) =
     match [@ocaml.warning "-4"] fix with
-      | FFix (((reci,i),(nas,_,bds as rdcl)),env) ->
+      | FFix (((reci,i),(_,_,bds as rdcl)),env) ->
           (bds.(i),
-           (fun j -> { mark = mark Cstr (opt_of_rel nas.(j).binder_relevance);
+           (fun j -> { mark = mark Cstr;
                        term = FFix (((reci,j),rdcl),env) }),
            env, Array.length bds)
-      | FCoFix ((i,(nas,_,bds as rdcl)),env) ->
+      | FCoFix ((i,(_,_,bds as rdcl)),env) ->
           (bds.(i),
-           (fun j -> { mark = mark Cstr (opt_of_rel nas.(j).binder_relevance);
+           (fun j -> { mark = mark Cstr;
                        term = FCoFix ((j,rdcl),env) }),
            env, Array.length bds)
       | _ -> assert false
@@ -1071,7 +1044,7 @@ module FNativeEntries =
 
     let mk_construct c =
       (* All constructors used in primitive functions are relevant *)
-      { mark = mark Cstr KnownR; term = FConstruct (Univ.in_punivs c) }
+      { mark = mark Cstr; term = FConstruct (Univ.in_punivs c) }
 
     let get = Array.get
 
@@ -1090,7 +1063,7 @@ module FNativeEntries =
       | FArray (_u,t,_ty) -> t
       | _ -> raise Not_found
 
-    let dummy = {mark = mark Ntrl KnownR; term = FRel 0}
+    let dummy = {mark = mark Ntrl; term = FRel 0}
 
     let current_retro = ref Retroknowledge.empty
     let defined_int = ref false
@@ -1100,7 +1073,7 @@ module FNativeEntries =
       match retro.Retroknowledge.retro_int63 with
       | Some c ->
         defined_int := true;
-        fint := { mark = mark Ntrl KnownR; term = FFlex (ConstKey (Univ.in_punivs c)) }
+        fint := { mark = mark Ntrl; term = FFlex (ConstKey (Univ.in_punivs c)) }
       | None -> defined_int := false
 
     let defined_float = ref false
@@ -1110,7 +1083,7 @@ module FNativeEntries =
       match retro.Retroknowledge.retro_float64 with
       | Some c ->
         defined_float := true;
-        ffloat := { mark = mark Ntrl KnownR; term = FFlex (ConstKey (Univ.in_punivs c)) }
+        ffloat := { mark = mark Ntrl; term = FFlex (ConstKey (Univ.in_punivs c)) }
       | None -> defined_float := false
 
     let defined_bool = ref false
@@ -1161,7 +1134,7 @@ module FNativeEntries =
         fLt := mk_construct cLt;
         fGt := mk_construct cGt;
         let (icmp, _) = cEq in
-        fcmp := { mark = mark Ntrl KnownR; term = FInd (Univ.in_punivs icmp) }
+        fcmp := { mark = mark Ntrl; term = FInd (Univ.in_punivs icmp) }
       | None -> defined_cmp := false
 
     let defined_f_cmp = ref false
@@ -1265,11 +1238,11 @@ module FNativeEntries =
 
     let mkInt env i =
       check_int env;
-      { mark = mark Cstr KnownR; term = FInt i }
+      { mark = mark Cstr; term = FInt i }
 
     let mkFloat env f =
       check_float env;
-      { mark = mark Cstr KnownR; term = FFloat f }
+      { mark = mark Cstr; term = FFloat f }
 
     let mkBool env b =
       check_bool env;
@@ -1277,17 +1250,17 @@ module FNativeEntries =
 
     let mkCarry env b e =
       check_carry env;
-      {mark = mark Cstr KnownR;
+      {mark = mark Cstr;
        term = FApp ((if b then !fC1 else !fC0),[|!fint;e|])}
 
     let mkIntPair env e1 e2 =
       check_pair env;
-      { mark = mark Cstr KnownR; term = FApp(!fPair, [|!fint;!fint;e1;e2|]) }
+      { mark = mark Cstr; term = FApp(!fPair, [|!fint;!fint;e1;e2|]) }
 
     let mkFloatIntPair env f i =
       check_pair env;
       check_float env;
-      { mark = mark Cstr KnownR; term = FApp(!fPair, [|!ffloat;!fint;f;i|]) }
+      { mark = mark Cstr; term = FApp(!fPair, [|!ffloat;!fint;f;i|]) }
 
     let mkLt env =
       check_cmp env;
@@ -1355,7 +1328,7 @@ module FNativeEntries =
 
     let mkArray env u t ty =
       check_array env;
-      { mark = mark Whnf KnownR; term = FArray (u,t,ty)}
+      { mark = mark Whnf; term = FArray (u,t,ty)}
 
   end
 
@@ -1444,29 +1417,29 @@ and knht info e t stk =
         (mk_irrelevant, skip_irrelevant_stack stk)
       else
         let term = FCaseInvert (ci, u, pms, p, (Array.map (mk_clos e) indices), mk_clos e t, br, e) in
-        { mark = mark Red Unknown; term }, stk
+        { mark = mark Red; term }, stk
     | Fix (((_, n), (lna, _, _)) as fx) ->
       if is_irrelevant info.i_cache.i_mode (lna.(n)).binder_relevance then
         (mk_irrelevant, skip_irrelevant_stack stk)
       else
-        knh info { mark = mark Cstr Unknown; term = FFix (fx, e) } stk
+        knh info { mark = mark Cstr; term = FFix (fx, e) } stk
     | Cast(a,_,_) -> knht info e a stk
     | Rel n -> knh info (clos_rel e n) stk
-    | Proj (p, c) -> knh info { mark = mark Red Unknown; term = FProj (p, mk_clos e c) } stk
+    | Proj (p, c) -> knh info { mark = mark Red; term = FProj (p, mk_clos e c) } stk
     | (Ind _|Const _|Construct _|Var _|Meta _ | Sort _ | Int _|Float _) -> (mk_clos e t, stk)
-    | CoFix cfx -> { mark = mark Cstr Unknown; term = FCoFix (cfx,e) }, stk
-    | Lambda _ -> { mark = mark Cstr Unknown; term = mk_lambda e t }, stk
+    | CoFix cfx -> { mark = mark Cstr; term = FCoFix (cfx,e) }, stk
+    | Lambda _ -> { mark = mark Cstr ; term = mk_lambda e t }, stk
     | Prod (n, t, c) ->
-      { mark = mark Whnf KnownR; term = FProd (n, mk_clos e t, c, e) }, stk
+      { mark = mark Whnf; term = FProd (n, mk_clos e t, c, e) }, stk
     | LetIn (n,b,t,c) ->
-      { mark = mark Red Unknown; term = FLetIn (n, mk_clos e b, mk_clos e t, c, e) }, stk
-    | Evar ev -> { mark = mark Red Unknown; term = FEvar (ev, e) }, stk
+      { mark = mark Red; term = FLetIn (n, mk_clos e b, mk_clos e t, c, e) }, stk
+    | Evar ev -> { mark = mark Red; term = FEvar (ev, e) }, stk
     | Array(u,t,def,ty) ->
       let len = Array.length t in
       let ty = mk_clos e ty in
       let t = Parray.init (Uint63.of_int len) (fun i -> mk_clos e t.(i)) (mk_clos e def) in
       let term = FArray (u,t,ty) in
-      knh info { mark = mark Cstr Unknown; term } stk
+      knh info { mark = mark Cstr; term } stk
 
 (************************************************************************)
 
@@ -1545,8 +1518,8 @@ let rec knr info tab m stk =
              | Some m ->
              kni info tab m s
              | None ->
-               let f = {mark = mark Whnf KnownR; term = FFlex (ConstKey c)} in
-               let m = {mark = mark Whnf KnownR; term = FApp(f,args)} in
+               let f = {mark = mark Whnf; term = FFlex (ConstKey c)} in
+               let m = {mark = mark Whnf; term = FApp(f,args)} in
                (m,s)
            end
          | (kd,a)::nargs ->
@@ -1756,6 +1729,3 @@ let infos_with_reds infos reds =
   { infos with i_flags = reds }
 
 let unfold_reference env st tab key = ref_value_cache env st Conversion tab key
-
-let relevance_of f = Mark.relevance f.mark
-let set_relevance r f = f.mark <- Mark.mark (Mark.red_state f.mark) (opt_of_rel r)

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -118,6 +118,7 @@ type fterm =
   | FArray of Univ.Instance.t * fconstr Parray.t * fconstr
   | FLIFT of int * fconstr
   | FCLOS of constr * fconstr subs
+  | FIrrelevant
   | FLOCKED
 
 (***********************************************************************
@@ -145,7 +146,8 @@ val get_native_args1 : CPrimitives.t -> pconstant -> stack ->
   fconstr list * fconstr * fconstr next_native_args * stack
 
 val stack_args_size : stack -> int
-val eta_expand_stack : stack -> stack
+val eta_expand_stack : Name.t Context.binder_annot -> stack -> stack
+val skip_irrelevant_stack : stack -> stack
 
 val inductive_subst : Declarations.mutual_inductive_body
   -> Univ.Instance.t
@@ -177,6 +179,8 @@ val set_relevance : Sorts.relevance -> fconstr -> unit
 (** Global and local constant cache *)
 type clos_infos
 type clos_tab
+val create_conv_infos :
+  ?univs:UGraph.t -> ?evars:(existential->constr option) -> reds -> env -> clos_infos
 val create_clos_infos :
   ?univs:UGraph.t -> ?evars:(existential->constr option) -> reds -> env -> clos_infos
 val oracle_of_infos : clos_infos -> Conv_oracle.oracle

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -171,11 +171,6 @@ val term_of_fconstr : fconstr -> constr
 val destFLambda :
   (fconstr subs -> constr -> fconstr) -> fconstr -> Name.t Context.binder_annot * fconstr * fconstr
 
-type optrel = Unknown | KnownR | KnownI
-
-val relevance_of : fconstr -> optrel
-val set_relevance : Sorts.relevance -> fconstr -> unit
-
 (** Global and local constant cache *)
 type clos_infos
 type clos_tab

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -80,6 +80,8 @@ type env = private {
   env_nb_rel        : int;
   env_universes : UGraph.t;
   env_universes_lbound : UGraph.Bound.t;
+  irr_constants : Cset_env.t;
+  irr_inds : Indset_env.t;
   env_typing_flags  : typing_flags;
   retroknowledge : Retroknowledge.retroknowledge;
   indirect_pterms : Opaqueproof.opaquetab;

--- a/kernel/inferCumulativity.ml
+++ b/kernel/inferCumulativity.ml
@@ -207,6 +207,7 @@ let rec infer_fterm cv_pb infos variances hd stk =
 
   (* Removed by whnf *)
   | FLOCKED | FCaseT _ | FLetIn _ | FApp _ | FLIFT _ | FCLOS _ -> assert false
+  | FIrrelevant -> assert false (* TODO: use create_conv_infos below and use it? *)
 
 and infer_stack infos variances (stk:CClosure.stack) =
   match stk with

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -328,10 +328,6 @@ let push_relevance infos r =
 let push_relevances infos nas =
   { infos with cnv_inf = CClosure.push_relevances infos.cnv_inf nas }
 
-let is_irrelevant infos lft c =
-  let env = info_env infos.cnv_inf in
-  try Relevanceops.relevance_of_fterm env (info_relevances infos.cnv_inf) lft c == Sorts.Irrelevant with _ -> false
-
 let identity_of_ctx (ctx:Constr.rel_context) =
   Context.Rel.instance mkRel 0 ctx
 
@@ -368,8 +364,7 @@ let esubst_of_rel_context_instance_list ctx u args e =
 
 (* Conversion between  [lft1]term1 and [lft2]term2 *)
 let rec ccnv cv_pb l2r infos lft1 lft2 term1 term2 cuniv =
-  try eqappr cv_pb l2r infos (lft1, (term1,[])) (lft2, (term2,[])) cuniv
-  with NotConvertible when is_irrelevant infos lft1 term1 && is_irrelevant infos lft2 term2 -> cuniv
+  eqappr cv_pb l2r infos (lft1, (term1,[])) (lft2, (term2,[])) cuniv
 
 (* Conversion between [lft1](hd1 v1) and [lft2](hd2 v2) *)
 and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
@@ -381,6 +376,8 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
   let appr1 = (lft1, appr1) and appr2 = (lft2, appr2) in
   (** We delay the computation of the lifts that apply to the head of the term
       with [el_stack] inside the branches where they are actually used. *)
+  (** Irrelevant terms are guaranteed to be [FIrrelevant], except for [FFlex],
+      [FRel] and [FLambda]. Those ones are handled specifically below. *)
   match (fterm_of hd1, fterm_of hd2) with
     (* case of leaves *)
     | (FAtom a1, FAtom a2) ->
@@ -396,6 +393,7 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
                else raise NotConvertible
            | _ -> raise NotConvertible)
     | (FEvar ((ev1,args1),env1), FEvar ((ev2,args2),env2)) ->
+        (* TODO: handle irrelevance *)
         if Evar.equal ev1 ev2 then
           let el1 = el_stack lft1 v1 in
           let el2 = el_stack lft2 v2 in
@@ -409,9 +407,18 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
     | (FRel n, FRel m) ->
         let el1 = el_stack lft1 v1 in
         let el2 = el_stack lft2 v2 in
-        if Int.equal (reloc_rel n el1) (reloc_rel m el2)
-        then convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
-        else raise NotConvertible
+        let n = reloc_rel n el1 in
+        let m = reloc_rel m el2 in
+        let rn = Range.get (info_relevances infos.cnv_inf) (n - 1) in
+        let rm = Range.get (info_relevances infos.cnv_inf) (m - 1) in
+        if rn == Sorts.Irrelevant && rm == Sorts.Irrelevant then
+          let v1 = CClosure.skip_irrelevant_stack v2 in
+          let v2 = CClosure.skip_irrelevant_stack v2 in
+          convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
+        else if Int.equal n m then
+          convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
+        else
+          raise NotConvertible
 
     (* 2 constants, 2 local defined vars or 2 defined rels *)
     | (FFlex fl1, FFlex fl2) ->
@@ -527,7 +534,7 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
         let (x1,_ty1,bd1) = destFLambda mk_clos hd1 in
         let infos = push_relevance infos x1 in
         eqappr CONV l2r infos
-          (el_lift lft1, (bd1, [])) (el_lift lft2, (hd2, eta_expand_stack v2)) cuniv
+          (el_lift lft1, (bd1, [])) (el_lift lft2, (hd2, eta_expand_stack x1 v2)) cuniv
     | (_, FLambda _) ->
         let () = match v2 with
         | [] -> ()
@@ -537,7 +544,7 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
         let (x2,_ty2,bd2) = destFLambda mk_clos hd2 in
         let infos = push_relevance infos x2 in
         eqappr CONV l2r infos
-          (el_lift lft1, (hd1, eta_expand_stack v1)) (el_lift lft2, (bd2, [])) cuniv
+          (el_lift lft1, (hd1, eta_expand_stack x2 v1)) (el_lift lft2, (bd2, [])) cuniv
 
     (* only one constant, defined var or defined rel *)
     | (FFlex fl1, c2)      ->
@@ -702,13 +709,32 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
       let cuniv = Parray.fold_left2 (fun u v1 v2 -> ccnv CONV l2r infos el1 el2 v1 v2 u) cuniv t1 t2 in
       convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
 
+    | (FRel n1, FIrrelevant) ->
+      let n1 = reloc_rel n1 (el_stack lft1 v1) in
+      let r1 = Range.get (info_relevances infos.cnv_inf) (n1 - 1) in
+      if r1 == Sorts.Irrelevant then
+        let v1 = CClosure.skip_irrelevant_stack v1 in
+        convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
+      else raise NotConvertible
+
+    | (FIrrelevant, FRel n2) ->
+      let n2 = reloc_rel n2 (el_stack lft2 v2) in
+      let r2 = Range.get (info_relevances infos.cnv_inf) (n2 - 1) in
+      if r2 == Sorts.Irrelevant then
+        let v2 = CClosure.skip_irrelevant_stack v2 in
+        convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
+      else raise NotConvertible
+
+    | FIrrelevant, FIrrelevant ->
+      convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
+
      (* Should not happen because both (hd1,v1) and (hd2,v2) are in whnf *)
      | ( (FLetIn _, _) | (FCaseT _,_) | (FApp _,_) | (FCLOS _,_) | (FLIFT _,_)
        | (_, FLetIn _) | (_,FCaseT _) | (_,FApp _) | (_,FCLOS _) | (_,FLIFT _)
        | (FLOCKED,_) | (_,FLOCKED) ) -> assert false
 
      | (FRel _ | FAtom _ | FInd _ | FFix _ | FCoFix _ | FCaseInvert _
-        | FProd _ | FEvar _ | FInt _ | FFloat _ | FArray _), _ -> raise NotConvertible
+       | FProd _ | FEvar _ | FInt _ | FFloat _ | FArray _ | FIrrelevant), _ -> raise NotConvertible
 
 and convert_stacks l2r infos lft1 lft2 stk1 stk2 cuniv =
   let f (l1, t1) (l2, t2) cuniv = ccnv CONV l2r infos l1 l2 t1 t2 cuniv in
@@ -830,7 +856,7 @@ and convert_list l2r infos lft1 lft2 v1 v2 cuniv = match v1, v2 with
 
 let clos_gen_conv trans cv_pb l2r evars env graph univs t1 t2 =
   let reds = CClosure.RedFlags.red_add_transparent betaiotazeta trans in
-  let infos = create_clos_infos ~univs:graph ~evars reds env in
+  let infos = create_conv_infos ~univs:graph ~evars reds env in
   let infos = {
     cnv_inf = infos;
     lft_tab = create_tab ();

--- a/kernel/relevanceops.ml
+++ b/kernel/relevanceops.ml
@@ -74,6 +74,7 @@ let rec relevance_of_fterm env extra lft f =
       | FCLOS (c, e) -> relevance_of_term_extra env extra lft e c
 
       | FEvar (_, _) -> Sorts.Relevant (* let's assume evars are relevant for now *)
+      | FIrrelevant -> Sorts.Irrelevant
       | FLOCKED -> assert false
     in
     CClosure.set_relevance r f;

--- a/kernel/relevanceops.ml
+++ b/kernel/relevanceops.ml
@@ -39,63 +39,19 @@ let relevance_of_projection env p =
   let mib = lookup_mind mind env in
   Declareops.relevance_of_projection_repr mib (Projection.repr p)
 
-let relevance_of_flex env = function
-  | ConstKey (c,_) -> relevance_of_constant env c
-  | VarKey x -> relevance_of_var env x
-  | RelKey p -> relevance_of_rel env p
-
-let rec relevance_of_fterm env extra lft f =
-  let open CClosure in
-  match CClosure.relevance_of f with
-  | KnownR -> Sorts.Relevant
-  | KnownI -> Sorts.Irrelevant
-  | Unknown ->
-    let r = match fterm_of f with
-      | FRel n -> Range.get extra (Esubst.reloc_rel n lft - 1)
-      | FAtom c -> relevance_of_term_extra env extra lft (Esubst.subs_id 0) c
-      | FFlex key -> relevance_of_flex env key
-      | FInt _ | FFloat _ | FArray _ -> Sorts.Relevant
-      | FInd _ | FProd _ -> Sorts.Relevant (* types are always relevant *)
-      | FConstruct (c,_) -> relevance_of_constructor env c
-      | FApp (f, _) -> relevance_of_fterm env extra lft f
-      | FProj (p, _) -> relevance_of_projection env p
-      | FFix (((_,i),(lna,_,_)), _) -> (lna.(i)).binder_relevance
-      | FCoFix ((i,(lna,_,_)), _) -> (lna.(i)).binder_relevance
-      | FCaseT (ci, _, _, _, _, _, _) | FCaseInvert (ci, _, _, _, _, _, _, _) -> ci.ci_relevance
-      | FLambda (len, tys, bdy, e) ->
-        let extra = List.fold_left (fun accu (x, _) -> Range.cons (binder_relevance x) accu) extra tys in
-        let lft = Esubst.el_liftn len lft in
-        let e = Esubst.subs_liftn len e in
-        relevance_of_term_extra env extra lft e bdy
-      | FLetIn (x, _, _, bdy, e) ->
-        relevance_of_term_extra env (Range.cons x.binder_relevance extra)
-          (Esubst.el_lift lft) (Esubst.subs_lift e) bdy
-      | FLIFT (k, f) -> relevance_of_fterm env extra (Esubst.el_shft k lft) f
-      | FCLOS (c, e) -> relevance_of_term_extra env extra lft e c
-
-      | FEvar (_, _) -> Sorts.Relevant (* let's assume evars are relevant for now *)
-      | FIrrelevant -> Sorts.Irrelevant
-      | FLOCKED -> assert false
-    in
-    CClosure.set_relevance r f;
-    r
-
-and relevance_of_term_extra env extra lft subs c =
+let rec relevance_of_term_extra env extra lft c =
   match kind c with
   | Rel n ->
-    begin match Esubst.expand_rel n subs with
-     | Inl (k, f) -> relevance_of_fterm env extra (Esubst.el_liftn k lft) f
-     | Inr (n, None) -> Range.get extra (Esubst.reloc_rel n lft - 1)
-     | Inr (_, Some p) -> relevance_of_rel env p
-    end
+    if n <= lft then Range.get extra (n - 1)
+    else relevance_of_rel env (n - lft)
   | Var x -> relevance_of_var env x
   | Sort _ | Ind _ | Prod _ -> Sorts.Relevant (* types are always relevant *)
-  | Cast (c, _, _) -> relevance_of_term_extra env extra lft subs c
+  | Cast (c, _, _) -> relevance_of_term_extra env extra lft c
   | Lambda ({binder_relevance=r;_}, _, bdy) ->
-    relevance_of_term_extra env (Range.cons r extra) (Esubst.el_lift lft) (Esubst.subs_lift subs) bdy
+    relevance_of_term_extra env (Range.cons r extra) (lft + 1) bdy
   | LetIn ({binder_relevance=r;_}, _, _, bdy) ->
-    relevance_of_term_extra env (Range.cons r extra) (Esubst.el_lift lft) (Esubst.subs_lift subs) bdy
-  | App (c, _) -> relevance_of_term_extra env extra lft subs c
+    relevance_of_term_extra env (Range.cons r extra) (lft + 1) bdy
+  | App (c, _) -> relevance_of_term_extra env extra lft c
   | Const (c,_) -> relevance_of_constant env c
   | Construct (c,_) -> relevance_of_constructor env c
   | Case (ci, _, _, _, _, _, _) -> ci.ci_relevance
@@ -107,11 +63,5 @@ and relevance_of_term_extra env extra lft subs c =
 
   | Meta _ | Evar _ -> Sorts.Relevant (* let's assume metas and evars are relevant for now *)
 
-let relevance_of_fterm env extra lft c =
-  if Environ.sprop_allowed env then relevance_of_fterm env extra lft c
-  else Sorts.Relevant
-
 let relevance_of_term env c =
-  if Environ.sprop_allowed env
-  then relevance_of_term_extra env Range.empty Esubst.el_id (Esubst.subs_id 0) c
-  else Sorts.Relevant
+  relevance_of_term_extra env Range.empty 0 c

--- a/kernel/relevanceops.mli
+++ b/kernel/relevanceops.mli
@@ -14,11 +14,6 @@
 
 val relevance_of_term : Environ.env -> Constr.constr -> Sorts.relevance
 
-val relevance_of_fterm : Environ.env -> Sorts.relevance Range.t ->
-  Esubst.lift -> CClosure.fconstr ->
-  Sorts.relevance
-
-
 (** Helpers *)
 open Names
 val relevance_of_rel : Environ.env -> int -> Sorts.relevance

--- a/test-suite/bugs/bug_14014.v
+++ b/test-suite/bugs/bug_14014.v
@@ -1,0 +1,12 @@
+Inductive SFalse : SProp := .
+Definition adjust_of_sprop {A} {x y : A} (pf : x <> y) : x <> y
+  := fun e : x = y => SFalse_ind (fun _ => False) (match pf e return SFalse with end).
+
+Definition adjust_of_sprop_idempotent {A x y pf} : @adjust_of_sprop A x y (@adjust_of_sprop A x y pf) = @adjust_of_sprop A x y pf.
+Proof. cbv [adjust_of_sprop]; reflexivity. Defined.
+Definition adjust_of_sprop_idempotent' {A x y pf} : @adjust_of_sprop A x y (@adjust_of_sprop A x y pf) = @adjust_of_sprop A x y pf
+  := Eval cbv in @adjust_of_sprop_idempotent A x y pf.
+
+Inductive sF : SProp := .
+
+Definition ff (x y:sF) : match x return nat with end = match y with end := eq_refl.

--- a/test-suite/success/sprop_fast.v
+++ b/test-suite/success/sprop_fast.v
@@ -1,0 +1,18 @@
+Fixpoint big n : unit := match n with 0 => tt | S n => match big n with tt => big n end end.
+
+Inductive squash (A : Type) : SProp := Squash : A -> squash A.
+Inductive box (A : SProp) : Type := Box : A -> box A.
+
+(* If this is ever unfolded, this will explode *)
+Goal Box _ (Squash _ (big 50)) = Box _ (Squash _ tt).
+Proof.
+reflexivity.
+Qed.
+
+Definition SquashC := Squash.
+
+(* If this is ever unfolded, this will explode *)
+Goal Box _ (SquashC _ (big 50)) = Box _ (SquashC _ tt).
+Proof.
+reflexivity.
+Qed.


### PR DESCRIPTION
This PR introduce a new irrelevant term in the reduction machine. It is used to shortcut computation of terms living in a strict proposition, and behaves as an exception.

Fix #14015