### PR TITLE
Non rectypes Nativevalues.t using GADT

### DIFF
--- a/kernel/nativeconv.ml
+++ b/kernel/nativeconv.ml
@@ -25,9 +25,9 @@ let rec conv_val env pb lvl v1 v2 cu =
         let v = mk_rel_accu lvl in
         conv_val env CONV (lvl+1) (f1 v) (f2 v) cu
     | Vfun _f1, _ ->
-        conv_val env CONV lvl v1 (fun x -> v2 x) cu
+      conv_val env CONV lvl v1 (eta_expand v2) cu
     | _, Vfun _f2 ->
-        conv_val env CONV lvl (fun x -> v1 x) v2 cu
+        conv_val env CONV lvl (eta_expand v1) v2 cu
     | Vaccu k1, Vaccu k2 ->
         conv_accu env pb lvl k1 k2 cu
     | Vconst i1, Vconst i2 ->
@@ -102,7 +102,7 @@ and conv_atom env pb lvl a1 a2 cu =
               let ci =
                 if Int.equal arity 0 then mk_const tag
                 else mk_block tag (mk_rels_accu lvl arity) in
-              let bi1 = bs1 ci and bi2 = bs2 ci in
+              let bi1 = apply bs1 ci and bi2 = apply bs2 ci in
               if Int.equal i max then conv_val env CONV (lvl + arity) bi1 bi2 cu
               else aux (i+1) (conv_val env CONV (lvl + arity) bi1 bi2 cu) in
             aux 0 cu
@@ -121,7 +121,7 @@ and conv_atom env pb lvl a1 a2 cu =
     | Aprod(_,d1,_c1), Aprod(_,d2,_c2) ->
        let cu = conv_val env CONV lvl d1 d2 cu in
        let v = mk_rel_accu lvl in
-       conv_val env pb (lvl + 1) (d1 v) (d2 v) cu
+       conv_val env pb (lvl + 1) (apply d1 v) (apply d2 v) cu
     | Aproj((ind1, i1), ac1), Aproj((ind2, i2), ac2) ->
        if not (Ind.CanOrd.equal ind1 ind2 && Int.equal i1 i2) then raise NotConvertible
        else conv_accu env CONV lvl ac1 ac2 cu

--- a/kernel/nativevalues.mli
+++ b/kernel/nativevalues.mli
@@ -14,7 +14,17 @@ open Names
 the native compiler. Be careful when removing apparently dead code from this
 interface, as it may be used by programs generated at runtime. *)
 
-type t = t -> t
+type t
+
+val apply : t -> t -> t
+val of_fun : (t -> t) -> t
+
+val eta_expand : t -> t
+
+type ('a,'b) eq = ('a,'b) Util.eq = Refl : ('a,'a) eq
+val t_eq : (t, t -> t) eq
+(** When -rectypes, matching on this makes [t = ('a -> 'a) as 'a].
+    When not -rectypes, it does nothing AFAICT so you have to generalize your problem to use this. *)
 
 type accumulator
 
@@ -47,11 +57,11 @@ type atom =
   | Aind of pinductive
   | Asort of Sorts.t
   | Avar of Id.t
-  | Acase of annot_sw * accumulator * t * (t -> t)
+  | Acase of annot_sw * accumulator * t * t
   | Afix of t array * t array * rec_pos * int
   | Acofix of t array * t array * int * t
   | Acofixe of t array * t array * int * t
-  | Aprod of Name.t * t * (t -> t)
+  | Aprod of Name.t * t * t
   | Ameta of metavariable * t
   | Aevar of Evar.t * t array (* arguments *)
   | Aproj of (inductive * int) * accumulator
@@ -368,7 +378,7 @@ val is_parray : t -> bool
 
 val arraymake : t -> t -> t -> t -> t (* accu A n def *)
 val arrayget : t -> t -> t -> t -> t (* accu A t n *)
-val arraydefault : t -> t -> t (* accu A t *)
+val arraydefault : t -> t -> t -> t (* accu A t *)
 val arrayset : t -> t -> t -> t -> t -> t (* accu A t n v *)
 val arraycopy : t -> t -> t -> t (* accu A t *)
 val arraylength : t -> t -> t -> t (* accu A t *)
@@ -376,7 +386,7 @@ val arraylength : t -> t -> t -> t (* accu A t *)
 val no_check_arraymake : t -> t -> t
 [@@ocaml.inline always]
 
-val no_check_arrayget : t -> t -> t -> t
+val no_check_arrayget : t -> t -> t
 [@@ocaml.inline always]
 
 val no_check_arraydefault : t -> t

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -168,7 +168,7 @@ let branch_of_switch lvl ans bs =
     let ci =
       if Int.equal arity 0 then mk_const tag
       else mk_block tag (mk_rels_accu lvl arity) in
-    bs ci in
+    apply bs ci in
   Array.init (Array.length tbl) branch
 
 let get_proj env (ind, proj_arg) =
@@ -273,7 +273,7 @@ and nf_atom env sigma atom =
     let n = make_annot n rdom in
     let vn = mk_rel_accu (nb_rel env) in
     let env = push_rel (LocalAssum (n,dom)) env in
-    let codom = nf_type env sigma (codom vn) in
+    let codom = nf_type env sigma (apply codom vn) in
     mkProd(n,dom,codom)
   | Ameta (mv,_) -> mkMeta mv
   | Aproj (p, c) ->
@@ -354,7 +354,7 @@ and nf_atom_type env sigma atom =
       let n = make_annot n r1 in
       let vn = mk_rel_accu (nb_rel env) in
       let env = push_rel (LocalAssum (n,dom)) env in
-      let codom,s2 = nf_type_sort env sigma (codom vn) in
+      let codom,s2 = nf_type_sort env sigma (apply codom vn) in
       mkProd(n,dom,codom), Typeops.type_of_product env n s1 s2
   | Aevar(evk,args) ->
     nf_evar env sigma evk args


### PR DESCRIPTION
This uses morally a single `Obj.magic` to produce a witness `(t, t -> t) eq` for abstract `Nativevalues.t` (in practice 4 `Obj.magic` for varying arities for efficiency reasons, based on looking at generated assembly).

Rectypes is still needed for the generated files as `let Refl = (t_eq : (t, t -> t) eq = ...` only works when rectypes is on.

However if we also deal with the misc uses in coq (constr, logic monad, etc) we should be able to remove -rectypes from the dune flags and only use it when calling ocamlopt for native compile.
