### PR TITLE
Remove the univ_of_sort function from the API.

### DIFF
--- a/checker/checkInductive.ml
+++ b/checker/checkInductive.ml
@@ -86,7 +86,7 @@ let check_arity env ar1 ar2 = match ar1, ar2 with
     Constr.equal ar.mind_user_arity mind_user_arity &&
     Sorts.equal ar.mind_sort mind_sort
   | TemplateArity ar, TemplateArity {template_level} ->
-    Sorts.check_leq_sort (universes env) template_level ar.template_level
+    UGraph.check_leq_sort (universes env) template_level ar.template_level
     (* template_level is inferred by indtypes, so functor application can produce a smaller one *)
   | (RegularArity _ | TemplateArity _), _ -> assert false
 

--- a/checker/checker.ml
+++ b/checker/checker.ml
@@ -241,11 +241,11 @@ let explain_exn = function
       hov 0 (anomaly_string () ++ str "uncaught exception Invalid_argument " ++ guill s ++ report ())
   | Sys.Break ->
     hov 0 (fnl () ++ str "User interrupt.")
-  | Univ.UniverseInconsistency i ->
+  | UGraph.UniverseInconsistency i ->
     let msg =
       if CDebug.(get_flag misc) then
         str "." ++ spc() ++
-          Univ.explain_universe_inconsistency Univ.Level.pr i
+          UGraph.explain_universe_inconsistency Univ.Level.pr i
       else
         mt() in
       hov 0 (str "Error: Universe inconsistency" ++ msg ++ str ".")

--- a/dev/ci/user-overlays/15856-ppedrot-universes-rm-univ-of-sort.sh
+++ b/dev/ci/user-overlays/15856-ppedrot-universes-rm-univ-of-sort.sh
@@ -1,0 +1,9 @@
+overlay elpi https://github.com/ppedrot/coq-elpi universes-rm-univ-of-sort 15856
+
+overlay equations https://github.com/ppedrot/Coq-Equations universes-rm-univ-of-sort 15856
+
+overlay itauto https://gitlab.inria.fr/pedrot/itauto universes-rm-univ-of-sort 15856
+
+overlay metacoq https://github.com/ppedrot/metacoq universes-rm-univ-of-sort 15856
+
+overlay unicoq https://github.com/ppedrot/unicoq universes-rm-univ-of-sort 15856

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -859,7 +859,7 @@ let compare_cumulative_instances cv_pb variances u u' sigma =
   match Evd.add_constraints sigma cstrs with
   | sigma ->
     Inl (Evd.add_universe_constraints sigma soft)
-  | exception Univ.UniverseInconsistency p -> Inr p
+  | exception UGraph.UniverseInconsistency p -> Inr p
 
 let compare_constructor_instances evd u u' =
   let open UnivProblem in
@@ -889,7 +889,7 @@ let eq_constr_univs_test ~evd ~extended_evd t u =
     if Sorts.equal s1 s2 then true
     else
       try sigma := add_universe_constraints !sigma UnivProblem.(Set.singleton (UEq (s1, s2))); true
-      with Univ.UniverseInconsistency _ | UniversesDiffer -> false
+      with UGraph.UniverseInconsistency _ | UniversesDiffer -> false
   in
   let kind1 = kind_of_term_upto evd in
   let kind2 = kind_of_term_upto extended_evd in

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -213,7 +213,7 @@ val eq_constr_univs_test :
    if possible. Returns [Inr p] when the former is impossible. *)
 val compare_cumulative_instances : Reduction.conv_pb -> Univ.Variance.t array ->
   Univ.Instance.t -> Univ.Instance.t -> evar_map ->
-  (evar_map, Univ.univ_inconsistency) Util.union
+  (evar_map, UGraph.univ_inconsistency) Util.union
 
 (** We should only compare constructors at convertible types, so this
    is only an opportunity to unify universes. *)

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1056,10 +1056,10 @@ let set_leq_sort env evd s1 s2 =
      else evd
 
 let check_eq evd s s' =
-  Sorts.check_eq_sort (UState.ugraph evd.universes) s s'
+  UGraph.check_eq_sort (UState.ugraph evd.universes) s s'
 
 let check_leq evd s s' =
-  Sorts.check_leq_sort (UState.ugraph evd.universes) s s'
+  UGraph.check_leq_sort (UState.ugraph evd.universes) s s'
 
 let check_constraints evd csts =
   UGraph.check_constraints csts (UState.ugraph evd.universes)

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -187,7 +187,7 @@ let drop_weak_constraints =
     ~value:false
 
 let sort_inconsistency cst l r =
-  raise (UGraph.UniverseInconsistency (cst, Sorts.univ_of_sort l, Sorts.univ_of_sort r, None))
+  raise (UGraph.UniverseInconsistency (cst, l, r, None))
 
 let subst_univs_sort normalize s =
   Sorts.sort_of_univ (subst_univs_universe normalize (Sorts.univ_of_sort s))
@@ -315,7 +315,9 @@ let process_universe_constraints uctx cstrs =
   (* Remove constraints mentioning Prop / SProp *)
   let maybe_univ_inconsistency c l r =
     if UGraph.type_in_type univs then false
-    else raise (UGraph.UniverseInconsistency (c, Universe.make l, Universe.make r, None))
+    else
+      let mk u = Sorts.sort_of_univ @@ Universe.make u in
+      raise (UGraph.UniverseInconsistency (c, mk l, mk r, None))
   in
   let filter (l, c, r) = match c with
   | Eq ->

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -250,7 +250,7 @@ let process_universe_constraints uctx cstrs =
           enforce_leq inst lu local
         else sort_inconsistency Eq (Sorts.sort_of_univ lu) r
   | Inl _, Inl _ (* both are algebraic *) ->
-    if Sorts.check_eq_sort univs l r then local
+    if UGraph.check_eq_sort univs l r then local
     else sort_inconsistency Eq l r
   in
   let unify_universes cst local =
@@ -261,7 +261,7 @@ let process_universe_constraints uctx cstrs =
           | ULe (l, r) ->
             begin match Univ.Universe.level (Sorts.univ_of_sort r) with
             | None ->
-              if Sorts.check_leq_sort univs l r then local
+              if UGraph.check_leq_sort univs l r then local
               else user_err Pp.(str "Algebraic universe on the right")
             | Some r' ->
               if Level.is_small r' then
@@ -269,7 +269,7 @@ let process_universe_constraints uctx cstrs =
                   then (* l contains a +1 and r=r' small so l <= r impossible *)
                     sort_inconsistency Le l r
                   else
-                    if Sorts.check_leq_sort univs l r then match Univ.Universe.level (Sorts.univ_of_sort l) with
+                    if UGraph.check_leq_sort univs l r then match Univ.Universe.level (Sorts.univ_of_sort l) with
                     | Some l ->
                       Univ.Constraints.add (l, Le, r') local
                     | None -> local
@@ -295,7 +295,7 @@ let process_universe_constraints uctx cstrs =
                      Hence, by doing this, we avoid a costly check here, and
                      make further checks of this constraint easier since it will
                      exist directly in the graph. *)
-                  Sorts.enforce_leq_sort l r local
+                  UGraph.enforce_leq_sort l r local
               end
           | ULub (l, r) ->
               equalize_variables true (Sorts.sort_of_univ (Universe.make l)) l (Sorts.sort_of_univ (Universe.make r)) r local

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -187,7 +187,7 @@ let drop_weak_constraints =
     ~value:false
 
 let sort_inconsistency cst l r =
-  raise (UniverseInconsistency (cst, Sorts.univ_of_sort l, Sorts.univ_of_sort r, None))
+  raise (UGraph.UniverseInconsistency (cst, Sorts.univ_of_sort l, Sorts.univ_of_sort r, None))
 
 let subst_univs_sort normalize s =
   Sorts.sort_of_univ (subst_univs_universe normalize (Sorts.univ_of_sort s))
@@ -307,7 +307,7 @@ let process_universe_constraints uctx cstrs =
   in
   let unify_universes cst local =
     if not (UGraph.type_in_type univs) then unify_universes cst local
-    else try unify_universes cst local with UniverseInconsistency _ -> local
+    else try unify_universes cst local with UGraph.UniverseInconsistency _ -> local
   in
   let local =
     UnivProblem.Set.fold unify_universes cstrs Constraints.empty
@@ -315,7 +315,7 @@ let process_universe_constraints uctx cstrs =
   (* Remove constraints mentioning Prop / SProp *)
   let maybe_univ_inconsistency c l r =
     if UGraph.type_in_type univs then false
-    else raise (UniverseInconsistency (c, Universe.make l, Universe.make r, None))
+    else raise (UGraph.UniverseInconsistency (c, Universe.make l, Universe.make r, None))
   in
   let filter (l, c, r) = match c with
   | Eq ->

--- a/engine/univProblem.ml
+++ b/engine/univProblem.ml
@@ -32,8 +32,8 @@ let check_eq_level g u v =
   else UGraph.check_eq_level g u v
 
 let check g = function
-  | ULe (u,v) -> Sorts.check_leq_sort g u v
-  | UEq (u,v) -> Sorts.check_eq_sort g u v
+  | ULe (u,v) -> UGraph.check_leq_sort g u v
+  | UEq (u,v) -> UGraph.check_eq_sort g u v
   | ULub (u,v) -> check_eq_level g u v
   | UWeak _ -> true
 

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -2809,10 +2809,10 @@ let interp_univ_constraints env evd cstrs =
     let cstrs' = Univ.Constraints.add cstr cstrs in
     try let evd = Evd.add_constraints evd (Univ.Constraints.singleton cstr) in
         evd, cstrs'
-    with Univ.UniverseInconsistency e as exn ->
+    with UGraph.UniverseInconsistency e as exn ->
       let _, info = Exninfo.capture exn in
       CErrors.user_err ~info
-        (Univ.explain_universe_inconsistency (Termops.pr_evd_level evd) e)
+        (UGraph.explain_universe_inconsistency (Termops.pr_evd_level evd) e)
   in
   List.fold_left interp (evd,Univ.Constraints.empty) cstrs
 

--- a/kernel/constr.ml
+++ b/kernel/constr.ml
@@ -1034,7 +1034,7 @@ let leq_constr_univs_infer univs m n =
           (try let c, _ = UGraph.enforce_leq_alg_sort s1 s2 univs in
             cstrs := Univ.Constraints.union c !cstrs;
             true
-          with Univ.UniverseInconsistency _ -> false)
+          with UGraph.UniverseInconsistency _ -> false)
     in
     let rec eq_constr' nargs m n =
       m == n || compare_head_gen eq_universes eq_sorts eq_constr' nargs m n

--- a/kernel/constr.ml
+++ b/kernel/constr.ml
@@ -974,7 +974,7 @@ let eq_constr_univs univs m n =
   if m == n then true
   else
     let eq_universes _ = UGraph.check_eq_instances univs in
-    let eq_sorts s1 s2 = s1 == s2 || Sorts.check_eq_sort univs s1 s2 in
+    let eq_sorts s1 s2 = s1 == s2 || UGraph.check_eq_sort univs s1 s2 in
     let rec eq_constr' nargs m n =
       m == n ||	compare_head_gen eq_universes eq_sorts eq_constr' nargs m n
     in compare_head_gen eq_universes eq_sorts eq_constr' 0 m n
@@ -984,9 +984,9 @@ let leq_constr_univs univs m n =
   else
     let eq_universes _ = UGraph.check_eq_instances univs in
     let eq_sorts s1 s2 = s1 == s2 ||
-      Sorts.check_eq_sort univs s1 s2 in
+      UGraph.check_eq_sort univs s1 s2 in
     let leq_sorts s1 s2 = s1 == s2 ||
-      Sorts.check_leq_sort univs s1 s2 in
+      UGraph.check_leq_sort univs s1 s2 in
     let rec eq_constr' nargs m n =
       m == n || compare_head_gen eq_universes eq_sorts eq_constr' nargs m n
     in
@@ -1003,9 +1003,9 @@ let eq_constr_univs_infer univs m n =
     let eq_sorts s1 s2 =
       if Sorts.equal s1 s2 then true
       else
-        if Sorts.check_eq_sort univs s1 s2 then true
+        if UGraph.check_eq_sort univs s1 s2 then true
         else
-          (cstrs := Sorts.enforce_eq_sort s1 s2 !cstrs;
+          (cstrs := UGraph.enforce_eq_sort s1 s2 !cstrs;
            true)
     in
     let rec eq_constr' nargs m n =
@@ -1022,16 +1022,16 @@ let leq_constr_univs_infer univs m n =
     let eq_sorts s1 s2 =
       if Sorts.equal s1 s2 then true
       else
-        if Sorts.check_eq_sort univs s1 s2 then true
-        else (cstrs := Sorts.enforce_eq_sort s1 s2 !cstrs;
+        if UGraph.check_eq_sort univs s1 s2 then true
+        else (cstrs := UGraph.enforce_eq_sort s1 s2 !cstrs;
               true)
     in
     let leq_sorts s1 s2 =
       if Sorts.equal s1 s2 then true
       else
-        if Sorts.check_leq_sort univs s1 s2 then true
+        if UGraph.check_leq_sort univs s1 s2 then true
         else
-          (try let c, _ = Sorts.enforce_leq_alg_sort s1 s2 univs in
+          (try let c, _ = UGraph.enforce_leq_alg_sort s1 s2 univs in
             cstrs := Univ.Constraints.union c !cstrs;
             true
           with Univ.UniverseInconsistency _ -> false)

--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -70,9 +70,12 @@ type univ_info = { ind_squashed : bool; ind_has_relevant_arg : bool;
                    missing : Sorts.t list; (* missing u <= ind_univ constraints *)
                  }
 
-let sup_sort s1 s2 =
-  let open Sorts in
-  sort_of_univ (Universe.sup (univ_of_sort s1) (univ_of_sort s2))
+let sup_sort s1 s2 = match s1, s2 with
+| (_, SProp) -> assert false (* template SProp not allowed *)
+| (SProp, s) | (Prop, s) | (s, Prop) -> s
+| (Set, Set) -> Sorts.set
+| (Set, Type u) | (Type u, Set) -> Sorts.sort_of_univ (Universe.sup u Universe.type0)
+| (Type u, Type v) -> Sorts.sort_of_univ (Universe.sup u v)
 
 let check_univ_leq ?(is_real_arg=false) env u info =
   let ind_univ = info.ind_univ in

--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -81,7 +81,7 @@ let check_univ_leq ?(is_real_arg=false) env u info =
     else info
   in
   (* Inductive types provide explicit lifting from SProp to other universes, so allow SProp <= any. *)
-  if Sorts.is_sprop u || Sorts.check_leq_sort (universes env) u ind_univ
+  if Sorts.is_sprop u || UGraph.check_leq_sort (universes env) u ind_univ
   then { info with ind_min_univ = Option.map (sup_sort u) info.ind_min_univ }
   else if is_impredicative_sort env ind_univ
        && Option.is_empty info.ind_min_univ then { info with ind_squashed = true }

--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -307,7 +307,10 @@ let abstract_packets usubst ((arity,lc),(indices,splayed_lc),univ_info) =
       args,out)
       splayed_lc
   in
-  let ind_univ = Sorts.sort_of_univ  (Univ.subst_univs_level_universe usubst (Sorts.univ_of_sort univ_info.ind_univ)) in
+  let ind_univ = match univ_info.ind_univ with
+  | Prop | SProp | Set -> univ_info.ind_univ
+  | Type u -> Sorts.sort_of_univ (Univ.subst_univs_level_universe usubst u)
+  in
 
   let arity = match univ_info.ind_min_univ with
     | None -> RegularArity {mind_user_arity = arity; mind_sort = ind_univ}

--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -46,7 +46,7 @@ type signature_mismatch_error =
   | RecordFieldExpected of bool
   | RecordProjectionsExpected of Name.t list
   | NotEqualInductiveAliases
-  | IncompatibleUniverses of Univ.univ_inconsistency
+  | IncompatibleUniverses of UGraph.univ_inconsistency
   | IncompatiblePolymorphism of env * types * types
   | IncompatibleConstraints of { got : Univ.AbstractContext.t; expect : Univ.AbstractContext.t }
   | IncompatibleVariance

--- a/kernel/modops.mli
+++ b/kernel/modops.mli
@@ -105,7 +105,7 @@ type signature_mismatch_error =
   | RecordFieldExpected of bool
   | RecordProjectionsExpected of Name.t list
   | NotEqualInductiveAliases
-  | IncompatibleUniverses of Univ.univ_inconsistency
+  | IncompatibleUniverses of UGraph.univ_inconsistency
   | IncompatiblePolymorphism of env * types * types
   | IncompatibleConstraints of { got : Univ.AbstractContext.t; expect : Univ.AbstractContext.t }
   | IncompatibleVariance

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -432,7 +432,7 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
          let cuniv = conv_table_key infos.cnv_inf ~nargs fl1 fl2 cuniv in
          let () = if irr_flex (info_env infos.cnv_inf) fl1 then raise NotConvertible (* trigger the fallback *) in
          convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
-       with NotConvertible | Univ.UniverseInconsistency _ ->
+       with NotConvertible | UGraph.UniverseInconsistency _ ->
         let r1 = unfold_ref_with_args infos.cnv_inf infos.lft_tab fl1 v1 in
         let r2 = unfold_ref_with_args infos.cnv_inf infos.rgt_tab fl2 v2 in
         match r1, r2 with

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -872,10 +872,10 @@ let clos_gen_conv trans cv_pb l2r evars env graph univs t1 t2 =
 
 
 let check_eq univs u u' =
-  if not (Sorts.check_eq_sort univs u u') then raise NotConvertible
+  if not (UGraph.check_eq_sort univs u u') then raise NotConvertible
 
 let check_leq univs u u' =
-  if not (Sorts.check_leq_sort univs u u') then raise NotConvertible
+  if not (UGraph.check_leq_sort univs u u') then raise NotConvertible
 
 let check_sort_cmp_universes pb s0 s1 univs =
   match pb with
@@ -915,14 +915,14 @@ let () =
   CClosure.set_conv conv
 
 let infer_eq (univs, cstrs as cuniv) u u' =
-  if Sorts.check_eq_sort univs u u' then cuniv
+  if UGraph.check_eq_sort univs u u' then cuniv
   else
-    univs, (Sorts.enforce_eq_sort u u' cstrs)
+    univs, (UGraph.enforce_eq_sort u u' cstrs)
 
 let infer_leq (univs, cstrs as cuniv) u u' =
-  if Sorts.check_leq_sort univs u u' then cuniv
+  if UGraph.check_leq_sort univs u u' then cuniv
   else
-    let cstrs', _ = Sorts.enforce_leq_alg_sort u u' univs in
+    let cstrs', _ = UGraph.enforce_leq_alg_sort u u' univs in
       univs, Univ.Constraints.union cstrs cstrs'
 
 let infer_cmp_universes _env pb s0 s1 univs =

--- a/kernel/sorts.ml
+++ b/kernel/sorts.ml
@@ -25,12 +25,6 @@ let prop = Prop
 let set = Set
 let type1 = Type type1_univ
 
-let univ_of_sort = function
-  | Type u -> u
-  | Set -> Universe.type0
-  | Prop -> Universe.type0m
-  | SProp -> Universe.sprop
-
 let sort_of_univ u =
   if Universe.is_sprop u then sprop
   else if is_type0m_univ u then prop
@@ -38,7 +32,18 @@ let sort_of_univ u =
   else Type u
 
 let compare s1 s2 =
-  if s1 == s2 then 0 else Universe.compare (univ_of_sort s1) (univ_of_sort s2)
+  if s1 == s2 then 0 else
+    match s1, s2 with
+    | SProp, SProp -> 0
+    | SProp, (Prop | Set | Type _) -> -1
+    | (Prop | Set | Type _), SProp -> 1
+    | Prop, Prop -> 0
+    | Prop, (Set | Type _) -> -1
+    | Set, Prop -> 1
+    | Set, Set -> 0
+    | Set, Type _ -> -1
+    | Type u1, Type u2 -> Universe.compare u1 u2
+    | Type _, (Prop | Set) -> 1
 
 let equal s1 s2 = Int.equal (compare s1 s2) 0
 
@@ -62,7 +67,11 @@ let is_small = function
   | SProp | Prop | Set -> true
   | Type _ -> false
 
-let levels s = Universe.levels (univ_of_sort s)
+let levels s = match s with
+| SProp -> Level.Set.singleton Level.sprop
+| Prop -> Level.Set.singleton Level.prop
+| Set -> Level.Set.singleton Level.set
+| Type u -> Universe.levels u
 
 let family = function
   | SProp -> InSProp

--- a/kernel/sorts.ml
+++ b/kernel/sorts.ml
@@ -64,61 +64,6 @@ let is_small = function
 
 let levels s = Universe.levels (univ_of_sort s)
 
-(* The functions below rely on the invariant that no universe in the graph
-   can be unified with Prop / SProp. This is ensured by UGraph, which only
-   contains Set as a "small" level. *)
-
-let check_eq_sort ugraph s1 s2 = match s1, s2 with
-| (SProp, SProp) | (Prop, Prop) | (Set, Set) -> true
-| (SProp, _) | (_, SProp) | (Prop, _) | (_, Prop) ->
-  UGraph.type_in_type ugraph
-| (Type _ | Set), (Type _ | Set) ->
-  UGraph.check_eq ugraph (univ_of_sort s1) (univ_of_sort s2)
-
-let check_leq_sort ugraph s1 s2 = match s1, s2 with
-| (SProp, SProp) | (Prop, Prop) | (Set, Set) -> true
-| (SProp, _) -> UGraph.cumulative_sprop ugraph || UGraph.type_in_type ugraph
-| (Prop, SProp) -> UGraph.type_in_type ugraph
-| (Prop, (Set | Type _)) -> true
-| (_, (SProp | Prop)) -> UGraph.type_in_type ugraph
-| (Type _ | Set), (Type _ | Set) ->
-  UGraph.check_leq ugraph (univ_of_sort s1) (univ_of_sort s2)
-
-let enforce_eq_sort s1 s2 cst = match s1, s2 with
-| (SProp, SProp) | (Prop, Prop) | (Set, Set) -> cst
-| (((Prop | Set | Type _) as s1), (Prop | SProp as s2))
-| ((Prop | SProp as s1), ((Prop | Set | Type _) as s2)) ->
-  let s1 = univ_of_sort s1 in
-  let s2 = univ_of_sort s2 in
-  raise (Univ.UniverseInconsistency (Eq, s1, s2, None))
-| (Set | Type _), (Set | Type _) ->
-  Univ.enforce_eq (univ_of_sort s1) (univ_of_sort s2) cst
-
-let enforce_leq_sort s1 s2 cst = match s1, s2 with
-| (SProp, SProp) | (Prop, Prop) | (Set, Set) -> cst
-| (Prop, (Set | Type _)) -> cst
-| (((Prop | Set | Type _) as s1), (Prop | SProp as s2))
-| ((SProp as s1), ((Prop | Set | Type _) as s2)) ->
-  let s1 = univ_of_sort s1 in
-  let s2 = univ_of_sort s2 in
-  raise (Univ.UniverseInconsistency (Le, s1, s2, None))
-| (Set | Type _), (Set | Type _) ->
-  Univ.enforce_leq (univ_of_sort s1) (univ_of_sort s2) cst
-
-let enforce_leq_alg_sort s1 s2 g = match s1, s2 with
-| (SProp, SProp) | (Prop, Prop) | (Set, Set) -> Constraints.empty, g
-| (Prop, (Set | Type _)) -> Constraints.empty, g
-| (((Prop | Set | Type _) as s1), (Prop | SProp as s2))
-| ((SProp as s1), ((Prop | Set | Type _) as s2)) ->
-  if UGraph.cumulative_sprop g && is_sprop s1 then
-    Constraints.empty, g
-  else
-    let s1 = univ_of_sort s1 in
-    let s2 = univ_of_sort s2 in
-    raise (Univ.UniverseInconsistency (Le, s1, s2, None))
-| (Set | Type _), (Set | Type _) ->
-  UGraph.enforce_leq_alg (univ_of_sort s1) (univ_of_sort s2) g
-
 let family = function
   | SProp -> InSProp
   | Prop -> InProp

--- a/kernel/sorts.mli
+++ b/kernel/sorts.mli
@@ -46,13 +46,6 @@ val sort_of_univ : Univ.Universe.t -> t
 
 val levels : t -> Univ.Level.Set.t
 
-val check_eq_sort : UGraph.t -> t -> t -> bool
-val check_leq_sort : UGraph.t -> t -> t -> bool
-
-val enforce_eq_sort : t -> t -> Univ.Constraints.t -> Univ.Constraints.t
-val enforce_leq_sort : t -> t -> Univ.Constraints.t -> Univ.Constraints.t
-val enforce_leq_alg_sort : t -> t -> UGraph.t -> Univ.Constraints.t * UGraph.t
-
 val super : t -> t
 
 (** On binders: is this variable proof relevant *)

--- a/kernel/sorts.mli
+++ b/kernel/sorts.mli
@@ -41,7 +41,6 @@ val family_compare : family -> family -> int
 val family_equal : family -> family -> bool
 val family_leq : family -> family -> bool
 
-val univ_of_sort : t -> Univ.Universe.t
 val sort_of_univ : Univ.Universe.t -> t
 
 val levels : t -> Univ.Level.Set.t

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -91,7 +91,7 @@ let check_conv_error error why cst poly f env a1 a2 =
         else error (IncompatiblePolymorphism (env, a1, a2))
       else Constraints.union cst cst'
   with NotConvertible -> error why
-     | Univ.UniverseInconsistency e -> error (IncompatibleUniverses e)
+     | UGraph.UniverseInconsistency e -> error (IncompatibleUniverses e)
 
 let check_universes error env u1 u2 =
   match u1, u2 with

--- a/kernel/uGraph.ml
+++ b/kernel/uGraph.ml
@@ -14,7 +14,6 @@ module G = AcyclicGraph.Make(struct
     type t = Level.t
     module Set = Level.Set
     module Map = Level.Map
-    module Constraints = Constraints
 
     let equal = Level.equal
     let compare = Level.compare
@@ -183,8 +182,12 @@ exception UndeclaredLevel = G.Undeclared
 let check_declared_universes g l =
   G.check_declared g.graph (Level.Set.remove Level.prop (Level.Set.remove Level.sprop l))
 
-let constraints_of_universes g = G.constraints_of g.graph
-let constraints_for ~kept g = G.constraints_for ~kept:(Level.Set.remove Level.prop (Level.Set.remove Level.sprop kept)) g.graph
+let constraints_of_universes g =
+  let add cst accu = Constraints.add cst accu in
+  G.constraints_of g.graph add Constraints.empty
+let constraints_for ~kept g =
+  let add cst accu = Constraints.add cst accu in
+  G.constraints_for ~kept:(Level.Set.remove Level.prop (Level.Set.remove Level.sprop kept)) g.graph add Constraints.empty
 
 (** Subtyping of polymorphic contexts *)
 

--- a/kernel/uGraph.ml
+++ b/kernel/uGraph.ml
@@ -241,12 +241,17 @@ let check_universes_invariants g = G.check_invariants ~required_canonical:Level.
 
 open Sorts
 
+let get_algebraic = function
+| Prop | SProp -> assert false
+| Set -> Universe.type0
+| Type u -> u
+
 let check_eq_sort ugraph s1 s2 = match s1, s2 with
 | (SProp, SProp) | (Prop, Prop) | (Set, Set) -> true
 | (SProp, _) | (_, SProp) | (Prop, _) | (_, Prop) ->
   type_in_type ugraph
 | (Type _ | Set), (Type _ | Set) ->
-  check_eq ugraph (Sorts.univ_of_sort s1) (Sorts.univ_of_sort s2)
+  check_eq ugraph (get_algebraic s1) (get_algebraic s2)
 
 let check_leq_sort ugraph s1 s2 = match s1, s2 with
 | (SProp, SProp) | (Prop, Prop) | (Set, Set) -> true
@@ -255,7 +260,7 @@ let check_leq_sort ugraph s1 s2 = match s1, s2 with
 | (Prop, (Set | Type _)) -> true
 | (_, (SProp | Prop)) -> type_in_type ugraph
 | (Type _ | Set), (Type _ | Set) ->
-  check_leq ugraph (Sorts.univ_of_sort s1) (Sorts.univ_of_sort s2)
+  check_leq ugraph (get_algebraic s1) (get_algebraic s2)
 
 let enforce_eq_sort s1 s2 cst = match s1, s2 with
 | (SProp, SProp) | (Prop, Prop) | (Set, Set) -> cst
@@ -263,7 +268,7 @@ let enforce_eq_sort s1 s2 cst = match s1, s2 with
 | ((Prop | SProp as s1), ((Prop | Set | Type _) as s2)) ->
   raise (UniverseInconsistency (Eq, s1, s2, None))
 | (Set | Type _), (Set | Type _) ->
-  Univ.enforce_eq (Sorts.univ_of_sort s1) (Sorts.univ_of_sort s2) cst
+  Univ.enforce_eq (get_algebraic s1) (get_algebraic s2) cst
 
 let enforce_leq_sort s1 s2 cst = match s1, s2 with
 | (SProp, SProp) | (Prop, Prop) | (Set, Set) -> cst
@@ -272,7 +277,7 @@ let enforce_leq_sort s1 s2 cst = match s1, s2 with
 | ((SProp as s1), ((Prop | Set | Type _) as s2)) ->
   raise (UniverseInconsistency (Le, s1, s2, None))
 | (Set | Type _), (Set | Type _) ->
-  Univ.enforce_leq (Sorts.univ_of_sort s1) (Sorts.univ_of_sort s2) cst
+  Univ.enforce_leq (get_algebraic s1) (get_algebraic s2) cst
 
 let enforce_leq_alg_sort s1 s2 g = match s1, s2 with
 | (SProp, SProp) | (Prop, Prop) | (Set, Set) -> Constraints.empty, g
@@ -284,7 +289,7 @@ let enforce_leq_alg_sort s1 s2 g = match s1, s2 with
   else
     raise (UniverseInconsistency (Le, s1, s2, None))
 | (Set | Type _), (Set | Type _) ->
-  enforce_leq_alg (Sorts.univ_of_sort s1) (Sorts.univ_of_sort s2) g
+  enforce_leq_alg (get_algebraic s1) (get_algebraic s2) g
 
 (** Pretty-printing *)
 

--- a/kernel/uGraph.mli
+++ b/kernel/uGraph.mli
@@ -47,7 +47,7 @@ val check_eq_instances : Instance.t check_function
   universes graph. It raises the exception [UniverseInconsistency] if the
   constraints are not satisfiable. *)
 
-type univ_inconsistency = constraint_type * Universe.t * Universe.t * explanation Lazy.t option
+type univ_inconsistency = constraint_type * Sorts.t * Sorts.t * explanation Lazy.t option
 
 exception UniverseInconsistency of univ_inconsistency
 

--- a/kernel/uGraph.mli
+++ b/kernel/uGraph.mli
@@ -48,13 +48,18 @@ val check_eq_instances : Instance.t check_function
   constraints are not satisfiable. *)
 
 val enforce_constraint : univ_constraint -> t -> t
+
+val enforce_eq_sort : Sorts.t -> Sorts.t -> Univ.Constraints.t -> Univ.Constraints.t
+val enforce_leq_sort : Sorts.t -> Sorts.t -> Univ.Constraints.t -> Univ.Constraints.t
+
 val merge_constraints : Constraints.t -> t -> t
 
 val check_constraint  : t -> univ_constraint -> bool
 val check_constraints : Constraints.t -> t -> bool
-
+val check_eq_sort : t -> Sorts.t  -> Sorts.t -> bool
+val check_leq_sort : t -> Sorts.t -> Sorts.t -> bool
 (** Picks an arbitrary set of constraints sufficient to ensure [u <= v]. *)
-val enforce_leq_alg : Universe.t -> Universe.t -> t -> Constraints.t * t
+val enforce_leq_alg_sort : Sorts.t -> Sorts.t -> t -> Univ.Constraints.t * t
 
 (** Adds a universe to the graph, ensuring it is >= or > Set.
    @raise AlreadyDeclared if the level is already declared in the graph. *)

--- a/kernel/uGraph.mli
+++ b/kernel/uGraph.mli
@@ -47,6 +47,10 @@ val check_eq_instances : Instance.t check_function
   universes graph. It raises the exception [UniverseInconsistency] if the
   constraints are not satisfiable. *)
 
+type univ_inconsistency = constraint_type * Universe.t * Universe.t * explanation Lazy.t option
+
+exception UniverseInconsistency of univ_inconsistency
+
 val enforce_constraint : univ_constraint -> t -> t
 
 val enforce_eq_sort : Sorts.t -> Sorts.t -> Univ.Constraints.t -> Univ.Constraints.t
@@ -116,6 +120,9 @@ val repr : t -> node Level.Map.t
 (** {6 Pretty-printing of universes. } *)
 
 val pr_universes : (Level.t -> Pp.t) -> node Level.Map.t -> Pp.t
+
+val explain_universe_inconsistency : (Level.t -> Pp.t) ->
+  univ_inconsistency -> Pp.t
 
 (** {6 Debugging} *)
 val check_universes_invariants : t -> unit

--- a/kernel/univ.ml
+++ b/kernel/univ.ml
@@ -1246,31 +1246,3 @@ let hcons_universe_context_set (v, c) =
   (hcons_universe_set v, hcons_constraints c)
 
 let hcons_univ x = Universe.hcons x
-
-(* Universe inconsistency: error raised when trying to enforce a relation
-   that would create a cycle in the graph of universes. *)
-
-type univ_inconsistency = constraint_type * universe * universe * explanation Lazy.t option
-
-(* Do not use in this file as we may be type-in-type *)
-exception UniverseInconsistency of univ_inconsistency
-
-let explain_universe_inconsistency prl (o,u,v,p : univ_inconsistency) =
-  let pr_uni = Universe.pr_with prl in
-  let pr_rel = function
-    | Eq -> str"=" | Lt -> str"<" | Le -> str"<="
-  in
-  let reason = match p with
-    | None -> mt()
-    | Some p ->
-      let p = Lazy.force p in
-      if p = [] then mt ()
-      else
-        str " because" ++ spc() ++ pr_uni v ++
-        prlist (fun (r,v) -> spc() ++ pr_rel r ++ str" " ++ prl v)
-          p ++
-        (if Universe.equal (Universe.make (snd (List.last p))) u then mt() else
-           (spc() ++ str "= " ++ pr_uni u))
-  in
-    str "Cannot enforce" ++ spc() ++ pr_uni u ++ spc() ++
-      pr_rel o ++ spc() ++ pr_uni v ++ reason

--- a/kernel/univ.mli
+++ b/kernel/univ.mli
@@ -243,9 +243,6 @@ val enforce_leq_level : Level.t constraint_function
   Constraints.t...
 *)
 type explanation = (constraint_type * Level.t) list
-type univ_inconsistency = constraint_type * Universe.t * Universe.t * explanation Lazy.t option
-
-exception UniverseInconsistency of univ_inconsistency
 
 (** {6 Support for universe polymorphism } *)
 
@@ -537,8 +534,6 @@ val pr_universe_context : (Level.t -> Pp.t) -> ?variance:Variance.t array ->
 val pr_abstract_universe_context : (Level.t -> Pp.t) -> ?variance:Variance.t array ->
   AbstractContext.t -> Pp.t
 val pr_universe_context_set : (Level.t -> Pp.t) -> ContextSet.t -> Pp.t
-val explain_universe_inconsistency : (Level.t -> Pp.t) ->
-  univ_inconsistency -> Pp.t
 
 val pr_universe_level_subst : universe_level_subst -> Pp.t
 val pr_universe_subst : universe_subst -> Pp.t

--- a/lib/acyclicGraph.mli
+++ b/lib/acyclicGraph.mli
@@ -18,8 +18,6 @@ module type Point = sig
   module Set : CSig.SetS with type elt = t
   module Map : CMap.ExtS with type key = t and module Set := Set
 
-  module Constraints : CSet.S with type elt = (t * constraint_type * t)
-
   val equal : t -> t -> bool
   val compare : t -> t -> int
 
@@ -57,9 +55,11 @@ module Make (Point:Point) : sig
   val enforce_leq : Point.t -> Point.t -> t -> t
   val enforce_lt : Point.t -> Point.t -> t -> t
 
-  val constraints_of : t -> Point.Constraints.t * Point.Set.t list
+  type 'a constraint_fold = Point.t * constraint_type * Point.t -> 'a -> 'a
 
-  val constraints_for : kept:Point.Set.t -> t -> Point.Constraints.t
+  val constraints_of : t -> 'a constraint_fold -> 'a -> 'a * Point.Set.t list
+
+  val constraints_for : kept:Point.Set.t -> t -> 'a constraint_fold -> 'a -> 'a
 
   val domain : t -> Point.Set.t
 

--- a/lib/acyclicGraph.mli
+++ b/lib/acyclicGraph.mli
@@ -21,9 +21,6 @@ module type Point = sig
   val equal : t -> t -> bool
   val compare : t -> t -> int
 
-  type explanation = (constraint_type * t) list
-  val error_inconsistency : constraint_type -> t -> t -> explanation lazy_t option -> 'a
-
   val pr : t -> Pp.t
 end
 
@@ -51,9 +48,13 @@ module Make (Point:Point) : sig
   val check_leq : Point.t check_function
   val check_lt : Point.t check_function
 
-  val enforce_eq : Point.t -> Point.t -> t -> t
-  val enforce_leq : Point.t -> Point.t -> t -> t
-  val enforce_lt : Point.t -> Point.t -> t -> t
+  val enforce_eq : Point.t -> Point.t -> t -> t option
+  val enforce_leq : Point.t -> Point.t -> t -> t option
+  val enforce_lt : Point.t -> Point.t -> t -> t option
+
+  val get_explanation : (Point.t * constraint_type * Point.t) -> t -> (constraint_type * Point.t) list
+  (** Assuming that the corresponding call to [enforce_*] returned [None], this
+      will give a trace for the failure. *)
 
   type 'a constraint_fold = Point.t * constraint_type * Point.t -> 'a -> 'a
 

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -233,7 +233,7 @@ let change_property_sort evd toSort princ princName =
         in
         let s = Constr.destSort ty in
         Global.add_constraints
-          (Sorts.enforce_leq_sort
+          (UGraph.enforce_leq_sort
              toSort s Univ.Constraints.empty);
         Term.compose_prod args (Constr.mkSort toSort) )
   in

--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -620,7 +620,7 @@ module Env = struct
       let csts = UnivProblem.Set.force csts in
       match Evd.add_universe_constraints sigma csts with
       | sigma -> Some (env, sigma)
-      | exception Univ.UniverseInconsistency _ -> None )
+      | exception UGraph.UniverseInconsistency _ -> None )
     | None -> None
 
   let compute_rank_add env v is_prop =

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -374,7 +374,7 @@ let compare_heads env evd ~nargs term term' =
   let check_strict evd u u' =
     let cstrs = Univ.enforce_eq_instances u u' Univ.Constraints.empty in
     try Success (Evd.add_constraints evd cstrs)
-    with Univ.UniverseInconsistency p -> UnifFailure (evd, UnifUnivInconsistency p)
+    with UGraph.UniverseInconsistency p -> UnifFailure (evd, UnifUnivInconsistency p)
   in
   match EConstr.kind evd term, EConstr.kind evd term' with
   | Const (c, u), Const (c', u') when QConstant.equal env c c' ->
@@ -553,7 +553,7 @@ let infer_conv_noticing_evars ~pb ~ts env sigma t1 t2 =
   | None ->
     if !has_evar then None
     else Some (UnifFailure (sigma, ConversionFailed (env,t1,t2)))
-  | exception Univ.UniverseInconsistency e ->
+  | exception UGraph.UniverseInconsistency e ->
     if !has_evar then None
     else Some (UnifFailure (sigma, UnifUnivInconsistency e))
 
@@ -661,7 +661,7 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) flags env evd pbty
     else
       ise_and evd [(fun i ->
           try compare_heads env i ~nargs term term'
-          with Univ.UniverseInconsistency p -> UnifFailure (i, UnifUnivInconsistency p));
+          with UGraph.UniverseInconsistency p -> UnifFailure (i, UnifUnivInconsistency p));
          (fun i -> exact_ise_stack2 env i (evar_conv_x flags) sk sk')]
   in
   let consume l2r (_, skF as apprF) (_,skM as apprM) i =
@@ -957,7 +957,7 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) flags env evd pbty
               ise_and i [(fun i ->
                 try Success (Evd.add_universe_constraints i univs)
                 with UniversesDiffer -> UnifFailure (i,NotSameHead)
-                | Univ.UniverseInconsistency p -> UnifFailure (i, UnifUnivInconsistency p));
+                | UGraph.UniverseInconsistency p -> UnifFailure (i, UnifUnivInconsistency p));
                          (fun i -> exact_ise_stack2 env i (evar_conv_x flags) sk1 sk2)]
           | None ->
             UnifFailure (i,NotSameHead)
@@ -1069,7 +1069,7 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) flags env evd pbty
                  then Evd.set_eq_sort env evd s1 s2
                  else Evd.set_leq_sort env evd s1 s2
                in Success evd'
-             with Univ.UniverseInconsistency p ->
+             with UGraph.UniverseInconsistency p ->
                UnifFailure (evd,UnifUnivInconsistency p)
              | e when CErrors.noncritical e -> UnifFailure (evd,NotSameHead))
 

--- a/pretyping/pretype_errors.ml
+++ b/pretyping/pretype_errors.ml
@@ -24,7 +24,7 @@ type unification_error =
   | MetaOccurInBody of Evar.t
   | InstanceNotSameType of Evar.t * env * types * types
   | InstanceNotFunctionalType of Evar.t * env * constr * types
-  | UnifUnivInconsistency of Univ.univ_inconsistency
+  | UnifUnivInconsistency of UGraph.univ_inconsistency
   | CannotSolveConstraint of Evd.evar_constraint * unification_error
   | ProblemBeyondCapabilities
 

--- a/pretyping/pretype_errors.mli
+++ b/pretyping/pretype_errors.mli
@@ -27,7 +27,7 @@ type unification_error =
   | MetaOccurInBody of Evar.t
   | InstanceNotSameType of Evar.t * env * types * types
   | InstanceNotFunctionalType of Evar.t * env * constr * types
-  | UnifUnivInconsistency of Univ.univ_inconsistency
+  | UnifUnivInconsistency of UGraph.univ_inconsistency
   | CannotSolveConstraint of Evd.evar_constraint * unification_error
   | ProblemBeyondCapabilities
 

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -1299,23 +1299,11 @@ let pretype_type self c ?loc ~flags valcon (env : GlobEnv.t) sigma = match DAst.
     in
     let sigma, tycon' = split_as_array !!env sigma tycon in
     let sigma, jty = eval_type_pretyper self ~flags tycon' env sigma ty in
-    (* XXX not sure if we need to be this complex, I wrote this while
-       being confused by broken universe substitutions *)
-    let sigma, u = match Univ.Universe.level (Sorts.univ_of_sort jty.utj_type) with
-      | Some v ->
-        let sigma = Evd.make_nonalgebraic_variable sigma v in
-        let sigma = Option.cata (Evd.set_leq_level sigma v) sigma u in
-        sigma, Option.default v u
-      | None ->
-        let sigma, u = match u with
-          | Some u -> sigma, u
-          | None -> Evd.new_univ_level_variable UState.univ_flexible sigma
-        in
-        let sigma = Evd.set_leq_sort !!env sigma jty.utj_type
-            (Sorts.sort_of_univ (Univ.Universe.make u))
-        in
-        sigma, u
+    let sigma, u = match u with
+    | Some u -> sigma, u
+    | None -> Evd.new_univ_level_variable UState.univ_flexible sigma
     in
+    let sigma = Evd.set_leq_sort !!env sigma jty.utj_type (Sorts.sort_of_univ (Univ.Universe.make u)) in
     let sigma, jdef = eval_pretyper self ~flags (mk_tycon jty.utj_val) env sigma def in
     let pretype_elem = eval_pretyper self ~flags (mk_tycon jty.utj_val) env in
     let sigma, jt = Array.fold_left_map pretype_elem sigma t in

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1073,7 +1073,7 @@ let check_conv ?(pb=Reduction.CUMUL) ?(ts=TransparentState.full) env sigma x y =
     let env = Environ.set_universes (Evd.universes sigma) env in
     try f ~reds:ts env ~evars:(existential_opt_value0 sigma) x y; true
     with Reduction.NotConvertible -> false
-    | Univ.UniverseInconsistency _ -> false
+    | UGraph.UniverseInconsistency _ -> false
     | e ->
       let e = Exninfo.capture e in
       report_anomaly e
@@ -1086,7 +1086,7 @@ let sigma_compare_sorts env pb s0 s1 sigma =
 let sigma_compare_instances ~flex i0 i1 sigma =
   try Evd.set_eq_instances ~flex sigma i0 i1
   with Evd.UniversesDiffer
-     | Univ.UniverseInconsistency _ ->
+     | UGraph.UniverseInconsistency _ ->
         raise Reduction.NotConvertible
 
 let sigma_check_inductive_instances cv_pb variance u1 u2 sigma =
@@ -1141,7 +1141,7 @@ let infer_conv_gen conv_fun ?(catch_incon=true) ?(pb=Reduction.CUMUL)
       | None -> None
       | Some cstr ->
         try Some (Evd.add_universe_constraints sigma cstr)
-        with Univ.UniverseInconsistency _ | Evd.UniversesDiffer -> None
+        with UGraph.UniverseInconsistency _ | Evd.UniversesDiffer -> None
       in
       match ans with
       | Some sigma -> ans
@@ -1155,7 +1155,7 @@ let infer_conv_gen conv_fun ?(catch_incon=true) ?(pb=Reduction.CUMUL)
         Some sigma'
   with
   | Reduction.NotConvertible -> None
-  | Univ.UniverseInconsistency _ when catch_incon -> None
+  | UGraph.UniverseInconsistency _ when catch_incon -> None
   | e ->
     let e = Exninfo.capture e in
     report_anomaly e
@@ -1184,7 +1184,7 @@ let infer_conv_ustate ?(catch_incon=true) ?(pb=Reduction.CUMUL)
         Some cstr
   with
   | Reduction.NotConvertible -> None
-  | Univ.UniverseInconsistency _ when catch_incon -> None
+  | UGraph.UniverseInconsistency _ when catch_incon -> None
   | e ->
     let e = Exninfo.capture e in
     report_anomaly e

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -583,11 +583,11 @@ let constr_cmp pb env sigma flags ?nargs t u =
   match cstrs with
   | Some cstrs ->
       begin try Some (Evd.add_universe_constraints sigma cstrs)
-      with Univ.UniverseInconsistency _ -> None
+      with UGraph.UniverseInconsistency _ -> None
       | Evd.UniversesDiffer ->
         if is_rigid_head sigma flags t then
           try Some (Evd.add_universe_constraints sigma (force_eqs cstrs))
-          with Univ.UniverseInconsistency _ -> None
+          with UGraph.UniverseInconsistency _ -> None
         else None
       end
   | None ->
@@ -1060,7 +1060,7 @@ let rec unify_0_with_initial_metas (sigma,ms,es as subst : subst0) conv_at_top e
           let uprob = UnivProblem.Set.union uprob uprob' in
           begin match Evd.add_universe_constraints sigma uprob with
           | sigma -> Some (sigma, metasubst, evarsubst)
-          | exception (Univ.UniverseInconsistency _ | UniversesDiffer) -> None
+          | exception (UGraph.UniverseInconsistency _ | UniversesDiffer) -> None
           end
         | None ->
           if is_ground_term sigma m1 && is_ground_term sigma n1 then

--- a/tactics/cbn.ml
+++ b/tactics/cbn.ml
@@ -454,7 +454,11 @@ let magically_constant_of_fixbody env sigma reference bd = function
                 let l, r = match cst with
                   | ULub (u, v) | UWeak (u, v) -> u, v
                   | UEq (u, v) | ULe (u, v) ->
-                    let get u = Option.get (Universe.level (Sorts.univ_of_sort u)) in
+                    let get u = match u with
+                    | Sorts.SProp | Sorts.Prop -> assert false
+                    | Sorts.Set -> Level.set
+                    | Sorts.Type u -> Option.get (Universe.level u)
+                    in
                     get u, get v
                 in
                 Univ.Level.Map.add l r acc)

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -5080,7 +5080,7 @@ let constr_eq ~strict x y =
         let csts = UnivProblem.Set.force csts in
         begin match Evd.add_universe_constraints evd csts with
            | evd -> Proofview.Unsafe.tclEVARS evd
-           | exception (Univ.UniverseInconsistency _ as e) ->
+           | exception (UGraph.UniverseInconsistency _ as e) ->
              let _, info = Exninfo.capture e in
              fail_universes ~info
         end

--- a/test-suite/output/prim_array.out
+++ b/test-suite/output/prim_array.out
@@ -4,6 +4,6 @@
      : array nat
 [| | 0 : nat |]@{Set}
      : array@{Set} nat
-[| bool; list nat | nat : Set |]@{prim_array.4}
-     : array@{prim_array.4} Set
-(* {prim_array.4} |= Set < prim_array.4 *)
+[| bool; list nat | nat : Set |]@{prim_array.8}
+     : array@{prim_array.8} Set
+(* {prim_array.8} |= Set < prim_array.8 *)

--- a/test-suite/success/Template.v
+++ b/test-suite/success/Template.v
@@ -172,3 +172,11 @@ Definition B := Set : Type@{u}.
 End S.
 Fail Check box True : Prop.
 End OkNotCovered.
+
+Module BoxBox.
+
+  Inductive Box (A:Type) := box (_:A).
+  Inductive Box' (A:Type) := box' (_:Box A).
+  Check Box' True : Prop.
+
+End BoxBox.

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -194,7 +194,9 @@ let extract_level env evd min tys =
       sign_level env evd (LocalAssum (make_annot Anonymous Sorts.Relevant, concl) :: ctx)) tys
   in sup_list min sorts
 
-let is_flexible_sort evd u =
+let is_flexible_sort evd s = match s with
+| Set | Prop | SProp -> false
+| Type u ->
   match Univ.Universe.level u with
   | Some l -> Evd.is_flexible_level evd l
   | None -> false
@@ -324,10 +326,9 @@ let inductive_levels env evd arities inds =
             Evd.set_leq_sort env evd Sorts.set du
           else evd
         in
-        let duu = Sorts.univ_of_sort du in
         let template_prop, evd, arity =
           if not (Sorts.is_small du) && Sorts.equal cu du then
-            if is_flexible_sort evd duu && not (Evd.check_leq evd Sorts.set du)
+            if is_flexible_sort evd du && not (Evd.check_leq evd Sorts.set du)
             then if Term.isArity arity
             (* If not a syntactic arity, the universe may be used in a
                polymorphic instance and so cannot be lowered to Prop.

--- a/vernac/comInductive.mli
+++ b/vernac/comInductive.mli
@@ -98,3 +98,8 @@ val variance_of_entry
     universes than originally specified.
     If monomorphic, [cumulative] is treated as [false].
 *)
+
+module Internal :
+sig
+  val compute_constructor_level : Environ.env -> Evd.evar_map -> EConstr.rel_context -> Sorts.t
+end

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -346,7 +346,7 @@ let explain_unification_error env sigma p1 p2 = function
         strbrk " is expected to have a functional type but it has type " ++ u]
      | UnifUnivInconsistency p ->
        [str "universe inconsistency: " ++
-        Univ.explain_universe_inconsistency (Termops.pr_evd_level sigma) p]
+        UGraph.explain_universe_inconsistency (Termops.pr_evd_level sigma) p]
      | CannotSolveConstraint ((pb,env,t,u),e) ->
         let env = make_all_name_different env sigma in
         (strbrk "cannot satisfy constraint " ++ pr_leconstr_env env sigma t ++
@@ -1000,7 +1000,7 @@ let explain_not_match_error = function
         status (not b) ++ str" declaration was found"
   | IncompatibleUniverses incon ->
     str"the universe constraints are inconsistent: " ++
-      Univ.explain_universe_inconsistency UnivNames.(pr_with_global_universes empty_binders) incon
+      UGraph.explain_universe_inconsistency UnivNames.(pr_with_global_universes empty_binders) incon
   | IncompatiblePolymorphism (env, t1, t2) ->
     str "conversion of polymorphic values generates additional constraints: " ++
       quote (Printer.safe_pr_lconstr_env env (Evd.from_env env) t1) ++ spc () ++
@@ -1448,9 +1448,9 @@ let explain_exn_default = function
 let _ = CErrors.register_handler (wrap_unhandled explain_exn_default)
 
 let rec vernac_interp_error_handler = function
-  | Univ.UniverseInconsistency i ->
+  | UGraph.UniverseInconsistency i ->
     str "Universe inconsistency." ++ spc() ++
-    Univ.explain_universe_inconsistency UnivNames.(pr_with_global_universes empty_binders) i ++ str "."
+    UGraph.explain_universe_inconsistency UnivNames.(pr_with_global_universes empty_binders) i ++ str "."
   | TypeError(ctx,te) ->
     let te = map_ptype_error EConstr.of_constr te in
     explain_type_error ctx Evd.empty te

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -83,15 +83,23 @@ let interp_fields_evars env sigma ~ninds ~nparams impls_env nots l =
   in
   sigma, (impls, newfs)
 
+(** FIXME: This is a horrible hack, use a saner heuristic *)
+let max_sort s1 s2 = match s1, s2 with
+| (SProp, SProp) | (Prop, Prop) | (Set, Set) -> s1
+| (SProp, (Prop | Set | Type _ as s)) | ((Prop | Set | Type _) as s, SProp) -> s
+| (Prop, (Set | Type _ as s)) | ((Set | Type _) as s, Prop) -> s
+| (Set, Type u) | (Type u, Set) -> Sorts.sort_of_univ (Univ.Universe.sup Univ.Universe.type0 u)
+| (Type u, Type v) -> Sorts.sort_of_univ (Univ.Universe.sup u v)
+
 let compute_constructor_level evars env l =
   List.fold_right (fun d (env, univ) ->
     let univ =
       if is_local_assum d then
         let s = Retyping.get_sort_of env evars (RelDecl.get_type d) in
-          Univ.sup (Sorts.univ_of_sort s) univ
+        max_sort s univ
       else univ
     in (EConstr.push_rel d env, univ))
-    l (env, Univ.Universe.sprop)
+    l (env, Sorts.sprop)
 
 let check_anonymous_type ind =
   match ind with
@@ -135,7 +143,7 @@ type projection_flags = {
    type-inference *)
 module DataR = struct
   type t =
-    { min_univ : Univ.Universe.t
+    { min_univ : Sorts.t
     ; arity : Constr.t
     ; implfs : Impargs.manual_implicits list
     ; fields : Constr.rel_declaration list
@@ -223,16 +231,16 @@ let typecheck_params_and_fields def poly udecl ps (records : DataI.t list) : tc_
     Pretyping.solve_remaining_evars Pretyping.all_and_fail_flags env_ar sigma in
   let fold sigma (typ, sort) (_, newfs) =
     let _, univ = compute_constructor_level sigma env_ar newfs in
-    let univ = if Sorts.is_sprop sort then univ else Univ.Universe.sup univ Univ.type0m_univ in
+    let univ = if Sorts.is_sprop sort then univ else max_sort univ Sorts.prop in
       if not def && is_impredicative_sort env0 sort then
         sigma, (univ, typ)
       else
-        let sigma = Evd.set_leq_sort env_ar sigma (Sorts.sort_of_univ univ) sort in
-        if Univ.is_small_univ univ &&
+        let sigma = Evd.set_leq_sort env_ar sigma univ sort in
+        if Sorts.is_small univ &&
            Option.cata (Evd.is_flexible_level sigma) false (Evd.is_sort_variable sigma sort) then
            (* We can assume that the level in aritysort is not constrained
                and clear it, if it is flexible *)
-   Evd.set_eq_sort env_ar sigma Sorts.set sort, (univ, EConstr.mkSort (Sorts.sort_of_univ univ))
+   Evd.set_eq_sort env_ar sigma Sorts.set sort, (univ, EConstr.mkSort univ)
         else sigma, (univ, typ)
   in
   let (sigma, typs) = List.fold_left2_map fold sigma typs data in
@@ -473,7 +481,7 @@ let check_template ~template ~poly ~univs ~params { Data.id; rdata = { DataR.min
         param_levels fields
     in
     ComInductive.template_polymorphism_candidate ~ctor_levels univs params
-      (Some (Sorts.sort_of_univ min_univ))
+      (Some min_univ)
   in
   match template with
   | Some template, _ ->


### PR DESCRIPTION
This is a trap convincing the user that universes and sorts are isomorphic and can be safely translated between one another. But the reality is that this should not be the case and the user should match on the inductive description of sorts instead. Soon universes will be restricted to algebraic expressions, making this function impossible to write.

This PR required a bit of architectural move. Now Sorts live below UGraph in order for the UniverseInconsistency error to contain sorts rather than universes. This exception was also moved from Univ to UGraph, and some related API changes were introduced.

This is formally the continuation of #15837.

Overlays:
- https://github.com/mattam82/Coq-Equations/pull/483
- https://github.com/unicoq/unicoq/pull/68
- https://github.com/MetaCoq/metacoq/pull/670
- https://github.com/LPCIC/coq-elpi/pull/353
- https://gitlab.inria.fr/fbesson/itauto/-/merge_requests/5