### PR TITLE
Bump default OCaml version to 4.12 in Nix setup

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -22,7 +22,7 @@
 # a symlink to where Coq was installed.
 
 { pkgs ? import ./dev/nixpkgs.nix {}
-, ocamlPackages ? pkgs.ocaml-ng.ocamlPackages_4_09
+, ocamlPackages ? pkgs.ocaml-ng.ocamlPackages_4_12
 , buildIde ? true
 , buildDoc ? true
 , doInstallCheck ? true
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
   ]
   ++ optionals buildIde [
     ocamlPackages.lablgtk3-sourceview3
-    glib gnome3.defaultIconTheme wrapGAppsHook
+    glib gnome3.adwaita-icon-theme wrapGAppsHook
   ]
   ++ optionals buildDoc [
     # Sphinx doc dependencies

--- a/dev/nixpkgs.nix
+++ b/dev/nixpkgs.nix
@@ -1,4 +1,4 @@
 import (fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/a6a0964eacef611f364ca22256d6882d8670721c.tar.gz";
-  sha256 = "0h2cv4zdlmf1di55i64vcavc0rfh7cvbnax4wll2vbjj7bahawyc";
+  url = "https://github.com/NixOS/nixpkgs/archive/46e3ed49ec36f341c173331dc788115d6836c7ab.tar.gz";
+  sha256 = "0lr8lry0d3skb287f0wbm46iakr1q7vqqy6y54r9hl2jb3d18z9z";
 })


### PR DESCRIPTION
Using older OCaml versions for developing Coq can give headaches with some
warnings not being emitted locally but being fatal in CI builds. It seems to
make sense to avoid the headaches in the default setup.
