### PR TITLE
Adapt the bytecode interpreter to the latest changes from OCaml 5.

### DIFF
--- a/kernel/byterun/coq_interp.c
+++ b/kernel/byterun/coq_interp.c
@@ -567,9 +567,8 @@ value coq_interprete
       CHECK_STACK(0);
       /* We also check for signals */
 #if OCAML_VERSION >= 50000
-      if (Caml_check_gc_interrupt(Caml_state) || caml_check_for_pending_signals()) {
-        // FIXME: it should be caml_process_pending_actions_exn
-        value res = caml_process_pending_signals_exn();
+      if (Caml_check_gc_interrupt(Caml_state)) {
+        value res = caml_process_pending_actions_exn();
         Handle_potential_exception(res);
       }
 #elif OCAML_VERSION >= 41000

--- a/kernel/byterun/coq_memory.c
+++ b/kernel/byterun/coq_memory.c
@@ -78,9 +78,9 @@ static void coq_scan_roots(scanning_action action)
   if (coq_prev_scan_roots_hook != NULL) (*coq_prev_scan_roots_hook)(action);
 }
 #else
-static void (*coq_prev_scan_roots_hook) (scanning_action, void *, caml_domain_state *);
+static void (*coq_prev_scan_roots_hook) (scanning_action, scanning_action_flags, void *, caml_domain_state *);
 
-static void coq_scan_roots(scanning_action action, void *ctx, caml_domain_state *state)
+static void coq_scan_roots(scanning_action action, scanning_action_flags flags, void *ctx, caml_domain_state *state)
 {
   register value * i;
   /* Scan the stack */
@@ -89,7 +89,7 @@ static void coq_scan_roots(scanning_action action, void *ctx, caml_domain_state 
     (*action) (ctx, *i, i);
   };
   /* Hook */
-  if (coq_prev_scan_roots_hook != NULL) (*coq_prev_scan_roots_hook)(action, ctx, state);
+  if (coq_prev_scan_roots_hook != NULL) (*coq_prev_scan_roots_hook)(action, flags, ctx, state);
 }
 #endif
 


### PR DESCRIPTION
- `process_pending_actions_exn` is now available.
- `check_pending_signals` is no longer needed, since "the interrupt word should be enough".
- `scan_roots_hook` got an additional parameter.