### PR TITLE
CI: Put "v8.16" in CACHEKEY

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ variables:
   # Format: $IMAGE-V$DATE-$hash
   # The $hash is the first 10 characters of the md5 of the Dockerfile. e.g.
   # echo $(md5sum dev/ci/docker/bionic_coq/Dockerfile | head -c 10)
-  CACHEKEY: "bionic_coq-V2022-05-20-c34331afa5"
+  CACHEKEY: "bionic_coq-v8.16-V2022-05-20-c34331afa5"
   IMAGE: "$CI_REGISTRY_IMAGE:$CACHEKEY"
   # By default, jobs run in the base switch; override to select another switch
   OPAM_SWITCH: "base"


### PR DESCRIPTION
This should keep the image from getting cleaned up in the future.
