### PR TITLE
[vernac] expose API to elaborate declarations

### DIFF
--- a/dev/ci/user-overlays/15872-gares-interp-inductive.sh
+++ b/dev/ci/user-overlays/15872-gares-interp-inductive.sh
@@ -1,0 +1,2 @@
+overlay elpi https://github.com/gares/coq-elpi elab-arg 15872
+overlay hierarchy_builder https://github.com/gares/hierarchy-builder elab-arg 15872

--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -238,9 +238,7 @@ let context_nosection sigma ~poly ctx =
   let _ : Vars.substl = List.fold_left_i fn 0 [] ctx in
   ()
 
-let context ~poly l =
-  let env = Global.env() in
-  let sigma = Evd.from_env env in
+let interp_context env sigma l =
   let sigma, (_, ((_env, ctx), impls)) = interp_context_evars ~program_mode:false env sigma l in
   (* Note, we must use the normalized evar from now on! *)
   let ce t = Pretyping.check_evars env sigma t in
@@ -265,6 +263,12 @@ let context ~poly l =
       name,b,t,impl)
       ctx
   in
+   sigma, ctx
+
+let do_context ~poly l =
+  let env = Global.env() in
+  let sigma = Evd.from_env env in
+  let sigma, ctx = interp_context env sigma l in
   if Global.sections_are_opened ()
   then context_insection sigma ~poly ctx
   else context_nosection sigma ~poly ctx

--- a/vernac/comAssumption.mli
+++ b/vernac/comAssumption.mli
@@ -56,7 +56,14 @@ val declare_axiom
 
 (** Context command *)
 
-val context
+val do_context
   :  poly:bool
   -> local_binder_expr list
   -> unit
+
+(** The first half of the context command, from expr to constr *)
+val interp_context
+  :  Environ.env
+  -> Evd.evar_map
+  -> local_binder_expr list
+  -> Evd.evar_map * (Id.t * Constr.t option * Constr.t * Glob_term.binding_kind) list

--- a/vernac/comInductive.mli
+++ b/vernac/comInductive.mli
@@ -47,6 +47,7 @@ module Mind_decl : sig
 (** inductive_expr at the constr level *)
 type t = {
   mie : Entries.mutual_inductive_entry;
+  nuparams : int option;
   univ_binders : UnivNames.universe_binders;
   implicits : DeclareInd.one_inductive_impls list;
   uctx : Univ.ContextSet.t;

--- a/vernac/comInductive.mli
+++ b/vernac/comInductive.mli
@@ -42,6 +42,36 @@ val do_mutual_inductive
 
 val make_cases : Names.inductive -> string list list
 
+module Mind_decl : sig
+
+(** inductive_expr at the constr level *)
+type t = {
+  mie : Entries.mutual_inductive_entry;
+  univ_binders : UnivNames.universe_binders;
+  implicits : DeclareInd.one_inductive_impls list;
+  uctx : Univ.ContextSet.t;
+  where_notations : Metasyntax.where_decl_notation list;
+  coercions : Libnames.qualid list;
+}
+
+end
+
+(** elaborates an inductive declaration (the first half of do_mutual_inductive) *)
+val interp_mutual_inductive
+  :  env:Environ.env
+  -> template:bool option
+  -> cumul_univ_decl_expr option
+  -> (one_inductive_expr * decl_notation list) list
+  -> cumulative:bool
+  -> poly:bool
+  -> ?typing_flags:Declarations.typing_flags
+  -> private_ind:bool
+  -> uniform:uniform_inductive_flag
+  -> Declarations.recursivity_kind
+  -> Mind_decl.t
+
+(** the post-elaboration part of interp_mutual_inductive, mainly dealing with
+    universe levels *)
 val interp_mutual_inductive_constr
   : sigma:Evd.evar_map
   -> template:bool option

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -542,6 +542,7 @@ let data_name id rdata =
 module Record_decl = struct
   type t = {
     mie : Entries.mutual_inductive_entry;
+    records : Data.t list;
     primitive_proj : bool;
     impls : DeclareInd.one_inductive_impls list;
     globnames : UState.named_universes_entry;
@@ -550,7 +551,6 @@ module Record_decl = struct
     ubinders : UnivNames.universe_binders;
     projections_kind : Decls.definition_object_kind;
     poly : bool;
-    records : Data.t list;
   }
 end
 

--- a/vernac/record.mli
+++ b/vernac/record.mli
@@ -52,9 +52,12 @@ val definition_structure
       }
   end
 
+  (** A record is an inductive [mie] with extra metadata in [records] *)
   module Record_decl : sig
     type t = {
       mie : Entries.mutual_inductive_entry;
+      records : Data.t list;
+      (* TODO: this part could be factored in mie *)
       primitive_proj : bool;
       impls : DeclareInd.one_inductive_impls list;
       globnames : UState.named_universes_entry;
@@ -63,7 +66,6 @@ val definition_structure
       ubinders : UnivNames.universe_binders;
       projections_kind : Decls.definition_object_kind;
       poly : bool;
-      records : Data.t list;
     }
 end
 

--- a/vernac/record.mli
+++ b/vernac/record.mli
@@ -36,6 +36,50 @@ val definition_structure
   -> Ast.t list
   -> GlobRef.t list
 
+  module Data : sig
+    type projection_flags = {
+      pf_subclass: bool;
+      pf_canonical: bool;
+    }
+    type raw_data
+    type t =
+      { id : Id.t
+      ; idbuild : Id.t
+      ; is_coercion : bool
+      ; coers : projection_flags list
+      ; rdata : raw_data
+      ; inhabitant_id : Id.t
+      }
+  end
+
+  module Record_decl : sig
+    type t = {
+      mie : Entries.mutual_inductive_entry;
+      primitive_proj : bool;
+      impls : DeclareInd.one_inductive_impls list;
+      globnames : UState.named_universes_entry;
+      global_univ_decls : Univ.ContextSet.t option;
+      projunivs : Entries.universes_entry;
+      ubinders : UnivNames.universe_binders;
+      projections_kind : Decls.definition_object_kind;
+      poly : bool;
+      records : Data.t list;
+    }
+end
+
+(** Ast.t list at the constr level *)
+val interp_structure
+  :  cumul_univ_decl_expr option
+  -> inductive_kind
+  -> template:bool option
+  -> cumulative:bool
+  -> poly:bool
+  -> primitive_proj:bool
+  -> Declarations.recursivity_kind
+  -> Ast.t list
+  -> Record_decl.t
+
+
 val declare_existing_class : GlobRef.t -> unit
 
 (* Implementation internals, consult Coq developers before using;

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2363,7 +2363,7 @@ let translate_vernac ?loc ~atts v = let open Vernacextend in match v with
   | VernacDeclareInstance (id, bl, inst, info) ->
     vtdefault(fun () -> vernac_declare_instance ~atts id bl inst info)
   | VernacContext sup ->
-    vtdefault(fun () -> ComAssumption.context ~poly:(only_polymorphism atts) sup)
+    vtdefault(fun () -> ComAssumption.do_context ~poly:(only_polymorphism atts) sup)
   | VernacExistingInstance insts ->
     vtdefault(fun () -> vernac_existing_instance ~atts insts)
   | VernacExistingClass id ->

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -799,31 +799,16 @@ let vernac_record ~template udecl ~cumulative k ~poly ?typing_flags ~primitive_p
   let map ((is_coercion, name), binders, sort, nameopt, cfs, ido) =
     let idbuild = match nameopt with
     | None -> Nameops.add_prefix "Build_" name.v
-    | Some lid ->
-      let () = Dumpglob.dump_definition lid false "constr" in
-      lid.v
+    | Some lid -> lid.v
     in
     let default_inhabitant_id = Option.map (fun CAst.{v=id} -> id) ido in
-    let () =
-      if Dumpglob.dump () then
-        let () = Dumpglob.dump_definition name false "rec" in
-        let iter (x, _) = match x with
-        | Vernacexpr.(AssumExpr ({loc;v=Name id}, _, _) | DefExpr ({loc;v=Name id}, _, _, _)) ->
-          Dumpglob.dump_definition (make ?loc id) false "proj"
-        | _ -> ()
-        in
-        List.iter iter cfs
-    in
     Record.Ast.{ name; is_coercion; binders; cfs; idbuild; sort; default_inhabitant_id }
   in
   let records = List.map map records in
   match typing_flags with
   | Some _ ->
     CErrors.user_err (Pp.str "Typing flags are not yet supported for records.")
-  | None ->
-    let _ : _ list =
-      Record.definition_structure ~template udecl k ~cumulative ~poly ~primitive_proj finite records in
-    ()
+  | None -> records
 
 let extract_inductive_udecl (indl:(inductive_expr * decl_notation list) list) =
   match indl with
@@ -869,7 +854,33 @@ let primitive_proj =
   | Some t -> return t
   | None -> return (primitive_flag ())
 
-let vernac_inductive ~atts kind indl =
+module Preprocessed_Mind_decl = struct
+  type flags = {
+    template : bool option;
+    udecl : Constrexpr.cumul_univ_decl_expr option;
+    cumulative : bool;
+    poly : bool;
+    finite : Declarations.recursivity_kind;
+  }
+  type record = {
+    flags : flags;
+    primitive_proj : bool;
+    kind : Vernacexpr.inductive_kind;
+    records : Record.Ast.t list;
+  }
+  type inductive = {
+    flags : flags;
+    typing_flags : Declarations.typing_flags option;
+    private_ind : bool;
+    uniform : ComInductive.uniform_inductive_flag;
+    inductives : (Vernacexpr.one_inductive_expr * Vernacexpr.decl_notation list) list;
+  }
+  type t =
+    | Record of record
+    | Inductive of inductive
+end
+
+let preprocess_inductive_decl ~atts kind indl =
   let udecl, indl = extract_inductive_udecl indl in
   let is_defclass = match kind, indl with
   | Class _, [ ( id , bl , c , Constructors [l]), [] ] -> Some (id, bl, c, l)
@@ -898,16 +909,6 @@ let vernac_inductive ~atts kind indl =
           ++ private_ind ++ typing_flags ++ prim_proj_attr)
         atts)
   in
-  if Dumpglob.dump () then
-    List.iter (fun (((coe,lid), _, _, cstrs), _) ->
-      match cstrs with
-        | Constructors cstrs ->
-            Dumpglob.dump_definition lid false "ind";
-            List.iter (fun (_, (lid, _)) ->
-                         Dumpglob.dump_definition lid false "constr") cstrs
-        | _ -> () (* dumping is done by vernac_record (called below) *) )
-      indl;
-
   if Option.has_some is_defclass then
     (* Definitional class case *)
     let (id, bl, c, l) = Option.get is_defclass in
@@ -921,8 +922,10 @@ let vernac_inductive ~atts kind indl =
     let coe' = if coe then BackInstance else NoInstance in
     let f = AssumExpr ((make ?loc:lid.loc @@ Name lid.v), [], ce),
             { rf_subclass = coe' ; rf_priority = None ; rf_notation = [] ; rf_canonical = true } in
-    vernac_record ~template udecl ~cumulative (Class true) ~poly ?typing_flags ~primitive_proj
-      finite [id, bl, c, None, [f], None]
+    let recordl = [id, bl, c, None, [f], None] in
+    let kind = Class true in
+    let records = vernac_record ~template udecl ~cumulative kind ~poly ?typing_flags ~primitive_proj finite recordl in
+    indl, Preprocessed_Mind_decl.(Record { flags = { template; udecl; cumulative; poly; finite; }; primitive_proj; kind; records })
   else if List.for_all is_record indl then
     (* Mutual record case *)
     let () = match kind with
@@ -947,7 +950,8 @@ let vernac_inductive ~atts kind indl =
     in
     let kind = match kind with Class _ -> Class false | _ -> kind in
     let recordl = List.map unpack indl in
-    vernac_record ~template udecl ~cumulative kind ~poly ?typing_flags ~primitive_proj finite recordl
+    let records = vernac_record ~template udecl ~cumulative kind ~poly ?typing_flags ~primitive_proj finite recordl in
+    indl, Preprocessed_Mind_decl.(Record { flags = { template; udecl; cumulative; poly; finite; }; primitive_proj; kind; records })
   else if List.for_all is_constructor indl then
     (* Mutual inductive case *)
     let () = match kind with
@@ -969,11 +973,46 @@ let vernac_inductive ~atts kind indl =
     | Constructors l -> (id, bl, c, l), ntn
     | RecordDecl _ -> assert false (* ruled out above *)
     in
-    let indl = List.map unpack indl in
+    let inductives = List.map unpack indl in
     let uniform = should_treat_as_uniform () in
-    ComInductive.do_mutual_inductive ~template udecl indl ~cumulative ~poly ?typing_flags ~private_ind ~uniform finite
+    indl, Preprocessed_Mind_decl.(Inductive { flags = { template; udecl; cumulative; poly; finite }; typing_flags; private_ind; uniform; inductives })
   else
     user_err (str "Mixed record-inductive definitions are not allowed.")
+  ;;
+
+
+let vernac_inductive ~atts kind indl =
+  let open Preprocessed_Mind_decl in
+  let indl_for_glob, decl = preprocess_inductive_decl ~atts kind indl in
+  if Dumpglob.dump () then
+    List.iter (fun (((coe,lid), _, _, cstrs), _) ->
+      match cstrs with
+        | Constructors cstrs ->
+            Dumpglob.dump_definition lid false "ind";
+            List.iter (fun (_, (lid, _)) ->
+                         Dumpglob.dump_definition lid false "constr") cstrs
+        | _ -> ())
+      indl_for_glob;
+  match decl with
+  | Record { flags = { template; udecl; cumulative; poly; finite; }; kind; primitive_proj; records } ->
+    let () =
+      if Dumpglob.dump () then
+        let dump_glob_proj (x, _) = match x with
+          | Vernacexpr.(AssumExpr ({loc;v=Name id}, _, _) | DefExpr ({loc;v=Name id}, _, _, _)) ->
+              Dumpglob.dump_definition (make ?loc id) false "proj"
+          | _ -> () in
+        records |> List.iter (fun { Record.Ast.cfs; name } ->
+          let () = Dumpglob.dump_definition name false "rec" in
+          List.iter dump_glob_proj cfs)
+    in
+    let _ : _ list =
+      Record.definition_structure ~template udecl kind ~cumulative ~poly ~primitive_proj finite records in
+    ()
+  | Inductive { flags = { template; udecl; cumulative; poly; finite; }; typing_flags; private_ind; uniform; inductives } ->
+    ComInductive.do_mutual_inductive ~template udecl inductives ~cumulative ~poly ?typing_flags ~private_ind ~uniform finite
+;;
+let preprocess_inductive_decl ~atts kind indl =
+  snd @@ preprocess_inductive_decl ~atts kind indl
 
 let vernac_fixpoint_common ~atts discharge l =
   if Dumpglob.dump () then

--- a/vernac/vernacentries.mli
+++ b/vernac/vernacentries.mli
@@ -27,3 +27,36 @@ val interp_redexp_hook : (Environ.env -> Evd.evar_map -> Genredexpr.raw_red_expr
 val command_focus : unit Proof.focus_kind
 
 val allow_sprop_opt_name : string list
+
+(** pre-processing and validation of VernacInductive *)
+module Preprocessed_Mind_decl : sig
+  type flags = {
+    template : bool option;
+    udecl : Constrexpr.cumul_univ_decl_expr option;
+    cumulative : bool;
+    poly : bool;
+    finite : Declarations.recursivity_kind;
+  }
+  type record = {
+    flags : flags;
+    primitive_proj : bool;
+    kind : Vernacexpr.inductive_kind;
+    records : Record.Ast.t list;
+  }
+  type inductive = {
+    flags : flags;
+    typing_flags : Declarations.typing_flags option;
+    private_ind : bool;
+    uniform : ComInductive.uniform_inductive_flag;
+    inductives : (Vernacexpr.one_inductive_expr * Vernacexpr.decl_notation list) list;
+  }
+  type t =
+    | Record of record
+    | Inductive of inductive
+end
+
+val preprocess_inductive_decl
+  :  atts:Attributes.vernac_flags
+  -> Vernacexpr.inductive_kind
+  -> (Vernacexpr.inductive_expr * Vernacexpr.decl_notation list) list
+  -> Preprocessed_Mind_decl.t


### PR DESCRIPTION
In the context of Elpi I want to let coq elaborate an inductive declaration (up to the constr level) without necessarily adding it to the environment, the same for records and context.
This PR exports the first half of do_mutual_inductive (the part which is side effect free) and do_record and do_context.

Fixes #14737

TODO:
- [x] overlay for coq-elpi using the new API