### PR TITLE
Add -bytecode-compiler flag for enabling vm_compute in coqchk

### DIFF
--- a/checker/checkFlags.ml
+++ b/checker/checkFlags.ml
@@ -11,6 +11,7 @@
 open Declarations
 
 let set_local_flags flags env =
+  (* Explicitly ignored flags have been commented out *)
   let flags =
     { (Environ.typing_flags env) with
       check_guarded = flags.check_guarded;
@@ -18,6 +19,11 @@ let set_local_flags flags env =
       check_universes = flags.check_universes;
       conv_oracle = flags.conv_oracle;
       share_reduction = flags.share_reduction;
+      enable_VM = flags.enable_VM;
+      (* enable_native_compiler = flags.enable_native_compiler; *)
+      (* indices_matter = flags.indices_matter; *)
+      (* impredicative_set = flags.impredicative_set; *)
+      (* sprop_allowed = flags.sprop_allowed; *)
       cumulative_sprop = flags.cumulative_sprop;
       allow_uip = flags.allow_uip;
     }

--- a/checker/checkFlags.ml
+++ b/checker/checkFlags.ml
@@ -11,21 +11,23 @@
 open Declarations
 
 let set_local_flags flags env =
-  (* Explicitly ignored flags have been commented out *)
-  let flags =
-    { (Environ.typing_flags env) with
-      check_guarded = flags.check_guarded;
-      check_positive = flags.check_positive;
-      check_universes = flags.check_universes;
-      conv_oracle = flags.conv_oracle;
-      share_reduction = flags.share_reduction;
-      enable_VM = flags.enable_VM;
-      (* enable_native_compiler = flags.enable_native_compiler; *)
-      (* indices_matter = flags.indices_matter; *)
-      (* impredicative_set = flags.impredicative_set; *)
-      (* sprop_allowed = flags.sprop_allowed; *)
-      cumulative_sprop = flags.cumulative_sprop;
-      allow_uip = flags.allow_uip;
-    }
+  (* Explicitly ignored flags are set to not change *)
+  let envflags = Environ.typing_flags env in
+  let flags = {
+    (* These flags may be overridden *)
+    check_guarded = flags.check_guarded;
+    check_positive = flags.check_positive;
+    check_universes = flags.check_universes;
+    conv_oracle = flags.conv_oracle;
+    share_reduction = flags.share_reduction;
+    enable_VM = flags.enable_VM;
+    cumulative_sprop = flags.cumulative_sprop;
+    allow_uip = flags.allow_uip;
+    (* These flags may not *)
+    enable_native_compiler = envflags.enable_native_compiler;
+    indices_matter = envflags.indices_matter;
+    impredicative_set = envflags.impredicative_set;
+    sprop_allowed = envflags.sprop_allowed;
+  }
   in
   Environ.set_typing_flags flags env

--- a/checker/checkFlags.ml
+++ b/checker/checkFlags.ml
@@ -20,10 +20,10 @@ let set_local_flags flags env =
     check_universes = flags.check_universes;
     conv_oracle = flags.conv_oracle;
     share_reduction = flags.share_reduction;
-    enable_VM = flags.enable_VM;
     cumulative_sprop = flags.cumulative_sprop;
     allow_uip = flags.allow_uip;
     (* These flags may not *)
+    enable_VM = envflags.enable_VM;
     enable_native_compiler = envflags.enable_native_compiler;
     indices_matter = envflags.indices_matter;
     impredicative_set = envflags.impredicative_set;

--- a/checker/checkFlags.mli
+++ b/checker/checkFlags.mli
@@ -9,4 +9,4 @@
 (************************************************************************)
 
 val set_local_flags : Declarations.typing_flags -> Environ.env -> Environ.env
-(** Set flags except for those ignored by the checker (eg vm_compute). *)
+(** Set flags except for those ignored by the checker (see .ml file for those). *)

--- a/checker/checker.ml
+++ b/checker/checker.ml
@@ -138,11 +138,13 @@ let set_impredicative_set () = impredicative_set := true
 
 let indices_matter = ref false
 
+let enable_vm = ref false
+
 let make_senv () =
   let senv = Safe_typing.empty_environment in
   let senv = Safe_typing.set_impredicative_set !impredicative_set senv in
   let senv = Safe_typing.set_indices_matter !indices_matter senv in
-  let senv = Safe_typing.set_VM false senv in
+  let senv = Safe_typing.set_VM !enable_vm senv in
   let senv = Safe_typing.set_allow_sprop true senv in (* be smarter later *)
   Safe_typing.set_native_compiler false senv
 
@@ -321,6 +323,11 @@ let parse_args argv =
 
     | "-indices-matter" :: rem ->
       indices_matter:=true; parse rem
+
+    | "-bytecode-compiler" :: "yes" :: rem ->
+      enable_vm := true; parse rem
+    | "-bytecode-compiler" :: "no" :: rem ->
+      enable_vm := false; parse rem
 
     | "-coqlib" :: s :: rem ->
       if not (exists_dir s) then

--- a/checker/checker.ml
+++ b/checker/checker.ml
@@ -180,23 +180,27 @@ let print_usage_channel co command =
   output_string co command;
   output_string co "coqchk options are:\n";
   output_string co
-"  -Q dir coqdir          map physical dir to logical coqdir\
-\n  -R dir coqdir          synonymous for -Q\
+"\
+\n  -Q dir coqdir               map physical dir to logical coqdir\
+\n  -R dir coqdir               synonymous for -Q\
+\n  -coqlib dir                 set coqchk's standard library location\
 \n\
+\n  -admit module               load module and dependencies without checking\
+\n  -norec module               check module but admit dependencies without checking\
 \n\
-\n  -admit module          load module and dependencies without checking\
-\n  -norec module          check module but admit dependencies without checking\
+\n  -debug                      enable debugging info\
+\n  -where                      print coqchk's standard library location and exit\
+\n  -v, --version               print coqchk version and exit\
+\n  -o, --output-context        print the list of assumptions\
+\n  -m, --memory                print the maximum heap size\
+\n  -silent                     disable trace of constants being checked\
 \n\
-\n  -coqlib dir            set coqchk's standard library location\
-\n  -where                 print coqchk's standard library location and exit\
-\n  -v                     print coqchk version and exit\
-\n  -o, --output-context   print the list of assumptions\
-\n  -m, --memory           print the maximum heap size\
-\n  -silent                disable trace of constants being checked\
+\n  -impredicative-set          set sort Set impredicative\
+\n  -indices-matter             levels of indices (and nonuniform parameters)\
+\n                              contribute to the level of inductives\
+\n  -bytecode-compiler (yes|no) enable the vm_compute reduction machine\
 \n\
-\n  -impredicative-set     set sort Set impredicative\
-\n\
-\n  -h, --help             print this list of options\
+\n  -h, --help                  print this list of options\
 \n"
 
 (* print the usage on standard error *)

--- a/checker/checker.ml
+++ b/checker/checker.ml
@@ -198,7 +198,7 @@ let print_usage_channel co command =
 \n  -impredicative-set          set sort Set impredicative\
 \n  -indices-matter             levels of indices (and nonuniform parameters)\
 \n                              contribute to the level of inductives\
-\n  -bytecode-compiler (yes|no) enable the vm_compute reduction machine\
+\n  -bytecode-compiler (yes|no) enable the vm_compute reduction machine (default is no)\
 \n\
 \n  -h, --help                  print this list of options\
 \n"

--- a/doc/changelog/08-cli-tools/15886-enable-vm-coqchk.rst
+++ b/doc/changelog/08-cli-tools/15886-enable-vm-coqchk.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  Added -bytecode-compiler (yes|no) flag for ``coqchk`` enabling
+  :tacn:`vm_compute` during checks, which is off by default.
+  (`#15886 <https://github.com/coq/coq/pull/15886>`_,
+  by Ali Caglayan).


### PR DESCRIPTION
I also cleaned up the --help for coqchk

<!-- Remove anything that doesn't apply in the following checklist. -->

- [x] Added **changelog**.
- [x] Added / updated **documentation**.
