### PR TITLE
Fix problems with `destruct using`

### DIFF
--- a/doc/changelog/05-Ltac-language/16605-fix-destruct-using.rst
+++ b/doc/changelog/05-Ltac-language/16605-fix-destruct-using.rst
@@ -1,0 +1,4 @@
+- **Fixed:**
+  Make the behavior of `destruct .. using ..` more powerful and more similar to `destruct ..`
+  (`#16605 <https://github.com/coq/coq/pull/16605>`_,
+  by Lasse Blaauwbroek).

--- a/pretyping/tacred.mli
+++ b/pretyping/tacred.mli
@@ -106,12 +106,14 @@ val reduce_to_quantified_ind : env ->  evar_map -> types -> (inductive * EInstan
 val eval_to_quantified_ind : env -> evar_map -> types -> (inductive * EInstance.t)
 
 (** [reduce_to_quantified_ref env sigma ref t] try to put [t] in the form
-   [t'=(x1:A1)..(xn:An)(ref args)] and fails with user error if not possible *)
+    [t'=(x1:A1)..(xn:An)(ref args)]. When this is not possible, if [allow_failure]
+    is specified, [t] is unfolded until the point where this impossibility is plainly
+    visible. Otherwise, it fails with user error. *)
 val reduce_to_quantified_ref :
-  env ->  evar_map -> GlobRef.t -> types -> types
+  ?allow_failure:bool -> env ->  evar_map -> GlobRef.t -> types -> types
 
 val reduce_to_atomic_ref :
-  env ->  evar_map -> GlobRef.t -> types -> types
+  ?allow_failure:bool -> env ->  evar_map -> GlobRef.t -> types -> types
 
 val find_hnf_rectype :
   env ->  evar_map -> types -> (inductive * EInstance.t) * constr list

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -4610,7 +4610,7 @@ let use_bindings env sigma elim must_be_closed (c,lbind) typ =
       match scheme.indref with
       | None -> error CannotFindInductiveArgument
       | Some indref ->
-        Tacred.reduce_to_quantified_ref env sigma indref typ
+        Tacred.reduce_to_quantified_ref ~allow_failure:true env sigma indref typ
   in
   let rec find_clause typ =
     try

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -3483,13 +3483,11 @@ let atomize_param_of_ind_then (indref,nparams,_) hyp0 tac =
   let env = Proofview.Goal.env gl in
   let sigma = Tacmach.project gl in
   let tmptyp0 = Tacmach.pf_get_hyp_typ hyp0 gl in
-  let reduce_to_quantified_ref = Tacmach.pf_apply reduce_to_quantified_ref gl in
-  let typ0 = reduce_to_quantified_ref indref tmptyp0 in
-  let prods, indtyp = decompose_prod_assum sigma typ0 in
+  let reduce_to_atomic_ref = Tacmach.pf_apply reduce_to_atomic_ref gl in
+  let indtyp = reduce_to_atomic_ref indref tmptyp0 in
   let hd,argl = decompose_app sigma indtyp in
-  let env' = push_rel_context prods env in
   let params = List.firstn nparams argl in
-  let params' = List.map (expand_projections env' sigma) params in
+  let params' = List.map (expand_projections env sigma) params in
   (* le gl est important pour ne pas préévaluer *)
   let rec atomize_one i args args' avoid =
     if Int.equal i nparams then
@@ -3507,7 +3505,7 @@ let atomize_param_of_ind_then (indref,nparams,_) hyp0 tac =
                current environment so that it is clearable after destruction *)
             atomize_one (i-1) (c::args) (c::args') (Id.Set.add id avoid)
         | _ ->
-           let c' = expand_projections env' sigma c in
+           let c' = expand_projections env sigma c in
             let dependent t = dependent sigma c t in
             if List.exists dependent params' ||
                List.exists dependent args'

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -4591,17 +4591,6 @@ let clear_unselected_context id inhyps cls =
   | None -> Proofview.tclUNIT ()
   end
 
-let splay_prod_until env sigma glb =
-  let rec decrec env m t =
-    if EConstr.isRefX sigma glb t then m, t else
-      let t = whd_all env sigma t in
-      match EConstr.kind sigma t with
-      | Prod (n,a,c0) ->
-        decrec (push_rel (LocalAssum (n,a)) env) ((n,a)::m) c0
-      | _ -> m,t
-  in
-  decrec env []
-
 let use_bindings env sigma elim must_be_closed (c,lbind) typ =
   let typ =
     (* Normalize [typ] until the induction reference becomes plainly visible *)
@@ -4621,7 +4610,7 @@ let use_bindings env sigma elim must_be_closed (c,lbind) typ =
       match scheme.indref with
       | None -> error CannotFindInductiveArgument
       | Some indref ->
-        let sign,t = splay_prod_until env sigma indref typ in it_mkProd t sign
+        Tacred.reduce_to_quantified_ref env sigma indref typ
   in
   let rec find_clause typ =
     try

--- a/test-suite/bugs/bug_16605.v
+++ b/test-suite/bugs/bug_16605.v
@@ -3,3 +3,18 @@ Definition test2 := forall x, test x.
 Lemma t (H : test2) : True.
 edestruct H using test_rect.
 Abort.
+
+(* Testcase derived from an earlier coq-corn failure *)
+Definition existsC :=
+ fun P : unit -> Prop => False.
+
+Lemma ex_ind2 : forall (P : unit -> Prop) (Q:Prop), existsC P -> Q.
+Proof.
+intros. destruct H.
+Qed.
+
+Goal (existsC (fun x => True)) -> True.
+Proof.
+intros.
+destruct (H) using ex_ind2. (* parenthesis around (H) are intentional *)
+Qed.

--- a/test-suite/bugs/bug_16605.v
+++ b/test-suite/bugs/bug_16605.v
@@ -1,0 +1,5 @@
+Inductive test : unit -> Prop :=.
+Definition test2 := forall x, test x.
+Lemma t (H : test2) : True.
+edestruct H using test_rect.
+Abort.


### PR DESCRIPTION
This consists of two parts:

### Remove broken code-path in product param atomization of `destruct`

`Tactics.atomize_param_of_ind_then` thinks that it has the ability to atomize
parameters inside of products. This code-path is at least partially broken.
I also believe that there is no way to exercise this code-path in a
non-trivial way that does not generate anomalies. (In other words: I think it is
dead code.) Hence we remove it.

Testcase:
```
Inductive test : unit -> Prop :=.
Definition test2 := forall x, test x.
Lemma t (H : test2) : True.
edestruct H using test_rect.
Abort.
(* Used to error with:
Unbound reference: In environment
H, t : test2
The reference 1 is free.

Now errors with:
Not an inductive definition.
*)
```

### Equalize behavior between `destruct` and `destruct using`

Let `X` be an inductive. Then one would expect `destruct H` and `destruct H
using X_rect` to behave identically (`H` being an appropriate term).

Currently this is not the case however:
```
Inductive test : unit -> Prop :=.
Definition test2 := forall x, test x.
Lemma t (H : test2) : True.
Fail edestruct H using test_rect.
edestruct H.
Abort.
```

The issue is that `edestruct using` fails to normalize the type of `H` enough.
We fix this by using `Tacred.reduce_to_quantified_ref` to reduce `H` (and a a `allow_failure` mode to this function).