### PR TITLE
Make equality hints export and hidden inside a Hints module.

### DIFF
--- a/theories/Bool/BoolOrder.v
+++ b/theories/Bool/BoolOrder.v
@@ -102,4 +102,5 @@ Module BoolOrd <: UsualDecidableTypeFull <: OrderedTypeFull <: TotalOrder.
   Definition eq_trans := @eq_Transitive bool.
   Definition eqb := eqb.
   Definition eqb_eq := eqb_true_iff.
+  Module Hints. End Hints.
 End BoolOrd.

--- a/theories/FSets/FMapAVL.v
+++ b/theories/FSets/FMapAVL.v
@@ -2026,6 +2026,7 @@ Module IntMake (I:Int)(X: OrderedType) <: S with Module E := X.
  - apply (is_bst m').
  Qed.
 
+ Module Hints. End Hints.
 End IntMake.
 
 

--- a/theories/FSets/FMapFacts.v
+++ b/theories/FSets/FMapFacts.v
@@ -68,6 +68,8 @@ split; intros (e0,H0); exists e0.
 - apply (MapsTo_1 (E.eq_sym H) H0); auto.
 Qed.
 
+Import E.Hints.
+
 Lemma MapsTo_iff : forall m x y e, E.eq x y -> (MapsTo x e m <-> MapsTo y e m).
 Proof.
 split; apply MapsTo_1; auto.
@@ -513,6 +515,8 @@ case_eq (find x m); intros.
     * rewrite (find_1 H4) in H1; discriminate.
 Qed.
 
+Import E.Hints.
+
 Lemma elements_o : forall m x,
  find x m = findA (eqb x) (elements m).
 Proof.
@@ -757,6 +761,8 @@ Module WProperties_fun (E:DecidableType)(M:WSfun E).
 
   Notation eqke := (@eq_key_elt elt).
   Notation eqk := (@eq_key elt).
+
+  Import E.Hints.
 
   Instance eqk_equiv : Equivalence eqk.
   Proof. unfold eq_key; split; eauto. Qed.
@@ -1732,6 +1738,8 @@ Module WProperties_fun (E:DecidableType)(M:WSfun E).
   - rewrite <- Hm1, <- Hm2, <- Hm3; auto.
   - rewrite Hm1, Hm2, Hm3; auto.
  Qed.
+
+ Import E.Hints.
 
  Add Parametric Morphism elt : (@update elt)
    with signature Equal ==> Equal ==> Equal as update_m.

--- a/theories/FSets/FMapFullAVL.v
+++ b/theories/FSets/FMapFullAVL.v
@@ -643,6 +643,7 @@ Module IntMake (I:Int)(X: OrderedType) <: S with Module E := X.
  - apply (is_bst m').
  Qed.
 
+ Module Hints. End Hints.
 End IntMake.
 
 

--- a/theories/FSets/FMapInterface.v
+++ b/theories/FSets/FMapInterface.v
@@ -253,6 +253,7 @@ Module Type WSfun (E : DecidableType).
     remove_2 find_1 fold_1 map_1 mapi_1 mapi_2
     : map.
 
+  Module Hints. End Hints.
 End WSfun.
 
 

--- a/theories/FSets/FMapList.v
+++ b/theories/FSets/FMapList.v
@@ -1167,6 +1167,7 @@ Section Elt.
  exact (@Raw.map2_2 elt elt' elt'' f (this m) (sorted m) (this m') (sorted m') x).
  Qed.
 
+ Module Hints. End Hints.
 End Make.
 
 Module Make_ord (X: OrderedType)(D : OrderedType) <:

--- a/theories/FSets/FMapPositive.v
+++ b/theories/FSets/FMapPositive.v
@@ -1067,6 +1067,7 @@ Module PositiveMap <: S with Module E:=PositiveOrderedTypeBits.
            ++ try discriminate.
   Qed.
 
+  Module Hints. End Hints.
 End PositiveMap.
 
 (** Here come some additional facts about this implementation.

--- a/theories/FSets/FMapWeakList.v
+++ b/theories/FSets/FMapWeakList.v
@@ -143,6 +143,8 @@ Qed.
 
 (* Not part of the exported specifications, used later for [combine]. *)
 
+Import X.Hints.
+
 Lemma find_eq : forall m (Hm:NoDupA m) x x',
    X.eq x x' -> find x m = find x' m.
 Proof.
@@ -531,6 +533,8 @@ Proof.
  - inversion H.
  - destruct a; inversion H; auto.
 Qed.
+
+Import X.Hints.
 
 (** Specification of [mapi] *)
 
@@ -997,5 +1001,6 @@ Section Elt.
  exact (@Raw.map2_2 elt elt' elt'' f (this m) (NoDup m) (this m') (NoDup m') x).
  Qed.
 
+ Module Hints. End Hints.
 End Make.
 

--- a/theories/FSets/FSetEqProperties.v
+++ b/theories/FSets/FSetEqProperties.v
@@ -87,6 +87,8 @@ Proof.
 auto with set.
 Qed.
 
+Import E.Hints.
+
 Lemma add_mem_1: mem x (add x s)=true.
 Proof.
 auto with set.
@@ -650,6 +652,8 @@ Proof.
 auto with set.
 Qed.
 
+Import E.Hints.
+
 Lemma filter_add_1 : forall s x, f x = true ->
  filter f (add x s) [=] add x (filter f s).
 Proof.
@@ -907,6 +911,8 @@ intros s;pattern s; apply set_rec.
   unfold Empty; intros.
   rewrite filter_iff; auto; set_iff; tauto.
 Qed.
+
+Import E.Hints.
 
 Lemma fold_compat :
   forall (A:Type)(eqA:A->A->Prop)(st:Equivalence eqA)

--- a/theories/FSets/FSetFacts.v
+++ b/theories/FSets/FSetFacts.v
@@ -34,6 +34,8 @@ Section IffSpec.
 Variable s s' s'' : t.
 Variable x y z : elt.
 
+Import E.Hints.
+
 Lemma In_eq_iff : E.eq x y -> (In x s <-> In y s).
 Proof.
 split; apply In_1; auto.
@@ -242,6 +244,8 @@ generalize (mem_iff (filter f s) x)(mem_iff s x)(filter_iff s x H).
 destruct (mem x s); destruct (mem x (filter f s)); destruct (f x); simpl; intuition.
 Qed.
 
+Import E.Hints.
+
 Lemma for_all_b : compat_bool E.eq f ->
   for_all f s = forallb f (elements s).
 Proof.
@@ -342,6 +346,8 @@ generalize (H0 x); clear H0; rewrite (In_eq_iff s' H).
 generalize (mem_iff s x)(mem_iff s' y).
 destruct (mem x s); destruct (mem y s'); intuition.
 Qed.
+
+Import E.Hints.
 
 #[global]
 Instance singleton_m : Proper (E.eq ==> Equal) singleton.

--- a/theories/FSets/FSetProperties.v
+++ b/theories/FSets/FSetProperties.v
@@ -289,6 +289,8 @@ Module WProperties_fun (Import E : DecidableType)(M : WSfun E).
 
   (** * Properties of elements *)
 
+  Import E.Hints.
+
   Lemma elements_Empty : forall s, Empty s <-> elements s = nil.
   Proof.
   intros.

--- a/theories/Structures/DecidableType.v
+++ b/theories/Structures/DecidableType.v
@@ -52,6 +52,8 @@ Module KeyDecidableType(D:DecidableType).
 
   (* eqk, eqke are equalities *)
 
+  Import Hints.
+
   Lemma eqk_refl : forall e, eqk e e.
   Proof. auto. Qed.
 

--- a/theories/Structures/DecidableTypeEx.v
+++ b/theories/Structures/DecidableTypeEx.v
@@ -53,6 +53,8 @@ Module PairDecidableType(D1 D2:DecidableType) <: DecidableType.
 
  Definition eq x y := D1.eq (fst x) (fst y) /\ D2.eq (snd x) (snd y).
 
+ Import D1.Hints D2.Hints.
+
  Lemma eq_refl : forall x : t, eq x x.
  Proof.
  intros (x1,x2); red; simpl; auto.
@@ -74,6 +76,7 @@ Module PairDecidableType(D1 D2:DecidableType) <: DecidableType.
  destruct (D1.eq_dec x1 y1); destruct (D2.eq_dec x2 y2); intuition.
  Defined.
 
+ Module Hints. End Hints.
 End PairDecidableType.
 
 (** Similarly for pairs of UsualDecidableType *)
@@ -93,4 +96,5 @@ Module PairUsualDecidableType(D1 D2:UsualDecidableType) <: UsualDecidableType.
  (right; injection; auto).
  Defined.
 
+ Module Hints. End Hints.
 End PairUsualDecidableType.

--- a/theories/Structures/Equalities.v
+++ b/theories/Structures/Equalities.v
@@ -54,10 +54,14 @@ Module Type IsEqOrig (Import E:Eq').
   Axiom eq_refl : forall x : t, x==x.
   Axiom eq_sym : forall x y : t, x==y -> y==x.
   Axiom eq_trans : forall x y z : t, x==y -> y==z -> x==z.
-  #[global]
-  Hint Immediate eq_sym : core.
-  #[global]
-  Hint Resolve eq_refl eq_trans : core.
+  Module Hints.
+    (** In order to avoid polluting the global hint database, we put these
+      equality hints into a Module. When implementing IsEqOrig, you will have to
+      include an empty [Module Hints. End Hints.]. *)
+    #[export] Hint Immediate eq_sym : core.
+    #[export] Hint Resolve eq_refl : core. #[export] Hint Resolve eq_trans :
+    core.
+  End Hints.
 End IsEqOrig.
 
 (** * Types with decidable equality *)
@@ -134,6 +138,7 @@ Module BackportEq (E:Eq)(F:IsEq E) <: IsEqOrig E.
  Definition eq_refl := @Equivalence_Reflexive _ _ F.eq_equiv.
  Definition eq_sym := @Equivalence_Symmetric _ _ F.eq_equiv.
  Definition eq_trans := @Equivalence_Transitive _ _ F.eq_equiv.
+ Module Hints. End Hints.
 End BackportEq.
 
 Module UpdateEq (E:Eq)(F:IsEqOrig E) <: IsEq E.
@@ -251,6 +256,7 @@ Module Type UsualIsEqOrig (E:UsualEq) <: IsEqOrig E.
  Definition eq_refl := @Logic.eq_refl E.t.
  Definition eq_sym := @Logic.eq_sym E.t.
  Definition eq_trans := @Logic.eq_trans E.t.
+ Module Hints. End Hints.
 End UsualIsEqOrig.
 
 Module Type UsualEqualityType <: EqualityType

--- a/theories/Structures/OrderedType.v
+++ b/theories/Structures/OrderedType.v
@@ -58,6 +58,7 @@ Module Type OrderedType.
      redundant field allows seeing an OrderedType as a DecidableType. *)
   Parameter eq_dec : forall x y, { eq x y } + { ~ eq x y }.
 
+  Module Hints. End Hints.
 End OrderedType.
 
 Module MOT_to_OT (Import O : MiniOrderedType) <: OrderedType.
@@ -69,6 +70,7 @@ Module MOT_to_OT (Import O : MiniOrderedType) <: OrderedType.
    assert (~ eq y x)...
   Defined.
 
+  Module Hints. End Hints.
 End MOT_to_OT.
 
 (** * Ordered types properties *)

--- a/theories/Structures/OrderedTypeAlt.v
+++ b/theories/Structures/OrderedTypeAlt.v
@@ -82,6 +82,7 @@ Module OrderedType_from_Alt (O:OrderedTypeAlt) <: OrderedType.
  case (x ?= y); [ left | right | right ]; auto; discriminate.
  Defined.
 
+ Module Hints. End Hints.
 End OrderedType_from_Alt.
 
 (** From the original presentation to this alternative one. *)

--- a/theories/Structures/OrderedTypeEx.v
+++ b/theories/Structures/OrderedTypeEx.v
@@ -30,6 +30,7 @@ Module Type UsualOrderedType.
  Axiom lt_not_eq : forall x y : t, lt x y -> ~ eq x y.
  Parameter compare : forall x y : t, Compare lt eq x y.
  Parameter eq_dec : forall x y : t, { eq x y } + { ~ eq x y }.
+ Module Hints. End Hints.
 End UsualOrderedType.
 
 (** a [UsualOrderedType] is in particular an [OrderedType]. *)
@@ -65,6 +66,7 @@ Module Nat_as_OT <: UsualOrderedType.
 
   Definition eq_dec := eq_nat_dec.
 
+  Module Hints. End Hints.
 End Nat_as_OT.
 
 
@@ -98,6 +100,7 @@ Module Z_as_OT <: UsualOrderedType.
 
   Definition eq_dec := Z.eq_dec.
 
+  Module Hints. End Hints.
 End Z_as_OT.
 
 (** [positive] is an ordered type with respect to the usual order on natural numbers. *)
@@ -130,6 +133,7 @@ Module Positive_as_OT <: UsualOrderedType.
 
   Definition eq_dec := Pos.eq_dec.
 
+  Module Hints. End Hints.
 End Positive_as_OT.
 
 
@@ -156,6 +160,7 @@ Module N_as_OT <: UsualOrderedType.
 
   Definition eq_dec := N.eq_dec.
 
+  Module Hints. End Hints.
 End N_as_OT.
 
 
@@ -223,6 +228,7 @@ Module PairOrderedType(O1 O2:OrderedType) <: OrderedType.
  - assert (~ eq y x); auto using lt_not_eq, eq_sym.
  Defined.
 
+ Module Hints. End Hints.
 End PairOrderedType.
 
 
@@ -314,6 +320,7 @@ Module PositiveOrderedTypeBits <: UsualOrderedType.
   - right. intro. subst y. now rewrite (Pos.compare_refl x) in *.
   Qed.
 
+  Module Hints. End Hints.
 End PositiveOrderedTypeBits.
 
 Module Ascii_as_OT <: UsualOrderedType.
@@ -389,6 +396,7 @@ Module Ascii_as_OT <: UsualOrderedType.
     end Logic.eq_refl.
 
   Definition eq_dec (x y : ascii): {x = y} + { ~ (x = y)} := ascii_dec x y.
+  Module Hints. End Hints.
 End Ascii_as_OT.
 
 (** [String] is an ordered type with respect to the usual lexical order. *)
@@ -545,4 +553,5 @@ Module String_as_OT <: UsualOrderedType.
     end Logic.eq_refl.
 
   Definition eq_dec (x y : string): {x = y} + { ~ (x = y)} := string_dec x y.
+  Module Hints. End Hints.
 End String_as_OT.


### PR DESCRIPTION
This was a particularly annoying patch to do. I wonder if there is a way to mark `Hints` as "just there for the signature" so we don't have to include it everywhere.

@ppedrot any ideas?

Regarding this, I have no idea if we want to go this way, but it would be interesting to see how many people are even relying on this behaviour.


Fixes / closes coq/stdlib#18

- [ ] Added / updated **test-suite**.
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
- [ ] Opened **overlay** pull requests.

cc @JasonGross 