### PR TITLE
Use Alloc_small_enter_GC with OCaml 5.

### DIFF
--- a/kernel/byterun/coq_interp.c
+++ b/kernel/byterun/coq_interp.c
@@ -115,8 +115,12 @@ if (sp - num_args < coq_stack_threshold) {                                     \
 #define Restore_after_caml_call coq_env = *sp++;
 
 #if OCAML_VERSION >= 50000
-#define Coq_alloc_small(result, wosize, tag) Alloc_small(result, wosize, tag, \
-  { Setup_for_gc; caml_process_pending_actions(); Restore_after_gc; })
+#define Enter_gc(dom_st, wosize) do {        \
+    Setup_for_gc;                            \
+    Alloc_small_enter_GC(dom_st, wosize);    \
+    Restore_after_gc;                        \
+  } while (0)
+#define Coq_alloc_small(result, wosize, tag) Alloc_small(result, wosize, tag, Enter_gc)
 #else
 #define Coq_alloc_small(result, wosize, tag) Alloc_small(result, wosize, tag)
 #endif


### PR DESCRIPTION
Cotnrarily to OCaml 4, function `caml_process_pending_actions` is no longer guaranteed to perform a collection if the minor heap is full, which means that `Alloc_small` would return a pointer outside the minor heap. Macro `Alloc_small_enter_GC` makes sure that the minor heap contains enough free space before returning.

As before, compilation of the standard library was tested locally:
```console
$ make world
...
dune build  coq-core.install coq-stdlib.install coqide-server.install coqide.install coq.install
                                           
$ ocamlc --version
5.0.0~beta1
```