### PR TITLE
Warn about redundant catch-all clause in Ltac2 pattern match

### DIFF
--- a/plugins/ltac2/tac2intern.ml
+++ b/plugins/ltac2/tac2intern.ml
@@ -132,14 +132,14 @@ let is_rec_rhs = function
 | GTacCse _ | GTacOpn _ | GTacWth _ | GTacFullMatch _-> false
 
 let warn_not_unit =
-  CWarnings.create ~name:"not-unit" ~category:"ltac"
+  CWarnings.create ~name:"not-unit" ~category:"ltac2"
     (fun (env, t) ->
       strbrk "This expression should have type unit but has type " ++
       pr_glbtype env t ++ str ".")
 
 let warn_redundant_clause =
-  CWarnings.create ~name:"redundant-clause" ~category:"ltac"
-    (fun () -> strbrk "The following clause is redundant.")
+  CWarnings.create ~name:"redundant-clause" ~category:"ltac2"
+    (fun () -> strbrk "Redundant branch in match.")
 
 let check_elt_unit loc env t =
   let maybe_unit = match kind env t with

--- a/test-suite/output/ltac2_match_warning_14135.out
+++ b/test-suite/output/ltac2_match_warning_14135.out
@@ -1,0 +1,4 @@
+File "./output/ltac2_match_warning_14135.v", line 19, characters 4-10:
+Warning: The following clause is redundant. [redundant-clause,ltac]
+File "./output/ltac2_match_warning_14135.v", line 26, characters 4-5:
+Warning: The following clause is redundant. [redundant-clause,ltac]

--- a/test-suite/output/ltac2_match_warning_14135.out
+++ b/test-suite/output/ltac2_match_warning_14135.out
@@ -1,4 +1,4 @@
 File "./output/ltac2_match_warning_14135.v", line 19, characters 4-10:
-Warning: The following clause is redundant. [redundant-clause,ltac]
+Warning: Redundant branch in match. [redundant-clause,ltac2]
 File "./output/ltac2_match_warning_14135.v", line 26, characters 4-5:
-Warning: The following clause is redundant. [redundant-clause,ltac]
+Warning: Redundant branch in match. [redundant-clause,ltac2]

--- a/test-suite/output/ltac2_match_warning_14135.v
+++ b/test-suite/output/ltac2_match_warning_14135.v
@@ -1,0 +1,27 @@
+Require Import Ltac2.Ltac2.
+
+Ltac2 good_1(o: 'a option) :=
+  match o with
+  | Some x => 1
+  | None => 2
+  end.
+
+Ltac2 good_2(o: 'a option) :=
+  match o with
+  | Some x => 1
+  | _ => 2
+  end.
+
+Ltac2 redundant_constructor(o: 'a option) :=
+  match o with
+  | Some x => 1
+  | None => 2
+  | Some y => 3
+  end.
+
+Ltac2 redundant_catch_all(o: 'a option) :=
+  match o with
+  | Some x => 1
+  | None => 2
+  | _ => 3
+  end.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #14135

Fix applies only to the basic Ltac2 pattern match, not the deep match (#16023) - the deep match has no redundancy warnings at all yet 

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

