### PR TITLE
Multiple scopes in Arguments and Bind Scope

### DIFF
--- a/dev/ci/user-overlays/16472-proux01-argument_multiple_scopes.sh
+++ b/dev/ci/user-overlays/16472-proux01-argument_multiple_scopes.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/proux01/coq-elpi coq_16472 16472

--- a/doc/changelog/03-notations/16472-argument_multiple_scopes.rst
+++ b/doc/changelog/03-notations/16472-argument_multiple_scopes.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Support for multiple scopes in the :cmd:`Arguments` command
+  (`#16472 <https://github.com/coq/coq/pull/16472>`_,
+  by Pierre Roux, review by Jim Fehrle, Hugo Herbelin and Enrico Tassi).

--- a/doc/changelog/03-notations/16472-argument_multiple_scopes.rst
+++ b/doc/changelog/03-notations/16472-argument_multiple_scopes.rst
@@ -2,3 +2,8 @@
   Support for multiple scopes in the :cmd:`Arguments` command
   (`#16472 <https://github.com/coq/coq/pull/16472>`_,
   by Pierre Roux, review by Jim Fehrle, Hugo Herbelin and Enrico Tassi).
+- **Added:**
+  Attributes :attr:`add_top` and :attr:`add_bottom` to bind
+  multiple scopes through the :cmd:`Bind Scope` command
+  (`#16472 <https://github.com/coq/coq/pull/16472>`_,
+  by Pierre Roux, review by Jim Fehrle, Hugo Herbelin and Enrico Tassi).

--- a/doc/sphinx/language/extensions/arguments-command.rst
+++ b/doc/sphinx/language/extensions/arguments-command.rst
@@ -5,16 +5,16 @@ Setting properties of a function's arguments
 
 .. cmd:: Arguments @reference {* @arg_specs } {* , {* @implicits_alt } } {? : {+, @args_modifier } }
 
-   .. insertprodn argument_spec args_modifier
+   .. insertprodn arg_specs args_modifier
 
    .. prodn::
-      argument_spec ::= {? ! } @name {? % @scope }
       arg_specs ::= @argument_spec
       | /
       | &
       | ( {+ @argument_spec } ) {? % @scope }
       | [ {+ @argument_spec } ] {? % @scope }
       | %{ {+ @argument_spec } %} {? % @scope }
+      argument_spec ::= {? ! } @name {? % @scope }
       implicits_alt ::= @name
       | [ {+ @name } ]
       | %{ {+ @name } %}

--- a/doc/sphinx/language/extensions/arguments-command.rst
+++ b/doc/sphinx/language/extensions/arguments-command.rst
@@ -11,10 +11,10 @@ Setting properties of a function's arguments
       arg_specs ::= @argument_spec
       | /
       | &
-      | ( {+ @argument_spec } ) {? % @scope }
-      | [ {+ @argument_spec } ] {? % @scope }
-      | %{ {+ @argument_spec } %} {? % @scope }
-      argument_spec ::= {? ! } @name {? % @scope }
+      | ( {+ @argument_spec } ) {* % @scope }
+      | [ {+ @argument_spec } ] {* % @scope }
+      | %{ {+ @argument_spec } %} {* % @scope }
+      argument_spec ::= {? ! } @name {* % @scope }
       implicits_alt ::= @name
       | [ {+ @name } ]
       | %{ {+ @name } %}
@@ -65,28 +65,35 @@ Setting properties of a function's arguments
          .. exn:: The & modifier may only occur once.
             :undocumented:
 
-      :n:`( ... ) {? % @scope }`
-         :n:`(@name__1 @name__2 ...)%@scope` is shorthand for :n:`@name__1%@scope @name__2%@scope ...`
+      :n:`( {+ @argument_spec } ) {* % @scope }`
+         :n:`(@name__1 @name__2 ...){* %@scope }` is shorthand for
+         :n:`@name__1{* %@scope } @name__2{* %@scope } ...`
 
-      :n:`[ ... ] {? % @scope }`
+      :n:`[ {+ @argument_spec } ] {* % @scope }`
          declares the enclosed names as implicit, non-maximally inserted.
-         :n:`[@name__1 @name__2 ... ]%@scope` is equivalent to :n:`[@name__1]%@scope [@name__2]%@scope ...`
+         :n:`[@name__1 @name__2 ... ]{* %@scope }` is equivalent to
+         :n:`[@name__1]{* %@scope } [@name__2]{* %@scope } ...`
 
-      :n:`%{ ... %} {? % @scope }`
+      :n:`%{ {+ @argument_spec } %} {* % @scope }`
          declares the enclosed names as implicit, maximally inserted.
-         :n:`%{@name__1 @name__2 ... %}%@scope` is equivalent to :n:`%{@name__1%}%@scope %{@name__2%}%@scope ...`
+         :n:`%{@name__1 @name__2 ... %}{* %@scope }` is equivalent to
+         :n:`%{@name__1%}{* %@scope } %{@name__2%}{* %@scope } ...`
 
       `!`
          the function will be unfolded only if all the arguments marked with `!`
          evaluate to constructors.  See :ref:`Args_effect_on_unfolding`.
 
-      :n:`@name {? % @scope }`
+      :n:`@name {* % @scope }`
          a *formal parameter* of the function :n:`@reference` (i.e.
          the parameter name used in the function definition).  Unless `rename` is specified,
          the list of :n:`@name`\s must be a prefix of the formal parameters, including all implicit
          arguments.  `_` can be used to skip over a formal parameter.
-         The construct :n:`@name {? % @scope }` declares :n:`@name` as non-implicit if `clear implicits` is specified or at least one other name is declared implicit in the same list of :n:`@name`\s.
-         :token:`scope` can be either a scope name or its delimiting key.  See :ref:`binding_to_scope`.
+         This construct declares :n:`@name` as
+         non-implicit if `clear implicits` is specified or any
+         other :n:`@name` in the :cmd:`Arguments` command is declared implicit.
+         :token:`scope` can be either scope names or their delimiting
+         keys. When multiple scopes are present, notations are interpreted in the
+         leftmost scope containing them. See :ref:`binding_to_scope`.
 
          .. exn:: To rename arguments the 'rename' flag must be specified.
             :undocumented:
@@ -274,24 +281,26 @@ Renaming implicit arguments
 
 .. _binding_to_scope:
 
-Binding arguments to a scope
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Binding arguments to scopes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
    The following command declares that the first two arguments of :g:`plus_fct`
-   are in the :token:`scope` delimited by the key ``F`` (``Rfun_scope``) and the third
-   argument is in the scope delimited by the key ``R`` (``R_scope``).
+   are interpreted in the :token:`scope` delimited by the key ``F``
+   and the third argument is first interpreted in the scope delimited by
+   the key ``R``, then in ``F`` (when a notation has
+   no interpretation in ``R``).
 
       .. coqdoc::
 
-         Arguments plus_fct (f1 f2)%F x%R.
+         Arguments plus_fct (f1 f2)%F x%R%F.
 
    When interpreting a term, if some of the arguments of :token:`reference` are built
    from a notation, then this notation is interpreted in the scope stack
-   extended by the scope bound (if any) to this argument. The effect of
-   the scope is limited to the argument itself. It does not propagate to
+   extended by the scopes bound (if any) to this argument. The effect of
+   these scopes is limited to the argument itself. It does not propagate to
    subterms but the subterms that, after interpretation of the notation,
    turn to be themselves arguments of a reference are interpreted
-   accordingly to the argument scopes bound to this reference.
+   according to the argument scopes bound to this reference.
 
 .. note::
 

--- a/doc/sphinx/language/extensions/arguments-command.rst
+++ b/doc/sphinx/language/extensions/arguments-command.rst
@@ -35,10 +35,10 @@ Setting properties of a function's arguments
    control over the elaboration process (i.e. the translation of Gallina language
    extensions into the core language used by the kernel).  The command's effects include:
 
-   * Making arguments implicit. Afterward, implicit arguments
+   * Making arguments implicit. Afterward, :term:`implicit arguments <implicit argument>`
      must be omitted in any expression that applies :token:`reference`.
    * Declaring that some arguments of a given function should
-     be interpreted in a given scope.
+     be interpreted in a given :term:`notation scope`.
    * Affecting when the :tacn:`simpl` and :tacn:`cbn` tactics unfold the function.
      See :ref:`Args_effect_on_unfolding`.
    * Providing bidirectionality hints.  See :ref:`bidirectionality_hints`.

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -1313,7 +1313,7 @@ Note that `_` by itself is a valid :n:`@name` but is not a valid :n:`@ident`.
 Notation scopes
 ---------------
 
-A *notation scope* is a set of notations for terms with their
+A :gdef:`notation scope` is a set of notations for terms with their
 interpretations. Notation scopes provide a weak, purely
 syntactic form of notation overloading: a symbol may
 refer to different definitions depending on which notation scopes

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -1424,15 +1424,16 @@ The arguments of an :ref:`abbreviation <Abbreviations>` can be interpreted
 in a scope stack locally extended with a given scope by using the modifier
 :n:`{+, @ident } in scope @scope_name`.s
 
-Binding types or coercion classes to a notation scope
-++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Binding types or coercion classes to notation scopes
+++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. cmd:: Bind Scope @scope_name with {+ @class }
 
    Binds the notation scope :token:`scope_name` to the type or coercion class :token:`class`.
    When bound, arguments of that type for any function will be interpreted in
    that scope by default.  This default can be overridden for individual functions
-   with the :cmd:`Arguments` command.  The association may be convenient
+   with the :cmd:`Arguments` command. See :ref:`binding_to_scope` for details.
+   The association may be convenient
    when a notation scope is naturally associated with a :token:`type` (e.g.
    `nat` and the natural numbers).
 
@@ -1441,6 +1442,20 @@ Binding types or coercion classes to a notation scope
    :g:`forall X:Type, X -> X` and type :g:`t` is bound to a scope ``scope``,
    then :g:`a` of type :g:`t` in :g:`f t a` is not recognized as an argument to
    be interpreted in scope ``scope``.
+
+   This command supports the :attr:`local`, :attr:`global`,
+   :attr:`add_top` and :attr:`add_bottom` attributes.
+
+   .. attr:: add_top
+      :undocumented:
+
+   .. attr:: add_bottom
+
+      These :ref:`attributes <attribute>` allow adding additional
+      bindings at the top or bottom of the stack of already declared
+      bindings. In absence of such attributes, any new binding clears
+      the previous ones. This makes it possible to bind multiple scopes
+      to the same :token:`class`.
 
    .. coqtop:: in reset
 

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -1457,21 +1457,64 @@ Binding types or coercion classes to notation scopes
       the previous ones. This makes it possible to bind multiple scopes
       to the same :token:`class`.
 
-   .. coqtop:: in reset
+   .. example:: Binding scopes to a type
 
-      Parameter U : Set.
-      Declare Scope U_scope.
-      Bind Scope U_scope with U.
-      Parameter Uplus : U -> U -> U.
-      Parameter P : forall T:Set, T -> U -> Prop.
-      Parameter f : forall T:Set, T -> U.
-      Infix "+" := Uplus : U_scope.
-      Unset Printing Notations.
-      Open Scope nat_scope.
+      Let's declare two scopes with a notation in each and an arbitrary
+      function on type ``bool``.
 
-   .. coqtop:: all
+      .. coqtop:: in reset
 
-      Check (fun x y1 y2 z t => P _ (x + t) ((f _ (y1 + y2) + z))).
+         Declare Scope T_scope.
+         Declare Scope F_scope.
+         Notation "#" := true (only parsing) : T_scope.
+         Notation "#" := false (only parsing) : F_scope.
+
+         Parameter f : bool -> bool.
+
+      By default, the argument of ``f`` is interpreted in the
+      currently opened scopes.
+
+      .. coqtop:: all
+
+         Open Scope T_scope.
+         Check f #.
+         Open Scope F_scope.
+         Check f #.
+
+      This can be changed by binding scopes to the type ``bool``.
+
+      .. coqtop:: all
+
+         Bind Scope T_scope with bool.
+         Check f #.
+
+      When multiple scopes are attached to a type, notations are
+      interpreted in the first scope containing them, from the top of
+      the stack.
+
+      .. coqtop:: all
+
+         #[add_top] Bind Scope F_scope with bool.
+         Check f #.
+
+         Notation "##" := (negb false) (only parsing) : T_scope.
+         Check f ##.
+
+      Bindings for functions can be displayed with the
+      :cmd:`About` command.
+
+      .. coqtop:: all
+
+         About f.
+
+      .. note:: Such stacks of scopes can be handy to share notations
+         between multiple types. For instance, the scope ``T_scope``
+         above could contain many generic notations used for both the
+         ``bool`` and ``nat`` types, while the scope ``F_scope`` could
+         override some of these notations specifically for
+         ``bool`` and another ``F'_scope`` could override them
+         specifically for ``nat``, which could then be bound to
+         ``%F'_scope%T_scope``.
 
    .. note:: When active, a bound scope has effect on all defined functions
              (even if they are defined after the :cmd:`Bind Scope` directive), except

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1224,16 +1224,16 @@ scope_delimiter: [
 ]
 
 argument_spec: [
-| OPT "!" name OPT scope_delimiter
+| OPT "!" name LIST0 scope_delimiter
 ]
 
 arg_specs: [
 | argument_spec
 | "/"
 | "&"
-| "(" LIST1 argument_spec ")" OPT scope_delimiter
-| "[" LIST1 argument_spec "]" OPT scope_delimiter
-| "{" LIST1 argument_spec "}" OPT scope_delimiter
+| "(" LIST1 argument_spec ")" LIST0 scope_delimiter
+| "[" LIST1 argument_spec "]" LIST0 scope_delimiter
+| "{" LIST1 argument_spec "}" LIST0 scope_delimiter
 ]
 
 implicits_alt: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -796,13 +796,13 @@ arg_specs: [
 | argument_spec
 | "/"
 | "&"
-| "(" LIST1 argument_spec ")" OPT ( "%" scope )
-| "[" LIST1 argument_spec "]" OPT ( "%" scope )
-| "{" LIST1 argument_spec "}" OPT ( "%" scope )
+| "(" LIST1 argument_spec ")" LIST0 ( "%" scope )
+| "[" LIST1 argument_spec "]" LIST0 ( "%" scope )
+| "{" LIST1 argument_spec "}" LIST0 ( "%" scope )
 ]
 
 argument_spec: [
-| OPT "!" name OPT ( "%" scope )
+| OPT "!" name LIST0 ( "%" scope )
 ]
 
 implicits_alt: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -792,10 +792,6 @@ reference: [
 | string OPT [ "%" scope_key ]
 ]
 
-argument_spec: [
-| OPT "!" name OPT ( "%" scope )
-]
-
 arg_specs: [
 | argument_spec
 | "/"
@@ -803,6 +799,10 @@ arg_specs: [
 | "(" LIST1 argument_spec ")" OPT ( "%" scope )
 | "[" LIST1 argument_spec "]" OPT ( "%" scope )
 | "{" LIST1 argument_spec "}" OPT ( "%" scope )
+]
+
+argument_spec: [
+| OPT "!" name OPT ( "%" scope )
 ]
 
 implicits_alt: [

--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -63,7 +63,7 @@ val compute_internalization_env : env -> evar_map -> ?impls:internalization_env 
   internalization_env
 
 val extend_internalization_data :
-  var_internalization_data -> Impargs.implicit_status -> scope_name option -> var_internalization_data
+  var_internalization_data -> Impargs.implicit_status -> scope_name list -> var_internalization_data
 
 type ltac_sign = {
   ltac_vars : Id.Set.t;

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1960,8 +1960,15 @@ let initial_scope_class_map : scope_name list ScopeClassMap.t =
 
 let scope_class_map = ref initial_scope_class_map
 
-let declare_scope_class sc cl =
-  scope_class_map := ScopeClassMap.add cl [sc] !scope_class_map
+type add_scope_where = AddScopeTop | AddScopeBottom
+
+let declare_scope_class sc ?where cl =
+  let scl = match where with
+    | None -> [sc]
+    | Some where ->
+       let scl = try ScopeClassMap.find cl !scope_class_map with Not_found -> [] in
+       match where with AddScopeTop -> sc :: scl | AddScopeBottom -> scl @ [sc] in
+  scope_class_map := ScopeClassMap.add cl scl !scope_class_map
 
 let find_scope_class cl =
   ScopeClassMap.find cl !scope_class_map

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -79,7 +79,7 @@ let ntpe_eq t1 t2 = match t1, t2 with
 
 let var_attributes_eq (_, ((entry1, sc1), tp1)) (_, ((entry2, sc2), tp2)) =
   notation_entry_level_eq entry1 entry2 &&
-  pair_eq (Option.equal String.equal) (List.equal String.equal) sc1 sc2 &&
+  pair_eq (List.equal String.equal) (List.equal String.equal) sc1 sc2 &&
   ntpe_eq tp1 tp2
 
 let interpretation_eq (vars1, t1 as x1) (vars2, t2 as x2) =
@@ -265,8 +265,8 @@ let push_scope sc scopes = OpenScopeItem sc :: scopes
 
 let push_scopes = List.fold_right push_scope
 
-let make_current_scopes (tmp_scope,scopes) =
-  Option.fold_right push_scope tmp_scope (push_scopes scopes !scope_stack)
+let make_current_scopes (tmp_scopes,scopes) =
+  push_scopes tmp_scopes (push_scopes scopes !scope_stack)
 
 (**********************************************************************)
 (* Delimiters *)
@@ -1955,20 +1955,20 @@ end
 
 module ScopeClassMap = Map.Make(ScopeClassOrd)
 
-let initial_scope_class_map : scope_name ScopeClassMap.t =
+let initial_scope_class_map : scope_name list ScopeClassMap.t =
   ScopeClassMap.empty
 
 let scope_class_map = ref initial_scope_class_map
 
 let declare_scope_class sc cl =
-  scope_class_map := ScopeClassMap.add cl sc !scope_class_map
+  scope_class_map := ScopeClassMap.add cl [sc] !scope_class_map
 
 let find_scope_class cl =
   ScopeClassMap.find cl !scope_class_map
 
 let find_scope_class_opt = function
-  | None -> None
-  | Some cl -> try Some (find_scope_class cl) with Not_found -> None
+  | None -> []
+  | Some cl -> try find_scope_class cl with Not_found -> []
 
 (**********************************************************************)
 (* Special scopes associated to arguments of a global reference *)
@@ -1991,7 +1991,7 @@ let compute_arguments_scope env sigma t = fst (compute_arguments_scope_full env 
 let compute_type_scope env sigma t =
   find_scope_class_opt (try Some (compute_scope_class env sigma t) with Not_found -> None)
 
-let current_type_scope_name () =
+let current_type_scope_names () =
    find_scope_class_opt (Some CL_SORT)
 
 let scope_class_of_class (x : cl_typ) : scope_class =
@@ -2004,7 +2004,7 @@ let scope_class_of_class (x : cl_typ) : scope_class =
 
 let update_scope cl sco =
   match find_scope_class_opt cl with
-  | None -> sco
+  | [] -> sco
   | sco' -> sco'
 
 let rec update_scopes cls scl = match cls, scl with
@@ -2020,7 +2020,7 @@ type arguments_scope_discharge_request =
   | ArgsScopeNoDischarge
 
 let load_arguments_scope _ (_,r,n,scl,cls) =
-  List.iter (Option.iter check_scope) scl;
+  List.iter (List.iter check_scope) scl;
   let initial_stamp = ScopeClassMap.empty in
   arguments_scope := GlobRef.Map.add r (scl,cls,initial_stamp) !arguments_scope
 
@@ -2078,7 +2078,7 @@ type arguments_scope_obj =
     arguments_scope_discharge_request * GlobRef.t *
     (* Used to communicate information from discharge to rebuild *)
     (* set to 0 otherwise *) int *
-    scope_name option list * scope_class option list
+    scope_name list list * scope_class option list
 
 let inArgumentsScope : arguments_scope_obj -> obj =
   declare_object {(default_object "ARGUMENTS-SCOPE") with
@@ -2172,7 +2172,7 @@ let pr_delimiters_info = function
   | Some key -> str "Delimiting key is " ++ str key
 
 let classes_of_scope sc =
-  ScopeClassMap.fold (fun cl sc' l -> if String.equal sc sc' then cl::l else l) !scope_class_map []
+  ScopeClassMap.fold (fun cl sc' l -> if List.mem_f String.equal sc sc' then cl::l else l) !scope_class_map []
 
 let pr_scope_class = pr_class
 

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -312,7 +312,9 @@ val scope_class_compare : scope_class -> scope_class -> int
 val subst_scope_class :
   Environ.env -> Mod_subst.substitution -> scope_class -> scope_class option
 
-val declare_scope_class : scope_name -> scope_class -> unit
+type add_scope_where = AddScopeTop | AddScopeBottom
+(** add new scope at top or bottom of existing stack (default is reset) *)
+val declare_scope_class : scope_name -> ?where:add_scope_where -> scope_class -> unit
 val declare_ref_arguments_scope : Evd.evar_map -> GlobRef.t -> unit
 
 val compute_arguments_scope : Environ.env -> Evd.evar_map -> EConstr.types -> scope_name list list

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -300,9 +300,9 @@ val interp_notation_as_global_reference : ?loc:Loc.t -> head:bool -> (GlobRef.t 
 
 (** Declares and looks for scopes associated to arguments of a global ref *)
 val declare_arguments_scope :
-  bool (** true=local *) -> GlobRef.t -> scope_name option list -> unit
+  bool (** true=local *) -> GlobRef.t -> scope_name list list -> unit
 
-val find_arguments_scope : GlobRef.t -> scope_name option list
+val find_arguments_scope : GlobRef.t -> scope_name list list
 
 type scope_class
 
@@ -315,11 +315,11 @@ val subst_scope_class :
 val declare_scope_class : scope_name -> scope_class -> unit
 val declare_ref_arguments_scope : Evd.evar_map -> GlobRef.t -> unit
 
-val compute_arguments_scope : Environ.env -> Evd.evar_map -> EConstr.types -> scope_name option list
-val compute_type_scope : Environ.env -> Evd.evar_map -> EConstr.types -> scope_name option
+val compute_arguments_scope : Environ.env -> Evd.evar_map -> EConstr.types -> scope_name list list
+val compute_type_scope : Environ.env -> Evd.evar_map -> EConstr.types -> scope_name list
 
-(** Get the current scope bound to Sortclass, if it exists *)
-val current_type_scope_name : unit -> scope_name option
+(** Get the current scopes bound to Sortclass *)
+val current_type_scope_names : unit -> scope_name list
 
 val scope_class_of_class : Coercionops.cl_typ -> scope_class
 

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -1249,9 +1249,9 @@ let remove_sigma x (terms,termlists,binders,binderlists) =
 let remove_bindinglist_sigma x (terms,termlists,binders,binderlists) =
   (terms,termlists,binders,Id.List.remove_assoc x binderlists)
 
-let add_ldots_var metas = (ldots_var,((Constrexpr.InConstrEntrySomeLevel,(None,[])),NtnTypeConstr))::metas
+let add_ldots_var metas = (ldots_var,((Constrexpr.InConstrEntrySomeLevel,([],[])),NtnTypeConstr))::metas
 
-let add_meta_bindinglist x metas = (x,((Constrexpr.InConstrEntrySomeLevel,(None,[])),NtnTypeBinderList))::metas
+let add_meta_bindinglist x metas = (x,((Constrexpr.InConstrEntrySomeLevel,([],[])),NtnTypeBinderList))::metas
 
 (* This tells if letins in the middle of binders should be included in
    the sequence of binders *)
@@ -1296,7 +1296,7 @@ let match_binderlist match_fun alp metas sigma rest x y iter termin revert =
   let alp,sigma = bind_bindinglist_env alp sigma x bl in
   match_fun alp metas sigma rest termin
 
-let add_meta_term x metas = (x,((Constrexpr.InConstrEntrySomeLevel,(None,[])),NtnTypeConstr))::metas (* Should reuse the scope of the partner of x! *)
+let add_meta_term x metas = (x,((Constrexpr.InConstrEntrySomeLevel,([],[])),NtnTypeConstr))::metas (* Should reuse the scope of the partner of x! *)
 
 let match_termlist match_fun alp metas sigma rest x y iter termin revert =
   let rec aux alp sigma acc rest =

--- a/interp/notation_term.ml
+++ b/interp/notation_term.ml
@@ -59,7 +59,7 @@ type scope_name = string
 
 type tmp_scope_name = scope_name
 
-type subscopes = tmp_scope_name option * scope_name list
+type subscopes = tmp_scope_name list * scope_name list
 
 type extended_subscopes = Constrexpr.notation_entry_level * subscopes
 

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -382,7 +382,7 @@ let interp_index ist env sigma idx =
         begin match Tacinterp.Value.to_constr v with
         | Some c ->
           let rc = Detyping.detype Detyping.Now false Id.Set.empty env sigma c in
-          begin match Notation.uninterp_prim_token rc (None, []) with
+          begin match Notation.uninterp_prim_token rc ([], []) with
           | Constrexpr.Number n, _ when NumTok.Signed.is_int n ->
             int_of_string (NumTok.Signed.to_string n)
           | _ -> raise Not_found

--- a/test-suite/output/ArgumentsScope.out
+++ b/test-suite/output/ArgumentsScope.out
@@ -94,3 +94,21 @@ f tt
      : bool
 f false
      : bool
+g : bool -> bool
+
+g is not universe polymorphic
+Arguments g x%A_scope%B_scope
+g is transparent
+Expands to: Constant ArgumentsScope.g
+g' : nat -> nat
+
+g' is not universe polymorphic
+Arguments g' x%B_scope%A_scope
+g' is transparent
+Expands to: Constant ArgumentsScope.g'
+g'' : unit -> unit
+
+g'' is not universe polymorphic
+Arguments g'' x%B_scope
+g'' is transparent
+Expands to: Constant ArgumentsScope.g''

--- a/test-suite/output/ArgumentsScope.out
+++ b/test-suite/output/ArgumentsScope.out
@@ -74,3 +74,23 @@ negb'' is not universe polymorphic
 Arguments negb'' b
 negb'' is transparent
 Expands to: Constant ArgumentsScope.negb''
+f : bool -> bool
+
+f is not universe polymorphic
+Arguments f x%A_scope%B_scope
+f is transparent
+Expands to: Constant ArgumentsScope.f
+f tt
+     : bool
+f true
+     : bool
+f : bool -> bool
+
+f is not universe polymorphic
+Arguments f x%B_scope%A_scope
+f is transparent
+Expands to: Constant ArgumentsScope.f
+f tt
+     : bool
+f false
+     : bool

--- a/test-suite/output/ArgumentsScope.v
+++ b/test-suite/output/ArgumentsScope.v
@@ -28,3 +28,30 @@ End A.
 About negb.
 About negb'.
 About negb''.
+
+(* Check multiple scopes *)
+
+Declare Scope A_scope.
+Delimit Scope A_scope with A.
+Declare Scope B_scope.
+Delimit Scope B_scope with B.
+Notation "'tt'" := true : A_scope.
+Notation "'tt'" := false : B_scope.
+
+Definition f (x : bool) := x.
+
+Arguments f x%A%B.
+About f.
+
+Check f tt.
+Set Printing All.
+Check f tt.
+Unset Printing All.
+
+Arguments f x%B%A.
+About f.
+
+Check f tt.
+Set Printing All.
+Check f tt.
+Unset Printing All.

--- a/test-suite/output/ArgumentsScope.v
+++ b/test-suite/output/ArgumentsScope.v
@@ -55,3 +55,26 @@ Check f tt.
 Set Printing All.
 Check f tt.
 Unset Printing All.
+
+(* Check binding scope inside/outside *)
+
+Bind Scope A_scope with bool.
+#[add_bottom] Bind Scope B_scope with bool.
+
+Definition g (x : bool) := x.
+
+About g.
+
+Bind Scope A_scope with nat.
+#[add_top] Bind Scope B_scope with nat.
+
+Definition g' (x : nat) := x.
+
+About g'.
+
+Bind Scope A_scope with unit.
+Bind Scope B_scope with unit.  (* default: reset *)
+
+Definition g'' (x : unit) := x.
+
+About g''.

--- a/vernac/attributes.ml
+++ b/vernac/attributes.ml
@@ -360,4 +360,11 @@ let typing_flags_parser : Declarations.typing_flags key_parser = fun ?loc orig a
 let typing_flags =
   attribute_of_list ["bypass_check", typing_flags_parser]
 
+let bind_scope_where =
+  let name = "where to bind scope" in
+  attribute_of_list [
+    ("add_top", single_key_parser ~name ~key:"add_top" Notation.AddScopeTop);
+    ("add_bottom", single_key_parser ~name ~key:"add_bottom" Notation.AddScopeBottom);
+  ]
+
 let raw_attributes : _ attribute = fun flags -> [], flags

--- a/vernac/attributes.mli
+++ b/vernac/attributes.mli
@@ -62,6 +62,7 @@ val canonical_field : bool attribute
 val canonical_instance : bool attribute
 val using : string option attribute
 val hint_locality : default:(unit -> Hints.hint_locality) -> Hints.hint_locality attribute
+val bind_scope_where : Notation.add_scope_where option attribute
 
 (** With the warning for Hint (and not for Instance etc) *)
 val really_hint_locality : Hints.hint_locality attribute

--- a/vernac/comArguments.ml
+++ b/vernac/comArguments.ml
@@ -129,9 +129,9 @@ let vernac_arguments ~section_local reference args more_implicits flags =
   let rec check_extra_args extra_args =
     match extra_args with
     | [] -> ()
-    | { notation_scope = None } :: _ ->
-      CErrors.user_err Pp.(str"Extra arguments should specify a scope.")
-    | { notation_scope = Some _ } :: args -> check_extra_args args
+    | { notation_scope = [] } :: _ ->
+      CErrors.user_err Pp.(str"Extra arguments should specify scopes.")
+    | { notation_scope = _ :: _ } :: args -> check_extra_args args
   in
 
   let args, scopes =
@@ -150,7 +150,7 @@ let vernac_arguments ~section_local reference args more_implicits flags =
   if Option.cata (fun n -> n > num_args) false nargs_before_bidi then
     CErrors.user_err Pp.(str "The \"&\" modifier should be put before any extra scope.");
 
-  let scopes_specified = List.exists Option.has_some scopes in
+  let scopes_specified = List.exists ((<>) []) scopes in
 
   if scopes_specified && clear_scopes_flag then
     CErrors.user_err Pp.(str "The \"clear scopes\" flag is incompatible with scope annotations.");
@@ -265,7 +265,7 @@ let vernac_arguments ~section_local reference args more_implicits flags =
   end;
 
   if scopes_specified || clear_scopes_flag then begin
-    let scopes = List.map (Option.map (fun {loc;v=k} ->
+    let scopes = List.map (List.map (fun {loc;v=k} ->
         try ignore (Notation.find_scope k); k
         with CErrors.UserError _ ->
           Notation.find_delimiters_scope ?loc k)) scopes

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -199,7 +199,7 @@ let build_wellfounded pm (recname,pl,bl,arityc,body) poly ?typing_flags ?using r
     let newimpls = Id.Map.singleton recname
         (Constrintern.extend_internalization_data interning_data
            (Some ((Name (Id.of_string "recproof"),1,None), Impargs.Manual, (true, false)))
-           None) in
+           []) in
     interp_casted_constr_evars ~program_mode:true (push_rel_context ctx env) sigma
       ~impls:newimpls body (lift 1 top_arity)
   in

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -11,7 +11,6 @@
 {
 
 open Pp
-open CErrors
 open Util
 open Names
 open Glob_term
@@ -839,8 +838,8 @@ GRAMMAR EXTEND Gram
     [ [ "%"; key = IDENT -> { key } ] ]
   ;
   argument_spec: [
-       [ b = OPT "!"; id = name ; s = OPT scope_delimiter ->
-       { id.CAst.v, not (Option.is_empty b), Option.map (fun x -> CAst.make ~loc x) s }
+       [ b = OPT "!"; id = name ; s = LIST0 scope_delimiter ->
+       { id.CAst.v, not (Option.is_empty b), List.map (fun x -> CAst.make ~loc x) s }
     ]
   ];
   (* List of arguments implicit status, scope, modifiers *)
@@ -852,29 +851,23 @@ GRAMMAR EXTEND Gram
              implicit_status = Explicit}] }
     | "/" -> { [VolatileArg] }
     | "&" -> { [BidiArg] }
-    | "("; items = LIST1 argument_spec; ")"; sc = OPT scope_delimiter ->
-       { let f x = match sc, x with
-         | None, x -> x | x, None -> Option.map (fun y -> CAst.make ~loc y) x
-         | Some _, Some _ -> user_err ~loc Pp.(str "scope declared twice") in
+    | "("; items = LIST1 argument_spec; ")"; scl = LIST0 scope_delimiter ->
+       { let scl = List.map (CAst.make ~loc) scl in
        List.map (fun (name,recarg_like,notation_scope) ->
            RealArg { name=name; recarg_like=recarg_like;
-                 notation_scope=f notation_scope;
+                 notation_scope = notation_scope @ scl;
                  implicit_status = Explicit}) items }
-    | "["; items = LIST1 argument_spec; "]"; sc = OPT scope_delimiter ->
-       { let f x = match sc, x with
-         | None, x -> x | x, None -> Option.map (fun y -> CAst.make ~loc y) x
-         | Some _, Some _ -> user_err ~loc Pp.(str "scope declared twice") in
+    | "["; items = LIST1 argument_spec; "]"; scl = LIST0 scope_delimiter ->
+       { let scl = List.map (CAst.make ~loc) scl in
        List.map (fun (name,recarg_like,notation_scope) ->
            RealArg { name=name; recarg_like=recarg_like;
-                 notation_scope=f notation_scope;
+                 notation_scope = notation_scope @ scl;
                  implicit_status = NonMaxImplicit}) items }
-    | "{"; items = LIST1 argument_spec; "}"; sc = OPT scope_delimiter ->
-       { let f x = match sc, x with
-         | None, x -> x | x, None -> Option.map (fun y -> CAst.make ~loc y) x
-         | Some _, Some _ -> user_err ~loc Pp.(str "scope declared twice") in
+    | "{"; items = LIST1 argument_spec; "}"; scl = LIST0 scope_delimiter ->
+       { let scl = List.map (CAst.make ~loc) scl in
        List.map (fun (name,recarg_like,notation_scope) ->
            RealArg { name=name; recarg_like=recarg_like;
-                 notation_scope=f notation_scope;
+                 notation_scope = notation_scope @ scl;
                  implicit_status = MaxImplicit}) items }
     ]
   ];

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1184,7 +1184,7 @@ let make_interpretation_vars
   (* For binders, default is to parse only as an ident *) ?(default_if_binding=AsName)
    recvars level allvars typs =
   let eq_subscope (sc1, l1) (sc2, l2) =
-    Option.equal String.equal sc1 sc2 &&
+    List.equal String.equal sc1 sc2 &&
     List.equal String.equal l1 l2
   in
   let check (x, y) =

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1810,7 +1810,7 @@ type scope_command =
   | ScopeDeclare
   | ScopeDelimAdd of string
   | ScopeDelimRemove
-  | ScopeClasses of scope_class list
+  | ScopeClasses of add_scope_where option * scope_class list
 
 let load_scope_command_common silently_define_scope_if_undefined _ (local,scope,o) =
   let declare_scope_if_needed =
@@ -1822,7 +1822,7 @@ let load_scope_command_common silently_define_scope_if_undefined _ (local,scope,
   (* the call to declare_scope_if_needed will have to be removed below *)
   | ScopeDelimAdd dlm -> declare_scope_if_needed scope
   | ScopeDelimRemove -> declare_scope_if_needed scope
-  | ScopeClasses cl -> declare_scope_if_needed scope
+  | ScopeClasses _ -> declare_scope_if_needed scope
 
 let load_scope_command =
   load_scope_command_common true
@@ -1833,20 +1833,20 @@ let open_scope_command i (local,scope,o) =
     | ScopeDeclare -> ()
     | ScopeDelimAdd dlm -> Notation.declare_delimiters scope dlm
     | ScopeDelimRemove -> Notation.remove_delimiters scope
-    | ScopeClasses cl -> List.iter (Notation.declare_scope_class scope) cl
+    | ScopeClasses (where, cl) -> List.iter (Notation.declare_scope_class scope ?where) cl
 
 let cache_scope_command o =
   load_scope_command_common false 1 o;
   open_scope_command 1 o
 
 let subst_scope_command (subst,(local,scope,o as x)) = match o with
-  | ScopeClasses cl ->
+  | ScopeClasses (where, cl) ->
       let env = Global.env () in
       let cl' = List.map_filter (subst_scope_class env subst) cl in
       let cl' =
         if List.for_all2eq (==) cl cl' then cl
         else cl' in
-      local, scope, ScopeClasses cl'
+      local, scope, ScopeClasses (where, cl')
   | _ -> x
 
 let classify_scope_command (local, _, _) =
@@ -1869,8 +1869,8 @@ let add_delimiters local scope key =
 let remove_delimiters local scope =
   Lib.add_leaf (inScopeCommand(local,scope,ScopeDelimRemove))
 
-let add_class_scope local scope cl =
-  Lib.add_leaf (inScopeCommand(local,scope,ScopeClasses cl))
+let add_class_scope local scope where cl =
+  Lib.add_leaf (inScopeCommand(local,scope,ScopeClasses (where, cl)))
 
 let interp_abbreviation_modifiers deprecation modl =
   let mods, skipped = interp_non_syntax_modifiers ~reserved:false ~infix:false ~abbrev:true deprecation modl in

--- a/vernac/metasyntax.mli
+++ b/vernac/metasyntax.mli
@@ -27,7 +27,7 @@ val add_notation_extra_printing_rule : string -> string -> string -> unit
 val declare_scope : locality_flag -> scope_name -> unit
 val add_delimiters : locality_flag -> scope_name -> string -> unit
 val remove_delimiters : locality_flag -> scope_name -> unit
-val add_class_scope : locality_flag -> scope_name -> scope_class list -> unit
+val add_class_scope : locality_flag -> scope_name -> add_scope_where option -> scope_class list -> unit
 
 (** Add a notation interpretation associated to a "where" clause (already has pa/pp rules) *)
 

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -1120,7 +1120,7 @@ let pr_vernac_expr v =
       hov 2 (
         keyword "Arguments" ++ spc() ++
         pr_smart_global q ++
-        let pr_s = function None -> str"" | Some {v=s} -> str "%" ++ str s in
+        let pr_s = prlist (fun {v=s} -> str "%" ++ str s) in
         let pr_if b x = if b then x else str "" in
         let pr_one_arg (x,k) = pr_if k (str"!") ++ Name.print x in
         let pr_br imp force x =
@@ -1133,11 +1133,11 @@ let pr_vernac_expr v =
           left ++ x ++ right
         in
         let get_arguments_like s imp tl =
-          if s = None && imp = Glob_term.Explicit then [], tl
+          if s = [] && imp = Glob_term.Explicit then [], tl
           else
             let rec fold extra = function
               | RealArg arg :: tl when
-                  Option.equal (fun a b -> String.equal a.CAst.v b.CAst.v) arg.notation_scope s
+                  List.equal (fun a b -> String.equal a.CAst.v b.CAst.v) arg.notation_scope s
                   && arg.implicit_status = imp ->
                 fold ((arg.name,arg.recarg_like) :: extra) tl
               | args -> List.rev extra, args

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -268,12 +268,12 @@ let dummy = {
   Vernacexpr.implicit_status = Glob_term.Explicit;
    name = Anonymous;
    recarg_like = false;
-   notation_scope = None;
+   notation_scope = [];
  }
 
 let is_dummy = function
   | Vernacexpr.(RealArg {implicit_status; name; recarg_like; notation_scope}) ->
-    name = Anonymous && not recarg_like && notation_scope = None && implicit_status = Glob_term.Explicit
+    name = Anonymous && not recarg_like && notation_scope = [] && implicit_status = Glob_term.Explicit
   | _ -> false
 
 let rec main_implicits i renames recargs scopes impls =
@@ -290,8 +290,8 @@ let rec main_implicits i renames recargs scopes impls =
       | [], (None::_ | []) -> (Anonymous, Glob_term.Explicit)
     in
     let notation_scope = match scopes with
-      | scope :: _ -> Option.map CAst.make scope
-      | [] -> None
+      | scope :: _ -> List.map CAst.make scope
+      | [] -> []
     in
     let status = {Vernacexpr.implicit_status; name; recarg_like; notation_scope} in
     let tl = function [] -> [] | _::tl -> tl in

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -524,8 +524,9 @@ let vernac_delimiters ~module_local sc action =
   | Some lr -> Metasyntax.add_delimiters module_local sc lr
   | None -> Metasyntax.remove_delimiters module_local sc
 
-let vernac_bind_scope ~module_local sc cll =
-  Metasyntax.add_class_scope module_local sc (List.map scope_class_of_qualid cll)
+let vernac_bind_scope ~atts sc cll =
+  let module_local, where = Attributes.(parse Notations.(module_locality ++ bind_scope_where) atts) in
+  Metasyntax.add_class_scope module_local sc where (List.map scope_class_of_qualid cll)
 
 let vernac_open_close_scope ~section_local (b,s) =
   Notation.open_close_scope (section_local,b,s)
@@ -2302,7 +2303,7 @@ let translate_vernac ?loc ~atts v = let open Vernacextend in match v with
   | VernacDelimiters (sc,lr) ->
     vtdefault(fun () -> with_module_locality ~atts vernac_delimiters sc lr)
   | VernacBindScope (sc,rl) ->
-    vtdefault(fun () -> with_module_locality ~atts vernac_bind_scope sc rl)
+    vtdefault(fun () -> vernac_bind_scope ~atts sc rl)
   | VernacOpenCloseScope (b, s) ->
     vtdefault(fun () -> with_section_locality ~atts vernac_open_close_scope (b,s))
   | VernacNotation (infix,c,infpl,sc) ->

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -294,7 +294,7 @@ type module_binder = export_with_cats option * lident list * module_ast_inl
 type vernac_one_argument_status = {
   name : Name.t;
   recarg_like : bool;
-  notation_scope : string CAst.t option;
+  notation_scope : string CAst.t list;
   implicit_status : Glob_term.binding_kind;
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

The `Arguments` command only supported at most one scope for each argument. This PR enables multiple scopes. This would be useful for instance in MathComp where we'd like to bind types like `int` or `rat` to both the generic `ring_scope` and the specifics `int_scope` or `rat_scope` (for instance operators like `+` or `*` should be the generic ring ones in both cases but parsing of constants can be specific to int or rat). The change should be fully backward compatible.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] ~Documented any new / changed **user messages**.~
  - [x] Updated **documented syntax** by running `make -f Makefile.dune doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [x] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md -->

#### Overlays (to be merged in sync with the PR)
* https://github.com/LPCIC/coq-elpi/pull/389