### PR TITLE
[vernac] Fix cache invalidation as not to mess with non-imperative state

### DIFF
--- a/test-suite/ide/bug14981.fake
+++ b/test-suite/ide/bug14981.fake
@@ -1,0 +1,6 @@
+# -*- coq-prog-args: ("-async-proofs-command-error-resilience" "on"); -*-
+
+ADD { Section Foo. }
+ADD { Definition bar := Bar. }
+ADD { End Foo. }
+FAILJOIN

--- a/vernac/vernacstate.ml
+++ b/vernac/vernacstate.ml
@@ -103,9 +103,7 @@ let s_lemmas = ref None
 let s_program = ref (NeList.singleton Declare.OblState.empty)
 
 let invalidate_cache () =
-  s_cache := None;
-  s_lemmas := None;
-  s_program := NeList.singleton Declare.OblState.empty
+  s_cache := None
 
 let update_cache rf v =
   rf := Some v; v


### PR DESCRIPTION
For some reason we had totally bugged code here it seems.

Thanks to Gaëtan Gilbert for finding the issue in #15594 , which this
PR supersedes.

Fixes #14981