### PR TITLE
[eauto] goal loop detection

### DIFF
--- a/dev/ci/user-overlays/16289-mrhaandi-eauto-cost.sh
+++ b/dev/ci/user-overlays/16289-mrhaandi-eauto-cost.sh
@@ -1,0 +1,1 @@
+overlay metacoq https://github.com/mrhaandi/metacoq eauto-cost 16289

--- a/doc/changelog/04-tactics/16289-eauto-cost.rst
+++ b/doc/changelog/04-tactics/16289-eauto-cost.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  :tacn:`eauto` respects priorities of ``Extern`` hints
+  (`#16289 <https://github.com/coq/coq/pull/16289>`_,
+  fixes `#5163 <https://github.com/coq/coq/issues/5163>`_
+  and `#16282 <https://github.com/coq/coq/issues/16282>`_,
+  by Andrej Dudenhefner).

--- a/test-suite/bugs/bug_16282.v
+++ b/test-suite/bugs/bug_16282.v
@@ -1,0 +1,15 @@
+Lemma TrueI : unit -> True.
+Proof. easy. Qed.
+
+Create HintDb db.
+
+#[local] Hint Extern 99 => shelve : db.
+#[local] Hint Extern 0 (True) => apply TrueI : db.
+#[local] Hint Extern 0 (unit) => exact tt : db.
+
+Goal True.
+Proof.
+  Succeed (solve [unshelve auto with db nocore]).
+  Succeed (solve [unshelve typeclasses eauto with db nocore]).
+  Succeed (solve [unshelve eauto with db nocore]).
+Abort.

--- a/test-suite/bugs/bug_5163.v
+++ b/test-suite/bugs/bug_5163.v
@@ -1,0 +1,16 @@
+Lemma TrueI : unit -> True.
+Proof. easy. Qed.
+
+Create HintDb db.
+
+Ltac diverge a := diverge a.
+#[local] Hint Extern 99 => diverge idtac : db.
+#[local] Hint Extern 0 (True) => apply TrueI : db.
+#[local] Hint Extern 0 (unit) => exact tt : db.
+
+Goal True.
+Proof.
+  Succeed (solve [unshelve auto with db nocore]).
+  Succeed (solve [unshelve typeclasses eauto with db nocore]).
+  Succeed (solve [timeout 1 unshelve eauto with db nocore]).
+Abort.


### PR DESCRIPTION
Basic loop detection in auto based on https://github.com/coq/coq/pull/16289 and similar to https://github.com/coq/coq/pull/16316. Currently only for benchmarking.

Pathological example:
```coq
#[local] Hint Resolve eq_sym : core.

Goal forall (n m : nat), n = m.
Proof.
  (* lots of useless eq_sym applications *)
  time debug eauto 1000. 
Abort.
```