### PR TITLE
[v8.0] Add support for `-h` and `--help` to configure

### DIFF
--- a/configure
+++ b/configure
@@ -68,8 +68,6 @@ usage () {
     echo -e "\tAdd debugging information in the Coq executables\n"
     echo "-profile"
     echo -e "\tAdd profiling information in the Coq executables\n"
-    echo "-annotate"
-    echo -e "\tCompiles Coq with -dtypes option"
 }
 
 
@@ -102,6 +100,8 @@ COQSRC=`pwd`
 while : ; do
   case "$1" in
     "") break;;
+    -help|--help) usage
+                  exit;;
     -prefix|--prefix) prefix_spec=yes
                       prefix="$2"
 		      shift;;


### PR DESCRIPTION
d8b4083b2e865d6ab32e3aa33fa7eb50fa9c901f added a usage function without
adding support for calling it.

This will allow my scripts that configure multiple versions of Coq to
work more fluently.