### PR TITLE
Cache relevance inside projections.

### DIFF
--- a/checker/values.ml
+++ b/checker/values.ml
@@ -126,7 +126,7 @@ let v_caseinfo =
 
 let v_cast = v_enum "cast_kind" 3
 
-let v_proj_repr = v_tuple "projection_repr" [|v_ind;Int;Int;v_id|]
+let v_proj_repr = v_tuple "projection_repr" [|v_ind;v_bool;Int;Int;v_id|]
 let v_proj = v_tuple "projection" [|v_proj_repr; v_bool|]
 
 let v_uint63 =

--- a/dev/ci/user-overlays/15943-ppedrot-cache-projection-relevance.sh
+++ b/dev/ci/user-overlays/15943-ppedrot-cache-projection-relevance.sh
@@ -1,0 +1,1 @@
+overlay metacoq https://github.com/ppedrot/metacoq cache-projection-relevance 15943

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -1355,12 +1355,8 @@ let is_irrelevant_constructor infos (ind,_) = match infos.i_cache.i_mode with
 | Conversion -> Indset_env.mem ind infos.i_cache.i_env.irr_inds
 | Reduction -> false
 
-(* FIXME: cache relevance in projection like Fix / Case nodes or in env like constants and inds *)
 let is_irrelevant_projection infos p = match infos.i_cache.i_mode with
-| Conversion ->
-  let mind = Projection.mind p in
-  let mib = lookup_mind mind infos.i_cache.i_env in
-  Declareops.relevance_of_projection_repr mib (Projection.repr p) == Sorts.Irrelevant
+| Conversion -> not @@ Projection.Repr.relevant @@ Projection.repr p
 | Reduction -> false
 
 (*********************************************************************)

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -304,10 +304,15 @@ let inductive_make_projection ind mib ~proj_arg =
   | NotRecord | FakeRecord ->
     CErrors.anomaly Pp.(str "inductive_make_projection: not a primitive record.")
   | PrimRecord infos ->
-    let _, labs, _, _ = infos.(snd ind) in
+    let _, labs, relevances, _ = infos.(snd ind) in
+    let proj_relevant = match relevances.(proj_arg) with
+    | Sorts.Irrelevant -> false
+    | Sorts.Relevant -> true
+    in
     if proj_arg < 0 || Array.length labs <= proj_arg
     then CErrors.anomaly Pp.(str "inductive_make_projection: invalid proj_arg.");
     Names.Projection.Repr.make ind
+      ~proj_relevant
       ~proj_npars:mib.mind_nparams
       ~proj_arg
       labs.(proj_arg)
@@ -316,9 +321,13 @@ let inductive_make_projections ind mib =
   match mib.mind_record with
   | NotRecord | FakeRecord -> None
   | PrimRecord infos ->
-    let _, labs, _, _ = infos.(snd ind) in
+    let _, labs, relevances, _ = infos.(snd ind) in
     let projs = Array.mapi (fun proj_arg lab ->
-        Names.Projection.Repr.make ind ~proj_npars:mib.mind_nparams ~proj_arg lab)
+        let proj_relevant = match relevances.(proj_arg) with
+        | Sorts.Irrelevant -> false
+        | Sorts.Relevant -> true
+        in
+        Names.Projection.Repr.make ind ~proj_relevant ~proj_npars:mib.mind_nparams ~proj_arg lab)
         labs
     in
     Some projs

--- a/kernel/indtypes.ml
+++ b/kernel/indtypes.ml
@@ -454,7 +454,8 @@ let compute_projections (_, i as ind) mib =
       | Name id ->
         let r = na.Context.binder_relevance in
         let lab = Label.of_id id in
-        let kn = Projection.Repr.make ind ~proj_npars:mib.mind_nparams ~proj_arg:i lab in
+        let proj_relevant = match r with Sorts.Irrelevant -> false | Sorts.Relevant -> true in
+        let kn = Projection.Repr.make ind ~proj_relevant ~proj_npars:mib.mind_nparams ~proj_arg:i lab in
         (* from [params, field1,..,fieldj |- t(params,field1,..,fieldj)]
            to [params, x:I, field1,..,fieldj |- t(params,field1,..,fieldj] *)
         let t = liftn 1 j t in

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -615,7 +615,7 @@ module Projection : sig
   module Repr : sig
     type t
 
-    val make : inductive -> proj_npars:int -> proj_arg:int -> Label.t -> t
+    val make : inductive -> proj_npars:int -> proj_arg:int -> proj_relevant:bool -> Label.t -> t
 
     include QNameS with type t := t
 
@@ -627,6 +627,7 @@ module Projection : sig
     val npars : t -> int
     val arg : t -> int
     val label : t -> Label.t
+    val relevant : t -> bool
 
     val equal : t -> t -> bool [@@ocaml.deprecated "Use QProjection.equal"]
     val hash : t -> int [@@ocaml.deprecated "Use QProjection.hash"]

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -1077,7 +1077,8 @@ let fake_match_projection env p =
       let ty = Vars.substl subst (liftn 1 j ty) in
       if arg != proj_arg then
         let lab = match na.binder_name with Name id -> Label.of_id id | Anonymous -> assert false in
-        let kn = Projection.Repr.make ind ~proj_npars:mib.mind_nparams ~proj_arg:arg lab in
+        let proj_relevant = match na.binder_relevance with Sorts.Irrelevant -> false | Sorts.Relevant -> true in
+        let kn = Projection.Repr.make ind ~proj_relevant ~proj_npars:mib.mind_nparams ~proj_arg:arg lab in
         fold (arg+1) (j+1) (mkProj (Projection.make kn false, mkRel 1)::subst) rem
       else
         let p = ([|x|], liftn 1 2 ty) in

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -515,7 +515,8 @@ let compute_projections env (kn, i as ind) =
       match na.binder_name with
       | Name id ->
         let lab = Label.of_id id in
-        let kn = Projection.Repr.make ind ~proj_npars:mib.mind_nparams ~proj_arg lab in
+        let proj_relevant = match na.binder_relevance with Sorts.Irrelevant -> false | Sorts.Relevant -> true in
+        let kn = Projection.Repr.make ind ~proj_relevant ~proj_npars:mib.mind_nparams ~proj_arg lab in
         (* from [params, field1,..,fieldj |- t(params,field1,..,fieldj)]
            to [params, x:I, field1,..,fieldj |- t(params,field1,..,fieldj] *)
         let t = liftn 1 j t in

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -340,8 +340,9 @@ let build_named_proj ~primitive ~flags ~poly ~univs ~uinstance ~kind env paramde
       (* [ccl] is defined in context [params;x:rp] *)
       (* [ccl'] is defined in context [params;x:rp;x:rp] *)
       if primitive then
+        let proj_relevant = match rci with Sorts.Irrelevant -> false | Sorts.Relevant -> true in
         let p = Projection.Repr.make indsp
-            ~proj_npars:mib.mind_nparams ~proj_arg:i (Label.of_id fid) in
+            ~proj_relevant ~proj_npars:mib.mind_nparams ~proj_arg:i (Label.of_id fid) in
         mkProj (Projection.make p true, mkRel 1), Some p
       else
         let ccl' = liftn 1 2 ccl in


### PR DESCRIPTION
This should speed up unimath by a few percents.

Overlays:
- https://github.com/MetaCoq/metacoq/pull/698