### PR TITLE
Fix printing of ssreflect `abstract` tactic.

### DIFF
--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1837,7 +1837,6 @@ simple_tactic: [
 | "pose" ssrcofixfwd      (* SSR plugin *)
 | "pose" ssrfwdid ssrposefwd      (* SSR plugin *)
 | "set" ssrfwdid ssrsetfwd ssrclauses      (* SSR plugin *)
-| "abstract" ssrdgens      (* SSR plugin *)
 | "have" ssrhavefwdwbinders      (* SSR plugin *)
 | "have" "suff" ssrhpats_nobs ssrhavefwd      (* SSR plugin *)
 | "have" "suffices" ssrhpats_nobs ssrhavefwd      (* SSR plugin *)

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -2491,20 +2491,32 @@ END
 
 (* Pltac. *)
 
+{
+
+  let tclabstractkey =
+    let open Pptactic in
+    let prods = [ TacTerm "abstract"; mk_non_term wit_ssrdgens (Names.Id.of_string "gens") ] in
+    let tac = begin fun args ist -> match args with
+      | [gens] ->
+        let gens = cast_arg wit_ssrdgens gens in
+        if List.length (fst gens) <> 1 then
+          errorstrm (str"dependents switches '/' not allowed here");
+        Ssripats.ssrabstract (ssrdgens_of_parsed_dgens gens)
+      | _ -> assert false
+      end in
+    register_ssrtac "tclabstract" tac prods
+
+let tclabstract_expr ?loc gens =
+  let arg = in_gen (rawwit wit_ssrdgens) gens in
+  ssrtac_expr ?loc tclabstractkey [arg]
+
+}
+
 (* The standard TACTIC EXTEND does not work for abstract *)
 GRAMMAR EXTEND Gram
   GLOBAL: ltac_expr;
   ltac_expr: LEVEL "3"
-    [ [ IDENT "abstract"; gens = ssrdgens ->
-               { CAst.make ~loc (TacML (
-                     ssrtac_entry "abstract", [Tacexpr.TacGeneric (None, Genarg.in_gen (Genarg.rawwit wit_ssrdgens) gens)]))
-                 } ]];
-END
-TACTIC EXTEND ssrabstract
-| [ "abstract" ssrdgens(gens) ] -> {
-    if List.length (fst gens) <> 1 then
-      errorstrm (str"dependents switches '/' not allowed here");
-    Ssripats.ssrabstract (ssrdgens_of_parsed_dgens gens) }
+    [ [ IDENT "abstract"; gens = ssrdgens -> { tclabstract_expr ~loc gens } ] ];
 END
 
 TACTIC EXTEND ssrhave

--- a/test-suite/output/bug_16558.out
+++ b/test-suite/output/bug_16558.out
@@ -1,0 +1,1 @@
+Ltac t x y := abstract : x 

--- a/test-suite/output/bug_16558.v
+++ b/test-suite/output/bug_16558.v
@@ -1,0 +1,3 @@
+Require Import ssreflect.
+Ltac t x y := abstract: x.
+Print t.


### PR DESCRIPTION
Testcase:
```
Require Import ssreflect.

Ltac t x y := abstract: x.
Print t.
(* Was: Ltac t x y := <coq-core.plugins.ssreflect::ssrabstract@0> : x
   Is now: Ltac t x y := abstract : x 
*)
```