### PR TITLE
Test suite: disable native compile for SchemeEquality

### DIFF
--- a/test-suite/success/SchemeEquality.v
+++ b/test-suite/success/SchemeEquality.v
@@ -1,3 +1,4 @@
+(* -*- coq-prog-args: ("-native-compiler" "no"); -*- *)
 (* Examples of use of Scheme Equality *)
 
 Module A.


### PR DESCRIPTION
Considering https://gitlab.com/coq/coq/-/jobs/3124630634 it is probably why it kept hanging.
