### PR TITLE
dune_rule_gen: stop considering .aux as targets

### DIFF
--- a/tools/dune_rule_gen/coq_module.ml
+++ b/tools/dune_rule_gen/coq_module.ml
@@ -53,7 +53,6 @@ let base_obj_files ~rule coq_module =
   let aux_objs = if quick then []
     else
       [ mod_to_obj coq_module ~ext:".glob"
-      ; "." ^ mod_to_obj coq_module ~ext:".aux"
       ; mod_to_obj coq_module ~ext:".vos"
       ]
   in


### PR DESCRIPTION
They may cause cache issues

See also https://github.com/ocaml/dune/pull/6024