### PR TITLE
Document `head_of_constr` as internal (in generalized rewriting chapter).

### DIFF
--- a/doc/sphinx/addendum/generalized-rewriting.rst
+++ b/doc/sphinx/addendum/generalized-rewriting.rst
@@ -659,6 +659,10 @@ new :tacn:`setoid_rewrite` tactic differs slightly from the old one and
 :tacn:`rewrite`.
 
 
+.. tacn:: head_of_constr @ident @one_term
+
+   For internal use only.  It may be removed without warning.  Do not use.
+
 Extensions
 ----------
 

--- a/doc/sphinx/proof-engine/ltac.rst
+++ b/doc/sphinx/proof-engine/ltac.rst
@@ -1600,9 +1600,6 @@ succeeds, and results in an error otherwise.
 
    Like :tacn:`constr_eq_strict`, but all universes are considered equal.
 
-.. tacn:: head_of_constr @ident @one_term
-   :undocumented:
-
 .. tacn:: unify @one_term @one_term {? with @ident }
 
    Succeeds if the arguments are unifiable, potentially


### PR DESCRIPTION
Closes #16844.