### PR TITLE
Fix representation of empty arrays (fix #16832).

### DIFF
--- a/kernel/byterun/coq_interp.c
+++ b/kernel/byterun/coq_interp.c
@@ -925,10 +925,14 @@ value coq_interprete
         mlsize_t i;
         value block;
         print_instr("MAKEBLOCK, tag=");
-        Coq_alloc_small(block, wosize, tag);
-        Field(block, 0) = accu;
-        for (i = 1; i < wosize; i++) Field(block, i) = *sp++;
-        accu = block;
+        if (wosize == 0) {
+          accu = Atom(tag);
+        } else {
+          Coq_alloc_small(block, wosize, tag);
+          Field(block, 0) = accu;
+          for (i = 1; i < wosize; i++) Field(block, i) = *sp++;
+          accu = block;
+        }
         Next;
       }
       Instruct(MAKEBLOCK1) {

--- a/kernel/vmbytegen.ml
+++ b/kernel/vmbytegen.ml
@@ -756,7 +756,8 @@ let rec compile_lam env cenv lam sz cont =
   | Lmakeblock (_, tag, args) ->
     let arity = Array.length args in
     let cont = code_makeblock ~stack_size:(sz+arity-1) ~arity ~tag cont in
-    comp_args (compile_lam env) cenv args sz cont
+    if Int.equal arity 0 then cont
+    else comp_args (compile_lam env) cenv args sz cont
 
   | Lparray (args, def) ->
     (* Hack: brutally pierce through the abstraction of PArray *)

--- a/kernel/vmemitcodes.ml
+++ b/kernel/vmemitcodes.ml
@@ -335,8 +335,7 @@ let emit_instr env = function
   | Kconst c ->
       out env opGETGLOBAL; slot_for_const env c
   | Kmakeblock(n, t) ->
-      if Int.equal n 0 then invalid_arg "emit_instr : block size = 0"
-      else if n < 4 then (out env(opMAKEBLOCK1 + n - 1); out_int env t)
+      if 0 < n && n < 4 then (out env(opMAKEBLOCK1 + n - 1); out_int env t)
       else (out env opMAKEBLOCK; out_int env n; out_int env t)
   | Kmakeswitchblock(typlbl,swlbl,annot,sz) ->
       out env opMAKESWITCHBLOCK;


### PR DESCRIPTION
Since there are no arguments, `Vmbytegen.comp_args` cannot be called in that case, so we just skip it.

The `MAKEBLOCK` opcode needs to be adapted accordingly, since size-0 blocks have a special representation in OCaml.

Remark: OCaml's bytecode interpreter uses special opcodes `ATOM`, `PUSHATOM`, `ATOM0`, and `PUSHATOM0`, for that purpose; but that seems excessive in the case of Coq.

Fixes / closes #16832