### PR TITLE
DRAFT: for debugging a dune issue (sharing Win32-specific C code between coqide and coqidetop)

### DIFF
--- a/ide/coqide/coq.ml
+++ b/ide/coqide/coq.ml
@@ -172,7 +172,9 @@ type ccb = { open_ccb : 't. 't scoped_ccb -> 't }
 let mk_ccb poly = { open_ccb = fun scope -> scope.bind_ccb poly }
 let with_ccb ccb e = ccb.open_ccb e
 
+(* overridden on Windows; see file coqide_WIN32.c.in *)
 let interrupter = ref (fun pid -> Unix.kill pid Sys.sigint)
+let cvt_pid = ref (fun pid -> pid)
 
 (* todo: does not work on windows (sigusr1 not supported) *)
 let breaker = ref (fun pid -> Unix.kill pid Sys.sigusr1)
@@ -609,9 +611,20 @@ let db_stack x = eval_call ~db:true (Xmlprotocol.db_stack x)
 let db_vars x = eval_call ~db:true (Xmlprotocol.db_vars x)
 let db_configd x = eval_call ~db:true (Xmlprotocol.db_configd x)
 
+let get_interrupt_fname pid =
+  Filename.concat (Minilib.coqide_config_home ())
+      (Printf.sprintf "interrupt_%d" (!cvt_pid pid))
+
 let interrupt_coqtop coqtop workers =
   if coqtop.status = Busy then
-    try !interrupter (CoqTop.unixpid coqtop.handle.proc)
+    try
+      let pid = CoqTop.unixpid coqtop.handle.proc in
+      if Sys.os_type = "Win32" then begin
+        (* indicate which process to interrupt *)
+        let fd = open_out (get_interrupt_fname pid) in
+        close_out fd
+    end;
+    !interrupter pid
     with _ -> Minilib.log "Error while sending Ctrl-C"
   else
     let rec aux = function

--- a/ide/coqide/coq.ml
+++ b/ide/coqide/coq.ml
@@ -174,7 +174,6 @@ let with_ccb ccb e = ccb.open_ccb e
 
 (* overridden on Windows; see file coqide_WIN32.c.in *)
 let interrupter = ref (fun pid -> Unix.kill pid Sys.sigint)
-let cvt_pid = ref (fun pid -> pid)
 
 (* todo: does not work on windows (sigusr1 not supported) *)
 let breaker = ref (fun pid -> Unix.kill pid Sys.sigusr1)
@@ -611,17 +610,13 @@ let db_stack x = eval_call ~db:true (Xmlprotocol.db_stack x)
 let db_vars x = eval_call ~db:true (Xmlprotocol.db_vars x)
 let db_configd x = eval_call ~db:true (Xmlprotocol.db_configd x)
 
-let get_interrupt_fname pid =
-  Filename.concat (Minilib.coqide_config_home ())
-      (Printf.sprintf "interrupt_%d" (!cvt_pid pid))
-
 let interrupt_coqtop coqtop workers =
   if coqtop.status = Busy then
     try
       let pid = CoqTop.unixpid coqtop.handle.proc in
       if Sys.os_type = "Win32" then begin
         (* indicate which process to interrupt *)
-        let fd = open_out (get_interrupt_fname pid) in
+        let fd = open_out (Shared.get_interrupt_fname pid) in
         close_out fd
     end;
     !interrupter pid

--- a/ide/coqide/coq.mli
+++ b/ide/coqide/coq.mli
@@ -106,9 +106,6 @@ val init_coqtop : coqtop -> unit task -> unit
 val interrupt_coqtop : coqtop -> string list -> unit
 (** Terminate the current computation of coqtop or the worker if coqtop is not running. *)
 
-val get_interrupt_fname: int -> string
-(** get filename used to pass interrupt pid on Win32 *)
-
 val close_coqtop : coqtop -> unit
 (** Close coqtop. Subsequent requests will be discarded. Hook ignored. *)
 
@@ -222,7 +219,6 @@ val check_connection : string list -> unit
 val interrupter : (int -> unit) ref
 val breaker : (int -> unit) ref
 val send_break : coqtop -> unit
-val cvt_pid : (int -> int) ref
 
 val save_all : (unit -> unit) ref
 

--- a/ide/coqide/coq.mli
+++ b/ide/coqide/coq.mli
@@ -106,6 +106,9 @@ val init_coqtop : coqtop -> unit task -> unit
 val interrupt_coqtop : coqtop -> string list -> unit
 (** Terminate the current computation of coqtop or the worker if coqtop is not running. *)
 
+val get_interrupt_fname: int -> string
+(** get filename used to pass interrupt pid on Win32 *)
+
 val close_coqtop : coqtop -> unit
 (** Close coqtop. Subsequent requests will be discarded. Hook ignored. *)
 
@@ -219,6 +222,7 @@ val check_connection : string list -> unit
 val interrupter : (int -> unit) ref
 val breaker : (int -> unit) ref
 val send_break : coqtop -> unit
+val cvt_pid : (int -> int) ref
 
 val save_all : (unit -> unit) ref
 

--- a/ide/coqide/coqide.ml
+++ b/ide/coqide/coqide.ml
@@ -442,8 +442,12 @@ let revert_all ?parent _ =
       end)
     notebook#pages
 
+let win_interrupt = ref false
+
 let quit ?parent _ =
-  if not !FileAux.in_quit_dialog then
+  if !win_interrupt then
+    win_interrupt := false
+  else if not !FileAux.in_quit_dialog then
     try FileAux.check_quit ?parent saveall; exit 0
     with FileAux.DontQuit -> ()
 
@@ -842,6 +846,7 @@ module Nav = struct
       Coq.reset_coqtop sn.coqtop (* calls init_bpts *)
     end
   let interrupt _ =  (* terminate computation *)
+    if Sys.os_type = "Win32" then File.win_interrupt := true;
     Minilib.log "User interrupt received";
     if not (resume_debugger Interface.Interrupt) && notebook#pages <> [] then begin
       let osn = (find_db_sn ()) in

--- a/ide/coqide/coqide_WIN32.c.in
+++ b/ide/coqide/coqide_WIN32.c.in
@@ -14,8 +14,8 @@
    because the console is shared.  Idetop.win_interrupt is used to ignore the signal send
    to CoqIDE. */
 
-CAMLprim value win32_interrupt(value pseudopid) {
-  CAMLparam1(pseudopid);
+CAMLprim value win32_interrupt() {
+  CAMLparam0();
   GenerateConsoleCtrlEvent(CTRL_C_EVENT,0); /* signal our co-console */
   CAMLreturn(Val_unit);
 }

--- a/ide/coqide/coqide_WIN32.c.in
+++ b/ide/coqide/coqide_WIN32.c.in
@@ -6,28 +6,27 @@
 
 /* Win32 emulation of a kill -2 (SIGINT) */
 
-/* This code rely of the fact that coqide is now without initial console.
-   Otherwise, no console creation in win32unix/createprocess.c, hence
-   the same console for coqide and all coqtop, and everybody will be
-   signaled at the same time by the code below. */
-
-/* Moreover, AttachConsole exists only since WinXP, and GetProcessId
-   since WinXP SP1. For avoiding the GetProcessId, we could adapt code
-   from win32unix/createprocess.c to make it return both the pid and the
-   handle. For avoiding the AttachConsole, I don't know, maybe having
-   an intermediate process between coqide and coqtop ? */
+/* It appears that the documentation for SetConsoleCtrlHandler used in the
+   prior code (f5276a11) is incorrect.  When that's present, it causes some of
+   the strange behavior described in #13550.
+   
+   This code signals all processes in the process group (multiple coqidetops and coqide.
+   because the console is shared.  Idetop.win_interrupt is used to ignore the signal send
+   to CoqIDE. */
 
 CAMLprim value win32_interrupt(value pseudopid) {
   CAMLparam1(pseudopid);
-  HANDLE h;
-  DWORD pid;
-  FreeConsole(); /* Normally unnecessary, just to be sure... */
-  h = (HANDLE)(Long_val(pseudopid));
-  pid = GetProcessId(h);
-  AttachConsole(pid);
-  /* We want to survive the Ctrl-C that will also concerns us */
-  SetConsoleCtrlHandler(NULL,TRUE); /* NULL + TRUE means ignore */
   GenerateConsoleCtrlEvent(CTRL_C_EVENT,0); /* signal our co-console */
-  FreeConsole();
   CAMLreturn(Val_unit);
+}
+
+/* convert an OCaml pid (a process-local handle #) to a Win32 pid  (global) */
+CAMLprim value win32_cvtpid(value pseudopid) {
+  CAMLparam1(pseudopid);
+  HANDLE h;
+  DWORD win32_pid;
+  
+  h = (HANDLE)(Long_val(pseudopid));
+  win32_pid = GetProcessId(h);
+  CAMLreturn(Val_int(win32_pid));
 }

--- a/ide/coqide/coqide_WIN32.ml.in
+++ b/ide/coqide/coqide_WIN32.ml.in
@@ -46,7 +46,7 @@ let () =
   Coq.gio_channel_of_descr_socket := Glib.Io.channel_of_descr_socket;
   set_win32_path ();
   Coq.interrupter := win32_interrupt;
-  Coq.cvt_pid := win32_cvtpid;
+  Shared.cvt_pid := win32_cvtpid;
   reroute_stdout_stderr ();
   try ignore (Unix.getenv "GTK_CSD") with Not_found -> Unix.putenv "GTK_CSD" "0"
 

--- a/ide/coqide/coqide_WIN32.ml.in
+++ b/ide/coqide/coqide_WIN32.ml.in
@@ -40,11 +40,13 @@ let reroute_stdout_stderr () =
 (* We also provide a specific interrupt function. *)
 
 external win32_interrupt : int -> unit = "win32_interrupt"
+external win32_cvtpid : int -> int = "win32_cvtpid"
 
 let () =
   Coq.gio_channel_of_descr_socket := Glib.Io.channel_of_descr_socket;
   set_win32_path ();
   Coq.interrupter := win32_interrupt;
+  Coq.cvt_pid := win32_cvtpid;
   reroute_stdout_stderr ();
   try ignore (Unix.getenv "GTK_CSD") with Not_found -> Unix.putenv "GTK_CSD" "0"
 

--- a/ide/coqide/dune
+++ b/ide/coqide/dune
@@ -13,7 +13,7 @@
  (public_name coqidetop.opt)
  (package coqide-server)
  (modules idetop)
- (libraries coq-core.toplevel coqide-server.protocol)
+ (libraries coqide_gui coq-core.toplevel coqide-server.protocol)
  (modes native byte)
  (link_flags -linkall))
 

--- a/ide/coqide/dune
+++ b/ide/coqide/dune
@@ -13,7 +13,7 @@
  (public_name coqidetop.opt)
  (package coqide-server)
  (modules idetop)
- (libraries coqide_gui coq-core.toplevel coqide-server.protocol)
+ (libraries coq-core.toplevel coqide-server.protocol platform_specific)
  (modes native byte)
  (link_flags -linkall))
 
@@ -26,12 +26,22 @@
 (library
  (name coqide_gui)
  (wrapped false)
- (modules (:standard \ document idetop coqide_main default_bindings_src gen_gtk_platform))
+ (modules (:standard \ document idetop coqide_main default_bindings_src gen_gtk_platform
+    shared shared_os_specific))
  (foreign_stubs
   (language c)
   (names coqide_os_stubs))
- (optional)
- (libraries coqide-server.protocol coqide-server.core lablgtk3-sourceview3))
+(optional)
+ (libraries coqide-server.protocol coqide-server.core lablgtk3-sourceview3 platform_specific))
+
+(library
+ (name platform_specific)
+ (wrapped false)
+ (modules shared shared_os_specific)
+ (foreign_stubs
+  (language c)
+  (names shared_os_stubs))
+)
 
 (executable
  (name gen_gtk_platform)
@@ -47,8 +57,16 @@
  (action (copy# coqide_%{read:gtk_platform.conf}.ml.in %{targets})))
 
 (rule
+ (targets shared_os_specific.ml)
+ (action (copy# shared_%{read:gtk_platform.conf}.ml.in %{targets})))
+
+(rule
  (targets coqide_os_stubs.c)
  (action (copy coqide_%{read:gtk_platform.conf}.c.in %{targets})))
+
+(rule
+ (targets shared_os_stubs.c)
+ (action (copy shared_%{read:gtk_platform.conf}.c.in %{targets})))
 
 (executable
  (name coqide_main)

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -30,7 +30,7 @@ let catch_break = ref false
 (* tell whether we have a bona fide windows interrupt *)
 let check_win32 () =
   if Sys.os_type = "Win32" then begin
-    let fname = Coq.get_interrupt_fname (Unix.getpid ()) in
+    let fname = Shared.get_interrupt_fname (Unix.getpid ()) in
     let exists = Sys.file_exists fname in
     if exists then Unix.unlink fname;
     true, exists
@@ -704,6 +704,7 @@ let islave_default_opts = Coqargs.default
 
 let () =
   let open Coqtop in
+  Shared_os_specific.init ();
   let custom = {
       parse_extra = islave_parse ;
       usage = coqidetop_specific_usage;

--- a/ide/coqide/shared.ml
+++ b/ide/coqide/shared.ml
@@ -1,0 +1,19 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(* overridden on Windows; see file coqide_WIN32.c.in *)
+let cvt_pid = ref (fun pid -> pid)
+
+let get_interrupt_fname pid =
+  let x =
+  Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "coqide_interrupt_%d" (!cvt_pid pid)) in
+  Printf.eprintf "file is %s\n%!" x;
+  x

--- a/ide/coqide/shared.mli
+++ b/ide/coqide/shared.mli
@@ -1,0 +1,15 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+val get_interrupt_fname : int -> string
+(** get filename used to pass interrupt pid on Win32 *)
+
+val cvt_pid : (int -> int) ref
+(* On Win32, convert OCaml "pid" (a handle) to a genuine Win32 pid *)

--- a/ide/coqide/shared_WIN32.c.in
+++ b/ide/coqide/shared_WIN32.c.in
@@ -1,0 +1,16 @@
+#define _WIN32_WINNT 0x0501  /* Cf below, we restrict to  */
+
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <windows.h>
+
+/* convert an OCaml pid (a process-local handle #) to a Win32 pid  (global) */
+CAMLprim value win32_cvtpid(value pseudopid) {
+  CAMLparam1(pseudopid);
+  HANDLE h;
+  DWORD win32_pid;
+  
+  h = (HANDLE)(Long_val(pseudopid));
+  win32_pid = GetProcessId(h);
+  CAMLreturn(Val_int(win32_pid));
+}

--- a/ide/coqide/shared_WIN32.ml.in
+++ b/ide/coqide/shared_WIN32.ml.in
@@ -1,0 +1,16 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+external win32_cvtpid : int -> int = "win32_cvtpid"
+
+let () =
+  Shared.cvt_pid := win32_cvtpid 
+
+let init () = ()

--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -82,6 +82,7 @@ let spawn_sock env prog args =
   prerr_endline ("EXEC: " ^ String.concat " " (Array.to_list args));
   let pid =
     Unix.create_process_env prog args env Unix.stdin Unix.stdout Unix.stderr in
+  prerr_endline ("PID " ^ string_of_int pid);
   if pid = 0 then begin
     Unix.sleep 1; (* to avoid respawning like crazy *)
     raise (Failure "create_process failed")
@@ -180,7 +181,7 @@ let kill ({ pid = unixpid; oob_resp; oob_req; cin; cout; alive; watch } as p) =
     close_out_noerr cout;
     Option.iter close_in_noerr oob_resp;
     Option.iter close_out_noerr oob_req;
-    if Sys.os_type = "Unix" then Unix.kill unixpid 9;
+    if Sys.os_type = "Unix" then Unix.kill unixpid Sys.sigkill;
     p.watch <- None
   with e -> prerr_endline ("kill: "^Printexc.to_string e) end
 
@@ -250,7 +251,7 @@ let kill ({ pid = unixpid; oob_req; oob_resp; cin; cout; alive } as p) =
     close_out_noerr cout;
     Option.iter close_in_noerr oob_resp;
     Option.iter close_out_noerr oob_req;
-    if Sys.os_type = "Unix" then Unix.kill unixpid 9;
+    if Sys.os_type = "Unix" then Unix.kill unixpid Sys.sigkill;
   with e -> prerr_endline ("kill: "^Printexc.to_string e) end
 
 let rec wait p =


### PR DESCRIPTION
NOT FOR REVIEW YET

Here's what I get:

```
$ time (dune build -p coq-core,coqide-server,coqide && dune install coq-core coqide-server coqide)
File "ide/coqide/dune", line 11, characters 0-258:
11 | (executable
12 |  (name idetop)
13 |  (public_name coqidetop.opt)
14 |  (package coqide-server)
15 |  (modules idetop)
16 |   (foreign_stubs
17 |    (language c)
18 |    (names coqide_os_stubs))
19 |  (libraries coq-core.toplevel coqide-server.protocol)
20 |  (modes native byte)
21 |  (link_flags -linkall))
Error: Pure bytecode executables cannot contain foreign stubs.
Hint: If you only need to build a native executable use "(modes exe)".
File "ide/coqide/dune", line 35, characters 9-24:
35 |   (names coqide_os_stubs))
              ^^^^^^^^^^^^^^^
Error: Multiple definitions for the same object file "coqide_os_stubs.o". See
another definition at ide/coqide/dune:18.
Hint: You can avoid the name clash by renaming one of the objects, or by
placing it into a different directory.

real    0m6.714s
user    0m0.000s
sys     0m0.046s
```

I'd like to reuse `coqide_os_specific.ml` and `coqide_os_stubs.c` (both generated, not in git).  I'll need to add a call to `Coqide_os_specific.init` somewhere for the server (as was done in `coqide_main.ml`).

Attn: @rgrinberg
