### PR TITLE
Passing interning flag strict_check functionally

### DIFF
--- a/dev/ci/user-overlays/16935-herbelin-master+functional-strict_check.sh
+++ b/dev/ci/user-overlays/16935-herbelin-master+functional-strict_check.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/herbelin/coq-elpi coq-master+adapt-coq-pr16935-strict_check-functional 16935 master+functional-strict_check

--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -82,7 +82,7 @@ val intern_constr : env -> evar_map -> constr_expr -> glob_constr
 val intern_type : env -> evar_map -> constr_expr -> glob_constr
 
 val intern_gen : typing_constraint -> env -> evar_map ->
-  ?impls:internalization_env -> ?pattern_mode:bool -> ?ltacvars:ltac_sign ->
+  ?impls:internalization_env -> ?strict_check:bool -> ?pattern_mode:bool -> ?ltacvars:ltac_sign ->
   constr_expr -> glob_constr
 
 val intern_unknown_if_term_or_type : env -> evar_map -> constr_expr -> glob_constr
@@ -141,7 +141,7 @@ val interp_type_evars_impls : ?flags:inference_flags -> env -> evar_map ->
 
 (** Without typing *)
 val intern_constr_pattern :
-  env -> evar_map -> ?as_type:bool -> ?ltacvars:ltac_sign ->
+  env -> evar_map -> ?as_type:bool -> ?strict_check:bool -> ?ltacvars:ltac_sign ->
     constr_pattern_expr -> patvar list * constr_pattern
 
 (** With typing *)
@@ -196,15 +196,12 @@ val interp_notation_constr : env -> ?impls:internalization_env ->
 (** Idem but to glob_constr (weaker check of binders) *)
 
 val intern_core : typing_constraint ->
-  env -> evar_map -> ?pattern_mode:bool -> ?ltacvars:ltac_sign ->
+  env -> evar_map -> ?strict_check:bool -> ?pattern_mode:bool -> ?ltacvars:ltac_sign ->
   Genintern.intern_variable_status -> constr_expr ->
   glob_constr
 
 (** Globalization options *)
 val parsing_explicit : bool ref
-
-(** Globalization leak for Grammar *)
-val for_grammar : ('a -> 'b) -> 'a -> 'b
 
 (** Placeholder for global option, should be moved to a parameter *)
 val get_asymmetric_patterns : unit -> bool

--- a/interp/genintern.ml
+++ b/interp/genintern.ml
@@ -27,6 +27,7 @@ type glob_sign = {
   genv : Environ.env;
   extra : Store.t;
   intern_sign : intern_variable_status;
+  strict_check : bool;
 }
 
 let empty_intern_sign = {
@@ -34,11 +35,12 @@ let empty_intern_sign = {
   notation_variable_status = Id.Map.empty;
 }
 
-let empty_glob_sign env = {
+let empty_glob_sign ~strict env = {
   ltacvars = Id.Set.empty;
   genv = env;
   extra = Store.empty;
   intern_sign = empty_intern_sign;
+  strict_check = strict;
 }
 
 (** In globalize tactics, we need to keep the initial [constr_expr] to recompute

--- a/interp/genintern.mli
+++ b/interp/genintern.mli
@@ -27,9 +27,10 @@ type glob_sign = {
   genv : Environ.env;
   extra : Store.t;
   intern_sign : intern_variable_status;
+  strict_check : bool;
 }
 
-val empty_glob_sign : Environ.env -> glob_sign
+val empty_glob_sign : strict:bool -> Environ.env -> glob_sign
 
 (** In globalize tactics, we need to keep the initial [constr_expr] to recompute
    in the environment by the effective calls to Intro, Inversion, etc

--- a/plugins/ltac/g_obligations.mlg
+++ b/plugins/ltac/g_obligations.mlg
@@ -34,7 +34,7 @@ let () =
   Declare.Obls.default_tactic := tac
 
 let with_tac f tac =
-  let env = Genintern.empty_glob_sign (Global.env ()) in
+  let env = Genintern.empty_glob_sign ~strict:true (Global.env ()) in
   let tac = match tac with
   | None -> None
   | Some tac ->

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -385,7 +385,7 @@ let extend_atomic_tactic name entries =
       let default = epsilon_value inj e in
       match default with
       | None -> raise NonEmptyArgument
-      | Some def -> Tacintern.intern_tactic_or_tacarg (Genintern.empty_glob_sign Environ.empty_env) def
+      | Some def -> Tacintern.intern_tactic_or_tacarg (Genintern.empty_glob_sign ~strict:true Environ.empty_env) def
     in
     try Some (hd, List.map empty_value rem) with NonEmptyArgument -> None
   in
@@ -505,9 +505,9 @@ let register_ltac local ?deprecation tacl =
     in
     List.fold_left fold [] rfun
   in
-  let ist = Tacintern.make_empty_glob_sign () in
+  let ist = Tacintern.make_empty_glob_sign ~strict:true in
   let map (name, body) =
-    let body = Flags.with_option Tacintern.strict_check (Tacintern.intern_tactic_or_tacarg ist) body in
+    let body = Tacintern.intern_tactic_or_tacarg ist body in
     (name, body)
   in
   let defs () =

--- a/plugins/ltac/tacintern.mli
+++ b/plugins/ltac/tacintern.mli
@@ -23,11 +23,12 @@ type glob_sign = Genintern.glob_sign = {
   genv : Environ.env;
   extra : Genintern.Store.t;
   intern_sign : Genintern.intern_variable_status;
+  strict_check : bool;
 }
 
-val make_empty_glob_sign : unit -> glob_sign
+val make_empty_glob_sign : strict:bool -> glob_sign
  (** build an empty [glob_sign] using [Global.env()] as
-     environment *)
+     environment; strict_check if true *)
 
 (** Main globalization functions *)
 
@@ -58,6 +59,3 @@ val intern_genarg : glob_sign -> raw_generic_argument -> glob_generic_argument
 (** Reduction expressions *)
 
 val intern_red_expr : glob_sign -> raw_red_expr -> glob_red_expr
-
-(* Hooks *)
-val strict_check : bool ref

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -585,7 +585,7 @@ let interp_glob_closure ist env sigma ?(kind=WithoutTypeConstraint) ?(pattern_mo
         ltac_bound = Id.Map.domain ist.lfun;
         ltac_extra = Genintern.Store.empty;
       } in
-      { closure ; term = for_grammar (fun () -> intern_gen kind ~pattern_mode ~ltacvars env sigma term_expr) () }
+      { closure ; term = intern_gen kind ~strict_check:false ~pattern_mode ~ltacvars env sigma term_expr }
 
 let interp_uconstr ist env sigma c = interp_glob_closure ist env sigma c
 
@@ -2026,7 +2026,7 @@ let interp_tac_gen lfun avoid_ids debug t =
   let ist = { lfun; poly; extra } in
   let ltacvars = Id.Map.domain lfun in
   eval_tactic_ist ist
-    (intern_pure_tactic { (Genintern.empty_glob_sign env) with ltacvars } t)
+    (intern_pure_tactic { (Genintern.empty_glob_sign ~strict:false env) with ltacvars } t)
   end
 
 let interp t = interp_tac_gen Id.Map.empty Id.Set.empty (get_debug()) t
@@ -2041,7 +2041,7 @@ type ltac_expr = {
 (* [global] means that [t] should be internalized outside of goals. *)
 let hide_interp {global;ast} =
   let hide_interp env =
-    let ist = Genintern.empty_glob_sign env in
+    let ist = Genintern.empty_glob_sign ~strict:false env in
     let te = intern_pure_tactic ist ast in
     let t = eval_tactic te in
     t
@@ -2169,7 +2169,7 @@ let interp_ltac_constr ist c k = Ftactic.run (interp_ltac_constr ist c) k
 
 let interp_redexp env sigma r =
   let ist = default_ist () in
-  let gist = Genintern.empty_glob_sign env in
+  let gist = Genintern.empty_glob_sign ~strict:true env in
   interp_red_expr ist env sigma (intern_red_expr gist r)
 
 (***************************************************************************)

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -1410,8 +1410,8 @@ let () =
   let intern self ist c =
     let env = ist.Genintern.genv in
     let sigma = Evd.from_env env in
-    let warn = if !Ltac_plugin.Tacintern.strict_check then fun x -> x else Constrintern.for_grammar in
-    let _, pat = warn (fun () ->Constrintern.intern_constr_pattern env sigma ~as_type:false c) () in
+    let strict_check = ist.Genintern.strict_check in
+    let _, pat = Constrintern.intern_constr_pattern env sigma ~strict_check ~as_type:false c in
     GlbVal pat, gtypref t_pattern
   in
   let subst subst c =

--- a/plugins/ltac2/tac2intern.ml
+++ b/plugins/ltac2/tac2intern.ml
@@ -1252,15 +1252,9 @@ let rec intern_rec env {loc;v=e} = match e with
   (* External objects do not have access to the named context because this is
      not stable by dynamic semantics. *)
   let genv = Global.env_of_context Environ.empty_named_context_val in
-  let ist = empty_glob_sign genv in
+  let ist = empty_glob_sign ~strict:(env_strict env) genv in
   let ist = { ist with extra = Store.set ist.extra ltac2_env env } in
-  let arg, tpe =
-    if env_strict env then
-      let arg () = obj.ml_intern self ist arg in
-      Flags.with_option Ltac_plugin.Tacintern.strict_check arg ()
-    else
-      obj.ml_intern self ist arg
-  in
+  let arg, tpe = obj.ml_intern self ist arg in
   let e = match arg with
   | GlbVal arg -> GTacExt (tag, arg)
   | GlbTacexpr e -> e
@@ -1842,8 +1836,7 @@ let () =
     let env = match Genintern.Store.get ist.extra ltac2_env with
     | None ->
       (* Only happens when Ltac2 is called from a toplevel ltac1 quotation *)
-      let strict = !Ltac_plugin.Tacintern.strict_check in
-      empty_env ~strict ()
+      empty_env ~strict:ist.strict_check ()
     | Some env -> env
     in
     let fold env id =
@@ -1863,8 +1856,7 @@ let () =
     let env = match Genintern.Store.get ist.extra ltac2_env with
     | None ->
       (* Only happens when Ltac2 is called from a constr quotation *)
-      let strict = !Ltac_plugin.Tacintern.strict_check in
-      empty_env ~strict ()
+      empty_env ~strict:ist.strict_check ()
     | Some env -> env
     in
     (* Special handling of notation variables *)
@@ -1892,8 +1884,7 @@ let () =
     let env = match Genintern.Store.get ist.extra ltac2_env with
     | None ->
       (* Only happens when Ltac2 is called from a constr or ltac1 quotation *)
-      let strict = !Ltac_plugin.Tacintern.strict_check in
-      empty_env ~strict ()
+      empty_env ~strict:ist.strict_check ()
     | Some env -> env
     in
     (* Special handling of notation variables *)

--- a/plugins/ssr/ssrview.ml
+++ b/plugins/ssr/ssrview.ml
@@ -157,6 +157,7 @@ let is_tac_in_term ?extra_scope { annotation; body; glob_env; interp_env } =
         extra = ist.ast_extra;
         intern_sign = ist.ast_intern_sign;
         genv;
+        strict_check = true;
       }
     in
     (* We open extra_scope *)

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -746,7 +746,7 @@ let tag_var = tag Tag.variable
 
   let transf env sigma c =
     if !Flags.beautify_file then
-      let r = Constrintern.for_grammar (Constrintern.intern_constr env sigma) c in
+      let r = Constrintern.intern_gen ~strict_check:false WithoutTypeConstraint env sigma c in
       Constrextern.(extern_glob_constr (extern_env env sigma)) r
     else c
 

--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -544,7 +544,7 @@ let default_hint_rewrite_locality () =
 let add_rew_rules ~locality base lrul =
   let env = Global.env () in
   let sigma = Evd.from_env env in
-  let ist = Genintern.empty_glob_sign (Global.env ()) in
+  let ist = Genintern.empty_glob_sign ~strict:true (Global.env ()) in
   let intern tac = snd (Genintern.generic_intern ist tac) in
   let map {CAst.loc;v=((c,ctx),b,t)} =
     let sigma = Evd.merge_context_set Evd.univ_rigid sigma ctx in

--- a/test-suite/success/intros.v
+++ b/test-suite/success/intros.v
@@ -147,7 +147,7 @@ unshelve (intros x).
 - auto.
 Qed.
 
-Definition d := ltac:(intro x; exact (x*x)).
+Definition d := ltac:(let x := fresh in intro x; exact (x*x)).
 
 Definition d' : nat -> _ := ltac:(intros;exact 0).
 

--- a/test-suite/success/ltac.v
+++ b/test-suite/success/ltac.v
@@ -459,3 +459,14 @@ Module MatchCastInPattern.
   Abort.
 
 End MatchCastInPattern.
+
+Module StrictModeConfusion.
+
+Goal True.
+Fail let x := constr:(match _ with x x => _ end) in idtac.
+(* for_grammar does not reset the ref when an exception is raised *)
+Abort.
+
+Fail Ltac bad := exact x. (* was wrongly accepted *)
+
+End StrictModeConfusion.

--- a/theories/micromega/ZifyComparison.v
+++ b/theories/micromega/ZifyComparison.v
@@ -41,7 +41,7 @@ Add Zify BinOp BinOp_Zcompare.
 
 #[global]
 Instance Op_eq_comparison : BinRel (@eq comparison) :=
-  {TR := @eq Z ; TRInj := ltac:(destruct n,m; simpl ; intuition congruence) }.
+  {TR := @eq Z ; TRInj := ltac:(intros [] []; simpl ; intuition congruence) }.
 Add Zify BinRel Op_eq_comparison.
 
 #[global]

--- a/vernac/comHints.ml
+++ b/vernac/comHints.ml
@@ -161,7 +161,7 @@ let interp_hints ~poly h =
     let ltacvars =
       List.fold_left (fun accu x -> Id.Set.add x accu) Id.Set.empty l
     in
-    let env = Genintern.{(empty_glob_sign env) with ltacvars} in
+    let env = Genintern.{(empty_glob_sign ~strict:true env) with ltacvars} in
     let _, tacexp = Genintern.generic_intern env tacexp in
     HintsExternEntry
       ({Typeclasses.hint_priority = Some pri; hint_pattern = pat}, tacexp)

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1585,7 +1585,7 @@ let command_focus = Proof.new_focus_kind ()
 let focus_command_cond = Proof.no_cond command_focus
 
 let vernac_set_end_tac ~pstate tac =
-  let env = Genintern.empty_glob_sign (Global.env ()) in
+  let env = Genintern.empty_glob_sign ~strict:true (Global.env ()) in
   let _, tac = Genintern.generic_intern env tac in
   (* TO DO verifier s'il faut pas mettre exist s | TacId s ici*)
   Declare.Proof.set_endline_tactic tac pstate


### PR DESCRIPTION
I suppose being here more functional would be consensual.

~~This has the consequence that quotations in terms (e.g. ltac:(), ltac2:(), ...) at the first level of interpretation are now strict by default.~~ --> the change of semantics is moved to #17085.

- [x] Opened **overlay** pull requests : LPCIC/coq-elpi#421

