### PR TITLE
auto regression tests

### DIFF
--- a/test-suite/bugs/bug_4064.v
+++ b/test-suite/bugs/bug_4064.v
@@ -1,0 +1,7 @@
+#[local] Hint Extern 0 False => idtac+admit : core.
+
+Goal False.
+Proof.
+  Succeed solve [debug auto].
+  Succeed solve [auto].
+Abort.

--- a/test-suite/bugs/bug_6195.v
+++ b/test-suite/bugs/bug_6195.v
@@ -1,0 +1,22 @@
+Parameter monotonic : forall {A B} (leA : A -> A -> Prop) (leB : B -> B -> Prop),
+  (A -> B) -> Prop.
+
+Axiom monotonic_cst : forall A B (leA : A -> A -> Prop) (leB : B -> B -> Prop),
+  forall (b:B), monotonic leA leB (fun _ : A => b).
+
+#[local] Hint Extern 0 (monotonic _ _ (fun _ => ?x)) =>
+  simple apply monotonic_cst : mymonotonic.
+
+Parameter (foo : nat -> nat).
+
+Goal (forall a, monotonic le le (fun _ => foo a)).
+Proof.
+  typeclasses eauto with mymonotonic.
+Qed.
+
+#[local] Hint Extern 999999 (monotonic _ _ _) => shelve : mymonotonic.
+
+Goal (forall a, monotonic le le (fun _ => foo a)).
+Proof.
+  unshelve typeclasses eauto with mymonotonic.
+Qed.


### PR DESCRIPTION
Adds regression tests for the already fixed `auto` issues for proper closure.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Closes #6195
Closes #4064

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.