### PR TITLE
Term_typing: centralizing the processing of universes

### DIFF
--- a/kernel/term_typing.mli
+++ b/kernel/term_typing.mli
@@ -41,7 +41,7 @@ val check_delayed : 'a effect_handler -> typing_context -> 'a proof_output -> (C
 
 (** Internal functions, mentioned here for debug purpose only *)
 
-val infer_declaration : env ->
+val infer_constant : env ->
   constant_entry -> typing_context Discharge.result
 
 val build_constant_declaration :


### PR DESCRIPTION
**Kind:** cleanup

This is a proposition to make the code of `term_typing.m` globally more uniform in style, especially regarding universes. For that purpose, we factor all `push_context_set`, `abstract_universes`, `instance`, `make_instance_subst` behind a common entry point `process_universes`.

Of course, there is some part of subjectivity in the way it is done. Comments welcome.