### PR TITLE
Do not compute the return sort of template inductive types in the kernel.

### DIFF
--- a/test-suite/bugs/bug_16057.v
+++ b/test-suite/bugs/bug_16057.v
@@ -1,0 +1,11 @@
+Record squash (A : Type) : Prop := sq { _ : A }.
+
+(* This is a contrived test to check that squash is *not* template poly. A
+   template poly behaves as is it were living in Type for typing purposes,
+   so the name [H] below generated for the hypothesis would be instead based on
+   the type of the argument (i.e. [f] for [False]). *)
+Goal squash False -> True.
+Proof.
+intros [?].
+destruct H.
+Qed.

--- a/test-suite/success/Template.v
+++ b/test-suite/success/Template.v
@@ -59,10 +59,14 @@ Module ExplicitTemplate.
   #[universes(template)]
   Inductive identity@{i} (A : Type@{i}) (a : A) : A -> Type@{i} := id_refl : identity A a a.
 
-  (* Weird interaction of template polymorphism and inductive types
-     which naturally fall in Prop: this one is template polymorphic but not on i:
-     it just lives in any universe *)
-  Check (identity Type nat nat : Prop).
+  (* There used to be a weird interaction of template polymorphism and inductive
+     types which fall in Prop due to kernel sort inference. This inductive is
+     template polymorphic, but the universe annotation Type@{i} was ignored by
+     the kernel which infered it lived in any universe and thus put it in Prop.
+     This is not the case anymore since return sort inference has been removed
+     from the kernel. Now the universe annotation is respected by the kernel. *)
+  Fail Check (identity Type nat nat : Prop).
+  Check (identity True I I : Prop).
 End ExplicitTemplate.
 
 Polymorphic Definition f@{i} : Type@{i} := nat.

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -318,7 +318,7 @@ let inductive_levels env evd arities inds =
     CList.fold_left3 (fun (evd, arities) cu (arity,(ctx,du)) len ->
       if is_impredicative_sort env du then
         (* Any product is allowed here. *)
-        evd, (false, arity) :: arities
+        evd, arity :: arities
       else (* If in a predicative sort, or asked to infer the type,
               we take the max of:
               - indices (if in indices-matter mode)
@@ -341,7 +341,7 @@ let inductive_levels env evd arities inds =
             Evd.set_leq_sort env evd Sorts.set du
           else evd
         in
-        let template_prop, evd, arity =
+        let evd, arity =
           if not (Sorts.is_small du) && Sorts.equal cu du then
             if is_flexible_sort evd du && not (Evd.check_leq evd Sorts.set du)
             then if Term.isArity arity
@@ -354,12 +354,12 @@ let inductive_levels env evd arities inds =
                    constructor so we cook up a new type and unify the unbound
                    universe to a dummy value. *)
                 let evd = Evd.set_eq_sort env evd Sorts.set du in
-                true, evd, Term.mkArity (ctx, Sorts.prop)
-              else false, Evd.set_eq_sort env evd Sorts.set du, arity
-            else false, evd, arity
-          else false, Evd.set_eq_sort env evd cu du, arity
+                evd, Term.mkArity (ctx, Sorts.prop)
+              else Evd.set_eq_sort env evd Sorts.set du, arity
+            else evd, arity
+          else Evd.set_eq_sort env evd cu du, arity
         in
-          (evd, (template_prop, arity) :: arities))
+          (evd, arity :: arities))
     (evd,[]) (Array.to_list levels') destarities sizes
   in evd, List.rev arities
 
@@ -453,15 +453,15 @@ let interp_mutual_inductive_constr ~sigma ~template ~udecl ~variances ~ctx_param
   let sigma, arities = inductive_levels env_ar_params sigma arities constructors in
   let sigma = Evd.minimize_universes sigma in
   let nf = Evarutil.nf_evars_universes sigma in
-  let arities = List.map (on_snd nf) arities in
+  let arities = List.map nf arities in
   let constructors = List.map (on_snd (List.map nf)) constructors in
   let ctx_params = List.map Termops.(map_rel_decl (EConstr.to_constr sigma)) ctx_params in
   let arityconcl = List.map (Option.map (fun (_anon, s) -> EConstr.ESorts.kind sigma s)) arityconcl in
-  let sigma = restrict_inductive_universes sigma ctx_params (List.map snd arities) constructors in
+  let sigma = restrict_inductive_universes sigma ctx_params arities constructors in
   let univ_entry, binders = Evd.check_univ_decl ~poly sigma udecl in
 
   (* Build the inductive entries *)
-  let entries = List.map3 (fun indname (templatearity, arity) (cnames,ctypes) ->
+  let entries = List.map3 (fun indname arity (cnames,ctypes) ->
       { mind_entry_typename = indname;
         mind_entry_arity = arity;
         mind_entry_consnames = cnames;
@@ -469,11 +469,23 @@ let interp_mutual_inductive_constr ~sigma ~template ~udecl ~variances ~ctx_param
       })
       indnames arities constructors
   in
-  let is_template = match entries, arities, arityconcl with
-  | [entry], [templatearity, _], [concl] ->
+  let is_template = match entries, arityconcl with
+  | [entry], [concl] ->
     begin match template with
     | Some template -> template
     | None ->
+      (* Heuristic: the user has not written Prop explicitly in the return
+         arity, but inference has decided to lower it to Prop. *)
+      let templatearity =
+        if Term.isArity entry.mind_entry_arity then
+          let (_, s) = Reduction.dest_arity env_ar_params entry.mind_entry_arity in
+          if Sorts.is_prop s then match concl with
+          | None | Some (Type _ | Set)-> true
+          | Some Prop -> false
+          | Some SProp -> assert false
+          else false
+        else false
+      in
       let template_candidate =
         templatearity ||
         let ctor_levels =

--- a/vernac/comInductive.mli
+++ b/vernac/comInductive.mli
@@ -8,7 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open Names
 open Vernacexpr
 open Constrexpr
 
@@ -95,24 +94,16 @@ val interp_mutual_inductive_constr
 (** Internal API, exported for Record                                   *)
 (************************************************************************)
 
-val should_auto_template : Id.t -> bool -> bool
-(** [should_auto_template x b] is [true] when [b] is [true] and we
-   automatically use template polymorphism. [x] is the name of the
-   inductive under consideration. *)
-
-val template_polymorphism_candidate
-  : ctor_levels:Univ.Level.Set.t
-  -> UState.universes_entry
-  -> Constr.rel_context
+val compute_template_inductive
+  : user_template:bool option
+  -> env_ar_params:Environ.env
+  -> ctx_params:(Constr.constr, Constr.constr) Context.Rel.Declaration.pt list
+  -> univ_entry:UState.universes_entry
+  -> Entries.one_inductive_entry
   -> Sorts.t option
   -> bool
-(** [template_polymorphism_candidate ~ctor_levels uctx params
-   conclsort] is [true] iff an inductive with params [params],
-   conclusion [conclsort] and universe levels appearing in the
-   constructor arguments [ctor_levels] would be definable as template
-   polymorphic. It should have at least one universe in its
-   monomorphic universe context that can be made parametric in its
-   conclusion sort, if one is given. *)
+(** [compute_template_inductive] computes whether an inductive can be template
+    polymorphic. *)
 
 val maybe_unify_params_in : Environ.env -> Evd.evar_map -> ninds:int -> nparams:int -> binders:int
   -> EConstr.t -> Evd.evar_map


### PR DESCRIPTION
The upper layers should be sending the right information already.

This changes a fringe case test, where a universe with an explicitly provided instance is not made template anymore. Given the comment for this test, I believe we can safely consider that it was a bug.