### PR TITLE
Remove the no-argument instantiate tactic.

### DIFF
--- a/doc/changelog/04-tactics/16910-rm-instantiate.rst
+++ b/doc/changelog/04-tactics/16910-rm-instantiate.rst
@@ -1,0 +1,4 @@
+- **Removed:**
+  the no-argument form of the :tacn:`instantiate` tactic, deprecated since 8.16
+  (`#16910 <https://github.com/coq/coq/pull/16910>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -1705,7 +1705,7 @@ Controlling the proof flow
    The body of this binding is a fresh existential variable.  If the second
    form is used, Coq chooses the name.
 
-.. tacn:: instantiate {? ( @ident := @term ) }
+.. tacn:: instantiate ( @ident := @term )
           instantiate ( @natural := @term ) {? @hloc }
    :name: instantiate; _
 
@@ -1728,11 +1728,6 @@ Controlling the proof flow
              explicitly, be aware that Coq may make a different decision on how to
              name the variable in the current goal and in the context of the
              existential variable. This can lead to surprising behaviors.
-
-   .. deprecated:: 8.16
-
-      The no argument form is equivalent to :tacn:`idtac`.  This form (only)
-      is deprecated in 8.16.
 
    The second form refines an existential variable selected by its position.  The
    :n:`@natural` argument is the position of the existential variable

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1084,9 +1084,6 @@ simple_tactic: [
 | REPLACE "einjection" destruction_arg "as" LIST0 simple_intropattern
 | WITH "einjection" OPT destruction_arg OPT ( "as" LIST0 simple_intropattern )
 | EDIT "simple" "injection" ADD_OPT destruction_arg
-| REPLACE "instantiate" "(" ident ":=" lglob ")"
-| WITH "instantiate" OPT ( "(" ident ":=" lglob ")" )
-| DELETE "instantiate"
 | DELETE "intro"  (* todo: change the mlg to simplify! *)
 | DELETE "intro" ident
 | DELETE "intro" ident "at" "top"

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1657,7 +1657,6 @@ simple_tactic: [
 | "evar" constr
 | "instantiate" "(" ident ":=" lglob ")"
 | "instantiate" "(" natural ":=" lglob ")" hloc
-| "instantiate"
 | "stepl" constr "by" tactic
 | "stepl" constr
 | "stepr" constr "by" tactic

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1692,7 +1692,7 @@ simple_tactic: [
 | "simple" "subst"
 | "evar" "(" ident ":" type ")"
 | "evar" one_type
-| "instantiate" OPT ( "(" ident ":=" term ")" )
+| "instantiate" "(" ident ":=" term ")"
 | "instantiate" "(" natural ":=" term ")" OPT hloc
 | "stepl" one_term OPT ( "by" ltac_expr )
 | "stepr" one_term OPT ( "by" ltac_expr )

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -378,10 +378,6 @@ TACTIC EXTEND instantiate
     { instantiate_tac i c hl }
 END
 
-TACTIC EXTEND instantiate_noarg DEPRECATED { Deprecation.make ~since:"8.16" () }
-| [ "instantiate" ] -> { Proofview.tclUNIT () }
-END
-
 (**********************************************************************)
 (** Nijmegen "step" tactic for setoid rewriting                       *)
 


### PR DESCRIPTION
It was deprecated and turned into a noop in 8.16.

Waiting for backwards compatible overlay
- https://github.com/DeepSpec/sf/pull/8