### PR TITLE
Replace undocumented `Print TypeClasses` with `Print Typeclasses`

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/16690-master.rst
+++ b/doc/changelog/08-vernac-commands-and-options/16690-master.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  `Print Typeclasses` replaces the undocumented `Print TypeClasses` command
+  which displays the list of typeclasses
+  (`#16690 <https://github.com/coq/coq/pull/16690>`_,
+  fixes `#16686 <https://github.com/coq/coq/issues/16686>`_,
+  by Ali Caglayan).

--- a/doc/sphinx/addendum/type-classes.rst
+++ b/doc/sphinx/addendum/type-classes.rst
@@ -407,8 +407,9 @@ Summary of the commands
 
    Shows the list of instances associated with the typeclass :token:`reference`.
 
-.. cmd:: Print TypeClasses
-   :undocumented:
+.. cmd:: Print Typeclasses
+
+   Shows the list of typeclasses.
 
 .. tacn:: typeclasses eauto {? {| bfs | dfs | best_effort } } {? @nat_or_var } {? with {+ @ident } }
 

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1291,7 +1291,7 @@ printable: [
 | "Debug" "GC"
 | "Graph"
 | "Classes"
-| "TypeClasses"
+| "Typeclasses"
 | "Instances" smart_global
 | "Coercions"
 | "Coercion" "Paths" class_rawexpr class_rawexpr

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -894,7 +894,7 @@ command: [
 | "Print" "Debug" "GC"
 | "Print" "Graph"
 | "Print" "Classes"
-| "Print" "TypeClasses"
+| "Print" "Typeclasses"
 | "Print" "Instances" reference
 | "Print" "Coercions"
 | "Print" "Notation" string OPT [ "in" "custom" ident ]

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -1035,7 +1035,7 @@ GRAMMAR EXTEND Gram
       | IDENT "Debug"; IDENT "GC" -> { PrintDebugGC }
       | IDENT "Graph" -> { PrintGraph }
       | IDENT "Classes" -> {  PrintClasses }
-      | IDENT "TypeClasses" -> { PrintTypeClasses }
+      | IDENT "Typeclasses" -> { PrintTypeclasses }
       | IDENT "Instances"; qid = smart_global -> { PrintInstances qid }
       | IDENT "Coercions" -> { PrintCoercions }
       | IDENT "Coercion"; IDENT "Paths"; s = class_rawexpr; t = class_rawexpr ->

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -578,8 +578,8 @@ let pr_printable = function
     keyword "Print Graph"
   | PrintClasses ->
     keyword "Print Classes"
-  | PrintTypeClasses ->
-    keyword "Print TypeClasses"
+  | PrintTypeclasses ->
+    keyword "Print Typeclasses"
   | PrintInstances qid ->
     keyword "Print Instances" ++ spc () ++ pr_smart_global qid
   | PrintCoercions ->

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2083,8 +2083,8 @@ let vernac_print ~pstate =
     dump_global qid;
     Prettyp.print_name env sigma qid udecl
   | PrintGraph -> Prettyp.print_graph ()
-  | PrintClasses -> Prettyp.print_classes()
-  | PrintTypeClasses -> Prettyp.print_typeclasses()
+  | PrintClasses -> Prettyp.print_classes ()
+  | PrintTypeclasses -> Prettyp.print_typeclasses ()
   | PrintInstances c -> Prettyp.print_instances (smart_global c)
   | PrintCoercions -> Prettyp.print_coercions ()
   | PrintNotation (entry, ntnstr) -> Prettyp.print_notation env sigma entry ntnstr

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -43,7 +43,7 @@ type printable =
   | PrintName of qualid or_by_notation * UnivNames.univ_name_list option
   | PrintGraph
   | PrintClasses
-  | PrintTypeClasses
+  | PrintTypeclasses
   | PrintInstances of qualid or_by_notation
   | PrintCoercions
   | PrintCoercionPaths of class_rawexpr * class_rawexpr


### PR DESCRIPTION
I have made this AsError to see the effect on CI. Perhaps we should just remove it completely.

Fix #16686

- [x] Documentation
- [x] Changelog