### PR TITLE
coqide depends on coq-core

### DIFF
--- a/coqide.opam
+++ b/coqide.opam
@@ -18,6 +18,7 @@ doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
   "dune" {>= "2.5"}
+  "coq-core" {= version}
   "coqide-server" {= version}
 ]
 build: [


### PR DESCRIPTION
This fixes installation via the opam file.

coqide now relies on coq-core.boot which was changed in https://github.com/coq/coq/pull/15645 however I neglected to change the opam file.