### PR TITLE
Clean up the implementation of ssrmatching

### DIFF
--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -1019,7 +1019,7 @@ let get_hyp env sigma id =
 (* XXX the k of the redex should percolate out *)
 let pf_interp_gen_aux env sigma ~concl to_ind ((oclr, occ), t) =
   let pat = interp_cpattern env sigma t None in (* UGLY API *)
-  let sigma = Evd.merge_universe_context sigma (Evd.evar_universe_context @@ fst pat) in
+  let sigma = Evd.merge_universe_context sigma (Evd.evar_universe_context @@ pat.pat_sigma) in
   let sigma, c, cl = fill_rel_occ_pattern env sigma concl pat occ in
   let clr = interp_clr sigma (oclr, (tag_of_cpattern t, c)) in
   if not(occur_existential sigma c) then
@@ -1031,7 +1031,7 @@ let pf_interp_gen_aux env sigma ~concl to_ind ((oclr, occ), t) =
       | NamedDecl.LocalDef (name, b, ty) -> true, pat, EConstr.mkLetIn (map_annot Name.mk_name name,b,ty,cl),c,clr, sigma
     else let sigma, ccl =  pf_mkprod env sigma c cl in false, pat, ccl, c, clr, sigma
   else if to_ind && occ = None then
-    let p, evs, ucst' = abs_evars env sigma (fst pat, c) in
+    let p, evs, ucst' = abs_evars env sigma (pat.pat_sigma, c) in
     let sigma = Evd.merge_universe_context sigma ucst' in
     if List.is_empty evs then anomaly "occur_existential but no evars" else
     let sigma, pty, rp = pfe_type_relevance_of env sigma p in
@@ -1103,7 +1103,7 @@ let abs_wgen env sigma keep_let f gen (args,c) =
   | _, Some ((x, "@"), Some p) ->
      let x = hoi_id x in
      let cp = interp_cpattern env sigma p None in
-     let sigma = Evd.merge_universe_context sigma (Evd.evar_universe_context (fst cp)) in
+     let sigma = Evd.merge_universe_context sigma (Evd.evar_universe_context cp.pat_sigma) in
      let sigma, t, c = fill_rel_occ_pattern env sigma c cp None in
      evar_closed t p;
      let ut = red_product_skip_id env sigma t in
@@ -1112,7 +1112,7 @@ let abs_wgen env sigma keep_let f gen (args,c) =
   | _, Some ((x, _), Some p) ->
      let x = hoi_id x in
      let cp = interp_cpattern env sigma p None in
-     let sigma = Evd.merge_universe_context sigma (Evd.evar_universe_context (fst cp)) in
+     let sigma = Evd.merge_universe_context sigma (Evd.evar_universe_context cp.pat_sigma) in
      let sigma, t, c = fill_rel_occ_pattern env sigma c cp None in
      evar_closed t p;
      let sigma, ty, r = pfe_type_relevance_of env sigma t in

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -712,7 +712,7 @@ let rwargtac ?under ?map_redex ist ((dir, mult), (((oclr, occ), grx), (kind, gt)
   let fail = ref false in
   let interp_rpattern env sigma gc =
     try interp_rpattern env sigma gc
-    with _ when snd mult = May -> fail := true; sigma, T EConstr.mkProp in
+    with _ when snd mult = May -> fail := true; { pat_sigma = sigma; pat_pat = T EConstr.mkProp } in
   let interp env sigma gc =
     try interp_term env sigma ist gc
     with _ when snd mult = May -> fail := true; (sigma, EConstr.mkProp) in
@@ -724,7 +724,7 @@ let rwargtac ?under ?map_redex ist ((dir, mult), (((oclr, occ), grx), (kind, gt)
     (* Evarmaps below are extensions of sigma, so setting the universe context is correct *)
     let sigma = match rx with
     | None -> sigma
-    | Some (s,_) -> Evd.set_universe_context sigma (Evd.evar_universe_context s)
+    | Some { pat_sigma = s } -> Evd.set_universe_context sigma (Evd.evar_universe_context s)
     in
     let t = interp env sigma gt in
     let sigma = Evd.set_universe_context sigma  (Evd.evar_universe_context (fst t)) in

--- a/plugins/ssr/ssripats.ml
+++ b/plugins/ssr/ssripats.ml
@@ -752,7 +752,7 @@ let tclLAST_GEN ~to_ind ((oclr, occ), t) conclusion = tclINDEPENDENTL begin
       tclUNIT (false, ccl, c, clr)
   else
     if to_ind && occ = None then
-      let p, _, ucst' = Ssrcommon.abs_evars env sigma0 (fst pat, c) in
+      let p, _, ucst' = Ssrcommon.abs_evars env sigma0 (pat.pat_sigma, c) in
       let sigma = Evd.merge_universe_context sigma ucst' in
       Unsafe.tclEVARS sigma <*>
       Ssrcommon.tacTYPEOF p >>= fun pty ->

--- a/plugins/ssrmatching/ssrmatching.mli
+++ b/plugins/ssrmatching/ssrmatching.mli
@@ -43,7 +43,11 @@ type ('ident, 'term) ssrpattern =
   | E_In_X_In_T of 'term * 'ident * 'term
   | E_As_X_In_T of 'term * 'ident * 'term
 
-type pattern = Evd.evar_map * (EConstr.existential, EConstr.t) ssrpattern
+type pattern = {
+  pat_sigma : Evd.evar_map;
+  pat_pat : (EConstr.existential, EConstr.t) ssrpattern;
+}
+
 val pp_pattern : env -> pattern -> Pp.t
 
 (** The type of rewrite patterns, the patterns of the [rewrite] tactic.

--- a/plugins/ssrmatching/ssrmatching.mli
+++ b/plugins/ssrmatching/ssrmatching.mli
@@ -122,8 +122,10 @@ val fill_rel_occ_pattern :
 type ssrdir = L2R | R2L
 val pr_dir_side : ssrdir -> Pp.t
 
-(** a pattern for a term with wildcards *)
-type tpattern
+(** patterns for a term with wildcards *)
+type tpatterns
+
+val empty_tpatterns : Evd.evar_map -> tpatterns
 
 (** [mk_tpattern env sigma0 sigma_p ok p_origin dir t] compiles a term [t]
     living in [env] [sigma] (an extension of [sigma0]) intro a [tpattern].
@@ -136,9 +138,9 @@ val mk_tpattern :
   ?ok:(EConstr.t -> evar_map -> bool) ->
   rigid:(Evar.t -> bool) ->
   env ->
-  evar_map * EConstr.t ->
+  EConstr.t ->
   ssrdir -> EConstr.t ->
-    evar_map * tpattern
+  tpatterns -> tpatterns
 
 (** [findP env t i k] is a stateful function that finds the next occurrence
     of a tpattern and calls the callback [k] to map the subterm matched.
@@ -170,8 +172,7 @@ val mk_tpattern_matcher :
   ?all_instances:bool ->
   ?raise_NoMatch:bool ->
   ?upats_origin:ssrdir * EConstr.t ->
-  evar_map -> occ -> evar_map * tpattern list ->
-    find_P * conclude
+  evar_map -> occ -> tpatterns -> find_P * conclude
 
 (** Example of [mk_tpattern_matcher] to implement
     [rewrite \{occ\}\[in t\]rules].


### PR DESCRIPTION
We enforce a few static invariants and perform a few cleanups around the ssrmatching implementation.
- Simplifying the code layout.
- Wrap some types and opacify some others to enforce a specific use pattern
- Make explicit the local use of metas in the `evars_for_FO`.