### PR TITLE
Improve documentation of Disable Notation

### DIFF
--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -458,7 +458,8 @@ Enabling and disabling notations
 
    Enables or disables notations previously defined with
    :cmd:`Notation` or :cmd:`Notation (abbreviation)`.
-   It has no effect on notations reserved with :cmd:`Reserved Notation`.
+   Disabling a notation doesn't remove parsing rules or tokens defined by the notation.
+   The command has no effect on notations reserved with :cmd:`Reserved Notation`.
    At least one of
    :token:`string`, :token:`qualid`, :token:`one_term` or :token:`scope_name` must be
    provided.


### PR DESCRIPTION
Make explicit that this doesn't remove parsing rules.

This is a followup of https://github.com/coq/coq/pull/12324 after the discussion there starting at https://github.com/coq/coq/pull/12324#issuecomment-1313389990
