### PR TITLE
Register disequality (`_ <> _`) as a symmetric relation

### DIFF
--- a/test-suite/output/Search.out
+++ b/test-suite/output/Search.out
@@ -452,18 +452,19 @@ iff_Reflexive: Reflexive iff
 impl_Reflexive: Reflexive Basics.impl
 eq_Symmetric: forall {A : Type}, Symmetric eq
 eq_Reflexive: forall {A : Type}, Reflexive eq
-Equivalence_Symmetric:
-  forall {A : Type} {R : Relation_Definitions.relation A},
-  Equivalence R -> Symmetric R
 Equivalence_Reflexive:
   forall {A : Type} {R : Relation_Definitions.relation A},
   Equivalence R -> Reflexive R
-PER_Symmetric:
+Equivalence_Symmetric:
   forall {A : Type} {R : Relation_Definitions.relation A},
-  PER R -> Symmetric R
+  Equivalence R -> Symmetric R
 PreOrder_Reflexive:
   forall {A : Type} {R : Relation_Definitions.relation A},
   PreOrder R -> Reflexive R
+PER_Symmetric:
+  forall {A : Type} {R : Relation_Definitions.relation A},
+  PER R -> Symmetric R
+neq_Symmetric: forall {A : Type}, Symmetric (fun x y : A => x <> y)
 reflexive_eq_dom_reflexive:
   forall {A B : Type} {R' : Relation_Definitions.relation B},
   Reflexive R' -> Reflexive (eq ==> R')%signature

--- a/theories/Classes/RelationClasses.v
+++ b/theories/Classes/RelationClasses.v
@@ -182,6 +182,11 @@ Section Defs.
     Global Program Instance eq_equivalence : Equivalence (@eq A) | 10.
   End Leibniz.
   
+  (** Leibniz disequality. *)
+  Section LeibnizNot.
+    (** Disequality is symmetric. *)
+    Global Instance neq_Symmetric : Symmetric (fun x y : A => x <> y) := (@not_eq_sym A).
+  End LeibnizNot.
 End Defs.
 
 (** Default rewrite relations handled by [setoid_rewrite] on Prop. *)


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->
Disequality (`<>`) is registered as symmetric in `RelationClasses`. This allows things like :
```coq
Require RelationClasses.
Theorem foo {A : Type} (x y : A) : x <> y -> y <> x.
Proof. now symmetry. Qed.
```

I dont't think it needs testing since it only adds a small feature.

This is my first PR ever, so do not hesitate to tell me what I'm not doing right.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
