### PR TITLE
add Stalmarck plugin to CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -874,3 +874,6 @@ plugin:ci-vscoq:
 
 plugin:ci-smtcoq:
   extends: .ci-template
+
+plugin:ci-stalmarck:
+  extends: .ci-template

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -68,6 +68,7 @@ CI_TARGETS= \
     ci-sf \
     ci-simple_io \
     ci-smtcoq \
+    ci-stalmarck \
     ci-stdlib2 \
     ci-tlc \
     ci-unimath \

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -349,3 +349,8 @@ project serapi "https://github.com/ejgallego/coq-serapi" "main"
 # SMTCoq
 ########################################################################
 project smtcoq "https://github.com/smtcoq/smtcoq" "coq-master"
+
+########################################################################
+# Stalmarck
+########################################################################
+project stalmarck "https://github.com/coq-community/stalmarck" "master"

--- a/dev/ci/ci-stalmarck.sh
+++ b/dev/ci/ci-stalmarck.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+git_download stalmarck
+
+if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
+
+( cd "${CI_BUILD_DIR}/stalmarck"
+  make
+  make install
+
+  rm -f coq-stalmarck.opam # work around https://github.com/ocaml/dune/issues/4814
+  dune build @install -p coq-stalmarck-tactic
+  dune install -p coq-stalmarck-tactic --prefix="$CI_INSTALL_DIR"
+)


### PR DESCRIPTION
[Stalmarck](https://github.com/coq-community/stalmarck) is a verified tautology checker, formerly a Coq Contrib. It consists of a Coq library and a plugin with a tactic that uses code extracted from the library. The project is maintained by me as part of Coq-Community.

The CI script first builds and installs the library. Then, Dune extracts code and builds and installs the plugin. I tried to follow other Dune projects in CI like MathComp Word.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->

<!-- If this is a feature pull request / breaks compatibility: -->

<!-- If this breaks external libraries or plugins in CI: -->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
