### PR TITLE
Add support for output directory in extraction

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/16126-extraction-output.rst
+++ b/doc/changelog/08-vernac-commands-and-options/16126-extraction-output.rst
@@ -1,0 +1,6 @@
+- **Added:**
+  :opt:`Extraction Output Directory` option for specifying the
+  directory in which extracted files are written
+  (`#16126 <https://github.com/coq/coq/pull/16126>`_,
+  fixes `#9148 <https://github.com/coq/coq/issues/9148>`_,
+  by Ali Caglayan).

--- a/doc/sphinx/addendum/extraction.rst
+++ b/doc/sphinx/addendum/extraction.rst
@@ -471,6 +471,11 @@ Additional settings
 
    If this :term:`flag` is set, fully expand Coq types in ML.  See the Coq source code to learn more.
 
+.. opt:: Extraction Output Directory @string
+
+   Sets the directory where extracted files will be written.
+   The default is the current directory, which can be displayed with :cmd:`Pwd`.
+
 Differences between Coq and ML type systems
 ----------------------------------------------
 

--- a/doc/sphinx/practical-tools/coq-commands.rst
+++ b/doc/sphinx/practical-tools/coq-commands.rst
@@ -363,7 +363,7 @@ and ``coqtop``, unless stated otherwise:
        - none
        - none
 
-:-native-output-dir: Set the directory in which to put the aforementioned
+:-native-output-dir *dir*: Set the directory in which to put the aforementioned
   ``.cmxs`` for :tacn:`native_compute`. Defaults to ``.coq-native``.
 :-vos: Indicate Coq to skip the processing of opaque proofs
   (i.e., proofs ending with :cmd:`Qed` or :cmd:`Admitted`), output a ``.vos`` files

--- a/dune-project
+++ b/dune-project
@@ -1,6 +1,7 @@
 (lang dune 2.9)
 (name coq)
 (using coq 0.3)
+(cram enable)
 
 (formatting
  (enabled_for ocaml))

--- a/lib/system.ml
+++ b/lib/system.ml
@@ -56,6 +56,13 @@ let exists_dir dir =
   let dir = if Sys.os_type = "Win32" then strip_trailing_slash dir else dir in
   try Sys.is_directory dir with Sys_error _ -> false
 
+let rec mkdir dir =
+  if not (exists_dir dir) then
+    begin
+      mkdir (Filename.dirname dir);
+      Unix.mkdir dir 0o755;
+    end
+
 let apply_subdir f path name =
   (* we avoid all files and subdirs starting by '.' (e.g. .svn) *)
   (* as well as skipped files like CVS, ... *)

--- a/lib/system.mli
+++ b/lib/system.mli
@@ -22,6 +22,11 @@ val (//) : unix_path -> string -> unix_path
 
 val exists_dir : unix_path -> bool
 
+(** [mkdir path] ensures that [path] exists as a directory, creating
+    the missing suffix if necessary (like Unix' mkdirhier) *)
+
+val mkdir : unix_path -> unit
+
 (** [exclude_search_in_dirname path] excludes [path] when processing
     directories *)
 

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -444,15 +444,23 @@ let mono_filename f =
             with UserError _ ->
               user_err Pp.(str "Extraction: provided filename is not a valid identifier")
         in
+        let f =
+          if Filename.is_relative f then
+            Filename.concat (output_directory ()) f
+          else f
+        in
         Some (f^d.file_suffix), Option.map ((^) f) d.sig_suffix, id
 
 (* Builds a suitable filename from a module id *)
 
 let module_filename mp =
   let f = file_of_modfile mp in
+  let id = Id.of_string f in
+  let f = Filename.concat (output_directory ()) f in
   let d = descr () in
-  let p = d.file_naming mp ^ d.file_suffix in
-  Some p, Option.map ((^) f) d.sig_suffix, Id.of_string f
+  let fimpl_base = d.file_naming mp ^ d.file_suffix in
+  let fimpl = Filename.concat (output_directory ()) fimpl_base in
+  Some fimpl, Option.map ((^) f) d.sig_suffix, id
 
 (*s Extraction of one decl to stdout. *)
 
@@ -610,7 +618,8 @@ let full_extr f (refs,mps) =
   print_structure_to_file (mono_filename f) false struc;
   reset ()
 
-let full_extraction f lr = full_extr f (locate_ref lr)
+let full_extraction f lr =
+  full_extr f (locate_ref lr)
 
 (*s Separate extraction is similar to recursive extraction, with the output
    decomposed in many files, one per Coq .v file *)

--- a/plugins/extraction/table.mli
+++ b/plugins/extraction/table.mli
@@ -105,6 +105,10 @@ val remove_opaque : GlobRef.t -> unit
 
 val reset_tables : unit -> unit
 
+(*s Output Directory parameter *)
+
+val output_directory : unit -> string
+
 (*s AccessOpaque parameter *)
 
 val access_opaque : unit -> bool

--- a/test-suite/cram/dune
+++ b/test-suite/cram/dune
@@ -1,0 +1,2 @@
+(cram
+ (deps %{bin:coqc} %{project_root}/theories/extraction/Extraction.vo %{project_root}/theories/Arith/PeanoNat.vo))

--- a/test-suite/cram/extraction-output1.t/a.v
+++ b/test-suite/cram/extraction-output1.t/a.v
@@ -1,0 +1,4 @@
+From Coq Require Import Extraction.
+Extraction "bar" nat.
+Set Extraction Output Directory "foo".
+Extraction "zar" nat.

--- a/test-suite/cram/extraction-output1.t/run.t
+++ b/test-suite/cram/extraction-output1.t/run.t
@@ -1,0 +1,27 @@
+Testing the output directory of extraction
+  $ ls
+  a.v
+
+  $ coqc a.v
+  File "./a.v", line 2, characters 0-21:
+  Warning: Setting extraction output directory by default to
+  "$TESTCASE_ROOT".
+  Use "Set Extraction Output Directory" to set a different directory for
+  extracted files to appear in. [extraction-default-directory,extraction]
+Extraction is able to create ouput directories as specified by the user
+
+  $ ls . foo
+  .:
+  a.glob
+  a.v
+  a.vo
+  a.vok
+  a.vos
+  bar.ml
+  bar.mli
+  foo
+  
+  foo:
+  zar.ml
+  zar.mli
+

--- a/test-suite/cram/extraction-output2.t/a.v
+++ b/test-suite/cram/extraction-output2.t/a.v
@@ -1,0 +1,4 @@
+From Coq Require Import Extraction.
+Extraction "bar" nat.
+Set Extraction Output Directory "foo".
+Extraction "zar" nat.

--- a/test-suite/cram/extraction-output2.t/run.t
+++ b/test-suite/cram/extraction-output2.t/run.t
@@ -1,0 +1,50 @@
+Testing the output directory of extraction
+ 
+  $ cat > b.v << EOF
+  > From Coq Require PeanoNat.
+  > Recursive Extraction Library PeanoNat.
+  > EOF
+
+  $ coqc b.v -require-import Extraction -set "Extraction Output Directory"="bar"
+  File "./b.v", line 2, characters 0-38:
+  Warning: The extraction is currently set to bypass opacity, the following
+  opaque constant bodies have been accessed
+  : PeanoNat.Nat.OddT_2 PeanoNat.Nat.OddT_1 PeanoNat.Nat.odd_OddT
+    PeanoNat.Nat.EvenT_OddT_rect PeanoNat.Nat.EvenT_S_OddT
+    PeanoNat.Nat.OddT_S_EvenT PeanoNat.Nat.Even_EvenT
+    PeanoNat.Nat.EvenT_OddT_dec PeanoNat.Nat.even_EvenT
+    PeanoNat.Nat.OddT_EvenT_rect PeanoNat.Nat.Odd_OddT PeanoNat.Nat.EvenT_2
+    PeanoNat.Nat.EvenT_0.
+   [extraction-opaque-accessed,extraction]
+
+  $ ls . bar
+  .:
+  a.v
+  b.glob
+  b.v
+  b.vo
+  b.vok
+  b.vos
+  bar
+  
+  bar:
+  Bool.ml
+  Bool.mli
+  Datatypes.ml
+  Datatypes.mli
+  DecidableClass.ml
+  DecidableClass.mli
+  Decimal.ml
+  Decimal.mli
+  Hexadecimal.ml
+  Hexadecimal.mli
+  Logic.ml
+  Logic.mli
+  Number.ml
+  Number.mli
+  PeanoNat.ml
+  PeanoNat.mli
+  Specif.ml
+  Specif.mli
+  Wf.ml
+  Wf.mli


### PR DESCRIPTION
We add an `Extraction Output Directory` option that defaults to the current directory for extraction.

This is meant to address:
- https://github.com/coq/coq/issues/9148

We "kind of" have a command line option for this. The following will work:
```
coqc test.v -require-import Extraction -set "Extraction Output Directory"="bar"
```

Some more documentation and tests are needed. My own tests seem to have worked OK.

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  - [x] Documented any new / changed **user messages**.
  - [x] Updated **documented syntax** by running `make -f Makefile.dune doc_gram_rsts`.
- [ ] Opened **overlay** pull requests.

This will also let us:
- https://github.com/coq/coq/pull/16119

Closes #9148