### PR TITLE
Selectively print the contents of goals in CoqIDE.

### DIFF
--- a/ide/coqide/coq.ml
+++ b/ide/coqide/coq.ml
@@ -716,5 +716,8 @@ end
 let goals x h k =
   PrintOpt.enforce h (fun () -> eval_call (Xmlprotocol.goals x) h k)
 
+let subgoals x h k =
+  PrintOpt.enforce h (fun () -> eval_call (Xmlprotocol.subgoals x) h k)
+
 let evars x h k =
   PrintOpt.enforce h (fun () -> eval_call (Xmlprotocol.evars x) h k)

--- a/ide/coqide/coq.mli
+++ b/ide/coqide/coq.mli
@@ -153,6 +153,7 @@ val edit_at    : Interface.edit_at_sty    -> Interface.edit_at_rty query
 val query      : Interface.query_sty      -> Interface.query_rty query
 val status     : Interface.status_sty     -> Interface.status_rty query
 val goals      : Interface.goals_sty      -> Interface.goals_rty query
+val subgoals   : Interface.subgoals_sty   -> Interface.subgoals_rty query
 val evars      : Interface.evars_sty      -> Interface.evars_rty query
 val hints      : Interface.hints_sty      -> Interface.hints_rty query
 val mkcases    : Interface.mkcases_sty    -> Interface.mkcases_rty query

--- a/ide/coqide/coqOps.ml
+++ b/ide/coqide/coqOps.ml
@@ -238,6 +238,12 @@ type queue_msg =
   | MsgFeedback of Feedback.feedback
   | MsgDebug of string * Pp.t
 
+let rec flatten = function
+| [] -> []
+| (lg, rg) :: l ->
+  let inner = flatten l in
+  List.rev_append lg inner @ rg
+
 class coqops
   (_script:Wg_ScriptView.script_view)
   (_pv:Wg_ProofView.proof_view)
@@ -380,18 +386,39 @@ object(self)
         script#recenter_insert
       end
     end;
-    Coq.bind (Coq.goals ()) (function
+    let flags = { gf_mode = "full"; gf_fg = true; gf_bg = true; gf_shelved = false; gf_given_up = false } in
+    let return x = Coq.return (Good x) in
+    let (>>=) m f = Coq.bind m (function
+    | Fail x -> Coq.return (Fail x)
+    | Good v -> f v)
+    in
+    let call =
+      Coq.subgoals flags >>= begin function
+      | None -> return Wg_ProofView.NoGoals
+      | Some { fg_goals = ((_ :: _) as fg); bg_goals = bg } ->
+        let bg = flatten (List.rev bg) in
+        return (Wg_ProofView.FocusGoals { fg; bg; })
+      | Some { fg_goals = []; bg_goals = bg } ->
+        let flags = { gf_mode = "short"; gf_fg = false; gf_bg = false; gf_shelved = true; gf_given_up = true } in
+        Coq.subgoals flags >>= fun rem ->
+        Coq.evars () >>= fun evars ->
+        let evars = match evars with None -> [] | Some l -> l in
+        let bg = flatten (List.rev bg) in
+        let shelved, given_up = match rem with
+        | None -> [], []
+        | Some goals -> goals.shelved_goals, goals.given_up_goals
+        in
+        return (Wg_ProofView.NoFocusGoals { bg; evars; shelved; given_up })
+      end
+    in
+    Coq.bind call begin function
     | Fail x -> self#handle_failure_aux ~move_insert x
     | Good goals ->
-      Coq.bind (Coq.evars ()) (function
-        | Fail x -> self#handle_failure_aux ~move_insert x
-        | Good evs ->
-          proof#set_goals goals;
-          proof#set_evars evs;
-          proof#refresh ~force:true;
-          Coq.return ()
-        )
-      )
+      proof#set_goals goals;
+      proof#refresh ~force:true;
+      Coq.return ()
+    end
+
   method show_goals = self#show_goals_aux ()
 
   (* This method is intended to perform stateless commands *)

--- a/ide/coqide/coqOps.ml
+++ b/ide/coqide/coqOps.ml
@@ -401,14 +401,12 @@ object(self)
       | Some { fg_goals = []; bg_goals = bg } ->
         let flags = { gf_mode = "short"; gf_fg = false; gf_bg = false; gf_shelved = true; gf_given_up = true } in
         Coq.subgoals flags >>= fun rem ->
-        Coq.evars () >>= fun evars ->
-        let evars = match evars with None -> [] | Some l -> l in
         let bg = flatten (List.rev bg) in
         let shelved, given_up = match rem with
         | None -> [], []
         | Some goals -> goals.shelved_goals, goals.given_up_goals
         in
-        return (Wg_ProofView.NoFocusGoals { bg; evars; shelved; given_up })
+        return (Wg_ProofView.NoFocusGoals { bg; shelved; given_up })
       end
     in
     Coq.bind call begin function

--- a/ide/coqide/protocol/interface.ml
+++ b/ide/coqide/protocol/interface.ml
@@ -97,6 +97,15 @@ type search_constraint =
     the flag should be negated. *)
 type search_flags = (search_constraint * bool) list
 
+(** Subset of goals to print. *)
+type goal_flags = {
+  gf_mode : string;
+  gf_fg : bool;
+  gf_bg : bool;
+  gf_shelved : bool;
+  gf_given_up : bool;
+}
+
 (** A named object in Coq. [coq_object_qualid] is the shortest path defined for
     the user. [coq_object_prefix] is the missing part to recover the fully
     qualified name, i.e [fully_qualified = coq_object_prefix + coq_object_qualid].
@@ -174,6 +183,11 @@ type query_rty = unit
     progress, [Some gl] otherwise. *)
 type goals_sty = unit
 type goals_rty = goals option
+
+(** Same as above, but specific kind of goals can be retrieved by setting the
+    flags. *)
+type subgoals_sty = goal_flags
+type subgoals_rty = goals option
 
 (** Retrieve the list of uninstantiated evars in the current proof. [None] if no
     proof is in progress. *)
@@ -302,5 +316,6 @@ type handler = {
   wait        : wait_sty        -> wait_rty;
   (* Retrocompatibility stuff *)
   interp      : interp_sty      -> interp_rty;
+  subgoals    : subgoals_sty -> subgoals_rty;
 }
 

--- a/ide/coqide/protocol/xmlprotocol.mli
+++ b/ide/coqide/protocol/xmlprotocol.mli
@@ -44,6 +44,7 @@ val db_continue : db_continue_sty -> db_continue_rty call
 val db_stack    : db_stack_sty    -> db_stack_rty call
 val db_vars     : db_vars_sty     -> db_vars_rty call
 val db_configd  : db_configd_sty  -> db_configd_rty call
+val subgoals    : subgoals_sty -> subgoals_rty call
 
 val abstract_eval_call : handler -> 'a call -> bool * 'a value
 

--- a/ide/coqide/wg_ProofView.ml
+++ b/ide/coqide/wg_ProofView.ml
@@ -12,6 +12,16 @@ open Util
 open Preferences
 open Ideutils
 
+type goals =
+| NoGoals
+| FocusGoals of { fg : Interface.goal list; bg : Interface.goal list }
+| NoFocusGoals of {
+  bg : Interface.goal list;
+  shelved : Interface.goal list;
+  given_up : Interface.goal list;
+  evars : Interface.evar list;
+}
+
 class type proof_view =
   object
     inherit GObj.widget
@@ -19,8 +29,7 @@ class type proof_view =
     method buffer : GText.buffer
     method refresh : force:bool -> unit
     method clear : unit -> unit
-    method set_goals : Interface.goals option -> unit
-    method set_evars : Interface.evar list option -> unit
+    method set_goals : goals -> unit
     method set_debug_goal : Pp.t -> unit
   end
 
@@ -121,11 +130,10 @@ let mode_tactic sel_cb (proof : #GText.view_skel) goals ~unfoc_goals hints = mat
       if Coq.PrintOpt.printing_unfocused () then
         begin
           ignore(proof#buffer#place_cursor ~where:(proof#buffer#end_iter));
-          let unfoc = List.flatten (List.rev (List.map (fun (x,y) -> x@y) unfoc_goals)) in
-          if unfoc<>[] then
+          if unfoc_goals<>[] then
             begin
               proof#buffer#insert "\nUnfocused Goals:\n";
-              Util.List.fold_left_i (fold_goal ~shownum:false) 0 () unfoc
+              Util.List.fold_left_i (fold_goal ~shownum:false) 0 () unfoc_goals
             end
         end;
       ignore(proof#buffer#place_cursor
@@ -133,22 +141,16 @@ let mode_tactic sel_cb (proof : #GText.view_skel) goals ~unfoc_goals hints = mat
                          (Some Tags.Proof.goal)));
       ignore(proof#scroll_to_mark `INSERT)
 
-let rec flatten = function
-| [] -> []
-| (lg, rg) :: l ->
-  let inner = flatten l in
-  List.rev_append lg inner @ rg
-
-let display mode (view : #GText.view_skel) goals hints evars =
+let display mode (view : #GText.view_skel) goals hints =
   let () = view#buffer#set_text "" in
   let width = Ideutils.textview_width view in
   match goals with
-  | None -> ()
+  | NoGoals -> ()
     (* No proof in progress *)
-  | Some { Interface.fg_goals = []; bg_goals = bg; shelved_goals; given_up_goals; } ->
-    let bg = flatten (List.rev bg) in
-    let evars = match evars with None -> [] | Some evs -> evs in
-    begin match (bg, shelved_goals,given_up_goals, evars) with
+  | FocusGoals { fg; bg } ->
+    mode view fg ~unfoc_goals:bg hints
+  | NoFocusGoals { bg; shelved; given_up; evars } ->
+    begin match (bg, shelved, given_up, evars) with
     | [], [], [], [] ->
       view#buffer#insert "No more goals."
     | [], [], [], _ :: _ ->
@@ -167,7 +169,7 @@ let display mode (view : #GText.view_skel) goals hints evars =
         insert_xml view#buffer (Richpp.richpp_of_pp ~width goal.Interface.goal_ccl);
         view#buffer#insert "\n"
       in
-      List.iter iter given_up_goals;
+      List.iter iter given_up;
       view#buffer#insert "\nYou need to go back and solve them."
     | [], _, _, _ ->
       (* All the goals have been resolved but those on the shelf. *)
@@ -176,7 +178,7 @@ let display mode (view : #GText.view_skel) goals hints evars =
         insert_xml view#buffer (Richpp.richpp_of_pp ~width goal.Interface.goal_ccl);
         view#buffer#insert "\n"
       in
-      List.iter iter shelved_goals
+      List.iter iter shelved
     | _, _, _, _ ->
       (* No foreground proofs, but still unfocused ones *)
       let total = List.length bg in
@@ -195,8 +197,6 @@ let display mode (view : #GText.view_skel) goals hints evars =
       in
       List.iteri iter bg
     end
-  | Some { Interface.fg_goals = fg; bg_goals = bg } ->
-    mode view fg ~unfoc_goals:bg hints
 
 
 let proof_view () =
@@ -221,8 +221,7 @@ let proof_view () =
 
   let pf = object(self)
     inherit GObj.widget view#as_widget
-    val mutable goals = None
-    val mutable evars = None
+    val mutable goals = NoGoals
     val mutable debug_goal = None
     val mutable last_width = -1
 
@@ -233,8 +232,6 @@ let proof_view () =
     method clear () = buffer#set_text ""
 
     method set_goals gls = goals <- gls; debug_goal <- None
-
-    method set_evars evs = evars <- evs
 
     method set_debug_goal msg =
       (* Appearance is a bit different from the regular goals display.
@@ -260,7 +257,7 @@ let proof_view () =
         match debug_goal with
         | None ->
           let dummy _ () = () in
-          display (mode_tactic dummy) view goals None evars
+          display (mode_tactic dummy) view goals None
         | Some msg -> self#set_debug_goal msg
       end
   end

--- a/ide/coqide/wg_ProofView.mli
+++ b/ide/coqide/wg_ProofView.mli
@@ -8,6 +8,16 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+type goals =
+| NoGoals
+| FocusGoals of { fg : Interface.goal list; bg : Interface.goal list }
+| NoFocusGoals of {
+  bg : Interface.goal list;
+  shelved : Interface.goal list;
+  given_up : Interface.goal list;
+  evars : Interface.evar list;
+}
+
 class type proof_view =
   object
     inherit GObj.widget
@@ -15,8 +25,7 @@ class type proof_view =
     method buffer : GText.buffer
     method refresh : force:bool -> unit
     method clear : unit -> unit
-    method set_goals : Interface.goals option -> unit
-    method set_evars : Interface.evar list option -> unit
+    method set_goals : goals -> unit
     method set_debug_goal : Pp.t -> unit
   end
 

--- a/ide/coqide/wg_ProofView.mli
+++ b/ide/coqide/wg_ProofView.mli
@@ -15,7 +15,6 @@ type goals =
   bg : Interface.goal list;
   shelved : Interface.goal list;
   given_up : Interface.goal list;
-  evars : Interface.evar list;
 }
 
 class type proof_view =


### PR DESCRIPTION
Instead of unconditionally printing all goals internally even if we don't display them, we introduce a new call to selectively print part of the proof environment. Since this does not touch the previous goal call, this change is backwards compatible w.r.t. the XML protocol.

Fixes #10623, a longstanding pretty annoying bug.