### PR TITLE
[internal] Avoid deprecation warnings in OCaml 5.0

### DIFF
--- a/stm/asyncTaskQueue.ml
+++ b/stm/asyncTaskQueue.ml
@@ -255,7 +255,7 @@ module Make(T : Task) () = struct
     let cleaner queue =
       while true do
         try ignore(TQueue.pop ~picky:(fun (_,cancelled) -> !cancelled) queue)
-        with TQueue.BeingDestroyed -> Thread.exit ()
+        with TQueue.BeingDestroyed -> (Thread.exit [@warning "-3"]) ()
       done in
     let queue = TQueue.create () in
     {

--- a/stm/workerPool.ml
+++ b/stm/workerPool.ml
@@ -78,7 +78,11 @@ let rec create_worker extra pool priority id =
   let cancel = ref false in
   let name, process, ic, oc as worker = Model.spawn id priority in
   master_handshake name ic oc;
-  let exit () = cancel := true; cleanup pool priority; Thread.exit () in
+  let exit () =
+    cancel := true;
+    cleanup pool priority;
+    (Thread.exit [@warning "-3"]) ()
+  in
   let cancelled () = !cancel in
   let cpanel = { exit; cancelled; extra } in
   let manager = CThread.create (Model.manager cpanel) worker in


### PR DESCRIPTION
This should have `make world` working in OCaml 5.0

