### PR TITLE
[build] [bootstrap] Ignore a warning for better compat with OCaml 5.0

### DIFF
--- a/lib/control.ml
+++ b/lib/control.ml
@@ -70,7 +70,7 @@ let windows_timeout n f x =
       if n <= cur -. init then begin
         interrupt := true;
         exited := true;
-        Thread.exit ()
+        Thread.exit () [@ocaml.warning "-3"]
       end;
       Thread.delay 0.5
     done


### PR DESCRIPTION
The way we build the bootstrap rule generation will trigger a fatal warning in OCaml 5.0

We should improve the bootstrapping setup, but for now this patch does the job and should allow `coq.dev` and others to work correctly.

