### PR TITLE
Ensure `coqide.opam` actually installs `coqide`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,7 +82,7 @@ before_script:
     expire_in: 1 month
   script:
     - PKGS=coq-core,coq-stdlib,coqide-server,coq
-    - if [ "$COQIDE" != "no" ]; then PKGS=${PKGS},coqide; fi
+    - if [ "$COQIDE" != "no" ]; then PKGS=${PKGS},coqide; COQ_EXTRA_CONF="${COQ_EXTRA_CONF} -coqide ${COQIDE}"; fi
     - dev/ci/gitlab-section.sh start coq.clean coq.clean
     - make clean # ensure that `make clean` works on a fresh clone
     - dev/ci/gitlab-section.sh end coq.clean
@@ -244,7 +244,9 @@ build:edge+flambda:
   variables:
     OPAM_SWITCH: edge
     OPAM_VARIANT: "+flambda"
-    COQ_EXTRA_CONF: "-native-compiler yes -coqide opt"
+    COQ_EXTRA_CONF: "-native-compiler yes"
+    # Redundant, but was explicit?
+    COQIDE: "opt"
 
 build:edge+flambda:dev:
   extends: .build-template:dev
@@ -252,7 +254,9 @@ build:edge+flambda:dev:
 build:base+async:
   extends: .build-template
   variables:
-    COQ_EXTRA_CONF: "-native-compiler yes -coqide opt"
+    COQ_EXTRA_CONF: "-native-compiler yes"
+    # Redundant, but was explicit?
+    COQIDE: "opt"
     COQ_DUNE_EXTRA_OPT: "-async"
   after_script:
     - dmesg > dmesg.txt

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,6 +68,8 @@ before_script:
 .build-template:
   stage: build
   interruptible: true
+  variables:
+    COQIDE: "opt"
   artifacts:
     name: "$CI_JOB_NAME"
     paths:
@@ -79,6 +81,8 @@ before_script:
       - config/dune.c_flags
     expire_in: 1 month
   script:
+    - PKGS=coq-core,coq-stdlib,coqide-server,coq
+    - if [ "$COQIDE" != "no" ]; then PKGS=${PKGS},coqide; fi
     - dev/ci/gitlab-section.sh start coq.clean coq.clean
     - make clean # ensure that `make clean` works on a fresh clone
     - dev/ci/gitlab-section.sh end coq.clean
@@ -89,11 +93,11 @@ before_script:
 
     - dev/ci/gitlab-section.sh start coq.build coq.build
     - make dunestrap
-    - dune build -p coq-core,coq-stdlib,coqide-server,coqide,coq
+    - dune build -p $PKGS
     - dev/ci/gitlab-section.sh end coq.build
 
     - dev/ci/gitlab-section.sh start coq.install coq.install
-    - dune install --prefix="$(pwd)/_install_ci" coq-core coq-stdlib coqide-server coqide coq
+    - dune install --prefix="$(pwd)/_install_ci" $(sed -e 's/,/ /g' <<< ${PKGS})
     - dev/ci/gitlab-section.sh end coq.install
 
 # Developer build, with build layout. Faster and useful for those
@@ -230,6 +234,7 @@ build:base+32bit:
   variables:
     OPAM_VARIANT: "+32bit"
     COQ_EXTRA_CONF: "-native-compiler yes"
+    COQIDE: "no"
   only: &full-ci
     variables:
       - $FULL_CI == "true"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -245,8 +245,6 @@ build:edge+flambda:
     OPAM_SWITCH: edge
     OPAM_VARIANT: "+flambda"
     COQ_EXTRA_CONF: "-native-compiler yes"
-    # Redundant, but was explicit?
-    COQIDE: "opt"
 
 build:edge+flambda:dev:
   extends: .build-template:dev
@@ -255,8 +253,6 @@ build:base+async:
   extends: .build-template
   variables:
     COQ_EXTRA_CONF: "-native-compiler yes"
-    # Redundant, but was explicit?
-    COQIDE: "opt"
     COQ_DUNE_EXTRA_OPT: "-async"
   after_script:
     - dmesg > dmesg.txt

--- a/coqide.opam
+++ b/coqide.opam
@@ -19,6 +19,7 @@ bug-reports: "https://github.com/coq/coq/issues"
 depends: [
   "dune" {>= "2.9"}
   "coqide-server" {= version}
+  "lablgtk3-sourceview3" {>= "3.1.2"}
 ]
 build: [
   # Requires dune 2.8 due to https://github.com/ocaml/dune/issues/3219

--- a/dune-project
+++ b/dune-project
@@ -84,7 +84,8 @@ structured way."))
 (package
  (name coqide)
  (depends
-  (coqide-server (= :version)))
+  (coqide-server (= :version))
+  (lablgtk3-sourceview3 (>= 3.1.2)))
  (synopsis "The Coq Proof Assistant --- GTK3 IDE")
  (description "Coq is a formal proof management system. It provides
 a formal language to write mathematical definitions, executable

--- a/ide/coqide/dune
+++ b/ide/coqide/dune
@@ -30,7 +30,6 @@
  (foreign_stubs
   (language c)
   (names coqide_os_stubs))
- (optional)
  (libraries coqide-server.protocol coqide-server.core lablgtk3-sourceview3))
 
 (executable
@@ -54,7 +53,6 @@
  (name coqide_main)
  (public_name coqide)
  (package coqide)
- (optional)
  (modules coqide_main)
  (modes exe byte)
  (libraries coqide_gui))


### PR DESCRIPTION
Naive, but worth an attempt. I encourage people to take over or open new PRs if this is useful.

Without this change, `dune build coqide.install` fails silently when dependencies are missing. With this patch, `dune build coqide-server.install` still succeeds while `dune build coqide.install` reports the missing deps:

```
$ dune build coqide.install
File "ide/coqide/dune", line 33, characters 54-74:
33 |  (libraries coqide-server.protocol coqide-server.core lablgtk3-sourceview3))
                                                           ^^^^^^^^^^^^^^^^^^^^
Error: Library "lablgtk3-sourceview3" not found.
-> required by library "coqide_gui" in _build/default/ide/coqide
-> required by executable coqide_main in ide/coqide/dune:53
-> required by _build/default/ide/coqide/coqide_main.exe
-> required by _build/install/default/bin/coqide
-> required by _build/default/coqide.install
```

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added **changelog**.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
