### PR TITLE
Remove UnknownIfTermOrType constructor from Pretyping.typing_constraint

### DIFF
--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -85,6 +85,8 @@ val intern_gen : typing_constraint -> env -> evar_map ->
   ?impls:internalization_env -> ?pattern_mode:bool -> ?ltacvars:ltac_sign ->
   constr_expr -> glob_constr
 
+val intern_unknown_if_term_or_type : env -> evar_map -> constr_expr -> glob_constr
+
 val intern_pattern : env -> cases_pattern_expr ->
   lident list * (Id.t Id.Map.t * cases_pattern) list
 

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -47,7 +47,7 @@ open Evarconv
 
 module NamedDecl = Context.Named.Declaration
 
-type typing_constraint = UnknownIfTermOrType | IsType | OfType of types | WithoutTypeConstraint
+type typing_constraint = IsType | OfType of types | WithoutTypeConstraint
 
 let (!!) env = GlobEnv.env env
 
@@ -1374,7 +1374,7 @@ let ise_pretype_gen (flags : inference_flags) env sigma lvar kind c =
   let hypnaming = if flags.program_mode then ProgramNaming vars else RenameExistingBut vars in
   let env = GlobEnv.make ~hypnaming env sigma lvar in
   let sigma', c', c'_ty = match kind with
-    | WithoutTypeConstraint | UnknownIfTermOrType ->
+    | WithoutTypeConstraint ->
       let sigma, j = pretype ~flags:pretype_flags empty_tycon env sigma c in
       sigma, j.uj_val, j.uj_type
     | OfType exptyp ->

--- a/pretyping/pretyping.mli
+++ b/pretyping/pretyping.mli
@@ -36,7 +36,6 @@ val search_guard :
   ?loc:Loc.t -> env -> int list list -> Constr.rec_declaration -> int array
 
 type typing_constraint =
-  | UnknownIfTermOrType (** E.g., unknown if manual implicit arguments allowed *)
   | IsType (** Necessarily a type *)
   | OfType of types (** A term of the expected type *)
   | WithoutTypeConstraint (** A term of unknown expected type *)

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1962,7 +1962,8 @@ let query_command_selector ?loc = function
 let vernac_check_may_eval ~pstate redexp glopt rc =
   let glopt = query_command_selector glopt in
   let sigma, env = get_current_context_of_args ~pstate glopt in
-  let sigma, c = Constrintern.interp_open_constr ~expected_type:Pretyping.UnknownIfTermOrType env sigma rc in
+  let gc = Constrintern.intern_unknown_if_term_or_type env sigma rc in
+  let sigma, c = Pretyping.understand_tcc env sigma gc in
   let sigma = Evarconv.solve_unif_constraints_with_heuristics env sigma in
   Evarconv.check_problems_are_solved env sigma;
   let sigma = Evd.minimize_universes sigma in


### PR DESCRIPTION
It's used only for Check in the intern phase, pretyping treats it as WithoutTypeConstraint
