### PR TITLE
Use the compact representation in the case typing rule

### DIFF
--- a/dev/ci/user-overlays/16641-ppedrot-typeops-no-case-expand.sh
+++ b/dev/ci/user-overlays/16641-ppedrot-typeops-no-case-expand.sh
@@ -1,0 +1,1 @@
+overlay serapi https://github.com/ppedrot/coq-serapi typeops-no-case-expand 16641

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -452,12 +452,9 @@ let type_case_branches env ((ind, u'), largs) u pms (pctx, p, pt, ps) c =
     try check_allowed_sort (Sorts.family ps) specif
     with LocalArity kinds -> error_elim_arity env (ind, u) c pj kinds
   in
-  (* We return the "higher" inductive universe instance from the predicate,
-     the branches must be typeable using these universes. *)
-  let lc = build_branches_type (ind, u) specif params (Term.it_mkLambda_or_LetIn p pctx) in
   let subst = Vars.subst_of_rel_context_instance_list pctx (realargs @ [c]) in
   let ty = Vars.substl subst p in
-  (lc, ty)
+  ty
 
 (************************************************************************)
 (* Checking the case annotation is relevant *)

--- a/kernel/inductive.mli
+++ b/kernel/inductive.mli
@@ -114,8 +114,9 @@ val instantiate_context : Instance.t -> Vars.substl -> Name.t Context.binder_ann
    the universe constraints generated.
  *)
 val type_case_branches :
-  env -> pinductive * constr list -> unsafe_judgment -> constr
-    -> types array * types
+  env -> pinductive * constr list ->
+  Instance.t -> constr array -> rel_context * constr * types * Sorts.t -> constr ->
+  types array * types
 
 val build_branches_type :
   pinductive -> mutual_inductive_body * one_inductive_body ->

--- a/kernel/inductive.mli
+++ b/kernel/inductive.mli
@@ -116,7 +116,7 @@ val instantiate_context : Instance.t -> Vars.substl -> Name.t Context.binder_ann
 val type_case_branches :
   env -> pinductive * constr list ->
   Instance.t -> constr array -> rel_context * constr * types * Sorts.t -> constr ->
-  types array * types
+  types
 
 val build_branches_type :
   pinductive -> mutual_inductive_body * one_inductive_body ->

--- a/kernel/inductive.mli
+++ b/kernel/inductive.mli
@@ -106,18 +106,6 @@ val contract_case : env -> (case_info * constr * case_invert * constr * constr a
 val instantiate_context : Instance.t -> Vars.substl -> Name.t Context.binder_annot array ->
   rel_context -> rel_context
 
-(** [type_case_branches env (I,args) (p:A) c] computes useful types
-   about the following Cases expression:
-      <p>Cases (c :: (I args)) of b1..bn end
-   It computes the type of every branch (pattern variables are
-   introduced by products), the type for the whole expression, and
-   the universe constraints generated.
- *)
-val type_case_branches :
-  env -> pinductive * constr list ->
-  Instance.t -> constr array -> rel_context * constr * types * Sorts.t -> constr ->
-  types
-
 val build_branches_type :
   pinductive -> mutual_inductive_body * one_inductive_body ->
     constr list -> constr -> types array

--- a/kernel/type_errors.mli
+++ b/kernel/type_errors.mli
@@ -47,19 +47,14 @@ type fix_guard_error = constr pfix_guard_error
 type cofix_guard_error = constr pcofix_guard_error
 type guard_error = constr pguard_error
 
-type arity_error =
-  | NonInformativeToInformative
-  | StrongEliminationOnNonSmallType
-  | WrongArity
-
 type ('constr, 'types) ptype_error =
   | UnboundRel of int
   | UnboundVar of variable
   | NotAType of ('constr, 'types) punsafe_judgment
   | BadAssumption of ('constr, 'types) punsafe_judgment
   | ReferenceVariables of Id.t * GlobRef.t
-  | ElimArity of pinductive * 'constr * ('constr, 'types) punsafe_judgment
-      * (Sorts.family * Sorts.family * Sorts.family * arity_error) option
+  | ElimArity of pinductive * 'constr *
+      (('constr, 'types) punsafe_judgment * Sorts.family * Sorts.family * Sorts.family) option
   | CaseNotInductive of ('constr, 'types) punsafe_judgment
   | WrongCaseInfo of pinductive * case_info
   | NumberBranches of ('constr, 'types) punsafe_judgment * int
@@ -115,8 +110,8 @@ val error_assumption : env -> unsafe_judgment -> 'a
 val error_reference_variables : env -> Id.t -> GlobRef.t -> 'a
 
 val error_elim_arity :
-  env -> pinductive -> constr -> unsafe_judgment ->
-      (Sorts.family * Sorts.family * Sorts.family * arity_error) option -> 'a
+  env -> pinductive -> constr ->
+    (unsafe_judgment * Sorts.family * Sorts.family * Sorts.family) option -> 'a
 
 val error_case_not_inductive : env -> unsafe_judgment -> 'a
 
@@ -142,8 +137,6 @@ val error_ill_formed_rec_body :
 
 val error_ill_typed_rec_body  :
   env -> int -> Name.t Context.binder_annot array -> unsafe_judgment array -> types array -> 'a
-
-val error_elim_explain : Sorts.family -> Sorts.family -> arity_error
 
 val error_unsatisfied_constraints : env -> Constraints.t -> 'a
 

--- a/pretyping/pretype_errors.ml
+++ b/pretyping/pretype_errors.ml
@@ -113,9 +113,9 @@ let error_ill_typed_rec_body ?loc env sigma i na jl tys =
   raise_type_error ?loc
     (env, sigma, IllTypedRecBody (i, na, jl, tys))
 
-let error_elim_arity ?loc env sigma pi c j a =
+let error_elim_arity ?loc env sigma pi c a =
   raise_type_error ?loc
-    (env, sigma, ElimArity (pi, c, j, a))
+    (env, sigma, ElimArity (pi, c, a))
 
 let error_not_a_type ?loc env sigma j =
   raise_type_error ?loc (env, sigma, NotAType j)

--- a/pretyping/pretype_errors.mli
+++ b/pretyping/pretype_errors.mli
@@ -109,7 +109,7 @@ val error_ill_typed_rec_body :
 val error_elim_arity :
   ?loc:Loc.t -> env -> Evd.evar_map ->
       pinductive -> constr ->
-      unsafe_judgment -> (Sorts.family * Sorts.family * Sorts.family * arity_error) option -> 'b
+      (unsafe_judgment * Sorts.family * Sorts.family * Sorts.family) option -> 'b
 
 val error_not_a_type :
   ?loc:Loc.t -> env -> Evd.evar_map -> unsafe_judgment -> 'b

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -125,7 +125,7 @@ let max_sort l =
 let is_correct_arity env sigma c pj ind specif params =
   let arsign = make_arity_signature env sigma true (make_ind_family (ind,params)) in
   let allowed_sorts = sorts_below (elim_sort specif) in
-  let error () = Pretype_errors.error_elim_arity env sigma ind c pj None in
+  let error () = Pretype_errors.error_elim_arity env sigma ind c None in
   let rec srec env sigma pt ar =
     let pt' = whd_all env sigma pt in
     match EConstr.kind sigma pt', ar with
@@ -209,11 +209,10 @@ let check_allowed_sort env sigma ind c p =
   let _, s = splay_prod env sigma pj.uj_type in
   let ksort = match EConstr.kind sigma s with
   | Sort s -> Sorts.family (ESorts.kind sigma s)
-  | _ -> error_elim_arity env sigma ind c pj None in
+  | _ -> error_elim_arity env sigma ind c None in
   if not (Sorts.family_leq ksort sorts) then
     let s = inductive_sort_family (snd specif) in
-    error_elim_arity env sigma ind c pj
-      (Some(sorts,ksort,s,Type_errors.error_elim_explain ksort s))
+    error_elim_arity env sigma ind c (Some (pj, sorts, ksort, s))
   else
     Sorts.relevance_of_sort_family ksort
 

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -266,12 +266,12 @@ let warning_or_error ~info flags indsp err =
            strbrk " not defined.")
     | BadTypedProj (fi,_ctx,te) ->
         match te with
-          | ElimArity (_,_,_,Some (_,_,_,NonInformativeToInformative)) ->
+          | ElimArity (_, _, Some (_, _, (InType | InSet), InProp)) ->
               (Id.print fi ++
                 strbrk" cannot be defined because it is informative and " ++
                 Printer.pr_inductive (Global.env()) indsp ++
                 strbrk " is not.")
-          | ElimArity (_,_,_,Some (_,_,_,StrongEliminationOnNonSmallType)) ->
+          | ElimArity (_, _, Some (_, _, InType, InSet)) ->
               (Id.print fi ++
                 strbrk" cannot be defined because it is large and " ++
                 Printer.pr_inductive (Global.env()) indsp ++


### PR DESCRIPTION
I followed the metacoq implementation so up to involuntarily introduced bugs this should be correct.

Hopefully this should also be much faster because we stop rechecking stuff that is known to be correct (i.e. branch and return clause contexts) by only checking the minimal data (i.e. universe instances and parameters).

Overlays:
- https://github.com/ejgallego/coq-serapi/pull/292