### PR TITLE
Warn when trying to deprecate a definition

### DIFF
--- a/doc/changelog/07-vernac-commands-and-options/15760-deprecation_lemmas.rst
+++ b/doc/changelog/07-vernac-commands-and-options/15760-deprecation_lemmas.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  a warning when trying to deprecate a definition
+  (`#15760 <https://github.com/coq/coq/pull/15760>`_,
+  by Pierre Roux).

--- a/test-suite/output/deprecation_definition.out
+++ b/test-suite/output/deprecation_definition.out
@@ -1,0 +1,20 @@
+File "./output/deprecation_definition.v", line 1, characters 0-59:
+The command has indeed failed with message:
+This command does not support this attribute: deprecated (use a notation and deprecate that instead).
+[unsupported-attributes,parsing]
+File "./output/deprecation_definition.v", line 4, characters 0-62:
+The command has indeed failed with message:
+This command does not support this attribute: deprecated (use a notation and deprecate that instead).
+[unsupported-attributes,parsing]
+File "./output/deprecation_definition.v", line 7, characters 0-61:
+The command has indeed failed with message:
+This command does not support this attribute: deprecated (use a notation and deprecate that instead).
+[unsupported-attributes,parsing]
+File "./output/deprecation_definition.v", line 10, characters 0-68:
+The command has indeed failed with message:
+This command does not support this attribute: deprecated (use a notation and deprecate that instead).
+[unsupported-attributes,parsing]
+File "./output/deprecation_definition.v", line 13, characters 0-106:
+The command has indeed failed with message:
+This command does not support this attribute: deprecated (use a notation and deprecate that instead).
+[unsupported-attributes,parsing]

--- a/test-suite/output/deprecation_definition.v
+++ b/test-suite/output/deprecation_definition.v
@@ -1,0 +1,14 @@
+Fail #[deprecated(note="not deprecable")]
+Lemma foo : True.
+
+Fail #[deprecated(note="not deprecable")]
+Theorem foo' : True.
+
+Fail #[deprecated(note="not deprecable")]
+Axiom foo'' : True.
+
+Fail #[deprecated(note="not deprecable")]
+Definition foo''' := True.
+
+Fail #[deprecated(note="not deprecable")]
+Fixpoint foo'''' n := match n with S n => foo''' n | 0 => 1 end.

--- a/theories/Init/Datatypes.v
+++ b/theories/Init/Datatypes.v
@@ -286,12 +286,10 @@ Definition uncurry {A B C:Type} (f:A -> B -> C)
    on a Notation instead (thus printing deprecation warning when used)
    and should probably be removed in 8.17 as if it had been
    deprecated(since = "8.15", *)
-#[deprecated(since = "8.13", note = "Use curry instead.")]
 Definition prod_uncurry_subdef (A B C:Type) : (A * B -> C) -> A -> B -> C := curry.
 #[deprecated(since = "8.13", note = "Use curry instead.")]
 Notation prod_uncurry := prod_uncurry_subdef.
 
-#[deprecated(since = "8.13", note = "Use uncurry instead.")]
 Definition prod_curry_subdef (A B C:Type) : (A -> B -> C) -> A * B -> C := uncurry.
 #[deprecated(since = "8.13", note = "Use uncurry instead.")]
 Notation prod_curry := prod_curry_subdef.

--- a/theories/NArith/Ndigits.v
+++ b/theories/NArith/Ndigits.v
@@ -606,23 +606,25 @@ Qed.
 (** To state nonetheless a second result about composition of
  conversions, we define a conversion on a given number of bits : *)
 
-#[deprecated(since = "8.9.0", note = "Use N2Bv_sized instead.")]
-Fixpoint N2Bv_gen (n:nat)(a:N) : Bvector n :=
+Fixpoint N2Bv_gen_deprecated (n:nat)(a:N) : Bvector n :=
  match n return Bvector n with
    | 0 => Bnil
    | S n => match a with
        | N0 => Bvect_false (S n)
        | Npos xH => Bcons true _ (Bvect_false n)
-       | Npos (xO p) => Bcons false _ (N2Bv_gen n (Npos p))
-       | Npos (xI p) => Bcons true _ (N2Bv_gen n (Npos p))
+       | Npos (xO p) => Bcons false _ (N2Bv_gen_deprecated n (Npos p))
+       | Npos (xI p) => Bcons true _ (N2Bv_gen_deprecated n (Npos p))
       end
   end.
 
+#[deprecated(since = "8.9.0", note = "Use N2Bv_sized instead.")]
+Notation N2Bv_gen := N2Bv_gen_deprecated (only parsing).
+
 (** The first [N2Bv] is then a special case of [N2Bv_gen] *)
 
-Lemma N2Bv_N2Bv_gen : forall (a:N), N2Bv a = N2Bv_gen (N.size_nat a) a.
+Lemma N2Bv_N2Bv_gen (a:N) : N2Bv a = N2Bv_gen_deprecated (N.size_nat a) a.
 Proof.
-intro a; destruct a as [|p]; simpl.
+destruct a as [|p]; simpl.
 auto.
 induction p; simpl; intros; auto; congruence.
 Qed.
@@ -631,7 +633,8 @@ Qed.
    [a] plus some zeros. *)
 
 Lemma N2Bv_N2Bv_gen_above : forall (a:N)(k:nat),
- N2Bv_gen (N.size_nat a + k) a = Vector.append (N2Bv a) (Bvect_false k).
+  N2Bv_gen_deprecated (N.size_nat a + k) a
+  = Vector.append (N2Bv a) (Bvect_false k).
 Proof.
 intros a k; destruct a as [|p]; simpl.
 destruct k; simpl; auto.
@@ -641,7 +644,7 @@ Qed.
 (** Here comes now the second composition result. *)
 
 Lemma N2Bv_Bv2N : forall n (bv:Bvector n),
-   N2Bv_gen n (Bv2N n bv) = bv.
+  N2Bv_gen_deprecated n (Bv2N n bv) = bv.
 Proof.
 intros n bv; induction bv as [|h n bv IHbv]; intros.
 auto.

--- a/theories/Numbers/Cyclic/Int63/Cyclic63.v
+++ b/theories/Numbers/Cyclic/Int63/Cyclic63.v
@@ -317,11 +317,11 @@ Module Uint63Cyclic <: CyclicType.
 End Uint63Cyclic.
 
 Module Int63Cyclic <: CyclicType.
-  #[deprecated(since="8.14",note="Use Uint63Cyclic.t instead.")]
+  (* #[deprecated(since="8.14",note="Use Uint63Cyclic.t instead.")] *)
   Definition t := int.
-  #[deprecated(since="8.14",note="Use Uint63Cyclic.ops instead.")]
+  (* #[deprecated(since="8.14",note="Use Uint63Cyclic.ops instead.")] *)
   Definition ops := int_ops.
-  #[deprecated(since="8.14",note="Use Uint63Cyclic.specs instead.")]
+  (* #[deprecated(since="8.14",note="Use Uint63Cyclic.specs instead.")] *)
   Definition specs := int_specs.
 End Int63Cyclic.
 

--- a/theories/ZArith/Zdiv.v
+++ b/theories/ZArith/Zdiv.v
@@ -112,11 +112,10 @@ Proof.
   now destruct (Z.eq_dec b 0) as [->|?]; [destruct a|apply Z.div_mod].
 Qed.
 
-#[deprecated(since="8.14",note="Z_div_mod_eq_full instead")]
-Lemma Z_div_mod_eq a b : b > 0 -> a = b*(a/b) + (a mod b).
-Proof.
-  intros. apply Z_div_mod_eq_full.
-Qed.
+Lemma Z_div_mod_eq_deprecated a b : b > 0 -> a = b*(a/b) + (a mod b).
+Proof. intros. apply Z_div_mod_eq_full. Qed.
+#[deprecated(since="8.14",note="Use Z_div_mod_eq_full instead")]
+Notation Z_div_mod_eq := Z_div_mod_eq_deprecated (only parsing).
 
 Lemma Zmod_eq_full a b : b<>0 -> a mod b = a - (a/b)*b.
 Proof. intros. rewrite Z.mul_comm. now apply Z.mod_eq. Qed.
@@ -736,12 +735,14 @@ Arguments Zdiv_eucl_extended : default implicits.
 
 (** * Division and modulo in Z agree with same in nat: *)
 
-#[deprecated(since="8.14",note="Use Nat2Z.inj_div instead.")]
-Lemma div_Zdiv (n m: nat): m <> O ->
+Lemma div_Zdiv_deprecated (n m: nat): m <> O ->
   Z.of_nat (n / m) = Z.of_nat n / Z.of_nat m.
 Proof. intros. apply Nat2Z.inj_div. Qed.
+#[deprecated(since="8.14",note="Use Nat2Z.inj_div instead.")]
+Notation div_Zdiv := div_Zdiv_deprecated (only parsing).
 
-#[deprecated(since="8.14",note="Use Nat2Z.inj_mod instead.")]
-Lemma mod_Zmod (n m: nat): m <> O ->
+Lemma mod_Zmod_deprecated (n m: nat): m <> O ->
   Z.of_nat (n mod m) = (Z.of_nat n) mod (Z.of_nat m).
 Proof. intros. apply Nat2Z.inj_mod. Qed.
+#[deprecated(since="8.14",note="Use Nat2Z.inj_mod instead.")]
+Notation mod_Zmod := mod_Zmod_deprecated (only parsing).

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -66,6 +66,8 @@ module DefAttributes = struct
     let (((((locality, deprecated), polymorphic), program), canonical_instance), typing_flags), using =
       parse Notations.(locality ++ deprecation ++ polymorphic ++ program ++ canonical_instance ++ typing_flags ++ using) f
     in
+    if Option.has_some deprecated then
+      Attributes.unsupported_attributes [CAst.make ("deprecated (use a notation and deprecate that instead)",VernacFlagEmpty)];
     let using = Option.map Proof_using.using_from_string using in
     { polymorphic; program; locality; deprecated; canonical_instance; typing_flags; using }
 end


### PR DESCRIPTION
The refman reads "Attribute deprecated [...] This attribute is supported by the following commands: Ltac, Tactic Notation, Notation, Infix, Ltac2, Ltac2 Notation, Ltac2 external" but it was silently doing nothing on definitions, which already made a few deprecations fail.

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
- [x] ~Added / updated **documentation**.~

Overlays (should be merged before merging the current PR):

* https://github.com/math-comp/math-comp/pull/857
* https://github.com/mit-plv/coqutil/pull/59