### PR TITLE
[loc] Make location type private, start to enforce some invariants.

### DIFF
--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -90,10 +90,9 @@ let set_doc doc = ide_doc := Some doc
 
 let add ((((s,eid),(sid,verbose)),off),(line_nb,bol_pos)) =
   let doc = get_doc () in
-  let open Loc in
   (* note: this won't yield correct values for bol_pos_last,
      but the debugger doesn't use that *)
-  let loc = { (initial ToplevelInput) with bp=off; line_nb; bol_pos } in
+  let loc = Loc.create ToplevelInput line_nb bol_pos off off in
   let r_stream = Gramlib.Stream.of_string ~offset:off s in
   let pa = Pcoq.Parsable.make ~loc r_stream in
   match Stm.parse_sentence ~doc sid ~entry:Pvernac.main_entry pa with

--- a/lib/loc.mli
+++ b/lib/loc.mli
@@ -14,7 +14,7 @@ type source =
   | InFile of { dirpath : string option; file : string }
   | ToplevelInput
 
-type t = {
+type t = private {
   fname : source; (** filename or toplevel input *)
   line_nb : int; (** start line number *)
   bol_pos : int; (** position of the beginning of start line *)
@@ -62,6 +62,25 @@ val shift_loc : int -> int -> t -> t
 (** [shift_loc loc n p] shifts the beginning of location by [n] and
     the end by [p]; it is assumed that the shifts do not change the
     lines at which the location starts and ends *)
+
+(** Increase the line number, with newline starting at location [offset] *)
+val incr_line : t -> line_offset:int -> t
+
+(**   *)
+val bump_loc_line_last : t -> line_offset:int -> t
+
+(** [next loc] will advance a lexing location as the lexer does; this
+    can be used to implement parsing resumption from a given position:
+{[
+  let loc = Pcoq.Parsable.loc pa |> next in
+  let str = Gramlib.Stream.of_string ~offset:loc.ep text in
+  let pa = Pcoq.Parsable.make ~loc str in
+  (* ready to resume parsing *)
+]}
+*)
+
+
+val next : t -> t
 
 (** {5 Located exceptions} *)
 

--- a/parsing/cLexer.mli
+++ b/parsing/cLexer.mli
@@ -53,19 +53,6 @@ val terminal : keyword_state -> string -> string Tok.p
 (** Precondition: the input is a number (c.f. [NumTok.t]) *)
 val terminal_number : string -> NumTok.Unsigned.t Tok.p
 
-(** [after loc] Will advance a lexing location as the lexer does; this
-    can be used to implement parsing resumption from a given position:
-{[
-  let loc = Pcoq.Parsable.loc pa |> after in
-  let str = Gramlib.Stream.of_string text in
-  (* Stream.count being correct is critical for Coq's lexer *)
-  Gramlib.Stream.njunk loc.ep str;
-  let pa = Pcoq.Parsable.make ~loc str in
-  (* ready to resume parsing *)
-]}
-*)
-val after : Loc.t -> Loc.t
-
 (** The lexer of Coq: *)
 
 module Lexer :

--- a/test-suite/unit-tests/parsing/resumption.ml
+++ b/test-suite/unit-tests/parsing/resumption.ml
@@ -37,7 +37,7 @@ let parse_whole () =
 let parse_n n =
   let pa = Pcoq.Parsable.make (Gramlib.Stream.of_string doc) in
   let res1 = parse pa n in
-  let loc = Pcoq.Parsable.loc pa |> CLexer.after in
+  let loc = Pcoq.Parsable.loc pa |> Loc.next in
   let str = Gramlib.Stream.of_string doc in
   Gramlib.Stream.njunk () loc.bp str;
   let pa = Pcoq.Parsable.make ~loc str in
@@ -48,7 +48,7 @@ let parse_n n =
 let parse_n_offset n =
   let pa = Pcoq.Parsable.make (Gramlib.Stream.of_string doc) in
   let res1 = parse pa n in
-  let loc = Pcoq.Parsable.loc pa |> CLexer.after in
+  let loc = Pcoq.Parsable.loc pa |> Loc.next in
   let doc = String.sub doc loc.bp (String.length doc - loc.bp) in
   let str = Gramlib.Stream.of_string ~offset:loc.bp doc in
   let pa = Pcoq.Parsable.make ~loc str in

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -122,8 +122,8 @@ let blanch_utf8_string s bp ep = let open Bytes in
   done;
   Bytes.sub_string s' 0 !j
 
-let adjust_loc_buf ib loc = let open Loc in
-  { loc with ep = loc.ep - ib.start; bp = loc.bp - ib.start }
+let adjust_loc_buf ib loc =
+  Loc.shift_loc (-ib.start) (-ib.start) loc
 
 let print_highlight_location ib loc =
   let (bp,ep) = Loc.unloc loc in


### PR DESCRIPTION
Due to historical reasons, Coq used the location type present in Camlp5, and some cruft did accumulate in the lexer as the bugfixes couldn't be usptreamed easily.

This is not the case anymore, so we make the location type private and start to enforce some invariants.

Moreover, some parts of the code rely on old-style [start-end] pure offset-based location. While there is nothing wrong with this, it is extremely convenient for IDEs that Coq provides both the offset and the line / column number (so for example IDEs can reuse editors line to offset conversion cache to handle unicode etc...)

We thus remove the APIs that allow to create locations with missing / incorrect line numbers.

c.f. #17031

TODO:
 - Remove Loc.after
 - Remove Loc.make_loc

