### PR TITLE
Declareops.inductive_make_projection doesn't return option

### DIFF
--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -296,13 +296,16 @@ let inductive_is_cumulative mib =
 
 let inductive_make_projection ind mib ~proj_arg =
   match mib.mind_record with
-  | NotRecord | FakeRecord -> None
+  | NotRecord | FakeRecord ->
+    CErrors.anomaly Pp.(str "inductive_make_projection: not a primitive record.")
   | PrimRecord infos ->
     let _, labs, _, _ = infos.(snd ind) in
-    Some (Names.Projection.Repr.make ind
-            ~proj_npars:mib.mind_nparams
-            ~proj_arg
-            labs.(proj_arg))
+    if proj_arg < 0 || Array.length labs <= proj_arg
+    then CErrors.anomaly Pp.(str "inductive_make_projection: invalid proj_arg.");
+    Names.Projection.Repr.make ind
+      ~proj_npars:mib.mind_nparams
+      ~proj_arg
+      labs.(proj_arg)
 
 let inductive_make_projections ind mib =
   match mib.mind_record with

--- a/kernel/declareops.mli
+++ b/kernel/declareops.mli
@@ -68,8 +68,10 @@ val inductive_is_polymorphic : mutual_inductive_body -> bool
 (** Is the inductive cumulative? *)
 val inductive_is_cumulative : mutual_inductive_body -> bool
 
+(** Anomaly when not a primitive record or invalid proj_arg *)
 val inductive_make_projection : Names.inductive -> mutual_inductive_body -> proj_arg:int ->
-  Names.Projection.Repr.t option
+  Names.Projection.Repr.t
+
 val inductive_make_projections : Names.inductive -> mutual_inductive_body ->
   Names.Projection.Repr.t array option
 

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -255,7 +255,9 @@ val is_primitive_type : env -> Constant.t -> bool
 (** Checks that the number of parameters is correct. *)
 val lookup_projection : Names.Projection.t -> env -> types
 
-val get_projection : env -> inductive -> proj_arg:int -> Names.Projection.Repr.t option
+(** Anomaly when not a primitive record or invalid proj_arg. *)
+val get_projection : env -> inductive -> proj_arg:int -> Names.Projection.Repr.t
+
 val get_projections : env -> inductive -> Names.Projection.Repr.t array option
 
 (** {5 Inductive types } *)

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -181,12 +181,8 @@ let branch_of_switch lvl ans bs =
   Array.init (Array.length tbl) branch
 
 let get_proj env (ind, proj_arg) =
-  let mib = Environ.lookup_mind (fst ind) env in
-  match Declareops.inductive_make_projection ind mib ~proj_arg with
-  | None ->
-    CErrors.anomaly (Pp.strbrk "Return type is not a primitive record")
-  | Some p ->
-    Projection.make p true
+  let p = Environ.get_projection env ind ~proj_arg in
+  Projection.make p true
 
 let rec nf_val env sigma v typ =
   match kind_of_value v with

--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -303,7 +303,7 @@ and nf_stk ?from:(from=0) env sigma c t stk  =
       let ty = Vars.subst_instance_constr (EConstr.Unsafe.to_instance u) tys.(p) in
       substl (c :: List.rev_map EConstr.Unsafe.to_constr pars) ty
     in
-    let p = Option.get @@ Declareops.inductive_make_projection ind mib ~proj_arg:p in
+    let p = Declareops.inductive_make_projection ind mib ~proj_arg:p in
     let p = Projection.make p true in
     nf_stk env sigma (mkProj (p, c)) ty stk
 


### PR DESCRIPTION
This is how it's always used, and it was raising on invalid proj_arg already.
