### PR TITLE
Windows CI: use coq-ci branch from Platform.

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -31,8 +31,8 @@ jobs:
 
       - name: Download Platform
         env:
-          # Pinned to master branch after the opam pin fix, should be replaced by next tag once it is set.
-          PLATFORM: "https://github.com/coq/platform/archive/00e757ae93800aa016a667d3eb81244625310dcf.zip"
+          # Use a dedicated branch that follows master with some lag (manually updated)
+          PLATFORM: "https://github.com/coq/platform/archive/coq-ci.zip"
         run: |
           .\dev\ci\platform\coq-pf-02-download.bat
 


### PR DESCRIPTION
More flexible than an explicitly pinned version.

See https://coq.zulipchat.com/#narrow/stream/237656-Coq-devs-.26-plugin-devs/topic/windows.20failing for context.

This should fix the Windows CI.