### PR TITLE
[stdlib] add Fin and Vector lemmas

### DIFF
--- a/doc/changelog/11-standard-library/16765-stdlib-more-vector.rst
+++ b/doc/changelog/11-standard-library/16765-stdlib-more-vector.rst
@@ -1,0 +1,10 @@
+- **Added:**
+  lemmas :g:`L_inj`, :g:`R_inj`, :g:`L_R_neq`, :g:`case_L_R`, :g:`case_L_R'` to ``Fin.v``,
+  and :g:`nil_spec`, :g:`nth_append_L`, :g:`nth_append_R`, :g:`In_nth`, :g:`nth_replace_eq`, :g:`nth_replace_neq`,
+  :g:`replace_append_L`, :g:`replace_append_R`, :g:`append_const`, :g:`map_append`, :g:`map2_ext`, :g:`append_inj`,
+  :g:`In_cons_iff`, :g:`Forall_cons_iff`, :g:`Forall_map`, :g:`Forall_append`, :g:`Forall_nth`, :g:`Forall2_nth`, :g:`Forall2_append`,
+  :g:`map_shiftin`, :g:`fold_right_shiftin`, :g:`In_shiftin`, :g:`Forall_shiftin`, :g:`rev_nil`, :g:`rev_cons`, :g:`rev_shiftin`,
+  :g:`rev_rev`, :g:`map_rev`, :g:`fold_left_rev_right`, :g:`In_rev`, :g:`Forall_rev` to ``VectorSpec.v``
+  (`#16765 <https://github.com/coq/coq/pull/16765>`_,
+  closes `#6459 <https://github.com/coq/coq/issues/6459>`_,
+  by Andrej Dudenhefner).

--- a/theories/Vectors/VectorDef.v
+++ b/theories/Vectors/VectorDef.v
@@ -177,10 +177,8 @@ Proof.
   - apply shiftout.
 
     rewrite <- Nat.sub_succ_l.
-    + apply f.
-      * auto with *.
-      * exact v.
-    + auto with *.
+    + exact (f (Nat.lt_le_incl _ _ H) v).
+    + exact (Nat.lt_le_incl _ _ H).
 Defined.
 
 (** Concatenation of two vectors *)


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

- added to `Fin`
  + `L_inj`, `R_inj`, `L_R_neq`, `case_L_R'`, `case_L_R`
- added to `Vector`
  + `nth_append_L`, `nth_append_R`, `In_nth`, `nth_replace_eq`, `nth_replace_neq`, `replace_append_L`, `replace_append_R`, `append_const`, `map_append`, `map2_ext`, `append_inj`, `In_cons_iff`, `Forall_cons_iff`, `Forall_map`, `Forall_append`, `Forall_nth`, `Forall2_nth`, `Forall2_append`, `map_shiftin`, `fold_right_shiftin`, `In_shiftin`, `Forall_shiftin`, `rev_nil`, `rev_cons`, `rev_shiftin`, `rev_rev`, `map_rev`, `fold_left_rev_right`, `In_rev`, `Forall_rev`

Notably, `rev_rev` and `fold_left_rev_right` lemmas are shown for the tail-recursive `rev` definition, in contrast to PR coq/coq#16742.
Only properties of existing definitions are shown, no new definitions are added.


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Closes coq/stdlib#54


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md
