### PR TITLE
Debug long doc jobs.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -139,7 +139,7 @@ before_script:
   script:
     - ulimit -s 16384
     - tar xfj _build.tar.bz2
-    - make -f Makefile.dune --display=short "$DUNE_TARGET"
+    - make DUNEOPT="--display=short" "$DUNE_TARGET"
   variables:
     OPAM_SWITCH: edge
     OPAM_VARIANT: "+flambda"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -139,7 +139,7 @@ before_script:
   script:
     - ulimit -s 16384
     - tar xfj _build.tar.bz2
-    - make -f Makefile.dune "$DUNE_TARGET"
+    - make -f Makefile.dune --display=short "$DUNE_TARGET"
   variables:
     OPAM_SWITCH: edge
     OPAM_VARIANT: "+flambda"

--- a/Makefile.dune
+++ b/Makefile.dune
@@ -148,13 +148,13 @@ test-suite: dunestrap
 	dune runtest --no-buffer $(DUNEOPT)
 
 refman-html: dunestrap
-	dune build --no-buffer @refman-html
+	dune build --no-buffer $(DUNEOPT) @refman-html
 
 refman-pdf: dunestrap
-	dune build --no-buffer @refman-pdf
+	dune build --no-buffer $(DUNEOPT) @refman-pdf
 
 stdlib-html: dunestrap
-	dune build @stdlib-html
+	dune build $(DUNEOPT) @stdlib-html
 
 apidoc:
 	dune build $(DUNEOPT) @doc


### PR DESCRIPTION
With @Alizter, we noticed that the refman and stdlib-doc jobs take about 10 minutes longer in master compared to the equivalent Dune jobs in v8.16.