### PR TITLE
Introduce a dedicated type for evar instances.

### DIFF
--- a/clib/sList.ml
+++ b/clib/sList.ml
@@ -1,0 +1,123 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+type 'a t =
+| Nil
+| Cons of 'a * 'a t
+| Default of int * 'a t
+(* Invariant: no two consecutive [Default] nodes, the integer is always > 0 *)
+
+let empty = Nil
+let cons x l = Cons (x, l)
+let defaultn n l =
+  if Int.equal n 0 then l
+  else match l with
+  | Nil | Cons _ -> Default (n, l)
+  | Default (m, l) -> Default (n + m, l)
+
+let default l = match l with
+| Nil | Cons _ -> Default (1, l)
+| Default (m, l) -> Default (m + 1, l)
+
+let cons_opt o l = match o with
+| None -> default l
+| Some x -> cons x l
+
+let is_empty = function
+| Nil -> true
+| Cons _ | Default _ -> false
+
+let view = function
+| Nil -> None
+| Cons (x, l) -> Some (Some x, l)
+| Default (1, l) -> Some (None, l)
+| Default (n, l) -> Some (None, Default (n - 1, l))
+
+let rec to_list l = match l with
+| Nil -> []
+| Cons (x, l) -> Some x :: to_list l
+| Default (n, l) ->
+  let l = to_list l in
+  let rec iterate n l = if n <= 0 then l else iterate (n - 1) (None :: l) in
+  iterate n l
+
+let of_full_list l = List.fold_right cons l empty
+
+let equal eq l1 l2 =
+  let eq o1 o2 = match o1, o2 with
+  | None, None -> true
+  | Some x1, Some x2 -> eq x1 x2
+  | Some _, None | None, Some _ -> false
+  in
+  CList.for_all2eq eq (to_list l1) (to_list l2)
+
+let compare cmp l1 l2 = CList.compare (Option.compare cmp) (to_list l1) (to_list l2)
+
+let length l =
+  let rec length n = function
+  | Nil -> n
+  | Cons (_, l) -> length (n + 1) l
+  | Default (k, l) -> length (k + n) l
+  in
+  length 0 l
+
+module Skip =
+struct
+
+let rec iter f = function
+| Nil -> ()
+| Cons (x, l) ->
+  let () = f x in
+  iter f l
+| Default (_, l) -> iter f l
+
+let rec map f = function
+| Nil -> Nil
+| Cons (x, l) -> Cons (f x, map f l)
+| Default (n, l) -> Default (n, map f l)
+
+let rec fold f accu = function
+| Nil -> accu
+| Cons (x, l) -> fold f (f accu x) l
+| Default (_, l) -> fold f accu l
+
+let rec exists f l = match l with
+| Nil -> false
+| Cons (x, l) -> f x || exists f l
+| Default (_, l) -> exists f l
+
+end
+
+module Smart =
+struct
+
+let rec map f l = match l with
+| Nil -> empty
+| Cons (x, r) ->
+  let x' = f x in
+  let r' = map f r in
+  if x' == x && r' == r then l else cons x' r'
+| Default (n, r) ->
+  let r' = map f r in
+  if r' == r then l else Default (n, r')
+
+let rec fold_left_map f accu l0 = match l0 with
+| Nil -> accu, empty
+| Cons (x, l) ->
+  let accu, x' = f accu x in
+  let accu, l' = fold_left_map f accu l in
+  let r = if x' == x && l' == l then l0 else Cons (x', l') in
+  accu, r
+| Default (n, l) ->
+  let accu, l' = fold_left_map f accu l in
+  let r = if l' == l then l0 else Default (n, l') in
+  accu, r
+
+end

--- a/clib/sList.mli
+++ b/clib/sList.mli
@@ -1,0 +1,74 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** Sparse lists. *)
+
+(** {5 Constructors} *)
+
+type +'a t = private
+| Nil
+| Cons of 'a * 'a t
+| Default of int * 'a t
+(** ['a t] is an efficient representation of ['a option list]. *)
+
+val empty : 'a t
+(** The empty list. *)
+
+val cons : 'a -> 'a t -> 'a t
+(** Isomorphic to [Some x :: l]. *)
+
+val default : 'a t -> 'a t
+(** Isomorphic to [None :: l]. *)
+
+val cons_opt : 'a option -> 'a t -> 'a t
+(** {!cons} if [Some], {!default} otherwise *)
+
+val defaultn : int -> 'a t -> 'a t
+(** Iterated variant of [default]. *)
+
+(** {5 Destructor} *)
+
+val view : 'a t -> ('a option * 'a t) option
+
+val is_empty : 'a t -> bool
+
+(** {5 Usual list-like operators} *)
+
+val length : 'a t -> int
+
+val equal : ('a -> 'b -> bool) -> 'a t -> 'b t -> bool
+
+val compare : ('a -> 'a -> int) -> 'a t -> 'a t -> int
+
+val to_list : 'a t -> 'a option list
+
+val of_full_list : 'a list -> 'a t
+
+(** {5 Iterators ignoring optional values} *)
+
+module Skip :
+sig
+
+val iter : ('a -> unit) -> 'a t -> unit
+val map : ('a -> 'b) -> 'a t -> 'b t
+val fold : ('a -> 'b -> 'a) -> 'a -> 'b t -> 'a
+val exists : ('a -> bool) -> 'a t -> bool
+
+end
+(** These iterators ignore the default values in the list. *)
+
+(** {5 Smart iterators} *)
+
+module Smart :
+sig
+val map : ('a -> 'a) -> 'a t -> 'a t
+val fold_left_map : ('a -> 'b -> 'a * 'b) -> 'a -> 'b t -> 'a * 'b t
+end
+(** These iterators also ignore the default values in the list. *)

--- a/dev/ci/user-overlays/16442-ppedrot-evar-compact-instance.sh
+++ b/dev/ci/user-overlays/16442-ppedrot-evar-compact-instance.sh
@@ -1,0 +1,13 @@
+overlay equations https://github.com/ppedrot/Coq-Equations evar-compact-instance 16442
+
+overlay metacoq https://github.com/ppedrot/metacoq evar-compact-instance 16442
+
+overlay quickchick https://github.com/ppedrot/QuickChick evar-compact-instance 16442
+
+overlay elpi https://github.com/ppedrot/coq-elpi evar-compact-instance 16442
+
+overlay coqhammer https://github.com/ppedrot/coqhammer evar-compact-instance 16442
+
+overlay unicoq https://github.com/ppedrot/unicoq evar-compact-instance 16442
+
+overlay mtac2 https://github.com/ppedrot/Mtac2 evar-compact-instance 16442

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -296,7 +296,11 @@ let constr_display csr =
       "LetIn("^(name_display na)^","^(term_display b)^","
       ^(term_display t)^","^(term_display c)^")"
   | App (c,l) -> "App("^(term_display c)^","^(array_display l)^")\n"
-  | Evar (e,l) -> "Evar("^(Pp.string_of_ppcmds (Evar.print e))^","^(array_display (Array.of_list l))^")"
+  | Evar (e,l) ->
+    let l = SList.to_list l in
+    let map = function None -> "?" | Some t -> term_display t in
+    let l = List.map map l in
+    "Evar("^(Pp.string_of_ppcmds (Evar.print e))^", [|"^(String.concat "; " l)^"|])"
   | Const (c,u) -> "Const("^(Constant.to_string c)^","^(universes_display u)^")"
   | Ind ((sp,i),u) ->
       "MutInd("^(MutInd.to_string sp)^","^(string_of_int i)^","^(universes_display u)^")"
@@ -393,7 +397,8 @@ let print_pure_constr csr =
       Array.iter (fun x -> print_space (); box_display x) l;
       print_string ")"
   | Evar (e,l) -> print_string "Evar#"; print_int (Evar.repr e); print_string "{";
-      List.iter (fun x -> print_space (); box_display x) l;
+      let iter = function None -> print_space (); print_string "?" | Some t -> print_space (); box_display t in
+      List.iter iter (SList.to_list l);
       print_string"}"
   | Const (c,u) -> print_string "Cons(";
       sp_con_display c;

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -160,6 +160,9 @@ val mkNamedProd : Evd.evar_map -> Id.t Context.binder_annot -> types -> types ->
 val mkNamedLambda_or_LetIn : Evd.evar_map -> named_declaration -> types -> types
 val mkNamedProd_or_LetIn : Evd.evar_map -> named_declaration -> types -> types
 
+val mkLEvar : Evd.evar_map -> Evar.t * t list -> t
+(** Variant of {!mkEvar} that removes identity variable instances from its argument. *)
+
 (** {6 Simple case analysis} *)
 
 val isRel  : Evd.evar_map -> t -> bool
@@ -246,6 +249,7 @@ val eq_constr : Evd.evar_map -> t -> t -> bool
 val eq_constr_nounivs : Evd.evar_map -> t -> t -> bool
 val eq_constr_universes : Environ.env -> Evd.evar_map -> ?nargs:int -> t -> t -> UnivProblem.Set.t option
 val leq_constr_universes : Environ.env -> Evd.evar_map -> ?nargs:int -> t -> t -> UnivProblem.Set.t option
+val eq_existential : Evd.evar_map ->  (t -> t -> bool) -> existential -> existential -> bool
 
 (** [eq_constr_universes_proj] can equate projections and their eta-expanded constant form. *)
 val eq_constr_universes_proj : Environ.env -> Evd.evar_map -> t -> t -> UnivProblem.Set.t option
@@ -258,6 +262,7 @@ val map : Evd.evar_map -> (t -> t) -> t -> t
 val map_with_binders : Evd.evar_map -> ('a -> 'a) -> ('a -> t -> t) -> 'a -> t -> t
 val map_branches : (t -> t) -> case_branch array -> case_branch array
 val map_return_predicate : (t -> t) -> case_return -> case_return
+val map_existential : Evd.evar_map -> (t -> t) -> existential -> existential
 val iter : Evd.evar_map -> (t -> unit) -> t -> unit
 val iter_with_binders : Evd.evar_map -> ('a -> 'a) -> ('a -> t -> unit) -> 'a -> t -> unit
 val iter_with_full_binders : Environ.env -> Evd.evar_map -> (rel_declaration -> 'a -> 'a) -> ('a -> t -> unit) -> 'a -> t -> unit
@@ -347,7 +352,7 @@ val map_rel_context_in_env :
 val match_named_context_val :
   named_context_val -> (named_declaration * lazy_val * named_context_val) option
 
-val identity_subst_val : named_context_val -> t list
+val identity_subst_val : named_context_val -> t SList.t
 
 (* XXX Missing Sigma proxy *)
 val fresh_global :

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -252,7 +252,7 @@ let empty_csubst = {
   csubst_rev = Id.Map.empty;
 }
 
-let csubst_subst { csubst_len = k; csubst_var = v; csubst_rel = s } c =
+let csubst_subst sigma { csubst_len = k; csubst_var = v; csubst_rel = s } c =
   (* Safe because this is a substitution *)
   let c = EConstr.Unsafe.to_constr c in
   let rec subst n c = match Constr.kind c with
@@ -262,7 +262,23 @@ let csubst_subst { csubst_len = k; csubst_var = v; csubst_rel = s } c =
     else mkRel (m - k)
   | Var id ->
     begin try Id.Map.find id v with Not_found -> c end
+  | Evar (evk, args) ->
+    let evi = Evd.find sigma evk in
+    let args' = subst_instance n (evar_filtered_context evi) args in
+    if args' == args then c else Constr.mkEvar (evk, args') (* FIXME: preserve sharing *)
   | _ -> Constr.map_with_binders succ subst n c
+
+  and subst_instance n ctx args = match ctx, SList.view args with
+  | [], None -> SList.empty
+  | decl :: ctx, Some (c, args) ->
+    let c' = match c with
+    | None -> begin try Some (Id.Map.find (NamedDecl.get_id decl) v) with Not_found -> c end
+    | Some c ->
+      let c' = subst n c in
+      if isVarId (NamedDecl.get_id decl) c' then None else Some c'
+    in
+    SList.cons_opt c' (subst_instance n ctx args)
+  | _ :: _, None | [], Some _ -> assert false
   in
   let c = if k = 0 && Id.Map.is_empty v then c else subst 0 c in
   EConstr.of_constr c
@@ -361,7 +377,7 @@ let push_rel_decl_to_named_context
             incorrect. We revert to a less robust behaviour where
             the new binder has name [id]. Which amounts to the same
             behaviour than when [id=id0]. *)
-        let d = decl |> NamedDecl.of_rel_decl (fun _ -> id) |> map_decl (csubst_subst subst) in
+        let d = decl |> NamedDecl.of_rel_decl (fun _ -> id) |> map_decl (csubst_subst sigma subst) in
         (push_var id subst, Id.Set.add id avoid, push_named_context_val d nc)
       else
         (* spiwack: if [id<>id0], rather than introducing a new
@@ -369,7 +385,7 @@ let push_rel_decl_to_named_context
             by the user) and rename [id0] into [id] in the named
             context. Unless [id] is a section variable. *)
         let subst = update_var id0 id subst in
-        let d = decl |> NamedDecl.of_rel_decl (fun _ -> id0) |> map_decl (csubst_subst subst) in
+        let d = decl |> NamedDecl.of_rel_decl (fun _ -> id0) |> map_decl (csubst_subst sigma subst) in
         let nc = replace_var_named_declaration id0 id nc in
         let avoid = Id.Set.add id (Id.Set.add id0 avoid) in
         (push_var id0 subst, avoid, push_named_context_val d nc)
@@ -377,25 +393,37 @@ let push_rel_decl_to_named_context
        user_err Pp.(Id.print id0 ++ str " is already used.")
     end
   | None ->
-    let d = decl |> NamedDecl.of_rel_decl (fun _ -> id) |> map_decl (csubst_subst subst) in
+    let d = decl |> NamedDecl.of_rel_decl (fun _ -> id) |> map_decl (csubst_subst sigma subst) in
     (push_var id subst, Id.Set.add id avoid, push_named_context_val d nc)
+
+let csubst_instance subst ctx =
+  let fold decl accu = match Id.Map.find (NamedDecl.get_id decl) subst.csubst_rev with
+  | SRel n -> SList.cons (EConstr.mkRel (subst.csubst_len - n)) accu
+  | SVar id -> SList.cons (EConstr.mkVar id) accu
+  | exception Not_found -> SList.default accu
+  in
+  List.fold_right fold ctx SList.empty
+
+let default_ext_instance (subst, _, ctx) =
+  csubst_instance subst (named_context_of_val ctx)
 
 let push_rel_context_to_named_context ~hypnaming env sigma typ =
   (* compute the instances relative to the named context and rel_context *)
   let open EConstr in
-  let inst_vars = EConstr.identity_subst_val (named_context_val env) in
+  let ctx = named_context_val env in
   if List.is_empty (Environ.rel_context env) then
-    (named_context_val env, typ, inst_vars, empty_csubst)
+    let inst = SList.defaultn (List.length @@ named_context_of_val ctx) SList.empty in
+    (ctx, typ, inst, empty_csubst)
   else
     let avoid = Environ.ids_of_named_context_val (named_context_val env) in
-    let inst_rels = List.rev (rel_list 0 (nb_rel env)) in
     (* move the rel context to a named context and extend the named instance *)
     (* with vars of the rel context *)
     (* We do keep the instances corresponding to local definition (see above) *)
-    let (subst, _, env) =
+    let (subst, _, env) as ext =
       Context.Rel.fold_outside (fun d acc -> push_rel_decl_to_named_context ~hypnaming sigma d acc)
-        (rel_context env) ~init:(empty_csubst, avoid, named_context_val env) in
-    (env, csubst_subst subst typ, inst_rels@inst_vars, subst)
+        (rel_context env) ~init:(empty_csubst, avoid, ctx) in
+    let inst = default_ext_instance ext in
+    (env, csubst_subst sigma subst typ, inst, subst)
 
 (*------------------------------------*
  * Entry points to define new evars   *
@@ -403,7 +431,7 @@ let push_rel_context_to_named_context ~hypnaming env sigma typ =
 
 let default_source = Loc.tag @@ Evar_kinds.InternalHole
 
-let new_pure_evar ?(src=default_source) ?(filter = Filter.identity) ?identity ?(relevance = Sorts.Relevant)
+let new_pure_evar ?(src=default_source) ?(filter = Filter.identity) ?(relevance = Sorts.Relevant)
   ?(abstract_arguments = Abstraction.identity) ?candidates
   ?(naming = IntroAnonymous) ?typeclass_candidate ?(principal=false) sign evd typ =
   let name = match naming with
@@ -414,10 +442,6 @@ let new_pure_evar ?(src=default_source) ?(filter = Filter.identity) ?identity ?(
     let id = Namegen.next_ident_away_from id has_name in
     Some id
   in
-  let identity = match identity with
-  | None -> Identity.none ()
-  | Some inst -> inst
-  in
   let evi = {
     evar_hyps = sign;
     evar_concl = typ;
@@ -426,7 +450,6 @@ let new_pure_evar ?(src=default_source) ?(filter = Filter.identity) ?identity ?(
     evar_abstract_arguments = abstract_arguments;
     evar_source = src;
     evar_candidates = candidates;
-    evar_identity = identity;
     evar_relevance = relevance;
   }
   in
@@ -447,15 +470,14 @@ let new_evar ?src ?filter ?abstract_arguments ?candidates ?naming ?typeclass_can
   | None -> RenameExistingBut (VarSet.variables (Global.env ()))
   in
   let sign,typ',instance,subst = push_rel_context_to_named_context ~hypnaming env evd typ in
-  let map c = csubst_subst subst c in
+  let map c = csubst_subst evd subst c in
   let candidates = Option.map (fun l -> List.map map l) candidates in
   let instance =
     match filter with
     | None -> instance
-    | Some filter -> Filter.filter_list filter instance in
-  let identity = if Int.equal (Environ.nb_rel env) 0 then Some (Identity.make instance) else None in
+    | Some filter -> Filter.filter_slist filter instance in
   let relevance = Sorts.Relevant in (* FIXME: relevant_of_type not defined yet *)
-  let (evd, evk) = new_pure_evar sign evd typ' ?src ?filter ?identity ~relevance ?abstract_arguments ?candidates ?naming
+  let (evd, evk) = new_pure_evar sign evd typ' ?src ?filter ~relevance ?abstract_arguments ?candidates ?naming
     ?typeclass_candidate ?principal in
   (evd, EConstr.mkEvar (evk, instance))
 
@@ -489,6 +511,7 @@ let add_unification_pb ?(tail=false) pb evd =
 let generalize_evar_over_rels sigma (ev,args) =
   let open EConstr in
   let evi = Evd.find sigma ev in
+  let args = Evd.expand_existential sigma (ev, args) in
   let sign = named_context_of_val evi.evar_hyps in
   List.fold_left2
     (fun (c,inst as x) a d ->
@@ -562,6 +585,7 @@ let rec check_and_clear_in_constr ~is_section_variable env evdref err ids ~globa
                   (* Check if some id to clear occurs in the instance
                      a of rid in ev and remember the dependency *)
                     let check id = if Id.Set.mem id ids then raise (Depends id) in
+                    let a = match a with None -> mkVar (NamedDecl.get_id h) | Some a -> a in
                     let () = Id.Set.iter check (collect_vars !evdref (EConstr.of_constr a)) in
                   (* Check if some rid to clear in the context of ev
                      has dependencies in another hyp of the context of ev
@@ -574,7 +598,7 @@ let rec check_and_clear_in_constr ~is_section_variable env evdref err ids ~globa
                   (* No dependency at all, we can keep this ev's context hyp *)
                     (ri, true::filter)
                   with Depends id -> (Id.Map.add (NamedDecl.get_id h) id ri, false::filter))
-                ctxt l (Id.Map.empty,[]) in
+                ctxt (SList.to_list l) (Id.Map.empty,[]) in
             (* Check if some rid to clear in the context of ev has dependencies
                in the type of ev and adjust the source of the dependency *)
             let _nconcl : Constr.t =
@@ -690,7 +714,7 @@ let undefined_evars_of_term evd t =
     match EConstr.kind evd c with
       | Evar (n, l) ->
         let acc = Evar.Set.add n acc in
-        List.fold_left evrec acc l
+        SList.Skip.fold evrec acc l
       | _ -> EConstr.fold evd evrec acc c
   in
   evrec Evar.Set.empty t
@@ -837,9 +861,13 @@ let eq_constr_univs_test ~evd ~extended_evd t u =
       try sigma := add_universe_constraints !sigma UnivProblem.(Set.singleton (UEq (s1, s2))); true
       with UGraph.UniverseInconsistency _ | UniversesDiffer -> false
   in
+  let eq_existential eq e1 e2 =
+    let eq c1 c2 = eq 0 (EConstr.Unsafe.to_constr c1) (EConstr.Unsafe.to_constr c2) in
+    EConstr.eq_existential evd eq (EConstr.of_existential e1) (EConstr.of_existential e2)
+  in
   let kind1 = kind_of_term_upto evd in
   let kind2 = kind_of_term_upto extended_evd in
   let rec eq_constr' nargs m n =
-    Constr.compare_head_gen_with kind1 kind2 eq_universes eq_sorts eq_constr' nargs m n
+    Constr.compare_head_gen_with kind1 kind2 eq_universes eq_sorts (eq_existential eq_constr') eq_constr' nargs m n
   in
-  Constr.compare_head_gen_with kind1 kind2 eq_universes eq_sorts eq_constr' 0 t u
+  Constr.compare_head_gen_with kind1 kind2 eq_universes eq_sorts (eq_existential eq_constr') eq_constr' 0 t u

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -63,7 +63,10 @@ let kind_of_term_upto = EConstr.kind_upto
 
 let nf_evars_universes sigma t = EConstr.to_constr ~abort_on_undefined_evars:false sigma (EConstr.of_constr t)
 let whd_evar = EConstr.whd_evar
-let nf_evar sigma c = EConstr.of_constr (EConstr.to_constr ~abort_on_undefined_evars:false sigma c)
+
+let nf_evar sigma c =
+  let evar_value ev = Evd.existential_opt_value0 sigma ev in
+  EConstr.of_constr @@ UnivSubst.nf_evars_and_universes_opt_subst evar_value (universe_subst sigma) (EConstr.Unsafe.to_constr c)
 
 let j_nf_evar sigma j =
   { uj_val = nf_evar sigma j.uj_val;

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -48,7 +48,6 @@ val new_evar :
 (** Low-level interface to create an evar.
   @param src User-facing source for the evar
   @param filter See {!Evd.Filter}, must be the same length as [named_context_val]
-  @param identity See {!Evd.Identity}, must be the name projection of [named_context_val]
   @param naming A naming scheme for the evar
   @param principal Whether the evar is the principal goal
   @param named_context_val The context of the evar
@@ -56,7 +55,7 @@ val new_evar :
 *)
 val new_pure_evar :
   ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
-  ?identity:Identity.t -> ?relevance:Sorts.relevance ->
+  ?relevance:Sorts.relevance ->
   ?abstract_arguments:Abstraction.t -> ?candidates:constr list ->
   ?naming:intro_pattern_naming_expr ->
   ?typeclass_candidate:bool ->
@@ -252,17 +251,19 @@ val check_and_clear_in_constr
 type csubst
 
 val empty_csubst : csubst
-val csubst_subst : csubst -> constr -> constr
+val csubst_subst : Evd.evar_map -> csubst -> constr -> constr
 
 type ext_named_context =
   csubst * Id.Set.t * named_context_val
+
+val default_ext_instance : ext_named_context -> constr SList.t
 
 val push_rel_decl_to_named_context : hypnaming:naming_mode ->
   evar_map -> rel_declaration -> ext_named_context -> ext_named_context
 
 val push_rel_context_to_named_context : hypnaming:naming_mode ->
   Environ.env -> evar_map -> types ->
-  named_context_val * types * constr list * csubst
+  named_context_val * types * constr SList.t * csubst
 
 val generalize_evar_over_rels : evar_map -> existential -> types * constr list
 

--- a/engine/univSubst.ml
+++ b/engine/univSubst.ml
@@ -194,7 +194,7 @@ let nf_evars_and_universes_opt_subst f subst =
   let rec aux c =
     match kind c with
     | Evar (evk, args) ->
-      let args' = List.Smart.map aux args in
+      let args' = SList.Smart.map aux args in
       (match try f (evk, args') with Not_found -> None with
       | None -> if args == args' then c else mkEvar (evk, args')
       | Some c -> aux c)

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -1467,8 +1467,10 @@ let rec glob_of_pat avoid env sigma pat = DAst.make @@ match pat with
   | PRef ref -> GRef (ref,None)
   | PVar id  -> GVar id
   | PEvar (evk,l) ->
-      let test decl = function PVar id' -> Id.equal (NamedDecl.get_id decl) id' | _ -> false in
-      let l = Evd.evar_instance_array test (Evd.find sigma evk) l in
+      let filter (id, pat) = match pat with PVar id' -> Id.equal id id' | _ -> true in
+      let hyps = Evd.evar_filtered_context (Evd.find sigma evk) in
+      let map decl pat = NamedDecl.get_id decl, pat in
+      let l = List.filter filter @@ List.map2 map hyps l in
       let id = match Evd.evar_ident evk sigma with
       | None -> Id.of_string "__"
       | Some id -> id

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -94,6 +94,8 @@ type finvert
 
 type 'a usubs = 'a subs Univ.puniverses
 
+type evar_repack
+
 type fterm =
   | FRel of int
   | FAtom of constr (** Metas and Sorts *)
@@ -109,7 +111,7 @@ type fterm =
   | FLambda of int * (Name.t Context.binder_annot * constr) list * constr * fconstr usubs
   | FProd of Name.t Context.binder_annot * fconstr * constr * fconstr usubs
   | FLetIn of Name.t Context.binder_annot * fconstr * fconstr * constr * fconstr usubs
-  | FEvar of existential * fconstr usubs
+  | FEvar of Evar.t * constr list * fconstr usubs * evar_repack
   | FInt of Uint63.t
   | FFloat of Float64.t
   | FArray of Univ.Instance.t * fconstr Parray.t * fconstr

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -79,7 +79,7 @@ let build_lazy_val vk key = vk := VKvalue (CEphemeron.create key)
 type named_context_val = {
   env_named_ctx : Constr.named_context;
   env_named_map : (Constr.named_declaration * lazy_val) Id.Map.t;
-  env_named_var : Constr.t list;
+  env_named_idx : Constr.named_declaration Range.t;
 }
 
 type rel_context_val = {
@@ -104,7 +104,7 @@ type env = {
 let empty_named_context_val = {
   env_named_ctx = [];
   env_named_map = Id.Map.empty;
-  env_named_var = [];
+  env_named_idx = Range.empty;
 }
 
 let empty_rel_context_val = {
@@ -177,7 +177,7 @@ let push_named_context_val_val d rval ctxt =
   {
     env_named_ctx = Context.Named.add d ctxt.env_named_ctx;
     env_named_map = Id.Map.add (NamedDecl.get_id d) (d, rval) ctxt.env_named_map;
-    env_named_var = mkVar (NamedDecl.get_id d) :: ctxt.env_named_var;
+    env_named_idx = Range.cons d ctxt.env_named_idx;
   }
 
 let push_named_context_val d ctxt =
@@ -188,7 +188,7 @@ let match_named_context_val c = match c.env_named_ctx with
 | decl :: ctx ->
   let (_, v) = Id.Map.find (NamedDecl.get_id decl) c.env_named_map in
   let map = Id.Map.remove (NamedDecl.get_id decl) c.env_named_map in
-  let cval = { env_named_ctx = ctx; env_named_map = map; env_named_var = List.tl c.env_named_var } in
+  let cval = { env_named_ctx = ctx; env_named_map = map; env_named_idx = Range.tl c.env_named_idx } in
   Some (decl, v, cval)
 
 let map_named_val f ctxt =
@@ -203,7 +203,9 @@ let map_named_val f ctxt =
   in
   let map, ctx = List.Smart.fold_left_map fold ctxt.env_named_map ctxt.env_named_ctx in
   if map == ctxt.env_named_map then ctxt
-  else { env_named_ctx = ctx; env_named_map = map; env_named_var = ctxt.env_named_var }
+  else
+    let idx = List.fold_right Range.cons ctx Range.empty in
+    { env_named_ctx = ctx; env_named_map = map; env_named_idx = idx }
 
 let push_named d env =
   {env with env_named_context = push_named_context_val d env.env_named_context}

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -62,10 +62,8 @@ type named_context_val = private {
   env_named_ctx : Constr.named_context;
   env_named_map : (Constr.named_declaration * lazy_val) Id.Map.t;
   (** Identifier-indexed version of [env_named_ctx] *)
-  env_named_var : Constr.t list;
-  (** List of identifiers in [env_named_ctx], in the same order, including
-      let-ins. This is not used in the kernel, but is critical to preserve
-      sharing of evar instances in the proof engine. *)
+  env_named_idx : Constr.named_declaration Range.t;
+  (** Same as env_named_ctx but with a fast-access list. *)
 }
 
 type rel_context_val = private {

--- a/kernel/inferCumulativity.ml
+++ b/kernel/inferCumulativity.ml
@@ -177,9 +177,7 @@ let rec infer_fterm cv_pb infos variances hd stk =
       | Meta _ -> infer_stack infos variances stk
       | _ -> assert false
     end
-  | FEvar ((_,args),e) ->
-    let variances = infer_stack infos variances stk in
-    infer_list infos variances (List.map (mk_clos e) args)
+  | FEvar _ -> assert false
   | FRel _ -> infer_stack infos variances stk
   | FInt _ -> infer_stack infos variances stk
   | FFloat _ -> infer_stack infos variances stk
@@ -282,9 +280,6 @@ and infer_stack infos variances (stk:CClosure.stack) =
 
 and infer_vect infos variances v =
   Array.fold_left (fun variances c -> infer_fterm CONV infos variances c []) variances v
-
-and infer_list infos variances v =
-  List.fold_left (fun variances c -> infer_fterm CONV infos variances c []) variances v
 
 let infer_term cv_pb env variances c =
   let open CClosure in

--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -408,7 +408,7 @@ let rec map_kn f f' c =
             if (ct'== ct && l'==l) then c
             else mkApp (ct',l')
       | Evar (e,l) ->
-          let l' = List.Smart.map func l in
+          let l' = SList.Smart.map func l in
             if (l'==l) then c
             else mkEvar (e,l')
       | Fix (ln,(lna,tl,bl)) ->

--- a/kernel/nativelambda.ml
+++ b/kernel/nativelambda.ml
@@ -481,12 +481,12 @@ let rec lambda_of_constr cache env sigma c =
      let ty = meta_type sigma mv in
      Lmeta (mv, lambda_of_constr cache env sigma ty)
 
-  | Evar (evk,args as ev) ->
+  | Evar ev ->
      (match evar_value sigma ev with
-     | None ->
+     | Constr.EvarUndefined (evk, args) ->
         let args = Array.map_of_list (fun c -> lambda_of_constr cache env sigma c) args in
         Levar(evk, args)
-     | Some t -> lambda_of_constr cache env sigma t)
+     | Constr.EvarDefined t -> lambda_of_constr cache env sigma t)
 
   | Cast (c, _, _) -> lambda_of_constr cache env sigma c
 

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -386,7 +386,7 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
                then convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
                else raise NotConvertible
            | _ -> raise NotConvertible)
-    | (FEvar ((ev1,args1),env1), FEvar ((ev2,args2),env2)) ->
+    | (FEvar (ev1, args1, env1, _), FEvar (ev2, args2, env2, _)) ->
         (* TODO: handle irrelevance *)
         if Evar.equal ev1 ev2 then
           let el1 = el_stack lft1 v1 in

--- a/kernel/vmbytegen.ml
+++ b/kernel/vmbytegen.ml
@@ -898,9 +898,7 @@ let compile_constant_body ~fail_on_error env univs = function
             let con= Constant.make1 (Constant.canonical kn') in
               Some (BCalias (get_alias env con))
         | _ ->
-            let evar_expand _ = assert false in
-            let evar_relevance _ = assert false in
-            let sigma = { evar_expand = evar_expand; evar_relevance } in
+            let sigma = Constr.default_evar_handler in
             let res = compile ~fail_on_error ~universes:instance_size env sigma body in
             Option.map (fun (code, fv) -> BCdefined (code, fv)) res
 

--- a/kernel/vmlambda.ml
+++ b/kernel/vmlambda.ml
@@ -631,13 +631,13 @@ open Renv
 let rec lambda_of_constr env c =
   match Constr.kind c with
   | Meta _ -> raise (Invalid_argument "Vmbytegen.lambda_of_constr: Meta")
-  | Evar (evk, args as ev) ->
-      begin match env.evar_body.evar_expand ev with
-      | None ->
-          let args = Array.map_of_list (fun c -> lambda_of_constr env c) args in
-          Levar (evk, args)
-      | Some t -> lambda_of_constr env t
-      end
+  | Evar ev ->
+    begin match env.evar_body.evar_expand ev with
+    | Constr.EvarUndefined (evk, args) ->
+        let args = Array.map_of_list (fun c -> lambda_of_constr env c) args in
+        Levar (evk, args)
+    | Constr.EvarDefined t -> lambda_of_constr env t
+    end
 
   | Cast (c, _, _) -> lambda_of_constr env c
 

--- a/plugins/ssr/ssrelim.ml
+++ b/plugins/ssr/ssrelim.ml
@@ -56,6 +56,7 @@ let analyze_eliminator elimty env sigma =
        let count = ref 0 in
        let rec occur_rec n c = match EConstr.kind sigma c with
          | Rel m -> if m = n then incr count
+         | Evar (_, args) -> SList.Skip.iter (fun c -> occur_rec n c) args
          | _ -> EConstr.iter_with_binders sigma succ occur_rec n c
        in
        occur_rec n term; !count in

--- a/pretyping/cbv.ml
+++ b/pretyping/cbv.ml
@@ -500,13 +500,14 @@ let rec norm_head info env t stack =
       else
         (CBN(t,env), stack) (* Should we consider a commutative cut ? *)
 
-  | Evar ev ->
+  | Evar ((e, _) as ev) ->
       (match Evd.existential_opt_value0 info.sigma ev with
           Some c -> norm_head info env c stack
         | None ->
-          let e, xs = ev in
-          let xs' = List.map (apply_env env) xs in
-          (VAL(0, mkEvar (e,xs')), stack))
+          let ev = EConstr.of_existential ev in
+          let map c = EConstr.of_constr @@ apply_env env (EConstr.Unsafe.to_constr c) in
+          let ev' = EConstr.map_existential info.sigma map ev in
+          (VAL(0, EConstr.Unsafe.to_constr @@ EConstr.mkEvar ev'), stack))
 
   (* non-neutral cases *)
   | Lambda _ ->

--- a/pretyping/constr_matching.ml
+++ b/pretyping/constr_matching.ml
@@ -465,6 +465,7 @@ let matches_core env sigma allow_bound_rels
           Array.fold_left2 (fun subst na1 na2 -> add_binders na1 na2 binding_vars subst) subst lna1 lna2
 
       | PEvar (c1,args1), Evar (c2,args2) when Evar.equal c1 c2 ->
+        let args2 = Evd.expand_existential sigma (c2, args2) in
          List.fold_left2 (sorec ctx env) subst args1 args2
       | PInt i1, Int i2 when Uint63.equal i1 i2 -> subst
 

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -1302,7 +1302,9 @@ let occur_evars sigma evs c =
   if Evar.Set.is_empty evs then false
   else
     let rec occur_rec c = match EConstr.kind sigma c with
-      | Evar (sp,_) when Evar.Set.mem sp evs -> raise Occur
+      | Evar (sp, args) ->
+        if Evar.Set.mem sp evs then raise Occur
+        else SList.Skip.iter occur_rec args
       | _ -> EConstr.iter sigma occur_rec c
     in
     try occur_rec c; false with Occur -> true

--- a/pretyping/evardefine.ml
+++ b/pretyping/evardefine.ml
@@ -8,7 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open Util
 open Pp
 open Names
 open Constr
@@ -112,7 +111,7 @@ let define_evar_as_product env evd (evk,args) =
   (* Quick way to compute the instantiation of evk with args *)
   let na,dom,rng = destProd evd prod in
   let evdom = mkEvar (fst (destEvar evd dom), args) in
-  let evrngargs = mkRel 1 :: List.map (lift 1) args in
+  let evrngargs = SList.cons (mkRel 1) (SList.Skip.map (lift 1) args) in
   let evrng =  mkEvar (fst (destEvar evd rng), evrngargs) in
   evd, mkProd (na, evdom, evrng)
 
@@ -151,7 +150,7 @@ let define_evar_as_lambda env evd (evk,args) =
   let evd,lam = define_pure_evar_as_lambda env evd evk in
   (* Quick way to compute the instantiation of evk with args *)
   let na,dom,body = destLambda evd lam in
-  let evbodyargs = mkRel 1 :: List.map (lift 1) args in
+  let evbodyargs = SList.cons (mkRel 1) (SList.Skip.map (lift 1) args) in
   let evbody = mkEvar (fst (destEvar evd body), evbodyargs) in
   evd, mkLambda (na, dom, evbody)
 
@@ -162,7 +161,7 @@ let rec evar_absorb_arguments env evd (evk,args as ev) = function
       let evd,lam = define_pure_evar_as_lambda env evd evk in
       let _,_,body = destLambda evd lam in
       let evk = fst (destEvar evd body) in
-      evar_absorb_arguments env evd (evk, a :: args) l
+      evar_absorb_arguments env evd (evk, SList.cons a args) l
 
 (* Refining an evar to a sort *)
 

--- a/pretyping/evarsolve.mli
+++ b/pretyping/evarsolve.mli
@@ -127,7 +127,7 @@ val refresh_universes :
   env -> evar_map -> types -> evar_map * types
 
 val solve_refl : ?can_drop:bool -> conversion_check -> unify_flags -> env ->  evar_map ->
-  bool option -> Evar.t -> constr list -> constr list -> evar_map
+  bool option -> Evar.t -> constr SList.t -> constr SList.t -> evar_map
 
 val solve_evar_evar : ?force:bool ->
   (env -> evar_map -> bool option -> existential -> constr -> evar_map) ->

--- a/pretyping/globEnv.ml
+++ b/pretyping/globEnv.ml
@@ -98,14 +98,9 @@ let push_rec_types ~hypnaming sigma (lna,typarray) env =
   Array.map get_annot ctx, env
 
 let new_evar env sigma ?src ?naming typ =
-  let inst_vars = EConstr.identity_subst_val (named_context_val env.renamed_env) in
-  let rec rel_list n accu =
-    if n <= 0 then accu
-    else rel_list (n - 1) (mkRel n :: accu)
-  in
-  let instance = rel_list (nb_rel env.renamed_env) inst_vars in
-  let (subst, _, sign) = Lazy.force env.extra in
-  let typ' = csubst_subst subst typ in
+  let (subst, _, sign) as ext = Lazy.force env.extra in
+  let instance = Evarutil.default_ext_instance ext in
+  let typ' = csubst_subst sigma subst typ in
   let (sigma, evk) = new_pure_evar sign sigma typ' ?src ?naming in
   (sigma, mkEvar (evk, instance))
 

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -407,7 +407,7 @@ and nf_evar env sigma evk args =
   if List.is_empty hyps then begin
     assert (Array.is_empty args);
     let ty = EConstr.to_constr ~abort_on_undefined_evars:false sigma @@ Evd.evar_concl evi in
-    mkEvar (evk, []), ty
+    mkEvar (evk, SList.empty), ty
   end
   else
     (* Let-bound arguments are present in the evar arguments but not
@@ -421,7 +421,7 @@ and nf_evar env sigma evk args =
     (* nf_args takes arguments in the reverse order but produces them
        in the correct one, so we have to reverse them again for the
        evar node *)
-    mkEvar (evk, List.rev args), ty
+    mkEvar (evk, SList.of_full_list @@ List.rev args), ty
 
 and nf_array env sigma t typ =
   let ty, allargs = app_type env sigma (EConstr.of_constr typ) in

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -421,7 +421,7 @@ and nf_evar env sigma evk args =
     (* nf_args takes arguments in the reverse order but produces them
        in the correct one, so we have to reverse them again for the
        evar node *)
-    mkEvar (evk, SList.of_full_list @@ List.rev args), ty
+    EConstr.(Unsafe.to_constr @@ mkLEvar sigma (evk, List.rev_map of_constr args)), ty
 
 and nf_array env sigma t typ =
   let ty, allargs = app_type env sigma (EConstr.of_constr typ) in

--- a/pretyping/pattern.ml
+++ b/pretyping/pattern.ml
@@ -23,7 +23,7 @@ type case_info_pattern =
 type constr_pattern =
   | PRef of GlobRef.t
   | PVar of Id.t
-  | PEvar of constr_pattern Constr.pexistential
+  | PEvar of (Evar.t * constr_pattern list)
   | PRel of int
   | PApp of constr_pattern * constr_pattern array
   | PSoApp of patvar * constr_pattern list

--- a/pretyping/patternops.ml
+++ b/pretyping/patternops.ml
@@ -199,7 +199,9 @@ let pattern_of_constr ~broken env sigma t =
         (* These are the two evar kinds used for existing goals *)
         (* see Proofview.mark_in_evm *)
          if Evd.is_defined sigma evk then pattern_of_constr env (Evd.existential_value0 sigma ev)
-         else PEvar (evk,List.map (pattern_of_constr env) ctxt)
+         else
+          let ctxt = Evd.expand_existential sigma (EConstr.of_existential ev) in
+          PEvar (evk,List.map (fun c -> pattern_of_constr env (EConstr.Unsafe.to_constr c)) ctxt)
       | Evar_kinds.MatchingVar (Evar_kinds.SecondOrderPatVar ido) -> assert false
       | _ ->
         PMeta None)

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -643,7 +643,7 @@ struct
         with Not_found -> error_evar_not_found ?loc:locid !!env sigma id in
       let hyps = evar_filtered_context (Evd.find sigma evk) in
       let sigma, args = pretype_instance self ~flags env sigma loc hyps evk inst in
-      let c = mkEvar (evk, args) in
+      let c = mkLEvar sigma (evk, args) in
       let j = Retyping.get_judgment_of !!env sigma c in
       discard_trace @@ inh_conv_coerce_to_tycon ?loc ~flags env sigma j tycon
 

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -95,7 +95,7 @@ let evaluable_reference_eq sigma r1 r2 = match r1, r2 with
 | EvalVar id1, EvalVar id2 -> Id.equal id1 id2
 | EvalRel i1, EvalRel i2 -> Int.equal i1 i2
 | EvalEvar (e1, ctx1), EvalEvar (e2, ctx2) ->
-  Evar.equal e1 e2 && List.equal (EConstr.eq_constr sigma) ctx1 ctx2
+  EConstr.eq_constr sigma (mkEvar (e1, ctx1)) (mkEvar (e2, ctx2))
 | _ -> false
 
 let mkEvalRef ref u =
@@ -392,7 +392,7 @@ let substl_with_function subst sigma constr =
         let (sigma, evk) = Evarutil.new_pure_evar empty_named_context_val sigma dummy in
         evd := sigma;
         minargs := Evar.Map.add evk (min, fx, ref) !minargs;
-        mkEvar (evk, [])
+        mkEvar (evk, SList.empty)
       | (fx, None) -> Vars.lift k fx
     else mkRel (i - Array.length v)
   | _ ->
@@ -439,7 +439,7 @@ let substl_checking_arity env subst sigma c =
   (* we propagate the constraints: solved problems are substituted;
      the other ones are replaced by the function symbol *)
   let rec nf_fix k c = match EConstr.kind sigma c with
-  | Evar (i, []) ->
+  | Evar (i, SList.Nil) ->
     (* FIXME: find a less hackish way of doing this *)
     begin match Evar.Map.find i minargs with
     | (_, fx, ref) ->

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -88,6 +88,7 @@ let occur_meta_evd sigma mv c =
     let c = whd_meta sigma c in
     match EConstr.kind sigma c with
     | Meta mv' when Int.equal mv mv' -> raise Occur
+    | Evar (_, args) -> SList.Skip.iter occrec args
     | _ -> EConstr.iter sigma occrec c
   in try occrec c; false with Occur -> true
 

--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -224,8 +224,9 @@ and nf_evar env sigma evk stk =
     let t, args = nf_args env sigma args t in
     let inst, args = Array.chop (List.length hyps) args in
     (* Evar instances are reversed w.r.t. argument order *)
-    let inst = Array.rev_to_list inst in
-    let c = mkApp (mkEvar (evk, SList.of_full_list inst), args) in
+    let inst = Array.to_list inst in
+    let ev = EConstr.(Unsafe.to_constr @@ mkLEvar sigma (evk, List.rev_map of_constr inst)) in
+    let c = mkApp (ev, args) in
     nf_stk env sigma c t stk
   | _ ->
     CErrors.anomaly (Pp.str "Argument size mismatch when decompiling an evar")

--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -209,7 +209,7 @@ and nf_evar env sigma evk stk =
   let hyps = EConstr.named_context_of_val (Evd.evar_filtered_hyps evi) in
   if List.is_empty hyps then
     let concl = EConstr.to_constr ~abort_on_undefined_evars:false sigma @@ Evd.evar_concl evi in
-    nf_stk env sigma (mkEvar (evk, [])) concl stk
+    nf_stk env sigma (mkEvar (evk, SList.empty)) concl stk
   else match stk with
   | Zapp args :: stk ->
     (* We assume that there is no consecutive Zapp nodes in a VM stack. Is that
@@ -225,7 +225,7 @@ and nf_evar env sigma evk stk =
     let inst, args = Array.chop (List.length hyps) args in
     (* Evar instances are reversed w.r.t. argument order *)
     let inst = Array.rev_to_list inst in
-    let c = mkApp (mkEvar (evk, inst), args) in
+    let c = mkApp (mkEvar (evk, SList.of_full_list inst), args) in
     nf_stk env sigma c t stk
   | _ ->
     CErrors.anomaly (Pp.str "Argument size mismatch when decompiling an evar")

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -658,7 +658,7 @@ let should_print_dependent_evars =
 let evar_nodes_of_term c =
   let rec evrec acc c =
     match kind c with
-    | Evar (n, l) -> Evar.Set.add n (List.fold_left evrec acc l)
+    | Evar (n, l) -> Evar.Set.add n (SList.Skip.fold evrec acc l)
     | _ -> Constr.fold evrec acc c
   in
   evrec Evar.Set.empty (EConstr.Unsafe.to_constr c)

--- a/tactics/btermdn.ml
+++ b/tactics/btermdn.ml
@@ -71,7 +71,7 @@ let decomp sigma t =
     | App (f,l) -> decrec (Array.fold_right (fun a l -> a::l) l acc) f
     | Proj (p, c) ->
       (* Hack: fake evar to generate [Everything] in the functions below *)
-      let hole = mkEvar (Evar.unsafe_of_int (-1), []) in
+      let hole = mkEvar (Evar.unsafe_of_int (-1), SList.empty) in
       let params = List.make (Projection.npars p) hole in
       (mkConst (Projection.constant p), params @ c :: acc)
     | Cast (c1,_,_) -> decrec acc c1

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -1549,7 +1549,7 @@ let assert_replacing id newt tac =
         if Id.equal n id then ev' else mkVar n
       in
       let (e, _) = destEvar sigma ev in
-      (sigma, mkEvar (e, List.map map nc))
+      (sigma, mkLEvar sigma (e, List.map map nc))
     end
   end in
   Proofview.tclTHEN prf (Proofview.tclFOCUS 2 2 tac)

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -176,7 +176,7 @@ let fold_with_full_binders g f n acc c =
   | LetIn (na,b,t,c) -> f (g (LocalDef (na,b,t)) n) (f n (f n acc b) t) c
   | App (c,l) -> Array.fold_left (f n) (f n acc c) l
   | Proj (_,c) -> f n acc c
-  | Evar (_,l) -> List.fold_left (f n) acc l
+  | Evar _ -> assert false
   | Case (ci, u, pms, p, iv, c, bl) ->
     let mib = lookup_mind (fst ci.ci_ind) in
     let (ci, p, iv, c, bl) = Inductive.expand_case_specif mib (ci, u, pms, p, iv, c, bl) in

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -66,7 +66,9 @@ let rec contract3' env sigma a b c = function
   | OccurCheck (evk,d) ->
     let x,d = contract4 env sigma a b c d in x,OccurCheck(evk, d)
   | NotClean ((evk,args),env',d) ->
+      let args = Evd.expand_existential sigma (evk, args) in
       let env',d,args = contract1 env' sigma d args in
+      let args = SList.of_full_list args in
       contract3 env sigma a b c,NotClean((evk,args),env',d)
   | ConversionFailed (env',t1,t2) ->
       let (env',t1,t2) = contract2 env' sigma t1 t2 in
@@ -301,6 +303,7 @@ let explain_unification_error env sigma p1 p2 = function
         strbrk " with term " ++ pr_leconstr_env env sigma rhs ++
         strbrk " that would depend on itself"]
      | NotClean ((evk,args),env,c) ->
+        let args = Evd.expand_existential sigma (evk, args) in
         let env = make_all_name_different env sigma in
         [str "cannot instantiate " ++ quote (pr_existential_key env sigma evk)
         ++ strbrk " because " ++ pr_leconstr_env env sigma c ++

--- a/vernac/retrieveObl.ml
+++ b/vernac/retrieveObl.ml
@@ -71,6 +71,7 @@ let subst_evar_constr evm evs n idf t =
          and we must not apply to defined ones (i.e. LetIn's)
       *)
       let args =
+        let args = Evd.expand_existential evm (k, args) in
         let n = match chop with None -> 0 | Some c -> c in
         let l, r = CList.chop n (List.rev args) in
         List.rev r


### PR DESCRIPTION
We use a form of sparse lists, so that bunches of identity instances are represented as a O(1) constructor.

Overlays:
- https://github.com/mattam82/Coq-Equations/pull/512
- https://github.com/MetaCoq/metacoq/pull/755
- https://github.com/QuickChick/QuickChick/pull/304
- https://github.com/LPCIC/coq-elpi/pull/391
- https://github.com/lukaszcz/coqhammer/pull/148
- https://github.com/unicoq/unicoq/pull/74
- https://github.com/Mtac2/Mtac2/pull/368

Fixes #12526
