### PR TITLE
Fix Print Assumptions ignoring missing proofs with -vok

### DIFF
--- a/dev/ci/user-overlays/16434-SkySkimmer-assumptions-vos.sh
+++ b/dev/ci/user-overlays/16434-SkySkimmer-assumptions-vos.sh
@@ -1,0 +1,1 @@
+overlay paramcoq https://github.com/SkySkimmer/paramcoq assumptions-vos 16434

--- a/doc/changelog/08-vernac-commands-and-options/16434-assumptions-vos.rst
+++ b/doc/changelog/08-vernac-commands-and-options/16434-assumptions-vos.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  :cmd:`Print Assumptions` treats opaque definitions with missing proofs (as found in ``.vos`` files, see :ref:`compiled-interfaces`) as axioms instead of ignoring them
+  (`#16434 <https://github.com/coq/coq/pull/16434>`_,
+  fixes `#16411 <https://github.com/coq/coq/issues/16411>`_,
+  by Gaëtan Gilbert).

--- a/test-suite/output/bug_16411.out
+++ b/test-suite/output/bug_16411.out
@@ -1,0 +1,6 @@
+Axioms:
+foo : nat
+0
+     : nat
+Axioms:
+axiom : nat

--- a/test-suite/output/bug_16411.v
+++ b/test-suite/output/bug_16411.v
@@ -1,0 +1,9 @@
+(* -*- mode: coq; coq-prog-args: ("-vok") -*- *)
+
+Require Import TestSuite.for_vos.
+
+Print Assumptions foo.
+
+Check 0. (* separator *)
+
+Print Assumptions bar.

--- a/test-suite/prerequisite/for_vos.v
+++ b/test-suite/prerequisite/for_vos.v
@@ -1,0 +1,13 @@
+(* -*- mode: coq; coq-prog-args: ("-vos") -*- *)
+
+Axiom axiom : nat.
+
+Lemma foo : nat.
+Proof.
+  exact axiom.
+Qed.
+
+Lemma bar : nat.
+Proof.
+  exact axiom.
+Defined.

--- a/vernac/assumptions.mli
+++ b/vernac/assumptions.mli
@@ -23,7 +23,7 @@ open Printer
 *)
 val traverse :
   Label.t -> constr ->
-    (GlobRef.Set_env.t * GlobRef.Set_env.t GlobRef.Map_env.t *
+    (GlobRef.Set_env.t * GlobRef.Set_env.t option GlobRef.Map_env.t *
      (Label.t * Constr.rel_context * types) list GlobRef.Map_env.t)
 
 (** Collects all the assumptions (optionally including opaque definitions)


### PR DESCRIPTION
This is a rough fix which just treats missing proofs as regular axioms.

Fix #16411

Overlays:
- https://github.com/coq-community/paramcoq/pull/101