### PR TITLE
fix coqdep not recognizing ignore import_categories syntax

### DIFF
--- a/test-suite/misc/coqdep-require-filter-categories/fD.v
+++ b/test-suite/misc/coqdep-require-filter-categories/fD.v
@@ -1,0 +1,1 @@
+Require Import -(bla) fA(bli).

--- a/test-suite/misc/coqdep-require-filter-categories/fE.v
+++ b/test-suite/misc/coqdep-require-filter-categories/fE.v
@@ -1,0 +1,1 @@
+Require Import-(bla) fA(bli).

--- a/test-suite/misc/coqdep-require-filter-categories/fF.v
+++ b/test-suite/misc/coqdep-require-filter-categories/fF.v
@@ -1,0 +1,1 @@
+Require Import - (bla) fA(bli).

--- a/test-suite/misc/coqdep-require-filter-categories/fG.v
+++ b/test-suite/misc/coqdep-require-filter-categories/fG.v
@@ -1,0 +1,1 @@
+Require Import- (bla) fA(bli).

--- a/test-suite/misc/coqdep-require-filter-categories/stdout.ref
+++ b/test-suite/misc/coqdep-require-filter-categories/stdout.ref
@@ -4,3 +4,11 @@ fB.vo fB.glob fB.v.beautified fB.required_vo: fB.v fA.vo
 fB.vio: fB.v fA.vio
 fC.vo fC.glob fC.v.beautified fC.required_vo: fC.v fB.vo
 fC.vio: fC.v fB.vio
+fD.vo fD.glob fD.v.beautified fD.required_vo: fD.v fA.vo
+fD.vio: fD.v fA.vio
+fE.vo fE.glob fE.v.beautified fE.required_vo: fE.v fA.vo
+fE.vio: fE.v fA.vio
+fF.vo fF.glob fF.v.beautified fF.required_vo: fF.v fA.vo
+fF.vio: fF.v fA.vio
+fG.vo fG.glob fG.v.beautified fG.required_vo: fG.v fA.vo
+fG.vio: fG.v fA.vio

--- a/tools/coqdep/lib/lexer.mll
+++ b/tools/coqdep/lib/lexer.mll
@@ -120,14 +120,10 @@ and extra_dep_rule from = parse
 and require_modifiers from = parse
   | "(*"
       { comment lexbuf; require_modifiers from lexbuf }
-  | "Import" space+
+  | "Import" space*
       { require_file from lexbuf }
-  | "Export" space+
+  | "Export" space*
       { require_file from lexbuf }
-  | "Import" "("
-      { skip_parenthesized lexbuf; require_file from lexbuf }
-  | "Export" "("
-      { skip_parenthesized lexbuf; require_file from lexbuf }
   | space+
       { require_modifiers from lexbuf }
   | eof
@@ -192,7 +188,7 @@ and load_file = parse
 and require_file from = parse
   | "(*"
       { comment lexbuf; require_file from lexbuf }
-  | "("
+  | ("-" space*)? "("
     { skip_parenthesized lexbuf; require_file from lexbuf }
   | space+
       { require_file from lexbuf }


### PR DESCRIPTION
Fixes #16673 

- [x ] Added / updated **test-suite**. (a few tests for different cases of ignore import_categories modifiers)