### PR TITLE
Fix #15603: ocamldebug fails with Reference to undefined global Dynlink.

### DIFF
--- a/dev/core_dune.dbg
+++ b/dev/core_dune.dbg
@@ -7,6 +7,7 @@ load_printer boot.cma
 load_printer lib.cma
 load_printer gramlib.cma
 load_printer coqrun.cma
+load_printer dynlink.cma
 load_printer kernel.cma
 load_printer library.cma
 load_printer engine.cma


### PR DESCRIPTION
It works for 4.07, but can somebody test with more recent versions?