### PR TITLE
Fixes "simpl proj" when the projection to reduce has extra arguments

### DIFF
--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -1047,9 +1047,10 @@ let simpl env sigma c =
 (* Reduction at specific subterms *)
 
 let matches_head env sigma c t =
-  match EConstr.kind sigma t with
-    | App (f,_) -> Constr_matching.matches env sigma c f
-    | Proj (p, _) -> Constr_matching.matches env sigma c (mkConstU (Projection.constant p, EInstance.empty))
+  let t, l = decompose_app sigma t in
+  match EConstr.kind sigma t, l with
+    | Proj (p, _), _ -> Constr_matching.matches env sigma c (mkConstU (Projection.constant p, EInstance.empty))
+    | _, _::_ -> Constr_matching.matches env sigma c t
     | _ -> raise Constr_matching.PatternMatchingFailure
 
 (** FIXME: Specific function to handle projections: it ignores what happens on the

--- a/test-suite/success/simpl.v
+++ b/test-suite/success/simpl.v
@@ -105,3 +105,12 @@ Goal 2=1+1.
 match goal with |- (_ = ?c) => simpl c end.
 match goal with |- 2 = 2 => idtac end. (* Check that it reduced *)
 Abort.
+
+Module FurtherAppliedPrimitiveProjections.
+Set Primitive Projections.
+Record T := { u : nat -> nat }.
+Goal {| u:= fun x => x |}.(u) 0 = 0.
+simpl u.
+match goal with |- 0 = 0 => idtac end. (* Check that it reduced *)
+Abort.
+End FurtherAppliedPrimitiveProjections.


### PR DESCRIPTION
**Kind:** fix

There was a small bug in checking whether an applied subterm matches a projection name given to `simpl`. The case when the projection was further applied was not taken into account.
```
Set Primitive Projections.
Record T := { u : nat -> nat }.
Eval simpl u in {| u:= fun x => x |}.(u). (* was reducing *)
Eval simpl u in {| u:= fun x => x |}.(u) 0. (* was not reducing *)
```
- [x] Added / updated **test-suite**.