### PR TITLE
Preserve the ESorts abstraction in the upper layers.

### DIFF
--- a/dev/ci/user-overlays/16933-ppedrot-esorts-respect-api.sh
+++ b/dev/ci/user-overlays/16933-ppedrot-esorts-respect-api.sh
@@ -1,0 +1,15 @@
+overlay aac_tactics https://github.com/ppedrot/aac-tactics esorts-respect-api 16933
+
+overlay elpi https://github.com/ppedrot/coq-elpi esorts-respect-api 16933
+
+overlay equations https://github.com/ppedrot/Coq-Equations esorts-respect-api 16933
+
+overlay itauto https://gitlab.inria.fr/pedrot/itauto esorts-respect-api 16933
+
+overlay lean_importer https://github.com/ppedrot/coq-lean-import esorts-respect-api 16933
+
+overlay unicoq https://github.com/ppedrot/unicoq esorts-respect-api 16933
+
+overlay paramcoq https://github.com/ppedrot/paramcoq esorts-respect-api 16933
+
+overlay metacoq https://github.com/ppedrot/metacoq esorts-respect-api 16933

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -21,6 +21,24 @@ module ESorts = struct
 
   let equal sigma s1 s2 =
     Sorts.equal (kind sigma s1) (kind sigma s2)
+
+  let is_small sigma s = Sorts.is_small (kind sigma s)
+  let is_prop sigma s = Sorts.is_prop (kind sigma s)
+  let is_sprop sigma s = Sorts.is_sprop (kind sigma s)
+  let is_set sigma s = Sorts.is_set (kind sigma s)
+
+  let prop = make Sorts.prop
+  let sprop = make Sorts.sprop
+  let set = make Sorts.set
+  let type1 = make Sorts.type1
+
+  let super sigma s =
+    make (Sorts.super (kind sigma s))
+
+  let relevance_of_sort sigma s = Sorts.relevance_of_sort (kind sigma s)
+
+  let family sigma s = Sorts.family (kind sigma s)
+
 end
 
 module EInstance = struct
@@ -44,7 +62,7 @@ type case = (t, t, EInstance.t) pcase
 type fixpoint = (t, t) pfixpoint
 type cofixpoint = (t, t) pcofixpoint
 type unsafe_judgment = (constr, types) Environ.punsafe_judgment
-type unsafe_type_judgment = types Environ.punsafe_type_judgment
+type unsafe_type_judgment = (types, ESorts.t) Environ.punsafe_type_judgment
 type named_declaration = (constr, types) Context.Named.Declaration.pt
 type rel_declaration = (constr, types) Context.Rel.Declaration.pt
 type named_context = (constr, types) Context.Named.pt
@@ -62,7 +80,7 @@ let mkRel n = of_kind (Rel n)
 let mkVar id = of_kind (Var id)
 let mkMeta n = of_kind (Meta n)
 let mkEvar e = of_kind (Evar e)
-let mkSort s = of_kind (Sort (ESorts.make s))
+let mkSort s = of_kind (Sort s)
 let mkCast (b, k, t) = of_kind (Cast (b, k, t))
 let mkProd (na, t, u) = of_kind (Prod (na, t, u))
 let mkLambda (na, t, c) = of_kind (Lambda (na, t, c))
@@ -93,7 +111,7 @@ let mkRef (gr,u) = let open GlobRef in match gr with
 
 let mkLEvar = Evd.MiniEConstr.mkLEvar
 
-let type1 = mkSort Sorts.type1
+let type1 = mkSort ESorts.type1
 
 let applist (f, arg) = mkApp (f, Array.of_list arg)
 let applistc f arg = mkApp (f, Array.of_list arg)

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -25,7 +25,7 @@ type case_branch = t pcase_branch
 type fixpoint = (t, t) pfixpoint
 type cofixpoint = (t, t) pcofixpoint
 type unsafe_judgment = (constr, types) Environ.punsafe_judgment
-type unsafe_type_judgment = types Environ.punsafe_type_judgment
+type unsafe_type_judgment = (types, Evd.esorts) Environ.punsafe_type_judgment
 type named_declaration = (constr, types) Context.Named.Declaration.pt
 type rel_declaration = (constr, types) Context.Rel.Declaration.pt
 type named_context = (constr, types) Context.Named.pt
@@ -35,7 +35,7 @@ type rel_context = (constr, types) Context.Rel.pt
 
 module ESorts :
 sig
-  type t
+  type t = Evd.esorts
   (** Type of sorts up-to universe unification. Essentially a wrapper around
       Sorts.t so that normalization is ensured statically. *)
 
@@ -45,6 +45,24 @@ sig
   val kind : Evd.evar_map -> t -> Sorts.t
   (** Returns the view into the current sort. Note that the kind of a variable
       may change if the unification state of the evar map changes. *)
+
+  val equal : Evd.evar_map -> t -> t -> bool
+
+  val is_small : Evd.evar_map -> t -> bool
+  val is_prop : Evd.evar_map -> t -> bool
+  val is_sprop : Evd.evar_map -> t -> bool
+  val is_set : Evd.evar_map -> t -> bool
+
+  val prop : t
+  val sprop : t
+  val set : t
+  val type1 : t
+
+  val super : Evd.evar_map -> t -> t
+
+  val relevance_of_sort : Evd.evar_map -> t -> Sorts.relevance
+
+  val family : Evd.evar_map -> t -> Sorts.family
 
 end
 
@@ -115,7 +133,7 @@ val mkRel : int -> t
 val mkVar : Id.t -> t
 val mkMeta : metavariable -> t
 val mkEvar : t pexistential -> t
-val mkSort : Sorts.t -> t
+val mkSort : ESorts.t -> t
 val mkSProp : t
 val mkProp : t
 val mkSet  : t

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -757,7 +757,7 @@ let occur_evar_upto sigma n c =
 let judge_of_new_Type evd =
   let open EConstr in
   let (evd', s) = new_sort_variable univ_rigid evd in
-  (evd', { uj_val = mkSort s; uj_type = mkSort (Sorts.super s) })
+  (evd', { uj_val = mkSort s; uj_type = mkSort (ESorts.super evd s) })
 
 let subterm_source evk ?where (loc,k) =
   let evk = match k with

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -64,7 +64,7 @@ val new_type_evar :
   ?naming:intro_pattern_naming_expr ->
   ?principal:bool -> ?hypnaming:naming_mode ->
   env -> evar_map -> rigid ->
-  evar_map * (constr * Sorts.t)
+  evar_map * (constr * ESorts.t)
 
 val new_Type : ?rigid:rigid -> evar_map -> evar_map * constr
 

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -23,6 +23,7 @@ module NamedDecl = Context.Named.Declaration
 
 type econstr = constr
 type etypes = types
+type esorts = Sorts.t
 
 (** Generic filters *)
 module Filter :

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -30,6 +30,7 @@ open Environ
 
 type econstr
 type etypes = econstr
+type esorts
 
 (** {5 Existential variables and unification states} *)
 
@@ -625,7 +626,7 @@ val universe_of_name : evar_map -> Id.t -> Univ.Level.t
 val universe_binders : evar_map -> UnivNames.universe_binders
 
 val new_univ_level_variable : ?loc:Loc.t -> ?name:Id.t -> rigid -> evar_map -> evar_map * Univ.Level.t
-val new_sort_variable : ?loc:Loc.t -> ?name:Id.t -> rigid -> evar_map -> evar_map * Sorts.t
+val new_sort_variable : ?loc:Loc.t -> ?name:Id.t -> rigid -> evar_map -> evar_map * esorts
 
 val add_global_univ : evar_map -> Univ.Level.t -> evar_map
 
@@ -636,7 +637,7 @@ val make_flexible_variable : evar_map -> algebraic:bool -> Univ.Level.t -> evar_
 val make_nonalgebraic_variable : evar_map -> Univ.Level.t -> evar_map
 (** See [UState.make_nonalgebraic_variable]. *)
 
-val is_sort_variable : evar_map -> Sorts.t -> Univ.Level.t option
+val is_sort_variable : evar_map -> esorts -> Univ.Level.t option
 (** [is_sort_variable evm s] returns [Some u] or [None] if [s] is
     not a local sort variable declared in [evm] *)
 
@@ -644,15 +645,15 @@ val is_flexible_level : evar_map -> Univ.Level.t -> bool
 
 val normalize_universe_instance : evar_map -> Univ.Instance.t -> Univ.Instance.t
 
-val set_leq_sort : env -> evar_map -> Sorts.t -> Sorts.t -> evar_map
-val set_eq_sort : env -> evar_map -> Sorts.t -> Sorts.t -> evar_map
+val set_leq_sort : env -> evar_map -> esorts -> esorts -> evar_map
+val set_eq_sort : env -> evar_map -> esorts -> esorts -> evar_map
 val set_eq_level : evar_map -> Univ.Level.t -> Univ.Level.t -> evar_map
 val set_leq_level : evar_map -> Univ.Level.t -> Univ.Level.t -> evar_map
 val set_eq_instances : ?flex:bool ->
   evar_map -> Univ.Instance.t -> Univ.Instance.t -> evar_map
 
-val check_eq : evar_map -> Sorts.t -> Sorts.t -> bool
-val check_leq : evar_map -> Sorts.t -> Sorts.t -> bool
+val check_eq : evar_map -> esorts -> esorts -> bool
+val check_leq : evar_map -> esorts -> esorts -> bool
 
 val check_constraints : evar_map -> Univ.Constraints.t -> bool
 
@@ -690,7 +691,7 @@ val update_sigma_univs : UGraph.t -> evar_map -> evar_map
 (** Polymorphic universes *)
 
 val fresh_sort_in_family : ?loc:Loc.t -> ?rigid:rigid
-  -> evar_map -> Sorts.family -> evar_map * Sorts.t
+  -> evar_map -> Sorts.family -> evar_map * esorts
 val fresh_constant_instance : ?loc:Loc.t -> ?rigid:rigid
   -> env -> evar_map -> Constant.t -> evar_map * pconstant
 val fresh_inductive_instance : ?loc:Loc.t -> ?rigid:rigid
@@ -730,7 +731,7 @@ val create_evar_defs : evar_map -> evar_map
 (** Use this module only to bootstrap EConstr *)
 module MiniEConstr : sig
   module ESorts : sig
-    type t
+    type t = esorts
     val make : Sorts.t -> t
     val kind : evar_map -> t -> Sorts.t
     val unsafe_to_sorts : t -> Sorts.t

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -517,6 +517,7 @@ let rec check_glob env sigma g c = match DAst.get g, Constr.kind c with
      sigma, mkArray (u,t,def,ty)
   | Glob_term.GSort s, Constr.Sort s' ->
      let sigma,s = Evd.fresh_sort_in_family sigma (Glob_ops.glob_sort_family s) in
+     let s = EConstr.ESorts.kind sigma s in
      if not (Sorts.equal s s') then raise NotAValidPrimToken;
      sigma,mkSort s
   | _ -> raise NotAValidPrimToken
@@ -574,6 +575,7 @@ let rec constr_of_glob to_post post env sigma g = match DAst.get g with
        sigma, mkArray (u',t',def',ty')
   | Glob_term.GSort gs ->
       let sigma,c = Evd.fresh_sort_in_family sigma (Glob_ops.glob_sort_family gs) in
+      let c = EConstr.ESorts.kind sigma c in
       sigma,mkSort c
   | _ ->
       raise NotAValidPrimToken

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -783,11 +783,11 @@ let make_judge v tj =
 let j_val j = j.uj_val
 let j_type j = j.uj_type
 
-type 'types punsafe_type_judgment = {
+type ('types, 'sorts) punsafe_type_judgment = {
   utj_val : 'types;
-  utj_type : Sorts.t }
+  utj_type : 'sorts }
 
-type unsafe_type_judgment = types punsafe_type_judgment
+type unsafe_type_judgment = (types, Sorts.t) punsafe_type_judgment
 
 exception Hyp_not_found
 

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -391,11 +391,11 @@ val make_judge : 'constr -> 'types -> ('constr, 'types) punsafe_judgment
 val j_val  : ('constr, 'types) punsafe_judgment -> 'constr
 val j_type : ('constr, 'types) punsafe_judgment -> 'types
 
-type 'types punsafe_type_judgment = {
+type ('types, 'sorts) punsafe_type_judgment = {
   utj_val : 'types;
-  utj_type : Sorts.t }
+  utj_type : 'sorts }
 
-type unsafe_type_judgment = types punsafe_type_judgment
+type unsafe_type_judgment = (types, Sorts.t) punsafe_type_judgment
 
 exception Hyp_not_found
 

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -49,7 +49,7 @@ let whd_in_concl =
 (* decompose member of equality in an applicative format *)
 
 (** FIXME: evar leak *)
-let sf_of env sigma c = snd (sort_of env sigma c)
+let sf_of env sigma c = ESorts.kind sigma (snd (sort_of env sigma c))
 
 let rec decompose_term env sigma t =
     match EConstr.kind sigma (whd env sigma t) with

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -651,7 +651,7 @@ let () = define1 "constr_make" valexpr begin fun knd ->
     EConstr.mkLEvar sigma (evk, Array.to_list args)
   | (4, [|s|]) ->
     let s = Value.to_ext Value.val_sort s in
-    EConstr.mkSort (EConstr.Unsafe.to_sorts s)
+    EConstr.mkSort s
   | (5, [|c; k; t|]) ->
     let c = Value.to_constr c in
     let k = Value.to_ext Value.val_cast k in
@@ -803,7 +803,7 @@ let () = define3 "constr_in_context" ident constr closure begin fun id t c ->
         let t_ty = Retyping.get_type_of env sigma t in
         (* If the user passed eg ['_] for the type we force it to indeed be a type *)
         let sigma, j = Typing.type_judgment env sigma {uj_val=t; uj_type=t_ty} in
-        sigma, Sorts.relevance_of_sort j.utj_type
+        sigma, EConstr.ESorts.relevance_of_sort sigma j.utj_type
       in
       let nenv = EConstr.push_named (LocalAssum (Context.make_annot id t_rel, t)) env in
       let (sigma, (evt, _)) = Evarutil.new_type_evar nenv sigma Evd.univ_flexible in

--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -938,7 +938,7 @@ let mkformula_binary b g term f1 f2 =
 
 let is_prop env sigma term =
   let sort = Retyping.get_sort_of env sigma term in
-  Sorts.is_prop sort
+  EConstr.ESorts.is_prop sigma sort
 
 type formula_op =
   { op_impl : EConstr.t option (* only for booleans *)

--- a/plugins/micromega/zify.ml
+++ b/plugins/micromega/zify.ml
@@ -1022,7 +1022,7 @@ let arrow =
 
 let is_prop env sigma term =
   let sort = Retyping.get_sort_of env sigma term in
-  Sorts.is_prop sort
+  EConstr.ESorts.is_prop sigma sort
 
 let is_arrow env evd a p1 p2 =
   is_prop env evd p1

--- a/plugins/ssr/ssrfwd.ml
+++ b/plugins/ssr/ssrfwd.ml
@@ -116,7 +116,7 @@ let combineCG t1 t2 f g = match t1, t2 with
       let _, info = Exninfo.capture e in
       Tacticals.tclZEROMSG ~info (str "Not a proposition or a type.")
     | sigma, s ->
-      let r = Sorts.relevance_of_sort s in
+      let r = ESorts.relevance_of_sort sigma s in
       let sigma, f, glf =
         match k with
         | HaveTransp ->

--- a/plugins/syntax/number.ml
+++ b/plugins/syntax/number.ml
@@ -193,6 +193,7 @@ let locate_global_sort_inductive_or_constant sigma qid =
     match Abbreviation.search_abbreviation kn with
     | [], Notation_term.NSort r ->
        let sigma,c = Evd.fresh_sort_in_family sigma (Glob_ops.glob_sort_family r) in
+       let c = EConstr.ESorts.kind sigma c in
        sigma,Constr.mkSort c
     | _ -> raise Not_found in
   try locate_sort qid

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -1924,7 +1924,7 @@ let build_inversion_problem ~program_mode loc env sigma tms t =
   (* [pb] is the auxiliary pattern-matching serving as skeleton for the
       return type of the original problem Xi *)
   let s = Retyping.get_sort_of !!env sigma t in
-  let sigma, s = Sorts.(match s with
+  let sigma, s = Sorts.(match ESorts.kind sigma s with
   | SProp | Prop | Set ->
     (* To anticipate a possible restriction on an elimination from
        SProp, Prop or (impredicative) Set we preserve the sort of the

--- a/pretyping/coercion.ml
+++ b/pretyping/coercion.ml
@@ -555,7 +555,7 @@ let inh_app_fun ~program_mode ~resolve_tc ?use_coercions env sigma body typ =
 
 let type_judgment env sigma j =
   match EConstr.kind sigma (whd_all env sigma j.uj_type) with
-    | Sort s -> {utj_val = j.uj_val; utj_type = ESorts.kind sigma s }
+    | Sort s -> {utj_val = j.uj_val; utj_type = s }
     | _ -> error_not_a_type env sigma j
 
 let inh_tosort_force ?loc env sigma ({ uj_val; uj_type } as j) =
@@ -570,7 +570,7 @@ let inh_tosort_force ?loc env sigma ({ uj_val; uj_type } as j) =
 let inh_coerce_to_sort ?loc ?(use_coercions=true) env sigma j =
   let typ = whd_all env sigma j.uj_type in
     match EConstr.kind sigma typ with
-    | Sort s -> (sigma,{ utj_val = j.uj_val; utj_type = ESorts.kind sigma s })
+    | Sort s -> (sigma,{ utj_val = j.uj_val; utj_type = s })
     | Evar ev ->
         let (sigma,s) = Evardefine.define_evar_as_sort env sigma ev in
           (sigma,{ utj_val = j.uj_val; utj_type = s })

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -1067,8 +1067,6 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) flags env evd pbty
 
         | Sort s1, Sort s2 when app_empty ->
             (try
-              let s1 = ESorts.kind evd s1 in
-              let s2 = ESorts.kind evd s2 in
                let evd' =
                  if pbty == CONV
                  then Evd.set_eq_sort env evd s1 s2

--- a/pretyping/evardefine.ml
+++ b/pretyping/evardefine.ml
@@ -96,8 +96,8 @@ let define_pure_evar_as_product env evd evk =
         let evd3, (rng, srng) =
           new_type_evar newenv evd1 status ~src ~filter
         in
-        let prods = Typeops.sort_of_product env u1 srng in
-        let evd3 = Evd.set_leq_sort evenv evd3 prods (ESorts.kind evd1 s) in
+        let prods = Typeops.sort_of_product env (ESorts.kind evd3 u1) (ESorts.kind evd3 srng) in
+        let evd3 = Evd.set_leq_sort evenv evd3 (ESorts.make prods) s in
           evd3, rng
   in
   let prod = mkProd (make_annot (Name id) rdom, dom, subst_var evd2 id rng) in
@@ -171,7 +171,7 @@ let define_evar_as_sort env evd (ev,args) =
   let concl = Reductionops.whd_all (evar_env env evi) evd (Evd.evar_concl evi) in
   let sort = destSort evd concl in
   let evd' = Evd.define ev (mkSort s) evd in
-  Evd.set_leq_sort env evd' (Sorts.super s) (ESorts.kind evd' sort), s
+  Evd.set_leq_sort env evd' (ESorts.super evd' s) sort, s
 
 (* Unify with unknown array *)
 
@@ -190,12 +190,12 @@ let define_pure_evar_as_array env sigma evk =
   let evksrc = evar_source evi in
   let src = subterm_source evk ~where:Domain evksrc in
   let sigma, u = new_univ_level_variable univ_flexible sigma in
-  let s' = Sorts.sort_of_univ @@ Univ.Universe.make u in
+  let s' = ESorts.make @@ Sorts.sort_of_univ @@ Univ.Universe.make u in
   let sigma, ty = new_evar evenv sigma ~typeclass_candidate:false ~src ~filter:(evar_filter evi) (mkSort s') in
   let concl = Reductionops.whd_all evenv sigma (Evd.evar_concl evi) in
   let s = destSort sigma concl in
   (* array@{u} ty : Type@{u} <= Type@{s} *)
-  let sigma = Evd.set_leq_sort env sigma s' (ESorts.kind sigma s) in
+  let sigma = Evd.set_leq_sort env sigma s' s in
   let ar = Typeops.type_of_array env (Univ.Instance.of_array [|u|]) in
   let sigma = Evd.define evk (mkApp (EConstr.of_constr ar, [| ty |])) sigma in
   sigma

--- a/pretyping/evardefine.mli
+++ b/pretyping/evardefine.mli
@@ -40,7 +40,7 @@ val lift_tycon : int -> type_constraint -> type_constraint
 
 val define_evar_as_product : env -> evar_map -> existential -> evar_map * types
 val define_evar_as_lambda : env -> evar_map -> existential -> evar_map * types
-val define_evar_as_sort : env -> evar_map -> existential -> evar_map * Sorts.t
+val define_evar_as_sort : env -> evar_map -> existential -> evar_map * ESorts.t
 
 (** {6 debug pretty-printer:} *)
 

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -116,7 +116,6 @@ let refresh_universes ?(status=univ_rigid) ?(onlyalg=false) ?(refreshset=false)
   let evdref = ref evd in
   (* direction: true for fresh universes lower than the existing ones *)
   let refresh_sort status ~direction s =
-    let s = ESorts.kind !evdref s in
     let sigma, s' = new_sort_variable status !evdref in
     evdref := sigma;
     let evd =
@@ -1457,8 +1456,6 @@ let solve_evar_evar ?(force=false) f unify flags env evd pbty (evk1,args1 as ev1
       let evi2 = Evd.find evd evk2 in
       let evi2env = Evd.evar_env env evi2 in
       let ctx2, j = Reductionops.dest_arity evi2env evd (Evd.evar_concl evi2) in
-      let i = ESorts.kind evd i in
-      let j = ESorts.kind evd j in
         if i == j || Evd.check_eq evd i j
         then (* Shortcut, i = j *)
           evd

--- a/pretyping/indrec.ml
+++ b/pretyping/indrec.ml
@@ -576,8 +576,8 @@ let weaken_sort_scheme env evd set sort npars term ty =
       | Prod (n,t,c) ->
           let ctx = LocalAssum (n, t) :: ctx in
           if Int.equal np 0 then
-            let osort, t' = change_sort_arity sort t in
-              evdref := (if set then Evd.set_eq_sort else Evd.set_leq_sort) env !evdref sort osort;
+            let osort, t' = change_sort_arity (EConstr.ESorts.kind !evdref sort) t in
+              evdref := (if set then Evd.set_eq_sort else Evd.set_leq_sort) env !evdref sort (EConstr.ESorts.make osort);
               mkProd (n, t', c),
               mkLambda (n, t', mkApp(term, Context.Rel.instance mkRel 0 ctx))
           else

--- a/pretyping/indrec.mli
+++ b/pretyping/indrec.mli
@@ -57,7 +57,7 @@ val build_mutual_induction_scheme :
    scheme quantified on sort [s]. [set] asks for [s] be declared equal to [i],
   otherwise just less or equal to [i]. *)
 
-val weaken_sort_scheme : env -> evar_map -> bool -> Sorts.t -> int -> constr -> types ->
+val weaken_sort_scheme : env -> evar_map -> bool -> EConstr.ESorts.t -> int -> constr -> types ->
   evar_map * types * constr
 
 (** Recursor names utilities *)

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -699,9 +699,10 @@ let rec instantiate_universes env evdref scl is = function
         else
           (* unconstrained sort: replace by fresh universe *)
           let evm, s = Evd.new_sort_variable Evd.univ_flexible !evdref in
-          let evm = Evd.set_leq_sort env evm s (Sorts.sort_of_univ u) in
+          let evm = Evd.set_leq_sort env evm s (EConstr.ESorts.make (Sorts.sort_of_univ u)) in
             evdref := evm; s
       in
+      let s = EConstr.ESorts.kind !evdref s in
       (LocalAssum (na,mkArity(ctx,s))) :: instantiate_universes env evdref scl is (sign, exp)
   | sign, [] -> sign (* Uniform parameters are exhausted *)
   | [], _ -> assert false
@@ -715,12 +716,12 @@ let type_of_inductive_knowing_conclusion env sigma ((mib,mip),u) conclty =
     | Some t -> t
     in
     let _,scl = splay_arity env sigma conclty in
-    let scl = EConstr.ESorts.kind sigma scl in
     let ctx = List.rev mip.mind_arity_ctxt in
     let evdref = ref sigma in
     let ctx =
       instantiate_universes
         env evdref scl ar.template_level (ctx,templ.template_param_levels) in
+    let scl = EConstr.ESorts.kind !evdref scl in
       !evdref, EConstr.of_constr (mkArity (List.rev ctx,scl))
 
 let type_of_projection_constant env (p,u) =

--- a/pretyping/inductiveops.mli
+++ b/pretyping/inductiveops.mli
@@ -181,7 +181,7 @@ val get_arity        : env -> inductive_family -> Constr.rel_context * Sorts.fam
 val build_dependent_constructor : constructor_summary -> constr
 val build_dependent_inductive   : env -> inductive_family -> constr
 val make_arity_signature : env -> evar_map -> bool -> inductive_family -> EConstr.rel_context
-val make_arity : env -> evar_map -> bool -> inductive_family -> Sorts.t -> EConstr.types
+val make_arity : env -> evar_map -> bool -> inductive_family -> EConstr.ESorts.t -> EConstr.types
 val build_branch_type : env -> evar_map -> bool -> constr -> constructor_summary -> types
 
 (** Raise [Not_found] if not given a valid inductive type *)

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1080,8 +1080,8 @@ let check_conv ?(pb=Reduction.CUMUL) ?(ts=TransparentState.full) env sigma x y =
 
 let sigma_compare_sorts env pb s0 s1 sigma =
   match pb with
-  | Reduction.CONV -> Evd.set_eq_sort env sigma s0 s1
-  | Reduction.CUMUL -> Evd.set_leq_sort env sigma s0 s1
+  | Reduction.CONV -> Evd.set_eq_sort env sigma (ESorts.make s0) (ESorts.make s1)
+  | Reduction.CUMUL -> Evd.set_leq_sort env sigma (ESorts.make s0) (ESorts.make s1)
 
 let sigma_compare_instances ~flex i0 i1 sigma =
   try Evd.set_eq_instances ~flex sigma i0 i1

--- a/pretyping/retyping.mli
+++ b/pretyping/retyping.mli
@@ -35,7 +35,7 @@ val get_type_of_constr : ?polyprop:bool -> ?lax:bool
   -> env -> ?uctx:UState.t -> Constr.t -> Constr.types
 
 val get_sort_of :
-  ?polyprop:bool -> env -> evar_map -> types -> Sorts.t
+  ?polyprop:bool -> env -> evar_map -> types -> ESorts.t
 
 val get_sort_family_of :
   ?polyprop:bool -> env -> evar_map -> types -> Sorts.family
@@ -49,7 +49,7 @@ val type_of_global_reference_knowing_parameters : env -> evar_map -> constr ->
 val type_of_global_reference_knowing_conclusion :
   env -> evar_map -> constr -> types -> evar_map * types
 
-val sorts_of_context : env -> evar_map -> rel_context -> Sorts.t list
+val sorts_of_context : env -> evar_map -> rel_context -> ESorts.t list
 
 val expand_projection : env -> evar_map -> Names.Projection.t -> constr -> constr list -> constr
 

--- a/pretyping/typing.mli
+++ b/pretyping/typing.mli
@@ -22,7 +22,7 @@ open Evd
 val type_of : ?refresh:bool -> env -> evar_map -> constr -> evar_map * types
 
 (** Typecheck a type and return its sort *)
-val sort_of : env -> evar_map -> types -> evar_map * Sorts.t
+val sort_of : env -> evar_map -> types -> evar_map * ESorts.t
 
 (** Typecheck a term has a given type (assuming the type is OK) *)
 val check : env -> evar_map -> constr -> types -> evar_map
@@ -57,9 +57,9 @@ val judge_of_set : unsafe_judgment
 val judge_of_variable : env -> Id.t -> unsafe_judgment
 val judge_of_apply : env -> evar_map -> unsafe_judgment -> unsafe_judgment array ->
   evar_map * unsafe_judgment
-val judge_of_abstraction : Environ.env -> Name.t ->
+val judge_of_abstraction : Environ.env -> evar_map -> Name.t ->
   unsafe_type_judgment -> unsafe_judgment -> unsafe_judgment
-val judge_of_product : Environ.env -> Name.t ->
+val judge_of_product : Environ.env -> evar_map -> Name.t ->
   unsafe_type_judgment -> unsafe_type_judgment -> unsafe_judgment
 val judge_of_projection : env -> evar_map -> Projection.t -> unsafe_judgment -> unsafe_judgment
 val judge_of_int : Environ.env -> Uint63.t -> unsafe_judgment

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -810,8 +810,6 @@ let rec unify_0_with_initial_metas (sigma,ms,es as subst : subst0) conv_at_top e
               else error_cannot_unify_local curenv sigma (m,n,cN)
         | Sort s1, Sort s2 ->
             (try
-              let s1 = ESorts.kind sigma s1 in
-              let s2 = ESorts.kind sigma s2 in
                let sigma' =
                  if pb == CUMUL
                  then Evd.set_leq_sort curenv sigma s1 s2

--- a/tactics/contradiction.ml
+++ b/tactics/contradiction.ml
@@ -32,7 +32,7 @@ let absurd c =
     let j = Retyping.get_judgment_of env sigma c in
     let sigma, j = Coercion.inh_coerce_to_sort env sigma j in
     let t = j.Environ.utj_val in
-    let r = Sorts.relevance_of_sort j.Environ.utj_type in
+    let r = ESorts.relevance_of_sort sigma j.Environ.utj_type in
     Proofview.Unsafe.tclEVARS sigma <*>
     Tacticals.pf_constr_of_global (Coqlib.(lib_ref "core.not.type")) >>= fun coqnot ->
     Tacticals.pf_constr_of_global (Coqlib.(lib_ref "core.False.type")) >>= fun coqfalse ->

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -1482,7 +1482,7 @@ let cl_rewrite_clause_aux ?(abs=None) strat env avoid sigma concl is_hyp : resul
   let evars = (!evdref, Evar.Set.empty) in
   let evars, cstr =
     let prop, (evars, arrow) =
-      if Sorts.is_prop sort then true, app_poly_sort true env evars impl [||]
+      if ESorts.is_prop sigma sort then true, app_poly_sort true env evars impl [||]
       else false, app_poly_sort false env evars TypeGlobal.arrow [||]
     in
     match is_hyp with

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -519,14 +519,14 @@ let id_of_name_with_default id = function
   | Anonymous -> id
   | Name id   -> id
 
-let default_id_of_sort s =
-  if Sorts.is_small s then default_small_ident else default_type_ident
+let default_id_of_sort sigma s =
+  if ESorts.is_small sigma s then default_small_ident else default_type_ident
 
 let default_id env sigma decl =
   let open Context.Rel.Declaration in
   match decl with
   | LocalAssum (name,t) ->
-      let dft = default_id_of_sort (Retyping.get_sort_of env sigma t) in
+      let dft = default_id_of_sort sigma (Retyping.get_sort_of env sigma t) in
       id_of_name_with_default dft name.binder_name
   | LocalDef (name,b,_) -> id_of_name_using_hdchar env sigma b name.binder_name
 
@@ -1472,7 +1472,7 @@ let cut c =
       let _, info = Exninfo.capture e in
       Tacticals.tclZEROMSG ~info (str "Not a proposition or a type.")
     | sigma, s ->
-      let r = Sorts.relevance_of_sort s in
+      let r = ESorts.relevance_of_sort sigma s in
       let id = next_name_away_with_default "H" Anonymous (Tacmach.pf_ids_set_of_hyps gl) in
       Proofview.tclTHEN (Proofview.Unsafe.tclEVARS sigma)
         (Refine.refine ~typecheck:false begin fun h ->


### PR DESCRIPTION
We should never go back and forth between the low-level representation and the high level one that keeps a quotient relative to a universe state.

Overlays:
- https://github.com/coq-community/aac-tactics/pull/121
- https://github.com/LPCIC/coq-elpi/pull/409
- https://github.com/mattam82/Coq-Equations/pull/518
- https://gitlab.inria.fr/fbesson/itauto/-/merge_requests/7
- https://github.com/SkySkimmer/coq-lean-import/pull/2
- https://github.com/unicoq/unicoq/pull/76
- https://github.com/coq-community/paramcoq/pull/103
- https://github.com/MetaCoq/metacoq/pull/797