### PR TITLE
coq_makefile: flip logic for KEEP_ERROR, avoid double negations in comment

### DIFF
--- a/dev/ci/user-overlays/15880-blaisorblade-coq_mk-delete-on-err.sh
+++ b/dev/ci/user-overlays/15880-blaisorblade-coq_mk-delete-on-err.sh
@@ -1,0 +1,7 @@
+#overlay <project> <giturl> <ref> <prnumber> [<prbranch>]
+
+#overlay JasonGross/coq-tools
+
+#JasonGross/coq-tools#117
+
+overlay coq_tools https://github.com/JasonGross/coq-tools fix-keep-error 15880 coq_mk-delete-on-err

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -60,12 +60,12 @@ OCAMLWARN         := $(COQMF_WARN)
 # practice is discouraged since _CoqProject better not contain make specific
 # code (be nice to user interfaces).
 
-# set KEEP_ERROR to prevent make from deleting files produced by failing rules.
-# For instance if coqc creates a .vo but then fails to native compile,
-# the .vo will be deleted unless KEEP_ERROR is nonempty.
+# Set KEEP_ERROR to have make keep files produced by failing rules.
+# By default, KEEP_ERROR is empty. So for instance if coqc creates a .vo but
+# then fails to native compile, the .vo will be deleted.
 # May confuse make so use only for debugging.
 KEEP_ERROR?=
-ifneq (,$(KEEP_ERROR))
+ifeq (,$(KEEP_ERROR))
 .DELETE_ON_ERROR:
 endif
 


### PR DESCRIPTION
This implements the logic documented in https://github.com/coq/coq/pull/14238.

To clarify docs, avoid double negations.

Fixes issue described in https://coq.zulipchat.com/#narrow/stream/237656-Coq-devs-.26-plugin-devs/topic/DELETE_ON_ERROR.20flipped.20logic.