### PR TITLE
Use natural instead of integer in instantiate tactic syntax

### DIFF
--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1619,7 +1619,7 @@ simple_tactic: [
 | "evar" test_lpar_id_colon "(" ident ":" lconstr ")"
 | "evar" constr
 | "instantiate" "(" ident ":=" lglob ")"
-| "instantiate" "(" integer ":=" lglob ")" hloc
+| "instantiate" "(" natural ":=" lglob ")" hloc
 | "instantiate"
 | "stepl" constr "by" tactic
 | "stepl" constr

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1688,7 +1688,7 @@ simple_tactic: [
 | "evar" "(" ident ":" term ")"
 | "evar" one_term
 | "instantiate" OPT ( "(" ident ":=" term ")" )
-| "instantiate" "(" integer ":=" term ")" OPT hloc
+| "instantiate" "(" natural ":=" term ")" OPT hloc
 | "stepl" one_term OPT ( "by" ltac_expr )
 | "stepr" one_term OPT ( "by" ltac_expr )
 | "generalize_eqs" ident

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -374,7 +374,7 @@ END
 TACTIC EXTEND instantiate
 | [ "instantiate" "(" ident(id) ":=" lglob(c) ")" ] ->
     { instantiate_tac_by_name id c }
-| [ "instantiate" "(" integer(i) ":=" lglob(c) ")" hloc(hl) ] ->
+| [ "instantiate" "(" natural(i) ":=" lglob(c) ")" hloc(hl) ] ->
     { instantiate_tac i c hl }
 END
 


### PR DESCRIPTION
The underlying code in `Evar_tactics.instantiate_tac` already generates an error message for n < 0.