### PR TITLE
[coercions] Remove uniform inheritance condition

### DIFF
--- a/doc/changelog/02-specification-language/15789-coercions-no-uniform-cond.rst
+++ b/doc/changelog/02-specification-language/15789-coercions-no-uniform-cond.rst
@@ -1,0 +1,13 @@
+- **Added:**
+  support for coercions not fulfilling
+  the uniform inheritance condition,
+  allowing more freedom for the parameters that are now inferred
+  using unification, canonical structures or typeclasses
+  (`#15789 <https://github.com/coq/coq/pull/15789>`_,
+  fixes `#2828 <https://github.com/coq/coq/issues/2828>`_,
+  `#4593 <https://github.com/coq/coq/issues/4593>`_,
+  `#3115 <https://github.com/coq/coq/issues/3115>`_,
+  `#5222 <https://github.com/coq/coq/issues/5222>`_,
+  `#9696 <https://github.com/coq/coq/issues/9696>`_
+  and `#8540 <https://github.com/coq/coq/issues/8540>`_,
+  by Pierre Roux, reviewed by Ali Caglayan, Enrico Tassi, Kazuhiko Sakaguchi and Jim Fehrle).

--- a/doc/sphinx/addendum/implicit-coercions.rst
+++ b/doc/sphinx/addendum/implicit-coercions.rst
@@ -56,51 +56,39 @@ A name ``f`` can be declared as a coercion between a source user-defined class
 conditions holds:
 
  * ``D`` is a user-defined class, then the type of ``f`` must have the form
-   :g:`forall (x₁:A₁)..(xₙ:Aₙ)(y:C x₁..xₙ), D u₁..uₘ` where :math:`m`
+   :g:`forall (x₁:A₁)..(xₖ:Aₖ)(y:C v₁..vₙ), D u₁..uₘ` where :math:`m`
    is the number of parameters of ``D``.
  * ``D`` is ``Funclass``, then the type of ``f`` must have the form
-   :g:`forall (x₁:A₁)..(xₙ:Aₙ)(y:C x₁..xₙ)(x:A), B`.
+   :g:`forall (x₁:A₁)..(xₖ:Aₖ)(y:C v₁..vₙ)(x:A), B`.
  * ``D`` is ``Sortclass``, then the type of ``f`` must have the form
-   :g:`forall (x₁:A₁)..(xₙ:Aₙ)(y:C x₁..xₙ), s` with ``s`` a sort.
+   :g:`forall (x₁:A₁)..(xₖ:Aₖ)(y:C v₁..vₙ), s` with ``s`` a sort.
 
-We then write :g:`f : C >-> D`. The restriction on the type
-of coercions is called *the uniform inheritance condition*.
+We then write :g:`f : C >-> D`.
+
+.. _ambiguous-paths:
+
+When you declare a new coercion (e.g. with :cmd:`Coercion`), new coercion
+paths with the same classes as existing ones are ignored. Coq will generate
+a warning when the two paths may be non convertible. When the :g:`x₁..xₖ` are exactly
+the :g:`v₁..vₙ` (in the same order), the coercion is said to satisfy
+the :gdef:`uniform inheritance condition`. When possible, we recommend
+using coercions that satisfy this condition. This guarantees that
+no spurious warning will be generated.
 
 .. note:: The built-in class ``Sortclass`` can be used as a source class, but
           the built-in class ``Funclass`` cannot.
 
 To coerce an object :g:`t:C t₁..tₙ` of ``C`` towards ``D``, we have to
-apply the coercion ``f`` to it; the obtained term :g:`f t₁..tₙ t` is
+apply the coercion ``f`` to it; the obtained term :g:`f _.._ t` is
 then an object of ``D``.
 
 
 Identity Coercions
 -------------------
 
-Identity coercions are special cases of coercions used to go around
-the uniform inheritance condition. Let ``C`` and ``D`` be two classes
-with respectively `n` and `m` parameters and
-:g:`f:forall (x₁:T₁)..(xₖ:Tₖ)(y:C u₁..uₙ), D v₁..vₘ` a function which
-does not verify the uniform inheritance condition. To declare ``f`` as
-coercion, one has first to declare a subclass ``C'`` of ``C``:
-
-  :g:`C' := fun (x₁:T₁)..(xₖ:Tₖ) => C u₁..uₙ`
-
-We then define an *identity coercion* between ``C'`` and ``C``:
-
-  :g:`Id_C'_C  := fun (x₁:T₁)..(xₖ:Tₖ)(y:C' x₁..xₖ) => (y:C u₁..uₙ)`
-
-We can now declare ``f`` as coercion from ``C'`` to ``D``, since we can
-"cast" its type as
-:g:`forall (x₁:T₁)..(xₖ:Tₖ)(y:C' x₁..xₖ),D v₁..vₘ`.
-
-The identity coercions have a special status: to coerce an object
-:g:`t:C' t₁..tₖ`
-of ``C'`` towards ``C``, we do not have to insert explicitly ``Id_C'_C``
-since :g:`Id_C'_C t₁..tₖ t` is convertible with ``t``.  However we
-"rewrite" the type of ``t`` to become an object of ``C``; in this case,
-it becomes :g:`C uₙ'..uₖ'` where each ``uᵢ'`` is the result of the
-substitution in ``uᵢ`` of the variables ``xⱼ`` by ``tⱼ``.
+To make coercions work for both a named class and for
+``Sortclass`` or ``Funclass``, use the :cmd:`Identity Coercion` command.
+There is an example :ref:`here <example-identity-coercion>`.
 
 Inheritance Graph
 ------------------
@@ -152,25 +140,25 @@ Declaring Coercions
   .. exn:: Cannot recognize @class as a source class of @qualid.
      :undocumented:
 
-  .. warn:: @qualid does not respect the uniform inheritance condition.
-     :undocumented:
-
   .. exn:: Found target class ... instead of ...
      :undocumented:
 
+  .. warn:: @qualid does not respect the uniform inheritance condition.
+
+     The :ref:`test for ambiguous coercion paths <ambiguous-paths>`
+     may yield false positives involving the coercion :token:`qualid`.
+
   .. warn:: New coercion path ... is ambiguous with existing ...
 
-     When the coercion :token:`qualid` is added to the inheritance graph, new
-     coercion paths which have the same classes as existing ones are ignored.
-     The :cmd:`Coercion` command tries to check the convertibility of new ones and
-     existing ones. The paths for which this check fails are displayed by a warning
+     The check for :ref:`ambiguous paths <ambiguous-paths>` failed.
+     The paths for which this check fails are displayed by a warning
      in the form :g:`[f₁;..;fₙ] : C >-> D`.
 
      The convertibility checking procedure for coercion paths is complete for
-     paths consisting of coercions satisfying the uniform inheritance condition,
+     paths consisting of coercions satisfying the :term:`uniform inheritance condition`,
      but some coercion paths could be reported as ambiguous even if they are
      convertible with existing ones when they have coercions that don't satisfy
-     the uniform inheritance condition.
+     this condition.
 
   .. warn:: ... is not definitionally an identity function.
 
@@ -193,6 +181,7 @@ Use :n:`:>` instead of :n:`:` before the
    number of parameters of ``D``.  Then we define an identity
    function with type :g:`forall (x₁:T₁)..(xₙ:Tₙ)(y:C x₁..xₙ),D t₁..tₘ`,
    and we declare it as an identity coercion between ``C`` and ``D``.
+   See below for an :ref:`example <example-identity-coercion>`.
 
    This command supports the :attr:`local` attribute, which makes the coercion local to the current section.
 
@@ -254,9 +243,8 @@ Classes as Records
 *Structures with Inheritance* may be defined using the :cmd:`Record` command.
 
 Use `>` before the record name to declare the constructor name as
-a coercion from the class of the last field type to the record name
-(this may fail if the uniform inheritance condition is not
-satisfied).  See :token:`record_definition`.
+a coercion from the class of the last field type to the record name.
+See :token:`record_definition`.
 
 Use `:>` in the field type to declare the field as a coercion from the record name
 to the class of the field type.  See :token:`of_type`.
@@ -269,8 +257,7 @@ mechanism. The global classes and coercions defined inside a section
 are redefined after its closing, using their new value and new
 type. The classes and coercions which are local to the section are
 simply forgotten.
-Coercions with a local source class or a local target class, and
-coercions which do not verify the uniform inheritance condition any longer
+Coercions with a local source class or a local target class
 are also forgotten.
 
 Coercions and Modules
@@ -325,20 +312,6 @@ We give an example of coercion between classes with parameters.
   Set Printing Coercions.
   Check (T c).
   Unset Printing Coercions.
-
-We give now an example using identity coercions.
-
-.. coqtop:: all
-
-  Definition D' (b:bool) := D 1 b.
-  Identity Coercion IdD'D : D' >-> D.
-  Print IdD'D.
-  Parameter d' : D' true.
-  Check (T d').
-  Set Printing Coercions.
-  Check (T d').
-  Unset Printing Coercions.
-
 
 In the case of functional arguments, we use the monotonic rule of
 sub-typing. To coerce :g:`t : forall x : A, B` towards
@@ -413,6 +386,32 @@ coercion path between ``A`` and ``Funclass`` if it exists.
   Set Printing Coercions.
   Check (b 0).
   Unset Printing Coercions.
+
+.. _example-identity-coercion:
+
+.. example:: Identity coercions.
+
+  .. coqtop:: in
+
+    Definition fct := nat -> nat.
+    Parameter incr_fct : Set.
+    Parameter fct_of_incr_fct : incr_fct -> fct.
+
+  .. coqtop:: all
+
+    Fail Coercion fct_of_incr_fct : incr_fct >-> Funclass.
+
+  .. coqtop:: in
+
+    Coercion fct_of_incr_fct : incr_fct >-> fct.
+    Parameter f' : incr_fct.
+
+  .. coqtop:: all
+
+    Check f' : fct.
+    Fail Check f' 0.
+    Identity Coercion Id_fct_Funclass : fct >-> Funclass.
+    Check f' 0.
 
 Let us see the resulting graph after all these examples.
 

--- a/doc/sphinx/addendum/implicit-coercions.rst
+++ b/doc/sphinx/addendum/implicit-coercions.rst
@@ -271,121 +271,115 @@ Examples
 
 There are three situations:
 
-Coercion at function application
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. example:: Coercion at function application
 
-:g:`f a` is ill-typed where :g:`f:forall x:A,B` and :g:`a:A'`. If there is a
-coercion path between ``A'`` and ``A``, then :g:`f a` is transformed into
-:g:`f a'` where ``a'`` is the result of the application of this
-coercion path to ``a``.
+  :g:`f a` is ill-typed where :g:`f:forall x:A,B` and :g:`a:A'`. If there is a
+  coercion path between ``A'`` and ``A``, then :g:`f a` is transformed into
+  :g:`f a'` where ``a'`` is the result of the application of this
+  coercion path to ``a``.
 
-We first give an example of coercion between atomic inductive types
+  We first give an example of coercion between atomic inductive types
 
-.. coqtop:: all
+  .. coqtop:: all
 
-  Definition bool_in_nat (b:bool) := if b then 0 else 1.
-  Coercion bool_in_nat : bool >-> nat.
-  Check (0 = true).
-  Set Printing Coercions.
-  Check (0 = true).
-  Unset Printing Coercions.
+    Definition bool_in_nat (b:bool) := if b then 0 else 1.
+    Coercion bool_in_nat : bool >-> nat.
+    Check (0 = true).
+    Set Printing Coercions.
+    Check (0 = true).
+    Unset Printing Coercions.
 
+  .. warning::
 
-.. warning::
+    Note that ``Check (true = O)`` would fail. This is "normal" behavior of
+    coercions. To validate ``true=O``, the coercion is searched from
+    ``nat`` to ``bool``. There is none.
 
-  Note that ``Check (true = O)`` would fail. This is "normal" behavior of
-  coercions. To validate ``true=O``, the coercion is searched from
-  ``nat`` to ``bool``. There is none.
+  We give an example of coercion between classes with parameters.
 
-We give an example of coercion between classes with parameters.
+  .. coqtop:: all
 
-.. coqtop:: all
+    Parameters (C : nat -> Set) (D : nat -> bool -> Set) (E : bool -> Set).
+    Parameter f : forall n:nat, C n -> D (S n) true.
+    Coercion f : C >-> D.
+    Parameter g : forall (n:nat) (b:bool), D n b -> E b.
+    Coercion g : D >-> E.
+    Parameter c : C 0.
+    Parameter T : E true -> nat.
+    Check (T c).
+    Set Printing Coercions.
+    Check (T c).
+    Unset Printing Coercions.
 
-  Parameters (C : nat -> Set) (D : nat -> bool -> Set) (E : bool -> Set).
-  Parameter f : forall n:nat, C n -> D (S n) true.
-  Coercion f : C >-> D.
-  Parameter g : forall (n:nat) (b:bool), D n b -> E b.
-  Coercion g : D >-> E.
-  Parameter c : C 0.
-  Parameter T : E true -> nat.
-  Check (T c).
-  Set Printing Coercions.
-  Check (T c).
-  Unset Printing Coercions.
+  In the case of functional arguments, we use the monotonic rule of
+  sub-typing. To coerce :g:`t : forall x : A, B` towards
+  :g:`forall x : A', B'`, we have to coerce ``A'`` towards ``A`` and ``B``
+  towards ``B'``. An example is given below:
 
-In the case of functional arguments, we use the monotonic rule of
-sub-typing. To coerce :g:`t : forall x : A, B` towards
-:g:`forall x : A', B'`, we have to coerce ``A'`` towards ``A`` and ``B``
-towards ``B'``. An example is given below:
+  .. coqtop:: all
 
-.. coqtop:: all
+    Parameters (A B : Set) (h : A -> B).
+    Coercion h : A >-> B.
+    Parameter U : (A -> E true) -> nat.
+    Parameter t : B -> C 0.
+    Check (U t).
+    Set Printing Coercions.
+    Check (U t).
+    Unset Printing Coercions.
 
-  Parameters (A B : Set) (h : A -> B).
-  Coercion h : A >-> B.
-  Parameter U : (A -> E true) -> nat.
-  Parameter t : B -> C 0.
-  Check (U t).
-  Set Printing Coercions.
-  Check (U t).
-  Unset Printing Coercions.
+  Remark the changes in the result following the modification of the
+  previous example.
 
-Remark the changes in the result following the modification of the
-previous example.
+  .. coqtop:: all
 
-.. coqtop:: all
+    Parameter U' : (C 0 -> B) -> nat.
+    Parameter t' : E true -> A.
+    Check (U' t').
+    Set Printing Coercions.
+    Check (U' t').
+    Unset Printing Coercions.
 
-  Parameter U' : (C 0 -> B) -> nat.
-  Parameter t' : E true -> A.
-  Check (U' t').
-  Set Printing Coercions.
-  Check (U' t').
-  Unset Printing Coercions.
+.. example:: Coercion to a type
 
+  An assumption ``x:A`` when ``A`` is not a type, is ill-typed.  It is
+  replaced by ``x:A'`` where ``A'`` is the result of the application to
+  ``A`` of the coercion path between the class of ``A`` and
+  ``Sortclass`` if it exists.  This case occurs in the abstraction
+  :g:`fun x:A => t`, universal quantification :g:`forall x:A,B`, global
+  variables and parameters of (co)inductive definitions and
+  functions. In :g:`forall x:A,B`, such a coercion path may also be applied
+  to ``B`` if necessary.
 
-Coercion to a type
-~~~~~~~~~~~~~~~~~~
+  .. coqtop:: all
 
-An assumption ``x:A`` when ``A`` is not a type, is ill-typed.  It is
-replaced by ``x:A'`` where ``A'`` is the result of the application to
-``A`` of the coercion path between the class of ``A`` and
-``Sortclass`` if it exists.  This case occurs in the abstraction
-:g:`fun x:A => t`, universal quantification :g:`forall x:A,B`, global
-variables and parameters of (co)inductive definitions and
-functions. In :g:`forall x:A,B`, such a coercion path may also be applied
-to ``B`` if necessary.
+    Parameter Graph : Type.
+    Parameter Node : Graph -> Type.
+    Coercion Node : Graph >-> Sortclass.
+    Parameter G : Graph.
+    Parameter Arrows : G -> G -> Type.
+    Check Arrows.
+    Parameter fg : G -> G.
+    Check fg.
+    Set Printing Coercions.
+    Check fg.
+    Unset Printing Coercions.
 
-.. coqtop:: all
+.. example:: Coercion to a function
 
-  Parameter Graph : Type.
-  Parameter Node : Graph -> Type.
-  Coercion Node : Graph >-> Sortclass.
-  Parameter G : Graph.
-  Parameter Arrows : G -> G -> Type.
-  Check Arrows.
-  Parameter fg : G -> G.
-  Check fg.
-  Set Printing Coercions.
-  Check fg.
-  Unset Printing Coercions.
+  ``f a`` is ill-typed because ``f:A`` is not a function. The term
+  ``f`` is replaced by the term obtained by applying to ``f`` the
+  coercion path between ``A`` and ``Funclass`` if it exists.
 
+  .. coqtop:: all
 
-Coercion to a function
-~~~~~~~~~~~~~~~~~~~~~~
-
-``f a`` is ill-typed because ``f:A`` is not a function. The term
-``f`` is replaced by the term obtained by applying to ``f`` the
-coercion path between ``A`` and ``Funclass`` if it exists.
-
-.. coqtop:: all
-
-  Parameter bij : Set -> Set -> Set.
-  Parameter ap : forall A B:Set, bij A B -> A -> B.
-  Coercion ap : bij >-> Funclass.
-  Parameter b : bij nat nat.
-  Check (b 0).
-  Set Printing Coercions.
-  Check (b 0).
-  Unset Printing Coercions.
+    Parameter bij : Set -> Set -> Set.
+    Parameter ap : forall A B:Set, bij A B -> A -> B.
+    Coercion ap : bij >-> Funclass.
+    Parameter b : bij nat nat.
+    Check (b 0).
+    Set Printing Coercions.
+    Check (b 0).
+    Unset Printing Coercions.
 
 .. _example-identity-coercion:
 
@@ -413,8 +407,10 @@ coercion path between ``A`` and ``Funclass`` if it exists.
     Identity Coercion Id_fct_Funclass : fct >-> Funclass.
     Check f' 0.
 
-Let us see the resulting graph after all these examples.
+.. example:: Inheritance Graph
 
-.. coqtop:: all
+  Let us see the resulting graph after all these examples.
 
-  Print Graph.
+  .. coqtop:: all
+
+    Print Graph.

--- a/doc/sphinx/language/core/records.rst
+++ b/doc/sphinx/language/core/records.rst
@@ -45,9 +45,8 @@ Defining record types
 
    :n:`{? > }`
      If specified, the constructor is declared as
-     a coercion from the class of the last field type to the record name
-     (this may fail if the uniform inheritance condition is not
-     satisfied). See :ref:`coercions`.
+     a coercion from the class of the last field type to the record name.
+     See :ref:`coercions`.
 
    :n:`@ident_decl`
      The :n:`@ident` within is the record name.

--- a/pretyping/coercionops.ml
+++ b/pretyping/coercionops.ml
@@ -244,21 +244,19 @@ let apply_on_class_of env sigma t cont =
     let (cl,u,args) = find_class_type env sigma t in
     let { cl_param = n1 } = class_info cl in
     if not (Int.equal (List.length args) n1) then raise Not_found;
-    t, cont cl
+    cont cl
   with Not_found ->
     (* Is it worth to be more incremental on the delta steps? *)
     let t = Tacred.hnf_constr env sigma t in
     let (cl, u, args) = find_class_type env sigma t in
     let { cl_param = n1 } = class_info cl in
     if not (Int.equal (List.length args) n1) then raise Not_found;
-    t, cont cl
+    cont cl
 
-let lookup_path_between env sigma (s,t) =
-  let (s,(t,p)) =
-    apply_on_class_of env sigma s (fun i ->
+let lookup_path_between env sigma ~src:s ~tgt:t =
+  apply_on_class_of env sigma s (fun i ->
       apply_on_class_of env sigma t (fun j ->
-        lookup_path_between_class (i,j))) in
-  (s,t,p)
+          lookup_path_between_class (i,j)))
 
 let lookup_path_to_fun_from env sigma s =
   apply_on_class_of env sigma s lookup_path_to_fun_from_class

--- a/pretyping/coercionops.mli
+++ b/pretyping/coercionops.mli
@@ -79,12 +79,10 @@ val coercion_info : coe_typ -> coe_info_typ
 (** @raise Not_found in the following functions when no path exists *)
 
 val lookup_path_between_class : cl_typ * cl_typ -> inheritance_path
-val lookup_path_between : env -> evar_map -> types * types ->
-      types * types * inheritance_path
-val lookup_path_to_fun_from : env -> evar_map -> types ->
-      types * inheritance_path
-val lookup_path_to_sort_from : env -> evar_map -> types ->
-      types * inheritance_path
+val lookup_path_between : env -> evar_map -> src:types -> tgt:types ->
+  inheritance_path
+val lookup_path_to_fun_from : env -> evar_map -> types -> inheritance_path
+val lookup_path_to_sort_from : env -> evar_map -> types -> inheritance_path
 val lookup_pattern_path_between :
   env -> inductive * inductive -> (constructor * int) list
 

--- a/test-suite/bugs/bug_2828.v
+++ b/test-suite/bugs/bug_2828.v
@@ -1,5 +1,5 @@
 Parameter A B : Type.
 Coercion POL (p : prod A B) := fst p.
 Goal forall x : prod A B, A.
-  intro x. Fail exact x.
+  intro x. exact x.
 Abort.

--- a/test-suite/bugs/bug_3115.v
+++ b/test-suite/bugs/bug_3115.v
@@ -1,0 +1,18 @@
+Axioms A B : Type -> Type.
+Axiom f : A nat -> B Type.
+
+Definition A' := A nat.
+Definition f' : A' -> B Type := f.
+Coercion f' : A' >-> B.
+Check (_ : A nat) : A'.
+Fail Check (_ : A nat) : B Type. (* The term "?11:A nat" has type "A nat" while it is expected to have type "B Type". *)
+Check ((_ : A nat) : A') : B Type. (* ((?11:A nat):A'):B Type *)
+
+Fail Identity Coercion f'_id : A >-> A'. (* Error: in build_id_coercion: A must be a transparent constant. *)
+Identity Coercion f'_id : A' >-> A.
+
+Fail Check (_ : A nat) : B Type. (* The term "?11:A nat" has type "A nat" while it is expected to have type "B Type". *)
+
+Coercion f : A >-> B. (* Warning: f does not respect the uniform inheritance condition *)
+
+Check (_ : A nat) : B Type. (* Anomaly: apply_coercion_args. Please report. *)

--- a/test-suite/bugs/bug_4593.v
+++ b/test-suite/bugs/bug_4593.v
@@ -1,0 +1,7 @@
+Class Funext := {}.
+
+Axioms A B : Type.
+Axiom f : forall {_ : Funext}, A -> B.
+Coercion f : A >-> B.
+
+Definition f' {_ : Funext} (a : A) : B := a.

--- a/test-suite/bugs/bug_9696.v
+++ b/test-suite/bugs/bug_9696.v
@@ -1,0 +1,3 @@
+Axiom f : forall {A}, option (option A) -> list A.
+Coercion f : option >-> list.
+Check (Some (Some 0) : list nat).

--- a/test-suite/output/bug_5222.out
+++ b/test-suite/output/bug_5222.out
@@ -1,0 +1,11 @@
+1 goal
+  
+  ============================
+  True = (nil : T1 nat)
+File "./output/bug_5222.v", line 16, characters 2-40:
+Warning: C2 does not respect the uniform inheritance condition.
+[uniform-inheritance,typechecker]
+1 goal
+  
+  ============================
+  True = (nil : T2 nat)

--- a/test-suite/output/bug_5222.v
+++ b/test-suite/output/bug_5222.v
@@ -1,0 +1,23 @@
+(* coq-prog-args: ("-async-proofs" "off") *)
+
+Definition T1 (X : Type) : Type := list X.
+Coercion C1 (X: Type) (A : T1 X) : Prop := True.
+(* Works fine. *)
+
+Goal True = (nil : T1 nat).
+Proof.
+  Show.
+  trivial.
+Qed.
+
+Definition T2 (X : Type) : Type := list X.
+Section S.
+  Context (X : Type).
+  Coercion C2 (A : T2 X) : Prop := True.
+End S.
+
+Goal True = (nil : T2 nat).     (* The coercion works... *)
+Proof.
+  Show.
+  trivial.
+Qed.

--- a/test-suite/output/coercions_cs.out
+++ b/test-suite/output/coercions_cs.out
@@ -1,0 +1,6 @@
+f foo_nat x : T2 nat
+     : T2 nat
+f (foo_A nat ?n) x : T2 nat
+     : T2 nat
+where
+?n : [ |- nat]

--- a/test-suite/output/coercions_cs.v
+++ b/test-suite/output/coercions_cs.v
@@ -1,0 +1,26 @@
+Set Warnings "-uniform-inheritance".
+Set Printing All.
+
+Module CS.
+
+Structure foo := { sort :> Type; a : sort }.
+
+Axiom T1 : Type -> Type.
+Axiom T2 : Type -> Type.
+Axiom x : T1 nat.
+
+Module T1.
+Axiom f : forall A : foo, T1 (sort A) -> T2 nat.
+#[canonical] Definition foo_nat := {| sort := nat; a := 1 |}.
+Coercion f : T1 >-> T2.
+Check (x : T2 _).
+End T1.
+
+Module T2.
+Axiom f : forall A : foo, T1 (sort A) -> T2 nat.
+#[canonical] Definition foo_A A x := {| sort := A; a := x |}.
+Coercion f : T1 >-> T2.
+Check (f _ x : T2 _).
+End T2.
+
+End CS.

--- a/test-suite/output/coercions_tc.out
+++ b/test-suite/output/coercions_tc.out
@@ -1,0 +1,9 @@
+f nat (pair_foo nat bool nat_foo bool_foo) x : T2 nat
+     : T2 nat
+f ?T ?f x : T2 ?T
+     : T2 ?T
+where
+?T : [ |- Type]
+?f : [ |- foo ?T]
+f bool bool_foo x : T2 bool
+     : T2 bool

--- a/test-suite/output/coercions_tc.v
+++ b/test-suite/output/coercions_tc.v
@@ -1,0 +1,30 @@
+Set Warnings "-uniform-inheritance".
+Set Printing All.
+
+Module TC.
+
+Class foo (A : Type) := { a : A }.
+#[local] Hint Mode foo + : typeclass_instances.
+
+#[local] Instance bool_foo : foo bool := {| a := true |}.
+#[local] Instance nat_foo : foo nat := {| a := 1 |}.
+#[local] Instance pair_foo A B : foo A -> foo B -> foo (A * B) := fun x y => {| a := (a,a) |}.
+
+Axiom T1 : Type -> Type.
+Axiom T2 : Type -> Type.
+Axiom x : T1 nat.
+
+Module T1.
+Axiom f : forall A, foo (A * bool) -> T1 A -> T2 nat.
+Coercion f : T1 >-> T2.
+Check (x : T2 _).
+End T1.
+
+Module T2.
+Axiom f : forall A, foo A -> T1 nat -> T2 A.
+Coercion f : T1 >-> T2.
+Check (x : T2 _).
+Check (x : T2 bool).
+End T2.
+
+End TC.

--- a/vernac/comCoercion.ml
+++ b/vernac/comCoercion.ml
@@ -299,7 +299,7 @@ let warn_uniform_inheritance =
   CWarnings.create ~name:"uniform-inheritance" ~category:"typechecker"
          (fun g ->
           Printer.pr_global g ++
-            strbrk" does not respect the uniform inheritance condition")
+            strbrk" does not respect the uniform inheritance condition.")
 
 let add_new_coercion_core coef stre poly source target isid : unit =
   check_source source;
@@ -332,7 +332,8 @@ let add_new_coercion_core coef stre poly source target isid : unit =
   | `LOCAL -> true
   | `GLOBAL -> false
   in
-  declare_coercion coef t ~local ~isid ~src:cls ~target:clt ~params:(List.length lvs) ()
+  let params = List.length (Context.Rel.instance_list EConstr.mkRel 0 ctx) in
+  declare_coercion coef t ~local ~isid ~src:cls ~target:clt ~params ()
 
 
 let try_add_new_coercion_core ref ~local c d e f =


### PR DESCRIPTION
This follows a discussion on Zulip: https://coq.zulipchat.com/#narrow/stream/237977-Coq-users/topic/Identity.20Coercions
This removes the uniform inheritance condition by using inference (mostly unification, but also canonical structures or typeclasses) to obtain the parameters of coercions.


* Fixes: https://github.com/coq/coq/issues/2828
* Fixes: https://github.com/coq/coq/issues/4593
* Fixes: https://github.com/coq/coq/issues/3115
* Fixes: https://github.com/coq/coq/issues/5222
* Fixes: https://github.com/coq/coq/issues/9696
* Fixes: https://github.com/coq/coq/issues/8540
* (and maybe others?)

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
- [x] Added / updated **documentation**.

Will conflict with https://github.com/coq/coq/pull/15693 I could rebase whichever is not merged first.

Overlay (should be merged before merging the current PR):
* https://github.com/UniMath/UniMath/pull/1469