### PR TITLE
Enforce that algebraic module expressions do not need functor arguments.

### DIFF
--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -120,7 +120,7 @@ let rec check_module env opac mp mb opacify =
       let opacify = collect_constants_without_body sign mb.mod_mp opacify in
       let sign, opac = check_signature env opac sign_struct mb.mod_mp mb.mod_delta opacify in
       Some (sign, mb.mod_delta), opac
-    | Algebraic me -> Some (check_mexpression env opac me mb.mod_mp mb.mod_delta), opac
+    | Algebraic me -> Some (check_mexpression env opac me mb.mod_type mb.mod_mp mb.mod_delta), opac
     | Abstract|FullStruct -> None, opac
   in
   let () = match optsign with
@@ -172,13 +172,13 @@ and check_mexpr env opac mse mp_mse res = match mse with
   | MEwith _ -> CErrors.user_err Pp.(str "Unsupported 'with' constraint in module implementation")
 
 
-and check_mexpression env opac sign mp_mse res = match sign with
-  | MoreFunctor (arg_id, mtb, body) ->
-      check_module_type env mtb;
+and check_mexpression env opac sign mbtyp mp_mse res = match sign with
+  | MEMoreFunctor body ->
+      let arg_id, mtb, mbtyp = Modops.destr_functor mbtyp in
       let env' = Modops.add_module_type (MPbound arg_id) mtb env in
-      let body, delta = check_mexpression env' opac body mp_mse res in
+      let body, delta = check_mexpression env' opac body mbtyp mp_mse res in
       MoreFunctor(arg_id,mtb,body), delta
-  | NoFunctor me -> check_mexpr env opac me mp_mse res
+  | MENoFunctor me -> check_mexpr env opac me mp_mse res
 
 and check_signature env opac sign mp_mse res opacify = match sign with
   | MoreFunctor (arg_id, mtb, body) ->

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -354,8 +354,8 @@ and v_sign =
     [|v_uid;v_modtype;v_sign|]|])  (* MoreFunctor *)
 and v_mexpr =
   Sum ("module_expr",0,
-  [|[|v_mae|];                     (* NoFunctor *)
-    [|v_uid;v_modtype;v_mexpr|]|]) (* MoreFunctor *)
+  [|[|v_mae|];                     (* MENoFunctor *)
+    [|v_mexpr|]|])                 (* MEMoreFunctor *)
 and v_impl =
   Sum ("module_impl",2, (* Abstract, FullStruct *)
   [|[|v_mexpr|];  (* Algebraic *)

--- a/dev/ci/user-overlays/17007-ppedrot-module-alg-compact.sh
+++ b/dev/ci/user-overlays/17007-ppedrot-module-alg-compact.sh
@@ -1,0 +1,3 @@
+overlay elpi https://github.com/ppedrot/coq-elpi module-alg-compact 17007
+
+overlay serapi https://github.com/ppedrot/coq-serapi module-alg-compact 17007

--- a/kernel/declarations.ml
+++ b/kernel/declarations.ml
@@ -301,6 +301,14 @@ type 'uconstr module_alg_expr =
   | MEapply of 'uconstr module_alg_expr * ModPath.t
   | MEwith of 'uconstr module_alg_expr * 'uconstr with_declaration
 
+type 'uconstr functor_alg_expr =
+| MENoFunctor of 'uconstr module_alg_expr
+| MEMoreFunctor of 'uconstr functor_alg_expr
+
+(** A module expression is an algebraic expression, possibly functorized. *)
+
+type module_expression = (constr * Univ.AbstractContext.t option) functor_alg_expr
+
 (** A component of a module structure *)
 
 type structure_field_body =
@@ -320,10 +328,6 @@ and structure_body = (Label.t * structure_field_body) list
 (** A module signature is a structure, with possibly functors on top of it *)
 
 and module_signature = (module_type_body,structure_body) functorize
-
-(** A module expression is an algebraic expression, possibly functorized. *)
-
-and module_expression = (module_type_body, (constr * Univ.AbstractContext.t option) module_alg_expr) functorize
 
 and module_implementation =
   | Abstract (** no accessible implementation *)

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -389,6 +389,14 @@ let hcons_functorize hty he hself f = match f with
 
 let hcons_module_alg_expr me = me
 
+let rec hcons_module_expression me = match me with
+| MENoFunctor malg ->
+  let malg' = hcons_module_alg_expr malg in
+  if malg == malg' then me else MENoFunctor malg'
+| MEMoreFunctor mf ->
+  let mf' = hcons_module_expression mf in
+  if mf' == mf then me else MEMoreFunctor mf'
+
 let rec hcons_structure_field_body sb = match sb with
 | SFBconst cb ->
   let cb' = hcons_const_body cb in
@@ -414,9 +422,6 @@ and hcons_structure_body sb =
 
 and hcons_module_signature ms =
   hcons_functorize hcons_module_type hcons_structure_body hcons_module_signature ms
-
-and hcons_module_expression me =
-  hcons_functorize hcons_module_type hcons_module_alg_expr hcons_module_expression me
 
 and hcons_module_implementation mip = match mip with
 | Abstract -> Abstract

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -314,7 +314,7 @@ and translate_modtype state env mp inl (params,mte) =
     from an already-translated (or interactive) implementation and
     an (optional) signature entry, produces a final [module_body] *)
 
-let finalize_module (cst, ustate) env mp (sign,alg,reso) restype = match restype with
+let finalize_module_alg (cst, ustate) env mp (sign,alg,reso) restype = match restype with
   | None ->
     let impl = match alg with Some e -> Algebraic e | None -> FullStruct in
     mk_mod mp impl sign reso, cst
@@ -331,6 +331,9 @@ let finalize_module (cst, ustate) env mp (sign,alg,reso) restype = match restype
     (** constraints from module body typing + subtyping + module type. *)
     cst
 
+let finalize_module univs env mp (sign, reso) typ =
+  finalize_module_alg univs env mp (sign, None, reso) typ
+
 let translate_module (cst, ustate) env mp inl = function
   | MType (params,ty) ->
     let mtb, cst = translate_modtype (cst, ustate) env mp inl (params,ty) in
@@ -338,7 +341,7 @@ let translate_module (cst, ustate) env mp inl = function
   |MExpr (params,mse,oty) ->
     let (sg,alg,reso,cst) = translate_mse_funct (cst, ustate) env ~is_mod:true mp inl mse params in
     let restype = Option.map (fun ty -> ((params,ty),inl)) oty in
-    finalize_module (cst, ustate) env mp (sg,Some alg,reso) restype
+    finalize_module_alg (cst, ustate) env mp (sg,Some alg,reso) restype
 
 (** We now forbid any Include of functors with restricted signatures.
     Otherwise, we could end with the creation of undesired axioms

--- a/kernel/mod_typing.mli
+++ b/kernel/mod_typing.mli
@@ -53,7 +53,7 @@ val translate_mse :
 
 val finalize_module :
   'a Reduction.universe_state ->
-  env -> ModPath.t -> module_signature * module_expression option * delta_resolver ->
+  env -> ModPath.t -> module_signature * delta_resolver ->
   (module_type_entry * inline) option ->
   module_body * 'a
 

--- a/kernel/modops.mli
+++ b/kernel/modops.mli
@@ -37,6 +37,9 @@ val implem_smart_map :
   (module_expression -> module_expression) ->
   (module_implementation -> module_implementation)
 
+val annotate_module_expression : module_expression -> module_signature ->
+  (module_type_body, (constr * Univ.AbstractContext.t option) module_alg_expr) functorize
+
 (** {6 Substitutions } *)
 
 val subst_signature : substitution -> module_signature -> module_signature

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1142,7 +1142,7 @@ let build_module_body params restype senv =
   let state = check_state senv in
   let mb, _ =
     Mod_typing.finalize_module state senv.env senv.modpath
-      (struc,None,senv.modresolver) restype'
+      (struc, senv.modresolver) restype'
   in
   let mb' = functorize_module params mb in
   { mb' with mod_retroknowledge = ModBodyRK senv.local_retroknowledge }

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1131,10 +1131,11 @@ let propagate_loads senv =
 
 let functorize_module params mb =
   let f x = functorize params x in
+  let fe x = iterate (fun e -> MEMoreFunctor e) (List.length params) x in
   { mb with
-    mod_expr = Modops.implem_smart_map f f mb.mod_expr;
+    mod_expr = Modops.implem_smart_map f fe mb.mod_expr;
     mod_type = f mb.mod_type;
-    mod_type_alg = Option.map f mb.mod_type_alg }
+    mod_type_alg = Option.map fe mb.mod_type_alg }
 
 let build_module_body params restype senv =
   let struc = NoFunctor (List.rev senv.revstruct) in

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -91,7 +91,7 @@ and fields_of_mp mp =
   Modops.subst_structure subs fields
 
 and fields_of_mb subs mb args = match mb.mod_expr with
-  | Algebraic expr -> fields_of_expression subs mb.mod_mp args expr
+  | Algebraic expr -> fields_of_expression subs mb.mod_mp args mb.mod_type expr
   | Struct sign -> fields_of_signature subs mb.mod_mp args sign
   | Abstract|FullStruct -> fields_of_signature subs mb.mod_mp args mb.mod_type
 
@@ -110,7 +110,9 @@ and fields_of_expr subs mp0 args = function
   | MEapply (me1,mp2) -> fields_of_expr subs mp0 (mp2::args) me1
   | MEwith _ -> assert false (* no 'with' in [mod_expr] *)
 
-and fields_of_expression x = fields_of_functor fields_of_expr x
+and fields_of_expression subs mp args mty me =
+  let me = Modops.annotate_module_expression me mty in
+  fields_of_functor fields_of_expr subs mp args me
 
 let lookup_constant_in_impl cst fallback =
   try

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -1015,7 +1015,7 @@ let end_module_core id m_info objects fs =
   let state = ((Global.universes (), Univ.Constraints.empty), Reductionops.inferred_universes) in
   let _, (_, cst) =
     Mod_typing.finalize_module state (Global.env ()) (Global.current_modpath ())
-      (struc, None, current_modresolver ()) restype'
+      (struc, current_modresolver ()) restype'
   in
   let () = Global.add_constraints cst in
 


### PR DESCRIPTION
This data is always the same as the corresponding functor arguments from the associated module type. Hence, instead of duplicating these types we simply annotate the number of functor abstractions.

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/415
- https://github.com/ejgallego/coq-serapi/pull/298