### PR TITLE
Correctly prevent editable status of text when CoqIDE is busy.

### DIFF
--- a/ide/coqide/session.ml
+++ b/ide/coqide/session.ml
@@ -244,7 +244,13 @@ let set_buffer_handlers
     | Some s -> if misc () then Minilib.log (s^" moved")
     | None -> ()
   in
+  let set_busy b =
+    let prop = `EDITABLE b in
+    let tags = [Tags.Script.processed; Tags.Script.to_process; Tags.Script.incomplete] in
+    List.iter (fun tag -> tag#set_property prop) tags
+  in
   (* Pluging callbacks *)
+  let () = Coq.setup_script_editable coqtop set_busy in
   let _ = buffer#connect#insert_text ~callback:insert_cb in
   let _ = buffer#connect#delete_range ~callback:delete_cb in
   let _ = buffer#connect#begin_user_action ~callback:begin_action_cb in
@@ -409,7 +415,6 @@ let create file coqtop_args =
   let reset () = Coq.reset_coqtop coqtop in
   let buffer = create_buffer () in
   let script = create_script coqtop buffer in
-  Coq.setup_script_editable coqtop (fun v -> script#set_editable2 v);
   let proof = create_proof () in
   incr next_sid;
   let sid = !next_sid in
@@ -421,7 +426,6 @@ let create file coqtop_args =
   let messages = create_messages () in
   let segment = new Wg_Segment.segment () in
   let finder = new Wg_Find.finder basename (script :> GText.view) in
-  finder#setup_is_script_editable (fun _ -> script#editable2);
   let debugger = Wg_Debugger.debugger (Printf.sprintf "Debugger (%s)" basename) sid in
   let fops = new FileOps.fileops (buffer :> GText.buffer) file reset in
   let _ = fops#update_stats in

--- a/ide/coqide/tags.ml
+++ b/ide/coqide/tags.ml
@@ -22,10 +22,10 @@ struct
   let warning = make_tag table ~name:"warning" [`UNDERLINE `SINGLE; `FOREGROUND "blue"]
   let error = make_tag table ~name:"error" [`UNDERLINE `SINGLE]
   let error_bg = make_tag table ~name:"error_bg" []
-  let to_process = make_tag table ~name:"to_process" []
+  let to_process = make_tag table ~name:"to_process" [`EDITABLE false]
   let processed = make_tag table ~name:"processed" []
   let debugging = make_tag table ~name:"debugging" []
-  let incomplete = make_tag table ~name:"incomplete" []
+  let incomplete = make_tag table ~name:"incomplete" [`EDITABLE false]
   let unjustified = make_tag table ~name:"unjustified" [`BACKGROUND "gold"]
   let tooltip = make_tag table ~name:"tooltip" [] (* debug:`BACKGROUND "blue" *)
   let ephemere =

--- a/ide/coqide/wg_Find.ml
+++ b/ide/coqide/wg_Find.ml
@@ -56,12 +56,7 @@ class finder name (view : GText.view) =
       let stop = view#buffer#get_iter `SEL_BOUND in
       view#buffer#get_text ~start ~stop ()
 
-    val mutable is_script_editable = ((fun _ -> failwith "is_script_editable") : unit -> bool)
-
-    method setup_is_script_editable (f : unit -> bool) = is_script_editable <- f
-
     method private may_replace () =
-      (is_script_editable ()) &&
       (self#search_text <> "") &&
       (Str.string_match self#regex (self#get_selected_word ()) 0)
 
@@ -135,11 +130,9 @@ class finder name (view : GText.view) =
           let next_ct = if edited then ct + 1 else ct in
           replace_at next next_ct (tot + 1)
       in
-      if is_script_editable () then begin
-        let () = view#buffer#begin_user_action () in
-        let () = replace_at view#buffer#start_iter 0 0 in
-        view#buffer#end_user_action ()
-      end
+      let () = view#buffer#begin_user_action () in
+      let () = replace_at view#buffer#start_iter 0 0 in
+      view#buffer#end_user_action ()
 
     method private set_not_found () =
       find_entry#misc#modify_bg [`NORMAL, `NAME "#F7E6E6"];

--- a/ide/coqide/wg_Find.mli
+++ b/ide/coqide/wg_Find.mli
@@ -17,5 +17,4 @@ class finder : string -> GText.view ->
     method replace_all : unit -> unit
     method find_backward : unit -> unit
     method find_forward : unit -> unit
-    method setup_is_script_editable : (unit -> bool) -> unit
   end

--- a/ide/coqide/wg_ScriptView.mli
+++ b/ide/coqide/wg_ScriptView.mli
@@ -20,8 +20,6 @@ object
   method clear_undo : unit -> unit
   method auto_complete : bool
   method set_auto_complete : bool -> unit
-  method set_editable2 : bool -> unit
-  method editable2 : bool
   method right_margin_position : int
   method set_right_margin_position : int -> unit
   method show_right_margin : bool


### PR DESCRIPTION
We stop the nonsense classification of keypresses and rely instead on the built-in tag mechanism. Supersedes #15766 and #15714.