### PR TITLE
Fix extraction of max/min to Stdlib.max/min

### DIFF
--- a/theories/extraction/ExtrOcamlNatInt.v
+++ b/theories/extraction/ExtrOcamlNatInt.v
@@ -48,11 +48,11 @@ Extract Inductive nat => int [ "0" "Stdlib.Int.succ" ]
 (** Efficient (but uncertified) versions for usual [nat] functions *)
 
 Extract Constant plus => "(+)".
-Extract Constant pred => "fun n -> Stdlib.Int.max 0 (n-1)".
-Extract Constant minus => "fun n m -> Stdlib.Int.max 0 (n-m)".
+Extract Constant pred => "fun n -> Stdlib.max 0 (n-1)".
+Extract Constant minus => "fun n m -> Stdlib.max 0 (n-m)".
 Extract Constant mult => "( * )".
-Extract Inlined Constant max => "Stdlib.Int.max".
-Extract Inlined Constant min => "Stdlib.Int.min".
+Extract Inlined Constant max => "Stdlib.max".
+Extract Inlined Constant min => "Stdlib.min".
 (*Extract Inlined Constant nat_beq => "(=)".*)
 Extract Inlined Constant Nat.eqb => "(=)".
 Extract Inlined Constant EqNat.eq_nat_decide => "(=)".


### PR DESCRIPTION
Turns out in https://github.com/coq/coq/pull/15333 that `Stdlib.Int.max` and `Stdlib.Int.min` only appear in OCaml 4.13. So we revert to the versions already there.

Thanks for the catch @liyishuai!

https://github.com/coq/coq/pull/15333#discussion_r884177773

cc @ppedrot I would like to push this for 8.16.