### PR TITLE
[default.nix] Put `buildDoc` back to true and update nixpkgs to get Sphinx 4.5.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -24,7 +24,7 @@
 { pkgs ? import ./dev/nixpkgs.nix {}
 , ocamlPackages ? pkgs.ocaml-ng.ocamlPackages_4_12
 , buildIde ? true
-, buildDoc ? false
+, buildDoc ? true
 , doInstallCheck ? true
 , shell ? false
   # We don't use lib.inNixShell because that would also apply

--- a/dev/nixpkgs.nix
+++ b/dev/nixpkgs.nix
@@ -1,4 +1,4 @@
 import (fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/46e3ed49ec36f341c173331dc788115d6836c7ab.tar.gz";
-  sha256 = "0lr8lry0d3skb287f0wbm46iakr1q7vqqy6y54r9hl2jb3d18z9z";
+  url = "https://github.com/NixOS/nixpkgs/archive/16de63fcc54e88b9a106a603038dd5dd2feb21eb.tar.gz";
+  sha256 = "13nw1d09pkxmnn7i6sh1d9p2a88m0jx2n4izvcb39g9cyjfvci3d";
 })


### PR DESCRIPTION
#15560 has temporarily disabled the documentation build in the Nix CI job (see #16198) by commenting out the appropriate lines *and* turning `buildDoc` to false. The latter is redundant and is making it more difficult to get the documentation dependencies in a `nix-shell` environment, so we turn it back to `true`.

The update of nixpkgs allow getting Sphinx 4.5 for which support was recently merged (#16193).