### PR TITLE
assert_succeeds preserves the underlying error

### DIFF
--- a/doc/changelog/04-tactics/15728-assert-succeeds-message.rst
+++ b/doc/changelog/04-tactics/15728-assert-succeeds-message.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  When it fails, :tacn:`assert_succeeds` fails with the argument tactic's original error instead of ``Tactic failure: <tactic closure> fails.``
+  (`#15728 <https://github.com/coq/coq/pull/15728>`_,
+  fixes `#10970 <https://github.com/coq/coq/issues/10970>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/proof-engine/ltac.rst
+++ b/doc/sphinx/proof-engine/ltac.rst
@@ -828,11 +828,7 @@ success:
 .. tacn:: assert_succeeds @ltac_expr3
 
    If :n:`@ltac_expr3` has at least one success, the proof state is unchanged and
-   no message is printed.  If :n:`@ltac_expr3` fails, the tactic performs
-   a :tacn:`gfail` :n:`0`, printing the following message:
-
-   .. exn:: Tactic failure: <tactic closure> fails.
-      :undocumented:
+   no message is printed.  If :n:`@ltac_expr3` fails, the tactic fails with the same error.
 
 Checking for failure: assert_fails
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1556,6 +1556,7 @@ simple_tactic: [
 | "clear" "-" LIST1 hyp
 | "clearbody" LIST1 hyp
 | "generalize" "dependent" constr
+| "assert_succeeds" tactic3
 | "replace" uconstr "with" constr clause by_arg_tac
 | "replace" "->" uconstr clause
 | "replace" "<-" uconstr clause

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -30,6 +30,11 @@ open Vernacextend
 
 DECLARE PLUGIN "coq-core.plugins.ltac"
 
+TACTIC EXTEND assert_succeeds
+| [ "assert_succeeds" tactic3(tac) ]
+  -> { Internals.assert_succeeds (Tacinterp.tactic_of_value ist tac) }
+END
+
 TACTIC EXTEND replace
 | ["replace" uconstr(c1) "with" constr(c2) clause(cl) by_arg_tac(tac) ]
 -> { Internals.replace_in_clause_maybe_by ist c1 c2 cl tac }

--- a/plugins/ltac/internals.ml
+++ b/plugins/ltac/internals.ml
@@ -21,6 +21,13 @@ open Tactypes
 open Tactics
 open Proofview.Notations
 
+let assert_succeeds tac =
+  let open Proofview in
+  let exception Succeeded in
+  tclORELSE (tclONCE tac <*> tclZERO Succeeded) (function
+      | Succeeded, _ -> tclUNIT ()
+      | exn, info -> tclZERO ~info exn)
+
 let mytclWithHoles tac with_evars c =
   Proofview.Goal.enter begin fun gl ->
     let env = Tacmach.pf_env gl in

--- a/plugins/ltac/internals.mli
+++ b/plugins/ltac/internals.mli
@@ -18,6 +18,8 @@ open Ltac_pretype
 
 (** {5 Tactics} *)
 
+val assert_succeeds : unit Proofview.tactic -> unit Proofview.tactic
+
 val mytclWithHoles : (Tactics.evars_flag ->
   EConstr.constr Tactypes.with_bindings Tactics.destruction_arg option ->
     unit Proofview.tactic) ->

--- a/test-suite/output/Tactics.out
+++ b/test-suite/output/Tactics.out
@@ -9,7 +9,10 @@ File "./output/Tactics.v", line 23, characters 20-26:
 The command has indeed failed with message:
 H is already used.
 a
-File "./output/Tactics.v", line 37, characters 16-17:
+File "./output/Tactics.v", line 36, characters 29-34:
+The command has indeed failed with message:
+The term "False" has type "Prop" while it is expected to have type "True".
+File "./output/Tactics.v", line 42, characters 16-17:
 The command has indeed failed with message:
 This variable is used in hypothesis H.
 Ltac test a b c d e := apply a, b in c as [], d, e as ->

--- a/test-suite/output/Tactics.v
+++ b/test-suite/output/Tactics.v
@@ -31,6 +31,11 @@ Goal True.
   assert_succeeds (idtac "a" + idtac "b"). (* should only output "a" *)
 Abort.
 
+(* assert_succeeds preserves the error *)
+Goal True.
+  Fail assert_succeeds exact False.
+Abort.
+
 Module IntroWildcard.
 
 Theorem foo : { p:nat*nat & p = (0,0) } -> True.

--- a/theories/Init/Tactics.v
+++ b/theories/Init/Tactics.v
@@ -340,10 +340,6 @@ Ltac time_constr tac :=
 
 Ltac assert_fails tac :=
   tryif (once tac) then gfail 0 tac "succeeds" else idtac.
-Ltac assert_succeeds tac :=
-  tryif (assert_fails tac) then gfail 0 tac "fails" else idtac.
-Tactic Notation "assert_succeeds" tactic3(tac) :=
-  assert_succeeds tac.
 Tactic Notation "assert_fails" tactic3(tac) :=
   assert_fails tac.
 


### PR DESCRIPTION
Fix #10970 

