### PR TITLE
fix(coq.opam.docker): Remove leftover `make byte`

### DIFF
--- a/coq.opam.docker
+++ b/coq.opam.docker
@@ -36,7 +36,6 @@ build: [
     "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]
-  [make "-j%{jobs}%" "byte"]
 ]
 install: [
   [make "install"]


### PR DESCRIPTION
Context: [this Zulip topic](https://coq.zulipchat.com/#narrow/stream/237656-Coq-devs.20.26.20plugin.20devs/topic/Why.20.60coqorg.2Fcoq.3Adev.60.20FTBFS.20currently.3F/near/270316804).

* Fixes https://github.com/coq/coq/commit/6184404b74da850ecebc16d33a3784e2867a10cb (incomplete cleanup commit)

* Related: https://github.com/coq/coq/pull/15506

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md