### PR TITLE
Fixes #12467: internal inconsistency when a notation variable is used both for binder lists and for term lists

### DIFF
--- a/dev/ci/user-overlays/16937-herbelin-master+fix12467-inconsistent-convention-mixed-binderlist-termlist-notation.sh
+++ b/dev/ci/user-overlays/16937-herbelin-master+fix12467-inconsistent-convention-mixed-binderlist-termlist-notation.sh
@@ -1,0 +1,1 @@
+overlay serapi https://github.com/herbelin/coq-serapi master+fix12467-inconsistency-binderlist-termlist-notation 16937 master+fix12467-inconsistent-convention-mixed-binderlist-termlist-notation

--- a/doc/changelog/03-notations/16937-master+fix12467-inconsistent-convention-mixed-binderlist-termlist-notation.rst
+++ b/doc/changelog/03-notations/16937-master+fix12467-inconsistent-convention-mixed-binderlist-termlist-notation.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Add support to parse a recursive pattern as a sequence of terms in a
+  recursive notation even when this recursive pattern is used in
+  position of binders; it was formerly raising an anomaly (`#16937
+  <https://github.com/coq/coq/pull/16937>`_, fixes `#12467
+  <https://github.com/coq/coq/issues/12467>`_, by Hugo Herbelin).

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -998,13 +998,13 @@ let cases_pattern_of_name {loc;v=na} =
   CAst.make ?loc (CPatAtom atom)
 
 let cases_pattern_of_binder_as_constr a = function
-  | AsNameOrPattern | AsStrictPattern -> coerce_to_cases_pattern_expr a
+  | AsAnyPattern | AsStrictPattern -> coerce_to_cases_pattern_expr a
   | AsIdent -> cases_pattern_of_id (coerce_to_id a)
   | AsName -> cases_pattern_of_name (coerce_to_name a)
 
 let is_onlyident = function
   | AsIdent | AsName -> true
-  | AsNameOrPattern | AsStrictPattern -> false
+  | AsAnyPattern | AsStrictPattern -> false
 
 let split_by_type ids (subst : constr_notation_substitution) =
   let bind id scl l s =

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -954,7 +954,7 @@ let is_term_meta id metas =
   with Not_found -> false
 
 let is_onlybinding_strict_meta id metas =
-  try match Id.List.assoc id metas with _,NtnTypeBinder (NtnParsedAsPattern true) -> true | _ -> false
+  try match Id.List.assoc id metas with _,NtnTypeBinder (NtnBinderParsedAsSomeBinderKind AsStrictPattern) -> true | _ -> false
   with Not_found -> false
 
 let is_onlybinding_meta id metas =
@@ -963,15 +963,16 @@ let is_onlybinding_meta id metas =
 
 let is_onlybinding_pattern_like_meta isvar id metas =
   try match Id.List.assoc id metas with
-      | _,NtnTypeBinder (NtnBinderParsedAsConstr
-                           (AsNameOrPattern | AsStrictPattern)) -> true
-      | _,NtnTypeBinder (NtnParsedAsPattern strict) -> not (strict && isvar)
-      | _,NtnTypeBinder NtnParsedAsBinder -> not isvar
-      | _ -> false
+    | _,NtnTypeBinder (NtnBinderParsedAsConstr (AsNameOrPattern | AsStrictPattern)) -> true
+    | _,NtnTypeBinder (NtnBinderParsedAsSomeBinderKind AsStrictPattern | NtnBinderParsedAsBinder) -> not isvar
+    | _,NtnTypeBinder (NtnBinderParsedAsSomeBinderKind AsNameOrPattern) -> true
+    | _,NtnTypeBinder (NtnBinderParsedAsSomeBinderKind (AsIdent | AsName)) -> false
+    | _,NtnTypeBinder (NtnBinderParsedAsConstr (AsIdent | AsName)) -> false
+    | _,NtnTypeBinderList _ | _,NtnTypeConstr | _,NtnTypeConstrList -> false
   with Not_found -> false
 
 let is_bindinglist_meta id metas =
-  try match Id.List.assoc id metas with _,NtnTypeBinderList -> true | _ -> false
+  try match Id.List.assoc id metas with _,NtnTypeBinderList _ -> true | _ -> false
   with Not_found -> false
 
 exception No_match
@@ -1310,7 +1311,7 @@ let remove_bindinglist_sigma x (terms,termlists,binders,binderlists) =
 
 let add_ldots_var metas = (ldots_var,((Constrexpr.InConstrEntrySomeLevel,([],[])),NtnTypeConstr))::metas
 
-let add_meta_bindinglist x metas = (x,((Constrexpr.InConstrEntrySomeLevel,([],[])),NtnTypeBinderList))::metas
+let add_meta_bindinglist x metas = (x,((Constrexpr.InConstrEntrySomeLevel,([],[])),NtnTypeBinderList (*arbitrary:*) NtnBinderParsedAsBinder))::metas
 
 (* This tells if letins in the middle of binders should be included in
    the sequence of binders *)
@@ -1612,30 +1613,45 @@ and match_disjunctive_equations u alp metas sigma {CAst.v=(ids,disjpatl1,rhs1)} 
       (alp,sigma) disjpatl1 disjpatl2 in
   match_in u alp metas sigma rhs1 rhs2
 
-let match_notation_constr ~print_univ c ~vars (metas,pat) =
-  let terms,termlists,binders,binderlists =
-    match_ false print_univ {actualvars=vars;staticbinders=[];renaming=[]} metas ([],[],[],[]) c pat in
-  (* Turning substitution based on binding/constr distinction into a
-     substitution based on entry productions *)
+(* Turning substitution based on binding/term distinction into a
+   substitution based on entry production: indeed some binders may
+   have to be seen as terms from the parsing/printing point of view *)
+let group_by_type ids (terms,termlists,binders,binderlists) =
   List.fold_right (fun (x,(scl,typ)) (terms',termlists',binders',binderlists') ->
     match typ with
     | NtnTypeConstr ->
-      let vars,_alp',term = try Id.List.assoc x terms with Not_found -> raise No_match in
+       (* term -> term *)
+       let vars,_alp',term = try Id.List.assoc x terms with Not_found -> raise No_match in
        (((vars,term),scl)::terms',termlists',binders',binderlists')
     | NtnTypeBinder (NtnBinderParsedAsConstr _) ->
+       (* binder -> term *)
        (match Id.List.assoc x binders with
         | vars,[pat] ->
           let v = glob_constr_of_cases_pattern (Global.env()) pat in
           (((vars,v),scl)::terms',termlists',binders',binderlists')
         | _ -> raise No_match)
-    | NtnTypeBinder (NtnParsedAsIdent | NtnParsedAsName | NtnParsedAsPattern _ | NtnParsedAsBinder) ->
+    | NtnTypeBinder (NtnBinderParsedAsBinder | NtnBinderParsedAsSomeBinderKind _) ->
+       (* term list -> term list *)
        (terms',termlists',(Id.List.assoc x binders,scl)::binders',binderlists')
     | NtnTypeConstrList ->
+       (* term list -> term list *)
        (terms',(Id.List.assoc x termlists,scl)::termlists',binders',binderlists')
-    | NtnTypeBinderList ->
+    | NtnTypeBinderList (NtnBinderParsedAsConstr _) ->
+       (* binder list -> term list *)
+       let vars,patl = try Id.List.assoc x binderlists with Not_found -> raise No_match in
+       let v = List.map (fun pat -> match DAst.get pat with
+           | GLocalPattern ((disjpat,_),_,_,_) -> List.map (glob_constr_of_cases_pattern (Global.env())) disjpat
+           | _ -> raise No_match) patl in
+       (terms',((vars,List.flatten v),scl)::termlists',binders',binderlists')
+    | NtnTypeBinderList (NtnBinderParsedAsBinder | NtnBinderParsedAsSomeBinderKind _) ->
+      (* binder list -> binder list *)
       let bl = try Id.List.assoc x binderlists with Not_found -> raise No_match in
-       (terms',termlists',binders',(bl, scl)::binderlists'))
-    metas ([],[],[],[])
+       (terms',termlists',binders',(bl,scl)::binderlists'))
+    ids ([],[],[],[])
+
+let match_notation_constr ~print_univ c ~vars (metas,pat) =
+  let subst = match_ false print_univ {actualvars=vars;staticbinders=[];renaming=[]} metas ([],[],[],[]) c pat in
+  group_by_type metas subst
 
 (* Matching cases pattern *)
 
@@ -1711,7 +1727,7 @@ let reorder_canonically_substitution terms termlists metas =
     match typ with
       | NtnTypeConstr -> ((Id.List.assoc x terms, scl)::terms',termlists')
       | NtnTypeConstrList -> (terms',(Id.List.assoc x termlists,scl)::termlists')
-      | NtnTypeBinder _ | NtnTypeBinderList -> anomaly (str "Unexpected binder in pattern notation."))
+      | NtnTypeBinder _ | NtnTypeBinderList _ -> anomaly (str "Unexpected binder in pattern notation."))
     metas ([],[])
 
 let match_notation_constr_cases_pattern c (metas,pat) =

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -963,9 +963,9 @@ let is_onlybinding_meta id metas =
 
 let is_onlybinding_pattern_like_meta isvar id metas =
   try match Id.List.assoc id metas with
-    | _,NtnTypeBinder (NtnBinderParsedAsConstr (AsNameOrPattern | AsStrictPattern)) -> true
+    | _,NtnTypeBinder (NtnBinderParsedAsConstr (AsAnyPattern | AsStrictPattern)) -> true
     | _,NtnTypeBinder (NtnBinderParsedAsSomeBinderKind AsStrictPattern | NtnBinderParsedAsBinder) -> not isvar
-    | _,NtnTypeBinder (NtnBinderParsedAsSomeBinderKind AsNameOrPattern) -> true
+    | _,NtnTypeBinder (NtnBinderParsedAsSomeBinderKind AsAnyPattern) -> true
     | _,NtnTypeBinder (NtnBinderParsedAsSomeBinderKind (AsIdent | AsName)) -> false
     | _,NtnTypeBinder (NtnBinderParsedAsConstr (AsIdent | AsName)) -> false
     | _,NtnTypeBinderList _ | _,NtnTypeConstr | _,NtnTypeConstrList -> false

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -1641,7 +1641,9 @@ let group_by_type ids (terms,termlists,binders,binderlists) =
        let vars,patl = try Id.List.assoc x binderlists with Not_found -> raise No_match in
        let v = List.map (fun pat -> match DAst.get pat with
            | GLocalPattern ((disjpat,_),_,_,_) -> List.map (glob_constr_of_cases_pattern (Global.env())) disjpat
-           | _ -> raise No_match) patl in
+           | GLocalAssum (Anonymous,bk,t) -> [DAst.make (GCast (DAst.make (GHole (Evar_kinds.BinderType Anonymous,IntroAnonymous)), DEFAULTcast, t))]
+           | GLocalAssum (Name id,bk,t) -> [DAst.make (GCast (DAst.make (GVar id), DEFAULTcast, t))]
+           | GLocalDef _ -> raise No_match) patl in
        (terms',((vars,List.flatten v),scl)::termlists',binders',binderlists')
     | NtnTypeBinderList (NtnBinderParsedAsBinder | NtnBinderParsedAsSomeBinderKind _) ->
       (* binder list -> binder list *)

--- a/interp/notation_term.ml
+++ b/interp/notation_term.ml
@@ -73,7 +73,7 @@ type notation_binder_kind =
   (* This accepts only name *)
   | AsName
   (* This accepts pattern *)
-  | AsNameOrPattern
+  | AsAnyPattern
   (* This accepts only strict pattern (i.e. no single variable) at printing *)
   | AsStrictPattern
 

--- a/interp/notation_term.ml
+++ b/interp/notation_term.ml
@@ -67,27 +67,29 @@ type extended_subscopes = Constrexpr.notation_entry_level * subscopes
 (** Type of the meta-variables of an notation_constr: in a recursive pattern x..y,
     x carries the sequence of objects bound to the list x..y  *)
 
-type constr_as_binder_kind =
+type notation_binder_kind =
+  (* This accepts only ident *)
   | AsIdent
+  (* This accepts only name *)
   | AsName
+  (* This accepts pattern *)
   | AsNameOrPattern
+  (* This accepts only strict pattern (i.e. no single variable) at printing *)
   | AsStrictPattern
 
 type notation_binder_source =
-  (* This accepts only pattern *)
-  (* NtnParsedAsPattern true means only strict pattern (no single variable) at printing *)
-  | NtnParsedAsPattern of bool
-  (* This accepts only ident *)
-  | NtnParsedAsIdent
-  (* This accepts only name *)
-  | NtnParsedAsName
-  (* This accepts ident, or pattern, or both *)
-  | NtnBinderParsedAsConstr of constr_as_binder_kind
-  (* This accepts ident, _, and quoted pattern *)
-  | NtnParsedAsBinder
+  (* Parsed as constr and constrained to be ident, name or pattern, depending on kind *)
+  | NtnBinderParsedAsConstr of notation_binder_kind
+  (* Parsed and interpreted as ident, name or pattern, depending on kind *)
+  | NtnBinderParsedAsSomeBinderKind of notation_binder_kind
+  (* Parsed as open or closed binder: This accepts ident, _, quoted pattern, etc. *)
+  | NtnBinderParsedAsBinder
 
 type notation_var_instance_type =
-  | NtnTypeConstr | NtnTypeBinder of notation_binder_source | NtnTypeConstrList | NtnTypeBinderList
+  | NtnTypeConstr
+  | NtnTypeConstrList
+  | NtnTypeBinder of notation_binder_source
+  | NtnTypeBinderList of notation_binder_source
 
 (** Type of variables when interpreting a constr_expr as a notation_constr:
     in a recursive pattern x..y, both x and y carry the individual type

--- a/interp/notationextern.ml
+++ b/interp/notationextern.ml
@@ -27,20 +27,25 @@ let notation_entry_level_eq s1 s2 = match (s1,s2) with
 
 let pair_eq f g (x1, y1) (x2, y2) = f x1 x2 && g y1 y2
 
+let notation_binder_kind_eq k1 k2 = match k1, k2 with
+| AsIdent, AsIdent -> true
+| AsName, AsName -> true
+| AsNameOrPattern, AsNameOrPattern -> true
+| AsStrictPattern, AsStrictPattern -> true
+| (AsIdent | AsName | AsNameOrPattern | AsStrictPattern), _ -> false
+
 let notation_binder_source_eq s1 s2 = match s1, s2 with
-| NtnParsedAsIdent,  NtnParsedAsIdent -> true
-| NtnParsedAsName,  NtnParsedAsName -> true
-| NtnParsedAsPattern b1, NtnParsedAsPattern b2 -> b1 = b2
-| NtnBinderParsedAsConstr bk1, NtnBinderParsedAsConstr bk2 -> bk1 = bk2
-| NtnParsedAsBinder,  NtnParsedAsBinder -> true
-| (NtnParsedAsIdent | NtnParsedAsName | NtnParsedAsPattern _ | NtnBinderParsedAsConstr _ | NtnParsedAsBinder), _ -> false
+| NtnBinderParsedAsSomeBinderKind bk1, NtnBinderParsedAsSomeBinderKind bk2 -> notation_binder_kind_eq bk1 bk2
+| NtnBinderParsedAsBinder, NtnBinderParsedAsBinder -> true
+| NtnBinderParsedAsConstr bk1, NtnBinderParsedAsConstr bk2 -> notation_binder_kind_eq bk1 bk2
+| (NtnBinderParsedAsSomeBinderKind _ | NtnBinderParsedAsBinder | NtnBinderParsedAsConstr _), _ -> false
 
 let ntpe_eq t1 t2 = match t1, t2 with
 | NtnTypeConstr, NtnTypeConstr -> true
 | NtnTypeBinder s1, NtnTypeBinder s2 -> notation_binder_source_eq s1 s2
 | NtnTypeConstrList, NtnTypeConstrList -> true
-| NtnTypeBinderList, NtnTypeBinderList -> true
-| (NtnTypeConstr | NtnTypeBinder _ | NtnTypeConstrList | NtnTypeBinderList), _ -> false
+| NtnTypeBinderList s1, NtnTypeBinderList s2 -> notation_binder_source_eq s1 s2
+| (NtnTypeConstr | NtnTypeBinder _ | NtnTypeConstrList | NtnTypeBinderList _), _ -> false
 
 let var_attributes_eq (_, ((entry1, sc1), tp1)) (_, ((entry2, sc2), tp2)) =
   notation_entry_level_eq entry1 entry2 &&

--- a/interp/notationextern.ml
+++ b/interp/notationextern.ml
@@ -30,9 +30,9 @@ let pair_eq f g (x1, y1) (x2, y2) = f x1 x2 && g y1 y2
 let notation_binder_kind_eq k1 k2 = match k1, k2 with
 | AsIdent, AsIdent -> true
 | AsName, AsName -> true
-| AsNameOrPattern, AsNameOrPattern -> true
+| AsAnyPattern, AsAnyPattern -> true
 | AsStrictPattern, AsStrictPattern -> true
-| (AsIdent | AsName | AsNameOrPattern | AsStrictPattern), _ -> false
+| (AsIdent | AsName | AsAnyPattern | AsStrictPattern), _ -> false
 
 let notation_binder_source_eq s1 s2 = match s1, s2 with
 | NtnBinderParsedAsSomeBinderKind bk1, NtnBinderParsedAsSomeBinderKind bk2 -> notation_binder_kind_eq bk1 bk2

--- a/parsing/extend.ml
+++ b/parsing/extend.ml
@@ -62,11 +62,11 @@ type simple_constr_prod_entry_key =
 
 (** Entries used in productions (in right-hand-side of grammar rules), to parse non-terminals *)
 
-type binder_entry_kind = ETBinderOpen | ETBinderClosed of (bool * string) list
-
 type binder_target = ForBinder | ForTerm
 
-type constr_prod_entry_key =
+type binder_entry_kind = ETBinderOpen | ETBinderClosed of constr_prod_entry_key option * (bool * string) list
+
+and constr_prod_entry_key =
   | ETProdIdent           (* Parsed as an ident *)
   | ETProdName            (* Parsed as a name (ident or _) *)
   | ETProdGlobal          (* Parsed as a global reference *)

--- a/parsing/extend.ml
+++ b/parsing/extend.ml
@@ -36,7 +36,7 @@ type 'a constr_entry_key_gen =
   | ETGlobal
   | ETBigint
   | ETBinder of bool  (* open list of binders if true, closed list of binders otherwise *)
-  | ETConstr of Constrexpr.notation_entry * Notation_term.constr_as_binder_kind option * 'a
+  | ETConstr of Constrexpr.notation_entry * Notation_term.notation_binder_kind option * 'a
   | ETPattern of bool * int option (* true = strict pattern, i.e. not a single variable *)
 
 let constr_entry_key_eq v1 v2 = match v1, v2 with

--- a/parsing/extend.mli
+++ b/parsing/extend.mli
@@ -48,11 +48,11 @@ type simple_constr_prod_entry_key =
 
 (** Entries used in productions (in right-hand-side of grammar rules), to parse non-terminals *)
 
-type binder_entry_kind = ETBinderOpen | ETBinderClosed of (bool * string) list
-
 type binder_target = ForBinder | ForTerm
 
-type constr_prod_entry_key =
+type binder_entry_kind = ETBinderOpen | ETBinderClosed of constr_prod_entry_key option * (bool * string) list
+
+and constr_prod_entry_key =
   | ETProdIdent           (* Parsed as an ident *)
   | ETProdName            (* Parsed as a name (ident or _) *)
   | ETProdGlobal          (* Parsed as a global reference *)

--- a/parsing/extend.mli
+++ b/parsing/extend.mli
@@ -31,7 +31,7 @@ type 'a constr_entry_key_gen =
   | ETGlobal
   | ETBigint
   | ETBinder of bool  (* open list of binders if true, closed list of binders otherwise *)
-  | ETConstr of Constrexpr.notation_entry * Notation_term.constr_as_binder_kind option * 'a
+  | ETConstr of Constrexpr.notation_entry * Notation_term.notation_binder_kind option * 'a
   | ETPattern of bool * int option (* true = strict pattern, i.e. not a single variable *)
 
 (** Entries level (left-hand side of grammar rules) *)

--- a/printing/ppextend.ml
+++ b/printing/ppextend.ml
@@ -41,7 +41,10 @@ type unparsing =
   | UnpMetaVar of entry_relative_level * Extend.side option
   | UnpBinderMetaVar of entry_relative_level * pattern_quote_style
   | UnpListMetaVar of entry_relative_level * unparsing list * Extend.side option
-  | UnpBinderListMetaVar of bool * unparsing list
+  | UnpBinderListMetaVar of
+      bool (* true if open binder *) *
+      bool (* true if printed with a quote *) *
+      unparsing list
   | UnpTerminal of string
   | UnpBox of ppbox * unparsing Loc.located list
   | UnpCut of ppcut
@@ -52,7 +55,7 @@ let rec unparsing_eq unp1 unp2 = match (unp1,unp2) with
   | UnpMetaVar (p1,s1), UnpMetaVar (p2,s2) -> entry_relative_level_eq p1 p2 && s1 = s2
   | UnpBinderMetaVar (p1,s1), UnpBinderMetaVar (p2,s2) -> entry_relative_level_eq p1 p2 && s1 = s2
   | UnpListMetaVar (p1,l1,s1), UnpListMetaVar (p2,l2,s2) -> entry_relative_level_eq p1 p2 && List.for_all2eq unparsing_eq l1 l2 && s1 = s2
-  | UnpBinderListMetaVar (b1,l1), UnpBinderListMetaVar (b2,l2) -> b1 = b2 && List.for_all2eq unparsing_eq l1 l2
+  | UnpBinderListMetaVar (b1,q1,l1), UnpBinderListMetaVar (b2,q2,l2) -> b1 = b2 && q1 = q2 && List.for_all2eq unparsing_eq l1 l2
   | UnpTerminal s1, UnpTerminal s2 -> String.equal s1 s2
   | UnpBox (b1,l1), UnpBox (b2,l2) -> b1 = b2 && List.for_all2eq unparsing_eq (List.map snd l1) (List.map snd l2)
   | UnpCut p1, UnpCut p2 -> p1 = p2

--- a/printing/ppextend.mli
+++ b/printing/ppextend.mli
@@ -35,7 +35,10 @@ type unparsing =
   | UnpMetaVar of entry_relative_level * Extend.side option
   | UnpBinderMetaVar of entry_relative_level * pattern_quote_style
   | UnpListMetaVar of entry_relative_level * unparsing list * Extend.side option
-  | UnpBinderListMetaVar of bool * unparsing list
+  | UnpBinderListMetaVar of
+      bool (* true if open binder *) *
+      bool (* true if printed with a quote *) *
+      unparsing list
   | UnpTerminal of string
   | UnpBox of ppbox * unparsing Loc.located list
   | UnpCut of ppcut

--- a/test-suite/bugs/bug_12467.v
+++ b/test-suite/bugs/bug_12467.v
@@ -1,0 +1,44 @@
+Module ClosedBinder.
+
+Notation "'WITH' ( x1 : t1 ) , x2t2 , .. , xntn  'PRE'  [ ] P 'POST' [ ] Q" :=
+  ((fun x1 : t1 => (fun x2t2 => .. (fun xntn => (pair .. (pair x1 x2t2) .. xntn)) .. )),
+   (fun x1 : t1 => (fun x2t2 => .. (fun xntn => P) .. )),
+   (fun x1 : t1 => (fun x2t2 => .. (fun xntn => Q) .. )))
+    (at level 200, x1 at level 0, x2t2 closed binder, P at level 100, Q at level 100, only parsing).
+Check WITH (x : nat) , (y : nat) , (z : nat) PRE [] (x, y, z) POST [] (z, y, x).
+
+End ClosedBinder.
+
+Module OpenBinder.
+
+(* Not eligible as an open binder because of the separating comma *)
+Fail Notation "'WITH' ( x1 : t1 ) , x2t2 , .. , xntn  'PRE'  [ ] P 'POST' [ ] Q" :=
+  ((fun x1 : t1 => (fun x2t2 => .. (fun xntn => (pair .. (pair x1 x2t2) .. xntn)) .. )),
+   (fun x1 : t1 => (fun x2t2 => .. (fun xntn => P) .. )),
+   (fun x1 : t1 => (fun x2t2 => .. (fun xntn => Q) .. )))
+    (at level 200, x1 at level 0, x2t2 binder, P at level 100, Q at level 100, only parsing).
+
+End OpenBinder.
+
+Module Constr.
+
+Notation "'WITH' ( x1 : t1 ) , x2t2 , .. , xntn  'PRE'  [ ] P 'POST' [ ] Q" :=
+  ((fun x1 : t1 => (fun x2t2 => .. (fun xntn => (pair .. (pair x1 x2t2) .. xntn)) .. )),
+   (fun x1 : t1 => (fun x2t2 => .. (fun xntn => P) .. )),
+   (fun x1 : t1 => (fun x2t2 => .. (fun xntn => Q) .. )))
+    (at level 200, x1 at level 0, x2t2, P at level 100, Q at level 100, only parsing).
+(* Fail because, constr used for binder defaults to name *)
+Fail Check WITH (x : nat) , (y : nat) , (z : nat) PRE [] (x, y, z) POST [] (z, y, x).
+
+End Constr.
+
+Module ConstrAsPattern.
+
+Notation "'WITH' ( x1 : t1 ) , x2t2 , .. , xntn  'PRE'  [ ] P 'POST' [ ] Q" :=
+  ((fun x1 : t1 => (fun x2t2 => .. (fun xntn => (pair .. (pair x1 x2t2) .. xntn)) .. )),
+   (fun x1 : t1 => (fun x2t2 => .. (fun xntn => P) .. )),
+   (fun x1 : t1 => (fun x2t2 => .. (fun xntn => Q) .. )))
+    (at level 200, x1 at level 0, x2t2 constr as pattern, P at level 100, Q at level 100, only parsing).
+Check WITH (x : nat) , (y : nat) , (z : nat) PRE [] (x, y, z) POST [] (z, y, x).
+
+End ConstrAsPattern.

--- a/test-suite/bugs/bug_12467.v
+++ b/test-suite/bugs/bug_12467.v
@@ -53,3 +53,12 @@ Notation "'WITH' ( x1 : t1 ) , x2t2 , .. , xntn  'PRE'  [ ] P 'POST' [ ] Q" :=
 Check WITH (x : nat) , (y : nat) , (z : nat) PRE [] (x, y, z) POST [] (z, y, x).
 
 End Pattern.
+
+Module OnlyRecursiveBinderPartOfIssue17904.
+
+Notation "∀ x .. y , P" := (forall x , .. (forall y , P) .. )
+  (at level 200, x constr at level 8 as pattern, right associativity,
+      format "'[  ' '[  ' ∀  x  ..  y ']' ,  '/' P ']'") : type_scope.
+Check ∀ a b, a + b = 0.
+
+End OnlyRecursiveBinderPartOfIssue17904.

--- a/test-suite/bugs/bug_12467.v
+++ b/test-suite/bugs/bug_12467.v
@@ -42,3 +42,14 @@ Notation "'WITH' ( x1 : t1 ) , x2t2 , .. , xntn  'PRE'  [ ] P 'POST' [ ] Q" :=
 Check WITH (x : nat) , (y : nat) , (z : nat) PRE [] (x, y, z) POST [] (z, y, x).
 
 End ConstrAsPattern.
+
+Module Pattern.
+
+Notation "'WITH' ( x1 : t1 ) , x2t2 , .. , xntn  'PRE'  [ ] P 'POST' [ ] Q" :=
+  ((fun x1 : t1 => (fun x2t2 => .. (fun xntn => (pair .. (pair x1 x2t2) .. xntn)) .. )),
+   (fun x1 : t1 => (fun x2t2 => .. (fun xntn => P) .. )),
+   (fun x1 : t1 => (fun x2t2 => .. (fun xntn => Q) .. )))
+    (at level 200, x1 at level 0, x2t2 pattern, P at level 100, Q at level 100, only parsing).
+Check WITH (x : nat) , (y : nat) , (z : nat) PRE [] (x, y, z) POST [] (z, y, x).
+
+End Pattern.

--- a/test-suite/output/Notations3.out
+++ b/test-suite/output/Notations3.out
@@ -255,3 +255,5 @@ myfoo01 tt
   |-_0
    xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx *
    xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+FORALL [[a, b]], a - b = 0
+     : Prop

--- a/test-suite/output/Notations3.out
+++ b/test-suite/output/Notations3.out
@@ -257,3 +257,6 @@ myfoo01 tt
    xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 FORALL [[a, b]], a - b = 0
      : Prop
+∀ (A : TypTerm) (B : ◻ A -> TypTerm),
+(∀ a : ◻ A, ◻ {B a}) -> ◻ (∀' {a : ◻ A}, {B a})
+     : Type

--- a/test-suite/output/Notations3.v
+++ b/test-suite/output/Notations3.v
@@ -447,3 +447,28 @@ Notation "[[ x , y ]]" := (x, y).
 Check FORALL [[a , b]], a - b = 0.
 
 End PartOfIssue17094.
+
+Module PartOfIssue17094PrintingAssumption.
+
+Declare Custom Entry quoted.
+Notation "( x )" := x (in custom quoted at level 0, x at level 200).
+Notation "x" := x (in custom quoted at level 0, x global).
+Notation "{ A }" := A (in custom quoted at level 0, A constr at level 200).
+
+Axiom TypTerm : Type.
+Axiom qType : Type -> TypTerm.
+Axiom ValTerm : TypTerm -> Type.
+Notation "◻ A" := (ValTerm A) (at level 9, right associativity, A custom quoted at level 9).
+Notation "◻ A" := (qType (ValTerm A))
+  (in custom quoted at level 9, right associativity, A custom quoted at level 9).
+
+Declare Custom Entry quoted_binder.
+Notation "{ x }" := x (in custom quoted_binder at level 0, x constr).
+
+Axiom FORALL : forall {A : TypTerm} (B : ValTerm A -> TypTerm), TypTerm.
+Notation "∀' x .. y , P" := (FORALL (fun x => .. (FORALL (fun y => P)) .. ))
+  (in custom quoted at level 200, x custom quoted_binder as pattern, right associativity,
+      format "'[  ' '[  ' ∀'  x  ..  y ']' ,  '/' P ']'") : type_scope.
+Check ∀ A (B : ValTerm A -> TypTerm), (∀ (a : ◻A), ◻{B a}) -> ◻(∀' {a}, {B a}).
+
+End PartOfIssue17094PrintingAssumption.

--- a/test-suite/output/Notations3.v
+++ b/test-suite/output/Notations3.v
@@ -437,3 +437,13 @@ Show.
 Abort.
 
 End GoalConclBox.
+
+Module PartOfIssue17094.
+
+Notation "'FORALL' x .. y , P" := (forall x , .. (forall y , P) .. )
+  (at level 200, x constr at level 8 as pattern, right associativity,
+      format "'[  ' '[  ' 'FORALL'  x  ..  y ']' ,  '/' P ']'") : type_scope.
+Notation "[[ x , y ]]" := (x, y).
+Check FORALL [[a , b]], a - b = 0.
+
+End PartOfIssue17094.

--- a/vernac/egramcoq.ml
+++ b/vernac/egramcoq.ml
@@ -371,6 +371,7 @@ let rec symbol_of_entry : type s r. _ -> _ -> (s, r) entry -> (s, r) mayrec_symb
   | MayRecNo s -> MayRecNo (Pcoq.Symbol.list1sep s (make_sep_rules tkl) false)
   | MayRecMay s -> MayRecMay (Pcoq.Symbol.list1sep s (make_sep_rules tkl) false) end
 | TTPattern p -> MayRecNo (Pcoq.Symbol.nterml Constr.pattern (string_of_int p))
+| TTOpenBinderList -> MayRecNo (Pcoq.Symbol.nterm Constr.open_binders)
 | TTClosedBinderListPure [] -> MayRecNo (Pcoq.Symbol.list1 (Pcoq.Symbol.nterm Constr.binder))
 | TTClosedBinderListPure tkl -> MayRecNo (Pcoq.Symbol.list1sep (Pcoq.Symbol.nterm Constr.binder) (make_sep_rules tkl) false)
 | TTClosedBinderListOther (typ,[]) ->
@@ -385,7 +386,6 @@ let rec symbol_of_entry : type s r. _ -> _ -> (s, r) entry -> (s, r) mayrec_symb
 | TTName -> MayRecNo (Pcoq.Symbol.nterm Prim.name)
 | TTBinder true -> MayRecNo (Pcoq.Symbol.nterm Constr.one_open_binder)
 | TTBinder false -> MayRecNo (Pcoq.Symbol.nterm Constr.one_closed_binder)
-| TTOpenBinderList -> MayRecNo (Pcoq.Symbol.nterm Constr.open_binders)
 | TTBigint -> MayRecNo (Pcoq.Symbol.nterm Prim.bignat)
 | TTGlobal -> MayRecNo (Pcoq.Symbol.nterm Constr.global)
 

--- a/vernac/egramcoq.ml
+++ b/vernac/egramcoq.ml
@@ -260,7 +260,8 @@ type (_, _) entry =
 | TTConstrList : notation_entry * prod_info * (bool * string) list * 'r target -> ('r, 'r list) entry
 | TTPattern : int -> ('self, cases_pattern_expr) entry
 | TTOpenBinderList : ('self, local_binder_expr list) entry
-| TTClosedBinderList : (bool * string) list -> ('self, local_binder_expr list list) entry
+| TTClosedBinderListPure : (bool * string) list -> ('self, local_binder_expr list list) entry
+| TTClosedBinderListOther : ('self, 'a) entry * (bool * string) list -> ('self, 'a list) entry
 
 type _ any_entry = TTAny : ('s, 'r) entry -> 's any_entry
 
@@ -359,7 +360,7 @@ let symbol_of_target : type s. _ -> _ -> _ -> _ -> s target -> (s, s) mayrec_sym
     | NumLevel lev -> MayRecNo (Pcoq.Symbol.nterml g (string_of_int lev))
     end
 
-let symbol_of_entry : type s r. _ -> _ -> (s, r) entry -> (s, r) mayrec_symbol = fun assoc from typ -> match typ with
+let rec symbol_of_entry : type s r. _ -> _ -> (s, r) entry -> (s, r) mayrec_symbol = fun assoc from typ -> match typ with
 | TTConstr (s, p, forpat) -> symbol_of_target s p assoc from forpat
 | TTConstrList (s, typ', [], forpat) ->
   begin match symbol_of_target s typ' assoc from forpat with
@@ -370,8 +371,16 @@ let symbol_of_entry : type s r. _ -> _ -> (s, r) entry -> (s, r) mayrec_symbol =
   | MayRecNo s -> MayRecNo (Pcoq.Symbol.list1sep s (make_sep_rules tkl) false)
   | MayRecMay s -> MayRecMay (Pcoq.Symbol.list1sep s (make_sep_rules tkl) false) end
 | TTPattern p -> MayRecNo (Pcoq.Symbol.nterml Constr.pattern (string_of_int p))
-| TTClosedBinderList [] -> MayRecNo (Pcoq.Symbol.list1 (Pcoq.Symbol.nterm Constr.binder))
-| TTClosedBinderList tkl -> MayRecNo (Pcoq.Symbol.list1sep (Pcoq.Symbol.nterm Constr.binder) (make_sep_rules tkl) false)
+| TTClosedBinderListPure [] -> MayRecNo (Pcoq.Symbol.list1 (Pcoq.Symbol.nterm Constr.binder))
+| TTClosedBinderListPure tkl -> MayRecNo (Pcoq.Symbol.list1sep (Pcoq.Symbol.nterm Constr.binder) (make_sep_rules tkl) false)
+| TTClosedBinderListOther (typ,[]) ->
+  begin match symbol_of_entry assoc from typ with
+  | MayRecNo s -> MayRecNo (Pcoq.Symbol.list1 s)
+  | MayRecMay s -> MayRecMay (Pcoq.Symbol.list1 s) end
+| TTClosedBinderListOther (typ,tkl) ->
+  begin match symbol_of_entry assoc from typ with
+  | MayRecNo s -> MayRecNo (Pcoq.Symbol.list1sep s (make_sep_rules tkl) false)
+  | MayRecMay s -> MayRecMay (Pcoq.Symbol.list1sep s (make_sep_rules tkl) false) end
 | TTIdent -> MayRecNo (Pcoq.Symbol.nterm Prim.identref)
 | TTName -> MayRecNo (Pcoq.Symbol.nterm Prim.name)
 | TTBinder true -> MayRecNo (Pcoq.Symbol.nterm Constr.one_open_binder)
@@ -380,7 +389,7 @@ let symbol_of_entry : type s r. _ -> _ -> (s, r) entry -> (s, r) mayrec_symbol =
 | TTBigint -> MayRecNo (Pcoq.Symbol.nterm Prim.bignat)
 | TTGlobal -> MayRecNo (Pcoq.Symbol.nterm Constr.global)
 
-let interp_entry forpat e = match e with
+let rec interp_entry forpat e = match e with
 | ETProdIdent -> TTAny TTIdent
 | ETProdName -> TTAny TTName
 | ETProdGlobal -> TTAny TTGlobal
@@ -390,7 +399,9 @@ let interp_entry forpat e = match e with
 | ETProdPattern p -> TTAny (TTPattern p)
 | ETProdConstrList (s, p, tkl) -> TTAny (TTConstrList (s, p, tkl, forpat))
 | ETProdBinderList ETBinderOpen -> TTAny TTOpenBinderList
-| ETProdBinderList (ETBinderClosed tkl) -> TTAny (TTClosedBinderList tkl)
+| ETProdBinderList (ETBinderClosed (None, tkl)) -> TTAny (TTClosedBinderListPure tkl)
+| ETProdBinderList (ETBinderClosed (Some e, tkl)) ->
+  let TTAny e = interp_entry forpat e in TTAny (TTClosedBinderListOther (e, tkl))
 
 let cases_pattern_expr_of_id { CAst.loc; v = id } =
   CAst.make ?loc @@ CPatAtom (Some (qualid_of_ident ?loc id))
@@ -428,7 +439,11 @@ match e with
   end
 | TTBinder o -> { subst with binders = v :: subst.binders }
 | TTOpenBinderList -> { subst with binderlists = v :: subst.binderlists }
-| TTClosedBinderList _ -> { subst with binderlists = List.flatten v :: subst.binderlists }
+| TTClosedBinderListPure _ -> { subst with binderlists = List.flatten v :: subst.binderlists }
+| TTClosedBinderListOther (TTIdent, _) -> { subst with binderlists = List.map (fun a -> CLocalPattern (cases_pattern_expr_of_id a)) v :: subst.binderlists }
+| TTClosedBinderListOther (TTName, _) -> { subst with binderlists = List.map (fun a -> CLocalPattern (cases_pattern_expr_of_name a)) v :: subst.binderlists }
+| TTClosedBinderListOther (TTPattern _, _) -> { subst with binderlists = List.map (fun a -> CLocalPattern a) v :: subst.binderlists }
+| TTClosedBinderListOther _ -> user_err (Pp.str "Invalid binder list entry.")
 | TTBigint ->
   begin match forpat with
   | ForConstr ->  push_constr subst (CAst.make @@ CPrim (Number (NumTok.Signed.of_int_string v)))

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -1320,7 +1320,7 @@ GRAMMAR EXTEND Gram
   binder_interp:
     [ [ "as"; IDENT "ident" -> { warn_deprecated_as_ident_kind (); Notation_term.AsIdent }
       | "as"; IDENT "name" -> { Notation_term.AsName }
-      | "as"; IDENT "pattern" -> { Notation_term.AsNameOrPattern }
+      | "as"; IDENT "pattern" -> { Notation_term.AsAnyPattern }
       | "as"; IDENT "strict"; IDENT "pattern" -> { Notation_term.AsStrictPattern } ] ]
   ;
 END

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1151,8 +1151,8 @@ let join_auxiliary_recursive_types recvars etyps =
     recvars etyps
 
 let internalization_type_of_entry_type = function
-  | ETBinder _ -> NtnInternTypeOnlyBinder
-  | ETConstr _ | ETBigint | ETGlobal
+  | ETBinder _ | ETConstr (_,Some _,_) -> NtnInternTypeOnlyBinder
+  | ETConstr (_,None,_) | ETBigint | ETGlobal
   | ETIdent | ETName | ETPattern _ -> NtnInternTypeAny None
 
 let make_internalization_vars recvars maintyps =

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -331,6 +331,8 @@ let precedence_of_entry_type (from_custom,from_level) = function
   | ETPattern (_,n) -> let n = match n with None -> 0 | Some n -> n in LevelLe n
   | _ -> LevelSome (* should not matter *)
 
+let pattern_entry_level = function None -> 0 | Some n -> n
+
 (** Computing precedences for future insertion of parentheses at
     the time of printing using hard-wired constr levels *)
 let unparsing_precedence_of_entry_type from_level = function
@@ -344,7 +346,7 @@ let unparsing_precedence_of_entry_type from_level = function
        explicit insertion of entry coercions at the time of building
        a [constr_expr] *)
     LevelSome, None
-  | ETPattern (_,n) -> (* in constr *) LevelLe (match n with Some n -> n | None -> 0), None
+  | ETPattern (_,n) -> (* in constr *) LevelLe (pattern_entry_level n), None
   | _ -> LevelSome, None (* should not matter *)
 
 (* Some breaking examples *)
@@ -694,7 +696,7 @@ let prod_entry_type = function
   | ETBigint -> ETProdBigint
   | ETBinder o -> ETProdOneBinder o
   | ETConstr (s,_,p) -> ETProdConstr (s,p)
-  | ETPattern (_,n) -> ETProdPattern (match n with None -> 0 | Some n -> n)
+  | ETPattern (_,n) -> ETProdPattern (pattern_entry_level n)
 
 let keyword_needed need s =
   (* Ensure that IDENT articulation terminal symbols are keywords *)

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -476,7 +476,11 @@ let make_hunks etyps symbols from_level =
           | ETConstr _ -> UnpListMetaVar (prec,List.map snd sl',side)
           | ETBinder isopen ->
               check_open_binder isopen sl m;
-              UnpBinderListMetaVar (isopen,List.map snd sl')
+              UnpBinderListMetaVar (isopen,true,List.map snd sl')
+          | ETName | ETIdent ->
+              UnpBinderListMetaVar (false,true,List.map snd sl')
+          | ETPattern _ ->
+              UnpBinderListMetaVar (false,false,List.map snd sl')
           | _ -> assert false in
         (None, hunk) :: make_with_space b prods
 
@@ -618,7 +622,11 @@ let hunks_of_format (from_level,(vars,typs)) symfmt =
         | ETConstr _ -> UnpListMetaVar (prec,slfmt,side)
         | ETBinder isopen ->
             check_open_binder isopen sl m;
-            UnpBinderListMetaVar (isopen,slfmt)
+            UnpBinderListMetaVar (isopen,true,slfmt)
+        | ETName | ETIdent ->
+            UnpBinderListMetaVar (false,true,slfmt)
+        | ETPattern _ ->
+            UnpBinderListMetaVar (false,false,slfmt)
         | _ -> assert false in
       symbs, hunk :: l
   | symbs, (_,UnpBox (a,b)) :: fmt ->
@@ -736,9 +744,18 @@ let make_production (_,lev,_) etyps symbols =
             expand_list_rule s typ tkl x 1 p (aux true l')
         | ETBinder o ->
             check_open_binder o sl x;
-            let typ = if o then (assert (tkl = []); ETBinderOpen) else ETBinderClosed tkl in
+            let typ = if o then (assert (tkl = []); ETBinderOpen) else ETBinderClosed (None,tkl) in
             distribute
               [GramConstrNonTerminal (ETProdBinderList typ, Some x)] (aux false l)
+        | ETIdent ->
+            distribute
+              [GramConstrNonTerminal (ETProdBinderList (ETBinderClosed (Some ETProdIdent,tkl)), Some x)] (aux false l)
+        | ETName ->
+            distribute
+              [GramConstrNonTerminal (ETProdBinderList (ETBinderClosed (Some ETProdName,tkl)), Some x)] (aux false l)
+        | ETPattern (st,n) ->
+            distribute
+              [GramConstrNonTerminal (ETProdBinderList (ETBinderClosed (Some (ETProdPattern (pattern_entry_level n)),tkl)), Some x)] (aux false l)
         | _ ->
            user_err Pp.(str "Components of recursive patterns in notation must be terms or binders.") in
   let need = (* a leading ident/number factorizes iff at level 0 *) lev <> 0 in

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1178,8 +1178,8 @@ let make_interpretation_type isrec isbinding default_if_binding typ =
   | ETName, true -> NtnTypeBinderList (NtnBinderParsedAsSomeBinderKind AsName)
   | ETName, false -> NtnTypeBinder (NtnBinderParsedAsSomeBinderKind AsName)
   (* Parsed as ident/pattern, primarily interpreted as binder; maybe strict at printing *)
-  | ETPattern (ppstrict,_), true -> NtnTypeBinderList (NtnBinderParsedAsSomeBinderKind (if ppstrict then AsStrictPattern else AsNameOrPattern))
-  | ETPattern (ppstrict,_), false -> NtnTypeBinder (NtnBinderParsedAsSomeBinderKind (if ppstrict then AsStrictPattern else AsNameOrPattern))
+  | ETPattern (ppstrict,_), true -> NtnTypeBinderList (NtnBinderParsedAsSomeBinderKind (if ppstrict then AsStrictPattern else AsAnyPattern))
+  | ETPattern (ppstrict,_), false -> NtnTypeBinder (NtnBinderParsedAsSomeBinderKind (if ppstrict then AsStrictPattern else AsAnyPattern))
   | ETBinder _, true -> NtnTypeBinderList NtnBinderParsedAsBinder
   | ETBinder _, false -> NtnTypeBinder NtnBinderParsedAsBinder
   (* Others *)
@@ -1926,7 +1926,7 @@ let add_abbreviation ~local deprecation env ident (vars,c) modl =
       interp_notation_constr env nenv c
   in
   let in_pat (id,_) = (id,ETConstr (Constrexpr.InConstrEntry,None,(NextLevel,InternalProd))) in
-  let interp = make_interpretation_vars ~default_if_binding:AsNameOrPattern [] 0 acvars (List.map in_pat vars) in
+  let interp = make_interpretation_vars ~default_if_binding:AsAnyPattern [] 0 acvars (List.map in_pat vars) in
   let vars = List.map (fun (x,_) -> (x, Id.Map.find x interp)) vars in
   let also_in_cases_pattern = has_no_binders_type vars in
   let onlyparsing = only_parsing || fst (printability None [] vars false reversibility pat) in

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -199,7 +199,7 @@ let level_of_pattern_level = function None -> DefaultLevel | Some n -> NumLevel 
 let pr_constr_as_binder_kind = let open Notation_term in function
     | AsIdent -> spc () ++ keyword "as ident"
     | AsName -> spc () ++ keyword "as name"
-    | AsNameOrPattern -> spc () ++ keyword "as pattern"
+    | AsAnyPattern -> spc () ++ keyword "as pattern"
     | AsStrictPattern -> spc () ++ keyword "as strict pattern"
 
 let pr_strict b = if b then str "strict " else mt ()

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -147,7 +147,7 @@ type notation_format =
   | TextFormat of lstring
 
 type syntax_modifier =
-  | SetItemLevel of string list * Notation_term.constr_as_binder_kind option * Extend.production_level
+  | SetItemLevel of string list * Notation_term.notation_binder_kind option * Extend.production_level
   | SetItemScope of string list * scope_name
   | SetLevel of int
   | SetCustomEntry of string * int option


### PR DESCRIPTION
The first commit clarifies the conversion between the parsing status of list of binders and the internal (semantic) status of list of binders (functions split_by_type, group_by_type, make_interpretation_type).

This allows to adopt a convention on the internal representation of lists of binders (thus always as binders). This fixes #12467.

The second commit is anecdotical.

The third commit adds parsing and printing of lists of binders restricted to be lists of idents or lists of names or lists of patterns. This is quite a lot of ad hoc code for an interest which is unclear. Comments are welcome. For instance, this allows to define:
```
Notation "'WITH' ( x1 : t1 ) , x2t2 , .. , xntn  'PRE'  [ ] P 'POST' [ ] Q" :=
  ((fun x1 : t1 => (fun x2t2 => .. (fun xntn => (pair .. (pair x1 x2t2) .. xntn)) .. )),
   (fun x1 : t1 => (fun x2t2 => .. (fun xntn => P) .. )), 
   (fun x1 : t1 => (fun x2t2 => .. (fun xntn => Q) .. )))
    (at level 200, x1 at level 0, x2t2 pattern, P at level 100, Q at level 100, only parsing). 
```
while with the first commit, only `x2t2 constr`, or `x2t2 constr as pattern` are allowed (thus parsing any constr, enforcing after parsing that it is a pattern, rather than parsing only patterns).

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
- [x] Opened **overlay** pull request : ejgallego/coq-serapi#304
