### PR TITLE
Ltac2: complete Int functions with div, mod, abs and logical functions

### DIFF
--- a/doc/changelog/05-tactic-language/15637-ltac2-int-div-boolops.rst
+++ b/doc/changelog/05-tactic-language/15637-ltac2-int-div-boolops.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Ltac2 `Int` functions `div`, `mod`, `asr`, `lsl`, `lsr`, `land`, `lor` , `lxor` and `lnot`.
+  (`#15637 <https://github.com/coq/coq/pull/15637>`_,
+  by Michael Soegtrop).

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -140,6 +140,9 @@ let err_notfound =
 let err_matchfailure =
   Tac2interp.LtacError (coq_core "Match_failure", [||])
 
+let err_division_by_zero =
+  Tac2interp.LtacError (coq_core "Division_by_zero", [||])
+
 (** Helper functions *)
 
 let thaw f = Tac2ffi.apply f [v_unit]
@@ -386,6 +389,10 @@ let () = define2 "int_equal" int int begin fun m n ->
   return (Value.of_bool (m == n))
 end
 
+let unop n f = define1 n int begin fun m ->
+  return (Value.of_int (f m))
+end
+
 let binop n f = define2 n int int begin fun m n ->
   return (Value.of_int (f m n))
 end
@@ -394,10 +401,24 @@ let () = binop "int_compare" Int.compare
 let () = binop "int_add" (+)
 let () = binop "int_sub" (-)
 let () = binop "int_mul" ( * )
-
-let () = define1 "int_neg" int begin fun m ->
-  return (Value.of_int (~- m))
+let () = define2 "int_div" int int begin fun m n ->
+  if n == 0 then throw err_division_by_zero
+  else return (Value.of_int (m / n))
 end
+let () = define2 "int_mod" int int begin fun m n ->
+  if n == 0 then throw err_division_by_zero
+  else return (Value.of_int (m mod n))
+end
+let () = unop "int_neg" (~-)
+let () = unop "int_abs" abs
+
+let () = binop "int_asr" (asr)
+let () = binop "int_lsl" (lsl)
+let () = binop "int_lsr" (lsr)
+let () = binop "int_land" (land)
+let () = binop "int_lor" (lor)
+let () = binop "int_lxor" (lxor)
+let () = unop "int_lnot" lnot
 
 (** Char *)
 

--- a/test-suite/ltac2/int.v
+++ b/test-suite/ltac2/int.v
@@ -1,0 +1,51 @@
+Require Import Ltac2.Ltac2.
+Require Ltac2.Int.
+Require Ltac2.Bool.
+
+(* Int comparison functions which throw an exception on unequal *)
+
+Ltac2 Type exn ::= [ Regression_Test_Failure ].
+
+Ltac2 check_eq_int a b :=
+  if Int.equal a b then () else Control.throw Regression_Test_Failure .
+
+Ltac2 check_eq_bool a b :=
+  if Bool.equal a b then () else Control.throw Regression_Test_Failure .
+
+Goal True.
+  (* Test failure *)
+  Fail check_eq_int 2 3.
+  Fail check_eq_bool true false.
+
+  check_eq_bool (Int.equal 2 2) true.
+  check_eq_bool (Int.equal 2 3) false.
+
+  check_eq_int (Int.add 5 7) 12.
+  check_eq_int (Int.sub 5 7) -2.
+  check_eq_int (Int.mul 5 7) 35.
+  check_eq_int (Int.div 7 5) 1.
+  check_eq_int (Int.div 7 -5) -1.
+  check_eq_int (Int.div -7 5) -1.
+  check_eq_int (Int.div -7 -5) 1.
+  Fail Ltac2 Eval Int.div 1 0.
+  check_eq_int (Int.mod 7 5) 2.
+  check_eq_int (Int.mod 7 -5) 2.
+  check_eq_int (Int.mod -7 5) -2.
+  check_eq_int (Int.mod -7 -5) -2.
+  Fail Ltac2 Eval Int.mod 1 0.
+  check_eq_int (Int.neg 5) -5.
+  check_eq_int (Int.abs -5) 5.
+
+  check_eq_int (Int.asr 16 2) 4.
+  check_eq_int (Int.asr -16 2) -4.
+  check_eq_int (Int.lsl 16 2) 64.
+  check_eq_int (Int.lsl -16 2) -64.
+  check_eq_int (Int.lsr 16 2) 4.
+  check_eq_int (Int.compare (Int.lsr -16 2) 0) 1.
+  check_eq_int (Int.land 7 12) 4.
+  check_eq_int (Int.lor 7 12) 15.
+  check_eq_int (Int.lxor 7 12) 11.
+  check_eq_int (Int.lnot -1) 0.
+
+  exact I.
+Qed.

--- a/user-contrib/Ltac2/Init.v
+++ b/user-contrib/Ltac2/Init.v
@@ -85,3 +85,6 @@ Ltac2 Type exn ::= [ Tactic_failure (message option) ].
 
 Ltac2 Type exn ::= [ Assertion_failure ].
 (** Used to indicate that an Ltac2 function ran into a situation that should never occcur. *)
+
+Ltac2 Type exn ::= [ Division_by_zero ].
+(** Int division by zero or modulus by zero *)

--- a/user-contrib/Ltac2/Int.v
+++ b/user-contrib/Ltac2/Int.v
@@ -10,14 +10,24 @@
 
 Require Import Ltac2.Init.
 
-Ltac2 Type exn ::= [ Division_by_zero ].
-
 Ltac2 @ external equal : int -> int -> bool := "ltac2" "int_equal".
 Ltac2 @ external compare : int -> int -> int := "ltac2" "int_compare".
 Ltac2 @ external add : int -> int -> int := "ltac2" "int_add".
 Ltac2 @ external sub : int -> int -> int := "ltac2" "int_sub".
 Ltac2 @ external mul : int -> int -> int := "ltac2" "int_mul".
+(* Note: unlike Coq Z division, Ltac2 matches OCaml division and rounds towards 0, so 1/-2 = 0 *)
+Ltac2 @ external div : int -> int -> int := "ltac2" "int_div".
+Ltac2 @ external mod : int -> int -> int := "ltac2" "int_mod".
 Ltac2 @ external neg : int -> int := "ltac2" "int_neg".
+Ltac2 @ external abs : int -> int := "ltac2" "int_abs".
+
+Ltac2 @ external asr : int -> int -> int := "ltac2" "int_asr".
+Ltac2 @ external lsl : int -> int -> int := "ltac2" "int_lsl".
+Ltac2 @ external lsr : int -> int -> int := "ltac2" "int_lsr".
+Ltac2 @ external land : int -> int -> int := "ltac2" "int_land".
+Ltac2 @ external lor : int -> int -> int := "ltac2" "int_lor".
+Ltac2 @ external lxor : int -> int -> int := "ltac2" "int_lxor".
+Ltac2 @ external lnot : int -> int := "ltac2" "int_lnot".
 
 Ltac2 lt (x : int) (y : int) := equal (compare x y) -1.
 Ltac2 gt (x : int) (y : int) := equal (compare x y) 1.


### PR DESCRIPTION
This PR completes the set of Int functions available in Ltac2 with:

`div`, `mod`, `abs`, `asr`, `lsl`, `lsr`, `land`, `lor`, `lxor`, `lnot`.

Note: moving the "division by zero" exception to Init.v was required - otherwise I get a "Not found" anomaly on division by zero. This way one gets a proper Ltac2 exception.

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
