### PR TITLE
Fix printing of `functional induction`

### DIFF
--- a/plugins/funind/g_indfun.mlg
+++ b/plugins/funind/g_indfun.mlg
@@ -71,11 +71,10 @@ END
 
 {
 
-let pr_intro_as_pat _prc _ _ pat =
+let pr_intro_as_pat prc pat =
   match pat with
     | Some pat ->
-      spc () ++ str "as" ++ spc () ++ (* Miscprint.pr_intro_pattern prc  pat *)
-        str"<simple_intropattern>"
+      str "as" ++ spc () ++ Miscprint.pr_intro_pattern prc pat
     | None -> mt ()
 
 let out_disjunctive = CAst.map (function
@@ -84,7 +83,10 @@ let out_disjunctive = CAst.map (function
 
 }
 
-ARGUMENT EXTEND with_names TYPED AS intro_pattern option PRINTED BY { pr_intro_as_pat }
+ARGUMENT EXTEND with_names TYPED AS intro_pattern option
+  PRINTED BY { fun prc _ _ -> pr_intro_as_pat (fun c -> prc env sigma @@ snd @@ c env sigma) }
+  RAW_PRINTED BY { fun prc _ _ -> pr_intro_as_pat (prc env sigma) }
+  GLOB_PRINTED BY { fun prc _ _ -> pr_intro_as_pat (prc env sigma) }
 | [ "as"  simple_intropattern(ipat) ] -> { Some ipat }
 | []  -> { None }
 END

--- a/test-suite/output/bug_16565.out
+++ b/test-suite/output/bug_16565.out
@@ -1,0 +1,1 @@
+Ltac u a b := functional induction a as b

--- a/test-suite/output/bug_16565.v
+++ b/test-suite/output/bug_16565.v
@@ -1,0 +1,3 @@
+Require Import FunInd.
+Ltac u a b := functional induction a as b.
+Print u.


### PR DESCRIPTION
Testcase:
```
Require Import FunInd.
Ltac u a b := functional induction a as b.
Print u.
(* used to be Ltac u a b := functional induction a  as <simple_intropattern> *)
```