### PR TITLE
Clarify documentation of `contradiction` tactic

### DIFF
--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -1799,7 +1799,7 @@ name of the variable (here :g:`n`) is chosen based on :g:`T`.
    find in the current context (after all intros) a hypothesis that is
    equivalent to an empty inductive type (e.g. :g:`False`), to the negation of
    a singleton inductive type (e.g. :g:`True` or :g:`x=x`), or two contradictory
-   hypotheses.
+   hypotheses :g:`P` and :g:`not P`.
 
    .. exn:: No such assumption.
       :undocumented:


### PR DESCRIPTION
It is not for arbitrary contradictions, just somewhat "syntactic" ones: https://coq.zulipchat.com/#narrow/stream/237977-Coq-users/topic/Isn't.20this.20a.20contradiction.

FWIW, this still isn't quite accurate, but it's as accurate as Coq's 8.0 changelog while remaining readable.

Apparently, the source appears to find `\forall x: P -> T` (up to weak head reduction?), then search for `P` (up to some form of conversion?), then try eliminating `T`. While ssreflect would document this, I don't think it would be consistent with the current manual style (outside the ssreflect chapter), or be necessarily a public interface.

- [x] Added / updated **documentation**.