### PR TITLE
Add a staging notion to option declarations

### DIFF
--- a/dev/ci/user-overlays/16938-SkySkimmer-staged-options.sh
+++ b/dev/ci/user-overlays/16938-SkySkimmer-staged-options.sh
@@ -1,0 +1,15 @@
+overlay paramcoq https://github.com/SkySkimmer/paramcoq staged-options 16938
+
+overlay unicoq https://github.com/SkySkimmer/unicoq staged-options 16938
+
+overlay lean_importer https://github.com/SkySkimmer/coq-lean-import staged-options 16938
+
+overlay equations https://github.com/SkySkimmer/Coq-Equations staged-options 16938
+
+overlay metacoq https://github.com/SkySkimmer/metacoq staged-options 16938
+
+overlay elpi https://github.com/SkySkimmer/coq-elpi staged-options 16938
+
+overlay coqhammer https://github.com/SkySkimmer/coqhammer staged-options 16938
+
+overlay itauto https://gitlab.inria.fr/ggilbert/itauto staged-options 16938

--- a/engine/namegen.ml
+++ b/engine/namegen.ml
@@ -217,18 +217,21 @@ let it_mkLambda_or_LetIn_name env sigma b hyps =
 
 let get_mangle_names =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Mangle";"Names"]
     ~value:false
 
 let get_mangle_names_light =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Mangle";"Names";"Light"]
     ~value:false
 
 let mangle_names_prefix =
   Goptions.declare_interpreted_string_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Mangle";"Names";"Prefix"]
     ~value:("_")

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -56,8 +56,11 @@ let empty =
     minim_extra = UnivMinim.empty_extra; }
 
 let elaboration_sprop_cumul =
-  Goptions.declare_bool_option_and_ref ~depr:false
-    ~key:["Elaboration";"StrictProp";"Cumulativity"] ~value:true
+  Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
+    ~depr:false
+    ~key:["Elaboration";"StrictProp";"Cumulativity"]
+    ~value:true
 
 let make ~lbound univs =
   let univs = UGraph.set_cumulative_sprop (elaboration_sprop_cumul ()) univs in
@@ -183,6 +186,7 @@ exception UniversesDiffer
 
 let drop_weak_constraints =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Cumulativity";"Weak";"Constraints"]
     ~value:false

--- a/engine/univMinim.ml
+++ b/engine/univMinim.ml
@@ -14,6 +14,7 @@ open UnivSubst
 (* To disallow minimization to Set *)
 let get_set_minimization =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Universe";"Minimization";"ToSet"]
     ~value:true

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -66,6 +66,7 @@ let print_no_symbol = ref false
 (* This tells to skip types if a variable has this type by default *)
 let print_use_implicit_types =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Printing";"Use";"Implicit";"Types"]
     ~value:true
@@ -105,6 +106,7 @@ let without_symbols f = Flags.with_option print_no_symbol f
 (* Set Record Printing flag *)
 let get_record_print =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Printing";"Records"]
     ~value:true

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -1665,6 +1665,7 @@ let is_non_zero_pat c = match c with
   | _ -> false
 
 let get_asymmetric_patterns = Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Asymmetric";"Patterns"]
     ~value:false

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -967,6 +967,7 @@ let bigint_of_coqpos_neg_int63 c =
   | _ -> raise NotAValidPrimToken
 
 let get_printing_float = Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Printing";"Float"]
     ~value:true

--- a/library/goptions.mli
+++ b/library/goptions.mli
@@ -113,6 +113,7 @@ end
    the helper functions declare_*_option_and_ref. *)
 
 type 'a option_sig = {
+  optstage   : Summary.Stage.t;
   optdepr    : bool;
   (** whether the option is DEPRECATED *)
   optkey     : option_name;
@@ -139,7 +140,7 @@ val declare_stringopt_option: ?preprocess:(string option -> string option) ->
 
 (** Helpers to declare a reference controlled by an option. Read-only
    as to avoid races. *)
-type 'a opt_decl = depr:bool -> key:option_name -> 'a
+type 'a opt_decl = stage:Summary.Stage.t -> depr:bool -> key:option_name -> 'a
 
 val declare_int_option_and_ref : (value:int -> (unit -> int)) opt_decl
 val declare_intopt_option_and_ref : (unit -> int option) opt_decl
@@ -166,16 +167,18 @@ val get_string_table :
 val get_ref_table :
   option_name -> Libnames.qualid table_of_A
 
-(** The first argument is a locality flag. *)
-val set_int_option_value_gen    : ?locality:option_locality -> option_name -> int option -> unit
-val set_bool_option_value_gen   : ?locality:option_locality -> option_name -> bool   -> unit
-val set_string_option_value_gen : ?locality:option_locality -> option_name -> string -> unit
-val set_string_option_append_value_gen : ?locality:option_locality -> option_name -> string -> unit
-val unset_option_value_gen : ?locality:option_locality -> option_name -> unit
+(** The first argument is a locality flag.
+    If [stage] is provided, the option is set/unset only if it is declared in the corresponding stage.
+    If omitted, the option is always set/unset. *)
+val set_int_option_value_gen    : ?locality:option_locality -> ?stage:Summary.Stage.t -> option_name -> int option -> unit
+val set_bool_option_value_gen   : ?locality:option_locality -> ?stage:Summary.Stage.t -> option_name -> bool   -> unit
+val set_string_option_value_gen : ?locality:option_locality -> ?stage:Summary.Stage.t -> option_name -> string -> unit
+val set_string_option_append_value_gen : ?locality:option_locality -> ?stage:Summary.Stage.t -> option_name -> string -> unit
+val unset_option_value_gen : ?locality:option_locality -> ?stage:Summary.Stage.t -> option_name -> unit
 
-val set_int_option_value    : option_name -> int option -> unit
-val set_bool_option_value   : option_name -> bool   -> unit
-val set_string_option_value : option_name -> string -> unit
+val set_int_option_value    : ?stage:Summary.Stage.t -> option_name -> int option -> unit
+val set_bool_option_value   : ?stage:Summary.Stage.t -> option_name -> bool   -> unit
+val set_string_option_value : ?stage:Summary.Stage.t -> option_name -> string -> unit
 
 val print_option_value : option_name -> unit
 
@@ -189,7 +192,7 @@ type table_value =
   | StringRefValue of string
   | QualidRefValue of Libnames.qualid
 
-val set_option_value : ?locality:option_locality ->
+val set_option_value : ?locality:option_locality -> ?stage:Summary.Stage.t ->
   ('a -> option_value -> option_value) -> option_name -> 'a -> unit
 (** [set_option_value ?locality f name v] sets [name] to the result of
     applying [f] to [v] and [name]'s current value. Use for behaviour

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -499,7 +499,11 @@ let info_file f =
    so we register them to coq save/undo mechanism. *)
 
 let my_bool_option name value =
-  declare_bool_option_and_ref ~depr:false ~key:["Extraction"; name] ~value
+  declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
+    ~depr:false
+    ~key:["Extraction"; name]
+    ~value
 
 (*s Extraction AccessOpaque *)
 
@@ -565,13 +569,15 @@ let chg_flag n = int_flag_ref := n; opt_flag_ref := flag_of_int n
 let optims () = !opt_flag_ref
 
 let () = declare_bool_option
-          {optdepr = false;
+          {optstage = Summary.Stage.Interp;
+           optdepr = false;
            optkey = ["Extraction"; "Optimize"];
            optread = (fun () -> not (Int.equal !int_flag_ref 0));
            optwrite = (fun b -> chg_flag (if b then int_flag_init else 0))}
 
 let () = declare_int_option
-          { optdepr = false;
+          { optstage = Summary.Stage.Interp;
+            optdepr = false;
             optkey = ["Extraction";"Flag"];
             optread = (fun _ -> Some !int_flag_ref);
             optwrite = (function
@@ -582,6 +588,7 @@ let () = declare_int_option
    toplevel constant is defined. *)
 let conservative_types =
   declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Extraction"; "Conservative"; "Types"]
     ~value:false
@@ -589,6 +596,7 @@ let conservative_types =
 (* Allows to print a comment at the beginning of the output files *)
 let file_comment =
   declare_string_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Extraction"; "File"; "Comment"]
     ~value:""

--- a/plugins/firstorder/g_ground.mlg
+++ b/plugins/firstorder/g_ground.mlg
@@ -30,7 +30,11 @@ DECLARE PLUGIN "coq-core.plugins.firstorder"
 {
 
 let ground_depth =
-  declare_nat_option_and_ref ~depr:false ~key:["Firstorder";"Depth"] ~value:3
+  declare_nat_option_and_ref
+    ~stage:Summary.Stage.Interp
+    ~depr:false
+    ~key:["Firstorder";"Depth"]
+    ~value:3
 
 let default_intuition_tac =
   let tac _ _ = Auto.h_auto None [] (Some []) in

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -302,12 +302,17 @@ let pr_table env sigma = pr_table env sigma !from_function
 (* Debugging *)
 
 let do_rewrite_dependent =
-  Goptions.declare_bool_option_and_ref ~depr:false
+  Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
+    ~depr:false
     ~key:["Functional"; "Induction"; "Rewrite"; "Dependent"]
     ~value:true
 
 let do_observe =
-  Goptions.declare_bool_option_and_ref ~depr:false ~key:["Function_debug"]
+  Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
+    ~depr:false
+    ~key:["Function_debug"]
     ~value:false
 
 let observe strm = if do_observe () then Feedback.msg_debug strm else ()
@@ -352,7 +357,10 @@ let observe_tac ~header s tac =
   if do_observe () then do_observe_tac ~header s tac else tac
 
 let is_strict_tcc =
-  Goptions.declare_bool_option_and_ref ~depr:false ~key:["Function_raw_tcc"]
+  Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
+    ~depr:false
+    ~key:["Function_raw_tcc"]
     ~value:false
 
 exception Building_graph of exn

--- a/plugins/ltac/profile_ltac.ml
+++ b/plugins/ltac/profile_ltac.ml
@@ -458,7 +458,8 @@ let _ = Declaremods.append_end_library_hook do_print_results_at_close
 let () =
   let open Goptions in
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Ltac"; "Profiling"];
       optread  = get_profiling;
       optwrite = set_profiling }

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -2201,7 +2201,8 @@ let vernac_debug b =
 let () =
   let open Goptions in
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Ltac";"Debug"];
       optread  = (fun () -> get_debug () != Tactic_debug.DebugOff);
       optwrite = vernac_debug }
@@ -2209,7 +2210,8 @@ let () =
 let () =
   let open Goptions in
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Ltac"; "Backtrace"];
       optread  = (fun () -> !log_trace);
       optwrite = (fun b -> log_trace := b) }

--- a/plugins/ltac/tactic_debug.ml
+++ b/plugins/ltac/tactic_debug.ml
@@ -465,7 +465,8 @@ open Goptions
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Ltac";"Batch";"Debug"];
       optread  = (fun () -> !batch);
       optwrite = (fun x -> batch := x) }

--- a/plugins/ltac/tauto.ml
+++ b/plugins/ltac/tauto.ml
@@ -67,7 +67,8 @@ let negation_unfolding = ref true
 open Goptions
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Intuition";"Negation";"Unfolding"];
       optread  = (fun () -> !negation_unfolding);
       optwrite = (:=) negation_unfolding }

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -915,6 +915,7 @@ let register_struct atts str = match str with
 (** Toplevel exception *)
 
 let _ = Goptions.declare_bool_option {
+  Goptions.optstage = Summary.Stage.Interp;
   Goptions.optdepr = false;
   Goptions.optkey = ["Ltac2"; "Backtrace"];
   Goptions.optread = (fun () -> !Tac2interp.print_ltac2_backtrace);

--- a/plugins/micromega/certificate.ml
+++ b/plugins/micromega/certificate.ml
@@ -30,7 +30,7 @@ open Mutils
 (* If set to some [file], arithmetic goals are dumped in [file].v *)
 
 let dump_file =
-  Goptions.declare_stringopt_option_and_ref ~depr:false ~key:["Dump"; "Arith"]
+  Goptions.declare_stringopt_option_and_ref ~stage:Summary.Stage.Interp ~depr:false ~key:["Dump"; "Arith"]
 
 type ('prf, 'model) res = Prf of 'prf | Model of 'model | Unknown
 type zres = (Mc.zArithProof, int * Mc.z list) res

--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -39,14 +39,14 @@ let max_depth = max_int
 
 (* Search limit for provers over Q R *)
 let lra_proof_depth =
-  declare_int_option_and_ref ~depr:true ~key:["Lra"; "Depth"] ~value:max_depth
+  declare_int_option_and_ref ~stage:Summary.Stage.Interp ~depr:true ~key:["Lra"; "Depth"] ~value:max_depth
 
 (* Search limit for provers over Z *)
 let lia_enum =
-  declare_bool_option_and_ref ~depr:true ~key:["Lia"; "Enum"] ~value:true
+  declare_bool_option_and_ref ~stage:Summary.Stage.Interp ~depr:true ~key:["Lia"; "Enum"] ~value:true
 
 let lia_proof_depth =
-  declare_int_option_and_ref ~depr:true ~key:["Lia"; "Depth"] ~value:max_depth
+  declare_int_option_and_ref ~stage:Summary.Stage.Interp ~depr:true ~key:["Lia"; "Depth"] ~value:max_depth
 
 let get_lia_option () =
   (true, lia_enum (), lia_proof_depth ())
@@ -54,13 +54,13 @@ let get_lia_option () =
 (* Enable/disable caches *)
 
 let use_lia_cache =
-  declare_bool_option_and_ref ~depr:false ~key:["Lia"; "Cache"] ~value:true
+  declare_bool_option_and_ref ~stage:Summary.Stage.Interp ~depr:false ~key:["Lia"; "Cache"] ~value:true
 
 let use_nia_cache =
-  declare_bool_option_and_ref ~depr:false ~key:["Nia"; "Cache"] ~value:true
+  declare_bool_option_and_ref ~stage:Summary.Stage.Interp ~depr:false ~key:["Nia"; "Cache"] ~value:true
 
 let use_nra_cache =
-  declare_bool_option_and_ref ~depr:false ~key:["Nra"; "Cache"] ~value:true
+  declare_bool_option_and_ref ~stage:Summary.Stage.Interp ~depr:false ~key:["Nra"; "Cache"] ~value:true
 
 let use_csdp_cache () = true
 

--- a/plugins/rtauto/proof_search.ml
+++ b/plugins/rtauto/proof_search.ml
@@ -47,6 +47,7 @@ let reset_info () =
 
 let pruning =
   declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Rtauto";"Pruning"]
     ~value:true

--- a/plugins/rtauto/refl_tauto.ml
+++ b/plugins/rtauto/refl_tauto.ml
@@ -254,12 +254,14 @@ let build_env gamma=
 
 let verbose =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Rtauto";"Verbose"]
     ~value:false
 
 let check =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Rtauto";"Check"]
     ~value:false

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -32,7 +32,8 @@ open Proofview.Notations
 let ssroldreworder = Summary.ref ~name:"SSR:oldreworder" false
 let () =
   Goptions.(declare_bool_option
-    { optkey   = ["SsrOldRewriteGoalsOrder"];
+    { optstage = Summary.Stage.Interp;
+      optkey   = ["SsrOldRewriteGoalsOrder"];
       optread  = (fun _ -> !ssroldreworder);
       optdepr  = false;
       optwrite = (fun b -> ssroldreworder := b) })

--- a/plugins/ssr/ssrfwd.ml
+++ b/plugins/ssr/ssrfwd.ml
@@ -86,7 +86,8 @@ let ssrhaveNOtcresolution = Summary.ref ~name:"SSR:havenotcresolution" false
 
 let () =
   Goptions.(declare_bool_option
-    { optkey   = ["SsrHave";"NoTCResolution"];
+    { optstage = Summary.Stage.Interp;
+      optkey   = ["SsrHave";"NoTCResolution"];
       optread  = (fun _ -> !ssrhaveNOtcresolution);
       optdepr  = false;
       optwrite = (fun b -> ssrhaveNOtcresolution := b);

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -1657,7 +1657,8 @@ let ssr_reserved_ids = Summary.ref ~name:"SSR:idents" true
 
 let () =
   Goptions.(declare_bool_option
-    { optkey   = ["SsrIdents"];
+    { optstage = Summary.Stage.Synterp;
+      optkey   = ["SsrIdents"];
       optdepr  = false;
       optread  = (fun _ -> !ssr_reserved_ids);
       optwrite = (fun b -> ssr_reserved_ids := b)
@@ -2405,7 +2406,8 @@ let ssr_rw_syntax = Summary.ref ~name:"SSR:rewrite" true
 
 let () =
   Goptions.(declare_bool_option
-    { optkey   = ["SsrRewrite"];
+    { optstage = Summary.Stage.Synterp;
+      optkey   = ["SsrRewrite"];
       optread  = (fun _ -> !ssr_rw_syntax);
       optdepr  = false;
       optwrite = (fun b -> ssr_rw_syntax := b) })

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -50,7 +50,8 @@ let debug b =
   if b then pp_ref := ssr_pp else pp_ref := fun _ -> ()
 let _ =
   Goptions.declare_bool_option
-    { Goptions.optkey   = ["Debug";"SsrMatching"];
+    { Goptions.optstage = Summary.Stage.Interp;
+      Goptions.optkey   = ["Debug";"SsrMatching"];
       Goptions.optdepr  = false;
       Goptions.optread  = (fun _ -> !pp_ref == ssr_pp);
       Goptions.optwrite = debug }

--- a/pretyping/coercion.ml
+++ b/pretyping/coercion.ml
@@ -36,6 +36,7 @@ open Globnames
 
 let get_use_typeclasses_for_conversion =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Typeclass"; "Resolution"; "For"; "Conversion"]
     ~value:true

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -202,7 +202,8 @@ let print_evar_arguments = ref false
 let () =
   let open Goptions in
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Printing";"Existential";"Instances"];
       optread  = (fun () -> !print_evar_arguments);
       optwrite = (:=) print_evar_arguments }
@@ -292,30 +293,35 @@ module PrintingLet = Goptions.MakeRefTable(PrintingCasesLet)
 
 let force_wildcard =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Printing";"Wildcard"]
     ~value:true
 
 let fast_name_generation =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Fast";"Name";"Printing"]
     ~value:false
 
 let synthetize_type =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Printing";"Synth"]
     ~value:true
 
 let reverse_matching =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Printing";"Matching"]
     ~value:true
 
 let print_primproj_params =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Printing";"Primitive";"Projection";"Parameters"]
     ~value:false
@@ -381,6 +387,7 @@ let lookup_index_as_renamed env sigma t n =
 
 let print_factorize_match_patterns =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Printing";"Factorizable";"Match";"Patterns"]
     ~value:true
@@ -389,6 +396,7 @@ let print_allow_match_default_opt_name =
   ["Printing";"Allow";"Match";"Default";"Clause"]
 let print_allow_match_default_clause =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:print_allow_match_default_opt_name
     ~value:true

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -31,6 +31,7 @@ exception Find_at of int
 
 let get_timing_enabled =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["NativeCompute"; "Timing"]
     ~value:false
@@ -39,6 +40,7 @@ let get_timing_enabled =
 
 let get_profiling_enabled =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["NativeCompute"; "Profiling"]
     ~value:false
@@ -57,6 +59,7 @@ let profiler_platform () =
 
 let get_profile_filename =
   Goptions.declare_string_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["NativeCompute"; "Profile"; "Filename"]
     ~value:"native_compute_profile.data"

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -124,6 +124,7 @@ let esearch_guard ?loc env sigma indexes fix =
 
 let is_strict_universe_declarations =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Strict";"Universe";"Declaration"]
     ~value:true

--- a/pretyping/program.ml
+++ b/pretyping/program.ml
@@ -76,21 +76,24 @@ open Goptions
 
 let () =
   declare_bool_option
-  { optdepr  = false;
+  { optstage = Summary.Stage.Interp;
+    optdepr  = false;
     optkey   = ["Transparent";"Obligations"];
     optread  = get_proofs_transparency;
     optwrite = set_proofs_transparency; }
 
 let () =
   declare_bool_option
-  { optdepr  = false;
+  { optstage = Summary.Stage.Interp;
+    optdepr  = false;
     optkey   = ["Program";"Cases"];
     optread  = (fun () -> !program_cases);
     optwrite = (:=) program_cases }
 
 let () =
   declare_bool_option
-  { optdepr  = false;
+  { optstage = Summary.Stage.Interp;
+    optdepr  = false;
     optkey   = ["Program";"Generalized";"Coercion"];
     optread  = (fun () -> !program_generalized_coercion);
     optwrite = (:=) program_generalized_coercion }

--- a/pretyping/typeclasses.ml
+++ b/pretyping/typeclasses.ml
@@ -29,6 +29,7 @@ type hint_info = (Pattern.patvar list * Pattern.constr_pattern) hint_info_gen
 
 let get_typeclasses_unique_solutions =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Typeclasses";"Unique";"Solutions"]
     ~value:false

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -44,6 +44,7 @@ module NamedDecl = Context.Named.Declaration
 
 let is_keyed_unification =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Keyed";"Unification"]
     ~value:false

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -29,18 +29,21 @@ module CompactedDecl = Context.Compacted.Declaration
 let print_goal_tag_opt_name = ["Printing";"Goal";"Tags"]
 let should_tag =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:print_goal_tag_opt_name
     ~value:false
 
 let should_unfoc =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Printing";"Unfocused"]
     ~value:false
 
 let should_gname =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Printing";"Goal";"Names"]
     ~value:false
@@ -434,7 +437,10 @@ let pr_context_limit_compact ?n env sigma =
 (* The number of printed hypothesis in a goal *)
 (* If [None], no limit *)
 let print_hyps_limit =
-  Goptions.declare_intopt_option_and_ref ~depr:false ~key:["Hyps";"Limit"]
+  Goptions.declare_intopt_option_and_ref
+    ~stage:Summary.Stage.Interp
+    ~depr:false
+    ~key:["Hyps";"Limit"]
 
 let pr_context_of env sigma = match print_hyps_limit () with
   | None -> hv 0 (pr_context_limit_compact env sigma)
@@ -651,6 +657,7 @@ let print_evar_constraints gl sigma =
 
 let should_print_dependent_evars =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Printing";"Dependent";"Evars";"Line"]
     ~value:false

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -69,6 +69,7 @@ let opt_name = ["Diffs"]
 
 let diff_option =
   Goptions.declare_interpreted_string_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:opt_name
     ~value:DiffOff

--- a/proofs/goal_select.ml
+++ b/proofs/goal_select.ml
@@ -52,6 +52,7 @@ let parse_goal_selector = function
    without an explicit selector. *)
 let get_default_goal_selector =
   Goptions.declare_interpreted_string_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Default";"Goal";"Selector"]
     ~value:(SelectNth 1)

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -469,6 +469,7 @@ let pr_proof p =
 
 let use_unification_heuristics =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Solve";"Unification";"Constraints"]
     ~value:true

--- a/proofs/proof_bullet.ml
+++ b/proofs/proof_bullet.ml
@@ -176,6 +176,7 @@ end
 (* Current bullet behavior, controlled by the option *)
 let current_behavior =
   Goptions.declare_interpreted_string_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Bullet";"Behavior"]
     ~value:Strict.strict

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -2581,6 +2581,7 @@ let process_back_meta_command ~newtip ~head oid aast =
 
 let get_allow_nested_proofs =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:Vernac_classifier.stm_allow_nested_proofs_option_name
     ~value:false

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -143,7 +143,8 @@ let global_info_auto = ref false
 
 let add_option ls refe =
   Goptions.(declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ls;
       optread  = (fun () -> !refe);
       optwrite = (:=) refe })

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -33,6 +33,7 @@ let typeclasses_db = "typeclass_instances"
 let typeclasses_depth_opt_name = ["Typeclasses";"Depth"]
 let get_typeclasses_depth =
   Goptions.declare_intopt_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:typeclasses_depth_opt_name
 
@@ -45,12 +46,14 @@ let set_typeclasses_depth =
     cost (in terms of search depth) can differ. *)
 let get_typeclasses_limit_intros =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Typeclasses";"Limit";"Intros"]
     ~value:true
 
 let get_typeclasses_dependency_order =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Typeclasses";"Dependency";"Order"]
     ~value:false
@@ -58,6 +61,7 @@ let get_typeclasses_dependency_order =
 let iterative_deepening_opt_name = ["Typeclasses";"Iterative";"Deepening"]
 let get_typeclasses_iterative_deepening =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:iterative_deepening_opt_name
     ~value:false
@@ -83,7 +87,8 @@ end = struct
   let () =
     let open Goptions in
     declare_bool_option
-      { optdepr  = false;
+      { optstage = Summary.Stage.Interp;
+        optdepr  = false;
         optkey   = ["Typeclasses";"Debug"];
         optread  = get_typeclasses_debug;
         optwrite = set_typeclasses_debug; }
@@ -91,7 +96,8 @@ end = struct
   let () =
     let open Goptions in
     declare_int_option
-      { optdepr  = false;
+      { optstage = Summary.Stage.Interp;
+        optdepr  = false;
         optkey   = ["Typeclasses";"Debug";"Verbosity"];
         optread  = get_typeclasses_verbose;
         optwrite = set_typeclasses_verbose; }

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -296,14 +296,16 @@ let global_info_eauto = ref false
 
 let () =
   Goptions.(declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Debug";"Eauto"];
       optread  = (fun () -> !global_debug_eauto);
       optwrite = (:=) global_debug_eauto })
 
 let () =
   Goptions.(declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Info";"Eauto"];
       optread  = (fun () -> !global_info_eauto);
       optwrite = (:=) global_info_eauto })

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -63,7 +63,10 @@ let use_injection_pattern_l2r_order = function
 
 let injection_in_context_flag =
   declare_bool_option_and_ref
-    ~depr:false ~key:["Structural";"Injection"] ~value:false
+    ~stage:Summary.Stage.Interp
+    ~depr:false
+    ~key:["Structural";"Injection"]
+    ~value:false
 
 (* Rewriting tactics *)
 
@@ -715,7 +718,8 @@ let keep_proof_equalities_for_injection = ref false
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Keep";"Proof";"Equalities"];
       optread  = (fun () -> !keep_proof_equalities_for_injection) ;
       optwrite = (fun b -> keep_proof_equalities_for_injection := b) }

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -202,6 +202,7 @@ let string_to_warn_hint = function
 
 let warn_hint =
   Goptions.declare_interpreted_string_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Loose"; "Hint"; "Behavior"]
     ~value:HintLax

--- a/tactics/redexpr.ml
+++ b/tactics/redexpr.ml
@@ -53,7 +53,11 @@ let cbv_native env sigma c =
 let whd_cbn = Cbn.whd_cbn
 
 let simplIsCbn =
-  Goptions.declare_bool_option_and_ref ~depr:false ~key:["SimplIsCbn"] ~value:false
+  Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
+    ~depr:false
+    ~key:["SimplIsCbn"]
+    ~value:false
 
 let set_strategy_one ref l  =
   let k =

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -65,7 +65,8 @@ let use_clear_hyp_by_default () = !clear_hyp_by_default
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Default";"Clearing";"Used";"Hypotheses"];
       optread  = (fun () -> !clear_hyp_by_default) ;
       optwrite = (fun b -> clear_hyp_by_default := b) }

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -399,7 +399,10 @@ let top_goal_print ~doc c oldp newp =
 
 let exit_on_error =
   let open Goptions in
-  declare_bool_option_and_ref ~depr:false ~key:["Coqtop";"Exit";"On";"Error"]
+  declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
+    ~depr:false
+    ~key:["Coqtop";"Exit";"On";"Error"]
     ~value:false
 
 let show_proof_diff_cmd ~state diff_opt =

--- a/vernac/attributes.ml
+++ b/vernac/attributes.ml
@@ -208,7 +208,8 @@ let program_mode = ref false
 
 let () = let open Goptions in
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = program_mode_option_name;
       optread  = (fun () -> !program_mode);
       optwrite = (fun b -> program_mode:=b) }
@@ -259,7 +260,8 @@ let is_universe_polymorphism =
   let b = ref false in
   let () = let open Goptions in
     declare_bool_option
-      { optdepr  = false;
+      { optstage = Summary.Stage.Interp;
+        optdepr  = false;
         optkey   = universe_polymorphism_option_name;
         optread  = (fun () -> !b);
         optwrite = ((:=) b) }

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -39,7 +39,8 @@ let should_auto_template =
   let open Goptions in
   let auto = ref true in
   let () = declare_bool_option
-      { optdepr  = false;
+      { optstage = Summary.Stage.Interp;
+        optdepr  = false;
         optkey   = ["Auto";"Template";"Polymorphism"];
         optread  = (fun () -> !auto);
         optwrite = (fun b -> auto := b); }

--- a/vernac/comSearch.ml
+++ b/vernac/comSearch.ml
@@ -100,7 +100,8 @@ let search_output_name_only = ref false
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Search";"Output";"Name";"Only"];
       optread  = (fun () -> !search_output_name_only);
       optwrite = (:=) search_output_name_only }

--- a/vernac/comTactic.ml
+++ b/vernac/comTactic.ml
@@ -37,7 +37,10 @@ type parallel_solver =
   Declare.Proof.t
 
 let print_info_trace =
-  declare_intopt_option_and_ref ~depr:false ~key:["Info" ; "Level"]
+  declare_intopt_option_and_ref
+    ~stage:Summary.Stage.Interp
+    ~depr:false
+    ~key:["Info" ; "Level"]
 
 let solve_core ~pstate n ~info t ~with_end_tac:b =
   let pstate, status = Declare.Proof.map_fold_endline ~f:(fun etac p ->

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1607,6 +1607,7 @@ let get_po_name { name } = name
 
 let private_poly_univs =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Private";"Polymorphic";"Universes"]
     ~value:true
@@ -1984,6 +1985,7 @@ end
 (* Admitted *)
 let get_keep_admitted_vars =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Keep"; "Admitted"; "Variables"]
     ~value:true

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -40,7 +40,8 @@ type internal_flag =
 let elim_flag = ref true
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Elimination";"Schemes"];
       optread  = (fun () -> !elim_flag) ;
       optwrite = (fun b -> elim_flag := b) }
@@ -48,7 +49,8 @@ let () =
 let bifinite_elim_flag = ref false
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Nonrecursive";"Elimination";"Schemes"];
       optread  = (fun () -> !bifinite_elim_flag) ;
       optwrite = (fun b -> bifinite_elim_flag := b) }
@@ -56,7 +58,8 @@ let () =
 let case_flag = ref false
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Case";"Analysis";"Schemes"];
       optread  = (fun () -> !case_flag) ;
       optwrite = (fun b -> case_flag := b) }
@@ -64,7 +67,8 @@ let () =
 let eq_flag = ref false
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Boolean";"Equality";"Schemes"];
       optread  = (fun () -> !eq_flag) ;
       optwrite = (fun b -> eq_flag := b) }
@@ -74,7 +78,8 @@ let is_eq_flag () = !eq_flag
 let eq_dec_flag = ref false
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Decidable";"Equality";"Schemes"];
       optread  = (fun () -> !eq_dec_flag) ;
       optwrite = (fun b -> eq_dec_flag := b) }
@@ -82,7 +87,8 @@ let () =
 let rewriting_flag = ref false
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Rewriting";"Schemes"];
       optread  = (fun () -> !rewriting_flag) ;
       optwrite = (fun b -> rewriting_flag := b) }

--- a/vernac/printmod.ml
+++ b/vernac/printmod.ml
@@ -42,7 +42,8 @@ let short = ref false
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Short";"Module";"Printing"];
       optread  = (fun () -> !short) ;
       optwrite = ((:=) short) }

--- a/vernac/proof_using.ml
+++ b/vernac/proof_using.ml
@@ -177,7 +177,8 @@ let suggest_proof_using = ref false
 
 let () =
   Goptions.(declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Suggest";"Proof";"Using"];
       optread  = (fun () -> !suggest_proof_using);
       optwrite = ((:=) suggest_proof_using) })
@@ -214,7 +215,8 @@ let using_from_string us = Pcoq.Entry.parse entry
 let proof_using_opt_name = ["Default";"Proof";"Using"]
 let () =
   Goptions.(declare_stringopt_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = proof_using_opt_name;
       optread  = (fun () -> Option.map using_to_string !value);
       optwrite = (fun b -> value := Option.map using_from_string b);

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -30,12 +30,14 @@ module RelDecl = Context.Rel.Declaration
 
 let typeclasses_strict =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Typeclasses";"Strict";"Resolution"]
     ~value:false
 
 let typeclasses_unique =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Typeclasses";"Unique";"Instances"]
     ~value:false

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -789,7 +789,10 @@ let vernac_assumption ~atts discharge kind l nl =
   ComAssumption.do_assumptions ~poly:atts.polymorphic ~program_mode:atts.program ~scope ~kind nl l
 
 let is_polymorphic_inductive_cumulativity =
-  declare_bool_option_and_ref ~depr:false ~value:false
+  declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
+    ~depr:false
+    ~value:false
     ~key:["Polymorphic";"Inductive";"Cumulativity"]
 
 let polymorphic_cumulative ~is_defclass =
@@ -830,6 +833,7 @@ let polymorphic_cumulative ~is_defclass =
 
 let get_uniform_inductive_parameters =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Uniform"; "Inductive"; "Parameters"]
     ~value:false
@@ -886,6 +890,7 @@ let private_ind =
 (** Flag governing use of primitive projections. Disabled by default. *)
 let primitive_flag =
   Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
     ~depr:false
     ~key:["Primitive";"Projections"]
     ~value:false
@@ -1701,126 +1706,144 @@ let cumul_sprop_opt_name = ["Cumulative";"StrictProp"]
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = allow_sprop_opt_name;
       optread  = (fun () -> Global.sprop_allowed());
       optwrite = Global.set_allow_sprop }
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = cumul_sprop_opt_name;
       optread  = Global.is_cumulative_sprop;
       optwrite = Global.set_cumulative_sprop }
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Silent"];
       optread  = (fun () -> !Flags.quiet);
       optwrite = ((:=) Flags.quiet) }
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Implicit";"Arguments"];
       optread  = Impargs.is_implicit_args;
       optwrite = Impargs.make_implicit_args }
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Strict";"Implicit"];
       optread  = Impargs.is_strict_implicit_args;
       optwrite = Impargs.make_strict_implicit_args }
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Strongly";"Strict";"Implicit"];
       optread  = Impargs.is_strongly_strict_implicit_args;
       optwrite = Impargs.make_strongly_strict_implicit_args }
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Contextual";"Implicit"];
       optread  = Impargs.is_contextual_implicit_args;
       optwrite = Impargs.make_contextual_implicit_args }
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Reversible";"Pattern";"Implicit"];
       optread  = Impargs.is_reversible_pattern_implicit_args;
       optwrite = Impargs.make_reversible_pattern_implicit_args }
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Maximal";"Implicit";"Insertion"];
       optread  = Impargs.is_maximal_implicit_args;
       optwrite = Impargs.make_maximal_implicit_args }
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Printing";"Coercions"];
       optread  = (fun () -> !Constrextern.print_coercions);
       optwrite = (fun b ->  Constrextern.print_coercions := b) }
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Printing";"Parentheses"];
       optread  = (fun () -> !Constrextern.print_parentheses);
       optwrite = (fun b ->  Constrextern.print_parentheses := b) }
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Printing";"Implicit"];
       optread  = (fun () -> !Constrextern.print_implicits);
       optwrite = (fun b ->  Constrextern.print_implicits := b) }
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Printing";"Implicit";"Defensive"];
       optread  = (fun () -> !Constrextern.print_implicits_defensive);
       optwrite = (fun b ->  Constrextern.print_implicits_defensive := b) }
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Printing";"Projections"];
       optread  = (fun () -> !Constrextern.print_projections);
       optwrite = (fun b ->  Constrextern.print_projections := b) }
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Printing";"Notations"];
       optread  = (fun () -> not !Constrextern.print_no_symbol);
       optwrite = (fun b ->  Constrextern.print_no_symbol := not b) }
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Printing";"Raw";"Literals"];
       optread  = (fun () -> !Constrextern.print_raw_literal);
       optwrite = (fun b ->  Constrextern.print_raw_literal := b) }
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Printing";"All"];
       optread  = (fun () -> !Flags.raw_print);
       optwrite = (fun b -> Flags.raw_print := b) }
 
 let () =
   declare_int_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Inline";"Level"];
       optread  = (fun () -> Some (Flags.get_inline_level ()));
       optwrite = (fun o ->
@@ -1829,98 +1852,112 @@ let () =
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Kernel"; "Term"; "Sharing"];
       optread  = (fun () -> (Global.typing_flags ()).Declarations.share_reduction);
       optwrite = Global.set_share_reduction }
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Printing";"Compact";"Contexts"];
       optread  = (fun () -> Printer.get_compact_context());
       optwrite = (fun b -> Printer.set_compact_context b) }
 
 let () =
   declare_int_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Printing";"Depth"];
       optread  = Topfmt.get_depth_boxes;
       optwrite = Topfmt.set_depth_boxes }
 
 let () =
   declare_int_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Printing";"Width"];
       optread  = Topfmt.get_margin;
       optwrite = Topfmt.set_margin }
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Printing";"Universes"];
       optread  = (fun () -> !Constrextern.print_universes);
       optwrite = (fun b -> Constrextern.print_universes:=b) }
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Dump";"Bytecode"];
       optread  = (fun () -> !Vmbytegen.dump_bytecode);
       optwrite = (:=) Vmbytegen.dump_bytecode }
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Dump";"Lambda"];
       optread  = (fun () -> !Vmlambda.dump_lambda);
       optwrite = (:=) Vmlambda.dump_lambda }
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Parsing";"Explicit"];
       optread  = (fun () -> !Constrintern.parsing_explicit);
       optwrite = (fun b ->  Constrintern.parsing_explicit := b) }
 
 let () =
   declare_string_option ~preprocess:CWarnings.normalize_flags_string
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Warnings"];
       optread  = CWarnings.get_flags;
       optwrite = CWarnings.set_flags }
 
 let () =
   declare_string_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Debug"];
       optread  = CDebug.get_flags;
       optwrite = CDebug.set_flags }
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Guard"; "Checking"];
       optread  = (fun () -> (Global.typing_flags ()).Declarations.check_guarded);
       optwrite = (fun b -> Global.set_check_guarded b) }
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Positivity"; "Checking"];
       optread  = (fun () -> (Global.typing_flags ()).Declarations.check_positive);
       optwrite = (fun b -> Global.set_check_positive b) }
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Universe"; "Checking"];
       optread  = (fun () -> (Global.typing_flags ()).Declarations.check_universes);
       optwrite = (fun b -> Global.set_check_universes b) }
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Definitional"; "UIP"];
       optread  = (fun () -> (Global.typing_flags ()).Declarations.allow_uip);
       optwrite = (fun b -> Global.set_typing_flags

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -39,6 +39,7 @@ let proof_mode_opt_name = ["Default";"Proof";"Mode"]
 
 let get_default_proof_mode =
   Goptions.declare_interpreted_string_option_and_ref
+    ~stage:Summary.Stage.Synterp
     ~depr:false
     ~key:proof_mode_opt_name
     ~value:(Pvernac.register_proof_mode "Noedit" Pvernac.Vernac_.noedit_mode)
@@ -244,7 +245,8 @@ let interp_qed_delayed_control ~proof ~st ~control { CAst.loc; v=pe } =
 (* General interp with management of state *)
 let () = let open Goptions in
   declare_int_option
-    { optdepr  = false;
+    { optstage = Summary.Stage.Interp;
+      optdepr  = false;
       optkey   = ["Default";"Timeout"];
       optread  = (fun () -> !default_timeout);
       optwrite = ((:=) default_timeout) }


### PR DESCRIPTION
In rare cases, options can have an impact on parsing, hence have to be computed in the synterp stage. The `Default Proof Mode` option is such an example.

This is a step towards #15409.

Overlays:
- https://github.com/coq-community/paramcoq/pull/104
- https://github.com/unicoq/unicoq/pull/77
- https://github.com/SkySkimmer/coq-lean-import/pull/4
- https://github.com/mattam82/Coq-Equations/pull/520
- https://github.com/MetaCoq/metacoq/pull/804
- https://github.com/LPCIC/coq-elpi/pull/412
- https://github.com/lukaszcz/coqhammer/pull/150
- https://gitlab.inria.fr/fbesson/itauto/-/merge_requests/8