### PR TITLE
Add flag to skip computing diffs for hypotheses

### DIFF
--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -195,14 +195,14 @@ let process_goal short sigma g =
   in
   { Interface.goal_hyp = List.rev hyps; Interface.goal_ccl = ccl; Interface.goal_id = Proof.goal_uid g; Interface.goal_name = name }
 
-let process_goal_diffs diff_goal_map oldp nsigma ng =
+let process_goal_diffs ~short diff_goal_map oldp nsigma ng =
   let env = Global.env () in
   let name = if Printer.print_goal_names () then Some (Names.Id.to_string (Termops.evar_suggested_name env nsigma ng)) else None in
   let og_s = match oldp, diff_goal_map with
   | Some oldp, Some diff_goal_map -> Proof_diffs.map_goal ng diff_goal_map
   | None, _ | _, None -> None
   in
-  let (hyps_pp_list, concl_pp) = Proof_diffs.diff_goal ?og_s (Proof_diffs.make_goal env nsigma ng) in
+  let (hyps_pp_list, concl_pp) = Proof_diffs.diff_goal ~short ?og_s (Proof_diffs.make_goal env nsigma ng) in
   { Interface.goal_hyp = hyps_pp_list; Interface.goal_ccl = concl_pp;
     Interface.goal_id = Proof.goal_uid ng; Interface.goal_name = name }
 
@@ -240,7 +240,7 @@ let subgoals flags =
         | None -> None
         | Some oldp -> Some (Proof_diffs.make_goal_map oldp newp)
         in
-        Some (export_pre_goals flags Proof.(data newp) (process_goal_diffs diff_goal_map oldp))
+        Some (export_pre_goals flags Proof.(data newp) (process_goal_diffs ~short diff_goal_map oldp))
        with Pp_diff.Diff_Failure msg ->
          Proof_diffs.notify_proof_diff_failure msg;
          Some (export_pre_goals flags Proof.(data newp) (process_goal short)))

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -320,13 +320,14 @@ let goal_info goal =
     ( List.rev !line_idents, !map, concl_pp )
   with _ -> ([], !map, Pp.mt ())
 
-let diff_goal_info o_info n_info =
+let diff_goal_info ~short o_info n_info =
   let (o_idents_in_lines, o_hyp_map, o_concl_pp) = o_info in
   let (n_idents_in_lines, n_hyp_map, n_concl_pp) = n_info in
   let show_removed = Some (show_removed ()) in
   let concl_pp = diff_pp_combined ~tokenize_string ?show_removed o_concl_pp n_concl_pp in
 
-  let hyp_diffs_list = diff_hyps o_idents_in_lines o_hyp_map n_idents_in_lines n_hyp_map in
+  let hyp_diffs_list =
+    if short then [] else diff_hyps o_idents_in_lines o_hyp_map n_idents_in_lines n_hyp_map in
   (hyp_diffs_list, concl_pp)
 
 let unwrap g_s =
@@ -334,8 +335,8 @@ let unwrap g_s =
   | Some g_s -> goal_info g_s
   | None -> ([], CString.Map.empty, Pp.mt ())
 
-let diff_goal ?og_s ng =
-  diff_goal_info (unwrap og_s) (goal_info ng)
+let diff_goal ?(short=false) ?og_s ng =
+  diff_goal_info ~short (unwrap og_s) (goal_info ng)
 
 (*** Code to determine which calls to compare between the old and new proofs ***)
 

--- a/printing/proof_diffs.mli
+++ b/printing/proof_diffs.mli
@@ -42,9 +42,14 @@ raise Diff_Failure under some "impossible" conditions.
 
 If you want to make your call especially bulletproof, catch these
 exceptions, print a user-visible message, then recall this routine with
-the first argument set to None, which will skip the diff.
+the second argument ('og_s') set to None, which will skip the diff.
+
+The 'short' flag skips computing the diffs of the hypotheses, which allows the
+Subgoals XML command to fetch just the conclusion of a goal.  This is useful,
+for example, when an IDE only needs to display the number of admitted goals or
+preview the next unsolved goal.
 *)
-val diff_goal : ?og_s:goal -> goal -> Pp.t list * Pp.t
+val diff_goal : ?short:bool -> ?og_s:goal -> goal -> Pp.t list * Pp.t
 
 (** Convert a string to a list of token strings using the lexer *)
 val tokenize_string : string -> string list


### PR DESCRIPTION
Fixes / closes #16564 

This causes the `gf_mode = "short"` flag of the `Subgoals` command to be respected when proof diffs are enabled, which can result in a significant speedup when there are lots of shelved/given up goals. Just setting `hyps_pp_list = []` didn't show much improvement, so instead I forward the flag to `diff_goal` and skip computing the hypothesis diffs entirely.

I'm not sure if this could/should be added to the testsuite, but the example I was using to manually test is:
```coq
Set Diffs "off". (* Have to set in CoqIDE menu *)

Goal True.
Proof.
  do 1000 (assert True by admit); clear.
  idtac. (* Fast before/after changes *)
  auto.  (* Fast before/after changes *)
Abort.

Set Diffs "on". (* Have to set in CoqIDE menu *)

Goal True.
Proof.
  do 1000 (assert True by admit); clear.
  idtac. (* Fast before/after changes *)
  auto.  (* Slow before changes, fast after *)
Abort.
```