### PR TITLE
[Experiment] fconstr-aware Type checking

### DIFF
--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -926,18 +926,11 @@ let conv_leq = gen_conv CUMUL
 
 let gen_conv_fconstr cv_pb ?(l2r=false) ?(reds=TransparentState.full) env ?(evars=default_evar_handler) t1 t2 =
   let univs = Environ.universes env in
-  let b =
-    if cv_pb = CUMUL then leq_constr_univs univs t1 (term_of_fconstr t2)
-    else eq_constr_univs univs t1 (term_of_fconstr t2)
-  in
-  if b then ()
-  else
-    let _ = clos_gen_conv reds cv_pb l2r evars env univs (univs, checked_universes) (inject t1) t2 in
-    ()
+  let _ = clos_gen_conv reds cv_pb l2r evars env univs (univs, checked_universes) t1 (inject t2) in
+  ()
 
 let conv_fconstr = gen_conv_fconstr CONV
 let conv_leq_fconstr = gen_conv_fconstr CUMUL
-
 
 let gen_conv_fconstr2 cv_pb ?(l2r=false) ?(reds=TransparentState.full) env ?(evars=default_evar_handler) t1 t2 =
   let univs = Environ.universes env in

--- a/kernel/reduction.mli
+++ b/kernel/reduction.mli
@@ -10,6 +10,7 @@
 
 open Constr
 open Environ
+open CClosure
 
 (***********************************************************************
   s Reduction functions *)
@@ -29,10 +30,13 @@ val nf_betaiota      : env -> constr -> constr
 exception NotConvertible
 
 type 'a kernel_conversion_function = env -> 'a -> 'a -> unit
-type 'a extended_conversion_function =
+
+type ('l,'r) extended_conversion_function_2 =
   ?l2r:bool -> ?reds:TransparentState.t -> env ->
   ?evars:constr evar_handler ->
-  'a -> 'a -> unit
+  'l -> 'r -> unit
+
+type 'a extended_conversion_function = ('a,'a) extended_conversion_function_2
 
 type conv_pb = CONV | CUMUL
 
@@ -69,8 +73,13 @@ val checked_universes : UGraph.t universe_compare
 
 (** These two functions can only raise NotConvertible *)
 val conv : constr extended_conversion_function
+val conv_fconstr : (constr, fconstr) extended_conversion_function_2
 
 val conv_leq : types extended_conversion_function
+val conv_leq_fconstr2 : (fconstr, fconstr) extended_conversion_function_2
+val conv_leq_fconstr : (types, fconstr) extended_conversion_function_2
+
+
 
 (** Depending on the universe state functions, this might raise
   [UniverseInconsistency] in addition to [NotConvertible] (for better error

--- a/kernel/reduction.mli
+++ b/kernel/reduction.mli
@@ -73,11 +73,11 @@ val checked_universes : UGraph.t universe_compare
 
 (** These two functions can only raise NotConvertible *)
 val conv : constr extended_conversion_function
-val conv_fconstr : (constr, fconstr) extended_conversion_function_2
+val conv_fconstr : (fconstr, types) extended_conversion_function_2
 
 val conv_leq : types extended_conversion_function
+val conv_leq_fconstr : (fconstr, types) extended_conversion_function_2
 val conv_leq_fconstr2 : (fconstr, fconstr) extended_conversion_function_2
-val conv_leq_fconstr : (types, fconstr) extended_conversion_function_2
 
 
 

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -200,6 +200,12 @@ let type_of_apply env func funt argsv (argstv : CClosure.fconstr array) =
       | FProd (_, c1, c2, e) ->
         let arg = argsv.(i) in
         let argt = argstv.(i) in
+        (* it is necessary to copy [c1] to avoid retaining reduction when
+           type checking in [c2]. this is currently implemented by converting
+           to [constr] and back, but it would be nicer if we could retain
+           some of the sharing that exists in [c1]. This would require a
+           [copy_fconstr] function.
+         *)
         let c1 = term_of_fconstr c1 in
         begin match conv_leq_fconstr env argt c1 with (* << checks that the type of the argument is compatible with the type of the binder *)
         | () -> apply_rec (i+1) (mk_clos (CClosure.usubs_cons (inject arg) e) c2)

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -200,10 +200,10 @@ let type_of_apply env func funt argsv (argstv : CClosure.fconstr array) =
       | FProd (_, c1, c2, e) ->
         let arg = argsv.(i) in
         let argt = argstv.(i) in
-        begin match conv_leq_fconstr2 env argt c1 with (* << checks that the type of the argument is compatible with the type of the binder *)
+        let c1 = term_of_fconstr c1 in
+        begin match conv_leq_fconstr env argt c1 with (* << checks that the type of the argument is compatible with the type of the binder *)
         | () -> apply_rec (i+1) (mk_clos (CClosure.usubs_cons (inject arg) e) c2)
         | exception NotConvertible ->
-          let c1 = term_of_fconstr c1 in
           error_cant_apply_bad_type env
             (i+1,c1,term_of_fconstr argt)
             (make_judge func (CClosure.term_of_fconstr funt))
@@ -708,7 +708,7 @@ let dest_judgev v =
 
 let judge_of_apply env funj argjv =
   let args, argtys = dest_judgev argjv in
-  let typ = type_of_apply env funj.uj_val funj.uj_type args (Array.map CClosure.inject argtys) in
+  let typ = type_of_apply env funj.uj_val (CClosure.inject funj.uj_type) args (Array.map CClosure.inject argtys) in
   make_judge (mkApp (funj.uj_val, args)) (CClosure.term_of_fconstr typ)
 
 (* let judge_of_abstraction env x varj bodyj = *)


### PR DESCRIPTION
This PR is an experiment to see if there is any (performance) benefit to exposing the fact that type checking some expressions naturally produces an `fconstr`. For example, when type checking `foo (bar baz)`, the current type checker constructs an `fconstr` for the type of `bar baz`, converts it to a `constr` and then converts it back to an `fconstr` to see if it is compatible with the argument of `foo`. This PR avoids this round-trip.

This is related to https://github.com/coq/coq/pull/16497.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.