### PR TITLE
Remove Unification.unsafe_occur_meta_or_existential

### DIFF
--- a/dev/ci/user-overlays/16960-SkySkimmer-rm-unsafe-occur-metaevar.sh
+++ b/dev/ci/user-overlays/16960-SkySkimmer-rm-unsafe-occur-metaevar.sh
@@ -1,0 +1,1 @@
+overlay fiat_crypto_legacy https://github.com/SkySkimmer/fiat-crypto rm-unsafe-occur-metaevar 16960

--- a/doc/changelog/04-tactics/16960-rm-unsafe-occur-metaevar.rst
+++ b/doc/changelog/04-tactics/16960-rm-unsafe-occur-metaevar.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  unification is less sensitive to whether a subterm is
+  an indirection through a defined existential variable or a direct term node.
+  This results in less constant unfoldings in rare cases
+  (`#16960 <https://github.com/coq/coq/pull/16960>`_,
+  by Gaëtan Gilbert).

--- a/test-suite/bugs/bug_16960.v
+++ b/test-suite/bugs/bug_16960.v
@@ -21,7 +21,8 @@ Axiom Q : forall (n : Z) (Wdecoder : decoder n W), Type.
 Lemma is_Q {n decode }
   : Q (1 * n) (@tuple_decoder n decode 1).
 Proof.
-  apply tuple_decoder_1.
+  Fail apply tuple_decoder_1.
+  refine (tuple_decoder_1 _).
 (* master: no goals remain
 this PR: Error: Found no subterm matching "(Z.of_nat 1 * n)%Z" in the current goal. *)
 Qed.


### PR DESCRIPTION
It was marked as needs to be unsafe when econstr was introduced, hopefully it can be removed now.

Overlay:
- https://github.com/mit-plv/fiat-crypto/pull/1574