### PR TITLE
hygienic local_db in auto

### DIFF
--- a/doc/changelog/04-tactics/16302-auto-hygienic.rst
+++ b/doc/changelog/04-tactics/16302-auto-hygienic.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  :tacn:`auto` now properly updates local hypotheses after hint application
+  (`#16302 <https://github.com/coq/coq/pull/16302>`_,
+  fixes `#15814 <https://github.com/coq/coq/issues/15814>`_
+  and `#6332 <https://github.com/coq/coq/issues/6332>`_,
+  by Andrej Dudenhefner).

--- a/test-suite/bugs/bug_15814.v
+++ b/test-suite/bugs/bug_15814.v
@@ -1,0 +1,42 @@
+Module ExternRewrite.
+
+Parameter a b c : unit.
+Parameter P : unit -> Prop.
+Axiom Eac : a = c.
+Axiom (Pab : P a -> P b).
+
+Ltac Xtac :=
+  match goal with
+  | [ H : (True -> P a) |- _  ] => rewrite Eac in H
+  end.
+
+Create HintDb db.
+#[local] Hint Resolve Pab : db.
+#[local] Hint Extern 0 => Xtac : db.
+
+Goal True -> (True -> P a) -> P b.
+Proof.
+  auto with db nocore.
+Qed.
+
+End ExternRewrite.
+
+Module ExternClear.
+
+Parameter P Q R : Prop.
+Axiom (HQR : Q -> R).
+Axiom (HP : P).
+
+Ltac Xtac := match goal with [H : _ |- _] => clear H end.
+
+Create HintDb db.
+#[local] Hint Resolve HQR : db.
+#[local] Hint Resolve HP : db.
+#[local] Hint Extern 0 => Xtac : db.
+
+Goal (P -> Q) -> R.
+Proof.
+  auto with db nocore.
+Qed.
+
+End ExternClear.

--- a/test-suite/bugs/bug_6332.v
+++ b/test-suite/bugs/bug_6332.v
@@ -1,0 +1,13 @@
+Section test.
+  Variable (A : Type) (a b : A) (P : A -> Prop).
+  Hypothesis H : forall b : A, P b -> P a.
+  Hypothesis H' : P b.
+
+  Ltac tac := assert (HH: P b -> P a) by (apply (H b)); clear H; idtac "OK".
+  #[local] Hint Extern 1 => tac : core.
+
+  Goal P a.
+  Proof.
+    auto. (* Prints "OK", solves the goal *)
+  Qed.
+End test.


### PR DESCRIPTION
Previously, `auto` assumed that no hint can modify the local hypotheses.
This results in arbitrary behavior with `Hint Extern`.

A solution is (as is done in `eauto`) to check after a tactic application whether local hypotheses have changed, and potentially update `local_db` accordingly.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes #15814
Fixes #6332

<!-- Remove anything that doesn't apply in the following checklist. -->

- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.

<!-- If this breaks external libraries or plugins in CI: -->
<!-- - [ ] Opened **overlay** pull requests. -->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
