### PR TITLE
Make unfold hints automatically generated by Program as #[export].

### DIFF
--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -973,7 +973,7 @@ let unfold_entry cst = Hints.HintsUnfoldEntry [Tacred.EvalConstRef cst]
 
 let add_hint local prg cst =
   (* XXX checking sections here is suspicious but matches historical (unintended?) behaviour *)
-  let locality = if local || Global.sections_are_opened () then Hints.Local else Hints.SuperGlobal in
+  let locality = if local || Global.sections_are_opened () then Hints.Local else Hints.Export in
   Hints.add_hints ~locality [Id.to_string prg.prg_cinfo.CInfo.name] (unfold_entry cst)
 
 let declare_obligation prg obl ~uctx ~types ~body =


### PR DESCRIPTION
For some reason this was set to #[global] in 73789bc (by @SkySkimmer) as part of a seemingly unrelated fix, but the previous patch that introduced export hints correctly marked it as #[export] without any effect, otherwise the CI would not have passed.

I don't think this is really used but this unfortunate change is only part of 8.16 for now, so I'd recommend backporting it to 8.16.0 to the corresponding RM. That is to say, myself, but double checking that it seems reasonable.