### PR TITLE
Remove the Apply With Renaming option.

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/16909-rm-apply-with-renaming.rst
+++ b/doc/changelog/08-vernac-commands-and-options/16909-rm-apply-with-renaming.rst
@@ -1,0 +1,5 @@
+- **Removed:**
+  the flag `Apply With Renaming` which was deprecated
+  since 8.15
+  (`#16909 <https://github.com/coq/coq/pull/16909>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/changes.rst
+++ b/doc/sphinx/changes.rst
@@ -715,7 +715,7 @@ Coq version 8.15 integrates many bug fixes, deprecations and cleanups as well
 as a few new features. We highlight some of the most impactful changes here:
 
   - The :tacn:`apply with <apply>` tactic :ref:`no longer renames arguments <815ApplyWith>`
-    unless compatibility flag :flag:`Apply With Renaming` is set.
+    unless compatibility flag `Apply With Renaming` is set.
 
   - :ref:`Improvements <815Auto>` to the :tacn:`auto` tactic family,
     fixing the :cmd:`Hint Unfold` behavior, and generalizing the use
@@ -911,7 +911,7 @@ Tactics
   .. _815ApplyWith:
 
 - **Changed:**
-  ``apply with`` does not rename arguments unless using compatibility flag :flag:`Apply With Renaming`
+  ``apply with`` does not rename arguments unless using compatibility flag `Apply With Renaming`
   (`#13837 <https://github.com/coq/coq/pull/13837>`_,
   fixes `#13759 <https://github.com/coq/coq/issues/13759>`_,
   by Gaëtan Gilbert).

--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -814,15 +814,6 @@ Applying theorems
    .. todo: we should be listing things like "Debug tactic-unification" in
       in the options index.  Maybe we should add ":debug:" as a new tag.
 
-   .. flag:: Apply With Renaming
-
-      When on, this flag causes the names in the :n:`@term`'s type to be renamed for uniqueness.
-      By default no renaming is done.
-
-      .. deprecated:: 8.15
-
-         Provided for compatibility with versions prior to 8.15.
-
    .. _apply_backward:
    .. example:: Backward reasoning in the goal with `apply`
 

--- a/engine/namegen.ml
+++ b/engine/namegen.ml
@@ -481,21 +481,3 @@ let compute_displayed_name_in_gen f env sigma =
 let compute_displayed_let_name_in env sigma flags avoid na =
   let fresh_id = next_name_for_display env sigma flags na avoid in
   (Name fresh_id, Id.Set.add fresh_id avoid)
-
-let rename_bound_vars_as_displayed env sigma avoid tenv c =
-  let rec rename avoid tenv c =
-    match EConstr.kind sigma c with
-    | Prod (na,c1,c2)  ->
-        let na',avoid' =
-          compute_displayed_name_in env sigma
-            (RenamingElsewhereFor (tenv,c2)) avoid na.binder_name c2 in
-        mkProd ({na with binder_name=na'}, c1, rename avoid' (na' :: tenv) c2)
-    | LetIn (na,c1,t,c2) ->
-        let na',avoid' =
-          compute_displayed_let_name_in env sigma
-            (RenamingElsewhereFor (tenv,c2)) avoid na.binder_name in
-        mkLetIn ({na with binder_name=na'},c1,t, rename avoid' (na' :: tenv) c2)
-    | Cast (c,k,t) -> mkCast (rename avoid tenv c, k,t)
-    | _ -> c
-  in
-  rename avoid tenv c

--- a/engine/namegen.mli
+++ b/engine/namegen.mli
@@ -117,8 +117,6 @@ val compute_displayed_name_in :
   Environ.env -> evar_map -> renaming_flags -> Id.Set.t -> Name.t -> constr -> Name.t * Id.Set.t
 val compute_displayed_let_name_in :
   Environ.env -> evar_map -> renaming_flags -> Id.Set.t -> Name.t -> Name.t * Id.Set.t
-val rename_bound_vars_as_displayed :
-  Environ.env -> evar_map -> Id.Set.t -> Name.t list -> types -> types
 
 (* Generic function expecting a "not occurn" function *)
 val compute_displayed_name_in_gen :

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -103,15 +103,6 @@ let pf_get_new_ids idl g =
 let next_ident_away_in_goal ids avoid =
   next_ident_away_in_goal (Global.env ()) ids (Id.Set.of_list avoid)
 
-let compute_renamed_type gls id =
-  let t = Tacmach.pf_get_hyp_typ id gls in
-  if Clenv.rename_with () then
-    rename_bound_vars_as_displayed (Global.env ()) (Proofview.Goal.sigma gls)
-      (*no avoid*) Id.Set.empty (*no rels*) []
-      t
-  else
-    t
-
 let h'_id = Id.of_string "h'"
 let teq_id = Id.of_string "teq"
 let ano_id = Id.of_string "anonymous"
@@ -956,7 +947,7 @@ let rec make_rewrite_list expr_info max = function
             (fun _ _ -> str "rewrite heq on " ++ Id.print p)
             (Proofview.Goal.enter (fun g ->
                  let sigma = Proofview.Goal.sigma g in
-                 let t_eq = compute_renamed_type g hp in
+                 let t_eq = Tacmach.pf_get_hyp_typ hp g in
                  let k, def =
                    let k_na, _, t = destProd sigma t_eq in
                    let _, _, t = destProd sigma t in
@@ -989,7 +980,7 @@ let make_rewrite expr_info l hp max =
        (tclTHENS
           (Proofview.Goal.enter (fun g ->
                let sigma = Proofview.Goal.sigma g in
-               let t_eq = compute_renamed_type g hp in
+               let t_eq = Tacmach.pf_get_hyp_typ hp g in
                let k, def =
                  let k_na, _, t = destProd sigma t_eq in
                  let _, _, t = destProd sigma t in

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -17,7 +17,6 @@ open Nameops
 open Termops
 open Constr
 open Context
-open Namegen
 open Environ
 open Evd
 open EConstr
@@ -968,15 +967,11 @@ let unify ?(flags=fail_quick_unif_flags) m =
 (****************************************************************)
 (* Clausal environment for an application *)
 
-let rename_with = Goptions.declare_bool_option_and_ref ~depr:true ~key:["Apply";"With";"Renaming"]
-    ~value:false
-
 let make_clenv_binding_gen hyps_only n env sigma (c,t) = function
   | ImplicitBindings largs ->
       let clause = mk_clenv_from_env env sigma n (c,t) in
       clenv_constrain_dep_args hyps_only largs clause
   | ExplicitBindings lbind ->
-      let t = if rename_with () then rename_bound_vars_as_displayed env sigma Id.Set.empty [] t else t in
       let clause = mk_clenv_from_env env sigma n (c, t) in clenv_match_args lbind clause
   | NoBindings ->
       mk_clenv_from_env env sigma n (c,t)
@@ -1015,7 +1010,6 @@ let make_evar_clause env sigma ?len t =
   | None -> -1
   | Some n -> assert (0 <= n); n
   in
-  let t = if rename_with () then rename_bound_vars_as_displayed env sigma Id.Set.empty [] t else t in
   let rec clrec (sigma, holes) inst n t =
     if n = 0 then (sigma, holes, t)
     else match EConstr.kind sigma t with

--- a/proofs/clenv.mli
+++ b/proofs/clenv.mli
@@ -152,9 +152,6 @@ val solve_evar_clause : env -> evar_map -> bool -> clause -> EConstr.constr bind
     not in the conclusion. This boolean is only used when [bl] is of the form
     [ImplicitBindings _]. *)
 
-val rename_with : unit -> bool
-(** For funind *)
-
 module Internal :
 sig
 


### PR DESCRIPTION
It was deprecated since Coq 8.15.