### PR TITLE
Avoid roundtrip [fconstr] -> [constr] -> [fconstr] in the kernel

### DIFF
--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -339,7 +339,7 @@ let empty_stack = []
 let append_stack v s =
   if Int.equal (Array.length v) 0 then s else
   match s with
-  | Zapp l :: s -> Zapp (Array.append v l) :: s
+  | Zapp l :: s -> Zapp (Array.append v l) :: s (* <<<< this is an allocation *)
   | (ZcaseT _ | Zproj _ | Zfix _ | Zshift _ | Zupdate _ | Zprimitive _) :: _ | [] ->
     Zapp v :: s
 

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -90,6 +90,8 @@ type fconstr
 (** [fconstr] can be accessed by using the function [fterm_of] and by
    matching on type [fterm] *)
 
+val copy_fconstr : fconstr -> fconstr
+
 type finvert
 
 type 'a usubs = 'a subs Univ.puniverses

--- a/kernel/esubst.ml
+++ b/kernel/esubst.ml
@@ -115,7 +115,20 @@ type 'a tree =
 
 *)
 
+let or_var_map f = function
+  | Arg x -> Arg (f x)
+  | Var x -> Var x
+
+let rec tree_map f = function
+  | Leaf (s, x) -> Leaf (s, or_var_map f x)
+  | Node (s1, x, l, r, s2) -> Node (s1, or_var_map f x, tree_map f l, tree_map f r, s2)
+
 type 'a subs = Nil of shf * int | Cons of int * 'a tree * 'a subs
+
+let rec subs_map f = function
+  | Nil _ as x -> x
+  | Cons (i, t, s) -> Cons (i, tree_map f t, subs_map f s)
+
 (*
   In the naive semantics mentioned above, we have the following.
 

--- a/kernel/esubst.mli
+++ b/kernel/esubst.mli
@@ -44,6 +44,9 @@ val subs_lift: 'a subs -> 'a subs
 (** Assuming Γ ⊢ σ : Δ and |Ξ| = n, then Γ, Ξ ⊢ subs_liftn n σ : Δ, Ξ *)
 val subs_liftn: int -> 'a subs -> 'a subs
 
+(** map *)
+val subs_map: ('a -> 'b) -> 'a subs -> 'b subs
+
 (** [expand_rel k subs] expands de Bruijn [k] in the explicit substitution
     [subs]. The result is either (Inl(lams,v)) when the variable is
     substituted by value [v] under [lams] binders (i.e. v *has* to be

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -923,17 +923,10 @@ let gen_conv cv_pb ?(l2r=false) ?(reds=TransparentState.full) env ?(evars=defaul
 let conv = gen_conv CONV
 let conv_leq = gen_conv CUMUL
 
-
 let gen_conv_fconstr cv_pb ?(l2r=false) ?(reds=TransparentState.full) env ?(evars=default_evar_handler) t1 t2 =
   let univs = Environ.universes env in
-  let b =
-    if cv_pb = CUMUL then leq_constr_univs univs t1 (term_of_fconstr t2)
-    else eq_constr_univs univs t1 (term_of_fconstr t2)
-  in
-  if b then ()
-  else
-    let _ = clos_gen_conv reds cv_pb l2r evars env univs (univs, checked_universes) (inject t1) t2 in
-    ()
+  let _ = clos_gen_conv reds cv_pb l2r evars env univs (univs, checked_universes) (inject t1) t2 in
+  ()
 
 let conv_fconstr = gen_conv_fconstr CONV
 let conv_leq_fconstr = gen_conv_fconstr CUMUL

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -187,10 +187,12 @@ let whd_allnolet env t =
 type 'a kernel_conversion_function = env -> 'a -> 'a -> unit
 
 (* functions of this type can be called from outside the kernel *)
-type 'a extended_conversion_function =
+type ('l,'r) extended_conversion_function_2 =
   ?l2r:bool -> ?reds:TransparentState.t -> env ->
   ?evars:constr evar_handler ->
-  'a -> 'a -> unit
+  'l -> 'r -> unit
+
+type 'a extended_conversion_function = ('a,'a) extended_conversion_function_2
 
 exception NotConvertible
 
@@ -853,7 +855,7 @@ and convert_list l2r infos lft1 lft2 v1 v2 cuniv = match v1, v2 with
   convert_list l2r infos lft1 lft2 v1 v2 cuniv
 | _, _ -> raise NotConvertible
 
-let clos_gen_conv trans cv_pb l2r evars env graph univs t1 t2 =
+let clos_gen_conv trans cv_pb l2r evars env graph univs l r =
   let reds = CClosure.RedFlags.red_add_transparent betaiotazeta trans in
   let infos = create_conv_infos ~univs:graph ~evars reds env in
   let infos = {
@@ -861,7 +863,7 @@ let clos_gen_conv trans cv_pb l2r evars env graph univs t1 t2 =
     lft_tab = create_tab ();
     rgt_tab = create_tab ();
   } in
-  ccnv cv_pb l2r infos el_id el_id (inject t1) (inject t2) univs
+  ccnv cv_pb l2r infos el_id el_id l r univs
 
 
 let check_eq univs u u' =
@@ -915,16 +917,31 @@ let gen_conv cv_pb ?(l2r=false) ?(reds=TransparentState.full) env ?(evars=defaul
   in
     if b then ()
     else
-      let _ = clos_gen_conv reds cv_pb l2r evars env univs (univs, checked_universes) t1 t2 in
+      let _ = clos_gen_conv reds cv_pb l2r evars env univs (univs, checked_universes) (inject t1) (inject t2) in
         ()
 
 let conv = gen_conv CONV
 let conv_leq = gen_conv CUMUL
 
+
+let gen_conv_fconstr cv_pb ?(l2r=false) ?(reds=TransparentState.full) env ?(evars=default_evar_handler) t1 t2 =
+  let univs = Environ.universes env in
+  let b =
+    if cv_pb = CUMUL then leq_constr_univs univs t1 (term_of_fconstr t2)
+    else eq_constr_univs univs t1 (term_of_fconstr t2)
+  in
+  if b then ()
+  else
+    let _ = clos_gen_conv reds cv_pb l2r evars env univs (univs, checked_universes) (inject t1) t2 in
+    ()
+
+let conv_fconstr = gen_conv_fconstr CONV
+let conv_leq_fconstr = gen_conv_fconstr CUMUL
+
 let generic_conv cv_pb ~l2r evars reds env univs t1 t2 =
   let graph = Environ.universes env in
   let (s, _) =
-    clos_gen_conv reds cv_pb l2r evars env graph univs t1 t2
+    clos_gen_conv reds cv_pb l2r evars env graph univs (inject t1) (inject t2)
   in s
 
 let default_conv cv_pb env t1 t2 =

--- a/kernel/reduction.mli
+++ b/kernel/reduction.mli
@@ -10,6 +10,7 @@
 
 open Constr
 open Environ
+open CClosure
 
 (***********************************************************************
   s Reduction functions *)
@@ -29,10 +30,13 @@ val nf_betaiota      : env -> constr -> constr
 exception NotConvertible
 
 type 'a kernel_conversion_function = env -> 'a -> 'a -> unit
-type 'a extended_conversion_function =
+
+type ('l,'r) extended_conversion_function_2 =
   ?l2r:bool -> ?reds:TransparentState.t -> env ->
   ?evars:constr evar_handler ->
-  'a -> 'a -> unit
+  'l -> 'r -> unit
+
+type 'a extended_conversion_function = ('a,'a) extended_conversion_function_2
 
 type conv_pb = CONV | CUMUL
 
@@ -69,8 +73,11 @@ val checked_universes : UGraph.t universe_compare
 
 (** These two functions can only raise NotConvertible *)
 val conv : constr extended_conversion_function
+val conv_fconstr : (constr, fconstr) extended_conversion_function_2
 
 val conv_leq : types extended_conversion_function
+val conv_leq_fconstr : (types, fconstr) extended_conversion_function_2
+
 
 (** Depending on the universe state functions, this might raise
   [UniverseInconsistency] in addition to [NotConvertible] (for better error

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -195,7 +195,12 @@ let type_of_apply env func funt argsv argstv =
       match fterm_of typ with
       | FProd (_, c1, c2, e) ->
         let argt = argstv.(i) in
-        begin match conv_leq_fconstr env argt c1 with
+        (* reductions necessary to compare the type of the argument
+           to the type of [c1] should *not* be retained when checking
+           the rest of the term. To achieve this, while retaining sharing,
+           we perform the conversion check on a copy of [c1].
+         *)
+        begin match conv_leq_fconstr env argt (copy_fconstr c1) with
         | () ->
           let arg = argsv.(i) in
           apply_rec (i+1) (mk_clos (CClosure.usubs_cons (inject arg) e) c2)

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -205,7 +205,7 @@ let type_of_apply env func funt argsv argstv =
           let arg = argsv.(i) in
           apply_rec (i+1) (mk_clos (CClosure.usubs_cons (inject arg) e) c2)
         | exception NotConvertible ->
-          let c1 = term_of_fconstr c1 in (* << this was already done inside [conv_leq_fconstr] *)
+          let c1 = term_of_fconstr c1 in
           error_cant_apply_bad_type env
             (i+1,c1,argt)
             (make_judge func funt)

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -194,12 +194,13 @@ let type_of_apply env func funt argsv argstv =
       let () = assert (check_empty_stack stk) in
       match fterm_of typ with
       | FProd (_, c1, c2, e) ->
-        let arg = argsv.(i) in
         let argt = argstv.(i) in
-        begin match conv_leq_fconstr env argt c1 with (* << checks that the type of the argument is compatible with the type of the binder *)
-        | () -> apply_rec (i+1) (mk_clos (CClosure.usubs_cons (inject arg) e) c2)
+        begin match conv_leq_fconstr env argt c1 with
+        | () ->
+          let arg = argsv.(i) in
+          apply_rec (i+1) (mk_clos (CClosure.usubs_cons (inject arg) e) c2)
         | exception NotConvertible ->
-          let c1 = term_of_fconstr c1 in
+          let c1 = term_of_fconstr c1 in (* << this was already done inside [conv_leq_fconstr] *)
           error_cant_apply_bad_type env
             (i+1,c1,argt)
             (make_judge func funt)

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -196,10 +196,10 @@ let type_of_apply env func funt argsv argstv =
       | FProd (_, c1, c2, e) ->
         let arg = argsv.(i) in
         let argt = argstv.(i) in
-        let c1 = term_of_fconstr c1 in
-        begin match conv_leq env argt c1 with
+        begin match conv_leq_fconstr env argt c1 with (* << checks that the type of the argument is compatible with the type of the binder *)
         | () -> apply_rec (i+1) (mk_clos (CClosure.usubs_cons (inject arg) e) c2)
         | exception NotConvertible ->
+          let c1 = term_of_fconstr c1 in
           error_cant_apply_bad_type env
             (i+1,c1,argt)
             (make_judge func funt)


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
This is based on the discussion here: https://coq.zulipchat.com/#narrow/stream/237656-Coq-devs-.26-plugin-devs/topic/reduction.20in.20the.20kernel

It should be completely backwards compatible. I would like to get a benchmark run to determine if there is any impact. The code is a hackish right now (and contains some extra comments) just to test the potential performance difference, I will clean up before merge if we determine if it is useful.

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
