### PR TITLE
Disable most CI jobs by default.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -205,6 +205,9 @@ before_script:
     when: always
   needs:
     - build:base
+  only: &full-ci
+    variables:
+      - $FULL_CI == "true"
 
 .ci-template-flambda:
   extends: .ci-template
@@ -237,9 +240,7 @@ build:base+32bit:
     OPAM_VARIANT: "+32bit"
     COQ_EXTRA_CONF: "-native-compiler yes"
     COQIDE: "no"
-  only: &full-ci
-    variables:
-      - $FULL_CI == "true"
+  only: *full-ci
 
 build:edge+flambda:
   extends: .build-template


### PR DESCRIPTION
Because of GitLab drastically reducing the CI minutes available to us.

One can run a full pipeline by setting FULL_CI to true.

Context: https://coq.zulipchat.com/#narrow/stream/237656-Coq-devs-.26-plugin-devs/topic/Too.20many.20pipelines/near/302078588

Note that we could also have chosen a solution similar to the `SKIP_DOCKER` one, that would require manually setting a variable in the GitLab settings.