### PR TITLE
Make TC resolution overrideable by a plugin

### DIFF
--- a/pretyping/typeclasses.ml
+++ b/pretyping/typeclasses.ml
@@ -33,10 +33,12 @@ let get_typeclasses_unique_solutions =
     ~key:["Typeclasses";"Unique";"Solutions"]
     ~value:false
 
-let get_solve_one_instance, solve_one_instance_hook = Hook.make ()
+let solve_one_instance = ref (fun env evm t unique -> assert false)
 
 let resolve_one_typeclass ?(unique=get_typeclasses_unique_solutions ()) env evm t =
-  Hook.get get_solve_one_instance env evm t unique
+  !solve_one_instance env evm t unique
+
+let set_solve_one_instance f = solve_one_instance := f
 
 type class_method = {
   meth_name : Name.t;
@@ -236,10 +238,12 @@ let has_typeclasses filter evd =
   let check ev = filter ev (lazy (snd (Evd.find evd ev).evar_source)) in
   Evar.Set.exists check tcs
 
-let get_solve_all_instances, solve_all_instances_hook = Hook.make ()
+let solve_all_instances_hook = ref (fun env evd filter unique split fail -> assert false)
 
 let solve_all_instances env evd filter unique split fail =
-  Hook.get get_solve_all_instances env evd filter unique split fail
+  !solve_all_instances_hook env evd filter unique split fail
+
+let set_solve_all_instances f = solve_all_instances_hook := f
 
 let resolve_typeclasses ?(filter=no_goals) ?(unique=get_typeclasses_unique_solutions ())
     ?(split=true) ?(fail=true) env evd =

--- a/pretyping/typeclasses.mli
+++ b/pretyping/typeclasses.mli
@@ -123,5 +123,8 @@ val resolve_typeclasses : ?filter:evar_filter -> ?unique:bool ->
   ?split:bool -> ?fail:bool -> env -> evar_map -> evar_map
 val resolve_one_typeclass : ?unique:bool -> env -> evar_map -> EConstr.types -> evar_map * EConstr.constr
 
-val solve_all_instances_hook : (env -> evar_map -> evar_filter -> bool -> bool -> bool -> evar_map) Hook.t
-val solve_one_instance_hook : (env -> evar_map -> EConstr.types -> bool -> evar_map * EConstr.constr) Hook.t
+(** A plugin can override the TC resolution engine by calling these two APIs.
+    Beware this action is not registed in the summary (the Undo system) so
+    it is up to the plugin to do so. *)
+val set_solve_all_instances : (env -> evar_map -> evar_filter -> bool -> bool -> bool -> evar_map) -> unit
+val set_solve_one_instance : (env -> evar_map -> EConstr.types -> bool -> evar_map * EConstr.constr) -> unit

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -1343,7 +1343,7 @@ let solve_inst env evd filter unique split fail =
   sigma
 
 let () =
-  Hook.set Typeclasses.solve_all_instances_hook solve_inst
+  Typeclasses.set_solve_all_instances solve_inst
 
 let resolve_one_typeclass env ?(sigma=Evd.from_env env) concl unique =
   let (term, sigma) = Hints.wrap_hint_warning_fun env sigma begin fun sigma ->
@@ -1370,7 +1370,7 @@ let resolve_one_typeclass env ?(sigma=Evd.from_env env) concl unique =
   (sigma, term)
 
 let () =
-  Hook.set Typeclasses.solve_one_instance_hook
+  Typeclasses.set_solve_one_instance
     (fun x y z w -> resolve_one_typeclass x ~sigma:y z w)
 
 (** Take the head of the arity of a constr.


### PR DESCRIPTION
I'm working on an alternative TC resolution engine, and I'd like it to be implemented in a plugin, a bit like unicoq is an alternative to evarconv. Unfortunately the Hook API makes it work only if the default value of the hook is set from the same file. This PR lifts this limitation.