### PR TITLE
[vernac] duplicate extra dep is a warning

### DIFF
--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -761,7 +761,7 @@ follows:
 
    Adds an additional dependency of the current `.v`  file on an external file.  This
    information is included in the ``coqdep`` tool generated list of dependencies.
-   The file name :n:`@string` must exist relative to only one of the top directories
+   The file name :n:`@string` must exist relative to one of the top directories
    associated with :n:`@dirpath`.  :n:`@string` can include directory separators
    (``/``) to select a file in a subdirectory.
    Path elements in :n:`@string` must be valid Coq identifiers, e.g. they cannot
@@ -774,6 +774,12 @@ in a plugin, to access the full path of the external file via the API
 This command has been available through the :cmd:`Comments` command,
 e.g. :n:`Comments From … Dependency …`.  The :n:`Comments` form is deprecated
 in Coq 8.16.
+
+.. warn:: File ... found twice in ...
+
+   The file is found in more than once in the top directories
+   associated to the given :n:`@dirpath`. In this case the first occurrence
+   is selected.
 
 .. _backtracking_subsection:
 

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -775,11 +775,11 @@ This command has been available through the :cmd:`Comments` command,
 e.g. :n:`Comments From … Dependency …`.  The :n:`Comments` form is deprecated
 in Coq 8.16.
 
-.. warn:: File ... found twice in ...
+   .. warn:: File ... found twice in ...
 
-   The file is found in more than once in the top directories
-   associated to the given :n:`@dirpath`. In this case the first occurrence
-   is selected.
+      The file is found in more than once in the top directories
+      associated with the given :n:`@dirpath`. In this case the first occurrence
+      is selected.
 
 .. _backtracking_subsection:
 

--- a/test-suite/success/extra_dep.v
+++ b/test-suite/success/extra_dep.v
@@ -8,5 +8,6 @@ Fail From TestSuite Extra Dependency "extra_dep.txt" as d1.
 From TestSuite Extra Dependency "extra_dep.txt" as d2.
 
 Add LoadPath "prerequisite/subdir" as TestSuite.
+Set Warnings "+ambiguous-extra-dep".
 Fail From TestSuite Extra Dependency "extra_dep.txt".
 Fail Comments From TestSuite Extra Dependency "extra_dep.txt".

--- a/vernac/comExtraDeps.ml
+++ b/vernac/comExtraDeps.ml
@@ -11,7 +11,14 @@
 open Names
 open CErrors
 
-let rec ensure_only_one_path_contains from file acc = function
+let warn_file_found_multiple_times =
+  CWarnings.create ~name:"ambiguous-extra-dep" ~category:"filesystem"
+    (fun (file,from,other,extra) ->
+      Pp.(str "File " ++ str file ++ str " found twice in " ++
+      DirPath.print from ++ str":" ++ spc () ++ str other ++ str " (selected)," ++
+      spc() ++ str extra ++ str ".") )
+
+let rec first_path_containing ?loc from file acc = function
   | [] ->
       begin match acc with
       | Some x -> x
@@ -23,13 +30,12 @@ let rec ensure_only_one_path_contains from file acc = function
       let abspath = x ^ "/" ^ file in
       if Sys.file_exists abspath then begin
         match acc with
-        | None -> ensure_only_one_path_contains from file (Some abspath) xs
+        | None -> first_path_containing ?loc from file (Some abspath) xs
         | Some other ->
-            user_err Pp.(str "File " ++ str file ++ str " found twice in " ++
-              DirPath.print from ++ str":" ++ spc () ++ str other ++ str "," ++
-              spc() ++ str abspath ++ str ".")
+            warn_file_found_multiple_times ?loc (file,from,other,abspath);
+            first_path_containing ?loc from file acc xs
       end else
-        ensure_only_one_path_contains from file acc xs
+        first_path_containing ?loc from file acc xs
 
 let extra_deps = Summary.ref ~name:"extra_deps" Id.Map.empty
 
@@ -45,7 +51,7 @@ let declare_extra_dep ?loc ~from ~file id =
   match Loadpath.find_with_logical_path from with
   | _ :: _ as paths ->
     let paths = List.map Loadpath.physical paths in
-    let file_path = ensure_only_one_path_contains from file None paths in
+    let file_path = first_path_containing ?loc from file None paths in
     Option.iter (bind_extra_dep ?loc file_path) id
   | [] -> user_err Pp.(str "No LoadPath found for " ++ DirPath.print from ++ str".")
 

--- a/vernac/loadpath.mli
+++ b/vernac/loadpath.mli
@@ -43,6 +43,10 @@ val find_load_path : CUnix.physical_path -> t
 val find_with_logical_path : Names.DirPath.t -> t list
 (** get the list of load paths that correspond to a given logical path *)
 
+val find_extra_dep_with_logical_path :
+  ?loc:Loc.t -> from:Names.DirPath.t -> file:string -> unit -> CUnix.physical_path
+(** finds a file rooted in from. @raise UserError if the file is not found *)
+
 val locate_file : string -> string
 (** Locate a file among the registered paths. Do not use this function, as
     it does not respect the visibility of paths. *)


### PR DESCRIPTION
Before this patch the system would error if an Extra Dependency was found twice.
Unfortunately this is the case if the extra file is installed system wide, and you are compiling the same project.
AFAIK this affects only Coq-Elpi.

CC 8.16 RM @ppedrot since this may go (but not motivate) a minor release.