### PR TITLE
[experiment] Use kernel reduction in Inductiveops.find_rectype and variants.

### DIFF
--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -548,7 +548,7 @@ let extract_mrectype sigma t =
     | _ -> raise Not_found
 
 let find_mrectype_vect env sigma c =
-  let (t, l) = Termops.decompose_app_vect sigma (whd_all env sigma c) in
+  let (t, l) = Termops.decompose_app_vect sigma (Reductionops.whd_all env sigma c) in
   match EConstr.kind sigma t with
     | Ind ind -> (ind, l)
     | _ -> raise Not_found
@@ -558,37 +558,28 @@ let find_mrectype env sigma c =
 
 let find_rectype env sigma c =
   let open EConstr in
-  let (t, l) = decompose_app sigma (whd_all env sigma c) in
-  match EConstr.kind sigma t with
-    | Ind (ind,u) ->
-        let (mib,mip) = Inductive.lookup_mind_specif env ind in
-        if mib.mind_nparams > List.length l then raise Not_found;
-        let l = List.map EConstr.Unsafe.to_constr l in
-        let (par,rargs) = List.chop mib.mind_nparams l in
-        let indu = (ind, EInstance.kind sigma u) in
-        IndType((indu, par),List.map EConstr.of_constr rargs)
-    | _ -> raise Not_found
+  let (ind, u), l = find_mrectype_vect env sigma c in
+  let (mib,mip) = Inductive.lookup_mind_specif env ind in
+  if mib.mind_nparams > Array.length l then raise Not_found;
+  let l = Array.map_to_list EConstr.Unsafe.to_constr l in
+  let (par,rargs) = List.chop mib.mind_nparams l in
+  let indu = (ind, EInstance.kind sigma u) in
+  IndType((indu, par),List.map EConstr.of_constr rargs)
 
 let find_inductive env sigma c =
-  let open EConstr in
-  let (t, l) = decompose_app sigma (whd_all env sigma c) in
-  match EConstr.kind sigma t with
-    | Ind ind
-        when (fst (Inductive.lookup_mind_specif env (fst ind))).mind_finite <> CoFinite ->
-        let l = List.map EConstr.Unsafe.to_constr l in
-        (ind, l)
-    | _ -> raise Not_found
+  let (ind, l) = find_mrectype_vect env sigma c in
+  if  (fst (Inductive.lookup_mind_specif env (fst ind))).mind_finite <> CoFinite then
+    let l = Array.map_to_list EConstr.Unsafe.to_constr l in
+    (ind, l)
+  else
+   raise Not_found
 
 let find_coinductive env sigma c =
-  let open EConstr in
-  let (t, l) = decompose_app sigma (whd_all env sigma c) in
-  match EConstr.kind sigma t with
-    | Ind ind
-        when (fst (Inductive.lookup_mind_specif env (fst ind))).mind_finite == CoFinite ->
-        let l = List.map EConstr.Unsafe.to_constr l in
-        (ind, l)
-    | _ -> raise Not_found
-
+  let (ind, l) = find_mrectype_vect env sigma c in
+  if (fst (Inductive.lookup_mind_specif env (fst ind))).mind_finite == CoFinite then
+    let l = Array.map_to_list EConstr.Unsafe.to_constr l in
+    (ind, l)
+  else raise Not_found
 
 (***********************************************)
 (* find appropriate names for pattern variables. Useful in the Case


### PR DESCRIPTION
We also factorize a bit the code.