### PR TITLE
Remove type-unsafe primitives in Proof.focus_kind.

### DIFF
--- a/proofs/proof.mli
+++ b/proofs/proof.mli
@@ -132,7 +132,7 @@ val done_cond : ?loose_end:bool -> 'a focus_kind -> 'a focus_condition
 val focus : 'a focus_condition -> 'a -> int -> t -> t
 
 (* focus on goal named id *)
-val focus_id : 'aa focus_condition -> 'a -> Names.Id.t -> t -> t
+val focus_id : 'a focus_condition -> 'a -> Names.Id.t -> t -> t
 
 exception FullyUnfocused
 exception CannotUnfocusThisWay


### PR DESCRIPTION
Incidentally fix a potential type unsoundness in Proof.focus_id which had a typo in its signature.
