### PR TITLE
An optimization in the guard checker

### DIFF
--- a/test-suite/complexity/guard_return_predicate.v
+++ b/test-suite/complexity/guard_return_predicate.v
@@ -1,0 +1,18 @@
+(* Testk that we don't unfold unnecessarily in guard condition the
+   body of a return predicate *)
+(* Expected time < 1.00s *)
+
+Fixpoint slow n : Type -> Type :=
+  match n with
+  | 0 => fun A => A
+  | S k => fun A => slow k (slow k A)
+  end.
+
+Parameter y : unit.
+Parameter h : slow 100 nat -> nat.
+
+Timeout 5 Time Fixpoint F (g:nat->slow 100 nat) n : nat :=
+  match n with
+  | 0 => 0
+  | S k => (fun x => h (match y return slow 100 nat with tt => g (F g x) end)) k
+  end.


### PR DESCRIPTION
**Kind:** Performance

We avoid reducing the body of the return predicate when not necessary in `filter_stack_domain`. 

In particular, this should reduce the 17s spent in guard checking to ~0s in the Qed for `extend_tc.tc_expr_cenv_sub` in VST, out of 77s for the whole Qed (figures based on current CI).
