### PR TITLE
Add some trigonometry lemmas

### DIFF
--- a/doc/changelog/10-standard-library/15599-x-sinx-x.rst
+++ b/doc/changelog/10-standard-library/15599-x-sinx-x.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Added a proof of ``sin x < x`` for positive ``x`` and ``x < sin x`` for negative ``x``
+  (`#15599 <https://github.com/coq/coq/pull/15599>`_,
+  by stop-cran).

--- a/theories/Reals/Ratan.v
+++ b/theories/Reals/Ratan.v
@@ -2177,3 +2177,27 @@ Unshelve.
     pose proof Rsqr_bounds_lt 1 x ltac:(lra) as Hxb; rewrite Rsqr_1 in Hxb.
     apply sqrt_lt_1; lra.
 Qed.
+
+Lemma sin_lt_x x : 0 < x -> sin x < x.
+Proof.
+  intros.
+  pose proof PI2_1.
+  destruct (SIN_bound x), (Rle_or_lt x (PI / 2)); try lra.
+  pose (f x := x - sin x).
+  cut (f 0 < f x); [now unfold f; rewrite sin_0; lra|].
+  eapply (MVT.derive_increasing_interv 0 (PI/2) (id - sin)%F); try lra.
+  intros t Ht.
+  rewrite derive_pt_minus, derive_pt_id, derive_pt_sin.
+  pose proof (COS_bound t).
+  pose proof cos_0.
+  pose proof (cos_inj 0 t).
+  lra.
+Qed.
+
+Lemma sin_gt_x x : x < 0 -> x < sin x.
+Proof.
+  intros.
+  pose proof (sin_lt_x (- x)).
+  pose proof (sin_neg x).
+  lra.
+Qed.


### PR DESCRIPTION
Just added some minor but generic lemmas:
- `sin x < x` for positive `x`.
- `PI > 2` - apparently now there's only a proof of `PI > 0` in the standard library.