### PR TITLE
Remove Evarutil.non_instantiated

### DIFF
--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -170,10 +170,6 @@ let new_meta () = incr meta_ctr; !meta_ctr
 
 (* The list of non-instantiated existential declarations (order is important) *)
 
-let non_instantiated sigma =
-  let listev = Evd.undefined_map sigma in
-  Evar.Map.Smart.map (fun evi -> nf_evar_info sigma evi) listev
-
 (*------------------------------------*
  * functional operations on evar sets *
  *------------------------------------*)

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -68,10 +68,6 @@ val new_type_evar :
 
 val new_Type : ?rigid:rigid -> evar_map -> evar_map * constr
 
-(** {6 Evars/Metas switching...} *)
-
-val non_instantiated : evar_map -> evar_info Evar.Map.t
-
 (** {6 Unification utils} *)
 
 (** [head_evar c] returns the head evar of [c] if any *)

--- a/vernac/retrieveObl.ml
+++ b/vernac/retrieveObl.ml
@@ -208,7 +208,7 @@ let retrieve_obligations env name evm fs ?deps ?status t ty =
   let nc = Environ.named_context env in
   let nc_len = Context.Named.length nc in
   let evm = Evarutil.nf_evar_map_undefined evm in
-  let evl = Evarutil.non_instantiated evm in
+  let evl = Evd.undefined_map evm in
   let evl = match deps with
   | None -> evl
   | Some deps -> Evar.Map.filter (fun ev _ -> Evar.Set.mem ev deps) evl


### PR DESCRIPTION
It is Evd.undefined_map composed with nf_evar, but its only caller already does nf_evar separately.
