### PR TITLE
Add a :: notation to make field typeclass instances

### DIFF
--- a/dev/ci/user-overlays/16230-proux01-field_instance.sh
+++ b/dev/ci/user-overlays/16230-proux01-field_instance.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/proux01/coq-elpi coq_16230 16230

--- a/doc/changelog/08-vernac-commands-and-options/16230-field_instance.rst
+++ b/doc/changelog/08-vernac-commands-and-options/16230-field_instance.rst
@@ -1,0 +1,15 @@
+- **Added:**
+  :g:`::` syntax to declare fields of records as :ref:`typeclass <typeclasses>` instances
+  (`#16230 <https://github.com/coq/coq/pull/16230>`_,
+  fixes `#16224 <https://github.com/coq/coq/issues/16224>`_,
+  by Pierre Roux, reviewed by Ali Caglayan, Jim Fehrle, Gaëtan Gilbert
+  and Pierre-Marie Pédrot).
+- **Deprecated**
+  :g:`:>` syntax, to declare fields of :ref:`typeclasses` as instances,
+  since it is now replaced by :g:`::` (see :n:`@of_type_inst`).
+  This will allow, in a future release, making :g:`:>` declare :ref:`coercions`
+  as it does in :ref:`record <records>` definitions
+  (`#16230 <https://github.com/coq/coq/pull/16230>`_,
+  fixes `#16224 <https://github.com/coq/coq/issues/16224>`_,
+  by Pierre Roux, reviewed by Ali Caglayan, Jim Fehrle, Gaëtan Gilbert
+  and Pierre-Marie Pédrot).

--- a/doc/sphinx/addendum/type-classes.rst
+++ b/doc/sphinx/addendum/type-classes.rst
@@ -277,10 +277,10 @@ explanation). These may be used as parts of other classes:
 .. coqtop:: all
 
    Class PreOrder (A : Type) (R : relation A) :=
-     { PreOrder_Reflexive :> Reflexive A R ;
-       PreOrder_Transitive :> Transitive A R }.
+     { PreOrder_Reflexive :: Reflexive A R ;
+       PreOrder_Transitive :: Transitive A R }.
 
-The syntax ``:>`` indicates that each ``PreOrder`` can be seen as a
+The syntax ``::`` indicates that each ``PreOrder`` can be seen as a
 ``Reflexive`` relation. So each time a reflexive relation is needed, a
 preorder can be used instead. This is very similar to the coercion
 mechanism of ``Structure`` declarations. The implementation simply
@@ -332,9 +332,19 @@ Summary of the commands
 
          This command has no effect when used on a typeclass.
 
+.. _warn-future-coercion-class-field:
+
+   .. warn:: A coercion will be introduced instead of an instance in future versions when using ':>' in 'Class' declarations. Replace ':>' with '::' (or use '#[global] Existing Instance field.' for compatibility with Coq < 8.17).
+
+      In future versions, :g:`:>` will
+      declare a :ref:`coercion<coercions>`, as it does
+      for other :cmd:`Record` commands.
+      To eliminate the warning,
+      use :g:`::`.
+
    .. warn:: Ignored instance declaration for “@ident”: “@term” is not a class
 
-      Using this ``:>`` syntax with a right-hand-side that is not itself a Class
+      Using this ``::`` (or deprecated ``:>``) syntax with a right-hand-side that is not itself a Class
       has no effect (apart from emitting this warning).
 
 .. cmd:: Instance {? @ident_decl {* @binder } } : @type {? @hint_info } {? {| := %{ {* @field_val } %} | := @term } }

--- a/doc/sphinx/language/core/inductive.rst
+++ b/doc/sphinx/language/core/inductive.rst
@@ -13,7 +13,7 @@ Inductive types
 
    .. prodn::
       inductive_definition ::= @ident {? @cumul_univ_decl } {* @binder } {? %| {* @binder } } {? : @type } := {? %| } {+| @constructor } {? @decl_notations }
-      constructor ::= @ident {* @binder } {? @of_type }
+      constructor ::= @ident {* @binder } {? @of_type_inst }
 
    Defines one or more
    inductive types and its constructors.  Coq generates

--- a/doc/sphinx/language/core/records.rst
+++ b/doc/sphinx/language/core/records.rst
@@ -18,14 +18,15 @@ Defining record types
 .. cmd:: {| Record | Structure } @record_definition
    :name: Record; Structure
 
-   .. insertprodn record_definition field_spec
+   .. insertprodn record_definition of_type_inst
 
    .. prodn::
       record_definition ::= {? > } @ident_decl {* @binder } {? : @sort } {? := {? @ident } %{ {*; @record_field } {? ; } %} {? as @ident } }
       record_field ::= {* #[ {*, @attribute } ] } @name {? @field_spec } {? %| @natural }
-      field_spec ::= {* @binder } @of_type
+      field_spec ::= {* @binder } @of_type_inst
       | {* @binder } := @term
-      | {* @binder } @of_type := @term
+      | {* @binder } @of_type_inst := @term
+      of_type_inst ::= {| : | :> | :: | ::> } @type
 
    Defines a non-recursive record type, creating projections for each field
    that has a name other than `_`. The field body and type can depend on previous
@@ -85,20 +86,28 @@ Defining record types
      :n:`| @natural`
        Specifies the priority of the field.  It is only allowed in :cmd:`Class` commands.
 
-   In :n:`@field_spec`:
+     :n:`:`
+       Specifies the type of the field.
 
-     :n:`:>` in :n:`@of_type`
+     :n:`:>`
        If specified, the field is declared as a coercion from the record name
        to the class of the field type. See :ref:`coercions`.
        Note that this currently does something else in :cmd:`Class` commands.
 
-     - :n:`{+ @binder } : @of_type` is equivalent to
-       :n:`: forall {+ @binder } , @of_type`
+     :n:`::`
+       If specified, the field is declared a typeclass instance of the class
+       of the field type. See :ref:`typeclasses`.
+
+     :n:`::>`
+       Acts as a combination of :n:`::` and :n:`:>`.
+
+     - :n:`{+ @binder } : @of_type_inst` is equivalent to
+       :n:`: forall {+ @binder } , @of_type_inst`
 
      - :n:`{+ @binder } := @term` is equivalent to
        :n:`:= fun {+ @binder } => @term`
 
-     - :n:`{+ @binder } @of_type := @term` is equivalent to
+     - :n:`{+ @binder } @of_type_inst := @term` is equivalent to
        :n:`: forall {+ @binder } , @type := fun {+ @binder } => @term`
 
      :n:`:= @term`, if present, gives the value of the field, which may depend

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -660,6 +660,14 @@ of_type: [
 | [ ":" | ":>" ] type
 ]
 
+of_type_inst: [
+| DELETENT
+]
+
+of_type_inst: [
+| [ ":" | ":>" | "::" | "::>" ] type
+]
+
 def_body: [
 | DELETE binders ":=" reduce lconstr
 | REPLACE binders ":" lconstr ":=" reduce lconstr
@@ -1459,10 +1467,10 @@ binder_tactic: [
 ]
 
 field_body: [
-| REPLACE binders of_type lconstr
-| WITH binders of_type
-| REPLACE binders of_type lconstr ":=" lconstr
-| WITH binders of_type ":=" lconstr
+| REPLACE binders of_type_inst lconstr
+| WITH binders of_type_inst
+| REPLACE binders of_type_inst lconstr ":=" lconstr
+| WITH binders of_type_inst ":=" lconstr
 ]
 
 assumpt: [
@@ -1471,8 +1479,8 @@ assumpt: [
 ]
 
 constructor_type: [
-| REPLACE binders [ of_type lconstr | ]
-| WITH binders OPT of_type
+| REPLACE binders [ of_type_inst lconstr | ]
+| WITH binders OPT of_type_inst
 ]
 
 (* todo: is this really correct? Search for "Pvernac.register_proof_mode" *)

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -997,8 +997,8 @@ record_fields: [
 ]
 
 field_body: [
-| binders of_type lconstr
-| binders of_type lconstr ":=" lconstr
+| binders of_type_inst lconstr
+| binders of_type_inst lconstr ":=" lconstr
 | binders ":=" lconstr
 ]
 
@@ -1021,7 +1021,7 @@ assumpt: [
 ]
 
 constructor_type: [
-| binders [ of_type lconstr | ]
+| binders [ of_type_inst lconstr | ]
 ]
 
 constructor: [
@@ -1031,6 +1031,14 @@ constructor: [
 of_type: [
 | ":>"
 | ":" ">"
+| ":"
+]
+
+of_type_inst: [
+| ":>"
+| ":" ">"
+| "::"
+| "::>"
 | ":"
 ]
 

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -678,9 +678,13 @@ record_field: [
 ]
 
 field_spec: [
-| LIST0 binder of_type
+| LIST0 binder of_type_inst
 | LIST0 binder ":=" term
-| LIST0 binder of_type ":=" term
+| LIST0 binder of_type_inst ":=" term
+]
+
+of_type_inst: [
+| [ ":" | ":>" | "::" | "::>" ] type
 ]
 
 term_record: [
@@ -705,7 +709,7 @@ inductive_definition: [
 ]
 
 constructor: [
-| ident LIST0 binder OPT of_type
+| ident LIST0 binder OPT of_type_inst
 ]
 
 import_categories: [

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -1480,7 +1480,7 @@ let do_build_inductive evd (funconstants : pconstant list)
   let ext_rels_constructors =
     Array.map
       (List.map (fun (id, t) ->
-           ( false
+           ( Vernacexpr.NoCoercion
            , ( CAst.make id
              , with_full_print
                  Constrextern.(extern_glob_type empty_extern_env)
@@ -1531,7 +1531,7 @@ let do_build_inductive evd (funconstants : pconstant list)
     let repacked_rel_inds =
       List.map
         (fun ((a, b, c, l), ntn) ->
-          (((false, (a, None)), b, c, Vernacexpr.Constructors l), ntn))
+          (Vernacexpr.((NoCoercion, (a, None)), b, c, Constructors l), ntn))
         rel_inds
     in
     let msg =
@@ -1554,7 +1554,7 @@ let do_build_inductive evd (funconstants : pconstant list)
     let repacked_rel_inds =
       List.map
         (fun ((a, b, c, l), ntn) ->
-          (((false, (a, None)), b, c, Vernacexpr.Constructors l), ntn))
+          (Vernacexpr.((NoCoercion, (a, None)), b, c, Constructors l), ntn))
         rel_inds
     in
     let msg =

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -1480,7 +1480,7 @@ let do_build_inductive evd (funconstants : pconstant list)
   let ext_rels_constructors =
     Array.map
       (List.map (fun (id, t) ->
-           ( Vernacexpr.NoCoercion
+           ( Vernacexpr.(NoCoercion, NoInstance)
            , ( CAst.make id
              , with_full_print
                  Constrextern.(extern_glob_type empty_extern_env)

--- a/test-suite/output/bug_16224.out
+++ b/test-suite/output/bug_16224.out
@@ -1,8 +1,19 @@
 File "./output/bug_16224.v", line 9, characters 0-24:
+Warning: The default value for field instance locality is currently "global",
+but is scheduled to change in a future release. For the time being, adding
+field instances without specifying an explicit locality attribute is
+therefore deprecated. It is recommended to use "export" whenever possible.
+Use the attributes #[local], #[global] and #[export] depending on your
+choice. For example: "Class foo := { #[export] field :: bar }."
+[deprecated-field-instance-without-locality,deprecated]
+File "./output/bug_16224.v", line 9, characters 0-24:
 Warning: A coercion will be introduced instead of an instance in future
 versions when using ':>' in 'Class' declarations. Replace ':>' with '::' (or
 use '#[global] Existing Instance field.' for compatibility with Coq < 8.17).
-[future-coercion-class-field,records]
+Beware that the default locality for '::' is #[export], as opposed to
+#[global] for ':>' currently. Add an explicit #[global] attribute to the
+field if you need to keep the current behavior. For example: "Class foo := {
+#[global] field :: bar }." [future-coercion-class-field,records]
 [rc] : Rc >-> A (reversible)
 [ric] : Ric >-> A (reversible)
 ric : Ric -> A

--- a/test-suite/output/bug_16224.out
+++ b/test-suite/output/bug_16224.out
@@ -1,0 +1,12 @@
+File "./output/bug_16224.v", line 9, characters 0-24:
+Warning: A coercion will be introduced instead of an instance in future
+versions when using ':>' in 'Class' declarations. Replace ':>' with '::' (or
+use '#[global] Existing Instance field.' for compatibility with Coq < 8.17).
+[future-coercion-class-field,records]
+[rc] : Rc >-> A (reversible)
+[ric] : Ric >-> A (reversible)
+ric : Ric -> A
+cic : Cic -> A
+ri : Ri -> A
+ci : Ci -> A
+cc : Cc -> A

--- a/test-suite/output/bug_16224.v
+++ b/test-suite/output/bug_16224.v
@@ -1,0 +1,21 @@
+Class A := { n : nat }.
+
+Record Rn := { rn : A }.
+
+Class Cn := { cn : A }.
+
+Record Rc := { rc :> A }.
+
+Class Cc := { cc :> A }.
+
+Record Ri := { ri :: A }.
+
+Class Ci := { ci :: A }.
+
+Record Ric := { ric ::> A }.
+
+Class Cic := { cic ::> A }.
+
+Print Graph.
+
+Print Instances A.

--- a/theories/Classes/CRelationClasses.v
+++ b/theories/Classes/CRelationClasses.v
@@ -70,14 +70,14 @@ Section Defs.
   (** A [PreOrder] is both Reflexive and Transitive. *)
 
   Class PreOrder (R : crelation A)  := {
-    PreOrder_Reflexive :: Reflexive R | 2 ;
-    PreOrder_Transitive :: Transitive R | 2 }.
+    #[global] PreOrder_Reflexive :: Reflexive R | 2 ;
+    #[global] PreOrder_Transitive :: Transitive R | 2 }.
 
   (** A [StrictOrder] is both Irreflexive and Transitive. *)
 
   Class StrictOrder (R : crelation A)  := {
-    StrictOrder_Irreflexive :: Irreflexive R ;
-    StrictOrder_Transitive :: Transitive R }.
+    #[global] StrictOrder_Irreflexive :: Irreflexive R ;
+    #[global] StrictOrder_Transitive :: Transitive R }.
 
   (** By definition, a strict order is also asymmetric *)
   Global Instance StrictOrder_Asymmetric `(StrictOrder R) : Asymmetric R.
@@ -86,15 +86,15 @@ Section Defs.
   (** A partial equivalence crelation is Symmetric and Transitive. *)
   
   Class PER (R : crelation A)  := {
-    PER_Symmetric :: Symmetric R | 3 ;
-    PER_Transitive :: Transitive R | 3 }.
+    #[global] PER_Symmetric :: Symmetric R | 3 ;
+    #[global] PER_Transitive :: Transitive R | 3 }.
 
   (** Equivalence crelations. *)
 
   Class Equivalence (R : crelation A)  := {
-    Equivalence_Reflexive :: Reflexive R ;
-    Equivalence_Symmetric :: Symmetric R ;
-    Equivalence_Transitive :: Transitive R }.
+    #[global] Equivalence_Reflexive :: Reflexive R ;
+    #[global] Equivalence_Symmetric :: Symmetric R ;
+    #[global] Equivalence_Transitive :: Transitive R }.
 
   (** An Equivalence is a PER plus reflexivity. *)
   

--- a/theories/Classes/CRelationClasses.v
+++ b/theories/Classes/CRelationClasses.v
@@ -70,14 +70,14 @@ Section Defs.
   (** A [PreOrder] is both Reflexive and Transitive. *)
 
   Class PreOrder (R : crelation A)  := {
-    PreOrder_Reflexive :> Reflexive R | 2 ;
-    PreOrder_Transitive :> Transitive R | 2 }.
+    PreOrder_Reflexive :: Reflexive R | 2 ;
+    PreOrder_Transitive :: Transitive R | 2 }.
 
   (** A [StrictOrder] is both Irreflexive and Transitive. *)
 
   Class StrictOrder (R : crelation A)  := {
-    StrictOrder_Irreflexive :> Irreflexive R ;
-    StrictOrder_Transitive :> Transitive R }.
+    StrictOrder_Irreflexive :: Irreflexive R ;
+    StrictOrder_Transitive :: Transitive R }.
 
   (** By definition, a strict order is also asymmetric *)
   Global Instance StrictOrder_Asymmetric `(StrictOrder R) : Asymmetric R.
@@ -86,15 +86,15 @@ Section Defs.
   (** A partial equivalence crelation is Symmetric and Transitive. *)
   
   Class PER (R : crelation A)  := {
-    PER_Symmetric :> Symmetric R | 3 ;
-    PER_Transitive :> Transitive R | 3 }.
+    PER_Symmetric :: Symmetric R | 3 ;
+    PER_Transitive :: Transitive R | 3 }.
 
   (** Equivalence crelations. *)
 
   Class Equivalence (R : crelation A)  := {
-    Equivalence_Reflexive :> Reflexive R ;
-    Equivalence_Symmetric :> Symmetric R ;
-    Equivalence_Transitive :> Transitive R }.
+    Equivalence_Reflexive :: Reflexive R ;
+    Equivalence_Symmetric :: Symmetric R ;
+    Equivalence_Transitive :: Transitive R }.
 
   (** An Equivalence is a PER plus reflexivity. *)
   

--- a/theories/Classes/RelationClasses.v
+++ b/theories/Classes/RelationClasses.v
@@ -60,14 +60,14 @@ Section Defs.
   (** A [PreOrder] is both Reflexive and Transitive. *)
   
   Class PreOrder (R : relation A) : Prop := {
-    PreOrder_Reflexive :> Reflexive R | 2 ;
-    PreOrder_Transitive :> Transitive R | 2 }.
+    PreOrder_Reflexive :: Reflexive R | 2 ;
+    PreOrder_Transitive :: Transitive R | 2 }.
 
   (** A [StrictOrder] is both Irreflexive and Transitive. *)
 
   Class StrictOrder (R : relation A) : Prop := {
-    StrictOrder_Irreflexive :> Irreflexive R ;
-    StrictOrder_Transitive :> Transitive R }.
+    StrictOrder_Irreflexive :: Irreflexive R ;
+    StrictOrder_Transitive :: Transitive R }.
 
   (** By definition, a strict order is also asymmetric *)
   Global Instance StrictOrder_Asymmetric `(StrictOrder R) : Asymmetric R.
@@ -76,15 +76,15 @@ Section Defs.
   (** A partial equivalence relation is Symmetric and Transitive. *)
   
   Class PER (R : relation A) : Prop := {
-    PER_Symmetric :> Symmetric R | 3 ;
-    PER_Transitive :> Transitive R | 3 }.
+    PER_Symmetric :: Symmetric R | 3 ;
+    PER_Transitive :: Transitive R | 3 }.
 
   (** Equivalence relations. *)
 
   Class Equivalence (R : relation A) : Prop := {
-    Equivalence_Reflexive :> Reflexive R ;
-    Equivalence_Symmetric :> Symmetric R ;
-    Equivalence_Transitive :> Transitive R }.
+    Equivalence_Reflexive :: Reflexive R ;
+    Equivalence_Symmetric :: Symmetric R ;
+    Equivalence_Transitive :: Transitive R }.
 
   (** An Equivalence is a PER plus reflexivity. *)
   

--- a/theories/Classes/RelationClasses.v
+++ b/theories/Classes/RelationClasses.v
@@ -60,14 +60,14 @@ Section Defs.
   (** A [PreOrder] is both Reflexive and Transitive. *)
   
   Class PreOrder (R : relation A) : Prop := {
-    PreOrder_Reflexive :: Reflexive R | 2 ;
-    PreOrder_Transitive :: Transitive R | 2 }.
+    #[global] PreOrder_Reflexive :: Reflexive R | 2 ;
+    #[global] PreOrder_Transitive :: Transitive R | 2 }.
 
   (** A [StrictOrder] is both Irreflexive and Transitive. *)
 
   Class StrictOrder (R : relation A) : Prop := {
-    StrictOrder_Irreflexive :: Irreflexive R ;
-    StrictOrder_Transitive :: Transitive R }.
+    #[global] StrictOrder_Irreflexive :: Irreflexive R ;
+    #[global] StrictOrder_Transitive :: Transitive R }.
 
   (** By definition, a strict order is also asymmetric *)
   Global Instance StrictOrder_Asymmetric `(StrictOrder R) : Asymmetric R.
@@ -76,15 +76,15 @@ Section Defs.
   (** A partial equivalence relation is Symmetric and Transitive. *)
   
   Class PER (R : relation A) : Prop := {
-    PER_Symmetric :: Symmetric R | 3 ;
-    PER_Transitive :: Transitive R | 3 }.
+    #[global] PER_Symmetric :: Symmetric R | 3 ;
+    #[global] PER_Transitive :: Transitive R | 3 }.
 
   (** Equivalence relations. *)
 
   Class Equivalence (R : relation A) : Prop := {
-    Equivalence_Reflexive :: Reflexive R ;
-    Equivalence_Symmetric :: Symmetric R ;
-    Equivalence_Transitive :: Transitive R }.
+    #[global] Equivalence_Reflexive :: Reflexive R ;
+    #[global] Equivalence_Symmetric :: Symmetric R ;
+    #[global] Equivalence_Transitive :: Transitive R }.
 
   (** An Equivalence is a PER plus reflexivity. *)
   

--- a/theories/Classes/SetoidClass.v
+++ b/theories/Classes/SetoidClass.v
@@ -29,7 +29,7 @@ Require Export Coq.Classes.Morphisms.
 
 Class Setoid A := {
   equiv : relation A ;
-  setoid_equiv :: Equivalence equiv }.
+  #[global] setoid_equiv :: Equivalence equiv }.
 
 (* Too dangerous instance *)
 (* Program Instance [ eqa : Equivalence A eqA ] =>  *)
@@ -135,7 +135,7 @@ Program Instance setoid_partial_app_morphism `(sa : Setoid A) (x : A) : Proper (
 (** Partial setoids don't require reflexivity so we can build a partial setoid on the function space. *)
 
 Class PartialSetoid (A : Type) :=
-  { pequiv : relation A ; pequiv_prf :: PER pequiv }.
+  { pequiv : relation A ; #[global] pequiv_prf :: PER pequiv }.
 
 (** Overloaded notation for partial setoid equivalence. *)
 

--- a/theories/Classes/SetoidClass.v
+++ b/theories/Classes/SetoidClass.v
@@ -29,7 +29,7 @@ Require Export Coq.Classes.Morphisms.
 
 Class Setoid A := {
   equiv : relation A ;
-  setoid_equiv :> Equivalence equiv }.
+  setoid_equiv :: Equivalence equiv }.
 
 (* Too dangerous instance *)
 (* Program Instance [ eqa : Equivalence A eqA ] =>  *)
@@ -135,7 +135,7 @@ Program Instance setoid_partial_app_morphism `(sa : Setoid A) (x : A) : Proper (
 (** Partial setoids don't require reflexivity so we can build a partial setoid on the function space. *)
 
 Class PartialSetoid (A : Type) :=
-  { pequiv : relation A ; pequiv_prf :> PER pequiv }.
+  { pequiv : relation A ; pequiv_prf :: PER pequiv }.
 
 (** Overloaded notation for partial setoid equivalence. *)
 

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -272,17 +272,6 @@ let class_input : typeclass -> obj =
 let add_class cl =
   Lib.add_leaf (class_input cl)
 
-let add_class env sigma cl =
-  add_class cl;
-  List.iter (fun m ->
-      match m.meth_info with
-      | Some info ->
-        (match m.meth_const with
-         | None -> CErrors.user_err Pp.(str "Non-definable projection can not be declared as a subinstance")
-         | Some b -> declare_instance ~warn:true env sigma (Some info) SuperGlobal (GlobRef.ConstRef b))
-      | _ -> ())
-    cl.cl_projs
-
 let intern_info {hint_priority;hint_pattern} =
   let env = Global.env() in
   let sigma = Evd.from_env env in

--- a/vernac/classes.mli
+++ b/vernac/classes.mli
@@ -70,7 +70,7 @@ val declare_new_instance
   -> Vernacexpr.hint_info_expr
   -> unit
 
-val add_class : env -> Evd.evar_map -> typeclass -> unit
+val add_class : typeclass -> unit
 
 (** Setting opacity *)
 

--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -29,7 +29,10 @@ let declare_variable is_coe ~kind typ univs imps impl {CAst.v=name} =
   let env = Global.env () in
   let sigma = Evd.from_env env in
   let () = Classes.declare_instance env sigma None Hints.Local r in
-  let () = if is_coe then ComCoercion.try_add_new_coercion r ~local:true ~poly:false ~nonuniform:false ~reversible:true in
+  let () =
+    if is_coe = Vernacexpr.AddCoercion then
+      ComCoercion.try_add_new_coercion
+        r ~local:true ~poly:false ~nonuniform:false ~reversible:true in
   ()
 
 let instance_of_univ_entry = function
@@ -62,7 +65,10 @@ let declare_axiom is_coe ~poly ~local ~kind typ (univs, ubinders) imps nl {CAst.
     | Locality.ImportNeedQualified -> true
     | Locality.ImportDefaultBehavior -> false
   in
-  let () = if is_coe then ComCoercion.try_add_new_coercion gr ~local ~poly ~nonuniform:false ~reversible:true in
+  let () =
+    if is_coe = Vernacexpr.AddCoercion then
+      ComCoercion.try_add_new_coercion
+        gr ~local ~poly ~nonuniform:false ~reversible:true in
   let inst = instance_of_univ_entry univs in
   (gr,inst)
 
@@ -191,7 +197,7 @@ let context_insection sigma ~poly ctx =
     let () = match d with
       | name, None, t, impl ->
         let kind = Decls.Context in
-        declare_variable false ~kind t univs [] impl (CAst.make name)
+        declare_variable NoCoercion ~kind t univs [] impl (CAst.make name)
       | name, Some b, t, impl ->
         let entry = Declare.definition_entry ~univs ~types:t b in
         (* XXX Fixme: Use Declare.prepare_definition *)

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -713,7 +713,7 @@ let eq_params (up1,p1) (up2,p2) =
 
 let extract_coercions indl =
   let mkqid (_,({CAst.v=id},_)) = qualid_of_ident id in
-  let extract lc = List.filter (fun (iscoe,_) -> iscoe) lc in
+  let extract lc = List.filter (fun (iscoe,_) -> iscoe = Vernacexpr.AddCoercion) lc in
   List.map mkqid (List.flatten(List.map (fun (_,_,_,lc) -> extract lc) indl))
 
 let extract_params indl =

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -713,7 +713,11 @@ let eq_params (up1,p1) (up2,p2) =
 
 let extract_coercions indl =
   let mkqid (_,({CAst.v=id},_)) = qualid_of_ident id in
-  let extract lc = List.filter (fun (iscoe,_) -> iscoe = Vernacexpr.AddCoercion) lc in
+  let iscoe (coe, inst) = match inst with
+    (* remove BackInstanceWarning after deprecation phase *)
+    | Vernacexpr.(NoInstance | BackInstanceWarning) -> coe = Vernacexpr.AddCoercion
+    | _ -> user_err (Pp.str "'::' not allowed in inductives.") in
+  let extract lc = List.filter (fun (coe,_) -> iscoe coe) lc in
   List.map mkqid (List.flatten(List.map (fun (_,_,_,lc) -> extract lc) indl))
 
 let extract_params indl =

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -419,8 +419,8 @@ GRAMMAR EXTEND Gram
   ;
 *)
   opt_coercion:
-    [ [ ">" -> { true }
-      |  -> { false } ] ]
+    [ [ ">" -> { AddCoercion }
+      |  -> { NoCoercion } ] ]
   ;
   (* (co)-fixpoints *)
   fix_definition:
@@ -508,15 +508,15 @@ GRAMMAR EXTEND Gram
   ;
   assumpt:
     [ [ idl = LIST1 ident_decl; oc = of_type; c = lconstr ->
-        { (oc <> NoInstance,(idl,c)) } ] ]
+        { ((if oc <> NoInstance then AddCoercion else NoCoercion),(idl,c)) } ] ]
   ;
 
   constructor_type:
     [[ l = binders;
       t= [ coe = of_type; c = lconstr ->
-                    { fun l id -> (coe <> NoInstance,(id,mkProdCN ~loc l c)) }
+                    { fun l id -> ((if coe <> NoInstance then AddCoercion else NoCoercion),(id,mkProdCN ~loc l c)) }
             |  ->
-                 { fun l id -> (false,(id,mkProdCN ~loc l (CAst.make ~loc @@ CHole (None, IntroAnonymous, None)))) } ]
+                 { fun l id -> (NoCoercion,(id,mkProdCN ~loc l (CAst.make ~loc @@ CHole (None, IntroAnonymous, None)))) } ]
          -> { t l }
      ]]
 ;

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -472,9 +472,9 @@ GRAMMAR EXTEND Gram
   [ [ attr = LIST0 quoted_attributes ;
       bd = record_binder; rf_priority = OPT [ "|"; n = natural -> { n } ];
       rf_notation = decl_notations -> {
-      let rf_canonical, rf_reverse = attr |> List.flatten |> parse Notations.(canonical_field ++ reversible) in
+      let rf_canonical, rf_reversible = attr |> List.flatten |> parse Notations.(canonical_field ++ reversible) in
       let rf_subclass, rf_decl = bd in
-      rf_decl, { rf_subclass ; rf_reverse ; rf_priority ; rf_notation ; rf_canonical } } ] ]
+      rf_decl, { rf_subclass ; rf_reversible ; rf_priority ; rf_notation ; rf_canonical } } ] ]
   ;
   record_fields:
     [ [ f = record_field; ";"; fs = record_fields -> { f :: fs }

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -51,6 +51,7 @@ let def_body = Entry.create "def_body"
 let decl_notations = Entry.create "decl_notations"
 let record_field = Entry.create "record_field"
 let of_type = Entry.create "of_type"
+let of_type_inst = Entry.create "of_type_inst"
 let section_subset_expr = Entry.create "section_subset_expr"
 let scope_delimiter = Entry.create "scope_delimiter"
 let syntax_modifiers = Entry.create "syntax_modifiers"
@@ -208,7 +209,7 @@ let test_variance_ident =
 
 (* Gallina declarations *)
 GRAMMAR EXTEND Gram
-  GLOBAL: gallina gallina_ext thm_token def_token assumption_token def_body of_type
+  GLOBAL: gallina gallina_ext thm_token def_token assumption_token def_body of_type of_type_inst
     record_field decl_notations fix_definition ident_decl univ_decl inductive_or_record_definition;
 
   gallina:
@@ -473,8 +474,8 @@ GRAMMAR EXTEND Gram
       bd = record_binder; rf_priority = OPT [ "|"; n = natural -> { n } ];
       rf_notation = decl_notations -> {
       let rf_canonical, rf_reversible = attr |> List.flatten |> parse Notations.(canonical_field ++ reversible) in
-      let rf_subclass, rf_decl = bd in
-      rf_decl, { rf_subclass ; rf_reversible ; rf_priority ; rf_notation ; rf_canonical } } ] ]
+      let (rf_coercion, rf_instance), rf_decl = bd in
+      rf_decl, { rf_coercion ; rf_reversible ; rf_instance ; rf_priority ; rf_notation ; rf_canonical } } ] ]
   ;
   record_fields:
     [ [ f = record_field; ";"; fs = record_fields -> { f :: fs }
@@ -483,21 +484,21 @@ GRAMMAR EXTEND Gram
     ] ]
   ;
   field_body:
-    [ [ l = binders; oc = of_type;
+    [ [ l = binders; oc = of_type_inst;
          t = lconstr -> { fun id -> (oc,AssumExpr (id,l,t)) }
-      | l = binders; oc = of_type;
+      | l = binders; oc = of_type_inst;
          t = lconstr; ":="; b = lconstr -> { fun id ->
            (oc,DefExpr (id,l,b,Some t)) }
       | l = binders; ":="; b = lconstr -> { fun id ->
         (* Why are we dropping cast info here? *)
          match b.CAst.v with
          | CCast(b', _, t) ->
-             (NoInstance,DefExpr(id,l,b',Some t))
+             ((NoCoercion,NoInstance),DefExpr(id,l,b',Some t))
          | _ ->
-             (NoInstance,DefExpr(id,l,b,None)) } ] ]
+             ((NoCoercion,NoInstance),DefExpr(id,l,b,None)) } ] ]
   ;
   record_binder:
-    [ [ id = name -> { (NoInstance,AssumExpr(id, [], CAst.make ~loc @@ CHole (None, IntroAnonymous, None))) }
+    [ [ id = name -> { ((NoCoercion,NoInstance),AssumExpr(id, [], CAst.make ~loc @@ CHole (None, IntroAnonymous, None))) }
       | id = name; f = field_body -> { f id } ] ]
   ;
   assum_list:
@@ -508,15 +509,15 @@ GRAMMAR EXTEND Gram
   ;
   assumpt:
     [ [ idl = LIST1 ident_decl; oc = of_type; c = lconstr ->
-        { ((if oc <> NoInstance then AddCoercion else NoCoercion),(idl,c)) } ] ]
+        { (oc,(idl,c)) } ] ]
   ;
 
   constructor_type:
     [[ l = binders;
-      t= [ coe = of_type; c = lconstr ->
-                    { fun l id -> ((if coe <> NoInstance then AddCoercion else NoCoercion),(id,mkProdCN ~loc l c)) }
+      t= [ coe = of_type_inst; c = lconstr ->
+                    { fun l id -> (coe,(id,mkProdCN ~loc l c)) }
             |  ->
-                 { fun l id -> (NoCoercion,(id,mkProdCN ~loc l (CAst.make ~loc @@ CHole (None, IntroAnonymous, None)))) } ]
+                 { fun l id -> ((NoCoercion,NoInstance),(id,mkProdCN ~loc l (CAst.make ~loc @@ CHole (None, IntroAnonymous, None)))) } ]
          -> { t l }
      ]]
 ;
@@ -525,9 +526,16 @@ GRAMMAR EXTEND Gram
     [ [ id = identref; c=constructor_type -> { c id } ] ]
   ;
   of_type:
-    [ [   ":>" -> { BackInstance }
-        | ":"; ">" -> { BackInstance }
-        | ":" -> { NoInstance } ] ]
+    [ [   ":>" -> { AddCoercion }
+        | ":"; ">" -> { AddCoercion }
+        | ":" -> { NoCoercion } ] ]
+  ;
+  of_type_inst:
+    [ [   ":>" -> { (AddCoercion, BackInstanceWarning) (* replace with NoInstance at end of deprecation phase *) }
+        | ":"; ">" -> { (AddCoercion, BackInstanceWarning) (* replace with NoInstance at end of deprecation phase *) }
+        | "::" -> { (NoCoercion, BackInstance) }
+        | "::>" -> { (AddCoercion, BackInstance) }
+        | ":" -> { (NoCoercion, NoInstance) } ] ]
   ;
 END
 

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -473,9 +473,12 @@ GRAMMAR EXTEND Gram
   [ [ attr = LIST0 quoted_attributes ;
       bd = record_binder; rf_priority = OPT [ "|"; n = natural -> { n } ];
       rf_notation = decl_notations -> {
-      let rf_canonical, rf_reversible = attr |> List.flatten |> parse Notations.(canonical_field ++ reversible) in
+      let (rf_canonical, rf_reversible), rf_locality = attr |> List.flatten
+        |> parse Notations.(canonical_field ++ reversible ++ option_locality) in
       let (rf_coercion, rf_instance), rf_decl = bd in
-      rf_decl, { rf_coercion ; rf_reversible ; rf_instance ; rf_priority ; rf_notation ; rf_canonical } } ] ]
+      rf_decl,
+      { rf_coercion ; rf_reversible ; rf_instance ; rf_priority ; rf_locality ;
+        rf_notation ; rf_canonical } } ] ]
   ;
   record_fields:
     [ [ f = record_field; ";"; fs = record_fields -> { f :: fs }

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -837,14 +837,14 @@ let pr_vernac_expr v =
     let n = List.length (List.flatten (List.map fst (List.map snd l))) in
     let pr_params (c, (xl, t)) =
       hov 2 (prlist_with_sep sep pr_ident_decl xl ++ spc() ++
-             (if c then str":>" else str":" ++ spc() ++ pr_lconstr_expr t)) in
+             str(match c with AddCoercion -> ":>" | NoCoercion -> ":") ++ spc() ++ pr_lconstr_expr t) in
     let assumptions = prlist_with_sep spc (fun p -> hov 1 (str "(" ++ pr_params p ++ str ")")) l in
     return (hov 2 (pr_assumption_token (n > 1) discharge kind ++
                    pr_non_empty_arg pr_assumption_inline t ++ spc() ++ assumptions))
   | VernacInductive (f,l) ->
     let pr_constructor (coe,(id,c)) =
       hov 2 (pr_lident id ++ str" " ++
-             (if coe then str":>" else str":") ++
+             str(match coe with AddCoercion -> ":>" | NoCoercion -> ":") ++
              Flags.without_option Flags.beautify pr_spc_lconstr c)
     in
     let pr_constructor_list l = match l with
@@ -860,7 +860,7 @@ let pr_vernac_expr v =
     let pr_oneind key (((coe,iddecl),(indupar,indpar),s,lc),ntn) =
       hov 0 (
         str key ++ spc() ++
-        (if coe then str"> " else str"") ++ pr_cumul_ident_decl iddecl ++
+        str(match coe with AddCoercion -> "> " | NoCoercion -> "") ++ pr_cumul_ident_decl iddecl ++
         pr_and_type_binders_arg indupar ++
         pr_opt (fun p -> str "|" ++ spc() ++ pr_and_type_binders_arg p) indpar ++
         pr_opt (fun s -> str":" ++ spc() ++ pr_lconstr_expr s) s ++

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -633,6 +633,7 @@ let pre_process_structure udecl kind ~template ~cumulative ~poly ~primitive_proj
       | None, _ -> Namegen.next_ident_away name.CAst.v (Termops.vars_of_env (Global.env()))
       | Some n, _ -> n
     in
+    let is_coercion = match is_coercion with AddCoercion -> true | NoCoercion -> false in
     { Data.id = name.CAst.v; idbuild; rdata; is_coercion; coers; inhabitant_id }
   in
   let data = List.map2 map data records in

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -558,9 +558,16 @@ let check_unique_names records =
   | [] -> ()
   | id :: _ -> user_err (str "Two objects have the same name" ++ spc () ++ quote (Id.print id) ++ str ".")
 
+type kind_class = NotClass | RecordClass | DefClass
+
+let kind_class =
+  let open Vernacexpr in
+  function Class true -> DefClass | Class false -> RecordClass
+  | Inductive_kw | CoInductive | Variant | Record | Structure -> NotClass
+
 let check_priorities kind records =
   let open Vernacexpr in
-  let isnot_class = match kind with Class false -> false | _ -> true in
+  let isnot_class = kind_class kind <> RecordClass in
   let has_priority { Ast.cfs; _ } =
     List.exists (fun (_, { rf_priority }) -> not (Option.is_empty rf_priority)) cfs
   in
@@ -582,13 +589,6 @@ let extract_record_data records =
     ps
   in
   ps, data
-
-type kind_class = NotClass | RecordClass | DefClass
-
-let kind_class =
-  let open Vernacexpr in
-  function Class true -> DefClass | Class false -> RecordClass
-  | Inductive_kw | CoInductive | Variant | Record | Structure -> NotClass
 
 let implicits_of_context ctx =
   List.map (fun name -> CAst.make (Some (name,true)))

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -614,12 +614,12 @@ let pre_process_structure udecl kind ~template ~cumulative ~poly ~primitive_proj
     | _ -> implicits_of_context params @ impls in
   let data = List.map (fun ({ DataR.implfs; _ } as d) -> { d with DataR.implfs = List.map adjust_impls implfs }) data in
   let map rdata { Ast.name; is_coercion; cfs; idbuild; default_inhabitant_id; _ } =
-    let coers = List.map (fun (_, { rf_subclass ; rf_reverse ; rf_priority ; rf_canonical }) ->
+    let coers = List.map (fun (_, { rf_subclass ; rf_reversible ; rf_priority ; rf_canonical }) ->
       let pf_subclass, pf_reversible =
         match rf_subclass with
-        | Vernacexpr.BackInstance -> true, Option.default true rf_reverse
+        | Vernacexpr.BackInstance -> true, Option.default true rf_reversible
         | Vernacexpr.NoInstance ->
-          if rf_reverse <> None then
+          if rf_reversible <> None then
             Attributes.(unsupported_attributes
               [CAst.make ("reversible (without :>)",VernacFlagEmpty)]);
           false, false in

--- a/vernac/record.mli
+++ b/vernac/record.mli
@@ -48,7 +48,7 @@ val definition_structure
       { id : Id.t
       ; idbuild : Id.t
       ; is_coercion : bool
-      ; coers : projection_flags list
+      ; proj_flags : projection_flags list
       ; rdata : raw_data
       ; inhabitant_id : Id.t
       }

--- a/vernac/record.mli
+++ b/vernac/record.mli
@@ -42,6 +42,7 @@ val definition_structure
       pf_reversible: bool;
       pf_instance: bool;
       pf_priority: int option;
+      pf_locality: Goptions.option_locality;
       pf_canonical: bool;
     }
     type raw_data
@@ -95,6 +96,7 @@ module Internal : sig
     pf_reversible: bool;
     pf_instance: bool;
     pf_priority: int option;
+    pf_locality: Goptions.option_locality;
     pf_canonical: bool;
   }
 

--- a/vernac/record.mli
+++ b/vernac/record.mli
@@ -38,8 +38,9 @@ val definition_structure
 
   module Data : sig
     type projection_flags = {
-      pf_subclass: bool;
+      pf_coercion: bool;
       pf_reversible: bool;
+      pf_instance: bool;
       pf_priority: int option;
       pf_canonical: bool;
     }
@@ -90,8 +91,9 @@ val declare_existing_class : GlobRef.t -> unit
    current user Elpi, see https://github.com/LPCIC/coq-elpi/pull/151 *)
 module Internal : sig
   type projection_flags = {
-    pf_subclass: bool;
+    pf_coercion: bool;
     pf_reversible: bool;
+    pf_instance: bool;
     pf_priority: int option;
     pf_canonical: bool;
   }

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -922,7 +922,8 @@ let preprocess_inductive_decl ~atts kind indl =
       user_err Pp.(str "Definitional classes do not support the \">\" syntax.");
     let ((rf_coercion, rf_instance), (lid, ce)) = l in
     let f = AssumExpr ((make ?loc:lid.loc @@ Name lid.v), [], ce),
-            { rf_coercion ; rf_reversible = None ; rf_instance ; rf_priority = None ; rf_notation = [] ; rf_canonical = true } in
+            { rf_coercion ; rf_reversible = None ; rf_instance ; rf_priority = None ;
+              rf_locality = Goptions.OptDefault ; rf_notation = [] ; rf_canonical = true } in
     let recordl = [id, bl, c, None, [f], None] in
     let kind = Class true in
     let records = vernac_record ~template udecl ~cumulative kind ~poly ?typing_flags ~primitive_proj finite recordl in

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -920,10 +920,9 @@ let preprocess_inductive_decl ~atts kind indl =
     in
     if fst id = AddCoercion then
       user_err Pp.(str "Definitional classes do not support the \">\" syntax.");
-    let (coe, (lid, ce)) = l in
-    let coe' = match coe with AddCoercion -> BackInstance | NoCoercion -> NoInstance in
+    let ((rf_coercion, rf_instance), (lid, ce)) = l in
     let f = AssumExpr ((make ?loc:lid.loc @@ Name lid.v), [], ce),
-            { rf_subclass = coe' ; rf_reversible = None ; rf_priority = None ; rf_notation = [] ; rf_canonical = true } in
+            { rf_coercion ; rf_reversible = None ; rf_instance ; rf_priority = None ; rf_notation = [] ; rf_canonical = true } in
     let recordl = [id, bl, c, None, [f], None] in
     let kind = Class true in
     let records = vernac_record ~template udecl ~cumulative kind ~poly ?typing_flags ~primitive_proj finite recordl in

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -918,10 +918,10 @@ let preprocess_inductive_decl ~atts kind indl =
       | bl, None -> bl
       | _ -> CErrors.user_err Pp.(str "Definitional classes do not support the \"|\" syntax.")
     in
-    if fst id then
+    if fst id = AddCoercion then
       user_err Pp.(str "Definitional classes do not support the \">\" syntax.");
     let (coe, (lid, ce)) = l in
-    let coe' = if coe then BackInstance else NoInstance in
+    let coe' = match coe with AddCoercion -> BackInstance | NoCoercion -> NoInstance in
     let f = AssumExpr ((make ?loc:lid.loc @@ Name lid.v), [], ce),
             { rf_subclass = coe' ; rf_reverse = None ; rf_priority = None ; rf_notation = [] ; rf_canonical = true } in
     let recordl = [id, bl, c, None, [f], None] in
@@ -964,7 +964,7 @@ let preprocess_inductive_decl ~atts kind indl =
     | Variant | Inductive_kw | CoInductive -> ()
     in
     let check_name ((na, _, _, _), _) = match na with
-    | (true, _) ->
+    | (AddCoercion, _) ->
       user_err (str "Variant types do not handle the \"> Name\" \
         syntax, which is reserved for records. Use the \":>\" \
         syntax on constructors instead.")

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -923,7 +923,7 @@ let preprocess_inductive_decl ~atts kind indl =
     let (coe, (lid, ce)) = l in
     let coe' = match coe with AddCoercion -> BackInstance | NoCoercion -> NoInstance in
     let f = AssumExpr ((make ?loc:lid.loc @@ Name lid.v), [], ce),
-            { rf_subclass = coe' ; rf_reverse = None ; rf_priority = None ; rf_notation = [] ; rf_canonical = true } in
+            { rf_subclass = coe' ; rf_reversible = None ; rf_priority = None ; rf_notation = [] ; rf_canonical = true } in
     let recordl = [id, bl, c, None, [f], None] in
     let kind = Class true in
     let records = vernac_record ~template udecl ~cumulative kind ~poly ?typing_flags ~primitive_proj finite recordl in

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -106,7 +106,10 @@ type search_restriction =
 
 type verbose_flag   = bool (* true = Verbose;       false = Silent         *)
 type coercion_flag  = AddCoercion | NoCoercion
-type instance_flag  = BackInstance | NoInstance
+(* Remove BackInstanceWarning at end of deprecation phase
+   (this is just to print a warning when :> is used instead of ::
+   to declare instances in classes) *)
+type instance_flag  = BackInstance | BackInstanceWarning | NoInstance
 
 type export_flag = Lib.export_flag = Export | Import
 
@@ -182,15 +185,17 @@ type inductive_kind = Inductive_kw | CoInductive | Variant | Record | Structure 
 type simple_binder = lident list  * constr_expr
 type class_binder = lident * constr_expr list
 type 'a with_coercion = coercion_flag * 'a
+type 'a with_coercion_instance = (coercion_flag * instance_flag) * 'a
 (* Attributes of a record field declaration *)
 type record_field_attr = {
-  rf_subclass: instance_flag; (* the projection is an implicit coercion or an instance *)
-  rf_reversible: bool option;
+  rf_coercion: coercion_flag; (* the projection is an implicit coercion *)
+  rf_reversible: bool option; (* coercion is reversible, if relevant *)
+  rf_instance: instance_flag; (* the projection is an instance *)
   rf_priority: int option; (* priority of the instance, if relevant *)
   rf_notation: decl_notation list;
   rf_canonical: bool; (* use this projection in the search for canonical instances *)
   }
-type constructor_expr = (lident * constr_expr) with_coercion
+type constructor_expr = (lident * constr_expr) with_coercion_instance
 type constructor_list_or_record_decl_expr =
   | Constructors of constructor_expr list
   | RecordDecl of lident option * (local_decl_expr * record_field_attr) list * lident option

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -105,7 +105,7 @@ type search_restriction =
   | SearchOutside of qualid list
 
 type verbose_flag   = bool (* true = Verbose;       false = Silent         *)
-type coercion_flag  = bool (* true = AddCoercion    false = NoCoercion     *)
+type coercion_flag  = AddCoercion | NoCoercion
 type instance_flag  = BackInstance | NoInstance
 
 type export_flag = Lib.export_flag = Export | Import

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -192,6 +192,7 @@ type record_field_attr = {
   rf_reversible: bool option; (* coercion is reversible, if relevant *)
   rf_instance: instance_flag; (* the projection is an instance *)
   rf_priority: int option; (* priority of the instance, if relevant *)
+  rf_locality: Goptions.option_locality; (* locality of coercion and instance *)
   rf_notation: decl_notation list;
   rf_canonical: bool; (* use this projection in the search for canonical instances *)
   }

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -185,7 +185,7 @@ type 'a with_coercion = coercion_flag * 'a
 (* Attributes of a record field declaration *)
 type record_field_attr = {
   rf_subclass: instance_flag; (* the projection is an implicit coercion or an instance *)
-  rf_reverse: bool option;
+  rf_reversible: bool option;
   rf_priority: int option; (* priority of the instance, if relevant *)
   rf_notation: decl_notation list;
   rf_canonical: bool; (* use this projection in the search for canonical instances *)


### PR DESCRIPTION
And deprecate :> in Class definitions so that it can be used to declare coercions (like it does in record definitions) in a few versions.

Fixes / closes #16224 

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  - [x] Documented any new / changed **user messages**.
  - [x] Updated **documented syntax** by running `make -f Makefile.dune doc_gram_rsts`.
- [x] Opened **overlay** pull requests.

#### Overlay (to be merged in sync with this PR)

- https://github.com/LPCIC/coq-elpi/pull/369