### PR TITLE
Remove the Vuniv_level constructor of VM value kinds.

### DIFF
--- a/dev/vm_printers.ml
+++ b/dev/vm_printers.ml
@@ -86,7 +86,6 @@ and ppwhd whd =
   | Vatom_stk(a,s) ->
       open_hbox();ppatom a;close_box();
       print_string"@";ppstack s
-  | Vuniv_level lvl -> Feedback.msg_notice (Univ.Level.pr lvl)
 
 and ppvblock b =
   open_hbox();

--- a/kernel/vconv.ml
+++ b/kernel/vconv.ml
@@ -41,12 +41,6 @@ let rec conv_val env pb k v1 v2 cu =
 and conv_whd env pb k whd1 whd2 cu =
 (*  Pp.(msg_debug (str "conv_whd(" ++ pr_whd whd1 ++ str ", " ++ pr_whd whd2 ++ str ")")) ; *)
   match whd1, whd2 with
-  | Vuniv_level _ , _
-  | _ , Vuniv_level _ ->
-    (** Both of these are invalid since universes are handled via
-     ** special cases in the code.
-     **)
-    assert false
   | Vprod p1, Vprod p2 ->
       let cu = conv_val env CONV k (dom p1) (dom p2) cu in
       conv_fun env pb k (codom p1) (codom p2) cu

--- a/kernel/vm.ml
+++ b/kernel/vm.ml
@@ -181,5 +181,4 @@ let apply_whd k whd =
       interprete (cofix_upd_code to_up) (cofix_upd_val to_up) (cofix_upd_env to_up) 0
   | Vatom_stk(a,stk) ->
       apply_stack (val_of_atom a) stk v
-  | Vuniv_level _lvl -> assert false
 

--- a/kernel/vmvalues.ml
+++ b/kernel/vmvalues.ml
@@ -282,7 +282,6 @@ type whd =
   | Vfloat64 of float
   | Varray of values Parray.t
   | Vatom_stk of atom * stack
-  | Vuniv_level of Univ.Level.t
 
 (* Functions over arguments *)
 let nargs : arguments -> int = fun args -> Obj.size (Obj.repr args) - 3
@@ -297,29 +296,7 @@ let arg args i =
 (* Destructors ***********************************)
 (*************************************************)
 
-let uni_lvl_val (v : values) : Univ.Level.t =
-    let whd = Obj.magic v in
-    match whd with
-    | Vuniv_level lvl -> lvl
-    | _ ->
-      let pr =
-        let open Pp in
-        match whd with
-        | Vprod _ -> str "Vprod"
-        | Vfun _ -> str "Vfun"
-        | Vfix _ -> str "Vfix"
-        | Vcofix _ -> str "Vcofix"
-        | Vconstr_const _i -> str "Vconstr_const"
-        | Vconstr_block _b -> str "Vconstr_block"
-        | Vint64 _ -> str "Vint64"
-        | Vfloat64 _ -> str "Vfloat64"
-        | Varray _ -> str "Varray"
-        | Vatom_stk (_a,_stk) -> str "Vatom_stk"
-        | Vuniv_level _ -> assert false
-      in
-      CErrors.anomaly
-        Pp.(   strbrk "Parsing virtual machine value expected universe level, got "
-            ++ pr ++ str ".")
+let uni_lvl_val (v : values) : Univ.Level.t = Obj.magic v
 
 let rec whd_accu a stk =
   let stk =
@@ -430,7 +407,7 @@ let obj_of_str_const str =
   | Const_sort s -> obj_of_atom (Asort s)
   | Const_ind ind -> obj_of_atom (Aind ind)
   | Const_b0 tag -> Obj.repr tag
-  | Const_univ_level l -> Obj.repr (Vuniv_level l)
+  | Const_univ_level l -> Obj.repr l
   | Const_val v -> Obj.repr v
   | Const_uint i -> Obj.repr i
   | Const_float f -> Obj.repr f
@@ -678,8 +655,7 @@ and pr_whd w =
   | Vint64 i -> i |> Format.sprintf "Vint64(%LiL)" |> str
   | Vfloat64 f -> str "Vfloat64(" ++ str (Float64.(to_string (of_float f))) ++ str ")"
   | Varray _ -> str "Varray"
-  | Vatom_stk (a,stk) -> str "Vatom_stk(" ++ pr_atom a ++ str ", " ++ pr_stack stk ++ str ")"
-  | Vuniv_level _ -> assert false)
+  | Vatom_stk (a,stk) -> str "Vatom_stk(" ++ pr_atom a ++ str ", " ++ pr_stack stk ++ str ")")
 and pr_stack stk =
   Pp.(match stk with
       | [] -> str "[]"

--- a/kernel/vmvalues.mli
+++ b/kernel/vmvalues.mli
@@ -126,7 +126,6 @@ type whd =
   | Vfloat64 of float
   | Varray of values Parray.t
   | Vatom_stk of atom * stack
-  | Vuniv_level of Univ.Level.t
 
 (** For debugging purposes only *)
 

--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -187,8 +187,6 @@ and nf_whd env sigma whd typ =
      nf_univ_args ~nb_univs mk env sigma stk
   | Vatom_stk(Asort s, stk) ->
     assert (List.is_empty stk); mkSort s
-  | Vuniv_level lvl ->
-    assert false
 
 and nf_univ_args ~nb_univs mk env sigma stk =
   let u =


### PR DESCRIPTION
This was not making any sense, because the code was confusing the untyped representation of the value and the view of this datum as an inductive classification. If anything, this would probably have led to segfaults if used improperly, but thankfully the few callers were doing trivial things with the cast functions.

Extracted from #16629.