### PR TITLE
remove unnecessary second premise from stdlib's set_diff_nodup

### DIFF
--- a/doc/changelog/11-standard-library/16926-set_diff_nodup-premise.rst
+++ b/doc/changelog/11-standard-library/16926-set_diff_nodup-premise.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  drop the unnecessary second assumption :g:`NoDup l'` from :g:`set_diff_nodup` in ``ListSet.v``,
+  with `-compat 8.17` providing the old version of :g:`set_diff_nodup` for compatibility
+  (`#16926 <https://github.com/coq/coq/pull/16926>`_,
+  by Karl Palmskog with help from Traian Florin Şerbănuţă and Andres Erbsen).

--- a/theories/Compat/Coq817.v
+++ b/theories/Compat/Coq817.v
@@ -11,3 +11,20 @@
 (** Compatibility file for making Coq act similar to Coq v8.17 *)
 
 Require Export Coq.Compat.Coq818.
+
+Require Coq.Lists.ListSet.
+Global Set Warnings "-masking-absolute-name".
+Module Export Coq.
+  Module Export Lists.
+    Module Export ListSet.
+      Import List ListSet.
+      Local Lemma Private_set_diff_nodup :
+        forall (A:Type) (Aeq_dec : forall x y:A, {x = y} + {x <> y}) l l',
+         NoDup l -> NoDup l' -> NoDup (set_diff Aeq_dec l l').
+      Proof. auto using set_diff_nodup. Qed.
+      #[deprecated(since="8.18", note="The NoDup assumption for the second list has been dropped, please adjust uses of the lemma")]
+      Notation set_diff_nodup := Private_set_diff_nodup.
+    End ListSet.
+  End Lists.
+End Coq.
+Global Set Warnings "masking-absolute-name".

--- a/theories/Lists/ListSet.v
+++ b/theories/Lists/ListSet.v
@@ -454,9 +454,9 @@ Section first_definitions.
   - destruct 1. now apply set_diff_intro.
   Qed.
 
-  Lemma set_diff_nodup l l' : NoDup l -> NoDup l' -> NoDup (set_diff l l').
+  Lemma set_diff_nodup l l' : NoDup l -> NoDup (set_diff l l').
   Proof.
-   induction 1 as [|x l H H' IH]; intro Hl'; simpl.
+   induction 1 as [|x l H IH]; simpl.
    - constructor.
    - destruct (set_mem x l'); auto using set_add_nodup.
   Qed.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->
The statement of `ListSet.set_diff_nodup` is currently:
```coq
Lemma set_diff_nodup l l' : NoDup l -> NoDup l' -> NoDup (set_diff l l').
```
However, the second premise (`NoDup l'`) is unnecessary, which was first pointed out to me by @traiansf. Here, I remove this premise so that we instead get the stronger lemma:
```coq
Lemma set_diff_nodup l l' : NoDup l -> NoDup (set_diff l l').
```

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.