### PR TITLE
Update mod_delta in safe_typing.add_include

### DIFF
--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1243,13 +1243,13 @@ let add_include me is_module inl senv =
   let resolver, str = compute_sign sign resolver in
   let senv = update_resolver (Mod_subst.add_delta_resolver resolver) senv in
   let add senv ((l,elem) as field) =
-    let new_name = match elem with
+    let field, new_name = match elem with
       | SFBconst _ ->
-        C (Mod_subst.constant_of_delta_kn resolver (KerName.make mp_sup l))
+        field, C (Mod_subst.constant_of_delta_kn resolver (KerName.make mp_sup l))
       | SFBmind _ ->
-        I (Mod_subst.mind_of_delta_kn resolver (KerName.make mp_sup l))
-      | SFBmodule _ -> M
-      | SFBmodtype _ -> MT
+        field, I (Mod_subst.mind_of_delta_kn resolver (KerName.make mp_sup l))
+      | SFBmodule mb -> (l, SFBmodule {mb with mod_delta = Mod_subst.add_delta_resolver resolver mb.mod_delta}), M
+      | SFBmodtype _ -> (l, SFBmodtype {mb with mod_delta = Mod_subst.add_delta_resolver resolver mb.mod_delta}), MT
     in
     add_field field new_name senv
   in

--- a/test-suite/bugs/bug_16622.v
+++ b/test-suite/bugs/bug_16622.v
@@ -1,0 +1,15 @@
+Module Outer.
+  Module Simple.
+    Definition t := nat.
+  End Simple.
+  Module Contain.
+    Include Simple.
+  End Contain.
+  Module E.
+  End E.
+  Module Def := E.
+End Outer.
+
+Include Outer.
+Search Nat.add.
+(* Error: Anomaly "Uncaught exception Not_found." Please report at http://coq.inria.fr/bugs/. *)


### PR DESCRIPTION
Fix #16622

Without this we add (Contain.t, Outer.Contain.t) to the env but it should be (Contain.t, Outer.Simple.t).
