### PR TITLE
[libobject] Store definition location in the .vo files

### DIFF
--- a/checker/values.ml
+++ b/checker/values.ml
@@ -379,6 +379,10 @@ let v_compiled_lib =
 
 let v_obj = Dyn
 
+let v_source = Sum("source",1, [| [| Opt String; String |] |])
+let v_loc = Tuple("loc", [| v_source ; Int; Int; Int; Int; Int; Int |])
+let v_obj_data = Tuple("obj_data", [| Opt v_loc; Opt String; Opt v_id |])
+
 let v_open_filter = Sum ("open_filter",1,[|[|v_pred String|]|])
 
 let rec v_aobjs = Sum("algebraic_objects", 0,
@@ -393,7 +397,7 @@ and v_libobjt = Sum("Libobject.t",0,
      [| v_aobjs |];
      [| v_id; v_libobjs |];
      [| List (v_pair v_open_filter v_mp)|];
-     [| v_obj |]
+     [| v_obj_data; v_obj |]
   |])
 
 and v_libobjs = List v_libobjt

--- a/doc/changelog/13-misc/16261-libobj+locate.rst
+++ b/doc/changelog/13-misc/16261-libobj+locate.rst
@@ -1,0 +1,9 @@
+- **Added:**
+  Coq now can store common metadata for objects in the .vo files;
+  in particular, we store precise file location for definitions
+  and inductives, which is used by ``Search`` and ``Locate``.
+  Other features such as attaching documentation to commands are
+  also possible
+  (`#16261 <https://github.com/coq/coq/pull/16484>`_,
+  (`#16261 <https://github.com/coq/coq/pull/16261>`_,
+  by Emilio Jesus Gallego Arias).

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -98,9 +98,10 @@ described elsewhere
    are not considered.  The :table:`Search Blacklist` table can also
    be used to exclude some things from all calls to :cmd:`Search`.
 
-   The output of the command is a list of qualified identifiers and
-   their types.  If the :flag:`Search Output Name Only` flag is on,
-   the types are omitted.
+   The output of the command is a list of qualified identifiers, their
+   types, and the locations. See `Locate` for more information on the
+   location information that is displayed. If the :flag:`Search Output
+   Name Only` flag is on, the types are omitted.
 
    .. insertprodn search_query search_query
 
@@ -403,12 +404,17 @@ Requests to the environment
 
    Displays the full name of objects from Coq's various qualified namespaces
    such as terms, modules and Ltac, thereby showing the module they are defined
-   in.  It also displays notation definitions.
+   in and the location inside the file.  It also displays notation definitions.
 
    Note that objects are reported only when the module containing them has
    been loaded, such as through a :cmd:`Require` command.  Notation definitions
    are reported only when the containing module has been imported
    (e.g. with :cmd:`Require Import` or :cmd:`Import`).
+
+   Also note that the filename reported in the location is relative to
+   the ``coqc`` call used to generate it; in order to jump to the
+   concrete file, the original project build info is needed by the
+   user inteface.
 
    :n:`@qualid`
      refers to object names that end with :n:`@qualid`.

--- a/interp/abbreviation.ml
+++ b/interp/abbreviation.ml
@@ -112,7 +112,8 @@ let declare_abbreviation ~local ?(also_in_cases_pattern=true) deprecation id ~on
       abbrev_activated = true;
     }
   in
-  add_leaf (inAbbreviation id (local,abbrev))
+  let data = Data.make ~name:id () in
+  add_leaf ~data (inAbbreviation id (local,abbrev))
 
 let pr_abbreviation kn = pr_qualid (Nametab.shortest_qualid_of_abbreviation Id.Set.empty kn)
 

--- a/lib/loc.ml
+++ b/lib/loc.ml
@@ -12,8 +12,8 @@
 
 type source =
   (* OCaml won't allow using DirPath.t in InFile *)
-  | InFile of { dirpath : string option; file : string }
   | ToplevelInput
+  | InFile of { dirpath : string option; file : string }
 
 type t = {
   fname : source; (** filename or toplevel input *)

--- a/lib/loc.mli
+++ b/lib/loc.mli
@@ -11,8 +11,8 @@
 (** {5 Basic types} *)
 
 type source =
-  | InFile of { dirpath : string option; file : string }
   | ToplevelInput
+  | InFile of { dirpath : string option; file : string }
 
 type t = {
   fname : source; (** filename or toplevel input *)

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -40,7 +40,7 @@ type library_segment = (node * Libobject.t list) list
 (** Adding operations (which call the [cache] method, and getting the
   current list of operations (most recent ones coming first). *)
 
-val add_leaf : Libobject.obj -> unit
+val add_leaf : ?data:Libobject.Data.t -> Libobject.obj -> unit
 
 (** {6 ... } *)
 

--- a/library/libobject.ml
+++ b/library/libobject.ml
@@ -104,6 +104,27 @@ let ident_subst_function (_,a) = a
 
 type obj = Dyn.t (* persistent dynamic objects *)
 
+module Data : sig
+
+  type t
+
+  val empty : t
+  val make : ?loc:Loc.t -> ?doc:string -> ?name:Names.Id.t -> unit -> t
+  val name : t -> Names.Id.t option
+
+end = struct
+
+  type t =
+    { loc : Loc.t option
+    ; doc : string option
+    ; name : Names.Id.t option
+    }
+
+  let make ?loc ?doc ?name () = { loc; doc; name }
+  let empty = make ()
+  let name { name } = name
+end
+
 (** {6 Substitutive objects}
 
     - The list of bound identifiers is nonempty only if the objects
@@ -124,7 +145,7 @@ and t =
   | IncludeObject of algebraic_objects
   | KeepObject of Names.Id.t * t list
   | ExportObject of { mpl : (open_filter * Names.ModPath.t) list }
-  | AtomicObject of obj
+  | AtomicObject of { data : Data.t ; obj : obj }
 
 and substitutive_objects = Names.MBId.t list * algebraic_objects
 

--- a/library/libobject.ml
+++ b/library/libobject.ml
@@ -110,6 +110,8 @@ module Data : sig
 
   val empty : t
   val make : ?loc:Loc.t -> ?doc:string -> ?name:Names.Id.t -> unit -> t
+  val loc : t -> Loc.t option
+  val doc : t -> string option
   val name : t -> Names.Id.t option
 
 end = struct
@@ -122,6 +124,8 @@ end = struct
 
   let make ?loc ?doc ?name () = { loc; doc; name }
   let empty = make ()
+  let loc { loc } = loc
+  let doc { doc } = doc
   let name { name } = name
 end
 

--- a/library/libobject.mli
+++ b/library/libobject.mli
@@ -140,6 +140,8 @@ module Data : sig
 
   val empty : t
   val make : ?loc:Loc.t -> ?doc:string -> ?name:Id.t -> unit -> t
+  val loc : t -> Loc.t option
+  val doc : t -> string option
   val name : t -> Id.t option
 
 end

--- a/plugins/ltac/tacenv.ml
+++ b/plugins/ltac/tacenv.ml
@@ -205,7 +205,8 @@ let inMD : tacdef -> obj =
      classify_function = classify_md}
 
 let register_ltac for_ml local ?deprecation id tac =
-  Lib.add_leaf (inMD {local; replace=NoReplace id; for_ml; expr=tac; depr=deprecation})
+  let data = Libobject.Data.make ~name:id () in
+  Lib.add_leaf ~data (inMD {local; replace=NoReplace id; for_ml; expr=tac; depr=deprecation})
 
 let redefine_ltac local ?deprecation kn tac =
   Lib.add_leaf (inMD {local; replace=Replace kn; for_ml=false; expr=tac; depr=deprecation})

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -369,7 +369,8 @@ let register_ltac ?deprecation ?(local = false) ?(mut = false) isrec tactics =
       tacdef_type = t;
       tacdef_deprecation = deprecation;
     } in
-    Lib.add_leaf (inTacDef id def)
+    let data = Libobject.Data.make ~name:id () in
+    Lib.add_leaf ~data (inTacDef id def)
   in
   List.iter iter defs
 
@@ -460,7 +461,9 @@ let register_typedef ?(local = false) isrec types =
     (id, typdef)
   in
   let types = List.map map types in
-  let iter (id, def) = Lib.add_leaf (inTypDef id def) in
+  let iter (id, def) =
+    let data = Libobject.Data.make ~name:id () in
+    Lib.add_leaf ~data (inTypDef id def) in
   List.iter iter types
 
 let register_primitive ?deprecation ?(local = false) {loc;v=id} t ml =
@@ -489,7 +492,8 @@ let register_primitive ?deprecation ?(local = false) {loc;v=id} t ml =
     tacdef_type = t;
     tacdef_deprecation = deprecation;
   } in
-  Lib.add_leaf (inTacDef id def)
+  let data = Libobject.Data.make ~name:id () in
+  Lib.add_leaf ~data (inTacDef id def)
 
 let register_open ?(local = false) qid (params, def) =
   let kn =
@@ -837,7 +841,8 @@ let register_notation_interpretation = function
   | Abbreviation (id, deprecation, body) ->
     let body = Tac2intern.globalize Id.Set.empty body in
     let abbr = { abbr_body = body; abbr_depr = deprecation } in
-    Lib.add_leaf (inTac2Abbreviation id abbr)
+    let data = Libobject.Data.make ~name:id () in
+    Lib.add_leaf ~data (inTac2Abbreviation id abbr)
   | Synext (local,kn,ids,body) ->
     let body = Tac2intern.globalize ids body in
     Lib.add_leaf (inTac2NotationInterp (local,kn,body))

--- a/vernac/comDefinition.ml
+++ b/vernac/comDefinition.ml
@@ -115,7 +115,7 @@ let definition_using env evd ~body ~types ~using =
   let terms = Option.List.cons types [body] in
   Option.map (fun using -> Proof_using.definition_using env evd ~using ~terms) using
 
-let do_definition ?hook ~name ?scope ~poly ?typing_flags ~kind ?using udecl bl red_option c ctypopt =
+let do_definition ?hook ~name ?scope ~poly ?loc ?typing_flags ~kind ?using udecl bl red_option c ctypopt =
   let program_mode = false in
   let env = Global.env() in
   let env = Environ.update_typing_flags ?typing_flags env in
@@ -126,7 +126,7 @@ let do_definition ?hook ~name ?scope ~poly ?typing_flags ~kind ?using udecl bl r
   in
   let using = definition_using env evd ~body ~types ~using in
   let kind = Decls.IsDefinition kind in
-  let cinfo = Declare.CInfo.make ~name ~impargs ~typ:types ?using () in
+  let cinfo = Declare.CInfo.make ~name ~impargs ?loc ~typ:types ?using () in
   let info = Declare.Info.make ?scope ~kind ?hook ~udecl ~poly ?typing_flags () in
   let _ : Names.GlobRef.t =
     Declare.declare_definition ~info ~cinfo ~opaque:false ~body evd

--- a/vernac/comDefinition.mli
+++ b/vernac/comDefinition.mli
@@ -30,6 +30,7 @@ val do_definition
   -> name:Id.t
   -> ?scope:Locality.definition_scope
   -> poly:bool
+  -> ?loc:Loc.t
   -> ?typing_flags:Declarations.typing_flags
   -> kind:Decls.definition_object_kind
   -> ?using:Vernacexpr.section_subset_expr

--- a/vernac/comFixpoint.mli
+++ b/vernac/comFixpoint.mli
@@ -53,7 +53,8 @@ val adjust_rec_order
   -> lident option
 
 (** names / relevance / defs / types *)
-type ('constr, 'types) recursive_preentry = Id.t list * Sorts.relevance list * 'constr option list * 'types list
+type ('constr, 'types) recursive_preentry =
+  (Id.t * Loc.t option) list * Sorts.relevance list * 'constr option list * 'types list
 
 (** Exported for Program *)
 val interp_recursive :

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -286,7 +286,7 @@ let do_program_recursive ~pm ~scope ~poly ?typing_flags ?using fixkind fixl =
   let evd = Typeclasses.resolve_typeclasses ~filter:Typeclasses.no_goals ~fail:true env evd in
     (* Solve remaining evars *)
   let evd = nf_evar_map_undefined evd in
-  let collect_evars name def typ impargs =
+  let collect_evars (name,_) def typ impargs =
     (* Generalize by the recursive prototypes  *)
     let terms = [def; typ] in
     let using = Option.map (fun using -> Proof_using.definition_using env evd ~using ~terms) using in
@@ -307,9 +307,9 @@ let do_program_recursive ~pm ~scope ~poly ?typing_flags ?using fixkind fixl =
       let possible_indexes = List.map ComFixpoint.compute_possible_guardness_evidences info in
       (* XXX: are we allowed to have evars here? *)
       let fixtypes = List.map (EConstr.to_constr ~abort_on_undefined_evars:false evd) fixtypes in
-      let fixdefs = List.map (EConstr.Vars.subst_vars evd (List.rev fixnames)) fixdefs in
+      let fixdefs = List.map (EConstr.Vars.subst_vars evd (List.rev fixnames |> List.map fst)) fixdefs in
       let fixdefs = List.map (EConstr.to_constr ~abort_on_undefined_evars:false evd) fixdefs in
-      let fixdecls = Array.of_list (List.map2 (fun x r -> make_annot (Name x) r) fixnames fixrs),
+      let fixdecls = Array.of_list (List.map2 (fun (x,_loc) r -> make_annot (Name x) r) fixnames fixrs),
         Array.of_list fixtypes,
         Array.of_list fixdefs
       in

--- a/vernac/comSearch.ml
+++ b/vernac/comSearch.ml
@@ -106,11 +106,11 @@ let () =
       optread  = (fun () -> !search_output_name_only);
       optwrite = (:=) search_output_name_only }
 
-let interp_search env sigma s r =
+let interp_search ?(print_loc=false) env sigma s r =
   let r = interp_search_restriction r in
   let get_pattern c = snd (Constrintern.intern_constr_pattern env sigma c) in
   let warnlist = ref [] in
-  let pr_search ref kind env c =
+  let pr_search ?loc ref kind env c =
     let pr = pr_global ref in
     let pp = if !search_output_name_only
       then pr
@@ -124,7 +124,9 @@ let interp_search env sigma s r =
              (List.skipn_at_least (Termops.nb_prod_modulo_zeta Evd.(from_env env) (EConstr.of_constr c)) impargs)
           then warnlist := pr :: !warnlist;
         let pc = pr_ltype_env env Evd.(from_env env) ~impargs c in
-        hov 2 (pr ++ str":" ++ spc () ++ pc)
+        let loc_hdr =
+          Option.map (fun loc -> if print_loc then str "in " ++ Loc.pr loc ++ fnl () else mt ()) loc in
+        pr_opt (fun x -> x) loc_hdr ++ hov 2 (pr ++ str":" ++ spc () ++ pc)
       end
     in Feedback.msg_notice pp
   in

--- a/vernac/comSearch.mli
+++ b/vernac/comSearch.mli
@@ -10,5 +10,5 @@
 
 (* Interpretation of search commands *)
 
-val interp_search : Environ.env -> Evd.evar_map ->
+val interp_search : ?print_loc:bool -> Environ.env -> Evd.evar_map ->
   Vernacexpr.searchable -> Vernacexpr.search_restriction -> unit

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -221,8 +221,9 @@ let update_tables c =
 
 let register_constant kn kind local =
   let id = Label.to_id (Constant.label kn) in
+  let data = Libobject.Data.make ~name:id () in
   let o = inConstant (id, { cst_kind = kind; cst_locl = local; }) in
-  let () = Lib.add_leaf o in
+  let () = Lib.add_leaf ~data o in
   update_tables kn
 
 let register_side_effect (c, body, role) =
@@ -520,7 +521,8 @@ let declare_variable_core ~name ~kind d =
   in
   Nametab.push (Nametab.Until 1) (Libnames.make_path DirPath.empty name) (GlobRef.VarRef name);
   Decls.(add_variable_data name {opaque;kind});
-  Lib.add_leaf (inVariable name);
+  let data = Libobject.Data.make ~name () in
+  Lib.add_leaf ~data (inVariable name);
   Impargs.declare_var_implicits ~impl name;
   Notation.declare_ref_arguments_scope Evd.empty (GlobRef.VarRef name)
 

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -77,6 +77,8 @@ module CInfo : sig
   val make :
     name : Id.t
     -> typ:'constr
+    -> ?loc:Loc.t
+    (** (Optional) location in the file where the constant was declared. *)
     -> ?args:Name.t list
     -> ?impargs:Impargs.manual_implicits
     -> ?using:Proof_using.t
@@ -393,6 +395,7 @@ val declare_constant
   :  ?local:Locality.import_status
   -> name:Id.t
   -> kind:Decls.logical_kind
+  -> ?loc:Loc.t
   -> ?typing_flags:Declarations.typing_flags
   -> constant_entry
   -> Constant.t

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -558,7 +558,7 @@ val is_local_constant : Constant.t -> bool
 
 module Internal : sig
 
-  (* Liboject exports *)
+  (* Libobject exports *)
   module Constant : sig
     type t
     val tag : (Id.t * t) Libobject.Dyn.tag

--- a/vernac/declareInd.ml
+++ b/vernac/declareInd.ml
@@ -108,7 +108,8 @@ let declare_mind ?typing_flags mie =
       Declare.check_exists typ;
       List.iter Declare.check_exists cons) names;
   let mind = Global.add_mind ?typing_flags id mie in
-  let () = Lib.add_leaf (inInductive (id, { ind_names = names })) in
+  let data = Libobject.Data.make ~name:id () in
+  let () = Lib.add_leaf ~data (inInductive (id, { ind_names = names })) in
   if is_unsafe_typing_flags() then feedback_axiom ();
   let isprim = Inductive.is_primitive_record (Inductive.lookup_mind_specif (Global.env()) (mind,0)) in
   Impargs.declare_mib_implicits mind;

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -1688,3 +1688,13 @@ let end_modtype () =
 let declare_include me_asts =
   let l = Synterp.declare_include me_asts in
   Interp.declare_include l
+
+(* Utility *)
+let data_of_path mp lbl =
+  let modmap = modmap () in
+  match Names.MPmap.find_opt mp modmap with
+  | None -> None
+  | Some { module_substituted_objects_by_name; _ } ->
+    match Id.Map.find_opt (Label.to_id lbl) module_substituted_objects_by_name with
+    | Some (AtomicObject { data }) -> Some data
+    | _ -> None

--- a/vernac/declaremods.mli
+++ b/vernac/declaremods.mli
@@ -160,7 +160,6 @@ val end_library :
 (** append a function to be executed at end_library *)
 val append_end_library_hook : (unit -> unit) -> unit
 
-
 (** {6 ... } *)
 (** [iter_all_interp_segments] iterate over all segments, the modules'
     segments first and then the current segment. Modules are presented
@@ -169,7 +168,6 @@ val append_end_library_hook : (unit -> unit) -> unit
 
 val iter_all_interp_segments :
   (Nametab.object_prefix -> Libobject.t -> unit) -> unit
-
 
 val debug_print_modtab : unit -> Pp.t
 
@@ -229,3 +227,6 @@ type module_objects = private
   }
 
 val modmap : unit -> module_objects Names.MPmap.t
+
+(** This likely wants to be moved*)
+val data_of_path : Names.ModPath.t -> Names.Label.t -> Libobject.Data.t option

--- a/vernac/declaremods.mli
+++ b/vernac/declaremods.mli
@@ -218,3 +218,14 @@ val end_modtype : unit -> ModPath.t
 val declare_include :
   (Constrexpr.module_ast * inline) list ->
   unit
+
+(** Experimental API *)
+type module_objects = private
+  { module_prefix : Nametab.object_prefix
+  ; module_substituted_objects : Libobject.t list
+  ; module_substituted_objects_by_name : Libobject.t Id.Map.t
+  ; module_keep_objects : Libobject.t list
+  ; module_keep_objects_by_name : Libobject.t Id.Map.t
+  }
+
+val modmap : unit -> module_objects Names.MPmap.t

--- a/vernac/mltop.ml
+++ b/vernac/mltop.ml
@@ -388,7 +388,7 @@ let () =
     ; Summary.unfreeze_function = unfreeze_ml_modules
     ; Summary.init_function = reset_loaded_modules }
 
-(* Liboject entries of declared ML Modules *)
+(* Libobject entries of declared ML Modules *)
 type ml_module_object =
   { mlocal : Vernacexpr.locality_flag
   ; mnames : PluginSpec.t list

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -709,7 +709,7 @@ let handle h (Libobject.Dyn.Dyn (tag, o)) = match DynHandle.find tag h with
    needs to be done in a more principled way. *)
 let gallina_print_library_leaf env sigma with_values mp lobj =
   match lobj with
-  | AtomicObject o ->
+  | AtomicObject { obj; _ } ->
     let handler =
       DynHandle.add Declare.Internal.objVariable begin fun id ->
           (* Outside sections, VARIABLES still exist but only with universes
@@ -726,7 +726,7 @@ let gallina_print_library_leaf env sigma with_values mp lobj =
       end @@
       DynHandle.empty
     in
-    handle handler o
+    handle handler obj
   | ModuleObject (id,_) ->
     Some (print_module ~with_body:with_values (MPdot (mp,Label.of_id id)))
   | ModuleTypeObject (id,_) ->
@@ -877,7 +877,7 @@ let print_full_pure_atomic env sigma mp lobj =
   handleF handler lobj
 
 let print_full_pure_leaf env sigma mp = function
-  | AtomicObject lobj -> print_full_pure_atomic env sigma mp lobj
+  | AtomicObject { obj; _ } -> print_full_pure_atomic env sigma mp obj
   | ModuleObject (id, _) ->
     (* TODO: make it reparsable *)
     print_module (MPdot (mp,Label.of_id id)) ++ str "." ++ fnl () ++ fnl ()

--- a/vernac/search.ml
+++ b/vernac/search.ml
@@ -77,7 +77,7 @@ let generic_search env (fn : GlobRef.t -> Decls.logical_kind option -> env -> co
   List.iter (fun d -> fn (GlobRef.VarRef (NamedDecl.get_id d)) None env (NamedDecl.get_type d))
     (Environ.named_context env);
   let iter_obj prefix lobj = match lobj with
-    | AtomicObject o ->
+    | AtomicObject { obj } ->
       let handler =
         DynHandle.add Declare.Internal.Constant.tag begin fun (id,obj) ->
           let kn = KerName.make prefix.Nametab.obj_mp (Label.of_id id) in
@@ -104,7 +104,7 @@ let generic_search env (fn : GlobRef.t -> Decls.logical_kind option -> env -> co
         end @@
         DynHandle.empty
       in
-      handle handler o
+      handle handler obj
     | _ -> ()
   in
   try Declaremods.iter_all_interp_segments iter_obj

--- a/vernac/search.ml
+++ b/vernac/search.ml
@@ -23,8 +23,9 @@ module NamedDecl = Context.Named.Declaration
 
 type filter_function =
   GlobRef.t -> Decls.logical_kind option -> env -> Evd.evar_map -> constr -> bool
+
 type display_function =
-  GlobRef.t -> Decls.logical_kind option -> env -> constr -> unit
+  ?loc:Loc.t -> GlobRef.t -> Decls.logical_kind option -> env -> constr -> unit
 
 (* This option restricts the output of [SearchPattern ...], etc.
 to the names of the symbols matching the
@@ -73,11 +74,14 @@ let handle h (Libobject.Dyn.Dyn (tag, o)) = match DynHandle.find tag h with
 | exception Not_found -> ()
 
 (* General search over declarations *)
-let generic_search env (fn : GlobRef.t -> Decls.logical_kind option -> env -> constr -> unit) =
+let generic_search env (fn : ?loc:Loc.t -> GlobRef.t -> Decls.logical_kind option -> env -> constr -> unit) =
   List.iter (fun d -> fn (GlobRef.VarRef (NamedDecl.get_id d)) None env (NamedDecl.get_type d))
     (Environ.named_context env);
   let iter_obj prefix lobj = match lobj with
-    | AtomicObject { obj } ->
+    | AtomicObject { data; obj } ->
+      (* Before it was: *)
+      (* let loc = Option.bind (Declaremods.data_of_path (Constant.modpath cst) (Constant.label cst)) Libobject.Data.loc in *)
+      let loc = Libobject.Data.loc data in
       let handler =
         DynHandle.add Declare.Internal.Constant.tag begin fun (id,obj) ->
           let kn = KerName.make prefix.Nametab.obj_mp (Label.of_id id) in
@@ -85,7 +89,7 @@ let generic_search env (fn : GlobRef.t -> Decls.logical_kind option -> env -> co
           let gr = GlobRef.ConstRef cst in
           let (typ, _) = Typeops.type_of_global_in_context (Global.env ()) gr in
           let kind = Declare.Internal.Constant.kind obj in
-          fn gr (Some kind) env typ
+          fn ?loc gr (Some kind) env typ
         end @@
         DynHandle.add DeclareInd.Internal.objInductive begin fun (id,_) ->
           let kn = KerName.make prefix.Nametab.obj_mp (Label.of_id id) in
@@ -121,7 +125,7 @@ module ConstrPriority = struct
 
   (* The priority is memoised here. Because of the very localised use
      of this module, it is not worth it making a convenient interface. *)
-  type t = GlobRef.t * Decls.logical_kind option * Environ.env * Constr.t * priority
+  type t = GlobRef.t * Decls.logical_kind option * Environ.env * Constr.t * Loc.t option * priority
   and priority = int
 
   module ConstrSet = CSet.Make(Constr)
@@ -146,7 +150,7 @@ module ConstrPriority = struct
   let priority gref t : priority =
     -(3*(num_symbols t) + size t)
 
-  let compare (_,_,_,_,p1) (_,_,_,_,p2) =
+  let compare (_,_,_,_,_,p1) (_,_,_,_,_,p2) =
     pervasives_compare p1 p2
 end
 
@@ -155,16 +159,16 @@ module PriorityQueue = Heap.Functional(ConstrPriority)
 let rec iter_priority_queue q fn =
   (* Tail-rec! *)
   match PriorityQueue.maximum q with
-  | (gref,kind,env,t,_) ->
-    fn gref kind env t;
+  | (gref,kind,env,t,loc,_) ->
+    fn ?loc gref kind env t;
     iter_priority_queue (PriorityQueue.remove q) fn
   | exception Heap.EmptyHeap -> ()
 
-let prioritize_search seq fn =
+let prioritize_search (seq : display_function -> unit) (fn : display_function) : unit =
   let acc = ref PriorityQueue.empty in
-  let iter gref kind env t =
+  let iter ?loc gref kind env t =
     let p = ConstrPriority.priority gref t in
-    acc := PriorityQueue.add (gref,kind,env,t,p) !acc
+    acc := PriorityQueue.add (gref,kind,env,t,loc,p) !acc
   in
   let () = seq iter in
   iter_priority_queue !acc fn
@@ -231,8 +235,8 @@ let search_pattern env sigma pat mods pr_search =
     pattern_filter pat ref env sigma (EConstr.of_constr typ) &&
     blacklist_filter ref kind env sigma typ
   in
-  let iter ref kind env typ =
-    if filter ref kind env typ then pr_search ref kind env typ
+  let iter ?loc ref kind env typ =
+    if filter ref kind env typ then pr_search ?loc ref kind env typ
   in
   generic_search env iter
 
@@ -255,8 +259,8 @@ let search_rewrite env sigma pat mods pr_search =
        pattern_filter pat2 ref env sigma (EConstr.of_constr typ)) &&
     blacklist_filter ref kind env sigma typ
   in
-  let iter ref kind env typ =
-    if filter ref kind env typ then pr_search ref kind env typ
+  let iter ?loc ref kind env typ =
+    if filter ref kind env typ then pr_search ?loc ref kind env typ
   in
   generic_search env iter
 
@@ -272,8 +276,8 @@ let search env sigma items mods pr_search =
       and aux' (b,s) = eqb b (aux s) in
       List.for_all aux' items && blacklist_filter ref kind env sigma typ
   in
-  let iter ref kind env typ =
-    if filter ref kind env typ then pr_search ref kind env typ
+  let iter ?loc ref kind env typ =
+    if filter ref kind env typ then pr_search ?loc ref kind env typ
   in
   generic_search env iter
 
@@ -333,7 +337,7 @@ let interface_search env sigma =
     (blacklist || blacklist_filter ref kind env sigma constr)
   in
   let ans = ref [] in
-  let print_function ref env constr =
+  let print_function ?loc ref env constr =
     let fullpath = DirPath.repr (Nametab.dirpath_of_global ref) in
     let qualid = Nametab.shortest_qualid_of_global Id.Set.empty ref in
     let (shortpath, basename) = Libnames.repr_qualid qualid in
@@ -356,8 +360,8 @@ let interface_search env sigma =
     } in
     ans := answer :: !ans;
   in
-  let iter ref kind env typ =
-    if filter_function ref env typ then print_function ref env typ
+  let iter ?loc ref kind env typ =
+    if filter_function ref env typ then print_function ?loc ref env typ
   in
   let () = generic_search env iter in
   !ans

--- a/vernac/search.mli
+++ b/vernac/search.mli
@@ -28,8 +28,9 @@ type glob_search_request =
 
 type filter_function =
   GlobRef.t -> Decls.logical_kind option -> env -> Evd.evar_map -> constr -> bool
+
 type display_function =
-  GlobRef.t -> Decls.logical_kind option -> env -> constr -> unit
+  ?loc:Loc.t -> GlobRef.t -> Decls.logical_kind option -> env -> constr -> unit
 
 (** {6 Generic filter functions} *)
 


### PR DESCRIPTION
This has been a long-requested feature that we need to implement it
properly for users; after a bit of discussion with Ali we decided to
go ahead.

For now, the patch is a proof of concept, however it does seem to work
fine, but in general we should make the location of objects a generic
property, not an ad-hoc one as done here. In particular, locations
need to be handled better (and likely first-class) in libobject as to
cover some corner cases.

I'm willing to shepherd anyone willing to work on it.

At least, the `CInfo` refactoring did pay off pretty well, so this was
not too hard.

As a POC of the feature, I've enabled location printing in `Search`
and `Locate`:

```
Locate add.

Constant Coq.Init.Nat.add
  File "./Nat.v", line 47, characters 9-12
  (shorter name to refer to it in current context is Nat.add)
```