### PR TITLE
Remove a bunch of evar normalization in pretyping.

### DIFF
--- a/pretyping/evardefine.ml
+++ b/pretyping/evardefine.ml
@@ -24,11 +24,6 @@ open Pretype_errors
 
 module RelDecl = Context.Rel.Declaration
 
-let env_nf_evar sigma env =
-  let nf_evar c = nf_evar sigma c in
-  process_rel_context
-    (fun d e -> push_rel (RelDecl.map_constr nf_evar d) e) env
-
 let env_nf_betaiotaevar sigma env =
   process_rel_context
     (fun d env ->

--- a/pretyping/evardefine.mli
+++ b/pretyping/evardefine.mli
@@ -12,7 +12,6 @@ open EConstr
 open Evd
 open Environ
 
-val env_nf_evar : evar_map -> env -> env
 val env_nf_betaiotaevar : evar_map -> env -> env
 
 type type_constraint = types option

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -1751,7 +1751,7 @@ let rec invert_definition unify flags choose imitate_defs
       Id.Set.subset (collect_vars evd rhs) !names
   in
   let body =
-    if fast rhs then nf_evar evd rhs (* FIXME? *)
+    if fast rhs then rhs
     else
       let t' = imitate (env,0) rhs in
         if !progress then

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -514,8 +514,7 @@ let type_of ?(refresh=false) env sigma c =
 
 let solve_evars env sigma c =
   let sigma, j = execute env sigma c in
-  (* side-effect on evdref *)
-  sigma, nf_evar sigma j.uj_val
+  sigma, j.uj_val
 
 let _ = Evarconv.set_solve_evars (fun env sigma c -> solve_evars env sigma c)
 


### PR DESCRIPTION
It was probably a remnant of the time where one half of the API was using the Constr type and the other half the EConstr type.