### PR TITLE
Asymptotically more efficient implementation of FutureGoals.t.

### DIFF
--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -458,17 +458,11 @@ type side_effects = {
 
 module FutureGoals : sig
 
-  type t = private {
-    comb : Evar.t list;
-    principal : Evar.t option; (** if [Some e], [e] must be
-                                   contained in
-                                   [comb]. The evar
-                                   [e] will inherit
-                                   properties (now: the
-                                   name) of the evar which
-                                   will be instantiated with
-                                   a term containing [e]. *)
-  }
+  type t
+
+  val comb : t -> Evar.t list
+
+  val principal : t -> Evar.t option
 
   val map_filter : (Evar.t -> Evar.t option) -> t -> t
   (** Applies a function on the future goals *)
@@ -503,6 +497,10 @@ end = struct
                                    will be instantiated with
                                    a term containing [e]. *)
   }
+
+  let comb g = g.comb
+
+  let principal g = g.principal
 
   type stack = t list
 

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -487,7 +487,9 @@ module FutureGoals : sig
 end = struct
 
   type t = {
-    comb : Evar.t list;
+    uid : int;
+    comb : Evar.t Int.Map.t;
+    revmap : int Evar.Map.t;
     principal : Evar.t option; (** if [Some e], [e] must be
                                    contained in
                                    [comb]. The evar
@@ -498,7 +500,9 @@ end = struct
                                    a term containing [e]. *)
   }
 
-  let comb g = g.comb
+  let comb g =
+    (* Keys are reversed, highest number is last introduced *)
+    Int.Map.fold (fun _ evk accu -> evk :: accu) g.comb []
 
   let principal g = g.principal
 
@@ -511,7 +515,8 @@ end = struct
 
   let add ~principal evk stack =
     let add fgl =
-      let comb = evk :: fgl.comb in
+      let comb = Int.Map.add fgl.uid evk fgl.comb in
+      let revmap = Evar.Map.add evk fgl.uid fgl.revmap in
       let principal =
         if principal then
           match fgl.principal with
@@ -519,7 +524,9 @@ end = struct
           | None -> Some evk
         else fgl.principal
       in
-      { comb; principal }
+      let uid = fgl.uid + 1 in
+      let () = assert (0 <= uid) in
+      { comb; revmap; principal; uid }
     in
     set add stack
 
@@ -527,14 +534,19 @@ end = struct
     let remove fgl =
       let filter e' = not (Evar.equal e e') in
       let principal = Option.filter filter fgl.principal in
-      let comb = List.filter filter fgl.comb in
-      { principal; comb }
+      let comb, revmap = match Evar.Map.find e fgl.revmap with
+      | index -> (Int.Map.remove index fgl.comb, Evar.Map.remove e fgl.revmap)
+      | exception Not_found -> fgl.comb, fgl.revmap
+      in
+      { principal; comb; revmap; uid = fgl.uid }
     in
     List.map remove stack
 
   let empty = {
+    uid = 0;
     principal = None;
-    comb = [];
+    comb = Int.Map.empty;
+    revmap = Evar.Map.empty;
   }
 
   let empty_stack = [empty]
@@ -549,22 +561,32 @@ end = struct
 
   let fold f acc stack =
     let future_goals = List.hd stack in
-    List.fold_left f acc future_goals.comb
+    List.fold_left f acc (comb future_goals)
 
   let filter f fgl =
-    let comb = List.filter f fgl.comb in
+    let fold index evk (comb, revmap) =
+      if f evk then (comb, revmap)
+      else (Int.Map.remove index comb, Evar.Map.remove evk revmap)
+    in
+    let (comb, revmap) = Int.Map.fold fold fgl.comb (fgl.comb, fgl.revmap) in
     let principal = Option.filter f fgl.principal in
-    { comb; principal }
+    { comb; principal; revmap; uid = fgl.uid }
 
   let map_filter f fgl =
-    let comb = List.map_filter f fgl.comb in
+    let fold index evk (comb, revmap) = match f evk with
+    | None -> (comb, revmap)
+    | Some evk' ->
+      (Int.Map.add index evk' comb, Evar.Map.add evk' index revmap)
+    in
+    let (comb, revmap) = Int.Map.fold fold fgl.comb (Int.Map.empty, Evar.Map.empty) in
     let principal = Option.bind fgl.principal f in
-    { comb; principal }
+    { comb; revmap; principal; uid = fgl.uid }
 
   let pr_stack stack =
     let open Pp in
     let pr_future_goals fgl =
-      prlist_with_sep spc Evar.print fgl.comb ++
+      let comb = comb fgl in
+      prlist_with_sep spc Evar.print comb ++
         pr_opt (fun ev -> str"(principal: " ++ Evar.print ev ++ str")") fgl.principal
     in
     if List.is_empty stack then str"(empty stack)"

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -379,17 +379,14 @@ val declare_principal_goal : Evar.t -> evar_map -> evar_map
 
 module FutureGoals : sig
 
-  type t = private {
-    comb : Evar.t list;
-    principal : Evar.t option; (** if [Some e], [e] must be
-                                   contained in
-                                   [future_comb]. The evar
-                                   [e] will inherit
-                                   properties (now: the
-                                   name) of the evar which
-                                   will be instantiated with
-                                   a term containing [e]. *)
-  }
+  type t
+
+  val comb : t -> Evar.t list
+
+  val principal : t -> Evar.t option
+  (** if [Some e], [e] must be contained in [future_comb]. The evar [e] will
+      inherit properties (now: the name) of the evar which will be instantiated
+      with a term containing [e]. *)
 
   val map_filter : (Evar.t -> Evar.t option) -> t -> t
   (** Applies a function on the future goals *)

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -766,7 +766,7 @@ let with_shelf tac =
   (* TODO: is it still relevant since the removal of the compat layer? *)
   let fgl, sigma = Evd.pop_future_goals sigma in
   (* Ensure we mark and return only unsolved goals *)
-  let gls' = CList.rev_append fgl.Evd.FutureGoals.comb gls in
+  let gls' = CList.rev_append (Evd.FutureGoals.comb fgl) gls in
   let gls' = undefined_evars sigma gls' in
   let sigma = mark_in_evm ~goal:false sigma gls' in
   let npv = { npv with solution = sigma } in

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -376,7 +376,7 @@ let run_tactic env tac pr =
       they to be marked as unresolvable. *)
     let retrieved, sigma = Evd.pop_future_goals sigma in
     let retrieved = Evd.FutureGoals.filter (Evd.is_undefined sigma) retrieved in
-    let retrieved = List.rev retrieved.Evd.FutureGoals.comb in
+    let retrieved = List.rev (Evd.FutureGoals.comb retrieved) in
     let sigma = Proofview.Unsafe.mark_as_goals sigma retrieved in
     let to_shelve, sigma = Evd.pop_shelf sigma in
     Proofview.Unsafe.tclEVARS sigma >>= fun () ->

--- a/proofs/refine.ml
+++ b/proofs/refine.ml
@@ -83,7 +83,7 @@ let generic_refine ~typecheck f gl =
     (* Nothing to do, the goal has been solved by side-effect *)
     sigma
   | Some self ->
-    match future_goals.Evd.FutureGoals.principal with
+    match (Evd.FutureGoals.principal future_goals) with
     | None -> Evd.define self c sigma
     | Some evk ->
         let id = Evd.evar_ident self sigma in
@@ -93,8 +93,8 @@ let generic_refine ~typecheck f gl =
         | Some id -> Evd.rename evk id sigma
   in
   (* Mark goals *)
-  let sigma = Proofview.Unsafe.mark_as_goals sigma future_goals.Evd.FutureGoals.comb in
-  let comb = CList.rev_map (fun x -> Proofview.goal_with_state x state) future_goals.Evd.FutureGoals.comb in
+  let sigma = Proofview.Unsafe.mark_as_goals sigma (Evd.FutureGoals.comb future_goals) in
+  let comb = CList.rev_map (fun x -> Proofview.goal_with_state x state) (Evd.FutureGoals.comb future_goals) in
   let trace () = Pp.(hov 2 (str"simple refine"++spc()++
                                    Termops.Internal.print_constr_env env sigma c)) in
   Proofview.Trace.name_tactic trace (Proofview.tclUNIT v) >>= fun v ->

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -371,7 +371,7 @@ let declare_instance_open sigma ?hook ~tac ~locality ~poly id pri impargs udecl 
      consequence, we use the low-level primitives to code
      the refinement manually.*)
   let future_goals, sigma = Evd.pop_future_goals sigma in
-  let gls = List.rev future_goals.Evd.FutureGoals.comb in
+  let gls = List.rev (Evd.FutureGoals.comb future_goals) in
   let sigma = Evd.push_future_goals sigma in
   let kind = Decls.(IsDefinition Instance) in
   let hook = Declare.Hook.(make (fun { S.dref ; _ } -> instance_hook pri locality ?hook dref)) in


### PR DESCRIPTION
Removing an evar from this type was O(n) before this patch, leading to quadratic or worse behaviours at toplevel. We replace the naive list implementation with a index-based balanced map structure.