### PR TITLE
Remove CClosure stats infrastructure

### DIFF
--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -14,11 +14,6 @@ open Declarations
 open Environ
 open Esubst
 
-(** Flags for profiling reductions. *)
-val stats : bool ref
-
-val with_stats: 'a Lazy.t -> 'a
-
 (** {6 ... } *)
 (** Delta implies all consts (both global (= by
   [kernel_name]) and local (= by [Rel] or [Var])), all evars, and letin's.

--- a/pretyping/cbv.ml
+++ b/pretyping/cbv.ml
@@ -759,7 +759,7 @@ and cbv_norm_value info = function (* reduction under binders *)
 (* with profiling *)
 let cbv_norm infos constr =
   let constr = EConstr.Unsafe.to_constr constr in
-  EConstr.of_constr (with_stats (lazy (cbv_norm_term infos (subs_id 0) constr)))
+  EConstr.of_constr (cbv_norm_term infos (subs_id 0) constr)
 
 (* constant bodies are normalized at the first expansion *)
 let create_cbv_infos reds env sigma =


### PR DESCRIPTION
It seems there is not much desire to see them as in
https://github.com/coq/coq/pull/15828 so let's remove them.
