### PR TITLE
deprecate Cyclic.ZModulo.ZModulo

### DIFF
--- a/doc/changelog/11-standard-library/16914-deprecate-ZModulo.rst
+++ b/doc/changelog/11-standard-library/16914-deprecate-ZModulo.rst
@@ -1,0 +1,7 @@
+- **Deprecated:** :g:`Cyclic.ZModulo.ZModulo` because there have been no known
+  use cases for this module and because it does not implement `Z/nZ` for
+  arbitrary `n` as one might expect based on the name. The same construction
+  will remain a part of the Coq test suite to ensure consistency of
+  `CyclicAxioms`
+  (`#16914 <https://github.com/coq/coq/pull/16914>`_,
+  by Andres Erbsen).

--- a/theories/Numbers/Cyclic/ZModulo/ZModulo.v
+++ b/theories/Numbers/Cyclic/ZModulo/ZModulo.v
@@ -11,6 +11,8 @@
 (** * Type [Z] viewed modulo a particular constant corresponds to [Z/nZ]
       as defined abstractly in CyclicAxioms. *)
 
+(** This library has been deprecated since Coq version 8.17. *)
+
 (** Even if the construction provided here is not reused for building
   the efficient arbitrary precision numbers, it provides a simple
   implementation of CyclicAxioms, hence ensuring its coherence. *)


### PR DESCRIPTION
The string `ZModulo` does not appear anywhere in the CI; in this repo it only appears in the [stdlib index](https://github.com/coq/coq/blob/790030f359136a2a31124236587bac53db5fdfcf/doc/stdlib/index-list.html.template#L282).

My only encounters with this library have been when it is mistaken for a general implementation of integers modulo another integer, much earlier by myself and recently by others.

I think having a sanity-check for `CyclicAxioms` is valuable, but can be accomplished under a less catchy name or even in the test suite.

This PR is intended to be merged in addition to https://github.com/coq/coq/pull/16913

- [x] Added **changelog**.