### PR TITLE
Make cclosure stats available through Set Debug

### DIFF
--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -15,9 +15,7 @@ open Environ
 open Esubst
 
 (** Flags for profiling reductions. *)
-val stats : bool ref
-
-val with_stats: 'a Lazy.t -> 'a
+val with_stats: whatfor:string -> (unit -> 'a) -> 'a
 
 (** {6 ... } *)
 (** Delta implies all consts (both global (= by

--- a/pretyping/cbv.ml
+++ b/pretyping/cbv.ml
@@ -751,7 +751,7 @@ and cbv_norm_value info = function (* reduction under binders *)
 (* with profiling *)
 let cbv_norm infos constr =
   let constr = EConstr.Unsafe.to_constr constr in
-  EConstr.of_constr (with_stats (lazy (cbv_norm_term infos (subs_id 0) constr)))
+  EConstr.of_constr (with_stats ~whatfor:"cbv" (fun () -> cbv_norm_term infos (subs_id 0) constr))
 
 (* constant bodies are normalized at the first expansion *)
 let create_cbv_infos reds env sigma =

--- a/tactics/cbn.ml
+++ b/tactics/cbn.ml
@@ -837,4 +837,4 @@ let norm_cbn flags env sigma t =
   let rec strongrec env t =
     map_constr_with_full_binders env sigma
       push_rel_check_zeta strongrec env (whd_cbn flags env sigma t) in
-  strongrec env t
+  CClosure.with_stats ~whatfor:"cbn" (fun () -> strongrec env t)


### PR DESCRIPTION
Not sure if saving the stats is useful (ie if we ever call with_stats
in a nested way) but it's easier to do it than to think about it.