### PR TITLE
[gramlib] Extend API to allow finer stream control.

### DIFF
--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -18,8 +18,21 @@ module type S = sig
 
   module Parsable : sig
     type t
+    (** [Parsable.t] Stream tokenizers with Coq-specific funcitonality *)
+
     val make : ?loc:Loc.t -> char Stream.t -> t
+    (** [make ?loc strm] Build a parsable from stream [strm], resuming
+       at position [?loc] *)
+
     val comments : t -> ((int * int) * string) list
+
+    val loc : t -> Loc.t
+    (** [loc pa] Return parsing position for [pa] *)
+
+    val consume : t -> int -> unit
+    (** [consume pa n] Discard [n] tokens from [pa], updating the
+       parsing position *)
+
   end
 
   module Entry : sig
@@ -1654,6 +1667,8 @@ module Parsable = struct
 
   let comments p = L.State.get_comments !(p.lexer_state)
 
+  let loc t = LStream.current_loc t.pa_tok_strm
+  let consume { pa_tok_strm } len = LStream.njunk len pa_tok_strm
 end
 
 module Entry = struct

--- a/gramlib/grammar.mli
+++ b/gramlib/grammar.mli
@@ -30,6 +30,8 @@ module type S = sig
     type t
     val make : ?loc:Loc.t -> char Stream.t -> t
     val comments : t -> ((int * int) * string) list
+    val loc : t -> Loc.t
+    val consume : t -> int -> unit
   end
 
   module Entry : sig

--- a/gramlib/lStream.ml
+++ b/gramlib/lStream.ml
@@ -75,5 +75,6 @@ let peek_nth n strm =
   loop list n
 
 let junk strm = Stream.junk strm.strm
+let njunk len strm = Stream.njunk len strm.strm
 
 let next strm = Stream.next strm.strm

--- a/gramlib/lStream.mli
+++ b/gramlib/lStream.mli
@@ -43,6 +43,9 @@ val npeek : int -> 'a t -> 'a list
 val junk : 'a t -> unit
   (** consumes the next element if there is one *)
 
+val njunk : int -> 'a t -> unit
+(** [njunk n strm] consumes [n] elements from [strm] *)
+
 val next : 'a t -> 'a
   (** [next strm] returns and consumes the next element;
       raise [Stream.Failure] if the stream is empty *)


### PR DESCRIPTION
This is needed to implement caching of parsing. Tested.

- `Parsable.loc`: determine current position
- `Parsable.consume`: advance the stream on a cache hit.

