### PR TITLE
Deprecate "~=" notation for JMeq in Program.Equality

### DIFF
--- a/doc/changelog/11-standard-library/16436-depr-jmed-notation.rst
+++ b/doc/changelog/11-standard-library/16436-depr-jmed-notation.rst
@@ -1,0 +1,4 @@
+- **Deprecated:**
+  notation ``_ ~= _`` for ``JMeq`` in
+  ``Coq.Program.Equality`` (`#16436
+  <https://github.com/coq/coq/pull/16436>`_, by Gaëtan Gilbert).

--- a/theories/Program/Equality.v
+++ b/theories/Program/Equality.v
@@ -33,7 +33,7 @@ Ltac block_goal := match goal with [ |- ?T ] => change (block T) end.
 Ltac unblock_goal := unfold block in *.
 
 (** Notation for heterogeneous equality. *)
-
+#[deprecated(since="8.17")]
 Notation " x ~= y " := (@JMeq _ x _ y) (at level 70, no associativity).
 
 (** Do something on an heterogeneous equality appearing in the context. *)


### PR DESCRIPTION
Because of coq/stdlib#16
