### PR TITLE
[v8.14] Backport #15271: Delay removing native_compute .ml files until exit

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ variables:
   # Format: $IMAGE-V$DATE-$hash
   # The $hash is the first 10 characters of the md5 of the Dockerfile. e.g.
   # echo $(md5sum dev/ci/docker/bionic_coq/Dockerfile | head -c 10)
-  CACHEKEY: "bionic_coq-V2021-05-22-9c7889b60a"
+  CACHEKEY: "bionic_coq-v8.14-V2021-05-22-5ae31e9b90"
   IMAGE: "$CI_REGISTRY_IMAGE:$CACHEKEY"
   # By default, jobs run in the base switch; override to select another switch
   OPAM_SWITCH: "base"

--- a/dev/ci/docker/bionic_coq/Dockerfile
+++ b/dev/ci/docker/bionic_coq/Dockerfile
@@ -63,12 +63,13 @@ RUN opam switch create "${COMPILER}+32bit" && eval $(opam env) && \
 
 # EDGE switch, dune 2.8 is required for OCaml 4.12
 ENV COMPILER_EDGE="4.12.0" \
-    BASE_OPAM_EDGE="dune.2.8.5 dune-release.1.4.0"
+    BASE_OPAM_EDGE="dune.2.8.5 dune-release.1.4.0" \
+    COQIDE_OPAM_EDGE="lablgtk3-sourceview3.3.1.2"
 
 # EDGE+flambda switch, we install CI_OPAM as to be able to use
 # `ci-template-flambda` with everything.
 RUN opam switch create 4.12.0+flambda --packages="ocaml-variants.${COMPILER_EDGE}+options,ocaml-option-flambda" && eval $(opam env) && \
-    opam install $BASE_OPAM $BASE_OPAM_EDGE $COQIDE_OPAM $CI_OPAM
+    opam install $BASE_OPAM $BASE_OPAM_EDGE $COQIDE_OPAM_EDGE $CI_OPAM
 
 RUN opam clean -a -c
 

--- a/kernel/nativelib.ml
+++ b/kernel/nativelib.ml
@@ -48,6 +48,11 @@ let () = at_exit (fun () ->
           Pp.(str "Native compile: failed to cleanup: " ++
               str(Printexc.to_string e) ++ fnl()))
 
+let delay_cleanup_file =
+  let toclean = ref [] in
+  let () = at_exit (fun () -> List.iter (fun f -> if Sys.file_exists f then Sys.remove f) !toclean) in
+  fun f -> if not (keep_debug_files()) then toclean := f :: !toclean
+
 (* We have to delay evaluation of include_dirs because coqlib cannot
    be guessed until flags have been properly initialized. It also lets
    us avoid forcing [my_temp_dir] if we don't need it (eg stdlib file
@@ -146,7 +151,9 @@ let call_compiler ?profile:(profile=false) ml_filename =
 let compile fn code ~profile:profile =
   write_ml_code fn code;
   let r = call_compiler ~profile fn in
-  if (not (keep_debug_files ())) && Sys.file_exists fn then Sys.remove fn;
+  (* NB: to prevent reusing the same filename we MUST NOT remove the file until exit
+     cf #15263 *)
+  delay_cleanup_file fn;
   r
 
 type native_library = Nativecode.global list * Nativevalues.symbols
@@ -164,7 +171,7 @@ let compile_library (code, symb) fn =
   let fn = dirname / basename in
   write_ml_code fn ~header code;
   let _ = call_compiler fn in
-  if (not (keep_debug_files ())) && Sys.file_exists fn then Sys.remove fn
+  delay_cleanup_file fn
 
 let execute_library ~prefix f upds =
   rt1 := dummy_value ();


### PR DESCRIPTION
Issue #15263 continues to cause problems on the CI of https://github.com/coq-community/coq-performance-tests, which builds performance plots on old versions of Coq.  I'd therefore like to have #15271 backported and merged into the dev branches of the older versions of Coq.	