### PR TITLE
Remove the support of metavariables from native and VM compilation.

### DIFF
--- a/kernel/genlambda.mli
+++ b/kernel/genlambda.mli
@@ -20,7 +20,6 @@ type case_annot = case_info * reloc_table * Declarations.recursivity_kind
 type 'v lambda =
 | Lrel          of Name.t * int
 | Lvar          of Id.t
-| Lmeta         of metavariable * 'v lambda (* type *)
 | Levar         of Evar.t * 'v lambda array (* arguments *)
 | Lprod         of 'v lambda * 'v lambda
 | Llam          of Name.t Context.binder_annot array * 'v lambda
@@ -51,8 +50,7 @@ and 'v lam_branches =
 and 'v fix_decl = Name.t Context.binder_annot array * 'v lambda array * 'v lambda array
 
 type evars =
-    { evars_val : constr evar_handler;
-      evars_metas : metavariable -> types }
+  { evars_val : constr evar_handler }
 
 val empty_evars : evars
 

--- a/kernel/nativecode.mli
+++ b/kernel/nativecode.mli
@@ -43,8 +43,6 @@ val get_match : symbols -> int -> Nativevalues.annot_sw
 
 val get_ind : symbols -> int -> inductive
 
-val get_meta : symbols -> int -> metavariable
-
 val get_evar : symbols -> int -> Evar.t
 
 val get_level : symbols -> int -> Univ.Level.t

--- a/kernel/nativeconv.ml
+++ b/kernel/nativeconv.ml
@@ -74,8 +74,6 @@ and conv_atom env pb lvl a1 a2 cu =
   if a1 == a2 then cu
   else
     match a1, a2 with
-    | Ameta (m1,_), Ameta (m2,_) ->
-      if Int.equal m1 m2 then cu else raise NotConvertible
     | Aevar (ev1, args1), Aevar (ev2, args2) ->
       if Evar.equal ev1 ev2 then
         Array.fold_right2 (conv_val env CONV lvl) args1 args2 cu
@@ -126,7 +124,7 @@ and conv_atom env pb lvl a1 a2 cu =
        else conv_accu env CONV lvl ac1 ac2 cu
     | Arel _, _ | Aind _, _ | Aconstant _, _ | Asort _, _ | Avar _, _
     | Acase _, _ | Afix _, _ | Acofix _, _
-    | Aproj _, _ | Ameta _, _ | Aevar _, _ -> raise NotConvertible
+    | Aproj _, _ | Aevar _, _ -> raise NotConvertible
 
 (* Precondition length t1 = length f1 = length f2 = length t2 *)
 and conv_fix env lvl t1 f1 t2 f2 cu =

--- a/kernel/nativelambda.ml
+++ b/kernel/nativelambda.ml
@@ -25,7 +25,7 @@ type lambda = Nativevalues.t Genlambda.lambda
 let can_subst lam =
   match lam with
   | Lrel _ | Lvar _ | Lconst _ | Lval _ | Lsort _ | Lind _ | Llam _
-  | Lmeta _ | Levar _ -> true
+  | Levar _ -> true
   | _ -> false
 
 let simplify subst lam = simplify can_subst subst lam

--- a/kernel/nativevalues.ml
+++ b/kernel/nativevalues.ml
@@ -93,7 +93,6 @@ type atom =
   | Afix of t array * t array * rec_pos * int
             (* types, bodies, rec_pos, pos *)
   | Acofix of t array * t array * int * vcofix
-  | Ameta of metavariable * t
   | Aevar of Evar.t * t array
   | Aproj of (inductive * int) * accumulator
 
@@ -104,7 +103,6 @@ type symbol =
   | SymbConst of Constant.t
   | SymbMatch of annot_sw
   | SymbInd of inductive
-  | SymbMeta of metavariable
   | SymbEvar of Evar.t
   | SymbLevel of Univ.Level.t
   | SymbProj of (inductive * int)
@@ -212,9 +210,6 @@ let mk_prod s dom codom =
      have length >= 2. *)
   let block = Obj.repr (Vprod (s, dom, codom)) in
   (Obj.magic (ref block) : t)
-
-let mk_meta_accu mv = of_fun (fun ty ->
-  mk_accu (Ameta (mv,ty)))
 
 let mk_evar_accu ev args =
   mk_accu (Aevar (ev, args))

--- a/kernel/nativevalues.mli
+++ b/kernel/nativevalues.mli
@@ -62,7 +62,6 @@ type atom =
   | Acase of annot_sw * accumulator * t * t
   | Afix of t array * t array * rec_pos * int
   | Acofix of t array * t array * int * vcofix
-  | Ameta of metavariable * t
   | Aevar of Evar.t * t array (* arguments *)
   | Aproj of (inductive * int) * accumulator
 
@@ -73,7 +72,6 @@ type symbol =
   | SymbConst of Constant.t
   | SymbMatch of annot_sw
   | SymbInd of inductive
-  | SymbMeta of metavariable
   | SymbEvar of Evar.t
   | SymbLevel of Univ.Level.t
   | SymbProj of (inductive * int)
@@ -94,7 +92,6 @@ val mk_var_accu : Id.t -> t
 val mk_sw_accu : annot_sw -> accumulator -> t -> (t -> t)
 val mk_fix_accu : rec_pos  -> int -> t array -> t array -> t
 val mk_cofix_accu : int -> t array -> t array -> t
-val mk_meta_accu : metavariable -> t
 val mk_evar_accu : Evar.t -> t array -> t
 val mk_proj_accu : (inductive * int) -> accumulator -> t
 val upd_cofix : t -> t -> unit

--- a/kernel/vmbytegen.ml
+++ b/kernel/vmbytegen.ml
@@ -529,10 +529,6 @@ let rec compile_lam env cenv lam sz cont =
 
   | Lvar id -> pos_named id cenv :: cont
 
-  | Lmeta (_mv, _ty) ->
-    (* TODO: handle me *)
-    raise (Invalid_argument "Vmbytegen.compile_lam: Meta")
-
   | Levar (evk, args) ->
       if Array.is_empty args then
         compile_fv_elem cenv (FVevar evk) sz cont

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -291,7 +291,6 @@ and nf_atom env sigma atom =
   | Aind ind -> mkIndU ind
   | Asort s -> mkSort s
   | Avar id -> mkVar id
-  | Ameta (mv,_) -> mkMeta mv
   | Aproj (p, c) ->
       let c = nf_accu env sigma c in
       let p = get_proj env p in
@@ -367,9 +366,6 @@ and nf_atom_type env sigma atom =
       mkCoFix(s,(names,tt,ft)), tt.(s)
   | Aevar(evk,args) ->
     nf_evar env sigma evk args
-  | Ameta(mv,ty) ->
-     let ty = nf_type env sigma ty in
-     mkMeta mv, ty
   | Aproj(p,c) ->
       let c,tc = nf_accu_type env sigma c in
       let cj = make_judge c tc in
@@ -443,8 +439,7 @@ and nf_array env sigma t typ =
   mkArray(u, t, nf_val env sigma vdef typ_elem, typ_elem)
 
 let evars_of_evar_map sigma =
-  { Genlambda.evars_val = Evd.evar_handler sigma;
-    Genlambda.evars_metas = Evd.meta_type0 sigma }
+  { Genlambda.evars_val = Evd.evar_handler sigma }
 
 (* fork perf process, return profiler's process id *)
 let start_profiler_linux profile_fn =

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1190,8 +1190,7 @@ let infer_conv_ustate ?(catch_incon=true) ?(pb=Reduction.CUMUL)
     report_anomaly e
 
 let evars_of_evar_map sigma =
-  { Genlambda.evars_val = Evd.evar_handler sigma;
-    Genlambda.evars_metas = Evd.meta_type0 sigma }
+  { Genlambda.evars_val = Evd.evar_handler sigma }
 
 let vm_infer_conv ?(pb=Reduction.CUMUL) env sigma t1 t2 =
   infer_conv_gen (fun pb ~l2r sigma ts ->

--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -440,8 +440,7 @@ and nf_array env sigma t typ =
   mkArray(u, t, nf_val env sigma vdef typ_elem, typ_elem)
 
 let evars_of_evar_map sigma =
-  { Genlambda.evars_val = Evd.evar_handler sigma;
-    Genlambda.evars_metas = Evd.meta_type0 sigma }
+  { Genlambda.evars_val = Evd.evar_handler sigma }
 
 let cbv_vm env sigma c t  =
   if Termops.occur_meta sigma c then


### PR DESCRIPTION
This was virtually unused, because nowadays metas essentially never occur outside of the internals of the unification engine. Given the fact that meta typing is fundamentally unsound, it was also probably exposing ways to trigger memory corruption of the host system.

Depends on #16671.