### PR TITLE
Fix undefined evars in `case q: T`

### DIFF
--- a/test-suite/bugs/bug_16587.v
+++ b/test-suite/bugs/bug_16587.v
@@ -1,0 +1,9 @@
+Require Import ssreflect.
+Goal True.
+unshelve case q: (S _); auto.
+exact 0.
+Qed.
+Goal True.
+unshelve case: (S _); auto.
+exact 0.
+Qed.


### PR DESCRIPTION
Take the following snippet, that compiles today:
```
Require Import ssreflect.
Goal True.
unshelve case: (S _); auto.
exact 0.
Qed.
```
When adding an equation to this, ssreflect runs into trouble:
```
Require Import ssreflect.
Goal True.
Fail unshelve case q: (S _); auto.
```
This results in an unresolved evars anomaly on 8.16 and `Tried to normalize ill-typed term` on master since #16442 (not sure why this PR started hiding the missing evar issue).

This issue happens because the evar that is substituted for the hole in `S _` is not added to the evar map by ssreflect. This PR remedies this in a rather insane way by just grafting the required evars on top of the evar map. The surrounding code also seems to do some rather crazy evar surgery so maybe this is okay.. :-\