### PR TITLE
Drop minimum zarith version to 1.11

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -21,7 +21,7 @@ jobs:
           opam switch set ocaml-base-compiler.$COMPILER
           eval $(opam env)
           opam update
-          opam install -j "$NJOBS" ocamlfind${FINDLIB_VER} ounit lablgtk3-sourceview3 zarith.1.12 dune.2.8.5
+          opam install -j "$NJOBS" ocamlfind${FINDLIB_VER} ounit lablgtk3-sourceview3 zarith.1.11 dune.2.8.5
           opam list
         env:
           COMPILER: "4.12.0"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ variables:
   # Format: $IMAGE-V$DATE-$hash
   # The $hash is the first 10 characters of the md5 of the Dockerfile. e.g.
   # echo $(md5sum dev/ci/docker/bionic_coq/Dockerfile | head -c 10)
-  CACHEKEY: "bionic_coq-V2022-04-29-a6d02127cf"
+  CACHEKEY: "bionic_coq-V2022-05-17-2aac594e85"
   IMAGE: "$CI_REGISTRY_IMAGE:$CACHEKEY"
   # By default, jobs run in the base switch; override to select another switch
   OPAM_SWITCH: "base"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,7 +22,7 @@ To compile Coq yourself, you need:
 
 - The [Dune OCaml build system](https://github.com/ocaml/dune/) >= 2.5.1
 
-- The [ZArith library](https://github.com/ocaml/Zarith) >= 1.12
+- The [ZArith library](https://github.com/ocaml/Zarith) >= 1.11
 
 - The [findlib](http://projects.camlcity.org/projects/findlib.html) library (version >= 1.8.0)
 

--- a/coq-core.opam
+++ b/coq-core.opam
@@ -30,7 +30,7 @@ depends: [
   "dune" {>= "2.5"}
   "ocaml" {>= "4.09.0"}
   "ocamlfind" {>= "1.8.1"}
-  "zarith" {>= "1.12"}
+  "zarith" {>= "1.11"}
   "ounit2" {with-test}
 ]
 build: [

--- a/coq.opam.docker
+++ b/coq.opam.docker
@@ -23,7 +23,7 @@ version: "dev"
 depends: [
   "ocaml"     { >= "4.09.0" }
   "ocamlfind" { build }
-  "zarith"    { >= "1.12" }
+  "zarith"    { >= "1.11" }
   "conf-findutils" {build}
 ]
 

--- a/dev/ci/docker/bionic_coq/Dockerfile
+++ b/dev/ci/docker/bionic_coq/Dockerfile
@@ -44,7 +44,7 @@ ENV NJOBS="2" \
 ENV COMPILER="4.09.0"
 
 # Common OPAM packages
-ENV BASE_OPAM="zarith.1.12 ocamlfind.1.9.1 ounit2.2.2.3 odoc.1.5.3" \
+ENV BASE_OPAM="zarith.1.11 ocamlfind.1.9.1 ounit2.2.2.3 odoc.1.5.3" \
     CI_OPAM="ocamlgraph.1.8.8 yojson.1.7.0 cppo.1.6.8" \
     BASE_ONLY_OPAM="dune.2.9.1 elpi.1.15.2 stdlib-shims.0.1.0"
 
@@ -60,7 +60,7 @@ RUN opam init -a --disable-sandboxing --compiler="$COMPILER" default https://opa
 
 # base+32bit switch, note the zarith hack
 RUN opam switch create "${COMPILER}+32bit" && eval $(opam env) && \
-        i386 env CC='gcc -m32' opam install zarith.1.12 && \
+        i386 env CC='gcc -m32' opam install zarith.1.11 && \
         opam install $BASE_OPAM
 
 # EDGE switch

--- a/doc/changelog/11-infrastructure-and-dependencies/15483-bump-zarith-doc.rst
+++ b/doc/changelog/11-infrastructure-and-dependencies/15483-bump-zarith-doc.rst
@@ -1,6 +1,7 @@
 - **Changed:**
-  Minimum supported zarith version is now 1.12
+  Minimum supported zarith version is now 1.11
   (`#15483 <https://github.com/coq/coq/pull/15483>`_
-  and `#16005 <https://github.com/coq/coq/pull/16005>`_,
+  and `#16005 <https://github.com/coq/coq/pull/16005>`_
+  and `#16030 <https://github.com/coq/coq/pull/16030>`,
   closes `#15496 <https://github.com/coq/coq/issues/15496>`_,
-  by Gaëtan Gilbert and Théo Zimmermann).
+  by Gaëtan Gilbert and Théo Zimmermann and Jason Gross).

--- a/dune-project
+++ b/dune-project
@@ -26,7 +26,7 @@
  (depends
   (ocaml (>= 4.09.0))
   (ocamlfind (>= 1.8.1))
-  (zarith (>= 1.12))
+  (zarith (>= 1.11))
   (ounit2 :with-test))
  (synopsis "The Coq Proof Assistant -- Core Binaries and Tools")
  (description "Coq is a formal proof management system. It provides

--- a/tools/configure/configure.ml
+++ b/tools/configure/configure.ml
@@ -218,10 +218,10 @@ let check_for_zarith prefs =
     die "Zarith library installed but no development files found (try installing the -dev package)"
   | _   ->
     let zarith_version_int = generic_version_nums ~name:"Zarith" zarith_version in
-    if zarith_version_int >= [1;12;0] then
+    if zarith_version_int >= [1;11;0] then
       cprintf prefs "You have the Zarith library %s installed. Good!" zarith_version
     else
-      die ("Zarith version 1.12 is required, you have " ^ zarith_version)
+      die ("Zarith version 1.11 is required, you have " ^ zarith_version)
 
 (** * Documentation : do we have latex, hevea, ... *)
 


### PR DESCRIPTION
There's no reason to forbid 1.11, and it's useful for some of my
launchpad packages

