### PR TITLE
[coqdep] Untangle makefile-specific code from common

### DIFF
--- a/tools/coqdep/coqdep.ml
+++ b/tools/coqdep/coqdep.ml
@@ -33,7 +33,7 @@ let coqdep () =
   (try ignore (Loadpath.find_dir_logpath (Sys.getcwd()))
    with Not_found -> Loadpath.add_norec_dir_import (Loadpath.add_known lst) "." []);
   (* We don't setup any loadpath if the -boot is passed *)
-  if not !Options.boot then begin
+  if not args.Args.boot then begin
     let env = Boot.Env.init () in
     let stdlib = Boot.Env.(stdlib env |> Path.to_string) in
     let plugins = Boot.Env.(plugins env |> Path.to_string) in
@@ -46,10 +46,10 @@ let coqdep () =
       (Envars.xdg_dirs ~warn:(fun x -> Warning.give "%s" x));
     List.iter (fun s -> Loadpath.add_rec_dir_no_import (Loadpath.add_coqlib_known lst) s []) Envars.coqpath;
   end;
-  if !Options.sort then
+  if args.Args.sort then
     sort st
   else
-    compute_deps st |> List.iter (Dep_info.print Format.std_formatter)
+    compute_deps st |> List.iter (Makefile.print_dep Format.std_formatter)
 
 let () =
   try

--- a/tools/coqdep/lib/args.ml
+++ b/tools/coqdep/lib/args.ml
@@ -16,7 +16,7 @@ type t =
   ; coqproject : string option
   ; ml_path : string list
   ; vo_path : (bool * string * string) list
-  ; dyndep : Options.Dynlink.t
+  ; dyndep : string
   ; meta_files : string list
   ; files : string list
   }
@@ -29,7 +29,7 @@ let make () =
   ; coqproject = None
   ; ml_path = []
   ; vo_path = []
-  ; dyndep = Options.Dynlink.Both
+  ; dyndep = "both"
   ; meta_files = []
   ; files = []
   }
@@ -72,11 +72,7 @@ let parse st args =
     | "-exclude-dir" :: [] -> usage ()
     | "-coqlib" :: r :: ll -> Boot.Env.set_coqlib r; parse st ll
     | "-coqlib" :: [] -> usage ()
-    | "-dyndep" :: "no" :: ll -> parse { st with dyndep = Options.Dynlink.No } ll
-    | "-dyndep" :: "opt" :: ll -> parse { st with dyndep = Options.Dynlink.Opt } ll
-    | "-dyndep" :: "byte" :: ll -> parse { st with dyndep = Options.Dynlink.Byte } ll
-    | "-dyndep" :: "both" :: ll -> parse { st with dyndep = Options.Dynlink.Both } ll
-    | "-dyndep" :: "var" :: ll -> parse { st with dyndep = Options.Dynlink.Variable } ll
+    | "-dyndep" :: dyndep :: ll -> parse { st with dyndep } ll
     | "-m" :: m :: ll -> parse { st with meta_files = st.meta_files @ [m]} ll
     | ("-h"|"--help"|"-help") :: _ -> usage ()
     | opt :: ll when String.length opt > 0 && opt.[0] = '-' ->

--- a/tools/coqdep/lib/common.mli
+++ b/tools/coqdep/lib/common.mli
@@ -21,24 +21,6 @@ val init : Args.t -> State.t
 (** [treat_file_command_line file] Add an input file to be considered  *)
 val treat_file_command_line : string -> unit
 
-module Dep : sig
-  type t =
-  | Require of string (* one basename, to which we later append .vo or .vio or .vos *)
-  | Other of string   (* filenames of dependencies, separated by spaces *)
-
-  val to_string : suffix:string -> t -> string
-end
-
-module Dep_info : sig
-  type t =
-    { name : string
-    ; deps : Dep.t list
-    }
-
-  (** Print dependencies in makefile format *)
-  val print : Format.formatter -> t -> unit
-end
-
 val sort : State.t -> unit
 
 val compute_deps : State.t -> Dep_info.t list

--- a/tools/coqdep/lib/dep_info.ml
+++ b/tools/coqdep/lib/dep_info.ml
@@ -8,12 +8,16 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-module Dynlink = struct
-  type t = Opt | Byte | Both | No | Variable
+module Dep = struct
+  type t =
+  | Require of string (* one basename, to which we later append .vo or .vio or .vos *)
+  | Ml of string * string
+  | Other of string (* filenames of dependencies, separated by spaces *)
 end
 
-let boot = ref false
-let sort = ref false
-let write_vos = ref false
-let noglob = ref false
-let dynlink = ref Dynlink.Both
+type t =
+  { name : string  (* This should become [module : Coq_module.t] eventually *)
+  ; deps : Dep.t list
+  }
+
+let make ~name ~deps = { name; deps }

--- a/tools/coqdep/lib/dep_info.mli
+++ b/tools/coqdep/lib/dep_info.mli
@@ -8,12 +8,19 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-module Dynlink : sig
-  type t = Opt | Byte | Both | No | Variable
+module Dep : sig
+  type t =
+  | Require of string
+  (** module basename, to which we later append .vo or .vio or .vos *)
+  | Ml of string * string
+  (** plugin basename and byte extension, resolved from Declare Ml Module *)
+  | Other of string
+  (** load, meta, and external dependencies *)
 end
 
-val boot : bool ref
-val sort : bool ref
-val write_vos : bool ref
-val noglob : bool ref
-val dynlink : Dynlink.t ref
+type t =
+  { name : string  (* This should become [module : Coq_module.t] eventually *)
+  ; deps : Dep.t list
+  }
+
+val make : name:string -> deps:Dep.t list -> t

--- a/tools/coqdep/lib/loadpath.mli
+++ b/tools/coqdep/lib/loadpath.mli
@@ -9,9 +9,7 @@
 (************************************************************************)
 
 (** To move  *)
-val absolute_dir : string -> string
 val get_extension : string -> string list -> string * string
-val absolute_file_name : string -> string option -> string
 
 (* Loadpaths *)
 type basename = string
@@ -28,7 +26,7 @@ type result =
 module State : sig
   type t
 
-  val make : unit -> t
+  val make : boot:bool -> t
 end
 
 val search_v_known : State.t -> ?from:dirpath -> dirpath -> result option
@@ -69,3 +67,7 @@ val add_coqlib_known : State.t -> bool -> root -> dirname -> dirpath -> basename
    it hasn't. We may also use this to warn if ap hysical path is met
    twice.*)
 val find_dir_logpath : string -> string list
+
+(* Used only in "canonize" *)
+val absolute_dir : string -> string
+val absolute_file_name : string -> string option -> string

--- a/tools/coqdep/lib/makefile.ml
+++ b/tools/coqdep/lib/makefile.ml
@@ -1,0 +1,90 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(* Makefile's escaping rules are awful: $ is escaped by doubling and
+   other special characters are escaped by backslash prefixing while
+   backslashes themselves must be escaped only if part of a sequence
+   followed by a special character (i.e. in case of ambiguity with a
+   use of it as escaping character).  Moreover (even if not crucial)
+   it is apparently not possible to directly escape ';' and leading '\t'. *)
+
+let escape =
+  let s' = Buffer.create 10 in
+  fun s ->
+    Buffer.clear s';
+    for i = 0 to String.length s - 1 do
+      let c = s.[i] in
+      if c = ' ' || c = '#' || c = ':' (* separators and comments *)
+        || c = '%' (* pattern *)
+        || c = '?' || c = '[' || c = ']' || c = '*' (* expansion in filenames *)
+        || i=0 && c = '~' && (String.length s = 1 || s.[1] = '/' ||
+            'A' <= s.[1] && s.[1] <= 'Z' ||
+            'a' <= s.[1] && s.[1] <= 'z') (* homedir expansion *)
+      then begin
+        let j = ref (i-1) in
+        while !j >= 0 && s.[!j] = '\\' do
+          Buffer.add_char s' '\\'; decr j (* escape all preceding '\' *)
+        done;
+        Buffer.add_char s' '\\';
+      end;
+      if c = '$' then Buffer.add_char s' '$';
+      Buffer.add_char s' c
+    done;
+    Buffer.contents s'
+
+open Format
+
+type dynlink = Opt | Byte | Both | No | Variable
+let option_dynlink = ref Both
+
+let set_dyndep = function
+  | "no" -> option_dynlink := No
+  | "opt" -> option_dynlink := Opt
+  | "byte" -> option_dynlink := Byte
+  | "both" -> option_dynlink := Both
+  | "var" -> option_dynlink := Variable
+  | o -> CErrors.user_err Pp.(str "Incorrect -dyndep option: " ++ str o)
+
+let mldep_to_make (base, suff) =
+  match !option_dynlink with
+  | No -> []
+  | Byte -> [sprintf "%s%s" base suff]
+  | Opt -> [sprintf "%s.cmxs" base]
+  | Both ->
+    [sprintf "%s%s" base suff ; sprintf "%s.cmxs" base]
+  | Variable ->
+    [sprintf "%s%s" base (if suff=".cmo" then "$(DYNOBJ)" else "$(DYNLIB)")]
+
+let string_of_dep ~suffix = let open Dep_info.Dep in
+  function
+  | Require basename -> [escape basename ^ suffix]
+  | Ml (base,suff) -> mldep_to_make (escape base,suff)
+  | Other s -> [escape s]
+
+let string_of_dependency_list ~suffix deps =
+  List.map (string_of_dep ~suffix) deps
+  |> List.concat |> String.concat " "
+
+let option_noglob = ref false
+let option_write_vos = ref false
+let set_noglob glob = option_noglob := glob
+let set_write_vos vos = option_write_vos := vos
+
+let print_dep fmt { Dep_info.name; deps } =
+  let ename = escape name in
+    let glob = if !option_noglob then "" else ename^".glob " in
+  fprintf fmt "%s.vo %s%s.v.beautified %s.required_vo: %s.v %s\n" ename glob ename ename ename
+    (string_of_dependency_list ~suffix:".vo" deps);
+  fprintf fmt "%s.vio: %s.v %s\n" ename ename
+    (string_of_dependency_list ~suffix:".vio" deps);
+  if !option_write_vos then
+    fprintf fmt "%s.vos %s.vok %s.required_vos: %s.v %s\n" ename ename ename ename
+      (string_of_dependency_list ~suffix:".vos" deps);
+  fprintf fmt "%!"

--- a/tools/coqdep/lib/makefile.mli
+++ b/tools/coqdep/lib/makefile.mli
@@ -8,19 +8,11 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-type t =
-  { boot : bool
-  ; sort : bool
-  ; vos : bool
-  ; noglob : bool
-  ; coqproject : string option
-  ; ml_path : string list
-  ; vo_path : (bool * string * string) list
-  ; dyndep : string
-  ; meta_files : string list
-  ; files : string list
-  }
+val print_dep :
+  Format.formatter
+  -> Dep_info.t
+  -> unit
 
-val make : unit -> t
-val usage : unit -> 'a
-val parse : t -> string list -> t
+val set_dyndep : string -> unit
+val set_noglob : bool -> unit
+val set_write_vos : bool -> unit


### PR DESCRIPTION
We introduce a generic `Dep_info` module, and handle the make-specific
stuff there.

