### PR TITLE
Ltac2 patterns allow incomplete record field list

### DIFF
--- a/test-suite/ltac2/matching.v
+++ b/test-suite/ltac2/matching.v
@@ -159,6 +159,10 @@ Module Record.
        r.(contents) := 1;
        check_eq_int (bang r) 0.
 
+  Ltac2 Type foo := { a : int; b : int }.
+
+  Ltac2 bar x := match x with { a := a } => a end.
+
 End Record.
 
 Module Atom.


### PR DESCRIPTION
~The first commit uses GADTs in a kinda overengineered way, the second commit removes the GADT use at the cost of a bit of static checking. Assignee picks which version they prefer.~

New version fully pulling the recursion out of intern_record, I prefer this.