### PR TITLE
Bump version number to 8.18 and add compat infrastructure.

### DIFF
--- a/doc/stdlib/index-list.html.template
+++ b/doc/stdlib/index-list.html.template
@@ -713,6 +713,7 @@ through the <tt>Require Import</tt> command.</p>
     theories/Compat/Coq815.v
     theories/Compat/Coq816.v
     theories/Compat/Coq817.v
+    theories/Compat/Coq818.v
   </dd>
 
   <dt> <b>Array</b>:

--- a/sysinit/coqargs.ml
+++ b/sysinit/coqargs.ml
@@ -221,6 +221,7 @@ let set_option = let open Goptions in function
   | opt, OptionAppend v -> set_string_option_append_value_gen ~locality:OptLocal opt v
 
 let get_compat_file = function
+  | "8.18" -> "Coq.Compat.Coq818"
   | "8.17" -> "Coq.Compat.Coq817"
   | "8.16" -> "Coq.Compat.Coq816"
   | "8.15" -> "Coq.Compat.Coq815"

--- a/test-suite/success/CompatCurrentFlag.v
+++ b/test-suite/success/CompatCurrentFlag.v
@@ -1,3 +1,3 @@
-(* -*- coq-prog-args: ("-compat" "8.17") -*- *)
+(* -*- coq-prog-args: ("-compat" "8.18") -*- *)
 (** Check that the current compatibility flag actually requires the relevant modules. *)
-Import Coq.Compat.Coq817.
+Import Coq.Compat.Coq818.

--- a/test-suite/success/CompatOldFlag.v
+++ b/test-suite/success/CompatOldFlag.v
@@ -1,5 +1,5 @@
-(* -*- coq-prog-args: ("-compat" "8.15") -*- *)
+(* -*- coq-prog-args: ("-compat" "8.16") -*- *)
 (** Check that the current-minus-two compatibility flag actually requires the relevant modules. *)
+Import Coq.Compat.Coq818.
 Import Coq.Compat.Coq817.
 Import Coq.Compat.Coq816.
-Import Coq.Compat.Coq815.

--- a/test-suite/success/CompatOldOldFlag.v
+++ b/test-suite/success/CompatOldOldFlag.v
@@ -1,0 +1,6 @@
+(* -*- coq-prog-args: ("-compat" "8.15") -*- *)
+(** Check that the current-minus-three compatibility flag actually requires the relevant modules. *)
+Import Coq.Compat.Coq818.
+Import Coq.Compat.Coq817.
+Import Coq.Compat.Coq816.
+Import Coq.Compat.Coq815.

--- a/test-suite/success/CompatPreviousFlag.v
+++ b/test-suite/success/CompatPreviousFlag.v
@@ -1,4 +1,4 @@
-(* -*- coq-prog-args: ("-compat" "8.16") -*- *)
+(* -*- coq-prog-args: ("-compat" "8.17") -*- *)
 (** Check that the current-minus-one compatibility flag actually requires the relevant modules. *)
+Import Coq.Compat.Coq818.
 Import Coq.Compat.Coq817.
-Import Coq.Compat.Coq816.

--- a/test-suite/tools/update-compat/run.sh
+++ b/test-suite/tools/update-compat/run.sh
@@ -6,4 +6,4 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 # we assume that the script lives in test-suite/tools/update-compat/,
 # and that update-compat.py lives in dev/tools/
 cd "${SCRIPT_DIR}/../../.."
-dev/tools/update-compat.py --assert-unchanged --release || exit $?
+dev/tools/update-compat.py --assert-unchanged --master || exit $?

--- a/theories/Compat/Coq818.v
+++ b/theories/Compat/Coq818.v
@@ -8,6 +8,4 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(** Compatibility file for making Coq act similar to Coq v8.17 *)
-
-Require Export Coq.Compat.Coq818.
+(** Compatibility file for making Coq act similar to Coq v8.18 *)

--- a/tools/configure/configure.ml
+++ b/tools/configure/configure.ml
@@ -22,8 +22,8 @@ open CmdArgs.Prefs
 
 let (/) = Filename.concat
 
-let coq_version = "8.17+alpha"
-let vo_magic = 81699
+let coq_version = "8.18+alpha"
+let vo_magic = 81799
 let is_a_released_version = false
 
 (** Default OCaml binaries *)


### PR DESCRIPTION
Part of the commit was auto-generated by running `dev/tools/update-compat.py --master`.
Can I get an assignee so that this is merged quickly when CI passes?