### PR TITLE
Fixes #16303: evar defined before its instance was checked, leading to error message trying to unexpectingly display an already defined evar

### DIFF
--- a/dev/ci/user-overlays/16311-herbelin-master+fix16303-evar-defined-before-being-checked.sh
+++ b/dev/ci/user-overlays/16311-herbelin-master+fix16303-evar-defined-before-being-checked.sh
@@ -1,0 +1,1 @@
+overlay equations https://github.com/herbelin/Coq-Equations master+adapt-coq-pr16311-check-evar-body-before-defining  16311 master+fix16303-evar-defined-before-being-checked

--- a/doc/changelog/02-specification-language/16311-master+fix16303-evar-defined-before-being-checked.rst
+++ b/doc/changelog/02-specification-language/16311-master+fix16303-evar-defined-before-being-checked.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  A case where unification raised an anomaly instead of a regular ill-typed instantiation error
+  (`#16311 <https://github.com/coq/coq/pull/16311>`_,
+  fixes `#16303 <https://github.com/coq/coq/issues/16303>`_,
+  by Hugo Herbelin).

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -709,6 +709,8 @@ let find d e =
 
 let find_undefined d e = EvMap.find e d.undf_evars
 
+let find_defined d e = EvMap.find e d.defn_evars
+
 let mem d e = EvMap.mem e d.undf_evars || EvMap.mem e d.defn_evars
 
 let undefined_map d = d.undf_evars

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -906,6 +906,9 @@ let extract_changed_conv_pbs evd p =
 let extract_all_conv_pbs evd =
   extract_conv_pbs evd (fun _ -> true)
 
+let pr_last_mods evd =
+  pr_sequence (fun x -> int (Evar.repr x)) (Evar.Set.elements evd.last_mods)
+
 let loc_of_conv_pb evd (pbty,env,t1,t2) =
   match kind (fst (decompose_app t1)) with
   | Evar (evk1,_) -> fst (evar_source evk1 evd)

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -196,6 +196,9 @@ val find_undefined : evar_map -> Evar.t -> evar_info
 (** Same as {!find} but restricted to undefined evars. For efficiency
     reasons. *)
 
+val find_defined : evar_map -> Evar.t -> evar_info
+(** Same as {!find} but restricted to defined evars *)
+
 val remove : evar_map -> Evar.t -> evar_map
 (** Remove an evar from an evar map. Use with caution. *)
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -545,6 +545,8 @@ val extract_changed_conv_pbs : evar_map ->
 val extract_all_conv_pbs : evar_map -> evar_map * evar_constraint list
 val loc_of_conv_pb : evar_map -> evar_constraint -> Loc.t option
 
+val pr_last_mods : evar_map -> Pp.t
+
 (** The following functions return the set of undefined evars
     contained in the object. *)
 

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -292,6 +292,8 @@ let pr_evar_map_gen with_univs pr_evars env sigma =
     else
     str "CONSTRAINTS:" ++ brk (0, 1) ++
       pr_evar_constraints sigma conv_pbs ++ fnl ()
+  and last_mods =
+    str "LAST MODS:" ++ brk (0, 1) ++ Evd.pr_last_mods sigma ++ fnl ()
   and typeclasses =
     let evars = Evd.get_typeclass_evars sigma in
     if Evar.Set.is_empty evars then mt ()
@@ -313,7 +315,7 @@ let pr_evar_map_gen with_univs pr_evars env sigma =
   and future_goals =
     str "FUTURE GOALS STACK:" ++ brk (0, 1) ++ Evd.pr_future_goals_stack sigma ++ fnl ()
   in
-  evs ++ svs ++ cstrs ++ typeclasses ++ obligations ++ metas ++ shelf ++ future_goals
+  evs ++ svs ++ last_mods ++ cstrs ++ typeclasses ++ obligations ++ metas ++ shelf ++ future_goals
 
 let pr_evar_list env sigma l =
   let open Evd in

--- a/test-suite/bugs/bug_16303.v
+++ b/test-suite/bugs/bug_16303.v
@@ -1,0 +1,4 @@
+Fact uip_nat {n : nat} (e : n = n) : e = eq_refl.
+(* Should not fail with an anomaly *)
+Fail refine match e with eq_refl => eq_refl end.
+Abort.

--- a/test-suite/success/unification2.v
+++ b/test-suite/success/unification2.v
@@ -1,0 +1,17 @@
+(* A test on the order of treatment of conversion problems *)
+(* See #16311 *)
+
+Require Import Coq.Lists.List.
+Import ListNotations.
+
+Parameter symbol : Type.
+Parameter production : Type.
+Parameter prod_rhs_rev: production -> list symbol.
+
+Definition future_of_prod prod dot_pos : list symbol :=
+  (fix loop n lst :=
+    match n with
+    | O => lst
+    | S x => match loop x lst with [] => [] | _::q => q end
+    end)
+  dot_pos (rev' (prod_rhs_rev prod)).

--- a/test-suite/success/unification3.v
+++ b/test-suite/success/unification3.v
@@ -1,0 +1,46 @@
+(* A test on the order of treatment of conversion problems *)
+(* Extracted from fiat-crypto *)
+(* See #16311 *)
+
+Require Import Coq.ZArith.ZArith Coq.Lists.List.
+
+Reserved Notation "'dlet' x .. y := v 'in' f"
+         (at level 200, x binder, y binder, f at level 200, format "'dlet'  x .. y  :=  v  'in' '//' f").
+Reserved Notation "~> R" (at level 70).
+Reserved Notation "'return' x" (at level 70, format "'return'  x").
+Definition Let_In {A P} (x : A) (f : forall a : A, P a) : P x.
+Admitted.
+Notation "'dlet' x .. y := v 'in' f" := (Let_In v (fun x => .. (fun y => f) .. )).
+
+Declare Scope cps_scope.
+
+Notation "~> R" := (forall T (_:R->T), T) : type_scope.
+
+Definition cpsreturn {T} (x:T) := x.
+
+Notation "'return' x" := (cpsreturn (fun T (continuation:_->T) => continuation x)) : cps_scope.
+Local Open Scope Z_scope.
+Declare Scope runtime_scope.
+Delimit Scope runtime_scope with RT.
+Local Open Scope cps_scope.
+
+
+Parameter runtime_mul : Z -> Z -> Z.
+Infix "*" := runtime_mul : runtime_scope.
+
+Definition square_cps (p:list (Z*Z)) : ~> list (Z*Z).
+exact (list_rect
+      _
+      (return nil)
+      (fun t ts acc T k
+       => (dlet two_t2 := (2 * snd t)%RT in
+               acc
+                 _
+                 (fun acc
+                  => k (((fst t * fst t, (snd t * snd t)%RT)
+                           :: (map (fun t'
+                                    => (fst t * fst t', (two_t2 * snd t')%RT))
+                                   ts))
+                          ++ acc))))
+      p).
+Defined.


### PR DESCRIPTION
This improves commit 26a5b65df from PR #14797.

Fixes #16303

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
