### PR TITLE
[stdlib] [Permutation] constructive pigeonhole principle for lists

### DIFF
--- a/doc/changelog/10-standard-library/15986-pigeonhole.rst
+++ b/doc/changelog/10-standard-library/15986-pigeonhole.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  lemmas :g:`Permutation_incl_cons_inv_r`, :g:`Permutation_pigeonhole`, :g:`Permutation_pigeonhole_rel` to ``Permutation.v``, and :g:`Forall2_cons_iff`, :g:`Forall2_length`, :g:`Forall2_impl`, :g:`Forall2_flip`, :g:`Forall_Exists_exists_Forall2` to ``List.v``
+  (`#15986 <https://github.com/coq/coq/pull/15986>`_,
+  by Andrej Dudenhefner, with help from Dominique Larchey-Wendling and Olivier Laurent).

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -3050,6 +3050,22 @@ Section Forall2.
   Theorem Forall2_refl : Forall2 [] [].
   Proof. intros; apply Forall2_nil. Qed.
 
+  Theorem Forall2_cons_iff : forall x y l l',
+    Forall2 (x :: l) (y :: l') <-> R x y /\ Forall2 l l'.
+  Proof.
+    intros x y l l'. split.
+    - intros H. now inversion H.
+    - intros [? ?]. now constructor.
+  Qed.
+
+  Theorem Forall2_length : forall l l',
+    Forall2 l l' -> length l = length l'.
+  Proof.
+    intros l. induction l as [|x l IH]; intros l' Hl'; inversion Hl'.
+    - reflexivity.
+    - cbn. f_equal. now apply IH.
+  Qed.
+
   Theorem Forall2_app_inv_l : forall l1 l2 l',
     Forall2 (l1 ++ l2) l' ->
     exists l1' l2', Forall2 l1 l1' /\ Forall2 l2 l2' /\ l' = l1' ++ l2'.
@@ -3077,7 +3093,30 @@ Section Forall2.
   Proof.
     intros l1 l2 l1' l2' H H0. induction l1 in l1', H, H0 |- *; inversion H; subst; simpl; auto.
   Qed.
+
+  Theorem Forall_Exists_exists_Forall2 l1 l2 :
+    Forall (fun a => Exists (R a) l2) l1 ->
+    exists l2', Forall2 l1 l2' /\ incl l2' l2.
+  Proof.
+    induction l1 as [|a l1 IH].
+    - intros _. now exists [].
+    - intros [[b [Hb Hab]] %Exists_exists Hl1l2] %Forall_cons_iff.
+      destruct (IH Hl1l2) as [l2' [Hl1l2' Hl2'l2]].
+      exists (b :: l2'). now eauto using incl_cons.
+  Qed.
 End Forall2.
+
+Lemma Forall2_impl (A B : Type) (R1 R2 : A -> B -> Prop) : (forall a b, R1 a b -> R2 a b) ->
+  forall l1 l2, Forall2 R1 l1 l2 -> Forall2 R2 l1 l2.
+Proof.
+  intros HPQ l1 l2 HPl1l2. induction HPl1l2; now eauto using Forall2.
+Qed.
+
+Lemma Forall2_flip (A B : Type) (R : A -> B -> Prop) l1 l2 :
+  Forall2 R l1 l2 -> Forall2 (fun b a => R a b) l2 l1.
+Proof.
+  intros HPl1l2. induction HPl1l2; now eauto using Forall2.
+Qed.
 
 #[global]
 Hint Constructors Forall2 : core.


### PR DESCRIPTION
Kind: feature

This PR adds the constructive pigeonhole principle for lists:
```coq
Lemma Permutation_pigeonhole_rel (R : B -> A -> Prop) (l1 : list B) (l2 : list A) :
  Forall (fun (b : B) => Exists (R b) l2) l1 ->
  length l2 < length l1 ->
  exists (b b' : B) (l3 : list B), Permutation l1 (b :: b' :: l3) /\ exists a, In a l2 /\ R b a /\ R b' a.
```

My motivation is the constructive computability theory, where this lemma is quite useful.
Note: the proof does not require excluded middle, decidable equality, or decidable `R` on the underlying types.
Other formulations in the stdlib are
- `Pigeonhole_principle` from `Sets.Image`, which requires classical logic
- `NoDup_Permutation_bis` from `Sorting.Permutation`, which is dual. It is not sufficient because contrapositive `not (Nodup l)` is constructively too weak.

Lemmas added to `Permutation.v`
- `Permutation_incl_cons_inv_r`
- `Permutation_pigeonhole`
- `Permutation_pigeonhole_rel`

Lemmas added to `List.v`
- `Forall2_cons_iff`
- `Forall2_length`

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.

<!-- If this breaks external libraries or plugins in CI: 
- [ ] Opened **overlay** pull requests. -->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
-->