### PR TITLE
Improve performance of byte offset -> unicode conversion

### DIFF
--- a/ide/coqide/coqOps.ml
+++ b/ide/coqide/coqOps.ml
@@ -541,6 +541,11 @@ object(self)
   method set_debug_goal msg =
     proof#set_debug_goal msg
 
+  method private check_last_b2c_offsets sentence =
+   let s_off = (buffer#get_iter_at_mark sentence.start)#offset in
+   if s_off < (fst !last_b2c_offsets) then
+     last_b2c_offsets := (0,0);
+
   method private process_feedback msg =
     (* Minilib.log ("Feedback received: " ^ Xml_printer.to_string_fmt Xmlprotocol.(of_feedback Ppcmds msg)); *)
     let pr_feedback msg =
@@ -579,6 +584,7 @@ object(self)
       | Processed, None ->  msg_wo_sent "Processed"
       | ProcessingIn _,  Some (id,sentence) ->
           log ?id "ProcessingIn";
+          self#check_last_b2c_offsets sentence;
           add_flag sentence `PROCESSING;
           self#mark_as_needed sentence
       | ProcessingIn _, None ->  msg_wo_sent "ProcessingIn"
@@ -772,6 +778,7 @@ object(self)
             loop tip topstack
         | `Sentence sentence, _ :: _ -> assert false
         | `Sentence ({ edit_id } as sentence), [] ->
+            self#check_last_b2c_offsets sentence;
             add_flag sentence `PROCESSING;
             Doc.push document sentence;
             let start, _, phrase = self#get_sentence sentence in


### PR DESCRIPTION
With this change Pff.v (1143KB) takes 103 seconds to run compared to 231 seconds without it.

The issue is visible in this file because there are a large number of deprecation warnings.  The warning messages are almost always in monotonically increasing order in the buffer. Due to #15797, a lot of messages are repeated twice.

I also fixed the beginning of line value passed to Coq in `process_queue`.

Let me know what you think.

Related to: #15787 (this PR fixes the #2 time waster)