### PR TITLE
ci-color: disable native

### DIFF
--- a/dev/ci/ci-color.sh
+++ b/dev/ci/ci-color.sh
@@ -9,9 +9,7 @@ git_download color
 
 if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
 
-ulimit -s
-ulimit -s 65536
-ulimit -s
+export COQEXTRAFLAGS='-native-compiler no'
 ( cd "${CI_BUILD_DIR}/color"
   make
 )


### PR DESCRIPTION
It fails intermittently with "ocamlopt.opt got signal and exited"
