### PR TITLE
Add a test for #7068.

### DIFF
--- a/test-suite/bugs/bug_7068.v
+++ b/test-suite/bugs/bug_7068.v
@@ -4,3 +4,4 @@
 Inductive foo : let T := Type in T := .
 Definition bob1 := Eval vm_compute in foo_rect.
 Definition bob2 := Eval native_compute in foo_rect.
+Definition bob3 := Eval lazy in foo_rect.


### PR DESCRIPTION
Fixes #7068.

(This was really fixed by the change of case representation.)