### PR TITLE
Fixes #16752: irrelevance check missing for opaque names in kernel conversion

### DIFF
--- a/doc/changelog/01-kernel/16768-master+fix16752-irrelevance-opaque-conversion.rst
+++ b/doc/changelog/01-kernel/16768-master+fix16752-irrelevance-opaque-conversion.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Coq 8.16.0 missed `SProp` check for opaque names in conversion
+  (`#16768 <https://github.com/coq/coq/pull/16768>`_,
+  fixes `#16752 <https://github.com/coq/coq/issues/16752>`_,
+  by Hugo Herbelin).

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -488,22 +488,15 @@ let is_irrelevant mode r = match mode, r with
 let shortcut_irrelevant mode r =
   if is_irrelevant mode r then raise Irrelevant
 
-let assoc_defined mode id env = match Environ.lookup_named id env with
-| LocalDef (na, c, _) ->
-  let () = shortcut_irrelevant mode (binder_relevance na) in
-  c
-| LocalAssum (na, _) ->
-  let () = shortcut_irrelevant mode (binder_relevance na) in
-  raise Not_found
+let assoc_defined = function
+| LocalDef (_, c, _) -> inject c
+| LocalAssum (_, _) -> raise Not_found
 
-let constant_value_in mode env (kn,u) =
-  let cb = lookup_constant kn env in
-  let () = shortcut_irrelevant mode (cb.const_relevance) in
-  match cb.const_body with
-    | Def b -> injectu b u
-    | OpaqueDef _ -> raise (NotEvaluableConst Opaque)
-    | Undef _ -> raise (NotEvaluableConst NoBody)
-    | Primitive p -> raise (NotEvaluableConst (IsPrimitive (u,p)))
+let constant_value_in u = function
+| Def b -> injectu b u
+| OpaqueDef _ -> raise (NotEvaluableConst Opaque)
+| Undef _ -> raise (NotEvaluableConst NoBody)
+| Primitive p -> raise (NotEvaluableConst (IsPrimitive (u,p)))
 
 let ref_value_cache env flags mode tab ref =
   try
@@ -528,12 +521,14 @@ let ref_value_cache env flags mode tab ref =
             in
             inject body
           | VarKey id ->
-            if TransparentState.is_transparent_variable flags id
-            then inject (assoc_defined mode id env)
+            let def = Environ.lookup_named id env in
+            let () = shortcut_irrelevant mode (binder_relevance (get_annot def)) in
+            if TransparentState.is_transparent_variable flags id then assoc_defined def
             else raise Not_found
-          | ConstKey cst ->
-            if TransparentState.is_transparent_constant flags (fst cst)
-            then constant_value_in mode env cst
+          | ConstKey (cst,u) ->
+            let cb = lookup_constant cst env in
+            let () = shortcut_irrelevant mode (cb.const_relevance) in
+            if TransparentState.is_transparent_constant flags cst then constant_value_in u cb.const_body
             else raise Not_found
         in
         Def body

--- a/test-suite/bugs/bug_16752.v
+++ b/test-suite/bugs/bug_16752.v
@@ -1,0 +1,12 @@
+Axiom P : SProp.
+Axioms a b : P.
+Axiom Q : P->Prop.
+Axiom q : Q b.
+Axiom zog : forall p:P, Q p -> unit.
+
+Lemma foobar : zog a q = tt.
+Proof.
+  set (u := zog _ q).
+  (* should be "u = tt" *)
+  match goal with |- u = tt => idtac end.
+Abort.


### PR DESCRIPTION
This is a possible fix against master for #16752 (v8.16 would require a slightly different fix).

Fixes / closes #16752

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
