### PR TITLE
Remove a redundant typing check in Ssrelim.

### DIFF
--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -231,7 +231,7 @@ val saturate :
            EConstr.constr ->
            ?ty:EConstr.types ->
            int ->
-           EConstr.constr * EConstr.types * (int * EConstr.constr) list * evar_map
+           EConstr.constr * EConstr.types * (int * EConstr.constr * EConstr.types) list * evar_map
 val refine_with :
            ?first_goes_last:bool ->
            ?beta:bool ->

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -157,7 +157,8 @@ let newssrcongrtac arg ist =
   Proofview.Unsafe.tclEVARS sigma <*>
   tclMATCH_GOAL env sigma' equality
   (fun sigma' ->
-    let ty = fs sigma' (List.assoc 0 eq_args) in
+    let x = List.find_map (fun (n, x, _) -> if n = 0 then Some x else None) eq_args in
+    let ty = fs sigma' x in
     congrtac (arg, Detyping.detype Detyping.Now false Id.Set.empty env sigma ty) ist)
   (fun () ->
     try

--- a/test-suite/ssr/bug_15770.v
+++ b/test-suite/ssr/bug_15770.v
@@ -1,0 +1,14 @@
+Require Import Coq.ssr.ssreflect.
+
+Axiom xget : forall {T} (P : T -> Prop), T.
+
+Variant xget_spec {T} (P : T -> Prop) : T -> Prop -> Type :=
+| XGetSome x of P x : xget_spec P x True.
+
+Axiom xgetP : forall {T} (P : T -> Prop), xget_spec P (xget P) (P (xget P)).
+
+Lemma xgetPex {T} (P : T -> Prop) : P (xget P).
+Proof.
+case: xgetP.
+constructor.
+Qed.


### PR DESCRIPTION
Normally, the term has been already typechecked and is only modified through transformations that preserve the well-typedness.
