### PR TITLE
Better printing when exception in exception printer

### DIFF
--- a/lib/cErrors.ml
+++ b/lib/cErrors.ml
@@ -122,8 +122,9 @@ let print_gen ~anomaly (e, info) =
   with exn ->
     let exn, info = Exninfo.capture exn in
     (* exception in error printer *)
-    str "<in exception printer>:" ++ print_backtrace info ++
-    str "<original exception:" ++ print_anomaly anomaly exn
+    str "<in exception printer>:" ++ spc() ++ print_anomaly anomaly exn ++
+    print_backtrace info ++ fnl() ++
+    str "<original exception>:" ++ spc() ++ print_anomaly false e
 
 (** The standard exception printer *)
 let iprint (e, info) =


### PR DESCRIPTION
When printing Exn1 raises Exn2,

it used to say
~~~
<in exception printer>: backtrace of Exn2
<original exception: Exn2
backtrace of Exn1
~~~

now it says
~~~
<in exception printer>: Exn2
backtrace of Exn2
<original exception>: Exn1
backtrace of Exn1
~~~