### PR TITLE
Remove the unused assert_before_replacing tactic from the API.

### DIFF
--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -626,7 +626,6 @@ let assert_before_gen b naming t =
   assert_before_then_gen b naming t (fun _ -> Proofview.tclUNIT ())
 
 let assert_before na = assert_before_gen false (naming_of_name na)
-let assert_before_replacing id = assert_before_gen true (NamingMustBe (CAst.make id))
 
 let replace_error_option err tac =
   match err with

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -358,7 +358,6 @@ val intros_transitivity         : constr option -> unit Proofview.tactic
 
 (** {6 Cut tactics. } *)
 
-val assert_before_replacing: Id.t -> types -> unit Proofview.tactic
 val assert_after_replacing : Id.t -> types -> unit Proofview.tactic
 val assert_before : Name.t -> types -> unit Proofview.tactic
 val assert_after  : Name.t -> types -> unit Proofview.tactic


### PR DESCRIPTION
Trivial cleanup I wrote once.