### PR TITLE
Merge the Acofix and Acofixe constructors of native atoms.

### DIFF
--- a/kernel/nativeconv.ml
+++ b/kernel/nativeconv.ml
@@ -111,8 +111,7 @@ and conv_atom env pb lvl a1 a2 cu =
         if not (Int.equal s1 s2) || not (Array.equal Int.equal rp1 rp2) then raise NotConvertible;
         if f1 == f2 then cu
         else conv_fix env lvl t1 f1 t2 f2 cu
-    | (Acofix(t1,f1,s1,_) | Acofixe(t1,f1,s1,_)),
-      (Acofix(t2,f2,s2,_) | Acofixe(t2,f2,s2,_)) ->
+    | Acofix (t1, f1, s1, _), Acofix (t2, f2, s2, _) ->
         if not (Int.equal s1 s2) then raise NotConvertible;
         if f1 == f2 then cu
         else
@@ -126,7 +125,7 @@ and conv_atom env pb lvl a1 a2 cu =
        if not (Ind.CanOrd.equal ind1 ind2 && Int.equal i1 i2) then raise NotConvertible
        else conv_accu env CONV lvl ac1 ac2 cu
     | Arel _, _ | Aind _, _ | Aconstant _, _ | Asort _, _ | Avar _, _
-    | Acase _, _ | Afix _, _ | Acofix _, _ | Acofixe _, _ | Aprod _, _
+    | Acase _, _ | Afix _, _ | Acofix _, _ | Aprod _, _
     | Aproj _, _ | Ameta _, _ | Aevar _, _ -> raise NotConvertible
 
 (* Precondition length t1 = length f1 = length f2 = length t2 *)

--- a/kernel/nativevalues.mli
+++ b/kernel/nativevalues.mli
@@ -51,6 +51,8 @@ type rec_pos = int array
 
 val eq_rec_pos : rec_pos -> rec_pos -> bool
 
+type vcofix
+
 type atom =
   | Arel of int
   | Aconstant of pconstant
@@ -59,8 +61,7 @@ type atom =
   | Avar of Id.t
   | Acase of annot_sw * accumulator * t * t
   | Afix of t array * t array * rec_pos * int
-  | Acofix of t array * t array * int * t
-  | Acofixe of t array * t array * int * t
+  | Acofix of t array * t array * int * vcofix
   | Aprod of Name.t * t * t
   | Ameta of metavariable * t
   | Aevar of Evar.t * t array (* arguments *)

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -338,7 +338,7 @@ and nf_atom_type env sigma atom =
       let norm_body i v = nf_val env sigma (napply v fargs) (lift nbfix tt.(i)) in
       let ft = Array.mapi norm_body ft in
       mkFix((rp,s),(names,tt,ft)), tt.(s)
-  | Acofix(tt,ft,s,_) | Acofixe(tt,ft,s,_) ->
+  | Acofix(tt,ft,s,_) ->
       let tt = Array.map (fun t -> nf_type_sort env sigma t) tt in
       let tt = Array.map fst tt and rt = Array.map snd tt in
       let name = Name (Id.of_string "Fcofix") in


### PR DESCRIPTION
This prevents potential confusions between the two forms, since anyways only the Nativevalues module cares about the difference. This also brings the VM and native atom representations closer.

Extracted from #16629.