### PR TITLE
Do not abort on undefined evars in ring

### DIFF
--- a/plugins/ring/ring.ml
+++ b/plugins/ring/ring.ml
@@ -345,7 +345,7 @@ let find_ring_structure env sigma l =
               (str"Arguments of ring_simplify do not have all the same type.")
         in
         List.iter check cl';
-        (try ring_for_carrier (EConstr.to_constr sigma ty)
+        (try ring_for_carrier (EConstr.to_constr ~abort_on_undefined_evars:false sigma ty)
         with Not_found ->
           CErrors.user_err
             (str"Cannot find a declared ring structure over"++

--- a/test-suite/bugs/bug_16728.v
+++ b/test-suite/bugs/bug_16728.v
@@ -1,0 +1,8 @@
+Require Import Ring.
+Lemma Rlt_n_Sn : exists P:Prop, True -> P.
+Proof.
+eexists.
+intro.
+apply f_equal.
+try ring_simplify.
+Abort.


### PR DESCRIPTION
Another case of storing constrs in maps in a plugin...

Testcase:
```
Require Import Ring.
Goal exists P:Prop, P.
Proof.
eexists.
apply f_equal.
try ring_simplify.
(* Anomaly "in econstr: grounding a non evar-free term" *)
Abort.
```