### PR TITLE
Faster algorithm to recognize inductive pattern of destruct.

### DIFF
--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -1153,9 +1153,9 @@ let tclINTERP_AST_CLOSURE_TERM_AS_CONSTR c =
   tclUNIT t
 end
 
-let tacREDUCE_TO_QUANTIFIED_IND ty =
+let tacEVAL_TO_QUANTIFIED_IND ty =
   pf_apply begin fun env sigma ->
-  try tclUNIT (Tacred.reduce_to_quantified_ind env sigma ty)
+  try tclUNIT (Tacred.eval_to_quantified_ind env sigma ty)
   with e -> tclZERO e
   end
 
@@ -1311,7 +1311,7 @@ let tclOPTION o d =
 
 let tacIS_INJECTION_CASE ?ty t = begin
   tclOPTION ty (tacTYPEOF t) >>= fun ty ->
-  tacREDUCE_TO_QUANTIFIED_IND ty >>= fun ((mind,_),_) ->
+  tacEVAL_TO_QUANTIFIED_IND ty >>= fun (mind,_) ->
   tclUNIT (Coqlib.check_ind_ref "core.eq.type" mind)
 end
 

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -309,10 +309,6 @@ val unfold : EConstr.t list -> unit Proofview.tactic
 val tclINTERP_AST_CLOSURE_TERM_AS_CONSTR :
   ast_closure_term -> EConstr.t list Proofview.tactic
 
-val tacREDUCE_TO_QUANTIFIED_IND :
-  EConstr.types ->
-    ((Names.inductive * EConstr.EInstance.t) * EConstr.types) Proofview.tactic
-
 val tacTYPEOF : EConstr.t -> EConstr.types Proofview.tactic
 
 val tclINTRO_ID : Id.t -> unit Proofview.tactic

--- a/plugins/ssr/ssrelim.ml
+++ b/plugins/ssr/ssrelim.ml
@@ -561,7 +561,7 @@ let injectl2rtac sigma c = match EConstr.kind sigma c with
 
 let is_injection_case env sigma c =
   let sigma, cty = Typing.type_of env sigma c in
-  let (mind,_), _ = Tacred.reduce_to_quantified_ind env sigma cty in
+  let (mind,_) = Tacred.eval_to_quantified_ind env sigma cty in
   Coqlib.check_ind_ref "core.eq.type" mind
 
 let perform_injection c =

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -397,7 +397,7 @@ let pirrel_rewrite ?(under=false) ?(map_redex=id_map_redex) pred rdx rdx_ty new_
     match Equality.eq_elimination_ref (dir = L2R) sort with
     | Some r -> Evd.fresh_global env sigma r
     | None ->
-      let ((kn, i) as ind, _), unfolded_c_ty = Tacred.reduce_to_quantified_ind env sigma c_ty in
+      let ((kn, i) as ind, _) = Tacred.eval_to_quantified_ind env sigma c_ty in
       let sort = Tacticals.elimination_sort_of_goal gl in
       let sigma, elim = Evd.fresh_global env sigma (Indrec.lookup_eliminator env ind sort) in
       if dir = R2L then sigma, elim else

--- a/pretyping/tacred.mli
+++ b/pretyping/tacred.mli
@@ -101,6 +101,10 @@ val reduce_to_atomic_ind : env ->  evar_map -> types -> (inductive * EInstance.t
    returns [I] and [t'] or fails with a user error *)
 val reduce_to_quantified_ind : env ->  evar_map -> types -> (inductive * EInstance.t) * types
 
+(** Same as {!reduce_to_quantified_ind} but more efficient because it does not
+    return the normalized type. *)
+val eval_to_quantified_ind : env -> evar_map -> types -> (inductive * EInstance.t)
+
 (** [reduce_to_quantified_ref env sigma ref t] try to put [t] in the form
    [t'=(x1:A1)..(xn:An)(ref args)] and fails with user error if not possible *)
 val reduce_to_quantified_ref :

--- a/proofs/tacmach.ml
+++ b/proofs/tacmach.ml
@@ -82,9 +82,6 @@ let pf_whd_all gl t = pf_apply whd_all gl t
 
 let pf_get_type_of gl t = pf_apply Retyping.get_type_of gl t
 
-let pf_reduce_to_quantified_ind gl t =
-  pf_apply reduce_to_quantified_ind gl t
-
 let pf_hnf_constr gl t = pf_apply hnf_constr gl t
 let pf_hnf_type_of gl t =
   pf_whd_all gl (pf_get_type_of gl t)

--- a/proofs/tacmach.mli
+++ b/proofs/tacmach.mli
@@ -43,7 +43,6 @@ val pf_get_hyp_typ        : Id.t -> Proofview.Goal.t -> types
 val pf_last_hyp           : Proofview.Goal.t -> named_declaration
 
 val pf_nf_concl : Proofview.Goal.t -> types
-val pf_reduce_to_quantified_ind : Proofview.Goal.t -> types -> (inductive * EInstance.t) * types
 
 val pf_hnf_constr : Proofview.Goal.t -> constr -> types
 val pf_hnf_type_of : Proofview.Goal.t -> constr -> types


### PR DESCRIPTION
Some callers do not use the returned normalized type. Since it can be costly to compute it, as it performs a strong βι,  we expose a variant that only performs head reductions. We use it everywhere possible.
