### PR TITLE
Addressing issue #4712: keyword detection preserves contiguous characters forming a valid identifier subsequence

### DIFF
--- a/clib/unicode.ml
+++ b/clib/unicode.ml
@@ -253,6 +253,10 @@ let is_ident_sep = function
   | IdentSep -> true
   | Letter | IdentPart | Symbol | Unknown | Separator | Control -> false
 
+let is_letter = function
+  | Letter -> true
+  | IdentSep | IdentPart | Symbol | Unknown | Separator | Control -> false
+
 let ident_refutation s =
   if s = ".." then None else try
     let j, n = next_utf8 s 0 in

--- a/clib/unicode.mli
+++ b/clib/unicode.mli
@@ -25,6 +25,9 @@ val is_valid_ident_initial : status -> bool
 (** Tells if a valid non-initial character for an identifier *)
 val is_valid_ident_trailing : status -> bool
 
+(** Tells if a letter *)
+val is_letter : status -> bool
+
 (** Tells if a character is unclassified *)
 val is_unknown : status -> bool
 

--- a/doc/changelog/03-notations/16322-master+addressing-issue4712-keyword-detection-preserve-contiguous-alphanumerical-chars.rst
+++ b/doc/changelog/03-notations/16322-master+addressing-issue4712-keyword-detection-preserve-contiguous-alphanumerical-chars.rst
@@ -1,0 +1,9 @@
+- **Changed:**
+  When multiple tokens match the beginning of a sequence of characters,
+  the longest matching token not cutting a subsequence of contiguous
+  letters in the middle is used. Previously, this was only the longest
+  matching token. See :ref:`lexical conventions <lexing-unseparated-keywords>`
+  for details and examples.
+  (`#16322 <https://github.com/coq/coq/pull/16322>`_,
+  fixes `#4712 <https://github.com/coq/coq/issues/4712>`_,
+  by Hugo Herbelin).

--- a/doc/sphinx/language/core/basic.rst
+++ b/doc/sphinx/language/core/basic.rst
@@ -189,11 +189,18 @@ Other tokens
   tokens.
 
   When multiple tokens match the beginning of a sequence of characters,
-  the longest matching token is used.
+  the longest matching token not cutting the sequence of characters in the middle of a subsequence forming a valid identifier is used.
   Occasionally you may need to insert spaces to separate tokens.  For example,
   if ``~`` and ``~~`` are both defined as tokens, the inputs ``~ ~`` and
   ``~~`` generate different tokens, whereas if `~~` is not defined, then the
-  two inputs are equivalent.
+  two inputs are equivalent. Also, if ``~`` and ``~_h`` are both
+  defined as tokens, the input ``~_ho`` is interpreted as ``~ _ho``
+  rather than ``~_h o`` so as not to cut the identifier-like
+  subsequence ``ho``. Contrastingly, if only ``~_h`` is defined as a token,
+  then ``~_ho`` is an error because no token can be found that includes
+  the whole subsequence ``ho`` without cutting it in the middle. Finally, if
+  all of ``~``, ``~_h`` and ``~_ho`` are defined as tokens, the input
+  ``~_ho`` is interpreted using the longest match rule, i.e. as the token ``~_ho``.
 
 Essential vocabulary
 --------------------

--- a/doc/sphinx/language/core/basic.rst
+++ b/doc/sphinx/language/core/basic.rst
@@ -189,10 +189,10 @@ Other tokens
   tokens.
 
   When multiple tokens match the beginning of a sequence of characters,
-  the longest matching token not cutting the sequence of characters in the middle of a subsequence forming a valid identifier is used.
+  the longest matching token not cutting a subsequence of contiguous letters in the middle is used.
   Occasionally you may need to insert spaces to separate tokens.  For example,
   if ``~`` and ``~~`` are both defined as tokens, the inputs ``~ ~`` and
-  ``~~`` generate different tokens, whereas if `~~` is not defined, then the
+  ``~~`` generate different tokens, whereas if ``~~`` is not defined, then the
   two inputs are equivalent. Also, if ``~`` and ``~_h`` are both
   defined as tokens, the input ``~_ho`` is interpreted as ``~ _ho``
   rather than ``~_h o`` so as not to cut the identifier-like

--- a/doc/sphinx/language/core/basic.rst
+++ b/doc/sphinx/language/core/basic.rst
@@ -188,6 +188,8 @@ Other tokens
   Note that loading additional modules or plugins may expand the set of defined
   tokens.
 
+.. _lexing-unseparated-keywords:
+
   When multiple tokens match the beginning of a sequence of characters,
   the longest matching token not cutting a subsequence of contiguous letters in the middle is used.
   Occasionally you may need to insert spaces to separate tokens.  For example,

--- a/parsing/cLexer.ml
+++ b/parsing/cLexer.ml
@@ -219,15 +219,10 @@ let status_of_utf8 = function
 let lookup_utf8 loc cs =
   status_of_utf8 (lookup_utf8_char loc 0 cs)
 
-let is_ident_head l =
+let is_letter l =
   match status_of_utf8 l with
   | EmptyStream -> false
-  | Utf8Token (st,_) -> Unicode.is_valid_ident_initial st
-
-let is_ident_trailing l =
-  match status_of_utf8 l with
-  | EmptyStream -> false
-  | Utf8Token (st,_) -> Unicode.is_valid_ident_trailing st
+  | Utf8Token (st,_) -> Unicode.is_letter st
 
 let unlocated f x =
   let dummy_loc = Loc.(initial ToplevelInput) in
@@ -497,22 +492,22 @@ let update_longest_valid_token last nj tt cs =
 
 (* try to progress by peeking the next utf-8 lexeme *)
 (* and retain the longest valid special token obtained *)
-let rec progress_further loc last nj in_ident_part tt cs =
+let rec progress_further loc last nj last_is_letter tt cs =
   match lookup_utf8_char loc nj cs with
   | [] -> snd (update_longest_valid_token last nj tt cs)
-  | l -> progress_utf8 loc last nj in_ident_part tt cs l
+  | l -> progress_utf8 loc last nj last_is_letter tt cs l
 
 (* under the same assumptions as [update_longest_valid_token], *)
 (* read the [n] bytes of the current utf-8 lexeme whose first byte is [c] *)
-and progress_utf8 loc last nj in_ident_part tt cs l =
-  let in_ident_part' = if in_ident_part then is_ident_trailing l else is_ident_head l in
+and progress_utf8 loc last nj last_is_letter tt cs l =
+  let is_letter' = is_letter l in
   (* compute longest match before considering utf8 block [l] *)
   (* not allowing update if in the middle of an ident part *)
-  let nj, last = if in_ident_part && in_ident_part' then nj, last else update_longest_valid_token last nj tt cs in
+  let nj, last = if last_is_letter && is_letter' then nj, last else update_longest_valid_token last nj tt cs in
   try
     (* descend in tree according to current utf8 block [l] *)
     let tt = List.fold_left (fun tt c -> CharMap.find c tt.branch) tt l in
-    progress_further loc last (nj + List.length l) in_ident_part' tt cs
+    progress_further loc last (nj + List.length l) is_letter' tt cs
   with Not_found ->
     last
 

--- a/test-suite/bugs/bug_4712.v
+++ b/test-suite/bugs/bug_4712.v
@@ -1,0 +1,14 @@
+Module Example1.
+
+Notation "x =_s y" := (x = y) (at level 50).
+Fail Check id=_sid.
+
+End Example1.
+
+Module Example2.
+(* see https://coq.zulipchat.com/#narrow/stream/237664-math-comp-users/topic/Surprising.20parsing.20of.20the.20.E2.80.9C*l.E2.80.9D.20notation *)
+
+Notation "*l" := Nat.add.
+Check forall (T lT: Type) (x: T*lT), x = x. (* Expected to be "(x : T * lT)" *)
+
+End Example2.

--- a/test-suite/output/bug_4712_part2.out
+++ b/test-suite/output/bug_4712_part2.out
@@ -1,0 +1,8 @@
+File "./output/bug_4712_part2.v", line 6, characters 21-28:
+The command has indeed failed with message:
+The reference foobarA was not found in the current environment.
+File "./output/bug_4712_part2.v", line 8, characters 21-22:
+Error: Syntax Error: Lexer: Undefined token
+
+
+coqc exited with code 1

--- a/test-suite/output/bug_4712_part2.v
+++ b/test-suite/output/bug_4712_part2.v
@@ -1,0 +1,10 @@
+Module Example2.
+
+Notation "'foobar'" := 1.
+Definition a := foobar.
+Definition A := 2.
+Fail Definition b := foobarA.
+Notation "'\foobar'" := (fun x => 1 + x).
+Fail Definition b := \foobarA.
+
+End Example2.

--- a/test-suite/output/lexical_convention_in_doc.out
+++ b/test-suite/output/lexical_convention_in_doc.out
@@ -1,0 +1,17 @@
+not (not True)
+     : Prop
+not True
+     : Prop
+not (not True)
+     : Prop
+not (not True)
+     : Prop
+not False
+     : Prop
+(fun x : Prop => not (not x)) o
+     : Prop
+File "./output/lexical_convention_in_doc.v", line 50, characters 12-15:
+The command has indeed failed with message:
+The reference _ho was not found in the current environment.
+True
+     : Prop

--- a/test-suite/output/lexical_convention_in_doc.v
+++ b/test-suite/output/lexical_convention_in_doc.v
@@ -1,0 +1,66 @@
+Set Printing All.
+
+(* if ``~`` and ``~~`` are both defined as tokens,
+   the inputs ``~ ~`` and ``~~`` generate different tokens *)
+Section TestLexer0.
+
+Local Notation "~" := not.
+Local Notation "~~" := not.
+
+Check ~ ~ True.
+Check ~~ True.
+
+End TestLexer0.
+
+(* whereas if ``~~`` is not defined,
+   then the two inputs are equivalent *)
+Section TestLexer1.
+
+Local Notation "~" := not.
+
+Set Printing All.
+Check ~ ~ True.
+Check ~~ True.
+
+End TestLexer1.
+
+(* Also, if ``~`` and ``~_h`` are both defined as tokens, the input
+   ``~_ho`` is interpreted as ``~ _ho`` rather than ``~_h o`` so as
+   not to cut the identifier-like subsequence ``ho``. *)
+Section TestLexer2.
+
+Local Notation "~" := not.
+Local Notation "~_h" := (fun x => not (not x)).
+Local Notation "'_ho'" := False.
+Let o := True.
+
+Check ~_ho.
+Check ~_h o.
+
+End TestLexer2.
+
+
+(* Contrastingly, if only ``~_h`` is defined as a token, then ``~_ho``
+   is an error because no token can be found that includes the whole
+   subsequence ``ho`` without cutting it in the middle. *)
+Section TestLexer3.
+
+Local Notation "~_h" := (fun x => not (not x)).
+
+Fail Check ~_ho.
+
+End TestLexer3.
+
+(* Finally, if all of ``~``, ``~_h`` and ``~_ho`` are defined as
+   tokens, the input ``~_ho`` is interpreted using the longest match
+   rule, i.e. as the token ``~_ho``. *)
+Section TestLexer4.
+
+Local Notation "~" := not.
+Local Notation "~_h" := (fun x => not (not x)).
+Local Notation "'_ho'" := False.
+Local Notation "~_ho" := True.
+
+Check ~_ho.
+
+End TestLexer4.


### PR DESCRIPTION
**Kind:** wish granted, enhancement

This addresses two different kinds of examples:
- not allowing splitting glued digits and characters:
```
Definition e :=
  match 0as z return 0 = 0with
  | _ => eq_refl
 end.
```
- keywords that would cut a valid identifier subsequence in the middle:
```
Notation "x =_s y" := (x = y) (at level 50).
Fail Check id=_sid. (* was succeeding before *)
```


Closes #4712 

Depends on #16321

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
