### PR TITLE
Make the evar_info type private.

### DIFF
--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -405,18 +405,19 @@ let push_rel_context_to_named_context ~hypnaming env sigma typ =
 
 let new_pure_evar = Evd.new_pure_evar
 
+let next_evar_name sigma naming = match naming with
+| IntroAnonymous -> None
+| IntroIdentifier id -> Some id
+| IntroFresh id ->
+  let has_name id = try let _ = Evd.evar_key id sigma in true with Not_found -> false in
+  let id = Namegen.next_ident_away_from id has_name in
+  Some id
+
 (* [new_evar] declares a new existential in an env env with type typ *)
 (* Converting the env into the sign of the evar to define *)
 let new_evar ?src ?filter ?abstract_arguments ?candidates ?(naming = IntroAnonymous) ?typeclass_candidate
     ?principal ?hypnaming env evd typ =
-  let name = match naming with
-  | IntroAnonymous -> None
-  | IntroIdentifier id -> Some id
-  | IntroFresh id ->
-    let has_name id = try let _ = Evd.evar_key id evd in true with Not_found -> false in
-    let id = Namegen.next_ident_away_from id has_name in
-    Some id
-  in
+  let name = next_evar_name evd naming in
   let hypnaming = match hypnaming with
   | Some n -> n
   | None -> RenameExistingBut (VarSet.variables (Global.env ()))

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -403,11 +403,12 @@ let push_rel_context_to_named_context ~hypnaming env sigma typ =
  * Entry points to define new evars   *
  *------------------------------------*)
 
-let default_source = Loc.tag @@ Evar_kinds.InternalHole
+let new_pure_evar = Evd.new_pure_evar
 
-let new_pure_evar ?(src=default_source) ?(filter = Filter.identity) ?(relevance = Sorts.Relevant)
-  ?(abstract_arguments = Abstraction.identity) ?candidates
-  ?(naming = IntroAnonymous) ?typeclass_candidate ?(principal=false) sign evd typ =
+(* [new_evar] declares a new existential in an env env with type typ *)
+(* Converting the env into the sign of the evar to define *)
+let new_evar ?src ?filter ?abstract_arguments ?candidates ?(naming = IntroAnonymous) ?typeclass_candidate
+    ?principal ?hypnaming env evd typ =
   let name = match naming with
   | IntroAnonymous -> None
   | IntroIdentifier id -> Some id
@@ -416,29 +417,6 @@ let new_pure_evar ?(src=default_source) ?(filter = Filter.identity) ?(relevance 
     let id = Namegen.next_ident_away_from id has_name in
     Some id
   in
-  let evi = {
-    evar_hyps = sign;
-    evar_concl = typ;
-    evar_body = Evar_empty;
-    evar_filter = filter;
-    evar_abstract_arguments = abstract_arguments;
-    evar_source = src;
-    evar_candidates = candidates;
-    evar_relevance = relevance;
-  }
-  in
-  let typeclass_candidate = if principal then Some false else typeclass_candidate in
-  let (evd, newevk) = Evd.new_evar evd ?name ?typeclass_candidate evi in
-  let evd =
-    if principal then Evd.declare_principal_goal newevk evd
-    else Evd.declare_future_goal newevk evd
-  in
-  (evd, newevk)
-
-(* [new_evar] declares a new existential in an env env with type typ *)
-(* Converting the env into the sign of the evar to define *)
-let new_evar ?src ?filter ?abstract_arguments ?candidates ?naming ?typeclass_candidate
-    ?principal ?hypnaming env evd typ =
   let hypnaming = match hypnaming with
   | Some n -> n
   | None -> RenameExistingBut (VarSet.variables (Global.env ()))
@@ -451,7 +429,7 @@ let new_evar ?src ?filter ?abstract_arguments ?candidates ?naming ?typeclass_can
     | None -> instance
     | Some filter -> Filter.filter_slist filter instance in
   let relevance = Sorts.Relevant in (* FIXME: relevant_of_type not defined yet *)
-  let (evd, evk) = new_pure_evar sign evd typ' ?src ?filter ~relevance ?abstract_arguments ?candidates ?naming
+  let (evd, evk) = new_pure_evar sign evd typ' ?src ?filter ~relevance ?abstract_arguments ?candidates ?name
     ?typeclass_candidate ?principal in
   (evd, EConstr.mkEvar (evk, instance))
 

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -45,19 +45,12 @@ val new_evar :
   ?principal:bool -> ?hypnaming:naming_mode ->
   env -> evar_map -> types -> evar_map * EConstr.t
 
-(** Low-level interface to create an evar.
-  @param src User-facing source for the evar
-  @param filter See {!Evd.Filter}, must be the same length as [named_context_val]
-  @param naming A naming scheme for the evar
-  @param principal Whether the evar is the principal goal
-  @param named_context_val The context of the evar
-  @param types The type of conclusion of the evar
-*)
+(** Alias of {!Evd.new_evar} *)
 val new_pure_evar :
   ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
   ?relevance:Sorts.relevance ->
   ?abstract_arguments:Abstraction.t -> ?candidates:constr list ->
-  ?naming:intro_pattern_naming_expr ->
+  ?name:Id.t ->
   ?typeclass_candidate:bool ->
   ?principal:bool ->
   named_context_val -> evar_map -> types -> evar_map * Evar.t

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -24,6 +24,8 @@ val new_meta : unit -> metavariable
 
 (** {6 Creating a fresh evar given their type and context} *)
 
+val next_evar_name : evar_map -> intro_pattern_naming_expr -> Id.t option
+
 module VarSet :
 sig
   type t

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -98,7 +98,7 @@ type evar_body =
   | Evar_empty
   | Evar_defined of econstr
 
-type evar_info = {
+type evar_info = private {
   evar_concl : econstr;
   (** Type of the evar. *)
   evar_hyps : named_context_val; (* TODO econstr? *)
@@ -178,6 +178,23 @@ val new_evar : evar_map ->
   ?name:Id.t -> ?typeclass_candidate:bool -> evar_info -> evar_map * Evar.t
 (** Creates a fresh evar mapping to the given information. *)
 
+val new_pure_evar :
+  ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
+  ?relevance:Sorts.relevance ->
+  ?abstract_arguments:Abstraction.t -> ?candidates:econstr list ->
+  ?name:Id.t ->
+  ?typeclass_candidate:bool ->
+  ?principal:bool ->
+  named_context_val -> evar_map -> etypes -> evar_map * Evar.t
+(** Low-level interface to create an evar.
+  @param src User-facing source for the evar
+  @param filter See {!Evd.Filter}, must be the same length as [named_context_val]
+  @param name A name for the evar
+  @param principal Whether the evar is the principal goal
+  @param named_context_val The context of the evar
+  @param types The type of conclusion of the evar
+*)
+
 val add : evar_map -> Evar.t -> evar_info -> evar_map
 (** [add sigma ev info] adds [ev] with evar info [info] in sigma.
     Precondition: ev must not preexist in [sigma]. *)
@@ -191,6 +208,9 @@ val find_undefined : evar_map -> Evar.t -> evar_info
 
 val remove : evar_map -> Evar.t -> evar_map
 (** Remove an evar from an evar map. Use with caution. *)
+
+val undefine : evar_map -> Evar.t -> evar_map [@@ocaml.deprecated]
+(** Remove the body of an evar. Only there for backward compat, do not use. *)
 
 val mem : evar_map -> Evar.t -> bool
 (** Whether an evar is present in an evarmap. *)

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -1085,26 +1085,6 @@ module Goal = struct
       state = state ;
       self = goal }
 
-  let nf_gmake env sigma goal =
-    let state = get_state goal in
-    let goal = drop_state goal in
-    let info = Evarutil.nf_evar_info sigma (Evd.find sigma goal) in
-    let sigma = Evd.add sigma goal info in
-    gmake_with info env sigma goal state , sigma
-
-  let nf_enter f =
-    InfoL.tag (Info.Dispatch) begin
-    iter_goal begin fun goal ->
-      tclENV >>= fun env ->
-      tclEVARMAP >>= fun sigma ->
-      try
-        let (gl, sigma) = nf_gmake env sigma goal in
-        tclTHEN (Unsafe.tclEVARS sigma) (InfoL.tag (Info.DBranch) (f gl))
-      with e when catchable_exception e ->
-        let (e, info) = Exninfo.capture e in
-        tclZERO ~info e
-    end
-    end
   let gmake env sigma goal =
     let state = get_state goal in
     let goal = drop_state goal in

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -529,14 +529,9 @@ module Goal : sig
   val sigma : t -> Evd.evar_map
   val state : t -> Proofview_monad.StateStore.t
 
-  (** [nf_enter t] applies the goal-dependent tactic [t] in each goal
+  (** [enter t] applies the goal-dependent tactic [t] in each goal
       independently, in the manner of {!tclINDEPENDENT} except that
-      the current goal is also given as an argument to [t]. The goal
-      is normalised with respect to evars. *)
-  val nf_enter : (t -> unit tactic) -> unit tactic
-  [@@ocaml.deprecated "Normalization is enforced by EConstr, please use [enter]"]
-
-  (** Like {!nf_enter}, but does not normalize the goal beforehand. *)
+      the current goal is also given as an argument to [t]. *)
   val enter : (t -> unit tactic) -> unit tactic
 
   (** Like {!enter}, but assumes exactly one goal under focus, raising

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -1123,8 +1123,7 @@ let eval_pattern ?raise_NoMatch env0 sigma0 concl0 pattern occ (do_subst : subst
           str " did not instantiate ?" ++ int (Evar.repr e) ++ spc () ++
           str "Does the variable bound by the \"in\" construct occur "++
           str "in the pattern?") in
-    let sigma =
-      Evd.add (Evd.remove sigma e) e {e_def with Evd.evar_body = Evar_empty} in
+    let sigma = Evd.undefine sigma e [@@ocaml.warning "-3"] in
     sigma, e_body in
   let mk_upat_for ?hack ~rigid (sigma, t) =
     let sigma,pat= mk_tpattern ?hack ~rigid env0 (sigma, t) L2R (fs sigma t) in

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -1388,8 +1388,7 @@ let project_evar_on_evar force unify flags env evd aliases k2 pbty (evk1,argsv1 
 let update_evar_info ev1 ev2 evd =
   (* We update the source of obligation evars during evar-evar unifications. *)
   let loc, evs1 = evar_source ev1 evd in
-  let evi = Evd.find evd ev2 in
-  Evd.add evd ev2 {evi with evar_source = loc, evs1}
+  Evd.update_source evd ev2 (loc, evs1)
 
 let solve_evar_evar_l2r force f unify flags env evd aliases pbty ev1 (evk2,_ as ev2) =
   try

--- a/pretyping/globEnv.ml
+++ b/pretyping/globEnv.ml
@@ -101,14 +101,7 @@ let new_evar env sigma ?src ?(naming = Namegen.IntroAnonymous) typ =
   let (subst, _, sign) as ext = Lazy.force env.extra in
   let instance = Evarutil.default_ext_instance ext in
   let typ' = csubst_subst sigma subst typ in
-  let name = match naming with
-  | IntroAnonymous -> None
-  | IntroIdentifier id -> Some id
-  | IntroFresh id ->
-    let has_name id = try let _ = Evd.evar_key id sigma in true with Not_found -> false in
-    let id = Namegen.next_ident_away_from id has_name in
-    Some id
-  in
+  let name = Evarutil.next_evar_name sigma naming in
   let (sigma, evk) = new_pure_evar sign sigma typ' ?src ?name in
   (sigma, mkEvar (evk, instance))
 


### PR DESCRIPTION
This is a very rough guarantee that the callers will not start messing with the internals of this datatype. First step towards a separate representation for defined and undefined evars.

(The second commit is a related cleanup, as it get rids of a call to Evd.add.)

Overlays:
- https://github.com/Mtac2/Mtac2/pull/369
- https://github.com/mattam82/Coq-Equations/pull/514