### PR TITLE
Support parsing Ltac2 array literals

### DIFF
--- a/doc/changelog/06-Ltac2-language/16859-ltac2_parse_arrays.rst
+++ b/doc/changelog/06-Ltac2-language/16859-ltac2_parse_arrays.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  Support for parsing Ltac2 array literals ``[| ... |]``
+  (`#16859 <https://github.com/coq/coq/pull/16859>`_,
+  fixes `#13976 <https://github.com/coq/coq/issues/13976>`_,
+  by Samuel Gruetter).

--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -278,13 +278,11 @@ There is dedicated syntax for list and array literals.
    ltac2_expr0 ::= ( @ltac2_expr )
    | ( @ltac2_expr : @ltac2_type )
    | ()
-   | @array_literal
-   | @list_literal
+   | [ %| {*; @ltac2_expr5 } %| ]
+   | [ {*; @ltac2_expr5 } ]
    | %{ @ltac2_expr0 with {? {+; @tac2rec_fieldexpr } {? ; } } %}
    | %{ {? {+; @tac2rec_fieldexpr } {? ; } } %}
    | @ltac2_tactic_atom
-   array_literal ::= [ %| {*; @ltac2_expr5 } %| ]
-   list_literal ::= [ {*; @ltac2_expr5 } ]
    tac2rec_fieldpats ::= @tac2rec_fieldpat ; {? @tac2rec_fieldpats }
    | @tac2rec_fieldpat ;
    | @tac2rec_fieldpat

--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -278,10 +278,13 @@ There is dedicated syntax for list and array literals.
    ltac2_expr0 ::= ( @ltac2_expr )
    | ( @ltac2_expr : @ltac2_type )
    | ()
-   | [ {*; @ltac2_expr5 } ]
+   | @array_literal
+   | @list_literal
    | %{ @ltac2_expr0 with {? {+; @tac2rec_fieldexpr } {? ; } } %}
    | %{ {? {+; @tac2rec_fieldexpr } {? ; } } %}
    | @ltac2_tactic_atom
+   array_literal ::= [ %| {*; @ltac2_expr5 } %| ]
+   list_literal ::= [ {*; @ltac2_expr5 } ]
    tac2rec_fieldpats ::= @tac2rec_fieldpat ; {? @tac2rec_fieldpats }
    | @tac2rec_fieldpat ;
    | @tac2rec_fieldpat

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -2155,6 +2155,8 @@ SPLICE: [
 | ltac2_binder
 | branch
 | anti
+| array_literal
+| list_literal
 ]
 
 ltac2_expr5: [

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -3354,10 +3354,19 @@ ltac2_expr0: [
 | "(" ltac2_expr6 ":" ltac2_type5 ")"      (* ltac2 plugin *)
 | "()"      (* ltac2 plugin *)
 | "(" ")"      (* ltac2 plugin *)
-| "[" LIST0 ltac2_expr5 SEP ";" "]"      (* ltac2 plugin *)
+| array_literal      (* ltac2 plugin *)
+| list_literal      (* ltac2 plugin *)
 | "{" test_ident_with_or_lpar_or_rbrac ltac2_expr0 "with" tac2rec_fieldexprs "}"      (* ltac2 plugin *)
 | "{" tac2rec_fieldexprs "}"      (* ltac2 plugin *)
 | G_LTAC2_tactic_atom      (* ltac2 plugin *)
+]
+
+array_literal: [
+| test_array_opening "[" "|" LIST0 ltac2_expr5 SEP ";" test_array_closing "|" "]"      (* ltac2 plugin *)
+]
+
+list_literal: [
+| "[" LIST0 ltac2_expr5 SEP ";" "]"      (* ltac2 plugin *)
 ]
 
 G_LTAC2_branches: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -2367,10 +2367,19 @@ ltac2_expr0: [
 | "(" ltac2_expr ")"      (* ltac2 plugin *)
 | "(" ltac2_expr ":" ltac2_type ")"      (* ltac2 plugin *)
 | "()"      (* ltac2 plugin *)
-| "[" LIST0 ltac2_expr5 SEP ";" "]"      (* ltac2 plugin *)
+| array_literal      (* ltac2 plugin *)
+| list_literal      (* ltac2 plugin *)
 | "{" ltac2_expr0 "with" OPT ( LIST1 tac2rec_fieldexpr SEP ";" OPT ";" ) "}"      (* ltac2 plugin *)
 | "{" OPT ( LIST1 tac2rec_fieldexpr SEP ";" OPT ";" ) "}"      (* ltac2 plugin *)
 | ltac2_tactic_atom      (* ltac2 plugin *)
+]
+
+array_literal: [
+| "[" "|" LIST0 ltac2_expr5 SEP ";" "|" "]"      (* ltac2 plugin *)
+]
+
+list_literal: [
+| "[" LIST0 ltac2_expr5 SEP ";" "]"      (* ltac2 plugin *)
 ]
 
 tac2rec_fieldpats: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -2367,19 +2367,11 @@ ltac2_expr0: [
 | "(" ltac2_expr ")"      (* ltac2 plugin *)
 | "(" ltac2_expr ":" ltac2_type ")"      (* ltac2 plugin *)
 | "()"      (* ltac2 plugin *)
-| array_literal      (* ltac2 plugin *)
-| list_literal      (* ltac2 plugin *)
+| "[" "|" LIST0 ltac2_expr5 SEP ";" "|" "]"      (* ltac2 plugin *)
+| "[" LIST0 ltac2_expr5 SEP ";" "]"      (* ltac2 plugin *)
 | "{" ltac2_expr0 "with" OPT ( LIST1 tac2rec_fieldexpr SEP ";" OPT ";" ) "}"      (* ltac2 plugin *)
 | "{" OPT ( LIST1 tac2rec_fieldexpr SEP ";" OPT ";" ) "}"      (* ltac2 plugin *)
 | ltac2_tactic_atom      (* ltac2 plugin *)
-]
-
-array_literal: [
-| "[" "|" LIST0 ltac2_expr5 SEP ";" "|" "]"      (* ltac2 plugin *)
-]
-
-list_literal: [
-| "[" LIST0 ltac2_expr5 SEP ";" "]"      (* ltac2 plugin *)
 ]
 
 tac2rec_fieldpats: [

--- a/plugins/ltac2/g_ltac2.mlg
+++ b/plugins/ltac2/g_ltac2.mlg
@@ -77,6 +77,18 @@ let test_ident_with_or_lpar_or_rbrac =
     (lk_ident >> lk_kw "with") <+> lk_kw "(" <+> lk_kw "{"
   end
 
+let test_array_opening =
+  let open Pcoq.Lookahead in
+  to_entry "test_array_opening" begin
+    lk_kw "[" >> lk_kw "|" >> check_no_space
+  end
+
+let test_array_closing =
+  let open Pcoq.Lookahead in
+  to_entry "test_array_closing" begin
+    lk_kw "|" >> lk_kw "]" >> check_no_space
+  end
+
 let ltac2_expr = Tac2entries.Pltac.ltac2_expr
 let _ltac2_expr = ltac2_expr
 let ltac2_type = Entry.create "ltac2_type"
@@ -200,14 +212,22 @@ GRAMMAR EXTEND Gram
         { CAst.make ~loc @@ CTacCst (AbsKn (Tuple 0)) }
       | "("; ")" ->
         { CAst.make ~loc @@ CTacCst (AbsKn (Tuple 0)) }
-      | "["; a = LIST0 ltac2_expr LEVEL "5" SEP ";"; "]" ->
-        { Tac2quote.of_list ~loc (fun x -> x) a }
+      | a = array_literal -> { a }
+      | a = list_literal -> { a }
       | "{"; test_ident_with_or_lpar_or_rbrac; e = ltac2_expr LEVEL "0"; "with"; a = tac2rec_fieldexprs; "}" ->
         { CAst.make ~loc @@ CTacRec (Some e, a) }
       | "{"; a = tac2rec_fieldexprs; "}" ->
         { CAst.make ~loc @@ CTacRec (None, a) }
       | a = tactic_atom -> { a } ]
     ]
+  ;
+  array_literal:
+  [ [ test_array_opening; "["; "|"; a = LIST0 ltac2_expr LEVEL "5" SEP ";"; test_array_closing; "|"; "]" ->
+      { Tac2quote.array_of_list (Tac2quote.of_list ~loc (fun x -> x) a) } ] ]
+  ;
+  list_literal:
+  [ [ "["; a = LIST0 ltac2_expr LEVEL "5" SEP ";"; "]" ->
+       { Tac2quote.of_list ~loc (fun x -> x) a } ] ]
   ;
   branches:
   [ [ -> { [] }

--- a/plugins/ltac2/tac2quote.ml
+++ b/plugins/ltac2/tac2quote.ml
@@ -134,6 +134,10 @@ let rec of_list ?loc f = function
 | e :: l ->
   constructor ?loc (coq_core "::") [f e; of_list ?loc f l]
 
+let array_of_list ?loc l =
+  let of_list = global_ref ?loc (kername array_prefix "of_list")  in
+  CAst.make ?loc @@ CTacApp (of_list, [l])
+
 let of_qhyp {loc;v=h} = match h with
 | QAnonHyp n -> std_constructor ?loc "AnonHyp" [of_int n]
 | QNamedHyp id -> std_constructor ?loc "NamedHyp" [of_ident id]

--- a/plugins/ltac2/tac2quote.mli
+++ b/plugins/ltac2/tac2quote.mli
@@ -42,6 +42,8 @@ val of_preterm : ?delimiters:Id.t list -> Constrexpr.constr_expr -> raw_tacexpr
 
 val of_list : ?loc:Loc.t -> ('a -> raw_tacexpr) -> 'a list -> raw_tacexpr
 
+val array_of_list : ?loc:Loc.t -> raw_tacexpr -> raw_tacexpr
+
 val of_bindings : bindings -> raw_tacexpr
 
 val of_intro_pattern : intro_pattern -> raw_tacexpr

--- a/test-suite/ltac2/array_notation.v
+++ b/test-suite/ltac2/array_notation.v
@@ -19,9 +19,23 @@ Proof.
   split > [|constructor]. constructor.
 Qed.
 
+Goal forall a b: nat, a = b -> True /\ a = b /\ True.
+Proof.
+  intros.
+  (split > [|split]) > [|exact H|].
+  all: constructor.
+Qed.
+
 Set Default Proof Mode "Classic".
 
 Goal True /\ True.
 Proof.
   split; [|constructor]. constructor.
+Qed.
+
+Goal forall a b: nat, a = b -> True /\ a = b /\ True.
+Proof.
+  intros.
+  (split; [|split]); [|exact H|].
+  all: constructor.
 Qed.

--- a/test-suite/ltac2/array_notation.v
+++ b/test-suite/ltac2/array_notation.v
@@ -1,0 +1,27 @@
+Require Import Ltac2.Ltac2.
+
+Ltac2 Type exn ::= [ Regression_Test_Failure ].
+
+Ltac2 check_eq_int_array(a1: int array)(a2: int array) :=
+  if Array.equal Int.equal a1 a2 then () else Control.throw Regression_Test_Failure.
+
+Goal True.
+  check_eq_int_array [| 1; 22; 333 |] (Array.of_list [1; 22; 333]).
+  check_eq_int_array [| 22 |] (Array.of_list [22]).
+  check_eq_int_array [| |] (Array.of_list []). (* space between [| and |] is mandatory *)
+  constructor.
+Qed.
+
+(* Test that tactic dispatch where "[|" is two tokens still works: *)
+
+Goal True /\ True.
+Proof.
+  split > [|constructor]. constructor.
+Qed.
+
+Set Default Proof Mode "Classic".
+
+Goal True /\ True.
+Proof.
+  split; [|constructor]. constructor.
+Qed.


### PR DESCRIPTION
Fixes #13976

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
- [x] Updated **documented syntax** by running `make doc_gram_rsts`.
