### PR TITLE
Change category of non-primitive-record from `record` to `records`

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/16989-record-cat.rst
+++ b/doc/changelog/08-vernac-commands-and-options/16989-record-cat.rst
@@ -1,0 +1,6 @@
+- **Changed:** warning `non-primitive-record` is now in category
+  `records` instead of `record`. This was the only use of `record` but
+  the plural version is also used by `cannot-define-projection`
+  `future-coercion-class-constructor` and
+  `future-coercion-class-field`. (`#16989
+  <https://github.com/coq/coq/pull/16989>`_, by Gaëtan Gilbert).

--- a/vernac/declareInd.ml
+++ b/vernac/declareInd.ml
@@ -130,7 +130,7 @@ let is_recursive mie =
   List.exists (fun ind -> List.exists (fun t -> is_recursive_constructor (nparams+1) nind t) ind.mind_entry_lc) mie.mind_entry_inds
 
 let warn_non_primitive_record =
-  CWarnings.create ~name:"non-primitive-record" ~category:"record"
+  CWarnings.create ~name:"non-primitive-record" ~category:"records"
     (fun indsp ->
        Pp.(hov 0 (str "The record " ++ Nametab.pr_global_env Id.Set.empty (GlobRef.IndRef indsp) ++
                   strbrk" could not be defined as a primitive record.")))


### PR DESCRIPTION
This was the only use of `record` but the plural version is also used by `cannot-define-projection` `future-coercion-class-constructor` and `future-coercion-class-field`.
