### PR TITLE
Uniform naming scheme for VM kind views

### DIFF
--- a/dev/vm_printers.ml
+++ b/dev/vm_printers.ml
@@ -78,8 +78,8 @@ and ppwhd whd =
   | Vfun _ -> print_string "function"
   | Vfix _ -> print_vfix()
   | Vcofix _ -> print_string "cofix"
-  | Vconstr_const i -> print_string "C(";print_int i;print_string")"
-  | Vconstr_block b -> ppvblock b
+  | Vconst i -> print_string "C(";print_int i;print_string")"
+  | Vblock b -> ppvblock b
   | Vint64 i -> printf "int64(%LiL)" i
   | Vfloat64 f -> printf "float64(%.17g)" f
   | Varray t -> ppvarray t

--- a/dev/vm_printers.ml
+++ b/dev/vm_printers.ml
@@ -83,7 +83,7 @@ and ppwhd whd =
   | Vint64 i -> printf "int64(%LiL)" i
   | Vfloat64 f -> printf "float64(%.17g)" f
   | Varray t -> ppvarray t
-  | Vatom_stk(a,s) ->
+  | Vaccu (a, s) ->
       open_hbox();ppatom a;close_box();
       print_string"@";ppstack s
 

--- a/kernel/vconv.ml
+++ b/kernel/vconv.ml
@@ -53,9 +53,9 @@ and conv_whd env pb k whd1 whd2 cu =
   | Vcofix (cf1,_,Some args1), Vcofix (cf2,_,Some args2) ->
       if nargs args1 <> nargs args2 then raise NotConvertible
       else conv_arguments env k args1 args2 (conv_cofix env k cf1 cf2 cu)
-  | Vconstr_const i1, Vconstr_const i2 ->
+  | Vconst i1, Vconst i2 ->
       if Int.equal i1 i2 then cu else raise NotConvertible
-  | Vconstr_block b1, Vconstr_block b2 ->
+  | Vblock b1, Vblock b2 ->
       let tag1 = btag b1 and tag2 = btag b2 in
       let sz = bsize b1 in
       if Int.equal tag1 tag2 && Int.equal sz (bsize b2) then
@@ -81,8 +81,8 @@ and conv_whd env pb k whd1 whd2 cu =
      (* on the fly eta expansion *)
       conv_val env CONV (k+1) (apply_whd k whd1) (apply_whd k whd2) cu
 
-  | Vprod _, _ | Vfix _, _ | Vcofix _, _  | Vconstr_const _, _ | Vint64 _, _
-  | Vfloat64 _, _ | Varray _, _ | Vconstr_block _, _ | Vaccu _, _ -> raise NotConvertible
+  | Vprod _, _ | Vfix _, _ | Vcofix _, _  | Vconst _, _ | Vint64 _, _
+  | Vfloat64 _, _ | Varray _, _ | Vblock _, _ | Vaccu _, _ -> raise NotConvertible
 
 
 and conv_atom env pb k a1 stk1 a2 stk2 cu =

--- a/kernel/vconv.ml
+++ b/kernel/vconv.ml
@@ -75,14 +75,14 @@ and conv_whd env pb k whd1 whd2 cu =
     let n = Parray.length_int t1 in
     if not (Int.equal n (Parray.length_int t2)) then raise NotConvertible;
     Parray.fold_left2 (fun cu v1 v2 -> conv_val env CONV k v1 v2 cu) cu t1 t2
-  | Vatom_stk(a1,stk1), Vatom_stk(a2,stk2) ->
+  | Vaccu (a1, stk1), Vaccu (a2, stk2) ->
       conv_atom env pb k a1 stk1 a2 stk2 cu
   | Vfun _, _ | _, Vfun _ ->
      (* on the fly eta expansion *)
       conv_val env CONV (k+1) (apply_whd k whd1) (apply_whd k whd2) cu
 
   | Vprod _, _ | Vfix _, _ | Vcofix _, _  | Vconstr_const _, _ | Vint64 _, _
-  | Vfloat64 _, _ | Varray _, _ | Vconstr_block _, _ | Vatom_stk _, _ -> raise NotConvertible
+  | Vfloat64 _, _ | Varray _, _ | Vconstr_block _, _ | Vaccu _, _ -> raise NotConvertible
 
 
 and conv_atom env pb k a1 stk1 a2 stk2 cu =

--- a/kernel/vm.ml
+++ b/kernel/vm.ml
@@ -163,7 +163,7 @@ let rec apply_stack a stk v =
 let apply_whd k whd =
   let v = val_of_rel k in
   match whd with
-  | Vprod _ | Vconstr_const _ | Vconstr_block _ | Vint64 _ | Vfloat64 _ | Varray _ ->
+  | Vprod _ | Vconst _ | Vblock _ | Vint64 _ | Vfloat64 _ | Varray _ ->
      assert false
   | Vfun f -> reduce_fun k f
   | Vfix(f, None) ->

--- a/kernel/vm.ml
+++ b/kernel/vm.ml
@@ -179,6 +179,6 @@ let apply_whd k whd =
       push_ra stop;
       push_val v;
       interprete (cofix_upd_code to_up) (cofix_upd_val to_up) (cofix_upd_env to_up) 0
-  | Vatom_stk(a,stk) ->
+  | Vaccu (a, stk) ->
       apply_stack (val_of_atom a) stk v
 

--- a/kernel/vmvalues.ml
+++ b/kernel/vmvalues.ml
@@ -277,8 +277,8 @@ type whd =
   | Vfun of vfun
   | Vfix of vfix * arguments option
   | Vcofix of vcofix * to_update * arguments option
-  | Vconstr_const of int
-  | Vconstr_block of vblock
+  | Vconst of int
+  | Vblock of vblock
   | Vint64 of int64
   | Vfloat64 of float
   | Varray of values Parray.t
@@ -369,7 +369,7 @@ let accumulate = accumulate ()
 
 let whd_val (v: values) =
   let o = Obj.repr v in
-  if Obj.is_int o then Vconstr_const (Obj.obj o)
+  if Obj.is_int o then Vconst (Obj.obj o)
   else
     let tag = Obj.tag o in
     if Int.equal tag 0 then
@@ -387,7 +387,7 @@ let whd_val (v: values) =
     else if Int.equal tag Obj.custom_tag then Vint64 (Obj.magic v)
     else if Int.equal tag Obj.double_tag then Vfloat64 (Obj.magic v)
     else
-      Vconstr_block (Obj.obj o)
+      Vblock (Obj.obj o)
 
 (**********************************************)
 (* Constructors *******************************)
@@ -651,8 +651,8 @@ and pr_whd w =
   | Vfun _ -> str "Vfun"
   | Vfix _ -> str "Vfix"
   | Vcofix _ -> str "Vcofix"
-  | Vconstr_const i -> str "Vconstr_const(" ++ int i ++ str ")"
-  | Vconstr_block _b -> str "Vconstr_block"
+  | Vconst i -> str "Vconst(" ++ int i ++ str ")"
+  | Vblock _b -> str "Vblock"
   | Vint64 i -> i |> Format.sprintf "Vint64(%LiL)" |> str
   | Vfloat64 f -> str "Vfloat64(" ++ str (Float64.(to_string (of_float f))) ++ str ")"
   | Varray _ -> str "Varray"

--- a/kernel/vmvalues.mli
+++ b/kernel/vmvalues.mli
@@ -121,8 +121,8 @@ type whd =
   | Vfun of vfun
   | Vfix of vfix * arguments option
   | Vcofix of vcofix * to_update * arguments option
-  | Vconstr_const of int
-  | Vconstr_block of vblock
+  | Vconst of int
+  | Vblock of vblock
   | Vint64 of int64
   | Vfloat64 of float
   | Varray of values Parray.t

--- a/kernel/vmvalues.mli
+++ b/kernel/vmvalues.mli
@@ -117,6 +117,7 @@ type stack = zipper list
 
 type whd =
   | Vprod of vprod
+  | Vaccu of atom * stack
   | Vfun of vfun
   | Vfix of vfix * arguments option
   | Vcofix of vcofix * to_update * arguments option
@@ -125,7 +126,6 @@ type whd =
   | Vint64 of int64
   | Vfloat64 of float
   | Varray of values Parray.t
-  | Vatom_stk of atom * stack
 
 (** For debugging purposes only *)
 

--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -185,9 +185,9 @@ and nf_whd env sigma whd typ =
   | Vint64 i -> i |> Uint63.of_int64 |> mkInt
   | Vfloat64 f -> f |> Float64.of_float |> mkFloat
   | Varray t -> nf_array env sigma t typ
-  | Vatom_stk(Aid idkey, stk) ->
+  | Vaccu (Aid idkey, stk) ->
       constr_type_of_idkey env sigma idkey stk
-  | Vatom_stk(Aind ((mi,i) as ind), stk) ->
+  | Vaccu (Aind ((mi, i) as ind), stk) ->
      let mib = Environ.lookup_mind mi env in
      let nb_univs =
        Univ.AbstractContext.size (Declareops.inductive_polymorphic_context mib)
@@ -196,7 +196,7 @@ and nf_whd env sigma whd typ =
        let pind = (ind, u) in (mkIndU pind, type_of_ind env pind)
      in
      nf_univ_args ~nb_univs mk env sigma stk
-  | Vatom_stk(Asort s, stk) ->
+  | Vaccu (Asort s, stk) ->
     assert (List.is_empty stk); mkSort s
 
 and nf_univ_args ~nb_univs mk env sigma stk =

--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -169,14 +169,14 @@ and nf_whd env sigma whd typ =
       let t = ta.(i) in
       let _, args = nf_args env sigma vargs t in
       mkApp(cfd,args)
-  | Vconstr_const n ->
+  | Vconst n ->
     construct_of_constr_const env sigma n typ
-  | Vconstr_block b ->
+  | Vblock b ->
       let tag = btag b in
       let (tag,ofs) =
         if tag = Obj.last_non_constant_constructor_tag then
           match whd_val (bfield b 0) with
-          | Vconstr_const tag -> (tag+Obj.last_non_constant_constructor_tag, 1)
+          | Vconst tag -> (tag+Obj.last_non_constant_constructor_tag, 1)
           | _ -> assert false
         else (tag, 0) in
       let capp,ctyp = construct_of_constr_block env sigma tag typ in


### PR DESCRIPTION
This makes the constructor names consistent with the native implementation.

Extracted from #16629.