### PR TITLE
Add a `Print Notation` command

### DIFF
--- a/doc/changelog/07-vernac-commands-and-options/15683-14907-print-notation.rst
+++ b/doc/changelog/07-vernac-commands-and-options/15683-14907-print-notation.rst
@@ -1,0 +1,8 @@
+- **Added:**
+  :cmd:`Print Notation` command that prints the level and
+  associativity of a given notation definition string
+  (`#15683 <https://github.com/coq/coq/pull/15683>`_,
+  fixes `#14907 <https://github.com/coq/coq/issues/14907>`_
+  and `#4436 <https://github.com/coq/coq/issues/4436>`_
+  and `#7730 <https://github.com/coq/coq/issues/7730>`_,
+  by Ali Caglayan and Ana Borges, with help from Emilio Jesus Gallego Arias).

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -462,6 +462,70 @@ Displaying information about notations
 
    :flag:`Printing All` to disable other elements in addition to notations.
 
+.. cmd:: Print Notation @string {? in custom @ident }
+
+   Displays information about the previously reserved notation string
+   :token:`string`. :token:`ident`, if specified, is the name of the associated
+   custom entry. See :cmd:`Declare Custom Entry`.
+
+   .. coqtop:: all
+
+      Reserved Notation "x # y" (at level 123, right associativity).
+      Print Notation "_ # _".
+
+   Variables can be indicated with either `"_"` or names, as long as these can
+   not be confused with notation symbols. When confusion may arise, for example
+   with notation symbols that are entirely made up of letters, use single quotes
+   to delimit those symbols. Using `"_"` is preferred, as it avoids this
+   confusion. Note that there must always be (at least) a space between notation
+   symbols and arguments, even when the notation format does not include those
+   spaces.
+
+   .. example:: :cmd:`Print Notation`
+
+      .. coqtop:: all
+
+         Reserved Notation "x 'mod' y" (at level 40, no associativity).
+         Print Notation "_ mod _".
+         Print Notation "x 'mod' y".
+
+         Reserved Notation "/ x /" (at level 0, format "/ x /").
+         Fail Print Notation "/x/".
+         Print Notation "/ x /".
+
+         Reserved Notation "( x , y , .. , z )" (at level 0).
+         Print Notation "( _ , _ , .. , _ )".
+
+
+         Reserved Notation "x $ y" (at level 50, left associativity).
+
+         Declare Custom Entry expr.
+         Reserved Notation "x $ y"
+           (in custom expr at level 30, x custom expr, y at level 80, no associativity).
+
+         Print Notation "_ $ _".
+         Print Notation "_ $ _" in custom expr.
+
+   .. exn:: @string cannot be interpreted as a known notation. Make sure that symbols are surrounded by spaces and that holes are explicitly denoted by "_".
+
+      Occurs when :cmd:`Print Notation` can't find a notation associated with
+      :token:`string`. This can happen, for example, when the notation does not
+      exist in the current context, :token:`string` is not specific enough,
+      there are missing spaces between symbols, or some symbols need to be
+      quoted with `"'"`.
+
+   .. exn:: @string cannot be interpreted as a known notation in @ident entry. Make sure that symbols are surrounded by spaces and that holes are explicitly denoted by "_".
+      :undocumented:
+
+   .. exn:: Unknown custom entry: @ident.
+
+      Occurs when :cmd:`Print Notation` can't find the custom entry given by the
+      user.
+
+.. seealso::
+
+    :cmd:`Locate` for information on the definitions and scopes associated with
+    a notation.
 
 .. cmd:: Print Grammar @ident
 
@@ -1268,6 +1332,11 @@ Here are the syntax elements used by the various notation commands.
    .. todo: the note above should be removed at the end of deprecation
       phase of ident
    ..
+
+.. exn:: Unknown custom entry: @ident.
+
+   Occurs when :cmd:`Notation` can't find the custom entry given by the user.
+
 .. _Scopes:
 
 Notation scopes

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1272,6 +1272,8 @@ printable: [
 | "Custom" "Grammar" IDENT
 | "LoadPath" OPT dirpath
 | "Libraries"
+| "Notation" string
+| "Notation" string "in" "custom" IDENT
 | "ML" "Path"
 | "ML" "Modules"
 | "Debug" "GC"

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -892,6 +892,8 @@ command: [
 | "Print" "TypeClasses"
 | "Print" "Instances" reference
 | "Print" "Coercions"
+| "Print" "Notation" string
+| "Print" "Notation" string "in" "custom" ident
 | "Print" "Coercion" "Paths" class class
 | "Print" "Canonical" "Projections" LIST0 reference
 | "Print" "Typing" "Flags"

--- a/gramlib/gramext.ml
+++ b/gramlib/gramext.ml
@@ -9,3 +9,8 @@ type position =
   | After of string
 
 type g_assoc = NonA | RightA | LeftA
+
+let pr_assoc = function
+  | LeftA -> Pp.str "left associativity"
+  | RightA -> Pp.str "right associativity"
+  | NonA -> Pp.str "no associativity"

--- a/gramlib/gramext.mli
+++ b/gramlib/gramext.mli
@@ -9,3 +9,6 @@ type position =
   | After of string
 
 type g_assoc = NonA | RightA | LeftA
+
+val pr_assoc : g_assoc -> Pp.t
+(** Prints a [g_assoc] value. *)

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -291,6 +291,9 @@ val is_printing_inactive_rule : interp_rule -> interpretation -> bool
 
 (** {6 Miscellaneous} *)
 
+(** Take a notation string and turn it into a notation key. eg. ["x +  y"] becomes ["_ + _"]. *)
+val interpret_notation_string : string -> string
+
 (** If head is true, also allows applied global references. *)
 val interp_notation_as_global_reference : ?loc:Loc.t -> head:bool -> (GlobRef.t -> bool) ->
       notation_key -> delimiters option -> GlobRef.t

--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -222,6 +222,8 @@ let pr_arg pr x = spc () ++ pr x
 let pr_non_empty_arg pr x = let pp = pr x in if ismt pp then mt () else spc () ++ pr x
 let pr_opt pr = function None -> mt () | Some x -> pr_arg pr x
 let pr_opt_no_spc pr = function None -> mt () | Some x -> pr x
+let pr_opt_default prdf pr = function None -> prdf () | Some x -> pr_arg pr x
+let pr_opt_no_spc_default prdf pr = function None -> prdf () | Some x -> pr x
 
 (** TODO: merge with CString.ordinal *)
 let pr_nth n =

--- a/lib/pp.mli
+++ b/lib/pp.mli
@@ -135,6 +135,12 @@ val pr_opt : ('a -> t) -> 'a option -> t
 val pr_opt_no_spc : ('a -> t) -> 'a option -> t
 (** Same as [pr_opt] but without the leading space. *)
 
+val pr_opt_default : (unit -> t) -> ('a -> t) -> 'a option -> t
+(** Prints [pr v] if [ov] is [Some v], else [prdf ()]. *)
+
+val pr_opt_no_spc_default : (unit -> t) -> ('a -> t) -> 'a option -> t
+(** Same as [pr_opt_default] but without the leading space. *)
+
 val pr_nth : int -> t
 (** Ordinal number with the correct suffix (i.e. "st", "nd", "th", etc.). *)
 

--- a/test-suite/output/PrintNotation.out
+++ b/test-suite/output/PrintNotation.out
@@ -1,0 +1,323 @@
+Notation "_ $ _" at level 123 with arguments constr at next level, constr
+at next level, no associativity.
+bar (bar ?f ?f0) ?f1
+     : foo
+where
+?f : [ |- foo]
+?f0 : [ |- foo]
+?f1 : [ |- foo]
+Notation "_ $ _" at level 123 with arguments constr at next level, constr
+at next level, no associativity.
+bar (bar ?f ?f0) ?f1
+     : foo
+where
+?f : [ |- foo]
+?f0 : [ |- foo]
+?f1 : [ |- foo]
+Notation "_ $ _" at level 123 with arguments constr at level 123, constr
+at next level, left associativity.
+bar (bar ?f ?f0) ?f1
+     : foo
+where
+?f : [ |- foo]
+?f0 : [ |- foo]
+?f1 : [ |- foo]
+Notation "_ $ _" at level 123 with arguments constr at next level, constr
+at level 123, right associativity.
+bar ?f (bar ?f0 ?f1)
+     : foo
+where
+?f : [ |- foo]
+?f0 : [ |- foo]
+?f1 : [ |- foo]
+File "./output/PrintNotation.v", line 36, characters 2-30:
+The command has indeed failed with message:
+"_ $ x" cannot be interpreted as a known notation. Make sure that symbols are
+surrounded by spaces and that holes are explicitly denoted by "_".
+File "./output/PrintNotation.v", line 37, characters 2-28:
+The command has indeed failed with message:
+"_ $" cannot be interpreted as a known notation. Make sure that symbols are
+surrounded by spaces and that holes are explicitly denoted by "_".
+File "./output/PrintNotation.v", line 38, characters 2-28:
+The command has indeed failed with message:
+"$ x" cannot be interpreted as a known notation. Make sure that symbols are
+surrounded by spaces and that holes are explicitly denoted by "_".
+File "./output/PrintNotation.v", line 39, characters 2-28:
+The command has indeed failed with message:
+"x$y" cannot be interpreted as a known notation. Make sure that symbols are
+surrounded by spaces and that holes are explicitly denoted by "_".
+File "./output/PrintNotation.v", line 40, characters 2-28:
+The command has indeed failed with message:
+"_$_" cannot be interpreted as a known notation. Make sure that symbols are
+surrounded by spaces and that holes are explicitly denoted by "_".
+Notation "_ $ _" at level 123 with arguments constr at next level, constr
+at level 123, right associativity.
+Notation "_ $ _" at level 123 with arguments constr at next level, constr
+at level 123, right associativity.
+Notation "_ -> _" at level 99 with arguments constr at next level, constr
+at level 200, no associativity.
+Notation "_ <-> _" at level 95 with arguments constr at next level, constr
+at next level, no associativity.
+Notation "_ /\ _" at level 80 with arguments constr at next level, constr
+at level 80, right associativity.
+Notation "_ \/ _" at level 85 with arguments constr at next level, constr
+at level 85, right associativity.
+Notation "~ _" at level 75 with arguments constr at level 75,
+right associativity.
+Notation "_ = _ :> _" at level 70 with arguments constr at next level, constr
+at next level, constr at next level, no associativity.
+Notation "_ = _" at level 70 with arguments constr at next level, constr
+at next level, no associativity.
+Notation "_ = _ = _" at level 70 with arguments constr at next level, constr
+at next level, constr at next level, no associativity.
+Notation "_ <> _ :> _" at level 70 with arguments constr at next level,
+constr at next level, constr at next level, no associativity.
+Notation "_ <> _" at level 70 with arguments constr at next level, constr
+at next level, no associativity.
+Notation "_ <= _" at level 70 with arguments constr at next level, constr
+at next level, no associativity.
+Notation "_ < _" at level 70 with arguments constr at next level, constr
+at next level, no associativity.
+Notation "_ >= _" at level 70 with arguments constr at next level, constr
+at next level, no associativity.
+Notation "_ > _" at level 70 with arguments constr at next level, constr
+at next level, no associativity.
+Notation "_ <= _ <= _" at level 70 with arguments constr at next level,
+constr at next level, constr at next level, no associativity.
+Notation "_ <= _ < _" at level 70 with arguments constr at next level, constr
+at next level, constr at next level, no associativity.
+Notation "_ < _ < _" at level 70 with arguments constr at next level, constr
+at next level, constr at next level, no associativity.
+Notation "_ < _ <= _" at level 70 with arguments constr at next level, constr
+at next level, constr at next level, no associativity.
+Notation "_ + _" at level 50 with arguments constr at level 50, constr
+at next level, left associativity.
+Notation "_ - _" at level 50 with arguments constr at level 50, constr
+at next level, left associativity.
+Notation "_ * _" at level 40 with arguments constr at level 40, constr
+at next level, left associativity.
+Notation "_ / _" at level 40 with arguments constr at level 40, constr
+at next level, left associativity.
+Notation "- _" at level 35 with arguments constr at level 35,
+right associativity.
+Notation "/ _" at level 35 with arguments constr at level 35,
+right associativity.
+Notation "_ ^ _" at level 30 with arguments constr at next level, constr
+at level 30, right associativity.
+Notation "_ || _" at level 50 with arguments constr at level 50, constr
+at next level, left associativity.
+Notation "_ && _" at level 40 with arguments constr at level 40, constr
+at next level, left associativity.
+Notation "( _ , _ , .. , _ )" at level 0 with arguments constr, constr,
+no associativity.
+Notation "{ _ }" at level 0 with arguments constr at level 99,
+no associativity.
+Notation "{ _ } + { _ }" at level 50 with arguments constr, constr,
+left associativity.
+Notation "_ + { _ }" at level 50 with arguments constr at level 50, constr,
+left associativity.
+Notation "{ _ | _ }" at level 0 with arguments constr at level 99, constr,
+no associativity.
+Notation "{ _ | _ & _ }" at level 0 with arguments constr at level 99,
+constr, constr, no associativity.
+Notation "{ _ : _ | _ }" at level 0 with arguments constr at level 99,
+constr, constr, no associativity.
+Notation "{ _ : _ | _ & _ }" at level 0 with arguments constr at level 99,
+constr, constr, constr, no associativity.
+Notation "{ _ & _ }" at level 0 with arguments constr at level 99, constr,
+no associativity.
+Notation "{ _ & _ & _ }" at level 0 with arguments constr at level 99,
+constr, constr, no associativity.
+Notation "{ _ : _ & _ }" at level 0 with arguments constr at level 99,
+constr, constr, no associativity.
+Notation "{ _ : _ & _ & _ }" at level 0 with arguments constr at level 99,
+constr, constr, constr, no associativity.
+Notation "{ ' _ | _ }" at level 0 with arguments strict pattern at level 0,
+constr, no associativity.
+Notation "{ ' _ | _ & _ }" at level 0 with arguments strict pattern
+at level 0, constr, constr, no associativity.
+Notation "{ ' _ : _ | _ }" at level 0 with arguments strict pattern
+at level 0, constr, constr, no associativity.
+Notation "{ ' _ : _ | _ & _ }" at level 0 with arguments strict pattern
+at level 0, constr, constr, constr, no associativity.
+Notation "{ ' _ & _ }" at level 0 with arguments strict pattern at level 0,
+constr, no associativity.
+Notation "{ ' _ & _ & _ }" at level 0 with arguments strict pattern
+at level 0, constr, constr, no associativity.
+Notation "{ ' _ : _ & _ }" at level 0 with arguments strict pattern
+at level 0, constr, constr, no associativity.
+Notation "{ ' _ : _ & _ & _ }" at level 0 with arguments strict pattern
+at level 0, constr, constr, constr, no associativity.
+Notation "if _ is _ then _ else _" at level 200 with arguments constr,
+pattern at level 100 at level 100, constr, constr at next level,
+no associativity.
+Notation "_ -> _" at level 99 with arguments constr at next level, constr
+at level 200, no associativity.
+Notation "_ <-> _" at level 95 with arguments constr at next level, constr
+at next level, no associativity.
+Notation "_ /\ _" at level 80 with arguments constr at next level, constr
+at level 80, right associativity.
+Notation "_ \/ _" at level 85 with arguments constr at next level, constr
+at level 85, right associativity.
+Notation "~ _" at level 75 with arguments constr at level 75,
+right associativity.
+Notation "_ = _ :> _" at level 70 with arguments constr at next level, constr
+at next level, constr at next level, no associativity.
+Notation "_ = _" at level 70 with arguments constr at next level, constr
+at next level, no associativity.
+Notation "_ = _ = _" at level 70 with arguments constr at next level, constr
+at next level, constr at next level, no associativity.
+Notation "_ <> _ :> _" at level 70 with arguments constr at next level,
+constr at next level, constr at next level, no associativity.
+Notation "_ <> _" at level 70 with arguments constr at next level, constr
+at next level, no associativity.
+Notation "_ <= _" at level 70 with arguments constr at next level, constr
+at next level, no associativity.
+Notation "_ < _" at level 70 with arguments constr at next level, constr
+at next level, no associativity.
+Notation "_ >= _" at level 70 with arguments constr at next level, constr
+at next level, no associativity.
+Notation "_ > _" at level 70 with arguments constr at next level, constr
+at next level, no associativity.
+Notation "_ <= _ <= _" at level 70 with arguments constr at next level,
+constr at next level, constr at next level, no associativity.
+Notation "_ <= _ < _" at level 70 with arguments constr at next level, constr
+at next level, constr at next level, no associativity.
+Notation "_ < _ < _" at level 70 with arguments constr at next level, constr
+at next level, constr at next level, no associativity.
+Notation "_ < _ <= _" at level 70 with arguments constr at next level, constr
+at next level, constr at next level, no associativity.
+Notation "_ + _" at level 50 with arguments constr at level 50, constr
+at next level, left associativity.
+Notation "_ - _" at level 50 with arguments constr at level 50, constr
+at next level, left associativity.
+Notation "_ * _" at level 40 with arguments constr at level 40, constr
+at next level, left associativity.
+Notation "_ / _" at level 40 with arguments constr at level 40, constr
+at next level, left associativity.
+Notation "- _" at level 35 with arguments constr at level 35,
+right associativity.
+Notation "/ _" at level 35 with arguments constr at level 35,
+right associativity.
+Notation "_ ^ _" at level 30 with arguments constr at next level, constr
+at level 30, right associativity.
+Notation "_ || _" at level 50 with arguments constr at level 50, constr
+at next level, left associativity.
+Notation "_ && _" at level 40 with arguments constr at level 40, constr
+at next level, left associativity.
+Notation "( _ , _ , .. , _ )" at level 0 with arguments constr, constr,
+no associativity.
+Notation "{ _ }" at level 0 with arguments constr at level 99,
+no associativity.
+Notation "{ _ } + { _ }" at level 50 with arguments constr, constr,
+left associativity.
+Notation "_ + { _ }" at level 50 with arguments constr at level 50, constr,
+left associativity.
+Notation "{ _ | _ }" at level 0 with arguments constr at level 99, constr,
+no associativity.
+Notation "{ _ | _ & _ }" at level 0 with arguments constr at level 99,
+constr, constr, no associativity.
+Notation "{ _ : _ | _ }" at level 0 with arguments constr at level 99,
+constr, constr, no associativity.
+Notation "{ _ : _ | _ & _ }" at level 0 with arguments constr at level 99,
+constr, constr, constr, no associativity.
+Notation "{ _ & _ }" at level 0 with arguments constr at level 99, constr,
+no associativity.
+Notation "{ _ & _ & _ }" at level 0 with arguments constr at level 99,
+constr, constr, no associativity.
+Notation "{ _ : _ & _ }" at level 0 with arguments constr at level 99,
+constr, constr, no associativity.
+Notation "{ _ : _ & _ & _ }" at level 0 with arguments constr at level 99,
+constr, constr, constr, no associativity.
+Notation "{ ' _ | _ }" at level 0 with arguments strict pattern at level 0,
+constr, no associativity.
+Notation "{ ' _ | _ & _ }" at level 0 with arguments strict pattern
+at level 0, constr, constr, no associativity.
+Notation "{ ' _ : _ | _ }" at level 0 with arguments strict pattern
+at level 0, constr, constr, no associativity.
+Notation "{ ' _ : _ | _ & _ }" at level 0 with arguments strict pattern
+at level 0, constr, constr, constr, no associativity.
+Notation "{ ' _ & _ }" at level 0 with arguments strict pattern at level 0,
+constr, no associativity.
+Notation "{ ' _ & _ & _ }" at level 0 with arguments strict pattern
+at level 0, constr, constr, no associativity.
+Notation "{ ' _ : _ & _ }" at level 0 with arguments strict pattern
+at level 0, constr, constr, no associativity.
+Notation "{ ' _ : _ & _ & _ }" at level 0 with arguments strict pattern
+at level 0, constr, constr, constr, no associativity.
+Notation "if _ is _ then _ else _" at level 200 with arguments constr,
+pattern at level 100 at level 100, constr, constr at next level,
+no associativity.
+Notation "{{ _ }}" in Foo at level 0 with arguments custom Foo,
+no associativity.
+Notation "{{ _ }}" in Foo at level 0 with arguments custom Foo,
+no associativity.
+File "./output/PrintNotation.v", line 156, characters 2-46:
+The command has indeed failed with message:
+Unknown custom entry: Bar.
+File "./output/PrintNotation.v", line 157, characters 2-46:
+The command has indeed failed with message:
+Unknown custom entry: Bar.
+File "./output/PrintNotation.v", line 158, characters 2-46:
+The command has indeed failed with message:
+"[[ x ]]" cannot be interpreted as a known notation in Foo entry. Make sure
+that symbols are surrounded by spaces and that holes are explicitly denoted
+by "_".
+File "./output/PrintNotation.v", line 159, characters 2-46:
+The command has indeed failed with message:
+"[[ _ ]]" cannot be interpreted as a known notation in Foo entry. Make sure
+that symbols are surrounded by spaces and that holes are explicitly denoted
+by "_".
+File "./output/PrintNotation.v", line 164, characters 2-32:
+The command has indeed failed with message:
+"x mod y" cannot be interpreted as a known notation. Make sure that symbols
+are surrounded by spaces and that holes are explicitly denoted by "_".
+Notation "_ mod _" at level 40 with arguments constr at next level, constr
+at next level, no associativity.
+Notation "_ mod _" at level 40 with arguments constr at next level, constr
+at next level, no associativity.
+Notation "_ mod _" at level 40 with arguments constr at next level, constr
+at next level, no associativity.
+bar (bar ?f ?f0) ?f1
+     : foo
+where
+?f : [ |- foo]
+?f0 : [ |- foo]
+?f1 : [ |- foo]
+File "./output/PrintNotation.v", line 176, characters 2-34:
+The command has indeed failed with message:
+"x 'mod' y" cannot be interpreted as a known notation. Make sure that symbols
+are surrounded by spaces and that holes are explicitly denoted by "_".
+Notation "_ 'mod' _" at level 40 with arguments constr at next level, constr
+at next level, no associativity.
+File "./output/PrintNotation.v", line 178, characters 2-34:
+The command has indeed failed with message:
+"_ 'mod' _" cannot be interpreted as a known notation. Make sure that symbols
+are surrounded by spaces and that holes are explicitly denoted by "_".
+Notation "_ 'mod' _" at level 40 with arguments constr at next level, constr
+at next level, no associativity.
+bar (bar ?f ?f0) ?f1
+     : foo
+where
+?f : [ |- foo]
+?f0 : [ |- foo]
+?f1 : [ |- foo]
+File "./output/PrintNotation.v", line 190, characters 2-42:
+The command has indeed failed with message:
+"exists x .. y , p" cannot be interpreted as a known notation. Make sure that
+symbols are surrounded by spaces and that holes are explicitly denoted by
+"_".
+Notation "exists _ .. _ , _" at level 200 with arguments binder, constr
+at level 200, right associativity.
+Notation "exists _ .. _ , _" at level 200 with arguments binder, constr
+at level 200, right associativity.
+File "./output/PrintNotation.v", line 193, characters 2-37:
+The command has indeed failed with message:
+"exists _ , _" cannot be interpreted as a known notation. Make sure that
+symbols are surrounded by spaces and that holes are explicitly denoted by
+"_".
+File "./output/PrintNotation.v", line 194, characters 2-39:
+The command has indeed failed with message:
+"exists _ _ , _" cannot be interpreted as a known notation. Make sure that
+symbols are surrounded by spaces and that holes are explicitly denoted by
+"_".

--- a/test-suite/output/PrintNotation.v
+++ b/test-suite/output/PrintNotation.v
@@ -1,0 +1,195 @@
+Set Printing All.
+Module NoDefinedAssoc.
+  Reserved Notation "x $ y" (at level 123).
+  Print Notation "x $ x".
+  Axiom foo : Type.
+  Axiom bar : forall _ : foo, forall _ : foo, foo.
+  Notation "x $ y" := (bar x y) (only parsing).
+  Check (_ $ _ $ _).
+End NoDefinedAssoc.
+
+Module NoAssoc.
+  Reserved Notation "x $ y" (at level 123, no associativity).
+  Print Notation "x $ x".
+  Axiom foo : Type.
+  Axiom bar : forall _ : foo, forall _ : foo, foo.
+  Notation "x $ y" := (bar x y) (only parsing).
+  Check (_ $ _ $ _).
+End NoAssoc.
+
+Module LeftAssoc.
+  Reserved Notation "x $ y" (at level 123, left associativity).
+  Print Notation "x $ x".
+  Axiom foo : Type.
+  Axiom bar : forall _ : foo, forall _ : foo, foo.
+  Notation "x $ y" := (bar x y) (only parsing).
+  Check (_ $ _ $ _).
+End LeftAssoc.
+
+Module RightAssoc.
+  Reserved Notation "x $ y" (at level 123, right associativity).
+  Print Notation "x $ x".
+  Axiom foo : Type.
+  Axiom bar : forall _ : foo, forall _ : foo, foo.
+  Notation "x $ y" := (bar x y) (only parsing).
+  Check (_ $ _ $ _).
+  Fail Print Notation "_ $ x".
+  Fail Print Notation "_ $".
+  Fail Print Notation "$ x".
+  Fail Print Notation "x$y".
+  Fail Print Notation "_$_".
+  Print Notation "y $ x".
+  Print Notation "_ $ _".
+End RightAssoc.
+
+(** Stdlib notations *)
+Module StdlibNotations.
+  Import IfNotations.
+  Print Notation "x -> y".
+  Print Notation "x <-> y".
+  Print Notation "x /\ y".
+  Print Notation "x \/ y".
+  Print Notation "~ x".
+  Print Notation "x = y  :>  T".
+  Print Notation "x = y".
+  Print Notation "x = y = z".
+  Print Notation "x <> y  :>  T".
+  Print Notation "x <> y".
+  Print Notation "x <= y".
+  Print Notation "x < y".
+  Print Notation "x >= y".
+  Print Notation "x > y".
+  Print Notation "x <= y <= z".
+  Print Notation "x <= y < z".
+  Print Notation "x < y < z".
+  Print Notation "x < y <= z".
+  Print Notation "x + y".
+  Print Notation "x - y".
+  Print Notation "x * y".
+  Print Notation "x / y".
+  Print Notation "- x".
+  Print Notation "/ x".
+  Print Notation "x ^ y".
+  Print Notation "x || y".
+  Print Notation "x && y".
+  Print Notation "( x , y , .. , z )".
+  Print Notation "{ x }".
+  Print Notation "{ A }  +  { B }".
+  Print Notation "A  +  { B }".
+  Print Notation "{ x | P }".
+  Print Notation "{ x | P & Q }".
+  Print Notation "{ x : A | P }".
+  Print Notation "{ x : A | P & Q }".
+  Print Notation "{ x & P }".
+  Print Notation "{ x & P & Q }".
+  Print Notation "{ x : A & P }".
+  Print Notation "{ x : A & P & Q }".
+  Print Notation "{ ' pat | P }".
+  Print Notation "{ ' pat | P & Q }".
+  Print Notation "{ ' pat : A | P }".
+  Print Notation "{ ' pat : A | P & Q }".
+  Print Notation "{ ' pat & P }".
+  Print Notation "{ ' pat & P & Q }".
+  Print Notation "{ ' pat : A & P }".
+  Print Notation "{ ' pat : A & P & Q }".
+  Print Notation "'if' c 'is' p 'then' u 'else' v".
+End StdlibNotations.
+
+Module StdlibNotationsUnderscored.
+  Import IfNotations.
+  Print Notation "_ -> _".
+  Print Notation "_ <-> _".
+  Print Notation "_ /\ _".
+  Print Notation "_ \/ _".
+  Print Notation "~ _".
+  Print Notation "_ = _  :> _".
+  Print Notation "_ = _".
+  Print Notation "_ = _ = _".
+  Print Notation "_ <> _  :> _".
+  Print Notation "_ <> _".
+  Print Notation "_ <= _".
+  Print Notation "_ < _".
+  Print Notation "_ >= _".
+  Print Notation "_ > _".
+  Print Notation "_ <= _ <= _".
+  Print Notation "_ <= _ < _".
+  Print Notation "_ < _ < _".
+  Print Notation "_ < _ <= _".
+  Print Notation "_ + _".
+  Print Notation "_ - _".
+  Print Notation "_ * _".
+  Print Notation "_ / _".
+  Print Notation "- _".
+  Print Notation "/ _".
+  Print Notation "_ ^ _".
+  Print Notation "_ || _".
+  Print Notation "_ && _".
+  Print Notation "( _ , _ , .. , _ )".
+  Print Notation "{ _ }".
+  Print Notation "{ _ }  +  { _ }".
+  Print Notation "_  +  { _ }".
+  Print Notation "{ _ | _ }".
+  Print Notation "{ _ | _ & _ }".
+  Print Notation "{ _ : _ | _ }".
+  Print Notation "{ _ : _ | _ & _ }".
+  Print Notation "{ _ & _ }".
+  Print Notation "{ _ & _ & _ }".
+  Print Notation "{ _ : _ & _ }".
+  Print Notation "{ _ : _ & _ & _ }".
+  Print Notation "{ ' _ | _ }".
+  Print Notation "{ ' _ | _ & _ }".
+  Print Notation "{ ' _ : _ | _ }".
+  Print Notation "{ ' _ : _ | _ & _ }".
+  Print Notation "{ ' _ & _ }".
+  Print Notation "{ ' _ & _ & _ }".
+  Print Notation "{ ' _ : _ & _ }".
+  Print Notation "{ ' _ : _ & _ & _ }".
+  Print Notation "if _ is _ then _ else _".
+End StdlibNotationsUnderscored.
+
+(* Print Notatation doesn't work with custom notations *)
+Module Custom.
+  Declare Custom Entry Foo.
+  Reserved Notation "{{ x }}" (in custom Foo at level 0).
+  Print Notation "{{ x }}" in custom Foo.
+  Print Notation "{{ _ }}" in custom Foo.
+  Fail Print Notation "{{ x }}" in custom Bar.
+  Fail Print Notation "{{ _ }}" in custom Bar.
+  Fail Print Notation "[[ x ]]" in custom Foo.
+  Fail Print Notation "[[ _ ]]" in custom Foo.
+End Custom.
+
+Module OnlyLetters.
+  Reserved Infix "mod" (at level 40, no associativity).
+  Fail Print Notation "x mod y".
+  Print Notation "x 'mod' y".
+  Print Notation "_ mod _".
+  Print Notation "_ 'mod' _".
+  Axiom foo : Type.
+  Axiom bar : forall _ : foo, forall _ : foo, foo.
+  Infix "mod" := bar (only parsing).
+  Check (_ mod _ mod _).
+End OnlyLetters.
+
+Module SingleQuotes.
+  Reserved Infix "'mod'" (at level 40, no associativity).
+  Fail Print Notation "x 'mod' y".
+  Print Notation "x ''mod'' y".
+  Fail Print Notation "_ 'mod' _". (* FIXME I expected this to work *)
+  Print Notation "_ ''mod'' _".
+  Axiom foo : Type.
+  Axiom bar : forall _ : foo, forall _ : foo, foo.
+  Infix "'mod'" := bar (only parsing).
+  Check (_ 'mod' _ 'mod' _).
+End SingleQuotes.
+
+Module Recursive.
+  Reserved Notation "'exists' x .. y , p"
+    (at level 200, x binder, right associativity,
+    format "'[' 'exists'  '/  ' x  ..  y ,  '/  ' p ']'").
+  Fail Print Notation "exists x .. y , p".
+  Print Notation "'exists' x .. y , p".
+  Print Notation "exists _ .. _ , _".
+  Fail Print Notation "exists _ , _".
+  Fail Print Notation "exists _ _ , _".
+End Recursive.

--- a/vernac/egramcoq.ml
+++ b/vernac/egramcoq.ml
@@ -78,16 +78,19 @@ let create_assoc = function
   | None -> Gramlib.Gramext.RightA
   | Some a -> a
 
+exception NotationLevelMismatch
+  of entry_level * Gramlib.Gramext.g_assoc * Gramlib.Gramext.g_assoc
+
+let () = CErrors.register_handler (function
+  | NotationLevelMismatch (p, current, expected) ->
+      Some Pp.(str "Level " ++ int p ++ str " is already declared to have " ++
+        Gramlib.Gramext.pr_assoc current ++
+        str " while it is now expected to have " ++
+        Gramlib.Gramext.pr_assoc expected ++ str ".")
+  | _ -> None)
+
 let error_level_assoc p current expected =
-  let open Pp in
-  let pr_assoc = function
-    | Gramlib.Gramext.LeftA -> str "left"
-    | Gramlib.Gramext.RightA -> str "right"
-    | Gramlib.Gramext.NonA -> str "non" in
-  user_err
-    (str "Level " ++ int p ++ str " is already declared " ++
-     pr_assoc current ++ str " associative while it is now expected to be " ++
-     pr_assoc expected ++ str " associative.")
+  raise @@ NotationLevelMismatch (p, current, expected)
 
 type position = NewFirst | NewAfter of int | ReuseFirst | ReuseLevel of int
 

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -1017,6 +1017,11 @@ GRAMMAR EXTEND Gram
       | IDENT "LoadPath"; dir = OPT dirpath -> { PrintLoadPath dir }
       | IDENT "Libraries" -> { PrintLibraries }
 
+      | IDENT "Notation"; ntn = string ->
+        { PrintNotation (Constrexpr.InConstrEntry, ntn) }
+      | IDENT "Notation"; ntn = string; IDENT "in"; IDENT "custom"; ent = IDENT ->
+        { PrintNotation (Constrexpr.InCustomEntry ent, ntn) }
+
       | IDENT "ML"; IDENT "Path" -> { PrintMLLoadPath }
       | IDENT "ML"; IDENT "Modules" -> { PrintMLModules }
       | IDENT "Debug"; IDENT "GC" -> { PrintDebugGC }
@@ -1025,10 +1030,10 @@ GRAMMAR EXTEND Gram
       | IDENT "TypeClasses" -> { PrintTypeClasses }
       | IDENT "Instances"; qid = smart_global -> { PrintInstances qid }
       | IDENT "Coercions" -> { PrintCoercions }
-      | IDENT "Coercion"; IDENT "Paths"; s = class_rawexpr; t = class_rawexpr
-         -> { PrintCoercionPaths (s,t) }
-      | IDENT "Canonical"; IDENT "Projections"; qids = LIST0 smart_global
-         -> { PrintCanonicalConversions qids }
+      | IDENT "Coercion"; IDENT "Paths"; s = class_rawexpr; t = class_rawexpr ->
+          { PrintCoercionPaths (s,t) }
+      | IDENT "Canonical"; IDENT "Projections"; qids = LIST0 smart_global ->
+          { PrintCanonicalConversions qids }
       | IDENT "Typing"; IDENT "Flags" -> { PrintTypingFlags }
       | IDENT "Tables" -> { PrintTables }
       | IDENT "Options" -> { PrintTables (* A Synonymous to Tables *) }

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -886,9 +886,15 @@ let default = {
 
 end
 
+exception UnknownCustomEntry of string
+
+let () = CErrors.register_handler @@ function
+  | UnknownCustomEntry entry -> Some Pp.(str "Unknown custom entry: " ++ str entry ++ str ".")
+  | _ -> None
+
 let check_custom_entry entry =
   if not (Egramcoq.exists_custom_entry entry) then
-    user_err Pp.(str "Unknown custom entry: " ++ str entry ++ str ".")
+    raise @@ UnknownCustomEntry entry
 
 let check_entry_type = function
   | ETConstr (InCustomEntry entry,_,_) -> check_custom_entry entry

--- a/vernac/metasyntax.mli
+++ b/vernac/metasyntax.mli
@@ -63,3 +63,10 @@ val pr_custom_grammar : string -> Pp.t
 val with_syntax_protection : ('a -> 'b) -> 'a -> 'b
 
 val declare_custom_entry : locality_flag -> string -> unit
+(** Declare given string as a custom grammar entry *)
+
+val check_custom_entry : string -> unit
+(** Check that the given string is a valid custom entry that has been declared *)
+
+val pr_level : Constrexpr.notation -> Notation.level -> Extend.constr_entry_key list -> Pp.t
+(** Pretty print level information of a notation and all of its arguments *)

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -637,6 +637,10 @@ let pr_printable = function
     keyword "Print Strategy" ++ pr_smart_global qid
   | PrintRegistered ->
     keyword "Print Registered"
+  | PrintNotation (Constrexpr.InConstrEntry, ntn_key) ->
+    keyword "Print Notation" ++ spc() ++ str ntn_key
+  | PrintNotation (Constrexpr.InCustomEntry ent, ntn_key) ->
+    keyword "Print Notation" ++ spc() ++ str ent ++ str ntn_key
 
 let pr_using e =
   let rec aux = function

--- a/vernac/prettyp.mli
+++ b/vernac/prettyp.mli
@@ -48,6 +48,10 @@ val print_name : env -> Evd.evar_map
   -> qualid Constrexpr.or_by_notation
   -> UnivNames.univ_name_list option
   -> Pp.t
+val print_notation : env -> Evd.evar_map
+  -> Constrexpr.notation_entry
+  -> string
+  -> Pp.t
 val print_opaque_name : env -> Evd.evar_map -> qualid -> Pp.t
 val print_about : env -> Evd.evar_map -> qualid Constrexpr.or_by_notation ->
   UnivNames.univ_name_list option -> Pp.t

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2002,6 +2002,7 @@ let vernac_print ~pstate =
   | PrintTypeClasses -> Prettyp.print_typeclasses()
   | PrintInstances c -> Prettyp.print_instances (smart_global c)
   | PrintCoercions -> Prettyp.print_coercions ()
+  | PrintNotation (entry, ntnstr) -> Prettyp.print_notation env sigma entry ntnstr
   | PrintCoercionPaths (cls,clt) ->
     Prettyp.print_path_between (cl_of_qualid cls) (cl_of_qualid clt)
   | PrintCanonicalConversions qids ->

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -60,6 +60,7 @@ type printable =
   | PrintAssumptions of bool * bool * qualid or_by_notation
   | PrintStrategy of qualid or_by_notation option
   | PrintRegistered
+  | PrintNotation of Constrexpr.notation_entry * string
 
 type glob_search_where = InHyp | InConcl | Anywhere
 


### PR DESCRIPTION
We add a `Print Notation` command that displays parsing information about a notation. For example:
```coq
Print Notation "x + y".
```
gives
```
Notation "_ + _" at level 50 with arguments
constr at level 50, constr at next level,
left associativity.
```

It also works with custom entries:
```coq
Declare Custom Entry expr.
Reserved Infix "$" (in custom expr at level 40).
Print Notation "_ $ _" in custom expr.
```
gives
```
Notation "_ $ _" in expr at level 40 with arguments custom expr
at next level, custom expr at next level, no associativity.
```

---

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
* Fixes https://github.com/coq/coq/issues/14907
* Fixes https://github.com/coq/coq/issues/4436
* Fixes https://github.com/coq/coq/issues/7730

<!-- Remove anything that doesn't apply in the following checklist. -->

- [x] Error message for print notation needs to be improved
- [x] (and documented).
- [x]  Replace "No associativity defined" with "no associativity"

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.
  - [x] Tests have been added, but we should probably test more things.
  - [x] Tests for stdlib notations in the prelude have been added.
  - [ ] We need to test more edge cases with weird characters and alphanumeric symbols. It appears using `..` in a notation is a no-no so we will not worry about that.
  - [x] We should add some tests of things that don't work, ie, tests starting with `Fail`

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  - [x] Preliminary documentation has been added, more to come.
  - [x] Documented any new / changed **user messages**.
  - [x] Mention the two ways of providing input: `"a + b"` or `"_ + _"` (but that the latter should be preferred).
  - [x] Updated **documented syntax** by running `make -f Makefile.dune doc_gram_rsts`.

cc. @Alizter @ejgallego 
