### PR TITLE
[declare] expose API to export side effects

### DIFF
--- a/dev/ci/user-overlays/16328-gares-declare-export-seff.sh
+++ b/dev/ci/user-overlays/16328-gares-declare-export-seff.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/gares/coq-elpi declare-export-seff 16328

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -631,6 +631,8 @@ module Internal = struct
 
   let objVariable = objVariable
 
+  let export_side_effects = export_side_effects
+
 end
 
 let declare_definition_scheme ~internal ~univs ~role ~name c =

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -416,12 +416,6 @@ val build_by_tactic
   -> unit Proofview.tactic
   -> Constr.constr * Constr.types option * (UState.named_universes_entry) * bool * UState.t
 
-(** [export_side_effects eff] makes the side effects [eff] global. This
-    usually happens at the end of a proof (during Qed or Defined), but
-    one may need to declare them by hand, for example because the
-    tactic was run as part of a command *)
-val export_side_effects : Evd.side_effects -> unit
-
 (** {2 Program mode API} *)
 
 (** Coq's Program mode support. This mode extends declarations of
@@ -576,5 +570,11 @@ module Internal : sig
   end
 
   val objVariable : Id.t Libobject.Dyn.tag
+
+  (** [export_side_effects eff] makes the side effects [eff] global. This
+    usually happens at the end of a proof (during Qed or Defined), but
+    one may need to declare them by hand, for example because the
+    tactic was run as part of a command *)
+  val export_side_effects : Evd.side_effects -> unit
 
 end

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -416,6 +416,8 @@ val build_by_tactic
   -> unit Proofview.tactic
   -> Constr.constr * Constr.types option * (UState.named_universes_entry) * bool * UState.t
 
+val export_side_effects : Evd.side_effects -> unit
+
 (** {2 Program mode API} *)
 
 (** Coq's Program mode support. This mode extends declarations of

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -416,6 +416,10 @@ val build_by_tactic
   -> unit Proofview.tactic
   -> Constr.constr * Constr.types option * (UState.named_universes_entry) * bool * UState.t
 
+(** [export_side_effects eff] makes the side effects [eff] global. This
+    usually happens at the end of a proof (during Qed or Defined), but
+    one may need to declare them by hand, for example because the
+    tactic was run as part of a command *)
 val export_side_effects : Evd.side_effects -> unit
 
 (** {2 Program mode API} *)


### PR DESCRIPTION
without necessarily defining a constant (by a tactic
which has side effects)

see also https://coq.zulipchat.com/#narrow/stream/253928-Elpi-users-.26-devs/topic/Using.20.60abstract.60.20from.20Ltac1.20in.20Elpi

overlay PR:
- https://github.com/LPCIC/coq-elpi/pull/373