### PR TITLE
Fix printing of ssr `unlock` tactic

### DIFF
--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -2439,7 +2439,10 @@ END
 
 {
 
-let pr_unlockarg (occ, t) = pr_occ occ ++ pr_term t
+let pr_unlockarg (occ, t) =
+  (match occ with
+   | None -> Pp.mt ()
+   | _ -> pr_occ occ) ++ pr_term t
 let pr_ssrunlockarg _ _ _ = pr_unlockarg
 
 }

--- a/test-suite/output/bug_16562.out
+++ b/test-suite/output/bug_16562.out
@@ -1,0 +1,1 @@
+Ltac t x := unlock x

--- a/test-suite/output/bug_16562.v
+++ b/test-suite/output/bug_16562.v
@@ -1,0 +1,4 @@
+Require Import ssreflect.
+
+Ltac t x := unlock x.
+Print t.


### PR DESCRIPTION
Testcase:
```
Require Import ssreflect.

Ltac t x := unlock x.
Print t.
(* used to print unparsable 'unlock {}x' *)
```