### PR TITLE
prevent coqdoc binder indexes from being generated by default

### DIFF
--- a/doc/changelog/09-cli-tools/17045-remove-coqdoc-binder-index.rst
+++ b/doc/changelog/09-cli-tools/17045-remove-coqdoc-binder-index.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  disable inclusion of variable binders in coqdoc indexes by default,
+  and provide a new coqdoc option `--binder-index` for including them
+  (`#17045 <https://github.com/coq/coq/pull/17045>`_,
+  fixes `#13155 <https://github.com/coq/coq/issues/13155>`_,
+  by Karl Palmskog).

--- a/doc/sphinx/using/tools/coqdoc.rst
+++ b/doc/sphinx/using/tools/coqdoc.rst
@@ -346,6 +346,8 @@ Command line options
   into ``index.html``.
 
   :--no-index: Do not output the index.
+  :--binder-index: Include variable binders in the index. Not recommended
+    with large source files, where binder information may dominate the index.
   :--multi-index: Generate one page for each category and each letter in
     the index, together with a top page ``index.html``.
   :--index string: Make the filename of the index string instead of

--- a/tools/coqdoc/cmdArgs.ml
+++ b/tools/coqdoc/cmdArgs.ml
@@ -146,6 +146,8 @@ let args_options = Arg.align [
   "<file> append <file> as html footer";
   "--no-index", arg_set (fun p -> { p with index = false }),
   " Do not output the index";
+  "--binder-index", arg_set (fun p -> { p with binder_index = true }),
+  " Include variable binders in index";
   "--multi-index", arg_set (fun p -> { p with multi_index = true }),
   " Index split in multiple files";
   "--index <string>", arg_string (fun p s -> { p with index_name = s }),

--- a/tools/coqdoc/common.ml
+++ b/tools/coqdoc/common.ml
@@ -39,6 +39,7 @@ type t = {
   footer_file_spec : bool;
   footer_file : string;
   index: bool;
+  binder_index : bool;
   multi_index : bool;
   index_name : string;
   toc: bool;
@@ -76,6 +77,7 @@ let default : t = {
   index = true;
   multi_index = false;
   index_name = "index";
+  binder_index = false;
   toc = false;
   files = [];
   glob_source = DotGlob;

--- a/tools/coqdoc/common.mli
+++ b/tools/coqdoc/common.mli
@@ -44,6 +44,7 @@ type t = {
   footer_file_spec : bool;
   footer_file : string;
   index : bool;
+  binder_index : bool;
   multi_index : bool;
   index_name : string;
   toc : bool;

--- a/tools/coqdoc/index.ml
+++ b/tools/coqdoc/index.ml
@@ -232,6 +232,10 @@ let prepare_entry s = function
   | _ ->
       s
 
+let include_entry = function
+| Binder -> !prefs.binder_index
+| _ -> true
+
 let all_entries () =
   let gl = ref [] in
   let add_g s m t = gl := (s,(m,t)) :: !gl in
@@ -240,7 +244,11 @@ let all_entries () =
     let l = try Hashtbl.find bt t with Not_found -> [] in
       Hashtbl.replace bt t ((s,m) :: l)
   in
-  let classify m (s,t) = (add_g s m t; add_bt t s m) in
+  let classify m (s,t) =
+    if include_entry t then begin
+      add_g s m t; add_bt t s m
+    end
+  in
     Hashtbl.iter classify deftable;
     Hashtbl.iter (fun id m -> add_g id m Library; add_bt Library id m) modules;
     { idx_name = "global";


### PR DESCRIPTION
Ever since #12033 (shipped in 8.12), coqdoc reads and process information about binders from `.glob` files. These binders then all end up being listed both in the global coqdoc index and in a special binder coqdoc index. This is a problem for large projects, since the number of binders across all modules can easily be tens of thousands and make the index difficult to read and less relevant (binder listings are generally not helpful). As per #13155, the inclusion of binders in indexes was not a deliberate decision.

In this PR, I ensure that binders are not included in coqdoc indexes by default, restoring the behavior of Coq 8.11 and earlier. For people that do want binders listed in indexes, I add the (boolean) `--binder-index` option.

There are many possible designs here, e.g., binders in indexes could be completely disabled, or the indexed entry types (Definitions, Sections, etc.) could be explicitly passed as options to coqdoc. I tried to make changes small and conservative. It would be nice to add tests, but I couldn't figure out how to sufficiently control coqdoc options in the test-suite. Advice welcome.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes #13155


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.