### PR TITLE
[loadpath] Small API cleanup

### DIFF
--- a/vernac/library.mli
+++ b/vernac/library.mli
@@ -65,9 +65,6 @@ val library_is_loaded : DirPath.t -> bool
   (** - Tell which libraries are loaded *)
 val loaded_libraries : unit -> DirPath.t list
 
-  (** - Return the full filename of a loaded library. *)
-val library_full_filename : DirPath.t -> string
-
 (** {6 Native compiler. } *)
 val native_name_from_filename : string -> string
 

--- a/vernac/loadpath.ml
+++ b/vernac/loadpath.ml
@@ -141,7 +141,6 @@ let locate_file fname =
 (************************************************************************)
 (*s Locate absolute or partially qualified library names in the path *)
 
-type library_location = LibLoaded | LibInPath
 type locate_error = LibUnmappedDir | LibNotFound
 type 'a locate_result = ('a, locate_error) result
 
@@ -211,7 +210,7 @@ let locate_absolute_library dir : CUnix.physical_path locate_result =
     | Error fail -> Error fail
 
 let locate_qualified_library ?root qid :
-  (library_location * DP.t * CUnix.physical_path) locate_result =
+  (DP.t * CUnix.physical_path) locate_result =
   (* Search library in loadpath *)
   let dir, base = Libnames.repr_qualid qid in
   match expand_path ?root dir with
@@ -235,11 +234,7 @@ let locate_qualified_library ?root qid :
     match result with
     | Ok (dir,file) ->
       let library = Libnames.add_dirpath_suffix dir base in
-      (* Look if loaded *)
-      if Library.library_is_loaded library
-      then Ok (LibLoaded, library, Library.library_full_filename library)
-      (* Otherwise, look for it in the file system *)
-      else Ok (LibInPath, library, file)
+      Ok (library, file)
     | Error _ as e -> e
 
 let error_unmapped_dir qid =

--- a/vernac/loadpath.mli
+++ b/vernac/loadpath.mli
@@ -48,14 +48,13 @@ val locate_file : string -> string
     it does not respect the visibility of paths. *)
 
 (** {6 Locate a library in the load path } *)
-type library_location = LibLoaded | LibInPath
 type locate_error = LibUnmappedDir | LibNotFound
 type 'a locate_result = ('a, locate_error) result
 
 val locate_qualified_library
   :  ?root:DirPath.t
   -> Libnames.qualid
-  -> (library_location * DirPath.t * CUnix.physical_path) locate_result
+  -> (DirPath.t * CUnix.physical_path) locate_result
 
 (** Locates a library by implicit name.
 

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -456,10 +456,11 @@ let locate_file f =
   let file = Flags.silently Loadpath.locate_file f in
   str file
 
-let msg_found_library = function
-  | Loadpath.LibLoaded, fulldir, file ->
+let msg_found_library (fulldir, file) =
+  if Library.library_is_loaded fulldir then
+    let file = Library.library_full_filename fulldir in
     hov 0 (DirPath.print fulldir ++ strbrk " has been loaded from file " ++ str file)
-  | Loadpath.LibInPath, fulldir, file ->
+  else
     hov 0 (DirPath.print fulldir ++ strbrk " is bound to file " ++ str file)
 
 let err_unmapped_library ?from qid =
@@ -1451,7 +1452,7 @@ let vernac_require from export qidl =
   let locate (qid,_) =
     let open Loadpath in
     match locate_qualified_library ?root qid with
-    | Ok (_,dir,f) -> dir, f
+    | Ok (dir,f) -> dir, f
     | Error LibUnmappedDir -> raise (UnmappedLibrary (root, qid))
     | Error LibNotFound -> raise (NotFoundLibrary (root, qid))
   in

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -458,7 +458,6 @@ let locate_file f =
 
 let msg_found_library (fulldir, file) =
   if Library.library_is_loaded fulldir then
-    let file = Library.library_full_filename fulldir in
     hov 0 (DirPath.print fulldir ++ strbrk " has been loaded from file " ++ str file)
   else
     hov 0 (DirPath.print fulldir ++ strbrk " is bound to file " ++ str file)


### PR DESCRIPTION
We remove the "library location" information bit as it is only used for printing and introduces a dependency on `Library` which is unnecessary, as in my opinion we'd like loadpath resolution to become an independent library (so it can be shared with other tools).

This bit was added more than 20 years ago!
