### PR TITLE
Add equality functions for many of the Ltac2 constr kind types

### DIFF
--- a/doc/changelog/06-Ltac2-language/16537-ltac2-more-kind-equal.rst
+++ b/doc/changelog/06-Ltac2-language/16537-ltac2-more-kind-equal.rst
@@ -1,0 +1,9 @@
+- **Added:**
+  ``Ltac2.Constant.equal``, ``Ltac2.Constant.t``, ``Ltac2.Constructor.equal``,
+  ``Ltac2.Constructor.t``, ``Ltac2.Evar.equal``, ``Ltac2.Evar.t``,
+  ``Ltac2.Float.equal``, ``Ltac2.Float.t``, ``Ltac2.Meta.equal``,
+  ``Ltac2.Meta.t``, ``Ltac2.Proj.equal``, ``Ltac2.Proj.t``,
+  ``Ltac2.Uint63.equal``, ``Ltac2.Uint63.t``, ``Ltac2.Char.equal``,
+  ``Ltac2.Char.compare``, ``Ltac2.Constr.Unsafe.Case.equal``
+  (`#16537 <https://github.com/coq/coq/pull/16537>`_,
+  by Jason Gross).

--- a/doc/stdlib/index-list.html.template
+++ b/doc/stdlib/index-list.html.template
@@ -671,23 +671,30 @@ through the <tt>Require Import</tt> command.</p>
     user-contrib/Ltac2/Array.v
     user-contrib/Ltac2/Bool.v
     user-contrib/Ltac2/Char.v
+    user-contrib/Ltac2/Constant.v
     user-contrib/Ltac2/Constr.v
+    user-contrib/Ltac2/Constructor.v
     user-contrib/Ltac2/Control.v
     user-contrib/Ltac2/Env.v
+    user-contrib/Ltac2/Evar.v
+    user-contrib/Ltac2/Float.v
     user-contrib/Ltac2/Fresh.v
     user-contrib/Ltac2/Ident.v
-    user-contrib/Ltac2/Init.v
     user-contrib/Ltac2/Ind.v
+    user-contrib/Ltac2/Init.v
     user-contrib/Ltac2/Int.v
     user-contrib/Ltac2/List.v
     user-contrib/Ltac2/Ltac1.v
     user-contrib/Ltac2/Message.v
+    user-contrib/Ltac2/Meta.v
     user-contrib/Ltac2/Notations.v
     user-contrib/Ltac2/Option.v
     user-contrib/Ltac2/Pattern.v
     user-contrib/Ltac2/Printf.v
+    user-contrib/Ltac2/Proj.v
     user-contrib/Ltac2/Std.v
     user-contrib/Ltac2/String.v
+    user-contrib/Ltac2/Uint63.v
   </dd>
 
   <dt> <b>Unicode</b>:

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -243,6 +243,10 @@ let define2 name r0 r1 f = define_primitive name (arity_suc arity_one) begin fun
   f (Value.repr_to r0 x) (Value.repr_to r1 y)
 end
 
+let define_equality name r eq = define2 name r r begin fun x y ->
+    return (Value.of_bool (eq x y))
+end
+
 let define3 name r0 r1 r2 f = define_primitive name (arity_suc (arity_suc arity_one)) begin fun x y z ->
   f (Value.repr_to r0 x) (Value.repr_to r1 y) (Value.repr_to r2 z)
 end
@@ -850,6 +854,20 @@ let () = define1 "constr_has_evar" constr begin fun c ->
   let b = Evarutil.has_undefined_evars sigma c in
   Proofview.tclUNIT (Value.of_bool b)
 end
+
+(** Extra equalities *)
+
+let () = define_equality "evar_equal" evar Evar.equal
+let () = define_equality "float_equal" float Float64.equal
+let () = define_equality "uint63_equal" uint63 Uint63.equal
+let () = define_equality "meta_equal" int Int.equal
+
+let () = define_equality "constant_equal" constant Constant.UserOrd.equal
+let () = define_equality "constr_case_equal" (repr_ext val_case) begin fun x y ->
+    Ind.UserOrd.equal x.ci_ind y.ci_ind && Sorts.relevance_equal x.ci_relevance y.ci_relevance
+end
+let () = define_equality "constructor_equal" (repr_ext val_constructor) Construct.UserOrd.equal
+let () = define_equality "projection_equal" (repr_ext val_projection) Projection.UserOrd.equal
 
 (** Patterns *)
 

--- a/user-contrib/Ltac2/Constant.v
+++ b/user-contrib/Ltac2/Constant.v
@@ -9,10 +9,5 @@
 (************************************************************************)
 
 Require Import Ltac2.Init.
-Require Ltac2.Int.
 
-Ltac2 @external of_int : int -> char := "ltac2" "char_of_int".
-Ltac2 @external to_int : char -> int := "ltac2" "char_to_int".
-
-Ltac2 equal (x : char) (y : char) : bool := Int.equal (to_int x) (to_int y).
-Ltac2 compare (x : char) (y : char) : int := Int.compare (to_int x) (to_int y).
+Ltac2 @ external equal : constant -> constant -> bool := "ltac2" "constant_equal".

--- a/user-contrib/Ltac2/Constr.v
+++ b/user-contrib/Ltac2/Constr.v
@@ -92,6 +92,10 @@ Ltac2 @ external constructor : inductive -> int -> constructor := "ltac2" "const
 (** Generate the i-th constructor for a given inductive type. Indexing starts
     at 0. Panics if there is no such constructor. *)
 
+Module Case.
+Ltac2 @ external equal : case -> case -> bool := "ltac2" "constr_case_equal".
+End Case.
+
 End Unsafe.
 
 Module Binder.

--- a/user-contrib/Ltac2/Constructor.v
+++ b/user-contrib/Ltac2/Constructor.v
@@ -9,10 +9,7 @@
 (************************************************************************)
 
 Require Import Ltac2.Init.
-Require Ltac2.Int.
 
-Ltac2 @external of_int : int -> char := "ltac2" "char_of_int".
-Ltac2 @external to_int : char -> int := "ltac2" "char_to_int".
+Ltac2 Type t := constructor.
 
-Ltac2 equal (x : char) (y : char) : bool := Int.equal (to_int x) (to_int y).
-Ltac2 compare (x : char) (y : char) : int := Int.compare (to_int x) (to_int y).
+Ltac2 @ external equal : t -> t -> bool := "ltac2" "constructor_equal".

--- a/user-contrib/Ltac2/Evar.v
+++ b/user-contrib/Ltac2/Evar.v
@@ -9,10 +9,7 @@
 (************************************************************************)
 
 Require Import Ltac2.Init.
-Require Ltac2.Int.
 
-Ltac2 @external of_int : int -> char := "ltac2" "char_of_int".
-Ltac2 @external to_int : char -> int := "ltac2" "char_to_int".
+Ltac2 Type t := evar.
 
-Ltac2 equal (x : char) (y : char) : bool := Int.equal (to_int x) (to_int y).
-Ltac2 compare (x : char) (y : char) : int := Int.compare (to_int x) (to_int y).
+Ltac2 @ external equal : t -> t -> bool := "ltac2" "evar_equal".

--- a/user-contrib/Ltac2/Float.v
+++ b/user-contrib/Ltac2/Float.v
@@ -9,10 +9,7 @@
 (************************************************************************)
 
 Require Import Ltac2.Init.
-Require Ltac2.Int.
 
-Ltac2 @external of_int : int -> char := "ltac2" "char_of_int".
-Ltac2 @external to_int : char -> int := "ltac2" "char_to_int".
+Ltac2 Type t := float.
 
-Ltac2 equal (x : char) (y : char) : bool := Int.equal (to_int x) (to_int y).
-Ltac2 compare (x : char) (y : char) : int := Int.compare (to_int x) (to_int y).
+Ltac2 @ external equal : t -> t -> bool := "ltac2" "float_equal".

--- a/user-contrib/Ltac2/Ltac2.v
+++ b/user-contrib/Ltac2/Ltac2.v
@@ -13,9 +13,13 @@ Require Export Ltac2.Init.
 Require Ltac2.Array.
 Require Ltac2.Bool.
 Require Ltac2.Char.
+Require Ltac2.Constant.
 Require Ltac2.Constr.
+Require Ltac2.Constructor.
 Require Ltac2.Control.
 Require Ltac2.Env.
+Require Ltac2.Evar.
+Require Ltac2.Float.
 Require Ltac2.Fresh.
 Require Ltac2.Ident.
 Require Ltac2.Ind.
@@ -23,10 +27,13 @@ Require Ltac2.Int.
 Require Ltac2.List.
 Require Ltac2.Ltac1.
 Require Ltac2.Message.
+Require Ltac2.Meta.
 Require Ltac2.Option.
 Require Ltac2.Pattern.
 Require Ltac2.Printf.
+Require Ltac2.Proj.
 Require Ltac2.Std.
 Require Ltac2.String.
+Require Ltac2.Uint63.
 
 Require Export Ltac2.Notations.

--- a/user-contrib/Ltac2/Meta.v
+++ b/user-contrib/Ltac2/Meta.v
@@ -9,10 +9,7 @@
 (************************************************************************)
 
 Require Import Ltac2.Init.
-Require Ltac2.Int.
 
-Ltac2 @external of_int : int -> char := "ltac2" "char_of_int".
-Ltac2 @external to_int : char -> int := "ltac2" "char_to_int".
+Ltac2 Type t := meta.
 
-Ltac2 equal (x : char) (y : char) : bool := Int.equal (to_int x) (to_int y).
-Ltac2 compare (x : char) (y : char) : int := Int.compare (to_int x) (to_int y).
+Ltac2 @ external equal : t -> t -> bool := "ltac2" "meta_equal".

--- a/user-contrib/Ltac2/Proj.v
+++ b/user-contrib/Ltac2/Proj.v
@@ -9,10 +9,7 @@
 (************************************************************************)
 
 Require Import Ltac2.Init.
-Require Ltac2.Int.
 
-Ltac2 @external of_int : int -> char := "ltac2" "char_of_int".
-Ltac2 @external to_int : char -> int := "ltac2" "char_to_int".
+Ltac2 Type t := projection.
 
-Ltac2 equal (x : char) (y : char) : bool := Int.equal (to_int x) (to_int y).
-Ltac2 compare (x : char) (y : char) : int := Int.compare (to_int x) (to_int y).
+Ltac2 @ external equal : t -> t -> bool := "ltac2" "projection_equal".

--- a/user-contrib/Ltac2/Uint63.v
+++ b/user-contrib/Ltac2/Uint63.v
@@ -9,10 +9,7 @@
 (************************************************************************)
 
 Require Import Ltac2.Init.
-Require Ltac2.Int.
 
-Ltac2 @external of_int : int -> char := "ltac2" "char_of_int".
-Ltac2 @external to_int : char -> int := "ltac2" "char_to_int".
+Ltac2 Type t := uint63.
 
-Ltac2 equal (x : char) (y : char) : bool := Int.equal (to_int x) (to_int y).
-Ltac2 compare (x : char) (y : char) : int := Int.compare (to_int x) (to_int y).
+Ltac2 @ external equal : t -> t -> bool := "ltac2" "uint63_equal".


### PR DESCRIPTION
This is a work in progress; is someone from @coq/ltac2-maintainers willing to help me complete the OCaml side of this?

- [ ] Added / updated **test-suite**. (is this needed?)
- [x] Added **changelog**.
- [ ] Added / updated **documentation**. (no doc to update?)
