### PR TITLE
Add a separator to unsupported-attributes message

### DIFF
--- a/test-suite/output/bug_16613.out
+++ b/test-suite/output/bug_16613.out
@@ -1,0 +1,3 @@
+File "./output/bug_16613.v", line 2, characters 2-10:
+Warning: This command does not support these attributes: bar, foo.
+[unsupported-attributes,parsing]

--- a/test-suite/output/bug_16613.v
+++ b/test-suite/output/bug_16613.v
@@ -1,0 +1,2 @@
+Set Warnings "unsupported-attributes".
+#[foo, bar] Definition foo := I.

--- a/vernac/attributes.ml
+++ b/vernac/attributes.ml
@@ -39,7 +39,7 @@ let warn_unsupported_attributes =
        let keys = List.map (fun x -> fst x.CAst.v) atts in
        let keys = List.sort_uniq String.compare keys in
        let conj = match keys with [_] -> "this attribute: " | _ -> "these attributes: " in
-       Pp.(str "This command does not support " ++ str conj ++ prlist str keys ++ str"."))
+       Pp.(str "This command does not support " ++ str conj ++ prlist_with_sep (fun () -> strbrk ", ") str keys ++ str"."))
 
 let unsupported_attributes = function
   | [] -> ()


### PR DESCRIPTION
Fixes #16613

- [x] Added / updated **test-suite**.
- [ ] Added **changelog**. (not needed?)

<strike>(I haven't yet tested this locally)</strike>
