### PR TITLE
[coqdep] Don't "canonize" files.

### DIFF
--- a/tools/coqdep/lib/loadpath.mli
+++ b/tools/coqdep/lib/loadpath.mli
@@ -67,7 +67,3 @@ val add_coqlib_known : State.t -> bool -> root -> dirname -> dirpath -> basename
    it hasn't. We may also use this to warn if ap hysical path is met
    twice.*)
 val find_dir_logpath : string -> string list
-
-(* Used only in "canonize" *)
-val absolute_dir : string -> string
-val absolute_file_name : filename_concat:(string -> string -> string) -> string -> string option -> string


### PR DESCRIPTION
"Canonization" is a fragile (and expensive) process, instead, we
require that files passed to coqdep match the layout given in the `-R`
/ `-Q` options.

