### PR TITLE
Ltac2 deep matches (unoptimized interpretation)

### DIFF
--- a/doc/changelog/05-tactic-language/16023-tac2match.rst
+++ b/doc/changelog/05-tactic-language/16023-tac2match.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Deep :ref:`pattern matching <ltac2_match_on_values>` for Ltac2
+  (`#16023 <https://github.com/coq/coq/pull/16023>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -37,7 +37,6 @@ Current limitations include:
 
   - Printing functions are limited and awkward to use.  Only a few data types are
     printable.
-  - Deep pattern matching and matching on tuples don't work.
   - A convenient way to build terms with casts through the low-level API. Because the
     cast type is opaque, building terms with casts currently requires an awkward construction like the
     following, which also incurs extra overhead to repeat typechecking for each
@@ -1120,6 +1119,8 @@ Match over goals
       end.
 
 
+.. _ltac2_match_on_values:
+
 Match on values
 ~~~~~~~~~~~~~~~
 
@@ -1132,16 +1133,17 @@ Match on values
    .. insertprodn ltac2_branches atomic_tac2pat
 
    .. prodn::
-      ltac2_branches ::= {? %| } {+| @tac2pat1 => @ltac2_expr }
+      ltac2_branches ::= {? %| } {+| {? @atomic_tac2pat } => @ltac2_expr }
       tac2pat1 ::= @qualid {+ @tac2pat0 }
       | @qualid
-      | [ ]
       | @tac2pat0 :: @tac2pat0
+      | @tac2pat0 %| {+| @tac2pat1 }
       | @tac2pat0
       tac2pat0 ::= _
       | ()
       | @qualid
       | ( {? @atomic_tac2pat } )
+      | [ {*; @tac2pat1 } ]
       atomic_tac2pat ::= @tac2pat1 : @ltac2_type
       | @tac2pat1 , {*, @tac2pat1 }
       | @tac2pat1
@@ -1152,10 +1154,6 @@ Match on values
    Equivalent to a :tacn:`match <match (Ltac2)>` on a boolean value.  If the
    :n:`@ltac2_expr5__test` evaluates to true, :n:`@ltac2_expr5__then`
    is evaluated.  Otherwise :n:`@ltac2_expr5__else` is evaluated.
-
-.. note::
-
-   For now, deep pattern matching is not implemented.
 
 
 .. _ltac2_notations:

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -3246,8 +3246,8 @@ string_option: [
 tac2pat1: [
 | Prim.qualid LIST1 tac2pat0      (* ltac2 plugin *)
 | Prim.qualid      (* ltac2 plugin *)
-| "[" "]"      (* ltac2 plugin *)
 | tac2pat0 "::" tac2pat0      (* ltac2 plugin *)
+| tac2pat0 "|" LIST1 tac2pat1 SEP "|"      (* ltac2 plugin *)
 | tac2pat0      (* ltac2 plugin *)
 ]
 
@@ -3256,6 +3256,7 @@ tac2pat0: [
 | "()"      (* ltac2 plugin *)
 | Prim.qualid      (* ltac2 plugin *)
 | "(" atomic_tac2pat ")"      (* ltac2 plugin *)
+| "[" LIST0 tac2pat1 SEP ";" "]"      (* ltac2 plugin *)
 ]
 
 atomic_tac2pat: [
@@ -3316,7 +3317,7 @@ G_LTAC2_branches: [
 ]
 
 branch: [
-| tac2pat1 "=>" ltac2_expr6      (* ltac2 plugin *)
+| atomic_tac2pat "=>" ltac2_expr6      (* ltac2 plugin *)
 ]
 
 rec_flag: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -2374,14 +2374,14 @@ ltac1_expr_in_env: [
 ]
 
 ltac2_branches: [
-| OPT "|" LIST1 ( tac2pat1 "=>" ltac2_expr ) SEP "|"
+| OPT "|" LIST1 ( OPT atomic_tac2pat "=>" ltac2_expr ) SEP "|"
 ]
 
 tac2pat1: [
 | qualid LIST1 tac2pat0      (* ltac2 plugin *)
 | qualid      (* ltac2 plugin *)
-| "[" "]"      (* ltac2 plugin *)
 | tac2pat0 "::" tac2pat0      (* ltac2 plugin *)
+| tac2pat0 "|" LIST1 tac2pat1 SEP "|"      (* ltac2 plugin *)
 | tac2pat0      (* ltac2 plugin *)
 ]
 
@@ -2390,6 +2390,7 @@ tac2pat0: [
 | "()"      (* ltac2 plugin *)
 | qualid      (* ltac2 plugin *)
 | "(" OPT atomic_tac2pat ")"      (* ltac2 plugin *)
+| "[" LIST0 tac2pat1 SEP ";" "]"      (* ltac2 plugin *)
 ]
 
 atomic_tac2pat: [

--- a/lib/cAst.ml
+++ b/lib/cAst.ml
@@ -26,3 +26,10 @@ let with_val f n = f n.v
 let with_loc_val f n = f ?loc:n.loc n.v
 
 let eq f x y = f x.v y.v
+
+module Smart = struct
+  let map f n =
+    let v' = f n.v in
+    if v' == n.v then n
+    else {n with v=v'}
+end

--- a/lib/cAst.mli
+++ b/lib/cAst.mli
@@ -24,3 +24,7 @@ val with_val : ('a -> 'b) -> 'a t -> 'b
 val with_loc_val : (?loc:Loc.t -> 'a -> 'b) -> 'a t -> 'b
 
 val eq : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+
+module Smart : sig
+  val map : ('a -> 'a) -> 'a t -> 'a t
+end

--- a/plugins/ltac2/g_ltac2.mlg
+++ b/plugins/ltac2/g_ltac2.mlg
@@ -121,15 +121,24 @@ GRAMMAR EXTEND Gram
         else
           CErrors.user_err ~loc (Pp.str "Syntax error") }
       | qid = Prim.qualid -> { pattern_of_qualid qid }
-      | "["; "]" -> { CAst.make ~loc @@ CPatRef (AbsKn (Other Tac2core.Core.c_nil), []) }
+      (* | "["; "]" -> { CAst.make ~loc @@ CPatRef (AbsKn (Other Tac2core.Core.c_nil), []) } *)
       | p1 = tac2pat; "::"; p2 = tac2pat ->
         { CAst.make ~loc @@ CPatRef (AbsKn (Other Tac2core.Core.c_cons), [p1; p2])}
+      | p = tac2pat; "|"; pl = LIST1 tac2pat SEP "|" ->
+        { let pl = p :: pl in
+          CAst.make ~loc @@ CPatOr pl }
       ]
     | "0"
       [ "_" -> { CAst.make ~loc @@ CPatVar Anonymous }
       | "()" -> { CAst.make ~loc @@ CPatRef (AbsKn (Tuple 0), []) }
       | qid = Prim.qualid -> { pattern_of_qualid qid }
       | "("; p = atomic_tac2pat; ")" -> { p }
+      | "["; pats = LIST0 tac2pat SEP ";"; "]" ->
+        {
+          let nil = CAst.make ~loc @@ CPatRef (AbsKn (Other Tac2core.Core.c_nil), []) in
+          let cons hd tl = CAst.make ~loc @@ CPatRef (AbsKn (Other Tac2core.Core.c_cons), [hd;tl]) in
+          List.fold_right cons pats nil
+        }
     ] ]
   ;
   atomic_tac2pat:
@@ -195,7 +204,7 @@ GRAMMAR EXTEND Gram
   ]
   ;
   branch:
-  [ [ pat = tac2pat LEVEL "1"; "=>"; e = ltac2_expr LEVEL "6" -> { (pat, e) } ] ]
+  [ [ pat = atomic_tac2pat; "=>"; e = ltac2_expr LEVEL "6" -> { (pat, e) } ] ]
   ;
   rec_flag:
     [ [ IDENT "rec" -> { true }

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -292,7 +292,7 @@ let fresh_var avoid x =
 
 let extract_pattern_type ({loc;v=p} as pat) = match p with
 | CPatCnv (pat, ty) -> pat, Some ty
-| CPatVar _ | CPatRef _ -> pat, None
+| CPatVar _ | CPatRef _ | CPatOr _ -> pat, None
 
 (** Mangle recursive tactics *)
 let inline_rec_tactic tactics =

--- a/plugins/ltac2/tac2expr.mli
+++ b/plugins/ltac2/tac2expr.mli
@@ -93,6 +93,7 @@ type raw_patexpr_r =
 | CPatVar of Name.t
 | CPatRef of ltac_constructor or_tuple or_relid * raw_patexpr list
 | CPatCnv of raw_patexpr * raw_typexpr
+| CPatOr of raw_patexpr list
 
 and raw_patexpr = raw_patexpr_r CAst.t
 
@@ -118,6 +119,32 @@ and raw_taccase = raw_patexpr * raw_tacexpr
 
 and raw_recexpr = (ltac_projection or_relid * raw_tacexpr) list
 
+(* We want to generate these easily in the Closed case, otherwise we
+   could have the kn in the ctor_data_for_patterns type. Maybe still worth doing?? *)
+type ctor_indx =
+  | Closed of int
+  | Open of ltac_constructor
+
+type ctor_data_for_patterns = {
+  ctyp : type_constant;
+  cnargs : int;
+  cindx : ctor_indx;
+}
+
+type glb_pat =
+  | GPatVar of Name.t
+  | GPatRef of ctor_data_for_patterns or_tuple * glb_pat list
+  | GPatOr of glb_pat list
+
+module PartialPat : sig
+  type r =
+    | Var of Name.t
+    | Ref of ctor_data_for_patterns or_tuple * t list
+    | Or of t list
+    | Extension
+  and t = r CAst.t
+end
+
 type case_info = type_constant or_tuple
 
 type 'a open_match = {
@@ -140,6 +167,7 @@ type glb_tacexpr =
 | GTacSet of type_constant * glb_tacexpr * int * glb_tacexpr
 | GTacOpn of ltac_constructor * glb_tacexpr list
 | GTacWth of glb_tacexpr open_match
+| GTacFullMatch of glb_tacexpr * (glb_pat * glb_tacexpr) list
 | GTacExt : (_, 'a) Tac2dyn.Arg.tag * 'a -> glb_tacexpr
 | GTacPrm of ml_tactic_name * glb_tacexpr list
 

--- a/plugins/ltac2/tac2print.mli
+++ b/plugins/ltac2/tac2print.mli
@@ -31,6 +31,10 @@ val pr_internal_constructor : type_constant -> int -> bool -> Pp.t
 val pr_projection : ltac_projection -> Pp.t
 val pr_glbexpr_gen : exp_level -> glb_tacexpr -> Pp.t
 val pr_glbexpr : glb_tacexpr -> Pp.t
+val pr_partial_pat : PartialPat.t -> Pp.t
+
+(** Utility function *)
+val partial_pat_of_glb_pat : glb_pat -> PartialPat.t
 
 (** {5 Printing values}*)
 

--- a/test-suite/ltac2/matching.v
+++ b/test-suite/ltac2/matching.v
@@ -69,3 +69,60 @@ Goal 2 = 3.
         | e => Control.zero e
         end).
 Abort.
+
+Fail Ltac2 Eval fun x => match x with (x,x) => x end.
+Ltac2 Eval fun x => match x with (x,y) => x end.
+
+Module StupidTuple.
+  Ltac2 foo x :=
+    match x with
+    | ((a,b),c) => b
+    end .
+
+  Fail Ltac2 Eval foo (1,2).
+End StupidTuple.
+
+Module Empty.
+  Ltac2 Type empty := [].
+  Ltac2 bar (x:empty) := match x with end.
+End Empty.
+
+Module DeepType.
+  Ltac2 Type rec mylist := [ Nil | One (unit option) | Cons (unit option, mylist) ].
+
+  Fail Ltac2 test x :=
+    match x with
+    | Nil, _ => ()
+    | _, Nil => ()
+    | One None, _ => ()
+    | _, One None => ()
+    end.
+
+  Fail Ltac2 test x :=
+    match x with
+    | Nil, _ => ()
+    | _, Nil => ()
+    | One None, _ => ()
+    | _, One None => ()
+    | Cons _ _, Cons _ _ => ()
+    end.
+
+  Succeed Ltac2 test x :=
+    match x with
+    | Nil, _ => ()
+    | _, Nil => ()
+    | One None, _ => ()
+    | _, One None => ()
+    | _, _ => ()
+    end.
+
+  Succeed Ltac2 test x :=
+    match x with
+    | Nil, _ => ()
+    | _, Nil => ()
+    | One _, _ => ()
+    | _, One _ => ()
+    | Cons _ _, _ => ()
+    | _, Cons _ _ => ()
+    end.
+End DeepType.


### PR DESCRIPTION
The system checks that the match is exhaustive printing an example
missing pattern when it's not (unlike ocaml it's an error not a
warning).

If the already existing code can handle the match we then intern it
that way. This keeps the same efficient evaluation for matches which
were already handled. Otherwise we have a naive interpreter where a
match is just a list of `pattern * expression` and we test each
pattern in order.

Not sure if it's worth keeping the optimized glb cases for simple
matches. I guess we should find some bench cases to know what the
difference looks like.

Empty matches only work if the type is empty in a shallow way, ie
`fun x => match x with end` works for `x:empty` but not for `x:empty * empty`.

Future work:
- useless pattern analysis (ie warn if the user write `None | None`)
- patterns for records, strings, ints, floats
- more efficient compilation
