### PR TITLE
Fast path in Tactics.cook_hyps.

### DIFF
--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -3617,7 +3617,7 @@ let cook_sign hyp0_opt inhyps indvars env sigma =
       toclear := hyp::!toclear;
       rhyp
     end else
-      let dephyp0 = List.is_empty inhyps &&
+      let dephyp0 = not !before && List.is_empty inhyps &&
         (Option.cata (fun id -> occur_var_in_decl env sigma id decl) false hyp0_opt)
       in
       let depother = List.is_empty inhyps &&


### PR DESCRIPTION
We do not have to check for the presence of the variable to abstract in the context before the point it is introduced.

This mitigates #16339: destruct is linear in the size of the context.