### PR TITLE
Ltac2 is now compiled with "-noinit"

### DIFF
--- a/doc/stdlib/index-list.html.template
+++ b/doc/stdlib/index-list.html.template
@@ -667,6 +667,7 @@ through the <tt>Require Import</tt> command.</p>
   </dt>
   <dd>
     user-contrib/Ltac2/Ltac2.v
+    user-contrib/Ltac2/Noinit.v
     user-contrib/Ltac2/Array.v
     user-contrib/Ltac2/Bool.v
     user-contrib/Ltac2/Char.v

--- a/user-contrib/Ltac2/Init.v
+++ b/user-contrib/Ltac2/Init.v
@@ -8,6 +8,12 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+Declare ML Module "ltac_plugin".
+(* This is already declared in the Stdlib prelude, however in order to use Ltac2
+    with the "-noinit" flag we need to compile the entire Ltac2 library with
+    this flag. This requires explicitly (re)declaring the preceding plugin.
+    Note that redeclaring does no harm since this is an idempotent operation. *)
+
 Declare ML Module "ltac2_plugin".
 
 #[export] Set Default Proof Mode "Ltac2".

--- a/user-contrib/Ltac2/Init.v
+++ b/user-contrib/Ltac2/Init.v
@@ -8,11 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-Declare ML Module "ltac_plugin".
-(* This is already declared in the Stdlib prelude, however in order to use Ltac2
-    with the "-noinit" flag we need to compile the entire Ltac2 library with
-    this flag. This requires explicitly (re)declaring the preceding plugin.
-    Note that redeclaring does no harm since this is an idempotent operation. *)
+From Coq Require Import Init.Ltac.
 
 Declare ML Module "ltac2_plugin".
 

--- a/user-contrib/Ltac2/Ltac2.v
+++ b/user-contrib/Ltac2/Ltac2.v
@@ -8,8 +8,5 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-Require Export Ltac2.Init.
-
-Require Noinit.
-
-Require Export Ltac2.Notations.
+From Ltac2 Require Export Init Notations.
+From Ltac2 Require Noinit Ltac1.

--- a/user-contrib/Ltac2/Noinit.v
+++ b/user-contrib/Ltac2/Noinit.v
@@ -8,8 +8,25 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+(** The parts of Ltac2 that do not require the stdlib to be loaded. *)
+
 Require Export Ltac2.Init.
 
-Require Noinit.
-
-Require Export Ltac2.Notations.
+Require Ltac2.Array.
+Require Ltac2.Bool.
+Require Ltac2.Char.
+Require Ltac2.Constr.
+Require Ltac2.Control.
+Require Ltac2.Env.
+Require Ltac2.Fresh.
+Require Ltac2.Ident.
+Require Ltac2.Ind.
+Require Ltac2.Int.
+Require Ltac2.List.
+Require Ltac2.Ltac1.
+Require Ltac2.Message.
+Require Ltac2.Option.
+Require Ltac2.Pattern.
+Require Ltac2.Printf.
+Require Ltac2.Std.
+Require Ltac2.String.

--- a/user-contrib/Ltac2/Noinit.v
+++ b/user-contrib/Ltac2/Noinit.v
@@ -23,7 +23,6 @@ Require Ltac2.Ident.
 Require Ltac2.Ind.
 Require Ltac2.Int.
 Require Ltac2.List.
-Require Ltac2.Ltac1.
 Require Ltac2.Message.
 Require Ltac2.Option.
 Require Ltac2.Pattern.

--- a/user-contrib/Ltac2/Notations.v
+++ b/user-contrib/Ltac2/Notations.v
@@ -8,6 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+From Coq Require Import Init.Prelude.
 Require Import Ltac2.Init.
 Require Ltac2.Control Ltac2.Pattern Ltac2.Array Ltac2.Int Ltac2.Std.
 

--- a/user-contrib/Ltac2/dune
+++ b/user-contrib/Ltac2/dune
@@ -2,5 +2,5 @@
  (name Ltac2)
  (package coq-stdlib)
  (synopsis "Ltac2 tactic language")
- (flags -w -deprecated-native-compiler-option)
+ (flags -w -deprecated-native-compiler-option -noinit)
  (libraries coq-core.plugins.ltac2))


### PR DESCRIPTION
We now compile all of Ltac2 with the "-noinit" flag. There is now only a small dependence on the stdlib. The first is on `Coq.Init.Ltac`, and the second is in `Ltac2.Notations,` due to a dependency on `f_equal` from the `cc_plugin` and `easy` from 	`Coq.Init.Tactics`.

Ltac2.Ltac2 is now accompanied by Ltac2.Noinit which the former `Require`s. This allows projects which use "-noinit" to import
Ltac2.Noinit and use Ltac2 without importing the entire prelude. For other projects, Ltac2.Ltac2 should have the same behaviour as before.

The original motivation for this is to let the HoTT library (which uses "-noinit") use Ltac2 without importing any of the stdlib (which causes problems).

I will need to also write some tests for the test-suite to check it is usable. 

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

- [ ] Added / updated **test-suite**.
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make -f Makefile.dune doc_gram_rsts`.
- [ ] Opened **overlay** pull requests.

