### PR TITLE
Make lazy_val use local to vmsymtable

### DIFF
--- a/dev/ci/user-overlays/16958-SkySkimmer-no-lazy-val.sh
+++ b/dev/ci/user-overlays/16958-SkySkimmer-no-lazy-val.sh
@@ -1,0 +1,1 @@
+overlay serapi https://github.com/SkySkimmer/coq-serapi no-lazy-val 16958

--- a/dev/doc/critical-bugs
+++ b/dev/doc/critical-bugs
@@ -417,6 +417,17 @@ Conversion machines
   GH issue number: #16829
   risk: some if using primitive arrays
 
+  component: "virtual" reduction machine
+  summary: tactic code could mutate a global cache of values for section variables
+  introduced: V8.1
+  impacted released versions: V8.1-V8.16.1
+  impacted coqchk versions: none (no tactics in coqchk, VM only sees checked terms)
+  fixed in: V8.17.0
+  found by: Gaëtan Gilbert with hint from Pierre-Marie Pédrot
+  GH issue number: #16957
+  risk: the full exploitation seems to require "Definition := ltac:()"
+        with change_no_check on a section variable in the ltac
+
 Side-effects
 
   component: side-effects

--- a/doc/changelog/01-kernel/16958-no-lazy-val.rst
+++ b/doc/changelog/01-kernel/16958-no-lazy-val.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  inconsistency linked to ``vm_compute``. The fix removes a vulnerable cache which may result in slowdowns when ``vm_compute`` is used repeatedly, if you encounter such slowdowns please report your use case
+  (`#16958 <https://github.com/coq/coq/pull/16958>`_,
+  fixes `#16957 <https://github.com/coq/coq/issues/16957>`_,
+  by Gaëtan Gilbert).

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -981,7 +981,7 @@ let map_rel_context_in_env f env sign =
   aux env [] (List.rev sign)
 
 let match_named_context_val :
-  named_context_val -> (named_declaration * lazy_val * named_context_val) option =
+  named_context_val -> (named_declaration * named_context_val) option =
   match unsafe_eq with
   | Refl -> match_named_context_val
 

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -392,7 +392,7 @@ val map_rel_context_in_env :
   (env -> constr -> constr) -> env -> rel_context -> rel_context
 
 val match_named_context_val :
-  named_context_val -> (named_declaration * lazy_val * named_context_val) option
+  named_context_val -> (named_declaration * named_context_val) option
 
 val identity_subst_val : named_context_val -> t SList.t
 

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -318,7 +318,7 @@ let push_rel_decl_to_named_context
   in
   let rec replace_var_named_declaration id0 id nc = match match_named_context_val nc with
   | None -> empty_named_context_val
-  | Some (decl, _, nc) ->
+  | Some (decl, nc) ->
     if Id.equal id0 (NamedDecl.get_id decl) then
       (* Stop here, the variable cannot occur before its definition *)
       push_named_context_val (NamedDecl.set_id id decl) nc
@@ -592,18 +592,7 @@ let clear_hyps_in_evi_main env sigma hyps terms ids =
       let err = OccurHypInSimpleClause (Some (NamedDecl.get_id decl)) in
       NamedDecl.map_constr (check_and_clear_in_constr ~is_section_variable env evdref err ids ~global) decl
     in
-    let check_value vk = match force_lazy_val vk with
-    | None -> vk
-    | Some (_, d) ->
-      if (Id.Set.for_all (fun e -> not (Id.Set.mem e d)) ids) then
-        (* v does depend on any of ids, it's ok *)
-        vk
-      else
-        (* v depends on one of the cleared hyps:
-            we forget the computed value *)
-        dummy_lazy_val ()
-    in
-      remove_hyps ids check_context check_value hyps
+    remove_hyps ids check_context hyps
   in
   (!evdref, nhyps,List.map EConstr.of_constr terms)
 

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -509,7 +509,7 @@ let ref_value_cache env flags mode tab ref =
           | RelKey n ->
             let open! Context.Rel.Declaration in
             let i = n - 1 in
-            let (d, _) =
+            let d =
               try Range.get env.env_rel_context.env_rel_map i
               with Invalid_argument _ -> raise Not_found
             in

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -28,12 +28,6 @@ open Declarations
    - a set of universe constraints
    - a flag telling if Set is, can be, or cannot be set impredicative *)
 
-type lazy_val
-
-val build_lazy_val : lazy_val -> (Vmvalues.values * Id.Set.t) -> unit
-val force_lazy_val : lazy_val -> (Vmvalues.values * Id.Set.t) option
-val dummy_lazy_val : unit -> lazy_val
-
 (** Linking information for the native compiler *)
 type link_info =
   | Linked of string
@@ -60,7 +54,7 @@ end
 
 type named_context_val = private {
   env_named_ctx : Constr.named_context;
-  env_named_map : (Constr.named_declaration * lazy_val) Id.Map.t;
+  env_named_map : Constr.named_declaration Id.Map.t;
   (** Identifier-indexed version of [env_named_ctx] *)
   env_named_idx : Constr.named_declaration Range.t;
   (** Same as env_named_ctx but with a fast-access list. *)
@@ -68,7 +62,7 @@ type named_context_val = private {
 
 type rel_context_val = private {
   env_rel_ctx : Constr.rel_context;
-  env_rel_map : (Constr.rel_declaration * lazy_val) Range.t;
+  env_rel_map : Constr.rel_declaration Range.t;
 }
 
 type env = private {
@@ -127,7 +121,6 @@ val push_rec_types   : rec_declaration -> env -> env
 (** Looks up in the context of local vars referred by indice ([rel_context])
    raises [Not_found] if the index points out of the context *)
 val lookup_rel    : int -> env -> Constr.rel_declaration
-val lookup_rel_val : int -> env -> lazy_val
 val evaluable_rel : int -> env -> bool
 val env_of_rel     : int -> env -> env
 
@@ -161,7 +154,6 @@ val push_named_context_val  :
    raises [Not_found] if the Id.t is not found *)
 
 val lookup_named     : variable -> env -> Constr.named_declaration
-val lookup_named_val : variable -> env -> lazy_val
 val lookup_named_ctxt : variable -> named_context_val -> Constr.named_declaration
 val evaluable_named  : variable -> env -> bool
 val named_type : variable -> env -> types
@@ -172,7 +164,7 @@ val named_body : variable -> env -> constr option
 val fold_named_context :
   (env -> Constr.named_declaration -> 'a -> 'a) -> env -> init:'a -> 'a
 
-val match_named_context_val : named_context_val -> (named_declaration * lazy_val * named_context_val) option
+val match_named_context_val : named_context_val -> (named_declaration * named_context_val) option
 
 (** Recurrence on [named_context] starting from younger decl *)
 val fold_named_context_reverse :
@@ -406,7 +398,7 @@ val apply_to_hyp : named_context_val -> variable ->
   (Constr.named_context -> Constr.named_declaration -> Constr.named_context -> Constr.named_declaration) ->
     named_context_val
 
-val remove_hyps : Id.Set.t -> (Constr.named_declaration -> Constr.named_declaration) -> (lazy_val -> lazy_val) -> named_context_val -> named_context_val
+val remove_hyps : Id.Set.t -> (Constr.named_declaration -> Constr.named_declaration) -> named_context_val -> named_context_val
 
 val is_polymorphic : env -> Names.GlobRef.t -> bool
 val is_template_polymorphic : env -> GlobRef.t -> bool

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -791,7 +791,7 @@ let () = define3 "constr_in_context" ident constr closure begin fun id t c ->
     let sigma = Proofview.Goal.sigma gl in
     let has_var =
       try
-        let _ = Environ.lookup_named_val id env in
+        let _ = Environ.lookup_named id env in
         true
       with Not_found -> false
     in

--- a/proofs/logic.ml
+++ b/proofs/logic.ml
@@ -165,7 +165,7 @@ let split_sign env sigma hfrom l =
   let () = if not (mem_id_context hfrom l) then error_no_such_hypothesis env sigma hfrom in
   let rec splitrec left sign = match EConstr.match_named_context_val sign with
   | None -> assert false
-  | Some (d, _, right) ->
+  | Some (d, right) ->
     let hyp = NamedDecl.get_id d in
     if Id.equal hyp hfrom then (left, right, d)
     else splitrec (d :: left) right
@@ -209,9 +209,9 @@ let move_hyp env sigma toleft (left,declfrom,right) hto =
   in
   let rec moverec_toright first middle depvars right = match EConstr.match_named_context_val right with
     | None -> push_rev first @@ push_rev middle right
-    | Some (d, _, _) when move_location_eq hto (MoveBefore (NamedDecl.get_id d)) ->
+    | Some (d, _) when move_location_eq hto (MoveBefore (NamedDecl.get_id d)) ->
         push_rev first @@ push_rev middle @@ right
-    | Some (d, _, right) ->
+    | Some (d, right) ->
         let hyp = NamedDecl.get_id d in
         let (first', middle', depvars') =
           if Id.Set.mem hyp depvars then

--- a/test-suite/bugs/bug_16957.v
+++ b/test-suite/bugs/bug_16957.v
@@ -1,0 +1,64 @@
+Module Test1.
+
+  Goal True.
+  Proof.
+    evar (x:nat).
+    generalize (eq_refl:x = x).
+    vm_compute.
+    intros _.
+    generalize (eq_refl:x + 1 = x + 1).
+    let x := constr:(eq_refl : x = 0) in idtac.
+    vm_compute.
+    (* vm_compute still thinks variable x is defined to an undefined evar, so computes to a blocked fix *)
+
+    match goal with |- 1 = 1 -> True => idtac end.
+  Abort.
+
+  Goal False.
+  Proof.
+    evar (x:nat).
+    assert_succeeds (
+        let y := constr:(eq_refl : x = 1) in
+        generalize (eq_refl:x = x);
+        vm_compute).
+    (* vm_compute now believes x = 1 *)
+    generalize (eq_refl:x = 0).
+    vm_compute.
+    match goal with |- 0 = 0 -> False => idtac end.
+  Abort.
+
+End Test1.
+
+Module Test2.
+  Section S.
+
+    Let x := 0.
+
+    (* Notes:
+     - using a Proof. instead of ltac:() would make the context go through
+       Declare.initialize_named_context_for_proof which renews the lazy_vals
+       and so prevents proof time mutation from affecting the kernel.
+     - we could use the previous examples of the bug to get a variable y := false
+       but believed by vm_compute to be true, then use that to get change to turn
+       x := 0 into x := 1 up to vm_compute.
+       However change goes through Logic.reorder_val_context which renewes the lazy_vals
+       before we can get vm_compute to believe in x := 1.
+       Since this means we have to use change_no_check, we don't bother with the trickery
+       and just change 0 with 1.
+     *)
+    Fail Definition foo : x = 1
+      := ltac:(
+                 change_no_check 0 with 1 in x;
+                 vm_compute;
+                 reflexivity).
+
+  End S.
+End Test2.
+
+Module Test3.
+  Section S.
+    Let x := 0.
+    Fail Definition foo : x = 1 := ltac:(change_no_check 0 with 1 in x; vm_compute).
+    Fail Definition foo : x = 1 := ltac:(vm_cast_no_check (eq_refl 1)).
+  End S.
+End Test3.


### PR DESCRIPTION
Fix #16957

This may make the vm slower if called repeatedly in a section where variables take long to evaluate.

Overlay: 
- https://github.com/ejgallego/coq-serapi/pull/297