### PR TITLE
Fixes #5698: let simpl grants the never flag for primitive projections independently of the internal unfolded status

### DIFF
--- a/dev/ci/user-overlays/15661-herbelin-master+simpl-stop-distinguishing-projection-status.sh
+++ b/dev/ci/user-overlays/15661-herbelin-master+simpl-stop-distinguishing-projection-status.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/herbelin/coq-elpi coq-master+adapt-coq-pr15661-reduction-behavior-get 15661 master+simpl-stop-distinguishing-projection-status

--- a/doc/changelog/04-tactics/15661-master+simpl-stop-distinguishing-projection-status.rst
+++ b/doc/changelog/04-tactics/15661-master+simpl-stop-distinguishing-projection-status.rst
@@ -1,0 +1,7 @@
+- **Fixed:**
+  Some cases where :tacn:`simpl` and :tacn:`cbn` simplified a
+  primitive projection even though the `simpl never` modifier (see
+  :cmd:`Arguments`) was set for the projection
+  (`#15661 <https://github.com/coq/coq/pull/15661>`_,
+  fixes `#5698 <https://github.com/coq/coq/issues/5698>`_,
+  by Hugo Herbelin).

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -842,12 +842,11 @@ and whd_simpl_stack infos env sigma =
         end
       | Proj (p, r, c) ->
         let ans =
-           let unf = Projection.unfolded p in
-           if unf || is_evaluable env (EvalProjectionRef (Projection.repr p)) then
+           if is_evaluable env (EvalProjectionRef (Projection.repr p)) then
              let npars = Projection.npars p in
-             match unf, ReductionBehaviour.get_from_db infos.red_behavior (Projection.constant p) with
-              | false, Some NeverUnfold -> NotReducible
-              | false, Some (UnfoldWhen { recargs } | UnfoldWhenNoMatch { recargs })
+             match ReductionBehaviour.get_from_db infos.red_behavior (Projection.constant p) with
+              | Some NeverUnfold -> NotReducible
+              | Some (UnfoldWhen { recargs } | UnfoldWhenNoMatch { recargs })
                 when not (List.is_empty recargs) ->
                 let l' = List.map_filter (fun i ->
                     let idx = (i - (npars + 1)) in

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -619,10 +619,6 @@ let match_eval_ref_value env sigma constr stack =
       Some (EConstr.of_constr (constant_value_in env (sp, u)))
     else
       None
-  | Proj (p, r, c) when not (Projection.unfolded p) ->
-     if is_evaluable env (EvalProjectionRef (Projection.repr p)) then
-       Some (mkProj (Projection.unfold p, r, c))
-     else None
   | Var id when is_evaluable env (EvalVarRef id) ->
      env |> lookup_named id |> NamedDecl.get_value
   | Rel n ->

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -1098,6 +1098,11 @@ let whd_simpl_orelse_delta_but_fix_old env sigma c =
   in app_stack (redrec (c, empty_stack))
 *)
 
+let is_constant_associated_to_projection env sigma constr p =
+  match EConstr.kind sigma constr with
+  | Const (c', _) -> QConstant.equal env (Projection.constant p) c'
+  | _ -> false
+
 (* Same as [whd_simpl] but also reduces constants that do not hide a
    reducible fix, but does this reduction of constants only until it
    immediately hides a non reducible fix or a cofix *)
@@ -1110,10 +1115,7 @@ let whd_simpl_orelse_delta_but_fix env sigma c =
     | Some c ->
       (match EConstr.kind sigma (snd (decompose_lambda sigma c)) with
       | CoFix _ | Fix _ -> s'
-      | Proj (p,_,t) when
-          (match EConstr.kind sigma constr with
-          | Const (c', _) -> QConstant.equal env (Projection.constant p) c'
-          | _ -> false) ->
+      | Proj (p, _, t) when is_constant_associated_to_projection env sigma constr p ->
         let npars = Projection.npars p in
           if List.length stack <= npars then
             (* Do not show the eta-expanded form *)

--- a/test-suite/bugs/bug_5698.v
+++ b/test-suite/bugs/bug_5698.v
@@ -1,0 +1,23 @@
+(* Check that simpl grants the never flag for primitive projections
+   independently of the internal folded status *)
+
+Set Primitive Projections.
+
+Record foo := Foo {
+  foo_car : Type;
+  foo_0 : foo_car;
+}.
+
+Arguments foo_car : simpl never.
+Arguments foo_0 : simpl never.
+
+Definition nat_foo := Foo nat 0.
+
+Set Printing All.
+
+Goal foo_0 nat_foo = 0.
+Proof.
+  Fail progress simpl.
+  progress unfold foo_0.
+  Fail progress simpl.
+Abort.

--- a/test-suite/success/primproj_ssreflect.v
+++ b/test-suite/success/primproj_ssreflect.v
@@ -33,7 +33,7 @@ Module R.
   Goal forall (A : Type) (φ : A -> Prop), (bi_forall (fun a : A => P)).
   Proof.
     intros A φ.
-    Succeed (progress unfold bi_forall); (progress simpl).
+    Fail (progress unfold bi_forall); (progress simpl). (* simpl never and no folded/unfolded difference *)
     progress rewrite /bi_forall.
   Abort.
 End R.


### PR DESCRIPTION
**Kind:** cleanup, fix

This PR does the following:
- it fixes #5698 (simpl unfolding a primitive projection even if told not to unfold it)
- it parametrizes the code of `simpl` with the reduction behavior so that `hnf` can call it without having to hack for the reduction behavior finally not taken into account
- it is an incremental step towards #14640 aiming at getting rid of the unfolded flag and separating `(f t)` from `t.(f)` for primitive projections

Note: One may also argue that a primitive projection is not strictly a constant and thus should not be subject to the `simpl` modifiers but I believe it is quite intuitive to want to control the reduction of a primitive projection, especially when compared to the situation with non primitive records.

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
