### PR TITLE
Reversible coercions

### DIFF
--- a/dev/ci/user-overlays/15693-gares-reverse-coercions.sh
+++ b/dev/ci/user-overlays/15693-gares-reverse-coercions.sh
@@ -1,0 +1,4 @@
+overlay elpi https://github.com/proux01/coq-elpi coq_15693 15693
+overlay hierarchy_builder https://github.com/gares/hierarchy-builder reverse-coercions 15693
+#overlay mathcomp https://github.com/gares/math-comp reverse-coercions 15693
+overlay mtac2 https://github.com/proux01/Mtac2 coq_15693 15693

--- a/doc/changelog/02-specification-language/15693-reverse-coercions.rst
+++ b/doc/changelog/02-specification-language/15693-reverse-coercions.rst
@@ -1,0 +1,8 @@
+- **Added:**
+  :term:`Reversible coercions <reversible coercion>` are coercions which cannot be
+  represented by a regular coercion (a Gallina function)
+  but rather a meta procedure, such as type class inference
+  or canonical structure resolution
+  (`#15693 <https://github.com/coq/coq/pull/15693>`_,
+  by Cyril Cohen, Pierre Roux, Enrico Tassi,
+  reviewed by Ali Caglayan, Jim Fehrle and Gaëtan Gilert).

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -721,11 +721,12 @@ gallina_ext: [
 
 | DELETE "Coercion" global ":" class_rawexpr ">->" class_rawexpr
 | REPLACE "Coercion" by_notation ":" class_rawexpr ">->" class_rawexpr
-| WITH "Coercion" smart_global ":" class_rawexpr ">->" class_rawexpr
+| WITH "Coercion" smart_global OPT [ ":" class_rawexpr ">->" class_rawexpr ]
 
 (* semantically restricted per https://github.com/coq/coq/pull/12936#discussion_r492705820 *)
-| REPLACE "Coercion" global OPT univ_decl def_body
-| WITH "Coercion" ident OPT univ_decl def_body
+(* global OPT univ_decl is just ident_decl, the first OPT is moved to the rule above *)
+| REPLACE "Coercion" global OPT [ OPT univ_decl def_body ]
+| WITH "Coercion" ident_decl def_body
 
 | REPLACE "Include" "Type" module_type_inl LIST0 ext_module_type
 | WITH "Include" "Type" LIST1 module_type_inl SEP "<+"

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1053,7 +1053,7 @@ gallina_ext: [
 | "Strategy" LIST1 [ strategy_level "[" LIST1 smart_global "]" ]
 | "Canonical" OPT "Structure" global OPT [ OPT univ_decl def_body ]
 | "Canonical" OPT "Structure" by_notation
-| "Coercion" global OPT univ_decl def_body
+| "Coercion" global OPT [ OPT univ_decl def_body ]
 | "Identity" "Coercion" identref ":" class_rawexpr ">->" class_rawexpr
 | "Coercion" global ":" class_rawexpr ">->" class_rawexpr
 | "Coercion" by_notation ":" class_rawexpr ">->" class_rawexpr

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1084,9 +1084,9 @@ command: [
 | "Strategy" LIST1 [ strategy_level "[" LIST1 reference "]" ]
 | "Canonical" OPT "Structure" ident_decl def_body
 | "Canonical" OPT "Structure" reference
-| "Coercion" ident OPT univ_decl def_body
+| "Coercion" ident_decl def_body
 | "Identity" "Coercion" ident ":" class ">->" class
-| "Coercion" reference ":" class ">->" class
+| "Coercion" reference OPT [ ":" class ">->" class ]
 | "Context" LIST1 binder
 | "Instance" OPT ( ident_decl LIST0 binder ) ":" type OPT hint_info OPT [ ":=" "{" LIST0 field_val "}" | ":=" term ]
 | "Existing" "Instance" qualid OPT hint_info

--- a/pretyping/coercionops.mli
+++ b/pretyping/coercionops.mli
@@ -39,6 +39,7 @@ type coe_info_typ = {
   coe_value : GlobRef.t;
   coe_typ : Constr.t;
   coe_local : bool;
+  coe_reversible : bool;
   coe_is_identity : bool;
   coe_is_projection : Projection.Repr.t option;
   coe_source : cl_typ;
@@ -67,7 +68,8 @@ val class_args_of : env -> evar_map -> types -> constr list
 
 val subst_coercion : substitution -> coe_info_typ -> coe_info_typ
 
-val declare_coercion : env -> evar_map -> coe_info_typ -> unit
+(** Set [update] to update an already declared coercion (default [false]). *)
+val declare_coercion : env -> evar_map -> ?update:bool -> coe_info_typ -> unit
 
 (** {6 Access to coercions infos } *)
 val coercion_exists : coe_typ -> bool
@@ -78,6 +80,9 @@ val coercion_info : coe_typ -> coe_info_typ
 
 (** @raise Not_found in the following functions when no path exists *)
 
+(** given one (or two) types these function also return the class (classes)
+    of the type and its class_args_of *)
+
 val lookup_path_between_class : cl_typ * cl_typ -> inheritance_path
 val lookup_path_between : env -> evar_map -> src:types -> tgt:types ->
   inheritance_path
@@ -85,6 +90,8 @@ val lookup_path_to_fun_from : env -> evar_map -> types -> inheritance_path
 val lookup_path_to_sort_from : env -> evar_map -> types -> inheritance_path
 val lookup_pattern_path_between :
   env -> inductive * inductive -> (constructor * int) list
+
+val path_is_reversible : inheritance_path -> bool
 
 (**/**)
 (* Crade *)
@@ -104,3 +111,7 @@ val coercions : unit -> coe_info_typ list
 (** [hide_coercion] returns the number of params to skip if the coercion must
    be hidden, [None] otherwise; it raises [Not_found] if not a coercion *)
 val hide_coercion : coe_typ -> int option
+
+module ClTypSet : Set.S with type elt = cl_typ
+
+val reachable_from : cl_typ -> ClTypSet.t

--- a/test-suite/output/relaxed_ambiguous_paths.out
+++ b/test-suite/output/relaxed_ambiguous_paths.out
@@ -44,17 +44,17 @@ New coercion path [ab; ba] : A >-> A is not definitionally an identity function.
 [B_A] : B >-> A
 [C_A] : C >-> A
 [D_A] : D >-> A
-[D_B] : D >-> B
-[D_C] : D >-> C
-[A'_A] : A' >-> A
+[D_B] : D >-> B (reversible)
+[D_C] : D >-> C (reversible)
+[A'_A] : A' >-> A (reversible)
 [B_A'; A'_A] : B >-> A
 [B_A'] : B >-> A'
 [C_A'; A'_A] : C >-> A
 [C_A'] : C >-> A'
 [D_A] : D >-> A
 [D_B; B_A'] : D >-> A'
-[D_B] : D >-> B
-[D_C] : D >-> C
+[D_B] : D >-> B (reversible)
+[D_C] : D >-> C (reversible)
 File "./output/relaxed_ambiguous_paths.v", line 147, characters 0-86:
 Warning:
 New coercion path [D_C; C_A'] : D >-> A' is ambiguous with existing 
@@ -66,17 +66,17 @@ New coercion path [D_C; C_A'] : D >-> A' is ambiguous with existing
 [C_A'] : C >-> A'
 [D_A] : D >-> A
 [D_B; B_A'] : D >-> A'
-[D_B] : D >-> B
-[D_C] : D >-> C
+[D_B] : D >-> B (reversible)
+[D_C] : D >-> C (reversible)
 File "./output/relaxed_ambiguous_paths.v", line 156, characters 0-47:
 Warning:
-New coercion path [unwrap_nat; wrap_nat] : NAT >-> NAT is not definitionally an identity function.
+New coercion path [unwrap_nat; wrap_nat] : NAT >-> NAT (reversible) is not definitionally an identity function.
 [ambiguous-paths,typechecker]
 File "./output/relaxed_ambiguous_paths.v", line 157, characters 0-64:
 Warning:
-New coercion path [unwrap_list; wrap_list] : LIST >-> LIST is not definitionally an identity function.
+New coercion path [unwrap_list; wrap_list] : LIST >-> LIST (reversible) is not definitionally an identity function.
 [ambiguous-paths,typechecker]
 File "./output/relaxed_ambiguous_paths.v", line 158, characters 0-51:
 Warning:
-New coercion path [unwrap_Type; wrap_Type] : TYPE >-> TYPE is not definitionally an identity function.
+New coercion path [unwrap_Type; wrap_Type] : TYPE >-> TYPE (reversible) is not definitionally an identity function.
 [ambiguous-paths,typechecker]

--- a/test-suite/success/reverse_coercions.v
+++ b/test-suite/success/reverse_coercions.v
@@ -1,0 +1,188 @@
+Module Test0.
+
+(* By default all coercions from a Structure/Record are also reversible, unless:
+
+     Structure foo := {
+      ..
+      #[reversible=no] bla :> blu
+     }
+
+   is given
+*)
+
+(* Declaring/undeclaring a reverse coercion after the facts:
+
+    #[reversible] Coercion sort.
+    #[reversible=yes] Coercion sort.
+
+    #[reversible=no] Coercion sort.
+*)
+
+Structure S := {
+  ssort :> Type;
+  sstuff : ssort;
+}.
+
+Definition test1 (s : S) (x : s) := sstuff s.
+Definition test2 (s : S) := sstuff s.
+
+Canonical Structure S_nat := {| ssort := nat; sstuff := 0; |}.
+Set Printing All.
+Check test1 _ (0 : nat).
+
+(* old hack *)
+Definition test' {s : S} (t : Type) (f : ssort s -> t) := sstuff s.
+Notation test t := (test' t (fun x => x)).
+Check test nat.
+
+(* new *)
+Check test2 (nat : Type).
+Definition nat' (x:unit) := nat.
+Arguments nat' &.
+(* checks that reapply_coercions gets the right trace *)
+Check test2 (nat' tt).
+Check (nat : S).
+
+Structure R := {
+  rsort :> Type;
+  rstuff : rsort;
+  srstuff : rsort;
+}.
+
+Coercion RtoS (r : R) := {| ssort := rsort r ; sstuff := srstuff r|}.
+Canonical RtoS.
+
+Canonical Structure R_nat := {| rsort := nat; rstuff := 1; srstuff := 0 |}.
+
+Definition test3 (r : R) := rstuff r.
+
+Set Printing All.
+Check test3 nat.
+Check test3 S_nat.
+
+Structure T := {
+  tsort :> Type;
+}.
+
+Canonical T_nat (x : unit) := {| tsort := nat |}.
+
+Check test2 (T_nat tt).
+
+
+
+Structure A := { }.
+Structure A' := { }.
+Structure B := { ba :> A; #[canonical=no] ba' :> A' }.
+Structure C := { ca :> A; #[canonical=no] ca' :> A' }.
+Axiom f : A -> A'.
+Coercion f : A >-> A'.
+
+Canonical b : B := {| ba := Build_A; ba' := Build_A' |}.
+Canonical c : C := {| ca := Build_A; ca' := Build_A' |}.
+
+Definition test4 (x : B) := 1.
+Check test4 c.
+
+
+
+
+
+
+(* ~~> test S_nat : S_nat.sort
+                             Type ==?== S
+                               :
+                             f : nat ---> S_nat
+
+                              sort : S >-> Type
+
+                             f :=
+                              nat ----> ?x
+                              sort ?x ==?== nat
+                            *)
+
+End Test0.
+
+(* Test the reverse attribute *)
+Module Test1.
+
+Structure S := {
+  ssort : Type;
+  sstuff : ssort;
+}.
+
+#[reversible=no] Coercion ssort : S >-> Sortclass.
+
+Definition test2 (s : S) := sstuff s.
+
+Canonical Structure S_nat := {| ssort := nat; sstuff := 0; |}.
+Fail Check test2 (nat : Type).
+
+End Test1.
+
+(* Test the reverse attribute *)
+Module Test1'.
+
+Structure S := {
+  ssort : Type;
+  sstuff : ssort;
+}.
+
+Coercion ssort : S >-> Sortclass.
+
+Definition test2 (s : S) := sstuff s.
+
+Canonical Structure S_nat := {| ssort := nat; sstuff := 0; |}.
+Fail Check test2 (nat : Type).
+
+End Test1'.
+
+(* Test the reverse attribute *)
+Module Test2.
+
+Structure S := {
+  #[reversible=no] ssort :> Type;
+  sstuff : ssort;
+}.
+
+Definition test2 (s : S) := sstuff s.
+
+Canonical Structure S_nat := {| ssort := nat; sstuff := 0; |}.
+Fail Check test2 (nat : Type).
+
+End Test2.
+
+(* Test the reverse attribute *)
+Module Test3.
+
+Structure S := {
+  #[reversible=no] ssort :> Type;
+  sstuff : ssort;
+}.
+
+Definition test2 (s : S) := sstuff s.
+
+Canonical Structure S_nat := {| ssort := nat; sstuff := 0; |}.
+
+#[reversible] Coercion ssort.
+
+Check test2 (nat : Type).
+
+End Test3.
+
+(* Test the reverse attribute *)
+Module Test4.
+
+Structure S := {
+  ssort :> Type;
+  sstuff : ssort;
+}.
+
+Definition test2 (s : S) := sstuff s.
+
+Canonical Structure S_nat := {| ssort := nat; sstuff := 0; |}.
+
+#[reversible=no] Coercion ssort.
+
+Fail Check test2 (nat : Type).
+
+End Test4.

--- a/test-suite/success/reverse_coercions_ac.v
+++ b/test-suite/success/reverse_coercions_ac.v
@@ -1,0 +1,37 @@
+Set Implicit Arguments.
+
+Class Inhab (A:Type) : Prop :=
+  { inhab: exists (x:A), True }.
+
+Record IType : Type := IType_make
+  { IType_type :> Type;
+    IType_inhab : Inhab IType_type }.
+
+Canonical default_IType t ct : IType := @IType_make t ct.
+
+Arguments IType_make IType_type {IType_inhab}.
+
+Global Instance Inhab_IType : forall (A:IType), Inhab A.
+Proof using. constructor. apply IType_inhab. Defined.
+
+Parameter P : Type -> Prop.
+
+(** A [IType] can be provided where an type [A] with a proof of [Inhab A] is expected. *)
+Parameter K : forall (A:Type) (IA:Inhab A), P A.
+Lemma testK : forall (A:IType), P A.
+Proof using. intros. eapply K. eauto with typeclass_instances. Qed.
+
+(** A type [A] can be provided where a [IType] is expected, by wrapping it with [IType_make]. *)
+Parameter T : forall (A:IType), P A.
+Lemma testT : forall (A:Type) (IA:Inhab A), P A.
+Proof using. intros. eapply (T A). Qed.
+
+(* Above, it would be nice to write [eapply (T A)], or just [eapply T].
+   For that, we'd need to coerce [A:Type] to the type [IType]
+   by applying on-the-fly the operation [IType_make A _]. Thus, we need something like:
+   [Coercion (fun (A:Type) => IType_make A _) : Sortclass >-> IType.]
+  Would that be possible?
+
+  I understand that [IType_type] is already a reverse coercion from [IType] to [Type],
+  but I don't see why it would necessarily cause trouble to have cycles
+  in the coercion graphs. *)

--- a/test-suite/success/reverse_coercions_typeclasses_and_canonical.v
+++ b/test-suite/success/reverse_coercions_typeclasses_and_canonical.v
@@ -1,0 +1,30 @@
+Set Primitive Projections.
+
+Class IsPointed (A : Type) := point : A.
+
+Record pType : Type := {
+  pointed_type : Type ;
+  ispointed_pointed_type : IsPointed pointed_type ;
+}.
+#[reversible]
+Coercion pointed_type : pType >-> Sortclass.
+Fail Canonical Build_pType.
+Canonical Structure Build_pType' (A : Type) (a : IsPointed A) := Build_pType A a.
+
+Axiom A : Type.
+#[export]
+Instance a : IsPointed A. Proof. Admitted.
+
+Axiom lemma_about_ptype : forall (X : pType), Type.
+
+Type (A : pType).
+Type (lemma_about_ptype A).
+
+(*
+Ok, so here is what happens:
+* you give `A : Type` where `?x : pType` is expected
+* no coercion `Sortclass >-> pType` but (according to `Print Graph`) we have `[pointed_type] : pType ↣ Sortclass (reversible)`
+* so reversible coercions look for `?x : pType` such that `pointed_type ?x = A`
+* and canonical structure mechanism infers `?x = Build_pType' A _`
+* finally, typeclass resolution fills the last `_` with `a`
+*)

--- a/vernac/attributes.ml
+++ b/vernac/attributes.ml
@@ -299,6 +299,8 @@ let vernac_polymorphic_flag loc =
 let vernac_monomorphic_flag loc =
   CAst.make ?loc (ukey, VernacFlagList [CAst.make ?loc ("polymorphic", VernacFlagLeaf (FlagIdent "no"))])
 
+let reversible = bool_attribute ~name:"reversible"
+
 let canonical_field =
   enable_attribute ~key:"canonical" ~default:(fun () -> true)
 let canonical_instance =

--- a/vernac/attributes.mli
+++ b/vernac/attributes.mli
@@ -57,6 +57,7 @@ val template : bool option attribute
 val locality : bool option attribute
 val option_locality : Goptions.option_locality attribute
 val deprecation : Deprecation.t option attribute
+val reversible : bool option attribute
 val canonical_field : bool attribute
 val canonical_instance : bool attribute
 val using : string option attribute

--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -29,7 +29,7 @@ let declare_variable is_coe ~kind typ univs imps impl {CAst.v=name} =
   let env = Global.env () in
   let sigma = Evd.from_env env in
   let () = Classes.declare_instance env sigma None Hints.Local r in
-  let () = if is_coe then ComCoercion.try_add_new_coercion r ~local:true ~poly:false ~nonuniform:false in
+  let () = if is_coe then ComCoercion.try_add_new_coercion r ~local:true ~poly:false ~nonuniform:false ~reversible:true in
   ()
 
 let instance_of_univ_entry = function
@@ -62,7 +62,7 @@ let declare_axiom is_coe ~poly ~local ~kind typ (univs, ubinders) imps nl {CAst.
     | Locality.ImportNeedQualified -> true
     | Locality.ImportDefaultBehavior -> false
   in
-  let () = if is_coe then ComCoercion.try_add_new_coercion gr ~local ~poly ~nonuniform:false in
+  let () = if is_coe then ComCoercion.try_add_new_coercion gr ~local ~poly ~nonuniform:false ~reversible:true in
   let inst = instance_of_univ_entry univs in
   (gr,inst)
 

--- a/vernac/comCoercion.mli
+++ b/vernac/comCoercion.mli
@@ -20,6 +20,7 @@ val try_add_new_coercion_with_target
   -> local:bool
   -> poly:bool
   -> nonuniform:bool
+  -> reversible:bool
   -> source:cl_typ
   -> target:cl_typ
   -> unit
@@ -27,19 +28,21 @@ val try_add_new_coercion_with_target
 (** [try_add_new_coercion ref s] declares [ref], assumed to be of type
    [(x1:T1)...(xn:Tn)src->tg], as a coercion from [src] to [tg] *)
 val try_add_new_coercion : GlobRef.t -> local:bool -> poly:bool ->
-  nonuniform:bool -> unit
+  nonuniform:bool ->
+  reversible:bool -> unit
 
 (** [try_add_new_coercion_subclass cst s] expects that [cst] denotes a
    transparent constant which unfolds to some class [tg]; it declares
    an identity coercion from [cst] to [tg], named something like
    ["Id_cst_tg"] *)
 val try_add_new_coercion_subclass : cl_typ -> local:bool -> poly:bool ->
-  nonuniform:bool -> unit
+  nonuniform:bool ->
+  reversible:bool -> unit
 
 (** [try_add_new_coercion_with_source ref s src] declares [ref] as a coercion
    from [src] to [tg] where the target is inferred from the type of [ref] *)
 val try_add_new_coercion_with_source : GlobRef.t -> local:bool ->
-  poly:bool -> nonuniform:bool -> source:cl_typ -> unit
+  poly:bool -> nonuniform:bool -> reversible:bool -> source:cl_typ -> unit
 
 (** [try_add_new_identity_coercion id s src tg] enriches the
    environment with a new definition of name [id] declared as an
@@ -49,12 +52,14 @@ val try_add_new_identity_coercion
   -> local:bool
   -> poly:bool -> source:cl_typ -> target:cl_typ -> unit
 
-val add_coercion_hook : poly:bool -> nonuniform:bool -> Declare.Hook.t
+val add_coercion_hook : poly:bool -> nonuniform:bool -> reversible:bool -> Declare.Hook.t
 
-val add_subclass_hook : poly:bool -> Declare.Hook.t
+val add_subclass_hook : poly:bool -> reversible:bool -> Declare.Hook.t
 
 val class_of_global : GlobRef.t -> cl_typ
 
 (** Attribute to silence warning for coercions that don't satisfy
    the uniform inheritance condition. *)
 val nonuniform : bool option Attributes.attribute
+
+val change_reverse : GlobRef.t -> reversible:bool -> unit

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -713,7 +713,7 @@ let do_mutual_inductive ~template udecl indl ~cumulative ~poly ?typing_flags ~pr
   (* Declare the possible notations of inductive types *)
   List.iter (Metasyntax.add_notation_interpretation ~local:false (Global.env ())) where_notations;
   (* Declare the coercions *)
-  List.iter (fun qid -> ComCoercion.try_add_new_coercion (Nametab.locate qid) ~local:false ~poly ~nonuniform:false) coercions
+  List.iter (fun qid -> ComCoercion.try_add_new_coercion (Nametab.locate qid) ~local:false ~poly ~nonuniform:false ~reversible:true) coercions
 
 (** Prepare a "match" template for a given inductive type.
     For each branch of the match, we list the constructor name

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -472,9 +472,9 @@ GRAMMAR EXTEND Gram
   [ [ attr = LIST0 quoted_attributes ;
       bd = record_binder; rf_priority = OPT [ "|"; n = natural -> { n } ];
       rf_notation = decl_notations -> {
-      let rf_canonical = attr |> List.flatten |> parse canonical_field in
+      let rf_canonical, rf_reverse = attr |> List.flatten |> parse Notations.(canonical_field ++ reversible) in
       let rf_subclass, rf_decl = bd in
-      rf_decl, { rf_subclass ; rf_priority ; rf_notation ; rf_canonical } } ] ]
+      rf_decl, { rf_subclass ; rf_reverse ; rf_priority ; rf_notation ; rf_canonical } } ] ]
   ;
   record_fields:
     [ [ f = record_field; ";"; fs = record_fields -> { f :: fs }
@@ -744,18 +744,19 @@ GRAMMAR EXTEND Gram
           { VernacCanonical CAst.(make ~loc @@ ByNotation ntn) }
 
       (* Coercions *)
-      | IDENT "Coercion"; qid = global; u = OPT univ_decl; d = def_body ->
-          { let s = coerce_reference_to_id qid in
-          VernacDefinition ((NoDischarge,Coercion),((CAst.make ?loc:qid.CAst.loc (Name s)),u),d) }
+      | IDENT "Coercion"; qid = global; ud = OPT [ u = OPT univ_decl; d = def_body -> { u, d } ] ->
+          { match ud with Some (u, d) -> let s = coerce_reference_to_id qid in
+          VernacDefinition ((NoDischarge,Coercion),((CAst.make ?loc:qid.CAst.loc (Name s)),u),d)
+          | None -> VernacCoercion (CAst.make ~loc @@ AN qid, None) }
       | IDENT "Identity"; IDENT "Coercion"; f = identref; ":";
          s = class_rawexpr; ">->"; t = class_rawexpr ->
            { VernacIdentityCoercion (f, s, t) }
       | IDENT "Coercion"; qid = global; ":"; s = class_rawexpr; ">->";
          t = class_rawexpr ->
-          { VernacCoercion (CAst.make ~loc @@ AN qid, s, t) }
+          { VernacCoercion (CAst.make ~loc @@ AN qid, Some(s, t)) }
       | IDENT "Coercion"; ntn = by_notation; ":"; s = class_rawexpr; ">->";
          t = class_rawexpr ->
-          { VernacCoercion (CAst.make ~loc @@ ByNotation ntn, s, t) }
+          { VernacCoercion (CAst.make ~loc @@ ByNotation ntn, Some (s, t)) }
 
       | IDENT "Context"; c = LIST1 binder ->
           { VernacContext (List.flatten c) }

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -959,12 +959,18 @@ let pr_vernac_expr v =
     return (
       keyword "Canonical Structure" ++ spc() ++ pr_smart_global q
     )
-  | VernacCoercion (id,c1,c2) ->
+  | VernacCoercion (id,Some(c1,c2)) ->
     return (
       hov 1 (
         keyword "Coercion" ++ spc() ++
         pr_smart_global id ++ spc() ++ str":" ++ spc() ++ pr_class_rawexpr c1 ++
         spc() ++ str">->" ++ spc() ++ pr_class_rawexpr c2)
+    )
+  | VernacCoercion (id,None) ->
+    return (
+      hov 1 (
+        keyword "Coercion" ++ spc() ++
+        pr_smart_global id)
     )
   | VernacIdentityCoercion (id,c1,c2) ->
     return (

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -198,7 +198,11 @@ let print_opacity ref =
 (*******************)
 
 let print_if_is_coercion ref =
-  if Coercionops.coercion_exists ref then [pr_global ref ++ str " is a coercion"] else []
+  if Coercionops.coercion_exists ref then
+    let i = Coercionops.coercion_info ref in
+    let r = if i.Coercionops.coe_reversible then " reversible" else "" in
+    [pr_global ref ++ str " is a" ++ str r ++ str " coercion"]
+  else []
 
 (*******************)
 (* *)
@@ -1038,7 +1042,8 @@ let print_path ((i,j),p) =
   hov 2 (
     str"[" ++ hov 0 (prlist_with_sep pr_semicolon print_coercion_value p) ++
     str"] : ") ++
-  pr_class i ++ str" >-> " ++ pr_class j
+  pr_class i ++ str" >-> " ++ pr_class j ++
+  str (if path_is_reversible p then " (reversible)" else "")
 
 let _ = Coercionops.install_path_printer print_path
 

--- a/vernac/record.mli
+++ b/vernac/record.mli
@@ -39,6 +39,7 @@ val definition_structure
   module Data : sig
     type projection_flags = {
       pf_subclass: bool;
+      pf_reversible: bool;
       pf_canonical: bool;
     }
     type raw_data
@@ -89,6 +90,7 @@ val declare_existing_class : GlobRef.t -> unit
 module Internal : sig
   type projection_flags = {
     pf_subclass: bool;
+    pf_reversible: bool;
     pf_canonical: bool;
   }
 

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -183,6 +183,7 @@ type 'a with_coercion = coercion_flag * 'a
 (* Attributes of a record field declaration *)
 type record_field_attr = {
   rf_subclass: instance_flag; (* the projection is an implicit coercion or an instance *)
+  rf_reverse: bool option;
   rf_priority: int option; (* priority of the instance, if relevant *)
   rf_notation: decl_notation list;
   rf_canonical: bool; (* use this projection in the search for canonical instances *)
@@ -369,7 +370,7 @@ type nonrec vernac_expr =
   | VernacImport of export_flag * import_categories option * (qualid * import_filter_expr) list
   | VernacCanonical of qualid or_by_notation
   | VernacCoercion of qualid or_by_notation *
-      class_rawexpr * class_rawexpr
+      (class_rawexpr * class_rawexpr) option
   | VernacIdentityCoercion of lident * class_rawexpr * class_rawexpr
   | VernacNameSectionHypSet of lident * section_subset_expr
 


### PR DESCRIPTION
Intro:
This PR implements a feature along the lines of https://arxiv.org/abs/1103.3320 where *any* term `t` (even a type) can be elaborated to another term `s` whenever `t ~c~> t'` via regular a coercion path `c` (even of length 0) and `t' <~rc~ s` via a reversible coercion path `rc`. Reversible coercions are coercions that are also equipped with canonical inference. The elaboration is obtained by solving the unification problem `c t ==?== rc ?s` (`t'` is `c t`, `rc` is a canonical projection).

As a result a function `f` taking a record argument (eg an `eqType`) can be passed a naked type (eg `nat`) and be elaborated to `f nat_eqType` (in this case `c` has length 0, `t'` is `nat` already). In the usual coercion jargon this is `Sortclass >-> eqType` which cannot be a type theoretic function (you can't match on inhabitants of `Type`), hence the unification and its hints are defining how this "coercion" is computed.

In the presence of a hierarchy with a diamond (made of `left` `right` `bottom` `top`), a function can expect the `left` structure and be passed the an inhabitant of the `right` structure, since that term can be directly coerced to the `bottom` structure and enriched back (reverse coerced) to the `left` one. We try to compute the pushout if it exists, that is, if `bottom` has a coercion to a simpler structure `lower` (`bottom` inherits `lower`), we don't coerce to `lower` and enrich back to `left` (we try to lose as little information as possible via direct coercions).
```
       top
   /        \
left      right
  \          /
     bottom
      |
     lower
```

TODO:
- [x] fix the trace: add a constructor that means `(fun _ => the_new_term)`
- [x] attribute syntax, then filter the reverse path search using only allowed (flagged as reverse) coercions
- [x] tests for parameters
- [x] doc
- [x] changelog

MAYBE another PR:
- [x] interleave regular coercions and reverse coercions as in `(x : R) >-> S <~< T` to enrich `x` to `T` lowering it down first to `S`.

#### Overlays to be merged after the PR
* https://github.com/math-comp/math-comp/pull/853 [DO NOT MERGE]

#### Overlays to be merged before the PR
* https://github.com/math-comp/math-comp/pull/867 (except if https://github.com/coq/coq/issues/15843 is fixed first)
* https://github.com/math-comp/hierarchy-builder/pull/289

#### Overlays to be merged in sync with the PR
* https://github.com/LPCIC/coq-elpi/pull/355
* https://github.com/Mtac2/Mtac2/pull/356

CC @CohenCyril @pi8027 @SkySkimmer 