### PR TITLE
Remove essentially duplicated code

### DIFF
--- a/interp/dumpglob.ml
+++ b/interp/dumpglob.ml
@@ -260,7 +260,7 @@ let mp_of_kn kn =
 let add_glob_kn ?loc kn =
   if dump () then
     let sp = Nametab.path_of_abbreviation kn in
-    let lib_dp = Lib.dp_of_mp (mp_of_kn kn) in
+    let lib_dp = Names.ModPath.dp (mp_of_kn kn) in
     add_glob_gen ?loc sp lib_dp "abbrev"
 
 let dump_def ?loc ty secpath id = Option.iter (fun loc ->

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -432,11 +432,6 @@ let mp_of_global = let open GlobRef in function
   | IndRef ind -> Names.Ind.modpath ind
   | ConstructRef constr -> Names.Construct.modpath constr
 
-let rec dp_of_mp = function
-  |Names.MPfile dp -> dp
-  |Names.MPbound _ -> library_dp ()
-  |Names.MPdot (mp,_) -> dp_of_mp mp
-
 let rec split_modpath = function
   |Names.MPfile dp -> dp, []
   |Names.MPbound mbid -> library_dp (), [Names.MBId.to_id mbid]
@@ -446,7 +441,7 @@ let rec split_modpath = function
 
 let library_part = function
   | GlobRef.VarRef id -> library_dp ()
-  | ref -> dp_of_mp (mp_of_global ref)
+  | ref -> ModPath.dp (mp_of_global ref)
 
 let discharge_proj_repr p =
   let ind = Projection.Repr.inductive p in

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -118,7 +118,6 @@ val end_compilation : DirPath.t -> Nametab.object_prefix * classified_objects
 val library_dp : unit -> DirPath.t
 
 (** Extract the library part of a name even if in a section *)
-val dp_of_mp : ModPath.t -> DirPath.t
 val split_modpath : ModPath.t -> DirPath.t * Id.t list
 val library_part :  GlobRef.t -> DirPath.t
 


### PR DESCRIPTION
We remove a small function in `Lib`, using a seemingly equivalent one from `Names`.