### PR TITLE
Separate parsing effect and interpretation effect in `Notation` command

### DIFF
--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1712,9 +1712,7 @@ let set_notation_for_interpretation env impls (decl_ntn, main_data, notation_sym
   Lib.add_leaf (inNotation notation);
   Option.iter (fun sc -> Notation.open_close_scope (false,true,sc)) sc
 
-(* Main entry point for command Notation *)
-
-let add_notation ~local ~infix deprecation env c ({CAst.loc;v=df},modifiers) sc =
+let build_notation_syntax ~local ~infix deprecation c ({CAst.loc;v=df},modifiers) =
   (* Extract the modifiers not affecting the parsing rule *)
   let (main_data,syntax_modifiers) = interp_non_syntax_modifiers ~reserved:false ~infix ~abbrev:false deprecation modifiers in
   (* Extract the modifiers not affecting the parsing rule *)
@@ -1726,27 +1724,43 @@ let add_notation ~local ~infix deprecation env c ({CAst.loc;v=df},modifiers) sc 
   (* Build or rebuild the syntax rules *)
   let syntax_rules =
     if isnumeral then (check_no_syntax_modifiers_for_numeral syntax_modifiers; PrimTokenSyntax) else
-    match syntax_modifiers with
-    | [] ->
-      (* No syntax data: try to rely on a previously declared rule *)
-      (try SpecificSyntax (recover_notation_syntax ntn)
-      with NoSyntaxRule ->
-        (* Try to determine a default syntax rule *)
-        let sd = compute_syntax_data ~local main_data notation_symbols ntn NotationMods.default in
-        SpecificSyntax (make_syntax_rules false main_data ntn sd))
+  match syntax_modifiers with
+  | [] ->
+    (* No syntax data: try to rely on a previously declared rule *)
+    (try SpecificSyntax (recover_notation_syntax ntn)
+    with NoSyntaxRule ->
+      (* Try to determine a default syntax rule *)
+      let sd = compute_syntax_data ~local main_data notation_symbols ntn NotationMods.default in
+      SpecificSyntax (make_syntax_rules false main_data ntn sd))
 
-    | _ ->
-      let mods = interp_modifiers main_data.entry syntax_modifiers in
-      let sd = compute_syntax_data ~local main_data notation_symbols ntn mods in
-      SpecificSyntax (make_syntax_rules false main_data ntn sd)
+  | _ ->
+    let mods = interp_modifiers main_data.entry syntax_modifiers in
+    let sd = compute_syntax_data ~local main_data notation_symbols ntn mods in
+    SpecificSyntax (make_syntax_rules false main_data ntn sd)
   in
+  main_data, notation_symbols, ntn, syntax_rules, c, df
+
+(* Main entry point for command Notation *)
+
+let add_notation_syntax ~local ~infix deprecation c ast =
+  (* Build or rebuild the syntax rules *)
+  let main_data, notation_symbols, ntn, syntax_rules, c, df = build_notation_syntax ~local ~infix deprecation c ast in
+  (* Declare syntax *)
+  syntax_rules_iter (fun sy -> Lib.add_leaf (inSyntaxExtension (local,(ntn,sy)))) syntax_rules
+
+let add_notation_interp ~local ~infix deprecation env c ({CAst.loc;v=df},modifiers as ast) sc =
+  (* Build or rebuild the syntax rules *)
+  let main_data, notation_symbols, ntn, syntax_rules, c, df = build_notation_syntax ~local ~infix deprecation c ast in
   (* Build the interpretation *)
   let notation = make_notation_interpretation ~local main_data notation_symbols ntn syntax_rules df env c sc in
-  (* Declare both syntax and interpretation *)
-  syntax_rules_iter (fun sy -> Lib.add_leaf (inSyntaxExtension (local,(ntn,sy)))) syntax_rules;
+  (* Declare interpretation *)
   Lib.add_leaf (inNotation notation);
   (* Dump the location of the notation for coqdoc *)
   Dumpglob.dump_notation (CAst.make ?loc ntn) sc true
+
+let add_notation ~local ~infix deprecation env c ast sc =
+  add_notation_syntax ~local ~infix deprecation c ast;
+  add_notation_interp ~local ~infix deprecation env c ast sc
 
 (* Main entry point for Format Notation *)
 

--- a/vernac/metasyntax.mli
+++ b/vernac/metasyntax.mli
@@ -15,8 +15,16 @@ open Constrexpr
 open Notation_term
 open Environ
 
-(** Adding a (constr) notation in the environment*)
+(** Declare syntax rules for a notation *)
+val add_notation_syntax : local:bool -> infix:bool -> Deprecation.t option -> constr_expr ->
+  (lstring * syntax_modifier CAst.t list) -> unit
 
+(** Declare interpretation for a notation *)
+val add_notation_interp : local:bool -> infix:bool -> Deprecation.t option -> env -> constr_expr ->
+  (lstring * syntax_modifier CAst.t list) -> scope_name option -> unit
+
+(** Declare a (constr) notation. This function is the composition of
+    [add_notation_syntax] and [add_notation_interp]. *)
 val add_notation : local:bool -> infix:bool -> Deprecation.t option -> env -> constr_expr ->
   (lstring * syntax_modifier CAst.t list) -> scope_name option -> unit
 


### PR DESCRIPTION
This patch is needed for #15409. It exposes a metasyntax API with one function for parsing effects and another for interpretation effects, together with an `add_notation` function which is the composition and should be fully backward compatible.