### PR TITLE
Remove `overwrite_library_filenames` function in library.ml

### DIFF
--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -141,12 +141,6 @@ let library_full_filename dir =
   try DPmap.find dir !libraries_filename_table
   with Not_found -> "<unavailable filename>"
 
-let overwrite_library_filenames f =
-  let f =
-    if Filename.is_relative f then Filename.concat (Sys.getcwd ()) f else f in
-  DPmap.iter (fun dir _ -> register_library_filename dir f)
-    !libraries_table
-
 let library_is_loaded dir =
   try let _ = find_library dir in true
   with Not_found -> false

--- a/vernac/library.mli
+++ b/vernac/library.mli
@@ -68,9 +68,6 @@ val loaded_libraries : unit -> DirPath.t list
   (** - Return the full filename of a loaded library. *)
 val library_full_filename : DirPath.t -> string
 
-  (** - Overwrite the filename of all libraries (used when restoring a state) *)
-val overwrite_library_filenames : string -> unit
-
 (** {6 Native compiler. } *)
 val native_name_from_filename : string -> string
 


### PR DESCRIPTION
It seems to be dead code.