### PR TITLE
Excluding Variant and Record from function find_inductive

### DIFF
--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -40,7 +40,7 @@ let find_inductive env c =
   let (t, l) = decompose_app (whd_all env c) in
   match kind t with
     | Ind ind
-        when (fst (lookup_mind_specif env (out_punivs ind))).mind_finite <> CoFinite -> (ind, l)
+        when (fst (lookup_mind_specif env (out_punivs ind))).mind_finite == Finite -> (ind, l)
     | _ -> raise Not_found
 
 let find_coinductive env c =
@@ -1486,9 +1486,6 @@ let inductive_of_mutfix env ((nvect,bodynum),(names,types,bodies as recdef)) =
                   try find_inductive env a
                   with Not_found ->
                     raise_err env i (RecursionNotOnInductiveType a) in
-                let mib,_ = lookup_mind_specif env (out_punivs mind) in
-                if mib.mind_finite != Finite then
-                  raise_err env i (RecursionNotOnInductiveType a);
                 (mind, (env', b))
               else check_occur env' (n+1) b
             else anomaly ~label:"check_one_fix" (Pp.str "Bad occurrence of recursive call.")

--- a/kernel/inductive.mli
+++ b/kernel/inductive.mli
@@ -16,11 +16,12 @@ open Environ
 
 (** {6 Extracting an inductive type from a construction } *)
 
-(** [find_m*type env sigma c] coerce [c] to an recursive type (I args).
+(** [find_*type env c] coerces [c] to an
+   inductive/coinductive/variant/record type of the form (I args).
    [find_rectype], [find_inductive] and [find_coinductive]
-   respectively accepts any recursive type, only an inductive type and
-   only a coinductive type.
-   They raise [Not_found] if not convertible to a recursive type. *)
+   respectively accept any inductive/coinductive/variant/record type,
+   only an inductive type and only a coinductive type.
+   They raise [Not_found] if not convertible to such type. *)
 
 val find_rectype     : env -> types -> pinductive * constr list
 val find_inductive   : env -> types -> pinductive * constr list

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -575,7 +575,7 @@ let find_inductive env sigma c =
   let (t, l) = decompose_app sigma (whd_all env sigma c) in
   match EConstr.kind sigma t with
     | Ind ind
-        when (fst (Inductive.lookup_mind_specif env (fst ind))).mind_finite <> CoFinite ->
+        when (fst (Inductive.lookup_mind_specif env (fst ind))).mind_finite == Finite ->
         let l = List.map EConstr.Unsafe.to_constr l in
         (ind, l)
     | _ -> raise Not_found

--- a/test-suite/success/fix.v
+++ b/test-suite/success/fix.v
@@ -96,3 +96,8 @@ assumption.
 apply bcons.
 assumption.
 Qed.
+
+Variant V := C.
+Lemma a2 : V -> V.
+Fail fix a 1. (* no fix on a variant *)
+Abort.

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -453,7 +453,7 @@ let explain_ill_formed_fix_body env sigma names i = function
       str "Not enough abstractions in the definition"
   | RecursionNotOnInductiveType c ->
       str "Recursive definition on" ++ spc () ++ pr_leconstr_env env sigma c ++
-      spc () ++ str "which should be a recursive inductive type"
+      spc () ++ str "which should be an inductive type"
   | RecursionOnIllegalTerm(j,(arg_env, arg),le_lt) ->
       let arg_env = make_all_name_different arg_env sigma in
       let called =


### PR DESCRIPTION
**Kind:** clarification of semantics

This simplifies the description of the condition about when a fixpoint is allowed (see #407, 7ceed3c76e), and let the tactic `fix` follows the same rule as the term constructor `fix`.

More precisely, `find_inductive` becomes a check of `mind_finite = Finite` (which at the current time means defined with the keyword `Inductive`; eventually, it could rather mean truly-recursive Inductive, excluding e.g. `prod`, `unit`, ...).

- [x] Added / updated **test-suite**

