### PR TITLE
Switch the default locality of hint-like commands to #[export].

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/16258-hint-locality-switch-export.rst
+++ b/doc/changelog/08-vernac-commands-and-options/16258-hint-locality-switch-export.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  the default locality of `Hint` and :cmd:`Instance` commands was
+  switched to :attr:`export`.
+  (`#16258 <https://github.com/coq/coq/pull/16258>`_,
+  by Pierre-Marie Pédrot).

--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -536,22 +536,9 @@ let find_applied_relation ?loc env sigma c left2right =
                     (str"The type" ++ spc () ++ Printer.pr_econstr_env env sigma ctype ++
                        spc () ++ str"of this term does not end with an applied relation.")
 
-let warn_deprecated_hint_rewrite_without_locality =
-  CWarnings.create ~name:"deprecated-hint-rewrite-without-locality" ~category:"deprecated"
-    ~default:CWarnings.AsError
-    (fun () -> strbrk "The default value for rewriting hint locality is currently \
-    \"local\" in a section and \"global\" otherwise, but is scheduled to change \
-    in a future release. For the time being, adding rewriting hints outside of sections \
-    without specifying an explicit locality attribute is therefore deprecated. It is \
-    recommended to use \"export\" whenever possible. Use the attributes \
-    #[local], #[global] and #[export] depending on your choice. For example: \
-    \"#[export] Hint Rewrite foo : bar.\" This is supported since Coq 8.14.")
-
 let default_hint_rewrite_locality () =
   if Global.sections_are_opened () then Hints.Local
-  else
-    let () = warn_deprecated_hint_rewrite_without_locality () in
-    Hints.SuperGlobal
+  else Hints.Export
 
 (* To add rewriting rules to a base *)
 let add_rew_rules ~locality base lrul =

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1297,21 +1297,8 @@ let make_hint ~locality name action =
   hint_action = action;
 }
 
-let warn_deprecated_hint_without_locality =
-  CWarnings.create ~name:"deprecated-hint-without-locality" ~category:"deprecated"
-    ~default:CWarnings.AsError
-    (fun () -> strbrk "The default value for hint locality is currently \
-    \"local\" in a section and \"global\" otherwise, but is scheduled to change \
-    in a future release. For the time being, adding hints outside of sections \
-    without specifying an explicit locality attribute is therefore deprecated. It is \
-    recommended to use \"export\" whenever possible. Use the attributes \
-    #[local], #[global] and #[export] depending on your choice. For example: \
-    \"#[export] Hint Unfold foo : bar.\"")
-
 let default_hint_locality () =
-  if Global.sections_are_opened () then Local else
-    let () = warn_deprecated_hint_without_locality () in
-    SuperGlobal
+  if Global.sections_are_opened () then Local else Export
 
 let remove_hints ~locality dbnames grs =
   let () = check_locality locality in

--- a/test-suite/bugs/bug_14704.v
+++ b/test-suite/bugs/bug_14704.v
@@ -1,4 +1,0 @@
-Class Test := { wit : nat }.
-
-Set Warnings "+deprecated-instance-without-locality".
-Fail Instance test: Test.

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -145,23 +145,9 @@ let instance_input : instance_obj -> obj =
       rebuild_function = rebuild_instance;
       subst_function = subst_instance }
 
-let warn_deprecated_instance_without_locality =
-  let open Pp in
-  CWarnings.create ~name:"deprecated-instance-without-locality" ~category:"deprecated"
-    ~default:CWarnings.AsError
-    (fun () -> strbrk "The default value for instance locality is currently \
-    \"local\" in a section and \"global\" otherwise, but is scheduled to change \
-    in a future release. For the time being, adding instances outside of sections \
-    without specifying an explicit locality attribute is therefore deprecated. It is \
-    recommended to use \"export\" whenever possible. Use the attributes \
-    #[local], #[global] and #[export] depending on your choice. For example: \
-    \"#[export] Instance Foo : Bar := baz.\"")
-
 let default_locality () =
   if Global.sections_are_opened () then Local
-  else
-    let () = warn_deprecated_instance_without_locality () in
-    SuperGlobal
+  else Export
 
 let instance_locality =
   Attributes.hint_locality ~default:default_locality


### PR DESCRIPTION
This is a sister draft PR of #16004, whose only goal is to check that the changes in CI devs are compatible with the switch of semantics. Eventually this should also be merged but we'll have to wait for one release containing #16004 only. 

Given that #16004 is going to be part of 8.17, this should be merged into 8.18 at the earliest.