### PR TITLE
Generalize kernel evar handling

### DIFF
--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -23,7 +23,7 @@ module NamedDecl = Context.Named.Declaration
 
 let create_clos_infos env sigma flags =
   let open CClosure in
-  let evars ev = Evd.existential_opt_value0 sigma ev in
+  let evars = Evd.evar_handler sigma in
   create_clos_infos ~univs:(Evd.universes sigma) ~evars flags env
 
 

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -403,7 +403,7 @@ let push_rel_context_to_named_context ~hypnaming env sigma typ =
 
 let default_source = Loc.tag @@ Evar_kinds.InternalHole
 
-let new_pure_evar ?(src=default_source) ?(filter = Filter.identity) ?identity
+let new_pure_evar ?(src=default_source) ?(filter = Filter.identity) ?identity ?(relevance = Sorts.Relevant)
   ?(abstract_arguments = Abstraction.identity) ?candidates
   ?(naming = IntroAnonymous) ?typeclass_candidate ?(principal=false) sign evd typ =
   let name = match naming with
@@ -427,6 +427,7 @@ let new_pure_evar ?(src=default_source) ?(filter = Filter.identity) ?identity
     evar_source = src;
     evar_candidates = candidates;
     evar_identity = identity;
+    evar_relevance = relevance;
   }
   in
   let typeclass_candidate = if principal then Some false else typeclass_candidate in
@@ -453,7 +454,8 @@ let new_evar ?src ?filter ?abstract_arguments ?candidates ?naming ?typeclass_can
     | None -> instance
     | Some filter -> Filter.filter_list filter instance in
   let identity = if Int.equal (Environ.nb_rel env) 0 then Some (Identity.make instance) else None in
-  let (evd, evk) = new_pure_evar sign evd typ' ?src ?filter ?identity ?abstract_arguments ?candidates ?naming
+  let relevance = Sorts.Relevant in (* FIXME: relevant_of_type not defined yet *)
+  let (evd, evk) = new_pure_evar sign evd typ' ?src ?filter ?identity ~relevance ?abstract_arguments ?candidates ?naming
     ?typeclass_candidate ?principal in
   (evd, EConstr.mkEvar (evk, instance))
 

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -56,7 +56,7 @@ val new_evar :
 *)
 val new_pure_evar :
   ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
-  ?identity:Identity.t ->
+  ?identity:Identity.t -> ?relevance:Sorts.relevance ->
   ?abstract_arguments:Abstraction.t -> ?candidates:constr list ->
   ?naming:intro_pattern_naming_expr ->
   ?typeclass_candidate:bool ->

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -183,6 +183,7 @@ type evar_info = {
   evar_source : Evar_kinds.t Loc.located;
   evar_candidates : constr list option; (* if not None, list of allowed instances *)
   evar_identity : Identity.t;
+  evar_relevance: Sorts.relevance;
 }
 
 let make_evar hyps ccl = {
@@ -194,6 +195,7 @@ let make_evar hyps ccl = {
   evar_source = Loc.tag @@ Evar_kinds.InternalHole;
   evar_candidates = None;
   evar_identity = Identity.none ();
+  evar_relevance = Sorts.Relevant; (* FIXME *)
 }
 
 let instance_mismatch () =
@@ -764,9 +766,13 @@ let existential_value d ev = match existential_opt_value d ev with
   | None -> raise NotInstantiatedEvar
   | Some v -> v
 
-let evar_handler sigma = {
-  evar_expand = (fun ev -> existential_opt_value sigma ev);
-}
+let evar_handler sigma =
+  let evar_expand ev = existential_opt_value sigma ev in
+  let evar_relevance (evk, _) = match find sigma evk with
+  | evi -> evi.evar_relevance
+  | exception Not_found -> Sorts.Relevant
+  in
+  { evar_expand; evar_relevance }
 
 let existential_value0 = existential_value
 

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -764,6 +764,10 @@ let existential_value d ev = match existential_opt_value d ev with
   | None -> raise NotInstantiatedEvar
   | Some v -> v
 
+let evar_handler sigma = {
+  evar_expand = (fun ev -> existential_opt_value sigma ev);
+}
+
 let existential_value0 = existential_value
 
 let existential_opt_value0 = existential_opt_value

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -126,6 +126,8 @@ type evar_info = {
   evar_identity : Identity.t;
   (** Default evar instance, i.e. a list of Var nodes projected from the
       filtered environment. *)
+  evar_relevance : Sorts.relevance;
+  (** Relevance of the conclusion of the evar. *)
 }
 
 val make_evar : named_context_val -> etypes -> evar_info

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -273,6 +273,8 @@ val existential_opt_value : evar_map -> econstr pexistential -> econstr option
 
 val existential_opt_value0 : evar_map -> existential -> constr option
 
+val evar_handler : evar_map -> constr evar_handler
+
 val evar_instance_array : (Constr.named_declaration -> 'a -> bool) -> evar_info ->
   'a list -> (Id.t * 'a) list
 

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -291,7 +291,7 @@ let update ~share v1 mark t =
 
 type infos_cache = {
   i_env : env;
-  i_sigma : existential -> constr option;
+  i_sigma : constr evar_handler;
   i_share : bool;
   i_univs : UGraph.t;
   i_mode : mode;
@@ -1415,7 +1415,7 @@ and knht info e t stk =
       { mark = Red; term = FLetIn (n, mk_clos e b, mk_clos e t, c, e) }, stk
     | Evar ev ->
       (* FIXME: handle relevance *)
-      begin match info.i_cache.i_sigma ev with
+      begin match info.i_cache.i_sigma.evar_expand ev with
       | Some c -> knht info e c stk
       | None -> { mark = Whnf; term = FEvar (ev, e) }, stk
       end
@@ -1678,7 +1678,7 @@ let whd_stack infos tab m stk = match m.mark with
   in
   k
 
-let create_conv_infos ?univs ?(evars=fun _ -> None) flgs env =
+let create_conv_infos ?univs ?(evars=default_evar_handler) flgs env =
   let univs = Option.default (universes env) univs in
   let share = (Environ.typing_flags env).Declarations.share_reduction in
   let cache = {
@@ -1690,7 +1690,7 @@ let create_conv_infos ?univs ?(evars=fun _ -> None) flgs env =
   } in
   { i_flags = flgs; i_relevances = Range.empty; i_cache = cache }
 
-let create_clos_infos ?univs ?(evars=fun _ -> None) flgs env =
+let create_clos_infos ?univs ?(evars=default_evar_handler) flgs env =
   let univs = Option.default (universes env) univs in
   let share = (Environ.typing_flags env).Declarations.share_reduction in
   let cache = {

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -1414,10 +1414,13 @@ and knht info e t stk =
     | LetIn (n,b,t,c) ->
       { mark = Red; term = FLetIn (n, mk_clos e b, mk_clos e t, c, e) }, stk
     | Evar ev ->
-      (* FIXME: handle relevance *)
       begin match info.i_cache.i_sigma.evar_expand ev with
       | Some c -> knht info e c stk
-      | None -> { mark = Whnf; term = FEvar (ev, e) }, stk
+      | None ->
+        if is_irrelevant info.i_cache.i_mode (info.i_cache.i_sigma.evar_relevance ev) then
+          (mk_irrelevant, skip_irrelevant_stack stk)
+        else
+          { mark = Whnf; term = FEvar (ev, e) }, stk
       end
     | Array(u,t,def,ty) ->
       let len = Array.length t in

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -179,9 +179,9 @@ val destFLambda :
 type clos_infos
 type clos_tab
 val create_conv_infos :
-  ?univs:UGraph.t -> ?evars:(existential->constr option) -> reds -> env -> clos_infos
+  ?univs:UGraph.t -> ?evars:constr evar_handler -> reds -> env -> clos_infos
 val create_clos_infos :
-  ?univs:UGraph.t -> ?evars:(existential->constr option) -> reds -> env -> clos_infos
+  ?univs:UGraph.t -> ?evars:constr evar_handler -> reds -> env -> clos_infos
 val oracle_of_infos : clos_infos -> Conv_oracle.oracle
 
 val create_tab : unit -> clos_tab

--- a/kernel/constr.ml
+++ b/kernel/constr.ml
@@ -1465,11 +1465,13 @@ type named_context = named_declaration list
 type compacted_context = compacted_declaration list
 
 type 'constr evar_handler = {
-   evar_expand : 'constr pexistential -> 'constr option;
+  evar_expand : 'constr pexistential -> 'constr option;
+  evar_relevance : 'constr pexistential -> Sorts.relevance;
 }
 
 let default_evar_handler = {
-  evar_expand = fun _ -> None;
+  evar_expand = (fun _ -> None);
+  evar_relevance = (fun _ -> Sorts.Relevant);
 }
 
 (** Minimalistic constr printer, typically for debugging *)

--- a/kernel/constr.ml
+++ b/kernel/constr.ml
@@ -1464,6 +1464,14 @@ type rel_context = rel_declaration list
 type named_context = named_declaration list
 type compacted_context = compacted_declaration list
 
+type 'constr evar_handler = {
+   evar_expand : 'constr pexistential -> 'constr option;
+}
+
+let default_evar_handler = {
+  evar_expand = fun _ -> None;
+}
+
 (** Minimalistic constr printer, typically for debugging *)
 
 let debug_print_fix pr_constr ((t,i),(lna,tl,bl)) =

--- a/kernel/constr.mli
+++ b/kernel/constr.mli
@@ -610,6 +610,12 @@ val compare_head_gen_leq : Univ.Instance.t instance_compare_fn ->
 val eq_invert : ('a -> 'a -> bool)
   -> 'a pcase_invert -> 'a pcase_invert -> bool
 
+type 'constr evar_handler = {
+   evar_expand : 'constr pexistential -> 'constr option;
+}
+
+val default_evar_handler : 'constr evar_handler
+
 (** {6 Hashconsing} *)
 
 val hash : constr -> int

--- a/kernel/constr.mli
+++ b/kernel/constr.mli
@@ -611,7 +611,8 @@ val eq_invert : ('a -> 'a -> bool)
   -> 'a pcase_invert -> 'a pcase_invert -> bool
 
 type 'constr evar_handler = {
-   evar_expand : 'constr pexistential -> 'constr option;
+  evar_expand : 'constr pexistential -> 'constr option;
+  evar_relevance : 'constr pexistential -> Sorts.relevance;
 }
 
 val default_evar_handler : 'constr evar_handler

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -55,10 +55,10 @@ let rec rebuild_mp mp l =
   | i::r -> rebuild_mp (MPdot(mp,Label.of_id i)) r
 
 let infer_gen_conv state env c1 c2 =
-  Reduction.generic_conv Reduction.CONV ~l2r:false (fun _ -> None) TransparentState.full env state c1 c2
+  Reduction.generic_conv Reduction.CONV ~l2r:false Constr.default_evar_handler TransparentState.full env state c1 c2
 
 let infer_gen_conv_leq state env c1 c2 =
-  Reduction.generic_conv Reduction.CUMUL ~l2r:false (fun _ -> None) TransparentState.full env state c1 c2
+  Reduction.generic_conv Reduction.CUMUL ~l2r:false Constr.default_evar_handler TransparentState.full env state c1 c2
 
 let rec check_with_def (cst, ustate) env struc (idl,(c,ctx)) mp reso =
   let lab,idl = match idl with

--- a/kernel/nativelambda.ml
+++ b/kernel/nativelambda.ml
@@ -59,7 +59,7 @@ and lam_branches =
 and fix_decl =  Name.t Context.binder_annot array * lambda array * lambda array
 
 type evars =
-    { evars_val : existential -> constr option;
+    { evars_val : constr evar_handler;
       evars_metas : metavariable -> types }
 
 (*s Constructors *)
@@ -453,12 +453,12 @@ let is_lazy t =
   | App _ | LetIn _ | Case _ | Proj _ -> true
   | _ -> false
 
-let evar_value sigma ev = sigma.evars_val ev
+let evar_value sigma ev = sigma.evars_val.evar_expand ev
 
 let meta_type sigma mv = sigma.evars_metas mv
 
 let empty_evars =
-  { evars_val = (fun _ -> None);
+  { evars_val = default_evar_handler;
     evars_metas = (fun _ -> assert false) }
 
 (** Extract the inductive type over which a fixpoint is decreasing *)

--- a/kernel/nativelambda.mli
+++ b/kernel/nativelambda.mli
@@ -53,7 +53,7 @@ and lam_branches =
 and fix_decl =  Name.t Context.binder_annot array * lambda array * lambda array
 
 type evars =
-    { evars_val : existential -> constr option;
+    { evars_val : constr evar_handler;
       evars_metas : metavariable -> types }
 
 val empty_evars : evars

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -189,7 +189,7 @@ type 'a kernel_conversion_function = env -> 'a -> 'a -> unit
 (* functions of this type can be called from outside the kernel *)
 type 'a extended_conversion_function =
   ?l2r:bool -> ?reds:TransparentState.t -> env ->
-  ?evars:(existential->constr option) ->
+  ?evars:constr evar_handler ->
   'a -> 'a -> unit
 
 exception NotConvertible
@@ -907,7 +907,7 @@ let () =
   in
   CClosure.set_conv conv
 
-let gen_conv cv_pb ?(l2r=false) ?(reds=TransparentState.full) env ?(evars=(fun _ -> None)) t1 t2 =
+let gen_conv cv_pb ?(l2r=false) ?(reds=TransparentState.full) env ?(evars=default_evar_handler) t1 t2 =
   let univs = Environ.universes env in
   let b =
     if cv_pb = CUMUL then leq_constr_univs univs t1 t2

--- a/kernel/reduction.mli
+++ b/kernel/reduction.mli
@@ -31,7 +31,7 @@ exception NotConvertible
 type 'a kernel_conversion_function = env -> 'a -> 'a -> unit
 type 'a extended_conversion_function =
   ?l2r:bool -> ?reds:TransparentState.t -> env ->
-  ?evars:(existential->constr option) ->
+  ?evars:constr evar_handler ->
   'a -> 'a -> unit
 
 type conv_pb = CONV | CUMUL
@@ -75,7 +75,7 @@ val conv_leq : types extended_conversion_function
 (** Depending on the universe state functions, this might raise
   [UniverseInconsistency] in addition to [NotConvertible] (for better error
   messages). *)
-val generic_conv : conv_pb -> l2r:bool -> (existential->constr option) ->
+val generic_conv : conv_pb -> l2r:bool -> constr evar_handler ->
   TransparentState.t -> (constr,'a) generic_conversion_function
 
 val default_conv     : conv_pb -> types kernel_conversion_function

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -90,7 +90,7 @@ let check_conv_error error why state poly pb env a1 a2 =
         fst state
       with NotConvertible -> error (IncompatiblePolymorphism (env, a1, a2))
     else
-      Reduction.generic_conv pb ~l2r:false (fun _ -> None) TransparentState.full env state a1 a2
+      Reduction.generic_conv pb ~l2r:false default_evar_handler TransparentState.full env state a1 a2
   with NotConvertible -> error why
      | UGraph.UniverseInconsistency e -> error (IncompatibleUniverses e)
 

--- a/kernel/typeops.mli
+++ b/kernel/typeops.mli
@@ -105,7 +105,7 @@ val type_of_global_in_context : env -> GlobRef.t -> types * Univ.AbstractContext
 (** {6 Miscellaneous. } *)
 
 (** Check that hyps are included in env and fails with error otherwise *)
-val check_hyps_inclusion : env -> ?evars:(existential->constr option) ->
+val check_hyps_inclusion : env -> ?evars:constr evar_handler ->
   GlobRef.t -> Constr.named_context -> unit
 
 (** Types for primitives *)

--- a/kernel/vconv.ml
+++ b/kernel/vconv.ml
@@ -212,4 +212,4 @@ let vm_conv cv_pb env t1 t2 =
   in
   if not b then
     let state = (univs, checked_universes) in
-    let _ = vm_conv_gen cv_pb (fun _ -> None) env state t1 t2 in ()
+    let _ = vm_conv_gen cv_pb Constr.default_evar_handler env state t1 t2 in ()

--- a/kernel/vconv.mli
+++ b/kernel/vconv.mli
@@ -17,4 +17,4 @@ val vm_conv : conv_pb -> types kernel_conversion_function
 
 (** A conversion function parametrized by a universe comparator and
    evar normalizer. Used outside of the kernel. *)
-val vm_conv_gen : conv_pb -> (existential -> constr option) -> (types, 'a) generic_conversion_function
+val vm_conv_gen : conv_pb -> constr evar_handler -> (types, 'a) generic_conversion_function

--- a/kernel/vmbytegen.ml
+++ b/kernel/vmbytegen.ml
@@ -898,7 +898,7 @@ let compile_constant_body ~fail_on_error env univs = function
             let con= Constant.make1 (Constant.canonical kn') in
               Some (BCalias (get_alias env con))
         | _ ->
-            let sigma _ = assert false in
+            let sigma = { evar_expand = fun _ -> assert false } in
             let res = compile ~fail_on_error ~universes:instance_size env sigma body in
             Option.map (fun (code, fv) -> BCdefined (code, fv)) res
 

--- a/kernel/vmbytegen.ml
+++ b/kernel/vmbytegen.ml
@@ -898,7 +898,9 @@ let compile_constant_body ~fail_on_error env univs = function
             let con= Constant.make1 (Constant.canonical kn') in
               Some (BCalias (get_alias env con))
         | _ ->
-            let sigma = { evar_expand = fun _ -> assert false } in
+            let evar_expand _ = assert false in
+            let evar_relevance _ = assert false in
+            let sigma = { evar_expand = evar_expand; evar_relevance } in
             let res = compile ~fail_on_error ~universes:instance_size env sigma body in
             Option.map (fun (code, fv) -> BCdefined (code, fv)) res
 

--- a/kernel/vmbytegen.mli
+++ b/kernel/vmbytegen.mli
@@ -17,7 +17,7 @@ open Environ
 (** Should only be used for monomorphic terms *)
 val compile :
   fail_on_error:bool -> ?universes:int ->
-  env -> (existential -> constr option) -> constr ->
+  env -> constr evar_handler -> constr ->
   (to_patch * fv) option
 (** init, fun, fv *)
 

--- a/kernel/vmlambda.ml
+++ b/kernel/vmlambda.ml
@@ -587,7 +587,7 @@ struct
 
   type t = {
     global_env : env;
-    evar_body : existential -> constr option;
+    evar_body : constr evar_handler;
     name_rel : Name.t Vect.t;
     construct_tbl : (constructor, constructor_info) Hashtbl.t;
   }
@@ -632,7 +632,7 @@ let rec lambda_of_constr env c =
   match Constr.kind c with
   | Meta _ -> raise (Invalid_argument "Vmbytegen.lambda_of_constr: Meta")
   | Evar (evk, args as ev) ->
-      begin match env.evar_body ev with
+      begin match env.evar_body.evar_expand ev with
       | None ->
           let args = Array.map_of_list (fun c -> lambda_of_constr env c) args in
           Levar (evk, args)

--- a/kernel/vmlambda.mli
+++ b/kernel/vmlambda.mli
@@ -33,7 +33,7 @@ and fix_decl =  Name.t Context.binder_annot array * lambda array * lambda array
 
 exception TooLargeInductive of Pp.t
 
-val lambda_of_constr : optimize:bool -> env -> (existential -> constr option) -> Constr.t -> lambda
+val lambda_of_constr : optimize:bool -> env -> constr evar_handler -> Constr.t -> lambda
 
 val decompose_Llam : lambda -> Name.t Context.binder_annot array * lambda
 

--- a/kernel/vmsymtable.mli
+++ b/kernel/vmsymtable.mli
@@ -14,6 +14,6 @@ open Constr
 open Environ
 open Vmvalues
 
-val val_of_constr : env -> (existential -> constr option) -> constr -> Vmvalues.values
+val val_of_constr : env -> constr evar_handler -> constr -> Vmvalues.values
 
 val vm_interp : tcode -> values -> vm_env -> int -> values

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -548,7 +548,11 @@ let infer_conv_noticing_evars ~pb ~ts env sigma t1 t2 =
     if Option.is_empty v then has_evar := true;
     v
   in
-  let conv pb ~l2r sigma = Reduction.generic_conv pb ~l2r { evar_expand } in
+  let evar_relevance (evk, _) = match Evd.find sigma evk with
+  | evi -> evi.Evd.evar_relevance
+  | exception Not_found -> Sorts.Relevant
+  in
+  let conv pb ~l2r sigma = Reduction.generic_conv pb ~l2r { evar_expand; evar_relevance } in
   match infer_conv_gen conv ~catch_incon:false ~pb ~ts env sigma t1 t2 with
   | Some sigma -> Some (Success sigma)
   | None ->

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -543,11 +543,12 @@ let conv_fun f flags on_types =
 
 let infer_conv_noticing_evars ~pb ~ts env sigma t1 t2 =
   let has_evar = ref false in
-  let conv pb ~l2r sigma = Reduction.generic_conv pb ~l2r (fun ev ->
-      let v = existential_opt_value0 sigma ev in
-      if Option.is_empty v then has_evar := true;
-      v)
+  let evar_expand ev =
+    let v = existential_opt_value0 sigma ev in
+    if Option.is_empty v then has_evar := true;
+    v
   in
+  let conv pb ~l2r sigma = Reduction.generic_conv pb ~l2r { evar_expand } in
   match infer_conv_gen conv ~catch_incon:false ~pb ~ts env sigma t1 t2 with
   | Some sigma -> Some (Success sigma)
   | None ->

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -432,7 +432,7 @@ and nf_array env sigma t typ =
   mkArray(u, t, nf_val env sigma vdef typ_elem, typ_elem)
 
 let evars_of_evar_map sigma =
-  { Nativelambda.evars_val = Evd.existential_opt_value0 sigma;
+  { Nativelambda.evars_val = Evd.evar_handler sigma;
     Nativelambda.evars_metas = Evd.meta_type0 sigma }
 
 (* fork perf process, return profiler's process id *)

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1050,7 +1050,7 @@ let f_conv_leq ?l2r ?reds env ?evars x y =
 
 let test_trans_conversion (f: constr Reduction.extended_conversion_function) reds env sigma x y =
   try
-    let evars ev = existential_opt_value0 sigma ev in
+    let evars = Evd.evar_handler sigma in
     let env = Environ.set_universes (Evd.universes sigma) env in
     let _ = f ~reds env ~evars x y in
     true
@@ -1071,7 +1071,7 @@ let check_conv ?(pb=Reduction.CUMUL) ?(ts=TransparentState.full) env sigma x y =
     | Reduction.CUMUL -> f_conv_leq
   in
     let env = Environ.set_universes (Evd.universes sigma) env in
-    try f ~reds:ts env ~evars:(existential_opt_value0 sigma) x y; true
+    try f ~reds:ts env ~evars:(Evd.evar_handler sigma) x y; true
     with Reduction.NotConvertible -> false
     | UGraph.UniverseInconsistency _ -> false
     | e ->
@@ -1161,7 +1161,7 @@ let infer_conv_gen conv_fun ?(catch_incon=true) ?(pb=Reduction.CUMUL)
     report_anomaly e
 
 let infer_conv = infer_conv_gen (fun pb ~l2r sigma ->
-      Reduction.generic_conv pb ~l2r (existential_opt_value0 sigma))
+      Reduction.generic_conv pb ~l2r (Evd.evar_handler sigma))
 
 let infer_conv_ustate ?(catch_incon=true) ?(pb=Reduction.CUMUL)
     ?(ts=TransparentState.full) env sigma x y =
@@ -1179,7 +1179,7 @@ let infer_conv_ustate ?(catch_incon=true) ?(pb=Reduction.CUMUL)
         let y = EConstr.Unsafe.to_constr y in
         let env = Environ.set_universes (Evd.universes sigma) env in
         let cstr =
-          Reduction.generic_conv pb ~l2r:false (existential_opt_value0 sigma) ts
+          Reduction.generic_conv pb ~l2r:false (Evd.evar_handler sigma) ts
             env (UnivProblem.Set.empty, univproblem_univ_state) x y in
         Some cstr
   with
@@ -1191,12 +1191,12 @@ let infer_conv_ustate ?(catch_incon=true) ?(pb=Reduction.CUMUL)
 
 let vm_infer_conv ?(pb=Reduction.CUMUL) env sigma t1 t2 =
   infer_conv_gen (fun pb ~l2r sigma ts ->
-      Vconv.vm_conv_gen pb (Evd.existential_opt_value0 sigma))
+      Vconv.vm_conv_gen pb (Evd.evar_handler sigma))
     ~catch_incon:true ~pb env sigma t1 t2
 
 let native_conv_generic pb sigma t =
   let evars_of_evar_map sigma =
-    { Nativelambda.evars_val = Evd.existential_opt_value0 sigma;
+    { Nativelambda.evars_val = Evd.evar_handler sigma;
       Nativelambda.evars_metas = Evd.meta_type0 sigma }
   in
   Nativeconv.native_conv_gen pb (evars_of_evar_map sigma) t

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -295,7 +295,7 @@ let judge_of_letin env name defj typj j =
 
 let check_hyps_inclusion env sigma x hyps =
   let env = Environ.set_universes (Evd.universes sigma) env in
-  let evars = Evd.existential_opt_value0 sigma in
+  let evars = Evd.evar_handler sigma in
   Typeops.check_hyps_inclusion env ~evars x hyps
 
 let type_of_constant env sigma (c,u) =

--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -431,5 +431,5 @@ let cbv_vm env sigma c t  =
   (* This evar-normalizes terms beforehand *)
   let c = EConstr.Unsafe.to_constr c in
   let t = EConstr.Unsafe.to_constr t in
-  let v = Vmsymtable.val_of_constr env (Evd.existential_opt_value0 sigma) c in
+  let v = Vmsymtable.val_of_constr env (Evd.evar_handler sigma) c in
   EConstr.of_constr (nf_val env sigma v t)


### PR DESCRIPTION
This PR cleans up the handling of evars in the kernel.
- It tweaks the kernel reduction so that defined evars are not head-normal forms anymore
- It introduces a dedicated type for kernel-facing evar expansion functions
- Assuming the upper layers set the data correctly (they don't yet), kernel conversion now handles irrelevant evars.