### PR TITLE
Return the type of the eliminator in case-analysis building functions.

### DIFF
--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -2229,12 +2229,8 @@ let build_case_scheme fa =
     let ind = (first_fun_kn, funs_indexes) in
     ((ind, Univ.Instance.empty) (*FIXME*), prop_sort)
   in
-  let sigma, scheme =
+  let sigma, scheme, scheme_type =
     Indrec.build_case_analysis_scheme_default env sigma ind sf
-  in
-  let scheme_type =
-    EConstr.Unsafe.to_constr
-      ((Retyping.get_type_of env sigma) (EConstr.of_constr scheme))
   in
   let sorts = (fun (_, _, x) -> fst @@ UnivGen.fresh_sort_in_family x) fa in
   let princ_name = (fun (x, _, _) -> x) fa in

--- a/pretyping/indrec.mli
+++ b/pretyping/indrec.mli
@@ -29,13 +29,13 @@ type dep_flag = bool
 (** Build a case analysis elimination scheme in some sort family *)
 
 val build_case_analysis_scheme : env -> Evd.evar_map -> pinductive ->
-      dep_flag -> Sorts.family -> evar_map * Constr.t
+      dep_flag -> Sorts.family -> evar_map * Constr.t * Constr.types
 
 (** Build a dependent case elimination predicate unless type is in Prop
    or is a recursive record with primitive projections. *)
 
 val build_case_analysis_scheme_default : env -> evar_map -> pinductive ->
-      Sorts.family -> evar_map * Constr.t
+      Sorts.family -> evar_map * Constr.t * Constr.types
 
 (** Builds a recursive induction scheme (Peano-induction style) in the same
    sort family as the inductive family; it is dependent if not in Prop

--- a/tactics/elimschemes.ml
+++ b/tactics/elimschemes.ml
@@ -124,7 +124,7 @@ let nondep_elim_scheme from_kind to_kind =
 let build_case_analysis_scheme_in_type env dep sort ind =
   let sigma = Evd.from_env env in
   let (sigma, indu) = Evd.fresh_inductive_instance env sigma ind in
-  let (sigma, c) = build_case_analysis_scheme env sigma indu dep sort in
+  let (sigma, c, _) = build_case_analysis_scheme env sigma indu dep sort in
     c, Evd.evar_universe_context sigma
 
 let case_scheme_kind_from_type =

--- a/tactics/eqschemes.ml
+++ b/tactics/eqschemes.ml
@@ -687,7 +687,7 @@ let fix_r2l_forward_rew_scheme env (c, ctx') =
 let build_r2l_rew_scheme dep env ind k =
   let sigma = Evd.from_env env in
   let (sigma, indu) = Evd.fresh_inductive_instance env sigma ind in
-  let (sigma, c) = build_case_analysis_scheme env sigma indu dep k in
+  let (sigma, c, _) = build_case_analysis_scheme env sigma indu dep k in
     c, Evd.evar_universe_context sigma
 
 (**********************************************************************)


### PR DESCRIPTION
This saves a costly typing of a term that is known to be well-typed. Furthermore, this should also enhance the situation in #10764 w.r.t. the typing of transiently ill-formed coinduction operators.
