### PR TITLE
Use a user-provided equality in Pcoq rule factorizing instead of (==).

### DIFF
--- a/clib/cList.ml
+++ b/clib/cList.ml
@@ -659,9 +659,9 @@ let drop_prefix cmp p l =
   in
   drop_prefix_rec (p,l)
 
-let share_tails l1 l2 =
+let share_tails eq l1 l2 =
   let rec shr_rev acc = function
-    | (x1 :: l1, x2 :: l2) when x1 == x2 -> shr_rev (x1 :: acc) (l1,l2)
+    | (x1 :: l1, x2 :: l2) when eq x1 x2 -> shr_rev (x1 :: acc) (l1,l2)
     | (l1, l2) -> (List.rev l1, List.rev l2, acc)
   in
   shr_rev [] (List.rev l1, List.rev l2)

--- a/clib/cList.mli
+++ b/clib/cList.mli
@@ -277,7 +277,7 @@ val insert : 'a eq -> 'a -> 'a list -> 'a list
 (** Insert at the (first) position so that if the list is ordered wrt to the
     total order given as argument, the order is preserved *)
 
-val share_tails : 'a list -> 'a list -> 'a list * 'a list * 'a list
+val share_tails : 'a eq -> 'a list -> 'a list -> 'a list * 'a list * 'a list
 (** [share_tails l1 l2] returns [(l1',l2',l)] such that [l1] is
     [l1'\@l] and [l2] is [l2'\@l] and [l] is maximal amongst all such
     decompositions *)

--- a/parsing/pcoq.mli
+++ b/parsing/pcoq.mli
@@ -225,7 +225,10 @@ type extend_rule =
 | ExtendRule : 'a Entry.t * 'a extend_statement -> extend_rule
 | ExtendRuleReinit : 'a Entry.t * gram_reinit * 'a extend_statement -> extend_rule
 
-type 'a grammar_extension = 'a -> GramState.t -> extend_rule list * GramState.t
+type 'a grammar_extension = {
+  gext_fun : 'a -> GramState.t -> extend_rule list * GramState.t;
+  gext_eq : 'a -> 'a -> bool;
+}
 (** Grammar extension entry point. Given some ['a] and a current grammar state,
     such a function must produce the list of grammar extensions that will be
     applied in the same order and kept synchronized w.r.t. the summary, together
@@ -244,7 +247,10 @@ type ('a, 'b) entry_command
 (** Type of synchronized entry creation. The ['a] type should be
     marshallable. *)
 
-type ('a, 'b) entry_extension = 'a -> GramState.t -> string list * GramState.t
+type ('a, 'b) entry_extension = {
+  eext_fun : 'a -> GramState.t -> string list * GramState.t;
+  eext_eq : 'a -> 'a -> bool;
+}
 (** Entry extension entry point. Given some ['a] and a current grammar state,
     such a function must produce the list of entry extensions that will be
     created and kept synchronized w.r.t. the summary, together

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -192,7 +192,7 @@ let add_tactic_entry (kn, ml, tg) state =
   ([r], state)
 
 let tactic_grammar =
-  create_grammar_command "TacticGrammar" add_tactic_entry
+  create_grammar_command "TacticGrammar" { gext_fun = add_tactic_entry; gext_eq = (==) (* FIXME *) }
 
 let extend_tactic_grammar kn ml ntn = extend_grammar_command tactic_grammar (kn, ml, ntn)
 

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -691,7 +691,7 @@ let perform_notation syn st =
     ([Pcoq.ExtendRuleReinit (Pltac.ltac2_expr, reinit, rule)], st)
 
 let ltac2_notation =
-  Pcoq.create_grammar_command "ltac2-notation" perform_notation
+  Pcoq.create_grammar_command "ltac2-notation" { gext_fun = perform_notation; gext_eq = (==) (* FIXME *) }
 
 let cache_synext syn =
   Pcoq.extend_grammar_command ltac2_notation syn

--- a/vernac/egramcoq.ml
+++ b/vernac/egramcoq.ml
@@ -265,9 +265,9 @@ type (_, _) entry =
 type _ any_entry = TTAny : ('s, 'r) entry -> 's any_entry
 
 let constr_custom_entry : (string, Constrexpr.constr_expr) entry_command =
-  create_entry_command "constr" (fun s st -> [s], st)
+  create_entry_command "constr" { eext_fun = (fun s st -> [s], st); eext_eq = (==) (* FIXME *) }
 let pattern_custom_entry : (string, Constrexpr.cases_pattern_expr) entry_command =
-  create_entry_command "pattern" (fun s st -> [s], st)
+  create_entry_command "pattern" { eext_fun = (fun s st -> [s], st); eext_eq = (==) (* FIXME *) }
 
 let custom_entry_locality = Summary.ref ~name:"LOCAL-CUSTOM-ENTRY" String.Set.empty
 (** If the entry is present then local *)
@@ -638,6 +638,6 @@ let extend_constr_notation ng state =
   (r @ r', state)
 
 let constr_grammar : one_notation_grammar grammar_command =
-  create_grammar_command "Notation" extend_constr_notation
+  create_grammar_command "Notation" { gext_fun = extend_constr_notation; gext_eq = (==) (* FIXME *) }
 
 let extend_constr_grammar ntn = extend_grammar_command constr_grammar ntn


### PR DESCRIPTION
This is an alternative to #16281. For now all callers still use physical equality but the situation is already a bit better because we only check for proper subcomponents and ignore the redundant grammar state.