### PR TITLE
Put Ltac2.Bool notations in a separate module

### DIFF
--- a/doc/changelog/06-Ltac2-language/16536-bool-notations-submodule.rst
+++ b/doc/changelog/06-Ltac2-language/16536-bool-notations-submodule.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  ``Ltac2.Bool`` notations are now in a module ``Ltac2.Bool.BoolNotations``
+  (exported by default), so that these notations can be imported separately
+  (`#16536 <https://github.com/coq/coq/pull/16536>`_,
+  by Jason Gross).

--- a/doc/changelog/06-Ltac2-language/16536-bool-notations-submodule.rst
+++ b/doc/changelog/06-Ltac2-language/16536-bool-notations-submodule.rst
@@ -1,4 +1,4 @@
-- **Added:**
+- **Changed:**
   ``Ltac2.Bool`` notations are now in a module ``Ltac2.Bool.BoolNotations``
   (exported by default), so that these notations can be imported separately
   (`#16536 <https://github.com/coq/coq/pull/16536>`_,

--- a/user-contrib/Ltac2/Bool.v
+++ b/user-contrib/Ltac2/Bool.v
@@ -66,6 +66,9 @@ Ltac2 equal x y :=
 
 (** * Boolean operators with lazy evaluation of the second argument *)
 
+(** We place the notations in a separate module so that we can import them separately *)
+Module Export BoolNotations.
+
 Ltac2 Notation x(self) "&&" y(thunk(self)) : 2 :=
   match x with
   | true => y ()
@@ -77,3 +80,5 @@ Ltac2 Notation x(self) "||" y(thunk(self)) : 3 :=
   | true => true
   | false => y ()
   end.
+
+End BoolNotations.


### PR DESCRIPTION
This way we can import them separately from the boolean operators.  We name it `BoolNotations` after `Coq.Lists.List.ListNotations`.

- [ ] Added / updated **test-suite**. (nothing to do?)
- [x] Added **changelog**.
- [ ] Added / updated **documentation**. (nothing to do?)
