### PR TITLE
Import categories for all importing commands and import filters for Require

### DIFF
--- a/dev/ci/user-overlays/15945-SkySkimmer-require-filters.sh
+++ b/dev/ci/user-overlays/15945-SkySkimmer-require-filters.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/SkySkimmer/coq-elpi require-filters 15945

--- a/doc/changelog/07-vernac-commands-and-options/15945-require-filters.rst
+++ b/doc/changelog/07-vernac-commands-and-options/15945-require-filters.rst
@@ -1,0 +1,6 @@
+- **Added:** All commands which can import modules (e.g. ``Module
+  Import M.``, ``Module F (Import X : T).``, ``Require Import M.``,
+  etc) now support :token:`import_categories`. :cmd:`Require Import`
+  and :cmd:`Require Export` also support :token:`filtered_import`.
+  (`#15945 <https://github.com/coq/coq/pull/15945>`_, fixes `#14872
+  <https://github.com/coq/coq/issues/14872>`_, by Gaëtan Gilbert).

--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -59,12 +59,12 @@ The module system provides a way of packaging related elements
 together, as well as a means of massive abstraction.
 
 
-.. cmd:: Module {? {| Import | Export } } @ident {* @module_binder } {? @of_module_type } {? := {+<+ @module_expr_inl } }
+.. cmd:: Module {? {| Import {? @import_categories } | Export {? @import_categories } } } @ident {* @module_binder } {? @of_module_type } {? := {+<+ @module_expr_inl } }
 
    .. insertprodn module_binder module_expr_inl
 
    .. prodn::
-      module_binder ::= ( {? {| Import | Export } } {+ @ident } : @module_type_inl )
+      module_binder ::= ( {? {| Import {? @import_categories } | Export {? @import_categories } } } {+ @ident } : @module_type_inl )
       module_type_inl ::= ! @module_type
       | @module_type {? @functor_app_annot }
       functor_app_annot ::= [ inline at level @natural ]
@@ -188,7 +188,7 @@ are now available through the dot notation.
 
       Use :cmd:`Include` instead.
 
-.. cmd:: Declare Module {? {| Import | Export } } @ident {* @module_binder } : @module_type_inl
+.. cmd:: Declare Module {? {| Import {? @import_categories } | Export {? @import_categories } } } @ident {* @module_binder } : @module_type_inl
 
    Declares a module :token:`ident` of type :token:`module_type_inl`.
 

--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -59,12 +59,12 @@ The module system provides a way of packaging related elements
 together, as well as a means of massive abstraction.
 
 
-.. cmd:: Module {? {| Import {? @import_categories } | Export {? @import_categories } } } @ident {* @module_binder } {? @of_module_type } {? := {+<+ @module_expr_inl } }
+.. cmd:: Module {? {| Import | Export } {? @import_categories } } @ident {* @module_binder } {? @of_module_type } {? := {+<+ @module_expr_inl } }
 
    .. insertprodn module_binder module_expr_inl
 
    .. prodn::
-      module_binder ::= ( {? {| Import {? @import_categories } | Export {? @import_categories } } } {+ @ident } : @module_type_inl )
+      module_binder ::= ( {? {| Import | Export } {? @import_categories } } {+ @ident } : @module_type_inl )
       module_type_inl ::= ! @module_type
       | @module_type {? @functor_app_annot }
       functor_app_annot ::= [ inline at level @natural ]
@@ -188,7 +188,7 @@ are now available through the dot notation.
 
       Use :cmd:`Include` instead.
 
-.. cmd:: Declare Module {? {| Import {? @import_categories } | Export {? @import_categories } } } @ident {* @module_binder } : @module_type_inl
+.. cmd:: Declare Module {? {| Import | Export } {? @import_categories } } @ident {* @module_binder } : @module_type_inl
 
    Declares a module :token:`ident` of type :token:`module_type_inl`.
 

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -520,7 +520,7 @@ Chapter :ref:`thecoqcommands` for documentation on how to compile a file). A com
 file is a particular case of a module called a *library file*.
 
 
-.. cmd:: {? From @dirpath } Require {? {| Import | Export } } {+ @qualid }
+.. cmd:: {? From @dirpath } Require {? {| Import {? @import_categories } | Export {? @import_categories } } } {+ @qualid }
    :name: From … Require; Require; Require Import; Require Export
 
    Loads compiled files into the Coq environment. For each

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -520,7 +520,7 @@ Chapter :ref:`thecoqcommands` for documentation on how to compile a file). A com
 file is a particular case of a module called a *library file*.
 
 
-.. cmd:: {? From @dirpath } Require {? {| Import {? @import_categories } | Export {? @import_categories } } } {+ @filtered_import }
+.. cmd:: {? From @dirpath } Require {? {| Import | Export } {? @import_categories } } {+ @filtered_import }
    :name: From … Require; Require; Require Import; Require Export
 
    Loads compiled files into the Coq environment. For each

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -520,7 +520,7 @@ Chapter :ref:`thecoqcommands` for documentation on how to compile a file). A com
 file is a particular case of a module called a *library file*.
 
 
-.. cmd:: {? From @dirpath } Require {? {| Import {? @import_categories } | Export {? @import_categories } } } {+ @qualid }
+.. cmd:: {? From @dirpath } Require {? {| Import {? @import_categories } | Export {? @import_categories } } } {+ @filtered_import }
    :name: From … Require; Require; Require Import; Require Export
 
    Loads compiled files into the Coq environment. For each

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -750,6 +750,12 @@ gallina_ext: [
 | WITH "From" dirpath "Extra" "Dependency" ne_string OPT [ "as" IDENT ]
 ]
 
+export_token: [
+| REPLACE "Import" OPT import_categories
+| WITH [ "Import" | "Export" ] OPT import_categories
+| DELETE "Export" OPT import_categories
+]
+
 (* lexer stuff *)
 LEFTQMARK: [
 | "?"

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -742,9 +742,9 @@ gallina_ext: [
 | REPLACE "Instance" instance_name ":" term200 hint_info [ ":=" "{" record_declaration "}" | ":=" lconstr | ]
 | WITH "Instance" instance_name ":" type hint_info OPT [ ":=" "{" record_declaration "}" | ":=" lconstr ]
 
-| DELETE "Require" export_token LIST1 global
-| REPLACE "From" global "Require" export_token LIST1 global
-| WITH OPT [ "From" dirpath ] "Require" export_token LIST1 global
+| DELETE "Require" export_token LIST1 filtered_import
+| REPLACE "From" global "Require" export_token LIST1 filtered_import
+| WITH OPT [ "From" dirpath ] "Require" export_token LIST1 filtered_import
 
 | REPLACE "From" global "Extra" "Dependency" ne_string OPT [ "as" IDENT ]
 | WITH "From" dirpath "Extra" "Dependency" ne_string OPT [ "as" IDENT ]

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1085,8 +1085,8 @@ one_import_filter_name: [
 ]
 
 export_token: [
-| "Import"
-| "Export"
+| "Import" OPT import_categories
+| "Export" OPT import_categories
 |
 ]
 

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1042,8 +1042,8 @@ gallina_ext: [
 | "End" identref
 | "Collection" identref ":=" section_subset_expr
 | "From" global "Extra" "Dependency" ne_string OPT [ "as" IDENT ]
-| "Require" export_token LIST1 global
-| "From" global "Require" export_token LIST1 global
+| "Require" export_token LIST1 filtered_import
+| "From" global "Require" export_token LIST1 filtered_import
 | "Import" OPT import_categories LIST1 filtered_import
 | "Export" OPT import_categories LIST1 filtered_import
 | "Include" module_type_inl LIST0 ext_module_expr

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -751,7 +751,7 @@ one_pattern: [
 ]
 
 module_binder: [
-| "(" OPT [ "Import" OPT import_categories | "Export" OPT import_categories ] LIST1 ident ":" module_type_inl ")"
+| "(" OPT ( [ "Import" | "Export" ] OPT import_categories ) LIST1 ident ":" module_type_inl ")"
 ]
 
 module_type_inl: [
@@ -1054,7 +1054,6 @@ command: [
 | "Let" "CoFixpoint" cofix_definition LIST0 ( "with" cofix_definition )
 | "Scheme" OPT ( ident ":=" ) scheme_kind LIST0 ( "with" OPT ( ident ":=" ) scheme_kind )
 | "Scheme" OPT "Boolean" "Equality" "for" reference
-| "Module" OPT [ "Import" OPT import_categories | "Export" OPT import_categories ] ident LIST0 module_binder OPT of_module_type OPT ( ":=" LIST1 module_expr_inl SEP "<+" )
 | "Combined" "Scheme" ident "from" LIST1 ident SEP ","
 | "Register" qualid "as" qualid
 | "Register" "Inline" qualid
@@ -1068,13 +1067,14 @@ command: [
 | [ "Record" | "Structure" ] record_definition
 | "Class" record_definition
 | "Class" ident_decl LIST0 binder OPT [ ":" sort ] ":=" constructor
+| "Module" OPT ( [ "Import" | "Export" ] OPT import_categories ) ident LIST0 module_binder OPT of_module_type OPT ( ":=" LIST1 module_expr_inl SEP "<+" )
 | "Module" "Type" ident LIST0 module_binder LIST0 ( "<:" module_type_inl ) OPT ( ":=" LIST1 module_type_inl SEP "<+" )
-| "Declare" "Module" OPT [ "Import" OPT import_categories | "Export" OPT import_categories ] ident LIST0 module_binder ":" module_type_inl
+| "Declare" "Module" OPT ( [ "Import" | "Export" ] OPT import_categories ) ident LIST0 module_binder ":" module_type_inl
 | "Section" ident
 | "End" ident
 | "Collection" ident ":=" section_var_expr
 | "From" dirpath "Extra" "Dependency" string OPT [ "as" ident ]
-| OPT [ "From" dirpath ] "Require" OPT [ "Import" OPT import_categories | "Export" OPT import_categories ] LIST1 filtered_import
+| OPT [ "From" dirpath ] "Require" OPT ( [ "Import" | "Export" ] OPT import_categories ) LIST1 filtered_import
 | "Import" OPT import_categories LIST1 filtered_import
 | "Export" OPT import_categories LIST1 filtered_import
 | "Include" module_type_inl LIST0 ( "<+" module_expr_inl )

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -751,7 +751,7 @@ one_pattern: [
 ]
 
 module_binder: [
-| "(" OPT [ "Import" | "Export" ] LIST1 ident ":" module_type_inl ")"
+| "(" OPT [ "Import" OPT import_categories | "Export" OPT import_categories ] LIST1 ident ":" module_type_inl ")"
 ]
 
 module_type_inl: [
@@ -1054,6 +1054,7 @@ command: [
 | "Let" "CoFixpoint" cofix_definition LIST0 ( "with" cofix_definition )
 | "Scheme" OPT ( ident ":=" ) scheme_kind LIST0 ( "with" OPT ( ident ":=" ) scheme_kind )
 | "Scheme" OPT "Boolean" "Equality" "for" reference
+| "Module" OPT [ "Import" OPT import_categories | "Export" OPT import_categories ] ident LIST0 module_binder OPT of_module_type OPT ( ":=" LIST1 module_expr_inl SEP "<+" )
 | "Combined" "Scheme" ident "from" LIST1 ident SEP ","
 | "Register" qualid "as" qualid
 | "Register" "Inline" qualid
@@ -1067,14 +1068,13 @@ command: [
 | [ "Record" | "Structure" ] record_definition
 | "Class" record_definition
 | "Class" ident_decl LIST0 binder OPT [ ":" sort ] ":=" constructor
-| "Module" OPT [ "Import" | "Export" ] ident LIST0 module_binder OPT of_module_type OPT ( ":=" LIST1 module_expr_inl SEP "<+" )
 | "Module" "Type" ident LIST0 module_binder LIST0 ( "<:" module_type_inl ) OPT ( ":=" LIST1 module_type_inl SEP "<+" )
-| "Declare" "Module" OPT [ "Import" | "Export" ] ident LIST0 module_binder ":" module_type_inl
+| "Declare" "Module" OPT [ "Import" OPT import_categories | "Export" OPT import_categories ] ident LIST0 module_binder ":" module_type_inl
 | "Section" ident
 | "End" ident
 | "Collection" ident ":=" section_var_expr
 | "From" dirpath "Extra" "Dependency" string OPT [ "as" ident ]
-| OPT [ "From" dirpath ] "Require" OPT [ "Import" | "Export" ] LIST1 qualid
+| OPT [ "From" dirpath ] "Require" OPT [ "Import" OPT import_categories | "Export" OPT import_categories ] LIST1 qualid
 | "Import" OPT import_categories LIST1 filtered_import
 | "Export" OPT import_categories LIST1 filtered_import
 | "Include" module_type_inl LIST0 ( "<+" module_expr_inl )

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1074,7 +1074,7 @@ command: [
 | "End" ident
 | "Collection" ident ":=" section_var_expr
 | "From" dirpath "Extra" "Dependency" string OPT [ "as" ident ]
-| OPT [ "From" dirpath ] "Require" OPT [ "Import" OPT import_categories | "Export" OPT import_categories ] LIST1 qualid
+| OPT [ "From" dirpath ] "Require" OPT [ "Import" OPT import_categories | "Export" OPT import_categories ] LIST1 filtered_import
 | "Import" OPT import_categories LIST1 filtered_import
 | "Export" OPT import_categories LIST1 filtered_import
 | "Include" module_type_inl LIST0 ( "<+" module_expr_inl )

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -16,7 +16,8 @@ open Libnames
 open Libobject
 
 type is_type = bool (* Module Type or just Module *)
-type export = bool option (* None for a Module Type *)
+type export_flag = Export | Import
+type export = export_flag option (* None for a Module Type *)
 
 let make_oname Nametab.{ obj_dir; obj_mp } id =
   Names.(make_path obj_dir id, KerName.make obj_mp (Label.of_id id))

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -17,7 +17,7 @@ open Libobject
 
 type is_type = bool (* Module Type or just Module *)
 type export_flag = Export | Import
-type export = export_flag option (* None for a Module Type *)
+type export = (export_flag * Libobject.open_filter) option (* None for a Module Type *)
 
 let make_oname Nametab.{ obj_dir; obj_mp } id =
   Names.(make_path obj_dir id, KerName.make obj_mp (Label.of_id id))

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -17,7 +17,8 @@ open Names
    mechanism (at a low level; discharge is not known at this step). *)
 
 type is_type = bool (* Module Type or just Module *)
-type export = bool option (* None for a Module Type *)
+type export_flag = Export | Import
+type export = export_flag option (* None for a Module Type *)
 
 val make_oname : Nametab.object_prefix -> Names.Id.t -> Libobject.object_name
 val make_foname : Names.Id.t -> Libobject.object_name

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -18,7 +18,7 @@ open Names
 
 type is_type = bool (* Module Type or just Module *)
 type export_flag = Export | Import
-type export = export_flag option (* None for a Module Type *)
+type export = (export_flag * Libobject.open_filter) option (* None for a Module Type *)
 
 val make_oname : Nametab.object_prefix -> Names.Id.t -> Libobject.object_name
 val make_foname : Names.Id.t -> Libobject.object_name

--- a/sysinit/coqargs.ml
+++ b/sysinit/coqargs.ml
@@ -42,7 +42,7 @@ type option_command =
 
 type injection_command =
   | OptionInjection of (Goptions.option_name * option_command)
-  | RequireInjection of (string * string option * bool option)
+  | RequireInjection of (string * string option * Lib.export_flag option)
   | WarnNoNative of string
   | WarnNativeDeprecated
 
@@ -292,7 +292,7 @@ let parse_args ~usage ~init arglist : t * string list =
       }}
 
     |"-compat" ->
-      add_vo_require oval (get_compat_file (next ())) None (Some false)
+      add_vo_require oval (get_compat_file (next ())) None (Some Lib.Import)
 
     |"-exclude-dir" ->
       System.exclude_directory (next ()); oval
@@ -321,15 +321,15 @@ let parse_args ~usage ~init arglist : t * string list =
     |"-rfrom" ->
       let from = next () in add_vo_require oval (next ()) (Some from) None
 
-    |"-require-import" | "-ri" -> add_vo_require oval (next ()) None (Some false)
+    |"-require-import" | "-ri" -> add_vo_require oval (next ()) None (Some Lib.Import)
 
-    |"-require-export" | "-re" -> add_vo_require oval (next ()) None (Some true)
+    |"-require-export" | "-re" -> add_vo_require oval (next ()) None (Some Lib.Export)
 
     |"-require-import-from" | "-rifrom" ->
-      let from = next () in add_vo_require oval (next ()) (Some from) (Some false)
+      let from = next () in add_vo_require oval (next ()) (Some from) (Some Lib.Import)
 
     |"-require-export-from" | "-refrom" ->
-      let from = next () in add_vo_require oval (next ()) (Some from) (Some true)
+      let from = next () in add_vo_require oval (next ()) (Some from) (Some Lib.Export)
 
     |"-top" ->
       let topname = Libnames.dirpath_of_string (next ()) in
@@ -402,7 +402,7 @@ let parse_args ~usage ~init arglist : t * string list =
       oval
     |"-time" -> { oval with config = { oval.config with time = true }}
     |"-type-in-type" -> set_logic (fun o -> { o with type_in_type = true }) oval
-    |"-unicode" -> add_vo_require oval "Utf8_core" None (Some false)
+    |"-unicode" -> add_vo_require oval "Utf8_core" None (Some Lib.Import)
     |"-where" -> set_query oval PrintWhere
     |"-h"|"-H"|"-?"|"-help"|"--help" -> set_query oval (PrintHelp usage)
     |"-v"|"--version" -> set_query oval PrintVersion
@@ -437,7 +437,7 @@ let parse_args ~usage ~init args =
 (* Startup LoadPath and Modules                                               *)
 (******************************************************************************)
 (* prelude_data == From Coq Require Import Prelude. *)
-let prelude_data = "Prelude", Some "Coq", Some false
+let prelude_data = "Prelude", Some "Coq", Some Lib.Import
 
 let injection_commands opts =
   if opts.pre.load_init then RequireInjection prelude_data :: opts.pre.injections else opts.pre.injections

--- a/sysinit/coqargs.mli
+++ b/sysinit/coqargs.mli
@@ -23,11 +23,11 @@ type option_command =
 type injection_command =
   | OptionInjection of (Goptions.option_name * option_command)
   (** Set flags or options before the initial state is ready. *)
-  | RequireInjection of (string * string option * bool option)
+  | RequireInjection of (string * string option * Lib.export_flag option)
   (** Require libraries before the initial state is
      ready. Parameters follow [Library], that is to say,
      [lib,prefix,import_export] means require library [lib] from
-     optional [prefix] and [import_export] if [Some false/Some true]
+     optional [prefix] and [import_export] if [Some Lib.Import]/[Some Lib.Export]
       is used.  *)
   | WarnNoNative of string
   (** Used so that "-w -native-compiler-disabled -native-compiler yes"

--- a/sysinit/coqinit.ml
+++ b/sysinit/coqinit.ml
@@ -161,7 +161,7 @@ let require_file (dir, from, exp) =
   let mp = Libnames.qualid_of_string dir in
   let mfrom = Option.map Libnames.qualid_of_string from in
   let exp = Option.map (fun e -> e, None) exp in
-  Flags.silently (Vernacentries.vernac_require mfrom exp) [mp]
+  Flags.silently (Vernacentries.vernac_require mfrom exp) [mp,Vernacexpr.ImportAll]
 
 let warn_no_native_compiler =
   CWarnings.create ~name:"native-compiler-disabled" ~category:"native-compiler"

--- a/sysinit/coqinit.ml
+++ b/sysinit/coqinit.ml
@@ -160,6 +160,7 @@ let init_runtime opts =
 let require_file (dir, from, exp) =
   let mp = Libnames.qualid_of_string dir in
   let mfrom = Option.map Libnames.qualid_of_string from in
+  let exp = Option.map (fun e -> e, None) exp in
   Flags.silently (Vernacentries.vernac_require mfrom exp) [mp]
 
 let warn_no_native_compiler =

--- a/test-suite/success/ImportCat.v
+++ b/test-suite/success/ImportCat.v
@@ -61,7 +61,7 @@ End Test2.
 
 Module TestExport.
   Import M(AB).
-  Module X.
+  Module Import(notations) X.
     Module Y.
       Definition bla := 0.
       Coercion AB : A >-> B.
@@ -69,7 +69,6 @@ Module TestExport.
     Export(coercions) Y.
   End X.
 
-  Import(notations) X.
   Fail Check a : B.
 
   Import X.
@@ -96,3 +95,7 @@ Module Notas.
   Lemma foo : False.
   Proof. @@. Abort.
 End Notas.
+
+Require Import(notations) Sumbool.
+Check Sumbool.sumbool_of_bool.
+Fail Check sumbool_of_bool.

--- a/test-suite/success/PartialImport.v
+++ b/test-suite/success/PartialImport.v
@@ -103,3 +103,12 @@ Module FancyFunctor.
   Check eq_refl : x = 0.
 
 End FancyFunctor.
+
+Require Import Sumbool(sumbool_of_bool).
+Check sumbool_of_bool.
+Check Sumbool.bool_eq_rec.
+Fail Check bool_eq_rec.
+
+Fail Require Sumbool(sumbool_of_bool).
+Fail Require Import Sumbool(not_a_real_definition).
+Fail Require Import(notations) Sumbool(sumbool_of_bool).

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -1106,7 +1106,9 @@ let end_library ~output_native_objects dir =
 let import_modules ~export mpl =
   let _,objs = collect_modules mpl (MPmap.empty, []) in
   List.iter (fun (f,o) -> open_object f 1 o) objs;
-  if export then Lib.add_leaf_entry (ExportObject { mpl })
+  match export with
+  | Lib.Import -> ()
+  | Lib.Export -> Lib.add_leaf_entry (ExportObject { mpl })
 
 let import_module f ~export mp =
   import_modules ~export [f,mp]

--- a/vernac/declaremods.mli
+++ b/vernac/declaremods.mli
@@ -44,7 +44,7 @@ val declare_module :
   (Constrexpr.module_ast * inline) list -> ModPath.t
 
 val start_module :
-  Lib.export_flag option -> Id.t ->
+  Lib.export -> Id.t ->
   module_params ->
   (Constrexpr.module_ast * inline) module_signature -> ModPath.t
 

--- a/vernac/declaremods.mli
+++ b/vernac/declaremods.mli
@@ -44,7 +44,7 @@ val declare_module :
   (Constrexpr.module_ast * inline) list -> ModPath.t
 
 val start_module :
-  bool option -> Id.t ->
+  Lib.export_flag option -> Id.t ->
   module_params ->
   (Constrexpr.module_ast * inline) module_signature -> ModPath.t
 
@@ -97,11 +97,11 @@ val append_end_library_hook : (unit -> unit) -> unit
    or when [mp] corresponds to a functor. If [export] is [true], the module is also
    opened every time the module containing it is. *)
 
-val import_module : Libobject.open_filter -> export:bool -> ModPath.t -> unit
+val import_module : Libobject.open_filter -> export:Lib.export_flag -> ModPath.t -> unit
 
 (** Same as [import_module] but for multiple modules, and more optimized than
     iterating [import_module]. *)
-val import_modules : export:bool -> (Libobject.open_filter * ModPath.t) list -> unit
+val import_modules : export:Lib.export_flag -> (Libobject.open_filter * ModPath.t) list -> unit
 
 (** Include  *)
 

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -594,9 +594,9 @@ GRAMMAR EXTEND Gram
         ; qidl = LIST1 global ->
         { VernacRequire (Some ns, export, qidl) }
       | IDENT "Import"; cats = OPT import_categories; qidl = LIST1 filtered_import ->
-        { VernacImport (Import,cats,qidl) }
+        { VernacImport ((Import,cats),qidl) }
       | IDENT "Export"; cats = OPT import_categories; qidl = LIST1 filtered_import ->
-        { VernacImport (Export,cats,qidl) }
+        { VernacImport ((Export,cats),qidl) }
       | IDENT "Include"; e = module_type_inl; l = LIST0 ext_module_expr ->
           { VernacInclude(e::l) }
       | IDENT "Include"; "Type"; e = module_type_inl; l = LIST0 ext_module_type ->
@@ -617,8 +617,8 @@ GRAMMAR EXTEND Gram
     [ [ n = global; etc = OPT [ "("; ".."; ")" -> { () } ] -> { n, Option.has_some etc } ] ]
   ;
   export_token:
-    [ [ IDENT "Import" -> { Some Import }
-      | IDENT "Export" -> { Some Export }
+    [ [ IDENT "Import"; cats = OPT import_categories -> { Some (Import,cats) }
+      | IDENT "Export"; cats = OPT import_categories -> { Some (Export,cats) }
       |  -> { None } ] ]
   ;
   ext_module_type:

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -588,10 +588,10 @@ GRAMMAR EXTEND Gram
           { VernacExtraDependency (ns, f, Option.map Id.of_string id) }
 
       (* Requiring an already compiled module *)
-      | IDENT "Require"; export = export_token; qidl = LIST1 global ->
+      | IDENT "Require"; export = export_token; qidl = LIST1 filtered_import ->
           { VernacRequire (None, export, qidl) }
       | IDENT "From" ; ns = global ; IDENT "Require"; export = export_token
-        ; qidl = LIST1 global ->
+        ; qidl = LIST1 filtered_import ->
         { VernacRequire (Some ns, export, qidl) }
       | IDENT "Import"; cats = OPT import_categories; qidl = LIST1 filtered_import ->
         { VernacImport ((Import,cats),qidl) }

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -594,9 +594,9 @@ GRAMMAR EXTEND Gram
         ; qidl = LIST1 global ->
         { VernacRequire (Some ns, export, qidl) }
       | IDENT "Import"; cats = OPT import_categories; qidl = LIST1 filtered_import ->
-        { VernacImport (false,cats,qidl) }
+        { VernacImport (Import,cats,qidl) }
       | IDENT "Export"; cats = OPT import_categories; qidl = LIST1 filtered_import ->
-        { VernacImport (true,cats,qidl) }
+        { VernacImport (Export,cats,qidl) }
       | IDENT "Include"; e = module_type_inl; l = LIST0 ext_module_expr ->
           { VernacInclude(e::l) }
       | IDENT "Include"; "Type"; e = module_type_inl; l = LIST0 ext_module_type ->
@@ -617,8 +617,8 @@ GRAMMAR EXTEND Gram
     [ [ n = global; etc = OPT [ "("; ".."; ")" -> { () } ] -> { n, Option.has_some etc } ] ]
   ;
   export_token:
-    [ [ IDENT "Import" -> { Some false }
-      | IDENT "Export" -> { Some true }
+    [ [ IDENT "Import" -> { Some Import }
+      | IDENT "Export" -> { Some Export }
       |  -> { None } ] ]
   ;
   ext_module_type:

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -365,17 +365,11 @@ let warn_require_in_module =
     (fun () -> strbrk "Use of “Require” inside a module is fragile." ++ spc() ++
                strbrk "It is not recommended to use this functionality in finished proof scripts.")
 
-let require_library_from_dirpath ~lib_resolver modrefl export =
+let require_library_from_dirpath ~lib_resolver modrefl =
   let needed, contents = List.fold_left (rec_intern_library ~lib_resolver) ([], DPmap.empty) modrefl in
   let needed = List.rev_map (fun dir -> DPmap.find dir contents) needed in
-  let modrefl = List.map fst modrefl in
   if Lib.is_module_or_modtype () then warn_require_in_module ();
-  Lib.add_leaf (in_require needed);
-  Option.iter (fun export ->
-    let mpl = List.map (fun m -> unfiltered, MPfile m) modrefl in
-    (* TODO import filters *)
-    Declaremods.import_modules ~export mpl)
-    export
+  Lib.add_leaf (in_require needed)
 
 (************************************************************************)
 (*s Initializing the compilation of a library. *)

--- a/vernac/library.mli
+++ b/vernac/library.mli
@@ -19,12 +19,10 @@ open Names
 *)
 
 (** {6 ... }
-    Require = load in the environment + open (if the optional boolean
-    is not [None]); mark also for export if the boolean is [Some true] *)
+    Require = load in the environment *)
 val require_library_from_dirpath
   :  lib_resolver:(DirPath.t -> CUnix.physical_path)
   -> (DirPath.t * string) list
-  -> bool option
   -> unit
 
 (** {6 Start the compilation of a library } *)

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -367,9 +367,12 @@ let pr_export_flag = function
   | Export -> keyword "Export"
   | Import -> keyword "Import"
 
+let pr_export_with_cats (export,cats) =
+  pr_export_flag export ++ pr_import_cats cats
+
 let pr_require_token = function
   | Some export ->
-    pr_export_flag export ++ spc ()
+    pr_export_with_cats export ++ spc ()
   | None -> mt()
 
 let pr_module_vardecls pr_c (export,idl,(mty,inl)) =
@@ -952,9 +955,9 @@ let pr_vernac_expr v =
         (from ++ keyword "Require" ++ spc() ++ pr_require_token exp ++
          prlist_with_sep sep pr_module l)
     )
-  | VernacImport (f,cats,l) ->
+  | VernacImport (f,l) ->
     return (
-      pr_export_flag f ++ pr_import_cats cats ++ spc() ++
+      pr_export_with_cats f ++ spc() ++
       prlist_with_sep sep pr_import_module l
     )
   | VernacCanonical q ->

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -953,7 +953,7 @@ let pr_vernac_expr v =
     return (
       hov 2
         (from ++ keyword "Require" ++ spc() ++ pr_require_token exp ++
-         prlist_with_sep sep pr_module l)
+         prlist_with_sep sep pr_import_module l)
     )
   | VernacImport (f,l) ->
     return (

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -363,11 +363,13 @@ let pr_of_module_type prc = function
   | Check mtys ->
     prlist_strict (fun m -> str "<:" ++ pr_module_ast_inl true prc m) mtys
 
+let pr_export_flag = function
+  | Export -> keyword "Export"
+  | Import -> keyword "Import"
+
 let pr_require_token = function
-  | Some true ->
-    keyword "Export" ++ spc ()
-  | Some false ->
-    keyword "Import" ++ spc ()
+  | Some export ->
+    pr_export_flag export ++ spc ()
   | None -> mt()
 
 let pr_module_vardecls pr_c (export,idl,(mty,inl)) =
@@ -952,7 +954,7 @@ let pr_vernac_expr v =
     )
   | VernacImport (f,cats,l) ->
     return (
-      (if f then keyword "Export" else keyword "Import") ++ pr_import_cats cats ++ spc() ++
+      pr_export_flag f ++ pr_import_cats cats ++ spc() ++
       prlist_with_sep sep pr_import_module l
     )
   | VernacCanonical q ->

--- a/vernac/printmod.ml
+++ b/vernac/printmod.ml
@@ -219,7 +219,7 @@ let process_module_binding = Declaremods.process_module_binding
 
 let nametab_register_module_body mp struc =
   (* If [mp] is a globally visible module, we simply import it *)
-  try import_module ~export:false mp
+  try import_module ~export:Lib.Import mp
   with Not_found ->
     (* Otherwise we try to emulate an import by playing with nametab *)
     nametab_register_dir mp;

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1422,7 +1422,7 @@ let warn_require_in_section =
     (fun () -> strbrk "Use of “Require” inside a section is fragile." ++ spc() ++
                strbrk "It is not recommended to use this functionality in finished proof scripts.")
 
-let vernac_require from import qidl =
+let vernac_require from export qidl =
   if Global.sections_are_opened () then warn_require_in_section ();
   let root = match from with
   | None -> None
@@ -1441,7 +1441,12 @@ let vernac_require from import qidl =
   if Dumpglob.dump () then
     List.iter2 (fun {CAst.loc} (dp,_) -> Dumpglob.dump_libref ?loc dp "lib") qidl modrefl;
   let lib_resolver = Loadpath.try_locate_absolute_library in
-  Library.require_library_from_dirpath ~lib_resolver modrefl import
+  Library.require_library_from_dirpath ~lib_resolver modrefl;
+  Option.iter (fun export ->
+    let mpl = List.map (fun (m,_) -> Libobject.unfiltered, MPfile m) modrefl in
+    (* TODO import filters *)
+    Declaremods.import_modules ~export mpl)
+    export
 
 (* Coercions and canonical structures *)
 

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1187,8 +1187,9 @@ let inExportNames = Libobject.declare_object
 
 let import_names ~export m ns =
   let ns = interp_names m ns in
-  if export then Lib.add_leaf (inExportNames ns)
-  else cache_names ns
+  match export with
+  | Lib.Export -> Lib.add_leaf (inExportNames ns)
+  | Lib.Import -> cache_names ns
 
 let vernac_import export cats refl =
   if Option.has_some cats then

--- a/vernac/vernacentries.mli
+++ b/vernac/vernacentries.mli
@@ -17,7 +17,7 @@ val translate_vernac
 
 (** Vernacular require command *)
 val vernac_require :
-  Libnames.qualid option -> Lib.export_flag option -> Libnames.qualid list -> unit
+  Libnames.qualid option -> Vernacexpr.export_with_cats option -> Libnames.qualid list -> unit
 
 (** Hook to dissappear when #8240 is fixed *)
 val interp_redexp_hook : (Environ.env -> Evd.evar_map -> Genredexpr.raw_red_expr ->

--- a/vernac/vernacentries.mli
+++ b/vernac/vernacentries.mli
@@ -17,7 +17,7 @@ val translate_vernac
 
 (** Vernacular require command *)
 val vernac_require :
-  Libnames.qualid option -> bool option -> Libnames.qualid list -> unit
+  Libnames.qualid option -> Lib.export_flag option -> Libnames.qualid list -> unit
 
 (** Hook to dissappear when #8240 is fixed *)
 val interp_redexp_hook : (Environ.env -> Evd.evar_map -> Genredexpr.raw_red_expr ->

--- a/vernac/vernacentries.mli
+++ b/vernac/vernacentries.mli
@@ -15,9 +15,12 @@ val translate_vernac
   -> Vernacexpr.vernac_expr
   -> Vernacextend.typed_vernac
 
-(** Vernacular require command *)
-val vernac_require :
-  Libnames.qualid option -> Vernacexpr.export_with_cats option -> Libnames.qualid list -> unit
+(** Vernacular require command, used by the command line *)
+val vernac_require
+  : Libnames.qualid option
+  -> Vernacexpr.export_with_cats option
+  -> (Libnames.qualid * Vernacexpr.import_filter_expr) list
+  -> unit
 
 (** Hook to dissappear when #8240 is fixed *)
 val interp_redexp_hook : (Environ.env -> Evd.evar_map -> Genredexpr.raw_red_expr ->

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -115,6 +115,8 @@ type import_categories = {
   import_cats : string CAst.t list;
 }
 
+type export_with_cats = export_flag * import_categories option
+
 type infix_flag     = bool (* true = Infix;         false = Notation       *)
 
 type one_import_filter_name = qualid * bool (* import inductive components *)
@@ -278,7 +280,7 @@ type register_kind =
 (** {6 Types concerning the module layer} *)
 
 type module_ast_inl = module_ast * Declaremods.inline
-type module_binder = export_flag option * lident list * module_ast_inl
+type module_binder = export_with_cats option * lident list * module_ast_inl
 
 (** {6 The type of vernacular expressions} *)
 
@@ -366,8 +368,8 @@ type nonrec vernac_expr =
   | VernacEndSegment of lident
   | VernacExtraDependency of qualid * string * Id.t option
   | VernacRequire of
-      qualid option * export_flag option * qualid list
-  | VernacImport of export_flag * import_categories option * (qualid * import_filter_expr) list
+      qualid option * export_with_cats option * qualid list
+  | VernacImport of export_with_cats * (qualid * import_filter_expr) list
   | VernacCanonical of qualid or_by_notation
   | VernacCoercion of qualid or_by_notation *
       (class_rawexpr * class_rawexpr) option
@@ -396,9 +398,9 @@ type nonrec vernac_expr =
   | VernacExistingClass of qualid (* inductive or definition name *)
 
   (* Modules and Module Types *)
-  | VernacDeclareModule of export_flag option * lident *
+  | VernacDeclareModule of export_with_cats option * lident *
       module_binder list * module_ast_inl
-  | VernacDefineModule of export_flag option * lident * module_binder list *
+  | VernacDefineModule of export_with_cats option * lident * module_binder list *
       module_ast_inl Declaremods.module_signature * module_ast_inl list
   | VernacDeclareModuleType of lident *
       module_binder list * module_ast_inl list * module_ast_inl list

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -108,7 +108,7 @@ type verbose_flag   = bool (* true = Verbose;       false = Silent         *)
 type coercion_flag  = bool (* true = AddCoercion    false = NoCoercion     *)
 type instance_flag  = BackInstance | NoInstance
 
-type export_flag    = bool (* true = Export;        false = Import         *)
+type export_flag = Lib.export_flag = Export | Import
 
 type import_categories = {
   negative : bool;
@@ -278,7 +278,7 @@ type register_kind =
 (** {6 Types concerning the module layer} *)
 
 type module_ast_inl = module_ast * Declaremods.inline
-type module_binder = bool option * lident list * module_ast_inl
+type module_binder = export_flag option * lident list * module_ast_inl
 
 (** {6 The type of vernacular expressions} *)
 
@@ -396,9 +396,9 @@ type nonrec vernac_expr =
   | VernacExistingClass of qualid (* inductive or definition name *)
 
   (* Modules and Module Types *)
-  | VernacDeclareModule of bool option * lident *
+  | VernacDeclareModule of export_flag option * lident *
       module_binder list * module_ast_inl
-  | VernacDefineModule of bool option * lident * module_binder list *
+  | VernacDefineModule of export_flag option * lident * module_binder list *
       module_ast_inl Declaremods.module_signature * module_ast_inl list
   | VernacDeclareModuleType of lident *
       module_binder list * module_ast_inl list * module_ast_inl list

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -368,7 +368,7 @@ type nonrec vernac_expr =
   | VernacEndSegment of lident
   | VernacExtraDependency of qualid * string * Id.t option
   | VernacRequire of
-      qualid option * export_with_cats option * qualid list
+      qualid option * export_with_cats option * (qualid * import_filter_expr) list
   | VernacImport of export_with_cats * (qualid * import_filter_expr) list
   | VernacCanonical of qualid or_by_notation
   | VernacCoercion of qualid or_by_notation *


### PR DESCRIPTION
(there is no sane syntax for import filters with most other commands, eg `Module Import M(names).` looks too much like a functor. Maybe we could do `Module F (Import X(names)).` but it doesn't seem worth the bother.)

Overlays:
- https://github.com/Lysxia/coq-simple-io/pull/52
- https://github.com/LPCIC/coq-elpi/pull/364