### PR TITLE
[stdlib] stronger div, mod lemmas via module type

### DIFF
--- a/doc/changelog/11-standard-library/16203-concise_mod_type.rst
+++ b/doc/changelog/11-standard-library/16203-concise_mod_type.rst
@@ -1,0 +1,22 @@
+- **Added:**
+  modules :g:`Nat.Div0` and :g:`Nat.Lcm0` in :g:`PeanoNat`, and :g:`N.Div0` and :g:`N.Lcm0` in :g:`BinNat`
+  containing lemmas regarding :g:`div` and :g:`mod`, which take into account `n div 0 = 0` and `n mod 0 = n`.
+  Strictly weaker lemmas are deprecated, and will be removed in the future.
+  After the weaker lemmas are removed, the modules :g:`Div0` and :g:`Lcm0` will be deprecated,
+  and their contents included directly into :g:`Nat` and :g:`N`.
+  Locally, you can use :g:`Module Nat := Nat.Div0.` or :g:`Module Nat := Nat.Lcm0.` to approximate this inclusion
+  (`#16203 <https://github.com/coq/coq/pull/16203>`_,
+  fixes `#16186 <https://github.com/coq/coq/issues/16186>`_,
+  by Andrej Dudenhefner).
+- **Added:**
+  lemma :g:`measure_induction` in :g:`Nat` and :g:`N` analogous to :g:`Wf_nat.induction_ltof1`,
+  which is compatible with the `using` clause for the :tacn:`induction` tactic
+  (`#16203 <https://github.com/coq/coq/pull/16203>`_,
+  by Andrej Dudenhefner).
+- **Removed:**
+  from :g:`Nat` and :g:`N` superfluous lemmas :g:`rs_rs'`, :g:`rs'_rs''`, :g:`rbase`, :g:`A'A_right`,
+  :g:`ls_ls'`, :g:`ls'_ls''`, :g:`rs'_rs''`, :g:`lbase`, :g:`A'A_left`, and also
+  redundant non-negativity assumptions in :g:`gcd_unique`, :g:`gcd_unique_alt`,
+  :g:`divide_gcd_iff`, and :g:`gcd_mul_diag_l`
+  (`#16203 <https://github.com/coq/coq/pull/16203>`_,
+  by Andrej Dudenhefner).

--- a/doc/stdlib/index-list.html.template
+++ b/doc/stdlib/index-list.html.template
@@ -297,6 +297,7 @@ through the <tt>Require Import</tt> command.</p>
     theories/Numbers/Natural/Abstract/NStrongRec.v
     theories/Numbers/Natural/Abstract/NSub.v
     theories/Numbers/Natural/Abstract/NDiv.v
+    theories/Numbers/Natural/Abstract/NDiv0.v
     theories/Numbers/Natural/Abstract/NMaxMin.v
     theories/Numbers/Natural/Abstract/NParity.v
     theories/Numbers/Natural/Abstract/NPow.v
@@ -304,6 +305,7 @@ through the <tt>Require Import</tt> command.</p>
     theories/Numbers/Natural/Abstract/NLog.v
     theories/Numbers/Natural/Abstract/NGcd.v
     theories/Numbers/Natural/Abstract/NLcm.v
+    theories/Numbers/Natural/Abstract/NLcm0.v
     theories/Numbers/Natural/Abstract/NBits.v
     theories/Numbers/Natural/Abstract/NProperties.v
     theories/Numbers/Natural/Binary/NBinary.v

--- a/test-suite/output/Search.out
+++ b/test-suite/output/Search.out
@@ -424,8 +424,8 @@ Bool.orb_comm: forall b1 b2 : bool, (b1 || b2)%bool = (b2 || b1)%bool
 Bool.andb_comm: forall b1 b2 : bool, (b1 && b2)%bool = (b2 && b1)%bool
 Nat.eqb_sym: forall x y : nat, (x =? y) = (y =? x)
 Nat.bit0_eqb: forall a : nat, Nat.testbit a 0 = (a mod 2 =? 1)
+Nat.Div0.div_exact: forall a b : nat, a = b * (a / b) <-> a mod b = 0
 Nat.land_ones: forall a n : nat, Nat.land a (Nat.ones n) = a mod 2 ^ n
-Nat.div_exact: forall a b : nat, b <> 0 -> a = b * (a / b) <-> a mod b = 0
 Nat.testbit_spec':
   forall a n : nat, Nat.b2n (Nat.testbit a n) = (a / 2 ^ n) mod 2
 Nat.pow_div_l:
@@ -436,8 +436,8 @@ Nat.testbit_false:
 Nat.testbit_true:
   forall a n : nat, Nat.testbit a n = true <-> (a / 2 ^ n) mod 2 = 1
 Nat.bit0_eqb: forall a : nat, Nat.testbit a 0 = (a mod 2 =? 1)
+Nat.Div0.div_exact: forall a b : nat, a = b * (a / b) <-> a mod b = 0
 Nat.land_ones: forall a n : nat, Nat.land a (Nat.ones n) = a mod 2 ^ n
-Nat.div_exact: forall a b : nat, b <> 0 -> a = b * (a / b) <-> a mod b = 0
 Nat.testbit_spec':
   forall a n : nat, Nat.b2n (Nat.testbit a n) = (a / 2 ^ n) mod 2
 Nat.pow_div_l:

--- a/test-suite/output/Search.v
+++ b/test-suite/output/Search.v
@@ -6,7 +6,7 @@ Search (@eq nat).			(* complex pattern *)
 Search (@eq _ _ true).
 Search (@eq _ _ _) true -false.         (* andb_prop *)
 Search (@eq _ _ _) true -false "prop" -"intro".  (* andb_prop *)
-       
+
 Definition newdef := fun x:nat => x.
 
 Goal forall n:nat, n <> newdef n -> newdef n <> n -> False.

--- a/theories/Arith/PeanoNat.v
+++ b/theories/Arith/PeanoNat.v
@@ -745,9 +745,15 @@ Proof. inversion H. Qed.
 Definition shiftl_spec_high a n m (_:0<=m) := shiftl_specif_high a n m.
 Definition shiftr_spec a n m (_:0<=m) := shiftr_specif a n m.
 
+Lemma div_0_r a : a / 0 = 0.
+Proof. reflexivity. Qed.
+
+Lemma mod_0_r a : a mod 0 = a.
+Proof. reflexivity. Qed.
+
 (** Properties of advanced functions (pow, sqrt, log2, ...) *)
 
-Include NExtraProp.
+Include NExtraPreProp <+ NExtraProp0.
 
 (** Properties of tail-recursive addition and multiplication *)
 

--- a/theories/NArith/BinNat.v
+++ b/theories/NArith/BinNat.v
@@ -884,10 +884,16 @@ Proof.
  - apply pos_ldiff_spec.
 Qed.
 
+Lemma div_0_r a : a / 0 = 0.
+Proof. now destruct a. Qed.
+
+Lemma mod_0_r a : a mod 0 = a.
+Proof. now destruct a. Qed.
+
 (** Instantiation of generic properties of advanced functions
     (pow, sqrt, log2, div, gcd, ...) *)
 
-Include NExtraProp.
+Include NExtraPreProp <+ NExtraProp0.
 
 (** In generic statements, the predicates [lt] and [le] have been
   favored, whereas [gt] and [ge] don't even exist in the abstract

--- a/theories/Numbers/Integer/Abstract/ZGcd.v
+++ b/theories/Numbers/Integer/Abstract/ZGcd.v
@@ -170,13 +170,11 @@ Proof.
   (* First, a version restricted to natural numbers *)
   assert (aux : forall n, 0<=n -> forall m, 0<=m -> Bezout n m (gcd n m)). {
     intros n Hn; pattern n.
-    apply (fun H => strong_right_induction _ H 0); trivial.
-    { unfold Bezout. solve_proper. }
+    apply (fun H => strong_right_induction H 0); trivial.
     clear n Hn. intros n Hn IHn.
     apply le_lteq in Hn; destruct Hn as [Hn|Hn].
     - intros m Hm; pattern m.
-      apply (fun H => strong_right_induction _ H 0); trivial.
-      { unfold Bezout. solve_proper. }
+      apply (fun H => strong_right_induction H 0); trivial.
       clear m Hm. intros m Hm IHm.
       destruct (lt_trichotomy n m) as [LT|[EQ|LT]].
       + (* n < m *)

--- a/theories/Numbers/NatInt/NZDiv.v
+++ b/theories/Numbers/NatInt/NZDiv.v
@@ -34,6 +34,13 @@ Module Type NZDivSpec (Import A : NZOrdAxiomsSig')(Import B : DivMod' A).
  Axiom mod_bound_pos : forall a b, 0<=a -> 0<b -> 0 <= a mod b < b.
 End NZDivSpec.
 
+(** Euclidean Division with a / 0 == 0 and a mod 0 == a *)
+
+Module Type NZDivSpec0 (Import A : Eq')(Import B : ZeroSuccPred' A)(Import C : DivMod' A).
+  Axiom div_0_r : forall a, a / 0 == 0.
+  Axiom mod_0_r : forall a, a mod 0 == a.
+End NZDivSpec0.
+
 (** The different divisions will only differ in the conditions
     they impose on [modulo]. For NZ, we have only described the
     behavior on positive numbers.
@@ -560,4 +567,3 @@ Proof.
 Qed.
 
 End NZDivProp.
-

--- a/theories/Numbers/Natural/Abstract/NBits.v
+++ b/theories/Numbers/Natural/Abstract/NBits.v
@@ -356,7 +356,7 @@ Qed.
 Lemma bits_inj : forall a b, testbit a === testbit b -> a == b.
 Proof.
  intros a. pattern a.
- apply strong_right_induction with 0;[solve_proper|clear a|apply le_0_l].
+ apply strong_right_induction with 0;[clear a|apply le_0_l].
  intros a _ IH b H.
  destruct (eq_0_gt_0_cases a) as [EQ|LT].
  - rewrite EQ in H |- *. symmetry. apply bits_inj_0.

--- a/theories/Numbers/Natural/Abstract/NDiv.v
+++ b/theories/Numbers/Natural/Abstract/NDiv.v
@@ -228,6 +228,21 @@ Lemma mod_mul_r : forall a b c, b~=0 -> c~=0 ->
  a mod (b*c) == a mod b + b*((a/b) mod c).
 Proof. intros. apply mod_mul_r; auto'. Qed.
 
+Lemma add_mul_mod_distr_l : forall a b c d, b~=0 -> 0<=d<c ->
+  (c*a+d) mod (c*b) == c*(a mod b)+d.
+Proof.
+  intros a b c d Hb ?. apply add_mul_mod_distr_l.
+  - apply le_0_l.
+  - assert (H'b := le_0_l b). order.
+  - assumption.
+Qed.
+
+Lemma add_mul_mod_distr_r : forall a b c d, b~=0 -> 0<=d<c ->
+  (a*c+d) mod (b*c) == (a mod b)*c+d.
+Proof.
+  intros a b c d ? ?. now rewrite !(mul_comm _ c), add_mul_mod_distr_l.
+Qed.
+
 (** A last inequality: *)
 
 Theorem div_mul_le:

--- a/theories/Numbers/Natural/Abstract/NDiv0.v
+++ b/theories/Numbers/Natural/Abstract/NDiv0.v
@@ -1,0 +1,340 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+Require Import NAxioms NSub NDiv.
+
+Module Type NDivPropPrivate (N : NAxiomsSig') (NP : NSubProp N).
+Declare Module Private_NDivProp : NDivProp N NP.
+End NDivPropPrivate.
+
+(** Properties of Euclidean Division with a / 0 == 0 and a mod 0 == a *)
+
+Module Type NDivProp0
+  (Import N : NAxiomsSig')
+  (Import NP : NSubProp N)
+  (Import D0 : NZDivSpec0 N N N)
+  (Import P : NDivPropPrivate N NP).
+
+Import Private_NDivProp.
+
+(** Let's now state again theorems, but without useless hypothesis. *)
+
+Module Div0.
+
+Lemma div_0_l : forall a, 0/a == 0.
+Proof.
+  intros a. destruct (eq_decidable a 0) as [->|Ha].
+  - apply div_0_r.
+  - now apply div_0_l.
+Qed.
+
+Lemma mod_0_l : forall a, 0 mod a == 0.
+Proof.
+  intros a. destruct (eq_decidable a 0) as [->|Hb].
+  - apply mod_0_r.
+  - now apply mod_0_l.
+Qed.
+
+#[local] Hint Rewrite div_0_l mod_0_l div_0_r mod_0_r : nz.
+
+Lemma div_mod : forall a b, a == b*(a/b) + (a mod b).
+Proof.
+  intros a b. destruct (eq_decidable b 0) as [->|Hb].
+  - now nzsimpl.
+  - now apply div_mod.
+Qed.
+
+Lemma mod_eq : forall a b, a mod b == a - b*(a/b).
+Proof.
+  intros a b. destruct (eq_decidable b 0) as [->|Hb].
+  - now nzsimpl.
+  - now apply mod_eq.
+Qed.
+
+Lemma mod_same : forall a, a mod a == 0.
+Proof.
+  intros a. destruct (eq_decidable a 0) as [->|Ha].
+  - now nzsimpl.
+  - now apply mod_same.
+Qed.
+
+Lemma mod_mul : forall a b, (a*b) mod b == 0.
+Proof.
+  intros a b. destruct (eq_decidable b 0) as [->|Hb].
+  - now nzsimpl.
+  - now apply mod_mul.
+Qed.
+
+Lemma mod_le : forall a b, a mod b <= a.
+Proof.
+  intros a b. destruct (eq_decidable b 0) as [->|Hb].
+  - now nzsimpl.
+  - now apply mod_le.
+Qed.
+
+Lemma div_le_mono : forall a b c, a<=b -> a/c <= b/c.
+Proof.
+  intros a b c. destruct (eq_decidable c 0) as [->|Hc].
+  - now nzsimpl.
+  - now apply div_le_mono.
+Qed.
+
+Lemma mul_div_le : forall a b, b*(a/b) <= a.
+Proof.
+  intros a b. destruct (eq_decidable b 0) as [->|Hb].
+  - nzsimpl. apply le_0_l.
+  - now apply mul_div_le.
+Qed.
+
+Lemma div_exact : forall a b, (a == b*(a/b) <-> a mod b == 0).
+Proof.
+  intros a b. destruct (eq_decidable b 0) as [->|Hb].
+  - now nzsimpl.
+  - now apply div_exact.
+Qed.
+
+Lemma div_lt_upper_bound : forall a b q, a < b*q -> a/b < q.
+Proof.
+  intros a b q. destruct (eq_decidable b 0) as [->|Hb].
+  - nzsimpl. now intros ?%nlt_0_r.
+  - now apply div_lt_upper_bound.
+Qed.
+
+Lemma div_le_upper_bound : forall a b q, a <= b*q -> a/b <= q.
+Proof.
+  intros a b c. destruct (eq_decidable b 0) as [->|Hb].
+  - nzsimpl. intros. apply le_0_l.
+  - now apply div_le_upper_bound.
+Qed.
+
+Lemma mod_add : forall a b c, (a + b * c) mod c == a mod c.
+Proof.
+  intros a b c. destruct (eq_decidable c 0) as [->|Hc].
+  - now nzsimpl.
+  - now apply mod_add.
+Qed.
+
+Lemma div_mul_cancel_r : forall a b c, c~=0 -> (a*c)/(b*c) == a/b.
+Proof.
+  intros a b c. destruct (eq_decidable b 0) as [->|Hb].
+  - now nzsimpl.
+  - now apply div_mul_cancel_r.
+Qed.
+
+Lemma div_mul_cancel_l : forall a b c, c~=0 -> (c*a)/(c*b) == a/b.
+Proof.
+  intros a b c. destruct (eq_decidable b 0) as [->|Hb].
+  - now nzsimpl.
+  - now apply div_mul_cancel_l.
+Qed.
+
+Lemma mul_mod_distr_r : forall a b c, (a*c) mod (b*c) == (a mod b) * c.
+Proof.
+  intros a b c. destruct (eq_decidable b 0) as [->|Hb].
+  - now nzsimpl.
+  - destruct (eq_decidable c 0) as [->|Hc].
+    + now nzsimpl.
+    + now apply mul_mod_distr_r.
+Qed.
+
+Lemma mul_mod_distr_l : forall a b c, (c*a) mod (c*b) == c * (a mod b).
+Proof.
+  intros a b c. destruct (eq_decidable b 0) as [->|Hb].
+  - now nzsimpl.
+  - destruct (eq_decidable c 0) as [->|Hc].
+    + now nzsimpl.
+    + now apply mul_mod_distr_l.
+Qed.
+
+Lemma mod_mod : forall a n, (a mod n) mod n == a mod n.
+Proof.
+  intros a n. destruct (eq_decidable n 0) as [->|Hn].
+  - now nzsimpl.
+  - now apply mod_mod.
+Qed.
+
+Lemma mul_mod_idemp_l : forall a b n, ((a mod n)*b) mod n == (a*b) mod n.
+Proof.
+  intros a b n. destruct (eq_decidable n 0) as [->|Hn].
+  - now nzsimpl.
+  - now apply mul_mod_idemp_l.
+Qed.
+
+Lemma mul_mod_idemp_r : forall a b n, (a*(b mod n)) mod n == (a*b) mod n.
+Proof.
+  intros a b n. destruct (eq_decidable n 0) as [->|Hn].
+  - now nzsimpl.
+  - now apply mul_mod_idemp_r.
+Qed.
+
+Lemma mul_mod : forall a b n, (a * b) mod n == ((a mod n) * (b mod n)) mod n.
+Proof.
+  intros a b n. destruct (eq_decidable n 0) as [->|Hn].
+  - now nzsimpl.
+  - now apply mul_mod.
+Qed.
+
+Lemma add_mod_idemp_l : forall a b n, ((a mod n)+b) mod n == (a+b) mod n.
+Proof.
+  intros a b n. destruct (eq_decidable n 0) as [->|Hn].
+  - now nzsimpl.
+  - now apply add_mod_idemp_l.
+Qed.
+
+Lemma add_mod_idemp_r : forall a b n, (a+(b mod n)) mod n == (a+b) mod n.
+Proof.
+  intros a b n. destruct (eq_decidable n 0) as [->|Hn].
+  - now nzsimpl.
+  - now apply add_mod_idemp_r.
+Qed.
+
+Lemma add_mod : forall a b n, (a+b) mod n == (a mod n + b mod n) mod n.
+Proof.
+  intros a b n. destruct (eq_decidable n 0) as [->|Hn].
+  - now nzsimpl.
+  - now apply add_mod.
+Qed.
+
+Lemma div_div : forall a b c, (a/b)/c == a/(b*c).
+Proof.
+  intros a b c. destruct (eq_decidable b 0) as [->|Hb].
+  - now nzsimpl.
+  - destruct (eq_decidable c 0) as [->|Hc].
+    + now nzsimpl.
+    + now apply div_div.
+Qed.
+
+Lemma mod_mul_r : forall a b c, a mod (b*c) == a mod b + b*((a/b) mod c).
+Proof.
+  intros a b c. destruct (eq_decidable b 0) as [->|Hb].
+  - now nzsimpl.
+  - destruct (eq_decidable c 0) as [->|Hc].
+    + nzsimpl. rewrite add_comm. apply div_mod.
+    + now apply mod_mul_r.
+Qed.
+
+Lemma add_mul_mod_distr_l : forall a b c d, d<c -> (c*a+d) mod (c*b) == c*(a mod b)+d.
+Proof.
+  intros a b c d ?. destruct (eq_decidable b 0) as [->|Hb].
+  - now nzsimpl.
+  - apply add_mul_mod_distr_l; intuition auto using le_0_l.
+Qed.
+
+Lemma add_mul_mod_distr_r : forall a b c d, d<c -> (a*c+d) mod (b*c) == (a mod b)*c+d.
+Proof.
+  intros a b c d ?. destruct (eq_decidable b 0) as [->|Hb].
+  - now nzsimpl.
+  - apply add_mul_mod_distr_r; intuition auto using le_0_l.
+Qed.
+
+Lemma div_mul_le : forall a b c, c*(a/b) <= (c*a)/b.
+Proof.
+  intros a b c. destruct (eq_decidable b 0) as [->|Hb].
+  - now nzsimpl.
+  - now apply div_mul_le.
+Qed.
+
+Lemma mod_divides : forall a b, (a mod b == 0 <-> exists c, a == b*c).
+Proof.
+  intros a b. destruct (eq_decidable b 0) as [Hb|Hb].
+  - split.
+    + intros Hab. exists 0. revert Hab. rewrite Hb. now nzsimpl.
+    + intros [c Hc]. revert Hc. rewrite Hb. now nzsimpl.
+  - now apply mod_divides.
+Qed.
+
+End Div0.
+
+(** Unchanged theorems. *)
+
+Definition mod_upper_bound := mod_upper_bound.
+Definition div_mod_unique := div_mod_unique.
+Definition div_unique := div_unique.
+Definition mod_unique := mod_unique.
+Definition div_unique_exact := div_unique_exact.
+Definition div_same := div_same.
+Definition div_small := div_small.
+Definition mod_small := mod_small.
+Definition div_1_r := div_1_r.
+Definition mod_1_r := mod_1_r.
+Definition div_1_l := div_1_l.
+Definition mod_1_l := mod_1_l.
+Definition div_mul := div_mul.
+Definition div_str_pos := div_str_pos.
+Definition div_small_iff := div_small_iff.
+Definition mod_small_iff := mod_small_iff.
+Definition div_str_pos_iff := div_str_pos_iff.
+Definition div_lt := div_lt.
+Definition mul_succ_div_gt := mul_succ_div_gt.
+Definition div_le_lower_bound := div_le_lower_bound.
+Definition div_le_compat_l := div_le_compat_l.
+Definition div_add := div_add.
+Definition div_add_l := div_add_l.
+
+(** Deprecation statements.
+    After deprecation phase, remove statements below
+    in favor of Div0 statements. *)
+
+#[deprecated(since="8.17",note="Use Div0.mod_eq instead.")]
+Notation mod_eq := mod_eq (only parsing).
+#[deprecated(since="8.17",note="Use Div0.mod_same instead.")]
+Notation mod_same := mod_same (only parsing).
+#[deprecated(since="8.17",note="Use Div0.div_0_l instead.")]
+Notation div_0_l := div_0_l (only parsing).
+#[deprecated(since="8.17",note="Use Div0.mod_0_l instead.")]
+Notation mod_0_l := mod_0_l (only parsing).
+#[deprecated(since="8.17",note="Use Div0.mod_mul instead.")]
+Notation mod_mul := mod_mul (only parsing).
+#[deprecated(since="8.17",note="Use Div0.mod_le instead.")]
+Notation mod_le := mod_le (only parsing).
+#[deprecated(since="8.17",note="Use Div0.div_le_mono instead.")]
+Notation div_le_mono := div_le_mono (only parsing).
+#[deprecated(since="8.17",note="Use Div0.mul_div_le instead.")]
+Notation mul_div_le := mul_div_le (only parsing).
+#[deprecated(since="8.17",note="Use Div0.div_exact instead.")]
+Notation div_exact := div_exact (only parsing).
+#[deprecated(since="8.17",note="Use Div0.div_lt_upper_bound instead.")]
+Notation div_lt_upper_bound := div_lt_upper_bound (only parsing).
+#[deprecated(since="8.17",note="Use Div0.div_le_upper_bound instead.")]
+Notation div_le_upper_bound := div_le_upper_bound (only parsing).
+#[deprecated(since="8.17",note="Use Div0.mod_add instead.")]
+Notation mod_add := mod_add (only parsing).
+#[deprecated(since="8.17",note="Use Div0.div_mul_cancel_r instead.")]
+Notation div_mul_cancel_r := div_mul_cancel_r (only parsing).
+#[deprecated(since="8.17",note="Use Div0.div_mul_cancel_l instead.")]
+Notation div_mul_cancel_l := div_mul_cancel_l (only parsing).
+#[deprecated(since="8.17",note="Use Div0.mul_mod_distr_r instead.")]
+Notation mul_mod_distr_r := mul_mod_distr_r (only parsing).
+#[deprecated(since="8.17",note="Use Div0.mul_mod_distr_l instead.")]
+Notation mul_mod_distr_l := mul_mod_distr_l (only parsing).
+#[deprecated(since="8.17",note="Use Div0.mod_mod instead.")]
+Notation mod_mod := mod_mod (only parsing).
+#[deprecated(since="8.17",note="Use Div0.mul_mod_idemp_l instead.")]
+Notation mul_mod_idemp_l := mul_mod_idemp_l (only parsing).
+#[deprecated(since="8.17",note="Use Div0.mul_mod_idemp_r instead.")]
+Notation mul_mod_idemp_r := mul_mod_idemp_r (only parsing).
+#[deprecated(since="8.17",note="Use Div0.mul_mod instead.")]
+Notation mul_mod := mul_mod (only parsing).
+#[deprecated(since="8.17",note="Use Div0.add_mod_idemp_l instead.")]
+Notation add_mod_idemp_l := add_mod_idemp_l (only parsing).
+#[deprecated(since="8.17",note="Use Div0.add_mod_idemp_r instead.")]
+Notation add_mod_idemp_r := add_mod_idemp_r (only parsing).
+#[deprecated(since="8.17",note="Use Div0.add_mod instead.")]
+Notation add_mod := add_mod (only parsing).
+#[deprecated(since="8.17",note="Use Div0.div_div instead.")]
+Notation div_div := div_div (only parsing).
+#[deprecated(since="8.17",note="Use Div0.mod_mul_r instead.")]
+Notation mod_mul_r := mod_mul_r (only parsing).
+#[deprecated(since="8.17",note="Use Div0.div_mul_le instead.")]
+Notation div_mul_le := div_mul_le (only parsing).
+#[deprecated(since="8.17",note="Use Div0.mod_divides instead.")]
+Notation mod_divides := mod_divides (only parsing).
+
+End NDivProp0.

--- a/theories/Numbers/Natural/Abstract/NLcm0.v
+++ b/theories/Numbers/Natural/Abstract/NLcm0.v
@@ -1,0 +1,144 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+Require Import NAxioms NSub NDiv0 NGcd NLcm.
+
+Module Type NLcmPropPrivate
+  (A : NAxiomsSig') (B : NSubProp A) (C : NDivPropPrivate A B) (D : NGcdProp A B).
+Declare Module Private_NLcmProp : NLcmProp A B (C.Private_NDivProp) D.
+End NLcmPropPrivate.
+
+Module Type NLcmProp0
+  (Import A : NAxiomsSig')
+  (Import B : NSubProp A)
+  (Import A' : NZDivSpec0 A A A)
+  (Import D : NGcdProp A B)
+  (Import C : NDivPropPrivate A B)
+  (Import C' : NDivProp0 A B A' C)
+  (Import E : NLcmPropPrivate A B C D).
+
+Import Private_NLcmProp.
+Import Div0.
+
+Definition lcm a b := a*(b/gcd a b).
+#[global] Instance lcm_wd : Proper (eq==>eq==>eq) lcm := lcm_wd.
+
+(* The types are restated to avoid [Private_NLcmProp.lcm] indirection. *)
+Definition gcd_div_gcd : forall a b g, g ~= 0 -> g == gcd a b ->
+  gcd (a / g) (b / g) == 1 := gcd_div_gcd.
+Definition divide_lcm_l : forall a b, (a | lcm a b) := divide_lcm_l.
+Definition gcd_div_swap : forall a b, a / gcd a b * b == a * (b / gcd a b) := gcd_div_swap.
+Definition divide_lcm_r : forall a b, (b | lcm a b) := divide_lcm_r.
+Definition lcm_least : forall a b c, (a | c) -> (b | c) -> (lcm a b | c) := lcm_least.
+Definition lcm_comm : forall a b, lcm a b == lcm b a := lcm_comm.
+Definition lcm_divide_iff : forall n m p, (lcm n m | p) <-> (n | p) /\ (m | p) := lcm_divide_iff.
+Definition lcm_assoc : forall n m p, lcm n (lcm m p) == lcm (lcm n m) p := lcm_assoc.
+Definition lcm_0_l : forall n, lcm 0 n == 0 := lcm_0_l.
+Definition lcm_0_r : forall n, lcm n 0 == 0 := lcm_0_r.
+Definition lcm_1_l : forall n, lcm 1 n == n := lcm_1_l.
+Definition lcm_1_r : forall n, lcm n 1 == n := lcm_1_r.
+Definition lcm_diag : forall n : t, lcm n n == n := lcm_diag.
+Definition lcm_eq_0 : forall n m, lcm n m == 0 <-> n == 0 \/ m == 0 := lcm_eq_0.
+Definition divide_lcm_eq_r : forall n m, (n | m) -> lcm n m == m := divide_lcm_eq_r.
+Definition divide_lcm_iff : forall n m, (n | m) <-> lcm n m == m := divide_lcm_iff.
+Definition lcm_mul_mono_l : forall n m p, lcm (p * n) (p * m) == p * lcm n m := lcm_mul_mono_l.
+Definition lcm_mul_mono_r : forall n m p, lcm (n * p) (m * p) == lcm n m * p := lcm_mul_mono_r.
+Definition gcd_1_lcm_mul : forall n m, n ~= 0 -> m ~= 0 ->
+  gcd n m == 1 <-> lcm n m == n * m := gcd_1_lcm_mul.
+Module Lcm0.
+
+#[local] Hint Rewrite div_0_l mod_0_l div_0_r mod_0_r gcd_0_l gcd_0_r : nz.
+
+Lemma mod_divide : forall a b, (a mod b == 0 <-> (b|a)).
+Proof.
+  intros a b. destruct (eq_decidable b 0) as [Hb|Hb].
+  - split.
+    + intros Hab. exists 0. revert Hab. rewrite Hb. now nzsimpl.
+    + intros [c Hc]. revert Hc. rewrite Hb. now nzsimpl.
+  - now apply mod_divide.
+Qed.
+
+Lemma divide_div_mul_exact : forall a b c, (b|a) -> (c*a)/b == c*(a/b).
+Proof.
+  intros a b c. destruct (eq_decidable b 0) as [->|Hb].
+  - now nzsimpl.
+  - now apply divide_div_mul_exact.
+Qed.
+
+Lemma gcd_div_factor : forall a b c, (c|a) -> (c|b) ->
+  gcd (a/c) (b/c) == (gcd a b)/c.
+Proof.
+  intros a b c. destruct (eq_decidable c 0) as [->|Hc].
+  - now nzsimpl.
+  - now apply gcd_div_factor.
+Qed.
+
+Lemma gcd_mod : forall a b, gcd (a mod b) b == gcd b a.
+Proof.
+  intros a b. destruct (eq_decidable b 0) as [->|Hb].
+  - now nzsimpl.
+  - now apply gcd_mod.
+Qed.
+
+Lemma lcm_equiv1 : forall a b, a * (b / gcd a b) == (a*b)/gcd a b.
+Proof.
+  intros a b. destruct (eq_decidable (gcd a b) 0) as [->|?].
+  - now nzsimpl.
+  - now apply lcm_equiv1.
+Qed.
+
+Lemma lcm_equiv2 : forall a b, (a / gcd a b) * b == (a*b)/gcd a b.
+Proof.
+  intros a b. destruct (eq_decidable (gcd a b) 0) as [->|?].
+  - now nzsimpl.
+  - now apply lcm_equiv2.
+Qed.
+
+Lemma divide_div : forall a b c, (a|b) -> (b|c) -> (b/a|c/a).
+Proof.
+  intros a b c. destruct (eq_decidable a 0) as [->|Ha].
+  - now nzsimpl.
+  - now apply divide_div.
+Qed.
+
+Lemma lcm_unique : forall n m p,
+  (n|p) -> (m|p) -> (forall q, (n|q) -> (m|q) -> (p|q)) -> lcm n m == p.
+Proof. intros n m p. apply lcm_unique, le_0_l. Qed.
+
+Lemma lcm_unique_alt : forall n m p,
+  (forall q, (p|q) <-> (n|q) /\ (m|q)) -> lcm n m == p.
+Proof. intros n m p. apply lcm_unique_alt, le_0_l. Qed.
+
+End Lcm0.
+
+(** Deprecation statements.
+    After deprecation phase, remove statements below
+    in favor of Lcm0 statements. *)
+
+#[deprecated(since="8.17",note="Use Lcm0.mod_divide instead.")]
+Notation mod_divide := mod_divide (only parsing).
+#[deprecated(since="8.17",note="Use Lcm0.divide_div_mul_exact instead.")]
+Notation divide_div_mul_exact := divide_div_mul_exact (only parsing).
+#[deprecated(since="8.17",note="Use Lcm0.gcd_div_factor instead.")]
+Notation gcd_div_factor := gcd_div_factor (only parsing).
+#[deprecated(since="8.17",note="Use Lcm0.gcd_mod instead.")]
+Notation gcd_mod := gcd_mod (only parsing).
+#[deprecated(since="8.17",note="Use Lcm0.gcd_mod instead.")]
+Notation lcm_equiv1 := lcm_equiv1 (only parsing).
+#[deprecated(since="8.17",note="Use Lcm0.lcm_equiv2 instead.")]
+Notation lcm_equiv2 := lcm_equiv2 (only parsing).
+#[deprecated(since="8.17",note="Use Lcm0.divide_div instead.")]
+Notation divide_div := divide_div (only parsing).
+#[deprecated(since="8.17",note="Use Lcm0.lcm_unique instead.")]
+Notation lcm_unique := lcm_unique (only parsing).
+#[deprecated(since="8.17",note="Use Lcm0.lcm_unique_alt instead.")]
+Notation lcm_unique_alt := lcm_unique_alt (only parsing).
+
+End NLcmProp0.

--- a/theories/Numbers/Natural/Abstract/NOrder.v
+++ b/theories/Numbers/Natural/Abstract/NOrder.v
@@ -252,5 +252,12 @@ intros n m; cases n.
 - intro n. rewrite pred_succ. apply succ_le_mono.
 Qed.
 
-End NOrderProp.
+Lemma measure_induction : forall (X : Type) (f : X -> t) (A : X -> Type),
+  (forall x, (forall y, f y < f x -> A y) -> A x) ->
+  forall x, A x.
+Proof.
+  intros X f A IH x. apply (measure_right_induction X f A 0); [|apply le_0_l].
+  intros y _ IH'. apply IH. intros. apply IH'. now split; [apply le_0_l|].
+Defined.
 
+End NOrderProp.

--- a/theories/Numbers/Natural/Abstract/NProperties.v
+++ b/theories/Numbers/Natural/Abstract/NProperties.v
@@ -9,7 +9,7 @@
 (************************************************************************)
 
 Require Export NAxioms.
-Require Import NMaxMin NParity NPow NSqrt NLog NDiv NGcd NLcm NBits.
+Require Import NMaxMin NParity NPow NSqrt NLog NDiv NDiv0 NGcd NLcm NLcm0 NBits.
 
 (** The two following functors summarize all known facts about N.
 
@@ -18,13 +18,23 @@ Require Import NMaxMin NParity NPow NSqrt NLog NDiv NGcd NLcm NBits.
 
     - [NExtraProp] provides properties of advanced functions:
       pow, sqrt, log2, div, gcd, and bitwise functions.
+      [NExtraProp0] additionally assumes a / 0 == 0 and a mod 0 == a.
 
     If necessary, the earlier all-in-one functor [NProp]
     could be re-obtained via [NBasicProp <+ NExtraProp] *)
 
 Module Type NBasicProp (N:NAxiomsMiniSig) := NMaxMinProp N.
 
+Module Type NExtraPreProp (N:NAxiomsSig)(P:NBasicProp N) :=
+ NParityProp N P <+ NPowProp N P <+ NSqrtProp N P <+ NLog2Prop N P <+ NGcdProp N P.
+
 Module Type NExtraProp (N:NAxiomsSig)(P:NBasicProp N) :=
- NParityProp N P <+ NPowProp N P <+ NSqrtProp N P
-  <+ NLog2Prop N P <+ NDivProp N P <+ NGcdProp N P <+ NLcmProp N P
-  <+ NBitsProp N P.
+ NExtraPreProp N P <+ NDivProp N P <+ NLcmProp N P <+ NBitsProp N P.
+
+Module Type NExtraProp0 (N:NAxiomsSig)(P:NBasicProp N)(D0:NZDivSpec0 N N N)(E:NExtraPreProp N P).
+ Module Private_NDivProp := Nop <+ NDivProp N P.
+ Include NDivProp0 N P D0.
+ Module Private_NLcmProp := Nop <+ NLcmProp N P Private_NDivProp E.
+ Include NLcmProp0 N P D0 E.
+ Include NBitsProp N P E E Private_NDivProp E.
+End NExtraProp0.


### PR DESCRIPTION
This is a follow-up to uniformization of `div` and `mod` in https://github.com/coq/coq/pull/14086.
As a consequence, we can uniformly derive stronger lemmas for `Nat` and `N` assuming `a / 0 == 0` and `a mod 0 == a`.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Closes https://github.com/coq/coq/issues/16186

The basic idea is to have an abstract, optional specification
```coq
Module Type NZDivSpec0 (Import A : Eq')(Import B : ZeroSuccPred' A)(Import C : DivMod' A).
  Axiom div_0_r : forall a, a / 0 == 0.
  Axiom mod_0_r : forall a, a mod 0 == a.
End NZDivSpec0.
```
In addition, modules `NDiv0.NDivProp0` (as apposed to `NDiv.NDivProp`) and `NLcm0.NLcmProp0` (as apposed to `NLcm.NLcmProp`) provide stronger lemmas based on `NZDivSpec0`. For example: 
```coq
(* NDivProp  *) Lemma div_div : forall a b c, b~=0 -> c~=0 -> (a/b)/c == a/(b*c).
(* NDivProp0 *) Lemma Div0.div_div : forall a b c, (a/b)/c == a/(b*c).
```
Any number system which satisfies `NZDivSpec0` may for free benefit from the stronger lemmas.

- We instantiate `PeanoNat.Nat` and `BinNat.N` as above.
- We do **not** deprecate `NDivProp` or `NLcmProp`, which are valid (and useful) for number systems that do not satisfy `NZDivSpec0`.
- We do **not** touch `Z`, which is a separate concern.

### Deprecation Phases
We aim for maximal compatibility for each phase with deprecation warnings.
#### Phase 1
- Stronger lemmas are encapsulated in `Div0` and `Lcm0` modules.
- Weaker lemmas encapsulated in `Notation` with a `deprecated` attribute.
- `Search` does not display weaker lemmas due to `Private_` prefix.
#### Phase 2
- Stronger lemmas are both top-level and in `Div0` and `Lcm0` modules.
- Weaker lemmas are removed.
- `Div0` and `Lcm0` modules are deprecated.
#### Phase 3
- Modules `Div0` and `Lcm0` are removed.

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: 
- [ ] Added / updated **test-suite**.
-->

<!-- If this is a feature pull request / breaks compatibility: 
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
-->
  <!-- Check if the following applies, otherwise remove these lines. 
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make -f Makefile.dune doc_gram_rsts`.
-->

<!-- If this breaks external libraries or plugins in CI: 
- [ ] Opened **overlay** pull requests.
-->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
