### PR TITLE
Do not rely on Evar.unsafe_of_int in Ltac2.

### DIFF
--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -586,7 +586,7 @@ let () = define1 "constr_make" valexpr begin fun knd ->
     let n = Value.to_int n in
     EConstr.mkMeta n
   | (3, [|evk; args|]) ->
-    let evk = Evar.unsafe_of_int (Value.to_int evk) in
+    let evk = to_evar evk in
     let args = Value.to_array Value.to_constr args in
     EConstr.mkEvar (evk, Array.to_list args)
   | (4, [|s|]) ->
@@ -954,8 +954,7 @@ let () = define0 "shelve_unifiable" begin
   Proofview.shelve_unifiable >>= fun () -> return v_unit
 end
 
-let () = define1 "new_goal" int begin fun ev ->
-  let ev = Evar.unsafe_of_int ev in
+let () = define1 "new_goal" evar begin fun ev ->
   Proofview.tclEVARMAP >>= fun sigma ->
   if Evd.mem sigma ev then
     Proofview.Unsafe.tclNEWGOALS [Proofview.with_empty_state ev] <*> Proofview.tclUNIT v_unit

--- a/plugins/ltac2/tac2ffi.ml
+++ b/plugins/ltac2/tac2ffi.ml
@@ -94,6 +94,7 @@ let val_pattern = Val.create "pattern"
 let val_preterm = Val.create "preterm"
 let val_matching_context = Val.create "matching_context"
 let val_pp = Val.create "pp"
+let val_evar = Val.create "evar"
 let val_sort = Val.create "sort"
 let val_cast = Val.create "cast"
 let val_inductive = Val.create "inductive"
@@ -233,6 +234,10 @@ let ident = repr_ext val_ident
 let of_pattern c = of_ext val_pattern c
 let to_pattern c = to_ext val_pattern c
 let pattern = repr_ext val_pattern
+
+let of_evar ev = of_ext val_evar ev
+let to_evar ev = to_ext val_evar ev
+let evar = repr_ext val_evar
 
 let internal_err =
   let open Names in

--- a/plugins/ltac2/tac2ffi.mli
+++ b/plugins/ltac2/tac2ffi.mli
@@ -129,6 +129,10 @@ val of_pattern : Pattern.constr_pattern -> valexpr
 val to_pattern : valexpr -> Pattern.constr_pattern
 val pattern : Pattern.constr_pattern repr
 
+val of_evar : Evar.t -> valexpr
+val to_evar : valexpr -> Evar.t
+val evar : Evar.t repr
+
 val of_pp : Pp.t -> valexpr
 val to_pp : valexpr -> Pp.t
 val pp : Pp.t repr
@@ -173,6 +177,7 @@ val val_ident : Id.t Val.tag
 val val_pattern : Pattern.constr_pattern Val.tag
 val val_preterm : Ltac_pretype.closed_glob_constr Val.tag
 val val_matching_context : Constr_matching.context Val.tag
+val val_evar : Evar.t Val.tag
 val val_pp : Pp.t Val.tag
 val val_sort : ESorts.t Val.tag
 val val_cast : Constr.cast_kind Val.tag


### PR DESCRIPTION
Instead we expose the Evar.t type as a internally built-in type with explicit wrapping.
