### PR TITLE
ExtrOcamlChar: efficient extraction for Ascii.compare

### DIFF
--- a/theories/extraction/ExtrOcamlChar.v
+++ b/theories/extraction/ExtrOcamlChar.v
@@ -35,6 +35,10 @@ Extract Constant shift =>
 
 Extract Inlined Constant ascii_dec => "(=)".
 Extract Inlined Constant Ascii.eqb => "(=)".
+Extract Constant Ascii.compare =>
+  "fun c1 c2 ->
+    let cmp = Char.compare c1 c2 in
+    if cmp < 0 then Lt else if cmp = 0 then Eq else Gt".
 
 (* python -c 'print(" ".join(r""" "%s" """.strip() % (r"'"'\''"'" if chr(i) == "'"'"'" else repr(""" "" """.strip()) if chr(i) == """ " """.strip() else repr(chr(i))) for i in range(256)))' # " to satisfy Coq's comment parser *)
 Extract Inductive byte => char


### PR DESCRIPTION
I was asked to look at the efficient of a Coq program whose runtime was dominated by `Ascii.compare`.

Current `ExtrOcamlChar` provides efficient constants for equality (`ascii_dec`, `Ascii.eqb`) but no efficient definition for comparison.

Before:

```ocaml
(** val n_of_digits : bool list -> n **)
let rec n_of_digits = function
| [] -> N0
| b :: l' ->
  N.add (if b then Npos XH else N0) (N.mul (Npos (XO XH)) (n_of_digits l'))

(** val n_of_ascii : char -> n **)
let n_of_ascii a =
  (* If this appears, you're using Ascii internals. Please don't *)
 (fun f c ->
  let n = Char.code c in
  let h i = (n land (1 lsl i)) <> 0 in
  f (h 0) (h 1) (h 2) (h 3) (h 4) (h 5) (h 6) (h 7))
    (fun a0 a1 a2 a3 a4 a5 a6 a7 ->
    n_of_digits
      (a0 :: (a1 :: (a2 :: (a3 :: (a4 :: (a5 :: (a6 :: (a7 :: [])))))))))
    a

(** val compare0 : char -> char -> comparison **)
let compare0 a b =
  N.compare (n_of_ascii a) (n_of_ascii b)
```

After:

```ocaml
(** val compare0 : char -> char -> comparison **)
let compare0 = fun c1 c2 ->
    let cmp = Char.compare c1 c2 in
    if cmp < 0 then Lt else if cmp = 0 then Eq else Gt
```

After this change, the runtime of the extracted program is halved. (The particular program I was looking at.)