### PR TITLE
Hooks have no default value

### DIFF
--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -734,7 +734,7 @@ let expand_existential sigma (evk, args) =
 
 let expand_existential0 = expand_existential
 
-let get_is_maybe_typeclass, (is_maybe_typeclass_hook : (evar_map -> constr -> bool) Hook.t) = Hook.make ~default:(fun evd c -> false) ()
+let get_is_maybe_typeclass, (is_maybe_typeclass_hook : (evar_map -> constr -> bool) Hook.t) = Hook.make ()
 
 let is_maybe_typeclass sigma c = Hook.get get_is_maybe_typeclass sigma c
 

--- a/lib/hook.ml
+++ b/lib/hook.ml
@@ -10,7 +10,6 @@
 
 type 'a content =
 | Unset
-| Default of 'a
 | Set of 'a
 
 type 'a t = 'a content ref
@@ -19,16 +18,12 @@ type 'a value = 'a t
 
 let get (hook : 'a value) = match !hook with
 | Unset -> assert false
-| Default data | Set data -> data
+| Set data -> data
 
 let set (hook : 'a t) data = match !hook with
-| Unset | Default _ -> hook := Set data
+| Unset -> hook := Set data
 | Set _ -> assert false
 
-let make ?default () =
-  let data = match default with
-  | None -> Unset
-  | Some data -> Default data
-  in
-  let ans = ref data in
+let make () =
+  let ans = ref Unset in
   (ans, ans)

--- a/lib/hook.mli
+++ b/lib/hook.mli
@@ -17,7 +17,7 @@ type 'a t
 type 'a value
 (** The content part of a hook. *)
 
-val make : ?default:'a -> unit -> ('a value * 'a t)
+val make : unit -> ('a value * 'a t)
 (** Create a new hook together with a way to retrieve its runtime value. *)
 
 val get : 'a value -> 'a

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -1243,11 +1243,11 @@ let evar_conv_x flags = evar_conv_x flags
 
 let evar_unify = conv_fun evar_conv_x
 
-let evar_conv_hook_get, evar_conv_hook_set = Hook.make ~default:evar_conv_x ()
+let evar_conv_hook = ref evar_conv_x
 
-let evar_conv_x flags = Hook.get evar_conv_hook_get flags
+let evar_conv_x flags = !evar_conv_hook flags
 
-let set_evar_conv f = Hook.set evar_conv_hook_set f
+let set_evar_conv f = evar_conv_hook := f
 
 
 (* We assume here |l1| <= |l2| *)

--- a/stm/stm.mli
+++ b/stm/stm.mli
@@ -266,28 +266,27 @@ val register_proof_block_delimiter :
  * the alternative toploop for the worker can be selected by changing
  * the name of the Task(s) above) *)
 
-val state_computed_hook : (doc:doc -> Stateid.t -> in_cache:bool -> unit) Hook.t
-val unreachable_state_hook :
-  (doc:doc -> Stateid.t -> Exninfo.iexn -> unit) Hook.t
+val state_computed_hook : (doc:doc -> Stateid.t -> in_cache:bool -> unit) -> unit
+val unreachable_state_hook : (doc:doc -> Stateid.t -> Exninfo.iexn -> unit) -> unit
 
 (* ready means that master has it at hand *)
-val state_ready_hook : (doc:doc -> Stateid.t -> unit) Hook.t
+val state_ready_hook : (doc:doc -> Stateid.t -> unit) -> unit
 
 (* Messages from the workers to the master *)
-val forward_feedback_hook : (Feedback.feedback -> unit) Hook.t
+val forward_feedback_hook : (Feedback.feedback -> unit) -> unit
 
 (*
  * Hooks into the UI for plugins (not for general use)
  *)
 
 (** User adds a sentence to the document (after parsing) *)
-val document_add_hook : (Vernacexpr.vernac_control -> Stateid.t -> unit) Hook.t
+val document_add_hook : (Vernacexpr.vernac_control -> Stateid.t -> unit) -> unit
 
 (** User edits a sentence in the document *)
-val document_edit_hook : (Stateid.t -> unit) Hook.t
+val document_edit_hook : (Stateid.t -> unit) -> unit
 
 (** User requests evaluation of a sentence *)
-val sentence_exec_hook : (Stateid.t -> unit) Hook.t
+val sentence_exec_hook : (Stateid.t -> unit) -> unit
 
 val get_doc : Feedback.doc_id -> doc
 


### PR DESCRIPTION
Hooks are meant to be a workaround to lack of cross-file recursive module, and as such a hook is meant to refer to 1 specific function.

Hooks with default values were either meant to be set to arbitrary functions by plugins in which case they should be refs, or the default was not actually used.
