### PR TITLE
Don't invoke debug code from async worker processes

### DIFF
--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -116,8 +116,8 @@ let debug = ref DebugOff
 (* Sets the debugger on or off *)
 let set_debug pos = debug := pos
 
-(* Gives the state of debug *)
-let get_debug () = !debug
+(* Gives the state of debug; disabled in worker processes *)
+let get_debug () = if Flags.async_proofs_is_worker () then DebugOff else !debug
 
 let log_trace = ref false
 

--- a/plugins/ltac/tactic_debug.mli
+++ b/plugins/ltac/tactic_debug.mli
@@ -9,7 +9,6 @@
 (************************************************************************)
 
 open Environ
-open Pattern
 open Names
 open Tacexpr
 open EConstr
@@ -39,30 +38,6 @@ val db_initialize : bool -> unit Proofview.NonLogical.t
 (** Prints a constr *)
 val db_constr : debug_info -> env -> evar_map -> constr -> unit Proofview.NonLogical.t
 
-(** Prints the pattern rule *)
-val db_pattern_rule :
-  debug_info -> env -> evar_map -> int -> (Genintern.glob_constr_and_expr * constr_pattern,glob_tactic_expr) match_rule -> unit Proofview.NonLogical.t
-
-(** Prints a matched hypothesis *)
-val db_matched_hyp :
-  debug_info -> env -> evar_map -> Id.t * constr option * constr -> Name.t -> unit Proofview.NonLogical.t
-
-(** Prints the matched conclusion *)
-val db_matched_concl : debug_info -> env -> evar_map -> constr -> unit Proofview.NonLogical.t
-
-(** Prints a success message when the goal has been matched *)
-val db_mc_pattern_success : debug_info -> unit Proofview.NonLogical.t
-
-(** Prints a failure message for an hypothesis pattern *)
-val db_hyp_pattern_failure :
-  debug_info -> env -> evar_map -> Name.t * constr_pattern match_pattern -> unit Proofview.NonLogical.t
-
-(** Prints a matching failure message for a rule *)
-val db_matching_failure : debug_info -> unit Proofview.NonLogical.t
-
-(** Prints an evaluation failure message for a rule *)
-val db_eval_failure : debug_info -> Pp.t -> unit Proofview.NonLogical.t
-
 (** An exception handler *)
 val explain_logic_error: exn -> Pp.t
 
@@ -72,15 +47,9 @@ val explain_logic_error: exn -> Pp.t
    from users that they report these anomalies. *)
 val explain_logic_error_no_anomaly : exn -> Pp.t
 
-(** Prints a logic failure message for a rule *)
-val db_logic_failure : debug_info -> exn -> unit Proofview.NonLogical.t
-
 (** Check for/process idtac breakpoint *)
 val db_breakpoint : debug_info ->
   lident message_token list -> unit Proofview.NonLogical.t
-
-val extract_ltac_trace :
-  ?loc:Loc.t -> Tacexpr.ltac_stack -> Pp.t Loc.located
 
 (** Prints a message only if debugger stops at the next step *)
 val defer_output : (unit -> Pp.t) -> unit Proofview.NonLogical.t


### PR DESCRIPTION
Fixes #15564

I expected the fix would be more complicated, e.g. that I'd have to disable worker processes in Stm when the `Ltac Debug` flag is set.  After much poking around in the code, I discovered that this one line change is sufficient.  It works correctly in CoqIDE using a script with about 20 theorems, to which I added 4-5 more that stop in the debugger.  Printing out the process ids, the debugger always stopped in the same `coqidetop.opt` process.  So it seems like a good fix, even if I can't fully explain the interaction with async processing.  @gares, do you have any thoughts on this? 

I also removed some dead code.
