### PR TITLE
[libobject] Common metadata for declared objects

### DIFF
--- a/checker/values.ml
+++ b/checker/values.ml
@@ -379,6 +379,10 @@ let v_compiled_lib =
 
 let v_obj = Dyn
 
+let v_source = Sum("source",1, [| [| Opt String; String |] |])
+let v_loc = Tuple("loc", [| v_source ; Int; Int; Int; Int; Int; Int |])
+let v_obj_data = Tuple("obj_data", [| Opt v_loc; Opt String; Opt v_id |])
+
 let v_open_filter = Sum ("open_filter",1,[|[|v_pred String|]|])
 
 let rec v_aobjs = Sum("algebraic_objects", 0,
@@ -393,7 +397,7 @@ and v_libobjt = Sum("Libobject.t",0,
      [| v_aobjs |];
      [| v_id; v_libobjs |];
      [| List (v_pair v_open_filter v_mp)|];
-     [| v_obj |]
+     [| v_obj_data; v_obj |]
   |])
 
 and v_libobjs = List v_libobjt

--- a/interp/abbreviation.ml
+++ b/interp/abbreviation.ml
@@ -112,7 +112,8 @@ let declare_abbreviation ~local ?(also_in_cases_pattern=true) deprecation id ~on
       abbrev_activated = true;
     }
   in
-  add_leaf (inAbbreviation id (local,abbrev))
+  let data = Data.make ~name:id () in
+  add_leaf ~data (inAbbreviation id (local,abbrev))
 
 let pr_abbreviation kn = pr_qualid (Nametab.shortest_qualid_of_abbreviation Id.Set.empty kn)
 

--- a/lib/loc.ml
+++ b/lib/loc.ml
@@ -12,8 +12,8 @@
 
 type source =
   (* OCaml won't allow using DirPath.t in InFile *)
-  | InFile of { dirpath : string option; file : string }
   | ToplevelInput
+  | InFile of { dirpath : string option; file : string }
 
 type t = {
   fname : source; (** filename or toplevel input *)

--- a/lib/loc.mli
+++ b/lib/loc.mli
@@ -11,8 +11,8 @@
 (** {5 Basic types} *)
 
 type source =
-  | InFile of { dirpath : string option; file : string }
   | ToplevelInput
+  | InFile of { dirpath : string option; file : string }
 
 type t = {
   fname : source; (** filename or toplevel input *)

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -40,7 +40,7 @@ type library_segment = (node * Libobject.t list) list
 (** Adding operations (which call the [cache] method, and getting the
   current list of operations (most recent ones coming first). *)
 
-val add_leaf : Libobject.obj -> unit
+val add_leaf : ?data:Libobject.Data.t -> Libobject.obj -> unit
 
 (** {6 ... } *)
 

--- a/library/libobject.ml
+++ b/library/libobject.ml
@@ -104,6 +104,27 @@ let ident_subst_function (_,a) = a
 
 type obj = Dyn.t (* persistent dynamic objects *)
 
+module Data : sig
+
+  type t
+
+  val empty : t
+  val make : ?loc:Loc.t -> ?doc:string -> ?name:Names.Id.t -> unit -> t
+  val name : t -> Names.Id.t option
+
+end = struct
+
+  type t =
+    { loc : Loc.t option
+    ; doc : string option
+    ; name : Names.Id.t option
+    }
+
+  let make ?loc ?doc ?name () = { loc; doc; name }
+  let empty = make ()
+  let name { name } = name
+end
+
 (** {6 Substitutive objects}
 
     - The list of bound identifiers is nonempty only if the objects
@@ -124,7 +145,7 @@ and t =
   | IncludeObject of algebraic_objects
   | KeepObject of Names.Id.t * t list
   | ExportObject of { mpl : (open_filter * Names.ModPath.t) list }
-  | AtomicObject of obj
+  | AtomicObject of { data : Data.t ; obj : obj }
 
 and substitutive_objects = Names.MBId.t list * algebraic_objects
 

--- a/plugins/ltac/tacenv.ml
+++ b/plugins/ltac/tacenv.ml
@@ -205,7 +205,8 @@ let inMD : tacdef -> obj =
      classify_function = classify_md}
 
 let register_ltac for_ml local ?deprecation id tac =
-  Lib.add_leaf (inMD {local; replace=NoReplace id; for_ml; expr=tac; depr=deprecation})
+  let data = Libobject.Data.make ~name:id () in
+  Lib.add_leaf ~data (inMD {local; replace=NoReplace id; for_ml; expr=tac; depr=deprecation})
 
 let redefine_ltac local ?deprecation kn tac =
   Lib.add_leaf (inMD {local; replace=Replace kn; for_ml=false; expr=tac; depr=deprecation})

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -369,7 +369,8 @@ let register_ltac ?deprecation ?(local = false) ?(mut = false) isrec tactics =
       tacdef_type = t;
       tacdef_deprecation = deprecation;
     } in
-    Lib.add_leaf (inTacDef id def)
+    let data = Libobject.Data.make ~name:id () in
+    Lib.add_leaf ~data (inTacDef id def)
   in
   List.iter iter defs
 
@@ -460,7 +461,9 @@ let register_typedef ?(local = false) isrec types =
     (id, typdef)
   in
   let types = List.map map types in
-  let iter (id, def) = Lib.add_leaf (inTypDef id def) in
+  let iter (id, def) =
+    let data = Libobject.Data.make ~name:id () in
+    Lib.add_leaf ~data (inTypDef id def) in
   List.iter iter types
 
 let register_primitive ?deprecation ?(local = false) {loc;v=id} t ml =
@@ -489,7 +492,8 @@ let register_primitive ?deprecation ?(local = false) {loc;v=id} t ml =
     tacdef_type = t;
     tacdef_deprecation = deprecation;
   } in
-  Lib.add_leaf (inTacDef id def)
+  let data = Libobject.Data.make ~name:id () in
+  Lib.add_leaf ~data (inTacDef id def)
 
 let register_open ?(local = false) qid (params, def) =
   let kn =
@@ -837,7 +841,8 @@ let register_notation_interpretation = function
   | Abbreviation (id, deprecation, body) ->
     let body = Tac2intern.globalize Id.Set.empty body in
     let abbr = { abbr_body = body; abbr_depr = deprecation } in
-    Lib.add_leaf (inTac2Abbreviation id abbr)
+    let data = Libobject.Data.make ~name:id () in
+    Lib.add_leaf ~data (inTac2Abbreviation id abbr)
   | Synext (local,kn,ids,body) ->
     let body = Tac2intern.globalize ids body in
     Lib.add_leaf (inTac2NotationInterp (local,kn,body))

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -221,8 +221,9 @@ let update_tables c =
 
 let register_constant kn kind local =
   let id = Label.to_id (Constant.label kn) in
+  let data = Libobject.Data.make ~name:id () in
   let o = inConstant (id, { cst_kind = kind; cst_locl = local; }) in
-  let () = Lib.add_leaf o in
+  let () = Lib.add_leaf ~data o in
   update_tables kn
 
 let register_side_effect (c, body, role) =
@@ -520,7 +521,8 @@ let declare_variable_core ~name ~kind d =
   in
   Nametab.push (Nametab.Until 1) (Libnames.make_path DirPath.empty name) (GlobRef.VarRef name);
   Decls.(add_variable_data name {opaque;kind});
-  Lib.add_leaf (inVariable name);
+  let data = Libobject.Data.make ~name () in
+  Lib.add_leaf ~data (inVariable name);
   Impargs.declare_var_implicits ~impl name;
   Notation.declare_ref_arguments_scope Evd.empty (GlobRef.VarRef name)
 

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -558,7 +558,7 @@ val is_local_constant : Constant.t -> bool
 
 module Internal : sig
 
-  (* Liboject exports *)
+  (* Libobject exports *)
   module Constant : sig
     type t
     val tag : (Id.t * t) Libobject.Dyn.tag

--- a/vernac/declareInd.ml
+++ b/vernac/declareInd.ml
@@ -108,7 +108,8 @@ let declare_mind ?typing_flags mie =
       Declare.check_exists typ;
       List.iter Declare.check_exists cons) names;
   let mind = Global.add_mind ?typing_flags id mie in
-  let () = Lib.add_leaf (inInductive (id, { ind_names = names })) in
+  let data = Libobject.Data.make ~name:id () in
+  let () = Lib.add_leaf ~data (inInductive (id, { ind_names = names })) in
   if is_unsafe_typing_flags() then feedback_axiom ();
   let isprim = Inductive.is_primitive_record (Inductive.lookup_mind_specif (Global.env()) (mind,0)) in
   Impargs.declare_mib_implicits mind;

--- a/vernac/declaremods.mli
+++ b/vernac/declaremods.mli
@@ -218,3 +218,14 @@ val end_modtype : unit -> ModPath.t
 val declare_include :
   (Constrexpr.module_ast * inline) list ->
   unit
+
+(** Experimental API *)
+type module_objects = private
+  { module_prefix : Nametab.object_prefix
+  ; module_substituted_objects : Libobject.t list
+  ; module_substituted_objects_by_name : Libobject.t Id.Map.t
+  ; module_keep_objects : Libobject.t list
+  ; module_keep_objects_by_name : Libobject.t Id.Map.t
+  }
+
+val modmap : unit -> module_objects Names.MPmap.t

--- a/vernac/mltop.ml
+++ b/vernac/mltop.ml
@@ -388,7 +388,7 @@ let () =
     ; Summary.unfreeze_function = unfreeze_ml_modules
     ; Summary.init_function = reset_loaded_modules }
 
-(* Liboject entries of declared ML Modules *)
+(* Libobject entries of declared ML Modules *)
 type ml_module_object =
   { mlocal : Vernacexpr.locality_flag
   ; mnames : PluginSpec.t list

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -709,7 +709,7 @@ let handle h (Libobject.Dyn.Dyn (tag, o)) = match DynHandle.find tag h with
    needs to be done in a more principled way. *)
 let gallina_print_library_leaf env sigma with_values mp lobj =
   match lobj with
-  | AtomicObject o ->
+  | AtomicObject { obj; _ } ->
     let handler =
       DynHandle.add Declare.Internal.objVariable begin fun id ->
           (* Outside sections, VARIABLES still exist but only with universes
@@ -726,7 +726,7 @@ let gallina_print_library_leaf env sigma with_values mp lobj =
       end @@
       DynHandle.empty
     in
-    handle handler o
+    handle handler obj
   | ModuleObject (id,_) ->
     Some (print_module ~with_body:with_values (MPdot (mp,Label.of_id id)))
   | ModuleTypeObject (id,_) ->
@@ -877,7 +877,7 @@ let print_full_pure_atomic env sigma mp lobj =
   handleF handler lobj
 
 let print_full_pure_leaf env sigma mp = function
-  | AtomicObject lobj -> print_full_pure_atomic env sigma mp lobj
+  | AtomicObject { obj; _ } -> print_full_pure_atomic env sigma mp obj
   | ModuleObject (id, _) ->
     (* TODO: make it reparsable *)
     print_module (MPdot (mp,Label.of_id id)) ++ str "." ++ fnl () ++ fnl ()

--- a/vernac/search.ml
+++ b/vernac/search.ml
@@ -77,7 +77,7 @@ let generic_search env (fn : GlobRef.t -> Decls.logical_kind option -> env -> co
   List.iter (fun d -> fn (GlobRef.VarRef (NamedDecl.get_id d)) None env (NamedDecl.get_type d))
     (Environ.named_context env);
   let iter_obj prefix lobj = match lobj with
-    | AtomicObject o ->
+    | AtomicObject { obj } ->
       let handler =
         DynHandle.add Declare.Internal.Constant.tag begin fun (id,obj) ->
           let kn = KerName.make prefix.Nametab.obj_mp (Label.of_id id) in
@@ -104,7 +104,7 @@ let generic_search env (fn : GlobRef.t -> Decls.logical_kind option -> env -> co
         end @@
         DynHandle.empty
       in
-      handle handler o
+      handle handler obj
     | _ -> ()
   in
   try Declaremods.iter_all_interp_segments iter_obj


### PR DESCRIPTION
This is a first implementation of CEP https://github.com/coq/ceps/pull/65

We add a common metadata object to atomic libobjects, so we can store
documentation, location, names, and other interesting attributes that
are needed by clients to implement functionality.

As we allow storing names of the objects, we can index them by name to
provide efficient reverse lookup.

We export an experimental API for clients to consume this metadata.

PR https://github.com/coq/coq/pull/16261 is implemented on top of this one.