### PR TITLE
Reals: Renaming R_dist into Rdist for better naming uniformity

### DIFF
--- a/doc/changelog/11-standard-library/16874-master+renaming-R_dist-Rdist-for-uniformity.rst
+++ b/doc/changelog/11-standard-library/16874-master+renaming-R_dist-Rdist-for-uniformity.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  For uniformity of naming and ease of remembering, `R_dist` and
+  theorems mentioning `R_dist` in their name become available with spelling `Rdist`
+  (`#16874 <https://github.com/coq/coq/pull/16874>`_,
+  by Hugo Herbelin).

--- a/theories/Reals/Alembert.v
+++ b/theories/Reals/Alembert.v
@@ -93,7 +93,7 @@ Proof.
     intro; cut (forall n:nat, (n >= x)%nat -> An (S n) < / 2 * An n).
     { intro H4; replace (S x + S i)%nat with (S (S x + i)) by auto with zarith.
       apply H4; unfold ge; apply tech8. }
-    intros; unfold R_dist in H2; apply Rmult_lt_reg_l with (/ An n).
+    intros; unfold Rdist in H2; apply Rmult_lt_reg_l with (/ An n).
     { apply Rinv_0_lt_compat; apply H. }
     do 2 rewrite (Rmult_comm (/ An n)); rewrite Rmult_assoc;
     rewrite <- Rinv_r_sym.
@@ -146,8 +146,8 @@ Proof.
     elim (H0 (eps / 3) H7); intros.
     exists x; intros.
     assert (H10 := H8 n H9).
-    unfold R_dist; unfold Rminus; rewrite Ropp_0;
-      rewrite Rplus_0_r; rewrite Rabs_Rabsolu; unfold R_dist in H10;
+    unfold Rdist; unfold Rminus; rewrite Ropp_0;
+      rewrite Rplus_0_r; rewrite Rabs_Rabsolu; unfold Rdist in H10;
       unfold Rminus in H10; rewrite Ropp_0 in H10; rewrite Rplus_0_r in H10;
       rewrite Rabs_Rabsolu in H10; rewrite Rabs_right.
     2:{ left; change (0 < Vn (S n) / Vn n); unfold Rdiv;
@@ -260,7 +260,7 @@ Proof.
         + ring.
         + discrR.
       - discrR. }
-  unfold R_dist;
+  unfold Rdist;
     replace (sum_f_R0 Vn n - sum_f_R0 Wn n - (x - x0)) with
     (sum_f_R0 Vn n - x + - (sum_f_R0 Wn n - x0)) by ring;
     apply Rle_lt_trans with
@@ -268,9 +268,9 @@ Proof.
   { apply Rabs_triang. }
   rewrite Rabs_Ropp; apply Rlt_le_trans with (eps / 2 + eps / 2).
   + apply Rplus_lt_compat.
-    * unfold R_dist in H8; apply H8; unfold ge; apply Nat.le_trans with N;
+    * unfold Rdist in H8; apply H8; unfold ge; apply Nat.le_trans with N;
         [ unfold N; apply Nat.le_max_l | assumption ].
-    * unfold R_dist in H9; apply H9; unfold ge; apply Nat.le_trans with N;
+    * unfold Rdist in H9; apply H9; unfold ge; apply Nat.le_trans with N;
         [ unfold N; apply Nat.le_max_r | assumption ].
   + right; symmetry ; apply double_var.
 Qed.
@@ -294,7 +294,7 @@ Proof.
   2:{ unfold Rdiv; apply Rmult_lt_0_compat;
       [ assumption | apply Rinv_0_lt_compat; apply Rabs_pos_lt; assumption ]. }
   intro; elim (H1 (eps / Rabs x) H4); intros.
-  exists x0; intros; unfold R_dist; unfold Rminus;
+  exists x0; intros; unfold Rdist; unfold Rminus;
     rewrite Ropp_0; rewrite Rplus_0_r; rewrite Rabs_Rabsolu;
       unfold Bn;
 	replace (An (S n) * x ^ S n / (An n * x ^ n)) with (An (S n) / An n * x).
@@ -311,9 +311,9 @@ Proof.
     rewrite <- Rinv_l_sym.
   2:{ apply Rabs_no_R0; assumption. }
   rewrite Rmult_1_l; rewrite <- (Rmult_comm eps); unfold Rdiv in H5;
-    replace (Rabs (An (S n) / An n)) with (R_dist (Rabs (An (S n) * / An n)) 0).
+    replace (Rabs (An (S n) / An n)) with (Rdist (Rabs (An (S n) * / An n)) 0).
   { apply H5; assumption. }
-  unfold R_dist; unfold Rminus; rewrite Ropp_0;
+  unfold Rdist; unfold Rminus; rewrite Ropp_0;
     rewrite Rplus_0_r; rewrite Rabs_Rabsolu; unfold Rdiv;
       reflexivity.
 Qed.
@@ -324,7 +324,7 @@ Proof.
   intros; exists (An 0%nat).
   unfold Pser; unfold infinite_sum; intros; exists 0%nat; intros;
     replace (sum_f_R0 (fun n0:nat => An n0 * x ^ n0) n) with (An 0%nat).
-  - unfold R_dist; unfold Rminus; rewrite Rplus_opp_r;
+  - unfold Rdist; unfold Rminus; rewrite Rplus_opp_r;
       rewrite Rabs_R0; assumption.
   - induction  n as [| n Hrecn].
     + simpl; ring.
@@ -547,7 +547,7 @@ Proof.
           rewrite <- Rinv_r_sym.
           { lra. }
           apply pow_nonzero;lra. }
-      unfold R_dist.
+      unfold Rdist.
       rewrite Rabs_mult.
       replace (Rabs (An (S n) / An n) * Rabs x - k * Rabs x) with
         (Rabs x * (Rabs (An (S n) / An n) - k)) by ring.
@@ -560,14 +560,14 @@ Proof.
       2:{ apply Rabs_no_R0; lra. }
       rewrite Rmult_1_l.
       rewrite <- (Rmult_comm eps).
-      unfold R_dist in H5.
+      unfold Rdist in H5.
       unfold Rdiv; unfold Rdiv in H5; apply H5; assumption.
   - exists (An 0%nat).
     unfold Un_cv.
     intros.
     exists 0%nat.
     intros.
-    unfold R_dist.
+    unfold Rdist.
     replace (sum_f_R0 (fun i:nat => An i * x ^ i) n) with (An 0%nat).
     { unfold Rminus; rewrite Rplus_opp_r; rewrite Rabs_R0; assumption. }
     induction n as [| n Hrecn].
@@ -613,7 +613,7 @@ Proof.
           rewrite <- Rinv_r_sym.
           { lra. }
           apply pow_nonzero;lra. }
-      unfold R_dist.
+      unfold Rdist.
       rewrite Rabs_mult.
       replace (Rabs (An (S n) / An n) * Rabs x - k * Rabs x) with
         (Rabs x * (Rabs (An (S n) / An n) - k)); [ idtac | ring ].
@@ -627,7 +627,7 @@ Proof.
       2:{ apply Rabs_no_R0. lra. }
       rewrite Rmult_1_l.
       rewrite <- (Rmult_comm eps).
-      unfold R_dist in H5.
+      unfold Rdist in H5.
       unfold Rdiv; unfold Rdiv in H5; apply H5; assumption.
 Qed.
 

--- a/theories/Reals/AltSeries.v
+++ b/theories/Reals/AltSeries.v
@@ -160,8 +160,8 @@ Proof.
   assert (H3 := CV_ALT_step4 _ H H0).
   destruct (growing_cv _ H2 H3) as (x,p).
   exists x.
-  unfold Un_cv; unfold R_dist; unfold Un_cv in H1;
-    unfold R_dist in H1; unfold Un_cv in p; unfold R_dist in p.
+  unfold Un_cv; unfold Rdist; unfold Un_cv in H1;
+    unfold Rdist in H1; unfold Un_cv in p; unfold Rdist in p.
   intros; cut (0 < eps / 2);
     [ intro
       | unfold Rdiv; apply Rmult_lt_0_compat;
@@ -238,8 +238,8 @@ Theorem alternated_series_ineq :
 Proof.
   intros.
   assert (Un_cv (fun N:nat => sum_f_R0 (tg_alt Un) (2 * N)) l). {
-    unfold Un_cv; unfold R_dist; unfold Un_cv in H1;
-      unfold R_dist in H1; intros.
+    unfold Un_cv; unfold Rdist; unfold Un_cv in H1;
+      unfold Rdist in H1; intros.
     elim (H1 eps H2); intros.
     exists x; intros.
     apply H3.
@@ -247,8 +247,8 @@ Proof.
     rewrite <- Nat.double_twice; apply Nat.le_add_r.
   }
   assert (Un_cv (fun N:nat => sum_f_R0 (tg_alt Un) (S (2 * N))) l). {
-    unfold Un_cv; unfold R_dist; unfold Un_cv in H1;
-      unfold R_dist in H1; intros.
+    unfold Un_cv; unfold Rdist; unfold Un_cv in H1;
+      unfold Rdist in H1; intros.
     elim (H1 eps H3); intros.
     exists x; intros.
     apply H4.
@@ -300,7 +300,7 @@ Qed.
 
 Lemma PI_tg_cv : Un_cv PI_tg 0.
 Proof.
-  unfold Un_cv; unfold R_dist; intros.
+  unfold Un_cv; unfold Rdist; intros.
   assert (0 < 2 * eps) by lra.
   assert (H1 := archimed (/ (2 * eps))).
   assert (0 <= up (/ (2 * eps)))%Z. {

--- a/theories/Reals/Cos_plus.v
+++ b/theories/Reals/Cos_plus.v
@@ -32,8 +32,8 @@ Proof.
       apply RmaxLess1. }
   assert (0 < C0) by (unfold C0; apply pow_lt; assumption).
   assert (H1 := cv_speed_pow_fact C0).
-  unfold Un_cv in H1; unfold R_dist in H1.
-  unfold Un_cv; unfold R_dist; intros.
+  unfold Un_cv in H1; unfold Rdist in H1.
+  unfold Un_cv; unfold Rdist; intros.
   cut (0 < eps / C0);
     [ intro
       | unfold Rdiv; apply Rmult_lt_0_compat;
@@ -569,8 +569,8 @@ Lemma reste1_cv_R0 : forall x y:R, Un_cv (Reste1 x y) 0.
 Proof.
   intros.
   assert (H := Majxy_cv_R0 x y).
-  unfold Un_cv in H; unfold R_dist in H.
-  unfold Un_cv; unfold R_dist; intros.
+  unfold Un_cv in H; unfold Rdist in H.
+  unfold Un_cv; unfold Rdist; intros.
   elim (H eps H0); intros N0 H1.
   exists (S N0); intros.
   unfold Rminus; rewrite Ropp_0; rewrite Rplus_0_r.
@@ -601,8 +601,8 @@ Lemma reste2_cv_R0 : forall x y:R, Un_cv (Reste2 x y) 0.
 Proof.
   intros.
   assert (H := Majxy_cv_R0 x y).
-  unfold Un_cv in H; unfold R_dist in H.
-  unfold Un_cv; unfold R_dist; intros.
+  unfold Un_cv in H; unfold Rdist in H.
+  unfold Un_cv; unfold Rdist; intros.
   elim (H eps H0); intros N0 H1.
   exists (S N0); intros.
   unfold Rminus; rewrite Ropp_0; rewrite Rplus_0_r.
@@ -645,8 +645,8 @@ Proof.
       * reflexivity.
     + unfold Bn.
       assert (H0 := reste1_cv_R0 x y).
-      unfold Un_cv in H0; unfold R_dist in H0.
-      unfold Un_cv; unfold R_dist; intros.
+      unfold Un_cv in H0; unfold Rdist in H0.
+      unfold Un_cv; unfold Rdist; intros.
       elim (H0 eps H1); intros N0 H2.
       exists N0; intros.
       apply H2.
@@ -666,7 +666,7 @@ Proof.
   { assert (Un_cv (C1 x y) (cos (x + y))) by apply C1_cvg.
     intros.
     apply UL_sequence with (C1 x y); assumption. }
-  unfold Un_cv; unfold R_dist.
+  unfold Un_cv; unfold Rdist.
   intros.
   assert (H0 := A1_cvg x).
   assert (H1 := A1_cvg y).
@@ -676,7 +676,7 @@ Proof.
   assert (H5 := CV_mult _ _ _ _ H2 H3).
   assert (H6 := reste_cv_R0 x y).
   unfold Un_cv in H4; unfold Un_cv in H5; unfold Un_cv in H6.
-  unfold R_dist in H4; unfold R_dist in H5; unfold R_dist in H6.
+  unfold Rdist in H4; unfold Rdist in H5; unfold Rdist in H6.
   cut (0 < eps / 3);
     [ intro
       | unfold Rdiv; apply Rmult_lt_0_compat;

--- a/theories/Reals/Cos_rel.v
+++ b/theories/Reals/Cos_rel.v
@@ -231,8 +231,8 @@ Lemma A1_cvg : forall x:R, Un_cv (A1 x) (cos x).
 Proof.
 intro.
 unfold cos; destruct (exist_cos (Rsqr x)) as (x0,p).
-unfold cos_in, cos_n, infinite_sum, R_dist in p.
-unfold Un_cv, R_dist; intros.
+unfold cos_in, cos_n, infinite_sum, Rdist in p.
+unfold Un_cv, Rdist; intros.
 destruct (p eps H) as (x1,H0).
 exists x1; intros.
 unfold A1.
@@ -252,8 +252,8 @@ Proof.
 intros.
 unfold cos.
 destruct (exist_cos (Rsqr (x + y))) as (x0,p).
-unfold cos_in, cos_n, infinite_sum, R_dist in p.
-unfold Un_cv, R_dist; intros.
+unfold cos_in, cos_n, infinite_sum, Rdist in p.
+unfold Un_cv, Rdist; intros.
 destruct (p eps H) as (x1,H0).
 exists x1; intros.
 unfold C1.
@@ -277,7 +277,7 @@ case (Req_dec x 0); intro.
 { rewrite H.
   rewrite sin_0.
   unfold B1.
-  unfold Un_cv; unfold R_dist; intros; exists 0%nat; intros.
+  unfold Un_cv; unfold Rdist; intros; exists 0%nat; intros.
   replace (sum_f_R0 (fun k:nat => (-1) ^ k / INR (fact (2 * k + 1)) * 0 ^ (2 * k + 1)) n) with 0.
   { unfold Rminus; rewrite Rplus_opp_r; rewrite Rabs_R0; assumption. }
   - induction  n as [| n Hrecn].
@@ -286,8 +286,8 @@ case (Req_dec x 0); intro.
     { simpl; ring. }
     unfold ge; apply Nat.le_0_l. }
 unfold sin. destruct (exist_sin (Rsqr x)) as (x0,p).
-unfold sin_in, sin_n, infinite_sum, R_dist in p.
-unfold Un_cv, R_dist; intros.
+unfold sin_in, sin_n, infinite_sum, Rdist in p.
+unfold Un_cv, Rdist; intros.
 cut (0 < eps / Rabs x);
  [ intro
  | unfold Rdiv; apply Rmult_lt_0_compat;

--- a/theories/Reals/Exp_prop.v
+++ b/theories/Reals/Exp_prop.v
@@ -350,7 +350,7 @@ Proof.
         [ assumption | apply Rinv_0_lt_compat; prove_sup0 ] ].
   elim (H _ H1); intros N0 H2.
   exists (max (2 * S N0) 2); intros.
-  unfold R_dist in H2; unfold R_dist; rewrite Rminus_0_r;
+  unfold Rdist in H2; unfold Rdist; rewrite Rminus_0_r;
     unfold Majxy in H2; unfold maj_Reste_E.
   set (M := Rmax 1 (Rmax (Rabs x) (Rabs y))) in *.
   assert (HM1 : 1 <= M) by apply RmaxLess1.
@@ -450,7 +450,7 @@ Proof.
   intros; assert (H := maj_Reste_cv_R0 x y).
   unfold Un_cv in H; unfold Un_cv; intros; elim (H _ H0); intros.
   exists (max x0 1); intros.
-  unfold R_dist; rewrite Rminus_0_r.
+  unfold Rdist; rewrite Rminus_0_r.
   apply Rle_lt_trans with (maj_Reste_E x y n).
   - apply Reste_E_maj.
     apply Nat.lt_le_trans with 1%nat.
@@ -458,12 +458,12 @@ Proof.
     + apply Nat.le_trans with (max x0 1).
       * apply Nat.le_max_r.
       * apply H2.
-  - replace (maj_Reste_E x y n) with (R_dist (maj_Reste_E x y n) 0).
+  - replace (maj_Reste_E x y n) with (Rdist (maj_Reste_E x y n) 0).
     + apply H1.
       unfold ge; apply Nat.le_trans with (max x0 1).
       * apply Nat.le_max_l.
       * apply H2.
-    + unfold R_dist; rewrite Rminus_0_r; apply Rabs_right.
+    + unfold Rdist; rewrite Rminus_0_r; apply Rabs_right.
       apply Rle_ge; apply Rle_trans with (Rabs (Reste_E x y n)).
       * apply Rabs_pos.
       * apply Reste_E_maj.
@@ -560,7 +560,7 @@ Proof.
     unfold continuity in H1.
     assert (H2 := H1 0).
     unfold continuity_pt in H2; unfold continue_in in H2; unfold limit1_in in H2;
-      unfold limit_in in H2; simpl in H2; unfold R_dist in H2.
+      unfold limit_in in H2; simpl in H2; unfold Rdist in H2.
     elim (H2 _ H); intros alp H3.
     elim H3; intros.
     exists (mkposreal _ H4); intros.
@@ -579,7 +579,7 @@ Proof.
       { apply Hu. }
       unfold Un_cv, SP in |- *.
       intros; exists 1%nat; intros.
-      unfold R_dist; rewrite decomp_sum.
+      unfold Rdist; rewrite decomp_sum.
       2:lia.
       rewrite Rplus_comm.
       replace (fn 0%nat 0) with 1.
@@ -606,14 +606,14 @@ Proof.
       }
       elim (Hexp _ H9); intros N0 H10.
       exists N0; intros.
-      unfold R_dist.
+      unfold Rdist.
       apply Rmult_lt_reg_l with (Rabs h).
       { apply Rabs_pos_lt; assumption. }
       rewrite <- Rabs_mult.
       rewrite Rmult_minus_distr_l.
       replace (h * ((x - 1) / h)) with (x - 1).
       2:{ field. assumption. }
-      unfold R_dist in H10.
+      unfold Rdist in H10.
       replace (h * SP fn n h - (x - 1)) with
         (sum_f_R0 (fun i:nat => / INR (fact i) * h ^ i) (S n) - x).
       { rewrite (Rmult_comm (Rabs h)).
@@ -685,9 +685,9 @@ Proof.
     exists N0; intros.
     assert (hyp_sn:(S n >= N0)%nat) by lia.
     assert (H6 := H4 _ hyp_sn).
-    unfold R_dist in H6; rewrite Rminus_0_r in H6.
+    unfold Rdist in H6; rewrite Rminus_0_r in H6.
     rewrite Rabs_Rabsolu in H6.
-    unfold R_dist; rewrite Rminus_0_r.
+    unfold Rdist; rewrite Rminus_0_r.
     rewrite Rabs_Rabsolu.
     replace
       (Rabs (r ^ S n / INR (fact (S (S n)))) / Rabs (r ^ n / INR (fact (S n))))

--- a/theories/Reals/Machin.v
+++ b/theories/Reals/Machin.v
@@ -156,10 +156,10 @@ assert (cv : Un_cv PI_2_3_7_tg 0).
   unfold PI_2_3_7_tg.
   rewrite <- (Rplus_0_l 0).
   apply Rle_lt_trans with
-    (1 := R_dist_plus (2 * Ratan_seq (/3) n) 0 (Ratan_seq (/7) n) 0).
+    (1 := Rdist_plus (2 * Ratan_seq (/3) n) 0 (Ratan_seq (/7) n) 0).
   replace eps with (2 * eps/3 + eps/3) by field.
   apply Rplus_lt_compat.
-  { unfold R_dist, Rminus, Rdiv.
+  { unfold Rdist, Rminus, Rdiv.
     rewrite <- (Rmult_0_r 2), <- Ropp_mult_distr_r_reverse.
     rewrite <- Rmult_plus_distr_l, Rabs_mult, (Rabs_pos_eq 2);[|lra].
     rewrite Rmult_assoc; apply Rmult_lt_compat_l;[lra | ].
@@ -176,7 +176,7 @@ assert (main : Un_cv (sum_f_R0 (tg_alt PI_2_3_7_tg)) (2 * v3 + v7)).
                                sum_f_R0 (tg_alt (Ratan_seq (/7))) n) (2 * v3 + v7)).
   { apply CV_plus;[ | assumption].
     apply CV_mult;[ | assumption].
-    exists 0%nat; intros; rewrite R_dist_eq; assumption. }
+    exists 0%nat; intros; rewrite Rdist_eq; assumption. }
   apply Un_cv_ext with (2 := main).
   intros n; rewrite scal_sum, <- plus_sum; apply sum_eq; intros.
   rewrite Rmult_comm; unfold PI_2_3_7_tg, tg_alt; field. }

--- a/theories/Reals/PSeries_reg.v
+++ b/theories/Reals/PSeries_reg.v
@@ -161,14 +161,14 @@ Proof.
     unfold Un_cv in H1; unfold Un_cv; intros.
     elim (H1 _ H3); intros.
     exists x; intros.
-    unfold R_dist; unfold R_dist in H4.
+    unfold Rdist; unfold Rdist in H4.
     rewrite Rminus_0_r; apply H4; assumption.
   }
   unfold Un_cv in H3.
   elim (H3 eps H); intros N0 H4.
   exists N0; intros.
   apply Rle_lt_trans with (Rabs (sum_f_R0 (fun k:nat => Rabs (An k)) n - s)).
-  2:{ unfold R_dist in H4; unfold Rminus in H4; rewrite Ropp_0 in H4.
+  2:{ unfold Rdist in H4; unfold Rminus in H4; rewrite Ropp_0 in H4.
       assert (H7 := H4 n H5).
       rewrite Rplus_0_r in H7; apply H7. }
   rewrite <- (Rabs_Ropp (sum_f_R0 (fun k:nat => Rabs (An k)) n - s));
@@ -202,7 +202,7 @@ Lemma CVU_continuity :
 Proof.
   intros; unfold continuity_pt; unfold continue_in;
     unfold limit1_in; unfold limit_in;
-      simpl; unfold R_dist; intros.
+      simpl; unfold Rdist; intros.
   unfold CVU in H.
   cut (0 < eps / 3);
     [ intro
@@ -230,7 +230,7 @@ Proof.
   }
   elim H6; intros del1 H7.
   unfold continuity_pt in H5; unfold continue_in in H5; unfold limit1_in in H5;
-    unfold limit_in in H5; simpl in H5; unfold R_dist in H5.
+    unfold limit_in in H5; simpl in H5; unfold Rdist in H5.
   elim (H5 _ H3); intros del2 H8.
   set (del := Rmin del1 del2).
   exists del; intros.
@@ -366,7 +366,7 @@ Lemma CVU_cv : forall f g c d, CVU f g c d ->
    forall x, Boule c d x -> Un_cv (fun n => f n x) (g x).
 Proof.
 intros f g c d cvu x bx eps ep; destruct (cvu eps ep) as [N Pn].
- exists N; intros n nN; rewrite R_dist_sym; apply Pn; assumption.
+ exists N; intros n nN; rewrite Rdist_sym; apply Pn; assumption.
 Qed.
 
 (* convergence is preserved through extensional equality *)
@@ -421,13 +421,13 @@ assert (ctrho : forall n z, Boule c d z -> continuity_pt (rho_ n) z). {
                               replace z with (z - x + x) by ring; rewrite zx0, Rplus_0_l].
     }
     assert (t' : forall y : R,
-               R_dist y z < Rmin delta (Rabs (z - x)) ->
+               Rdist y z < Rmin delta (Rabs (z - x)) ->
                (fun z : R => (f n z - f n x) / (z - x)) y = rho_ n y). {
       intros y dyz; unfold rho_; destruct (Req_EM_T y x) as [xy | xny].
       - rewrite xy in dyz.
         destruct (Rle_dec  delta (Rabs (z - x))).
-        + rewrite Rmin_left, R_dist_sym in dyz; unfold R_dist in dyz; lra.
-        + rewrite Rmin_right, R_dist_sym in dyz; unfold R_dist in dyz;
+        + rewrite Rmin_left, Rdist_sym in dyz; unfold Rdist in dyz; lra.
+        + rewrite Rmin_right, Rdist_sym in dyz; unfold Rdist in dyz;
             [case (Rlt_irrefl _ dyz) |apply Rlt_le, Rnot_le_gt; assumption].
       - reflexivity.
     }
@@ -528,18 +528,18 @@ assert (CVU rho_ rho c d ). {
         apply Rmult_lt_0_compat; repeat apply Rmin_glb_lt; try assumption.
         { apply cond_pos. }
         apply Rinv_0_lt_compat, Rlt_0_2. }
-      apply Rle_trans with (1 := R_dist_tri _ _ (rho_ n (y + Rmin (Rmin d' d2) delta/2))).
+      apply Rle_trans with (1 := Rdist_tri _ _ (rho_ n (y + Rmin (Rmin d' d2) delta/2))).
       replace (eps/2) with (eps/8 + (eps/4 + eps/8)) by field.
       apply Rplus_le_compat.
-      + rewrite R_dist_sym; apply Rlt_le, Pd;split;[split;[exact I | ] | ].
+      + rewrite Rdist_sym; apply Rlt_le, Pd;split;[split;[exact I | ] | ].
         * apply Rminus_not_eq_right; rewrite Rplus_comm; unfold Rminus;
             rewrite Rplus_assoc, Rplus_opp_r, Rplus_0_r; apply Rgt_not_eq; assumption.
-        * simpl; unfold R_dist.
+        * simpl; unfold Rdist.
           unfold Rminus; rewrite (Rplus_comm y), Rplus_assoc, Rplus_opp_r, Rplus_0_r.
           rewrite Rabs_pos_eq;[ |apply Rlt_le; assumption ].
           apply Rlt_le_trans with (Rmin (Rmin d' d2) delta);[lra | ].
           apply Rle_trans with (Rmin d' d2); apply Rmin_l.
-      + apply Rle_trans with (1 := R_dist_tri _ _ (rho_ p (y + Rmin (Rmin d' d2) delta/2))).
+      + apply Rle_trans with (1 := Rdist_tri _ _ (rho_ p (y + Rmin (Rmin d' d2) delta/2))).
         apply Rplus_le_compat.
         * apply Rlt_le.
           replace (rho_ n (y + Rmin (Rmin d' d2) delta / 2)) with
@@ -563,7 +563,7 @@ assert (CVU rho_ rho c d ). {
              now apply Rlt_le, Rinv_0_lt_compat, Rlt_0_2.
 
         * apply Rlt_le, Pd2; split;[split;[exact I | apply Rlt_not_eq; lra] | ].
-          simpl; unfold R_dist.
+          simpl; unfold Rdist.
           unfold Rminus; rewrite (Rplus_comm y), Rplus_assoc, Rplus_opp_r, Rplus_0_r.
           rewrite Rabs_pos_eq;[ | lra].
           apply Rlt_le_trans with (Rmin (Rmin d' d2) delta); [lra |].
@@ -578,20 +578,20 @@ assert (CVU rho_ rho c d ). {
     assert (cvrho : forall y, Boule c d y -> Un_cv (fun n => rho_ n y) (rho y)). {
       intros y b_y; unfold rho_, rho; destruct (Req_EM_T y x).
       - intros eps' ep'; destruct (cvu eps' ep') as [N2 Pn2].
-        exists N2; intros n nN2; rewrite R_dist_sym; apply Pn2; assumption.
+        exists N2; intros n nN2; rewrite Rdist_sym; apply Pn2; assumption.
       - apply CV_mult.
         + apply CV_minus.
           * apply cvp; assumption.
           * apply cvp; assumption.
-        + intros eps' ep'; simpl; exists 0%nat; intros; rewrite R_dist_eq; assumption.
+        + intros eps' ep'; simpl; exists 0%nat; intros; rewrite Rdist_eq; assumption.
     }
     intros p pN y b_y.
     replace eps with (eps/2 + eps/2) by field.
     assert (ep2 : 0 < eps/2) by lra.
     destruct (cvrho y b_y _ ep2) as [N2 Pn2].
-    apply Rle_lt_trans with (1 := R_dist_tri _ _ (rho_ (max N N2) y)).
+    apply Rle_lt_trans with (1 := Rdist_tri _ _ (rho_ (max N N2) y)).
     apply Rplus_lt_le_compat.
-    - solve[rewrite R_dist_sym; apply Pn2, Nat.le_max_r].
+    - solve[rewrite Rdist_sym; apply Pn2, Nat.le_max_r].
     - apply unif_ac; auto; solve [apply Nat.le_max_l].
   }
   exists N; intros; apply unif_ac'; solve[auto].
@@ -603,7 +603,7 @@ replace ((g (x + h) - g x) / h) with (rho (x + h)).
 - replace (g' x) with (rho x).
   + apply Pd; unfold D_x, no_cond;split;[split;[solve[auto] | ] | ].
     * intros xxh; case hn0; replace h with (x + h - x) by ring; rewrite <- xxh; ring.
-    * simpl; unfold R_dist; replace (x + h - x) with h by ring; exact dh.
+    * simpl; unfold Rdist; replace (x + h - x) with h by ring; exact dh.
   + unfold rho; destruct (Req_EM_T x x) as [ _ | abs];[ | case abs]; reflexivity.
 - unfold rho; destruct (Req_EM_T (x + h) x) as [abs | _];[ | ].
   + case hn0; replace h with (x + h - x) by ring; rewrite abs; ring.

--- a/theories/Reals/PartSum.v
+++ b/theories/Reals/PartSum.v
@@ -225,7 +225,7 @@ Proof.
       set (N := max x0 x); cut (N >= x0)%nat.
       * cut (N >= x)%nat.
         -- intros; assert (H7 := H3 N H5); assert (H8 := H4 N H6).
-           cut (Rabs (l1 - l2) <= R_dist (sum_f_R0 An N) l1 + R_dist (sum_f_R0 An N) l2).
+           cut (Rabs (l1 - l2) <= Rdist (sum_f_R0 An N) l1 + Rdist (sum_f_R0 An N) l2).
            ++ intro; assert (H10 := Rplus_lt_compat _ _ _ _ H7 H8);
                 assert (H11 := Rle_lt_trans _ _ _ H9 H10); unfold Rdiv in H11;
                 rewrite Rabs_mult in H11.
@@ -238,7 +238,7 @@ Proof.
                    [ intro H20; generalize (lt_INR_0 2 (proj1 (Nat.neq_0_lt_0 2) (Nat.neq_sym 0 2 H20))); unfold INR;
                      intro; assumption
                    | discriminate ].
-           ++ unfold R_dist; rewrite <- (Rabs_Ropp (sum_f_R0 An N - l1));
+           ++ unfold Rdist; rewrite <- (Rabs_Ropp (sum_f_R0 An N - l1));
                 rewrite Ropp_minus_distr'.
               replace (l1 - l2) with (l1 - sum_f_R0 An N + (sum_f_R0 An N - l2));
                 [ idtac | ring ].
@@ -384,19 +384,19 @@ Proof.
   exists x.
   intros.
   cut
-    (R_dist (sum_f_R0 An n) (sum_f_R0 An m) <=
-      R_dist (sum_f_R0 (fun i:nat => Rabs (An i)) n)
+    (Rdist (sum_f_R0 An n) (sum_f_R0 An m) <=
+      Rdist (sum_f_R0 (fun i:nat => Rabs (An i)) n)
       (sum_f_R0 (fun i:nat => Rabs (An i)) m)).
   - intro.
     apply Rle_lt_trans with
-      (R_dist (sum_f_R0 (fun i:nat => Rabs (An i)) n)
+      (Rdist (sum_f_R0 (fun i:nat => Rabs (An i)) n)
               (sum_f_R0 (fun i:nat => Rabs (An i)) m)).
     + assumption.
     + apply H1; assumption.
   - destruct (lt_eq_lt_dec n m) as [[ | -> ]|].
     + rewrite (tech2 An n m); [ idtac | assumption ].
       rewrite (tech2 (fun i:nat => Rabs (An i)) n m); [ idtac | assumption ].
-      unfold R_dist.
+      unfold Rdist.
       unfold Rminus.
       do 2 rewrite Ropp_plus_distr.
       do 2 rewrite <- Rplus_assoc.
@@ -414,12 +414,12 @@ Proof.
       * apply Rle_ge.
         apply cond_pos_sum.
         intro; apply Rabs_pos.
-    + unfold R_dist.
+    + unfold Rdist.
       unfold Rminus; do 2 rewrite Rplus_opp_r.
       rewrite Rabs_R0; right; reflexivity.
     + rewrite (tech2 An m n); [ idtac | assumption ].
       rewrite (tech2 (fun i:nat => Rabs (An i)) m n); [ idtac | assumption ].
-      unfold R_dist.
+      unfold Rdist.
       unfold Rminus.
       do 2 rewrite Rplus_assoc.
       rewrite (Rplus_comm (sum_f_R0 An m)).
@@ -455,8 +455,8 @@ Proof.
     elim (p (eps / 2) H0); intros.
     exists x0.
     intros.
-    apply Rle_lt_trans with (R_dist (sum_f_R0 An n) x + R_dist (sum_f_R0 An m) x).
-    + unfold R_dist.
+    apply Rle_lt_trans with (Rdist (sum_f_R0 An n) x + Rdist (sum_f_R0 An m) x).
+    + unfold Rdist.
       replace (sum_f_R0 An n - sum_f_R0 An m) with
         (sum_f_R0 An n - x + - (sum_f_R0 An m - x)); [ idtac | ring ].
       rewrite <- (Rabs_Ropp (sum_f_R0 An m - x)).
@@ -512,7 +512,7 @@ Proof.
         set (N0 := max x N); cut (N0 >= x)%nat.
         -- intro; assert (H5 := H3 N0 H4).
            cut (l1 <= sum_f_R0 An N0).
-           ++ intro; unfold R_dist in H5; rewrite Rabs_right in H5.
+           ++ intro; unfold Rdist in H5; rewrite Rabs_right in H5.
               ** cut (sum_f_R0 An N0 < l1).
                  { intro; elim (Rlt_irrefl _ (Rlt_le_trans _ _ _ H7 H6)). }
                  apply Rplus_lt_reg_l with (- l).
@@ -551,7 +551,7 @@ Proof.
         elim (H _ H3); intros Na H4.
         elim (H0 _ H3); intros Nb H5.
         set (N := max Na Nb).
-        unfold R_dist in H4, H5.
+        unfold Rdist in H4, H5.
         cut (Rabs (sum_f_R0 An N - l2) < (Rabs l1 - l2) / 2).
         1:intro; cut (Rabs (Rabs l1 - Rabs (SP fn N x)) < (Rabs l1 - l2) / 2).
         1:intro; cut (sum_f_R0 An N < (Rabs l1 + l2) / 2).

--- a/theories/Reals/Ranalysis1.v
+++ b/theories/Reals/Ranalysis1.v
@@ -83,7 +83,7 @@ Arguments continuity_pt f%F x0%R.
 Arguments continuity f%F.
 
 Lemma continuity_pt_locally_ext :
-  forall f g a x, 0 < a -> (forall y, R_dist y x < a -> f y = g y) ->
+  forall f g a x, 0 < a -> (forall y, Rdist y x < a -> f y = g y) ->
   continuity_pt f x -> continuity_pt g x.
 intros f g a x a0 q cf eps ep.
 destruct (cf eps ep) as [a' [a'p Pa']].
@@ -94,7 +94,7 @@ exists (Rmin a a'); split.
 - intros y cy; rewrite <- !q.
   + apply Pa'.
     split;[| apply Rlt_le_trans with (Rmin a a');[ | apply Rmin_r]];tauto.
-  + rewrite R_dist_eq; assumption.
+  + rewrite Rdist_eq; assumption.
   + apply Rlt_le_trans with (Rmin a a');[ | apply Rmin_l]; tauto.
 Qed.
 
@@ -138,7 +138,7 @@ Proof.
       intros; exists 1; split;
         [ apply Rlt_0_1
           | intros; generalize (H x x0); intro; rewrite H2; simpl;
-            rewrite R_dist_eq; assumption ].
+            rewrite Rdist_eq; assumption ].
 Qed.
 
 Lemma continuity_pt_scal :
@@ -149,7 +149,7 @@ Proof.
     intros; apply (limit_mul (fun x:R => a) f (D_x no_cond x0) a (f x0) x0).
   - unfold limit1_in; unfold limit_in; intros; exists 1; split.
     + apply Rlt_0_1.
-    + intros; rewrite R_dist_eq; assumption.
+    + intros; rewrite Rdist_eq; assumption.
   - assumption.
 Qed.
 
@@ -193,7 +193,7 @@ Proof.
     + apply H.
     + apply H0.
   - unfold limit1_in; unfold limit_in; unfold dist;
-      simpl; unfold R_dist; intros.
+      simpl; unfold Rdist; intros.
     assert (H3 := H1 eps H2).
     elim H3; intros.
     exists x0.
@@ -334,7 +334,7 @@ Proof.
   - unfold Rdiv; apply prod_neq_R0.
     + red; intro; rewrite H2 in H1; elim (Rlt_irrefl _ H1).
     + apply Rinv_neq_0_compat; discrR.
-  - unfold R_dist; unfold Rminus; rewrite Ropp_0;
+  - unfold Rdist; unfold Rminus; rewrite Ropp_0;
       rewrite Rplus_0_r; unfold Rdiv; rewrite Rabs_mult.
     replace (Rabs (/ 2)) with (/ 2).
     + replace (Rabs alp) with alp.
@@ -361,7 +361,7 @@ Proof.
   exists (pos x0).
   split.
   - apply (cond_pos x0).
-  - simpl; unfold R_dist; intros.
+  - simpl; unfold Rdist; intros.
     elim H3; intros.
     apply H2;
       [ assumption
@@ -379,7 +379,7 @@ Proof.
   elim (H eps H0).
   intros; elim H1; intros.
   exists (mkposreal x0 H2).
-  simpl; intros; unfold R_dist in H3; apply (H3 h).
+  simpl; intros; unfold Rdist in H3; apply (H3 h).
   split;
     [ assumption
       | unfold Rminus; rewrite Ropp_0; rewrite Rplus_0_r; assumption ].
@@ -437,7 +437,7 @@ Lemma derive_pt_D_in :
 Proof.
   intros; split.
   - unfold D_in; unfold limit1_in; unfold limit_in;
-      simpl; unfold R_dist; intros.
+      simpl; unfold Rdist; intros.
     apply derive_pt_eq_0.
     unfold derivable_pt_lim.
     intros; elim (H eps H0); intros alpha H1; elim H1; intros;
@@ -454,7 +454,7 @@ Proof.
   - intro.
     assert (H0 := derive_pt_eq_1 f x (df x) pr H).
     unfold D_in; unfold limit1_in; unfold limit_in;
-      unfold dist; simpl; unfold R_dist;
+      unfold dist; simpl; unfold Rdist;
       intros.
     elim (H0 eps H1); intros alpha H2; exists (pos alpha); split.
     + apply (cond_pos alpha).
@@ -471,7 +471,7 @@ Lemma derivable_pt_lim_D_in :
 Proof.
   intros; split.
   - unfold D_in; unfold limit1_in; unfold limit_in;
-      simpl; unfold R_dist; intros.
+      simpl; unfold Rdist; intros.
     unfold derivable_pt_lim.
     intros; elim (H eps H0); intros alpha H1; elim H1; intros;
       exists (mkposreal alpha H2); intros; generalize (H3 (x + h));
@@ -487,7 +487,7 @@ Proof.
   - intro.
     unfold derivable_pt_lim in H.
     unfold D_in; unfold limit1_in; unfold limit_in;
-      unfold dist; simpl; unfold R_dist;
+      unfold dist; simpl; unfold Rdist;
       intros.
     elim (H eps H0); intros alpha H2; exists (pos alpha); split.
     + apply (cond_pos alpha).
@@ -623,7 +623,7 @@ Proof.
       assumption.
   - unfold Dgf, D_in, no_cond; unfold limit1_in;
       unfold limit_in; unfold dist; simpl;
-      unfold R_dist; intros.
+      unfold Rdist; intros.
     elim (H1 eps H3); intros.
     exists x0; intros; split.
     + elim H5; intros; assumption.
@@ -639,9 +639,9 @@ Lemma derivable_pt_lim_opp :
 Proof.
   intros f x l H.
   apply uniqueness_step3.
-  unfold opp_fct, limit1_in, limit_in, dist; simpl; unfold R_dist.
+  unfold opp_fct, limit1_in, limit_in, dist; simpl; unfold Rdist.
   apply uniqueness_step2 in H.
-  unfold limit1_in, limit_in, dist in H; simpl in H; unfold R_dist in H.
+  unfold limit1_in, limit_in, dist in H; simpl in H; unfold Rdist in H.
   intros eps Heps; specialize (H eps Heps).
   destruct H as [alp [Halp H]]; exists alp.
   split; [assumption|].
@@ -656,9 +656,9 @@ Lemma derivable_pt_lim_opp_fwd :
 Proof.
   intros f x l H.
   apply uniqueness_step3.
-  unfold opp_fct, limit1_in, limit_in, dist; simpl; unfold R_dist.
+  unfold opp_fct, limit1_in, limit_in, dist; simpl; unfold Rdist.
   apply uniqueness_step2 in H.
-  unfold limit1_in, limit_in, dist in H; simpl in H; unfold R_dist in H.
+  unfold limit1_in, limit_in, dist in H; simpl in H; unfold Rdist in H.
   intros eps Heps; specialize (H eps Heps).
   destruct H as [alp [Halp H]]; exists alp.
   split; [assumption|].
@@ -715,7 +715,7 @@ Lemma derivable_pt_lim_plus :
       (limit_plus (fun h':R => (f1 (x + h') - f1 x) / h')
                   (fun h':R => (f2 (x + h') - f2 x) / h') (fun h:R => h <> 0) l1 l2 0 H1 H2).
     unfold limit1_in; unfold limit_in; unfold dist;
-      simpl; unfold R_dist; intros.
+      simpl; unfold Rdist; intros.
     elim (H4 eps H5); intros.
     exists x0.
     elim H6; intros.
@@ -744,7 +744,7 @@ Proof.
       (limit_minus (fun h':R => (f1 (x + h') - f1 x) / h')
                    (fun h':R => (f2 (x + h') - f2 x) / h') (fun h:R => h <> 0) l1 l2 0 H1 H2).
     unfold limit1_in; unfold limit_in; unfold dist;
-      simpl; unfold R_dist; intros.
+      simpl; unfold Rdist; intros.
     elim (H4 eps H5); intros.
     exists x0.
     elim H6; intros.

--- a/theories/Reals/Ranalysis2.v
+++ b/theories/Reals/Ranalysis2.v
@@ -380,7 +380,7 @@ Proof.
     (dist R_met (x0 + h) x0 < x ->
       dist R_met (f (x0 + h)) (f x0) < Rabs (f x0 / 2)).
   2:{ assert (H6 := Req_dec x0 (x0 + h)); elim H6; intro.
-      - intro; rewrite <- H7. unfold R_met, dist; unfold R_dist;
+      - intro; rewrite <- H7. unfold R_met, dist; unfold Rdist;
           unfold Rminus; rewrite Rplus_opp_r; rewrite Rabs_R0;
           apply Rabs_pos_lt.
         unfold Rdiv; apply prod_neq_R0;
@@ -391,7 +391,7 @@ Proof.
           split; trivial || assumption.
         + assumption.
   }
-  unfold dist; simpl; unfold R_dist;
+  unfold dist; simpl; unfold Rdist;
     replace (x0 + h - x0) with h by ring.
   intros; assert (H7 := H6 H4).
   red; intro.

--- a/theories/Reals/Ranalysis3.v
+++ b/theories/Reals/Ranalysis3.v
@@ -32,7 +32,7 @@ Proof.
   assert (H3 := derivable_continuous_pt _ _ X).
   unfold continuity_pt in H3; unfold continue_in in H3; unfold limit1_in in H3;
     unfold limit_in in H3; unfold dist in H3.
-  simpl in H3; unfold R_dist in H3.
+  simpl in H3; unfold Rdist in H3.
   elim (H3 (Rabs (f2 x) / 2));
     [ idtac
       | unfold Rdiv; change (0 < Rabs (f2 x) * / 2);
@@ -180,7 +180,7 @@ Proof.
   unfold limit_in in H10.
   unfold dist in H10.
   simpl in H10.
-  unfold R_dist in H10.
+  unfold Rdist in H10.
   elim (H10 (Rabs (eps * Rsqr (f2 x) / (8 * l1)))).
   2:{ change (0 < Rabs (eps * Rsqr (f2 x) / (8 * l1))).
       apply Rabs_pos_lt; unfold Rdiv, Rsqr; repeat rewrite Rmult_assoc;
@@ -352,7 +352,7 @@ Proof.
   unfold limit_in in H12.
   unfold dist in H12.
   simpl in H12.
-  unfold R_dist in H12.
+  unfold Rdist in H12.
   elim (H12 (Rabs (Rsqr (f2 x) * f2 x * eps / (8 * f1 x * l2)))).
   2:{ change (0 < Rabs (Rsqr (f2 x) * f2 x * eps / (8 * f1 x * l2))).
       apply Rabs_pos_lt.
@@ -455,7 +455,7 @@ Proof.
   unfold limit_in in H11.
   unfold dist in H11.
   simpl in H11.
-  unfold R_dist in H11.
+  unfold Rdist in H11.
   elim (H11 (Rabs (eps * Rsqr (f2 x) / (8 * l1)))).
   2:{ change (0 < Rabs (eps * Rsqr (f2 x) / (8 * l1))).
       apply Rabs_pos_lt.
@@ -557,7 +557,7 @@ Proof.
   unfold limit_in in H12.
   unfold dist in H12.
   simpl in H12.
-  unfold R_dist in H12.
+  unfold Rdist in H12.
   elim (H12 (Rabs (Rsqr (f2 x) * f2 x * eps / (8 * f1 x * l2)))).
   2:{ change (0 < Rabs (Rsqr (f2 x) * f2 x * eps / (8 * f1 x * l2)));
       apply Rabs_pos_lt.

--- a/theories/Reals/Ranalysis4.v
+++ b/theories/Reals/Ranalysis4.v
@@ -61,9 +61,9 @@ Proof.
   - intro H2; assert (H3 := uniqueness_step1 _ _ _ _ H0 H2).
     assumption.
   - unfold limit1_in; unfold limit_in; unfold dist;
-      simpl; unfold R_dist; unfold limit1_in in H1;
+      simpl; unfold Rdist; unfold limit1_in in H1;
       unfold limit_in in H1; unfold dist in H1; simpl in H1;
-      unfold R_dist in H1.
+      unfold Rdist in H1.
     intros; elim (H1 eps H2); intros.
     elim H3; intros.
     exists x2.
@@ -166,7 +166,7 @@ Proof.
   case (Req_dec x 0); intro.
   - unfold continuity_pt; unfold continue_in;
       unfold limit1_in; unfold limit_in;
-      simpl; unfold R_dist; intros; exists eps;
+      simpl; unfold Rdist; intros; exists eps;
       split.
     + apply H0.
     + intros; rewrite H; rewrite Rabs_R0; unfold Rminus; rewrite Ropp_0;

--- a/theories/Reals/Ranalysis5.v
+++ b/theories/Reals/Ranalysis5.v
@@ -246,12 +246,12 @@ Proof.
   split.
   - apply Rle_cv_lim with (Vn:=dicho_up x y D) (Un:=fun n => x).
     + intro n ; exact (proj1 (Main n)).
-    + unfold Un_cv ; intros ; exists 0%nat ; intros ; unfold R_dist ; replace (x -x) with 0 by field ; rewrite Rabs_R0 ; assumption.
+    + unfold Un_cv ; intros ; exists 0%nat ; intros ; unfold Rdist ; replace (x -x) with 0 by field ; rewrite Rabs_R0 ; assumption.
     + assumption.
   - apply Rle_cv_lim with (Un:=dicho_up x y D) (Vn:=fun n => y).
     + intro n ; exact (proj2 (Main n)).
     + assumption.
-    + unfold Un_cv ; intros ; exists 0%nat ; intros ; unfold R_dist ; replace (y -y) with 0 by field ; rewrite Rabs_R0 ; assumption.
+    + unfold Un_cv ; intros ; exists 0%nat ; intros ; unfold Rdist ; replace (y -y) with 0 by field ; rewrite Rabs_R0 ; assumption.
 Qed.
 
 Lemma IVT_interv : forall (f : R -> R) (x y : R),
@@ -344,7 +344,7 @@ Proof.
       destruct (total_order_T 0 (f x0)) as [[Hlt|<-]|Hgt].
       - left; assumption.
       - right; reflexivity.
-      - unfold Un_cv in H7; unfold R_dist in H7.
+      - unfold Un_cv in H7; unfold Rdist in H7.
         cut (0 < - f x0).
         { intro.
           elim (H7 (- f x0) H8); intros.
@@ -367,7 +367,7 @@ Proof.
   { apply IVT_interv_prelim1 with (D:=(fun z : R => cond_positivity (f z))) ; assumption. }
   assert (H7 := continuity_seq f Vn x0 (H x0 Temp) H5).
   destruct (total_order_T 0 (f x0)) as [[Hlt|Heq]|].
-  - unfold Un_cv in H7; unfold R_dist in H7.
+  - unfold Un_cv in H7; unfold Rdist in H7.
     elim (H7 (f x0) Hlt); intros.
     cut (x2 >= x2)%nat; [ intro | unfold ge; apply le_n ].
     assert (H10 := H8 x2 H9).
@@ -414,7 +414,7 @@ Proof.
   - intro y_encad4.
     clear y_encad y_encad1 y_encad3.
     assert (Cont : forall a : R, lb <= a <= ub -> continuity_pt (fun x => f x - y) a).
-    { intros a a_encad. unfold continuity_pt, continue_in, limit1_in, limit_in ; simpl ; unfold R_dist.
+    { intros a a_encad. unfold continuity_pt, continue_in, limit1_in, limit_in ; simpl ; unfold Rdist.
       intros eps eps_pos. elim (f_cont_interv a a_encad eps eps_pos).
       intros alpha alpha_pos. destruct alpha_pos as (alpha_pos,Temp).
       exists alpha. split.
@@ -488,7 +488,7 @@ Proof.
     { intro cond. apply Rlt_le ; apply f_incr_interv ; assumption. }
     intro cond ; right ; rewrite cond ; reflexivity. }
   unfold continuity_pt, continue_in, limit1_in, limit_in ; intros eps eps_pos.
-  unfold dist ; simpl ; unfold R_dist.
+  unfold dist ; simpl ; unfold Rdist.
   assert (b_encad_e : f lb <= b <= f ub) by intuition.
   elim (f_interv_is_interv f lb ub b lb_lt_ub b_encad_e f_cont_interv) ; intros x Temp.
   destruct Temp as (x_encad,f_x_b).
@@ -665,9 +665,9 @@ Proof.
     exists deltatemp ; exact Htemp. }
   elim (Hf_deriv eps eps_pos).
   intros deltatemp Htemp.
-  red in Hlinv ; red in Hlinv ; unfold dist in Hlinv ; unfold R_dist in Hlinv.
+  red in Hlinv ; red in Hlinv ; unfold dist in Hlinv ; unfold Rdist in Hlinv.
   assert (Hlinv' := Hlinv (fun h => (f (y+h) - f y)/h) (fun h => h <>0) l 0).
-  unfold limit1_in, limit_in, dist in Hlinv' ; simpl in Hlinv'. unfold R_dist in Hlinv'.
+  unfold limit1_in, limit_in, dist in Hlinv' ; simpl in Hlinv'. unfold Rdist in Hlinv'.
   assert (Premisse : forall eps : R,
              eps > 0 ->
              exists alp : R,
@@ -792,7 +792,7 @@ Proof.
   unfold continuity_pt, continue_in, limit1_in, limit_in in g_cont_pur.
   elim (g_cont_pur mydelta mydelta_pos).
   intros delta3 cond3.
-  unfold dist in cond3 ; simpl in cond3 ; unfold R_dist in cond3.
+  unfold dist in cond3 ; simpl in cond3 ; unfold Rdist in cond3.
   unfold h'.
   assert (mydelta_le_alpha : mydelta <= alpha).
   { unfold mydelta, Rmin ; case (Rle_dec delta alpha).
@@ -800,7 +800,7 @@ Proof.
     intro ; intuition. }
   apply Rlt_le_trans with (r2:=mydelta).
   2:assumption.
-  unfold dist in g_cont ; simpl in g_cont ; unfold R_dist in g_cont ; apply g_cont.
+  unfold dist in g_cont ; simpl in g_cont ; unfold Rdist in g_cont ; apply g_cont.
   split.
   { unfold D_x ; simpl.
     split.
@@ -1239,12 +1239,12 @@ Proof.
     replace (h * fn' N c - h * g x) with (h * (fn' N c - g x)) by field.
     rewrite Rabs_mult.
     apply Rlt_trans with (Rabs h * eps / 4 + Rabs (f x - fn N x) + Rabs h * Rabs (fn' N c - g x)).
-    { apply Rplus_lt_compat_r ; apply Rplus_lt_compat_r ; unfold R_dist in fnxh_CV_fxh ;
+    { apply Rplus_lt_compat_r ; apply Rplus_lt_compat_r ; unfold Rdist in fnxh_CV_fxh ;
         rewrite Rabs_minus_sym ; apply fnxh_CV_fxh.
       unfold N; lia. }
     apply Rlt_trans with (Rabs h * eps / 4 + Rabs h * eps / 4 + Rabs h * Rabs (fn' N c - g x)).
     { apply Rplus_lt_compat_r ; apply Rplus_lt_compat_l.
-      unfold R_dist in fnx_CV_fx ; rewrite Rabs_minus_sym ; apply fnx_CV_fx.
+      unfold Rdist in fnx_CV_fx ; rewrite Rabs_minus_sym ; apply fnx_CV_fx.
       unfold N ; lia. }
     replace (fn' N c - g x)  with ((fn' N c - g c) +  (g c - g x)) by field.
     apply Rle_lt_trans with (Rabs h * eps / 4 + Rabs h * eps / 4 +
@@ -1325,12 +1325,12 @@ Proof.
   { replace (h * fn' N c - h * g x) with (h * (fn' N c - g x)) by field.
     rewrite Rabs_mult.
     apply Rlt_trans with (Rabs h * eps / 4 + Rabs (f x - fn N x) + Rabs h * Rabs (fn' N c - g x)).
-    { apply Rplus_lt_compat_r ; apply Rplus_lt_compat_r ; unfold R_dist in fnxh_CV_fxh ;
+    { apply Rplus_lt_compat_r ; apply Rplus_lt_compat_r ; unfold Rdist in fnxh_CV_fxh ;
         rewrite Rabs_minus_sym ; apply fnxh_CV_fxh.
       unfold N; lia. }
     apply Rlt_trans with (Rabs h * eps / 4 + Rabs h * eps / 4 + Rabs h * Rabs (fn' N c - g x)).
     { apply Rplus_lt_compat_r ; apply Rplus_lt_compat_l.
-      unfold R_dist in fnx_CV_fx ; rewrite Rabs_minus_sym ; apply fnx_CV_fx.
+      unfold Rdist in fnx_CV_fx ; rewrite Rabs_minus_sym ; apply fnx_CV_fx.
       unfold N ; lia. }
     replace (fn' N c - g x)  with ((fn' N c - g c) +  (g c - g x)) by field.
     apply Rle_lt_trans with (Rabs h * eps / 4 + Rabs h * eps / 4 +

--- a/theories/Reals/Ratan.v
+++ b/theories/Reals/Ratan.v
@@ -64,7 +64,7 @@ Lemma Alt_first_term_bound : forall f l N n,
     Un_decreasing f -> Un_cv f 0 ->
     Un_cv (sum_f_R0 (tg_alt f)) l ->
     (N <= n)%nat ->
-    R_dist (sum_f_R0 (tg_alt f) n) l <= f N.
+    Rdist (sum_f_R0 (tg_alt f) n) l <= f N.
 Proof.
   intros f l.
   assert (WLOG :
@@ -75,7 +75,7 @@ Proof.
   intros N; pattern N; apply WLOG; clear N.
   2:{ clear WLOG; intros Hyp [ | n] decr to0 cv _.
       { generalize (alternated_series_ineq f l 0 decr to0 cv).
-        unfold R_dist, tg_alt; simpl; rewrite !Rmult_1_l, !Rmult_1_r.
+        unfold Rdist, tg_alt; simpl; rewrite !Rmult_1_l, !Rmult_1_r.
         assert (f 1%nat <= f 0%nat) by apply decr.
         intros [A B]; rewrite Rabs_pos_eq; lra. }
       apply Rle_trans with (f 1%nat).
@@ -97,11 +97,11 @@ Proof.
     intros n' nM.
     match goal with |- ?C => set (U := C) end.
     assert (nM' : (n' + S N >= M)%nat) by lia.
-    generalize (PM _ nM'); unfold R_dist.
+    generalize (PM _ nM'); unfold Rdist.
     rewrite (tech2 (tg_alt f) N (n' + S N)).
     2:lia.
     assert (t : forall a b c, (a + b) - c = b - (c - a)) by (intros; ring).
-    rewrite t; clear t; unfold U, R_dist; clear U.
+    rewrite t; clear t; unfold U, Rdist; clear U.
     replace (n' + S N - S N)%nat with n' by lia.
     rewrite <- (sum_eq (tg_alt (fun i => (-1) ^ S N * f(S N + i)%nat))).
     { tauto. }
@@ -117,14 +117,14 @@ Proof.
       rewrite <- pow_mult, Nat.mul_comm, pow_mult; replace ((-1) ^2) with 1 by ring.
       rewrite pow1; reflexivity. }
     apply CV_mult.
-    { solve[intros eps ep; exists 0%nat; intros; rewrite R_dist_eq; auto]. }
+    { solve[intros eps ep; exists 0%nat; intros; rewrite Rdist_eq; auto]. }
     assumption. }
   destruct (even_odd_cor N) as [p [Neven | Nodd]].
   - rewrite Neven; destruct (alternated_series_ineq _ _ p decr to0 cv) as [B C].
     case (even_odd_cor n) as [p' [neven | nodd]].
     + rewrite neven.
       destruct (alternated_series_ineq _ _ p' decr to0 cv) as [D E].
-      unfold R_dist; rewrite Rabs_pos_eq;[ | lra].
+      unfold Rdist; rewrite Rabs_pos_eq;[ | lra].
       assert (dist : (p <= p')%nat) by lia.
       assert (t := decreasing_prop _ _ _ (CV_ALT_step1 f decr) dist).
       apply Rle_trans with (sum_f_R0 (tg_alt f) (2 * p) - l).
@@ -135,7 +135,7 @@ Proof.
           (rewrite tech5; unfold tg_alt; rewrite pow_1_odd; ring); lra
       end.
     + rewrite nodd; destruct (alternated_series_ineq _ _ p' decr to0 cv) as [D E].
-      unfold R_dist; rewrite <- Rabs_Ropp, Rabs_pos_eq, Ropp_minus_distr;
+      unfold Rdist; rewrite <- Rabs_Ropp, Rabs_pos_eq, Ropp_minus_distr;
         [ | lra].
       assert (dist : (p <= p')%nat) by lia.
       apply Rle_trans with (l - sum_f_R0 (tg_alt f) (S (2 * p))).
@@ -149,7 +149,7 @@ Proof.
     case (even_odd_cor n) as [p' [neven | nodd]].
     + rewrite neven;
         destruct (alternated_series_ineq _ _ p' decr to0 cv) as [D E].
-      unfold R_dist; rewrite Rabs_pos_eq;[ | lra].
+      unfold Rdist; rewrite Rabs_pos_eq;[ | lra].
       assert (dist : (S p < S p')%nat) by lia.
       apply Rle_trans with (sum_f_R0 (tg_alt f) (2 * S p) - l).
       { unfold Rminus; apply Rplus_le_compat_r,
@@ -158,7 +158,7 @@ Proof.
       rewrite keep, tech5; unfold tg_alt at 2; rewrite <- keep, pow_1_even.
       lra.
     + rewrite nodd; destruct (alternated_series_ineq _ _ p' decr to0 cv) as [D E].
-      unfold R_dist; rewrite <- Rabs_Ropp, Rabs_pos_eq;[ | lra].
+      unfold Rdist; rewrite <- Rabs_Ropp, Rabs_pos_eq;[ | lra].
       rewrite Ropp_minus_distr.
       apply Rle_trans with (l - sum_f_R0 (tg_alt f) (S (2 * p))).
       { unfold Rminus; apply Rplus_le_compat_l, Ropp_le_contravar, Rge_le,
@@ -186,7 +186,7 @@ Proof.
   apply Rle_lt_trans with (h n).
   { apply bound; assumption. }
   clear - nN Pn.
-  generalize (Pn _ nN); unfold R_dist; rewrite Rminus_0_r; intros t.
+  generalize (Pn _ nN); unfold Rdist; rewrite Rminus_0_r; intros t.
   apply Rabs_def2 in t; tauto.
 Qed.
 
@@ -379,7 +379,7 @@ assert (f_cont : forall a : R, lb <= a <= ub -> continuity_pt tan a).
   - apply Rlt_le_trans with (r2:=lb) ; intuition.
   - apply Rle_lt_trans with (r2:=ub) ; intuition. }
 assert (Cont : forall a : R, lb <= a <= ub -> continuity_pt (fun x => tan x - y) a).
-{ intros a a_encad. unfold continuity_pt, continue_in, limit1_in, limit_in ; simpl ; unfold R_dist.
+{ intros a a_encad. unfold continuity_pt, continue_in, limit1_in, limit_in ; simpl ; unfold Rdist.
   intros eps eps_pos. elim (f_cont a a_encad eps eps_pos).
   intros alpha alpha_pos. destruct alpha_pos as (alpha_pos,Temp).
   exists alpha. split.
@@ -837,7 +837,7 @@ fold N in HN.
 clear H H0.
 exists N.
 intros n Hn.
-unfold R_dist.
+unfold Rdist.
 rewrite Rminus_0_r.
 unfold Ratan_seq.
 rewrite Rabs_right.
@@ -925,7 +925,7 @@ apply (Un_cv_ext (fun n => (- 1) * sum_f_R0 (tg_alt (Ratan_seq (- x))) n)).
 { intros n; rewrite sum_Ratan_seq_opp; ring. }
 replace (-v) with (-1 * v) by ring.
 apply CV_mult;[ | assumption].
-solve[intros; exists 0%nat; intros; rewrite R_dist_eq; auto].
+solve[intros; exists 0%nat; intros; rewrite Rdist_eq; auto].
 Qed.
 
 Definition in_int (x : R) : {-1 <= x <= 1}+{~ -1 <= x <= 1}.
@@ -955,7 +955,7 @@ destruct (in_int 0) as [h1 | h2].
   { symmetry;apply sum_eq_R0.
     intros i _; unfold tg_alt, Ratan_seq; rewrite Nat.add_comm; simpl.
     unfold Rdiv; rewrite !Rmult_0_l, Rmult_0_r; reflexivity. }
-  intros eps ep; exists 0%nat; intros n _; unfold R_dist.
+  intros eps ep; exists 0%nat; intros n _; unfold Rdist.
   rewrite Rminus_0_r, Rabs_pos_eq; auto with real. }
 case h2; split; lra.
 Qed.
@@ -967,7 +967,7 @@ intros x h h'; destruct (ps_atan_exists_1 (-x) h) as [v Pv].
 destruct (ps_atan_exists_1 x h') as [u Pu]; simpl.
 assert (Pu' : Un_cv (fun N => (-1) * sum_f_R0 (tg_alt (Ratan_seq x)) N) (-1 * u)).
 { apply CV_mult;[ | assumption].
-  intros eps ep; exists 0%nat; intros; rewrite R_dist_eq; assumption. }
+  intros eps ep; exists 0%nat; intros; rewrite Rdist_eq; assumption. }
 assert (Pv' : Un_cv
                 (fun N : nat => -1 * sum_f_R0 (tg_alt (Ratan_seq x)) N) v).
 { apply Un_cv_ext with (2 := Pv); intros n; rewrite sum_Ratan_seq_opp; ring. }
@@ -1156,7 +1156,7 @@ assert (x_ub2 : Rabs (x^2) < 1).
     by (split;[apply Rabs_pos | apply Rabs_def1; auto]).
   apply (pow_lt_1_compat _ 2) in H;[tauto | lia]. }
 elim (pow_lt_1_zero (x^2) x_ub2 eps eps_pos) ; intros N HN ; exists N ; intros n Hn.
-unfold R_dist, Datan_seq.
+unfold Rdist, Datan_seq.
 replace (x ^ (2 * n) - 0) with ((x ^ 2) ^ n). { apply HN ; assumption. }
 rewrite pow_mult ; field.
 Qed.
@@ -1183,7 +1183,7 @@ assert (H1 : - x^2 <> 1).
 { apply Rlt_not_eq; apply Rle_lt_trans with (2 := Rlt_0_1).
   assert (t := pow2_ge_0 x); lra. }
 rewrite Datan_sum_eq.
-unfold R_dist.
+unfold Rdist.
 assert (tool : forall a b, a / b - /b = (-1 + a) /b).
 { intros a b; rewrite <- (Rmult_1_l (/b)); unfold Rdiv, Rminus.
   rewrite <- Ropp_mult_distr_l_reverse, Rmult_plus_distr_r, Rplus_comm.
@@ -1462,7 +1462,7 @@ Qed.
 
 Lemma ps_atan_continuity_pt_1 : forall eps : R,
   eps > 0 ->
-  exists alp : R, alp > 0 /\ (forall x, x < 1 -> 0 < x -> R_dist x 1 < alp ->
+  exists alp : R, alp > 0 /\ (forall x, x < 1 -> 0 < x -> Rdist x 1 < alp ->
   dist R_met (ps_atan x) (Alt_PI/4) < eps).
 Proof.
 intros eps eps_pos.
@@ -1480,7 +1480,7 @@ assert (O_lb : 0 <= 1) by intuition ; assert (O_ub : 1 <= 1) by intuition ;
   clear -HN1 HN2 Halpha eps_3_pos; destruct Halpha as (alpha_pos, Halpha).
 exists alpha ; split;[assumption | ].
 intros x x_ub x_lb x_bounds.
-simpl ; unfold R_dist.
+simpl ; unfold Rdist.
 replace (ps_atan x - v) with
   ((ps_atan x - sum_f_R0 (tg_alt (Ratan_seq x)) N)
    + (sum_f_R0 (tg_alt (Ratan_seq x)) N - sum_f_R0 (tg_alt (Ratan_seq 1)) N)
@@ -1500,7 +1500,7 @@ apply Rplus_lt_compat.
   { apply Rabs_triang. }
   apply Rlt_le_trans with (r2:= eps / 3 + eps / 3).
   { apply Rplus_lt_compat.
-    { simpl in Halpha ; unfold R_dist in Halpha.
+    { simpl in Halpha ; unfold Rdist in Halpha.
       apply Halpha ; split.
       { unfold D_x, no_cond ; split ; [ | apply Rgt_not_eq ] ; intuition. }
       intuition. }
@@ -1609,7 +1609,7 @@ assert (t2 := PI_4).
 assert (m := Alt_PI_RGT_0).
 assert (-PI/2 < 1 < PI/2) by (rewrite Ropp_div; split; lra).
 apply cond_eq; intros eps ep.
-change (R_dist (Alt_PI/4) (PI/4) < eps).
+change (Rdist (Alt_PI/4) (PI/4) < eps).
 assert (ca : continuity_pt atan 1).
 { apply derivable_continuous_pt, derivable_pt_atan. }
 assert (Xe : exists eps', exists eps'',
@@ -1618,8 +1618,8 @@ assert (Xe : exists eps', exists eps'',
 destruct Xe as [eps' [eps'' [eps_ineq [ep' ep'']]]].
 destruct (ps_atan_continuity_pt_1 _ ep') as [alpha [a0 Palpha]].
 destruct (ca _ ep'') as [beta [b0 Pbeta]].
-assert (Xa : exists a, 0 < a < 1 /\ R_dist a 1 < alpha /\
-                    R_dist a 1 < beta).
+assert (Xa : exists a, 0 < a < 1 /\ Rdist a 1 < alpha /\
+                    Rdist a 1 < beta).
 { exists (Rmax (/2) (Rmax (1 - alpha /2) (1 - beta /2))).
   assert (/2 <= Rmax (/2) (Rmax (1 - alpha /2) (1 - beta /2))) by apply Rmax_l.
   assert (Rmax (1 - alpha /2) (1 - beta /2) <=
@@ -1633,13 +1633,13 @@ assert (Xa : exists a, 0 < a < 1 /\ R_dist a 1 < alpha /\
   { assert (Rmax (/2) (Rmax (1 - alpha / 2)
                             (1 - beta /2)) <= 1) by (apply Rmax_lub; lra).
     lra. }
-  split; unfold R_dist; rewrite <-Rabs_Ropp, Ropp_minus_distr,
+  split; unfold Rdist; rewrite <-Rabs_Ropp, Ropp_minus_distr,
     Rabs_pos_eq;lra. }
 destruct Xa as [a [[Pa0 Pa1] [P1 P2]]].
-apply Rle_lt_trans with (1 := R_dist_tri _ _ (ps_atan a)).
+apply Rle_lt_trans with (1 := Rdist_tri _ _ (ps_atan a)).
 apply Rlt_le_trans with (2 := eps_ineq).
 apply Rplus_lt_compat.
-{ rewrite R_dist_sym; apply Palpha; assumption. }
+{ rewrite Rdist_sym; apply Palpha; assumption. }
 rewrite <- atan_eq_ps_atan.
 { rewrite <- atan_1; apply (Pbeta a); auto.
   split; [ | exact P2].

--- a/theories/Reals/Rcomplete.v
+++ b/theories/Reals/Rcomplete.v
@@ -45,7 +45,7 @@ Proof.
       elim (p0 (eps / 3) H4); intros.
       exists (max x1 x2).
       intros.
-      unfold R_dist.
+      unfold Rdist.
       apply Rle_lt_trans with (Rabs (Un n - Vn n) + Rabs (Vn n - x)).
       { replace (Un n - x) with (Un n - Vn n + (Vn n - x));
           [ apply Rabs_triang | ring ]. }
@@ -82,19 +82,19 @@ Proof.
              [ apply Rabs_triang | ring ].
         -- apply Rlt_le_trans with (eps / 3 + eps / 3 + eps / 3).
            1:repeat apply Rplus_lt_compat.
-           ++ unfold R_dist in H1.
+           ++ unfold Rdist in H1.
               apply H1.
               unfold ge; apply Nat.le_trans with (max x1 x2).
               ** apply Nat.le_max_l.
               ** assumption.
            ++ rewrite <- Rabs_Ropp.
               replace (- (x - Vn n)) with (Vn n - x); [ idtac | ring ].
-              unfold R_dist in H3.
+              unfold Rdist in H3.
               apply H3.
               unfold ge; apply Nat.le_trans with (max x1 x2).
               ** apply Nat.le_max_r.
               ** assumption.
-           ++ unfold R_dist in H3.
+           ++ unfold Rdist in H3.
               apply H3.
               unfold ge; apply Nat.le_trans with (max x1 x2).
               ** apply Nat.le_max_r.
@@ -110,11 +110,11 @@ Proof.
     cut (0 < eps / 5).
      + intro.
        unfold Un_cv in p; unfold Un_cv in p0.
-       unfold R_dist in p; unfold R_dist in p0.
+       unfold Rdist in p; unfold Rdist in p0.
        elim (p (eps / 5) H1); intros N1 H4.
        elim (p0 (eps / 5) H1); intros N2 H5.
        unfold Cauchy_crit in H.
-       unfold R_dist in H.
+       unfold Rdist in H.
        elim (H (eps / 5) H1); intros N3 H6.
        set (N := max (max N1 N2) N3).
        apply Rle_lt_trans with (Rabs (x - Wn N) + Rabs (Wn N - x0)).

--- a/theories/Reals/Rderiv.v
+++ b/theories/Reals/Rderiv.v
@@ -43,13 +43,13 @@ Proof.
   - split with (Rmin 1 x); split.
     + elim (Rmin_Rgt 1 x 0); intros a b; apply (b (conj Rlt_0_1 H)).
     + intros; elim H3; clear H3; intros;
-        generalize (let (H1, H2) := Rmin_Rgt 1 x (R_dist x1 x0) in H1);
+        generalize (let (H1, H2) := Rmin_Rgt 1 x (Rdist x1 x0) in H1);
         unfold Rgt; intro; elim (H5 H4); clear H5;
         intros; generalize (H1 x1 (conj H3 H6)); clear H1;
         intro; unfold D_x in H3; elim H3; intros.
-      rewrite H2 in H1; unfold R_dist; unfold R_dist in H1;
+      rewrite H2 in H1; unfold Rdist; unfold Rdist in H1;
         cut (Rabs (f x1 - f x0) < eps * Rabs (x1 - x0)).
-      * intro; unfold R_dist in H5;
+      * intro; unfold Rdist in H5;
           generalize (Rmult_lt_compat_l eps (Rabs (x1 - x0)) 1 H0 H5);
           rewrite Rmult_1_r; intro; apply Rlt_trans with (r2 := eps * Rabs (x1 - x0));
           assumption.
@@ -81,9 +81,9 @@ Proof.
     + intros; elim H3; clear H3; intros;
         generalize
           (let (H1, H2) :=
-             Rmin_Rgt (Rmin (/ 2) x) (eps * / Rabs (2 * d x0)) (R_dist x1 x0) in
+             Rmin_Rgt (Rmin (/ 2) x) (eps * / Rabs (2 * d x0)) (Rdist x1 x0) in
            H1); unfold Rgt; intro; elim (H5 H4); clear H5;
-        intros; generalize (let (H1, H2) := Rmin_Rgt (/ 2) x (R_dist x1 x0) in H1);
+        intros; generalize (let (H1, H2) := Rmin_Rgt (/ 2) x (Rdist x1 x0) in H1);
         unfold Rgt; intro; elim (H7 H5); clear H7;
         intros; clear H4 H5; generalize (H1 x1 (conj H3 H8));
         clear H1; intro; unfold D_x in H3; elim H3; intros;
@@ -91,7 +91,7 @@ Proof.
         generalize (Rminus_eq_contra x1 x0 H5); intro; generalize H1;
         pattern (d x0) at 1;
         rewrite <- (let (H1, H2) := Rmult_ne (d x0) in H2);
-        rewrite <- (Rinv_l (x1 - x0) H9); unfold R_dist;
+        rewrite <- (Rinv_l (x1 - x0) H9); unfold Rdist;
         unfold Rminus at 1; rewrite (Rmult_comm (f x1 - f x0) (/ (x1 - x0)));
         rewrite (Rmult_comm (/ (x1 - x0) * (x1 - x0)) (d x0));
         rewrite <- (Ropp_mult_distr_l_reverse (d x0) (/ (x1 - x0) * (x1 - x0)));
@@ -138,12 +138,12 @@ Proof.
                        (Rabs (d x0 * (x1 - x0)) + Rabs (x1 - x0) * eps) eps H1 H11).
       * clear H1 H5 H3 H10; generalize (Rabs_pos_lt (d x0) H2); intro;
           unfold Rgt in H0;
-          generalize (Rmult_lt_compat_l eps (R_dist x1 x0) (/ 2) H0 H7);
+          generalize (Rmult_lt_compat_l eps (Rdist x1 x0) (/ 2) H0 H7);
           clear H7; intro;
           generalize
-            (Rmult_lt_compat_l (Rabs (d x0)) (R_dist x1 x0) (
+            (Rmult_lt_compat_l (Rabs (d x0)) (Rdist x1 x0) (
                                  eps * / Rabs (2 * d x0)) H1 H6); clear H6; intro;
-          rewrite (Rmult_comm eps (R_dist x1 x0)) in H3; unfold R_dist in H3, H5;
+          rewrite (Rmult_comm eps (Rdist x1 x0)) in H3; unfold Rdist in H3, H5;
           rewrite <- (Rabs_mult (d x0) (x1 - x0)) in H5;
           rewrite (Rabs_mult 2 (d x0)) in H5; cut (Rabs 2 <> 0).
         -- intro; fold (Rabs (d x0) > 0) in H1;
@@ -179,7 +179,7 @@ Proof.
     unfold limit_in; unfold Rdiv; intros;
       simpl; split with eps; split; auto.
   intros; rewrite (Rminus_diag_eq y y (eq_refl y)); rewrite Rmult_0_l;
-    unfold R_dist; rewrite (Rminus_diag_eq 0 0 (eq_refl 0));
+    unfold Rdist; rewrite (Rminus_diag_eq 0 0 (eq_refl 0));
       unfold Rabs; case (Rcase_abs 0); intro.
   - absurd (0 < 0); auto.
     red; intro; apply (Rlt_irrefl 0 H1).
@@ -195,7 +195,7 @@ Proof.
       split; auto.
   intros; elim H0; clear H0; intros; unfold D_x in H0; elim H0; intros;
     rewrite (Rinv_r (x - x0) (Rminus_eq_contra x x0 (sym_not_eq H3)));
-      unfold R_dist; rewrite (Rminus_diag_eq 1 1 (refl_equal 1));
+      unfold Rdist; rewrite (Rminus_diag_eq 1 1 (refl_equal 1));
         unfold Rabs; case (Rcase_abs 0) as [Hlt|Hge].
   - absurd (0 < 0); auto.
     red in |- *; intro; apply (Rlt_irrefl 0 Hlt).
@@ -270,7 +270,7 @@ Proof.
     + intro; rewrite H3 in H1; assumption.
     + ring.
   - unfold limit1_in; unfold limit_in; simpl; intros;
-      split with eps; split; auto; intros; elim (R_dist_refl (g x0) (g x0));
+      split with eps; split; auto; intros; elim (Rdist_refl (g x0) (g x0));
       intros a b; rewrite (b (eq_refl (g x0))); unfold Rgt in H;
       assumption.
 Qed.
@@ -379,7 +379,7 @@ Proof.
       clear H5 H7; intros; elim H5; elim H7; clear H5 H7;
       intros; split with (Rmin x x1); split.
     + elim (Rmin_Rgt x x1 0); intros a b; apply (b (conj H9 H5)); clear a b.
-    + intros; elim H11; clear H11; intros; elim (Rmin_Rgt x x1 (R_dist x2 x0));
+    + intros; elim H11; clear H11; intros; elim (Rmin_Rgt x x1 (Rdist x2 x0));
         intros a b; clear b; unfold Rgt in a; elim (a H12);
         clear H5 a; intros; unfold D_x, Dgf in H11, H7, H10;
         clear H12; elim (Req_dec (f x2) (f x0)); intro.
@@ -392,7 +392,7 @@ Proof.
           rewrite (Rmult_0_l (/ (x2 - x0))); assumption.
       * clear H10 H5; elim H11; clear H11; intros; elim H5; clear H5; intros;
           cut
-            (((Df x2 /\ x0 <> x2) /\ Dg (f x2) /\ f x0 <> f x2) /\ R_dist x2 x0 < x1);
+            (((Df x2 /\ x0 <> x2) /\ Dg (f x2) /\ f x0 <> f x2) /\ Rdist x2 x0 < x1);
           auto; intro; generalize (H7 x2 H14); intro;
           generalize (Rminus_eq_contra (f x2) (f x0) H12); intro;
           rewrite

--- a/theories/Reals/Rfunctions.v
+++ b/theories/Reals/Rfunctions.v
@@ -850,21 +850,21 @@ Qed.
 (*******************************)
 
 (*********)
-Definition R_dist (x y:R) : R := Rabs (x - y).
+Definition Rdist (x y:R) : R := Rabs (x - y).
 
 (*********)
-Lemma R_dist_pos : forall x y:R, R_dist x y >= 0.
+Lemma Rdist_pos : forall x y:R, Rdist x y >= 0.
 Proof.
-  intros; unfold R_dist; unfold Rabs; case (Rcase_abs (x - y));
+  intros; unfold Rdist; unfold Rabs; case (Rcase_abs (x - y));
     intro l.
   - unfold Rge; left; apply (Ropp_gt_lt_0_contravar (x - y) l).
   - trivial.
 Qed.
 
 (*********)
-Lemma R_dist_sym : forall x y:R, R_dist x y = R_dist y x.
+Lemma Rdist_sym : forall x y:R, Rdist x y = Rdist y x.
 Proof.
-  unfold R_dist; intros; split_Rabs; try ring.
+  unfold Rdist; intros; split_Rabs; try ring.
   - generalize (Ropp_gt_lt_0_contravar (y - x) Hlt0); intro;
       rewrite (Ropp_minus_distr y x) in H; generalize (Rlt_asym (x - y) 0 Hlt);
       intro; unfold Rgt in H; exfalso; auto.
@@ -874,9 +874,9 @@ Proof.
 Qed.
 
 (*********)
-Lemma R_dist_refl : forall x y:R, R_dist x y = 0 <-> x = y.
+Lemma Rdist_refl : forall x y:R, Rdist x y = 0 <-> x = y.
 Proof.
-  unfold R_dist; intros; split_Rabs; split; intros.
+  unfold Rdist; intros; split_Rabs; split; intros.
   - rewrite (Ropp_minus_distr x y) in H; symmetry;
       apply (Rminus_diag_uniq y x H).
   - rewrite (Ropp_minus_distr x y); generalize (eq_sym H); intro;
@@ -885,34 +885,43 @@ Proof.
   - apply (Rminus_diag_eq x y H).
 Qed.
 
-Lemma R_dist_eq : forall x:R, R_dist x x = 0.
+Lemma Rdist_eq : forall x:R, Rdist x x = 0.
 Proof.
-  unfold R_dist; intros; split_Rabs; intros; ring.
+  unfold Rdist; intros; split_Rabs; intros; ring.
 Qed.
 
 (***********)
-Lemma R_dist_tri : forall x y z:R, R_dist x y <= R_dist x z + R_dist z y.
+Lemma Rdist_tri : forall x y z:R, Rdist x y <= Rdist x z + Rdist z y.
 Proof.
-  intros; unfold R_dist; replace (x - y) with (x - z + (z - y));
+  intros; unfold Rdist; replace (x - y) with (x - z + (z - y));
     [ apply (Rabs_triang (x - z) (z - y)) | ring ].
 Qed.
 
 (*********)
-Lemma R_dist_plus :
-  forall a b c d:R, R_dist (a + c) (b + d) <= R_dist a b + R_dist c d.
+Lemma Rdist_plus :
+  forall a b c d:R, Rdist (a + c) (b + d) <= Rdist a b + Rdist c d.
 Proof.
-  intros; unfold R_dist;
+  intros; unfold Rdist;
     replace (a + c - (b + d)) with (a - b + (c - d)).
   - exact (Rabs_triang (a - b) (c - d)).
   - ring.
 Qed.
 
-Lemma R_dist_mult_l : forall a b c,
-  R_dist (a * b) (a * c) = Rabs a * R_dist b c.
+Lemma Rdist_mult_l : forall a b c,
+  Rdist (a * b) (a * c) = Rabs a * Rdist b c.
 Proof.
-unfold R_dist. 
+unfold Rdist.
 intros a b c; rewrite <- Rmult_minus_distr_l, Rabs_mult; reflexivity.
 Qed.
+
+Notation R_dist := Rdist (only parsing).
+Notation R_dist_pos := Rdist_pos (only parsing).
+Notation R_dist_sym := Rdist_sym (only parsing).
+Notation R_dist_refl := Rdist_refl (only parsing).
+Notation R_dist_eq := Rdist_eq (only parsing).
+Notation R_dist_tri := Rdist_tri (only parsing).
+Notation R_dist_plus := Rdist_plus (only parsing).
+Notation R_dist_mult_l := Rdist_mult_l (only parsing).
 
 (*******************************)
 (** *     Infinite Sum          *)
@@ -922,7 +931,7 @@ Definition infinite_sum (s:nat -> R) (l:R) : Prop :=
   forall eps:R,
     eps > 0 ->
     exists N : nat,
-      (forall n:nat, (n >= N)%nat -> R_dist (sum_f_R0 s n) l < eps).
+      (forall n:nat, (n >= N)%nat -> Rdist (sum_f_R0 s n) l < eps).
 
 (** Compatibility with previous versions *)
 Notation infinit_sum := infinite_sum (only parsing).

--- a/theories/Reals/RiemannInt.v
+++ b/theories/Reals/RiemannInt.v
@@ -93,8 +93,8 @@ Lemma RiemannInt_P2 :
 Proof.
   intros; apply R_complete; unfold Un_cv in H; unfold Cauchy_crit;
     intros; assert (H3 : 0 < eps / 2) by lra.
-  elim (H _ H3); intros N0 H4; exists N0; intros; unfold R_dist;
-    unfold R_dist in H4; elim (H1 n); elim (H1 m); intros;
+  elim (H _ H3); intros N0 H4; exists N0; intros; unfold Rdist;
+    unfold Rdist in H4; elim (H1 n); elim (H1 m); intros;
     replace (RiemannInt_SF (vn n) - RiemannInt_SF (vn m)) with
     (RiemannInt_SF (vn n) + -1 * RiemannInt_SF (vn m));
     [ idtac | ring ]; rewrite <- StepFun_P30;
@@ -176,7 +176,7 @@ Proof.
   assert (H3 := RiemannInt_P2 _ _ _ _ H H1 H2); elim H3; intros x p;
     exists (- x); unfold Un_cv; unfold Un_cv in p;
     intros; elim (p _ H4); intros; exists x0; intros;
-    generalize (H5 _ H6); unfold R_dist, RiemannInt_SF;
+    generalize (H5 _ H6); unfold Rdist, RiemannInt_SF;
     destruct (Rle_dec b a) as [Hle'|Hnle']; destruct (Rle_dec a b) as [Hle''|Hnle''];
     intros.
   1,3,4: lra.
@@ -213,7 +213,7 @@ Lemma RiemannInt_P4 :
     Un_cv (fun N:nat => RiemannInt_SF (phi_sequence un pr1 N)) l ->
     Un_cv (fun N:nat => RiemannInt_SF (phi_sequence vn pr2 N)) l.
 Proof.
-  unfold Un_cv; unfold R_dist; intros f; intros;
+  unfold Un_cv; unfold Rdist; intros f; intros;
     assert (H3 : 0 < eps / 3).
   { unfold Rdiv; apply Rmult_lt_0_compat;
       [ assumption | apply Rinv_0_lt_compat; prove_sup0 ]. }
@@ -337,7 +337,7 @@ Proof.
         [ apply H0; unfold ge; apply Nat.le_trans with N; try assumption;
           unfold N; apply Nat.le_trans with (max N0 N1);
           [ apply Nat.le_max_r | apply Nat.le_max_l ]
-        | unfold R_dist; unfold Rminus; rewrite Ropp_0;
+        | unfold Rdist; unfold Rminus; rewrite Ropp_0;
           rewrite Rplus_0_r; apply Rabs_right; apply Rle_ge;
           left; apply (cond_pos (vn n)) ]. }
     apply Rlt_trans with (pos (un n)).
@@ -366,7 +366,7 @@ Proof.
     clear H0; intros; assert (H2 : (0 <= up (/ eps))%Z).
   { apply le_IZR; left; apply Rlt_trans with (/ eps);
       [ apply Rinv_0_lt_compat; assumption | assumption ]. }
-  elim (IZN _ H2); intros; exists x; intros; unfold R_dist;
+  elim (IZN _ H2); intros; exists x; intros; unfold Rdist;
     simpl; unfold Rminus; rewrite Ropp_0;
     rewrite Rplus_0_r; assert (H5 : 0 < INR n + 1).
   { apply Rplus_le_lt_0_compat; [ apply pos_INR | apply Rlt_0_1 ]. }
@@ -843,7 +843,7 @@ Proof.
   { unfold Rdiv; apply Rmult_lt_0_compat;
       [ assumption | apply Rinv_0_lt_compat; prove_sup0 ]. }
   unfold Un_cv in H1; elim (H1 _ H3); clear H1; intros N0 H1;
-    unfold R_dist in H1; simpl in H1;
+    unfold Rdist in H1; simpl in H1;
     assert (H4 : forall n:nat, (n >= N0)%nat -> RinvN n < eps / 3).
   { intros; assert (H5 := H1 _ H4);
       replace (pos (RinvN n)) with (Rabs (/ (INR n + 1) - 0));
@@ -851,7 +851,7 @@ Proof.
       | unfold Rminus; rewrite Ropp_0; rewrite Rplus_0_r; apply Rabs_right;
         left; apply (cond_pos (RinvN n)) ]. }
   clear H1; destruct (HUn _ H3) as (N1,H1);
-    exists (max N0 N1); intros; unfold R_dist;
+    exists (max N0 N1); intros; unfold Rdist;
     apply Rle_lt_trans with
     (Rabs
        (RiemannInt_SF (phi_sequence RinvN pr1 n) +
@@ -865,7 +865,7 @@ Proof.
       [ apply Rabs_triang | ring ]. }
   replace eps with (2 * (eps / 3) + eps / 3) by lra.
   apply Rplus_lt_compat.
-  2:{ unfold R_dist in H1; apply H1; unfold ge;
+  2:{ unfold Rdist in H1; apply H1; unfold ge;
       apply Nat.le_trans with (max N0 N1); [ apply Nat.le_max_r | assumption ]. }
   rewrite (StepFun_P39 (phi_sequence RinvN pr2 n));
     replace
@@ -1053,7 +1053,7 @@ Proof.
   - assert (H4 : 0 < eps / 3) by lra.
     elim (H _ H4); clear H; intros N0 H.
     elim (H2 _ H4); clear H2; intros N1 H2.
-    set (N := max N0 N1); exists N; intros; unfold R_dist.
+    set (N := max N0 N1); exists N; intros; unfold Rdist.
     apply Rle_lt_trans with
       (Rabs (RiemannInt_SF (phi2 n) - RiemannInt_SF (phi1 n)) +
          Rabs (RiemannInt_SF (phi1 n) - l)).
@@ -1062,7 +1062,7 @@ Proof.
            (RiemannInt_SF (phi1 n) - l)); [ apply Rabs_triang | ring ]. }
     replace eps with (2 * (eps / 3) + eps / 3) by lra.
     apply Rplus_lt_compat.
-    2:{ unfold R_dist in H2; apply H2; unfold ge; apply Nat.le_trans with N;
+    2:{ unfold Rdist in H2; apply H2; unfold ge; apply Nat.le_trans with N;
         try assumption; unfold N; apply Nat.le_max_r. }
     replace (RiemannInt_SF (phi2 n) - RiemannInt_SF (phi1 n)) with
       (RiemannInt_SF (phi2 n) + -1 * RiemannInt_SF (phi1 n));
@@ -1095,26 +1095,26 @@ Proof.
       { elim (H0 n); intros; apply Rle_lt_trans with (Rabs (RiemannInt_SF (psi1 n))).
         { apply RRle_abs. }
         assumption. }
-      replace (pos (un n)) with (R_dist (un n) 0).
+      replace (pos (un n)) with (Rdist (un n) 0).
       { apply H; unfold ge; apply Nat.le_trans with N; try assumption.
         unfold N; apply Nat.le_max_l. }
-      unfold R_dist; unfold Rminus; rewrite Ropp_0;
+      unfold Rdist; unfold Rminus; rewrite Ropp_0;
         rewrite Rplus_0_r; apply Rabs_right.
       apply Rle_ge; left; apply (cond_pos (un n)). }
     apply Rlt_trans with (pos (un n)).
     { elim (H1 n); intros; apply Rle_lt_trans with (Rabs (RiemannInt_SF (psi2 n))).
       { apply RRle_abs; assumption. }
       assumption. }
-    replace (pos (un n)) with (R_dist (un n) 0).
+    replace (pos (un n)) with (Rdist (un n) 0).
     { apply H; unfold ge; apply Nat.le_trans with N; try assumption;
         unfold N; apply Nat.le_max_l. }
-    unfold R_dist; unfold Rminus; rewrite Ropp_0;
+    unfold Rdist; unfold Rminus; rewrite Ropp_0;
       rewrite Rplus_0_r; apply Rabs_right; apply Rle_ge;
       left; apply (cond_pos (un n)).
   - assert (H4 : 0 < eps / 3) by lra.
     elim (H _ H4); clear H; intros N0 H.
     elim (H2 _ H4); clear H2; intros N1 H2.
-    set (N := max N0 N1); exists N; intros; unfold R_dist.
+    set (N := max N0 N1); exists N; intros; unfold Rdist.
     apply Rle_lt_trans with
       (Rabs (RiemannInt_SF (phi2 n) - RiemannInt_SF (phi1 n)) +
          Rabs (RiemannInt_SF (phi1 n) - l)).
@@ -1125,7 +1125,7 @@ Proof.
     { auto with real. }
     replace eps with (2 * (eps / 3) + eps / 3) by lra.
     apply Rplus_lt_compat.
-    2:{ unfold R_dist in H2; apply H2; unfold ge; apply Nat.le_trans with N;
+    2:{ unfold Rdist in H2; apply H2; unfold ge; apply Nat.le_trans with N;
         try assumption; unfold N; apply Nat.le_max_r. }
     replace (RiemannInt_SF (phi2 n) - RiemannInt_SF (phi1 n)) with
       (RiemannInt_SF (phi2 n) + -1 * RiemannInt_SF (phi1 n));
@@ -1176,20 +1176,20 @@ Proof.
       { elim (H0 n); intros; apply Rle_lt_trans with (Rabs (RiemannInt_SF (psi1 n))).
         { rewrite <- Rabs_Ropp; apply RRle_abs. }
         assumption. }
-      replace (pos (un n)) with (R_dist (un n) 0).
+      replace (pos (un n)) with (Rdist (un n) 0).
       { apply H; unfold ge; apply Nat.le_trans with N; try assumption.
         unfold N; apply Nat.le_max_l. }
-      unfold R_dist; unfold Rminus; rewrite Ropp_0;
+      unfold Rdist; unfold Rminus; rewrite Ropp_0;
         rewrite Rplus_0_r; apply Rabs_right.
       apply Rle_ge; left; apply (cond_pos (un n)). }
     apply Rlt_trans with (pos (un n)).
     { elim (H1 n); intros; apply Rle_lt_trans with (Rabs (RiemannInt_SF (psi2 n))).
       { rewrite <- Rabs_Ropp; apply RRle_abs; assumption. }
       assumption. }
-    replace (pos (un n)) with (R_dist (un n) 0).
+    replace (pos (un n)) with (Rdist (un n) 0).
     { apply H; unfold ge; apply Nat.le_trans with N; try assumption;
         unfold N; apply Nat.le_max_l. }
-    unfold R_dist; unfold Rminus; rewrite Ropp_0;
+    unfold Rdist; unfold Rminus; rewrite Ropp_0;
       rewrite Rplus_0_r; apply Rabs_right; apply Rle_ge;
       left; apply (cond_pos (un n)).
 Qed.
@@ -1241,7 +1241,7 @@ Proof.
         [ prove_sup0 | apply Rabs_pos_lt; assumption ] ]. }
   elim (HUn_cv _ H5); clear HUn_cv; intros N2 H6; assert (H7 := RinvN_cv);
     unfold Un_cv in H7; elim (H7 _ H5); clear H7 H5; intros N3 H5;
-    unfold R_dist in H3, H4, H5, H6; set (N := max (max N0 N1) (max N2 N3)).
+    unfold Rdist in H3, H4, H5, H6; set (N := max (max N0 N1) (max N2 N3)).
   assert (H7 : forall n:nat, (n >= N1)%nat -> RinvN n < eps / 5).
   { intros; replace (pos (RinvN n)) with (Rabs (RinvN n - 0));
       [ unfold RinvN; apply H4; assumption
@@ -1254,7 +1254,7 @@ Proof.
       | unfold Rminus; rewrite Ropp_0; rewrite Rplus_0_r; apply Rabs_right;
         left; apply (cond_pos (RinvN n)) ]. }
   clear H5; assert (H5 := H7); clear H7; exists N; intros;
-    unfold R_dist.
+    unfold Rdist.
   apply Rle_lt_trans with
     (Rabs
        (RiemannInt_SF (phi_sequence RinvN pr3 n) -
@@ -1490,7 +1490,7 @@ Proof.
     unfold psi2; rewrite StepFun_P18; rewrite Rmult_0_l; rewrite Rabs_R0;
       apply (cond_pos (RinvN n)).
   - assumption.
-  - unfold Un_cv; intros; split with 0%nat; intros; unfold R_dist;
+  - unfold Un_cv; intros; split with 0%nat; intros; unfold Rdist;
     unfold phi2; rewrite StepFun_P18; unfold Rminus;
     rewrite Rplus_opp_r; rewrite Rabs_R0; apply H.
 Qed.
@@ -1517,7 +1517,7 @@ Proof.
   assert (H3 : 0 < (l1 - l2) / 2).
   { unfold Rdiv; apply Rmult_lt_0_compat;
       [ apply Rlt_Rminus; assumption | apply Rinv_0_lt_compat; prove_sup0 ]. }
-  elim (H1 _ H3); elim (H0 _ H3); clear H0 H1; unfold R_dist; intros;
+  elim (H1 _ H3); elim (H0 _ H3); clear H0 H1; unfold Rdist; intros;
     set (N := max x x0); cut (Vn N < Un N).
   { intro; elim (Rlt_irrefl _ (Rle_lt_trans _ _ _ (H N) H4)). }
   apply Rlt_trans with ((l1 + l2) / 2).
@@ -2179,7 +2179,7 @@ Proof.
                  RiemannInt_SF (phi_sequence RinvN pr2 n))) 0).
   { intro; elim (H3 _ H0); clear H3; intros N3 H3;
       set (N0 := max (max N1 N2) N3); exists N0; intros;
-      unfold R_dist;
+      unfold Rdist;
       apply Rle_lt_trans with
       (Rabs
          (RiemannInt_SF (phi_sequence RinvN pr3 n) -
@@ -2197,7 +2197,7 @@ Proof.
         [ apply Rabs_triang | ring ]. }
     replace eps with (eps / 3 + eps / 3 + eps / 3) by lra.
     rewrite Rplus_assoc; apply Rplus_lt_compat.
-    { unfold R_dist in H3; cut (n >= N3)%nat.
+    { unfold Rdist in H3; cut (n >= N3)%nat.
       { intro; assert (H6 := H3 _ H5); unfold Rminus in H6; rewrite Ropp_0 in H6;
           rewrite Rplus_0_r in H6; apply H6. }
       unfold ge; apply Nat.le_trans with N0;
@@ -2212,12 +2212,12 @@ Proof.
            (RiemannInt_SF (phi_sequence RinvN pr2 n) - x0));
         [ apply Rabs_triang | ring ]. }
     apply Rplus_lt_compat.
-    { unfold R_dist in H1; apply H1.
+    { unfold Rdist in H1; apply H1.
       unfold ge; apply Nat.le_trans with N0;
         [ apply Nat.le_trans with (max N1 N2);
           [ apply Nat.le_max_l | unfold N0; apply Nat.le_max_l ]
         | assumption ]. }
-    unfold R_dist in H2; apply H2.
+    unfold Rdist in H2; apply H2.
     unfold ge; apply Nat.le_trans with N0;
       [ apply Nat.le_trans with (max N1 N2);
         [ apply Nat.le_max_r | unfold N0; apply Nat.le_max_l ]
@@ -2262,13 +2262,13 @@ Proof.
     assert (H5 : forall n:nat, (n >= N0)%nat -> RinvN n < eps / 3).
   { intros;
       replace (pos (RinvN n)) with
-      (R_dist (mkposreal (/ (INR n + 1)) (RinvN_pos n)) 0).
+      (Rdist (mkposreal (/ (INR n + 1)) (RinvN_pos n)) 0).
     { apply H; assumption. }
-    unfold R_dist; unfold Rminus; rewrite Ropp_0;
+    unfold Rdist; unfold Rminus; rewrite Ropp_0;
       rewrite Rplus_0_r; apply Rabs_right; apply Rle_ge;
       left; apply (cond_pos (RinvN n)). }
   exists N0; intros; elim (H1 n); elim (H2 n); elim (H3 n); clear H1 H2 H3;
-    intros; unfold R_dist; unfold Rminus;
+    intros; unfold Rdist; unfold Rminus;
     rewrite Ropp_0; rewrite Rplus_0_r;
     set (phi1 := phi_sequence RinvN pr1 n) in H8 |- *;
     set (phi2 := phi_sequence RinvN pr2 n) in H3 |- *;
@@ -2457,7 +2457,7 @@ Proof.
   { unfold Rdiv; apply Rmult_lt_0_compat;
       [ assumption | apply Rinv_0_lt_compat; prove_sup0 ]. }
   elim (H1 _ Hyp); unfold dist, D_x, no_cond; simpl;
-    unfold R_dist; intros; set (del := Rmin x0 (Rmin (b - x) (x - a)));
+    unfold Rdist; intros; set (del := Rmin x0 (Rmin (b - x) (x - a)));
     assert (H4 : 0 < del).
   { unfold del; unfold Rmin; case (Rle_dec (b - x) (x - a));
       intro.
@@ -2685,7 +2685,7 @@ Proof.
     { unfold Rdiv; apply Rmult_lt_0_compat;
         [ assumption | apply Rinv_0_lt_compat; prove_sup0 ]. }
     elim (H7 _ H8); unfold D_x, no_cond, dist; simpl;
-      unfold R_dist; intros; set (del := Rmin x0 (Rmin x1 (b - a)));
+      unfold Rdist; intros; set (del := Rmin x0 (Rmin x1 (b - a)));
       assert (H10 : 0 < del).
     { unfold del; unfold Rmin; case (Rle_dec x1 (b - a)); intros.
       { destruct (Rle_dec x0 x1) as [Hle|Hnle];
@@ -2846,7 +2846,7 @@ Proof.
     { unfold Rdiv; apply Rmult_lt_0_compat;
         [ assumption | apply Rinv_0_lt_compat; prove_sup0 ]. }
     elim (H6 _ H7); unfold D_x, no_cond, dist; simpl;
-      unfold R_dist; intros.
+      unfold Rdist; intros.
     set (del := Rmin x0 (Rmin x1 (b - a))).
     assert (H9 : 0 < del).
     { unfold del; unfold Rmin.

--- a/theories/Reals/Rlimit.v
+++ b/theories/Reals/Rlimit.v
@@ -143,9 +143,9 @@ Definition limit_in (X X':Metric_Space) (f:Base X -> Base X')
 
 (*********)
 Definition R_met : Metric_Space :=
-  Build_Metric_Space R R_dist R_dist_pos R_dist_sym R_dist_refl R_dist_tri.
+  Build_Metric_Space R Rdist Rdist_pos Rdist_sym Rdist_refl Rdist_tri.
 
-Declare Equivalent Keys dist R_dist.
+Declare Equivalent Keys dist Rdist.
 
 (*******************************)
 (** *      Limit 1 arg         *)
@@ -201,11 +201,11 @@ Proof.
           split with (Rmin x1 x); split.
   - exact (Rmin_Rgt_r x1 x 0 (conj H H2)).
   - intros; elim H4; clear H4; intros;
-      cut (R_dist (f x2) l + R_dist (g x2) l' < eps).
-    + cut (R_dist (f x2 + g x2) (l + l') <= R_dist (f x2) l + R_dist (g x2) l').
+      cut (Rdist (f x2) l + Rdist (g x2) l' < eps).
+    + cut (Rdist (f x2 + g x2) (l + l') <= Rdist (f x2) l + Rdist (g x2) l').
       * exact (Rle_lt_trans _ _ _).
-      * exact (R_dist_plus _ _ _ _).
-    + elim (Rmin_Rgt_l x1 x (R_dist x2 x0) H5); clear H5; intros.
+      * exact (Rdist_plus _ _ _ _).
+    + elim (Rmin_Rgt_l x1 x (Rdist x2 x0) H5); clear H5; intros.
       generalize (H3 x2 (conj H4 H6)); generalize (H0 x2 (conj H4 H5)); intros;
         replace eps with (eps * / 2 + eps * / 2).
       * exact (Rplus_lt_compat _ _ _ _ H7 H8).
@@ -220,10 +220,10 @@ Proof.
   unfold limit1_in; unfold limit_in; simpl; intros;
     elim (H eps H0); clear H; intros; elim H; clear H;
       intros; split with x; split; auto; intros; generalize (H1 x1 H2);
-        clear H1; intro; unfold R_dist; unfold Rminus;
+        clear H1; intro; unfold Rdist; unfold Rminus;
           rewrite (Ropp_involutive l); rewrite (Rplus_comm (- f x1) l);
-            fold (l - f x1); fold (R_dist l (f x1));
-              rewrite R_dist_sym; assumption.
+            fold (l - f x1); fold (Rdist l (f x1));
+              rewrite Rdist_sym; assumption.
 Qed.
 
 (*********)
@@ -242,7 +242,7 @@ Lemma limit_free :
     limit1_in (fun h:R => f x) D (f x) x0.
 Proof.
   unfold limit1_in; unfold limit_in; simpl; intros;
-    split with eps; split; auto; intros; elim (R_dist_refl (f x) (f x));
+    split with eps; split; auto; intros; elim (Rdist_refl (f x) (f x));
       intros a b; rewrite (b (eq_refl (f x))); unfold Rgt in H;
         assumption.
 Qed.
@@ -260,7 +260,7 @@ Proof.
           clear H H0; simpl; intros; elim H; elim H0;
             clear H H0; intros; split with (Rmin x1 x); split.
   { exact (Rmin_Rgt_r x1 x 0 (conj H H2)). }
-  intros; elim H4; clear H4; intros; unfold R_dist;
+  intros; elim H4; clear H4; intros; unfold Rdist;
     replace (f x2 * g x2 - l * l') with (f x2 * (g x2 - l') + l' * (f x2 - l)).
   - cut (Rabs (f x2 * (g x2 - l')) + Rabs (l' * (f x2 - l)) < eps).
     { cut
@@ -276,7 +276,7 @@ Proof.
       (Rabs (f x2) * Rabs (g x2 - l') + Rabs l' * Rabs (f x2 - l) <
          (1 + Rabs l) * (eps * mul_factor l l') + Rabs l' * (eps * mul_factor l l')).
     + exact (Rlt_le_trans _ _ _).
-    + elim (Rmin_Rgt_l x1 x (R_dist x2 x0) H5); clear H5; intros;
+    + elim (Rmin_Rgt_l x1 x (Rdist x2 x0) H5); clear H5; intros;
         generalize (H0 x2 (conj H4 H5)); intro; generalize (Rmin_Rgt_l _ _ _ H7);
         intro; elim H8; intros; clear H0 H8; apply Rplus_lt_le_compat.
       * apply Rmult_ge_0_gt_0_lt_compat.
@@ -284,7 +284,7 @@ Proof.
            exact (Rabs_pos (g x2 - l')).
         -- rewrite (Rplus_comm 1 (Rabs l)); unfold Rgt; apply Rle_lt_0_plus_1;
              exact (Rabs_pos l).
-        -- unfold R_dist in H9;
+        -- unfold Rdist in H9;
              apply (Rplus_lt_reg_l (- Rabs l) (Rabs (f x2)) (1 + Rabs l)).
            rewrite <- (Rplus_assoc (- Rabs l) 1 (Rabs l));
              rewrite (Rplus_comm (- Rabs l) 1);
@@ -310,7 +310,7 @@ Qed.
 
 (*********)
 Definition adhDa (D:R -> Prop) (a:R) : Prop :=
-  forall alp:R, alp > 0 ->  exists x : R, D x /\ R_dist x a < alp.
+  forall alp:R, alp > 0 ->  exists x : R, D x /\ Rdist x a < alp.
 
 (*********)
 Lemma single_limit :
@@ -320,7 +320,7 @@ Proof.
   unfold limit1_in; unfold limit_in; intros.
   simpl in *.
   cut (forall eps:R, eps > 0 -> dist R_met l l' < 2 * eps).
-  - clear H0 H1; unfold dist in |- *; unfold R_met; unfold R_dist in |- *;
+  - clear H0 H1; unfold dist in |- *; unfold R_met; unfold Rdist in |- *;
       unfold Rabs; case (Rcase_abs (l - l')) as [Hlt|Hge]; intros.
     + cut (forall eps:R, eps > 0 -> - (l - l') < eps).
       * intro; generalize (prop_eps (- (l - l')) H1); intro;
@@ -370,16 +370,16 @@ Proof.
       simpl; simpl in H1, H4; generalize (Rmin_Rgt x x1 0);
       intro; elim H5; intros; clear H5; elim (H (Rmin x x1) (H7 (conj H3 H0)));
       intros; elim H5; intros; clear H5 H H6 H7;
-      generalize (Rmin_Rgt x x1 (R_dist x2 x0)); intro;
+      generalize (Rmin_Rgt x x1 (Rdist x2 x0)); intro;
       elim H; intros; clear H H6; unfold Rgt in H5; elim (H5 H9);
       intros; clear H5 H9; generalize (H1 x2 (conj H8 H6));
       generalize (H4 x2 (conj H8 H)); clear H8 H H6 H1 H4 H0 H3;
       intros;
       generalize
-        (Rplus_lt_compat (R_dist (f x2) l) eps (R_dist (f x2) l') eps H H0);
-      unfold R_dist; intros; rewrite (Rabs_minus_sym (f x2) l) in H1;
+        (Rplus_lt_compat (Rdist (f x2) l) eps (Rdist (f x2) l') eps H H0);
+      unfold Rdist; intros; rewrite (Rabs_minus_sym (f x2) l) in H1;
       rewrite (Rmult_comm 2 eps); replace (eps *2) with (eps + eps) by ring;
-      generalize (R_dist_tri l l' (f x2)); unfold R_dist;
+      generalize (Rdist_tri l l' (f x2)); unfold Rdist;
       intros;
       apply
         (Rle_lt_trans (Rabs (l - l')) (Rabs (l - f x2) + Rabs (f x2 - l'))
@@ -410,7 +410,7 @@ Lemma limit_inv :
     limit1_in f D l x0 -> l <> 0 -> limit1_in (fun x:R => / f x) D (/ l) x0.
 Proof.
   unfold limit1_in; unfold limit_in; simpl;
-    unfold R_dist; intros; elim (H (Rabs l / 2)).
+    unfold Rdist; intros; elim (H (Rabs l / 2)).
   - intros delta1 H2; elim (H (eps * (Rsqr l / 2))).
     + intros delta2 H3; elim H2; elim H3; intros; exists (Rmin delta1 delta2);
         split.

--- a/theories/Reals/Rpower.v
+++ b/theories/Reals/Rpower.v
@@ -78,7 +78,7 @@ Proof.
     rewrite Rmult_1_r; apply le_INR; apply fact_le; apply Nat.le_succ_diag_r.
   - assert (H0 := cv_speed_pow_fact 1); unfold Un_cv; unfold Un_cv in H0;
       intros; elim (H0 _ H1); intros; exists x0; intros;
-      unfold R_dist in H2; unfold R_dist;
+      unfold Rdist in H2; unfold Rdist;
       replace (/ INR (fact n)) with (1 ^ n / INR (fact n));auto.
     unfold Rdiv; rewrite pow1; rewrite Rmult_1_l; reflexivity.
   - unfold infinite_sum in e; unfold Un_cv, tg_alt; intros; elim (e _ H0);
@@ -355,7 +355,7 @@ Proof.
   }
   exists (Rmin (y * (exp eps - 1)) (y * (1 - exp (- eps)))); split.
   { red; apply Rmin_case; nra. }
-  unfold dist, R_met, R_dist; simpl.
+  unfold dist, R_met, Rdist; simpl.
   intros x [[H3 H4] H5].
   assert (Hxyy:y * (x * / y) = x). {
     field. lra.
@@ -637,7 +637,7 @@ Proof.
   { apply ln_continue; auto. }
   assert (H0 := derivable_pt_lim_exp (ln y)); unfold derivable_pt_lim in H0;
     unfold limit1_in; unfold limit_in;
-      simpl; unfold R_dist; intros; elim (H0 _ H);
+      simpl; unfold Rdist; intros; elim (H0 _ H);
         intros; exists (pos x); split.
   { apply (cond_pos x). }
   intros; pattern y at 3; rewrite <- exp_ln.
@@ -654,7 +654,7 @@ Qed.
 Lemma derivable_pt_lim_ln : forall x:R, 0 < x -> derivable_pt_lim ln x (/ x).
 Proof.
   intros; assert (H0 := Dln x H); unfold D_in in H0; unfold limit1_in in H0;
-    unfold limit_in in H0; simpl in H0; unfold R_dist in H0;
+    unfold limit_in in H0; simpl in H0; unfold Rdist in H0;
       unfold derivable_pt_lim; intros; elim (H0 _ H1);
         intros; elim H2; clear H2; intros; set (alp := Rmin x0 (x / 2));
           assert (H4 : 0 < alp).

--- a/theories/Reals/Rseries.v
+++ b/theories/Reals/Rseries.v
@@ -40,7 +40,7 @@ Section sequence.
   Definition Un_cv (l:R) : Prop :=
     forall eps:R,
       eps > 0 ->
-      exists N : nat, (forall n:nat, (n >= N)%nat -> R_dist (Un n) l < eps).
+      exists N : nat, (forall n:nat, (n >= N)%nat -> Rdist (Un n) l < eps).
 
 (*********)
   Definition Cauchy_crit : Prop :=
@@ -48,7 +48,7 @@ Section sequence.
       eps > 0 ->
       exists N : nat,
         (forall n m:nat,
-          (n >= N)%nat -> (m >= N)%nat -> R_dist (Un n) (Un m) < eps).
+          (n >= N)%nat -> (m >= N)%nat -> Rdist (Un n) (Un m) < eps).
 
 (*********)
   Definition Un_growing : Prop := forall n:nat, Un n <= Un (S n).
@@ -95,7 +95,7 @@ Section sequence.
     intros (N, H3).
     exists N.
     intros n H4.
-    unfold R_dist.
+    unfold Rdist.
     rewrite Rabs_left1, Ropp_minus_distr.
     - apply Rplus_lt_reg_l with (Un n - eps).
       apply Rlt_le_trans with (Un N).
@@ -290,7 +290,7 @@ Section sequence.
             clear H; intros; unfold EUn in H; elim H; clear H;
               intros; elim (H1 x2); clear H1; intro y.
     - unfold ge in H0; generalize (H0 x2 (le_n x) y); clear H0; intro;
-        rewrite <- H in H0; unfold R_dist in H0; elim (Rabs_def2 (Un x - x1) 1 H0);
+        rewrite <- H in H0; unfold Rdist in H0; elim (Rabs_def2 (Un x - x1) 1 H0);
         clear H0; intros; elim (Rmax_Rle x0 (Un x + 1) x1);
         intros; apply H4; clear H3 H4; right; clear H H0 y;
         apply (Rlt_le x1 (Un x + 1)); generalize (Rlt_minus (-1) (Un x - x1) H1);
@@ -326,7 +326,7 @@ Proof.
     elim (Req_dec x 0).
   - intros; exists 0%nat; intros; rewrite H1; rewrite Rminus_0_r; rewrite Rinv_1;
       cut (sum_f_R0 (fun n0:nat => 1 * 0 ^ n0) n = 1).
-    + intros; rewrite H3; rewrite R_dist_eq; auto.
+    + intros; rewrite H3; rewrite Rdist_eq; auto.
     + elim n; simpl.
       * ring.
       * intros; rewrite H3; ring.
@@ -338,7 +338,7 @@ Proof.
       * intros; rewrite H5;
           apply
             (Rmult_lt_reg_l (Rabs (1 - x))
-                            (R_dist (sum_f_R0 (fun n0:nat => x ^ n0) n) (/ (1 - x))) eps).
+                            (Rdist (sum_f_R0 (fun n0:nat => x ^ n0) n) (/ (1 - x))) eps).
         -- apply Rabs_pos_lt.
            apply Rminus_eq_contra.
            apply Rlt_dichotomy_converse.
@@ -346,7 +346,7 @@ Proof.
            apply (Rle_lt_trans x (Rabs x) 1).
            ++ apply RRle_abs.
            ++ assumption.
-        -- unfold R_dist; rewrite <- Rabs_mult.
+        -- unfold Rdist; rewrite <- Rabs_mult.
            rewrite Rmult_minus_distr_l.
            cut
              ((1 - x) * sum_f_R0 (fun n0:nat => x ^ n0) n =

--- a/theories/Reals/Rsqrt_def.v
+++ b/theories/Reals/Rsqrt_def.v
@@ -335,7 +335,7 @@ Proof.
   { intro.
     assert (H4 := UL_sequence _ _ _ H2 H3).
     symmetry ; apply Rminus_diag_uniq_sym; assumption. }
-  unfold Un_cv; unfold R_dist.
+  unfold Un_cv; unfold Rdist.
   intros.
   assert (H4 := cv_infty_cv_0 pow_2_n pow_2_n_infty).
   destruct (total_order_T x y) as [[ Hlt | -> ]|Hgt].
@@ -349,7 +349,7 @@ Proof.
         rewrite Rabs_R0; assumption.
       - assumption. }
   2:{ elim (Rlt_irrefl _ (Rle_lt_trans _ _ _ H Hgt)). }
-  unfold Un_cv in H4; unfold R_dist in H4.
+  unfold Un_cv in H4; unfold Rdist in H4.
   assert (Hyp:0 < y - x) by lra.
   assert (0 < eps / (y - x)). {
     unfold Rdiv; apply Rmult_lt_0_compat;
@@ -393,7 +393,7 @@ Proof.
   unfold limit_in.
   unfold dist.
   simpl.
-  unfold R_dist.
+  unfold Rdist.
   intros.
   elim (H eps H1); intros alp H2.
   elim H2; intros.
@@ -447,7 +447,7 @@ Qed.
 Lemma cv_pow_half : forall a, Un_cv (fun n => a/2^n) 0.
 intros a; unfold Rdiv; replace 0 with (a * 0) by ring.
 apply CV_mult.
-- intros eps ep; exists 0%nat; rewrite R_dist_eq; intros n _; assumption.
+- intros eps ep; exists 0%nat; rewrite Rdist_eq; intros n _; assumption.
 - exact (cv_infty_cv_0 pow_2_n pow_2_n_infty).
 Qed.
 
@@ -532,7 +532,7 @@ Proof.
       destruct (total_order_T 0 (f x0)) as [[Hlt|<-]|Hgt].
       { left; assumption. }
       { right; reflexivity. }
-      unfold Un_cv in H7; unfold R_dist in H7.
+      unfold Un_cv in H7; unfold Rdist in H7.
       assert (0 < - f x0) by (apply Ropp_0_gt_lt_contravar; assumption).
       elim (H7 (- f x0) H8); intros.
       cut (x2 >= x2)%nat; [ intro | unfold ge; apply le_n ].
@@ -552,7 +552,7 @@ Proof.
       destruct (total_order_T 0 (f x0)) as [[Hlt|<-]|Hgt].
       2:{ right; reflexivity. }
       2:{ left; assumption. }
-      unfold Un_cv in H7; unfold R_dist in H7.
+      unfold Un_cv in H7; unfold Rdist in H7.
       elim (H7 (f x0) Hlt); intros.
       cut (x2 >= x2)%nat; [ intro | unfold ge; apply le_n ].
       assert (H10 := H8 x2 H9).

--- a/theories/Reals/Rtopology.v
+++ b/theories/Reals/Rtopology.v
@@ -275,7 +275,7 @@ Proof.
   - intros; unfold neighbourhood in H0.
     elim H0; intros del1 H1.
     unfold continuity_pt in H; unfold continue_in in H; unfold limit1_in in H;
-      unfold limit_in in H; simpl in H; unfold R_dist in H.
+      unfold limit_in in H; simpl in H; unfold Rdist in H.
     assert (H2 := H del1 (cond_pos del1)).
     elim H2; intros del2 H3.
     elim H3; intros.
@@ -302,8 +302,8 @@ Proof.
         intros del1 H7.
       exists (pos del1); split.
       * apply (cond_pos del1).
-      * intros; elim H8; intros; simpl in H10; unfold R_dist in H10; simpl;
-          unfold R_dist; apply (H6 _ (H7 _ H10)).
+      * intros; elim H8; intros; simpl in H10; unfold Rdist in H10; simpl;
+          unfold Rdist; apply (H6 _ (H7 _ H10)).
     + unfold neighbourhood, disc; exists (mkposreal eps H0);
         unfold included; intros; assumption.
 Qed.
@@ -334,7 +334,7 @@ Proof.
   - intros; apply continuity_P2; assumption.
   - intros; unfold continuity; unfold continuity_pt;
       unfold continue_in; unfold limit1_in;
-      unfold limit_in; simpl; unfold R_dist;
+      unfold limit_in; simpl; unfold Rdist;
       intros; cut (open_set (disc (f x) (mkposreal _ H0))).
     + intro; assert (H2 := H _ H1).
       unfold open_set, image_rec in H2; cut (disc (f x) (mkposreal _ H0) (f x)).
@@ -994,7 +994,7 @@ Proof.
     + unfold continuity; intro; case (Rtotal_order x a); intro.
       * unfold continuity_pt; unfold continue_in;
           unfold limit1_in; unfold limit_in;
-          simpl; unfold R_dist; intros; exists (a - x);
+          simpl; unfold Rdist; intros; exists (a - x);
           split.
         -- change (0 < a - x); apply Rlt_Rminus; assumption.
         -- intros; elim H5; clear H5; intros _ H5; unfold h.
@@ -1012,9 +1012,9 @@ Proof.
            }
            assert (H6 := H0 _ H5); unfold continuity_pt in H6; unfold continue_in in H6;
              unfold limit1_in in H6; unfold limit_in in H6; simpl in H6;
-             unfold R_dist in H6; unfold continuity_pt;
+             unfold Rdist in H6; unfold continuity_pt;
              unfold continue_in; unfold limit1_in;
-             unfold limit_in; simpl; unfold R_dist;
+             unfold limit_in; simpl; unfold Rdist;
              intros; elim (H6 _ H7); intros; exists (Rmin x0 (b - a));
              split.
            ++ unfold Rmin; case (Rle_dec x0 (b - a)); intro.
@@ -1047,9 +1047,9 @@ Proof.
               }
               assert (H7 := H0 _ H6); unfold continuity_pt in H7; unfold continue_in in H7;
                 unfold limit1_in in H7; unfold limit_in in H7; simpl in H7;
-                unfold R_dist in H7; unfold continuity_pt;
+                unfold Rdist in H7; unfold continuity_pt;
                 unfold continue_in; unfold limit1_in;
-                unfold limit_in; simpl; unfold R_dist;
+                unfold limit_in; simpl; unfold Rdist;
                 intros; elim (H7 _ H8); intros; elim H9; clear H9;
                 intros.
               assert (H11 : 0 < x - a).
@@ -1097,9 +1097,9 @@ Proof.
                  }
                  assert (H8 := H0 _ H7); unfold continuity_pt in H8; unfold continue_in in H8;
                    unfold limit1_in in H8; unfold limit_in in H8; simpl in H8;
-                   unfold R_dist in H8; unfold continuity_pt;
+                   unfold Rdist in H8; unfold continuity_pt;
                    unfold continue_in; unfold limit1_in;
-                   unfold limit_in; simpl; unfold R_dist;
+                   unfold limit_in; simpl; unfold Rdist;
                    intros; elim (H8 _ H9); intros; exists (Rmin x0 (b - a));
                    split.
                  { unfold Rmin; case (Rle_dec x0 (b - a)); intro.
@@ -1135,7 +1135,7 @@ Proof.
                  apply Rmin_r.
               ** unfold continuity_pt; unfold continue_in;
                    unfold limit1_in; unfold limit_in;
-                   simpl; unfold R_dist; intros; exists (x - b);
+                   simpl; unfold Rdist; intros; exists (x - b);
                    split.
                  { change (0 < x - b); apply Rlt_Rminus; assumption. }
                  intros; elim H8; clear H8; intros.
@@ -1639,7 +1639,7 @@ Proof.
                  { assumption. }
                  assert (H4 := H _ H3); unfold continuity_pt in H4; unfold continue_in in H4;
                    unfold limit1_in in H4; unfold limit_in in H4; simpl in H4;
-                   unfold R_dist in H4; elim (H4 (eps / 2) (H1 eps));
+                   unfold Rdist in H4; elim (H4 (eps / 2) (H1 eps));
                    intros;
                    set
                      (E :=
@@ -1810,7 +1810,7 @@ Proof.
                    - assert (H12 :  exists x : R, E x). {
                        assert (H13 := H _ H9); unfold continuity_pt in H13;
                          unfold continue_in in H13; unfold limit1_in in H13;
-                         unfold limit_in in H13; simpl in H13; unfold R_dist in H13;
+                         unfold limit_in in H13; simpl in H13; unfold Rdist in H13;
                          elim (H13 _ (H1 eps)); intros; elim H12; clear H12;
                          intros; exists (Rmin x0 (M - m)); unfold E;
                          intros; split.

--- a/theories/Reals/Rtrigo1.v
+++ b/theories/Reals/Rtrigo1.v
@@ -75,8 +75,8 @@ Proof.
   }
   elim (H0 _ H2); intros N0 H3.
   exists N0; intros.
-  unfold R_dist in |- *; assert (H5 := H3 _ H4).
-  unfold R_dist in H5;
+  unfold Rdist in |- *; assert (H5 := H3 _ H4).
+  unfold Rdist in H5;
     replace
     (Rabs
       (Rabs (/ INR (fact (2 * S n)) * r ^ (2 * S n)) /
@@ -130,7 +130,7 @@ Proof.
     apply SFL_continuity; assumption.
   - unfold continuity in |- *; unfold continuity_pt in |- *;
       unfold continue_in in |- *; unfold limit1_in in |- *;
-      unfold limit_in in |- *; simpl in |- *; unfold R_dist in |- *;
+      unfold limit_in in |- *; simpl in |- *; unfold Rdist in |- *;
       intros.
     elim (H1 x _ H2); intros.
     exists x0; intros.
@@ -145,7 +145,7 @@ Proof.
     + unfold cos_in, infinite_sum in Hcos; unfold Un_cv in |- *; intros.
       elim (Hcos _ H0); intros N0 H1.
       exists N0; intros.
-      unfold R_dist in H1; unfold R_dist, SP in |- *.
+      unfold Rdist in H1; unfold Rdist, SP in |- *.
       replace (sum_f_R0 (fun k:nat => fn k x) n) with
         (sum_f_R0 (fun i:nat => cos_n i * Rsqr x ^ i) n).
       * apply H1; assumption.

--- a/theories/Reals/Rtrigo_alt.v
+++ b/theories/Reals/Rtrigo_alt.v
@@ -123,14 +123,14 @@ Proof.
         apply Rplus_le_compat_r.
       pose proof (pos_INR n0). nra.
   - assert (H3 := cv_speed_pow_fact a); unfold Un; unfold Un_cv in H3;
-      unfold R_dist in H3; unfold Un_cv; unfold R_dist;
+      unfold Rdist in H3; unfold Un_cv; unfold Rdist;
       intros; elim (H3 eps H4); intros N H5.
     exists N; intros; apply H5.
     lia.
   - unfold sin.
     destruct (exist_sin (Rsqr a)) as (x,p).
-    unfold sin_in, infinite_sum, R_dist in p;
-      unfold Un_cv, R_dist;
+    unfold sin_in, infinite_sum, Rdist in p;
+      unfold Un_cv, Rdist;
       intros.
     assert (H4:0 < eps / Rabs a). {
       unfold Rdiv; apply Rmult_lt_0_compat.
@@ -260,12 +260,12 @@ Proof.
     { nra. }
     pose proof (pos_INR n1);nra.
   -  assert (H4 := cv_speed_pow_fact a0); unfold Un; unfold Un_cv in H4;
-       unfold R_dist in H4; unfold Un_cv; unfold R_dist;
+       unfold Rdist in H4; unfold Un_cv; unfold Rdist;
        intros; elim (H4 eps H5); intros N H6; exists N; intros.
      apply H6; nia.
   - unfold cos. destruct (exist_cos (Rsqr a0)) as (x,p).
-    unfold cos_in, infinite_sum, R_dist in p;
-      unfold Un_cv, R_dist; intros.
+    unfold cos_in, infinite_sum, Rdist in p;
+      unfold Un_cv, Rdist; intros.
     destruct (p _ H4) as (N,H6).
     exists N; intros.
     replace (sum_f_R0 (tg_alt Un) n1) with

--- a/theories/Reals/Rtrigo_def.v
+++ b/theories/Reals/Rtrigo_def.v
@@ -52,7 +52,7 @@ Proof.
   - unfold exp_in; unfold infinite_sum; intros.
     exists 0%nat.
     intros; replace (sum_f_R0 (fun i:nat => / INR (fact i) * 0 ^ i) n) with 1.
-    + unfold R_dist; replace (1 - 1) with 0;
+    + unfold Rdist; replace (1 - 1) with 0;
         [ rewrite Rabs_R0; assumption | ring ].
     + induction  n as [| n Hrecn].
       * simpl; rewrite Rinv_1; ring.
@@ -158,7 +158,7 @@ Proof.
   unfold Un_cv; intros.
   assert (H0 := archimed_cor1 eps H).
   elim H0; intros; exists x.
-  intros; rewrite simpl_cos_n; unfold R_dist; unfold Rminus;
+  intros; rewrite simpl_cos_n; unfold Rdist; unfold Rminus;
     rewrite Ropp_0; rewrite Rplus_0_r; rewrite Rabs_Rabsolu;
       rewrite Rabs_Ropp; rewrite Rabs_right.
   2:{ apply Rle_ge; left; apply Rinv_0_lt_compat.
@@ -250,7 +250,7 @@ Lemma Alembert_sin : Un_cv (fun n:nat => Rabs (sin_n (S n) / sin_n n)) 0.
 Proof.
   unfold Un_cv; intros; assert (H0 := archimed_cor1 eps H).
   elim H0; intros; exists x.
-  intros; rewrite simpl_sin_n; unfold R_dist; unfold Rminus;
+  intros; rewrite simpl_sin_n; unfold Rdist; unfold Rminus;
     rewrite Ropp_0; rewrite Rplus_0_r; rewrite Rabs_Rabsolu;
       rewrite Rabs_Ropp; rewrite Rabs_right.
   2:{ left; apply Rinv_0_lt_compat.
@@ -335,7 +335,7 @@ Proof.
       exact (proj2_sig (exist_cos (Rsqr 0))).
   - unfold cos_in; unfold infinite_sum; intros; exists 0%nat.
     intros.
-    unfold R_dist.
+    unfold Rdist.
     induction  n as [| n Hrecn].
     + unfold cos_n; simpl.
       unfold Rdiv; rewrite Rinv_1.

--- a/theories/Reals/Rtrigo_fun.v
+++ b/theories/Reals/Rtrigo_fun.v
@@ -23,7 +23,7 @@ Lemma Alembert_exp :
   Un_cv (fun n:nat => Rabs (/ INR (fact (S n)) * / / INR (fact n))) 0.
 Proof.
   unfold Un_cv; intros; destruct (Rgt_dec eps 1) as [Hgt|Hnotgt].
-  - split with 0%nat; intros; rewrite (simpl_fact n); unfold R_dist;
+  - split with 0%nat; intros; rewrite (simpl_fact n); unfold Rdist;
       rewrite (Rminus_0_r (Rabs (/ INR (S n))));
       rewrite (Rabs_Rabsolu (/ INR (S n))); cut (/ INR (S n) > 0).
     + intro; rewrite (Rabs_pos_eq (/ INR (S n))).
@@ -52,7 +52,7 @@ Proof.
     + unfold Rgt; apply Rinv_0_lt_compat; apply lt_INR_0; apply Nat.lt_0_succ.
   - cut (0 <= up (/ eps - 1))%Z.
     + intro; elim (IZN (up (/ eps - 1)) H0); intros; split with x; intros;
-        rewrite (simpl_fact n); unfold R_dist;
+        rewrite (simpl_fact n); unfold Rdist;
         rewrite (Rminus_0_r (Rabs (/ INR (S n))));
         rewrite (Rabs_Rabsolu (/ INR (S n))); cut (/ INR (S n) > 0).
       * intro; rewrite (Rabs_pos_eq (/ INR (S n))).

--- a/theories/Reals/Rtrigo_reg.v
+++ b/theories/Reals/Rtrigo_reg.v
@@ -25,10 +25,10 @@ Proof.
   unfold continuity; intro.
   assert (H0 := continuity_cos (PI / 2 - x)).
   unfold continuity_pt in H0; unfold continue_in in H0; unfold limit1_in in H0;
-    unfold limit_in in H0; simpl in H0; unfold R_dist in H0;
+    unfold limit_in in H0; simpl in H0; unfold Rdist in H0;
       unfold continuity_pt; unfold continue_in;
         unfold limit1_in; unfold limit_in;
-          simpl; unfold R_dist; intros.
+          simpl; unfold Rdist; intros.
   elim (H0 _ H); intros.
   exists x0; intros.
   elim H1; intros.
@@ -94,8 +94,8 @@ Proof.
   }
   elim (H1 _ H3); intros N0 H4.
   exists N0; intros.
-  unfold R_dist; assert (H6 := H4 _ H5).
-  unfold R_dist in H5;
+  unfold Rdist; assert (H6 := H4 _ H5).
+  unfold Rdist in H5;
     replace
     (Rabs
       (Rabs (/ INR (fact (2 * S n + 1)) * r ^ (2 * S n)) /
@@ -169,7 +169,7 @@ Proof.
   }
   assert (H2 := SFL_continuity_pt _ cv _ X0 H0 _ H1).
   unfold continuity_pt in H2; unfold continue_in in H2; unfold limit1_in in H2;
-    unfold limit_in in H2; simpl in H2; unfold R_dist in H2.
+    unfold limit_in in H2; simpl in H2; unfold Rdist in H2.
   elim (H2 _ H); intros alp H3.
   elim H3; intros.
   exists (mkposreal _ H4).
@@ -190,7 +190,7 @@ Proof.
     eapply UL_sequence.
     - apply HUn.
     - unfold SP, fn; unfold Un_cv; intros; exists 1%nat; intros.
-      unfold R_dist;
+      unfold Rdist;
         replace
           (sum_f_R0 (fun k:nat => (-1) ^ k / INR (fact (2 * k + 1)) * 0 ^ (2 * k)) n)
         with 1.
@@ -216,7 +216,7 @@ Proof.
       unfold SP, fn, Un_cv; intros.
     elim (Hsin _ H10); intros N0 H11.
     exists N0; intros.
-    unfold R_dist; unfold R_dist in H11.
+    unfold Rdist; unfold Rdist in H11.
     replace
       (sum_f_R0 (fun k:nat => (-1) ^ k / INR (fact (2 * k + 1)) * h ^ (2 * k)) n)
       with
@@ -237,7 +237,7 @@ Proof.
   assert (continuity_pt sin 0) by apply continuity_sin.
   unfold continuity_pt in H3; unfold continue_in in H3;
     unfold limit1_in in H3; unfold limit_in in H3; simpl in H3;
-    unfold R_dist in H3.
+    unfold Rdist in H3.
   cut (0 < eps / 2); [ intro | assumption ].
   elim (H3 _ H4); intros del_c H5.
   assert (0 < Rmin del del_c). {

--- a/theories/Reals/SeqProp.v
+++ b/theories/Reals/SeqProp.v
@@ -57,10 +57,10 @@ Proof.
   - intros (x,p).
     exists (- x).
     unfold Un_cv in p.
-    unfold R_dist in p.
+    unfold Rdist in p.
     unfold opp_seq in p.
     unfold Un_cv.
-    unfold R_dist.
+    unfold Rdist.
     intros.
     elim (p eps H1); intros.
     exists x0; intros.
@@ -401,7 +401,7 @@ Lemma cauchy_opp :
 Proof.
   intro.
   unfold Cauchy_crit.
-  unfold R_dist.
+  unfold Rdist.
   intros.
   elim (H eps H0); intros.
   exists x; intros.
@@ -588,7 +588,7 @@ Qed.
 Lemma UL_sequence :
   forall (Un:nat -> R) (l1 l2:R), Un_cv Un l1 -> Un_cv Un l2 -> l1 = l2.
 Proof.
-  intros Un l1 l2; unfold Un_cv; unfold R_dist; intros.
+  intros Un l1 l2; unfold Un_cv; unfold Rdist; intros.
   apply cond_eq.
   intros; cut (0 < eps / 2);
     [ intro
@@ -611,7 +611,7 @@ Lemma CV_plus :
   forall (An Bn:nat -> R) (l1 l2:R),
     Un_cv An l1 -> Un_cv Bn l2 -> Un_cv (fun i:nat => An i + Bn i) (l1 + l2).
 Proof.
-  unfold Un_cv; unfold R_dist; intros.
+  unfold Un_cv; unfold Rdist; intros.
   cut (0 < eps / 2);
     [ intro
       | unfold Rdiv; apply Rmult_lt_0_compat;
@@ -636,7 +636,7 @@ Lemma cv_cvabs :
   forall (Un:nat -> R) (l:R),
     Un_cv Un l -> Un_cv (fun i:nat => Rabs (Un i)) (Rabs l).
 Proof.
-  unfold Un_cv; unfold R_dist; intros.
+  unfold Un_cv; unfold Rdist; intros.
   elim (H eps H0); intros.
   exists x; intros.
   apply Rle_lt_trans with (Rabs (Un n - l)).
@@ -650,14 +650,14 @@ Lemma CV_Cauchy :
 Proof.
   intros Un X; elim X; intros.
   unfold Cauchy_crit; intros.
-  unfold Un_cv in p; unfold R_dist in p.
+  unfold Un_cv in p; unfold Rdist in p.
   cut (0 < eps / 2);
     [ intro
       | unfold Rdiv; apply Rmult_lt_0_compat;
         [ assumption | apply Rinv_0_lt_compat; prove_sup0 ] ].
   elim (p (eps / 2) H0); intros.
   exists x0; intros.
-  unfold R_dist;
+  unfold Rdist;
     apply Rle_lt_trans with (Rabs (Un n - x) + Rabs (x - Un m)).
   - replace (Un n - Un m) with (Un n - x + (x - Un m));
       [ apply Rabs_triang | ring ].
@@ -709,11 +709,11 @@ Proof.
   assert (H1 := maj_by_pos An X).
   elim H1; intros M H2.
   elim H2; intros.
-  unfold Un_cv; unfold R_dist; intros.
+  unfold Un_cv; unfold Rdist; intros.
   cut (0 < eps / (2 * M)).
   - intro.
     case (Req_dec l2 0); intro.
-    + unfold Un_cv in H0; unfold R_dist in H0.
+    + unfold Un_cv in H0; unfold Rdist in H0.
       elim (H0 (eps / (2 * M)) H6); intros.
       exists x; intros.
       apply Rle_lt_trans with
@@ -759,8 +759,8 @@ Proof.
         apply Rinv_0_lt_compat; apply Rmult_lt_0_compat;
           [ prove_sup0 | apply Rabs_pos_lt; assumption ].
       }
-      unfold Un_cv in H; unfold R_dist in H; unfold Un_cv in H0;
-        unfold R_dist in H0.
+      unfold Un_cv in H; unfold Rdist in H; unfold Un_cv in H0;
+        unfold Rdist in H0.
       elim (H (eps / (2 * Rabs l2)) H8); intros N1 H9.
       elim (H0 (eps / (2 * M)) H6); intros N2 H10.
       set (N := max N1 N2).
@@ -861,7 +861,7 @@ Proof.
     + intro; elim (H0 ((1 - k) / 2) H1); intros.
       exists x; intros.
       assert (H4 := H2 n H3).
-      unfold R_dist in H4; rewrite <- Rabs_Rabsolu;
+      unfold Rdist in H4; rewrite <- Rabs_Rabsolu;
         replace (Rabs (An (S n) / An n)) with (Rabs (An (S n) / An n) - k + k);
         [ idtac | ring ];
         apply Rle_lt_trans with (Rabs (Rabs (An (S n) / An n) - k) + Rabs k).
@@ -886,7 +886,7 @@ Proof.
   - left; assumption.
   - right; assumption.
   - cut (0 < Un n - l).
-    + intro; unfold Un_cv in H0; unfold R_dist in H0.
+    + intro; unfold Un_cv in H0; unfold Rdist in H0.
       elim (H0 (Un n - l) H1); intros N1 H2.
       set (N := max n N1).
       cut (Un n - l <= Un N - l).
@@ -911,7 +911,7 @@ Lemma CV_opp :
   forall (An:nat -> R) (l:R), Un_cv An l -> Un_cv (opp_seq An) (- l).
 Proof.
   intros An l.
-  unfold Un_cv; unfold R_dist; intros.
+  unfold Un_cv; unfold Rdist; intros.
   elim (H eps H0); intros.
   exists x; intros.
   unfold opp_seq; replace (- An n - - l) with (- (An n - l));
@@ -953,7 +953,7 @@ Definition cv_infty (Un:nat -> R) : Prop :=
 Lemma cv_infty_cv_0 :
   forall Un:nat -> R, cv_infty Un -> Un_cv (fun n:nat => / Un n) 0.
 Proof.
-  unfold cv_infty, Un_cv; unfold R_dist; intros Un H0 eps H1.
+  unfold cv_infty, Un_cv; unfold Rdist; intros Un H0 eps H1.
   elim (H0 (/ eps)); intros N0 H2.
   exists N0; intros n H3.
   unfold Rminus; rewrite Ropp_0; rewrite Rplus_0_r;
@@ -1013,7 +1013,7 @@ Proof.
       (Un_cv (fun n:nat => Rabs x ^ n / INR (fact n)) 0 ->
         Un_cv (fun n:nat => x ^ n / INR (fact n)) 0).
   { intro; apply H.
-    unfold Un_cv; unfold R_dist; intros; case (Req_dec x 0);
+    unfold Un_cv; unfold Rdist; intros; case (Req_dec x 0);
       intro.
     - exists 1%nat; intros.
       rewrite H1; unfold Rminus; rewrite Ropp_0; rewrite Rplus_0_r;
@@ -1023,7 +1023,7 @@ Proof.
     - assert (H2 := Rabs_pos_lt x H1); set (M := up (Rabs x)); cut (0 <= M)%Z.
       + intro; elim (IZN M H3); intros M_nat H4.
         set (Un := fun n:nat => Rabs x ^ (M_nat + n) / INR (fact (M_nat + n))).
-        cut (Un_cv Un 0); unfold Un_cv; unfold R_dist; intros.
+        cut (Un_cv Un 0); unfold Un_cv; unfold Rdist; intros.
         * elim (H5 eps H0); intros N H6.
           exists (M_nat + N)%nat; intros;
             cut (exists p : nat, (p >= N)%nat /\ n = (M_nat + p)%nat).
@@ -1045,7 +1045,7 @@ Proof.
           1:intro; cut (Un_decreasing Un).
           1:intro; cut (forall n:nat, Un (S n) <= Vn n).
           1:intro; cut (Un_cv Vn 0).
-          -- unfold Un_cv; unfold R_dist; intros.
+          -- unfold Un_cv; unfold Rdist; intros.
              elim (H10 eps0 H5); intros N1 H11.
              exists (S N1); intros.
              cut (forall n:nat, 0 < Vn n).
@@ -1065,7 +1065,7 @@ Proof.
              intro; apply Rlt_le_trans with (Un (S n0)); [ apply H7 | apply H9 ].
           -- cut (cv_infty (fun n:nat => INR (S n))).
              1:intro; cut (Un_cv (fun n:nat => / INR (S n)) 0).
-             1:unfold Un_cv, R_dist; intros; unfold Vn.
+             1:unfold Un_cv, Rdist; intros; unfold Vn.
              1:cut (0 < eps1 / (Rabs x * Un 0%nat)).
              ++ intro; elim (H11 _ H13); intros N H14.
                 exists N; intros;
@@ -1181,7 +1181,7 @@ Proof.
         { assumption. }
         elim (archimed (Rabs x)); intros; assumption.
   }
-  unfold Un_cv; unfold R_dist; intros; elim (H eps H0); intros.
+  unfold Un_cv; unfold Rdist; intros; elim (H eps H0); intros.
   exists x0; intros;
     apply Rle_lt_trans with (Rabs (Rabs x ^ n / INR (fact n) - 0)).
   - unfold Rminus; rewrite Ropp_0; do 2 rewrite Rplus_0_r;

--- a/theories/Reals/SeqSeries.v
+++ b/theories/Reals/SeqSeries.v
@@ -37,8 +37,8 @@ Proof.
     exists (l1 - SP fn N x).
     unfold Un_cv in H; unfold Un_cv; intros.
     elim (H eps H2); intros N0 H3.
-    unfold R_dist in H3; exists N0; intros.
-    unfold R_dist, SP.
+    unfold Rdist in H3; exists N0; intros.
+    unfold Rdist, SP.
     replace
       (sum_f_R0 (fun l:nat => fn (S N + l)%nat x) n -
          (l1 - sum_f_R0 (fun k:nat => fn k x) N)) with
@@ -78,8 +78,8 @@ Proof.
     exists (l2 - sum_f_R0 An N).
     unfold Un_cv in H0; unfold Un_cv; intros.
     elim (H0 eps H2); intros N0 H3.
-    unfold R_dist in H3; exists N0; intros.
-    unfold R_dist;
+    unfold Rdist in H3; exists N0; intros.
+    unfold Rdist;
       replace (sum_f_R0 (fun l:nat => An (S N + l)%nat) n - (l2 - sum_f_R0 An N))
       with (sum_f_R0 An N + sum_f_R0 (fun l:nat => An (S N + l)%nat) n - l2);
       [ idtac | ring ].
@@ -123,8 +123,8 @@ Proof.
     { apply H3. }
     unfold Un_cv in H0; unfold Un_cv; intros; elim (H0 eps H5);
       intros N0 H6.
-    unfold R_dist in H6; exists N0; intros.
-    unfold R_dist;
+    unfold Rdist in H6; exists N0; intros.
+    unfold Rdist;
       replace (sum_f_R0 (fun l:nat => An (S N + l)%nat) n - (l2 - sum_f_R0 An N))
       with (sum_f_R0 An N + sum_f_R0 (fun l:nat => An (S N + l)%nat) n - l2);
       [ idtac | ring ].
@@ -155,8 +155,8 @@ Proof.
   { apply H2. }
   unfold Un_cv in H; unfold Un_cv; intros.
   elim (H eps H4); intros N0 H5.
-  unfold R_dist in H5; exists N0; intros.
-  unfold R_dist, SP;
+  unfold Rdist in H5; exists N0; intros.
+  unfold Rdist, SP;
     replace
       (sum_f_R0 (fun l:nat => fn (S N + l)%nat x) n -
          (l1 - sum_f_R0 (fun k:nat => fn k x) N)) with
@@ -204,15 +204,15 @@ Proof.
   intros; elim (H0 eps H1); intros.
   exists x; intros.
   cut
-    (R_dist (sum_f_R0 An n) (sum_f_R0 An m) <=
-      R_dist (sum_f_R0 Bn n) (sum_f_R0 Bn m)).
-  { intro; apply Rle_lt_trans with (R_dist (sum_f_R0 Bn n) (sum_f_R0 Bn m)).
+    (Rdist (sum_f_R0 An n) (sum_f_R0 An m) <=
+      Rdist (sum_f_R0 Bn n) (sum_f_R0 Bn m)).
+  { intro; apply Rle_lt_trans with (Rdist (sum_f_R0 Bn n) (sum_f_R0 Bn m)).
     - assumption.
     - apply H2; assumption. }
   destruct (lt_eq_lt_dec n m) as [[| -> ]|].
   - rewrite (tech2 An n m); [ idtac | assumption ].
     rewrite (tech2 Bn n m); [ idtac | assumption ].
-    unfold R_dist; unfold Rminus; do 2 rewrite Ropp_plus_distr;
+    unfold Rdist; unfold Rminus; do 2 rewrite Ropp_plus_distr;
       do 2 rewrite <- Rplus_assoc; do 2 rewrite Rplus_opp_r;
         do 2 rewrite Rplus_0_l; do 2 rewrite Rabs_Ropp; repeat rewrite Rabs_right.
     + apply sum_Rle; intros.
@@ -223,12 +223,12 @@ Proof.
       apply Rle_trans with (An (S n + n0)%nat); assumption.
     + apply Rle_ge; apply cond_pos_sum; intro.
       elim (H (S n + n0)%nat); intros; assumption.
-  - unfold R_dist; unfold Rminus;
+  - unfold Rdist; unfold Rminus;
     do 2 rewrite Rplus_opp_r; rewrite Rabs_R0; right;
       reflexivity.
   - rewrite (tech2 An m n); [ idtac | assumption ].
     rewrite (tech2 Bn m n); [ idtac | assumption ].
-    unfold R_dist; unfold Rminus; do 2 rewrite Rplus_assoc;
+    unfold Rdist; unfold Rminus; do 2 rewrite Rplus_assoc;
       rewrite (Rplus_comm (sum_f_R0 An m)); rewrite (Rplus_comm (sum_f_R0 Bn m));
         do 2 rewrite Rplus_assoc; do 2 rewrite Rplus_opp_l;
           do 2 rewrite Rplus_0_r; repeat rewrite Rabs_right.
@@ -275,7 +275,7 @@ Proof.
           -- prove_sup.
           -- apply Rabs_pos_lt;assumption.
       + elim (H5 _ H8); intros; exists x; intros; assert (H11 := H9 _ H10);
-          unfold R_dist in H11; unfold Rminus in H11; rewrite Ropp_0 in H11;
+          unfold Rdist in H11; unfold Rminus in H11; rewrite Ropp_0 in H11;
           rewrite Rplus_0_r in H11.
         apply Rle_lt_trans with (Rabs (C / sum_f_R0 An n)).
         { apply RRle_abs. }
@@ -289,7 +289,7 @@ Proof.
         * apply Rabs_no_R0;assumption.
   }
   elim H7; clear H7; intros N2 H7; set (N := max N1 N2); exists (S N); intros;
-    unfold R_dist;
+    unfold Rdist;
     replace (sum_f_R0 (fun k:nat => An k * Bn k) n / sum_f_R0 An n - l) with
     (sum_f_R0 (fun k:nat => An k * (Bn k - l)) n / sum_f_R0 An n).
   2:{ replace (sum_f_R0 (fun k:nat => An k * (Bn k - l)) n) with
@@ -315,7 +315,7 @@ Proof.
       + trivial.
     - apply Rle_ge; left; apply Rinv_0_lt_compat;trivial. }
 
-  unfold R_dist in H; unfold Rdiv; rewrite Rabs_mult;
+  unfold Rdist in H; unfold Rdiv; rewrite Rabs_mult;
     rewrite (Rabs_right (/ sum_f_R0 An n)).
   2:{ apply Rle_ge; left; apply Rinv_0_lt_compat;trivial. }
   apply Rle_lt_trans with
@@ -377,7 +377,7 @@ Proof.
         * apply lt_INR; apply Nat.lt_succ_r. trivial. }
   assert (H3 := Cesaro _ _ _ H H0 H2).
   unfold Un_cv; unfold Un_cv in H3; intros; elim (H3 _ H4); intros;
-    exists (S x); intros; unfold R_dist; unfold R_dist in H5;
+    exists (S x); intros; unfold Rdist; unfold Rdist in H5;
       apply Rle_lt_trans with
         (Rabs
           (sum_f_R0 (fun k:nat => An k * Bn k) (pred n) / sum_f_R0 An (pred n) - l)).

--- a/theories/Reals/Sqrt_reg.v
+++ b/theories/Reals/Sqrt_reg.v
@@ -84,7 +84,7 @@ Lemma sqrt_continuity_pt_R1 : continuity_pt sqrt 1.
 Proof.
   unfold continuity_pt; unfold continue_in;
     unfold limit1_in; unfold limit_in;
-      unfold dist; simpl; unfold R_dist;
+      unfold dist; simpl; unfold Rdist;
         intros.
   set (alpha := Rmin eps 1).
   exists alpha; intros.
@@ -109,7 +109,7 @@ Proof.
   intros; generalize sqrt_continuity_pt_R1.
   unfold continuity_pt; unfold continue_in;
     unfold limit1_in; unfold limit_in;
-      unfold dist; simpl; unfold R_dist;
+      unfold dist; simpl; unfold Rdist;
         intros.
   assert (0 < eps / sqrt x). {
     unfold Rdiv; apply Rmult_lt_0_compat.
@@ -228,7 +228,7 @@ Proof.
   intro; assert (H2 := continuity_pt_inv g 0 H0 H1).
   unfold derivable_pt_lim; intros; unfold continuity_pt in H2;
     unfold continue_in in H2; unfold limit1_in in H2;
-      unfold limit_in in H2; simpl in H2; unfold R_dist in H2.
+      unfold limit_in in H2; simpl in H2; unfold Rdist in H2.
   elim (H2 eps H3); intros alpha H4.
   elim H4; intros.
   set (alpha1 := Rmin alpha x).
@@ -304,7 +304,7 @@ Proof.
   2:exfalso;lra.
   unfold continuity_pt; unfold continue_in;
     unfold limit1_in; unfold limit_in;
-    simpl; unfold R_dist; intros.
+    simpl; unfold Rdist; intros.
   exists (Rsqr eps); intros.
   split.
   { change (0 < Rsqr eps); apply Rsqr_pos_lt;lra. }


### PR DESCRIPTION
This is useful for basic teaching using the Reals library (non-uniformity of naming is source of confusion).

Compatibility is preserved using a notation. I can add a deprecation if there is some demand, but I don't see it as a problem to keep synonyms (after all, there should eventually be a day anyway where Coq automatically corrects misspelling of names...)

- [x] Added **changelog**.
