### PR TITLE
Enhance Print Grammar to print whole grammar or subsets of it.

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/16440-print-grammar-in.rst
+++ b/doc/changelog/08-vernac-commands-and-options/16440-print-grammar-in.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  :cmd:`Print Grammar` can print arbitrary nonterminals or the whole grammar instead of a small adhoc list of nonterminals
+  (`#16440 <https://github.com/coq/coq/pull/16440>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -534,20 +534,19 @@ Displaying information about notations
    Prints the current reserved :ref:`keywords <keywords>` and parser tokens, one
    per line. Keywords cannot be used as identifiers.
 
-.. cmd:: Print Grammar @ident
+.. cmd:: Print Grammar {* @ident }
 
-   Shows the grammar for the nonterminal :token:`ident`, which must be one of the following:
+   When no :token:`ident` is provided, shows the whole grammar.
+   Otherwise shows the grammar for the nonterminal :token:`ident`\s, except for
+   the following, which will include some related nonterminals:
 
    - `constr` - for :token:`term`\s
-   - `pattern` - for :token:`pattern`\s
    - `tactic` - for currently-defined tactic notations, :token:`tactic`\s and tacticals
      (corresponding to :token:`ltac_expr` in the documentation).
    - `vernac` - for :token:`command`\s
    - `ltac2` - for Ltac2 notations (corresponding to :token:`ltac2_expr`)
 
-   This command doesn't display all nonterminals of the grammar.  For example,
-   productions shown by `Print Grammar tactic` refer to nonterminals `tactic_then_locality`
-   and `for_each_goal` which are not shown and can't be printed.
+   This command can display any nonterminal in the grammar reachable from `vernac_control`.
 
    Most of the grammar in the documentation was updated in 8.12 to make it accurate and
    readable.  This was done using a new developer tool that extracts the grammar from the

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1279,7 +1279,7 @@ printable: [
 | "Term" smart_global OPT univ_name_list
 | "All"
 | "Section" global
-| "Grammar" IDENT
+| "Grammar" LIST0 IDENT
 | "Custom" "Grammar" IDENT
 | "Keywords"
 | "LoadPath" OPT dirpath

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -880,7 +880,7 @@ command: [
 | "Type" term
 | "Print" "All"
 | "Print" "Section" qualid
-| "Print" "Grammar" ident
+| "Print" "Grammar" LIST0 ident
 | "Print" "Custom" "Grammar" ident
 | "Print" "Keywords"
 | "Print" "LoadPath" OPT dirpath

--- a/gramlib/grammar.mli
+++ b/gramlib/grammar.mli
@@ -43,6 +43,9 @@ module type S = sig
     val parse_token_stream : 'a t -> te LStream.t -> 'a
     val print : Format.formatter -> 'a t -> unit
     val is_empty : 'a t -> bool
+
+    type any_t = Any : 'a t -> any_t
+    val accumulate_in : 'a t -> any_t list CString.Map.t
   end
 
   module rec Symbol : sig

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -51,7 +51,7 @@ end
 
 (* Strings *)
 
-module String : CString.ExtS = CString
+module String = CString
 
 let subst_command_placeholder s t =
   let buff = Buffer.create (String.length s + String.length t) in

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -53,7 +53,7 @@ end
 
 (** {6 Strings. } *)
 
-module String : CString.ExtS
+module String = CString
 
 (** Substitute %s in the first chain by the second chain *)
 val subst_command_placeholder : string -> string -> string

--- a/parsing/pcoq.ml
+++ b/parsing/pcoq.ml
@@ -406,9 +406,7 @@ let extend_dyn_grammar (e, _) = match e with
 
 (** Registering extra grammar *)
 
-type any_entry = AnyEntry : 'a Entry.t -> any_entry
-
-let grammar_names : any_entry list String.Map.t ref = ref String.Map.empty
+let grammar_names : Entry.any_t list String.Map.t ref = ref String.Map.empty
 
 let register_grammars_by_name name grams =
   grammar_names := String.Map.add name grams !grammar_names
@@ -417,7 +415,7 @@ let find_grammars_by_name name =
   try String.Map.find name !grammar_names
   with Not_found ->
     let fold (EntryDataMap.Any (tag, EntryData.Ex map)) accu =
-      try AnyEntry (String.Map.find name map) :: accu
+      try Entry.Any (String.Map.find name map) :: accu
       with Not_found -> accu
     in
     EntryDataMap.fold fold !camlp5_entries []

--- a/parsing/pcoq.mli
+++ b/parsing/pcoq.mli
@@ -270,10 +270,8 @@ val parser_summary_tag : frozen_t Summary.Dyn.tag
 
 (** Registering grammars by name *)
 
-type any_entry = AnyEntry : 'a Entry.t -> any_entry
-
-val register_grammars_by_name : string -> any_entry list -> unit
-val find_grammars_by_name : string -> any_entry list
+val register_grammars_by_name : string -> Entry.any_t list -> unit
+val find_grammars_by_name : string -> Entry.any_t list
 
 (** Parsing state handling *)
 val freeze : marshallable:bool -> frozen_t

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -591,11 +591,12 @@ let print_ltac id =
 (** Grammar *)
 
 let () =
+  let open Pcoq.Entry in
   let entries = [
-    AnyEntry Pltac.ltac_expr;
-    AnyEntry Pltac.binder_tactic;
-    AnyEntry Pltac.simple_tactic;
-    AnyEntry Pltac.tactic_value;
+    Any Pltac.ltac_expr;
+    Any Pltac.binder_tactic;
+    Any Pltac.simple_tactic;
+    Any Pltac.tactic_value;
   ] in
   register_grammars_by_name "tactic" entries
 

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -53,7 +53,7 @@ let () =
   let entries = [
     Pcoq.AnyEntry Pltac.ltac2_expr;
   ] in
-  Pcoq.register_grammars_by_name "coq-core.plugins.ltac2" entries
+  Pcoq.register_grammars_by_name "ltac2" entries
 
 (** Tactic definition *)
 

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -51,7 +51,7 @@ end
 
 let () =
   let entries = [
-    Pcoq.AnyEntry Pltac.ltac2_expr;
+    Pcoq.Entry.Any Pltac.ltac2_expr;
   ] in
   Pcoq.register_grammars_by_name "ltac2" entries
 

--- a/test-suite/output/PrintGrammar.out
+++ b/test-suite/output/PrintGrammar.out
@@ -1,0 +1,153 @@
+Entry binder_constr is
+[ LEFTA
+  [ "exists2"; "'"; pattern LEVEL "0"; ":"; term LEVEL "200"; ","; term LEVEL
+    "200"; "&"; term LEVEL "200"
+  | "exists2"; "'"; pattern LEVEL "0"; ","; term LEVEL "200"; "&"; term LEVEL
+    "200"
+  | "exists2"; name; ":"; term LEVEL "200"; ","; term LEVEL "200"; "&"; term
+    LEVEL "200"
+  | "exists2"; name; ","; term LEVEL "200"; "&"; term LEVEL "200"
+  | "exists"; "!"; open_binders; ","; term LEVEL "200"
+  | "exists"; open_binders; ","; term LEVEL "200"
+  | "forall"; open_binders; ","; term LEVEL "200"
+  | "fun"; open_binders; "=>"; term LEVEL "200"
+  | "let"; "fix"; fix_decl; "in"; term LEVEL "200"
+  | "let"; "cofix"; cofix_body; "in"; term LEVEL "200"
+  | "let"; "'"; pattern LEVEL "200"; ":="; term LEVEL "200"; "in"; term LEVEL
+    "200"
+  | "let"; "'"; pattern LEVEL "200"; ":="; term LEVEL "200"; case_type; "in";
+    term LEVEL "200"
+  | "let"; "'"; pattern LEVEL "200"; "in"; pattern LEVEL "200"; ":="; term
+    LEVEL "200"; case_type; "in"; term LEVEL "200"
+  | "let"; name; binders; let_type_cstr; ":="; term LEVEL "200"; "in"; term
+    LEVEL "200"
+  | "let"; [ "("; LIST0 name SEP ","; ")" | "()" ]; as_return_type; ":=";
+    term LEVEL "200"; "in"; term LEVEL "200"
+  | "if"; term LEVEL "200"; as_return_type; "then"; term LEVEL "200"; "else";
+    term LEVEL "200"
+  | "fix"; fix_decls
+  | "cofix"; cofix_decls ] ]
+
+Entry constr is
+[ LEFTA
+  [ "@"; global; univ_annot
+  | term LEVEL "8" ] ]
+
+Entry lconstr is
+[ LEFTA
+  [ term LEVEL "200" ] ]
+
+Entry term is
+[ "200" RIGHTA
+  [ binder_constr ]
+| "100" RIGHTA
+  [ SELF; "<:"; term LEVEL "200"
+  | SELF; "<<:"; term LEVEL "200"
+  | SELF; ":"; term LEVEL "200" ]
+| "99" RIGHTA
+  [ SELF; "->"; term LEVEL "200" ]
+| "95" RIGHTA
+  [ SELF; "<->"; NEXT ]
+| "90" RIGHTA
+  [  ]
+| "85" RIGHTA
+  [ SELF; "\\/"; term LEVEL "85" ]
+| "80" RIGHTA
+  [ SELF; "/\\"; term LEVEL "80" ]
+| "75" RIGHTA
+  [ "~"; term LEVEL "75" ]
+| "70" RIGHTA
+  [ SELF; ">"; NEXT
+  | SELF; ">="; NEXT
+  | SELF; "<"; NEXT; "<="; NEXT
+  | SELF; "<"; NEXT; "<"; NEXT
+  | SELF; "<"; NEXT
+  | SELF; "<="; NEXT; "<"; NEXT
+  | SELF; "<="; NEXT; "<="; NEXT
+  | SELF; "<="; NEXT
+  | SELF; "<>"; NEXT; ":>"; NEXT
+  | SELF; "<>"; NEXT
+  | SELF; "="; NEXT; "="; NEXT
+  | SELF; "="; NEXT; ":>"; NEXT
+  | SELF; "="; NEXT ]
+| "60" RIGHTA
+  [ SELF; "++"; term LEVEL "60"
+  | SELF; "::"; term LEVEL "60" ]
+| "50" LEFTA
+  [ SELF; "||"; NEXT
+  | SELF; "-"; NEXT
+  | SELF; "+"; NEXT ]
+| "40" LEFTA
+  [ SELF; "&&"; NEXT
+  | SELF; "/"; NEXT
+  | SELF; "*"; NEXT ]
+| "35" RIGHTA
+  [ "/"; term LEVEL "35"
+  | "-"; term LEVEL "35" ]
+| "30" RIGHTA
+  [ SELF; "^"; term LEVEL "30" ]
+| "10" LEFTA
+  [ SELF; LIST1 arg
+  | "@"; global; univ_annot; LIST0 NEXT
+  | "@"; pattern_ident; LIST1 identref ]
+| "9" LEFTA
+  [ ".."; term LEVEL "0"; ".." ]
+| "8" LEFTA
+  [  ]
+| "1" LEFTA
+  [ SELF; ".("; "@"; global; univ_annot; LIST0 (term LEVEL "9"); ")"
+  | SELF; ".("; global; univ_annot; LIST0 arg; ")"
+  | SELF; "%"; IDENT ]
+| "0" LEFTA
+  [ IDENT "ltac"; ":"; "("; ltac_expr; ")"
+  | "("; term LEVEL "200"; ","; term LEVEL "200"; ","; LIST1 (term LEVEL
+    "200") SEP ","; ")"
+  | "("; term LEVEL "200"; ","; term LEVEL "200"; ")"
+  | "("; term LEVEL "200"; ")"
+  | "{|"; record_declaration; '|}'
+  | "{"; "'"; pattern LEVEL "0"; "&"; term LEVEL "200"; "&"; term LEVEL
+    "200"; "}"
+  | "{"; "'"; pattern LEVEL "0"; "&"; term LEVEL "200"; "}"
+  | "{"; "'"; pattern LEVEL "0"; ":"; term LEVEL "200"; "&"; term LEVEL
+    "200"; "&"; term LEVEL "200"; "}"
+  | "{"; "'"; pattern LEVEL "0"; ":"; term LEVEL "200"; "&"; term LEVEL
+    "200"; "}"
+  | "{"; "'"; pattern LEVEL "0"; ":"; term LEVEL "200"; "|"; term LEVEL
+    "200"; "&"; term LEVEL "200"; "}"
+  | "{"; "'"; pattern LEVEL "0"; ":"; term LEVEL "200"; "|"; term LEVEL
+    "200"; "}"
+  | "{"; "'"; pattern LEVEL "0"; "|"; term LEVEL "200"; "&"; term LEVEL
+    "200"; "}"
+  | "{"; "'"; pattern LEVEL "0"; "|"; term LEVEL "200"; "}"
+  | "{"; term LEVEL "99"; "&"; term LEVEL "200"; "&"; term LEVEL "200"; "}"
+  | "{"; term LEVEL "99"; "&"; term LEVEL "200"; "}"
+  | "{"; term LEVEL "99"; ":"; term LEVEL "200"; "&"; term LEVEL "200"; "&";
+    term LEVEL "200"; "}"
+  | "{"; term LEVEL "99"; ":"; term LEVEL "200"; "&"; term LEVEL "200"; "}"
+  | "{"; term LEVEL "99"; ":"; term LEVEL "200"; "|"; term LEVEL "200"; "&";
+    term LEVEL "200"; "}"
+  | "{"; term LEVEL "99"; ":"; term LEVEL "200"; "|"; term LEVEL "200"; "}"
+  | "{"; term LEVEL "99"; "|"; term LEVEL "200"; "&"; term LEVEL "200"; "}"
+  | "{"; term LEVEL "99"; "|"; term LEVEL "200"; "}"
+  | "{"; term LEVEL "99"; "}"
+  | "{"; binder_constr; "}"
+  | "`{"; term LEVEL "200"; "}"
+  | "`("; term LEVEL "200"; ")"
+  | NUMBER
+  | atomic_constr
+  | term_match
+  | ident; fields; univ_annot
+  | ident; univ_annot
+  | test_array_opening; "["; "|"; array_elems; "|"; lconstr; type_cstr;
+    test_array_closing; "|"; "]"; univ_annot ] ]
+
+Entry univ_annot is
+[ LEFTA
+  [ "@{"; LIST0 universe_level; "}"
+  |  ] ]
+
+Entry fix_decls is
+[ LEFTA
+  [ fix_decl; "with"; LIST1 fix_decl SEP "with"; "for"; identref
+  | fix_decl ] ]
+

--- a/test-suite/output/PrintGrammar.v
+++ b/test-suite/output/PrintGrammar.v
@@ -1,0 +1,4 @@
+
+Print Grammar constr univ_annot.
+
+Print Grammar fix_decls.

--- a/test-suite/output/PrintGrammarConstr.out
+++ b/test-suite/output/PrintGrammarConstr.out
@@ -1,11 +1,4 @@
-Entry constr is
-[ LEFTA
-  [ "@"; global; univ_annot
-  | term LEVEL "8" ] ]
-and lconstr is
-[ LEFTA
-  [ term LEVEL "200" ] ]
-where binder_constr is
+Entry binder_constr is
 [ LEFTA
   [ "forall"; open_binders; ","; term LEVEL "200"
   | "fun"; open_binders; "=>"; term LEVEL "200"
@@ -25,7 +18,17 @@ where binder_constr is
     term LEVEL "200"
   | "fix"; fix_decls
   | "cofix"; cofix_decls ] ]
-and term is
+
+Entry constr is
+[ LEFTA
+  [ "@"; global; univ_annot
+  | term LEVEL "8" ] ]
+
+Entry lconstr is
+[ LEFTA
+  [ term LEVEL "200" ] ]
+
+Entry term is
 [ "200" RIGHTA
   [ binder_constr ]
 | "100" RIGHTA

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -1021,9 +1021,9 @@ GRAMMAR EXTEND Gram
     [ [ IDENT "Term"; qid = smart_global; l = OPT univ_name_list -> { PrintName (qid,l) }
       | IDENT "All" -> { PrintFullContext }
       | IDENT "Section"; s = global -> { PrintSectionContext s }
-      | IDENT "Grammar"; ent = IDENT ->
+      | IDENT "Grammar"; ents = LIST0 IDENT ->
           (* This should be in "syntax" section but is here for factorization*)
-          { PrintGrammar ent }
+          { PrintGrammar ents }
       | IDENT "Custom"; IDENT "Grammar"; ent = IDENT ->
           (* Should also be in "syntax" section *)
           { PrintCustomGrammar ent }

--- a/vernac/metasyntax.mli
+++ b/vernac/metasyntax.mli
@@ -57,7 +57,7 @@ val add_abbreviation : local:bool -> Deprecation.t option -> env ->
 
 (** Print the Camlp5 state of a grammar *)
 
-val pr_grammar : string -> Pp.t
+val pr_grammar : string list -> Pp.t
 val pr_custom_grammar : string -> Pp.t
 val pr_keywords : unit -> Pp.t
 

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -559,7 +559,8 @@ let pr_printable = function
   | PrintSectionContext s ->
     keyword "Print Section" ++ spc() ++ Libnames.pr_qualid s
   | PrintGrammar ent ->
-    keyword "Print Grammar" ++ spc() ++ str ent
+    keyword "Print Grammar" ++ spc() ++
+    prlist_with_sep spc str ent
   | PrintCustomGrammar ent ->
     keyword "Print Custom Grammar" ++ spc() ++ str ent
   | PrintKeywords ->

--- a/vernac/pvernac.ml
+++ b/vernac/pvernac.ml
@@ -38,9 +38,9 @@ module Vernac_ =
     let gallina_ext = Entry.create "gallina_ext"
     let command = Entry.create "command"
     let syntax = Entry.create "syntax_command"
-    let vernac_control = Entry.create "Vernac.vernac_control"
-    let inductive_or_record_definition = Entry.create "Vernac.inductive_or_record_definition"
-    let fix_definition = Entry.create "Vernac.fix_definition"
+    let vernac_control = Entry.create "vernac_control"
+    let inductive_or_record_definition = Entry.create "inductive_or_record_definition"
+    let fix_definition = Entry.create "fix_definition"
     let red_expr = Entry.create "red_expr"
     let hint_info = Entry.create "hint_info"
     (* Main vernac entry *)

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -29,7 +29,7 @@ type printable =
   | PrintFullContext
   | PrintSectionContext of qualid
   | PrintInspect of int
-  | PrintGrammar of string
+  | PrintGrammar of string list
   | PrintCustomGrammar of string
   | PrintKeywords
   | PrintLoadPath of DirPath.t option


### PR DESCRIPTION
The doc says
>This command doesn't display all nonterminals of the grammar. For example, productions shown by `Print Grammar tactic` refer to nonterminals `tactic_then_locality` and `for_each_goal` which are not shown and can't be printed.

This PR provides a way to print them, ie `Print Grammar tactic_then_locality` works.
We can also `Print Grammar` to print the whole grammar (assuming root vernac_control).

See the provided output test for an example.