### PR TITLE
Don't drop evar map in auto on ground terms

### DIFF
--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -79,7 +79,7 @@ let exact h =
         Proofview.Unsafe.tclEVARSADVANCE sigma <*>
         exact_no_check c
       with e when CErrors.noncritical e -> Proofview.tclZERO e
-    else exact_check c
+    else Proofview.Unsafe.tclEVARS sigma <*> exact_check c
   end
 
 (* Util *)

--- a/test-suite/bugs/bug_16771.v
+++ b/test-suite/bugs/bug_16771.v
@@ -1,0 +1,18 @@
+Require Import CRelationClasses.
+
+Structure ConstructiveReals : Type :=
+  {
+    CRcarrier : Prop;
+    CRle (x y : CRcarrier) := False;
+  }.
+
+#[local] Hint Resolve iff_equivalence : mydb.
+
+Goal forall {R : ConstructiveReals},
+    CRelationClasses.Equivalence (CRle R).
+Proof.
+intros.
+auto with mydb.
+(* Anomaly "in Univ.repr: Universe Top.169 undefined."
+Please report at http://coq.inria.fr/bugs/.*)
+Abort.


### PR DESCRIPTION
Fix #16771
