### PR TITLE
Disable even more jobs when FULL_CI is not set to true.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -248,6 +248,7 @@ build:edge+flambda:
     OPAM_SWITCH: edge
     OPAM_VARIANT: "+flambda"
     COQ_EXTRA_CONF: "-native-compiler yes"
+  only: *full-ci
 
 build:edge+flambda:dev:
   extends: .build-template:dev
@@ -263,7 +264,7 @@ build:base+async:
   allow_failure: true # See https://github.com/coq/coq/issues/9658
   only:
     variables:
-      - $UNRELIABLE =~ /enabled/
+      - $UNRELIABLE =~ /enabled/ && $FULL_CI == "true"
   artifacts:
     when: always
     paths:
@@ -537,7 +538,7 @@ test-suite:base+async:
   allow_failure: true
   only:
     variables:
-      - $UNRELIABLE =~ /enabled/
+      - $UNRELIABLE =~ /enabled/ && $FULL_CI == "true"
 
 validate:base:
   extends: .validate-template


### PR DESCRIPTION
Following a suggestion of @ppedrot, completed by noticing that some base jobs are not useful if none of the ci-* jobs are run.

On top of #16600: I'm opening this as a separate PR, because I don't think this justifies delaying merging #16600.