### PR TITLE
Share the Lambda code generation phase in VM and native compilation

### DIFF
--- a/kernel/genlambda.ml
+++ b/kernel/genlambda.ml
@@ -521,3 +521,231 @@ let lambda_of_prim env kn op args =
     let extra_args = Array.sub args arity (Array.length args - arity) in
     mkLapp(prim env kn op prim_args) extra_args
   | _ -> mkLapp (expand_prim env kn op arity) args
+
+module RelDecl = Context.Rel.Declaration
+
+type tag = int
+
+module type S =
+sig
+  type value
+  val as_value : int -> value lambda array -> value option
+  val get_constant : pconstant -> constant_body -> value lambda
+  val check_inductive : inductive -> mutual_inductive_body -> unit
+end
+
+module Make (Val : S) =
+struct
+
+(* [nparams] is the number of parameters still expected *)
+let makeblock _env ind tag nparams arity args =
+  makeblock Val.as_value ind tag nparams arity args
+
+(*i Global environment *)
+
+let get_names decl =
+  let decl = Array.of_list decl in
+  Array.map fst decl
+
+let empty_args = [||]
+
+module Cache =
+  struct
+
+    module ConstrHash =
+    struct
+      type t = constructor
+      let equal = Construct.CanOrd.equal
+      let hash = Construct.CanOrd.hash
+    end
+
+    module ConstrTable = Hashtbl.Make(ConstrHash)
+
+    type constructor_info = tag * int * int (* nparam nrealargs *)
+
+    let get_construct_info cache env c : constructor_info =
+      try ConstrTable.find cache c
+      with Not_found ->
+        let ((mind,j), i) = c in
+        let oib = lookup_mind mind env in
+        let oip = oib.mind_packets.(j) in
+        let () = Val.check_inductive (mind, j) oib in
+        let tag,arity = oip.mind_reloc_tbl.(i-1) in
+        let nparams = oib.mind_nparams in
+        let r = (tag, nparams, arity) in
+        ConstrTable.add cache c r;
+        r
+  end
+
+let evar_value sigma ev = sigma.evars_val.evar_expand ev
+
+let meta_type sigma mv = sigma.evars_metas mv
+
+(** Extract the inductive type over which a fixpoint is decreasing *)
+let rec get_fix_struct env i t = match kind (Reduction.whd_all env t) with
+| Prod (na, dom, t) ->
+  if Int.equal i 0 then
+    let dom = Reduction.whd_all env dom in
+    let (dom, _) = decompose_appvect dom in
+    match kind dom with
+    | Ind (ind, _) -> ind
+    | _ -> assert false
+  else
+    let env = Environ.push_rel (RelDecl.LocalAssum (na, dom)) env in
+    get_fix_struct env (i - 1) t
+| _ -> assert false
+
+let rec lambda_of_constr cache env sigma c =
+  match kind c with
+  | Meta mv ->
+     let ty = meta_type sigma mv in
+     Lmeta (mv, lambda_of_constr cache env sigma ty)
+
+  | Evar ev ->
+     (match evar_value sigma ev with
+     | Constr.EvarUndefined (evk, args) ->
+        let args = Array.map_of_list (fun c -> lambda_of_constr cache env sigma c) args in
+        Levar(evk, args)
+     | Constr.EvarDefined t -> lambda_of_constr cache env sigma t)
+
+  | Cast (c, _, _) -> lambda_of_constr cache env sigma c
+
+  | Rel i -> Lrel (RelDecl.get_name (Environ.lookup_rel i env), i)
+
+  | Var id -> Lvar id
+
+  | Sort s -> Lsort s
+
+  | Ind pind -> Lind pind
+
+  | Prod(id, dom, codom) ->
+      let ld = lambda_of_constr cache env sigma dom in
+      let env = Environ.push_rel (RelDecl.LocalAssum (id, dom)) env in
+      let lc = lambda_of_constr cache env sigma codom in
+      Lprod(ld,  Llam([|id|], lc))
+
+  | Lambda _ ->
+      let params, body = Term.decompose_lam c in
+      let fold (na, t) env = Environ.push_rel (RelDecl.LocalAssum (na, t)) env in
+      let env = List.fold_right fold params env in
+      let lb = lambda_of_constr cache env sigma body in
+      let ids = get_names (List.rev params) in
+      mkLlam ids lb
+
+  | LetIn(id, def, t, body) ->
+      let ld = lambda_of_constr cache env sigma def in
+      let env = Environ.push_rel (RelDecl.LocalDef (id, def, t)) env in
+      let lb = lambda_of_constr cache env sigma body in
+      Llet(id, ld, lb)
+
+  | App(f, args) -> lambda_of_app cache env sigma f args
+
+  | Const _ -> lambda_of_app cache env sigma c empty_args
+
+  | Construct _ ->  lambda_of_app cache env sigma c empty_args
+
+  | Proj (p, c) ->
+    let c = lambda_of_constr cache env sigma c in
+    Lproj (Projection.repr p, c)
+
+  | Case (ci, u, pms, t, iv, a, br) -> (* XXX handle iv *)
+    let (ci, t, _iv, a, branches) = Inductive.expand_case env (ci, u, pms, t, iv, a, br) in
+    let (mind, i) = ci.ci_ind in
+    let mib = lookup_mind mind env in
+    let oib = mib.mind_packets.(i) in
+    let tbl = oib.mind_reloc_tbl in
+    (* Building info *)
+    let annot_sw = (ci, tbl, mib.mind_finite) in
+    (* translation of the argument *)
+    let la = lambda_of_constr cache env sigma a in
+    (* translation of the type *)
+    let lt = lambda_of_constr cache env sigma t in
+    (* translation of branches *)
+    let dummy = Lrel(Anonymous,0) in
+    let consts = Array.make oib.mind_nb_constant dummy in
+    let blocks = Array.make oib.mind_nb_args ([||],dummy) in
+    let rtbl = oib.mind_reloc_tbl in
+    for i = 0 to Array.length rtbl - 1 do
+      let tag, arity = rtbl.(i) in
+      let b = lambda_of_constr cache env sigma branches.(i) in
+      if arity = 0 then consts.(tag) <- b
+      else
+        let b =
+          match b with
+          | Llam(ids, body) when Array.length ids = arity -> (ids, body)
+          | _ ->
+            let anon = Context.make_annot Anonymous Sorts.Relevant in (* TODO relevance *)
+            let ids = Array.make arity anon in
+            let args = make_args arity 1 in
+            let ll = lam_lift arity b in
+            (ids, mkLapp  ll args)
+        in blocks.(tag-1) <- b
+    done;
+    let branches =
+      { constant_branches = consts;
+        nonconstant_branches = blocks }
+    in
+    Lcase(annot_sw, lt, la, branches)
+
+  | Fix((pos, i), (names,type_bodies,rec_bodies)) ->
+      let ltypes = lambda_of_args cache env sigma 0 type_bodies in
+      let map i t = get_fix_struct env i t in
+      let inds = Array.map2 map pos type_bodies in
+      let env = Environ.push_rec_types (names, type_bodies, rec_bodies) env in
+      let lbodies = lambda_of_args cache env sigma 0 rec_bodies in
+      Lfix((pos, inds, i), (names, ltypes, lbodies))
+
+  | CoFix(init,(names,type_bodies,rec_bodies)) ->
+      let rec_bodies = Array.map2 (Reduction.eta_expand env) rec_bodies type_bodies in
+      let ltypes = lambda_of_args cache env sigma 0 type_bodies in
+      let env = Environ.push_rec_types (names, type_bodies, rec_bodies) env in
+      let lbodies = lambda_of_args cache env sigma 0 rec_bodies in
+      Lcofix(init, (names, ltypes, lbodies))
+
+  | Int i -> Luint i
+
+  | Float f -> Lfloat f
+
+  | Array (_u, t, def, _ty) ->
+    let def = lambda_of_constr cache env sigma def in
+    Lparray (lambda_of_args cache env sigma 0 t, def)
+
+and lambda_of_app cache env sigma f args =
+  match kind f with
+  | Const (kn, u as c) ->
+      let kn = get_alias env kn in
+      let cb = lookup_constant kn env in
+      begin match cb.const_body with
+      | Primitive op -> lambda_of_prim env c op (lambda_of_args cache env sigma 0 args)
+      | Def csubst -> (* TODO optimize if f is a proj and argument is known *)
+        if cb.const_inline_code then lambda_of_app cache env sigma csubst args
+        else
+          let t = Val.get_constant (kn, u) cb in
+          mkLapp t (lambda_of_args cache env sigma 0 args)
+      | OpaqueDef _ | Undef _ ->
+          mkLapp (Lconst (kn, u)) (lambda_of_args cache env sigma 0 args)
+      end
+  | Construct ((ind,_ as c),_) ->
+    let tag, nparams, arity = Cache.get_construct_info cache env c in
+    let nargs = Array.length args in
+    if nparams < nargs then (* got all parameters *)
+      let args = lambda_of_args cache env sigma nparams args in
+      makeblock env ind tag 0 arity args
+    else makeblock env ind tag (nparams - nargs) arity empty_args
+  | _ ->
+      let f = lambda_of_constr cache env sigma f in
+      let args = lambda_of_args cache env sigma 0 args in
+      mkLapp f args
+
+and lambda_of_args cache env sigma start args =
+  let nargs = Array.length args in
+  if start < nargs then
+    Array.init (nargs - start)
+      (fun i -> lambda_of_constr cache env sigma args.(start + i))
+  else empty_args
+
+let lambda_of_constr env sigma c =
+  let cache = Cache.ConstrTable.create 91 in
+  lambda_of_constr cache env sigma c
+
+end

--- a/kernel/genlambda.ml
+++ b/kernel/genlambda.ml
@@ -490,6 +490,17 @@ let expand_constructor ind tag nparams arity =
   let args = make_args arity 1 in
   Llam(ids, Lmakeblock (ind, tag, args))
 
+let makeblock as_val ind tag nparams arity args =
+  let nargs = Array.length args in
+  if nparams > 0 || nargs < arity then
+    mkLapp (expand_constructor ind tag nparams arity) args
+  else
+    (* The constructor is fully applied *)
+  if arity = 0 then Lint tag
+  else match as_val tag args with
+  | Some v -> Lval v
+  | None -> Lmakeblock (ind, tag, args)
+
 (* Compilation of primitive *)
 
 let prim _env kn p args =

--- a/kernel/genlambda.ml
+++ b/kernel/genlambda.ml
@@ -477,10 +477,20 @@ let rec get_alias env kn =
      | Vmemitcodes.BCalias kn' -> get_alias env kn'
      | _ -> kn)
 
-(* Compilation of primitive *)
+(* Translation of constructors *)
 
 let make_args start _end =
   Array.init (start - _end + 1) (fun i -> Lrel (Anonymous, start - i))
+
+let expand_constructor ind tag nparams arity =
+  let anon = Context.make_annot Anonymous Sorts.Relevant in (* TODO relevance *)
+  let ids = Array.make (nparams + arity) anon in
+  if Int.equal arity 0 then mkLlam ids (Lint tag)
+  else
+  let args = make_args arity 1 in
+  Llam(ids, Lmakeblock (ind, tag, args))
+
+(* Compilation of primitive *)
 
 let prim _env kn p args =
   Lprim (kn, p, args)

--- a/kernel/genlambda.mli
+++ b/kernel/genlambda.mli
@@ -84,6 +84,7 @@ val remove_let : 'v lambda Esubst.subs -> 'v lambda -> 'v lambda
 
 val get_alias : Environ.env -> Constant.t -> Constant.t
 val make_args : int -> int -> 'v lambda array
+val expand_constructor : inductive -> int -> int -> int -> 'v lambda
 val lambda_of_prim : Environ.env -> pconstant -> CPrimitives.t -> 'v lambda array -> 'v lambda
 
 (** {5 Printing} *)

--- a/kernel/genlambda.mli
+++ b/kernel/genlambda.mli
@@ -89,6 +89,19 @@ val makeblock : (int -> 'v lambda array -> 'v option) ->
 
 val lambda_of_prim : Environ.env -> pconstant -> CPrimitives.t -> 'v lambda array -> 'v lambda
 
+module type S =
+sig
+  type value
+  val as_value : int -> value lambda array -> value option
+  val get_constant : pconstant -> Declarations.constant_body -> value lambda
+  val check_inductive : inductive -> Declarations.mutual_inductive_body -> unit
+end
+
+module Make (Val : S) :
+sig
+  val lambda_of_constr : Environ.env -> evars -> Constr.constr -> Val.value lambda
+end
+
 (** {5 Printing} *)
 
 val pp_lam : 'v lambda -> Pp.t

--- a/kernel/genlambda.mli
+++ b/kernel/genlambda.mli
@@ -84,7 +84,9 @@ val remove_let : 'v lambda Esubst.subs -> 'v lambda -> 'v lambda
 
 val get_alias : Environ.env -> Constant.t -> Constant.t
 val make_args : int -> int -> 'v lambda array
-val expand_constructor : inductive -> int -> int -> int -> 'v lambda
+val makeblock : (int -> 'v lambda array -> 'v option) ->
+  inductive -> int -> int -> int -> 'v lambda array -> 'v lambda
+
 val lambda_of_prim : Environ.env -> pconstant -> CPrimitives.t -> 'v lambda array -> 'v lambda
 
 (** {5 Printing} *)

--- a/kernel/nativecode.ml
+++ b/kernel/nativecode.ml
@@ -54,6 +54,21 @@ let fresh_lname n =
   incr lname_ctr;
   { lname = n; luid = !lname_ctr }
 
+type prefix = string
+
+(* Linked code location utilities *)
+let get_mind_prefix env mind =
+   let _,name = lookup_mind_key mind env in
+   match !name with
+   | NotLinked -> ""
+   | Linked s -> s
+
+let get_const_prefix env c =
+   let _,(nameref,_) = lookup_constant_key c env in
+   match !nameref with
+   | NotLinked -> ""
+   | Linked s -> s
+
 (** Global names **)
 type gname =
   | Gind of string * inductive (* prefix, inductive name *)

--- a/kernel/nativelambda.ml
+++ b/kernel/nativelambda.ml
@@ -56,13 +56,6 @@ let get_value lc =
   | _ -> raise Not_found
 
 (* Translation of constructors *)
-let expand_constructor ind tag nparams arity =
-  let anon = Context.make_annot Anonymous Sorts.Relevant in (* TODO relevance *)
-  let ids = Array.make (nparams + arity) anon in
-  if Int.equal arity 0 then mkLlam ids (Lint tag)
-  else
-  let args = make_args arity 1 in
-  Llam(ids, Lmakeblock (ind, tag, args))
 
 (* [nparams] is the number of parameters still expected *)
 let makeblock _env ind tag nparams arity args =

--- a/kernel/nativelambda.ml
+++ b/kernel/nativelambda.ml
@@ -55,17 +55,7 @@ let get_value lc =
   | Lfloat f -> Nativevalues.mk_float f
   | _ -> raise Not_found
 
-(* Translation of constructors *)
-
-(* [nparams] is the number of parameters still expected *)
-let makeblock _env ind tag nparams arity args =
-  let nargs = Array.length args in
-  if nparams > 0 || nargs < arity then
-    mkLapp (expand_constructor ind tag nparams arity) args
-  else
-  (* The constructor is fully applied *)
-  if Int.equal arity 0 then Lint tag
-  else
+let as_value tag args =
   if Array.for_all is_value args then
     let dummy_val = Obj.magic 0 in
     let args =
@@ -73,9 +63,14 @@ let makeblock _env ind tag nparams arity args =
          function eval_to_patch, file kernel/csymtable.ml *)
       let a = Array.make (Array.length args) dummy_val in
       Array.iteri (fun i v -> a.(i) <- get_value v) args; a in
-    Lval (Nativevalues.mk_block tag args)
-  else
-    Lmakeblock(ind, tag, args)
+    Some (Nativevalues.mk_block tag args)
+  else None
+
+(* Translation of constructors *)
+
+(* [nparams] is the number of parameters still expected *)
+let makeblock _env ind tag nparams arity args =
+  Genlambda.makeblock as_value ind tag nparams arity args
 
 let makearray args def =
   Lparray (args, def)

--- a/kernel/nativelambda.ml
+++ b/kernel/nativelambda.ml
@@ -19,7 +19,6 @@ open Nativevalues
 module RelDecl = Context.Rel.Declaration
 
 (** This file defines the lambda code generation phase of the native compiler *)
-type prefix = string
 
 type lambda = Nativevalues.t Genlambda.lambda
 
@@ -27,19 +26,6 @@ type lambda = Nativevalues.t Genlambda.lambda
 
 (*s Operators on substitution *)
 let subst_id = subs_id 0
-
-(* Linked code location utilities *)
-let get_mind_prefix env mind =
-   let _,name = lookup_mind_key mind env in
-   match !name with
-   | NotLinked -> ""
-   | Linked s -> s
-
-let get_const_prefix env c =
-   let _,(nameref,_) = lookup_constant_key c env in
-   match !nameref with
-   | NotLinked -> ""
-   | Linked s -> s
 
 (** Simplification of lambda expression *)
 

--- a/kernel/nativelambda.ml
+++ b/kernel/nativelambda.ml
@@ -7,25 +7,17 @@
 (*         *     GNU Lesser General Public License Version 2.1          *)
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
+
 open Util
-open Names
 open Esubst
 open Constr
-open Declarations
-open Environ
 open Genlambda
-open Nativevalues
-
-module RelDecl = Context.Rel.Declaration
 
 (** This file defines the lambda code generation phase of the native compiler *)
 
 type lambda = Nativevalues.t Genlambda.lambda
 
 (*s Constructors *)
-
-(*s Operators on substitution *)
-let subst_id = subs_id 0
 
 (** Simplification of lambda expression *)
 
@@ -37,10 +29,6 @@ let can_subst lam =
   | _ -> false
 
 let simplify subst lam = simplify can_subst subst lam
-
-(*s Translation from [constr] to [lambda] *)
-
-(* Translation of constructor *)
 
 let is_value lc =
   match lc with
@@ -66,241 +54,24 @@ let as_value tag args =
     Some (Nativevalues.mk_block tag args)
   else None
 
-(* Translation of constructors *)
-
-(* [nparams] is the number of parameters still expected *)
-let makeblock _env ind tag nparams arity args =
-  Genlambda.makeblock as_value ind tag nparams arity args
-
-let makearray args def =
-  Lparray (args, def)
-
-(*i Global environment *)
-
-let get_names decl =
-  let decl = Array.of_list decl in
-  Array.map fst decl
-
-let empty_args = [||]
-
-module Cache =
-  struct
-
-    module ConstrHash =
-    struct
-      type t = constructor
-      let equal = Construct.CanOrd.equal
-      let hash = Construct.CanOrd.hash
-    end
-
-    module ConstrTable = Hashtbl.Make(ConstrHash)
-
-    type constructor_info = tag * int * int (* nparam nrealargs *)
-
-    let get_construct_info cache env c : constructor_info =
-      try ConstrTable.find cache c
-      with Not_found ->
-        let ((mind,j), i) = c in
-        let oib = lookup_mind mind env in
-        let oip = oib.mind_packets.(j) in
-        let tag,arity = oip.mind_reloc_tbl.(i-1) in
-        let nparams = oib.mind_nparams in
-        let r = (tag, nparams, arity) in
-        ConstrTable.add cache c r;
-        r
-  end
-
 let is_lazy t =
   match Constr.kind t with
   | App _ | LetIn _ | Case _ | Proj _ -> true
   | _ -> false
 
-let evar_value sigma ev = sigma.evars_val.evar_expand ev
+module Val =
+struct
+  open Declarations
+  type value = Nativevalues.t
+  let as_value = as_value
+  let check_inductive _ _ = ()
+  let get_constant knu cb = match cb.const_body with
+  | Def body -> if is_lazy body then mkLapp Lforce [|Lconst knu|] else Lconst knu
+  | Undef _ | OpaqueDef _ | Primitive _ -> assert false
+end
 
-let meta_type sigma mv = sigma.evars_metas mv
-
-(** Extract the inductive type over which a fixpoint is decreasing *)
-let rec get_fix_struct env i t = match kind (Reduction.whd_all env t) with
-| Prod (na, dom, t) ->
-  if Int.equal i 0 then
-    let dom = Reduction.whd_all env dom in
-    let (dom, _) = decompose_appvect dom in
-    match kind dom with
-    | Ind (ind, _) -> ind
-    | _ -> assert false
-  else
-    let env = Environ.push_rel (RelDecl.LocalAssum (na, dom)) env in
-    get_fix_struct env (i - 1) t
-| _ -> assert false
-
-let rec lambda_of_constr cache env sigma c =
-  match kind c with
-  | Meta mv ->
-     let ty = meta_type sigma mv in
-     Lmeta (mv, lambda_of_constr cache env sigma ty)
-
-  | Evar ev ->
-     (match evar_value sigma ev with
-     | Constr.EvarUndefined (evk, args) ->
-        let args = Array.map_of_list (fun c -> lambda_of_constr cache env sigma c) args in
-        Levar(evk, args)
-     | Constr.EvarDefined t -> lambda_of_constr cache env sigma t)
-
-  | Cast (c, _, _) -> lambda_of_constr cache env sigma c
-
-  | Rel i -> Lrel (RelDecl.get_name (Environ.lookup_rel i env), i)
-
-  | Var id -> Lvar id
-
-  | Sort s -> Lsort s
-
-  | Ind pind -> Lind pind
-
-  | Prod(id, dom, codom) ->
-      let ld = lambda_of_constr cache env sigma dom in
-      let env = Environ.push_rel (RelDecl.LocalAssum (id, dom)) env in
-      let lc = lambda_of_constr cache env sigma codom in
-      Lprod(ld,  Llam([|id|], lc))
-
-  | Lambda _ ->
-      let params, body = Term.decompose_lam c in
-      let fold (na, t) env = Environ.push_rel (RelDecl.LocalAssum (na, t)) env in
-      let env = List.fold_right fold params env in
-      let lb = lambda_of_constr cache env sigma body in
-      let ids = get_names (List.rev params) in
-      mkLlam ids lb
-
-  | LetIn(id, def, t, body) ->
-      let ld = lambda_of_constr cache env sigma def in
-      let env = Environ.push_rel (RelDecl.LocalDef (id, def, t)) env in
-      let lb = lambda_of_constr cache env sigma body in
-      Llet(id, ld, lb)
-
-  | App(f, args) -> lambda_of_app cache env sigma f args
-
-  | Const _ -> lambda_of_app cache env sigma c empty_args
-
-  | Construct _ ->  lambda_of_app cache env sigma c empty_args
-
-  | Proj (p, c) ->
-    let c = lambda_of_constr cache env sigma c in
-    Lproj (Projection.repr p, c)
-
-  | Case (ci, u, pms, t, iv, a, br) -> (* XXX handle iv *)
-    let (ci, t, _iv, a, branches) = Inductive.expand_case env (ci, u, pms, t, iv, a, br) in
-    let (mind, i) = ci.ci_ind in
-    let mib = lookup_mind mind env in
-    let oib = mib.mind_packets.(i) in
-    let tbl = oib.mind_reloc_tbl in
-    (* Building info *)
-    let annot_sw = (ci, tbl, mib.mind_finite) in
-    (* translation of the argument *)
-    let la = lambda_of_constr cache env sigma a in
-    (* translation of the type *)
-    let lt = lambda_of_constr cache env sigma t in
-    (* translation of branches *)
-    let dummy = Lrel(Anonymous,0) in
-    let consts = Array.make oib.mind_nb_constant dummy in
-    let blocks = Array.make oib.mind_nb_args ([||],dummy) in
-    let rtbl = oib.mind_reloc_tbl in
-    for i = 0 to Array.length rtbl - 1 do
-      let tag, arity = rtbl.(i) in
-      let b = lambda_of_constr cache env sigma branches.(i) in
-      if arity = 0 then consts.(tag) <- b
-      else
-        let b =
-          match b with
-          | Llam(ids, body) when Array.length ids = arity -> (ids, body)
-          | _ ->
-            let anon = Context.make_annot Anonymous Sorts.Relevant in (* TODO relevance *)
-            let ids = Array.make arity anon in
-            let args = make_args arity 1 in
-            let ll = lam_lift arity b in
-            (ids, mkLapp  ll args)
-        in blocks.(tag-1) <- b
-    done;
-    let branches =
-      { constant_branches = consts;
-        nonconstant_branches = blocks }
-    in
-    Lcase(annot_sw, lt, la, branches)
-
-  | Fix((pos, i), (names,type_bodies,rec_bodies)) ->
-      let ltypes = lambda_of_args cache env sigma 0 type_bodies in
-      let map i t = get_fix_struct env i t in
-      let inds = Array.map2 map pos type_bodies in
-      let env = Environ.push_rec_types (names, type_bodies, rec_bodies) env in
-      let lbodies = lambda_of_args cache env sigma 0 rec_bodies in
-      Lfix((pos, inds, i), (names, ltypes, lbodies))
-
-  | CoFix(init,(names,type_bodies,rec_bodies)) ->
-      let rec_bodies = Array.map2 (Reduction.eta_expand env) rec_bodies type_bodies in
-      let ltypes = lambda_of_args cache env sigma 0 type_bodies in
-      let env = Environ.push_rec_types (names, type_bodies, rec_bodies) env in
-      let lbodies = lambda_of_args cache env sigma 0 rec_bodies in
-      Lcofix(init, (names, ltypes, lbodies))
-
-  | Int i -> Luint i
-
-  | Float f -> Lfloat f
-
-  | Array (_u, t, def, _ty) ->
-    let def = lambda_of_constr cache env sigma def in
-    makearray (lambda_of_args cache env sigma 0 t) def
-
-and lambda_of_app cache env sigma f args =
-  match kind f with
-  | Const (kn, u as c) ->
-      let kn = get_alias env kn in
-      let cb = lookup_constant kn env in
-      begin match cb.const_body with
-      | Primitive op -> lambda_of_prim env c op (lambda_of_args cache env sigma 0 args)
-      | Def csubst -> (* TODO optimize if f is a proj and argument is known *)
-          if cb.const_inline_code then
-            lambda_of_app cache env sigma csubst args
-          else
-          let t =
-            if is_lazy csubst then
-              mkLapp Lforce [|Lconst (kn, u)|]
-            else Lconst (kn, u)
-          in
-        mkLapp t (lambda_of_args cache env sigma 0 args)
-      | OpaqueDef _ | Undef _ ->
-          mkLapp (Lconst (kn, u)) (lambda_of_args cache env sigma 0 args)
-      end
-  | Construct ((ind,_ as c),_) ->
-    let tag, nparams, arity = Cache.get_construct_info cache env c in
-    let nargs = Array.length args in
-    if nparams < nargs then (* got all parameters *)
-      let args = lambda_of_args cache env sigma nparams args in
-      makeblock env ind tag 0 arity args
-    else makeblock env ind tag (nparams - nargs) arity empty_args
-  | _ ->
-      let f = lambda_of_constr cache env sigma f in
-      let args = lambda_of_args cache env sigma 0 args in
-      mkLapp f args
-
-and lambda_of_args cache env sigma start args =
-  let nargs = Array.length args in
-  if start < nargs then
-    Array.init (nargs - start)
-      (fun i -> lambda_of_constr cache env sigma args.(start + i))
-  else empty_args
-
-let optimize lam =
-  let lam = simplify subst_id lam in
-(*  if Flags.vm_draw_opt () then
-    (msgerrnl (str "Simplify = \n" ++ pp_lam lam);flush_all());
-  let lam = remove_let subst_id lam in
-  if Flags.vm_draw_opt () then
-    (msgerrnl (str "Remove let = \n" ++ pp_lam lam);flush_all()); *)
-  lam
+module Lambda = Genlambda.Make(Val)
 
 let lambda_of_constr env sigma c =
-  let cache = Cache.ConstrTable.create 91 in
-  let lam = lambda_of_constr cache env sigma c in
-(*  if Flags.vm_draw_opt () then begin
-    (msgerrnl (str "Constr = \n" ++ pr_constr c);flush_all());
-    (msgerrnl (str "Lambda = \n" ++ pp_lam lam);flush_all());
-  end; *)
-  optimize lam
+  let lam = Lambda.lambda_of_constr env sigma c in
+  simplify (subs_id 0) lam

--- a/kernel/nativelambda.mli
+++ b/kernel/nativelambda.mli
@@ -7,19 +7,14 @@
 (*         *     GNU Lesser General Public License Version 2.1          *)
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
-open Names
 open Constr
 open Environ
 open Genlambda
 
 (** This file defines the lambda code generation phase of the native compiler *)
-type prefix = string
 
 type lambda = Nativevalues.t Genlambda.lambda
 
 val is_lazy : constr -> bool
-
-val get_mind_prefix : env -> MutInd.t -> string
-val get_const_prefix : env -> Constant.t -> string
 
 val lambda_of_constr : env -> evars -> Constr.constr -> lambda

--- a/kernel/vmlambda.ml
+++ b/kernel/vmlambda.ml
@@ -63,18 +63,7 @@ let get_value lc =
   | Lint i -> val_of_int i
   | _ -> raise Not_found
 
-let make_args start _end =
-  Array.init (start - _end + 1) (fun i -> Lrel (Anonymous, start - i))
-
 (* Translation of constructors *)
-let expand_constructor ind tag nparams arity =
-  let anon = Context.make_annot Anonymous Sorts.Relevant in (* TODO relevance *)
-  let ids = Array.make (nparams + arity) anon in
-  if arity = 0 then mkLlam ids (Lint tag)
-  else
-    let args = make_args arity 1 in
-    Llam (ids, Lmakeblock (ind, tag, args))
-
 let makeblock ind tag nparams arity args =
   let nargs = Array.length args in
   if nparams > 0 || nargs < arity then

--- a/kernel/vmlambda.ml
+++ b/kernel/vmlambda.ml
@@ -1,19 +1,11 @@
 open Util
 open Names
 open Esubst
-open Term
-open Constr
 open Declarations
 open Genlambda
 open Vmvalues
-open Environ
-
-module RelDecl = Context.Rel.Declaration
 
 type lambda = structured_values Genlambda.lambda
-
-(*s Operators on substitution *)
-let subst_id = subs_id 0
 
 (** Simplification of lambda expression *)
 
@@ -73,217 +65,26 @@ let as_value tag args =
       Some (val_of_block Obj.last_non_constant_constructor_tag args)
   else None
 
-(* Translation of constructors *)
-let makeblock ind tag nparams arity args =
-  Genlambda.makeblock as_value ind tag nparams arity args
-
-let makearray args def = Lparray (args, def)
-
-(*i Global environment *)
-
-let get_names decl =
-  let decl = Array.of_list decl in
-  Array.map fst decl
-
-let dummy_lambda = Lrel(Anonymous, 0)
-
-let empty_args = [||]
-
-module Renv =
+module Val =
 struct
-
-  type constructor_info = tag * int * int (* nparam nrealargs *)
-
-  type t = {
-    env : env;
-    evar_body : constr evar_handler;
-    meta_type : metavariable -> types;
-    construct_tbl : (constructor, constructor_info) Hashtbl.t;
-  }
-
-  let make env sigma = {
-    env = env;
-    evar_body = sigma.evars_val;
-    meta_type = sigma.evars_metas;
-    construct_tbl = Hashtbl.create 111
-  }
-
-  let push_rel env decl = { env with env = Environ.push_rel decl env.env }
-
-  let push_rels env decls = { env with env = Environ.push_rel_context decls env.env }
-
-  let push_rec_types env rect = { env with env = Environ.push_rec_types rect env.env }
-
-  let get env n =
-    let na = RelDecl.get_name @@ Environ.lookup_rel n env.env in
-    Lrel (na, n)
-
-  let get_construct_info env c =
-    try Hashtbl.find env.construct_tbl c
-    with Not_found ->
-      let ((mind,j), i) = c in
-      let oib = lookup_mind mind env.env in
-      let oip = oib.mind_packets.(j) in
-      check_compilable oip;
-      let tag,arity = oip.mind_reloc_tbl.(i-1) in
-      let nparams = oib.mind_nparams in
-      let r = (tag, nparams, arity) in
-      Hashtbl.add env.construct_tbl c r;
-      r
+  type value = structured_values
+  let as_value = as_value
+  let check_inductive (_, i) mb = check_compilable mb.mind_packets.(i)
+  let get_constant knu _ = Lconst knu
 end
 
-open Renv
-
-let rec lambda_of_constr env c =
-  match Constr.kind c with
-  | Meta mv ->
-    let ty = lambda_of_constr env (env.meta_type mv) in
-    Lmeta (mv, ty)
-  | Evar ev ->
-    begin match env.evar_body.evar_expand ev with
-    | Constr.EvarUndefined (evk, args) ->
-        let args = Array.map_of_list (fun c -> lambda_of_constr env c) args in
-        Levar (evk, args)
-    | Constr.EvarDefined t -> lambda_of_constr env t
-    end
-
-  | Cast (c, _, _) -> lambda_of_constr env c
-
-  | Rel i -> Renv.get env i
-
-  | Var id -> Lvar id
-
-  | Sort s -> Lsort s
-  | Ind ind -> Lind ind
-
-  | Prod(id, dom, codom) ->
-    let ld = lambda_of_constr env dom in
-    let nenv = Renv.push_rel env (RelDecl.LocalAssum (id, dom)) in
-    let lc = lambda_of_constr nenv codom in
-    Lprod(ld, Llam([|id|], lc))
-
-  | Lambda _ ->
-    let params, body = decompose_lam c in
-    let decls = List.map (fun (id, dom) -> RelDecl.LocalAssum (id, dom)) params in
-    let nenv = Renv.push_rels env decls in
-    let lb = lambda_of_constr nenv body in
-    mkLlam (get_names (List.rev params)) lb
-
-  | LetIn(id, def, ty, body) ->
-    let ld = lambda_of_constr env def in
-    let nenv = Renv.push_rel env (RelDecl.LocalDef (id, def, ty)) in
-    let lb = lambda_of_constr nenv body in
-    Llet(id, ld, lb)
-
-  | App(f, args) -> lambda_of_app env f args
-
-  | Const _ -> lambda_of_app env c empty_args
-
-  | Construct _ ->  lambda_of_app env c empty_args
-
-  | Case (ci, u, pms, t, iv, a, br) -> (* XXX handle iv *)
-    let (ci, t, _iv, a, branches) = Inductive.expand_case env.env (ci, u, pms, t, iv, a, br) in
-    let ind = ci.ci_ind in
-    let mib = lookup_mind (fst ind) env.env in
-    let oib = mib.mind_packets.(snd ind) in
-    let () = check_compilable oib in
-    let rtbl = oib.mind_reloc_tbl in
-
-
-    (* translation of the argument *)
-    let la = lambda_of_constr env a in
-    (* translation of the type *)
-    let lt = lambda_of_constr env t in
-    (* translation of branches *)
-    let consts = Array.make oib.mind_nb_constant dummy_lambda in
-    let blocks = Array.make oib.mind_nb_args ([||],dummy_lambda) in
-    for i = 0 to Array.length rtbl - 1 do
-      let tag, arity = rtbl.(i) in
-      let b = lambda_of_constr env branches.(i) in
-      if arity = 0 then consts.(tag) <- b
-      else
-        let b =
-          match b with
-          | Llam(ids, body) when Array.length ids = arity -> (ids, body)
-          | _ ->
-            let anon = Context.make_annot Anonymous Sorts.Relevant in (* TODO relevance *)
-            let ids = Array.make arity anon in
-            let args = make_args arity 1 in
-            let ll = lam_lift arity b in
-            (ids, mkLapp  ll args)
-        in blocks.(tag-1) <- b
-    done;
-    let branches =
-      { constant_branches = consts;
-        nonconstant_branches = blocks }
-    in
-    let annot = (ci, rtbl, mib.mind_finite) in
-    Lcase (annot, lt, la, branches)
-
-  | Fix ((ln, i), (names, type_bodies, rec_bodies)) ->
-    let ltypes = lambda_of_args env 0 type_bodies in
-    let nenv = Renv.push_rec_types env (names, type_bodies, rec_bodies) in
-    let lbodies = lambda_of_args nenv 0 rec_bodies in
-    let dummy = [||] in (* FIXME: not used by the VM, requires the environment to be computed *)
-    Lfix ((ln, dummy, i), (names, ltypes, lbodies))
-
-  | CoFix(init,(names,type_bodies,rec_bodies)) ->
-    let rec_bodies = Array.map2 (Reduction.eta_expand env.env) rec_bodies type_bodies in
-    let ltypes = lambda_of_args env 0 type_bodies in
-    let nenv = Renv.push_rec_types env (names, type_bodies, rec_bodies) in
-    let lbodies = lambda_of_args nenv 0 rec_bodies in
-    Lcofix(init, (names, ltypes, lbodies))
-
-  | Proj (p,c) ->
-    let lc = lambda_of_constr env c in
-    Lproj (Projection.repr p,lc)
-
-  | Int i -> Luint i
-  | Float f -> Lfloat f
-  | Array(_u, t,def,_ty) ->
-    let def = lambda_of_constr env def in
-    makearray (lambda_of_args env 0 t) def
-
-and lambda_of_app env f args =
-  match Constr.kind f with
-  | Const (kn,u as c) ->
-      let kn = get_alias env.env kn in
-      let cb = lookup_constant kn env.env in
-      begin match cb.const_body with
-      | Primitive op -> lambda_of_prim env.env (kn,u) op (lambda_of_args env 0 args)
-      | Def csubst when cb.const_inline_code ->
-          lambda_of_app env csubst args
-      | Def _ | OpaqueDef _ | Undef _ -> mkLapp (Lconst c) (lambda_of_args env 0 args)
-      end
-  | Construct (c,_) ->
-      let tag, nparams, arity = Renv.get_construct_info env c in
-      let nargs = Array.length args in
-      if nparams < nargs then (* got all parameters *)
-        let args = lambda_of_args env nparams args in
-        makeblock (fst c) tag 0 arity args
-      else makeblock (fst c) tag (nparams - nargs) arity empty_args
-  | _ ->
-      let f = lambda_of_constr env f in
-      let args = lambda_of_args env 0 args in
-      mkLapp f args
-
-and lambda_of_args env start args =
-  let nargs = Array.length args in
-  if start < nargs then
-    Array.init (nargs - start)
-      (fun i -> lambda_of_constr env args.(start + i))
-  else empty_args
+module Lambda = Genlambda.Make(Val)
 
 (*********************************)
 let dump_lambda = ref false
 
 let optimize_lambda lam =
+  let subst_id = subs_id 0 in
   let lam = simplify subst_id lam in
   remove_let subst_id lam
 
-let lambda_of_constr ~optimize genv sigma c =
-  let env = Renv.make genv sigma in
-  let lam = lambda_of_constr env c in
+let lambda_of_constr ~optimize env sigma c =
+  let lam = Lambda.lambda_of_constr env sigma c in
   let lam = if optimize then optimize_lambda lam else lam in
   if !dump_lambda then
     Feedback.msg_debug (pp_lam lam);

--- a/kernel/vmlambda.ml
+++ b/kernel/vmlambda.ml
@@ -63,23 +63,19 @@ let get_value lc =
   | Lint i -> val_of_int i
   | _ -> raise Not_found
 
-(* Translation of constructors *)
-let makeblock ind tag nparams arity args =
-  let nargs = Array.length args in
-  if nparams > 0 || nargs < arity then
-    mkLapp (expand_constructor ind tag nparams arity) args
-  else
-    (* The constructor is fully applied *)
-  if arity = 0 then Lint tag
-  else
+let as_value tag args =
   if Array.for_all is_value args then
     if tag < Obj.last_non_constant_constructor_tag then
-      Lval(val_of_block tag (Array.map get_value args))
+      Some (val_of_block tag (Array.map get_value args))
     else
       let args = Array.map get_value args in
       let args = Array.append [| val_of_int (tag - Obj.last_non_constant_constructor_tag) |] args in
-      Lval(val_of_block Obj.last_non_constant_constructor_tag args)
-  else Lmakeblock (ind, tag, args)
+      Some (val_of_block Obj.last_non_constant_constructor_tag args)
+  else None
+
+(* Translation of constructors *)
+let makeblock ind tag nparams arity args =
+  Genlambda.makeblock as_value ind tag nparams arity args
 
 let makearray args def = Lparray (args, def)
 


### PR DESCRIPTION
Follow-up of #16671. We now have a single function producing both the VM and native ASTs, reducing the risk of divergence and creeping bugs. The code is exported as a functor in `Genlambda`, and the differences between VM and native are exposed as an argument to the functor.