### PR TITLE
[parsing] Remove hack which hampered correct parsing resumption, fix CoqIDE tooltip display.

### DIFF
--- a/gramlib/stream.ml
+++ b/gramlib/stream.ml
@@ -94,14 +94,14 @@ let is_empty s =
 
 (* Stream building functions *)
 
-let from f = {count = 0; data = Sgen {curr = None; func = f}}
+let from ?(offset=0) f = {count = offset; data = Sgen {curr = None; func = f}}
 
 (* NB we need the thunk for value restriction *)
 let empty () = {count = 0; data = Sempty}
 
-let of_string s =
+let of_string ?(offset=0) s =
   let count = ref 0 in
-  from (fun () ->
+  from ~offset (fun () ->
     let c = !count in
     if c < String.length s
     then (incr count; Some s.[c])

--- a/gramlib/stream.mli
+++ b/gramlib/stream.mli
@@ -29,19 +29,22 @@ exception Error of string
 
 (** {1 Stream builders} *)
 
-val from : (unit -> 'a option) -> 'a t
+val from : ?offset:int -> (unit -> 'a option) -> 'a t
 (** [Stream.from f] returns a stream built from the function [f]. To
     create a new stream element, the function [f] is called. The user
     function [f] must return either [Some <value>] for a value or
-    [None] to specify the end of the stream.
+    [None] to specify the end of the stream. [offset] will initialize
+    the stream [count] to start with [offset] consumed items, which is
+    useful for some uses cases such as parsing resumption.
 *)
 
 val empty : unit -> 'a t
 (** Return the stream holding the elements of the list in the same
    order. *)
 
-val of_string : string -> char t
-(** Return the stream of the characters of the string parameter. *)
+val of_string : ?offset:int -> string -> char t
+(** Return the stream of the characters of the string parameter. If
+    set. [offset] parameter is similar to [from]. *)
 
 val of_channel : in_channel -> char t
 (** Return the stream of the characters read from the input channel. *)

--- a/ide/coqide/coqOps.ml
+++ b/ide/coqide/coqOps.ml
@@ -494,11 +494,17 @@ object(self)
 
   method private attach_tooltip ?loc sentence text =
     let start_sentence, stop_sentence, phrase = self#get_sentence sentence in
-    let pre_bytes, post_bytes = Option.cata Loc.unloc (0, String.length phrase) loc in
-    let pre = b2c phrase (pre_bytes - (sentence.byte_start)) in
-    let post = b2c phrase (post_bytes - (sentence.byte_start)) in
-    let start = start_sentence#forward_chars pre in
-    let stop = start_sentence#forward_chars post in
+    let start, stop = match loc with
+      | None -> start_sentence, stop_sentence
+      | Some loc ->
+        (* This needs to call the char to byte conversion functions,
+           or even better directly [buffer#get_iter_at_byte], but that
+           requires the [line] parameter, we can likely get it from
+           [loc]. *)
+        let start = buffer#get_iter_at_char loc.Loc.bp in
+        let stop = buffer#get_iter_at_char loc.ep in
+        start, stop
+    in
     let markup = Glib.Markup.escape_text text in
     buffer#apply_tag Tags.Script.tooltip ~start ~stop;
     add_tooltip sentence start#offset stop#offset markup

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -93,7 +93,7 @@ let add ((((s,eid),(sid,verbose)),off),(line_nb,bol_pos)) =
   let open Loc in
   (* note: this won't yield correct values for bol_pos_last,
      but the debugger doesn't use that *)
-  let loc = { (initial ToplevelInput) with bp=off; line_nb } in
+  let loc = { (initial ToplevelInput) with bp=off; line_nb; bol_pos } in
   let r_stream = Gramlib.Stream.of_string ~offset:off s in
   let pa = Pcoq.Parsable.make ~loc r_stream in
   match Stm.parse_sentence ~doc sid ~entry:Pvernac.main_entry pa with

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -88,18 +88,13 @@ let ide_doc = ref None
 let get_doc () = Option.get !ide_doc
 let set_doc doc = ide_doc := Some doc
 
-(* Adds n spaces at the beggining of the string *)
-let wrap_string n s = String.make n ' ' ^ s
-
 let add ((((s,eid),(sid,verbose)),off),(line_nb,bol_pos)) =
   let doc = get_doc () in
   let open Loc in
   (* note: this won't yield correct values for bol_pos_last,
      but the debugger doesn't use that *)
   let loc = { (initial ToplevelInput) with bp=off; line_nb } in
-  let s_wrapped = wrap_string off s in
-  let r_stream = Gramlib.Stream.of_string s_wrapped in
-  let () = Gramlib.Stream.njunk off r_stream in
+  let r_stream = Gramlib.Stream.of_string ~offset:off s in
   let pa = Pcoq.Parsable.make ~loc r_stream in
   match Stm.parse_sentence ~doc sid ~entry:Pvernac.main_entry pa with
   | None -> assert false (* s may not be empty *)

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -88,13 +88,19 @@ let ide_doc = ref None
 let get_doc () = Option.get !ide_doc
 let set_doc doc = ide_doc := Some doc
 
+(* Adds n spaces at the beggining of the string *)
+let wrap_string n s = String.make n ' ' ^ s
+
 let add ((((s,eid),(sid,verbose)),off),(line_nb,bol_pos)) =
   let doc = get_doc () in
   let open Loc in
   (* note: this won't yield correct values for bol_pos_last,
      but the debugger doesn't use that *)
   let loc = { (initial ToplevelInput) with bp=off; line_nb } in
-  let pa = Pcoq.Parsable.make ~loc (Gramlib.Stream.of_string s) in
+  let s_wrapped = wrap_string off s in
+  let r_stream = Gramlib.Stream.of_string s_wrapped in
+  let () = Gramlib.Stream.njunk off r_stream in
+  let pa = Pcoq.Parsable.make ~loc r_stream in
   match Stm.parse_sentence ~doc sid ~entry:Pvernac.main_entry pa with
   | None -> assert false (* s may not be empty *)
   | Some ast ->

--- a/ide/coqide/ideutils.mli
+++ b/ide/coqide/ideutils.mli
@@ -19,6 +19,7 @@ val browse_keyword : (string -> unit) -> string -> unit
 val byte_offset_to_char_offset : string -> int -> int
 val byte_off_to_buffer_off : GText.buffer -> int -> int
 val buffer_off_to_byte_off : GText.buffer -> int -> int
+
 val ulen : int -> int
 
 type timer = { run : ms:int -> callback:(unit->bool) -> unit;

--- a/parsing/cLexer.ml
+++ b/parsing/cLexer.ml
@@ -773,18 +773,12 @@ let rec next_token ~diff_mode loc s =
 (** {6 The lexer of Coq} *)
 
 let func next_token ?(loc=Loc.(initial ToplevelInput)) cs =
-  let bp_ = Loc.(loc.bp) in
   let cur_loc = ref loc in
   Gramlib.LStream.from ~loc
     (fun () ->
       let (tok, loc) = next_token !cur_loc cs in
       cur_loc := after loc;
-      let aloc = Loc.{loc with bol_pos = loc.bol_pos + bp_;
-                                    bp = loc.bp + bp_;
-                                    ep = loc.ep + bp_} in
-     (* Debug: uncomment this for tracing tokens seen by coq...*)
-     (*  Printf.eprintf "(line %i, %i-%i)[%s]\n%!" aloc.line_nb aloc.bp aloc.ep (Tok.extract_string diff_mode t);*)
-      Some (tok,aloc))
+      Some (tok,loc))
 
 module MakeLexer (Diff : sig val mode : bool end) = struct
   type te = Tok.t

--- a/parsing/cLexer.mli
+++ b/parsing/cLexer.mli
@@ -52,6 +52,19 @@ val terminal : string -> string Tok.p
 (** Precondition: the input is a number (c.f. [NumTok.t]) *)
 val terminal_number : string -> NumTok.Unsigned.t Tok.p
 
+(** [after loc] Will advance a lexing location as the lexer does; this
+    can be used to implement parsing resumption from a given position:
+{[
+  let loc = Pcoq.Parsable.loc pa |> after in
+  let str = Gramlib.Stream.of_string text in
+  (* Stream.count being correct is critical for Coq's lexer *)
+  Gramlib.Stream.njunk loc.ep str;
+  let pa = Pcoq.Parsable.make ~loc str in
+  (* ready to resume parsing *)
+]}
+*)
+val after : Loc.t -> Loc.t
+
 (** The lexer of Coq: *)
 
 module Lexer :

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -320,7 +320,7 @@ unit-tests: $(UNIT_LOGFILES)
 # Build executable, run it to generate log file
 unit-tests/%.ml.log: unit-tests/%.ml unit-tests/src/$(UNIT_LINK)
 	$(SHOW) 'TEST      $<'
-	$(HIDE)$(OCAMLBEST) -linkpkg -package coq-core.toplevel,ounit2 \
+	$(HIDE)$(OCAMLBEST) -w -29 -linkpkg -package coq-core.toplevel,ounit2 \
 	     -I unit-tests/src $(UNIT_LINK) $< -o $<.test;
 	$(HIDE)./$<.test
 

--- a/test-suite/interactive/ltac_debugger.v
+++ b/test-suite/interactive/ltac_debugger.v
@@ -1,0 +1,10 @@
+Set Ltac Debug.
+
+Ltac my_tac :=
+  let i := 1 in
+  let con := constr:(forall a b c : nat,
+    (a + b) * c = a * c + b * c) in
+  idtac "A"; idtac "B"; idtac "C".
+
+Goal True.
+my_tac.

--- a/test-suite/unit-tests/parsing/dune
+++ b/test-suite/unit-tests/parsing/dune
@@ -1,0 +1,5 @@
+(executable
+ (name resumption)
+ (modules resumption)
+ (libraries coq-core.vernac)
+ (link_flags -linkall))

--- a/test-suite/unit-tests/parsing/resumption.ml
+++ b/test-suite/unit-tests/parsing/resumption.ml
@@ -1,11 +1,13 @@
 let doc =
 "Definition a := Type.
 Definition b := Prop.
-Definition c :=
+ Definition c :=
     b.
 Definition d :=
       c.
 (* this is a comment *)
+  Definition m :=
+ forall (x : Type), x.
 "
 
 let parse pa n =
@@ -23,29 +25,32 @@ let raw_pr_loc fmt (l : Loc.t) =
   Format.fprintf fmt "| line_nb: %d | bol_pos: %d | line_nb_last: %d | bol_pos_last: %d | bp: %d | ep: %d |"
     line_nb bol_pos line_nb_last bol_pos_last bp ep
 
-let _print_locs fmt { CAst.loc; _ } =
-  Option.iter (Format.fprintf fmt "@[%a@]@\n" raw_pr_loc) loc
+let print_locs fmt { CAst.loc; _ } =
+  Option.iter (Format.fprintf fmt "@[%a@]" raw_pr_loc) loc
 
 let parse_whole () =
   let text = doc in
   let pa = Pcoq.Parsable.make (Gramlib.Stream.of_string text) in
   parse pa 10
 
-(* From clexer *)
-let after loc =
-  Loc.{ loc with
-        line_nb = loc.line_nb_last;
-        bol_pos = loc.bol_pos_last;
-        bp      = loc.ep;
-      }
-
+(* Use junk *)
 let parse_n n =
   let pa = Pcoq.Parsable.make (Gramlib.Stream.of_string doc) in
   let res1 = parse pa n in
   let loc = Pcoq.Parsable.loc pa |> CLexer.after in
-  (* Format.eprintf "@\nlast loc:@\n@[%a@]@\n@\n%!" raw_pr_loc loc; *)
   let str = Gramlib.Stream.of_string doc in
-  Gramlib.Stream.njunk loc.ep str;
+  Gramlib.Stream.njunk loc.bp str;
+  let pa = Pcoq.Parsable.make ~loc str in
+  let res2 = parse pa 10 in
+  res1 @ res2
+
+(* Use offset to set count and avoid the junk *)
+let parse_n_offset n =
+  let pa = Pcoq.Parsable.make (Gramlib.Stream.of_string doc) in
+  let res1 = parse pa n in
+  let loc = Pcoq.Parsable.loc pa |> CLexer.after in
+  let doc = String.sub doc loc.bp (String.length doc - loc.bp) in
+  let str = Gramlib.Stream.of_string ~offset:loc.bp doc in
   let pa = Pcoq.Parsable.make ~loc str in
   let res2 = parse pa 10 in
   res1 @ res2
@@ -54,11 +59,14 @@ let log_file = __FILE__ ^ ".log"
 
 let main () =
   let reference = parse_whole () in
-  let test = [parse_n 1; parse_n 2; parse_n 3; parse_n 4] in
-  let res = List.for_all (fun t -> t = reference) test in
+  let test1 = [parse_n 1; parse_n 2; parse_n 3; parse_n 4; parse_n 5] in
+  let test2 = [parse_n_offset 1; parse_n_offset 2; parse_n_offset 3; parse_n_offset 4; parse_n_offset 5] in
+  let tests = test1 @ test2 in
+  let res = List.for_all (fun t -> t = reference) tests in
   let oc = Stdlib.open_out log_file in
   let outf = Format.formatter_of_out_channel oc in
   Format.fprintf outf "split parsing test passed: %b@\n%!" res;
+  List.iter (Format.fprintf outf "locs@\n@[<v>%a@]@\n@\n" (Format.pp_print_list print_locs)) tests;
   Format.pp_print_flush outf ();
   Stdlib.close_out oc;
   if res then exit 0 else exit 1

--- a/test-suite/unit-tests/parsing/resumption.ml
+++ b/test-suite/unit-tests/parsing/resumption.ml
@@ -1,0 +1,66 @@
+let doc =
+"Definition a := Type.
+Definition b := Prop.
+Definition c :=
+    b.
+Definition d :=
+      c.
+(* this is a comment *)
+"
+
+let parse pa n =
+  let entry = Pvernac.Vernac_.main_entry in
+  let rec loop res n =
+    if n = 0 then res else
+      match Pcoq.Entry.parse entry pa with
+      | None -> res
+      | Some r -> loop (r :: res) (n-1)
+  in
+  loop [] n |> List.rev
+
+let raw_pr_loc fmt (l : Loc.t) =
+  let { Loc.fname=_; line_nb; bol_pos; line_nb_last; bol_pos_last; bp; ep } = l in
+  Format.fprintf fmt "| line_nb: %d | bol_pos: %d | line_nb_last: %d | bol_pos_last: %d | bp: %d | ep: %d |"
+    line_nb bol_pos line_nb_last bol_pos_last bp ep
+
+let _print_locs fmt { CAst.loc; _ } =
+  Option.iter (Format.fprintf fmt "@[%a@]@\n" raw_pr_loc) loc
+
+let parse_whole () =
+  let text = doc in
+  let pa = Pcoq.Parsable.make (Gramlib.Stream.of_string text) in
+  parse pa 10
+
+(* From clexer *)
+let after loc =
+  Loc.{ loc with
+        line_nb = loc.line_nb_last;
+        bol_pos = loc.bol_pos_last;
+        bp      = loc.ep;
+      }
+
+let parse_n n =
+  let pa = Pcoq.Parsable.make (Gramlib.Stream.of_string doc) in
+  let res1 = parse pa n in
+  let loc = Pcoq.Parsable.loc pa |> CLexer.after in
+  (* Format.eprintf "@\nlast loc:@\n@[%a@]@\n@\n%!" raw_pr_loc loc; *)
+  let str = Gramlib.Stream.of_string doc in
+  Gramlib.Stream.njunk loc.ep str;
+  let pa = Pcoq.Parsable.make ~loc str in
+  let res2 = parse pa 10 in
+  res1 @ res2
+
+let log_file = __FILE__ ^ ".log"
+
+let main () =
+  let reference = parse_whole () in
+  let test = [parse_n 1; parse_n 2; parse_n 3; parse_n 4] in
+  let res = List.for_all (fun t -> t = reference) test in
+  let oc = Stdlib.open_out log_file in
+  let outf = Format.formatter_of_out_channel oc in
+  Format.fprintf outf "split parsing test passed: %b@\n%!" res;
+  Format.pp_print_flush outf ();
+  Stdlib.close_out oc;
+  if res then exit 0 else exit 1
+
+let () = main ()


### PR DESCRIPTION
This is a follow up of #14220 and #14898 ; in particular, we revert the hack in `CLexer.func` and instead require the caller to set the stream to right count, as this is critical for the current architecture.

Together with #16476, which addedd `Parsable.loc`, and the export of `CLexer.after` in this PR, it seems we can now properly implement parsing resumption (and memoization) in the following manner:

- when done with parsing, use `Pcoq.Parsable.loc` to get the last lexing position `loc` used by the parser.
- advance `loc` using `CLexer.after`
- setup a new stream with the resuming text, you *must* make sure the `count` in the stream corresponds to `loc.bp`, easiest is to use `Stream.njunk`.
- pass `loc` to `Pcoq.Parsable.make ~loc`

Memoization is a bit more advanced and requires using `Pcoq.Parsable.consume`.

It would be nice drop the `Stream.njunk` requirement, but Coq's lexer internals do heavily rely on `Stream.count` so that would imply a full rewrite of the lexer which is something I'd rather don't do now.

Unit test added.

Moreover, we start to fix issues in CoqIDE now that the semantics of XML's protocol `add` call is sane.

Fixes #15087 
Fixes #16987
