### PR TITLE
Restore typing check in notation.eval_constr

### DIFF
--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -613,6 +613,7 @@ module PrimTokenNotation = struct
 
 let eval_constr env sigma (c : Constr.t) =
   let c = EConstr.of_constr c in
+  let sigma, _ = Typing.type_of env sigma c in
   let c' = Tacred.compute env sigma c in
   EConstr.Unsafe.to_constr c'
 

--- a/test-suite/output/NumberNotations.out
+++ b/test-suite/output/NumberNotations.out
@@ -419,7 +419,15 @@ Ip3 (S (S (S O))) nat bool
 eq_refl
      : 1 = 1
 0
+     : 0 = 0
+eq_refl
+     : id 0 = id 0
+eq_refl
      : 1 = 1
+0
+     : 0 = 0
+eq_refl
+     : id 0 = id 0
 2
      : extra_list_unit
 cons O unit tt (cons O unit tt (nil O unit))
@@ -462,7 +470,7 @@ where
      : Fin.t 3
 2 : Fin.t 3
      : Fin.t 3
-File "./output/NumberNotations.v", line 914, characters 11-42:
+File "./output/NumberNotations.v", line 918, characters 11-42:
 The command has indeed failed with message:
 The term "3" has type "Fin.t (S (S (S (S ?n))))"
 while it is expected to have type "Fin.t 3".
@@ -488,7 +496,7 @@ where
      : Fin.t (S (S (S O)))
 @Fin.FS (S (S O)) (@Fin.FS (S O) (@Fin.F1 O)) : Fin.t (S (S (S O)))
      : Fin.t (S (S (S O)))
-File "./output/NumberNotations.v", line 923, characters 11-12:
+File "./output/NumberNotations.v", line 927, characters 11-12:
 The command has indeed failed with message:
 The term
  "@Fin.FS (S (S (S ?n))) (@Fin.FS (S (S ?n)) (@Fin.FS (S ?n) (@Fin.F1 ?n)))"
@@ -516,7 +524,7 @@ where
      : Fin.t 3
 2 : Fin.t 3
      : Fin.t 3
-File "./output/NumberNotations.v", line 968, characters 11-42:
+File "./output/NumberNotations.v", line 972, characters 11-42:
 The command has indeed failed with message:
 The term "3" has type "Fin.t (S (S (S (S ?n))))"
 while it is expected to have type "Fin.t 3".
@@ -542,7 +550,7 @@ where
      : Fin.t (S (S (S O)))
 @Fin.FS (S (S O)) (@Fin.FS (S O) (@Fin.F1 O)) : Fin.t (S (S (S O)))
      : Fin.t (S (S (S O)))
-File "./output/NumberNotations.v", line 977, characters 11-12:
+File "./output/NumberNotations.v", line 981, characters 11-12:
 The command has indeed failed with message:
 The term
  "@Fin.FS (S (S (S ?n))) (@Fin.FS (S (S ?n)) (@Fin.FS (S ?n) (@Fin.F1 ?n)))"

--- a/test-suite/output/NumberNotations.v
+++ b/test-suite/output/NumberNotations.v
@@ -782,11 +782,15 @@ Number Notation eqO eqO_of_uint eqO_to_uint : nat_scope.
 
 Check 42.
 Check eq_refl (S O).  (* doesn't match eq _ O, printer not called *)
+Check eq_refl O. (* matches eq _ O, printer called *)
+Check eq_refl (id O). (* doesn't match eq _ O, printer not called *)
 
 Notation eq_ := (eq _ _) (only parsing).
 Number Notation eq_ eqO_of_uint eqO_to_uint : nat_scope.
 
-Check eq_refl (S O).  (* matches eq _ _, printer called *)
+Check eq_refl (S O).  (* matches eq _ _, printer called, but type incorrect *)
+Check eq_refl O. (* matches eq _ _, printer called *)
+Check eq_refl (id O). (* matches eq _ _, but contains a global constant, printer not called *)
 
 Inductive extra_list : Type -> Type :=
 | nil (n : nat) (v : Type) : extra_list v

--- a/test-suite/output/bug_15709.out
+++ b/test-suite/output/bug_15709.out
@@ -1,0 +1,2 @@
+String "]"
+     : string -> string

--- a/test-suite/output/bug_15709.v
+++ b/test-suite/output/bug_15709.v
@@ -1,0 +1,4 @@
+Require Import Coq.Strings.String.
+Require Import Coq.Strings.Ascii.
+
+Check String "]".


### PR DESCRIPTION
The check was lost in b0f8e09c3212fa96934817e7ca99465cd634f57c (8.10)

Fix #15709
