### PR TITLE
Unification.make_pattern_test: use newer evar map instead of older

### DIFF
--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1670,7 +1670,7 @@ let make_pattern_test from_prefix_of_ind is_correct_type env sigma (pending,c) =
     | e when CErrors.noncritical e -> raise (NotUnifiable None) in
   let merge_fun c1 c2 =
     match c1, c2 with
-    | Some (evd,c1,x), Some (_,c2,_) ->
+    | Some (_,c1,x), Some (evd,c2,_) ->
       begin match infer_conv ~pb:CONV env evd c1 c2 with
       | Some evd ->
        (let t1 = get_type_of env evd c1 in

--- a/test-suite/bugs/bug_15978.v
+++ b/test-suite/bugs/bug_15978.v
@@ -1,0 +1,9 @@
+Inductive trinat (n:nat): nat -> nat -> Prop := r : trinat n n n.
+
+Polymorphic Axiom n@{u}: nat.
+
+Lemma foo@{u v} : trinat n@{u} n@{v} n@{v}.
+Proof.
+  set (m := n).
+  apply r.
+Qed.


### PR DESCRIPTION
Fix #15978
