### PR TITLE
Warn when plugins look up references at linking time

### DIFF
--- a/dev/ci/user-overlays/16966-SkySkimmer-plugin-check-lib-ref.sh
+++ b/dev/ci/user-overlays/16966-SkySkimmer-plugin-check-lib-ref.sh
@@ -1,0 +1,7 @@
+overlay metacoq https://github.com/SkySkimmer/metacoq plugin-check-lib-ref 16966
+
+overlay mtac2 https://github.com/SkySkimmer/Mtac2 plugin-check-lib-ref 16966
+
+overlay coqhammer https://github.com/SkySkimmer/coqhammer plugin-check-lib-ref 16966
+
+overlay quickchick https://github.com/SkySkimmer/QuickChick plugin-check-lib-ref 16966

--- a/doc/changelog/13-misc/16966-plugin-check-lib-ref.rst
+++ b/doc/changelog/13-misc/16966-plugin-check-lib-ref.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  warning `dynlink-name-lookup` when a plugin looks up a reference at linking time.
+  Such lookups are the most common cause of incompatibility with asynchronous proofs
+  (`#16966 <https://github.com/coq/coq/pull/16966>`_,
+  by Gaëtan Gilbert).

--- a/lib/flags.ml
+++ b/lib/flags.ml
@@ -80,3 +80,5 @@ let get_inline_level () = !inline_level
 
 let profile_ltac = ref false
 let profile_ltac_cutoff = ref 2.0
+
+let loading_plugin = ref false

--- a/lib/flags.mli
+++ b/lib/flags.mli
@@ -96,3 +96,6 @@ val default_inline_level : int
 (** Global profile_ltac flag  *)
 val profile_ltac : bool ref
 val profile_ltac_cutoff : float ref
+
+(** Are we executing dynlink for a plugin? *)
+val loading_plugin : bool ref

--- a/library/coqlib.ml
+++ b/library/coqlib.ml
@@ -47,6 +47,7 @@ let check_ind_ref s ind =
   | exception Not_found -> false
 
 let lib_ref s =
+  let () = Nametab.check_loading (lazy (Pp.str s)) in
   try CString.Map.find s !table
   with Not_found ->
     CErrors.user_err Pp.(str "not found in table: " ++ str s)

--- a/library/nametab.mli
+++ b/library/nametab.mli
@@ -258,3 +258,5 @@ module Modules : sig
   val unfreeze : t -> unit
   val summary_tag : t Summary.Dyn.tag
 end
+
+val check_loading : Pp.t Lazy.t -> unit

--- a/vernac/mltop.ml
+++ b/vernac/mltop.ml
@@ -168,6 +168,8 @@ end = struct
       Dynlink.loadfile gname;
       Findlib.(record_package Record_load) lib
 
+  let load l : unit = Flags.with_option Flags.loading_plugin load l
+
   let digest s =
     match s with
     | { file = Some file; _ } ->


### PR DESCRIPTION
Failure to obey this condition leads to errors when using async proofs.


Overlays:
- https://github.com/MetaCoq/metacoq/pull/809
- https://github.com/Mtac2/Mtac2/pull/371
- https://github.com/QuickChick/QuickChick/pull/313
- https://github.com/lukaszcz/coqhammer/pull/151