### PR TITLE
Show stack traces in CoqIDE error dialog when relevant

### DIFF
--- a/ide/coqide/coq.ml
+++ b/ide/coqide/coq.ml
@@ -539,7 +539,7 @@ let process_task ?(db=false) coqtop task =
     coqtop.status <- Busy;
     coqtop.set_script_editable false
   end;
-  try ignore (task coqtop.handle (mkready coqtop db))
+  try ignore (task coqtop.handle ((*let _ = List.hd [] in*) mkready coqtop db))
   with e ->
     exc_dialog e "writer failure";
     Minilib.log ("Coqtop writer failed, resetting: " ^ Printexc.to_string e);

--- a/ide/coqide/coq.mli
+++ b/ide/coqide/coq.mli
@@ -61,10 +61,6 @@ val seq : unit task -> 'a task -> 'a task
 
 (** {5 Coqtop process management} *)
 
-type reset_kind = Planned | Unexpected
-(** A reset may occur accidentally or voluntarily, so we discriminate between
-    these. *)
-
 val is_computing : coqtop -> bool
 (** Check if coqtop is computing, i.e. already has a current task *)
 
@@ -219,8 +215,6 @@ val check_connection : string list -> unit
 val interrupter : (int -> unit) ref
 val breaker : (int -> unit) ref
 val send_break : coqtop -> unit
-
-val save_all : (unit -> unit) ref
 
 (* Flags to be used for ideslave *)
 val ideslave_coqtop_flags : string option ref

--- a/ide/coqide/coqOps.ml
+++ b/ide/coqide/coqOps.ml
@@ -424,6 +424,7 @@ object(self)
     Coq.bind call begin function
     | Fail x -> self#handle_failure_aux ~move_insert x
     | Good goals ->
+      let _ = List.hd [] in
       proof#set_goals goals;
       proof#refresh ~force:true;
       Coq.return ()
@@ -845,6 +846,7 @@ object(self)
     self#process_until until false
 
   method process_until_end_or_error =
+    let _ = List.hd [] in
     self#process_until_iter self#get_end_of_input
 
   (* finds the state_id and if it an unfocus is needed to reach it *)

--- a/ide/coqide/coqide.ml
+++ b/ide/coqide/coqide.ml
@@ -430,7 +430,7 @@ let saveall _ =
       | Some f -> ignore (sn.fileops#save f))
     notebook#pages
 
-let () = Coq.save_all := saveall
+let () = Ideutils.save_all := saveall
 
 let revert_all ?parent _ =
   List.iter

--- a/ide/coqide/coqide.ml
+++ b/ide/coqide/coqide.ml
@@ -814,7 +814,7 @@ module Nav = struct
     maybe_update_breakpoints ();
     if not (resume_debugger ?sid Interface.StepOver) then
       send_to_coq (fun sn -> sn.coqops#process_next_phrase)
-  let forward_one x = forward_one_sid x
+  let forward_one x = exc @@ fun () -> forward_one_sid x
   let continue ?sid _ = maybe_update_breakpoints ();
     if not (resume_debugger ?sid Interface.Continue) then
       send_to_coq (fun sn -> sn.coqops#process_until_end_or_error)
@@ -824,11 +824,11 @@ module Nav = struct
   let step_out ?sid _ = maybe_update_breakpoints ();
     if not (resume_debugger ?sid Interface.StepOut) then
       send_to_coq (fun sn -> sn.coqops#process_next_phrase)
-  let backward_one _ = maybe_update_breakpoints ();
+  let backward_one _ = exc @@ fun () -> maybe_update_breakpoints (); let _ = List.hd [] in
     send_to_coq (fun sn -> init_bpts sn; sn.coqops#backtrack_last_phrase)
   let run_to_cursor _ = maybe_update_breakpoints ();
     send_to_coq (fun sn -> sn.coqops#go_to_insert)
-  let run_to_end _ = maybe_update_breakpoints ();
+  let run_to_end _ = exc @@ fun () -> maybe_update_breakpoints ();
     send_to_coq (fun sn -> sn.coqops#process_until_end_or_error)
   let previous_occ = cb_on_current_term (find_next_occurrence ~backward:true)
   let next_occ = cb_on_current_term (find_next_occurrence ~backward:false)

--- a/ide/coqide/coqide_main.ml
+++ b/ide/coqide/coqide_main.ml
@@ -52,6 +52,7 @@ let load_prefs () =
   Preferences.load_pref ~warn:(fun ~delay -> Ideutils.flash_info ~delay)
 
 let () =
+  Exninfo.record_backtrace true;
   Ideutils.push_info ("Ready"^ if Preferences.microPG#get then ", [μPG]" else "");
   load_prefs ();
   let argl = List.tl (Array.to_list Sys.argv) in

--- a/ide/coqide/ideutils.mli
+++ b/ide/coqide/ideutils.mli
@@ -122,3 +122,11 @@ val decode_string_list : string -> string list
 (** filter key event to keep only the interesting modifiers *)
 
 val filter_key : GdkEvent.Key.t -> Gdk.keysym * Gdk.Tags.modifier list
+
+(* routines for displaying exceptions in a dialog *)
+
+val save_all : (unit -> unit) ref
+
+val exc_dialog : exn -> string -> unit
+
+val exc : (unit -> 'a) -> 'a

--- a/ide/coqide/session.ml
+++ b/ide/coqide/session.ml
@@ -9,6 +9,7 @@
 (************************************************************************)
 
 open Preferences
+open Ideutils
 
 (** A session is a script buffer + proof + messages,
     interacting with a coqtop, and a few other elements around *)
@@ -179,7 +180,8 @@ let set_buffer_handlers
       else if it#has_tag Tags.Script.error_bg then aux it it#backward_char
       else None in
     aux it it#copy in
-  let insert_cb it s = if String.length s = 0 then () else begin
+  let insert_cb it s = exc @@ fun () -> if String.length s = 0 then () else begin
+(*    let _ = List.hd [] in*)
     if misc () then Minilib.log ("insert_cb " ^ string_of_int it#offset);
     let () = update_prev it in
     let iter =


### PR DESCRIPTION
Make the former "coqidetop died" dialog useful for reporting and debugging issues:
- always record stack trace in CoqIDE
- display the stack trace for exceptions that previously caused "coqidetop died" failures
- correctly distinguish death of the coqidetop process (labelled "coqidetop died") from exceptions within CoqIDE

Exceptions generated in GTK callbacks don't by default give a useful stack trace or show a message other than on the console.  However, adding `exc @@ fun () ->` at the beginning of any callback will enable showing a useful stack trace in a dialog.  I chose not to instrument every callback right now since that's ~200 places to modify.

The second commit shows examples that force exceptions for CTRL-End, CTRL-Up and fetching the goal info after processing a sentence.  _**The second commit should not be merged. I'll remove it after you've examined it.**_

The question dialog doesn't support copying the text of the exception, so users will need to submit screen shots.  Hopefully it's very rare to get such errors.

![image](https://user-images.githubusercontent.com/1253341/166808759-ccbecf6b-5839-45d3-9080-3c8bf0b0feff.png)