### PR TITLE
Remove O(n*n) runtime for unicode -> byte offset conversion

### DIFF
--- a/ide/coqide/ideutils.ml
+++ b/ide/coqide/ideutils.ml
@@ -162,6 +162,7 @@ let byte_offset_to_char_offset s byte_offset =
   done;
   byte_offset - !extra_bytes
 
+(* get byte length of a Unicode character *)
 let ulen uni_ch =
   if uni_ch < 0x80 then 1
   else if uni_ch < 0x800 then 2

--- a/ide/coqide/ideutils.mli
+++ b/ide/coqide/ideutils.mli
@@ -19,6 +19,7 @@ val browse_keyword : (string -> unit) -> string -> unit
 val byte_offset_to_char_offset : string -> int -> int
 val byte_off_to_buffer_off : GText.buffer -> int -> int
 val buffer_off_to_byte_off : GText.buffer -> int -> int
+val ulen : int -> int
 
 type timer = { run : ms:int -> callback:(unit->bool) -> unit;
                kill : unit -> unit }


### PR DESCRIPTION
With this change List.v (100KB) takes 6 seconds to run compared to 46 seconds without it.

Fixes: #15786

Let me know what you think.

