### PR TITLE
[build] Bump minimal Dune required version to 2.9

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -21,7 +21,7 @@ jobs:
           opam switch set ocaml-base-compiler.$COMPILER
           eval $(opam env)
           opam update
-          opam install -j "$NJOBS" ocamlfind${FINDLIB_VER} ounit lablgtk3-sourceview3 zarith.1.11 dune.2.8.5
+          opam install -j "$NJOBS" ocamlfind${FINDLIB_VER} ounit lablgtk3-sourceview3 zarith.1.11 dune.2.9.1
           opam list
         env:
           COMPILER: "4.12.0"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ variables:
   # Format: $IMAGE-V$DATE-$hash
   # The $hash is the first 10 characters of the md5 of the Dockerfile. e.g.
   # echo $(md5sum dev/ci/docker/bionic_coq/Dockerfile | head -c 10)
-  CACHEKEY: "bionic_coq-V2022-05-20-cb9fc1de6b"
+  CACHEKEY: "bionic_coq-V2022-05-20-028d98bc38"
   IMAGE: "$CI_REGISTRY_IMAGE:$CACHEKEY"
   # By default, jobs run in the base switch; override to select another switch
   OPAM_SWITCH: "base"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,7 +20,7 @@ To compile Coq yourself, you need:
 - [OCaml](https://ocaml.org/) (version >= 4.09.0)
   (This version of Coq has been tested up to OCaml 4.14.0)
 
-- The [Dune OCaml build system](https://github.com/ocaml/dune/) >= 2.5.1
+- The [Dune OCaml build system](https://github.com/ocaml/dune/) >= 2.9.1
 
 - The [ZArith library](https://github.com/ocaml/Zarith) >= 1.11
 

--- a/Makefile.install
+++ b/Makefile.install
@@ -52,23 +52,13 @@ endif
 # We ought to improve this, as of today the case of an opam-built dune
 # installing to a global prefix such as /usr/local/ may not follow the FHS.
 # For now, we respect the values given at configure's time.
-ifdef DUNE_29_PLUS
 install-dune: $(BCONTEXT)/coq-core.install $(BCONTEXT)/coqide-server.install
 	dune install $(_DOPT) $(DESTDIRARG) --mandir="$(MANDIR)" --prefix="$(COQPREFIX)" --etcdir="$(CONFIGDIR)" --docdir="$(DOCDIR)" coq-core
 	dune install $(_DOPT) $(DESTDIRARG) --mandir="$(MANDIR)" --prefix="$(COQPREFIX)" --etcdir="$(CONFIGDIR)" --docdir="$(DOCDIR)" coqide-server
-else
-install-dune: $(BCONTEXT)/coq-core.install $(BCONTEXT)/coqide-server.install
-	dune install $(_DOPT) $(DESTDIRARG) --mandir="$(MANDIR)" --prefix="$(COQPREFIX)" coq-core
-	dune install $(_DOPT) $(DESTDIRARG) --mandir="$(MANDIR)" --prefix="$(COQPREFIX)" coqide-server
-endif
 
-# IMPORTANT NOTE: before Dune 2.9, the --docdir and --etcdir options
-# were not supported, if using Dune >= 2.9, Coq's configure will set
-# the DUNE_29_PLUS=yes` variable to use the call with the right options.
-#
-# Additionally, you can also add --libdir=$(COQLIBINSTALL) if required
-# by your distribution, but we recommend using the default configured
-# with Dune.
+# You can also add --libdir=$(COQLIBINSTALL) if required by your
+# distribution, but we recommend using the default configured with
+# Dune.
 
 install-coq: install-dune install-library
 
@@ -100,15 +90,9 @@ endif
 ifeq ($(HASCOQIDE),no)
 install-coqide:
 else
-ifdef DUNE_29_PLUS
 install-coqide: $(BCONTEXT)/coqide.install
 	dune install $(_DOPT) $(DESTDIRARG) --mandir="$(MANDIR)" --prefix="$(COQPREFIX)" --etcdir="$(CONFIGDIR)" --docdir="$(DOCDIR)" coqide
-else
-	dune install $(_DOPT) $(DESTDIRARG) --mandir="$(MANDIR)" --prefix="$(COQPREFIX)" coqide
 endif
-endif
-
-
 
 # For emacs:
 # Local Variables:

--- a/coq-core.opam
+++ b/coq-core.opam
@@ -27,7 +27,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "2.5"}
+  "dune" {>= "2.9"}
   "ocaml" {>= "4.09.0"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}

--- a/coq-doc.opam
+++ b/coq-doc.opam
@@ -16,7 +16,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {build & >= "2.5.0"}
+  "dune" {>= "2.9"}
   "conf-python-3" {build}
   "coq" {build & = version}
 ]

--- a/coq-stdlib.opam
+++ b/coq-stdlib.opam
@@ -23,7 +23,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "2.5"}
+  "dune" {>= "2.9"}
   "coq-core" {= version}
 ]
 build: [

--- a/coq.opam
+++ b/coq.opam
@@ -20,7 +20,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "2.5"}
+  "dune" {>= "2.9"}
   "coq-core" {= version}
   "coq-stdlib" {= version}
 ]

--- a/coq.opam.docker
+++ b/coq.opam.docker
@@ -22,6 +22,7 @@ version: "dev"
 
 depends: [
   "ocaml"     { >= "4.09.0" }
+  "dune"      { >= "2.9" }
   "ocamlfind" { build }
   "zarith"    { >= "1.11" }
   "conf-findutils" {build}

--- a/coqide-server.opam
+++ b/coqide-server.opam
@@ -19,7 +19,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "2.5"}
+  "dune" {>= "2.9"}
   "coq-core" {= version}
 ]
 build: [

--- a/coqide.opam
+++ b/coqide.opam
@@ -17,7 +17,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "2.5"}
+  "dune" {>= "2.9"}
   "coqide-server" {= version}
 ]
 build: [

--- a/dev/ci/docker/bionic_coq/Dockerfile
+++ b/dev/ci/docker/bionic_coq/Dockerfile
@@ -65,7 +65,7 @@ RUN opam switch create "${COMPILER}+32bit" && eval $(opam env) && \
 
 # EDGE switch
 ENV COMPILER_EDGE="4.14.0" \
-    BASE_OPAM_EDGE="dune.2.9.1 dune-release.1.5.0 ocamlfind.1.9.1 odoc.2.0.2" \
+    BASE_OPAM_EDGE="dune.2.9.3 dune-release.1.6.1 ocamlfind.1.9.1 odoc.2.0.2" \
     COQIDE_OPAM_EDGE="lablgtk3-sourceview3.3.1.2"
 
 # EDGE+flambda switch, we install CI_OPAM as to be able to use

--- a/doc/changelog/11-infrastructure-and-dependencies/16118-build+bump_dune.rst
+++ b/doc/changelog/11-infrastructure-and-dependencies/16118-build+bump_dune.rst
@@ -1,0 +1,4 @@
+- **Changed:**
+  Building Coq now requires Dune >= 2.9
+  (`#16118 <https://github.com/coq/coq/pull/16118>`_,
+  by Emilio Jesus Gallego Arias).

--- a/dune-project
+++ b/dune-project
@@ -1,13 +1,11 @@
-(lang dune 2.5)
+(lang dune 2.9)
 (name coq)
-(using coq 0.2)
+(using coq 0.3)
 
 (formatting
  (enabled_for ocaml))
 
-; Pending on dune 2.8 as to avoid bug with dune subst
-; see https://github.com/ocaml/dune/pull/3879 and
-; https://github.com/ocaml/dune/pull/3879
+; After Dune 2.8 we can use this, but let's wait for the build consolidation PR
 ; (generate_opam_files true)
 
 (license LGPL-2.1-only)
@@ -98,7 +96,6 @@ development of interactive proofs."))
  (name coq-doc)
  (license "OPL-1.0")
  (depends
-  (dune (and :build (>= 2.5.0)))
   (conf-python-3 :build)
   (coq (and :build (= :version))))
  (synopsis "The Coq Proof Assistant --- Reference Manual")

--- a/kernel/byterun/dune
+++ b/kernel/byterun/dune
@@ -5,7 +5,7 @@
  (foreign_stubs
   (language c)
   (names coq_fix_code coq_float64 coq_memory coq_values coq_interp)
-  (flags (:include %{project_root}/config/dune.c_flags))))
+  (flags :standard (:include %{project_root}/config/dune.c_flags))))
 
 (rule
  (targets coq_instruct.h)

--- a/theories/dune
+++ b/theories/dune
@@ -2,11 +2,9 @@
  (name Coq)
  (package coq-stdlib)
  (synopsis "Coq's Standard Library")
- (flags -q -w -deprecated-native-compiler-option)
+ ; Uncomment this to have dune compile native files in release mode
  ; (mode native)
  (boot)
- ; (per_file
- ;  (Init/*.v -> -boot))
  (libraries
    ltac_plugin
    tauto_plugin

--- a/tools/configure/configure.ml
+++ b/tools/configure/configure.ml
@@ -186,25 +186,6 @@ let hasnatdynlink prefs best_compiler = prefs.natdynlink && best_compiler = "opt
 
 (** * OS dependent libraries *)
 
-(** Check for dune *)
-
-let dune_install_warning () =
-  warn "You are using Dune < 2.9, the install procedure will not respect the -docdir and -configdir configure directives; please see dev/doc/INSTALL.make.md for more information"
-
-(* returns true if dune >= 2.9 *)
-let check_for_dune_29 () =
-  let dune_version, _  = tryrun "dune" ["--version"] in
-  let dune_version = generic_version_nums ~name:"dune" dune_version in
-  match dune_version with
-  (* Development version, consider it >= 2.9 *)
-  | [] -> true
-  | _ ->
-    if dune_version < [2;9;0] then
-      (dune_install_warning ();
-       false)
-    else
-      true
-
 (** Zarith library *)
 
 let check_for_zarith prefs =
@@ -521,7 +502,7 @@ let write_configml camlenv coqenv caml_flags caml_version_nums arch arch_is_win3
 
 (** * Build the config/Makefile file *)
 
-let write_makefile prefs install_dirs best_compiler caml_flags coq_caml_flags coqide arch exe dune_29 o =
+let write_makefile prefs install_dirs best_compiler caml_flags coq_caml_flags coqide arch exe o =
   let pr s = fprintf o s in
   pr "###### config/Makefile : Configuration file for Coq ##############\n";
   pr "#                                                                #\n";
@@ -564,7 +545,6 @@ let write_makefile prefs install_dirs best_compiler caml_flags coq_caml_flags co
   pr "COQWARNERROR=%s\n" (if prefs.warn_error then "-w +default" else "");
   pr "CONFIGURE_DPROFILE=%s\n" prefs.dune_profile;
   pr "COQ_INSTALL_ENABLED=%b\n" prefs.install_enabled;
-  if dune_29 then pr "DUNE_29_PLUS=yes\n";
   ()
 
 let write_dune_c_flags cflags o =
@@ -581,7 +561,6 @@ let write_configpy o =
 let main () =
   let prefs = CmdArgs.parse_args () in
   Util.debug := prefs.debug;
-  let dune_29 = check_for_dune_29 () in
   let coq_annot_flag = coq_annot_flag prefs in
   let coq_bin_annot_flag = coq_bin_annot_flag prefs in
   let arch = arch prefs in
@@ -612,7 +591,7 @@ let main () =
   write_config_file ~file:"config/coq_config.ml"
     (write_configml camlenv coqenv caml_flags caml_version_nums arch arch_is_win32 hasnatdynlink browser idearchdef prefs);
   write_config_file ~file:"config/Makefile"
-    (write_makefile prefs install_dirs best_compiler caml_flags coq_caml_flags coqide arch exe dune_29);
+    (write_makefile prefs install_dirs best_compiler caml_flags coq_caml_flags coqide arch exe);
   write_config_file ~file:"config/dune.c_flags" (write_dune_c_flags cflags);
   write_config_file ~file:"config/coq_config.py" write_configpy;
   ()


### PR DESCRIPTION
2.9 has been around for a while and should allow us to:

- generate the opam files
- make progress on https://github.com/coq/coq/pull/14519
- make progress on https://github.com/coq/coq/pull/14241