### PR TITLE
Refine checks to avoid modifying processed code when Coq is busy

### DIFF
--- a/ide/coqide/coqide_main.ml
+++ b/ide/coqide/coqide_main.ml
@@ -49,7 +49,7 @@ let catch_gtk_messages () =
 let () = catch_gtk_messages ()
 
 let load_prefs () =
-  Preferences.load_pref ~warn:(fun ~delay -> Ideutils.flash_info ~delay)
+  Preferences.load_pref ~warn:(fun ~delay -> Ideutils.flash_info ~delay ~if_empty:false)
 
 let () =
   Ideutils.push_info ("Ready"^ if Preferences.microPG#get then ", [μPG]" else "");

--- a/ide/coqide/ideutils.ml
+++ b/ide/coqide/ideutils.ml
@@ -66,9 +66,10 @@ let flash_info =
                    queue := pop !queue;
                    process (); false))
     | Nil -> () in
-  fun ?(delay=5000) text ->
+  fun ?(delay=5000) ?(if_empty=false) text ->
     let processing = !queue <> Nil in
-    enqueue (delay,text) queue;
+    if not (processing && if_empty) then
+      enqueue (delay,text) queue;
     if not processing then process ()
 
 (* Note: Setting the same attribute with two separate tags appears to use

--- a/ide/coqide/ideutils.mli
+++ b/ide/coqide/ideutils.mli
@@ -51,7 +51,7 @@ val status : GMisc.statusbar
 val push_info : string -> unit
 val pop_info : unit -> unit
 val clear_info : unit -> unit
-val flash_info : ?delay:int -> string -> unit
+val flash_info : ?delay:int -> ?if_empty:bool ->string -> unit
 
 val insert_xml : ?mark:GText.mark -> ?tags:GText.tag list ->
   #GText.buffer_skel -> Richpp.richpp -> unit

--- a/ide/coqide/session.ml
+++ b/ide/coqide/session.ml
@@ -421,7 +421,10 @@ let create file coqtop_args =
   let messages = create_messages () in
   let segment = new Wg_Segment.segment () in
   let finder = new Wg_Find.finder basename (script :> GText.view) in
-  finder#setup_is_script_editable (fun _ -> script#editable2);
+  finder#setup_is_script_editable (fun processed ->
+      let it = buffer#get_iter (`MARK (buffer#get_mark (`NAME "insert"))) in
+      (* note code in Session.insert_cb/delete_cb for other tags *)
+      script#editable2 || (processed && not (it#has_tag Tags.Script.processed)));
   let debugger = Wg_Debugger.debugger (Printf.sprintf "Debugger (%s)" basename) sid in
   let fops = new FileOps.fileops (buffer :> GText.buffer) file reset in
   let _ = fops#update_stats in

--- a/ide/coqide/wg_Find.ml
+++ b/ide/coqide/wg_Find.ml
@@ -56,12 +56,12 @@ class finder name (view : GText.view) =
       let stop = view#buffer#get_iter `SEL_BOUND in
       view#buffer#get_text ~start ~stop ()
 
-    val mutable is_script_editable = ((fun _ -> failwith "is_script_editable") : unit -> bool)
+    val mutable is_script_editable = ((fun _ -> failwith "is_script_editable") : bool -> bool)
 
-    method setup_is_script_editable (f : unit -> bool) = is_script_editable <- f
+    method setup_is_script_editable (f : bool -> bool) = is_script_editable <- f
 
     method private may_replace () =
-      (is_script_editable ()) &&
+      (is_script_editable true) &&
       (self#search_text <> "") &&
       (Str.string_match self#regex (self#get_selected_word ()) 0)
 
@@ -135,7 +135,7 @@ class finder name (view : GText.view) =
           let next_ct = if edited then ct + 1 else ct in
           replace_at next next_ct (tot + 1)
       in
-      if is_script_editable () then begin
+      if is_script_editable false then begin
         let () = view#buffer#begin_user_action () in
         let () = replace_at view#buffer#start_iter 0 0 in
         view#buffer#end_user_action ()

--- a/ide/coqide/wg_Find.mli
+++ b/ide/coqide/wg_Find.mli
@@ -17,5 +17,5 @@ class finder : string -> GText.view ->
     method replace_all : unit -> unit
     method find_backward : unit -> unit
     method find_forward : unit -> unit
-    method setup_is_script_editable : (unit -> bool) -> unit
+    method setup_is_script_editable : (bool -> bool) -> unit
   end

--- a/ide/coqide/wg_ScriptView.mli
+++ b/ide/coqide/wg_ScriptView.mli
@@ -15,8 +15,8 @@ type source_view = [ Gtk.text_view | `sourceview ] Gtk.obj
 class script_view : source_view -> Coq.coqtop ->
 object
   inherit GSourceView3.source_view
-  method undo : unit -> unit
-  method redo : unit -> unit
+  method undo : bool -> unit
+  method redo : bool -> unit
   method clear_undo : unit -> unit
   method auto_complete : bool
   method set_auto_complete : bool -> unit


### PR DESCRIPTION
Fixes for @eponier's comments in #15714, which are:

> - the message "Input discarded" is sometimes shown without reason (I think one still needs to make it print at least once, but then it reappears sometimes, I don't understand why)

"Input discarded" is generated for each keystroke in the green area.  The flash_info routine queues these; each message is shown for a default of 5000 msec.  If you type a lot of characters, the message could be shown many seconds after it was generated.  I reduced the time to show this message to 1000 msec.  Also, the message is now generated only if the queue is empty.

> - in my setup, I have a really strange behaviour : I can enter as many "a" as I want in the green zone when it should be frozen; this is the only key on my keyboard that allows that

Ctrl-A (select all) should always be allowed.  The code was allowing "a" with any modifier (any subset of Ctrl, Shift, Alt)--and in particular with no modifier.

> - the undo/redo has the right to change the green part

The code was checking whether the buffer insertion point was marked processed rather than the point of the undo/redo, which is likely somewhere else.

I think a changelog is not needed for this one.  This is really a continuation of #15714.