### PR TITLE
CI: reenable Coq Platform based Windows CI

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Download Platform
         env:
-          PLATFORM: "https://github.com/coq/platform/archive/dev-ci.zip"
+          PLATFORM: "https://github.com/coq/platform/archive/main.zip"
         run: |
           .\dev\ci\platform\coq-pf-02-download.bat
 

--- a/dev/ci/platform/coq-pf-03-build.bat
+++ b/dev/ci/platform/coq-pf-03-build.bat
@@ -13,6 +13,7 @@ cd platform-*
 
 call coq_platform_make_windows.bat ^
   -arch=%ARCH% ^
+  -pick=dev ^
   -destcyg=%CYGROOT% ^
   -cygcache=%CYGCACHE% ^
   -extent=i ^


### PR DESCRIPTION
This PR reenables the Coq Platform based Windows CI after porting the "-override-dev-pkg" functionality to the Coq Platform main branch.

Please note that I also plan to have a Coq Platform "pick" which resembles the package versions in Coq CI. There is currently a pick "dev" which are the opam dev packages. This would allow for a larger Windows CI (not just Coq and CoqIDE) if one feels one needs this (I don't think it is required since it will be tested in Coq Platform CI then).

@SkySkimmer : FYI