### PR TITLE
Partially revert #9139.

### DIFF
--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -620,7 +620,7 @@ let shelve =
   let open Proof in
   Comb.get >>= fun initial ->
   Comb.set [] >>
-  InfoL.leaf (Info.Tactic (fun _ _ -> Pp.str"shelve")) >>
+  InfoL.leaf (Info.Tactic (fun () -> Pp.str"shelve")) >>
   let initial = CList.map drop_state initial in
   Pv.modify (fun pv -> { pv with solution = Evd.shelve pv.solution initial })
 
@@ -629,7 +629,7 @@ let shelve_goals l =
   Comb.get >>= fun initial ->
   let comb = CList.filter (fun g -> not (CList.mem (drop_state g) l)) initial in
   Comb.set comb >>
-  InfoL.leaf (Info.Tactic (fun _ _ -> Pp.str"shelve_goals")) >>
+  InfoL.leaf (Info.Tactic (fun () -> Pp.str"shelve_goals")) >>
   Pv.modify (fun pv -> { pv with solution = Evd.shelve pv.solution l })
 
 (** [depends_on sigma src tgt] checks whether the goal [src] appears
@@ -695,7 +695,7 @@ let shelve_unifiable_informative =
   Pv.get >>= fun initial ->
   let (u,n) = partition_unifiable initial.solution initial.comb in
   Comb.set n >>
-  InfoL.leaf (Info.Tactic (fun _ _ -> Pp.str"shelve_unifiable")) >>
+  InfoL.leaf (Info.Tactic (fun () -> Pp.str"shelve_unifiable")) >>
   let u = CList.map drop_state u in
   Pv.modify (fun pv -> { pv with solution = Evd.shelve pv.solution u }) >>
   tclUNIT u
@@ -784,7 +784,7 @@ let goodmod p m =
 
 let cycle n =
   let open Proof in
-  InfoL.leaf (Info.Tactic (fun _ _ -> Pp.(str"cycle "++int n))) >>
+  InfoL.leaf (Info.Tactic (fun () -> Pp.(str"cycle "++int n))) >>
   Comb.modify begin fun initial ->
     let l = CList.length initial in
     let n' = goodmod n l in
@@ -794,7 +794,7 @@ let cycle n =
 
 let swap i j =
   let open Proof in
-  InfoL.leaf (Info.Tactic (fun _ _ -> Pp.(hov 2 (str"swap"++spc()++int i++spc()++int j)))) >>
+  InfoL.leaf (Info.Tactic (fun () -> Pp.(hov 2 (str"swap"++spc()++int i++spc()++int j)))) >>
   Comb.modify begin fun initial ->
     let l = CList.length initial in
     let i = if i>0 then i-1 else i and j = if j>0 then j-1 else j in
@@ -809,7 +809,7 @@ let swap i j =
 
 let revgoals =
   let open Proof in
-  InfoL.leaf (Info.Tactic (fun _ _ -> Pp.str"revgoals")) >>
+  InfoL.leaf (Info.Tactic (fun () -> Pp.str"revgoals")) >>
   Comb.modify CList.rev
 
 let numgoals =
@@ -853,7 +853,7 @@ let give_up =
   Comb.get >>= fun initial ->
   Comb.set [] >>
   mark_as_unsafe >>
-  InfoL.leaf (Info.Tactic (fun _ _ -> Pp.str"give_up")) >>
+  InfoL.leaf (Info.Tactic (fun () -> Pp.str"give_up")) >>
   Pv.modify (give_up initial)
 
 

--- a/engine/proofview_monad.mli
+++ b/engine/proofview_monad.mli
@@ -45,7 +45,7 @@ end
 
 (** We typically label nodes of [Trace.tree] with messages to
     print. But we don't want to compute the result. *)
-type lazy_msg = Environ.env -> Evd.evar_map -> Pp.t
+type lazy_msg = unit -> Pp.t
 
 (** Info trace. *)
 module Info : sig

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -97,7 +97,7 @@ let pr_appl h vs =
 let rec name_with_list appl t =
   match appl with
   | [] -> t
-  | (h,vs)::l -> Proofview.Trace.name_tactic (fun _ _ -> pr_appl h vs) (name_with_list l t)
+  | (h,vs)::l -> Proofview.Trace.name_tactic (fun () -> pr_appl h vs) (name_with_list l t)
 let name_if_glob appl t =
   match appl with
   | UnnamedAppl -> t
@@ -1139,7 +1139,7 @@ and eval_tactic_ist ist tac : unit Proofview.tactic =
         return (hov 0 msg , hov 0 msg)
       in
       let print (_,msgnl) = Proofview.(tclLIFT (NonLogical.print_info msgnl)) in
-      let log (msg,_) = Proofview.Trace.log (fun _ _ -> msg) in
+      let log (msg,_) = Proofview.Trace.log (fun () -> msg) in
       let break = Proofview.tclLIFT (db_breakpoint (curr_debug ist) s) in
       Ftactic.run msgnl begin fun msgnl ->
         print msgnl <*> log msgnl <*> break
@@ -1220,7 +1220,7 @@ and eval_tactic_ist ist tac : unit Proofview.tactic =
       in
       let tac =
         Ftactic.with_env interp_vars >>= fun (env, lr) ->
-        let name _ _ = Pptactic.pr_alias (fun v -> print_top_val env v) 0 s lr in
+        let name () = Pptactic.pr_alias (fun v -> print_top_val env v) 0 s lr in
         Proofview.Trace.name_tactic name (tac lr)
       (* spiwack: this use of name_tactic is not robust to a
          change of implementation of [Ftactic]. In such a situation,
@@ -1244,7 +1244,7 @@ and eval_tactic_ist ist tac : unit Proofview.tactic =
       let tac = Tacenv.interp_ml_tactic opn in
       let args = Ftactic.List.map_right (fun a -> interp_tacarg ist a) l in
       let tac args =
-        let name _ _ = Pptactic.pr_extend (fun v -> print_top_val () v) 0 opn args in
+        let name () = Pptactic.pr_extend (fun v -> print_top_val () v) 0 opn args in
         let (stack, _) = trace in
         Proofview.Trace.name_tactic name (catch_error_tac_loc loc stack (tac args ist))
       in
@@ -1670,7 +1670,7 @@ and name_atomic ?env tacexpr tac : unit Proofview.tactic =
   | None -> Proofview.tclENV
   end >>= fun env ->
   Proofview.tclEVARMAP >>= fun sigma ->
-  let name _ _ = Pptactic.pr_atomic_tactic env sigma tacexpr in
+  let name () = Pptactic.pr_atomic_tactic env sigma tacexpr in
   Proofview.Trace.name_tactic name tac
 
 (* Interprets a primitive tactic *)
@@ -1690,7 +1690,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
       end
   | TacApply (a,ev,cb,cl) ->
       (* spiwack: until the tactic is in the monad *)
-      Proofview.Trace.name_tactic (fun _ _ -> Pp.str"<apply>") begin
+      Proofview.Trace.name_tactic (fun () -> Pp.str"<apply>") begin
       Proofview.Goal.enter begin fun gl ->
         let env = Proofview.Goal.env gl in
         let sigma = project gl in
@@ -1731,7 +1731,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
       end
   | TacMutualFix (id,n,l) ->
       (* spiwack: until the tactic is in the monad *)
-      Proofview.Trace.name_tactic (fun _ _ -> Pp.str"<mutual fix>") begin
+      Proofview.Trace.name_tactic (fun () -> Pp.str"<mutual fix>") begin
       Proofview.Goal.enter begin fun gl ->
         let env = pf_env gl in
         let f sigma (id,n,c) =
@@ -1746,7 +1746,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
       end
   | TacMutualCofix (id,l) ->
       (* spiwack: until the tactic is in the monad *)
-      Proofview.Trace.name_tactic (fun _ _ -> Pp.str"<mutual cofix>") begin
+      Proofview.Trace.name_tactic (fun () -> Pp.str"<mutual cofix>") begin
       Proofview.Goal.enter begin fun gl ->
         let env = pf_env gl in
         let f sigma (id,c) =
@@ -1861,7 +1861,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
       end
   | TacChange (check,None,c,cl) ->
       (* spiwack: until the tactic is in the monad *)
-      Proofview.Trace.name_tactic (fun _ _ -> Pp.str"<change>") begin
+      Proofview.Trace.name_tactic (fun () -> Pp.str"<change>") begin
       Proofview.Goal.enter begin fun gl ->
         let is_onhyps = match cl.onhyps with
           | None | Some [] -> true
@@ -1886,7 +1886,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
       end
   | TacChange (check,Some op,c,cl) ->
       (* spiwack: until the tactic is in the monad *)
-      Proofview.Trace.name_tactic (fun _ _ -> Pp.str"<change>") begin
+      Proofview.Trace.name_tactic (fun () -> Pp.str"<change>") begin
       Proofview.Goal.enter begin fun gl ->
         let env = Proofview.Goal.env gl in
         let sigma = project gl in

--- a/proofs/refine.ml
+++ b/proofs/refine.ml
@@ -95,7 +95,7 @@ let generic_refine ~typecheck f gl =
   (* Mark goals *)
   let sigma = Proofview.Unsafe.mark_as_goals sigma future_goals.Evd.FutureGoals.comb in
   let comb = CList.rev_map (fun x -> Proofview.goal_with_state x state) future_goals.Evd.FutureGoals.comb in
-  let trace env sigma = Pp.(hov 2 (str"simple refine"++spc()++
+  let trace _ _ = Pp.(hov 2 (str"simple refine"++spc()++
                                    Termops.Internal.print_constr_env env sigma c)) in
   Proofview.Trace.name_tactic trace (Proofview.tclUNIT v) >>= fun v ->
   Proofview.Unsafe.tclSETENV (Environ.reset_context env) <*>

--- a/proofs/refine.ml
+++ b/proofs/refine.ml
@@ -95,7 +95,7 @@ let generic_refine ~typecheck f gl =
   (* Mark goals *)
   let sigma = Proofview.Unsafe.mark_as_goals sigma future_goals.Evd.FutureGoals.comb in
   let comb = CList.rev_map (fun x -> Proofview.goal_with_state x state) future_goals.Evd.FutureGoals.comb in
-  let trace _ _ = Pp.(hov 2 (str"simple refine"++spc()++
+  let trace () = Pp.(hov 2 (str"simple refine"++spc()++
                                    Termops.Internal.print_constr_env env sigma c)) in
   Proofview.Trace.name_tactic trace (Proofview.tclUNIT v) >>= fun v ->
   Proofview.Unsafe.tclSETENV (Environ.reset_context env) <*>

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1027,9 +1027,9 @@ let reduce redexp cl =
     let pr = ((fun e -> pr_econstr_env e), (fun e -> pr_leconstr_env e), pr_evaluable_reference, pr_constr_pattern_env) in
     Pp.(hov 2 (Ppred.pr_red_expr_env env sigma pr str redexp))
   in
-  Proofview.Trace.name_tactic trace begin
   Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
+  let sigma = Proofview.Goal.sigma gl in
   let hyps = concrete_clause_of (fun () -> Tacmach.pf_ids_of_hyps gl) cl in
   let nbcl = (if cl.concl_occs = NoOccurrences then 0 else 1) + List.length hyps in
   let check = match redexp with Fold _ | Pattern _ -> true | _ -> false in
@@ -1043,6 +1043,7 @@ let reduce redexp cl =
   | ExtraRedExpr _ -> StableHypConv (* Should we be that lenient ?*)
   in
   let redexp = Redexpr.eval_red_expr env redexp in
+  Proofview.Trace.name_tactic (fun () -> trace env sigma) begin
   begin match cl.concl_occs with
   | NoOccurrences -> Proofview.tclUNIT ()
   | occs ->


### PR DESCRIPTION
This change (#9139) was a footgun because it was inciting the caller to use the provided environment and evarmap to perform printing of the thunk, although that data could have been unrelated to the current one. Given that the trace mechanism is supposed to be called from within the monad, always, it is natural to simply fetch the relevant information from the ambient pure state rather than fiddle with broken contraptions.

See the first commit of the PR for such a latent issue that was revealed by #16442. 