### PR TITLE
Remove universe inference from the kernel.

### DIFF
--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -129,9 +129,9 @@ let rec check_module env opac mp mb opacify =
     let mtb1 = mk_mtb mp sign delta
     and mtb2 = mk_mtb mp mb.mod_type mb.mod_delta in
     let env = Modops.add_module_type mp mtb1 env in
-    let cu = Subtyping.check_subtypes env mtb1 mtb2 in
-    if not (Environ.check_constraints cu env) then
-      CErrors.user_err Pp.(str "Incorrect universe constraints for module subtyping");
+    let state = (Environ.universes env, Reduction.checked_universes) in
+    let _ : UGraph.t = Subtyping.check_subtypes state env mtb1 mtb2 in
+    ()
   in
   opac
 
@@ -165,9 +165,8 @@ and check_mexpr env opac mse mp_mse res = match mse with
       let sign, delta = check_mexpr env opac f mp_mse res in
       let farg_id, farg_b, fbody_b = Modops.destr_functor sign in
       let mtb = Modops.module_type_of_module (lookup_module mp env) in
-      let cu = Subtyping.check_subtypes env mtb farg_b in
-      if not (Environ.check_constraints cu env) then
-        CErrors.user_err Pp.(str "Incorrect universe constraints for module subtyping");
+      let state = (Environ.universes env, Reduction.checked_universes) in
+      let _ : UGraph.t = Subtyping.check_subtypes state env mtb farg_b in
       let subst = Mod_subst.map_mbid farg_id mp Mod_subst.empty_delta_resolver in
       Modops.subst_signature subst fbody_b, Mod_subst.subst_codom_delta_resolver subst delta
   | MEwith _ -> CErrors.user_err Pp.(str "Unsupported 'with' constraint in module implementation")

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -228,7 +228,7 @@ let add_local cst local =
 
 (* Constraint with algebraic on the left and a single level on the right *)
 let enforce_leq_up u v local =
-  { local with local_cst = Univ.enforce_leq u (Universe.make v) local.local_cst }
+  { local with local_cst = UnivSubst.enforce_leq u (Universe.make v) local.local_cst }
 
 let process_universe_constraints uctx cstrs =
   let open UnivSubst in

--- a/engine/univSubst.mli
+++ b/engine/univSubst.mli
@@ -41,3 +41,12 @@ val nf_evars_and_universes_opt_subst : (existential -> constr option) ->
 val subst_univs_universe : (Level.t -> Universe.t) -> Universe.t -> Universe.t
 
 val pr_universe_subst : universe_subst -> Pp.t
+
+val enforce_eq : Universe.t constraint_function
+val enforce_leq : Universe.t constraint_function
+
+val enforce_eq_sort : Sorts.t -> Sorts.t -> Univ.Constraints.t -> Univ.Constraints.t
+val enforce_leq_sort : Sorts.t -> Sorts.t -> Univ.Constraints.t -> Univ.Constraints.t
+
+(** Picks an arbitrary set of constraints sufficient to ensure [u <= v]. *)
+val enforce_leq_alg_sort : Sorts.t -> Sorts.t -> UGraph.t -> Univ.Constraints.t * UGraph.t

--- a/kernel/constr.ml
+++ b/kernel/constr.ml
@@ -995,56 +995,6 @@ let leq_constr_univs univs m n =
     and leq_constr' nargs m n = m == n || compare_leq nargs m n in
     compare_leq 0 m n
 
-let eq_constr_univs_infer univs m n =
-  if m == n then true, Constraints.empty
-  else
-    let cstrs = ref Constraints.empty in
-    let eq_universes _ = UGraph.check_eq_instances univs in
-    let eq_sorts s1 s2 =
-      if Sorts.equal s1 s2 then true
-      else
-        if UGraph.check_eq_sort univs s1 s2 then true
-        else
-          (cstrs := UGraph.enforce_eq_sort s1 s2 !cstrs;
-           true)
-    in
-    let rec eq_constr' nargs m n =
-      m == n || compare_head_gen eq_universes eq_sorts eq_constr' nargs m n
-    in
-    let res = compare_head_gen eq_universes eq_sorts eq_constr' 0 m n in
-    res, !cstrs
-
-let leq_constr_univs_infer univs m n =
-  if m == n then true, Constraints.empty
-  else
-    let cstrs = ref Constraints.empty in
-    let eq_universes _ l l' = UGraph.check_eq_instances univs l l' in
-    let eq_sorts s1 s2 =
-      if Sorts.equal s1 s2 then true
-      else
-        if UGraph.check_eq_sort univs s1 s2 then true
-        else (cstrs := UGraph.enforce_eq_sort s1 s2 !cstrs;
-              true)
-    in
-    let leq_sorts s1 s2 =
-      if Sorts.equal s1 s2 then true
-      else
-        if UGraph.check_leq_sort univs s1 s2 then true
-        else
-          (try let c, _ = UGraph.enforce_leq_alg_sort s1 s2 univs in
-            cstrs := Univ.Constraints.union c !cstrs;
-            true
-          with UGraph.UniverseInconsistency _ -> false)
-    in
-    let rec eq_constr' nargs m n =
-      m == n || compare_head_gen eq_universes eq_sorts eq_constr' nargs m n
-    in
-    let rec compare_leq nargs m n =
-      compare_head_gen_leq eq_universes leq_sorts eq_constr' leq_constr' nargs m n
-    and leq_constr' nargs m n = m == n || compare_leq nargs m n in
-    let res = compare_leq 0 m n in
-    res, !cstrs
-
 let rec eq_constr_nounivs m n =
   (m == n) || compare_head_gen (fun _ _ _ -> true) (fun _ _ -> true) (fun _ -> eq_constr_nounivs) 0 m n
 

--- a/kernel/constr.mli
+++ b/kernel/constr.mli
@@ -417,14 +417,6 @@ val eq_constr_univs : constr UGraph.check_function
     alpha, casts, application grouping and the universe inequalities in [u]. *)
 val leq_constr_univs : constr UGraph.check_function
 
-(** [eq_constr_univs u a b] is [true] if [a] equals [b] modulo alpha, casts,
-   application grouping and the universe equalities in [u]. *)
-val eq_constr_univs_infer : UGraph.t -> constr -> constr -> bool Univ.constrained
-
-(** [leq_constr_univs u a b] is [true] if [a] is convertible to [b] modulo
-    alpha, casts, application grouping and the universe inequalities in [u]. *)
-val leq_constr_univs_infer : UGraph.t -> constr -> constr -> bool Univ.constrained
-
 (** [eq_constr_univs a b] [true, c] if [a] equals [b] modulo alpha, casts,
    application grouping and ignoring universe instances. *)
 val eq_constr_nounivs : constr -> constr -> bool

--- a/kernel/mod_typing.mli
+++ b/kernel/mod_typing.mli
@@ -23,13 +23,15 @@ open Names
 *)
 
 val translate_module :
-  env -> ModPath.t -> inline -> module_entry -> module_body * Univ.Constraints.t
+  'a Reduction.universe_state ->
+  env -> ModPath.t -> inline -> module_entry -> module_body * 'a
 
 (** [translate_modtype] produces a [module_type_body] whose [mod_type_alg]
     cannot be [None] (and of course [mod_expr] is [Abstract]). *)
 
 val translate_modtype :
-  env -> ModPath.t -> inline -> module_type_entry -> module_type_body * Univ.Constraints.t
+  'a Reduction.universe_state ->
+  env -> ModPath.t -> inline -> module_type_entry -> module_type_body * 'a
 
 (** Low-level function for translating a module struct entry :
     - We translate to a module when a [ModPath.t] is given,
@@ -42,20 +44,22 @@ type 'alg translation =
   module_signature * 'alg * delta_resolver * Univ.Constraints.t
 
 val translate_mse :
+  'a Reduction.universe_state ->
   env -> ModPath.t option -> inline -> module_struct_entry ->
-    (Constr.t * Univ.AbstractContext.t option) module_alg_expr translation
+  module_signature * (Constr.t * Univ.AbstractContext.t option) module_alg_expr * delta_resolver * 'a
 
 (** From an already-translated (or interactive) implementation and
     an (optional) signature entry, produces a final [module_body] *)
 
 val finalize_module :
-  env -> ModPath.t -> (module_expression option) translation ->
+  'a Reduction.universe_state ->
+  env -> ModPath.t -> module_signature * module_expression option * delta_resolver ->
   (module_type_entry * inline) option ->
-  module_body * Univ.Constraints.t
+  module_body * 'a
 
 (** [translate_mse_incl] translate the mse of a module or
     module type given to an Include *)
 
 val translate_mse_include :
-  bool -> env -> ModPath.t -> inline -> module_struct_entry ->
-    unit translation
+  bool -> 'a Reduction.universe_state -> Environ.env -> ModPath.t -> inline ->
+  module_struct_entry -> module_signature * unit * delta_resolver * 'a

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -967,21 +967,6 @@ let generic_conv cv_pb ~l2r evars reds env univs t1 t2 =
     clos_gen_conv reds cv_pb l2r evars env graph univs t1 t2
   in s
 
-let infer_conv_universes cv_pb ?(l2r=false) ?(evars=fun _ -> None) ?(ts=TransparentState.full) env t1 t2 =
-  let univs = Environ.universes env in
-  let b, cstrs =
-    if cv_pb == CUMUL then Constr.leq_constr_univs_infer univs t1 t2
-    else Constr.eq_constr_univs_infer univs t1 t2
-  in
-    if b then cstrs
-    else
-      let state = ((univs, Univ.Constraints.empty), inferred_universes) in
-      let ((_,cstrs), _) = clos_gen_conv ts cv_pb l2r evars env univs state t1 t2 in
-        cstrs
-
-let infer_conv = infer_conv_universes CONV
-let infer_conv_leq = infer_conv_universes CUMUL
-
 let default_conv cv_pb env t1 t2 =
     gen_conv cv_pb env t1 t2
 

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -914,39 +914,6 @@ let () =
   in
   CClosure.set_conv conv
 
-let infer_eq (univs, cstrs as cuniv) u u' =
-  if UGraph.check_eq_sort univs u u' then cuniv
-  else
-    univs, (UGraph.enforce_eq_sort u u' cstrs)
-
-let infer_leq (univs, cstrs as cuniv) u u' =
-  if UGraph.check_leq_sort univs u u' then cuniv
-  else
-    let cstrs', _ = UGraph.enforce_leq_alg_sort u u' univs in
-      univs, Univ.Constraints.union cstrs cstrs'
-
-let infer_cmp_universes _env pb s0 s1 univs =
-  match pb with
-  | CUMUL -> infer_leq univs s0 s1
-  | CONV -> infer_eq univs s0 s1
-
-let infer_convert_instances ~flex u u' (univs,cstrs) =
-  let cstrs' =
-    if flex then
-      if UGraph.check_eq_instances univs u u' then cstrs
-      else raise NotConvertible
-    else Univ.enforce_eq_instances u u' cstrs
-  in (univs, cstrs')
-
-let infer_inductive_instances cv_pb variance u1 u2 (univs,csts') =
-  let csts = get_cumulativity_constraints cv_pb variance u1 u2 in
-  (univs, Univ.Constraints.union csts csts')
-
-let inferred_universes : (UGraph.t * Univ.Constraints.t) universe_compare =
-  { compare_sorts = infer_cmp_universes;
-    compare_instances = infer_convert_instances;
-    compare_cumul_instances = infer_inductive_instances; }
-
 let gen_conv cv_pb ?(l2r=false) ?(reds=TransparentState.full) env ?(evars=(fun _ -> None)) t1 t2 =
   let univs = Environ.universes env in
   let b =

--- a/kernel/reduction.mli
+++ b/kernel/reduction.mli
@@ -64,10 +64,8 @@ constructors. *)
 val convert_instances : flex:bool -> Univ.Instance.t -> Univ.Instance.t ->
   'a * 'a universe_compare -> 'a * 'a universe_compare
 
-(** These two never raise UnivInconsistency, inferred_universes
-    just gathers the constraints. *)
+(** This function never raise UnivInconsistency. *)
 val checked_universes : UGraph.t universe_compare
-val inferred_universes : (UGraph.t * Univ.Constraints.t) universe_compare
 
 (** These two functions can only raise NotConvertible *)
 val conv : constr extended_conversion_function

--- a/kernel/reduction.mli
+++ b/kernel/reduction.mli
@@ -74,13 +74,6 @@ val conv : constr extended_conversion_function
 
 val conv_leq : types extended_conversion_function
 
-(** These conversion functions are used by module subtyping, which needs to infer
-    universe constraints inside the kernel *)
-val infer_conv : ?l2r:bool -> ?evars:(existential->constr option) ->
-  ?ts:TransparentState.t -> constr infer_conversion_function
-val infer_conv_leq : ?l2r:bool -> ?evars:(existential->constr option) ->
-  ?ts:TransparentState.t -> types infer_conversion_function
-
 (** Depending on the universe state functions, this might raise
   [UniverseInconsistency] in addition to [NotConvertible] (for better error
   messages). *)

--- a/kernel/subtyping.mli
+++ b/kernel/subtyping.mli
@@ -8,8 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open Univ
 open Declarations
 open Environ
 
-val check_subtypes : env -> module_type_body -> module_type_body -> Constraints.t
+val check_subtypes : 'a Reduction.universe_state -> env -> module_type_body -> module_type_body -> 'a

--- a/kernel/uGraph.ml
+++ b/kernel/uGraph.ml
@@ -236,35 +236,6 @@ let check_leq_sort ugraph s1 s2 = match s1, s2 with
 | (Type _ | Set), (Type _ | Set) ->
   check_leq ugraph (get_algebraic s1) (get_algebraic s2)
 
-let enforce_eq_sort s1 s2 cst = match s1, s2 with
-| (SProp, SProp) | (Prop, Prop) | (Set, Set) -> cst
-| (((Prop | Set | Type _) as s1), (Prop | SProp as s2))
-| ((Prop | SProp as s1), ((Prop | Set | Type _) as s2)) ->
-  raise (UniverseInconsistency (Eq, s1, s2, None))
-| (Set | Type _), (Set | Type _) ->
-  Univ.enforce_eq (get_algebraic s1) (get_algebraic s2) cst
-
-let enforce_leq_sort s1 s2 cst = match s1, s2 with
-| (SProp, SProp) | (Prop, Prop) | (Set, Set) -> cst
-| (Prop, (Set | Type _)) -> cst
-| (((Prop | Set | Type _) as s1), (Prop | SProp as s2))
-| ((SProp as s1), ((Prop | Set | Type _) as s2)) ->
-  raise (UniverseInconsistency (Le, s1, s2, None))
-| (Set | Type _), (Set | Type _) ->
-  Univ.enforce_leq (get_algebraic s1) (get_algebraic s2) cst
-
-let enforce_leq_alg_sort s1 s2 g = match s1, s2 with
-| (SProp, SProp) | (Prop, Prop) | (Set, Set) -> Constraints.empty, g
-| (Prop, (Set | Type _)) -> Constraints.empty, g
-| (((Prop | Set | Type _) as s1), (Prop | SProp as s2))
-| ((SProp as s1), ((Prop | Set | Type _) as s2)) ->
-  if cumulative_sprop g && is_sprop s1 then
-    Constraints.empty, g
-  else
-    raise (UniverseInconsistency (Le, s1, s2, None))
-| (Set | Type _), (Set | Type _) ->
-  enforce_leq_alg (get_algebraic s1) (get_algebraic s2) g
-
 (** Pretty-printing *)
 
 let pr_pmap sep pr map =

--- a/kernel/uGraph.mli
+++ b/kernel/uGraph.mli
@@ -53,17 +53,14 @@ exception UniverseInconsistency of univ_inconsistency
 
 val enforce_constraint : univ_constraint -> t -> t
 
-val enforce_eq_sort : Sorts.t -> Sorts.t -> Univ.Constraints.t -> Univ.Constraints.t
-val enforce_leq_sort : Sorts.t -> Sorts.t -> Univ.Constraints.t -> Univ.Constraints.t
-
 val merge_constraints : Constraints.t -> t -> t
 
 val check_constraint  : t -> univ_constraint -> bool
 val check_constraints : Constraints.t -> t -> bool
 val check_eq_sort : t -> Sorts.t  -> Sorts.t -> bool
 val check_leq_sort : t -> Sorts.t -> Sorts.t -> bool
-(** Picks an arbitrary set of constraints sufficient to ensure [u <= v]. *)
-val enforce_leq_alg_sort : Sorts.t -> Sorts.t -> t -> Univ.Constraints.t * t
+
+val enforce_leq_alg : Univ.Universe.t -> Univ.Universe.t -> t -> Univ.Constraints.t * t
 
 (** Adds a universe to the graph, ensuring it is >= or > Set.
    @raise AlreadyDeclared if the level is already declared in the graph. *)

--- a/kernel/univ.mli
+++ b/kernel/univ.mli
@@ -179,8 +179,6 @@ val constraints_of : 'a constrained -> Constraints.t
 (** Enforcing Constraints.t. *)
 type 'a constraint_function = 'a -> 'a -> Constraints.t -> Constraints.t
 
-val enforce_eq : Universe.t constraint_function
-val enforce_leq : Universe.t constraint_function
 val enforce_eq_level : Level.t constraint_function
 val enforce_leq_level : Level.t constraint_function
 

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -159,11 +159,14 @@ let factor_fix env sg l cb msb =
 
 let expand_mexpr env mpo me =
   let inl = Some (Flags.get_inline_level()) in
-  Mod_typing.translate_mse env mpo inl me
+  let state = ((Environ.universes env, Univ.Constraints.empty), Reduction.inferred_universes) in
+  let sign, expr, delta, (_, cst) = Mod_typing.translate_mse state env mpo inl me in
+  sign, expr, delta, cst
 
 let expand_modtype env mp me =
   let inl = Some (Flags.get_inline_level()) in
-  let mtb, _cst = Mod_typing.translate_modtype env mp inl ([],me) in
+  let state = ((Environ.universes env, Univ.Constraints.empty), Reduction.inferred_universes) in
+  let mtb, _cst = Mod_typing.translate_modtype state env mp inl ([],me) in
   mtb
 
 let no_delta = Mod_subst.empty_delta_resolver

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -159,13 +159,13 @@ let factor_fix env sg l cb msb =
 
 let expand_mexpr env mpo me =
   let inl = Some (Flags.get_inline_level()) in
-  let state = ((Environ.universes env, Univ.Constraints.empty), Reduction.inferred_universes) in
+  let state = ((Environ.universes env, Univ.Constraints.empty), Reductionops.inferred_universes) in
   let sign, expr, delta, (_, cst) = Mod_typing.translate_mse state env mpo inl me in
   sign, expr, delta, cst
 
 let expand_modtype env mp me =
   let inl = Some (Flags.get_inline_level()) in
-  let state = ((Environ.universes env, Univ.Constraints.empty), Reduction.inferred_universes) in
+  let state = ((Environ.universes env, Univ.Constraints.empty), Reductionops.inferred_universes) in
   let mtb, _cst = Mod_typing.translate_modtype state env mp inl ([],me) in
   mtb
 

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -233,7 +233,7 @@ let change_property_sort evd toSort princ princName =
         in
         let s = Constr.destSort ty in
         Global.add_constraints
-          (UGraph.enforce_leq_sort
+          (UnivSubst.enforce_leq_sort
              toSort s Univ.Constraints.empty);
         Term.compose_prod args (Constr.mkSort toSort) )
   in

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1492,12 +1492,12 @@ open Reduction
 let infer_eq (univs, cstrs as cuniv) u u' =
   if UGraph.check_eq_sort univs u u' then cuniv
   else
-    univs, (UGraph.enforce_eq_sort u u' cstrs)
+    univs, (UnivSubst.enforce_eq_sort u u' cstrs)
 
 let infer_leq (univs, cstrs as cuniv) u u' =
   if UGraph.check_leq_sort univs u u' then cuniv
   else
-    let cstrs', _ = UGraph.enforce_leq_alg_sort u u' univs in
+    let cstrs', _ = UnivSubst.enforce_leq_alg_sort u u' univs in
       univs, Univ.Constraints.union cstrs cstrs'
 
 let infer_cmp_universes _env pb s0 s1 univs =

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1484,3 +1484,44 @@ let nf_meta env sigma c =
   let sigma = create_meta_instance_subst sigma in
   let cl = mk_freelisted c in
   meta_instance env sigma { cl with rebus = cl.rebus }
+
+module Infer = struct
+
+open Reduction
+
+let infer_eq (univs, cstrs as cuniv) u u' =
+  if UGraph.check_eq_sort univs u u' then cuniv
+  else
+    univs, (UGraph.enforce_eq_sort u u' cstrs)
+
+let infer_leq (univs, cstrs as cuniv) u u' =
+  if UGraph.check_leq_sort univs u u' then cuniv
+  else
+    let cstrs', _ = UGraph.enforce_leq_alg_sort u u' univs in
+      univs, Univ.Constraints.union cstrs cstrs'
+
+let infer_cmp_universes _env pb s0 s1 univs =
+  match pb with
+  | CUMUL -> infer_leq univs s0 s1
+  | CONV -> infer_eq univs s0 s1
+
+let infer_convert_instances ~flex u u' (univs,cstrs) =
+  let cstrs' =
+    if flex then
+      if UGraph.check_eq_instances univs u u' then cstrs
+      else raise NotConvertible
+    else Univ.enforce_eq_instances u u' cstrs
+  in (univs, cstrs')
+
+let infer_inductive_instances cv_pb variance u1 u2 (univs,csts') =
+  let csts = get_cumulativity_constraints cv_pb variance u1 u2 in
+  (univs, Univ.Constraints.union csts csts')
+
+let inferred_universes : (UGraph.t * Univ.Constraints.t) universe_compare =
+  { compare_sorts = infer_cmp_universes;
+    compare_instances = infer_convert_instances;
+    compare_cumul_instances = infer_inductive_instances; }
+
+end
+
+let inferred_universes = Infer.inferred_universes

--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -276,3 +276,6 @@ val meta_instance : env -> meta_instance_subst -> constr freelisted -> constr
 val nf_meta       : env -> evar_map -> constr -> constr
 
 exception AnomalyInConversion of exn
+
+(* inferred_universes just gathers the constraints. *)
+val inferred_universes : (UGraph.t * Univ.Constraints.t) Reduction.universe_compare

--- a/tactics/eqschemes.ml
+++ b/tactics/eqschemes.ml
@@ -809,7 +809,7 @@ let build_congr env (eq,refl,ctx) ind =
   let rci = Sorts.Relevant in (* TODO relevance *)
   let ci = make_case_info env ind rci RegularStyle in
   let uni, ctx = Univ.extend_in_context_set (UnivGen.new_global_univ ()) ctx in
-  let ctx = (fst ctx, Univ.enforce_leq uni (univ_of_eq env eq) (snd ctx)) in
+  let ctx = (fst ctx, UnivSubst.enforce_leq uni (univ_of_eq env eq) (snd ctx)) in
   let c =
   my_it_mkLambda_or_LetIn paramsctxt
      (mkNamedLambda (make_annot varB Sorts.Relevant) (mkType uni)

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -577,7 +577,7 @@ let intern_arg (acc, cst) (idl,(typ,ann)) =
   let (mty, cst') = Modintern.interp_module_ast env kind base mty in
   let () = Global.push_context_set ~strict:true cst' in
   let () =
-    let state = ((Global.universes (), Univ.Constraints.empty), Reduction.inferred_universes) in
+    let state = ((Global.universes (), Univ.Constraints.empty), Reductionops.inferred_universes) in
     let _, (_, cst) = Mod_typing.translate_modtype state (Global.env ()) base inl ([], mty) in
     Global.add_constraints cst
   in
@@ -616,7 +616,7 @@ let intern_args params =
 
 let check_sub mtb sub_mtb_l =
   let fold sub_mtb (ocst, env) =
-    let state = ((Environ.universes env, Univ.Constraints.empty), Reduction.inferred_universes) in
+    let state = ((Environ.universes env, Univ.Constraints.empty), Reductionops.inferred_universes) in
     let _, cst = Subtyping.check_subtypes state env mtb sub_mtb in
     (Univ.Constraints.union ocst cst, Environ.add_constraints cst env)
   in
@@ -652,7 +652,7 @@ let build_subtypes env mp args mtys =
        let mte, ctx' = Modintern.interp_module_ast env Modintern.ModType base mte in
        let env = Environ.push_context_set ~strict:true ctx' env in
        let ctx = Univ.ContextSet.union ctx ctx' in
-       let state = ((Environ.universes env, Univ.Constraints.empty), Reduction.inferred_universes) in
+       let state = ((Environ.universes env, Univ.Constraints.empty), Reductionops.inferred_universes) in
        let mtb, (_, cst) = Mod_typing.translate_modtype state env mp inl (args,mte) in
        let ctx = Univ.ContextSet.add_constraints cst ctx in
        ctx, mtb)
@@ -707,7 +707,7 @@ let start_module export id args res fs =
         let (mte, ctx) = Modintern.interp_module_ast env kind base mte in
         let env = Environ.push_context_set ~strict:true ctx env in
         (* We check immediately that mte is well-formed *)
-        let state = ((Environ.universes env, Univ.Constraints.empty), Reduction.inferred_universes) in
+        let state = ((Environ.universes env, Univ.Constraints.empty), Reductionops.inferred_universes) in
         let _, _, _, (_, cst) = Mod_typing.translate_mse state env None inl mte in
         let ctx = Univ.ContextSet.add_constraints cst ctx in
         Some (mte, inl), [], ctx
@@ -736,7 +736,7 @@ let end_module () =
 
   let struc = current_struct () in
   let restype' = Option.map (fun (ty,inl) -> (([],ty),inl)) m_info.cur_typ in
-  let state = ((Global.universes (), Univ.Constraints.empty), Reduction.inferred_universes) in
+  let state = ((Global.universes (), Univ.Constraints.empty), Reductionops.inferred_universes) in
   let _, (_, cst) =
     Mod_typing.finalize_module state (Global.env ()) (Global.current_modpath ())
       (struc, None, current_modresolver ()) restype'
@@ -784,7 +784,7 @@ let declare_module id args res mexpr_o fs =
         let (mte, ctx) = Modintern.interp_module_ast env kind base mte in
         let env = Environ.push_context_set ~strict:true ctx env in
         (* We check immediately that mte is well-formed *)
-        let state = ((Environ.universes env, Univ.Constraints.empty), Reduction.inferred_universes) in
+        let state = ((Environ.universes env, Univ.Constraints.empty), Reductionops.inferred_universes) in
         let _, _, _, (_, cst) = Mod_typing.translate_mse state env None inl mte in
         let ctx = Univ.ContextSet.add_constraints cst ctx in
         Some mte, [], inl, ctx
@@ -822,7 +822,7 @@ let declare_module id args res mexpr_o fs =
   | _ -> inl_res
   in
   let () = Global.push_context_set ~strict:true ctx in
-  let state = ((Global.universes (), Univ.Constraints.empty), Reduction.inferred_universes) in
+  let state = ((Global.universes (), Univ.Constraints.empty), Reductionops.inferred_universes) in
   let _, (_, cst) = Mod_typing.translate_module state (Global.env ()) mp inl entry in
   let () = Global.add_constraints cst in
   let mp_env,resolver = Global.add_module id entry inl in
@@ -883,7 +883,7 @@ let declare_modtype id args mtys (mty,ann) fs =
   let () = Global.push_context_set ~strict:true mte_ctx in
   let env = Global.env () in
   (* We check immediately that mte is well-formed *)
-  let state = ((Global.universes (), Univ.Constraints.empty), Reduction.inferred_universes) in
+  let state = ((Global.universes (), Univ.Constraints.empty), Reductionops.inferred_universes) in
   let _, _, _, (_, mte_cst) = Mod_typing.translate_mse state env None inl mte in
   let () = Global.push_context_set ~strict:true (Univ.Level.Set.empty,mte_cst) in
   let env = Global.env () in
@@ -970,7 +970,7 @@ let declare_one_include (me_ast,annot) =
   in
   let base_mp = get_module_path me in
 
-  let state = ((Global.universes (), Univ.Constraints.empty), Reduction.inferred_universes) in
+  let state = ((Global.universes (), Univ.Constraints.empty), Reductionops.inferred_universes) in
   let sign, (), resolver, (_, cst) =
     Mod_typing.translate_mse_include is_mod state (Global.env ()) (Global.current_modpath ()) inl me
   in
@@ -980,7 +980,7 @@ let declare_one_include (me_ast,annot) =
   let rec compute_sign sign mb resolver =
     match sign with
     | MoreFunctor(mbid,mtb,str) ->
-      let state = ((Global.universes (), Univ.Constraints.empty), Reduction.inferred_universes) in
+      let state = ((Global.universes (), Univ.Constraints.empty), Reductionops.inferred_universes) in
       let (_, cst) = Subtyping.check_subtypes state (Global.env ()) mb mtb in
       let () = Global.add_constraints cst in
       let mpsup_delta =

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -576,6 +576,11 @@ let intern_arg (acc, cst) (idl,(typ,ann)) =
   let (mty, base, kind) = Modintern.intern_module_ast Modintern.ModType typ in
   let (mty, cst') = Modintern.interp_module_ast env kind base mty in
   let () = Global.push_context_set ~strict:true cst' in
+  let () =
+    let state = ((Global.universes (), Univ.Constraints.empty), Reduction.inferred_universes) in
+    let _, (_, cst) = Mod_typing.translate_modtype state (Global.env ()) base inl ([], mty) in
+    Global.add_constraints cst
+  in
   let env = Global.env () in
   let sobjs = get_module_sobjs false env inl mty in
   let mp0 = get_module_path mty in
@@ -610,13 +615,13 @@ let intern_args params =
 (** {6 Auxiliary functions concerning subtyping checks} *)
 
 let check_sub mtb sub_mtb_l =
-  (* FIXME: The constraints are checked and forgot immediately *)
-  let fold sub_mtb env =
+  let fold sub_mtb (ocst, env) =
     let state = ((Environ.universes env, Univ.Constraints.empty), Reduction.inferred_universes) in
     let _, cst = Subtyping.check_subtypes state env mtb sub_mtb in
-    Environ.add_constraints cst env
+    (Univ.Constraints.union ocst cst, Environ.add_constraints cst env)
   in
-  ignore (List.fold_right fold sub_mtb_l (Global.env ()))
+  let cst, _ = List.fold_right fold sub_mtb_l (Univ.Constraints.empty, Global.env ()) in
+  Global.add_constraints cst
 
 (** This function checks if the type calculated for the module [mp] is
     a "<:"-like subtype of all signatures in [sub_mtb_l]. Uses only
@@ -647,7 +652,7 @@ let build_subtypes env mp args mtys =
        let mte, ctx' = Modintern.interp_module_ast env Modintern.ModType base mte in
        let env = Environ.push_context_set ~strict:true ctx' env in
        let ctx = Univ.ContextSet.union ctx ctx' in
-        let state = ((Environ.universes env, Univ.Constraints.empty), Reduction.inferred_universes) in
+       let state = ((Environ.universes env, Univ.Constraints.empty), Reduction.inferred_universes) in
        let mtb, (_, cst) = Mod_typing.translate_modtype state env mp inl (args,mte) in
        let ctx = Univ.ContextSet.add_constraints cst ctx in
        ctx, mtb)
@@ -655,6 +660,12 @@ let build_subtypes env mp args mtys =
   in
   (ans, ctx)
 
+let current_modresolver () =
+  fst @@ Safe_typing.delta_of_senv @@ Global.safe_env ()
+
+let current_struct () =
+  let struc = Safe_typing.structure_body_of_safe_env @@ Global.safe_env () in
+  NoFunctor (List.rev struc)
 
 (** {6 Current module information}
 
@@ -722,10 +733,20 @@ let end_module () =
       get_module_sobjs false (Global.env()) inline mty, [], []
   in
   let olddp, id = split_dirpath oldprefix.Nametab.obj_dir in
+
+  let struc = current_struct () in
+  let restype' = Option.map (fun (ty,inl) -> (([],ty),inl)) m_info.cur_typ in
+  let state = ((Global.universes (), Univ.Constraints.empty), Reduction.inferred_universes) in
+  let _, (_, cst) =
+    Mod_typing.finalize_module state (Global.env ()) (Global.current_modpath ())
+      (struc, None, current_modresolver ()) restype'
+  in
+  let () = Global.add_constraints cst in
+
   let mp,mbids,resolver = Global.end_module fs id m_info.cur_typ in
   let sobjs = let (ms,objs) = sobjs0 in (mbids@ms,objs) in
 
-  check_subtypes mp m_info.cur_typs;
+  let () = check_subtypes mp m_info.cur_typs in
 
   (* We substitute objects if the module is sealed by a signature *)
   let sobjs =
@@ -801,13 +822,16 @@ let declare_module id args res mexpr_o fs =
   | _ -> inl_res
   in
   let () = Global.push_context_set ~strict:true ctx in
+  let state = ((Global.universes (), Univ.Constraints.empty), Reduction.inferred_universes) in
+  let _, (_, cst) = Mod_typing.translate_module state (Global.env ()) mp inl entry in
+  let () = Global.add_constraints cst in
   let mp_env,resolver = Global.add_module id entry inl in
 
   (* Name consistency check : kernel vs. library *)
   assert (ModPath.equal mp (mp_of_kn (Lib.make_kn id)));
   assert (ModPath.equal mp mp_env);
 
-  check_subtypes mp subs;
+  let () = check_subtypes mp subs in
 
   let sobjs = subst_sobjs (map_mp mp0 mp resolver) sobjs in
   add_leaf (ModuleObject (id,sobjs));
@@ -837,8 +861,8 @@ let end_modtype () =
   let {Lib.substobjs = substitute; keepobjs = _; anticipateobjs = special; } = lib_stack in
   let sub_mty_l = !openmodtype_info in
   let mp, mbids = Global.end_modtype fs id in
+  let () = check_subtypes_mt mp sub_mty_l in
   let modtypeobjs = (mbids, Objs substitute) in
-  check_subtypes_mt mp sub_mty_l;
   let () = add_leaves id (special@[ModuleTypeObject (id,modtypeobjs)]) in
   (* Check name consistence : start_ vs. end_modtype, kernel vs. library *)
   assert (DirPath.equal (Lib.prefix()).Nametab.obj_dir olddp);
@@ -859,7 +883,7 @@ let declare_modtype id args mtys (mty,ann) fs =
   let () = Global.push_context_set ~strict:true mte_ctx in
   let env = Global.env () in
   (* We check immediately that mte is well-formed *)
-  let state = ((Environ.universes env, Univ.Constraints.empty), Reduction.inferred_universes) in
+  let state = ((Global.universes (), Univ.Constraints.empty), Reduction.inferred_universes) in
   let _, _, _, (_, mte_cst) = Mod_typing.translate_mse state env None inl mte in
   let () = Global.push_context_set ~strict:true (Univ.Level.Set.empty,mte_cst) in
   let env = Global.env () in
@@ -886,7 +910,7 @@ let declare_modtype id args mtys (mty,ann) fs =
   assert (ModPath.equal mp_env mp);
 
   (* Subtyping checks *)
-  check_subtypes_mt mp sub_mty_l;
+  let () = check_subtypes_mt mp sub_mty_l in
 
   add_leaf (ModuleTypeObject (id, sobjs));
   mp
@@ -940,11 +964,45 @@ let declare_one_include (me_ast,annot) =
     try
       if List.is_empty mbids then raise NoIncludeSelf;
       let typ = type_of_incl env is_mod me in
-      let reso,_ = Safe_typing.delta_of_senv (Global.safe_env ()) in
+      let reso = current_modresolver () in
       include_subst env cur_mp reso mbids typ inl
     with NoIncludeSelf -> empty_subst
   in
   let base_mp = get_module_path me in
+
+  let state = ((Global.universes (), Univ.Constraints.empty), Reduction.inferred_universes) in
+  let sign, (), resolver, (_, cst) =
+    Mod_typing.translate_mse_include is_mod state (Global.env ()) (Global.current_modpath ()) inl me
+  in
+  let () = Global.add_constraints cst in
+  let () = assert (ModPath.equal cur_mp (Global.current_modpath ())) in
+  (* Include Self support  *)
+  let rec compute_sign sign mb resolver =
+    match sign with
+    | MoreFunctor(mbid,mtb,str) ->
+      let state = ((Global.universes (), Univ.Constraints.empty), Reduction.inferred_universes) in
+      let (_, cst) = Subtyping.check_subtypes state (Global.env ()) mb mtb in
+      let () = Global.add_constraints cst in
+      let mpsup_delta =
+        Modops.inline_delta_resolver (Global.env ()) inl cur_mp mbid mtb mb.mod_delta
+      in
+      let subst = Mod_subst.map_mbid mbid cur_mp mpsup_delta in
+      let resolver = Mod_subst.subst_codom_delta_resolver subst resolver in
+      compute_sign (Modops.subst_signature subst str) mb resolver
+    | NoFunctor str -> ()
+  in
+  let () =
+    let struc = current_struct () in
+    let mtb = { mod_mp = cur_mp;
+    mod_expr = ();
+    mod_type = struc;
+    mod_type_alg = None;
+    mod_delta = current_modresolver ();
+    mod_retroknowledge = ModTypeRK }
+    in
+    compute_sign sign mtb resolver
+  in
+
   let resolver = Global.add_include me is_mod inl in
   let subst = join subst_self (map_mp base_mp cur_mp resolver) in
   let aobjs = subst_aobjs subst aobjs in


### PR DESCRIPTION
The only place that was still using it was the typing of modules. We generalize the module-handling code to take a `universe_state` argument, and adapt the kernel to only use checking. We have to add a bit of redundant universe inference in Declaremods but we' were already doing it partially. I believe we can reduce some redundancy by enforcing more carefully which modules and module types are well-typed in the current graph.