### PR TITLE
When resetting edit_at after error, print error before changing state

### DIFF
--- a/test-suite/output-coqtop/bug_16745.out
+++ b/test-suite/output-coqtop/bug_16745.out
@@ -1,0 +1,17 @@
+
+Coq < Coq < 1 goal
+  
+  ============================
+  True
+
+Unnamed_thm < 
+Unnamed_thm < Unnamed_thm < Unnamed_thm < Toplevel input, characters 111-112:
+>     | match goal with x := ?v |- _ => exact v end].
+>                                             ^
+Error:
+In environment
+x := Unnamed_thm_subproof : nat
+The term "Unnamed_thm_subproof" has type "nat"
+while it is expected to have type "True".
+
+Unnamed_thm < 

--- a/test-suite/output-coqtop/bug_16745.v
+++ b/test-suite/output-coqtop/bug_16745.v
@@ -1,0 +1,6 @@
+
+Goal True.
+Proof.
+  unshelve refine (let x := _ : nat in _);[
+      abstract exact 0
+    | match goal with x := ?v |- _ => exact v end].


### PR DESCRIPTION
Fix #16745
