### PR TITLE
Fix the locality hint warnings in core files

### DIFF
--- a/doc/plugin_tutorial/tuto3/theories/Data.v
+++ b/doc/plugin_tutorial/tuto3/theories/Data.v
@@ -15,7 +15,7 @@ Notation "!!!" := (pack _) (at level 0, only printing).
 
 Class EvenNat the_even := {half : nat; half_prop : 2 * half = the_even}.
 
-Instance EvenNat0 : EvenNat 0 := {half := 0; half_prop := eq_refl}.
+#[export] Instance EvenNat0 : EvenNat 0 := {half := 0; half_prop := eq_refl}.
 
 Lemma even_rec n h : 2 * h = n -> 2 * S h = S (S n).
 Proof.
@@ -24,7 +24,7 @@ Proof.
   reflexivity.
 Qed.
 
-Instance EvenNat_rec n (p : EvenNat n) : EvenNat (S (S n)) :=
+#[export] Instance EvenNat_rec n (p : EvenNat n) : EvenNat (S (S n)) :=
  {half := S (@half _ p); half_prop := even_rec n (@half _ p) (@half_prop _ p)}.
 
 Definition tuto_div2 n (p : EvenNat n) := @half _ p.

--- a/test-suite/bugs/HoTT_coq_007.v
+++ b/test-suite/bugs/HoTT_coq_007.v
@@ -18,7 +18,7 @@ Module Comment1.
 
   Create HintDb functor discriminated.
 
-  Hint Rewrite @FIdentityOf : functor.
+  #[export] Hint Rewrite @FIdentityOf : functor.
 
   Polymorphic Definition ComposeFunctors objC C objD D objE E (G : @Functor objD D objE E) (F : @Functor objC C objD D) : Functor C E.
   refine {| ObjectOf := (fun c => G (F c));
@@ -66,7 +66,7 @@ Module Comment2.
 
   Create HintDb morphism discriminated.
 
-  Polymorphic Hint Resolve @LeftIdentity : morphism.
+  #[export] Polymorphic Hint Resolve @LeftIdentity : morphism.
 
   Polymorphic Definition ProductCategory objC (C : Category objC) objD (D : Category objD) : @Category (objC * objD)%type.
   refine {|
@@ -107,8 +107,8 @@ Module Comment3.
   trivial.
   Qed.
 
-  Polymorphic Hint Resolve foo. (* success *)
-  Polymorphic Hint Rewrite @foo. (* Success *)
-  Polymorphic Hint Resolve @foo. (* Error: @foo is a term and cannot be made a polymorphic hint, only global references can be polymorphic hints. *)
-  Fail Polymorphic Hint Rewrite foo. (* Error: Cannot infer the implicit parameter obj of foo. *)
+  #[export] Polymorphic Hint Resolve foo. (* success *)
+  #[export] Polymorphic Hint Rewrite @foo. (* Success *)
+  #[export] Polymorphic Hint Resolve @foo. (* Error: @foo is a term and cannot be made a polymorphic hint, only global references can be polymorphic hints. *)
+  Fail #[export] Polymorphic Hint Rewrite foo. (* Error: Cannot infer the implicit parameter obj of foo. *)
 End Comment3.

--- a/test-suite/bugs/HoTT_coq_025.v
+++ b/test-suite/bugs/HoTT_coq_025.v
@@ -2,7 +2,7 @@ Module monomorphic.
   Class Inhabited (A : Type) : Prop := populate { _ : A }.
   Arguments populate {_} _.
 
-  Instance prod_inhabited {A B : Type} (iA : Inhabited A)
+  #[export] Instance prod_inhabited {A B : Type} (iA : Inhabited A)
            (iB : Inhabited B) :   Inhabited (A * B) :=
     match iA, iB with
       | populate x, populate y => populate (x,y)
@@ -21,7 +21,7 @@ Module polymorphic.
   Class Inhabited (A : Type) : Prop := populate { _ : A }.
   Arguments populate {_} _.
 
-  Instance prod_inhabited {A B : Type} (iA : Inhabited A)
+  #[export] Instance prod_inhabited {A B : Type} (iA : Inhabited A)
            (iB : Inhabited B) :   Inhabited (A * B) :=
     match iA, iB with
       | populate x, populate y => populate (x,y)

--- a/test-suite/bugs/HoTT_coq_062.v
+++ b/test-suite/bugs/HoTT_coq_062.v
@@ -39,7 +39,7 @@ Record Equiv A B :=
       equiv_isequiv :> IsEquiv equiv_fun
     }.
 
-Existing Instance equiv_isequiv.
+#[export] Existing Instance equiv_isequiv.
 
 Notation "A <~> B" := (Equiv A B) (at level 85) : equiv_scope.
 

--- a/test-suite/bugs/HoTT_coq_063.v
+++ b/test-suite/bugs/HoTT_coq_063.v
@@ -11,7 +11,7 @@ Module A.
   Existing Class IsTrunc.
 
 
-  Instance is_trunc_unit : IsTrunc 0 unit.
+  #[export] Instance is_trunc_unit : IsTrunc 0 unit.
   Proof. apply BuildContr with (center:=tt). now intros []. Defined.
 
   Check (_ : IsTrunc 0 unit).
@@ -26,7 +26,7 @@ Module B.
 
   Existing Class IsTrunc.
 
-  Instance is_trunc_unit : IsTrunc 0 unit.
+  #[export] Instance is_trunc_unit : IsTrunc 0 unit.
   Proof. exact I. Defined.
 
   Check (_ : IsTrunc 0 unit).

--- a/test-suite/bugs/HoTT_coq_064.v
+++ b/test-suite/bugs/HoTT_coq_064.v
@@ -37,7 +37,7 @@ Module Export Overture.
 
   Class Funext.
   Axiom isequiv_apD10 : `{Funext} -> forall (A : Type) (P : A -> Type) f g, IsEquiv (@apD10 A P f g) .
-  Existing Instance isequiv_apD10.
+  #[export] Existing Instance isequiv_apD10.
 
   Definition path_forall `{Funext} {A : Type} {P : A -> Type} (f g : forall x : A, P x) :
     (forall x, f x = g x) -> f = g
@@ -178,7 +178,7 @@ Definition IsColimit `{Funext} C D (F : Functor D C)
 
 Generalizable All Variables.
 Axiom fs : Funext.
-Existing Instance fs.
+#[export] Existing Instance fs.
 
 Section bar.
 

--- a/test-suite/bugs/HoTT_coq_079.v
+++ b/test-suite/bugs/HoTT_coq_079.v
@@ -10,7 +10,7 @@ Notation "x = y" := (x = y :> _).
 Record foo := { x : Type; H : x = x }.
 
 Create HintDb bar discriminated.
-Hint Resolve H : bar.
+#[export] Hint Resolve H : bar.
 Goal forall y : foo, @x y = @x y.
 intro y.
 progress auto with bar. (* failed to progress *)

--- a/test-suite/bugs/HoTT_coq_090.v
+++ b/test-suite/bugs/HoTT_coq_090.v
@@ -81,7 +81,7 @@ Arguments transport {A} P {x y} p%path_scope u : simpl nomatch.
 
 
 
-Instance isequiv_path {A B : Type} (p : A = B)
+#[export] Instance isequiv_path {A B : Type} (p : A = B)
   : IsEquiv (transport (fun X:Type => X) p) | 0.
 Proof.
   unshelve refine (@BuildIsEquiv _ _ _ (transport (fun X:Type => X) p^) _ _ _);

--- a/test-suite/bugs/HoTT_coq_107.v
+++ b/test-suite/bugs/HoTT_coq_107.v
@@ -45,7 +45,7 @@ Class IsTrunc (n : trunc_index) (A : Type) : Type :=
 
 Notation Contr := (IsTrunc minus_two).
 
-Hint Extern 0 => progress change Contr_internal with Contr in * : typeclass_instances.
+#[export] Hint Extern 0 => progress change Contr_internal with Contr in * : typeclass_instances.
 
 Definition path_contr `{Contr A} (x y : A) : x = y
   := admit.
@@ -54,7 +54,7 @@ Definition path_sigma' {A : Type} (P : A -> Type) {x x' : A} {y : P x} {y' : P x
            (p : x = x') (q : transport _ p y = y')
 : existT _ x y = existT _ x' y'
   := admit.
-Instance trunc_sigma `{P : A -> Type}
+#[export] Instance trunc_sigma `{P : A -> Type}
          `{IsTrunc n A} `{forall a, IsTrunc n (P a)}
 : IsTrunc n (sigT P) | 100.
 

--- a/test-suite/bugs/HoTT_coq_108.v
+++ b/test-suite/bugs/HoTT_coq_108.v
@@ -52,7 +52,7 @@ Fixpoint IsTrunc_internal (n : trunc_index) (A : Type) : Type :=
 Class IsTrunc (n : trunc_index) (A : Type) : Type :=
   Trunc_is_trunc : IsTrunc_internal n A.
 
-Instance istrunc_paths (A : Type) n `{H : IsTrunc (trunc_S n) A} (x y : A)
+#[export] Instance istrunc_paths (A : Type) n `{H : IsTrunc (trunc_S n) A} (x y : A)
 : IsTrunc n (x = y)
   := H x y.
 
@@ -66,7 +66,7 @@ Global Instance contr_forall `{Funext} `{P : A -> Type} `{forall a, Contr (P a)}
 : Contr (forall a, P a) | 100.
 admit.
 Defined.
-Hint Extern 0 => progress change Contr_internal with Contr in * : typeclass_instances.
+#[export] Hint Extern 0 => progress change Contr_internal with Contr in * : typeclass_instances.
 Global Instance trunc_forall `{Funext} `{P : A -> Type} `{forall a, IsTrunc n (P a)}
 : IsTrunc n (forall a, P a) | 100.
 Proof.
@@ -83,7 +83,7 @@ Record PreCategory :=
     compose : forall s d d', morphism d d' -> morphism s d -> morphism s d';
     trunc_morphism : forall s d, IsHSet (morphism s d) }.
 
-Existing Instance trunc_morphism.
+#[export] Existing Instance trunc_morphism.
 Infix "o" := (@compose _ _ _ _) : morphism_scope.
 Local Open Scope morphism_scope.
 

--- a/test-suite/bugs/HoTT_coq_112.v
+++ b/test-suite/bugs/HoTT_coq_112.v
@@ -35,7 +35,7 @@ Notation "A <~> B" := (Equiv A B) (at level 85) : equiv_scope.
 Notation "f ^-1" := (@equiv_inv _ _ f _) (at level 3) : equiv_scope.
 Local Open Scope equiv_scope.
 
-Instance isequiv_path {A B : Type} (p : A = B)
+#[export] Instance isequiv_path {A B : Type} (p : A = B)
   : IsEquiv (transport (fun X:Type => X) p) | 0
   := admit.
 Definition equiv_path (A B : Type) (p : A = B) : A <~> B

--- a/test-suite/bugs/HoTT_coq_117.v
+++ b/test-suite/bugs/HoTT_coq_117.v
@@ -16,26 +16,26 @@ Definition path_forall `{Funext} {A : Type} {P : A -> Type} (f g : forall x : A,
 Admitted.
 
 Inductive Empty : Set := .
-Fail Instance contr_from_Empty {_ : Funext} (A : Type) :
+Fail #[export] Instance contr_from_Empty {_ : Funext} (A : Type) :
   Contr_internal (Empty -> A) :=
   BuildContr _
              (Empty_rect (fun _ => A))
              (fun f => path_forall _ f (fun x => Empty_rect _ x)).
 
-Fail Instance contr_from_Empty {F : Funext} (A : Type) :
+Fail #[export] Instance contr_from_Empty {F : Funext} (A : Type) :
   Contr_internal (Empty -> A) :=
   BuildContr _
              (Empty_rect (fun _ => A))
              (fun f => path_forall _ f (fun x => Empty_rect _ x)).
 
 (** This could be disallowed, this uses the Funext argument *)
-Instance contr_from_Empty {_ : Funext} (A : Type) :
+#[export] Instance contr_from_Empty {_ : Funext} (A : Type) :
   Contr_internal (Empty -> A) :=
   BuildContr _
              (Empty_rect (fun _ => A))
              (fun f => path_forall _ f (fun x => Empty_rect (fun _ => _ x = f x) x)).
 
-Instance contr_from_Empty' {_ : Funext} (A : Type) :
+#[export] Instance contr_from_Empty' {_ : Funext} (A : Type) :
   Contr_internal (Empty -> A) :=
   BuildContr _
              (Empty_rect (fun _ => A))

--- a/test-suite/bugs/HoTT_coq_118.v
+++ b/test-suite/bugs/HoTT_coq_118.v
@@ -10,9 +10,9 @@ Arguments idpath {A a} , [A] a.
 Notation "x = y" := (@paths _ x y) : type_scope.
 Class Contr_internal (A : Type) := BuildContr { center : A }.
 Arguments center A {_}.
-Instance contr_paths_contr `{Contr_internal A} (x y : A) : Contr_internal (x = y) := admit.
+#[export] Instance contr_paths_contr `{Contr_internal A} (x y : A) : Contr_internal (x = y) := admit.
 Inductive Unit : Set := tt.
-Instance contr_unit : Contr_internal Unit | 0 := admit.
+#[export] Instance contr_unit : Contr_internal Unit | 0 := admit.
 Record PreCategory := { morphism : Type }.
 Class IsIsomorphism {C : PreCategory} (m : morphism C) := { left_inverse : m = m }.
 Definition indiscrete_category : PreCategory := @Build_PreCategory Unit.

--- a/test-suite/bugs/HoTT_coq_120.v
+++ b/test-suite/bugs/HoTT_coq_120.v
@@ -44,11 +44,11 @@ Notation IsHSet := (IsTrunc 0).
 Class Funext := {}.
 Inductive Unit : Set := tt.
 
-Instance contr_unit : Contr Unit | 0 := let x := {|
+#[export] Instance contr_unit : Contr Unit | 0 := let x := {|
                                               center := tt;
                                               contr := fun t : Unit => match t with tt => idpath end
                                             |} in x.
-Instance trunc_succ `{IsTrunc n A} : IsTrunc (trunc_S n) A | 1000.
+#[export] Instance trunc_succ `{IsTrunc n A} : IsTrunc (trunc_S n) A | 1000.
 admit.
 Defined.
 Record hProp := hp { hproptype :> Type ; isp : IsHProp hproptype}.
@@ -90,7 +90,7 @@ Definition set_cat : PreCategory
                         (fun x y => forall _ : x, y)%core
                         (fun _ _ _ f g x => f (g x))%core.
 Inductive minus1Trunc (A :Type) : Type := min1 : A -> minus1Trunc A.
-Instance minus1Trunc_is_prop {A : Type} : IsHProp (minus1Trunc A) | 0. Admitted.
+#[export] Instance minus1Trunc_is_prop {A : Type} : IsHProp (minus1Trunc A) | 0. Admitted.
 Definition hexists {X} (P:X->Type):Type:= minus1Trunc (sigT  P).
 Definition isepi {X Y} `(f:X->Y) := forall Z: hSet,
                                     forall g h: Y -> Z, (fun x => g (f x)) = (fun x => h (f x)) -> g = h.

--- a/test-suite/bugs/HoTT_coq_122.v
+++ b/test-suite/bugs/HoTT_coq_122.v
@@ -22,4 +22,4 @@ Record PreCategory :=
       left_identity : forall a b (f : morphism a b), identity b o f = f
     }.
 
-Hint Rewrite @left_identity. (* stack overflow *)
+#[export] Hint Rewrite @left_identity. (* stack overflow *)

--- a/test-suite/bugs/HoTT_coq_123.v
+++ b/test-suite/bugs/HoTT_coq_123.v
@@ -13,7 +13,7 @@ Arguments idpath {A a} , [A] a.
 Notation "x = y" := (@paths _ x y) : type_scope.
 Definition pointwise_paths {A} {P:A->Type} (f g:forall x:A, P x) : Type
   := forall x:A, f x = g x.
-Hint Unfold pointwise_paths : typeclass_instances.
+#[export] Hint Unfold pointwise_paths : typeclass_instances.
 Notation "f == g" := (pointwise_paths f g) (at level 70, no associativity) : type_scope.
 Definition apD10 {A} {B:A->Type} {f g : forall x, B x} (h:f=g)
 : forall x, f x = g x
@@ -39,7 +39,7 @@ Fixpoint IsTrunc_internal (n : trunc_index) (A : Type) : Type :=
 Class IsTrunc (n : trunc_index) (A : Type) : Type :=
   Trunc_is_trunc : IsTrunc_internal n A.
 
-Instance istrunc_paths (A : Type) n `{H : IsTrunc (trunc_S n) A} (x y : A)
+#[export] Instance istrunc_paths (A : Type) n `{H : IsTrunc (trunc_S n) A} (x y : A)
 : IsTrunc n (x = y)
   := H x y.
 
@@ -52,7 +52,7 @@ Local Open Scope equiv_scope.
 
 Global Instance isequiv_inverse `{IsEquiv A B f} : IsEquiv f^-1 | 10000
   := BuildIsEquiv B A f^-1 f.
-Instance trunc_succ `{IsTrunc n A} : IsTrunc (trunc_S n) A | 1000.
+#[export] Instance trunc_succ `{IsTrunc n A} : IsTrunc (trunc_S n) A | 1000.
 
 admit.
 
@@ -92,7 +92,7 @@ Record PreCategory :=
 
       trunc_morphism : forall s d, IsHSet (morphism s d)
     }.
-Existing Instance trunc_morphism.
+#[export] Existing Instance trunc_morphism.
 
 Infix "o" := (@compose _ _ _ _) : morphism_scope.
 Delimit Scope functor_scope with functor.
@@ -116,7 +116,7 @@ Proof.
   - admit.
   - pose (fun f g => trunc_equiv (@apD10 A P f g) ^-1); admit.
 Defined.
-Instance trunc_sigma `{P : A -> Type}
+#[export] Instance trunc_sigma `{P : A -> Type}
          `{IsTrunc n A} `{forall a, IsTrunc n (P a)}
 : IsTrunc n (sigT P) | 100.
 admit.

--- a/test-suite/bugs/bug_10225.v
+++ b/test-suite/bugs/bug_10225.v
@@ -1,7 +1,7 @@
 
 Class Bar := {}.
-Instance bb : Bar := {}.
+#[export] Instance bb : Bar := {}.
 
 Class Foo := { xx : Bar; foo : nat }.
 
-Fail Instance bar : Foo := { foo := 1 + 1; foo := 2 + 2 }.
+Fail #[export] Instance bar : Foo := { foo := 1 + 1; foo := 2 + 2 }.

--- a/test-suite/bugs/bug_10264.v
+++ b/test-suite/bugs/bug_10264.v
@@ -3,7 +3,7 @@ Require Import Program.Tactics.
 Definition bla (A:Type) := A.
 Existing Class bla.
 
-Program Instance fubar : bla nat := {}.
+#[export] Program Instance fubar : bla nat := {}.
 Next Obligation.
 Fail exact bool.
 exact 0.

--- a/test-suite/bugs/bug_10762.v
+++ b/test-suite/bugs/bug_10762.v
@@ -7,7 +7,7 @@ Parameter val: Type.
 Class Enc (A:Type) : Type :=
   make_Enc { enc : A -> val }.
 
-Hint Mode Enc + : typeclass_instances.
+#[export] Hint Mode Enc + : typeclass_instances.
 
 Parameter bar : forall A (EA:Enc A), EA = EA.
 

--- a/test-suite/bugs/bug_10923.v
+++ b/test-suite/bugs/bug_10923.v
@@ -11,7 +11,7 @@ Reserved Notation "A <- X ; B" (at level 70, X at next level, right associativit
 Notation "v <- x ; f" := (bind x (fun v => f)).
 Axiom bind_Proper : Proper (eq ==> (eq ==> eq) ==> eq) bind.
 Axiom bind_Proper' : Proper (eq ==> pointwise_relation _ eq ==> eq) bind.
-Existing Instances bind_Proper bind_Proper'.
+#[export] Existing Instances bind_Proper bind_Proper'.
 
 Module Thunked.
   Definition nat_rect P (O_case : unit -> P) (S_case : nat -> P -> P) (n : nat) : P

--- a/test-suite/bugs/bug_11011.v
+++ b/test-suite/bugs/bug_11011.v
@@ -6,7 +6,7 @@ Parameter B C : Type.
 Parameter P : Type -> Type -> Type.
 
 (* This is used for rewrites for lem_P and lem_P_iffT. *)
-Instance P_Proper : Proper (iffT ==> iffT ==> iffT) (P).
+#[export] Instance P_Proper : Proper (iffT ==> iffT ==> iffT) (P).
 Admitted.
 
 Lemma lem_P : forall A, iffT A B -> P A C -> P B C.
@@ -22,11 +22,11 @@ Proof.
 Abort.
 
 (* Trying to do the same with iffT instead of P. *)
-Instance iffT_Proper : Proper (iffT ==> iffT ==> iffT) iffT.
+#[export] Instance iffT_Proper : Proper (iffT ==> iffT ==> iffT) iffT.
 Admitted.
 
 (* Just in case? *)
-Instance arrow_Proper  : Proper (iffT ==> iffT ==> iffT ) (arrow).
+#[export] Instance arrow_Proper  : Proper (iffT ==> iffT ==> iffT ) (arrow).
 Admitted.
 
 Lemma lem_iffT_P : forall A, iffT A B -> iffT A C -> P B C.

--- a/test-suite/bugs/bug_11161.v
+++ b/test-suite/bugs/bug_11161.v
@@ -3,8 +3,8 @@
 
 Class Foo (n:nat) := {x : bool}.
 
-Instance bar n : Foo n. Admitted.
+#[export] Instance bar n : Foo n. Admitted.
 
-Instance bar' n : Foo n. split. abstract exact true. Qed.
+#[export] Instance bar' n : Foo n. split. abstract exact true. Qed.
 
-Instance bar'' n : Foo n. split. abstract exact true. Defined.
+#[export] Instance bar'' n : Foo n. split. abstract exact true. Defined.

--- a/test-suite/bugs/bug_11553.v
+++ b/test-suite/bugs/bug_11553.v
@@ -22,7 +22,7 @@ vl_rename (sb : var -> var) v : vl :=
   | var_vl x => var_vl (sb x)
   end.
 
-Instance rename_vl : Rename vl := vl_rename.
+#[export] Instance rename_vl : Rename vl := vl_rename.
 
 Lemma foo ξ x: rename_vl ξ (var_vl x) = var_vl x.
 (* Succeeds *)

--- a/test-suite/bugs/bug_12240.v
+++ b/test-suite/bugs/bug_12240.v
@@ -8,11 +8,11 @@ Inductive R A : A -> A -> Type :=
    (* with crelation A here and CMorphisms on top: no failure *)
 | cR1 l : R l l
 | cR2 l : R l l.  (* with only one constructor, only Fail 1 fails *)
-Hint Constructors R : core.
+#[export] Hint Constructors R : core.
 
-Instance R_refl A : Reflexive (@R A).
+#[export] Instance R_refl A : Reflexive (@R A).
 Proof. auto. Qed.
-Instance R_trans A : Transitive (@R A).
+#[export] Instance R_trans A : Transitive (@R A).
 Proof. intros x y z HR1 HR2; destruct HR1, HR2; auto. Qed.
 
 Goal forall (a b : nat), R a b -> R (id a) (id b).
@@ -30,9 +30,9 @@ Abort.
 
 Definition GuR A (uu : unit) := match uu with unit => @R A end.
 
-Instance GuR_refl A uu : Reflexive (@GuR A uu).
+#[export] Instance GuR_refl A uu : Reflexive (@GuR A uu).
 Proof. destruct uu; apply R_refl. Qed.
-Instance GuR_trans A uu : Transitive (@GuR A uu).
+#[export] Instance GuR_trans A uu : Transitive (@GuR A uu).
 Proof. destruct uu; apply R_trans. Qed.
 
 Goal forall uu (a b : nat), GuR uu a b -> GuR uu (id a) (id b).
@@ -47,9 +47,9 @@ Abort.
 
 Definition GbR A (bb : bool) := if bb then @R A else @R A.
 
-Instance GbR_refl A bb : Reflexive (@GbR A bb).
+#[export] Instance GbR_refl A bb : Reflexive (@GbR A bb).
 Proof. destruct bb; apply R_refl. Qed.
-Instance GbR_trans A bb : Transitive (@GbR A bb).
+#[export] Instance GbR_trans A bb : Transitive (@GbR A bb).
 Proof. destruct bb; apply R_trans. Qed.
 
 Goal forall bb (a b : nat), GbR bb a b -> GbR bb (id a) (id b).

--- a/test-suite/bugs/bug_12418.v
+++ b/test-suite/bugs/bug_12418.v
@@ -14,7 +14,7 @@ Class Cava  := {
 
 Axiom F : forall {A : Type}, (bool -> A) -> Datatypes.unit.
 
-Fail Instance T : Cava := {
+Fail #[export] Instance T : Cava := {
 
   constant b := match b with
     | true => ret tt

--- a/test-suite/bugs/bug_12529.v
+++ b/test-suite/bugs/bug_12529.v
@@ -13,9 +13,9 @@ Class F A := f : A.
 Inductive pFalse : Prop  := .
 Inductive sFalse : SProp := .
 
-Hint Extern 0 (F Prop) => exact pFalse : typeclass_instances.
+#[export] Hint Extern 0 (F Prop) => exact pFalse : typeclass_instances.
 Definition pf := f : Prop.
 
-Hint Extern 0 (F SProp) => exact sFalse : typeclass_instances.
+#[export] Hint Extern 0 (F SProp) => exact sFalse : typeclass_instances.
 Definition sf := (f : SProp).
 Definition pf' := (f : Prop).

--- a/test-suite/bugs/bug_12566_1.v
+++ b/test-suite/bugs/bug_12566_1.v
@@ -1,7 +1,7 @@
 
 Class C (n:nat) := c{}.
 
-Instance c0 : C 0 := {}.
+#[export] Instance c0 : C 0 := {}.
 
 Definition x := 0.
 
@@ -10,7 +10,7 @@ Opaque x.
 Type _ : C x.
 (* this is maybe wrong behaviour, if it changes just update the test *)
 
-Hint Opaque x : typeclass_instances.
+#[export] Hint Opaque x : typeclass_instances.
 Transparent x.
 
 Fail Type _ : C x.

--- a/test-suite/bugs/bug_12571.v
+++ b/test-suite/bugs/bug_12571.v
@@ -2,7 +2,7 @@ Axiom IsTrunc : Type -> Type.
 
 Existing Class IsTrunc.
 
-Declare Instance trunc_forall :
+#[export] Declare Instance trunc_forall :
   forall (A : Type) (P : A -> Type),
   IsTrunc (forall a : A, P a).
 

--- a/test-suite/bugs/bug_12623.v
+++ b/test-suite/bugs/bug_12623.v
@@ -12,7 +12,7 @@ Class Seq (C : Type) :=
   seq : C -> gtactic.
 Arguments seq {C _} _.
 
-Instance seq_one : Seq@{Set _ _} (gtactic) := fun t2 => fun g => raise.
+#[export] Instance seq_one : Seq@{Set _ _} (gtactic) := fun t2 => fun g => raise.
 
 Definition x1 : gtactic := @seq@{_ _ _} _ _ (fun g : goal => raise).
 Definition x2 : gtactic := @seq@{_ _ _} _ seq_one (fun g : goal => raise).

--- a/test-suite/bugs/bug_12975.v
+++ b/test-suite/bugs/bug_12975.v
@@ -16,8 +16,8 @@ Record bar :=
 Existing Class myprop.
 Existing Class myotherprop.
 
-Instance : forall O, myprop O. Abort.
-Instance : forall (O : bar), myotherprop O.
+#[export] Instance : forall O, myprop O. Abort.
+#[export] Instance : forall (O : bar), myotherprop O.
 Proof.
   intros O. destruct O; cbn. exact someprop0.
 Defined.

--- a/test-suite/bugs/bug_13129.v
+++ b/test-suite/bugs/bug_13129.v
@@ -29,8 +29,8 @@ Structure ofeT := OfeT {
   ofe_dist : Dist ofe_car;
   ofe_mixin : OfeMixin ofe_car
 }.
-Hint Extern 0 (Equiv _) => eapply (@ofe_equiv _) : typeclass_instances.
-Hint Extern 0 (Dist _) => eapply (@ofe_dist _) : typeclass_instances.
+#[export] Hint Extern 0 (Equiv _) => eapply (@ofe_equiv _) : typeclass_instances.
+#[export] Hint Extern 0 (Dist _) => eapply (@ofe_dist _) : typeclass_instances.
 
 (** Lifting properties from the mixin *)
 Section ofe_mixin.

--- a/test-suite/bugs/bug_13209.v
+++ b/test-suite/bugs/bug_13209.v
@@ -1,8 +1,8 @@
 Class A (n : nat) := {}.
 Definition three := 3.
-Instance A_three : A three := {}.
+#[export] Instance A_three : A three := {}.
 Definition three' := if true then three else 1.
 (* 1 *) Goal A (if true then three else 1). apply _. Qed.
-Hint Opaque three : typeclass_instances.
+#[export] Hint Opaque three : typeclass_instances.
 (* 2 *) Goal A (if true then three else 1). apply _. Qed.
 (* 3 *) Goal A (three'). apply _. Qed.

--- a/test-suite/bugs/bug_13216.v
+++ b/test-suite/bugs/bug_13216.v
@@ -1,4 +1,4 @@
 Class A.
-Declare Instance a:A.
+#[export] Declare Instance a:A.
 Inductive T `(A) := C.
 Definition f x := match x with C _ => 0 end.

--- a/test-suite/bugs/bug_13246.v
+++ b/test-suite/bugs/bug_13246.v
@@ -18,7 +18,7 @@ Structure bi :=
        bi_impl : bi_car → bi_car → bi_car;
        bi_forall : ∀ A, (A → bi_car) → bi_car; }.
 
-Declare Instance bi_equiv `{PROP:bi} : Equiv (bi_car PROP).
+#[export] Declare Instance bi_equiv `{PROP:bi} : Equiv (bi_car PROP).
 
 Arguments bi_car : simpl never.
 Arguments bi_entails {PROP} _%I _%I : simpl never, rename.

--- a/test-suite/bugs/bug_13348.v
+++ b/test-suite/bugs/bug_13348.v
@@ -6,5 +6,5 @@ Arguments populate {_} _.
 Set Mangle Names.
 Axioms _0 _1 _2 : Prop.
 
-Instance impl_inhabited {A} {B} {_3:Inhabited B} : Inhabited (A -> B)
+#[export] Instance impl_inhabited {A} {B} {_3:Inhabited B} : Inhabited (A -> B)
   := populate (fun _ => inhabitant).

--- a/test-suite/bugs/bug_14125.v
+++ b/test-suite/bugs/bug_14125.v
@@ -1,13 +1,13 @@
 Class A (x : True) := a : True.
 Class B x (y : A x) := b : True.
 Axiom pf : forall x y, B x y -> False.
-Instance: B I I := I.
+#[export] Instance: B I I := I.
 Goal False.
-  Hint Mode A + : typeclass_instances.
+  #[export] Hint Mode A + : typeclass_instances.
   Set Typeclasses Debug.
   pose (pf _ _ _).
   Set Typeclasses Debug Verbosity 2.
 
-  Hint Mode A - : typeclass_instances.
+  #[export] Hint Mode A - : typeclass_instances.
   pose (pf _ _ _).
 Abort.

--- a/test-suite/bugs/bug_1416.v
+++ b/test-suite/bugs/bug_1416.v
@@ -11,7 +11,7 @@ Record Place (Env A: Type) : Type := {
   write_read: forall (e:Env), (write e (read e))=e
 }.
 
-Hint Rewrite -> write_read: placeeq.
+#[export] Hint Rewrite -> write_read: placeeq.
 
 Record sumPl (Env A B: Type) (vL:(Place Env A)) (vR:(Place Env B)) : Type :=
  {
@@ -20,7 +20,7 @@ Record sumPl (Env A B: Type) (vL:(Place Env A)) (vR:(Place Env B)) : Type :=
  }.
 
 (* when the following line is commented, the bug does not appear *)
-Hint Rewrite -> mkEnv2writeL: placeeq.
+#[export] Hint Rewrite -> mkEnv2writeL: placeeq.
 
 Lemma autorewrite_raise_anomaly: forall (Env A:Type) (e: Env) (p:Place Env A),
   (exists e1:Env, e=(write p e1 (read p e))).

--- a/test-suite/bugs/bug_14221.v
+++ b/test-suite/bugs/bug_14221.v
@@ -24,7 +24,7 @@ Ltac cat :=
   auto with category_laws;
   try reflexivity.
 
-Hint Extern 4 (equiv ?A ?A) => reflexivity : category_laws.
+#[export] Hint Extern 4 (equiv ?A ?A) => reflexivity : category_laws.
 
 Ltac proper := repeat intro; simpl; try cat; intuition.
 
@@ -81,7 +81,7 @@ Coercion fobj : Functor >-> Funclass.
 Notation "fmap[ F ]" := (@fmap _ _ F%functor _ _)
   (at level 9, format "fmap[ F ]") : morphism_scope.
 
-Hint Rewrite @fmap_id : categories.
+#[export] Hint Rewrite @fmap_id : categories.
 
 Definition Product (C D : Category) : Category := {|
   obj     := C * D;
@@ -137,7 +137,7 @@ End Bifunctor.
 Notation "bimap[ F ]" := (@bimap _ _ _ F%functor _ _ _ _)
   (at level 9, format "bimap[ F ]") : morphism_scope.
 
-Hint Rewrite @bimap_id_id : categories.
+#[export] Hint Rewrite @bimap_id_id : categories.
 
 Reserved Infix "⨂" (at level 30, right associativity).
 
@@ -150,7 +150,7 @@ Notation "x ⨂ y" := (@tensor _ _ (x%object, y%object))
 Notation "f ⨂ g" := (bimap[@tensor _ _] f g)
   (at level 30, right associativity) : morphism_scope.
 
-Program Instance PP
+#[export] Program Instance PP
         {C : Category} {D : Category} `{@Monoidal D}
         {F : Functor C D} {G : Functor C D} : Functor C D := {
   fobj := fun x => (F x ⨂ G x)%object;

--- a/test-suite/bugs/bug_14239.v
+++ b/test-suite/bugs/bug_14239.v
@@ -4,7 +4,7 @@ Parameter reli : forall (dummy:unit)(R:relation unit), relation unit.
 
 Parameter f g : unit -> unit.
 
-Declare Instance c
+#[export] Declare Instance c
   (dummy : unit) (R : relation unit) :
   Proper (reli dummy R ==> R) f.
 

--- a/test-suite/bugs/bug_14441.v
+++ b/test-suite/bugs/bug_14441.v
@@ -1,19 +1,19 @@
 Require Import Utf8 Relation_Definitions.
 
 Class Equiv A := equiv: relation A.
-Hint Mode Equiv ! : typeclass_instances.
+#[export] Hint Mode Equiv ! : typeclass_instances.
 
 Class Lookup (K A M : Type) := lookup: K → M → option A.
-Hint Mode Lookup ! - - : typeclass_instances.
-Hint Mode Lookup - - ! : typeclass_instances.
+#[export] Hint Mode Lookup ! - - : typeclass_instances.
+#[export] Hint Mode Lookup - - ! : typeclass_instances.
 
 Parameter list_equiv : ∀ A, Equiv A → Equiv (list A).
 Parameter option_equiv : ∀ A, Equiv A → Equiv (option A).
 Parameter list_lookup : ∀ A, Lookup nat A (list A).
 
-Existing Instance list_equiv.
-Existing Instance option_equiv.
-Existing Instance list_lookup.
+#[export] Existing Instance list_equiv.
+#[export] Existing Instance option_equiv.
+#[export] Existing Instance list_lookup.
 
 Set Typeclasses Debug.
 (* fails *)

--- a/test-suite/bugs/bug_14652.v
+++ b/test-suite/bugs/bug_14652.v
@@ -2,11 +2,11 @@ Record myRecord := {
   my_class : Type ;
 }.
 
-Fail Instance my_instance : forall x, my_class x.
+Fail #[export] Instance my_instance : forall x, my_class x.
 
 Existing Class my_class.
 
-Instance my_instance : forall x, my_class x. Abort.
+#[export] Instance my_instance : forall x, my_class x. Abort.
 
 Definition my_existing_instance : forall x, my_class x. Admitted.
 
@@ -19,11 +19,11 @@ Record myOtherRecord := {
   my_other_class : Type ;
 }.
 
-Fail Instance my_other_instance : forall x, my_other_class x.
+Fail #[export] Instance my_other_instance : forall x, my_other_class x.
 
 Existing Class my_other_class.
 
-Instance my_other_instance : forall x, my_other_class x. Abort.
+#[export] Instance my_other_instance : forall x, my_other_class x. Abort.
 
 Definition my_other_existing_instance : forall x, my_other_class x. Admitted.
 

--- a/test-suite/bugs/bug_14734.v
+++ b/test-suite/bugs/bug_14734.v
@@ -7,7 +7,7 @@
     }.
 Monomorphic Inductive X@{s | Set < s} : Type@{s} := x.
 
-#[refine]
+#[refine, export]
  Instance t_X_refl {A} : t X A A := {|prf := _|}.
 Proof. auto. Qed.
 

--- a/test-suite/bugs/bug_15099.v
+++ b/test-suite/bugs/bug_15099.v
@@ -48,7 +48,7 @@ Open Scope functor_type_scope.
 Notation "C ⟶ D" := (@Functor C%category D%category)
   (at level 90, right associativity) : functor_type_scope.
 
-Hint Rewrite @fmap_id : categories.
+#[export] Hint Rewrite @fmap_id : categories.
 
 Ltac cat_simpl :=
   simpl; intros;

--- a/test-suite/bugs/bug_1784.v
+++ b/test-suite/bugs/bug_1784.v
@@ -50,7 +50,7 @@ with slist_in : list sv -> list sv -> Prop :=
   slist_in sv sv' ->
   slist_in (s::sv) sv'.
 
-Hint Constructors sin slt slist_in.
+#[export] Hint Constructors sin slt slist_in.
 
 Require Import Program.
 

--- a/test-suite/bugs/bug_2095.v
+++ b/test-suite/bugs/bug_2095.v
@@ -14,6 +14,6 @@ End OPT.
 
 Definition f_nat (n: nat):  MyOption nat := MySome _ n.
 
-Instance Nat_Opt: Opt nat := {
+#[export] Instance Nat_Opt: Opt nat := {
   f_opt := f_nat
 }.

--- a/test-suite/bugs/bug_2127.v
+++ b/test-suite/bugs/bug_2127.v
@@ -4,5 +4,5 @@
 (* (this is a simplification of the original bug report) *)
 
 Module A.
-Hint Rewrite eq_sym using apply eq_refl : foo.
+#[global] Hint Rewrite eq_sym using apply eq_refl : foo.
 End A.

--- a/test-suite/bugs/bug_2362.v
+++ b/test-suite/bugs/bug_2362.v
@@ -14,7 +14,7 @@ Set Implicit Arguments.
 
 Notation "( x ,> y )" := (fpair x y) (at level 0).
 
-Instance Pointed_FPair B neutral:
+#[export] Instance Pointed_FPair B neutral:
  Pointed (fun A => FPair A B neutral) :=
  { creturn := fun A (a:A) => (a,> neutral) }.
 Definition blah_fail (x:bool) : FPair bool nat O :=
@@ -27,7 +27,7 @@ Definition blah_explicit (x:bool) : FPair bool nat O :=
 Print blah_explicit.
 
 
-Instance Pointed_FPair_mono:
+#[export] Instance Pointed_FPair_mono:
  Pointed (fun A => FPair A nat 0) :=
  { creturn := fun A (a:A) => (a,> 0) }.
 

--- a/test-suite/bugs/bug_2417.v
+++ b/test-suite/bugs/bug_2417.v
@@ -1,6 +1,6 @@
 Parameter x y : nat.
 Axiom H : x = y.
-Hint Rewrite H : mybase.
+#[export] Hint Rewrite H : mybase.
 
 Ltac bar base := autorewrite with base.
 

--- a/test-suite/bugs/bug_2428.v
+++ b/test-suite/bugs/bug_2428.v
@@ -2,7 +2,7 @@ Axiom P : nat -> Prop.
 
 Definition myFact := forall x, P x.
 
-Hint Extern 1 (P _) => progress (unfold myFact in *).
+#[export] Hint Extern 1 (P _) => progress (unfold myFact in *).
 
 Lemma test : (True -> myFact) -> P 3.
 Proof.

--- a/test-suite/bugs/bug_2713.v
+++ b/test-suite/bugs/bug_2713.v
@@ -7,7 +7,7 @@ Lemma pred_le_refl : forall A (P:A->Prop),
   pred_le P P.
 Proof. unfold pred_le. auto. Qed.
 
-Hint Resolve pred_le_refl.
+#[export] Hint Resolve pred_le_refl.
 
 Lemma test :
   forall (P1 P2:nat->Prop),

--- a/test-suite/bugs/bug_2830.v
+++ b/test-suite/bugs/bug_2830.v
@@ -180,7 +180,7 @@ intros. apply fmap_respects. assumption. Qed.
 
 (* HERE IS THE PROBLEMATIC INSTANCE. If we change this to a regular Definition,
    then the problem goes away. *)
-Instance functor_comp `{C:Category} `{D:Category} `{E:Category}
+#[export] Instance functor_comp `{C:Category} `{D:Category} `{E:Category}
   {Gim} (G:Functor D E Gim) {Fim} (F:Functor C D Fim)
   : Functor C E (Basics.compose Gim Fim).
 intros. apply Build_Functor with (fmap := fun a b f => fmap G (fmap F f)).
@@ -190,12 +190,12 @@ abstract (intros; repeat (rewrite fmap_preserves_comp); reflexivity).
 Defined.
 
 Definition skel {A:Type} : relation A := @eq A.
-Instance skel_equiv A : Equivalence (@skel A).
+#[export] Instance skel_equiv A : Equivalence (@skel A).
 Admitted.
 
 Import FunctionalExtensionality.
 
-Instance set_cat : Category Type (fun A B => A -> B).
+#[export] Instance set_cat : Category Type (fun A B => A -> B).
 refine {|
   id := fun A => fun x => x
   ; comp c b a f g := fun x => f (g x)
@@ -211,7 +211,7 @@ Defined.
 Require Import List.
 
 Definition setList (A:set_cat) := list A.
-Instance list_functor : Functor set_cat set_cat setList.
+#[export] Instance list_functor : Functor set_cat set_cat setList.
 apply Build_Functor with (fmap := @map).
 intros. rewrite H. reflexivity.
 intros; simpl; apply functional_extensionality.

--- a/test-suite/bugs/bug_3028.v
+++ b/test-suite/bugs/bug_3028.v
@@ -1,3 +1,3 @@
 Class WT (A : Type) := inhabited : A.
-Instance nat_WT : WT nat := O.
+#[export] Instance nat_WT : WT nat := O.
 Inductive dumb (B : Type) {B_WT : WT B} := cons : dumb nat -> dumb B.

--- a/test-suite/bugs/bug_3188.v
+++ b/test-suite/bugs/bug_3188.v
@@ -3,8 +3,8 @@
 Module Long.
   Require Import Coq.Classes.RelationClasses.
 
-  Hint Extern 0 => apply reflexivity : typeclass_instances.
-  Hint Extern 1 => symmetry.
+  #[export] Hint Extern 0 => apply reflexivity : typeclass_instances.
+  #[export] Hint Extern 1 => symmetry.
 
   Lemma foo : exists m' : Type, True.
     intuition. (* Anomaly: Uncaught exception Not_found. Please report. *)
@@ -14,7 +14,7 @@ End Long.
 Module Short.
   Require Import Coq.Classes.RelationClasses.
 
-  Hint Extern 0 => apply reflexivity : typeclass_instances.
+  #[export] Hint Extern 0 => apply reflexivity : typeclass_instances.
 
   Lemma foo : exists m' : Type, True.
     try symmetry. (* Anomaly: Uncaught exception Not_found. Please report. *)

--- a/test-suite/bugs/bug_3199.v
+++ b/test-suite/bugs/bug_3199.v
@@ -3,9 +3,9 @@ Axiom admit : forall n : nat, P n -> P n -> n = S n.
 Axiom foo : forall n, P n.
 
 Create HintDb bar.
-Hint Extern 3 => symmetry : bar.
-Hint Resolve admit : bar.
-Hint Immediate foo : bar.
+#[export] Hint Extern 3 => symmetry : bar.
+#[export] Hint Resolve admit : bar.
+#[export] Hint Immediate foo : bar.
 
 Lemma qux : forall n : nat, n = S n.
 Proof.

--- a/test-suite/bugs/bug_3258.v
+++ b/test-suite/bugs/bug_3258.v
@@ -3,7 +3,7 @@ Require Import Coq.Classes.Morphisms Coq.Classes.RelationClasses Coq.Program.Pro
 
 Global Set Implicit Arguments.
 
-Hint Extern 0 => apply reflexivity : typeclass_instances.
+#[export] Hint Extern 0 => apply reflexivity : typeclass_instances.
 
 Inductive Comp : Type -> Type :=
 | Pick : forall A, (A -> Prop) -> Comp A.

--- a/test-suite/bugs/bug_3265.v
+++ b/test-suite/bugs/bug_3265.v
@@ -1,5 +1,5 @@
 Require Import Setoid.
-Hint Extern 0 => apply reflexivity : typeclass_instances.
+#[export] Hint Extern 0 => apply reflexivity : typeclass_instances.
 Goal forall (B : Type) (P : B -> Prop), exists y : B, P y.
   intros.
   try reflexivity. (* Anomaly: Uncaught exception Not_found. Please report. *)

--- a/test-suite/bugs/bug_3267.v
+++ b/test-suite/bugs/bug_3267.v
@@ -40,7 +40,7 @@ End d.
 Parameter A B : Prop.
 Axiom a:B.
 
-Hint Extern 1 => match goal with H:_ -> id _ |- _ => try (unfold id in H) end.
+#[export] Hint Extern 1 => match goal with H:_ -> id _ |- _ => try (unfold id in H) end.
 Goal (B -> id A) -> A.
 intros.
 eauto using a.

--- a/test-suite/bugs/bug_3289.v
+++ b/test-suite/bugs/bug_3289.v
@@ -5,19 +5,19 @@ Class Contr_internal (A : Type) :=
                contr : (forall y : A, True) }.
 Class Contr A := Contr_is_contr : Contr_internal A.
 Inductive Unit : Set := tt.
-Instance contr_unit : Contr Unit | 0 :=
+#[export] Instance contr_unit : Contr Unit | 0 :=
   let x := {|
         center := tt;
         contr := fun t : Unit => I
       |} in x. (* success *)
 
-Instance contr_internal_unit' : Contr_internal Unit | 0 :=
+#[export] Instance contr_internal_unit' : Contr_internal Unit | 0 :=
   {|
     center := tt;
     contr := fun t : Unit => I
   |}.
 
-Instance contr_unit' : Contr Unit | 0 :=
+#[export] Instance contr_unit' : Contr Unit | 0 :=
   {|
     center := tt;
     contr := fun t : Unit => I

--- a/test-suite/bugs/bug_3298.v
+++ b/test-suite/bugs/bug_3298.v
@@ -1,6 +1,6 @@
 Require Import TestSuite.admit.
 Module JGross.
-  Hint Extern 1 => match goal with |- match ?E with end => case E end.
+  #[global] Hint Extern 1 => match goal with |- match ?E with end => case E end.
 
   Goal forall H : False, match H return Set with end.
   Proof.

--- a/test-suite/bugs/bug_3323.v
+++ b/test-suite/bugs/bug_3323.v
@@ -16,7 +16,7 @@ Definition transport {A : Type} (P : A -> Type) {x y : A} (p : x = y) (u : P x) 
 Definition Sect {A B : Type} (s : A -> B) (r : B -> A) := forall x : A, r (s x) = x.
 Class IsEquiv {A B : Type} (f : A -> B) := BuildIsEquiv { equiv_inv : B -> A ; eisretr : Sect equiv_inv f }.
 Record Equiv A B := BuildEquiv { equiv_fun :> A -> B ; equiv_isequiv :> IsEquiv equiv_fun }.
-Existing Instance equiv_isequiv.
+#[export] Existing Instance equiv_isequiv.
 Global Instance isequiv_inverse `{IsEquiv A B f} : IsEquiv (@equiv_inv _ _ f _) | 10000 := admit.
 Definition equiv_path_sigma `(P : A -> Type) (u v : sigT P)
 : Equiv {p : projT1 u = projT1 v &  transport _ p (projT2 u) = projT2 v} (u = v) := admit.

--- a/test-suite/bugs/bug_3325.v
+++ b/test-suite/bugs/bug_3325.v
@@ -10,15 +10,15 @@ Class StateIs := {
   stateIs : valueType -> sProp
 }.
 
-Instance NatStateIs : StateIs := {
+#[export] Instance NatStateIs : StateIs := {
   valueType := nat;
   stateIs := fun _ => sp
 }.
 Canonical Structure NatStateIs.
 
 Class LogicOps F := { land: F -> F }.
-Instance : LogicOps sProp. Admitted.
-Instance : LogicOps Prop. Admitted.
+#[export] Instance : LogicOps sProp. Admitted.
+#[export] Instance : LogicOps Prop. Admitted.
 
 Parameter (n : nat).
 (* If this is a [Definition], the resolution goes through fine. *)
@@ -32,11 +32,11 @@ Definition BAD : sProp :=
 
 
 Class A T := { foo : T -> Prop }.
-Instance: A nat. Admitted.
-Instance: A Set. Admitted.
+#[export] Instance: A nat. Admitted.
+#[export] Instance: A Set. Admitted.
 
 Class B := { U : Type ; b : U }.
-Instance bi: B := {| U := nat ; b := 0 |}.
+#[export] Instance bi: B := {| U := nat ; b := 0 |}.
 Canonical Structure bi.
 
 Notation b0N := (@b _ : nat).

--- a/test-suite/bugs/bug_3329.v
+++ b/test-suite/bugs/bug_3329.v
@@ -9,7 +9,7 @@ Notation "g 'o' f" := (compose g f).
 Inductive paths {A : Type} (a : A) : A -> Type := idpath : paths a a where "x = y" := (@paths _ x y) : type_scope.
 Arguments idpath {A a} , [A] a.
 Definition pointwise_paths {A} {P:A->Type} (f g:forall x:A, P x) : Type := forall x:A, f x = g x.
-Hint Unfold pointwise_paths : typeclass_instances.
+#[export] Hint Unfold pointwise_paths : typeclass_instances.
 Definition apD10 {A} {B:A->Type} {f g : forall x, B x} (h:f=g)
 : forall x, f x = g x
   := fun x => match h with idpath => idpath end.

--- a/test-suite/bugs/bug_3330.v
+++ b/test-suite/bugs/bug_3330.v
@@ -62,7 +62,7 @@ Definition concat {A : Type} {x y z : A} (p : x = y) (q : y = z) : x = z :=
 Definition inverse {A : Type} {x y : A} (p : x = y) : y = x
   := match p with idpath => idpath end.
 
-Instance symmetric_paths {A} : Symmetric (@paths A) | 0 := @inverse A.
+#[global] Instance symmetric_paths {A} : Symmetric (@paths A) | 0 := @inverse A.
 
 Notation "1" := idpath : path_scope.
 
@@ -79,7 +79,7 @@ Definition ap {A B:Type} (f:A -> B) {x y:A} (p:x = y) : f x = f y
 Definition pointwise_paths {A} {P:A->Type} (f g:forall x:A, P x) : Type
   := forall x:A, f x = g x.
 
-Hint Unfold pointwise_paths : typeclass_instances.
+#[global] Hint Unfold pointwise_paths : typeclass_instances.
 
 Notation "f == g" := (pointwise_paths f g) (at level 70, no associativity) : type_scope.
 
@@ -211,9 +211,9 @@ Definition Build_PreCategory
        right_identity
        (fun _ => left_identity _ _ _).
 
-Existing Instance trunc_morphism.
+#[global] Existing Instance trunc_morphism.
 
-Hint Resolve @left_identity @right_identity @associativity : category morphism.
+#[global] Hint Resolve @left_identity @right_identity @associativity : category morphism.
 
 Module Export CategoryCoreNotations.
 

--- a/test-suite/bugs/bug_3331.v
+++ b/test-suite/bugs/bug_3331.v
@@ -12,7 +12,7 @@ Fixpoint IsTrunc_internal (n : trunc_index) (A : Type) : Type :=
     | trunc_S n' => forall (x y : A), IsTrunc_internal n' (x = y)
   end.
 Class IsTrunc (n : trunc_index) (A : Type) : Type := Trunc_is_trunc : IsTrunc_internal n A.
-Instance istrunc_paths (A : Type) n `{H : IsTrunc (trunc_S n) A} (x y : A) : IsTrunc n (x = y) := H x y.
+#[export] Instance istrunc_paths (A : Type) n `{H : IsTrunc (trunc_S n) A} (x y : A) : IsTrunc n (x = y) := H x y.
 Notation Contr := (IsTrunc minus_two).
 Section groupoid_category.
   Variable X : Type.

--- a/test-suite/bugs/bug_3422.v
+++ b/test-suite/bugs/bug_3422.v
@@ -6,7 +6,7 @@ Axiom admit : forall {T}, T.
 Reserved Infix "o" (at level 40, left associativity).
 Class IsEquiv {A B : Type} (f : A -> B) := { equiv_inv : B -> A }.
 Record Equiv A B := { equiv_fun :> A -> B ; equiv_isequiv :> IsEquiv equiv_fun }.
-Existing Instance equiv_isequiv.
+#[export] Existing Instance equiv_isequiv.
 Delimit Scope equiv_scope with equiv.
 Local Open Scope equiv_scope.
 Notation "A <~> B" := (Equiv A B) (at level 85) : equiv_scope.

--- a/test-suite/bugs/bug_3427.v
+++ b/test-suite/bugs/bug_3427.v
@@ -100,12 +100,12 @@ Definition transport2 {A : Type} (P : A -> Type) {x y : A} {p q : x = y}
 Inductive Unit : Type0 :=
   tt : Unit.
 
-Instance contr_unit : Contr Unit | 0 := let x := {|
+#[export] Instance contr_unit : Contr Unit | 0 := let x := {|
                                               center := tt;
                                               contr := fun t : Unit => match t with tt => 1 end
                                             |} in x.
 
-Instance trunc_succ `{IsTrunc n A} : IsTrunc (trunc_S n) A | 1000.
+#[export] Instance trunc_succ `{IsTrunc n A} : IsTrunc (trunc_S n) A | 1000.
 admit.
 Defined.
 
@@ -121,7 +121,7 @@ Definition path_hprop `{Funext} X Y := (@ap _ _ hproptype X Y)^-1%equiv.
 Record hSet := BuildhSet {setT:> Type; iss :> IsHSet setT}.
 Local Open Scope equiv_scope.
 
-Instance isequiv_path {A B : Type} (p : A = B)
+#[export] Instance isequiv_path {A B : Type} (p : A = B)
 : IsEquiv (transport (fun X:Type => X) p) | 0
   := BuildIsEquiv _ _ _ (transport (fun X:Type => X) p^)
                   (fun b => ((transport_pp idmap p^ p b)^ @ transport2 idmap (concat_Vp p) b))
@@ -149,7 +149,7 @@ End Univalence.
 Inductive minus1Trunc (A :Type) : Type :=
   min1 : A -> minus1Trunc A.
 
-Instance minus1Trunc_is_prop {A : Type} : IsHProp (minus1Trunc A) | 0.
+#[export] Instance minus1Trunc_is_prop {A : Type} : IsHProp (minus1Trunc A) | 0.
 admit.
 Defined.
 

--- a/test-suite/bugs/bug_3439.v
+++ b/test-suite/bugs/bug_3439.v
@@ -6,7 +6,7 @@ Axiom IsHSet : Type -> Type.
 Existing Class IsHSet.
 Record PreCategory := { object :> Type }.
 Notation IsStrictCategory C := (IsHSet (object C)).
-Instance trunc_prod `{IsHSet A} `{IsHSet B} : IsHSet (A * B) | 100.
+#[export] Instance trunc_prod `{IsHSet A} `{IsHSet B} : IsHSet (A * B) | 100.
 admit.
 Defined.
 Typeclasses Transparent object.
@@ -20,7 +20,7 @@ Defined.
 Set Typeclasses Debug.
 (* File reduced by coq-bug-finder from original input, then from 7425 lines to 154 lines, then from 116 lines to 20 lines *)
 Class Contr (A : Type) := { center : A }.
-Instance contr_unit : Contr unit | 0 := {| center := tt |}.
+#[export] Instance contr_unit : Contr unit | 0 := {| center := tt |}.
 Module non_prim.
   Unset Primitive Projections.
   Record PreCategory := { object :> Type }.

--- a/test-suite/bugs/bug_3446.v
+++ b/test-suite/bugs/bug_3446.v
@@ -44,7 +44,7 @@ Notation "p # x" := (transport _ p x) (right associativity, at level 65, only pa
 Class IsEquiv {A B : Type} (f : A -> B) := { equiv_inv : B -> A }.
 Notation "f ^-1" := (@equiv_inv _ _ f _) (at level 3).
 Axiom path_sigma_uncurried : forall {A : Type} (P : A -> Type) (u v : sigT P) (pq : {p : u.1 = v.1 &  p # u.2 = v.2}), u = v.
-Instance isequiv_pr1_contr {A} {P : A -> Type} : IsEquiv (@pr1 A P) | 100.
+#[export] Instance isequiv_pr1_contr {A} {P : A -> Type} : IsEquiv (@pr1 A P) | 100.
 Admitted.
 
 Definition path_sigma_hprop {A : Type} {P : A -> Type} (u v : sigT P) : u.1 = v.1 -> u = v :=

--- a/test-suite/bugs/bug_3485.v
+++ b/test-suite/bugs/bug_3485.v
@@ -16,7 +16,7 @@ Notation "x .2" := (projT2 x) (at level 3) : fibration_scope.
 Inductive paths {A : Type} (a : A) : A -> Type := idpath : paths a a where "x = y" := (@paths _ x y) : type_scope.
 Arguments idpath {A a} , [A] a.
 Definition concat {A : Type} {x y z : A} (p : x = y) (q : y = z) : x = z := match p, q with idpath, idpath => idpath end.
-Instance transitive_paths {A} : Transitive (@paths A) | 0 := @concat A.
+#[export] Instance transitive_paths {A} : Transitive (@paths A) | 0 := @concat A.
 Definition transport {A : Type} (P : A -> Type) {x y : A} (p : x = y) (u : P x) : P y := match p with idpath => u end.
 Definition ap {A B:Type} (f:A -> B) {x y:A} (p:x = y) : f x = f y
   := match p with idpath => idpath end.

--- a/test-suite/bugs/bug_3487.v
+++ b/test-suite/bugs/bug_3487.v
@@ -1,7 +1,7 @@
 Notation bar := ltac:(exact I).
 Notation foo := bar (only parsing).
 Class baz := { x : False }.
-Instance: baz.
+#[export] Instance: baz.
 Admitted.
 Definition baz0 := ((_ : baz) = (_ : baz)).
 Definition foo1 := (foo = foo).

--- a/test-suite/bugs/bug_3495.v
+++ b/test-suite/bugs/bug_3495.v
@@ -1,7 +1,7 @@
 Require Import RelationClasses.
 
 Axiom R : Prop -> Prop -> Prop.
-Declare Instance R_refl : Reflexive R.
+#[export] Declare Instance R_refl : Reflexive R.
 
 Class bar := { x : False }.
 Record foo := { a : Prop ; b : bar }.

--- a/test-suite/bugs/bug_3509.v
+++ b/test-suite/bugs/bug_3509.v
@@ -2,5 +2,5 @@ Inductive T := Foo : T.
 Axiom (b : T) (R : forall x : T, Prop) (f : forall x : T, R x).
 Axiom a1 : match b with Foo => f end = f.
 Axiom a2 : match b with Foo => f b end = f b.
-Hint Rewrite a1 : bar.
-Hint Rewrite a2 : bar.
+#[export] Hint Rewrite a1 : bar.
+#[export] Hint Rewrite a2 : bar.

--- a/test-suite/bugs/bug_3510.v
+++ b/test-suite/bugs/bug_3510.v
@@ -2,4 +2,4 @@ Inductive T := Foo : T.
 Axiom (b : T) (R : forall x : T, Prop) (f : forall x : T, R x).
 Axiom a1 : match b with Foo => f end = f.
 Axiom a2 : match b with Foo => f b end = f b.
-Hint Rewrite a1 a2 : bar.
+#[export] Hint Rewrite a1 a2 : bar.

--- a/test-suite/bugs/bug_3513.v
+++ b/test-suite/bugs/bug_3513.v
@@ -13,7 +13,7 @@ Infix "|--"  := lentails (at level 79, no associativity).
 Class ILogic Frm {ILOps: ILogicOps Frm} := { lentailsPre:> PreOrder lentails }.
 Definition lequiv `{ILogic Frm} P Q := P |-- Q /\ Q |-- P.
 Infix "-|-"  := lequiv (at level 85, no associativity).
-Instance lequiv_inverse_lentails `{ILogic Frm} {inverse} : subrelation lequiv (inverse lentails) := admit.
+#[export] Instance lequiv_inverse_lentails `{ILogic Frm} {inverse} : subrelation lequiv (inverse lentails) := admit.
 Record ILFunFrm (T : Type) `{e : Equiv T} `{ILOps : ILogicOps Frm} := mkILFunFrm { ILFunFrm_pred :> T -> Frm }.
 Section ILogic_Fun.
   Context (T: Type) `{TType: type T}.
@@ -22,13 +22,13 @@ Section ILogic_Fun.
   Definition ILFun_ILogic : ILogic (@ILFunFrm T _ Frm _) := admit.
 End ILogic_Fun.
 Arguments ILFunFrm _ {e} _ {ILOps}.
-Instance ILogicOps_Prop : ILogicOps Prop | 2 := {| lentails P Q := (P : Prop) -> Q;
+#[export] Instance ILogicOps_Prop : ILogicOps Prop | 2 := {| lentails P Q := (P : Prop) -> Q;
                                                    ltrue        := True;
                                                    land     P Q := P /\ Q;
                                                    lor      P Q := P \/ Q |}.
 Axiom Action : Set.
 Definition Actions := list Action.
-Instance ActionsEquiv : Equiv Actions := { equiv a1 a2 := a1 = a2 }.
+#[export] Instance ActionsEquiv : Equiv Actions := { equiv a1 a2 := a1 = a2 }.
 Definition OPred := ILFunFrm Actions Prop.
 Local Existing Instance ILFun_Ops.
 Local Existing Instance ILFun_ILogic.
@@ -43,10 +43,10 @@ Record PointedOPred := mkPointedOPred {
                            OPred_pred :> OPred;
                            OPred_inhabited: IsPointed_OPred OPred_pred
                          }.
-Existing Instance OPred_inhabited.
+#[export] Existing Instance OPred_inhabited.
 Canonical Structure default_PointedOPred O `{IsPointed_OPred O} : PointedOPred
   := {| OPred_pred := O ; OPred_inhabited := _ |}.
-Instance IsPointed_catOP `{IsPointed_OPred P, IsPointed_OPred Q} : IsPointed_OPred (catOP P Q) := admit.
+#[export] Instance IsPointed_catOP `{IsPointed_OPred P, IsPointed_OPred Q} : IsPointed_OPred (catOP P Q) := admit.
 Goal forall (T : Type) (O0 : T -> OPred) (O1 : T -> PointedOPred)
             (tr : T -> T) (O2 : PointedOPred) (x : T)
             (H : forall x0 : T, catOP (O0 x0) (O1 (tr x0)) |-- O1 x0),

--- a/test-suite/bugs/bug_3559.v
+++ b/test-suite/bugs/bug_3559.v
@@ -31,7 +31,7 @@ Fixpoint IsTrunc_internal (n : trunc_index) (A : Type@{i}) : Type@{i} :=
 Notation minus_one:=(trunc_S minus_two).
 Class IsTrunc (n : trunc_index) (A : Type) : Type := Trunc_is_trunc :
 IsTrunc_internal n A.
-Instance istrunc_paths (A : Type) n `{H : IsTrunc (trunc_S n) A} (x y : A) :
+#[export] Instance istrunc_paths (A : Type) n `{H : IsTrunc (trunc_S n) A} (x y : A) :
 IsTrunc n (x = y) := H x y.
 
 Axiom cheat : forall {A}, A.
@@ -65,7 +65,7 @@ Axiom path_iff_hprop_uncurried : forall `{IsHProp A, IsHProp B}, (A <-> B) -> A
 = B.
 Inductive V : Type@{U'} := | set {A : Type@{U}} (f : A -> V) : V.
 Axiom is0trunc_V : IsTrunc (trunc_S (trunc_S minus_two)) V.
-Existing Instance is0trunc_V.
+#[export] Existing Instance is0trunc_V.
 Axiom bisimulation : V@{U' U} -> V@{U' U} -> hProp@{U'}.
 Axiom bisimulation_refl : forall (v : V), bisimulation v v.
 Axiom bisimulation_eq : forall (u v : V), bisimulation u v -> u = v.

--- a/test-suite/bugs/bug_3618.v
+++ b/test-suite/bugs/bug_3618.v
@@ -31,11 +31,11 @@ Definition istrunc_paths (A : Type) n `{H : IsTrunc (trunc_S n) A} (x y : A)
 : IsTrunc n (x = y).
 Admitted.
 
-Hint Extern 4 (IsTrunc _ (_ = _)) => eapply @istrunc_paths : typeclass_instances.
+#[export] Hint Extern 4 (IsTrunc _ (_ = _)) => eapply @istrunc_paths : typeclass_instances.
 
 Class Funext.
 
-Instance isequiv_compose A B C f g `{IsEquiv A B f} `{IsEquiv B C g}
+#[export] Instance isequiv_compose A B C f g `{IsEquiv A B f} `{IsEquiv B C g}
   : IsEquiv (compose g f) | 1000.
 Admitted.
 
@@ -47,23 +47,23 @@ Section IsEquivHomotopic.
     := ( BuildIsEquiv _ _ g (@equiv_inv _ _ f _) sect retr).
 End IsEquivHomotopic.
 
-Instance trunc_succ A n `{IsTrunc n A} : IsTrunc (trunc_S n) A | 1000. Admitted.
+#[export] Instance trunc_succ A n `{IsTrunc n A} : IsTrunc (trunc_S n) A | 1000. Admitted.
 
 Global Instance trunc_forall A n `{P : A -> Type} `{forall a, IsTrunc n (P a)}
   : IsTrunc n (forall a, P a) | 100.
 Admitted.
 
-Instance trunc_prod A B n `{IsTrunc n A} `{IsTrunc n B} : IsTrunc n (A * B) | 100.
+#[export] Instance trunc_prod A B n `{IsTrunc n A} `{IsTrunc n B} : IsTrunc n (A * B) | 100.
 Admitted.
 
 Global Instance trunc_arrow n {A B : Type} `{IsTrunc n B} : IsTrunc n (A -> B) | 100.
 Admitted.
 
-Instance isequiv_pr1_contr {A} {P : A -> Type} `{forall a, IsTrunc minus_two (P a)}
+#[export] Instance isequiv_pr1_contr {A} {P : A -> Type} `{forall a, IsTrunc minus_two (P a)}
 : IsEquiv (@projT1 A P) | 100.
 Admitted.
 
-Instance trunc_sigma n A `{P : A -> Type} `{IsTrunc n A} `{forall a, IsTrunc n (P a)}
+#[export] Instance trunc_sigma n A `{P : A -> Type} `{IsTrunc n A} `{forall a, IsTrunc n (P a)}
 : IsTrunc n (sigT P) | 100.
 Admitted.
 
@@ -76,7 +76,7 @@ Definition BiInv {A B} (f : A -> B) : Type
 Global Instance isprop_biinv {A B} (f : A -> B) : IsTrunc (trunc_S minus_two) (BiInv f) | 0.
 Admitted.
 
-Instance isequiv_path {A B : Type} (p : A = B)
+#[export] Instance isequiv_path {A B : Type} (p : A = B)
 : IsEquiv (transport (fun X:Type => X) p) | 0.
 Admitted.
 
@@ -96,7 +96,7 @@ Global Instance hprop_inO {fs : Funext} {subU : ReflectiveSubuniverse} (T : Type
 Admitted.
 
 (* To avoid looping class resolution *)
-Hint Mode IsEquiv - - + : typeclass_instances.
+#[export] Hint Mode IsEquiv - - + : typeclass_instances.
 
 Fail Definition equiv_O_rectnd {fs : Funext} {subU : ReflectiveSubuniverse}
            (P Q : Type) {Q_inO : inO_internal Q}

--- a/test-suite/bugs/bug_3647.v
+++ b/test-suite/bugs/bug_3647.v
@@ -55,7 +55,7 @@ Section MorphConsts.
     mkMorph (fun x => mkMorph (f x) (p x)) q.
 
 End MorphConsts.
-Instance Equiv_PropP : Equiv Prop.
+#[export] Instance Equiv_PropP : Equiv Prop.
 admit.
 Defined.
 
@@ -172,10 +172,10 @@ Section Exponentials.
 End Exponentials.
 
 Inductive empty : Set := .
-Instance empty_Equiv : Equiv empty.
+#[export] Instance empty_Equiv : Equiv empty.
 admit.
 Defined.
-Instance empty_type : type empty.
+#[export] Instance empty_type : type empty.
 admit.
 Defined.
 
@@ -282,7 +282,7 @@ Class ILogic Frm {ILOps: ILogicOps Frm} := {
                                             landAdj: forall P Q C, C |-- (P -->> Q) -> C //\\ P |-- Q;
                                             limplAdj: forall P Q C, C //\\ P |-- Q -> C |-- (P -->> Q)
                                           }.
-Hint Extern 0 (?x |-- ?x) => reflexivity.
+#[export] Hint Extern 0 (?x |-- ?x) => reflexivity.
 
 Section ILogicExtra.
   Context `{IL: ILogic Frm}.
@@ -344,7 +344,7 @@ Next Obligation.
   admit.
 Defined.
 
-Instance ILogicOps_Prop : ILogicOps Prop | 2 := {|
+#[export] Instance ILogicOps_Prop : ILogicOps Prop | 2 := {|
                                                  lentails P Q := (P : Prop) -> Q;
                                                  ltrue        := True;
                                                  lfalse       := False;
@@ -355,7 +355,7 @@ Instance ILogicOps_Prop : ILogicOps Prop | 2 := {|
                                                  lexists  T F := exists x:T, F x
                                                |}.
 
-Instance ILogic_Prop : ILogic Prop.
+#[export] Instance ILogic_Prop : ILogic Prop.
 admit.
 Defined.
 
@@ -433,7 +433,7 @@ Inductive Action :=
 
 Definition Actions := list Action.
 
-Instance ActionsEquiv : Equiv Actions := {
+#[export] Instance ActionsEquiv : Equiv Actions := {
                                           equiv a1 a2 := a1 = a2
                                         }.
 
@@ -461,14 +461,14 @@ Record PointedOPred := mkPointedOPred {
                            OPred_inhabited: IsPointed_OPred OPred_pred
                          }.
 
-Existing Instance OPred_inhabited.
+#[export] Existing Instance OPred_inhabited.
 
 Canonical Structure default_PointedOPred O `{IsPointed_OPred O} : PointedOPred
   := {| OPred_pred := O ; OPred_inhabited := _ |}.
-Instance IsPointed_eq_opred x : IsPointed_OPred (eq_opred x).
+#[export] Instance IsPointed_eq_opred x : IsPointed_OPred (eq_opred x).
 admit.
 Defined.
-Instance IsPointed_catOP `{IsPointed_OPred P, IsPointed_OPred Q} : IsPointed_OPred (catOP P Q).
+#[export] Instance IsPointed_catOP `{IsPointed_OPred P, IsPointed_OPred Q} : IsPointed_OPred (catOP P Q).
 admit.
 Defined.
 
@@ -492,15 +492,15 @@ Definition PState : Type.
 admit.
 Defined.
 
-Instance PStateEquiv : Equiv PState.
+#[export] Instance PStateEquiv : Equiv PState.
 admit.
 Defined.
 
-Instance PStateType : type PState.
+#[export] Instance PStateType : type PState.
 admit.
 Defined.
 
-Instance PStateSepAlgOps: SepAlgOps PState.
+#[export] Instance PStateSepAlgOps: SepAlgOps PState.
 admit.
 Defined.
 Definition SPred : Type.
@@ -584,7 +584,7 @@ Defined.
 Axiom behead : forall {T}, list T -> list T.
 Axiom all : forall {T}, (T -> bool) -> list T -> bool.
 Axiom all_behead : forall {T} (xs : list T) P, all P xs = true -> all P (behead xs) = true.
-Instance IsPointed_foldlOP A B C f g (init : A * B) `{IsPointed_OPred (g init)}
+#[export] Instance IsPointed_foldlOP A B C f g (init : A * B) `{IsPointed_OPred (g init)}
          `{forall a acc, IsPointed_OPred (g acc) -> IsPointed_OPred (g (f acc a))}
          (ls : list C)
 : IsPointed_OPred (g (foldl f init ls)).

--- a/test-suite/bugs/bug_3652.v
+++ b/test-suite/bugs/bug_3652.v
@@ -8,7 +8,7 @@ Inductive Erasable(A : Set) : Prop :=
 
 Arguments erasable [A] _.
 
-Hint Constructors Erasable.
+#[export] Hint Constructors Erasable.
 
 Scheme Erasable_elim := Induction for Erasable Sort Prop.
 
@@ -51,7 +51,7 @@ Ltac ring_simplify' := rewrite ?Twoto0; ring_simplify.
 
 Definition mp2a1s(x : Z)(n : nat) := x * 2^n + (2^n-1).
 
-Hint Unfold mp2a1s.
+#[export] Hint Unfold mp2a1s.
 
 Definition zotval(n1s : nat)(is2 : bool)(next_value : Z) : Z :=
   2 * mp2a1s next_value n1s + if is2 then 2 else 0.

--- a/test-suite/bugs/bug_3657.v
+++ b/test-suite/bugs/bug_3657.v
@@ -3,7 +3,7 @@
 
 Class foo {A} {a : A} := { bar := a; baz : bar = bar }.
 Arguments bar {_} _ {_}.
-Instance: forall A a, @foo A a.
+#[export] Instance: forall A a, @foo A a.
 intros; constructor.
 abstract reflexivity.
 Defined.

--- a/test-suite/bugs/bug_3658.v
+++ b/test-suite/bugs/bug_3658.v
@@ -17,7 +17,7 @@ Module NonPrim.
     end.
   Class IsTrunc (n : trunc_index) (A : Type) : Type := Trunc_is_trunc : IsTrunc_internal n A.
   Notation Contr := (IsTrunc -2).
-  Hint Extern 0 => progress change Contr_internal with Contr in * : typeclass_instances.
+  #[export] Hint Extern 0 => progress change Contr_internal with Contr in * : typeclass_instances.
   Goal forall (H : Type) (H0 : H -> H -> Type) (H1 : Type)
               (H2 : Contr H1) (H3 : H1) (H4 : H1 -> H)
               (H5 : H0 (H4 (center H1)) (H4 H3))
@@ -52,7 +52,7 @@ Module Prim.
     end.
   Class IsTrunc (n : trunc_index) (A : Type) : Type := Trunc_is_trunc : IsTrunc_internal n A.
   Notation Contr := (IsTrunc -2).
-  Hint Extern 0 => progress change Contr_internal with Contr in * : typeclass_instances.
+  #[export] Hint Extern 0 => progress change Contr_internal with Contr in * : typeclass_instances.
   Goal forall (H : Type) (H0 : H -> H -> Type) (H1 : Type)
               (H2 : Contr H1) (H3 : H1) (H4 : H1 -> H)
               (H5 : H0 (H4 (center H1)) (H4 H3))

--- a/test-suite/bugs/bug_3660.v
+++ b/test-suite/bugs/bug_3660.v
@@ -8,7 +8,7 @@ Class IsEquiv {A B : Type} (f : A -> B) := { equiv_inv : B -> A }.
 Record Equiv A B := { equiv_fun :> A -> B ; equiv_isequiv :> IsEquiv equiv_fun }.
 Notation "A <~> B" := (Equiv A B) (at level 85) : equiv_scope.
 Axiom IsHSet : Type -> Type.
-Instance isequiv_compose `{IsEquiv A B f} `{IsEquiv B C g} : IsEquiv (compose g f) | 1000.
+#[export] Instance isequiv_compose `{IsEquiv A B f} `{IsEquiv B C g} : IsEquiv (compose g f) | 1000.
 admit.
 Defined.
 Set Primitive Projections.

--- a/test-suite/bugs/bug_3661.v
+++ b/test-suite/bugs/bug_3661.v
@@ -30,7 +30,7 @@ Proof.
   constructor.
   exact (T^-1 x).
 Defined.
-Hint Immediate isisomorphism_components_of : typeclass_instances.
+#[export] Hint Immediate isisomorphism_components_of : typeclass_instances.
 Goal forall (x3 x9 : PreCategory) (x12 f0 : Functor x9 x3)
             (x35 : @Isomorphic (@functor_category x9 x3) f0 x12)
             (x37 : object x9)

--- a/test-suite/bugs/bug_3682.v
+++ b/test-suite/bugs/bug_3682.v
@@ -1,6 +1,6 @@
 Require Import TestSuite.admit.
 Class Foo.
 Definition bar `{Foo} (x : Set) := Set.
-Instance: Foo := {}.
+#[export] Instance: Foo := {}.
 Definition bar1 := bar nat.
 Definition bar2 := bar ltac:(admit).

--- a/test-suite/bugs/bug_3798.v
+++ b/test-suite/bugs/bug_3798.v
@@ -3,7 +3,7 @@ Require Setoid.
 
 Parameter f : nat -> nat.
 Axiom a : forall n, 0 < n -> f n = 0.
-Hint Rewrite a using ( simpl; admit ).
+#[export] Hint Rewrite a using ( simpl; admit ).
 
 Goal f 1 = 0.
 Proof.

--- a/test-suite/bugs/bug_3815.v
+++ b/test-suite/bugs/bug_3815.v
@@ -2,7 +2,7 @@ Require Import Setoid Coq.Program.Basics.
 Global Open Scope program_scope.
 Axiom foo : forall A (f : A -> A), f ∘ f = f.
 Require Import Coq.Program.Combinators.
-Hint Rewrite foo.
+#[export] Hint Rewrite foo.
 Theorem t {A B C D} (f : A -> A) (g : B -> C) (h : C -> D)
 : f ∘ f = f.
 Proof.

--- a/test-suite/bugs/bug_3854.v
+++ b/test-suite/bugs/bug_3854.v
@@ -10,7 +10,7 @@ Arguments BuildhProp _ {_}.
 Canonical Structure default_hProp := fun T P => (@BuildhProp T P).
 Generalizable Variables A B f g e n.
 Axiom trunc_forall : forall `{P : A -> Type}, IsHProp (forall a, P a).
-Existing Instance trunc_forall.
+#[export] Existing Instance trunc_forall.
 Inductive V : Type := | set {A : Type} (f : A -> V) : V.
 Axiom mem : V -> V -> hProp.
 Axiom mem_induction

--- a/test-suite/bugs/bug_3890.v
+++ b/test-suite/bugs/bug_3890.v
@@ -3,9 +3,9 @@ Set Nested Proofs Allowed.
 Class Foo.
 Class Bar := b : Type.
 
-Instance foo : Foo.
+#[export] Instance foo : Foo.
 
-Instance bar : Bar.
+#[export] Instance bar : Bar.
 exact Type.
 Defined.
 

--- a/test-suite/bugs/bug_3916.v
+++ b/test-suite/bugs/bug_3916.v
@@ -1,2 +1,2 @@
 Require Import List.
-Fail Hint Resolve -> in_map.
+Fail #[export] Hint Resolve -> in_map.

--- a/test-suite/bugs/bug_3928.v
+++ b/test-suite/bugs/bug_3928.v
@@ -3,9 +3,9 @@ Typeclasses eauto := (bfs).
 Class Foo := {}.
 Class Bar := {}.
 
-Instance: Bar := {}.
-Instance: Foo -> Bar -> Foo -> Foo | 1 := {}.
-Instance: Bar -> Foo | 100 := {}.
-Instance: Foo -> Bar -> Foo -> Foo | 1 := {}.
+#[export] Instance: Bar := {}.
+#[export] Instance: Foo -> Bar -> Foo -> Foo | 1 := {}.
+#[export] Instance: Bar -> Foo | 100 := {}.
+#[export] Instance: Foo -> Bar -> Foo -> Foo | 1 := {}.
 
 Check (_ : Foo). (* timeout *)

--- a/test-suite/bugs/bug_3938.v
+++ b/test-suite/bugs/bug_3938.v
@@ -1,6 +1,6 @@
 Require Import TestSuite.admit.
 Require Import Coq.Arith.PeanoNat.
-Hint Extern 1 => admit : typeclass_instances.
+#[export] Hint Extern 1 => admit : typeclass_instances.
 Require Import Setoid.
 Goal forall a b (f : nat -> Set) (R : nat -> nat -> Prop),
        Equivalence R -> R a b -> f a = f b.

--- a/test-suite/bugs/bug_3960.v
+++ b/test-suite/bugs/bug_3960.v
@@ -9,7 +9,7 @@ Class myClass (A: Type) :=
     bar : A -> Prop
   }.
 
-Program Instance myInstance : myClass nat :=
+#[export] Program Instance myInstance : myClass nat :=
   {
     bar := foo
   }.
@@ -20,7 +20,7 @@ Class myClassP (A : Type)  :=
     barP : forall (a : A), bar a
   }.
 
-Instance myInstanceP : myClassP nat :=
+#[export] Instance myInstanceP : myClassP nat :=
   {
     barP := fooP
   }.

--- a/test-suite/bugs/bug_3998.v
+++ b/test-suite/bugs/bug_3998.v
@@ -1,11 +1,11 @@
 Class FieldType (F : Set) := mkFieldType { fldTy: F -> Set }.
-Hint Mode FieldType + : typeclass_instances. (* The F parameter is an input *)
+#[export] Hint Mode FieldType + : typeclass_instances. (* The F parameter is an input *)
 
 Inductive I1 := C.
 Inductive I2 := .
 
-Instance I1FieldType : FieldType I1 := { fldTy := I1_rect _ bool }.
-Instance I2FieldType : FieldType I2 := { fldTy := I2_rect _ }.
+#[export] Instance I1FieldType : FieldType I1 := { fldTy := I1_rect _ bool }.
+#[export] Instance I2FieldType : FieldType I2 := { fldTy := I2_rect _ }.
 
 Definition RecordOf F (FT: FieldType F) := forall f:F, fldTy f.
 
@@ -14,7 +14,7 @@ Class MapOps (M K : Set) := {
   update: M -> forall k:K, tgtTy k -> M
 }.
 
-Instance RecordMapOps F (FT: FieldType F) : MapOps (RecordOf F FT) F :=
+#[export] Instance RecordMapOps F (FT: FieldType F) : MapOps (RecordOf F FT) F :=
 { tgtTy := fldTy; update := fun r (f: F) (x: fldTy f) z => r z }.
 
 Axiom ex : RecordOf _ I1FieldType.

--- a/test-suite/bugs/bug_4016.v
+++ b/test-suite/bugs/bug_4016.v
@@ -1,7 +1,7 @@
 Require Import Setoid.
 
 Parameter eq : relation nat.
-Declare Instance Equivalence_eq : Equivalence eq.
+#[export] Declare Instance Equivalence_eq : Equivalence eq.
 
 Lemma foo : forall z, eq z 0 -> forall x, eq x 0 -> eq z x.
 Proof.

--- a/test-suite/bugs/bug_4046.v
+++ b/test-suite/bugs/bug_4046.v
@@ -2,5 +2,5 @@ Module Import Foo.
   Class Foo := { foo : Type }.
 End Foo.
 
-Instance f : Foo := { foo := nat }. (* works fine *)
-Instance f' : Foo.Foo := { Foo.foo := nat }.
+#[export] Instance f : Foo := { foo := nat }. (* works fine *)
+#[export] Instance f' : Foo.Foo := { Foo.foo := nat }.

--- a/test-suite/bugs/bug_4095.v
+++ b/test-suite/bugs/bug_4095.v
@@ -15,7 +15,7 @@ Infix "|--"  := lentails (at level 79, no associativity).
 Class ILogic Frm {ILOps: ILogicOps Frm} := { lentailsPre:> PreOrder lentails }.
 Definition lequiv `{ILogic Frm} P Q := P |-- Q /\ Q |-- P.
 Infix "-|-"  := lequiv (at level 85, no associativity).
-Instance lequiv_inverse_lentails `{ILogic Frm} {inverse} : subrelation lequiv (inverse lentails) := admit.
+#[export] Instance lequiv_inverse_lentails `{ILogic Frm} {inverse} : subrelation lequiv (inverse lentails) := admit.
 Record ILFunFrm (T : Type) `{e : Equiv T} `{ILOps : ILogicOps Frm} := mkILFunFrm { ILFunFrm_pred :> T -> Frm }.
 Section ILogic_Fun.
   Context (T: Type) `{TType: type T}.
@@ -24,13 +24,13 @@ Section ILogic_Fun.
   Definition ILFun_ILogic : ILogic (@ILFunFrm T _ Frm _) := admit.
 End ILogic_Fun.
 Arguments ILFunFrm _ {e} _ {ILOps}.
-Instance ILogicOps_Prop : ILogicOps Prop | 2 := {| lentails P Q := (P : Prop) -> Q;
+#[export] Instance ILogicOps_Prop : ILogicOps Prop | 2 := {| lentails P Q := (P : Prop) -> Q;
                                                    ltrue        := True;
                                                    land     P Q := P /\ Q;
                                                    lor      P Q := P \/ Q |}.
 Axiom Action : Set.
 Definition Actions := list Action.
-Instance ActionsEquiv : Equiv Actions := { equiv a1 a2 := a1 = a2 }.
+#[export] Instance ActionsEquiv : Equiv Actions := { equiv a1 a2 := a1 = a2 }.
 Definition OPred := ILFunFrm Actions Prop.
 Local Existing Instance ILFun_Ops.
 Local Existing Instance ILFun_ILogic.
@@ -45,10 +45,10 @@ Record PointedOPred := mkPointedOPred {
                            OPred_pred :> OPred;
                            OPred_inhabited: IsPointed_OPred OPred_pred
                          }.
-Existing Instance OPred_inhabited.
+#[export] Existing Instance OPred_inhabited.
 Canonical Structure default_PointedOPred O `{IsPointed_OPred O} : PointedOPred
   := {| OPred_pred := O ; OPred_inhabited := _ |}.
-Instance IsPointed_catOP `{IsPointed_OPred P, IsPointed_OPred Q} : IsPointed_OPred (catOP P Q) := admit.
+#[export] Instance IsPointed_catOP `{IsPointed_OPred P, IsPointed_OPred Q} : IsPointed_OPred (catOP P Q) := admit.
 Goal forall (T : Type) (O0 : T -> OPred) (O1 : T -> PointedOPred)
             (tr : T -> T) (O2 : PointedOPred) (x : T)
             (H : forall x0 : T, catOP (O0 x0) (O1 (tr x0)) |-- O1 x0),

--- a/test-suite/bugs/bug_4121.v
+++ b/test-suite/bugs/bug_4121.v
@@ -10,9 +10,9 @@ Set Universe Polymorphism.
 Class Contr_internal (A : Type) := BuildContr { center : A }.
 Arguments center A {_}.
 Class Contr (A : Type) : Type := Contr_is_trunc : Contr_internal A.
-Hint Extern 0 => progress change Contr_internal with Contr in * : typeclass_instances.
+#[export] Hint Extern 0 => progress change Contr_internal with Contr in * : typeclass_instances.
 Definition contr_paths_contr0 {A} `{Contr A} : Contr A := {| center := center A |}.
-Instance contr_paths_contr1 {A} `{Contr A} : Contr A := {| center := center A |}.
+#[export] Instance contr_paths_contr1 {A} `{Contr A} : Contr A := {| center := center A |}.
 Check @contr_paths_contr0@{i}.
 Check @contr_paths_contr1@{i}. (* Error: Universe instance should have length 2 *)
 (** It should have length 1, just like contr_paths_contr0 *)

--- a/test-suite/bugs/bug_4256.v
+++ b/test-suite/bugs/bug_4256.v
@@ -21,7 +21,7 @@ Record pType :=
   { pointed_type : Type ;
     ispointed_type : IsPointed pointed_type }.
 Coercion pointed_type : pType >-> Sortclass.
-Existing Instance ispointed_type.
+#[export] Existing Instance ispointed_type.
 
 Private Inductive Trunc (n : trunc_index) (A :Type) : Type :=
   tr : A -> Trunc n A.

--- a/test-suite/bugs/bug_4450.v
+++ b/test-suite/bugs/bug_4450.v
@@ -3,7 +3,7 @@ Polymorphic Axiom inhabited@{u} : Type@{u} -> Prop.
 Polymorphic Axiom unit@{u} : Type@{u}.
 Polymorphic Axiom tt@{u} : inhabited unit@{u}.
 
-Polymorphic Hint Resolve tt : the_lemmas.
+#[export] Polymorphic Hint Resolve tt : the_lemmas.
 Set Printing All.
 Set Printing Universes.
 Goal inhabited unit.
@@ -21,7 +21,7 @@ Goal (forall U, f U) -> (*(f unit -> False) ->  *)False /\ False.
   eauto using (fapp unit funi). (* The two fapp's have different universes *)
 Qed.
 
-Hint Resolve (fapp unit funi) : mylems.
+#[export] Hint Resolve (fapp unit funi) : mylems.
 
 Goal (forall U, f U) -> (*(f unit -> False) ->  *)False /\ False.
   eauto with mylems. (* Forces the two fapps at the same level *)

--- a/test-suite/bugs/bug_4529.v
+++ b/test-suite/bugs/bug_4529.v
@@ -26,7 +26,7 @@ Structure cofeT := CofeT {
   cofe_dist : Dist cofe_car;
   cofe_mixin : CofeMixin cofe_car
 }.
-Existing Instances cofe_equiv cofe_dist.
+#[export] Existing Instances cofe_equiv cofe_dist.
 Arguments cofe_car : simpl never.
 
 Section cofe_mixin.

--- a/test-suite/bugs/bug_4544.v
+++ b/test-suite/bugs/bug_4544.v
@@ -174,7 +174,7 @@ Global Instance istrunc_paths (A : Type) n `{H : IsTrunc n.+1 A} (x y : A)
 Notation Contr := (IsTrunc -2).
 Notation IsHProp := (IsTrunc -1).
 
-Hint Extern 0 => progress change Contr_internal with Contr in * : typeclass_instances.
+#[global] Hint Extern 0 => progress change Contr_internal with Contr in * : typeclass_instances.
 
 Monomorphic Axiom dummy_funext_type : Type0.
 Monomorphic Class Funext := { dummy_funext_value : dummy_funext_type }.

--- a/test-suite/bugs/bug_4580.v
+++ b/test-suite/bugs/bug_4580.v
@@ -2,5 +2,5 @@ Require Import Program.
 
 Class Foo (A : Type) := foo : A.
 
-Program Instance f1 : Foo nat := S _.
+#[export] Program Instance f1 : Foo nat := S _.
 Next Obligation. exact 0. Defined.

--- a/test-suite/bugs/bug_4638.v
+++ b/test-suite/bugs/bug_4638.v
@@ -4,7 +4,7 @@ Class Foo.
 
 Goal True.
 
-Instance foo: Foo.
+#[export] Instance foo: Foo.
 Qed.
 
 trivial.

--- a/test-suite/bugs/bug_4754.v
+++ b/test-suite/bugs/bug_4754.v
@@ -10,7 +10,7 @@ Axiom FG : forall f, f None = None -> F f = G f.
 
 Axiom admit : forall {T}, T.
 
-Existing Instance eq_Reflexive.
+#[export] Existing Instance eq_Reflexive.
 
 Global Instance foo (A := nat)
   : Proper ((pointwise_relation _ eq)

--- a/test-suite/bugs/bug_4762.v
+++ b/test-suite/bugs/bug_4762.v
@@ -3,7 +3,7 @@ Inductive myand (P Q : Prop) := myconj : P -> Q -> myand P Q.
 Lemma foo P Q R : R = myand P Q -> P -> Q -> R.
 Proof. intros ->; constructor; auto. Qed.
 
-Hint Extern 0 (myand _ _) => eapply foo; [reflexivity| |] : test1.
+#[export] Hint Extern 0 (myand _ _) => eapply foo; [reflexivity| |] : test1.
 
 Goal forall P Q R : Prop, P -> Q -> R -> myand P (myand Q R).
 Proof.
@@ -11,7 +11,7 @@ Proof.
   eauto with test1.
 Qed.
 
-Hint Extern 0 =>
+#[export] Hint Extern 0 =>
   match goal with
   | |- myand _ _ => eapply foo; [reflexivity| |]
   end : test2.

--- a/test-suite/bugs/bug_4780.v
+++ b/test-suite/bugs/bug_4780.v
@@ -33,7 +33,7 @@ Delimit Scope path_scope with path.
 Local Open Scope path_scope.
 Definition concat {A : Type} {x y z : A} (p : x = y) (q : y = z) : x = z :=
   match p, q with idpath, idpath => idpath end.
-Instance transitive_paths {A} : Transitive (@paths A) | 0 := @concat A.
+#[export] Instance transitive_paths {A} : Transitive (@paths A) | 0 := @concat A.
 Definition inverse {A : Type} {x y : A} (p : x = y) : y = x
   := match p with idpath => idpath end.
 Notation "1" := idpath : path_scope.

--- a/test-suite/bugs/bug_4781.v
+++ b/test-suite/bugs/bug_4781.v
@@ -6,7 +6,7 @@ Ltac force_clear :=
          end.
 
 Class abstract_term {T} (x : T) := by_abstract_term : T.
-Hint Extern 0 (@abstract_term ?T ?x) => force_clear; change T; abstract (exact x) : typeclass_instances.
+#[export] Hint Extern 0 (@abstract_term ?T ?x) => force_clear; change T; abstract (exact x) : typeclass_instances.
 
 Goal True.
 (* These work: *)

--- a/test-suite/bugs/bug_4782.v
+++ b/test-suite/bugs/bug_4782.v
@@ -15,8 +15,8 @@ Record T := { dom : Type }.
 Definition pairT A B := {| dom := (dom A * dom B)%type |}.
 Class C (A:Type).
 Parameter B:T.
-Instance c (A:T) : C (dom A) := {}.
-Instance cn : C (dom B) := {}.
+#[export] Instance c (A:T) : C (dom A) := {}.
+#[export] Instance cn : C (dom B) := {}.
 Parameter F : forall A:T, C (dom A) -> forall x:dom A, x=x -> A = A.
 Set Typeclasses Debug.
 Goal forall (A:T) (x:dom A), pairT A A = pairT A A.

--- a/test-suite/bugs/bug_4852.v
+++ b/test-suite/bugs/bug_4852.v
@@ -14,7 +14,7 @@ Tactic Notation "wfinduction" constr(term) "on" ne_hyp_list(Hs) "as" ident(H) :=
   induction R as [R H] using wfi_lt;
   intros; subst R.
 
-Hint Rewrite @app_comm_cons @app_assoc @app_length : app_rws.
+#[export] Hint Rewrite @app_comm_cons @app_assoc @app_length : app_rws.
 
 Ltac solve_nat := autorewrite with app_rws in *; cbn in *; lia.
 

--- a/test-suite/bugs/bug_4863.v
+++ b/test-suite/bugs/bug_4863.v
@@ -10,7 +10,7 @@ Proof.
   intuition congruence.
 Qed.
 
-Hint Extern 100 (Decidable (?A = ?B)) => abstract (abstract (abstract (apply Decidable_sumbool; decide equality))) : typeclass_instances.
+#[export] Hint Extern 100 (Decidable (?A = ?B)) => abstract (abstract (abstract (apply Decidable_sumbool; decide equality))) : typeclass_instances.
 
 Goal forall (a b : Foo), {a=b}+{a<>b}.
 intros.

--- a/test-suite/bugs/bug_4966.v
+++ b/test-suite/bugs/bug_4966.v
@@ -1,7 +1,7 @@
 (* Interpretation of auto as an argument of an ltac function (i.e. as an ident) was wrongly "auto with *" *)
 
 Axiom proof_admitted : False.
-Hint Extern 0 => case proof_admitted : unused.
+#[export] Hint Extern 0 => case proof_admitted : unused.
 Ltac do_tac tac := tac.
 
 Goal False.

--- a/test-suite/bugs/bug_4969.v
+++ b/test-suite/bugs/bug_4969.v
@@ -1,8 +1,8 @@
 Require Import Classes.Init.
 
 Class C A := c : A.
-Instance nat_C : C nat := 0.
-Instance bool_C : C bool := true.
+#[export] Instance nat_C : C nat := 0.
+#[export] Instance bool_C : C bool := true.
 Lemma silly {A} `{C A} : 0 = 0 -> c = c -> True.
 Proof. auto. Qed.
 

--- a/test-suite/bugs/bug_5093.v
+++ b/test-suite/bugs/bug_5093.v
@@ -2,8 +2,8 @@ Axiom P : nat -> Prop.
 Axiom PS : forall n, P n -> P (S n).
 Axiom P0 : P 0.
 
-Hint Resolve PS : foobar.
-Hint Resolve P0 : foobar.
+#[export] Hint Resolve PS : foobar.
+#[export] Hint Resolve P0 : foobar.
 
 Goal P 100.
 Proof.

--- a/test-suite/bugs/bug_5123.v
+++ b/test-suite/bugs/bug_5123.v
@@ -11,7 +11,7 @@ Class Eqdec A := eqdec : forall a b : A, {a=b}+{a<>b}.
 
 Require Bool.
 
-Instance Bool_eqdec : Eqdec bool := Bool.bool_dec.
+#[export] Instance Bool_eqdec : Eqdec bool := Bool.bool_dec.
 
 Context `{vect_sigT_eqdec : forall A : Type, Eqdec A -> Eqdec {a : nat & vect A a}}.
 

--- a/test-suite/bugs/bug_5153.v
+++ b/test-suite/bugs/bug_5153.v
@@ -1,6 +1,6 @@
 (* An example where it does not hurt having more type-classes resolution *)
 Class some_type := { Ty : Type }.
-Instance: some_type := { Ty := nat }.
+#[export] Instance: some_type := { Ty := nat }.
 Arguments Ty : clear implicits.
 Goal forall (H : forall t : some_type, @Ty t -> False) (H' : False -> 1 = 2), 1 = 2.
 Proof.

--- a/test-suite/bugs/bug_5215.v
+++ b/test-suite/bugs/bug_5215.v
@@ -230,14 +230,14 @@ Program Definition sum_Sum (A B : Type) : (@Sum Type_Cat A B) :=
 Next Obligation. simpl; auto. Defined.
 Next Obligation. simpl; auto. Defined.
 
-Program Instance Type_Cat_Has_Sums : Has_Sums Type_Cat := sum_Sum.
+#[export] Program Instance Type_Cat_Has_Sums : Has_Sums Type_Cat := sum_Sum.
 
 Definition Sum_Func {C : Category} {HS : Has_Sums C} :
   Functor (Prod_Cat C C) C := Opposite_Functor (Prod_Func (Opposite C) HS).
 
 Arguments Sum_Func _ _, _ {_}.
 
-Program Instance unit_Type_term : Terminal Type_Cat :=
+#[export] Program Instance unit_Type_term : Terminal Type_Cat :=
 {
   terminal := unit;
   t_morph := fun _ _=> tt

--- a/test-suite/bugs/bug_5369.v
+++ b/test-suite/bugs/bug_5369.v
@@ -4,7 +4,7 @@ Axiom Hfg : forall n m, n = n -> f n m = g n m.
 Axiom LetIn : forall {A B} (x : A) (f : A -> B), B.
 Axiom LetIn_Proper : forall A B, Proper (eq ==> pointwise_relation _ eq ==> eq)
 (@ LetIn A B).
-Existing Instance LetIn_Proper.
+#[export] Existing Instance LetIn_Proper.
 
 Goal forall n, LetIn n (fun n' => f 1 n') = LetIn n (fun n' => g 1 n').
 Proof.

--- a/test-suite/bugs/bug_5384.v
+++ b/test-suite/bugs/bug_5384.v
@@ -19,7 +19,7 @@ Proof.
 firstorder.
 Qed.
 
-Instance Included_PreOrder : forall A, PreOrder (@Included A).
+#[export] Instance Included_PreOrder : forall A, PreOrder (@Included A).
 Proof.
 firstorder.
 Qed.

--- a/test-suite/bugs/bug_5401.v
+++ b/test-suite/bugs/bug_5401.v
@@ -5,7 +5,7 @@ Parameter P : nat -> Type.
 Parameter v : forall m, P m.
 Parameter f : forall (P : nat -> Type), (forall a, P a) -> P 0.
 Class U (R : P 0) (m : forall x, P x) : Prop.
-Instance w : U (f _ (fun _ => v _)) v := {}.
+#[export] Instance w : U (f _ (fun _ => v _)) v := {}.
 Print HintDb typeclass_instances.
 End A.
 
@@ -16,6 +16,6 @@ Axiom rel : Type -> Prop.
 Axiom arrow_rel : forall {A1}, A1 -> rel A1.
 Axiom forall_rel : forall E, (forall v1 : Type, E v1 -> rel v1) -> Prop.
 Axiom inl_rel: forall_rel _ (fun _ => arrow_rel).
-Hint Resolve inl_rel : foo.
+#[export] Hint Resolve inl_rel : foo.
 Print HintDb foo.
 End B.

--- a/test-suite/bugs/bug_5521.v
+++ b/test-suite/bugs/bug_5521.v
@@ -32,7 +32,7 @@ Class Isomorphism `{C : Category} (X Y : @ob C) : Type := {
   ; iso_from_to : compose from to = id
 }.
 
-Program Instance isomorphism_equivalence `{C : Category} :
+#[export] Program Instance isomorphism_equivalence `{C : Category} :
   Equivalence Isomorphism.
 Next Obligation.
   repeat intro.

--- a/test-suite/bugs/bug_5683.v
+++ b/test-suite/bugs/bug_5683.v
@@ -41,7 +41,7 @@ Class Monad M `{Functor M} :=
 (bind m f) g = bind m (fun x => bind (f x) g)
 }.
 
-Instance Succ_Functor : Functor Succ.
+#[export] Instance Succ_Functor : Functor Succ.
 Proof.
   unshelve econstructor.
   - intros A B f fa.

--- a/test-suite/bugs/bug_5703.v
+++ b/test-suite/bugs/bug_5703.v
@@ -1,6 +1,6 @@
 Class A := {}.
-Instance a:A := {}.
-Hint Extern 0 A => abstract (exact a) : typeclass_instances.
+#[export] Instance a:A := {}.
+#[export] Hint Extern 0 A => abstract (exact a) : typeclass_instances.
 Lemma lem : A.
 Proof.
   let a := constr:(_:A) in

--- a/test-suite/bugs/bug_5752.v
+++ b/test-suite/bugs/bug_5752.v
@@ -1,6 +1,6 @@
 Class C (A : Type) := c : A.
 
-Hint Mode C ! : typeclass_instances.
+#[export] Hint Mode C ! : typeclass_instances.
 
 Goal forall f : (forall A, C A -> C (list A)), True.
 intros.

--- a/test-suite/bugs/bug_6042.v
+++ b/test-suite/bugs/bug_6042.v
@@ -1,7 +1,7 @@
 Class C (n: nat) := T{x:True}.
 Generalizable All Variables.
 
-Fail Instance i : C n.
+Fail #[export] Instance i : C n.
 
-Instance i : `(C n).
+#[export] Instance i : `(C n).
 Proof. repeat constructor. Defined.

--- a/test-suite/bugs/bug_6278.v
+++ b/test-suite/bugs/bug_6278.v
@@ -3,10 +3,10 @@ Require Setoids.Setoid.
 
 Axiom Equiv : Type -> Type -> Type.
 
-Instance equivalence_equiv : CRelationClasses.Equivalence Equiv.
+#[export] Instance equivalence_equiv : CRelationClasses.Equivalence Equiv.
 Admitted.
 
-Instance prod_equiv : CMorphisms.Proper (Equiv ==> Equiv ==> Equiv) prod.
+#[export] Instance prod_equiv : CMorphisms.Proper (Equiv ==> Equiv ==> Equiv) prod.
 Admitted.
 
 Lemma foo {A B C:Type} (X: Equiv A B) : Equiv (prod C A) (prod C B).

--- a/test-suite/bugs/bug_6661.v
+++ b/test-suite/bugs/bug_6661.v
@@ -33,7 +33,7 @@ Global Set Printing Universes.
  Inductive unit : UU0 := tt : unit.
 
 Inductive paths@{i} {A:Type@{i}} (a:A) : A -> Type@{i} := idpath : paths a a.
-Hint Resolve idpath : core .
+#[export] Hint Resolve idpath : core .
 Notation "a = b" := (paths a b) (at level 70, no associativity) : type_scope.
 
 Set Primitive Projections.
@@ -61,7 +61,7 @@ Proof.
   intros. induction e1. exact e2.
 Defined.
 
-Hint Resolve @pathscomp0 : pathshints.
+#[export] Hint Resolve @pathscomp0 : pathshints.
 
 Notation "p @ q" := (pathscomp0 p q).
 

--- a/test-suite/bugs/bug_7812.v
+++ b/test-suite/bugs/bug_7812.v
@@ -21,7 +21,7 @@ Module Simple_sparse_proof.
   Definition edge_notin G l : node -> node -> Prop :=
     Foo.inter node (has_edge G) (notin l).
 
-  Hint Unfold Foo.inter notin edge_notin : rel_crush.
+  #[export] Hint Unfold Foo.inter notin edge_notin : rel_crush.
 
   Lemma edge_notin_nil G : forall x y, edge_notin G nil x y <-> has_edge G x y.
   Proof.

--- a/test-suite/bugs/bug_7867.v
+++ b/test-suite/bugs/bug_7867.v
@@ -1,4 +1,4 @@
 (* Was a printer anomaly due to an internal lambda with no binders *)
 
 Class class := { foo : nat }.
-Fail Instance : class := { foo := 0 ; bar := 0 }.
+Fail #[export] Instance : class := { foo := 0 ; bar := 0 }.

--- a/test-suite/bugs/bug_7904.v
+++ b/test-suite/bugs/bug_7904.v
@@ -1,7 +1,7 @@
 
 
 Class abstract_term {T} (x : T) := by_abstract_term : T.
-Hint Extern 0 (@abstract_term ?T ?x) => change T; abstract (exact x) : typeclass_instances.
+#[export] Hint Extern 0 (@abstract_term ?T ?x) => change T; abstract (exact x) : typeclass_instances.
 
 Goal True.
   let term := constr:(I) in

--- a/test-suite/bugs/bug_7916.v
+++ b/test-suite/bugs/bug_7916.v
@@ -10,7 +10,7 @@ Lemma test {A}
 Proof.
   intros list_lookup_op l1 l2.
   (* setoid_rewrite list_lookup_op. Undo. *)
-Hint Mode Reflexive ! ! : typeclass_instances.
+#[export] Hint Mode Reflexive ! ! : typeclass_instances.
 
   setoid_rewrite list_lookup_op.
 Abort.
@@ -454,10 +454,10 @@ Module SSr.
 
    End RealLemmas.
 
-   Hint Resolve eqR_refl leRR ltRW.
+   #[export] Hint Resolve eqR_refl leRR ltRW.
 
-   Existing Instance real_equality.
-   Existing Instance addR_Proper.
+   #[export] Existing Instance real_equality.
+   #[export] Existing Instance addR_Proper.
 
    Section RealMorph.
 

--- a/test-suite/bugs/bug_8004.v
+++ b/test-suite/bugs/bug_8004.v
@@ -28,7 +28,7 @@ Fixpoint list_equiv `{Setoid A} (xs ys : list A) : Type :=
 Axiom proof_admitted : False.
 Tactic Notation "admit" := abstract case proof_admitted.
 
-Program Instance list_equivalence `{Setoid A} : Equivalence list_equiv.
+#[export] Program Instance list_equivalence `{Setoid A} : Equivalence list_equiv.
 Next Obligation.
   repeat intro.
   induction x; simpl; split; auto.

--- a/test-suite/bugs/bug_8791.v
+++ b/test-suite/bugs/bug_8791.v
@@ -2,8 +2,8 @@ Class Inhabited (A : Type) : Type := populate { inhabitant : A }.
 
 Definition A := 42.
 
-Instance foo (A: Type): Inhabited (list A).
+#[export] Instance foo (A: Type): Inhabited (list A).
 Check A.
 Abort.
 
-Fail Instance foo (A : nat) (A : Type) : Inhabited nat.
+Fail #[export] Instance foo (A : nat) (A : Type) : Inhabited nat.

--- a/test-suite/bugs/bug_9000.v
+++ b/test-suite/bugs/bug_9000.v
@@ -2,7 +2,7 @@ Set Primitive Projections.
 Class type (t : Type) : Type :=
   { bar : t -> Prop  }.
 
-Instance type_nat : type nat :=
+#[export] Instance type_nat : type nat :=
   { bar := fun _ => True }.
 
 Definition foo_bar {n : nat} : bar n := I.

--- a/test-suite/bugs/bug_9058.v
+++ b/test-suite/bugs/bug_9058.v
@@ -1,8 +1,8 @@
 Class A (X : Type) := {}.
-Hint Mode A ! : typeclass_instances.
+#[export] Hint Mode A ! : typeclass_instances.
 
 Class B X {aX: A X} Y := { opB: X -> Y -> Y }.
-Hint Mode B - - ! : typeclass_instances.
+#[export] Hint Mode B - - ! : typeclass_instances.
 
 Section Section.
 

--- a/test-suite/bugs/bug_9300.v
+++ b/test-suite/bugs/bug_9300.v
@@ -1,6 +1,6 @@
 Existing Class True.
 
-Instance foo {n : nat} (x := I) : forall {b : bool} (s : nat * nat), True. auto. Defined.
+#[export] Instance foo {n : nat} (x := I) : forall {b : bool} (s : nat * nat), True. auto. Defined.
 
 Fail Check foo (n := 3) true (s := (4 , 5)).
 Check foo (n := 3) (b := true) (4 , 5).

--- a/test-suite/bugs/bug_9313.v
+++ b/test-suite/bugs/bug_9313.v
@@ -1,13 +1,13 @@
 Set Implicit Arguments.
 Existing Class True.
 
-Instance foo1 (a : nat) {b : nat} (e : a = b) : True := I.
+#[export] Instance foo1 (a : nat) {b : nat} (e : a = b) : True := I.
 Check foo1 (a := 3) (b := 4).
 
 Definition foo2 (a : nat) {b : nat} (e : a = b) : True := I.
 Check foo2 (a := 3) (b := 4).
 
-Instance foo3 (a : nat) {b : nat} (e : a = b) : True.
+#[export] Instance foo3 (a : nat) {b : nat} (e : a = b) : True.
 exact I.
 Qed.
 Check foo3 (a := 3) (b := 4).

--- a/test-suite/bugs/bug_9631.v
+++ b/test-suite/bugs/bug_9631.v
@@ -1,7 +1,7 @@
 
-Fail Instance x : _.
+Fail #[export] Instance x : _.
 
 Existing Class True.
 (* the type is checked for typeclass-ness before interping the body so
    this is the same error *)
-Fail Instance x : _ := I.
+Fail #[export] Instance x : _ := I.

--- a/test-suite/failure/autorewritein.v
+++ b/test-suite/failure/autorewritein.v
@@ -4,7 +4,7 @@ Axiom Ack0 : forall m : nat, Ack 0 m = S m.
 Axiom Ack1 : forall n : nat, Ack (S n) 0 = Ack n 1.
 Axiom Ack2 : forall n m : nat, Ack (S n) (S m) = Ack n (Ack (S n) m).
 
-Hint Rewrite Ack0 Ack1 Ack2 : base0.
+#[export] Hint Rewrite Ack0 Ack1 Ack2 : base0.
 
 Lemma ResAck2 : forall H:(Ack 2 2 = 7 -> False), H=H  -> False.
 Proof.

--- a/test-suite/micromega/bug_14054.v
+++ b/test-suite/micromega/bug_14054.v
@@ -36,7 +36,7 @@ Module LittleEndian.
   Admitted.
 End LittleEndian.
 
-Instance InjByteTuple{n: nat}: InjTyp (tuple byte n) Z := {|
+#[export] Instance InjByteTuple{n: nat}: InjTyp (tuple byte n) Z := {|
   inj := LittleEndian.combine n;
   pred x := 0 <= x < 2 ^ (8 * Z.of_nat n);
   cstr := @LittleEndian.combine_bound n;

--- a/test-suite/micromega/rsyntax.v
+++ b/test-suite/micromega/rsyntax.v
@@ -26,7 +26,7 @@ Abort.
 
 Require Import DeclConstant.
 
-Instance Dsqrt : DeclaredConstant Z.sqrt := {}.
+#[export] Instance Dsqrt : DeclaredConstant Z.sqrt := {}.
 
 Goal ( IZR (Z.sqrt 4) = 2)%R.
 Proof.
@@ -46,7 +46,7 @@ Proof.
   Fail lra.
 Abort.
 
-Instance Dplus : DeclaredConstant Init.Nat.add := {}.
+#[export] Instance Dplus : DeclaredConstant Init.Nat.add := {}.
 
 Goal ( 1 ^ (2 + 2) = 1)%R.
 Proof.

--- a/test-suite/micromega/zify.v
+++ b/test-suite/micromega/zify.v
@@ -203,7 +203,7 @@ Definition znat := mk nat 0%nat.
 Require Import ZifyClasses.
 Require Import ZifyInst.
 
-Instance Zero : CstOp (@zero znat : nat) := Op_O.
+#[export] Instance Zero : CstOp (@zero znat : nat) := Op_O.
 Add Zify CstOp Zero.
 
 
@@ -260,7 +260,7 @@ Qed.
 
 Require Import ZifyBool.
 
-Instance Op_bool_inj : UnOp (inj : bool -> bool) :=
+#[export] Instance Op_bool_inj : UnOp (inj : bool -> bool) :=
   { TUOp := id; TUOpInj := fun _ => eq_refl }.
 Add Zify UnOp Op_bool_inj.
 

--- a/test-suite/misc/7595/FOO.v
+++ b/test-suite/misc/7595/FOO.v
@@ -15,7 +15,7 @@ Tactic Notation "destruct_decide" constr(dec) :=
 
 
 (** * Monadic operations *)
-Instance option_guard: MGuard option := λ P dec A f,
+#[export] Instance option_guard: MGuard option := λ P dec A f,
   match dec with left H => f H | _ => None end.
 
 (** * Tactics *)

--- a/test-suite/misc/7595/base.v
+++ b/test-suite/misc/7595/base.v
@@ -9,7 +9,7 @@ Global Generalizable All Variables.
 (** This type class by (Spitters/van der Weegen, 2011) collects decidable
 propositions. *)
 Class Decision (P : Prop) := decide : {P} + {¬P}.
-Hint Mode Decision ! : typeclass_instances.
+#[export] Hint Mode Decision ! : typeclass_instances.
 Arguments decide _ {_} : simpl never, assert.
 
 (** ** Proof irrelevant types *)
@@ -17,7 +17,7 @@ Arguments decide _ {_} : simpl never, assert.
 elements of the type are equal. We use this notion only used for propositions,
 but by universe polymorphism we can generalize it. *)
 Class ProofIrrel (A : Type) : Prop := proof_irrel (x y : A) : x = y.
-Hint Mode ProofIrrel ! : typeclass_instances.
+#[export] Hint Mode ProofIrrel ! : typeclass_instances.
 
 Class MGuard (M : Type → Type) :=
   mguard: ∀ P {dec : Decision P} {A}, (P → M A) → M A.

--- a/test-suite/modules/Nat.v
+++ b/test-suite/modules/Nat.v
@@ -2,7 +2,7 @@ Definition T := nat.
 
 Definition le := le.
 
-Hint Unfold le : core.
+#[global] Hint Unfold le : core.
 
 Lemma le_refl : forall n : nat, le n n.
   auto.

--- a/test-suite/modules/PO.v
+++ b/test-suite/modules/PO.v
@@ -12,7 +12,7 @@ Module Type PO.
   Axiom le_trans : forall x y z : T, le x y -> le y z -> le x z.
   Axiom le_antis : forall x y : T, le x y -> le y x -> x = y.
 
-  Hint Resolve le_refl le_trans le_antis.
+  #[global] Hint Resolve le_refl le_trans le_antis.
 End PO.
 
 
@@ -20,7 +20,7 @@ Module Pair (X: PO) (Y: PO) <: PO.
   Definition T := (X.T * Y.T)%type.
   Definition le p1 p2 := X.le (fst p1) (fst p2) /\ Y.le (snd p1) (snd p2).
 
-  Hint Unfold le.
+  #[global] Hint Unfold le.
 
   Lemma le_refl : forall p : T, le p p.
     auto.

--- a/test-suite/modules/modul.v
+++ b/test-suite/modules/modul.v
@@ -4,7 +4,7 @@ Module M.
 
   Axiom w : forall n : nat, rel 0 (S n).
 
-  Hint Resolve w.
+  #[export] Hint Resolve w.
 
   (* <Warning> : Grammar is replaced by Notation *)
 

--- a/test-suite/prerequisite/ssr_mini_mathcomp.v
+++ b/test-suite/prerequisite/ssr_mini_mathcomp.v
@@ -91,7 +91,7 @@ Notation eqxx := eq_refl.
 Lemma eq_sym (T : eqType) (x y : T) : (x == y) = (y == x).
 Proof. exact/eqP/eqP. Qed.
 
-Hint Resolve eq_refl eq_sym.
+#[global] Hint Resolve eq_refl eq_sym.
 
 
 Definition eqb b := addb (~~ b).
@@ -422,7 +422,7 @@ Lemma leq0n n : 0 <= n.                 Proof. by []. Qed.
 Lemma ltn0Sn n : 0 < n.+1.              Proof. by []. Qed.
 Lemma ltn0 n : n < 0 = false.           Proof. by []. Qed.
 Lemma leqnn n : n <= n.                 Proof. by elim: n. Qed.
-Hint Resolve leqnn.
+#[global] Hint Resolve leqnn.
 Lemma leqnSn n : n <= n.+1.             Proof. by elim: n. Qed.
 
 Lemma leq_trans n m p : m <= n -> n <= p -> m <= p.
@@ -431,10 +431,10 @@ Lemma leq_ltn_trans n m p : m <= n -> n < p -> m < p.
 Admitted.
 Lemma leqW m n : m <= n -> m <= n.+1.
 Admitted.
-Hint Resolve leqnSn.
+#[global] Hint Resolve leqnSn.
 Lemma ltnW m n : m < n -> m <= n.
 Proof. exact: leq_trans. Qed.
-Hint Resolve ltnW.
+#[global] Hint Resolve ltnW.
 
 Definition addn_rec := plus.
 Notation "m + n" := (addn_rec m n) : nat_rec_scope.
@@ -1323,7 +1323,7 @@ Admitted.
 Lemma mem_index_enum T i : i \in index_enum T.
 Admitted.
 
-Hint Resolve mem_index_enum.
+#[global] Hint Resolve mem_index_enum.
 
 (*
 Lemma filter_index_enum T P : filter P (index_enum T) = enum P.

--- a/test-suite/ssr/absevarprop.v
+++ b/test-suite/ssr/absevarprop.v
@@ -57,7 +57,7 @@ move=> P2; apply: ex_intro (exist _ 2 _) _.
 match goal with |- @sval _ _ (@exist _ _ 2 P2) = 2 => done | _ => fail end.
 Qed.
 
-Hint Resolve P1.
+#[export] Hint Resolve P1.
 
 Lemma testmE12 : myEx.
 Proof.
@@ -69,7 +69,7 @@ Qed.
 
 Create HintDb SSR.
 
-Hint Resolve P11 : SSR.
+#[export] Hint Resolve P11 : SSR.
 
 Ltac ssrautoprop := trivial with SSR.
 
@@ -85,7 +85,7 @@ Definition R1 := fun (x : nat) (p : P x) m (q : P (x+1)) (r : Q x p) => m > 0.
 Inductive myEx1 : Type :=
   ExI1 : forall n (pn : P n) pn' (q : Q n pn), R1 n pn n pn' q -> myEx1.
 
-Hint Resolve (Q1 P1) : SSR.
+#[export] Hint Resolve (Q1 P1) : SSR.
 
 (* tests that goals in prop are solved in the right order, propagating instantiations,
    thus the goal Q 1 ?p1 is faced by trivial after ?p1, and is thus evar free *)

--- a/test-suite/ssr/case_TC3.v
+++ b/test-suite/ssr/case_TC3.v
@@ -5,7 +5,7 @@ Set Debug Ssreflect.
 
 Class Class sort := { op : sort → bool }.
 Arguments op {_ _}.
-Hint Mode Class !.
+#[export] Hint Mode Class !.
 
 Lemma opP A (C: Class A) (a: A) : reflect True (op a).
 Proof. Admitted.

--- a/test-suite/ssr/have_TC.v
+++ b/test-suite/ssr/have_TC.v
@@ -15,7 +15,7 @@ Require Import ssreflect.
 Axiom daemon : False. Ltac myadmit := case: daemon.
 
 Class foo (T : Type) := { n : nat }.
-Instance five : foo nat := {| n := 5 |}.
+#[export] Instance five : foo nat := {| n := 5 |}.
 
 Definition bar T {f : foo T} m : Prop :=
   @n _ f = m.
@@ -51,7 +51,7 @@ Qed.
 
 Unset SsrHave NoTCResolution.
 
-Instance test : foo bool.
+#[export] Instance test : foo bool.
 Proof.
   have : foo nat.
 Abort.

--- a/test-suite/ssr/tc.v
+++ b/test-suite/ssr/tc.v
@@ -14,9 +14,9 @@ Require Import ssreflect.
 
 
 Class foo (A : Type) : Type := mkFoo { val : A }.
-Instance foo_pair {A B} {f1 : foo A} {f2 : foo B} : foo (A * B) | 2 :=
+#[export] Instance foo_pair {A B} {f1 : foo A} {f2 : foo B} : foo (A * B) | 2 :=
   {| val := (@val _ f1, @val _ f2) |}.
-Instance foo_nat : foo nat | 3 := {| val := 0 |}.
+#[export] Instance foo_nat : foo nat | 3 := {| val := 0 |}.
 
 Definition id {A} (x : A) := x.
 Axiom E : forall A {f : foo A} (a : A), id a = (@val _ f).

--- a/test-suite/success/HintMode.v
+++ b/test-suite/success/HintMode.v
@@ -5,9 +5,9 @@ Class Empty T := { empty : T }.
 Class EmptyIn (A T : Type) `{In A T} `{Empty T} :=
  { isempty : forall x, IsIn x empty -> False }.
 
-Hint Mode EmptyIn ! ! - - : typeclass_instances.
-Hint Mode Empty ! : typeclass_instances.
-Hint Mode In ! - : typeclass_instances.
+#[export] Hint Mode EmptyIn ! ! - - : typeclass_instances.
+#[export] Hint Mode Empty ! : typeclass_instances.
+#[export] Hint Mode In ! - : typeclass_instances.
 Existing Class IsIn.
 Goal forall A T `{In A T} `{Empty T} `{EmptyIn A T}, forall x : A, IsIn x empty -> False.
  Proof.
@@ -43,8 +43,8 @@ Module BestEffort.
   Class B (T : Type).
   Global Hint Mode B + : typeclass_instances.
 
-  Instance a_imp_b T : A T -> B T := {}.
-  Instance anat : B nat := {}.
+  #[export] Instance a_imp_b T : A T -> B T := {}.
+  #[export] Instance anat : B nat := {}.
   Lemma b : B nat * A nat.
   Proof.
     Fail split; typeclasses eauto.

--- a/test-suite/success/Hints.v
+++ b/test-suite/success/Hints.v
@@ -1,25 +1,25 @@
 (* Checks syntax of Hints commands *)
 (* Old-style syntax *)
-Hint Resolve eq_refl eq_sym.
-Hint Resolve eq_refl eq_sym: foo.
-Hint Immediate eq_refl eq_sym.
-Hint Immediate eq_refl eq_sym: foo.
-Hint Unfold fst eq_sym.
-Hint Unfold fst eq_sym: foo.
+#[export] Hint Resolve eq_refl eq_sym.
+#[export] Hint Resolve eq_refl eq_sym: foo.
+#[export] Hint Immediate eq_refl eq_sym.
+#[export] Hint Immediate eq_refl eq_sym: foo.
+#[export] Hint Unfold fst eq_sym.
+#[export] Hint Unfold fst eq_sym: foo.
 
 (* Checks that qualified names are accepted *)
 
 (* New-style syntax *)
-Hint Resolve eq_refl: core arith.
-Hint Immediate eq_trans.
-Hint Unfold eq_sym: core.
-Hint Constructors eq: foo bar.
-Hint Extern 3 (_ = _) => apply eq_refl: foo bar.
+#[export] Hint Resolve eq_refl: core arith.
+#[export] Hint Immediate eq_trans.
+#[export] Hint Unfold eq_sym: core.
+#[export] Hint Constructors eq: foo bar.
+#[export] Hint Extern 3 (_ = _) => apply eq_refl: foo bar.
 
 (* Extended new syntax with patterns *)
-Hint Resolve eq_refl | 4 (_ = _) : baz.
-Hint Resolve eq_sym eq_trans : baz.
-Hint Extern 3 (_ = _) => apply eq_sym : baz.
+#[export] Hint Resolve eq_refl | 4 (_ = _) : baz.
+#[export] Hint Resolve eq_sym eq_trans : baz.
+#[export] Hint Extern 3 (_ = _) => apply eq_sym : baz.
 
 Parameter pred : nat -> Prop.
 Parameter pred0 : pred 0.
@@ -27,13 +27,13 @@ Parameter f : nat -> nat.
 Parameter predf : forall n, pred n -> pred (f n).
 
 (* No conversion on let-bound variables and constants in pred (the default) *)
-Hint Resolve pred0 | 1 (pred _) : pred.
-Hint Resolve predf | 0 : pred.
+#[export] Hint Resolve pred0 | 1 (pred _) : pred.
+#[export] Hint Resolve predf | 0 : pred.
 
 (* Allow full conversion on let-bound variables and constants *)
 Create HintDb predconv discriminated.
-Hint Resolve pred0 | 1 (pred _) : predconv.
-Hint Resolve predf | 0 : predconv.
+#[export] Hint Resolve pred0 | 1 (pred _) : predconv.
+#[export] Hint Resolve predf | 0 : predconv.
 
 Goal exists n, pred n.
   eexists.
@@ -47,14 +47,14 @@ Parameter predconv : forall n, pred n -> pred (0 + S n).
 
 (* The inferred pattern contains 0 + ?n, syntactic match will fail to see convertible
  terms *)
-Hint Resolve pred0 : pred2.
-Hint Resolve predconv : pred2.
+#[export] Hint Resolve pred0 : pred2.
+#[export] Hint Resolve predconv : pred2.
 
 (** In this database we allow predconv to apply to pred (S _) goals, more generally
   than the inferred pattern (pred (0 + S _)). *)
 Create HintDb pred2conv discriminated.
-Hint Resolve pred0 : pred2conv.
-Hint Resolve predconv | 1 (pred (S _)) : pred2conv.
+#[export] Hint Resolve pred0 : pred2conv.
+#[export] Hint Resolve predconv | 1 (pred (S _)) : pred2conv.
 
 Goal pred 3.
   Fail typeclasses eauto with pred2.
@@ -63,8 +63,8 @@ Abort.
 
 Set Typeclasses Filtered Unification.
 Set Typeclasses Debug Verbosity 2.
-Hint Resolve predconv | 1 (pred _) : pred.
-Hint Resolve predconv | 1 (pred (S _)) : predconv.
+#[export] Hint Resolve predconv | 1 (pred _) : pred.
+#[export] Hint Resolve predconv | 1 (pred (S _)) : predconv.
 Test Typeclasses Limit Intros.
 Goal pred 3.
   (* predf is not tried as it doesn't match the goal *)
@@ -111,7 +111,7 @@ End A.
 
 Axiom a : forall n, n=0 <-> n<=0.
 
-Hint Resolve -> a.
+#[export] Hint Resolve -> a.
 Goal forall n, n=0 -> n<=0.
 auto.
 Qed.
@@ -129,7 +129,7 @@ Axiom cast_coalesce :
   forall (T1 T2 T3 : Set) (e : T1) (pf1 : T1 = T2) (pf2 : T2 = T3),
   ((e :? pf1) :? pf2) = (e :? trans_eq pf1 pf2).
 
-Hint Rewrite cast_coalesce : ltamer.
+#[export] Hint Rewrite cast_coalesce : ltamer.
 
 Require Import Program.
 Module HintCut.
@@ -139,34 +139,34 @@ Class C (f : nat -> nat) := c : True.
 Class D (f : nat -> nat) := d : True.
 Class E (f : nat -> nat) := e : True.
 
-Instance a_is_b f : A f -> B f.
+#[export] Instance a_is_b f : A f -> B f.
 Proof. easy. Qed.
-Instance b_is_c f : B f -> C f.
+#[export] Instance b_is_c f : B f -> C f.
 Proof. easy. Qed.
-Instance c_is_d f : C f -> D f.
+#[export] Instance c_is_d f : C f -> D f.
 Proof. easy. Qed.
-Instance d_is_e f : D f -> E f.
-Proof. easy. Qed.
-
-Instance a_compose f g : A f -> A g -> A (compose f g).
-Proof. easy. Qed.
-Instance b_compose f g : B f -> B g -> B (compose f g).
-Proof. easy. Qed.
-Instance c_compose f g : C f -> C g -> C (compose f g).
-Proof. easy. Qed.
-Instance d_compose f g : D f -> D g -> D (compose f g).
-Proof. easy. Qed.
-Instance e_compose f g : E f -> E g -> E (compose f g).
+#[export] Instance d_is_e f : D f -> E f.
 Proof. easy. Qed.
 
-Instance a_id : A id.
+#[export] Instance a_compose f g : A f -> A g -> A (compose f g).
+Proof. easy. Qed.
+#[export] Instance b_compose f g : B f -> B g -> B (compose f g).
+Proof. easy. Qed.
+#[export] Instance c_compose f g : C f -> C g -> C (compose f g).
+Proof. easy. Qed.
+#[export] Instance d_compose f g : D f -> D g -> D (compose f g).
+Proof. easy. Qed.
+#[export] Instance e_compose f g : E f -> E g -> E (compose f g).
 Proof. easy. Qed.
 
-Instance foo f :
+#[export] Instance a_id : A id.
+Proof. easy. Qed.
+
+#[export] Instance foo f :
   E (id ∘ id ∘ id ∘ id ∘ id ∘ id ∘ id ∘ id ∘ id ∘ id ∘ id ∘ id ∘ id ∘ id ∘ id ∘
      id ∘ id ∘ id ∘ id ∘ id ∘ f ∘ id ∘ id ∘ id ∘ id ∘ id ∘ id ∘ id).
 Proof.
-Hint Cut [_* (a_is_b | b_is_c | c_is_d | d_is_e)
+#[export] Hint Cut [_* (a_is_b | b_is_c | c_is_d | d_is_e)
                  (a_compose | b_compose | c_compose | d_compose | e_compose)] : typeclass_instances.
 
   Timeout 1 Fail apply _. (* 0.06s *)

--- a/test-suite/success/InductiveVsImplicitsVsTC.v
+++ b/test-suite/success/InductiveVsImplicitsVsTC.v
@@ -15,7 +15,7 @@ Module ForConv.
 
   Class Bla := { bla : Type }.
 
-  Instance bli : Bla := { bla := nat }.
+  #[export] Instance bli : Bla := { bla := nat }.
 
   Inductive vs := C : forall x : bla, x = 2 -> vs.
   (* here we need to resolve TC to pass the conversion problem if we

--- a/test-suite/success/Record.v
+++ b/test-suite/success/Record.v
@@ -10,7 +10,7 @@ Arguments vector : clear implicits.
 
 Coercion vec_list : vector >-> list.
 
-Hint Rewrite @vec_len : datatypes.
+#[export] Hint Rewrite @vec_len : datatypes.
 
 Ltac crush := repeat (program_simplify ; autorewrite with list datatypes ; auto with *).
 
@@ -21,7 +21,7 @@ Program Definition vnil {A} : vector A 0 := {| vec_list := [] |}.
 Program Definition vcons {A n} (a : A) (v : vector A n) : vector A (S n) :=
   {| vec_list := cons a (vec_list v) |}.
 
-Hint Rewrite map_length rev_length : datatypes.
+#[export] Hint Rewrite map_length rev_length : datatypes.
 
 Program Definition vmap {A B n} (f : A -> B) (v : vector A n) : vector B n :=
   {| vec_list := map f v |}.

--- a/test-suite/success/RefineInstance.v
+++ b/test-suite/success/RefineInstance.v
@@ -2,22 +2,22 @@
 
 Class Foo := foo { a : nat; b : bool }.
 
-Fail Instance bla : Foo := { b:= true }.
+Fail #[export] Instance bla : Foo := { b:= true }.
 
-#[refine] Instance bla : Foo := { b:= true }.
+#[refine, export] Instance bla : Foo := { b:= true }.
 Proof.
 exact 0.
 Defined.
 
-Instance bli : Foo := { a:=1; b := false}.
+#[export] Instance bli : Foo := { a:=1; b := false}.
 Check bli.
 
 Fail #[program, refine] Instance bla : Foo := {b := true}.
 
-#[program] Instance blo : Foo := {b := true}.
+#[program, export] Instance blo : Foo := {b := true}.
 Next Obligation. exact 2. Qed.
 Check blo.
 
-#[refine] Instance xbar : Foo := {a:=4; b:=true}.
+#[refine, export] Instance xbar : Foo := {a:=4; b:=true}.
 Proof. Qed.
 Check xbar.

--- a/test-suite/success/SchemeEquality.v
+++ b/test-suite/success/SchemeEquality.v
@@ -21,7 +21,7 @@ Module C.
   Parameter eq_A : A->A->bool.
   Parameter A_bl : forall x y, eq_A x y = true -> x = y.
   Parameter A_lb : forall x y, x = y -> eq_A x y = true.
-  Hint Resolve A_bl A_lb : core.
+  #[export] Hint Resolve A_bl A_lb : core.
   Inductive I := C : A -> I.
   Scheme Equality for I.
   Inductive J := D : list A -> J.

--- a/test-suite/success/TCbacktrack.v
+++ b/test-suite/success/TCbacktrack.v
@@ -13,15 +13,15 @@ Set Typeclasses Unique Instances.
 Class D.
 Class C (A : Type) := c : A.
 
-Hint Mode C +.
+#[export] Hint Mode C +.
 Fail Definition test := c.
 
 Unset Typeclasses Unique Instances.
-Instance cN1 : B -> D -> C nat := fun _ _ => 0.
-Instance cN2 : A -> D -> C nat := fun _ _ => 1.
-Instance cB : B -> C bool := fun _ => true.
+#[export] Instance cN1 : B -> D -> C nat := fun _ _ => 0.
+#[export] Instance cN2 : A -> D -> C nat := fun _ _ => 1.
+#[export] Instance cB : B -> C bool := fun _ => true.
 
-Instance Copt : forall A, C A -> C (option A) := fun A _ => None.
+#[export] Instance Copt : forall A, C A -> C (option A) := fun A _ => None.
 
 Set Typeclasses Debug.
 
@@ -49,10 +49,10 @@ Module BacktrackGreenCut.
 
   Class D (A : Type) : Type := { c_of_d :> C A }.
 
-  Instance D1 : D unit.
+  #[export] Instance D1 : D unit.
   Admitted.
 
-  Instance D2 : D unit.
+  #[export] Instance D2 : D unit.
   Admitted.
 
   (** Two instances of D unit, but when searching for [C unit], no
@@ -71,8 +71,8 @@ Module BacktrackGreenCut.
   Class PartialOrder (A : Type) := { partialorder_trans :> Transitive A }.
   Class PartialOrder' (A : Type) := { partialorder_trans' :> Transitive A }.
 
-  Instance: PreOrder nat. Admitted.
-  Instance: PartialOrder nat. Admitted.
+  #[export] Instance: PreOrder nat. Admitted.
+  #[export] Instance: PartialOrder nat. Admitted.
 
   Class NoInst (A : Type) := {}.
 

--- a/test-suite/success/Typeclasses.v
+++ b/test-suite/success/Typeclasses.v
@@ -3,10 +3,10 @@ Module applydestruct.
   Class Foo (A : Type) :=
     { bar : nat -> A;
       baz  : A -> nat }.
-  Hint Mode Foo + : typeclass_instances.
+  #[export] Hint Mode Foo + : typeclass_instances.
 
   Class C (A : Type).
-  Hint Mode C + : typeclass_instances.
+  #[export] Hint Mode C + : typeclass_instances.
 
   Variable fool : forall {A} {F : Foo A} (x : A), C A -> bar 0 = x.
   (* apply leaves non-dependent subgoals of typeclass type
@@ -65,7 +65,7 @@ Module onlyclasses.
 (* In 8.6 we still allow non-class subgoals *)
   Variable Foo : Type.
   Variable foo : Foo.
-  Hint Extern 0 Foo => exact foo : typeclass_instances.
+  #[export] Hint Extern 0 Foo => exact foo : typeclass_instances.
   Goal Foo * Foo.
     split. shelve.
     Set Typeclasses Debug.
@@ -76,8 +76,8 @@ Module onlyclasses.
   Module RJung.
     Class Foo (x : nat).
       
-      Instance foo x : x = 2 -> Foo x := {}.
-      Hint Extern 0 (_ = _) => reflexivity : typeclass_instances.
+      #[export] Instance foo x : x = 2 -> Foo x := {}.
+      #[export] Hint Extern 0 (_ = _) => reflexivity : typeclass_instances.
       Typeclasses eauto := debug.
       Check (_ : Foo 2).
 
@@ -90,9 +90,9 @@ End onlyclasses.
 Module shelve_non_class_subgoals.
   Variable Foo : Type.
   Variable foo : Foo.
-  Hint Extern 0 Foo => exact foo : typeclass_instances.
+  #[export] Hint Extern 0 Foo => exact foo : typeclass_instances.
   Class Bar := {}.
-  Instance bar1 (f:Foo) : Bar := {}.
+  #[export] Instance bar1 (f:Foo) : Bar := {}.
 
   Typeclasses eauto := debug.
   Set Typeclasses Debug Verbosity 2.
@@ -105,9 +105,9 @@ End shelve_non_class_subgoals.
 Module RefineVsNoTceauto.
 
   Class Foo (A : Type) := foo : A.
-  Instance: Foo nat := { foo := 0 }.
-  Instance: Foo nat := { foo := 42 }.
-  Hint Extern 0 (_ = _) => refine eq_refl : typeclass_instances.
+  #[export] Instance: Foo nat := { foo := 0 }.
+  #[export] Instance: Foo nat := { foo := 42 }.
+  #[export] Hint Extern 0 (_ = _) => refine eq_refl : typeclass_instances.
   Goal exists (f : Foo nat), @foo _ f = 0.
   Proof.
     unshelve (notypeclasses refine (ex_intro _ _ _)). 
@@ -125,7 +125,7 @@ End RefineVsNoTceauto.
 Module Leivantex2PR339.
   (** Was a bug preventing to find hints associated with no pattern *)
   Class Bar := {}.
-  Instance bar1 (t:Type) : Bar := {}.
+  #[export] Instance bar1 (t:Type) : Bar := {}.
   Local Hint Extern 0 => exact True : typeclass_instances.
   Typeclasses eauto := debug.
   Goal Bar.
@@ -156,13 +156,13 @@ Record Equ (A : Type) (R : A -> A -> Prop).
 Definition equiv {A} R (e : Equ A R) := R.
 Record Refl (A : Type) (R : A -> A -> Prop).
 Axiom equ_refl : forall A R (e : Equ A R), Refl _ (@equiv A R e).
-Hint Extern 0 (Refl _ _) => unshelve class_apply @equ_refl; [shelve|] : foo.
+#[export] Hint Extern 0 (Refl _ _) => unshelve class_apply @equ_refl; [shelve|] : foo.
 
 Variable R : nat -> nat -> Prop.
 Lemma bas : Equ nat R.
 Admitted.
-Hint Resolve bas : foo.
-Hint Extern 1 => match goal with |- (_ -> _ -> Prop) => shelve end : foo.
+#[export] Hint Resolve bas : foo.
+#[export] Hint Extern 1 => match goal with |- (_ -> _ -> Prop) => shelve end : foo.
 
 Goal exists R, @Refl nat R.
   eexists.
@@ -219,7 +219,7 @@ Module deftwice.
 
   Record Inhab (A : Type) := { witness : A }.
 
-  Instance inhab_C : C Type := Inhab.
+  #[export] Instance inhab_C : C Type := Inhab.
 
   Axiom full : forall A (X : C A), forall x : A, c x.
 
@@ -254,8 +254,8 @@ End sec.
 Module UniqueSolutions.
   Set Typeclasses Unique Solutions.
   Class Eq (A : Type) : Set.
-    Instance eqa : Eq nat := {}.
-    Instance eqb : Eq nat := {}.
+    #[export] Instance eqa : Eq nat := {}.
+    #[export] Instance eqb : Eq nat := {}.
 
     Goal Eq nat.
       try apply _.
@@ -269,10 +269,10 @@ Module UniqueInstances.
       for it. *)
   Set Typeclasses Unique Instances.
   Class Eq (A : Type) : Set.
-    Instance eqa : Eq nat. Qed.
-    Instance eqb : Eq nat := {}.
+    #[export] Instance eqa : Eq nat. Qed.
+    #[export] Instance eqb : Eq nat := {}.
     Class Foo (A : Type) (e : Eq A) : Set.
-    Instance fooa : Foo _ eqa := {}.
+    #[export] Instance fooa : Foo _ eqa := {}.
 
     Tactic Notation "refineu" open_constr(c) := unshelve refine c.
 
@@ -291,10 +291,10 @@ Module IterativeDeepening.
   Class B.
   Class C.
 
-  Instance: B -> A | 0 := {}.
-  Instance: C -> A | 0 := {}.
-  Instance: C -> B -> A | 0 := {}.
-  Instance: A -> A | 0 := {}.
+  #[export] Instance: B -> A | 0 := {}.
+  #[export] Instance: C -> A | 0 := {}.
+  #[export] Instance: C -> B -> A | 0 := {}.
+  #[export] Instance: A -> A | 0 := {}.
   
   Goal C -> A.
     intros.
@@ -318,7 +318,7 @@ Module AxiomsAreNotInstances.
   Fail Definition testdef2 : TestClass2 := _.
 
   (* we didn't break typeclasses *)
-  Existing Instance testax2.
+  #[export] Existing Instance testax2.
   Definition testdef2 : TestClass2 := _.
 
 End AxiomsAreNotInstances.
@@ -334,7 +334,7 @@ Module InternalHintBacktracking.
   Local Hint Extern 0 (A _) => exact a1 + exact a0 : typeclass_instances.
 
   Class B (T : Type).
-  Instance b0 : B nat := {}.
+  #[export] Instance b0 : B nat := {}.
 
   Definition foo {T} {x : A T} {b : B T} : T := ofA.
   (* This definition only passes because we backtrack on [exact a1] above and try a0 : A nat *)

--- a/test-suite/success/applyTC.v
+++ b/test-suite/success/applyTC.v
@@ -7,7 +7,7 @@ Admitted.
 
 Notation "{val:= v }" := (@val _ v).
 
-Instance zero : class nat := {| val := 0 |}.
+#[export] Instance zero : class nat := {| val := 0 |}.
 
 Lemma test : P 0.
 Fail apply usetc.

--- a/test-suite/success/auto.v
+++ b/test-suite/success/auto.v
@@ -11,7 +11,7 @@ Parameters
   (L: forall A (P: A -> Prop), G A P -> forall x, F (P x))
   (Q: unit -> Prop).
 
-Hint Resolve L.
+#[export] Hint Resolve L.
 
 Goal G unit Q -> F (Q tt).
   intro.
@@ -29,17 +29,17 @@ Qed.
 Create HintDb test discriminated.
 
 Parameter foo : forall x, x = x + 0.
-Hint Resolve foo : test.
+#[export] Hint Resolve foo : test.
 
 Variable C : nat -> Type -> Prop.
 
 Variable c_inst : C 0 nat.
 
-Hint Resolve c_inst : test.
+#[export] Hint Resolve c_inst : test.
 
-Hint Mode C - + : test.
-Hint Resolve c_inst : test2.
-Hint Mode C + + : test2.
+#[export] Hint Mode C - + : test.
+#[export] Hint Resolve c_inst : test2.
+#[export] Hint Mode C + + : test2.
 
 Goal exists n, C n nat.
 Proof.
@@ -52,7 +52,7 @@ Qed.
 
 Class B (A : Type).
 Class I. 
-Instance i : I := {}.
+#[export] Instance i : I := {}.
   
 Definition flip {A B C : Type} (f : A -> B -> C) := fun y x => f x y.
 Class D (f : nat -> nat -> nat).
@@ -96,7 +96,7 @@ Module InstnopatApply.
 End InstnopatApply.
   
 Module InstPat.
-  Hint Extern 3 (B nat) => split : typeclass_instances.
+  #[export] Hint Extern 3 (B nat) => split : typeclass_instances.
   (* map_eauto -> Extern hint *)
   (* Constr_matching.matches -> true *)
   Check (_ : B nat).
@@ -115,7 +115,7 @@ Module InstPat.
     Fail typeclasses eauto.
   Abort.
 
-  Hint Extern 0 (D (flip _)) => apply flipD : typeclass_instances.
+  #[export] Hint Extern 0 (D (flip _)) => apply flipD : typeclass_instances.
   Module withftest.
     Local Instance: D ftest := {}.
 
@@ -125,7 +125,7 @@ Module InstPat.
     (* ... : D (flip ftest) *)
   End withftest.
   Module withoutftest.
-    Hint Extern 0 (D ftest) => split : typeclass_instances.
+    #[export] Hint Extern 0 (D ftest) => split : typeclass_instances.
     Check (_ : D _).
     (* ? : D ?, _not_ looping *)
     Check (_ : D (flip _)).

--- a/test-suite/success/bteauto.v
+++ b/test-suite/success/bteauto.v
@@ -3,8 +3,8 @@ Require Import Program.Tactics.
 Module Backtracking.
   Class A := { foo : nat }.
 
-  Instance A_1 : A | 2 := { foo := 42 }.
-  Instance A_0 : A | 1 := { foo := 0 }.
+  #[global] Instance A_1 : A | 2 := { foo := 42 }.
+  #[global] Instance A_0 : A | 1 := { foo := 0 }.
   Lemma aeq (a : A) : foo = foo.
     reflexivity.
   Qed.
@@ -33,7 +33,7 @@ Module Backtracking.
 
   Print find42.
   
-  Hint Extern 0 (_ = _) => reflexivity : equality.
+  #[global] Hint Extern 0 (_ = _) => reflexivity : equality.
   
   Goal exists n, n = 42.
     eexists.
@@ -56,7 +56,7 @@ Module Backtracking.
     Axiom A : Type.
     Existing Class A.
     Axioms a b c d e: A.
-    Existing Instances a b c d e.
+    #[global] Existing Instances a b c d e.
     
     Ltac get_value H := eval cbv delta [H] in H.
     
@@ -74,10 +74,10 @@ Module Backtracking.
 End Backtracking.
 
 
-Hint Resolve 100 eq_sym eq_trans : core.
-Hint Cut [(_)* eq_sym eq_sym] : core.
-Hint Cut [_* eq_trans eq_trans] : core.
-Hint Cut [_* eq_trans eq_sym eq_trans] : core.
+#[export] Hint Resolve 100 eq_sym eq_trans : core.
+#[export] Hint Cut [(_)* eq_sym eq_sym] : core.
+#[export] Hint Cut [_* eq_trans eq_trans] : core.
+#[export] Hint Cut [_* eq_trans eq_sym eq_trans] : core.
 
 
 Goal forall x y z : nat, x = y -> z = y -> x = z.
@@ -90,14 +90,14 @@ Module Hierarchies.
   Class A := mkA { data : nat }.
   Class B := mkB { aofb :> A }.
 
-  Existing Instance mkB.
+  #[export] Existing Instance mkB.
 
   Definition makeB (a : A) : B := _.
   Definition makeA (a : B) : A := _.
 
   Fail Timeout 1 Definition makeA' : A := _.
 
-  Hint Cut [_* mkB aofb] : typeclass_instances.
+  #[export] Hint Cut [_* mkB aofb] : typeclass_instances.
   Fail Definition makeA' : A := _.
   Fail Definition makeB' : B := _.
 End Hierarchies.
@@ -108,9 +108,9 @@ Class Equality (A : Type) := { eqp : A -> A -> Prop }.
 
 Check (eqp 0%nat 0).
 
-Instance nat_equality : Equality nat := { eqp := eq }.
+#[export] Instance nat_equality : Equality nat := { eqp := eq }.
 
-Instance default_equality A : Equality A | 1000 :=
+#[export] Instance default_equality A : Equality A | 1000 :=
   { eqp := eq }.
 
 Check (eqp 0%nat 0).
@@ -120,7 +120,7 @@ Check (fun x y => eqp x y).
 (* No more defaulting, reduce "trigger-happiness" *)
 Definition ambiguous x y := eqp x y.
 
-Hint Mode Equality ! : typeclass_instances.
+#[export] Hint Mode Equality ! : typeclass_instances.
 Fail Definition ambiguous' x y := eqp x y.
 Definition nonambiguous (x y : nat) := eqp x y.
 
@@ -130,7 +130,7 @@ Definition flip {A B C} (f : A -> B -> C) := fun x y => f y x.
 Class SomeProp {A : Type} (f : A -> A -> A) :=
   { prf : forall x y, f x y = f x y }.
 
-Instance propflip (A : Type) (f : A -> A -> A) :
+#[export] Instance propflip (A : Type) (f : A -> A -> A) :
   SomeProp f -> SomeProp (flip f).
 Proof.
   intros []. constructor. reflexivity.
@@ -138,7 +138,7 @@ Qed.
 
 Fail Timeout 1 Check prf.
 
-Hint Mode SomeProp + + : typeclass_instances.
+#[export] Hint Mode SomeProp + + : typeclass_instances.
 Check prf.
 Check (fun H : SomeProp plus => _ : SomeProp (flip plus)).
 
@@ -150,10 +150,10 @@ Module IterativeDeepening.
   Class B.
   Class C.
 
-  Instance: B -> A | 0 := {}.
-  Instance: C -> A | 0 := {}.
-  Instance: C -> B -> A | 0 := {}.
-  Instance: A -> A | 0 := {}.
+  #[export] Instance: B -> A | 0 := {}.
+  #[export] Instance: C -> A | 0 := {}.
+  #[export] Instance: C -> B -> A | 0 := {}.
+  #[export] Instance: A -> A | 0 := {}.
   
   Goal C -> A.
     intros.

--- a/test-suite/success/dependentind.v
+++ b/test-suite/success/dependentind.v
@@ -66,7 +66,7 @@ Inductive term : ctx -> type -> Type :=
 
 where " Γ ⊢ τ " := (term Γ τ) : type_scope.
 
-Hint Constructors term : lambda.
+#[export] Hint Constructors term : lambda.
 
 Local Open Scope context_scope.
 

--- a/test-suite/success/destruct.v
+++ b/test-suite/success/destruct.v
@@ -263,7 +263,7 @@ Abort.
 (* This one was working in 8.4 (because of full conv on closed arguments) *)
 
 Class E.
-Instance a:E := {}.
+#[export] Instance a:E := {}.
 Goal forall h : E -> nat -> nat, h (id a) 0 = h a 0.
 intros.
 destruct (h _).

--- a/test-suite/success/eauto.v
+++ b/test-suite/success/eauto.v
@@ -9,11 +9,11 @@
 (************************************************************************)
 
 Class A (A : Type).
-  Instance an: A nat := {}.
+#[export] Instance an: A nat := {}.
 
 Class B (A : Type) (a : A).
-Instance bn0: B nat 0 := {}.
-Instance bn1: B nat 1 := {}.
+#[export] Instance bn0: B nat 0 := {}.
+#[export] Instance bn1: B nat 1 := {}.
 
 Goal A nat.
 Proof.
@@ -30,7 +30,7 @@ Proof.
   eexists. typeclasses eauto.
 Defined.
 
-Hint Extern 0 (_ /\ _) => constructor : typeclass_instances.
+#[export] Hint Extern 0 (_ /\ _) => constructor : typeclass_instances.
 
 Existing Class and.
 
@@ -39,7 +39,7 @@ Proof.
   eexists. eexists. typeclasses eauto.
 Defined.
 
-Instance ab: A bool := {}. (* Backtrack on A instance *)
+#[export] Instance ab: A bool := {}. (* Backtrack on A instance *)
 Goal exists (T : Type) (t : T), A T /\ B T t.
 Proof.
   eexists. eexists. typeclasses eauto.
@@ -47,11 +47,11 @@ Defined.
 
 Class C {T} `(a : A T) (t : T). 
 Require Import Classes.Init.
-Hint Extern 0 { x : ?A & _ } =>
+#[export] Hint Extern 0 { x : ?A & _ } =>
   unshelve class_apply @existT : typeclass_instances.
 Existing Class sigT.
 Set Typeclasses Debug.
-Instance can: C an 0 := {}.
+#[export] Instance can: C an 0 := {}.
 (* Backtrack on instance implementation *)
 Goal exists (T : Type) (t : T), { x : A T & C x t }.
 Proof.
@@ -59,7 +59,7 @@ Proof.
 Defined.
 
 Class D T `(a: A T).
-  Instance: D _ an := {}.
+#[export] Instance: D _ an := {}.
 Goal exists (T : Type), { x : A T & D T x }.
 Proof.
   eexists. typeclasses eauto.
@@ -114,18 +114,18 @@ Parameter fooTobar : forall a (H : Foo a), {b: myType & Bar b}.
 
 Parameter barToqux : forall a (H : Bar a), {b: myType & Qux b}.
 
-Hint Extern 5 (Bar ?D.1) =>
+#[export] Hint Extern 5 (Bar ?D.1) =>
     destruct D; simpl : typeclass_instances.
 
-Hint Extern 5 (Qux ?D.1) =>
+#[export] Hint Extern 5 (Qux ?D.1) =>
     destruct D; simpl : typeclass_instances.
 
-Hint Extern 1 myType =>
+#[export] Hint Extern 1 myType =>
   unshelve refine (fooTobar _ _).1 : typeclass_instances.
 
-Hint Extern 1 myType => unshelve refine (barToqux _ _).1 : typeclass_instances.
+#[export] Hint Extern 1 myType => unshelve refine (barToqux _ _).1 : typeclass_instances.
 
-Hint Extern 0 { x : _ & _ } => simple refine (existT _ _ _) : typeclass_instances.
+#[export] Hint Extern 0 { x : _ & _ } => simple refine (existT _ _ _) : typeclass_instances.
 
 Unset Typeclasses Debug.
 Definition trivial a (H : Foo a) : {b : myType & Qux b}. 
@@ -157,19 +157,19 @@ Parameter fooTobar : forall a (H : Foo a), {b: myType & Bar b}.
 
 Parameter barToqux : forall a (H : Bar a), {b: myType & Qux b}.
 
-Hint Extern 5 (Bar ?D.1) =>
+#[export] Hint Extern 5 (Bar ?D.1) =>
     destruct D; simpl : typeclass_instances.
 
-Hint Extern 5 (Qux ?D.1) =>
+#[export] Hint Extern 5 (Qux ?D.1) =>
     destruct D; simpl : typeclass_instances.
 
-Hint Extern 1 myType =>
+#[export] Hint Extern 1 myType =>
   unshelve notypeclasses refine (fooTobar _ _).1 : typeclass_instances.
 
-Hint Extern 1 myType =>
+#[export] Hint Extern 1 myType =>
   unshelve notypeclasses refine (barToqux _ _).1 : typeclass_instances.
 
-Hint Extern 0 { x : _ & _ } =>
+#[export] Hint Extern 0 { x : _ & _ } =>
   unshelve notypeclasses refine (existT _ _ _) : typeclass_instances.
 
 Unset Typeclasses Debug.
@@ -213,7 +213,7 @@ Axiom
     forall (l1 l2 : list (nat * nat)) (n : nat),
     not_in_list l1 n -> not_in_list l2 n -> not_in_list (l1 ++ l2) n.
 
-Hint Resolve lem1 lem2 lem3 lem4: essai.
+#[export] Hint Resolve lem1 lem2 lem3 lem4: essai.
 
 Goal
 forall (l : list (nat * nat)) (n p q : nat),

--- a/test-suite/success/evars.v
+++ b/test-suite/success/evars.v
@@ -66,7 +66,7 @@ Check (fun f:(forall (v:Type->Type), v (v nat) -> nat) => f _ (Some (Some O))).
 
 Theorem contradiction : forall p, ~ p -> p -> False.
 Proof. trivial. Qed.
-Hint Resolve contradiction.
+#[export] Hint Resolve contradiction.
 Goal False.
 eauto.
 Abort.

--- a/test-suite/success/hintdb_in_ltac.v
+++ b/test-suite/success/hintdb_in_ltac.v
@@ -1,6 +1,6 @@
 Definition x := 0.
 
-Hint Unfold x : mybase.
+#[export] Hint Unfold x : mybase.
 
 Ltac autounfoldify base := autounfold with base.
 

--- a/test-suite/success/hintdb_in_ltac_bis.v
+++ b/test-suite/success/hintdb_in_ltac_bis.v
@@ -1,7 +1,7 @@
 Parameter Foo : Prop.
 Axiom H : Foo.
 
-Hint Resolve H : mybase.
+#[export] Hint Resolve H : mybase.
 
 Ltac foo base := eauto with base.
 

--- a/test-suite/success/rewrite_dep.v
+++ b/test-suite/success/rewrite_dep.v
@@ -8,7 +8,7 @@ Notation Vcons n t := (@Vector.cons _ n _ t).
 Class Equiv A := equiv : A -> A -> Prop.
 Class Setoid A `{Equiv A} := setoid_equiv:> Equivalence (equiv).
 
-Instance vecequiv A `{Equiv A} n : Equiv (vector A n).
+#[export] Instance vecequiv A `{Equiv A} n : Equiv (vector A n).
 admit.
 Qed.
 
@@ -17,7 +17,7 @@ Global Instance vcons_proper A `{Equiv A} `{!Setoid A} :
         (@Vector.cons A).
 Proof. Admitted.
 
-Instance vecseotid A `{Setoid A} n : Setoid (vector A n).
+#[export] Instance vecseotid A `{Setoid A} n : Setoid (vector A n).
 Proof. Admitted.
 
 (* Instance equiv_setoid A {e : Equiv A} {s : @Setoid A e} : Equivalence e. *)

--- a/test-suite/success/rewrite_strat.v
+++ b/test-suite/success/rewrite_strat.v
@@ -11,7 +11,7 @@ Variable lem1 : forall x, g x x = f x.
 Variable lem2 : forall n x, h (S n) x = g (h n x) (h n x).
 Variable lem3 : forall x, h 0 x = x.
 
-Hint Rewrite lem0 lem1 lem2 lem3 : rew.
+#[export] Hint Rewrite lem0 lem1 lem2 lem3 : rew.
 
 Goal forall x, h 10 x = f x.
 Proof. 

--- a/test-suite/success/setoid_test.v
+++ b/test-suite/success/setoid_test.v
@@ -157,8 +157,8 @@ End mult.
 Parameter beq_nat : forall x y : nat, bool.
 
 Class Foo (A : Type) := {foo_neg : A -> A ; foo_prf : forall x : A, x = foo_neg x}.
-Instance: Foo nat. admit. Defined.
-Instance: Foo bool. admit. Defined.
+#[export] Instance: Foo nat. admit. Defined.
+#[export] Instance: Foo bool. admit. Defined.
 
 Goal forall (x : nat) (y : bool), beq_nat (foo_neg x) 0 = foo_neg y.
 Proof. intros. setoid_rewrite <- foo_prf. change (beq_nat x 0 = y). Abort.
@@ -171,7 +171,7 @@ Proof. intros. setoid_rewrite <- @foo_prf at 1. change (beq_nat x 0 = foo_neg y)
 Definition t := nat -> bool.
 Definition h (a b : t) := forall n, a n = b n.
 
-Instance subrelh : subrelation h (Morphisms.pointwise_relation nat eq).
+#[export] Instance subrelh : subrelation h (Morphisms.pointwise_relation nat eq).
 Proof. intros x y H; assumption. Qed.
 
 Goal forall a b, h a b -> a 0 = b 0.
@@ -194,7 +194,7 @@ Qed.
 
 Axiom add_0_r_peq : forall x : nat, eq (x + 0)%nat x.
 
-Instance All_proper {A} :
+#[export] Instance All_proper {A} :
   CMorphisms.Proper ((pointwise_relation A iffT) ==> eq ==> iffT) All.
 Proof.
   intros f g Hfg x y e. destruct e. split; apply All_impl, Hfg.
@@ -276,29 +276,29 @@ Arguments peq_refl {A a}.
 #[universes(polymorphic)]
 Axiom add_0_r_peq : forall x : nat, peq (x + 0)%nat x.
 
-#[universes(polymorphic)]
+#[universes(polymorphic), export]
 Instance peq_left {A : Type} {B : Type} {R : crelation B} (f : A -> B) `{Reflexive B R} : Proper (peq ==> R) f.
 Admitted.
 
-Instance reflexive_eq_dom_reflexive@{i j jr mij mijr} {A : Type@{i}} {B : Type@{j}} (R : crelation@{j jr} B) :
+#[export] Instance reflexive_eq_dom_reflexive@{i j jr mij mijr} {A : Type@{i}} {B : Type@{j}} (R : crelation@{j jr} B) :
   Reflexive@{j jr} R ->
   Reflexive@{mij mijr} (@peq A ==> R)%signatureT.
 Proof.
   intros hr x ? ? e. destruct e. apply hr.
 Qed.
 
-#[universes(polymorphic)]
+#[universes(polymorphic), export]
 Instance All_proper {A} :
   CMorphisms.Proper ((pointwise_relation A iffT) ==> peq ==> iffT) All.
 Proof.
   intros f g Hfg x y e. destruct e. split; apply All_impl, Hfg.
 Qed.
 
-#[universes(polymorphic)]
+#[universes(polymorphic), export]
 Instance eq_proper_proxy@{i} {A : Type@{i}} (x : A) : ProperProxy@{i i} peq x.
 Proof. red. exact peq_refl. Defined.
 
-#[universes(polymorphic)]
+#[universes(polymorphic), export]
 Instance peq_equiv {A} : Equivalence (@peq A).
 Proof.
   split.

--- a/test-suite/success/setoid_test2.v
+++ b/test-suite/success/setoid_test2.v
@@ -120,7 +120,7 @@ Axiom eqS1: S1 -> S1 -> Prop.
 Axiom SetoidS1 : Setoid_Theory S1 eqS1.
 Add Setoid S1 eqS1 SetoidS1 as S1setoid.
 
-Instance eqS1_default : DefaultRelation eqS1 := {}.
+#[export] Instance eqS1_default : DefaultRelation eqS1 := {}.
 
 Axiom eqS1': S1 -> S1 -> Prop.
 Axiom SetoidS1' : Setoid_Theory S1 eqS1'.
@@ -220,7 +220,7 @@ Axiom eqS1_test8: S1_test8 -> S1_test8 -> Prop.
 Axiom SetoidS1_test8 : Setoid_Theory S1_test8 eqS1_test8.
 Add Setoid S1_test8 eqS1_test8 SetoidS1_test8 as S1_test8setoid.
 
-Instance eqS1_test8_default : DefaultRelation eqS1_test8 := {}.
+#[export] Instance eqS1_test8_default : DefaultRelation eqS1_test8 := {}.
 
 Axiom f_test8 : S2 -> S1_test8.
 Add Morphism f_test8 with signature (eqS2 ==> eqS1_test8) as f_compat_test8. Admitted.

--- a/test-suite/success/setoid_test_function_space.v
+++ b/test-suite/success/setoid_test_function_space.v
@@ -21,7 +21,7 @@ auto.
 Qed.
 End feq.
 Infix "=f":= feq  (at level 80, right associativity).
-Hint Unfold feq. Hint Resolve feq_refl feq_sym feq_trans.
+#[export] Hint Unfold feq. #[export] Hint Resolve feq_refl feq_sym feq_trans.
 
 Variable K:(nat -> nat)->Prop.
 Variable K_ext:forall a b, (K a)->(a =f b)->(K b).

--- a/test-suite/success/transparent_abstract.v
+++ b/test-suite/success/transparent_abstract.v
@@ -1,5 +1,5 @@
 Class by_transparent_abstract {T} (x : T) := make_by_transparent_abstract : T.
-Hint Extern 0 (@by_transparent_abstract ?T ?x) => change T; transparent_abstract exact_no_check x : typeclass_instances.
+#[export] Hint Extern 0 (@by_transparent_abstract ?T ?x) => change T; transparent_abstract exact_no_check x : typeclass_instances.
 
 Goal True /\ True.
 Proof.

--- a/test-suite/success/unification_delta.v
+++ b/test-suite/success/unification_delta.v
@@ -26,14 +26,14 @@ Axiom euclid : nat -> { x : nat | x > 0 } -> nat.
 Definition eq_proj {A} {s : A -> Prop} : relation (sig s) :=
   fun x y => `x = `y.
 
-Program Instance foo {A : Type} {s : A -> Prop} : @Equivalence (sig s) eq_proj.
+#[export] Program Instance foo {A : Type} {s : A -> Prop} : @Equivalence (sig s) eq_proj.
 
 Next Obligation.
 Proof.
   cbv in *;congruence.
 Qed.
 
-Instance bar : Proper (eq ==> eq_proj ==> eq) euclid.
+#[export] Instance bar : Proper (eq ==> eq_proj ==> eq) euclid.
 Proof.
 Admitted.
 

--- a/test-suite/success/univnames.v
+++ b/test-suite/success/univnames.v
@@ -23,13 +23,13 @@ Inductive blacopy@{k l} : Type@{k} := blacopyI : Type@{l} -> blacopy.
 
 Class Wrap A := wrap : A.
 
-Fail Instance bad@{} : Wrap Type := Type.
+Fail #[export] Instance bad@{} : Wrap Type := Type.
 
-Instance bad@{} : Wrap Type.
+#[export] Instance bad@{} : Wrap Type.
 Fail Proof Type.
 Abort.
 
-Instance bar@{u} : Wrap@{u} Set. Proof nat.
+#[export] Instance bar@{u} : Wrap@{u} Set. Proof nat.
 
 
 Monomorphic Universe g.


### PR DESCRIPTION
We port the stdlib, the plugin tutorial and the test-suite. This makes Coq compatible with #16004 without backwards incompatibility.

- For the stdlib and the tutorial this is a subset of #16004 (and thus authored by @Alizter)
- For the test-suite, this was done manually so that the more precise export locality was put when it was clear it was not going to affect the behaviour of the test. Some nasty `Fail` commands had to be also modified manually.

As a side-note we should really consider removing all the warnings in the test-suite. There are really weird things going on there and it's not even clear that some tests are actually testing what they were written for in the first place.