### PR TITLE
Mini reorganization keyword detection before addressing issue 4712

### DIFF
--- a/test-suite/bugs/bug_14003.v
+++ b/test-suite/bugs/bug_14003.v
@@ -3,7 +3,7 @@ Require Import Ltac2.Ltac2.
 Module Foo.
 
 Ltac2 foo := ().
-Ltac2 Type bar := [ BAR ].
+Ltac2 Type bar := [ BAR ].
 Ltac2 Type quz := [ .. ].
 Ltac2 Type quz ::= [ QUZ ].
 


### PR DESCRIPTION
*Kind*: cleanup

We do the following:
- add new Unicode classes `Separator` and `Control` so as to be able to classify the `0x00-0x7F` ascii fragment of Unicode without a specific treatment
- merge code for ascii and non-ascii utf-8 characters in the lexer
- prepare `progress_further` to address #4712 and its variants