### PR TITLE
Ensure that the acyclic graph explanation contains both end points

### DIFF
--- a/kernel/uGraph.ml
+++ b/kernel/uGraph.ml
@@ -33,9 +33,9 @@ type t = {
 (* Universe inconsistency: error raised when trying to enforce a relation
    that would create a cycle in the graph of universes. *)
 
-type explanation = G.explanation Lazy.t
+type explanation = G.explanation
 
-type univ_inconsistency = constraint_type * Sorts.t * Sorts.t * explanation option
+type univ_inconsistency = constraint_type * Sorts.t * Sorts.t * explanation Lazy.t option
 
 exception UniverseInconsistency of univ_inconsistency
 

--- a/kernel/uGraph.ml
+++ b/kernel/uGraph.ml
@@ -33,7 +33,21 @@ type t = {
 (* Universe inconsistency: error raised when trying to enforce a relation
    that would create a cycle in the graph of universes. *)
 
-type univ_inconsistency = constraint_type * Sorts.t * Sorts.t * explanation Lazy.t option
+(** Type explanation is used to decorate error messages to provide
+  useful explanation why a given constraint is rejected. It is composed
+  of a path of universes and relation kinds [(r1,u1);..;(rn,un)] means
+   .. <(r1) u1 <(r2) ... <(rn) un (where <(ri) is the relation symbol
+  denoted by ri, currently only < and <=). The lowest end of the chain
+  is supposed known (see UniverseInconsistency exn). The upper end may
+  differ from the second univ of UniverseInconsistency because all
+  universes in the path are canonical. Note that each step does not
+  necessarily correspond to an actual constraint, but reflect how the
+  system stores the graph and may result from combination of several
+  Constraints.t...
+*)
+type explanation = (constraint_type * Level.t) list Lazy.t
+
+type univ_inconsistency = constraint_type * Sorts.t * Sorts.t * explanation option
 
 exception UniverseInconsistency of univ_inconsistency
 

--- a/kernel/uGraph.mli
+++ b/kernel/uGraph.mli
@@ -47,9 +47,9 @@ val check_eq_instances : Instance.t check_function
   universes graph. It raises the exception [UniverseInconsistency] if the
   constraints are not satisfiable. *)
 
-type explanation
+type explanation = Level.t * (constraint_type * Level.t) list
 
-type univ_inconsistency = constraint_type * Sorts.t * Sorts.t * explanation option
+type univ_inconsistency = constraint_type * Sorts.t * Sorts.t * Univ.explanation Lazy.t option
 
 exception UniverseInconsistency of univ_inconsistency
 

--- a/kernel/uGraph.mli
+++ b/kernel/uGraph.mli
@@ -47,7 +47,9 @@ val check_eq_instances : Instance.t check_function
   universes graph. It raises the exception [UniverseInconsistency] if the
   constraints are not satisfiable. *)
 
-type univ_inconsistency = constraint_type * Sorts.t * Sorts.t * explanation Lazy.t option
+type explanation
+
+type univ_inconsistency = constraint_type * Sorts.t * Sorts.t * explanation option
 
 exception UniverseInconsistency of univ_inconsistency
 

--- a/kernel/univ.ml
+++ b/kernel/univ.ml
@@ -1051,3 +1051,5 @@ let hcons_universe_context_set (v, c) =
   (hcons_universe_set v, hcons_constraints c)
 
 let hcons_univ x = Universe.hcons x
+
+type explanation = Level.t * (constraint_type * Level.t) list

--- a/kernel/univ.ml
+++ b/kernel/univ.ml
@@ -476,8 +476,6 @@ end
 
 type constraint_type = AcyclicGraph.constraint_type = Lt | Le | Eq
 
-type explanation = (constraint_type * Level.t) list
-
 let constraint_type_ord c1 c2 = match c1, c2 with
 | Lt, Lt -> 0
 | Lt, _ -> -1

--- a/kernel/univ.mli
+++ b/kernel/univ.mli
@@ -182,20 +182,6 @@ type 'a constraint_function = 'a -> 'a -> Constraints.t -> Constraints.t
 val enforce_eq_level : Level.t constraint_function
 val enforce_leq_level : Level.t constraint_function
 
-(** Type explanation is used to decorate error messages to provide
-  useful explanation why a given constraint is rejected. It is composed
-  of a path of universes and relation kinds [(r1,u1);..;(rn,un)] means
-   .. <(r1) u1 <(r2) ... <(rn) un (where <(ri) is the relation symbol
-  denoted by ri, currently only < and <=). The lowest end of the chain
-  is supposed known (see UniverseInconsistency exn). The upper end may
-  differ from the second univ of UniverseInconsistency because all
-  universes in the path are canonical. Note that each step does not
-  necessarily correspond to an actual constraint, but reflect how the
-  system stores the graph and may result from combination of several
-  Constraints.t...
-*)
-type explanation = (constraint_type * Level.t) list
-
 (** {6 Support for universe polymorphism } *)
 
 module Variance :

--- a/kernel/univ.mli
+++ b/kernel/univ.mli
@@ -437,3 +437,5 @@ val hcons_universe_set : Level.Set.t -> Level.Set.t
 val hcons_universe_context : UContext.t -> UContext.t
 val hcons_abstract_universe_context : AbstractContext.t -> AbstractContext.t
 val hcons_universe_context_set : ContextSet.t -> ContextSet.t
+
+type explanation = Level.t * (constraint_type * Level.t) list

--- a/lib/acyclicGraph.mli
+++ b/lib/acyclicGraph.mli
@@ -52,7 +52,21 @@ module Make (Point:Point) : sig
   val enforce_leq : Point.t -> Point.t -> t -> t option
   val enforce_lt : Point.t -> Point.t -> t -> t option
 
-  val get_explanation : (Point.t * constraint_type * Point.t) -> t -> (constraint_type * Point.t) list
+  (** Type explanation is used to decorate error messages to provide a
+      useful explanation why a given constraint is rejected. It is composed
+      of a starting universe [u0] and a path of universes and relation kinds
+      [(r1,u1);..;(rn,un)] meaning [u0 <(r1) u1 <(r2) ... <(rn) un]
+      (where [<(ri)] is the relation symbol denoted by ri).
+      When the rejected constraint is a [a <= b] or [a < b] then the path is from[b] to [a],
+      ie [u0 == b] and [un == a].
+      when the rejected constraint is an equality the path may go in either direction.
+      Note that each step does not necessarily correspond to an actual constraint,
+      but reflect how the system stores the graph
+      and may result from combination of several Constraints.t...
+  *)
+  type explanation = Point.t * (constraint_type * Point.t) list
+
+  val get_explanation : (Point.t * constraint_type * Point.t) -> t -> explanation
   (** Assuming that the corresponding call to [enforce_*] returned [None], this
       will give a trace for the failure. *)
 

--- a/test-suite/output/bug_17002.out
+++ b/test-suite/output/bug_17002.out
@@ -1,0 +1,12 @@
+File "./output/bug_17002.v", line 7, characters 2-24:
+The command has indeed failed with message:
+Universe inconsistency. Cannot enforce u < v because v = u.
+File "./output/bug_17002.v", line 8, characters 2-24:
+The command has indeed failed with message:
+Universe inconsistency. Cannot enforce v < u because u = v.
+File "./output/bug_17002.v", line 15, characters 2-24:
+The command has indeed failed with message:
+Universe inconsistency. Cannot enforce u = v because u < v.
+File "./output/bug_17002.v", line 16, characters 2-24:
+The command has indeed failed with message:
+Universe inconsistency. Cannot enforce v = u because u < v.

--- a/test-suite/output/bug_17002.v
+++ b/test-suite/output/bug_17002.v
@@ -1,0 +1,17 @@
+
+Module Eq.
+  Universes u v.
+  Constraint u = v.
+
+  (* we test both directions to be invariant wrt which universe got picked as canonical *)
+  Fail Constraint u < v.
+  Fail Constraint v < u.
+End Eq.
+
+Module Lt.
+  Universes u v.
+  Constraint u < v.
+
+  Fail Constraint u = v.
+  Fail Constraint v = u.
+End Lt.


### PR DESCRIPTION

This lets us avoid hacking a ending `= u` when printing it.

Typically when correctly used this would happen with `u <= v = w`
trying to enforce `w < u` if `v` was the canonical node for the
equivalence class `{v, w}`. Now we just print `u <= w`.

We already ignored equalities between intermediate nodes in the path,
so IMO there is no need to treat the end specially.

Since the equality constraints can come from collapsing cycles they
don't tend to be very informative so I don't think we should start
printing the intermediate ones either.

Fix #17002
