### PR TITLE
Ltac2 constr_kind correctly cast evars

### DIFF
--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -510,7 +510,7 @@ let () = define1 "constr_kind" constr begin fun c ->
   | Evar (evk, args) ->
     let args = Evd.expand_existential sigma (evk, args) in
     v_blk 3 [|
-      Value.of_int (Evar.repr evk);
+      Value.of_evar evk;
       Value.of_array Value.of_constr (Array.of_list args);
     |]
   | Sort s ->

--- a/test-suite/bugs/bug_16617.v
+++ b/test-suite/bugs/bug_16617.v
@@ -1,0 +1,12 @@
+Require Import Ltac2.Ltac2.
+Import Constr.Unsafe.
+Goal True.
+  let e := '_ in
+  let ev := match kind e with
+            | Evar e _ => e
+            | _ => Control.throw (Tactic_failure None)
+            end in
+  let t := Constr.type e in
+  unify $t bool;
+  Control.new_goal ev > [ exact I | exact true ].
+Qed.


### PR DESCRIPTION
Fix #16617

Bug since d141cb39d8b27a8744582c1b3fb050ee43bb3e8f (https://github.com/coq/coq/pull/16373)
