### PR TITLE
Deprecated undocumented and unused `>` clear modifier.

### DIFF
--- a/doc/changelog/04-tactics/16407-deprecate-keep-clear.rst
+++ b/doc/changelog/04-tactics/16407-deprecate-keep-clear.rst
@@ -1,0 +1,6 @@
+- **Deprecated:**
+  `>` clear modifier that could be used in some tactics like
+  :tacn:`apply` and :tacn:`rewrite` but was never documented.
+  Open an issue if you actually depend on this feature
+  (`#16407 <https://github.com/coq/coq/pull/16407>`_,
+  by Théo Zimmermann).

--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -679,7 +679,7 @@ Applying theorems
    :tacn:`refine` tactic. ``"ho-unification"`` prints information
    about higher order heuristics.
 
-.. tacn:: apply {+, {? > } @one_term_with_bindings } {? @in_hyp_as }
+.. tacn:: apply {+, @one_term_with_bindings } {? @in_hyp_as }
 
    .. insertprodn in_hyp_as as_ipat
 
@@ -986,7 +986,7 @@ Applying theorems
          Show Proof.     (* apply has instantiated P with (fun n : nat => n + y = y + n)
                         and the goal can be proven *)
 
-   .. tacn:: eapply {+, {? > } @one_term_with_bindings } {? @in_hyp_as }
+   .. tacn:: eapply {+, @one_term_with_bindings } {? @in_hyp_as }
 
       Behaves like :tacn:`apply`, but creates
       :ref:`existential variables <Existential-Variables>`
@@ -1009,7 +1009,7 @@ Applying theorems
       Note that you must :n:`Require Import Coq.Program.Tactics` to
       use :tacn:`rapply`.
 
-   .. tacn:: simple apply {+, {? > } @one_term_with_bindings } {? @in_hyp_as }
+   .. tacn:: simple apply {+, @one_term_with_bindings } {? @in_hyp_as }
 
       Behaves like :tacn:`apply` but it reasons modulo conversion only on subterms
       that contain no variables to instantiate and does not traverse tuples.
@@ -1030,7 +1030,7 @@ Applying theorems
       faster than :tacn:`apply` and it is thus well-suited for use in user-defined
       tactics that backtrack often.
 
-   .. tacn:: simple eapply {+, {? > } @one_term_with_bindings } {? @in_hyp_as }
+   .. tacn:: simple eapply {+, @one_term_with_bindings } {? @in_hyp_as }
       :undocumented:
 
    .. tacn:: lapply @one_term

--- a/doc/sphinx/proofs/writing-proofs/equality.rst
+++ b/doc/sphinx/proofs/writing-proofs/equality.rst
@@ -102,7 +102,7 @@ Rewriting with Leibniz and setoid equality
    .. insertprodn oriented_rewriter oriented_rewriter
 
    .. prodn::
-      oriented_rewriter ::= {? {| -> | <- } } {? @natural } {? {| ? | ! } } {? > } @one_term_with_bindings
+      oriented_rewriter ::= {? {| -> | <- } } {? @natural } {? {| ? | ! } } @one_term_with_bindings
 
    Replaces subterms with other subterms that have been proven to be equal.
    The type of :n:`@one_term` must have the form:

--- a/doc/sphinx/proofs/writing-proofs/reasoning-inductives.rst
+++ b/doc/sphinx/proofs/writing-proofs/reasoning-inductives.rst
@@ -126,7 +126,7 @@ analysis on inductive or coinductive objects (see :ref:`variants`).
 
    .. prodn::
       induction_clause ::= @induction_arg {? as @or_and_intropattern } {? eqn : @naming_intropattern } {? @occurrences }
-      induction_arg ::= {? > } @one_term_with_bindings
+      induction_arg ::= @one_term_with_bindings
       | @natural
 
    Performs case analysis by generating a subgoal for each constructor of the
@@ -384,7 +384,7 @@ Induction
       the unresolved premises are posed as existential variables to be inferred
       later, in the same way as :tacn:`eapply` does.
 
-.. tacn:: elim {? > } @one_term_with_bindings {? using @one_term_with_bindings }
+.. tacn:: elim @one_term_with_bindings {? using @one_term_with_bindings }
 
    An older, more basic induction tactic.  Unlike :tacn:`induction`, ``elim`` only
    modifies the goal; it does not modify the :term:`local context`.  We recommend
@@ -400,7 +400,7 @@ Induction
      :n:`@bindings` clause allows instantiating premises of the type of
      :n:`@one_term`.
 
-   .. tacn:: eelim {? > } @one_term_with_bindings {? using @one_term_with_bindings }
+   .. tacn:: eelim @one_term_with_bindings {? using @one_term_with_bindings }
 
       If the type of :n:`@one_term` has dependent premises, this turns them into
       existential variables to be resolved later on.

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -2486,7 +2486,7 @@ ssrapplyarg: [
 ]
 
 constr_with_bindings_arg: [
-| EDIT ADD_OPT ">" constr_with_bindings
+| DELETE ">" constr_with_bindings
 ]
 
 destruction_arg: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1766,12 +1766,12 @@ simple_tactic: [
 | "eintros" LIST0 intropattern
 | "decide" "equality"
 | "compare" one_term one_term
-| "apply" LIST1 ( OPT ">" one_term_with_bindings ) SEP "," OPT in_hyp_as
-| "eapply" LIST1 ( OPT ">" one_term_with_bindings ) SEP "," OPT in_hyp_as
-| "simple" "apply" LIST1 ( OPT ">" one_term_with_bindings ) SEP "," OPT in_hyp_as
-| "simple" "eapply" LIST1 ( OPT ">" one_term_with_bindings ) SEP "," OPT in_hyp_as
-| "elim" OPT ">" one_term_with_bindings OPT ( "using" one_term_with_bindings )
-| "eelim" OPT ">" one_term_with_bindings OPT ( "using" one_term_with_bindings )
+| "apply" LIST1 one_term_with_bindings SEP "," OPT in_hyp_as
+| "eapply" LIST1 one_term_with_bindings SEP "," OPT in_hyp_as
+| "simple" "apply" LIST1 one_term_with_bindings SEP "," OPT in_hyp_as
+| "simple" "eapply" LIST1 one_term_with_bindings SEP "," OPT in_hyp_as
+| "elim" one_term_with_bindings OPT ( "using" one_term_with_bindings )
+| "eelim" one_term_with_bindings OPT ( "using" one_term_with_bindings )
 | "case" LIST1 induction_clause SEP "," OPT induction_principle
 | "ecase" LIST1 induction_clause SEP "," OPT induction_principle
 | "fix" ident natural OPT ( "with" LIST1 ( "(" ident LIST0 simple_binder OPT ( "{" "struct" name "}" ) ":" type ")" ) )
@@ -1963,7 +1963,7 @@ as_ipat: [
 ]
 
 oriented_rewriter: [
-| OPT [ "->" | "<-" ] OPT natural OPT [ "?" | "!" ] OPT ">" one_term_with_bindings
+| OPT [ "->" | "<-" ] OPT natural OPT [ "?" | "!" ] one_term_with_bindings
 ]
 
 induction_clause: [
@@ -1971,7 +1971,7 @@ induction_clause: [
 ]
 
 induction_arg: [
-| OPT ">" one_term_with_bindings
+| one_term_with_bindings
 | natural
 ]
 

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -188,6 +188,12 @@ let deprecated_conversion_at_with =
     ~name:"conversion_at_with" ~category:"deprecated"
     (fun () -> Pp.str "The syntax [at ... with ...] is deprecated. Use [with ... at ...] instead.")
 
+(* 8.17 *)
+let deprecated_clear_modifier =
+  CWarnings.create
+    ~name:"deprecated-clear-modifier" ~category:"deprecated"
+    (fun () -> Pp.strbrk "The undocumented clear modifier \">\" is deprecated. Open an issue at https://github.com/coq/coq/issues/new if you actually depend on this feature in your work.")
+
 (* Auxiliary grammar rules *)
 
 open Pvernac.Vernac_
@@ -225,7 +231,9 @@ GRAMMAR EXTEND Gram
     ] ]
   ;
   constr_with_bindings_arg:
-    [ [ ">"; c = constr_with_bindings -> { (Some true,c) }
+    [ [ ">"; c = constr_with_bindings ->
+      { deprecated_clear_modifier (); (* 8.17 *)
+        (Some true,c) }
       | c = constr_with_bindings -> { (None,c) } ] ]
   ;
   quantified_hypothesis:


### PR DESCRIPTION
The keep/clear modifier `>` is undocumented and **apparently unused in the whole CI** (tested by Jim in #15015). This feature does not look important enough to me to deserve a one-character shorthand, so instead of promoting it by documenting it, I propose to deprecate it in Coq 8.17 and remove it in Coq 8.18.

Note that while I can see the point of the clear modifier, with `apply` or `rewrite` (but it is easily replaced by appropriate calls to `clear`), I can't even find a relevant use case in the "keep" case (e.g., with `destruct`). If there is one, please let me know.

cc @herbelin who introduced the feature in 262e3151ce483aaab3b4f60e3d1dbdf875ea05ae (2014). BTW, at that time, the keep modifier was `!`, which according to 387351b4c0ffeff65d8a7192f5073cfd4bd20f53 was replaced by the use of parentheses around the argument. So I wonder why `>` ends up being supported in the `destruct` / `induction` case.

- [x] Added **changelog**.
- [x] Added / updated **documentation**.