### PR TITLE
Direct implementation of check_evars_are_solved for typeclasses

### DIFF
--- a/pretyping/typeclasses.mli
+++ b/pretyping/typeclasses.mli
@@ -123,6 +123,10 @@ val resolve_typeclasses : ?filter:evar_filter -> ?unique:bool ->
   ?split:bool -> ?fail:bool -> env -> evar_map -> evar_map
 val resolve_one_typeclass : ?unique:bool -> env -> evar_map -> EConstr.types -> evar_map * EConstr.constr
 
+val get_filtered_typeclass_evars : evar_filter -> evar_map -> Evar.Set.t
+
+val error_unresolvable : env -> evar_map -> Evar.Set.t option -> 'a
+
 (** A plugin can override the TC resolution engine by calling these two APIs.
     Beware this action is not registed in the summary (the Undo system) so
     it is up to the plugin to do so. *)

--- a/test-suite/output/ClassMissingInstance.out
+++ b/test-suite/output/ClassMissingInstance.out
@@ -1,0 +1,8 @@
+File "./output/ClassMissingInstance.v", line 7, characters 0-28:
+The command has indeed failed with message:
+Unable to satisfy the following constraints:
+
+?arg_2 : "Foo 1"
+
+?arg_20 : "Foo 2"
+

--- a/test-suite/output/ClassMissingInstance.v
+++ b/test-suite/output/ClassMissingInstance.v
@@ -1,0 +1,7 @@
+
+Class Foo (n:nat) := {}.
+
+Axiom thing : forall n {_:Foo n}, nat.
+
+(* both missing args are reported *)
+Fail Goal thing 1 = thing 2.


### PR DESCRIPTION
ie without running resolution and throwing the result away

A more conservative approach than https://github.com/coq/coq/pull/11984