### PR TITLE
Make Permutation_cons and _app' #[export]

### DIFF
--- a/doc/changelog/10-standard-library/15597-exprt-bad-perm-instances.rst
+++ b/doc/changelog/10-standard-library/15597-exprt-bad-perm-instances.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  typeclass instances `Permutation_app'` and `Permutation_cons` are `#[export]` instead of `#[global]`
+  (`#15597 <https://github.com/coq/coq/pull/15597>`_,
+  fixes `#15596 <https://github.com/coq/coq/issues/15596>`_,
+  by Gaëtan Gilbert).

--- a/theories/Sorting/Permutation.v
+++ b/theories/Sorting/Permutation.v
@@ -106,7 +106,7 @@ Proof.
   now apply IHHP; rewrite <- app_assoc.
 Qed.
 
-#[global]
+#[export]
 Instance Permutation_cons A :
  Proper (Logic.eq ==> @Permutation A ==> @Permutation A) (@cons A).
 Proof.
@@ -161,7 +161,7 @@ Proof.
   apply Permutation_app_tail; assumption.
 Qed.
 
-Global Instance Permutation_app' :
+#[export] Instance Permutation_app' :
  Proper (@Permutation A ==> @Permutation A ==> @Permutation A) (@app A).
 Proof.
   repeat intro; now apply Permutation_app.


### PR DESCRIPTION
Fix #15596 (we still get a slowdown on Require Import)
Maybe we should use Hint Extern or just don't declare these Proper
instances instead.
