### PR TITLE
Fix failure introduced by a semantic merge conflict.

### DIFF
--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -1675,7 +1675,7 @@ Controlling the proof flow
    form is used, Coq chooses the name.
 
 .. tacn:: instantiate {? ( @ident := @term ) }
-          instantiate ( @integer := @term ) {? @hloc }
+          instantiate ( @natural := @term ) {? @hloc }
    :name: instantiate; _
 
    .. insertprodn hloc hloc


### PR DESCRIPTION
#16642 changed the grammar and #16498 made `doc_grammar` check the tactics chapter. Because of this, the lint job is now failing on `master`.
