### PR TITLE
Allow undefined evars when converting to `Constr.t` in `congruence`

### DIFF
--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -153,12 +153,12 @@ let patterns_of_constr b env sigma nrels term =
             if not (Int.equal (Int.Set.cardinal rels1) nrels) then Creates_variables
             else if has_open_head patt1 then Creates_variables (* consider open head as variable-creating *)
             else if non_trivial patt1 then Normal
-            else Trivial (EConstr.to_constr sigma args.(0))
+            else Trivial (EConstr.to_constr ~abort_on_undefined_evars:false sigma args.(0))
           and valid2 =
             if not (Int.equal (Int.Set.cardinal rels2) nrels) then Creates_variables
             else if has_open_head patt2 then Creates_variables (* consider open head as variable-creating *)
             else if non_trivial patt2 then Normal
-            else Trivial (EConstr.to_constr sigma args.(0)) in
+            else Trivial (EConstr.to_constr ~abort_on_undefined_evars:false sigma args.(0)) in
             if valid1 != Creates_variables
               || valid2 != Creates_variables  then
               nrels,valid1,patt1,valid2,patt2

--- a/test-suite/bugs/bug_16597.v
+++ b/test-suite/bugs/bug_16597.v
@@ -1,0 +1,4 @@
+Goal exists A, forall (H : forall b : A, b = b), True.
+eexists. intro.
+try congruence. (* Used to fail with Anomaly "in econstr: grounding a non evar-free term" *)
+Abort.


### PR DESCRIPTION
Testcase:
```
Goal exists A, forall (H : forall b : A, b = b), True.
eexists. intro.
try congruence. (* Used to fail with Anomaly "in econstr: grounding a non evar-free term" *)
Abort.
```