### PR TITLE
speedup HexadecimalPos.v

### DIFF
--- a/theories/Numbers/HexadecimalPos.v
+++ b/theories/Numbers/HexadecimalPos.v
@@ -282,7 +282,7 @@ Proof.
   induction d; [reflexivity|..];
   simpl_of_lu; rewrite Nadd_alt; simpl_to_nat;
   rewrite ?nat_iter_S, nat_iter_0, ?to_lu_succ, to_of_lu_tenfold by assumption;
-  unfold lnorm; simpl; destruct nztail; auto.
+  unfold lnorm; simpl nztail; destruct nztail; reflexivity.
 Qed.
 
 (** Second bijection result *)


### PR DESCRIPTION
This change improves compilation speed of `Numbers/HexadecimalPos.v` from 3s to 1s (on my machine).

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
