### PR TITLE
Fixes #15606: transitive dependencies missing in clearbody.

### DIFF
--- a/doc/changelog/04-tactics/15634-master+fix-15606-clearbody-transitive-check.rst
+++ b/doc/changelog/04-tactics/15634-master+fix-15606-clearbody-transitive-check.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Ill-typed goals created by :tacn:`clearbody` in the presence of
+  transitive dependencies in the body of a hypothesis
+  (`#15634 <https://github.com/coq/coq/pull/15634>`_,
+  fixes `#15606 <https://github.com/coq/coq/issues/15606>`_,
+  by Hugo Herbelin).

--- a/test-suite/bugs/bug_15606.v
+++ b/test-suite/bugs/bug_15606.v
@@ -1,0 +1,5 @@
+(* Test transitive dependencies for clearbody *)
+Goal let U := Set in forall T : U, T -> True.
+intros.
+Fail clearbody U.
+Abort.


### PR DESCRIPTION
**Kind:** fix

Tactic `clearbody` was missing check of transitive dependencies.

Fixes / closes #15606

I seized the opportunity to avoid computing too early the error messages possibly raised by `clearbody`, and rewrote the algorithm to stop exploring the context whenever the bodies to clear are all found.

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.