### PR TITLE
Fix the conversion of Prod values in the native compiler.

### DIFF
--- a/dev/doc/critical-bugs
+++ b/dev/doc/critical-bugs
@@ -386,6 +386,16 @@ Conversion machines
   risk: none, unless mixing open terms and primitive floats inside primitive
   arrays; critical otherwise
 
+  component: "native" conversion machine (translation to OCaml which compiles to native code)
+  summary: conversion of Prod / Prod values was comparing the wrong components
+  introduced: V8.5
+  impacted released versions: V8.5-V8.16.0 (when built with native computation enabled)
+  impacted coqchk versions: none (no native computation in coqchk)
+  fixed in: 8.16.1
+  found by: Melquiond
+  GH issue number: #16645
+  risk: systematic
+
 Side-effects
 
   component: side-effects

--- a/doc/changelog/01-kernel/16651-fix-native-vprod-unsoundness.rst
+++ b/doc/changelog/01-kernel/16651-fix-native-vprod-unsoundness.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  conversion of Prod values in the native compiler.
+  (`#16651 <https://github.com/coq/coq/pull/16651>`_,
+  fixes `#16645 <https://github.com/coq/coq/issues/16645>`_,
+  by Pierre-Marie Pédrot).

--- a/kernel/nativeconv.ml
+++ b/kernel/nativeconv.ml
@@ -118,10 +118,10 @@ and conv_atom env pb lvl a1 a2 cu =
         else
           if not (Int.equal (Array.length f1) (Array.length f2)) then raise NotConvertible
           else conv_fix env lvl t1 f1 t2 f2 cu
-    | Aprod(_,d1,_c1), Aprod(_,d2,_c2) ->
+    | Aprod(_,d1,c1), Aprod(_,d2,c2) ->
        let cu = conv_val env CONV lvl d1 d2 cu in
        let v = mk_rel_accu lvl in
-       conv_val env pb (lvl + 1) (apply d1 v) (apply d2 v) cu
+       conv_val env pb (lvl + 1) (apply c1 v) (apply c2 v) cu
     | Aproj((ind1, i1), ac1), Aproj((ind2, i2), ac2) ->
        if not (Ind.CanOrd.equal ind1 ind2 && Int.equal i1 i2) then raise NotConvertible
        else conv_accu env CONV lvl ac1 ac2 cu

--- a/test-suite/bugs/bug_16645.v
+++ b/test-suite/bugs/bug_16645.v
@@ -1,0 +1,7 @@
+Goal False.
+Proof.
+assert (H: forall x:unit, False).
+{ native_cast_no_check (fun x:unit => I). }
+exact (H tt).
+Fail Qed.
+Abort.


### PR DESCRIPTION
Fixes #16645: Inconsistent handling of products in the native machine.

- [X] Added / updated **test-suite**.
- [x] Added **changelog**.
- [x] Added / updated **documentation**.