### PR TITLE
Disable warning 40 (Constructor or label name used out of scope)

### DIFF
--- a/dev/doc/style.txt
+++ b/dev/doc/style.txt
@@ -66,6 +66,13 @@ OCaml Style:
     (setq tuareg-with-indent 0)
     (setq tuareg-function-indent 0)
     (setq tuareg-let-always-indent nil)
+  - when a match fails to compile due to unbound constructors (eg
+    "match x with VarRef x -> bla | ConstRef x -> bli | _ -> blo" when
+    GlobRef is not open) it can be resolved in several ways:
+    + locally or globally open GlobRef
+    + type annotate "x : GlobRef.t" (where it is introduced, or in the match expression, whichever is nicer)
+    + annotate the first branch "GlobRef.VarRef x -> bla"
+      this last solution is not robust to branch reordering so should not be prefered
 
 - Coding methodology
   - no "try ... with _ -> ..." which catches even Sys.Break (Ctrl-C),

--- a/dune
+++ b/dune
@@ -1,9 +1,9 @@
 ; Default flags for all Coq libraries.
 (env
- (dev     (flags :standard -rectypes -w -9-27@40@60-70 \ -short-paths))
+ (dev     (flags :standard -rectypes -w -9-27@60-70 \ -short-paths))
  (release (flags :standard -rectypes)
           (ocamlopt_flags :standard -O3 -unbox-closures))
- (ireport (flags :standard -rectypes -w -9-27-40+60-70)
+ (ireport (flags :standard -rectypes -w -9-27+60-70)
           (ocamlopt_flags :standard -O3 -unbox-closures -inlining-report)))
 
 ; Information about flags for release mode:

--- a/kernel/dune
+++ b/kernel/dune
@@ -30,7 +30,7 @@
 ; In dev profile, we check the kernel against a more strict set of
 ; warnings.
 (env
- (dev (flags :standard -w @a-4-44-50-70)))
+ (dev (flags :standard -w @a-4-40-44-50-70)))
 
 (deprecated_library_name
  (old_public_name coq.kernel)

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1380,7 +1380,6 @@ let vernac_end_segment lid =
         let () = vernac_end_segment ~pm ~proof lid in
         (), ())
   }
-[@@ocaml.warning "-40"]
 
 let vernac_begin_segment ~interactive f =
   let inproof = Vernacextend.InProof.(if interactive then Reject else Ignore) in
@@ -1391,7 +1390,6 @@ let vernac_begin_segment ~interactive f =
         let () = f () in
         (), ())
   }
-[@@ocaml.warning "-40"]
 
 (* External dependencies *)
 

--- a/vernac/vernacextend.ml
+++ b/vernac/vernacextend.ml
@@ -128,8 +128,6 @@ type typed_vernac =
       run : pm:'inprog -> proof:'inproof -> 'outprog * 'outproof;
     } -> typed_vernac
 
-[@@@ocaml.warning "-40"]
-
 let vtdefault f =
   TypedVernac { inprog = Ignore; outprog = No; inproof = Ignore; outproof = No;
                 run = (fun ~pm:() ~proof:() ->
@@ -205,8 +203,6 @@ let vtopenproofprogram f =
                     let pm, proof = f ~pm in
                     pm, proof)
               }
-
-[@@@ocaml.warning "+40"]
 
 type vernac_command = ?loc:Loc.t -> atts:Attributes.vernac_flags -> unit -> typed_vernac
 


### PR DESCRIPTION
Typically this lets us do

~~~ocaml
let elimination_suffix = function
  | Sorts.InSProp -> "_sind"
  | InProp -> "_ind"
  | InSet -> "_rec"
  | InType -> "_rect"
~~~
instead of
~~~ocaml
let elimination_suffix = function
  | Sorts.InSProp -> "_sind"
  | Sorts.InProp -> "_ind"
  | Sorts.InSet -> "_rec"
  | Sorts.InType -> "_rect"
~~~
or having to open `Sorts`.

This change was previously proposed and rejected in
https://github.com/coq/coq/pull/11485 but more recent discussion with
@ejgallego indicated that opinions may have changed since.
