### PR TITLE
[proof engine] Forbid tactic code to raise exceptions

### DIFF
--- a/dev/doc/changes.md
+++ b/dev/doc/changes.md
@@ -1,3 +1,9 @@
+## Changes between Coq 8.15 and Coq 8.16
+
+### Tactic API
+
+  - **CRITICAL** raising inside tactic code is now forbidden.
+
 ## Changes between Coq 8.14 and Coq 8.15
 
 ### XML protocol

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -1107,7 +1107,15 @@ module Goal = struct
         tclTHEN (Unsafe.tclEVARS sigma) (InfoL.tag (Info.DBranch) (f gl))
       with e when catchable_exception e ->
         let (e, info) = Exninfo.capture e in
-        tclZERO ~info e
+        let raw_msg = Printexc.to_string e |> Pp.str in
+        let bt_msg =
+          match Exninfo.get_backtrace info with
+          | None -> Pp.str "no bt"
+          | Some bt -> Exninfo.backtrace_to_string bt |> Pp.str
+        in
+        let e_msg = CErrors.print e in
+        Feedback.msg_warning Pp.(str "[nf_enter] exn inside tactic: " ++ bt_msg ++ fnl () ++ raw_msg ++ fnl () ++ e_msg);
+        CErrors.anomaly (Pp.str "boom!")
     end
     end
   let gmake env sigma goal =
@@ -1125,7 +1133,15 @@ module Goal = struct
       try f (gmake env sigma goal)
       with e when catchable_exception e ->
         let (e, info) = Exninfo.capture e in
-        tclZERO ~info e
+        let raw_msg = Printexc.to_string e |> Pp.str in
+        let bt_msg =
+          match Exninfo.get_backtrace info with
+          | None -> Pp.str "no bt"
+          | Some bt -> Exninfo.backtrace_to_string bt |> Pp.str
+        in
+        let e_msg = CErrors.print e in
+        Feedback.msg_warning Pp.(str "[enter] exn inside tactic: " ++ bt_msg ++ fnl () ++ raw_msg ++ fnl () ++ e_msg);
+        CErrors.anomaly (Pp.str "boom!")
     end
     end
 
@@ -1138,7 +1154,15 @@ module Goal = struct
        try f (gmake env sigma goal)
        with e when catchable_exception e ->
          let (e, info) = Exninfo.capture e in
-         tclZERO ~info e
+         let raw_msg = Printexc.to_string e |> Pp.str in
+         let bt_msg =
+           match Exninfo.get_backtrace info with
+           | None -> Pp.str "no bt"
+           | Some bt -> Exninfo.backtrace_to_string bt |> Pp.str
+         in
+         let e_msg = CErrors.print e in
+         Feedback.msg_warning Pp.(str "[enter_one] exn inside tactic: " ++ bt_msg ++ fnl () ++ raw_msg ++ fnl () ++ e_msg);
+         CErrors.anomaly (Pp.str "boom!")
       end
     | _ ->
        CErrors.anomaly Pp.(str __LOC__ ++ str " enter_one")
@@ -1236,7 +1260,15 @@ module V82 = struct
       Pv.set { solution = evd; comb = sgs; }
     with e when catchable_exception e ->
       let (e, info) = Exninfo.capture e in
-      tclZERO ~info e
+      let raw_msg = Printexc.to_string e |> Pp.str in
+      let bt_msg =
+        match Exninfo.get_backtrace info with
+        | None -> Pp.str "no bt"
+        | Some bt -> Exninfo.backtrace_to_string bt |> Pp.str
+      in
+      let e_msg = CErrors.print e in
+      Feedback.msg_warning Pp.(str "[V82.tactic] exn inside tactic: " ++ bt_msg ++ fnl () ++ raw_msg ++ fnl () ++ e_msg);
+      CErrors.anomaly (Pp.str "boom!")
 
   let of_tactic t gls =
     try

--- a/lib/cErrors.ml
+++ b/lib/cErrors.ml
@@ -56,7 +56,9 @@ let raw_anomaly e = match e with
   | _ ->
     str "Uncaught exception " ++ str (Printexc.to_string e) ++ str "."
 
-let print_backtrace e = match Exninfo.get_backtrace e with
+let print_backtrace _ = mt ()
+
+let _print_backtrace e = match Exninfo.get_backtrace e with
 | None -> mt ()
 | Some bt ->
   let bt = str (Exninfo.backtrace_to_string bt) in

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -559,8 +559,13 @@ let mk_eq f c1 c2 k =
     let evm, ty = pf_apply type_of gl c1 in
     let evm, ty = Evarsolve.refresh_universes (Some false) (pf_env gl) evm ty in
     let term = mkApp (fc, [| ty; c1; c2 |]) in
-    let evm, _ =  type_of (pf_env gl) evm term in
-    Proofview.tclTHEN (Proofview.Unsafe.tclEVARS evm) (k term)
+    try
+      let evm, _ =  type_of (pf_env gl) evm term in
+      Proofview.tclTHEN (Proofview.Unsafe.tclEVARS evm) (k term)
+    with
+    | Pretype_errors.PretypeError _ as exn ->
+      let exn, info = Exninfo.capture exn in
+      Proofview.tclZERO ~info exn
     end
 
 let f_equal =

--- a/plugins/ltac/internals.ml
+++ b/plugins/ltac/internals.ml
@@ -383,8 +383,15 @@ let exact ist (c : Ltac_pretype.closed_glob_constr) =
   let open Tacmach in
   Proofview.Goal.enter begin fun gl ->
   let expected_type = Pretyping.OfType (pf_concl gl) in
-  let sigma, c = Tacinterp.type_uconstr ~expected_type ist c (pf_env gl) (project gl) in
-  Proofview.tclTHEN (Proofview.Unsafe.tclEVARS sigma) (Tactics.exact_no_check c)
+  try
+    let sigma, c = Tacinterp.type_uconstr ~expected_type ist c (pf_env gl) (project gl) in
+    Proofview.tclTHEN (Proofview.Unsafe.tclEVARS sigma) (Tactics.exact_no_check c)
+  with
+  | CErrors.UserError _
+  | UnivGen.UniverseLengthMismatch _
+  | Pretype_errors.PretypeError _ as exn ->
+    let exn, info = Exninfo.capture exn in
+    Proofview.tclZERO ~info exn
   end
 
 (** ProofGeneral specific command *)

--- a/plugins/ltac/taccoerce.mli
+++ b/plugins/ltac/taccoerce.mli
@@ -29,6 +29,8 @@ exception CannotCoerceTo of string
 
 *)
 
+exception CoercionError of Id.t * (Environ.env * Evd.evar_map) option * Val.t * string
+
 module Value :
 sig
   type t = Val.t

--- a/plugins/nsatz/nsatz.ml
+++ b/plugins/nsatz/nsatz.ml
@@ -538,8 +538,10 @@ let return_term t =
   generalize [a]
 
 let nsatz_compute t =
-  let lpol =
-    try nsatz t
-    with Ideal.NotInIdeal ->
-      user_err Pp.(str "nsatz cannot solve this problem") in
-  return_term lpol
+  try
+    let lpol = nsatz t in
+    return_term lpol
+  with
+  | Ideal.NotInIdeal as exn ->
+    let _exn, info = Exninfo.capture exn in
+    Proofview.tclZERO ~info (CErrors.UserError Pp.(str "nsatz cannot solve this problem"))

--- a/plugins/ring/ring.ml
+++ b/plugins/ring/ring.ml
@@ -678,14 +678,19 @@ let ring_lookup (f : Value.t) lH rl t =
   Proofview.Goal.enter begin fun gl ->
     let sigma = Tacmach.project gl in
     let env = Proofview.Goal.env gl in
-    let rl = make_args_list sigma rl t in
-    let e = find_ring_structure env sigma rl in
-    let sigma, l = make_term_list env sigma (EConstr.of_constr e.ring_carrier) rl in
-    let rl = Value.of_constr l in
-    let sigma, l = make_hyp_list env sigma lH in
-    let lH = carg l in
-    let ring = ltac_ring_structure e in
-    Proofview.tclTHEN (Proofview.Unsafe.tclEVARS sigma) (Value.apply f (ring@[lH;rl]))
+    try
+      let rl = make_args_list sigma rl t in
+      let e = find_ring_structure env sigma rl in
+      let sigma, l = make_term_list env sigma (EConstr.of_constr e.ring_carrier) rl in
+      let rl = Value.of_constr l in
+      let sigma, l = make_hyp_list env sigma lH in
+      let lH = carg l in
+      let ring = ltac_ring_structure e in
+      Proofview.tclTHEN (Proofview.Unsafe.tclEVARS sigma) (Value.apply f (ring@[lH;rl]))
+    with
+    | CErrors.UserError _ as exn ->
+      let exn, info = Exninfo.capture exn in
+      Proofview.tclZERO ~info exn
   end
 
 (***********************************************************************)
@@ -971,11 +976,16 @@ let field_lookup (f : Value.t) lH rl t =
     let sigma = Tacmach.project gl in
     let env = Proofview.Goal.env gl in
     let rl = make_args_list sigma rl t in
-    let e = find_field_structure env sigma rl in
-    let sigma, c = make_term_list env sigma (EConstr.of_constr e.field_carrier) rl in
-    let rl = Value.of_constr c in
-    let sigma, l = make_hyp_list env sigma lH in
-    let lH = carg l in
-    let field = ltac_field_structure e in
-    Proofview.tclTHEN (Proofview.Unsafe.tclEVARS sigma) (Value.apply f (field@[lH;rl]))
+    try
+      let e = find_field_structure env sigma rl in
+      let sigma, c = make_term_list env sigma (EConstr.of_constr e.field_carrier) rl in
+      let rl = Value.of_constr c in
+      let sigma, l = make_hyp_list env sigma lH in
+      let lH = carg l in
+      let field = ltac_field_structure e in
+      Proofview.tclTHEN (Proofview.Unsafe.tclEVARS sigma) (Value.apply f (field@[lH;rl]))
+    with
+    | CErrors.UserError _ as exn ->
+      let exn, info = Exninfo.capture exn in
+      Proofview.tclZERO ~info exn
   end

--- a/plugins/ssr/ssrbwd.ml
+++ b/plugins/ssr/ssrbwd.ml
@@ -146,9 +146,14 @@ let inner_ssrapplytac gviews (ggenl, gclr) ist =
       (cleartac clr)
   | [], [agens] ->
     let sigma = Proofview.Goal.sigma gl in
-    let clr', lemma = interp_agens ist (pf_env gl) sigma ~concl:(pf_concl gl) agens in
-    let sigma = Evd.merge_universe_context sigma (Evd.evar_universe_context (fst lemma)) in
-    Tacticals.tclTHENLIST [Proofview.Unsafe.tclEVARS sigma; cleartac clr; refine_with ~beta:true lemma; cleartac clr']
+    (try
+       let clr', lemma = interp_agens ist (pf_env gl) sigma ~concl:(pf_concl gl) agens in
+       let sigma = Evd.merge_universe_context sigma (Evd.evar_universe_context (fst lemma)) in
+       Tacticals.tclTHENLIST [Proofview.Unsafe.tclEVARS sigma; cleartac clr; refine_with ~beta:true lemma; cleartac clr']
+     with
+     | CErrors.UserError _ as exn ->
+       let e, info = Exninfo.capture exn in
+       Proofview.tclZERO ~info e)
   | _, _ ->
     Tacticals.tclTHENLIST [apply_top_tac; cleartac clr]))
 

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -315,11 +315,16 @@ let unfoldintac occ rdx t (kt,_) =
         with _ -> errorstrm Pp.(str "The term " ++
           pr_econstr_env env sigma c ++spc()++ str "does not unify with " ++ pr_econstr_pat env sigma t)),
     ignore in
-  let concl =
-    try beta env0 (eval_pattern env0 sigma0 concl0 rdx occ unfold)
-    with Option.IsNone -> errorstrm Pp.(str"Failed to unfold " ++ pr_econstr_pat env0 sigma t) in
-  let () = conclude () in
-  convert_concl ~check:true concl
+  try
+    let concl =
+      try beta env0 (eval_pattern env0 sigma0 concl0 rdx occ unfold)
+      with Option.IsNone -> errorstrm Pp.(str"Failed to unfold " ++ pr_econstr_pat env0 sigma t) in
+    let () = conclude () in
+    convert_concl ~check:true concl
+  with
+  | CErrors.UserError _ as exn ->
+    let exn, info = Exninfo.capture exn in
+    Proofview.tclZERO ~info exn
   end
 
 let foldtac occ rdx ft =
@@ -410,6 +415,7 @@ let pirrel_rewrite ?(under=false) ?(map_redex=id_map_redex) pred rdx rdx_ty new_
   (* We check the proof is well typed. We assume that the type of [elim] is of
      the form [forall (A : Type) (x : A) (P : A -> Type@{s}), T] s.t. the only
      universes to unify are by checking the [A] and [P] arguments. *)
+  try
   let sigma =
     try
       let open EConstr in
@@ -455,6 +461,11 @@ let pirrel_rewrite ?(under=false) ?(map_redex=id_map_redex) pred rdx rdx_ty new_
     | _ -> anomaly "rewrite rule not an application" in
       tclZEROMSG Pp.(Himsg.explain_refiner_error env sigma (Logic.UnresolvedBindings miss)++
       (Pp.fnl()++str"Rule's type:" ++ spc() ++ pr_econstr_env env sigma hd_ty)))
+
+  with
+  | PRtype_error _ as exn ->
+    let exn, info = Exninfo.capture exn in
+    Proofview.tclZERO ~info exn
   end
 
 let pf_merge_uc_of s sigma =
@@ -471,61 +482,66 @@ let rwcltac ?under ?map_redex cl rdx dir (sigma, r) =
   let r_n' = abs_cterm env sigma0 n r_n in
   let r' = EConstr.Vars.subst_var pattern_id r_n' in
   let sigma0 = Evd.set_universe_context sigma0 ucst in
-  let sigma, rdxt = Typing.type_of env sigma rdx in
-  let () = debug_ssr (fun () -> Pp.(str"r@rwcltac=" ++ pr_econstr_env env sigma r)) in
-  let cvtac, rwtac, sigma0 =
-    if EConstr.Vars.closed0 sigma0 r' then
-      let c_eq = Coqlib.(lib_ref "core.eq.type") in
-      let sigma, c_ty = Typing.type_of env sigma r in
-      let () = debug_ssr (fun () -> Pp.(str"c_ty@rwcltac=" ++ pr_econstr_env env sigma c_ty)) in
-      let open EConstr in
-      match kind_of_type sigma (Reductionops.whd_all env sigma c_ty) with
-      | AtomicType(e, a) when Ssrcommon.is_ind_ref sigma e c_eq ->
+  try
+    let sigma, rdxt = Typing.type_of env sigma rdx in
+    let () = debug_ssr (fun () -> Pp.(str"r@rwcltac=" ++ pr_econstr_env env sigma r)) in
+    let cvtac, rwtac, sigma0 =
+      if EConstr.Vars.closed0 sigma0 r' then
+        let c_eq = Coqlib.(lib_ref "core.eq.type") in
+        let sigma, c_ty = Typing.type_of env sigma r in
+        let () = debug_ssr (fun () -> Pp.(str"c_ty@rwcltac=" ++ pr_econstr_env env sigma c_ty)) in
+        let open EConstr in
+        match kind_of_type sigma (Reductionops.whd_all env sigma c_ty) with
+        | AtomicType(e, a) when Ssrcommon.is_ind_ref sigma e c_eq ->
           let new_rdx = if dir = L2R then a.(2) else a.(1) in
           pirrel_rewrite ?under ?map_redex cl rdx a.(0) new_rdx dir (sigma, r) c_ty, Tacticals.tclIDTAC, sigma0
-      | _ ->
+        | _ ->
           let cl' = EConstr.mkApp (EConstr.mkNamedLambda (make_annot pattern_id Sorts.Relevant) rdxt cl, [|rdx|]) in
           let sigma, _ = Typing.type_of env sigma cl' in
           let sigma0 = pf_merge_uc_of sigma sigma0 in
           convert_concl ~check:true cl', rewritetac ?under dir r', sigma0
-    else
-      let dc, r2 = EConstr.decompose_lam_n_assum sigma0 n r' in
-      let r3, _, r3t  =
-        try EConstr.destCast sigma0 r2 with _ ->
-        errorstrm Pp.(str "no cast from " ++ pr_econstr_pat env sigma0 r
-                    ++ str " to " ++ pr_econstr_env env sigma0 r2) in
-      let cl' = EConstr.mkNamedProd (make_annot rule_id Sorts.Relevant) (EConstr.it_mkProd_or_LetIn r3t dc) (EConstr.Vars.lift 1 cl) in
-      let cl'' = EConstr.mkNamedProd (make_annot pattern_id Sorts.Relevant) rdxt cl' in
-      let itacs = [introid pattern_id; introid rule_id] in
-      let cltac = Tactics.clear [pattern_id; rule_id] in
-      let rwtacs = [
-        Tacticals.tclTHENLIST [
-          rewritetac ?under dir (EConstr.mkVar rule_id);
-          if !ssroldreworder || Option.default false under then
-            Proofview.tclUNIT ()
-          else
-            Proofview.cycle 1
+      else
+        let dc, r2 = EConstr.decompose_lam_n_assum sigma0 n r' in
+        let r3, _, r3t  =
+          try EConstr.destCast sigma0 r2 with _ ->
+            errorstrm Pp.(str "no cast from " ++ pr_econstr_pat env sigma0 r
+                          ++ str " to " ++ pr_econstr_env env sigma0 r2) in
+        let cl' = EConstr.mkNamedProd (make_annot rule_id Sorts.Relevant) (EConstr.it_mkProd_or_LetIn r3t dc) (EConstr.Vars.lift 1 cl) in
+        let cl'' = EConstr.mkNamedProd (make_annot pattern_id Sorts.Relevant) rdxt cl' in
+        let itacs = [introid pattern_id; introid rule_id] in
+        let cltac = Tactics.clear [pattern_id; rule_id] in
+        let rwtacs = [
+          Tacticals.tclTHENLIST [
+            rewritetac ?under dir (EConstr.mkVar rule_id);
+            if !ssroldreworder || Option.default false under then
+              Proofview.tclUNIT ()
+            else
+              Proofview.cycle 1
           ];
-        cltac] in
-      Tactics.apply_type ~typecheck:true cl'' [rdx; EConstr.it_mkLambda_or_LetIn r3 dc], Tacticals.tclTHENLIST (itacs @ rwtacs), sigma0
-  in
-  let cvtac' =
-    Proofview.tclORELSE cvtac begin function
-    | (PRtype_error e, _) ->
-      let error = Option.cata (fun (env, sigma, te) ->
-          Pp.(fnl () ++ str "Type error was: " ++ Himsg.explain_pretype_error env sigma te))
-          (Pp.mt ()) e in
-      if occur_existential sigma0 (Tacmach.pf_concl gl)
-      then Tacticals.tclZEROMSG Pp.(str "Rewriting impacts evars" ++ error)
-      else Tacticals.tclZEROMSG Pp.(str "Dependent type error in rewrite of "
-        ++ pr_econstr_env env sigma0
-          (EConstr.mkNamedLambda (make_annot pattern_id Sorts.Relevant) rdxt cl)
-        ++ error)
-    | (e, info) -> Proofview.tclZERO ~info e
-    end
-  in
-  Proofview.Unsafe.tclEVARS sigma0 <*>
-  Tacticals.tclTHEN cvtac' rwtac
+          cltac] in
+        Tactics.apply_type ~typecheck:true cl'' [rdx; EConstr.it_mkLambda_or_LetIn r3 dc], Tacticals.tclTHENLIST (itacs @ rwtacs), sigma0
+    in
+    let cvtac' =
+      Proofview.tclORELSE cvtac begin function
+      | (PRtype_error e, _) ->
+        let error = Option.cata (fun (env, sigma, te) ->
+            Pp.(fnl () ++ str "Type error was: " ++ Himsg.explain_pretype_error env sigma te))
+            (Pp.mt ()) e in
+        if occur_existential sigma0 (Tacmach.pf_concl gl)
+        then Tacticals.tclZEROMSG Pp.(str "Rewriting impacts evars" ++ error)
+        else Tacticals.tclZEROMSG Pp.(str "Dependent type error in rewrite of "
+                                      ++ pr_econstr_env env sigma0
+                                        (EConstr.mkNamedLambda (make_annot pattern_id Sorts.Relevant) rdxt cl)
+                                      ++ error)
+      | (e, info) -> Proofview.tclZERO ~info e
+      end
+    in
+    Proofview.Unsafe.tclEVARS sigma0 <*>
+    Tacticals.tclTHEN cvtac' rwtac
+  with
+    CErrors.UserError _ as exn ->
+    let exn, info = Exninfo.capture exn in
+    Proofview.tclZERO ~info exn
   end
 
 [@@@ocaml.warning "-3"]
@@ -671,10 +687,14 @@ let rwrxtac ?under ?map_redex occ rdx_pat dir rule =
       (fun concl -> closed0_check env0 sigma0 concl e;
         let (d,(ev,ctx,c)) , x = assert_done r in (d,(true, ev,ctx, Reductionops.nf_evar ev c)) , x) in
   let concl0 = Reductionops.nf_evar sigma0 concl0 in
-  let concl = eval_pattern env0 sigma0 concl0 rdx_pat occ find_R in
-  let (d, (_, sigma, uc, t)), rdx = conclude concl in
-  let r = Evd.merge_universe_context sigma uc, t in
-  rwcltac ?under ?map_redex concl rdx d r
+  try
+    let concl = eval_pattern env0 sigma0 concl0 rdx_pat occ find_R in
+    let (d, (_, sigma, uc, t)), rdx = conclude concl in
+    let r = Evd.merge_universe_context sigma uc, t in
+    rwcltac ?under ?map_redex concl rdx d r
+  with CErrors.UserError _ as exn ->
+    let exn, info = Exninfo.capture exn in
+    Proofview.tclZERO ~info exn
   end
 
 let ssrinstancesofrule ist dir arg =

--- a/plugins/ssr/ssripats.ml
+++ b/plugins/ssr/ssripats.ml
@@ -299,8 +299,13 @@ end
 
 let tacCHECK_HYPS_EXIST hyps = Goal.enter begin fun gl ->
   let ctx = Goal.hyps gl in
-  List.iter (Ssrcommon.check_hyp_exists ctx) hyps;
-  tclUNIT ()
+  try
+    List.iter (Ssrcommon.check_hyp_exists ctx) hyps;
+    tclUNIT ()
+  with
+  | CErrors.UserError _ as exn ->
+    let exn, info = Exninfo.capture exn in
+    Proofview.tclZERO ~info exn
 end
 
 let tacFILTER_HYP_EXIST hyps k = Goal.enter begin fun gl ->

--- a/stm/partac.ml
+++ b/stm/partac.ml
@@ -157,7 +157,9 @@ let assign_tac ~abstract res : unit Proofview.tactic =
         in
         (if abstract then Abstract.tclABSTRACT None else (fun x -> x))
             (push_state uc <*> Tactics.exact_no_check (EConstr.of_constr pt))
-  | Some (Exn e) -> raise e
+  | Some (Exn e) ->
+    let exn, info = Exninfo.capture e in
+    Proofview.tclZERO ~info exn
   end)
 
 let enable_par ~nworkers = ComTactic.set_par_implementation

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -752,8 +752,14 @@ let tclDELAYEDWITHHOLES check x tac =
   Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
     let sigma = Proofview.Goal.sigma gl in
-    let (sigma, x) = x env sigma in
-    tclWITHHOLES check (tac x) sigma
+    try
+      let (sigma, x) = x env sigma in
+      tclWITHHOLES check (tac x) sigma
+    with
+    | Pretype_errors.PretypeError _
+    | Nametab.GlobalizationError _ as exn ->
+      let exn, info = Exninfo.capture exn in
+      Proofview.tclZERO ~info exn
   end
 
 let tclTIMEOUT n t =

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -76,10 +76,10 @@ endif
 COQEXTRAFLAGS?=
 COQFLAGS?=$(COQEXTRAFLAGS)
 
-coqc := $(BIN)coqc -q -R prerequisite TestSuite $(COQFLAGS)
+coqc := $(BIN)coqc -d backtrace -q -R prerequisite TestSuite $(COQFLAGS)
 coqchk := $(BIN)coqchk -R prerequisite TestSuite
 coqdoc := $(BIN)coqdoc
-coqtop := $(BIN)coqtop -q -test-mode -R prerequisite TestSuite
+coqtop := $(BIN)coqtop -d backtrace -q -test-mode -R prerequisite TestSuite
 coqtopbyte := $(BIN)coqtop.byte -q
 
 ifeq ($(BEST),opt)

--- a/theories/dune
+++ b/theories/dune
@@ -2,7 +2,7 @@
  (name Coq)
  (package coq-stdlib)
  (synopsis "Coq's Standard Library")
- (flags -q -w -deprecated-native-compiler-option)
+ (flags -q -w -deprecated-native-compiler-option -d backtrace)
  ; (mode native)
  (boot)
  ; (per_file


### PR DESCRIPTION
Motivated by the recent discussion on Zulip about exceptions and
tactics, we move forward with the porting of tactic code to the
monadic proof engine and forbid tactics to raise non-critical
exceptions.

Instead, tactics calling exceptional code should catch and reify the
exception locally and use the proper proof engine API `tclZero`.

I think this is a very long due cleanup.

I hope @ppedrot likes this!

As of now, this is a draft, and not yet ready for benchmark. Stdlib
compiles, test suite is close to pass.

This should be combined with the work on PR #XXXX that adds exception
static analysis to Coq's codebase.

Next step is to remove `wrap_exceptions`, but that will require some
more tweaks as it appears is some critical paths.

(Hint: Click "hide whitespace" on the GH review tab to see relevant changes better)