### PR TITLE
setoid_rewrite: try subterms when rewriting produces identity

### DIFF
--- a/doc/changelog/04-tactics/15612-rewrite-with-progress.rst
+++ b/doc/changelog/04-tactics/15612-rewrite-with-progress.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  When :tacn:`setoid_rewrite` succeeds in rewriting at some occurrence but the resulting equality is the identity, it now tries rewriting in subterms of that occurrence instead of giving up
+  (`#15612 <https://github.com/coq/coq/pull/15612>`_,
+  fixes `#8080 <https://github.com/coq/coq/issues/8080>`_,
+  by Gaëtan Gilbert).

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -1454,7 +1454,7 @@ let rewrite_with l2r flags c occs : strategy = { strategy =
     let app = apply_rule unify in
     let strat =
       Strategies.fix (fun aux ->
-        Strategies.choice app (subterm true default_flags aux))
+        Strategies.choice (Strategies.progress app) (subterm true default_flags aux))
     in
     let occs, res = strat.strategy { input with state = initialize_occurrence_counter occs } in
     check_used_occurrences occs;


### PR DESCRIPTION
Fix #8080
