### PR TITLE
added Nat.le_add_l

### DIFF
--- a/doc/changelog/10-standard-library/16184-dropin_nat.rst
+++ b/doc/changelog/10-standard-library/16184-dropin_nat.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  lemma :g:`le_add_l` to ``NAddOrder.v``. Use :g:`Nat.le_add_l` as replacement for the deprecated :g:`Plus.le_plus_r`
+  (`#16184 <https://github.com/coq/coq/pull/16184>`_,
+  by Andrej Dudenhefner).

--- a/theories/Arith/Arith_prebase.v
+++ b/theories/Arith/Arith_prebase.v
@@ -202,7 +202,8 @@ Hint Resolve -> Nat.add_le_mono_l : arith. (* Plus.plus_le_compat_l *)
 #[global]
 Hint Resolve -> Nat.add_le_mono_r : arith. (* Plus.plus_le_compat_r *)
 #[local]
-Definition le_plus_r_stt := (fun n m => eq_ind _ _ (Nat.le_add_r m n) _ (Nat.add_comm m n)).
+Definition le_plus_r_stt := (fun n m => Nat.le_add_l m n).
+#[local]
 Definition le_plus_trans_stt := (fun n m p Hle => Nat.le_trans n _ _ Hle (Nat.le_add_r m p)).
 Opaque le_plus_r_stt le_plus_trans_stt.
 #[global]

--- a/theories/Arith/Plus.v
+++ b/theories/Arith/Plus.v
@@ -88,7 +88,7 @@ Notation plus_lt_le_compat := Nat.add_lt_le_mono (only parsing).
 Notation plus_lt_compat := Nat.add_lt_mono (only parsing).
 #[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.le_add_r instead.")]
 Notation le_plus_l := Nat.le_add_r (only parsing).
-#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.le_add_r (together with Nat.add_comm) instead.")]
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.le_add_l (with arguments reversed) instead.")]
 Notation le_plus_r := Arith_prebase.le_plus_r_stt.
 #[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.le_add_r (together with Nat.le_trans) instead.")]
 Notation le_plus_trans := Arith_prebase.le_plus_trans_stt.

--- a/theories/FSets/FSetProperties.v
+++ b/theories/FSets/FSetProperties.v
@@ -826,7 +826,7 @@ Module WProperties_fun (Import E : DecidableType)(M : WSfun E).
   rewrite <- (diff_inter_cardinal s' s).
   rewrite (inter_sym s' s).
   rewrite (inter_subset_equal H).
-  rewrite Nat.add_comm; apply Nat.le_add_r.
+  apply Nat.le_add_l.
   Qed.
 
   Lemma subset_cardinal_lt :

--- a/theories/MSets/MSetProperties.v
+++ b/theories/MSets/MSetProperties.v
@@ -832,7 +832,7 @@ Module WPropertiesOn (Import E : DecidableType)(M : WSetsOn E).
   rewrite <- (diff_inter_cardinal s' s).
   rewrite (inter_sym s' s).
   rewrite (inter_subset_equal H).
-  rewrite Nat.add_comm; apply Nat.le_add_r.
+  apply Nat.le_add_l.
   Qed.
 
   Lemma subset_cardinal_lt :

--- a/theories/Numbers/DecimalFacts.v
+++ b/theories/Numbers/DecimalFacts.v
@@ -249,7 +249,7 @@ Proof.
   induction (to_list d) as [|h t IHl]; [now simpl|].
   rewrite <-List.app_comm_cons.
   now case h; [| simpl; rewrite List.app_length; intro Hl; exfalso; revert Hl;
-    apply Nat.le_ngt; rewrite Nat.add_comm; apply Nat.le_add_r..].
+    apply Nat.le_ngt, Nat.le_add_l..].
 Qed.
 
 Lemma nzhead_app_nil_r d d' : nzhead (app d d') = Nil -> nzhead d' = Nil.
@@ -265,7 +265,7 @@ Proof.
   induction (to_list d) as [|h t IHl]; [now simpl|].
   now case h; [now simpl|..];
     simpl;intro H; exfalso; revert H; apply Nat.le_ngt;
-    rewrite List.app_length, Nat.add_comm; apply Nat.le_add_r.
+    rewrite List.app_length; apply Nat.le_add_l.
 Qed.
 
 Lemma nzhead_app_nil_l d d' : nzhead (app d d') = Nil -> nzhead d = Nil.

--- a/theories/Numbers/HexadecimalFacts.v
+++ b/theories/Numbers/HexadecimalFacts.v
@@ -263,7 +263,7 @@ Proof.
   induction (to_list d) as [|h t IHl]; [now simpl|].
   rewrite <-List.app_comm_cons.
   now case h; [| simpl; rewrite List.app_length; intro Hl; exfalso; revert Hl;
-    apply Nat.le_ngt; rewrite Nat.add_comm; apply Nat.le_add_r..].
+    apply Nat.le_ngt, Nat.le_add_l..].
 Qed.
 
 Lemma nzhead_app_nil_r d d' : nzhead (app d d') = Nil -> nzhead d' = Nil.
@@ -279,7 +279,7 @@ Proof.
   induction (to_list d) as [|h t IHl]; [now simpl|].
   now case h; [now simpl|..];
     simpl;intro H; exfalso; revert H; apply Nat.le_ngt;
-    rewrite List.app_length, Nat.add_comm; apply Nat.le_add_r.
+    rewrite List.app_length; apply Nat.le_add_l.
 Qed.
 
 Lemma nzhead_app_nil_l d d' : nzhead (app d d') = Nil -> nzhead d = Nil.

--- a/theories/Numbers/Natural/Abstract/NAddOrder.v
+++ b/theories/Numbers/Natural/Abstract/NAddOrder.v
@@ -24,6 +24,11 @@ intros n m; induct m.
 - intros m IH. rewrite add_succ_r; now apply le_le_succ_r.
 Qed.
 
+Theorem le_add_l : forall n m, n <= m + n.
+Proof.
+intros n m; rewrite add_comm; apply le_add_r.
+Qed.
+
 Theorem lt_lt_add_r : forall n m p, n < m -> n < m + p.
 Proof.
 intros n m p H; rewrite <- (add_0_r n).

--- a/theories/Reals/SeqSeries.v
+++ b/theories/Reals/SeqSeries.v
@@ -53,7 +53,7 @@ Proof.
       unfold ge; apply Nat.le_trans with n.
       - apply H4.
       - apply Nat.le_trans with (N + n)%nat.
-        + rewrite Nat.add_comm; apply Nat.le_add_r.
+        + apply Nat.le_add_l.
         + apply Nat.le_succ_diag_r. }
     cut (0 <= N)%nat.
     2:{ apply Nat.le_0_l. }
@@ -106,7 +106,7 @@ Proof.
     apply H3; unfold ge; apply Nat.le_trans with n.
     - apply H4.
     - apply Nat.le_trans with (N + n)%nat.
-      + rewrite Nat.add_comm; apply Nat.le_add_r.
+      + apply Nat.le_add_l.
       + apply Nat.le_succ_diag_r.
   }
   elim X; intros l1N H2.
@@ -133,7 +133,7 @@ Proof.
     { apply H6; unfold ge; apply Nat.le_trans with n.
       - apply H7.
       - apply Nat.le_trans with (N + n)%nat.
-        + rewrite Nat.add_comm; apply Nat.le_add_r.
+        + apply Nat.le_add_l.
         + apply Nat.le_succ_diag_r. }
     cut (0 <= N)%nat.
     2:{ apply Nat.le_0_l. }
@@ -170,7 +170,7 @@ Proof.
   { unfold SP in H5; apply H5; unfold ge; apply Nat.le_trans with n.
     - apply H6.
     - apply Nat.le_trans with (N + n)%nat.
-      + rewrite Nat.add_comm; apply Nat.le_add_r.
+      + apply Nat.le_add_l.
       + apply Nat.le_succ_diag_r. }
   cut (0 <= N)%nat.
   2:{ apply Nat.le_0_l. }

--- a/theories/funind/Recdef.v
+++ b/theories/funind/Recdef.v
@@ -31,7 +31,7 @@ Qed.
 
 Theorem Splus_lt x y : y < S (x + y).
 Proof.
- apply Nat.lt_succ_r. rewrite Nat.add_comm. apply Nat.le_add_r.
+ apply Nat.lt_succ_r. apply Nat.le_add_l.
 Qed.
 
 Theorem SSplus_lt x y : x < S (S (x + y)).


### PR DESCRIPTION
This PR systematically adds `le_add_l` to `NAddOrder.v` (all other lemmas in `NAddOrder.v` have both `_l` and `_r` variants).

This makes for a better drop-in replacement of the deprecated `Plus.le_plus_r`.
The deprecation message suggests to rewrite with commutativity first. This is tricky in automation and can lead to regressions.

<!-- If this is a feature pull request / breaks compatibility: 
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
-->

<!-- If this breaks external libraries or plugins in CI: 
- [ ] Opened **overlay** pull requests.
-->

<!-- Pointers to relevant developer documentation:
Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md
Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
-->