### PR TITLE
Evaluating possibly costly illegal fix recursive call error only at printing time

### DIFF
--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -1006,7 +1006,8 @@ let check_is_subterm x tree =
 exception FixGuardError of env * guard_error
 
 let error_illegal_rec_call renv fx (arg_renv,arg) =
-  let (_,le_vars,lt_vars) =
+  let le_lt_vars =
+  lazy (let (_,le_vars,lt_vars) =
     List.fold_left
       (fun (i,le,lt) sbt ->
         match Lazy.force sbt with
@@ -1014,9 +1015,10 @@ let error_illegal_rec_call renv fx (arg_renv,arg) =
           | (Subterm(Large,_)) -> (i+1, i::le, lt)
           | _ -> (i+1, le ,lt))
       (1,[],[]) renv.genv in
+        (le_vars,lt_vars)) in
   raise (FixGuardError (renv.env,
                         RecursionOnIllegalTerm(fx,(arg_renv.env, arg),
-                                               le_vars,lt_vars)))
+                                               le_lt_vars)))
 
 let error_partial_apply renv fx =
   raise (FixGuardError (renv.env,NotEnoughArgumentsForFixCall fx))

--- a/kernel/type_errors.ml
+++ b/kernel/type_errors.ml
@@ -20,7 +20,7 @@ type 'constr pguard_error =
   (* Fixpoints *)
   | NotEnoughAbstractionInFixBody
   | RecursionNotOnInductiveType of 'constr
-  | RecursionOnIllegalTerm of int * (env * 'constr) * int list * int list
+  | RecursionOnIllegalTerm of int * (env * 'constr) * (int list * int list) Lazy.t
   | NotEnoughArgumentsForFixCall of int
   (* CoFixpoints *)
   | CodomainNotInductiveType of 'constr
@@ -170,7 +170,7 @@ let error_bad_variance env ~lev ~expected ~actual =
 let map_pguard_error f = function
 | NotEnoughAbstractionInFixBody -> NotEnoughAbstractionInFixBody
 | RecursionNotOnInductiveType c -> RecursionNotOnInductiveType (f c)
-| RecursionOnIllegalTerm (n, (env, c), l1, l2) -> RecursionOnIllegalTerm (n, (env, f c), l1, l2)
+| RecursionOnIllegalTerm (n, (env, c), l1_l2) -> RecursionOnIllegalTerm (n, (env, f c), l1_l2)
 | NotEnoughArgumentsForFixCall n -> NotEnoughArgumentsForFixCall n
 | CodomainNotInductiveType c -> CodomainNotInductiveType (f c)
 | NestedRecursiveOccurrences -> NestedRecursiveOccurrences

--- a/kernel/type_errors.mli
+++ b/kernel/type_errors.mli
@@ -21,7 +21,7 @@ type 'constr pguard_error =
   (** Fixpoints *)
   | NotEnoughAbstractionInFixBody
   | RecursionNotOnInductiveType of 'constr
-  | RecursionOnIllegalTerm of int * (env * 'constr) * int list * int list
+  | RecursionOnIllegalTerm of int * (env * 'constr) * (int list * int list) Lazy.t
   | NotEnoughArgumentsForFixCall of int
   (** CoFixpoints *)
   | CodomainNotInductiveType of 'constr

--- a/test-suite/complexity/guard_illegal_call.v
+++ b/test-suite/complexity/guard_illegal_call.v
@@ -1,0 +1,16 @@
+(* Examples to check that the guard condition does not evaluate
+   irrelevant subterms *)
+(* Expected time < 1.00s *)
+Require Import Bool.
+
+Fixpoint slow n (s:bool) :=
+ match n with
+ | 0 => true
+ | S k => andb (slow k s) (slow k s)
+ end.
+
+Timeout 5 Time Fixpoint F s n :=
+  match n with
+  | 0 => fun _ => 0
+  | S k => fun s' => F s k
+  end (slow 100 s).

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -463,7 +463,7 @@ let explain_ill_formed_rec_body env sigma err names i fixenv vdefj =
   | RecursionNotOnInductiveType c ->
       str "Recursive definition on" ++ spc () ++ pr_lconstr_env env sigma c ++
       spc () ++ str "which should be a recursive inductive type"
-  | RecursionOnIllegalTerm(j,(arg_env, arg),le,lt) ->
+  | RecursionOnIllegalTerm(j,(arg_env, arg),le_lt) ->
       let arg_env = make_all_name_different arg_env sigma in
       let called =
         match names.(j).binder_name with
@@ -471,13 +471,13 @@ let explain_ill_formed_rec_body env sigma err names i fixenv vdefj =
           | Anonymous -> str "the " ++ pr_nth i ++ str " definition" in
       let pr_db x = quote (pr_db env x) in
       let vars =
-        match (lt,le) with
+        match Lazy.force le_lt with
             ([],[]) -> assert false
-          | ([],[x]) -> str "a subterm of " ++ pr_db x
-          | ([],_) -> str "a subterm of the following variables: " ++
+          | ([x],[]) -> str "a subterm of " ++ pr_db x
+          | (le,[]) -> str "a subterm of the following variables: " ++
               pr_sequence pr_db le
-          | ([x],_) -> pr_db x
-          | _ ->
+          | (_,[x]) -> pr_db x
+          | (_,lt) ->
               str "one of the following variables: " ++
               pr_sequence pr_db lt in
       str "Recursive call to " ++ called ++ spc () ++


### PR DESCRIPTION
**Kind:** efficiency

It can sometimes be costly, either because of internal backtracking or in looking for the decreasing argument. In particular, in the latter case, the possibly costly error message is computed and thrown away for the non-decreasing arguments.

Here is an example:
```
Require Import Bool.

Fixpoint slow n (s:bool) :=
 match n with
 | 0 => true
 | S k => andb (slow k s) (slow k s)
 end.

Fixpoint F s n :=
  match n with
  | 0 => fun _ => 0
  | S k => fun s' => F s k
  end (slow 100 s).
(* Very long *)
```
where what is slow is to compute in the ignored error message sent to `search_guard` that `s'` is not a valid variable for the recursive call.

Found while experimenting with `fresh_strings_of_set` in `stringmap.v` in stdpp (it has a `wf_guard 32` to pre-compute fuel).

- [X] Added / updated **test-suite**.