### PR TITLE
[build] [mltop] Distinguish plugin loading API from module loading API

### DIFF
--- a/lib/cErrors.ml
+++ b/lib/cErrors.ml
@@ -32,6 +32,15 @@ let anomaly ?loc ?info ?label pp =
 
 exception UserError of Pp.t (* User errors *)
 
+(* We register Coq Errors with the global printer here as they will be
+   printed if Dynlink.loadfile raises UserError in the module
+   intializers, and in some other cases. We should make this more
+   principled. *)
+let _ = Printexc.register_printer (function
+    | UserError msg ->
+      Some (Format.asprintf "@[Coq Error: %a@]" Pp.pp_with msg)
+    | _ -> None)
+
 let user_err ?loc ?info strm =
   let info = Option.default Exninfo.null info in
   let info = Option.cata (Loc.add_loc info) info loc in

--- a/test-suite/micromega/witness_tactics.v
+++ b/test-suite/micromega/witness_tactics.v
@@ -2,7 +2,7 @@ Require Import ZArith QArith.
 From Coq.micromega Require Import RingMicromega EnvRing Tauto.
 From Coq.micromega Require Import ZMicromega QMicromega.
 
-Declare ML Module "micromega_plugin".
+Declare ML Module "micromega_plugin:coq-core.plugins.micromega".
 
 Goal True.
 Proof.

--- a/theories/Init/Byte.v
+++ b/theories/Init/Byte.v
@@ -16,7 +16,7 @@ Require Import Coq.Init.Logic.
 Require Import Coq.Init.Specif.
 Require Coq.Init.Nat.
 
-Declare ML Module "number_string_notation_plugin".
+Declare ML Module "number_string_notation_plugin:coq-core.plugins.number_string_notation".
 
 (** We define an inductive for use with the [String Notation] command
     which contains all ascii characters.  We use 256 constructors for

--- a/theories/Init/Ltac.v
+++ b/theories/Init/Ltac.v
@@ -8,6 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-Declare ML Module "ltac_plugin".
+Declare ML Module "ltac_plugin:coq-core.plugins.ltac".
 
 Export Set Default Proof Mode "Classic".

--- a/theories/Init/Prelude.v
+++ b/theories/Init/Prelude.v
@@ -26,8 +26,8 @@ Require Export Coq.Init.Tauto.
    - ltac_plugin (in Ltac)
    - tauto_plugin (in Tauto).
 *)
-Declare ML Module "cc_plugin".
-Declare ML Module "firstorder_plugin".
+Declare ML Module "cc_plugin:coq-core.plugins.cc".
+Declare ML Module "firstorder_plugin:coq-core.plugins.firstorder".
 
 (* Parsing / printing of hexadecimal numbers *)
 Arguments Nat.of_hex_uint d%hex_uint_scope.

--- a/theories/Init/Tauto.v
+++ b/theories/Init/Tauto.v
@@ -15,7 +15,7 @@ Require Import Ltac.
 Require Import Datatypes.
 Require Import Logic.
 
-Declare ML Module "tauto_plugin".
+Declare ML Module "tauto_plugin:coq-core.plugins.tauto".
 
 Local Ltac not_dep_intros :=
   repeat match goal with

--- a/theories/btauto/Btauto.v
+++ b/theories/btauto/Btauto.v
@@ -1,3 +1,3 @@
 Require Import Algebra Reflect.
 
-Declare ML Module "btauto_plugin".
+Declare ML Module "btauto_plugin:coq-core.plugins.btauto".

--- a/theories/derive/Derive.v
+++ b/theories/derive/Derive.v
@@ -1,1 +1,1 @@
-Declare ML Module "derive_plugin".
+Declare ML Module "derive_plugin:coq-core.plugins.derive".

--- a/theories/extraction/Extraction.v
+++ b/theories/extraction/Extraction.v
@@ -8,4 +8,4 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-Declare ML Module "extraction_plugin".
+Declare ML Module "extraction_plugin:coq-core.plugins.extraction".

--- a/theories/funind/FunInd.v
+++ b/theories/funind/FunInd.v
@@ -9,4 +9,4 @@
 (************************************************************************)
 
 Require Coq.extraction.Extraction.
-Declare ML Module "funind_plugin".
+Declare ML Module "funind_plugin:coq-core.plugins.funind".

--- a/theories/micromega/Lia.v
+++ b/theories/micromega/Lia.v
@@ -17,7 +17,7 @@
 Require Import ZMicromega RingMicromega VarMap DeclConstant.
 Require Import BinNums.
 Require Coq.micromega.Tauto.
-Declare ML Module "micromega_plugin".
+Declare ML Module "micromega_plugin:coq-core.plugins.micromega".
 
 Ltac zchecker :=
   let __wit := fresh "__wit" in

--- a/theories/micromega/Lqa.v
+++ b/theories/micromega/Lqa.v
@@ -20,7 +20,7 @@ Require Import RingMicromega.
 Require Import VarMap.
 Require Import DeclConstant.
 Require Coq.micromega.Tauto.
-Declare ML Module "micromega_plugin".
+Declare ML Module "micromega_plugin:coq-core.plugins.micromega".
 
 Ltac rchange :=
   intros ?__wit ?__varmap ?__ff ;

--- a/theories/micromega/Lra.v
+++ b/theories/micromega/Lra.v
@@ -21,7 +21,7 @@ Require Import RingMicromega.
 Require Import VarMap.
 Require Coq.micromega.Tauto.
 Require Import Rregisternames.
-Declare ML Module "micromega_plugin".
+Declare ML Module "micromega_plugin:coq-core.plugins.micromega".
 
 Ltac rchange :=
   intros ?__wit ?__varmap ?__ff ;

--- a/theories/micromega/Psatz.v
+++ b/theories/micromega/Psatz.v
@@ -27,7 +27,7 @@ Require Lia.
 Require Lra.
 Require Lqa.
 
-Declare ML Module "micromega_plugin".
+Declare ML Module "micromega_plugin:coq-core.plugins.micromega".
 
 Ltac lia := Lia.lia.
 

--- a/theories/micromega/QMicromega.v
+++ b/theories/micromega/QMicromega.v
@@ -19,7 +19,6 @@ Require Import RingMicromega.
 Require Import Refl.
 Require Import QArith.
 Require Import Qfield.
-(*Declare ML Module "micromega_plugin".*)
 
 Lemma Qsor : SOR 0 1 Qplus Qmult Qminus Qopp Qeq  Qle Qlt.
 Proof.

--- a/theories/micromega/RMicromega.v
+++ b/theories/micromega/RMicromega.v
@@ -24,7 +24,6 @@ Require Import Qreals.
 Require Import DeclConstant.
 
 Require Setoid.
-(*Declare ML Module "micromega_plugin".*)
 
 Definition Rsrt : ring_theory R0 R1 Rplus Rmult Rminus Ropp (@eq R).
 Proof.

--- a/theories/micromega/ZMicromega.v
+++ b/theories/micromega/ZMicromega.v
@@ -24,7 +24,6 @@ Require Import ZArith_base.
 Require Import ZArithRing.
 Require Import Ztac.
 Require PreOmega.
-(*Declare ML Module "micromega_plugin".*)
 Local Open Scope Z_scope.
 
 Ltac flatten_bool :=

--- a/theories/micromega/Zify.v
+++ b/theories/micromega/Zify.v
@@ -9,7 +9,7 @@
 (************************************************************************)
 
 Require Import ZifyClasses ZifyInst.
-Declare ML Module "zify_plugin".
+Declare ML Module "zify_plugin:coq-core.plugins.zify".
 
 (** [zify_pre_hook] and [zify_post_hook] are there to be redefined. *)
 Ltac zify_pre_hook := idtac.

--- a/theories/micromega/ZifyInst.v
+++ b/theories/micromega/ZifyInst.v
@@ -14,7 +14,7 @@
 
 Require Import Arith BinInt BinNat Znat Nnat.
 Require Import ZifyClasses.
-Declare ML Module "zify_plugin".
+Declare ML Module "zify_plugin:coq-core.plugins.zify".
 Local Open Scope Z_scope.
 
 Ltac refl :=

--- a/theories/nsatz/NsatzTactic.v
+++ b/theories/nsatz/NsatzTactic.v
@@ -32,7 +32,7 @@ Require Export Integral_domain.
 Require Import ZArith.
 Require Import Lia.
 
-Declare ML Module "nsatz_plugin".
+Declare ML Module "nsatz_plugin:coq-core.plugins.nsatz".
 
 Section nsatz1.
 

--- a/theories/rtauto/Rtauto.v
+++ b/theories/rtauto/Rtauto.v
@@ -13,7 +13,7 @@ Require Export List.
 Require Export Bintree.
 Require Import Bool BinPos.
 
-Declare ML Module "rtauto_plugin".
+Declare ML Module "rtauto_plugin:coq-core.plugins.rtauto".
 
 Ltac clean:=try (simpl;congruence).
 

--- a/theories/setoid_ring/Ring_base.v
+++ b/theories/setoid_ring/Ring_base.v
@@ -12,7 +12,7 @@
    ring tactic. Abstract rings need more theory, depending on
    ZArith_base. *)
 
-Declare ML Module "ring_plugin".
+Declare ML Module "ring_plugin:coq-core.plugins.ring".
 Require Export Ring_theory.
 Require Export Ring_tac.
 Require Import InitialRing.

--- a/theories/setoid_ring/Ring_tac.v
+++ b/theories/setoid_ring/Ring_tac.v
@@ -15,7 +15,7 @@ Require Import Ring_polynom.
 Require Import BinList.
 Require Export ListTactics.
 Require Import InitialRing.
-Declare ML Module "ring_plugin".
+Declare ML Module "ring_plugin:coq-core.plugins.ring".
 
 
 (* adds a definition t' on the normal form of t and an hypothesis id

--- a/theories/ssr/ssreflect.v
+++ b/theories/ssr/ssreflect.v
@@ -14,8 +14,7 @@
 
 Require Import Bool. (* For bool_scope delimiter 'bool'. *)
 Require Import ssrmatching.
-Declare ML Module "ssreflect_plugin".
-
+Declare ML Module "ssreflect_plugin:coq-core.plugins.ssreflect".
 
 (**
  This file is the Gallina part of the ssreflect plugin implementation.

--- a/theories/ssrmatching/ssrmatching.v
+++ b/theories/ssrmatching/ssrmatching.v
@@ -10,7 +10,7 @@
 
 (* (c) Copyright 2006-2015 Microsoft Corporation and Inria.                  *)
 
-Declare ML Module "ssrmatching_plugin".
+Declare ML Module "ssrmatching_plugin:coq-core.plugins.ssrmatching".
 
 Module SsrMatchingSyntax.
 

--- a/tools/coqdep/lib/common.ml
+++ b/tools/coqdep/lib/common.ml
@@ -132,7 +132,10 @@ let declare_ml_to_file file decl =
     Fl.findlib_resolve ~meta_files ~file ~package ~legacy_name:(Some legacy) ~plugin_name
   | [package :: plugin_name] ->
     Fl.findlib_resolve ~meta_files ~file ~package ~legacy_name:None ~plugin_name
-  | _ -> assert false
+  | plist ->
+    CErrors.user_err
+      Pp.(str "Failed to resolve plugin " ++
+          pr_sequence (pr_sequence str) plist)
 
 let rec find_dependencies st basename =
   let verbose = true in (* for past/future use? *)

--- a/tools/coqdep/lib/error.ml
+++ b/tools/coqdep/lib/error.ml
@@ -36,7 +36,8 @@ let _ = CErrors.register_handler @@ function
     Some Pp.(str (Printf.sprintf "in file %s, %s is not a valid plugin name anymore." f s)
       ++ str "Plugins should be loaded using their public name according to findlib," ++ spc ()
       ++ str "for example package-name.foo and not foo_plugin." ++ spc ()
-      ++ str "If you are building with dune < 2.9.4 you must specify both" ++ spc ()
+      ++ str "If you are using a buid system that doesn't yet support the new loading method" ++ spc ()
+      ++ str "(such as Dune) you must specify both" ++ spc ()
       ++ str "the legacy and the findlib plugin name as in:" ++ spc ()
       ++ str "Declare ML Module \"foo_plugin:package-name.foo\".")
 

--- a/user-contrib/Ltac2/Init.v
+++ b/user-contrib/Ltac2/Init.v
@@ -8,7 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-Declare ML Module "ltac2_plugin".
+Declare ML Module "ltac2_plugin:coq-core.plugins.ltac2".
 
 #[export] Set Default Proof Mode "Ltac2".
 

--- a/vernac/mltop.ml
+++ b/vernac/mltop.ml
@@ -11,33 +11,22 @@
 open Util
 open Pp
 
-(* Code to hook Coq into the ML toplevel -- depends on having the
-   objective-caml compiler mostly visible. The functions implemented here are:
-   \begin{itemize}
-   \item [dir_ml_load name]: Loads the ML module fname from the current ML
-     path.
-   \item [dir_ml_use]: Directive #use of Ocaml toplevel
-   \item [add_ml_dir]: Directive #directory of Ocaml toplevel
-   \end{itemize}
+(* Code to interact with ML "toplevel", in particular, handling ML
+   plugin loading.
 
-   How to build an ML module interface with these functions.
+   We use Fl_dynload to load plugins, which can correctly track
+   dependencies, and manage path for us.
 
-   The idea is that the ML directory path is like the Coq directory
-   path, so we can maintain the two in parallel, though nowaways we
-   use findlib to resolve plugins too.
+   A bit of infrastructure is still in place to support a "legacy"
+   mode where Coq used to manage the OCaml include paths and directly
+   load .cmxs/.cma files itself.
 
-   In the same way, we can use the "ml_env" as a kind of ML
-   environment, which we freeze, unfreeze, and add things to just like
-   to the other environments.
+   We also place here the required code for interacting with the
+   Summary and Libobject, and provide an API so plugins can interact
+   with this loading/unloading for Coq-specific purposes adding their
+   own init functions, given that OCaml cannot unlink a dynamic module.
 
-   Finally, we can create an object which is an ML module, and require
-   that the "caching" of the ML module cause the loading of the
-   associated ML file, if that file has not been yet loaded.  Of
-   course, the problem is how to record dependencies between ML
-   modules.
-
-   (I do not know of a solution to this problem, other than to
-   put all the needed names into the ML Module object.) *)
+*)
 
 
 (* This path is where we look for .cmo/.cmxs using the legacy method *)

--- a/vernac/mltop.ml
+++ b/vernac/mltop.ml
@@ -80,20 +80,42 @@ module Fl_internals = struct
     in
     fl_split_in_words archive |> List.map (Findlib.resolve_path ~base)
 
+  (* We register errors at for Dynlink and Findlib, it is possible to
+     do so Symtable too, as we used to do in the bytecode init code.
+     *)
+  let _ = CErrors.register_handler (function
+      | Dynlink.Error msg ->
+        let paths = Findlib.search_path () in
+        Some (hov 0 (str "Dynlink error: " ++ str (Dynlink.error_message msg) ++
+                     cut () ++ str "Findlib paths:" ++ cut () ++ v 0 (prlist_with_sep cut str paths) ++ fnl()))
+      | Fl_package_base.No_such_package(p,msg) ->
+        let paths = Findlib.search_path () in
+        Some (hov 0 (str "Findlib error: " ++ str p ++
+                     str " not found in:" ++ cut () ++ v 0 (prlist_with_sep cut str paths) ++ fnl() ++ str msg))
+      | _ ->
+        None
+    )
+
 end
 
 module PluginSpec : sig
 
   type t
 
-  val make : lib:string -> t
-  val make_legacy : file:string -> lib:string -> t
+  (* Main constructor, takes the format used in Declare ML Module *)
+  val of_declare_ml_format : string -> t
 
+  (* repr/unrepr are internal and only needed for the summary and other low-level stuff *)
   val repr : t -> string option * string
   val unrepr : string option * string -> t
 
+  (* Load a plugin, low-level, that is to say, will directly call the
+     loading mechanism in OCaml/findlib *)
   val load : t -> unit
 
+  (* Compute a digest, a findlib library name have more than one
+     plugin .cmxs, however this is not the case in Coq. Maybe we
+     should strengthen this invariant. *)
   val digest : t -> Digest.t list
 
   val pp : t -> string
@@ -102,6 +124,42 @@ module PluginSpec : sig
   module Map : CMap.ExtS with type key = t and module Set := Set
 
 end = struct
+
+  type t = { file : string option; lib : string }
+
+  module Errors = struct
+
+    let plugin_name_should_contain_dot m =
+      CErrors.user_err
+        Pp.(str Format.(asprintf "%s is not a valid plugin name anymore." m) ++ spc() ++
+            str "Plugins should be loaded using their public name" ++ spc () ++
+            str "according to findlib, for example package-name.foo and not " ++
+            str "foo_plugin.")
+
+    let plugin_name_invalid_format m =
+      CErrors.user_err
+        Pp.(str Format.(asprintf "%s is not a valid plugin name." m) ++ spc () ++
+            str "It should be a public findlib name, e.g. package-name.foo," ++ spc () ++
+            str "or a legacy name followed by a findlib public name, e.g. "++ spc () ++
+            str "legacy_plugin:package-name.plugin.")
+
+  end
+
+  let legacy_mapping = Core_plugins_findlib_compat.legacy_to_findlib
+
+  let of_declare_ml_format m =
+    match String.split_on_char ':' m with
+    | [file] when List.mem_assoc file legacy_mapping ->
+      { file = Some file; lib = String.concat "." ("coq-core" :: List.assoc file legacy_mapping) }
+    | [x] when not (Fl_internals.validate_lib_name x) ->
+      Errors.plugin_name_should_contain_dot m
+    | [ file; lib ] ->
+      { file = Some file; lib }
+    | [ lib ] ->
+      { file = None; lib }
+    | [] -> assert false
+    | _ :: _ :: _ ->
+      Errors.plugin_name_invalid_format m
 
   (* Adds the corresponding extension .cmo/.cma or .cmxs. Dune and
      coq_makefile byte plugins do differ in the choice of extension,
@@ -113,14 +171,6 @@ end = struct
       let name = base ^ ".cmo" in
       if System.is_in_path !coq_mlpath_copy name
       then name else base ^ ".cma"
-
-  type t = { file : string option; lib : string }
-
-  let make ~lib =
-    { file = None; lib }
-
-  let make_legacy ~file ~lib =
-    { file = Some file; lib }
 
   let load = function
     | { file = None; lib } ->
@@ -163,10 +213,16 @@ end = struct
 end
 
 (* If there is a toplevel under Coq *)
-type toplevel = {
-  load_obj : PluginSpec.t -> unit;
-  add_dir  : string -> unit;
-  ml_loop  : unit -> unit }
+type toplevel =
+  { load_plugin : PluginSpec.t -> unit
+  (** Load a findlib library, given by public name *)
+  ; load_module : string -> unit
+  (** Load a cmxs / cmo module, used by the native compiler to load objects *)
+  ; add_dir  : string -> unit
+  (** Adds a dir to the module search path *)
+  ; ml_loop  : unit -> unit
+  (** Implementation of Drop *)
+  }
 
 (* Determines the behaviour of Coq with respect to ML files (compiled
    or not) *)
@@ -180,9 +236,7 @@ let load = ref WithoutTop
 (* Sets and initializes a toplevel (if any) *)
 let set_top toplevel = load :=
   WithTop toplevel;
-  Nativelib.load_obj := (fun file ->
-      let ps = PluginSpec.make_legacy ~file ~lib:file in
-      toplevel.load_obj ps)
+  Nativelib.load_obj := toplevel.load_module
 
 (* Removes the toplevel (if any) *)
 let remove () =
@@ -204,76 +258,9 @@ let ocaml_toploop () =
     | WithTop t -> Printexc.catch t.ml_loop ()
     | _ -> ()
 
-(* Dynamic loading of .cmo/.cma *)
-
-(* We register Coq Errors with the global printer here as they will be
-   printed if Dynlink.loadfile raises UserError in the module
-   intializers. We should make this more principled tho. *)
-let _ = Printexc.register_printer (function
-    | CErrors.UserError msg ->
-      Some (Format.asprintf "@[%a@]" Pp.pp_with msg)
-    | _ -> None)
-
-(* We register errors at least for Dynlink, it is possible to do so Symtable
-   too, as we do in the bytecode init code.
-*)
-let _ = CErrors.register_handler (function
-    | Dynlink.Error msg ->
-      let paths = Findlib.search_path () in
-      Some (hov 0 (str "Dynlink error: " ++ str (Dynlink.error_message msg) ++
-        cut () ++ str "Findlib paths:" ++ cut () ++ v 0 (prlist_with_sep cut str paths) ++ fnl()))
-    | Fl_package_base.No_such_package(p,msg) ->
-      let paths = Findlib.search_path () in
-      Some (hov 0 (str "Findlib error: " ++ str p ++
-        str " not found in:" ++ cut () ++ v 0 (prlist_with_sep cut str paths) ++ fnl() ++ str msg))
-    | _ ->
-      None
-  )
-
-module Legacy_code_waiting_for_dune_release = struct
-
-  let legacy_mapping = Core_plugins_findlib_compat.legacy_to_findlib
-
-  module Errors = struct
-
-    let plugin_name_should_contain_dot m =
-      CErrors.user_err
-        Pp.(str Format.(asprintf "%s is not a valid plugin name anymore." m) ++ spc() ++
-            str "Plugins should be loaded using their public name" ++ spc () ++
-            str "according to findlib, for example package-name.foo and not " ++
-            str "foo_plugin.")
-
-    let plugin_name_invalid_format m =
-      CErrors.user_err
-        Pp.(str Format.(asprintf "%s is not a valid plugin name." m) ++ spc () ++
-            str "It should be a public findlib name, e.g. package-name.foo," ++ spc () ++
-            str "or a legacy name followed by a findlib public name, e.g. "++ spc () ++
-            str "legacy_plugin:package-name.plugin.")
-
-  end
-
-  let resolve_legacy_name_if_needed m =
-    match String.split_on_char ':' m with
-    | [x] when not (Fl_internals.validate_lib_name x) ->
-      Errors.plugin_name_should_contain_dot m
-    | [ file; lib ] ->
-      PluginSpec.make_legacy ~file ~lib
-    | [ lib ] ->
-      PluginSpec.make ~lib
-    | [] -> assert false
-    | _ :: _ :: _ ->
-      Errors.plugin_name_invalid_format m
-
-  let resolve_legacy_name_if_needed m =
-    List.assoc_opt m legacy_mapping
-    |> Option.cata (fun flname -> m ^ ":coq-core." ^ String.concat "." @@ flname) m
-    |> resolve_legacy_name_if_needed
-
-end
-
 let ml_load p =
   match !load with
-  | WithTop t -> t.load_obj p
+  | WithTop t -> t.load_plugin p
   | WithoutTop ->
     PluginSpec.load p
 
@@ -309,7 +296,7 @@ let plugin_is_known mname = PluginSpec.Set.mem mname !known_loaded_modules
 let known_loaded_plugins : (unit -> unit) PluginSpec.Map.t ref = ref PluginSpec.Map.empty
 
 let add_known_plugin init name =
-  let name = Legacy_code_waiting_for_dune_release.resolve_legacy_name_if_needed name in
+  let name = PluginSpec.of_declare_ml_format name in
   add_known_module name;
   known_loaded_plugins := PluginSpec.Map.add name init !known_loaded_plugins
 
@@ -322,7 +309,7 @@ let init_known_plugins () =
 let cache_objs = ref PluginSpec.Map.empty
 
 let declare_cache_obj f name =
-  let name = PluginSpec.make ~lib:name in
+  let name = PluginSpec.of_declare_ml_format name in
   let objs = try PluginSpec.Map.find name !cache_objs with Not_found -> [] in
   let objs = f :: objs in
   cache_objs := PluginSpec.Map.add name objs !cache_objs
@@ -346,11 +333,11 @@ let load_ml_object mname =
   init_ml_object mname
 
 let add_known_module name =
-  let name = Legacy_code_waiting_for_dune_release.resolve_legacy_name_if_needed name in
+  let name = PluginSpec.of_declare_ml_format name in
   add_known_module name
 
 let module_is_known mname =
-  let mname = Legacy_code_waiting_for_dune_release.resolve_legacy_name_if_needed mname in
+  let mname = PluginSpec.of_declare_ml_format mname in
   module_is_known mname
 
 (* Summary of declared ML Modules *)
@@ -443,7 +430,7 @@ let inMLModule : ml_module_object -> Libobject.obj =
 
 
 let declare_ml_modules local l =
-  let mnames = List.map Legacy_code_waiting_for_dune_release.resolve_legacy_name_if_needed l in
+  let mnames = List.map PluginSpec.of_declare_ml_format l in
   if Global.sections_are_opened()
   then CErrors.user_err Pp.(str "Cannot Declare ML Module while sections are opened.");
   (* List.concat_map only available in 4.10 *)

--- a/vernac/mltop.mli
+++ b/vernac/mltop.mli
@@ -31,10 +31,16 @@ module PluginSpec : sig
   val pp : t -> string
 end
 
-type toplevel = {
-  load_obj : PluginSpec.t -> unit;
-  add_dir  : string -> unit;
-  ml_loop  : unit -> unit }
+type toplevel =
+  { load_plugin : PluginSpec.t -> unit
+  (** Load a findlib library, given by public name *)
+  ; load_module : string -> unit
+  (** Load a cmxs / cmo module, used by the native compiler to load objects *)
+  ; add_dir  : string -> unit
+  (** Adds a dir to the module search path *)
+  ; ml_loop  : unit -> unit
+  (** Implementation of Drop *)
+  }
 
 (** Sets and initializes a toplevel (if any) *)
 val set_top : toplevel -> unit


### PR DESCRIPTION
We cleanup the `Mltop.toplevel` API, which includes a kind of critical fix due to `Mltop.toplevel` having indeed to export both a .cmxs loader and a findlib loader, the first for native, but this will also allow jsCoq for example to keep working, as I'm unsure Fl_dynload is gonna work there.

We also provide a better error message instead of `assert false` for the common case of an incorrect `Declare Ml Module`, and strengthen the invariant in `Mltop.PluginSpec`.