### PR TITLE
Dump Ltac2 into glob files

### DIFF
--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -3424,8 +3424,8 @@ tac2alg_constructors: [
 ]
 
 tac2alg_constructor: [
-| Prim.ident      (* ltac2 plugin *)
-| Prim.ident "(" LIST0 ltac2_type5 SEP "," ")"      (* ltac2 plugin *)
+| locident      (* ltac2 plugin *)
+| locident "(" LIST0 ltac2_type5 SEP "," ")"      (* ltac2 plugin *)
 ]
 
 tac2rec_fields: [

--- a/interp/dumpglob.ml
+++ b/interp/dumpglob.ml
@@ -184,6 +184,13 @@ let dump_modref ?loc mp ty =
   let ident = "<>" in
   dump_ref ?loc filepath modpath ident ty
 
+let dump_knref ?loc kn ty =
+  let (dp, l) = Lib.split_modpath (Names.KerName.modpath kn) in
+  let filepath = Names.DirPath.to_string dp in
+  let modpath = Names.DirPath.to_string (Names.DirPath.make l) in
+  let ident = Names.Label.to_string (Names.KerName.label kn) in
+  dump_ref ?loc filepath modpath ident ty
+
 let dump_libref ?loc dp ty =
   dump_ref ?loc (Names.DirPath.to_string dp) "<>" "<>" ty
 
@@ -293,3 +300,9 @@ let dump_notation {CAst.loc;v=df} sc sec = Option.iter (fun loc ->
 
 let dump_binding ?loc uid =
   dump_def ?loc "binder" "<>" uid
+
+let dump_kndef ?loc kn ty =
+  let (_, l) = Lib.split_modpath (Names.KerName.modpath kn) in
+  let modpath = Names.DirPath.to_string (Names.DirPath.make l) in
+  let ident = Names.Label.to_string (Names.KerName.label kn) in
+  dump_def ?loc ty modpath ident

--- a/interp/dumpglob.mli
+++ b/interp/dumpglob.mli
@@ -55,6 +55,9 @@ val dump_constraint : Names.lname -> bool -> string -> unit
 
 val dump_string : string -> unit
 
+val dump_knref : ?loc:Loc.t -> Names.KerName.t -> string -> unit
+val dump_kndef : ?loc:Loc.t -> Names.KerName.t -> string -> unit
+
 val type_of_global_ref : Names.GlobRef.t -> string
 
 (** Registration of constant information *)

--- a/plugins/ltac2/g_ltac2.mlg
+++ b/plugins/ltac2/g_ltac2.mlg
@@ -161,10 +161,10 @@ GRAMMAR EXTEND Gram
     | "4" LEFTA [ ]
     | "3" [ e0 = SELF; ","; el = LIST1 NEXT SEP "," ->
         { let el = e0 :: el in
-          CAst.make ~loc @@ CTacApp (CAst.make ~loc @@ CTacCst (AbsKn (Tuple (List.length el))), el) } ]
+          CAst.make ~loc @@ CTacApp (CAst.make @@ CTacCst (AbsKn (Tuple (List.length el))), el) } ]
     | "2" RIGHTA
       [ e1 = ltac2_expr; "::"; e2 = ltac2_expr ->
-        { CAst.make ~loc @@ CTacApp (CAst.make ~loc @@ CTacCst (AbsKn (Other Tac2core.Core.c_cons)), [e1; e2]) }
+        { CAst.make ~loc @@ CTacApp (CAst.make @@ CTacCst (AbsKn (Other Tac2core.Core.c_cons)), [e1; e2]) }
       ]
     | "1" LEFTA
       [ e = ltac2_expr; el = LIST1 ltac2_expr LEVEL "0" ->

--- a/plugins/ltac2/g_ltac2.mlg
+++ b/plugins/ltac2/g_ltac2.mlg
@@ -321,8 +321,8 @@ GRAMMAR EXTEND Gram
       | cs = LIST0 tac2alg_constructor SEP "|" -> { cs } ] ]
   ;
   tac2alg_constructor:
-    [ [ c = Prim.ident -> { (c, []) }
-      | c = Prim.ident; "("; args = LIST0 ltac2_type SEP ","; ")"-> { (c, args) } ] ]
+    [ [ c = locident -> { (c, []) }
+      | c = locident; "("; args = LIST0 ltac2_type SEP ","; ")"-> { (c, args) } ] ]
   ;
   tac2rec_fields:
     [ [ f = tac2rec_field; ";"; l = tac2rec_fields -> { f :: l }

--- a/plugins/ltac2/g_ltac2.mlg
+++ b/plugins/ltac2/g_ltac2.mlg
@@ -121,9 +121,9 @@ GRAMMAR EXTEND Gram
         else
           CErrors.user_err ~loc (Pp.str "Syntax error") }
       | qid = Prim.qualid -> { pattern_of_qualid qid }
-      | "["; "]" -> { CAst.make ~loc @@ CPatRef (AbsKn (Other Tac2core.Core.c_nil), []) }
+      | "["; "]" -> { CAst.make ~loc @@ CPatRef (AbsKn (Other (CAst.make ~loc Tac2core.Core.c_nil)), []) }
       | p1 = tac2pat; "::"; p2 = tac2pat ->
-        { CAst.make ~loc @@ CPatRef (AbsKn (Other Tac2core.Core.c_cons), [p1; p2])}
+        { CAst.make ~loc @@ CPatRef (AbsKn (Other (CAst.make Tac2core.Core.c_cons)), [p1; p2])}
       ]
     | "0"
       [ "_" -> { CAst.make ~loc @@ CPatVar Anonymous }

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -351,6 +351,7 @@ let register_ltac ?deprecation ?(local = false) ?(mut = false) isrec tactics =
         user_err ?loc (str "Tactic definition must be a syntactical value")
     in
     let kn = Lib.make_kn id in
+    Dumpglob.dump_kndef ?loc kn "tac2val";
     let exists =
       try let _ = Tac2env.interp_global kn in true with Not_found -> false
     in
@@ -464,6 +465,7 @@ let register_typedef ?(local = false) isrec types =
   List.iter iter types
 
 let register_primitive ?deprecation ?(local = false) {loc;v=id} t ml =
+  Dumpglob.dump_kndef ?loc (Lib.make_kn id) "tac2val";
   let t = intern_open_type t in
   let rec count_arrow = function
   | GTypArrow (_, t) -> 1 + count_arrow t

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -408,22 +408,23 @@ let register_typedef ?(local = false) isrec types =
         user_err ?loc (str "The type abbreviation " ++ Id.print id ++
           str " cannot be recursive")
     | CTydAlg cs ->
-      let same_name (id1, _) (id2, _) = Id.equal id1 id2 in
+      let same_name ({v=id1}, _) ({v=id2}, _) = Id.equal id1 id2 in
       let () = match List.duplicates same_name cs with
       | [] -> ()
-      | (id, _) :: _ ->
-        user_err (str "Multiple definitions of the constructor " ++ Id.print id)
+      | ({loc;v=id}, _) :: _ ->
+        user_err ?loc (str "Multiple definitions of the constructor " ++ Id.print id)
       in
       let () =
-        let check_uppercase_ident (id,_) =
+        let check_uppercase_ident ({loc;v=id},_) =
           if not (Tac2env.is_constructor_id id)
-          then user_err (str "Constructor name should start with an uppercase letter " ++ Id.print id)
+          then user_err ?loc (str "Constructor name should start with an uppercase letter " ++ Id.print id)
         in
         List.iter check_uppercase_ident cs
       in
       let () =
-        let check_existing_ctor (id, _) =
+        let check_existing_ctor ({loc;v=id}, _) =
           let (_, kn) = Lib.make_foname id in
+          Dumpglob.dump_kndef ?loc kn "tac2ctor";
           try let _ = Tac2env.interp_constructor kn in
             user_err (str "Constructor already defined in this module " ++ Id.print id)
           with Not_found -> ()
@@ -513,16 +514,17 @@ let register_open ?(local = false) qid (params, def) =
   | CTydOpn -> ()
   | CTydAlg def ->
     let () =
-      let same_name (id1, _) (id2, _) = Id.equal id1 id2 in
+      let same_name ({v=id1}, _) ({v=id2}, _) = Id.equal id1 id2 in
       let () = match List.duplicates same_name def with
         | [] -> ()
-        | (id, _) :: _ ->
-          user_err (str "Multiple definitions of the constructor " ++ Id.print id)
+        | ({loc;v=id}, _) :: _ ->
+          user_err ?loc (str "Multiple definitions of the constructor " ++ Id.print id)
       in
-      let check_existing_ctor (id, _) =
+      let check_existing_ctor ({loc;v=id}, _) =
           let (_, kn) = Lib.make_foname id in
+          Dumpglob.dump_kndef ?loc kn "tac2ctor";
           try let _ = Tac2env.interp_constructor kn in
-            user_err (str "Constructor already defined in this module " ++ Id.print id)
+            user_err ?loc (str "Constructor already defined in this module " ++ Id.print id)
           with Not_found -> ()
       in
       let () = List.iter check_existing_ctor def in
@@ -535,9 +537,9 @@ let register_open ?(local = false) qid (params, def) =
       | GTydDef (Some t) -> t
       | _ -> assert false
     in
-    let map (id, tpe) =
+    let map ({loc;v=id}, tpe) =
       if not (Tac2env.is_constructor_id id)
-      then user_err (str "Constructor name should start with an uppercase letter " ++ Id.print id) ;
+      then user_err ?loc (str "Constructor name should start with an uppercase letter " ++ Id.print id) ;
       let tpe = List.map intern_type tpe in
       { edata_name = id; edata_args = tpe }
     in

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -395,6 +395,7 @@ let register_typedef ?(local = false) isrec types =
     List.iter check_existing_type types
   in
   let check ({loc;v=id}, (params, def)) =
+    Dumpglob.dump_kndef ?loc (Lib.make_kn id) "tac2type";
     let same_name {v=id1} {v=id2} = Id.equal id1 id2 in
     let () = match List.duplicates same_name params with
     | [] -> ()

--- a/plugins/ltac2/tac2expr.mli
+++ b/plugins/ltac2/tac2expr.mli
@@ -53,7 +53,7 @@ and raw_typexpr = raw_typexpr_r CAst.t
 
 type raw_typedef =
 | CTydDef of raw_typexpr option
-| CTydAlg of (uid * raw_typexpr list) list
+| CTydAlg of (lident * raw_typexpr list) list
 | CTydRec of (lid * mutable_flag * raw_typexpr) list
 | CTydOpn
 

--- a/plugins/ltac2/tac2expr.mli
+++ b/plugins/ltac2/tac2expr.mli
@@ -47,7 +47,7 @@ type 'a or_tuple =
 type raw_typexpr_r =
 | CTypVar of Name.t
 | CTypArrow of raw_typexpr * raw_typexpr
-| CTypRef of type_constant or_tuple or_relid * raw_typexpr list
+| CTypRef of type_constant CAst.t or_tuple or_relid * raw_typexpr list
 
 and raw_typexpr = raw_typexpr_r CAst.t
 

--- a/plugins/ltac2/tac2expr.mli
+++ b/plugins/ltac2/tac2expr.mli
@@ -91,7 +91,7 @@ type atom =
 (** Tactic expressions *)
 type raw_patexpr_r =
 | CPatVar of Name.t
-| CPatRef of ltac_constructor or_tuple or_relid * raw_patexpr list
+| CPatRef of ltac_constructor CAst.t or_tuple or_relid * raw_patexpr list
 | CPatCnv of raw_patexpr * raw_typexpr
 
 and raw_patexpr = raw_patexpr_r CAst.t

--- a/plugins/ltac2/tac2intern.ml
+++ b/plugins/ltac2/tac2intern.ml
@@ -1100,6 +1100,7 @@ and intern_case env loc e pl =
 
 and intern_constructor env loc kn args = match kn with
 | Other kn ->
+  Dumpglob.dump_knref ?loc kn "tac2ctor";
   let cstr = interp_constructor kn in
   let nargs = List.length cstr.cdata_args in
   if Int.equal nargs (List.length args) then
@@ -1222,7 +1223,7 @@ let intern_typedef self (ids, t) : glb_quant_typedef =
   | CTydDef None -> (count, GTydDef None)
   | CTydDef (Some t) -> (count, GTydDef (Some (intern t)))
   | CTydAlg constrs ->
-    let map (c, t) = (c, List.map intern t) in
+    let map ({v=c}, t) = (c, List.map intern t) in
     let constrs = List.map map constrs in
     let getn (const, nonconst) (c, args) = match args with
     | [] -> (succ const, nonconst)

--- a/plugins/ltac2/tac2intern.ml
+++ b/plugins/ltac2/tac2intern.ml
@@ -694,6 +694,7 @@ let rec intern_rec env {loc;v=e} = match e with
     let sch = Id.Map.find id env.env_var in
     (GTacVar id, fresh_mix_type_scheme env sch)
   | ArgArg (TacConstant kn) ->
+    Dumpglob.dump_knref ?loc kn "tac2val";
     let { Tac2env.gdata_type = sch; gdata_deprecation = depr } =
       try Tac2env.interp_global kn
       with Not_found ->
@@ -1278,6 +1279,9 @@ let rec globalize ids ({loc;v=er} as e) = match er with
   begin match get_variable0 mem ref with
   | ArgVar _ -> e
   | ArgArg kn ->
+    let () = match kn with
+      | TacConstant kn -> Dumpglob.dump_knref ?loc kn "tac2val"
+      | _ -> () in
     let () = check_deprecated_ltac2 ?loc ref kn in
     CAst.make ?loc @@ CTacRef (AbsKn kn)
   end

--- a/plugins/ltac2/tac2quote.ml
+++ b/plugins/ltac2/tac2quote.ml
@@ -60,7 +60,7 @@ let std_proj ?loc name =
 let thunk e =
   let t_unit = coq_core "unit" in
   let loc = e.loc in
-  let ty = CAst.make?loc @@ CTypRef (AbsKn (Other t_unit), []) in
+  let ty = CAst.make?loc @@ CTypRef (AbsKn (Other (CAst.make t_unit)), []) in
   let pat = CAst.make ?loc @@ CPatVar (Anonymous) in
   let pat = CAst.make ?loc @@ CPatCnv (pat, ty) in
   CAst.make ?loc @@ CTacFun ([pat], e)
@@ -276,7 +276,7 @@ let abstract_vars loc ?typ vars tac =
   | None -> pat
   | Some typ ->
     let t_array = coq_core "array" in
-    let typ = CAst.make ?loc @@ CTypRef (AbsKn (Other t_array), [typ]) in
+    let typ = CAst.make ?loc @@ CTypRef (AbsKn (Other (CAst.make t_array)), [typ]) in
     CAst.make ?loc @@ CPatCnv (pat, typ)
   in
   CAst.make ?loc @@ CTacFun ([pat], tac)
@@ -424,7 +424,7 @@ let of_constr_matching {loc;v=m} =
     (* Annotate the bound array variable with constr type *)
     let typ =
       let t_constr = coq_core "constr" in
-      CAst.make ?loc @@ CTypRef (AbsKn (Other t_constr), [])
+      CAst.make ?loc @@ CTypRef (AbsKn (Other (CAst.make t_constr)), [])
     in
     let e = abstract_vars loc ~typ vars tac in
     let e = CAst.make ?loc @@ CTacFun ([CAst.make ?loc @@ CPatVar na], e) in

--- a/plugins/ltac2/tac2quote.ml
+++ b/plugins/ltac2/tac2quote.ml
@@ -47,9 +47,9 @@ let global_ref ?loc kn =
   CAst.make ?loc @@ CTacRef (AbsKn (TacConstant kn))
 
 let constructor ?loc kn args =
-  let cst = CAst.make ?loc @@ CTacCst (AbsKn (Other kn)) in
-  if List.is_empty args then cst
-  else CAst.make ?loc @@ CTacApp (cst, args)
+  let cst = CTacCst (AbsKn (Other kn)) in
+  if List.is_empty args then CAst.make ?loc cst
+  else CAst.make ?loc @@ CTacApp (CAst.make cst, args)
 
 let std_constructor ?loc name args =
   constructor ?loc (std_core name) args
@@ -410,11 +410,11 @@ let of_constr_matching {loc;v=m} =
   let map {loc;v=({loc=ploc;v=pat}, tac)} =
     let (knd, pat, na) = match pat with
     | QConstrMatchPattern pat ->
-      let knd = constructor ?loc (pattern_core "MatchPattern") [] in
+      let knd = constructor (pattern_core "MatchPattern") [] in
       (knd, pat, Anonymous)
     | QConstrMatchContext (id, pat) ->
-      let na = extract_name ?loc id in
-      let knd = constructor ?loc (pattern_core "MatchContext") [] in
+      let na = extract_name ?loc:ploc id in
+      let knd = constructor (pattern_core "MatchContext") [] in
       (knd, pat, na)
     in
     let vars = pattern_vars pat in

--- a/tools/coqdoc/cpretty.mll
+++ b/tools/coqdoc/cpretty.mll
@@ -466,7 +466,8 @@ let set_kw =
 let gallina_kw_to_hide =
     "Implicit" space+ "Arguments"
   | "Arguments"
-  | ("Local" space+)? "Ltac"
+  | "Ltac"
+  | "Ltac2"
   | "From"
   | "Require"
   | "Import"

--- a/tools/coqdoc/glob_file.ml
+++ b/tools/coqdoc/glob_file.ml
@@ -11,6 +11,8 @@
 open Printf
 open Index
 
+let other_types = Hashtbl.create 19
+
 let type_of_string = function
   | "def" | "coe" | "subclass" | "canonstruc" | "fix" | "cofix" | "ex"
    |"scheme" ->
@@ -32,7 +34,12 @@ let type_of_string = function
   | "tac" -> TacticDefinition
   | "sec" -> Section
   | "binder" -> Binder
-  | s -> invalid_arg ("type_of_string:" ^ s)
+  | s ->
+      let s =
+        match Hashtbl.find_opt other_types s with
+        | Some s -> s
+        | None -> Hashtbl.add other_types s s; s in
+      Other s
 
 let ill_formed_glob_file f =
   eprintf "Warning: ill-formed file %s (links will not be available)\n" f

--- a/tools/coqdoc/index.ml
+++ b/tools/coqdoc/index.ml
@@ -32,6 +32,7 @@ type entry_type =
   | Notation
   | Section
   | Binder
+  | Other of string
 
 type index_entry =
   | Def of string * entry_type
@@ -178,6 +179,7 @@ let type_name = function
   | Notation -> "notation"
   | Section -> "section"
   | Binder -> "binder"
+  | Other s -> s
 
 let prepare_entry s = function
   | Notation ->

--- a/tools/coqdoc/index.mli
+++ b/tools/coqdoc/index.mli
@@ -31,6 +31,7 @@ type entry_type =
   | Notation
   | Section
   | Binder
+  | Other of string
 
 val type_name : entry_type -> string
 

--- a/tools/coqdoc/output.ml
+++ b/tools/coqdoc/output.ml
@@ -37,7 +37,7 @@ let is_keyword =
       "Hypothesis"; "Hypotheses";
       "Resolve"; "Unfold"; "Immediate"; "Extern"; "Constructors"; "Rewrite";
       "Implicit"; "Import"; "Inductive";
-      "Infix"; "Lemma"; "Let"; "Load"; "Local"; "Locate"; "Ltac";
+      "Infix"; "Lemma"; "Let"; "Load"; "Local"; "Locate"; "Ltac"; "Ltac2";
       "Module"; "Module Type"; "Declare Module"; "Include";
       "Mutual"; "Parameter"; "Parameters"; "Print"; "Printing"; "All"; "Proof"; "Proof with"; "Qed";
       "Record"; "Recursive"; "Remark"; "Require"; "Save"; "Scheme"; "Assumptions"; "Axioms"; "Universes";


### PR DESCRIPTION
Fixes / closes #15617

Currently supported:
- [x] types
- [x] constructors
- [x] constructors in patterns
- [x] values
- [ ] record fields
- [x] Gallina terms
- [ ] Ltac1 tactics
- [ ] notations
- [x] notation bodies