### PR TITLE
Prototype: Update Proof using ... statements automatically

### DIFF
--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -329,10 +329,12 @@ GRAMMAR EXTEND Gram
   command: TOP
     [ [ IDENT "Proof"; "with"; ta = Pltac.tactic;
         l = OPT [ IDENT "using"; l = G_vernac.section_subset_expr -> { l } ] ->
-          { Vernacexpr.VernacProof (Some (in_tac ta), l) }
+          { Update_proof_using.save_proof loc;
+            Vernacexpr.VernacProof (Some (in_tac ta), l) }
       | IDENT "Proof"; IDENT "using"; l = G_vernac.section_subset_expr;
         "with"; ta = Pltac.tactic ->
-          { Vernacexpr.VernacProof (Some (in_tac ta),Some l) } ] ]
+          { Update_proof_using.save_proof loc;
+            Vernacexpr.VernacProof (Some (in_tac ta),Some l) } ] ]
   ;
   hint: TOP
     [ [ IDENT "Extern"; n = natural; c = OPT Constr.constr_pattern ; "=>";

--- a/toplevel/ccompile.ml
+++ b/toplevel/ccompile.ml
@@ -217,8 +217,11 @@ let compile_file opts stm_opts copts injections (f_in, echo) =
   if !Flags.beautify then
     Flags.with_option Flags.beautify_file
       (fun f_in -> compile opts stm_opts copts injections ~echo ~f_in ~f_out) f_in
-  else
-    compile opts stm_opts copts injections ~echo ~f_in ~f_out
+  else begin
+    if copts.update_proof_using then Update_proof_using.start_file f_in;
+    compile opts stm_opts copts injections ~echo ~f_in ~f_out;
+    if copts.update_proof_using then Update_proof_using.end_file ()
+  end
 
 let compile_file opts stm_opts copts injections =
   Option.iter (compile_file opts stm_opts copts injections) copts.compile_file

--- a/toplevel/coqc.ml
+++ b/toplevel/coqc.ml
@@ -36,6 +36,7 @@ coqc specific options:\
 \n  -vok                   process the file by loading .vos instead of .vo files for\
 \n                         dependencies, and produce an empty .vok file on success\
 \n  -vio                   process statements and suspend opaque proofs, and produce a .vio file\
+\n  -update-proof-using    Update source files using info from Set Suggest Proof Using\n
 \n\
 \nUndocumented:\
 \n  -quick                 (deprecated) alias for -vio\

--- a/toplevel/coqcargs.ml
+++ b/toplevel/coqcargs.ml
@@ -26,6 +26,7 @@ type t =
   ; glob_out    : Dumpglob.glob_output
 
   ; output_context : bool
+  ; update_proof_using : bool
   }
 
 let default =
@@ -44,6 +45,7 @@ let default =
   ; glob_out = Dumpglob.MultFiles
 
   ; output_context = false
+  ; update_proof_using = false
   }
 
 let depr opt =
@@ -208,6 +210,9 @@ let parse arglist : t =
         |"-dump-glob" ->
           let file = next () in
           { oval with glob_out = Dumpglob.File file }
+
+        |"-update-proof-using" ->
+          { oval with update_proof_using = true }
 
         (* Rest *)
         | s ->

--- a/toplevel/coqcargs.mli
+++ b/toplevel/coqcargs.mli
@@ -40,6 +40,7 @@ type t =
   ; glob_out    : Dumpglob.glob_output
 
   ; output_context : bool
+  ; update_proof_using : bool
   }
 
 val default : t

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -645,17 +645,17 @@ let declare_entry_core ~name ?(scope=Locality.default_scope) ~kind ~typing_flags
   let should_suggest =
     entry.proof_entry_opaque
     && not (List.is_empty (Global.named_context()))
-    && Option.is_empty entry.proof_entry_secctx
   in
+  let no_sec_vars = Option.is_empty entry.proof_entry_secctx  in
   let dref = match scope with
   | Locality.Discharge ->
     let () = declare_variable_core ~name ~kind (SectionLocalDef entry) in
-    if should_suggest then Proof_using.suggest_variable (Global.env ()) name;
+    if should_suggest then Proof_using.suggest_variable (Global.env ()) name no_sec_vars;
     Names.GlobRef.VarRef name
   | Locality.Global local ->
     let kn = declare_constant ~name ~local ~kind ~typing_flags (DefinitionEntry entry) in
     let gr = Names.GlobRef.ConstRef kn in
-    if should_suggest then Proof_using.suggest_constant (Global.env ()) kn;
+    if should_suggest then Proof_using.suggest_constant (Global.env ()) kn no_sec_vars;
     gr
   in
   let () = Impargs.maybe_declare_manual_implicits false dref impargs in

--- a/vernac/g_proofs.mlg
+++ b/vernac/g_proofs.mlg
@@ -56,9 +56,12 @@ GRAMMAR EXTEND Gram
   command: TOP
     [ [ IDENT "Goal"; c = lconstr ->
         { VernacDefinition (Decls.(NoDischarge, Definition), ((CAst.make ~loc Names.Anonymous), None), ProveBody ([], c)) }
-      | IDENT "Proof" -> { VernacProof (None,None) }
-      | IDENT "Proof"; IDENT "using"; l = G_vernac.section_subset_expr ->
-          { VernacProof (None,Some l) }
+      | IDENT "Proof" -> {
+          Update_proof_using.save_proof loc;
+          VernacProof (None,None) }
+      | IDENT "Proof"; IDENT "using"; l = G_vernac.section_subset_expr -> {
+          Update_proof_using.save_proof loc;
+          VernacProof (None,Some l) }
       | IDENT "Proof" ; IDENT "Mode" ; mn = string -> { VernacProofMode mn }
       | IDENT "Proof"; c = lconstr -> { VernacExactProof c }
       | IDENT "Abort" -> { VernacAbort }

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -217,7 +217,8 @@ GRAMMAR EXTEND Gram
         l = LIST0
           [ "with"; id = ident_decl; bl = binders; ":"; c = lconstr ->
           { (id,(bl,c)) } ] ->
-          { VernacStartTheoremProof (thm, (id,(bl,c))::l) }
+          { Update_proof_using.save_theorem loc;
+            VernacStartTheoremProof (thm, (id,(bl,c))::l) }
       | stre = assumption_token; nl = inline; bl = assum_list ->
           { VernacAssumption (stre, nl, bl) }
       | tk = assumptions_token; nl = inline; bl = assum_list ->
@@ -693,8 +694,9 @@ GRAMMAR EXTEND Gram
   (* Proof using *)
   section_subset_expr:
     [ [ test_only_starredidentrefs; l = LIST0 starredidentref ->
-          { starredidentreflist_to_expr l }
-      | e = ssexpr -> { e } ]]
+          { Update_proof_using.save_section_vars_list loc;
+            starredidentreflist_to_expr l }
+      | e = ssexpr -> { Update_proof_using.save_section_vars_list loc; e } ]]
   ;
   starredidentref:
     [ [ i = identref -> { SsSingl i }

--- a/vernac/proof_using.mli
+++ b/vernac/proof_using.mli
@@ -24,9 +24,9 @@ val definition_using
 
 val name_set : Names.Id.t -> Vernacexpr.section_subset_expr -> unit
 
-val suggest_constant : Environ.env -> Names.Constant.t -> unit
+val suggest_constant : Environ.env -> Names.Constant.t -> bool -> unit
 
-val suggest_variable : Environ.env -> Names.Id.t -> unit
+val suggest_variable : Environ.env -> Names.Id.t -> bool -> unit
 
 val get_default_proof_using : unit -> Vernacexpr.section_subset_expr option
 

--- a/vernac/update_proof_using.ml
+++ b/vernac/update_proof_using.ml
@@ -1,0 +1,83 @@
+let theorem_loc : Loc.t option ref = ref None
+let proof_loc: Loc.t option ref = ref None
+let section_vars_loc : Loc.t option ref = ref None
+
+let fname : string option ref = ref None
+let offset = ref 0
+let fin : in_channel ref = ref stdin
+let fout : out_channel ref = ref stdout
+
+let tmp_file fn = fn ^ "_update"
+
+let start_file f =
+  try
+    offset := 0;
+    fin := open_in_bin f;
+        fout := open_out_bin (tmp_file f);
+        fname := Some f
+  with e -> () (* todo: print message *)
+
+let save_theorem loc =
+  theorem_loc := Some loc;
+  proof_loc := None;
+  section_vars_loc := None
+
+let save_proof loc =
+  proof_loc := Some loc
+
+let save_section_vars_list loc =
+  section_vars_loc := Some loc
+
+let bufsize = 1024
+let buf = Bytes.create bufsize
+
+let of_some = function
+  | Some x -> x
+  | None -> failwith "of_some"
+
+(* copy range from bp to ep+1 inclusive *)
+let copy bp ep =
+  assert (bp <= ep);
+  seek_in !fin bp;
+  let rec aux len =
+    if len <= 0 then ()
+    else begin
+      let actlen = input !fin buf 0 (min len bufsize) in
+      output !fout buf 0 actlen;
+      aux (len - actlen)
+    end
+  in
+  let len = 1 + ep - bp in
+  aux len;
+  offset := !offset + len
+
+let save_needed syms =
+  let open Loc in
+  if !fname <> None && !theorem_loc <> None then begin
+    let insert = String.concat " " syms in
+    let insert = if insert = "" then "" else " " ^ insert in
+    copy !offset (of_some (!theorem_loc)).ep;
+    match !proof_loc with
+    | None -> output_string !fout (Printf.sprintf "\nProof using%s." insert)
+    | Some ploc ->
+      let using = match !section_vars_loc with
+        | None -> copy !offset (ploc.ep - 1); " using"  (* add "using ...", keep "." *)
+        | Some svs -> copy !offset (svs.bp-2); offset := svs.ep; "" (* replace items in "using ..." *)
+      in
+      output_string !fout (Printf.sprintf "%s%s" using insert)
+  end;
+  theorem_loc := None;
+  proof_loc := None;
+  section_vars_loc := None
+
+let end_file () =
+  match !fname with
+  | Some _ ->
+    let fn = of_some !fname in
+    let flen = (Unix.stat fn).st_size in
+    copy !offset (flen-1);
+    fname := None;
+    close_in !fin;
+    close_out !fout;
+    Unix.rename (tmp_file fn) fn
+  | None -> ()

--- a/vernac/update_proof_using.mli
+++ b/vernac/update_proof_using.mli
@@ -1,0 +1,6 @@
+val start_file : string -> unit
+val save_theorem : Loc.t -> unit
+val save_proof : Loc.t -> unit
+val save_section_vars_list : Loc.t  -> unit
+val save_needed : string list -> unit
+val end_file : unit -> unit


### PR DESCRIPTION
This is a quick and dirty way to add `Proof using` commands based on what `Set Suggest Print Using` would suggest.  A new command line option `-update-proof-using` causes `coqc` to makes changes directly in the source file.

It also updates existing `Proof using` commands.  This works fine if a section variable is no longer needed.  Unfortunately, if there is a missing section variable, compilation is aborted with an exception like the one shown and the file is not updated.  I think that makes this far less valuable, more like half a feature, so I may just abandon this.  Or is it possible to disable the checking in the Qed?

@Blaisorblade @mrhaandi What do you think?

```
File "./Pff.v", line 4325, characters 0-4:
Error:
The following section variable is used but not declared:
pGivesBound.

You can either update your proof to not depend on pGivesBound, or you can update your Proof line from
Proof using FtoRradix b precision precisionNotZero radix
radixMoreThanOne
to
Proof using b pGivesBound precision precisionNotZero radix
radixMoreThanOne
```