### PR TITLE
Use warn-error for dune dev mode warnings

### DIFF
--- a/dune
+++ b/dune
@@ -1,6 +1,6 @@
 ; Default flags for all Coq libraries.
 (env
- (dev     (flags :standard -rectypes -w -9-27+40+60-70 \ -short-paths))
+ (dev     (flags :standard -rectypes -w -9-27@40@60-70 \ -short-paths))
  (release (flags :standard -rectypes)
           (ocamlopt_flags :standard -O3 -unbox-closures))
  (ireport (flags :standard -rectypes -w -9-27-40+60-70)

--- a/kernel/dune
+++ b/kernel/dune
@@ -30,7 +30,7 @@
 ; In dev profile, we check the kernel against a more strict set of
 ; warnings.
 (env
- (dev (flags :standard -w +a-4-44-50-70)))
+ (dev (flags :standard -w @a-4-44-50-70)))
 
 (deprecated_library_name
  (old_public_name coq.kernel)


### PR DESCRIPTION
I think at some point dune had `-warn-error +a` but now it seems to be
fully control through `-w`.
