### PR TITLE
Handle deletion of end of sentence char correctly

### DIFF
--- a/ide/coqide/session.ml
+++ b/ide/coqide/session.ml
@@ -196,7 +196,7 @@ let set_buffer_handlers
     let rec aux iter =
       if iter#equal max_iter then None
       else if iter#has_tag Tags.Script.processed then
-        Some min_iter
+        Some min_iter#backward_char
       else if iter#has_tag Tags.Script.error_bg then
         processed_sentence_just_before_error iter
       else aux iter#forward_char


### PR DESCRIPTION
Fixes #15861

The problem was that `delete_cb` set a mark on the character to be deleted through `handle_iter`.  It appears that removing the character either removes the mark or moves it to the following character.  Then `end_action_cb` couldn't find the mark or the right character.  Setting the mark on the character before the deletion appears to be a good fix.

@Alizter Perhaps you would test the fix some more?  I tried everything I could think of.