### PR TITLE
Remove a warning due to leftover code from #15907.

### DIFF
--- a/ide/coqide/coqide_ui.ml
+++ b/ide/coqide/coqide_ui.ml
@@ -153,7 +153,6 @@ let init () =
 \n    <menuitem action='Browse Coq Library' />\
 \n    <menuitem action='Help for keyword' />\
 \n    <menuitem action='Help for μPG mode' />\
-\n    <menuitem action='Memory usage' />\
 \n    <separator />\
 \n    <menuitem name='Abt' action='About Coq' />\
 \n  </menu>\


### PR DESCRIPTION
It was printing things like
```
(coqide:147495): Gtk-WARNING **: 13:37:50.102: Memory usage: missing action Memory usage
```
on the CLI.