### PR TITLE
Follow-up to #12324 (disable/enable notations)

### DIFF
--- a/clib/cMap.ml
+++ b/clib/cMap.ml
@@ -36,6 +36,7 @@ sig
   val fold_right : (key -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
   val height : 'a t -> int
   val filter_range : (key -> int) -> 'a t -> 'a t
+  val of_list : (key * 'a) list -> 'a t
   module Smart :
   sig
     val map : ('a -> 'a) -> 'a t -> 'a t
@@ -61,6 +62,7 @@ sig
   val fold_right : (M.t -> 'a -> 'b -> 'b) -> 'a map -> 'b -> 'b
   val height : 'a map -> int
   val filter_range : (M.t -> int) -> 'a map -> 'a map
+  val of_list : (M.t * 'a) list -> 'a map
   module Smart :
   sig
     val map : ('a -> 'a) -> 'a map -> 'a map
@@ -186,6 +188,10 @@ struct
           let m = aux m (map_prj r) in
           F.add v d m
     in aux F.empty (map_prj m)
+
+  let of_list l =
+    let fold accu (x, v) = F.add x v accu in
+    List.fold_left fold F.empty l
 
   module Smart =
   struct

--- a/clib/cMap.mli
+++ b/clib/cMap.mli
@@ -66,6 +66,9 @@ sig
       [filter_range] returns the submap of [m] whose keys are in
       range. Note that [in_range] has to define a continouous range. *)
 
+  val of_list : (key * 'a) list -> 'a t
+  (** Turns an association list into a map *)
+
   module Smart :
   sig
     val map : ('a -> 'a) -> 'a t -> 'a t

--- a/clib/hMap.ml
+++ b/clib/hMap.ml
@@ -415,6 +415,10 @@ struct
   let filter_range f s =
     filter (fun x _ -> f x = 0) s
 
+  let of_list l =
+    let fold accu (x, v) = add x v accu in
+    List.fold_left fold empty l
+
   let update k f m =
     let aux = function
       | None -> (match f None with

--- a/doc/changelog/03-notations/12324-master+nametab-method-remove.rst
+++ b/doc/changelog/03-notations/12324-master+nametab-method-remove.rst
@@ -1,6 +1,6 @@
 - **Added:**
   :cmd:`Enable Notation` and :cmd:`Disable Notation` commands
   to enable or disable previously defined notations
-  (`#12324 <https://github.com/coq/coq/pull/12324>`_,
+  (`#12324 <https://github.com/coq/coq/pull/12324>`_ and `#16945 <https://github.com/coq/coq/pull/16945>`_,
   by Hugo Herbelin and Pierre Roux, extending previous work by Lionel Rieg,
   review by Jim Fehrle).

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -444,7 +444,7 @@ Here are examples:
 Enabling and disabling notations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. cmd:: {| Enable | Disable } Notation {? {| @string | @qualid } } {? := @one_term } {? ( {+, @enable_notation_flag } ) } {? {| : @scope_name | : no scope } }
+.. cmd:: {| Enable | Disable } Notation {? {| @string | @qualid {* @ident__parm } } } {? := @one_term } {? ( {+, @enable_notation_flag } ) } {? {| : @scope_name | : no scope } }
    :name: Enable Notation; Disable Notation
 
    .. insertprodn enable_notation_flag enable_notation_flag
@@ -472,15 +472,19 @@ Enabling and disabling notations
    :n:`@string`
       Notations to enable or disable. :n:`@string` can be a single
       token in the notation such as "`->`" or a pattern that matches
-      the notation. See :ref:`locating-notations`.
+      the notation. See :ref:`locating-notations`. If no :n:`{? :=
+      @one_term }` is given, the variables of the notation can be
+      replaced by :n:`_`.
 
-   :n:`@qualid`
-      :ref:`Abbreviation <Abbreviations>` to enable or disable.
+   :n:`@qualid {* @ident__parm }`
+      :ref:`Abbreviation <Abbreviations>` to enable or disable, where :n:`{* @ident__parm }` are the parameters of the abbreviation. See :cmd:`Notation (abbreviation)`.
 
    :n:`{? := @one_term }`
       Enable or disable notations matching :token:`one_term`.
       :token:`one_term` can be written using notations or not, as well
-      as :n:`_`, just like in the :cmd:`Notation` command.
+      as :n:`_`, just like in the :cmd:`Notation` command. If no
+      :n:`@string` nor :n:`@qualid {* @ident__parm }` is given, the
+      variables of the notation can be replaced by :n:`_`.
 
    :n:`all`
       Enable or disable all notations meeting the given constraints,

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -472,12 +472,14 @@ Enabling and disabling notations
    :n:`@string`
       Notations to enable or disable. :n:`@string` can be a single
       token in the notation such as "`->`" or a pattern that matches
-      the notation. See :ref:`locating-notations`. If no :n:`{? :=
-      @one_term }` is given, the variables of the notation can be
+      the notation. See :ref:`locating-notations`. If no
+      :n:`{? := @one_term }` is given, the variables of the notation can be
       replaced by :n:`_`.
 
    :n:`@qualid {* @ident__parm }`
-      :ref:`Abbreviation <Abbreviations>` to enable or disable, where :n:`{* @ident__parm }` are the parameters of the abbreviation. See :cmd:`Notation (abbreviation)`.
+      Enable or disable :ref:`abbreviations <Abbreviations>` whose
+      absolute name has :n:`@qualid` as a suffix. The :n:`{* @ident__parm }`
+      are the parameters of the abbreviation.
 
    :n:`{? := @one_term }`
       Enable or disable notations matching :token:`one_term`.
@@ -528,9 +530,9 @@ Enabling and disabling notations
       Use :n:`all` to allow enabling or disabling multiple
       notations in a single command.
 
-   .. exn:: Not an abbreviation.
+   .. exn:: Unknown custom entry.
 
-      No abbreviation matches the given :token:`qualid`.
+      In :n:`in custom @ident`, :token:`ident` is not a valid custom entry name.
 
    .. exn:: No notation provided.
 
@@ -545,6 +547,14 @@ Enabling and disabling notations
    .. warn:: Activation of abbreviations does not expect mentioning a scope.
 
       Scopes are not compatible with :ref:`abbreviations <Abbreviations>`.
+
+   .. example:: Enabling and disabling notations
+
+      .. coqtop:: all
+
+         Disable Notation "+" (all).
+         Enable Notation "_ + _" (all) : type_scope.
+         Disable Notation "x + y" := (sum x y).
 
 Displaying information about notations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1458,7 +1458,7 @@ enable_notation_flag: [
 | "all"
 | "only" "parsing"
 | "only" "printing"
-| "in" "custom" IDENT
+| "in" "custom" identref
 | "in" "constr"
 ]
 

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1440,7 +1440,7 @@ enable_enable_disable: [
 
 enable_notation_rule: [
 | ne_string
-| global
+| global LIST0 ident
 |
 ]
 

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1107,7 +1107,7 @@ command: [
 | "Notation" string ":=" one_term OPT ( "(" LIST1 syntax_modifier SEP "," ")" ) OPT [ ":" scope_name ]
 | "Reserved" "Infix" string OPT ( "(" LIST1 syntax_modifier SEP "," ")" )
 | "Reserved" "Notation" string OPT ( "(" LIST1 syntax_modifier SEP "," ")" )
-| [ "Enable" | "Disable" ] "Notation" OPT [ string | qualid ] OPT ( ":=" one_term ) OPT ( "(" LIST1 enable_notation_flag SEP "," ")" ) OPT [ ":" scope_name | ":" "no" "scope" ]
+| [ "Enable" | "Disable" ] "Notation" OPT [ string | qualid LIST0 ident ] OPT ( ":=" one_term ) OPT ( "(" LIST1 enable_notation_flag SEP "," ")" ) OPT [ ":" scope_name | ":" "no" "scope" ]
 | "Eval" red_expr "in" term
 | "Compute" term
 | "Check" term

--- a/interp/abbreviation.mli
+++ b/interp/abbreviation.mli
@@ -25,6 +25,8 @@ val search_filtered_abbreviation : ?loc:Loc.t ->
 
 val import_abbreviation : int -> Libnames.full_path -> KerName.t -> unit
 
+(** Activate (if on:true) or deactivate (if on:false) an abbreviation assumed to exist *)
 val toggle_abbreviation : on:bool -> use:notation_use -> abbreviation -> unit
 
-val toggle_abbreviations : on:bool -> use:notation_use -> (KerName.t -> interpretation -> bool) -> unit
+(** Activate (if on:true) or deactivate (if on:false) all abbreviations satisfying a criterion *)
+val toggle_abbreviations : on:bool -> use:notation_use -> (Libnames.full_path -> interpretation -> bool) -> unit

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -276,7 +276,7 @@ type 'a notation_query_pattern_gen = {
     interpretation_pattern : interpretation option;
   }
 
-type notation_query_pattern = Globnames.abbreviation notation_query_pattern_gen
+type notation_query_pattern = qualid notation_query_pattern_gen
 
 val toggle_notations : on:bool -> all:bool -> (glob_constr -> Pp.t) -> notation_query_pattern -> unit
 

--- a/library/libnames.ml
+++ b/library/libnames.ml
@@ -134,6 +134,12 @@ let repr_qualid {CAst.v=qid} = repr_path qid
 
 let qualid_eq qid1 qid2 = eq_full_path qid1.CAst.v qid2.CAst.v
 
+let is_qualid_suffix_of_full_path
+    CAst.{v={dirpath=dirpath1;basename=basename1}} {dirpath=dirpath2;basename=basename2} =
+  let dir1 = DirPath.repr dirpath1 in
+  let dir2 = DirPath.repr dirpath2 in
+  Id.equal basename1 basename2 && List.prefix_of Id.equal dir1 dir2
+
 let string_of_qualid qid = string_of_path qid.CAst.v
 let pr_qualid qid = pr_path qid.CAst.v
 

--- a/library/libnames.mli
+++ b/library/libnames.mli
@@ -66,6 +66,7 @@ val make_qualid : ?loc:Loc.t -> DirPath.t -> Id.t -> qualid
 val repr_qualid : qualid -> DirPath.t * Id.t
 
 val qualid_eq : qualid -> qualid -> bool
+val is_qualid_suffix_of_full_path : qualid -> full_path -> bool
 
 val pr_qualid : qualid -> Pp.t
 val string_of_qualid : qualid -> string

--- a/library/nametab.ml
+++ b/library/nametab.ml
@@ -225,6 +225,9 @@ let push visibility uname o tab =
     let ptab = modify () empty_tree in
     Id.Map.add id ptab tab
 
+(** [remove_path uname tree dir] removes all bindings pointing to
+    [uname] along the path [dir] in [tree] (i.e. all such bindings are
+    assumed to be on this path) *)
 
 let rec remove_path uname tree = function
   | modid :: path ->
@@ -246,6 +249,8 @@ let rec remove_path uname tree = function
         List.filter test tree.path
       in
       mktree this tree.map
+
+(** Remove all bindings pointing to [uname] in [tab] *)
 
 let remove uname tab =
   let id,dir = U.repr uname in

--- a/test-suite/output/Notations5.out
+++ b/test-suite/output/Notations5.out
@@ -321,19 +321,19 @@ fun a : T => match a with
              end
      : T -> nat
 The following notations have been disabled:
-Notation "x + y" := (Nat.add x y)
+Notation "x + y" := (Nat.add x y) : nat_scope
 Nat.add 0 0
      : nat
 File "./output/Notations5.v", line 414, characters 11-12:
 The command has indeed failed with message:
 The term "0" has type "nat" while it is expected to have type "Type".
 The following notations have been disabled:
-Notation "x + y" := (sum x y)
+Notation "x + y" := (sum x y) : type_scope
 File "./output/Notations5.v", line 417, characters 11-16:
 The command has indeed failed with message:
 Unknown interpretation for notation "_ + _".
 The following notations have been disabled:
-Notation f
+Notation Notations5.Activation.f x := (Some x)
 Some 0
      : option nat
 File "./output/Notations5.v", line 424, characters 11-12:

--- a/test-suite/output/activation.out
+++ b/test-suite/output/activation.out
@@ -1,22 +1,60 @@
 The following notations have been disabled:
-Notation "x + y" := (Nat.add x y)
+Notation "x + y" := (Nat.add x y) : nat_scope
+File "./output/activation.v", line 5, characters 0-47:
+The command has indeed failed with message:
+More than one interpretation bound to this notation, confirm with the "all"
+modifier.
+The following notations have been disabled:
+Notation "x * y" := (Nat.mul x y) : nat_scope
+Notation "x * y" := (Nat.mul x y) (in custom foo)
+The following notations have been enabled:
+Notation "x * y" := (Nat.mul x y) : nat_scope
 The following notations have been disabled:
 Notation "'exists2' x : A , p & q" := (ex2 (fun x => p) (fun x => q))
+  : type_scope
 Notation "'exists2' x , p & q" := (ex2 (fun x => p) (fun x => q))
+  : type_scope
 Notation "'exists2' ' x : A , p & q" := (ex2 (fun x => p) (fun x => q))
+  : type_scope
 Notation "'exists2' ' x , p & q" := (ex2 (fun x => p) (fun x => q))
+  : type_scope
 The following notations have been disabled:
-Notation "x <= y <= z" := (and (le x y) (le y z))
-Notation "x <= y < z" := (and (le x y) (lt y z))
-Notation "n <= m" := (le n m)
-Notation "x < y <= z" := (and (lt x y) (le y z))
+Notation "x <= y <= z" := (and (le x y) (le y z)) : nat_scope
+Notation "x <= y < z" := (and (le x y) (lt y z)) : nat_scope
+Notation "n <= m" := (le n m) : nat_scope
+Notation "x < y <= z" := (and (lt x y) (le y z)) : nat_scope
 The following notations have been disabled:
-Notation "x >= y" := (ge x y)
-Notation "x > y" := (gt x y)
-Notation "x < y < z" := (and (lt x y) (lt y z))
-Notation "x < y" := (lt x y)
-Notation "x - y" := (Nat.sub x y)
-Notation "x * y" := (Nat.mul x y)
-File "./output/activation.v", line 5, characters 0-22:
+Notation "x >= y" := (ge x y) : nat_scope
+Notation "x > y" := (gt x y) : nat_scope
+Notation "x < y < z" := (and (lt x y) (lt y z)) : nat_scope
+Notation "x < y" := (lt x y) : nat_scope
+Notation "x - y" := (Nat.sub x y) : nat_scope
+Notation "x * y" := (Nat.mul x y) : nat_scope
+File "./output/activation.v", line 12, characters 0-22:
 The command has indeed failed with message:
 No notation provided.
+File "./output/activation.v", line 15, characters 0-24:
+The command has indeed failed with message:
+Found no matching notation to enable or disable.
+The following notations have been disabled:
+Notation activation.Abbrev.f w := (S w)
+The following notations have been enabled:
+Notation activation.Abbrev.f w := (S w)
+The following notations have been disabled:
+Notation activation.Abbrev.A.a := Prop
+a
+     : Type
+The following notations have been disabled:
+Notation activation.Abbrev.a := Prop
+File "./output/activation.v", line 24, characters 11-12:
+The command has indeed failed with message:
+The reference a was not found in the current environment.
+Prop
+     : Type
+The following notations have been enabled:
+Notation activation.Abbrev.a := Prop
+Notation activation.Abbrev.A.a := Prop
+a
+     : Type
+a
+     : Type

--- a/test-suite/output/activation.v
+++ b/test-suite/output/activation.v
@@ -1,5 +1,29 @@
-Disable Notation "_ + _" := (Nat.add _ _).
+Disable Notation "x + y" := (Nat.add x y).
+
+Declare Custom Entry foo.
+Notation "x * y" := (Nat.mul x y) (in custom foo at level 0).
+Fail Disable Notation "x * y" := (Nat.mul x y). (* need flag all *)
+Disable Notation "x * y" := (Nat.mul x y) (all).
+Enable Notation := (Nat.mul _ _) : nat_scope.
+
 Disable Notation := ex2 (all).
 Disable Notation "<=" (all).
 Disable Notation (all) : nat_scope.
 Fail Disable Notation.
+
+Module Abbrev.
+Fail Disable Notation f. (* no abbreviation with such suffix *)
+Notation f w := (S w).
+Disable Notation f w := (S w).
+Enable Notation := (S _).
+
+Module A. Notation a := Prop. End A. Include A.
+Disable Notation A.a.
+Check a.
+Disable Notation a.
+Fail Check a.
+Check Prop.
+Enable Notation a (all). (* Note: reactivation is not necessarily in the same order as it was earlier *)
+Check a.
+Check Prop.
+End Abbrev.

--- a/test-suite/output/onlyprinting.out
+++ b/test-suite/output/onlyprinting.out
@@ -28,18 +28,18 @@ Bound to class nat
 "x + y" := (Nat.add x y)
 "x * y" := (Nat.mul x y)
 The following notations have been disabled:
-Notation "x +_c y" := (Nat.add x y)
+Notation "x +_c y" := (Nat.add x y) : nat_scope
 1 +_b 2
      : nat
 The following notations have been disabled:
-Notation "x +_b y" := (Nat.add x y)
+Notation "x +_b y" := (Nat.add x y) : nat_scope
 1 +_a 2
      : nat
 The following notations have been disabled for printing:
-Notation "x +_a y" := (Nat.add x y)
+Notation "x +_a y" := (Nat.add x y) : nat_scope
 1 + 2
      : nat
 The following notations have been enabled for printing:
-Notation "x +_c y" := (Nat.add x y)
+Notation "x +_c y" := (Nat.add x y) : nat_scope
 1 +_c 2
      : nat

--- a/tools/coqdoc/cpretty.mll
+++ b/tools/coqdoc/cpretty.mll
@@ -410,6 +410,10 @@ let notation_kw =
   | "Infix"
   | "Reserved" space+ "Notation"
   | "Reserved" space+ "Infix"
+  | "Number" space+ "Notation"
+  | "String" space+ "Notation"
+  | "Enable" space+ "Notation"
+  | "Disable" space+ "Notation"
 
 let commands =
   "Pwd"

--- a/tools/coqdoc/output.ml
+++ b/tools/coqdoc/output.ml
@@ -44,7 +44,7 @@ let is_keyword =
       "Induction"; "for"; "Sort"; "Section"; "Show"; "Structure"; "Syntactic"; "Syntax"; "Tactic"; "Theorem";
       "Search"; "SearchPattern"; "SearchRewrite";
       "Set"; "Types"; "Undo"; "Unset"; "Variable"; "Variables"; "Context";
-      "Notation"; "Reserved Notation"; "Tactic Notation";
+      "Notation"; "Reserved Notation"; "Tactic Notation"; "Number Notation"; "String Notation"; "Enable Notation"; "Disable Notation";
       "Delimit"; "Bind"; "Open"; "Scope"; "Inline";
       "Implicit Arguments"; "Add"; "Strict";
       "Typeclasses"; "Instance"; "Global Instance"; "Class"; "Instantiation";

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -1247,7 +1247,7 @@ GRAMMAR EXTEND Gram
   ;
   enable_notation_rule:
     [ [ s = ne_string -> { Some (Inl s) }
-      | qid = global -> { Some (Inr qid) }
+      | qid = global; idl = LIST0 ident -> { Some (Inr (idl,qid)) }
       | -> { None } ] ]
   ;
   enable_notation_interpretation:

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -1262,8 +1262,8 @@ GRAMMAR EXTEND Gram
     [ [ IDENT "all" -> { EnableNotationAll }
       | IDENT "only"; IDENT "parsing" -> { EnableNotationOnly Notationextern.OnlyParsing }
       | IDENT "only"; IDENT "printing" -> { EnableNotationOnly Notationextern.OnlyPrinting }
-      | "in"; IDENT "custom"; x = IDENT -> { EnableNotationEntry (InCustomEntry x) }
-      | "in"; IDENT "constr" -> { EnableNotationEntry InConstrEntry } ] ]
+      | "in"; IDENT "custom"; x = identref -> { EnableNotationEntry CAst.(make ?loc:x.loc (InCustomEntry (Id.to_string x.v))) }
+      | "in"; IDENT "constr" -> { EnableNotationEntry (CAst.make ~loc InConstrEntry) } ] ]
   ;
   opt_scope:
     [ [ ":"; sc = IDENT -> { Some (NotationInScope sc) }

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1918,7 +1918,13 @@ let cache_notation_toggle o =
   load_notation_toggle 1 o;
   open_notation_toggle 1 o
 
-let subst_notation_toggle (subst,x) = x (* TODO: pat *)
+let subst_notation_toggle (subst,(local,(on,all,pat))) =
+  let {notation_entry_pattern; interp_rule_key_pattern; use_pattern;
+       scope_pattern; interpretation_pattern} = pat in
+  let interpretation_pattern = Option.map (subst_interpretation subst) interpretation_pattern in
+  let interp_rule_key_pattern = Option.map (Union.map (fun x -> x) (Mod_subst.subst_kn subst)) interp_rule_key_pattern in
+  (local,(on,all,{notation_entry_pattern; interp_rule_key_pattern; use_pattern;
+                  scope_pattern; interpretation_pattern}))
 
 let classify_notation_toggle (local,_) =
   if local then Dispose else Substitute

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1673,10 +1673,6 @@ let make_use reserved onlyparse onlyprint =
 (**********************************************************************)
 (* Main functions about notations                                     *)
 
-let to_map l =
-  let fold accu (x, v) = Id.Map.add x v accu in
-  List.fold_left fold Id.Map.empty l
-
 let make_notation_interpretation ~local main_data notation_symbols ntn syntax_rules df env ?(impls=empty_internalization_env) c scope =
   let {recvars;mainvars;symbols} = notation_symbols in
   (* Recover types of variables and pa/pp rules; redeclare them if needed *)
@@ -1694,8 +1690,8 @@ let make_notation_interpretation ~local main_data notation_symbols ntn syntax_ru
   let df' = ntn, (path,df) in
   let i_vars = make_internalization_vars recvars i_typs in
   let nenv = {
-    ninterp_var_type = to_map i_vars;
-    ninterp_rec_vars = to_map recvars;
+    ninterp_var_type = Id.Map.of_list i_vars;
+    ninterp_rec_vars = Id.Map.of_list recvars;
   } in
   let (acvars, ac, reversibility) = interp_notation_constr env ~impls nenv c in
   let plevel = match level with Some (from,level,l) -> level | None (* numeral: irrelevant )*) -> 0 in

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1922,7 +1922,7 @@ let subst_notation_toggle (subst,(local,(on,all,pat))) =
   let {notation_entry_pattern; interp_rule_key_pattern; use_pattern;
        scope_pattern; interpretation_pattern} = pat in
   let interpretation_pattern = Option.map (subst_interpretation subst) interpretation_pattern in
-  let interp_rule_key_pattern = Option.map (Union.map (fun x -> x) (Mod_subst.subst_kn subst)) interp_rule_key_pattern in
+  let interp_rule_key_pattern = interp_rule_key_pattern in
   (local,(on,all,{notation_entry_pattern; interp_rule_key_pattern; use_pattern;
                   scope_pattern; interpretation_pattern}))
 

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -785,8 +785,8 @@ let pr_vernac_expr v =
     )
   | VernacEnableNotation (on,rule,interp,flags,scope) ->
     let pr_flag = function
-      | EnableNotationEntry InConstrEntry -> str "in constr"
-      | EnableNotationEntry (InCustomEntry s) -> str "in custom " ++ str s
+      | EnableNotationEntry CAst.{v=InConstrEntry} -> str "in constr"
+      | EnableNotationEntry CAst.{v=InCustomEntry s} -> str "in custom " ++ str s
       | EnableNotationOnly OnlyParsing -> str "only parsing"
       | EnableNotationOnly OnlyPrinting -> str "only printing"
       | EnableNotationOnly ParsingAndPrinting -> assert false

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -186,6 +186,9 @@ let pr_notation_entry = function
   | InConstrEntry -> keyword "constr"
   | InCustomEntry s -> keyword "custom" ++ spc () ++ str s
 
+let pr_abbreviation pr (ids, c) =
+  pr c ++ spc () ++ prlist_with_sep spc pr_id ids
+
 let pr_at_level = function
   | NumLevel n -> spc () ++ keyword "at" ++ spc () ++ keyword "level" ++ spc () ++ int n
   | NextLevel -> spc () ++ keyword "at" ++ spc () ++ keyword "next" ++ spc () ++ keyword "level"
@@ -794,7 +797,7 @@ let pr_vernac_expr v =
     let pr_rule = match rule with
       | None -> mt ()
       | Some (Inl ntn) -> quote (str ntn)
-      | Some (Inr qid) -> pr_qualid qid in
+      | Some (Inr abbrev) -> pr_abbreviation pr_qualid abbrev in
     let pr_opt_scope = function
       | None -> mt ()
       | Some (NotationInScope s) -> spc () ++ str ": " ++ str s
@@ -1129,8 +1132,7 @@ let pr_vernac_expr v =
   | VernacSyntacticDefinition (id,(ids,c),l) ->
     return (
       hov 2
-        (keyword "Notation" ++ spc () ++ pr_lident id ++ spc () ++
-         prlist_with_sep spc pr_id ids ++ str":=" ++ pr_constrarg c ++
+        (keyword "Notation" ++ spc () ++ pr_abbreviation pr_lident (ids,id) ++ str":=" ++ pr_constrarg c ++
          pr_syntax_modifiers l)
     )
   | VernacArguments (q, args, more_implicits, mods) ->

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -542,13 +542,11 @@ let interp_enable_notation_rule on ntn interp flags scope =
   let open Notation in
   let rule = Option.map (function
     | Inl ntn -> Inl (interpret_notation_string ntn)
-    | Inr (_,qid) ->
-      match Nametab.locate_extended qid with
-      | Globnames.TrueGlobal _ -> user_err (str "Not an abbreviation.")
-      | Globnames.Abbrev kn -> Inr kn) ntn in
+    | Inr (vars,qid) -> Inr qid) ntn in
   let rec parse_notation_enable_flags all query = function
     | [] -> all, query
-    | EnableNotationEntry entry :: flags ->
+    | EnableNotationEntry CAst.{loc;v=entry} :: flags ->
+      (match entry with InCustomEntry s when not (Egramcoq.exists_custom_entry s) -> user_err ?loc (str "Unknown custom entry.") | _ -> ());
       parse_notation_enable_flags all { query with notation_entry_pattern = entry :: query.notation_entry_pattern } flags
     | EnableNotationOnly use :: flags ->
       parse_notation_enable_flags all { query with use_pattern = use } flags

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -356,7 +356,7 @@ type nonrec vernac_expr =
       infix_flag * constr_expr * (lstring * syntax_modifier CAst.t list) *
       scope_name option
   | VernacDeclareCustomEntry of string
-  | VernacEnableNotation of bool * (string, qualid) Util.union option * constr_expr option * notation_enable_modifier list * notation_with_optional_scope option
+  | VernacEnableNotation of bool * (string, Id.t list * qualid) Util.union option * constr_expr option * notation_enable_modifier list * notation_with_optional_scope option
 
   (* Gallina *)
   | VernacDefinition of (discharge * Decls.definition_object_kind) * name_decl * definition_expr

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -158,7 +158,7 @@ type syntax_modifier =
   | SetFormat of notation_format
 
 type notation_enable_modifier =
-  | EnableNotationEntry of notation_entry
+  | EnableNotationEntry of notation_entry CAst.t
   | EnableNotationOnly of Notationextern.notation_use
   | EnableNotationAll
 


### PR DESCRIPTION
[Updated 9/12/22]

This is a follow-up to #12324, filling two forgotten TODO:
- `subst` function for disable/enable commands,
- requiring commands of the form `Disable Notation "_ + _" := (Nat.add _ _)."` to be written `Disable Notation "x + y" := (Nat.add x y)."`,

fixing two bugs: 
  - anomaly if a custom entry name did not exist,
  - abbreviation name sometimes wrongly printed with quotes around (in the result of commands such as `Disable Notation abbrev := body`),

adding the following enhancements:
- extension of the syntax of `Disable Notation f := (...)` to `Disable Notation f x := (... x ...).`, i.e. with possibly a list of arguments,
- in the results,  now printing the scope (if any) and custom entry (if not constr), which is consistent I think with the scope and entry name being usable as a selection criterion,
- in the results, now printing the interpretation of abbreviations, consistently with what is done with parsing notations,
- slightly refining the documentaion,

changing the semantics for selecting abbreviations:
- when a name is given, it is not any longer supposed to denote the abbreviation bound to this name in the nametab but any abbreviation whose full name ends with the given name (this is more consistent with what happens for parsing notations and it makes reactivation easier, see discussion [below](https://github.com/coq/coq/pull/16945#issuecomment-1344096604)).

- [x] Added / updated test-suite
- [x] Added / updated **documentation**.
  - [x] Updated **documented syntax** by running `make doc_gram_rsts`.
