### PR TITLE
Clean the API of the congruence plugin

### DIFF
--- a/plugins/cc/ccalgo.ml
+++ b/plugins/cc/ccalgo.ml
@@ -237,8 +237,8 @@ type rule=
 type from=
     Goal
   | Hyp of constr
-  | HeqG of constr
-  | HeqnH of constr * constr
+  | HeqG of Id.t
+  | HeqnH of Id.t * Id.t
 
 type 'a eq = {lhs:int;rhs:int;rule:'a}
 
@@ -590,11 +590,14 @@ let rec add_aterm state t' =
                       Not_found -> Int.Set.empty));
             b
 
-let add_equality state c s' t' =
+let add_equality0 state c s' t' =
   let i = add_aterm state s' in
   let j = add_aterm state t' in
     Queue.add {lhs=i;rhs=j;rule=Axiom(c,false)} state.combine;
     Constrhash.add state.uf.axioms c (s',t')
+
+let add_equality state id s t =
+  add_equality0 state (mkVar id) s t
 
 let add_disequality state from s' t' =
   let i = add_aterm state s' in
@@ -645,7 +648,7 @@ let add_inst state (inst,int_subst) =
                    (str "Adding new equality, depth="++ int state.rew_depth) ++ fnl () ++
                   (str "  [" ++ Printer.pr_econstr_env state.env state.sigma (EConstr.of_constr prf) ++ str " : " ++
                            pr_term state.env state.sigma s ++ str " == " ++ pr_term state.env state.sigma t ++ str "]"));
-                add_equality state prf s t
+                add_equality0 state prf s t
               end
             else
               begin

--- a/plugins/cc/ccalgo.ml
+++ b/plugins/cc/ccalgo.ml
@@ -229,9 +229,13 @@ type ccpattern =
     PApp of ATerm.t * ccpattern list (* arguments are reversed *)
   | PVar of int * ccpattern list (* arguments are reversed *)
 
+type axiom = constr
+
+let constr_of_axiom c = c
+
 type rule=
     Congruence
-  | Axiom of constr * bool
+  | Axiom of axiom * bool
   | Injection of int * pa_constructor * int * pa_constructor * int
 
 type from=
@@ -408,7 +412,7 @@ let get_constructor_info uf i=
 let size uf i=
   (get_representative uf i).weight
 
-let axioms uf = uf.axioms
+let axioms uf c = Constrhash.find uf.axioms c
 
 let epsilons uf = uf.epsilons
 

--- a/plugins/cc/ccalgo.ml
+++ b/plugins/cc/ccalgo.ml
@@ -135,7 +135,6 @@ module ATerm :
 sig
   type t
   val proj : t -> t term
-  val make : t term -> t
   val mkSymb : constr -> t
   val mkProduct : (Sorts.t * Sorts.t) -> t
   val mkEps : Id.t -> t

--- a/plugins/cc/ccalgo.mli
+++ b/plugins/cc/ccalgo.mli
@@ -16,14 +16,6 @@ type pa_constructor =
       arity : int;
       args  : int list}
 
-type pa_fun=
-    {fsym:int;
-     fnargs:int}
-
-
-module PafMap : CSig.MapS with type key = pa_fun
-module PacMap : CSig.MapS with type key = pa_constructor
-
 type cinfo =
     {ci_constr: pconstructor; (* inductive type *)
      ci_arity: int;     (* # args *)
@@ -34,23 +26,21 @@ type 'a term
 module ATerm :
 sig
   type t
-  val proj : t -> t term
-  val make : t term -> t (* computes and caches constr and hash *)
   val mkSymb : constr -> t
   val mkProduct : (Sorts.t * Sorts.t) -> t
-  val mkEps : Id.t -> t
   val mkAppli : (t * t) -> t
   val mkConstructor : cinfo -> t
 
   val equal : t -> t -> bool (* does not depend on cached values *)
   val constr : t -> constr
-  val hash : t -> int
   val nth_arg : t -> int -> t
 end
 
-module Constrhash : Hashtbl.S with type key = constr
-module Termhash : Hashtbl.S with type key = ATerm.t
-
+module Constrhash :
+sig
+  type 'a t
+  val find : 'a t -> constr -> 'a
+end
 
 type ccpattern =
     PApp of ATerm.t * ccpattern list
@@ -78,47 +68,7 @@ type patt_kind =
   | Trivial of types
   | Creates_variables
 
-type quant_eq=
-    {qe_hyp_id: Id.t;
-     qe_pol: bool;
-     qe_nvars:int;
-     qe_lhs: ccpattern;
-     qe_lhs_valid:patt_kind;
-     qe_rhs: ccpattern;
-     qe_rhs_valid:patt_kind}
-
-type inductive_status =
-    Unknown
-  | Partial of pa_constructor
-  | Partial_applied
-  | Total of (int * pa_constructor)
-
-type representative=
-    {mutable weight:int;
-     mutable lfathers:Int.Set.t;
-     mutable fathers:Int.Set.t;
-     mutable inductive_status: inductive_status;
-     class_type : types;
-     mutable functions: Int.Set.t PafMap.t} (*pac -> term = app(constr,t) *)
-
-type cl = Rep of representative| Eqto of int*equality
-
-type vertex = Leaf| Node of (int*int)
-
-type node =
-    {mutable clas:cl;
-     mutable cpath: int;
-     mutable constructors: int PacMap.t;
-     vertex:vertex;
-     aterm:ATerm.t}
-
-type forest=
-    {mutable max_size:int;
-     mutable size:int;
-     mutable map: node array;
-     axioms: (ATerm.t * ATerm.t) Constrhash.t;
-     mutable epsilons: pa_constructor list;
-     syms: int Termhash.t}
+type forest
 
 type state
 
@@ -126,8 +76,6 @@ type explanation =
     Discrimination of (int*pa_constructor*int*pa_constructor)
   | Contradiction of disequality
   | Incomplete
-
-type matching_problem
 
 val debug_congruence : CDebug.t
 
@@ -149,8 +97,6 @@ val add_quant : state -> Id.t -> bool ->
   int * patt_kind * ccpattern * patt_kind * ccpattern -> unit
 
 val tail_pac : pa_constructor -> pa_constructor
-
-val find : forest -> int -> int
 
 val find_oldest_pac : forest -> int -> pa_constructor -> int
 

--- a/plugins/cc/ccalgo.mli
+++ b/plugins/cc/ccalgo.mli
@@ -36,19 +36,17 @@ sig
   val nth_arg : t -> int -> t
 end
 
-module Constrhash :
-sig
-  type 'a t
-  val find : 'a t -> constr -> 'a
-end
-
 type ccpattern =
     PApp of ATerm.t * ccpattern list
   | PVar of int * ccpattern list
 
+type axiom
+
+val constr_of_axiom : axiom -> constr
+
 type rule=
     Congruence
-  | Axiom of constr * bool
+  | Axiom of axiom * bool
   | Injection of int * pa_constructor * int * pa_constructor * int
 
 type from=
@@ -81,7 +79,7 @@ val debug_congruence : CDebug.t
 
 val forest : state -> forest
 
-val axioms : forest -> (ATerm.t * ATerm.t) Constrhash.t
+val axioms : forest -> axiom -> ATerm.t * ATerm.t
 
 val epsilons : forest -> pa_constructor list
 

--- a/plugins/cc/ccalgo.mli
+++ b/plugins/cc/ccalgo.mli
@@ -54,8 +54,8 @@ type rule=
 type from=
     Goal
   | Hyp of constr
-  | HeqG of constr
-  | HeqnH of constr*constr
+  | HeqG of Id.t
+  | HeqnH of Id.t * Id.t
 
 type 'a eq = {lhs:int;rhs:int;rule:'a}
 
@@ -89,7 +89,7 @@ val empty : Environ.env -> Evd.evar_map -> int -> state
 
 val add_aterm : state -> ATerm.t -> int
 
-val add_equality : state -> constr -> ATerm.t -> ATerm.t -> unit
+val add_equality : state -> Id.t -> ATerm.t -> ATerm.t -> unit
 
 val add_disequality : state -> from -> ATerm.t -> ATerm.t -> unit
 

--- a/plugins/cc/ccalgo.mli
+++ b/plugins/cc/ccalgo.mli
@@ -30,8 +30,6 @@ sig
   val mkProduct : (Sorts.t * Sorts.t) -> t
   val mkAppli : (t * t) -> t
   val mkConstructor : cinfo -> t
-
-  val equal : t -> t -> bool (* does not depend on cached values *)
   val constr : t -> constr
   val nth_arg : t -> int -> t
 end

--- a/plugins/cc/ccproof.ml
+++ b/plugins/cc/ccproof.ml
@@ -11,7 +11,6 @@
 (* This file uses the (non-compressed) union-find structure to generate *)
 (* proof-trees that will be transformed into proof-terms in cctac.mlg   *)
 
-open CErrors
 open Constr
 open Ccalgo
 open Pp
@@ -45,11 +44,9 @@ let rec ptrans p1 p3=
     | Congr(p1,p2), Trans({p_rule=Congr(p3,p4)},p5) ->
         ptrans (pcongr (ptrans p1 p3) (ptrans p2 p4)) p5
   | _, _ ->
-      if ATerm.equal p1.p_rhs p3.p_lhs then
-        {p_lhs=p1.p_lhs;
-         p_rhs=p3.p_rhs;
-         p_rule=Trans (p1,p3)}
-      else anomaly (Pp.str "invalid cc transitivity.")
+      {p_lhs=p1.p_lhs;
+        p_rhs=p3.p_rhs;
+        p_rule=Trans (p1,p3)}
 
 let rec psym p =
   match p.p_rule with

--- a/plugins/cc/ccproof.ml
+++ b/plugins/cc/ccproof.ml
@@ -17,8 +17,8 @@ open Ccalgo
 open Pp
 
 type rule=
-    Ax of constr
-  | SymAx of constr
+    Ax of axiom
+  | SymAx of axiom
   | Refl of ATerm.t
   | Trans of proof*proof
   | Congr of proof*proof
@@ -69,14 +69,14 @@ let rec psym p =
   | Trans (p1,p2)-> ptrans (psym p2) (psym p1)
   | Congr (p1,p2)-> pcongr (psym p1) (psym p2)
 
-let pax axioms s =
-  let l,r = Constrhash.find axioms s in
+let pax uf s =
+  let l,r = Ccalgo.axioms uf s in
     {p_lhs=l;
      p_rhs=r;
      p_rule=Ax s}
 
-let psymax axioms s =
-  let l,r = Constrhash.find axioms s in
+let psymax uf s =
+  let l,r = Ccalgo.axioms uf s in
     {p_lhs=r;
      p_rhs=l;
      p_rule=SymAx s}
@@ -99,8 +99,8 @@ and edge_proof env sigma uf ((i,j),eq)=
   let pij=
     match eq.rule with
       Axiom (s,reversed)->
-        if reversed then psymax (axioms uf) s
-        else pax (axioms uf) s
+        if reversed then psymax uf s
+        else pax uf s
     | Congruence ->congr_proof env sigma uf eq.lhs eq.rhs
     | Injection (ti,ipac,tj,jpac,k) -> (* pi_k ipac = p_k jpac *)
       let p=ind_proof env sigma uf ti ipac tj jpac in

--- a/plugins/cc/ccproof.mli
+++ b/plugins/cc/ccproof.mli
@@ -12,8 +12,8 @@ open Ccalgo
 open Constr
 
 type rule=
-    Ax of constr
-  | SymAx of constr
+    Ax of axiom
+  | SymAx of axiom
   | Refl of ATerm.t
   | Trans of proof*proof
   | Congr of proof*proof

--- a/plugins/cc/ccproof.mli
+++ b/plugins/cc/ccproof.mli
@@ -21,36 +21,6 @@ type rule=
 and proof =
     private {p_lhs:ATerm.t;p_rhs:ATerm.t;p_rule:rule}
 
-(** Proof smart constructors *)
-
-val prefl:ATerm.t -> proof
-
-val pcongr: proof -> proof -> proof
-
-val ptrans: proof -> proof -> proof
-
-val psym: proof -> proof
-
-val pax : (ATerm.t * ATerm.t) Ccalgo.Constrhash.t ->
-           Ccalgo.Constrhash.key -> proof
-
-val psymax :  (ATerm.t * ATerm.t) Ccalgo.Constrhash.t ->
-           Ccalgo.Constrhash.key -> proof
-
-val pinject :  proof -> pconstructor -> int -> int -> proof
-
-(** Proof building functions *)
-
-val equal_proof : Environ.env -> Evd.evar_map -> forest -> int -> int -> proof
-
-val edge_proof : Environ.env -> Evd.evar_map -> forest -> (int*int)*equality -> proof
-
-val path_proof : Environ.env -> Evd.evar_map -> forest -> int -> ((int*int)*equality) list -> proof
-
-val congr_proof : Environ.env -> Evd.evar_map -> forest -> int -> int -> proof
-
-val ind_proof : Environ.env -> Evd.evar_map -> forest -> int -> pa_constructor -> int -> pa_constructor -> proof
-
 (** Main proof building function *)
 
 val build_proof :

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -315,9 +315,9 @@ let constr_of_term c = EConstr.of_constr (ATerm.constr c)
 let rec proof_tac p : unit Proofview.tactic =
   Proofview.Goal.enter begin fun gl ->
   match p.p_rule with
-      Ax c -> exact_check (EConstr.of_constr c)
+      Ax c -> exact_check (EConstr.of_constr (constr_of_axiom c))
     | SymAx c ->
-        let c = EConstr.of_constr c in
+        let c = EConstr.of_constr (constr_of_axiom c) in
         let l=constr_of_term p.p_lhs and
             r=constr_of_term p.p_rhs in
         type_and_refresh l (fun typ ->

--- a/plugins/cc/cctac.mli
+++ b/plugins/cc/cctac.mli
@@ -10,10 +10,6 @@
 
 open EConstr
 
-val proof_tac: Ccproof.proof -> unit Proofview.tactic
-
-val cc_tactic : int -> constr list -> bool -> unit Proofview.tactic
-
 val congruence_tac : int -> constr list -> unit Proofview.tactic
 
 val simple_congruence_tac : int -> constr list -> unit Proofview.tactic


### PR DESCRIPTION
We remove from the API stuff that is exported but clearly internal details, and enforce a few invariants by typing.