### PR TITLE
Deprecate elimtype and casetype tactics

### DIFF
--- a/doc/changelog/04-tactics/16904-deprecate-elim-case-type.rst
+++ b/doc/changelog/04-tactics/16904-deprecate-elim-case-type.rst
@@ -1,0 +1,4 @@
+- **Deprecated:**
+  the :tacn:`elimtype` and :tacn:`casetype` tactics
+  (`#16904 <https://github.com/coq/coq/pull/16904>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -1770,7 +1770,7 @@ Controlling the proof flow
    Implements the “ex falso quodlibet” logical principle: an
    elimination of False is performed on the current goal, and the user is
    then required to prove that False is indeed provable in the current
-   context. This tactic is equivalent to :tacn:`elimtype` :n:`False`.
+   context.
 
 Classical tactics
 -----------------

--- a/doc/sphinx/proofs/writing-proofs/reasoning-inductives.rst
+++ b/doc/sphinx/proofs/writing-proofs/reasoning-inductives.rst
@@ -242,6 +242,8 @@ analysis on inductive or coinductive objects (see :ref:`variants`).
 .. tacn:: casetype @one_type
    :undocumented:
 
+   .. deprecated:: 8.18
+
 .. tacn:: simple destruct {| @ident | @natural }
 
    Equivalent to :tacn:`intros` :n:`until {| @ident | @natural }; case @ident`
@@ -413,6 +415,8 @@ Induction
    Conversely, if :g:`t` is a :n:`@one_term` of (inductive) type :g:`I` that does
    not occur in the goal, then :n:`elim t` is equivalent to
    :n:`elimtype I; only 2:` :tacn:`exact` `t.`
+
+   .. deprecated:: 8.18
 
 .. tacn:: simple induction {| @ident | @natural }
 

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1915,7 +1915,6 @@ ltac_defined_tactics: [
 | "contradict" ident
 | "discrR"
 | "easy"
-| "exfalso"
 | "inversion_sigma" OPT ( ident OPT ( "as" simple_intropattern ) )
 | "lia"
 | "lra"

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1548,6 +1548,7 @@ simple_tactic: [
 | "native_cast_no_check" constr
 | "casetype" constr
 | "elimtype" constr
+| "exfalso"
 | "lapply" constr
 | "transitivity" constr
 | "left"

--- a/plugins/ltac/coretactics.mlg
+++ b/plugins/ltac/coretactics.mlg
@@ -66,6 +66,10 @@ TACTIC EXTEND elimtype
 | [ "elimtype" constr(c) ] -> { Tactics.elim_type c }
 END
 
+TACTIC EXTEND exfalso
+| [ "exfalso" ] -> { Tactics.exfalso }
+END
+
 TACTIC EXTEND lapply
 | [ "lapply" constr(c) ] -> { Tactics.cut_and_apply c }
 END

--- a/plugins/ltac/coretactics.mlg
+++ b/plugins/ltac/coretactics.mlg
@@ -58,11 +58,11 @@ TACTIC EXTEND native_cast_no_check
 | [ "native_cast_no_check" constr(c) ] -> { Tactics.native_cast_no_check c }
 END
 
-TACTIC EXTEND casetype
+TACTIC EXTEND casetype DEPRECATED { Deprecation.make ~since:"8.18" ~note:"Use [case] instead." () }
 | [ "casetype" constr(c) ] -> { Tactics.case_type c }
 END
 
-TACTIC EXTEND elimtype
+TACTIC EXTEND elimtype DEPRECATED { Deprecation.make ~since:"8.18" ~note:"Use [elim] instead." () }
 | [ "elimtype" constr(c) ] -> { Tactics.elim_type c }
 END
 

--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -2432,7 +2432,7 @@ let exfalso_if_concl_not_Prop =
       Tacmach.(
         if is_prop (pf_env gl) (project gl) (pf_concl gl) then
           Tacticals.tclIDTAC
-        else Tactics.elim_type (Lazy.force coq_False)))
+        else Tactics.exfalso))
 
 let micromega_gen parse_arith pre_process cnf spec dumpexpr prover tac =
   Tacticals.tclTHEN exfalso_if_concl_not_Prop

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -1040,7 +1040,6 @@ let pf_interp_gen_aux env sigma ~concl to_ind ((oclr, occ), t) =
 
 let genclrtac cl cs clr =
   let open Proofview.Notations in
-  let open Tacticals in
   (* apply_type may give a type error, but the useful message is
    * the one of clear.  You type "move: x" and you get
    * "x is used in hyp H" instead of
@@ -1048,8 +1047,7 @@ let genclrtac cl cs clr =
   (Proofview.tclORELSE
     (Tactics.apply_type ~typecheck:true cl cs)
     (fun (type_err, info) ->
-      pf_constr_of_global Coqlib.(lib_ref "core.False.type") >>= fun f ->
-      (Tactics.elim_type f) <*>
+      (Tactics.exfalso) <*>
       (cleartac clr) <*>
       (Proofview.tclZERO ~info type_err)))
   <*>

--- a/tactics/contradiction.ml
+++ b/tactics/contradiction.ml
@@ -35,9 +35,8 @@ let absurd c =
     let r = ESorts.relevance_of_sort sigma j.Environ.utj_type in
     Proofview.Unsafe.tclEVARS sigma <*>
     Tacticals.pf_constr_of_global (Coqlib.(lib_ref "core.not.type")) >>= fun coqnot ->
-    Tacticals.pf_constr_of_global (Coqlib.(lib_ref "core.False.type")) >>= fun coqfalse ->
     Tacticals.tclTHENLIST [
-      elim_type coqfalse;
+      Tactics.exfalso;
       Simple.apply (mk_absurd_proof coqnot r t)
     ]
   end

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -4943,6 +4943,13 @@ let case_type t =
   Proofview.tclTHEN (Proofview.Unsafe.tclEVARS evd) (elim_scheme_type (elimc, elimt) t)
   end
 
+let exfalso =
+  Proofview.Goal.enter begin fun gl ->
+    let env = Proofview.Goal.env gl in
+    let sigma = Proofview.Goal.sigma gl in
+    let (sigma, f) = Evd.fresh_global env sigma (Coqlib.lib_ref "core.False.type") in
+    Proofview.Unsafe.tclEVARS sigma <*> elim_type f
+  end
 
 (************************************************)
 (*  Tactics related with logic connectives      *)

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -309,6 +309,7 @@ val induction_destruct : rec_flag -> evars_flag ->
 
 val case_type         : types -> unit Proofview.tactic
 val elim_type         : types -> unit Proofview.tactic
+val exfalso : unit Proofview.tactic
 
 (** {6 Constructor tactics. } *)
 

--- a/test-suite/coq-makefile/vos/B.v
+++ b/test-suite/coq-makefile/vos/B.v
@@ -11,7 +11,7 @@ Section Foo.
 Variable (HFalse : False).
 
 Lemma yeq' : y = y.
-Proof using HFalse. elimtype False. apply HFalse. Qed.
+Proof using HFalse. exfalso. apply HFalse. Qed.
 
 End Foo.
 

--- a/theories/Init/Tactics.v
+++ b/theories/Init/Tactics.v
@@ -16,8 +16,7 @@ Require Import Specif.
 (** * Useful tactics *)
 
 (** Ex falso quodlibet : a tactic for proving False instead of the current goal.
-    This is just a nicer name for tactics such as [elimtype False]
-    and other [cut False]. *)
+    This is just a nicer name for tactics such as [cut False]. *)
 
 Ltac exfalso := Coq.Init.Ltac.exfalso.
 

--- a/theories/Init/Tactics.v
+++ b/theories/Init/Tactics.v
@@ -19,7 +19,7 @@ Require Import Specif.
     This is just a nicer name for tactics such as [elimtype False]
     and other [cut False]. *)
 
-Ltac exfalso := elimtype False.
+Ltac exfalso := Coq.Init.Ltac.exfalso.
 
 (** A tactic for proof by contradiction. With contradict H,
     -   H:~A |-  B    gives       |-  A

--- a/theories/Reals/Ranalysis5.v
+++ b/theories/Reals/Ranalysis5.v
@@ -397,7 +397,7 @@ Ltac case_le H :=
    let h' := fresh in
       match t with ?x <= ?y => case (total_order_T x y);
          [intros h'; case h'; clear h' |
-          intros h'; clear -H h'; elimtype False; lra ] end.
+          intros h'; clear -H h'; exfalso; lra ] end.
 (* end hide *)
 
 

--- a/theories/Sets/Finite_sets_facts.v
+++ b/theories/Sets/Finite_sets_facts.v
@@ -172,7 +172,7 @@ Section Finite_sets_facts.
         elim (classic (In U X0 x)).
         * intro H'6; apply f_equal.
           apply H'0 with (Y := Subtract U (Add U X0 x0) x).
-          -- elimtype (pred (S c2) = c2); auto with sets.
+          -- assert (pred (S c2) = c2) as []; auto with sets.
              apply card_soustr_1; auto with sets.
           -- rewrite <- H'5.
              apply Sub_Add_new; auto with sets.
@@ -243,7 +243,7 @@ Section Finite_sets_facts.
         intros X0 c2 H'2 H'3 x0 H'4 H'5; elim (classic (In U X0 x)).
         * intro H'6; apply -> Nat.succ_lt_mono.
           apply H'0 with (Y := Subtract U (Add U X0 x0) x).
-          -- elimtype (pred (S c2) = c2); [ | reflexivity ].
+          -- assert (pred (S c2) = c2) as []; [ reflexivity | ].
              apply card_soustr_1; auto with sets.
           -- apply incl_st_add_soustr; assumption.
         * elim (classic (x = x0)).

--- a/theories/Sets/Infinite_sets.v
+++ b/theories/Sets/Infinite_sets.v
@@ -111,8 +111,8 @@ Section Infinite_sets.
     intros A X H' n H'0 H'1; try assumption.
     elim H'1.
     intros H'2 H'3.
-    elimtype (exists Y : _, cardinal U Y (S n) /\ Included U Y A).
-    - intros x H'4; elim H'4; intros H'5 H'6; try exact H'5; clear H'4.
+    cut (exists Y : _, cardinal U Y (S n) /\ Included U Y A).
+    - intros [x H'4]; elim H'4; intros H'5 H'6; try exact H'5; clear H'4.
       exists x; auto with sets.
       split; [ auto with sets | idtac ].
       apply Defn_of_Approximant; auto with sets.

--- a/theories/Wellfounded/Union.v
+++ b/theories/Wellfounded/Union.v
@@ -45,7 +45,7 @@ Section WfUnion.
     apply Acc_intro; intros.
     elim H3; intros; auto with sets.
     cut (clos_trans A R1 y x); auto with sets.
-    elimtype (Acc (clos_trans A R1) y); intros.
+    cut (Acc (clos_trans A R1) y); [ intro H'; elim H' | ]; intros.
     - apply Acc_intro; intros.
       elim H8; intros.
       + apply H6; auto with sets.


### PR DESCRIPTION
These are basically vestigial tactics that survived the V7-V8 geological crisis. They only survived in some rare instances in the stdlib, and I suspect that they're just not used in the CI. In order to test this the last commit of the PR removes them just to see what happens, as an experiment.

EDIT: all the instances of elimtype removed from the stdlib in this PR were already there in Coq V5, so we're really talking archaeology here.