### PR TITLE
[vernac] Fix nested proof handling in interpretation.

### DIFF
--- a/test-suite/bugs/bug_16278.v
+++ b/test-suite/bugs/bug_16278.v
@@ -1,0 +1,1 @@
+Load "bugs/bug_16278_load.v".

--- a/test-suite/bugs/bug_16278_load.v
+++ b/test-suite/bugs/bug_16278_load.v
@@ -1,0 +1,8 @@
+Set Nested Proofs Allowed.
+
+Lemma outer : True.
+Proof.
+  Lemma inner : True.
+  Proof. constructor. Qed.
+  exact inner.
+Qed.

--- a/vernac/vernacextend.ml
+++ b/vernac/vernacextend.ml
@@ -98,18 +98,9 @@ module OutProof = struct
   type _ t =
     | No : unit t
     | Close : unit t
-    | Yes : Declare.Proof.t t
+    | Update : Declare.Proof.t t
+    | New : Declare.Proof.t t
 
-  type result =
-    | Ignored
-    | Closed
-    | Open of Declare.Proof.t
-
-  let cast (type a) (x:a) (ty:a t) : result =
-    match ty with
-    | No -> Ignored
-    | Close -> Closed
-    | Yes -> Open x
 end
 
 type ('inprog,'outprog,'inproof,'outproof) vernac_type = {
@@ -149,14 +140,14 @@ let vtcloseproof f =
               }
 
 let vtopenproof f =
-  TypedVernac { inprog = Ignore; outprog = No; inproof = Ignore; outproof = Yes;
+  TypedVernac { inprog = Ignore; outprog = No; inproof = Ignore; outproof = New;
                 run = (fun ~pm:() ~proof:() ->
                     let proof = f () in
                     (), proof)
               }
 
 let vtmodifyproof f =
-  TypedVernac { inprog = Ignore; outprog = No; inproof = Use; outproof = Yes;
+  TypedVernac { inprog = Ignore; outprog = No; inproof = Use; outproof = Update;
                 run = (fun ~pm:() ~proof ->
                     let proof = f ~pstate:proof in
                     (), proof)
@@ -191,14 +182,14 @@ let vtmodifyprogram f =
               }
 
 let vtdeclareprogram f =
-  TypedVernac { inprog = Use; outprog = No; inproof = Ignore; outproof = Yes;
+  TypedVernac { inprog = Use; outprog = No; inproof = Ignore; outproof = New;
                 run = (fun ~pm ~proof:() ->
                     let proof = f ~pm in
                     (), proof)
               }
 
 let vtopenproofprogram f =
-  TypedVernac { inprog = Use; outprog = Yes; inproof = Ignore; outproof = Yes;
+  TypedVernac { inprog = Use; outprog = Yes; inproof = Ignore; outproof = New;
                 run = (fun ~pm ~proof:() ->
                     let pm, proof = f ~pm in
                     pm, proof)

--- a/vernac/vernacextend.mli
+++ b/vernac/vernacextend.mli
@@ -98,17 +98,13 @@ module InProof : sig
 end
 
 module OutProof : sig
+
   type _ t =
     | No : unit t
     | Close : unit t
-    | Yes : Declare.Proof.t t
+    | Update : Declare.Proof.t t
+    | New : Declare.Proof.t t
 
-  type result =
-    | Ignored
-    | Closed
-    | Open of Declare.Proof.t
-
-  val cast : 'a -> 'a t -> result
 end
 
 type ('inprog,'outprog,'inproof,'outproof) vernac_type = {

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -22,12 +22,14 @@ let interp_typed_vernac (Vernacextend.TypedVernac { inprog; outprog; inproof; ou
       ~proof:(InProof.cast proof inproof)
   in
   let pm = OutProg.cast pm' outprog pm in
-  let stack = let open OutProof in match stack, OutProof.cast proof' outproof with
-    | stack, Ignored -> stack
-    | Some stack, Closed -> snd (LStack.pop stack)
-    | None, Closed -> assert false
-    | Some stack, Open proof -> Some (LStack.map_top ~f:(fun _ -> proof) stack)
-    | None, Open proof -> Some (LStack.push None proof)
+  let stack = let open OutProof in
+    match stack, outproof with
+    | stack, No -> stack
+    | None, Close -> assert false
+    | Some stack, Close -> snd (LStack.pop stack)
+    | None, Update -> assert false
+    | Some stack, Update -> Some (LStack.map_top ~f:(fun _ -> proof') stack)
+    | stack, New -> Some (LStack.push stack proof')
   in
   stack, pm
 


### PR DESCRIPTION
It seems that #14779 could have introduced a bug here, the proof is
always dropped so the stack has constant size of one.

Unfortunately we cannot test this well as the STM overrides the vernac
implementation for nested proofs.

This will make coq-lsp and the simple compiler happy on nested proofs tho.

