### PR TITLE
[coqdep] Turn dependency resolution failure from a warning to a fatal error

### DIFF
--- a/tools/coqdep/lib/error.ml
+++ b/tools/coqdep/lib/error.ml
@@ -8,6 +8,13 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+(* This distinction is not so important *)
+type what = Library | External
+let str_of_what = function Library -> "library" | External -> "external file"
+
+exception MlNotFound of string * string
+exception FileNotFound of string * what * string option * string
+
 exception CannotParseFile of string * (int * int)
 exception CannotParseProjectFile of string * string
 
@@ -15,7 +22,16 @@ exception CannotOpenFile of string * string
 exception CannotOpenProjectFile of string
 
 
-let () = CErrors.register_handler @@ function
+let _ = CErrors.register_handler @@ function
+  | MlNotFound(file,ml_mod) ->
+    Some Pp.(str "in file " ++ str file ++ str " declared ML module " ++ str ml_mod ++ str " has not been found!")
+
+  | FileNotFound(file,what,from,coq_mod) ->
+    let what = Pp.str (str_of_what what) in
+    let root = Option.cata (fun pth -> Pp.(str " from root " ++ str pth)) (Pp.mt ()) from in
+    Some Pp.(str "in file " ++ str file ++ spc () ++ what ++ spc () ++ str coq_mod ++
+             str " is required" ++ root ++ spc () ++ str "and has not been found in the loadpath!")
+
   | CannotParseFile (s,(i,j)) ->
     Some Pp.(str "File \"" ++ str s ++ str "\"," ++ str "characters" ++ spc ()
       ++ int i ++ str "-" ++ int j ++ str ":" ++ spc () ++ str "Syntax error")
@@ -32,6 +48,13 @@ let () = CErrors.register_handler @@ function
     Some Pp.(str msg)
 
   | _ -> None
+
+let mlnotfound file ml_mod = raise @@ MlNotFound(file,ml_mod)
+
+let filenotfound file what from coq_mod =
+  let from = Option.map (String.concat ".") from in
+  let coq_mod = String.concat "." coq_mod in
+  raise @@ FileNotFound(file,what,from,coq_mod)
 
 let cannot_parse s ij = raise @@ CannotParseFile (s, ij)
 let cannot_open_project_file msg = raise @@ CannotOpenProjectFile msg

--- a/tools/coqdep/lib/error.mli
+++ b/tools/coqdep/lib/error.mli
@@ -17,3 +17,8 @@ val cannot_parse : string -> int * int -> 'a
 val cannot_open_project_file : string -> 'a
 val cannot_parse_project_file : string -> string -> 'a
 val cannot_open : string -> string -> 'a
+
+type what = Library | External
+val str_of_what : what -> string
+val mlnotfound : string -> string -> 'a
+val filenotfound : string -> what -> string list option -> string list -> 'a


### PR DESCRIPTION
Strict mode means we fail when we cannot locate a file.

This is an experiment before implementing `-modules`.

Relevant OCaml issue is https://github.com/ocaml/ocaml/issues/8625
