### PR TITLE
[pcoq] Don't use physical equality to determine Pcoq.freeze worklist

### DIFF
--- a/clib/cList.ml
+++ b/clib/cList.ml
@@ -659,9 +659,9 @@ let drop_prefix cmp p l =
   in
   drop_prefix_rec (p,l)
 
-let share_tails l1 l2 =
+let share_tails eq l1 l2 =
   let rec shr_rev acc = function
-    | (x1 :: l1, x2 :: l2) when x1 == x2 -> shr_rev (x1 :: acc) (l1,l2)
+    | (x1 :: l1, x2 :: l2) when eq x1 x2 -> shr_rev (x1 :: acc) (l1,l2)
     | (l1, l2) -> (List.rev l1, List.rev l2, acc)
   in
   shr_rev [] (List.rev l1, List.rev l2)

--- a/clib/cList.mli
+++ b/clib/cList.mli
@@ -277,7 +277,7 @@ val insert : 'a eq -> 'a -> 'a list -> 'a list
 (** Insert at the (first) position so that if the list is ordered wrt to the
     total order given as argument, the order is preserved *)
 
-val share_tails : 'a list -> 'a list -> 'a list * 'a list * 'a list
+val share_tails : 'a eq -> 'a list -> 'a list -> 'a list * 'a list * 'a list
 (** [share_tails l1 l2] returns [(l1',l2',l)] such that [l1] is
     [l1'\@l] and [l2] is [l2'\@l] and [l] is maximal amongst all such
     decompositions *)


### PR DESCRIPTION
I've been observing huge parsing slowdowns in interactive use for a
while, and I finally found out that these are due to physical equality
in `share_tails` missing a lot of same-entries, thus creating a huge
work list for setting the parsing state in `Pcoq.freeze`.

This experimental commit uses a more precise equality, which is a 50x
win over a file interactive reparse, but indeed, it seems that we
should go for a more radical solution, which to really put the parsing
state in a reference we can just switch in O(1).

cc: @Alizter @herbelin maybe @ppedrot ?