### PR TITLE
Replace remaining uses of `/bin/bash` with more portable `/usr/bin/env bash`

### DIFF
--- a/dev/doc/profiling.txt
+++ b/dev/doc/profiling.txt
@@ -31,7 +31,7 @@ aggregate profile on a component-by-component basis. Here is how to do the
 second for the standard library ([example output](https://cdn.rawgit.com/andres-erbsen/b29b29cb6480dfc6a662062e4fcd0ae3/raw/304fc3fea9630c8e453929aa7920ca8a2a570d0b/stdlib_categorized_outermost.svg)).
 
 ~~~~~
-#!/bin/bash
+#!/usr/bin/env bash
 make clean
 make states
 perf record -F99  `# ~1GB of data` --call-graph=dwarf -- make -f Makefile.dune world

--- a/test-suite/primitive/float/gen_compare.sh
+++ b/test-suite/primitive/float/gen_compare.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # -*- compile-command: "mv -f compare.v{,~} && ./gen_compare.sh" -*-
 set -e
 


### PR DESCRIPTION
The remaining uses after this are:
```
$ git grep '/bash'
dev/ci/docker/README.md:To open a shell inside an image do `docker run -ti --entrypoint /bin/bash <imageID>`
dev/ci/nix/default.nix:      ${bash}/bin/bash configure --libdir=$out/lib/coq/${coq.coq-version}/user-contrib/Flocq
doc/plugin_tutorial/.travis.yml:  docker exec COQ /bin/bash --login -c "
doc/plugin_tutorial/.travis.yml:  docker exec COQ /bin/bash --login -c "
test-suite/coq-makefile/coqdoc1/run.sh:# to learn about <(cmd) see https://www.gnu.org/software/bash/manual/html_node/Process-Substitution.html
```

