### PR TITLE
Namegen: don't add a generated name to the avoid set when not used

### DIFF
--- a/engine/namegen.ml
+++ b/engine/namegen.ml
@@ -466,13 +466,10 @@ let next_name_for_display env sigma flags =
 
 (* Remark: Anonymous var may be dependent in Evar's contexts *)
 let compute_displayed_name_in_gen_poly noccurn_fun env sigma flags avoid na c =
-  match na with
-  | Anonymous when noccurn_fun sigma 1 c ->
-    (Anonymous,avoid)
-  | _ ->
+  if noccurn_fun sigma 1 c then Anonymous, avoid
+  else
     let fresh_id = next_name_for_display env sigma flags na avoid in
-    let idopt = if noccurn_fun sigma 1 c then Anonymous else Name fresh_id in
-    (idopt, Id.Set.add fresh_id avoid)
+    Name fresh_id, Id.Set.add fresh_id avoid
 
 let compute_displayed_name_in = compute_displayed_name_in_gen_poly noccurn
 

--- a/test-suite/output/Cases.out
+++ b/test-suite/output/Cases.out
@@ -214,7 +214,7 @@ fun x : J' bool (true, true) =>
 match x with
 | D' _ _ _ m _ e => existT (fun x0 : nat => x0 = x0) m e
 end
-     : J' bool (true, true) -> {x0 : nat & x0 = x0}
+     : J' bool (true, true) -> {x : nat & x = x}
 fun x : J' bool (true, true) =>
 match x with
 | @D' _ _ _ _ n _ p _ => n + p
@@ -245,7 +245,7 @@ fun x : J' bool (true, true) =>
 match x with
 | @D' _ _ _ _ _ m _ e => existT (fun x0 : nat => x0 = x0) m e
 end
-     : J' bool (true, true) -> {x0 : nat & x0 = x0}
+     : J' bool (true, true) -> {x : nat & x = x}
 fun x : J' bool (true, true) =>
 match x with
 | @D' _ _ _ _ n _ p _ => (n, p)

--- a/test-suite/output/Notations3.out
+++ b/test-suite/output/Notations3.out
@@ -130,14 +130,12 @@ return (1, 2, 3, 4)
 ! '{{x, y}}, x.y = 0
      : Prop
 exists x : nat,
-  nat ->
-  exists y : nat,
-    nat -> exists '{{u, t}}, forall z1 : nat, z1 = 0 /\ x.y = 0 /\ u.t = 0
+  nat -> exists y : nat, nat -> exists_mixed '{{u, t}}, x.y = 0 /\ u.t = 0
      : Prop
 exists x : nat,
   nat ->
   exists y : nat,
-    nat -> exists '{{z, t}}, forall z2 : nat, z2 = 0 /\ x.y = 0 /\ z.t = 0
+    nat -> exists '{{z, t}}, forall z0 : nat, z0 = 0 /\ x.y = 0 /\ z.t = 0
      : Prop
 exists_true '{{x, y}} (u := 0) '{{z, t}}, x.y = 0 /\ z.t = 0
      : Prop


### PR DESCRIPTION
Typically `fun (x:nat) => fun (x:nat) => x` gets printed as `fun _ x => x` instead of `fun _ x0 => x0`.
