### PR TITLE
Revert "Remove probably unused catch of Not_found in search"

### DIFF
--- a/vernac/search.ml
+++ b/vernac/search.ml
@@ -86,8 +86,13 @@ let generic_search env (fn : GlobRef.t -> Decls.logical_kind option -> env -> co
   in
   List.iter iter_var (Environ.named_context env);
   let globals = Environ.Globals.view env.env_globals in
-  Cmap_env.iter iter_constant globals.constants;
-  Mindmap_env.iter iter_inductive globals.inductives
+  try
+    Cmap_env.iter iter_constant globals.constants;
+    Mindmap_env.iter iter_inductive globals.inductives
+  with Not_found ->
+    (* Not sure what is supposed to raise Not_found, TODO try removing
+       this catch and add comment if actually needed *)
+    ()
 
 (** This module defines a preference on constrs in the form of a
     [compare] function (preferred constr must be big for this


### PR DESCRIPTION
This reverts commit 5d74070bd3bb4183f6f41f04a04329dc393307ba.

Could this be the fiat-crypto Not_found?
