### PR TITLE
Use more portable find(1) syntax

### DIFF
--- a/Makefile.make
+++ b/Makefile.make
@@ -46,9 +46,9 @@
 
 # !! Before using FIND_SKIP_DIRS, please read how you should in the !!
 # !! FIND_SKIP_DIRS section of dev/doc/build-system.dev.txt         !!
-# "-not -name ." to avoid skipping everything since we "find ."
+# "! -name ." to avoid skipping everything since we "find ."
 # "-type d" to be able to find .merlin.in files
-FIND_SKIP_DIRS:=-not -name . '(' \
+FIND_SKIP_DIRS:=! -name . '(' \
   -name '.*' -type d -o \
   -name 'debian' -o \
   -name "$${GIT_DIR}" -o \


### PR DESCRIPTION
-not is not POSIX compliant, and e.g. NetBSD does not support it.
