### PR TITLE
Remove unwanted "(optional)"

### DIFF
--- a/ide/coqide/dune
+++ b/ide/coqide/dune
@@ -31,7 +31,6 @@
  (foreign_stubs
   (language c)
   (names coqide_os_stubs))
- (optional)
  (libraries coqide-server.protocol coqide-server.core lablgtk3-sourceview3 platform_specific))
 
 (library


### PR DESCRIPTION
Fix the merge error introduced in #16142.  See [here](https://github.com/coq/coq/pull/16142#discussion_r995835567).

What are the consequences of having "(optional)"?  Should this PR be included with the backport of #16142 to 8.16.1?  Will it be a problem for users of the latest Coq Platform beta?

Attn: @ejgallego