### PR TITLE
Make processed part of script read only when Coq is busy

### DIFF
--- a/doc/changelog/09-coqide/15714-lost_keystrokes.rst
+++ b/doc/changelog/09-coqide/15714-lost_keystrokes.rst
@@ -1,0 +1,9 @@
+- **Fixed:**
+  Attempted edits to the processed part of a buffer while
+  Coq is busy processing a request are now ignored to
+  ensure "processed" highlighting is accurate
+  (`#15714 <https://github.com/coq/coq/pull/15714>`_,
+  fixes `#15733 <https://github.com/coq/coq/issues/15733>`_
+  and `#15675 <https://github.com/coq/coq/issues/15675>`_
+  and `#15725 <https://github.com/coq/coq/issues/15725>`_,
+  by Jim Fehrle).

--- a/ide/coqide/session.ml
+++ b/ide/coqide/session.ml
@@ -174,11 +174,11 @@ let set_buffer_handlers
     if misc () then Minilib.log ("insert_cb " ^ string_of_int it#offset);
     let text_mark = add_mark it in
     let () = update_prev it in
-    if it#has_tag Tags.Script.to_process then
-      cancel_signal "Altering the script being processed is not implemented"
-    else if it#has_tag Tags.Script.incomplete then
+    if it#has_tag Tags.Script.to_process ||
+       it#has_tag Tags.Script.incomplete then
       cancel_signal "Altering the script being processed is not implemented"
     else if it#has_tag Tags.Script.processed then
+      (* note code in Wg_scriptview.keypress_cb *)
       call_coq_or_cancel_action (coqops#go_to_mark (`MARK text_mark))
     else if it#has_tag Tags.Script.error_bg then begin
       match processed_sentence_just_before_error it with
@@ -195,10 +195,9 @@ let set_buffer_handlers
     let text_mark = add_mark min_iter in
     let rec aux min_iter =
       if min_iter#equal max_iter then ()
-      else if min_iter#has_tag Tags.Script.incomplete then
-        cancel_signal "Altering the script being processed in not implemented"
-      else if min_iter#has_tag Tags.Script.to_process then
-        cancel_signal "Altering the script being processed in not implemented"
+      else if min_iter#has_tag Tags.Script.to_process ||
+              min_iter#has_tag Tags.Script.incomplete then
+        cancel_signal "Altering the script being processed is not implemented"
       else if min_iter#has_tag Tags.Script.processed then
         call_coq_or_cancel_action (coqops#go_to_mark (`MARK text_mark))
       else if min_iter#has_tag Tags.Script.error_bg then
@@ -410,7 +409,7 @@ let create file coqtop_args =
   let reset () = Coq.reset_coqtop coqtop in
   let buffer = create_buffer () in
   let script = create_script coqtop buffer in
-  Coq.setup_script_editable coqtop (fun v -> script#set_editable v;script#set_editable2 v);
+  Coq.setup_script_editable coqtop (fun v -> script#set_editable2 v);
   let proof = create_proof () in
   incr next_sid;
   let sid = !next_sid in


### PR DESCRIPTION
In CoqIDE, prevents modifying _processed_ (green) parts of the script while Coq is busy (i.e. processing an XML request), which is important for the debugger.  Unlike the earlier code, it lets the user modify unmarked parts of the script (white/default background), which should address the main issue in #15675.  Note that code marked _to_process_ or _incomplete_ was already uneditable.

Includes some cleanup in `session.ml`.

@Alizter / @MSoegtropIMC  Perhaps you could try this in the next couple days?

I'd appreciate a prompt review so this can make it into 8.15.1.

Fixes: #15733
Fixes: #15675
Fixes: #15725