### PR TITLE
inferCumulativity: do not unfold constants unless necessary

### DIFF
--- a/doc/changelog/01-kernel/15662-speed-infer-cumul.rst
+++ b/doc/changelog/01-kernel/15662-speed-infer-cumul.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  performance blowups while inferring variance information for :ref:`cumulative` inductive types
+  (`#15662 <https://github.com/coq/coq/pull/15662>`_,
+  fixes `#11741 <https://github.com/coq/coq/issues/11741>`_,
+  by Gaëtan Gilbert).

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -222,9 +222,22 @@ val eta_expand_ind_stack : env -> inductive -> fconstr -> stack ->
 
 (** Conversion auxiliary functions to do step by step normalisation *)
 
-(** [unfold_reference] unfolds references in a [fconstr] *)
+(** [unfold_reference] unfolds references in a [fconstr]. Produces a
+    [FIrrelevant] when the reference is irrelevant. *)
 val unfold_reference : Environ.env -> TransparentState.t ->
   clos_tab -> table_key -> (fconstr, Util.Empty.t) constant_def
+
+(** Like [unfold_reference], but handles primitives: if there are not
+    enough arguments, return [None]. Otherwise return [Some] with
+    [ZPrimitive] added to the stack. Produces a [FIrrelevant] when the
+    reference is irrelevant and the infos was created with
+    [create_conv_infos]. *)
+val unfold_ref_with_args
+  : clos_infos
+  -> clos_tab
+  -> table_key
+  -> stack
+  -> (fconstr * stack) option
 
 (** Hook for Reduction *)
 val set_conv : (clos_infos -> clos_tab -> fconstr -> fconstr -> bool) -> unit

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -295,17 +295,6 @@ let conv_table_key infos ~nargs k1 k2 cuniv =
   | RelKey n, RelKey n' when Int.equal n n' -> cuniv
   | _ -> raise NotConvertible
 
-let unfold_ref_with_args infos tab fl v =
-  let env = info_env infos in
-  let flags = RedFlags.red_transparent (info_flags infos) in
-  match unfold_reference env flags tab fl with
-  | Def def -> Some (def, v)
-  | Primitive op when check_native_args op v ->
-    let c = match fl with ConstKey c -> c | _ -> assert false in
-    let rargs, a, nargs, v = get_native_args1 op c v in
-    Some (a, (Zupdate a::(Zprimitive(op,c,rargs,nargs)::v)))
-  | Undef _ | OpaqueDef _ | Primitive _ -> None
-
 let same_args_size sk1 sk2 =
   let n = CClosure.stack_args_size sk1 in
   if Int.equal n (CClosure.stack_args_size sk2) then n

--- a/test-suite/bugs/bug_15916.v
+++ b/test-suite/bugs/bug_15916.v
@@ -44,3 +44,23 @@ Module WithAxiom.
     := match (C1@{u} x) : I1@{v} with C1 y => y end.
 
 End WithAxiom.
+
+Module WithVars.
+
+  Module Rel.
+    Fail Cumulative Inductive foo@{*u +} (X:=Type@{u}) := C (_:X).
+
+    Cumulative Inductive foo@{+u +} (X:=Type@{u}) := C (_:X).
+  End Rel.
+
+  Module Var.
+    Section S.
+      Let X:=Type.
+      Cumulative Inductive foo := C (_:X).
+    End S.
+
+    Fail Cumulative Inductive bar@{*u} := C' (_:foo@{u}).
+    Cumulative Inductive bar@{+u} := C' (_:foo@{u}).
+  End Var.
+
+End WithVars.

--- a/test-suite/success/CumulInd.v
+++ b/test-suite/success/CumulInd.v
@@ -18,3 +18,9 @@ Fail Inductive not_irrelevant@{*u} : Prop := nirr (_ : Type@{u}).
 Inductive check_covariant@{+u} : Prop := cov (_ : Type@{u}).
 
 Fail Inductive not_covariant@{+u} : Prop := ncov (_ : Type@{u} -> nat).
+
+Inductive must_unfold@{+u *v} : Prop := cmust (_ : @id Type@{v} Type@{u}).
+
+Inductive actually_default_unfold@{u v} : Prop := cnodef (_ : @id Type@{v} Type@{u}).
+Inductive actually_default_unfold_check@{+u *v} : Prop
+  := cnodef_check (_ : actually_default_unfold@{u v}).

--- a/test-suite/success/cumulativity.v
+++ b/test-suite/success/cumulativity.v
@@ -25,7 +25,7 @@ Record Tp' := { tp' : Tp }.
 
 Definition CTp := Tp.
 (* here we have to reduce a constant to infer the correct subtyping. *)
-Record Tp'' := { tp'' : CTp }.
+Record Tp''@{+u} := { tp'' : CTp@{u} }.
 
 Definition LiftTp'@{i j|i <= j} : Tp'@{i} -> Tp'@{j} := fun x => x.
 Definition LiftTp''@{i j|i <= j} : Tp''@{i} -> Tp''@{j} := fun x => x.


### PR DESCRIPTION
Fix #11741
