### PR TITLE
Verdi Raft and related projects no longer use configure script

### DIFF
--- a/dev/ci/ci-verdi_raft.sh
+++ b/dev/ci/ci-verdi_raft.sh
@@ -14,30 +14,25 @@ git_download verdi_raft
 if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
 
 ( cd "${CI_BUILD_DIR}/struct_tact"
-  ./configure
   make
   make install
 )
 
 ( cd "${CI_BUILD_DIR}/inf_seq_ext"
-  ./configure
   make
   make install
 )
 
 ( cd "${CI_BUILD_DIR}/cheerios"
-  ./configure
   make
   make install
 )
 
 ( cd "${CI_BUILD_DIR}/verdi"
-  ./configure
   make
   make install
 )
 
 ( cd "${CI_BUILD_DIR}/verdi_raft"
-  ./configure
   make
 )

--- a/dev/ci/nix/verdi-raft.nix
+++ b/dev/ci/nix/verdi-raft.nix
@@ -1,5 +1,4 @@
 { Verdi }:
 {
   coqBuildInputs = [ Verdi ];
-  configure = "./configure";
 }


### PR DESCRIPTION
I've made changes in the repos of projects in the Verdi Raft family (StructTact, InfSeqExt, Cheerios, Verdi, Verdi Raft) so that they no longer need a configure script - just plain `make`. The  `configure` files are currently empty, but I'd like to remove them from the repos, hence this change to the CI script for Verdi Raft.

I assume some upstream Nix packages will need to be changed too? If so, I'll wait to remove `configure` until I get green light from Nix maintainers.
