### PR TITLE
Fixing reference manual wrt the no-impact of the "simpl never" modifier on hnf

### DIFF
--- a/doc/sphinx/language/extensions/arguments-command.rst
+++ b/doc/sphinx/language/extensions/arguments-command.rst
@@ -321,8 +321,8 @@ Binding arguments to a scope
 Effects of :cmd:`Arguments` on unfolding
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-+ `simpl never` indicates that a :term:`constant` should never be unfolded by :tacn:`cbn`,
-  :tacn:`simpl` or :tacn:`hnf`:
++ `simpl never` indicates that a :term:`constant` should never be unfolded by :tacn:`cbn` or
+  :tacn:`simpl`:
 
   .. example::
 


### PR DESCRIPTION
**Kind** documentation fix

As far as I could recollect, the reference manual has been wrong about `hnf` being affected by the `simpl never` modifier.

- [x] Added / updated **documentation**.

Don't know which of 8.15.1 or 8.16 is best.