### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -2,6 +2,9 @@ name: GitHub macOS CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   macOS:
     runs-on: macOS-10.15

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -2,6 +2,9 @@ name: Windows CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   Windows:
     name: Windows

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,9 +5,14 @@ on:
     # Every workday at 2am
     - cron: '0 2 * * 1-5'
 
+permissions:
+  contents: read
+
 jobs:
   stale_prs:
     # Do not run on forks (we want this request to happen only once every night)
+    permissions:
+      contents: none
     if: github.repository_owner == 'coq'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
