### PR TITLE
Support "Printing Record" and "Printing Synth" options in CoqIDE View menu

### DIFF
--- a/ide/coqide/coq.ml
+++ b/ide/coqide/coq.ml
@@ -652,6 +652,8 @@ struct
   let universes = BoolOpt ["Printing"; "Universes"]
   let unfocused = BoolOpt ["Printing"; "Unfocused"]
   let goal_names = BoolOpt ["Printing"; "Goal"; "Names"]
+  let record = BoolOpt ["Printing"; "Records"]
+  let synth = BoolOpt ["Printing"; "Synth"]
   let diff = StringOpt ["Diffs"]
 
   type 'a descr = { opts : 'a t list; init : 'a; label : string }
@@ -671,7 +673,9 @@ struct
     { opts = [all_basic;existential;universes]; init = false;
       label = "Display all _low-level contents" };
     { opts = [unfocused]; init = false; label = "Display _unfocused goals" };
-    { opts = [goal_names]; init = false; label = "Display _goal names" }
+    { opts = [goal_names]; init = false; label = "Display _goal names" };
+    { opts = [record]; init = true; label = "Use _record syntax" };
+    { opts = [synth]; init = true; label = "Hide _synthesizable types" }
   ]
 
   let diff_item = { opts = [diff]; init = "off"; label = "Display _proof diffs" }
@@ -706,7 +710,9 @@ struct
      below are generally called one after the other. *)
   let enforce h k =
     let mkopt o v acc = (o, v) :: acc in
-    let opts = Hashtbl.fold mkopt current_state [] in
+    let opts = List.sort (fun a b ->
+          String.compare (String.concat " " (fst a)) (String.concat " " (fst b)))
+        (Hashtbl.fold mkopt current_state []) in
     eval_call (Xmlprotocol.set_options opts) h
       (function
         | Interface.Good () -> k ()

--- a/ide/coqide/coqide_ui.ml
+++ b/ide/coqide/coqide_ui.ml
@@ -86,6 +86,8 @@ let init () =
 \n    <menuitem action='Display all low-level contents' />\
 \n    <menuitem action='Display unfocused goals' />\
 \n    <menuitem action='Display goal names' />\
+\n    <menuitem action='Use record syntax' />\
+\n    <menuitem action='Hide synthesizable types' />\
 \n    <separator/>\
 \n    <menuitem action='Unset diff' />\
 \n    <menuitem action='Set diff' />\

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -66,6 +66,7 @@ let coqide_known_option table = List.mem table [
   ["Printing";"Existential";"Instances"];
   ["Printing";"Universes"];
   ["Printing";"Unfocused"];
+  ["Printing";"Goal";"Names"];
   ["Diffs"]]
 
 let is_known_option cmd = match cmd with


### PR DESCRIPTION
In CoqIDE, `Idetop.coqide_known_option` is used to generate a "Set this option from the IDE menu instead" message when the  script asks to set an option that's available in the View menu.  I noticed these inconsistencies between this list and the menus:

- "Printing Records" and "Printing Synth" are in the list but not in the menu
- "Printing Goal Names" is in the menu but not in the list

I've assumed that the right thing to do is to add these missing items.  If some of these should be dropped, then I'm happy to do that too.

The on setting for "Printing Records" and "Printing Synth" means less info is printed, so the wording of the menu item shouldn't be "Display ...".

I also sort the options by keyname when passing to the server for the sake of debugging readability. It's easier to find a particular option when it's sorted, e.g.

```
[DEBUG] Start eval_call SetOptions [(["Diffs"],on);(["Printing";"All"],false);(["Printing";"Coercions"],false);
(["Printing";"Existential";"Instances"],false);(["Printing";"Goal";"Names"],false);(["Printing";"Implicit"],false);
(["Printing";"Matching"],true);(["Printing";"Notations"],true);(["Printing";"Parentheses"],false);
(["Printing";"Records"],true);(["Printing";"Synth"],false);(["Printing";"Unfocused"],false);
(["Printing";"Universes"],false)]
```
is easier to read than

```
[DEBUG] Start eval_call SetOptions [(["Diffs"],on);(["Printing";"Coercions"],false);(["Printing";"Matching"],true);
(["Printing";"Notations"],true);(["Printing";"Existential";"Instances"],false);(["Printing";"Synth"],true);
(["Printing";"Unfocused"],false);(["Printing";"Goal";"Names"],false);(["Printing";"Records"],true);
(["Printing";"Parentheses"],false);(["Printing";"Implicit"],false);(["Printing";"All"],false);
(["Printing";"Universes"],false)]
```