### PR TITLE
[auto] more robust on evars

### DIFF
--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -408,7 +408,7 @@ let gen_trivial ?(debug=Off) lems dbnames =
       | Some dbnames -> make_db_list dbnames
       | None -> current_pure_db ()
     in
-    tclTRY_dbg d (trivial_fail_db ~with_evars:true d db_list lems None)
+    tclTRY_dbg d (trivial_fail_db ~with_evars:false d db_list lems None)
   end
 
 let trivial ?(debug=Off) lems dbnames = gen_trivial ~debug lems (Some dbnames)
@@ -431,7 +431,7 @@ let search d n db_list lems =
       let info = Exninfo.reify () in
       Tacticals.tclZEROMSG ~info (str"BOUND 2")
     else
-      Tacticals.tclORELSE0 (dbg_eassumption d) @@
+      Tacticals.tclORELSE0 (dbg_assumption d) @@
       Tacticals.tclORELSE0 (intro_register d (search d n) local_db) @@
       Proofview.Goal.enter begin fun gl ->
         let env = Proofview.Goal.env gl in

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -341,7 +341,7 @@ let intro_register dbg kont db =
         Tacticals.onLastDecl (fun decl -> kont (Some (extend_local_db decl db)))
       end
 
-let rec trivial_fail_db ?(evars=true) dbg db_list lems local_db =
+let rec trivial_fail_db ?(with_evars=true) dbg db_list lems local_db =
   Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
     let sigma = Proofview.Goal.sigma gl in
@@ -354,29 +354,29 @@ let rec trivial_fail_db ?(evars=true) dbg db_list lems local_db =
     let secvars = compute_secvars gl in
     let head = head_constr sigma concl in
     let tacs =
-      try List.map (fun h -> Tacticals.tclCOMPLETE (tac_of_hint ~evars dbg db_list local_db concl h))
+      try List.map (fun h -> Tacticals.tclCOMPLETE (tac_of_hint ~with_evars dbg db_list local_db concl h))
         (priority @@ List.map_append (hintmap_of env sigma secvars head concl) (local_db::db_list))
       with Not_found -> []
     in
     Tacticals.tclFIRST @@
-      ((if evars then dbg_eassumption else dbg_assumption) dbg)::
-        (intro_register dbg (trivial_fail_db ~evars dbg db_list lems) (Some local_db))::
+      ((if with_evars then dbg_eassumption else dbg_assumption) dbg)::
+        (intro_register dbg (trivial_fail_db ~with_evars dbg db_list lems) (Some local_db))::
           tacs
   end
 
-and tac_of_hint ?(evars=true) dbg db_list local_db concl h =
+and tac_of_hint ?(with_evars=true) dbg db_list local_db concl h =
   let tactic = function
     | Res_pf h -> unify_resolve_nodelta h
     | ERes_pf _ -> Proofview.Goal.enter (fun gl ->
         let info = Exninfo.reify () in
         Tacticals.tclZEROMSG ~info (str "eres_pf"))
-    | Give_exact h -> (if evars then e_exact else exact) h
+    | Give_exact h -> (if with_evars then e_exact else exact) h
     | Res_pf_THEN_trivial_fail h ->
       Tacticals.tclTHEN
         (unify_resolve_nodelta h)
         (* With "(debug) trivial", we shouldn't end here, and
            with "debug auto" we don't display the details of inner trivial *)
-        (trivial_fail_db ~evars (no_dbg dbg) db_list [] (Some local_db))
+        (trivial_fail_db ~with_evars (no_dbg dbg) db_list [] (Some local_db))
     | Unfold_nth c ->
       Proofview.Goal.enter begin fun gl ->
        if exists_evaluable_reference (Tacmach.pf_env gl) c then
@@ -408,7 +408,7 @@ let gen_trivial ?(debug=Off) lems dbnames =
       | Some dbnames -> make_db_list dbnames
       | None -> current_pure_db ()
     in
-    tclTRY_dbg d (trivial_fail_db ~evars:false d db_list lems None)
+    tclTRY_dbg d (trivial_fail_db ~with_evars:true d db_list lems None)
   end
 
 let trivial ?(debug=Off) lems dbnames = gen_trivial ~debug lems (Some dbnames)
@@ -452,7 +452,7 @@ let search d n db_list lems =
             with Not_found -> []
           in
           first_delayed_map begin fun h ->
-            let tac = tac_of_hint ~evars:true d db_list local_db concl h in
+            let tac = tac_of_hint ~with_evars:true d db_list local_db concl h in
             Tacticals.tclTHEN tac @@
               Proofview.Goal.enter begin fun gl ->
                 let hyps' = Proofview.Goal.hyps gl in


### PR DESCRIPTION
In `auto` added evar unification to `exact` and `assumption` uses.
As a result, all cases in #16323 behave uniformly.
Previously, `auto` used three different unification procedures for
1) hypotheses with zero arguments
2) hints with zero arguments
3) hypotheses or hints with at least one argument

While this PR moves `auto` slightly closer to `eauto`, the semantics and separation from `eauto` is more clear.

~~Possibly, `trivial` should not be strengthened by this PR but split into `trivial` and `etrivial` (with/without evar unification).
The reasoning is that `tac; trivial` is a pattern to solve trivial subgoals with no evar interaction.~~
`trivial` should behave as `auto` with zero-cost hints (and unlimited depth?).

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #16323

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
