### PR TITLE
Add a deprecation warning to > in Class 

### DIFF
--- a/doc/changelog/07-vernac-commands-and-options/15802-deprecate_backinstance.rst
+++ b/doc/changelog/07-vernac-commands-and-options/15802-deprecate_backinstance.rst
@@ -1,0 +1,10 @@
+- **Added:**
+  A deprecation warning that :n:`>` in a field of a :cmd:`Class`
+  and the :g:`Class >` syntax will in the future also
+  declare :ref:`coercions <coercions>` as they do when used in
+  :cmd:`Record` commands
+  (`#15802 <https://github.com/coq/coq/pull/15802>`_,
+  addresses `#2643 <https://github.com/coq/coq/issues/2643>`_
+  and `#9014 <https://github.com/coq/coq/issues/9014>`_,
+  by Pierre Roux, reviewed by Gaëtan Gilbert, Ali Caglayan,
+  Jason Gross, Jim Fehrle and Théo Zimmermann).

--- a/doc/sphinx/addendum/type-classes.rst
+++ b/doc/sphinx/addendum/type-classes.rst
@@ -274,23 +274,25 @@ This declares singleton classes for reflexive and transitive relations,
 (see the :ref:`singleton class <singleton-class>` variant for an
 explanation). These may be used as parts of other classes:
 
+.. coqtop:: none
+
+   Set Warnings "-future-coercion-class-field".
+
 .. coqtop:: all
 
    Class PreOrder (A : Type) (R : relation A) :=
      { PreOrder_Reflexive :> Reflexive A R ;
        PreOrder_Transitive :> Transitive A R }.
 
+.. coqtop:: none
+
+   Set Warnings "+future-coercion-class-field".
+
 The syntax ``:>`` indicates that each ``PreOrder`` can be seen as a
 ``Reflexive`` relation. So each time a reflexive relation is needed, a
 preorder can be used instead. This is very similar to the coercion
 mechanism of ``Structure`` declarations. The implementation simply
 declares each projection as an instance.
-
-.. warn:: Ignored instance declaration for “@ident”: “@term” is not a class
-
-   Using this ``:>`` syntax with a right-hand-side that is not itself a Class
-   has no effect (apart from emitting this warning). In particular, is does not
-   declare a coercion.
 
 One can also declare existing objects or structure projections using
 the Existing Instance command to achieve the same effect.
@@ -300,7 +302,7 @@ Summary of the commands
 -----------------------
 
 .. cmd:: Class @record_definition
-         Class {? > } @ident_decl {* @binder } {? : @sort } := @constructor
+         Class @ident_decl {* @binder } {? : @sort } := @constructor
 
    The first form declares a record and makes the record a typeclass with parameters
    :n:`{* @binder }` and the listed record fields.
@@ -318,6 +320,10 @@ Summary of the commands
    declared rigid during resolution so that the class abstraction is
    maintained.
 
+   The `>` in
+   :token:`record_definition` currently does nothing. In a future version, it will
+   create coercions as it does when used in :cmd:`Record` commands.
+
    Like any command declaring a record, this command supports the
    :attr:`universes(polymorphic)`, :attr:`universes(template)`,
    :attr:`universes(cumulative)` and :attr:`private(matching)` attributes.
@@ -333,6 +339,22 @@ Summary of the commands
       .. warn:: @ident is already declared as a typeclass
 
          This command has no effect when used on a typeclass.
+
+.. _warn-future-coercion-class-field:
+
+   .. warn:: A coercion will be introduced in future versions when using ':>' in 'Class' declarations. Use '#[global] Existing Instance field.' instead if you don't want the coercion.
+
+      In future versions, :g:`:>` will also
+      declare a :ref:`coercion<coercions>`, as it does
+      for other :cmd:`Record` commands.
+      To eliminate the warning or to avoid creating the coercion
+      in the future, use :cmd:`Existing Instance` or :cmd:`Coercion` separately rather
+      than :g:`:>`.
+
+   .. warn:: Ignored instance declaration for “@ident”: “@term” is not a class
+
+      Using this ``:>`` syntax with a right-hand-side that is not itself a Class
+      has no effect (apart from emitting this warning).
 
 .. cmd:: Instance {? @ident_decl {* @binder } } : @type {? @hint_info } {? {| := %{ {* @field_val } %} | := @term } }
 

--- a/doc/sphinx/language/core/records.rst
+++ b/doc/sphinx/language/core/records.rst
@@ -88,6 +88,12 @@ Defining record types
 
    In :n:`@field_spec`:
 
+     :n:`:>` in :n:`@of_type`
+       If specified, the field is declared as a coercion from the record name
+       to the class of the field type. See :ref:`coercions`.
+       Note that this currently does something else in :cmd:`Class` commands.
+       See :ref:`warning in Class <warn-future-coercion-class-field>`.
+
      - :n:`{+ @binder } : @of_type` is equivalent to
        :n:`: forall {+ @binder } , @of_type`
 

--- a/doc/sphinx/language/core/records.rst
+++ b/doc/sphinx/language/core/records.rst
@@ -40,7 +40,7 @@ Defining record types
    See :ref:`proofschemes-induction-principles`.
 
    The :cmd:`Class` command can be used to define records that are also
-   :ref`typeclasses`, which permit Coq to automatically infer the inhabitants of
+   :ref:`typeclasses`, which permit Coq to automatically infer the inhabitants of
    the record.
 
    :n:`{? > }`

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -565,7 +565,7 @@ record_definition: [
 (* No mutual recursion, no inductive classes, type must be a sort *)
 (* constructor is optional but "Class record_definition" covers that case *)
 singleton_class_definition: [
-| opt_coercion ident_decl binders OPT [ ":" sort ] ":=" constructor
+| ident_decl binders OPT [ ":" sort ] ":=" constructor
 ]
 
 (* No record syntax, opt_coercion not supported for Variant, := ... required *)

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1061,7 +1061,7 @@ command: [
 | "Variant" variant_definition
 | [ "Record" | "Structure" ] record_definition
 | "Class" record_definition
-| "Class" OPT ">" ident_decl LIST0 binder OPT [ ":" sort ] ":=" constructor
+| "Class" ident_decl LIST0 binder OPT [ ":" sort ] ":=" constructor
 | "Module" OPT [ "Import" | "Export" ] ident LIST0 module_binder OPT of_module_type OPT ( ":=" LIST1 module_expr_inl SEP "<+" )
 | "Module" "Type" ident LIST0 module_binder LIST0 ( "<:" module_type_inl ) OPT ( ":=" LIST1 module_type_inl SEP "<+" )
 | "Declare" "Module" OPT [ "Import" | "Export" ] ident LIST0 module_binder ":" module_type_inl

--- a/theories/Classes/CRelationClasses.v
+++ b/theories/Classes/CRelationClasses.v
@@ -70,14 +70,18 @@ Section Defs.
   (** A [PreOrder] is both Reflexive and Transitive. *)
 
   Class PreOrder (R : crelation A)  := {
-    PreOrder_Reflexive :> Reflexive R | 2 ;
-    PreOrder_Transitive :> Transitive R | 2 }.
+    PreOrder_Reflexive : Reflexive R | 2 ;
+    PreOrder_Transitive : Transitive R | 2 }.
+  #[global] Existing Instance PreOrder_Reflexive.
+  #[global] Existing Instance PreOrder_Transitive.
 
   (** A [StrictOrder] is both Irreflexive and Transitive. *)
 
   Class StrictOrder (R : crelation A)  := {
-    StrictOrder_Irreflexive :> Irreflexive R ;
-    StrictOrder_Transitive :> Transitive R }.
+    StrictOrder_Irreflexive : Irreflexive R ;
+    StrictOrder_Transitive : Transitive R }.
+  #[global] Existing Instance StrictOrder_Irreflexive.
+  #[global] Existing Instance StrictOrder_Transitive.
 
   (** By definition, a strict order is also asymmetric *)
   Global Instance StrictOrder_Asymmetric `(StrictOrder R) : Asymmetric R.
@@ -86,15 +90,20 @@ Section Defs.
   (** A partial equivalence crelation is Symmetric and Transitive. *)
   
   Class PER (R : crelation A)  := {
-    PER_Symmetric :> Symmetric R | 3 ;
-    PER_Transitive :> Transitive R | 3 }.
+    PER_Symmetric : Symmetric R | 3 ;
+    PER_Transitive : Transitive R | 3 }.
+  #[global] Existing Instance PER_Symmetric.
+  #[global] Existing Instance PER_Transitive.
 
   (** Equivalence crelations. *)
 
   Class Equivalence (R : crelation A)  := {
-    Equivalence_Reflexive :> Reflexive R ;
-    Equivalence_Symmetric :> Symmetric R ;
-    Equivalence_Transitive :> Transitive R }.
+    Equivalence_Reflexive : Reflexive R ;
+    Equivalence_Symmetric : Symmetric R ;
+    Equivalence_Transitive : Transitive R }.
+  #[global] Existing Instance Equivalence_Reflexive.
+  #[global] Existing Instance Equivalence_Symmetric.
+  #[global] Existing Instance Equivalence_Transitive.
 
   (** An Equivalence is a PER plus reflexivity. *)
   

--- a/theories/Classes/RelationClasses.v
+++ b/theories/Classes/RelationClasses.v
@@ -60,14 +60,18 @@ Section Defs.
   (** A [PreOrder] is both Reflexive and Transitive. *)
   
   Class PreOrder (R : relation A) : Prop := {
-    PreOrder_Reflexive :> Reflexive R | 2 ;
-    PreOrder_Transitive :> Transitive R | 2 }.
+    PreOrder_Reflexive : Reflexive R | 2 ;
+    PreOrder_Transitive : Transitive R | 2 }.
+  #[global] Existing Instance PreOrder_Reflexive.
+  #[global] Existing Instance PreOrder_Transitive.
 
   (** A [StrictOrder] is both Irreflexive and Transitive. *)
 
   Class StrictOrder (R : relation A) : Prop := {
-    StrictOrder_Irreflexive :> Irreflexive R ;
-    StrictOrder_Transitive :> Transitive R }.
+    StrictOrder_Irreflexive : Irreflexive R ;
+    StrictOrder_Transitive : Transitive R }.
+  #[global] Existing Instance StrictOrder_Irreflexive.
+  #[global] Existing Instance StrictOrder_Transitive.
 
   (** By definition, a strict order is also asymmetric *)
   Global Instance StrictOrder_Asymmetric `(StrictOrder R) : Asymmetric R.
@@ -76,15 +80,20 @@ Section Defs.
   (** A partial equivalence relation is Symmetric and Transitive. *)
   
   Class PER (R : relation A) : Prop := {
-    PER_Symmetric :> Symmetric R | 3 ;
-    PER_Transitive :> Transitive R | 3 }.
+    PER_Symmetric : Symmetric R | 3 ;
+    PER_Transitive : Transitive R | 3 }.
+  #[global] Existing Instance PER_Symmetric.
+  #[global] Existing Instance PER_Transitive.
 
   (** Equivalence relations. *)
 
   Class Equivalence (R : relation A) : Prop := {
-    Equivalence_Reflexive :> Reflexive R ;
-    Equivalence_Symmetric :> Symmetric R ;
-    Equivalence_Transitive :> Transitive R }.
+    Equivalence_Reflexive : Reflexive R ;
+    Equivalence_Symmetric : Symmetric R ;
+    Equivalence_Transitive : Transitive R }.
+  #[global] Existing Instance Equivalence_Reflexive.
+  #[global] Existing Instance Equivalence_Symmetric.
+  #[global] Existing Instance Equivalence_Transitive.
 
   (** An Equivalence is a PER plus reflexivity. *)
   

--- a/theories/Classes/SetoidClass.v
+++ b/theories/Classes/SetoidClass.v
@@ -29,7 +29,8 @@ Require Export Coq.Classes.Morphisms.
 
 Class Setoid A := {
   equiv : relation A ;
-  setoid_equiv :> Equivalence equiv }.
+  setoid_equiv : Equivalence equiv }.
+#[global] Existing Instance setoid_equiv.
 
 (* Too dangerous instance *)
 (* Program Instance [ eqa : Equivalence A eqA ] =>  *)
@@ -135,7 +136,8 @@ Program Instance setoid_partial_app_morphism `(sa : Setoid A) (x : A) : Proper (
 (** Partial setoids don't require reflexivity so we can build a partial setoid on the function space. *)
 
 Class PartialSetoid (A : Type) :=
-  { pequiv : relation A ; pequiv_prf :> PER pequiv }.
+  { pequiv : relation A ; pequiv_prf : PER pequiv }.
+#[global] Existing Instance pequiv_prf.
 
 (** Overloaded notation for partial setoid equivalence. *)
 

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -913,6 +913,8 @@ let vernac_inductive ~atts kind indl =
       | bl, None -> bl
       | _ -> CErrors.user_err Pp.(str "Definitional classes do not support the \"|\" syntax.")
     in
+    if fst id then
+      user_err Pp.(str "Definitional classes do not support the \">\" syntax.");
     let (coe, (lid, ce)) = l in
     let coe' = if coe then BackInstance else NoInstance in
     let f = AssumExpr ((make ?loc:lid.loc @@ Name lid.v), [], ce),


### PR DESCRIPTION
This follows a discussion in https://github.com/coq/coq/issues/2643

Currently, `field :> field_type`  declares field a coercion in every record declaration, except typeclasses where it is instead declared a typeclass instance. It seems more principled to remove that exception (so in typeclasses, both an instance and a coercion are declared).

This is currently only introducing a warning to start a deprecation phase.

Adresses #2643 #9014

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
- [x] Added / updated **documentation**.

Overlays (backward compatibles, kindly provided but don't need to be merged in sync with the current PR):
* https://github.com/math-comp/analysis/pull/599
* https://github.com/HoTT/HoTT/pull/1640
* https://github.com/mit-plv/fiat/pull/68
* https://github.com/jwiegley/category-theory/pull/27