### PR TITLE
Update actions/checkout in GitHub workflows.

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macos-11
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -23,7 +23,7 @@ jobs:
           git config --global core.eol lf
 
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: System Information
         run: |


### PR DESCRIPTION
The `@v2` is using a deprecated Node.js version according to warnings from GitHub.

Noticed by @palmskog on unrelated projects.

FTR, the warning we get on master is: "Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2".