### PR TITLE
Opacify the evar_info type.

### DIFF
--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -47,7 +47,7 @@ val new_evar :
   ?principal:bool -> ?hypnaming:naming_mode ->
   env -> evar_map -> types -> evar_map * EConstr.t
 
-(** Alias of {!Evd.new_evar} *)
+(** Alias of {!Evd.new_pure_evar} *)
 val new_pure_evar :
   ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
   ?relevance:Sorts.relevance ->

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -798,11 +798,6 @@ let evar_counter_summary_name = "evar counter"
 let evar_ctr, evar_counter_summary_tag = Summary.ref_tag 0 ~name:evar_counter_summary_name
 let new_untyped_evar () = incr evar_ctr; Evar.unsafe_of_int !evar_ctr
 
-let new_evar evd ?name ?typeclass_candidate evi =
-  let evk = new_untyped_evar () in
-  let evd = add_with_name evd ?name ?typeclass_candidate evk evi in
-  (evd, evk)
-
 let default_source = Loc.tag @@ Evar_kinds.InternalHole
 
 let remove d e =
@@ -1308,7 +1303,8 @@ let new_pure_evar ?(src=default_source) ?(filter = Filter.identity) ?(relevance 
   }
   in
   let typeclass_candidate = if principal then Some false else typeclass_candidate in
-  let (evd, newevk) = new_evar evd ?name ?typeclass_candidate evi in
+  let newevk = new_untyped_evar () in
+  let evd = add_with_name evd ?name ?typeclass_candidate newevk evi in
   let evd =
     if principal then declare_principal_goal newevk evd
     else declare_future_goal newevk evd

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -235,6 +235,10 @@ let evar_filtered_context evi =
 
 let evar_candidates evi = evi.evar_candidates
 
+let evar_abstract_arguments evi = evi.evar_abstract_arguments
+
+let evar_relevance evi = evi.evar_relevance
+
 let evar_hyps evi = evi.evar_hyps
 
 let evar_filtered_hyps evi = match Filter.repr (evar_filter evi) with
@@ -991,7 +995,7 @@ let add_conv_pb ?(tail=false) pb d =
 
 let conv_pbs d = d.conv_pbs
 
-let evar_source evk d = (find d evk).evar_source
+let evar_source evi = evi.evar_source
 
 let evar_ident evk evd = EvNames.ident evk evd.evar_names
 let evar_key id evd = EvNames.key id evd.evar_names
@@ -1031,10 +1035,10 @@ let extract_all_conv_pbs evd =
 
 let loc_of_conv_pb evd (pbty,env,t1,t2) =
   match kind (fst (decompose_app t1)) with
-  | Evar (evk1,_) -> fst (evar_source evk1 evd)
+  | Evar (evk1,_) -> fst (evar_source (find evd evk1))
   | _ ->
   match kind (fst (decompose_app t2)) with
-  | Evar (evk2,_) -> fst (evar_source evk2 evd)
+  | Evar (evk2,_) -> fst (evar_source (find evd evk2))
   | _             -> None
 
 (**********************************************************)

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -173,10 +173,6 @@ val has_shelved : evar_map -> bool
 (** [has_shelved sigma] is [true] if and only if
     there are shelved evars in [sigma]. *)
 
-val new_evar : evar_map ->
-  ?name:Id.t -> ?typeclass_candidate:bool -> evar_info -> evar_map * Evar.t
-(** Creates a fresh evar mapping to the given information. *)
-
 val new_pure_evar :
   ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
   ?relevance:Sorts.relevance ->

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -98,37 +98,44 @@ type evar_body =
   | Evar_empty
   | Evar_defined of econstr
 
-type evar_info = private {
-  evar_concl : econstr;
-  (** Type of the evar. *)
-  evar_hyps : named_context_val; (* TODO econstr? *)
-  (** Context of the evar. *)
-  evar_body : evar_body;
-  (** Optional content of the evar. *)
-  evar_filter : Filter.t;
-  (** Boolean mask over {!evar_hyps}. Should have the same length.
-      When filtered out, the corresponding variable is not allowed to occur
-      in the solution *)
-  evar_abstract_arguments : Abstraction.t;
-  (** Boolean information over {!evar_hyps}, telling if an hypothesis instance
-      can be imitated or should stay abstract in HO unification problems
-      and inversion (see [second_order_matching_with_args] for its use). *)
-  evar_source : Evar_kinds.t located;
-  (** Information about the evar. *)
-  evar_candidates : econstr list option;
-  (** List of possible solutions when known that it is a finite list *)
-  evar_relevance : Sorts.relevance;
-  (** Relevance of the conclusion of the evar. *)
-}
+type evar_info
+
+(** {6 Projections from evar infos} *)
 
 val evar_concl : evar_info -> econstr
+(** Type of the evar. *)
+
 val evar_context : evar_info -> (econstr, etypes) Context.Named.pt
-val evar_filtered_context : evar_info -> (econstr, etypes) Context.Named.pt
+(** Context of the evar. *)
+
 val evar_hyps : evar_info -> named_context_val
-val evar_filtered_hyps : evar_info -> named_context_val
+(** Context of the evar. *)
+
 val evar_body : evar_info -> evar_body
-val evar_candidates : evar_info -> constr list option
+(** Optional content of the evar. *)
+
+val evar_candidates : evar_info -> econstr list option
+(** List of possible solutions when known that it is a finite list *)
+
+val evar_source : evar_info -> Evar_kinds.t located
+
 val evar_filter : evar_info -> Filter.t
+(** Boolean mask over {!evar_hyps}. Should have the same length.
+    When filtered out, the corresponding variable is not allowed to occur
+    in the solution *)
+
+val evar_abstract_arguments : evar_info -> Abstraction.t
+(** Boolean information over {!evar_hyps}, telling if an hypothesis instance
+    can be imitated or should stay abstract in HO unification problems
+    and inversion (see [second_order_matching_with_args] for its use). *)
+
+val evar_relevance : evar_info -> Sorts.relevance
+(** Relevance of the conclusion of the evar. *)
+
+(** {6 Derived projections} *)
+
+val evar_filtered_context : evar_info -> (econstr, etypes) Context.Named.pt
+val evar_filtered_hyps : evar_info -> named_context_val
 val evar_env : env -> evar_info -> env
 val evar_filtered_env : env -> evar_info -> env
 val evar_identity_subst : evar_info -> econstr SList.t
@@ -339,10 +346,6 @@ val is_obligation_evar : evar_map -> Evar.t -> bool
 val downcast : Evar.t-> etypes -> evar_map -> evar_map
 (** Change the type of an undefined evar to a new type assumed to be a
     subtype of its current type; subtyping must be ensured by caller *)
-
-val evar_source : Evar.t -> evar_map -> Evar_kinds.t located
-(** Convenience function. Wrapper around {!find} to recover the source of an
-    evar in a given evar map. *)
 
 val evar_ident : Evar.t -> evar_map -> Id.t option
 

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -737,7 +737,7 @@ let mark_in_evm ~goal evd evars =
     if goal then
       let mark evd content =
         let info = Evd.find evd content in
-        let source = match info.Evd.evar_source with
+        let source = match Evd.evar_source info with
         (* Two kinds for goal evars:
             - GoalEvar (morally not dependent)
             - VarInstance (morally dependent of some name).
@@ -892,10 +892,9 @@ module Progress = struct
     | _ -> false
 
   let eq_evar_info sigma1 sigma2 ei1 ei2 =
-    let open Evd in
-    eq_constr sigma1 sigma2 ei1.evar_concl ei2.evar_concl &&
-    eq_named_context_val sigma1 sigma2 (ei1.evar_hyps) (ei2.evar_hyps) &&
-    eq_evar_body sigma1 sigma2 ei1.evar_body ei2.evar_body
+    eq_constr sigma1 sigma2 (Evd.evar_concl ei1) (Evd.evar_concl ei2) &&
+    eq_named_context_val sigma1 sigma2 (Evd.evar_hyps ei1) (Evd.evar_hyps ei2) &&
+    eq_evar_body sigma1 sigma2 (Evd.evar_body ei1) (Evd.evar_body ei2)
 
   (** Equality function on goals *)
   let goal_equal ~evd ~extended_evd evar extended_evar =

--- a/plugins/funind/glob_termops.ml
+++ b/plugins/funind/glob_termops.ml
@@ -575,7 +575,7 @@ let resolve_and_replace_implicits ?(flags = Pretyping.all_and_fail_flags)
         (* we scan the new evar map to find the evar corresponding to this hole (by looking the source *)
         Evd.fold (* to simulate an iter *)
           (fun _ evi _ ->
-            match evi.evar_source with
+            match Evd.evar_source evi with
             | loc_evi, ImplicitArg (gr_evi, p_evi, b_evi) ->
               if
                 GlobRef.equal grk gr_evi && pk = p_evi && bk = b_evi
@@ -587,7 +587,7 @@ let resolve_and_replace_implicits ?(flags = Pretyping.all_and_fail_flags)
         rt
       with Found evi -> (
         (* we found the evar corresponding to this hole *)
-        match evi.evar_body with
+        match Evd.evar_body evi with
         | Evar_defined c ->
           (* we just have to lift the solution in glob_term *)
           Detyping.detype Detyping.Now false Id.Set.empty env ctx (f c)
@@ -599,7 +599,7 @@ let resolve_and_replace_implicits ?(flags = Pretyping.all_and_fail_flags)
           (* we scan the new evar map to find the evar corresponding to this hole (by looking the source *)
           Evd.fold (* to simulate an iter *)
             (fun _ evi _ ->
-              match evi.evar_source with
+              match Evd.evar_source evi with
               | loc_evi, BinderType na' ->
                 if Name.equal na na' && rt.CAst.loc = loc_evi then
                   raise (Found evi)
@@ -609,7 +609,7 @@ let resolve_and_replace_implicits ?(flags = Pretyping.all_and_fail_flags)
           rt
         with Found evi -> (
           (* we found the evar corresponding to this hole *)
-          match evi.evar_body with
+          match Evd.evar_body evi with
           | Evar_defined c ->
             (* we just have to lift the solution in glob_term *)
             Detyping.detype Detyping.Now false Id.Set.empty env ctx (f c)

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -405,7 +405,7 @@ let abs_evars env sigma0 ?(rigid = []) (sigma, c0) =
   let abs_evar n k =
     let open EConstr in
     let evi = Evd.find sigma k in
-    let concl = evi.evar_concl in
+    let concl = Evd.evar_concl evi in
     let dc = CList.firstn n (evar_filtered_context evi) in
     let abs_dc c = function
     | NamedDecl.LocalDef (x,b,t) -> mkNamedLetIn sigma x b t (mkArrow t x.binder_relevance c)
@@ -475,7 +475,7 @@ let abs_evars_pirrel env sigma0 (sigma, c0) =
   let abs_evar n k =
     let open EConstr in
     let evi = Evd.find sigma k in
-    let concl = evi.evar_concl in
+    let concl = Evd.evar_concl evi in
     let dc = CList.firstn n (evar_filtered_context evi) in
     let abs_dc c = function
     | NamedDecl.LocalDef (x,b,t) -> mkNamedLetIn sigma x b t (mkArrow t x.binder_relevance c)

--- a/plugins/ssr/ssripats.ml
+++ b/plugins/ssr/ssripats.ml
@@ -929,7 +929,7 @@ let tacEXAMINE_ABSTRACT id =
 let find_abstract_proof env sigma check_lock abstract_n =
   let abstract = Ssrcommon.mkSsrRef "abstract" in
     let l = Evd.fold_undefined (fun e ei l ->
-      match EConstr.kind sigma ei.Evd.evar_concl with
+      match EConstr.kind sigma (Evd.evar_concl ei) with
       | App(hd, [|ty; n; lock|])
         when (not check_lock ||
                    (occur_existential_or_casted_meta sigma ty &&

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -371,7 +371,7 @@ let evars_for_FO ~hack ~rigid env (ise0:evar_map) c0 =
     | Context.Named.Declaration.LocalAssum (x, t) ->
         mkVar x.binder_name :: d, mkNamedProd !sigma x (put t) c in
     let a, t =
-      Context.Named.fold_inside abs_dc ~init:([], put evi.evar_concl) dc
+      Context.Named.fold_inside abs_dc ~init:([], put (Evd.evar_concl evi)) dc
     in
     let m = Evarutil.new_meta () in
     let () = metas := Metamap.add m t !metas in
@@ -1192,8 +1192,8 @@ let eval_pattern ?raise_NoMatch env0 sigma0 concl0 pattern occ (do_subst : subst
   let rigid ev = Evd.mem sigma0 ev in
   let fs sigma x = Reductionops.nf_evar sigma x in
   let pop_evar sigma e p =
-    let { Evd.evar_body = e_body } as e_def = Evd.find sigma e in
-    let e_body = match e_body with Evar_defined c -> c
+    let e_def = Evd.find sigma e in
+    let e_body = match Evd.evar_body e_def with Evar_defined c -> c
     | _ -> errorstrm (str "Matching the pattern " ++ pr_econstr_env env0 sigma0 p ++
           str " did not instantiate ?" ++ int (Evar.repr e) ++ spc () ++
           str "Does the variable bound by the \"in\" construct occur "++

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -1060,7 +1060,7 @@ let adjust_impossible_cases sigma pb pred tomatch submat =
        evar. See e.g. first definition of test for bug #3388. *)
     let pred = EConstr.Unsafe.to_constr pred in
     begin match Constr.kind pred with
-    | Evar (evk,_) when snd (evar_source evk sigma) == Evar_kinds.ImpossibleCase ->
+    | Evar (evk,_) when snd (Evd.evar_source (Evd.find sigma evk)) == Evar_kinds.ImpossibleCase ->
         let sigma =
           if not (Evd.is_defined sigma evk) then
             let sigma, default = coq_unit_judge !!(pb.env) sigma in

--- a/pretyping/evardefine.ml
+++ b/pretyping/evardefine.ml
@@ -75,10 +75,10 @@ let define_pure_evar_as_product env evd evk =
   let open Context.Named.Declaration in
   let evi = Evd.find_undefined evd evk in
   let evenv = evar_env env evi in
-  let id = next_ident_away idx (Environ.ids_of_named_context_val evi.evar_hyps) in
-  let concl = Reductionops.whd_all evenv evd evi.evar_concl in
+  let id = next_ident_away idx (Environ.ids_of_named_context_val (Evd.evar_hyps evi)) in
+  let concl = Reductionops.whd_all evenv evd (Evd.evar_concl evi) in
   let s = destSort evd concl in
-  let evksrc = evar_source evk evd in
+  let evksrc = evar_source evi in
   let src = subterm_source evk ~where:Domain evksrc in
   let evd1,(dom,u1) =
     new_type_evar evenv evd univ_flexible_alg ~src ~filter:(evar_filter evi)
@@ -133,15 +133,15 @@ let define_pure_evar_as_lambda env evd evk =
   | Prod (na,dom,rng) -> (evd,(na,dom,rng))
   | Evar ev' -> let evd,typ = define_evar_as_product env evd ev' in evd,destProd evd typ
   | _ -> error_not_product env evd typ in
-  let avoid = Environ.ids_of_named_context_val evi.evar_hyps in
+  let avoid = Environ.ids_of_named_context_val (Evd.evar_hyps evi) in
   let id =
     map_annot (fun na -> next_name_away_with_default_using_types "x" na avoid
       (Reductionops.whd_evar evd dom)) na
   in
   let newenv = push_named (LocalAssum (id, dom)) evenv in
   let filter = Filter.extend 1 (evar_filter evi) in
-  let src = subterm_source evk ~where:Body (evar_source evk evd1) in
-  let abstract_arguments = Abstraction.abstract_last evi.evar_abstract_arguments in
+  let src = subterm_source evk ~where:Body (evar_source (Evd.find evd1 evk)) in
+  let abstract_arguments = Abstraction.abstract_last (Evd.evar_abstract_arguments evi) in
   let evd2,body = new_evar newenv evd1 ~src (subst1 (mkVar id.binder_name) rng) ~filter ~abstract_arguments in
   let lam = mkLambda (map_annot Name.mk_name id, dom, subst_var evd2 id.binder_name body) in
   Evd.define evk lam evd2, lam
@@ -168,7 +168,7 @@ let rec evar_absorb_arguments env evd (evk,args as ev) = function
 let define_evar_as_sort env evd (ev,args) =
   let evd, s = new_sort_variable univ_rigid evd in
   let evi = Evd.find_undefined evd ev in
-  let concl = Reductionops.whd_all (evar_env env evi) evd evi.evar_concl in
+  let concl = Reductionops.whd_all (evar_env env evi) evd (Evd.evar_concl evi) in
   let sort = destSort evd concl in
   let evd' = Evd.define ev (mkSort s) evd in
   Evd.set_leq_sort env evd' (Sorts.super s) (ESorts.kind evd' sort), s
@@ -187,12 +187,12 @@ let rec presplit env sigma c =
 let define_pure_evar_as_array env sigma evk =
   let evi = Evd.find_undefined sigma evk in
   let evenv = evar_env env evi in
-  let evksrc = evar_source evk sigma in
+  let evksrc = evar_source evi in
   let src = subterm_source evk ~where:Domain evksrc in
   let sigma, u = new_univ_level_variable univ_flexible sigma in
   let s' = Sorts.sort_of_univ @@ Univ.Universe.make u in
   let sigma, ty = new_evar evenv sigma ~typeclass_candidate:false ~src ~filter:(evar_filter evi) (mkSort s') in
-  let concl = Reductionops.whd_all evenv sigma evi.evar_concl in
+  let concl = Reductionops.whd_all evenv sigma (Evd.evar_concl evi) in
   let s = destSort sigma concl in
   (* array@{u} ty : Type@{u} <= Type@{s} *)
   let sigma = Evd.set_leq_sort env sigma s' (ESorts.kind sigma s) in

--- a/pretyping/patternops.ml
+++ b/pretyping/patternops.ml
@@ -179,7 +179,7 @@ let pattern_of_constr ~broken env sigma t =
         (match
           match kind f with
           | Evar (evk,args) ->
-            (match snd (Evd.evar_source evk sigma) with
+            (match snd (Evd.evar_source (Evd.find sigma evk)) with
               Evar_kinds.MatchingVar (Evar_kinds.SecondOrderPatVar id) -> Some id
             | _ -> None)
           | _ -> None
@@ -192,7 +192,7 @@ let pattern_of_constr ~broken env sigma t =
     | Proj (p, c) ->
       pattern_of_constr env (EConstr.Unsafe.to_constr (Retyping.expand_projection env sigma p (EConstr.of_constr c) []))
     | Evar (evk,ctxt as ev) ->
-      (match snd (Evd.evar_source evk sigma) with
+      (match snd (Evd.evar_source (Evd.find sigma evk)) with
       | Evar_kinds.MatchingVar (Evar_kinds.FirstOrderPatVar id) ->
         PMeta (Some id)
       | Evar_kinds.GoalEvar | Evar_kinds.VarInstance _ ->

--- a/pretyping/pretype_errors.ml
+++ b/pretyping/pretype_errors.ml
@@ -188,7 +188,7 @@ let unsatisfiable_constraints env evd ev comp =
     let err = UnsatisfiableConstraints (None, comp) in
     raise (PretypeError (env,evd,err))
   | Some ev ->
-    let loc, kind = Evd.evar_source ev evd in
+    let loc, kind = Evd.evar_source (Evd.find evd ev) in
     let err = UnsatisfiableConstraints (Some (ev, kind), comp) in
     Loc.raise ?loc (PretypeError (env,evd,err))
 

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -277,7 +277,7 @@ let check_extra_evars_are_solved env current_sigma frozen = match frozen with
   Evar.Set.iter
     (fun evk ->
       if not (Evd.is_defined current_sigma evk) then
-        let (loc,k) = evar_source evk current_sigma in
+        let (loc,k) = evar_source (Evd.find current_sigma evk) in
         match k with
         | Evar_kinds.ImplicitArg (gr, (i, id), false) -> ()
         | _ ->
@@ -292,7 +292,7 @@ let check_evars env ?initial sigma c =
       (match initial with
        | Some initial when Evd.mem initial evk -> ()
        | _ ->
-         let (loc,k) = evar_source evk sigma in
+         let (loc,k) = evar_source (Evd.find sigma evk) in
          begin match k with
            | Evar_kinds.ImplicitArg (gr, (i, id), false) -> ()
            | _ -> Pretype_errors.error_unsolvable_implicit ?loc env sigma evk None
@@ -339,7 +339,7 @@ let adjust_evar_source sigma na c =
   match na, kind sigma c with
   | Name id, Evar (evk,args) ->
      let evi = Evd.find sigma evk in
-     begin match evi.evar_source with
+     begin match Evd.evar_source evi with
      | loc, Evar_kinds.QuestionMark {
          Evar_kinds.qm_obligation=b;
          Evar_kinds.qm_name=Anonymous;

--- a/pretyping/typeclasses.ml
+++ b/pretyping/typeclasses.ml
@@ -139,7 +139,7 @@ let rec is_class_type evd c =
     | _ -> is_class_constr evd c
 
 let is_class_evar evd evi =
-  is_class_type evd evi.Evd.evar_concl
+  is_class_type evd (Evd.evar_concl evi)
 
 let rec is_maybe_class_type evd c =
   let c, _ = Termops.decompose_app_vect evd c in
@@ -233,7 +233,7 @@ let no_goals_or_obligations _ source =
 
 let has_typeclasses filter evd =
   let tcs = get_typeclass_evars evd in
-  let check ev = filter ev (lazy (snd (Evd.find evd ev).evar_source)) in
+  let check ev = filter ev (lazy (snd (Evd.evar_source (Evd.find evd ev)))) in
   Evar.Set.exists check tcs
 
 let get_solve_all_instances, solve_all_instances_hook = Hook.make ()

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1491,7 +1491,7 @@ let w_merge env with_types flags (evd,metas,evars : subst0) =
     let (evd', c) = applyHead sp_env evd hdc args in
     let (evd'',mc,ec) =
       unify_0 sp_env evd' CUMUL flags
-        (get_type_of sp_env evd' c) ev.evar_concl in
+        (get_type_of sp_env evd' c) (Evd.evar_concl ev) in
     let evd''' = w_merge_rec evd'' mc ec [] in
     if evd' == evd'''
     then Evd.define sp c evd'''

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -532,9 +532,9 @@ let pr_evgl_sign env sigma evi =
     if List.is_empty ids then mt () else
       (str " (" ++ prlist_with_sep pr_comma pr_id ids ++ str " cannot be used)")
   in
-  let pc = pr_leconstr_env env sigma evi.evar_concl in
+  let pc = pr_leconstr_env env sigma (Evd.evar_concl evi) in
   let candidates =
-    match evi.evar_body, evi.evar_candidates with
+    match Evd.evar_body evi, Evd.evar_candidates evi with
     | Evar_empty, Some l ->
        spc () ++ str "= {" ++
          prlist_with_sep (fun () -> str "|") (pr_leconstr_env env sigma) l ++ str "}"
@@ -632,7 +632,7 @@ let print_evar_constraints gl sigma =
              spc () ++ pr_leconstr_env env sigma t2)
   in
   let pr_candidate ev evi (candidates,acc) =
-    if Option.has_some evi.evar_candidates then
+    if Option.has_some (Evd.evar_candidates evi) then
       (succ candidates, acc ++ pr_evar sigma (ev,evi) ++ fnl ())
     else (candidates, acc)
   in
@@ -673,15 +673,15 @@ let process_dependent_evar q acc evm is_dependent e =
   let evi = Evd.find evm e in
   (* Queues evars appearing in the types of the goal (conclusion, then
      hypotheses), they are all dependent. *)
-  queue_term q true evi.evar_concl;
+  queue_term q true (Evd.evar_concl evi);
   List.iter begin fun decl ->
     let open NamedDecl in
     queue_term q true (NamedDecl.get_type decl);
     match decl with
     | LocalAssum _ -> ()
     | LocalDef (_,b,_) -> queue_term q true b
-  end (EConstr.named_context_of_val evi.evar_hyps);
-  match evi.evar_body with
+  end (EConstr.named_context_of_val (Evd.evar_hyps evi));
+  match Evd.evar_body evi with
   | Evar_empty ->
       if is_dependent then Evar.Map.add e None acc else acc
   | Evar_defined b ->

--- a/proofs/evar_refiner.ml
+++ b/proofs/evar_refiner.ml
@@ -59,7 +59,7 @@ let w_refine (evk,evi) (ltac_var,rawc) env sigma =
       polymorphic = false;
     } in
     try Pretyping.understand_ltac flags
-      env sigma ltac_var (Pretyping.OfType evi.evar_concl) rawc
+      env sigma ltac_var (Pretyping.OfType (Evd.evar_concl evi)) rawc
     with e when CErrors.noncritical e ->
       let loc = Glob_ops.loc_of_glob_constr rawc in
       user_err ?loc

--- a/stm/proofBlockDelimiter.ml
+++ b/stm/proofBlockDelimiter.ml
@@ -41,7 +41,7 @@ let simple_goal sigma g gs =
   let open Evd in
   let open Evarutil in
   let evi = Evd.find sigma g in
-  Set.is_empty (evars_of_term sigma evi.evar_concl) &&
+  Set.is_empty (evars_of_term sigma (Evd.evar_concl evi)) &&
   Set.is_empty (evars_of_filtered_evar_info sigma (nf_evar_info sigma evi)) &&
   not (List.exists (Proofview.depends_on sigma g) gs)
 

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -1209,7 +1209,7 @@ let is_inference_forced p evd ev =
   try
     if Evar.Set.mem ev (Evd.get_typeclass_evars evd) && p ev
     then
-      let (loc, k) = evar_source ev evd in
+      let (loc, k) = evar_source (Evd.find evd ev) in
       match k with
         | Evar_kinds.ImplicitArg (_, _, b) -> b
         | Evar_kinds.QuestionMark _ -> false
@@ -1228,7 +1228,7 @@ let error_unresolvable env comp evd =
   | Some s -> Evar.Set.mem ev s
   in
   let fold ev evi (found, accu) =
-    let ev_class = class_of_constr env evd evi.evar_concl in
+    let ev_class = class_of_constr env evd (Evd.evar_concl evi) in
     if not (Option.is_empty ev_class) && is_part ev then
       (* focus on one instance if only one was searched for *)
       if not found then (true, Some ev)
@@ -1315,7 +1315,7 @@ let resolve_all_evars depth unique env p oevd do_split fail =
 
 let initial_select_evars filter =
   fun evd ev evi ->
-    filter ev (Lazy.from_val (snd evi.Evd.evar_source)) &&
+    filter ev (Lazy.from_val (snd (Evd.evar_source evi))) &&
     (* Typeclass evars can contain evars whose conclusion is not
        yet determined to be a class or not. *)
     Typeclasses.is_class_evar evd evi
@@ -1417,5 +1417,5 @@ let autoapply c i =
   Clenv.res_pf ~with_evars:true ~with_classes:false ~flags ce <*>
       Proofview.tclEVARMAP >>= (fun sigma ->
       let sigma = Typeclasses.make_unresolvables
-          (fun ev -> Typeclasses.all_goals ev (Lazy.from_val (snd (Evd.find sigma ev).evar_source))) sigma in
+          (fun ev -> Typeclasses.all_goals ev (Lazy.from_val (snd (Evd.evar_source (Evd.find sigma ev))))) sigma in
       Proofview.Unsafe.tclEVARS sigma) end

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -647,8 +647,8 @@ let solve_remaining_by env sigma holes by =
       | None -> sigma
         (* Evar should not be defined, but just in case *)
       | Some evi ->
-        let env = Environ.reset_with_named_context evi.evar_hyps env in
-        let ty = evi.evar_concl in
+        let env = Evd.evar_env env evi in
+        let ty = Evd.evar_concl evi in
         let name, poly = Id.of_string "rewrite", false in
         let c, sigma = Proof.refine_by_tactic ~name ~poly env sigma ty solve_tac in
         Evd.define evk (EConstr.of_constr c) sigma

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -408,7 +408,7 @@ let check_evars env sigma extsigma origsigma =
   match rest with
   | [] -> ()
   | (evk,evi) :: _ ->
-    let (loc,_) = evi.Evd.evar_source in
+    let (loc,_) = Evd.evar_source evi in
     Pretype_errors.error_unsolvable_implicit ?loc env sigma evk None
 
 let tclMAPDELAYEDWITHHOLES accept_unresolved_holes l tac =

--- a/vernac/retrieveObl.ml
+++ b/vernac/retrieveObl.ml
@@ -22,7 +22,7 @@ let check_evars env evm =
     (fun key evi ->
       if Evd.is_obligation_evar evm key then ()
       else
-        let loc, k = Evd.evar_source key evm in
+        let loc, k = Evd.evar_source evi in
         Pretype_errors.error_unsolvable_implicit ?loc env evm key None)
     (Evd.undefined_map evm)
 
@@ -235,13 +235,13 @@ let retrieve_obligations env name evm fs ?deps ?status t ty =
       (fun (id, (n, nstr), ev) l ->
         let hyps = Evd.evar_filtered_context ev in
         let hyps = trunc_named_context nc_len hyps in
-        let evtyp, deps, transp = etype_of_evar evm l hyps ev.Evd.evar_concl in
+        let evtyp, deps, transp = etype_of_evar evm l hyps (Evd.evar_concl ev) in
         let evtyp, hyps, chop =
           match chop_product fs evtyp with
           | Some t -> (t, trunc_named_context fs hyps, fs)
           | None -> (evtyp, hyps, 0)
         in
-        let loc, k = Evd.evar_source id evm in
+        let loc, k = Evd.evar_source (Evd.find evm id) in
         let status =
           match k with
           | Evar_kinds.QuestionMark {Evar_kinds.qm_obligation = o} -> o

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -554,7 +554,7 @@ let program_inference_hook env sigma ev =
   let evi = Evarutil.nf_evar_info sigma evi in
   let env = Evd.evar_filtered_env env evi in
   try
-    let concl = evi.Evd.evar_concl in
+    let concl = Evd.evar_concl evi in
     if not (Evarutil.is_ground_env sigma env &&
             Evarutil.is_ground_term sigma concl)
     then None


### PR DESCRIPTION
We enforce that all evar info field accesses go through their getters.