### PR TITLE
Be stricter about substitution of evar instances.

### DIFF
--- a/dev/ci/user-overlays/16488-ppedrot-stricter-evar-access.sh
+++ b/dev/ci/user-overlays/16488-ppedrot-stricter-evar-access.sh
@@ -1,0 +1,9 @@
+overlay unicoq https://github.com/ppedrot/unicoq stricter-evar-access 16488
+
+overlay rewriter https://github.com/ppedrot/rewriter stricter-evar-access 16488
+
+overlay equations https://github.com/ppedrot/Coq-Equations stricter-evar-access 16488
+
+overlay mtac2 https://github.com/ppedrot/Mtac2 stricter-evar-access 16488
+
+overlay relation_algebra https://github.com/ppedrot/relation-algebra stricter-evar-access 16488

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -154,11 +154,11 @@ val mkLambda_or_LetIn : rel_declaration -> t -> t
 val it_mkProd_or_LetIn : t -> rel_context -> t
 val it_mkLambda_or_LetIn : t -> rel_context -> t
 
-val mkNamedLambda : Id.t Context.binder_annot -> types -> constr -> constr
-val mkNamedLetIn : Id.t Context.binder_annot -> constr -> types -> constr -> constr
-val mkNamedProd : Id.t Context.binder_annot -> types -> types -> types
-val mkNamedLambda_or_LetIn : named_declaration -> types -> types
-val mkNamedProd_or_LetIn : named_declaration -> types -> types
+val mkNamedLambda : Evd.evar_map -> Id.t Context.binder_annot -> types -> constr -> constr
+val mkNamedLetIn : Evd.evar_map -> Id.t Context.binder_annot -> constr -> types -> constr -> constr
+val mkNamedProd : Evd.evar_map -> Id.t Context.binder_annot -> types -> types -> types
+val mkNamedLambda_or_LetIn : Evd.evar_map -> named_declaration -> types -> types
+val mkNamedProd_or_LetIn : Evd.evar_map -> named_declaration -> types -> types
 
 (** {6 Simple case analysis} *)
 
@@ -289,10 +289,10 @@ val substnl_decl : substl -> int -> rel_declaration -> rel_declaration
 val substl_decl : substl -> rel_declaration -> rel_declaration
 val subst1_decl : t -> rel_declaration -> rel_declaration
 
-val replace_vars : (Id.t * t) list -> t -> t
-val substn_vars : int -> Id.t list -> t -> t
-val subst_vars : Id.t list -> t -> t
-val subst_var : Id.t -> t -> t
+val replace_vars : Evd.evar_map -> (Id.t * t) list -> t -> t
+val substn_vars : Evd.evar_map -> int -> Id.t list -> t -> t
+val subst_vars : Evd.evar_map -> Id.t list -> t -> t
+val subst_var : Evd.evar_map -> Id.t -> t -> t
 
 val noccurn : Evd.evar_map -> int -> t -> bool
 val noccur_between : Evd.evar_map -> int -> int -> t -> bool

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -331,7 +331,7 @@ let push_rel_decl_to_named_context
     else
       let nc = replace_var_named_declaration id0 id nc in
       let vsubst = [id0 , mkVar id] in
-      push_named_context_val (map_decl (fun c -> replace_vars vsubst c) decl) nc
+      push_named_context_val (map_decl (fun c -> replace_vars sigma vsubst c) decl) nc
   in
   let extract_if_neq id = function
     | Anonymous -> None
@@ -492,7 +492,7 @@ let generalize_evar_over_rels sigma (ev,args) =
   let sign = named_context_of_val evi.evar_hyps in
   List.fold_left2
     (fun (c,inst as x) a d ->
-      if isRel sigma a then (mkNamedProd_or_LetIn d c,a::inst) else x)
+      if isRel sigma a then (mkNamedProd_or_LetIn sigma d c,a::inst) else x)
      (evi.evar_concl,[]) args sign
 
 (************************************)

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -280,7 +280,7 @@ val evar_handler : evar_map -> constr evar_handler
 val evar_instance_array : (Constr.named_declaration -> 'a -> bool) -> evar_info ->
   'a list -> (Id.t * 'a) list
 
-val instantiate_evar_array : evar_info -> econstr -> econstr list -> econstr
+val instantiate_evar_array : evar_map -> evar_info -> econstr -> econstr list -> econstr
 
 val evars_reset_evd  : ?with_conv_pbs:bool -> ?with_univs:bool ->
   evar_map ->  evar_map -> evar_map
@@ -749,6 +749,8 @@ module MiniEConstr : sig
   val kind_upto : evar_map -> constr -> (constr, types, Sorts.t, Univ.Instance.t) Constr.kind_of_term
 
   val whd_evar : evar_map -> t -> t
+
+  val replace_vars : evar_map -> (Id.t * t) list -> t -> t
 
   val of_kind : (t, t, ESorts.t, EInstance.t) Constr.kind_of_term -> t
 

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -510,9 +510,9 @@ let it_named_context_quantifier f ~init =
 let it_mkProd_or_LetIn init = it_named_context_quantifier mkProd_or_LetIn ~init
 let it_mkProd_wo_LetIn init = it_named_context_quantifier mkProd_wo_LetIn ~init
 let it_mkLambda_or_LetIn init = it_named_context_quantifier mkLambda_or_LetIn ~init
-let it_mkNamedProd_or_LetIn init = it_named_context_quantifier EConstr.mkNamedProd_or_LetIn ~init
+let it_mkNamedProd_or_LetIn sigma init = it_named_context_quantifier (EConstr.mkNamedProd_or_LetIn sigma) ~init
 let it_mkNamedProd_wo_LetIn init = it_named_context_quantifier mkNamedProd_wo_LetIn ~init
-let it_mkNamedLambda_or_LetIn init = it_named_context_quantifier EConstr.mkNamedLambda_or_LetIn ~init
+let it_mkNamedLambda_or_LetIn sigma init = it_named_context_quantifier (EConstr.mkNamedLambda_or_LetIn sigma) ~init
 
 let it_mkLambda_or_LetIn_from_no_LetIn c decls =
   let open RelDecl in

--- a/engine/termops.mli
+++ b/engine/termops.mli
@@ -39,9 +39,9 @@ val it_mkLambda : constr -> (Name.t Context.binder_annot * types) list -> constr
 val it_mkProd_or_LetIn : types -> rel_context -> types
 val it_mkProd_wo_LetIn : types -> rel_context -> types
 val it_mkLambda_or_LetIn : Constr.constr -> Constr.rel_context -> Constr.constr
-val it_mkNamedProd_or_LetIn : types -> named_context -> types
+val it_mkNamedProd_or_LetIn : Evd.evar_map -> types -> named_context -> types
 val it_mkNamedProd_wo_LetIn : Constr.types -> Constr.named_context -> Constr.types
-val it_mkNamedLambda_or_LetIn : constr -> named_context -> constr
+val it_mkNamedLambda_or_LetIn : Evd.evar_map -> constr -> named_context -> constr
 
 (* Ad hoc version reinserting letin, assuming the body is defined in
    the context where the letins are expanded *)

--- a/kernel/vars.ml
+++ b/kernel/vars.ml
@@ -235,6 +235,8 @@ let replace_vars var_alist x =
       | var -> lift_substituend n var
       | exception Not_found -> c
       end
+    | Constr.Evar _ ->
+      CErrors.anomaly (Pp.str "Substituting an evar in the kernel")
     | _ -> Constr.map_with_binders succ substrec n c
     in
     substrec 0 x

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -1342,7 +1342,7 @@ let abstract_type sigma gl =
   Environ.fold_named_context_reverse (fun t decl ->
                                         if is_proof_var decl then
                                           let decl = Termops.map_named_decl EConstr.of_constr decl in
-                                          mkNamedProd_or_LetIn decl t
+                                          mkNamedProd_or_LetIn sigma decl t
                                         else
                                           t
                                       ) ~init:(Evd.evar_concl evi) env

--- a/plugins/ltac/leminv.ml
+++ b/plugins/ltac/leminv.ml
@@ -167,7 +167,7 @@ let compute_first_inversion_scheme env sigma ind sort dep_option =
                (revargs,hyps))
           env ~init:([],[])
       in
-      let pty = it_mkNamedProd_or_LetIn (mkSort sort) ownsign in
+      let pty = it_mkNamedProd_or_LetIn sigma (mkSort sort) ownsign in
       let goal = mkArrow i Sorts.Relevant (applist(mkVar p, List.rev revargs)) in
       (pty,goal)
   in
@@ -227,7 +227,7 @@ let inversion_scheme ~name ~poly env sigma t sort dep_option inv_op =
   in
   let c = fill_holes pfterm in
   (* warning: side-effect on ownSign *)
-  let invProof = it_mkNamedLambda_or_LetIn c !ownSign in
+  let invProof = it_mkNamedLambda_or_LetIn sigma c !ownSign in
   invProof, sigma
 
 let add_inversion_lemma ~poly name env sigma t sort dep inv_op =

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -681,7 +681,8 @@ let () = define3 "constr_substnl" (list constr) int constr begin fun subst k c -
 end
 
 let () = define3 "constr_closenl" (list ident) int constr begin fun ids k c ->
-  let ans = EConstr.Vars.substn_vars k ids c in
+  Proofview.tclEVARMAP >>= fun sigma ->
+  let ans = EConstr.Vars.substn_vars sigma k ids c in
   return (Value.of_constr ans)
 end
 

--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -1350,13 +1350,13 @@ let make_goal_of_formula gl dexpr form =
      * TODO: reverse the list of bindings!
   *)
 
-let set l concl =
+let set sigma l concl =
   let rec xset acc = function
     | [] -> acc
     | e :: l ->
       let name, expr, typ = e in
       xset
-        (EConstr.mkNamedLetIn
+        (EConstr.mkNamedLetIn sigma
            (make_annot (Names.Id.of_string name) Sorts.Relevant)
            expr typ acc)
         l
@@ -1513,9 +1513,10 @@ let micromega_order_change spec cert cert_typ env ff (*: unit Proofview.tactic*)
   let vm = dump_varmap spec.typ (vm_of_list env) in
   (* todo : directly generate the proof term - or generalize before conversion? *)
   Proofview.Goal.enter (fun gl ->
+    let sigma = Proofview.Goal.sigma gl in
       Tacticals.tclTHENLIST
         [ Tactics.change_concl
-            (set
+            (set sigma
                [ ( "__ff"
                  , ff
                  , EConstr.mkApp
@@ -1996,9 +1997,10 @@ let micromega_order_changer cert env ff =
   let ff = dump_formula formula_typ (dump_cstr coeff dump_coeff) ff in
   let vm = dump_varmap typ (vm_of_list env) in
   Proofview.Goal.enter (fun gl ->
+    let sigma = Proofview.Goal.sigma gl in
       Tacticals.tclTHENLIST
         [ Tactics.change_concl
-            (set
+            (set sigma
                [ ( "__ff"
                  , ff
                  , EConstr.mkApp

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -391,7 +391,7 @@ let pirrel_rewrite ?(under=false) ?(map_redex=id_map_redex) pred rdx rdx_ty new_
   let sigma, new_rdx = map_redex env sigma ~before:rdx ~after:new_rdx in
   let sigma, p = (* The resulting goal *)
     Evarutil.new_evar env sigma (beta (EConstr.Vars.subst1 new_rdx pred)) in
-  let pred = EConstr.mkNamedLambda (make_annot pattern_id Sorts.Relevant) rdx_ty pred in
+  let pred = EConstr.mkNamedLambda sigma (make_annot pattern_id Sorts.Relevant) rdx_ty pred in
   let sigma, elim =
     let sort = Tacticals.elimination_sort_of_goal gl in
     match Equality.eq_elimination_ref (dir = L2R) sort with
@@ -469,7 +469,7 @@ let rwcltac ?under ?map_redex cl rdx dir (sigma, r) =
   let r_n, evs, ucst = abs_evars env sigma0 (sigma, r) in
   let n = List.length evs in
   let r_n' = abs_cterm env sigma0 n r_n in
-  let r' = EConstr.Vars.subst_var pattern_id r_n' in
+  let r' = EConstr.Vars.subst_var sigma pattern_id r_n' in
   let sigma0 = Evd.set_universe_context sigma0 ucst in
   let sigma, rdxt = Typing.type_of env sigma rdx in
   let () = debug_ssr (fun () -> Pp.(str"r@rwcltac=" ++ pr_econstr_env env sigma r)) in
@@ -484,7 +484,7 @@ let rwcltac ?under ?map_redex cl rdx dir (sigma, r) =
           let new_rdx = if dir = L2R then a.(2) else a.(1) in
           pirrel_rewrite ?under ?map_redex cl rdx a.(0) new_rdx dir (sigma, r) c_ty, Tacticals.tclIDTAC, sigma0
       | _ ->
-          let cl' = EConstr.mkApp (EConstr.mkNamedLambda (make_annot pattern_id Sorts.Relevant) rdxt cl, [|rdx|]) in
+          let cl' = EConstr.mkApp (EConstr.mkNamedLambda sigma (make_annot pattern_id Sorts.Relevant) rdxt cl, [|rdx|]) in
           let sigma, _ = Typing.type_of env sigma cl' in
           let sigma0 = pf_merge_uc_of sigma sigma0 in
           convert_concl ~check:true cl', rewritetac ?under dir r', sigma0
@@ -494,8 +494,8 @@ let rwcltac ?under ?map_redex cl rdx dir (sigma, r) =
         try EConstr.destCast sigma0 r2 with _ ->
         errorstrm Pp.(str "no cast from " ++ pr_econstr_pat env sigma0 r
                     ++ str " to " ++ pr_econstr_env env sigma0 r2) in
-      let cl' = EConstr.mkNamedProd (make_annot rule_id Sorts.Relevant) (EConstr.it_mkProd_or_LetIn r3t dc) (EConstr.Vars.lift 1 cl) in
-      let cl'' = EConstr.mkNamedProd (make_annot pattern_id Sorts.Relevant) rdxt cl' in
+      let cl' = EConstr.mkNamedProd sigma (make_annot rule_id Sorts.Relevant) (EConstr.it_mkProd_or_LetIn r3t dc) (EConstr.Vars.lift 1 cl) in
+      let cl'' = EConstr.mkNamedProd sigma (make_annot pattern_id Sorts.Relevant) rdxt cl' in
       let itacs = [introid pattern_id; introid rule_id] in
       let cltac = Tactics.clear [pattern_id; rule_id] in
       let rwtacs = [
@@ -519,7 +519,7 @@ let rwcltac ?under ?map_redex cl rdx dir (sigma, r) =
       then Tacticals.tclZEROMSG Pp.(str "Rewriting impacts evars" ++ error)
       else Tacticals.tclZEROMSG Pp.(str "Dependent type error in rewrite of "
         ++ pr_econstr_env env sigma0
-          (EConstr.mkNamedLambda (make_annot pattern_id Sorts.Relevant) rdxt cl)
+          (EConstr.mkNamedLambda sigma (make_annot pattern_id Sorts.Relevant) rdxt cl)
         ++ error)
     | (e, info) -> Proofview.tclZERO ~info e
     end

--- a/plugins/ssr/ssrfwd.ml
+++ b/plugins/ssr/ssrfwd.ml
@@ -325,8 +325,8 @@ let wlogtac ist (((clr0, pats),_),_) (gens, ((_, ct))) hint suff ghave =
         EConstr.push_rel rd env, c) (env, c) gens in
     let sigma, _, ct, _ = pf_interp_ty env sigma ist ct in
     let rec var2rel c g s = match EConstr.kind sigma c, g with
-      | Prod({binder_name=Anonymous} as x,_,c), [] -> EConstr.mkProd(x, EConstr.Vars.subst_vars s ct, c)
-      | Sort _, [] -> EConstr.Vars.subst_vars s ct
+      | Prod({binder_name=Anonymous} as x,_,c), [] -> EConstr.mkProd(x, EConstr.Vars.subst_vars sigma s ct, c)
+      | Sort _, [] -> EConstr.Vars.subst_vars sigma s ct
       | LetIn({binder_name=Name id} as n,b,ty,c), _::g -> EConstr.mkLetIn (n,b,ty,var2rel c g (id::s))
       | Prod({binder_name=Name id} as n,ty,c), _::g -> EConstr.mkProd (n,ty,var2rel c g (id::s))
       | _ -> CErrors.anomaly(str"SSR: wlog: var2rel: " ++ pr_econstr_env env sigma c) in

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -355,9 +355,9 @@ let evars_for_FO ~hack ~rigid env (ise0:evar_map) c0 =
     let dc = List.firstn (max 0 (List.length a - nenv)) (evar_filtered_context evi) in
     let abs_dc (d, c) = function
     | Context.Named.Declaration.LocalDef (x, b, t) ->
-        d, mkNamedLetIn x (put b) (put t) c
+        d, mkNamedLetIn !sigma x (put b) (put t) c
     | Context.Named.Declaration.LocalAssum (x, t) ->
-        mkVar x.binder_name :: d, mkNamedProd x (put t) c in
+        mkVar x.binder_name :: d, mkNamedProd !sigma x (put t) c in
     let a, t =
       Context.Named.fold_inside abs_dc ~init:([], put evi.evar_concl) dc
     in

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -1459,7 +1459,7 @@ let second_order_matching flags env_rhs evd (evk,args) (test,argoccs) rhs =
       let evs = ref [] in
       let c = nf_evar evd c in
       (* ty is in env_rhs now *)
-      let ty = replace_vars argsubst t in
+      let ty = replace_vars evd argsubst t in
       let filter' = filter_possible_projections evd c (nf_evar evd ty) ctxt args in
       (id,t,c,ty,evs,Filter.make filter',occs) :: make_subst (ctxt',l,occsl)
     | _, _, [] -> []

--- a/pretyping/evardefine.ml
+++ b/pretyping/evardefine.ml
@@ -101,7 +101,7 @@ let define_pure_evar_as_product env evd evk =
         let evd3 = Evd.set_leq_sort evenv evd3 prods (ESorts.kind evd1 s) in
           evd3, rng
   in
-  let prod = mkProd (make_annot (Name id) rdom, dom, subst_var id rng) in
+  let prod = mkProd (make_annot (Name id) rdom, dom, subst_var evd2 id rng) in
   let evd3 = Evd.define evk prod evd2 in
     evd3,prod
 
@@ -144,7 +144,7 @@ let define_pure_evar_as_lambda env evd evk =
   let src = subterm_source evk ~where:Body (evar_source evk evd1) in
   let abstract_arguments = Abstraction.abstract_last evi.evar_abstract_arguments in
   let evd2,body = new_evar newenv evd1 ~src (subst1 (mkVar id.binder_name) rng) ~filter ~abstract_arguments in
-  let lam = mkLambda (map_annot Name.mk_name id, dom, subst_var id.binder_name body) in
+  let lam = mkLambda (map_annot Name.mk_name id, dom, subst_var evd2 id.binder_name body) in
   Evd.define evk lam evd2, lam
 
 let define_evar_as_lambda env evd (evk,args) =

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -694,7 +694,7 @@ let solve_pattern_eqn env sigma l c =
           let d = map_constr (lift n) (lookup_rel n env) in
           mkLambda_or_LetIn d c'
       | VarAlias id ->
-          let d = lookup_named id env in mkNamedLambda_or_LetIn d c'
+          let d = lookup_named id env in mkNamedLambda_or_LetIn sigma d c'
     )
     l c in
   (* Warning: we may miss some opportunity to eta-reduce more since c'
@@ -1029,7 +1029,7 @@ let rec do_projection_effects unify flags define_fun env ty evd = function
            one (however, regarding coercions, because t is obtained by
            unif, we know that no coercion can be inserted) *)
         let subst = make_pure_subst evi argsv in
-        let ty' = replace_vars subst evi.evar_concl in
+        let ty' = replace_vars evd subst evi.evar_concl in
         if isEvar evd ty' then define_fun env evd (Some false) (destEvar evd ty') ty else evd
       else
         evd
@@ -1257,7 +1257,7 @@ let postpone_non_unique_projection env evd pbty (evk,argsv as ev) sols rhs =
  *)
 
 let filter_compatible_candidates unify flags env evd evi args rhs c =
-  let c' = instantiate_evar_array evi c args in
+  let c' = instantiate_evar_array evd evi c args in
   match unify flags TermUnification env evd Reduction.CONV rhs c' with
   | Success evd -> Inl (c,evd)
   | UnifFailure _ -> Inr c'
@@ -1277,7 +1277,7 @@ let restrict_candidates unify flags env evd filter1 (evk1,argsv1) (evk2,argsv2) 
   | Some l1, Some l2 ->
       let l1 = filter_effective_candidates evd evi1 filter1 l1 in
       let l1' = List.filter (fun c1 ->
-        let c1' = instantiate_evar_array evi1 c1 argsv1 in
+        let c1' = instantiate_evar_array evd evi1 c1 argsv1 in
         let filter c2 =
           let compatibility = filter_compatible_candidates unify flags env evd evi2 argsv2 c1' c2 in
           match compatibility with

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -565,8 +565,8 @@ let eval_type_pretyper self ~flags tycon env sigma t =
 let pretype_instance self ~flags env sigma loc hyps evk update =
   let f decl (subst,update,sigma) =
     let id = NamedDecl.get_id decl in
-    let b = Option.map (replace_vars subst) (NamedDecl.get_value decl) in
-    let t = replace_vars subst (NamedDecl.get_type decl) in
+    let b = Option.map (replace_vars sigma subst) (NamedDecl.get_value decl) in
+    let t = replace_vars sigma subst (NamedDecl.get_type decl) in
     let check_body sigma id c =
       match b, c with
       | Some b, Some c ->

--- a/tactics/abstract.ml
+++ b/tactics/abstract.ml
@@ -79,7 +79,7 @@ let cache_term_by_tactic_then ~opaque ~name_op ?(goal_type=None) tac tacK =
       | None ->  Proofview.Goal.concl gl
       | Some ty -> ty
     in
-    let concl = it_mkNamedProd_or_LetIn concl sign in
+    let concl = it_mkNamedProd_or_LetIn sigma concl sign in
     let solve_tac = tclCOMPLETE
         (Tactics.intros_mustbe_force (List.rev_map NamedDecl.get_id sign) <*>
          tac)

--- a/tactics/eqdecide.ml
+++ b/tactics/eqdecide.ml
@@ -121,11 +121,12 @@ let idx = Id.of_string "x"
 let idy = Id.of_string "y"
 
 let mkGenDecideEqGoal rectype ops g =
+  let sigma = Proofview.Goal.sigma g in
   let hypnames = pf_ids_set_of_hyps g in
   let xname    = next_ident_away idx hypnames in
   let yname    = next_ident_away idy (Id.Set.add xname hypnames) in
-  (mkNamedProd (make_annot xname Sorts.Relevant) rectype
-     (mkNamedProd (make_annot yname Sorts.Relevant) rectype
+  (mkNamedProd sigma (make_annot xname Sorts.Relevant) rectype
+     (mkNamedProd sigma (make_annot yname Sorts.Relevant) rectype
         (mkDecideEqGoal true ops
           rectype (mkVar xname) (mkVar yname))))
 

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -1015,8 +1015,9 @@ let discrimination_pf e (t,t1,t2) discriminator lbeq to_kind =
   build_coq_I () >>= fun i ->
   ind_scheme_of_eq lbeq to_kind >>= fun eq_elim ->
     pf_constr_of_global eq_elim >>= fun eq_elim ->
+    Proofview.tclEVARMAP >>= fun sigma ->
     Proofview.tclUNIT
-       (applist (eq_elim, [t;t1;mkNamedLambda (make_annot e Sorts.Relevant) t discriminator;i;t2]))
+       (applist (eq_elim, [t;t1;mkNamedLambda sigma (make_annot e Sorts.Relevant) t discriminator;i;t2]))
 
 type equality = {
   eq_data  : (coq_eq_data * (EConstr.t * EConstr.t * EConstr.t));
@@ -1410,7 +1411,7 @@ let inject_at_positions env sigma l2r eq posns tac =
     try
       (* arbitrarily take t1' as the injector default value *)
       let sigma, (injbody,resty) = build_injector e_env !evdref t1' (mkVar e) cpath in
-      let injfun = mkNamedLambda (make_annot e Sorts.Relevant) t injbody in
+      let injfun = mkNamedLambda sigma (make_annot e Sorts.Relevant) t injbody in
       let sigma,congr = Evd.fresh_global env sigma eq.congr in
       (* pf : eq t t1 t2 -> eq resty (injfun t1) (injfun t2) *)
       let mk c = Retyping.get_judgment_of env sigma c in

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1431,7 +1431,7 @@ let prepare_hint env init (sigma,c) =
       let id = next_ident_away_from default_prepare_hint_ident (fun id -> Id.Set.mem id !vars) in
       vars := Id.Set.add id !vars;
       subst := (evar,mkVar id)::!subst;
-      mkNamedLambda (make_annot id Sorts.Relevant) t (iter (replace_term sigma evar (mkVar id) c)) in
+      mkNamedLambda sigma (make_annot id Sorts.Relevant) t (iter (replace_term sigma evar (mkVar id) c)) in
   let c' = iter c in
     let diff = Univ.ContextSet.diff (Evd.universe_context_set sigma) (Evd.universe_context_set init) in
     (c', diff)

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -828,7 +828,7 @@ let resolve_morphism env m args args' (b,cstr) evars =
     let env' = EConstr.push_named (LocalDef (make_annot dosub_id Sorts.Relevant, dosub, appsub)) env in
     let evars, morph = new_cstr_evar evars env' app in
     (* Replace the free [dosub_id] in the evar by the global reference *)
-    let morph = Vars.replace_vars [dosub_id , dosub] morph in
+    let morph = Vars.replace_vars (fst evars) [dosub_id , dosub] morph in
     evars, morph, sigargs, appm, morphobjs, morphobjs'
   in
   let projargs, subst, evars, respars, typeargs =


### PR DESCRIPTION
Forecasting the change of representation of evar instances, we now assume we cannot access the default parts of the instance without access to an evarmap. This means that all functions from the kernel now raise an anomaly when trying to mess with potential Var nodes of evar instances, and that their counterpart in the upper layer now take an additional evarmap argument.

Overlays:
- https://github.com/mattam82/Coq-Equations/pull/511
- https://github.com/Mtac2/Mtac2/pull/367
- https://github.com/unicoq/unicoq/pull/73
- https://github.com/mit-plv/rewriter/pull/59
- https://github.com/damien-pous/relation-algebra/pull/36