### PR TITLE
Move the Prod case from native atoms to values.

### DIFF
--- a/kernel/nativecode.ml
+++ b/kernel/nativecode.ml
@@ -1822,7 +1822,7 @@ let pp_mllam fmt l =
     Array.iter pp_branch bs
 
   and pp_primitive fmt = function
-    | Mk_prod -> Format.fprintf fmt "mk_prod_accu"
+    | Mk_prod -> Format.fprintf fmt "mk_prod"
     | Mk_sort -> Format.fprintf fmt "mk_sort_accu"
     | Mk_ind -> Format.fprintf fmt "mk_ind_accu"
     | Mk_const -> Format.fprintf fmt "mk_constant_accu"

--- a/kernel/nativevalues.ml
+++ b/kernel/nativevalues.ml
@@ -93,7 +93,6 @@ type atom =
   | Afix of t array * t array * rec_pos * int
             (* types, bodies, rec_pos, pos *)
   | Acofix of t array * t array * int * vcofix
-  | Aprod of Name.t * t * t
   | Ameta of metavariable * t
   | Aevar of Evar.t * t array
   | Aproj of (inductive * int) * accumulator
@@ -189,8 +188,19 @@ let mk_var_accu id =
 let mk_sw_accu annot c p ac =
   mk_accu (Acase(annot,c,p,ac))
 
-let mk_prod_accu s dom codom =
-  mk_accu (Aprod (s,dom,codom))
+let prod_tag = 2
+
+let mk_prod s dom codom =
+  (* [Prod (s, dom, codom)] is coded as [tag:0|[tag:2|s; dom; codom]]
+     This looks like a PArray but has a tag distinct from all PArray values on
+     the inner block. This cannot be an accumulator because all accumulators
+     have length >= 2. *)
+  let block = Obj.new_block prod_tag 3 in
+  let block : Obj.t array = Obj.obj block in
+  let () = block.(0) <- (Obj.repr s) in
+  let () = block.(1) <- (Obj.repr dom) in
+  let () = block.(2) <- (Obj.repr codom) in
+  (Obj.magic (ref block) : t)
 
 let mk_meta_accu mv = of_fun (fun ty ->
   mk_accu (Ameta (mv,ty)))
@@ -283,6 +293,7 @@ let block_tag (b:block) =
 
 type kind_of_value =
   | Vaccu of accumulator
+  | Vprod of Name.t * t * t
   | Vfun of (t -> t)
   | Vconst of int
   | Vint64 of int64
@@ -296,7 +307,15 @@ let kind_of_value (v:t) =
   else
     let tag = Obj.tag o in
     if Int.equal tag accumulate_tag then
-      if Int.equal (Obj.size o) 1 then Varray (Obj.magic v)
+      if Int.equal (Obj.size o) 1 then
+        let w = Obj.field o 0 in
+        let tag = Obj.tag w in
+        if Int.equal tag prod_tag then
+          let na : Name.t = Obj.obj (Obj.field w 0) in
+          let dom : t = Obj.obj (Obj.field w 1) in
+          let codom : t = Obj.obj (Obj.field w 2) in
+          Vprod (na, dom, codom)
+        else Varray (Obj.magic v)
       else Vaccu (Obj.magic v)
     else if Int.equal tag Obj.custom_tag then Vint64 (Obj.magic v)
     else if Int.equal tag Obj.double_tag then Vfloat64 (Obj.magic v)
@@ -788,6 +807,9 @@ let next_down accu x =
   else apply accu x
 
 let is_parray t =
+  (* This is only used over values known to inhabit an array type, so we just
+     have to discriminate between actual arrays and accumulators. The latter
+     are always closures with the tag set to 0, so they have size >= 2. *)
   let t = Obj.magic t in
   Obj.is_block t && Obj.size t = 1
 

--- a/kernel/nativevalues.mli
+++ b/kernel/nativevalues.mli
@@ -140,8 +140,8 @@ val block_tag : block -> int
 
 type kind_of_value =
   | Vaccu of accumulator
-  | Vprod of Name.t * t * t
   | Vfun of (t -> t)
+  | Vprod of Name.t * t * t
   | Vconst of int
   | Vint64 of int64
   | Vfloat64 of float

--- a/kernel/nativevalues.mli
+++ b/kernel/nativevalues.mli
@@ -62,7 +62,6 @@ type atom =
   | Acase of annot_sw * accumulator * t * t
   | Afix of t array * t array * rec_pos * int
   | Acofix of t array * t array * int * vcofix
-  | Aprod of Name.t * t * t
   | Ameta of metavariable * t
   | Aevar of Evar.t * t array (* arguments *)
   | Aproj of (inductive * int) * accumulator
@@ -93,7 +92,6 @@ val mk_ind_accu : inductive -> Univ.Level.t array -> t
 val mk_sort_accu : Sorts.t -> Univ.Level.t array -> t
 val mk_var_accu : Id.t -> t
 val mk_sw_accu : annot_sw -> accumulator -> t -> (t -> t)
-val mk_prod_accu : Name.t -> t -> t -> t
 val mk_fix_accu : rec_pos  -> int -> t array -> t array -> t
 val mk_cofix_accu : int -> t array -> t array -> t
 val mk_meta_accu : metavariable -> t
@@ -103,6 +101,7 @@ val upd_cofix : t -> t -> unit
 val force_cofix : t -> t
 val mk_const : tag -> t
 val mk_block : tag -> t array -> t
+val mk_prod : Name.t -> t -> t -> t
 
 val mk_bool : bool -> t
 [@@ocaml.inline always]
@@ -141,6 +140,7 @@ val block_tag : block -> int
 
 type kind_of_value =
   | Vaccu of accumulator
+  | Vprod of Name.t * t * t
   | Vfun of (t -> t)
   | Vconst of int
   | Vint64 of int64


### PR DESCRIPTION
We had to cheat a bit to abuse the value representation of blocks of tag 0 in the native compiler. There used to be two possible kinds of 0-tagged blocks:

- Either they had size >= 2 in which case they were accumulators coded as closures, where the tag 0 was the well-known hack to make them behave as an ADT constructor at runtime.
- Or they had size 1, in which case they were persistent arrays. The fact this works was abusing the internal representation of persistent arrays, which are a reference on some ADT with 2 non-constant constructors.

In order to extend this, we simply wrap Prod values into a dummy 0-tagged block and encode them as a 3-uple with a tag that is distinct from the ones defined by the PArray implementation.
