### PR TITLE
Use Sys.sigkill (= -7) instead of 9 in Unix.kill

### DIFF
--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -180,7 +180,7 @@ let kill ({ pid = unixpid; oob_resp; oob_req; cin; cout; alive; watch } as p) =
     close_out_noerr cout;
     Option.iter close_in_noerr oob_resp;
     Option.iter close_out_noerr oob_req;
-    if Sys.os_type = "Unix" then Unix.kill unixpid 9;
+    if Sys.os_type = "Unix" then Unix.kill unixpid Sys.sigkill;
     p.watch <- None
   with e -> prerr_endline ("kill: "^Printexc.to_string e) end
 
@@ -250,7 +250,7 @@ let kill ({ pid = unixpid; oob_req; oob_resp; cin; cout; alive } as p) =
     close_out_noerr cout;
     Option.iter close_in_noerr oob_resp;
     Option.iter close_out_noerr oob_req;
-    if Sys.os_type = "Unix" then Unix.kill unixpid 9;
+    if Sys.os_type = "Unix" then Unix.kill unixpid Sys.sigkill;
   with e -> prerr_endline ("kill: "^Printexc.to_string e) end
 
 let rec wait p =


### PR DESCRIPTION
Clearly incorrect.

Per https://v2.ocaml.org/api/Unix.html#TYPEprocess_status, "See module [Sys](https://v2.ocaml.org/api/Sys.html) for the definitions of the standard signal numbers. Note that they are not the numbers used by the OS."

This code is called by the "Reset Coq" button/menu item.  No change in behavior on Linux.  Can't start the Windows version at the moment.