### PR TITLE
Correctly handle functor arguments for module subtyping check.

### DIFF
--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -312,9 +312,9 @@ and check_modtypes cst env mtb1 mtb2 subst1 subst2 equiv =
         MoreFunctor (arg_id2,arg_t2,body_t2) ->
         let mp2 = MPbound arg_id2 in
         let subst1 = join (map_mbid arg_id1 mp2 arg_t2.mod_delta) subst1 in
+        let env = add_module_type mp2 arg_t2 env in
         let cst = check_modtypes cst env arg_t2 arg_t1 subst2 subst1 equiv in
         (* contravariant *)
-        let env = add_module_type mp2 arg_t2 env in
         let env =
           if Modops.is_functor body_t1 then env
           else add_module

--- a/test-suite/bugs/bug_15883.v
+++ b/test-suite/bugs/bug_15883.v
@@ -1,0 +1,17 @@
+Module Type S.
+Definition T := nat.
+Parameter n : T.
+End S.
+
+Module Type S'.
+Definition T := nat.
+Parameter n : nat.
+End S'.
+
+Module Type F(X : S).
+End F.
+
+Module K (X : S').
+End K.
+
+Module R : F := K.


### PR DESCRIPTION
The invariant of the subtyping function is that the intended subtype is expected to be part of the current environment. Unfortunately, it was added too late for the check of the argument types to be performed correctly.

I do not have a reproducible example but this is a variant of #8937 I have discovered while tweaking the conversion algorithm used for subtyping. This test only passes in master because it takes the fast path for conversion based on equality, but the terms conversion is provided with are referring to unbound inductive types in the current environment.