### PR TITLE
Port deprecated Format code in recent versions of OCaml.

### DIFF
--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -197,9 +197,9 @@ let pp_with ft pp =
     | Ppcmd_print_break(m,n)  -> pp_print_break ft m n
     | Ppcmd_force_newline     -> pp_force_newline ft ()
     | Ppcmd_comment coms      -> List.iter (pr_com ft) coms
-    | Ppcmd_tag(tag, s)       -> pp_open_tag  ft tag [@warning "-3"];
+    | Ppcmd_tag(tag, s)       -> pp_open_stag ft (String_tag tag);
                                  pp_cmd s;
-                                 pp_close_tag ft () [@warning "-3"]
+                                 pp_close_stag ft ()
   in
   pp_cmd pp
 


### PR DESCRIPTION
After the bump to 4.09 we can now use the new Format API, in order to stop relying on an API that is deprecated in later 4.x releases and removed in OCaml 5.0.

Based on subpatches from #15494.