### PR TITLE
Update frozen evars after running typeclasses in solve_remaining_evars

### DIFF
--- a/dev/ci/user-overlays/16743-SkySkimmer-refreeze.sh
+++ b/dev/ci/user-overlays/16743-SkySkimmer-refreeze.sh
@@ -1,0 +1,5 @@
+overlay compcert https://github.com/SkySkimmer/CompCert refreeze 16743
+
+overlay vst https://github.com/SkySkimmer/VST refreeze 16743
+
+overlay fiat_crypto https://github.com/SkySkimmer/fiat-crypto refreeze 16743

--- a/doc/changelog/04-tactics/16743-refreeze.rst
+++ b/doc/changelog/04-tactics/16743-refreeze.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  typeclass inference sometimes caused remaining holes to fail to be detected
+  (`#16743 <https://github.com/coq/coq/pull/16743>`_,
+  fixes `#5239 <https://github.com/coq/coq/issues/5239>`_,
+  by Gaëtan Gilbert).

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -323,6 +323,7 @@ let solve_remaining_evars ?hook (flags : inference_flags) env ?initial sigma =
     | UseTC -> apply_typeclasses ~program_mode ~fail_evar:false env sigma frozen
     | NoUseTC | UseTCForConv -> sigma
   in
+  let frozen = frozen_and_pending_holes (initial, sigma) in
   let sigma = match hook with
   | None -> sigma
   | Some hook -> apply_inference_hook hook env sigma frozen

--- a/test-suite/bugs/bug_5239.v
+++ b/test-suite/bugs/bug_5239.v
@@ -1,0 +1,10 @@
+Class Inhabited (A:Type) := {repr : A}.
+
+(* Removing this instance gets rid of the bug *)
+#[local] Instance Inhabited_option A : Inhabited (option A) := {repr := None}.
+
+Lemma option_refl {A}: forall `{Inhabited A} (u : A), u = u.
+Proof. reflexivity. Qed.
+
+Succeed #[local] Hint Rewrite @option_refl : core.
+Fail #[local] Hint Rewrite option_refl : core.


### PR DESCRIPTION
Fix #5239

Overlays:
- https://github.com/AbsInt/CompCert/pull/465
- https://github.com/PrincetonUniversity/VST/pull/642
- https://github.com/mit-plv/fiat-crypto/pull/1519