### PR TITLE
[CI] Test coq-native separately from split packages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -322,7 +322,26 @@ lint:
     OPAM_SWITCH: "edge"
     OPAM_VARIANT: "+flambda"
 
-pkg:opam:
+pkg:opam-native:
+  stage: build
+  except:
+    variables:
+      - $ONLY_WINDOWS == "true"
+  interruptible: true
+  # OPAM will build out-of-tree so no point in importing artifacts
+  script:
+    - opam install coq-native
+    - opam pin add --locked=docker --kind=path coq.dev .
+    # Check that native works
+    - echo "Definition f x := x + x." > test_native.v
+    - coqc -native-compiler yes test_native.v
+    - test -f .coq-native/Ntest_native.cmxs
+  variables:
+    OPAM_SWITCH: "edge"
+    OPAM_VARIANT: "+flambda"
+  only: *full-ci
+
+pkg:opam-split:
   stage: build
   except:
     variables:


### PR DESCRIPTION
This tests OPAM with the coq-native package and the single coq package.
The split packages (coq-core and coq-stdlib) are not tested with coq-native as this is currently broken (c.f. https://github.com/coq/coq/pull/15951 )
https://github.com/coq/coq/pull/15560 aims, among many other things, at fixing the split packages