### PR TITLE
Evarsolve.solve_candidates: check_evar_instance before Evd.define

### DIFF
--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -1543,8 +1543,9 @@ let solve_candidates unify flags env evd (evk,argsv) rhs =
           (* solve_candidates might have been called recursively in the mean *)
           (* time and the evar been solved by the filtering process *)
          if Evd.is_undefined evd evk then
-           let evd' = Evd.define evk c evd in
-             check_evar_instance unify flags env evd' evk c
+           let evd = check_evar_instance unify flags env evd evk c in
+           let evd = Evd.define evk c evd in
+           evd
          else evd
       | l, _::_  (* At least one discarded candidate *) ->
           let candidates = List.map fst l in

--- a/test-suite/output/bug_16816.out
+++ b/test-suite/output/bug_16816.out
@@ -1,0 +1,9 @@
+File "./output/bug_16816.v", line 6, characters 15-16:
+The command has indeed failed with message:
+In environment
+s : Box unit
+T : Type
+x : T
+The term "x" has type "T" while it is expected to have type 
+"?S@{u0:=T}" (unable to find a well-typed instantiation for 
+"?S": cannot ensure that "Type" is a subtype of "Set").

--- a/test-suite/output/bug_16816.v
+++ b/test-suite/output/bug_16816.v
@@ -1,0 +1,7 @@
+Inductive Box : Type -> Type :=
+| box : forall A, A -> Box A.
+
+Fail Definition open_box (s : Box unit) : unit :=
+  match s with
+  | box _ x => x
+  end.


### PR DESCRIPTION
Fix #16816
