### PR TITLE
[micromega] Fix pre-processing

### DIFF
--- a/dev/ci/user-overlays/15721-fajb-micromega-interval-analysis.sh
+++ b/dev/ci/user-overlays/15721-fajb-micromega-interval-analysis.sh
@@ -1,0 +1,1 @@
+overlay bedrock2 https://github.com/fajb/bedrock2 pr15711 15721

--- a/plugins/micromega/certificate.ml
+++ b/plugins/micromega/certificate.ml
@@ -375,7 +375,7 @@ let saturate_by_linear_equalities sys =
   tr_sys "saturate_by_linear_equalities" saturate_by_linear_equalities sys
 
 let bound_monomials (sys : WithProof.t list) =
-  let l =
+  let (bounds,_) =
     extract_all
       (fun p ->
         match BoundWithProof.make p with
@@ -407,13 +407,13 @@ let bound_monomials (sys : WithProof.t list) =
           match BoundWithProof.mul_bound w1 w2 with
           | None -> None
           | Some b -> Some (i1 + i2, b))
-      (fst l)
+      bounds
   in
   let has_mon (_, b) =
     let Vect.Bound.{cst; var; coeff} = BoundWithProof.bound b in
     if ISet.mem var vars then Some (BoundWithProof.proof b) else None
   in
-  CList.map_filter has_mon bounds @ snd l
+  CList.map_filter has_mon bounds
 
 let bound_monomials = tr_sys "bound_monomials" bound_monomials
 
@@ -915,14 +915,13 @@ let rev_concat l =
 let pre_process sys =
   let sys = normalise sys in
   let bnd1 = bound_monomials sys in
-  let sys1 = normalise (subst sys) in
+  let sys1 = normalise (subst (List.rev_append sys bnd1)) in
   let pbnd1 = fourier_small sys1 in
   let sys2 = elim_redundant (List.rev_append pbnd1 sys1) in
   let bnd2 = bound_monomials sys2 in
-  let pbnd2 = [] (*fourier_small sys2*) in
   (* Should iterate ? *)
   let sys =
-    rev_concat [pbnd2; bnd1; bnd2; saturate_by_linear_equalities sys2; sys2]
+    rev_concat [bnd2; saturate_by_linear_equalities sys2; sys2]
   in
   sys
 

--- a/test-suite/micromega/bug_15583.v
+++ b/test-suite/micromega/bug_15583.v
@@ -1,0 +1,37 @@
+Require Import ZArith Lia.
+Open Scope Z_scope.
+
+Unset Lia Cache.
+
+Require Import Coq.ZArith.ZArith. Open Scope Z_scope.
+Require Import Coq.micromega.Lia.
+
+Goal forall
+    (w0  w1  w2  q0  q : Z)
+    (H10 : 0 < w2)
+    (q1  q2  r3  q3 : Z)
+    (H8 : 0 <= w0)
+    (H21 : w1 + - 2 ^ 32 * q2 - 2 ^ 32 * q < 2 ^ 32)
+    (H15 : 0 <= w2 * q0 + 0)
+    (H4 : w0 - w1 = 2 ^ 32 * q1 + (w2 * q0 + 0))
+    (H19 : w2 = 2 ^ 32 * q3 + r3)
+    (Hc : w1 + - 2 ^ 32 * q2 - 2 ^ 32 * q > w0)
+    (H : q0 <= 0) ,
+  False.
+Proof.
+  intros.
+  lia.
+Qed.
+
+Goal forall (T : Type) (f : T -> nat) (vs1 : T) (w0 w1 w2 : Z),
+    f vs1 = Z.to_nat ((w0 - w1) mod 2 ^ 32 / w2) ->
+    ((w0 - w1) mod 2 ^ 32) mod w2 = 0 ->
+    0 <= w0 < 2 ^ 32 ->
+    0 <= w1 < 2 ^ 32 ->
+    0 <= w2 < 2 ^ 32 ->
+    (w1 + (w2 mod 2 ^ 32 * Z.of_nat (f vs1)) mod 2 ^ 32) mod 2 ^ 32 = w0.
+Proof.
+  intros.
+  Z.div_mod_to_equations.
+  lia.
+Qed.


### PR DESCRIPTION
The bound_monomial was supposed to return an augmented system but was
forgetting the existing bounds.  Now, bound_monomial only generates
new bounds and the pre-processing is updated accordingly.

Fixes #15583



<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

