### PR TITLE
CI: Split test suite run out of serapi job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -867,9 +867,13 @@ plugin:ci-rewriter:
 
 plugin:ci-serapi:
   extends: .ci-template-flambda
+
+plugin:ci-serapi_test:
+  extends: .ci-template-flambda
   needs:
   - build:edge+flambda
   - library:ci-mathcomp
+  - plugin:ci-serapi
 
 plugin:ci-vscoq:
   extends: .ci-template

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -65,6 +65,7 @@ CI_TARGETS= \
     ci-relation_algebra \
     ci-rewriter \
     ci-serapi \
+    ci-serapi_test \
     ci-sf \
     ci-simple_io \
     ci-smtcoq \
@@ -128,7 +129,7 @@ ci-compcert: ci-menhir ci-flocq
 
 ci-relation_algebra: ci-aac_tactics ci-mathcomp
 
-ci-serapi: ci-mathcomp
+ci-serapi_test: ci-mathcomp ci-serapi
 
 # Generic rule, we use make to ease CI integration
 $(CI_TARGETS): ci-%:

--- a/dev/ci/ci-serapi_test.sh
+++ b/dev/ci/ci-serapi_test.sh
@@ -5,10 +5,8 @@ set -e
 ci_dir="$(dirname "$0")"
 . "${ci_dir}/ci-common.sh"
 
-git_download serapi
-
 if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
 
 ( cd "${CI_BUILD_DIR}/serapi"
-  make
+  make test
 )


### PR DESCRIPTION
This will be useful for #16964 where coq_lsp doesn't need to depend on serapi_test and mathcomp
cc @ejgallego 