### PR TITLE
Ltac2: put backtraces on more exceptions 

### DIFF
--- a/lib/cErrors.ml
+++ b/lib/cErrors.ml
@@ -93,7 +93,7 @@ let is_anomaly = function
 (** Printing of additional error info, from Exninfo *)
 let additional_error_info_handler = ref []
 
-let register_additional_error_info (f : Exninfo.info -> (Pp.t Loc.located) option) =
+let register_additional_error_info (f : Exninfo.info -> Pp.t option) =
   additional_error_info_handler := f :: !additional_error_info_handler
 
 (** [print_gen] is a general exception printer which tries successively
@@ -115,7 +115,7 @@ let print_gen ~anomaly (e, info) =
   let extra_msg =
     CList.map_filter (fun f -> f info) !additional_error_info_handler
     (* Location info in the handler is ignored *)
-    |> List.map snd |> Pp.seq
+    |> Pp.seq
   in
   try
     print_gen ~anomaly ~extra_msg !handle_stack e

--- a/lib/cErrors.mli
+++ b/lib/cErrors.mli
@@ -75,5 +75,5 @@ val noncritical : exn -> bool
    exceptions. This method is fragile and should be considered
    deprecated *)
 val register_additional_error_info
-  :  (Exninfo.info -> Pp.t Loc.located option)
+  :  (Exninfo.info -> Pp.t option)
   -> unit

--- a/plugins/ltac2/tac2core.mli
+++ b/plugins/ltac2/tac2core.mli
@@ -29,4 +29,4 @@ val c_false : ltac_constructor
 
 end
 
-val pf_apply : (Environ.env -> Evd.evar_map -> 'a Proofview.tactic) -> 'a Proofview.tactic
+val pf_apply : ?catch_exceptions:bool -> (Environ.env -> Evd.evar_map -> 'a Proofview.tactic) -> 'a Proofview.tactic

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -944,7 +944,7 @@ let () = CErrors.register_additional_error_info begin fun info ->
     let bt =
       str "Backtrace:" ++ fnl () ++ prlist_with_sep fnl pr_frame bt ++ fnl ()
     in
-    Some (Loc.tag bt)
+    Some bt
   else None
 end
 

--- a/test-suite/output/ltac2_anomaly_backtrace.out
+++ b/test-suite/output/ltac2_anomaly_backtrace.out
@@ -1,0 +1,11 @@
+File "./output/ltac2_anomaly_backtrace.v", line 9, characters 0-18:
+Error:
+Backtrace:
+Call foo
+Call Std.eval_hnf
+Prim <coq-core.plugins.ltac2:eval_hnf>
+Anomaly "Uncaught exception Not_found."
+Please report at http://coq.inria.fr/bugs/.
+
+
+coqc exited with code 129

--- a/test-suite/output/ltac2_anomaly_backtrace.v
+++ b/test-suite/output/ltac2_anomaly_backtrace.v
@@ -1,0 +1,12 @@
+Require Import Ltac2.Ltac2.
+Ltac2 foo () := let v := Constr.Unsafe.make (Constr.Unsafe.Rel -1) in
+                let x := Constr.Binder.make None 'True in
+                let vv := Constr.Unsafe.make (Constr.Unsafe.App v (Array.of_list [v])) in
+                let f := Constr.Unsafe.make (Constr.Unsafe.Lambda x vv) in
+                let ff := Constr.Unsafe.make (Constr.Unsafe.App f (Array.of_list [f])) in
+                Std.eval_hnf ff.
+Set Ltac2 Backtrace.
+Ltac2 Eval foo ().
+(* Error: Anomaly "Uncaught exception Not_found."
+Please report at http://coq.inria.fr/bugs/.
+*)


### PR DESCRIPTION
Fix #16410 (there may still be some that don't get caught)