### PR TITLE
[eauto] do not eagerly evaluate extern hints

### DIFF
--- a/doc/changelog/04-tactics/16289-eauto-cost.rst
+++ b/doc/changelog/04-tactics/16289-eauto-cost.rst
@@ -1,0 +1,12 @@
+- **Changed:**
+  :tacn:`eauto` respects priorities of ``Extern`` hints
+  (`#16289 <https://github.com/coq/coq/pull/16289>`_,
+  fixes `#5163 <https://github.com/coq/coq/issues/5163>`_
+  and `#16282 <https://github.com/coq/coq/issues/16282>`_,
+  by Andrej Dudenhefner).
+
+  .. warning:: Code that relies on eager evaluation of ``Extern`` hints
+     with high assigned cost by :tacn:`eauto` will change its performance
+     profile or potentially break.
+     To approximate prior behavior, set to zero the cost of ``Extern`` hints,
+     which may solve the goal in one step.

--- a/test-suite/bugs/bug_16282.v
+++ b/test-suite/bugs/bug_16282.v
@@ -1,0 +1,15 @@
+Lemma TrueI : unit -> True.
+Proof. easy. Qed.
+
+Create HintDb db.
+
+#[local] Hint Extern 99 => shelve : db.
+#[local] Hint Extern 0 (True) => apply TrueI : db.
+#[local] Hint Extern 0 (unit) => exact tt : db.
+
+Goal True.
+Proof.
+  Succeed (solve [unshelve auto with db nocore]).
+  Succeed (solve [unshelve typeclasses eauto with db nocore]).
+  Succeed (solve [unshelve eauto with db nocore]).
+Abort.

--- a/test-suite/bugs/bug_5163.v
+++ b/test-suite/bugs/bug_5163.v
@@ -1,0 +1,16 @@
+Lemma TrueI : unit -> True.
+Proof. easy. Qed.
+
+Create HintDb db.
+
+Ltac diverge a := diverge a.
+#[local] Hint Extern 99 => diverge idtac : db.
+#[local] Hint Extern 0 (True) => apply TrueI : db.
+#[local] Hint Extern 0 (unit) => exact tt : db.
+
+Goal True.
+Proof.
+  Succeed (solve [unshelve auto with db nocore]).
+  Succeed (solve [unshelve typeclasses eauto with db nocore]).
+  Succeed (solve [timeout 1 unshelve eauto with db nocore]).
+Abort.


### PR DESCRIPTION
Instead of eagerly evaluate every extern hint for success (which can be arbitrarily slow), approximate the subgoal cost by hint priority.
This forces `eauto` to respect priorities of `Extern` hints.
Also, this is more coherent with `auto` and `typeclasses eauto` behavior (see regression tests).

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes #5163
Fixes #16282 (and #15558)


<!-- Remove anything that doesn't apply in the following checklist. -->

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
- [x] Opened **overlay** pull requests.
  - [x] metacoq https://github.com/MetaCoq/metacoq/pull/734
  - [x] stdpp (merged) https://gitlab.mpi-sws.org/iris/stdpp/-/merge_requests/385
         

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
