### PR TITLE
Do not store the real functor argument type in Struct.

### DIFF
--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -141,6 +141,8 @@ let rec check_module env opac mp mb opacify =
   let optsign, opac = match mb.mod_expr with
     | Struct sign_struct ->
       let opacify = collect_constants_without_body mb.mod_type mb.mod_mp opacify in
+      (* TODO: a bit wasteful, we recheck the types of parameters twice *)
+      let sign_struct = Modops.annotate_struct_body sign_struct mb.mod_type in
       let opac = check_signature env opac sign_struct mb.mod_mp mb.mod_delta opacify in
       Some (sign_struct, mb.mod_delta), opac
     | Algebraic me -> Some (check_mexpression env opac me mb.mod_type mb.mod_mp mb.mod_delta), opac

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -359,7 +359,7 @@ and v_mexpr =
 and v_impl =
   Sum ("module_impl",2, (* Abstract, FullStruct *)
   [|[|v_mexpr|];  (* Algebraic *)
-    [|v_sign|]|])  (* Struct *)
+    [|v_struc|]|])  (* Struct *)
 and v_noimpl = v_unit
 and v_module =
   Tuple ("module_body",

--- a/dev/ci/user-overlays/17049-ppedrot-module-expr-compact.sh
+++ b/dev/ci/user-overlays/17049-ppedrot-module-expr-compact.sh
@@ -1,0 +1,1 @@
+overlay metacoq https://github.com/ppedrot/metacoq module-expr-compact 17049

--- a/kernel/declarations.ml
+++ b/kernel/declarations.ml
@@ -334,7 +334,7 @@ and module_signature = (module_type_body,structure_body) functorize
 and module_implementation =
   | Abstract (** no accessible implementation *)
   | Algebraic of module_expression (** non-interactive algebraic expression *)
-  | Struct of module_signature (** interactive body *)
+  | Struct of structure_body (** interactive body living in the parameter context of [mod_type] *)
   | FullStruct (** special case of [Struct] : the body is exactly [mod_type] *)
 
 and 'a generic_module_body =

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -429,7 +429,7 @@ and hcons_module_implementation mip = match mip with
   let me' = hcons_module_expression me in
   if me == me' then mip else Algebraic me'
 | Struct ms ->
-  let ms' = hcons_module_signature ms in
+  let ms' = hcons_structure_body ms in
   if ms == ms' then mip else Struct ms
 | FullStruct -> FullStruct
 

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -322,7 +322,15 @@ let finalize_module_alg (cst, ustate) env mp (sign,alg,reso) restype = match res
     let res_mtb, cst = translate_modtype (cst, ustate) env mp inl params_mte in
     let auto_mtb = mk_modtype mp sign reso in
     let cst = Subtyping.check_subtypes (cst, ustate) env auto_mtb res_mtb in
-    let impl = match alg with Some e -> Algebraic e | None -> Struct sign in
+    let impl = match alg with
+    | Some e -> Algebraic e
+    | None ->
+      let sign = match sign with
+      | NoFunctor s -> s
+      | MoreFunctor _ -> assert false (* All non-algebraic callers enforce this *)
+      in
+      Struct sign
+    in
     { res_mtb with
       mod_mp = mp;
       mod_expr = impl;

--- a/kernel/modops.mli
+++ b/kernel/modops.mli
@@ -33,12 +33,14 @@ val module_body_of_type : ModPath.t -> module_type_body -> module_body
 val check_modpath_equiv : env -> ModPath.t -> ModPath.t -> unit
 
 val implem_smart_map :
-  (module_signature -> module_signature) ->
+  (structure_body -> structure_body) ->
   (module_expression -> module_expression) ->
   (module_implementation -> module_implementation)
 
 val annotate_module_expression : module_expression -> module_signature ->
   (module_type_body, (constr * Univ.AbstractContext.t option) module_alg_expr) functorize
+
+val annotate_struct_body : structure_body -> module_signature -> module_signature
 
 (** {6 Substitutions } *)
 

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1133,7 +1133,7 @@ let functorize_module params mb =
   let f x = functorize params x in
   let fe x = iterate (fun e -> MEMoreFunctor e) (List.length params) x in
   { mb with
-    mod_expr = Modops.implem_smart_map f fe mb.mod_expr;
+    mod_expr = Modops.implem_smart_map (fun x -> x) fe mb.mod_expr;
     mod_type = f mb.mod_type;
     mod_type_alg = Option.map fe mb.mod_type_alg }
 

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -384,6 +384,7 @@ and extract_module env mp ~all mb =
       (* This module has a signature, otherwise it would be FullStruct.
          We extract just the elements required by this signature. *)
       let () = add_labels mp mb.mod_type in
+      let sign = Modops.annotate_struct_body sign mb.mod_type in
       extract_msignature env mp mb.mod_delta ~all:false sign
     | FullStruct -> extract_msignature env mp mb.mod_delta ~all mb.mod_type
   in

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -92,7 +92,9 @@ and fields_of_mp mp =
 
 and fields_of_mb subs mb args = match mb.mod_expr with
   | Algebraic expr -> fields_of_expression subs mb.mod_mp args mb.mod_type expr
-  | Struct sign -> fields_of_signature subs mb.mod_mp args sign
+  | Struct sign ->
+    let sign = Modops.annotate_struct_body sign mb.mod_type in
+    fields_of_signature subs mb.mod_mp args sign
   | Abstract|FullStruct -> fields_of_signature subs mb.mod_mp args mb.mod_type
 
 (** The Abstract case above corresponds to [Declare Module] *)

--- a/vernac/printmod.ml
+++ b/vernac/printmod.ml
@@ -388,7 +388,9 @@ let unsafe_print_module extent env mp with_body mb =
     | _, Algebraic me ->
       let me = Modops.annotate_module_expression me mb.mod_type in
       pr_equals ++ print_expression' false extent env mp me
-    | _, Struct sign -> pr_equals ++ print_signature' false extent env mp sign
+    | _, Struct sign ->
+      let sign = Modops.annotate_struct_body sign mb.mod_type in
+      pr_equals ++ print_signature' false extent env mp sign
     | _, FullStruct -> pr_equals ++ print_signature' false extent env mp mb.mod_type
   in
   let modtype = match mb.mod_expr, mb.mod_type_alg with


### PR DESCRIPTION
We drop the parameters of the signature of the Struct case of module expressions. All functions in the kernel were indeed guaranteed to produce the same list of arguments as the one found in mod_type, regardless of subtyping.

See also #17007.

Overlays:
- https://github.com/MetaCoq/metacoq/pull/824