### PR TITLE
Add a nonuniform attribute silencing warning on coercions

### DIFF
--- a/dev/ci/user-overlays/15853-proux01-nonuniform_attr.sh
+++ b/dev/ci/user-overlays/15853-proux01-nonuniform_attr.sh
@@ -1,0 +1,2 @@
+overlay elpi https://github.com/proux01/coq-elpi coq_15853 15853
+overlay mtac2 https://github.com/proux01/Mtac2 coq_15853 15853

--- a/doc/changelog/07-vernac-commands-and-options/15853-nonuniform_attr.rst
+++ b/doc/changelog/07-vernac-commands-and-options/15853-nonuniform_attr.rst
@@ -1,0 +1,6 @@
+- **Added:**
+  the :attr:`nonuniform` boolean attribute that silences the
+  non-uniform-inheritance warning when user needs to declare such a
+  coercion on purpose
+  (`#15853 <https://github.com/coq/coq/pull/15853>`_,
+  by Pierre Roux, reviewed by Gaëtan Gilbert and Jim Fehrle).

--- a/doc/sphinx/addendum/implicit-coercions.rst
+++ b/doc/sphinx/addendum/implicit-coercions.rst
@@ -122,6 +122,14 @@ Declaring Coercions
   and then declares :token:`ident` as a coercion between it source and its target.
   Both forms support the :attr:`local` attribute, which makes the coercion local to the current section.
 
+  This command supports the :attr:`local` and :attr:`global` attributes
+  (described :ref:`here <set_unset_scope_qualifiers>`) as well as the
+  :attr:`nonuniform` attribute.
+
+  .. attr:: nonuniform
+
+     Silence the non uniform inheritance warning.
+
   .. exn:: @qualid not declared.
      :undocumented:
 
@@ -147,6 +155,7 @@ Declaring Coercions
 
      The :ref:`test for ambiguous coercion paths <ambiguous-paths>`
      may yield false positives involving the coercion :token:`qualid`.
+     Use the :attr:`nonuniform` attribute to silence this warning.
 
   .. warn:: New coercion path ... is ambiguous with existing ...
 

--- a/test-suite/output/coercions_nonuniform.out
+++ b/test-suite/output/coercions_nonuniform.out
@@ -1,0 +1,10 @@
+File "./output/coercions_nonuniform.v", line 22, characters 0-21:
+Warning: f does not respect the uniform inheritance condition.
+[uniform-inheritance,typechecker]
+File "./output/coercions_nonuniform.v", line 55, characters 0-17:
+Warning: f' does not respect the uniform inheritance condition.
+[uniform-inheritance,typechecker]
+File "./output/coercions_nonuniform.v", line 71, characters 7-17:
+The command has indeed failed with message:
+This command does not support this attribute: nonuniform.
+[unsupported-attributes,parsing]

--- a/test-suite/output/coercions_nonuniform.v
+++ b/test-suite/output/coercions_nonuniform.v
@@ -1,0 +1,71 @@
+(* Test the nonuniform attribute to silence warnings on coercions
+   not satisfying the non uniform inheritance condition. *)
+
+Module Test0.
+
+Parameter C : nat -> bool -> Type.
+Parameter D : Type.
+Parameter f : forall (n : nat) (b : bool), C n b -> D.
+
+(* uniform inheritance satisfied, no warning *)
+Coercion f : C >-> D.
+
+End Test0.
+
+Module Test1.
+
+Parameter C : nat -> bool -> Type.
+Parameter D : Type.
+Parameter f : forall (b : bool) (n : nat), C n b -> D.
+
+(* uniform inheritance not satisfied, warning *)
+Coercion f : C >-> D.
+
+End Test1.
+
+Module Test2.
+
+Parameter C : nat -> bool -> Type.
+Parameter D : Type.
+Parameter f : forall (b : bool) (n : nat), C n b -> D.
+
+(* uniform inheritance not satisfied but attribute, no warning *)
+#[nonuniform] Coercion f : C >-> D.
+
+End Test2.
+
+Module Test3.
+
+Parameter C : nat -> bool -> Type.
+Parameter D : Type.
+Parameter f : forall (n : nat) (b : bool), C n b -> D.
+
+(* uniform inheritance satisfied, no warning *)
+Coercion f' := f.
+
+End Test3.
+
+Module Test4.
+
+Parameter C : nat -> bool -> Type.
+Parameter D : Type.
+Parameter f : forall (b : bool) (n : nat), C n b -> D.
+
+(* uniform inheritance not satisfied, warning *)
+Coercion f' := f.
+
+End Test4.
+
+Module Test5.
+
+Parameter C : nat -> bool -> Type.
+Parameter D : Type.
+Parameter f : forall (b : bool) (n : nat), C n b -> D.
+
+(* uniform inheritance not satisfied but attribute, no warning *)
+#[nonuniform] Coercion f' := f.
+
+End Test5.
+
+(* Check that attribute is not supported for non coercion definitions *)
+Fail #[nonuniform] Definition f := id.

--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -29,7 +29,7 @@ let declare_variable is_coe ~kind typ univs imps impl {CAst.v=name} =
   let env = Global.env () in
   let sigma = Evd.from_env env in
   let () = Classes.declare_instance env sigma None Hints.Local r in
-  let () = if is_coe then ComCoercion.try_add_new_coercion r ~local:true ~poly:false in
+  let () = if is_coe then ComCoercion.try_add_new_coercion r ~local:true ~poly:false ~nonuniform:false in
   ()
 
 let instance_of_univ_entry = function
@@ -62,7 +62,7 @@ let declare_axiom is_coe ~poly ~local ~kind typ (univs, ubinders) imps nl {CAst.
     | Locality.ImportNeedQualified -> true
     | Locality.ImportDefaultBehavior -> false
   in
-  let () = if is_coe then ComCoercion.try_add_new_coercion gr ~local ~poly in
+  let () = if is_coe then ComCoercion.try_add_new_coercion gr ~local ~poly ~nonuniform:false in
   let inst = instance_of_univ_entry univs in
   (gr,inst)
 

--- a/vernac/comCoercion.mli
+++ b/vernac/comCoercion.mli
@@ -19,24 +19,27 @@ val try_add_new_coercion_with_target
   :  GlobRef.t
   -> local:bool
   -> poly:bool
+  -> nonuniform:bool
   -> source:cl_typ
   -> target:cl_typ
   -> unit
 
 (** [try_add_new_coercion ref s] declares [ref], assumed to be of type
    [(x1:T1)...(xn:Tn)src->tg], as a coercion from [src] to [tg] *)
-val try_add_new_coercion : GlobRef.t -> local:bool -> poly:bool -> unit
+val try_add_new_coercion : GlobRef.t -> local:bool -> poly:bool ->
+  nonuniform:bool -> unit
 
 (** [try_add_new_coercion_subclass cst s] expects that [cst] denotes a
    transparent constant which unfolds to some class [tg]; it declares
    an identity coercion from [cst] to [tg], named something like
    ["Id_cst_tg"] *)
-val try_add_new_coercion_subclass : cl_typ -> local:bool -> poly:bool -> unit
+val try_add_new_coercion_subclass : cl_typ -> local:bool -> poly:bool ->
+  nonuniform:bool -> unit
 
 (** [try_add_new_coercion_with_source ref s src] declares [ref] as a coercion
    from [src] to [tg] where the target is inferred from the type of [ref] *)
 val try_add_new_coercion_with_source : GlobRef.t -> local:bool ->
-  poly:bool -> source:cl_typ -> unit
+  poly:bool -> nonuniform:bool -> source:cl_typ -> unit
 
 (** [try_add_new_identity_coercion id s src tg] enriches the
    environment with a new definition of name [id] declared as an
@@ -46,8 +49,12 @@ val try_add_new_identity_coercion
   -> local:bool
   -> poly:bool -> source:cl_typ -> target:cl_typ -> unit
 
-val add_coercion_hook : poly:bool -> Declare.Hook.t
+val add_coercion_hook : poly:bool -> nonuniform:bool -> Declare.Hook.t
 
 val add_subclass_hook : poly:bool -> Declare.Hook.t
 
 val class_of_global : GlobRef.t -> cl_typ
+
+(** Attribute to silence warning for coercions that don't satisfy
+   the uniform inheritance condition. *)
+val nonuniform : bool option Attributes.attribute

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -685,7 +685,7 @@ let do_mutual_inductive ~template udecl indl ~cumulative ~poly ?typing_flags ~pr
   (* Declare the possible notations of inductive types *)
   List.iter (Metasyntax.add_notation_interpretation ~local:false (Global.env ())) ntns;
   (* Declare the coercions *)
-  List.iter (fun qid -> ComCoercion.try_add_new_coercion (Nametab.locate qid) ~local:false ~poly) coes
+  List.iter (fun qid -> ComCoercion.try_add_new_coercion (Nametab.locate qid) ~local:false ~poly ~nonuniform:false) coes
 
 (** Prepare a "match" template for a given inductive type.
     For each branch of the match, we list the constructor name

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -380,7 +380,7 @@ let build_named_proj ~primitive ~flags ~poly ~univs ~uinstance ~kind env paramde
   Impargs.maybe_declare_manual_implicits false refi impls;
   if flags.pf_subclass then begin
     let cl = ComCoercion.class_of_global (GlobRef.IndRef indsp) in
-    ComCoercion.try_add_new_coercion_with_source refi ~local:false ~poly ~source:cl
+    ComCoercion.try_add_new_coercion_with_source refi ~local:false ~poly ~nonuniform:false ~source:cl
   end;
   let i = if is_local_assum decl then i+1 else i in
   (Some kn, i, Projection term::subst)
@@ -594,7 +594,7 @@ let declare_structure ~cumulative finite ~univs ~variances ~primitive_proj
     let cstr = (rsp, 1) in
     let projections = declare_projections rsp (projunivs,ubinders) ~kind inhabitant_id coers implfs fields in
     let build = GlobRef.ConstructRef cstr in
-    let () = if is_coercion then ComCoercion.try_add_new_coercion build ~local:false ~poly in
+    let () = if is_coercion then ComCoercion.try_add_new_coercion build ~local:false ~poly ~nonuniform:false in
     let struc = Structure.make (Global.env ()) rsp projections in
     let () = declare_structure_entry struc in
     rsp


### PR DESCRIPTION
This is a follow up of https://github.com/coq/coq/pull/15789 implementing a comment of @CohenCyril on Zulip: https://coq.zulipchat.com/#narrow/stream/237977-Coq-users/topic/Identity.20Coercions/near/276371166

The #[nonuniform] boolean attribute helps silencing the non-uniform-inheritance warning on coercions when the user needs to declare such a coercion on purpose.

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
- [x] Added / updated **documentation**.

#### Overlays (to be merged synchronously with the PR)
* https://github.com/LPCIC/coq-elpi/pull/352
* https://github.com/Mtac2/Mtac2/pull/355
