### PR TITLE
Formally deprecate the only remaining definition the Goal module.

### DIFF
--- a/proofs/goal.mli
+++ b/proofs/goal.mli
@@ -10,4 +10,4 @@
 
 (** Don't use this module. *)
 
-type goal = Evar.t
+type goal = Evar.t [@@ocaml.deprecated]


### PR DESCRIPTION
Probably an oversight.