### PR TITLE
[coqmod] Added new binary coqmod

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,6 +1,8 @@
-(lang dune 2.5)
+(lang dune 2.7)
 (name coq)
 (using coq 0.2)
+
+(cram enable)
 
 (formatting
  (enabled_for ocaml))

--- a/tools/coqmod/.ocamlformat
+++ b/tools/coqmod/.ocamlformat
@@ -1,0 +1,12 @@
+profile = ocamlformat
+version = 0.21.0
+
+exp-grouping = preserve
+sequence-style = terminator
+break-separators = after
+dock-collection-brackets = true
+field-space = loose
+
+break-cases = fit #fit-or-vertical
+# {fit|nested|toplevel|fit-or-vertical|all}
+cases-exp-indent=4

--- a/tools/coqmod/README.md
+++ b/tools/coqmod/README.md
@@ -1,0 +1,209 @@
+# coqmod
+
+- [coqmod](#coqmod)
+- [Example](#example)
+- [Testing](#testing)
+- [Specification](#specification)
+  - [Name](#name)
+  - [Require](#require)
+  - [From](#from)
+  - [Declare](#declare)
+  - [Load logical](#load-logical)
+  - [Load physical](#load-physical)
+  - [Extra Dependency](#extra-dependency)
+
+
+`coqmod` outputs Coq modules and OCaml libraries that a `.v` file depends on.
+
+It is intended to be a minimalistic replacement to `coqdep` for use by `dune`.
+
+Unlike `coqdep`, it does not scan directories making it lightweight in
+comparison.
+
+It has 3 `--format` modes:
+- `csexp` - canonical serial expresion (default)
+- `read` - human readable output
+- `sexp` - pretty printed serial expression
+
+When a single `.v` file is passed to `coqmod`, it will output the tokens
+corresponding to dependencies in the specified format.
+
+# Example
+
+Here is the output for an `example.v` file:
+
+```coq
+  From A.B.C Require Import R.X L.Y.G Z.W.
+
+  Load X.
+  Load "A/b/c".
+
+  Declare ML Module "foo.bar.baz".
+
+  Require A B C.
+
+  Require Import AI BI CI.
+```
+
+
+```lisp
+  $ coqmod example.v
+  (8:Document(4:Name9:example.v)(7:Require(((3:Loc(1:81:9)(1:82:10))1:A))(((3:Loc(2:102:16)(2:102:18))2:AI))(((3:Loc(1:82:11)(1:82:12))1:B))(((3:Loc(2:102:19)(2:102:21))2:BI))(((3:Loc(1:82:13)(1:82:14))1:C))(((3:Loc(2:102:22)(2:102:24))2:CI))(((3:Loc(1:31:6)(1:31:7))1:X))(((3:Loc(1:11:6)(1:12:11))5:A.B.C)((3:Loc(1:12:31)(1:12:36))5:L.Y.G))(((3:Loc(1:11:6)(1:12:11))5:A.B.C)((3:Loc(1:12:27)(1:12:30))3:R.X))(((3:Loc(1:11:6)(1:12:11))5:A.B.C)((3:Loc(1:12:37)(1:12:40))3:Z.W)))(7:Declare((3:Loc(1:62:19)(1:62:32))11:foo.bar.baz))(4:Load((3:Loc(1:41:6)(1:42:13))5:A/b/c)))
+```
+
+```coq
+  $ coqmod example.v --format=read
+  Begin example.v
+  Ln 8, Col 9-10 Require A
+  Ln 10, Col 16-18 Require AI
+  Ln 8, Col 11-12 Require B
+  Ln 10, Col 19-21 Require BI
+  Ln 8, Col 13-14 Require C
+  Ln 10, Col 22-24 Require CI
+  Ln 3, Col 6-7 Require X
+  Ln 1, Col 6-11 From A.B.C Ln 1, Col 31-36 Require L.Y.G
+  Ln 1, Col 6-11 From A.B.C Ln 1, Col 27-30 Require R.X
+  Ln 1, Col 6-11 From A.B.C Ln 1, Col 37-40 Require Z.W
+  Ln 6, Col 19-32 Declare ML Module Ln 6, Col 19-32 Require foo.bar.baz
+  Ln 4, Col 6-13 Physical "A/b/c"
+  End example.v
+```
+
+```lisp
+  $ coqmod example.v --format=sexp
+  (Document
+   (Name example.v)
+   (Require
+    (((Loc (8 9) (8 10)) A))
+    (((Loc (10 16) (10 18)) AI))
+    (((Loc (8 11) (8 12)) B))
+    (((Loc (10 19) (10 21)) BI))
+    (((Loc (8 13) (8 14)) C))
+    (((Loc (10 22) (10 24)) CI))
+    (((Loc (3 6) (3 7)) X))
+    (((Loc (1 6) (1 11)) A.B.C) ((Loc (1 31) (1 36)) L.Y.G))
+    (((Loc (1 6) (1 11)) A.B.C) ((Loc (1 27) (1 30)) R.X))
+    (((Loc (1 6) (1 11)) A.B.C) ((Loc (1 37) (1 40)) Z.W)))
+   (Declare
+    ((Loc (6 19) (6 32)) foo.bar.baz))
+   (Load
+    ((Loc (4 6) (4 13)) A/b/c)))
+```
+
+
+# Testing
+
+There is a cram test for `coqmod` in `tools/coqmod/test-coqmod.t/`.
+
+To run it do:
+```
+dune build @test-coqmod
+```
+
+You can also use watch mode `-w` to get a continuous build and `--auto-promote`
+to get the output of the cram test updated on each save.
+
+# Specification
+
+`coqmod` tokenizes Coq and OCaml module names and groups them in various
+s-expressions detailed as follows. All parsed files are wrapped in the
+`(Document ...)` s-exp.
+
+The `(Name ...)` token is always the name of the file that was passed to
+`coqmod`.
+
+Location s-exps `(Loc (1 9) (1 10))` correspond to the line and coloumn number
+of the begining and end of the token. In this case begining at `Ln 1, Col 9` and
+and ending at `Ln 1, Col 10`.
+
+Here are the corresponding s-exp for Coq vernac commands that add dependencies:
+
+## Name
+```lisp
+  $ cat > FileName.v << EOF
+  > EOF
+  $ coqmod FileName.v --format=sexp
+  (Document
+   (Name FileName.v))
+```
+## Require
+```lisp
+  $ cat > Require.v << EOF
+  > Require A B.
+  > Require B C.
+  > EOF
+  $ coqmod Require.v --format=sexp
+  (Document
+   (Name Require.v)
+   (Require
+    (((Loc (1 9) (1 10)) A))
+    (((Loc (2 9) (2 10)) B))
+    (((Loc (2 11) (2 12)) C))))
+```
+## From
+```lisp
+  $ cat > From.v << EOF
+  > From A Require B C.
+  > From A Require C D.
+  > From R Require E.
+  > EOF
+  $ coqmod From.v --format=sexp
+  (Document
+   (Name From.v)
+   (Require
+    (((Loc (1 6) (1 7)) A) ((Loc (1 16) (1 17)) B))
+    (((Loc (1 6) (1 7)) A) ((Loc (1 18) (1 19)) C))
+    (((Loc (2 6) (2 7)) A) ((Loc (2 18) (2 19)) D))
+    (((Loc (3 6) (3 7)) R) ((Loc (3 16) (3 17)) E))))
+```
+## Declare
+```lisp
+  $ cat > Declare.v << EOF
+  > Declare ML Module "foo" "bar.baz".
+  > Declare ML Module "zoo" "foo".
+  > EOF
+  $ coqmod Declare.v --format=sexp
+  (Document
+   (Name Declare.v)
+   (Declare
+    ((Loc (1 25) (1 34)) bar.baz)
+    ((Loc (2 25) (2 30)) foo)
+    ((Loc (2 19) (2 24)) zoo)))
+```
+## Load logical
+```lisp
+  $ cat > LoadLogical.v << EOF
+  > Load A.
+  > Load B.
+  > EOF
+  $ coqmod LoadLogical.v --format=sexp
+  (Document
+   (Name LoadLogical.v)
+   (Require
+    (((Loc (1 6) (1 7)) A))
+    (((Loc (2 6) (2 7)) B))))
+```
+## Load physical
+```lisp
+  $ cat > LoadPhysical.v << EOF
+  > Load "a/b/c".
+  > Load "c/d/e".
+  > EOF
+  $ coqmod LoadPhysical.v --format=sexp
+  (Document
+   (Name LoadPhysical.v)
+   (Load
+    ((Loc (1 6) (1 13)) a/b/c)
+    ((Loc (2 6) (2 13)) c/d/e)))
+```
+## Extra Dependency
+```lisp
+  $ cat > ExtraDependency.v << EOF
+  > From A Extra Dependency "b/c/d".
+  > EOF
+  $ coqmod ExtraDependency.v --format=sexp
+  (Document
+   (Name ExtraDependency.v)
+   (ExtraDep
+    (((Loc (1 6) (1 7)) A) (Loc (1 25) (1 32)) b/c/d)))
+```

--- a/tools/coqmod/coqmod.ml
+++ b/tools/coqmod/coqmod.ml
@@ -1,0 +1,52 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+let rec read_buffer t buf =
+  match Lexer.parse_coq t buf with
+  | t -> read_buffer t buf
+  | exception Lexer.End_of_file -> t
+
+let find_dependencies ~format f =
+  let print =
+    match !format with
+    | "csexp" -> fun tok -> Token.to_sexp tok |> Csexp.to_channel stdout
+    | "read" -> fun tok -> Printf.printf "%s\n" (Token.to_string tok)
+    | "sexp" ->
+        fun tok -> Token.to_sexp tok |> Token.Sexp.pp Format.std_formatter
+    | f -> Error.unknwon_output_format f
+  in
+  let chan = try open_in f with Sys_error msg -> Error.cannot_open f msg in
+  let buf = Lexing.from_channel chan in
+  let t = Token.set_filename Token.empty f in
+  let toks = read_buffer t buf in
+  close_in chan; print (Token.sort_uniq toks)
+
+let main () =
+  let usage_msg = "coqmod - A simple module lexer for Coq" in
+  let format = ref "csexp" in
+  let files = ref [] in
+  let anon_fun f = files := f :: !files in
+  let speclist =
+    [
+      ("--format", Arg.Set_string format, "Set output format [csexp|sexp|read]");
+      ("--debug", Arg.Set Error.debug_mode, "Output debugging information");
+    ]
+  in
+  let () = Arg.parse speclist anon_fun usage_msg in
+  match !files with
+  | [] -> Error.no_file_provided ()
+  | [file] -> find_dependencies ~format file
+  | files -> Error.too_many_files_provided ()
+
+let () =
+  try main ()
+  with exn ->
+    Format.eprintf "@[%a@]@\n%!" Pp.pp_with (CErrors.print exn);
+    exit 1

--- a/tools/coqmod/csexp/README.md
+++ b/tools/coqmod/csexp/README.md
@@ -1,0 +1,54 @@
+Csexp - Canonical S-expressions
+===============================
+
+This project provides minimal support for parsing and printing
+[S-expressions in canonical form][wikipedia], which is a very simple
+and canonical binary encoding of S-expressions.
+
+[wikipedia]: https://en.wikipedia.org/wiki/Canonical_S-expressions
+
+Example
+-------
+
+```ocaml
+# #require "csexp";;
+# module Sexp = struct type t = Atom of string | List of t list end;;
+module Sexp : sig type t = Atom of string | List of t list end
+# module Csexp = Csexp.Make(Sexp);;
+module Csexp :
+  sig
+    val parse_string : string -> (Sexp.t, int * string) result
+    val parse_string_many : string -> (Sexp.t list, int * string) result
+    val input : in_channel -> (Sexp.t, string) result
+    val input_opt : in_channel -> (Sexp.t option, string) result
+    val input_many : in_channel -> (Sexp.t list, string) result
+    val serialised_length : Sexp.t -> int
+    val to_string : Sexp.t -> string
+    val to_buffer : Buffer.t -> Sexp.t -> unit
+    val to_channel : out_channel -> Sexp.t -> unit
+  end
+# Csexp.to_string (List [ Atom "Hello"; Atom "world!" ]);;
+- : string = "(5:Hello6:world!)"
+```
+
+The MIT License
+
+Copyright (c) 2016 Jane Street Group, LLC <opensource@janestreet.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tools/coqmod/csexp/csexp.ml
+++ b/tools/coqmod/csexp/csexp.ml
@@ -1,0 +1,423 @@
+module type Sexp = sig
+  type t =
+    | Atom of string
+    | List of t list
+end
+
+module type Monad = sig
+  type 'a t
+
+  val return : 'a -> 'a t
+
+  val bind : 'a t -> ('a -> 'b t) -> 'b t
+end
+
+module type S = sig
+  type sexp
+
+  val parse_string : string -> (sexp, int * string) result
+
+  val parse_string_many : string -> (sexp list, int * string) result
+
+  val input : in_channel -> (sexp, string) result
+
+  val input_opt : in_channel -> (sexp option, string) result
+
+  val input_many : in_channel -> (sexp list, string) result
+
+  val serialised_length : sexp -> int
+
+  val to_string : sexp -> string
+
+  val to_buffer : Buffer.t -> sexp -> unit
+
+  val to_channel : out_channel -> sexp -> unit
+
+  module Parser : sig
+    exception Parse_error of string
+
+    val premature_end_of_input : string
+
+    module Lexer : sig
+      type t
+
+      val create : unit -> t
+
+      type _ token =
+        | Await : [> `other ] token
+        | Lparen : [> `other ] token
+        | Rparen : [> `other ] token
+        | Atom : int -> [> `atom ] token
+
+      val feed : t -> char -> [ `other | `atom ] token
+
+      val feed_eoi : t -> unit
+    end
+
+    module Stack : sig
+      type t =
+        | Empty
+        | Open of t
+        | Sexp of sexp * t
+
+      val to_list : t -> sexp list
+
+      val open_paren : t -> t
+
+      val close_paren : t -> t
+
+      val add_atom : string -> t -> t
+
+      val add_token : [ `other ] Lexer.token -> t -> t
+    end
+  end
+
+  module type Input = sig
+    type t
+
+    module Monad : sig
+      type 'a t
+
+      val return : 'a -> 'a t
+
+      val bind : 'a t -> ('a -> 'b t) -> 'b t
+    end
+
+    val read_string : t -> int -> (string, string) result Monad.t
+
+    val read_char : t -> (char, string) result Monad.t
+  end
+  [@@deprecated "Use Parser module instead"]
+
+  [@@@warning "-3"]
+
+  module Make_parser (Input : Input) : sig
+    val parse : Input.t -> (sexp, string) result Input.Monad.t
+
+    val parse_many : Input.t -> (sexp list, string) result Input.Monad.t
+  end
+  [@@deprecated "Use Parser module instead"]
+end
+
+module Make (Sexp : Sexp) = struct
+  open Sexp
+
+  module Parser = struct
+    exception Parse_error of string
+
+    let parse_error msg = raise (Parse_error msg)
+
+    let parse_errorf f = Format.ksprintf parse_error f
+
+    let premature_end_of_input = "premature end of input"
+
+    module Lexer = struct
+      type state =
+        | Init
+        | Parsing_length
+
+      type t =
+        { mutable state : state
+        ; mutable n : int
+        }
+
+      let create () = { state = Init; n = 0 }
+
+      let int_of_digit c = Char.code c - Char.code '0'
+
+      type _ token =
+        | Await : [> `other ] token
+        | Lparen : [> `other ] token
+        | Rparen : [> `other ] token
+        | Atom : int -> [> `atom ] token
+
+      let feed t c =
+        match (t.state, c) with
+        | Init, '(' -> Lparen
+        | Init, ')' -> Rparen
+        | Init, '0' .. '9' ->
+          t.state <- Parsing_length;
+          t.n <- int_of_digit c;
+          Await
+        | Init, _ ->
+          parse_errorf "invalid character %C, expected '(', ')' or '0'..'9'" c
+        | Parsing_length, '0' .. '9' ->
+          let len = (t.n * 10) + int_of_digit c in
+          if len > Sys.max_string_length then
+            parse_error "atom too big to represent"
+          else (
+            t.n <- len;
+            Await
+          )
+        | Parsing_length, ':' ->
+          t.state <- Init;
+          Atom t.n
+        | Parsing_length, _ ->
+          parse_errorf
+            "invalid character %C while parsing atom length, expected '0'..'9' \
+             or ':'"
+            c
+
+      let feed_eoi t =
+        match t.state with
+        | Init -> ()
+        | Parsing_length -> parse_error premature_end_of_input
+    end
+
+    module L = Lexer
+
+    module Stack = struct
+      type t =
+        | Empty
+        | Open of t
+        | Sexp of Sexp.t * t
+
+      let open_paren stack = Open stack
+
+      let close_paren =
+        let rec loop acc = function
+          | Empty ->
+            parse_error "right parenthesis without matching left parenthesis"
+          | Sexp (sexp, t) -> loop (sexp :: acc) t
+          | Open t -> Sexp (List acc, t)
+        in
+        fun t -> loop [] t
+
+      let to_list =
+        let rec loop acc = function
+          | Empty -> acc
+          | Sexp (sexp, t) -> loop (sexp :: acc) t
+          | Open _ -> parse_error premature_end_of_input
+        in
+        fun t -> loop [] t
+
+      let add_atom s stack = Sexp (Atom s, stack)
+
+      let add_token (x : [ `other ] Lexer.token) stack =
+        match x with
+        | L.Await -> stack
+        | L.Lparen -> open_paren stack
+        | L.Rparen -> close_paren stack
+    end
+  end
+
+  open Parser
+
+  let feed_eoi_single lexer stack =
+    match
+      Lexer.feed_eoi lexer;
+      Stack.to_list stack
+    with
+    | exception Parse_error msg -> Error msg
+    | [ x ] -> Ok x
+    | [] -> Error premature_end_of_input
+    | _ :: _ :: _ -> assert false
+
+  let feed_eoi_many lexer stack =
+    match
+      Lexer.feed_eoi lexer;
+      Stack.to_list stack
+    with
+    | exception Parse_error msg -> Error msg
+    | l -> Ok l
+
+  let one_token s pos len lexer stack k =
+    match Lexer.feed lexer (String.unsafe_get s pos) with
+    | exception Parse_error msg -> Error (pos, msg)
+    | L.Atom atom_len -> (
+      match String.sub s (pos + 1) atom_len with
+      | exception _ -> Error (len, premature_end_of_input)
+      | atom ->
+        let pos = pos + 1 + atom_len in
+        k s pos len lexer (Stack.add_atom atom stack) )
+    | (L.Await | L.Lparen | L.Rparen) as x -> (
+      match Stack.add_token x stack with
+      | exception Parse_error msg -> Error (pos, msg)
+      | stack -> k s (pos + 1) len lexer stack )
+    [@@inlined always]
+
+  let parse_string =
+    let rec loop s pos len lexer stack =
+      if pos = len then
+        match feed_eoi_single lexer stack with
+        | Error msg -> Error (pos, msg)
+        | Ok _ as ok -> ok
+      else
+        one_token s pos len lexer stack cont
+    and cont s pos len lexer stack =
+      match stack with
+      | Stack.Sexp (sexp, Empty) ->
+        if pos = len then
+          Ok sexp
+        else
+          Error (pos, "data after canonical S-expression")
+      | stack -> loop s pos len lexer stack
+    in
+    fun s -> loop s 0 (String.length s) (Lexer.create ()) Empty
+
+  let parse_string_many =
+    let rec loop s pos len lexer stack =
+      if pos = len then
+        match feed_eoi_many lexer stack with
+        | Error msg -> Error (pos, msg)
+        | Ok _ as ok -> ok
+      else
+        one_token s pos len lexer stack loop
+    in
+    fun s -> loop s 0 (String.length s) (Lexer.create ()) Empty
+
+  let one_token ic c lexer stack =
+    match Lexer.feed lexer c with
+    | L.Atom n -> (
+      match really_input_string ic n with
+      | exception End_of_file -> raise (Parse_error premature_end_of_input)
+      | s -> Stack.add_atom s stack )
+    | (L.Await | L.Lparen | L.Rparen) as x -> Stack.add_token x stack
+
+  let input_opt =
+    let rec loop ic lexer stack =
+      let c = input_char ic in
+      match one_token ic c lexer stack with
+      | Sexp (sexp, Empty) -> Ok (Some sexp)
+      | stack -> loop ic lexer stack
+    in
+    fun ic ->
+      let lexer = Lexer.create () in
+      match input_char ic with
+      | exception End_of_file -> Ok None
+      | c -> (
+        try
+          match Lexer.feed lexer c with
+          | L.Atom _ -> assert false
+          | (L.Await | L.Lparen | L.Rparen) as x ->
+            loop ic lexer (Stack.add_token x Empty)
+        with
+        | Parse_error msg -> Error msg
+        | End_of_file -> Error premature_end_of_input )
+
+  let input ic =
+    match input_opt ic with
+    | Ok None -> Error premature_end_of_input
+    | Ok (Some x) -> Ok x
+    | Error msg -> Error msg
+
+  let input_many =
+    let rec loop ic lexer stack =
+      match input_char ic with
+      | exception End_of_file ->
+        Lexer.feed_eoi lexer;
+        Ok (Stack.to_list stack)
+      | c -> loop ic lexer (one_token ic c lexer stack)
+    in
+    fun ic ->
+      try loop ic (Lexer.create ()) Empty with Parse_error msg -> Error msg
+
+  let serialised_length =
+    let rec loop acc t =
+      match t with
+      | Atom s ->
+        let len = String.length s in
+        let x = ref len in
+        let len_len = ref 1 in
+        while !x > 9 do
+          x := !x / 10;
+          incr len_len
+        done;
+        acc + !len_len + 1 + len
+      | List l -> List.fold_left loop acc l
+    in
+    fun t -> loop 0 t
+
+  let to_buffer buf sexp =
+    let rec loop = function
+      | Atom str ->
+        Buffer.add_string buf (string_of_int (String.length str));
+        Buffer.add_string buf ":";
+        Buffer.add_string buf str
+      | List e ->
+        Buffer.add_char buf '(';
+        List.iter loop e;
+        Buffer.add_char buf ')'
+    in
+    loop sexp
+
+  let to_string sexp =
+    let buf = Buffer.create (serialised_length sexp) in
+    to_buffer buf sexp;
+    Buffer.contents buf
+
+  let to_channel oc sexp =
+    let rec loop = function
+      | Atom str ->
+        output_string oc (string_of_int (String.length str));
+        output_char oc ':';
+        output_string oc str
+      | List l ->
+        output_char oc '(';
+        List.iter loop l;
+        output_char oc ')'
+    in
+    loop sexp
+
+  module type Input = sig
+    type t
+
+    module Monad : Monad
+
+    val read_string : t -> int -> (string, string) result Monad.t
+
+    val read_char : t -> (char, string) result Monad.t
+  end
+
+  module Make_parser (Input : Input) = struct
+    open Input.Monad
+
+    let ( >>= ) = bind
+
+    let ( >>=* ) m f =
+      m >>= function
+      | Error _ as err -> return err
+      | Ok x -> f x
+
+    let one_token input c lexer stack =
+      match Lexer.feed lexer c with
+      | exception Parse_error msg -> return (Error msg)
+      | L.Atom n ->
+        Input.read_string input n >>=* fun s ->
+        return (Ok (Stack.add_atom s stack))
+      | (L.Await | L.Lparen | L.Rparen) as x ->
+        return
+          ( match Stack.add_token x stack with
+          | exception Parse_error msg -> Error msg
+          | stack -> Ok stack )
+
+    let parse =
+      let rec loop input lexer stack =
+        Input.read_char input >>= function
+        | Error _ -> return (feed_eoi_single lexer stack)
+        | Ok c -> (
+          one_token input c lexer stack >>=* function
+          | Sexp (sexp, Empty) -> return (Ok sexp)
+          | stack -> loop input lexer stack )
+      in
+      fun input -> loop input (Lexer.create ()) Empty
+
+    let parse_many =
+      let rec loop input lexer stack =
+        Input.read_char input >>= function
+        | Error _ -> return (feed_eoi_many lexer stack)
+        | Ok c ->
+          one_token input c lexer stack >>=* fun stack -> loop input lexer stack
+      in
+      fun input -> loop input (Lexer.create ()) Empty
+  end
+end
+
+module T = struct
+  type t =
+    | Atom of string
+    | List of t list
+end
+
+include T
+include Make (T)

--- a/tools/coqmod/csexp/csexp.mli
+++ b/tools/coqmod/csexp/csexp.mli
@@ -1,0 +1,376 @@
+(** Canonical S-expressions *)
+
+(** This module provides minimal support for reading and writing S-expressions
+    in canonical form.
+
+    https://en.wikipedia.org/wiki/Canonical_S-expressions
+
+    Note that because the canonical representation of S-expressions is so
+    simple, this module doesn't go out of his way to provide a fully generic
+    parser and printer and instead just provides a few simple functions. If you
+    are using fancy input sources, simply copy the parser and adapt it. The
+    format is so simple that it's pretty difficult to get it wrong by accident.
+
+    To avoid a dependency on a particular S-expression library, the only module
+    of this library is parameterised by the type of S-expressions.
+
+    {[
+      let rec print = function
+        | Atom str -> Printf.printf "%d:%s" (String.length s)
+        | List l -> List.iter print l
+    ]} *)
+
+module type Sexp = sig
+  type t =
+    | Atom of string
+    | List of t list
+end
+
+module type S = sig
+  (** {2 Parsing} *)
+  type sexp
+
+  (** [parse_string s] parses a single S-expression encoded in canonical form in
+      [s]. It is an error for [s] to contain a S-expression followed by more
+      data. In case of error, the offset of the error as well as an error
+      message is returned. *)
+  val parse_string : string -> (sexp, int * string) result
+
+  (** [parse_string s] parses a sequence of S-expressions encoded in canonical
+      form in [s] *)
+  val parse_string_many : string -> (sexp list, int * string) result
+
+  (** Read exactly one canonical S-expressions from the given channel. Note that
+      this function never raises [End_of_file]. Instead, it returns [Error]. *)
+  val input : in_channel -> (sexp, string) result
+
+  (** Same as [input] but returns [Ok None] if the end of file has already been
+      reached. If some more characters are available but the end of file is
+      reached before reading a complete S-expression, this function returns
+      [Error]. *)
+  val input_opt : in_channel -> (sexp option, string) result
+
+  (** Read many S-expressions until the end of input is reached. *)
+  val input_many : in_channel -> (sexp list, string) result
+
+  (** {2 Serialising} *)
+
+  (** The length of the serialised representation of a S-expression *)
+  val serialised_length : sexp -> int
+
+  (** [to_string sexp] converts S-expression [sexp] to a string in canonical
+      form. *)
+  val to_string : sexp -> string
+
+  (** [to_buffer buf sexp] outputs the S-expression [sexp] converted to its
+      canonical form to buffer [buf]. *)
+  val to_buffer : Buffer.t -> sexp -> unit
+
+  (** [output oc sexp] outputs the S-expression [sexp] converted to its
+      canonical form to channel [oc]. *)
+  val to_channel : out_channel -> sexp -> unit
+
+  (** {3 Low level parser}
+
+      For efficiently parsing from sources other than strings or input channel.
+      For instance in Lwt or Async programs. *)
+
+  module Parser : sig
+    (** The [Parser] module offers an API that is a balance between sharing the
+        common logic of parsing canonical S-expressions while allowing to write
+        parsers that are as efficient as possible, both in terms of speed and
+        allocations. A carefully written parser using this API will be:
+
+        - fast
+        - perform minimal allocations
+        - perform zero [caml_modify] (a slow function of the OCaml runtime that
+          is emitted when mutating a constructed value)
+
+        {2 Lexers}
+
+        To parse using this API, you must first create a lexer via
+        {!Lexer.create}. The lexer is responsible for scanning the input and
+        forming tokens. The user must feed characters read from the input one by
+        one to the lexer until it yields a token. For instance:
+
+        {[
+          # let lexer = Lexer.create ();;
+          val lexer : Lexer.t = <abstract>
+          # Lexer.feed lexer '(';;
+          - : [ `atom | `other ] Lexer.token = Lparen
+          # Lexer.feed lexer ')';;
+          - : [ `atom | `other ] Lexer.token = Rparen
+        ]}
+
+        When the lexer doesn't have enough to return a token, it simply returns
+        the special token {!Lexer.Await}:
+
+        {[
+          # Lexer.feed lexer '1';;
+          - : [ `atom | `other ] Lexer.token = Await
+        ]}
+
+        Note that since atoms of canonical S-expressions do not need quoting,
+        they are always represented as a contiguous sequence of characters that
+        don't need further processing. To achieve maximum efficiency, the lexer
+        only returns the length of the atom and it is the responsibility of the
+        caller to extract the atom from the input source:
+
+        {[
+          # Lexer.feed lexer '2';;
+          - : [ `atom | `other ] Lexer.token = Await
+          # Lexer.feed lexer ':';;
+          - : [ `atom | `other ] Lexer.token = Atom 2
+        ]}
+
+        When getting [Atom n], the caller should then proceed to read the next
+        [n] characters of the input as a string. For instance, if the input is
+        an [in_channel] the caller should proceed with
+        [really_input_string ic n].
+
+        Finally, when the end of input is reached the user should call
+        {!Lexer.feed_eoi} to make sure the lexer is not awaiting more input. If
+        that is the case, {!Lexer.feed_eoi} will raise:
+
+        {[
+          # Lexer.feed lexer '1';;
+          - : [ `atom | `other ] Lexer.token = Await
+          # Lexer.feed_eoi lexer;;
+          Exception: Parse_error "premature end of input".
+        ]}
+
+        {2 Parsing stacks}
+
+        The lexer doesn't keep track of the structure of the S-expressions. In
+        order to construct a whole structured S-expressions, the caller must
+        maintain a parsing stack via the {!Stack} module. A {!Stack.t} value
+        simply represent a parsed prefix in reverse order.
+
+        For instance, the prefix "1:x((1:y1:z)" will be represented as:
+
+        {[ Sexp (List [ Atom "y"; Atom "z" ], Open (Sexp (Atom "x", Empty))) ]}
+
+        The {!Stack} module offers various primitives to open or close
+        parentheses or insert an atom. And for convenience it provides a
+        function {!Stack.add_token} that takes the output of {!Lexer.feed}
+        directly:
+
+        {[
+          # Stack.add_token Rparen Empty;;
+          - : Stack.t = Open Empty
+          # Stack.add_token Lparen (Open Empty);;
+          - : Stack.t = Sexp (List [], Empty)
+        ]}
+
+        Note that {!Stack.add_token} doesn't accept [Atom _]. This is enforced
+        at the type level by a GADT. The reason for this is that in order to
+        insert an atom, the user must have fetched the contents of the atom
+        themselves. In order to insert an atom into a stack, you can use the
+        function {!Stack.add_atom}:
+
+        {[
+          # Stack.add_atom "foo" (Open Empty);;
+          - : Stack.t = Sexp (Atom "foo", Open Empty)
+        ]}
+
+        When parsing is finished, one may call the function {!Stack.to_list} in
+        order to extract all the toplevel S-expressions from the stack:
+
+        {[
+          # Stack.to_list (Sexp (Atom "x", Sexp (List [Atom "y"], Empty)));;
+          - : sexp list = [List [Atom "y"; Atom "x"]]
+        ]}
+
+        If instead you want to stop parsing as soon a single full S-expression
+        has been discovered, you can match on the structure of the stack. If the
+        stack is of the form [Sexp (_, Empty)], then you know that exactly one
+        S-expression has been parsed and you can stop there.
+
+        {2 Parsing errors}
+
+        In order to reduce allocations to a minumim, parsing errors are reported
+        via the exception {!Parse_error}. It is the responsibility of the caller
+        to catch this exception and return it as an [Error _] value. Functions
+        that may raise [Parse_error] are documented as such.
+
+        When extracting an atom and the input doesn't have enough characters
+        left, the user may raise [Parse_error premature_end_of_input]. This will
+        produce an error message similar to what the various high-level
+        functions of this library produce.
+
+        {2 Building a parsing function}
+
+        Parsing functions should always follow the following pattern:
+
+        + create a lexer and start with an empty parsing stack
+        + iterate over the input, feeding the lexer characters one by one. When
+          the lexer returns [Atom n], fetch the next [n] characters from the
+          input to form an atom
+        + update the stack via [Stack.add_atom] or [Stack.add_token]
+        + if parsing the whole input, call [Lexer.feed_eoi] when the end of
+          input is reached, otherwise stop as soon as the stack is of the form
+          [Sexp (_, Empty)] -
+
+        For instance, to parse a string as a list of S-expressions:
+
+        {[
+          module Sexp = struct
+            type t =
+              | Atom of string
+              | List of t list
+          end
+
+          module Csexp = Csexp.Make (Sexp)
+
+          let extract_atom s pos len =
+            match String.sub s pos len with
+            | exception _ ->
+              (* Turn out-of-bounds errors into [Parse_error] *)
+              raise (Parse_error premature_end_of_input)
+            | s -> s
+
+          let parse_string =
+            let open Csexp.Parser in
+            let rec loop s pos len lexer stack =
+              if pos = len then (
+                Lexer.feed_eoi lexer;
+                Stack.to_list stack
+              ) else
+                match Lexer.feed lexer (String.unsafe_get s pos) with
+                | Atom atom_len ->
+                  let atom = extract_atom s (pos + 1) atom_len in
+                  loop s (pos + 1 + atom) len lexer (Stack.add_atom atom stack)
+                | (Await | Lparen | Rparen) as x ->
+                  loop s (pos + 1) len lexer (Stack.add_token x stack)
+            in
+            fun s ->
+              match loop s 0 (String.length s) (Lexer.create ()) Empty with
+              | v -> Ok v
+              | exception Parse_error msg -> Error msg
+        ]} *)
+
+    exception Parse_error of string
+
+    (** Error message signaling the end of input was reached prematurely. You
+        can use this when extracting an atom from the input and the input
+        doesn't have enough characters. *)
+    val premature_end_of_input : string
+
+    module Lexer : sig
+      (** Lexical analyser *)
+
+      type t
+
+      val create : unit -> t
+
+      type _ token =
+        | Await : [> `other ] token
+        | Lparen : [> `other ] token
+        | Rparen : [> `other ] token
+        | Atom : int -> [> `atom ] token
+
+      (** Feed a character to the parser.
+
+          @raise Parse_error *)
+      val feed : t -> char -> [ `other | `atom ] token
+
+      (** Feed the end of input to the parser.
+
+          You should call this function when the end of input has been reached
+          in order to ensure that the lexer is not awaiting more input, which
+          would be an error.
+
+          @raise Parse_error if the lexer is awaiting more input *)
+      val feed_eoi : t -> unit
+    end
+
+    module Stack : sig
+      (** Parsing stack *)
+
+      type t =
+        | Empty
+        | Open of t
+        | Sexp of sexp * t
+
+      (** Extract the list of full S-expressions contained in a stack.
+
+          For instance:
+
+          {[
+            # to_list (Sexp (Atom "y", Sexp (Atom "x", Empty)));;
+            - : Stack.t list = [Atom "x"; Atom "y"]
+          ]}
+          @raise Parse_error if the stack contains open parentheses that has not
+          been closed. *)
+      val to_list : t -> sexp list
+
+      (** Add a left parenthesis. *)
+      val open_paren : t -> t
+
+      (** Add a right parenthesis. Raise [Parse_error] if the stack contains no
+          opened parentheses.
+
+          For instance:
+
+          {[
+            # close_paren (Sexp (Atom "y", Sexp (Atom "x", Open Empty)));;
+            - : Stack.t = Sexp (List [Atom "x"; Atom "y"], Empty)
+          ]}
+          @raise Parse_error if the stack contains no open open parenthesis. *)
+      val close_paren : t -> t
+
+      (** Insert an atom in the parsing stack:
+
+          {[
+            # add_atom "foo" Empty;;
+            - : Stack.t = Sexp (Atom "foo", Empty)
+          ]} *)
+      val add_atom : string -> t -> t
+
+      (** Add a token as returned by the lexer.
+
+          @raise Parse_error *)
+      val add_token : [ `other ] Lexer.token -> t -> t
+    end
+  end
+
+  (** {3 Deprecated low-level parser} *)
+
+  (** The above are deprecated as the {!Input} signature does not allow to
+      distinguish between IO errors and end of input conditions. Additionally,
+      the use of monads tend to produce parsers that allocates a lot.
+
+      It is recommended to use the {!Parser} module instead. *)
+
+  module type Input = sig
+    type t
+
+    module Monad : sig
+      type 'a t
+
+      val return : 'a -> 'a t
+
+      val bind : 'a t -> ('a -> 'b t) -> 'b t
+    end
+
+    val read_string : t -> int -> (string, string) result Monad.t
+
+    val read_char : t -> (char, string) result Monad.t
+  end
+  [@@deprecated "Use Parser module instead"]
+
+  [@@@warning "-3"]
+
+  module Make_parser (Input : Input) : sig
+    val parse : Input.t -> (sexp, string) result Input.Monad.t
+
+    val parse_many : Input.t -> (sexp list, string) result Input.Monad.t
+  end
+  [@@deprecated "Use Parser module instead"]
+end
+
+module Make (Sexp : Sexp) : S with type sexp := Sexp.t
+
+include Sexp
+
+include S with type sexp := t

--- a/tools/coqmod/csexp/dune
+++ b/tools/coqmod/csexp/dune
@@ -1,0 +1,2 @@
+(library
+ (name csexp))

--- a/tools/coqmod/dune
+++ b/tools/coqmod/dune
@@ -1,0 +1,1 @@
+(vendored_dirs csexp)

--- a/tools/coqmod/dune
+++ b/tools/coqmod/dune
@@ -1,1 +1,9 @@
 (vendored_dirs csexp)
+
+(executable
+ (name coqmod)
+ (public_name coqmod)
+ (package coq-core)
+ (libraries coq-core.lib coq-core.clib csexp))
+
+(ocamllex lexer)

--- a/tools/coqmod/dune
+++ b/tools/coqmod/dune
@@ -7,3 +7,6 @@
  (libraries coq-core.lib coq-core.clib csexp))
 
 (ocamllex lexer)
+
+(cram
+ (deps %{bin:coqmod}))

--- a/tools/coqmod/error.ml
+++ b/tools/coqmod/error.ml
@@ -1,0 +1,42 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+let debug_mode = ref false
+
+exception CannotOpenFile of string * string
+
+exception UnknownOutputFormat of string
+
+exception NoFileProvided
+
+exception TooManyFilesProvided
+
+let _ =
+  CErrors.register_handler
+  @@ function
+  | CannotOpenFile (s, msg) -> Some Pp.(str s ++ str ":" ++ spc () ++ str msg)
+  | UnknownOutputFormat format ->
+      Some Pp.(strbrk "Error: Unkown output format: " ++ str format)
+  | NoFileProvided ->
+      Some Pp.(strbrk "Error: No file provided. Please provide a file.")
+  | TooManyFilesProvided ->
+      Some
+        Pp.(
+          strbrk
+            "Error: Too many files provided. Please provide only a single file.")
+  | _ -> None
+
+let cannot_open s msg = raise @@ CannotOpenFile (s, msg)
+
+let unknwon_output_format format = raise @@ UnknownOutputFormat format
+
+let no_file_provided () = raise @@ NoFileProvided
+
+let too_many_files_provided () = raise @@ TooManyFilesProvided

--- a/tools/coqmod/lexer.mll
+++ b/tools/coqmod/lexer.mll
@@ -1,0 +1,285 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+{
+
+  module Metadata = struct
+    type t = {
+      hint : string option;
+      who : string;
+      desc : string option;
+      loc : Token.Loc.t;
+      file : string
+    }
+  end
+
+  exception End_of_file
+  exception Syntax_error of Metadata.t
+
+  let unquote_string s =
+    String.sub s 1 (String.length s - 2)
+
+  let get_unquoted_vfile lexbuf =
+    let s = Lexing.lexeme lexbuf in
+    let f = unquote_string s in
+    if Filename.check_suffix f ".v" then
+      Filename.chop_suffix f ".v"
+    else f
+
+  let backtrack lexbuf =
+    let open Lexing in
+    lexbuf.lex_curr_pos <- lexbuf.lex_start_pos;
+    lexbuf.lex_curr_p <- lexbuf.lex_start_p
+
+  let syntax_error t ~who ?desc ?hint lexbuf =
+    let loc = Token.Loc.of_lexbuf lexbuf in
+    let file = Token.get_filename t in
+    raise (Syntax_error Metadata.{hint; who; desc; loc; file})
+
+  let get_module ?(quoted = false) lexbuf =
+    let logical_name =
+      if quoted then
+        Lexing.lexeme lexbuf |> unquote_string
+      else Lexing.lexeme lexbuf in
+    Token.Module.make (Token.Loc.of_lexbuf lexbuf) logical_name
+
+  (* Some standard error descriptions *)
+  let msg_eof = "File ended unexpectedly."
+  let msg_unable lexbuf =
+    Printf.sprintf "Unable to parse: \"%s\"." (Lexing.lexeme lexbuf)
+
+  let hint_eof_term = "Did you forget a \".\"?"
+
+}
+
+let whitespace = [' ' '\t' '\r']
+let newline = '\n'
+let quoted = '"' [^ '"']* '"'
+
+let coq_ident_start_char = ['A'-'Z' 'a'-'z' '_' '\128'-'\255']
+let coq_ident_char = ['A'-'Z' 'a'-'z' '_' '\'' '0'-'9' '\128'-'\255']
+let coq_ident = coq_ident_start_char coq_ident_char*
+let coq_field = '.' coq_ident
+let coq_qualid = coq_ident coq_field*
+let coq_qid_quot = '"' coq_qualid '"'
+
+let locality = "Local" | "Global" | "#[local]" | "#[global]"
+
+let comment_begin = "(*"
+let comment_end = "*)"
+
+rule parse_coq t = parse
+  (* All newlines must be manually processed in order to have good locations *)
+  | newline       { Lexing.new_line lexbuf; parse_coq t lexbuf }
+  | whitespace+   { parse_coq t lexbuf }
+  | comment_begin { parse_comment lexbuf; parse_coq t lexbuf }
+  | eof           { raise End_of_file }
+  (* Noops - These are ignored on purpose *)
+  | locality      { parse_coq t lexbuf }
+  | "Time"        { parse_coq t lexbuf }
+  | "Timeout"     { parse_timeout t lexbuf }
+  | "Comments"    { parse_vernac_comments t lexbuf }
+  (* Entry points to more sophisticated parsing *)
+  | "Declare"     { parse_declare t lexbuf }
+  | "Load"        { parse_load t lexbuf }
+  | "Require"     { parse_require_modifiers t None lexbuf }
+  | "From"        { parse_from t lexbuf }
+  (* Everything else *)
+  | _             { skip_to_dot t lexbuf; parse_coq t lexbuf }
+
+(* Parsing comments *)
+and parse_comment = parse
+  | newline       { Lexing.new_line lexbuf; parse_comment lexbuf }
+  | comment_begin { parse_comment lexbuf; parse_comment lexbuf }
+  | comment_end   { () }
+  | eof           { raise End_of_file }
+  | _             { parse_comment lexbuf }
+
+(* Rule for fast forwarding to a dot, skipping most things. *)
+and skip_to_dot t = parse
+  | newline                   { Lexing.new_line lexbuf; skip_to_dot t lexbuf }
+  | comment_begin             { parse_comment lexbuf; skip_to_dot t lexbuf }
+  | "." ( newline )           { Lexing.new_line lexbuf }
+  | '.' ( whitespace+ | eof)  { () }
+  | eof                       { syntax_error t lexbuf ~who:"skip_to_dot t"
+                                  ~desc:msg_eof ~hint:hint_eof_term }
+  | _                         { skip_to_dot t lexbuf }
+
+(* Parser for [Declare ML Module "mod.ule1" "mod.ule2"] *)
+and parse_declare t = parse
+  | newline       { Lexing.new_line lexbuf; parse_declare t lexbuf }
+  | whitespace+   { parse_declare t lexbuf }
+  | comment_begin { parse_comment lexbuf; parse_declare t lexbuf }
+  | "ML"          { parse_declare_ml t lexbuf }
+  | _             { syntax_error t lexbuf ~who:"parse_declare"
+                      ~desc:(msg_unable lexbuf) }
+and parse_declare_ml t = parse
+  | newline       { Lexing.new_line lexbuf; parse_declare_ml t lexbuf }
+  | whitespace+   { parse_declare_ml t lexbuf }
+  | comment_begin { parse_comment lexbuf; parse_declare_ml t lexbuf }
+  | "Module"      { parse_ml_modules t [] lexbuf }
+  | _             { syntax_error t lexbuf ~who:"parse_declare_ml"
+                      ~desc:(msg_unable lexbuf) }
+and parse_ml_modules t modules = parse
+  | newline       { Lexing.new_line lexbuf; parse_ml_modules t modules lexbuf }
+  | whitespace+   { parse_ml_modules t modules lexbuf }
+  | comment_begin { parse_comment lexbuf; parse_ml_modules t modules lexbuf }
+  | coq_qid_quot  { let modules = get_module ~quoted:true lexbuf :: modules in
+                    parse_ml_modules t modules lexbuf }
+  | '.'           { Token.add_declare_list t modules }
+  | eof           { syntax_error t lexbuf ~who:"parse_ml_modules"
+                      ~desc:msg_eof ~hint:hint_eof_term }
+  | _             { syntax_error t lexbuf ~who:"parse_ml_modules"
+                      ~desc:(msg_unable lexbuf) }
+
+(* The Timeout 1234 command is a noop, but requires parsing an extra token *)
+and parse_timeout t = parse
+  | newline       { Lexing.new_line lexbuf; parse_timeout t lexbuf }
+  | whitespace+   { parse_timeout t lexbuf }
+  | comment_begin { parse_comment lexbuf; parse_timeout t lexbuf }
+  | ['0'-'9']+    { parse_coq t lexbuf }
+  | eof           { syntax_error t lexbuf ~who:"parse_timeout" ~desc:msg_eof }
+  | _             { syntax_error t lexbuf ~who:"parse_timeout"
+                      ~desc:(msg_unable lexbuf) }
+
+(** Parser for Require with modifiers *)
+and parse_require_modifiers t from = parse
+  | newline       { Lexing.new_line lexbuf;
+                    parse_require_modifiers t from lexbuf }
+  | whitespace    { parse_require_modifiers t from lexbuf }
+  | comment_begin { parse_comment lexbuf;
+                    parse_require_modifiers t from lexbuf }
+  | "Import"      { parse_require_modifiers t from lexbuf }
+  | "Export"      { parse_require_modifiers t from lexbuf }
+  | "-"           { parse_require_modifiers t from lexbuf }
+  | "("           { skip_parenthesized lexbuf;
+                    parse_require_modifiers t from lexbuf }
+  | eof           { syntax_error t lexbuf ~who:"parse_require_modifiers"
+                      ~desc:msg_eof }
+  | _             { backtrack lexbuf; parse_require t from [] lexbuf }
+(** Utility for skipping parenthesized items (used for import categories) *)
+and skip_parenthesized = parse
+  | newline       { Lexing.new_line lexbuf; skip_parenthesized lexbuf }
+  | whitespace    { skip_parenthesized lexbuf }
+  | comment_begin { parse_comment lexbuf; skip_parenthesized lexbuf }
+  | "("           { skip_parenthesized lexbuf; skip_parenthesized lexbuf }
+  | ")"           { () }
+  | eof           { raise End_of_file }
+  | _             { skip_parenthesized lexbuf }
+(* Parser for Require + modules *)
+and parse_require t from modules = parse
+  | newline       { Lexing.new_line lexbuf;
+                    parse_require t from modules lexbuf }
+  | whitespace    { parse_require t from modules lexbuf }
+  | comment_begin { parse_comment lexbuf;
+                    parse_require t from modules lexbuf }
+  | "("           { skip_parenthesized lexbuf;
+                    parse_require t from modules lexbuf }
+  | coq_qualid    { let modules = get_module lexbuf :: modules in
+                    parse_require t from modules lexbuf }
+  | '.'           { Token.add_from_list t from modules }
+  | eof           { syntax_error t lexbuf ~who:"parse_require" ~desc:msg_eof
+                      ~hint:hint_eof_term }
+  | _             { syntax_error t lexbuf ~who:"parse_require"
+                      ~desc:(msg_unable lexbuf) }
+
+(* From ... Require Import parsing rules *)
+and parse_from t = parse
+  | newline       { Lexing.new_line lexbuf; parse_from t lexbuf }
+  | comment_begin { parse_comment lexbuf; parse_from t lexbuf }
+  | whitespace    { parse_from t lexbuf }
+  | coq_qualid    { let from = get_module lexbuf in
+                    parse_from_require_or_extradep t from lexbuf }
+  | eof           { syntax_error t lexbuf ~who:"parse_from t" ~desc:msg_eof }
+  | _             { syntax_error t lexbuf ~who:"parse_from t"
+                      ~desc:(msg_unable lexbuf) }
+and parse_from_require_or_extradep t from = parse
+  | newline       { Lexing.new_line lexbuf;
+                    parse_from_require_or_extradep t from lexbuf }
+  | comment_begin { parse_comment lexbuf;
+                    parse_from_require_or_extradep t from lexbuf }
+  | whitespace    { parse_from_require_or_extradep t from lexbuf }
+  | "Require"     { parse_require_modifiers t (Some from) lexbuf }
+  | "Extra"       { parse_dependency t from lexbuf }
+  | eof           { syntax_error t lexbuf ~who:"parse_from_require_or_extradep"
+                      ~desc:msg_eof }
+  | _             { syntax_error t lexbuf ~who:"parse_from_require_or_extradep"
+                      ~desc:(msg_unable lexbuf) }
+
+(* From ... Extra Dependency ... as ... parsing rules *)
+and parse_dependency t from = parse
+  | newline       { Lexing.new_line lexbuf; parse_dependency t from lexbuf }
+  | comment_begin { parse_comment lexbuf; parse_dependency t from lexbuf }
+  | whitespace    { parse_dependency t from lexbuf }
+  | "Dependency"  { parse_dependency_file t from lexbuf }
+  | eof           { syntax_error t lexbuf ~who:"parse_dependency" ~desc:msg_eof }
+  | _             { syntax_error t lexbuf ~who:"parse_dependency"
+                      ~desc:(msg_unable lexbuf) }
+and parse_dependency_file t from = parse
+  | newline       { Lexing.new_line lexbuf;
+                    parse_dependency_file t from lexbuf }
+  | comment_begin { parse_comment lexbuf;
+                    parse_dependency_file t from lexbuf }
+  | whitespace    { parse_dependency_file t from lexbuf }
+  | quoted        { let loc = Token.Loc.of_lexbuf lexbuf in
+                    let file = get_unquoted_vfile lexbuf in
+                    skip_to_dot t lexbuf;
+                    Token.add_extrdep t loc from file }
+  | eof           { syntax_error t lexbuf ~who:"parse_dependency_file"
+                      ~desc:msg_eof }
+  | _             { syntax_error t lexbuf ~who:"parse_dependency_file"
+                      ~desc:(msg_unable lexbuf) }
+
+(* Parsing load file *)
+and parse_load t = parse
+  | newline       { Lexing.new_line lexbuf; parse_load t lexbuf }
+  | comment_begin { parse_comment lexbuf; parse_load t lexbuf }
+  | whitespace    { parse_load t lexbuf }
+  | coq_qualid    { let load = get_module lexbuf in
+                    skip_to_dot t lexbuf; Token.add_require t load }
+  | quoted        { let loc = Token.Loc.of_lexbuf lexbuf in
+                    let path = get_unquoted_vfile lexbuf in
+                    skip_to_dot t lexbuf; Token.add_load t loc path }
+  | eof           { syntax_error t lexbuf ~who:"parse_load" ~desc:msg_eof }
+  | _             { syntax_error t lexbuf ~who:"parse_load"
+                      ~desc:(msg_unable lexbuf) }
+
+(* Vernac Commments parser *)
+and parse_vernac_comments t = parse
+  | newline       { Lexing.new_line lexbuf; parse_vernac_comments t lexbuf }
+  (* This is a backwards compatible way of declaring extra dependencies. *)
+  | "From"        { parse_from t lexbuf }
+  | '.'           { parse_coq t lexbuf }
+  | eof           { syntax_error t lexbuf ~who:"parse_vernac_comments"
+                      ~desc:msg_eof ~hint:hint_eof_term }
+  | _             { parse_vernac_comments t lexbuf }
+
+{
+
+  let print_syntax_error Metadata.{who; loc; file = s; desc; hint} =
+    let open Pp in
+    let location =
+      Token.Loc.to_string ~line:"line " ~lines:"lines "
+        ~char:"character " ~chars:"characters " loc
+    in
+    strbrk "File \"" ++ str s ++ str "\", " ++ str location ++ str ":" ++ fnl ()
+    ++ strbrk "Error: Syntax error during lexing."
+    ++ pr_opt_no_spc (fun x -> fnl () ++ str "Description: " ++ strbrk x) desc
+    ++ pr_opt_no_spc (fun x -> fnl () ++ str "Hint: " ++ strbrk x) hint
+    ++
+      if !Error.debug_mode then
+        fnl () ++ strbrk "Internal info: " ++ strbrk who ++ str "."
+      else str ""
+
+  let _ = CErrors.register_handler @@ function
+    | Syntax_error meta -> Some (print_syntax_error meta)
+    | _ -> None
+
+}

--- a/tools/coqmod/test-coqmod.t/TestAll.v
+++ b/tools/coqmod/test-coqmod.t/TestAll.v
@@ -1,0 +1,155 @@
+From A.B.C Require Import R.X L.Y.G Z.W.
+
+From
+
+
+    A.B.C
+
+     Require
+
+
+     Import R.X L.Y.G
+
+     Z.W.
+
+(** Some comments *)
+
+(** others
+with
+alot
+of
+lines *)
+
+Load X.
+Load "A/b/c".
+
+Time Require Import timed.
+
+Import not_required.
+
+Declare ML
+Module "foo.bar.baz".
+(* Declare ML Module "dont.include.me". *)
+
+Declare
+ML
+
+Module
+
+"foo"
+
+      "bar.baz"
+
+  "tar".
+
+
+Require A B
+
+C
+
+.
+
+Require Import AI BI CI.
+
+Timeout 1234  Declare ML Module "a".
+
+Load (* something *) here.
+
+From foo Extra Dependency "bar/file".
+Comments From foz Extra Dependency "baz/file".
+Comments but also regular comments.
+
+(* Import categories *)
+Require Import -(coercions) baz (Aasdf).
+Require Import - (coercions) baz (Aasdf).
+Require Import-(coercions) baz.
+Require Import (coercions, baz) baz (Aasdf).
+Require Import(coercions, baz) baz.
+Require Export -(coercions) baz (Aasdf).
+Require Export-(coercions) baz.
+Require Export (coercions, baz) baz (Aasdf).
+Require Export(coercions, baz) baz.
+
+(* Filtered imports *)
+Require Import baz (foo(bar)).
+
+Comments with confusing content such as Require foo.
+
+(** * Categories *)
+(** We collect here all of the files about categories. *)
+(** Since there are only notations in [Category.Notations], we can just export those. *)
+Require Export Category.Notations.
+
+(** ** Definition of precategories *)
+Require Category.Core.
+(** ** Opposite precategories *)
+Require Category.Dual.
+(** ** Morphisms in precategories *)
+Require Category.Morphisms.
+(** ** Classification of path space *)
+Require Category.Paths.
+(** ** Universal objects *)
+Require Category.Objects.
+(** ** Product precategories *)
+Require Category.Prod.
+(** ** Dependent product precategories *)
+Require Category.Pi.
+(** ** ∑-precategories *)
+Require Category.Sigma.
+(** ** Strict categories *)
+Require Category.Strict.
+(** ** Coproduct precategories *)
+Require Category.Sum.
+(** ** Categories (univalent or saturated) *)
+Require Category.Univalent.
+
+Local Set Warnings Append "-notation-overridden".
+Include Category.Core.
+Include Category.Dual.
+Include Category.Morphisms.
+Include Category.Paths.
+Include Category.Objects.
+Include Category.Prod.
+Include Category.Pi.
+(** We use the [Sigma] folder only to allow us to split up the various files and group conceptually similar lemmas, but not for namespacing.  So we include the main file in it. *)
+Include Category.Sigma.
+Include Category.Strict.
+Include Category.Sum.
+Include Category.Univalent.
+(** We don't want to make utf-8 notations the default, so we don't export them. *)
+
+(** ** Subcategories *)
+(** For the subfolders, we need to re-create the module structure.  Alas, namespacing in Coq is kind-of broken (see, e.g., https://coq.inria.fr/bugs/show_bug.cgi?id=3676), so we don't get the ability to rename subfolders by [Including] into other modules. *)
+Require Category.Subcategory.
+
+
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+Require Export Notations.
+Require Export Logic.
+Require Export Datatypes.
+Require Export Specif.
+Require Coq.Init.Byte.
+Require Coq.Init.Decimal.
+Require Coq.Init.Hexadecimal.
+Require Coq.Init.Number.
+Require Coq.Init.Nat.
+Require Export Peano.
+Require Export Coq.Init.Wf.
+Require Export Coq.Init.Ltac.
+Require Export Coq.Init.Tactics.
+Require Export Coq.Init.Tauto.
+(* Some initially available plugins. See also:
+   - ltac_plugin (in Ltac)
+   - tauto_plugin (in Tauto).
+*)
+Declare ML Module "cc_plugin".
+Declare ML Module "firstorder_plugin".

--- a/tools/coqmod/test-coqmod.t/run.t
+++ b/tools/coqmod/test-coqmod.t/run.t
@@ -1,0 +1,342 @@
+Testing the output of coqmod
+
+No file error
+  $ coqmod
+  Error: No file provided. Please provide a file.
+  [1]
+
+Too many files error
+  $ coqmod SomeFile.v SomeOtherFile.v
+  Error: Too many files provided. Please provide only a single file.
+  [1]
+
+Invalid format
+  $ coqmod --format=foo SomeFile.v
+  Error: Unkown output format: foo
+  [1]
+
+Help screen
+  $ coqmod --help
+  coqmod - A simple module lexer for Coq
+    --format Set output format [csexp|sexp|read]
+    --debug Output debugging information
+    -help  Display this list of options
+    --help  Display this list of options
+
+Specification:
+
+## Name
+```lisp
+  $ cat > FileName.v << EOF
+  > EOF
+  $ coqmod FileName.v --format=sexp
+  (Document
+   (Name FileName.v))
+```
+## Require
+```lisp
+  $ cat > Require.v << EOF
+  > Require A B.
+  > Require B C.
+  > EOF
+  $ coqmod Require.v --format=sexp
+  (Document
+   (Name Require.v)
+   (Require
+    (((Loc (1 9) (1 10)) A))
+    (((Loc (2 9) (2 10)) B))
+    (((Loc (2 11) (2 12)) C))))
+```
+## From
+```lisp
+  $ cat > From.v << EOF
+  > From A Require B C.
+  > From A Require C D.
+  > From R Require E.
+  > EOF
+  $ coqmod From.v --format=sexp
+  (Document
+   (Name From.v)
+   (Require
+    (((Loc (1 6) (1 7)) A) ((Loc (1 16) (1 17)) B))
+    (((Loc (1 6) (1 7)) A) ((Loc (1 18) (1 19)) C))
+    (((Loc (2 6) (2 7)) A) ((Loc (2 18) (2 19)) D))
+    (((Loc (3 6) (3 7)) R) ((Loc (3 16) (3 17)) E))))
+```
+## Declare
+```lisp
+  $ cat > Declare.v << EOF
+  > Declare ML Module "foo" "bar.baz".
+  > Declare ML Module "zoo" "foo".
+  > EOF
+  $ coqmod Declare.v --format=sexp
+  (Document
+   (Name Declare.v)
+   (Declare
+    ((Loc (1 25) (1 34)) bar.baz)
+    ((Loc (2 25) (2 30)) foo)
+    ((Loc (2 19) (2 24)) zoo)))
+```
+## Load logical
+```lisp
+  $ cat > LoadLogical.v << EOF
+  > Load A.
+  > Load B.
+  > EOF
+  $ coqmod LoadLogical.v --format=sexp
+  (Document
+   (Name LoadLogical.v)
+   (Require
+    (((Loc (1 6) (1 7)) A))
+    (((Loc (2 6) (2 7)) B))))
+```
+## Load physical
+```lisp
+  $ cat > LoadPhysical.v << EOF
+  > Load "a/b/c".
+  > Load "c/d/e".
+  > EOF
+  $ coqmod LoadPhysical.v --format=sexp
+  (Document
+   (Name LoadPhysical.v)
+   (Load
+    ((Loc (1 6) (1 13)) a/b/c)
+    ((Loc (2 6) (2 13)) c/d/e)))
+```
+## Extra Dependency
+```lisp
+  $ cat > ExtraDependency.v << EOF
+  > From A Extra Dependency "b/c/d".
+  > EOF
+  $ coqmod ExtraDependency.v --format=sexp
+  (Document
+   (Name ExtraDependency.v)
+   (ExtraDep
+    (((Loc (1 6) (1 7)) A) (Loc (1 25) (1 32)) b/c/d)))
+```
+End specification
+
+Simple Require
+  $ cat > B.v << EOF
+  > Require Import A.B.
+  > EOF
+  $ coqmod B.v
+  (8:Document(4:Name3:B.v)(7:Require(((3:Loc(1:12:16)(1:12:19))3:A.B))))
+  $ coqmod --format=read B.v
+  Begin B.v
+  Ln 1, Col 16-19 Require A.B
+  End B.v
+  $ coqmod --format=sexp B.v
+  (Document
+   (Name B.v)
+   (Require
+    (((Loc (1 16) (1 19)) A.B))))
+
+Empty file
+  $ cat > A.v << EOF
+  > EOF
+  $ coqmod A.v
+  (8:Document(4:Name3:A.v))
+
+Empty opening brace
+  $ cat > EmptyBrace.v << EOF
+  > {
+  > EOF
+  $ coqmod EmptyBrace.v
+  File "EmptyBrace.v", line 2, character 1:
+  Error: Syntax error during lexing.
+  Description: File ended unexpectedly.
+  Hint: Did you forget a "."?
+  [1]
+  $ cat > EmptyBrace.v << EOF
+  > { End.
+  > EOF
+  $ coqmod EmptyBrace.v
+  (8:Document(4:Name12:EmptyBrace.v))
+
+Abruptly ending a file
+  $ cat > AbruptEnd.v << EOF
+  > Require Suddenly.End.EOF
+  $ coqmod AbruptEnd.v --debug
+  File "AbruptEnd.v", line 2, character 1:
+  Error: Syntax error during lexing.
+  Description: File ended unexpectedly.
+  Hint: Did you forget a "."?
+  Internal info: parse_require.
+  [1]
+
+Not terminating with a .
+  $ cat > ForgotDot.v << EOF
+  > Require SomeThing
+  > EOF
+  $ coqmod ForgotDot.v --debug
+  File "ForgotDot.v", line 2, character 1:
+  Error: Syntax error during lexing.
+  Description: File ended unexpectedly.
+  Hint: Did you forget a "."?
+  Internal info: parse_require.
+  [1]
+
+README.md example
+  $ cat > example.v << EOF
+  > From A.B.C Require Import R.X L.Y.G Z.W.
+  > 
+  > Load X.
+  > Load "A/b/c".
+  > 
+  > Declare ML Module "foo.bar.baz".
+  > 
+  > Require A B C.
+  > 
+  > Require Import AI BI CI.
+  > EOF
+
+  $ coqmod example.v
+  (8:Document(4:Name9:example.v)(7:Require(((3:Loc(1:81:9)(1:82:10))1:A))(((3:Loc(2:102:16)(2:102:18))2:AI))(((3:Loc(1:82:11)(1:82:12))1:B))(((3:Loc(2:102:19)(2:102:21))2:BI))(((3:Loc(1:82:13)(1:82:14))1:C))(((3:Loc(2:102:22)(2:102:24))2:CI))(((3:Loc(1:31:6)(1:31:7))1:X))(((3:Loc(1:11:6)(1:12:11))5:A.B.C)((3:Loc(1:12:31)(1:12:36))5:L.Y.G))(((3:Loc(1:11:6)(1:12:11))5:A.B.C)((3:Loc(1:12:27)(1:12:30))3:R.X))(((3:Loc(1:11:6)(1:12:11))5:A.B.C)((3:Loc(1:12:37)(1:12:40))3:Z.W)))(7:Declare((3:Loc(1:62:19)(1:62:32))11:foo.bar.baz))(4:Load((3:Loc(1:41:6)(1:42:13))5:A/b/c)))
+  $ coqmod example.v --format=read
+  Begin example.v
+  Ln 8, Col 9-10 Require A
+  Ln 10, Col 16-18 Require AI
+  Ln 8, Col 11-12 Require B
+  Ln 10, Col 19-21 Require BI
+  Ln 8, Col 13-14 Require C
+  Ln 10, Col 22-24 Require CI
+  Ln 3, Col 6-7 Require X
+  Ln 1, Col 6-11 From A.B.C Ln 1, Col 31-36 Require L.Y.G
+  Ln 1, Col 6-11 From A.B.C Ln 1, Col 27-30 Require R.X
+  Ln 1, Col 6-11 From A.B.C Ln 1, Col 37-40 Require Z.W
+  Ln 6, Col 19-32 Declare ML Module Ln 6, Col 19-32 Require foo.bar.baz
+  Ln 4, Col 6-13 Physical "A/b/c"
+  End example.v
+  $ coqmod example.v --format=sexp
+  (Document
+   (Name example.v)
+   (Require
+    (((Loc (8 9) (8 10)) A))
+    (((Loc (10 16) (10 18)) AI))
+    (((Loc (8 11) (8 12)) B))
+    (((Loc (10 19) (10 21)) BI))
+    (((Loc (8 13) (8 14)) C))
+    (((Loc (10 22) (10 24)) CI))
+    (((Loc (3 6) (3 7)) X))
+    (((Loc (1 6) (1 11)) A.B.C) ((Loc (1 31) (1 36)) L.Y.G))
+    (((Loc (1 6) (1 11)) A.B.C) ((Loc (1 27) (1 30)) R.X))
+    (((Loc (1 6) (1 11)) A.B.C) ((Loc (1 37) (1 40)) Z.W)))
+   (Declare
+    ((Loc (6 19) (6 32)) foo.bar.baz))
+   (Load
+    ((Loc (4 6) (4 13)) A/b/c)))
+
+Various mixed dep commands
+  $ coqmod TestAll.v --debug
+  (8:Document(4:Name9:TestAll.v)(7:Require(((3:Loc(2:461:9)(2:462:10))1:A))(((3:Loc(2:522:16)(2:522:18))2:AI))(((3:Loc(2:462:11)(2:462:12))1:B))(((3:Loc(2:522:19)(2:522:21))2:BI))(((3:Loc(2:481:1)(2:481:2))1:C))(((3:Loc(2:522:22)(2:522:24))2:CI))(((3:Loc(2:841:9)(2:842:22))13:Category.Core))(((3:Loc(2:861:9)(2:862:22))13:Category.Dual))(((3:Loc(2:881:9)(2:882:27))18:Category.Morphisms))(((3:Loc(2:812:16)(2:812:34))18:Category.Notations))(((3:Loc(2:921:9)(2:922:25))16:Category.Objects))(((3:Loc(2:901:9)(2:902:23))14:Category.Paths))(((3:Loc(2:961:9)(2:962:20))11:Category.Pi))(((3:Loc(2:941:9)(2:942:22))13:Category.Prod))(((3:Loc(2:981:9)(2:982:23))14:Category.Sigma))(((3:Loc(3:1001:9)(3:1002:24))15:Category.Strict))(((3:Loc(3:1231:9)(3:1232:29))20:Category.Subcategory))(((3:Loc(3:1021:9)(3:1022:21))12:Category.Sum))(((3:Loc(3:1041:9)(3:1042:27))18:Category.Univalent))(((3:Loc(3:1401:9)(3:1402:22))13:Coq.Init.Byte))(((3:Loc(3:1411:9)(3:1412:25))16:Coq.Init.Decimal))(((3:Loc(3:1421:9)(3:1422:29))20:Coq.Init.Hexadecimal))(((3:Loc(3:1472:16)(3:1472:29))13:Coq.Init.Ltac))(((3:Loc(3:1441:9)(3:1442:21))12:Coq.Init.Nat))(((3:Loc(3:1431:9)(3:1432:24))15:Coq.Init.Number))(((3:Loc(3:1482:16)(3:1482:32))16:Coq.Init.Tactics))(((3:Loc(3:1492:16)(3:1492:30))14:Coq.Init.Tauto))(((3:Loc(3:1462:16)(3:1462:27))11:Coq.Init.Wf))(((3:Loc(3:1382:16)(3:1382:25))9:Datatypes))(((3:Loc(3:1372:16)(3:1372:21))5:Logic))(((3:Loc(3:1362:16)(3:1362:25))9:Notations))(((3:Loc(3:1452:16)(3:1452:21))5:Peano))(((3:Loc(3:1392:16)(3:1392:22))6:Specif))(((3:Loc(2:231:6)(2:231:7))1:X))(((3:Loc(2:742:16)(2:742:19))3:baz))(((3:Loc(2:562:22)(2:562:26))4:here))(((3:Loc(2:262:21)(2:262:26))5:timed))(((3:Loc(1:61:5)(1:62:10))5:A.B.C)((3:Loc(2:112:17)(2:112:22))5:L.Y.G))(((3:Loc(1:61:5)(1:62:10))5:A.B.C)((3:Loc(2:112:13)(2:112:16))3:R.X))(((3:Loc(1:61:5)(1:62:10))5:A.B.C)((3:Loc(2:131:6)(2:131:9))3:Z.W)))(7:Declare((3:Loc(2:542:33)(2:542:36))1:a)((3:Loc(2:411:7)(2:412:16))7:bar.baz)((3:Loc(3:1542:19)(3:1542:30))9:cc_plugin)((3:Loc(3:1552:19)(3:1552:38))17:firstorder_plugin)((3:Loc(2:391:1)(2:391:6))3:foo)((3:Loc(2:311:8)(2:312:21))11:foo.bar.baz)((3:Loc(2:431:3)(2:431:8))3:tar))(4:Load((3:Loc(2:241:6)(2:242:13))5:A/b/c))(8:ExtraDep(((3:Loc(2:581:6)(2:581:9))3:foo)(3:Loc(2:582:27)(2:582:37))8:bar/file)(((3:Loc(2:592:15)(2:592:18))3:foz)(3:Loc(2:592:36)(2:592:46))8:baz/file)))
+  $ coqmod TestAll.v --format=read
+  Begin TestAll.v
+  Ln 46, Col 9-10 Require A
+  Ln 52, Col 16-18 Require AI
+  Ln 46, Col 11-12 Require B
+  Ln 52, Col 19-21 Require BI
+  Ln 48, Col 1-2 Require C
+  Ln 52, Col 22-24 Require CI
+  Ln 84, Col 9-22 Require Category.Core
+  Ln 86, Col 9-22 Require Category.Dual
+  Ln 88, Col 9-27 Require Category.Morphisms
+  Ln 81, Col 16-34 Require Category.Notations
+  Ln 92, Col 9-25 Require Category.Objects
+  Ln 90, Col 9-23 Require Category.Paths
+  Ln 96, Col 9-20 Require Category.Pi
+  Ln 94, Col 9-22 Require Category.Prod
+  Ln 98, Col 9-23 Require Category.Sigma
+  Ln 100, Col 9-24 Require Category.Strict
+  Ln 123, Col 9-29 Require Category.Subcategory
+  Ln 102, Col 9-21 Require Category.Sum
+  Ln 104, Col 9-27 Require Category.Univalent
+  Ln 140, Col 9-22 Require Coq.Init.Byte
+  Ln 141, Col 9-25 Require Coq.Init.Decimal
+  Ln 142, Col 9-29 Require Coq.Init.Hexadecimal
+  Ln 147, Col 16-29 Require Coq.Init.Ltac
+  Ln 144, Col 9-21 Require Coq.Init.Nat
+  Ln 143, Col 9-24 Require Coq.Init.Number
+  Ln 148, Col 16-32 Require Coq.Init.Tactics
+  Ln 149, Col 16-30 Require Coq.Init.Tauto
+  Ln 146, Col 16-27 Require Coq.Init.Wf
+  Ln 138, Col 16-25 Require Datatypes
+  Ln 137, Col 16-21 Require Logic
+  Ln 136, Col 16-25 Require Notations
+  Ln 145, Col 16-21 Require Peano
+  Ln 139, Col 16-22 Require Specif
+  Ln 23, Col 6-7 Require X
+  Ln 74, Col 16-19 Require baz
+  Ln 56, Col 22-26 Require here
+  Ln 26, Col 21-26 Require timed
+  Ln 6, Col 5-10 From A.B.C Ln 11, Col 17-22 Require L.Y.G
+  Ln 6, Col 5-10 From A.B.C Ln 11, Col 13-16 Require R.X
+  Ln 6, Col 5-10 From A.B.C Ln 13, Col 6-9 Require Z.W
+  Ln 54, Col 33-36 Declare ML Module Ln 54, Col 33-36 Require a
+  Ln 41, Col 7-16 Declare ML Module Ln 41, Col 7-16 Require bar.baz
+  Ln 154, Col 19-30 Declare ML Module Ln 154, Col 19-30 Require cc_plugin
+  Ln 155, Col 19-38 Declare ML Module Ln 155, Col 19-38 Require firstorder_plugin
+  Ln 39, Col 1-6 Declare ML Module Ln 39, Col 1-6 Require foo
+  Ln 31, Col 8-21 Declare ML Module Ln 31, Col 8-21 Require foo.bar.baz
+  Ln 43, Col 3-8 Declare ML Module Ln 43, Col 3-8 Require tar
+  Ln 24, Col 6-13 Physical "A/b/c"
+  Ln 58, Col 27-37 From Ln 58, Col 6-9 Require foo Extra Dependency "bar/file"
+  Ln 59, Col 36-46 From Ln 59, Col 15-18 Require foz Extra Dependency "baz/file"
+  End TestAll.v
+  $ coqmod TestAll.v --format=sexp
+  (Document
+   (Name TestAll.v)
+   (Require
+    (((Loc (46 9) (46 10)) A))
+    (((Loc (52 16) (52 18)) AI))
+    (((Loc (46 11) (46 12)) B))
+    (((Loc (52 19) (52 21)) BI))
+    (((Loc (48 1) (48 2)) C))
+    (((Loc (52 22) (52 24)) CI))
+    (((Loc (84 9) (84 22)) Category.Core))
+    (((Loc (86 9) (86 22)) Category.Dual))
+    (((Loc (88 9) (88 27)) Category.Morphisms))
+    (((Loc (81 16) (81 34)) Category.Notations))
+    (((Loc (92 9) (92 25)) Category.Objects))
+    (((Loc (90 9) (90 23)) Category.Paths))
+    (((Loc (96 9) (96 20)) Category.Pi))
+    (((Loc (94 9) (94 22)) Category.Prod))
+    (((Loc (98 9) (98 23)) Category.Sigma))
+    (((Loc (100 9) (100 24)) Category.Strict))
+    (((Loc (123 9) (123 29)) Category.Subcategory))
+    (((Loc (102 9) (102 21)) Category.Sum))
+    (((Loc (104 9) (104 27)) Category.Univalent))
+    (((Loc (140 9) (140 22)) Coq.Init.Byte))
+    (((Loc (141 9) (141 25)) Coq.Init.Decimal))
+    (((Loc (142 9) (142 29)) Coq.Init.Hexadecimal))
+    (((Loc (147 16) (147 29)) Coq.Init.Ltac))
+    (((Loc (144 9) (144 21)) Coq.Init.Nat))
+    (((Loc (143 9) (143 24)) Coq.Init.Number))
+    (((Loc (148 16) (148 32)) Coq.Init.Tactics))
+    (((Loc (149 16) (149 30)) Coq.Init.Tauto))
+    (((Loc (146 16) (146 27)) Coq.Init.Wf))
+    (((Loc (138 16) (138 25)) Datatypes))
+    (((Loc (137 16) (137 21)) Logic))
+    (((Loc (136 16) (136 25)) Notations))
+    (((Loc (145 16) (145 21)) Peano))
+    (((Loc (139 16) (139 22)) Specif))
+    (((Loc (23 6) (23 7)) X))
+    (((Loc (74 16) (74 19)) baz))
+    (((Loc (56 22) (56 26)) here))
+    (((Loc (26 21) (26 26)) timed))
+    (((Loc (6 5) (6 10)) A.B.C) ((Loc (11 17) (11 22)) L.Y.G))
+    (((Loc (6 5) (6 10)) A.B.C) ((Loc (11 13) (11 16)) R.X))
+    (((Loc (6 5) (6 10)) A.B.C) ((Loc (13 6) (13 9)) Z.W)))
+   (Declare
+    ((Loc (54 33) (54 36)) a)
+    ((Loc (41 7) (41 16)) bar.baz)
+    ((Loc (154 19) (154 30)) cc_plugin)
+    ((Loc (155 19) (155 38)) firstorder_plugin)
+    ((Loc (39 1) (39 6)) foo)
+    ((Loc (31 8) (31 21)) foo.bar.baz)
+    ((Loc (43 3) (43 8)) tar))
+   (Load
+    ((Loc (24 6) (24 13)) A/b/c))
+   (ExtraDep
+    (((Loc (58 6) (58 9)) foo) (Loc (58 27) (58 37)) bar/file)
+    (((Loc (59 15) (59 18)) foz) (Loc (59 36) (59 46)) baz/file)))

--- a/tools/coqmod/token.ml
+++ b/tools/coqmod/token.ml
@@ -1,0 +1,234 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+module Loc = struct
+  type t = {start : Lexing.position; finish : Lexing.position}
+
+  let to_string ?(sep = ", ") ?(range_sep = "-") ?(line = "Ln ")
+      ?(lines = "Ln ") ?(char = "Col ") ?(chars = "Col ") t =
+    (* Configurable printing of locations *)
+    let line1 = t.start.Lexing.pos_lnum in
+    let line2 = t.finish.Lexing.pos_lnum in
+    let col1 = t.start.Lexing.pos_cnum - t.start.Lexing.pos_bol + 1 in
+    let col2 = t.finish.Lexing.pos_cnum - t.finish.Lexing.pos_bol + 1 in
+    let line_range =
+      if Int.equal line1 line2 then line ^ string_of_int line1
+      else lines ^ string_of_int line1 ^ range_sep ^ string_of_int line2
+    in
+    let col_range =
+      if Int.equal col1 col2 then char ^ string_of_int col1
+      else chars ^ string_of_int col1 ^ range_sep ^ string_of_int col2
+    in
+    line_range ^ sep ^ col_range
+
+  let dummy = {start = Lexing.dummy_pos; finish = Lexing.dummy_pos}
+
+  let of_lexbuf lexbuf =
+    Lexing.{start = lexeme_start_p lexbuf; finish = lexeme_end_p lexbuf}
+
+  let pos_to_sexp pos =
+    let open Csexp in
+    List
+      [
+        Atom (string_of_int pos.Lexing.pos_lnum);
+        Atom (string_of_int (pos.Lexing.pos_cnum - pos.Lexing.pos_bol + 1));
+      ]
+
+  let to_sexp t =
+    let open Csexp in
+    List [Atom "Loc"; pos_to_sexp t.start; pos_to_sexp t.finish]
+end
+
+module Module = struct
+  type t = {loc : Loc.t; logical_name : string}
+
+  let make loc logical_name = {loc; logical_name}
+
+  let to_string t = Loc.to_string t.loc ^ " Require " ^ t.logical_name
+
+  let to_string_as_prefix t = Loc.to_string t.loc ^ " From " ^ t.logical_name
+
+  let to_string_as_declare t =
+    Loc.to_string t.loc ^ " Declare ML Module " ^ to_string t
+
+  let to_sexp t =
+    let open Csexp in
+    List [Loc.to_sexp t.loc; Atom t.logical_name]
+
+  let compare x y = String.compare x.logical_name y.logical_name
+end
+
+module From = struct
+  type t = {prefix : Module.t option; require : Module.t}
+
+  let to_string t =
+    match t.prefix with
+    | None -> Module.to_string t.require
+    | Some prefix ->
+        Module.to_string_as_prefix prefix ^ " " ^ Module.to_string t.require
+
+  let to_sexp t =
+    let open Csexp in
+    match t.prefix with
+    | None -> List [Module.to_sexp t.require]
+    | Some prefix -> List [Module.to_sexp prefix; Module.to_sexp t.require]
+
+  let compare x y =
+    (* When comparing we ignore the locations *)
+    if
+      Option.equal
+        Module.(fun x y -> x.logical_name = y.logical_name)
+        x.prefix y.prefix
+    then Module.compare x.require y.require
+    else Option.compare Module.compare x.prefix y.prefix
+end
+
+module Load = struct
+  type t = {loc : Loc.t; path : string}
+
+  let to_string t =
+    Loc.to_string t.loc ^ " " ^ "Physical " ^ "\"" ^ t.path ^ "\""
+
+  let to_sexp t =
+    let open Csexp in
+    List [Loc.to_sexp t.loc; Atom t.path]
+
+  let compare x y = String.compare x.path y.path
+end
+
+module ExtraDep = struct
+  type t = {loc : Loc.t; from : Module.t; file : string}
+
+  let to_string t =
+    Loc.to_string t.loc ^ " From " ^ Module.to_string t.from
+    ^ " Extra Dependency " ^ "\"" ^ t.file ^ "\""
+
+  let to_sexp t =
+    let open Csexp in
+    List [Module.to_sexp t.from; Loc.to_sexp t.loc; Atom t.file]
+
+  (* TODO *)
+  let compare x y =
+    let open Module in
+    if x.from.logical_name = y.from.logical_name then
+      String.compare x.file y.file
+    else Module.compare x.from y.from
+end
+
+type t = {
+  filename : string option;
+  froms : From.t list;
+  declares : Module.t list;
+  loads : Load.t list;
+  extradeps : ExtraDep.t list;
+}
+
+let get_filename t = Option.get t.filename
+
+let empty =
+  {filename = None; froms = []; declares = []; loads = []; extradeps = []}
+
+let set_filename t filename = {t with filename = Some filename}
+
+let add_from t prefix require =
+  {t with froms = From.{prefix; require} :: t.froms}
+
+let add_from_list t prefix requires =
+  let froms = List.map (fun require -> From.{prefix; require}) requires in
+  {t with froms = froms @ t.froms}
+
+let add_require t require = add_from t None require
+
+let add_require_list t requires = add_from_list t None requires
+
+let add_declare_list t declares = {t with declares = declares @ t.declares}
+
+let add_load t loc path = {t with loads = Load.{loc; path} :: t.loads}
+
+let add_extrdep t loc from file =
+  {t with extradeps = ExtraDep.{loc; from; file} :: t.extradeps}
+
+let to_string t =
+  let default_filename = "<!!Unknown File!!>" in
+  [
+    ["Begin " ^ Option.default default_filename t.filename];
+    List.map From.to_string t.froms;
+    List.map Module.to_string_as_declare t.declares;
+    List.map Load.to_string t.loads;
+    List.map ExtraDep.to_string t.extradeps;
+    ["End " ^ Option.default default_filename t.filename];
+  ]
+  |> List.flatten |> String.concat "\n"
+
+let sexp_of_declares = function
+  | [] -> []
+  | declares ->
+      Csexp.[List (Atom "Declare" :: List.map Module.to_sexp declares)]
+
+let sexp_of_froms = function
+  | [] -> []
+  | froms -> Csexp.[List (Atom "Require" :: List.map From.to_sexp froms)]
+
+let sexp_of_loads = function
+  | [] -> []
+  | loads -> Csexp.[List (Atom "Load" :: List.map Load.to_sexp loads)]
+
+let sexp_extradeps = function
+  | [] -> []
+  | extradeps ->
+      Csexp.[List (Atom "ExtraDep" :: List.map ExtraDep.to_sexp extradeps)]
+
+let to_sexp t =
+  [
+    sexp_of_froms t.froms;
+    sexp_of_declares t.declares;
+    sexp_of_loads t.loads;
+    sexp_extradeps t.extradeps;
+  ]
+  |> List.flatten
+  |> fun x ->
+  let open Csexp in
+  List
+    ( Atom "Document"
+    :: List [Atom "Name"; Atom (Option.default "Unknown" t.filename)]
+    :: x )
+
+let sort_uniq t =
+  {
+    t with
+    froms = List.sort_uniq From.compare t.froms;
+    declares = List.sort_uniq Module.compare t.declares;
+    loads = List.sort_uniq Load.compare t.loads;
+    extradeps = List.sort_uniq ExtraDep.compare t.extradeps;
+  }
+
+module Sexp = struct
+  open Csexp
+
+  let rec pp fmt =
+    let pp_list = Format.pp_print_list pp ~pp_sep:Format.pp_print_space in
+    function
+    | Atom s -> Format.pp_print_string fmt s
+    (* Only vertically formatted s-expressions need to be included *)
+    | List (Atom "Load" :: ts) ->
+        Format.fprintf fmt "@[<v1>(Load@ %a@])" pp_list ts
+    | List (Atom "Declare" :: ts) ->
+        Format.fprintf fmt "@[<v1>(Declare@ %a@])" pp_list ts
+    | List (Atom "Require" :: ts) ->
+        Format.fprintf fmt "@[<v1>(Require@ %a@])" pp_list ts
+    | List (Atom "Document" :: ts) ->
+        Format.fprintf fmt "@[<v1>(Document@ %a@])" pp_list ts
+    | List (Atom "ExtraDep" :: ts) ->
+        Format.fprintf fmt "@[<v1>(ExtraDep@ %a@])" pp_list ts
+    | List ts ->
+        Format.fprintf fmt "@[<h1>(%a)@]"
+          (Format.pp_print_list pp ~pp_sep:Format.pp_print_space)
+          ts
+end

--- a/tools/coqmod/token.mli
+++ b/tools/coqmod/token.mli
@@ -1,0 +1,110 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+module Loc : sig
+  (** Locations of tokens. [start] is the Lexing.position value of the begining
+      of the token and [finish] is the Lexing.position value of the end of a
+      token. *)
+  type t
+  (* = {start : Lexing.position; finish : Lexing.position} *)
+
+  val to_string :
+    ?sep:string ->
+    ?range_sep:string ->
+    ?line:string ->
+    ?lines:string ->
+    ?char:string ->
+    ?chars:string ->
+    t ->
+    string
+  (** Locations can be converted to strings with some configuarability. If the
+        line numbers or coloumn numbers are the same, then the range is printed
+        with a single number. If they are different they are printed as [1-4]
+        seperated by a [range_sep].
+
+      - [sep] the seperator between lines and coloumns (defaults to [", "])
+      - [range_sep] the seperator when printing a range (defaults to ["-"])
+      - [line] the singular label for lines (defaults to ["Ln"])
+      - [lines] the plural label for lines (defaults to ["Ln"])
+      - [char] the singular label for coloumns/characters (defaults to ["Col"])
+      - [chars] the plural label for coloumns/characters (defaults to ["Col"]) *)
+
+  val dummy : t
+  (** Return a dummy location consisting of [Lexing.dummy_pos] values. *)
+
+  val of_lexbuf : Lexing.lexbuf -> t
+  (** The location of a recently parsed token for a given [Lexing.lexbuf]. *)
+
+  val pos_to_sexp : Lexing.position -> Csexp.t
+  (** Convert a [Lexing.position] to a [Csexp.t]. *)
+
+  val to_sexp : t -> Csexp.t
+  (** Convert a location to a [Csexp.t]. *)
+end
+
+module Module : sig
+  (** Tokens for modules consist of a location [loc] of the token and a string
+    [logical_name] for the value. *)
+  type t
+
+  val make : Loc.t -> string -> t
+  (** Construct a [Module.t] with given location and logical name. *)
+
+  val to_string : t -> string
+  (** Displays the [logical_name] of a module. *)
+
+  val to_sexp : t -> Csexp.t
+  (** Convert a module to a [Csexp.t] containing the location and
+    [logical_name]. *)
+end
+
+(** Abstract type of lexed dependency tokens. *)
+type t
+
+val get_filename : t -> string
+(** Name of the file the tokens were lexed in. *)
+
+val empty : t
+(** Empty token. *)
+
+val set_filename : t -> string -> t
+(** Set the filename of a token. *)
+
+val add_from_list : t -> Module.t option -> Module.t list -> t
+(** Add a list of modules to a token sharing the same prefix. *)
+
+val add_require : t -> Module.t -> t
+(** Add a single module to a token. *)
+
+val add_require_list : t -> Module.t list -> t
+(** Add a list of modules to a token. *)
+
+val add_declare_list : t -> Module.t list -> t
+(** Add a list of OCaml modules to a token. *)
+
+val add_load : t -> Loc.t -> string -> t
+(** Add a physical load to a token. *)
+
+val add_extrdep : t -> Loc.t -> Module.t -> string -> t
+(** Add an extra dependency to a token. *)
+
+val to_string : t -> string
+(** Convert a token to a string. This will print a readable document. *)
+
+val to_sexp : t -> Csexp.t
+(** Convert the token to a [Csexp.t]. *)
+
+val sort_uniq : t -> t
+(** Sort the entries of the token unique upto non-location data. *)
+
+module Sexp : sig
+  val pp : Format.formatter -> Csexp.t -> unit
+  (** Pretty printer for serial expresions of tokens. *)
+end


### PR DESCRIPTION
coqmod is a simple lexer for .v files which outputs parsed tokens that
can be interpreted as dependencies by another program. It is intended
as a replacement for coqdep for use in programs such as Dune.

Unlike coqdep, it does not scan directories making it lightweight in
comparison.

It has 3 --format modes:
- csexp - canonical serial expresion (default)
- sexp - pretty printed serial expression
- read - human readable output

See the README.md for more information.

---

I have a cram test which is a simple way of testing binaries with dune. However for this the dune version needs to be bumped past 2.7.

I'm also not too certain about keeping .ocamlformat around locally.
