### PR TITLE
DecidableClasses: added decidability instances for Z.le Z.lt Z.ge Z.gt

### DIFF
--- a/doc/changelog/10-standard-library/15620-z-arith-decidable.rst
+++ b/doc/changelog/10-standard-library/15620-z-arith-decidable.rst
@@ -1,4 +1,4 @@
 - **Added:**
-  Added decidability typeclass instances for Z.le, Z.lt, Z.ge and Z.gt, added lemmas Z.geb_ge and Z.gtb_gt
+  decidability typeclass instances for Z.le, Z.lt, Z.ge and Z.gt, added lemmas Z.geb_ge and Z.gtb_gt
   (`#15620 <https://github.com/coq/coq/pull/15620>`_,
   by Michael Soegtrop).

--- a/doc/changelog/10-standard-library/15620-z-arith-decidable.rst
+++ b/doc/changelog/10-standard-library/15620-z-arith-decidable.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Added decidability typeclass instances for Z.le, Z.lt, Z.ge and Z.gt, added lemmas Z.geb_ge and Z.gtb_gt
+  (`#15620 <https://github.com/coq/coq/pull/15620>`_,
+  by Michael Soegtrop).

--- a/theories/Classes/DecidableClass.v
+++ b/theories/Classes/DecidableClass.v
@@ -77,33 +77,45 @@ Next Obligation.
 Qed.
 
 #[global]
-Program Instance Decidable_eq_bool : forall (x y : bool), Decidable (eq x y) := {
-  Decidable_witness := Bool.eqb x y
+Instance Decidable_eq_bool : forall (x y : bool), Decidable (eq x y) := {
+  Decidable_spec := eqb_true_iff x y
 }.
-Next Obligation.
- apply eqb_true_iff.
-Qed.
 
 #[global]
-Program Instance Decidable_eq_nat : forall (x y : nat), Decidable (eq x y) := {
-  Decidable_witness := Nat.eqb x y
+Instance Decidable_eq_nat : forall (x y : nat), Decidable (eq x y) := {
+  Decidable_spec := Nat.eqb_eq x y
 }.
-Next Obligation.
- apply Nat.eqb_eq.
-Qed.
 
 #[global]
-Program Instance Decidable_le_nat : forall (x y : nat), Decidable (x <= y) := {
-  Decidable_witness := Nat.leb x y
+Instance Decidable_le_nat : forall (x y : nat), Decidable (x <= y) := {
+  Decidable_spec := Nat.leb_le x y
 }.
-Next Obligation.
- apply Nat.leb_le.
-Qed.
+
+(* Note: Decidable_lt_nat, Decidable_ge_nat, Decidable_gt_nat are not required,
+   because lt, ge and gt are defined based on le in a way which type class
+   resolution seems to understand. *)
 
 #[global]
-Program Instance Decidable_eq_Z : forall (x y : Z), Decidable (eq x y) := {
-  Decidable_witness := Z.eqb x y
+Instance Decidable_eq_Z : forall (x y : Z), Decidable (eq x y) := {
+  Decidable_spec := Z.eqb_eq x y
 }.
-Next Obligation.
- apply Z.eqb_eq.
-Qed.
+
+#[global]
+Instance Decidable_le_Z : forall (x y : Z), DecidableClass.Decidable (x <= y)%Z := {
+  Decidable_spec := Z.leb_le x y
+}.
+
+#[global]
+Instance Decidable_lt_Z : forall (x y : Z), DecidableClass.Decidable (x < y)%Z := {
+  Decidable_spec := Z.ltb_lt x y
+}.
+
+#[global]
+Instance Decidable_ge_Z : forall (x y : Z), DecidableClass.Decidable (x >= y)%Z := {
+  Decidable_spec := Z.geb_ge x y
+}.
+
+#[global]
+Instance Decidable_gt_Z : forall (x y : Z), DecidableClass.Decidable (x > y)%Z := {
+  Decidable_spec := Z.gtb_gt x y
+}.

--- a/theories/ZArith/BinInt.v
+++ b/theories/ZArith/BinInt.v
@@ -398,6 +398,16 @@ Proof.
  unfold leb, le. destruct compare; easy'.
 Qed.
 
+Lemma gtb_gt n m : (n >? m) = true <-> n > m.
+Proof.
+  unfold gtb, gt. destruct compare; easy'.
+Qed.
+
+Lemma geb_ge n m : (n >=? m) = true <-> n >= m.
+Proof.
+  unfold geb, ge. destruct compare; easy'.
+Qed.
+
 Lemma compare_eq_iff n m : (n ?= m) = Eq <-> n = m.
 Proof.
 destruct n, m; simpl; rewrite ?CompOpp_iff, ?Pos.compare_eq_iff;


### PR DESCRIPTION
This PR adds decidability instances for Z.le, Z.lt, Z.ge and Z.gt + 2 lemmas required for this.

With this QuickChick can handle out of the box rather intricate lemmas on Z arithmetic.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
