### PR TITLE
Add `Ltac2.Constr.Unsafe.liftn`

### DIFF
--- a/doc/changelog/06-Ltac2-language/16413-ltac2-lift.rst
+++ b/doc/changelog/06-Ltac2-language/16413-ltac2-lift.rst
@@ -1,4 +1,4 @@
 - **Added:**
-  Added :tacn:`Ltac2.Constr.Unsafe.liftn`
+  Added ``Ltac2.Constr.Unsafe.liftn``
   (`#16413 <https://github.com/coq/coq/pull/16413>`_,
   by Jason Gross).

--- a/doc/changelog/06-Ltac2-language/16413-ltac2-lift.rst
+++ b/doc/changelog/06-Ltac2-language/16413-ltac2-lift.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Added :tacn:`Ltac2.Constr.Unsafe.liftn`
+  (`#16413 <https://github.com/coq/coq/pull/16413>`_,
+  by Jason Gross).

--- a/kernel/vars.mli
+++ b/kernel/vars.mli
@@ -37,7 +37,7 @@ val noccur_with_meta : int -> int -> constr -> bool
 (** [exliftn el c] lifts [c] with arbitrary complex lifting [el] *)
 val exliftn : Esubst.lift -> constr -> constr
 
-(** [liftn n k c] lifts by [n] indexes above or equal to [k] in [c]
+(** [liftn n k c] lifts by [n] indices greater than or equal to [k] in [c]
    Note that with respect to substitution calculi's terminology, [n]
    is the _shift_ and [k] is the _lift_. *)
 val liftn : int -> int -> constr -> constr

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -676,6 +676,11 @@ let () = define1 "constr_check" constr begin fun c ->
   end
 end
 
+let () = define3 "constr_liftn" int int constr begin fun n k c ->
+  let ans = EConstr.Vars.liftn n k c in
+  return (Value.of_constr ans)
+end
+
 let () = define3 "constr_substnl" (list constr) int constr begin fun subst k c ->
   let ans = EConstr.Vars.substnl subst k c in
   return (Value.of_constr ans)

--- a/user-contrib/Ltac2/Constr.v
+++ b/user-contrib/Ltac2/Constr.v
@@ -59,6 +59,11 @@ Ltac2 @ external check : constr -> constr result := "ltac2" "constr_check".
     current environment, and returns it, or the error otherwise. Panics if
     not focused. *)
 
+Ltac2 @ external liftn : int -> int -> constr -> constr := "ltac2" "constr_liftn".
+(** [liftn n k c] lifts by [n] indices greater than or equal to [k] in [c]
+    Note that with respect to substitution calculi's terminology, [n]
+    is the _shift_ and [k] is the _lift_. *)
+
 Ltac2 @ external substnl : constr list -> int -> constr -> constr := "ltac2" "constr_substnl".
 (** [substnl [r₁;...;rₙ] k c] substitutes in parallel [Rel(k+1); ...; Rel(k+n)] with
     [r₁;...;rₙ] in [c]. *)


### PR DESCRIPTION

- [ ] Added / updated **test-suite**. (is this needed here, since we're just exposing unerlying ml primitives?)
- [x] Added **changelog**.
- [ ] Added / updated **documentation**. (is this needed?)

Is this a candidate for 8.16 (either .0 or .1)?