### PR TITLE
Turn some calls to `Evd.find` into `Evd.find_undefined`.

### DIFF
--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -715,7 +715,7 @@ let universes_of_constr sigma c =
       else
         Level.Set.fold Level.Set.add (Sorts.levels sort) s
     | Evar (k, args) ->
-      let concl = Evd.evar_concl (Evd.find sigma k) in
+      let concl = Evd.evar_concl (Evd.find_undefined sigma k) in
       fold sigma aux (aux s concl) c
     | Array (u,_,_,_) ->
       let s = Level.Set.fold Level.Set.add (Instance.levels (EInstance.kind sigma u)) s in

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -679,15 +679,6 @@ let undefined_evars_of_named_context evd nc =
     nc
     ~init:Evar.Set.empty
 
-let undefined_evars_of_evar_info evd evi =
-  Evar.Set.union (undefined_evars_of_term evd (Evd.evar_concl evi))
-    (Evar.Set.union
-       (match Evd.evar_body evi with
-         | Evar_empty -> Evar.Set.empty
-         | Evar_defined b -> undefined_evars_of_term evd b)
-       (undefined_evars_of_named_context evd
-          (named_context_of_val (Evd.evar_hyps evi))))
-
 type undefined_evars_cache = {
   mutable cache : (EConstr.named_declaration * Evar.Set.t) ref Id.Map.t;
 }

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -459,7 +459,7 @@ let add_unification_pb ?(tail=false) pb evd =
    the de Bruijn part of the context *)
 let generalize_evar_over_rels sigma (ev,args) =
   let open EConstr in
-  let evi = Evd.find sigma ev in
+  let evi = Evd.find_undefined sigma ev in
   let args = Evd.expand_existential sigma (ev, args) in
   let sign = named_context_of_val (Evd.evar_hyps evi) in
   List.fold_left2

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -100,7 +100,6 @@ val reachable_from_evars : evar_map -> Evar.Set.t -> Evar.Set.t
 
 val undefined_evars_of_term : evar_map -> constr -> Evar.Set.t
 val undefined_evars_of_named_context : evar_map -> Constr.named_context -> Evar.Set.t
-val undefined_evars_of_evar_info : evar_map -> evar_info -> Evar.Set.t
 
 type undefined_evars_cache
 

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -639,7 +639,7 @@ let shelve_goals l =
     as an existential variable in the definition of the goal [tgt] in
     [sigma]. *)
 let depends_on sigma src tgt =
-  let evi = Evd.find sigma tgt in
+  let evi = Evd.find_undefined sigma tgt in
   Evar.Set.mem src (Evd.evars_of_filtered_evar_info sigma (Evarutil.nf_evar_info sigma evi))
 
 let unifiable_delayed g l =

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -185,7 +185,7 @@ let concl_next_tac =
   ])
 
 let process_goal short sigma g =
-  let evi = Evd.find sigma g in
+  let evi = Evd.find_undefined sigma g in
   let env = Evd.evar_filtered_env (Global.env ()) evi in
   let min_env = Environ.reset_context env in
   let name = if Printer.print_goal_names () then Some (Names.Id.to_string (Termops.evar_suggested_name env sigma g)) else None in
@@ -285,7 +285,7 @@ let hints () =
     match goals with
     | [] -> None
     | g :: _ ->
-      let env = Evd.evar_filtered_env (Global.env ()) (Evd.find sigma g) in
+      let env = Evd.evar_filtered_env (Global.env ()) (Evd.find_undefined sigma g) in
       let get_hint_hyp env d accu = hyp_next_tac sigma env d :: accu in
       let hint_hyps = List.rev (Environ.fold_named_context get_hint_hyp env ~init: []) in
       Some (hint_hyps, concl_next_tac)

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -1321,7 +1321,7 @@ let whole_start concl_tac nb_args is_mes func input_type relation rec_arg_num :
 let abstract_type sigma gl =
   let open EConstr in
   let genv = Global.env () in
-  let evi = Evd.find sigma gl in
+  let evi = Evd.find_undefined sigma gl in
   let env = Evd.evar_filtered_env genv evi in
   let is_proof_var decl =
     try ignore (Environ.lookup_named (Context.Named.Declaration.get_id decl) genv); false

--- a/plugins/ltac/internals.ml
+++ b/plugins/ltac/internals.ml
@@ -407,7 +407,7 @@ let infoH ~pstate (tac : raw_tactic_expr) : unit =
     Proofview.tclEVARMAP >>= fun sigma ->
     let map gl =
       let gl = Proofview_monad.drop_state gl in
-      let hyps = Evd.evar_filtered_context (Evd.find sigma gl) in
+      let hyps = Evd.evar_filtered_context (Evd.find_undefined sigma gl) in
       List.map Context.Named.Declaration.get_id @@ hyps
     in
     let hyps = List.map map gls in

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -404,7 +404,7 @@ let abs_evars env sigma0 ?(rigid = []) (sigma, c0) =
   let nenv = env_size env in
   let abs_evar n k =
     let open EConstr in
-    let evi = Evd.find sigma k in
+    let evi = Evd.find_undefined sigma k in
     let concl = Evd.evar_concl evi in
     let dc = CList.firstn n (evar_filtered_context evi) in
     let abs_dc c = function
@@ -474,7 +474,7 @@ let abs_evars_pirrel env sigma0 (sigma, c0) =
   let nenv = env_size env in
   let abs_evar n k =
     let open EConstr in
-    let evi = Evd.find sigma k in
+    let evi = Evd.find_undefined sigma k in
     let concl = Evd.evar_concl evi in
     let dc = CList.firstn n (evar_filtered_context evi) in
     let abs_dc c = function
@@ -488,7 +488,7 @@ let abs_evars_pirrel env sigma0 (sigma, c0) =
     let n = max 0 (SList.length a - nenv) in
     let k_ty =
       Retyping.get_sort_family_of
-        env sigma (Evd.evar_concl (Evd.find sigma k)) in
+        env sigma (Evd.evar_concl (Evd.find_undefined sigma k)) in
     let is_prop = k_ty = InProp in
     let t = abs_evar n k in (k, (n, t, is_prop)) :: put evlist t
   | _ -> EConstr.fold sigma put evlist c in

--- a/plugins/ssr/ssrelim.ml
+++ b/plugins/ssr/ssrelim.ml
@@ -307,7 +307,7 @@ let check_pattern_instantiated env sigma patterns =
   let ev = List.fold_left Evar.Set.union Evar.Set.empty patterns_ev in
   let ty_ev = Evar.Set.fold (fun i e ->
         let ex = i in
-        let i_ty = Evd.evar_concl (Evd.find sigma ex) in
+        let i_ty = Evd.evar_concl (Evd.find_undefined sigma ex) in
         Evar.Set.union e (evars_of_term i_ty))
     ev Evar.Set.empty in
   let inter = Evar.Set.inter ev ty_ev in
@@ -374,7 +374,7 @@ let generate_pred env sigma0 ~concl patterns predty eqid is_rec deps elim_args n
         let erefl_ty = Retyping.get_type_of env sigma erefl in
         let eq_ty = Retyping.get_type_of env sigma erefl_ty in
         let ucst = Evd.evar_universe_context sigma in
-        let evds = Evar.Map.bind (Evd.find sigma) @@
+        let evds = Evar.Map.bind (Evd.find_undefined sigma) @@
           Evd.evars_of_term sigma new_concl in
         let gen_eq_tac =
           let open Proofview.Notations in

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -444,7 +444,7 @@ let pirrel_rewrite ?(under=false) ?(map_redex=id_map_redex) pred rdx rdx_ty new_
           let evs = Evar.Set.elements (Evarutil.undefined_evars_of_term sigma t) in
           let open_evs = List.filter (fun k ->
             Sorts.InProp <> Retyping.get_sort_family_of
-              env sigma (Evd.evar_concl (Evd.find sigma k)))
+              env sigma (Evd.evar_concl (Evd.find_undefined sigma k)))
             evs in
           if open_evs <> [] then Some name else None)
           (List.combine (Array.to_list args) names)

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -1021,7 +1021,7 @@ let interp_term env sigma = function
 
 let thin id sigma goal =
   let ids = Id.Set.singleton id in
-  let evi = Evd.find sigma goal in
+  let evi = Evd.find_undefined sigma goal in
   let env = Evd.evar_filtered_env (Global.env ()) evi in
   let cl = Evd.evar_concl evi in
   let ans =
@@ -1036,7 +1036,7 @@ let thin id sigma goal =
     in
     let sigma = Evd.remove_future_goal sigma evk in
     let id = Evd.evar_ident goal sigma in
-    let proof = EConstr.mkEvar (evk, Evd.evar_identity_subst @@ Evd.find sigma evk) in
+    let proof = EConstr.mkEvar (evk, Evd.evar_identity_subst @@ Evd.find_undefined sigma evk) in
     let sigma = Evd.define goal proof sigma in
     match id with
     | None -> sigma

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -228,7 +228,7 @@ let nf_open_term sigma0 ise c =
   | Evar ex ->
     let k, a = ex in let a' = SList.Skip.map nf a in
     if not (Evd.mem !s' k) then
-      s' := Evd.add !s' k (Evarutil.nf_evar_info ise (Evd.find ise k));
+      s' := Evd.add !s' k (Evarutil.nf_evar_info ise (Evd.find_undefined ise k));
     mkEvar (k, a')
   | _ -> map ise nf c' in
   let copy_def k _ () = match Evd.evar_body (Evd.find ise k) with
@@ -363,7 +363,7 @@ let evars_for_FO ~hack ~rigid env (ise0:evar_map) c0 =
   let rec put c = match EConstr.kind !sigma c with
   | Evar (k, a) ->
     if rigid k then map !sigma put c else
-    let evi = Evd.find !sigma k in
+    let evi = Evd.find_undefined !sigma k in
     let dc = List.firstn (max 0 (SList.length a - nenv)) (evar_filtered_context evi) in
     let abs_dc (d, c) = function
     | Context.Named.Declaration.LocalDef (x, b, t) ->

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -842,7 +842,7 @@ and detype_r d flags avoid env sigma t =
           | None -> Termops.evar_suggested_name (snd env) sigma evk
           | Some id -> id
           in
-          let info = Evd.find sigma evk in
+          let info = Evd.find_undefined sigma evk in
           let cl = Evd.expand_existential sigma (evk, cl) in
           let ctx = Evd.evar_filtered_context info in
           let get_instance f =

--- a/pretyping/evardefine.ml
+++ b/pretyping/evardefine.ml
@@ -140,7 +140,7 @@ let define_pure_evar_as_lambda env evd evk =
   in
   let newenv = push_named (LocalAssum (id, dom)) evenv in
   let filter = Filter.extend 1 (evar_filter evi) in
-  let src = subterm_source evk ~where:Body (evar_source (Evd.find evd1 evk)) in
+  let src = subterm_source evk ~where:Body (evar_source evi) in
   let abstract_arguments = Abstraction.abstract_last (Evd.evar_abstract_arguments evi) in
   let evd2,body = new_evar newenv evd1 ~src (subst1 (mkVar id.binder_name) rng) ~filter ~abstract_arguments in
   let lam = mkLambda (map_annot Name.mk_name id, dom, subst_var evd2 id.binder_name body) in

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -163,7 +163,7 @@ let refresh_universes ?(status=univ_rigid) ?(onlyalg=false) ?(refreshset=false)
        if f' == f && args' == args then t
        else mkApp (f', args')
     | Evar (ev, a) when onevars ->
-      let evi = Evd.find !evdref ev in
+      let evi = Evd.find_undefined !evdref ev in
       let ty = Evd.evar_concl evi in
       let ty' = refresh ~onlyalg univ_flexible ~direction:true ty in
       if ty == ty' then t
@@ -983,7 +983,7 @@ let rec find_projectable_vars aliases sigma y subst =
     else if Evd.is_defined sigma (fst c) then subst2 (* already solved *)
     else
       let (evk,argsv as t) = c in
-      let evi = Evd.find sigma evk in
+      let evi = Evd.find_undefined sigma evk in
       let subst = make_projectable_subst aliases sigma (evar_filtered_context evi) argsv in
       let l = find_projectable_vars aliases sigma y subst in
       match l with

--- a/pretyping/pretype_errors.ml
+++ b/pretyping/pretype_errors.ml
@@ -188,7 +188,7 @@ let unsatisfiable_constraints env evd ev comp =
     let err = UnsatisfiableConstraints (None, comp) in
     raise (PretypeError (env,evd,err))
   | Some ev ->
-    let loc, kind = Evd.evar_source (Evd.find evd ev) in
+    let loc, kind = Evd.evar_source (Evd.find_undefined evd ev) in
     let err = UnsatisfiableConstraints (Some (ev, kind), comp) in
     Loc.raise ?loc (PretypeError (env,evd,err))
 

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -285,7 +285,7 @@ let check_extra_evars_are_solved env current_sigma frozen = match frozen with
   Evar.Set.iter
     (fun evk ->
       if not (Evd.is_defined current_sigma evk) then
-        let (loc,k) = evar_source (Evd.find current_sigma evk) in
+        let (loc,k) = evar_source (Evd.find_undefined current_sigma evk) in
         match k with
         | Evar_kinds.ImplicitArg (gr, (i, id), false) -> ()
         | _ ->

--- a/pretyping/typeclasses.ml
+++ b/pretyping/typeclasses.ml
@@ -235,7 +235,7 @@ let no_goals_or_obligations _ source =
 
 let has_typeclasses filter evd =
   let tcs = get_typeclass_evars evd in
-  let check ev = filter ev (lazy (snd (Evd.evar_source (Evd.find evd ev)))) in
+  let check ev = filter ev (lazy (snd (Evd.evar_source (Evd.find_undefined evd ev)))) in
   Evar.Set.exists check tcs
 
 let get_filtered_typeclass_evars filter evd =

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -544,7 +544,7 @@ let match_goals ot nt =
 
 let get_proof_context (p : Proof.t) =
   let Proof.{goals; sigma} = Proof.data p in
-  let env = Evd.evar_filtered_env (Global.env ()) (Evd.find sigma (List.hd goals)) in
+  let env = Evd.evar_filtered_env (Global.env ()) (Evd.find_undefined sigma (List.hd goals)) in
   sigma, env
 
 let to_constr pf =

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -556,7 +556,7 @@ let refine_by_tactic ~name ~poly env sigma ty tac =
 let get_goal_context_gen pf i =
   let { sigma; goals } = data pf in
   let goal = try List.nth goals (i-1) with Failure _ -> raise (NoSuchGoal None) in
-  let env = Evd.evar_filtered_env (Global.env ()) (Evd.find sigma goal) in
+  let env = Evd.evar_filtered_env (Global.env ()) (Evd.find_undefined sigma goal) in
   (sigma, env)
 
 let get_proof_context p =

--- a/proofs/refine.ml
+++ b/proofs/refine.ml
@@ -26,7 +26,7 @@ let extract_prefix env info =
   share ctx1 ctx2 []
 
 let typecheck_evar ev env sigma =
-  let info = Evd.find sigma ev in
+  let info = Evd.find_undefined sigma ev in
   (* Typecheck the hypotheses. *)
   let type_hyp (sigma, env) decl =
     let t = NamedDecl.get_type decl in

--- a/stm/proofBlockDelimiter.ml
+++ b/stm/proofBlockDelimiter.ml
@@ -40,7 +40,8 @@ let simple_goal sigma g gs =
   let open Evar in
   let open Evd in
   let open Evarutil in
-  let evi = Evd.find sigma g in
+  let () = assert (not @@ Evd.is_defined sigma g) in
+  let evi = Evd.find_undefined sigma g in
   Set.is_empty (evars_of_term sigma (Evd.evar_concl evi)) &&
   Set.is_empty (evars_of_filtered_evar_info sigma (nf_evar_info sigma evi)) &&
   not (List.exists (Proofview.depends_on sigma g) gs)

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -111,7 +111,7 @@ let set_typeclasses_strategy = function
   | Bfs -> Goptions.set_bool_option_value iterative_deepening_opt_name true
 
 let pr_ev evs ev =
-  let evi = Evd.find evs ev in
+  let evi = Evd.find_undefined evs ev in
   let env = Evd.evar_filtered_env (Global.env ()) evi in
   Printer.pr_econstr_env env evs (Evd.evar_concl evi)
 
@@ -385,12 +385,12 @@ let top_sort evm undefs =
       tosee := Evar.Set.remove ev !tosee;
       Evar.Set.iter (fun ev ->
         if Evar.Set.mem ev !tosee then
-          visit ev (Evd.find evm ev)) evs;
+          visit ev (Evd.find_undefined evm ev)) evs;
       l' := ev :: !l';
   in
     while not (Evar.Set.is_empty !tosee) do
       let ev = Evar.Set.choose !tosee in
-        visit ev (Evd.find evm ev)
+        visit ev (Evd.find_undefined evm ev)
     done;
     List.rev !l'
 
@@ -1127,7 +1127,7 @@ let is_inference_forced p evd ev =
   try
     if Evar.Set.mem ev (Evd.get_typeclass_evars evd) && p ev
     then
-      let (loc, k) = evar_source (Evd.find evd ev) in
+      let (loc, k) = evar_source (Evd.find_undefined evd ev) in
       match k with
         | Evar_kinds.ImplicitArg (_, _, b) -> b
         | Evar_kinds.QuestionMark _ -> false
@@ -1145,7 +1145,7 @@ let is_mandatory p comp evd =
 let select_and_update_evars p oevd in_comp evd ev =
   try
     if Evd.is_typeclass_evar oevd ev then
-      (in_comp ev && p evd ev (Evd.find evd ev))
+      (in_comp ev && p evd ev (Evd.find_undefined evd ev))
     else false
   with Not_found -> false
 
@@ -1317,5 +1317,5 @@ let autoapply c i =
   Clenv.res_pf ~with_evars:true ~with_classes:false ~flags ce <*>
       Proofview.tclEVARMAP >>= (fun sigma ->
       let sigma = Typeclasses.make_unresolvables
-          (fun ev -> Typeclasses.all_goals ev (Lazy.from_val (snd (Evd.evar_source (Evd.find sigma ev))))) sigma in
+          (fun ev -> Typeclasses.all_goals ev (Lazy.from_val (snd (Evd.evar_source (Evd.find_undefined sigma ev))))) sigma in
       Proofview.Unsafe.tclEVARS sigma) end

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -379,8 +379,9 @@ let is_unique env sigma concl =
 let top_sort evm undefs =
   let l' = ref [] in
   let tosee = ref undefs in
+  let cache = Evarutil.create_undefined_evars_cache () in
   let rec visit ev evi =
-    let evs = Evarutil.undefined_evars_of_evar_info evm evi in
+    let evs = Evarutil.filtered_undefined_evars_of_evar_info ~cache evm evi in
       tosee := Evar.Set.remove ev !tosee;
       Evar.Set.iter (fun ev ->
         if Evar.Set.mem ev !tosee then

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1636,7 +1636,7 @@ let pr_applicable_hint pf =
   match goals with
   | [] -> CErrors.user_err Pp.(str "No focused goal.")
   | g::_ ->
-    pr_hint_term env sigma (Evd.evar_concl (Evd.find sigma g))
+    pr_hint_term env sigma (Evd.evar_concl (Evd.find_undefined sigma g))
 
 let pp_hint_mode = function
   | ModeInput -> str"+"

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -1472,7 +1472,7 @@ exception UnsolvedConstraints of Environ.env * Evd.evar_map * Evar.t
 let () = CErrors.register_handler begin function
 | UnsolvedConstraints (env, evars, ev) ->
   Some (str "Unsolved constraint remaining: " ++ spc () ++
-    Termops.pr_evar_info env evars (Evd.find evars ev) ++ str ".")
+    Termops.pr_evar_info env evars (Evd.find_undefined evars ev) ++ str ".")
 | _ -> None
 end
 

--- a/vernac/comTactic.ml
+++ b/vernac/comTactic.ml
@@ -60,7 +60,7 @@ let check_par_applicable pstate =
     (Proof.data p).Proof.goals |> List.iter (fun goal ->
     let is_ground =
       let { Proof.sigma = sigma0 } = Declare.Proof.fold pstate ~f:Proof.data in
-      let g = Evd.find sigma0 goal in
+      let g = Evd.find_undefined sigma0 goal in
       let concl, hyps = Evd.evar_concl g, Evd.evar_context g in
       Evarutil.is_ground_term sigma0 concl &&
       List.for_all (Context.Named.Declaration.for_all (Evarutil.is_ground_term sigma0)) hyps in

--- a/vernac/retrieveObl.ml
+++ b/vernac/retrieveObl.ml
@@ -167,7 +167,7 @@ let evar_dependencies evm oev =
   let one_step deps =
     Evar.Set.fold
       (fun ev s ->
-        let evi = Evd.find evm ev in
+        let evi = Evd.find_undefined evm ev in
         let deps' = Evd.evars_of_filtered_evar_info evm evi in
         if Evar.Set.mem oev deps' then
           invalid_arg
@@ -241,7 +241,7 @@ let retrieve_obligations env name evm fs ?deps ?status t ty =
           | Some t -> (t, trunc_named_context fs hyps, fs)
           | None -> (evtyp, hyps, 0)
         in
-        let loc, k = Evd.evar_source (Evd.find evm id) in
+        let loc, k = Evd.evar_source (Evd.find_undefined evm id) in
         let status =
           match k with
           | Evar_kinds.QuestionMark {Evar_kinds.qm_obligation = o} -> o

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -138,7 +138,7 @@ let show_intro ~proof all =
   let open EConstr in
   let Proof.{goals;sigma} = Proof.data proof in
   if not (List.is_empty goals) then begin
-    let evi = Evd.find sigma (List.hd goals) in
+    let evi = Evd.find_undefined sigma (List.hd goals) in
     let env = Evd.evar_filtered_env (Global.env ()) evi in
     let l,_= decompose_prod_assum sigma (Termops.strip_outer_cast sigma (Evd.evar_concl evi)) in
     if all then
@@ -591,7 +591,7 @@ let check_name_freshness locality {CAst.loc;v=id} : unit =
 
 let program_inference_hook env sigma ev =
   let tac = !Declare.Obls.default_tactic in
-  let evi = Evd.find sigma ev in
+  let evi = Evd.find_undefined sigma ev in
   let evi = Evarutil.nf_evar_info sigma evi in
   let env = Evd.evar_filtered_env env evi in
   try
@@ -2091,7 +2091,7 @@ let print_about_hyp_globs ~pstate ?loc ref_or_by_not udecl glopt =
             Failure _ -> user_err ?loc
                           (str "No such goal: " ++ int n ++ str "."))
       | _ , _ -> raise NoHyp in
-    let hyps = Evd.evar_filtered_context (Evd.find sigma ev) in
+    let hyps = Evd.evar_filtered_context (Evd.find_undefined sigma ev) in
     let decl = Context.Named.lookup id hyps in
     let natureofid = match decl with
                      | LocalAssum _ -> "Hypothesis"


### PR DESCRIPTION
This is both faster and semantically better, since it indicates we're assuming the evar to be undefined. The places where the change happened were cherry-picked so that it's somewhat clear from the context that the evar in question should be undefined.

This is a preparatory PR to make the `evar_info` type sensitive to the definedness status of the evar. This one should be backward-compatible API-wise.