### PR TITLE
fixed congruence regression #16140 in 8.16

### DIFF
--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -265,7 +265,7 @@ let app_global f args k =
   Tacticals.pf_constr_of_global (Lazy.force f) >>= fun fc -> k (mkApp (fc, args))
 
 let rec gen_holes env sigma t n accu =
-  if Int.equal n 0 then (sigma, List.rev accu, t)
+  if Int.equal n 0 then (sigma, List.rev accu)
   else match EConstr.kind sigma t with
   | Prod (_, u, t) ->
     let (sigma, ev) = Evarutil.new_evar env sigma u in
@@ -283,9 +283,9 @@ let app_global_with_holes f args n =
       let fj = Retyping.get_judgment_of env sigma fc in
       let argsj = Array.map (fun c -> Retyping.get_judgment_of env sigma c) args in
       let sigma, fj = Typing.judge_of_apply env sigma fj argsj in
-      let (sigma, holes, ty) = gen_holes env sigma fj.uj_type n [] in
+      let (sigma, holes) = gen_holes env sigma fj.uj_type n [] in
       let ans = applist (fj.uj_val, holes) in
-      let sigma = Typing.check_actual_type env sigma { uj_val = ans; uj_type = ty } concl in
+      let sigma = Typing.check env sigma ans concl in
       (sigma, ans)
     end
   end

--- a/test-suite/bugs/bug_16140.v
+++ b/test-suite/bugs/bug_16140.v
@@ -1,0 +1,26 @@
+(* Test regression https://github.com/coq/coq/issues/16140
+   where congruence produces ill-typed terms *)
+
+Inductive wrap1 : Type :=
+  wrap1I (u : unit) : match u with tt => bool end -> wrap1.
+
+Goal (wrap1I tt false) = (wrap1I tt true) -> False.
+Proof.
+  Fail congruence. (* expected to fail *)
+Abort.
+
+Inductive wrap2 : unit -> Type :=
+  wrap2I (u : unit) : match u with tt => bool end -> wrap2 u.
+
+Goal (wrap2I tt false) = (wrap2I tt true) -> False.
+Proof.
+  Fail congruence. (* expected to fail *)
+Abort.
+
+Inductive wrap3 (u : unit) : Type :=
+  wrap3I : match u with tt => bool end -> wrap3 u.
+
+Goal (wrap3I tt false) = (wrap3I tt true) -> False.
+Proof.
+  congruence.
+Qed.


### PR DESCRIPTION
- partially reverted https://github.com/coq/coq/pull/15796 to fix `congruence` regression https://github.com/coq/coq/issues/16140
- added regression test `test-suite/bugs/bug_16140.v`

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes #16140

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this breaks external libraries or plugins in CI: -->
<!-- - [ ] Opened **overlay** pull requests. -->

<!--
Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md
Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
-->