### PR TITLE
Clean the bytecode interpreter

### DIFF
--- a/kernel/byterun/coq_fix_code.c
+++ b/kernel/byterun/coq_fix_code.c
@@ -25,9 +25,17 @@
 #include "coq_fix_code.h"
 
 #ifdef THREADED_CODE
-char ** coq_instr_table;
-char * coq_instr_base;
+
+static char ** coq_instr_table;
+static char * coq_instr_base;
 #define VALINSTR(instr) ((opcode_t)(coq_instr_table[instr] - coq_instr_base))
+
+void coq_init_thread_code(void ** instr_table, void * instr_base)
+{
+  coq_instr_table = (char **) instr_table;
+  coq_instr_base = (char *) instr_base;
+}
+
 #else
 #define VALINSTR(instr) instr
 #endif /*  THREADED_CODE */

--- a/kernel/byterun/coq_fix_code.c
+++ b/kernel/byterun/coq_fix_code.c
@@ -27,6 +27,9 @@
 #ifdef THREADED_CODE
 char ** coq_instr_table;
 char * coq_instr_base;
+#define VALINSTR(instr) ((opcode_t)(coq_instr_table[instr] - coq_instr_base))
+#else
+#define VALINSTR(instr) instr
 #endif /*  THREADED_CODE */
 
 int coq_is_instruction(opcode_t instr1, opcode_t instr2)
@@ -39,6 +42,19 @@ void * coq_stat_alloc (asize_t sz)
   void * result = malloc (sz);
   if (result == NULL) caml_raise_out_of_memory ();
   return result;
+}
+
+static opcode_t accu_instr;
+code_t accumulate = &accu_instr;
+
+value coq_accumulate(value unit)
+{
+  CAMLparam1(unit);
+  CAMLlocal1(res);
+  accu_instr = VALINSTR(ACCUMULATE);
+  res = caml_alloc_small(1, Abstract_tag);
+  Code_val(res) = accumulate;
+  CAMLreturn(res);
 }
 
 value coq_makeaccu (value i) {

--- a/kernel/byterun/coq_fix_code.c
+++ b/kernel/byterun/coq_fix_code.c
@@ -29,6 +29,10 @@ char ** coq_instr_table;
 char * coq_instr_base;
 #endif /*  THREADED_CODE */
 
+int coq_is_instruction(opcode_t instr1, opcode_t instr2)
+{
+  return instr1 == VALINSTR(instr2);
+}
 
 void * coq_stat_alloc (asize_t sz)
 {
@@ -68,13 +72,6 @@ value coq_pushpop (value i) {
     *q = VALINSTR(STOP);
     CAMLreturn(res);
   }
-}
-
-value coq_is_accumulate_code(value code){
-  code_t q = Code_val(code);
-  int res;
-  res = Is_instruction(q,ACCUMULATE);
-  return Val_bool(res);
 }
 
 #ifdef ARCH_BIG_ENDIAN

--- a/kernel/byterun/coq_fix_code.h
+++ b/kernel/byterun/coq_fix_code.h
@@ -16,8 +16,7 @@
 void * coq_stat_alloc (asize_t sz);
 
 #ifdef THREADED_CODE
-extern char ** coq_instr_table;
-extern char * coq_instr_base;
+void coq_init_thread_code(void ** instr_table, void * instr_base);
 #endif /*  THREADED_CODE */
 
 extern code_t accumulate;

--- a/kernel/byterun/coq_fix_code.h
+++ b/kernel/byterun/coq_fix_code.h
@@ -23,12 +23,10 @@ extern char * coq_instr_base;
 #define VALINSTR(instr) instr
 #endif /*  THREADED_CODE */
 
-#define Is_instruction(pc,instr) (*pc == VALINSTR(instr))
-
+int coq_is_instruction(opcode_t, opcode_t);
 value coq_tcode_of_code(value code);
 value coq_makeaccu (value i);
 value coq_pushpop (value i);
 value coq_accucond (value i);
-value coq_is_accumulate_code(value code);
 
 #endif /* _COQ_FIX_CODE_ */

--- a/kernel/byterun/coq_fix_code.h
+++ b/kernel/byterun/coq_fix_code.h
@@ -18,13 +18,13 @@ void * coq_stat_alloc (asize_t sz);
 #ifdef THREADED_CODE
 extern char ** coq_instr_table;
 extern char * coq_instr_base;
-#define VALINSTR(instr) ((opcode_t)(coq_instr_table[instr] - coq_instr_base))
-#else
-#define VALINSTR(instr) instr
 #endif /*  THREADED_CODE */
+
+extern code_t accumulate;
 
 int coq_is_instruction(opcode_t, opcode_t);
 value coq_tcode_of_code(value code);
+value coq_accumulate(value);
 value coq_makeaccu (value i);
 value coq_pushpop (value i);
 value coq_accucond (value i);

--- a/kernel/byterun/coq_interp.c
+++ b/kernel/byterun/coq_interp.c
@@ -91,9 +91,9 @@ sp is a local copy of the global variable extern_sp. */
 /* #define _COQ_DEBUG_ */
 
 #ifdef _COQ_DEBUG_
-#   define print_instr(s) /*if (drawinstr)*/ printf("%s\n",s)
-#   define print_int(i)   /*if (drawinstr)*/ printf("%d\n",i)
-#   define print_lint(i)  /*if (drawinstr)*/ printf("%ld\n",i)
+#   define print_instr(s) printf("%s\n",s)
+#   define print_int(i)   printf("%d\n",i)
+#   define print_lint(i)  printf("%ld\n",i)
 # else
 #   define print_instr(s)
 #   define print_int(i)

--- a/kernel/byterun/coq_interp.c
+++ b/kernel/byterun/coq_interp.c
@@ -73,9 +73,9 @@ sp is a local copy of the global variable extern_sp. */
 #ifdef THREADED_CODE
 #  define Instruct(name) coq_lbl_##name:
 #  if defined(ARCH_SIXTYFOUR) && !defined(ARCH_CODE32)
-#    define coq_Jumptbl_base ((char *) &&coq_lbl_ACC0)
+#    define coq_Jumptbl_base &&coq_lbl_ACC0
 #  else
-#    define coq_Jumptbl_base ((char *) 0)
+#    define coq_Jumptbl_base 0
 #    define coq_jumptbl_base ((char *) 0)
 #  endif
 #  ifdef DEBUG
@@ -297,8 +297,7 @@ value coq_interprete
   if (coq_pc == NULL) {           /* Interpreter is initializing */
     print_instr("Interpreter is initializing");
 #ifdef THREADED_CODE
-    coq_instr_table = (char **) coq_jumptable;
-    coq_instr_base = coq_Jumptbl_base;
+    coq_init_thread_code(coq_jumptable, coq_Jumptbl_base);
 #endif
     CAMLreturn(Val_unit);
   }

--- a/kernel/byterun/coq_memory.c
+++ b/kernel/byterun/coq_memory.c
@@ -32,9 +32,7 @@ value * coq_stack_low;
 value * coq_stack_high;
 value * coq_stack_threshold;
 asize_t coq_max_stack_size = Coq_max_stack_size;
-/* global_data */
 
-int drawinstr;
 /* interp state */
 
 long coq_saved_sp_offset;
@@ -103,7 +101,6 @@ value init_coq_vm(value unit) /* ML */
   if (coq_vm_initialized == 1) {
     fprintf(stderr,"already open \n");fflush(stderr);}
   else {
-    drawinstr=0;
     /* Allocate the table of global and the stack */
     init_coq_stack();
     /* Initialing the interpreter */
@@ -144,10 +141,3 @@ void realloc_coq_stack(asize_t required_space)
   coq_sp = new_sp;
 #undef shift
 }
-
-value coq_set_drawinstr(value unit)
-{
-  drawinstr = 1;
-  return Val_unit;
-}
-

--- a/kernel/byterun/coq_memory.c
+++ b/kernel/byterun/coq_memory.c
@@ -39,8 +39,6 @@ int drawinstr;
 
 long coq_saved_sp_offset;
 value * coq_sp;
-/* Some predefined pointer code */
-code_t accumulate;
 
 /* functions over global environment */
 
@@ -52,15 +50,6 @@ void coq_stat_free (void * blk)
 value coq_static_alloc(value size) /* ML */
 {
   return (value) coq_stat_alloc((asize_t) Long_val(size));
-}
-
-value accumulate_code(value unit) /* ML */
-{
-  CAMLparam1(unit);
-  CAMLlocal1(res);
-  res = caml_alloc_small(1, Abstract_tag);
-  Code_val(res) = accumulate;
-  CAMLreturn(res);
 }
 
 #if OCAML_VERSION < 50000
@@ -119,18 +108,6 @@ value init_coq_vm(value unit) /* ML */
     init_coq_stack();
     /* Initialing the interpreter */
     init_coq_interpreter();
-
-    /* Some predefined pointer code.
-     * It is typically contained in accumulator blocks and thus might be
-     * scanned by the GC, so make it look like an OCaml block. */
-    value accu_block = (value) coq_stat_alloc(2 * sizeof(value));
-#if OCAML_VERSION < 50000
-    Hd_hp (accu_block) = Make_header (1, Abstract_tag, Caml_black);
-#else
-    Hd_hp (accu_block) = Make_header (1, Abstract_tag, NOT_MARKABLE);
-#endif
-    accumulate = (code_t) Val_hp(accu_block);
-    *accumulate = VALINSTR(ACCUMULATE);
 
   /* Initialize GC */
     if (coq_prev_scan_roots_hook == NULL)

--- a/kernel/byterun/coq_memory.c
+++ b/kernel/byterun/coq_memory.c
@@ -80,38 +80,32 @@ static void coq_scan_roots(scanning_action action, scanning_action_flags flags, 
 }
 #endif
 
-void init_coq_stack()
-{
-  coq_stack_low = (value *) coq_stat_alloc(Coq_stack_size);
-  coq_stack_high = coq_stack_low + Coq_stack_size / sizeof (value);
-  coq_stack_threshold = coq_stack_low + Coq_stack_threshold / sizeof(value);
-  coq_max_stack_size = Coq_max_stack_size;
-}
-
-void init_coq_interpreter()
-{
-  coq_sp = coq_stack_high;
-  coq_interprete(NULL, Val_unit, Atom(0), Atom(0), Val_unit, 0);
-}
-
 static int coq_vm_initialized = 0;
 
 value init_coq_vm(value unit) /* ML */
 {
-  if (coq_vm_initialized == 1) {
-    fprintf(stderr,"already open \n");fflush(stderr);}
-  else {
-    /* Allocate the table of global and the stack */
-    init_coq_stack();
-    /* Initialing the interpreter */
-    init_coq_interpreter();
+  if (coq_vm_initialized) {
+    fprintf(stderr, "already open\n");
+    fflush(stderr);
+    return Val_unit;
+  }
+
+  /* Allocate the table of global and the stack */
+  coq_stack_low = (value *) coq_stat_alloc(Coq_stack_size);
+  coq_stack_high = coq_stack_low + Coq_stack_size / sizeof (value);
+  coq_stack_threshold = coq_stack_low + Coq_stack_threshold / sizeof(value);
+  coq_max_stack_size = Coq_max_stack_size;
+
+  /* Initialize the interpreter */
+  coq_sp = coq_stack_high;
+  coq_interprete(NULL, Val_unit, Atom(0), Atom(0), Val_unit, 0);
 
   /* Initialize GC */
-    if (coq_prev_scan_roots_hook == NULL)
-      coq_prev_scan_roots_hook = caml_scan_roots_hook;
-    caml_scan_roots_hook = coq_scan_roots;
-    coq_vm_initialized = 1;
-  }
+  if (coq_prev_scan_roots_hook == NULL)
+    coq_prev_scan_roots_hook = caml_scan_roots_hook;
+  caml_scan_roots_hook = coq_scan_roots;
+  coq_vm_initialized = 1;
+
   return Val_unit;;
 }
 

--- a/kernel/byterun/coq_memory.h
+++ b/kernel/byterun/coq_memory.h
@@ -44,9 +44,7 @@ extern value * coq_sp;
 value coq_static_alloc(value size);  /* ML */
 
 value init_coq_vm(value unit); /* ML */
-value re_init_coq_vm(value unit); /* ML */
 
 void  realloc_coq_stack(asize_t required_space);
-value coq_set_transp_value(value transp); /* ML */
-value get_coq_transp_value(value unit); /* ML */
+
 #endif /* _COQ_MEMORY_ */

--- a/kernel/byterun/coq_memory.h
+++ b/kernel/byterun/coq_memory.h
@@ -39,8 +39,6 @@ extern int drawinstr;
 /* interp state */
 
 extern value * coq_sp;
-/* Some predefined pointer code */
-extern code_t accumulate;
 
 /* functions over global environment */
 

--- a/kernel/byterun/coq_memory.h
+++ b/kernel/byterun/coq_memory.h
@@ -35,7 +35,6 @@ extern value * coq_stack_threshold;
 
 extern int coq_all_transp;
 
-extern int drawinstr;
 /* interp state */
 
 extern value * coq_sp;
@@ -51,6 +50,3 @@ void  realloc_coq_stack(asize_t required_space);
 value coq_set_transp_value(value transp); /* ML */
 value get_coq_transp_value(value unit); /* ML */
 #endif /* _COQ_MEMORY_ */
-
-
-value coq_set_drawinstr(value unit);

--- a/kernel/byterun/coq_values.c
+++ b/kernel/byterun/coq_values.c
@@ -21,6 +21,8 @@
 #define Setup_for_gc
 #define Restore_after_gc
 
+#define Is_instruction(c, i) coq_is_instruction(*c, i)
+
 value coq_kind_of_closure(value v) {
   opcode_t * c;
   int is_app = 0;
@@ -32,6 +34,13 @@ value coq_kind_of_closure(value v) {
   return Val_int(0);
 }
 
+value coq_is_accumulate_code(value code)
+{
+  code_t q = Code_val(code);
+  int res;
+  res = Is_instruction(q,ACCUMULATE);
+  return Val_bool(res);
+}
 
 /* DESTRUCT ACCU */
 

--- a/kernel/vm.ml
+++ b/kernel/vm.ml
@@ -11,8 +11,6 @@
 open Values
 open Vmvalues
 
-external set_drawinstr : unit -> unit = "coq_set_drawinstr"
-
 external mkPopStopCode : int -> tcode = "coq_pushpop"
 
 let popstop_tbl =  ref (Array.init 30 mkPopStopCode)

--- a/kernel/vm.mli
+++ b/kernel/vm.mli
@@ -10,10 +10,6 @@
 
 open Vmvalues
 
-(** Debug printing *)
-
-val set_drawinstr : unit -> unit
-
 val reduce_fix : int -> vfix -> vfun array * values array
                               (** bodies ,  types *)
 

--- a/kernel/vmvalues.ml
+++ b/kernel/vmvalues.ml
@@ -355,7 +355,7 @@ type vm_closure_kind =
 external kind_of_closure : Obj.t -> vm_closure_kind = "coq_kind_of_closure"
 external is_accumulate : tcode -> bool = "coq_is_accumulate_code"
 external int_tcode : tcode -> int -> int = "coq_int_tcode"
-external accumulate : unit -> tcode = "accumulate_code"
+external accumulate : unit -> tcode = "coq_accumulate"
 external set_bytecode_field : Obj.t -> int -> tcode -> unit = "coq_set_bytecode_field"
 let accumulate = accumulate ()
 


### PR DESCRIPTION
This pull request moves some functions around, so as to reduce the interdependence between the C files of the bytecode interpreter. It also gets rid of some bitrotten unused code. The C files now have a clearer purpose:

- `coq_memory.c` focuses on handling the stack of the bytecode interpreter,
- `coq_fix_code.c` focuses on linking bytecode and generating builtin closures,
- `coq_values.c` deals with decompiling closures when classifying values.

This supersedes #16943.

Fixes / closes #16426