### PR TITLE
Do not reason up to aliasing in Evarsolve.assoc_up_to_alias.

### DIFF
--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -912,14 +912,7 @@ let rec assoc_up_to_alias sigma aliases y = function
     | None -> assoc_up_to_alias sigma aliases y l
     | Some c ->
       if eq_alias c y then id
-      else
-        match l with
-        | _ :: _ -> assoc_up_to_alias sigma aliases y l
-        | [] ->
-          (* Last chance, we reason up to alias conversion *)
-          let cc = normalize_alias sigma aliases c in
-          let yc = normalize_alias sigma aliases y in
-          if eq_alias cc yc then id else raise Not_found
+      else assoc_up_to_alias sigma aliases y l
 
 let rec find_projectable_vars aliases sigma y subst =
   let is_projectable _ idcl (subst1,subst2 as subst') =


### PR DESCRIPTION
This particular quirk was introduced by bfefc3f to allegedly solve an issue with the aliasing mechanism that was long forgotten to the mist of time. Now, given the current implementation I am not even sure how to trigger this piece of code in a way that makes an observable difference. Given that this prevents an efficient implementation of the lookup, I think that it is reasonable to simply remove it.
