### PR TITLE
changed Vector.rev to snoc-based implementation

### DIFF
--- a/theories/Vectors/VectorDef.v
+++ b/theories/Vectors/VectorDef.v
@@ -217,11 +217,20 @@ Definition rev_append {A n p} (v: t A n) (w: t A p)
   :t A (n + p) :=
   rew (Nat.tail_add_spec n p) in (rev_append_tail v w).
 
-(** rev [a₁ ; a₂ ; .. ; an] is [an ; a{n-1} ; .. ; a₁]
+(* if v has length n, then
+   snoc a v = v ++ [a] of length S n (instead of n + 1) *)
+Fixpoint snoc {A n} (a : A) (v : t A n) : t A (S n) :=
+  match v with
+  | [] => a :: []
+  | b :: v => b :: (snoc a v)
+  end.
 
-Caution : There is a lot of rewrite garbage in this definition *)
-Definition rev {A n} (v : t A n) : t A n :=
- rew <- (plus_n_O _) in (rev_append v []).
+(** rev [a₁ ; a₂ ; .. ; an] is [an ; a{n-1} ; .. ; a₁] *)
+Fixpoint rev {A n} (v : t A n) : t A n :=
+  match v with
+  | [] => []
+  | a :: v => snoc a (rev v)
+  end.
 
 End BASES.
 Local Notation "v [@ p ]" := (nth v p) (at level 1).

--- a/theories/Vectors/VectorSpec.v
+++ b/theories/Vectors/VectorSpec.v
@@ -387,6 +387,30 @@ intros P n v1 v2; split; induction n as [|n IHn].
     now rewrite <- (nth_order_tl _ _ _ _ Hi1), <- (nth_order_tl _ _ _ _ Hi2)  in HP.
 Qed.
 
+(** ** Properties of [rev] *)
+
+Lemma rev_snoc A: forall a n (v : t A n),
+  rev (snoc a v) = a :: rev v.
+Proof.
+intros a n v. induction v as [|b n v IH].
+- reflexivity.
+- cbn. now rewrite IH.
+Qed.
+
+Lemma snoc_rev A: forall a n (v : t A n),
+  snoc a (rev v) = rev (a :: v).
+Proof.
+reflexivity.
+Qed.
+
+Lemma rev_rev A: forall n (v : t A n),
+  rev (rev v) = v.
+Proof.
+intros n v. induction v as [|a n v IH].
+- reflexivity.
+- cbn. now rewrite rev_snoc, IH.
+Qed.
+
 (** ** Properties of [to_list] *)
 
 Lemma to_list_of_list_opp {A} (l: list A): to_list (of_list l) = l.
@@ -458,6 +482,13 @@ induction v1; simpl; trivial.
 now rewrite to_list_cons; f_equal.
 Qed.
 
+Lemma to_list_snoc A a n (v : t A n) : to_list (snoc a v) = (to_list v ++ a :: List.nil)%list.
+Proof.
+induction v as [|b n v IH].
+- reflexivity.
+- cbn. apply f_equal, IH.
+Qed.
+
 Lemma to_list_rev_append_tail A n m (v1 : t A n) (v2 : t A m):
   to_list (rev_append_tail v1 v2) = List.rev_append (to_list v1) (to_list v2).
 Proof. now revert m v2; induction v1 as [ | ? ? ? IHv1 ]; intros; [ | simpl; rewrite IHv1 ]. Qed.
@@ -469,8 +500,9 @@ Proof. unfold rev_append; rewrite <- (Nat.tail_add_spec n m); apply to_list_rev_
 Lemma to_list_rev A n (v : t A n):
   to_list (rev v) = List.rev (to_list v).
 Proof.
-unfold rev; rewrite (plus_n_O n); unfold eq_rect_r; simpl.
-now rewrite to_list_rev_append, List.rev_alt.
+induction v as [|a n v IH].
+- reflexivity.
+- simpl. now rewrite to_list_snoc, IH.
 Qed.
 
 Lemma to_list_map A B (f : A -> B) n (v : t A n) :


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

The present PR adds a simple, snoc-based `Vector.rev` implementation without rewrites.
For example, this makes `rev (rev v) = v` easy to prove, and has less dependent type issues overall.

```coq
(* if v has length n, then
   snoc a v = v ++ [a] of length S n (instead of n + 1) *)
Fixpoint snoc {A n} (a : A) (v : t A n) : t A (S n) :=
  match v with
  | [] => a :: []
  | b :: v => b :: (snoc a v)
  end.

(** rev [a₁ ; a₂ ; .. ; an] is [an ; a{n-1} ; .. ; a₁] *)
Fixpoint rev {A n} (v : t A n) : t A n :=
  match v with
  | [] => []
  | a :: v => snoc a (rev v)
  end.
```

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Addresses part of coq/stdlib#54

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
<!-- - [ ] Added / updated **test-suite**. -->

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
