### PR TITLE
Add `skipn_skipn`

### DIFF
--- a/doc/changelog/11-standard-library/16632-patch-1.rst
+++ b/doc/changelog/11-standard-library/16632-patch-1.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  the `skipn_skipn` lemma in `Lists/List.v`
+  (`#16632 <https://github.com/coq/coq/pull/16632>`_,
+  by Stephan Boyer).

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -2114,6 +2114,15 @@ Section Cutting.
     now rewrite skipn_firstn_comm, L.
   Qed.
 
+  Lemma skipn_skipn : forall x y l, skipn x (skipn y l) = skipn (x + y) l.
+  Proof.
+    intros x y. rewrite Nat.add_comm. induction y as [|y IHy].
+    - reflexivity.
+    - intros [|].
+      + now rewrite skipn_nil.
+      + now rewrite skipn_cons, IHy.
+  Qed.
+
   Lemma firstn_skipn : forall n l, firstn n l ++ skipn n l = l.
   Proof.
     intro n; induction n.


### PR DESCRIPTION
The standard library has a lemma called `firstn_firstn`, but no analogous lemma for `skipn`. I found myself needing this little fact in one of my recent developments: `skipn x (skipn y l) = skipn (x + y) l`.