### PR TITLE
Warn for unused var in pattern even when catching a single case

### DIFF
--- a/doc/changelog/02-specification-language/16135-warn_unused_pattern.rst
+++ b/doc/changelog/02-specification-language/16135-warn_unused_pattern.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  warning for unused variables in pattern-matching triggers
+  even when catching a single case. This warning used to be
+  triggered only when the unused variable was catching at least
+  two cases (`#16135 <https://github.com/coq/coq/pull/16135>`_,
+  by Pierre Roux).

--- a/doc/sphinx/language/extensions/match.rst
+++ b/doc/sphinx/language/extensions/match.rst
@@ -303,11 +303,10 @@ considered the sign of a potential error. For instance, it could
 result from an undetected misspelled constant constructor. By default,
 a warning is issued in such situations.
 
-.. warn:: Unused variable @ident catches more than one case.
+.. warn:: Unused variable @ident might be a misspelled constructor. Use _ or _@ident to silence this warning.
 
    This indicates that an unused pattern variable :token:`ident`
-   occurs in a pattern-matching clause used to complete at least two
-   cases of the pattern-matching problem.
+   occurs in a pattern-matching clause.
 
    The warning can be deactivated by using a variable name starting
    with ``_`` or by setting ``Set Warnings
@@ -472,8 +471,8 @@ second one and :g:`false` otherwise. We can write it as follows:
 
    Fixpoint lef (n m:nat) {struct m} : bool :=
      match n, m with
-     | O, x => true
-     | x, O => false
+     | O, _ => true
+     | _, O => false
      | S n, S m => lef n m
      end.
 
@@ -491,7 +490,7 @@ Another way to write this function is:
 
    Fixpoint lef (n m:nat) {struct m} : bool :=
      match n, m with
-     | O, x => true
+     | O, _ => true
      | S n, S m => lef n m
      | _, _ => false
      end.

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -563,7 +563,9 @@ let set_pattern_catch_all_var ?loc eqn = function
 let warn_named_multi_catch_all =
   CWarnings.create ~name:"unused-pattern-matching-variable" ~category:"pattern-matching"
          (fun id ->
-          strbrk "Unused variable " ++ Id.print id ++ strbrk " catches more than one case.")
+          strbrk "Unused variable " ++ Id.print id
+          ++ strbrk " might be a misspelled constructor. Use _ or _"
+          ++ Id.print id ++ strbrk " to silence this warning.")
 
 let wildcard_id = Id.of_string "wildcard'"
 
@@ -571,9 +573,8 @@ let is_wildcard id =
   Id.equal (Id.of_string (Nameops.atompart_of_id id)) wildcard_id
 
 let check_unused_pattern_eqn env vars eqn =
-  match List.length vars with
-  | 0 -> raise_pattern_matching_error ?loc:eqn.eqn_loc (env, Evd.empty, UnusedClause eqn.patterns)
-  | 1 -> ()
+  match vars with
+  | [] -> raise_pattern_matching_error ?loc:eqn.eqn_loc (env, Evd.empty, UnusedClause eqn.patterns)
   | _ ->
     let warn {CAst.v = id; loc} =
       (* Convention: Names starting with `_` and derivatives of Program's

--- a/test-suite/output/Cases.out
+++ b/test-suite/output/Cases.out
@@ -192,8 +192,8 @@ end
 
 Arguments stray N
 File "./output/Cases.v", line 253, characters 4-5:
-Warning: Unused variable B catches more than one case.
-[unused-pattern-matching-variable,pattern-matching]
+Warning: Unused variable B might be a misspelled constructor. Use _ or _B to
+silence this warning. [unused-pattern-matching-variable,pattern-matching]
 File "./output/Cases.v", line 266, characters 33-40:
 The command has indeed failed with message:
 Application of arguments to a recursive notation not supported in patterns.
@@ -252,11 +252,11 @@ match x with
 end
      : J' bool (true, true) -> nat * nat
 File "./output/Cases.v", line 313, characters 3-4:
-Warning: Unused variable x catches more than one case.
-[unused-pattern-matching-variable,pattern-matching]
+Warning: Unused variable x might be a misspelled constructor. Use _ or _x to
+silence this warning. [unused-pattern-matching-variable,pattern-matching]
 File "./output/Cases.v", line 314, characters 6-7:
-Warning: Unused variable y catches more than one case.
-[unused-pattern-matching-variable,pattern-matching]
+Warning: Unused variable y might be a misspelled constructor. Use _ or _y to
+silence this warning. [unused-pattern-matching-variable,pattern-matching]
 File "./output/Cases.v", line 314, characters 3-4:
-Warning: Unused variable x catches more than one case.
-[unused-pattern-matching-variable,pattern-matching]
+Warning: Unused variable x might be a misspelled constructor. Use _ or _x to
+silence this warning. [unused-pattern-matching-variable,pattern-matching]

--- a/test-suite/output/Notations.v
+++ b/test-suite/output/Notations.v
@@ -112,7 +112,7 @@ Notation "'pred' n" := (match n with 0 => 0 | S n' => n' end)
   (at level 0, n at level 0).
 Check (pred 3).
 Check (fun n => match n with 0 => 0 | S n => n end).
-Check (fun n => match n with S p as x => p | y => 0 end).
+Check (fun n => match n with S p as x => p | _ => 0 end).
 
 Notation "'ifn' x 'is' 'succ' n 'then' t 'else' u" :=
   (match x with O => u | S n => t end) (at level 0, u at level 0).

--- a/theories/Floats/SpecFloat.v
+++ b/theories/Floats/SpecFloat.v
@@ -364,7 +364,7 @@ Section FloatOps.
     | S754_infinity true => S754_nan
     | S754_finite true _ _ => S754_nan
     | S754_zero _ => x
-    | S754_finite sx mx ex =>
+    | S754_finite false mx ex =>
       let '(mz, ez, lz) := SFsqrt_core_binary (Zpos mx) ex in
       binary_round_aux false mz ez lz
     end.

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -367,7 +367,7 @@ Section Elts.
   Fixpoint nth (n:nat) (l:list A) (default:A) {struct l} : A :=
     match n, l with
       | O, x :: l' => x
-      | O, other => default
+      | O, [] => default
       | S m, [] => default
       | S m, x :: t => nth m t default
     end.
@@ -375,7 +375,7 @@ Section Elts.
   Fixpoint nth_ok (n:nat) (l:list A) (default:A) {struct l} : bool :=
     match n, l with
       | O, x :: l' => true
-      | O, other => false
+      | O, [] => false
       | S m, [] => false
       | S m, x :: t => nth_ok m t default
     end.


### PR DESCRIPTION
This warning was added in https://github.com/coq/coq/pull/12768 but according to https://github.com/coq/coq/pull/12768#issuecomment-700227387 it was activated only when the unused variable catches at least two cases because activating it for a single case would trigger 124 warnings in the stdlib. Since this number now seems to be down to three, let's activate the warning in all cases.

This follows a discussion on zulip: https://coq.zulipchat.com/#narrow/stream/237977-Coq-users/topic/match.20and.20long.20identifiers

Related issue: #12762

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  - [x] Documented any new / changed **user messages**.
  - ~[ ] Updated **documented syntax** by running `make -f Makefile.dune doc_gram_rsts`.~
