### PR TITLE
[vernac] Proof mode without STM

### DIFF
--- a/dev/ci/user-overlays/16366-gares-proof-mode-no-stm.sh
+++ b/dev/ci/user-overlays/16366-gares-proof-mode-no-stm.sh
@@ -1,0 +1,1 @@
+overlay vscoq https://github.com/gares/vscoq proof-mode-no-stm 16366

--- a/dev/tools/create_overlays.sh
+++ b/dev/tools/create_overlays.sh
@@ -65,7 +65,6 @@ do
     setup_contrib_git $_CONTRIB_DIR $_CONTRIB_GITPUSHURL
 
     echo "overlay ${_CONTRIB_NAME} $_CONTRIB_GITURL $OVERLAY_BRANCH $PR_NUMBER" >> $OVERLAY_FILE
-    echo "" >> $OVERLAY_FILE
     shift
 done
 

--- a/vernac/pvernac.ml
+++ b/vernac/pvernac.ml
@@ -76,4 +76,24 @@ let main_entry proof_mode =
   Vernac_.main_entry
 
 let () =
-  register_grammar Genredexpr.wit_red_expr (Vernac_.red_expr);
+  register_grammar Genredexpr.wit_red_expr (Vernac_.red_expr)
+
+(* Default proof mode, to be set at the beginning of proofs for
+programs that cannot be statically classified. *)
+let proof_mode_opt_name = ["Default";"Proof";"Mode"]
+
+let get_default_proof_mode =
+  Goptions.declare_interpreted_string_option_and_ref
+    ~stage:Summary.Stage.Synterp
+    ~depr:false
+    ~key:proof_mode_opt_name
+    ~value:(register_proof_mode "Noedit" Vernac_.noedit_mode)
+    (fun name -> match lookup_proof_mode name with
+    | Some pm -> pm
+    | None -> CErrors.user_err Pp.(str (Format.sprintf "No proof mode named \"%s\"." name)))
+    proof_mode_to_string
+
+let current_proof_mode = Summary.ref ~stage:Summary.Stage.Synterp ~name:"proof_mode" None
+
+let get_current_proof_mode () : proof_mode option =  !current_proof_mode
+let set_current_proof_mode m = current_proof_mode := m

--- a/vernac/pvernac.mli
+++ b/vernac/pvernac.mli
@@ -53,3 +53,8 @@ val main_entry : proof_mode option -> vernac_control option Entry.t
 val register_proof_mode : string -> Vernacexpr.vernac_expr Entry.t -> proof_mode
 val lookup_proof_mode : string -> proof_mode option
 val proof_mode_to_string : proof_mode -> string
+
+val proof_mode_opt_name : string list
+val get_default_proof_mode : unit -> proof_mode
+val get_current_proof_mode : unit -> proof_mode option
+val set_current_proof_mode : proof_mode option -> unit

--- a/vernac/vernac_classifier.ml
+++ b/vernac/vernac_classifier.ml
@@ -45,7 +45,7 @@ let stm_allow_nested_proofs_option_name = ["Nested";"Proofs";"Allowed"]
 let options_affecting_stm_scheduling =
   [ Attributes.universe_polymorphism_option_name;
     stm_allow_nested_proofs_option_name;
-    Vernacinterp.proof_mode_opt_name;
+    Pvernac.proof_mode_opt_name;
     Attributes.program_mode_option_name;
     Proof_using.proof_using_opt_name;
   ]

--- a/vernac/vernacinterp.mli
+++ b/vernac/vernacinterp.mli
@@ -8,7 +8,11 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(** The main interpretation function of vernacular expressions *)
+(** The main interpretation function of vernacular expressions.
+
+    Caveat: we don't correctly handle proof modes in the case of nested proofs,
+    in particular ending the inner one does not restore the proof mode of the
+    outern one if it is not the standard one.  *)
 val interp : ?verbosely:bool -> st:Vernacstate.t -> Vernacexpr.vernac_control -> Vernacstate.t
 
 (** Execute a Qed but with a proof_object which may contain a delayed

--- a/vernac/vernacinterp.mli
+++ b/vernac/vernacinterp.mli
@@ -23,7 +23,3 @@ val interp_qed_delayed_proof
 (** Flag set when the test-suite is called. Its only effect to display
     verbose information for [Fail] *)
 val test_mode : bool ref
-
-(** Default proof mode set by `start_proof` *)
-val get_default_proof_mode : unit -> Pvernac.proof_mode
-val proof_mode_opt_name : string list

--- a/vernac/vernacstate.ml
+++ b/vernac/vernacstate.ml
@@ -10,16 +10,18 @@
 
 module Parser = struct
 
-  type t = Pcoq.frozen_t
+  type t = Pcoq.frozen_t * Pvernac.proof_mode option
 
-  let init () = Pcoq.freeze ~marshallable:false
+  let init () = Pcoq.freeze ~marshallable:false, None
 
-  let cur_state () = Pcoq.freeze ~marshallable:false
+  let cur_state () = Pcoq.freeze ~marshallable:false, Pvernac.get_current_proof_mode ()
 
-  let parse ps entry pa =
+  let set_proof_mode pm (t,_) = (t,pm)
+
+  let parse (ps,proof_mode) entry pa =
     Pcoq.unfreeze ps;
     Flags.with_option Flags.we_are_parsing
-      (fun () -> Pcoq.Entry.parse entry pa)
+      (fun () -> Pcoq.Entry.parse (entry proof_mode) pa)
       ()
 
 end
@@ -131,7 +133,8 @@ let unfreeze_interp_state { system; lemmas; program; parsing; opaques } =
   s_lemmas := lemmas;
   s_program := program;
   Opaques.Summary.unfreeze opaques;
-  Pcoq.unfreeze parsing
+  Pcoq.unfreeze (fst parsing);
+  Pvernac.set_current_proof_mode (snd parsing)
 
 (* Compatibility module *)
 module Declare_ = struct

--- a/vernac/vernacstate.mli
+++ b/vernac/vernacstate.mli
@@ -14,7 +14,8 @@ module Parser : sig
   val init : unit -> t
   val cur_state : unit -> t
 
-  val parse : t -> 'a Pcoq.Entry.t -> Pcoq.Parsable.t -> 'a
+  val set_proof_mode : Pvernac.proof_mode option -> t -> t
+  val parse : t -> (Pvernac.proof_mode option -> 'a Pcoq.Entry.t) -> Pcoq.Parsable.t -> 'a
 
 end
 


### PR DESCRIPTION
The proof mode for the current proof was handled by the STM.
We move this piece of state in Pvernac and include it into Vernacstate.Parser.t so that "the parsing state" also includes the proof mode.