### PR TITLE
made Vector.nth substructural

### DIFF
--- a/doc/changelog/11-standard-library/16731-stdlib-vector.rst
+++ b/doc/changelog/11-standard-library/16731-stdlib-vector.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  implementation of :g:`Vector.nth` to follow OCaml and compute strict subterms
+  (`#16731 <https://github.com/coq/coq/pull/16731>`_,
+  fixes `#16738 <https://github.com/coq/coq/issues/16738>`_,
+  by Andrej Dudenhefner).

--- a/test-suite/bugs/bug_16738.v
+++ b/test-suite/bugs/bug_16738.v
@@ -1,0 +1,11 @@
+Require Vector.
+
+Inductive container : Type :=
+  | container_v : Vector.t container 2 -> container
+  | container_0 : container.
+
+Fixpoint test (c : container) : unit :=
+  match c with
+  | container_0 => tt
+  | container_v v => test (Vector.nth v (Fin.FS Fin.F1))
+  end.

--- a/theories/Vectors/VectorDef.v
+++ b/theories/Vectors/VectorDef.v
@@ -106,12 +106,15 @@ Definition const {A} (a:A) := nat_rect _ [] (fun n x => cons _ a n x).
 Computational behavior of this function should be the same as
 ocaml function. *)
 Definition nth {A} :=
-fix nth_fix {m} (v' : t A m) (p : Fin.t m) {struct v'} : A :=
-match p in Fin.t m' return t A m' -> A with
- |Fin.F1 => caseS (fun n v' => A) (fun h n t => h)
- |Fin.FS p' => fun v => (caseS (fun n v' => Fin.t n -> A)
-   (fun h n t p0 => nth_fix t p0) v) p'
-end v'.
+  fix nth_fix {n : nat} (v : t A n) {struct v} : Fin.t n -> A :=
+    match v with
+    | nil _ => fun p => False_rect A (Fin.case0 _ p)
+    | cons _ x m v' => fun p =>
+      match p in (Fin.t m') return t A (pred m') -> A with
+      | Fin.F1 => fun _ => x
+      | Fin.FS p' => fun v' => nth_fix v' p'
+      end v'
+    end.
 
 (** An equivalent definition of [nth]. *)
 Definition nth_order {A} {n} (v: t A n) {p} (H: p < n) :=


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

The documentation of `Vector.nth` states "Computational behavior of this function should be the same as ocaml function."
However, the current implementation is not structural in the vector, but in the position.
This is different from OCaml: https://github.com/ocaml/ocaml/blob/83762af41d5a302ed793d6fb4bbe18a3447e18b1/stdlib/list.ml#L37.

The present PR makes `Vector.nth` follow OCaml `nth` and return a strict subterm of the input vector.
For example, this allows recursion on `nth` (which otherwise complains about a non-decreasing argument):
```coq
Require Vector.

Inductive container : Type :=
  | c_0 : container
  | c_1 : Vector.t container 2 -> container.

Fixpoint test (c : container) : unit :=
  match c with
  | c_0 => tt
  | c_1 v => test (Vector.nth v (Fin.FS Fin.F1))
  end.
```

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #16738


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.
- [x] Added **changelog**.

<!-- If this breaks external libraries or plugins in CI: -->
<!-- - [ ] Opened **overlay** pull requests. -->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
