### PR TITLE
Cleaner handling of destdir for ocaml plugins

### DIFF
--- a/doc/changelog/08-cli-tools/15788-nix_coqmakefile.rst
+++ b/doc/changelog/08-cli-tools/15788-nix_coqmakefile.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  coq_makefile variable `COQPLUGININSTALL` to configure the installation of ML plugins
+  (`#15788 <https://github.com/coq/coq/pull/15788>`_,
+  by Cyril Cohen and Enrico Tassi).

--- a/doc/sphinx/practical-tools/utilities.rst
+++ b/doc/sphinx/practical-tools/utilities.rst
@@ -305,10 +305,10 @@ section of the generated makefile. These include:
    override the flags passed to ``coqdoc``. By default ``-interpolate -utf8``.
 :COQDOCEXTRAFLAGS:
    extend the flags passed to ``coqdoc``
-:COQLIBINSTALL, COQDOCINSTALL:
-   specify where the Coq libraries and documentation will be installed.
+:COQLIBINSTALL, COQPLUGININSTALL, COQDOCINSTALL:
+   specify where the Coq libraries, plugins and documentation will be installed.
    By default a combination of ``$(DESTDIR)`` (if defined) with
-   ``$(COQLIB)/user-contrib`` and ``$(DOCDIR)/user-contrib``.
+   ``$(COQLIB)/user-contrib``, ``$(COQCORELIB)/..`` and ``$(DOCDIR)/coq/user-contrib``.
 
 Use :ref:`coqmakefilelocallate` instead to access more variables.
 

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -161,14 +161,21 @@ ifdef DSTROOT
 DESTDIR := $(DSTROOT)
 endif
 
+# Substitution of the path by appending $(DESTDIR) if needed.
+# The variable $(COQMF_WINDRIVE) can be needed for Cygwin environments.
+windrive_path = $(if $(COQMF_WINDRIVE),$(subst $(COQMF_WINDRIVE),/,$(1)),$(1))
+destination_path = $(if $(DESTDIR),$(DESTDIR)/$(call windrive_path,$(1)),$(1))
+
+# Installation paths of libraries and documentation.
+COQLIBINSTALL ?= $(call destination_path,$(COQLIB)/user-contrib)
+COQDOCINSTALL ?= $(call destination_path,$(DOCDIR)/coq/user-contrib)
+COQPLUGININSTALL ?= $(call destination_path,$(COQCORELIB)/..)
+COQTOPINSTALL ?= $(call destination_path,$(COQLIB)/toploop) # FIXME: Unused variable?
+
 # findlib files installation
-ifeq ($(DESTDIR),)
-FINDLIBPREINST= true
-FINDLIBDESTDIR= -destdir "$(COQCORELIB)/../"
-else
-FINDLIBPREINST= mkdir -p "$(DESTDIR)/$(COQCORELIB)/../"
-FINDLIBDESTDIR= -destdir "$(DESTDIR)/$(COQCORELIB)/../"
-endif
+FINDLIBPREINST= mkdir -p "$(COQPLUGININSTALL)/"
+FINDLIBDESTDIR= -destdir "$(COQPLUGININSTALL)/"
+
 # we need to move out of sight $(METAFILE) otherwise findlib thinks the
 # package is already installed
 findlib_install = \
@@ -185,15 +192,6 @@ findlib_remove = \
 	  "$(OCAMLFIND)" remove $(FINDLIBDESTDIR) $(FINDLIBPACKAGE); \
 	fi
 
-# Substitution of the path by appending $(DESTDIR) if needed.
-# The variable $(COQMF_WINDRIVE) can be needed for Cygwin environments.
-windrive_path = $(if $(COQMF_WINDRIVE),$(subst $(COQMF_WINDRIVE),/,$(1)),$(1))
-destination_path = $(if $(DESTDIR),$(DESTDIR)/$(call windrive_path,$(1)),$(1))
-
-# Installation paths of libraries and documentation.
-COQLIBINSTALL ?= $(call destination_path,$(COQLIB)/user-contrib)
-COQDOCINSTALL ?= $(call destination_path,$(DOCDIR)/coq/user-contrib)
-COQTOPINSTALL ?= $(call destination_path,$(COQLIB)/toploop) # FIXME: Unused variable?
 
 ########## End of parameters ##################################################
 # What follows may be relevant to you only if you need to


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->

Adding a new `CoqMakefile.in` variable to configure the installation of ML plugins.
This makes the nix `mkCoqDerivation` cleaner. (Link to the nixpkgs issue upcomming)

CC @gares

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make -f Makefile.dune doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md