### PR TITLE
Reduce Universe.t footprint

### DIFF
--- a/checker/checkInductive.ml
+++ b/checker/checkInductive.ml
@@ -86,7 +86,7 @@ let check_arity env ar1 ar2 = match ar1, ar2 with
     Constr.equal ar.mind_user_arity mind_user_arity &&
     Sorts.equal ar.mind_sort mind_sort
   | TemplateArity ar, TemplateArity {template_level} ->
-    UGraph.check_leq (universes env) (Sorts.univ_of_sort template_level) (Sorts.univ_of_sort ar.template_level)
+    Sorts.check_leq_sort (universes env) template_level ar.template_level
     (* template_level is inferred by indtypes, so functor application can produce a smaller one *)
   | (RegularArity _ | TemplateArity _), _ -> assert false
 

--- a/checker/checkInductive.ml
+++ b/checker/checkInductive.ml
@@ -55,7 +55,7 @@ let to_entry mind (mb:mutual_inductive_body) : Entries.mutual_inductive_entry =
         | TemplateArity ar ->
           let ctx = ind.mind_arity_ctxt in
           let ctx = List.firstn (List.length ctx - nparams) ctx in
-          Term.mkArity (ctx, Sorts.sort_of_univ ar.template_level)
+          Term.mkArity (ctx, ar.template_level)
       in
       {
         mind_entry_typename = ind.mind_typename;
@@ -86,7 +86,7 @@ let check_arity env ar1 ar2 = match ar1, ar2 with
     Constr.equal ar.mind_user_arity mind_user_arity &&
     Sorts.equal ar.mind_sort mind_sort
   | TemplateArity ar, TemplateArity {template_level} ->
-    UGraph.check_leq (universes env) template_level ar.template_level
+    UGraph.check_leq (universes env) (Sorts.univ_of_sort template_level) (Sorts.univ_of_sort ar.template_level)
     (* template_level is inferred by indtypes, so functor application can produce a smaller one *)
   | (RegularArity _ | TemplateArity _), _ -> assert false
 

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -222,7 +222,7 @@ let v_oracle =
   |]
 
 let v_template_arity =
-  v_tuple "template_arity" [|v_univ|]
+  v_tuple "template_arity" [|v_sort|]
 
 let v_template_universes =
   v_tuple "template_universes" [|List(Opt v_level);v_context_set|]

--- a/dev/ci/user-overlays/15837-ppedrot-reduce-universe-footprint.sh
+++ b/dev/ci/user-overlays/15837-ppedrot-reduce-universe-footprint.sh
@@ -1,0 +1,7 @@
+overlay elpi https://github.com/ppedrot/coq-elpi reduce-universe-footprint 15837
+
+overlay metacoq https://github.com/ppedrot/metacoq reduce-universe-footprint 15837
+
+overlay mtac2 https://github.com/ppedrot/Mtac2 reduce-universe-footprint 15837
+
+overlay unicoq https://github.com/ppedrot/unicoq reduce-universe-footprint 15837

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -888,8 +888,7 @@ let eq_constr_univs_test ~evd ~extended_evd t u =
   let eq_sorts s1 s2 =
     if Sorts.equal s1 s2 then true
     else
-      let u1 = Sorts.univ_of_sort s1 and u2 = Sorts.univ_of_sort s2 in
-      try sigma := add_universe_constraints !sigma UnivProblem.(Set.singleton (UEq (u1, u2))); true
+      try sigma := add_universe_constraints !sigma UnivProblem.(Set.singleton (UEq (s1, s2))); true
       with Univ.UniverseInconsistency _ | UniversesDiffer -> false
   in
   let kind1 = kind_of_term_upto evd in

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -832,8 +832,8 @@ let occur_evar_upto sigma n c =
 
 let judge_of_new_Type evd =
   let open EConstr in
-  let (evd', s) = new_univ_variable univ_rigid evd in
-  (evd', { uj_val = mkType s; uj_type = mkType (Univ.super s) })
+  let (evd', s) = new_sort_variable univ_rigid evd in
+  (evd', { uj_val = mkSort s; uj_type = mkSort (Sorts.super s) })
 
 let subterm_source evk ?where (loc,k) =
   let evk = match k with

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -997,11 +997,7 @@ let is_flexible_level evd l =
 
 let is_eq_sort s1 s2 =
   if Sorts.equal s1 s2 then None
-  else
-    let u1 = univ_of_sort s1
-    and u2 = univ_of_sort s2 in
-      if Univ.Universe.equal u1 u2 then None
-      else Some (u1, u2)
+  else Some (s1, s2)
 
 (* Precondition: l is not defined in the substitution *)
 let universe_rigidity evd l =

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1056,10 +1056,10 @@ let set_leq_sort env evd s1 s2 =
      else evd
 
 let check_eq evd s s' =
-  UGraph.check_eq (UState.ugraph evd.universes) s s'
+  Sorts.check_eq_sort (UState.ugraph evd.universes) s s'
 
 let check_leq evd s s' =
-  UGraph.check_leq (UState.ugraph evd.universes) s s'
+  Sorts.check_leq_sort (UState.ugraph evd.universes) s s'
 
 let check_constraints evd csts =
   UGraph.check_constraints csts (UState.ugraph evd.universes)

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -619,7 +619,6 @@ val universe_of_name : evar_map -> Id.t -> Univ.Level.t
 val universe_binders : evar_map -> UnivNames.universe_binders
 
 val new_univ_level_variable : ?loc:Loc.t -> ?name:Id.t -> rigid -> evar_map -> evar_map * Univ.Level.t
-val new_univ_variable : ?loc:Loc.t -> ?name:Id.t -> rigid -> evar_map -> evar_map * Univ.Universe.t
 val new_sort_variable : ?loc:Loc.t -> ?name:Id.t -> rigid -> evar_map -> evar_map * Sorts.t
 
 val add_global_univ : evar_map -> Univ.Level.t -> evar_map
@@ -637,8 +636,6 @@ val is_sort_variable : evar_map -> Sorts.t -> Univ.Level.t option
 
 val is_flexible_level : evar_map -> Univ.Level.t -> bool
 
-(* val normalize_universe_level : evar_map -> Univ.Level.t -> Univ.Level.t *)
-val normalize_universe : evar_map -> Univ.Universe.t -> Univ.Universe.t
 val normalize_universe_instance : evar_map -> Univ.Instance.t -> Univ.Instance.t
 
 val set_leq_sort : env -> evar_map -> Sorts.t -> Sorts.t -> evar_map
@@ -648,8 +645,8 @@ val set_leq_level : evar_map -> Univ.Level.t -> Univ.Level.t -> evar_map
 val set_eq_instances : ?flex:bool ->
   evar_map -> Univ.Instance.t -> Univ.Instance.t -> evar_map
 
-val check_eq : evar_map -> Univ.Universe.t -> Univ.Universe.t -> bool
-val check_leq : evar_map -> Univ.Universe.t -> Univ.Universe.t -> bool
+val check_eq : evar_map -> Sorts.t -> Sorts.t -> bool
+val check_leq : evar_map -> Sorts.t -> Sorts.t -> bool
 
 val check_constraints : evar_map -> Univ.Constraints.t -> bool
 

--- a/engine/univProblem.mli
+++ b/engine/univProblem.mli
@@ -20,8 +20,8 @@ open Univ
 *)
 
 type t =
-  | ULe of Universe.t * Universe.t
-  | UEq of Universe.t * Universe.t
+  | ULe of Sorts.t * Sorts.t
+  | UEq of Sorts.t * Sorts.t
   | ULub of Level.t * Level.t
   | UWeak of Level.t * Level.t
 

--- a/kernel/constr.ml
+++ b/kernel/constr.ml
@@ -974,7 +974,7 @@ let eq_constr_univs univs m n =
   if m == n then true
   else
     let eq_universes _ = UGraph.check_eq_instances univs in
-    let eq_sorts s1 s2 = s1 == s2 || UGraph.check_eq univs (Sorts.univ_of_sort s1) (Sorts.univ_of_sort s2) in
+    let eq_sorts s1 s2 = s1 == s2 || Sorts.check_eq_sort univs s1 s2 in
     let rec eq_constr' nargs m n =
       m == n ||	compare_head_gen eq_universes eq_sorts eq_constr' nargs m n
     in compare_head_gen eq_universes eq_sorts eq_constr' 0 m n
@@ -984,9 +984,9 @@ let leq_constr_univs univs m n =
   else
     let eq_universes _ = UGraph.check_eq_instances univs in
     let eq_sorts s1 s2 = s1 == s2 ||
-      UGraph.check_eq univs (Sorts.univ_of_sort s1) (Sorts.univ_of_sort s2) in
+      Sorts.check_eq_sort univs s1 s2 in
     let leq_sorts s1 s2 = s1 == s2 ||
-      UGraph.check_leq univs (Sorts.univ_of_sort s1) (Sorts.univ_of_sort s2) in
+      Sorts.check_leq_sort univs s1 s2 in
     let rec eq_constr' nargs m n =
       m == n || compare_head_gen eq_universes eq_sorts eq_constr' nargs m n
     in
@@ -1003,10 +1003,9 @@ let eq_constr_univs_infer univs m n =
     let eq_sorts s1 s2 =
       if Sorts.equal s1 s2 then true
       else
-        let u1 = Sorts.univ_of_sort s1 and u2 = Sorts.univ_of_sort s2 in
-        if UGraph.check_eq univs u1 u2 then true
+        if Sorts.check_eq_sort univs s1 s2 then true
         else
-          (cstrs := Univ.enforce_eq u1 u2 !cstrs;
+          (cstrs := Sorts.enforce_eq_sort s1 s2 !cstrs;
            true)
     in
     let rec eq_constr' nargs m n =
@@ -1023,18 +1022,16 @@ let leq_constr_univs_infer univs m n =
     let eq_sorts s1 s2 =
       if Sorts.equal s1 s2 then true
       else
-        let u1 = Sorts.univ_of_sort s1 and u2 = Sorts.univ_of_sort s2 in
-        if UGraph.check_eq univs u1 u2 then true
-        else (cstrs := Univ.enforce_eq u1 u2 !cstrs;
+        if Sorts.check_eq_sort univs s1 s2 then true
+        else (cstrs := Sorts.enforce_eq_sort s1 s2 !cstrs;
               true)
     in
     let leq_sorts s1 s2 =
       if Sorts.equal s1 s2 then true
       else
-        let u1 = Sorts.univ_of_sort s1 and u2 = Sorts.univ_of_sort s2 in
-        if UGraph.check_leq univs u1 u2 then true
+        if Sorts.check_leq_sort univs s1 s2 then true
         else
-          (try let c, _ = UGraph.enforce_leq_alg u1 u2 univs in
+          (try let c, _ = Sorts.enforce_leq_alg_sort s1 s2 univs in
             cstrs := Univ.Constraints.union c !cstrs;
             true
           with Univ.UniverseInconsistency _ -> false)

--- a/kernel/declarations.ml
+++ b/kernel/declarations.ml
@@ -26,7 +26,7 @@ open Constr
 *)
 
 type template_arity = {
-  template_level : Univ.Universe.t;
+  template_level : Sorts.t;
 }
 
 type template_universes = {

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -50,7 +50,7 @@ let map_decl_arity f g = function
   | TemplateArity a -> TemplateArity (g a)
 
 let hcons_template_arity ar =
-  { template_level = Univ.hcons_univ ar.template_level; }
+  { template_level = Sorts.hcons ar.template_level; }
 
 let hcons_template_universe ar =
   { template_param_levels = ar.template_param_levels;

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -266,8 +266,6 @@ let is_impredicative_sort env = function
   | Sorts.Set -> is_impredicative_set env
   | Sorts.Type _ -> false
 
-let is_impredicative_univ env u = is_impredicative_sort env (Sorts.sort_of_univ u)
-
 let is_impredicative_family env = function
   | Sorts.InSProp | Sorts.InProp -> true
   | Sorts.InSet -> is_impredicative_set env

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -114,7 +114,6 @@ val deactivated_guard : env -> bool
 val indices_matter : env -> bool
 
 val is_impredicative_sort : env -> Sorts.t -> bool
-val is_impredicative_univ : env -> Univ.Universe.t -> bool
 val is_impredicative_family : env -> Sorts.family -> bool
 
 (** is the local context empty *)

--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -67,7 +67,7 @@ let mind_check_names mie =
 type univ_info = { ind_squashed : bool; ind_has_relevant_arg : bool;
                    ind_min_univ : Sorts.t option; (* Some for template *)
                    ind_univ : Sorts.t;
-                   missing : Universe.Set.t; (* missing u <= ind_univ constraints *)
+                   missing : Sorts.t list; (* missing u <= ind_univ constraints *)
                  }
 
 let sup_sort s1 s2 =
@@ -85,7 +85,7 @@ let check_univ_leq ?(is_real_arg=false) env u info =
   then { info with ind_min_univ = Option.map (sup_sort u) info.ind_min_univ }
   else if is_impredicative_sort env ind_univ
        && Option.is_empty info.ind_min_univ then { info with ind_squashed = true }
-  else {info with missing = Universe.Set.add (Sorts.univ_of_sort u) info.missing}
+  else {info with missing = u :: info.missing}
 
 let check_context_univs ~ctor env info ctx =
   let check_one d (info,env) =
@@ -114,7 +114,7 @@ let check_arity ~template env_params env_ar ind =
     ind_has_relevant_arg=false;
     ind_min_univ;
     ind_univ=ind_sort;
-    missing=Universe.Set.empty;
+    missing=[];
   }
   in
   let univ_info = check_indices_matter env_params univ_info indices in
@@ -296,7 +296,7 @@ let get_template univs params data =
     Some { template_param_levels = params; template_context = ctx }
 
 let abstract_packets usubst ((arity,lc),(indices,splayed_lc),univ_info) =
-  if not (Universe.Set.is_empty univ_info.missing)
+  if not (List.is_empty univ_info.missing)
   then raise (InductiveError (MissingConstraints (univ_info.missing,univ_info.ind_univ)));
   let arity = Vars.subst_univs_level_constr usubst arity in
   let lc = Array.map (Vars.subst_univs_level_constr usubst) lc in

--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -65,23 +65,27 @@ let mind_check_names mie =
 (************************************************************************)
 
 type univ_info = { ind_squashed : bool; ind_has_relevant_arg : bool;
-                   ind_min_univ : Universe.t option; (* Some for template *)
-                   ind_univ : Universe.t;
+                   ind_min_univ : Sorts.t option; (* Some for template *)
+                   ind_univ : Sorts.t;
                    missing : Universe.Set.t; (* missing u <= ind_univ constraints *)
                  }
 
+let sup_sort s1 s2 =
+  let open Sorts in
+  sort_of_univ (Universe.sup (univ_of_sort s1) (univ_of_sort s2))
+
 let check_univ_leq ?(is_real_arg=false) env u info =
   let ind_univ = info.ind_univ in
-  let info = if not info.ind_has_relevant_arg && is_real_arg && not (Univ.Universe.is_sprop u)
+  let info = if not info.ind_has_relevant_arg && is_real_arg && not (Sorts.is_sprop u)
     then {info with ind_has_relevant_arg=true}
     else info
   in
   (* Inductive types provide explicit lifting from SProp to other universes, so allow SProp <= any. *)
-  if Univ.Universe.is_sprop u || UGraph.check_leq (universes env) u ind_univ
-  then { info with ind_min_univ = Option.map (Universe.sup u) info.ind_min_univ }
-  else if is_impredicative_univ env ind_univ
+  if Sorts.is_sprop u || UGraph.check_leq (universes env) (Sorts.univ_of_sort u) (Sorts.univ_of_sort ind_univ)
+  then { info with ind_min_univ = Option.map (sup_sort u) info.ind_min_univ }
+  else if is_impredicative_sort env ind_univ
        && Option.is_empty info.ind_min_univ then { info with ind_squashed = true }
-  else {info with missing = Universe.Set.add u info.missing}
+  else {info with missing = Universe.Set.add (Sorts.univ_of_sort u) info.missing}
 
 let check_context_univs ~ctor env info ctx =
   let check_one d (info,env) =
@@ -89,7 +93,7 @@ let check_context_univs ~ctor env info ctx =
       | LocalAssum (_,t) ->
         (* could be retyping if it becomes available in the kernel *)
         let tj = Typeops.infer_type env t in
-        check_univ_leq ~is_real_arg:ctor env (Sorts.univ_of_sort tj.utj_type) info
+        check_univ_leq ~is_real_arg:ctor env tj.utj_type info
       | LocalDef _ -> info
     in
     info, push_rel d env
@@ -104,12 +108,12 @@ let check_indices_matter env_params info indices =
 let check_arity ~template env_params env_ar ind =
   let {utj_val=arity;utj_type=_} = Typeops.infer_type env_params ind.mind_entry_arity in
   let indices, ind_sort = Reduction.dest_arity env_params arity in
-  let ind_min_univ = if template then Some Universe.type0m else None in
+  let ind_min_univ = if template then Some Sorts.prop else None in
   let univ_info = {
     ind_squashed=false;
     ind_has_relevant_arg=false;
     ind_min_univ;
-    ind_univ=Sorts.univ_of_sort ind_sort;
+    ind_univ=ind_sort;
     missing=Universe.Set.empty;
   }
   in
@@ -145,10 +149,10 @@ let check_constructors env_ar_par isrecord params lc (arity,indices,univ_info) =
       then univ_info
       (* 1 constructor with arguments must squash if SProp
          (we could allow arguments in SProp but the reduction rule is a pain) *)
-      else check_univ_leq env_ar_par Univ.Universe.type0m univ_info
+      else check_univ_leq env_ar_par Sorts.prop univ_info
 
     (* More than 1 constructor: must squash if Prop/SProp *)
-    | _ -> check_univ_leq env_ar_par Univ.Universe.type0 univ_info
+    | _ -> check_univ_leq env_ar_par Sorts.set univ_info
   in
   let univ_info = Array.fold_left (check_constructor_univs env_ar_par) univ_info splayed_lc in
   (* generalize the constructors over the parameters *)
@@ -160,7 +164,7 @@ let check_record data =
       (* records must have all projections definable -> equivalent to not being squashed *)
       not info.ind_squashed
       (* relevant records must have at least 1 relevant argument *)
-      && (Univ.Universe.is_sprop info.ind_univ
+      && (Sorts.is_sprop info.ind_univ
           || info.ind_has_relevant_arg)
       && (match splayed_lc with
           (* records must have 1 constructor with at least 1 argument, and no anonymous fields *)
@@ -185,7 +189,7 @@ let check_record data =
 
 let allowed_sorts {ind_squashed;ind_univ;ind_min_univ=_;ind_has_relevant_arg=_;missing=_} =
   if not ind_squashed then InType
-  else Sorts.family (Sorts.sort_of_univ ind_univ)
+  else Sorts.family ind_univ
 
 (* For a level to be template polymorphic, it must be introduced
    by the definition (so have no constraint except lbound <= l)
@@ -211,7 +215,10 @@ let template_polymorphic_univs ~ctor_levels uctx paramsctxt concl =
     unbounded_from_below l (Univ.ContextSet.constraints uctx) &&
     not (Univ.Level.Set.mem l ctor_levels)
   in
-  let univs = Univ.Universe.levels concl in
+  let univs = match concl with
+  | Prop | Set | SProp -> Univ.Level.Set.empty
+  | Type u -> Univ.Universe.levels u
+  in
   let univs = Univ.Level.Set.filter (fun l -> check_level l) univs in
   let fold acc = function
     | (LocalAssum (_, p)) ->
@@ -225,9 +232,11 @@ let template_polymorphic_univs ~ctor_levels uctx paramsctxt concl =
     | LocalDef _ -> acc
   in
   let params = List.fold_left fold [] paramsctxt in
-  if Universe.is_type0m concl then Some (univs, params)
-  else if not @@ Univ.Level.Set.is_empty univs then Some (univs, params)
-  else None
+  match concl with
+  | Prop -> Some (univs, params)
+  | Set | SProp | Type _ ->
+    if not @@ Univ.Level.Set.is_empty univs then Some (univs, params)
+    else None
 
 let get_param_levels ctx params arity splayed_lc =
   let min_univ = match arity with
@@ -298,10 +307,10 @@ let abstract_packets usubst ((arity,lc),(indices,splayed_lc),univ_info) =
       args,out)
       splayed_lc
   in
-  let ind_univ = Univ.subst_univs_level_universe usubst univ_info.ind_univ in
+  let ind_univ = Sorts.sort_of_univ  (Univ.subst_univs_level_universe usubst (Sorts.univ_of_sort univ_info.ind_univ)) in
 
   let arity = match univ_info.ind_min_univ with
-    | None -> RegularArity {mind_user_arity = arity; mind_sort = Sorts.sort_of_univ ind_univ}
+    | None -> RegularArity {mind_user_arity = arity; mind_sort = ind_univ}
     | Some min_univ -> TemplateArity { template_level = min_univ; }
   in
 
@@ -361,7 +370,7 @@ let typecheck_inductive env ~sec_univs (mie:mutual_inductive_entry) =
         (* if someone tried to declare a record as SProp but it can't
            be primitive we must squash. *)
         let data = List.map (fun (a,b,univs) ->
-            a,b,check_univ_leq env_ar_par Univ.Universe.type0m univs)
+            a,b,check_univ_leq env_ar_par Sorts.prop univs)
             data
         in
         data, Some None

--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -81,7 +81,7 @@ let check_univ_leq ?(is_real_arg=false) env u info =
     else info
   in
   (* Inductive types provide explicit lifting from SProp to other universes, so allow SProp <= any. *)
-  if Sorts.is_sprop u || UGraph.check_leq (universes env) (Sorts.univ_of_sort u) (Sorts.univ_of_sort ind_univ)
+  if Sorts.is_sprop u || Sorts.check_leq_sort (universes env) u ind_univ
   then { info with ind_min_univ = Option.map (sup_sort u) info.ind_min_univ }
   else if is_impredicative_sort env ind_univ
        && Option.is_empty info.ind_min_univ then { info with ind_squashed = true }

--- a/kernel/indTyping.mli
+++ b/kernel/indTyping.mli
@@ -44,5 +44,5 @@ val template_polymorphic_univs :
   ctor_levels:Univ.Level.Set.t ->
   Univ.ContextSet.t ->
   Constr.rel_context ->
-  Univ.Universe.t ->
+  Sorts.t ->
   (Univ.Level.Set.t * Univ.Level.t option list) option

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -232,19 +232,6 @@ let constrained_type_of_inductive_knowing_parameters ((mib,_mip),u as pind) args
 let type_of_inductive_knowing_parameters ?(polyprop=true) mip args =
   type_of_inductive_gen ~polyprop mip args
 
-(* The max of an array of universes *)
-
-let cumulate_constructor_univ u = let open Sorts in function
-  | SProp | Prop ->
-    (* SProp is non cumulative but allowed in constructors of any
-       inductive (except non-sprop primitive records) *)
-    u
-  | Set -> Universe.sup Universe.type0 u
-  | Type u' -> Universe.sup u u'
-
-let max_inductive_sort =
-  Array.fold_left cumulate_constructor_univ Universe.type0m
-
 (************************************************************************)
 (* Type of a constructor *)
 

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -177,18 +177,14 @@ let make_subst =
 
 exception SingletonInductiveBecomesProp of Id.t
 
+let subst_univs_sort subs = function
+| Sorts.Prop | Sorts.Set | Sorts.SProp as s -> s
+| Sorts.Type u -> Sorts.sort_of_univ (Univ.subst_univs_universe subs u)
+
 let instantiate_universes ctx (templ, ar) args =
   let subst = make_subst (ctx,templ.template_param_levels,args) in
-  let level = Univ.subst_univs_universe (Univ.make_subst subst) ar.template_level in
-  let ty =
-    (* Singleton type not containing types are interpretable in Prop *)
-    if is_type0m_univ level then Sorts.prop
-    (* Non singleton type not containing types are interpretable in Set *)
-    else if is_type0_univ level then Sorts.set
-    (* This is a Type with constraints *)
-    else Sorts.sort_of_univ level
-  in
-    (ctx, ty)
+  let ty = subst_univs_sort (Univ.make_subst subst) ar.template_level in
+  (ctx, ty)
 
 (* Type of an inductive type *)
 
@@ -216,7 +212,7 @@ let type_of_inductive_gen ?(polyprop=true) ((mib,mip),u) paramtyps =
       (* The Ocaml extraction cannot handle (yet?) "Prop-polymorphism", i.e.
          the situation where a non-Prop singleton inductive becomes Prop
          when applied to Prop params *)
-      if not polyprop && not (is_type0m_univ ar.template_level) && Sorts.is_prop s
+      if not polyprop && not (Sorts.is_prop ar.template_level) && Sorts.is_prop s
       then raise (SingletonInductiveBecomesProp mip.mind_typename);
       Term.mkArity (List.rev ctx,s)
 

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -123,6 +123,7 @@ Remark: Set (predicative) is encoded as Type(0)
 (* in the domain or add [u |-> sup x su] if [u] is already mapped *)
 (* to [x]. *)
 let cons_subst u su subst =
+  let su = Sorts.univ_of_sort su in
   try
     Univ.Level.Map.add u (Univ.sup (Univ.Level.Map.find u subst) su) subst
   with Not_found -> Univ.Level.Map.add u su subst
@@ -135,12 +136,10 @@ let remember_subst u subst =
     Univ.Level.Map.add u (Univ.sup (Univ.Level.Map.find u subst) su) subst
   with Not_found -> subst
 
-type param_univs = (unit -> Universe.t) list
+type param_univs = (unit -> Sorts.t) list
 
 let make_param_univs env argtys =
-  Array.map_to_list (fun arg () ->
-      Sorts.univ_of_sort (snd (Reduction.dest_arity env arg)))
-    argtys
+  Array.map_to_list (fun arg () -> (snd (Reduction.dest_arity env arg))) argtys
 
 (* Bind expected levels of parameters to actual levels *)
 (* Propagate the new levels in the signature *)

--- a/kernel/inductive.mli
+++ b/kernel/inductive.mli
@@ -155,8 +155,6 @@ val check_cofix : env -> cofixpoint -> unit
 
 exception SingletonInductiveBecomesProp of Id.t
 
-val max_inductive_sort : Sorts.t array -> Universe.t
-
 (** {6 Debug} *)
 
 type size = Large | Strict

--- a/kernel/inductive.mli
+++ b/kernel/inductive.mli
@@ -46,7 +46,7 @@ val inductive_nonrec_rec_paramdecls : mutual_inductive_body puniverses -> Constr
 val instantiate_inductive_constraints :
   mutual_inductive_body -> Instance.t -> Constraints.t
 
-type param_univs = (unit -> Universe.t) list
+type param_univs = (unit -> Sorts.t) list
 
 val make_param_univs : Environ.env -> constr array -> param_univs
 (** The constr array is the types of the arguments to a template

--- a/kernel/inferCumulativity.ml
+++ b/kernel/inferCumulativity.ml
@@ -125,9 +125,9 @@ let infer_constructor_instance_eq env variances ((mi,ind),ctor) nargs u =
 let infer_sort cv_pb variances s =
   match cv_pb with
   | CONV ->
-    Level.Set.fold infer_level_eq (Universe.levels (Sorts.univ_of_sort s)) variances
+    Level.Set.fold infer_level_eq (Sorts.levels s) variances
   | CUMUL ->
-    Level.Set.fold infer_level_leq (Universe.levels (Sorts.univ_of_sort s)) variances
+    Level.Set.fold infer_level_leq (Sorts.levels s) variances
 
 let infer_table_key variances c =
   let open Names in

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -90,8 +90,7 @@ let rec check_with_def env struc (idl,(c,ctx)) mp reso =
           c', Monomorphic, cst
         | Polymorphic uctx, Some ctx ->
           let () =
-            if not (UGraph.check_subtype ~lbound:(Environ.universes_lbound env)
-                      (Environ.universes env) uctx ctx) then
+            if not (UGraph.check_subtype (Environ.universes env) uctx ctx) then
               error_incorrect_with_constraint lab
           in
           (** Terms are compared in a context with De Bruijn universe indices *)

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -872,17 +872,15 @@ let clos_gen_conv trans cv_pb l2r evars env graph univs t1 t2 =
 
 
 let check_eq univs u u' =
-  if not (UGraph.check_eq univs u u') then raise NotConvertible
+  if not (Sorts.check_eq_sort univs u u') then raise NotConvertible
 
 let check_leq univs u u' =
-  if not (UGraph.check_leq univs u u') then raise NotConvertible
+  if not (Sorts.check_leq_sort univs u u') then raise NotConvertible
 
 let check_sort_cmp_universes pb s0 s1 univs =
-  let u0 = Sorts.univ_of_sort s0
-  and u1 = Sorts.univ_of_sort s1 in
   match pb with
-  | CUMUL -> check_leq univs u0 u1
-  | CONV -> check_eq univs u0 u1
+  | CUMUL -> check_leq univs s0 s1
+  | CONV -> check_eq univs s0 s1
 
 let checked_sort_cmp_universes _env pb s0 s1 univs =
   check_sort_cmp_universes pb s0 s1 univs; univs
@@ -917,22 +915,20 @@ let () =
   CClosure.set_conv conv
 
 let infer_eq (univs, cstrs as cuniv) u u' =
-  if UGraph.check_eq univs u u' then cuniv
+  if Sorts.check_eq_sort univs u u' then cuniv
   else
-    univs, (Univ.enforce_eq u u' cstrs)
+    univs, (Sorts.enforce_eq_sort u u' cstrs)
 
 let infer_leq (univs, cstrs as cuniv) u u' =
-  if UGraph.check_leq univs u u' then cuniv
+  if Sorts.check_leq_sort univs u u' then cuniv
   else
-    let cstrs', _ = UGraph.enforce_leq_alg u u' univs in
+    let cstrs', _ = Sorts.enforce_leq_alg_sort u u' univs in
       univs, Univ.Constraints.union cstrs cstrs'
 
 let infer_cmp_universes _env pb s0 s1 univs =
-  let u0 = Sorts.univ_of_sort s0
-  and u1 = Sorts.univ_of_sort s1 in
   match pb with
-  | CUMUL -> infer_leq univs u0 u1
-  | CONV -> infer_eq univs u0 u1
+  | CUMUL -> infer_leq univs s0 s1
+  | CONV -> infer_eq univs s0 s1
 
 let infer_convert_instances ~flex u u' (univs,cstrs) =
   let cstrs' =

--- a/kernel/sorts.ml
+++ b/kernel/sorts.ml
@@ -73,6 +73,20 @@ let is_small = function
   | SProp | Prop | Set -> true
   | Type _ -> false
 
+let levels s = Universe.levels (univ_of_sort s)
+
+let check_eq_sort ugraph s1 s2 =
+  UGraph.check_eq ugraph (univ_of_sort s1) (univ_of_sort s2)
+
+let check_leq_sort ugraph s1 s2 =
+  UGraph.check_leq ugraph (univ_of_sort s1) (univ_of_sort s2)
+
+let enforce_eq_sort s1 s2 cst =
+  Univ.enforce_eq (univ_of_sort s1) (univ_of_sort s2) cst
+
+let enforce_leq_alg_sort s1 s2 cst =
+  UGraph.enforce_leq_alg (univ_of_sort s1) (univ_of_sort s2) cst
+
 let family = function
   | SProp -> InSProp
   | Prop -> InProp

--- a/kernel/sorts.ml
+++ b/kernel/sorts.ml
@@ -73,6 +73,9 @@ let check_leq_sort ugraph s1 s2 =
 let enforce_eq_sort s1 s2 cst =
   Univ.enforce_eq (univ_of_sort s1) (univ_of_sort s2) cst
 
+let enforce_leq_sort s1 s2 cst =
+  Univ.enforce_leq (univ_of_sort s1) (univ_of_sort s2) cst
+
 let enforce_leq_alg_sort s1 s2 cst =
   UGraph.enforce_leq_alg (univ_of_sort s1) (univ_of_sort s2) cst
 

--- a/kernel/sorts.ml
+++ b/kernel/sorts.ml
@@ -38,18 +38,7 @@ let sort_of_univ u =
   else Type u
 
 let compare s1 s2 =
-  if s1 == s2 then 0 else
-    match s1, s2 with
-    | SProp, SProp -> 0
-    | SProp, _ -> -1
-    | _, SProp -> 1
-    | Prop, Prop -> 0
-    | Prop, _ -> -1
-    | Set, Prop -> 1
-    | Set, Set -> 0
-    | Set, _ -> -1
-    | Type u1, Type u2 -> Universe.compare u1 u2
-    | Type _, _ -> -1
+  if s1 == s2 then 0 else Universe.compare (univ_of_sort s1) (univ_of_sort s2)
 
 let equal s1 s2 = Int.equal (compare s1 s2) 0
 

--- a/kernel/sorts.mli
+++ b/kernel/sorts.mli
@@ -50,6 +50,7 @@ val check_eq_sort : UGraph.t -> t -> t -> bool
 val check_leq_sort : UGraph.t -> t -> t -> bool
 
 val enforce_eq_sort : t -> t -> Univ.Constraints.t -> Univ.Constraints.t
+val enforce_leq_sort : t -> t -> Univ.Constraints.t -> Univ.Constraints.t
 val enforce_leq_alg_sort : t -> t -> UGraph.t -> Univ.Constraints.t * UGraph.t
 
 val super : t -> t

--- a/kernel/sorts.mli
+++ b/kernel/sorts.mli
@@ -44,6 +44,14 @@ val family_leq : family -> family -> bool
 val univ_of_sort : t -> Univ.Universe.t
 val sort_of_univ : Univ.Universe.t -> t
 
+val levels : t -> Univ.Level.Set.t
+
+val check_eq_sort : UGraph.t -> t -> t -> bool
+val check_leq_sort : UGraph.t -> t -> t -> bool
+
+val enforce_eq_sort : t -> t -> Univ.Constraints.t -> Univ.Constraints.t
+val enforce_leq_alg_sort : t -> t -> UGraph.t -> Univ.Constraints.t * UGraph.t
+
 val super : t -> t
 
 (** On binders: is this variable proof relevant *)

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -97,8 +97,7 @@ let check_universes error env u1 u2 =
   match u1, u2 with
   | Monomorphic, Monomorphic -> env
   | Polymorphic auctx1, Polymorphic auctx2 ->
-    let lbound = Environ.universes_lbound env in
-    if not (UGraph.check_subtype ~lbound (Environ.universes env) auctx2 auctx1) then
+    if not (UGraph.check_subtype (Environ.universes env) auctx2 auctx1) then
       error (IncompatibleConstraints { got = auctx1; expect = auctx2; } )
     else
       Environ.push_context ~strict:false (Univ.AbstractContext.repr auctx2) env

--- a/kernel/type_errors.ml
+++ b/kernel/type_errors.ml
@@ -86,7 +86,7 @@ type inductive_error =
   | NotAnArity of env * constr
   | BadEntry
   | LargeNonPropInductiveNotInType
-  | MissingConstraints of (Universe.Set.t * Sorts.t)
+  | MissingConstraints of (Sorts.t list * Sorts.t)
 
 exception InductiveError of inductive_error
 

--- a/kernel/type_errors.ml
+++ b/kernel/type_errors.ml
@@ -86,7 +86,7 @@ type inductive_error =
   | NotAnArity of env * constr
   | BadEntry
   | LargeNonPropInductiveNotInType
-  | MissingConstraints of (Universe.Set.t * Universe.t)
+  | MissingConstraints of (Universe.Set.t * Sorts.t)
 
 exception InductiveError of inductive_error
 

--- a/kernel/type_errors.mli
+++ b/kernel/type_errors.mli
@@ -89,7 +89,7 @@ type inductive_error =
   | NotAnArity of env * constr
   | BadEntry
   | LargeNonPropInductiveNotInType
-  | MissingConstraints of (Universe.Set.t * Sorts.t)
+  | MissingConstraints of (Sorts.t list * Sorts.t)
   (* each universe in the set should have been <= the other one *)
 
 exception InductiveError of inductive_error

--- a/kernel/type_errors.mli
+++ b/kernel/type_errors.mli
@@ -89,7 +89,7 @@ type inductive_error =
   | NotAnArity of env * constr
   | BadEntry
   | LargeNonPropInductiveNotInType
-  | MissingConstraints of (Universe.Set.t * Universe.t)
+  | MissingConstraints of (Universe.Set.t * Sorts.t)
   (* each universe in the set should have been <= the other one *)
 
 exception InductiveError of inductive_error

--- a/kernel/uGraph.ml
+++ b/kernel/uGraph.ml
@@ -196,13 +196,13 @@ let constraints_for ~kept g = G.constraints_for ~kept:(Level.Set.remove Level.sp
 
 (** Subtyping of polymorphic contexts *)
 
-let check_subtype ~lbound univs ctxT ctx =
+let check_subtype univs ctxT ctx =
   if AbstractContext.size ctxT == AbstractContext.size ctx then
     let uctx = AbstractContext.repr ctx in
     let inst = UContext.instance uctx in
     let cst = UContext.constraints uctx in
     let cstT = UContext.constraints (AbstractContext.repr ctxT) in
-    let push accu v = add_universe v ~lbound ~strict:false accu in
+    let push accu v = add_universe v ~lbound:Bound.Set ~strict:false accu in
     let univs = Array.fold_left push univs (Instance.to_array inst) in
     let univs = merge_constraints cstT univs in
     check_constraints cst univs

--- a/kernel/uGraph.ml
+++ b/kernel/uGraph.ml
@@ -186,8 +186,6 @@ let add_universe u ~lbound ~strict g =
   let d = if strict then Lt else Le in
   enforce_constraint (lbound,d,u) {g with graph}
 
-let add_universe_unconstrained u g = {g with graph=G.add u g.graph}
-
 exception UndeclaredLevel = G.Undeclared
 let check_declared_universes g l = G.check_declared g.graph (Level.Set.remove Level.sprop l)
 

--- a/kernel/uGraph.mli
+++ b/kernel/uGraph.mli
@@ -68,9 +68,6 @@ end
 
 val add_universe : Level.t -> lbound:Bound.t -> strict:bool -> t -> t
 
-(** Add a universe without (Prop,Set) <= u *)
-val add_universe_unconstrained : Level.t -> t -> t
-
 (** Check that the universe levels are declared. Otherwise
     @raise UndeclaredLevel l for the first undeclared level found. *)
 exception UndeclaredLevel of Univ.Level.t

--- a/kernel/uGraph.mli
+++ b/kernel/uGraph.mli
@@ -98,7 +98,7 @@ val constraints_for : kept:Level.Set.t -> t -> Constraints.t
 val domain : t -> Level.Set.t
 (** Known universes *)
 
-val check_subtype : lbound:Bound.t -> AbstractContext.t check_function
+val check_subtype : AbstractContext.t check_function
 (** [check_subtype univ ctx1 ctx2] checks whether [ctx2] is an instance of
     [ctx1]. *)
 

--- a/kernel/vars.ml
+++ b/kernel/vars.ml
@@ -396,8 +396,7 @@ let universes_of_constr c =
     | Ind ((_mind,_), u) | Construct (((_mind,_),_), u) ->
       Level.Set.fold Level.Set.add (Instance.levels u) s
     | Sort u when not (Sorts.is_small u) ->
-      let u = Sorts.univ_of_sort u in
-      Level.Set.fold Level.Set.add (Universe.levels u) s
+      Level.Set.fold Level.Set.add (Sorts.levels u) s
     | Array (u,_,_,_) ->
       let s = Level.Set.fold Level.Set.add (Instance.levels u) s in
       Constr.fold aux s c

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -233,9 +233,8 @@ let change_property_sort evd toSort princ princName =
         in
         let s = Constr.destSort ty in
         Global.add_constraints
-          (Univ.enforce_leq
-             (Sorts.univ_of_sort toSort)
-             (Sorts.univ_of_sort s) Univ.Constraints.empty);
+          (Sorts.enforce_leq_sort
+             toSort s Univ.Constraints.empty);
         Term.compose_prod args (Constr.mkSort toSort) )
   in
   let evd, princName_as_constr =

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -1404,14 +1404,13 @@ let solve_evar_evar ?(force=false) f unify flags env evd pbty (evk1,args1 as ev1
       let concl2 = EConstr.Unsafe.to_constr evi2.evar_concl in
       let ctx2, j = Reduction.dest_arity evi2env concl2 in
       let ctx2 = List.map (fun c -> map_rel_decl EConstr.of_constr c) ctx2 in
-      let ui, uj = univ_of_sort i, univ_of_sort j in
-        if i == j || Evd.check_eq evd ui uj
+        if i == j || Evd.check_eq evd i j
         then (* Shortcut, i = j *)
           evd
-        else if Evd.check_leq evd ui uj then
+        else if Evd.check_leq evd i j then
           let t2 = it_mkProd_or_LetIn (mkSort i) ctx2 in
           downcast evk2 t2 evd
-        else if Evd.check_leq evd uj ui then
+        else if Evd.check_leq evd j i then
           let t1 = it_mkProd_or_LetIn (mkSort j) ctx1 in
           downcast evk1 t1 evd
         else

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -675,6 +675,9 @@ let arity_of_case_predicate env (ind,params) dep k =
 (* Inferring the sort of parameters of a polymorphic inductive type
    knowing the sort of the conclusion *)
 
+let univ_level_mem l s = match s with
+| Prop | Set | SProp -> false
+| Type u -> univ_level_mem l u
 
 (* Compute the inductive argument types: replace the sorts
    that appear in the type of the inductive by the sort of the

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -934,7 +934,7 @@ struct
              information when typing the body. *)
           let s = Retyping.get_sort_of !!env sigma ty in
           if Environ.is_impredicative_sort !!env s
-             || Evd.check_leq sigma (Univ.Universe.type1) (Sorts.univ_of_sort s)
+             || Evd.check_leq sigma Sorts.type1 s
           then
             let sigma, prod = define_evar_as_product !!env sigma ev in
             let na,dom,rng = destProd sigma prod in

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1113,8 +1113,8 @@ let sigma_univ_state =
 let univproblem_compare_sorts env pb s0 s1 uset =
   let open UnivProblem in
   match pb with
-  | Reduction.CONV -> UnivProblem.Set.add (UEq (Sorts.univ_of_sort s0, Sorts.univ_of_sort s1)) uset
-  | Reduction.CUMUL -> UnivProblem.Set.add (ULe (Sorts.univ_of_sort s0, Sorts.univ_of_sort s1)) uset
+  | Reduction.CONV -> UnivProblem.Set.add (UEq (s0, s1)) uset
+  | Reduction.CUMUL -> UnivProblem.Set.add (ULe (s0, s1)) uset
 
 let univproblem_compare_instances ~flex i0 i1 uset =
   UnivProblem.enforce_eq_instances_univs flex i0 i1 uset
@@ -1122,7 +1122,7 @@ let univproblem_compare_instances ~flex i0 i1 uset =
 let univproblem_check_inductive_instances cv_pb variances u u' uset =
   let open UnivProblem in
   let open Univ.Variance in
-  let mk u = Univ.Universe.make u in
+  let mk u = Sorts.sort_of_univ @@ Univ.Universe.make u in
   let fold cstr v u u' = match v with
   | Irrelevant -> Set.add (UWeak (u,u')) cstr
   | Covariant when cv_pb == Reduction.CUMUL -> Set.add (ULe (mk u, mk u')) cstr

--- a/pretyping/retyping.ml
+++ b/pretyping/retyping.ml
@@ -208,7 +208,7 @@ let retype ?(polyprop=true) sigma =
       let paramtyps = Array.map_to_list (fun arg () ->
           let t = type_of env arg in
           let s = sort_of_arity_with_constraints env sigma t in
-          Sorts.univ_of_sort (ESorts.kind sigma s))
+          ESorts.kind sigma s)
           args
       in
       EConstr.of_constr

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -40,7 +40,7 @@ let inductive_type_knowing_parameters env sigma (ind,u) jl =
   let mspec = lookup_mind_specif env ind in
   let paramstyp = Array.map_to_list (fun j () ->
       let s = Reductionops.sort_of_arity env sigma j.uj_type in
-      Sorts.univ_of_sort (EConstr.ESorts.kind sigma s)) jl
+      EConstr.ESorts.kind sigma s) jl
   in
   Inductive.type_of_inductive_knowing_parameters (mspec,u) paramstyp
 

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -569,7 +569,7 @@ let force_eqs c =
   Set.fold
     (fun c acc ->
        let c' = match c with
-         | ULub (l, r) -> UEq (Univ.Universe.make l,Univ.Universe.make r)
+         | ULub (l, r) -> UEq (Sorts.sort_of_univ @@ Univ.Universe.make l, Sorts.sort_of_univ @@ Univ.Universe.make r)
          | ULe _ | UEq _ | UWeak _ -> c
        in
         Set.add c' acc)

--- a/tactics/cbn.ml
+++ b/tactics/cbn.ml
@@ -459,7 +459,7 @@ let magically_constant_of_fixbody env sigma reference bd = function
                 let l, r = match cst with
                   | ULub (u, v) | UWeak (u, v) -> u, v
                   | UEq (u, v) | ULe (u, v) ->
-                    let get u = Option.get (Universe.level u) in
+                    let get u = Option.get (Universe.level (Sorts.univ_of_sort u)) in
                     get u, get v
                 in
                 Univ.Level.Map.add l r acc)

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -353,7 +353,7 @@ let template_polymorphism_candidate ~ctor_levels uctx params concl =
     let concltemplate = Option.cata (fun s -> not (Sorts.is_small s)) false concl in
     if not concltemplate then false
     else
-      let conclu = Option.cata Sorts.univ_of_sort Univ.type0m_univ concl in
+      let conclu = Option.default Sorts.prop concl in
       Option.has_some @@ IndTyping.template_polymorphic_univs ~ctor_levels uctx params conclu
   | UState.Polymorphic_entry _ -> false
 

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -263,7 +263,7 @@ let solve_constraints_system levels level_bounds =
         (v.(i) <- Universe.sup v.(i) level_bounds.(j));
     done;
   done;
-  v
+  Array.map Sorts.sort_of_univ v
 
 let inductive_levels env evd arities inds =
   let destarities = List.map (fun x -> x, Reduction.dest_arity env x) arities in
@@ -311,13 +311,13 @@ let inductive_levels env evd arities inds =
         (* Constructors contribute. *)
         let evd =
           if Sorts.is_set du then
-            if not (Evd.check_leq evd cu Univ.type0_univ) then
+            if not (Evd.check_leq evd cu Sorts.set) then
               raise (InductiveError LargeNonPropInductiveNotInType)
             else evd
           else evd
         in
         let evd =
-          if len >= 2 && Univ.is_type0m_univ cu then
+          if len >= 2 && Sorts.is_prop cu then
            (* "Polymorphic" type constraint and more than one constructor,
                should not land in Prop. Add constraint only if it would
                land in Prop directly (no informative arguments as well). *)
@@ -326,8 +326,8 @@ let inductive_levels env evd arities inds =
         in
         let duu = Sorts.univ_of_sort du in
         let template_prop, evd =
-          if not (Univ.is_small_univ duu) && Univ.Universe.equal cu duu then
-            if is_flexible_sort evd duu && not (Evd.check_leq evd Univ.type0_univ duu)
+          if not (Sorts.is_small du) && Sorts.equal cu du then
+            if is_flexible_sort evd duu && not (Evd.check_leq evd Sorts.set du)
             then if Term.isArity arity
             (* If not a syntactic arity, the universe may be used in a
                polymorphic instance and so cannot be lowered to Prop.
@@ -335,7 +335,7 @@ let inductive_levels env evd arities inds =
               then true, Evd.set_eq_sort env evd Sorts.prop du
               else false, Evd.set_eq_sort env evd Sorts.set du
             else false, evd
-          else false, Evd.set_eq_sort env evd (sort_of_univ cu) du
+          else false, Evd.set_eq_sort env evd cu du
         in
           (evd, (template_prop, arity) :: arities))
     (evd,[]) (Array.to_list levels') destarities sizes

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1252,7 +1252,7 @@ let error_inductive_missing_constraints (us,ind_univ) =
   let pr_u = Univ.Universe.pr_with UnivNames.(pr_with_global_universes empty_binders) in
   str "Missing universe constraint declared for inductive type:" ++ spc()
   ++ v 0 (prlist_with_sep spc (fun u ->
-      hov 0 (pr_u u ++ str " <= " ++ pr_u ind_univ))
+      hov 0 (pr_u u ++ str " <= " ++ Printer.pr_sort Evd.empty ind_univ))
       (Univ.Universe.Set.elements us))
 
 (* Recursion schemes errors *)

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1249,11 +1249,10 @@ let error_large_non_prop_inductive_not_in_type () =
   str "Large non-propositional inductive types must be in Type."
 
 let error_inductive_missing_constraints (us,ind_univ) =
-  let pr_u = Univ.Universe.pr_with UnivNames.(pr_with_global_universes empty_binders) in
   str "Missing universe constraint declared for inductive type:" ++ spc()
   ++ v 0 (prlist_with_sep spc (fun u ->
-      hov 0 (pr_u u ++ str " <= " ++ Printer.pr_sort Evd.empty ind_univ))
-      (Univ.Universe.Set.elements us))
+      hov 0 (Printer.pr_sort Evd.empty u ++ str " <= " ++ Printer.pr_sort Evd.empty ind_univ))
+      us)
 
 (* Recursion schemes errors *)
 


### PR DESCRIPTION
This PR reduces the use of the `Universe.t` type and primitive to the bare minimum, in order to facilitate the introduction of the sort polymorphism infrastructure.

There is a confusion in the current state of the code between `Sorts.t` and `Universe.t`. They are essentially isomorphic, but this is actually a design issue. The former should be actual sorts as found in the parameters of `Type` constructors, but the latter should only be made of algebraic expressions formed of levels. In particular, when viewed as universe levels, `Prop` and `Set` are the same thing since they correspond to the lowest level of the hierarchy. But `Universe.t` (and also `Level.t`) consider them different and to add insult to injury also handle the `SProp` case. Most of the code is working around this confusion by trying to handle max of `Prop` and `SProp` as some kind of no-op but this does not make sense in general.

This PR is on the path to turn `Sort.t` into (a quotient of) the product of a quality together with a (universe) level. By reducing the uses of `Universe.t` to sole arguments of the `Type` constructor of `Sorts.t`, one can change the implementation to remove the base cases and turn them into a unified "zero" universe index.

As usual template poly is a bummer, and will have to be handled at once with the change of representation of sorts. As a result this PR is rather straightforward and standalone.

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/348
- https://github.com/Mtac2/Mtac2/pull/352
- https://github.com/unicoq/unicoq/pull/67
- https://github.com/MetaCoq/metacoq/pull/668