### PR TITLE
Remove progress_evars.

### DIFF
--- a/doc/changelog/04-tactics/16843-remove-progress-evars.rst
+++ b/doc/changelog/04-tactics/16843-remove-progress-evars.rst
@@ -1,0 +1,4 @@
+- **Removed:**
+  the undocumented `progress_evars` tactical
+  (`#16843 <https://github.com/coq/coq/pull/16842>`_,
+  by Théo Zimmermann).

--- a/doc/sphinx/proof-engine/ltac.rst
+++ b/doc/sphinx/proof-engine/ltac.rst
@@ -817,9 +817,6 @@ We can check if a tactic made progress with:
    .. exn:: Failed to progress.
       :undocumented:
 
-.. tacn:: progress_evars @ltac_expr
-   :undocumented:
-
 Success and failure
 -------------------
 

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1724,7 +1724,6 @@ simple_tactic: [
 | "not_evar" constr
 | "is_ground" constr
 | "autoapply" constr "with" preident
-| "progress_evars" tactic
 | "decide" "equality"
 | "compare" constr constr
 | "rewrite_strat" rewstrategy "in" hyp

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1761,7 +1761,6 @@ simple_tactic: [
 | "not_evar" one_term
 | "is_ground" one_term
 | "autoapply" one_term "with" ident
-| "progress_evars" ltac_expr
 | "rewrite_strat" rewstrategy OPT ( "in" ident )
 | "rewrite_db" ident OPT ( "in" ident )
 | "substitute" OPT [ "->" | "<-" ] one_term_with_bindings

--- a/plugins/ltac/g_class.mlg
+++ b/plugins/ltac/g_class.mlg
@@ -12,7 +12,6 @@
 
 open Class_tactics
 open Stdarg
-open Tacarg
 open Classes
 
 }
@@ -112,39 +111,4 @@ END
 
 TACTIC EXTEND autoapply
 | [ "autoapply" constr(c) "with" preident(i) ] -> { autoapply c i }
-END
-
-{
-
-(** TODO: DEPRECATE *)
-(* A progress test that allows to see if the evars have changed *)
-open Constr
-open Proofview.Notations
-
-let rec eq_constr_mod_evars sigma x y =
-  let open EConstr in
-  match EConstr.kind sigma x, EConstr.kind sigma y with
-  | Evar (e1, l1), Evar (e2, l2) when not (Evar.equal e1 e2) -> true
-  | _, _ -> compare_constr sigma (fun x y -> eq_constr_mod_evars sigma x y) x y
-
-let progress_evars t =
-  Proofview.Goal.enter begin fun gl ->
-    let concl = Proofview.Goal.concl gl in
-    let check =
-      Proofview.Goal.enter begin fun gl' ->
-        let sigma = Tacmach.project gl' in
-        let newconcl = Proofview.Goal.concl gl' in
-        if eq_constr_mod_evars sigma concl newconcl
-        then
-          let info = Exninfo.reify () in
-          Tacticals.tclFAIL ~info (Pp.str"No progress made (modulo evars)")
-        else Proofview.tclUNIT ()
-      end
-    in t <*> check
-  end
-
-}
-
-TACTIC EXTEND progress_evars
-| [ "progress_evars" tactic(t) ] -> { progress_evars (Tacinterp.tactic_of_value ist t) }
 END


### PR DESCRIPTION
The tactic was not documented in Coq 8.16 and the code says TODO deprecate. Instead of deprecating, I attempt to remove directly.

- [x] Added **changelog**.
- [x] Added / updated **documentation**.