### PR TITLE
Correct short SPDX tag for coq-doc

### DIFF
--- a/coq-doc.opam
+++ b/coq-doc.opam
@@ -11,7 +11,7 @@ semi-interactive development of machine-checked proofs.
 This package provides the Coq Reference Manual."""
 maintainer: ["The Coq development team <coqdev@inria.fr>"]
 authors: ["The Coq development team, INRIA, CNRS, and contributors"]
-license: "OPL-1.0"
+license: "OPUBL-1.0"
 homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"

--- a/dune-project
+++ b/dune-project
@@ -96,7 +96,7 @@ development of interactive proofs."))
 
 (package
  (name coq-doc)
- (license "OPL-1.0")
+ (license "OPUBL-1.0")
  (depends
   (conf-python-3 :build)
   (coq (and :build (= :version))))


### PR DESCRIPTION
The Fedora project is converting license information from our homegrown system to SPDX short tags.  While looking at the coq package, I noticed that the `OPL-1.0` tags in dune-project and coq-doc.opam refer to the Open _Public_ License, while `doc/LICENSE` contains the text of the Open _Publication_ License.  The short tag for the latter is OPUBL-1.0.  See https://spdx.org/licenses/OPUBL-1.0.html.
