### PR TITLE
[nix] bump to OCaml 4.13

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -22,7 +22,7 @@
 # a symlink to where Coq was installed.
 
 { pkgs ? import ./dev/nixpkgs.nix {}
-, ocamlPackages ? pkgs.ocaml-ng.ocamlPackages_4_12
+, ocamlPackages ? pkgs.ocaml-ng.ocamlPackages_4_13
 , buildIde ? true
 , buildDoc ? true
 , doInstallCheck ? true


### PR DESCRIPTION
ocaml-lsp doesn't seem to work on OCaml 4.12 any longer. We bump to 4.13 so that it can be used.

