### PR TITLE
[stdlib] Adding three lemmata related with finiteness and decidability of equality

### DIFF
--- a/doc/changelog/11-standard-library/16489-listing_decidable_eq.rst
+++ b/doc/changelog/11-standard-library/16489-listing_decidable_eq.rst
@@ -1,0 +1,14 @@
+- **Added:**
+  three lemmata related to finiteness and decidability of equality:
+  :g:`Listing_decidable_eq`, :g:`Finite_dec`
+  to ``FinFun.v`` and lemma :g:`NoDup_list_decidable` to ``ListDec.v``
+  (`#16489 <https://github.com/coq/coq/pull/16489>`_,
+  fixes `#16479 <https://github.com/coq/coq/issues/16479>`_,
+  by Bodo Igler, with help from Olivier Laurent and Andrej Dudenhefner).
+
+- **Deprecated:**
+  lemma :g:`Finite_alt` in ``FinFun.v``, which is a weaker version of
+  the newly added lemma :g:`Finite_dec`
+  (`#16489 <https://github.com/coq/coq/pull/16489>`_,
+  fixes `#16479 <https://github.com/coq/coq/issues/16479>`_,
+  by Bodo Igler, with help from Olivier Laurent).

--- a/theories/Lists/ListDec.v
+++ b/theories/Lists/ListDec.v
@@ -49,6 +49,12 @@ Proof using A dec.
      * right. inversion_clear 1. tauto.
 Qed.
 
+
+Lemma NoDup_list_decidable (l:list A) : NoDup l -> forall x y:A, In x l -> In y l -> decidable (x=y).
+Proof using A.
+  clear dec; intros Hl; induction Hl; firstorder congruence.
+Qed.
+
 End Dec_in_Prop.
 
 Section Dec_in_Type.
@@ -86,7 +92,7 @@ End Dec_in_Type.
 Lemma uniquify_map A B (d:decidable_eq B)(f:A->B)(l:list A) :
  exists l', NoDup (map f l') /\ incl (map f l) (map f l').
 Proof.
- induction l.
+ induction l as [|a l IHl].
  - exists nil. simpl. split; [now constructor | red; trivial].
  - destruct IHl as (l' & N & I).
    destruct (In_decidable d (f a) (map f l')).


### PR DESCRIPTION
According to suggestion in issue #16479 the following lemmata have been added:

* in coq/theories/Logic/FinFun.v:
  + Lemma Listing_decidable_eq {A:Type} (l:list A): Listing l -> decidable_eq A.
  + Lemma Finite_dec {A:Type}: Finite A /\ decidable_eq A <-> Finite' A.
* in coq/theories/Lists/ListDec.v:
  + Lemma NoDup_list_decidable A (l:list A) : NoDup l -> forall x y:A, In x l -> In y l -> decidable (x=y).

The first two lemmata clarify the role of decidable A in the relationship between Finite and Finite' and  provide an easy way to derive decidable A from Listing l and Finite' A

The third lemma provides the actual core of the proof for Listing_decidable_eq.

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

Fixes #16479