### PR TITLE
Restrict the universe level algebra to a single small level.

### DIFF
--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -292,13 +292,15 @@ let process_universe_constraints uctx cstrs =
               | LAlgebraic ->
                 (* l contains a +1 and r=r' small so l <= r impossible *)
                 sort_inconsistency Le l r
-              | LLevel _ | LMax _ ->
-                if UGraph.check_leq_sort univs l r then match get_levels l with
-                | LLevel l ->
-                  Univ.Constraints.add (l, Le, r') local
-                | LAlgebraic | LMax _ -> local
+              | LLevel l' ->
+                if UGraph.check_leq_sort univs l r then
+                  Univ.Constraints.add (l', Le, r') local
+                else if Level.is_small l' || is_local l' then
+                  equalize_variables false l l' r r' local
+                else sort_inconsistency Le l r
+              | LMax levels ->
+                if UGraph.check_leq_sort univs l r then local
                 else
-                let levels = Sorts.levels l in
                 let fold l' local =
                   let l = Sorts.sort_of_univ @@ Universe.make l' in
                   if Level.is_small l' || is_local l' then

--- a/engine/univProblem.ml
+++ b/engine/univProblem.ml
@@ -25,11 +25,7 @@ let force = function
   | ULe _ | UEq _ | UWeak _ as cst -> cst
   | ULub (u,v) -> UEq (Sorts.sort_of_univ @@ Universe.make u, Sorts.sort_of_univ @@ Universe.make v)
 
-let not_in_graph u = Level.is_prop u || Level.is_sprop u
-
-let check_eq_level g u v =
-  if not_in_graph u || not_in_graph v then UGraph.type_in_type g || Level.equal u v
-  else UGraph.check_eq_level g u v
+let check_eq_level g u v = UGraph.check_eq_level g u v
 
 let check g = function
   | ULe (u,v) -> UGraph.check_leq_sort g u v

--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -211,7 +211,10 @@ val check_duplicate : ?loc:Loc.t -> (qualid * constr_expr) list -> unit
 (** Check that a list of record field definitions doesn't contain
     duplicates. *)
 
-val interp_known_level : Evd.evar_map -> sort_name_expr -> Univ.Level.t
+val interp_univ_constraint
+  : Evd.evar_map
+  -> sort_name_expr * Univ.constraint_type * sort_name_expr
+  -> Univ.univ_constraint
 
 (** Local universe and constraint declarations. *)
 val interp_univ_decl : Environ.env -> universe_decl_expr ->

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -190,8 +190,7 @@ let subst_univs_sort subs = function
   let u = Universe.repr u in
   let supern u n = iterate Universe.super n u in
   let map (u, n) =
-    if Level.is_prop u || Level.is_sprop u then assert false
-    else if Level.is_set u then [Universe.type0, n]
+    if Level.is_set u then [Universe.type0, n]
     else match Level.Map.find u subs with
     | [] ->
       if Int.equal n 0 then

--- a/kernel/sorts.ml
+++ b/kernel/sorts.ml
@@ -26,10 +26,7 @@ let set = Set
 let type1 = Type type1_univ
 
 let sort_of_univ u =
-  if Universe.is_sprop u then sprop
-  else if is_type0m_univ u then prop
-  else if is_type0_univ u then set
-  else Type u
+  if is_type0_univ u then set else Type u
 
 let compare s1 s2 =
   if s1 == s2 then 0 else

--- a/kernel/sorts.ml
+++ b/kernel/sorts.ml
@@ -68,8 +68,7 @@ let is_small = function
   | Type _ -> false
 
 let levels s = match s with
-| SProp -> Level.Set.singleton Level.sprop
-| Prop -> Level.Set.singleton Level.prop
+| SProp | Prop -> Level.Set.empty
 | Set -> Level.Set.singleton Level.set
 | Type u -> Universe.levels u
 

--- a/kernel/uGraph.ml
+++ b/kernel/uGraph.ml
@@ -160,20 +160,6 @@ let enforce_leq_alg u v g =
     let e = UniverseInconsistency (c, mk u, mk v, Some e) in
     raise e
 
-let enforce_leq_alg u v g =
-  match Universe.is_sprop u, Universe.is_sprop v with
-  | true, true -> Constraints.empty, g
-  | false, false -> enforce_leq_alg u v g
-  | left, _ ->
-    if left && g.sprop_cumulative then Constraints.empty, g
-    else raise (UniverseInconsistency (Le, Sorts.sort_of_univ u, Sorts.sort_of_univ v, None))
-
-(* sanity check wrapper *)
-let enforce_leq_alg u v g =
-  let _,g as cg = enforce_leq_alg u v g in
-  assert (check_leq g u v);
-  cg
-
 module Bound =
 struct
   type t = Prop | Set

--- a/kernel/uGraph.ml
+++ b/kernel/uGraph.ml
@@ -61,21 +61,14 @@ let exists_bigger g ul l =
 let real_check_leq g u v =
   Universe.for_all (fun ul -> exists_bigger g ul v) u
 
-(** TODO: enforce this by typing *)
-let in_graph u = not (Level.is_prop u) && not (Level.is_sprop u)
-let in_graph_univ u = not (Universe.is_type0m u) && not (Universe.is_sprop u)
-
 let check_leq g u v =
-  let () = assert (in_graph_univ u && in_graph_univ v) in
   type_in_type g || Universe.equal u v || (real_check_leq g u v)
 
 let check_eq g u v =
-  let () = assert (in_graph_univ u && in_graph_univ v) in
   type_in_type g || Universe.equal u v ||
     (real_check_leq g u v && real_check_leq g v u)
 
 let check_eq_level g u v =
-  let () = assert (in_graph u && in_graph v) in
   u == v || type_in_type g || G.check_eq g.graph u v
 
 let empty_universes = {graph=G.empty; sprop_cumulative=false; type_in_type=false}
@@ -89,7 +82,6 @@ let initial_universes =
 let initial_universes_with g = {g with graph=initial_universes.graph}
 
 let enforce_constraint (u,d,v) g =
-  let () = assert (in_graph u && in_graph v) in
   match d with
   | Le -> G.enforce_leq u v g
   | Lt -> G.enforce_lt u v g
@@ -114,7 +106,6 @@ let enforce_constraint cst g = match enforce_constraint0 cst g with
 let merge_constraints csts g = Constraints.fold enforce_constraint csts g
 
 let check_constraint { graph = g; _ } (u,d,v) =
-  let () = assert (in_graph u && in_graph v) in
   match d with
   | Le -> G.check_leq g u v
   | Lt -> G.check_lt g u v
@@ -177,14 +168,14 @@ let add_universe u ~lbound ~strict g = match lbound with
 
 exception UndeclaredLevel = G.Undeclared
 let check_declared_universes g l =
-  G.check_declared g.graph (Level.Set.remove Level.prop (Level.Set.remove Level.sprop l))
+  G.check_declared g.graph l
 
 let constraints_of_universes g =
   let add cst accu = Constraints.add cst accu in
   G.constraints_of g.graph add Constraints.empty
 let constraints_for ~kept g =
   let add cst accu = Constraints.add cst accu in
-  G.constraints_for ~kept:(Level.Set.remove Level.prop (Level.Set.remove Level.sprop kept)) g.graph add Constraints.empty
+  G.constraints_for ~kept g.graph add Constraints.empty
 
 (** Subtyping of polymorphic contexts *)
 
@@ -211,11 +202,8 @@ let check_eq_instances g t1 t2 =
           (Int.equal i (Array.length t1)) || (check_eq_level g t1.(i) t2.(i) && aux (i + 1))
         in aux 0)
 
-let domain g = Level.Set.add Level.prop (Level.Set.add Level.sprop (G.domain g.graph))
-let choose p g u =
-  if not (in_graph u) then
-    if p u then Some u else None
-  else G.choose p g.graph u
+let domain g = G.domain g.graph
+let choose p g u = G.choose p g.graph u
 
 let check_universes_invariants g = G.check_invariants ~required_canonical:Level.is_set g.graph
 

--- a/kernel/univ.ml
+++ b/kernel/univ.ml
@@ -65,8 +65,6 @@ struct
   end
 
   type t =
-    | SProp
-    | Prop
     | Set
     | Level of UGlobal.t
     | Var of int
@@ -76,8 +74,6 @@ struct
   let equal x y =
     x == y ||
       match x, y with
-      | SProp, SProp -> true
-      | Prop, Prop -> true
       | Set, Set -> true
       | Level l, Level l' -> UGlobal.equal l l'
       | Var n, Var n' -> Int.equal n n'
@@ -85,12 +81,6 @@ struct
 
   let compare u v =
     match u, v with
-    | SProp, SProp -> 0
-    | SProp, _ -> -1
-    | _, SProp -> 1
-    | Prop,Prop -> 0
-    | Prop, _ -> -1
-    | _, Prop -> 1
     | Set, Set -> 0
     | Set, _ -> -1
     | _, Set -> 1
@@ -102,8 +92,6 @@ struct
   let hequal x y =
     x == y ||
       match x, y with
-      | SProp, SProp -> true
-      | Prop, Prop -> true
       | Set, Set -> true
       | UGlobal.(Level { library = d; process = s; uid = n }, Level  { library = d'; process = s'; uid = n' }) ->
         n == n' && s==s' && d == d'
@@ -111,8 +99,6 @@ struct
       | _ -> false
 
   let hcons = function
-    | SProp as x -> x
-    | Prop as x -> x
     | Set as x -> x
     | UGlobal.(Level { library = d; process = s; uid = n }) as x ->
       let s' = CString.hcons s in
@@ -123,8 +109,6 @@ struct
   open Hashset.Combine
 
   let hash = function
-    | SProp -> combinesmall 1 0
-    | Prop -> combinesmall 1 1
     | Set -> combinesmall 1 2
     | Var n -> combinesmall 2 n
     | Level l -> combinesmall 3 (UGlobal.hash l)
@@ -136,8 +120,6 @@ module Level = struct
   module UGlobal = RawLevel.UGlobal
 
   type raw_level = RawLevel.t =
-  | SProp
-  | Prop
   | Set
   | Level of UGlobal.t
   | Var of int
@@ -173,30 +155,16 @@ module Level = struct
   let make l = hcons { hash = RawLevel.hash l; data = l }
 
   let set = make Set
-  let prop = make Prop
-  let sprop = make SProp
 
   let is_small x =
     match data x with
     | Level _ -> false
     | Var _ -> false
-    | SProp -> true
-    | Prop -> true
     | Set -> true
-
-  let is_prop x =
-    match data x with
-    | Prop -> true
-    | _ -> false
 
   let is_set x =
     match data x with
     | Set -> true
-    | _ -> false
-
-  let is_sprop x =
-    match data x with
-    | SProp -> true
     | _ -> false
 
   let compare u v =
@@ -205,8 +173,6 @@ module Level = struct
 
   let to_string x =
     match data x with
-    | SProp -> "SProp"
-    | Prop -> "Prop"
     | Set -> "Set"
     | UGlobal.(Level { library = d; process = s; uid = n }) ->
       Names.DirPath.to_string d ^
@@ -339,8 +305,6 @@ struct
         if Int.equal 0 c then  Level.compare x x'
         else c
 
-    let sprop = hcons (Level.sprop, 0)
-    let prop = hcons (Level.prop, 0)
     let set = hcons (Level.set, 0)
     let type1 = hcons (Level.set, 1)
 
@@ -357,8 +321,6 @@ struct
     let leq (u,n) (v,n') =
       let cmp = Level.compare u v in
         if Int.equal cmp 0 then n <= n'
-        else if n <= n' then
-          (Level.is_prop u && not (Level.is_sprop v))
         else false
 
     let successor (u,n as e) =
@@ -386,16 +348,7 @@ struct
     let super (u,n) (v,n') =
       let cmp = Level.compare u v in
         if Int.equal cmp 0 then SuperSame (n < n')
-        else
-          let open RawLevel in
-          match Level.data u, n, Level.data v, n' with
-          | SProp, _, SProp, _ | Prop, _, Prop, _ -> SuperSame (n < n')
-          | SProp, 0, Prop, 0 -> SuperSame true
-          | Prop, 0, SProp, 0 -> SuperSame false
-          | (SProp | Prop), 0, _, _ -> SuperSame true
-          | _, _, (SProp | Prop), 0 -> SuperSame false
-
-          | _, _, _, _ -> SuperDiff cmp
+        else SuperDiff cmp
 
     let to_string (v, n) =
       if Int.equal n 0 then Level.to_string v
@@ -420,8 +373,6 @@ struct
     let map f (v, n as x) =
       let v' = f v in
         if v' == v then x
-        else if Level.is_prop v' && n != 0 then
-          (Level.set, n)
         else (v', n)
 
   end
@@ -479,7 +430,7 @@ struct
   let levels l =
     let fold acc x =
       let l = Expr.get_level x in
-      if Level.is_prop l || Level.is_sprop l then acc else Level.Set.add l acc
+      Level.Set.add l acc
     in
     List.fold_left fold Level.Set.empty l
 
@@ -488,12 +439,6 @@ struct
     | [l] -> Expr.is_small l
     | _ -> false
 
-  let sprop = tip Expr.sprop
-
-  (* The lower predicative level of the hierarchy that contains (impredicative)
-     Prop and singleton inductive types *)
-  let type0m = tip Expr.prop
-
   (* The level of sets *)
   let type0 = tip Expr.set
 
@@ -501,8 +446,6 @@ struct
      hence the definition of [type1_univ], the type of [Prop] *)
   let type1 = tip Expr.type1
 
-  let is_sprop x = equal sprop x
-  let is_type0m x = equal type0m x
   let is_type0 x = equal type0 x
 
   (* Returns the formal universe that lies just above the universe variable u.
@@ -557,10 +500,8 @@ end
 type universe = Universe.t
 
 (* The level of predicative Set *)
-let type0m_univ = Universe.type0m
 let type0_univ = Universe.type0
 let type1_univ = Universe.type1
-let is_type0m_univ = Universe.is_type0m
 let is_type0_univ = Universe.is_type0
 let is_univ_variable l = Universe.level l != None
 let is_small_univ = Universe.is_small
@@ -708,12 +649,7 @@ let check_univ_leq u v =
   Universe.for_all (fun u -> check_univ_leq_one u v) u
 
 let enforce_leq u v c =
-  match Universe.is_sprop u, Universe.is_sprop v with
-  | true, true -> c
-  | true, false -> Constraints.add (Level.sprop,Le,Level.prop) c
-  | false, true -> Constraints.add (Level.prop,Le,Level.sprop) c
-  | false, false ->
-    List.fold_left (fun c v -> (List.fold_left (fun c u -> constraint_add_leq u v c) c u)) c v
+  List.fold_left (fun c v -> (List.fold_left (fun c u -> constraint_add_leq u v c) c u)) c v
 
 let enforce_leq u v c =
   if check_univ_leq u v then c
@@ -883,7 +819,6 @@ struct
     else Array.append x y
 
   let of_array a =
-    assert(Array.for_all (fun x -> not (Level.is_prop x || Level.is_sprop x)) a);
     a
 
   let to_array a = a

--- a/kernel/univ.ml
+++ b/kernel/univ.ml
@@ -477,7 +477,11 @@ struct
     | _ -> None
 
   let levels l =
-    List.fold_left (fun acc x -> Level.Set.add (Expr.get_level x) acc) Level.Set.empty l
+    let fold acc x =
+      let l = Expr.get_level x in
+      if Level.is_prop l || Level.is_sprop l then acc else Level.Set.add l acc
+    in
+    List.fold_left fold Level.Set.empty l
 
   let is_small u =
     match u with

--- a/kernel/univ.mli
+++ b/kernel/univ.mli
@@ -30,17 +30,13 @@ sig
       definition or global. *)
 
   val set : t
-  val prop : t
-  val sprop : t
-  (** The set and prop universe levels. *)
+  (** The Set universe level. *)
 
   val is_small : t -> bool
-  (** Is the universe set or prop? *)
+  (** Is the universe Set? *)
 
-  val is_sprop : t -> bool
-  val is_prop : t -> bool
   val is_set : t -> bool
-  (** Is it specifically Prop or Set *)
+  (** Is it specifically Set *)
 
   val compare : t -> t -> int
   (** Comparison function *)
@@ -146,19 +142,12 @@ sig
   val sup   : t -> t -> t
   (** The l.u.b. of 2 universes *)
 
-  val sprop : t
-
-  val type0m : t
-  (** image of Prop in the universes hierarchy *)
-
   val type0 : t
   (** image of Set in the universes hierarchy *)
 
   val type1 : t
   (** the universe of the type of Prop/Set *)
 
-  val is_sprop : t -> bool
-  val is_type0m : t -> bool
   val is_type0 : t -> bool
 
   val exists : (Level.t * int -> bool) -> t -> bool
@@ -174,14 +163,12 @@ end
 
 val pr_uni : Universe.t -> Pp.t
 
-(** The universes hierarchy: Type 0- = Prop <= Type 0 = Set <= Type 1 <= ...
-   Typing of universes: Type 0-, Type 0 : Type 1; Type i : Type (i+1) if i>0 *)
-val type0m_univ : Universe.t
+(** The universes hierarchy: Type 0 = Set <= Type 1 <= ...
+   Typing of universes: Type 0 : Type 1; Type i : Type (i+1) if i>0 *)
 val type0_univ : Universe.t
 val type1_univ : Universe.t
 
 val is_type0_univ : Universe.t -> bool
-val is_type0m_univ : Universe.t -> bool
 val is_univ_variable : Universe.t -> bool
 val is_small_univ : Universe.t -> bool
 

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -723,8 +723,6 @@ let detype_cofix detype flags avoid env sigma n (names,tys,bodies) =
        Array.map (fun (_,bd,_) -> bd) v)
 
 let detype_level_name sigma l =
-  if Univ.Level.is_sprop l then GSProp else
-  if Univ.Level.is_prop l then GProp else
   if Univ.Level.is_set l then GSet else
     match UState.id_of_level (Evd.evar_universe_context sigma) l with
     | Some id -> GLocalUniv (CAst.make id)

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -394,24 +394,6 @@ let pretype_id pretype loc env sigma id =
 (*************************************************************************)
 (* Main pretyping function                                               *)
 
-let known_universe_level_name evd lid =
-  try Evd.universe_of_name evd lid.CAst.v
-  with Not_found ->
-    let u = Nametab.locate_universe (Libnames.qualid_of_lident lid) in
-    Univ.Level.make u
-
-let known_glob_level evd = function
-  | GSProp -> Univ.Level.sprop
-  | GProp -> Univ.Level.prop
-  | GSet -> Univ.Level.set
-  | GUniv u -> u
-  | GRawUniv u -> anomaly Pp.(str "Raw universe in known_glob_level.")
-  | GLocalUniv lid ->
-    try known_universe_level_name evd lid
-    with Not_found ->
-      user_err ?loc:lid.CAst.loc
-        (str "Undeclared universe " ++ Id.print lid.CAst.v)
-
 let glob_level ?loc evd : glob_level -> _ = function
   | UAnonymous {rigid} -> new_univ_level_variable ?loc (if rigid then univ_rigid else univ_flexible) evd
   | UNamed s ->

--- a/pretyping/pretyping.mli
+++ b/pretyping/pretyping.mli
@@ -30,8 +30,6 @@ val get_bidirectionality_hint : GlobRef.t -> int option
 
 val clear_bidirectionality_hint : GlobRef.t -> unit
 
-val known_glob_level : Evd.evar_map -> glob_sort_name -> Univ.Level.t
-
 (** An auxiliary function for searching for fixpoint guard indexes *)
 
 val search_guard :

--- a/test-suite/misc/universes.sh
+++ b/test-suite/misc/universes.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Sort universes for the whole standard library
-EXPECTED_UNIVERSES=4 # Prop is not counted
+EXPECTED_UNIVERSES=3 # Prop is not counted
 $coqc -R misc/universes Universes misc/universes/all_stdlib 2>&1
 $coqc -R misc/universes Universes misc/universes/universes 2>&1
 mv universes.txt misc/universes

--- a/vernac/declareUniv.ml
+++ b/vernac/declareUniv.ml
@@ -135,10 +135,9 @@ let do_universe ~poly l =
 let do_constraint ~poly l =
   let open Univ in
   let evd = Evd.from_env (Global.env ()) in
-  let u_of_id x = Constrintern.interp_known_level evd x in
-  let constraints = List.fold_left (fun acc (l, d, r) ->
-      let lu = u_of_id l and ru = u_of_id r in
-      Constraints.add (lu, d, ru) acc)
+  let constraints = List.fold_left (fun acc cst ->
+      let cst = Constrintern.interp_univ_constraint evd cst in
+      Constraints.add cst acc)
       Constraints.empty l
   in
   let uctx = ContextSet.add_constraints constraints ContextSet.empty in

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -411,13 +411,13 @@ let sort_universes g =
   let max_level = Level.Map.fold (fun _ n accu -> max n accu) levels 0 in
   let dummy_mp = Names.DirPath.make [Names.Id.of_string "Type"] in
   let ulevels = Array.init max_level (fun i -> Level.(make (UGlobal.make dummy_mp "" i))) in
-  let ulevels = Array.cons Level.set ulevels in
   (* Add the normal universes *)
   let fold (cur, ans) u =
     let ans = Level.Map.add cur (UGraph.Node (Level.Map.singleton u true)) ans in
     (u, ans)
   in
-  let _, ans = Array.fold_left fold (Level.prop, Level.Map.empty) ulevels in
+  let _, ans = Array.fold_left fold (Level.set, Level.Map.empty) ulevels in
+  let ulevels = Array.cons Level.set ulevels in
   (* Add alias pointers *)
   let fold u _ ans =
     if Level.is_small u then ans

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -360,11 +360,10 @@ let dump_universes_gen prl g s =
 
 let universe_subgraph ?loc kept univ =
   let open Univ in
-  let sigma = Evd.from_env (Global.env()) in
   let parse q =
-    let q = Constrexpr.CType q in
-    (* this function has a nice error message for not found univs *)
-    Constrintern.interp_known_level sigma q
+    try Level.make (Nametab.locate_universe q)
+    with Not_found ->
+      CErrors.user_err Pp.(str "Undeclared universe " ++ pr_qualid q ++ str".")
   in
   let kept = List.fold_left (fun kept q -> Level.Set.add (parse q) kept) Level.Set.empty kept in
   let csts = UGraph.constraints_for ~kept univ in


### PR DESCRIPTION
We remove Prop and SProp from the `Level.t` type, leaving only the root node corresponding to Set. This was expected in many parts of the code already but not ensured statically. In addition to enforcing these hidden invariants, it also exposes more details in the unification of universes.