### PR TITLE
[stdlib] add ` ~ NoDup l -> exists a l1 l2 l3, l = l1++a::l2++a::l3`

### DIFF
--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -2355,14 +2355,6 @@ Section ReDun.
   intros. now apply NoDup_remove.
   Qed.
 
-  Lemma NoDup_cons_cons a b (H: a <> b) l:
-    NoDup (a::l) -> NoDup (b::l) -> NoDup (a::b::l).
-  Proof.
-  intros N1 N2. constructor. 2: exact N2.
-  apply not_in_cons. split. 1: exact H.
-  now apply (NoDup_remove_2 nil).
-  Qed.
-
   Theorem NoDup_cons_iff a l:
     NoDup (a::l) <-> ~ In a l /\ NoDup l.
   Proof.
@@ -2390,21 +2382,9 @@ Section ReDun.
     apply filter_In in H; intuition.
   Qed.
 
-  Hypothesis decA: forall x y : A, {x = y} + {x <> y}.
-
-  Lemma dup_cons_in l a:
-    NoDup l -> ~ NoDup (a :: l) -> In a l.
-  Proof using decA.
-  intros. induction l.
-  - exfalso; apply H0. constructor; auto.
-  - cbn. destruct (decA a a0).
-    + left. now symmetry.
-    + right. apply IHl.
-      * apply (NoDup_remove_1 nil l a0). exact H.
-      * intro. apply H0. apply NoDup_cons_cons; assumption.
-  Qed.
-
   (** Effective computation of a list without duplicates *)
+
+  Hypothesis decA: forall x y : A, {x = y} + {x <> y}.
 
   Fixpoint nodup (l : list A) : list A :=
     match l with

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -2355,6 +2355,14 @@ Section ReDun.
   intros. now apply NoDup_remove.
   Qed.
 
+  Lemma NoDup_cons_cons a b (H: a <> b) l:
+    NoDup (a::l) -> NoDup (b::l) -> NoDup (a::b::l).
+  Proof.
+  intros N1 N2. constructor. 2: exact N2.
+  apply not_in_cons. split. 1: exact H.
+  now apply (NoDup_remove_2 nil).
+  Qed.
+
   Theorem NoDup_cons_iff a l:
     NoDup (a::l) <-> ~ In a l /\ NoDup l.
   Proof.
@@ -2382,9 +2390,21 @@ Section ReDun.
     apply filter_In in H; intuition.
   Qed.
 
-  (** Effective computation of a list without duplicates *)
-
   Hypothesis decA: forall x y : A, {x = y} + {x <> y}.
+
+  Lemma dup_cons_in l a:
+    NoDup l -> ~ NoDup (a :: l) -> In a l.
+  Proof using decA.
+  intros. induction l.
+  - exfalso; apply H0. constructor; auto.
+  - cbn. destruct (decA a a0).
+    + left. now symmetry.
+    + right. apply IHl.
+      * apply (NoDup_remove_1 nil l a0). exact H.
+      * intro. apply H0. apply NoDup_cons_cons; assumption.
+  Qed.
+
+  (** Effective computation of a list without duplicates *)
 
   Fixpoint nodup (l : list A) : list A :=
     match l with

--- a/theories/Lists/ListDec.v
+++ b/theories/Lists/ListDec.v
@@ -84,6 +84,21 @@ Proof using A dec.
      * right. inversion_clear 1. tauto.
 Qed.
 
+Lemma not_NoDup (l: list A):
+    ~ NoDup l -> exists a l1 l2 l3, l = l1++a::l2++a::l3.
+Proof using A dec.
+intro H. induction l.
+- exfalso; apply H. constructor.
+- destruct (NoDup_dec l).
+  + assert (In a l) by now apply (dup_cons_in dec).
+    exists a. exists nil. destruct (in_split _ _ H0) as [l2[l3]].
+    exists l2. exists l3. now rewrite H1.
+  + specialize (IHl n). destruct IHl as [b[?l[?l[?l]]]]. exists b.
+    destruct l0 as [|a0 l0].
+    * exists (a::nil). exists l1. exists l2. now rewrite H0.
+    * exists (a::a0::l0). exists l1. exists l2. now rewrite H0.
+Qed.
+
 End Dec_in_Type.
 
 (** An extra result: thanks to decidability, a list can be purged

--- a/theories/Lists/ListDec.v
+++ b/theories/Lists/ListDec.v
@@ -87,16 +87,16 @@ Qed.
 Lemma not_NoDup (l: list A):
     ~ NoDup l -> exists a l1 l2 l3, l = l1++a::l2++a::l3.
 Proof using A dec.
-intro H. induction l.
-- exfalso; apply H. constructor.
-- destruct (NoDup_dec l).
-  + assert (In a l) by now apply (dup_cons_in dec).
-    exists a. exists nil. destruct (in_split _ _ H0) as [l2[l3]].
-    exists l2. exists l3. now rewrite H1.
-  + specialize (IHl n). destruct IHl as [b[?l[?l[?l]]]]. exists b.
-    destruct l0 as [|a0 l0].
-    * exists (a::nil). exists l1. exists l2. now rewrite H0.
-    * exists (a::a0::l0). exists l1. exists l2. now rewrite H0.
+intro H0. induction l.
+- exfalso; apply H0. constructor.
+- destruct (NoDup_dec l) as [H1|H1].
+  + assert (In a l) as H2 by now apply (dup_cons_in dec).
+    destruct (in_split _ _ H2) as (l1 & l2 & ->).
+    now exists a, nil, l1, l2.
+  + specialize (IHl H1). destruct IHl as (b & l1 & l2 & l3 & ->).
+    destruct l1 as [|a1 l1].
+    * now exists b,(a::nil),l2,l3.
+    * now exists b,(a::a1::l1),l2,l3.
 Qed.
 
 End Dec_in_Type.

--- a/theories/Lists/ListDec.v
+++ b/theories/Lists/ListDec.v
@@ -88,7 +88,7 @@ Lemma not_NoDup (l: list A):
     ~ NoDup l -> exists a l1 l2 l3, l = l1++a::l2++a::l3.
 Proof using A dec.
 intro H0. induction l as [|a l IHl].
-- exfalso; apply H0. constructor.
+- contradiction H0; constructor.
 - destruct (NoDup_dec l) as [H1|H1].
   + destruct (In_dec a l) as [H2|H2].
     * destruct (in_split _ _ H2) as (l1 & l2 & ->).

--- a/theories/Lists/ListDec.v
+++ b/theories/Lists/ListDec.v
@@ -87,16 +87,15 @@ Qed.
 Lemma not_NoDup (l: list A):
     ~ NoDup l -> exists a l1 l2 l3, l = l1++a::l2++a::l3.
 Proof using A dec.
-intro H0. induction l.
+intro H0. induction l as [|a l IHl].
 - exfalso; apply H0. constructor.
 - destruct (NoDup_dec l) as [H1|H1].
-  + assert (In a l) as H2 by now apply (dup_cons_in dec).
-    destruct (in_split _ _ H2) as (l1 & l2 & ->).
-    now exists a, nil, l1, l2.
-  + specialize (IHl H1). destruct IHl as (b & l1 & l2 & l3 & ->).
-    destruct l1 as [|a1 l1].
-    * now exists b,(a::nil),l2,l3.
-    * now exists b,(a::a1::l1),l2,l3.
+  + destruct (In_dec a l) as [H2|H2].
+    * destruct (in_split _ _ H2) as (l1 & l2 & ->).
+      now exists a, nil, l1, l2.
+    * now contradiction H0; constructor.
+  + destruct (IHl H1) as (b & l1 & l2 & l3 & ->).
+    now exists b, (a::l1), l2, l3.
 Qed.
 
 End Dec_in_Type.

--- a/theories/Lists/ListDec.v
+++ b/theories/Lists/ListDec.v
@@ -49,6 +49,19 @@ Proof using A dec.
      * right. inversion_clear 1. tauto.
 Qed.
 
+Lemma not_NoDup (l: list A):
+    ~ NoDup l -> exists a l1 l2 l3, l = l1++a::l2++a::l3.
+Proof using A dec.
+intro H0. induction l as [|a l IHl].
+- contradiction H0; constructor.
+- destruct (NoDup_decidable l) as [H1|H1].
+  + destruct (In_decidable a l) as [H2|H2].
+    * destruct (in_split _ _ H2) as (l1 & l2 & ->).
+      now exists a, nil, l1, l2.
+    * now contradiction H0; constructor.
+  + destruct (IHl H1) as (b & l1 & l2 & l3 & ->).
+    now exists b, (a::l1), l2, l3.
+Qed.
 
 Lemma NoDup_list_decidable (l:list A) : NoDup l -> forall x y:A, In x l -> In y l -> decidable (x=y).
 Proof using A.
@@ -82,20 +95,6 @@ Proof using A dec.
    + destruct IH.
      * left. now constructor.
      * right. inversion_clear 1. tauto.
-Qed.
-
-Lemma not_NoDup (l: list A):
-    ~ NoDup l -> exists a l1 l2 l3, l = l1++a::l2++a::l3.
-Proof using A dec.
-intro H0. induction l as [|a l IHl].
-- contradiction H0; constructor.
-- destruct (NoDup_dec l) as [H1|H1].
-  + destruct (In_dec a l) as [H2|H2].
-    * destruct (in_split _ _ H2) as (l1 & l2 & ->).
-      now exists a, nil, l1, l2.
-    * now contradiction H0; constructor.
-  + destruct (IHl H1) as (b & l1 & l2 & l3 & ->).
-    now exists b, (a::l1), l2, l3.
 Qed.
 
 End Dec_in_Type.


### PR DESCRIPTION
I want to contribute following lemma for `NoDup` which might be useful:
* `Lemma not_NoDup (l: list A): ~ NoDup l -> exists a l1 l2 l3, l = l1++a::l2++a::l3.`

It uses following additional lemmata:
* `Lemma NoDup_cons_cons a b (H: a <> b) l: NoDup (a::l) -> NoDup (b::l) -> NoDup (a::b::l).`
* `Lemma dup_cons_in l a:  NoDup l -> ~ NoDup (a :: l) -> In a l.`

The results depend on the decidability of the base type `A` and  `NoDup`.