### PR TITLE
Use split:true for TC resolution everywhere

### DIFF
--- a/pretyping/coercion.ml
+++ b/pretyping/coercion.ml
@@ -354,7 +354,7 @@ let coerce_itf ?loc env sigma v t c1 =
 
 let saturate_evd env sigma =
   Typeclasses.resolve_typeclasses
-    ~filter:Typeclasses.no_goals ~split:true ~fail:false env sigma
+    ~filter:Typeclasses.no_goals ~fail:false env sigma
 
 type coercion_trace =
   | IdCoe

--- a/pretyping/pretype_errors.ml
+++ b/pretyping/pretype_errors.ml
@@ -61,7 +61,7 @@ type pretype_error =
   | TypingError of type_error
   | CannotUnifyOccurrences of subterm_unification_error
   | UnsatisfiableConstraints of
-    (Evar.t * Evar_kinds.t) option * Evar.Set.t option
+    (Evar.t * Evar_kinds.t) option * Evar.Set.t
   | DisallowedSProp
 
 exception PretypeError of env * Evd.evar_map * pretype_error

--- a/pretyping/pretype_errors.mli
+++ b/pretyping/pretype_errors.mli
@@ -67,7 +67,7 @@ type pretype_error =
   | TypingError of type_error
   | CannotUnifyOccurrences of subterm_unification_error
   | UnsatisfiableConstraints of
-    (Evar.t * Evar_kinds.t) option * Evar.Set.t option
+    (Evar.t * Evar_kinds.t) option * Evar.Set.t
     (** unresolvable evar, connex component *)
   | DisallowedSProp
 
@@ -166,7 +166,7 @@ val error_disallowed_sprop : env -> Evd.evar_map -> 'a
 (** {6 Typeclass errors } *)
 
 val unsatisfiable_constraints : env -> Evd.evar_map -> Evar.t option ->
-  Evar.Set.t option -> 'a
+  Evar.Set.t -> 'a
 
 val unsatisfiable_exception : exn -> bool
 

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -245,10 +245,10 @@ let typeclasses_filter ~program_mode frozen =
 let apply_typeclasses ~program_mode ~fail_evar env sigma frozen =
   let sigma = Typeclasses.resolve_typeclasses
       ~filter:(typeclasses_filter ~program_mode frozen)
-      ~split:true ~fail:fail_evar env sigma in
+      ~fail:fail_evar env sigma in
   let sigma = if program_mode then (* Try optionally solving the obligations *)
       Typeclasses.resolve_typeclasses
-        ~filter:(fun evk evi -> Typeclasses.all_evars evk evi && not (filter_frozen frozen evk)) ~split:true ~fail:false env sigma
+        ~filter:(fun evk evi -> Typeclasses.all_evars evk evi && not (filter_frozen frozen evk)) ~fail:false env sigma
     else sigma in
   sigma
 
@@ -277,7 +277,7 @@ let check_typeclasses_instances_are_solved ~program_mode env sigma frozen =
       sigma
   in
   if not (Evar.Set.is_empty tcs) then begin
-    Typeclasses.error_unresolvable env sigma (Some tcs)
+    Typeclasses.error_unresolvable env sigma tcs
   end
 
 let check_extra_evars_are_solved env current_sigma frozen = match frozen with

--- a/pretyping/typeclasses.ml
+++ b/pretyping/typeclasses.ml
@@ -244,25 +244,22 @@ let get_filtered_typeclass_evars filter evd =
   let check ev = filter ev (lazy (snd (Evd.evar_source (Evd.find evd ev)))) in
   Evar.Set.filter check tcs
 
-let solve_all_instances_hook = ref (fun env evd filter unique split fail -> assert false)
+let solve_all_instances_hook = ref (fun env evd filter unique fail -> assert false)
 
-let solve_all_instances env evd filter unique split fail =
-  !solve_all_instances_hook env evd filter unique split fail
+let solve_all_instances env evd filter unique fail =
+  !solve_all_instances_hook env evd filter unique fail
 
 let set_solve_all_instances f = solve_all_instances_hook := f
 
 let resolve_typeclasses ?(filter=no_goals) ?(unique=get_typeclasses_unique_solutions ())
-    ?(split=true) ?(fail=true) env evd =
+    ?(fail=true) env evd =
   if not (has_typeclasses filter evd) then evd
-  else solve_all_instances env evd filter unique split fail
+  else solve_all_instances env evd filter unique fail
 
 (** In case of unsatisfiable constraints, build a nice error message *)
 
 let error_unresolvable env evd comp =
-  let is_part ev = match comp with
-  | None -> true
-  | Some s -> Evar.Set.mem ev s
-  in
+  let is_part ev = Evar.Set.mem ev comp in
   let fold ev evi (found, accu) =
     let ev_class = class_of_constr env evd (Evd.evar_concl evi) in
     if not (Option.is_empty ev_class) && is_part ev then

--- a/pretyping/typeclasses.mli
+++ b/pretyping/typeclasses.mli
@@ -120,15 +120,15 @@ val is_class_evar : evar_map -> evar_info -> bool
 val is_class_type : evar_map -> EConstr.types -> bool
 
 val resolve_typeclasses : ?filter:evar_filter -> ?unique:bool ->
-  ?split:bool -> ?fail:bool -> env -> evar_map -> evar_map
+  ?fail:bool -> env -> evar_map -> evar_map
 val resolve_one_typeclass : ?unique:bool -> env -> evar_map -> EConstr.types -> evar_map * EConstr.constr
 
 val get_filtered_typeclass_evars : evar_filter -> evar_map -> Evar.Set.t
 
-val error_unresolvable : env -> evar_map -> Evar.Set.t option -> 'a
+val error_unresolvable : env -> evar_map -> Evar.Set.t -> 'a
 
 (** A plugin can override the TC resolution engine by calling these two APIs.
     Beware this action is not registed in the summary (the Undo system) so
     it is up to the plugin to do so. *)
-val set_solve_all_instances : (env -> evar_map -> evar_filter -> bool -> bool -> bool -> evar_map) -> unit
+val set_solve_all_instances : (env -> evar_map -> evar_filter -> bool -> bool -> evar_map) -> unit
 val set_solve_one_instance : (env -> evar_map -> EConstr.types -> bool -> evar_map * EConstr.constr) -> unit

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1569,8 +1569,7 @@ let check_types env flags (sigma,_,_ as subst) m n =
 
 let try_resolve_typeclasses env evd flag m n =
   if flag then
-    Typeclasses.resolve_typeclasses ~filter:Typeclasses.no_goals ~split:true
-      ~fail:true env evd
+    Typeclasses.resolve_typeclasses ~filter:Typeclasses.no_goals ~fail:true env evd
   else evd
 
 let w_unify_core_0 env evd with_types cv_pb flags m n =

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1569,7 +1569,7 @@ let check_types env flags (sigma,_,_ as subst) m n =
 
 let try_resolve_typeclasses env evd flag m n =
   if flag then
-    Typeclasses.resolve_typeclasses ~filter:Typeclasses.no_goals ~split:false
+    Typeclasses.resolve_typeclasses ~filter:Typeclasses.no_goals ~split:true
       ~fail:true env evd
   else evd
 

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -1457,7 +1457,7 @@ let apply_strategy (s : strategy) env unfresh concl (prop, cstr) evars =
 let solve_constraints env (evars,cstrs) =
   let oldtcs = Evd.get_typeclass_evars evars in
   let evars' = Evd.set_typeclass_evars evars cstrs in
-  let evars' = TC.resolve_typeclasses env ~filter:TC.all_evars ~split:true ~fail:true evars' in
+  let evars' = TC.resolve_typeclasses env ~filter:TC.all_evars ~fail:true evars' in
   Evd.set_typeclass_evars evars' oldtcs
 
 let nf_zeta =

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -1457,7 +1457,7 @@ let apply_strategy (s : strategy) env unfresh concl (prop, cstr) evars =
 let solve_constraints env (evars,cstrs) =
   let oldtcs = Evd.get_typeclass_evars evars in
   let evars' = Evd.set_typeclass_evars evars cstrs in
-  let evars' = TC.resolve_typeclasses env ~filter:TC.all_evars ~split:false ~fail:true evars' in
+  let evars' = TC.resolve_typeclasses env ~filter:TC.all_evars ~split:true ~fail:true evars' in
   Evd.set_typeclass_evars evars' oldtcs
 
 let nf_zeta =

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -884,10 +884,7 @@ let explain_unsatisfiable_constraints env sigma constr comp =
   let undef = Evd.undefined_map sigma in
   (* Only keep evars that are subject to resolution and members of the given
      component. *)
-  let is_kept evk _ = match comp with
-  | None -> Evar.Set.mem evk tcs
-  | Some comp -> Evar.Set.mem evk tcs && Evar.Set.mem evk comp
-  in
+  let is_kept evk _ = Evar.Set.mem evk tcs && Evar.Set.mem evk comp in
   let undef =
     let m = Evar.Map.filter is_kept undef in
       if Evar.Map.is_empty m then undef


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

As noted by Enrico and Maxime, there is no reason not to cluster/split the constraints before launching resolution on each component during typeclass resolution. We try to switch it on for the two calls in Coq's codebase that didn't use it.
It should only result in more precise/useful error messages.

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
