### PR TITLE
Add a "Coq Configuration Basics" section

### DIFF
--- a/doc/changelog/09-cli-tools/15888-config_doc.rst
+++ b/doc/changelog/09-cli-tools/15888-config_doc.rst
@@ -1,0 +1,6 @@
+- **Added:**
+  New documentation section "Coq configuration basics" covering use cases such
+  as setting up Coq with opam, where/how to set up source code for your projects
+  and use of _CoqProject
+  (`#15888 <https://github.com/coq/coq/pull/15888>`_,
+  by Jim Fehrle).

--- a/doc/sphinx/language/coq-library.rst
+++ b/doc/sphinx/language/coq-library.rst
@@ -763,7 +763,7 @@ subdirectories:
   * **Wellfounded** : Well-founded relations (basic results)
 
 
-These directories belong to the initial load path of the system, and
+These directories belong to the initial :term:`load path` of the system, and
 the modules they provide are compiled at installation time. So they
 are directly accessible with the command ``Require`` (see
 Section :ref:`compiled-files`).

--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -879,81 +879,72 @@ and :math:`Γ_C` is :math:`[c_1{:}∀ Γ_P, C_1 ; …; c_n{:}∀ Γ_P, C_n ]`.
 
 .. extracted from Gallina extensions chapter
 
-Libraries and qualified names
----------------------------------
-
-.. _names-of-libraries:
-
-Names of libraries
-~~~~~~~~~~~~~~~~~~
-
-The theories developed in Coq are stored in *library files* which are
-hierarchically classified into *libraries* and *sublibraries*. To
-express this hierarchy, library names are represented by qualified
-identifiers qualid, i.e. as list of identifiers separated by dots (see
-:ref:`qualified-names`). For instance, the library file ``Mult`` of the standard
-Coq library ``Arith`` is named ``Coq.Arith.Mult``. The identifier that starts
-the name of a library is called a *library root*. All library files of
-the standard library of Coq have the reserved root Coq but library
-filenames based on other roots can be obtained by using Coq commands
-(coqc, coqtop, coqdep, …) options ``-Q`` or ``-R`` (see :ref:`command-line-options`).
-Also, when an interactive Coq session starts, a library of root ``Top`` is
-started, unless option ``-top`` or ``-notop`` is set (see :ref:`command-line-options`).
-
 .. _qualified-names:
 
-Qualified identifiers
-~~~~~~~~~~~~~~~~~~~~~
+Qualified names
+---------------
 
-.. insertprodn qualid field_ident
+Qualified names (:token:`qualid`\s) are hierarchical names that are used to
+identify items such as definitions, theorems and parameters that may be defined
+inside modules (see :cmd:`Module`).  In addition, they are used to identify
+compiled files.  Syntactically, they have this form:
+
+.. insertprodn qualid qualid
 
 .. prodn::
-   qualid ::= @ident {* @field_ident }
-   field_ident ::= .@ident
+   qualid ::= @ident {* .@ident }
 
-Library files are modules which possibly contain submodules which
-eventually contain constructions (axioms, parameters, definitions,
-lemmas, theorems, remarks or facts). The *absolute name*, or *full
-name*, of a construction in some library file is a qualified
-identifier starting with the logical name of the library file,
-followed by the sequence of submodules names encapsulating the
-construction and ended by the proper name of the construction.
-Typically, the absolute name ``Coq.Init.Logic.eq`` denotes Leibniz’
-equality defined in the module Logic in the sublibrary ``Init`` of the
-standard library of Coq.
+*Fully qualified* or *absolute* qualified names uniquely identify files
+(as in the `Require` command) and items within files, such as a single
+:cmd:`Variable` definition.  It's usually possible to use a suffix of the fully
+qualified name (a *short name*) that uniquely identifies an item.
 
-The proper name that ends the name of a construction is the short name
-(or sometimes base name) of the construction (for instance, the short
-name of ``Coq.Init.Logic.eq`` is ``eq``). Any partial suffix of the absolute
-name is a *partially qualified name* (e.g. ``Logic.eq`` is a partially
-qualified name for ``Coq.Init.Logic.eq``). Especially, the short name of a
-construction is its shortest partially qualified name.
+The first part of a fully qualified name identifies a file, which may be followed
+by a second part that identifies a specific item within that file.  Qualified names
+that identify files don't have a second part.
 
-Coq does not accept two constructions (definition, theorem, …) with
-the same absolute name but different constructions can have the same
-short name (or even same partially qualified names as soon as the full
-names are different).
+While qualified names always consist of a series of dot-separated :n:`@ident`\s,
+*the following few paragraphs omit the dots for the sake of simplicity.*
 
-Notice that the notion of absolute, partially qualified and short
-names also applies to library filenames.
+**File part.** Files are identified by :gdef:`logical paths <logical path>`,
+which are prefixes in the form :n:`{* @ident__logical } {+ @ident__file }`, such
+as :n:`Coq.Init.Logic`, in which:
 
-**Visibility**
+- :n:`{* @ident__logical }`, the :gdef:`logical name`, maps to one or more
+  directories (or :gdef:`physical paths <physical path>`) in the user's file system.
+  The logical name
+  is used so that Coq scripts don't depend on where files are installed.
+  For example, the directory associated with :n:`Coq` contains Coq's standard library.
+  The logical name is generally a single :n:`@ident`.
 
-Coq maintains a table called the name table which maps partially qualified
-names of constructions to absolute names. This table is updated by the
-commands :cmd:`Require`, :cmd:`Import` and :cmd:`Export` and
-also each time a new declaration is added to the context. An absolute
-name is called visible from a given short or partially qualified name
-when this latter name is enough to denote it. This means that the
-short or partially qualified name is mapped to the absolute name in
-Coq name table. Definitions with the :attr:`local` attribute are only accessible with
+- :n:`{+ @ident__file }` corresponds to the file system path of the file relative
+  to the directory that contains it.  For example, :n:`Init.Logic`
+  corresponds to the file system path :n:`Init/Logic.v` on Linux)
+
+When Coq is processing a script that hasn't been saved in a file, such as a new
+buffer in CoqIDE or anything in coqtop, definitions in the script are associated
+with the logical name :n:`Top` and there is no associated file system path.
+
+**Item part.** Items are further qualified by a suffix in the form
+:n:`{* @ident__module } @ident__base` in which:
+
+- :n:`{* @ident__module }` gives the names of the nested modules, if any,
+  that syntactically contain the definition of the item.  (See :cmd:`Module`.)
+
+- :n:`@ident__base` is the base name used in the command defining
+  the item.  For example, :n:`eq` in the :cmd:`Inductive` command defining it
+  in `Coq.Init.Logic` is the base name for `Coq.Init.Logic.eq`, the standard library
+  definition of :term:`Leibniz equality`.
+
+If :n:`@qualid` is the fully qualified name of an item, Coq
+always interprets :n:`@qualid` as a reference to that item.  If :n:`@qualid` is also a
+partially qualified name for another item, then you must use provide a more-qualified
+name to uniquely identify that other item.  For example, if there are two
+fully qualified items named `Foo.Bar` and `Coq.X.Foo.Bar`, then `Foo.Bar` refers
+to the first item and `X.Foo.Bar` is the shortest name for referring to the second item.
+
+Definitions with the :attr:`local` attribute are only accessible with
 their fully qualified name (see :ref:`gallina-definitions`).
-
-It may happen that a visible name is hidden by the short name or a
-qualified name of another construction. In this case, the name that
-has been hidden must be referred to using one more level of
-qualification. To ensure that a construction always remains
-accessible, absolute names can never be hidden.
 
 .. example::
 
@@ -971,59 +962,8 @@ accessible, absolute names can never be hidden.
 
 .. seealso:: Commands :cmd:`Locate`.
 
-.. _libraries-and-filesystem:
-
-Libraries and filesystem
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-Compiled files (``.vo`` and ``.vio``) store sub-libraries. In order to refer
-to them inside Coq, a translation from file-system names to Coq names
-is needed. In this translation, names in the file system are called
-*physical* paths while Coq names are contrastingly called *logical*
-names.
-
-A logical prefix Lib can be associated with a physical path using
-either the command line option ``-Q`` `path` ``Lib`` or the command
-line option ``-R`` `path` ``Lib``. All subfolders of path are
-recursively associated with the logical path ``Lib`` extended with the
-corresponding suffix coming from the physical path. For instance, the
-folder ``path/Foo/Bar`` maps to ``Lib.Foo.Bar``. Subdirectories corresponding
-to invalid Coq identifiers are skipped, and, by convention,
-subdirectories named ``CVS`` or ``_darcs`` are skipped too.
-
-Thanks to this mechanism, ``.vo`` files are made available through the
-logical name of the folder they are in, extended with their own
-basename. For example, the name associated with the file
-``path/Foo/Bar/File.vo`` is ``Lib.Foo.Bar.File``. The same caveat applies for
-invalid identifiers. When compiling a source file, the ``.vo`` file stores
-its logical name, so that an error is issued if it is loaded with the
-wrong loadpath afterwards.
-
-Some folders have a special status and are automatically put in the
-path. Coq commands automatically associate a logical path to files in
-the repository tree rooted at the directory from where the command is
-launched, ``coqlib/user-contrib/``, the directories listed in the
-``$COQPATH``, ``${XDG_DATA_HOME}/coq/`` and ``${XDG_DATA_DIRS}/coq/``
-environment variables (see `XDG base directory specification
-<http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html>`_)
-with the same physical-to-logical translation and with an empty logical prefix.
-
-.. todo: Needs a more better explanation of COQPATH and XDG* with example(s)
-   and suggest best practices for their use
-
-The choice between ``-Q`` and ``-R`` impacts how ambiguous names are
-resolved in :cmd:`Require` (see :ref:`compiled-files`).
-
-There also exists another independent loadpath mechanism attached to
-OCaml object files (``.cmo`` or ``.cmxs``) rather than Coq object
-files as described above. The OCaml loadpath is managed using
-the option ``-I`` `path` (in the OCaml world, there is neither a
-notion of logical name prefix nor a way to access files in
-subdirectories of path). See the command :cmd:`Declare ML Module` in
-:ref:`compiled-files` to understand the need of the OCaml loadpath.
-
-See :ref:`command-line-options` for a more general view over the Coq command
-line options.
+:ref:`logical-paths-load-path` describes how :term:`logical paths <logical path>`
+become associated with specific files.
 
 .. _controlling-locality-of-commands:
 
@@ -1060,7 +1000,7 @@ while noting a few exceptional commands for which :attr:`local` and
       **Exception:** when :attr:`local` is applied to
       :cmd:`Definition`, :cmd:`Theorem` or their variants, its
       semantics are different: it makes the defined objects available
-      only through their fully-qualified names rather than their
+      only through their fully qualified names rather than their
       unqualified names after an :cmd:`Import`.
 
 .. attr:: export

--- a/doc/sphinx/practical-tools/coqide.rst
+++ b/doc/sphinx/practical-tools/coqide.rst
@@ -216,11 +216,41 @@ The `Compile` menu offers direct commands to:
 
 + compile the current buffer
 + run a compilation using `make`
-+ go to the last compilation error
++ go to the next compilation error and
 + create a `Makefile` using `coq_makefile`.
 
 At the moment these are not working well.  We recommend you compile
 from a terminal window for now.  We expect to fix them soon.
+
+`Compile buffer` saves the current buffer and compiles it with `coqc` as specified
+in the `Externals` section of the `Edit/Preferences` dialog.  Output appears
+in the `Messages` panel.  It's mostly useful for single-file projects because it doesn't
+automatically recompile other files that it depends on that may have changed.
+
+`Make` and `Make makefile` run the `make` and `coqmakefile` commands shown in
+the `Externals` section of the `Edit/Preferences` dialog.  Output appears in the
+`Messages` panel.  If you use `_CoqProject` files, you may want to change the settings to
+`make -f CoqMakefile` and `coq_makefile -f _CoqProject -o CoqMakefile` as suggested
+in :ref:`here <building_with_coqproject>`.  Alternatively, you may find it easier
+to do your `make` and `coq_makefile` commands from the command line.
+
+.. _coqide_make_note:
+
+Note that you must explicitly save changed buffers before you run `make`.
+`File/Save all` is helpful for this.  Notice that modified and unmodified buffers show
+different icons next to the filename on the tab.  You may find them helpful.
+
+To use the compiled files after compiling a project with the makefile,
+you must restart the Coq interpreter (using `Navigation/Start` in the
+menu or Ctrl-Home) for any buffer in which you're stepping through code
+that relies on the compiled files.
+
+To make changes to `_CoqProject` take effect, you must close and reopen buffers
+associated with files in the project.  Note that each buffer is independently associated
+with a `_CoqProject`.  The `Project` section of the Edit/Preferences` dialog
+specifies the name to use for the `_CoqProject` file.  We recommend not changing
+this.  Remember that these settings are done on a per-installation basis; they
+currently can't be set differently for each package you're developing.
 
 Customizations
 --------------
@@ -231,10 +261,10 @@ Preferences
 You may customize your environment with the *Preferences* dialog, which is
 accessible from *Edit/Preferences* on the menu. There are several sections:
 
-The first section is for selecting the text font used for scripts,
+The `Fonts` section is for selecting the text font used for scripts,
 goal and message panels.
 
-The second and third sections are for controlling colors and style of
+The `Colors` and `Tags` sections are for controlling colors and style of
 the three main buffers. A predefined Coq highlighting style as well
 as standard |GtkSourceView| styles are available. Other styles can be
 added e.g. in ``$HOME/.local/share/gtksourceview-3.0/styles/`` (see
@@ -244,15 +274,15 @@ CoqIDE is not under the control of |GtkSourceView| but of GTK+ and
 governed by files such as ``settings.ini`` and ``gtk.css`` in
 ``$XDG_CONFIG_HOME/gtk-3.0`` or files in
 ``$HOME/.themes/NameOfTheme/gtk-3.0``, as well as the environment
-variable ``GTK_THEME`` (search on internet for the various
+variable ``GTK_THEME`` (search the internet for the various
 possibilities).
 
-The fourth section is for customizing the editor. It includes in
+The `Editor` section is for customizing the editor. It includes in
 particular the ability to activate an Emacs mode named
 micro-Proof-General (use the Help menu to know more about the
 available bindings).
 
-The next section is devoted to file management: you may configure
+The `Files` section is devoted to file management: you may configure
 automatic saving of files, by periodically saving the contents into
 files named `#f#` for each opened file `f`. You may also activate the
 *revert* feature: in case a opened file is modified on the disk by a
@@ -261,15 +291,26 @@ you edited that same file, you will be prompted to choose to either
 discard your changes or not. The File charset encoding choice is
 described below in :ref:`character-encoding-saved-files`.
 
+`Project`
+
+`Appearance`
+
 The `Externals` section allows customizing the external commands for
 compilation, printing, web browsing. In the browser command, you may
 use `%s` to denote the URL to open, for example:
 `firefox -remote "OpenURL(%s)"`.
 
-Notice that these settings are saved in the file ``coqiderc`` in the
-``coq`` subdirectory of the user configuration directory which
-is the value of ``$XDG_CONFIG_HOME`` if this environment variable is
-set and which otherwise is ``$HOME/.config/``.
+`Shortcuts`
+
+`Misc`
+
+.. _user-configuration-directory:
+
+Preferences and key bindings are saved in the user configuration directory,
+which is ``$XDG_CONFIG_HOME/coq`` if the environment variable ``$XDG_CONFIG_HOME``
+is set.  If the variable isn't set, the directory is ``~/.config/coq`` on Linux
+and `C:\Users\<USERNAME>\AppData\Local\coq` on Windows.
+Preferences are in the file "coqiderc" and key bindings are in the file "coqide.keys".
 
 Key bindings
 ~~~~~~~~~~~~
@@ -278,10 +319,8 @@ Each menu item in the GUI shows its key binding, if one has been defined,
 on the right-hand side.  Typing the key binding is equivalent to selecting
 the associated item from the menu.
 A GTK+ accelerator keymap is saved under the name ``coqide.keys`` in
-the ``coq`` subdirectory of the user configuration directory,
-e.g. in `~/.config/coq/` on Linux and `C:\Users\<USERNAME>\AppData\Local\coq`
-on Windows. On some systems (not Linux or Windows),
-you can modify the key binding ("accelerator") for a menu entry by
+the :ref:`user configuration directory<user-configuration-directory>`.
+You can modify the key binding ("accelerator") for a menu entry by
 going to the corresponding menu item without releasing the
 mouse button, pressing the keys you want for the new binding and then releasing
 the mouse button.
@@ -395,9 +434,8 @@ Adding custom bindings
 ~~~~~~~~~~~~~~~~~~~~~~
 
 To extend the default set of bindings, create a file named ``coqide.bindings``
-and place it in the same folder as ``coqide.keys``. This would be
-the folder ``$XDG_CONFIG_HOME/coq``, defaulting to ``~/.config/coq``
-if ``XDG_CONFIG_HOME`` is unset. The file `coqide.bindings` should contain one
+in the :ref:`user configuration directory<user-configuration-directory>`.
+The file `coqide.bindings` should contain one
 binding per line, in the form ``\key value``, followed by an optional priority
 integer. (The key and value should not contain any space character.)
 
@@ -426,7 +464,7 @@ Each of the file tokens provided may consists of one of:
  -  a path to a custom bindings file,
  -  the token ``default``, which resolves to the default bindings file,
  -  the token ``local``, which resolves to the `coqide.bindings` file
-    stored in the user configuration directory.
+    stored in the :ref:`user configuration directory <user-configuration-directory>`.
 
 .. warning::
 

--- a/doc/sphinx/using/tools/index.rst
+++ b/doc/sphinx/using/tools/index.rst
@@ -5,17 +5,17 @@ Command-line and graphical tools
 ================================
 
 This chapter presents the command-line tools that users will need to
-build their Coq project, the documentation of the CoqIDE standalone
+build their Coq project, the documentation of the CoqIDE graphical
 user interface and the documentation of the parallel proof processing
-feature that is supported by CoqIDE and several other user interfaces.
+feature that is supported by CoqIDE and several other GUIs.
 A list of available user interfaces to interact with Coq is available
 on the `Coq website <https://coq.inria.fr/user-interfaces.html>`_.
 
 .. toctree::
    :maxdepth: 1
 
-   ../../practical-tools/coq-commands
    ../../practical-tools/utilities
+   ../../practical-tools/coq-commands
    coqdoc
    ../../practical-tools/coqide
    ../../addendum/parallel-proof-processing

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -240,14 +240,10 @@ fullyqualid: [
 | qualid
 ]
 
-field_ident: [
-| "." ident
-]
-
 qualid: [ | DELETENT ]
 
 qualid: [
-| ident LIST0 field_ident
+| ident LIST0 ("." ident)
 ]
 
 field: [ | DELETENT ]

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -115,11 +115,7 @@ of_type: [
 ]
 
 qualid: [
-| ident LIST0 field_ident
-]
-
-field_ident: [
-| "." ident
+| ident LIST0 ( "." ident )
 ]
 
 type: [

--- a/vernac/loadpath.ml
+++ b/vernac/loadpath.ml
@@ -16,7 +16,7 @@ module DP = Names.DirPath
 type t = {
   path_physical : CUnix.physical_path;
   path_logical : DP.t;
-  path_implicit : bool;
+  path_implicit : bool;  (* true for -R, false for -Q in command line *)
   path_root : (CUnix.physical_path * DP.t);
 }
 
@@ -272,7 +272,8 @@ type vo_path =
   ; coq_path  : DP.t
   (** Coq prefix for the path *)
   ; implicit  : bool
-  (** [implicit = true] avoids having to qualify with [coq_path] *)
+  (** [implicit = true] avoids having to qualify with [coq_path]
+      true for -R, false for -Q in command line *)
   ; has_ml    : bool
   (** If [has_ml] is true, the directory will also be added to the ml include path *)
   ; recursive : bool

--- a/vernac/loadpath.mli
+++ b/vernac/loadpath.mli
@@ -75,7 +75,8 @@ type vo_path =
   ; coq_path  : DirPath.t
   (** Coq prefix for the path *)
   ; implicit  : bool
-  (** [implicit = true] avoids having to qualify with [coq_path] *)
+  (** [implicit = true] avoids having to qualify with [coq_path]
+      true for -R, false for -Q in command line *)
   ; has_ml    : bool
   (** If [has_ml] is true, the directory will also be added to the ml include path *)
   ; recursive : bool


### PR DESCRIPTION
Adds a "Coq Configuration Basics" section written with more of a tutorial flavor compared to other parts of the doc.  It's meant to complement existing material on configuration (much of which could be improved BTW).  I believe most users want to minimize the time they spend learning about configuration.  This section tries to give the bigger picture by showing how the pieces fit together and thus get people going quickly.

This is an initial draft that I'm still refining, still some missing bits.  For now, general feedback on the organization and the advice it gives to users would be most useful (also Should this new material in `utilities.rst` be a new chapter or go elsewhere? and Is this helpful?)

@Zimmi48 I'm looking at you.  Hope you can give some initial comments soon.

- [x] Added **changelog**.
