### PR TITLE
[cleanup] for disentangling coqc and the stm

### DIFF
--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -563,7 +563,7 @@ let msg_format = ref (fun () ->
 let loop ( { Coqtop.run_mode; color_mode },_) ~opts:_ state =
   match run_mode with
   | Coqtop.Batch -> exit 0
-  | Coqtop.(Query PrintTags) -> Coqtop.print_style_tags color_mode; exit 0
+  | Coqtop.(Query PrintTags) -> Colors.print_style_tags color_mode; exit 0
   | Coqtop.(Query _) -> Printf.eprintf "Unknown query"; exit 1
   | Coqtop.Interactive ->
   let open Vernac.State in

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -226,7 +226,7 @@ let export_pre_goals flags Proof.{ sigma; goals; stack } process =
 
 let subgoals flags =
   let doc = get_doc () in
-  set_doc @@ Stm.finish ~doc;
+  set_doc @@ fst @@ Stm.finish ~doc;
   let short = match flags.Interface.gf_mode with
   | "short" -> true
   | _ -> false
@@ -257,7 +257,7 @@ let goals () =
 let evars () =
   try
     let doc = get_doc () in
-    set_doc @@ Stm.finish ~doc;
+    set_doc @@ fst @@ Stm.finish ~doc;
     let pfts = Vernacstate.Declare.give_me_the_proof () in
     let Proof.{ sigma } = Proof.data pfts in
     let exl = Evar.Map.bindings (Evd.undefined_map sigma) in
@@ -291,9 +291,9 @@ let status force =
   (* We remove the initial part of the current [DirPath.t]
      (usually Top in an interactive session, cf "coqtop -top"),
      and display the other parts (opened sections and modules) *)
-  set_doc (Stm.finish ~doc:(get_doc ()));
+  set_doc (fst @@ Stm.finish ~doc:(get_doc ()));
   if force then
-    set_doc (Stm.join ~doc:(get_doc ()));
+    set_doc (fst @@ Stm.join ~doc:(get_doc ()));
   let path =
     let l = Names.DirPath.repr (Lib.cwd ()) in
     List.rev_map Names.Id.to_string l
@@ -467,7 +467,7 @@ let init =
            get_doc (), init_sid, `NewTip in
          if Filename.check_suffix file ".v" then
            Stm.set_compilation_hints file;
-         set_doc (Stm.finish ~doc);
+         set_doc (fst @@ Stm.finish ~doc);
          initial_id
    end
 

--- a/stm/stm.mli
+++ b/stm/stm.mli
@@ -130,7 +130,7 @@ val edit_at : doc:doc -> Stateid.t -> doc * edit_focus
 val observe : doc:doc -> Stateid.t -> doc
 
 (* [finish doc] Fully checks a document up to the "current" tip. *)
-val finish : doc:doc -> doc
+val finish : doc:doc -> doc * Vernacstate.t
 
 (* Internal use (fake_ide) only, do not use *)
 val wait : doc:doc -> doc
@@ -138,7 +138,7 @@ val wait : doc:doc -> doc
 val stop_worker : string -> unit
 
 (* Joins the entire document.  Implies finish, but also checks proofs *)
-val join : doc:doc -> doc
+val join : doc:doc -> doc * Vernacstate.t
 
 (* Saves on the disk a .vio corresponding to the current status:
    - if the worker pool is empty, all tasks are saved

--- a/toplevel/ccompile.ml
+++ b/toplevel/ccompile.ml
@@ -154,32 +154,3 @@ let compile_file opts stm_opts copts injections (f_in, echo) =
 
 let compile_file opts stm_opts copts injections =
   Option.iter (compile_file opts stm_opts copts injections) copts.compile_file
-
-(******************************************************************************)
-(* VIO Dispatching                                                            *)
-(******************************************************************************)
-let check_vio_tasks copts =
-  Flags.async_proofs_worker_id := "VioChecking";
-  let rc =
-    List.fold_left (fun acc (n,f) ->
-        let f_in = ensure ~ext:".vio" ~src:f ~tgt:f in
-        ensure_exists f_in;
-        Vio_checking.check_vio (n,f_in) && acc)
-      true copts.vio_tasks in
-  if not rc then fatal_error Pp.(str "VIO Task Check failed")
-
-(* vio files *)
-let schedule_vio copts =
-  let l =
-    List.map (fun f -> let f_in = ensure ~ext:".vio" ~src:f ~tgt:f in ensure_exists f_in; f_in)
-      copts.vio_files in
-  if copts.vio_checking then
-    Vio_checking.schedule_vio_checking copts.vio_files_j l
-  else
-    Vio_checking.schedule_vio_compilation copts.vio_files_j l
-
-let do_vio opts copts _injections =
-  (* Vio compile pass *)
-  if copts.vio_files <> [] then schedule_vio copts;
-  (* Vio task pass *)
-  if copts.vio_tasks <> [] then check_vio_tasks copts

--- a/toplevel/ccompile.ml
+++ b/toplevel/ccompile.ml
@@ -18,35 +18,6 @@ let fatal_error msg =
   exit 1
 
 (******************************************************************************)
-(* Interactive Load File Simulation                                           *)
-(******************************************************************************)
-
-let load_init_file opts ~state =
-  if opts.pre.load_rcfile then
-    Topfmt.(in_phase ~phase:LoadingRcFile) (fun () ->
-        Coqrc.load_rcfile ~rcfile:opts.config.rcfile ~state) ()
-  else begin
-    Flags.if_verbose Feedback.msg_info (str"Skipping rcfile loading.");
-    state
-  end
-
-let load_vernacular opts ~state =
-  List.fold_left
-    (fun state (f_in, echo) ->
-      let s = Loadpath.locate_file f_in in
-      (* Should make the beautify logic clearer *)
-      let load_vernac f = Vernac.load_vernac ~echo ~interactive:false ~check:true ~state f in
-      if !Flags.beautify
-      then Flags.with_option Flags.beautify_file load_vernac f_in
-      else load_vernac s
-    ) state opts.pre.load_vernacular_list
-
-let load_init_vernaculars opts ~state =
-  let state = load_init_file opts ~state in
-  let state = load_vernacular opts ~state in
-  state
-
-(******************************************************************************)
 (* File Compilation                                                           *)
 (******************************************************************************)
 let warn_file_no_extension =
@@ -133,7 +104,7 @@ let compile opts stm_options injections copts ~echo ~f_in ~f_out =
           Stm.new_doc
           Stm.{ doc_type = VoDoc long_f_dot_out; injections; stm_options; } in
       let state = { doc; sid; proof = None; time = opts.config.time } in
-      let state = load_init_vernaculars opts ~state in
+      let state = Load.load_init_vernaculars opts ~state in
       let ldir = Stm.get_ldir ~doc:state.doc in
       Aux_file.(start_aux_file
         ~aux_file:(aux_file_name_for long_f_dot_out)
@@ -184,7 +155,7 @@ let compile opts stm_options injections copts ~echo ~f_in ~f_out =
               } in
 
       let state = { doc; sid; proof = None; time = opts.config.time } in
-      let state = load_init_vernaculars opts ~state in
+      let state = Load.load_init_vernaculars opts ~state in
       let ldir = Stm.get_ldir ~doc:state.doc in
       let state = Vernac.load_vernac ~echo ~check:false ~interactive:false ~state long_f_dot_in in
       let doc = Stm.finish ~doc:state.doc in

--- a/toplevel/colors.ml
+++ b/toplevel/colors.ml
@@ -1,0 +1,78 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+type color = [`ON | `AUTO | `EMACS | `OFF]
+
+let init_color opts =
+  let has_color = match opts with
+  | `OFF -> false
+  | `EMACS -> false
+  | `ON -> true
+  | `AUTO ->
+    Terminal.has_style Unix.stdout &&
+    Terminal.has_style Unix.stderr &&
+    (* emacs compilation buffer does not support colors by default,
+       its TERM variable is set to "dumb". *)
+    try Sys.getenv "TERM" <> "dumb" with Not_found -> false
+  in
+  let term_color =
+    if has_color then begin
+      let colors = try Some (Sys.getenv "COQ_COLORS") with Not_found -> None in
+      match colors with
+      | None -> Topfmt.default_styles (); true        (* Default colors *)
+      | Some "" -> false                              (* No color output *)
+      | Some s -> Topfmt.parse_color_config s; true   (* Overwrite all colors *)
+    end
+    else begin
+      Topfmt.default_styles (); false                 (* textual markers, no color *)
+    end
+  in
+  if opts = `EMACS then
+    Topfmt.set_emacs_print_strings ()
+  else if not term_color then begin
+      Proof_diffs.write_color_enabled term_color;
+    if Proof_diffs.show_diffs () then
+      (prerr_endline "Error: -diffs requires enabling -color"; exit 1)
+  end;
+  Topfmt.init_terminal_output ~color:term_color
+
+let print_style_tags opts =
+  let () = init_color opts in
+  let tags = Topfmt.dump_tags () in
+  let iter (t, st) =
+    let opt = Terminal.eval st ^ t ^ Terminal.reset ^ "\n" in
+    print_string opt
+  in
+  let make (t, st) =
+    let tags = List.map string_of_int (Terminal.repr st) in
+    (t ^ "=" ^ String.concat ";" tags)
+  in
+  let repr = List.map make tags in
+  let () = Printf.printf "COQ_COLORS=\"%s\"\n" (String.concat ":" repr) in
+  let () = List.iter iter tags in
+  flush_all ()
+
+
+let set_color = function
+  | "yes" | "on" -> `ON
+  | "no" | "off" -> `OFF
+  | "auto" ->`AUTO
+  | _ ->
+    Coqargs.error_wrong_arg ("Error: on/off/auto expected after option color")
+
+
+let parse_extra_colors extras =
+  let rec parse_extra color_mode = function
+  | "-color" :: next :: rest -> parse_extra (set_color next) rest
+  | "-list-tags" :: rest -> parse_extra color_mode rest
+  | x :: rest ->
+    let color_mode, rest = parse_extra color_mode rest in color_mode, x :: rest
+  | [] -> color_mode, [] in
+  parse_extra `AUTO extras

--- a/toplevel/colors.mli
+++ b/toplevel/colors.mli
@@ -1,0 +1,17 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** Initializer color for output *)
+
+type color = [`ON | `AUTO | `EMACS | `OFF]
+
+val init_color : color -> unit
+val parse_extra_colors : string list -> color * string list
+val print_style_tags : color -> unit

--- a/toplevel/common_compile.ml
+++ b/toplevel/common_compile.ml
@@ -1,0 +1,55 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Pp
+
+let fatal_error msg =
+  Topfmt.std_logger Feedback.Error msg;
+  flush_all ();
+  exit 1
+
+let warn_file_no_extension =
+  CWarnings.create ~name:"file-no-extension" ~category:"filesystem"
+         (fun (f,ext) ->
+          str "File \"" ++ str f ++
+            strbrk "\" has been implicitly expanded to \"" ++
+            str f ++ str ext ++ str "\"")
+
+let ensure_ext ext f =
+  if Filename.check_suffix f ext then f
+  else begin
+    warn_file_no_extension (f,ext);
+    f ^ ext
+  end
+
+let safe_chop_extension f =
+  try Filename.chop_extension f with _ -> f
+
+let ensure_bname src tgt =
+  let src, tgt = Filename.basename src, Filename.basename tgt in
+  let src, tgt = safe_chop_extension src, safe_chop_extension tgt in
+  if src <> tgt then
+    fatal_error (str "Source and target file names must coincide, directories can differ" ++ fnl () ++
+                   str "Source: " ++ str src                                                ++ fnl () ++
+                   str "Target: " ++ str tgt)
+
+let ensure ~ext ~src ~tgt = ensure_bname src tgt; ensure_ext ext tgt
+
+let ensure_exists f =
+  if not (Sys.file_exists f) then
+    fatal_error (hov 0 (str "Can't find file" ++ spc () ++ str f))
+
+let ensure_exists_with_prefix ~src ~tgt:f_out ~src_ext ~tgt_ext =
+  let long_f_dot_src = ensure ~ext:src_ext ~src ~tgt:src in
+  ensure_exists long_f_dot_src;
+  let long_f_dot_tgt = match f_out with
+    | None -> safe_chop_extension long_f_dot_src ^ tgt_ext
+    | Some f -> ensure ~ext:tgt_ext ~src:long_f_dot_src ~tgt:f in
+  long_f_dot_src, long_f_dot_tgt

--- a/toplevel/common_compile.mli
+++ b/toplevel/common_compile.mli
@@ -26,5 +26,9 @@ val ensure_exists : string -> unit
    [src_ext] and [tgt_ext] are expected to begin with dot, eg [".v"]. *)
 val ensure_exists_with_prefix : src:string -> tgt:string option -> src_ext:string -> tgt_ext:string -> string * string
 
-(* [safe_chop_extension f] is like Filename.chop_extension but fail safe *)
+(* [chop_extension f] is like Filename.chop_extension but fail safe *)
 val safe_chop_extension : string -> string
+
+(* [ensure_no_pending_proofs ~filename] checks that no proof or obligation
+   is open *)
+val ensure_no_pending_proofs : filename:string -> Vernacstate.t -> unit

--- a/toplevel/common_compile.mli
+++ b/toplevel/common_compile.mli
@@ -1,0 +1,30 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(* [fatal_error msg] prints msg and exits 1 *)
+val fatal_error : Pp.t -> 'a
+
+(* [ensure ext src tgt] checks that, once stripped by ext, both [src] and
+   [tgt] have the same basename, and returns [tgt] with the extension.
+   [ext] is expected to begin with dot, eg [".v"]. *)
+val ensure : ext:string -> src:string -> tgt:string -> string
+
+(* [ensure_exists f] fails if f does not exist *)
+val ensure_exists : string -> unit
+
+(* [ensure_exists_with_prefix src tgt src_ext tgt_ext] checks that [src] exists
+   (if needed adding the extension) and that [tgt] exists (if needed adding the
+   extension) and returns [src] and [tgt] with their respective extensions.
+   If [tgt] is [None], then it defaults to [src] (with [tgt_ext] as extension).
+   [src_ext] and [tgt_ext] are expected to begin with dot, eg [".v"]. *)
+val ensure_exists_with_prefix : src:string -> tgt:string option -> src_ext:string -> tgt_ext:string -> string * string
+
+(* [safe_chop_extension f] is like Filename.chop_extension but fail safe *)
+val safe_chop_extension : string -> string

--- a/toplevel/coqc.ml
+++ b/toplevel/coqc.ml
@@ -51,7 +51,7 @@ let coqc_main ((copts,_),stm_opts) injections ~opts =
   (* Careful this will modify the load-path and state so after this
      point some stuff may not be safe anymore. *)
   Topfmt.(in_phase ~phase:CompilationPhase)
-    Ccompile.do_vio opts copts injections;
+    Vio_compile.do_vio opts copts injections;
 
   flush_all();
 

--- a/toplevel/coqc.ml
+++ b/toplevel/coqc.ml
@@ -11,7 +11,7 @@
 let coqc_init ((_,color_mode),_) injections ~opts =
   Flags.quiet := true;
   System.trust_file_cache := true;
-  Coqtop.init_color (if opts.Coqargs.config.Coqargs.print_emacs then `EMACS else color_mode);
+  Colors.init_color (if opts.Coqargs.config.Coqargs.print_emacs then `EMACS else color_mode);
   DebugHook.Intf.(set
     { read_cmd = Coqtop.ltac_debug_parse
     ; submit_answer = Coqtop.ltac_debug_answer
@@ -73,10 +73,10 @@ let coqc_run copts ~opts injections =
     let exit_code = if (CErrors.is_anomaly exn) then 129 else 1 in
     exit exit_code
 
-let custom_coqc : ((Coqcargs.t * Coqtop.color) * Stm.AsyncOpts.stm_opt, 'b) Coqtop.custom_toplevel
+let custom_coqc : ((Coqcargs.t * Colors.color) * Stm.AsyncOpts.stm_opt, 'b) Coqtop.custom_toplevel
  = Coqtop.{
   parse_extra = (fun extras ->
-    let color_mode, extras = Coqtop.parse_extra_colors extras in
+    let color_mode, extras = Colors.parse_extra_colors extras in
     let stm_opts, extras = Stmargs.parse_args ~init:Stm.AsyncOpts.default_opts extras in
     let coqc_opts = Coqcargs.parse extras in
     ((coqc_opts, color_mode), stm_opts), []);

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -182,7 +182,7 @@ let init_document opts stm_options injections =
 
 let init_toploop opts stm_opts injections =
   let state = init_document opts stm_opts injections in
-  let state = Ccompile.load_init_vernaculars opts ~state in
+  let state = Load.load_init_vernaculars opts ~state in
   state
 
 let coqtop_init ({ run_mode; color_mode }, async_opts) injections ~opts =

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -81,57 +81,6 @@ let start_coq custom =
 (** ****************************************)
 (** Specific support for coqtop executable *)
 
-type color = [`ON | `AUTO | `EMACS | `OFF]
-
-let init_color opts =
-  let has_color = match opts with
-  | `OFF -> false
-  | `EMACS -> false
-  | `ON -> true
-  | `AUTO ->
-    Terminal.has_style Unix.stdout &&
-    Terminal.has_style Unix.stderr &&
-    (* emacs compilation buffer does not support colors by default,
-       its TERM variable is set to "dumb". *)
-    try Sys.getenv "TERM" <> "dumb" with Not_found -> false
-  in
-  let term_color =
-    if has_color then begin
-      let colors = try Some (Sys.getenv "COQ_COLORS") with Not_found -> None in
-      match colors with
-      | None -> Topfmt.default_styles (); true        (* Default colors *)
-      | Some "" -> false                              (* No color output *)
-      | Some s -> Topfmt.parse_color_config s; true   (* Overwrite all colors *)
-    end
-    else begin
-      Topfmt.default_styles (); false                 (* textual markers, no color *)
-    end
-  in
-  if opts = `EMACS then
-    Topfmt.set_emacs_print_strings ()
-  else if not term_color then begin
-      Proof_diffs.write_color_enabled term_color;
-    if Proof_diffs.show_diffs () then
-      (prerr_endline "Error: -diffs requires enabling -color"; exit 1)
-  end;
-  Topfmt.init_terminal_output ~color:term_color
-
-let print_style_tags opts =
-  let () = init_color opts in
-  let tags = Topfmt.dump_tags () in
-  let iter (t, st) =
-    let opt = Terminal.eval st ^ t ^ Terminal.reset ^ "\n" in
-    print_string opt
-  in
-  let make (t, st) =
-    let tags = List.map string_of_int (Terminal.repr st) in
-    (t ^ "=" ^ String.concat ";" tags)
-  in
-  let repr = List.map make tags in
-  let () = Printf.printf "COQ_COLORS=\"%s\"\n" (String.concat ":" repr) in
-  let () = List.iter iter tags in
-  flush_all ()
-
 let ltac_debug_answer = let open DebugHook.Answer in function
     | Prompt prompt ->
       (* No newline *)
@@ -160,7 +109,7 @@ type run_mode = Interactive | Batch | Query of query
 
 type toplevel_options = {
   run_mode : run_mode;
-  color_mode : color;
+  color_mode : Colors.color;
 }
 
 let init_document opts stm_options injections =
@@ -187,7 +136,7 @@ let init_toploop opts stm_opts injections =
 
 let coqtop_init ({ run_mode; color_mode }, async_opts) injections ~opts =
   if run_mode != Interactive then Flags.quiet := true;
-  init_color (if opts.config.print_emacs then `EMACS else color_mode);
+  Colors.init_color (if opts.config.print_emacs then `EMACS else color_mode);
   Flags.if_verbose (print_header ~boot:opts.pre.boot) ();
   DebugHook.Intf.(set
     { read_cmd = ltac_debug_parse
@@ -195,22 +144,6 @@ let coqtop_init ({ run_mode; color_mode }, async_opts) injections ~opts =
     ; isTerminal = true
     });
   init_toploop opts async_opts injections
-
-let set_color = function
-  | "yes" | "on" -> `ON
-  | "no" | "off" -> `OFF
-  | "auto" ->`AUTO
-  | _ ->
-    error_wrong_arg ("Error: on/off/auto expected after option color")
-
-let parse_extra_colors extras =
-  let rec parse_extra color_mode = function
-  | "-color" :: next :: rest -> parse_extra (set_color next) rest
-  | "-list-tags" :: rest -> parse_extra color_mode rest
-  | x :: rest ->
-    let color_mode, rest = parse_extra color_mode rest in color_mode, x :: rest
-  | [] -> color_mode, [] in
-  parse_extra `AUTO extras
 
 let coqtop_parse_extra extras =
   let rec parse_extra run_mode  = function
@@ -220,7 +153,7 @@ let coqtop_parse_extra extras =
     let run_mode, rest = parse_extra run_mode rest in run_mode, x :: rest
   | [] -> run_mode, [] in
   let run_mode, extras = parse_extra Interactive extras in
-  let color_mode, extras = parse_extra_colors extras in
+  let color_mode, extras = Colors.parse_extra_colors extras in
   let async_opts, extras = Stmargs.parse_args ~init:Stm.AsyncOpts.default_opts extras in
   ({ run_mode; color_mode}, async_opts), extras
 
@@ -241,7 +174,7 @@ let get_native_name s =
 let coqtop_run ({ run_mode; color_mode },_) ~opts state =
   match run_mode with
   | Interactive -> Coqloop.loop ~opts ~state;
-  | Query PrintTags -> print_style_tags color_mode; exit 0
+  | Query PrintTags -> Colors.print_style_tags color_mode; exit 0
   | Query (PrintModUid sl) ->
       let s = String.concat " " (List.map get_native_name sl) in
       print_endline s;

--- a/toplevel/coqtop.mli
+++ b/toplevel/coqtop.mli
@@ -28,14 +28,6 @@ type ('a,'b) custom_toplevel =
    [custom.run]. *)
 val start_coq : ('a * Stm.AsyncOpts.stm_opt,'b) custom_toplevel -> unit
 
-(** Initializer color for output *)
-
-type color = [`ON | `AUTO | `EMACS | `OFF]
-
-val init_color : color -> unit
-val parse_extra_colors : string list -> color * string list
-val print_style_tags : color -> unit
-
 (** Prepare state for interactive loop *)
 
 val init_toploop : Coqargs.t -> Stm.AsyncOpts.stm_opt -> Coqargs.injection_command list -> Vernac.State.t
@@ -47,7 +39,7 @@ type run_mode = Interactive | Batch | Query of query
 
 type toplevel_options = {
   run_mode : run_mode;
-  color_mode : color;
+  color_mode : Colors.color;
 }
 
 val coqtop_toplevel : (toplevel_options * Stm.AsyncOpts.stm_opt,Vernac.State.t) custom_toplevel

--- a/toplevel/load.ml
+++ b/toplevel/load.ml
@@ -1,0 +1,41 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Pp
+open Coqargs
+
+(******************************************************************************)
+(* Interactive Load File Simulation                                           *)
+(******************************************************************************)
+
+let load_init_file opts ~state =
+  if opts.pre.load_rcfile then
+    Topfmt.(in_phase ~phase:LoadingRcFile) (fun () ->
+        Coqrc.load_rcfile ~rcfile:opts.config.rcfile ~state) ()
+  else begin
+    Flags.if_verbose Feedback.msg_info (str"Skipping rcfile loading.");
+    state
+  end
+
+let load_vernacular opts ~state =
+  List.fold_left
+    (fun state (f_in, echo) ->
+      let s = Loadpath.locate_file f_in in
+      (* Should make the beautify logic clearer *)
+      let load_vernac f = Vernac.load_vernac ~echo ~interactive:false ~check:true ~state f in
+      if !Flags.beautify
+      then Flags.with_option Flags.beautify_file load_vernac f_in
+      else load_vernac s
+    ) state opts.pre.load_vernacular_list
+
+let load_init_vernaculars opts ~state =
+  let state = load_init_file opts ~state in
+  let state = load_vernacular opts ~state in
+  state

--- a/toplevel/load.mli
+++ b/toplevel/load.mli
@@ -8,8 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(** [compile_file opts] compile file specified in [opts] *)
-val compile_file : Coqargs.t -> Stm.AsyncOpts.stm_opt -> Coqcargs.t -> Coqargs.injection_command list -> unit
-
-(** [do_vio opts] process [.vio] files in [opts] *)
-val do_vio : Coqargs.t -> Coqcargs.t -> Coqargs.injection_command list -> unit
+  (** [load_init_vernaculars opts ~state] Load vernaculars from
+   the init (rc) file *)
+val load_init_vernaculars : Coqargs.t -> state:Vernac.State.t-> Vernac.State.t

--- a/toplevel/vio_compile.ml
+++ b/toplevel/vio_compile.ml
@@ -1,0 +1,41 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Coqcargs
+open Common_compile
+
+(******************************************************************************)
+(* VIO Dispatching                                                            *)
+(******************************************************************************)
+let check_vio_tasks copts =
+  Flags.async_proofs_worker_id := "VioChecking";
+  let rc =
+    List.fold_left (fun acc (n,f) ->
+        let f_in = ensure ~ext:".vio" ~src:f ~tgt:f in
+        ensure_exists f_in;
+        Vio_checking.check_vio (n,f_in) && acc)
+      true copts.vio_tasks in
+  if not rc then fatal_error Pp.(str "VIO Task Check failed")
+
+(* vio files *)
+let schedule_vio copts =
+  let l =
+    List.map (fun f -> let f_in = ensure ~ext:".vio" ~src:f ~tgt:f in ensure_exists f_in; f_in)
+      copts.vio_files in
+  if copts.vio_checking then
+    Vio_checking.schedule_vio_checking copts.vio_files_j l
+  else
+    Vio_checking.schedule_vio_compilation copts.vio_files_j l
+
+let do_vio opts copts _injections =
+  (* Vio compile pass *)
+  if copts.vio_files <> [] then schedule_vio copts;
+  (* Vio task pass *)
+  if copts.vio_tasks <> [] then check_vio_tasks copts

--- a/toplevel/vio_compile.mli
+++ b/toplevel/vio_compile.mli
@@ -8,5 +8,5 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(** [compile_file opts] compile file specified in [opts] *)
-val compile_file : Coqargs.t -> Stm.AsyncOpts.stm_opt -> Coqcargs.t -> Coqargs.injection_command list -> unit
+(** [do_vio opts] process [.vio] files in [opts] *)
+val do_vio : Coqargs.t -> Coqcargs.t -> Coqargs.injection_command list -> unit

--- a/vernac/vernacstate.mli
+++ b/vernac/vernacstate.mli
@@ -40,6 +40,7 @@ module LemmaStack : sig
   val map_top : f:(Declare.Proof.t -> Declare.Proof.t) -> t -> t
   val with_top : t -> f:(Declare.Proof.t -> 'a ) -> 'a
   val get_top : t -> Declare.Proof.t
+  val get_all_proof_names : t -> Names.Id.t list
 
 end
 


### PR DESCRIPTION
The final objective is to have a compiler which does not use the STM.

This pr is a simple cleanup which moves common code into files, to be later relocated in a common library (shared between the current coqc and the simpler version). In particular color handling and filename extension checking.

In passing we move the check for pending proofs to a non-legacy API, so that the simple compiler does not need to use it, and we document the APIs we now expose.