### PR TITLE
Process LoadPath directories in sorted order

### DIFF
--- a/doc/changelog/13-misc/16725-sort_dir.rst
+++ b/doc/changelog/13-misc/16725-sort_dir.rst
@@ -1,0 +1,7 @@
+- **Changed:**
+  Module names are now added to the loadpath in
+  alphabetical order for each (sub-)directory.
+  Previously they were added in the order of
+  the directory entries (as shown by "ls -U")
+  (`#16725 <https://github.com/coq/coq/pull/16725>`_,
+  by Jim Fehrle).

--- a/vernac/loadpath.ml
+++ b/vernac/loadpath.ml
@@ -334,6 +334,7 @@ let add_vo_path lp =
   let recursive = lp.recursive in
   if System.exists_dir unix_path then
     let dirs = if recursive then System.all_subdirs ~unix_path else [] in
+    let dirs = List.sort (fun a b -> String.compare (fst a) (fst b)) dirs in
     let prefix = DP.repr lp.coq_path in
     let convert_dirs (lp, cp) =
       try


### PR DESCRIPTION
Currently Coq adds items from a directory by stepping through the directory in the order the items appear in the directory, which is nondeterministic and not user friendly (i.e. the LoadPath items for a given -Q or -R are not in alphabetic order).  (Recall that `ls` defaults to sorting the entries.)

I think it's unlikely (perhaps impossible) this reordering will impact users.  Given that the order is currently nondeterministic, this seems like a reasonable thing to do.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.

<details><summary>For example:</summary>

**Current behavior**
Unsorted directory order:

```
$ ls -U _build/default/theories
ssrmatching  Unicode      Reals        Sets         funind         NArith
Bool         Wellfounded  btauto       Init         Structures     rtauto
Program      Classes      omega        extraction   Array          Relations
Numbers      Lists        PArith       _CoqProject  Sorting        QArith
Arith        Strings      ssr          Setoids      dune.disabled  Logic
MSets        dune         index.mld    Vectors      FSets          derive
Floats       ZArith       setoid_ring  micromega    nsatz          Compat
```


Print LoadPath.
(* notice that the subdirectories for Coq.Numbers are in scrambled order, too *)

Logical Path / Physical path:
<> /home/jfehrle/.local/share/coq
<> /home/proj/coq/_build/default/user-contrib
Ltac2 /home/proj/coq/_build/default/user-contrib/Ltac2
Coq /home/proj/coq/_build/default/theories
Coq.**ssrmatching** /home/proj/coq/_build/default/theories/ssrmatching
Coq.**Bool** /home/proj/coq/_build/default/theories/Bool
Coq.**Program** /home/proj/coq/_build/default/theories/Program
Coq.**Numbers** /home/proj/coq/_build/default/theories/Numbers
Coq.Numbers.**Natural** /home/proj/coq/_build/default/theories/Numbers/Natural
Coq.Numbers.Natural.Abstract
  /home/proj/coq/_build/default/theories/Numbers/Natural/Abstract
Coq.Numbers.Natural.Peano
  /home/proj/coq/_build/default/theories/Numbers/Natural/Peano
Coq.Numbers.Natural.Binary
  /home/proj/coq/_build/default/theories/Numbers/Natural/Binary
Coq.Numbers.**Integer** /home/proj/coq/_build/default/theories/Numbers/Integer
Coq.Numbers.Integer.NatPairs
  /home/proj/coq/_build/default/theories/Numbers/Integer/NatPairs
Coq.Numbers.Integer.Abstract
  /home/proj/coq/_build/default/theories/Numbers/Integer/Abstract
Coq.Numbers.Integer.Binary
  /home/proj/coq/_build/default/theories/Numbers/Integer/Binary
Coq.Numbers.**NatInt** /home/proj/coq/_build/default/theories/Numbers/NatInt
Coq.Numbers.**Cyclic** /home/proj/coq/_build/default/theories/Numbers/Cyclic
Coq.Numbers.Cyclic.Int63
  /home/proj/coq/_build/default/theories/Numbers/Cyclic/Int63
Coq.Numbers.Cyclic.ZModulo
  /home/proj/coq/_build/default/theories/Numbers/Cyclic/ZModulo
Coq.Numbers.Cyclic.Int31
  /home/proj/coq/_build/default/theories/Numbers/Cyclic/Int31
Coq.Numbers.Cyclic.Abstract
  /home/proj/coq/_build/default/theories/Numbers/Cyclic/Abstract
Coq.**Arith** /home/proj/coq/_build/default/theories/Arith
Coq.**MSets** /home/proj/coq/_build/default/theories/MSets
Coq.**Floats** /home/proj/coq/_build/default/theories/Floats
Coq.**Unicode** /home/proj/coq/_build/default/theories/Unicode
Coq.**Wellfounded** /home/proj/coq/_build/default/theories/Wellfounded
Coq.**Classes** /home/proj/coq/_build/default/theories/Classes
Coq.**Lists** /home/proj/coq/_build/default/theories/Lists
Coq.**Strings** /home/proj/coq/_build/default/theories/Strings
Coq.**ZArith** /home/proj/coq/_build/default/theories/ZArith
Coq.**Reals** /home/proj/coq/_build/default/theories/Reals
Coq.Reals.Cauchy /home/proj/coq/_build/default/theories/Reals/Cauchy
Coq.Reals.Abstract /home/proj/coq/_build/default/theories/Reals/Abstract
Coq.**btauto** /home/proj/coq/_build/default/theories/btauto
Coq.**omega** /home/proj/coq/_build/default/theories/omega
Coq.**PArith** /home/proj/coq/_build/default/theories/PArith
Coq.**ssr** /home/proj/coq/_build/default/theories/ssr
Coq.**setoid_ring** /home/proj/coq/_build/default/theories/setoid_ring
Coq.**Sets** /home/proj/coq/_build/default/theories/Sets
Coq.**Init** /home/proj/coq/_build/default/theories/Init
Coq.**extraction** /home/proj/coq/_build/default/theories/extraction
Coq.**Setoids** /home/proj/coq/_build/default/theories/Setoids
Coq.**Vectors** /home/proj/coq/_build/default/theories/Vectors
Coq.**micromega** /home/proj/coq/_build/default/theories/micromega
Coq.**funind** /home/proj/coq/_build/default/theories/funind
Coq.**Structures** /home/proj/coq/_build/default/theories/Structures
Coq.**Array** /home/proj/coq/_build/default/theories/Array
Coq.**Sorting** /home/proj/coq/_build/default/theories/Sorting
Coq.**FSets** /home/proj/coq/_build/default/theories/FSets
Coq.**nsatz** /home/proj/coq/_build/default/theories/nsatz
Coq.**NArith** /home/proj/coq/_build/default/theories/NArith
Coq.**rtauto** /home/proj/coq/_build/default/theories/rtauto
Coq.**Relations** /home/proj/coq/_build/default/theories/Relations
Coq.**QArith** /home/proj/coq/_build/default/theories/QArith
Coq.**Logic** /home/proj/coq/_build/default/theories/Logic
Coq.**derive** /home/proj/coq/_build/default/theories/derive
Coq.**Compat** /home/proj/coq/_build/default/theories/Compat
<> /home/proj/coq

**Sorted**

Print LoadPath.

Logical Path / Physical path:
<> /home/jfehrle/.local/share/coq
<> /home/proj/coq/_build/default/user-contrib
Ltac2 /home/proj/coq/_build/default/user-contrib/Ltac2
Coq /home/proj/coq/_build/default/theories
Coq.Arith /home/proj/coq/_build/default/theories/Arith
Coq.Array /home/proj/coq/_build/default/theories/Array
Coq.Bool /home/proj/coq/_build/default/theories/Bool
Coq.Classes /home/proj/coq/_build/default/theories/Classes
Coq.Compat /home/proj/coq/_build/default/theories/Compat
Coq.FSets /home/proj/coq/_build/default/theories/FSets
Coq.Floats /home/proj/coq/_build/default/theories/Floats
Coq.Init /home/proj/coq/_build/default/theories/Init
Coq.Lists /home/proj/coq/_build/default/theories/Lists
Coq.Logic /home/proj/coq/_build/default/theories/Logic
Coq.MSets /home/proj/coq/_build/default/theories/MSets
Coq.NArith /home/proj/coq/_build/default/theories/NArith
Coq.Numbers /home/proj/coq/_build/default/theories/Numbers
Coq.Numbers.Cyclic
  /home/proj/coq/_build/default/theories/Numbers/Cyclic
Coq.Numbers.Cyclic.Abstract
  /home/proj/coq/_build/default/theories/Numbers/Cyclic/Abstract
Coq.Numbers.Cyclic.Int31
  /home/proj/coq/_build/default/theories/Numbers/Cyclic/Int31
Coq.Numbers.Cyclic.Int63
  /home/proj/coq/_build/default/theories/Numbers/Cyclic/Int63
Coq.Numbers.Cyclic.ZModulo
  /home/proj/coq/_build/default/theories/Numbers/Cyclic/ZModulo
Coq.Numbers.Integer
  /home/proj/coq/_build/default/theories/Numbers/Integer
Coq.Numbers.Integer.Abstract
  /home/proj/coq/_build/default/theories/Numbers/Integer/Abstract
Coq.Numbers.Integer.Binary
  /home/proj/coq/_build/default/theories/Numbers/Integer/Binary
Coq.Numbers.Integer.NatPairs
  /home/proj/coq/_build/default/theories/Numbers/Integer/NatPairs
Coq.Numbers.NatInt
  /home/proj/coq/_build/default/theories/Numbers/NatInt
Coq.Numbers.Natural
  /home/proj/coq/_build/default/theories/Numbers/Natural
Coq.Numbers.Natural.Abstract
  /home/proj/coq/_build/default/theories/Numbers/Natural/Abstract
Coq.Numbers.Natural.Binary
  /home/proj/coq/_build/default/theories/Numbers/Natural/Binary
Coq.Numbers.Natural.Peano
  /home/proj/coq/_build/default/theories/Numbers/Natural/Peano
Coq.PArith /home/proj/coq/_build/default/theories/PArith
Coq.Program /home/proj/coq/_build/default/theories/Program
Coq.QArith /home/proj/coq/_build/default/theories/QArith
Coq.Reals /home/proj/coq/_build/default/theories/Reals
Coq.Reals.Abstract
  /home/proj/coq/_build/default/theories/Reals/Abstract
Coq.Reals.Cauchy
  /home/proj/coq/_build/default/theories/Reals/Cauchy
Coq.Relations /home/proj/coq/_build/default/theories/Relations
Coq.Setoids /home/proj/coq/_build/default/theories/Setoids
Coq.Sets /home/proj/coq/_build/default/theories/Sets
Coq.Sorting /home/proj/coq/_build/default/theories/Sorting
Coq.Strings /home/proj/coq/_build/default/theories/Strings
Coq.Structures /home/proj/coq/_build/default/theories/Structures
Coq.Unicode /home/proj/coq/_build/default/theories/Unicode
Coq.Vectors /home/proj/coq/_build/default/theories/Vectors
Coq.Wellfounded
  /home/proj/coq/_build/default/theories/Wellfounded
Coq.ZArith /home/proj/coq/_build/default/theories/ZArith
Coq.btauto /home/proj/coq/_build/default/theories/btauto
Coq.derive /home/proj/coq/_build/default/theories/derive
Coq.extraction /home/proj/coq/_build/default/theories/extraction
Coq.funind /home/proj/coq/_build/default/theories/funind
Coq.micromega /home/proj/coq/_build/default/theories/micromega
Coq.nsatz /home/proj/coq/_build/default/theories/nsatz
Coq.omega /home/proj/coq/_build/default/theories/omega
Coq.rtauto /home/proj/coq/_build/default/theories/rtauto
Coq.setoid_ring
  /home/proj/coq/_build/default/theories/setoid_ring
Coq.ssr /home/proj/coq/_build/default/theories/ssr
Coq.ssrmatching
  /home/proj/coq/_build/default/theories/ssrmatching
<> /home/proj/coq
</details>