### PR TITLE
[bench] control opam binary, update to 2.1.3

### DIFF
--- a/dev/bench/README.md
+++ b/dev/bench/README.md
@@ -1,0 +1,22 @@
+# Coq Bench Scripts
+
+## Path and Global Environment Setup
+
+The bench script will create a `$workdir/.bin` folder and place
+binaries it owns there. As of today, this is mainly the `opam` binary,
+so the script can easily control which version of `opam` is being used.
+
+This is fixed for a single bench invocation.
+
+## Local Environment Setup
+
+Local environment setup is done by creating opam switches, see the
+`bench.sh:create_opam` function.
+
+## Timing
+
+Timing of package builds is done by instrumenting opam to wrap build
+commands, using the `wrap-build-commands:` field to point to
+`wrapper.sh`, which in turn calls `time` and `perf`.
+
+This is not perfect, but seems like a good enough approximation.

--- a/dev/bench/bench.sh
+++ b/dev/bench/bench.sh
@@ -16,6 +16,20 @@ bt='`'               # backtick
 start_code_block='```'
 end_code_block='```'
 
+# We put local binaries such as opam in .bin and extend PATH
+BIN=$(pwd)/.bin
+mkdir "$BIN"
+wget https://github.com/ocaml/opam/releases/download/2.1.3/opam-2.1.3-x86_64-linux -O "$BIN"/opam
+chmod +x "$BIN"/opam
+
+export PATH="$BIN":$PATH
+
+echo "Global env info:"
+echo "----------------"
+echo "pwd: $PWD"
+echo "path: $PATH"
+echo "opam version: `opam --version`"
+
 number_of_processors=$(cat /proc/cpuinfo | grep '^processor *' | wc -l)
 
 program_name="$0"
@@ -34,8 +48,6 @@ check_variable () {
       exit 1
   fi
 }
-
-echo $PWD
 
 #check_variable "BUILD_ID"
 #check_variable "BUILD_URL"


### PR DESCRIPTION
Version was pretty old, so it is better we control this.

It seems at the bench we don't enjoy the luxury of docker.
