### PR TITLE
Stop inferring template universes in the kernel

### DIFF
--- a/test-suite/bugs/bug_11039.v
+++ b/test-suite/bugs/bug_11039.v
@@ -1,5 +1,7 @@
 (* this bug was a proof of False *)
 
+Set Warnings "+no-template-universe".
+
 (* when we require template poly Coq recognizes that it's not allowed *)
 Fail #[universes(template)]
   Inductive foo@{i} (A:Type@{i}) : Type@{i+1} := bar (X:Type@{i}) : foo A.

--- a/test-suite/output/Inductive.v
+++ b/test-suite/output/Inductive.v
@@ -3,7 +3,8 @@ Fail Inductive list' (A:Set) : Set :=
 | cons' : A -> list' A -> list' (A*A).
 
 (* Check printing of let-ins *)
-#[universes(template)] Inductive foo (A : Type) (x : A) (y := x) := Foo.
+Inductive foo (A : Type) (x : A) (y := x) := Foo.
+
 Print foo.
 
 (* Check where clause *)

--- a/test-suite/output/PrimitiveProjectionsAttribute_Records.out
+++ b/test-suite/output/PrimitiveProjectionsAttribute_Records.out
@@ -10,6 +10,6 @@ C has primitive projections with eta conversion.
 Expands to: Inductive PrimitiveProjectionsAttribute_Records.C
 G : Type
 
-G is template universe polymorphic
+G is not universe polymorphic
 G has primitive projections without eta conversion.
 Expands to: Inductive PrimitiveProjectionsAttribute_Records.G

--- a/test-suite/success/Template.v
+++ b/test-suite/success/Template.v
@@ -153,6 +153,8 @@ Module TestTemplateAttribute.
     Universe u.
     Context (A : Type@{u}).
 
+    Set Warnings "+no-template-universe".
+
     (* Failing as Bar cannot be made template polymorphic at all *)
     Fail #[universes(template)] Inductive Bar :=
     | bar : A -> Bar.
@@ -184,3 +186,27 @@ Module BoxBox.
   Check Box' True : Prop.
 
 End BoxBox.
+
+Module TemplateUnit.
+
+Set Warnings "-no-template-universe".
+
+(* This is marked as template without any actual template universe. *)
+#[universes(template)] Inductive foo := Foo.
+
+Check (foo : Prop).
+
+End TemplateUnit.
+
+Module TemplateParamUnit.
+
+(* In theory, A could be template but the upper layers don't mark it as such *)
+Set Warnings "+no-template-universe".
+Fail #[universes(template)] Inductive foo (A : Type) := Foo.
+
+Set Warnings "-no-template-universe".
+#[universes(template)] Inductive foo (A : Type) := Foo.
+
+Check (foo unit : Prop).
+
+End TemplateParamUnit.

--- a/theories/ssr/ssrbool.v
+++ b/theories/ssr/ssrbool.v
@@ -1626,8 +1626,7 @@ Notation "[ 'qualify' 'an' x : T | P ]" :=
 Section KeyPred.
 
 Variable T : Type.
-#[universes(template)]
-Variant pred_key (p : {pred T}) := DefaultPredKey.
+Variant pred_key (p : {pred T}) : Prop := DefaultPredKey.
 
 Variable p : {pred T}.
 Structure keyed_pred (k : pred_key p) :=

--- a/theories/ssr/ssreflect.v
+++ b/theories/ssr/ssreflect.v
@@ -246,8 +246,7 @@ Inductive external_view : Type := tactic_view of Type.
 
 Module TheCanonical.
 
-#[universes(template)]
-Variant put vT sT (v1 v2 : vT) (s : sT) := Put.
+Variant put vT sT (v1 v2 : vT) (s : sT) : Prop := Put.
 
 Definition get vT sT v s (p : @put vT sT v v s) := let: Put _ _ _ := p in s.
 
@@ -340,12 +339,10 @@ Notation "{ 'type' 'of' c 'for' s }" := (dependentReturnType c s) : type_scope.
    We also define a simpler version ("phant" / "Phant") of phantom for the
  common case where p_type is Type.                                           **)
 
-#[universes(template)]
-Variant phantom T (p : T) := Phantom.
+Variant phantom T (p : T) : Prop := Phantom.
 Arguments phantom : clear implicits.
 Arguments Phantom : clear implicits.
-#[universes(template)]
-Variant phant (p : Type) := Phant.
+Variant phant (p : Type) : Prop := Phant.
 
 (**  Internal tagging used by the implementation of the ssreflect elim.  **)
 

--- a/vernac/comInductive.mli
+++ b/vernac/comInductive.mli
@@ -101,7 +101,7 @@ val compute_template_inductive
   -> univ_entry:UState.universes_entry
   -> Entries.one_inductive_entry
   -> Sorts.t option
-  -> bool
+  -> Entries.inductive_universes_entry * Univ.ContextSet.t
 (** [compute_template_inductive] computes whether an inductive can be template
     polymorphic. *)
 


### PR DESCRIPTION
Instead we ask the upper levels to provide them and we only check that they are indeed template.

The new code is also slightly more lenient since it is more consistent in what is allowed to be template w.r.t. cumulative inductive types. Now, a template universe need not appear in the return arity anymore, it is enough for it to appear as a sort parameter. Similarly, Prop-valued inductive types can now have template parameters.
