### PR TITLE
drop -rectypes from coq_makefile OCaml compilation flags

### DIFF
--- a/dev/ci/user-overlays/17038-palmskog-drop-rectypes-coq_makefile.sh
+++ b/dev/ci/user-overlays/17038-palmskog-drop-rectypes-coq_makefile.sh
@@ -1,0 +1,5 @@
+overlay elpi https://github.com/palmskog/coq-elpi coq-master+rectypes 17038 drop-rectypes-coq_makefile
+
+overlay equations https://github.com/palmskog/Coq-Equations master+rectypes 17038 drop-rectypes-coq_makefile
+
+overlay itauto https://gitlab.inria.fr/ggilbert/itauto drop-rectypes-coq_makefile 17038

--- a/doc/changelog/09-cli-tools/17038-drop-rectypes-coq_makefile.rst
+++ b/doc/changelog/09-cli-tools/17038-drop-rectypes-coq_makefile.rst
@@ -1,0 +1,8 @@
+- **Changed:**
+  Do not pass the ``-rectypes`` flag by default in
+  ``coq_makefile`` when compiling OCaml code, since
+  it is no longer required by Coq. To re-enable passing
+  the flag, put ``CAMLFLAGS+=-rectypes`` in the local makefile,
+  e.g., ``CoqMakefile.local`` (see :ref:`coqmakefilelocal`)
+  (`#17038 <https://github.com/coq/coq/pull/17038>`_,
+  by Karl Palmskog with help from Gaëtan Gilbert).

--- a/tools/configure/configure.ml
+++ b/tools/configure/configure.ml
@@ -144,7 +144,7 @@ let coq_warn_error prefs =
 
 (* Flags used to compile Coq and plugins (via coq_makefile) *)
 let caml_flags =
-  Printf.sprintf "-thread -rectypes -bin-annot -strict-sequence %s" coq_warnings
+  Printf.sprintf "-thread -bin-annot -strict-sequence %s" coq_warnings
 
 (* Flags used to compile Coq but _not_ plugins (via coq_makefile) *)
 let coq_caml_flags = coq_warn_error


### PR DESCRIPTION
After #16007 was merged, there is no need to use `-rectypes` anymore when compiling OCaml code that uses `coq-core`, in particular plugins. However, `coq_makefile` still passes `-rectypes` when it compiles OCaml code, so we remove it.

@SkySkimmer does this need a changelog?

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/416
- https://github.com/mattam82/Coq-Equations/pull/523
- https://gitlab.inria.fr/fbesson/itauto/-/merge_requests/9