### PR TITLE
Abort is a regular command

### DIFF
--- a/doc/changelog/07-vernac-commands-and-options/15669-abort-time.rst
+++ b/doc/changelog/07-vernac-commands-and-options/15669-abort-time.rst
@@ -1,0 +1,4 @@
+- **Removed:**
+  :cmd:`Abort` no longer takes an :n:`@ident` as an argument (it has been ignored since 8.5)
+  (`#15669 <https://github.com/coq/coq/pull/15669>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/proofs/writing-proofs/proof-mode.rst
+++ b/doc/sphinx/proofs/writing-proofs/proof-mode.rst
@@ -222,15 +222,11 @@ When the proof is completed, you can exit proof mode with commands such as
    This command is available in proof mode to give up
    the current proof and declare the initial goal as an axiom.
 
-.. cmd:: Abort {? {| All | @ident } }
+.. cmd:: Abort {? All }
 
-   Cancels the current proof development, switching back to
-   the previous proof development, or to the Coq toplevel if no other
-   proof was being edited.
-
-   :n:`@ident`
-     Aborts editing the proof named :n:`@ident` for use when you have
-     nested proofs.  See also :flag:`Nested Proofs Allowed`.
+   Aborts the current proof.  If the current proof is a nested proof, the previous
+   proof becomes current.  If :n:`All` is given, all nested proofs are aborted.
+   See :flag:`Nested Proofs Allowed`.
 
    :n:`All`
      Aborts all current proofs.

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1343,10 +1343,9 @@ command: [
 | DELETE "Undo" natural
 | REPLACE "Undo" "To" natural
 | WITH "Undo" OPT ( OPT "To" natural )
-| DELETE "Abort"
 | DELETE "Abort" "All"
-| REPLACE "Abort" identref
-| WITH "Abort" OPT [ "All" | identref ]
+| REPLACE "Abort"
+| WITH "Abort" OPT [ "All" ]
 
 (* show the locate options as separate commands *)
 | DELETE "Locate" locatable

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -501,7 +501,6 @@ command: [
 | "Proof" lconstr
 | "Abort"
 | "Abort" "All"
-| "Abort" identref
 | "Admitted"
 | "Qed"
 | "Save" identref

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -956,7 +956,7 @@ command: [
 | "Proof"
 | "Proof" "Mode" string
 | "Proof" term
-| "Abort" OPT [ "All" | ident ]
+| "Abort" OPT "All"
 | "Admitted"
 | "Qed"
 | "Save" ident

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -1031,7 +1031,7 @@ let stm_vernac_interp ?route id st { verbose; expr } : Vernacstate.t =
   let is_filtered_command = function
     | VernacResetName _ | VernacResetInitial | VernacBack _
     | VernacRestart | VernacUndo _ | VernacUndoTo _
-    | VernacAbortAll | VernacAbort _ -> true
+    | VernacAbortAll -> true
     | _ -> false
   in
   (* XXX unsupported attributes *)

--- a/test-suite/output-modulo-time/abort.out
+++ b/test-suite/output-modulo-time/abort.out
@@ -1,0 +1,2 @@
+Chars 40 - 50 [Goal~_~True.] 0. secs (0.u,0.s)
+Chars 51 - 57 [Abort.] 0. secs (0.u,0.s)

--- a/test-suite/output-modulo-time/abort.v
+++ b/test-suite/output-modulo-time/abort.v
@@ -1,0 +1,5 @@
+(* -*- coq-prog-args: ("-time") -*- *)
+
+Goal True.
+Abort.
+(* #15666 *)

--- a/vernac/g_proofs.mlg
+++ b/vernac/g_proofs.mlg
@@ -61,9 +61,8 @@ GRAMMAR EXTEND Gram
           { VernacProof (None,Some l) }
       | IDENT "Proof" ; IDENT "Mode" ; mn = string -> { VernacProofMode mn }
       | IDENT "Proof"; c = lconstr -> { VernacExactProof c }
-      | IDENT "Abort" -> { VernacAbort None }
+      | IDENT "Abort" -> { VernacAbort }
       | IDENT "Abort"; IDENT "All" -> { VernacAbortAll }
-      | IDENT "Abort"; id = identref -> { VernacAbort (Some id) }
       | IDENT "Admitted" -> { VernacEndProof Admitted }
       | IDENT "Qed" -> { VernacEndProof (Proved (Opaque,None)) }
       | IDENT "Save"; id = identref ->

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -686,8 +686,8 @@ let pr_vernac_expr v =
     return (keyword "Unfocus")
   | VernacUnfocused ->
     return (keyword "Unfocused")
-  | VernacAbort id ->
-    return (keyword "Abort" ++ pr_opt pr_lident id)
+  | VernacAbort ->
+    return (keyword "Abort")
   | VernacUndo i ->
     return (
       if Int.equal i 1 then keyword "Undo" else keyword "Undo" ++ pr_intarg i

--- a/vernac/vernac_classifier.ml
+++ b/vernac/vernac_classifier.ml
@@ -60,7 +60,7 @@ let classify_vernac e =
         options_affecting_stm_scheduling ->
        VtSideff ([], VtNow)
     (* Qed *)
-    | VernacAbort _ -> VtQed VtDrop
+    | VernacAbort -> VtQed VtDrop
     | VernacEndProof Admitted -> VtQed (VtKeep VtKeepAxiom)
     | VernacEndProof (Proved (opaque,_)) -> VtQed (VtKeep (vtkeep_of_opaque opaque))
     | VernacExactProof _ -> VtQed (VtKeep VtKeepOpaque)

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -717,6 +717,8 @@ let vernac_end_proof ~lemma ~pm = let open Vernacexpr in function
     let pm, _ = Declare.Proof.save ~pm ~proof:lemma ~opaque ~idopt
     in pm
 
+let vernac_abort ~lemma:_ ~pm = pm
+
 let vernac_exact_proof ~lemma ~pm c =
   (* spiwack: for simplicity I do not enforce that "Proof proof_term" is
      called only at the beginning of a proof. *)
@@ -2155,8 +2157,7 @@ let translate_vernac ?loc ~atts v = let open Vernacextend in match v with
   | VernacUndoTo _
   | VernacResetName _
   | VernacResetInitial
-  | VernacBack _
-  | VernacAbort _ ->
+  | VernacBack _ ->
     anomaly (str "type_vernac")
   | VernacLoad _ ->
     anomaly (str "Load is not supported recursively")
@@ -2457,6 +2458,10 @@ let translate_vernac ?loc ~atts v = let open Vernacextend in match v with
   | VernacEndProof pe ->
     unsupported_attributes atts;
     vtcloseproof (vernac_end_proof pe)
+
+  | VernacAbort ->
+    unsupported_attributes atts;
+    vtcloseproof vernac_abort
 
   (* Extensions *)
   | VernacExtend (opn,args) ->

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -449,7 +449,7 @@ type nonrec vernac_expr =
   | VernacComments of comment list
 
   (* Proof management *)
-  | VernacAbort of lident option
+  | VernacAbort
   | VernacAbortAll
   | VernacRestart
   | VernacUndo of int

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -154,8 +154,6 @@ let rec interp_expr ?loc ~atts ~st c =
   | VernacResetInitial -> CErrors.anomaly (Pp.str "VernacResetInitial not handled by Stm.")
   | VernacBack _       -> CErrors.anomaly (Pp.str "VernacBack not handled by Stm.")
 
-  (* This one is possible to handle here *)
-  | VernacAbort id    -> CErrors.user_err (Pp.str "Abort cannot be used through the Load command")
   | VernacLoad (verbosely, fname) ->
     Attributes.unsupported_attributes atts;
     vernac_load ~verbosely fname


### PR DESCRIPTION
Fix #15666

Also remove the syntax for `Abort id` which has ignored the id since
the STM was introduced (b2f2727670853183bfbcbafb9dc19f0f71494a7b).
