### PR TITLE
[coqdev.el] Don't error if `ocamldebug` is not present.

### DIFF
--- a/dev/tools/coqdev.el
+++ b/dev/tools/coqdev.el
@@ -30,7 +30,7 @@
 ;; ./configure to compile Coq it is already too late).
 
 ;;; Code:
-(require 'ocamldebug)
+(require 'ocamldebug nil 'noerror)
 
 (require 'seq)
 (require 'subr-x)


### PR DESCRIPTION
This is useful when navigating on many opam switches and `ocamldebug`
may not be present.

