### PR TITLE
tactic unification debug: print terms when entering unification

### DIFF
--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1157,7 +1157,11 @@ let rec unify_0_with_initial_metas (sigma,ms,es as subst : subst0) conv_at_top e
     else error_cannot_unify (fst curenvnb) sigma (cM,cN)
   in
 
-  debug_tactic_unification (fun () -> str "Starting unification");
+  debug_tactic_unification (fun () ->
+      str "Starting unification: " ++
+      Termops.Internal.print_constr_env env sigma (fst m) ++ str" ~= " ++
+      Termops.Internal.print_constr_env env sigma (fst n));
+
   let opt = { at_top = conv_at_top; with_types = false; with_cs = true } in
   try
   let res =


### PR DESCRIPTION
without this it's possible to have useless prints "starting
unif/leaving unif with failure"
