### PR TITLE
Enable backtrace recording when raising anomalies.

### DIFF
--- a/lib/cErrors.ml
+++ b/lib/cErrors.ml
@@ -26,6 +26,7 @@ let _ =
   Printexc.register_printer pr
 
 let anomaly ?loc ?info ?label pp =
+  let () = Exninfo.record_backtrace true in
   let info = Option.default Exninfo.null info in
   let info = Option.cata (Loc.add_loc info) info loc in
   Exninfo.iraise (Anomaly (label, pp), info)


### PR DESCRIPTION
Not sure if this is the right thing to do but it could be helpful.

Making it work the same for non caught exceptions seems unfeasible since for
`assert false` we don't have a way to hook into where it's raised, and
for others like `Not_found` we don't know if it will be uncaught until
it bubbles all the way up.

Alternatively we could always turn on backtrace recording but print them
conditionally at some perf cost.

Note that
- record_backtrace is bound to a cdebug
- cdebug is a goption which are in the summary

so in interactive mode if we run a command producing an anomaly then
something else the 2nd command is not affected by enabling backtraces.
(in non interactive mode the process dies so we can't run a second
command)