### PR TITLE
`Ltac intuition_solver`: warn if `auto with *` was needed

### DIFF
--- a/doc/changelog/04-tactics/16026-intuition-with-core.rst
+++ b/doc/changelog/04-tactics/16026-intuition-with-core.rst
@@ -1,0 +1,10 @@
+- **Deprecated:** the default ``intuition_solver`` (see
+  :tacn:`intuition`) now outputs warning ``intuition-auto-with-star``
+  if it solves a goal with ``auto with *`` that was not solved with
+  just :tacn:`auto`. In a future version it will be changed to just
+  :tacn:`auto`. Use ``intuition tac`` locally or ``Ltac
+  Tauto.intuition_solver ::= tac`` globally to silence the warning in
+  a forward compatible way with your choice of tactic ``tac``
+  (``auto``, ``auto with *``, ``auto with`` your prefered databases,
+  or any other tactic) (`#16026
+  <https://github.com/coq/coq/pull/16026>`_, by Gaëtan Gilbert).

--- a/doc/sphinx/proofs/automatic-tactics/logic.rst
+++ b/doc/sphinx/proofs/automatic-tactics/logic.rst
@@ -56,7 +56,17 @@ Solvers for logic and equality
    Uses the search tree built by the decision procedure for :tacn:`tauto`
    to generate a set of subgoals equivalent to the original one (but
    simpler than it) and applies :n:`@ltac_expr` to them :cite:`Mun94`. If
-   :n:`@ltac_expr` is not specified, it defaults to :n:`auto with *`
+   :n:`@ltac_expr` is not specified, it defaults to ``Tauto.intuition_solver``.
+
+   The initial value of ``intuition_solver`` is equivalent to :n:`auto
+   with *` but prints warning ``intuition-auto-with-star`` when it
+   solves a goal that :tacn:`auto` cannot solve. In a future version
+   it will be changed to just :tacn:`auto`. Use ``intuition tac``
+   locally or ``Ltac Tauto.intuition_solver ::= tac`` globally to
+   silence the warning in a forward compatible way with your choice of
+   tactic ``tac`` (``auto``, ``auto with *``, ``auto with`` your
+   prefered databases, or any other tactic).
+
    If :n:`@ltac_expr` fails on some goals then :tacn:`intuition` fails. In fact,
    :tacn:`tauto` is simply :g:`intuition fail`.
 

--- a/plugins/ltac/tauto.ml
+++ b/plugins/ltac/tauto.ml
@@ -253,6 +253,20 @@ let with_flags flags _ ist =
   let ist = { ist with lfun = Id.Map.add x.CAst.v arg ist.lfun } in
   eval_tactic_ist ist (CAst.make @@ TacArg (TacCall (CAst.make (Locus.ArgVar f, [Reference (Locus.ArgVar x)]))))
 
+let warn_auto_with_star = CWarnings.create ~name:"intuition-auto-with-star" ~category:"deprecated"
+    Pp.(fun () ->
+        str "\"auto with *\" was used through the default \"intuition_solver\" tactic."
+        ++ spc() ++ str "This will be replaced by just \"auto\" in the future.")
+
+let warn_auto_with_star_tac _ _ =
+  Proofview.tclBIND
+    (Proofview.tclUNIT ())
+    begin fun () ->
+      warn_auto_with_star ();
+      Proofview.tclUNIT()
+    end
+
+
 let register_tauto_tactic tac name0 args =
   let ids = List.map (fun id -> Id.of_string id) args in
   let ids = List.map (fun id -> Name id) ids in
@@ -273,3 +287,4 @@ let () = register_tauto_tactic apply_nnpp "apply_nnpp" []
 let () = register_tauto_tactic reduction_not_iff "reduction_not_iff" []
 let () = register_tauto_tactic (with_flags tauto_uniform_unit_flags) "with_uniform_flags" ["f"]
 let () = register_tauto_tactic (with_flags tauto_power_flags) "with_power_flags" ["f"]
+let () = register_tauto_tactic warn_auto_with_star_tac "warn_auto_with_star" []

--- a/theories/Arith/Le.v
+++ b/theories/Arith/Le.v
@@ -67,7 +67,7 @@ Definition le_elim_rel_stt :
 Proof.
   intros P H0 HS n.
   induction n; trivial.
-  intros m Le. elim Le; intuition.
+  intros m Le. elim Le; intuition auto with arith.
 Qed.
 #[deprecated(since="8.16",note="The Arith.Le file is obsolete.")]
 Notation le_elim_rel := le_elim_rel_stt.

--- a/theories/Bool/Bool.v
+++ b/theories/Bool/Bool.v
@@ -16,6 +16,8 @@ Inductive bool : Set := true : bool | false : bool
 
 (** Most of the lemmas in this file are trivial by case analysis *)
 
+Local Ltac Tauto.intuition_solver ::= auto with bool.
+
 Ltac destr_bool :=
  intros; destruct_all bool; simpl in *; trivial; try discriminate.
 

--- a/theories/Bool/BoolOrder.v
+++ b/theories/Bool/BoolOrder.v
@@ -15,6 +15,7 @@
 Require Export Bool.
 Require Import Orders.
 Import BoolNotations.
+Local Ltac Tauto.intuition_solver ::= auto with typeclass_instances relations.
 
 (** * Order [le] *)
 

--- a/theories/Classes/CMorphisms.v
+++ b/theories/Classes/CMorphisms.v
@@ -717,7 +717,7 @@ Lemma StrictOrder_PartialOrder
   `(Equivalence A eqA, StrictOrder A R, Proper _ (eqA==>eqA==>iffT) R) :
   PartialOrder eqA (relation_disjunction R eqA).
 Proof.
-intros. intros x y. compute. intuition.
+intros. intros x y. compute. intuition auto with crelations.
 elim (StrictOrder_Irreflexive x).
 transitivity y; auto.
 Qed.

--- a/theories/Classes/CRelationClasses.v
+++ b/theories/Classes/CRelationClasses.v
@@ -282,7 +282,7 @@ Tactic Notation "apply" "*" constr(t) :=
 
 Ltac simpl_crelation :=
   unfold flip, impl, arrow ; try reduce ; program_simpl ;
-    try ( solve [ dintuition ]).
+    try ( solve [ dintuition auto with crelations ]).
 
 Local Obligation Tactic := simpl_crelation.
 

--- a/theories/Classes/Equivalence.v
+++ b/theories/Classes/Equivalence.v
@@ -54,7 +54,7 @@ Infix "=~=" := pequiv (at level 70, no associativity) : equiv_scope.
 (** Shortcuts to make proof search easier. *)
 
 #[global]
-Program Instance equiv_reflexive `(sa : Equivalence A) : Reflexive equiv | 1.
+ Program Instance equiv_reflexive `(sa : Equivalence A) : Reflexive equiv | 1.
 
 #[global]
 Program Instance equiv_symmetric `(sa : Equivalence A) : Symmetric equiv | 1.
@@ -63,8 +63,9 @@ Program Instance equiv_symmetric `(sa : Equivalence A) : Symmetric equiv | 1.
 Program Instance equiv_transitive `(sa : Equivalence A) : Transitive equiv | 1.
 
   Next Obligation.
-  Proof. intros A R sa x y z Hxy Hyz.
-         now transitivity y.
+  Proof.
+    intros A R sa x y z Hxy Hyz.
+    now transitivity y.
   Qed.
 
 Arguments equiv_symmetric {A R} sa x y : rename.

--- a/theories/Classes/Morphisms.v
+++ b/theories/Classes/Morphisms.v
@@ -788,7 +788,7 @@ Lemma StrictOrder_PartialOrder
   `(Equivalence A eqA, StrictOrder A R, Proper _ (eqA==>eqA==>iff) R) :
   PartialOrder eqA (relation_disjunction R eqA).
 Proof.
-intros. intros x y. compute. intuition.
+intros. intros x y. compute. intuition auto with relations.
 elim (StrictOrder_Irreflexive x).
 transitivity y; auto.
 Qed.

--- a/theories/Classes/RelationClasses.v
+++ b/theories/Classes/RelationClasses.v
@@ -291,7 +291,7 @@ Tactic Notation "apply" "*" constr(t) :=
 
 Ltac simpl_relation :=
   unfold flip, impl, arrow ; try reduce ; program_simpl ;
-    try ( solve [ dintuition ]).
+    try ( solve [ dintuition auto with relations ]).
 
 Local Obligation Tactic := try solve [ simpl_relation ].
 

--- a/theories/FSets/FMapAVL.v
+++ b/theories/FSets/FMapAVL.v
@@ -547,7 +547,7 @@ Ltac order := match goal with
  | _ => MX.order
 end.
 
-Ltac intuition_in := repeat (intuition; inv In; inv MapsTo).
+Ltac intuition_in := repeat (intuition auto; inv In; inv MapsTo).
 
 (* Function/Functional Scheme can't deal with internal fix.
    Let's do its job by hand: *)
@@ -1045,7 +1045,7 @@ Proof.
  - generalize (remove_min_bst H0); rewrite e1; simpl in *; auto.
  - intro; intro.
    apply H1; auto.
-   generalize (remove_min_in l2 x2 d2 r2 _x4 x); rewrite e1; simpl; intuition.
+   generalize (remove_min_in l2 x2 d2 r2 _x4 x); rewrite e1; simpl; intuition auto with relations.
  - generalize (remove_min_gt_tree H0); rewrite e1; simpl; auto.
 Qed.
 
@@ -1093,7 +1093,7 @@ Qed.
 
 Lemma remove_1 : forall m x y, bst m -> X.eq x y -> ~ In y (remove x m).
 Proof.
- intros; rewrite remove_in; intuition.
+ intros; rewrite remove_in; intuition auto with relations.
 Qed.
 
 Lemma remove_2 : forall m x y e, bst m -> ~X.eq x y ->
@@ -1319,7 +1319,7 @@ Proof.
  - intros.
    rewrite Hl.
    destruct (Hr acc x0 e0); clear Hl Hr.
-   intuition; inversion_clear H3; intuition.
+   intuition; inversion_clear H3; intuition auto with ordered_type.
    destruct H0; simpl in *; subst; intuition.
 Qed.
 

--- a/theories/FSets/FMapFacts.v
+++ b/theories/FSets/FMapFacts.v
@@ -20,6 +20,8 @@ Require Export FMapInterface.
 Set Implicit Arguments.
 Unset Strict Implicit.
 
+Local Ltac Tauto.intuition_solver ::= auto with bool map.
+
 #[global]
 Hint Extern 1 (Equivalence _) => constructor; congruence : core.
 
@@ -1948,7 +1950,7 @@ Module OrdProperties (M:S).
     rewrite InA_app_iff, InA_cons, InA_nil, <- 2 elements_mapsto_iff,
       find_mapsto_iff, (H0 t0), <- find_mapsto_iff,
       add_mapsto_iff.
-    unfold O.eqke; simpl. intuition.
+    unfold O.eqke; simpl. intuition auto with relations.
     destruct (E.eq_dec x t0) as [Heq|Hneq]; auto.
     exfalso.
     assert (In t0 m).
@@ -1981,7 +1983,7 @@ Module OrdProperties (M:S).
     rewrite InA_cons, <- 2 elements_mapsto_iff,
       find_mapsto_iff, (H0 t0), <- find_mapsto_iff,
       add_mapsto_iff.
-    unfold O.eqke; simpl. intuition.
+    unfold O.eqke; simpl. intuition auto with relations.
     destruct (E.eq_dec x t0) as [Heq|Hneq]; auto.
     exfalso.
     assert (In t0 m) by

--- a/theories/FSets/FMapList.v
+++ b/theories/FSets/FMapList.v
@@ -462,7 +462,7 @@ Lemma equal_2 : forall m (Hm:Sort m) m' (Hm:Sort m') cmp,
 Proof with auto with ordered_type.
  intros m Hm m' Hm' cmp; generalize Hm Hm'; clear Hm Hm'.
  functional induction (equal cmp m m'); simpl; subst;auto; unfold Equivb;
-  intuition; try discriminate; subst;
+  intuition auto; try discriminate; subst;
   try match goal with H: X.compare _ _ = _ |- _ => clear H end.
 
  - inversion H0.
@@ -631,7 +631,7 @@ Proof.
      * constructor 1.
        unfold eqke in *; simpl in *; intuition congruence.
    + destruct IHm as (y, hyp); auto.
-     exists y; intuition.
+     exists y; intuition auto with ordered_type.
 Qed.
 
 
@@ -1216,14 +1216,14 @@ Lemma eq_equal : forall m m', eq m m' <-> equal cmp m m' = true.
 Proof.
   intros (l,Hl); induction l.
   - intros (l',Hl'); unfold eq; simpl.
-    destruct l'; unfold equal; simpl; intuition.
+    destruct l'; unfold equal; simpl; intuition auto with bool.
   - intros (l',Hl'); unfold eq.
     destruct l'.
-    + destruct a; unfold equal; simpl; intuition.
+    + destruct a; unfold equal; simpl; intuition auto with bool.
     + destruct a as (x,e).
       destruct p as (x',e').
       unfold equal; simpl.
-      destruct (X.compare x x') as [Hlt|Heq|Hlt]; simpl; intuition.
+      destruct (X.compare x x') as [Hlt|Heq|Hlt]; simpl; intuition auto with bool.
       * unfold cmp at 1.
         MD.elim_comp; clear H; simpl.
         inversion_clear Hl.
@@ -1274,7 +1274,7 @@ Proof.
  intros (m,Hm); induction m;
  intros (m', Hm'); destruct m'; unfold eq; simpl;
  try destruct a as (x,e); try destruct p as (x',e'); auto.
- destruct (X.compare x x')  as [Hlt|Heq|Hlt]; MapS.Raw.MX.elim_comp; intuition.
+ destruct (X.compare x x')  as [Hlt|Heq|Hlt]; MapS.Raw.MX.elim_comp; intuition auto with ordered_type.
  inversion_clear Hm; inversion_clear Hm'.
  apply (IHm H0 (Build_slist H4)); auto.
 Qed.

--- a/theories/FSets/FSetBridge.v
+++ b/theories/FSets/FSetBridge.v
@@ -21,6 +21,7 @@ Set Firstorder Depth 2.
 (** * From non-dependent signature [S] to dependent signature [Sdep]. *)
 
 Module DepOfNodep (Import M: S) <: Sdep with Module E := M.E.
+  Local Ltac Tauto.intuition_solver ::= auto with bool set.
 
   Definition empty : {s : t | Empty s}.
   Proof.

--- a/theories/FSets/FSetCompat.v
+++ b/theories/FSets/FSetCompat.v
@@ -14,6 +14,8 @@ Require Import FSetInterface FSetFacts MSetInterface MSetFacts.
 Set Implicit Arguments.
 Unset Strict Implicit.
 
+Local Ltac Tauto.intuition_solver ::= auto with relations.
+
 (** * From new Weak Sets to old ones *)
 
 Module Backport_WSets

--- a/theories/FSets/FSetDecide.v
+++ b/theories/FSets/FSetDecide.v
@@ -507,7 +507,7 @@ the above form:
     Lemma dec_In : forall x s,
       decidable (In x s).
     Proof.
-      red; intros; generalize (F.mem_iff s x); case (mem x s); intuition.
+      red; intros; generalize (F.mem_iff s x); case (mem x s); intuition auto with bool.
     Qed.
 
     (** [E.eq] is decidable. *)

--- a/theories/FSets/FSetEqProperties.v
+++ b/theories/FSets/FSetEqProperties.v
@@ -152,7 +152,7 @@ Qed.
 
 Lemma equal_sym: equal s s'=equal s' s.
 Proof.
-intros; apply bool_1; do 2 rewrite <- equal_iff; intuition.
+intros; apply bool_1; do 2 rewrite <- equal_iff; intuition auto with relations.
 Qed.
 
 Lemma equal_trans:
@@ -492,7 +492,7 @@ Lemma exclusive_set : forall s s' x,
  ~(In x s/\In x s') <-> mem x s && mem x s'=false.
 Proof.
 intros; do 2 rewrite mem_iff.
-destruct (mem x s); destruct (mem x s'); intuition.
+destruct (mem x s); destruct (mem x s'); intuition auto with bool.
 Qed.
 
 Section Fold.

--- a/theories/FSets/FSetFacts.v
+++ b/theories/FSets/FSetFacts.v
@@ -46,7 +46,7 @@ Qed.
 
 Lemma not_mem_iff : ~In x s <-> mem x s = false.
 Proof.
-rewrite mem_iff; destruct (mem x s); intuition.
+rewrite mem_iff; destruct (mem x s); intuition auto with bool.
 Qed.
 
 Lemma equal_iff : s[=]s' <-> equal s s' = true.

--- a/theories/FSets/FSetProperties.v
+++ b/theories/FSets/FSetProperties.v
@@ -35,7 +35,7 @@ Module WProperties_fun (Import E : DecidableType)(M : WSfun E).
 
   Lemma In_dec : forall x s, {In x s} + {~ In x s}.
   Proof.
-  intros; generalize (mem_iff s x); case (mem x s); intuition.
+  intros; generalize (mem_iff s x); case (mem x s); intuition auto with bool.
   Qed.
 
   Definition Add x s s' := forall y, In y s' <-> E.eq x y \/ In y s.
@@ -711,7 +711,7 @@ Module WProperties_fun (Import E : DecidableType)(M : WSfun E).
         (forall x : elt, In x s <-> InA E.eq x l) /\
         cardinal s = length l.
   Proof.
-  intros; exists (elements s); intuition; apply cardinal_1.
+  intros; exists (elements s); intuition auto with set; apply cardinal_1.
   Qed.
 
   Lemma cardinal_1 : forall s, Empty s -> cardinal s = 0.
@@ -943,7 +943,7 @@ Module OrdProperties (M:S).
 
   Lemma leb_1 : forall x y, leb x y = true <-> ~E.lt y x.
   Proof.
-   intros; unfold leb, gtb; destruct (E.compare x y); intuition; try discriminate; ME.order.
+   intros; unfold leb, gtb; destruct (E.compare x y); intuition try discriminate; ME.order.
   Qed.
 
   Lemma gtb_compat : forall x, Proper (E.eq==>Logic.eq) (gtb x).
@@ -976,8 +976,7 @@ Module OrdProperties (M:S).
   intros.
   rewrite gtb_1 in H.
   assert (~E.lt y x). {
-   unfold gtb in *; destruct (E.compare x y); intuition;
-   try discriminate; ME.order.
+   unfold gtb in *; destruct (E.compare x y); intuition try discriminate; ME.order.
   }
   ME.order.
   Qed.
@@ -1011,8 +1010,8 @@ Module OrdProperties (M:S).
   - red; intros a.
     rewrite InA_app_iff, InA_cons, !filter_InA, <-elements_iff,
       leb_1, gtb_1, (H0 a) by auto with fset.
-    intuition.
-    destruct (E.compare a x); intuition.
+    intuition auto with relations set.
+    destruct (E.compare a x); intuition auto with set.
     fold (~E.lt a x); auto with ordered_type set.
   Qed.
 
@@ -1036,7 +1035,7 @@ Module OrdProperties (M:S).
       * inversion H3.
   - red; intros a.
     rewrite InA_app_iff, InA_cons, InA_nil.
-    do 2 rewrite <- elements_iff; rewrite (H0 a); intuition.
+    do 2 rewrite <- elements_iff; rewrite (H0 a); intuition auto with relations.
   Qed.
 
   Lemma elements_Add_Below : forall s s' x,
@@ -1058,7 +1057,7 @@ Module OrdProperties (M:S).
       * inversion H3.
   - red; intros a.
     rewrite InA_cons.
-    do 2 rewrite <- elements_iff; rewrite (H0 a); intuition.
+    do 2 rewrite <- elements_iff; rewrite (H0 a); intuition auto with relations.
   Qed.
 
   (** Two other induction principles on sets: we can be more restrictive

--- a/theories/Init/Tauto.v
+++ b/theories/Init/Tauto.v
@@ -101,7 +101,7 @@ Local Ltac tauto_gen flags := tauto_intuitionistic flags || tauto_classical flag
 Ltac tauto := with_uniform_flags ltac:(fun flags => tauto_gen flags).
 Ltac dtauto := with_power_flags ltac:(fun flags => tauto_gen flags).
 
-Ltac intuition_solver := auto with *.
+Ltac intuition_solver := auto.
 
 Local Ltac intuition_then tac := with_uniform_flags ltac:(fun flags => intuition_gen flags tac).
 Ltac intuition := intuition_then ltac:(idtac;intuition_solver).

--- a/theories/Init/Tauto.v
+++ b/theories/Init/Tauto.v
@@ -101,7 +101,9 @@ Local Ltac tauto_gen flags := tauto_intuitionistic flags || tauto_classical flag
 Ltac tauto := with_uniform_flags ltac:(fun flags => tauto_gen flags).
 Ltac dtauto := with_power_flags ltac:(fun flags => tauto_gen flags).
 
-Ltac intuition_solver := auto.
+Ltac intuition_solver :=
+  first [solve [auto]
+        | tryif solve [auto with *] then warn_auto_with_star else idtac].
 
 Local Ltac intuition_then tac := with_uniform_flags ltac:(fun flags => intuition_gen flags tac).
 Ltac intuition := intuition_then ltac:(idtac;intuition_solver).

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -350,6 +350,9 @@ Hint Resolve app_eq_unit app_inj_tail: datatypes.
 #[global]
 Hint Resolve in_eq in_cons in_inv in_nil in_app_or in_or_app: datatypes.
 
+(* XXX declare datatypes db and move to top of file *)
+Local Ltac Tauto.intuition_solver ::= auto with datatypes.
+
 
 
 (*******************************************)

--- a/theories/Lists/SetoidList.v
+++ b/theories/Lists/SetoidList.v
@@ -139,7 +139,7 @@ Qed.
 Global Instance eqlistA_equivlistA : subrelation eqlistA equivlistA.
 Proof.
   intros x x' H. induction H as [|? ? ? ? H ? IHeqlistA].
-  - intuition.
+  - intuition auto with relations.
   - red; intros x0.
     rewrite 2 InA_cons.
     rewrite (IHeqlistA x0), H; intuition.

--- a/theories/Lists/SetoidPermutation.v
+++ b/theories/Lists/SetoidPermutation.v
@@ -14,6 +14,8 @@ Require Import Permutation SetoidList.
 Set Implicit Arguments.
 Unset Strict Implicit.
 
+Local Ltac Tauto.intuition_solver ::= auto with relations.
+
 (** Permutations of list modulo a setoid equality. *)
 
 (** Contribution by Robbert Krebbers (Nijmegen University). *)

--- a/theories/MSets/MSetAVL.v
+++ b/theories/MSets/MSetAVL.v
@@ -750,8 +750,8 @@ Proof.
  functional induction union s1 s2; intros B1 B2; auto.
  factornode s2; destruct_split; inv.
  apply join_ok; auto with *.
- - intro y; rewrite union_spec, split_spec1; intuition_in.
- - intro y; rewrite union_spec, split_spec2; intuition_in.
+ - intro y; rewrite union_spec, split_spec1; intuition_in; exact _.
+ - intro y; rewrite union_spec, split_spec2; intuition_in; exact _.
 Qed.
 
 (** * Filter *)

--- a/theories/MSets/MSetDecide.v
+++ b/theories/MSets/MSetDecide.v
@@ -507,7 +507,7 @@ the above form:
     Lemma dec_In : forall x s,
       decidable (In x s).
     Proof.
-      red; intros; generalize (F.mem_iff s x); case (mem x s); intuition.
+      red; intros; generalize (F.mem_iff s x); case (mem x s); intuition auto with bool.
     Qed.
 
     (** [E.eq] is decidable. *)

--- a/theories/MSets/MSetEqProperties.v
+++ b/theories/MSets/MSetEqProperties.v
@@ -154,7 +154,7 @@ Qed.
 
 Lemma equal_sym: equal s s'=equal s' s.
 Proof.
-intros; apply bool_1; do 2 rewrite <- equal_iff; intuition.
+intros; apply bool_1; do 2 rewrite <- equal_iff; intuition auto with relations.
 Qed.
 
 Lemma equal_trans:
@@ -494,7 +494,7 @@ Lemma exclusive_set : forall s s' x,
  ~(In x s/\In x s') <-> mem x s && mem x s'=false.
 Proof.
 intros; do 2 rewrite mem_iff.
-destruct (mem x s); destruct (mem x s'); intuition.
+destruct (mem x s); destruct (mem x s'); intuition auto with bool.
 Qed.
 
 Section Fold.

--- a/theories/MSets/MSetFacts.v
+++ b/theories/MSets/MSetFacts.v
@@ -21,6 +21,8 @@ Require Export MSetInterface.
 Set Implicit Arguments.
 Unset Strict Implicit.
 
+Local Ltac Tauto.intuition_solver ::= auto with relations.
+
 (** First, a functor for Weak Sets in functorial version. *)
 
 Module WFactsOn (Import E : DecidableType)(Import M : WSetsOn E).
@@ -170,7 +172,7 @@ Proof. apply iff_sym, mem_spec. Qed.
 
 Lemma not_mem_iff : ~In x s <-> mem x s = false.
 Proof.
-rewrite <-mem_spec; destruct (mem x s); intuition.
+rewrite <-mem_spec; destruct (mem x s); intuition auto with bool.
 Qed.
 
 Lemma equal_iff : s[=]s' <-> equal s s' = true.

--- a/theories/MSets/MSetGenTree.v
+++ b/theories/MSets/MSetGenTree.v
@@ -382,7 +382,7 @@ Ltac invtree f :=
 
 Ltac inv := inv_ok; invtree InT.
 
-Ltac intuition_in := repeat (intuition; inv).
+Ltac intuition_in := repeat (intuition auto; inv).
 
 (** Helper tactic concerning order of elements. *)
 
@@ -1157,7 +1157,7 @@ Lemma maxdepth_log_cardinal s : s <> Leaf ->
 Proof.
  intros H.
  apply Nat.log2_lt_pow2.
- - destruct s; simpl; intuition.
+ - destruct s; simpl; intuition auto with arith.
  - apply maxdepth_cardinal.
 Qed.
 

--- a/theories/MSets/MSetList.v
+++ b/theories/MSets/MSetList.v
@@ -863,8 +863,8 @@ Module MakeRaw (X: OrderedType) <: RawSets X.
 
   Lemma compare_spec_aux : forall s s', CompSpec eq L.lt s s' (compare s s').
   Proof.
-  induction s as [|x s IH]; intros [|x' s']; simpl; intuition. 
-  elim_compare x x'; auto.
+    induction s as [|x s IH]; intros [|x' s']; simpl; intuition auto with relations.
+    elim_compare x x'; auto.
   Qed.
 
   Lemma compare_spec : forall s s', Ok s -> Ok s' ->

--- a/theories/MSets/MSetProperties.v
+++ b/theories/MSets/MSetProperties.v
@@ -21,6 +21,8 @@ Require Import PeanoNat DecidableTypeEx OrdersLists MSetFacts MSetDecide.
 Set Implicit Arguments.
 Unset Strict Implicit.
 
+Local Ltac Tauto.intuition_solver ::= auto with relations.
+
 #[global]
 Hint Unfold transpose : core.
 
@@ -33,7 +35,7 @@ Module WPropertiesOn (Import E : DecidableType)(M : WSetsOn E).
 
   Lemma In_dec : forall x s, {In x s} + {~ In x s}.
   Proof.
-  intros; generalize (mem_iff s x); case (mem x s); intuition.
+  intros; generalize (mem_iff s x); case (mem x s); intuition auto with bool.
   Qed.
 
   Definition Add x s s' := forall y, In y s' <-> E.eq x y \/ In y s.
@@ -709,7 +711,7 @@ Module WPropertiesOn (Import E : DecidableType)(M : WSetsOn E).
         (forall x : elt, In x s <-> InA E.eq x l) /\
         cardinal s = length l.
   Proof.
-  intros; exists (elements s); intuition; apply cardinal_1.
+  intros; exists (elements s); intuition auto with set; apply cardinal_1.
   Qed.
 
   Lemma cardinal_1 : forall s, Empty s -> cardinal s = 0.

--- a/theories/MSets/MSetWeakList.v
+++ b/theories/MSets/MSetWeakList.v
@@ -17,6 +17,8 @@ Require Import MSetInterface.
 Set Implicit Arguments.
 Unset Strict Implicit.
 
+Local Ltac Tauto.intuition_solver ::= auto with typeclass_instances.
+
 (** * Functions over lists
 
    First, we provide sets as lists which are (morally) without redundancy.
@@ -360,7 +362,7 @@ Module MakeRaw (X:DecidableType) <: WRawSets X.
   unfold Empty; intros.
   intuition.
   - specialize (H a). rewrite diff_spec in H; intuition.
-    rewrite <- (mem_spec a) in H |- *. destruct (mem a s'); intuition.
+    rewrite <- (mem_spec a) in H |- *. destruct (mem a s'); intuition auto with bool.
   - rewrite diff_spec in H0; intuition.
   Qed.
 

--- a/theories/Numbers/Integer/Abstract/ZDivEucl.v
+++ b/theories/Numbers/Integer/Abstract/ZDivEucl.v
@@ -251,7 +251,7 @@ Qed.
 Lemma div_1_r: forall a, a/1 == a.
 Proof.
 intros. symmetry. apply div_unique with 0.
-- assert (H:=lt_0_1); rewrite abs_pos; intuition; order.
+- assert (H:=lt_0_1); rewrite abs_pos; intuition auto; order.
 - now nzsimpl.
 Qed.
 

--- a/theories/Numbers/Integer/Abstract/ZDivFloor.v
+++ b/theories/Numbers/Integer/Abstract/ZDivFloor.v
@@ -162,7 +162,7 @@ Lemma div_opp_l_z :
  forall a b, b~=0 -> a mod b == 0 -> (-a)/b == -(a/b).
 Proof.
 intros a b Hb H. symmetry. apply div_unique with 0.
-- destruct (lt_ge_cases 0 b); [left|right]; intuition; order.
+- destruct (lt_ge_cases 0 b); [left|right]; intuition auto; order.
 - rewrite <- opp_0, <- H.
   rewrite mul_opp_r, <- opp_add_distr, <- div_mod; order.
 Qed.
@@ -184,7 +184,7 @@ Lemma mod_opp_l_z :
  forall a b, b~=0 -> a mod b == 0 -> (-a) mod b == 0.
 Proof.
 intros a b Hb H. symmetry. apply mod_unique with (-(a/b)).
-- destruct (lt_ge_cases 0 b); [left|right]; intuition; order.
+- destruct (lt_ge_cases 0 b); [left|right]; intuition auto; order.
 - rewrite <- opp_0, <- H.
   rewrite mul_opp_r, <- opp_add_distr, <- div_mod; order.
 Qed.

--- a/theories/Numbers/NatInt/NZDiv.v
+++ b/theories/Numbers/NatInt/NZDiv.v
@@ -71,7 +71,7 @@ assert (U : forall q1 q2 r1 r2,
 - intros q1 q2 r1 r2 Hr1 Hr2 EQ; destruct (lt_trichotomy q1 q2) as [LT|[EQ'|GT]].
   + elim (U q1 q2 r1 r2); intuition.
   + split; auto. rewrite EQ' in EQ. rewrite add_cancel_l in EQ; auto.
-  + elim (U q2 q1 r2 r1); intuition.
+  + elim (U q2 q1 r2 r1); intuition auto with relations.
 Qed.
 
 Theorem div_unique:
@@ -110,7 +110,7 @@ Qed.
 Lemma mod_same : forall a, 0<a -> a mod a == 0.
 Proof.
 intros. symmetry.
-apply mod_unique with 1; intuition; try order.
+apply mod_unique with 1; intuition auto; try order.
 now nzsimpl.
 Qed.
 

--- a/theories/Numbers/NatInt/NZOrder.v
+++ b/theories/Numbers/NatInt/NZOrder.v
@@ -82,7 +82,7 @@ Theorem le_gt_cases : forall n m, n <= m \/ n > m.
 Proof.
 intros n m; nzinduct n m.
 - left; apply le_refl.
-- intro n. rewrite lt_succ_r, le_succ_l, !lt_eq_cases. intuition.
+- intro n. rewrite lt_succ_r, le_succ_l, !lt_eq_cases. intuition auto with relations.
 Qed.
 
 Theorem lt_trichotomy : forall n m,  n < m \/ n == m \/ m < n.
@@ -145,7 +145,7 @@ Instance le_partialorder : PartialOrder _ le.
 Proof.
 intros x y. compute. split.
 - intro EQ; now rewrite EQ.
-- rewrite 2 lt_eq_cases. intuition. elim (lt_irrefl x). now transitivity y.
+- rewrite 2 lt_eq_cases. intuition auto with relations. elim (lt_irrefl x). now transitivity y.
 Qed.
 
 (** We know enough now to benefit from the generic [order] tactic. *)

--- a/theories/Numbers/Natural/Abstract/NAdd.v
+++ b/theories/Numbers/Natural/Abstract/NAdd.v
@@ -21,7 +21,7 @@ Include NBaseProp N.
 Theorem eq_add_0 : forall n m, n + m == 0 <-> n == 0 /\ m == 0.
 Proof.
 intros n m; induct n.
-- nzsimpl; intuition.
+- nzsimpl; intuition auto with relations.
 - intros n IH. nzsimpl.
 setoid_replace (S (n + m) == 0) with False by
  (apply neg_false; apply neq_succ_0).

--- a/theories/Reals/RIneq.v
+++ b/theories/Reals/RIneq.v
@@ -27,6 +27,8 @@ Local Open Scope R_scope.
 
 Implicit Type r : R.
 
+Local Ltac Tauto.intuition_solver ::= auto with real.
+
 (*********************************************************)
 (** ** Relation between orders and equality              *)
 (*********************************************************)

--- a/theories/Reals/Ranalysis5.v
+++ b/theories/Reals/Ranalysis5.v
@@ -18,6 +18,8 @@ Require Import Lia.
 Require Import Lra.
 Local Open Scope R_scope.
 
+Local Ltac Tauto.intuition_solver ::= auto with rorders real.
+
 (** * Preliminaries lemmas *)
 
 Lemma f_incr_implies_g_incr_interv : forall f g:R->R, forall lb ub,

--- a/theories/Reals/Ratan.v
+++ b/theories/Reals/Ratan.v
@@ -24,6 +24,7 @@ Require Import PartSum.
 Require Import Lia.
 
 Local Open Scope R_scope.
+Local Ltac Tauto.intuition_solver ::= auto with rorders real arith.
 
 (*********************************************************)
 (** * Preliminaries                                      *)

--- a/theories/Reals/Rminmax.v
+++ b/theories/Reals/Rminmax.v
@@ -10,6 +10,8 @@
 
 Require Import Orders Rbase Rbasic_fun ROrderedType GenericMinMax.
 
+Local Ltac Tauto.intuition_solver ::= auto with real.
+
 (** * Maximum and Minimum of two real numbers *)
 
 Local Open Scope R_scope.

--- a/theories/Sets/Powerset_facts.v
+++ b/theories/Sets/Powerset_facts.v
@@ -34,6 +34,8 @@ Require Export Partial_Order.
 Require Export Cpo.
 Require Export Powerset.
 
+Local Ltac Tauto.intuition_solver ::= auto with sets.
+
 Section Sets_as_an_algebra.
   Variable U : Type.
 

--- a/theories/Sets/Relations_1_facts.v
+++ b/theories/Sets/Relations_1_facts.v
@@ -28,6 +28,8 @@
 
 Require Export Relations_1.
 
+Local Ltac Tauto.intuition_solver ::= auto with sets.
+
 Definition Complement (U:Type) (R:Relation U) : Relation U :=
   fun x y:U => ~ R x y.
 

--- a/theories/Sorting/CPermutation.v
+++ b/theories/Sorting/CPermutation.v
@@ -21,6 +21,8 @@ Require Import List Permutation Morphisms PeanoNat.
 Import ListNotations. (* For notations [] and [a;b;c] *)
 Set Implicit Arguments.
 
+Local Ltac Tauto.intuition_solver ::= auto with datatypes.
+
 Section CPermutation.
 
 Variable A:Type.

--- a/theories/Sorting/PermutEq.v
+++ b/theories/Sorting/PermutEq.v
@@ -88,7 +88,7 @@ Section Perm.
     intros H H' [H0 H0'].
     destruct (multiplicity (list_contents l) a) as [|[|n]],
              (multiplicity (list_contents l') a) as [|[|n']];
-    [ tauto | intuition | | intuition | tauto | intuition |  | intuition | ]; exfalso.
+    [ tauto | | | | tauto | |  | | ]; try solve [intuition auto with arith]; exfalso.
     - now inversion H'.
     - now inversion H.
     - now inversion H.

--- a/theories/Sorting/Permutation.v
+++ b/theories/Sorting/Permutation.v
@@ -929,7 +929,8 @@ Qed.
 Lemma Permutation_Permutation_transp : forall l1 l2 : list A,
  Permutation l1 l2 <-> Permutation_transp l1 l2.
 Proof.
-  intros l1 l2; split; intros HP; induction HP; intuition.
+  intros l1 l2; split; intros HP; induction HP; intuition auto.
+  - solve_relation.
   - now apply Permutation_transp_cons.
   - rewrite <- (app_nil_l (y :: _)).
     rewrite <- (app_nil_l (x :: y :: _)).

--- a/theories/Structures/GenericMinMax.v
+++ b/theories/Structures/GenericMinMax.v
@@ -91,7 +91,7 @@ Lemma max_spec n m :
 Proof.
  destruct (lt_total n m); [left|right].
  - split; auto. apply max_r. rewrite le_lteq; auto.
- - assert (m <= n) by (rewrite le_lteq; intuition).
+ - assert (m <= n) by (rewrite le_lteq; intuition auto with relations).
    split; auto. now apply max_l.
 Qed.
 
@@ -247,7 +247,7 @@ Lemma min_spec n m :
 Proof.
  destruct (lt_total n m); [left|right].
  - split; auto. apply min_l. rewrite le_lteq; auto.
- - assert (m <= n) by (rewrite le_lteq; intuition).
+ - assert (m <= n) by (rewrite le_lteq; intuition auto with relations).
    split; auto. now apply min_r.
 Qed.
 
@@ -639,7 +639,7 @@ Module TOMaxEqDec_to_Compare
    absurd (x==y); auto. transitivity (max x y); auto.
    symmetry. apply max_l. rewrite le_lteq; intuition.
  - destruct (lt_total y x); auto.
-   absurd (max x y == y); auto. apply max_r; rewrite le_lteq; intuition.
+   absurd (max x y == y); auto. apply max_r; rewrite le_lteq; intuition auto with relations.
  Qed.
 
 End TOMaxEqDec_to_Compare.

--- a/theories/Structures/OrderedType.v
+++ b/theories/Structures/OrderedType.v
@@ -311,7 +311,7 @@ Module KeyOrderedType(O:OrderedType).
   Proof. auto with ordered_type. Qed.
 
   Lemma eqke_sym : forall e e', eqke e e' -> eqke e' e.
-  Proof. unfold eqke; intuition. Qed.
+  Proof. unfold eqke; intuition auto with relations. Qed.
 
   Lemma eqk_trans : forall e e' e'', eqk e e' -> eqk e' e'' -> eqk e e''.
   Proof. eauto with ordered_type. Qed.

--- a/theories/Structures/OrderedTypeEx.v
+++ b/theories/Structures/OrderedTypeEx.v
@@ -181,7 +181,7 @@ Module PairOrderedType(O1 O2:OrderedType) <: OrderedType.
 
  Lemma eq_sym : forall x y : t, eq x y -> eq y x.
  Proof.
- intros (x1,x2) (y1,y2); unfold eq; simpl; intuition.
+ intros (x1,x2) (y1,y2); unfold eq; simpl; intuition auto with relations.
  Qed.
 
  Lemma eq_trans : forall x y z : t, eq x y -> eq y z -> eq x z.

--- a/theories/Structures/Orders.v
+++ b/theories/Structures/Orders.v
@@ -318,7 +318,7 @@ Module TTLB_to_OTF (Import O : TotalTransitiveLeBool') <: OrderedTypeFull.
  Lemma eqb_eq : forall x y, eqb x y <-> eq x y.
  Proof.
  intros. unfold eq, eqb, le.
- case leb; simpl; intuition; discriminate.
+ case leb; simpl; intuition auto; discriminate.
  Qed.
 
  Include HasEqBool2Dec.
@@ -362,7 +362,7 @@ Module TTLB_to_OTF (Import O : TotalTransitiveLeBool') <: OrderedTypeFull.
  unfold lt, eq, le.
  split; [ | intuition ].
  intros LE.
- case_eq (y <=? x); [right|left]; intuition; try discriminate.
+ case_eq (y <=? x); [right|left]; intuition auto; discriminate.
  Qed.
 
 End TTLB_to_OTF.

--- a/theories/Structures/OrdersFacts.v
+++ b/theories/Structures/OrdersFacts.v
@@ -260,7 +260,7 @@ Instance lt_compat : Proper (eq==>eq==>iff) lt.
 Proof. unfold lt; auto with *. Qed.
 
 Lemma le_lteq : forall x y, le x y <-> lt x y \/ eq x y.
-Proof. intros; unfold le, lt, flip. rewrite O.le_lteq; intuition. Qed.
+Proof. intros; unfold le, lt, flip. rewrite O.le_lteq; intuition auto with relations. Qed.
 
 Definition compare := flip O.compare.
 

--- a/theories/Structures/OrdersTac.v
+++ b/theories/Structures/OrdersTac.v
@@ -81,8 +81,8 @@ Proof. auto with *. Qed.
 
 Lemma le_antisym : forall x y, x<=y -> y<=x -> x==y.
 Proof.
- intros x y; rewrite 2 P.le_lteq. intuition.
- elim (StrictOrder_Irreflexive x); transitivity y; auto.
+  intros x y; rewrite 2 P.le_lteq. intuition auto with relations.
+  elim (StrictOrder_Irreflexive x); transitivity y; auto.
 Qed.
 
 Lemma neq_sym : forall x y, ~x==y -> ~y==x.
@@ -134,7 +134,7 @@ Qed.
 Lemma not_ge_lt : forall x y, ~y<=x -> x<y.
 Proof.
 intros x y H. destruct (P.lt_total x y); auto.
-destruct H. rewrite P.le_lteq. intuition.
+destruct H. rewrite P.le_lteq. intuition auto with relations.
 Qed.
 
 Lemma not_gt_le : forall x y, ~y<x -> x<=y.

--- a/theories/ZArith/Int.v
+++ b/theories/ZArith/Int.v
@@ -21,6 +21,8 @@ Declare Scope Int_scope.
 Delimit Scope Int_scope with I.
 Local Open Scope Int_scope.
 
+Local Ltac Tauto.intuition_solver ::= auto with bool.
+
 (** * A specification of integers *)
 
 Module Type Int.

--- a/theories/ZArith/Zeven.v
+++ b/theories/ZArith/Zeven.v
@@ -17,6 +17,8 @@
 
 Require Import BinInt.
 
+Local Ltac Tauto.intuition_solver ::= auto with bool.
+
 Local Open Scope Z_scope.
 
 (** Historical formulation of even and odd predicates, based on

--- a/theories/ZArith/Znumtheory.v
+++ b/theories/ZArith/Znumtheory.v
@@ -18,6 +18,8 @@ Require Import Wf_nat.
 
 Open Scope Z_scope.
 
+Local Ltac Tauto.intuition_solver ::= auto with zarith.
+
 (** This file contains some notions of number theory upon Z numbers:
      - a divisibility predicate [Z.divide]
      - a gcd predicate [gcd]

--- a/theories/ZArith/Zquot.v
+++ b/theories/ZArith/Zquot.v
@@ -161,7 +161,7 @@ Definition Remainder_alt a b r :=
 Lemma Remainder_equiv : forall a b r,
  Remainder a b r <-> Remainder_alt a b r.
 Proof.
-  unfold Remainder, Remainder_alt; intuition.
+  unfold Remainder, Remainder_alt; intuition auto with zarith.
   - lia.
   - lia.
   - rewrite <-(Z.mul_opp_opp). apply Z.mul_nonneg_nonneg; lia.


### PR DESCRIPTION
Databases `relations` (mostly for `solve_relation`) and `bool` (mostly
for `diff_true_false`/`diff_false_true`) are commonly used in the
stdlib.

Depends https://github.com/coq/coq/pull/16106