### PR TITLE
Expose a bit more of the structures in Cooking

### DIFF
--- a/kernel/cooking.ml
+++ b/kernel/cooking.ml
@@ -333,6 +333,9 @@ let universe_context_of_cooking_info info =
 let instance_of_cooking_info info =
   Named.instance mkVar info.abstr_info.abstr_ctx
 
+let expand_info_of_cooking_info info =
+  info.expand_info
+
 let instance_of_cooking_cache { info; _ } =
   instance_of_cooking_info info
 

--- a/kernel/cooking.mli
+++ b/kernel/cooking.mli
@@ -23,7 +23,12 @@ open Constr
     (because the substitution are represented by their domain) but
     here, local definitions of the context have been dropped *)
 
-type abstr_inst_info
+type abstr_inst_info = {
+  abstr_rev_inst : Id.t list;
+  (** The variables to reapply (excluding "let"s of the context), in reverse order *)
+  abstr_uinst : Univ.Instance.t;
+  (** Abstracted universe variables to reapply *)
+}
 
 type 'a entry_map = 'a Cmap.t * 'a Mindmap.t
 type expand_info = abstr_inst_info entry_map
@@ -51,6 +56,8 @@ val names_info : cooking_info -> Id.Set.t
 val universe_context_of_cooking_info : cooking_info -> Univ.AbstractContext.t
 
 val instance_of_cooking_info : cooking_info -> Constr.t array
+
+val expand_info_of_cooking_info : cooking_info -> expand_info
 
 type cooking_cache
 


### PR DESCRIPTION
This is a followup on the discussion I started here: https://coq.zulipchat.com/#narrow/stream/237656-Coq-devs-.26-plugin-devs/topic/Discharging.20proof.20states

Summary: Since 8.16, the function `Cooking.expmod_constr` has disappeared due to https://github.com/coq/coq/pull/14727, which breaks my plugin. So I'd like to propose that either (1) this function is reintroduced or (2) some more of the internals of `Cooking` are exposed so that I can recreate `expmod_constr` in my own plugin.

This PR goes along the lines of (2) since that has the least disruption in Coq, although I would think that `expmod_constr` could also be useful for other people.