### PR TITLE
Remove redundant field instance locality warning

### DIFF
--- a/test-suite/output/bug_16224.out
+++ b/test-suite/output/bug_16224.out
@@ -1,12 +1,4 @@
 File "./output/bug_16224.v", line 9, characters 0-24:
-Warning: The default value for field instance locality is currently "global",
-but is scheduled to change in a future release. For the time being, adding
-field instances without specifying an explicit locality attribute is
-therefore deprecated. It is recommended to use "export" whenever possible.
-Use the attributes #[local], #[global] and #[export] depending on your
-choice. For example: "Class foo := { #[export] field :: bar }."
-[deprecated-field-instance-without-locality,deprecated]
-File "./output/bug_16224.v", line 9, characters 0-24:
 Warning: A coercion will be introduced instead of an instance in future
 versions when using ':>' in 'Class' declarations. Replace ':>' with '::' (or
 use '#[global] Existing Instance field.' for compatibility with Coq < 8.17).

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -629,18 +629,6 @@ let warn_future_coercion_class_field =
     strbrk "A coercion will be introduced instead of an instance in future versions when using ':>' in 'Class' declarations. "
     ++ strbrk "Replace ':>' with '::' (or use '#[global] Existing Instance field.' for compatibility with Coq < 8.17). Beware that the default locality for '::' is #[export], as opposed to #[global] for ':>' currently. Add an explicit #[global] attribute to the field if you need to keep the current behavior. For example: \"Class foo := { #[global] field :: bar }.\"")
 
-(* deprecated in 8.17 (c.f., https://github.com/coq/coq/pull/16230 ) *)
-let warn_deprecated_field_instance_without_locality =
-  let open Pp in
-  CWarnings.create ~name:"deprecated-field-instance-without-locality" ~category:"deprecated"
-    (fun () -> strbrk "The default value for field instance locality is \
-    currently \"global\", but is scheduled to change in a future release. \
-    For the time being, adding field instances without specifying an explicit \
-    locality attribute is therefore deprecated. It is recommended to use \
-    \"export\" whenever possible. Use the attributes #[local], #[global] \
-    and #[export] depending on your choice. For example: \
-    \"Class foo := { #[export] field :: bar }.\"")
-
 let check_proj_flags kind rf =
   let open Vernacexpr in
   let pf_coercion, pf_reversible =
@@ -666,11 +654,6 @@ let check_proj_flags kind rf =
        if rf.rf_locality = Goptions.OptExport then
          Attributes.(unsupported_attributes
            [CAst.make ("export (without ::)",VernacFlagEmpty)])
-    (* remove following case after deprecation phase (started in 8.17,
-       c.f., https://github.com/coq/coq/pull/16230 ) *)
-    | _, BackInstanceWarning when kind_class kind <> NotClass ->
-       if rf.rf_locality = Goptions.OptDefault then
-         warn_deprecated_field_instance_without_locality ()
     | _ -> ()
     end; rf.rf_locality in
   (* remove following let after deprecation phase (started in 8.17,


### PR DESCRIPTION
It was triggered exactly at the same time than `warn_future_coercion_class_field` that tells more.

<!-- If this is a bug fix, make sure the bug was reported beforehand.
Fixes / closes #???? -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility:
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make -f Makefile.dune doc_gram_rsts`. -->

<!-- If this breaks external libraries or plugins in CI: 
- [ ] Opened **overlay** pull requests. -->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
