### PR TITLE
CI: Install coq-native in pkg:opam job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -330,6 +330,7 @@ pkg:opam:
   interruptible: true
   # OPAM will build out-of-tree so no point in importing artifacts
   script:
+    - opam install coq-native
     - opam pin add --kind=path coq-core.dev .
     - opam pin add --kind=path coq-stdlib.dev .
     - opam pin add --kind=path coqide-server.dev .


### PR DESCRIPTION
This failed in a recent bench attempt so we should test it.
