### PR TITLE
Three fixes in printing Record/Inductive (universe instances and mutual types)

### DIFF
--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -907,6 +907,11 @@ let to_named_context =
     = fun Refl x -> x
   in
   gen unsafe_eq
+let to_rel_context =
+  let gen : type a b. (a, b) eq -> (a,a) Context.Rel.pt -> (b,b) Context.Rel.pt
+    = fun Refl x -> x
+  in
+  gen unsafe_eq
 let to_case_invert = unsafe_to_case_invert
 
 let eq = unsafe_eq

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -405,6 +405,8 @@ sig
 
   val to_named_context : (t, types) Context.Named.pt -> Constr.named_context
 
+  val to_rel_context : (t, types) Context.Rel.pt -> Constr.rel_context
+
   val to_sorts : ESorts.t -> Sorts.t
   (** Physical identity. Does not care for normalization. *)
 

--- a/engine/namegen.mli
+++ b/engine/namegen.mli
@@ -110,6 +110,7 @@ type renaming_flags =
   | RenamingForGoal (** avoid all globals (as in intro) *)
   | RenamingElsewhereFor of (Name.t list * constr)
 
+val make_all_rel_context_name_different : env -> evar_map -> rel_context -> env * rel_context
 val make_all_name_different : env -> evar_map -> env
 
 val compute_displayed_name_in :

--- a/kernel/context.ml
+++ b/kernel/context.ml
@@ -245,6 +245,14 @@ struct
       Outermost declarations are processed first. *)
   let fold_outside f l ~init = List.fold_right f l init
 
+  (** Return the set of all named variables bound in a given rel-context. *)
+  let to_vars l =
+    List.fold_left (fun accu decl ->
+        match Declaration.get_name decl with
+        | Name id -> Id.Set.add id accu
+        | Anonymous -> accu)
+      Id.Set.empty l
+
   (** Map a given rel-context to a list where each {e local assumption} is mapped to [true]
       and each {e local definition} is mapped to [false]. *)
   let to_tags l =

--- a/kernel/context.mli
+++ b/kernel/context.mli
@@ -160,6 +160,9 @@ sig
       Outermost declarations are processed first. *)
   val fold_outside : (('c, 't) Declaration.pt -> 'a -> 'a) -> ('c, 't) pt -> init:'a -> 'a
 
+  (** Return the set of all named variables bound in a given rel-context. *)
+  val to_vars : ('c, 't) pt -> Id.Set.t
+
   (** Map a given rel-context to a list where each {e local
       assumption} is mapped to [true] and each {e local definition} is
       mapped to [false]. The resulting list is in reverse order

--- a/test-suite/output/UnivBinders.out
+++ b/test-suite/output/UnivBinders.out
@@ -1,6 +1,6 @@
 Inductive Empty@{uu} : Type@{uu} :=  .
 (* uu |=  *)
-Record PWrap (A : Type@{uu}) : Type@{uu} := pwrap
+Record PWrap@{uu} (A : Type@{uu}) : Type@{uu} := pwrap
   { punwrap : A }.
 (* uu |=  *)
 
@@ -13,7 +13,7 @@ fun (A : Type@{uu}) (p : PWrap@{uu} A) => punwrap _ p
 (* uu |=  *)
 
 Arguments punwrap A%type_scope p
-Record RWrap (A : Type@{uu}) : Type@{uu} := rwrap
+Record RWrap@{uu} (A : Type@{uu}) : Type@{uu} := rwrap
   { runwrap : A }.
 (* uu |=  *)
 
@@ -86,7 +86,8 @@ Type@{u} -> Type@{v} -> Type@{uu}
 (* uu u v |=  *)
 Inductive Empty@{E} : Type@{E} :=  .
 (* E |=  *)
-Record PWrap (A : Type@{E}) : Type@{E} := pwrap { punwrap : A }.
+Record PWrap@{E} (A : Type@{E}) : Type@{E} := pwrap
+  { punwrap : A }.
 (* E |=  *)
 
 PWrap has primitive projections with eta conversion.
@@ -179,3 +180,43 @@ bind_univs.mono = Type@{bind_univs.mono.u}
 bind_univs.poly@{u} = Type@{u}
      : Type@{u+1}
 (* u |=  *)
+Inductive MutualR1@{u u0} (A : Type@{u}) : Type@{u0} :=
+    Build_MutualR1 : MutualR2@{u u0} A -> MutualR1@{u u0} A
+  with MutualR2@{u u0} (A : Type@{u}) : Type@{u0} :=
+    Build_MutualR2 : MutualR1@{u u0} A -> MutualR2@{u u0} A.
+(* u u0 |=  *)
+
+Arguments MutualR1 A%type_scope
+Arguments Build_MutualR1 A%type_scope p1
+Arguments MutualR2 A%type_scope
+Arguments Build_MutualR2 A%type_scope p2
+Inductive MutualI1@{u u0} (A : Type@{u}) : Type@{u0} :=
+    C1 : MutualI2@{u u0} A -> MutualI1@{u u0} A
+  with MutualI2@{u u0} (A : Type@{u}) : Type@{u0} :=
+    C2 : MutualI1@{u u0} A -> MutualI2@{u u0} A.
+(* u u0 |=  *)
+
+Arguments MutualI1 A%type_scope
+Arguments C1 A%type_scope p1
+Arguments MutualI2 A%type_scope
+Arguments C2 A%type_scope p2
+CoInductive MutualR1'@{u u0} (A : Type@{u}) : Type@{u0} :=
+    Build_MutualR1' : MutualR2'@{u u0} A -> MutualR1'@{u u0} A
+  with MutualR2'@{u u0} (A : Type@{u}) : Type@{u0} :=
+    Build_MutualR2' : MutualR1'@{u u0} A -> MutualR2'@{u u0} A.
+(* u u0 |=  *)
+
+Arguments MutualR1' A%type_scope
+Arguments Build_MutualR1' A%type_scope p1'
+Arguments MutualR2' A%type_scope
+Arguments Build_MutualR2' A%type_scope p2'
+CoInductive MutualI1'@{u u0} (A : Type@{u}) : Type@{u0} :=
+    C1' : MutualI2'@{u u0} A -> MutualI1'@{u u0} A
+  with MutualI2'@{u u0} (A : Type@{u}) : Type@{u0} :=
+    C2' : MutualI1'@{u u0} A -> MutualI2'@{u u0} A.
+(* u u0 |=  *)
+
+Arguments MutualI1' A%type_scope
+Arguments C1' A%type_scope p1
+Arguments MutualI2' A%type_scope
+Arguments C2' A%type_scope p2

--- a/test-suite/output/UnivBinders.v
+++ b/test-suite/output/UnivBinders.v
@@ -176,3 +176,23 @@ End NoAutoNames.
 Require TestSuite.bind_univs.
 Print bind_univs.mono.
 Print bind_univs.poly.
+
+Module MutualTypes.
+
+Inductive MutualR1 (A:Type) := { p1 : MutualR2 A }
+with MutualR2 (A:Type) := { p2 : MutualR1 A }.
+Print MutualR1.
+
+Inductive MutualI1 (A:Type) := C1 (p1 : MutualI2 A)
+with MutualI2 (A:Type) := C2 (p2 : MutualI1 A).
+Print MutualI1.
+
+CoInductive MutualR1' (A:Type) := { p1' : MutualR2' A }
+with MutualR2' (A:Type) := { p2' : MutualR1' A }.
+Print MutualR1'.
+
+CoInductive MutualI1' (A:Type) := C1' (p1 : MutualI2' A)
+with MutualI2' (A:Type) := C2' (p2 : MutualI1' A).
+Print MutualI2'.
+
+End MutualTypes.


### PR DESCRIPTION
**Kind:** fix

We fix three issues about printing `Record`/`Inductive`:
- Don't fail with anomaly when printing mutual records
  (anomaly was introduced in commit 16b12ef520d873262c44e738f2568305a8c53c6d of #15484 and it was not a correct fix to the buggy output of a mutual record)
- Print universe instances on the name of the type also for `Record` (like it was for `Inductive`)
  (however there is still the issue that printing produces an expression which is not reparsable: `@{...}` is not supported at interpretation time on the second and further types of a block, nor in the recursive occurrences of the type)
- Ensure that distinct variables are printed with distinct names (even for inductive types generated by tools such as elpi).

- [x] Added / updated **test-suite**.