### PR TITLE
Add flag to print unfolded projections as cases 

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/16994-pr-unfolded-proj.rst
+++ b/doc/changelog/08-vernac-commands-and-options/16994-pr-unfolded-proj.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  flag :flag:`Printing Unfolded Projection As Match` (off by default) to be able to distinguish unfolded and folded primitive projections
+  (`#16994 <https://github.com/coq/coq/pull/16994>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/language/core/records.rst
+++ b/doc/sphinx/language/core/records.rst
@@ -417,9 +417,9 @@ the :attr:`projections(primitive)` :term:`attribute`  must be supplied.
 
 .. flag:: Printing Primitive Projection Parameters
 
-   This compatibility :term:`flag` reconstructs internally omitted parameters at
-   printing time (even though they are absent in the actual AST manipulated
-   by the kernel).
+   This compatibility :term:`flag` (off by default) reconstructs
+   internally omitted parameters at printing time (even though they
+   are absent in the actual AST manipulated by the kernel).
 
 Reduction
 +++++++++
@@ -432,27 +432,12 @@ above, while the folded version delta-reduces to the unfolded version. This
 allows to precisely mimic the usual unfolding rules of :term:`constants <constant>`.
 Projections obey the usual ``simpl`` flags of the :cmd:`Arguments`
 command in particular.
-There is currently no way to input unfolded primitive projections at the
-user-level, and there is no way to display unfolded projections differently
-from folded ones.
 
+Unfolded primitive projections can be built using the compatibility
+match syntax for primitive records, or by reducing the compatibility constant.
 
-Compatibility Projections and :g:`match`
-++++++++++++++++++++++++++++++++++++++++
-
-To ease compatibility with ordinary record types, each primitive projection is
-also defined as an ordinary :term:`constant` taking parameters and an object of
-the record type as arguments, and whose :term:`body` is an application of the
-unfolded primitive projection of the same name. These constants are used when
-elaborating partial applications of the projection. One can distinguish them
-from applications of the primitive projection if the :flag:`Printing Primitive
-Projection Parameters` flag is off: For a primitive projection application,
-parameters are printed as underscores while for the compatibility projections
-they are printed as usual.
-
-Additionally, user-written :g:`match` constructs on primitive records are
-desugared into substitution of the projections, they cannot be printed back as
-:g:`match` constructs.
+User-written :g:`match` constructs on primitive records are
+desugared using the unfolded primitive projections and `let` bindings.
 
 .. example::
 
@@ -476,3 +461,23 @@ desugared into substitution of the projections, they cannot be printed back as
       Arguments p1 {_ _} _.
       Check fun x : Sigma nat (fun x => x = 0) =>
         match x return x.(p1) = 0 with sigma v e => e end.
+
+.. flag:: Printing Unfolded Projection As Match
+
+   By default this flag is off and unfolded primitive projections are
+   printed the same as folded primitive projections. By setting this
+   flag, unfolded primitive projections are instead printed as
+   let-style matches in the form ``let '{| p := p |} := c in p``.
+
+Compatibility Constants for Projections
++++++++++++++++++++++++++++++++++++++++
+
+To ease compatibility with ordinary record types, each primitive projection is
+also defined as an ordinary :term:`constant` taking parameters and an object of
+the record type as arguments, and whose :term:`body` is an application of the
+unfolded primitive projection of the same name. These constants are used when
+elaborating partial applications of the projection. One can distinguish them
+from applications of the primitive projection if the :flag:`Printing Primitive
+Projection Parameters` flag is off: For a primitive projection application,
+parameters are printed as underscores while for the compatibility projections
+they are printed as usual. They cannot be distinguished if the record has no parameters.

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -834,19 +834,15 @@ and detype_r d flags avoid env sigma t =
         GApp (DAst.make @@ GRef (GlobRef.ConstRef (Projection.constant p), None),
               (args @ [detype d flags avoid env sigma c]))
       in
-      if !Flags.in_debugger || !Flags.in_toplevel then
-        try noparams ()
-        with _ ->
-            (* lax mode, used by debug printers only *)
-          GApp (DAst.make @@ GRef (GlobRef.ConstRef (Projection.constant p), None),
-                [detype d flags avoid env sigma c])
-      else
-        if print_primproj_params () then
-          try
-            let c = Retyping.expand_projection (snd env) sigma p c [] in
-            DAst.get (detype d flags avoid env sigma c)
-          with Retyping.RetypeError _ -> noparams ()
-        else noparams ()
+      if !Flags.in_debugger || !Flags.in_toplevel
+         || not (print_primproj_params ())
+      then noparams ()
+      else begin
+        try
+          let c = Retyping.expand_projection (snd env) sigma p c [] in
+          DAst.get (detype d flags avoid env sigma c)
+        with Retyping.RetypeError _ -> noparams ()
+      end
 
     | Evar (evk,cl) ->
         let open Context.Named.Declaration in

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -335,6 +335,13 @@ let print_primproj_params =
     ~key:["Printing";"Primitive";"Projection";"Parameters"]
     ~value:false
 
+let print_unfolded_primproj_asmatch =
+  Goptions.declare_bool_option_and_ref
+    ~stage:Summary.Stage.Interp
+    ~depr:false
+    ~key:["Printing";"Unfolded";"Projection";"As";"Match"]
+    ~value:false
+
 (* Auxiliary function for MutCase printing *)
 (* [computable] tries to tell if the predicate typing the result is inferable*)
 
@@ -827,22 +834,45 @@ and detype_r d flags avoid env sigma t =
         (Array.map_to_list (detype d flags avoid env sigma) args)
     | Const (sp,u) -> GRef (GlobRef.ConstRef sp, detype_instance sigma u)
     | Proj (p,c) ->
-      let noparams () =
-        let pars = Projection.npars p in
-        let hole = DAst.make @@ GHole(Evar_kinds.InternalHole,Namegen.IntroAnonymous) in
-        let args = List.make pars hole in
-        GApp (DAst.make @@ GRef (GlobRef.ConstRef (Projection.constant p), None),
-              (args @ [detype d flags avoid env sigma c]))
-      in
-      if !Flags.in_debugger || !Flags.in_toplevel
-         || not (print_primproj_params ())
-      then noparams ()
-      else begin
-        try
-          let c = Retyping.expand_projection (snd env) sigma p c [] in
-          DAst.get (detype d flags avoid env sigma c)
-        with Retyping.RetypeError _ -> noparams ()
-      end
+      if Projection.unfolded p && print_unfolded_primproj_asmatch () then
+        let c = detype d flags avoid env sigma c in
+        let id = Label.to_id @@ Projection.label p in
+        let nargs, parg =
+          try
+            let _, mip = Global.lookup_inductive (Projection.inductive p) in
+            mip.mind_consnrealargs.(0), Projection.arg p
+          with _ when !Flags.in_debugger ->
+            (* kinda weird printing but the name should be enough to
+               indicate which projection it is *)
+            1, 0
+        in
+        let pathole = DAst.make @@ PatVar Anonymous in
+        let patargs = List.init nargs (fun i ->
+            if Int.equal i parg
+            then DAst.make @@ PatVar (Name id)
+            else pathole)
+        in
+        let pat = DAst.make @@ PatCstr ((Projection.inductive p, 1), patargs, Anonymous) in
+        let br = ([id], [pat], DAst.make @@ GVar id) in
+        (* MatchStyle looks relatively heavy *)
+        GCases (LetPatternStyle, None, [c, (Anonymous, None)], [CAst.make br])
+      else
+        let noparams () =
+          let pars = Projection.npars p in
+          let hole = DAst.make @@ GHole(Evar_kinds.InternalHole,Namegen.IntroAnonymous) in
+          let args = List.make pars hole in
+          GApp (DAst.make @@ GRef (GlobRef.ConstRef (Projection.constant p), None),
+                (args @ [detype d flags avoid env sigma c]))
+        in
+        if !Flags.in_debugger || !Flags.in_toplevel
+           || not (print_primproj_params ())
+        then noparams ()
+        else begin
+          try
+            let c = Retyping.expand_projection (snd env) sigma p c [] in
+            DAst.get (detype d flags avoid env sigma c)
+          with Retyping.RetypeError _ -> noparams ()
+        end
 
     | Evar (evk,cl) ->
         let open Context.Named.Declaration in

--- a/pretyping/glob_term.ml
+++ b/pretyping/glob_term.ml
@@ -106,7 +106,7 @@ and 'a tomatch_tuple_g = ('a glob_constr_g * 'a predicate_pattern_g)
 and 'a tomatch_tuples_g = 'a tomatch_tuple_g list
 
 and 'a cases_clause_g = (Id.t list * 'a cases_pattern_g list * 'a glob_constr_g) CAst.t
-(** [(p,il,cl,t)] = "|'cl' => 't'". Precondition: the free variables
+(** [(il,cl,t)] = "|'cl' => 't'". Precondition: the free variables
     of [t] are members of [il]. *)
 
 and 'a cases_clauses_g = 'a cases_clause_g list

--- a/test-suite/output/PrintPrimProj.out
+++ b/test-suite/output/PrintPrimProj.out
@@ -1,0 +1,7 @@
+(trip (unbox nat n) (unbox _ n) (unbox _ n))
+(trip (unbox nat n) (unbox _ n) (let '{| unbox := unbox |} := n in unbox))
+(trip n.(unbox nat) n.(unbox _) (let '{| unbox := unbox |} := n in unbox))
+(trip n.(unbox nat) n.(unbox _) n.(unbox _))
+(trip n.(unbox) n.(unbox) n.(unbox))
+(trip n.(unbox) n.(unbox) (let '{| unbox := unbox |} := n in unbox))
+(trip (unbox n) (unbox n) (let '{| unbox := unbox |} := n in unbox))

--- a/test-suite/output/PrintPrimProj.v
+++ b/test-suite/output/PrintPrimProj.v
@@ -1,0 +1,36 @@
+Set Primitive Projections.
+
+Record Box (A:Type) := box { unbox : A }.
+
+Definition ubox := @unbox.
+
+Axiom trip : nat -> nat -> nat -> Prop.
+
+Ltac show_goal := match goal with |- ?g => idtac g end.
+
+Lemma foo (n:Box nat) :
+  (* constant, folded, unfolded *)
+    trip (ubox _ n) (unbox _ n) (match n with box _ n => n end).
+Proof.
+  simpl. (* remove extra letins introduced by match compilation *)
+  cbv delta [ubox].
+  show_goal.
+
+  Set Printing Unfolded Projection As Match.
+  show_goal.
+
+  Set Printing Projections.
+  show_goal.
+
+  Unset Printing Unfolded Projection As Match.
+  show_goal.
+
+  Arguments unbox {_}.
+  show_goal.
+
+  Set Printing Unfolded Projection As Match.
+  show_goal.
+
+  Unset Printing Projections.
+  show_goal.
+Abort.


### PR DESCRIPTION
This does not perfectly reparse because matches on primitive records
produce some surrounding letins even when the match is just a
projection.

ie
~~~coq
let '{| unbox := unbox |} := x in unbox .
~~~
becomes
~~~coq
let x := x in let unbox := let '{| unbox := unbox |} := x in unbox in unbox
~~~