### PR TITLE
setoid-rewrite: Supply correct env in `mk_relty`

### DIFF
--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -298,7 +298,7 @@ end) = struct
     let mk_relty evars newenv ty obj =
       match obj with
       | None | Some (_, None) ->
-        let evars, relty = mk_relation env evars ty in
+        let evars, relty = mk_relation newenv evars ty in
           if closed0 (goalevars evars) ty then
             let env' = Environ.reset_with_named_context (Environ.named_context_val env) env in
               new_cstr_evar evars env' relty

--- a/test-suite/bugs/bug_16727.v
+++ b/test-suite/bugs/bug_16727.v
@@ -1,0 +1,13 @@
+Require Import Setoid.
+
+Axiom R : unit -> unit -> Prop.
+Axiom RP : forall a b, R a b -> Prop.
+
+Lemma RiemannInt_P2 :
+  forall (a b: unit) (vn: R a b) (wn : R a a),
+   RP a a wn ->
+    { l:unit | True }.
+Proof.
+intros a b vn.
+try rewrite vn.
+Abort.


### PR DESCRIPTION
Testcase:
```
Require Import Setoid.

Axiom R : unit -> unit -> Prop.
Axiom RP : forall a b, R a b -> Prop.

Lemma RiemannInt_P2 :
  forall (a b: unit) (vn: R a b) (wn : R a a),
   RP a a wn ->
    { l:unit | True }.
Proof.
intros a b vn.
try rewrite vn.
(* Anomaly
"in retyping: unbound local variable."
Please report at http://coq.inria.fr/bugs/. *)
Abort.
```