### PR TITLE
Define a dummy replacement for Obj.set_tag for OCaml 5.

### DIFF
--- a/kernel/byterun/coq_values.c
+++ b/kernel/byterun/coq_values.c
@@ -8,6 +8,7 @@
 /*                                                                     */
 /***********************************************************************/
 
+#include <stdlib.h>
 #include <stdio.h>
 #include <caml/memory.h>
 #include "coq_fix_code.h"
@@ -95,4 +96,15 @@ value coq_tcode_array(value tcodes) {
     Store_field(res, i, tmp);
   }
   CAMLreturn(res);
+}
+
+CAMLprim value coq_obj_set_tag (value arg, value new_tag)
+{
+#if OCAML_VERSION >= 50000
+// Placeholder used by native_compute
+  abort();
+#else
+  Tag_val (arg) = Int_val (new_tag);
+#endif
+  return Val_unit;
 }

--- a/kernel/nativevalues.ml
+++ b/kernel/nativevalues.ml
@@ -122,20 +122,22 @@ let ret_accu = Obj.repr (ref ())
 
 type accu_val = { mutable acc_atm : atom; acc_arg : Obj.t list }
 
+external set_tag : Obj.t -> int -> unit = "coq_obj_set_tag"
+
 let mk_accu (a : atom) : t =
   let rec accumulate data x =
     if x == ret_accu then Obj.repr data
     else
       let data = { data with acc_arg = x :: data.acc_arg } in
       let ans = Obj.repr (accumulate data) in
-      let () = Obj.set_tag ans accumulate_tag [@ocaml.warning "-3"] in
+      let () = set_tag ans accumulate_tag in
       ans
   in
   let acc = { acc_atm = a; acc_arg = [] } in
   let ans = Obj.repr (accumulate acc) in
   (** FIXME: use another representation for accumulators, this causes naked
       pointers. *)
-  let () = Obj.set_tag ans accumulate_tag [@ocaml.warning "-3"] in
+  let () = set_tag ans accumulate_tag in
   (Obj.obj ans : t)
 
 let get_accu (k : accumulator) =


### PR DESCRIPTION
Since it is a trivial C function, I implemented our own version directly in the VM runtime C files. This saves introducing some dune trickery to pick a file by OCaml version. It works locally on my machine (with the additional tweaks of #15494).

cc @silene 