### PR TITLE
Fix some ssreflect tactic printing code

### DIFF
--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -1090,7 +1090,7 @@ END
 {
 
 let pr_hint env sigma prt arg =
-  if arg = nohint then mt() else str "by " ++ pr_hintarg env sigma prt arg
+  if arg = nohint then mt() else spc () ++ str "by" ++ spc () ++ pr_hintarg env sigma prt arg
 let pr_ssrhint env sigma _ _ = pr_hint env sigma
 
 }
@@ -1488,10 +1488,10 @@ END
 
 {
 
-(* This does not print the type, it should be fixed... *)
-let pr_ssrsetfwd _ _ _ (((fk,_),(t,_)), docc) =
-  pr_gen_fwd (fun _ _ -> pr_cpattern)
-    (fun _ -> mt()) (fun _ -> mt()) fk ([Bcast ()],t)
+let pr_ssrsetfwd _ _ _ (((fk,_),(c,t)), docc) =
+  let t = Option.default [] @@ Option.map (fun t -> [Bcast t]) t in
+  pr_gen_fwd (fun _ _ c -> Pp.(pr_docc docc ++ pr_cpattern c))
+    (fun _ -> mt()) pr_ast_closure_term fk (t, c)
 
 }
 


### PR DESCRIPTION
Testcases:

```
Require Import ssreflect.

Ltac t a b c := set a : b := c.
Print t.
(* set  a  :  := c -> set  a  : b := c *)

Ltac u a b := set a := b.
Print u.
(* set  a  :  := b -> set  a  := b *)

Ltac v a b c d := set a : b := {1}d.
Print v.
(* set  a  :  := d -> set  a  : b := {+1}d *)

Ltac w a b := have: a by b.
Print w.
(* have : aby b -> have : a by b *)
```
<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.
