### PR TITLE
Inform dune that autoconfigure depends on PWD

### DIFF
--- a/config/dune
+++ b/config/dune
@@ -20,5 +20,6 @@
    %{project_root}/dev/header.c
    ; Needed to generate include lists for coq_makefile
    plugin_list
+  (env_var PWD) ; used in the fallback of COQ_CONFIGURE_PREFIX
   (env_var COQ_CONFIGURE_PREFIX))
  (action (chdir %{project_root} (run %{project_root}/tools/configure/configure.exe -no-ask -native-compiler no -bin-annot))))


### PR DESCRIPTION
dune not knowing this caused issues with dune cache
