### PR TITLE
Handle paste to beginning of buffer correctly.

### DIFF
--- a/ide/coqide/coqOps.ml
+++ b/ide/coqide/coqOps.ml
@@ -177,7 +177,7 @@ object
   method get_n_errors : int
   method get_errors : (int * string) list
   method get_slaves_status : int * int * string CString.Map.t
-
+  method backtrack_to_begin : unit -> unit task
   method handle_failure : handle_exn_rty -> unit task
 
   method destroy : unit -> unit
@@ -914,6 +914,10 @@ object(self)
                  (Doc.focused document && Doc.is_in_focus document safe_id))
     in
       undo to_id unfocus_needed)
+
+  method backtrack_to_begin =
+    let until (id : Doc.id option) _ stop = (id = (Some (Stateid.of_int 1))) in
+    fun () -> self#backtrack_to_id ~move_insert:false (self#find_id until)
 
   method private backtrack_until ?move_insert until =
     self#backtrack_to_id ?move_insert (self#find_id until)

--- a/ide/coqide/coqOps.mli
+++ b/ide/coqide/coqOps.mli
@@ -42,7 +42,7 @@ object
   method get_n_errors : int
   method get_errors : (int * string) list
   method get_slaves_status : int * int * string CString.Map.t
-
+  method backtrack_to_begin : unit -> unit task
   method handle_failure : handle_exn_rty -> unit task
 
   method destroy : unit -> unit


### PR DESCRIPTION
Fixes #15882

The cause is similar to that of  #15861.  When the entire buffer is replaced with a paste, the buffer is emptied and all the marks disappear, therefore a different approach is needed.

Not very elegant; IMHO the marks are not a great fit for the test.

@Alitzer Would you test this, too?  I tried the cases I could think of--not many.
