### PR TITLE
Simplify error message for "cannot move _ it occurs in the type of _"

### DIFF
--- a/proofs/logic.ml
+++ b/proofs/logic.ml
@@ -183,7 +183,7 @@ let () = CErrors.register_handler (function
     | CannotMoveHyp { from; hto; hyp } ->
       Some Pp.(str "Cannot move " ++ Id.print from ++
                pr_move_location Id.print hto ++
-               str ": it occurs in the type of " ++
+               str ": it occurs in the declaration of " ++
                Id.print hyp ++ str ".")
     | _ -> None)
 


### PR DESCRIPTION
This is sometimes incorrect as the issue can be the body of the variable.

We just say "it occurs in _" instead of specifying whether it's in the
type or the body because the code is too complicated to get that
information easily (it is not clearly available in moverec_toright).

Fix #16364
