### PR TITLE
CI: use macos 11 instead of 10.15

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   macOS:
-    runs-on: macOS-10.15
+    runs-on: macOS-11
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
10.15 is deprecated, see
https://github.com/actions/virtual-environments/issues/5583
it causes random failures eg https://github.com/coq/coq/actions/runs/2712348619
