### PR TITLE
Fix capitalization for macos in GitHub action

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   macOS:
-    runs-on: macOS-11
+    runs-on: macos-11
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
For now GitHub converts it for us, but we might as well be correct.

I was able to see this was an issue since my YAML linter complained that macOS didn't appear in the GitHub YAML schema.