### PR TITLE
Fix the level of the 'now' tactic.

### DIFF
--- a/theories/Init/Tactics.v
+++ b/theories/Init/Tactics.v
@@ -186,7 +186,7 @@ Ltac easy :=
   solve [ do_atom | use_hyps; do_ccl ] ||
   fail "Cannot solve this goal".
 
-Tactic Notation "now" tactic(t) := t; easy.
+Tactic Notation (at level 5) "now" tactic(t) := t; easy.
 
 (** Slightly more than [easy]*)
 


### PR DESCRIPTION
I'm not an expert on these levels, but the current level seems incorrect. Testcase:

```
Ltac test := now (f_equal; intro).
Ltac test2 := (now f_equal); intro.
Print test. (* Ltac test := now f_equal; intro*)
Print test2. (* Before PR: Ltac test2 := now f_equal; intro After PR: Ltac test2 := (now f_equal); intro
```

- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
