### PR TITLE
Deprecate the Typeclasses Filtered Unification flag.

### DIFF
--- a/doc/changelog/07-vernac-commands-and-options/15752-deprecate-filtered-tc.rst
+++ b/doc/changelog/07-vernac-commands-and-options/15752-deprecate-filtered-tc.rst
@@ -1,0 +1,5 @@
+- **Deprecated:**
+  the :flag:`Typeclasses Filtered Unification` flag. Due to
+  a buggy implementation, it is unlikely this is used in the wild
+  (`#15752 <https://github.com/coq/coq/pull/15752>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/addendum/type-classes.rst
+++ b/doc/sphinx/addendum/type-classes.rst
@@ -571,6 +571,7 @@ Settings
    explicitly appear in the pattern will make it never apply on a goal
    where there is a hole in that place.
 
+   .. deprecated:: 8.16
 
 .. flag:: Typeclasses Limit Intros
 

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -68,7 +68,7 @@ let get_typeclasses_iterative_deepening =
     used. *)
 let get_typeclasses_filtered_unification =
   Goptions.declare_bool_option_and_ref
-    ~depr:false
+    ~depr:true
     ~key:["Typeclasses";"Filtered";"Unification"]
     ~value:false
 


### PR DESCRIPTION
This flag is hopelessly broken. It enables a fast syntactic check for the application of TC hints. This is not per se a bad idea, but the implementation is completely crazy, since it considers evars in the goal as rigid for the check. That is, as soon as the the TC search must find a proof whose goal mentions an evar, this goes boom immediately.

As such, I suspect that nobody is using this flag in the wild. I believe that we should reimplement the feature from scratch for efficiency reasons, but in the meantime it does not hurt to signal to our end-users that they should not rely on the current implementation.

cc @mattam82 