### PR TITLE
[lia] option to use convertibility test during parsing.

### DIFF
--- a/doc/changelog/04-tactics/16661-lia-conversion.rst
+++ b/doc/changelog/04-tactics/16661-lia-conversion.rst
@@ -1,0 +1,6 @@
+- **Added:**
+  A :flag:`Psatz Conversion` flag to control whether to use :term:`definitional equality`
+  (:term:`convertibility <convertible>`) or syntactic equality during parsing of the goal
+  for the tactics :tacn:`lia`, :tacn:`nia`, :tacn:`lra`, :tacn:`nra` and :tacn:`psatz`.
+  (`#16661 <https://github.com/coq/coq/pull/16661>`_,
+  by Frédéric Besson).

--- a/doc/sphinx/addendum/micromega.rst
+++ b/doc/sphinx/addendum/micromega.rst
@@ -54,6 +54,11 @@ or only for reals by ``Require Import Lra``.
 
    This :term:`flag` (set by default) instructs :tacn:`nra` to cache its results in the file `.nra.cache`
 
+.. flag:: Psatz Conversion
+
+   When set, use :term:`definitional equality` (:term:`convertibility <convertible>`) instead of
+   syntactic equality to detect equal terms in the :tacn:`lia`, :tacn:`nia`, :tacn:`lra`,
+   :tacn:`nra` and :tacn:`psatz` tactics during parsing of the goal.  The default is unset.
 
 The tactics solve propositional formulas parameterized by atomic
 arithmetic expressions interpreted over a domain :math:`D \in \{\mathbb{Z},\mathbb{Q},\mathbb{R}\}`.

--- a/test-suite/micromega/bug_16634.v
+++ b/test-suite/micromega/bug_16634.v
@@ -1,0 +1,28 @@
+From Coq Require Import List Psatz.
+
+Set Psatz Conversion.
+
+Lemma foo {A : Type} (xs : list A) : @length (id A) xs = @length A xs.
+Proof.
+  lia.
+Qed.
+
+Structure my_struct := {
+  the_type : Type
+}.
+
+Coercion the_type : my_struct >-> Sortclass.
+
+Arguments the_type : simpl never.
+
+Definition A : Type := nat.
+Definition A_struct := Build_my_struct A.
+
+Lemma foo2 (xs ys zs : list A_struct) :
+  @length (the_type A_struct) xs <= @length A ys ->
+  @length (the_type A_struct) ys <= @length A zs ->
+  @length A xs <= @length (the_type A_struct) zs.
+Proof.
+  intros.
+  lia.
+Qed.


### PR DESCRIPTION
When the option `Psatz Conversion` is set, equality of terms is not syntactic but modulo conversion.


<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes #16634 


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [x] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
