### PR TITLE
Mark some debugging FunInd commands as internal and add a note on Equations.

### DIFF
--- a/doc/sphinx/using/libraries/funind.rst
+++ b/doc/sphinx/using/libraries/funind.rst
@@ -395,7 +395,6 @@ Generation of induction principles with ``Functional`` ``Scheme``
     Check tree_size_ind2.
 
 .. cmd:: Functional Case @func_scheme_def
-   :undocumented:
+         Generate graph for @qualid
 
-.. cmd:: Generate graph for @qualid
-   :undocumented:
+   Internal debugging commands.

--- a/doc/sphinx/using/libraries/funind.rst
+++ b/doc/sphinx/using/libraries/funind.rst
@@ -1,6 +1,17 @@
 Functional induction
 ====================
 
+.. note::
+
+   The functional induction (FunInd) plugin is legacy functionality. For
+   new code and new projects, we recommend `Equations <http://mattam82.github.io/Coq-Equations/>`_,
+   a more powerful plugin that provides most of FunInd's features. It can
+   be installed through the `Coq Platform <https://github.com/coq/platform/releases>`_.
+   Refer to the `Equations documentation <https://raw.githubusercontent.com/mattam82/Coq-Equations/master/doc/equations.pdf>`_
+   to learn more. FunInd is not deprecated and not planned for removal
+   yet because porting code from FunInd to Equations can be difficult
+   (due to differences in the generated induction principles).
+
 .. _advanced-recursive-functions:
 
 Advanced recursive functions


### PR DESCRIPTION
Closes #16847

Question: what about `soft functional induction`? Should it be documented, marked as internal, deprecated?