### PR TITLE
fix deprecation message for Arith.Plus.plus_Snm_nSm

### DIFF
--- a/theories/Arith/Plus.v
+++ b/theories/Arith/Plus.v
@@ -32,7 +32,7 @@ Notation plus_permute := Nat.add_shuffle3 (only parsing).
 #[local]
 Definition plus_Snm_nSm_stt : forall n m, S n + m = n + S m := Peano.plus_n_Sm.
 Opaque plus_Snm_nSm_stt.
-#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.add_succ_r (and symmetry of equality) instead.")]
+#[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.add_succ_comm instead.")]
 Notation plus_Snm_nSm := plus_Snm_nSm_stt.
 #[deprecated(since="8.16",note="The Arith.Plus file is obsolete. Use Nat.add_assoc (and symmetry of equality) instead.")]
 Notation plus_assoc_reverse := Arith_prebase.plus_assoc_reverse_stt.


### PR DESCRIPTION
While fixing deprecations in a project, I noticed that the deprecation message is wrong for the `Arith.Plus.plus_Snm_nSm`:
```coq
Check Arith.Plus.plus_Snm_nSm.
(* 
Warning: Notation plus_Snm_nSm is deprecated since 8.16. The Arith.Plus file is obsolete. 
The Arith.Plus file is obsolete. Use Nat.add_succ_r (and symmetry of equality)
[deprecated-syntactic-definition,deprecated]

Plus.plus_Snm_nSm
     : forall n m : nat, S n + m = n + S m
*)
```
To see the problem and solution, consider the following constant types:
```coq
From Coq Require Import Arith.
Check Nat.add_succ_r.
(* Nat.add_succ_r : forall n m : nat, n + S m = S (n + m) *)
Check Nat.add_succ_comm.
(* Nat.add_succ_comm : forall n m : nat, S n + m = n + S m *)
```
So, we advise to use `Nat.add_succ_comm` instead, with no mention of symmetry.