### PR TITLE
Make `About` print info about canonical names

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/16796-print-canon.rst
+++ b/doc/changelog/08-vernac-commands-and-options/16796-print-canon.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  :cmd:`About` now prints information when a constant or inductive is syntactically equal to another through module aliasing
+  (`#16796 <https://github.com/coq/coq/pull/16796>`_,
+  by Gaëtan Gilbert).

--- a/test-suite/output/PrintInfos.out
+++ b/test-suite/output/PrintInfos.out
@@ -94,3 +94,24 @@ Constant (let in) of the goal context.
 h:(n <> newdef n)
 
 Hypothesis of the goal context.
+Alias.eq : forall {A : Type}, A -> A -> Prop
+
+Alias.eq is not universe polymorphic
+Arguments Alias.eq {A}%type_scope x _
+Expands to: Inductive PrintInfos.Alias.eq (syntactically equal to
+Coq.Init.Logic.eq)
+Alias.eq_refl : forall {A : Type} {x : A}, x = x
+
+Alias.eq_refl is not universe polymorphic
+Arguments Alias.eq_refl {A}%type_scope {x}, [_] _
+Expands to: Constructor PrintInfos.Alias.eq_refl (syntactically equal to
+Coq.Init.Logic.eq_refl)
+Alias.eq_ind :
+forall [A : Type] (x : A) (P : A -> Prop), P x -> forall y : A, x = y -> P y
+
+Alias.eq_ind is not universe polymorphic
+Arguments Alias.eq_ind [A]%type_scope x P%function_scope f y e
+  (where some original arguments have been renamed)
+Alias.eq_ind is transparent
+Expands to: Constant PrintInfos.Alias.eq_ind (syntactically equal to
+Coq.Init.Logic.eq_ind)

--- a/test-suite/output/PrintInfos.v
+++ b/test-suite/output/PrintInfos.v
@@ -46,3 +46,9 @@ Goal forall n:nat, let g := newdef in n <> newdef n -> newdef n <> n -> False.
   About g.                              (* search hypothesis *)
   About h.                              (* search hypothesis *)
 Abort.
+
+Module Alias := Logic.
+
+About Alias.eq.
+About Alias.eq_refl.
+About Alias.eq_ind.

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -443,14 +443,23 @@ let locate_any_name qid =
     try String.Map.iter iter !locatable_map; Undefined qid
     with ObjFound obj -> obj
 
+let canonical_info ref =
+  let cref = canonical_gr ref in
+  if GlobRef.UserOrd.equal ref cref then mt ()
+  else match Nametab.path_of_global cref with
+    | path -> spc() ++ str "(syntactically equal to" ++ spc() ++ pr_path path ++ str ")"
+    | exception Not_found -> spc() ++ str "(missing canonical, bug?)"
+
 let pr_located_qualid = function
   | Term ref ->
       let ref_str = let open GlobRef in match ref with
           ConstRef _ -> "Constant"
         | IndRef _ -> "Inductive"
         | ConstructRef _ -> "Constructor"
-        | VarRef _ -> "Variable" in
-      str ref_str ++ spc () ++ pr_path (Nametab.path_of_global ref)
+        | VarRef _ -> "Variable"
+      in
+      let extra = canonical_info ref in
+      str ref_str ++ spc () ++ pr_path (Nametab.path_of_global ref) ++ extra
   | Abbreviation kn ->
       str "Notation" ++ spc () ++ pr_path (Nametab.path_of_abbreviation kn)
   | Dir dir ->


### PR DESCRIPTION
Without this AFAIK there is nothing indicating that an inductive is equal to its canonical.
