### PR TITLE
Fix #16922: bug in Nametab.remove which #12324 introduced (deactivation of notations)

### DIFF
--- a/dev/top_printers.dbg
+++ b/dev/top_printers.dbg
@@ -33,6 +33,7 @@ install_printer Top_printers.ppidset
 install_printer Top_printers.ppidmapgen
 install_printer Top_printers.ppintmapgen
 install_printer Top_printers.ppididmap
+install_printer Top_printers.ppmodidmapgen
 install_printer Top_printers.ppconstrunderbindersidmap
 install_printer Top_printers.ppevarsubst
 install_printer Top_printers.ppunbound_ltac_var_map

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -125,6 +125,8 @@ let pridmapgen l = prmapgen Id.print (Id.Set.elements (Id.Map.domain l))
 let ppidmapgen l = pp (pridmapgen l)
 let printmapgen l = prmapgen int (Int.Set.elements (Int.Map.domain l))
 let ppintmapgen l = pp (printmapgen l)
+let prmodidmapgen l = prmapgen Id.print (ModIdset.elements (ModIdmap.domain l))
+let ppmodidmapgen l = pp (prmodidmapgen l)
 
 let ppevarsubst = ppidmap (fun id0 -> prset (fun (c,copt,id) ->
   hov 0

--- a/dev/top_printers.mli
+++ b/dev/top_printers.mli
@@ -72,6 +72,9 @@ val ppidmapgen : 'a Names.Id.Map.t -> unit
 val printmapgen : 'a Int.Map.t -> Pp.t
 val ppintmapgen : 'a Int.Map.t -> unit
 
+val prmodidmapgen : 'a Names.ModIdmap.t -> Pp.t
+val ppmodidmapgen : 'a Names.ModIdmap.t -> unit
+
 val prididmap : Names.Id.t Names.Id.Map.t -> Pp.t
 val ppididmap : Names.Id.t Names.Id.Map.t -> unit
 

--- a/interp/constrextern.mli
+++ b/interp/constrextern.mli
@@ -84,16 +84,8 @@ val with_universes : ('a -> 'b) -> 'a -> 'b
 (** This suppresses printing of primitive tokens and notations *)
 val without_symbols : ('a -> 'b) -> 'a -> 'b
 
-(** This suppresses printing of specific notations only *)
-val without_specific_symbols : Notationextern.interp_rule list -> ('a -> 'b) -> 'a -> 'b
-
 (** This prints metas as anonymous holes *)
 val with_meta_as_hole : ('a -> 'b) -> 'a -> 'b
-
-(** Fine-grained activation and deactivation of notation printing.
- *)
-val toggle_scope_printing :
-  scope:Notation_term.scope_name -> activate:bool -> unit
 
 (** Probably shouldn't be used *)
 val empty_extern_env : extern_env

--- a/library/nametab.ml
+++ b/library/nametab.ml
@@ -228,16 +228,13 @@ let push visibility uname o tab =
 
 let rec remove_path uname tree = function
   | modid :: path ->
-      let map =
-        try
-          let submap = ModIdmap.find modid tree.map in
-          let submap = remove_path uname submap path in
-          if is_empty_tree submap then ModIdmap.empty
-          else ModIdmap.add modid submap tree.map
-        with Not_found ->
-          (* The name was actually not here *)
-          tree.map
+      let update = function
+        | None -> (* The name was actually not here *) None
+        | Some mc ->
+          let mc = remove_path uname mc path in
+          if is_empty_tree mc then None else Some mc
       in
+      let map = ModIdmap.update modid update tree.map in
       let this =
         let test = function Relative (uname',_) -> not (U.equal uname uname') | _ -> true in
         List.filter test tree.path

--- a/library/nametab.ml
+++ b/library/nametab.ml
@@ -134,8 +134,24 @@ struct
 
   let empty = Id.Map.empty
 
-  (* [push_until] is used to register [Until vis] visibility and
-     [push_exactly] to [Exactly vis] and [push_tree] chooses the right one*)
+  (* [push_until] is used to register [Until vis] visibility.
+
+     Example: [push_until Top.X.Y.t o (Until 1) tree [Y;X;Top]] adds the
+     value [Relative (Top.X.Y.t,o)] to occurrences [Y] and [Y.X] of
+     the tree, and [Absolute (Top.X.Y.t,o)] to occurrence [Y.X.Top] of
+     the tree. In particular, the tree now includes the following shape:
+     { map := Y |-> {map := X |-> {map := Top |-> {map := ...;
+                                                   path := Absolute (Top.X.Y.t,o)::...}
+                                          ...;
+                                   path := Relative (Top.X.Y.t,o)::...}
+                             ...;
+                     path := Relative (Top.X.Y.t,o)::...}
+               ...;
+       path := ...}
+     where ... denotes what was there before.
+
+     [push_exactly] is to register [Exactly vis] and [push] chooses
+     the right one *)
 
   let rec push_until uname o level tree = function
     | modid :: path ->

--- a/test-suite/bugs/bug_16922.v
+++ b/test-suite/bugs/bug_16922.v
@@ -1,0 +1,6 @@
+Module X.
+Inductive t : Type := .
+End X.
+Notation t := X.t.
+About t. (* was raising an anomaly from #12324 *)
+Print t.


### PR DESCRIPTION
`Nametab.remove_path` was inadvertantly losing brothers of modified subtrees.

In passing, we:
- document `Nametab.push_until` a small bit further
- add debugging printers for `Nametab.nametree`
- remove code made dead by #12324 but which was still present in the archive

Fixes / closes #16922

- [x] Added / updated **test-suite**.
