### PR TITLE
Change ltac2 value representation to reuse ocaml values

### DIFF
--- a/plugins/ltac2/tac2dyn.ml
+++ b/plugins/ltac2/tac2dyn.ml
@@ -25,5 +25,3 @@ struct
   type _ pack = Pack : ('raw, 'glb) M.t -> ('raw * 'glb) pack
   include Arg.Map(struct type 'a t = 'a pack end)
 end
-
-module Val = Dyn.Make(struct end)

--- a/plugins/ltac2/tac2dyn.mli
+++ b/plugins/ltac2/tac2dyn.mli
@@ -31,6 +31,3 @@ sig
   val find : ('a, 'b) Arg.tag -> t -> ('a * 'b) pack
   val mem : ('a, 'b) Arg.tag -> t -> bool
 end
-
-module Val : Dyn.S
-(** Toplevel values *)

--- a/plugins/ltac2/tac2expr.mli
+++ b/plugins/ltac2/tac2expr.mli
@@ -215,8 +215,6 @@ type strexpr =
     base cases, namely closures, strings, named constructors, and dynamic type
     coming from the Coq implementation. *)
 
-type tag = int
-
 type frame =
 | FrLtac of ltac_constant
 | FrAnon of glb_tacexpr

--- a/plugins/ltac2/tac2extffi.ml
+++ b/plugins/ltac2/tac2extffi.ml
@@ -9,34 +9,11 @@
 (************************************************************************)
 
 open Tac2ffi
-open Tac2types
-
-module Value = Tac2ffi
-
-(** Make a representation with a dummy from function *)
-let make_to_repr f = Tac2ffi.make_repr (fun _ -> assert false) f
 
 (** More ML representations *)
 
-let to_qhyp v = match Value.to_block v with
-| (0, [| i |]) -> AnonHyp (Value.to_int i)
-| (1, [| id |]) -> NamedHyp (CAst.make (Value.to_ident id))
-| _ -> assert false
+let qhyp = magic_repr ()
 
-let qhyp = make_to_repr to_qhyp
+let bindings = magic_repr ()
 
-let to_bindings = function
-| ValInt 0 -> NoBindings
-| ValBlk (0, [| vl |]) ->
-  ImplicitBindings (Value.to_list Value.to_constr vl)
-| ValBlk (1, [| vl |]) ->
-  ExplicitBindings ((Value.to_list (fun p -> to_pair to_qhyp Value.to_constr p) vl))
-| _ -> assert false
-
-let bindings = make_to_repr to_bindings
-
-let to_constr_with_bindings v = match Value.to_tuple v with
-| [| c; bnd |] -> (Value.to_constr c, to_bindings bnd)
-| _ -> assert false
-
-let constr_with_bindings = make_to_repr to_constr_with_bindings
+let constr_with_bindings = magic_repr ()

--- a/plugins/ltac2/tac2ffi.ml
+++ b/plugins/ltac2/tac2ffi.ml
@@ -11,7 +11,6 @@
 open Util
 open Names
 open Tac2dyn
-open Tac2expr
 open Proofview.Notations
 
 type ('a, _) arity0 =
@@ -21,7 +20,7 @@ type ('a, _) arity0 =
 type valexpr =
 | ValInt of int
   (** Immediate integers *)
-| ValBlk of tag * valexpr array
+| ValBlk of int * valexpr array
   (** Structured blocks *)
 | ValStr of Bytes.t
   (** Strings *)

--- a/plugins/ltac2/tac2ffi.ml
+++ b/plugins/ltac2/tac2ffi.ml
@@ -76,13 +76,12 @@ end
 type 'a repr = {
   r_of : 'a -> valexpr;
   r_to : valexpr -> 'a;
-  r_id : bool;
 }
 
 let repr_of r x = r.r_of x
 let repr_to r x = r.r_to x
 
-let make_repr r_of r_to = { r_of; r_to; r_id = false; }
+let make_repr r_of r_to = { r_of; r_to; }
 
 let map_repr f g r = {
   r_of = (fun x -> r.r_of (g x));
@@ -127,7 +126,6 @@ exception LtacError of KerName.t * valexpr array
 let valexpr = {
   r_of = (fun obj -> obj);
   r_to = (fun obj -> obj);
-  r_id = true;
 }
 
 let of_unit () = ValInt 0
@@ -139,7 +137,6 @@ let to_unit = function
 let unit = {
   r_of = of_unit;
   r_to = to_unit;
-  r_id = false;
 }
 
 let of_int n = ValInt n
@@ -150,7 +147,6 @@ let to_int = function
 let int = {
   r_of = of_int;
   r_to = to_int;
-  r_id = false;
 }
 
 let of_bool b = if b then ValInt 0 else ValInt 1
@@ -163,7 +159,6 @@ let to_bool = function
 let bool = {
   r_of = of_bool;
   r_to = to_bool;
-  r_id = false;
 }
 
 let of_char n = ValInt (Char.code n)
@@ -174,7 +169,6 @@ let to_char = function
 let char = {
   r_of = of_char;
   r_to = to_char;
-  r_id = false;
 }
 
 let of_bytes s = ValStr s
@@ -193,7 +187,6 @@ let to_string s = Bytes.to_string (to_bytes s)
 let string = {
   r_of = of_string;
   r_to = to_string;
-  r_id = false;
 }
 
 let rec of_list f = function
@@ -208,7 +201,6 @@ let rec to_list f = function
 let list r = {
   r_of = (fun l -> of_list r.r_of l);
   r_to = (fun l -> to_list r.r_to l);
-  r_id = false;
 }
 
 let of_closure cls = ValCls cls
@@ -220,7 +212,6 @@ let to_closure = function
 let closure = {
   r_of = of_closure;
   r_to = to_closure;
-  r_id = false;
 }
 
 let of_ext tag c =
@@ -233,7 +224,6 @@ let to_ext tag = function
 let repr_ext tag = {
   r_of = (fun e -> of_ext tag e);
   r_to = (fun e -> to_ext tag e);
-  r_id = false;
 }
 
 let of_constr c = of_ext val_constr c
@@ -275,7 +265,6 @@ let to_exn c = match c with
 let exn = {
   r_of = of_exn;
   r_to = to_exn;
-  r_id = false;
 }
 
 let of_option f = function
@@ -290,7 +279,6 @@ let to_option f = function
 let option r = {
   r_of = (fun l -> of_option r.r_of l);
   r_to = (fun l -> to_option r.r_to l);
-  r_id = false;
 }
 
 let of_pp c = of_ext val_pp c
@@ -309,7 +297,6 @@ let to_pair f g = function
 let pair r0 r1 = {
   r_of = (fun p -> of_pair r0.r_of r1.r_of p);
   r_to = (fun p -> to_pair r0.r_to r1.r_to p);
-  r_id = false;
 }
 
 let of_triple f g h (x, y, z) = ValBlk (0, [|f x; g y; h z|])
@@ -329,7 +316,6 @@ let to_array f = function
 let array r = {
   r_of = (fun l -> of_array r.r_of l);
   r_to = (fun l -> to_array r.r_to l);
-  r_id = false;
 }
 
 let of_block (n, args) = ValBlk (n, args)
@@ -340,7 +326,6 @@ let to_block = function
 let block = {
   r_of = of_block;
   r_to = to_block;
-  r_id = false;
 }
 
 let of_open (kn, args) = ValOpn (kn, args)
@@ -352,7 +337,6 @@ let to_open = function
 let open_ = {
   r_of = of_open;
   r_to = to_open;
-  r_id = false;
 }
 
 let of_uint63 n = ValUint63 n
@@ -363,7 +347,6 @@ let to_uint63 = function
 let uint63 = {
   r_of = of_uint63;
   r_to = to_uint63;
-  r_id = false;
 }
 
 let of_float f = ValFloat f
@@ -374,7 +357,6 @@ let to_float = function
 let float = {
   r_of = of_float;
   r_to = to_float;
-  r_id = false;
 }
 
 let of_constant c = of_ext val_constant c
@@ -397,7 +379,6 @@ let to_reference = let open GlobRef in function
 let reference = {
   r_of = of_reference;
   r_to = to_reference;
-  r_id = false;
 }
 
 type ('a, 'b) fun1 = closure

--- a/plugins/ltac2/tac2ffi.ml
+++ b/plugins/ltac2/tac2ffi.ml
@@ -10,32 +10,15 @@
 
 open Util
 open Names
-open Tac2dyn
 open Proofview.Notations
 
 type ('a, _) arity0 =
 | OneAty : ('a, 'a -> 'a Proofview.tactic) arity0
 | AddAty : ('a, 'b) arity0 -> ('a, 'a -> 'b) arity0
 
-type valexpr =
-| ValInt of int
-  (** Immediate integers *)
-| ValBlk of int * valexpr array
-  (** Structured blocks *)
-| ValStr of Bytes.t
-  (** Strings *)
-| ValCls of closure
-  (** Closures *)
-| ValOpn of KerName.t * valexpr array
-  (** Open constructors *)
-| ValExt : 'a Tac2dyn.Val.tag * 'a -> valexpr
-  (** Arbitrary data *)
-| ValUint63 of Uint63.t
-  (** Primitive integers *)
-| ValFloat of Float64.t
-  (** Primitive floats *)
+type valexpr = Obj.t
 
-and closure = MLTactic : (valexpr, 'v) arity0 * 'v -> closure
+type closure = MLTactic : (valexpr, 'v) arity0 * 'v -> closure
 
 let arity_one = OneAty
 let arity_suc a = AddAty a
@@ -49,73 +32,69 @@ struct
 
 type t = valexpr
 
-let is_int = function
-| ValInt _ -> true
-| ValBlk _ | ValStr _ | ValCls _ | ValOpn _ | ValExt _ | ValUint63 _ | ValFloat _ -> false
+let is_int = Obj.is_int
 
-let tag v = match v with
-| ValBlk (n, _) -> n
-| ValInt _ | ValStr _ | ValCls _ | ValOpn _ | ValExt _ | ValUint63 _ | ValFloat _ ->
-  CErrors.anomaly (Pp.str "Unexpected value shape")
+let tag = Obj.tag
 
-let field v n = match v with
-| ValBlk (_, v) -> v.(n)
-| ValInt _ | ValStr _ | ValCls _ | ValOpn _ | ValExt _ | ValUint63 _ | ValFloat _ ->
-  CErrors.anomaly (Pp.str "Unexpected value shape")
+let field = Obj.field
 
-let set_field v n w = match v with
-| ValBlk (_, v) -> v.(n) <- w
-| ValInt _ | ValStr _ | ValCls _ | ValOpn _ | ValExt _ | ValUint63 _ | ValFloat _ ->
-  CErrors.anomaly (Pp.str "Unexpected value shape")
+let fields v = Array.init (Obj.size v) (fun i -> Obj.field v i)
 
-let make_block tag v = ValBlk (tag, v)
-let make_int n = ValInt n
+let set_field = Obj.set_field
+
+let make_block tag v =
+  let o = Obj.new_block tag (Array.length v) in
+  Array.iteri (fun i v -> Obj.set_field o i v) v;
+  o
+
+let make_int n = Obj.repr (n:int)
 
 end
 
-type 'a repr = {
-  r_of : 'a -> valexpr;
-  r_to : valexpr -> 'a;
-}
+type 'a repr =
+  | Id : valexpr repr
+  | Functions of {
+      r_of : 'a -> valexpr;
+      r_to : valexpr -> 'a;
+    }
 
-let repr_of r x = r.r_of x
-let repr_to r x = r.r_to x
+let repr_of (type a) (r:a repr) (x:a) : valexpr = match r with
+  | Id -> x
+  | Functions { r_of } -> r_of x
+let repr_to (type a) (r:a repr) (x:valexpr) : a = match r with
+  | Id -> x
+  | Functions { r_to } -> r_to x
 
-let make_repr r_of r_to = { r_of; r_to; }
+let make_repr r_of r_to = Functions { r_of; r_to; }
 
-let map_repr f g r = {
-  r_of = (fun x -> r.r_of (g x));
-  r_to = (fun x -> f (r.r_to x));
-  r_id = false;
+let magic_repr () : _ repr = Obj.magic Id
+
+let map_repr f g r = Functions {
+  r_of = (fun x -> repr_of r (g x));
+  r_to = (fun x -> f (repr_to r x));
 }
 
 (** Dynamic tags *)
 
-let val_exn = Val.create "exn"
-let val_constr = Val.create "constr"
-let val_ident = Val.create "ident"
-let val_pattern = Val.create "pattern"
-let val_preterm = Val.create "preterm"
-let val_matching_context = Val.create "matching_context"
-let val_pp = Val.create "pp"
-let val_evar = Val.create "evar"
-let val_sort = Val.create "sort"
-let val_cast = Val.create "cast"
-let val_inductive = Val.create "inductive"
-let val_constant = Val.create "constant"
-let val_constructor = Val.create "constructor"
-let val_projection = Val.create "projection"
-let val_case = Val.create "case"
-let val_binder = Val.create "binder"
-let val_univ = Val.create "universe"
-let val_free : Names.Id.Set.t Val.tag = Val.create "free"
-let val_ltac1 : Geninterp.Val.t Val.tag = Val.create "ltac1"
-let val_ind_data : (Names.Ind.t * Declarations.mutual_inductive_body) Val.tag = Val.create "ind_data"
-
-let extract_val (type a) (type b) (tag : a Val.tag) (tag' : b Val.tag) (v : b) : a =
-match Val.eq tag tag' with
-| None -> assert false
-| Some Refl -> v
+let constr = magic_repr ()
+let ident = magic_repr ()
+let pattern = magic_repr ()
+let preterm = magic_repr ()
+let matching_context = magic_repr ()
+let pp = magic_repr ()
+let evar = magic_repr ()
+let sort = magic_repr ()
+let cast = magic_repr ()
+let inductive = magic_repr ()
+let constant = magic_repr ()
+let constructor = magic_repr ()
+let projection = magic_repr ()
+let case = magic_repr ()
+let binder = magic_repr ()
+let univ = magic_repr ()
+let free : Names.Id.Set.t repr = magic_repr ()
+let ltac1 : Geninterp.Val.t repr = magic_repr ()
+let ind_data : (Names.Ind.t * Declarations.mutual_inductive_body) repr = magic_repr ()
 
 (** Exception *)
 
@@ -123,124 +102,61 @@ exception LtacError of KerName.t * valexpr array
 
 (** Conversion functions *)
 
-let valexpr = {
-  r_of = (fun obj -> obj);
-  r_to = (fun obj -> obj);
-}
+let valexpr = Id
 
-let of_unit () = ValInt 0
+let unit : unit repr = magic_repr ()
+let of_unit = repr_of unit
+let to_unit = repr_to unit
 
-let to_unit = function
-| ValInt 0 -> ()
-| _ -> assert false
+let int : int repr = magic_repr ()
+let of_int = repr_of int
+let to_int = repr_to int
 
-let unit = {
-  r_of = of_unit;
-  r_to = to_unit;
-}
+let bool : bool repr = magic_repr ()
+let of_bool = repr_of bool
+let to_bool = repr_to bool
 
-let of_int n = ValInt n
-let to_int = function
-| ValInt n -> n
-| _ -> assert false
+let char : char repr = magic_repr ()
+let of_char = repr_of char
+let to_char = repr_to char
 
-let int = {
-  r_of = of_int;
-  r_to = to_int;
-}
+let bytes : Bytes.t repr = magic_repr ()
+let of_bytes = repr_of bytes
+let to_bytes = repr_to bytes
 
-let of_bool b = if b then ValInt 0 else ValInt 1
+let string = map_repr String.of_bytes String.to_bytes bytes
+let of_string = repr_of string
+let to_string = repr_to string
 
-let to_bool = function
-| ValInt 0 -> true
-| ValInt 1 -> false
-| _ -> assert false
+let of_list (f:_ -> valexpr) l = Obj.repr (List.map f l)
+let to_list (f:valexpr -> _) l = List.map f (Obj.magic l : valexpr list)
 
-let bool = {
-  r_of = of_bool;
-  r_to = to_bool;
-}
+let list (type a) (r:a repr) : a list repr = match r with
+  | Id -> magic_repr ()
+  | Functions { r_of; r_to } ->
+    Functions { r_of = (fun l -> of_list r_of l);
+                r_to = (fun l -> to_list r_to l);
+              }
 
-let of_char n = ValInt (Char.code n)
-let to_char = function
-| ValInt n -> Char.chr n
-| _ -> assert false
+let closure : closure repr = magic_repr ()
+let of_closure = repr_of closure
+let to_closure = repr_to closure
 
-let char = {
-  r_of = of_char;
-  r_to = to_char;
-}
+let of_constr c = repr_of constr c
+let to_constr c = repr_to constr c
 
-let of_bytes s = ValStr s
-let to_bytes = function
-| ValStr s -> s
-| _ -> assert false
+let of_ident c = repr_of ident c
+let to_ident c = repr_to ident c
 
-let bytes = {
-  r_of = of_bytes;
-  r_to = to_bytes;
-  r_id = false;
-}
+let of_pattern c = repr_of pattern c
+let to_pattern c = repr_to pattern c
 
-let of_string s = of_bytes (Bytes.of_string s)
-let to_string s = Bytes.to_string (to_bytes s)
-let string = {
-  r_of = of_string;
-  r_to = to_string;
-}
+let of_evar ev = repr_of evar ev
+let to_evar ev = repr_to evar ev
 
-let rec of_list f = function
-| [] -> ValInt 0
-| x :: l -> ValBlk (0, [| f x; of_list f l |])
-
-let rec to_list f = function
-| ValInt 0 -> []
-| ValBlk (0, [|v; vl|]) -> f v :: to_list f vl
-| _ -> assert false
-
-let list r = {
-  r_of = (fun l -> of_list r.r_of l);
-  r_to = (fun l -> to_list r.r_to l);
-}
-
-let of_closure cls = ValCls cls
-
-let to_closure = function
-| ValCls cls -> cls
-| ValExt _ | ValInt _ | ValBlk _ | ValStr _ | ValOpn _ | ValUint63 _ | ValFloat _ -> assert false
-
-let closure = {
-  r_of = of_closure;
-  r_to = to_closure;
-}
-
-let of_ext tag c =
-  ValExt (tag, c)
-
-let to_ext tag = function
-| ValExt (tag', e) -> extract_val tag tag' e
-| _ -> assert false
-
-let repr_ext tag = {
-  r_of = (fun e -> of_ext tag e);
-  r_to = (fun e -> to_ext tag e);
-}
-
-let of_constr c = of_ext val_constr c
-let to_constr c = to_ext val_constr c
-let constr = repr_ext val_constr
-
-let of_ident c = of_ext val_ident c
-let to_ident c = to_ext val_ident c
-let ident = repr_ext val_ident
-
-let of_pattern c = of_ext val_pattern c
-let to_pattern c = to_ext val_pattern c
-let pattern = repr_ext val_pattern
-
-let of_evar ev = of_ext val_evar ev
-let to_evar ev = to_ext val_evar ev
-let evar = repr_ext val_evar
+let open_ : (KerName.t * valexpr array) repr = magic_repr ()
+let of_open = repr_of open_
+let to_open = repr_to open_
 
 let internal_err =
   let open Names in
@@ -251,135 +167,85 @@ let internal_err =
 
 (** FIXME: handle backtrace in Ltac2 exceptions *)
 let of_exn c = match fst c with
-| LtacError (kn, c) -> ValOpn (kn, c)
-| _ -> ValOpn (internal_err, [|of_ext val_exn c|])
+| LtacError (kn, c) -> of_open (kn, c)
+| _ -> of_open (internal_err, [|Obj.magic c|])
 
-let to_exn c = match c with
-| ValOpn (kn, c) ->
+let to_exn c =
+  let (kn, c) = to_open c in
   if Names.KerName.equal kn internal_err then
-    to_ext val_exn c.(0)
+    Obj.magic c.(0)
   else
     (LtacError (kn, c), Exninfo.null)
-| _ -> assert false
 
-let exn = {
-  r_of = of_exn;
-  r_to = to_exn;
-}
+let exn = make_repr of_exn to_exn
 
-let of_option f = function
-| None -> ValInt 0
-| Some c -> ValBlk (0, [|f c|])
+let of_option f o = Obj.repr (Option.map f o)
+let to_option f o = Option.map f (Obj.magic o : valexpr option)
 
-let to_option f = function
-| ValInt 0 -> None
-| ValBlk (0, [|c|]) -> Some (f c)
-| _ -> assert false
+let option (type a) (r:a repr) : a option repr = match r with
+  | Id -> magic_repr ()
+  | Functions { r_of; r_to } ->
+    Functions { r_of = (fun l -> of_option r_of l);
+                r_to = (fun l -> to_option r_to l);
+              }
 
-let option r = {
-  r_of = (fun l -> of_option r.r_of l);
-  r_to = (fun l -> to_option r.r_to l);
-}
+let of_pp c = repr_of pp c
+let to_pp c = repr_to pp c
 
-let of_pp c = of_ext val_pp c
-let to_pp c = to_ext val_pp c
-let pp = repr_ext val_pp
+let of_tuple cl = Valexpr.make_block 0 cl
+let to_tuple v = Valexpr.fields v
 
-let of_tuple cl = ValBlk (0, cl)
-let to_tuple = function
-| ValBlk (0, cl) -> cl
-| _ -> assert false
+let of_pair f g (x, y) = Obj.repr (f x, g y)
+let to_pair f g p =
+  let (x, y : valexpr * valexpr) = Obj.magic p in
+  f x, g y
 
-let of_pair f g (x, y) = ValBlk (0, [|f x; g y|])
-let to_pair f g = function
-| ValBlk (0, [|x; y|]) -> (f x, g y)
-| _ -> assert false
-let pair r0 r1 = {
-  r_of = (fun p -> of_pair r0.r_of r1.r_of p);
-  r_to = (fun p -> to_pair r0.r_to r1.r_to p);
-}
+let pair (type a b) (r0:a repr) (r1:b repr) : (a * b) repr = match r0, r1 with
+  | Id, Id -> magic_repr ()
+  | _ -> make_repr (of_pair (repr_of r0) (repr_of r1)) (to_pair (repr_to r0) (repr_to r1))
 
-let of_triple f g h (x, y, z) = ValBlk (0, [|f x; g y; h z|])
-let to_triple f g h = function
-| ValBlk (0, [|x; y; z|]) -> (f x, g y, h z)
-| _ -> assert false
-let triple r0 r1 r2 = {
-  r_of = (fun p -> of_triple r0.r_of r1.r_of r2.r_of p);
-  r_to = (fun p -> to_triple r0.r_to r1.r_to r2.r_to p);
-  r_id = false;
-}
+let of_triple f g h (x, y, z) = Obj.repr (f x, g y, h z)
+let to_triple f g h p =
+  let (x, y, z : valexpr * valexpr * valexpr) = Obj.magic p in
+  f x, g y, h z
 
-let of_array f vl = ValBlk (0, Array.map f vl)
-let to_array f = function
-| ValBlk (0, vl) -> Array.map f vl
-| _ -> assert false
-let array r = {
-  r_of = (fun l -> of_array r.r_of l);
-  r_to = (fun l -> to_array r.r_to l);
-}
+let triple (type a b c) (r0:a repr) (r1:b repr) (r2:c repr) : (a * b * c) repr = match r0, r1, r2 with
+  | Id, Id, Id -> magic_repr ()
+  | _ -> make_repr (of_triple (repr_of r0) (repr_of r1) (repr_of r2))
+           (to_triple (repr_to r0) (repr_to r1) (repr_to r2))
 
-let of_block (n, args) = ValBlk (n, args)
-let to_block = function
-| ValBlk (n, args) -> (n, args)
-| _ -> assert false
+let of_array (f:_ -> valexpr) l = Obj.repr (Array.map f l)
+let to_array (f:valexpr -> _) l = Array.map f (Obj.magic l : valexpr array)
 
-let block = {
+let array (type a) (r:a repr) : a array repr = match r with
+  | Id -> magic_repr ()
+  | Functions { r_of; r_to } ->
+    Functions { r_of = (fun l -> of_array r_of l);
+                r_to = (fun l -> to_array r_to l);
+              }
+
+let of_block (n, args) = Valexpr.make_block n args
+let to_block v = Obj.tag v, Valexpr.fields v
+
+let block = Functions {
   r_of = of_block;
   r_to = to_block;
 }
 
-let of_open (kn, args) = ValOpn (kn, args)
+let uint63 : Uint63.t repr = magic_repr ()
+let of_uint63 = repr_of uint63
+let to_uint63 = repr_to uint63
 
-let to_open = function
-| ValOpn (kn, args) -> (kn, args)
-| _ -> assert false
+let float : Float64.t repr = magic_repr ()
+let of_float = repr_of float
+let to_float = repr_to float
 
-let open_ = {
-  r_of = of_open;
-  r_to = to_open;
-}
+let of_constant c = repr_of constant c
+let to_constant c = repr_to constant c
 
-let of_uint63 n = ValUint63 n
-let to_uint63 = function
-| ValUint63 n -> n
-| _ -> assert false
-
-let uint63 = {
-  r_of = of_uint63;
-  r_to = to_uint63;
-}
-
-let of_float f = ValFloat f
-let to_float = function
-| ValFloat f -> f
-| _ -> assert false
-
-let float = {
-  r_of = of_float;
-  r_to = to_float;
-}
-
-let of_constant c = of_ext val_constant c
-let to_constant c = to_ext val_constant c
-let constant = repr_ext val_constant
-
-let of_reference = let open GlobRef in function
-| VarRef id -> ValBlk (0, [| of_ident id |])
-| ConstRef cst -> ValBlk (1, [| of_constant cst |])
-| IndRef ind -> ValBlk (2, [| of_ext val_inductive ind |])
-| ConstructRef cstr -> ValBlk (3, [| of_ext val_constructor cstr |])
-
-let to_reference = let open GlobRef in function
-| ValBlk (0, [| id |]) -> VarRef (to_ident id)
-| ValBlk (1, [| cst |]) -> ConstRef (to_constant cst)
-| ValBlk (2, [| ind |]) -> IndRef (to_ext val_inductive ind)
-| ValBlk (3, [| cstr |]) -> ConstructRef (to_ext val_constructor cstr)
-| _ -> assert false
-
-let reference = {
-  r_of = of_reference;
-  r_to = to_reference;
-}
+let reference : GlobRef.t repr = magic_repr ()
+let of_reference = repr_of reference
+let to_reference = repr_to reference
 
 type ('a, 'b) fun1 = closure
 
@@ -388,7 +254,7 @@ let to_fun1 r0 r1 f = to_closure f
 
 let rec apply : type a. a arity -> a -> valexpr list -> valexpr Proofview.tactic =
   fun arity f args -> match args, arity with
-  | [], arity -> Proofview.tclUNIT (ValCls (MLTactic (arity, f)))
+  | [], arity -> Proofview.tclUNIT (of_closure (MLTactic (arity, f)))
   (* A few hardcoded cases for efficiency *)
   | [a0], OneAty -> f a0
   | [a0; a1], AddAty OneAty -> f a0 a1
@@ -419,4 +285,4 @@ let abstract n f =
   MLTactic (arity, f [])
 
 let app_fun1 cls r0 r1 x =
-  apply cls [r0.r_of x] >>= fun v -> Proofview.tclUNIT (r1.r_to v)
+  apply cls [repr_of r0 x] >>= fun v -> Proofview.tclUNIT (repr_to r1 v)

--- a/plugins/ltac2/tac2ffi.mli
+++ b/plugins/ltac2/tac2ffi.mli
@@ -11,7 +11,6 @@
 open Names
 open EConstr
 open Tac2dyn
-open Tac2expr
 
 (** {5 Toplevel values} *)
 
@@ -20,7 +19,7 @@ type closure
 type valexpr =
 | ValInt of int
   (** Immediate integers *)
-| ValBlk of tag * valexpr array
+| ValBlk of int * valexpr array
   (** Structured blocks *)
 | ValStr of Bytes.t
   (** Strings *)

--- a/plugins/ltac2/tac2intern.ml
+++ b/plugins/ltac2/tac2intern.ml
@@ -1145,7 +1145,8 @@ let rec intern_rec env {loc;v=e} = match e with
   let (e2, t2) = intern_rec env e2 in
   let () = unify ?loc env t (GTypRef (Other t_bool, [])) in
   let () = unify ?loc:loc1 env t1 t2 in
-  (GTacCse (e, Other t_bool, [|e1; e2|], [||]), t2)
+  (* bool = false | true *)
+  (GTacCse (e, Other t_bool, [|e2; e1|], [||]), t2)
 | CTacCse (e, pl) ->
   let e,brs,rt = intern_case env loc e pl in
   begin try

--- a/plugins/ltac2/tac2print.ml
+++ b/plugins/ltac2/tac2print.ml
@@ -561,7 +561,7 @@ let () = register_init "constr" begin fun env sigma c ->
 end
 
 let () = register_init "preterm" begin fun env sigma c ->
-  let c = to_ext val_preterm c in
+  let c = repr_to preterm c in
   let c = try Printer.pr_closed_glob_env env sigma c with _ -> str "..." in
   str "preterm:(" ++ c ++ str ")"
 end
@@ -577,7 +577,7 @@ let () = register_init "message" begin fun _ _ pp ->
 end
 
 let () = register_init "err" begin fun _ _ e ->
-  let e = to_ext val_exn e in
+  let e = to_exn e in
   str "err:(" ++ CErrors.iprint_no_report e ++ str ")"
 end
 
@@ -603,7 +603,7 @@ type format =
 | FmtLiteral of string
 | FmtAlpha
 
-let val_format = Tac2dyn.Val.create "format"
+let format : format list repr = magic_repr ()
 
 exception InvalidFormat
 

--- a/plugins/ltac2/tac2print.mli
+++ b/plugins/ltac2/tac2print.mli
@@ -61,7 +61,7 @@ type format =
 | FmtLiteral of string
 | FmtAlpha
 
-val val_format : format list Tac2dyn.Val.tag
+val format : format list Tac2ffi.repr
 
 exception InvalidFormat
 

--- a/plugins/ltac2/tac2tactics.mli
+++ b/plugins/ltac2/tac2tactics.mli
@@ -121,3 +121,6 @@ val unify : constr -> constr -> unit tactic
 val inversion : Inv.inversion_kind -> destruction_arg -> intro_pattern option -> Id.t list option -> unit tactic
 
 val contradiction : constr_with_bindings option -> unit tactic
+
+(** Type adapter *)
+val mk_qhyp : Tac2types.quantified_hypothesis -> Tactypes.quantified_hypothesis

--- a/plugins/ltac2/tac2types.mli
+++ b/plugins/ltac2/tac2types.mli
@@ -10,7 +10,6 @@
 
 open Names
 open EConstr
-open Proofview
 
 (** Redefinition of Ltac1 data structures because of impedance mismatch *)
 
@@ -19,9 +18,9 @@ type advanced_flag = bool
 
 type 'a thunk = (unit, 'a) Tac2ffi.fun1
 
-type quantified_hypothesis = Tactypes.quantified_hypothesis =
+type quantified_hypothesis =
 | AnonHyp of int
-| NamedHyp of lident
+| NamedHyp of Id.t
 
 type explicit_bindings = (quantified_hypothesis * EConstr.t) list
 
@@ -33,7 +32,7 @@ type bindings =
 type constr_with_bindings = EConstr.constr * bindings
 
 type core_destruction_arg =
-| ElimOnConstr of constr_with_bindings tactic
+| ElimOnConstr of constr_with_bindings thunk
 | ElimOnIdent of Id.t
 | ElimOnAnonHyp of int
 
@@ -87,7 +86,7 @@ type multi = Equality.multi =
 type rewriting =
   bool option *
   multi *
-  constr_with_bindings tactic
+  constr_with_bindings thunk
 
 type assertion =
 | AssertType of intro_pattern option * constr * unit thunk option

--- a/test-suite/ltac2/matching.v
+++ b/test-suite/ltac2/matching.v
@@ -38,6 +38,17 @@ in
 match! '(nat -> bool) with context [?a] => f a end.
 Abort.
 
+
+Goal True /\ (1 = 2).
+Proof.
+  Fail lazy_match! goal with
+  | [ |- ?a = ?b ] => ()
+  end.
+  lazy_match! goal with
+  | [ |- context [ ?a = ?b ] ] => ()
+  end.
+Abort.
+
 Goal forall (i j : unit) (x y : nat) (b : bool), True.
 Proof.
 Fail match! goal with

--- a/user-contrib/Ltac2/Init.v
+++ b/user-contrib/Ltac2/Init.v
@@ -36,6 +36,7 @@ Ltac2 Type constr.
 Ltac2 Type preterm.
 Ltac2 Type binder.
 
+Ltac2 Type loc.
 Ltac2 Type message.
 Ltac2 Type ('a, 'b, 'c, 'd) format.
 Ltac2 Type exn := [ .. ].
@@ -47,7 +48,7 @@ Ltac2 Type 'a option := [ None | Some ('a) ].
 
 Ltac2 Type 'a ref := { mutable contents : 'a }.
 
-Ltac2 Type bool := [ true | false ].
+Ltac2 Type bool := [ false | true ].
 
 Ltac2 Type 'a result := [ Val ('a) | Err (exn) ].
 

--- a/user-contrib/Ltac2/Pattern.v
+++ b/user-contrib/Ltac2/Pattern.v
@@ -16,8 +16,8 @@ Ltac2 Type t := pattern.
 Ltac2 Type context.
 
 Ltac2 Type match_kind := [
-| MatchPattern
 | MatchContext
+| MatchPattern
 ].
 
 Ltac2 @ external empty_context : unit -> context :=

--- a/user-contrib/Ltac2/Std.v
+++ b/user-contrib/Ltac2/Std.v
@@ -102,7 +102,7 @@ Ltac2 Type repeat := [
 | RepeatPlus
 ].
 
-Ltac2 Type orientation := [ LTR | RTL ].
+Ltac2 Type orientation := [ RTL | LTR ].
 
 Ltac2 Type rewriting := {
   rew_orient : orientation option;
@@ -246,9 +246,9 @@ Ltac2 @ external subst_all : unit -> unit := "ltac2" "tac_substall".
 
 (** auto *)
 
-Ltac2 Type debug := [ Off | Info | Debug ].
+Ltac2 Type debug := [ Debug | Info | Off ].
 
-Ltac2 Type strategy := [ BFS | DFS ].
+Ltac2 Type strategy := [ DFS | BFS ].
 
 Ltac2 @ external trivial : debug -> (unit -> constr) list -> ident list option -> unit := "ltac2" "tac_trivial".
 


### PR DESCRIPTION
This is definitely more fragile but perhaps faster or less memory hungry.