### PR TITLE
Ltac2: Reuse result of general pattern interning for simple cases

### DIFF
--- a/plugins/ltac2/tac2intern.ml
+++ b/plugins/ltac2/tac2intern.ml
@@ -103,15 +103,6 @@ let fresh_mix_type_scheme env (t : mix_type_scheme) : TVar.t glb_typexpr =
   in
   subst_type substf t
 
-let fresh_reftype env (kn : KerName.t or_tuple) =
-  let n = match kn with
-  | Other kn -> fst (Tac2env.interp_type kn)
-  | Tuple n -> n
-  in
-  let subst = Array.init n (fun _ -> fresh_id env) in
-  let t = GTypRef (kn, Array.map_to_list (fun i -> GTypVar i) subst) in
-  (subst, t)
-
 (** Term typing *)
 
 let is_pure_constructor kn =
@@ -217,53 +208,6 @@ let get_projection var = match var with
 let intern_atm env = function
 | AtmInt n -> (GTacAtm (AtmInt n), GTypRef (Other t_int, []))
 | AtmStr s -> (GTacAtm (AtmStr s), GTypRef (Other t_string, []))
-
-let invalid_pattern ?loc kn kn' =
-  let pr t = match t with
-  | Other kn' -> str "type " ++  pr_typref kn'
-  | Tuple n -> str "tuple of size " ++ int n
-  in
-  user_err ?loc (str "Invalid pattern, expected a pattern for " ++
-    pr kn ++ str ", found a pattern for " ++ pr kn') (** FIXME *)
-
-(** Pattern view *)
-
-type glb_patexpr =
-| GEPatVar of Name.t
-| GEPatRef of ltac_constructor or_tuple * glb_patexpr list
-
-exception HardCase
-
-let rec intern_patexpr env {loc;v=pat} = match pat with
-| CPatVar na -> GEPatVar na
-| CPatRef (qid, pl) ->
-  let kn = get_constructor env qid in
-  GEPatRef (kn, List.map (fun p -> intern_patexpr env p) pl)
-| CPatAtm _ | CPatCnv _ | CPatOr _ | CPatAs _ | CPatRecord _ ->
-  raise HardCase
-
-type pattern_kind =
-| PKind_empty
-| PKind_variant of type_constant or_tuple
-| PKind_open of type_constant
-| PKind_any
-
-let get_pattern_kind env pl = match pl with
-| [] -> PKind_empty
-| p :: pl ->
-  let rec get_kind (p, _) pl = match intern_patexpr env p with
-  | GEPatVar _ ->
-    begin match pl with
-    | [] -> PKind_any
-    | p :: pl -> get_kind p pl
-    end
-  | GEPatRef (Other kn, pl) ->
-    let data = Tac2env.interp_constructor kn in
-    if Option.is_empty data.cdata_indx then PKind_open data.cdata_type
-    else PKind_variant (Other data.cdata_type)
-  | GEPatRef (Tuple _, tp) -> PKind_variant (Tuple (List.length tp))
-  in
-  get_kind p pl
 
 (** Internalization *)
 
@@ -742,7 +686,7 @@ and lift_interned_pat_r = let open PartialPat in function
     | PatOr pats -> Or (List.map lift_interned_pat pats)
     | PatAs (p,x) -> As (lift_interned_pat p, x.v)
 
-(* invariant: ts is n types, pats is a matrix with n columns (nth pats i is row i) *)
+(* invariant: ts is n types, pats is a matrix with n columns ([nth pats i] is row i) *)
 let rec missing_matches env ts pats n =
   match n with
   | 0 -> begin match pats with [] -> Some [] | _::_ -> None end
@@ -787,6 +731,47 @@ let analyze_case env t pats =
                            pr_partial_pat missing)
   in
   ()
+
+(** Pattern view *)
+
+type glb_patexpr =
+| GEPatVar of Name.t
+| GEPatRef of ctor_data_for_patterns or_tuple * glb_patexpr list
+
+exception HardCase
+
+let rec to_patexpr env {loc;v=pat} = match pat with
+| PatVar na -> GEPatVar na
+| PatRef (ctor, pl) ->
+  GEPatRef (ctor, List.map (fun p -> to_patexpr env p) pl)
+| PatAtm _ | PatOr _ | PatAs _ ->
+  raise HardCase
+
+type pattern_kind =
+| PKind_empty
+| PKind_variant of type_constant or_tuple
+| PKind_open
+| PKind_any
+
+let get_pattern_kind env pl = match pl with
+| [] -> PKind_empty
+| p :: pl ->
+  let rec get_kind ((p:wip_pat), _) pl = match to_patexpr env p with
+  | GEPatVar _ ->
+    begin match pl with
+    | [] -> PKind_any
+    | p :: pl -> get_kind p pl
+    end
+  | GEPatRef (Other kn, pl) -> begin match kn.cindx with
+      | Open kn -> PKind_open
+      | Closed _ -> PKind_variant (Other kn.ctyp)
+    end
+    (* let data = Tac2env.interp_constructor kn in *)
+    (* if Option.is_empty data.cdata_indx then PKind_open data.cdata_type *)
+    (* else PKind_variant (Other data.cdata_type) *)
+  | GEPatRef (Tuple k, tp) -> PKind_variant (Tuple k)
+  in
+  get_kind p pl
 
 let rec intern_rec env {loc;v=e} = match e with
 | CTacAtm atm -> intern_atm env atm
@@ -896,9 +881,14 @@ let rec intern_rec env {loc;v=e} = match e with
   let () = unify ?loc:loc1 env t1 t2 in
   (GTacCse (e, Other t_bool, [|e1; e2|], [||]), t2)
 | CTacCse (e, pl) ->
-  let e',brs,rt = super_intern_case env loc e pl in
-  begin try intern_case env loc e pl
-  with HardCase -> GTacFullMatch (e',brs), rt
+  let e,brs,rt = super_intern_case env loc e pl in
+  begin try
+    let cse = intern_case env ?loc e brs in
+    cse, rt
+  with HardCase ->
+    let e, _ = e in
+    let brs = List.map (fun (p,br) -> glb_of_wip_pat p, br) brs in
+    GTacFullMatch (e,brs), rt
   end
 | CTacRec fs ->
   let kn, tparam, args = intern_record intern_rec_with_constraint env loc fs in
@@ -1024,142 +1014,104 @@ and intern_let_rec env loc ids el e =
 
 (** For now, patterns recognized by the pattern-matching compiling are limited
     to depth-one where leaves are either variables or catch-all *)
-and intern_case env loc e pl =
-  let (e', t) = intern_rec env e in
-  let todo ?loc () = raise HardCase in
+and intern_case env ?loc (e,t) pl =
+  let todo () = raise HardCase in
   match get_pattern_kind env pl with
   | PKind_any ->
     let (pat, b) = List.hd pl in
-    let na = match intern_patexpr env pat with
+    let na = match to_patexpr env pat with
     | GEPatVar na -> na
     | _ -> assert false
     in
     let () = check_redundant_clause (List.tl pl) in
-    let env = push_name na (monomorphic t) env in
-    let (b, tb) = intern_rec env b in
-    (GTacLet (false, [na, e'], b), tb)
+    GTacLet (false, [na, e], b)
   | PKind_empty ->
     let kn = check_elt_empty loc env t in
-    let r = fresh_id env in
-    (GTacCse (e', Other kn, [||], [||]), GTypVar r)
+    GTacCse (e, Other kn, [||], [||])
   | PKind_variant kn ->
-    let subst, tc = fresh_reftype env kn in
-    let () = unify ?loc:e.loc env t tc in
     let (nconst, nnonconst, arities) = match kn with
     | Tuple 0 -> 1, 0, [0]
     | Tuple n -> 0, 1, [n]
     | Other kn ->
       let (_, def) = Tac2env.interp_type kn in
-      let galg = match def with | GTydAlg c -> c | _ -> assert false in
+      let galg = match def with
+        | GTydAlg c -> c
+        | GTydRec _ -> raise HardCase
+        | _ -> assert false
+      in
       let arities = List.map (fun (_, args) -> List.length args) galg.galg_constructors in
       galg.galg_nconst, galg.galg_nnonconst, arities
     in
     let const = Array.make nconst None in
     let nonconst = Array.make nnonconst None in
-    let ret = GTypVar (fresh_id env) in
     let rec intern_branch = function
     | [] -> ()
     | (pat, br) :: rem ->
-      let tbr = match pat.v with
-      | CPatAtm _ | CPatCnv _ | CPatOr _ | CPatAs _ | CPatRecord _ ->
+      let () = match pat.v with
+      | PatAtm _ | PatOr _ | PatAs _ ->
         raise HardCase
-      | CPatVar (Name _) ->
-        let loc = pat.loc in
-        todo ?loc ()
-      | CPatVar Anonymous ->
+      | PatVar (Name _) -> todo ()
+      | PatVar Anonymous ->
         let () = check_redundant_clause rem in
-        let (br', brT) = intern_rec env br in
         (* Fill all remaining branches *)
         let fill (ncst, narg) arity =
           if Int.equal arity 0 then
             let () =
-              if Option.is_empty const.(ncst) then const.(ncst) <- Some br'
+              if Option.is_empty const.(ncst) then const.(ncst) <- Some br
             in
             (succ ncst, narg)
           else
             let () =
               if Option.is_empty nonconst.(narg) then
                 let ids = Array.make arity Anonymous in
-                nonconst.(narg) <- Some (ids, br')
+                nonconst.(narg) <- Some (ids, br)
             in
             (ncst, succ narg)
         in
-        let _ = List.fold_left fill (0, 0) arities in
-        brT
-      | CPatRef (qid, args) ->
+        let _, _ = List.fold_left fill (0, 0) arities in
+        ()
+      | PatRef (ctor, args) ->
         let loc = pat.loc in
-        let knc = get_constructor env qid in
-        let kn', index, arity = match knc with
-        | Tuple n -> Tuple n, 0, List.init n (fun i -> GTypVar i)
-        | Other knc ->
-          let data = Tac2env.interp_constructor knc in
-          let index = Option.get data.cdata_indx in
-          Other data.cdata_type, index, data.cdata_args
+        let index = match ctor with
+        | Tuple _ -> 0
+        | Other {cindx=Closed i} -> i
+        | Other {cindx=Open _} -> assert false (* Open in PKind_variant is forbidden by typing *)
         in
-        let () =
-          if not (eq_or_tuple KerName.equal kn kn') then
-            invalid_pattern ?loc kn kn'
-        in
-        let get_id pat = match pat with
-        | {v=CPatVar na} -> na
-        | {loc} -> todo ?loc ()
+        let get_id pat = match pat.v with
+        | PatVar na -> na
+        | _ -> todo ()
         in
         let ids = List.map get_id args in
-        let nids = List.length ids in
-        let nargs = List.length arity in
-        let () = match knc with
-        | Tuple n -> assert (n == nids)
-        | Other knc ->
-          if not (Int.equal nids nargs) then error_nargs_mismatch ?loc knc nargs nids
-        in
-        let fold env id tpe =
-          (* Instantiate all arguments *)
-          let subst n = GTypVar subst.(n) in
-          let tpe = subst_type subst tpe in
-          push_name id (monomorphic tpe) env
-        in
-        let nenv = List.fold_left2 fold env ids arity in
-        let (br', brT) = intern_rec nenv br in
         let () =
           if List.is_empty args then
-            if Option.is_empty const.(index) then const.(index) <- Some br'
+            if Option.is_empty const.(index) then const.(index) <- Some br
             else warn_redundant_clause ?loc ()
           else
             let ids = Array.of_list ids in
-            if Option.is_empty nonconst.(index) then nonconst.(index) <- Some (ids, br')
+            if Option.is_empty nonconst.(index) then nonconst.(index) <- Some (ids, br)
             else warn_redundant_clause ?loc ()
         in
-        brT
+        ()
       in
-      let () = unify ?loc:br.loc env tbr ret in
       intern_branch rem
     in
     let () = intern_branch pl in
     let map n is_const = function
-    | None ->
-      let kn = match kn with Other kn -> kn | _ -> assert false in
-      let cstr = pr_internal_constructor kn n is_const in
-      user_err ?loc (str "Unhandled match case for constructor " ++ cstr)
+    | None -> assert false (* exhaustivity check *)
     | Some x -> x
     in
     let const = Array.mapi (fun i o -> map i true o) const in
     let nonconst = Array.mapi (fun i o -> map i false o) nonconst in
-    let ce = GTacCse (e', kn, const, nonconst) in
-    (ce, ret)
-  | PKind_open kn ->
-    let subst, tc = fresh_reftype env (Other kn) in
-    let () = unify ?loc:e.loc env t tc in
-    let ret = GTypVar (fresh_id env) in
+    GTacCse (e, kn, const, nonconst)
+  | PKind_open ->
     let rec intern_branch map = function
     | [] ->
       user_err ?loc (str "Missing default case")
     | (pat, br) :: rem ->
-      match intern_patexpr env pat with
+      match to_patexpr env pat with
       | GEPatVar na ->
         let () = check_redundant_clause rem in
-        let nenv = push_name na (monomorphic tc) env in
-        let br' = intern_rec_with_constraint nenv br ret in
-        let def = (na, br') in
+        let def = (na, br) in
         (map, def)
       | GEPatRef (knc, args) ->
         let get = function
@@ -1168,39 +1120,21 @@ and intern_case env loc e pl =
         in
         let loc = pat.loc in
         let knc = match knc with
-        | Other knc -> knc
-        | Tuple n -> invalid_pattern ?loc (Other kn) (Tuple n)
+        | Other {cindx=Open knc} -> knc
+        | Other {cindx=Closed _} | Tuple _ -> assert false (* Closed / Tuple in PKind_open is forbidden by typing *)
         in
         let ids = List.map get args in
-        let data = Tac2env.interp_constructor knc in
-        let () =
-          if not (KerName.equal kn data.cdata_type) then
-            invalid_pattern ?loc (Other kn) (Other data.cdata_type)
-        in
-        let nids = List.length ids in
-        let nargs = List.length data.cdata_args in
-        let () =
-          if not (Int.equal nids nargs) then error_nargs_mismatch ?loc knc nargs nids
-        in
-        let fold env id tpe =
-          (* Instantiate all arguments *)
-          let subst n = GTypVar subst.(n) in
-          let tpe = subst_type subst tpe in
-          push_name id (monomorphic tpe) env
-        in
-        let nenv = List.fold_left2 fold env ids data.cdata_args in
-        let br' = intern_rec_with_constraint nenv br ret in
         let map =
           if KNmap.mem knc map then
             let () = warn_redundant_clause ?loc () in
             map
           else
-            KNmap.add knc (Anonymous, Array.of_list ids, br') map
+            KNmap.add knc (Anonymous, Array.of_list ids, br) map
         in
         intern_branch map rem
     in
     let (map, def) = intern_branch KNmap.empty pl in
-    (GTacWth { opn_match = e'; opn_branch = map; opn_default = def }, ret)
+    GTacWth { opn_match = e; opn_branch = map; opn_default = def }
 
 and intern_constructor env loc kn args = match kn with
 | Other kn ->
@@ -1245,8 +1179,7 @@ and super_intern_case env loc e pl =
       pl
   in
   let () = analyze_case env et (List.map fst pl) in
-  let pl = List.map (fun (p,br) -> glb_of_wip_pat p, br) pl in
-  (e,pl,rt)
+  ((e,et),pl,rt)
 
 type context = (Id.t * type_scheme) list
 


### PR DESCRIPTION
The redundant clause checks are preserved as they are not yet done in the general case.