### PR TITLE
Set language to an actual value in Sphinx config

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -129,7 +129,7 @@ release = coq_config.version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
Sphinx 5+ doesn't accept `None` as a language value. There must be a valid string present.
Setting an explicit value will work with older Sphinx versions as well as the newest ones.
Relevant changes: https://www.sphinx-doc.org/en/master/changes.html#release-5-0-0-released-may-30-2022