### PR TITLE
Remove the simplistic Evd.make_evar function.

### DIFF
--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -219,17 +219,6 @@ type evar_info = {
   evar_relevance: Sorts.relevance;
 }
 
-let make_evar hyps ccl = {
-  evar_concl = ccl;
-  evar_hyps = hyps;
-  evar_body = Evar_empty;
-  evar_filter = Filter.identity;
-  evar_abstract_arguments = Abstraction.identity;
-  evar_source = Loc.tag @@ Evar_kinds.InternalHole;
-  evar_candidates = None;
-  evar_relevance = Sorts.Relevant; (* FIXME *)
-}
-
 let instance_mismatch () =
   anomaly (Pp.str "Signature and its instance do not match.")
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -121,7 +121,6 @@ type evar_info = private {
   (** Relevance of the conclusion of the evar. *)
 }
 
-val make_evar : named_context_val -> etypes -> evar_info
 val evar_concl : evar_info -> econstr
 val evar_context : evar_info -> (econstr, etypes) Context.Named.pt
 val evar_filtered_context : evar_info -> (econstr, etypes) Context.Named.pt


### PR DESCRIPTION
This was a low-level function only used once in a trivial way, which was ignoring most of the subtleties of evar maps.

Overlay:
- https://github.com/QuickChick/QuickChick/pull/310 (backwards compatible)