### PR TITLE
Backport MathComp PRs #872 #874

### DIFF
--- a/doc/changelog/06-ssreflect/16158-backport_mc_872_874.rst
+++ b/doc/changelog/06-ssreflect/16158-backport_mc_872_874.rst
@@ -1,0 +1,11 @@
+- **Added:**
+  port the additions made to `ssrfun.v` and `ssrbool.v` in math-comp
+  `PR #872 <https://github.com/math-comp/math-comp/pull/872>`_
+  and  `PR #874 <https://github.com/math-comp/math-comp/pull/874>`_,
+  namely definitions `olift` and `pred_oapp` as well as lemmas
+  `all_sig2_cond`, `compA`, `obindEapp`, `omapEbind`, `omapEapp`,
+  `omap_comp`, `oapp_comp`, `olift_comp`, `ocan_comp`, `eqbLR`,
+  `eqbRL`, `can_in_pcan`, `pcan_in_inj`, `in_inj_comp`, `can_in_comp`,
+  `pcan_in_comp` and `ocan_in_comp`
+  (`#16158 <https://github.com/coq/coq/pull/16158>`_,
+  by Pierre Roux).

--- a/theories/ssr/ssrbool.v
+++ b/theories/ssr/ssrbool.v
@@ -1710,6 +1710,13 @@ Lemma all_sig_cond I T (C : pred I) P :
   {f : I -> T | forall x, C x -> P x (f x)}.
 Proof. by move=> y0; apply: all_sig_cond_dep. Qed.
 
+Lemma all_sig2_cond {I T} (C : pred I) P Q :
+  T -> (forall x, C x -> {y : T | P x y & Q x y}) ->
+  {f : I -> T | forall x, C x -> P x (f x) & forall x, C x -> Q x (f x)}.
+Proof.
+by move=> /all_sig_cond/[apply]-[f Pf]; exists f => i Di; have [] := Pf i Di.
+Qed.
+
 Section RelationProperties.
 
 (**


### PR DESCRIPTION
This ports the additions made to `ssrfun.v` and `ssrbool.v` in https://github.com/math-comp/math-comp/pull/782 and https://github.com/math-comp/math-comp/pull/784

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make -f Makefile.dune doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.
