### PR TITLE
Factorize the code for Print Dependent Evars.

### DIFF
--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -95,17 +95,6 @@ val has_undefined_evars : evar_map -> constr -> bool
 val is_ground_term :  evar_map -> constr -> bool
 val is_ground_env  :  evar_map -> env -> bool
 
-(** [gather_dependent_evars evm seeds] classifies the evars in [evm]
-    as dependent_evars and goals (these may overlap). A goal is an evar
-    appearing in the (partial) definition [seeds] (including defined evars). A
-    dependent evar is an evar appearing in the type
-    (hypotheses and conclusion) of a goal, or in the type or (partial)
-    definition of a dependent evar.  The value return is a map
-    associating to each dependent evar [None] if it has no (partial)
-    definition or [Some s] if [s] is the list of evars appearing in
-    its (partial) definition. *)
-val gather_dependent_evars : evar_map -> EConstr.t list -> (Evar.Set.t option) Evar.Map.t
-
 (** [advance sigma g] returns [Some g'] if [g'] is undefined and is
     the current avatar of [g] (for instance [g] was changed by [clear]
     into [g']). It returns [None] if [g] has been (partially)

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -201,8 +201,6 @@ val pr_evars_int           : evar_map -> shelf:Evar.t list -> given_up:Evar.t li
 val pr_ne_evar_set         : Pp.t -> Pp.t -> evar_map ->
   Evar.Set.t -> Pp.t
 
-val print_dependent_evars : Evar.t option -> evar_map -> Evar.t list -> Pp.t
-
 (** Declarations for the "Print Assumption" command *)
 type axiom =
   | Constant of Constant.t (* An axiom or a constant. *)

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -438,16 +438,7 @@ let process_toplevel_command ~state stm =
   | VernacShowGoal { gid; sid } ->
     let proof = Stm.get_proof ~doc:state.doc (Stateid.of_int sid) in
     let goal = Printer.pr_goal_emacs ~proof gid sid in
-    let evars =
-      match proof with
-      | None -> mt()
-      | Some p ->
-        let gl = (Evar.unsafe_of_int gid) in
-        let { Proof.sigma } = Proof.data p in
-        try Printer.print_dependent_evars (Some gl) sigma [ gl ]
-        with Not_found -> mt()
-    in
-    Feedback.msg_notice (v 0 (goal ++ evars));
+    let () = Feedback.msg_notice goal in
     state
 
   | VernacShowProofDiffs diff_opt ->


### PR DESCRIPTION
This is a horribly hacky vernac command that is only used by ProofGeneral. There is no need to expose the broken internals of this command to the OCaml plugin developer.