### PR TITLE
[cleanup] Don't use long-deprecated `Printexc.catch`

### DIFF
--- a/tools/ocamllibdep.mll
+++ b/tools/ocamllibdep.mll
@@ -253,5 +253,5 @@ let main () =
   mllib_dependencies ();
   mlpack_dependencies ()
 
-let _ = Printexc.catch main ()
+let _ = main ()
 }

--- a/vernac/mltop.ml
+++ b/vernac/mltop.ml
@@ -242,7 +242,7 @@ let has_dynlink = Coq_config.has_natdynlink || not Sys.(backend_type = Native)
 (* Runs the toplevel loop of Ocaml *)
 let ocaml_toploop () =
   match !load with
-    | WithTop t -> Printexc.catch t.ml_loop ()
+    | WithTop t -> t.ml_loop ()
     | _ -> ()
 
 let ml_load p =


### PR DESCRIPTION
This cleanups a OCaml 5.0 warning.

