### PR TITLE
[mltop] Fix bug storing legacy module info in Summary

### DIFF
--- a/dev/doc/changes.md
+++ b/dev/doc/changes.md
@@ -1,3 +1,23 @@
+## Changes between Coq 8.15 and Coq 8.16
+
+### Plugin Interface
+
+Plugins are now identified by a findlib library name of the form
+`pkg.lib`. This way, plugins can depend on other libraries and Coq can
+properly load the required dependencies.
+
+It is necessary to adjust plugin code:
+
+- `.mlg` files must now use `DECLARE PLUGIN "pkg.lib"` instead of
+  `DECLARE PLUGIN "library_name"`.
+
+- `.v` files should use `Declare ML Module "pkg.lib"`, or, if using
+  Dune, `Declare ML Module "library_name:pkg.lib"` until Dune is
+  adapted.
+
+You must also provide the corresponding `META` file if you build
+system doesn't generate it automatically.
+
 ## Changes between Coq 8.14 and Coq 8.15
 
 ### XML protocol

--- a/library/summary.ml
+++ b/library/summary.ml
@@ -36,7 +36,7 @@ type 'a summary_declaration = {
 module Decl = struct type 'a t = 'a summary_declaration end
 module DynMap = Dyn.Map(Decl)
 
-type ml_modules = (bool * string) list
+type ml_modules = (string option * string) list
 
 let sum_mod : ml_modules summary_declaration option ref = ref None
 let sum_map = ref DynMap.empty

--- a/library/summary.mli
+++ b/library/summary.mli
@@ -77,8 +77,11 @@ end
 (** Special summary for ML modules.  This summary entry is special
     because its unfreeze may load ML code and hence add summary
     entries.  Thus is has to be recognizable, and handled properly.
+
+    The args correspond to Mltop.PluginSpec.t , that is to say,
+    the optional legacy plugin name, and the findlib name for the plugin.
    *)
-val declare_ml_modules_summary : (bool * string) list summary_declaration -> unit
+val declare_ml_modules_summary : (string option * string) list summary_declaration -> unit
 
 (** For global tables registered statically before the end of coqtop
     launch, the following empty [init_function] could be used. *)

--- a/test-suite/coq-makefile/coqdoc1/run.sh
+++ b/test-suite/coq-makefile/coqdoc1/run.sh
@@ -28,6 +28,7 @@ sort -u > desired <<EOT
 ./test/test.glob
 ./test/test.v
 ./test/test.vo
+./test/test_plugin.cmxs
 ./test/sub
 ./test/sub/.coq-native
 ./test/sub/.coq-native/Ntest_sub_testsub.cmi

--- a/test-suite/coq-makefile/coqdoc2/run.sh
+++ b/test-suite/coq-makefile/coqdoc2/run.sh
@@ -26,6 +26,7 @@ sort -u > desired <<EOT
 ./test/test.glob
 ./test/test.v
 ./test/test.vo
+./test/test_plugin.cmxs
 ./test/sub
 ./test/sub/.coq-native
 ./test/sub/.coq-native/Ntest_sub_testsub.cmi

--- a/test-suite/coq-makefile/mlpack1/run.sh
+++ b/test-suite/coq-makefile/mlpack1/run.sh
@@ -19,6 +19,7 @@ sort > desired <<EOT
 ./test/test.glob
 ./test/test.v
 ./test/test.vo
+./test/test_plugin.cmxs
 EOT
 (coqc -config | grep -q "NATIVE_COMPILER_DEFAULT=yes") || sed -i.bak '/\.coq-native/d' desired
 diff -u desired actual

--- a/test-suite/coq-makefile/mlpack2/run.sh
+++ b/test-suite/coq-makefile/mlpack2/run.sh
@@ -19,6 +19,7 @@ sort > desired <<EOT
 ./test/test.glob
 ./test/test.v
 ./test/test.vo
+./test/test_plugin.cmxs
 EOT
 (coqc -config | grep -q "NATIVE_COMPILER_DEFAULT=yes") || sed -i.bak '/\.coq-native/d' desired
 diff -u desired actual

--- a/test-suite/coq-makefile/multiroot/run.sh
+++ b/test-suite/coq-makefile/multiroot/run.sh
@@ -27,6 +27,7 @@ sort > desired <<EOT
 ./test/test.glob
 ./test/test.v
 ./test/test.vo
+./test/test_plugin.cmxs
 ./test2
 ./test2/.coq-native
 ./test2/.coq-native/Ntest2_test.cmi

--- a/test-suite/coq-makefile/native1/run.sh
+++ b/test-suite/coq-makefile/native1/run.sh
@@ -26,6 +26,7 @@ sort > desired <<EOT
 ./test/test.glob
 ./test/test.v
 ./test/test.vo
+./test/test_plugin.cmxs
 ./test/.coq-native
 ./test/.coq-native/Ntest_test.cmi
 ./test/.coq-native/Ntest_test.cmx

--- a/test-suite/coq-makefile/native2/run.sh
+++ b/test-suite/coq-makefile/native2/run.sh
@@ -26,6 +26,7 @@ sort > desired <<EOT
 ./test/test.glob
 ./test/test.v
 ./test/test.vo
+./test/test_plugin.cmxs
 ./test/.coq-native
 ./test/.coq-native/Ntest_test.cmi
 ./test/.coq-native/Ntest_test.cmx

--- a/test-suite/coq-makefile/native3/run.sh
+++ b/test-suite/coq-makefile/native3/run.sh
@@ -26,6 +26,7 @@ sort > desired <<EOT
 ./test/test.glob
 ./test/test.v
 ./test/test.vo
+./test/test_plugin.cmxs
 ./test/.coq-native
 ./test/.coq-native/Ntest_test.cmi
 ./test/.coq-native/Ntest_test.cmx

--- a/test-suite/coq-makefile/native4/run.sh
+++ b/test-suite/coq-makefile/native4/run.sh
@@ -29,6 +29,7 @@ sort > desired <<EOT
 ./test/test.glob
 ./test/test.v
 ./test/test.vo
+./test/test_plugin.cmxs
 ./test/.coq-native
 ./test/.coq-native/Ntest_test.cmi
 ./test/.coq-native/Ntest_test.cmx

--- a/test-suite/coq-makefile/plugin1/run.sh
+++ b/test-suite/coq-makefile/plugin1/run.sh
@@ -20,6 +20,7 @@ sort > desired <<EOT
 ./test/test.glob
 ./test/test.v
 ./test/test.vo
+./test/test_plugin.cmxs
 EOT
 (coqc -config | grep -q "NATIVE_COMPILER_DEFAULT=yes") || sed -i.bak '/\.coq-native/d' desired
 diff -u desired actual

--- a/test-suite/coq-makefile/plugin2/run.sh
+++ b/test-suite/coq-makefile/plugin2/run.sh
@@ -20,6 +20,7 @@ sort > desired <<EOT
 ./test/test.glob
 ./test/test.v
 ./test/test.vo
+./test/test_plugin.cmxs
 EOT
 (coqc -config | grep -q "NATIVE_COMPILER_DEFAULT=yes") || sed -i.bak '/\.coq-native/d' desired
 diff -u desired actual

--- a/test-suite/coq-makefile/plugin3/run.sh
+++ b/test-suite/coq-makefile/plugin3/run.sh
@@ -20,6 +20,7 @@ sort > desired <<EOT
 ./test/test.glob
 ./test/test.v
 ./test/test.vo
+./test/test_plugin.cmxs
 EOT
 (coqc -config | grep -q "NATIVE_COMPILER_DEFAULT=yes") || sed -i.bak '/\.coq-native/d' desired
 diff -u desired actual

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -389,7 +389,8 @@ FILESTOINSTALL = \
 	$(VOFILES) \
 	$(VFILES) \
 	$(GLOBFILES) \
-	$(NATIVEFILES)
+	$(NATIVEFILES) \
+	$(CMXSFILES)		# to be removed when we remove legacy loading
 FINDLIBFILESTOINSTALL = \
 	$(CMIFILESTOINSTALL)
 ifeq '$(HASNATDYNLINK)' 'true'
@@ -653,6 +654,7 @@ uninstall::
 	 echo RMDIR "$(COQLIBINSTALL)/$$df/" &&\
 	 (rmdir "$(COQLIBINSTALL)/$$df/" 2>/dev/null || true); \
 	done
+
 .PHONY: uninstall
 
 uninstall-doc::

--- a/vernac/mltop.ml
+++ b/vernac/mltop.ml
@@ -8,7 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open CErrors
 open Util
 open Pp
 
@@ -22,44 +21,150 @@ open Pp
    \end{itemize}
 
    How to build an ML module interface with these functions.
+
    The idea is that the ML directory path is like the Coq directory
-   path.  So we can maintain the two in parallel.
+   path, so we can maintain the two in parallel, though nowaways we
+   use findlib to resolve plugins too.
+
    In the same way, we can use the "ml_env" as a kind of ML
    environment, which we freeze, unfreeze, and add things to just like
    to the other environments.
+
    Finally, we can create an object which is an ML module, and require
    that the "caching" of the ML module cause the loading of the
    associated ML file, if that file has not been yet loaded.  Of
    course, the problem is how to record dependencies between ML
    modules.
+
    (I do not know of a solution to this problem, other than to
    put all the needed names into the ML Module object.) *)
 
 
-(* This path is where we look for .cmo *)
+(* This path is where we look for .cmo/.cmxs using the legacy method *)
 let coq_mlpath_copy = ref [Sys.getcwd ()]
 let keep_copy_mlpath path =
   let cpath = CUnix.canonical_path_name path in
-  let filter path' = not (String.equal cpath path')
-  in
+  let filter path' = not (String.equal cpath path') in
   coq_mlpath_copy := cpath :: List.filter filter !coq_mlpath_copy
 
-type plugin =
-| Legacy of { obj_file_path : string; fl_public_name : string }
-| Findlib of { fl_public_name : string }
+module Fl_internals = struct
 
-let pp_plugin = function
-| Legacy { obj_file_path; _ } ->
-    Filename.(chop_extension @@ basename obj_file_path) ^ " (using legacy method)"
-| Findlib { fl_public_name } -> fl_public_name
+  (* Check that [m] is a findlib library name *)
+  let validate_lib_name m = String.index_opt m '.' <> None
 
-let canonical_plugin_name = function
-  | Findlib { fl_public_name }
-  | Legacy { fl_public_name } -> fl_public_name
+  (* Fl_split.in_words is not exported *)
+  let fl_split_in_words s =
+    (* splits s in words separated by commas and/or whitespace *)
+    let l = String.length s in
+    let rec split i j =
+      if j < l then
+        match s.[j] with
+        | (' '|'\t'|'\n'|'\r'|',') ->
+          if i<j then (String.sub s i (j-i)) :: (split (j+1) (j+1))
+          else split (j+1) (j+1)
+        |	_ ->
+          split i (j+1)
+      else
+      if i<j then [ String.sub s i (j-i) ] else []
+    in
+    split 0 0
+
+  (* simulate what fl_dynload does *)
+  let fl_find_plugins lib =
+    let base = Findlib.package_directory lib in
+    let preds = Findlib.recorded_predicates () in
+    let archive = try Findlib.package_property preds lib "plugin"
+      with Not_found ->
+      try fst (Findlib.package_property_2 ("plugin"::preds) lib "archive")
+      with Not_found -> ""
+    in
+    fl_split_in_words archive |> List.map (Findlib.resolve_path ~base)
+
+end
+
+module PluginSpec : sig
+
+  type t
+
+  val make : lib:string -> t
+  val make_legacy : file:string -> lib:string -> t
+
+  val repr : t -> string option * string
+  val unrepr : string option * string -> t
+
+  val load : t -> unit
+
+  val digest : t -> Digest.t list
+
+  val pp : t -> string
+
+  module Set : CSet.S with type elt = t
+  module Map : CMap.ExtS with type key = t and module Set := Set
+
+end = struct
+
+  (* Adds the corresponding extension .cmo/.cma or .cmxs. Dune and
+     coq_makefile byte plugins do differ in the choice of extension,
+     hence the probing. *)
+  let select_plugin_version base =
+    if Sys.(backend_type = Native)
+    then base ^ ".cmxs"
+    else
+      let name = base ^ ".cmo" in
+      if System.is_in_path !coq_mlpath_copy name
+      then name else base ^ ".cma"
+
+  type t = { file : string option; lib : string }
+
+  let make ~lib =
+    { file = None; lib }
+
+  let make_legacy ~file ~lib =
+    { file = Some file; lib }
+
+  let load = function
+    | { file = None; lib } ->
+      Fl_dynload.load_packages [lib]
+    | { file = Some file; lib } ->
+      let file = select_plugin_version file in
+      let _, gname = System.find_file_in_path ~warn:false !coq_mlpath_copy file in
+      Dynlink.loadfile gname;
+      Findlib.(record_package Record_load) lib
+
+  let digest s =
+    match s with
+    | { file = Some file; _ } ->
+      let file = select_plugin_version file in
+      let _, gname = System.find_file_in_path ~warn:false !coq_mlpath_copy file in
+      [Digest.file gname]
+    | { file = None; lib } ->
+      let plugins = Fl_internals.fl_find_plugins lib in
+      List.map Digest.file plugins
+
+  let repr { file; lib } = ( file, lib )
+  let unrepr ( file, lib ) = { file; lib }
+
+  let compare { lib = l1; _ } { lib = l2; _ } = String.compare l1 l2
+
+  let pp = function
+    | { file = None; lib } -> lib
+    | { file = Some file; lib } ->
+      let file = select_plugin_version file in
+      Filename.basename file ^ " (using legacy method)"
+
+  module Self = struct
+      type nonrec t = t
+      let compare = compare
+    end
+
+  module Set = CSet.Make(Self)
+  module Map = CMap.Make(Self)
+
+end
 
 (* If there is a toplevel under Coq *)
 type toplevel = {
-  load_obj : plugin -> unit;
+  load_obj : PluginSpec.t -> unit;
   add_dir  : string -> unit;
   ml_loop  : unit -> unit }
 
@@ -75,8 +180,9 @@ let load = ref WithoutTop
 (* Sets and initializes a toplevel (if any) *)
 let set_top toplevel = load :=
   WithTop toplevel;
-  Nativelib.load_obj := (fun x ->
-    toplevel.load_obj (Legacy { obj_file_path = x; fl_public_name = x }))
+  Nativelib.load_obj := (fun file ->
+      let ps = PluginSpec.make_legacy ~file ~lib:file in
+      toplevel.load_obj ps)
 
 (* Removes the toplevel (if any) *)
 let remove () =
@@ -100,6 +206,14 @@ let ocaml_toploop () =
 
 (* Dynamic loading of .cmo/.cma *)
 
+(* We register Coq Errors with the global printer here as they will be
+   printed if Dynlink.loadfile raises UserError in the module
+   intializers. We should make this more principled tho. *)
+let _ = Printexc.register_printer (function
+    | CErrors.UserError msg ->
+      Some (Format.asprintf "@[%a@]" Pp.pp_with msg)
+    | _ -> None)
+
 (* We register errors at least for Dynlink, it is possible to do so Symtable
    too, as we do in the bytecode init code.
 *)
@@ -118,99 +232,50 @@ let _ = CErrors.register_handler (function
 
 module Legacy_code_waiting_for_dune_release = struct
 
-(* convertit un nom quelconque en nom de fichier ou de module *)
-
-let get_ml_object_suffix name =
-  if Filename.check_suffix name ".cmo" then
-    Some ".cmo"
-  else if Filename.check_suffix name ".cma" then
-    Some ".cma"
-  else if Filename.check_suffix name ".cmxs" then
-    Some ".cmxs"
-  else
-    None
-
-let file_of_name name =
-  let suffix = get_ml_object_suffix name in
-  let fail s =
-    user_err
-      (str"File not found on loadpath: " ++ str s ++ str"\n" ++
-       str"Loadpath: " ++ str(String.concat ":" !coq_mlpath_copy) ++ str ".") in
-  if not (Filename.is_relative name) then
-    if Sys.file_exists name then name else fail name
-  else if Sys.(backend_type = Native) then
-    (* XXX: Dynlink.adapt_filename does the same? *)
-    let name = match suffix with
-      | Some ((".cmo"|".cma") as suffix) ->
-          (Filename.chop_suffix name suffix) ^ ".cmxs"
-      | Some ".cmxs" -> name
-      | _ -> name ^ ".cmxs"
-    in
-    if System.is_in_path !coq_mlpath_copy name then name else fail name
-  else
-    let (full, base) = match suffix with
-      | Some ".cmo" | Some ".cma" -> true, name
-      | Some ".cmxs" -> false, Filename.chop_suffix name ".cmxs"
-      | _ -> false, name
-    in
-    if full then
-      if System.is_in_path !coq_mlpath_copy base then base else fail base
-    else
-      let name = base ^ ".cma" in
-      if System.is_in_path !coq_mlpath_copy name then name else
-        let name = base ^ ".cmo" in
-        if System.is_in_path !coq_mlpath_copy name then name else
-          fail (base ^ ".cm[ao]")
-
   let legacy_mapping = Core_plugins_findlib_compat.legacy_to_findlib
+
+  module Errors = struct
+
+    let plugin_name_should_contain_dot m =
+      CErrors.user_err
+        Pp.(str Format.(asprintf "%s is not a valid plugin name anymore." m) ++ spc() ++
+            str "Plugins should be loaded using their public name" ++ spc () ++
+            str "according to findlib, for example package-name.foo and not " ++
+            str "foo_plugin.")
+
+    let plugin_name_invalid_format m =
+      CErrors.user_err
+        Pp.(str Format.(asprintf "%s is not a valid plugin name." m) ++ spc () ++
+            str "It should be a public findlib name, e.g. package-name.foo," ++ spc () ++
+            str "or a legacy name followed by a findlib public name, e.g. "++ spc () ++
+            str "legacy_plugin:package-name.plugin.")
+
+  end
 
   let resolve_legacy_name_if_needed m =
     match String.split_on_char ':' m with
-    | [x] when String.index_opt m '.' = None ->
-        CErrors.user_err Pp.(str Printf.(sprintf
-         "%s is not a valid plugin name anymore." m) ++ spc() ++
-         str "Plugins should be loaded using their public name" ++ spc () ++
-         str "according to findlib, for example package-name.foo and not " ++
-         str "foo_plugin.")
-    | [ x; fl_public_name] ->
-        begin try
-          let file = file_of_name x in
-          let _, obj_file_path = System.find_file_in_path ~warn:false !coq_mlpath_copy file in
-          Legacy { obj_file_path; fl_public_name }
-        with CErrors.UserError _ ->
-          Findlib { fl_public_name }
-        end
-    | [ fl_public_name ] -> Findlib { fl_public_name }
+    | [x] when not (Fl_internals.validate_lib_name x) ->
+      Errors.plugin_name_should_contain_dot m
+    | [ file; lib ] ->
+      PluginSpec.make_legacy ~file ~lib
+    | [ lib ] ->
+      PluginSpec.make ~lib
     | [] -> assert false
     | _ :: _ :: _ ->
-        CErrors.user_err Pp.(str Printf.(sprintf
-          "%s is not a valid plugin name." m) ++ spc () ++
-          str "It should be a public findlib name, e.g. package-name.foo," ++ spc () ++
-          str "or a legacy name followed by a findlib public name, e.g. "++ spc () ++
-          str "legacy_plugin:package-name.plugin.")
+      Errors.plugin_name_invalid_format m
 
   let resolve_legacy_name_if_needed m =
-    let m = match List.assoc m legacy_mapping with
-      | exception Not_found -> m
-      | flname -> m ^ ":coq-core." ^ String.concat "." @@ flname
-    in
-    resolve_legacy_name_if_needed m
+    List.assoc_opt m legacy_mapping
+    |> Option.cata (fun flname -> m ^ ":coq-core." ^ String.concat "." @@ flname) m
+    |> resolve_legacy_name_if_needed
 
 end
 
-let ml_load use_legacy_loading_if_possible p =
+let ml_load p =
   match !load with
   | WithTop t -> t.load_obj p
   | WithoutTop ->
-      match p with
-      | Findlib { fl_public_name } ->
-        Fl_dynload.load_packages [fl_public_name]
-      | Legacy { obj_file_path; fl_public_name } ->
-        if use_legacy_loading_if_possible then begin
-          Dynlink.loadfile obj_file_path;
-          Findlib.(record_package Record_load) fl_public_name
-        end else
-          Fl_dynload.load_packages [fl_public_name]
+    PluginSpec.load p
 
 (* Adds a path to the ML paths *)
 let add_ml_dir s =
@@ -229,56 +294,64 @@ let add_ml_dir s =
  * (linked or loaded with load_object). It is used not to load a
  * module twice. It is NOT the list of ML modules Coq knows. *)
 
-let known_loaded_modules = ref String.Set.empty
+(* TODO: Merge known_loaded_module and known_loaded_plugins *)
+let known_loaded_modules : PluginSpec.Set.t ref = ref PluginSpec.Set.empty
 
 let add_known_module mname =
-  if not (String.Set.mem mname !known_loaded_modules)  then
-    known_loaded_modules := String.Set.add mname !known_loaded_modules
+  if not (PluginSpec.Set.mem mname !known_loaded_modules) then
+    known_loaded_modules := PluginSpec.Set.add mname !known_loaded_modules
 
-let module_is_known mname =
-  String.Set.mem mname !known_loaded_modules
-let plugin_is_known x = module_is_known @@ canonical_plugin_name x
+let module_is_known mname = PluginSpec.Set.mem mname !known_loaded_modules
+let plugin_is_known mname = PluginSpec.Set.mem mname !known_loaded_modules
 
 (** A plugin is just an ML module with an initialization function. *)
 
-let known_loaded_plugins = ref String.Map.empty
+let known_loaded_plugins : (unit -> unit) PluginSpec.Map.t ref = ref PluginSpec.Map.empty
 
 let add_known_plugin init name =
+  let name = Legacy_code_waiting_for_dune_release.resolve_legacy_name_if_needed name in
   add_known_module name;
-  known_loaded_plugins := String.Map.add name init !known_loaded_plugins
+  known_loaded_plugins := PluginSpec.Map.add name init !known_loaded_plugins
 
 let init_known_plugins () =
-  String.Map.iter (fun _ f -> f()) !known_loaded_plugins
+  PluginSpec.Map.iter (fun _ f -> f()) !known_loaded_plugins
 
 (** Registering functions to be used at caching time, that is when the Declare
     ML module command is issued. *)
 
-let cache_objs = ref String.Map.empty
+let cache_objs = ref PluginSpec.Map.empty
 
 let declare_cache_obj f name =
-  let objs = try String.Map.find name !cache_objs with Not_found -> [] in
+  let name = PluginSpec.make ~lib:name in
+  let objs = try PluginSpec.Map.find name !cache_objs with Not_found -> [] in
   let objs = f :: objs in
-  cache_objs := String.Map.add name objs !cache_objs
+  cache_objs := PluginSpec.Map.add name objs !cache_objs
 
 let perform_cache_obj name =
-  let objs = try String.Map.find name !cache_objs with Not_found -> [] in
+  let objs = try PluginSpec.Map.find name !cache_objs with Not_found -> [] in
   let objs = List.rev objs in
   List.iter (fun f -> f ()) objs
-let perform_cache_obj x = perform_cache_obj @@ canonical_plugin_name x
+let perform_cache_obj x = perform_cache_obj x
 
 (** ml object = ml module or plugin *)
 
 let init_ml_object mname =
-  try String.Map.find mname !known_loaded_plugins ()
+  try PluginSpec.Map.find mname !known_loaded_plugins ()
   with Not_found -> ()
-let init_ml_object x = init_ml_object @@ canonical_plugin_name x
+let init_ml_object x = init_ml_object x
 
-let load_ml_object use_legacy_loading_if_possible mname =
-  ml_load use_legacy_loading_if_possible mname;
-  add_known_module @@ canonical_plugin_name mname;
+let load_ml_object mname =
+  ml_load mname;
+  add_known_module mname;
   init_ml_object mname
 
-let add_known_module m = add_known_module m
+let add_known_module name =
+  let name = Legacy_code_waiting_for_dune_release.resolve_legacy_name_if_needed name in
+  add_known_module name
+
+let module_is_known mname =
+  let mname = Legacy_code_waiting_for_dune_release.resolve_legacy_name_if_needed mname in
+  module_is_known mname
 
 (* Summary of declared ML Modules *)
 
@@ -286,17 +359,18 @@ let add_known_module m = add_known_module m
 
 let loaded_modules = ref []
 let get_loaded_modules () = List.rev !loaded_modules
+
+(* XXX: It seems this should be part of trigger_ml_object, and
+   moreover we should check the guard there *)
 let add_loaded_module md =
   if not (List.mem md !loaded_modules) then
     loaded_modules := md :: !loaded_modules
-let add_loaded_module (use_legacy_loading_if_possible,p) =
-  add_loaded_module (use_legacy_loading_if_possible,canonical_plugin_name p)
 let reset_loaded_modules () = loaded_modules := []
 
 let if_verbose_load verb f name =
   if not verb then f name
   else
-    let info = str "[Loading ML file " ++ str (pp_plugin name) ++ str " ..." in
+    let info = str "[Loading ML file " ++ str (PluginSpec.pp name) ++ str " ..." in
     try
       let path = f name in
       Feedback.msg_info (info ++ str " done]");
@@ -309,56 +383,50 @@ let if_verbose_load verb f name =
     or simulate its reload (i.e. doing nothing except maybe
     an initialization function). *)
 
-let trigger_ml_object ~verbose ~cache ~reinit ~use_legacy_loading_if_possible s =
-  let plugin = Legacy_code_waiting_for_dune_release.resolve_legacy_name_if_needed s in
-  let () = if plugin_is_known plugin then
-      begin if reinit then init_ml_object plugin end
-    else if not has_dynlink then
-      user_err
-        (str "Dynamic link not supported (module " ++ str (pp_plugin plugin) ++ str ").")
+let trigger_ml_object ~verbose ~cache ~reinit plugin =
+  let () =
+    if plugin_is_known plugin then
+      (if reinit then init_ml_object plugin)
     else
-      if_verbose_load (verbose && not !Flags.quiet) (load_ml_object use_legacy_loading_if_possible) plugin
+      begin
+        if not has_dynlink then
+          CErrors.user_err
+            (str "Dynamic link not supported (module " ++ str (PluginSpec.pp plugin) ++ str ").")
+        else
+          if_verbose_load (verbose && not !Flags.quiet) load_ml_object plugin
+      end
   in
-  add_loaded_module (use_legacy_loading_if_possible,plugin);
+  add_loaded_module plugin;
   if cache then perform_cache_obj plugin
 
 let unfreeze_ml_modules x =
   reset_loaded_modules ();
   List.iter
-    (fun (use_legacy_loading_if_possible,name) -> trigger_ml_object ~verbose:false ~cache:false ~reinit:false ~use_legacy_loading_if_possible name) x
+    (fun name ->
+       let name = PluginSpec.unrepr name in
+       trigger_ml_object ~verbose:false ~cache:false ~reinit:false name) x
 
 let () =
   Summary.declare_ml_modules_summary
-    { stage = Summary.Stage.Synterp;
-      Summary.freeze_function = (fun ~marshallable -> get_loaded_modules ());
-      Summary.unfreeze_function = unfreeze_ml_modules;
-      Summary.init_function = reset_loaded_modules }
+    { stage = Summary.Stage.Synterp
+    ; Summary.freeze_function = (fun ~marshallable ->
+          get_loaded_modules () |> List.map PluginSpec.repr)
+    ; Summary.unfreeze_function = unfreeze_ml_modules
+    ; Summary.init_function = reset_loaded_modules }
 
 (* Liboject entries of declared ML Modules *)
-
-type ml_module_digest =
-  | NoDigest
-  | AnyDigest of Digest.t list
-
-type ml_module_object = {
-  mlocal : Vernacexpr.locality_flag;
-  mnames : string list;
-  mdigests : ml_module_digest list;
-  dune_compat_logpathroot : Names.module_ident
-}
-let current_logpathroot () =
-  let open Names in
-  List.hd @@ List.rev @@ DirPath.repr @@ ModPath.dp @@ Global.current_modpath ()
+type ml_module_object =
+  { mlocal : Vernacexpr.locality_flag
+  ; mnames : PluginSpec.t list
+  ; mdigests : Digest.t list
+  }
 
 let cache_ml_objects mnames =
-  let use_legacy_loading_if_possible = true in
-  let iter obj = trigger_ml_object ~verbose:true ~cache:true ~reinit:true ~use_legacy_loading_if_possible obj in
+  let iter obj = trigger_ml_object ~verbose:true ~cache:true ~reinit:true obj in
   List.iter iter mnames
 
-let load_ml_objects _ {mnames; dune_compat_logpathroot; _} =
-  let use_legacy_loading_if_possible =
-    Names.Id.equal dune_compat_logpathroot (current_logpathroot ()) in
-  let iter obj = trigger_ml_object ~verbose:true ~cache:false ~reinit:true ~use_legacy_loading_if_possible obj in
+let load_ml_objects _ {mnames; _} =
+  let iter obj = trigger_ml_object ~verbose:true ~cache:false ~reinit:true obj in
   List.iter iter mnames
 
 let classify_ml_objects {mlocal=mlocal} =
@@ -373,52 +441,18 @@ let inMLModule : ml_module_object -> Libobject.obj =
       subst_function = (fun (_,o) -> o);
       classify_function = classify_ml_objects }
 
-(* Fl_split.in_words is not exported *)
-let fl_split_in_words s =
-  (* splits s in words separated by commas and/or whitespace *)
-  let l = String.length s in
-  let rec split i j =
-    if j < l then
-      match s.[j] with
-      | (' '|'\t'|'\n'|'\r'|',') ->
-        if i<j then (String.sub s i (j-i)) :: (split (j+1) (j+1))
-        else split (j+1) (j+1)
-      |	_ ->
-        split i (j+1)
-    else
-    if i<j then [ String.sub s i (j-i) ] else []
-  in
-  split 0 0
-
-let get_digest m =
-  match Legacy_code_waiting_for_dune_release.resolve_legacy_name_if_needed m with
-  | Legacy { obj_file_path=f } -> AnyDigest [Digest.file f]
-  | Findlib { fl_public_name=f } -> begin
-      (* simulate what fl_dynload does *)
-      let d = Findlib.package_directory f in
-      let preds = Findlib.recorded_predicates () in
-      let archive = try Findlib.package_property preds f "plugin"
-        with Not_found ->
-        try fst (Findlib.package_property_2 ("plugin"::preds) f "archive")
-        with Not_found -> ""
-      in
-      let files = fl_split_in_words archive in
-      let digests = List.map (fun file -> Digest.file (Findlib.resolve_path ~base:d file)) files in
-      AnyDigest digests
-    end
-
-let get_digest m = try get_digest m with e when noncritical e -> NoDigest
 
 let declare_ml_modules local l =
+  let mnames = List.map Legacy_code_waiting_for_dune_release.resolve_legacy_name_if_needed l in
   if Global.sections_are_opened()
-  then user_err Pp.(str "Cannot Declare ML Module while sections are opened.");
-  let dune_compat_logpathroot = current_logpathroot () in
-  let mdigests = List.map get_digest l in
-  Lib.add_leaf (inMLModule {mlocal=local; mnames=l; mdigests; dune_compat_logpathroot});
+  then CErrors.user_err Pp.(str "Cannot Declare ML Module while sections are opened.");
+  (* List.concat_map only available in 4.10 *)
+  let mdigests = List.map PluginSpec.digest mnames |> List.concat in
+  Lib.add_leaf (inMLModule {mlocal=local; mnames; mdigests});
   (* We can't put this in cache_function: it may declare other
      objects, and when the current module is required we want to run
      the ML-MODULE object before them. *)
-  cache_ml_objects l
+  cache_ml_objects mnames
 
 let print_ml_path () =
   let l = !coq_mlpath_copy in
@@ -429,7 +463,7 @@ let print_ml_path () =
 
 let print_ml_modules () =
   let l = get_loaded_modules () in
-  str"Loaded ML Modules: " ++ pr_vertical_list str (List.map snd l)
+  str"Loaded ML Modules: " ++ pr_vertical_list str (List.map PluginSpec.pp l)
 
 let print_gc () =
   let stat = Gc.stat () in

--- a/vernac/mltop.mli
+++ b/vernac/mltop.mli
@@ -10,15 +10,29 @@
 
 (** {5 Toplevel management} *)
 
-(** If there is a toplevel under Coq, it is described by the following
-   record. *)
-type plugin =
-| Legacy of { obj_file_path : string; fl_public_name : string }
-| Findlib of { fl_public_name : string }
-val pp_plugin : plugin -> string
+(** Coq plugins are identified by their OCaml library name (in the
+   Findlib sense) *)
+module PluginSpec : sig
+
+  (** A plugin is identified by its canonical library name,
+      such as [coq-core.plugins.ltac] *)
+  type t
+
+  (** [repr p] returns a pair of [legacy_name, lib_name] where
+     [lib_name] is the canoncial library name.
+
+      [legacy_name] may be [Some pname] for the cases the plugin was
+     specified in [Declare ML Module] with their legacy name (for
+     example [ltac_plugin]). This will stop being supported soon and
+     is only here for compatiblity. Note that the name doesn't include
+     the ".cmxs" / ".cma" extension *)
+  val repr : t -> string option * string
+
+  val pp : t -> string
+end
 
 type toplevel = {
-  load_obj : plugin -> unit;
+  load_obj : PluginSpec.t -> unit;
   add_dir  : string -> unit;
   ml_loop  : unit -> unit }
 
@@ -36,21 +50,24 @@ val ocaml_toploop : unit -> unit
 
 (** {5 ML Dynlink} *)
 
-(** Adds a dir to the plugin search path *)
+(** Adds a dir to the plugin search path, this also extends
+   OCamlfind's search path *)
 val add_ml_dir : string -> unit
 
 (** Tests if we can load ML files *)
 val has_dynlink : bool
 
-(** List of modules linked to the toplevel *)
-val add_known_module : string -> unit
 val module_is_known : string -> bool
 
 (** {5 Initialization functions} *)
 
-(** Declare a plugin and its initialization function.
-    A plugin is just an ML module with an initialization function.
-    Adding a known plugin implies adding it as a known ML module.
+(** Declare a plugin without an initialization function.  A plugin is
+   a findlib library name. Usually, this will be called automatically
+   when use do [DECLARE PLUGIN "pkg.lib"] in the .mlg file. *)
+val add_known_module : string -> unit
+(* EJGA: Todo, this could take a PluginSpec.t at some point *)
+
+(** Declare a plugin plus a Coq-specific initialization function.
     The initialization function is granted to be called after Coq is fully
     bootstrapped, even if the plugin is statically linked with the toplevel *)
 val add_known_plugin : (unit -> unit) -> string -> unit
@@ -67,6 +84,7 @@ val declare_cache_obj : (unit -> unit) -> string -> unit
 
 (** {5 Declaring modules} *)
 
+(** Implementation of the [Declare ML Module] vernacular command. *)
 val declare_ml_modules : Vernacexpr.locality_flag -> string list -> unit
 
 (** {5 Utilities} *)


### PR DESCRIPTION
The current implementation of the "legacy" loading for plugins doesn't
store the plugin name that was used in the `Summary` when saving a
`.vio` / `.vo` file. This is necessary in some cases such as when
doing `vio2vo` without installing Coq.

We simplify the logic here and store the full information in the
summary of how the plugin was loaded, which allow us to remove the
current hack we have, and makes the code path a bit more
deterministic.

The old loading method was "relocatable", in the sense -I controlled
the paths for the legacy plugin loading too for now.

This should improve the compat with build systems (such as Dune) that
don't support yet findlib plugin building.

We also do some general refactoring of the code, in particular:

- we make the digests mandatory
- we simplify the native / byte plugin selection logic

There are some other improvements we can make in future PRs:

- there are a few non-deterministic plans such as "if file X is here,
  do this" which is always suspicious, we could improve that: in
  incremental builds either a file is a dep
- also, `coqc` and `coqdep` have different semantics for `-I`, I'd be
  great if we could improve this.

Fixes in plugins due to better invariants in this PR:
- https://github.com/lukaszcz/coqhammer/pull/135
- https://github.com/coq-community/paramcoq/pull/97
- https://github.com/mattam82/Coq-Equations/pull/494
- https://github.com/QuickChick/QuickChick/pull/288