### PR TITLE
[stdlib] Cleaning deprecations from coq 8.15 and older

### DIFF
--- a/doc/changelog/11-standard-library/16920-deprecations.rst
+++ b/doc/changelog/11-standard-library/16920-deprecations.rst
@@ -1,0 +1,16 @@
+- **Deprecated:**
+  :g:`List.app_nil_end`, :g:`List.app_assoc_reverse`, :g:`List.ass_app`, :g:`List.app_ass`
+  (`#16920 <https://github.com/coq/coq/pull/16920>`_,
+  by Olivier Laurent).
+- **Removed:**
+  :g:`Datatypes.prod_curry`, :g:`Datatypes.prod_uncurry`, :g:`Datatypes.prodT_curry`, :g:`Datatypes.prodT_uncurry`, :g:`Combinators.prod_curry_uncurry`, :g:`Combinators.prod_uncurry_curry`,
+  :g:`Bool.leb`, :g:`Bool.leb_implb`,
+  :g:`List.skipn_none`,
+  :g:`Zdiv.Z_div_mod_eq`, :g:`Zdiv.div_Zdiv`, :g:`Zdiv.mod_Zmod`,
+  :g:`FloatOps.frexp`, :g:`FloatOps.ldexp`, :g:`FloatLemmas.frexp_spec`, :g:`FloatLemmas.ldexp_spec`,
+  :g:`RList.Rlist`, :g:`Rlist.cons`, :g:`Rlist.nil`, :g:`RList.Rlength`,
+  :g:`Rtrigo_calc.cos3PI4`, :g:`Rtrigo_calc.sin3PI4`,
+  :g:`MSetRBT.filter_app`
+  after deprecation for at least two Coq versions
+  (`#16920 <https://github.com/coq/coq/pull/16920>`_,
+  by Olivier Laurent).

--- a/theories/Bool/Bool.v
+++ b/theories/Bool/Bool.v
@@ -102,11 +102,6 @@ Proof.
   destr_bool; intuition.
 Qed.
 
-#[deprecated(since="8.12",note="Use Bool.le instead.")]
-Notation leb := le (only parsing).
-#[deprecated(since="8.12",note="Use Bool.le_implb instead.")]
-Notation leb_implb := le_implb (only parsing).
-
 #[ local ] Definition lt (b1 b2:bool) :=
   match b1 with
     | true => False

--- a/theories/FSets/FMapAVL.v
+++ b/theories/FSets/FMapAVL.v
@@ -1396,7 +1396,7 @@ Proof.
  induction s; simpl; intros; auto.
  rewrite IHs1, IHs2.
  unfold elements; simpl.
- rewrite 2 IHs1, IHs2, !app_nil_r, !app_ass; auto.
+ rewrite 2 IHs1, IHs2, !app_nil_r, <- !app_assoc; auto.
 Qed.
 
 Lemma elements_node :
@@ -1405,7 +1405,7 @@ Lemma elements_node :
  elements (Node t1 x e t2 z) ++ l.
 Proof.
  unfold elements; simpl; intros.
- rewrite !elements_app, !app_nil_r, !app_ass; auto.
+ rewrite !elements_app, !app_nil_r, <- !app_assoc; auto.
 Qed.
 
 (** * Fold *)

--- a/theories/Floats/FloatLemmas.v
+++ b/theories/Floats/FloatLemmas.v
@@ -25,8 +25,6 @@ Theorem Z_frexp_spec : forall f, let (m,e) := Z.frexp f in (Prim2SF m, e) = SFfr
   assert (H' := frshiftexp_spec f).
   now rewrite H in H'.
 Qed.
-#[deprecated(since = "8.15.0", note = "Use Z_frexp_spec instead.")]
-Notation frexp_spec := Z_frexp_spec (only parsing).
 
 Theorem Z_ldexp_spec : forall f e, Prim2SF (Z.ldexp f e) = SFldexp prec emax (Prim2SF f) e.
   intros.
@@ -329,5 +327,3 @@ Theorem Z_ldexp_spec : forall f e, Prim2SF (Z.ldexp f e) = SFldexp prec emax (Pr
       reflexivity.
     + exfalso; lia.
 Qed.
-#[deprecated(since = "8.15.0", note = "Use Z_ldexp_spec instead.")]
-Notation ldexp_spec := Z_ldexp_spec (only parsing).

--- a/theories/Floats/FloatOps.v
+++ b/theories/Floats/FloatOps.v
@@ -28,12 +28,6 @@ Module Z.
     ldshiftexp f (of_Z (e' + shift)).
 End Z.
 
-#[deprecated(since = "8.15.0", note = "Use Z.frexp instead.")]
-Notation frexp := Z.frexp (only parsing).
-
-#[deprecated(since = "8.15.0", note = "Use Z.ldexp instead.")]
-Notation ldexp := Z.ldexp (only parsing).
-
 Definition ulp f := Z.ldexp one (fexp prec emax (snd (Z.frexp f))).
 
 (** [Prim2SF] is an injective function that will be useful to express

--- a/theories/Init/Datatypes.v
+++ b/theories/Init/Datatypes.v
@@ -277,20 +277,6 @@ Definition curry {A B C:Type} (f:A * B -> C)
 Definition uncurry {A B C:Type} (f:A -> B -> C)
   (p:A * B) : C := match p with (x, y) => f x y end.
 
-(* These were deprecated in 8.13 but putting the "deprecated"
-   attribute on a Definition. Since, such a deprecation likely got
-   unnoticed from users, it was decided in 8.15 to put the attribute
-   on a Notation instead (thus printing deprecation warning when used)
-   and should probably be removed in 8.17 as if it had been
-   deprecated(since = "8.15", *)
-Definition prod_uncurry_subdef (A B C:Type) : (A * B -> C) -> A -> B -> C := curry.
-#[deprecated(since = "8.13", note = "Use curry instead.")]
-Notation prod_uncurry := prod_uncurry_subdef.
-
-Definition prod_curry_subdef (A B C:Type) : (A -> B -> C) -> A * B -> C := uncurry.
-#[deprecated(since = "8.13", note = "Use uncurry instead.")]
-Notation prod_curry := prod_curry_subdef.
-
 Import EqNotations.
 
 Lemma rew_pair A (P Q : A->Type) x1 x2 (y1:P x1) (y2:Q x1) (H:x1=x2) :
@@ -505,9 +491,5 @@ Notation prodT_rec := prod_rec (only parsing).
 Notation prodT_ind := prod_ind (only parsing).
 Notation fstT := fst (only parsing).
 Notation sndT := snd (only parsing).
-#[deprecated(since = "8.13", note = "Use curry instead.")]
-Notation prodT_uncurry := prod_uncurry_subdef (only parsing).
-#[deprecated(since = "8.13", note = "Use uncurry instead.")]
-Notation prodT_curry := prod_curry_subdef (only parsing).
 
 (* end hide *)

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -142,8 +142,8 @@ Section Facts.
   Qed.
 
   (* begin hide *)
-  (* Deprecated *)
-  Theorem app_nil_end (l:list A) : l = l ++ [].
+  (* Deprecated since 8.3 but attribute added in 8.18 *)
+  Theorem app_nil_end_deprecated (l:list A) : l = l ++ [].
   Proof. symmetry; apply app_nil_r. Qed.
   (* end hide *)
 
@@ -154,8 +154,8 @@ Section Facts.
   Qed.
 
   (* begin hide *)
-  (* Deprecated *)
-  Theorem app_assoc_reverse (l m n:list A) : (l ++ m) ++ n = l ++ m ++ n.
+  (* Deprecated since 8.3 but attribute added in 8.18 *)
+  Theorem app_assoc_reverse_deprecated (l m n:list A) : (l ++ m) ++ n = l ++ m ++ n.
   Proof. symmetry; apply app_assoc. Qed.
   (* end hide *)
 
@@ -340,7 +340,7 @@ Section Facts.
 End Facts.
 
 #[global]
-Hint Resolve app_assoc app_assoc_reverse: datatypes.
+Hint Resolve app_assoc app_assoc_reverse_deprecated: datatypes.
 #[global]
 Hint Resolve app_comm_cons app_cons_not_nil: datatypes.
 #[global]
@@ -2157,8 +2157,6 @@ Section Cutting.
   Lemma skipn_all : forall l, skipn (length l) l = nil.
   Proof. now intro l; induction l. Qed.
 
-#[deprecated(since="8.12",note="Use skipn_all instead.")] Notation skipn_none := skipn_all.
-
   Lemma skipn_all2 n: forall l, length l <= n -> skipn n l = [].
   Proof.
     intros l L%Nat.sub_0_le; rewrite <-(firstn_all l) at 1.
@@ -3543,8 +3541,10 @@ Notation tail := tl (only parsing).
 Notation head := hd_error (only parsing).
 Notation head_nil := hd_error_nil (only parsing).
 Notation head_cons := hd_error_cons (only parsing).
+#[deprecated(since = "8.18", note = "Use app_assoc instead.")]
 Notation ass_app := app_assoc (only parsing).
-Notation app_ass := app_assoc_reverse (only parsing).
+#[deprecated(since = "8.18", note = "Use app_assoc instead.")]
+Notation app_ass := app_assoc_reverse_deprecated (only parsing).
 Notation In_split := in_split (only parsing).
 Notation In_rev := in_rev (only parsing).
 Notation In_dec := in_dec (only parsing).
@@ -3553,8 +3553,13 @@ Notation rev_acc := rev_append (only parsing).
 Notation rev_acc_rev := rev_append_rev (only parsing).
 Notation AllS := Forall (only parsing). (* was formerly in TheoryList *)
 
+#[deprecated(since = "8.18", note = "Use app_nil_r instead.")]
+Notation app_nil_end := app_nil_end_deprecated (only parsing).
+#[deprecated(since = "8.18", note = "Use app_assoc instead.")]
+Notation app_assoc_reverse := app_assoc_reverse_deprecated (only parsing).
+
 #[global]
-Hint Resolve app_nil_end : datatypes.
+Hint Resolve app_nil_end_deprecated : datatypes.
 (* end hide *)
 
 

--- a/theories/Lists/SetoidList.v
+++ b/theories/Lists/SetoidList.v
@@ -929,7 +929,7 @@ Lemma eqlistA_rev_app : forall l1 l1',
 Proof.
 induction 1; auto.
 simpl; intros.
-do 2 rewrite app_ass; simpl; auto.
+do 2 rewrite <- app_assoc; simpl; auto.
 Qed.
 
 Global Instance rev_eqlistA_compat : Proper (eqlistA==>eqlistA) (@rev A).

--- a/theories/MSets/MSetGenTree.v
+++ b/theories/MSets/MSetGenTree.v
@@ -739,7 +739,7 @@ Proof.
  induction s; simpl; intros; auto.
  rewrite IHs1, IHs2.
  unfold elements; simpl.
- rewrite 2 IHs1, IHs2, !app_nil_r, !app_ass; auto.
+ rewrite 2 IHs1, IHs2, !app_nil_r, <- !app_assoc; auto.
 Qed.
 
 Lemma elements_node c l x r :
@@ -755,7 +755,7 @@ Proof.
  induction s; simpl; intros; auto.
  rewrite IHs1, IHs2.
  unfold rev_elements; simpl.
- rewrite IHs1, 2 IHs2, !app_nil_r, !app_ass; auto.
+ rewrite IHs1, 2 IHs2, !app_nil_r, <- !app_assoc; auto.
 Qed.
 
 Lemma rev_elements_node c l x r :
@@ -769,7 +769,7 @@ Lemma rev_elements_rev s : rev_elements s = rev (elements s).
 Proof.
  induction s as [|c l IHl x r IHr]; trivial.
  rewrite elements_node, rev_elements_node, IHl, IHr, rev_app_distr.
- simpl. now rewrite !app_ass.
+ simpl. now rewrite <- !app_assoc.
 Qed.
 
 (** The converse of [elements_spec2], used in MSetRBT *)
@@ -1036,7 +1036,7 @@ Lemma flatten_e_elements :
  forall l x r c e,
  elements l ++ flatten_e (More x r e) = elements (Node c l x r) ++ flatten_e e.
 Proof.
- intros. now rewrite elements_node, app_ass.
+ intros. now rewrite elements_node, <- app_assoc.
 Qed.
 
 Lemma cons_1 : forall s e,
@@ -1071,7 +1071,7 @@ Lemma compare_cont_Cmp : forall s1 cont e2 l,
  Cmp (compare_cont s1 cont e2) (elements s1 ++ l) (flatten_e e2).
 Proof.
  induction s1 as [|c1 l1 Hl1 x1 r1 Hr1]; intros; auto.
- rewrite elements_node, app_ass; simpl.
+ rewrite elements_node, <- app_assoc; simpl.
  apply Hl1; auto. clear e2. intros [|x2 r2 e2].
  - simpl; auto.
  - apply compare_more_Cmp.

--- a/theories/MSets/MSetRBT.v
+++ b/theories/MSets/MSetRBT.v
@@ -1062,9 +1062,6 @@ Qed.
 
 (** ** Filter *)
 
-#[deprecated(since="8.11",note="Lemma filter_app has been moved to module List.")]
-Notation filter_app := List.filter_app.
-
 Lemma filter_aux_elements s f acc :
  filter_aux f s acc = List.filter f (elements s) ++ acc.
 Proof.

--- a/theories/MSets/MSetRBT.v
+++ b/theories/MSets/MSetRBT.v
@@ -1002,7 +1002,7 @@ Proof.
     rewrite app_length, <- elements_cardinal. simpl.
     rewrite Nat.add_succ_r, <- Nat.succ_le_mono.
     apply Nat.add_le_mono_l. }
- rewrite elements_node, app_ass. now subst.
+ rewrite elements_node, <- app_assoc. now subst.
 Qed.
 
 Lemma treeify_aux_spec n (p:bool) :
@@ -1069,7 +1069,7 @@ Proof.
  induction s as [|c l IHl x r IHr]; trivial.
  intros acc.
  rewrite elements_node, List.filter_app. simpl.
- destruct (f x); now rewrite IHl, IHr, app_ass.
+ destruct (f x); now rewrite IHl, IHr, <- app_assoc.
 Qed.
 
 Lemma filter_elements s f :

--- a/theories/Program/Basics.v
+++ b/theories/Program/Basics.v
@@ -55,8 +55,3 @@ Definition flip {A B C} (f : A -> B -> C) x y := f y x.
 (** Application as a combinator. *)
 
 Definition apply {A B} (f : A -> B) (x : A) := f x.
-
-(** Curryfication of [prod] is defined in [Logic.Datatypes]. *)
-
-Arguments prod_curry_subdef   {A B C} f p.
-Arguments prod_uncurry_subdef {A B C} f x y.

--- a/theories/Program/Combinators.v
+++ b/theories/Program/Combinators.v
@@ -66,8 +66,3 @@ Proof.
   extensionality x ; extensionality p.
   destruct p ; simpl ; reflexivity.
 Qed.
-
-#[deprecated(since = "8.15", note = "Use curry_uncurry instead.")]
-Notation prod_uncurry_curry := curry_uncurry.
-#[deprecated(since = "8.15", note = "Use uncurry_curry instead.")]
-Notation prod_curry_uncurry := uncurry_curry.

--- a/theories/Reals/RList.v
+++ b/theories/Reals/RList.v
@@ -13,13 +13,6 @@ Require Import Rbase.
 Require Import Rfunctions.
 Local Open Scope R_scope.
 
-
-#[deprecated(since="8.12",note="use (list R) instead")]
-Notation Rlist := (list R).
-
-#[deprecated(since="8.12",note="use List.length instead")]
-Notation Rlength := List.length.
-
 Fixpoint MaxRlist (l:list R) : R :=
   match l with
     | nil => 0
@@ -743,9 +736,3 @@ Proof.
     + replace (r :: r0) with (app (r :: nil) r0);
         [ symmetry ; apply app_assoc | reflexivity ].
 Qed.
-
-#[deprecated(since="8.12",note="use List.cons instead")]
-Notation cons := List.cons.
-
-#[deprecated(since="8.12",note="use List.nil instead")]
-Notation nil := List.nil.

--- a/theories/Reals/Rtrigo_calc.v
+++ b/theories/Reals/Rtrigo_calc.v
@@ -185,15 +185,11 @@ Proof.
   ring.
 Qed.
 
-#[deprecated(since="8.10",note="Use cos_3PI4 instead.")] Notation cos3PI4 := cos_3PI4.
-
 Lemma sin_3PI4 : sin (3 * (PI / 4)) = 1 / sqrt 2.
 Proof.
   replace (3 * (PI / 4)) with (PI / 2 - - (PI / 4)) by field.
   now rewrite sin_shift, cos_neg, cos_PI4.
 Qed.
-
-#[deprecated(since="8.10",note="Use sin_3PI4 instead.")] Notation sin3PI4 := sin_3PI4.
 
 Lemma cos_PI6 : cos (PI / 6) = sqrt 3 / 2.
 Proof with trivial.

--- a/theories/Wellfounded/Lexicographic_Exponentiation.v
+++ b/theories/Wellfounded/Lexicographic_Exponentiation.v
@@ -132,7 +132,7 @@ Section Wf_Lexicographic_Exponentiation.
         * apply d_one.
         * apply d_nil.
     - induction y0 using rev_ind in x0, H0 |- *.
-      + rewrite <- app_nil_end in H0.
+      + rewrite app_nil_r in H0.
         rewrite <- H0.
         split.
         * apply d_conc; auto with sets.
@@ -142,11 +142,11 @@ Section Wf_Lexicographic_Exponentiation.
           split.
           -- apply app_inj_tail in H0 as (<-, _). assumption.
           -- apply d_one.
-        * rewrite <- 2!app_assoc_reverse in H0.
+        * rewrite 2!app_assoc in H0.
           apply app_inj_tail in H0 as (H0, <-).
           pose proof H0 as H0'.
           apply app_inj_tail in H0' as (_, ->).
-          rewrite app_assoc_reverse in H0.
+          rewrite <- app_assoc in H0.
           apply Hind in H0 as [].
           split.
           -- assumption.
@@ -261,10 +261,10 @@ Section Wf_Lexicographic_Exponentiation.
                forall y1 : Descl (l ++ x3),
                  ltl x3 [x1] -> Acc Lex_Exp << l ++ x3, y1 >>).
         * intros.
-          generalize (app_nil_end l); intros Heq.
+          generalize (app_nil_r l); intros Heq.
           generalize y1.
           clear y1.
-          rewrite <- Heq.
+          rewrite Heq.
           intro.
           apply Acc_intro.
           simple induction y2.
@@ -278,7 +278,7 @@ Section Wf_Lexicographic_Exponentiation.
           intros.
           generalize (desc_end x4 x1 l0 (conj H8 H5)); intros.
           generalize y1.
-          rewrite <- (app_assoc_reverse l l0 [x4]); intro.
+          rewrite (app_assoc l l0 [x4]); intro.
           generalize (HInd x4 H9 (l ++ l0)); intros HInd2.
           generalize (ltl_unit l0 x4 x1 H8 H5); intro.
           generalize (dist_Desc_concat (l ++ l0) [x4] y2).

--- a/theories/ZArith/Zdiv.v
+++ b/theories/ZArith/Zdiv.v
@@ -119,11 +119,6 @@ Proof.
   now destruct (Z.eq_dec b 0) as [->|?]; [destruct a|apply Z.div_mod].
 Qed.
 
-Lemma Z_div_mod_eq_deprecated a b : b > 0 -> a = b*(a/b) + (a mod b).
-Proof. intros. apply Z_div_mod_eq_full. Qed.
-#[deprecated(since="8.14",note="Use Z_div_mod_eq_full instead")]
-Notation Z_div_mod_eq := Z_div_mod_eq_deprecated (only parsing).
-
 Lemma Zmod_eq_full a b : b<>0 -> a mod b = a - (a/b)*b.
 Proof. intros. rewrite Z.mul_comm. now apply Z.mod_eq. Qed.
 
@@ -739,17 +734,3 @@ Proof.
 Qed.
 
 Arguments Zdiv_eucl_extended : default implicits.
-
-(** * Division and modulo in Z agree with same in nat: *)
-
-Lemma div_Zdiv_deprecated (n m: nat): m <> O ->
-  Z.of_nat (n / m) = Z.of_nat n / Z.of_nat m.
-Proof. intros. apply Nat2Z.inj_div. Qed.
-#[deprecated(since="8.14",note="Use Nat2Z.inj_div instead.")]
-Notation div_Zdiv := div_Zdiv_deprecated (only parsing).
-
-Lemma mod_Zmod_deprecated (n m: nat): m <> O ->
-  Z.of_nat (n mod m) = (Z.of_nat n) mod (Z.of_nat m).
-Proof. intros. apply Nat2Z.inj_mod. Qed.
-#[deprecated(since="8.14",note="Use Nat2Z.inj_mod instead.")]
-Notation mod_Zmod := mod_Zmod_deprecated (only parsing).


### PR DESCRIPTION
Cleaning of deprecations in the spirit of #14819 (but stdlib only).

- **Overlays** for Bool deprecations
  - [x] mit-plv/cross-crypto#31
  - [x] mit-plv/fiat#89
- **Overlays** for Datatypes deprecations
  - [x] [stdpp](https://gitlab.mpi-sws.org/iris/stdpp/-/blob/master/stdpp/base.v#L715) ~~(oldest Coq supported version 8.12, requires >= 8.13)~~
  - [x] math-comp/odd-order#44
  - [x] QuickChick/QuickChick#312 ~~(oldest Coq supported version 8.11, requires >= 8.13)~~
- **Overlays** for Reals deprecations
  - [x] [coquelicot](https://gitlab.inria.fr/coquelicot/coquelicot/-/merge_requests/3)
- **Overlays** for Zdiv deprecations
  - [x] mit-plv/bbv#43
  - [x] mit-plv/coqutil#82
  - [x] [flocq](https://gitlab.inria.fr/flocq/flocq/-/merge_requests/22)
  - [x] thery/coqprime#67
  - [x] jasmin-lang/coqword#16
  - [x] coq-community/corn#176 ~~(oldest Coq supported version 8.11, requires >= 8.14)~~
  - [x] mit-plv/kami#31
  - [x] AbsInt/CompCert#468 (oldest Coq supported version 8.12, requires >= 8.14) (_not required anymore: local version of `Z_div_mod_eq` introduced in CompCert to avoid warnings_)
  - [x] mit-plv/fiat-crypto#1529
  - [x] mit-plv/fiat-crypto#1589
  - [x] mit-plv/bedrock2#303
- **Overlays** for Floats deprecations
  - [x] [flocq](https://gitlab.inria.fr/flocq/flocq/-/merge_requests/22)

