### PR TITLE
[native compiler] Don't search for coqlib too eagerly.

### DIFF
--- a/kernel/nativelib.ml
+++ b/kernel/nativelib.ml
@@ -60,9 +60,12 @@ let delay_cleanup_file =
 let include_dirs = ref []
 
 let get_include_dirs () =
-  let env = Boot.Env.init () in
   let base = match !include_dirs with
   | [] ->
+    (* EJGA: Should this case go away in favor of always requiring
+       explicit -nI flags once we remove the make-based system? I think
+       so. *)
+    let env = Boot.Env.init () in
     [ Boot.Env.(Path.to_string (native_cmi env "kernel"))
     ; Boot.Env.(Path.to_string (native_cmi env "library"))
     ]


### PR DESCRIPTION
In the case where we pass `-nI` and `-boot`, we don't require the
stdlib to be found. I saw someone complaining about this.

We should anyways improve the need to guess for stuff, in particular
we drop the requirement to find `Prelude.vo` soon I hope.
