### PR TITLE
[stdlib] add nth_error_ext, map_repeat, to_list_nil_iff, to_list_inj

### DIFF
--- a/doc/changelog/11-standard-library/16756-vector_list_lemmas.rst
+++ b/doc/changelog/11-standard-library/16756-vector_list_lemmas.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  lemmas :g:`nth_error_ext`, :g:`map_repeat`, :g:`rev_repeat` to ``List.v``,
+  and :g:`to_list_nil_iff`, :g:`to_list_inj` to ``VectorSpec.v``
+  (`#16756 <https://github.com/coq/coq/pull/16756>`_,
+  by Stefan Haan).

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -580,6 +580,18 @@ Section Elts.
     cbn. now apply IHn, Nat.succ_le_mono.
   Qed.
 
+  Lemma nth_error_ext l l':
+    (forall n, nth_error l n = nth_error l' n) -> l = l'.
+  Proof.
+    revert l'. induction l as [|a l IHl];
+      intros l' Hnth; destruct l'.
+    - reflexivity.
+    - discriminate (Hnth 0).
+    - discriminate (Hnth 0).
+    - injection (Hnth 0) as ->. f_equal. apply IHl.
+      intro n. exact (Hnth (S n)).
+  Qed.
+
   (** Results directly relating [nth] and [nth_error] *)
 
   Lemma nth_error_nth : forall (l : list A) (n : nat) (x d : A),
@@ -3341,6 +3353,21 @@ Proof.
   - f_equal; apply IHn.
 Qed.
 
+Lemma map_repeat A B (a:A) n (f : A -> B):
+  map f (repeat a n) = repeat (f a) n.
+Proof.
+  induction n as [|n IHn].
+  - reflexivity.
+  - cbn. f_equal. exact IHn.
+Qed.
+
+Lemma rev_repeat A n (a:A):
+  rev (repeat a n) = repeat a n.
+Proof.
+  induction n as [|n IHn].
+  - reflexivity.
+  - cbn. rewrite IHn. symmetry. apply repeat_cons.
+Qed.
 
 (** Sum of elements of a list of [nat]: [list_sum] *)
 

--- a/theories/Vectors/VectorSpec.v
+++ b/theories/Vectors/VectorSpec.v
@@ -418,6 +418,23 @@ Lemma to_list_cons A h n (v : t A n):
   to_list (cons A h n v) = List.cons h (to_list v).
 Proof. reflexivity. Qed.
 
+Lemma to_list_nil_iff A v:
+  to_list v = List.nil <-> v = nil A.
+Proof.
+split; intro H.
+- now apply case0 with (P := fun v => v = []).
+- subst. apply to_list_nil.
+Qed.
+
+Lemma to_list_inj A n (v w : t A n):
+  to_list v = to_list w -> v = w.
+Proof.
+revert v. induction w as [| w0 n w IHw].
+- apply to_list_nil_iff.
+- intros v H. rewrite (eta v) in H.
+  injection H as [=H0 H1%IHw]. subst. apply eta.
+Qed.
+
 Lemma to_list_hd A n (v : t A (S n)) d:
   hd v = List.hd d (to_list v).
 Proof. now rewrite (eta v). Qed.


### PR DESCRIPTION
This PR adds following lemmas to stdlib:

**List**
* `nth_error_ext: (forall n, nth_error l n = nth_error l' n) -> l = l'.`
* `map_repeat: map f (repeat a n) = repeat (f a) n.`
*  `rev_repeat: rev (repeat a n) = repeat a n.`

**VectorSpec**
* `to_list_nil_iff: to_list v = List.nil <-> v = nil A.`
* `to_list_inj:  to_list v = to_list w -> v = w.`