### PR TITLE
Stop eagerly normalizing patterns and provide a broken flag instead.

### DIFF
--- a/dev/ci/user-overlays/15915-ppedrot-pattern-of-constr-nf-flag.sh
+++ b/dev/ci/user-overlays/15915-ppedrot-pattern-of-constr-nf-flag.sh
@@ -1,0 +1,1 @@
+overlay equations https://github.com/ppedrot/Coq-Equations pattern-of-constr-nf-flag 15915

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -2635,7 +2635,7 @@ let interp_constr_pattern env sigma ?(expected_type=WithoutTypeConstraint) c =
   let sigma, c = understand_tcc ~flags env sigma ~expected_type c in
   (* FIXME: it is necessary to be unsafe here because of the way we handle
      evars in the pretyper. Sometimes they get solved eagerly. *)
-  pattern_of_constr ~broken:true env sigma c
+  legacy_bad_pattern_of_constr env sigma c
 
 let intern_core kind env sigma ?(pattern_mode=false) ?(ltacvars=empty_ltac_sign)
       { Genintern.intern_ids = ids; Genintern.notation_variable_status = vl } c =

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -2635,7 +2635,7 @@ let interp_constr_pattern env sigma ?(expected_type=WithoutTypeConstraint) c =
   let sigma, c = understand_tcc ~flags env sigma ~expected_type c in
   (* FIXME: it is necessary to be unsafe here because of the way we handle
      evars in the pretyper. Sometimes they get solved eagerly. *)
-  pattern_of_constr env sigma (EConstr.Unsafe.to_constr c)
+  pattern_of_constr ~broken:true env sigma c
 
 let intern_core kind env sigma ?(pattern_mode=false) ?(ltacvars=empty_ltac_sign)
       { Genintern.intern_ids = ids; Genintern.notation_variable_status = vl } c =

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -684,7 +684,7 @@ let interp_typed_pattern ist env sigma (_,c,_) =
     interp_gen WithoutTypeConstraint ist true pure_open_constr_flags env sigma c in
   (* FIXME: it is necessary to be unsafe here because of the way we handle
      evars in the pretyper. Sometimes they get solved eagerly. *)
-  pattern_of_constr env sigma (EConstr.Unsafe.to_constr c)
+  pattern_of_constr ~broken:true env sigma c
 
 (* Interprets a constr expression *)
 let interp_constr_in_compound_list inj_fun dest_fun interp_fun ist env sigma l =
@@ -729,7 +729,7 @@ let interp_closed_typed_pattern_with_occurrences ist env sigma (occs, a) =
       try Inl (coerce_to_evaluable_ref env sigma x)
       with CannotCoerceTo _ ->
         let c = coerce_to_closed_constr env x in
-        Inr (pattern_of_constr env sigma (EConstr.Unsafe.to_constr c)) in
+        Inr (pattern_of_constr ~broken:true env sigma c) in
     (try try_interp_ltac_var coerce_eval_ref_or_constr ist (Some (env,sigma)) (CAst.make ?loc id)
      with Not_found as exn ->
        let _, info = Exninfo.capture exn in

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -684,7 +684,7 @@ let interp_typed_pattern ist env sigma (_,c,_) =
     interp_gen WithoutTypeConstraint ist true pure_open_constr_flags env sigma c in
   (* FIXME: it is necessary to be unsafe here because of the way we handle
      evars in the pretyper. Sometimes they get solved eagerly. *)
-  pattern_of_constr ~broken:true env sigma c
+  legacy_bad_pattern_of_constr env sigma c
 
 (* Interprets a constr expression *)
 let interp_constr_in_compound_list inj_fun dest_fun interp_fun ist env sigma l =
@@ -729,7 +729,7 @@ let interp_closed_typed_pattern_with_occurrences ist env sigma (occs, a) =
       try Inl (coerce_to_evaluable_ref env sigma x)
       with CannotCoerceTo _ ->
         let c = coerce_to_closed_constr env x in
-        Inr (pattern_of_constr ~broken:true env sigma c) in
+        Inr (legacy_bad_pattern_of_constr env sigma c) in
     (try try_interp_ltac_var coerce_eval_ref_or_constr ist (Some (env,sigma)) (CAst.make ?loc id)
      with Not_found as exn ->
        let _, info = Exninfo.capture exn in

--- a/pretyping/constr_matching.ml
+++ b/pretyping/constr_matching.ml
@@ -49,7 +49,7 @@ let instantiate_pattern env sigma lvar c =
               ctx
           in
           let c = substl inst c in
-          pattern_of_constr ~broken:false env sigma c
+          pattern_of_constr env sigma c
         with Not_found (* List.index failed *) ->
           let vars =
             List.map_filter (function Name id -> Some id | _ -> None) vars in

--- a/pretyping/constr_matching.ml
+++ b/pretyping/constr_matching.ml
@@ -49,9 +49,7 @@ let instantiate_pattern env sigma lvar c =
               ctx
           in
           let c = substl inst c in
-          (* FIXME: Stupid workaround to pattern_of_constr being evar sensitive *)
-          let c = Evarutil.nf_evar sigma c in
-          pattern_of_constr env sigma (EConstr.Unsafe.to_constr c)
+          pattern_of_constr ~broken:false env sigma c
         with Not_found (* List.index failed *) ->
           let vars =
             List.map_filter (function Name id -> Some id | _ -> None) vars in

--- a/pretyping/patternops.ml
+++ b/pretyping/patternops.ml
@@ -155,7 +155,7 @@ let head_of_constr_reference sigma c = match EConstr.kind sigma c with
   | Var id -> GlobRef.VarRef id
   | _ -> anomaly (Pp.str "Not a rigid reference.")
 
-let pattern_of_constr ?(broken=false) env sigma t =
+let pattern_of_constr ~broken env sigma t =
   let t = EConstr.Unsafe.to_constr t in
   let kind = if broken then Constr.kind else fun c -> EConstr.kind_upto sigma c in
   let rec pattern_of_constr env t =
@@ -240,6 +240,9 @@ let pattern_of_constr ?(broken=false) env sigma t =
     in
   pattern_of_constr env t
 
+let legacy_bad_pattern_of_constr env sigma c : constr_pattern = pattern_of_constr ~broken:true env sigma c
+let pattern_of_constr env sigma c : constr_pattern = pattern_of_constr ~broken:false env sigma c
+
 (* To process patterns, we need a translation without typing at all. *)
 
 let map_pattern_with_binders g f l = function
@@ -279,7 +282,7 @@ let rec subst_pattern env sigma subst pat =
     if ref' == ref then pat else (match t with
         | None -> PRef ref'
         | Some t ->
-          pattern_of_constr ~broken:false env sigma (EConstr.of_constr t.Univ.univ_abstracted_value))
+          pattern_of_constr env sigma (EConstr.of_constr t.Univ.univ_abstracted_value))
   | PVar _
   | PEvar _
   | PRel _

--- a/pretyping/patternops.ml
+++ b/pretyping/patternops.ml
@@ -155,7 +155,9 @@ let head_of_constr_reference sigma c = match EConstr.kind sigma c with
   | Var id -> GlobRef.VarRef id
   | _ -> anomaly (Pp.str "Not a rigid reference.")
 
-let pattern_of_constr env sigma t =
+let pattern_of_constr ?(broken=false) env sigma t =
+  let t = EConstr.Unsafe.to_constr t in
+  let kind = if broken then Constr.kind else fun c -> EConstr.kind_upto sigma c in
   let rec pattern_of_constr env t =
   let open Context.Rel.Declaration in
   match kind t with
@@ -277,7 +279,7 @@ let rec subst_pattern env sigma subst pat =
     if ref' == ref then pat else (match t with
         | None -> PRef ref'
         | Some t ->
-          pattern_of_constr env sigma t.Univ.univ_abstracted_value)
+          pattern_of_constr ~broken:false env sigma (EConstr.of_constr t.Univ.univ_abstracted_value))
   | PVar _
   | PEvar _
   | PRel _

--- a/pretyping/patternops.mli
+++ b/pretyping/patternops.mli
@@ -42,7 +42,10 @@ val head_of_constr_reference : Evd.evar_map -> constr -> GlobRef.t
    a pattern; currently, no destructor (Cases, Fix, Cofix) and no
    existential variable are allowed in [c] *)
 
-val pattern_of_constr : ?broken:bool -> Environ.env -> Evd.evar_map -> EConstr.constr -> constr_pattern
+val pattern_of_constr : Environ.env -> Evd.evar_map -> EConstr.constr -> constr_pattern
+
+(** Do not use, for internal Coq use only. *)
+val legacy_bad_pattern_of_constr : Environ.env -> Evd.evar_map -> EConstr.constr -> constr_pattern
 
 (** [pattern_of_glob_constr l c] translates a term [c] with metavariables into
    a pattern; variables bound in [l] are replaced by the pattern to which they

--- a/pretyping/patternops.mli
+++ b/pretyping/patternops.mli
@@ -42,7 +42,7 @@ val head_of_constr_reference : Evd.evar_map -> constr -> GlobRef.t
    a pattern; currently, no destructor (Cases, Fix, Cofix) and no
    existential variable are allowed in [c] *)
 
-val pattern_of_constr : Environ.env -> Evd.evar_map -> Constr.constr -> constr_pattern
+val pattern_of_constr : ?broken:bool -> Environ.env -> Evd.evar_map -> EConstr.constr -> constr_pattern
 
 (** [pattern_of_glob_constr l c] translates a term [c] with metavariables into
    a pattern; variables bound in [l] are replaced by the pattern to which they

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -819,7 +819,7 @@ let make_exact_entry env sigma info ?(name=PathAny) (c, cty, ctx) =
         let pat = match info.hint_pattern with
         | Some pat -> snd pat
         | None ->
-          Patternops.pattern_of_constr ~broken:false env sigma cty
+          Patternops.pattern_of_constr env sigma cty
         in
         let h = { rhint_term = c; rhint_type = cty; rhint_uctx = ctx; rhint_arty = 0 } in
         (Some hd,
@@ -845,7 +845,7 @@ let make_apply_entry env sigma hnf info ?(name=PathAny) (c, cty, ctx) =
     let pat = match info.hint_pattern with
     | Some p -> snd p
     | None ->
-      Patternops.pattern_of_constr ~broken:false env ce.evd c'
+      Patternops.pattern_of_constr env ce.evd c'
     in
     let h = { rhint_term = c; rhint_type = cty; rhint_uctx = ctx; rhint_arty = hyps; } in
     if Int.equal nmiss 0 then
@@ -956,7 +956,7 @@ let make_trivial env sigma ?(name=PathAny) r =
   let h = { rhint_term = c; rhint_type = t; rhint_uctx = ctx; rhint_arty = 0 } in
   (Some hd,
    { pri=1;
-     pat = Some (Patternops.pattern_of_constr ~broken:false env ce.evd (clenv_type ce));
+     pat = Some (Patternops.pattern_of_constr env ce.evd (clenv_type ce));
      name = name;
      db = None;
      secvars = secvars_of_constr env sigma c;

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -819,7 +819,7 @@ let make_exact_entry env sigma info ?(name=PathAny) (c, cty, ctx) =
         let pat = match info.hint_pattern with
         | Some pat -> snd pat
         | None ->
-          Patternops.pattern_of_constr env sigma (EConstr.to_constr ~abort_on_undefined_evars:false sigma cty)
+          Patternops.pattern_of_constr ~broken:false env sigma cty
         in
         let h = { rhint_term = c; rhint_type = cty; rhint_uctx = ctx; rhint_arty = 0 } in
         (Some hd,
@@ -845,7 +845,7 @@ let make_apply_entry env sigma hnf info ?(name=PathAny) (c, cty, ctx) =
     let pat = match info.hint_pattern with
     | Some p -> snd p
     | None ->
-      Patternops.pattern_of_constr env ce.evd (EConstr.to_constr ~abort_on_undefined_evars:false sigma c')
+      Patternops.pattern_of_constr ~broken:false env ce.evd c'
     in
     let h = { rhint_term = c; rhint_type = cty; rhint_uctx = ctx; rhint_arty = hyps; } in
     if Int.equal nmiss 0 then
@@ -956,7 +956,7 @@ let make_trivial env sigma ?(name=PathAny) r =
   let h = { rhint_term = c; rhint_type = t; rhint_uctx = ctx; rhint_arty = 0 } in
   (Some hd,
    { pri=1;
-     pat = Some (Patternops.pattern_of_constr env ce.evd (EConstr.to_constr sigma (clenv_type ce)));
+     pat = Some (Patternops.pattern_of_constr ~broken:false env ce.evd (clenv_type ce));
      name = name;
      db = None;
      secvars = secvars_of_constr env sigma c;


### PR DESCRIPTION
At least we clearly expose the parts that rely on the faulty behaviour while being more efficient.

Overlays:
- https://github.com/mattam82/Coq-Equations/pull/489