### PR TITLE
Extend the -async-proofs-tac-j option to accept the value 0.

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/16837-async-option-deactivate-par-altogether.rst
+++ b/doc/changelog/08-vernac-commands-and-options/16837-async-option-deactivate-par-altogether.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  The -async-proofs-tac-j command line option now accepts
+  the argument 0, which makes `par` block interpreted
+  without spawning any new process
+  (`#16837 <https://github.com/coq/coq/pull/16837>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/proof-engine/ltac.rst
+++ b/doc/sphinx/proof-engine/ltac.rst
@@ -366,6 +366,9 @@ behavior.)
       Applies :n:`@ltac_expr` to all focused goals in parallel.
       The number of workers can be controlled via the command line option
       :n:`-async-proofs-tac-j @natural` to specify the desired number of workers.
+      In the special case where :n:`@natural` is 0, this completely prevents
+      Coq from spawning any new process, and `par` blocks are treated as a
+      variant of `all` that additionally checks that each subgoal is solved.
       Limitations: ``par:`` only works on goals that don't contain existential
       variables.  :n:`@ltac_expr` must either solve the goal completely or do
       nothing (i.e. it cannot make some progress).

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -2354,7 +2354,8 @@ let init_process stm_flags =
 
 let init_core () =
   if !cur_opt.async_proofs_mode = APon then Control.enable_thread_delay := true;
-  if !Flags.async_proofs_worker_id = "master" then Partac.enable_par ~nworkers:!cur_opt.async_proofs_n_tacworkers;
+  if !Flags.async_proofs_worker_id = "master" && !cur_opt.async_proofs_n_tacworkers > 0 then
+    Partac.enable_par ~nworkers:!cur_opt.async_proofs_n_tacworkers;
   State.register_root_state ()
 
 

--- a/stm/stmargs.ml
+++ b/stm/stmargs.ml
@@ -76,8 +76,8 @@ let parse_args ~init arglist : Stm.AsyncOpts.stm_opt * string list =
 
     |"-async-proofs-tac-j" ->
       let j = Coqargs.get_int ~opt (next ()) in
-      if j <= 0 then begin
-        Coqargs.error_wrong_arg ("Error: -async-proofs-tac-j only accepts values greater than or equal to 1")
+      if j < 0 then begin
+        Coqargs.error_wrong_arg ("Error: -async-proofs-tac-j only accepts values greater than or equal to 0")
       end;
       { oval with
         Stm.AsyncOpts.async_proofs_n_tacworkers = j


### PR DESCRIPTION
When this option is passed the integer 0, it now replaces the par: selector with an equivalent combinator that does not spawn any new process and behaves as all: solve [tac] instead. This is different from when passed the integer 1, which means that a process is still spawned although it doesn't parallelize anything.

This provides a non-hacky way to implement #16801.