### PR TITLE
Don't make `[=` a keyword (fix #16785)

### DIFF
--- a/doc/changelog/03-notations/16788-fix_16785.rst
+++ b/doc/changelog/03-notations/16788-fix_16785.rst
@@ -1,0 +1,9 @@
+- **Removed:**
+  The `\'[=\'` keyword. `\'[=\'`
+  tokens in notation definitions should be replaced with the pair of
+  tokens `\'[\' \'=\'`. If compatibility with Coq < 8.18
+  is needed, replace `[=` in uses of the notation with
+  an added space (`[ =`)
+  (`#16788 <https://github.com/coq/coq/pull/16788>`_,
+  fixes `#16785 <https://github.com/coq/coq/issues/16785>`_,
+  by Pierre Roux).

--- a/doc/sphinx/language/core/basic.rst
+++ b/doc/sphinx/language/core/basic.rst
@@ -187,7 +187,7 @@ Other tokens
   The following character sequences are tokens defined in notations or plugins
   loaded in the :term:`prelude`::
 
-    ** [= |- || ->
+    ** |- || ->
 
   Note that loading additional modules or plugins may expand the set of defined
   tokens.

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -166,6 +166,7 @@ DELETE: [
 | test_array_closing
 | test_variance_ident
 | test_ident_with_or_lpar_or_rbrac
+| test_leftsquarebracket_equal
 
   (* SSR *)
 | ssr_null_entry
@@ -1272,6 +1273,11 @@ or_and_intropattern: [
 |   WITH  "(" LIST0 simple_intropattern SEP "&" ")"
 ]
 
+equality_intropattern: [
+| REPLACE "[" "=" intropatterns "]"
+| WITH    "[=" intropatterns "]"
+]
+
 bar_cbrace: [
 | REPLACE "|" "}"
 | WITH "|}"
@@ -2125,6 +2131,11 @@ ltac2_or_and_intropattern: [
 | WITH "(" LIST1 ltac2_simple_intropattern SEP "&" ")" TAG Ltac2
 ]
 
+ltac2_equality_intropattern: [
+| REPLACE "[" "=" ltac2_intropatterns "]"
+| WITH    "[=" ltac2_intropatterns "]"
+]
+
 SPLICE: [
 | tac2def_val
 | tac2def_typ
@@ -2320,6 +2331,11 @@ ssrsimpl_ne: [
 hat: [
 | DELETE "^" "~" ident      (* SSR plugin *)
 | DELETE "^" "~" natural      (* SSR plugin *)
+]
+
+ssrcpat: [
+| REPLACE "[" "=" ssriorpat "]"
+| WITH    "[=" ssriorpat "]"
 ]
 
 ssriorpat: [

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -2445,7 +2445,7 @@ or_and_intropattern: [
 equality_intropattern: [
 | "->"
 | "<-"
-| "[=" intropatterns "]"
+| test_leftsquarebracket_equal "[" "=" intropatterns "]"
 ]
 
 naming_intropattern: [
@@ -2465,8 +2465,8 @@ simple_intropattern: [
 ]
 
 simple_intropattern_closed: [
-| or_and_intropattern
 | equality_intropattern
+| or_and_intropattern
 | "_"
 | naming_intropattern
 ]
@@ -2614,8 +2614,8 @@ or_and_intropattern_loc: [
 ]
 
 as_or_and_ipat: [
-| "as" or_and_intropattern_loc
 | "as" equality_intropattern
+| "as" or_and_intropattern_loc
 |
 ]
 
@@ -2832,9 +2832,9 @@ ssriorpat: [
 ]
 
 ssrcpat: [
+| test_leftsquarebracket_equal test_nohidden "[" "=" ssriorpat "]"      (* SSR plugin *)
 | test_nohidden "[" hat "]"      (* SSR plugin *)
 | test_nohidden "[" ssriorpat "]"      (* SSR plugin *)
-| test_nohidden "[=" ssriorpat "]"      (* SSR plugin *)
 ]
 
 hat: [
@@ -3630,7 +3630,7 @@ G_LTAC2_or_and_intropattern: [
 G_LTAC2_equality_intropattern: [
 | "->"      (* ltac2 plugin *)
 | "<-"      (* ltac2 plugin *)
-| "[=" G_LTAC2_intropatterns "]"      (* ltac2 plugin *)
+| test_leftsquarebracket_equal "[" "=" G_LTAC2_intropatterns "]"      (* ltac2 plugin *)
 ]
 
 G_LTAC2_naming_intropattern: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1330,7 +1330,7 @@ ltac2_or_and_intropattern: [
 ltac2_equality_intropattern: [
 | "->"      (* ltac2 plugin *)
 | "<-"      (* ltac2 plugin *)
-| "[=" ltac2_intropatterns "]"      (* ltac2 plugin *)
+| "[=" ltac2_intropatterns "]"
 ]
 
 q_ident: [
@@ -1497,7 +1497,7 @@ ssriorpat: [
 ssrblockpat: [
 | "[" hat "]"      (* SSR plugin *)
 | "[" ssriorpat "]"      (* SSR plugin *)
-| "[=" ssriorpat "]"      (* SSR plugin *)
+| "[=" ssriorpat "]"
 ]
 
 ssrbinder: [

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -56,6 +56,12 @@ let test_lpar_idnum_coloneq =
     lk_kw "(" >> (lk_ident <+> lk_nat) >> lk_kw ":="
   end
 
+let test_leftsquarebracket_equal =
+  let open Pcoq.Lookahead in
+  to_entry "test_leftsquarebracket_equal" begin
+    lk_kw "[" >> lk_kw "=" >> check_no_space
+  end
+
 (* idem for (x:t) *)
 open Extraargs
 
@@ -292,7 +298,7 @@ GRAMMAR EXTEND Gram
   equality_intropattern:
     [ [ "->" -> { IntroRewrite true }
       | "<-" -> { IntroRewrite false }
-      | "[="; tc = intropatterns; "]" -> { IntroInjection tc } ] ]
+      | test_leftsquarebracket_equal; "["; "="; tc = intropatterns; "]" -> { IntroInjection tc } ] ]
   ;
   naming_intropattern:
     [ [ prefix = pattern_ident -> { IntroFresh prefix.CAst.v }
@@ -315,8 +321,8 @@ GRAMMAR EXTEND Gram
           CAst.make ~loc @@ List.fold_right f l pat } ] ]
   ;
   simple_intropattern_closed:
-    [ [ pat = or_and_intropattern   -> { CAst.make ~loc @@ IntroAction (IntroOrAndPattern pat) }
-      | pat = equality_intropattern -> { CAst.make ~loc @@ IntroAction pat }
+    [ [ pat = equality_intropattern -> { CAst.make ~loc @@ IntroAction pat }
+      | pat = or_and_intropattern   -> { CAst.make ~loc @@ IntroAction (IntroOrAndPattern pat) }
       | "_" -> { CAst.make ~loc @@ IntroAction IntroWildcard }
       | pat = naming_intropattern -> { CAst.make ~loc @@ IntroNaming pat } ] ]
   ;
@@ -466,12 +472,12 @@ GRAMMAR EXTEND Gram
       | locid = identref -> { ArgVar locid } ] ]
   ;
   as_or_and_ipat:
-    [ [ "as"; ipat = or_and_intropattern_loc -> { Some ipat }
-      | "as"; ipat = equality_intropattern ->
+    [ [ "as"; ipat = equality_intropattern ->
         { match ipat with
           | IntroRewrite _ -> user_err ~loc Pp.(str "Disjunctive/conjunctive pattern expected.")
           | IntroInjection _ -> user_err ~loc Pp.(strbrk "Found an injection pattern while a disjunctive/conjunctive pattern was expected; use " ++ str "\"injection as pattern\"" ++ strbrk " instead.")
           | _ -> assert false }
+      | "as"; ipat = or_and_intropattern_loc -> { Some ipat }
       | -> { None } ] ]
   ;
   eqn_ipat:

--- a/plugins/ltac2/g_ltac2.mlg
+++ b/plugins/ltac2/g_ltac2.mlg
@@ -89,6 +89,12 @@ let test_array_closing =
     lk_kw "|" >> lk_kw "]" >> check_no_space
   end
 
+let test_leftsquarebracket_equal =
+  let open Pcoq.Lookahead in
+  to_entry "test_leftsquarebracket_equal" begin
+    lk_kw "[" >> lk_kw "=" >> check_no_space
+  end
+
 let ltac2_expr = Tac2entries.Pltac.ltac2_expr
 let _ltac2_expr = ltac2_expr
 let ltac2_type = Entry.make "ltac2_type"
@@ -559,7 +565,7 @@ GRAMMAR EXTEND Gram
   equality_intropattern:
     [ [ "->" -> { CAst.make ~loc @@ QIntroRewrite true }
       | "<-" -> { CAst.make ~loc @@ QIntroRewrite false }
-      | "[="; tc = intropatterns; "]" -> { CAst.make ~loc @@ QIntroInjection tc } ] ]
+      | test_leftsquarebracket_equal; "["; "="; tc = intropatterns; "]" -> { CAst.make ~loc @@ QIntroInjection tc } ] ]
   ;
   naming_intropattern:
     [ [ LEFTQMARK; id = lident ->

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -830,6 +830,12 @@ END
 
 {
 
+let test_leftsquarebracket_equal =
+  let open Pcoq.Lookahead in
+  to_entry "test_leftsquarebracket_equal" begin
+    lk_kw "[" >> lk_kw "=" >> check_no_space
+  end
+
 let reject_ssrhid kwstate strm =
   match LStream.peek_nth kwstate 0 strm with
   | Tok.KEYWORD "[" ->
@@ -873,12 +879,12 @@ GRAMMAR EXTEND Gram
   | "^~"; n = natural -> { SuffixNum n }
   ]];
   ssrcpat: TOP [
-   [ test_nohidden; "["; hat_id = hat; "]" -> {
+   [ test_leftsquarebracket_equal; test_nohidden; "["; "="; iorpat = ssriorpat; "]" -> {
+      IPatInj iorpat }
+   | test_nohidden; "["; hat_id = hat; "]" -> {
       IPatCase (Block(hat_id)) }
    | test_nohidden; "["; iorpat = ssriorpat; "]" -> {
-      IPatCase (Regular iorpat) }
-   | test_nohidden; "[="; iorpat = ssriorpat; "]" -> {
-      IPatInj iorpat } ]];
+      IPatCase (Regular iorpat) } ]];
 END
 
 GRAMMAR EXTEND Gram

--- a/test-suite/bugs/bug_16785.v
+++ b/test-suite/bugs/bug_16785.v
@@ -1,0 +1,4 @@
+Reserved Notation "[ ==> a => b ]" (at level 0).
+Notation "[ ==> a => b ]" := (a /\ b) (only parsing).
+
+Check [==> True => True].

--- a/test-suite/output/PrintKeywords.out
+++ b/test-suite/output/PrintKeywords.out
@@ -57,7 +57,6 @@ Theorem
 Type
 Variable
 [
-[=
 \/
 ]
 ^


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #16785


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] ~Added **changelog**.~
- [ ] ~Added / updated **documentation**.~
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] ~Documented any new / changed **user messages**.~
  - [x] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [x] ~Opened **overlay** pull requests.~

#### Overlays

- IRIS: https://gitlab.mpi-sws.org/iris/iris/-/merge_requests/893 (merged)

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
