### PR TITLE
Reduce the surface attack of the meta API

### DIFF
--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -376,9 +376,6 @@ module Metaset = Int.Set
 
 module Metamap = Int.Map
 
-let metamap_to_list m =
-  Metamap.fold (fun n v l -> (n,v)::l) m []
-
 (*************************)
 (* Unification state *)
 
@@ -1256,14 +1253,14 @@ let set_metas evd metas = {
   extras = evd.extras;
 }
 
-let meta_list evd = metamap_to_list evd.metas
+let meta_list evd = evd.metas
 
 let undefined_metas evd =
-  let filter = function
-    | (n,Clval(_,_,typ)) -> None
-    | (n,Cltyp (_,typ))  -> Some n
+  let fold n b accu = match b with
+  | Clval(_,_,typ) -> accu
+  | Cltyp (_,typ)  -> n :: accu
   in
-  let m = List.map_filter filter (meta_list evd) in
+  let m = Metamap.fold fold evd.metas [] in
   List.sort Int.compare m
 
 let map_metas_fvalue f evd =

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1348,9 +1348,9 @@ let meta_reassign mv (v, pb) evd =
 
 let clear_metas evd = {evd with metas = Metamap.empty}
 
-let meta_merge evd1 evd2 =
-  let metas = Metamap.fold Metamap.add evd1.metas evd2.metas in
-  { evd2 with metas }
+let meta_merge metas sigma =
+  let metas = Metamap.fold Metamap.add metas sigma.metas in
+  { sigma with metas }
 
 type metabinding = metavariable * constr * instance_status
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -553,7 +553,7 @@ val evars_of_named_context : evar_map -> (econstr, etypes) Context.Named.pt -> E
 val evars_of_filtered_evar_info : evar_map -> evar_info -> Evar.Set.t
 
 (** Metas *)
-val meta_list : evar_map -> (metavariable * clbinding) list
+val meta_list : evar_map -> clbinding Metamap.t
 val meta_defined : evar_map -> metavariable -> bool
 
 val meta_value     : evar_map -> metavariable -> econstr

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -574,7 +574,7 @@ val meta_reassign  : metavariable -> econstr * instance_status -> evar_map -> ev
 val clear_metas : evar_map -> evar_map
 
 (** [meta_merge evd1 evd2] returns [evd2] extended with the metas of [evd1] *)
-val meta_merge : evar_map -> evar_map -> evar_map
+val meta_merge : clbinding Metamap.t -> evar_map -> evar_map
 
 val undefined_metas : evar_map -> metavariable list
 val map_metas_fvalue : (econstr -> econstr) -> evar_map -> evar_map

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -105,7 +105,7 @@ let pr_meta_map env sigma =
            str " : " ++ print_constr env sigma t.rebus ++
            spc () ++ pr_instance_status s ++ fnl ())
   in
-  prlist pr_meta_binding (meta_list sigma)
+  prlist pr_meta_binding (Evd.Metamap.bindings (meta_list sigma))
 
 let pr_decl env sigma (decl,ok) =
   let open NamedDecl in
@@ -305,7 +305,7 @@ let pr_evar_map_gen with_univs pr_evars env sigma =
       str "OBLIGATIONS:" ++ brk (0, 1) ++
       prlist_with_sep spc Evar.print (Evar.Set.elements evars) ++ fnl ()
   and metas =
-    if List.is_empty (Evd.meta_list sigma) then mt ()
+    if Evd.Metamap.is_empty (Evd.meta_list sigma) then mt ()
     else
       str "METAS:" ++ brk (0, 1) ++ pr_meta_map env sigma
   and shelf =

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -860,7 +860,7 @@ let applyn ~with_evars ?beta ?(with_shelve=false) ?(first_goes_last=false) n t =
       in loop sigma t [] n in
     pp(lazy(str"Refiner.refiner " ++ Printer.pr_econstr_env env sigma t));
     Tacticals.tclTHENLIST [
-      Logic.refiner ~check:false EConstr.Unsafe.(to_constr t);
+      Logic.refiner EConstr.Unsafe.(to_constr t);
       Proofview.(if first_goes_last then cycle 1 else tclUNIT ())
     ]
   end

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -847,20 +847,40 @@ let applyn ~with_evars ?beta ?(with_shelve=false) ?(first_goes_last=false) n t =
     Proofview.Goal.enter begin fun gl ->
     let sigma = Proofview.Goal.sigma gl in
     let env = Proofview.Goal.env gl in
-    let t, sigma = if n = 0 then t, sigma else
+    let sigma = Evd.push_future_goals sigma in
+    let hyps = Environ.named_context_val env in
+    let inst = EConstr.identity_subst_val hyps in
+    let identity = Evd.Identity.make inst in
+    let t, args, sigma =
       let rec loop sigma bo args = function (* saturate with metas *)
-        | 0 -> EConstr.mkApp (t, Array.of_list (List.rev args)), sigma
-        | n -> match EConstr.kind sigma bo with
+        | 0 -> (t, args, sigma)
+        | n ->
+          match EConstr.kind sigma bo with
           | Lambda (_, ty, bo) ->
-              if not (EConstr.Vars.closed0 sigma ty) then
-                raise dependent_apply_error;
-              let m = Evarutil.new_meta () in
-              loop (meta_declare m ty sigma) bo ((EConstr.mkMeta m)::args) (n-1)
+            let () = if not (EConstr.Vars.closed0 sigma ty) then raise dependent_apply_error in
+            let ty = Reductionops.nf_betaiota env sigma ty in
+            let src = Loc.tag Evar_kinds.GoalEvar in
+            let (sigma, evk) = Evarutil.new_pure_evar ~src ~typeclass_candidate:false ~identity hyps sigma ty in
+            loop sigma bo (evk :: args) (n - 1)
           | _ -> assert false
-      in loop sigma t [] n in
+      in
+      loop sigma t [] n
+    in
+    let _, sigma = Evd.pop_future_goals sigma in
     pp(lazy(str"Refiner.refiner " ++ Printer.pr_econstr_env env sigma t));
+
+    let map evk = Proofview.goal_with_state evk (Proofview.Goal.state gl) in
+    let sgl = List.rev_map map args in
+    let ans = EConstr.applist (t, List.rev_map (fun evk -> EConstr.mkEvar (evk, inst)) args) in
+    let evk = Proofview.Goal.goal gl in
+    let _ =
+      if not (Evarutil.occur_evar_upto sigma evk ans) then ()
+      else Pretype_errors.error_occur_check env sigma evk ans
+    in
+    let sigma = Evd.define evk ans sigma in
     Tacticals.tclTHENLIST [
-      Logic.refiner EConstr.Unsafe.(to_constr t);
+      Proofview.Unsafe.tclEVARS sigma;
+      Proofview.Unsafe.tclSETGOALS sgl;
       Proofview.(if first_goes_last then cycle 1 else tclUNIT ())
     ]
   end

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -948,7 +948,6 @@ let thin id sigma goal =
   let evi = Evd.find sigma goal in
   let env = Evd.evar_filtered_env (Global.env ()) evi in
   let cl = Evd.evar_concl evi in
-  let sigma = Evd.clear_metas sigma in
   let ans =
     try Some (Evarutil.clear_hyps_in_evi env sigma (Environ.named_context_val env) cl ids)
     with Evarutil.ClearDependencyError _ -> None

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1498,11 +1498,11 @@ let w_merge env with_types flags (evd,metas,evars : subst0) =
 
   let check_types evd =
     let metas = Evd.meta_list evd in
-    let eqns = List.fold_left (fun acc (mv, b) ->
+    let eqns = Metamap.fold (fun mv b acc ->
       match b with
       | Clval (n, (t, (c, TypeNotProcessed)), v) -> (mv, c, t.rebus) :: acc
-      | _ -> acc) [] metas
-    in w_merge_rec evd [] [] eqns
+      | _ -> acc) metas []
+    in w_merge_rec evd [] [] (List.rev eqns)
   in
   let res =  (* merge constraints *)
     w_merge_rec evd (order_metas metas)

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -424,7 +424,7 @@ let clenv_instantiate ?(flags=fchain_flags ()) mv clenv (c, ty) =
 
 let clenv_fchain ?(flags=fchain_flags ()) mv clenv nextclenv =
   (* Add the metavars of [nextclenv] to [clenv], with their name-environment *)
-  let evd = meta_merge nextclenv.evd clenv.evd in
+  let evd = meta_merge (Evd.meta_list nextclenv.evd) clenv.evd in
   let clenv' =
     { templval = clenv.templval;
       templtyp = clenv.templtyp;

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -637,7 +637,7 @@ let res_pf ?(with_evars=false) ?(with_classes=true) ?(flags=dft ()) clenv =
     let clenv = update_clenv_evd clenv evd' in
     Proofview.tclTHEN
       (Proofview.Unsafe.tclEVARS (Evd.clear_metas evd'))
-      (refiner ~check:false EConstr.Unsafe.(to_constr (clenv_cast_meta clenv (clenv_value clenv))))
+      (Logic.refiner EConstr.Unsafe.(to_constr (clenv_cast_meta clenv (clenv_value clenv))))
   end
 
 (* [unifyTerms] et [unify] ne semble pas gérer les Meta, en

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -50,7 +50,6 @@ let update_clenv_evd clenv evd =
 let cl_env ce = ce.env
 let cl_sigma ce =  ce.evd
 
-let clenv_term clenv c = meta_instance clenv.env clenv.cache c
 let clenv_meta_type clenv mv =
   let ty =
     try Evd.meta_ftype clenv.evd mv
@@ -421,27 +420,6 @@ let clenv_instantiate ?(flags=fchain_flags ()) mv clenv (c, ty) =
   (* unify the type of the template of [nextclenv] with the type of [mv] *)
   let clenv = clenv_unify ~flags CUMUL ty (clenv_meta_type clenv mv) clenv in
   clenv_assign mv c clenv
-
-let clenv_fchain ?(flags=fchain_flags ()) mv clenv nextclenv =
-  (* Add the metavars of [nextclenv] to [clenv], with their name-environment *)
-  let evd = meta_merge (Evd.meta_list nextclenv.evd) clenv.evd in
-  let clenv' =
-    { templval = clenv.templval;
-      templtyp = clenv.templtyp;
-      evd;
-      env = nextclenv.env;
-      cache = create_meta_instance_subst evd } in
-  (* unify the type of the template of [nextclenv] with the type of [mv] *)
-  let clenv'' =
-    clenv_unify ~flags CUMUL
-      (clenv_term clenv' nextclenv.templtyp)
-      (clenv_meta_type clenv' mv)
-      clenv' in
-  (* assign the metavar *)
-  let clenv''' =
-    clenv_assign mv (clenv_term clenv' nextclenv.templval) clenv''
-  in
-  clenv'''
 
 (***************************************************************)
 (* Bindings *)

--- a/proofs/clenv.mli
+++ b/proofs/clenv.mli
@@ -51,9 +51,6 @@ val mk_clenv_from_n : env -> evar_map -> int -> EConstr.constr * EConstr.types -
 
 val clenv_instantiate : ?flags:unify_flags -> metavariable -> clausenv -> (constr * types) -> clausenv
 
-val clenv_fchain :
-  ?flags:unify_flags -> metavariable -> clausenv -> clausenv -> clausenv
-
 (** {6 Unification with clenvs } *)
 
 (** Unifies two terms in a clenv. The boolean is [allow_K] (see [Unification]) *)

--- a/proofs/logic.mli
+++ b/proofs/logic.mli
@@ -26,7 +26,7 @@ open Evd
 
 (** The primitive refiner. *)
 
-val refiner : check:bool -> constr -> unit Proofview.tactic
+val refiner : constr -> unit Proofview.tactic
 
 (** {6 Refiner errors. } *)
 

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -1256,7 +1256,6 @@ let sig_clausal_form env sigma sort_of_ty siglen ty dflt =
         let sigma, exist_term = Evd.fresh_global env sigma sigdata.intro in
         sigma, applist(exist_term,[a;p_i_minus_1;ev;tuple_tail])
   in
-  let sigma = Evd.clear_metas sigma in
   let sigma, scf = sigrec_clausal_form sigma siglen ty in
   sigma, Evarutil.nf_evar sigma scf
 

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -1848,8 +1848,8 @@ let check_evar_map_of_evars_defs env evd =
          (Logic.RefinerError (env, evd, Logic.UnresolvedBindings [Evd.meta_name evd m]))
      end)
  in
-  List.iter
-   (fun (_,binding) ->
+  Evd.Metamap.iter
+   (fun _ binding ->
      match binding with
         Evd.Cltyp (_,{Evd.rebus=rebus; Evd.freemetas=freemetas}) ->
          check_freemetas_is_empty rebus freemetas

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1545,7 +1545,7 @@ let general_elim_clause with_evars flags where (c, ty) elim =
        | _  -> error IllFormedEliminationType)
   in
   (* Assumes that the metas of [c] are part of [sigma] already *)
-  let elimclause = Clenv.update_clenv_evd elimclause (meta_merge sigma elimclause.Clenv.evd) in
+  let elimclause = Clenv.update_clenv_evd elimclause (meta_merge (Evd.meta_list sigma) elimclause.Clenv.evd) in
   match where with
   | None ->
     let elimclause = clenv_instantiate ~flags indmv elimclause (c, ty) in
@@ -1568,7 +1568,7 @@ let general_elim with_evars clear_flag (c, lbindc) elim =
   let id = try Some (destVar sigma c) with DestKO -> None in
   let t = try snd (reduce_to_quantified_ind env sigma ct) with UserError _ -> ct in
   let indclause  = make_clenv_binding env sigma (c, t) lbindc in
-  let sigma = meta_merge sigma indclause.evd in
+  let sigma = meta_merge (Evd.meta_list sigma) indclause.evd in
   let flags = elim_flags () in
   Proofview.Unsafe.tclEVARS sigma <*>
   Tacticals.tclTHEN

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1902,7 +1902,12 @@ let progress_with_clause flags (id, t) clause mvs =
   if List.is_empty mvs then raise UnableToApply;
   let f mv =
     let rec find innerclause =
-      try Some (clenv_fchain mv ~flags clause innerclause)
+      try
+        let clause =
+          Clenv.update_clenv_evd clause
+            (meta_merge (Evd.meta_list innerclause.Clenv.evd) clause.Clenv.evd)
+        in
+        Some (clenv_instantiate mv ~flags clause (clenv_value innerclause, clenv_type innerclause))
       with e when noncritical e ->
       match clenv_push_prod innerclause with
       | Some (_, _, innerclause) -> find innerclause

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1567,10 +1567,9 @@ let general_elim with_evars clear_flag (c, lbindc) elim =
   let ct = Retyping.get_type_of env sigma c in
   let id = try Some (destVar sigma c) with DestKO -> None in
   let t = try snd (reduce_to_quantified_ind env sigma ct) with UserError _ -> ct in
-  let indclause  = make_clenv_binding env sigma (c, t) lbindc in
-  let sigma = meta_merge (Evd.meta_list sigma) indclause.evd in
+  let indclause = make_clenv_binding env sigma (c, t) lbindc in
   let flags = elim_flags () in
-  Proofview.Unsafe.tclEVARS sigma <*>
+  Proofview.Unsafe.tclEVARS indclause.evd <*>
   Tacticals.tclTHEN
     (general_elim_clause with_evars flags None (clenv_value indclause, clenv_type indclause) elim)
     (apply_clear_request clear_flag (use_clear_hyp_by_default ()) id)

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1454,7 +1454,7 @@ let clenv_refine_in ?err with_evars targetid replace sigma0 clenv tac =
   if not with_evars && occur_meta evd new_hyp_typ then
     error (CannotFindInstance (new_hyp_typ,clenv));
   let new_hyp_prf = clenv_value clenv in
-  let exact_tac = Logic.refiner ~check:false EConstr.Unsafe.(to_constr new_hyp_prf) in
+  let exact_tac = Logic.refiner EConstr.Unsafe.(to_constr new_hyp_prf) in
   let naming = NamingMustBe (CAst.make targetid) in
   Tacticals.tclTHEN
     (Proofview.Unsafe.tclEVARS (clear_metas evd))

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1425,7 +1425,7 @@ let cut c =
 let check_unresolved_evars_of_metas sigma clenv =
   (* This checks that Metas turned into Evars by *)
   (* Refiner.pose_all_metas_as_evars are resolved *)
-  List.iter (fun (mv,b) -> match b with
+  Metamap.iter (fun mv b -> match b with
   | Clval (_,(c,_),_) ->
     (match Constr.kind (EConstr.Unsafe.to_constr c.rebus) with
     | Evar (evk,_) when Evd.is_undefined clenv.evd evk


### PR DESCRIPTION
This is a cleanup PR that removes some functions from the legacy meta-based engine, and reduces the amount of dubious code that still relies on it.