### PR TITLE
Separate interpretation and syntax declaration in tactic notations

### DIFF
--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -2115,8 +2115,6 @@ ltac2_occs_nums: [
 ltac2_entry: [
 | REPLACE tac2def_typ      (* Ltac2 plugin *)
 | WITH "Ltac2" tac2def_typ
-| REPLACE tac2def_syn      (* Ltac2 plugin *)
-| WITH "Ltac2" tac2def_syn
 | REPLACE tac2def_mut      (* Ltac2 plugin *)
 | WITH "Ltac2" tac2def_mut
 | REPLACE tac2def_val     (* Ltac2 plugin *)
@@ -2145,6 +2143,7 @@ SPLICE: [
 | tac2def_typ
 | tac2def_ext
 | tac2def_syn
+| ltac2def_syn
 | tac2def_mut
 | rec_flag
 | locident

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -697,6 +697,7 @@ command: [
 | "Number" "Notation" reference reference reference OPT number_options ":" preident
 | "String" "Notation" reference reference reference OPT string_option ":" preident
 | "Ltac2" ltac2_entry      (* ltac2 plugin *)
+| "Ltac2" "Notation" ltac2def_syn      (* ltac2 plugin *)
 | "Ltac2" "Eval" ltac2_expr6      (* ltac2 plugin *)
 | "Print" "Ltac2" reference      (* ltac2 plugin *)
 | "Locate" "Ltac2" reference      (* ltac2 plugin *)
@@ -3561,7 +3562,7 @@ syn_level: [
 ]
 
 tac2def_syn: [
-| "Notation" LIST1 ltac2_scope syn_level ":=" ltac2_expr6      (* ltac2 plugin *)
+| LIST1 ltac2_scope syn_level ":=" ltac2_expr6      (* ltac2 plugin *)
 ]
 
 lident: [
@@ -3938,8 +3939,11 @@ ltac2_entry: [
 | tac2def_val      (* ltac2 plugin *)
 | tac2def_typ      (* ltac2 plugin *)
 | tac2def_ext      (* ltac2 plugin *)
-| tac2def_syn      (* ltac2 plugin *)
 | tac2def_mut      (* ltac2 plugin *)
+]
+
+ltac2def_syn: [
+| tac2def_syn      (* ltac2 plugin *)
 ]
 
 ltac2_expr: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1118,7 +1118,7 @@ command: [
 | "Ltac2" OPT "mutable" OPT "rec" tac2def_body LIST0 ( "with" tac2def_body )
 | "Ltac2" "Type" OPT "rec" tac2typ_def LIST0 ( "with" tac2typ_def )
 | "Ltac2" "@" "external" ident ":" ltac2_type ":=" string string
-| "Ltac2" "Notation" LIST1 ltac2_scope OPT ( ":" natural ) ":=" ltac2_expr
+| "Ltac2" "Notation" LIST1 ltac2_scope OPT ( ":" natural ) ":=" ltac2_expr      (* ltac2 plugin *)
 | "Ltac2" "Set" qualid OPT [ "as" ident ] ":=" ltac2_expr
 | "Ltac2" "Notation" [ string | lident ] ":=" ltac2_expr      (* Ltac2 plugin *)
 | "Ltac2" "Eval" ltac2_expr      (* ltac2 plugin *)

--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -467,7 +467,9 @@ VERNAC COMMAND EXTEND VernacTacticNotation
   { VtSideff ([], VtNow) } ->
   {
     let n = Option.default 0 n in
-    Tacentries.add_tactic_notation (Locality.make_module_locality locality) n ?deprecation r e;
+    let local = Locality.make_module_locality locality in
+    let tacobj = Tacentries.add_tactic_notation_syntax local n ?deprecation r in
+    Tacentries.add_tactic_notation ?deprecation tacobj e
   }
 END
 

--- a/plugins/ltac/tacentries.mli
+++ b/plugins/ltac/tacentries.mli
@@ -25,6 +25,8 @@ type 'a grammar_tactic_prod_item_expr = 'a Pptactic.grammar_tactic_prod_item_exp
 | TacTerm of string
 | TacNonTerm of ('a * Names.Id.t option) Loc.located
 
+type tactic_grammar_obj
+
 type raw_argument = string * string option
 (** An argument type as provided in Tactic notations, i.e. a string like
     "ne_foo_list_opt" together with a separator that only makes sense in the
@@ -35,11 +37,16 @@ type argument = Genarg.ArgT.any Extend.user_symbol
     leaves. *)
 
 val add_tactic_notation :
-  locality_flag -> int -> ?deprecation:Deprecation.t -> raw_argument
-  grammar_tactic_prod_item_expr list -> raw_tactic_expr -> unit
+  ?deprecation:Deprecation.t -> tactic_grammar_obj ->
+  raw_tactic_expr -> unit
 (** [add_tactic_notation local level prods expr] adds a tactic notation in the
     environment at level [level] with locality [local] made of the grammar
     productions [prods] and returning the body [expr] *)
+
+val add_tactic_notation_syntax :
+  locality_flag -> int -> ?deprecation:Deprecation.t -> raw_argument
+  grammar_tactic_prod_item_expr list ->
+  tactic_grammar_obj
 
 val register_tactic_notation_entry : string -> ('a, 'b, 'c) Genarg.genarg_type -> unit
 (** Register an argument under a given entry name for tactic notations. When

--- a/plugins/ltac2/g_ltac2.mlg
+++ b/plugins/ltac2/g_ltac2.mlg
@@ -437,9 +437,9 @@ GRAMMAR EXTEND Gram
     ] ]
   ;
   tac2def_syn:
-    [ [ "Notation"; toks = LIST1 ltac2_scope; n = syn_level; ":=";
+    [ [ toks = LIST1 ltac2_scope; n = syn_level; ":=";
         e = ltac2_expr ->
-        { StrSyn (toks, n, e) }
+        { (toks, n, e) }
     ] ]
   ;
   lident:
@@ -960,8 +960,12 @@ PRINTED BY { pr_ltac2entry }
 | [ tac2def_val(v) ] -> { v }
 | [ tac2def_typ(t) ] -> { t }
 | [ tac2def_ext(e) ] -> { e }
-| [ tac2def_syn(e) ] -> { e }
 | [ tac2def_mut(e) ] -> { e }
+END
+
+VERNAC ARGUMENT EXTEND ltac2def_syn
+PRINTED BY { pr_ltac2entry }
+| [ tac2def_syn(e) ] -> { e }
 END
 
 VERNAC ARGUMENT EXTEND ltac2_expr
@@ -969,17 +973,15 @@ PRINTED BY { pr_ltac2expr }
 | [ _ltac2_expr(e) ] -> { e }
 END
 
-{
-
-let classify_ltac2 = function
-| StrSyn _ -> Vernacextend.(VtSideff ([], VtNow))
-| StrMut _ | StrVal _ | StrPrm _  | StrTyp _ -> Vernacextend.classify_as_sideeff
-
-}
-
 VERNAC COMMAND EXTEND VernacDeclareTactic2Definition
-| #[ raw_attributes ] [ "Ltac2" ltac2_entry(e) ] => { classify_ltac2 e } -> {
+| #[ raw_attributes ] [ "Ltac2" ltac2_entry(e) ] => { Vernacextend.classify_as_sideeff } -> {
   Tac2entries.register_struct raw_attributes e
+  }
+| #[ raw_attributes ] [ "Ltac2" "Notation" ltac2def_syn(e) ] => { Vernacextend.(VtSideff ([], VtNow)) } ->
+  {
+    let (toks, n, body) = e in
+    let synterpv = Tac2entries.register_notation raw_attributes toks n body in
+    Tac2entries.register_notation_interpretation synterpv
   }
 | ![proof_opt_query] [ "Ltac2" "Eval" ltac2_expr(e) ] => { Vernacextend.classify_as_query } -> {
   fun ~pstate -> Tac2entries.perform_eval ~pstate e

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -628,8 +628,8 @@ end
 let parse_scope = ParseToken.parse_scope
 
 type synext = {
+  synext_kn : KerName.t;
   synext_tok : sexpr list;
-  synext_exp : raw_tacexpr;
   synext_lev : int;
   synext_loc : bool;
   synext_depr : Deprecation.t option;
@@ -679,7 +679,7 @@ let perform_notation syn st =
       ((CAst.make ?loc:e.loc @@ CPatVar na), e)
     in
     let bnd = List.map map args in
-    CAst.make ~loc @@ CTacLet (false, bnd, syn.synext_exp)
+    CAst.make ~loc @@ CTacSyn (bnd, syn.synext_kn)
   in
   let rule = Pcoq.Production.make rule (act mk) in
   let pos = Some (string_of_int syn.synext_lev) in
@@ -700,8 +700,9 @@ let open_synext i syn =
   if Int.equal i 1 then Pcoq.extend_grammar_command ltac2_notation syn
 
 let subst_synext (subst, syn) =
-  let e = Tac2intern.subst_rawexpr subst syn.synext_exp in
-  if e == syn.synext_exp then syn else { syn with synext_exp = e }
+  let kn = Mod_subst.subst_kn subst syn.synext_kn in
+  if kn == syn.synext_kn then syn
+  else { syn with synext_kn = kn }
 
 let classify_synext o =
   if o.synext_loc then Dispose else Substitute
@@ -715,6 +716,28 @@ let inTac2Notation : synext -> obj =
      open_function   = simple_open ~cat:ltac2_notation_cat open_synext;
      subst_function = subst_synext;
      classify_function = classify_synext}
+
+let cache_synext_interp (local,kn,tac) =
+  Tac2env.define_notation kn tac
+
+let open_synext_interp i o =
+  if Int.equal i 1 then cache_synext_interp o
+
+let subst_synext_interp (subst, (local,kn,tac as o)) =
+  let tac' = Tac2intern.subst_rawexpr subst tac in
+  let kn' = Mod_subst.subst_kn subst kn in
+  if kn' == kn && tac' == tac then o else
+  (local, kn', tac')
+
+let classify_synext_interp (local,_,_) =
+  if local then Dispose else Substitute
+
+let inTac2NotationInterp : (bool*KerName.t*raw_tacexpr) -> obj =
+  declare_object {(default_object "TAC2-NOTATION-INTERP") with
+     cache_function  = cache_synext_interp;
+     open_function   = simple_open ~cat:ltac2_notation_cat open_synext_interp;
+     subst_function = subst_synext_interp;
+     classify_function = classify_synext_interp}
 
 type abbreviation = {
   abbr_body : raw_tacexpr;
@@ -747,41 +770,77 @@ let inTac2Abbreviation : Id.t -> abbreviation -> obj =
      subst_function = subst_abbreviation;
      classify_function = classify_abbreviation}
 
-let register_notation ?deprecation ?(local = false) tkn lev body = match tkn, lev with
-| [SexprRec (_, {loc;v=Some id}, [])], None ->
-  (* Tactic abbreviation *)
-  let () = check_lowercase CAst.(make ?loc id) in
-  let body = Tac2intern.globalize Id.Set.empty body in
-  let abbr = { abbr_body = body; abbr_depr = deprecation } in
-  Lib.add_leaf (inTac2Abbreviation id abbr)
-| _ ->
-  (* Check that the tokens make sense *)
-  let entries = List.map ParseToken.parse_token tkn in
-  let fold accu tok = match tok with
-  | TacTerm _ -> accu
-  | TacNonTerm (Name id, _) -> Id.Set.add id accu
-  | TacNonTerm (Anonymous, _) -> accu
-  in
-  let ids = List.fold_left fold Id.Set.empty entries in
-  (* Globalize so that names are absolute *)
-  let body = Tac2intern.globalize ids body in
-  let lev = match lev with
-  | Some n ->
-    let () =
-      if n < 0 || n > 6 then
-        user_err (str "Notation levels must range between 0 and 6")
+let rec string_of_scope = function
+| SexprStr s -> Printf.sprintf "str(%s)" s.CAst.v
+| SexprInt i -> Printf.sprintf "int(%i)" i.CAst.v
+| SexprRec (_, {v=na}, []) -> Option.cata Id.to_string "_" na
+| SexprRec (_, {v=na}, e) ->
+  Printf.sprintf "%s(%s)" (Option.cata Id.to_string "_" na) (String.concat " " (List.map string_of_scope e))
+
+let string_of_token = function
+| SexprStr {v=s} -> Printf.sprintf "str(%s)" s
+| SexprRec (_, {v=na}, [tok]) -> string_of_scope tok
+| _ -> assert false
+
+let make_fresh_key tokens =
+  let prods = String.concat "_" (List.map string_of_token tokens) in
+  (* We embed the hash of the kernel name in the label so that the identifier
+      should be mostly unique. This ensures that including two modules
+      together won't confuse the corresponding labels. *)
+  let hash = (ModPath.hash (Lib.current_mp ())) land 0x7FFFFFFF in
+  let lbl = Id.of_string_soft (Printf.sprintf "%s_%08X" prods hash) in
+  Lib.make_kn lbl
+
+type notation_interpretation_data =
+| Abbreviation of Id.t * Deprecation.t option * raw_tacexpr
+| Synext of bool * KerName.t * Id.Set.t * raw_tacexpr
+
+let register_notation atts tkn lev body =
+  let deprecation, local = Attributes.(parse Notations.(deprecation ++ locality)) atts in
+  let local = Option.default false local in
+  match tkn, lev with
+  | [SexprRec (_, {loc;v=Some id}, [])], None ->
+    (* Tactic abbreviation *)
+    let () = check_lowercase CAst.(make ?loc id) in
+    Abbreviation(id, deprecation, body)
+  | _ ->
+    (* Check that the tokens make sense *)
+    let entries = List.map ParseToken.parse_token tkn in
+    let fold accu tok = match tok with
+    | TacTerm _ -> accu
+    | TacNonTerm (Name id, _) -> Id.Set.add id accu
+    | TacNonTerm (Anonymous, _) -> accu
     in
-    n
-  | None -> 5
-  in
-  let ext = {
-    synext_tok = tkn;
-    synext_exp = body;
-    synext_lev = lev;
-    synext_loc = local;
-    synext_depr = deprecation;
-  } in
-  Lib.add_leaf (inTac2Notation ext)
+    let ids = List.fold_left fold Id.Set.empty entries in
+    (* Globalize so that names are absolute *)
+    let lev = match lev with
+    | Some n ->
+      let () =
+        if n < 0 || n > 6 then
+          user_err (str "Notation levels must range between 0 and 6")
+      in
+      n
+    | None -> 5
+    in
+    let key = make_fresh_key tkn in
+    let ext = {
+      synext_kn = key;
+      synext_tok = tkn;
+      synext_lev = lev;
+      synext_loc = local;
+      synext_depr = deprecation;
+    } in
+    Lib.add_leaf (inTac2Notation ext);
+    Synext (local,key,ids,body)
+
+let register_notation_interpretation = function
+  | Abbreviation (id, deprecation, body) ->
+    let body = Tac2intern.globalize Id.Set.empty body in
+    let abbr = { abbr_body = body; abbr_depr = deprecation } in
+    Lib.add_leaf (inTac2Abbreviation id abbr)
+  | Synext (local,kn,ids,body) ->
+    let body = Tac2intern.globalize ids body in
+    Lib.add_leaf (inTac2NotationInterp (local,kn,body))
 
 type redefinition = {
   redef_kn : ltac_constant;
@@ -905,9 +964,6 @@ let register_struct atts str = match str with
   check_modtype "externals";
   let deprecation, local = Attributes.(parse Notations.(deprecation ++ locality)) atts in
   register_primitive ?deprecation ?local id t ml
-| StrSyn (tok, lev, e) ->
-  let deprecation, local = Attributes.(parse Notations.(deprecation ++ locality)) atts in
-  register_notation ?deprecation ?local tok lev e
 | StrMut (qid, old, e) ->
   let () = Attributes.unsupported_attributes atts in
   register_redefinition qid old e

--- a/plugins/ltac2/tac2entries.mli
+++ b/plugins/ltac2/tac2entries.mli
@@ -25,8 +25,12 @@ val register_primitive : ?deprecation:Deprecation.t -> ?local:bool ->
 
 val register_struct : Attributes.vernac_flags -> strexpr -> unit
 
-val register_notation : ?deprecation:Deprecation.t -> ?local:bool -> sexpr list ->
-  int option -> raw_tacexpr -> unit
+type notation_interpretation_data
+
+val register_notation : Attributes.vernac_flags -> sexpr list ->
+  int option -> raw_tacexpr -> notation_interpretation_data
+
+val register_notation_interpretation : notation_interpretation_data -> unit
 
 val perform_eval : pstate:Declare.Proof.t option -> raw_tacexpr -> unit
 

--- a/plugins/ltac2/tac2env.ml
+++ b/plugins/ltac2/tac2env.ml
@@ -59,6 +59,8 @@ let empty_state = {
 
 let ltac_state = Summary.ref empty_state ~name:"ltac2-state"
 
+let ltac_notations = Summary.ref KNmap.empty ~stage:Summary.Stage.Synterp ~name:"ltac2-notations"
+
 let define_global kn e =
   let state = !ltac_state in
   ltac_state := { state with ltac_tactics = KNmap.add kn e state.ltac_tactics }
@@ -93,6 +95,11 @@ let define_alias ?deprecation kn tac =
   ltac_state := { state with ltac_aliases = KNmap.add kn data state.ltac_aliases }
 
 let interp_alias kn = KNmap.find kn ltac_state.contents.ltac_aliases
+
+let define_notation kn tac =
+  ltac_notations := KNmap.add kn tac !ltac_notations
+
+let interp_notation kn = KNmap.find kn !ltac_notations
 
 module ML =
 struct

--- a/plugins/ltac2/tac2env.mli
+++ b/plugins/ltac2/tac2env.mli
@@ -83,6 +83,11 @@ type alias_data = {
 val define_alias : ?deprecation:Deprecation.t -> ltac_constant -> raw_tacexpr -> unit
 val interp_alias : ltac_constant -> alias_data
 
+(** {5 Toplevel definition of notations} *)
+
+val define_notation : ltac_notation -> raw_tacexpr -> unit
+val interp_notation : ltac_notation -> raw_tacexpr
+
 (** {5 Name management} *)
 
 val push_ltac : visibility -> full_path -> tacref -> unit

--- a/plugins/ltac2/tac2expr.mli
+++ b/plugins/ltac2/tac2expr.mli
@@ -19,6 +19,7 @@ type uid = Id.t
 
 type ltac_constant = KerName.t
 type ltac_alias = KerName.t
+type ltac_notation = KerName.t
 type ltac_constructor = KerName.t
 type ltac_projection = KerName.t
 type type_constant = KerName.t
@@ -106,6 +107,7 @@ type raw_tacexpr_r =
 | CTacCst of ltac_constructor or_tuple or_relid
 | CTacFun of raw_patexpr list * raw_tacexpr
 | CTacApp of raw_tacexpr * raw_tacexpr list
+| CTacSyn of (raw_patexpr * raw_tacexpr) list * KerName.t
 | CTacLet of rec_flag * (raw_patexpr * raw_tacexpr) list * raw_tacexpr
 | CTacCnv of raw_tacexpr * raw_typexpr
 | CTacSeq of raw_tacexpr * raw_tacexpr
@@ -202,8 +204,6 @@ type strexpr =
   (** Type definition *)
 | StrPrm of Names.lident * raw_typexpr * ml_tactic_name
   (** External definition *)
-| StrSyn of sexpr list * int option * raw_tacexpr
-  (** Syntactic extensions *)
 | StrMut of qualid * Names.lident option * raw_tacexpr
   (** Redefinition of mutable globals *)
 

--- a/plugins/ltac2/tac2intern.ml
+++ b/plugins/ltac2/tac2intern.ml
@@ -1123,6 +1123,9 @@ let rec intern_rec env {loc;v=e} = match e with
   let ids = List.fold_left fold Id.Set.empty el in
   if is_rec then intern_let_rec env loc ids el e
   else intern_let env loc ids el e
+| CTacSyn (el, kn) ->
+  let body = Tac2env.interp_notation kn in
+  intern_rec env @@ CAst.make ?loc @@ CTacLet(false, el, body)
 | CTacCnv (e, tc) ->
   let (e, t) = intern_rec env e in
   let tc = intern_type env tc in
@@ -1505,6 +1508,9 @@ let rec globalize ids ({loc;v=er} as e) = match er with
   in
   let bnd = List.map map bnd in
   CAst.make ?loc @@ CTacLet (isrec, bnd, e)
+| CTacSyn (el, kn) ->
+  let body = Tac2env.interp_notation kn in
+  globalize ids @@ CAst.make ?loc @@ CTacLet(false, el, body)
 | CTacCnv (e, t) ->
   let e = globalize ids e in
   CAst.make ?loc @@ CTacCnv (e, t)
@@ -1782,6 +1788,9 @@ let rec subst_rawexpr subst ({loc;v=tr} as t) = match tr with
   let bnd' = List.Smart.map map bnd in
   let e' = subst_rawexpr subst e in
   if bnd' == bnd && e' == e then t else CAst.make ?loc @@ CTacLet (isrec, bnd', e')
+| CTacSyn (el, kn) ->
+  let body = Tac2env.interp_notation kn in
+  subst_rawexpr subst @@ CAst.make ?loc @@ CTacLet(false, el, body)
 | CTacCnv (e, c) ->
   let e' = subst_rawexpr subst e in
   let c' = subst_rawtype subst c in


### PR DESCRIPTION
This change separates syntax and interpretation declaration in the tactic notation APIs (of Ltac1 and Ltac2).

This is a step towards #15409.
