### PR TITLE
Preserve more sharing in CClosure strong reduction

### DIFF
--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -1609,7 +1609,12 @@ and klt info tab e t = match kind t with
   let c' = klt (push_relevance info na) tab (usubs_lift e) c in
   if u' == u && c' == c then t
   else mkLambda (na, u', c')
-| Var _ | Const _ | CoFix _ | Fix _ | Prod _ | Evar _ | Case _ | Cast _ | LetIn _ | Proj _ | Array _ ->
+| Prod (na, u, v) ->
+  let u' = klt info tab e u in
+  let v' = klt (push_relevance info na) tab (usubs_lift e) v in
+  if u' == u && v' == v then t
+  else mkProd (na, u', v')
+| Var _ | Const _ | CoFix _ | Fix _ | Evar _ | Case _ | Cast _ | LetIn _ | Proj _ | Array _ ->
   let share = info.i_cache.i_share in
   let (nm,s) = knit info tab e t [] in
   let () = if share then ignore (fapp_stack (nm, s)) in (* to unlock Zupdates! *)

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -1604,7 +1604,12 @@ and klt info tab e t = match kind t with
     zip_term info tab (norm_head info tab nm) s
   | App _ -> assert false
   end
-| Var _ | Const _ | CoFix _ | Lambda _ | Fix _ | Prod _ | Evar _ | Case _ | Cast _ | LetIn _ | Proj _ | Array _ ->
+| Lambda (na, u, c) ->
+  let u' = klt info tab e u in
+  let c' = klt (push_relevance info na) tab (usubs_lift e) c in
+  if u' == u && c' == c then t
+  else mkLambda (na, u', c')
+| Var _ | Const _ | CoFix _ | Fix _ | Prod _ | Evar _ | Case _ | Cast _ | LetIn _ | Proj _ | Array _ ->
   let share = info.i_cache.i_share in
   let (nm,s) = knit info tab e t [] in
   let () = if share then ignore (fapp_stack (nm, s)) in (* to unlock Zupdates! *)

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -1614,7 +1614,8 @@ and klt info tab e t = match kind t with
   let v' = klt (push_relevance info na) tab (usubs_lift e) v in
   if u' == u && v' == v then t
   else mkProd (na, u', v')
-| Var _ | Const _ | CoFix _ | Fix _ | Evar _ | Case _ | Cast _ | LetIn _ | Proj _ | Array _ ->
+| Cast (t, _, _) -> klt info tab e t
+| Var _ | Const _ | CoFix _ | Fix _ | Evar _ | Case _ | LetIn _ | Proj _ | Array _ ->
   let share = info.i_cache.i_share in
   let (nm,s) = knit info tab e t [] in
   let () = if share then ignore (fapp_stack (nm, s)) in (* to unlock Zupdates! *)

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -1583,7 +1583,12 @@ let rec kl info tab m =
     zip_term info tab (norm_head info tab nm) s
 
 and klt info tab e t = match kind t with
-| Rel i -> kl info tab (clos_rel (fst e) i)
+| Rel i ->
+  begin match expand_rel i (fst e) with
+  | Inl (n, mt) -> kl info tab @@ lift_fconstr n mt
+  | Inr (k, None) -> if Int.equal k i then t else mkRel k
+  | Inr (k, Some p) -> kl info tab @@ lift_fconstr (k-p) {mark=Red;term=FFlex(RelKey p)}
+  end
 | App (hd, args) ->
   begin match kind hd with
   | Ind _ | Construct _ ->

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -1698,6 +1698,7 @@ let whd_val info tab v = term_of_fconstr (kh info tab v [])
 
 (* strong reduction *)
 let norm_val info tab v = kl info tab v
+let norm_term info tab e t = klt info tab e t
 
 let whd_stack infos tab m stk = match m.mark with
 | Whnf | Ntrl ->

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -206,6 +206,9 @@ val infos_with_reds : clos_infos -> reds -> clos_infos
 (** [norm_val] is for strong normalization *)
 val norm_val : clos_infos -> clos_tab -> fconstr -> constr
 
+(** Same as [norm_val] but for terms *)
+val norm_term : clos_infos -> clos_tab -> fconstr usubs -> Constr.constr -> Constr.constr
+
 (** [whd_val] is for weak head normalization *)
 val whd_val : clos_infos -> clos_tab -> fconstr -> constr
 

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -133,7 +133,7 @@ let whd_betaiota env t =
     | _ -> whd_val (create_clos_infos betaiota env) (create_tab ()) (inject t)
 
 let nf_betaiota env t =
-  norm_val (create_clos_infos betaiota env) (create_tab ()) (inject t)
+  norm_term (create_clos_infos betaiota env) (create_tab ()) (Esubst.subs_id 0, Univ.Instance.empty) t
 
 let whd_betaiotazeta env x =
   match kind x with

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -976,10 +976,10 @@ let nf_evar = Evarutil.nf_evar
    a [nf_evar] here *)
 let clos_norm_flags flgs env sigma t =
   try
-    EConstr.of_constr (CClosure.norm_val
+    EConstr.of_constr (CClosure.norm_term
       (Evarutil.create_clos_infos env sigma flgs)
       (CClosure.create_tab ())
-      (CClosure.inject (EConstr.Unsafe.to_constr t)))
+      (Esubst.subs_id 0, Univ.Instance.empty) (EConstr.Unsafe.to_constr t))
   with e when is_anomaly e -> user_err Pp.(str "Tried to normalize ill-typed term")
 
 let clos_whd_flags flgs env sigma t =


### PR DESCRIPTION
Instead of going full fconstr, which is rebuilding terms from the bottom up, we try to keep constrs around as much as possible in the `norm_val` subfunctions.

This should help reducing the memory use of VST, and tactic-heavy developments in general. Many tactics use indeed internally `nf_betaiota` on arbitrary goals for backwards compatibility, leading to a potential waste of memory. We could try to be even stricter than what this PR does, but this seems to be capturing a good chunk of the typical use.