### PR TITLE
[refman] scope_delimiter can be either scope_key or scope_name in Arguments

### DIFF
--- a/doc/sphinx/language/extensions/arguments-command.rst
+++ b/doc/sphinx/language/extensions/arguments-command.rst
@@ -8,13 +8,13 @@ Setting properties of a function's arguments
    .. insertprodn argument_spec args_modifier
 
    .. prodn::
-      argument_spec ::= {? ! } @name {? % @scope_key }
+      argument_spec ::= {? ! } @name {? % @scope }
       arg_specs ::= @argument_spec
       | /
       | &
-      | ( {+ @argument_spec } ) {? % @scope_key }
-      | [ {+ @argument_spec } ] {? % @scope_key }
-      | %{ {+ @argument_spec } %} {? % @scope_key }
+      | ( {+ @argument_spec } ) {? % @scope }
+      | [ {+ @argument_spec } ] {? % @scope }
+      | %{ {+ @argument_spec } %} {? % @scope }
       implicits_alt ::= @name
       | [ {+ @name } ]
       | %{ {+ @name } %}

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -356,7 +356,7 @@ scope: [
 
 scope_delimiter: [
 | REPLACE "%" IDENT
-| WITH "%" scope_key
+| WITH "%" scope
 ]
 
 term100: [
@@ -1736,7 +1736,7 @@ search_query: [
 
 search_item: [
 | REPLACE search_where ":" ne_string OPT scope_delimiter
-| WITH OPT ( search_where ":" ) ne_string OPT scope_delimiter
+| WITH OPT ( search_where ":" ) ne_string OPT ( "%" scope_key )
 | DELETE ne_string OPT scope_delimiter
 | REPLACE search_where ":" constr_pattern
 | WITH OPT ( search_where ":" ) constr_pattern

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -793,16 +793,16 @@ reference: [
 ]
 
 argument_spec: [
-| OPT "!" name OPT ( "%" scope_key )
+| OPT "!" name OPT ( "%" scope )
 ]
 
 arg_specs: [
 | argument_spec
 | "/"
 | "&"
-| "(" LIST1 argument_spec ")" OPT ( "%" scope_key )
-| "[" LIST1 argument_spec "]" OPT ( "%" scope_key )
-| "{" LIST1 argument_spec "}" OPT ( "%" scope_key )
+| "(" LIST1 argument_spec ")" OPT ( "%" scope )
+| "[" LIST1 argument_spec "]" OPT ( "%" scope )
+| "{" LIST1 argument_spec "}" OPT ( "%" scope )
 ]
 
 implicits_alt: [


### PR DESCRIPTION
The token `scope_delimiter` was used in two commands: `Arguments` and `Search` with the meaning `["%" scope_key]` in the latter but `["%" scope]` in the former (`scope` being either `scope_key` or `scope_name`). This makes the documentation consistent with the implementation.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] ~Added / updated **test-suite**.~

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] ~Added **changelog**.~
- [ ] ~Added / updated **documentation**.~
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] ~Documented any new / changed **user messages**.~
  - [x] Updated **documented syntax** by running `make -f Makefile.dune doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
