### PR TITLE
[v8.7] Backport #15271: Delay removing native_compute .ml files until exit

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ variables:
   # Format: $IMAGE-V$DATE [Cache is not used as of today but kept here
   # for reference]
   # We use the same image as for coq v8.8
-  CACHEKEY: "bionic_coq-v8.8-V2018-07-14"
+  CACHEKEY: "bionic_coq-v8.8-V2018-09-20"
   IMAGE: "$CI_REGISTRY_IMAGE:$CACHEKEY"
   # By default, jobs run in the base switch; override to select another switch
   OPAM_SWITCH: "base"


### PR DESCRIPTION
I figured I might as well backport the fix to issue #15263 all the way back to 8.5