### PR TITLE
[extraction] Rename `Pervasives.op` -> `Stdlib.Int.op`

### DIFF
--- a/theories/extraction/ExtrOcamlZInt.v
+++ b/theories/extraction/ExtrOcamlZInt.v
@@ -38,12 +38,13 @@ Extract Inductive N => int [ "0" "" ]
 (** Efficient (but uncertified) versions for usual functions *)
 
 Extract Constant Pos.add => "(+)".
-Extract Constant Pos.succ => "Pervasives.succ".
-Extract Constant Pos.pred => "fun n -> Pervasives.max 1 (n-1)".
-Extract Constant Pos.sub => "fun n m -> Pervasives.max 1 (n-m)".
+Extract Constant Pos.succ => "Stdlib.Int.succ".
+(* Stdlib.Int.max only available in >= 4.13 *)
+Extract Constant Pos.pred => "fun n -> Stdlib.max 1 (n-1)".
+Extract Constant Pos.sub => "fun n m -> Stdlib.max 1 (n-m)".
 Extract Constant Pos.mul => "( * )".
-Extract Constant Pos.min => "Pervasives.min".
-Extract Constant Pos.max => "Pervasives.max".
+Extract Constant Pos.min => "Stdlib.min".
+Extract Constant Pos.max => "Stdlib.max".
 Extract Constant Pos.compare =>
  "fun x y -> if x=y then Eq else if x<y then Lt else Gt".
 Extract Constant Pos.compare_cont =>
@@ -51,12 +52,13 @@ Extract Constant Pos.compare_cont =>
 
 
 Extract Constant N.add => "(+)".
-Extract Constant N.succ => "Pervasives.succ".
-Extract Constant N.pred => "fun n -> Pervasives.max 0 (n-1)".
-Extract Constant N.sub => "fun n m -> Pervasives.max 0 (n-m)".
+Extract Constant N.succ => "Stdlib.Int.succ".
+Extract Constant N.pred => "fun n -> Stdlib.Int.max 0 (n-1)".
+Extract Constant N.sub => "fun n m -> Stdlib.Int.max 0 (n-m)".
 Extract Constant N.mul => "( * )".
-Extract Constant N.min => "Pervasives.min".
-Extract Constant N.max => "Pervasives.max".
+(* Stdlib.Int.max only available in >= 4.13 *)
+Extract Constant N.min => "Stdlib.min".
+Extract Constant N.max => "Stdlib.max".
 Extract Constant N.div => "fun a b -> if b=0 then 0 else a/b".
 Extract Constant N.modulo => "fun a b -> if b=0 then a else a mod b".
 Extract Constant N.compare =>
@@ -64,19 +66,20 @@ Extract Constant N.compare =>
 
 
 Extract Constant Z.add => "(+)".
-Extract Constant Z.succ => "Pervasives.succ".
-Extract Constant Z.pred => "Pervasives.pred".
+Extract Constant Z.succ => "Stdlib.Int.succ".
+Extract Constant Z.pred => "Stdlib.Int.pred".
 Extract Constant Z.sub => "(-)".
 Extract Constant Z.mul => "( * )".
 Extract Constant Z.opp => "(~-)".
-Extract Constant Z.abs => "Pervasives.abs".
-Extract Constant Z.min => "Pervasives.min".
-Extract Constant Z.max => "Pervasives.max".
+Extract Constant Z.abs => "Stdlib.Int.abs".
+(* Stdlib.Int.max only available in >= 4.13 *)
+Extract Constant Z.min => "Stdlib.min".
+Extract Constant Z.max => "Stdlib.max".
 Extract Constant Z.compare =>
  "fun x y -> if x=y then Eq else if x<y then Lt else Gt".
 
 Extract Constant Z.of_N => "fun p -> p".
-Extract Constant Z.abs_N => "Pervasives.abs".
+Extract Constant Z.abs_N => "Stdlib.Int.abs".
 
 (** Z.div and Z.modulo are quite complex to define in terms of (/) and (mod).
     For the moment we don't even try *)


### PR DESCRIPTION
This is required for OCaml 5.0 support, as `Pervasives` is gone.

The bound on extraction was already OCaml 4.07 so I think this is fine
as is. Note that `Stdlib.Int.{max,min}` only appear in 4.13 so I've
mapped them for now to the polymorphic variants.

Fixes #11359


