### PR TITLE
Fix interpretation of VM/native values.

### DIFF
--- a/kernel/nativevalues.ml
+++ b/kernel/nativevalues.ml
@@ -292,7 +292,6 @@ type kind_of_value =
 let kind_of_value (v:t) =
   let o = Obj.repr v in
   if Obj.is_int o then Vconst (Obj.magic v)
-  else if Obj.tag o == Obj.double_tag then Vfloat64 (Obj.magic v)
   else
     let tag = Obj.tag o in
     if Int.equal tag accumulate_tag then

--- a/kernel/vmvalues.ml
+++ b/kernel/vmvalues.ml
@@ -371,10 +371,6 @@ let rec whd_accu a stk =
       | [Zapp args] -> Vcofix(vcofix, res, Some args)
       | _           -> assert false
       end
-  | i when Int.equal i Obj.custom_tag ->
-    Vint64 (Obj.magic i)
-  | i when Int.equal i Obj.double_tag ->
-    Vfloat64 (Obj.magic i)
   | tg ->
     CErrors.anomaly
       Pp.(strbrk "Failed to parse VM value. Tag = " ++ int tg ++ str ".")


### PR DESCRIPTION
These issues were found by visual inspection. The one in `nativevalues.ml` is minor, as it is just some redundant code. The ones in `vmvalues.ml` are slightly worse, as one should be able to use them to crash Coq by memory corruption, even accidentally. (I did not succeed, though.)

@maximedenes @proux01 