### PR TITLE
Fast Evarsolve aliasing algorithm

### DIFF
--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -457,23 +457,23 @@ let lift_aliases n aliases =
   in
   { aliases with rel_aliases }
 
-let get_alias_chain_of sigma aliases x = match x with
+let get_alias_chain_of aliases x = match x with
   | RelAlias n -> (try Some (Int.Map.find n aliases.rel_aliases) with Not_found -> None)
   | VarAlias id -> (try Some (cast_alias_chain (Id.Map.find id aliases.var_aliases)) with Not_found -> None)
 
 (* Expand an alias as much as possible while remaining a variable *)
 (* i.e. returns either a declared variable [y], or the last expansion
    of [x] defined to be [c] and [c] is not a variable *)
-let normalize_alias sigma aliases x =
-  match get_alias_chain_of sigma aliases x with
+let normalize_alias aliases x =
+  match get_alias_chain_of aliases x with
   | None | Some (NonVarAliasChain ([], _)) -> x
   | Some (NonVarAliasChain (l, _)) -> List.last l
   | Some (VarAliasChain (_, a)) -> a
 
 (* Idem, specifically for named variables *)
-let normalize_alias_var sigma var_aliases id =
+let normalize_alias_var var_aliases id =
   let aliases = { var_aliases; rel_aliases = Int.Map.empty } in
-  match normalize_alias sigma aliases (VarAlias id) with
+  match normalize_alias aliases (VarAlias id) with
   | VarAlias id -> id
   | RelAlias _ -> assert false (** var only aliases to variables *)
 
@@ -501,27 +501,27 @@ let extend_alias sigma decl { var_aliases; rel_aliases } =
     | LocalAssum _ -> rel_aliases in
   { var_aliases; rel_aliases }
 
-let expand_alias_once sigma aliases x =
-  match get_alias_chain_of sigma aliases x with
+let expand_alias_once aliases x =
+  match get_alias_chain_of aliases x with
   | None -> None
   | Some (VarAliasChain (x :: _, _) | NonVarAliasChain (x :: _, _) | VarAliasChain ([], x)) -> Some (Alias.make (of_alias x))
   | Some (NonVarAliasChain ([], a)) -> Some a
 
-let expansions_of_var sigma aliases x =
-  match get_alias_chain_of sigma aliases x with
+let expansions_of_var aliases x =
+  match get_alias_chain_of aliases x with
   | None -> [x]
   | Some (VarAliasChain (l, y)) -> x :: l @ [y]
   | Some (NonVarAliasChain (l, _)) -> x :: l
 
 let expansion_of_var sigma aliases x =
-  match get_alias_chain_of sigma aliases x with
+  match get_alias_chain_of aliases x with
   | None -> (false, Some x, [])
   | Some (VarAliasChain (l, x)) -> (true, Some x, l)
   | Some (NonVarAliasChain (l, a)) -> (true, Alias.repr sigma a, l)
 
 let rec expand_vars_in_term_using env sigma aliases t = match EConstr.kind sigma t with
-  | Rel n -> of_alias (normalize_alias sigma aliases (RelAlias n))
-  | Var id -> of_alias (normalize_alias sigma aliases (VarAlias id))
+  | Rel n -> of_alias (normalize_alias aliases (RelAlias n))
+  | Var id -> of_alias (normalize_alias aliases (VarAlias id))
   | _ ->
     let self aliases c = expand_vars_in_term_using env sigma aliases c in
     map_constr_with_full_binders env sigma (extend_alias sigma) self aliases t
@@ -574,8 +574,8 @@ let free_vars_and_rels_up_alias_expansion env sigma aliases c =
 (* Managing pattern-unification *)
 (********************************)
 
-let expand_and_check_vars sigma aliases l =
-  let map a = match get_alias_chain_of sigma aliases a with
+let expand_and_check_vars aliases l =
+  let map a = match get_alias_chain_of aliases a with
   | None -> Some a
   | Some (VarAliasChain (_, a)) -> Some a
   | Some (NonVarAliasChain ([], c)) -> None
@@ -621,7 +621,7 @@ let remove_instance_local_defs evd evk args =
 
 let find_unification_pattern_args env evd l t =
   let aliases = make_alias_map env evd in
-  match expand_and_check_vars evd aliases l with
+  match expand_and_check_vars aliases l with
   | Some l as x when distinct_actual_deps env evd aliases l t -> x
   | _ -> None
 
@@ -730,7 +730,7 @@ let make_projectable_subst aliases sigma evi args =
             let revmap = Id.Map.add id i revmap in
             (match EConstr.kind sigma c with
             | Var id' ->
-                let idc = normalize_alias_var sigma evar_aliases id' in
+                let idc = normalize_alias_var evar_aliases id' in
                 let ic, sub =
                   try let ic = Id.Map.find idc revmap in ic, Int.Map.find ic all
                   with Not_found -> i, [] (* e.g. [idc] is a filtered variable: treat [id] as an assumption *) in
@@ -1028,7 +1028,7 @@ let invert_arg_from_subst evd aliases k0 subst_in_env_extended_with_k_binders c_
   and aux' k t =
     try project_with_effects aliases evd t subst_in_env_extended_with_k_binders
     with Not_found ->
-      match expand_alias_once evd aliases t with
+      match expand_alias_once aliases t with
       | None -> raise Not_found
       | Some c -> aux k (Alias.eval (Alias.lift k c)) in
   try
@@ -1577,7 +1577,7 @@ let rec invert_definition unify flags choose imitate_defs
           let ty = Retyping.get_type_of env !evdref t' in
           let (evd,evar,(evk',argsv' as ev')) =
             materialize_evar (evar_define unify flags ~choose) env !evdref 0 ev ty in
-          let ts = expansions_of_var evd aliases t in
+          let ts = expansions_of_var aliases t in
           let test c = isEvar evd c || List.exists (is_alias evd c) ts in
           let filter = restrict_upon_filter evd evk test argsv' in
           let filter = closure_of_filter ~can_drop:choose evd evk' filter in


### PR DESCRIPTION
This PR tweaks the Evarsolve aliasing algorithm to change its algorithmic complexity, reducing it from O(n²) to O(n log n) where n is the length of the considered context. It can also be considered as a clean up because it exposes more invariants in the structure, factorizes code and removes dead parts.