### PR TITLE
Allow Ltac2 notations from within Ltac1

### DIFF
--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -1892,6 +1892,9 @@ It has the same typing rules as `ltac2:()` except the expression must have type 
      idtac v.
    Abort.
 
+.. cmd:: Ltac2 Ltac1 Notation @ltac2def_ltac1
+   :undocumented:
+
 Switching between Ltac languages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -700,6 +700,7 @@ command: [
 | "Print" "Ltac2" "Signatures"      (* ltac2 plugin *)
 | "Ltac2" "Check" ltac2_expr6      (* ltac2 plugin *)
 | "Ltac2" "Globalize" ltac2_expr6      (* ltac2 plugin *)
+| "Ltac2" "Ltac1" "Notation" ltac2def_ltac1      (* ltac2_ltac1 plugin *)
 ]
 
 reference_or_constr: [
@@ -3349,5 +3350,18 @@ tac2mode: [
 ltac1_expr_in_env: [
 | test_ltac1_env LIST0 identref "|-" ltac_expr5      (* ltac2_ltac1 plugin *)
 | ltac_expr5      (* ltac2_ltac1 plugin *)
+]
+
+tac2def_ltac1_notation: [
+| LIST1 ltac2_scope G_LTAC2_LTAC1_syn_level ":=" ltac2_expr6      (* ltac2_ltac1 plugin *)
+]
+
+G_LTAC2_LTAC1_syn_level: [
+|      (* ltac2_ltac1 plugin *)
+| ":" Prim.natural      (* ltac2_ltac1 plugin *)
+]
+
+ltac2def_ltac1: [
+| tac2def_ltac1_notation      (* ltac2_ltac1 plugin *)
 ]
 

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -982,6 +982,7 @@ command: [
 | "Print" "Ltac2" "Signatures"      (* ltac2 plugin *)
 | "Ltac2" "Check" ltac2_expr      (* ltac2 plugin *)
 | "Ltac2" "Globalize" ltac2_expr      (* ltac2 plugin *)
+| "Ltac2" "Ltac1" "Notation" ltac2def_ltac1      (* ltac2_ltac1 plugin *)
 | "Hint" "Resolve" LIST1 [ qualid | one_term ] OPT hint_info OPT ( ":" LIST1 ident )
 | "Hint" "Resolve" [ "->" | "<-" ] LIST1 qualid OPT natural OPT ( ":" LIST1 ident )
 | "Hint" "Immediate" LIST1 [ qualid | one_term ] OPT ( ":" LIST1 ident )
@@ -2029,6 +2030,18 @@ ltac2_scope: [
 | integer      (* ltac2 plugin *)
 | name      (* Ltac2 plugin *)
 | name "(" LIST1 ltac2_scope SEP "," ")"      (* Ltac2 plugin *)
+]
+
+tac2def_ltac1_notation: [
+| LIST1 ltac2_scope OPT G_LTAC2_LTAC1_syn_level ":=" ltac2_expr      (* ltac2_ltac1 plugin *)
+]
+
+G_LTAC2_LTAC1_syn_level: [
+| ":" natural      (* ltac2_ltac1 plugin *)
+]
+
+ltac2def_ltac1: [
+| tac2def_ltac1_notation      (* ltac2_ltac1 plugin *)
 ]
 
 ltac2_expr: [

--- a/plugins/ltac2/g_ltac2.mlg
+++ b/plugins/ltac2/g_ltac2.mlg
@@ -111,6 +111,7 @@ let tac2def_syn = Entry.make "tac2def_syn"
 let tac2def_mut = Entry.make "tac2def_mut"
 let tac2mode = Entry.make "ltac2_command"
 let ltac2_atom = Entry.make "ltac2_atom"
+let ltac2_scope = Entry.make "ltac2_scope"
 
 let tac2expr_in_env = Tac2entries.Pltac.tac2expr_in_env
 
@@ -140,7 +141,7 @@ let opt_fun ?loc args ty e =
 
 GRAMMAR EXTEND Gram
   GLOBAL: ltac2_expr ltac2_type tac2def_val tac2def_typ tac2def_ext tac2def_syn
-          tac2def_mut tac2expr_in_env ltac2_atom;
+          tac2def_mut tac2expr_in_env ltac2_atom ltac2_scope;
   tac2pat:
     [ "1" LEFTA
       [ qid = Prim.qualid; pl = LIST1 tac2pat LEVEL "0" -> {

--- a/plugins/ltac2/g_ltac2.mli
+++ b/plugins/ltac2/g_ltac2.mli
@@ -68,3 +68,5 @@ val wit_ltac2_expr : Tac2expr.raw_tacexpr Genarg.vernac_genarg_type
 val ltac2_expr : Tac2expr.raw_tacexpr Pcoq.Entry.t
 
 val ltac2_atom : Tac2expr.raw_tacexpr Pcoq.Entry.t
+
+val ltac2_scope : Tac2expr.sexpr Pcoq.Entry.t

--- a/plugins/ltac2/tac2entries.mli
+++ b/plugins/ltac2/tac2entries.mli
@@ -47,6 +47,8 @@ val register_scope : Id.t -> scope_interpretation -> unit
 val parse_scope : sexpr -> scope_rule
 (** Use this to interpret the subscopes for interpretation functions *)
 
+val ltac2_notation_cat : Libobject.category
+
 (** {5 Inspecting} *)
 
 val print_located_tactic : Libnames.qualid -> unit

--- a/plugins/ltac2_ltac1/g_ltac2_ltac1.mlg
+++ b/plugins/ltac2_ltac1/g_ltac2_ltac1.mlg
@@ -12,13 +12,17 @@ DECLARE PLUGIN "coq-core.plugins.ltac2_ltac1"
 
 {
 
+open Pcoq
 open Pcoq.Prim
+open Attributes
 open Ltac2_plugin
 open Tac2expr
 open Ltac_plugin
 open Ltac2_plugin.G_ltac2
 
 let ltac_expr = Pltac.ltac_expr
+
+let tac2def_ltac1_notation = Entry.make "tac2def_ltac1_notation"
 
 let inj_wit wit loc x = CAst.make ~loc @@ CTacExt (wit, x)
 
@@ -28,7 +32,7 @@ let inj_ltac1val loc e = inj_wit Tac2quote_ltac1.wit_ltac1val loc e
 }
 
 GRAMMAR EXTEND Gram
-  GLOBAL: ltac2_atom;
+  GLOBAL: ltac2_atom tac2def_ltac1_notation;
   ltac2_atom: TOP
   [ [ IDENT "ltac1"; ":"; "("; qid = ltac1_expr_in_env; ")" -> { inj_ltac1 loc qid }
     | IDENT "ltac1val"; ":"; "("; qid = ltac1_expr_in_env; ")" -> { inj_ltac1val loc qid } ] ]
@@ -38,4 +42,35 @@ GRAMMAR EXTEND Gram
       | e = ltac_expr -> { [], e }
     ] ]
   ;
+  tac2def_ltac1_notation:
+    [ [ toks = LIST1 ltac2_scope; n = syn_level; ":=";
+        e = ltac2_expr ->
+        { (toks, n, e) }
+    ] ]
+  ;
+  syn_level:
+    [ [ -> { None }
+      | ":"; n = Prim.natural -> { Some n }
+    ] ]
+  ;
+END
+
+{
+
+let pr_ltac2def_ltac1 _ = Pp.mt () (* FIXME *)
+
+}
+VERNAC ARGUMENT EXTEND ltac2def_ltac1
+PRINTED BY { pr_ltac2def_ltac1 }
+| [ tac2def_ltac1_notation(e) ] -> { e }
+END
+
+VERNAC COMMAND EXTEND Ltac2Ltac1Notation
+| #[ raw_attributes ] [ "Ltac2" "Ltac1" "Notation" ltac2def_ltac1(e) ] => { Vernacextend.(VtSideff ([], VtNow)) } SYNTERP AS synterpv {
+    let (toks, n, body) = e in
+    Tac2entries_ltac1.register_ltac1_notation raw_attributes toks n body
+  } ->
+  {
+    Tac2entries_ltac1.register_ltac1_notation_interpretation synterpv
+  }
 END

--- a/plugins/ltac2_ltac1/tac2entries_ltac1.ml
+++ b/plugins/ltac2_ltac1/tac2entries_ltac1.ml
@@ -1,0 +1,263 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Pp
+open Util
+open CAst
+open CErrors
+open Names
+open Libobject
+
+open Ltac2_plugin
+
+open Tac2expr
+
+let check_lowercase {loc;v=id} =
+  if Tac2env.is_constructor (Libnames.qualid_of_ident id) then
+    user_err ?loc (str "The identifier " ++ Id.print id ++ str " must be lowercase")
+
+(** Parsing *)
+
+type 'a token =
+| TacTerm of string
+| TacNonTerm of Name.t * 'a
+
+type scope_rule =
+| ScopeRule : (raw_tacexpr, _, 'a) Pcoq.Symbol.t * ('a -> raw_tacexpr) -> scope_rule
+
+type scope_interpretation = sexpr list -> scope_rule
+
+let scope_table : scope_interpretation Id.Map.t ref = ref Id.Map.empty
+
+module ParseToken =
+struct
+
+let loc_of_token = function
+| SexprStr {loc} -> loc
+| SexprInt {loc} -> loc
+| SexprRec (loc, _, _) -> Some loc
+
+let parse_scope = function
+| SexprRec (_, {loc;v=Some id}, toks) ->
+  if Id.Map.mem id !scope_table then
+    Id.Map.find id !scope_table toks
+  else
+    CErrors.user_err ?loc (str "Unknown scope" ++ spc () ++ Names.Id.print id)
+| SexprStr {v=str} ->
+  let v_unit = CAst.make @@ CTacCst (AbsKn (Tuple 0)) in
+  ScopeRule (Pcoq.Symbol.token (Tok.PIDENT (Some str)), (fun _ -> v_unit))
+| tok ->
+  let loc = loc_of_token tok in
+  CErrors.user_err ?loc (str "Invalid parsing token")
+
+let parse_token = function
+| SexprStr {v=s} -> TacTerm s
+| SexprRec (_, na, [tok]) ->
+  let na = match na.CAst.v with
+  | None -> Anonymous
+  | Some id ->
+    let () = check_lowercase (CAst.make ?loc:na.CAst.loc id) in
+    Name id
+  in
+  let scope = parse_scope tok in
+  TacNonTerm (na, scope)
+| tok ->
+  let loc = loc_of_token tok in
+  CErrors.user_err ?loc (str "Invalid parsing token")
+
+let rec print_scope = function
+| SexprStr s -> str s.CAst.v
+| SexprInt i -> int i.CAst.v
+| SexprRec (_, {v=na}, []) -> Option.cata Id.print (str "_") na
+| SexprRec (_, {v=na}, e) ->
+  Option.cata Id.print (str "_") na ++ str "(" ++ pr_sequence print_scope e ++ str ")"
+
+let print_token = function
+| SexprStr {v=s} -> quote (str s)
+| SexprRec (_, {v=na}, [tok]) -> print_scope tok
+| _ -> assert false
+
+end
+
+type ('self, 'r) nrule =
+| NRule :
+  ('self, Gramlib.Grammar.norec, 'act, Loc.t -> 'r) Pcoq.Rule.t *
+  ((Loc.t -> (Name.t * raw_tacexpr) list -> 'r) -> 'act) -> ('self, 'r) nrule
+
+let rec get_norec_rule : type self r. scope_rule token list -> (self, r) nrule = function
+| [] -> NRule (Pcoq.Rule.stop, fun k loc -> k loc [])
+| TacNonTerm (na, ScopeRule (scope, inj)) :: tok ->
+  let NRule (rule, act) = get_norec_rule tok in
+  let scope = match Pcoq.generalize_symbol scope with
+  | None -> user_err Pp.(str "Ltac1 notations cannot mention recursive scopes like \"self\"")
+  | Some scope -> scope
+  in
+  let rule = Pcoq.Rule.next_norec rule scope in
+  let act k e = act (fun loc acc -> k loc ((na, inj e) :: acc)) in
+  NRule (rule, act)
+| TacTerm t :: tok ->
+  let NRule (rule, act) = get_norec_rule tok in
+  let rule = Pcoq.(Rule.next_norec rule (Symbol.token (Pcoq.terminal t))) in
+  let act k _ = act k in
+  NRule (rule, act)
+
+let deprecated_ltac2_notation =
+  Deprecation.create_warning
+    ~object_name:"Ltac2 in Ltac1 notation"
+    ~warning_name_if_no_since:"deprecated-ltac2-in-ltac1-notation"
+    (fun (toks : sexpr list) -> pr_sequence ParseToken.print_token toks)
+
+let cache_synext_interp (local,kn,tac) =
+  Tac2env.define_notation kn (UntypedNota tac)
+
+let open_synext_interp i o =
+  if Int.equal i 1 then cache_synext_interp o
+
+let subst_synext_interp (subst, (local,kn,tac as o)) =
+  let tac' = Tac2intern.subst_rawexpr subst tac in
+  let kn' = Mod_subst.subst_kn subst kn in
+  if kn' == kn && tac' == tac then o else
+  (local, kn', tac')
+
+let classify_synext_interp (local,_,_) =
+  if local then Dispose else Substitute
+
+let inTac2NotationInterp : (bool*KerName.t*raw_tacexpr) -> obj =
+  declare_object {(default_object "TAC2-IN-TAC1-NOTATION-INTERP") with
+     cache_function  = cache_synext_interp;
+     open_function   = simple_open ~cat:Tac2entries.ltac2_notation_cat open_synext_interp;
+     subst_function = subst_synext_interp;
+     classify_function = classify_synext_interp}
+
+let rec string_of_scope = function
+| SexprStr s -> Printf.sprintf "str(%s)" s.CAst.v
+| SexprInt i -> Printf.sprintf "int(%i)" i.CAst.v
+| SexprRec (_, {v=na}, []) -> Option.cata Id.to_string "_" na
+| SexprRec (_, {v=na}, e) ->
+  Printf.sprintf "%s(%s)" (Option.cata Id.to_string "_" na) (String.concat " " (List.map string_of_scope e))
+
+let string_of_token = function
+| SexprStr {v=s} -> Printf.sprintf "str(%s)" s
+| SexprRec (_, {v=na}, [tok]) -> string_of_scope tok
+| _ -> assert false
+
+let make_fresh_key tokens =
+  let prods = String.concat "_" (List.map string_of_token tokens) in
+  (* We embed the hash of the kernel name in the label so that the identifier
+      should be mostly unique. This ensures that including two modules
+      together won't confuse the corresponding labels. *)
+  let hash = (ModPath.hash (Lib.current_mp ())) land 0x7FFFFFFF in
+  let lbl = Id.of_string_soft (Printf.sprintf "%s_%08X" prods hash) in
+  Lib.make_kn lbl
+
+type notation_interpretation_data =
+| Synext of bool * KerName.t * Id.Set.t * raw_tacexpr
+
+type tac1ext = {
+  tac1ext_kn : KerName.t;
+  tac1ext_tok : sexpr list;
+  tac1ext_lev : int;
+  tac1ext_loc : bool;
+  tac1ext_depr : Deprecation.t option;
+}
+
+let perform_ltac1_notation syn st =
+  let tok = List.rev_map ParseToken.parse_token syn.tac1ext_tok in
+  let NRule (rule, act) = get_norec_rule tok in
+  let mk loc args =
+    let () = match syn.tac1ext_depr with
+    | None -> ()
+    | Some depr -> deprecated_ltac2_notation ~loc (syn.tac1ext_tok, depr)
+    in
+    let map (na, e) =
+      ((CAst.make ?loc:e.loc @@ na), e)
+    in
+    let bnd = List.map map args in
+    let ast = CAst.make ~loc @@ CTacSyn (bnd, syn.tac1ext_kn) in
+    let ast = Genarg.in_gen (Genarg.rawwit Tac2env.wit_ltac2in1) ([], ast) in
+    let open Ltac_plugin.Tacexpr in
+    CAst.make ~loc @@ (TacArg (TacGeneric (Some "ltac2", ast)))
+  in
+  let rule = Pcoq.Production.make rule (act mk) in
+  let entry, pos =
+    let open Ltac_plugin in
+    if Int.equal syn.tac1ext_lev 0 then
+      Pltac.simple_tactic, None
+    else if 1 <= syn.tac1ext_lev && syn.tac1ext_lev <= 5 then
+      Pltac.ltac_expr, Some (string_of_int syn.tac1ext_lev)
+    else
+      user_err Pp.(str ("Invalid Tactic Notation level: "^(string_of_int syn.tac1ext_lev)^"."))
+  in
+  let rule = Pcoq.Reuse (pos, [rule]) in
+  ([Pcoq.ExtendRule (entry, rule)], st)
+
+let ltac2_in_ltac1_notation =
+  Pcoq.create_grammar_command "ltac2-in-ltac1-notation"
+    { gext_fun = perform_ltac1_notation; gext_eq = (==) (* FIXME *) }
+
+let cache_tac1ext syn =
+  Pcoq.extend_grammar_command ltac2_in_ltac1_notation syn
+
+let open_tac1ext i syn =
+  if Int.equal i 1 then Pcoq.extend_grammar_command ltac2_in_ltac1_notation syn
+
+let subst_tac1ext (subst, syn) =
+  let kn = Mod_subst.subst_kn subst syn.tac1ext_kn in
+  if kn == syn.tac1ext_kn then syn else { syn with tac1ext_kn = kn }
+
+let classify_tac1ext o =
+  if o.tac1ext_loc then Dispose else Substitute
+
+let inTac1Notation : tac1ext -> obj =
+  declare_object {(default_object "TAC2INTAC1-NOTATION") with
+     cache_function  = cache_tac1ext;
+     object_stage = Summary.Stage.Synterp;
+     open_function   = simple_open ~cat:Tac2entries.ltac2_notation_cat open_tac1ext;
+     subst_function = subst_tac1ext;
+     classify_function = classify_tac1ext}
+
+let register_ltac1_notation atts tkn lev body =
+  let deprecation, local = Attributes.(parse Notations.(deprecation ++ locality)) atts in
+  let local = Option.default false local in
+  match tkn, lev with
+  | [SexprRec (_, {loc;v=Some id}, [])], None ->
+    (* Tactic abbreviation *)
+    user_err (str "Abbreviations are not allowed for Ltac1")
+  | _ ->
+    (* Check that the tokens make sense *)
+    let entries = List.map ParseToken.parse_token tkn in
+    let fold accu tok = match tok with
+    | TacTerm _ -> accu
+    | TacNonTerm (Name id, _) -> Id.Set.add id accu
+    | TacNonTerm (Anonymous, _) -> accu
+    in
+    let ids = List.fold_left fold Id.Set.empty entries in
+    let key = make_fresh_key tkn in
+    let () =
+      let lev = match lev with
+      | Some n ->
+        n (* FIXME: check that it makes sense *)
+      | None -> 5
+      in
+      let ext = {
+        tac1ext_kn = key;
+        tac1ext_tok = tkn;
+        tac1ext_lev = lev;
+        tac1ext_loc = local;
+        tac1ext_depr = deprecation;
+      } in
+      Lib.add_leaf (inTac1Notation ext)
+    in
+    Synext (local, key, ids, body)
+
+let register_ltac1_notation_interpretation = function
+  | Synext (local, kn, ids, body) ->
+    let body = Tac2intern.globalize ids body in
+    Lib.add_leaf (inTac2NotationInterp (local,kn,body))

--- a/plugins/ltac2_ltac1/tac2entries_ltac1.mli
+++ b/plugins/ltac2_ltac1/tac2entries_ltac1.mli
@@ -1,0 +1,19 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Ltac2_plugin
+open Tac2expr
+
+type notation_interpretation_data
+
+val register_ltac1_notation : Attributes.vernac_flags -> sexpr list ->
+  int option -> raw_tacexpr -> notation_interpretation_data
+
+val register_ltac1_notation_interpretation : notation_interpretation_data -> unit


### PR DESCRIPTION
This is preliminary work to check that the design aligns with the requirements of the people who asked for this feature.

This PR adds a new Ltac2 vernacular command of the form
```coq
Ltac2 Ltac1 Notation ...
```
which follows the same syntax as the `Ltac2 Notation` but instead as adding the notation as an Ltac2 syntax, it adds it into the Ltac1 grammar. For instance, the following works.

```coq
Require Import Ltac2.Ltac2.

Require Import Ltac2.Printf.

Ltac2 Ltac1 Notation "printme" c(constr) : 5 := printf "%t" c.

Set Default Proof Mode "Classic".

Goal True.
Proof.
printme (nat -> nat). (* prints "nat -> nat" *)
Abort.
``` 

~~Voluntary limitation: no Ltac1 variable can be accessed from the Ltac2 notation.~~

Since it is reasonable to handle the special case of Ltac2 variables and defer their evaluation to the Ltac1 runtime, I've tweaked the PR to handle scopeless variables in Ltac1-to-Ltac2 notation as if they were bound by the Ltac1 quotation. That is,
```coq
Ltac2 Ltac1 Notation "foo" x := tac.
```
makes `foo y` behave as `let f := ltac2:(x |- tac) in f y`. All scopeless variables are similarly extruded, and additional scoped bindings behave as if they were inlined inside the quotation.

TODO:
- [ ] Bikeshed the syntax
- [ ] Write documentation / tests
- [ ] Fix scoping to be somewhat hygienic
