### PR TITLE
[auto] set use_metas_eagerly_in_conv_on_closed_terms = true

### DIFF
--- a/doc/changelog/04-tactics/16293-auto-metas.rst
+++ b/doc/changelog/04-tactics/16293-auto-metas.rst
@@ -1,0 +1,10 @@
+- **Changed:**
+  less discrepancies between :tacn:`auto` hint evaluation and :tacn:`simple apply`, :tacn:`exact` tactics
+  (`#16293 <https://github.com/coq/coq/pull/16293>`_,
+  fixes `#16062 <https://github.com/coq/coq/issues/16062>`_
+  and `#16323 <https://github.com/coq/coq/issues/16323>`_,
+  by Andrej Dudenhefner).
+
+  .. warning:: :tacn:`auto` may solve more goals.
+     As a result, non-monotone use of :tacn:`auto` such as :g:`tac1; auto. tac2.` may break.
+     For backwards compatibility use explicit goal management.

--- a/test-suite/bugs/bug_16062.v
+++ b/test-suite/bugs/bug_16062.v
@@ -1,0 +1,11 @@
+Create HintDb db.
+Parameter P : unit -> unit -> Prop.
+Axiom HP : forall b, P b (id b).
+
+#[local] Hint Resolve HP | 0 (P tt tt) : db.
+
+Goal P tt tt.
+Proof.
+  Succeed solve [simple apply HP].
+  solve [auto with db].
+Qed.

--- a/test-suite/bugs/bug_16323.v
+++ b/test-suite/bugs/bug_16323.v
@@ -1,0 +1,20 @@
+Create HintDb db1.
+Axiom eq_tt : tt = tt.
+#[local] Hint Resolve eq_tt : db1.
+
+Goal exists u, u = tt.
+Proof.
+  eexists.
+  Succeed solve [exact eq_tt].
+  solve [auto with nocore db1].
+Qed.
+
+Create HintDb db2.
+Axiom True_eq_tt : True -> tt = tt.
+#[local] Hint Resolve True_eq_tt : db2.
+
+Goal True -> exists u, u = tt.
+Proof.
+  intros. eexists.
+  solve [auto with nocore db2].
+Qed.

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -1668,7 +1668,6 @@ End Fold_Right_Recursor.
       - intros n d; destruct n; destruct d; simpl; auto.
         + destruct a; destruct (split l); simpl; auto.
         + destruct a; destruct (split l); simpl in *; auto.
-          apply IHl.
     Qed.
 
     Lemma split_length_l : forall (l:list (A*B)),

--- a/theories/Numbers/Cyclic/Int63/Uint63.v
+++ b/theories/Numbers/Cyclic/Int63/Uint63.v
@@ -1503,7 +1503,6 @@ Lemma sqrt2_spec : forall x y,
  assert (Hb: 0 <= wB) by (red; intros HH; discriminate).
  assert (Hi2: Φ(WW ih il ) < (φ max_int + 1) ^ 2). {
   apply Z.le_lt_trans with ((wB - 1) * wB + (wB - 1)); auto with zarith.
-  2: apply refl_equal.
   case (to_Z_bounded ih); case (to_Z_bounded il); intros H1 H2 H3 H4.
   unfold zn2z_to_Z; auto with zarith.
  }

--- a/theories/Strings/String.v
+++ b/theories/Strings/String.v
@@ -215,10 +215,9 @@ Proof.
 intros s1; elim s1; simpl; auto.
 - intros s2 n; rewrite Nat.add_comm; simpl; auto.
 - intros a s1' Rec s2 n; case n; simpl; auto.
-  + generalize (Rec s2 O); simpl; auto.
-  + intros.
-    (replace (n0 + S (length s1'))
-      with (S n0 + length s1') by now rewrite Nat.add_succ_r); auto.
+  intros.
+  (replace (n0 + S (length s1'))
+    with (S n0 + length s1') by now rewrite Nat.add_succ_r); auto.
 Qed.
 
 (** *** Substrings *)

--- a/theories/ZArith/Zcomplements.v
+++ b/theories/ZArith/Zcomplements.v
@@ -42,7 +42,6 @@ Proof.
  - rewrite !Pos2Z.inj_xI, (Pos2Z.inj_xO (xO _)), Pos2Z.inj_xO.
    split.
    + apply Z.le_trans with (2 * Z.pos p); auto with zarith.
-     rewrite <- (Z.add_0_r (2 * Z.pos p)) at 1; auto with zarith.
    + apply Z.lt_le_trans with (2 * (Z.pos p + 1)).
      * rewrite Z.mul_add_distr_l, Z.mul_1_r.
        apply Zplus_lt_compat_l; red; auto with zarith.

--- a/theories/ZArith/Zdiv.v
+++ b/theories/ZArith/Zdiv.v
@@ -227,7 +227,7 @@ Lemma Z_mod_same_full : forall a, a mod a = 0.
 Proof. intros a. zero_or_not a. apply Z.mod_same; auto. Qed.
 
 Lemma Z_mod_mult : forall a b, (a*b) mod b = 0.
-Proof. intros a b. now zero_or_not b; [apply Z.mul_0_r|apply Z.mod_mul]. Qed.
+Proof. intros a b. zero_or_not b. now apply Z.mod_mul. Qed.
 
 Lemma Z_div_mult_full : forall a b:Z, b <> 0 -> (a*b)/b = a.
 Proof Z.div_mul.
@@ -566,9 +566,8 @@ Theorem Zdiv_mult_le:
  forall a b c, 0<=a -> 0<=b -> 0<=c -> c*(a/b) <= (c*a)/b.
 Proof.
   intros a b c ? ? ?. zero_or_not b.
-  - now rewrite Z.mul_0_r.
-  - apply Z.div_mul_le; auto.
-    apply Z.le_neq; auto.
+  apply Z.div_mul_le; auto.
+  apply Z.le_neq; auto.
 Qed.
 
 (** Z.modulo is related to divisibility (see more in Znumtheory) *)

--- a/theories/ZArith/Znat.v
+++ b/theories/ZArith/Znat.v
@@ -571,7 +571,6 @@ Proof.
    - now apply Z.quot_pos.
  }
  destruct n, m; trivial; simpl.
- - trivial.
  - now rewrite <- Pos2Z.opp_pos, Z.quot_opp_r, inj_opp.
  - now rewrite <- Pos2Z.opp_pos, Z.quot_opp_l, inj_opp.
  - now rewrite <- 2 Pos2Z.opp_pos, Z.quot_opp_opp.
@@ -586,7 +585,6 @@ Proof.
    - now apply Z.rem_nonneg.
  }
  destruct n, m; trivial; simpl.
- - trivial.
  - now rewrite <- Pos2Z.opp_pos, Z.rem_opp_r.
  - now rewrite <- Pos2Z.opp_pos, Z.rem_opp_l, inj_opp.
  - now rewrite <- 2 Pos2Z.opp_pos, Z.rem_opp_opp, inj_opp.


### PR DESCRIPTION
Setting this flag in `auto` (and `eauto`) makes the resolution be slightly closer to `simple (e)apply`.
Also, this behavior is closer to `typeclasses eauto`.

Fixes #16323
Fixes #16062

Currently, `debug auto` lies to you, stating that `simple apply` failed.
```coq
Inductive test : unit -> unit -> Prop :=
  | test_intro b : test b (id b).

#[local] Hint Resolve test_intro | 0 (test tt tt) : db.

Goal test tt tt.
Proof.
  Succeed (solve [simple apply test_intro]).
  Fail (solve [debug auto with db]).
(* debug auto: 
* assumption. (*fail*)
* intro. (*fail*)
* simple apply test_intro (in db). (*fail*) *)
```

Also, `auto` may misleadingly report that `exact` failed #16323.

The present PR makes auto more potent, sometimes breaking goal management after `tac; auto`.

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.

<!-- If this breaks external libraries or plugins in CI: -->
- [x] Opened **overlay** pull requests.
  - [x] coqprime https://github.com/thery/coqprime/pull/53
  - [x] color https://github.com/fblanqui/color/pull/43
  - [x] ext_lib https://github.com/coq-community/coq-ext-lib/pull/128
  - [x] quickchick https://github.com/QuickChick/QuickChick/pull/295
  - [x] mtac2 https://github.com/Mtac2/Mtac2/pull/361
  - [x] fiat_parsers https://github.com/mit-plv/fiat/pull/76
  - [x] coq_dpdgraph https://github.com/coq-community/coq-dpdgraph/pull/106
  - [x] corn https://github.com/coq-community/corn/pull/171
  - [x] cross_crypto https://github.com/mit-plv/cross-crypto/pull/30
    - [x] fcf https://github.com/adampetcher/fcf/pull/39
  - [x] bedrock2 https://github.com/mit-plv/bedrock2/pull/261
    - [x] kami https://github.com/mit-plv/kami/pull/29
  - [x] tlc https://github.com/charguer/tlc/pull/12
  - [x] verdi_raft https://github.com/uwplse/verdi-raft/pull/91
  - [x] metacoq https://github.com/MetaCoq/metacoq/pull/737
  - [x] analysis https://github.com/math-comp/analysis/pull/692
  - [x] flocq (manual) https://github.com/mrhaandi/flocq/tree/auto-metas
  - [x] vst https://github.com/PrincetonUniversity/VST/pull/604
  - [x] compcert https://github.com/AbsInt/CompCert/pull/443

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
