### PR TITLE
Remove tactic `hresolve_core`

### DIFF
--- a/dev/ci/user-overlays/17035-SkySkimmer-no-hresolve.sh
+++ b/dev/ci/user-overlays/17035-SkySkimmer-no-hresolve.sh
@@ -1,0 +1,1 @@
+overlay paco https://github.com/SkySkimmer/paco no-hresolve 17035

--- a/doc/changelog/04-tactics/17035-no-hresolve.rst
+++ b/doc/changelog/04-tactics/17035-no-hresolve.rst
@@ -1,0 +1,4 @@
+- **Removed:**
+  undocumented tactics `hresolve_core` and `hget_evar`
+  (`#17035 <https://github.com/coq/coq/pull/17035>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/proofs/writing-proofs/equality.rst
+++ b/doc/sphinx/proofs/writing-proofs/equality.rst
@@ -799,19 +799,6 @@ which reduction engine to use.  See :ref:`type-cast`.)  For example:
 
    See the example :ref:`here <example_apply_pattern>`.
 
-.. tacn:: hresolve_core ( @ident := @one_term ) {? at @nat_or_var } in @one_term
-   :undocumented:
-
-   .. From Théo Zimmermann: resolve_core and hget_evar were added in
-      https://github.com/coq/coq/commit/028cbb32785b559c637f77864ce5172e0255d0d0
-      https://sf.snu.ac.kr/gil.hur/Hpattern/readme.txt explains their purpose.
-
-      These seem to be internal tactics for a library implementing a
-      generalization of pattern that is distributed on a website. We should
-      investigate whether this library is actively maintained, still useful,
-      and justifies keeping these tactics / whether it should be integrated
-      into Coq or Coq-community and distributed more widely.
-
 .. tacn:: hget_evar @nat_or_var
    :undocumented:
 

--- a/doc/sphinx/proofs/writing-proofs/equality.rst
+++ b/doc/sphinx/proofs/writing-proofs/equality.rst
@@ -799,9 +799,6 @@ which reduction engine to use.  See :ref:`type-cast`.)  For example:
 
    See the example :ref:`here <example_apply_pattern>`.
 
-.. tacn:: hget_evar @nat_or_var
-   :undocumented:
-
 Fast reduction tactics: vm_compute and native_compute
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1190,9 +1190,6 @@ simple_tactic: [
 | DELETE "finish_timing" OPT string
 | REPLACE "finish_timing" "(" string ")" OPT string
 | WITH "finish_timing" OPT ( "(" string ")" ) OPT string
-| REPLACE "hresolve_core" "(" ident ":=" constr ")" "at" nat_or_var "in" constr
-| WITH "hresolve_core" "(" ident ":=" constr ")" OPT ( "at" nat_or_var ) "in" constr
-| DELETE "hresolve_core" "(" ident ":=" constr ")" "in" constr
 | REPLACE "subst" LIST1 hyp
 | WITH "subst" LIST0 hyp
 | DELETE "subst"

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1665,7 +1665,6 @@ simple_tactic: [
 | "generalize_eqs_vars" hyp
 | "dependent" "generalize_eqs_vars" hyp
 | "specialize_eqs" hyp
-| "hget_evar" nat_or_var
 | "destauto"
 | "destauto" "in" hyp
 | "transparent_abstract" tactic3

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1665,8 +1665,6 @@ simple_tactic: [
 | "generalize_eqs_vars" hyp
 | "dependent" "generalize_eqs_vars" hyp
 | "specialize_eqs" hyp
-| "hresolve_core" "(" ident ":=" constr ")" "at" nat_or_var "in" constr
-| "hresolve_core" "(" ident ":=" constr ")" "in" constr
 | "hget_evar" nat_or_var
 | "destauto"
 | "destauto" "in" hyp

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1705,7 +1705,6 @@ simple_tactic: [
 | "generalize_eqs_vars" ident
 | "dependent" "generalize_eqs_vars" ident
 | "specialize_eqs" ident
-| "hresolve_core" "(" ident ":=" one_term ")" OPT ( "at" nat_or_var ) "in" one_term
 | "hget_evar" nat_or_var
 | "destauto" OPT ( "in" ident )
 | "transparent_abstract" ltac_expr3 OPT ( "using" ident )

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1705,7 +1705,6 @@ simple_tactic: [
 | "generalize_eqs_vars" ident
 | "dependent" "generalize_eqs_vars" ident
 | "specialize_eqs" ident
-| "hget_evar" nat_or_var
 | "destauto" OPT ( "in" ident )
 | "transparent_abstract" ltac_expr3 OPT ( "using" ident )
 | "constr_eq" one_term one_term

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -484,11 +484,6 @@ TACTIC EXTEND specialize_eqs
 | [ "specialize_eqs" hyp(id) ] -> { specialize_eqs id }
 END
 
-TACTIC EXTEND hresolve_core
-| [ "hresolve_core" "(" ident(id) ":=" constr(c) ")" "at" nat_or_var(occ) "in" constr(t) ] -> { Internals.hResolve id c occ t }
-| [ "hresolve_core" "(" ident(id) ":=" constr(c) ")" "in" constr(t) ] -> { Internals.hResolve_auto id c t }
-END
-
 (**
    hget_evar
 *)

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -484,14 +484,6 @@ TACTIC EXTEND specialize_eqs
 | [ "specialize_eqs" hyp(id) ] -> { specialize_eqs id }
 END
 
-(**
-   hget_evar
-*)
-
-TACTIC EXTEND hget_evar
-| [ "hget_evar" nat_or_var(n) ] -> { Evar_tactics.hget_evar n }
-END
-
 TACTIC EXTEND destauto
 | [ "destauto" ] -> { Internals.destauto }
 | [ "destauto" "in" hyp(id) ] -> { Internals.destauto_in id }

--- a/plugins/ltac/internals.mli
+++ b/plugins/ltac/internals.mli
@@ -42,9 +42,6 @@ val injHyp : Names.Id.t -> unit tactic
 val refine_tac : Tacinterp.interp_sign -> simple:bool -> with_classes:bool ->
   closed_glob_constr -> unit tactic
 
-val hResolve : Id.t -> EConstr.t -> int -> EConstr.t -> unit tactic
-val hResolve_auto : Id.t -> EConstr.t -> EConstr.t -> unit tactic
-
 val destauto : unit tactic
 val destauto_in : Id.t -> unit tactic
 

--- a/tactics/evar_tactics.ml
+++ b/tactics/evar_tactics.ml
@@ -11,7 +11,6 @@
 open Util
 open Names
 open Constr
-open Context
 open CErrors
 open Evd
 open Evarutil
@@ -146,19 +145,4 @@ let let_evar name typ =
     let (sigma, evar) = Evarutil.new_evar env sigma ~src ~naming:(Namegen.IntroFresh id) typ in
     Tacticals.tclTHEN (Proofview.Unsafe.tclEVARS sigma)
     (Tactics.pose_tac (Name.Name id) evar)
-  end
-
-let hget_evar n =
-  let open EConstr in
-  Proofview.Goal.enter begin fun gl ->
-  let sigma = Tacmach.project gl in
-  let concl = Proofview.Goal.concl gl in
-  let evl = evar_list sigma concl in
-  if List.length evl < n then
-    user_err Pp.(str "Not enough uninstantiated existential variables.");
-  if n <= 0 then user_err Pp.(str "Incorrect existential variable index.");
-  let ev = List.nth evl (n-1) in
-  let ev_type = EConstr.existential_type sigma ev in
-  let r = Retyping.relevance_of_type (Proofview.Goal.env gl) sigma ev_type in
-  Tactics.change_concl (mkLetIn (make_annot Name.Anonymous r,mkEvar ev,ev_type,concl))
   end

--- a/tactics/evar_tactics.mli
+++ b/tactics/evar_tactics.mli
@@ -18,5 +18,3 @@ val instantiate_tac_by_name : Id.t ->
   Ltac_pretype.closed_glob_constr -> unit Proofview.tactic
 
 val let_evar : Name.t -> EConstr.types -> unit Proofview.tactic
-
-val hget_evar : int -> unit Proofview.tactic


### PR DESCRIPTION
The implementation is fragile due to being based on detyping and a loc hack, and it seems unused.

It was also not in the doc until
https://github.com/coq/coq/pull/16498 (8.17) and then only got a doc stub.

Overlays:
- https://github.com/snu-sf/paco/pull/47 (note this is just a removal of unused tactic definitions)