### PR TITLE
[stdlib] some facts for NoDup

### DIFF
--- a/doc/changelog/11-standard-library/16588-NoDup_app_comm.rst
+++ b/doc/changelog/11-standard-library/16588-NoDup_app_comm.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  lemma :g:`not_NoDup` to ``ListDec.v`` and :g:`NoDup_app_remove_l`, :g:`NoDup_app_remove_r` to ``List.v``
+  (`#16588 <https://github.com/coq/coq/pull/16588>`_,
+  by Stefan Haan with a lot of help from Olivier Laurent and Ali Caglayan).

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -2363,6 +2363,20 @@ Section ReDun.
     + now constructor.
   Qed.
 
+  Lemma NoDup_app_remove_l l l' : NoDup (l++l') -> NoDup l'.
+  Proof.
+  induction l as [|a l IHl]; intro H.
+  - exact H.
+  - apply IHl, (NoDup_remove_1 nil _ _ H).
+  Qed.
+
+  Lemma NoDup_app_remove_r l l' : NoDup (l++l') -> NoDup l.
+  Proof.
+  induction l' as [|a l' IHl']; intro H.
+  - now rewrite app_nil_r in H.
+  - apply IHl', (NoDup_remove_1 _ _ _ H).
+  Qed.
+
   Lemma NoDup_rev l : NoDup l -> NoDup (rev l).
   Proof.
     induction l as [|a l IHl]; simpl; intros Hnd; [ constructor | ].

--- a/theories/Lists/ListDec.v
+++ b/theories/Lists/ListDec.v
@@ -49,6 +49,19 @@ Proof using A dec.
      * right. inversion_clear 1. tauto.
 Qed.
 
+Lemma not_NoDup (l: list A):
+    ~ NoDup l -> exists a l1 l2 l3, l = l1++a::l2++a::l3.
+Proof using A dec.
+intro H0. induction l as [|a l IHl].
+- contradiction H0; constructor.
+- destruct (NoDup_decidable l) as [H1|H1].
+  + destruct (In_decidable a l) as [H2|H2].
+    * destruct (in_split _ _ H2) as (l1 & l2 & ->).
+      now exists a, nil, l1, l2.
+    * now contradiction H0; constructor.
+  + destruct (IHl H1) as (b & l1 & l2 & l3 & ->).
+    now exists b, (a::l1), l2, l3.
+Qed.
 
 Lemma NoDup_list_decidable (l:list A) : NoDup l -> forall x y:A, In x l -> In y l -> decidable (x=y).
 Proof using A.


### PR DESCRIPTION
Re-opening of https://github.com/coq/coq/pull/16563 because GitHub does not allow me to rename the source branch for a PR.

This PR adds following lemmata for lists:
* ~`Lemma in_app_comm: forall l l' (a:A), In a (l++l') -> In a (l'++l).`~
* ~`Lemma NoDup_cons_remove l a : NoDup (a::l) -> NoDup l.`~
* ~`Lemma NoDup_app_remove1 l l': NoDup (l++l') -> NoDup l'.`~
* ~`Lemma NoDup_app_remove2 l l': NoDup (l++l') -> NoDup l.`~
* ~`Lemma NoDup_app_comm l l': NoDup (l++l') -> NoDup (l'++l).`~

**EDIT** discussions and merging with #16589 lead to:
* `Lemma NoDup_app_remove_l l l': NoDup (l++l') -> NoDup l'.`
* `Lemma NoDup_app_remove_r l l': NoDup (l++l') -> NoDup l.`
* `Lemma not_NoDup (l: list A): ~ NoDup l -> exists a l1 l2 l3, l = l1++a::l2++a::l3.`