### PR TITLE
Issue #16262: do not override generic format if not reserved and only printing

### DIFF
--- a/doc/changelog/03-notations/16329-master+experiment-addressing16262-heuristic-redefining-notation-format.rst
+++ b/doc/changelog/03-notations/16329-master+experiment-addressing16262-heuristic-redefining-notation-format.rst
@@ -1,0 +1,9 @@
+- **Changed:**
+  an :g:`only printing` interpretation of a notation with a specific
+  format does not change any longer the printing rule of other
+  interpretations of the notation; to globally change the default
+  printing rule of all interpretations of a notation, use instead
+  :g:`Reserved Notation`
+  (`#16329 <https://github.com/coq/coq/pull/16329>`_,
+  fixes `#16262 <https://github.com/coq/coq/issues/16262>`_,
+  by Hugo Herbelin).

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -91,7 +91,7 @@ In this case, no spaces are allowed in the symbol.  Also, if the
 symbol starts with a double quote, it must be surrounded with single
 quotes to prevent confusion with the beginning of a string symbol.
 
-A notation binds a syntactic expression to a term. Unless the parser
+A notation binds a syntactic expression to a term, called its :gdef:`interpretation`. Unless the parser
 and pretty-printer of Coq already know how to deal with the syntactic
 expression (such as through :cmd:`Reserved Notation` or for notations
 that contain only literals), explicit precedences and
@@ -100,7 +100,7 @@ associativity rules have to be given.
 .. note::
 
    The right-hand side of a notation is interpreted at the time the notation is
-   given. In particular, disambiguation of constants, :ref:`implicit arguments
+   given. Disambiguation of constants, :ref:`implicit arguments
    <ImplicitArguments>` and other notations are resolved at the
    time of the declaration of the notation. The right-hand side is
    currently typed only at use time but this may change in the future.
@@ -304,7 +304,8 @@ The second, more powerful control on printing is by using :n:`@syntax_modifier`\
        (IF_then_else True False True)
        (IF_then_else True False True)).
 
-A *format* is an extension of the string denoting the notation with
+A *format* tells how to control the indentation and line breaks when printing
+a notation. It is a string extending the notation with
 the possible following elements delimited by single quotes:
 
 - tokens of the form ``'/ '`` are translated into breaking points.  If
@@ -352,13 +353,11 @@ at the time of use of the notation.
    If a given notation string occurs only in ``only printing`` rules,
    the parser is not modified at all.
 
-   To a given notation string and scope can be attached at most one
-   notation with both parsing and printing or with only
-   parsing. Contrastingly, an arbitrary number of ``only printing``
-   notations differing in their right-hand sides but only a unique
-   right-hand side can be attached to a given string and
-   scope. Obviously, expressions printed by means of such extra
-   printing rules will not be reparsed to the same form.
+   Notations used for parsing, that is notations not restricted with
+   the ``only printing`` modifier, can have only a single
+   interpretation per scope. On the other side, notations marked with
+   ``only printing`` can have multiple associated interpretations,
+   even in the same scope.
 
 .. note::
 

--- a/test-suite/output/bug_16262.out
+++ b/test-suite/output/bug_16262.out
@@ -1,0 +1,11 @@
+nat -> nat
+     : Set
+nat -> nat
+     : Set
+(1->2)%foo
+     : nat * nat
+File "./output/bug_16262.v", line 9, characters 0-116:
+Warning: Notation "_ -> _" was already defined with a different format.
+[notation-incompatible-format,parsing,default]
+nat->nat
+     : Set

--- a/test-suite/output/bug_16262.v
+++ b/test-suite/output/bug_16262.v
@@ -1,0 +1,12 @@
+Declare Scope foo.
+Delimit Scope foo with foo.
+Check (nat -> nat).
+Notation "a -> b" := (a,b)
+   (b at level 200, only printing, right associativity, at level 99,
+   format "a -> b") : foo.
+Check (nat -> nat).
+Check (1,2).
+Reserved Notation "a -> b"
+   (b at level 200, only printing, right associativity, at level 99,
+   format "a -> b").
+Check (nat -> nat).

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1646,9 +1646,13 @@ let make_generic_printing_rules reserved main_data ntn sd =
       (* No intent to define a format, we reuse the existing generic rules *)
       Some rules
     | _ ->
-      let rules' = make_rule (make_pp_rule level sd.pp_syntax_data main_data.format) in
-      check_reserved_format ntn rules rules'.notation_printing_rules;
-      Some rules'
+      if not reserved && main_data.onlyprinting then
+        (* No intent to define a generic format *)
+        Some rules
+      else
+        let rules' = make_rule (make_pp_rule level sd.pp_syntax_data main_data.format) in
+        let () = check_reserved_format ntn rules rules'.notation_printing_rules in
+        Some rules'
   with Not_found ->
     Some (make_rule (make_pp_rule level sd.pp_syntax_data main_data.format))
 


### PR DESCRIPTION
**Kind**: enhancement

This is an experimental change of heuristic about when a notation defined using the `Notation "..." := ...` syntax is liable to modify a generic printing rule.

The argument for the change is that if we want to change the generic format of an only-printing rule, we can still do it with `Reserved Notation`, while before this PR, non-`Reserved` `Notation` forces a change of generic rule (i.e. a rule associated to the parsing/printing structure of a notation) even if the intent is only to declare a specific printing rule (i.e. a rule associated to a given interpretation of a notation).

Fixes / closes #16262.

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
