### PR TITLE
match dune `coq_flags` in `_CoqProject` (`-w +default`)

### DIFF
--- a/theories/Init/_CoqProject
+++ b/theories/Init/_CoqProject
@@ -1,2 +1,3 @@
 -R .. Coq
+-arg -w -arg +default
 -arg -noinit

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -1,1 +1,2 @@
 -R . Coq
+-arg -w -arg +default


### PR DESCRIPTION
Deprecation warnings used to be enabled only during build, not interactive editing. This change fixes that discrepency. I omitted `-q` from `_CoqProject` even though it appears in `dune printenv` on the basis that other developers may be relying on the rcfile for customization.

Tested manually with Coqtail through `dune exec -- sh -c 'env PATH="$PWD/dev/shim:$PATH" vim theories/Init/Datatypes.v'` and just `vim theories/Init/Datatypes.v` to  confirm that `Check prodT_curry` fails at the end of the file with this change and succeeds without this change.