### PR TITLE
Do not rely on a gensym in Tactic Notation libobjects.

### DIFF
--- a/plugins/ltac/pptactic.mli
+++ b/plugins/ltac/pptactic.mli
@@ -156,7 +156,6 @@ val pr_match_rule : bool -> ('a -> Pp.t) -> ('b -> Pp.t) ->
 
 val pr_value : entry_relative_level -> Val.t -> Pp.t
 
-
 val ltop : entry_relative_level
 
 val make_constr_printer : (env -> Evd.evar_map -> entry_relative_level -> 'a -> Pp.t) ->


### PR DESCRIPTION
Tactic Notations must be given a kernel name to identify them. From within a module, this name should be unique. The previous code was relying on a gensym to create fresh names. We instead use a name generator that faithfully represents the production list of the tactic notation.