### PR TITLE
make warn_deprecated_hint_without_locality AsError

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/16004-pr-Alizter-16004.rst
+++ b/doc/changelog/08-vernac-commands-and-options/16004-pr-Alizter-16004.rst
@@ -1,0 +1,10 @@
+- **Changed:**
+  `Hint` and :cmd:`Instance` commands with no locality attribute are deprecated.
+  Previous versions generated a warning, but this version generates an error by
+  default. This includes all `Hint` commands described in :ref:`creating_hints`,
+  :cmd:`Hint Rewrite`, and :cmd:`Instance`. As mentioned in the error, please
+  add an explicit locality to the hint command. The default was
+  #[:attr:`global`], but we recommend using #[:attr:`export`] where possible
+  (`#16004 <https://github.com/coq/coq/pull/16004>`_,
+  fixes `#13394 <https://github.com/coq/coq/issues/13394>`_,
+  by Ali Caglayan).

--- a/doc/sphinx/addendum/type-classes.rst
+++ b/doc/sphinx/addendum/type-classes.rst
@@ -366,10 +366,10 @@ Summary of the commands
 
    .. deprecated:: 8.14
 
-      The default value for instance locality will change in a future
-      release. Instances added outside of sections without an explicit
-      locality are now deprecated. We recommend using :attr:`export`
-      where possible.
+      The default value for instance locality will change in a future release.
+      Instances added outside of sections without an explicit locality are
+      deprecated. We recommend using :attr:`export` where possible. This warning
+      is treated as an error by default.
 
    Like :cmd:`Definition`, it also supports the :attr:`program`
    attribute to switch the type checking to `Program` (chapter

--- a/doc/sphinx/proofs/automatic-tactics/auto.rst
+++ b/doc/sphinx/proofs/automatic-tactics/auto.rst
@@ -370,10 +370,10 @@ Creating Hints
 
    .. deprecated:: 8.13
 
-     The default value for hint locality will change in a future
-     release. Hints added outside of sections without an explicit
-     locality are now deprecated. We recommend using :attr:`export`
-     where possible.
+      The default value for hint locality will change in a future release. Hints
+      added outside of sections without an explicit locality are deprecated. We
+      recommend using :attr:`export` where possible. This warning is treated as
+      an error by default.
 
    The `Hint` commands are:
 

--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -540,6 +540,7 @@ let find_applied_relation ?loc env sigma c left2right =
 
 let warn_deprecated_hint_rewrite_without_locality =
   CWarnings.create ~name:"deprecated-hint-rewrite-without-locality" ~category:"deprecated"
+    ~default:CWarnings.AsError
     (fun () -> strbrk "The default value for rewriting hint locality is currently \
     \"local\" in a section and \"global\" otherwise, but is scheduled to change \
     in a future release. For the time being, adding rewriting hints outside of sections \

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1279,6 +1279,7 @@ let make_hint ~locality name action =
 
 let warn_deprecated_hint_without_locality =
   CWarnings.create ~name:"deprecated-hint-without-locality" ~category:"deprecated"
+    ~default:CWarnings.AsError
     (fun () -> strbrk "The default value for hint locality is currently \
     \"local\" in a section and \"global\" otherwise, but is scheduled to change \
     in a future release. For the time being, adding hints outside of sections \

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -148,6 +148,7 @@ let instance_input : instance_obj -> obj =
 let warn_deprecated_instance_without_locality =
   let open Pp in
   CWarnings.create ~name:"deprecated-instance-without-locality" ~category:"deprecated"
+    ~default:CWarnings.AsError
     (fun () -> strbrk "The default value for instance locality is currently \
     \"local\" in a section and \"global\" otherwise, but is scheduled to change \
     in a future release. For the time being, adding instances outside of sections \


### PR DESCRIPTION
We turn the Hint locality warning into an error.

- close https://github.com/coq/coq/issues/13394
- [x] improve warning message?
- [x] documentation

Depends on:
- [x] https://github.com/coq/coq/pull/16251

Closed PRs are probably broken and need fixing/overtaking.
- [x] overlays:
  - [x] ci-analysis https://github.com/math-comp/analysis/pull/663
  - [x] ci-argosy https://github.com/mit-pdos/argosy/pull/5 
  - [x] ci-autosubst https://github.com/coq-community/autosubst/pull/27
  - [x] ci-bbv <strike>https://github.com/mit-plv/bbv/pull/40</strike> https://github.com/mit-plv/bbv/pull/41
  - [x] ci-bedrock2 https://github.com/mit-plv/bedrock2/pull/250
    - [x] https://github.com/mit-plv/coqutil/pull/66
    - [x] https://github.com/mit-plv/kami/pull/28
    - [x] https://github.com/mit-plv/riscv-coq/pull/30
  - [x] ci-bignums https://github.com/coq-community/bignums/pull/70
  - [x] ci-category_theory https://github.com/jwiegley/category-theory/pull/31
  - [x] ci-color https://github.com/fblanqui/color/pull/42
  - [x] ci-compcert https://github.com/AbsInt/CompCert/pull/439
  - [x] ci-coq_dpdgraph https://github.com/coq-community/coq-dpdgraph/pull/102
  - [x] ci-coq_performance_tests <strike>https://github.com/coq-community/coq-performance-tests/pull/21</strike> https://github.com/coq-community/coq-performance-tests/pull/24
  - [x] ci-coqprime https://github.com/thery/coqprime/pull/47 or https://github.com/thery/coqprime/pull/48 or https://github.com/thery/coqprime/pull/52
  - [x] ci-corn https://github.com/coq-community/corn/pull/169
  - [x] ci-cross_crypto https://github.com/mit-plv/cross-crypto/pull/29
  - [x] ci-deriving https://github.com/arthuraa/deriving/pull/19
  - [x] ci-engine_bench
  - [x] ci-fcsl_pcm https://github.com/imdea-software/fcsl-pcm/pull/34
  - [x] ci-fiat_crypto https://github.com/mit-plv/fiat-crypto/pull/1309
    - [x] mit-plv/rupicola
  - [x] ci-fiat_crypto_legacy https://github.com/mit-plv/fiat-crypto/pull/1310
  - [x] ci-fiat_parsers
  - [x] ci-geocoq https://github.com/GeoCoq/GeoCoq/pull/38
  - [X] ci-gappa
  - [x] ci-math_classes https://github.com/coq-community/math-classes/pull/111
  - [x] ci-mczify https://github.com/math-comp/mczify/pull/40
  - [x] ci-menhir (bump CI?)
  - [x] ci-metacoq https://github.com/MetaCoq/metacoq/pull/721
  - [x] ci-mtac2 https://github.com/Mtac2/Mtac2/pull/359 (Has instances but looks fine to me)
  - [x] ci-quichick https://github.com/QuickChick/QuickChick/pull/291
  - [x] ci-rewriter <strike>https://github.com/mit-plv/rewriter/pull/42 (We should just disable the warnings instead)</strike> https://github.com/mit-plv/rewriter/pull/45
  - [x] ci-stdlib2 https://github.com/coq/stdlib2/pull/27
  - [x] ci-tlc https://github.com/charguer/tlc/pull/11
  - [x] ci-unimath https://github.com/UniMath/UniMath/pull/1506
  - [x] ci-verdi_raft https://github.com/uwplse/verdi-raft/pull/90
    - [x] https://github.com/uwplse/StructTact/pull/61
    - [x] https://github.com/DistributedComponents/InfSeqExt/pull/4
    - [x] https://github.com/uwplse/cheerios/pull/11
    - [x] https://github.com/uwplse/verdi/pull/133
  - [x] ci-vst https://github.com/PrincetonUniversity/VST/pull/576

Sister draft PR: #16258