### PR TITLE
Remove a dubious use of Evd.add in ComProgramFixpoint.

### DIFF
--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -272,9 +272,7 @@ let out_def = function
   | None -> user_err Pp.(str "Program Fixpoint needs defined bodies.")
 
 let collect_evars_of_term evd c ty =
-  let evars = Evar.Set.union (Evd.evars_of_term evd c) (Evd.evars_of_term evd ty) in
-  Evar.Set.fold (fun ev acc -> Evd.add acc ev (Evd.find_undefined evd ev))
-  evars (Evd.from_ctx (Evd.evar_universe_context evd))
+  Evar.Set.union (Evd.evars_of_term evd c) (Evd.evars_of_term evd ty)
 
 let do_program_recursive ~pm ~scope ~poly ?typing_flags ?using fixkind fixl =
   let cofix = fixkind = Declare.Obls.IsCoFixpoint in
@@ -294,10 +292,10 @@ let do_program_recursive ~pm ~scope ~poly ?typing_flags ?using fixkind fixl =
     let using = Option.map (fun using -> Proof_using.definition_using env evd ~using ~terms) using in
     let def = nf_evar evd (EConstr.it_mkNamedLambda_or_LetIn evd def rec_sign) in
     let typ = nf_evar evd (EConstr.it_mkNamedProd_or_LetIn evd typ rec_sign) in
-    let evm = collect_evars_of_term evd def typ in
+    let deps = collect_evars_of_term evd def typ in
     let evars, _, def, typ =
-      RetrieveObl.retrieve_obligations env name evm
-        (List.length rec_sign) def typ in
+      RetrieveObl.retrieve_obligations env name evd
+        (List.length rec_sign) ~deps def typ in
     let cinfo = Declare.CInfo.make ~name ~typ ~impargs ?using () in
     (cinfo, def, evars)
   in

--- a/vernac/retrieveObl.ml
+++ b/vernac/retrieveObl.ml
@@ -203,12 +203,16 @@ let sort_dependencies evl =
   in
   aux evl Evar.Set.empty []
 
-let retrieve_obligations env name evm fs ?status t ty =
+let retrieve_obligations env name evm fs ?deps ?status t ty =
   (* 'Serialize' the evars *)
   let nc = Environ.named_context env in
   let nc_len = Context.Named.length nc in
   let evm = Evarutil.nf_evar_map_undefined evm in
   let evl = Evarutil.non_instantiated evm in
+  let evl = match deps with
+  | None -> evl
+  | Some deps -> Evar.Map.filter (fun ev _ -> Evar.Set.mem ev deps) evl
+  in
   let evl = Evar.Map.bindings evl in
   let evl = List.map (fun (id, ev) -> (id, ev, evar_dependencies evm id)) evl in
   let sevl = sort_dependencies evl in

--- a/vernac/retrieveObl.mli
+++ b/vernac/retrieveObl.mli
@@ -27,6 +27,7 @@ val retrieve_obligations :
   -> Names.Id.t
   -> Evd.evar_map
   -> int
+  -> ?deps:Evar.Set.t
   -> ?status:Evar_kinds.obligation_definition_status
   -> EConstr.t
   -> EConstr.types


### PR DESCRIPTION
We use a finer approach than in 9f5e248 by only keeping a set of evars rather than rebuilding an evarmap to perform evar surgery.