### PR TITLE
Remove Flags.native_compiler

### DIFF
--- a/dev/ci/user-overlays/16930-SkySkimmer-flag-native.sh
+++ b/dev/ci/user-overlays/16930-SkySkimmer-flag-native.sh
@@ -1,0 +1,3 @@
+overlay elpi https://github.com/SkySkimmer/coq-elpi flag-native 16930
+
+overlay serapi https://github.com/SkySkimmer/coq-serapi flag-native 16930

--- a/lib/flags.ml
+++ b/lib/flags.ml
@@ -80,11 +80,3 @@ let get_inline_level () = !inline_level
 
 let profile_ltac = ref false
 let profile_ltac_cutoff = ref 2.0
-
-let native_compiler = ref None
-let get_native_compiler () = match !native_compiler with
-| None -> assert false
-| Some b -> b
-let set_native_compiler b =
-  let () = assert (!native_compiler == None) in
-  native_compiler := Some b

--- a/lib/flags.mli
+++ b/lib/flags.mli
@@ -88,11 +88,6 @@ val without_option : bool ref -> ('a -> 'b) -> 'a -> 'b
 (** Temporarily extends the reference to a list *)
 val with_extra_values : 'c list ref -> 'c list -> ('a -> 'b) -> 'a -> 'b
 
-(** Native compilation flag *)
-val get_native_compiler : unit -> bool
-val set_native_compiler : bool -> unit
-(** Must be set exactly once at initialization time. *)
-
 (** Level of inlining during a functor application *)
 val set_inline_level : int -> unit
 val get_inline_level : unit -> int

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -528,6 +528,6 @@ let native_norm env sigma c ty =
     EConstr.of_constr res
 
 let native_norm env sigma c ty =
-  if not (Flags.get_native_compiler ()) then
+  if not (Environ.typing_flags env).enable_native_compiler then
     user_err Pp.(str "Native_compute reduction has been disabled.");
   native_norm env sigma c ty

--- a/sysinit/coqinit.ml
+++ b/sysinit/coqinit.ml
@@ -158,7 +158,6 @@ let init_runtime opts =
   Global.set_indices_matter opts.config.logic.indices_matter;
   Global.set_check_universes (not opts.config.logic.type_in_type);
   Global.set_VM opts.config.enable_VM;
-  Flags.set_native_compiler (match opts.config.native_compiler with NativeOff -> false | NativeOn _ -> true);
   Global.set_native_compiler (match opts.config.native_compiler with NativeOff -> false | NativeOn _ -> true);
 
   (* Native output dir *)

--- a/tactics/redexpr.ml
+++ b/tactics/redexpr.ml
@@ -36,7 +36,7 @@ let warn_native_compute_disabled =
    strbrk "native_compute disabled at configure time; falling back to vm_compute.")
 
 let cbv_native env sigma c =
-  if Flags.get_native_compiler () then
+  if (Environ.typing_flags env).enable_native_compiler then
     let ctyp = Retyping.get_type_of env sigma c in
     Nativenorm.native_norm env sigma c ctyp
   else

--- a/topbin/coqnative_bin.ml
+++ b/topbin/coqnative_bin.ml
@@ -264,7 +264,6 @@ let fb_handler = function
 
 let init_coq () =
   let senv = Safe_typing.empty_environment in
-  let () = Flags.set_native_compiler true in
   let senv = Safe_typing.set_native_compiler true senv in
   let () = Safe_typing.allow_delayed_constants := false in
   let dummy = Names.DirPath.make [Names.Id.of_string_soft "@native"] in

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -153,7 +153,7 @@ let register_loaded_library m =
   let libname = m.libsum_name in
   let rec aux = function
     | [] ->
-        if Flags.get_native_compiler () then begin
+        if (Global.typing_flags ()).enable_native_compiler then begin
             let dirname = Filename.dirname (library_full_filename libname) in
             Nativelib.enable_library dirname libname
           end;


### PR DESCRIPTION
redundant with the setting in the env typing flags

overlays:
- https://github.com/LPCIC/coq-elpi/pull/410
- https://github.com/ejgallego/coq-serapi/pull/294