### PR TITLE
[cleanup] Remove `Format Notation` command

### DIFF
--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -1251,8 +1251,8 @@ Here are the syntax elements used by the various notation commands.
       | right associativity
       | no associativity
       | only parsing
+      | format @string
       | only printing
-      | format @string {? @string }
       explicit_subentry ::= ident
       | name
       | global

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1430,7 +1430,6 @@ syntax: [
 | "Infix" ne_lstring ":=" constr syntax_modifiers OPT [ ":" IDENT ]
 | "Notation" identref LIST0 ident ":=" constr syntax_modifiers
 | "Notation" lstring ":=" constr syntax_modifiers OPT [ ":" IDENT ]
-| "Format" "Notation" STRING STRING STRING
 | "Reserved" "Infix" ne_lstring syntax_modifiers
 | "Reserved" "Notation" ne_lstring syntax_modifiers
 ]
@@ -1449,7 +1448,7 @@ syntax_modifier: [
 | "no" "associativity"
 | "only" "printing"
 | "only" "parsing"
-| "format" STRING OPT STRING
+| "format" lstring
 | IDENT; "," LIST1 IDENT SEP "," [ "at" level | "in" "scope" IDENT ]
 | IDENT; "at" level OPT binder_interp
 | IDENT; "in" "scope" IDENT

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1103,7 +1103,6 @@ command: [
 | "Infix" string ":=" one_term OPT ( "(" LIST1 syntax_modifier SEP "," ")" ) OPT [ ":" scope_name ]
 | "Notation" ident LIST0 ident ":=" one_term OPT ( "(" LIST1 syntax_modifier SEP "," ")" )
 | "Notation" string ":=" one_term OPT ( "(" LIST1 syntax_modifier SEP "," ")" ) OPT [ ":" scope_name ]
-| "Format" "Notation" string string string
 | "Reserved" "Infix" string OPT ( "(" LIST1 syntax_modifier SEP "," ")" )
 | "Reserved" "Notation" string OPT ( "(" LIST1 syntax_modifier SEP "," ")" )
 | "Eval" red_expr "in" term
@@ -1552,8 +1551,8 @@ syntax_modifier: [
 | "right" "associativity"
 | "no" "associativity"
 | "only" "parsing"
+| "format" string
 | "only" "printing"
-| "format" string OPT string
 ]
 
 explicit_subentry: [

--- a/printing/ppextend.ml
+++ b/printing/ppextend.ml
@@ -10,7 +10,6 @@
 
 open Util
 open Pp
-open CErrors
 open Notation
 open Constrexpr
 
@@ -48,7 +47,6 @@ type unparsing =
   | UnpCut of ppcut
 
 type unparsing_rule = unparsing list
-type extra_unparsing_rules = (string * string) list
 
 let rec unparsing_eq unp1 unp2 = match (unp1,unp2) with
   | UnpMetaVar (p1,s1), UnpMetaVar (p2,s2) -> entry_relative_level_eq p1 p2 && s1 = s2
@@ -66,7 +64,6 @@ let rec unparsing_eq unp1 unp2 = match (unp1,unp2) with
 type notation_printing_rules = {
   notation_printing_unparsing : unparsing_rule;
   notation_printing_level : entry_level;
-  notation_printing_extra : extra_unparsing_rules;
 }
 
 type generic_notation_printing_rules = {
@@ -100,25 +97,3 @@ let find_notation_printing_rule which ntn =
   | None -> raise Not_found (* Normally not the case *)
   | Some which -> (find_specific_notation_printing_rule (which,ntn))
   with Not_found -> (find_generic_notation_printing_rule ntn).notation_printing_rules
-
-let find_notation_extra_printing_rules which ntn =
-  try match which with
-  | None -> raise Not_found
-  | Some which -> (find_specific_notation_printing_rule (which,ntn)).notation_printing_extra
-  with Not_found -> (find_generic_notation_printing_rule ntn).notation_printing_rules.notation_printing_extra
-
-let add_notation_extra_printing_rule ntn k v =
-  try
-    generic_notation_printing_rules :=
-      let { notation_printing_reserved; notation_printing_rules } = NotationMap.find ntn !generic_notation_printing_rules in
-      let rules = {
-          notation_printing_reserved;
-          notation_printing_rules = {
-              notation_printing_rules with
-              notation_printing_extra = (k,v) :: notation_printing_rules.notation_printing_extra
-            }
-        } in
-      NotationMap.add ntn rules !generic_notation_printing_rules
-  with Not_found ->
-    user_err
-      (str "No such Notation.")

--- a/printing/ppextend.mli
+++ b/printing/ppextend.mli
@@ -41,14 +41,12 @@ type unparsing =
   | UnpCut of ppcut
 
 type unparsing_rule = unparsing list
-type extra_unparsing_rules = (string * string) list
 
 val unparsing_eq : unparsing -> unparsing -> bool
 
 type notation_printing_rules = {
   notation_printing_unparsing : unparsing_rule;
   notation_printing_level : entry_level;
-  notation_printing_extra : extra_unparsing_rules;
 }
 
 type generic_notation_printing_rules = {
@@ -62,5 +60,3 @@ val has_generic_notation_printing_rule : notation -> bool
 val find_generic_notation_printing_rule : notation -> generic_notation_printing_rules
 val find_specific_notation_printing_rule : specific_notation -> notation_printing_rules
 val find_notation_printing_rule : notation_with_optional_scope option -> notation -> notation_printing_rules
-val find_notation_extra_printing_rules : notation_with_optional_scope option -> notation -> extra_unparsing_rules
-val add_notation_extra_printing_rule : notation -> string -> string -> unit

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -1226,8 +1226,6 @@ GRAMMAR EXTEND Gram
          modl = syntax_modifiers;
          sc = OPT [ ":"; sc = IDENT -> { sc } ] ->
            { VernacNotation (false,c,(s,modl),sc) }
-     | IDENT "Format"; IDENT "Notation"; n = STRING; s = STRING; fmt = STRING ->
-           { VernacNotationAddFormat (n,s,fmt) }
 
      | IDENT "Reserved"; IDENT "Infix"; s = ne_lstring; l = syntax_modifiers ->
            { VernacReservedNotation (true,(s,l)) }

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -1250,11 +1250,7 @@ GRAMMAR EXTEND Gram
       | IDENT "no"; IDENT "associativity" -> { SetAssoc Gramlib.Gramext.NonA }
       | IDENT "only"; IDENT "printing" -> { SetOnlyPrinting }
       | IDENT "only"; IDENT "parsing" -> { SetOnlyParsing }
-      | IDENT "format"; s1 = [s = STRING -> { CAst.make ~loc s } ];
-                        s2 = OPT [s = STRING -> { CAst.make ~loc s } ] ->
-          { begin match s1, s2 with
-          | { CAst.v = k }, Some s -> SetFormat (ExtraFormat (k,s))
-          | s, None -> SetFormat (TextFormat s) end }
+      | IDENT "format"; s = lstring -> { SetFormat (TextFormat s) }
       | x = IDENT; ","; l = LIST1 IDENT SEP ","; v =
           [ "at"; lev = level -> { fun x l -> SetItemLevel (x::l,None,lev) }
           | "in"; IDENT "scope"; k = IDENT -> { fun x l -> SetItemScope(x::l,k) } ] -> { v x l }

--- a/vernac/metasyntax.mli
+++ b/vernac/metasyntax.mli
@@ -20,8 +20,6 @@ open Environ
 val add_notation : local:bool -> infix:bool -> Deprecation.t option -> env -> constr_expr ->
   (lstring * syntax_modifier CAst.t list) -> scope_name option -> unit
 
-val add_notation_extra_printing_rule : string -> string -> string -> unit
-
 (** Declaring scopes, delimiter keys and default scopes *)
 
 val declare_scope : locality_flag -> scope_name -> unit

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -777,10 +777,6 @@ let pr_vernac_expr v =
       keyword "Reserved Notation" ++ spc() ++ pr_ast qs s ++
       pr_syntax_modifiers l
     )
-  | VernacNotationAddFormat(s,k,v) ->
-    return (
-      keyword "Format Notation " ++ qs s ++ spc () ++ qs k ++ spc() ++ qs v
-    )
   | VernacDeclareCustomEntry s ->
     return (
       keyword "Declare Custom Entry " ++ str s

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -479,8 +479,7 @@ let pr_syntax_modifier = let open Gramlib.Gramext in CAst.with_val (function
     | SetEntryType (x,typ) -> str x ++ spc() ++ pr_set_simple_entry_type typ
     | SetOnlyPrinting -> keyword "only printing"
     | SetOnlyParsing -> keyword "only parsing"
-    | SetFormat (TextFormat s) -> keyword "format " ++ pr_ast qs s
-    | SetFormat (ExtraFormat (k,s)) -> keyword "format " ++ qs k ++ spc() ++ pr_ast qs s)
+    | SetFormat (TextFormat s) -> keyword "format " ++ pr_ast qs s)
 
 let pr_syntax_modifiers = function
   | [] -> mt()

--- a/vernac/vernac_classifier.ml
+++ b/vernac/vernac_classifier.ml
@@ -169,8 +169,7 @@ let classify_vernac e =
     | VernacDeclareCustomEntry _
     | VernacOpenCloseScope _ | VernacDeclareScope _
     | VernacDelimiters _ | VernacBindScope _
-    | VernacNotation _ | VernacNotationAddFormat _
-    | VernacReservedNotation _
+    | VernacNotation _ | VernacReservedNotation _
     | VernacSyntacticDefinition _
     | VernacRequire _ | VernacImport _ | VernacInclude _
     | VernacDeclareMLModule _

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2308,10 +2308,6 @@ let translate_vernac ?loc ~atts v = let open Vernacextend in match v with
     vtdefault(fun () -> with_section_locality ~atts vernac_open_close_scope (b,s))
   | VernacNotation (infix,c,infpl,sc) ->
     vtdefault(fun () -> vernac_notation ~atts ~infix c infpl sc)
-  | VernacNotationAddFormat(n,k,v) ->
-    vtdefault(fun () ->
-        unsupported_attributes atts;
-        Metasyntax.add_notation_extra_printing_rule n k v)
   | VernacDeclareCustomEntry s ->
     vtdefault(fun () -> with_module_locality ~atts vernac_custom_entry s)
 

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -351,7 +351,6 @@ type nonrec vernac_expr =
   | VernacNotation of
       infix_flag * constr_expr * (lstring * syntax_modifier CAst.t list) *
       scope_name option
-  | VernacNotationAddFormat of string * string * string
   | VernacDeclareCustomEntry of string
 
   (* Gallina *)

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -145,7 +145,6 @@ type definition_expr =
 
 type notation_format =
   | TextFormat of lstring
-  | ExtraFormat of string * lstring
 
 type syntax_modifier =
   | SetItemLevel of string list * Notation_term.constr_as_binder_kind option * Extend.production_level


### PR DESCRIPTION
closes #5534

Seems to have been a half-finished experiment. It is unused and supposedly useless.
