### PR TITLE
Avoid CoqIDE crash for #15873 (but not a full fix)

### DIFF
--- a/ide/coqide/coqOps.ml
+++ b/ide/coqide/coqOps.ml
@@ -665,7 +665,8 @@ object(self)
   method private fill_command_queue until queue =
     let topstack =
       if Doc.focused document then fst (Doc.context document) else [] in
-    let rec loop n iter =
+    let rec loop n iter prev_start =
+      (* prev_start is a workaround to avoid an endless loop.  See #15873/#15984 *)
       match Sentence.find buffer iter with
       | None -> ()
       | Some (start, stop) ->
@@ -677,7 +678,7 @@ object(self)
             stop#equal (buffer#get_iter_at_mark s.stop)) topstack
         then begin
           Queue.push (`Skip (start, stop)) queue;
-          loop n stop
+          loop n stop start#offset
         end else begin
           buffer#apply_tag Tags.Script.to_process ~start ~stop;
           let sentence =
@@ -686,10 +687,10 @@ object(self)
               ~stop:(`MARK (buffer#create_mark stop))
               [] in
           Queue.push (`Sentence sentence) queue;
-          if not stop#is_end then loop (succ n) stop
+          if start#offset <> prev_start && not stop#is_end then loop (succ n) stop start#offset
         end
     in
-    loop 0 self#get_start_of_input
+    loop 0 self#get_start_of_input (-1)
 
   method private discard_command_queue queue =
     while not (Queue.is_empty queue) do


### PR DESCRIPTION
An improvement but not a full fix.  With this change, CoqIDE no longer goes into an endless loop.  However, it still doesn't parse the `idtac ...` correctly.  You have to restart Coq to get it to parse.  (It's not sufficient just to navigate backward a few tactics.)

IMHO the `idtac...` syntax was an unfortunate choice.  While it's probably not used very often, it requires special case handling in several places.  The user can get the same effect with `Ltac x := auto` and putting `x.` after each line, which is likely clearer to readers and one less quirky feature to learn.

Ref: #15873
