### PR TITLE
Tactical `only` is at level 3, print it as such

### DIFF
--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -1031,7 +1031,7 @@ let pr_goal_selector ~toplevel s =
               keyword "solve" ++ spc () ++ pr_seq_body (pr_tac ltop) tl, llet
             | TacComplete t ->
               pr_tac (LevelLe lcomplete) t, lcomplete
-            | TacSelect (s, tac) -> pr_goal_selector ~toplevel:false s ++ spc () ++ pr_tac ltop tac, latom
+            | TacSelect (s, tac) -> pr_goal_selector ~toplevel:false s ++ spc () ++ pr_tac ltop tac, ltactical
             | TacId l ->
               keyword "idtac" ++ prlist (pr_arg (pr_message_token pr.pr_name)) l, latom
             | TacAtom t ->

--- a/test-suite/output/bug_16596.out
+++ b/test-suite/output/bug_16596.out
@@ -1,0 +1,1 @@
+Ltac t := unshelve (only 1: idtac)

--- a/test-suite/output/bug_16596.v
+++ b/test-suite/output/bug_16596.v
@@ -1,0 +1,2 @@
+Ltac t := unshelve (only 1: idtac).
+Print t.


### PR DESCRIPTION
Testcase:
```
Ltac t := unshelve (only 1: idtac).
Print t.
(* Used to print unshelve only 1: idtac *)
```
Note that `only 1: idtac` needs to be in parentheses because `unshelve` is at level 1, which is probably not ideal either...