### PR TITLE
At breakpoints, format goals the same way as CoqIDE usually does; redisplay the goal when the user changes display options

### DIFF
--- a/dev/doc/xml-protocol.md
+++ b/dev/doc/xml-protocol.md
@@ -241,7 +241,16 @@ proofs.
 <call val="Goal"><unit/></call>
 ```
 #### *Returns*
-* If there is a goal. `shelvedGoals` and `abandonedGoals` have the same structure as the first set of (current/foreground) goals. `backgroundGoals` contains a list of pairs of lists of goals (list ((list Goal)*(list Goal))); it represents a "focus stack" ([see code for reference](https://github.com/coq/coq/blob/trunk/engine/proofview.ml#L113)). Each time a proof is focused, it will add a new pair of lists-of-goals. The first pair is the most nested set of background goals, the last pair is the top level set of background goals. The first list in the pair is in reverse order. Each time you focus the goal (e.g. using `Focus` or a bullet), a new pair will be prefixed to the list.
+* If there is a goal, `shelvedGoals` and `abandonedGoals` have the same structure
+  as the first set of (current/foreground) goals. `backgroundGoals` contains a
+  list of pairs of lists of goals (list ((list Goal)*(list Goal))); it represents
+  a "focus stack"
+  ([see code for reference](https://github.com/coq/coq/blob/trunk/engine/proofview.ml#L113)).
+  Each time a proof is focused, it will add a new pair of lists-of-goals. The
+  first pair is the most nested set of background goals, the last pair is the
+  top level set of background goals. The first list in the pair is in reverse
+  order. Each time you focus the goal (e.g. using `Focus` or a bullet), a new
+  pair will be prefixed to the list.
 ```html
 <value val="good">
   <option val="some">
@@ -329,6 +338,28 @@ many there are.
 * The same as [Goal](#command-goal).
 
 -------------------------------
+
+### <a name="command-subgoals">**Subgoals()**</a>
+Returns filtered information on goals.  Passing "short" omits hypotheses
+in the returned goals.  The boolean values control whether various types of goals are
+included in the return value.
+
+```html
+<call val="Subgoals">
+  <goal_flags>
+    <string>full</string>  <!-- "full" or "short" -->
+    <bool val="true"/>     <!-- foreground goals -->
+    <bool val="true"/>     <!-- background goals -->
+    <bool val="false"/>    <!-- shelved goals -->
+    <bool val="false"/>    <!-- given_up goals -->
+  </goal_flags>
+</call>
+```
+#### *Returns*
+The reply format is the same as for the Goal message.
+
+-------------------------------
+
 
 ### <a name="command-status">**Status(force: bool)**</a>
 Returns information about the current proofs. CoqIDE typically sends this
@@ -948,8 +979,6 @@ The response contains an identifying tag and a `<ppdoc>`.
 Currently these tags are used:
 
 * **output** - ordinary output for display in the Messages panel
-* **goal** - the current goal for the debugger, for display in the Messages panel
-  or elsewhere
 * **prompt** - output for display in the Messages panel prompting the user to
   enter a debug command, allowing CoqIDE to display it without
   appending a newline.  It also signals that coqidetop is waiting to receive

--- a/doc/changelog/10-coqide/15737-better_goal_display2.rst
+++ b/doc/changelog/10-coqide/15737-better_goal_display2.rst
@@ -1,0 +1,8 @@
+- **Changed:**
+  When stopped in the debugger, display goals in the same format used when
+  CoqIDE is not in the debugger.  Redisplay goals in the debugger when the
+  user changes display options from the menu.
+  (`#15737 <https://github.com/coq/coq/pull/15737>`_,
+  fixes `#15345 <https://github.com/coq/coq/issues/15345>`_
+  and `#15315 <https://github.com/coq/coq/issues/15315>`_,
+  by Jim Fehrle).

--- a/ide/coqide/coq.ml
+++ b/ide/coqide/coq.ml
@@ -581,7 +581,7 @@ type 'a query = 'a Interface.value task
 let eval_call ?(db=false) call handle k =
   (* Send messages to coqtop and prepare the decoding of the answer *)
   let in_db = if db then "db " else "" in
-  Minilib.log ("Start " ^ in_db ^ "eval_call " ^ Xmlprotocol.pr_call call);
+  Minilib.log ("Start " ^ in_db ^ "eval_call " ^ Xmlprotocol.pr_call call ^ "\n");
   if db then begin
     assert (handle.alive && handle.db_waiting_for = None);
     handle.db_waiting_for <- Some (mk_ccb (call,k))
@@ -590,7 +590,7 @@ let eval_call ?(db=false) call handle k =
     handle.waiting_for <- Some (mk_ccb (call,k))
   end;
   Xml_printer.print handle.xml_oc (Xmlprotocol.of_call call);
-  Minilib.log ("End " ^ in_db ^ "eval_call");
+  Minilib.log ("Sent " ^ in_db ^ "eval_call");
   Void
 
 let add x = eval_call (Xmlprotocol.add x)
@@ -713,7 +713,7 @@ struct
     let opts = List.sort (fun a b ->
           String.compare (String.concat " " (fst a)) (String.concat " " (fst b)))
         (Hashtbl.fold mkopt current_state []) in
-    eval_call (Xmlprotocol.set_options opts) h
+    eval_call ~db:true (Xmlprotocol.set_options opts) h
       (function
         | Interface.Good () -> k ()
         | _ -> failwith "Cannot set options. Resetting coqtop")
@@ -723,8 +723,8 @@ end
 let goals x h k =
   PrintOpt.enforce h (fun () -> eval_call (Xmlprotocol.goals x) h k)
 
-let subgoals x h k =
-  PrintOpt.enforce h (fun () -> eval_call (Xmlprotocol.subgoals x) h k)
+let subgoals ?(db=false) x h k =
+  PrintOpt.enforce h (fun () -> eval_call ~db (Xmlprotocol.subgoals x) h k)
 
 let evars x h k =
   PrintOpt.enforce h (fun () -> eval_call (Xmlprotocol.evars x) h k)

--- a/ide/coqide/coq.mli
+++ b/ide/coqide/coq.mli
@@ -153,7 +153,7 @@ val edit_at    : Interface.edit_at_sty    -> Interface.edit_at_rty query
 val query      : Interface.query_sty      -> Interface.query_rty query
 val status     : Interface.status_sty     -> Interface.status_rty query
 val goals      : Interface.goals_sty      -> Interface.goals_rty query
-val subgoals   : Interface.subgoals_sty   -> Interface.subgoals_rty query
+val subgoals   : ?db:bool -> Interface.subgoals_sty   -> Interface.subgoals_rty query
 val evars      : Interface.evars_sty      -> Interface.evars_rty query
 val hints      : Interface.hints_sty      -> Interface.hints_rty query
 val mkcases    : Interface.mkcases_sty    -> Interface.mkcases_rty query

--- a/ide/coqide/coqOps.ml
+++ b/ide/coqide/coqOps.ml
@@ -11,6 +11,7 @@
 open Util
 open Coq
 open Interface
+open DebuggerTypes
 open Feedback
 
 type flag = [ `INCOMPLETE | `UNSAFE | `PROCESSING | `ERROR of string Loc.located | `WARNING of string Loc.located ]

--- a/ide/coqide/coqOps.ml
+++ b/ide/coqide/coqOps.ml
@@ -211,7 +211,7 @@ object
   method raw_coq_query :
     route_id:int -> next:(query_rty value -> unit task) -> string -> unit task
   method proof_diff : GText.mark -> next:(Pp.t value -> unit task) -> unit task
-  method show_goals : unit task
+  method show_goals : bool -> unit task
   method backtrack_last_phrase : unit task
   method initialize : unit task
   method join_document : unit task
@@ -226,9 +226,8 @@ object
   method destroy : unit -> unit
   method scroll_to_start_of_input : unit -> unit
   method set_forward_clear_db_highlight : (unit -> unit) -> unit
-  method set_forward_set_goals_of_dbg_session : (Pp.t -> unit) -> unit
+  method set_forward_get_other_proof : (unit -> Wg_ProofView.proof_view) -> unit
   method set_forward_init_db : (unit -> unit) -> unit
-  method set_debug_goal : Pp.t -> unit
 end
 
 let flags_to_color f =
@@ -328,8 +327,8 @@ object(self)
   val mutable forward_clear_db_highlight = ((fun x -> failwith "forward_clear_db_highlight")
                   : unit -> unit)
 
-  val mutable forward_set_goals_of_dbg_session = ((fun x -> failwith "forward_set_goals_of_dbg_session")
-                  : Pp.t -> unit)
+  val mutable forward_get_other_proof = ((fun x -> failwith "forward_get_other_proof")
+                  : unit -> Wg_ProofView.proof_view)
 
   val mutable forward_init_db = ((fun x -> failwith "forward_init_db")
                   : unit -> unit)
@@ -394,8 +393,8 @@ object(self)
   method set_forward_clear_db_highlight f =
     forward_clear_db_highlight <- f
 
-  method set_forward_set_goals_of_dbg_session f =
-    forward_set_goals_of_dbg_session <- f
+  method set_forward_get_other_proof f =
+    forward_get_other_proof <- f
 
   method set_forward_init_db f =
     forward_init_db <- f
@@ -433,7 +432,7 @@ object(self)
   method private get_insert =
     buffer#get_iter_at_mark `INSERT
 
-  method private show_goals_aux ?(move_insert=false) () =
+  method private show_goals_aux ?(move_insert=false) db =
     if move_insert then begin
       let dest = self#get_start_of_input in
       if (buffer#get_iter_at_mark `INSERT)#compare dest <= 0 then begin
@@ -448,14 +447,14 @@ object(self)
     | Good v -> f v)
     in
     let call =
-      Coq.subgoals flags >>= begin function
+      Coq.subgoals ~db flags >>= begin function
       | None -> return Wg_ProofView.NoGoals
       | Some { fg_goals = ((_ :: _) as fg); bg_goals = bg } ->
         let bg = flatten (List.rev bg) in
         return (Wg_ProofView.FocusGoals { fg; bg; })
       | Some { fg_goals = []; bg_goals = bg } ->
         let flags = { gf_mode = "short"; gf_fg = false; gf_bg = false; gf_shelved = true; gf_given_up = true } in
-        Coq.subgoals flags >>= fun rem ->
+        Coq.subgoals ~db flags >>= fun rem ->
         let bg = flatten (List.rev bg) in
         let shelved, given_up = match rem with
         | None -> [], []
@@ -469,10 +468,13 @@ object(self)
     | Good goals ->
       proof#set_goals goals;
       proof#refresh ~force:true;
+      let op = forward_get_other_proof () in
+      op#set_goals goals;
+      op#refresh ~force:true;
       Coq.return ()
     end
 
-  method show_goals = self#show_goals_aux ()
+  method show_goals db = self#show_goals_aux db
 
   (* This method is intended to perform stateless commands *)
   method raw_coq_query ~route_id ~next phrase : unit Coq.task =
@@ -547,14 +549,9 @@ object(self)
     match tag with
     | "prompt" ->
       messages#default_route#debug_prompt msg
-    | "goal" ->
-      forward_set_goals_of_dbg_session msg
     | "init" -> forward_init_db ()
     | _ ->
       messages#default_route#push Debug msg
-
-  method set_debug_goal msg =
-    proof#set_debug_goal msg
 
   method private process_feedback msg =
     (* Minilib.log ("Feedback received: " ^ Xml_printer.to_string_fmt Xmlprotocol.(of_feedback Ppcmds msg)); *)
@@ -690,9 +687,9 @@ object(self)
       buffer#place_cursor ~where:stop;
       messages#default_route#clear;
       messages#default_route#push Feedback.Error msg;
-      self#show_goals
+      self#show_goals false
     end else
-      self#show_goals_aux ~move_insert:true ()
+      self#show_goals_aux ~move_insert:true false
     )
 
   (** [fill_command_queue until q] fills a command queue until the [until]
@@ -759,7 +756,7 @@ object(self)
       Ideutils.pop_info ();
       script#recenter_insert;
       match topstack with
-      | [] -> self#show_goals_aux ?move_insert ()
+      | [] -> self#show_goals_aux ?move_insert false
       | (_,s)::_ -> self#backtrack_to_iter (buffer#get_iter_at_mark s.start) in
     let process_queue queue =
       let rec loop tip topstack =
@@ -922,7 +919,7 @@ object(self)
       buffer#remove_tag Tags.Script.incomplete ~start ~stop;
       buffer#remove_tag Tags.Script.to_process ~start ~stop;
       buffer#remove_tag Tags.Script.unjustified ~start ~stop;
-      self#show_goals in
+      self#show_goals false in
     Coq.bind (Coq.lift opening) (fun () ->
     let rec undo to_id unfocus_needed =
       Coq.bind (Coq.edit_at to_id) (function
@@ -939,7 +936,7 @@ object(self)
       | Fail (safe_id, loc, msg) ->
 (*           if loc <> None then messages#push Feedback.Error (Richpp.richpp_of_string "Fixme LOC"); *)
           messages#default_route#push Feedback.Error msg;
-          if Stateid.equal safe_id Stateid.dummy then self#show_goals
+          if Stateid.equal safe_id Stateid.dummy then self#show_goals false
           else undo safe_id
                  (Doc.focused document && Doc.is_in_focus document safe_id))
     in

--- a/ide/coqide/coqOps.mli
+++ b/ide/coqide/coqOps.mli
@@ -33,7 +33,7 @@ object
   method raw_coq_query :
     route_id:int -> next:(query_rty value -> unit task) -> string -> unit task
   method proof_diff : GText.mark -> next:(Pp.t value -> unit task) -> unit task
-  method show_goals : unit task
+  method show_goals : bool -> unit task
   method backtrack_last_phrase : unit task
   method initialize : unit task
   method join_document : unit task
@@ -48,9 +48,8 @@ object
   method destroy : unit -> unit
   method scroll_to_start_of_input : unit -> unit
   method set_forward_clear_db_highlight : (unit -> unit) -> unit
-  method set_forward_set_goals_of_dbg_session : (Pp.t -> unit) -> unit
+  method set_forward_get_other_proof : (unit -> Wg_ProofView.proof_view) -> unit
   method set_forward_init_db : (unit -> unit) -> unit
-  method set_debug_goal : Pp.t -> unit
 end
 
 class coqops :

--- a/ide/coqide/coqide.ml
+++ b/ide/coqide/coqide.ml
@@ -171,7 +171,7 @@ let db_cmd sn cmd =
       (sn.coqops#process_db_cmd cmd ~next:(function | _ -> Coq.return ()))
       (fun () -> Minilib.log "Coq busy, discarding db_cmd")
 
-let forward_db_goals_n_stack = ref ((fun _ -> failwith "forward_db_goals_n_stack")
+let forward_db_stack_n_goals = ref ((fun _ -> failwith "forward_db_stack_n_goals")
                      : session -> unit -> unit)
 let forward_db_vars = ref ((fun _ -> failwith "forward_db_vars")
                      : session -> int -> unit)
@@ -190,18 +190,12 @@ let create_session f =
   sn.debugger#set_forward_get_basename (fun _ -> sn.basename);
   Coq.set_restore_bpts sn.coqtop (fun _ -> !forward_restore_bpts sn);
   (sn.messages#route 0)#set_forward_send_db_cmd (db_cmd sn);
-  (sn.messages#route 0)#set_forward_db_goals_n_stack (!forward_db_goals_n_stack sn);
+  (sn.messages#route 0)#set_forward_db_stack_n_goals (!forward_db_stack_n_goals sn);
   sn.debugger#set_forward_highlight_code (!forward_highlight_code sn);
   sn.debugger#set_forward_clear_db_highlight (clear_db_highlight sn);
   sn.debugger#set_forward_db_vars (!forward_db_vars sn);
   sn.coqops#set_forward_clear_db_highlight (clear_db_highlight ~retn:true sn);
-  sn.coqops#set_forward_set_goals_of_dbg_session
-    (fun msg ->
-      sn.coqops#set_debug_goal msg;
-      sn.last_db_goals <- msg;
-      let osn = (find_secondary_sn sn) in
-      osn.coqops#set_debug_goal msg;
-      osn.last_db_goals <- msg);
+  sn.coqops#set_forward_get_other_proof (fun () -> (find_secondary_sn sn).proof);
   sn.coqops#set_forward_init_db (fun () -> !forward_init_db sn);
   let _ = set_drag sn.script#drag in
   sn
@@ -886,9 +880,16 @@ let _ = Wg_MessageView.forward_keystroke := forward_keystroke
 let _ = Wg_Debugger.forward_keystroke := forward_keystroke
 
 let printopts_callback opts v =
-  let b = v#get_active in
-  let () = List.iter (fun o -> Coq.PrintOpt.set o b) opts in
-  send_to_coq "show_goals" (fun sn -> sn.coqops#show_goals)
+  if notebook#pages = [] then ()
+  else begin
+    let sn = find_db_sn () in
+    let b = v#get_active in
+    let () = List.iter (fun o -> Coq.PrintOpt.set o b) opts in
+    Coq.add_do_when_ready sn.coqtop (fun _ ->
+      ignore @@ Coq.try_grab ~db:true sn.coqtop (sn.coqops#show_goals true)
+        (fun () -> Minilib.log "Coq busy, discarding show_goals")
+    )
+  end
 
 (** Templates menu *)
 
@@ -1040,8 +1041,6 @@ let highlight_code sn loc =
     clear_db_highlight sn ();
     notebook#current_term.script#set_debugging_highlight bp ep;
     sn.debug_stop_pt <- Some (notebook#current_term, bp, ep);
-    (* also show goal in secondary script goal panel *)
-    notebook#current_term.coqops#set_debug_goal sn.last_db_goals
   in
   if file = "ToplevelInput" then begin
     notebook#goto_term sn;
@@ -1062,7 +1061,8 @@ let highlight_code sn loc =
 
 let _ = forward_highlight_code := highlight_code
 
-let db_goals_n_stack sn _ =
+let db_stack_n_goals sn _ =
+  (* get stack first so goals can be shown in the right buffer *)
   Coq.add_do_when_ready sn.coqtop (fun _ ->
     ignore @@ Coq.try_grab ~db:true sn.coqtop (sn.coqops#process_db_stack
       ~next:(function
@@ -1073,9 +1073,13 @@ let db_goals_n_stack sn _ =
             Coq.return ()
           ))
       (fun () -> Minilib.log "Coq busy, discarding db_stack")
+  );
+  Coq.add_do_when_ready sn.coqtop (fun _ ->
+    ignore @@ Coq.try_grab ~db:true sn.coqtop (sn.coqops#show_goals true)
+      (fun () -> Minilib.log "Coq busy, discarding show_goals")
   )
 
-let _ = forward_db_goals_n_stack := db_goals_n_stack
+let _ = forward_db_stack_n_goals := db_stack_n_goals
 
 let db_vars sn line =
   Coq.add_do_when_ready sn.coqtop (fun _ ->
@@ -1507,7 +1511,7 @@ let build_ui () =
         | 1 -> List.iter (fun o -> Opt.set o "on"; diffs#set "on") Opt.diff_item.Opt.opts
         | 2 -> List.iter (fun o -> Opt.set o "removed"; diffs#set "removed") Opt.diff_item.Opt.opts
         | _ -> assert false);
-        send_to_coq "set diffs" (fun sn -> sn.coqops#show_goals)
+        send_to_coq "set diffs" (fun sn -> sn.coqops#show_goals true)
         end
       [
         radio "Unset diff" 0 ~label:"_Don't show diffs";

--- a/ide/coqide/coqide.ml
+++ b/ide/coqide/coqide.ml
@@ -171,7 +171,7 @@ let db_cmd sn cmd =
       (sn.coqops#process_db_cmd cmd ~next:(function | _ -> Coq.return ()))
       (fun () -> Minilib.log "Coq busy, discarding db_cmd")
 
-let forward_db_stack = ref ((fun _ -> failwith "forward_db_stack")
+let forward_db_goals_n_stack = ref ((fun _ -> failwith "forward_db_goals_n_stack")
                      : session -> unit -> unit)
 let forward_db_vars = ref ((fun _ -> failwith "forward_db_vars")
                      : session -> int -> unit)
@@ -190,7 +190,7 @@ let create_session f =
   sn.debugger#set_forward_get_basename (fun _ -> sn.basename);
   Coq.set_restore_bpts sn.coqtop (fun _ -> !forward_restore_bpts sn);
   (sn.messages#route 0)#set_forward_send_db_cmd (db_cmd sn);
-  (sn.messages#route 0)#set_forward_send_db_stack (!forward_db_stack sn);
+  (sn.messages#route 0)#set_forward_db_goals_n_stack (!forward_db_goals_n_stack sn);
   sn.debugger#set_forward_highlight_code (!forward_highlight_code sn);
   sn.debugger#set_forward_clear_db_highlight (clear_db_highlight sn);
   sn.debugger#set_forward_db_vars (!forward_db_vars sn);
@@ -732,12 +732,12 @@ let find_next_occurrence ~backward sn =
     |None -> ()
     |Some(where, _) -> b#place_cursor ~where; sn.script#recenter_insert
 
-let send_to_coq_aux f sn =
-  let info () = Minilib.log "Coq busy, discarding query" in
+let send_to_coq_aux name f sn =
+  let info () = Minilib.log ("Coq busy, discarding " ^ name) in
   let f = Coq.seq (f sn) (update_status sn) in
   ignore @@ Coq.try_grab sn.coqtop f info
 
-let send_to_coq f = on_current_term (send_to_coq_aux f)
+let send_to_coq name f = on_current_term (send_to_coq_aux name f)
 
 let db_continue opt sn =
   Coq.try_grab ~db:true sn.coqtop (sn.coqops#process_db_continue opt
@@ -819,23 +819,23 @@ module Nav = struct
   let forward_one_sid ?sid _ =
     maybe_update_breakpoints ();
     if not (resume_debugger ?sid Interface.StepOver) then
-      send_to_coq (fun sn -> sn.coqops#process_next_phrase)
+      send_to_coq "forward one" (fun sn -> sn.coqops#process_next_phrase)
   let forward_one x = forward_one_sid x
   let continue ?sid _ = maybe_update_breakpoints ();
     if not (resume_debugger ?sid Interface.Continue) then
-      send_to_coq (fun sn -> sn.coqops#process_until_end_or_error)
+      send_to_coq "continue" (fun sn -> sn.coqops#process_until_end_or_error)
   let step_in ?sid _ = maybe_update_breakpoints ();
     if not (resume_debugger ?sid Interface.StepIn) then
-      send_to_coq (fun sn -> sn.coqops#process_next_phrase)
+      send_to_coq "step in" (fun sn -> sn.coqops#process_next_phrase)
   let step_out ?sid _ = maybe_update_breakpoints ();
     if not (resume_debugger ?sid Interface.StepOut) then
-      send_to_coq (fun sn -> sn.coqops#process_next_phrase)
+      send_to_coq "step out" (fun sn -> sn.coqops#process_next_phrase)
   let backward_one _ = maybe_update_breakpoints ();
-    send_to_coq (fun sn -> init_bpts sn; sn.coqops#backtrack_last_phrase)
+    send_to_coq "back one" (fun sn -> init_bpts sn; sn.coqops#backtrack_last_phrase)
   let run_to_cursor _ = maybe_update_breakpoints ();
-    send_to_coq (fun sn -> sn.coqops#go_to_insert)
+    send_to_coq "run to cursor" (fun sn -> sn.coqops#go_to_insert)
   let run_to_end _ = maybe_update_breakpoints ();
-    send_to_coq (fun sn -> sn.coqops#process_until_end_or_error)
+    send_to_coq "run to end" (fun sn -> sn.coqops#process_until_end_or_error)
   let previous_occ = cb_on_current_term (find_next_occurrence ~backward:true)
   let next_occ = cb_on_current_term (find_next_occurrence ~backward:false)
   let restart _ =
@@ -860,7 +860,7 @@ module Nav = struct
     end
   let show_debugger _ =
     on_current_term (fun sn -> sn.debugger#show ())
-  let join_document _ = send_to_coq (fun sn -> sn.coqops#join_document)
+  let join_document _ = send_to_coq "join" (fun sn -> sn.coqops#join_document)
 end
 
 let f9       = GtkData.AccelGroup.parse "F9"
@@ -888,7 +888,7 @@ let _ = Wg_Debugger.forward_keystroke := forward_keystroke
 let printopts_callback opts v =
   let b = v#get_active in
   let () = List.iter (fun o -> Coq.PrintOpt.set o b) opts in
-  send_to_coq (fun sn -> sn.coqops#show_goals)
+  send_to_coq "show_goals" (fun sn -> sn.coqops#show_goals)
 
 (** Templates menu *)
 
@@ -1062,7 +1062,7 @@ let highlight_code sn loc =
 
 let _ = forward_highlight_code := highlight_code
 
-let db_stack sn _ =
+let db_goals_n_stack sn _ =
   Coq.add_do_when_ready sn.coqtop (fun _ ->
     ignore @@ Coq.try_grab ~db:true sn.coqtop (sn.coqops#process_db_stack
       ~next:(function
@@ -1075,7 +1075,7 @@ let db_stack sn _ =
       (fun () -> Minilib.log "Coq busy, discarding db_stack")
   )
 
-let _ = forward_db_stack := db_stack
+let _ = forward_db_goals_n_stack := db_goals_n_stack
 
 let db_vars sn line =
   Coq.add_do_when_ready sn.coqtop (fun _ ->
@@ -1507,7 +1507,7 @@ let build_ui () =
         | 1 -> List.iter (fun o -> Opt.set o "on"; diffs#set "on") Opt.diff_item.Opt.opts
         | 2 -> List.iter (fun o -> Opt.set o "removed"; diffs#set "removed") Opt.diff_item.Opt.opts
         | _ -> assert false);
-        send_to_coq (fun sn -> sn.coqops#show_goals)
+        send_to_coq "set diffs" (fun sn -> sn.coqops#show_goals)
         end
       [
         radio "Unset diff" 0 ~label:"_Don't show diffs";

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -211,7 +211,7 @@ let process_goal short sigma g =
       in
       hyps
   in
-  DebugHook.{ goal_hyp = List.rev hyps; goal_ccl = ccl; goal_id = Proof.goal_uid g; goal_name = name }
+  DebuggerTypes.{ goal_hyp = List.rev hyps; goal_ccl = ccl; goal_id = Proof.goal_uid g; goal_name = name }
 
 let process_goal_diffs ~short diff_goal_map oldp nsigma ng =
   let env = Global.env () in
@@ -225,7 +225,7 @@ let process_goal_diffs ~short diff_goal_map oldp nsigma ng =
     goal_id = Proof.goal_uid ng; goal_name = name }
 
 let export_pre_goals flags Proof.{ sigma; goals; stack } bg_proof process0 =
-  let open DebugHook in
+  let open DebuggerTypes in
   let process x = List.map (process0 sigma) x in
   let fg_goals = if flags.gf_fg then process goals else [] in
   let bg_goals =
@@ -258,7 +258,7 @@ let db_subgoals flags debug_proof =
   let doc = get_doc () in
   if not !DebuggerTypes.in_debug then
     ignore (Stm.finish ~doc : Vernacstate.t);
-  let short = match flags.DebugHook.gf_mode with
+  let short = match flags.DebuggerTypes.gf_mode with
   | "short" -> true
   | _ -> false
   in
@@ -299,7 +299,7 @@ let subgoals flags =
   end
 
 let goals () =
-  let open DebugHook in
+  let open DebuggerTypes in
   let all = { gf_mode = "full"; gf_fg = true; gf_bg = true; gf_shelved = true; gf_given_up = true } in
   subgoals all
 

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -186,11 +186,16 @@ let concl_next_tac =
     "right"
   ])
 
+let sugg_name env sigma g =
+  if Printer.print_goal_names () then
+    Some (Names.Id.to_string (Termops.evar_suggested_name env sigma g))
+  else None
+
 let process_goal short sigma g =
   let evi = Evd.find_undefined sigma g in
   let env = Evd.evar_filtered_env (Global.env ()) evi in
   let min_env = Environ.reset_context env in
-  let name = if Printer.print_goal_names () then Some (Names.Id.to_string (Termops.evar_suggested_name env sigma g)) else None in
+  let name = sugg_name env sigma g in
   let ccl =
     pr_letype_env ~goal_concl_style:true env sigma (Evd.evar_concl evi)
   in
@@ -210,7 +215,7 @@ let process_goal short sigma g =
 
 let process_goal_diffs ~short diff_goal_map oldp nsigma ng =
   let env = Global.env () in
-  let name = if Printer.print_goal_names () then Some (Names.Id.to_string (Termops.evar_suggested_name env nsigma ng)) else None in
+  let name = sugg_name env nsigma ng in
   let og_s = match oldp, diff_goal_map with
   | Some oldp, Some diff_goal_map -> Proof_diffs.map_goal ng diff_goal_map
   | None, _ | _, None -> None
@@ -219,12 +224,15 @@ let process_goal_diffs ~short diff_goal_map oldp nsigma ng =
   { Interface.goal_hyp = hyps_pp_list; Interface.goal_ccl = concl_pp;
     Interface.goal_id = Proof.goal_uid ng; Interface.goal_name = name }
 
-let export_pre_goals flags Proof.{ sigma; goals; stack } process =
+let export_pre_goals flags Proof.{ sigma; goals; stack } bg_proof process0 =
   let open Interface in
-  let process x = List.map (process sigma) x in
+  let process x = List.map (process0 sigma) x in
   let fg_goals = if flags.gf_fg then process goals else [] in
   let bg_goals =
-    if flags.gf_bg then List.(map (fun (lg,rg) -> process lg, process rg)) stack
+    if flags.gf_bg then
+      let Proof.{sigma; stack} = bg_proof in
+      let process x = List.map (process0 sigma) x in
+      List.(map (fun (lg,rg) -> process lg, process rg)) stack
     else []
   in
   let shelved_goals =
@@ -237,28 +245,43 @@ let export_pre_goals flags Proof.{ sigma; goals; stack } process =
   in
   { fg_goals; bg_goals; shelved_goals; given_up_goals }
 
+(* if in the debugger, bg goals must come from "p"; Ltac doesn't change bg goals *)
+let get_proof_data () =
+  let p = Proof.data (Vernacstate.Declare.give_me_the_proof ()) in
+  let open Proof in
+  match !DebugHook.debug_proof with
+  | Some (sigma, goals) -> { p with sigma; goals }, p
+  | None -> p, p
+  [@@ocaml.warning "-3"]
+
 let subgoals flags =
   let doc = get_doc () in
-  ignore (Stm.finish ~doc : Vernacstate.t);
+  let in_debugger = !DebugHook.debug_proof <> None in
+  if not in_debugger then
+    ignore (Stm.finish ~doc : Vernacstate.t);
   let short = match flags.Interface.gf_mode with
   | "short" -> true
   | _ -> false
   in
   try
-    let newp = Vernacstate.Declare.give_me_the_proof () in
-    if Proof_diffs.show_diffs () then begin
+    let proof_data, bg_proof_data = get_proof_data () in
+    (* todo: get correct data for diffs in the debugger *)
+    if Proof_diffs.show_diffs () && not in_debugger then begin
       let oldp = Stm.get_prev_proof ~doc (Stm.get_current_state ~doc) in
       (try
         let diff_goal_map = match oldp with
         | None -> None
-        | Some oldp -> Some (Proof_diffs.make_goal_map oldp newp)
+        | Some oldp ->
+          (* todo: refactor diffs to avoid the extra call to give_me_the_proof? *)
+          let newp = Vernacstate.Declare.give_me_the_proof () in
+          Some (Proof_diffs.make_goal_map oldp newp)
         in
-        Some (export_pre_goals flags Proof.(data newp) (process_goal_diffs ~short diff_goal_map oldp))
+        Some (export_pre_goals flags proof_data bg_proof_data (process_goal_diffs ~short diff_goal_map oldp))
        with Pp_diff.Diff_Failure msg ->
          Proof_diffs.notify_proof_diff_failure msg;
-         Some (export_pre_goals flags Proof.(data newp) (process_goal short)))
+         Some (export_pre_goals flags proof_data bg_proof_data (process_goal short)))
     end else
-      Some (export_pre_goals flags Proof.(data newp) (process_goal short))
+      Some (export_pre_goals flags proof_data bg_proof_data (process_goal short))
   with Vernacstate.Declare.NoCurrentProof -> None
   [@@ocaml.warning "-3"]
 
@@ -270,9 +293,9 @@ let goals () =
 let evars () =
   try
     let doc = get_doc () in
-    ignore (Stm.finish ~doc : Vernacstate.t);
-    let pfts = Vernacstate.Declare.give_me_the_proof () in
-    let Proof.{ sigma } = Proof.data pfts in
+    if !DebugHook.debug_proof = None then
+      ignore (Stm.finish ~doc : Vernacstate.t);
+    let Proof.{ sigma }, _ = get_proof_data () in
     let exl = Evar.Map.bindings (Evd.undefined_map sigma) in
     let map_evar ev = { Interface.evar_info = string_of_ppcmds (pr_evar sigma ev); } in
     let el = List.map map_evar exl in
@@ -598,7 +621,7 @@ let loop ( { Coqtop.run_mode; color_mode },_) ~opts:_ state =
         pr_with_pid (Xml_printer.to_string_fmt xml_query);
       let Xmlprotocol.Unknown q = Xmlprotocol.to_call xml_query in
       let () = pr_debug_call q in
-      let (send, r)  = eval_call q in
+      let (send, r) = eval_call q in
       (* conditional send so that db_stack and db_vars can reply through DebugHook.Answer *)
       if send then begin
         let () = pr_debug_answer q r in
@@ -629,7 +652,6 @@ let loop ( { Coqtop.run_mode; color_mode },_) ~opts:_ state =
     let open Xmlprotocol in
     let xml = match ans with
       | Prompt msg -> of_ltac_debug_answer ~tag:"prompt" msg
-      | Goal msg -> of_ltac_debug_answer ~tag:"goal" msg
       | Output msg -> of_ltac_debug_answer ~tag:"output" msg
       | Init -> of_ltac_debug_answer ~tag:"init" (str "")
       | Vars vars -> of_vars vars;
@@ -638,7 +660,8 @@ let loop ( { Coqtop.run_mode; color_mode },_) ~opts:_ state =
     print_xml xml_oc xml in
 
   (* XXX: no need to have a ref here *)
-  let ltac_debug_parse () =
+  let ltac_debug_parse in_debug =
+    DebugHook.set_in_debug in_debug;
     let raw_cmd =
       debug_cmd := DebugHook.Action.Ignore;
       process_xml_msg xml_ic xml_oc out_ch;
@@ -660,6 +683,7 @@ let loop ( { Coqtop.run_mode; color_mode },_) ~opts:_ state =
       });
 
   while not !quit do
+    DebugHook.set_in_debug false;
     process_xml_msg xml_ic xml_oc out_ch
   done;
   pr_debug "Exiting gracefully.";

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -246,27 +246,26 @@ let export_pre_goals flags Proof.{ sigma; goals; stack } bg_proof process0 =
   { fg_goals; bg_goals; shelved_goals; given_up_goals }
 
 (* if in the debugger, bg goals must come from "p"; Ltac doesn't change bg goals *)
-let get_proof_data () =
+let get_proof_data debug_proof =
   let p = Proof.data (Vernacstate.Declare.give_me_the_proof ()) in
   let open Proof in
-  match !DebugHook.debug_proof with
+  match debug_proof with
   | Some (sigma, goals) -> { p with sigma; goals }, p
   | None -> p, p
   [@@ocaml.warning "-3"]
 
-let subgoals flags =
+let db_subgoals flags debug_proof =
   let doc = get_doc () in
-  let in_debugger = !DebugHook.debug_proof <> None in
-  if not in_debugger then
+  if not !Xmlprotocol.in_debug then
     ignore (Stm.finish ~doc : Vernacstate.t);
   let short = match flags.Interface.gf_mode with
   | "short" -> true
   | _ -> false
   in
   try
-    let proof_data, bg_proof_data = get_proof_data () in
+    let proof_data, bg_proof_data = get_proof_data debug_proof in
     (* todo: get correct data for diffs in the debugger *)
-    if Proof_diffs.show_diffs () && not in_debugger then begin
+    if Proof_diffs.show_diffs () && not !Xmlprotocol.in_debug then begin
       let oldp = Stm.get_prev_proof ~doc (Stm.get_current_state ~doc) in
       (try
         let diff_goal_map = match oldp with
@@ -285,6 +284,20 @@ let subgoals flags =
   with Vernacstate.Declare.NoCurrentProof -> None
   [@@ocaml.warning "-3"]
 
+let _ = DebugHook.fwd_db_subgoals := db_subgoals
+
+let debug_cmd = ref DebugHook.Action.Ignore
+
+let subgoals flags =
+  let doc = get_doc () in
+  if !Xmlprotocol.in_debug then begin
+    debug_cmd := DebugHook.Action.Subgoals flags;
+    None (* return value passed through DebugHook.Answer *)
+  end else begin
+    set_doc @@ fst @@ Stm.finish ~doc;
+    db_subgoals flags None
+  end
+
 let goals () =
   let open Interface in
   let all = { gf_mode = "full"; gf_fg = true; gf_bg = true; gf_shelved = true; gf_given_up = true } in
@@ -293,9 +306,9 @@ let goals () =
 let evars () =
   try
     let doc = get_doc () in
-    if !DebugHook.debug_proof = None then
+    if not !Xmlprotocol.in_debug then
       ignore (Stm.finish ~doc : Vernacstate.t);
-    let Proof.{ sigma }, _ = get_proof_data () in
+    let Proof.{ sigma }, _ = get_proof_data None in
     let exl = Evar.Map.bindings (Evd.undefined_map sigma) in
     let map_evar ev = { Interface.evar_info = string_of_ppcmds (pr_evar sigma ev); } in
     let el = List.map map_evar exl in
@@ -415,8 +428,6 @@ let export_option_state s = {
   Interface.opt_value = export_option_value s.Goptions.opt_value;
 }
 
-exception NotSupported of string
-
 let proof_diff (diff_opt, sid) =
   let diff_opt = Proof_diffs.string_to_diffs diff_opt in
   let doc = get_doc () in
@@ -425,8 +436,6 @@ let proof_diff (diff_opt, sid) =
   | Some proof ->
       let old = Stm.get_prev_proof ~doc sid in
       Proof_diffs.diff_proofs ~diff_opt ?old proof
-
-let debug_cmd = ref DebugHook.Action.Ignore
 
 let db_cmd cmd =
   debug_cmd := DebugHook.Action.Command cmd
@@ -656,12 +665,13 @@ let loop ( { Coqtop.run_mode; color_mode },_) ~opts:_ state =
       | Init -> of_ltac_debug_answer ~tag:"init" (str "")
       | Vars vars -> of_vars vars;
       | Stack s -> of_stack s
+      | Subgoals g -> of_subgoals g
     in
     print_xml xml_oc xml in
 
   (* XXX: no need to have a ref here *)
   let ltac_debug_parse in_debug =
-    DebugHook.set_in_debug in_debug;
+    Xmlprotocol.in_debug := in_debug;
     let raw_cmd =
       debug_cmd := DebugHook.Action.Ignore;
       process_xml_msg xml_ic xml_oc out_ch;
@@ -683,7 +693,7 @@ let loop ( { Coqtop.run_mode; color_mode },_) ~opts:_ state =
       });
 
   while not !quit do
-    DebugHook.set_in_debug false;
+    Xmlprotocol.in_debug := false;
     process_xml_msg xml_ic xml_oc out_ch
   done;
   pr_debug "Exiting gracefully.";

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -211,7 +211,7 @@ let process_goal short sigma g =
       in
       hyps
   in
-  DebuggerTypes.{ goal_hyp = List.rev hyps; goal_ccl = ccl; goal_id = Proof.goal_uid g; goal_name = name }
+  DebugHook.{ goal_hyp = List.rev hyps; goal_ccl = ccl; goal_id = Proof.goal_uid g; goal_name = name }
 
 let process_goal_diffs ~short diff_goal_map oldp nsigma ng =
   let env = Global.env () in
@@ -225,7 +225,7 @@ let process_goal_diffs ~short diff_goal_map oldp nsigma ng =
     goal_id = Proof.goal_uid ng; goal_name = name }
 
 let export_pre_goals flags Proof.{ sigma; goals; stack } bg_proof process0 =
-  let open DebuggerTypes in
+  let open DebugHook in
   let process x = List.map (process0 sigma) x in
   let fg_goals = if flags.gf_fg then process goals else [] in
   let bg_goals =
@@ -258,7 +258,7 @@ let db_subgoals flags debug_proof =
   let doc = get_doc () in
   if not !DebuggerTypes.in_debug then
     ignore (Stm.finish ~doc : Vernacstate.t);
-  let short = match flags.DebuggerTypes.gf_mode with
+  let short = match flags.DebugHook.gf_mode with
   | "short" -> true
   | _ -> false
   in
@@ -299,7 +299,7 @@ let subgoals flags =
   end
 
 let goals () =
-  let open DebuggerTypes in
+  let open DebugHook in
   let all = { gf_mode = "full"; gf_fg = true; gf_bg = true; gf_shelved = true; gf_given_up = true } in
   subgoals all
 

--- a/ide/coqide/protocol/interface.ml
+++ b/ide/coqide/protocol/interface.ml
@@ -16,16 +16,7 @@ type raw = bool
 type verbose = bool
 
 (** The type of coqtop goals *)
-type goal = {
-  goal_id : string;
-  (** Unique goal identifier *)
-  goal_hyp : Pp.t list;
-  (** List of hypotheses *)
-  goal_ccl : Pp.t;
-  (** Goal conclusion *)
-  goal_name : string option;
-  (** User-level goal name *)
-}
+type goal = DebuggerTypes.goal
 
 type evar = {
   evar_info : string;
@@ -43,16 +34,7 @@ type status = {
   (** An id describing the state of the current proof. *)
 }
 
-type 'a pre_goals = {
-  fg_goals : 'a list;
-  (** List of the focused goals *)
-  bg_goals : ('a list * 'a list) list;
-  (** Zipper representing the unfocused background goals *)
-  shelved_goals : 'a list;
-  (** List of the goals on the shelf. *)
-  given_up_goals : 'a list;
-  (** List of the goals that have been given up *)
-}
+type 'a pre_goals = 'a DebuggerTypes.pre_goals
 
 type goals = goal pre_goals
 
@@ -98,13 +80,7 @@ type search_constraint =
 type search_flags = (search_constraint * bool) list
 
 (** Subset of goals to print. *)
-type goal_flags = {
-  gf_mode : string;
-  gf_fg : bool;
-  gf_bg : bool;
-  gf_shelved : bool;
-  gf_given_up : bool;
-}
+type goal_flags = DebuggerTypes.goal_flags
 
 (** A named object in Coq. [coq_object_qualid] is the shortest path defined for
     the user. [coq_object_prefix] is the missing part to recover the fully
@@ -182,12 +158,12 @@ type query_rty = unit
 (** Fetching the list of current goals. Return [None] if no proof is in
     progress, [Some gl] otherwise. *)
 type goals_sty = unit
-type goals_rty = goals option
+type goals_rty = DebuggerTypes.goals_rty
 
 (** Same as above, but specific kind of goals can be retrieved by setting the
     flags. *)
 type subgoals_sty = goal_flags
-type subgoals_rty = goals option
+type subgoals_rty = DebuggerTypes.subgoals_rty
 
 (** Retrieve the list of uninstantiated evars in the current proof. [None] if no
     proof is in progress. *)

--- a/ide/coqide/protocol/xmlprotocol.ml
+++ b/ide/coqide/protocol/xmlprotocol.ml
@@ -21,6 +21,7 @@ let msg_format = ref (Richpp { width = 72; depth = max_int })
 
 open Util
 open Interface
+open DebuggerTypes
 open Serialize
 open Xml_datatype
 
@@ -781,8 +782,6 @@ let db_vars x     : db_vars_rty call     = Db_vars x
 let db_configd x  : db_configd_rty call  = Db_configd x
 let subgoals x    : subgoals_rty call    = Subgoals x
 
-let in_debug = ref false (* tells whether we're in the Ltac debugger or not *)
-
 let abstract_eval_call : type a. _ -> a call -> bool * a value = fun handler c ->
   let send = ref true in
   let mkGood : type a. a -> bool * a value = fun x -> !send, (Good x) in
@@ -814,7 +813,8 @@ let abstract_eval_call : type a. _ -> a call -> bool * a value = fun handler c -
     | Db_stack x   -> send := false; mkGood (handler.db_stack x)
     | Db_vars x    -> send := false; mkGood (handler.db_vars x)
     | Db_configd x -> mkGood (handler.db_configd x)
-    | Subgoals x   -> send := not !in_debug; mkGood (handler.subgoals x)
+    | Subgoals x   -> send := not !DebuggerTypes.in_debug;
+                      mkGood (handler.subgoals x)
   with any ->
     let any = Exninfo.capture any in
     true, Fail (handler.handle_exn any)

--- a/ide/coqide/protocol/xmlprotocol.ml
+++ b/ide/coqide/protocol/xmlprotocol.ml
@@ -779,7 +779,9 @@ let db_continue x : db_continue_rty call = Db_continue x
 let db_stack x    : db_stack_rty call    = Db_stack x
 let db_vars x     : db_vars_rty call     = Db_vars x
 let db_configd x  : db_configd_rty call  = Db_configd x
-let subgoals x    : subgoals_rty call = Subgoals x
+let subgoals x    : subgoals_rty call    = Subgoals x
+
+let in_debug = ref false (* tells whether we're in the Ltac debugger or not *)
 
 let abstract_eval_call : type a. _ -> a call -> bool * a value = fun handler c ->
   let send = ref true in
@@ -812,7 +814,7 @@ let abstract_eval_call : type a. _ -> a call -> bool * a value = fun handler c -
     | Db_stack x   -> send := false; mkGood (handler.db_stack x)
     | Db_vars x    -> send := false; mkGood (handler.db_vars x)
     | Db_configd x -> mkGood (handler.db_configd x)
-    | Subgoals x   -> mkGood (handler.subgoals x)
+    | Subgoals x   -> send := not !in_debug; mkGood (handler.subgoals x)
   with any ->
     let any = Exninfo.capture any in
     true, Fail (handler.handle_exn any)
@@ -1158,6 +1160,7 @@ let msg_kind = function
 let of_vars vars = of_value (of_list (of_pair of_string of_pp)) (Good vars)
 let of_stack frames = of_value (of_list (of_pair of_string (of_option
     (of_pair of_string (of_list of_int))))) (Good frames)
+let of_subgoals gs = of_value (of_option of_goals) (Good gs)
 
 (* vim: set foldmethod=marker: *)
 

--- a/ide/coqide/protocol/xmlprotocol.ml
+++ b/ide/coqide/protocol/xmlprotocol.ml
@@ -463,8 +463,9 @@ end = struct
             Pp.string_of_ppcmds goal ^ "]" in
       String.concat " " (List.map pr_goal g.fg_goals)
   let pr_goal_flags (g : goal_flags) =
-    Printf.sprintf "{ fg := %s; bg := %s; shelved := %s; given_up := %s }"
-      (pr_bool g.gf_fg) (pr_bool g.gf_bg) (pr_bool g.gf_shelved) (pr_bool g.gf_given_up)
+    Printf.sprintf "{ mode = %s; fg := %s; bg := %s; shelved := %s; given_up := %s }"
+      (pr_string g.gf_mode) (pr_bool g.gf_fg) (pr_bool g.gf_bg) (pr_bool g.gf_shelved)
+      (pr_bool g.gf_given_up)
   let pr_evar (e : evar) = "[" ^ e.evar_info ^ "]"
   let pr_status (s : status) =
     let path =

--- a/ide/coqide/protocol/xmlprotocol.mli
+++ b/ide/coqide/protocol/xmlprotocol.mli
@@ -46,6 +46,7 @@ val db_vars     : db_vars_sty     -> db_vars_rty call
 val db_configd  : db_configd_sty  -> db_configd_rty call
 val subgoals    : subgoals_sty -> subgoals_rty call
 
+val in_debug : bool ref (* tells whether we're in the Ltac debugger or not *)
 val abstract_eval_call : handler -> 'a call -> bool * 'a value
 
 (** * Protocol version *)
@@ -89,7 +90,10 @@ val of_ltac_debug_answer : tag:string -> Pp.t -> xml
 val to_ltac_debug_answer : xml -> string * Pp.t
 
 (** * reply for db_vars message *)
-val of_vars : (string * Pp.t) list -> xml
+val of_vars : db_vars_rty -> xml
 
 (** * reply for db_stack message *)
-val of_stack : (string * (string * int list) option) list -> xml
+val of_stack : db_stack_rty -> xml
+
+(** * reply for subgoals message *)
+val of_subgoals : goals_rty -> (string * string) list gxml

--- a/ide/coqide/protocol/xmlprotocol.mli
+++ b/ide/coqide/protocol/xmlprotocol.mli
@@ -46,7 +46,6 @@ val db_vars     : db_vars_sty     -> db_vars_rty call
 val db_configd  : db_configd_sty  -> db_configd_rty call
 val subgoals    : subgoals_sty -> subgoals_rty call
 
-val in_debug : bool ref (* tells whether we're in the Ltac debugger or not *)
 val abstract_eval_call : handler -> 'a call -> bool * 'a value
 
 (** * Protocol version *)

--- a/ide/coqide/session.ml
+++ b/ide/coqide/session.ml
@@ -56,7 +56,6 @@ type session = {
   mutable abs_file_name : string option;
   mutable debug_stop_pt : (session * int * int) option;
   mutable breakpoints : breakpoint list;
-  mutable last_db_goals : Pp.t
 }
 
 let next_sid = ref 0
@@ -367,7 +366,7 @@ let create_jobpage coqtop coqops : jobpage =
       (fun columns store tp vc ->
         let row = store#get_iter tp in
         let w = store#get ~row ~column:(find_string_col "Worker" columns) in
-        let info () = Minilib.log ("Coq busy, discarding query") in
+        let info () = Minilib.log ("Coq busy, discarding stop_worker") in
         ignore @@ Coq.try_grab coqtop (coqops#stop_worker w) info
       ) in
   let tip = GMisc.label ~text:"Double click to interrupt worker" () in
@@ -482,7 +481,6 @@ let create file coqtop_args =
     abs_file_name = abs_file_name;
     debug_stop_pt = None;
     breakpoints = [];
-    last_db_goals = Pp.mt ()
   }
 
 let kill (sn:session) =

--- a/ide/coqide/session.mli
+++ b/ide/coqide/session.mli
@@ -54,7 +54,6 @@ type session = {
   mutable abs_file_name : string option;
   mutable debug_stop_pt : (session * int * int) option;
   mutable breakpoints : breakpoint list;
-  mutable last_db_goals : Pp.t
 }
 
 (** [create filename coqtop_args] *)

--- a/ide/coqide/wg_MessageView.ml
+++ b/ide/coqide/wg_MessageView.ml
@@ -45,7 +45,7 @@ class type message_view =
     method editable2 : bool
     method set_editable2 : bool -> unit
     method set_forward_send_db_cmd : (string -> unit) -> unit
-    method set_forward_send_db_stack : (unit -> unit) -> unit
+    method set_forward_db_goals_n_stack : (unit -> unit) -> unit
     method set_forward_show_debugger : (unit -> unit) -> unit
   end
 
@@ -265,7 +265,7 @@ let message_view sid : message_view =
     method editable2 = view#editable
     method set_editable2 v = view#set_editable v; view#set_cursor_visible v
     method set_forward_send_db_cmd f = forward_send_db_cmd := f
-    method set_forward_send_db_stack f = forward_send_db_stack := f
+    method set_forward_db_goals_n_stack f = forward_send_db_stack := f
     method set_forward_show_debugger f = forward_show_debugger := f
   end
   in

--- a/ide/coqide/wg_MessageView.ml
+++ b/ide/coqide/wg_MessageView.ml
@@ -45,7 +45,7 @@ class type message_view =
     method editable2 : bool
     method set_editable2 : bool -> unit
     method set_forward_send_db_cmd : (string -> unit) -> unit
-    method set_forward_db_goals_n_stack : (unit -> unit) -> unit
+    method set_forward_db_stack_n_goals : (unit -> unit) -> unit
     method set_forward_show_debugger : (unit -> unit) -> unit
   end
 
@@ -265,7 +265,7 @@ let message_view sid : message_view =
     method editable2 = view#editable
     method set_editable2 v = view#set_editable v; view#set_cursor_visible v
     method set_forward_send_db_cmd f = forward_send_db_cmd := f
-    method set_forward_db_goals_n_stack f = forward_send_db_stack := f
+    method set_forward_db_stack_n_goals f = forward_send_db_stack := f
     method set_forward_show_debugger f = forward_show_debugger := f
   end
   in

--- a/ide/coqide/wg_MessageView.mli
+++ b/ide/coqide/wg_MessageView.mli
@@ -33,7 +33,7 @@ class type message_view =
     method editable2 : bool
     method set_editable2 : bool -> unit
     method set_forward_send_db_cmd : (string -> unit) -> unit
-    method set_forward_db_goals_n_stack : (unit -> unit) -> unit
+    method set_forward_db_stack_n_goals : (unit -> unit) -> unit
     method set_forward_show_debugger : (unit -> unit) -> unit
   end
 

--- a/ide/coqide/wg_MessageView.mli
+++ b/ide/coqide/wg_MessageView.mli
@@ -33,7 +33,7 @@ class type message_view =
     method editable2 : bool
     method set_editable2 : bool -> unit
     method set_forward_send_db_cmd : (string -> unit) -> unit
-    method set_forward_send_db_stack : (unit -> unit) -> unit
+    method set_forward_db_goals_n_stack : (unit -> unit) -> unit
     method set_forward_show_debugger : (unit -> unit) -> unit
   end
 

--- a/ide/coqide/wg_ProofView.ml
+++ b/ide/coqide/wg_ProofView.ml
@@ -14,11 +14,11 @@ open Ideutils
 
 type goals =
 | NoGoals
-| FocusGoals of { fg : Interface.goal list; bg : Interface.goal list }
+| FocusGoals of { fg : DebuggerTypes.goal list; bg : DebuggerTypes.goal list }
 | NoFocusGoals of {
-  bg : Interface.goal list;
-  shelved : Interface.goal list;
-  given_up : Interface.goal list;
+  bg : DebuggerTypes.goal list;
+  shelved : DebuggerTypes.goal list;
+  given_up : DebuggerTypes.goal list;
 }
 
 class type proof_view =
@@ -61,7 +61,7 @@ let hook_tag_cb tag menu_content sel_cb hover_cb =
 
 let mode_tactic sel_cb (proof : #GText.view_skel) goals ~unfoc_goals hints = match goals with
   | [] -> assert false
-  | { Interface.goal_hyp = hyps; Interface.goal_ccl = cur_goal; Interface.goal_name = cur_name } :: rem_goals ->
+  | DebuggerTypes.{ goal_hyp = hyps; goal_ccl = cur_goal; goal_name = cur_name } :: rem_goals ->
       let on_hover sel_start sel_stop =
         proof#buffer#remove_tag
           ~start:proof#buffer#start_iter
@@ -118,7 +118,7 @@ let mode_tactic sel_cb (proof : #GText.view_skel) goals ~unfoc_goals hints = mat
         proof#buffer#insert "\n"
       in
       (* Insert remaining goals (no hypotheses) *)
-      let fold_goal ?(shownum=false) i _ { Interface.goal_ccl = g; Interface.goal_name = name } =
+      let fold_goal ?(shownum=false) i _ DebuggerTypes.{ goal_ccl = g; goal_name = name } =
         proof#buffer#insert (goal_str ~shownum i goals_cnt name);
         insert_xml proof#buffer (Richpp.richpp_of_pp ~width g);
         proof#buffer#insert "\n"
@@ -156,7 +156,7 @@ let display mode (view : #GText.view_skel) goals hints =
       (* The proof is finished, with the exception of given up goals. *)
       view#buffer#insert "No more goals, but there are some goals you gave up:\n\n";
       let iter goal =
-        insert_xml view#buffer (Richpp.richpp_of_pp ~width goal.Interface.goal_ccl);
+        insert_xml view#buffer (Richpp.richpp_of_pp ~width goal.DebuggerTypes.goal_ccl);
         view#buffer#insert "\n"
       in
       List.iter iter given_up;
@@ -165,7 +165,7 @@ let display mode (view : #GText.view_skel) goals hints =
       (* All the goals have been resolved but those on the shelf. *)
       view#buffer#insert "All the remaining goals are on the shelf:\n\n";
       let iter goal =
-        insert_xml view#buffer (Richpp.richpp_of_pp ~width goal.Interface.goal_ccl);
+        insert_xml view#buffer (Richpp.richpp_of_pp ~width goal.DebuggerTypes.goal_ccl);
         view#buffer#insert "\n"
       in
       List.iter iter shelved
@@ -181,8 +181,8 @@ let display mode (view : #GText.view_skel) goals hints =
       in
       view#buffer#insert "This subproof is complete, but there are some unfocused goals:\n\n";
       let iter i goal =
-        let () = view#buffer#insert (goal_str (succ i) goal.Interface.goal_id) in
-        insert_xml view#buffer (Richpp.richpp_of_pp ~width goal.Interface.goal_ccl);
+        let () = view#buffer#insert (goal_str (succ i) goal.DebuggerTypes.goal_id) in
+        insert_xml view#buffer (Richpp.richpp_of_pp ~width goal.DebuggerTypes.goal_ccl);
         view#buffer#insert "\n"
       in
       List.iteri iter bg

--- a/lib/debuggerTypes.ml
+++ b/lib/debuggerTypes.ml
@@ -1,0 +1,54 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** Debugger-defined types useful for communicating with IDEs *)
+
+(** The type of coqtop goals *)
+type goal = {
+  goal_id : string;
+  (** Unique goal identifier *)
+  goal_hyp : Pp.t list;
+  (** List of hypotheses *)
+  goal_ccl : Pp.t;
+  (** Goal conclusion *)
+  goal_name : string option;
+  (** User-level goal name *)
+}
+
+(** Subset of goals to print. *)
+type goal_flags = {
+   gf_mode : string;
+   gf_fg : bool;
+   gf_bg : bool;
+   gf_shelved : bool;
+   gf_given_up : bool;
+ }
+
+type 'a pre_goals = {
+  fg_goals : 'a list;
+  (** List of the focused goals *)
+  bg_goals : ('a list * 'a list) list;
+  (** Zipper representing the unfocused background goals *)
+  shelved_goals : 'a list;
+  (** List of the goals on the shelf. *)
+  given_up_goals : 'a list;
+  (** List of the goals that have been given up *)
+}
+
+type goals = goal pre_goals
+
+(* specific return types *)
+
+type subgoals_rty = goals option
+type goals_rty = goals option
+type db_stack_rty = (string * (string * int list) option) list
+type db_vars_rty = (string * Pp.t) list
+
+let in_debug = ref false (* tells whether we're in the Ltac debugger or not *)

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -628,7 +628,7 @@ let map_goal g (osigma, map) = match GoalMap.find_opt g map with
    match_goals to get a map between old and new evar names, then use this
    to create the map from new goal ids to old goal ids.
 *)
-let make_goal_map op np =
+let make_goal_map_i op np =
   let open Evar.Set in
   let ogs = Proof.all_goals op in
   let ngs = Proof.all_goals np in
@@ -665,7 +665,7 @@ let make_goal_map op np =
       Evar.Set.fold fold add_gs ng_to_og
 
 let make_goal_map op np =
-  let map = make_goal_map op np in
+  let map = make_goal_map_i op np in
   ((Proof.data op).Proof.sigma, map)
 
 let notify_proof_diff_failure msg =

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -90,10 +90,11 @@ let ltac_debug_answer = let open DebugHook.Answer in function
     | Init ->
       Format.fprintf !Topfmt.err_ft "@[%a@]@\n%!" Pp.pp_with (str "Init")
     | Stack _
-    | Vars _ -> CErrors.anomaly (str "ltac_debug_answer: unsupported Answer type")
+    | Vars _
+    | Subgoals _ -> CErrors.anomaly (str "ltac_debug_answer: unsupported Answer type")
 
 let ltac_debug_parse in_debug =
-  DebugHook.set_in_debug in_debug;
+  Xmlprotocol.in_debug := in_debug;
   let open DebugHook in
   let act =
     try Action.parse (read_line ())

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -85,8 +85,6 @@ let ltac_debug_answer = let open DebugHook.Answer in function
     | Prompt prompt ->
       (* No newline *)
       Format.fprintf !Topfmt.err_ft "@[%a@]%!" Pp.pp_with prompt
-    | Goal g ->
-      Format.fprintf !Topfmt.err_ft "@[%a@]@\n%!" Pp.pp_with g
     | Output o ->
       Format.fprintf !Topfmt.err_ft "@[%a@]@\n%!" Pp.pp_with o
     | Init ->
@@ -94,7 +92,8 @@ let ltac_debug_answer = let open DebugHook.Answer in function
     | Stack _
     | Vars _ -> CErrors.anomaly (str "ltac_debug_answer: unsupported Answer type")
 
-let ltac_debug_parse () =
+let ltac_debug_parse in_debug =
+  DebugHook.set_in_debug in_debug;
   let open DebugHook in
   let act =
     try Action.parse (read_line ())

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -94,7 +94,7 @@ let ltac_debug_answer = let open DebugHook.Answer in function
     | Subgoals _ -> CErrors.anomaly (str "ltac_debug_answer: unsupported Answer type")
 
 let ltac_debug_parse in_debug =
-  Xmlprotocol.in_debug := in_debug;
+  DebuggerTypes.in_debug := in_debug;
   let open DebugHook in
   let act =
     try Action.parse (read_line ())

--- a/toplevel/coqtop.mli
+++ b/toplevel/coqtop.mli
@@ -46,4 +46,4 @@ val coqtop_toplevel : (toplevel_options * Stm.AsyncOpts.stm_opt,Vernac.State.t) 
 
 val ltac_debug_answer : DebugHook.Answer.t -> unit
 
-val ltac_debug_parse : unit -> DebugHook.Action.t
+val ltac_debug_parse : bool -> DebugHook.Action.t

--- a/vernac/debugHook.ml
+++ b/vernac/debugHook.ml
@@ -23,7 +23,7 @@ module Action = struct
     | Configd
     | GetStack
     | GetVars of int
-    | Subgoals of Interface.goal_flags
+    | Subgoals of DebuggerTypes.goal_flags
     | RunCnt of int
     | RunBreakpoint of string
     | Command of string
@@ -71,7 +71,7 @@ module Answer = struct
     | Init
     | Stack of (string * (string * int list) option) list
     | Vars of (string * Pp.t) list
-    | Subgoals of Interface.goals_rty
+    | Subgoals of DebuggerTypes.goals_rty
 end
 
 module Intf = struct
@@ -91,5 +91,5 @@ module Intf = struct
 
 end
 
-let fwd_db_subgoals = Interface.(ref ((fun x y -> failwith "fwd_db_subgoals")
+let fwd_db_subgoals = DebuggerTypes.(ref ((fun x y -> failwith "fwd_db_subgoals")
                   : goal_flags -> (Evd.evar_map * Evar.t list) option -> subgoals_rty))

--- a/vernac/debugHook.ml
+++ b/vernac/debugHook.ml
@@ -66,7 +66,6 @@ end
 module Answer = struct
   type t =
     | Prompt of Pp.t
-    | Goal of Pp.t
     | Output of Pp.t
     | Init
     | Stack of (string * (string * int list) option) list
@@ -76,8 +75,8 @@ end
 module Intf = struct
 
   type t =
-    { read_cmd : unit -> Action.t
-    (** request a debugger command from the client *)
+    { read_cmd : bool -> Action.t
+    (** request a debugger command from the client.  true = in debugger *)
     ; submit_answer : Answer.t -> unit
     (** receive a debugger answer from Ltac *)
     ; isTerminal : bool
@@ -89,3 +88,10 @@ module Intf = struct
   let get () = !ltac_debug_ref
 
 end
+
+(* for displaying goals when stopped in debugger (only sigma and goals) *)
+let debug_proof = ref None
+
+(* tells whether we're in the debugger or not *)
+let set_in_debug in_debug =
+  if not in_debug then debug_proof := None

--- a/vernac/debugHook.ml
+++ b/vernac/debugHook.ml
@@ -23,6 +23,7 @@ module Action = struct
     | Configd
     | GetStack
     | GetVars of int
+    | Subgoals of Interface.goal_flags
     | RunCnt of int
     | RunBreakpoint of string
     | Command of string
@@ -70,6 +71,7 @@ module Answer = struct
     | Init
     | Stack of (string * (string * int list) option) list
     | Vars of (string * Pp.t) list
+    | Subgoals of Interface.goals_rty
 end
 
 module Intf = struct
@@ -89,9 +91,5 @@ module Intf = struct
 
 end
 
-(* for displaying goals when stopped in debugger (only sigma and goals) *)
-let debug_proof = ref None
-
-(* tells whether we're in the debugger or not *)
-let set_in_debug in_debug =
-  if not in_debug then debug_proof := None
+let fwd_db_subgoals = Interface.(ref ((fun x y -> failwith "fwd_db_subgoals")
+                  : goal_flags -> (Evd.evar_map * Evar.t list) option -> subgoals_rty))

--- a/vernac/debugHook.ml
+++ b/vernac/debugHook.ml
@@ -8,6 +8,48 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+
+(** The type of coqtop goals *)
+type goal = {
+  goal_id : string;
+  (** Unique goal identifier *)
+  goal_hyp : Pp.t list;
+  (** List of hypotheses *)
+  goal_ccl : Pp.t;
+  (** Goal conclusion *)
+  goal_name : string option;
+  (** User-level goal name *)
+}
+
+(** Subset of goals to print. *)
+type goal_flags = {
+   gf_mode : string;
+   gf_fg : bool;
+   gf_bg : bool;
+   gf_shelved : bool;
+   gf_given_up : bool;
+ }
+
+type 'a pre_goals = {
+  fg_goals : 'a list;
+  (** List of the focused goals *)
+  bg_goals : ('a list * 'a list) list;
+  (** Zipper representing the unfocused background goals *)
+  shelved_goals : 'a list;
+  (** List of the goals on the shelf. *)
+  given_up_goals : 'a list;
+  (** List of the goals that have been given up *)
+}
+
+type goals = goal pre_goals
+
+(* specific return types *)
+
+type subgoals_rty = goals option
+type goals_rty = goals option
+type db_stack_rty = (string * (string * int list) option) list
+type db_vars_rty = (string * Pp.t) list
+
 (** Ltac debugger interface; clients should register hooks to interact
    with their provided interface. *)
 module Action = struct
@@ -23,7 +65,7 @@ module Action = struct
     | Configd
     | GetStack
     | GetVars of int
-    | Subgoals of DebuggerTypes.goal_flags
+    | Subgoals of goal_flags
     | RunCnt of int
     | RunBreakpoint of string
     | Command of string
@@ -71,7 +113,7 @@ module Answer = struct
     | Init
     | Stack of (string * (string * int list) option) list
     | Vars of (string * Pp.t) list
-    | Subgoals of DebuggerTypes.goals_rty
+    | Subgoals of goals_rty
 end
 
 module Intf = struct
@@ -91,5 +133,5 @@ module Intf = struct
 
 end
 
-let fwd_db_subgoals = DebuggerTypes.(ref ((fun x y -> failwith "fwd_db_subgoals")
+let fwd_db_subgoals = (ref ((fun x y -> failwith "fwd_db_subgoals")
                   : goal_flags -> (Evd.evar_map * Evar.t list) option -> subgoals_rty))

--- a/vernac/debugHook.ml
+++ b/vernac/debugHook.ml
@@ -8,47 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-
-(** The type of coqtop goals *)
-type goal = {
-  goal_id : string;
-  (** Unique goal identifier *)
-  goal_hyp : Pp.t list;
-  (** List of hypotheses *)
-  goal_ccl : Pp.t;
-  (** Goal conclusion *)
-  goal_name : string option;
-  (** User-level goal name *)
-}
-
-(** Subset of goals to print. *)
-type goal_flags = {
-   gf_mode : string;
-   gf_fg : bool;
-   gf_bg : bool;
-   gf_shelved : bool;
-   gf_given_up : bool;
- }
-
-type 'a pre_goals = {
-  fg_goals : 'a list;
-  (** List of the focused goals *)
-  bg_goals : ('a list * 'a list) list;
-  (** Zipper representing the unfocused background goals *)
-  shelved_goals : 'a list;
-  (** List of the goals on the shelf. *)
-  given_up_goals : 'a list;
-  (** List of the goals that have been given up *)
-}
-
-type goals = goal pre_goals
-
-(* specific return types *)
-
-type subgoals_rty = goals option
-type goals_rty = goals option
-type db_stack_rty = (string * (string * int list) option) list
-type db_vars_rty = (string * Pp.t) list
+open DebuggerTypes
 
 (** Ltac debugger interface; clients should register hooks to interact
    with their provided interface. *)

--- a/vernac/debugHook.mli
+++ b/vernac/debugHook.mli
@@ -8,6 +8,47 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+(** The type of coqtop goals *)
+type goal = {
+  goal_id : string;
+  (** Unique goal identifier *)
+  goal_hyp : Pp.t list;
+  (** List of hypotheses *)
+  goal_ccl : Pp.t;
+  (** Goal conclusion *)
+  goal_name : string option;
+  (** User-level goal name *)
+}
+
+(** Subset of goals to print. *)
+type goal_flags = {
+   gf_mode : string;
+   gf_fg : bool;
+   gf_bg : bool;
+   gf_shelved : bool;
+   gf_given_up : bool;
+ }
+
+type 'a pre_goals = {
+  fg_goals : 'a list;
+  (** List of the focused goals *)
+  bg_goals : ('a list * 'a list) list;
+  (** Zipper representing the unfocused background goals *)
+  shelved_goals : 'a list;
+  (** List of the goals on the shelf. *)
+  given_up_goals : 'a list;
+  (** List of the goals that have been given up *)
+}
+
+type goals = goal pre_goals
+
+(* specific return types *)
+
+type subgoals_rty = goals option
+type goals_rty = goals option
+type db_stack_rty = (string * (string * int list) option) list
+type db_vars_rty = (string * Pp.t) list
+
 (** Ltac debugger interface; clients should register hooks to interact
    with their provided interface. *)
 
@@ -48,7 +89,7 @@ module Action : sig
                 (* request the variables defined for stack frame N,
                    returned as Answer.Vars.  0 is the topmost frame,
                    followed by 1,2,3, ... *)
-    | Subgoals of DebuggerTypes.goal_flags
+    | Subgoals of goal_flags
     | RunCnt of int
                 (* legacy: run for N steps *)
     | RunBreakpoint of string
@@ -69,7 +110,7 @@ module Answer : sig
                         e.g. in color without a newline at the end *)
     | Output of Pp.t (* general output *)
     | Init           (* signals initialization of the debugger *)
-    | Stack of DebuggerTypes.db_stack_rty
+    | Stack of db_stack_rty
                      (* (string * (string * int list) option) list *)
                      (* The call stack, starting from TOS.
                         Values are:
@@ -78,11 +119,11 @@ module Answer : sig
                         - absolute pathname of the file
                         - array containing Loc.bp and Loc.ep of the
                           corresponding code *)
-    | Vars of DebuggerTypes.db_vars_rty
+    | Vars of db_vars_rty
                      (* (string * Pp.t) list *)
                      (* The variable values for the specified stack
                         frame.  Values are variable name and variable value *)
-    | Subgoals of DebuggerTypes.goals_rty
+    | Subgoals of goals_rty
 end
 
 module Intf : sig
@@ -99,5 +140,4 @@ module Intf : sig
   val get : unit -> t option
 end
 
-open DebuggerTypes
 val fwd_db_subgoals : (goal_flags -> (Evd.evar_map * Evar.t list) option -> subgoals_rty) ref

--- a/vernac/debugHook.mli
+++ b/vernac/debugHook.mli
@@ -66,7 +66,6 @@ module Answer : sig
     | Prompt of Pp.t (* output signalling the debugger has stopped
                         Should be printed as a prompt for user input,
                         e.g. in color without a newline at the end *)
-    | Goal of Pp.t   (* goal for the current proof state *)
     | Output of Pp.t (* general output *)
     | Init           (* signals initialization of the debugger *)
     | Stack of (string * (string * int list) option) list
@@ -84,8 +83,8 @@ end
 
 module Intf : sig
   type t =
-    { read_cmd : unit -> Action.t
-    (** request a debugger command from the client *)
+    { read_cmd : bool -> Action.t
+    (** request a debugger command from the client.  true = in debugger *)
     ; submit_answer : Answer.t -> unit
     (** receive a debugger answer from Ltac *)
     ; isTerminal : bool
@@ -95,3 +94,9 @@ module Intf : sig
   val set : t -> unit
   val get : unit -> t option
 end
+
+(* for displaying goals when stopped in debugger (only sigma and goals) *)
+val debug_proof : (Evd.evar_map * Evar.t list) option ref
+
+(* tells whether we're in the debugger or not *)
+val set_in_debug : bool -> unit

--- a/vernac/debugHook.mli
+++ b/vernac/debugHook.mli
@@ -8,46 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(** The type of coqtop goals *)
-type goal = {
-  goal_id : string;
-  (** Unique goal identifier *)
-  goal_hyp : Pp.t list;
-  (** List of hypotheses *)
-  goal_ccl : Pp.t;
-  (** Goal conclusion *)
-  goal_name : string option;
-  (** User-level goal name *)
-}
-
-(** Subset of goals to print. *)
-type goal_flags = {
-   gf_mode : string;
-   gf_fg : bool;
-   gf_bg : bool;
-   gf_shelved : bool;
-   gf_given_up : bool;
- }
-
-type 'a pre_goals = {
-  fg_goals : 'a list;
-  (** List of the focused goals *)
-  bg_goals : ('a list * 'a list) list;
-  (** Zipper representing the unfocused background goals *)
-  shelved_goals : 'a list;
-  (** List of the goals on the shelf. *)
-  given_up_goals : 'a list;
-  (** List of the goals that have been given up *)
-}
-
-type goals = goal pre_goals
-
-(* specific return types *)
-
-type subgoals_rty = goals option
-type goals_rty = goals option
-type db_stack_rty = (string * (string * int list) option) list
-type db_vars_rty = (string * Pp.t) list
+open DebuggerTypes
 
 (** Ltac debugger interface; clients should register hooks to interact
    with their provided interface. *)

--- a/vernac/debugHook.mli
+++ b/vernac/debugHook.mli
@@ -48,7 +48,7 @@ module Action : sig
                 (* request the variables defined for stack frame N,
                    returned as Answer.Vars.  0 is the topmost frame,
                    followed by 1,2,3, ... *)
-    | Subgoals of Interface.goal_flags
+    | Subgoals of DebuggerTypes.goal_flags
     | RunCnt of int
                 (* legacy: run for N steps *)
     | RunBreakpoint of string
@@ -69,7 +69,7 @@ module Answer : sig
                         e.g. in color without a newline at the end *)
     | Output of Pp.t (* general output *)
     | Init           (* signals initialization of the debugger *)
-    | Stack of Interface.db_stack_rty
+    | Stack of DebuggerTypes.db_stack_rty
                      (* (string * (string * int list) option) list *)
                      (* The call stack, starting from TOS.
                         Values are:
@@ -78,11 +78,11 @@ module Answer : sig
                         - absolute pathname of the file
                         - array containing Loc.bp and Loc.ep of the
                           corresponding code *)
-    | Vars of Interface.db_vars_rty
+    | Vars of DebuggerTypes.db_vars_rty
                      (* (string * Pp.t) list *)
                      (* The variable values for the specified stack
                         frame.  Values are variable name and variable value *)
-    | Subgoals of Interface.goals_rty
+    | Subgoals of DebuggerTypes.goals_rty
 end
 
 module Intf : sig
@@ -99,5 +99,5 @@ module Intf : sig
   val get : unit -> t option
 end
 
-open Interface
+open DebuggerTypes
 val fwd_db_subgoals : (goal_flags -> (Evd.evar_map * Evar.t list) option -> subgoals_rty) ref

--- a/vernac/debugHook.mli
+++ b/vernac/debugHook.mli
@@ -48,6 +48,7 @@ module Action : sig
                 (* request the variables defined for stack frame N,
                    returned as Answer.Vars.  0 is the topmost frame,
                    followed by 1,2,3, ... *)
+    | Subgoals of Interface.goal_flags
     | RunCnt of int
                 (* legacy: run for N steps *)
     | RunBreakpoint of string
@@ -68,7 +69,8 @@ module Answer : sig
                         e.g. in color without a newline at the end *)
     | Output of Pp.t (* general output *)
     | Init           (* signals initialization of the debugger *)
-    | Stack of (string * (string * int list) option) list
+    | Stack of Interface.db_stack_rty
+                     (* (string * (string * int list) option) list *)
                      (* The call stack, starting from TOS.
                         Values are:
                         - description of the frame
@@ -76,9 +78,11 @@ module Answer : sig
                         - absolute pathname of the file
                         - array containing Loc.bp and Loc.ep of the
                           corresponding code *)
-    | Vars of (string * Pp.t) list
+    | Vars of Interface.db_vars_rty
+                     (* (string * Pp.t) list *)
                      (* The variable values for the specified stack
                         frame.  Values are variable name and variable value *)
+    | Subgoals of Interface.goals_rty
 end
 
 module Intf : sig
@@ -95,8 +99,5 @@ module Intf : sig
   val get : unit -> t option
 end
 
-(* for displaying goals when stopped in debugger (only sigma and goals) *)
-val debug_proof : (Evd.evar_map * Evar.t list) option ref
-
-(* tells whether we're in the debugger or not *)
-val set_in_debug : bool -> unit
+open Interface
+val fwd_db_subgoals : (goal_flags -> (Evd.evar_map * Evar.t list) option -> subgoals_rty) ref

--- a/vernac/dune
+++ b/vernac/dune
@@ -5,6 +5,6 @@
  (wrapped false)
  ; until ocaml/dune#4892 fixed
  ; (private_modules comProgramFixpoint egramcoq)
- (libraries tactics parsing findlib.dynload))
+ (libraries tactics parsing findlib.dynload protocol))
 
 (coq.pp (modules g_proofs g_vernac))

--- a/vernac/dune
+++ b/vernac/dune
@@ -5,6 +5,6 @@
  (wrapped false)
  ; until ocaml/dune#4892 fixed
  ; (private_modules comProgramFixpoint egramcoq)
- (libraries tactics parsing findlib.dynload protocol))
+ (libraries tactics parsing findlib.dynload))
 
 (coq.pp (modules g_proofs g_vernac))


### PR DESCRIPTION
When stopped in the debugger, display goals in the same format used when CoqIDE is not in the debugger.  Redisplay goals in the debugger when the user changes display options from the menu.

The main changes are:
- Replacing code that passed the formatted goal through the `DebugHook.Answer.Goal` constructor with an IDE-generated `Subgoals` call.  This allows formatting the goals to be done consistently in one place: in the IDE.  It also permits redisplaying the goals when the display options are changed, which the `Goal` constructor mechanism didn’t support.

- Modifying the processing of the `Subgoals` request to permit a nested call to `Subgoals` for displaying the goals at breakpoints.  `Stm` accumulates tactics and commands passed by the `Add` call but doesn’t process them (and potentially enter the debugger) until the `Subgoals` code calls `Stm.listen`.  On the server side, the first `Subgoals` call invokes `Stm.listen`.  If Coq stops at a breakpoint, CoqIDE makes a second nested call to `Subgoals` that skips the `Stm.listen` (which would cause a hang without that check, BTW).

In its current form, the debug proof state is saved in a `ref`, which `Subgoals` examines to determine whether it’s in the debugger or not, and if so, uses the value to generate the reply.  In any case, `Subgoals` needs to know whether it’s in the debugger or not.

The `ref` is cleared the next time `DebugHook.read_cmd` is called outside the debugger.  Note that supporting proof diffs while in the debugger (in a coming PR) requires saving a few previous proof states so there’s something to diff.  Also I plan to support a history-browsing mechanism that will let users view a potentially large (and configurable) number of previous states of the debugger (goals, stack and variables).  A `ref`seems like the obvious construct for this.

Fixes: #15345
Fixes: #15315

- [x] Added **changelog**.
