### PR TITLE
Stop parsing program attribute in Add Relation / Morphism.

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/17042-stop-parsing-program-attribute.rst
+++ b/doc/changelog/08-vernac-commands-and-options/17042-stop-parsing-program-attribute.rst
@@ -1,0 +1,8 @@
+- **Removed:**
+  :attr:`program` attribute is not accepted anymore with commands
+  :cmd:`Add Relation`, :cmd:`Add Parametric Relation`, :cmd:`Add
+  Setoid`, :cmd:`Add Parametric Setoid`, :cmd:`Add Morphism`,
+  :cmd:`Add Parametric Morphism`, :cmd:`Declare Morphism`. Previously,
+  it was accepted but ignored
+  (`#17042 <https://github.com/coq/coq/pull/17042>`_,
+  by Théo Zimmermann).

--- a/plugins/ltac/comRewrite.ml
+++ b/plugins/ltac/comRewrite.ml
@@ -36,7 +36,7 @@ type rewrite_attributes = { polymorphic : bool; global : bool }
 
 let rewrite_attributes =
   let open Attributes.Notations in
-  Attributes.(polymorphic ++ program ++ locality) >>= fun ((polymorphic, program), locality) ->
+  Attributes.(polymorphic ++ locality) >>= fun (polymorphic, locality) ->
   let global = not (Locality.make_section_locality locality) in
   Attributes.Notations.return { polymorphic; global }
 


### PR DESCRIPTION
Commit cfbfce0639a4e608210b21227f923a4f27ab6752 noticed that the attribute was not used, but did not go all the way and remove the parsing of this attribute.