### PR TITLE
Rename nonterminals in mlgs to be consistent with those used in documentation

### DIFF
--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -1641,8 +1641,8 @@ Here is the syntax for the :n:`q_*` nonterminals:
    ltac2_clause ::= in @ltac2_in_clause
    | at @ltac2_occs_nums
    ltac2_in_clause ::= * {? @ltac2_occs }
-   | * %|- {? @ltac2_concl_occ }
-   | {*, @ltac2_hypident_occ } {? %|- {? @ltac2_concl_occ } }
+   | * %|- {? @ltac2_concl_occs }
+   | {*, @ltac2_hyp_occs } {? %|- {? @ltac2_concl_occs } }
 
 .. insertprodn q_occurrences ltac2_hypident
 
@@ -1650,8 +1650,8 @@ Here is the syntax for the :n:`q_*` nonterminals:
    q_occurrences ::= {? @ltac2_occs }
    ltac2_occs ::= at @ltac2_occs_nums
    ltac2_occs_nums ::= {? - } {+ {| @natural | $ @ident } }
-   ltac2_concl_occ ::= * {? @ltac2_occs }
-   ltac2_hypident_occ ::= @ltac2_hypident {? @ltac2_occs }
+   ltac2_concl_occs ::= * {? @ltac2_occs }
+   ltac2_hyp_occs ::= @ltac2_hypident {? @ltac2_occs }
    ltac2_hypident ::= @ident_or_anti
    | ( type of @ident_or_anti )
    | ( value of @ident_or_anti )

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -348,24 +348,6 @@ IDENT: [
 | ident
 ]
 
-scope_key: [
-| IDENT
-]
-
-scope_name: [
-| IDENT
-]
-
-scope: [
-| scope_name
-| scope_key
-]
-
-scope_delimiter: [
-| REPLACE "%" IDENT
-| WITH "%" scope
-]
-
 term100: [
 | REPLACE term99 "<:" term200
 | WITH term99 "<:" type
@@ -539,11 +521,6 @@ pattern10: [
 | REPLACE pattern1 LIST1 pattern1
 | WITH pattern1 LIST0 pattern1
 | DELETE pattern1
-]
-
-pattern1: [
-| REPLACE pattern0 "%" IDENT
-| WITH pattern0 "%" scope_key
 ]
 
 pattern0: [
@@ -1282,10 +1259,6 @@ bar_cbrace: [
 ]
 
 printable: [
-| REPLACE "Scope" IDENT
-| WITH "Scope" scope_name
-| REPLACE "Visibility" OPT IDENT
-| WITH "Visibility" OPT scope_name
 | REPLACE [ "Sorted" | ] "Universes" OPT printunivs_subgraph OPT ne_string
 | WITH OPT "Sorted" "Universes" OPT printunivs_subgraph OPT ne_string
 | DELETE "Term" smart_global OPT univ_name_list  (* readded in commands *)
@@ -1437,9 +1410,6 @@ command: [
 | REPLACE "Print" smart_global OPT univ_name_list
 | WITH "Print" OPT "Term" smart_global OPT univ_name_list
 
-| REPLACE "Declare" "Scope" IDENT
-| WITH "Declare" "Scope" scope_name
-
 (* odd that these are in command while other notation-related ones are in syntax *)
 | REPLACE "Number" "Notation" reference reference reference OPT number_options ":" preident
 | WITH "Number" "Notation" reference reference reference OPT number_options ":" scope_name
@@ -1471,24 +1441,6 @@ command: [
 | "Show" "Zify" show_zify  TAG Micromega
 | REPLACE "Goal" lconstr
 | WITH "Goal" type
-]
-
-syntax: [
-| REPLACE "Open" "Scope" IDENT
-| WITH "Open" "Scope" scope
-| REPLACE "Close" "Scope" IDENT
-| WITH "Close" "Scope" scope
-| REPLACE "Delimit" "Scope" IDENT; "with" IDENT
-| WITH "Delimit" "Scope" scope_name; "with" scope_key
-| REPLACE "Undelimit" "Scope" IDENT
-| WITH "Undelimit" "Scope" scope_name
-| REPLACE "Bind" "Scope" IDENT; "with" LIST1 coercion_class
-| WITH "Bind" "Scope" scope_name; "with" LIST1 coercion_class
-]
-
-opt_scope: [
-| REPLACE ":" IDENT
-| WITH    ":" scope_name
 ]
 
 syntax_modifier: [
@@ -1781,16 +1733,6 @@ search_item: [
 | REPLACE search_where ":" constr_pattern
 | WITH OPT ( search_where ":" ) constr_pattern
 | DELETE constr_pattern
-]
-
-by_notation: [
-| REPLACE ne_string OPT [ "%" IDENT ]
-| WITH ne_string OPT [ "%" scope_key ]
-]
-
-notation_declaration: [
-| REPLACE lstring ":=" constr syntax_modifiers OPT [ ":" IDENT ]
-| WITH lstring ":=" constr syntax_modifiers OPT [ ":" scope_name ]
 ]
 
 ltac_production_item: [

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -135,6 +135,10 @@ RENAME: [
 | Constr.closed_binder closed_binder
 ]
 
+RENAME: [
+| type_ type  (* since "type" is an OCaml keyword *)
+]
+
 (* written in OCaml *)
 impl_ident_head: [
 | "{" ident
@@ -266,10 +270,6 @@ case_item: [
 | WITH term100 OPT ("as" name) OPT [ "in" pattern200 ]
 ]
 
-type: [
-| term200
-]
-
 one_type: [
 | constr
 ]
@@ -349,18 +349,12 @@ IDENT: [
 ]
 
 term100: [
-| REPLACE term99 "<:" term200
-| WITH term99 "<:" type
-| MOVETO term_cast term99 "<:" type
-| REPLACE term99 "<<:" term200
-| WITH term99 "<<:" type
-| MOVETO term_cast term99 "<<:" type
-| REPLACE term99 ":>" term200
-| WITH term99 ":>" type
-| MOVETO term_cast term99 ":>" type
-| REPLACE term99 ":" term200
-| WITH term99 ":" type
-| MOVETO term_cast term99 ":" type
+| MOVEALLBUT term_cast
+| term99
+]
+
+term100: [
+| term_cast
 ]
 
 constr: [
@@ -444,7 +438,7 @@ binder: [
 ]
 
 open_binders: [
-| REPLACE name LIST0 name ":" lconstr
+| REPLACE name LIST0 name ":" type
 | WITH LIST1 name ":" type
 (* @Zimmi48: Special token .. is for use in the Notation command. (see bug_3304.v) *)
 | DELETE name ".." name
@@ -456,7 +450,7 @@ open_binders: [
 closed_binder: [
 | name
 
-| REPLACE "(" name LIST1 name ":" lconstr ")"
+| REPLACE "(" name LIST1 name ":" type ")"
 | WITH "(" LIST1 name ":" type ")"
 | DELETE "(" name ":" lconstr ")"
 
@@ -562,8 +556,6 @@ variant_definition: [
 ]
 
 gallina: [
-| REPLACE thm_token ident_decl binders ":" lconstr LIST0 [ "with" ident_decl binders ":" lconstr ]
-| WITH thm_token ident_decl binders ":" type LIST0 [ "with" ident_decl binders ":" type ]
 | DELETE assumptions_token inline assum_list
 | REPLACE inductive_token LIST1 inductive_or_record_definition SEP "with"
 | WITH "Inductive" inductive_definition LIST0 ( "with" inductive_definition )
@@ -653,9 +645,9 @@ of_type_inst: [
 
 def_body: [
 | DELETE binders ":=" reduce lconstr
-| REPLACE binders ":" lconstr ":=" reduce lconstr
+| REPLACE binders ":" type ":=" reduce lconstr
 | WITH LIST0 binder OPT (":" type) ":=" reduce lconstr
-| REPLACE binders ":" lconstr
+| REPLACE binders ":" type
 | WITH LIST0 binder ":" type
 ]
 
@@ -731,8 +723,8 @@ gallina_ext: [
 | DELETE "Export" "Set" setting_name option_setting
 | REPLACE "Export" "Unset" setting_name
 | WITH "Unset" setting_name
-| REPLACE "Instance" instance_name ":" term200 hint_info [ ":=" "{" record_declaration "}" | ":=" lconstr | ]
-| WITH "Instance" instance_name ":" type hint_info OPT [ ":=" "{" record_declaration "}" | ":=" lconstr ]
+| REPLACE "Instance" instance_name ":" type hint_info     [ ":=" "{" record_declaration "}" | ":=" lconstr | ]
+| WITH    "Instance" instance_name ":" type hint_info OPT [ ":=" "{" record_declaration "}" | ":=" lconstr ]
 
 | DELETE "Require" export_token LIST1 filtered_import
 | REPLACE "From" global "Require" export_token LIST1 filtered_import
@@ -963,12 +955,8 @@ simple_occurrences: [
 ]
 
 simple_tactic: [
-| REPLACE "assert" "(" identref ":" lconstr ")" by_tactic
-| WITH "assert" "(" identref ":" type ")" by_tactic
 | REPLACE "assert" constr as_ipat by_tactic
 | WITH "assert" one_type as_ipat by_tactic
-| REPLACE "eassert" "(" identref ":" lconstr ")" by_tactic
-| WITH "eassert" "(" identref ":" type ")" by_tactic
 | REPLACE "eassert" constr as_ipat by_tactic
 | WITH "eassert" one_type as_ipat by_tactic
 | REPLACE "elimtype" constr
@@ -981,12 +969,8 @@ simple_tactic: [
 | WITH "absurd" one_type
 | REPLACE "casetype" constr
 | WITH "casetype" one_type
-| REPLACE "enough" "(" identref ":" lconstr ")" by_tactic
-| WITH "enough" "(" identref ":" type ")" by_tactic
 | REPLACE "enough" constr as_ipat by_tactic
 | WITH "enough" one_type as_ipat by_tactic
-| REPLACE "eenough" "(" identref ":" lconstr ")" by_tactic
-| WITH "eenough" "(" identref ":" type ")" by_tactic
 | REPLACE "eenough" constr as_ipat by_tactic
 | WITH "eenough" one_type as_ipat by_tactic
 | DELETE "autorewrite" "with" LIST1 preident clause
@@ -1046,7 +1030,7 @@ simple_tactic: [
 | REPLACE "generalize" constr occs as_name LIST0 [ "," pattern_occs as_name ]
 | WITH "generalize" LIST1 [ pattern_occs as_name ] SEP ","
 | REPLACE "evar" "(" ident ":" lconstr ")"
-| WITH "evar" "(" ident ":" type ")"
+| WITH    "evar" "(" ident ":" type ")"
 | EDIT "simplify_eq" ADD_OPT destruction_arg
 | EDIT "esimplify_eq" ADD_OPT destruction_arg
 | EDIT "discriminate" ADD_OPT destruction_arg
@@ -1439,8 +1423,6 @@ command: [
 | DELETE "Show" "Zify" "BinOpSpec"      (* micromega plugin *)
 (* keep this one | "Show" "Zify" "Spec"      (* micromega plugin *)*)
 | "Show" "Zify" show_zify  TAG Micromega
-| REPLACE "Goal" lconstr
-| WITH "Goal" type
 ]
 
 syntax_modifier: [
@@ -1534,11 +1516,6 @@ fix_definition: [
 cofix_definition: [
 | REPLACE ident_decl binders type_cstr OPT [ ":=" lconstr ] decl_notations
 | WITH ident_decl binders type_cstr OPT [ ":=" lconstr ] decl_notations
-]
-
-type_cstr: [
-| REPLACE ":" lconstr
-| WITH ":" type
 ]
 
 (* note that constructor -> identref constructor_type *)
@@ -1650,7 +1627,7 @@ fields_def: [ | DELETENT ]
 
 constr_body: [
 | DELETE ":=" lconstr
-| REPLACE ":" lconstr ":=" lconstr
+| REPLACE ":" type ":=" lconstr
 | WITH OPT ( ":" type ) ":=" lconstr
 ]
 
@@ -1658,11 +1635,6 @@ scheme: [
 | DELETE scheme_kind
 | REPLACE identref ":=" scheme_kind
 | WITH OPT ( identref ":=" ) scheme_kind
-]
-
-simple_reserv: [
-| REPLACE LIST1 identref ":" lconstr
-| WITH LIST1 identref ":" type
 ]
 
 in_clause: [
@@ -2181,16 +2153,6 @@ opt_clause: [
 | DELETE "at" occs_nums
 | DELETE
 | clause_dft_concl
-]
-
-fixdecl: [
-| REPLACE "(" ident LIST0 simple_binder struct_annot ":" lconstr ")"
-| WITH "(" ident LIST0 simple_binder struct_annot ":" type ")"
-]
-
-cofixdecl: [
-| REPLACE "(" ident LIST0 simple_binder ":" lconstr ")"
-| WITH "(" ident LIST0 simple_binder ":" type ")"
 ]
 
 ssrfwdview: [

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -2202,15 +2202,15 @@ ltac2_induction_clause: [
 | WITH ltac2_destruction_arg ltac2_as_or_and_ipat ltac2_eqn_ipat OPT ltac2_clause  TAG Ltac2
 ]
 
-starredidentref: [
+starred_ident_ref: [
 | EDIT identref ADD_OPT "*"
 | EDIT "Type" ADD_OPT "*"
 | "All"
 ]
 
 ssexpr0: [
-| DELETE "(" LIST0 starredidentref ")"
-| DELETE "(" LIST0 starredidentref ")" "*"
+| DELETE "(" LIST0 starred_ident_ref ")"
+| DELETE "(" LIST0 starred_ident_ref ")" "*"
 | DELETE "(" ssexpr35 ")"
 | DELETE "(" ssexpr35 ")" "*"
 | "(" section_subset_expr ")" OPT "*"
@@ -2882,7 +2882,6 @@ RENAME: [
 | Pltac.tactic ltac_expr  (* many uses in EXTENDs *)
 | ltac2_type5 ltac2_type
 | ltac2_expr6 ltac2_expr
-| starredidentref starred_ident_ref
 | ssrocc ssr_occurrences
 | ssrsimpl_ne s_item
 | ssrclear_ne ssrclear

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -2206,16 +2206,16 @@ starred_ident_ref: [
 | "All"
 ]
 
-ssexpr0: [
+section_var_expr0: [
 | DELETE "(" LIST0 starred_ident_ref ")"
 | DELETE "(" LIST0 starred_ident_ref ")" "*"
-| DELETE "(" ssexpr35 ")"
-| DELETE "(" ssexpr35 ")" "*"
+| DELETE "(" section_var_expr35 ")"
+| DELETE "(" section_var_expr35 ")" "*"
 | "(" section_subset_expr ")" OPT "*"
 ]
 
-ssexpr35: [
-| EDIT ADD_OPT "-" ssexpr50
+section_var_expr35: [
+| EDIT ADD_OPT "-" section_var_expr50
 ]
 
 simple_binding: [
@@ -2815,7 +2815,7 @@ SPLICE: [
 | with_names
 | eauto_search_strategy_name
 | simple_binding
-| ssexpr35 (* strange in mlg, ssexpr50 is after this *)
+| section_var_expr35 (* strange in mlg, section_var_expr50 is after this *)
 | number_string_mapping
 | number_options
 | string_option
@@ -2866,8 +2866,6 @@ RENAME: [
 | term200 term
 | pattern100 pattern
 (*| impl_ident_tail impl_ident*)
-| ssexpr50 section_var_expr50
-| ssexpr0 section_var_expr0
 | section_subset_expr section_var_expr
 | fun_scheme_arg func_scheme_def
 

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -62,8 +62,8 @@ SPLICE: [
 ]
 
 RENAME: [
-| G_LTAC2_delta_flag ltac2_delta_reductions
-| G_LTAC2_strategy_flag ltac2_reductions
+| G_LTAC2_delta_reductions ltac2_delta_reductions
+| G_LTAC2_reductions ltac2_reductions
 | G_LTAC2_binder ltac2_binder
 | G_LTAC2_branches ltac2_branches
 | G_LTAC2_let_clause ltac2_let_clause
@@ -85,8 +85,8 @@ RENAME: [
 | G_LTAC2_in_clause ltac2_in_clause
 | G_LTAC2_occs ltac2_occs
 | G_LTAC2_occs_nums ltac2_occs_nums
-| G_LTAC2_concl_occ ltac2_concl_occ
-| G_LTAC2_hypident_occ ltac2_hypident_occ
+| G_LTAC2_concl_occs ltac2_concl_occs
+| G_LTAC2_hyp_occs ltac2_hyp_occs
 | G_LTAC2_hypident ltac2_hypident
 | G_LTAC2_induction_clause ltac2_induction_clause
 | G_LTAC2_as_or_and_ipat ltac2_as_or_and_ipat
@@ -422,9 +422,9 @@ term0: [
 (* @Zimmi48: This rule is a hack, according to Hugo, and should not be shown in the manual. *)
 | DELETE "{" binder_constr "}"
 | REPLACE "{|" record_declaration bar_cbrace
-| WITH "{|" LIST0 field_def SEP ";" OPT ";" bar_cbrace
+| WITH "{|" LIST0 field_val SEP ";" OPT ";" bar_cbrace
 | MOVETO number_or_string NUMBER
-| MOVETO term_record "{|" LIST0 field_def SEP ";" OPT ";" bar_cbrace
+| MOVETO term_record "{|" LIST0 field_val SEP ";" OPT ";" bar_cbrace
 | MOVETO term_generalizing "`{" term200 "}"
 | MOVETO term_generalizing "`(" term200 ")"
 | MOVETO term_ltac "ltac" ":" "(" ltac_expr5 ")"
@@ -445,9 +445,9 @@ cofix_decls: [
 ]
 
 fields_def: [
-| REPLACE field_def ";" fields_def
-| WITH LIST1 field_def SEP ";"
-| DELETE field_def
+| REPLACE field_val ";" fields_def
+| WITH LIST1 field_val SEP ";"
+| DELETE field_val
 ]
 
 binders_fixannot: [
@@ -682,7 +682,7 @@ def_body: [
 | WITH LIST0 binder ":" type
 ]
 
-delta_flag: [
+delta_reductions: [
 | REPLACE "-" "[" LIST1 smart_global "]"
 | WITH OPT "-" "[" LIST1 smart_global "]"
 | DELETE "[" LIST1 smart_global "]"
@@ -697,11 +697,9 @@ ltac2_branches: [
 | EDIT ADD_OPT "|" LIST1 branch SEP "|"      (* Ltac2 plugin *)
 ]
 
-strategy_flag: [
-| REPLACE OPT delta_flag
-| WITH delta_flag
-(*| REPLACE LIST1 red_flags
-| WITH LIST1 red_flag*)
+reductions: [
+| REPLACE OPT delta_reductions
+| WITH delta_reductions
 | (* empty *)
 ]
 
@@ -1023,18 +1021,18 @@ simple_tactic: [
 | WITH "autounfold" hintbases OPT simple_occurrences
 | REPLACE "red" clause_dft_concl
 | WITH "red" simple_occurrences
-| REPLACE "simpl" OPT delta_flag OPT ref_or_pattern_occ clause_dft_concl
-| WITH "simpl" OPT delta_flag OPT ref_or_pattern_occ simple_occurrences
+| REPLACE "simpl" OPT delta_reductions OPT ref_or_pattern_occs clause_dft_concl
+| WITH "simpl" OPT delta_reductions OPT ref_or_pattern_occs simple_occurrences
 | REPLACE "hnf" clause_dft_concl
 | WITH "hnf" simple_occurrences
-| REPLACE "cbv" strategy_flag clause_dft_concl
-| WITH "cbv" strategy_flag simple_occurrences
-| REPLACE "compute" OPT delta_flag clause_dft_concl
-| WITH "compute" OPT delta_flag simple_occurrences
-| REPLACE "lazy" strategy_flag clause_dft_concl
-| WITH "lazy" strategy_flag simple_occurrences
-| REPLACE "cbn" strategy_flag clause_dft_concl
-| WITH "cbn" strategy_flag simple_occurrences
+| REPLACE "cbv" reductions clause_dft_concl
+| WITH "cbv" reductions simple_occurrences
+| REPLACE "compute" OPT delta_reductions clause_dft_concl
+| WITH "compute" OPT delta_reductions simple_occurrences
+| REPLACE "lazy" reductions clause_dft_concl
+| WITH "lazy" reductions simple_occurrences
+| REPLACE "cbn" reductions clause_dft_concl
+| WITH "cbn" reductions simple_occurrences
 | REPLACE "fold" LIST1 constr clause_dft_concl
 | WITH "fold" LIST1 constr simple_occurrences
 | DELETE "clear" LIST0 hyp
@@ -1068,8 +1066,8 @@ simple_tactic: [
 | DELETE "generalize" constr
 | REPLACE "generalize" constr LIST1 constr
 | WITH "generalize" LIST1 constr
-| REPLACE "generalize" constr occs as_name LIST0 [ "," pattern_occ as_name ]
-| WITH "generalize" LIST1 [ pattern_occ as_name ] SEP ","
+| REPLACE "generalize" constr occs as_name LIST0 [ "," pattern_occs as_name ]
+| WITH "generalize" LIST1 [ pattern_occs as_name ] SEP ","
 | REPLACE "evar" "(" ident ":" lconstr ")"
 | WITH "evar" "(" ident ":" type ")"
 | EDIT "simplify_eq" ADD_OPT destruction_arg
@@ -1518,7 +1516,7 @@ binder_tactic: [
 | MOVEALLBUT ltac_builtins
 ]
 
-field_body: [
+field_spec: [
 | REPLACE binders of_type_inst lconstr
 | WITH binders of_type_inst
 | REPLACE binders of_type_inst lconstr ":=" lconstr
@@ -1603,8 +1601,8 @@ constructors_or_record: [
 ]
 
 record_binder: [
-| REPLACE name field_body
-| WITH name OPT field_body
+| REPLACE name field_spec
+| WITH name OPT field_spec
 | DELETE name
 ]
 
@@ -1693,7 +1691,7 @@ tac2type_body: [
 
 record_declaration: [
 | DELETE fields_def
-| LIST0 field_def
+| LIST0 field_val
 ]
 
 fields_def: [ | DELETENT ]
@@ -1717,18 +1715,18 @@ simple_reserv: [
 
 in_clause: [
 | DELETE in_clause'
-| REPLACE LIST1 hypident_occ SEP "," "|-" concl_occ
-| WITH LIST1 hypident_occ SEP "," OPT ( "|-" concl_occ )
-| DELETE LIST1 hypident_occ SEP ","
+| REPLACE LIST1 hyp_occs SEP "," "|-" concl_occs
+| WITH LIST1 hyp_occs SEP "," OPT ( "|-" concl_occs )
+| DELETE LIST1 hyp_occs SEP ","
 | REPLACE "*" occs
-| WITH concl_occ
-(* todo: perhaps concl_occ should be "*" | "at" occs_nums *)
+| WITH concl_occs
+(* todo: perhaps concl_occs should be "*" | "at" occs_nums *)
 ]
 
 ltac2_in_clause: [
-| REPLACE LIST0 ltac2_hypident_occ SEP "," "|-" ltac2_concl_occ      (* Ltac2 plugin *)
-| WITH LIST0 ltac2_hypident_occ SEP "," OPT ( "|-" ltac2_concl_occ )  TAG Ltac2
-| DELETE LIST0 ltac2_hypident_occ SEP ","      (* Ltac2 plugin *)
+| REPLACE LIST0 ltac2_hyp_occs SEP "," "|-" ltac2_concl_occs      (* Ltac2 plugin *)
+| WITH LIST0 ltac2_hyp_occs SEP "," OPT ( "|-" ltac2_concl_occs )  TAG Ltac2
+| DELETE LIST0 ltac2_hyp_occs SEP ","      (* Ltac2 plugin *)
 ]
 
 decl_notations: [
@@ -2562,11 +2560,11 @@ hypident: [
 | DELETE "(" "value" "of" ident ")"      (* SSR plugin *)
 ]
 
-ref_or_pattern_occ: [
+ref_or_pattern_occs: [
 | DELETE smart_global OPT occs
 | DELETE constr OPT occs
-| unfold_occ
-| pattern_occ
+| reference_occs
+| pattern_occs
 ]
 
 clause_dft_concl: [
@@ -2828,7 +2826,7 @@ SPLICE: [
 | syn_level
 | firstorder_rhs
 | firstorder_using
-| ref_or_pattern_occ
+| ref_or_pattern_occs
 | cumul_ident_decl
 | variance
 | variance_identref
@@ -2902,18 +2900,8 @@ RENAME: [
 | hints_path hints_regexp
 | clause_dft_concl occurrences
 | in_clause goal_occurrences
-| unfold_occ reference_occs
-| pattern_occ pattern_occs
-| hypident_occ hyp_occs
-| concl_occ concl_occs
 | constr_with_bindings one_term_with_bindings
-| red_flag reduction
-| strategy_flag reductions
-| delta_flag delta_reductions
-| q_strategy_flag q_reductions
 | destruction_arg induction_arg
-| field_body field_spec
-| field_def field_val
 | bindings_with_parameters alias_definition
 ]
 
@@ -2963,7 +2951,7 @@ NOTINRSTS: [
 | q_destruction_arg
 | q_with_bindings
 | q_bindings
-| q_reductions
+| q_strategy_flag
 | q_reference
 | q_clause
 | q_occurrences

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -61,6 +61,10 @@ lconstr: [
 | term200
 ]
 
+type_: [
+| lconstr
+]
+
 constr: [
 | term8
 | "@" global univ_annot
@@ -72,10 +76,10 @@ term200: [
 ]
 
 term100: [
-| term99 "<:" term200
-| term99 "<<:" term200
-| term99 ":>" term200
-| term99 ":" term200
+| term99 "<:" type_
+| term99 "<<:" type_
+| term99 ":>" type_
+| term99 ":" type_
 | term99
 ]
 
@@ -308,7 +312,7 @@ binders_fixannot: [
 ]
 
 open_binders: [
-| name LIST0 name ":" lconstr
+| name LIST0 name ":" type_
 | name LIST0 name binders
 | name ".." name
 | closed_binder binders
@@ -325,7 +329,7 @@ binder: [
 ]
 
 closed_binder: [
-| "(" name LIST1 name ":" lconstr ")"
+| "(" name LIST1 name ":" type_ ")"
 | "(" name ":" lconstr ")"
 | "(" name ":=" lconstr ")"
 | "(" name ":" lconstr ":=" lconstr ")"
@@ -367,7 +371,7 @@ typeclass_constraint: [
 ]
 
 type_cstr: [
-| ":" lconstr
+| ":" type_
 |
 ]
 
@@ -503,7 +507,7 @@ opt_hintbases: [
 ]
 
 command: [
-| "Goal" lconstr
+| "Goal" type_
 | "Proof"
 | "Proof" "using" G_vernac.section_subset_expr
 | "Proof" "Mode" string
@@ -739,7 +743,7 @@ hint: [
 
 constr_body: [
 | ":=" lconstr
-| ":" lconstr ":=" lconstr
+| ":" type_ ":=" lconstr
 ]
 
 mode: [
@@ -814,7 +818,7 @@ subprf: [
 ]
 
 gallina: [
-| thm_token ident_decl binders ":" lconstr LIST0 [ "with" ident_decl binders ":" lconstr ]
+| thm_token ident_decl binders ":" type_ LIST0 [ "with" ident_decl binders ":" type_ ]
 | assumption_token inline assum_list
 | assumptions_token inline assum_list
 | def_token ident_decl def_body
@@ -924,8 +928,8 @@ finite_token: [
 
 def_body: [
 | binders ":=" reduce lconstr
-| binders ":" lconstr ":=" reduce lconstr
-| binders ":" lconstr
+| binders ":" type_ ":=" reduce lconstr
+| binders ":" type_
 ]
 
 reduce: [
@@ -1078,7 +1082,7 @@ gallina_ext: [
 | "Coercion" global ":" coercion_class ">->" coercion_class
 | "Coercion" by_notation ":" coercion_class ">->" coercion_class
 | "Context" LIST1 binder
-| "Instance" instance_name ":" term200 hint_info [ ":=" "{" record_declaration "}" | ":=" lconstr | ]
+| "Instance" instance_name ":" type_ hint_info [ ":=" "{" record_declaration "}" | ":=" lconstr | ]
 | "Existing" "Instance" global hint_info
 | "Existing" "Instances" LIST1 global OPT [ "|" natural ]
 | "Existing" "Class" global
@@ -1272,7 +1276,7 @@ reserv_tuple: [
 ]
 
 simple_reserv: [
-| LIST1 identref ":" lconstr
+| LIST1 identref ":" type_
 ]
 
 scope: [
@@ -1779,10 +1783,10 @@ simple_tactic: [
 | "eremember" constr as_name eqn_ipat clause_dft_all
 | "assert" test_lpar_id_coloneq "(" identref ":=" lconstr ")"
 | "eassert" test_lpar_id_coloneq "(" identref ":=" lconstr ")"
-| "assert" test_lpar_id_colon "(" identref ":" lconstr ")" by_tactic
-| "eassert" test_lpar_id_colon "(" identref ":" lconstr ")" by_tactic
-| "enough" test_lpar_id_colon "(" identref ":" lconstr ")" by_tactic
-| "eenough" test_lpar_id_colon "(" identref ":" lconstr ")" by_tactic
+| "assert" test_lpar_id_colon "(" identref ":" type_ ")" by_tactic
+| "eassert" test_lpar_id_colon "(" identref ":" type_ ")" by_tactic
+| "enough" test_lpar_id_colon "(" identref ":" type_ ")" by_tactic
+| "eenough" test_lpar_id_colon "(" identref ":" type_ ")" by_tactic
 | "assert" constr as_ipat by_tactic
 | "eassert" constr as_ipat by_tactic
 | "pose" "proof" test_lpar_id_coloneq "(" identref ":=" lconstr ")"
@@ -2598,7 +2602,7 @@ simple_binder: [
 ]
 
 fixdecl: [
-| "(" ident LIST0 simple_binder struct_annot ":" lconstr ")"
+| "(" ident LIST0 simple_binder struct_annot ":" type_ ")"
 ]
 
 struct_annot: [
@@ -2607,7 +2611,7 @@ struct_annot: [
 ]
 
 cofixdecl: [
-| "(" ident LIST0 simple_binder ":" lconstr ")"
+| "(" ident LIST0 simple_binder ":" type_ ")"
 ]
 
 bindings_with_parameters: [

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1177,7 +1177,7 @@ module_type: [
 
 section_subset_expr: [
 | test_only_starredidentrefs LIST0 starred_ident_ref
-| ssexpr35
+| section_var_expr35
 ]
 
 starred_ident_ref: [
@@ -1187,24 +1187,24 @@ starred_ident_ref: [
 | "Type" "*"
 ]
 
-ssexpr35: [
-| "-" ssexpr50
-| ssexpr50
+section_var_expr35: [
+| "-" section_var_expr50
+| section_var_expr50
 ]
 
-ssexpr50: [
-| ssexpr0 "-" ssexpr0
-| ssexpr0 "+" ssexpr0
-| ssexpr0
+section_var_expr50: [
+| section_var_expr0 "-" section_var_expr0
+| section_var_expr0 "+" section_var_expr0
+| section_var_expr0
 ]
 
-ssexpr0: [
+section_var_expr0: [
 | starred_ident_ref
 | "()"
 | "(" test_only_starredidentrefs LIST0 starred_ident_ref ")"
 | "(" test_only_starredidentrefs LIST0 starred_ident_ref ")" "*"
-| "(" ssexpr35 ")"
-| "(" ssexpr35 ")" "*"
+| "(" section_var_expr35 ")"
+| "(" section_var_expr35 ")" "*"
 ]
 
 args_modifier: [

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -134,12 +134,12 @@ record_declaration: [
 ]
 
 fields_def: [
-| field_def ";" fields_def
-| field_def
+| field_val ";" fields_def
+| field_val
 |
 ]
 
-field_def: [
+field_val: [
 | global binders ":=" lconstr
 ]
 
@@ -1000,7 +1000,7 @@ record_fields: [
 |
 ]
 
-field_body: [
+field_spec: [
 | binders of_type_inst lconstr
 | binders of_type_inst lconstr ":=" lconstr
 | binders ":=" lconstr
@@ -1008,7 +1008,7 @@ field_body: [
 
 record_binder: [
 | name
-| name field_body
+| name field_spec
 ]
 
 assum_list: [
@@ -1780,7 +1780,7 @@ simple_tactic: [
 | "eenough" constr as_ipat by_tactic
 | "generalize" constr
 | "generalize" constr LIST1 constr
-| "generalize" constr lookup_at_as_comma occs as_name LIST0 [ "," pattern_occ as_name ]
+| "generalize" constr lookup_at_as_comma occs as_name LIST0 [ "," pattern_occs as_name ]
 | "induction" induction_clause_list
 | "einduction" induction_clause_list
 | "destruct" induction_clause_list
@@ -1794,16 +1794,16 @@ simple_tactic: [
 | "inversion" quantified_hypothesis "using" constr in_hyp_list
 | "red" clause_dft_concl
 | "hnf" clause_dft_concl
-| "simpl" delta_flag OPT ref_or_pattern_occ clause_dft_concl
-| "cbv" strategy_flag clause_dft_concl
-| "cbn" strategy_flag clause_dft_concl
-| "lazy" strategy_flag clause_dft_concl
-| "compute" delta_flag clause_dft_concl
-| "vm_compute" OPT ref_or_pattern_occ clause_dft_concl
-| "native_compute" OPT ref_or_pattern_occ clause_dft_concl
-| "unfold" LIST1 unfold_occ SEP "," clause_dft_concl
+| "simpl" delta_reductions OPT ref_or_pattern_occs clause_dft_concl
+| "cbv" reductions clause_dft_concl
+| "cbn" reductions clause_dft_concl
+| "lazy" reductions clause_dft_concl
+| "compute" delta_reductions clause_dft_concl
+| "vm_compute" OPT ref_or_pattern_occs clause_dft_concl
+| "native_compute" OPT ref_or_pattern_occs clause_dft_concl
+| "unfold" LIST1 reference_occs SEP "," clause_dft_concl
 | "fold" LIST1 constr clause_dft_concl
-| "pattern" LIST1 pattern_occ SEP "," clause_dft_concl
+| "pattern" LIST1 pattern_occs SEP "," clause_dft_concl
 | "change" conversion clause_dft_concl
 | "change_no_check" conversion clause_dft_concl
 | "start" "ltac" "profiling"
@@ -1989,10 +1989,10 @@ by_arg_tac: [
 in_clause: [
 | in_clause'
 | "*" occs
-| "*" "|-" concl_occ
-| "|-" concl_occ
-| LIST1 hypident_occ SEP "," "|-" concl_occ
-| LIST1 hypident_occ SEP ","
+| "*" "|-" concl_occs
+| "|-" concl_occs
+| LIST1 hyp_occs SEP "," "|-" concl_occs
+| LIST1 hyp_occs SEP ","
 ]
 
 test_lpar_id_colon: [
@@ -2415,16 +2415,16 @@ occs: [
 |
 ]
 
-pattern_occ: [
+pattern_occs: [
 | constr occs
 ]
 
-ref_or_pattern_occ: [
+ref_or_pattern_occs: [
 | smart_global occs
 | constr occs
 ]
 
-unfold_occ: [
+reference_occs: [
 | smart_global occs
 ]
 
@@ -2492,40 +2492,40 @@ with_bindings: [
 |
 ]
 
-red_flag: [
+reduction: [
 | "beta"
 | "iota"
 | "match"
 | "fix"
 | "cofix"
 | "zeta"
-| "delta" delta_flag
+| "delta" delta_reductions
 ]
 
-delta_flag: [
+delta_reductions: [
 | "-" "[" LIST1 smart_global "]"
 | "[" LIST1 smart_global "]"
 |
 ]
 
-strategy_flag: [
-| LIST1 red_flag
-| delta_flag
+reductions: [
+| LIST1 reduction
+| delta_reductions
 ]
 
 red_expr: [
 | "red"
 | "hnf"
-| "simpl" delta_flag OPT ref_or_pattern_occ
-| "cbv" strategy_flag
-| "cbn" strategy_flag
-| "lazy" strategy_flag
-| "compute" delta_flag
-| "vm_compute" OPT ref_or_pattern_occ
-| "native_compute" OPT ref_or_pattern_occ
-| "unfold" LIST1 unfold_occ SEP ","
+| "simpl" delta_reductions OPT ref_or_pattern_occs
+| "cbv" reductions
+| "cbn" reductions
+| "lazy" reductions
+| "compute" delta_reductions
+| "vm_compute" OPT ref_or_pattern_occs
+| "native_compute" OPT ref_or_pattern_occs
+| "unfold" LIST1 reference_occs SEP ","
 | "fold" LIST1 constr
-| "pattern" LIST1 pattern_occ SEP ","
+| "pattern" LIST1 pattern_occs SEP ","
 | IDENT
 ]
 
@@ -2537,7 +2537,7 @@ hypident: [
 | "(" "value" "of" Prim.identref ")"      (* SSR plugin *)
 ]
 
-hypident_occ: [
+hyp_occs: [
 | hypident occs
 ]
 
@@ -2558,7 +2558,7 @@ opt_clause: [
 |
 ]
 
-concl_occ: [
+concl_occs: [
 | "*" occs
 |
 ]
@@ -3717,15 +3717,15 @@ G_LTAC2_hypident: [
 | "(" "value" "of" ident_or_anti ")"      (* ltac2 plugin *)
 ]
 
-G_LTAC2_hypident_occ: [
+G_LTAC2_hyp_occs: [
 | G_LTAC2_hypident G_LTAC2_occs      (* ltac2 plugin *)
 ]
 
 G_LTAC2_in_clause: [
 | "*" G_LTAC2_occs      (* ltac2 plugin *)
-| "*" "|-" G_LTAC2_concl_occ      (* ltac2 plugin *)
-| LIST0 G_LTAC2_hypident_occ SEP "," "|-" G_LTAC2_concl_occ      (* ltac2 plugin *)
-| LIST0 G_LTAC2_hypident_occ SEP ","      (* ltac2 plugin *)
+| "*" "|-" G_LTAC2_concl_occs      (* ltac2 plugin *)
+| LIST0 G_LTAC2_hyp_occs SEP "," "|-" G_LTAC2_concl_occs      (* ltac2 plugin *)
+| LIST0 G_LTAC2_hyp_occs SEP ","      (* ltac2 plugin *)
 ]
 
 clause: [
@@ -3737,7 +3737,7 @@ q_clause: [
 | clause      (* ltac2 plugin *)
 ]
 
-G_LTAC2_concl_occ: [
+G_LTAC2_concl_occs: [
 | "*" G_LTAC2_occs      (* ltac2 plugin *)
 |      (* ltac2 plugin *)
 ]
@@ -3811,7 +3811,7 @@ ltac2_red_flag: [
 | "fix"      (* ltac2 plugin *)
 | "cofix"      (* ltac2 plugin *)
 | "zeta"      (* ltac2 plugin *)
-| "delta" G_LTAC2_delta_flag      (* ltac2 plugin *)
+| "delta" G_LTAC2_delta_reductions      (* ltac2 plugin *)
 ]
 
 refglobal: [
@@ -3828,19 +3828,19 @@ refglobals: [
 | LIST1 refglobal      (* ltac2 plugin *)
 ]
 
-G_LTAC2_delta_flag: [
+G_LTAC2_delta_reductions: [
 | "-" "[" refglobals "]"      (* ltac2 plugin *)
 | "[" refglobals "]"      (* ltac2 plugin *)
 |      (* ltac2 plugin *)
 ]
 
-G_LTAC2_strategy_flag: [
+G_LTAC2_reductions: [
 | LIST1 ltac2_red_flag      (* ltac2 plugin *)
-| G_LTAC2_delta_flag      (* ltac2 plugin *)
+| G_LTAC2_delta_reductions      (* ltac2 plugin *)
 ]
 
 q_strategy_flag: [
-| G_LTAC2_strategy_flag      (* ltac2 plugin *)
+| G_LTAC2_reductions      (* ltac2 plugin *)
 ]
 
 hintdb: [

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -281,7 +281,7 @@ pattern10: [
 ]
 
 pattern1: [
-| pattern0 "%" IDENT
+| pattern0 "%" scope_key
 | pattern0
 ]
 
@@ -379,6 +379,14 @@ preident: [
 | IDENT
 ]
 
+scope_name: [
+| IDENT
+]
+
+scope_key: [
+| IDENT
+]
+
 ident: [
 | IDENT
 ]
@@ -424,7 +432,7 @@ qualid: [
 ]
 
 by_notation: [
-| ne_string OPT [ "%" IDENT ]
+| ne_string OPT [ "%" scope_key ]
 ]
 
 smart_global: [
@@ -531,7 +539,7 @@ command: [
 | "Hint" hint opt_hintbases
 | "Comments" LIST0 comment
 | "Declare" "Instance" ident_decl binders ":" term200 hint_info
-| "Declare" "Scope" IDENT
+| "Declare" "Scope" scope_name
 | "Pwd"
 | "Cd"
 | "Cd" ne_string
@@ -926,7 +934,7 @@ reduce: [
 ]
 
 notation_declaration: [
-| lstring ":=" constr syntax_modifiers OPT [ ":" IDENT ]
+| lstring ":=" constr syntax_modifiers OPT [ ":" scope_name ]
 ]
 
 decl_sep: [
@@ -1222,7 +1230,7 @@ args_modifier: [
 ]
 
 scope_delimiter: [
-| "%" IDENT
+| "%" scope
 ]
 
 argument_spec: [
@@ -1267,6 +1275,11 @@ simple_reserv: [
 | LIST1 identref ":" lconstr
 ]
 
+scope: [
+| scope_key
+| scope_name
+]
+
 query_command: [
 | "Eval" red_expr "in" lconstr "."
 | "Compute" lconstr "."
@@ -1306,8 +1319,8 @@ printable: [
 | "Hint" "*"
 | "HintDb" IDENT
 | "Scopes"
-| "Scope" IDENT
-| "Visibility" OPT IDENT
+| "Scope" scope_name
+| "Visibility" OPT scope_name
 | "Implicit" smart_global
 | [ "Sorted" | ] "Universes" OPT printunivs_subgraph OPT ne_string
 | "Assumptions" smart_global
@@ -1424,11 +1437,11 @@ univ_name_list: [
 ]
 
 syntax: [
-| "Open" "Scope" IDENT
-| "Close" "Scope" IDENT
-| "Delimit" "Scope" IDENT; "with" IDENT
-| "Undelimit" "Scope" IDENT
-| "Bind" "Scope" IDENT; "with" LIST1 coercion_class
+| "Open" "Scope" scope
+| "Close" "Scope" scope
+| "Delimit" "Scope" scope_name "with" scope_key
+| "Undelimit" "Scope" scope_name
+| "Bind" "Scope" scope_name "with" LIST1 coercion_class
 | "Infix" notation_declaration
 | "Notation" identref LIST0 ident ":=" constr syntax_modifiers
 | "Notation" notation_declaration
@@ -1467,7 +1480,7 @@ enable_notation_flag: [
 ]
 
 opt_scope: [
-| ":" IDENT
+| ":" scope_name
 | ":" "no" "scope"
 |
 ]

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1176,11 +1176,11 @@ module_type: [
 ]
 
 section_subset_expr: [
-| test_only_starredidentrefs LIST0 starredidentref
+| test_only_starredidentrefs LIST0 starred_ident_ref
 | ssexpr35
 ]
 
-starredidentref: [
+starred_ident_ref: [
 | identref
 | identref "*"
 | "Type"
@@ -1199,10 +1199,10 @@ ssexpr50: [
 ]
 
 ssexpr0: [
-| starredidentref
+| starred_ident_ref
 | "()"
-| "(" test_only_starredidentrefs LIST0 starredidentref ")"
-| "(" test_only_starredidentrefs LIST0 starredidentref ")" "*"
+| "(" test_only_starredidentrefs LIST0 starred_ident_ref ")"
+| "(" test_only_starredidentrefs LIST0 starred_ident_ref ")" "*"
 | "(" ssexpr35 ")"
 | "(" ssexpr35 ")" "*"
 ]

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -338,7 +338,7 @@ NOTINRSTS: [
 | q_destruction_arg
 | q_with_bindings
 | q_bindings
-| q_reductions
+| q_strategy_flag
 | q_reference
 | q_clause
 | q_occurrences
@@ -2073,8 +2073,8 @@ ltac2_clause: [
 
 ltac2_in_clause: [
 | "*" OPT ltac2_occs      (* ltac2 plugin *)
-| "*" "|-" OPT ltac2_concl_occ      (* ltac2 plugin *)
-| LIST0 ltac2_hypident_occ SEP "," OPT ( "|-" OPT ltac2_concl_occ )      (* Ltac2 plugin *)
+| "*" "|-" OPT ltac2_concl_occs      (* ltac2 plugin *)
+| LIST0 ltac2_hyp_occs SEP "," OPT ( "|-" OPT ltac2_concl_occs )      (* Ltac2 plugin *)
 ]
 
 q_occurrences: [
@@ -2089,11 +2089,11 @@ ltac2_occs_nums: [
 | OPT "-" LIST1 [ natural | "$" ident ]      (* Ltac2 plugin *)
 ]
 
-ltac2_concl_occ: [
+ltac2_concl_occs: [
 | "*" OPT ltac2_occs      (* ltac2 plugin *)
 ]
 
-ltac2_hypident_occ: [
+ltac2_hyp_occs: [
 | ltac2_hypident OPT ltac2_occs      (* ltac2 plugin *)
 ]
 
@@ -2153,7 +2153,7 @@ ltac2_goal_tactics: [
 | LIST0 ( OPT ltac2_expr ) SEP "|"      (* Ltac2 plugin *)
 ]
 
-q_reductions: [
+q_strategy_flag: [
 | ltac2_reductions      (* ltac2 plugin *)
 ]
 

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -97,7 +97,7 @@ GRAMMAR EXTEND Gram
   global constr_pattern cpattern Constr.ident
   closed_binder open_binders binder binders binders_fixannot
   record_declaration typeclass_constraint pattern arg type_cstr
-  one_closed_binder one_open_binder;
+  one_closed_binder one_open_binder scope_key;
   Constr.ident:
     [ [ id = Prim.ident -> { id } ] ]
   ;
@@ -181,7 +181,7 @@ GRAMMAR EXTEND Gram
       | c = term; ".("; "@"; f = global; i = univ_annot;
         args = LIST0 (term LEVEL "9"); ")" ->
         { CAst.make ~loc @@ CProj(true, (f,i), List.map (fun a -> (a,None)) args, c) }
-      | c = term; "%"; key = IDENT -> { CAst.make ~loc @@ CDelimiters (key,c) } ]
+      | c = term; "%"; key = IDENT (* scope_key *) -> { CAst.make ~loc @@ CDelimiters (key,c) } ]
     | "0"
       [ c = atomic_constr -> { c }
       | c = term_match -> { c }
@@ -373,7 +373,7 @@ GRAMMAR EXTEND Gram
       | "@"; r = Prim.reference; lp = LIST0 NEXT ->
         { CAst.make ~loc @@ CPatCstr (r, Some lp, []) } ]
     | "1" LEFTA
-      [ c = pattern; "%"; key = IDENT -> { CAst.make ~loc @@ CPatDelimiters (key,c) } ]
+      [ c = pattern; "%"; key = scope_key -> { CAst.make ~loc @@ CPatDelimiters (key,c) } ]
     | "0"
       [ r = Prim.reference                -> { CAst.make ~loc @@ CPatAtom (Some r) }
       | "{|"; pat = record_patterns; bar_cbrace -> { CAst.make ~loc @@ CPatRecord pat }

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -217,11 +217,11 @@ GRAMMAR EXTEND Gram
     [ [ fs = fields_def -> { CAst.make ~loc @@ CRecord fs } ] ]
   ;
   fields_def:
-    [ [ f = field_def; ";"; fs = fields_def -> { f :: fs }
-      | f = field_def -> { [f] }
+    [ [ f = field_val; ";"; fs = fields_def -> { f :: fs }
+      | f = field_val -> { [f] }
       | -> { [] } ] ]
   ;
-  field_def:
+  field_val:
     [ [ id = global; bl = binders; ":="; c = lconstr ->
         { (id, mkLambdaCN ~loc bl c) } ] ]
   ;

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -97,7 +97,7 @@ GRAMMAR EXTEND Gram
   global constr_pattern cpattern Constr.ident
   closed_binder open_binders binder binders binders_fixannot
   record_declaration typeclass_constraint pattern arg type_cstr
-  one_closed_binder one_open_binder scope_key;
+  one_closed_binder one_open_binder scope_key type_;
   Constr.ident:
     [ [ id = Prim.ident -> { id } ] ]
   ;
@@ -146,6 +146,9 @@ GRAMMAR EXTEND Gram
   lconstr:
     [ [ c = term LEVEL "200" -> { c } ] ]
   ;
+  type_:
+    [ [ t = lconstr -> { t } ] ]
+  ;
   constr:
     [ [ c = term LEVEL "8" -> { c }
       | "@"; f=global; i = univ_annot -> { CAst.make ~loc @@ CAppExpl((f,i),[]) } ] ]
@@ -154,13 +157,13 @@ GRAMMAR EXTEND Gram
     [ "200" RIGHTA
       [ c = binder_constr -> { c } ]
     | "100" RIGHTA
-      [ c1 = term; "<:"; c2 = term LEVEL "200" ->
+      [ c1 = term; "<:"; c2 = type_ ->
                  { CAst.make ~loc @@ CCast(c1, Some VMcast, c2) }
-      | c1 = term; "<<:"; c2 = term LEVEL "200" ->
+      | c1 = term; "<<:"; c2 = type_ ->
                  { CAst.make ~loc @@ CCast(c1, Some NATIVEcast, c2) }
-      | c1 = term; ":>"; c2 = term LEVEL "200" ->
+      | c1 = term; ":>"; c2 = type_ ->
                  { CAst.make ~loc @@ CCast(c1, None, c2) }
-      | c1 = term; ":"; c2 = term LEVEL "200" ->
+      | c1 = term; ":"; c2 = type_ ->
                  { CAst.make ~loc @@ CCast(c1, Some DEFAULTcast, c2) } ]
     | "99" RIGHTA [ ]
     | "90" RIGHTA [ ]
@@ -404,7 +407,7 @@ GRAMMAR EXTEND Gram
   open_binders:
     (* Same as binders but parentheses around a closed binder are optional if
        the latter is unique *)
-    [ [ id = name; idl = LIST0 name; ":"; c = lconstr ->
+    [ [ id = name; idl = LIST0 name; ":"; c = type_ ->
         { [CLocalAssum (id::idl,Default Explicit,c)] }
         (* binders factorized with open binder *)
       | id = name; idl = LIST0 name; bl = binders ->
@@ -423,7 +426,7 @@ GRAMMAR EXTEND Gram
       | bl = closed_binder -> { bl } ] ]
   ;
   closed_binder:
-    [ [ "("; id = name; idl = LIST1 name; ":"; c = lconstr; ")" ->
+    [ [ "("; id = name; idl = LIST1 name; ":"; c = type_; ")" ->
         { [CLocalAssum (id::idl,Default Explicit,c)] }
       | "("; id = name; ":"; c = lconstr; ")" ->
         { [CLocalAssum ([id],Default Explicit,c)] }
@@ -480,7 +483,7 @@ GRAMMAR EXTEND Gram
           { (CAst.make ~loc Anonymous), false, c } ] ]
   ;
   type_cstr:
-    [ [ ":"; c = lconstr -> { c }
+    [ [ ":"; c = type_-> { c }
       | -> { CAst.make ~loc @@ CHole (None, IntroAnonymous) } ] ]
   ;
   let_type_cstr:

--- a/parsing/g_prim.mlg
+++ b/parsing/g_prim.mlg
@@ -48,8 +48,14 @@ GRAMMAR EXTEND Gram
     bignat bigint natural integer identref name ident hyp preident
     fullyqualid qualid reference dirpath ne_lstring
     ne_string string lstring pattern_ident by_notation
-    smart_global bar_cbrace strategy_level fields;
+    smart_global bar_cbrace strategy_level fields scope_name scope_key;
   preident:
+    [ [ s = IDENT -> { s } ] ]
+  ;
+  scope_name:
+    [ [ s = IDENT -> { s } ] ]
+  ;
+  scope_key:
     [ [ s = IDENT -> { s } ] ]
   ;
   ident:
@@ -92,7 +98,7 @@ GRAMMAR EXTEND Gram
     [ [ qid = reference -> { qid } ] ]
   ;
   by_notation:
-    [ [ s = ne_string; sc = OPT ["%"; key = IDENT -> { key } ] -> { (s, sc) } ] ]
+    [ [ s = ne_string; sc = OPT ["%"; key = scope_key -> { key } ] -> { (s, sc) } ] ]
   ;
   smart_global:
     [ [ c = reference -> { CAst.make ~loc @@ Constrexpr.AN c }

--- a/parsing/pcoq.ml
+++ b/parsing/pcoq.ml
@@ -288,6 +288,8 @@ module Prim =
     (* Entries that can be referred via the string -> Entry.t table *)
     (* Typically for tactic or vernac extensions *)
     let preident = Entry.make "preident"
+    let scope_name = Entry.make "scope_name"
+    let scope_key = Entry.make "scope_key"
     let ident = Entry.make "ident"
     let natural = Entry.make "natural"
     let integer = Entry.make "integer"

--- a/parsing/pcoq.ml
+++ b/parsing/pcoq.ml
@@ -335,6 +335,7 @@ module Constr =
     let term = Entry.make "term"
     let constr_eoi = eoi_entry constr
     let lconstr = Entry.make "lconstr"
+    let type_ = Entry.make "type_"
     let binder_constr = Entry.make "binder_constr"
     let ident = Entry.make "ident"
     let global = Entry.make "global"

--- a/parsing/pcoq.mli
+++ b/parsing/pcoq.mli
@@ -143,6 +143,8 @@ module Prim :
     open Names
     open Libnames
     val preident : string Entry.t
+    val scope_name : string Entry.t
+    val scope_key : string Entry.t
     val ident : Id.t Entry.t
     val name : lname Entry.t
     val identref : lident Entry.t

--- a/parsing/pcoq.mli
+++ b/parsing/pcoq.mli
@@ -178,6 +178,7 @@ module Constr :
     val constr : constr_expr Entry.t
     val constr_eoi : constr_expr Entry.t
     val lconstr : constr_expr Entry.t
+    val type_ : constr_expr Entry.t
     val binder_constr : constr_expr Entry.t
     val term : constr_expr Entry.t
     val ident : Id.t Entry.t

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -262,16 +262,16 @@ GRAMMAR EXTEND Gram
   occs:
     [ [ "at"; occs = occs_nums -> { occs } | -> { AllOccurrences } ] ]
   ;
-  pattern_occ:
+  pattern_occs:
     [ [ c = constr; nl = occs -> { (nl,c) } ] ]
   ;
-  ref_or_pattern_occ:
+  ref_or_pattern_occs:
     (* If a string, it is interpreted as a ref
        (anyway a Coq string does not reduce) *)
     [ [ c = smart_global; nl = occs -> { nl,Inl c }
       | c = constr; nl = occs -> { nl,Inr c } ] ]
   ;
-  unfold_occ:
+  reference_occs:
     [ [ c = smart_global; nl = occs -> { (nl,c) } ] ]
   ;
   intropatterns:
@@ -341,40 +341,40 @@ GRAMMAR EXTEND Gram
   with_bindings:
     [ [ "with"; bl = bindings -> { bl } | -> { NoBindings } ] ]
   ;
-  red_flag:
+  reduction:
     [ [ IDENT "beta" -> { [FBeta] }
       | IDENT "iota" -> { [FMatch;FFix;FCofix] }
       | IDENT "match" -> { [FMatch] }
       | IDENT "fix" -> { [FFix] }
       | IDENT "cofix" -> { [FCofix] }
       | IDENT "zeta" -> { [FZeta] }
-      | IDENT "delta"; d = delta_flag -> { [d] }
+      | IDENT "delta"; d = delta_reductions -> { [d] }
     ] ]
   ;
-  delta_flag:
+  delta_reductions:
     [ [ "-"; "["; idl = LIST1 smart_global; "]" -> { FDeltaBut idl }
       | "["; idl = LIST1 smart_global; "]" -> { FConst idl }
       | -> { FDeltaBut [] }
     ] ]
   ;
-  strategy_flag:
-    [ [ s = LIST1 red_flag -> { Redops.make_red_flag (List.flatten s) }
-      | d = delta_flag -> { all_with d }
+  reductions:
+    [ [ s = LIST1 reduction -> { Redops.make_red_flag (List.flatten s) }
+      | d = delta_reductions -> { all_with d }
     ] ]
   ;
   red_expr:
     [ [ IDENT "red" -> { Red false }
       | IDENT "hnf" -> { Hnf }
-      | IDENT "simpl"; d = delta_flag; po = OPT ref_or_pattern_occ -> { Simpl (all_with d,po) }
-      | IDENT "cbv"; s = strategy_flag -> { Cbv s }
-      | IDENT "cbn"; s = strategy_flag -> { Cbn s }
-      | IDENT "lazy"; s = strategy_flag -> { Lazy s }
-      | IDENT "compute"; delta = delta_flag -> { Cbv (all_with delta) }
-      | IDENT "vm_compute"; po = OPT ref_or_pattern_occ -> { CbvVm po }
-      | IDENT "native_compute"; po = OPT ref_or_pattern_occ -> { CbvNative po }
-      | IDENT "unfold"; ul = LIST1 unfold_occ SEP "," -> { Unfold ul }
+      | IDENT "simpl"; d = delta_reductions; po = OPT ref_or_pattern_occs -> { Simpl (all_with d,po) }
+      | IDENT "cbv"; s = reductions -> { Cbv s }
+      | IDENT "cbn"; s = reductions -> { Cbn s }
+      | IDENT "lazy"; s = reductions -> { Lazy s }
+      | IDENT "compute"; delta = delta_reductions -> { Cbv (all_with delta) }
+      | IDENT "vm_compute"; po = OPT ref_or_pattern_occs -> { CbvVm po }
+      | IDENT "native_compute"; po = OPT ref_or_pattern_occs -> { CbvNative po }
+      | IDENT "unfold"; ul = LIST1 reference_occs SEP "," -> { Unfold ul }
       | IDENT "fold"; cl = LIST1 constr -> { Fold cl }
-      | IDENT "pattern"; pl = LIST1 pattern_occ SEP"," -> { Pattern pl }
+      | IDENT "pattern"; pl = LIST1 pattern_occs SEP"," -> { Pattern pl }
       | s = IDENT -> { ExtraRedExpr s } ] ]
   ;
   hypident:
@@ -389,7 +389,7 @@ GRAMMAR EXTEND Gram
         id,InHypValueOnly }
     ] ]
   ;
-  hypident_occ:
+  hyp_occs:
     [ [ h=hypident; occs=occs ->
         { let (id,l) = h in
         let id : lident = id in
@@ -398,13 +398,13 @@ GRAMMAR EXTEND Gram
   in_clause:
     [ [ "*"; occs=occs ->
           { {onhyps=None; concl_occs=occs} }
-      | "*"; "|-"; occs=concl_occ ->
+      | "*"; "|-"; occs=concl_occs ->
           { {onhyps=None; concl_occs=occs} }
-      | "|-"; occs=concl_occ ->
+      | "|-"; occs=concl_occs ->
           { {onhyps=Some []; concl_occs=occs} }
-      | hl = LIST1 hypident_occ SEP ","; "|-"; occs=concl_occ ->
+      | hl = LIST1 hyp_occs SEP ","; "|-"; occs=concl_occs ->
           { {onhyps=Some hl; concl_occs=occs} }
-      | hl = LIST1 hypident_occ SEP "," ->
+      | hl = LIST1 hyp_occs SEP "," ->
           { {onhyps=Some hl; concl_occs=NoOccurrences} } ] ]
   ;
   clause_dft_concl:
@@ -421,7 +421,7 @@ GRAMMAR EXTEND Gram
       | "at"; occs = occs_nums -> { Some {onhyps=Some[]; concl_occs=occs} }
       | -> { None } ] ]
   ;
-  concl_occ:
+  concl_occs:
     [ [ "*"; occs = occs -> { occs }
       | -> { NoOccurrences } ] ]
   ;
@@ -632,7 +632,7 @@ GRAMMAR EXTEND Gram
           CAst.make ~loc @@ TacAtom (TacGeneralize (List.map gen_everywhere (c::l))) }
       | IDENT "generalize"; c = constr; lookup_at_as_comma; nl = occs;
           na = as_name;
-          l = LIST0 [","; c = pattern_occ; na = as_name -> { (c,na) } ] ->
+          l = LIST0 [","; c = pattern_occs; na = as_name -> { (c,na) } ] ->
           { CAst.make ~loc @@ TacAtom (TacGeneralize (((nl,c),na)::l)) }
 
       (* Derived basic tactics *)
@@ -678,25 +678,25 @@ GRAMMAR EXTEND Gram
           { CAst.make ~loc @@ TacAtom (TacReduce (Red false, cl)) }
       | IDENT "hnf"; cl = clause_dft_concl ->
           { CAst.make ~loc @@ TacAtom (TacReduce (Hnf, cl)) }
-      | IDENT "simpl"; d = delta_flag; po = OPT ref_or_pattern_occ; cl = clause_dft_concl ->
+      | IDENT "simpl"; d = delta_reductions; po = OPT ref_or_pattern_occs; cl = clause_dft_concl ->
           { CAst.make ~loc @@ TacAtom (TacReduce (Simpl (all_with d, po), cl)) }
-      | IDENT "cbv"; s = strategy_flag; cl = clause_dft_concl ->
+      | IDENT "cbv"; s = reductions; cl = clause_dft_concl ->
           { CAst.make ~loc @@ TacAtom (TacReduce (Cbv s, cl)) }
-      | IDENT "cbn"; s = strategy_flag; cl = clause_dft_concl ->
+      | IDENT "cbn"; s = reductions; cl = clause_dft_concl ->
           { CAst.make ~loc @@ TacAtom (TacReduce (Cbn s, cl)) }
-      | IDENT "lazy"; s = strategy_flag; cl = clause_dft_concl ->
+      | IDENT "lazy"; s = reductions; cl = clause_dft_concl ->
           { CAst.make ~loc @@ TacAtom (TacReduce (Lazy s, cl)) }
-      | IDENT "compute"; delta = delta_flag; cl = clause_dft_concl ->
+      | IDENT "compute"; delta = delta_reductions; cl = clause_dft_concl ->
           { CAst.make ~loc @@ TacAtom (TacReduce (Cbv (all_with delta), cl)) }
-      | IDENT "vm_compute"; po = OPT ref_or_pattern_occ; cl = clause_dft_concl ->
+      | IDENT "vm_compute"; po = OPT ref_or_pattern_occs; cl = clause_dft_concl ->
           { CAst.make ~loc @@ TacAtom (TacReduce (CbvVm po, cl)) }
-      | IDENT "native_compute"; po = OPT ref_or_pattern_occ; cl = clause_dft_concl ->
+      | IDENT "native_compute"; po = OPT ref_or_pattern_occs; cl = clause_dft_concl ->
           { CAst.make ~loc @@ TacAtom (TacReduce (CbvNative po, cl)) }
-      | IDENT "unfold"; ul = LIST1 unfold_occ SEP ","; cl = clause_dft_concl ->
+      | IDENT "unfold"; ul = LIST1 reference_occs SEP ","; cl = clause_dft_concl ->
           { CAst.make ~loc @@ TacAtom (TacReduce (Unfold ul, cl)) }
       | IDENT "fold"; l = LIST1 constr; cl = clause_dft_concl ->
           { CAst.make ~loc @@ TacAtom (TacReduce (Fold l, cl)) }
-      | IDENT "pattern"; pl = LIST1 pattern_occ SEP","; cl = clause_dft_concl ->
+      | IDENT "pattern"; pl = LIST1 pattern_occs SEP","; cl = clause_dft_concl ->
           { CAst.make ~loc @@ TacAtom (TacReduce (Pattern pl, cl)) }
 
       (* Change ne doit pas s'appliquer dans un Definition t := Eval ... *)

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -446,14 +446,14 @@ GRAMMAR EXTEND Gram
   ;
   fixdecl:
     [ [ "("; id = ident; bl=LIST0 simple_binder; ann=struct_annot;
-        ":"; ty=lconstr; ")" -> { (loc, id, bl, ann, ty) } ] ]
+        ":"; ty=type_; ")" -> { (loc, id, bl, ann, ty) } ] ]
   ;
   struct_annot:
     [ [ "{"; IDENT "struct"; id=name; "}" -> { Some id }
       | -> { None } ] ]
   ;
   cofixdecl:
-    [ [ "("; id = ident; bl=LIST0 simple_binder; ":"; ty=lconstr; ")" ->
+    [ [ "("; id = ident; bl=LIST0 simple_binder; ":"; ty=type_; ")" ->
         { (loc, id, bl, None, ty) } ] ]
   ;
   bindings_with_parameters:
@@ -584,21 +584,21 @@ GRAMMAR EXTEND Gram
 
       (* Alternative syntax for "assert c as id by tac" *)
       | IDENT "assert"; test_lpar_id_colon; "("; lid = identref; ":";
-          c = lconstr; ")"; tac=by_tactic ->
+          c = type_; ")"; tac=by_tactic ->
           { let { CAst.loc = loc; v = id } = lid in
           CAst.make ?loc @@ TacAtom ( TacAssert (false,true,Some tac,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
       | IDENT "eassert"; test_lpar_id_colon; "("; lid = identref; ":";
-          c = lconstr; ")"; tac=by_tactic ->
+          c = type_; ")"; tac=by_tactic ->
           { let { CAst.loc = loc; v = id } = lid in
           CAst.make ?loc @@ TacAtom ( TacAssert (true,true,Some tac,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
 
       (* Alternative syntax for "enough c as id by tac" *)
       | IDENT "enough"; test_lpar_id_colon; "("; lid = identref; ":";
-          c = lconstr; ")"; tac=by_tactic ->
+          c = type_; ")"; tac=by_tactic ->
           { let { CAst.loc = loc; v = id } = lid in
           CAst.make ?loc @@ TacAtom ( TacAssert (false,false,Some tac,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
       | IDENT "eenough"; test_lpar_id_colon; "("; lid = identref; ":";
-          c = lconstr; ")"; tac=by_tactic ->
+          c = type_; ")"; tac=by_tactic ->
           { let { CAst.loc = loc; v = id } = lid in
           CAst.make ?loc @@ TacAtom ( TacAssert (true,false,Some tac,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
 

--- a/plugins/ltac2/g_ltac2.mlg
+++ b/plugins/ltac2/g_ltac2.mlg
@@ -655,17 +655,17 @@ GRAMMAR EXTEND Gram
         { id,Locus.InHypValueOnly }
     ] ]
   ;
-  hypident_occ:
+  hyp_occs:
     [ [ h=hypident; occs=occs -> { let (id,l) = h in ((occs,id),l) } ] ]
   ;
   in_clause:
     [ [ "*"; occs=occs ->
         { { q_onhyps = None; q_concl_occs = occs } }
-      | "*"; "|-"; occs = concl_occ ->
+      | "*"; "|-"; occs = concl_occs ->
         { { q_onhyps = None; q_concl_occs = occs } }
-      | hl = LIST0 hypident_occ SEP ","; "|-"; occs = concl_occ ->
+      | hl = LIST0 hyp_occs SEP ","; "|-"; occs = concl_occs ->
         { { q_onhyps = Some hl; q_concl_occs = occs } }
-      | hl = LIST0 hypident_occ SEP "," ->
+      | hl = LIST0 hyp_occs SEP "," ->
         { { q_onhyps = Some hl; q_concl_occs = CAst.make ~loc QNoOccurrences } }
     ] ]
   ;
@@ -678,7 +678,7 @@ GRAMMAR EXTEND Gram
   q_clause:
     [ [ cl = clause -> { cl } ] ]
   ;
-  concl_occ:
+  concl_occs:
     [ [ "*"; occs = occs -> { occs }
       | -> { CAst.make ~loc QNoOccurrences }
     ] ]
@@ -768,7 +768,7 @@ GRAMMAR EXTEND Gram
       | IDENT "fix" -> { CAst.make ~loc @@ QFix }
       | IDENT "cofix" -> { CAst.make ~loc @@ QCofix }
       | IDENT "zeta" -> { CAst.make ~loc @@ QZeta }
-      | IDENT "delta"; d = delta_flag -> { d }
+      | IDENT "delta"; d = delta_reductions -> { d }
     ] ]
   ;
   refglobal:
@@ -783,21 +783,21 @@ GRAMMAR EXTEND Gram
   refglobals:
     [ [ gl = LIST1 refglobal -> { CAst.make ~loc gl } ] ]
   ;
-  delta_flag:
+  delta_reductions:
     [ [ "-"; "["; idl = refglobals; "]" -> { CAst.make ~loc @@ QDeltaBut idl }
       | "["; idl = refglobals; "]" -> { CAst.make ~loc @@ QConst idl }
       | -> { CAst.make ~loc @@ QDeltaBut (CAst.make ~loc []) }
     ] ]
   ;
-  strategy_flag:
+  reductions:
     [ [ s = LIST1 ltac2_red_flag -> { CAst.make ~loc s }
-      | d = delta_flag ->
+      | d = delta_reductions ->
       { CAst.make ~loc
           [CAst.make ~loc QBeta; CAst.make ~loc QIota; CAst.make ~loc QZeta; d] }
     ] ]
   ;
   q_strategy_flag:
-    [ [ flag = strategy_flag -> { flag } ] ]
+    [ [ flag = reductions -> { flag } ] ]
   ;
   hintdb:
     [ [ "*" -> { CAst.make ~loc @@ QHintAll }

--- a/test-suite/output/PrintGrammar.out
+++ b/test-suite/output/PrintGrammar.out
@@ -41,10 +41,10 @@ Entry term is
 [ "200" RIGHTA
   [ binder_constr ]
 | "100" RIGHTA
-  [ SELF; "<:"; term LEVEL "200"
-  | SELF; "<<:"; term LEVEL "200"
-  | SELF; ":>"; term LEVEL "200"
-  | SELF; ":"; term LEVEL "200" ]
+  [ SELF; "<:"; type_
+  | SELF; "<<:"; type_
+  | SELF; ":>"; type_
+  | SELF; ":"; type_ ]
 | "99" RIGHTA
   [ SELF; "->"; term LEVEL "200" ]
 | "95" RIGHTA

--- a/test-suite/output/PrintGrammarConstr.out
+++ b/test-suite/output/PrintGrammarConstr.out
@@ -32,10 +32,10 @@ Entry term is
 [ "200" RIGHTA
   [ binder_constr ]
 | "100" RIGHTA
-  [ SELF; "<:"; term LEVEL "200"
-  | SELF; "<<:"; term LEVEL "200"
-  | SELF; ":>"; term LEVEL "200"
-  | SELF; ":"; term LEVEL "200" ]
+  [ SELF; "<:"; type_
+  | SELF; "<<:"; type_
+  | SELF; ":>"; type_
+  | SELF; ":"; type_ ]
 | "99" RIGHTA
   [  ]
 | "90" RIGHTA

--- a/vernac/g_proofs.mlg
+++ b/vernac/g_proofs.mlg
@@ -54,7 +54,7 @@ GRAMMAR EXTEND Gram
     | ":"; l = LIST1 [id = IDENT -> { id } ] -> { l } ] ]
   ;
   command: TOP
-    [ [ IDENT "Goal"; c = lconstr ->
+    [ [ IDENT "Goal"; c = type_ ->
         { VernacSynPure (VernacDefinition (Decls.(NoDischarge, Definition), ((CAst.make ~loc Names.Anonymous), None), ProveBody ([], c))) }
       | IDENT "Proof" -> { VernacSynPure (VernacProof (None,None)) }
       | IDENT "Proof"; IDENT "using"; l = G_vernac.section_subset_expr ->
@@ -128,7 +128,7 @@ GRAMMAR EXTEND Gram
     ;
   constr_body:
     [ [ ":="; c = lconstr -> { c }
-      | ":"; t = lconstr; ":="; c = lconstr -> { CAst.make ~loc @@ CCast(c,Some C.DEFAULTcast, t) } ] ]
+      | ":"; t = type_; ":="; c = lconstr -> { CAst.make ~loc @@ CCast(c,Some C.DEFAULTcast, t) } ] ]
   ;
   mode:
     [ [ l = LIST1 [ "+" -> { ModeInput }

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -215,9 +215,9 @@ GRAMMAR EXTEND Gram
 
   gallina:
       (* Definition, Theorem, Variable, Axiom, ... *)
-    [ [ thm = thm_token; id = ident_decl; bl = binders; ":"; c = lconstr;
+    [ [ thm = thm_token; id = ident_decl; bl = binders; ":"; c = type_;
         l = LIST0
-          [ "with"; id = ident_decl; bl = binders; ":"; c = lconstr ->
+          [ "with"; id = ident_decl; bl = binders; ":"; c = type_ ->
           { (id,(bl,c)) } ] ->
           { VernacStartTheoremProof (thm, (id,(bl,c))::l) }
       | stre = assumption_token; nl = inline; bl = assum_list ->
@@ -364,9 +364,9 @@ GRAMMAR EXTEND Gram
         { match c.CAst.v with
           | CCast(c, Some C.DEFAULTcast, t) -> DefineBody (bl, red, c, Some t)
           | _ -> DefineBody (bl, red, c, None) }
-    | bl = binders; ":"; t = lconstr; ":="; red = reduce; c = lconstr ->
+    | bl = binders; ":"; t = type_; ":="; red = reduce; c = lconstr ->
         { DefineBody (bl, red, c, Some t) }
-    | bl = binders; ":"; t = lconstr ->
+    | bl = binders; ":"; t = type_ ->
         { ProveBody (bl, t) } ] ]
   ;
   reduce:
@@ -775,7 +775,7 @@ GRAMMAR EXTEND Gram
           { VernacSynPure (VernacContext (List.flatten c)) }
 
       | IDENT "Instance"; namesup = instance_name; ":";
-         t = term LEVEL "200";
+         t = type_;
          info = hint_info ;
          props = [ ":="; "{"; r = record_declaration; "}" -> { Some (true,r) } |
              ":="; c = lconstr -> { Some (false,c) } | -> { None } ] ->
@@ -899,7 +899,7 @@ GRAMMAR EXTEND Gram
     [ [ "("; a = simple_reserv; ")" -> { a } ] ]
   ;
   simple_reserv:
-    [ [ idl = LIST1 identref; ":"; c = lconstr -> { (idl,c) } ] ]
+    [ [ idl = LIST1 identref; ":"; c = type_ -> { (idl,c) } ] ]
   ;
 
 END

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -705,7 +705,7 @@ GRAMMAR EXTEND Gram
   section_subset_expr:
     [ [ test_only_starredidentrefs; l = LIST0 starred_ident_ref ->
           { starredidentreflist_to_expr l }
-      | e = ssexpr -> { e } ]]
+      | e = section_var_expr -> { e } ]]
   ;
   starred_ident_ref:
     [ [ i = identref -> { SsSingl i }
@@ -713,12 +713,12 @@ GRAMMAR EXTEND Gram
       | "Type" -> { SsType }
       | "Type"; "*" -> { SsFwdClose SsType } ]]
   ;
-  ssexpr:
+  section_var_expr:
     [ "35"
-      [ "-"; e = ssexpr -> { SsCompl e } ]
+      [ "-"; e = section_var_expr -> { SsCompl e } ]
     | "50"
-      [ e1 = ssexpr; "-"; e2 = ssexpr-> { SsSubstr(e1,e2) }
-      | e1 = ssexpr; "+"; e2 = ssexpr-> { SsUnion(e1,e2) } ]
+      [ e1 = section_var_expr; "-"; e2 = section_var_expr-> { SsSubstr(e1,e2) }
+      | e1 = section_var_expr; "+"; e2 = section_var_expr-> { SsUnion(e1,e2) } ]
     | "0"
       [ i = starred_ident_ref -> { i }
       | "()" -> { SsEmpty }
@@ -726,8 +726,8 @@ GRAMMAR EXTEND Gram
           { starredidentreflist_to_expr l }
       | "("; test_only_starredidentrefs; l = LIST0 starred_ident_ref; ")"; "*" ->
           { SsFwdClose(starredidentreflist_to_expr l) }
-      | "("; e = ssexpr; ")"-> { e }
-      | "("; e = ssexpr; ")"; "*" -> { SsFwdClose e } ] ]
+      | "("; e = section_var_expr; ")"-> { e }
+      | "("; e = section_var_expr; ")"; "*" -> { SsFwdClose e } ] ]
   ;
 END
 

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -486,7 +486,7 @@ GRAMMAR EXTEND Gram
       | -> { [] }
     ] ]
   ;
-  field_body:
+  field_spec:
     [ [ l = binders; oc = of_type_inst;
          t = lconstr -> { fun id -> (oc,AssumExpr (id,l,t)) }
       | l = binders; oc = of_type_inst;
@@ -502,7 +502,7 @@ GRAMMAR EXTEND Gram
   ;
   record_binder:
     [ [ id = name -> { ((NoCoercion,NoInstance),AssumExpr(id, [], CAst.make ~loc @@ CHole (None, IntroAnonymous))) }
-      | id = name; f = field_body -> { f id } ] ]
+      | id = name; f = field_spec -> { f id } ] ]
   ;
   assum_list:
     [ [ bl = LIST1 assum_coe -> { bl } | b = assumpt -> { [b] } ] ]

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -55,6 +55,7 @@ let of_type_inst = Entry.make "of_type_inst"
 let section_subset_expr = Entry.make "section_subset_expr"
 let scope_delimiter = Entry.make "scope_delimiter"
 let syntax_modifiers = Entry.make "syntax_modifiers"
+let scope = Entry.make "scope"
 
 let make_bullet s =
   let open Proof_bullet in
@@ -375,7 +376,7 @@ GRAMMAR EXTEND Gram
   notation_declaration:
     [ [ ntn = lstring; ":="; c = constr;
         modl = syntax_modifiers;
-        scopt = OPT [ ":"; sc = IDENT -> { sc } ] ->
+        scopt = OPT [ ":"; sc = scope_name -> { sc } ] ->
       { { ntn_decl_string = ntn; ntn_decl_interp = c;
           ntn_decl_scope = scopt;
           ntn_decl_modifiers = modl;
@@ -836,7 +837,7 @@ GRAMMAR EXTEND Gram
       ] ]
   ;
   scope_delimiter:
-    [ [ "%"; key = IDENT -> { key } ] ]
+    [ [ "%"; key = scope -> { key } ] ]
   ;
   argument_spec: [
        [ b = OPT "!"; id = name ; s = LIST0 scope_delimiter ->
@@ -904,7 +905,8 @@ GRAMMAR EXTEND Gram
 END
 
 GRAMMAR EXTEND Gram
-  GLOBAL: command query_command coercion_class gallina_ext search_query search_queries;
+  GLOBAL: command query_command coercion_class gallina_ext search_query search_queries scope
+    scope_key;
 
   gallina_ext: TOP
     [ [ IDENT "Export"; "Set"; table = setting_name; v = option_setting ->
@@ -912,6 +914,11 @@ GRAMMAR EXTEND Gram
       | IDENT "Export"; IDENT "Unset"; table = setting_name ->
           { VernacSynterp (VernacSetOption (true, table, OptionUnset)) }
     ] ];
+
+  scope:
+    [ [ sk = scope_key -> { sk }
+      | sn = scope_name -> { sn } ] ]
+  ;
 
   command:
     [ [ IDENT "Comments"; l = LIST0 comment -> { VernacSynPure (VernacComments l) }
@@ -923,7 +930,7 @@ GRAMMAR EXTEND Gram
            { VernacSynPure (VernacDeclareInstance (id, bl, t, info)) }
 
       (* Should be in syntax, but camlp5 would not factorize *)
-      | IDENT "Declare"; IDENT "Scope"; sc = IDENT ->
+      | IDENT "Declare"; IDENT "Scope"; sc = scope_name ->
           { VernacSynPure (VernacDeclareScope sc) }
 
       (* System directory *)
@@ -1051,8 +1058,8 @@ GRAMMAR EXTEND Gram
       | IDENT "Hint"; "*" -> { PrintHintDb }
       | IDENT "HintDb"; s = IDENT -> { PrintHintDbName s }
       | IDENT "Scopes" -> { PrintScopes }
-      | IDENT "Scope"; s = IDENT -> { PrintScope s }
-      | IDENT "Visibility"; s = OPT IDENT -> { PrintVisibility s }
+      | IDENT "Scope"; s = scope_name -> { PrintScope s }
+      | IDENT "Visibility"; s = OPT scope_name -> { PrintVisibility s }
       | IDENT "Implicit"; qid = smart_global -> { PrintImplicit qid }
       | b = [ IDENT "Sorted" -> { true } | -> { false } ]; IDENT "Universes";
         g = OPT printunivs_subgraph; fopt = OPT ne_string ->
@@ -1201,18 +1208,18 @@ GRAMMAR EXTEND Gram
   GLOBAL: syntax syntax_modifiers;
 
   syntax:
-   [ [ IDENT "Open"; IDENT "Scope"; sc = IDENT ->
+   [ [ IDENT "Open"; IDENT "Scope"; sc = scope ->
          { VernacSynPure (VernacOpenCloseScope (true,sc)) }
 
-     | IDENT "Close"; IDENT "Scope"; sc = IDENT ->
+     | IDENT "Close"; IDENT "Scope"; sc = scope ->
          { VernacSynPure (VernacOpenCloseScope (false,sc)) }
 
-     | IDENT "Delimit"; IDENT "Scope"; sc = IDENT; "with"; key = IDENT ->
+     | IDENT "Delimit"; IDENT "Scope"; sc = scope_name; "with"; key = scope_key ->
          { VernacSynPure(VernacDelimiters (sc, Some key)) }
-     | IDENT "Undelimit"; IDENT "Scope"; sc = IDENT ->
+     | IDENT "Undelimit"; IDENT "Scope"; sc = scope_name ->
          { VernacSynPure(VernacDelimiters (sc, None)) }
 
-     | IDENT "Bind"; IDENT "Scope"; sc = IDENT; "with";
+     | IDENT "Bind"; IDENT "Scope"; sc = scope_name; "with";
        refl = LIST1 coercion_class -> { VernacSynPure (VernacBindScope (sc,refl)) }
 
      | IDENT "Infix"; ntn_decl = notation_declaration ->
@@ -1262,7 +1269,7 @@ GRAMMAR EXTEND Gram
       | "in"; IDENT "constr" -> { EnableNotationEntry (CAst.make ~loc InConstrEntry) } ] ]
   ;
   opt_scope:
-    [ [ ":"; sc = IDENT -> { Some (NotationInScope sc) }
+    [ [ ":"; sc = scope_name -> { Some (NotationInScope sc) }
       | ":"; IDENT "no"; IDENT "scope" -> { Some LastLonelyNotation }
       | -> { None } ] ]
   ;

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -703,11 +703,11 @@ GRAMMAR EXTEND Gram
   ;
   (* Proof using *)
   section_subset_expr:
-    [ [ test_only_starredidentrefs; l = LIST0 starredidentref ->
+    [ [ test_only_starredidentrefs; l = LIST0 starred_ident_ref ->
           { starredidentreflist_to_expr l }
       | e = ssexpr -> { e } ]]
   ;
-  starredidentref:
+  starred_ident_ref:
     [ [ i = identref -> { SsSingl i }
       | i = identref; "*" -> { SsFwdClose(SsSingl i) }
       | "Type" -> { SsType }
@@ -720,11 +720,11 @@ GRAMMAR EXTEND Gram
       [ e1 = ssexpr; "-"; e2 = ssexpr-> { SsSubstr(e1,e2) }
       | e1 = ssexpr; "+"; e2 = ssexpr-> { SsUnion(e1,e2) } ]
     | "0"
-      [ i = starredidentref -> { i }
+      [ i = starred_ident_ref -> { i }
       | "()" -> { SsEmpty }
-      | "("; test_only_starredidentrefs; l = LIST0 starredidentref; ")"->
+      | "("; test_only_starredidentrefs; l = LIST0 starred_ident_ref; ")"->
           { starredidentreflist_to_expr l }
-      | "("; test_only_starredidentrefs; l = LIST0 starredidentref; ")"; "*" ->
+      | "("; test_only_starredidentrefs; l = LIST0 starred_ident_ref; ")"; "*" ->
           { SsFwdClose(starredidentreflist_to_expr l) }
       | "("; e = ssexpr; ")"-> { e }
       | "("; e = ssexpr; ")"; "*" -> { SsFwdClose e } ] ]


### PR DESCRIPTION
A number of nonterminals that were renamed in `common.edit_mlg` have now been renamed in the mlgs for consistency and developer sanity.  This PR also introduces a few nonterminals that convey info about semantics such as `scope_key`, which is just an `IDENT`.

I also renamed a number of routines related to hints so that their names are consistent with the new nonterminal names in the mlg.

@herbelin Can you be the assignee?