### PR TITLE
[coqdep] Allow re-entrant calls to Coqdeplib

### DIFF
--- a/tools/coqdep/common.mli
+++ b/tools/coqdep/common.mli
@@ -15,11 +15,14 @@ val coqdep_warning : ('a, Format.formatter, unit, unit) format4 -> 'a
 (** Options *)
 val option_sort : bool ref
 
-val sort : unit -> unit
+module State : sig
+  type t
+  val loadpath : t -> Loadpath.State.t
+end
 
 (** [init args] Init coqdep, parsing arguments from [args]; returns
    the list of .v files passed as arguments *)
-val init : string list -> string list
+val init : string list -> string list * State.t
 
 (** Display the --help documentation *)
 val usage : unit -> unit
@@ -45,4 +48,6 @@ module Dep_info : sig
   val print : Format.formatter -> t -> unit
 end
 
-val compute_deps : unit -> Dep_info.t list
+val sort : State.t -> unit
+
+val compute_deps : State.t -> Dep_info.t list

--- a/tools/coqdep/coqdep.ml
+++ b/tools/coqdep/coqdep.ml
@@ -16,32 +16,33 @@ let coqdep () =
 
   (* Initialize coqdep, add files to dependency computation *)
   if Array.length Sys.argv < 2 then usage ();
-  let v_files = init (List.tl (Array.to_list Sys.argv)) in
+  let v_files, st = init (List.tl (Array.to_list Sys.argv)) in
+  let lst = Common.State.loadpath st in
   List.iter treat_file_command_line v_files;
 
   (* XXX: All the code below is just setting loadpaths, refactor to
      Common coq.boot library *)
   (* Add current dir with empty logical path if not set by options above. *)
   (try ignore (Loadpath.find_dir_logpath (Sys.getcwd()))
-   with Not_found -> Loadpath.add_norec_dir_import Loadpath.add_known "." []);
+   with Not_found -> Loadpath.add_norec_dir_import (Loadpath.add_known lst) "." []);
   (* We don't setup any loadpath if the -boot is passed *)
   if not !Options.boot then begin
     let env = Boot.Env.init () in
     let stdlib = Boot.Env.(stdlib env |> Path.to_string) in
     let plugins = Boot.Env.(plugins env |> Path.to_string) in
     let user_contrib = Boot.Env.(user_contrib env |> Path.to_string) in
-    Loadpath.add_rec_dir_import Loadpath.add_coqlib_known stdlib ["Coq"];
-    Loadpath.add_rec_dir_import Loadpath.add_coqlib_known plugins ["Coq"];
+    Loadpath.add_rec_dir_import (Loadpath.add_coqlib_known lst) stdlib ["Coq"];
+    Loadpath.add_rec_dir_import (Loadpath.add_coqlib_known lst) plugins ["Coq"];
     if Sys.file_exists user_contrib
-    then Loadpath.add_rec_dir_no_import Loadpath.add_coqlib_known user_contrib [];
-    List.iter (fun s -> Loadpath.add_rec_dir_no_import Loadpath.add_coqlib_known s [])
+    then Loadpath.add_rec_dir_no_import (Loadpath.add_coqlib_known lst) user_contrib [];
+    List.iter (fun s -> Loadpath.add_rec_dir_no_import (Loadpath.add_coqlib_known lst) s [])
       (Envars.xdg_dirs ~warn:(fun x -> coqdep_warning "%s" x));
-    List.iter (fun s -> Loadpath.add_rec_dir_no_import Loadpath.add_coqlib_known s []) Envars.coqpath;
+    List.iter (fun s -> Loadpath.add_rec_dir_no_import (Loadpath.add_coqlib_known lst) s []) Envars.coqpath;
   end;
   if !option_sort then
-    sort ()
+    sort st
   else
-    compute_deps () |> List.iter (Dep_info.print Format.std_formatter)
+    compute_deps st |> List.iter (Dep_info.print Format.std_formatter)
 
 let _ =
   try

--- a/tools/coqdep/loadpath.mli
+++ b/tools/coqdep/loadpath.mli
@@ -25,16 +25,24 @@ type result =
   | ExactMatches of filename list
   | PartialMatchesInSameRoot of root * filename list
 
-val search_v_known : ?from:dirpath -> dirpath -> result option
-val search_other_known : ?from:dirpath -> dirpath -> result option
-val search_mllib_known : string -> dir option
-val search_mlpack_known : string -> dir option
+module State : sig
+  type t
 
-val is_in_coqlib : ?from:dirpath -> dirpath -> bool
+  val make : unit -> t
+end
 
-val add_caml_dir : System.unix_path -> unit
-val add_q_include : System.unix_path -> string -> unit
-val add_r_include : System.unix_path -> string -> unit
+val search_v_known : State.t -> ?from:dirpath -> dirpath -> result option
+val search_other_known : State.t -> ?from:dirpath -> dirpath -> result option
+val search_mllib_known : State.t -> string -> dir option
+val search_mlpack_known : State.t -> string -> dir option
+
+val is_in_coqlib : State.t -> ?from:dirpath -> dirpath -> bool
+
+val add_caml_dir : State.t -> System.unix_path -> unit
+
+val add_current_dir : State.t -> System.unix_path -> unit
+val add_q_include : State.t -> System.unix_path -> string -> unit
+val add_r_include : State.t -> System.unix_path -> string -> unit
 
 (* These should disappear in favor of add_q / add_r *)
 
@@ -51,8 +59,8 @@ val add_rec_dir_no_import :
 val add_rec_dir_import :
   (bool -> root -> dirname -> dirpath -> basename -> unit) -> dirname -> dirpath -> unit
 
-val add_known : bool -> root -> dirname -> dirpath -> basename -> unit
-val add_coqlib_known : bool -> root -> dirname -> dirpath -> basename -> unit
+val add_known : State.t -> bool -> root -> dirname -> dirpath -> basename -> unit
+val add_coqlib_known : State.t -> bool -> root -> dirname -> dirpath -> basename -> unit
 
 (** [find_dir_logpath phys_dir] Return the logical path of directory
    [dir] if it has been given one. Raise [Not_found] otherwise. In


### PR DESCRIPTION
We functionalize enough of coqdep state as to be able to use
`Coqdeplib` as a re-entrant library by other tools.
