### PR TITLE
Display SHA1 in version

### DIFF
--- a/config/coq_config.mli
+++ b/config/coq_config.mli
@@ -33,6 +33,10 @@ val caml_version : string    (* OCaml version used to compile Coq *)
 val caml_version_nums : int list    (* OCaml version used to compile Coq by components *)
 val vo_version : int32
 
+val version_hash : string (* SHA1 key of current commit *)
+val version_hash_short : string (* Unambiguous shortening of version_hash *)
+val is_a_released_version : bool (* Is this a released version of coq? Used to display version numbering. *)
+
 val all_src_dirs : string list
 
 val exec_extension : string (* "" under Unix, ".exe" under MS-windows *)

--- a/sysinit/usage.ml
+++ b/sysinit/usage.ml
@@ -9,12 +9,16 @@
 (************************************************************************)
 
 let version () =
-  Printf.printf "The Coq Proof Assistant, version %s\n" Coq_config.version;
+  if Coq_config.is_a_released_version then
+    Printf.printf "The Coq Proof Assistant, version %s\n" Coq_config.version
+  else
+    Printf.printf "The Coq Proof Assistant, version %s %s\n"
+      Coq_config.version Coq_config.version_hash_short;
   Printf.printf "compiled with OCaml %s\n" Coq_config.caml_version
 
 let machine_readable_version () =
-  Printf.printf "%s %s\n"
-    Coq_config.version Coq_config.caml_version
+  Printf.printf "%s %s %s\n"
+    Coq_config.version Coq_config.version_hash Coq_config.caml_version
 
 (* print the usage of coqtop (or coqc) on channel co *)
 

--- a/tools/configure/configure.ml
+++ b/tools/configure/configure.ml
@@ -22,6 +22,8 @@ let (/) = Filename.concat
 let coq_version = "8.16+alpha"
 let vo_magic = 81591
 let is_a_released_version = false
+let coq_version_hash = fst (run "git" ["rev-parse"; "HEAD"])
+let coq_version_hash_short = fst (run "git" ["rev-parse"; "--short"; "HEAD"])
 
 (** Default OCaml binaries *)
 
@@ -469,6 +471,9 @@ let write_configml camlenv coqenv caml_flags caml_version_nums arch arch_is_win3
   pr_s "ocamlfind" camlexec.find;
   pr_s "caml_flags" caml_flags;
   pr_s "version" coq_version;
+  pr_s "version_hash" coq_version_hash;
+  pr_s "version_hash_short" coq_version_hash_short;
+  pr_b "is_a_released_version" is_a_released_version;
   pr_s "caml_version" caml_version;
   pr_li "caml_version_nums" caml_version_nums;
   pr_s "arch" arch;


### PR DESCRIPTION
We add the following to `Coq_config`:
- `version_hash`: A full SHA1 of the current commit.
- `version_hash_short`: A short SHA1 of the current commit. This is created unambiguously using git.
- `is_a_released_version`: This is the `bool` in `configure.ml` that declares if this is a released version.

If `is_a_released_version` is false then `Usage.version` displays the current Coq version together with a short SHA1.

If `is_a_released_version` is true then it only displays the current Coq version.

`Usage.machine_readable_version` now displays 3 pieces of information: The Coq version, the full SHA1, the OCaml version.

- [ ] Added / updated **test-suite**.
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make -f Makefile.dune doc_gram_rsts`.
- [ ] Opened **overlay** pull requests.

