### PR TITLE
Fix warning handling in compat files

### DIFF
--- a/theories/Compat/Coq815.v
+++ b/theories/Compat/Coq815.v
@@ -10,6 +10,6 @@
 
 (** Compatibility file for making Coq act similar to Coq v8.15 *)
 
-Require Export Coq.Compat.Coq816.
+Local Set Warnings "-masking-absolute-name".
 
-Local Set Warnings "-deprecated".
+Require Export Coq.Compat.Coq816.

--- a/theories/Compat/Coq816.v
+++ b/theories/Compat/Coq816.v
@@ -10,4 +10,6 @@
 
 (** Compatibility file for making Coq act similar to Coq v8.16 *)
 
+Local Set Warnings "-masking-absolute-name".
+
 Require Export Coq.Compat.Coq817.

--- a/theories/Compat/Coq817.v
+++ b/theories/Compat/Coq817.v
@@ -13,7 +13,9 @@
 Require Export Coq.Compat.Coq818.
 
 Require Coq.Lists.ListSet.
-Global Set Warnings "-masking-absolute-name".
+
+Local Set Warnings "-masking-absolute-name".
+
 Module Export Coq.
   Module Export Lists.
     Module Export ListSet.
@@ -27,4 +29,3 @@ Module Export Coq.
     End ListSet.
   End Lists.
 End Coq.
-Global Set Warnings "masking-absolute-name".


### PR DESCRIPTION
The previous method warned non-fatal in Coq816.v because Coq817 would "restore" the warnings with `Global Set Warnings
"masking-absolute-name".` even though the original state was `+`.

Instead we locally disable the warning for every user of this file.
