### PR TITLE
Efficient implementation of the intros ** / intros * tactics.

### DIFF
--- a/test-suite/output/Show.out
+++ b/test-suite/output/Show.out
@@ -1,10 +1,10 @@
-3 goals (ID 29)
+3 goals (ID 27)
   
   H : 0 = 0
   ============================
   1 = 1
 
-goal 2 (ID 33) is:
+goal 2 (ID 31) is:
  1 = S (S m')
-goal 3 (ID 20) is:
+goal 3 (ID 18) is:
  S (S n') = S m


### PR DESCRIPTION
After this patch, these tactics fill the goal in a one pass, generating a single evar.

Fixes:
- https://github.com/coq/coq/issues/8244