### PR TITLE
ltac2 apply/eapply: use open_constr in place of constr (fixes #15691)

### DIFF
--- a/doc/changelog/05-tactic-language/15741-ltac2-apply.rst
+++ b/doc/changelog/05-tactic-language/15741-ltac2-apply.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Ltac2 `apply` and `eapply` not unifying with implicit arguments;
+  unification inconsistent with `exact` and `eexact`
+  (`#15741 <https://github.com/coq/coq/pull/15741>`_,
+  by Ramkumar Ramachandra).

--- a/test-suite/ltac2/notations.v
+++ b/test-suite/ltac2/notations.v
@@ -33,7 +33,7 @@ Admitted.
 
 Lemma apply l1 l2 v1 v2 u1 u2 : l1 + l2 <= v1 + v2 <= u1 + u2.
 Proof.
-  Fail apply Z_add_bounds.
+  apply Z_add_bounds.
 Admitted.
 
 (** * Test cases for specific notations with special contexts *)

--- a/test-suite/ltac2/notations.v
+++ b/test-suite/ltac2/notations.v
@@ -25,6 +25,17 @@ Proof.
   refine (sl ["left" =? "right"]).
 Qed.
 
+Lemma Z_add_bounds {amin a amax bmin b bmax : Z}:
+  amin <= a <= amax ->
+  bmin <= b <= bmax ->
+  amin + bmin <= a + b <= amax + bmax.
+Admitted.
+
+Lemma apply l1 l2 v1 v2 u1 u2 : l1 + l2 <= v1 + v2 <= u1 + u2.
+Proof.
+  Fail apply Z_add_bounds.
+Admitted.
+
 (** * Test cases for specific notations with special contexts *)
 
 (** ** Test eval ... in / reduction tactics *)

--- a/user-contrib/Ltac2/Notations.v
+++ b/user-contrib/Ltac2/Notations.v
@@ -228,12 +228,12 @@ Ltac2 apply0 adv ev cb cl :=
   Std.apply adv ev cb cl.
 
 Ltac2 Notation "eapply"
-  cb(list1(thunk(seq(constr, with_bindings)), ","))
+  cb(list1(thunk(seq(open_constr, with_bindings)), ","))
   cl(opt(seq("in", ident, opt(seq("as", intropattern))))) :=
   apply0 true true cb cl.
 
 Ltac2 Notation "apply"
-  cb(list1(thunk(seq(constr, with_bindings)), ","))
+  cb(list1(thunk(seq(open_constr, with_bindings)), ","))
   cl(opt(seq("in", ident, opt(seq("as", intropattern))))) :=
   apply0 true false cb cl.
 


### PR DESCRIPTION
As Gaëtan and Pierre-Marie hinted in the issue, `open_constr` seems to fix the bug. I'm not an expert, and I _think_ it is correct, because the Notations for `exact` and `eexact` use `open_constr`; from my black-box usage of Coq, `apply` and `eapply` seem to be better at unifying things than `exact` and `eexact`, and `open_constr` is a generalization of `constr`.

Fixes #15691

[x] Added test.
