### PR TITLE
add coqide-server as a dependency of the coq opam package

### DIFF
--- a/coq.opam
+++ b/coq.opam
@@ -23,6 +23,7 @@ depends: [
   "dune" {>= "2.9"}
   "coq-core" {= version}
   "coq-stdlib" {= version}
+  "coqide-server" {= version}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/dune-project
+++ b/dune-project
@@ -113,7 +113,8 @@ This package provides the Coq Reference Manual."))
  (name coq)
  (depends
   (coq-core (= :version))
-  (coq-stdlib (= :version)))
+  (coq-stdlib (= :version))
+  (coqide-server (= :version)))
  (synopsis "The Coq Proof Assistant")
  (description "Coq is a formal proof management system. It provides
 a formal language to write mathematical definitions, executable


### PR DESCRIPTION
As discussed on the [Coq Zulip chat](https://coq.zulipchat.com/#narrow/stream/237656-Coq-devs-.26-plugin-devs/topic/coq.2Edev.20opam.20package.20not.20producing.20coqidetop.2Eopt.3F), the current `coq` opam package (depending on `coq-core` and `coq-stdlib`) does not include the `coqidetop` executable which is needed to use CoqIDE or VsCoq. Hence, users who install the `coq` opam package must figure out that they need to also install `coqide-server` to enable using CoqIDE or VsCoq. This is in contrast to all released `coq` opam packages, where `coqidetop` is included. This PR restores the old opam package content by making the `coq` opam package depend on the `coqide-server` package.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
