### PR TITLE
Improve printing of notations with anonymous binders, especially for recursive notations

### DIFF
--- a/doc/changelog/03-notations/17050-master+fix-anonymous-binders-recursive-notations.rst
+++ b/doc/changelog/03-notations/17050-master+fix-anonymous-binders-recursive-notations.rst
@@ -1,0 +1,4 @@
+- **Fixed:**
+  Improved ability to print notations involving anonymous binders
+  (`#17050 <https://github.com/coq/coq/pull/17050>`_,
+  by Hugo Herbelin).

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -1538,7 +1538,8 @@ and match_extended_binders ?loc isprod u alp metas na1 na2 bk t sigma b1 b2 =
      let alp,sigma = bind_binding_env alp sigma id disjpat in
      match_in u alp metas sigma b1 b2
      | _ -> assert false)
-  | _, _, Name id when is_bindinglist_meta id metas && (not isprod || na1 != Anonymous)->
+  | _, _, Name id when is_bindinglist_meta id metas ->
+      if (isprod && na1 = Anonymous) then raise No_match (* prefer using "A -> B" for anonymous forall *);
       let alp,sigma = bind_bindinglist_env alp sigma id [DAst.make ?loc @@ GLocalAssum (na1,bk,t)] in
       match_in u alp metas sigma b1 b2
   | _, _, _ ->

--- a/pretyping/glob_ops.ml
+++ b/pretyping/glob_ops.ml
@@ -454,7 +454,7 @@ let update_subst na l =
 let rename_var l id =
   try
     let id' = Id.List.assoc id l in
-    (* Check that no other earlier binding hide the one found *)
+    (* Check that no other earlier binding hides the one found *)
     let _,(id'',_) = List.extract_first (fun (_,id) -> Id.equal id id') l in
     if Id.equal id id'' then id' else raise UnsoundRenaming
   with Not_found ->

--- a/test-suite/output/Notations3.out
+++ b/test-suite/output/Notations3.out
@@ -129,13 +129,9 @@ return (1, 2, 3, 4)
      : (nat -> Prop) * ((nat -> Prop) * Prop)
 ! '{{x, y}}, x.y = 0
      : Prop
-exists x : nat,
-  nat -> exists y : nat, nat -> exists_mixed '{{u, t}}, x.y = 0 /\ u.t = 0
+exists_mixed (x y : nat) '{{u, t}}, x.y = 0 /\ u.t = 0
      : Prop
-exists x : nat,
-  nat ->
-  exists y : nat,
-    nat -> exists '{{z, t}}, forall z0 : nat, z0 = 0 /\ x.y = 0 /\ z.t = 0
+exists_mixed (x y : nat) '{{z, t}}, x.y = 0 /\ z.t = 0
      : Prop
 exists_true '{{x, y}} (u := 0) '{{z, t}}, x.y = 0 /\ z.t = 0
      : Prop

--- a/test-suite/output/Notations3.out
+++ b/test-suite/output/Notations3.out
@@ -145,7 +145,7 @@ exists_true (A : Type) (R : A -> A -> Prop) (_ : Reflexive R),
 exists_true (x : nat) (A : Type) (R : A -> A -> Prop) 
 (_ : Reflexive R) (y : nat), x.y = 0 -> forall z : A, R z z
      : Prop
-{{{{True, nat -> True}}, nat -> True}}
+!! _ _ : nat # True #
      : Prop * Prop * Prop
 {{D 1, 2}}
      : nat * nat * (nat * nat * (nat * nat))


### PR DESCRIPTION
4 commits:
- 1st commit is short preparation work
- 2nd commit refines when anonymous binders are supported for `forall`; for instance, it allows to print the following as it is parsed while still giving priority to using `A -> B` over an anonymous `forall` in notations involving a recursive `forall`:
  ```coq
  Notation "!! x .. y # A #" := (.. (A,(forall x, True)) ..,(forall y, True)) (at level 200, x binder).
  Check !! _ _ : nat # True #
  ```
- 3rd commit takes anonymous binders into account for recursive notations:
  - first, it accepts that a named binder is possibly not binding in practice and accepts to match it with `Anonymous` (this was a priori an unrealistic situation without recursive notations)
  - second, the alpha-renaming map is propagated when matching the iterator of a recursive notation rather than lost; for instance, the following is now printed as parsed, independently of the choice of internal names and thus independently of possible internal renamings made in `detyping.ml` (see [this comment of #17037](https://github.com/coq/coq/pull/17037#discussion_r1059370363))
  ```coq
  Notation "'exists_mixed' x .. y , P" :=
   (ex (fun x => forall z:nat, .. (ex (fun y => forall z:nat, z=0 /\ P)) ..)) (at level 200, x binder).
  Check exists_mixed x y '(u,t), x+y=0/\u+t=0. 
  ```
- 4th commit is cleaning/documenting the alpha-conversion maps; it is the largest commit but it has no semantic change in principle (it could be put in another PR if there is a demand for it)

- [X] Added / updated **test-suite**.

The changes are a priori too anecdotical to be worth a changelog
