### PR TITLE
Fix printing of `rewrite` when SsrSyntax is imported

### DIFF
--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -492,7 +492,15 @@ let string_of_genarg_arg (ArgumentType arg) =
         (prlist_with_sep (fun () -> str",")
            (fun id -> spc () ++ pr_hyp_location pr_id id) l ++ pr_occs)
 
-  let pr_orient b = if b then mt () else str "<- "
+
+  (* When the [ssreflect.SsrSynax] module is imported, ssreflect operates
+     in reduced compatibility mode. During printing, we try to account for
+     this when this module is imported. See [plugins/ssr/ssrparser.mlg] for
+     the code that enables the reduced compatibility mode. *)
+  let ssr_loaded = ref (fun () -> false)
+  let ssr_loaded_hook f = ssr_loaded := f
+
+  let pr_orient b = if b then if !ssr_loaded () then str "-> " else mt () else str "<- "
 
   let pr_multi = let open Equality in function
     | Precisely 1 -> mt ()

--- a/plugins/ltac/pptactic.mli
+++ b/plugins/ltac/pptactic.mli
@@ -161,3 +161,5 @@ val ltop : entry_relative_level
 
 val make_constr_printer : (env -> Evd.evar_map -> entry_relative_level -> 'a -> Pp.t) ->
   'a Genprint.top_printer
+
+val ssr_loaded_hook : (unit -> bool) -> unit

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -63,6 +63,7 @@ let is_ssr_loaded () =
   !ssr_loaded ||
   (if CLexer.is_keyword "SsrSyntax_is_Imported" then ssr_loaded:=true;
    !ssr_loaded)
+let () = Pptactic.ssr_loaded_hook is_ssr_loaded
 
 }
 

--- a/test-suite/output/bug_16566.out
+++ b/test-suite/output/bug_16566.out
@@ -1,0 +1,2 @@
+Ltac t a b := rewrite a, b
+Ltac t a b := rewrite -> a, -> b

--- a/test-suite/output/bug_16566.v
+++ b/test-suite/output/bug_16566.v
@@ -1,0 +1,4 @@
+Ltac t a b := rewrite a, b.
+Print t.
+Require Import ssreflect.
+Print t.


### PR DESCRIPTION
Ssreflect has some incompatible syntax with normal Coq, see https://coq.inria.fr/refman/proof-engine/ssreflect-proof-language.html#compatibility-issues. In particular `rewrite a, b` no longer works and has to be replaced with `rewrite -> a, -> b`. During printing, this is also a problem.

In this PR, we check wether `SsrSyntax` is loaded, an if so, we print `rewrite` with forward `->` arrows.

Testcase:
```
Ltac t a b := rewrite a, b.
Print t.
(* Used to print rewrite a, b and still does *)
Require Import ssreflect.
Print t.
(* Used to print rewrite a, b and now prints rewrite -> a, -> b *)
```
See also https://github.com/coq/coq/blob/81875cd7c86d6a95f0034aaee438bef883dc8279/plugins/ssr/ssrparser.mlg#L53-L65