### PR TITLE
Ltac2: binder_make produces a "not a type" message instead of raw retypeerror, provide unsafe_make

### DIFF
--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -764,9 +764,13 @@ end
 
 let () = define2 "constr_binder_make" (option ident) constr begin fun na ty ->
   pf_apply begin fun env sigma ->
-  let rel = Retyping.relevance_of_type env sigma ty in
-  let na = match na with None -> Anonymous | Some id -> Name id in
-  return (Value.of_ext val_binder (Context.make_annot na rel, ty))
+    match Retyping.relevance_of_type env sigma ty with
+    | rel ->
+      let na = match na with None -> Anonymous | Some id -> Name id in
+      return (Value.of_ext val_binder (Context.make_annot na rel, ty))
+    | exception (Retyping.RetypeError _ as e) ->
+      let e, info = Exninfo.capture e in
+      fail ~info (CErrors.UserError Pp.(str "Not a type."))
   end
 end
 

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -87,6 +87,17 @@ open Core
 let v_unit = Value.of_unit ()
 let v_blk = Valexpr.make_block
 
+let of_relevance = function
+  | Sorts.Relevant -> ValInt 0
+  | Sorts.Irrelevant -> ValInt 1
+
+let to_relevance = function
+  | ValInt 0 -> Sorts.Relevant
+  | ValInt 1 -> Sorts.Irrelevant
+  | _ -> assert false
+
+let relevance = make_repr of_relevance to_relevance
+
 let of_binder b =
   Value.of_ext Value.val_binder b
 
@@ -772,6 +783,11 @@ let () = define2 "constr_binder_make" (option ident) constr begin fun na ty ->
       let e, info = Exninfo.capture e in
       fail ~info (CErrors.UserError Pp.(str "Not a type."))
   end
+end
+
+let () = define3 "constr_binder_unsafe_make" (option ident) relevance constr begin fun na rel ty ->
+  let na = match na with None -> Anonymous | Some id -> Name id in
+  return (Value.of_ext val_binder (Context.make_annot na rel, ty))
 end
 
 let () = define1 "constr_binder_name" (repr_ext val_binder) begin fun (bnd, _) ->

--- a/plugins/ltac2/tac2print.ml
+++ b/plugins/ltac2/tac2print.ml
@@ -564,7 +564,7 @@ end
 
 let () = register_init "err" begin fun _ _ e ->
   let e = to_ext val_exn e in
-  str "err:(" ++ CErrors.iprint e ++ str ")"
+  str "err:(" ++ CErrors.iprint_no_report e ++ str ")"
 end
 
 let () =

--- a/user-contrib/Ltac2/Constr.v
+++ b/user-contrib/Ltac2/Constr.v
@@ -78,8 +78,14 @@ End Unsafe.
 
 Module Binder.
 
+Ltac2 Type relevance := [ Relevant | Irrelevant ].
+
 Ltac2 @ external make : ident option -> constr -> binder := "ltac2" "constr_binder_make".
-(** Create a binder given the name and the type of the bound variable. *)
+(** Create a binder given the name and the type of the bound variable.
+    Fails if the type is not a type in the current goal. *)
+
+Ltac2 @ external unsafe_make : ident option -> relevance -> constr -> binder := "ltac2" "constr_binder_unsafe_make".
+(** Create a binder given the name and the type and relevance of the bound variable. *)
 
 Ltac2 @ external name : binder -> ident option := "ltac2" "constr_binder_name".
 (** Retrieve the name of a binder. *)


### PR DESCRIPTION
Fix #12601