### PR TITLE
Add a staging notion to libobjects

### DIFF
--- a/checker/check.ml
+++ b/checker/check.ml
@@ -280,6 +280,7 @@ type library_objects = lib_objects * lib_objects
 
 type library_disk = {
   md_compiled : Safe_typing.compiled_library;
+  md_syntax_objects : library_objects;
   md_objects : library_objects;
 }
 

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -400,6 +400,8 @@ and v_libobjs = List v_libobjt
 
 let v_libraryobjs = Tuple ("library_objects",[|v_libobjs;v_libobjs|])
 
+let v_librarysyntaxobjs = Tuple ("library_syntax_objects",[|v_libobjs;v_libobjs|])
+
 (** STM objects *)
 
 let v_frozen = Tuple ("frozen", [|List (v_pair Int Dyn); Opt Dyn|])
@@ -431,7 +433,7 @@ let v_libsum =
   Tuple ("summary", [|v_dp;v_deps;String|])
 
 let v_lib =
-  Tuple ("library",[|v_compiled_lib;v_libraryobjs|])
+  Tuple ("library",[|v_compiled_lib;v_librarysyntaxobjs;v_libraryobjs|])
 
 let v_delayed_universes =
   Sum ("delayed_universes", 0, [| [| v_unit |]; [| v_context_set |] |])

--- a/interp/modintern.ml
+++ b/interp/modintern.ml
@@ -24,6 +24,8 @@ exception ModuleInternalizationError of module_internalization_error
 
 type module_kind = Module | ModType | ModAny
 
+type module_struct_expr = (universe_decl_expr option * constr_expr) Declarations.module_alg_expr
+
 let error_not_a_module_loc ~info kind loc qid =
   let e = match kind with
     | Module -> NotAModule qid

--- a/interp/modintern.mli
+++ b/interp/modintern.mli
@@ -34,10 +34,12 @@ exception ModuleInternalizationError of module_internalization_error
 
 type module_kind = Module | ModType | ModAny
 
+type module_struct_expr = (universe_decl_expr option * constr_expr) Declarations.module_alg_expr
+
 (** Module internalization, i.e. from AST to module expression *)
 val intern_module_ast :
-  module_kind -> module_ast -> (universe_decl_expr option * constr_expr) Declarations.module_alg_expr * ModPath.t * module_kind
+  module_kind -> module_ast -> module_struct_expr * ModPath.t * module_kind
 
 (** Module interpretation, i.e. from module expression to typed module entry *)
 val interp_module_ast :
-  env -> module_kind -> ModPath.t -> (universe_decl_expr option * constr_expr) Declarations.module_alg_expr -> module_struct_entry * Univ.ContextSet.t
+  env -> module_kind -> ModPath.t -> module_struct_expr -> module_struct_entry * Univ.ContextSet.t

--- a/library/global.ml
+++ b/library/global.ml
@@ -59,12 +59,12 @@ let globalize f =
 
 let globalize0_with_summary fs f =
   let env = f (safe_env ()) in
-  Summary.unfreeze_summaries fs;
+  Summary.unfreeze_summaries ~partial:true fs;
   GlobalSafeEnv.set_safe_env env
 
 let globalize_with_summary fs f =
   let res,env = f (safe_env ()) in
-  Summary.unfreeze_summaries fs;
+  Summary.unfreeze_summaries ~partial:true fs;
   GlobalSafeEnv.set_safe_env env;
   res
 

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -35,12 +35,6 @@ let prefix_id prefix = snd (Libnames.split_dirpath prefix.Nametab.obj_dir)
 
 type library_segment = (node * Libobject.t list) list
 
-type classified_objects = {
-  substobjs : Libobject.t list;
-  keepobjs : Libobject.t list;
-  anticipateobjs : Libobject.t list;
-}
-
 let module_kind is_type =
   if is_type then "module type" else "module"
 
@@ -77,9 +71,34 @@ let classify_segment seg =
   in
   clean ([],[],[]) (List.rev seg)
 
-let classify_segment seg =
-  let substobjs, keepobjs, anticipateobjs = classify_segment seg in
-  { substobjs; keepobjs; anticipateobjs; }
+let find_entries_p p stk =
+  let rec find = function
+    | [] -> []
+    | (ent,_)::l -> if p ent then ent::find l else find l
+  in
+  find stk
+
+let split_lib_at_opening stk =
+  match stk with
+  | [] -> assert false
+  | (node,leaves) :: rest -> List.rev leaves, node, rest
+
+let is_opening_node = function
+  | OpenedSection _ | OpenedModule _ -> true
+  | CompilingLibrary _ -> false
+
+let open_blocks_message es =
+  let open Pp in
+  let open_block_name = function
+    | OpenedSection (prefix,_) ->
+      str "section " ++ Id.print (prefix_id prefix)
+    | OpenedModule (ty,_,prefix,_) ->
+      str (module_kind ty) ++ spc () ++ Id.print (prefix_id prefix)
+    | _ -> assert false
+  in
+  str "The " ++ pr_enum open_block_name es ++ spc () ++
+  str "need" ++ str (if List.length es == 1 then "s" else "") ++
+  str " to be closed."
 
 (* We keep trace of operations in the stack [lib_stk].
    [path_prefix] is the current path of sections, where sections are stored in
@@ -93,36 +112,114 @@ let initial_prefix = Nametab.{
   obj_mp  = ModPath.initial;
 }
 
-type lib_state = {
-  comp_name   : DirPath.t option;
-  lib_stk     : library_segment;
+type synterp_state = {
+  comp_name : DirPath.t option;
+  lib_stk : library_segment;
   path_prefix : Nametab.object_prefix;
 }
 
-let initial_lib_state = {
-  comp_name   = None;
-  lib_stk     = [];
+let initial = {
+  comp_name = None;
+  lib_stk = [];
   path_prefix = initial_prefix;
 }
 
-let lib_state = ref initial_lib_state
+(** The lib state is split in two components:
+  - The synterp stage state which manages a recording of syntax-related objects and naming-related data (compilation unit name, current prefix).
+  - The interp stage state which manages a recording of regular objects.
+*)
+
+let synterp_state = ref initial
+let interp_state = ref []
+
+let contents () = !synterp_state.lib_stk @ !interp_state
+
+let start_compilation s mp =
+  if !synterp_state.comp_name != None then
+    CErrors.user_err Pp.(str "compilation unit is already started");
+  assert (List.is_empty !synterp_state.lib_stk);
+  assert (List.is_empty !interp_state);
+  if Global.sections_are_opened () then (* XXX not sure if we need this check *)
+    CErrors.user_err Pp.(str "some sections are already opened");
+  let prefix = Nametab.{ obj_dir = s; obj_mp = mp } in
+  let initial_stk = [ CompilingLibrary prefix, [] ] in
+  let st = {
+    comp_name = Some s;
+    path_prefix = prefix;
+    lib_stk = initial_stk;
+  }
+  in
+  synterp_state := st;
+  interp_state := initial_stk
+
+let end_compilation_checks dir =
+  let () = match find_entries_p is_opening_node !interp_state with
+    | [] -> ()
+    | es -> CErrors.user_err (open_blocks_message es) in
+  let () =
+    match !synterp_state.comp_name with
+      | None -> CErrors.anomaly (Pp.str "There should be a module name...")
+      | Some m ->
+          if not (Names.DirPath.equal m dir) then
+            CErrors.anomaly Pp.(str "The current open module has name"
+              ++ spc () ++ DirPath.print m ++ spc () ++ str "and not"
+              ++ spc () ++ DirPath.print m ++ str ".");
+  in
+  ()
+
+  (* State and initialization. *)
+
+  type frozen = {
+    synterp_state : synterp_state;
+    interp_state : library_segment;
+  }
+
+  let freeze () = {
+    synterp_state = !synterp_state;
+    interp_state = !interp_state;
+  }
+
+  let unfreeze st =
+  synterp_state := st.synterp_state;
+  interp_state := st.interp_state
+
+  let drop_objects st =
+    let drop_node = function
+      | CompilingLibrary _ as x -> x
+      | OpenedModule (it,e,op,_) ->
+        OpenedModule(it,e,op,Summary.empty_frozen)
+      | OpenedSection (op, _) ->
+        OpenedSection(op,Summary.empty_frozen)
+    in
+    let lib_synterp_stk = List.map (fun (node,_) -> drop_node node, []) st.synterp_state.lib_stk in
+    let synterp_state = { st.synterp_state with lib_stk = lib_synterp_stk } in
+    let lib_interp_stk = List.map (fun (node,_) -> drop_node node, []) st.interp_state in
+    let interp_state = lib_interp_stk in
+    { synterp_state; interp_state }
+
+  let init () =
+    unfreeze { synterp_state = initial; interp_state = [] };
+    Summary.init_summaries ()
 
 let library_dp () =
-  match !lib_state.comp_name with Some m -> m | None -> Libnames.default_library
+  match !synterp_state.comp_name with Some m -> m | None -> Libnames.default_library
 
 (* [path_prefix] is a pair of absolute dirpath and a pair of current
    module path and relative section path *)
 
-let prefix () = !lib_state.path_prefix
-let cwd () = !lib_state.path_prefix.Nametab.obj_dir
-let current_mp () = !lib_state.path_prefix.Nametab.obj_mp
+let prefix () = !synterp_state.path_prefix
+let cwd () = !synterp_state.path_prefix.Nametab.obj_dir
+let current_mp () = !synterp_state.path_prefix.Nametab.obj_mp
 let current_sections () = Safe_typing.sections_of_safe_env (Global.safe_env())
 
 let sections_depth () = match current_sections() with
   | None -> 0
   | Some sec -> Section.depth sec
 
-let sections_are_opened = Global.sections_are_opened
+let sections_are_opened () =
+  match split_lib_at_opening !synterp_state.lib_stk with
+  | (_, OpenedSection _, _) -> true
+  | _ -> false
 
 let cwd_except_section () =
   Libnames.pop_dirpath_n (sections_depth ()) (cwd ())
@@ -140,163 +237,36 @@ let make_kn id =
   let mp = current_mp () in
   Names.KerName.make mp (Names.Label.of_id id)
 
-let make_foname id = make_oname !lib_state.path_prefix id
-
-let find_entries_p p =
-  let rec find = function
-    | [] -> []
-    | (ent,_)::l -> if p ent then ent::find l else find l
-  in
-  find !lib_state.lib_stk
+let make_foname id = make_oname !synterp_state.path_prefix id
 
 (* Adding operations. *)
-
-let add_entry node =
-  lib_state := { !lib_state with lib_stk = (node,[]) :: !lib_state.lib_stk }
 
 let dummylib = CompilingLibrary
     {Nametab.obj_dir = DirPath.initial;
      Nametab.obj_mp = ModPath.MPfile DirPath.initial;
     }
 
-let add_leaf_entry leaf =
-  let lib_stk = match !lib_state.lib_stk with
-    | [] ->
-      (* top_printers does set_bool_option_value which adds a leaf *)
-      if !Flags.in_debugger then [dummylib, [leaf]] else assert false
-    | (node, leaves) :: rest -> (node, leaf :: leaves) :: rest
-  in
-  lib_state := { !lib_state with lib_stk }
-
-let add_discharged_leaf obj =
-  let newobj = Libobject.rebuild_object obj in
-  Libobject.cache_object (prefix(),newobj);
-  add_leaf_entry (AtomicObject newobj)
-
-let add_leaf obj =
-  Libobject.cache_object (prefix(),obj);
-  add_leaf_entry (AtomicObject obj)
-
-(* Modules. *)
-
-let is_opening_node = function
-  | OpenedSection _ | OpenedModule _ -> true
-  | _ -> false
-
-let start_mod is_type export id mp fs =
-  let dir =
-    Libnames.add_dirpath_suffix (!lib_state.path_prefix.Nametab.obj_dir) id
-  in
-  let prefix = Nametab.{ obj_dir = dir; obj_mp = mp; } in
-  let exists =
-    if is_type then Nametab.exists_cci (make_path id)
-    else Nametab.exists_module dir
-  in
-  if exists then
-    CErrors.user_err Pp.(Id.print id ++ str " already exists.");
-  add_entry (OpenedModule (is_type,export,prefix,fs));
-  lib_state := { !lib_state with path_prefix = prefix} ;
-  prefix
-
-let start_module = start_mod false
-let start_modtype = start_mod true None
-
-let split_lib_at_opening () =
-  match !lib_state.lib_stk with
-  | [] -> assert false
-  | (node,leaves) :: rest -> List.rev leaves, node, rest
-
 let error_still_opened s oname =
   CErrors.user_err Pp.(str "The " ++ str s ++ str " "
     ++ Id.print (prefix_id oname) ++ str " is still opened.")
 
 let recalc_path_prefix () =
-  let path_prefix = match pi2 (split_lib_at_opening ()) with
+  let path_prefix = match pi2 (split_lib_at_opening !synterp_state.lib_stk) with
     | CompilingLibrary dir
     | OpenedModule (_, _, dir, _)
     | OpenedSection (dir, _) -> dir
   in
-  lib_state := { !lib_state with path_prefix }
+  synterp_state := { !synterp_state with path_prefix }
 
 let pop_path_prefix () =
-  let op = !lib_state.path_prefix in
-  lib_state := {
-    !lib_state
+  let op = !synterp_state.path_prefix in
+  synterp_state := {
+    !synterp_state
     with path_prefix = Nametab.{
         op with obj_dir = Libnames.pop_dirpath op.obj_dir;
       } }
 
-let end_mod is_type =
-  let (after,mark,before) = split_lib_at_opening () in
-  (* The errors here should not happen because we checked in the upper layers *)
-  let prefix, fs = match mark with
-    | OpenedModule (ty,_,prefix,fs) ->
-      if ty == is_type then prefix, fs
-      else error_still_opened (module_kind ty) prefix
-    | OpenedSection (prefix, _) -> error_still_opened "section" prefix
-    | CompilingLibrary _ -> CErrors.user_err (Pp.str "No opened modules.")
-  in
-  lib_state := { !lib_state with lib_stk = before };
-  recalc_path_prefix ();
-  let after = classify_segment after in
-  (prefix, fs, after)
-
-let end_module () = end_mod false
-let end_modtype () = end_mod true
-
-let contents () = !lib_state.lib_stk
-
 (* Modules. *)
-
-(* TODO: use check_for_module ? *)
-let start_compilation s mp =
-  if !lib_state.comp_name != None then
-    CErrors.user_err Pp.(str "compilation unit is already started");
-  assert (List.is_empty !lib_state.lib_stk);
-  if Global.sections_are_opened () then (* XXX not sure if we need this check *)
-    CErrors.user_err Pp.(str "some sections are already opened");
-  let prefix = Nametab.{ obj_dir = s; obj_mp = mp } in
-  lib_state := {
-    comp_name = Some s;
-    path_prefix = prefix;
-    lib_stk = [ CompilingLibrary prefix, [] ];
-  }
-
-let open_blocks_message es =
-  let open Pp in
-  let open_block_name = function
-    | OpenedSection (prefix,_) ->
-      str "section " ++ Id.print (prefix_id prefix)
-    | OpenedModule (ty,_,prefix,_) ->
-      str (module_kind ty) ++ spc () ++ Id.print (prefix_id prefix)
-    | _ -> assert false
-  in
-  str "The " ++ pr_enum open_block_name es ++ spc () ++
-  str "need" ++ str (if List.length es == 1 then "s" else "") ++
-  str " to be closed."
-
-let end_compilation_checks dir =
-  let () = match find_entries_p is_opening_node with
-    | [] -> ()
-    | es -> CErrors.user_err (open_blocks_message es) in
-  let () =
-    match !lib_state.comp_name with
-      | None -> CErrors.anomaly (Pp.str "There should be a module name...")
-      | Some m ->
-          if not (Names.DirPath.equal m dir) then
-            CErrors.anomaly Pp.(str "The current open module has name"
-              ++ spc () ++ DirPath.print m ++ spc () ++ str "and not"
-              ++ spc () ++ DirPath.print m ++ str ".");
-  in
-  ()
-
-let end_compilation dir =
-  end_compilation_checks dir;
-  let (after,mark,before) = split_lib_at_opening () in
-  assert (List.is_empty before);
-  lib_state := { !lib_state with comp_name = None };
-  let after = classify_segment after in
-  !lib_state.path_prefix, after
 
 (* Returns true if we are inside an opened module or module type *)
 let is_module_or_modtype () =
@@ -316,20 +286,6 @@ let is_modtype_strict () =
 let is_module () =
   let modules = Safe_typing.module_is_modtype (Global.safe_env ()) in
   List.exists (fun x -> not x) modules
-
-(* Returns the opening node of a given name *)
-let find_opening_node id =
-  let entry = match !lib_state.lib_stk with
-    | [] -> assert false
-    | (CompilingLibrary _, _) :: _ ->
-        CErrors.user_err Pp.(str "There is nothing to end.")
-    | (entry, _) :: _ -> entry
-  in
-  let id' = prefix_id (node_prefix entry) in
-  if not (Names.Id.equal id id') then
-    CErrors.user_err Pp.(str "Last block to end has name "
-      ++ Id.print id' ++ str ".");
-  entry
 
 (* Discharge tables *)
 
@@ -366,68 +322,15 @@ let is_in_section ref = match sections () with
 let section_instance ref =
   Cooking.instance_of_cooking_info (section_segment_of_reference ref)
 
-(*************)
-(* Sections. *)
-let open_section id =
-  let () = Global.open_section () in
-  let opp = !lib_state.path_prefix in
-  let obj_dir = Libnames.add_dirpath_suffix opp.Nametab.obj_dir id in
-  let prefix = Nametab.{ obj_dir; obj_mp = opp.obj_mp; } in
-  if Nametab.exists_dir obj_dir then
-    CErrors.user_err Pp.(Id.print id ++ str " already exists.");
-  let fs = Summary.freeze_summaries ~marshallable:false in
-  add_entry (OpenedSection (prefix, fs));
-  (*Pushed for the lifetime of the section: removed by unfrozing the summary*)
-  Nametab.(push_dir (Until 1) obj_dir (GlobDirRef.DirOpenSection obj_dir));
-  lib_state := { !lib_state with path_prefix = prefix }
-
-(* Restore lib_stk and summaries as before the section opening, and
-   add a ClosedSection object. *)
-
 let discharge_item = Libobject.(function
   | ModuleObject _ | ModuleTypeObject _ | IncludeObject _ | KeepObject _
   | ExportObject _ -> None
   | AtomicObject obj -> discharge_object obj)
 
-let close_section () =
-  let (secdecls,mark,before) = split_lib_at_opening () in
-  let fs = match mark with
-    | OpenedSection (_,fs) -> fs
-    | _ -> CErrors.user_err Pp.(str "No opened section.")
-  in
-  lib_state := { !lib_state with lib_stk = before };
-  pop_path_prefix ();
-  let newdecls = List.map discharge_item secdecls in
-  let () = Global.close_section fs in
-  List.iter (Option.iter add_discharged_leaf) newdecls
-
-(* State and initialization. *)
-
-type frozen = lib_state
-
-let freeze () = !lib_state
-
-let unfreeze st = lib_state := st
-
-let drop_objects st =
-  let drop_node = function
-    | CompilingLibrary _ as x -> x
-    | OpenedModule (it,e,op,_) ->
-      OpenedModule(it,e,op,Summary.empty_frozen)
-    | OpenedSection (op, _) ->
-      OpenedSection(op,Summary.empty_frozen)
-  in
-  let lib_stk = List.map (fun (node,_) -> drop_node node, []) st.lib_stk in
-  { st with lib_stk }
-
-let init () =
-  unfreeze initial_lib_state;
-  Summary.init_summaries ()
-
 (* Misc *)
 
 let mp_of_global = let open GlobRef in function
-  | VarRef id -> !lib_state.path_prefix.Nametab.obj_mp
+  | VarRef id -> !synterp_state.path_prefix.Nametab.obj_mp
   | ConstRef cst -> Names.Constant.modpath cst
   | IndRef ind -> Names.Ind.modpath ind
   | ConstructRef constr -> Names.Construct.modpath constr
@@ -447,3 +350,284 @@ let discharge_proj_repr p =
   let ind = Projection.Repr.inductive p in
   let sec = section_segment_of_reference (GlobRef.IndRef ind) in
   Cooking.discharge_proj_repr sec p
+
+(** The [LibActions] abstraction represent the set of operations on the Lib
+    structure that is specific to a given stage. Two instances are defined below,
+    for Synterp and Interp. *)
+module type LibActions = sig
+
+  val stage : Summary.Stage.t
+  val check_mod_fresh : is_type:bool -> Nametab.object_prefix -> Id.t -> unit
+  val check_section_fresh : DirPath.t -> Id.t -> unit
+  val open_section : Id.t -> unit
+
+  val push_section_name : DirPath.t -> unit
+
+  val close_section : Summary.frozen -> unit
+
+  val add_entry : node -> unit
+  val add_leaf_entry : Libobject.t -> unit
+  val start_mod : is_type:is_type -> export -> Id.t -> ModPath.t -> Summary.frozen -> Nametab.object_prefix
+
+  val get_lib_stk : unit -> library_segment
+  val set_lib_stk : library_segment -> unit
+
+  val pop_path_prefix : unit -> unit
+  val recalc_path_prefix : unit -> unit
+
+end
+
+module SynterpActions : LibActions = struct
+
+  let stage = Summary.Stage.Synterp
+
+  let check_mod_fresh ~is_type prefix id =
+    let exists =
+      if is_type then Nametab.exists_cci (Libnames.make_path prefix.Nametab.obj_dir id)
+      else Nametab.exists_module prefix.Nametab.obj_dir
+    in
+    if exists then
+      CErrors.user_err Pp.(Id.print id ++ str " already exists.")
+
+  let check_section_fresh obj_dir id =
+    if Nametab.exists_dir obj_dir then
+      CErrors.user_err Pp.(Id.print id ++ str " already exists.")
+
+  let push_section_name obj_dir =
+    Nametab.(push_dir (Until 1) obj_dir (GlobDirRef.DirOpenSection obj_dir))
+
+  let close_section fs = Summary.unfreeze_summaries ~partial:true fs
+
+  let add_entry node =
+    synterp_state := { !synterp_state with lib_stk = (node,[]) :: !synterp_state.lib_stk }
+
+  let add_leaf_entry leaf =
+    let lib_stk = match !synterp_state.lib_stk with
+      | [] ->
+        (* top_printers does set_bool_option_value which adds a leaf *)
+        if !Flags.in_debugger then [dummylib, [leaf]] else assert false
+      | (node, leaves) :: rest -> (node, leaf :: leaves) :: rest
+    in
+    synterp_state := { !synterp_state with lib_stk }
+
+  (* Returns the opening node of a given name *)
+  let start_mod ~is_type export id mp fs =
+    let dir = Libnames.add_dirpath_suffix !synterp_state.path_prefix.Nametab.obj_dir id in
+    let prefix = Nametab.{ obj_dir = dir; obj_mp = mp; } in
+    check_mod_fresh ~is_type prefix id;
+    add_entry (OpenedModule (is_type,export,prefix,fs));
+    synterp_state := { !synterp_state with path_prefix = prefix } ;
+    prefix
+
+  let get_lib_stk () =
+    !synterp_state.lib_stk
+
+  let set_lib_stk stk =
+    synterp_state := { !synterp_state with lib_stk = stk }
+
+  let open_section id =
+    let opp = !synterp_state.path_prefix in
+    let obj_dir = Libnames.add_dirpath_suffix opp.Nametab.obj_dir id in
+    let prefix = Nametab.{ obj_dir; obj_mp=opp.obj_mp; } in
+    check_section_fresh obj_dir id;
+    let fs = Summary.freeze_staged_summaries stage ~marshallable:false in
+    add_entry (OpenedSection (prefix, fs));
+    (*Pushed for the lifetime of the section: removed by unfreezing the summary*)
+    push_section_name obj_dir;
+    synterp_state := { !synterp_state with path_prefix = prefix }
+
+  let pop_path_prefix () = pop_path_prefix ()
+  let recalc_path_prefix () = recalc_path_prefix ()
+
+end
+
+module InterpActions : LibActions = struct
+
+  let stage = Summary.Stage.Interp
+
+  let check_mod_fresh ~is_type prefix id = ()
+  let check_section_fresh _ _ = ()
+
+  let push_section_name _ = ()
+  let close_section fs = Global.close_section fs
+
+  let add_entry node =
+    interp_state := (node,[]) :: !interp_state
+
+  let add_leaf_entry leaf =
+    let lib_stk = match !interp_state with
+      | [] ->
+        (* top_printers does set_bool_option_value which adds a leaf *)
+        if !Flags.in_debugger then [dummylib, [leaf]] else assert false
+      | (node, leaves) :: rest -> (node, leaf :: leaves) :: rest
+    in
+    interp_state := lib_stk
+
+  (* Returns the opening node of a given name *)
+  let start_mod ~is_type export id mp fs =
+    let prefix = !synterp_state.path_prefix in
+    add_entry (OpenedModule (is_type,export,prefix,fs));
+    prefix
+
+  let get_lib_stk () =
+    !interp_state
+
+  let set_lib_stk stk =
+    interp_state := stk
+
+  let open_section id =
+    Global.open_section ();
+    let prefix = !synterp_state.path_prefix in
+    let fs = Summary.freeze_staged_summaries stage ~marshallable:false in
+    add_entry (OpenedSection (prefix, fs))
+
+  let pop_path_prefix () = ()
+  let recalc_path_prefix () = ()
+
+end
+
+let add_discharged_leaf obj =
+  let newobj = Libobject.rebuild_object obj in
+  Libobject.cache_object (prefix(),newobj);
+  match Libobject.object_stage newobj with
+  | Summary.Stage.Synterp ->
+    SynterpActions.add_leaf_entry (AtomicObject newobj)
+  | Summary.Stage.Interp ->
+    InterpActions.add_leaf_entry (AtomicObject newobj)
+
+let add_leaf obj =
+  Libobject.cache_object (prefix(),obj);
+  match Libobject.object_stage obj with
+  | Summary.Stage.Synterp ->
+    SynterpActions.add_leaf_entry (AtomicObject obj)
+  | Summary.Stage.Interp ->
+    InterpActions.add_leaf_entry (AtomicObject obj)
+
+module type StagedLibS = sig
+
+  type classified_objects = {
+    substobjs : Libobject.t list;
+    keepobjs : Libobject.t list;
+    anticipateobjs : Libobject.t list;
+  }
+  val classify_segment : Libobject.t list -> classified_objects
+
+  val find_opening_node : Id.t -> node
+
+  val add_entry : node -> unit
+  val add_leaf_entry : Libobject.t -> unit
+
+  (** {6 Sections } *)
+  val open_section : Id.t -> unit
+  val close_section : unit -> unit
+
+  (** {6 Modules and module types } *)
+  val start_module :
+    export -> module_ident -> ModPath.t ->
+    Summary.frozen -> Nametab.object_prefix
+
+  val start_modtype :
+    module_ident -> ModPath.t ->
+    Summary.frozen -> Nametab.object_prefix
+
+  val end_module :
+    unit ->
+    Nametab.object_prefix * Summary.frozen * classified_objects
+
+  val end_modtype :
+    unit ->
+    Nametab.object_prefix * Summary.frozen * classified_objects
+
+end
+
+(** The [StagedLib] abstraction factors out the code dealing with Lib structure
+    that is common to all stages. *)
+module StagedLib(Actions : LibActions) : StagedLibS = struct
+
+type classified_objects = {
+  substobjs : Libobject.t list;
+  keepobjs : Libobject.t list;
+  anticipateobjs : Libobject.t list;
+}
+
+let classify_segment seg =
+  let substobjs, keepobjs, anticipateobjs = classify_segment seg in
+  { substobjs; keepobjs; anticipateobjs; }
+
+let add_entry node = Actions.add_entry node
+let add_leaf_entry obj = Actions.add_leaf_entry obj
+
+let open_section id = Actions.open_section id
+
+let find_opening_node id =
+  let entry = match Actions.get_lib_stk () with
+    | [] -> assert false
+    | (CompilingLibrary _, _) :: _ ->
+        CErrors.user_err Pp.(str "There is nothing to end.")
+    | (entry, _) :: _ -> entry
+  in
+  let id' = prefix_id (node_prefix entry) in
+  if not (Names.Id.equal id id') then
+    CErrors.user_err Pp.(str "Last block to end has name "
+      ++ Id.print id' ++ str ".");
+  entry
+
+let start_module = Actions.start_mod ~is_type:false
+let start_modtype = Actions.start_mod ~is_type:true None
+
+let end_mod ~is_type =
+  let (after,mark,before) = split_lib_at_opening (Actions.get_lib_stk ()) in
+  (* The errors here should not happen because we checked in the upper layers *)
+  let prefix, fs = match mark with
+    | OpenedModule (ty,_,prefix,fs) ->
+      if ty == is_type then prefix, fs
+      else error_still_opened (module_kind ty) prefix
+    | OpenedSection (prefix, _) -> error_still_opened "section" prefix
+    | CompilingLibrary _ -> CErrors.user_err (Pp.str "No opened modules.")
+  in
+  Actions.set_lib_stk before;
+  Actions.recalc_path_prefix ();
+  let after = classify_segment after in
+  (prefix, fs, after)
+
+let end_module () = end_mod ~is_type:false
+let end_modtype () = end_mod ~is_type:true
+
+(* Restore lib_stk and summaries as before the section opening, and
+   add a ClosedSection object. *)
+let close_section () =
+  let (secdecls,mark,before) = split_lib_at_opening (Actions.get_lib_stk ()) in
+  let fs = match mark with
+    | OpenedSection (_,fs) -> fs
+    | _ -> CErrors.user_err Pp.(str "No opened section.")
+  in
+  Actions.set_lib_stk before;
+  Actions.pop_path_prefix ();
+  let newdecls = List.map discharge_item secdecls in
+  Actions.close_section fs;
+  List.iter (Option.iter add_discharged_leaf) newdecls
+
+end
+
+module Synterp : StagedLibS = StagedLib(SynterpActions)
+module Interp : StagedLibS = StagedLib(InterpActions)
+
+let end_compilation dir =
+  end_compilation_checks dir;
+  let (syntax_after,_,syntax_before) = split_lib_at_opening !synterp_state.lib_stk in
+  let (after,_,before) = split_lib_at_opening !interp_state in
+  assert (List.is_empty syntax_before);
+  assert (List.is_empty before);
+  synterp_state := { !synterp_state with comp_name = None };
+  let syntax_after = Synterp.classify_segment syntax_after in
+  let after = Interp.classify_segment after in
+  !synterp_state.path_prefix, after, syntax_after
+
+(** Compatibility layer *)
+let open_section id =
+  Synterp.open_section id;
+  Interp.open_section id
+
+let close_section () =
+  Synterp.close_section ();
+  Interp.close_section ()

--- a/library/libobject.ml
+++ b/library/libobject.ml
@@ -63,6 +63,7 @@ let filter_or f1 f2 = match f1, f2 with
 
 type ('a,'b) object_declaration = {
   object_name : string;
+  object_stage : Summary.Stage.t;
   cache_function : 'b -> unit;
   load_function : int -> 'b -> unit;
   open_function : open_filter -> int -> 'b -> unit;
@@ -74,6 +75,7 @@ type ('a,'b) object_declaration = {
 
 let default_object s = {
   object_name = s;
+  object_stage = Summary.Stage.Interp;
   cache_function = (fun _ -> ());
   load_function = (fun _ _ -> ());
   open_function = (fun _ _ _ -> ());
@@ -143,6 +145,7 @@ let declare_named_object_full odecl =
   let odecl =
     let oname = make_oname in
     { object_name = odecl.object_name;
+      object_stage = odecl.object_stage;
       cache_function = (fun (p, (id, o)) -> odecl.cache_function (oname p id, o));
       load_function = (fun i (p, (id, o)) -> odecl.load_function i (oname p id, o));
       open_function = (fun f i (p, (id, o)) -> odecl.open_function f i (oname p id, o));
@@ -209,6 +212,10 @@ let discharge_object (Dyn.Dyn (tag, v)) =
 let rebuild_object (Dyn.Dyn (tag, v)) =
   let decl = DynMap.find tag !cache_tab in
   Dyn.Dyn (tag, decl.rebuild_function v)
+
+let object_stage (Dyn.Dyn (tag, v)) =
+  let decl = DynMap.find tag !cache_tab in
+  decl.object_stage
 
 let dump = Dyn.dump
 

--- a/library/libobject.mli
+++ b/library/libobject.mli
@@ -76,6 +76,7 @@ type open_filter
 
 type ('a,'b) object_declaration = {
   object_name : string;
+  object_stage : Summary.Stage.t;
   cache_function : 'b -> unit;
   load_function : int -> 'b -> unit;
   open_function : open_filter -> int -> 'b -> unit;
@@ -185,6 +186,7 @@ val subst_object : substitution * obj -> obj
 val classify_object : obj -> substitutivity
 val discharge_object : obj -> obj option
 val rebuild_object : obj -> obj
+val object_stage : obj -> Summary.Stage.t
 
 (** Higher-level API for objects with fixed scope.
 

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -710,6 +710,7 @@ let ltac2_notation_cat = Libobject.create_category "ltac2.notations"
 
 let inTac2Notation : synext -> obj =
   declare_object {(default_object "TAC2-NOTATION") with
+     object_stage = Summary.Stage.Synterp;
      cache_function  = cache_synext;
      open_function   = simple_open ~cat:ltac2_notation_cat open_synext;
      subst_function = subst_synext;
@@ -1111,6 +1112,7 @@ let load_ltac2_init _ () =
 (** Dummy object that register global rules when Require is called *)
 let inTac2Init : unit -> obj =
   declare_object {(default_object "TAC2-INIT") with
+    object_stage = Summary.Stage.Synterp;
     cache_function = cache_ltac2_init;
     load_function = load_ltac2_init;
   }

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -1420,7 +1420,8 @@ let declare_module id args mtys me_l =
   let declare_me fs = match me_l with
     | [] ->
       let mp, args, body, sign = RawModOps.Synterp.declare_module id args mtys None fs in
-      (assert (Option.is_empty body); mp, args, [], sign)
+      assert (Option.is_empty body);
+      mp, args, [], sign
     | [me] ->
       let mp, args, body, sign = RawModOps.Synterp.declare_module id args mtys (Some me) fs in
       mp, args, [Option.get body], sign

--- a/vernac/declaremods.mli
+++ b/vernac/declaremods.mli
@@ -9,6 +9,7 @@
 (************************************************************************)
 
 open Names
+open Modintern
 
 (** {6 Modules } *)
 
@@ -30,6 +31,64 @@ type inline =
 (** Kinds of modules *)
 
 type module_params = (lident list * (Constrexpr.module_ast * inline)) list
+type module_expr = (module_struct_expr * ModPath.t * module_kind * Entries.inline)
+type module_params_expr = (MBId.t list * module_expr) list
+
+(** {6 Libraries i.e. modules on disk } *)
+
+type library_name = DirPath.t
+
+type library_objects
+
+module Synterp : sig
+
+val declare_module :
+  Id.t ->
+  module_params ->
+  (Constrexpr.module_ast * inline) module_signature ->
+  (Constrexpr.module_ast * inline) list ->
+  ModPath.t * module_params_expr * module_expr list * module_expr module_signature
+
+val start_module :
+  Lib.export -> Id.t ->
+  module_params ->
+  (Constrexpr.module_ast * inline) module_signature ->
+    ModPath.t * module_params_expr *
+    (module_struct_expr * ModPath.t * module_kind * Entries.inline) module_signature
+
+val end_module : unit -> ModPath.t
+
+val declare_include :
+  (Constrexpr.module_ast * inline) list ->
+  module_expr list
+
+val declare_modtype :
+  Id.t ->
+  module_params ->
+  (Constrexpr.module_ast * inline) list ->
+  (Constrexpr.module_ast * inline) list ->
+  ModPath.t * module_params_expr * module_expr list * module_expr list
+
+val start_modtype :
+  Id.t ->
+  module_params ->
+  (Constrexpr.module_ast * inline) list ->
+  ModPath.t * module_params_expr * module_expr list
+
+val end_modtype : unit -> ModPath.t
+
+val import_module : Libobject.open_filter -> export:Lib.export_flag -> ModPath.t -> unit
+
+val import_modules : export:Lib.export_flag -> (Libobject.open_filter * ModPath.t) list -> unit
+
+val register_library :
+  library_name ->
+  library_objects ->
+  unit
+
+end
+
+module Interp : sig
 
 (** [declare_module id fargs typ exprs] declares module [id], from
    functor arguments [fargs], with final type [typ].  [exprs] is
@@ -39,18 +98,16 @@ type module_params = (lident list * (Constrexpr.module_ast * inline)) list
 
 val declare_module :
   Id.t ->
-  module_params ->
-  (Constrexpr.module_ast * inline) module_signature ->
-  (Constrexpr.module_ast * inline) list -> ModPath.t
+  module_params_expr ->
+  module_expr module_signature ->
+  module_expr list -> ModPath.t
 
 val start_module :
   Lib.export -> Id.t ->
-  module_params ->
-  (Constrexpr.module_ast * inline) module_signature -> ModPath.t
+  module_params_expr ->
+  (module_struct_expr * ModPath.t * module_kind * Entries.inline) module_signature -> ModPath.t
 
 val end_module : unit -> ModPath.t
-
-
 
 (** {6 Module types } *)
 
@@ -59,37 +116,22 @@ val end_module : unit -> ModPath.t
 
 val declare_modtype :
   Id.t ->
-  module_params ->
-  (Constrexpr.module_ast * inline) list ->
-  (Constrexpr.module_ast * inline) list ->
+  module_params_expr ->
+  (module_struct_expr * ModPath.t * module_kind * Entries.inline) list ->
+  (module_struct_expr * ModPath.t * module_kind * Entries.inline) list ->
   ModPath.t
 
 val start_modtype :
   Id.t ->
-  module_params ->
-  (Constrexpr.module_ast * inline) list -> ModPath.t
+  module_params_expr ->
+  (module_struct_expr * ModPath.t * module_kind * Entries.inline) list -> ModPath.t
 
 val end_modtype : unit -> ModPath.t
-
-(** {6 Libraries i.e. modules on disk } *)
-
-type library_name = DirPath.t
-
-type library_objects
 
 val register_library :
   library_name ->
   Safe_typing.compiled_library -> library_objects -> Safe_typing.vodigest ->
   Univ.ContextSet.t -> unit
-
-val start_library : library_name -> unit
-
-val end_library :
-  output_native_objects:bool -> library_name ->
-    Safe_typing.compiled_library * library_objects * Nativelib.native_library
-
-(** append a function to be executed at end_library *)
-val append_end_library_hook : (unit -> unit) -> unit
 
 (** [import_module export mp] imports the module [mp].
    It modifies Nametab and performs the [open_object] function for
@@ -105,7 +147,19 @@ val import_modules : export:Lib.export_flag -> (Libobject.open_filter * ModPath.
 
 (** Include  *)
 
-val declare_include : (Constrexpr.module_ast * inline) list -> unit
+val declare_include : (module_struct_expr * ModPath.t * module_kind * Entries.inline) list -> unit
+
+end
+
+val start_library : library_name -> unit
+
+val end_library :
+  output_native_objects:bool -> library_name ->
+    Safe_typing.compiled_library * library_objects * library_objects * Nativelib.native_library
+
+(** append a function to be executed at end_library *)
+val append_end_library_hook : (unit -> unit) -> unit
+
 
 (** {6 ... } *)
 
@@ -118,3 +172,41 @@ val debug_print_modtab : unit -> Pp.t
 
 val process_module_binding :
   MBId.t -> (Constr.t * Univ.AbstractContext.t option) Declarations.module_alg_expr -> unit
+
+(** Compatibility layer *)
+
+val import_module : Libobject.open_filter -> export:Lib.export_flag -> ModPath.t -> unit
+
+val declare_module :
+  Id.t ->
+  module_params ->
+  (Constrexpr.module_ast * inline) module_signature ->
+  (Constrexpr.module_ast * inline) list ->
+  ModPath.t
+
+val start_module :
+  Lib.export -> Id.t ->
+  module_params ->
+  (Constrexpr.module_ast * inline) module_signature ->
+    ModPath.t
+
+val end_module : unit -> ModPath.t
+
+val declare_modtype :
+  Id.t ->
+  module_params ->
+  (Constrexpr.module_ast * inline) list ->
+  (Constrexpr.module_ast * inline) list ->
+  ModPath.t
+
+val start_modtype :
+  Id.t ->
+  module_params ->
+  (Constrexpr.module_ast * inline) list ->
+  ModPath.t
+
+val end_modtype : unit -> ModPath.t
+
+val declare_include :
+  (Constrexpr.module_ast * inline) list ->
+  unit

--- a/vernac/declaremods.mli
+++ b/vernac/declaremods.mli
@@ -53,8 +53,7 @@ val start_module :
   Lib.export -> Id.t ->
   module_params ->
   (Constrexpr.module_ast * inline) module_signature ->
-    ModPath.t * module_params_expr *
-    (module_struct_expr * ModPath.t * module_kind * Entries.inline) module_signature
+  ModPath.t * module_params_expr * module_expr module_signature
 
 val end_module : unit -> ModPath.t
 
@@ -81,10 +80,7 @@ val import_module : Libobject.open_filter -> export:Lib.export_flag -> ModPath.t
 
 val import_modules : export:Lib.export_flag -> (Libobject.open_filter * ModPath.t) list -> unit
 
-val register_library :
-  library_name ->
-  library_objects ->
-  unit
+val register_library : library_name -> library_objects -> unit
 
 end
 
@@ -100,12 +96,14 @@ val declare_module :
   Id.t ->
   module_params_expr ->
   module_expr module_signature ->
-  module_expr list -> ModPath.t
+  module_expr list ->
+  ModPath.t
 
 val start_module :
   Lib.export -> Id.t ->
   module_params_expr ->
-  (module_struct_expr * ModPath.t * module_kind * Entries.inline) module_signature -> ModPath.t
+  module_expr module_signature ->
+  ModPath.t
 
 val end_module : unit -> ModPath.t
 
@@ -117,21 +115,23 @@ val end_module : unit -> ModPath.t
 val declare_modtype :
   Id.t ->
   module_params_expr ->
-  (module_struct_expr * ModPath.t * module_kind * Entries.inline) list ->
-  (module_struct_expr * ModPath.t * module_kind * Entries.inline) list ->
+  module_expr list ->
+  module_expr list ->
   ModPath.t
 
 val start_modtype :
   Id.t ->
   module_params_expr ->
-  (module_struct_expr * ModPath.t * module_kind * Entries.inline) list -> ModPath.t
+  module_expr list ->
+  ModPath.t
 
 val end_modtype : unit -> ModPath.t
 
 val register_library :
   library_name ->
   Safe_typing.compiled_library -> library_objects -> Safe_typing.vodigest ->
-  Univ.ContextSet.t -> unit
+  Univ.ContextSet.t ->
+  unit
 
 (** [import_module export mp] imports the module [mp].
    It modifies Nametab and performs the [open_object] function for
@@ -147,7 +147,7 @@ val import_modules : export:Lib.export_flag -> (Libobject.open_filter * ModPath.
 
 (** Include  *)
 
-val declare_include : (module_struct_expr * ModPath.t * module_kind * Entries.inline) list -> unit
+val declare_include : module_expr list -> unit
 
 end
 
@@ -155,7 +155,7 @@ val start_library : library_name -> unit
 
 val end_library :
   output_native_objects:bool -> library_name ->
-    Safe_typing.compiled_library * library_objects * library_objects * Nativelib.native_library
+  Safe_typing.compiled_library * library_objects * library_objects * Nativelib.native_library
 
 (** append a function to be executed at end_library *)
 val append_end_library_hook : (unit -> unit) -> unit
@@ -188,7 +188,7 @@ val start_module :
   Lib.export -> Id.t ->
   module_params ->
   (Constrexpr.module_ast * inline) module_signature ->
-    ModPath.t
+  ModPath.t
 
 val end_module : unit -> ModPath.t
 

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -82,6 +82,7 @@ type compilation_unit_name = DirPath.t
 
 type library_disk = {
   md_compiled : Safe_typing.compiled_library;
+  md_syntax_objects : Declaremods.library_objects;
   md_objects : Declaremods.library_objects;
 }
 
@@ -317,7 +318,10 @@ let native_name_from_filename f =
 
 let register_library m =
   let l = m.library_data in
-  Declaremods.register_library
+  Declaremods.Synterp.register_library
+    m.library_name
+    l.md_syntax_objects;
+  Declaremods.Interp.register_library
     m.library_name
     l.md_compiled
     l.md_objects
@@ -451,7 +455,7 @@ let save_library_to todo_proofs ~output_native_objects dir f =
   let () = assert (not (Future.UUIDSet.is_empty except) ||
     Safe_typing.is_joined_environment (Global.safe_env ()))
   in
-  let cenv, seg, ast = Declaremods.end_library ~output_native_objects dir in
+  let cenv, seg, syntax_seg, ast = Declaremods.end_library ~output_native_objects dir in
   let tasks, utab =
     match todo_proofs with
     | ProofsTodoNone -> None, None
@@ -473,6 +477,7 @@ let save_library_to todo_proofs ~output_native_objects dir f =
   } in
   let md = {
     md_compiled = cenv;
+    md_syntax_objects = syntax_seg;
     md_objects = seg;
   } in
   if Array.exists (fun (d,_) -> DirPath.equal d dir) sd.md_deps then

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -904,6 +904,7 @@ let open_syntax_extension i o =
 let inSyntaxExtension : syntax_extension_obj -> obj =
   declare_object
     {(default_object "SYNTAX-EXTENSION") with
+     object_stage = Summary.Stage.Synterp;
      open_function = simple_open ~cat:notation_cat open_syntax_extension;
      cache_function = cache_syntax_extension;
      subst_function = subst_syntax_extension;
@@ -1925,6 +1926,7 @@ let classify_custom_entry (local,s) =
 
 let inCustomEntry : locality_flag * string -> obj =
   declare_object {(default_object "CUSTOM-ENTRIES") with
+      object_stage = Summary.Stage.Synterp;
       cache_function = cache_custom_entry;
       load_function = load_custom_entry;
       subst_function = subst_custom_entry;

--- a/vernac/mltop.ml
+++ b/vernac/mltop.ml
@@ -412,6 +412,7 @@ let inMLModule : ml_module_object -> Libobject.obj =
   let open Libobject in
   declare_object
     {(default_object "ML-MODULE") with
+      object_stage = Summary.Stage.Synterp;
       cache_function = (fun _ -> ());
       load_function = load_ml_objects;
       subst_function = (fun (_,o) -> o);
@@ -420,7 +421,7 @@ let inMLModule : ml_module_object -> Libobject.obj =
 
 let declare_ml_modules local l =
   let mnames = List.map PluginSpec.of_declare_ml_format l in
-  if Global.sections_are_opened()
+  if Lib.sections_are_opened()
   then CErrors.user_err Pp.(str "Cannot Declare ML Module while sections are opened.");
   (* List.concat_map only available in 4.10 *)
   let mdigests = List.map PluginSpec.digest mnames |> List.concat in

--- a/vernac/printmod.ml
+++ b/vernac/printmod.ml
@@ -214,7 +214,7 @@ let nametab_register_body mp dir (l,body) =
         mib.mind_packets
 
 (* TODO only import printing-relevant objects (or find a way to print without importing) *)
-let import_module = Declaremods.import_module Libobject.unfiltered
+let import_module = Declaremods.Interp.import_module Libobject.unfiltered
 let process_module_binding = Declaremods.process_module_binding
 
 let nametab_register_module_body mp struc =

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1201,7 +1201,8 @@ let interp_import_cats cats =
 (* Assumes cats is irrelevant if f is ImportNames *)
 let import_module_with_filter ~export cats m f =
   match f with
-  | ImportAll -> Declaremods.import_module cats ~export m
+  | ImportAll ->
+    Declaremods.import_module cats ~export m
   | ImportNames ns -> import_names ~export m ns
 
 let check_no_filter_when_using_cats l =
@@ -1339,7 +1340,8 @@ let vernac_include l = Declaremods.declare_include l
 
 let vernac_begin_section ~poly ({v=id} as lid) =
   Dumpglob.dump_definition lid true "sec";
-  Lib.open_section id;
+  Lib.Synterp.open_section id;
+  Lib.Interp.open_section id;
   (* If there was no polymorphism attribute this just sets the option
      to its current value ie noop. *)
   set_bool_option_value_gen ~locality:OptLocal ["Universe"; "Polymorphism"] poly
@@ -1347,7 +1349,8 @@ let vernac_begin_section ~poly ({v=id} as lid) =
 let vernac_end_section {CAst.loc; v} =
   Dumpglob.dump_reference ?loc
     (DirPath.to_string (Lib.current_dirpath true)) "<>" "sec";
-  Lib.close_section ()
+  Lib.Synterp.close_section ();
+  Lib.Interp.close_section ()
 
 let vernac_name_sec_hyp {v=id} set = Proof_using.name_set id set
 
@@ -1363,7 +1366,7 @@ let msg_of_subsection ss id =
   Pp.str kind ++ spc () ++ Id.print id
 
 let vernac_end_segment ~pm ~proof ({v=id} as lid) =
-  let ss = Lib.find_opening_node id in
+  let ss = Lib.Interp.find_opening_node id in
   let what_for = msg_of_subsection ss lid.v in
   if Option.has_some proof then
     CErrors.user_err (Pp.str "Command not supported (Open proofs remain).");


### PR DESCRIPTION
This change is the dual to #16056, where we introduced the same distinction on summaries.

Objects now take a stage at declaration time. We provide two instances of module operations and `Lib` (recording of session objects) maintenance and traversal, one for each stage.

This is a step towards #15409.
