### PR TITLE
[clib] [cThread] Don't inline `Mutex.unlock` manually.

### DIFF
--- a/clib/cThread.ml
+++ b/clib/cThread.ml
@@ -118,7 +118,7 @@ let create f x =
 *)
 
 (* We inline the call to Mutex.unlock to avoid polling in bytecode mode *)
-external unlock: Mutex.t -> unit = "caml_mutex_unlock"
+let[@inline always] unlock m = (Mutex.unlock [@inlined]) m
 
 let[@inline never] with_lock m ~scope =
   let () = Mutex.lock m (* BEGIN ATOMIC *) in


### PR DESCRIPTION
This was added as an optimization in #14046 , however it is not portable to OCaml 5, due to a renaming `caml_mutex_unlock` -> `caml_ml_mutex_unlock`

Instead of introducing some conditional compilation, we rely on the `inline` and `inlined` attributes, which should do the same job, and given that this is a very small optimization feels like less work.

