### PR TITLE
Revert "[build] [vm] Fix flags declaration in dune file."

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -5,10 +5,6 @@
 (formatting
  (enabled_for ocaml))
 
-; See discussion in https://github.com/coq/coq/pull/14519
-; we handle our CC flags at the low-level ourselves
-(use_standard_c_and_cxx_flags true)
-
 ; After Dune 2.8 we can use this, but let's wait for the build consolidation PR
 ; (generate_opam_files true)
 

--- a/kernel/byterun/dune
+++ b/kernel/byterun/dune
@@ -5,7 +5,7 @@
  (foreign_stubs
   (language c)
   (names coq_fix_code coq_float64 coq_memory coq_values coq_interp)
-  (flags -fPIC (:include %{project_root}/config/dune.c_flags))))
+  (flags :standard (:include %{project_root}/config/dune.c_flags))))
 
 (rule
  (targets coq_instruct.h)


### PR DESCRIPTION
This reverts commit d071ca25a5070bf39cd42269816c53c26d79d670 from PR #14519

because it broke the build on 32bit and on old gcc

Fixes #16830