### PR TITLE
Simplify the Cooking API

### DIFF
--- a/kernel/cooking.ml
+++ b/kernel/cooking.ml
@@ -320,6 +320,14 @@ let make_cooking_info expand_info hyps uctx =
   let names_info = Context.Named.to_vars hyps in
   { expand_info; abstr_info; abstr_inst_info; names_info }
 
+let add_inductive_info ind info =
+  let (cmap, imap) = info.expand_info in
+  { info with expand_info = (cmap, Mindmap.add ind info.abstr_inst_info imap) }
+
+let names_info info = info.names_info
+
+let abstr_inst_info info = info.abstr_inst_info
+
 let rel_context_of_cooking_cache { info; _ } =
   info.abstr_info.abstr_ctx
 

--- a/kernel/cooking.mli
+++ b/kernel/cooking.mli
@@ -13,8 +13,6 @@ open Constr
 
 (** {6 Data needed to abstract over the section variables and section universes } *)
 
-type abstr_info
-
 (** The instantiation to apply to generalized declarations so that
     they behave as if not generalized: this is the a1..an instance to
     apply to a declaration c in the following transformation:
@@ -25,12 +23,7 @@ type abstr_info
     (because the substitution are represented by their domain) but
     here, local definitions of the context have been dropped *)
 
-type abstr_inst_info = {
-  abstr_rev_inst : Id.t list;
-  (** The variables to reapply (excluding "let"s of the context), in reverse order *)
-  abstr_uinst : Univ.Instance.t;
-  (** Abstracted universe variables to reapply *)
-}
+type abstr_inst_info
 
 type 'a entry_map = 'a Cmap.t * 'a Mindmap.t
 type expand_info = abstr_inst_info entry_map
@@ -44,18 +37,19 @@ type expand_info = abstr_inst_info entry_map
     so, a cooking_info is the map [c ↦ x1..xn],
     the context x:T,y:U to generalize, and the substitution [x,y] *)
 
-type cooking_info = {
-  expand_info : expand_info;
-  abstr_info : abstr_info;
-  abstr_inst_info : abstr_inst_info; (* relevant for recursive types *)
-  names_info : Id.Set.t; (* set of generalized names *)
-}
+type cooking_info
 
 val empty_cooking_info : cooking_info
   (** Nothing to abstract *)
 
 val make_cooking_info : expand_info -> named_context -> Univ.UContext.t -> cooking_info
   (** Abstract a context assumed to be de-Bruijn free for terms and universes *)
+
+val add_inductive_info : MutInd.t -> cooking_info -> cooking_info
+
+val names_info : cooking_info -> Id.Set.t
+
+val abstr_inst_info : cooking_info -> abstr_inst_info
 
 val universe_context_of_cooking_info : cooking_info -> Univ.AbstractContext.t
 

--- a/kernel/discharge.ml
+++ b/kernel/discharge.ml
@@ -74,7 +74,7 @@ let cook_constant env info cb =
   in
   let tps = Vmbytegen.compile_constant_body ~fail_on_error:false env univs body in
   let typ = abstract_as_type cache cb.const_type in
-  let hyps = List.filter (fun d -> not (Id.Set.mem (NamedDecl.get_id d) info.names_info)) cb.const_hyps in
+  let hyps = List.filter (fun d -> not (Id.Set.mem (NamedDecl.get_id d) (names_info info))) cb.const_hyps in
   {
     const_hyps = hyps;
     const_body = body;
@@ -168,7 +168,7 @@ let cook_inductive info mib =
       PrimRecord data
   in
   let mind_hyps =
-    List.filter (fun d -> not (Id.Set.mem (NamedDecl.get_id d) info.names_info))
+    List.filter (fun d -> not (Id.Set.mem (NamedDecl.get_id d) (names_info info)))
       mib.mind_hyps
   in
   let mind_variance, mind_sec_variance =

--- a/kernel/section.ml
+++ b/kernel/section.ml
@@ -118,8 +118,7 @@ let segment_of_entry env e uctx sec =
      mind they belong to *)
   match e with
   | SecDefinition _ -> cooking_info
-  | SecInductive _ ->
-    { cooking_info with expand_info = add_emap e cooking_info.abstr_inst_info cooking_info.expand_info }
+  | SecInductive ind -> add_inductive_info ind cooking_info
 
 let push_global env ~poly e sec =
   if has_poly_univs sec && not poly
@@ -129,7 +128,7 @@ let push_global env ~poly e sec =
   else
     let cooking_info = segment_of_entry env e sec.poly_universes sec in
     let cooking_info_map = add_emap e cooking_info sec.cooking_info_map in
-    let expand_info_map = add_emap e cooking_info.abstr_inst_info sec.expand_info_map in
+    let expand_info_map = add_emap e (abstr_inst_info cooking_info) sec.expand_info_map in
     { sec with entries = e :: sec.entries; expand_info_map; cooking_info_map }
 
 let segment_of_constant con sec = Cmap.find con (fst sec.cooking_info_map)


### PR DESCRIPTION
We abstract away some types from the Cooking API. This reduces the amount of cruft exported.

I am leaving this as a draft for the time being to ensure with a bench that we don't blowup the vo size for some subtle loss-of-sharing reason.