### PR TITLE
Increase timeout for fiat-crypto.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -648,7 +648,7 @@ library:ci-fiat_crypto:
   - library:ci-coqprime
   - plugin:ci-bignums
   - plugin:ci-rewriter
-  timeout: 3h
+  timeout: 4h
 
 library:ci-fiat_crypto_legacy:
   extends: .ci-template-flambda


### PR DESCRIPTION
On `v8.17`, I'm getting too many timeouts related to fiat-crypto.