### PR TITLE
Zify: use Typing to check universe sensitive applications

### DIFF
--- a/test-suite/bugs/bug_16803.v
+++ b/test-suite/bugs/bug_16803.v
@@ -1,0 +1,102 @@
+Require Import Lia.
+Require Import ZArith.
+Import ZifyClasses.
+
+Module Test1.
+
+  Record Z2@{u} : Type@{u} := MkZ2 { unZ2 : Z }.
+
+  Global Instance Inj_Z2_Z : InjTyp Z2 Z :=
+    { inj := unZ2
+    ; pred := fun _ => True
+    ; cstr := fun _ => I
+    }.
+  Add Zify InjTyp Inj_Z2_Z.
+
+  Lemma eq_Z2_inj :
+    forall (n m : Z2),
+      n = m <-> unZ2 n = unZ2 m.
+  Proof.
+  Admitted.
+
+  Global Instance Op_eq : BinRel (@eq Z2) :=
+    { TR := @eq Z
+    ; TRInj := eq_Z2_inj
+    }.
+  Add Zify BinRel Op_eq.
+
+  Theorem lia_refl_ex : forall (a b : Z2), a = a.
+  Proof.
+    lia.
+  Qed.
+
+  Fail Constraint mkrel.u0 < unZ2.u.
+
+End Test1.
+
+Module Test2.
+  (* we need a separate copy of Z2 to test a different case because
+     otherwise the constraint is set in one of the tests *)
+
+  Record Z2@{u} : Type@{u} := MkZ2 { unZ2 : Z }.
+
+  Global Instance Inj_Z2_Z : InjTyp Z2 Z :=
+    { inj := unZ2
+    ; pred := fun _ => True
+    ; cstr := fun _ => I
+    }.
+  Add Zify InjTyp Inj_Z2_Z.
+
+  Lemma eq_Z2_inj :
+    forall (n m : Z2),
+      n = m <-> unZ2 n = unZ2 m.
+  Proof.
+  Admitted.
+
+  Global Instance Op_eq : BinRel (@eq Z2) :=
+    { TR := @eq Z
+    ; TRInj := eq_Z2_inj
+    }.
+  Add Zify BinRel Op_eq.
+
+  Theorem lia_refl_ex : forall (a b : Z2), a = b -> True.
+  Proof.
+    zify.
+    exact I.
+  Qed.
+
+  Fail Constraint mkrel.u0 < unZ2.u.
+
+End Test2.
+
+Module Test3.
+
+  Record Z2@{u} : Type@{u} := MkZ2 { unZ2 : Z }.
+
+  Global Instance Inj_Z2_Z : InjTyp Z2 Z :=
+    { inj := unZ2
+    ; pred := fun _ => True
+    ; cstr := fun _ => I
+    }.
+  Add Zify InjTyp Inj_Z2_Z.
+
+  Lemma eq_Z2_inj :
+    forall (n m : Z2),
+      n = m <-> unZ2 n = unZ2 m.
+  Proof.
+  Admitted.
+
+  Global Instance Op_eq : BinRel (@eq Z2) :=
+    { TR := @eq Z
+    ; TRInj := eq_Z2_inj
+    }.
+  Add Zify BinRel Op_eq.
+
+  Constraint mkrel.u0 < unZ2.u.
+
+  Theorem lia_refl_ex : forall (a b : Z2), a = a.
+  Proof.
+    Fail lia.
+  Abort.
+
+End Test3.


### PR DESCRIPTION
Fix #16803, in which some universe constraints were missing.

AFAICT before d2c7022 Equality.general_rewrite would end up calling Typing on the `prf` (or maybe a sufficient subterm of it) which would avoid the bug.

Probably a more precise fix would be to check a prefix of the application when it's built in `trans_binrel` but since that would need more code changes to pass evar maps around let's try this fix first.

