### PR TITLE
Remove the Typeclasses Filtered Unification flag.

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/16911-rm-tc-filtered-unification.rst
+++ b/doc/changelog/08-vernac-commands-and-options/16911-rm-tc-filtered-unification.rst
@@ -1,0 +1,5 @@
+- **Removed:**
+  the `Typeclasses Filtered Unification` flag, deprecated
+  since 8.16
+  (`#16911 <https://github.com/coq/coq/pull/16911>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/addendum/type-classes.rst
+++ b/doc/sphinx/addendum/type-classes.rst
@@ -573,22 +573,6 @@ Settings
    the dependent ones previously (Coq 8.5 and below). This can result in
    quite different performance behaviors of proof search.
 
-
-.. flag:: Typeclasses Filtered Unification
-
-   This :term:`flag`, which is off by default, switches the
-   hint application procedure to a filter-then-unify strategy. To apply a
-   hint, we first check that the goal *matches* syntactically the
-   inferred or specified pattern of the hint, and only then try to
-   *unify* the goal with the conclusion of the hint. This can drastically
-   improve performance by calling unification less often, matching
-   syntactic patterns being very quick. This also provides more control
-   on the triggering of instances. For example, forcing a :term:`constant` to
-   explicitly appear in the pattern will make it never apply on a goal
-   where there is a hole in that place.
-
-   .. deprecated:: 8.16
-
 .. flag:: Typeclasses Limit Intros
 
    This :term:`flag` (on by default) controls the ability to apply hints while

--- a/doc/sphinx/changes.rst
+++ b/doc/sphinx/changes.rst
@@ -407,7 +407,7 @@ Commands and options
   (`#15652 <https://github.com/coq/coq/pull/15652>`_,
   by Gaëtan Gilbert).
 - **Deprecated:**
-  the :flag:`Typeclasses Filtered Unification` flag. Due to
+  the `Typeclasses Filtered Unification` flag. Due to
   a buggy implementation, it is unlikely this is used in the wild
   (`#15752 <https://github.com/coq/coq/pull/15752>`_,
   by Pierre-Marie Pédrot).

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1773,10 +1773,6 @@ module FullHint =
 struct
   type t = full_hint
   let priority (h : t) = h.pri
-  let pattern (h : t) = match h.pat with
-  | None -> None
-  | Some (ConstrPattern p) -> Some p
-  | Some DefaultPattern -> None (* does not matter, only used by the deprecated Filtered typeclass option *)
   let database (h : t) = h.db
   let run (h : t) k = run_hint h.code k
   let print env sigma (h : t) = pr_hint env sigma h.code

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -56,7 +56,6 @@ module FullHint :
 sig
   type t
   val priority : t -> int
-  val pattern : t -> Pattern.constr_pattern option
   val database : t -> string option
   val run : t -> (hint hint_ast -> 'r Proofview.tactic) -> 'r Proofview.tactic
   val name : t -> hints_path_atom

--- a/test-suite/success/Hints.v
+++ b/test-suite/success/Hints.v
@@ -35,14 +35,6 @@ Create HintDb predconv discriminated.
 #[export] Hint Resolve pred0 | 1 (pred _) : predconv.
 #[export] Hint Resolve predf | 0 : predconv.
 
-Goal exists n, pred n.
-  eexists.
-  Set Typeclasses Filtered Unification.
-  Set Typeclasses Debug Verbosity 2.
-  (* predf is not tried as it doesn't match the goal *)
-  typeclasses eauto with pred.
-Qed.
-
 Parameter predconv : forall n, pred n -> pred (0 + S n).
 
 (* The inferred pattern contains 0 + ?n, syntactic match will fail to see convertible
@@ -61,7 +53,6 @@ Goal pred 3.
   typeclasses eauto with pred2conv.
 Abort.
 
-Set Typeclasses Filtered Unification.
 Set Typeclasses Debug Verbosity 2.
 #[export] Hint Resolve predconv | 1 (pred _) : pred.
 #[export] Hint Resolve predconv | 1 (pred (S _)) : predconv.
@@ -75,14 +66,6 @@ Goal pred 3.
      full unification is allowed *)
   typeclasses eauto with predconv.
 Qed.
-
-(** The other way around: goal contains redexes instead of instances *)
-Goal exists n, pred (0 + n).
-  eexists.
-  (* pred0 (pred _) matches the goal *)
-  typeclasses eauto with predconv.
-Qed.
-
 
 (* Checks that local names are accepted *)
 Section A.


### PR DESCRIPTION
It was deprecated in 8.16 and probably never used in practice.