### PR TITLE
Do not nf-βι normalize case-related error messages in Type_errors.

### DIFF
--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -132,9 +132,6 @@ let whd_betaiota env t =
       end
     | _ -> whd_val (create_clos_infos betaiota env) (create_tab ()) (inject t)
 
-let nf_betaiota env t =
-  norm_term (create_clos_infos betaiota env) (create_tab ()) (Esubst.subs_id 0, Univ.Instance.empty) t
-
 let whd_betaiotazeta env x =
   match kind x with
   | (Sort _|Var _|Meta _|Evar _|Const _|Ind _|Construct _|

--- a/kernel/reduction.mli
+++ b/kernel/reduction.mli
@@ -21,7 +21,6 @@ val whd_all                 : env -> constr -> constr
 val whd_allnolet : env -> constr -> constr
 
 val whd_betaiota     : env -> constr -> constr
-val nf_betaiota      : env -> constr -> constr
 
 (***********************************************************************
   s conversion functions *)

--- a/kernel/type_errors.ml
+++ b/kernel/type_errors.ml
@@ -11,7 +11,6 @@
 open Names
 open Constr
 open Environ
-open Reduction
 open Univ
 
 (* Type errors. *)
@@ -93,9 +92,6 @@ type inductive_error =
 
 exception InductiveError of inductive_error
 
-let nfj env {uj_val=c;uj_type=ct} =
-  {uj_val=c;uj_type=nf_betaiota env ct}
-
 let error_unbound_rel env n =
   raise (TypeError (env, UnboundRel n))
 
@@ -118,11 +114,10 @@ let error_case_not_inductive env j =
   raise (TypeError (env, CaseNotInductive j))
 
 let error_number_branches env cj expn =
-  raise (TypeError (env, NumberBranches (nfj env cj,expn)))
+  raise (TypeError (env, NumberBranches (cj, expn)))
 
 let error_ill_formed_branch env c i actty expty =
-  raise (TypeError (env,
-    IllFormedBranch (c,i,nf_betaiota env actty, nf_betaiota env expty)))
+  raise (TypeError (env, IllFormedBranch (c, i, actty, expty)))
 
 let error_generalization env nvar c =
   raise (TypeError (env, Generalization (nvar,c)))


### PR DESCRIPTION
This was the only place in the kernel where the strong normal form functions were used. Furthermore, there are various reasons why it shouldn't be done. First, this is redundant, it is already performed by the printer. Second, the EConstr equivalents in Pretype_error do not perform this reduction. Finally, since the change of case representation there is no point in trying to mangle the branches to produce something that looks like what the user wrote.