### PR TITLE
Fix "Interrupt computations" on Windows

### DIFF
--- a/doc/changelog/10-coqide/16142-fix_win_interrupt2.rst
+++ b/doc/changelog/10-coqide/16142-fix_win_interrupt2.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  "Interrupt computations" now works correctly on Windows
+  (`#16142 <https://github.com/coq/coq/pull/16142>`_,
+  fixes `#13550 <https://github.com/coq/coq/issues/13550>`_,
+  by Jim Fehrle).

--- a/ide/coqide/coq.ml
+++ b/ide/coqide/coq.ml
@@ -172,6 +172,7 @@ type ccb = { open_ccb : 't. 't scoped_ccb -> 't }
 let mk_ccb poly = { open_ccb = fun scope -> scope.bind_ccb poly }
 let with_ccb ccb e = ccb.open_ccb e
 
+(* overridden on Windows; see file coqide_WIN32.c.in *)
 let interrupter = ref (fun pid -> Unix.kill pid Sys.sigint)
 
 (* todo: does not work on windows (sigusr1 not supported) *)

--- a/ide/coqide/coqide.ml
+++ b/ide/coqide/coqide.ml
@@ -442,8 +442,12 @@ let revert_all ?parent _ =
       end)
     notebook#pages
 
+let win_interrupt = ref false
+
 let quit ?parent _ =
-  if not !FileAux.in_quit_dialog then
+  if !win_interrupt then
+    win_interrupt := false
+  else if not !FileAux.in_quit_dialog then
     try FileAux.check_quit ?parent saveall; exit 0
     with FileAux.DontQuit -> ()
 
@@ -842,6 +846,7 @@ module Nav = struct
       Coq.reset_coqtop sn.coqtop (* calls init_bpts *)
     end
   let interrupt _ =  (* terminate computation *)
+    if Sys.os_type = "Win32" then File.win_interrupt := true;
     Minilib.log "User interrupt received";
     if not (resume_debugger Interface.Interrupt) && notebook#pages <> [] then begin
       let osn = (find_db_sn ()) in

--- a/ide/coqide/coqide_WIN32.c.in
+++ b/ide/coqide/coqide_WIN32.c.in
@@ -6,28 +6,16 @@
 
 /* Win32 emulation of a kill -2 (SIGINT) */
 
-/* This code rely of the fact that coqide is now without initial console.
-   Otherwise, no console creation in win32unix/createprocess.c, hence
-   the same console for coqide and all coqtop, and everybody will be
-   signaled at the same time by the code below. */
-
-/* Moreover, AttachConsole exists only since WinXP, and GetProcessId
-   since WinXP SP1. For avoiding the GetProcessId, we could adapt code
-   from win32unix/createprocess.c to make it return both the pid and the
-   handle. For avoiding the AttachConsole, I don't know, maybe having
-   an intermediate process between coqide and coqtop ? */
+/* It appears that the documentation for SetConsoleCtrlHandler used in the
+   prior code (f5276a11) is incorrect.  When it's present, it causes some of
+   the strange behavior described in #13550.
+   
+   This code signals all processes in the process group (multiple coqidetops) and coqide.
+   because the console is shared.  Coqide.win_interrupt is used to ignore the signal sent
+   to CoqIDE. */
 
 CAMLprim value win32_interrupt(value pseudopid) {
   CAMLparam1(pseudopid);
-  HANDLE h;
-  DWORD pid;
-  FreeConsole(); /* Normally unnecessary, just to be sure... */
-  h = (HANDLE)(Long_val(pseudopid));
-  pid = GetProcessId(h);
-  AttachConsole(pid);
-  /* We want to survive the Ctrl-C that will also concerns us */
-  SetConsoleCtrlHandler(NULL,TRUE); /* NULL + TRUE means ignore */
-  GenerateConsoleCtrlEvent(CTRL_C_EVENT,0); /* signal our co-console */
-  FreeConsole();
+  GenerateConsoleCtrlEvent(CTRL_C_EVENT,0); /* signal each process in the process group */
   CAMLreturn(Val_unit);
 }

--- a/ide/coqide/coqide_WIN32.ml.in
+++ b/ide/coqide/coqide_WIN32.ml.in
@@ -41,10 +41,16 @@ let reroute_stdout_stderr () =
 
 external win32_interrupt : int -> unit = "win32_interrupt"
 
+let interrupter pid = 
+  (* indicate which process to interrupt *)
+  let fd = open_out (Shared.get_interrupt_fname pid) in
+  close_out fd;
+  win32_interrupt pid
+      
 let () =
   Coq.gio_channel_of_descr_socket := Glib.Io.channel_of_descr_socket;
   set_win32_path ();
-  Coq.interrupter := win32_interrupt;
+  Coq.interrupter := interrupter;
   reroute_stdout_stderr ();
   try ignore (Unix.getenv "GTK_CSD") with Not_found -> Unix.putenv "GTK_CSD" "0"
 

--- a/ide/coqide/coqide_main.ml
+++ b/ide/coqide/coqide_main.ml
@@ -63,6 +63,7 @@ let () =
   let w = Coqide.main files in
   Coqide.set_signal_handlers ~parent:w ();
   Coqide_os_specific.init ();
+  Shared_os_specific.init ();
   try
     GMain.main ();
     failwith "Gtk loop ended"

--- a/ide/coqide/dune
+++ b/ide/coqide/dune
@@ -13,7 +13,7 @@
  (public_name coqidetop.opt)
  (package coqide-server)
  (modules idetop)
- (libraries coq-core.toplevel coqide-server.protocol)
+ (libraries coq-core.toplevel coqide-server.protocol platform_specific)
  (modes native byte)
  (link_flags -linkall))
 
@@ -26,11 +26,22 @@
 (library
  (name coqide_gui)
  (wrapped false)
- (modules (:standard \ document idetop coqide_main default_bindings_src gen_gtk_platform))
+ (modules (:standard \ document idetop coqide_main default_bindings_src gen_gtk_platform
+    shared shared_os_specific))
  (foreign_stubs
   (language c)
   (names coqide_os_stubs))
- (libraries coqide-server.protocol coqide-server.core lablgtk3-sourceview3))
+ (optional)
+ (libraries coqide-server.protocol coqide-server.core lablgtk3-sourceview3 platform_specific))
+
+(library
+ (name platform_specific)
+ (wrapped false)
+ (modules shared shared_os_specific)
+ (foreign_stubs
+  (language c)
+  (names shared_os_stubs))
+)
 
 (executable
  (name gen_gtk_platform)
@@ -46,8 +57,16 @@
  (action (copy# coqide_%{read:gtk_platform.conf}.ml.in %{targets})))
 
 (rule
+ (targets shared_os_specific.ml)
+ (action (copy# shared_%{read:gtk_platform.conf}.ml.in %{targets})))
+
+(rule
  (targets coqide_os_stubs.c)
  (action (copy coqide_%{read:gtk_platform.conf}.c.in %{targets})))
+
+(rule
+ (targets shared_os_stubs.c)
+ (action (copy shared_%{read:gtk_platform.conf}.c.in %{targets})))
 
 (executable
  (name coqide_main)

--- a/ide/coqide/shared.ml
+++ b/ide/coqide/shared.ml
@@ -1,0 +1,16 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(* overridden on Windows; see file shared_WIN32.c.in *)
+let cvt_pid = ref (fun pid -> pid)
+
+let get_interrupt_fname pid =
+  Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "coqide_interrupt_%d" (!cvt_pid pid))

--- a/ide/coqide/shared.mli
+++ b/ide/coqide/shared.mli
@@ -1,0 +1,15 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+val get_interrupt_fname : int -> string
+(** get filename used to pass interrupt pid on Win32 *)
+
+val cvt_pid : (int -> int) ref
+(* On Win32, convert OCaml "pid" (a handle) to a genuine Win32 pid *)

--- a/ide/coqide/shared_QUARTZ.c.in
+++ b/ide/coqide/shared_QUARTZ.c.in
@@ -1,0 +1,1 @@
+/* no osx-specific stubs for now */

--- a/ide/coqide/shared_QUARTZ.ml.in
+++ b/ide/coqide/shared_QUARTZ.ml.in
@@ -1,0 +1,11 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+let init () = ()

--- a/ide/coqide/shared_WIN32.c.in
+++ b/ide/coqide/shared_WIN32.c.in
@@ -1,0 +1,16 @@
+#define _WIN32_WINNT 0x0501  /* Cf below, we restrict to  */
+
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <windows.h>
+
+/* convert an OCaml pid (a process-local handle #) to a Win32 pid (global) */
+CAMLprim value win32_cvtpid(value pseudopid) {
+  CAMLparam1(pseudopid);
+  HANDLE h;
+  DWORD win32_pid;
+  
+  h = (HANDLE)(Long_val(pseudopid));
+  win32_pid = GetProcessId(h);
+  CAMLreturn(Val_int(win32_pid));
+}

--- a/ide/coqide/shared_WIN32.ml.in
+++ b/ide/coqide/shared_WIN32.ml.in
@@ -1,0 +1,16 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+external win32_cvtpid : int -> int = "win32_cvtpid"
+
+let () =
+  Shared.cvt_pid := win32_cvtpid 
+
+let init () = ()

--- a/ide/coqide/shared_X11.c.in
+++ b/ide/coqide/shared_X11.c.in
@@ -1,0 +1,1 @@
+/* no Linux-specific stubs for now */

--- a/ide/coqide/shared_X11.ml.in
+++ b/ide/coqide/shared_X11.ml.in
@@ -1,0 +1,11 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+let init () = ()

--- a/ide/coqide/shared_os_specific.mli
+++ b/ide/coqide/shared_os_specific.mli
@@ -1,0 +1,11 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+val init : unit -> unit

--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -82,6 +82,7 @@ let spawn_sock env prog args =
   prerr_endline ("EXEC: " ^ String.concat " " (Array.to_list args));
   let pid =
     Unix.create_process_env prog args env Unix.stdin Unix.stdout Unix.stderr in
+  prerr_endline ("PID " ^ string_of_int pid);
   if pid = 0 then begin
     Unix.sleep 1; (* to avoid respawning like crazy *)
     raise (Failure "create_process failed")
@@ -180,7 +181,7 @@ let kill ({ pid = unixpid; oob_resp; oob_req; cin; cout; alive; watch } as p) =
     close_out_noerr cout;
     Option.iter close_in_noerr oob_resp;
     Option.iter close_out_noerr oob_req;
-    if Sys.os_type = "Unix" then Unix.kill unixpid 9;
+    if Sys.os_type = "Unix" then Unix.kill unixpid Sys.sigkill;
     p.watch <- None
   with e -> prerr_endline ("kill: "^Printexc.to_string e) end
 
@@ -250,7 +251,7 @@ let kill ({ pid = unixpid; oob_req; oob_resp; cin; cout; alive } as p) =
     close_out_noerr cout;
     Option.iter close_in_noerr oob_resp;
     Option.iter close_out_noerr oob_req;
-    if Sys.os_type = "Unix" then Unix.kill unixpid 9;
+    if Sys.os_type = "Unix" then Unix.kill unixpid Sys.sigkill;
   with e -> prerr_endline ("kill: "^Printexc.to_string e) end
 
 let rec wait p =


### PR DESCRIPTION
Windows doesn't support signals, so another mechanism was used to support "Interrupt computations" in CoqIDE.  On Windows, every process that shares a console (i.e. coqide and all the coqidetop's and worker processes) receives the interrupt.  This PR creates an empty file in a temp directory to signal which coqtopide should pay attention to the interrupt.  The others will ignore it.  

For all major releases back to 8.5pl3, interrupt stops working in a buffer after it's been reset.  The original code in `coqide_WIN32.c.in` dating from 2011 called `FreeConsole()`, which detaches coqide from the console.  Then when you subsequently reset the CoqIDE buffer, creating a new process, the new coqidetop doesn't inherit the console, so it can't be interrupted.

Also, contrary to the documentation, the `SetConsoleCtrlHandler` appears to affect more than the calling process.  Removing that means that coqide will send the signal to itself, so I added code to ignore the signal in that case.

I suspect the bug dates to the original code rather than being a regression.  It's possible this worked in 2011 and that the behavior of these Windows calls has changed.  I'm on Windows 10.

While I've tested this a lot, it would be nice to get someone with a fresh perspective to try it on Windows in case I missed something.

Fixes: #13550