### PR TITLE
Add Jasmin and mathcomp-word to CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -804,6 +804,19 @@ library:ci-deriving:
   - build:edge+flambda
   - library:ci-mathcomp
 
+library:ci-mathcomp_word:
+  extends: .ci-template-flambda
+  needs:
+  - build:edge+flambda
+  - library:ci-mathcomp
+
+library:ci-jasmin:
+  extends: .ci-template-flambda
+  needs:
+  - build:edge+flambda
+  - library:ci-mathcomp
+  - library:ci-mathcomp_word
+
 # Plugins are by definition the projects that depend on Coq's ML API
 
 plugin:ci-aac_tactics:

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -44,8 +44,10 @@ CI_TARGETS= \
     ci-coqhammer \
     ci-hott \
     ci-iris \
+    ci-jasmin \
     ci-math_classes \
     ci-mathcomp \
+    ci-mathcomp_word \
     ci-mczify \
     ci-mathcomp_base \
     ci-finmap \
@@ -100,9 +102,12 @@ ci-fourcolor: ci-mathcomp
 ci-oddorder: ci-mathcomp
 ci-fcsl_pcm: ci-mathcomp
 ci-mczify: ci-mathcomp
+ci-mathcomp_word: ci-mathcomp
 ci-finmap: ci-mathcomp_base
 ci-bigenough: ci-mathcomp_base
 ci-analysis: ci-elpi ci-finmap ci-bigenough
+
+ci-jasmin: ci-mathcomp_word
 
 ci-iris: ci-autosubst
 

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -334,3 +334,13 @@ project category_theory "https://github.com/jwiegley/category-theory" "master"
 # itauto
 ########################################################################
 project itauto "https://gitlab.inria.fr/fbesson/itauto" "master"
+
+########################################################################
+# Mathcomp-word
+########################################################################
+project mathcomp_word "https://github.com/jasmin-lang/coqword" "main"
+
+########################################################################
+# Jasmin
+########################################################################
+project jasmin "https://github.com/jasmin-lang/jasmin" "main"

--- a/dev/ci/ci-jasmin.sh
+++ b/dev/ci/ci-jasmin.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+git_download jasmin
+
+if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
+
+export COQEXTRAFLAGS='-native-compiler no'
+
+( cd "${CI_BUILD_DIR}/jasmin"
+  make -C proofs
+)

--- a/dev/ci/ci-mathcomp_word.sh
+++ b/dev/ci/ci-mathcomp_word.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+git_download mathcomp_word
+
+if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
+
+( cd "${CI_BUILD_DIR}/mathcomp_word"
+  dune build @install -p coq-mathcomp-word
+  dune install -p coq-mathcomp-word --prefix="$CI_INSTALL_DIR"
+)


### PR DESCRIPTION
This PR adds the Jasmin compiler (https://github.com/jasmin-lang/jasmin) to the Coq CI (and mathcomp-word, one of its dependencies). Two motivations :
- Jasmin and the (verified crypto) libraries produced using it look like a good entrypoint for Coq-related tools in industry
- it happened in the past that regressions introduced in new versions of Coq impacted Jasmin (but where not detected elsewhere)