### PR TITLE
[coqdep] Further cleanup of the loadpath API

### DIFF
--- a/tools/coqdep/coqdep.ml
+++ b/tools/coqdep/coqdep.ml
@@ -36,17 +36,18 @@ let coqdep () =
    with Not_found -> Loadpath.add_current_dir lst ".");
   (* We don't setup any loadpath if the -boot is passed *)
   if not args.Args.boot then begin
+    let in_tree = false in
     let env = Boot.Env.init () in
     let stdlib = Boot.Env.(stdlib env |> Path.to_string) in
     let plugins = Boot.Env.(plugins env |> Path.to_string) in
     let user_contrib = Boot.Env.(user_contrib env |> Path.to_string) in
-    Loadpath.add_loadpath ~implicit:true lst stdlib ["Coq"];
-    Loadpath.add_loadpath ~implicit:true lst plugins ["Coq"];
+    Loadpath.add_loadpath ~implicit:true ~in_tree lst stdlib ["Coq"];
+    Loadpath.add_loadpath ~implicit:true ~in_tree lst plugins ["Coq"];
     if Sys.file_exists user_contrib
-    then Loadpath.add_loadpath ~implicit:false lst user_contrib [];
-    List.iter (fun s -> Loadpath.add_loadpath ~implicit:false lst s [])
+    then Loadpath.add_loadpath ~implicit:false ~in_tree lst user_contrib [];
+    List.iter (fun s -> Loadpath.add_loadpath ~implicit:false ~in_tree lst s [])
       (Envars.xdg_dirs ~warn:(fun x -> Warning.give "%s" x));
-    List.iter (fun s -> Loadpath.add_loadpath ~implicit:false lst s []) Envars.coqpath;
+    List.iter (fun s -> Loadpath.add_loadpath ~implicit:false ~in_tree lst s []) Envars.coqpath;
   end;
   if args.Args.sort then
     sort st

--- a/tools/coqdep/coqdep.ml
+++ b/tools/coqdep/coqdep.ml
@@ -33,20 +33,20 @@ let coqdep () =
      Common coq.boot library *)
   (* Add current dir with empty logical path if not set by options above. *)
   (try ignore (Loadpath.find_dir_logpath (Sys.getcwd()))
-   with Not_found -> Loadpath.add_norec_dir_import (Loadpath.add_known lst) "." []);
+   with Not_found -> Loadpath.add_current_dir lst ".");
   (* We don't setup any loadpath if the -boot is passed *)
   if not args.Args.boot then begin
     let env = Boot.Env.init () in
     let stdlib = Boot.Env.(stdlib env |> Path.to_string) in
     let plugins = Boot.Env.(plugins env |> Path.to_string) in
     let user_contrib = Boot.Env.(user_contrib env |> Path.to_string) in
-    Loadpath.add_rec_dir_import (Loadpath.add_coqlib_known lst) stdlib ["Coq"];
-    Loadpath.add_rec_dir_import (Loadpath.add_coqlib_known lst) plugins ["Coq"];
+    Loadpath.add_loadpath ~implicit:true lst stdlib ["Coq"];
+    Loadpath.add_loadpath ~implicit:true lst plugins ["Coq"];
     if Sys.file_exists user_contrib
-    then Loadpath.add_rec_dir_no_import (Loadpath.add_coqlib_known lst) user_contrib [];
-    List.iter (fun s -> Loadpath.add_rec_dir_no_import (Loadpath.add_coqlib_known lst) s [])
+    then Loadpath.add_loadpath ~implicit:false lst user_contrib [];
+    List.iter (fun s -> Loadpath.add_loadpath ~implicit:false lst s [])
       (Envars.xdg_dirs ~warn:(fun x -> Warning.give "%s" x));
-    List.iter (fun s -> Loadpath.add_rec_dir_no_import (Loadpath.add_coqlib_known lst) s []) Envars.coqpath;
+    List.iter (fun s -> Loadpath.add_loadpath ~implicit:false lst s []) Envars.coqpath;
   end;
   if args.Args.sort then
     sort st

--- a/tools/coqdep/lib/common.ml
+++ b/tools/coqdep/lib/common.ml
@@ -333,12 +333,12 @@ let treat_coqproject st f =
     | UnableToOpenProjectFile msg -> Error.cannot_open_project_file msg
   in
   iter_sourced (fun { path } -> Loadpath.add_caml_dir st path) project.ml_includes;
-  iter_sourced (fun ({ path }, l) -> Loadpath.add_loadpath ~implicit:false st path (split_period l)) project.q_includes;
-  iter_sourced (fun ({ path }, l) -> Loadpath.add_loadpath ~implicit:true st path (split_period l)) project.r_includes;
+  iter_sourced (fun ({ path }, l) -> Loadpath.add_loadpath ~implicit:false ~in_tree:true st path (split_period l)) project.q_includes;
+  iter_sourced (fun ({ path }, l) -> Loadpath.add_loadpath ~implicit:true ~in_tree:true st path (split_period l)) project.r_includes;
   iter_sourced (fun f' -> treat_file_coq_project f f') (all_files project)
 
 let add_include st (implicit, r, ln) =
-  Loadpath.add_loadpath ~implicit st r (split_period ln)
+  Loadpath.add_loadpath ~implicit ~in_tree:true st r (split_period ln)
 
 let init ~make_separator_hack args =
   separator_hack := make_separator_hack;

--- a/tools/coqdep/lib/loadpath.ml
+++ b/tools/coqdep/lib/loadpath.ml
@@ -249,27 +249,12 @@ let add_paths recur root table phys_dir log_dir basename =
   let iter n = safe_add table root (n, file) in
   List.iter iter paths
 
-(* XXX: There are some differences in add_coqlib_known and add_known
-   that we need to solve *)
-
-(* Loadpath.add_rec_dir_import    (Loadpath.add_coqlib_known lst) stdlib       ["Coq"]; *)
-(* Loadpath.add_rec_dir_no_import (Loadpath.add_coqlib_known lst) user_contrib [];      *)
-(* let add_coqlib_known st recur root phys_dir log_dir f =
- *   let root = (phys_dir, log_dir) in
- *   match get_extension f [".vo"; ".vio"; ".vos"] with
- *     | (basename, (".vo" | ".vio" | ".vos")) ->
- *         add_paths recur root st.State.coqlib phys_dir log_dir basename
- *     | _ -> ()
- *)
-
 let add_known st recur root phys_dir log_dir f =
   match get_extension f [".v"; ".vo"; ".vio"; ".vos"] with
-    | (basename,".v") ->
-        add_paths recur root st.State.vfiles phys_dir log_dir basename
-    | (basename, (".vo" | ".vio" | ".vos")) when not st.State.boot ->
-        add_paths recur root st.State.vfiles phys_dir log_dir basename
+    | (basename, (".v" | ".vo" | ".vio" | ".vos")) ->
+      add_paths recur root st.State.vfiles phys_dir log_dir basename
     | (f,_) ->
-        add_paths recur root st.State.other phys_dir log_dir f
+      add_paths recur root st.State.other phys_dir log_dir f
 
 (** -I semantic: do not go in subdirs. *)
 let add_caml_dir st phys_dir =
@@ -280,5 +265,6 @@ let add_caml_dir st phys_dir =
 let add_current_dir st dir =
   add_directory false (add_known st true) dir []
 
-let add_loadpath st ~implicit path l =
-  add_directory implicit (add_known st implicit) path l
+let add_loadpath st ~implicit ~in_tree path l =
+  if in_tree then
+    add_directory implicit (add_known st implicit) path l

--- a/tools/coqdep/lib/loadpath.mli
+++ b/tools/coqdep/lib/loadpath.mli
@@ -13,7 +13,7 @@ val get_extension : string -> string list -> string * string
 
 (* Loadpaths *)
 type basename = string
-type dirname = string
+type dirname = System.unix_path
 type dir = string option
 type filename = string
 type dirpath = string list
@@ -34,31 +34,13 @@ val search_other_known : State.t -> ?from:dirpath -> dirpath -> result option
 val search_mllib_known : State.t -> string -> dir option
 val search_mlpack_known : State.t -> string -> dir option
 
-val is_in_coqlib : State.t -> ?from:dirpath -> dirpath -> bool
-
-val add_caml_dir : State.t -> System.unix_path -> unit
-
-val add_current_dir : State.t -> System.unix_path -> unit
-val add_q_include : State.t -> System.unix_path -> string -> unit
-val add_r_include : State.t -> System.unix_path -> string -> unit
-
-(* These should disappear in favor of add_q / add_r *)
+val add_caml_dir : State.t -> dirname -> unit
 
 (** Simply add this directory and imports it, no subdirs. This is used
     by the implicit adding of the current path. *)
-val add_norec_dir_import :
-  (bool -> root -> dirname -> dirpath -> basename -> unit) -> dirname -> dirpath -> unit
+val add_current_dir : State.t -> dirname -> unit
 
-(** -Q semantic: go in subdirs but only full logical paths are known. *)
-val add_rec_dir_no_import :
-  (bool -> root -> dirname -> dirpath -> basename -> unit) -> dirname -> dirpath -> unit
-
-(** -R semantic: go in subdirs and suffixes of logical paths are known. *)
-val add_rec_dir_import :
-  (bool -> root -> dirname -> dirpath -> basename -> unit) -> dirname -> dirpath -> unit
-
-val add_known : State.t -> bool -> root -> dirname -> dirpath -> basename -> unit
-val add_coqlib_known : State.t -> bool -> root -> dirname -> dirpath -> basename -> unit
+val add_loadpath : State.t -> implicit:bool -> dirname -> dirpath -> unit
 
 (** [find_dir_logpath phys_dir] Return the logical path of directory
    [dir] if it has been given one. Raise [Not_found] otherwise. In

--- a/tools/coqdep/lib/loadpath.mli
+++ b/tools/coqdep/lib/loadpath.mli
@@ -40,7 +40,11 @@ val add_caml_dir : State.t -> dirname -> unit
     by the implicit adding of the current path. *)
 val add_current_dir : State.t -> dirname -> unit
 
-val add_loadpath : State.t -> implicit:bool -> dirname -> dirpath -> unit
+(** [add_loadpath st ~implicit ~in_tree dn dp] Adds a loadpath to
+   coqdep's search path. [implicit] controls -Q/-R options, [in_tree]
+   controls whether the path was added by the user or by Coq's auto
+   initialization. *)
+val add_loadpath : State.t -> implicit:bool -> in_tree:bool -> dirname -> dirpath -> unit
 
 (** [find_dir_logpath phys_dir] Return the logical path of directory
    [dir] if it has been given one. Raise [Not_found] otherwise. In


### PR DESCRIPTION
In particular we remove the `coqlib` field which was just used to
suppress a warning.

This brings `coqdep/loadpath` closer to `vernac/loadpath.ml`, but
still a way to go. Many differences are unaccounted for here yet.

