### PR TITLE
CI: allow_failure for fiat_crypto_ocaml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -706,6 +706,7 @@ library:ci-fiat_crypto_ocaml:
   - plugin:ci-bignums
   - plugin:ci-rewriter
   - library:ci-fiat_crypto
+  allow_failure: true
 
 library:ci-flocq3:
   extends: .ci-template-flambda


### PR DESCRIPTION
Failing since https://gitlab.com/coq/coq/-/jobs/2537542809 (the PR's
CI succeeded https://gitlab.com/coq/coq/-/jobs/2527415579)

cc @JasonGross 