### PR TITLE
Avoid bad gcc warning

### DIFF
--- a/kernel/byterun/coq_fix_code.c
+++ b/kernel/byterun/coq_fix_code.c
@@ -25,8 +25,19 @@
 #include "coq_fix_code.h"
 
 #ifdef THREADED_CODE
-char ** coq_instr_table;
-char * coq_instr_base;
+static char ** coq_instr_table;
+static char * coq_instr_base;
+
+void coq_init_thread_code(void ** instr_table, void * instr_base)
+{
+  coq_instr_table = (char **) instr_table;
+  coq_instr_base = (char *) instr_base;
+}
+
+opcode_t coq_valinstr(int instr)
+{
+  return (opcode_t)(coq_instr_table[instr] - coq_instr_base);
+}
 #endif /*  THREADED_CODE */
 
 

--- a/kernel/byterun/coq_fix_code.h
+++ b/kernel/byterun/coq_fix_code.h
@@ -16,9 +16,9 @@
 void * coq_stat_alloc (asize_t sz);
 
 #ifdef THREADED_CODE
-extern char ** coq_instr_table;
-extern char * coq_instr_base;
-#define VALINSTR(instr) ((opcode_t)(coq_instr_table[instr] - coq_instr_base))
+void coq_init_thread_code(void ** instr_table, void * instr_base);
+opcode_t coq_valinstr(int instr);
+#define VALINSTR(instr) (coq_valinstr(instr))
 #else
 #define VALINSTR(instr) instr
 #endif /*  THREADED_CODE */

--- a/kernel/byterun/coq_interp.c
+++ b/kernel/byterun/coq_interp.c
@@ -73,9 +73,9 @@ sp is a local copy of the global variable extern_sp. */
 #ifdef THREADED_CODE
 #  define Instruct(name) coq_lbl_##name:
 #  if defined(ARCH_SIXTYFOUR) && !defined(ARCH_CODE32)
-#    define coq_Jumptbl_base ((char *) &&coq_lbl_ACC0)
+#    define coq_Jumptbl_base &&coq_lbl_ACC0
 #  else
-#    define coq_Jumptbl_base ((char *) 0)
+#    define coq_Jumptbl_base 0
 #    define coq_jumptbl_base ((char *) 0)
 #  endif
 #  ifdef DEBUG
@@ -297,8 +297,7 @@ value coq_interprete
   if (coq_pc == NULL) {           /* Interpreter is initializing */
     print_instr("Interpreter is initializing");
 #ifdef THREADED_CODE
-    coq_instr_table = (char **) coq_jumptable;
-    coq_instr_base = coq_Jumptbl_base;
+    coq_init_thread_code(coq_jumptable, coq_Jumptbl_base);
 #endif
     CAMLreturn(Val_unit);
   }


### PR DESCRIPTION
Fix #16426

see also https://github.com/ocaml/ocaml/pull/11379
