### PR TITLE
coqdev.el: add missing require to work with Spacemacs lazy loading

### DIFF
--- a/dev/tools/coqdev.el
+++ b/dev/tools/coqdev.el
@@ -30,6 +30,7 @@
 ;; ./configure to compile Coq it is already too late).
 
 ;;; Code:
+(require 'ocamldebug)
 
 (defun coqdev-default-directory ()
   "Return the Coq repository containing `default-directory'."


### PR DESCRIPTION
Out of the box, using `coqdev-ocamldebug` according to https://github.com/coq/coq/wiki/OCamldebug I got several errors such as
```
error in process filter: Symbol’s function definition is void: ocamldebug-filter [120 times]
```

This `require` appears to fix it, possibly at some startup cost. I am not confident this
is the right fix (I'm a Coq hacker not a ELisp one).