### PR TITLE
Ltac `match goal with hyp := _ <: _` does not drop the cast

### DIFF
--- a/doc/changelog/05-Ltac-language/16764-ltac1-match.rst
+++ b/doc/changelog/05-Ltac-language/16764-ltac1-match.rst
@@ -1,0 +1,9 @@
+- **Changed:**
+  In :tacn:`match goal`, ``match goal with hyp := body : typ |- _``
+  is syntax sugar for  ``match goal with hyp := [ body ] : typ |- _``
+  i.e. it matches ``typ`` with the type of the hypothesis
+  rather than matching the body as a cast term.
+  This transformation used to be done with any kind of cast (e.g. VM cast ``<:``)
+  and is now done only for default casts ``:``
+  (`#16764 <https://github.com/coq/coq/pull/16764>`_,
+  by Gaëtan Gilbert).

--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -242,7 +242,7 @@ GRAMMAR EXTEND Gram
         { let t, ty =
             match mpv with
             | Term t -> (match t with
-              | { CAst.v = CCast (t, _, ty) } -> Term t, Some (Term ty)
+              | { CAst.v = CCast (t, DEFAULTcast, ty) } -> Term t, Some (Term ty)
               | _ -> mpv, None)
             | _ -> mpv, None
           in Def (na, t, Option.default (Term (CAst.make @@ CHole (None, IntroAnonymous, None))) ty) }

--- a/test-suite/success/ltac.v
+++ b/test-suite/success/ltac.v
@@ -435,3 +435,27 @@ Module LocalRedef.
     Fail Qed.
   Abort.
 End LocalRedef.
+
+Module MatchCastInPattern.
+
+  Goal let x := True in True.
+  Proof.
+    intro x.
+    lazymatch goal with
+    | [ H := ?v : ?T |- _ ] => constr_eq T Prop
+    end.
+
+    Fail lazymatch goal with
+    | [ H := ?v <: ?T |- _ ] => constr_eq T Prop
+    end. (* Warning: Casts are ignored in patterns [cast-in-pattern,automation] *)
+
+    Set Warnings "+cast-in-pattern".
+    Fail lazymatch goal with
+    | [ H := ?v <: ?T |- _ ] => idtac
+    end.
+    Fail lazymatch goal with
+    | [ H := [ ?v : ?T ] : _ |- _ ] => idtac
+    end.
+  Abort.
+
+End MatchCastInPattern.


### PR DESCRIPTION
We only translate default casts to matches on the hypothesis type.
