### PR TITLE
Refine the evar-evar fast path criterion in Evarsolve.

### DIFF
--- a/clib/sList.ml
+++ b/clib/sList.ml
@@ -93,6 +93,11 @@ let rec fold f accu = function
 | Cons (x, l) -> fold f (f accu x) l
 | Default (_, l) -> fold f accu l
 
+let rec for_all f l = match l with
+| Nil -> true
+| Cons (x, l) -> f x && for_all f l
+| Default (_, l) -> for_all f l
+
 let rec exists f l = match l with
 | Nil -> false
 | Cons (x, l) -> f x || exists f l

--- a/clib/sList.mli
+++ b/clib/sList.mli
@@ -61,6 +61,7 @@ sig
 val iter : ('a -> unit) -> 'a t -> unit
 val map : ('a -> 'b) -> 'a t -> 'b t
 val fold : ('a -> 'b -> 'a) -> 'a -> 'b t -> 'a
+val for_all : ('a -> bool) -> 'a t -> bool
 val exists : ('a -> bool) -> 'a t -> bool
 
 end

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -1359,14 +1359,12 @@ exception EvarSolvedOnTheFly of evar_map * EConstr.constr
 (* Try to project evk1[argsv1] on evk2[argsv2], if [ev1] is a pattern on
    the common domain of definition *)
 let project_evar_on_evar force unify flags env evd aliases k2 pbty (evk1,argsv1 as ev1) (evk2,argsv2 as ev2) =
-  if Option.is_empty pbty && SList.is_default argsv1 && SList.is_default argsv2 &&
-    let l1 = SList.length argsv1 in
-    Int.equal l1 (SList.length argsv2) &&
-    (* This ensures that the named context of [evk1] is a permutation of the one
-       from [env], and transitively also for [evk2]. In particular their filter
-       must be trivial. *)
-    Int.equal l1 (Range.length (Environ.named_context_val env).env_named_idx) &&
-    Option.is_empty (Evd.find evd evk1).evar_candidates && Option.is_empty (Evd.find evd evk2).evar_candidates
+  if Option.is_empty pbty && SList.is_default argsv2 &&
+    (* This ensures that the named context of [evk2] is a permutation of the one
+       from [env]. In particular its filter must be trivial. *)
+    Int.equal (SList.length argsv2) (Range.length (Environ.named_context_val env).env_named_idx) &&
+    SList.Skip.for_all (fun arg -> noccur_evar env evd evk2 arg && closed0 evd arg) argsv1 &&
+    Option.is_empty (Evd.find evd evk2).evar_candidates
   then
     evd, EConstr.mkEvar ev1
   else


### PR DESCRIPTION
When unifying ?x[a] ~ ?y[b], the algorithm tries to define y := x[φ(a)], where φ(a) is some clever inversion of the arguments of x so that this is correct. The previous fast path was simply checking that a and b were trivial, in which case it would pick φ(a) := a, plus some additional checks for candidates. Actually, the only thing we care about a is that it makes sense in the default context of y. Thus, we generalize the fast path only check for a to be closed and not mentioning y. The previous behaviour is a special case, and as far as I can tell the new one is compatible with the non-fast-path branch.