### PR TITLE
More compact representation for cooking_info

### DIFF
--- a/checker/values.ml
+++ b/checker/values.ml
@@ -203,7 +203,7 @@ let v_expand_info =
   Tuple ("expand_info", [|v_hmap v_cst v_abstr_inst_info; v_hmap v_cst v_abstr_inst_info|])
 
 let v_cooking_info =
-  Tuple ("cooking_info", [|v_expand_info; v_abstr_info; v_abstr_inst_info; v_set v_id|])
+  Tuple ("cooking_info", [|v_expand_info; v_abstr_info; v_abstr_inst_info|])
 
 let v_opaque =
   v_sum "opaque" 0 [|[|List v_subst; List v_cooking_info; v_dp; Int|]|]

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -203,7 +203,7 @@ let v_expand_info =
   Tuple ("expand_info", [|v_hmap v_cst v_abstr_inst_info; v_hmap v_cst v_abstr_inst_info|])
 
 let v_cooking_info =
-  Tuple ("cooking_info", [|v_expand_info; v_abstr_info; v_abstr_inst_info|])
+  Tuple ("cooking_info", [|v_expand_info; v_abstr_info; List v_id|])
 
 let v_opaque =
   v_sum "opaque" 0 [|[|List v_subst; List v_cooking_info; v_dp; Int|]|]

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -194,7 +194,7 @@ let v_subst =
 (** kernel/lazyconstr *)
 
 let v_abstr_info =
-  Tuple ("abstr_info", [|v_rctxt; v_abs_context; List v_id; v_hmap v_level v_level|])
+  Tuple ("abstr_info", [|v_rctxt; v_abs_context; List v_id; v_instance|])
 
 let v_abstr_inst_info =
   Tuple ("abstr_inst_info", [|List v_id; v_instance|])

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -208,7 +208,7 @@ let v_expand_info =
   Tuple ("expand_info", [|v_hmap v_cst v_abstr_inst_info; v_hmap v_cst v_abstr_inst_info|])
 
 let v_cooking_info =
-  Tuple ("cooking_info", [|v_expand_info; v_abstr_info; List v_id|])
+  Tuple ("cooking_info", [|v_expand_info; v_abstr_info|])
 
 let v_opaque =
   v_sum "opaque" 0 [|[|List v_subst; List v_cooking_info; v_dp; Int|]|]

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -171,6 +171,11 @@ let v_rdecl = v_sum "rel_declaration" 0
        [|v_binder_annot v_name; v_constr; v_constr|] |]   (* LocalDef *)
 let v_rctxt = List v_rdecl
 
+let v_ndecl = v_sum "named_declaration" 0
+    [| [|v_binder_annot v_id; v_constr|];               (* LocalAssum *)
+       [|v_binder_annot v_id; v_constr; v_constr|] |]   (* LocalDef *)
+let v_nctxt = List v_ndecl
+
 let v_section_ctxt = v_enum "emptylist" 1
 
 
@@ -194,7 +199,7 @@ let v_subst =
 (** kernel/lazyconstr *)
 
 let v_abstr_info =
-  Tuple ("abstr_info", [|v_rctxt; v_abs_context; List v_id; v_instance|])
+  Tuple ("abstr_info", [|v_nctxt; v_abs_context; v_instance|])
 
 let v_abstr_inst_info =
   Tuple ("abstr_inst_info", [|List v_id; v_instance|])

--- a/kernel/cooking.ml
+++ b/kernel/cooking.ml
@@ -89,7 +89,6 @@ type cooking_info = {
   expand_info : expand_info;
   abstr_info : abstr_info;
   abstr_inst_info : abstr_inst_info; (* relevant for recursive types *)
-  names_info : Id.Set.t; (* set of generalized names *)
 }
 
 let empty_cooking_info = {
@@ -104,7 +103,6 @@ let empty_cooking_info = {
       abstr_rev_inst = [];
       abstr_uinst = Univ.Instance.empty;
     };
-  names_info = Id.Set.empty;
 }
 
 (*s Cooking the constants. *)
@@ -317,14 +315,15 @@ let make_cooking_info expand_info hyps uctx =
   let abstr_info = { abstr_ctx = []; abstr_subst = []; abstr_auctx; abstr_ausubst } in
   let abstr_info = abstract_named_context expand_info abstr_info hyps in
   let abstr_inst_info = { abstr_rev_inst; abstr_uinst } in
-  let names_info = Context.Named.to_vars hyps in
-  { expand_info; abstr_info; abstr_inst_info; names_info }
+  { expand_info; abstr_info; abstr_inst_info; }
 
 let add_inductive_info ind info =
   let (cmap, imap) = info.expand_info in
   { info with expand_info = (cmap, Mindmap.add ind info.abstr_inst_info imap) }
 
-let names_info info = info.names_info
+let names_info info =
+  let fold accu id = Id.Set.add id accu in
+  List.fold_left fold Id.Set.empty info.abstr_info.abstr_subst
 
 let abstr_inst_info info = info.abstr_inst_info
 

--- a/kernel/cooking.ml
+++ b/kernel/cooking.ml
@@ -305,23 +305,24 @@ let abstract_named_context expand_info abstr_info hyps =
     the instance to apply to take the generalization into account;
     collecting the information needed to do such as a transformation
     of judgment into a [cooking_info] *)
-let make_cooking_info expand_info hyps uctx =
+let make_cooking_info ~recursive expand_info hyps uctx =
   let abstr_inst_rev_inst = List.rev (Named.instance_list (fun id -> id) hyps) in
   let abstr_uinst, abstr_auctx = abstract_universes uctx in
   let abstr_ausubst = abstr_uinst in
   let abstr_info = { abstr_ctx = []; abstr_subst = []; abstr_auctx; abstr_ausubst } in
   let abstr_info = abstract_named_context expand_info abstr_info hyps in
-  { expand_info; abstr_info; abstr_inst_rev_inst; }
-
-let abstr_inst_info info = {
-  abstr_rev_inst = info.abstr_inst_rev_inst;
-  abstr_uinst = info.abstr_info.abstr_ausubst;
-}
-
-let add_inductive_info ind info =
-  let (cmap, imap) = info.expand_info in
-  let abstr_inst_info = abstr_inst_info info in
-  { info with expand_info = (cmap, Mindmap.add ind abstr_inst_info imap) }
+  let abstr_inst_info = {
+    abstr_rev_inst = abstr_inst_rev_inst;
+    abstr_uinst = abstr_info.abstr_ausubst;
+  } in
+  let info = { expand_info; abstr_info; abstr_inst_rev_inst; } in
+  let info = match recursive with
+  | None -> info
+  | Some ind ->
+    let (cmap, imap) = info.expand_info in
+    { info with expand_info = (cmap, Mindmap.add ind abstr_inst_info imap) }
+  in
+  info, abstr_inst_info
 
 let names_info info =
   let fold accu id = Id.Set.add id accu in

--- a/kernel/cooking.mli
+++ b/kernel/cooking.mli
@@ -42,14 +42,11 @@ type cooking_info
 val empty_cooking_info : cooking_info
   (** Nothing to abstract *)
 
-val make_cooking_info : expand_info -> named_context -> Univ.UContext.t -> cooking_info
-  (** Abstract a context assumed to be de-Bruijn free for terms and universes *)
-
-val add_inductive_info : MutInd.t -> cooking_info -> cooking_info
+val make_cooking_info : recursive:MutInd.t option -> expand_info ->
+  named_context -> Univ.UContext.t -> cooking_info * abstr_inst_info
+(** Abstract a context assumed to be de-Bruijn free for terms and universes *)
 
 val names_info : cooking_info -> Id.Set.t
-
-val abstr_inst_info : cooking_info -> abstr_inst_info
 
 val universe_context_of_cooking_info : cooking_info -> Univ.AbstractContext.t
 

--- a/kernel/discharge.ml
+++ b/kernel/discharge.ml
@@ -74,7 +74,8 @@ let cook_constant env info cb =
   in
   let tps = Vmbytegen.compile_constant_body ~fail_on_error:false env univs body in
   let typ = abstract_as_type cache cb.const_type in
-  let hyps = List.filter (fun d -> not (Id.Set.mem (NamedDecl.get_id d) (names_info info))) cb.const_hyps in
+  let names = names_info info in
+  let hyps = List.filter (fun d -> not (Id.Set.mem (NamedDecl.get_id d) names)) cb.const_hyps in
   {
     const_hyps = hyps;
     const_body = body;
@@ -167,8 +168,9 @@ let cook_inductive info mib =
       in
       PrimRecord data
   in
+  let names = names_info info in
   let mind_hyps =
-    List.filter (fun d -> not (Id.Set.mem (NamedDecl.get_id d) (names_info info)))
+    List.filter (fun d -> not (Id.Set.mem (NamedDecl.get_id d) names))
       mib.mind_hyps
   in
   let mind_variance, mind_sec_variance =

--- a/kernel/univ.ml
+++ b/kernel/univ.ml
@@ -955,12 +955,6 @@ let extend_in_context_set (a, ctx) ctx' =
 let empty_level_subst = Level.Map.empty
 let is_empty_level_subst = Level.Map.is_empty
 
-let lift_level_subst n =
-  Level.Map.map (function {Level.data=Level.Var p;_} -> Level.var (p+n) | u -> u)
-
-let merge_level_subst =
-  Level.Map.union (fun _ _ _ -> anomaly (str "Overlapping universe substitutions"))
-
 (** Substitution functions *)
 
 (** With level to level substitutions. *)

--- a/kernel/univ.mli
+++ b/kernel/univ.mli
@@ -402,12 +402,6 @@ type universe_level_subst = Level.t Level.Map.t
 val empty_level_subst : universe_level_subst
 val is_empty_level_subst : universe_level_subst -> bool
 
-val lift_level_subst : int -> universe_level_subst -> universe_level_subst
-(** Lift de Bruijn universe variables (Var) in the substitution *)
-
-val merge_level_subst : universe_level_subst -> universe_level_subst -> universe_level_subst
-(** Merge two substitutions assumed to have disjoint domains *)
-
 (** Substitution of universes. *)
 val subst_univs_level_level : universe_level_subst -> Level.t -> Level.t
 val subst_univs_level_universe : universe_level_subst -> Universe.t -> Universe.t


### PR DESCRIPTION
This simplifies the representation of the cooking_info datatype. At the same time, this PR enforces more invariants statically about the contents of the type, while hopefully resulting in a smaller footprint on disk.