### PR TITLE
deprecate Cd command

### DIFF
--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -921,9 +921,8 @@ GRAMMAR EXTEND Gram
           { VernacDeclareScope sc }
 
       (* System directory *)
-      | IDENT "Pwd" -> { VernacChdir None }
-      | IDENT "Cd" -> { VernacChdir None }
-      | IDENT "Cd"; dir = ne_string -> { VernacChdir (Some dir) }
+      | IDENT "Pwd" -> { VernacPwd }
+      | IDENT "Cd"; dir = ne_string -> { VernacChdir dir }
 
       | IDENT "Load"; verbosely = [ IDENT "Verbose" -> { true } | -> { false } ];
         s = [ s = ne_string -> { s } | s = IDENT -> { s } ] ->

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -1087,7 +1087,9 @@ let pr_vernac_expr v =
       hov 2 (keyword "Declare ML Module" ++ spc() ++ prlist_with_sep sep qs l)
     )
   | VernacChdir s ->
-    return (keyword "Cd" ++ pr_opt qs s)
+    return (keyword "Cd" ++ qs s)
+  | VernacPwd ->
+    return (keyword "Pwd")
 
   (* Commands *)
   | VernacCreateHintDb (dbname,b) ->

--- a/vernac/vernac_classifier.ml
+++ b/vernac/vernac_classifier.ml
@@ -138,7 +138,7 @@ let classify_vernac e =
     | VernacUniverse _ | VernacConstraint _
     | VernacCanonical _ | VernacCoercion _ | VernacIdentityCoercion _
     | VernacAddLoadPath _ | VernacRemoveLoadPath _ | VernacAddMLPath _
-    | VernacChdir _
+    | VernacChdir _ | VernacPwd
     | VernacCreateHintDb _ | VernacRemoveHints _ | VernacHints _
     | VernacArguments _
     | VernacReserve _

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1584,7 +1584,7 @@ let vernac_declare_ml_module ~local l =
   let l = List.map expand l in
   Mltop.declare_ml_modules local l
 
-let warn_cd = CWarnings.create ~name:"cd-deprecated" ~category:"deprecated"
+let warn_cd = CWarnings.create ~name:"cd-deprecated" ~category:"deprecated" ~default:CWarnings.AsError
   (fun () -> strbrk "The command \"Cd\" is deprecated." ++ spc () ++
              (* TODO: *)
              strbrk "TODO: something about how extraction will/does support an output dir so use that instead" ++ spc () ++

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -415,7 +415,8 @@ type nonrec vernac_expr =
   | VernacRemoveLoadPath of string
   | VernacAddMLPath of string
   | VernacDeclareMLModule of string list
-  | VernacChdir of string option
+  | VernacChdir of string
+  | VernacPwd
 
   (* Resetting *)
   | VernacResetName of lident


### PR DESCRIPTION
Keeping this as a draft for now. We need to provide output directory support for extraction first.