### PR TITLE
[coqdep] Refactor initialization API

### DIFF
--- a/tools/coqdep/common.mli
+++ b/tools/coqdep/common.mli
@@ -31,7 +31,6 @@ val option_sort : bool ref
 val option_boot : bool ref
 
 (** ML-related manipulation *)
-val coq_dependencies : unit -> unit
 val add_known : bool -> root -> dirname -> dirpath -> basename -> unit
 val add_coqlib_known : bool -> root -> dirname -> dirpath -> basename -> unit
 
@@ -54,8 +53,26 @@ val sort : unit -> unit
    the list of .v files passed as arguments *)
 val init : string list -> string list
 
-(*  *)
+(** Display the --help documentation *)
 val usage : unit -> unit
 
 (** [treat_file_command_line file] Add an input file to be considered  *)
 val treat_file_command_line : string -> unit
+
+module Dep : sig
+  type t =
+  | Require of string (* one basename, to which we later append .vo or .vio or .vos *)
+  | Other of string   (* filenames of dependencies, separated by spaces *)
+end
+
+module Dep_info : sig
+  type t =
+    { name : string
+    ; deps : Dep.t list
+    }
+
+  (** Print dependencies in makefile format *)
+  val print : Format.formatter -> t -> unit
+end
+
+val compute_deps : unit -> Dep_info.t list

--- a/tools/coqdep/common.mli
+++ b/tools/coqdep/common.mli
@@ -50,5 +50,12 @@ val add_rec_dir_import :
 
 val sort : unit -> unit
 
-(** Init coqdep, including argument parsing *)
-val init : unit -> unit
+(** [init args] Init coqdep, parsing arguments from [args]; returns
+   the list of .v files passed as arguments *)
+val init : string list -> string list
+
+(*  *)
+val usage : unit -> unit
+
+(** [treat_file_command_line file] Add an input file to be considered  *)
+val treat_file_command_line : string -> unit

--- a/tools/coqdep/coqdep.ml
+++ b/tools/coqdep/coqdep.ml
@@ -9,10 +9,15 @@
 (************************************************************************)
 
 (** The basic parts of coqdep are in [Common]. *)
-open Coqdeplib.Common
 
 let coqdep () =
-  init ();
+  let open Coqdeplib.Common in
+
+  (* Initialize coqdep, add files to dependency computation *)
+  if Array.length Sys.argv < 2 then usage ();
+  let v_files = init (List.tl (Array.to_list Sys.argv)) in
+  List.iter treat_file_command_line v_files;
+
   (* XXX: All the code below is just setting loadpaths, refactor to
      Common coq.boot library *)
   (* Add current dir with empty logical path if not set by options above. *)

--- a/tools/coqdep/coqdep.ml
+++ b/tools/coqdep/coqdep.ml
@@ -40,7 +40,7 @@ let coqdep () =
   if !option_sort then
     sort ()
   else
-    coq_dependencies ()
+    compute_deps () |> List.iter (Dep_info.print Format.std_formatter)
 
 let _ =
   try


### PR DESCRIPTION
We move adding the .v files to its own step; and some cleanups in
the way to the way coqdep init process is handled.

We also provide an API to get the dependencies of the files as an OCaml record without having to print them.

This is a step towards being able to use `coqdep` as a library.

Co-authored-by: Ali Caglayan

