### PR TITLE
[rewrite] Revert commenting of `Params` instance in Morphisms from #13969

### DIFF
--- a/test-suite/misc/universes.sh
+++ b/test-suite/misc/universes.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Sort universes for the whole standard library
-EXPECTED_UNIVERSES=3 # Prop is not counted
+EXPECTED_UNIVERSES=4 # Prop is not counted
 $coqc -R misc/universes Universes misc/universes/all_stdlib 2>&1
 $coqc -R misc/universes Universes misc/universes/universes 2>&1
 mv universes.txt misc/universes

--- a/theories/Classes/Morphisms.v
+++ b/theories/Classes/Morphisms.v
@@ -547,10 +547,10 @@ Class PartialApplication.
 CoInductive normalization_done : Prop := did_normalization.
 
 Class Params {A : Type} (of : A) (arity : nat).
-(* #[global] Instance eq_pars : Params (@eq) 1 := {}.
+#[global] Instance eq_pars : Params (@eq) 1 := {}.
 #[global] Instance iff_pars : Params (@iff) 0 := {}.
 #[global] Instance impl_pars : Params (@impl) 0 := {}.
-#[global] Instance flip_pars : Params (@flip) 3 := {}. *)
+#[global] Instance flip_pars : Params (@flip) 4 := {}.
 
 Ltac partial_application_tactic :=
   let rec do_partial_apps H m cont := 


### PR DESCRIPTION
This fixes an unintentional commenting of the `Params` instances from Morphisms.v that happened in #13969 ,
which can have an impact on setoid_rewrite's performance.
