### PR TITLE
Fix docgram

### DIFF
--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1220,6 +1220,9 @@ printable: [
 | WITH "Hint" OPT [ "*" | smart_global ]
 | DELETE "Hint" smart_global
 | DELETE "Hint" "*"
+| DELETE "Notation" string
+| REPLACE "Notation" string "in" "custom" IDENT
+| WITH "Notation" string OPT [ "in" "custom" IDENT ]
 
 | INSERTALL "Print"
 ]

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -737,6 +737,9 @@ gallina_ext: [
 | DELETE "Require" export_token LIST1 global
 | REPLACE "From" global "Require" export_token LIST1 global
 | WITH OPT [ "From" dirpath ] "Require" export_token LIST1 global
+
+| REPLACE "From" global "Extra" "Dependency" ne_string OPT [ "as" IDENT ]
+| WITH "From" dirpath "Extra" "Dependency" ne_string OPT [ "as" IDENT ]
 ]
 
 (* lexer stuff *)

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -892,8 +892,7 @@ command: [
 | "Print" "TypeClasses"
 | "Print" "Instances" reference
 | "Print" "Coercions"
-| "Print" "Notation" string
-| "Print" "Notation" string "in" "custom" ident
+| "Print" "Notation" string OPT [ "in" "custom" ident ]
 | "Print" "Coercion" "Paths" class class
 | "Print" "Canonical" "Projections" LIST0 reference
 | "Print" "Typing" "Flags"

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1067,7 +1067,7 @@ command: [
 | "Section" ident
 | "End" ident
 | "Collection" ident ":=" section_var_expr
-| "From" qualid "Extra" "Dependency" string OPT [ "as" ident ]
+| "From" dirpath "Extra" "Dependency" string OPT [ "as" ident ]
 | OPT [ "From" dirpath ] "Require" OPT [ "Import" | "Export" ] LIST1 qualid
 | "Import" OPT import_categories LIST1 filtered_import
 | "Export" OPT import_categories LIST1 filtered_import


### PR DESCRIPTION
The refman was edited by hand in a few recent PRs without running docgram, which made unexpected changes appear when running it.
