### PR TITLE
Fixes again #7903: notations with both ltac:() and binders

### DIFF
--- a/interp/genintern.ml
+++ b/interp/genintern.ml
@@ -49,7 +49,6 @@ type glob_constr_pattern_and_expr = Id.Set.t * glob_constr_and_expr * Pattern.co
 
 type ('raw, 'glb) intern_fun = glob_sign -> 'raw -> glob_sign * 'glb
 type 'glb subst_fun = substitution -> 'glb -> 'glb
-type 'glb ntn_subst_fun = glob_constr_and_expr Id.Map.t -> 'glb -> 'glb
 
 module InternObj =
 struct
@@ -65,16 +64,8 @@ struct
   let default _ = None
 end
 
-module NtnSubstObj =
-struct
-  type ('raw, 'glb, 'top) obj = 'glb ntn_subst_fun
-  let name = "notation_subst"
-  let default _ = None
-end
-
 module Intern = Register (InternObj)
 module Subst = Register (SubstObj)
-module NtnSubst = Register (NtnSubstObj)
 
 let intern = Intern.obj
 let register_intern0 = Intern.register0
@@ -92,12 +83,3 @@ let generic_substitute subs (GenArg (Glbwit wit, v)) =
   in_gen (glbwit wit) (substitute wit subs v)
 
 let () = Hook.set Detyping.subst_genarg_hook generic_substitute
-
-(** Notation substitution *)
-
-let substitute_notation = NtnSubst.obj
-let register_ntn_subst0 = NtnSubst.register0
-
-let generic_substitute_notation env (GenArg (Glbwit wit, v)) =
-  let v = substitute_notation wit env v in
-  in_gen (glbwit wit) v

--- a/interp/genintern.mli
+++ b/interp/genintern.mli
@@ -55,14 +55,6 @@ val substitute : ('raw, 'glb, 'top) genarg_type -> 'glb subst_fun
 
 val generic_substitute : glob_generic_argument subst_fun
 
-(** {5 Notation functions} *)
-
-type 'glb ntn_subst_fun = glob_constr_and_expr Id.Map.t -> 'glb -> 'glb
-
-val substitute_notation : ('raw, 'glb, 'top) genarg_type -> 'glb ntn_subst_fun
-
-val generic_substitute_notation : glob_generic_argument ntn_subst_fun
-
 (** Registering functions *)
 
 val register_intern0 : ('raw, 'glb, 'top) genarg_type ->
@@ -70,6 +62,3 @@ val register_intern0 : ('raw, 'glb, 'top) genarg_type ->
 
 val register_subst0 : ('raw, 'glb, 'top) genarg_type ->
   'glb subst_fun -> unit
-
-val register_ntn_subst0 : ('raw, 'glb, 'top) genarg_type ->
-  'glb ntn_subst_fun -> unit

--- a/interp/notation_ops.mli
+++ b/interp/notation_ops.mli
@@ -65,6 +65,10 @@ val glob_constr_of_notation_constr_with_binders : ?loc:Loc.t ->
 
 val glob_constr_of_notation_constr : ?loc:Loc.t -> notation_constr -> glob_constr
 
+val glob_cases_pattern_of_notation_glob_cases_pattern : ?loc:Loc.t ->
+  ('a -> Name.t -> glob_constr option -> 'a * ((Id.t list * cases_pattern_disjunction) * Id.t) option * Name.t * Glob_term.binding_kind * glob_constr option) ->
+  Names.Id.t list * 'a -> cases_pattern -> (Id.t list * 'a) * cases_pattern list
+
 (** {5 Matching a notation pattern against a [glob_constr]} *)
 
 (** [match_notation_constr] matches a [glob_constr] against a notation

--- a/interp/notation_term.ml
+++ b/interp/notation_term.ml
@@ -25,7 +25,7 @@ type notation_constr =
   | NVar of Id.t
   | NApp of notation_constr * notation_constr list
   | NProj of (Constant.t * glob_level list option) * notation_constr list * notation_constr
-  | NHole of Evar_kinds.t * Namegen.intro_pattern_naming_expr * Genarg.glob_generic_argument option
+  | NHole of Evar_kinds.t * Namegen.intro_pattern_naming_expr * (Genarg.glob_generic_argument * notation_constr_notation_substitution) option
   | NList of Id.t * Id.t * notation_constr * notation_constr * (* associativity: *) bool
   (* Part only in [glob_constr] *)
   | NLambda of Name.t * notation_constr option * notation_constr
@@ -47,6 +47,8 @@ type notation_constr =
   | NInt of Uint63.t
   | NFloat of Float64.t
   | NArray of notation_constr array * notation_constr * notation_constr
+
+and notation_constr_notation_substitution = notation_constr Names.Id.Map.t * cases_pattern list Names.Id.Map.t
 
 (** Note concerning NList: first constr is iterator, second is terminator;
     first id is where each argument of the list has to be substituted

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -20,6 +20,10 @@ let (-) = (-)
 let on_fst f (a,b) = (f a,b)
 let on_snd f (a,b) = (a,f b)
 let map_pair f (a,b) = (f a,f b)
+let smart_map_pair_het f g (a, b as p) =
+  let a' = f a in
+  let b' = g b in
+  if a' == a && b' == b then p else (a', b')
 
 (* Mapping under triplets *)
 

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -23,6 +23,7 @@ val (-) : int -> int -> int
 val on_fst : ('a -> 'b) -> 'a * 'c -> 'b * 'c
 val on_snd : ('a -> 'b) -> 'c * 'a -> 'c * 'b
 val map_pair : ('a -> 'b) -> 'a * 'a -> 'b * 'b
+val smart_map_pair_het : ('a -> 'a) -> ('b -> 'b) -> 'a * 'b -> 'a * 'b
 
 (** Mapping under triplets *)
 

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -818,19 +818,3 @@ let () =
   Genintern.register_intern0 wit_constr_with_bindings (lift intern_constr_with_bindings);
   Genintern.register_intern0 wit_destruction_arg (lift intern_destruction_arg);
   ()
-
-(** Substitution for notations containing tactic-in-terms *)
-
-let notation_subst bindings tac =
-  let fold id c accu =
-    let loc = Glob_ops.loc_of_glob_constr (fst c) in
-    let c = ConstrMayEval (ConstrTerm c) in
-    (make ?loc @@ Name id, c) :: accu
-  in
-  let bindings = Id.Map.fold fold bindings [] in
-  (* This is theoretically not correct due to potential variable
-     capture, but Ltac has no true variables so one cannot simply
-     substitute *)
-  CAst.make (TacLetIn (false, bindings, tac))
-
-let () = Genintern.register_ntn_subst0 wit_tactic notation_subst

--- a/plugins/ltac2/tac2intern.ml
+++ b/plugins/ltac2/tac2intern.ml
@@ -1859,9 +1859,10 @@ let () =
     | Some env -> env
     in
     (* Special handling of notation variables *)
-    let fold id _ (ids, env) =
+    let fold id (_,scopes,_) (ids, env) =
       let () = assert (not @@ mem_var id env) in
       let t = monomorphic (GTypRef (Other t_preterm, [])) in
+      (* force being used: *) scopes := Some ([],[]);
       let env = push_name (Name id) t env in
       (Id.Set.add id ids, env)
     in

--- a/plugins/ssr/ssrview.ml
+++ b/plugins/ssr/ssrview.ml
@@ -168,8 +168,9 @@ let is_tac_in_term ?extra_scope { annotation; body; glob_env; interp_env } =
     (* We unravel notations *)
     let g = intern_constr_expr ist sigma body in
     match DAst.get g with
-    | Glob_term.GHole (_,_, Some x)
-      when Genarg.has_type x (Genarg.glbwit Tacarg.wit_tactic)
+    | Glob_term.GHole (_,_, Some (x,(terms,bindings)))
+      when Genarg.has_type x (Genarg.glbwit Tacarg.wit_tactic) && terms = Id.Map.empty && bindings = Id.Map.empty
+        (* TODO: non empty bindings *)
         -> tclUNIT (`Tac (Genarg.out_gen (Genarg.glbwit Tacarg.wit_tactic) x))
     | _ -> tclUNIT (`Term (annotation, interp_env, g))
 end)

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -1177,7 +1177,12 @@ let rec subst_glob_constr env subst = DAst.map (function
       if nref == ref then knd else Evar_kinds.ImplicitArg (nref, i, b)
     | _ -> knd
     in
-    let nsolve = Option.Smart.map (Hook.get f_subst_genarg subst) solve in
+    let nsolve = Option.Smart.map
+        (smart_map_pair_het
+           (Hook.get f_subst_genarg subst)
+           (smart_map_pair_het
+              (Id.Map.map (subst_glob_constr env subst))
+              (Id.Map.map (List.Smart.map (subst_cases_pattern subst))))) solve in
     if nsolve == solve && nknd == knd then raw
     else GHole (nknd, naming, nsolve)
 

--- a/pretyping/globEnv.ml
+++ b/pretyping/globEnv.ml
@@ -189,6 +189,7 @@ let interp_ltac_id env id = ltac_interp_id env.lvar id
 
 type 'a obj_interp_fun =
   ?loc:Loc.t -> poly:bool -> t -> Evd.evar_map -> Evardefine.type_constraint ->
+  Glob_term.glob_constr_notation_substitution ->
   'a -> unsafe_judgment * Evd.evar_map
 
 module ConstrInterpObj =
@@ -202,8 +203,8 @@ module ConstrInterp = Genarg.Register(ConstrInterpObj)
 
 let register_constr_interp0 = ConstrInterp.register0
 
-let interp_glob_genarg ?loc ~poly env sigma ty arg =
+let interp_glob_genarg ?loc ~poly env sigma ty (arg, subst) =
   let open Genarg in
   let GenArg (Glbwit tag, arg) = arg in
   let interp = ConstrInterp.obj tag in
-  interp ?loc ~poly env sigma ty arg
+  interp ?loc ~poly env sigma ty subst arg

--- a/pretyping/globEnv.mli
+++ b/pretyping/globEnv.mli
@@ -23,6 +23,7 @@ type t
 
 type 'a obj_interp_fun =
   ?loc:Loc.t -> poly:bool -> t -> Evd.evar_map -> Evardefine.type_constraint ->
+  Glob_term.glob_constr_notation_substitution ->
   'a -> unsafe_judgment * Evd.evar_map
 
 val register_constr_interp0 :
@@ -91,4 +92,4 @@ val interp_ltac_id : t -> Id.t -> Id.t
     into account the possible renaming *)
 
 val interp_glob_genarg : ?loc:Loc.t -> poly:bool -> t -> evar_map -> Evardefine.type_constraint ->
-  Genarg.glob_generic_argument -> unsafe_judgment * evar_map
+  Glob_term.glob_generic_argument_closure -> unsafe_judgment * evar_map

--- a/pretyping/glob_term.ml
+++ b/pretyping/glob_term.ml
@@ -86,7 +86,7 @@ type 'a glob_constr_r =
   | GRec  of glob_fix_kind * Id.t array * 'a glob_decl_g list array *
              'a glob_constr_g array * 'a glob_constr_g array
   | GSort of glob_sort
-  | GHole of Evar_kinds.t * Namegen.intro_pattern_naming_expr * Genarg.glob_generic_argument option
+  | GHole of Evar_kinds.t * Namegen.intro_pattern_naming_expr * 'a glob_generic_argument_closure_g option
   | GCast of 'a glob_constr_g * Constr.cast_kind * 'a glob_constr_g
   | GProj of (Constant.t * glob_level list option) * 'a glob_constr_g list * 'a glob_constr_g
   | GInt of Uint63.t
@@ -110,6 +110,12 @@ and 'a cases_clause_g = (Id.t list * 'a cases_pattern_g list * 'a glob_constr_g)
 
 and 'a cases_clauses_g = 'a cases_clause_g list
 
+and 'a glob_generic_argument_closure_g = Genarg.glob_generic_argument * 'a glob_constr_notation_substitution_g
+
+and 'a glob_constr_notation_substitution_g =
+  'a glob_constr_g Names.Id.Map.t * (* terms *)
+  'a cases_pattern_g list Names.Id.Map.t (* disjunction of patterns *)
+
 type glob_constr = [ `any ] glob_constr_g
 type tomatch_tuple = [ `any ] tomatch_tuple_g
 type tomatch_tuples = [ `any ] tomatch_tuples_g
@@ -117,6 +123,8 @@ type cases_clause = [ `any ] cases_clause_g
 type cases_clauses = [ `any ] cases_clauses_g
 type glob_decl = [ `any ] glob_decl_g
 type predicate_pattern = [ `any ] predicate_pattern_g
+type glob_generic_argument_closure = [ `any ] glob_generic_argument_closure_g
+type glob_constr_notation_substitution = [ `any ] glob_constr_notation_substitution_g
 
 type any_glob_constr = AnyGlobConstr : 'r glob_constr_g -> any_glob_constr
 

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -517,7 +517,7 @@ type pretyper = {
   pretype_if : pretyper -> glob_constr * (Name.t * glob_constr option) * glob_constr * glob_constr -> unsafe_judgment pretype_fun;
   pretype_rec : pretyper -> glob_fix_kind * Id.t array * glob_decl list array * glob_constr array * glob_constr array -> unsafe_judgment pretype_fun;
   pretype_sort : pretyper -> glob_sort -> unsafe_judgment pretype_fun;
-  pretype_hole : pretyper -> Evar_kinds.t * Namegen.intro_pattern_naming_expr * Genarg.glob_generic_argument option -> unsafe_judgment pretype_fun;
+  pretype_hole : pretyper -> Evar_kinds.t * Namegen.intro_pattern_naming_expr * glob_generic_argument_closure option -> unsafe_judgment pretype_fun;
   pretype_cast : pretyper -> glob_constr * cast_kind * glob_constr -> unsafe_judgment pretype_fun;
   pretype_int : pretyper -> Uint63.t -> unsafe_judgment pretype_fun;
   pretype_float : pretyper -> Float64.t -> unsafe_judgment pretype_fun;

--- a/pretyping/pretyping.mli
+++ b/pretyping/pretyping.mli
@@ -168,7 +168,7 @@ type pretyper = {
   pretype_if : pretyper -> glob_constr * (Name.t * glob_constr option) * glob_constr * glob_constr -> unsafe_judgment pretype_fun;
   pretype_rec : pretyper -> glob_fix_kind * Id.t array * glob_decl list array * glob_constr array * glob_constr array -> unsafe_judgment pretype_fun;
   pretype_sort : pretyper -> glob_sort -> unsafe_judgment pretype_fun;
-  pretype_hole : pretyper -> Evar_kinds.t * Namegen.intro_pattern_naming_expr * Genarg.glob_generic_argument option -> unsafe_judgment pretype_fun;
+  pretype_hole : pretyper -> Evar_kinds.t * Namegen.intro_pattern_naming_expr * glob_generic_argument_closure option -> unsafe_judgment pretype_fun;
   pretype_cast : pretyper -> glob_constr * Constr.cast_kind * glob_constr -> unsafe_judgment pretype_fun;
   pretype_int : pretyper -> Uint63.t -> unsafe_judgment pretype_fun;
   pretype_float : pretyper -> Float64.t -> unsafe_judgment pretype_fun;

--- a/test-suite/bugs/bug_7903.v
+++ b/test-suite/bugs/bug_7903.v
@@ -1,4 +1,54 @@
 (* Slightly improving interpretation of Ltac subterms in notations *)
 
+Module Ltac1.
+
+(* x is only binding, absent in ltac *)
 Notation bar x f := (let z := ltac:(exact 1) in (fun x : nat => f)).
 Check fun x => bar x (x + x).
+Check bar x (x + x).
+Notation usebar v := (bar v (v + v)) (only parsing).
+Check usebar a.
+
+(* x is binding and bound, absent in ltac expression *)
+Notation bar' x f := (let z := ltac:(exact 1) in (x, fun x : nat => f)).
+Check fun x => bar' x (x + x).
+Notation usebar' v := (bar' v (v + v)) (only parsing).
+Check fun a => usebar' a.
+
+(* x is only binding *)
+Notation bar'' x f := (let z := ltac:(exact (fun x : nat => f)) in fun x : nat => f).
+Check fun x => bar'' x (x + x).
+Notation usebar'' v := (bar'' v (v + v)) (only parsing).
+Check usebar'' a.
+
+(* x is binding and bound *)
+Notation bar''' x f := (let z := ltac:(exact (x, fun x : nat => f)) in (x, fun x : nat => f)).
+Check fun x : bool => bar''' x (x + x).
+
+(* x is only bound in ltac *)
+Notation bar'''' x f := (let z := ltac:(exact x) in (x, fun x : nat => f)).
+Check fun x => bar'''' x (x + x).
+
+(* f is only bound in ltac *)
+Notation bar''''' x f := (let z := ltac:(exact f) in (fun x : nat => f)) (only parsing).
+Check fun p => bar''''' p (p + p).
+Notation usebar''''' v := (bar''''' v (v + v)) (only parsing).
+Check fun p => usebar''''' p.
+
+End Ltac1.
+
+Require Import Ltac2.Ltac2.
+
+Module Ltac2.
+
+(* x is binding and bound, absent in ltac2 expression *)
+Notation bar' x f := (let z := ltac2:(exact 1) in (x, fun x : nat => f)).
+Check fun x => bar' x (x + x).
+Notation usebar' v := (bar' v (v + v)) (only parsing).
+Check fun a => usebar' a.
+
+(* x is only bound in ltac2 *)
+Notation bar'''' x f := (let z := ltac2:(exact x) in (x, fun x : nat => f)).
+Check fun x => bar'''' x (x + x).
+
+End Ltac2.

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1208,7 +1208,7 @@ let warn_non_reversible_notation =
          (function
           | APrioriReversible -> assert false
           | HasLtac ->
-             strbrk "This notation contains Ltac expressions: it will not be used for printing."
+             strbrk "This notation contains quotations: it will not be used for printing."
           | NonInjective ids ->
              let n = List.length ids in
              strbrk (String.plural n "Variable") ++ spc () ++ pr_enum Id.print ids ++ spc () ++


### PR DESCRIPTION
The `ltac:(...)` code is not able to deal (in `Tacintern.notation_subst`) with subexpressions of a notation that are binders, so it can only fail and there is no point in passing those binders to `Tacintern.notation_subst` at the current time.

Fixes / closes #7903 (new fix).

- [x] Added / updated **test-suite**.
- [ ] Added **changelog**.
