### PR TITLE
Refactor Metasyntax API to better separate syntax and interpretation

### DIFF
--- a/dev/ci/user-overlays/16944-maximedenes-separate-notation-syntax.sh
+++ b/dev/ci/user-overlays/16944-maximedenes-separate-notation-syntax.sh
@@ -1,0 +1,3 @@
+overlay equations https://github.com/maximedenes/Coq-Equations separate-notation-syntax 16944
+
+overlay serapi https://github.com/maximedenes/coq-serapi separate-notation-syntax 16944

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -30,7 +30,12 @@ Notations
 Basic notations
 ~~~~~~~~~~~~~~~
 
-.. cmd:: Notation @string := @one_term {? ( {+, @syntax_modifier } ) } {? : @scope_name }
+.. cmd:: Notation @notation_declaration
+
+   .. insertprodn notation_declaration notation_declaration
+
+   .. prodn::
+      notation_declaration ::= @string := @one_term {? ( {+, @syntax_modifier } ) } {? : @scope_name }
 
    Defines a *notation*, an alternate syntax for entering or displaying
    a specific term or term pattern.
@@ -351,9 +356,13 @@ The Infix command
 The :cmd:`Infix` command is a shortcut for declaring notations for infix
 symbols.
 
-.. cmd:: Infix @string := @one_term {? ( {+, @syntax_modifier } ) } {? : @scope_name }
+.. cmd:: Infix @notation_declaration
 
-   This command is equivalent to
+   The command
+
+       :n:`Infix @string := @one_term {? ( {+, @syntax_modifier } ) } {? : @scope_name }`
+
+   is equivalent to
 
        :n:`Notation "x @string y" := (@one_term x y) {? ( {+, @syntax_modifier } ) } {? : @scope_name }`
 
@@ -401,20 +410,17 @@ Reserving notations
 Simultaneous definition of terms and notations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Thanks to reserved notations, inductive, coinductive, record, recursive and
+Thanks to reserved notations, inductive and coinductive type declarations, recursive and
 corecursive definitions can use customized notations. To do this, insert
 a :token:`decl_notations` clause after the definition of the (co)inductive type or
 (co)recursive term (or after the definition of each of them in case of mutual
-definitions). The exact syntax is given by :n:`@decl_notation` for inductive,
-coinductive, recursive and corecursive definitions and in :ref:`record-types`
-for records. Note that only syntax modifiers that do not require adding or
+definitions). Note that only syntax modifiers that do not require adding or
 changing a parsing rule are accepted.
 
-   .. insertprodn decl_notations decl_notation
+   .. insertprodn decl_notations decl_notations
 
    .. prodn::
-      decl_notations ::= where @decl_notation {* and @decl_notation }
-      decl_notation ::= @string := @one_term {? ( {+, @syntax_modifier } ) } {? : @scope_name }
+      decl_notations ::= where @notation_declaration {* and @notation_declaration }
 
 Here are examples:
 

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1485,10 +1485,6 @@ syntax: [
 | WITH "Undelimit" "Scope" scope_name
 | REPLACE "Bind" "Scope" IDENT; "with" LIST1 class_rawexpr
 | WITH "Bind" "Scope" scope_name; "with" LIST1 class_rawexpr
-| REPLACE "Infix" ne_lstring ":=" constr syntax_modifiers   OPT [ ":" IDENT ]
-| WITH    "Infix" ne_lstring ":=" constr syntax_modifiers OPT [ ":" scope_name ]
-| REPLACE "Notation" lstring ":=" constr syntax_modifiers   OPT [ ":" IDENT ]
-| WITH    "Notation" lstring ":=" constr syntax_modifiers OPT [ ":" scope_name ]
 ]
 
 opt_scope: [
@@ -1735,8 +1731,8 @@ ltac2_in_clause: [
 ]
 
 decl_notations: [
-| REPLACE "where" LIST1 decl_notation SEP decl_sep
-| WITH "where" decl_notation LIST0 (decl_sep decl_notation )
+| REPLACE "where" LIST1 notation_declaration SEP decl_sep
+| WITH "where" notation_declaration LIST0 (decl_sep notation_declaration )
 ]
 
 module_expr: [
@@ -1793,9 +1789,9 @@ by_notation: [
 | WITH ne_string OPT [ "%" scope_key ]
 ]
 
-decl_notation: [
-| REPLACE ne_lstring ":=" constr syntax_modifiers OPT [ ":" IDENT ]
-| WITH ne_lstring ":=" constr syntax_modifiers OPT [ ":" scope_name ]
+notation_declaration: [
+| REPLACE lstring ":=" constr syntax_modifiers OPT [ ":" IDENT ]
+| WITH lstring ":=" constr syntax_modifiers OPT [ ":" scope_name ]
 ]
 
 ltac_production_item: [

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -921,8 +921,8 @@ reduce: [
 |
 ]
 
-decl_notation: [
-| ne_lstring ":=" constr syntax_modifiers OPT [ ":" IDENT ]
+notation_declaration: [
+| lstring ":=" constr syntax_modifiers OPT [ ":" IDENT ]
 ]
 
 decl_sep: [
@@ -930,7 +930,7 @@ decl_sep: [
 ]
 
 decl_notations: [
-| "where" LIST1 decl_notation SEP decl_sep
+| "where" LIST1 notation_declaration SEP decl_sep
 |
 ]
 
@@ -1425,9 +1425,9 @@ syntax: [
 | "Delimit" "Scope" IDENT; "with" IDENT
 | "Undelimit" "Scope" IDENT
 | "Bind" "Scope" IDENT; "with" LIST1 class_rawexpr
-| "Infix" ne_lstring ":=" constr syntax_modifiers OPT [ ":" IDENT ]
+| "Infix" notation_declaration
 | "Notation" identref LIST0 ident ":=" constr syntax_modifiers
-| "Notation" lstring ":=" constr syntax_modifiers OPT [ ":" IDENT ]
+| "Notation" notation_declaration
 | "Reserved" "Infix" ne_lstring syntax_modifiers
 | "Reserved" "Notation" ne_lstring syntax_modifiers
 | enable_enable_disable "Notation" enable_notation_rule enable_notation_interpretation enable_notation_flags opt_scope

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1102,9 +1102,9 @@ command: [
 | "Delimit" "Scope" scope_name "with" scope_key
 | "Undelimit" "Scope" scope_name
 | "Bind" "Scope" scope_name "with" LIST1 class
-| "Infix" string ":=" one_term OPT ( "(" LIST1 syntax_modifier SEP "," ")" ) OPT [ ":" scope_name ]
+| "Infix" notation_declaration
 | "Notation" ident LIST0 ident ":=" one_term OPT ( "(" LIST1 syntax_modifier SEP "," ")" )
-| "Notation" string ":=" one_term OPT ( "(" LIST1 syntax_modifier SEP "," ")" ) OPT [ ":" scope_name ]
+| "Notation" notation_declaration
 | "Reserved" "Infix" string OPT ( "(" LIST1 syntax_modifier SEP "," ")" )
 | "Reserved" "Notation" string OPT ( "(" LIST1 syntax_modifier SEP "," ")" )
 | [ "Enable" | "Disable" ] "Notation" OPT [ string | qualid ] OPT ( ":=" one_term ) OPT ( "(" LIST1 enable_notation_flag SEP "," ")" ) OPT [ ":" scope_name | ":" "no" "scope" ]
@@ -1592,10 +1592,10 @@ level: [
 ]
 
 decl_notations: [
-| "where" decl_notation LIST0 ( "and" decl_notation )
+| "where" notation_declaration LIST0 ( "and" notation_declaration )
 ]
 
-decl_notation: [
+notation_declaration: [
 | string ":=" one_term OPT ( "(" LIST1 syntax_modifier SEP "," ")" ) OPT [ ":" scope_name ]
 ]
 

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -758,7 +758,7 @@ type t = {
   univ_binders : UnivNames.universe_binders;
   implicits : DeclareInd.one_inductive_impls list;
   uctx : Univ.ContextSet.t;
-  where_notations : Metasyntax.where_decl_notation list;
+  where_notations : Metasyntax.notation_interpretation_decl list;
   coercions : Libnames.qualid list;
 }
 

--- a/vernac/comInductive.mli
+++ b/vernac/comInductive.mli
@@ -22,7 +22,7 @@ type uniform_inductive_flag =
 val do_mutual_inductive
   :  template:bool option
   -> cumul_univ_decl_expr option
-  -> (one_inductive_expr * decl_notation list) list
+  -> (one_inductive_expr * notation_declaration list) list
   -> cumulative:bool
   -> poly:bool
   -> ?typing_flags:Declarations.typing_flags
@@ -50,7 +50,7 @@ type t = {
   univ_binders : UnivNames.universe_binders;
   implicits : DeclareInd.one_inductive_impls list;
   uctx : Univ.ContextSet.t;
-  where_notations : Metasyntax.where_decl_notation list;
+  where_notations : Metasyntax.notation_interpretation_decl list;
   coercions : Libnames.qualid list;
 }
 
@@ -61,7 +61,7 @@ val interp_mutual_inductive
   :  env:Environ.env
   -> template:bool option
   -> cumul_univ_decl_expr option
-  -> (one_inductive_expr * decl_notation list) list
+  -> (one_inductive_expr * notation_declaration list) list
   -> cumulative:bool
   -> poly:bool
   -> ?typing_flags:Declarations.typing_flags

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -836,7 +836,7 @@ module ProgramDecl = struct
     ; prg_obligations : obligations
     ; prg_deps : Id.t list
     ; prg_fixkind : fixpoint_kind option
-    ; prg_notations : Metasyntax.where_decl_notation list
+    ; prg_notations : Metasyntax.notation_interpretation_decl list
     ; prg_reduce : constr -> constr
     }
 

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -134,7 +134,7 @@ val declare_mutually_recursive
   : info:Info.t
   -> cinfo: Constr.t CInfo.t list
   -> opaque:bool
-  -> ntns:Metasyntax.where_decl_notation list
+  -> ntns:Metasyntax.notation_interpretation_decl list
   -> uctx:UState.t
   -> rec_declaration:Constr.rec_declaration
   -> possible_indexes:lemma_possible_guards option
@@ -520,7 +520,7 @@ val add_mutual_definitions :
   -> ?tactic:unit Proofview.tactic
   -> ?reduce:(Constr.t -> Constr.t)
   -> ?opaque:bool
-  -> ntns:Metasyntax.where_decl_notation list
+  -> ntns:Metasyntax.notation_interpretation_decl list
   -> fixpoint_kind
   -> OblState.t
 

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -47,6 +47,7 @@ let thm_token = Entry.create "thm_token"
 let def_token = Entry.create "def_token"
 let assumption_token = Entry.create "assumption_token"
 let def_body = Entry.create "def_body"
+let notation_declaration = Entry.create "notation_declaration"
 let decl_notations = Entry.create "decl_notations"
 let record_field = Entry.create "record_field"
 let of_type = Entry.create "of_type"
@@ -209,7 +210,7 @@ let test_variance_ident =
 (* Gallina declarations *)
 GRAMMAR EXTEND Gram
   GLOBAL: gallina gallina_ext thm_token def_token assumption_token def_body of_type of_type_inst
-    record_field decl_notations fix_definition ident_decl univ_decl inductive_or_record_definition;
+    record_field notation_declaration decl_notations fix_definition ident_decl univ_decl inductive_or_record_definition;
 
   gallina:
       (* Definition, Theorem, Variable, Axiom, ... *)
@@ -371,20 +372,20 @@ GRAMMAR EXTEND Gram
     [ [ IDENT "Eval"; r = red_expr; "in" -> { Some r }
       | -> { None } ] ]
   ;
-  decl_notation:
-    [ [ ntn = ne_lstring; ":="; c = constr;
+  notation_declaration:
+    [ [ ntn = lstring; ":="; c = constr;
         modl = syntax_modifiers;
         scopt = OPT [ ":"; sc = IDENT -> { sc } ] ->
-      { { decl_ntn_string = ntn; decl_ntn_interp = c;
-          decl_ntn_scope = scopt;
-          decl_ntn_modifiers = modl;
+      { { ntn_decl_string = ntn; ntn_decl_interp = c;
+          ntn_decl_scope = scopt;
+          ntn_decl_modifiers = modl;
       } } ] ]
   ;
   decl_sep:
     [ [ IDENT "and" -> { () } ] ]
   ;
   decl_notations:
-    [ [ "where"; l = LIST1 decl_notation SEP decl_sep -> { l }
+    [ [ "where"; l = LIST1 notation_declaration SEP decl_sep -> { l }
     | -> { [] } ] ]
   ;
   (* Inductives and records *)
@@ -1214,18 +1215,13 @@ GRAMMAR EXTEND Gram
      | IDENT "Bind"; IDENT "Scope"; sc = IDENT; "with";
        refl = LIST1 class_rawexpr -> { VernacBindScope (sc,refl) }
 
-     | IDENT "Infix"; op = ne_lstring; ":="; p = constr;
-         modl = syntax_modifiers;
-         sc = OPT [ ":"; sc = IDENT -> { sc } ] ->
-         { VernacNotation (true,p,(op,modl),sc) }
+     | IDENT "Infix"; ntn_decl = notation_declaration ->
+         { VernacNotation (true,ntn_decl) }
      | IDENT "Notation"; id = identref; idl = LIST0 ident;
          ":="; c = constr; modl = syntax_modifiers ->
            { VernacSyntacticDefinition (id,(idl,c), modl) }
-     | IDENT "Notation"; s = lstring; ":=";
-         c = constr;
-         modl = syntax_modifiers;
-         sc = OPT [ ":"; sc = IDENT -> { sc } ] ->
-           { VernacNotation (false,c,(s,modl),sc) }
+     | IDENT "Notation"; ntn_decl = notation_declaration ->
+           { VernacNotation (false,ntn_decl) }
 
      | IDENT "Reserved"; IDENT "Infix"; s = ne_lstring; l = syntax_modifiers ->
            { VernacReservedNotation (true,(s,l)) }

--- a/vernac/metasyntax.mli
+++ b/vernac/metasyntax.mli
@@ -15,10 +15,25 @@ open Constrexpr
 open Notation_term
 open Environ
 
-(** Adding a (constr) notation in the environment*)
+type notation_main_data
+type syntax_rules
 
-val add_notation : local:bool -> infix:bool -> Deprecation.t option -> env -> constr_expr ->
-  (lstring * syntax_modifier CAst.t list) -> scope_name option -> unit
+type notation_interpretation_decl
+(** This data type packages all the necessary information to declare a notation
+    interpretation, once the syntax is declared or recovered from a previous
+    declaration. *)
+
+val add_notation_syntax :
+  local:bool ->
+  infix:bool ->
+  Deprecation.t option ->
+  notation_declaration ->
+  notation_interpretation_decl
+(** Add syntax rules for a (constr) notation in the environment *)
+
+val add_notation_interpretation :
+  local:bool -> env -> notation_interpretation_decl -> unit
+(** Declare the interpretation of a notation *)
 
 (** Declaring scopes, delimiter keys and default scopes *)
 
@@ -33,18 +48,12 @@ val open_close_scope : locality_flag -> to_open:bool -> scope_name -> unit
 
 (** Add a notation interpretation associated to a "where" clause (already has pa/pp rules) *)
 
-type where_decl_notation
-
 val prepare_where_notation :
-  decl_notation -> where_decl_notation
+  notation_declaration -> notation_interpretation_decl
   (** Interpret the modifiers of a where-notation *)
 
-val add_notation_interpretation :
-  local:bool -> env -> where_decl_notation -> unit
-  (** Declare the interpretation of the where-notation *)
-
 val set_notation_for_interpretation :
-  env -> Constrintern.internalization_env -> where_decl_notation -> unit
+  env -> Constrintern.internalization_env -> notation_interpretation_decl -> unit
   (** Set the interpretation of the where-notation for interpreting a mutual block *)
 
 (** Add only the parsing/printing rule of a notation *)

--- a/vernac/pvernac.mli
+++ b/vernac/pvernac.mli
@@ -21,7 +21,7 @@ module Vernac_ :
     val command : vernac_expr Entry.t
     val syntax : vernac_expr Entry.t
     val vernac_control : vernac_control Entry.t
-    val inductive_or_record_definition : (inductive_expr * decl_notation list) Entry.t
+    val inductive_or_record_definition : (inductive_expr * notation_declaration list) Entry.t
     val fix_definition : fixpoint_expr Entry.t
     val noedit_mode : vernac_expr Entry.t
     val command_entry : vernac_expr Entry.t

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -112,7 +112,7 @@ module DataI = struct
     { name : Id.t
     ; arity : Constrexpr.constr_expr option
     (** declared sort for the record  *)
-    ; nots : Metasyntax.where_decl_notation list list
+    ; nots : Metasyntax.notation_interpretation_decl list list
     (** notations for fields *)
     ; fs : Vernacexpr.local_decl_expr list
     }

--- a/vernac/vernacentries.mli
+++ b/vernac/vernacentries.mli
@@ -51,7 +51,7 @@ module Preprocessed_Mind_decl : sig
     typing_flags : Declarations.typing_flags option;
     private_ind : bool;
     uniform : ComInductive.uniform_inductive_flag;
-    inductives : (Vernacexpr.one_inductive_expr * Vernacexpr.decl_notation list) list;
+    inductives : (Vernacexpr.one_inductive_expr * Vernacexpr.notation_declaration list) list;
   }
   type t =
     | Record of record
@@ -61,5 +61,5 @@ end
 val preprocess_inductive_decl
   :  atts:Attributes.vernac_flags
   -> Vernacexpr.inductive_kind
-  -> (Vernacexpr.inductive_expr * Vernacexpr.decl_notation list) list
+  -> (Vernacexpr.inductive_expr * Vernacexpr.notation_declaration list) list
   -> Preprocessed_Mind_decl.t

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -162,11 +162,11 @@ type notation_enable_modifier =
   | EnableNotationOnly of Notationextern.notation_use
   | EnableNotationAll
 
-type decl_notation =
-  { decl_ntn_string : lstring
-  ; decl_ntn_interp : constr_expr
-  ; decl_ntn_scope : scope_name option
-  ; decl_ntn_modifiers : syntax_modifier CAst.t list
+type notation_declaration =
+  { ntn_decl_string : lstring
+  ; ntn_decl_interp : constr_expr
+  ; ntn_decl_scope : scope_name option
+  ; ntn_decl_modifiers : syntax_modifier CAst.t list
   }
 
 type 'a fix_expr_gen =
@@ -176,7 +176,7 @@ type 'a fix_expr_gen =
   ; binders : local_binder_expr list
   ; rtype : constr_expr
   ; body_def : constr_expr option
-  ; notations : decl_notation list
+  ; notations : notation_declaration list
   }
 
 type fixpoint_expr = recursion_order_expr option fix_expr_gen
@@ -198,7 +198,7 @@ type record_field_attr = {
   rf_instance: instance_flag; (* the projection is an instance *)
   rf_priority: int option; (* priority of the instance, if relevant *)
   rf_locality: Goptions.option_locality; (* locality of coercion and instance *)
-  rf_notation: decl_notation list;
+  rf_notation: notation_declaration list;
   rf_canonical: bool; (* use this projection in the search for canonical instances *)
   }
 type constructor_expr = (lident * constr_expr) with_coercion_instance
@@ -352,9 +352,7 @@ type nonrec vernac_expr =
   | VernacDeclareScope of scope_name
   | VernacDelimiters of scope_name * string option
   | VernacBindScope of scope_name * class_rawexpr list
-  | VernacNotation of
-      infix_flag * constr_expr * (lstring * syntax_modifier CAst.t list) *
-      scope_name option
+  | VernacNotation of infix_flag * notation_declaration
   | VernacDeclareCustomEntry of string
   | VernacEnableNotation of bool * (string, qualid) Util.union option * constr_expr option * notation_enable_modifier list * notation_with_optional_scope option
 
@@ -365,7 +363,7 @@ type nonrec vernac_expr =
   | VernacExactProof of constr_expr
   | VernacAssumption of (discharge * Decls.assumption_object_kind) *
       Declaremods.inline * (ident_decl list * constr_expr) with_coercion list
-  | VernacInductive of inductive_kind * (inductive_expr * decl_notation list) list
+  | VernacInductive of inductive_kind * (inductive_expr * notation_declaration list) list
   | VernacFixpoint of discharge * fixpoint_expr list
   | VernacCoFixpoint of discharge * cofixpoint_expr list
   | VernacScheme of (lident option * scheme) list


### PR DESCRIPTION
We generalize the `decl_notation` type to a general representation of notation declarations, and use it to factorize some parsing rules.

The notation interpretation declaration API is unified with the one used by `where` notations.

Overlays:

https://github.com/mattam82/Coq-Equations/pull/521
https://github.com/ejgallego/coq-serapi/pull/296