### PR TITLE
Forbid template univ poly for mutual inductives

### DIFF
--- a/doc/changelog/01-kernel/15965-no-mutual-template.rst
+++ b/doc/changelog/01-kernel/15965-no-mutual-template.rst
@@ -1,0 +1,4 @@
+- **Removed:**
+  :ref:`Template-polymorphism` is now forbidden for mutual inductive types
+  (`#15965 <https://github.com/coq/coq/pull/15965>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/language/core/inductive.rst
+++ b/doc/sphinx/language/core/inductive.rst
@@ -1128,8 +1128,8 @@ Conversion is preserved as any (partial) instance :math:`I_j~q_1 … q_r` or
    inductive type to be template polymorphic, even if the :flag:`Auto
    Template Polymorphism` flag is on.
 
-In practice, the rule **Ind-Family** is used by Coq only when all the
-inductive types of the inductive definition are declared with an arity
+In practice, the rule **Ind-Family** is used by Coq only when there is only one
+inductive type in the inductive definition and it is declared with an arity
 whose sort is in the Type hierarchy. Then, the polymorphism is over
 the parameters whose type is an arity of sort in the Type hierarchy.
 The sorts :math:`s_j` are chosen canonically so that each :math:`s_j` is minimal with

--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -278,24 +278,11 @@ let get_template univs params data =
   match univs with
   | Polymorphic_ind_entry _ | Monomorphic_ind_entry -> None
   | Template_ind_entry ctx ->
-    (* For each type in the block, compute potential template parameters *)
-    let params = List.map (fun ((arity, _), (_, splayed_lc), _) -> get_param_levels ctx params arity splayed_lc) data in
-    (* Pick the lower bound of template parameters. Note that in particular, if
-       one of the the inductive types from the block is Prop-valued, then no
-       parameters are template. *)
-    let fold min params =
-      let map u v = match u, v with
-        | (None, _) | (_, None) -> None
-        | Some u, Some v ->
-          let () = assert (Univ.Level.equal u v) in
-          Some u
-      in
-      List.map2 map min params
+    let arity, splayed_lc = match data with
+      | [ (arity, _), (_, splayed_lc), _ ] -> arity, splayed_lc
+      | _ -> CErrors.user_err Pp.(str "Template-polymorphism not allowed with mutual inductives.")
     in
-    let params = match params with
-      | [] -> assert false
-      | hd :: rem -> List.fold_left fold hd rem
-    in
+    let params = get_param_levels ctx params arity splayed_lc in
     Some { template_param_levels = params; template_context = ctx }
 
 let abstract_packets usubst ((arity,lc),(indices,splayed_lc),univ_info) =

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -651,7 +651,11 @@ let interp_structure_core ~cumulative finite ~univs ~variances ~primitive_proj i
       mind_entry_lc = [type_constructor] }
   in
   let blocks = List.mapi mk_block data in
-  let template = List.for_all (check_template ~template ~univs ~poly ~params) data in
+  let template = match data, fst template with
+    | [data], _ -> check_template ~template ~univs ~poly ~params data
+    | _, Some true -> user_err Pp.(str "Template-polymorphism not allowed with mutual records.")
+    | _ -> false
+  in
   let primitive =
     primitive_proj  &&
     List.for_all (fun { Data.rdata = { DataR.fields; _ }; _ } -> List.exists is_local_assum fields) data


### PR DESCRIPTION
For now just the higher layer change, we can put a kernel check if CI
is OK
