### PR TITLE
[Ltac2] Avoid binding a variable name that is used within an expression

### DIFF
--- a/test-suite/bugs/bug_16543.v
+++ b/test-suite/bugs/bug_16543.v
@@ -1,0 +1,13 @@
+From Ltac2 Require Import Ltac2.
+
+(* The "p" comes from Tac2intern.fresh_var *)
+Fail Ltac2 foo (a, b) := p.
+Fail Ltac2 foo x := let (a, b) := x in p.
+Fail Ltac2 foo x := let (a, b) := p in x.
+Fail Ltac2 foo (a, b) := let (c, d) := p in c.
+Fail Ltac2 foo (a, b) := let (c, d) := (a, b) in p.
+Fail Ltac2 foo (a, b) := if a then p else p.
+Fail Ltac2 foo (a, b) := p; a.
+Ltac2 Type 'a ref := { mutable contents : 'a }.
+Ltac2 snd (a, b) := b.
+Fail Ltac2 foo (a, b) := a.(contents) := snd p.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #16543


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.


The downside of this solution is that it has to browse the entire AST to find variables.
Another way would be to  introduce a `Gensym` identifier, which would be guaranteed to be not equal to any other identifier, but that would cause a lot of collateral damage (i.e. complicate code in all other places)