### PR TITLE
Fix #16831: Inconsistency with vm_compute/native_compute and cofix.

### DIFF
--- a/dev/doc/critical-bugs
+++ b/dev/doc/critical-bugs
@@ -396,6 +396,16 @@ Conversion machines
   GH issue number: #16645
   risk: systematic
 
+  component: "virtual" and "native" conversion machines
+  summary: η-expansion of cofixpoints was performed in the wrong environment
+  introduced: V8.9
+  impacted released versions: V8.9-V8.16.0
+  impacted coqchk versions: none (no VM / native computation in coqchk)
+  fixed in: 8.16.1
+  found by: Gaëtan Gilbert and Pierre-Marie Pédrot
+  GH issue number: #16831
+  risk: low, as it requires carefully crafted cofixpoints
+
 Side-effects
 
   component: side-effects

--- a/doc/changelog/01-kernel/16845-fix-16831.rst
+++ b/doc/changelog/01-kernel/16845-fix-16831.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Pass the correct environment to compute η-expansion of cofixpoints
+  in VM and native compilation
+  (`#16845 <https://github.com/coq/coq/pull/16845>`_,
+  fixes `#16831 <https://github.com/coq/coq/issues/16831>`_,
+  by Pierre-Marie Pédrot).

--- a/kernel/genlambda.ml
+++ b/kernel/genlambda.ml
@@ -683,9 +683,10 @@ let rec lambda_of_constr cache env sigma c =
       Lfix((pos, inds, i), (names, ltypes, lbodies))
 
   | CoFix(init,(names,type_bodies,rec_bodies)) ->
-      let rec_bodies = Array.map2 (Reduction.eta_expand env) rec_bodies type_bodies in
       let ltypes = lambda_of_args cache env sigma 0 type_bodies in
       let env = Environ.push_rec_types (names, type_bodies, rec_bodies) env in
+      let map c ty = Reduction.eta_expand env c (Vars.lift (Array.length type_bodies) ty) in
+      let rec_bodies = Array.map2 map rec_bodies type_bodies in
       let lbodies = lambda_of_args cache env sigma 0 rec_bodies in
       Lcofix(init, (names, ltypes, lbodies))
 

--- a/test-suite/bugs/bug_16831.v
+++ b/test-suite/bugs/bug_16831.v
@@ -1,0 +1,16 @@
+Set Primitive Projections.
+CoInductive Foo := B { p : bool }.
+
+Definition f (x:=B false) (y:Foo) : Foo := cofix f := y.
+
+Definition v := (f (B true)).(p).
+
+Lemma v_true : v = true.
+Proof. reflexivity. Qed.
+
+(* bad! *)
+Lemma v_false : v = false.
+Proof. vm_compute. Fail reflexivity. Abort.
+
+Lemma v_false : v = false.
+Proof. native_compute. Fail reflexivity. Abort.


### PR DESCRIPTION
We pass the correct environment to the function performing eta-expansion of cofix bodies.

Fixes / closes #16831

- [X] Added / updated **test-suite**.
- [x] Added **changelog**.
- [x] Added / updated **documentation**.