### PR TITLE
Reduce the use of Logic.refiner

### DIFF
--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -48,7 +48,6 @@ let observe_tac s =
   New.observe_tac ~header:(str "observation") (fun _ _ -> Pp.str s)
 
 let finish_proof dynamic_infos = observe_tac "finish" assumption
-let refine c = Logic.refiner ~check:true EConstr.Unsafe.(to_constr c)
 let thin = clear
 let eq_constr sigma u v = EConstr.eq_constr_nounivs sigma u v
 
@@ -122,7 +121,7 @@ let prove_trivial_eq h_id context (constructor, type_of_term, term) =
             :: List.map mkVar context_hyps
           in
           let to_refine = applist (mkVar h_id, List.rev context_hyps') in
-          refine to_refine) ]
+          Tactics.exact_check to_refine) ]
 
 let find_rectype env sigma c =
   let t, l = decompose_app sigma (Reductionops.whd_betaiotazeta env sigma c) in
@@ -264,7 +263,7 @@ let change_eq env sigma hyp_id (context : rel_context) x t end_of_type =
              Typing.type_of (Proofview.Goal.env g) (Proofview.Goal.sigma g)
                to_refine
            in
-           tclTHEN (Proofview.Unsafe.tclEVARS evm) (refine to_refine)))
+           tclTHEN (Proofview.Unsafe.tclEVARS evm) (Tactics.exact_check to_refine)))
   in
   let simpl_eq_tac =
     change_hyp_with_using "prove_pattern_simplification" hyp_id new_type_of_hyp
@@ -391,7 +390,7 @@ let clean_hyp_with_heq ptes_infos eq_hyps hyp_id env sigma =
                     [ (* observe_tac "prove rec hyp" *)
                       prove_rec_hyp eq_hyps
                     ; (*                      observe_tac "prove rec hyp" *)
-                      refine to_refine ]) ]
+                      Tactics.exact_check to_refine ]) ]
         in
         tclTHENLIST
           [ (*              observe_tac "hyp rec"  *)
@@ -429,7 +428,7 @@ let clean_hyp_with_heq ptes_infos eq_hyps hyp_id env sigma =
                       ( mkVar hyp_id
                       , List.rev (coq_I :: List.map mkVar context_hyps) )
                   in
-                  refine to_refine) ]
+                  Tactics.exact_check to_refine) ]
         in
         tclTHENLIST
           [ change_hyp_with_using "prove_trivial" hyp_id real_type_of_hyp
@@ -774,7 +773,7 @@ let prove_rec_hyp_for_struct fix_info eq_hyps =
          let rec_hyp_proof =
            mkApp (mkVar fix_info.name, array_get_start pte_args)
          in
-         refine rec_hyp_proof))
+         Tactics.exact_check rec_hyp_proof))
 
 let prove_rec_hyp fix_info =
   {proving_tac = prove_rec_hyp_for_struct fix_info; is_valid = (fun _ -> true)}

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -1384,8 +1384,8 @@ let inject_if_homogenous_dependent_pair ty =
         tclTHENS (cut (mkApp (ceq,new_eq_args)))
           [clear [destVar sigma hyp];
            Tacticals.pf_constr_of_global inj2 >>= fun inj2 ->
-           Logic.refiner ~check:true EConstr.Unsafe.(to_constr
-             (mkApp(inj2,[|ar1.(0);mkConst c;ar1.(1);ar1.(2);ar1.(3);ar2.(3);hyp|])))
+           Tactics.exact_check
+             (mkApp(inj2,[|ar1.(0);mkConst c;ar1.(1);ar1.(2);ar1.(3);ar2.(3);hyp|]))
           ])]
   with Exit ->
     Proofview.tclUNIT ()


### PR DESCRIPTION
We remove some calls to Logic.refiner in Equality and funind where we statically know that the argument is meta-free, and thus equivalent to the exact tactic.