### PR TITLE
Correctly implement dest_arity for EConstr.

### DIFF
--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -1389,14 +1389,12 @@ let solve_evar_evar ?(force=false) f unify flags env evd pbty (evk1,args1 as ev1
       (* ?X : Π Δ. Type i = ?Y : Π Δ'. Type j.
          The body of ?X and ?Y just has to be of type Π Δ. Type k for some k <= i, j. *)
       let evienv = Evd.evar_env env evi in
-      let concl1 = EConstr.Unsafe.to_constr evi.evar_concl in
-      let ctx1, i = Reduction.dest_arity evienv concl1 in
-      let ctx1 = List.map (fun c -> map_rel_decl EConstr.of_constr c) ctx1 in
+      let ctx1, i = Reductionops.dest_arity evienv evd evi.evar_concl in
       let evi2 = Evd.find evd evk2 in
       let evi2env = Evd.evar_env env evi2 in
-      let concl2 = EConstr.Unsafe.to_constr evi2.evar_concl in
-      let ctx2, j = Reduction.dest_arity evi2env concl2 in
-      let ctx2 = List.map (fun c -> map_rel_decl EConstr.of_constr c) ctx2 in
+      let ctx2, j = Reductionops.dest_arity evi2env evd evi2.evar_concl in
+      let i = ESorts.kind evd i in
+      let j = ESorts.kind evd j in
         if i == j || Evd.check_eq evd i j
         then (* Shortcut, i = j *)
           evd

--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -197,6 +197,9 @@ val splay_prod_n : env ->  evar_map -> int -> constr -> rel_context * constr
 val splay_lam_n : env ->  evar_map -> int -> constr -> rel_context * constr
 (** Raises [Invalid_argument] *)
 
+val dest_arity : env -> evar_map -> constr -> rel_context * ESorts.t
+(** Raises [Reduction.NotArity] *)
+
 val reducible_mind_case : evar_map -> constr -> bool
 
 val find_conclusion : env -> evar_map -> constr -> (constr, constr, ESorts.t, EInstance.t) kind_of_term

--- a/test-suite/bugs/bug_5512.v
+++ b/test-suite/bugs/bug_5512.v
@@ -1,10 +1,9 @@
 (* Check that an anomaly is not raised *)
-(* It should however eventually succeed... *)
 Goal exists x, x.
 Proof.
 simple refine (ex_intro _ _ _).
 shelve.
 (* The failure is due to Type(u)<=Prop for u an arbitrary sort
    variable being rejected *)
-Fail simple refine (_ _).
+simple refine (_ _).
 Abort.


### PR DESCRIPTION
This prevents unsafe casting to EConstr, and properly fixes #5512.

Fixes #5512.