### PR TITLE
Cleanup open modules in `library/`

### DIFF
--- a/library/coqlib.ml
+++ b/library/coqlib.ml
@@ -8,9 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open CErrors
 open Util
-open Pp
 open Names
 open Libnames
 
@@ -52,7 +50,7 @@ let check_ind_ref s ind =
 let lib_ref s =
   try CString.Map.find s !table
   with Not_found ->
-    user_err Pp.(str "not found in table: " ++ str s)
+    CErrors.user_err Pp.(str "not found in table: " ++ str s)
 
 let add_ref s c =
   table := CString.Map.add s c !table
@@ -89,16 +87,16 @@ let gen_reference_in_modules locstr dirs s =
   match these with
     | [x] -> x
     | [] ->
-        anomaly ~label:locstr (str "cannot find " ++ str s ++
-        str " in module" ++ str (if List.length dirs > 1 then "s " else " ") ++
-        prlist_with_sep pr_comma DirPath.print dirs ++ str ".")
+      CErrors.anomaly ~label:locstr Pp.(str "cannot find " ++ str s
+        ++ str " in module" ++ str (if List.length dirs > 1 then "s " else " ")
+        ++ prlist_with_sep pr_comma DirPath.print dirs ++ str ".")
     | l ->
-      anomaly ~label:locstr
-        (str "ambiguous name " ++ str s ++ str " can represent " ++
-           prlist_with_sep pr_comma
-           (fun x -> Libnames.pr_path (Nametab.path_of_global x)) l ++
-           str " in module" ++ str (if List.length dirs > 1 then "s " else " ") ++
-           prlist_with_sep pr_comma DirPath.print dirs ++ str ".")
+      CErrors.anomaly ~label:locstr
+        Pp.(str "ambiguous name " ++ str s ++ str " can represent "
+          ++ prlist_with_sep pr_comma (fun x ->
+            Libnames.pr_path (Nametab.path_of_global x)) l ++ str " in module"
+          ++ str (if List.length dirs > 1 then "s " else " ")
+          ++ prlist_with_sep pr_comma DirPath.print dirs ++ str ".")
 
 (* For tactics/commands requiring vernacular libraries *)
 
@@ -113,8 +111,8 @@ let check_required_library d =
       | _ -> false
     in
     if not in_current_dir then
-      user_err
-        (str "Library " ++ DirPath.print dir ++ str " has to be required first.")
+      CErrors.user_err Pp.(str "Library " ++ DirPath.print dir
+        ++ str " has to be required first.")
 
 (************************************************************************)
 (* Specific Coq objects                                                 *)
@@ -321,4 +319,4 @@ let coq_or_ref     = Lazy.from_fun build_coq_or
 let coq_iff_ref    = Lazy.from_fun build_coq_iff
 
 (** Deprecated functions that search by library name. *)
-let build_sigma_set () = anomaly (Pp.str "Use build_sigma_type.")
+let build_sigma_set () = CErrors.anomaly (Pp.str "Use build_sigma_type.")

--- a/library/coqlib.ml
+++ b/library/coqlib.ml
@@ -10,7 +10,6 @@
 
 open Util
 open Names
-open Libnames
 
 let make_dir l = DirPath.make (List.rev_map Id.of_string l)
 
@@ -75,12 +74,12 @@ let register_ref s c =
 (* Generic functions to find Coq objects *)
 
 let has_suffix_in_dirs dirs ref =
-  let dir = dirpath (Nametab.path_of_global ref) in
-  List.exists (fun d -> is_dirpath_prefix_of d dir) dirs
+  let dir = Libnames.dirpath (Nametab.path_of_global ref) in
+  List.exists (fun d -> Libnames.is_dirpath_prefix_of d dir) dirs
 
 let gen_reference_in_modules locstr dirs s =
   let dirs = List.map make_dir dirs in
-  let qualid = qualid_of_string s in
+  let qualid = Libnames.qualid_of_string s in
   let all = Nametab.locate_all qualid in
   let all = List.sort_uniquize GlobRef.UserOrd.compare all in
   let these = List.filter (has_suffix_in_dirs dirs) all in

--- a/library/global.ml
+++ b/library/global.ml
@@ -9,7 +9,6 @@
 (************************************************************************)
 
 open Names
-open Environ
 
 (** We introduce here the global environment of the system,
     and we declare it as a synchronized table. *)
@@ -118,19 +117,19 @@ let add_module_parameter mbid mte inl =
 
 (** Queries on the global environment *)
 
-let universes () = universes (env())
-let universes_lbound () = universes_lbound (env())
-let named_context () = named_context (env())
-let named_context_val () = named_context_val (env())
+let universes () = Environ.universes (env())
+let universes_lbound () = Environ.universes_lbound (env())
+let named_context () = Environ.named_context (env())
+let named_context_val () = Environ.named_context_val (env())
 
-let lookup_named id = lookup_named id (env())
-let lookup_constant kn = lookup_constant kn (env())
+let lookup_named id = Environ.lookup_named id (env())
+let lookup_constant kn = Environ.lookup_constant kn (env())
 let lookup_inductive ind = Inductive.lookup_mind_specif (env()) ind
 let lookup_pinductive (ind,_) = Inductive.lookup_mind_specif (env()) ind
-let lookup_mind kn = lookup_mind kn (env())
+let lookup_mind kn = Environ.lookup_mind kn (env())
 
-let lookup_module mp = lookup_module mp (env())
-let lookup_modtype kn = lookup_modtype kn (env())
+let lookup_module mp = Environ.lookup_module mp (env())
+let lookup_modtype kn = Environ.lookup_modtype kn (env())
 
 let exists_objlabel id = Safe_typing.exists_objlabel id (safe_env ())
 
@@ -181,15 +180,19 @@ let import c u d = globalize (Safe_typing.import c u d)
     environment and a given context. *)
 
 let env_of_context hyps =
-  reset_with_named_context hyps (env())
+  Environ.reset_with_named_context hyps (env())
 
-let is_polymorphic r = Environ.is_polymorphic (env()) r
+let is_polymorphic r =
+  Environ.is_polymorphic (env()) r
 
-let is_template_polymorphic r = is_template_polymorphic (env ()) r
+let is_template_polymorphic r =
+  Environ.is_template_polymorphic (env ()) r
 
-let get_template_polymorphic_variables r = get_template_polymorphic_variables (env ()) r
+let get_template_polymorphic_variables r =
+  Environ.get_template_polymorphic_variables (env ()) r
 
-let is_type_in_type r = is_type_in_type (env ()) r
+let is_type_in_type r =
+  Environ.is_type_in_type (env ()) r
 
 let current_modpath () =
   Safe_typing.current_modpath (safe_env ())

--- a/library/globnames.ml
+++ b/library/globnames.ml
@@ -10,7 +10,6 @@
 
 open Names
 open Constr
-open Mod_subst
 
 type global_reference = GlobRef.t =
   | VarRef of variable     [@ocaml.deprecated "Use Names.GlobRef.VarRef"]
@@ -35,25 +34,25 @@ let destConstructRef = function ConstructRef ind -> ind | _ -> failwith "destCon
 let subst_global_reference subst ref = match ref with
   | VarRef var -> ref
   | ConstRef kn ->
-    let kn' = subst_constant subst kn in
+    let kn' = Mod_subst.subst_constant subst kn in
       if kn==kn' then ref else ConstRef kn'
   | IndRef ind ->
-    let ind' = subst_ind subst ind in
+    let ind' = Mod_subst.subst_ind subst ind in
       if ind==ind' then ref else IndRef ind'
   | ConstructRef ((kn,i),j as c) ->
-    let c' = subst_constructor subst c in
+    let c' = Mod_subst.subst_constructor subst c in
     if c'==c then ref else ConstructRef c'
 
 let subst_global subst ref = match ref with
   | VarRef var -> ref, None
   | ConstRef kn ->
-     let kn',t = subst_con subst kn in
+     let kn',t = Mod_subst.subst_con subst kn in
       if kn==kn' then ref, None else ConstRef kn', t
   | IndRef ind ->
-      let ind' = subst_ind subst ind in
+      let ind' = Mod_subst.subst_ind subst ind in
       if ind==ind' then ref, None else IndRef ind', None
   | ConstructRef ((kn,i),j as c) ->
-      let c' = subst_constructor subst c in
+      let c' = Mod_subst.subst_constructor subst c in
       if c'==c then ref,None else ConstructRef c', None
 
 let canonical_gr = function
@@ -118,5 +117,5 @@ module ExtRefMap = HMap.Make(ExtRefOrdered)
 module ExtRefSet = ExtRefMap.Set
 
 let subst_extended_reference sub = function
-  | Abbrev kn -> Abbrev (subst_kn sub kn)
+  | Abbrev kn -> Abbrev (Mod_subst.subst_kn sub kn)
   | TrueGlobal gr -> TrueGlobal (subst_global_reference sub gr)

--- a/library/goptions.ml
+++ b/library/goptions.ml
@@ -10,8 +10,6 @@
 
 (* This module manages customization parameters at the vernacular level     *)
 
-open Pp
-open CErrors
 open Util
 open Libobject
 open Libnames
@@ -39,12 +37,14 @@ type option_state = {
 let nickname table = String.concat " " table
 
 let error_no_table_of_this_type ~kind key =
-  user_err
-    (str ("There is no " ^ kind ^ "-valued table with this name: \"" ^ nickname key ^ "\"."))
+  CErrors.user_err
+    Pp.(str ("There is no " ^ kind ^ "-valued table with this name: \""
+      ^ nickname key ^ "\"."))
 
 let error_undeclared_key key =
-  user_err
-    (str ("There is no flag, option or table with this name: \"" ^ nickname key ^ "\"."))
+  CErrors.user_err
+    Pp.(str ("There is no flag, option or table with this name: \""
+      ^ nickname key ^ "\"."))
 
 (****************************************************************************)
 (* 1- Tables                                                                *)
@@ -77,9 +77,11 @@ module MakeTable =
 
     let nick = nickname A.key
 
-    let _ =
+    let () =
       if String.List.mem_assoc nick !A.table then
-        user_err Pp.(str "Sorry, this table name (" ++ str nick ++ str ") is already used.")
+        CErrors.user_err
+          Pp.(strbrk "Sorry, this table name (" ++ str nick
+            ++ strbrk ") is already used.")
 
     module MySet = A.Set
 
@@ -108,7 +110,7 @@ module MakeTable =
 
     let print_table table_name printer table =
       Feedback.msg_notice
-        (str table_name ++
+        Pp.(str table_name ++
            (hov 0
               (if MySet.is_empty table then str " None" ++ fnl ()
                else MySet.fold
@@ -151,7 +153,7 @@ struct
   let table = string_table
   let encode _env x = x
   let subst _ x = x
-  let printer = str
+  let printer = Pp.str
   let key = A.key
   let title = A.title
   let member_message = A.member_message
@@ -239,18 +241,19 @@ let get_option key = OptionMap.find key !value_tab
 
 let check_key key = try
   let _ = get_option key in
-  user_err Pp.(str "Sorry, this option name ("++ str (nickname key) ++ str ") is already used.")
+  CErrors.user_err Pp.(str "Sorry, this option name ("
+    ++ str (nickname key) ++ str ") is already used.")
 with Not_found ->
   if String.List.mem_assoc (nickname key) !string_table
     || String.List.mem_assoc (nickname key) !ref_table
-  then user_err Pp.(str "Sorry, this option name (" ++ str (nickname key) ++ str ") is already used.")
+  then CErrors.user_err Pp.(str "Sorry, this option name ("
+    ++ str (nickname key) ++ str ") is already used.")
 
 open Libobject
 
 let warn_deprecated_option =
-  CWarnings.create ~name:"deprecated-option" ~category:"deprecated"
-         (fun key -> str "Option" ++ spc () ++ str (nickname key) ++
-                       strbrk " is deprecated")
+  CWarnings.create ~name:"deprecated-option" ~category:"deprecated" (fun key ->
+    Pp.(str "Option" ++ spc () ++ str (nickname key) ++ strbrk " is deprecated"))
 
 let declare_option cast uncast append ?(preprocess = fun x -> x)
   { optdepr=depr; optkey=key; optread=read; optwrite=write } =
@@ -305,23 +308,23 @@ let declare_option cast uncast append ?(preprocess = fun x -> x)
 let declare_int_option =
   declare_option
     (fun v -> IntValue v)
-    (function IntValue v -> v | _ -> anomaly (Pp.str "async_option."))
-    (fun _ _ -> anomaly (Pp.str "async_option."))
+    (function IntValue v -> v | _ -> CErrors.anomaly (Pp.str "async_option."))
+    (fun _ _ -> CErrors.anomaly (Pp.str "async_option."))
 let declare_bool_option =
   declare_option
     (fun v -> BoolValue v)
-    (function BoolValue v -> v | _ -> anomaly (Pp.str "async_option."))
-    (fun _ _ -> anomaly (Pp.str "async_option."))
+    (function BoolValue v -> v | _ -> CErrors.anomaly (Pp.str "async_option."))
+    (fun _ _ -> CErrors.anomaly (Pp.str "async_option."))
 let declare_string_option =
   declare_option
     (fun v -> StringValue v)
-    (function StringValue v -> v | _ -> anomaly (Pp.str "async_option."))
+    (function StringValue v -> v | _ -> CErrors.anomaly (Pp.str "async_option."))
     (fun x y -> x^","^y)
 let declare_stringopt_option =
   declare_option
     (fun v -> StringOptValue v)
-    (function StringOptValue v -> v | _ -> anomaly (Pp.str "async_option."))
-    (fun _ _ -> anomaly (Pp.str "async_option."))
+    (function StringOptValue v -> v | _ -> CErrors.anomaly (Pp.str "async_option."))
+    (fun _ _ -> CErrors.anomaly (Pp.str "async_option."))
 
 
 type 'a opt_decl = depr:bool -> key:option_name -> 'a
@@ -416,7 +419,7 @@ let declare_interpreted_string_option_and_ref ~depr ~key ~(value:'a) from_string
 let warn_unknown_option =
   CWarnings.create
     ~name:"unknown-option" ~category:"option"
-    (fun key -> strbrk "There is no flag or option with this name: \"" ++
+    Pp.(fun key -> strbrk "There is no flag or option with this name: \"" ++
                   str (nickname key) ++ str "\".")
 
 let set_option_value ?(locality = OptDefault) check_and_cast key v =
@@ -427,12 +430,11 @@ let set_option_value ?(locality = OptDefault) check_and_cast key v =
     write locality (check_and_cast v (read ()))
 
 let bad_type_error ~expected ~got =
-  user_err Pp.(str "Bad type of value for this option:" ++ spc() ++
-               str "expected " ++ str expected ++
-               str ", got " ++ str got ++ str ".")
+  CErrors.user_err Pp.(strbrk "Bad type of value for this option:" ++ spc()
+    ++ str "expected " ++ str expected ++ str ", got " ++ str got ++ str ".")
 
 let error_flag () =
-  user_err Pp.(str "This is a flag. It does not take a value.")
+  CErrors.user_err Pp.(str "This is a flag. It does not take a value.")
 
 let check_int_value v = function
   | BoolValue _ -> error_flag ()
@@ -442,7 +444,9 @@ let check_int_value v = function
 
 let check_bool_value v = function
   | BoolValue _ -> BoolValue v
-  | _ -> user_err Pp.(str "This is an option. A value must be provided.")
+  | _ ->
+      CErrors.user_err
+        Pp.(str "This is an option. A value must be provided.")
 
 let check_string_value v = function
   | BoolValue _ -> error_flag ()
@@ -454,7 +458,9 @@ let check_unset_value v = function
   | BoolValue _ -> BoolValue false
   | IntValue _ -> IntValue None
   | StringOptValue _ -> StringOptValue None
-  | StringValue _ -> user_err Pp.(str "This option does not support the \"Unset\" command.")
+  | StringValue _ ->
+      CErrors.user_err
+        Pp.(str "This option does not support the \"Unset\" command.")
 
 (* Nota: For compatibility reasons, some errors are treated as
    warnings. This allows a script to refer to an option that doesn't
@@ -482,25 +488,25 @@ let set_string_option_value opt v = set_string_option_value_gen opt v
 
 (* Printing options/tables *)
 
-let msg_option_value v =
-  match v with
-    | BoolValue true  -> str "on"
-    | BoolValue false -> str "off"
-    | IntValue (Some n) -> int n
-    | IntValue None   -> str "undefined"
-    | StringValue s   -> quote (str s)
-    | StringOptValue None   -> str"undefined"
-    | StringOptValue (Some s)   -> quote (str s)
-(*     | IdentValue r    -> pr_global_env Id.Set.empty r *)
+let msg_option_value = Pp.(function
+  | BoolValue true -> str "on"
+  | BoolValue false -> str "off"
+  | IntValue (Some n) -> int n
+  | IntValue None -> str "undefined"
+  | StringValue s -> quote (str s)
+  | StringOptValue None -> str "undefined"
+  | StringOptValue (Some s) -> quote (str s))
 
 let print_option_value key =
   let (depr, (read,_,_)) = get_option key in
   let s = read () in
   match s with
     | BoolValue b ->
-        Feedback.msg_notice (prlist_with_sep spc str key ++ str " is " ++ str (if b then "on" else "off"))
+        Feedback.msg_notice Pp.(prlist_with_sep spc str key ++ str " is "
+          ++ str (if b then "on" else "off"))
     | _ ->
-        Feedback.msg_notice (str "Current value of " ++ prlist_with_sep spc str key ++ str " is " ++ msg_option_value s)
+        Feedback.msg_notice Pp.(str "Current value of "
+          ++ prlist_with_sep spc str key ++ str " is " ++ msg_option_value s)
 
 let get_tables () =
   let tables = !value_tab in
@@ -514,6 +520,7 @@ let get_tables () =
   OptionMap.fold fold tables OptionMap.empty
 
 let print_tables () =
+  let open Pp in
   let print_option key value depr =
     let msg = str "  " ++ str (nickname key) ++ str ": " ++ msg_option_value value in
     if depr then msg ++ str " [DEPRECATED]" ++ fnl ()

--- a/library/goptions.ml
+++ b/library/goptions.ml
@@ -11,7 +11,6 @@
 (* This module manages customization parameters at the vernacular level     *)
 
 open Util
-open Libnames
 
 type option_name = string list
 type option_value =
@@ -22,7 +21,7 @@ type option_value =
 
 type table_value =
   | StringRefValue of string
-  | QualidRefValue of qualid
+  | QualidRefValue of Libnames.qualid
 
 (** Summary of an option status *)
 type option_state = {
@@ -169,7 +168,7 @@ module type RefConvertArg =
 sig
   type t
   module Set : CSig.SetS with type elt = t
-  val encode : Environ.env -> qualid -> t
+  val encode : Environ.env -> Libnames.qualid -> t
   val subst : Mod_subst.substitution -> t -> t
   val printer : t -> Pp.t
   val key : option_name
@@ -180,7 +179,7 @@ end
 module RefConvert = functor (A : RefConvertArg) ->
 struct
   type t = A.t
-  type key = qualid
+  type key = Libnames.qualid
   module Set = A.Set
   let table = ref_table
   let encode = A.encode

--- a/library/goptions.ml
+++ b/library/goptions.ml
@@ -15,7 +15,6 @@ open CErrors
 open Util
 open Libobject
 open Libnames
-open Mod_subst
 
 type option_name = string list
 type option_value =
@@ -65,7 +64,7 @@ module MakeTable =
           module Set : CSig.SetS with type elt = t
           val table : (string * key table_of_A) list ref
           val encode : Environ.env -> key -> t
-          val subst : substitution -> t -> t
+          val subst : Mod_subst.substitution -> t -> t
           val printer : t -> Pp.t
           val key : option_name
           val title : string
@@ -170,7 +169,7 @@ sig
   type t
   module Set : CSig.SetS with type elt = t
   val encode : Environ.env -> qualid -> t
-  val subst : substitution -> t -> t
+  val subst : Mod_subst.substitution -> t -> t
   val printer : t -> Pp.t
   val key : option_name
   val title : string

--- a/library/goptions.ml
+++ b/library/goptions.ml
@@ -11,7 +11,6 @@
 (* This module manages customization parameters at the vernacular level     *)
 
 open Util
-open Libobject
 open Libnames
 
 type option_name = string list
@@ -97,10 +96,10 @@ module MakeTable =
             if p' == p then obj else
               (f,p')
         in
-        let inGo : option_mark * A.t -> obj =
+        let inGo : option_mark * A.t -> Libobject.obj =
           Libobject.declare_object {(Libobject.default_object nick) with
                 Libobject.load_function = load_options;
-                Libobject.open_function = simple_open load_options;
+                Libobject.open_function = Libobject.simple_open load_options;
                 Libobject.cache_function = cache_options;
                 Libobject.subst_function = subst_options;
                 Libobject.classify_function = (fun x -> Substitute)}

--- a/library/goptions.mli
+++ b/library/goptions.mli
@@ -45,9 +45,6 @@
    All options are synchronized with the document.
 *)
 
-open Libnames
-open Mod_subst
-
 type option_name = string list
 
 type option_locality = OptDefault | OptLocal | OptExport | OptGlobal
@@ -89,8 +86,8 @@ module MakeRefTable :
     (A : sig
        type t
        module Set : CSig.SetS with type elt = t
-       val encode : Environ.env -> qualid -> t
-       val subst : substitution -> t -> t
+       val encode : Environ.env -> Libnames.qualid -> t
+       val subst : Mod_subst.substitution -> t -> t
        val printer : t -> Pp.t
        val key : option_name
        val title : string
@@ -167,7 +164,7 @@ type 'a table_of_A =  {
 val get_string_table :
   option_name -> string table_of_A
 val get_ref_table :
-  option_name -> qualid table_of_A
+  option_name -> Libnames.qualid table_of_A
 
 (** The first argument is a locality flag. *)
 val set_int_option_value_gen    : ?locality:option_locality -> option_name -> int option -> unit
@@ -190,7 +187,7 @@ type option_value =
 
 type table_value =
   | StringRefValue of string
-  | QualidRefValue of qualid
+  | QualidRefValue of Libnames.qualid
 
 val set_option_value : ?locality:option_locality ->
   ('a -> option_value -> option_value) -> option_name -> 'a -> unit

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -13,7 +13,6 @@ open CErrors
 open Util
 open Names
 open Libnames
-open Libobject
 
 type is_type = bool (* Module Type or just Module *)
 type export_flag = Export | Import
@@ -59,6 +58,7 @@ let classify_segment seg =
   let rec clean ((substl,keepl,anticipl) as acc) = function
     | [] -> acc
     | o :: stk ->
+      let open Libobject in
       begin match o with
         | ModuleObject _ | ModuleTypeObject _ | IncludeObject _ ->
           clean (o::substl, keepl, anticipl) stk
@@ -172,12 +172,12 @@ let add_leaf_entry leaf =
   lib_state := { !lib_state with lib_stk }
 
 let add_discharged_leaf obj =
-  let newobj = rebuild_object obj in
-  cache_object (prefix(),newobj);
+  let newobj = Libobject.rebuild_object obj in
+  Libobject.cache_object (prefix(),newobj);
   add_leaf_entry (AtomicObject newobj)
 
 let add_leaf obj =
-  cache_object (prefix(),obj);
+  Libobject.cache_object (prefix(),obj);
   add_leaf_entry (AtomicObject obj)
 
 (* Modules. *)
@@ -382,10 +382,10 @@ let open_section id =
 (* Restore lib_stk and summaries as before the section opening, and
    add a ClosedSection object. *)
 
-let discharge_item = function
+let discharge_item = Libobject.(function
   | ModuleObject _ | ModuleTypeObject _ | IncludeObject _ | KeepObject _
   | ExportObject _ -> None
-  | AtomicObject obj -> discharge_object obj
+  | AtomicObject obj -> discharge_object obj)
 
 let close_section () =
   let (secdecls,mark,before) = split_lib_at_opening () in

--- a/library/libnames.ml
+++ b/library/libnames.ml
@@ -8,8 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open Pp
-open CErrors
 open Util
 open Names
 
@@ -58,14 +56,16 @@ let add_dirpath_suffix p id = DirPath.make (id :: DirPath.repr p)
 let parse_dir s =
   let len = String.length s in
   let rec decoupe_dirs dirs n =
-    if Int.equal n len && n > 0 then user_err Pp.(str @@ s ^ " is an invalid path.");
+    if Int.equal n len && n > 0 then
+      CErrors.user_err Pp.(str @@ s ^ " is an invalid path.");
     if n >= len then dirs else
     let pos =
       try
         String.index_from s n '.'
       with Not_found -> len
     in
-    if Int.equal pos n then user_err Pp.(str @@ s ^ " is an invalid path.");
+    if Int.equal pos n then
+      CErrors.user_err Pp.(str @@ s ^ " is an invalid path.");
     let dir = String.sub s n (pos-n) in
     decoupe_dirs ((Id.of_string dir)::dirs) (pos+1)
   in
@@ -123,7 +123,7 @@ let path_of_string s =
   with
     | Invalid_argument _ -> invalid_arg "path_of_string"
 
-let pr_path sp = str (string_of_path sp)
+let pr_path sp = Pp.str (string_of_path sp)
 
 (*s qualified names *)
 type qualid_r = full_path

--- a/library/libobject.ml
+++ b/library/libobject.ml
@@ -9,7 +9,6 @@
 (************************************************************************)
 
 open Pp
-open Names
 
 module Dyn = Dyn.Make ()
 
@@ -116,17 +115,17 @@ type obj = Dyn.t (* persistent dynamic objects *)
 
 type algebraic_objects =
   | Objs of t list
-  | Ref of ModPath.t * Mod_subst.substitution
+  | Ref of Names.ModPath.t * Mod_subst.substitution
 
 and t =
-  | ModuleObject of Id.t * substitutive_objects
-  | ModuleTypeObject of Id.t * substitutive_objects
+  | ModuleObject of Names.Id.t * substitutive_objects
+  | ModuleTypeObject of Names.Id.t * substitutive_objects
   | IncludeObject of algebraic_objects
-  | KeepObject of Id.t * t list
-  | ExportObject of { mpl : (open_filter * ModPath.t) list }
+  | KeepObject of Names.Id.t * t list
+  | ExportObject of { mpl : (open_filter * Names.ModPath.t) list }
   | AtomicObject of obj
 
-and substitutive_objects = MBId.t list * algebraic_objects
+and substitutive_objects = Names.MBId.t list * algebraic_objects
 
 module DynMap = Dyn.Map (struct type 'a t = ('a, Nametab.object_prefix * 'a) object_declaration end)
 
@@ -139,7 +138,7 @@ let declare_object_full odecl =
   tag
 
 let make_oname Nametab.{ obj_dir; obj_mp } id =
-  Libnames.make_path obj_dir id, KerName.make obj_mp (Label.of_id id)
+  Libnames.make_path obj_dir id, Names.KerName.make obj_mp (Names.Label.of_id id)
 
 let declare_named_object_full odecl =
   let odecl =

--- a/library/libobject.ml
+++ b/library/libobject.ml
@@ -8,8 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open Pp
-
 module Dyn = Dyn.Make ()
 
 type substitutivity = Dispose | Substitute | Keep | Anticipate
@@ -80,7 +78,8 @@ let default_object s = {
   load_function = (fun _ _ -> ());
   open_function = (fun _ _ _ -> ());
   subst_function = (fun _ ->
-    CErrors.anomaly (str "The object " ++ str s ++ str " does not know how to substitute!"));
+    CErrors.anomaly Pp.(str "The object " ++ str s
+      ++ str " does not know how to substitute!"));
   classify_function = (fun _ -> Keep);
   discharge_function = (fun _ -> None);
   rebuild_function = (fun x -> x);
@@ -230,7 +229,9 @@ let global_object_nodischarge ?cat s ~cache ~subst =
     cache_function = cache;
     open_function = simple_open ?cat import;
     subst_function = (match subst with
-        | None -> fun _ -> CErrors.anomaly (str "The object " ++ str s ++ str " does not know how to substitute!")
+        | None -> fun _ ->
+            CErrors.anomaly Pp.(str "The object " ++ str s
+              ++ str " does not know how to substitute!")
         | Some subst -> subst;
       );
     classify_function =
@@ -246,7 +247,9 @@ let superglobal_object_nodischarge s ~cache ~subst =
     load_function = (fun _ x -> cache x);
     cache_function = cache;
     subst_function = (match subst with
-        | None -> fun _ -> CErrors.anomaly (str "The object " ++ str s ++ str " does not know how to substitute!")
+        | None -> fun _ ->
+            CErrors.anomaly Pp.(str "The object " ++ str s
+              ++ str " does not know how to substitute!")
         | Some subst -> subst;
       );
     classify_function =

--- a/library/nametab.mli
+++ b/library/nametab.mli
@@ -10,7 +10,6 @@
 
 open Names
 open Libnames
-open Globnames
 
 (** This module contains the tables for globalization. *)
 
@@ -109,7 +108,7 @@ val push : visibility -> full_path -> GlobRef.t -> unit
 val push_modtype : visibility -> full_path -> ModPath.t -> unit
 val push_module : visibility -> DirPath.t -> ModPath.t -> unit
 val push_dir : visibility -> DirPath.t -> GlobDirRef.t -> unit
-val push_abbreviation : visibility -> full_path -> abbreviation -> unit
+val push_abbreviation : visibility -> full_path -> Globnames.abbreviation -> unit
 
 module UnivIdMap : CMap.ExtS with type key = Univ.UGlobal.t
 
@@ -121,9 +120,9 @@ val push_universe : visibility -> full_path -> Univ.UGlobal.t -> unit
    [Not_found] *)
 
 val locate : qualid -> GlobRef.t
-val locate_extended : qualid -> extended_global_reference
+val locate_extended : qualid -> Globnames.extended_global_reference
 val locate_constant : qualid -> Constant.t
-val locate_abbreviation : qualid -> abbreviation
+val locate_abbreviation : qualid -> Globnames.abbreviation
 val locate_modtype : qualid -> ModPath.t
 val locate_dir : qualid -> GlobDirRef.t
 val locate_module : qualid -> ModPath.t
@@ -141,13 +140,13 @@ val global_inductive : qualid -> inductive
    if [qualid] is valid as such, it comes first in the list *)
 
 val locate_all : qualid -> GlobRef.t list
-val locate_extended_all : qualid -> extended_global_reference list
+val locate_extended_all : qualid -> Globnames.extended_global_reference list
 val locate_extended_all_dir : qualid -> GlobDirRef.t list
 val locate_extended_all_modtype : qualid -> ModPath.t list
 val locate_extended_all_module : qualid -> ModPath.t list
 
 (** Experimental completion support, API is _unstable_ *)
-val completion_canditates : qualid -> extended_global_reference list
+val completion_canditates : qualid -> Globnames.extended_global_reference list
 (** [completion_canditates qualid] will return the list of global
     references that have [qualid] as a prefix. UI usually will want to
     compose this with [shortest_qualid_of_global] *)
@@ -155,7 +154,7 @@ val completion_canditates : qualid -> extended_global_reference list
 (** Mapping a full path to a global reference *)
 
 val global_of_path : full_path -> GlobRef.t
-val extended_global_of_path : full_path -> extended_global_reference
+val extended_global_of_path : full_path -> Globnames.extended_global_reference
 
 (** {6 These functions tell if the given absolute name is already taken } *)
 
@@ -178,7 +177,7 @@ val full_name_module : qualid -> DirPath.t
 (** Returns the full path bound to a global reference or syntactic
    definition, and the (full) dirpath associated to a module path *)
 
-val path_of_abbreviation : abbreviation -> full_path
+val path_of_abbreviation : Globnames.abbreviation -> full_path
 val path_of_global : GlobRef.t -> full_path
 val dirpath_of_module : ModPath.t -> DirPath.t
 val path_of_modtype : ModPath.t -> full_path
@@ -204,7 +203,7 @@ val pr_global_env : Id.Set.t -> GlobRef.t -> Pp.t
    @raise Not_found for unknown objects. *)
 
 val shortest_qualid_of_global : ?loc:Loc.t -> Id.Set.t -> GlobRef.t -> qualid
-val shortest_qualid_of_abbreviation : ?loc:Loc.t -> Id.Set.t -> abbreviation -> qualid
+val shortest_qualid_of_abbreviation : ?loc:Loc.t -> Id.Set.t -> Globnames.abbreviation -> qualid
 val shortest_qualid_of_modtype : ?loc:Loc.t -> ModPath.t -> qualid
 val shortest_qualid_of_module : ?loc:Loc.t -> ModPath.t -> qualid
 


### PR DESCRIPTION
I can squash later if needed. I kept them separate so we can pick and chose if needed.