### PR TITLE
Split defined and undefined evar infos using a type parameter.

### DIFF
--- a/dev/ci/user-overlays/17053-ppedrot-classify-evar-find-type.sh
+++ b/dev/ci/user-overlays/17053-ppedrot-classify-evar-find-type.sh
@@ -1,0 +1,11 @@
+overlay elpi https://github.com/ppedrot/coq-elpi classify-evar-find-type 17053
+
+overlay equations https://github.com/ppedrot/Coq-Equations classify-evar-find-type 17053
+
+overlay mtac2 https://github.com/ppedrot/Mtac2 classify-evar-find-type 17053
+
+overlay serapi https://github.com/ppedrot/coq-serapi classify-evar-find-type 17053
+
+overlay unicoq https://github.com/ppedrot/unicoq classify-evar-find-type 17053
+
+overlay vscoq https://github.com/ppedrot/vscoq classify-evar-find-type 17053

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -378,7 +378,8 @@ let map_instance sigma f evk args =
     else SList.cons c' rem'
   | [], Some _ | _ :: _, None -> assert false
   in
-  let ctx = Evd.evar_filtered_context @@ Evd.find sigma evk in
+  let EvarInfo evi = Evd.find sigma evk in
+  let ctx = Evd.evar_filtered_context evi in
   map ctx args
 
 let map sigma f c =

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -710,7 +710,7 @@ let cached_evar_of_hyp cache sigma decl accu = match cache with
   in
   Evar.Set.fold Evar.Set.add evs accu
 
-let filtered_undefined_evars_of_evar_info ?cache sigma evi =
+let filtered_undefined_evars_of_evar_info (type a) ?cache sigma (evi : a evar_info) =
   let evars_of_named_context cache accu nc =
     let fold decl accu = cached_evar_of_hyp cache sigma (EConstr.of_named_decl decl) accu in
     Context.Named.fold_outside fold nc ~init:accu

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -95,7 +95,7 @@ let nf_env_evar sigma env =
 let nf_evar_info evc info = map_evar_info (nf_evar evc) info
 
 let nf_evar_map evm =
-  Evd.raw_map (fun _ evi -> nf_evar_info evm evi) evm
+  Evd.raw_map { map = fun _ evi -> nf_evar_info evm evi } evm
 
 let nf_evar_map_undefined evm =
   Evd.raw_map_undefined (fun _ evi -> nf_evar_info evm evi) evm
@@ -250,7 +250,7 @@ let csubst_subst sigma { csubst_len = k; csubst_var = v; csubst_rel = s } c =
   | Var id ->
     begin try Id.Map.find id v with Not_found -> c end
   | Evar (evk, args) ->
-    let evi = Evd.find sigma evk in
+    let EvarInfo evi = Evd.find sigma evk in
     let args' = subst_instance n (evar_filtered_context evi) args in
     if args' == args then c else Constr.mkEvar (evk, args') (* FIXME: preserve sharing *)
   | _ -> Constr.map_with_binders succ subst n c
@@ -632,7 +632,7 @@ let clear_hyps2_in_evi env sigma hyps t concl ids =
    goal ([advance] is used to figure if a side effect has modified the
    goal) it terminates quickly. *)
 let rec advance sigma evk =
-  let evi = Evd.find sigma evk in
+  let EvarInfo evi = Evd.find sigma evk in
   match Evd.evar_body evi with
   | Evar_empty -> Some evk
   | Evar_defined v ->

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -105,7 +105,7 @@ type undefined_evars_cache
 
 val create_undefined_evars_cache : unit -> undefined_evars_cache
 
-val filtered_undefined_evars_of_evar_info : ?cache:undefined_evars_cache -> evar_map -> evar_info -> Evar.Set.t
+val filtered_undefined_evars_of_evar_info : ?cache:undefined_evars_cache -> evar_map -> 'a evar_info -> Evar.Set.t
 
 (** [occur_evar_upto sigma k c] returns [true] if [k] appears in
     [c]. It looks up recursively in [sigma] for the value of existential
@@ -137,7 +137,7 @@ val nf_named_context_evar : evar_map -> Constr.named_context -> Constr.named_con
 val nf_rel_context_evar : evar_map -> rel_context -> rel_context
 val nf_env_evar : evar_map -> env -> env
 
-val nf_evar_info : evar_map -> evar_info -> evar_info
+val nf_evar_info : evar_map -> 'a evar_info -> 'a evar_info
 val nf_evar_map : evar_map -> evar_map
 val nf_evar_map_undefined : evar_map -> evar_map
 

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -205,25 +205,23 @@ module Store = Store.Make ()
 
 let string_of_existential evk = "?X" ^ string_of_int (Evar.repr evk)
 
-type evar_body =
-  | Evar_empty
-  | Evar_defined of constr
-
 type defined = [ `defined ]
 type undefined = [ `undefined ]
 
-type evar_info0 = {
+type _ evar_body =
+  | Evar_empty : undefined evar_body
+  | Evar_defined : econstr -> defined evar_body
+
+type 'a evar_info = {
   evar_concl : constr;
   evar_hyps : named_context_val;
-  evar_body : evar_body;
+  evar_body : 'a evar_body;
   evar_filter : Filter.t;
   evar_abstract_arguments : Abstraction.t;
   evar_source : Evar_kinds.t Loc.located;
   evar_candidates : constr list option; (* if not None, list of allowed instances *)
   evar_relevance: Sorts.relevance;
 }
-
-type 'a evar_info = evar_info0
 
 type any_evar_info = EvarInfo : 'a evar_info -> any_evar_info
 
@@ -274,7 +272,7 @@ let evar_identity_subst evi =
   in
   SList.defaultn len SList.empty
 
-let map_evar_body f = function
+let map_evar_body (type a) f : a evar_body -> a evar_body = function
   | Evar_empty -> Evar_empty
   | Evar_defined d -> Evar_defined (f d)
 
@@ -733,7 +731,7 @@ let is_maybe_typeclass sigma c = Hook.get get_is_maybe_typeclass sigma c
 let rename evk id evd =
   { evd with evar_names = EvNames.rename evk id evd.evar_names }
 
-let add_with_name ?name ?(typeclass_candidate = true) d e i = match i.evar_body with
+let add_with_name (type a) ?name ?(typeclass_candidate = true) d e (i : a evar_info) = match i.evar_body with
 | Evar_empty ->
   let evar_names = EvNames.add_name_undefined name e i d.evar_names in
   let evar_flags =
@@ -843,30 +841,11 @@ let fold_undefined f d a = EvMap.fold f d.undf_evars a
 type map = { map : 'r. Evar.t -> 'r evar_info -> 'r evar_info }
 
 let raw_map f d =
-  let f evk info =
-    let ans = f.map evk info in
-    let () = match info.evar_body, ans.evar_body with
-    | Evar_defined _, Evar_empty
-    | Evar_empty, Evar_defined _ ->
-      anomaly (str "Unrespectful mapping function.")
-    | _ -> ()
-    in
-    ans
-  in
-  let defn_evars = EvMap.Smart.mapi f d.defn_evars in
-  let undf_evars = EvMap.Smart.mapi f d.undf_evars in
+  let defn_evars = EvMap.Smart.mapi f.map d.defn_evars in
+  let undf_evars = EvMap.Smart.mapi f.map d.undf_evars in
   { d with defn_evars; undf_evars; }
 
 let raw_map_undefined f d =
-  let f evk info =
-    let ans = f evk info in
-    let () = match ans.evar_body with
-    | Evar_defined _ ->
-      anomaly (str "Unrespectful mapping function.")
-    | _ -> ()
-    in
-    ans
-  in
   { d with undf_evars = EvMap.Smart.mapi f d.undf_evars; }
 
 let is_evar = mem
@@ -879,9 +858,8 @@ let existential_opt_value d (n, args) =
   match EvMap.find_opt n d.defn_evars with
   | None -> None
   | Some info ->
-    match evar_body info with
-    | Evar_defined c -> Some (instantiate_evar_array d info c args)
-    | Evar_empty -> None (* impossible but w/e *)
+    let Evar_defined c = evar_body info in
+    Some (instantiate_evar_array d info c args)
 
 let existential_value d ev = match existential_opt_value d ev with
   | None -> raise NotInstantiatedEvar
@@ -1672,9 +1650,8 @@ module MiniEConstr = struct
         Some (mkEvar (evk, SList.of_full_list args))
       else None
     | Some info ->
-      match evar_body info with
-      | Evar_defined c -> Some (instantiate_evar_array sigma info c args)
-      | Evar_empty -> assert false
+      let Evar_defined c = evar_body info in
+      Some (instantiate_evar_array sigma info c args)
     in
     let lsubst = universe_subst sigma in
     let level_value l =
@@ -1753,7 +1730,7 @@ let evars_of_named_context evd nc =
     nc
     ~init:Evar.Set.empty
 
-let evars_of_filtered_evar_info evd evi =
+let evars_of_filtered_evar_info (type a) evd (evi : a evar_info) =
   Evar.Set.union (evars_of_term evd evi.evar_concl)
     (Evar.Set.union
        (match evi.evar_body with

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -95,12 +95,12 @@ end
 
 (** {6 Evar infos} *)
 
-type evar_body =
-  | Evar_empty
-  | Evar_defined of econstr
-
 type defined = [ `defined ]
 type undefined = [ `undefined ]
+
+type _ evar_body =
+  | Evar_empty : undefined evar_body
+  | Evar_defined : econstr -> defined evar_body
 
 type 'a evar_info
 
@@ -117,7 +117,7 @@ val evar_context : 'a evar_info -> (econstr, etypes) Context.Named.pt
 val evar_hyps : 'a evar_info -> named_context_val
 (** Context of the evar. *)
 
-val evar_body : 'a evar_info -> evar_body
+val evar_body : 'a evar_info -> 'a evar_body
 (** Optional content of the evar. *)
 
 val evar_candidates : 'a evar_info -> econstr list option
@@ -146,7 +146,7 @@ val evar_env : env -> 'a evar_info -> env
 val evar_filtered_env : env -> 'a evar_info -> env
 val evar_identity_subst : 'a evar_info -> econstr SList.t
 
-val map_evar_body : (econstr -> econstr) -> evar_body -> evar_body
+val map_evar_body : (econstr -> econstr) -> 'a evar_body -> 'a evar_body
 val map_evar_info : (econstr -> econstr) -> 'a evar_info -> 'a evar_info
 
 (** {6 Unification state} **)

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -884,7 +884,7 @@ module Progress = struct
     (* NB: can't use List.equal because it shortcuts on physical equality *)
     List.for_all2eq eq_named_declaration c1 c2
 
-  let eq_evar_body sigma1 sigma2 b1 b2 =
+  let eq_evar_body (type a1 a2) sigma1 sigma2 (b1 : a1 Evd.evar_body) (b2 : a2 Evd.evar_body) =
     let open Evd in
     match b1, b2 with
     | Evar_empty, Evar_empty -> true

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -651,7 +651,7 @@ let free_evars sigma l =
   (* Computes the set of evars appearing in the hypotheses, the conclusion or
      the body of the evar_info [evi]. Note: since we want to use it on goals,
      the body is actually supposed to be empty. *)
-    let evi = Evd.find sigma ev in
+    let EvarInfo evi = Evd.find sigma ev in
     let fevs = lazy (Evarutil.filtered_undefined_evars_of_evar_info ~cache sigma evi) in
     (ev, fevs)
   in
@@ -664,7 +664,7 @@ let free_evars_with_state sigma l =
      the body of the evar_info [evi]. Note: since we want to use it on goals,
      the body is actually supposed to be empty. *)
     let ev = drop_state ev in
-    let evi = Evd.find sigma ev in
+    let EvarInfo evi = Evd.find sigma ev in
     let fevs = lazy (Evarutil.filtered_undefined_evars_of_evar_info ~cache sigma evi) in
     (ev, fevs)
   in
@@ -736,7 +736,7 @@ let mark_in_evm ~goal evd evars =
   let evd =
     if goal then
       let mark evd content =
-        let info = Evd.find evd content in
+        let EvarInfo info = Evd.find evd content in
         let source = match Evd.evar_source info with
         (* Two kinds for goal evars:
             - GoalEvar (morally not dependent)
@@ -898,8 +898,8 @@ module Progress = struct
 
   (** Equality function on goals *)
   let goal_equal ~evd ~extended_evd evar extended_evar =
-    let evi = Evd.find evd evar in
-    let extended_evi = Evd.find extended_evd extended_evar in
+    let EvarInfo evi = Evd.find evd evar in
+    let EvarInfo extended_evi = Evd.find extended_evd extended_evar in
     eq_evar_info evd extended_evd evi extended_evi
 
 end
@@ -1087,7 +1087,7 @@ module Goal = struct
   let gmake env sigma goal =
     let state = get_state goal in
     let goal = drop_state goal in
-    let info = Evd.find sigma goal in
+    let EvarInfo info = Evd.find sigma goal in
     gmake_with info env sigma goal state
 
   let enter f =

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -151,7 +151,7 @@ let pr_evar_source env sigma = function
      | Some Evar_kinds.Domain -> str "domain of "
      | Some Evar_kinds.Codomain -> str "codomain of ") ++ Evar.print evk
 
-let pr_evar_info env sigma evi =
+let pr_evar_info (type a) env sigma (evi : a Evd.evar_info) =
   let open Evd in
   let print_constr = print_kconstr in
   let phyps =
@@ -328,9 +328,10 @@ let pr_evar_list env sigma l =
     h (Evar.print ev ++
       str "==" ++ pr_evar_info env sigma evi ++
       pr_alias ev ++
-      (if Evd.evar_body evi == Evar_empty
-       then str " {" ++ pr_existential_key env sigma ev ++ str "}"
-       else mt ()))
+      begin match Evd.evar_body evi with
+      | Evar_empty -> str " {" ++ pr_existential_key env sigma ev ++ str "}"
+      | Evar_defined _ -> mt ()
+      end)
   in
   hv 0 (prlist_with_sep fnl pr l)
 

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -184,7 +184,7 @@ let pr_evar_info env sigma evi =
 let compute_evar_dependency_graph sigma =
   let open Evd in
   (* Compute the map binding ev to the evars whose body depends on ev *)
-  let fold evk evi acc =
+  let fold evk (EvarInfo evi) acc =
     let fold_ev evk' acc =
       let tab =
         try EvMap.find evk' acc
@@ -324,7 +324,7 @@ let pr_evar_list env sigma l =
     | None -> mt ()
     | Some ev' -> str " (aliased to " ++ Evar.print ev' ++ str ")"
   in
-  let pr (ev, evi) =
+  let pr (ev, EvarInfo evi) =
     h (Evar.print ev ++
       str "==" ++ pr_evar_info env sigma evi ++
       pr_alias ev ++
@@ -338,12 +338,12 @@ let to_list d =
   let open Evd in
   (* Workaround for change in Map.fold behavior in ocaml 3.08.4 *)
   let l = ref [] in
-  let fold_def evk evi () = match Evd.evar_body evi with
-    | Evar_defined _ -> l := (evk, evi) :: !l
+  let fold_def evk (EvarInfo evi) () = match Evd.evar_body evi with
+    | Evar_defined _ -> l := (evk, EvarInfo evi) :: !l
     | Evar_empty -> ()
   in
-  let fold_undef evk evi () = match Evd.evar_body evi with
-    | Evar_empty -> l := (evk, evi) :: !l
+  let fold_undef evk (EvarInfo evi) () = match Evd.evar_body evi with
+    | Evar_empty -> l := (evk, EvarInfo evi) :: !l
     | Evar_defined _ -> ()
   in
   Evd.fold fold_def d ();
@@ -365,7 +365,7 @@ let pr_evar_by_filter filter env sigma =
   let open Evd in
   let elts = Evd.fold (fun evk evi accu -> (evk, evi) :: accu) sigma [] in
   let elts = List.rev elts in
-  let is_def (_, evi) = match Evd.evar_body evi with
+  let is_def (_, EvarInfo evi) = match Evd.evar_body evi with
   | Evar_defined _ -> true
   | Evar_empty -> false
   in

--- a/engine/termops.mli
+++ b/engine/termops.mli
@@ -285,10 +285,10 @@ val pr_existential_key : env -> evar_map -> Evar.t -> Pp.t
 
 val evar_suggested_name : env -> evar_map -> Evar.t -> Id.t
 
-val pr_evar_info : env -> evar_map -> evar_info -> Pp.t
+val pr_evar_info : env -> evar_map -> 'a evar_info -> Pp.t
 val pr_evar_constraints : evar_map -> evar_constraint list -> Pp.t
 val pr_evar_map : ?with_univs:bool -> int option -> env -> evar_map -> Pp.t
-val pr_evar_map_filter : ?with_univs:bool -> (Evar.t -> evar_info -> bool) ->
+val pr_evar_map_filter : ?with_univs:bool -> (Evar.t -> any_evar_info -> bool) ->
   env -> evar_map -> Pp.t
 val pr_metaset : Metaset.t -> Pp.t
 val pr_evar_universe_context : UState.t -> Pp.t

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -1354,7 +1354,8 @@ let rec glob_of_pat avoid env sigma pat = DAst.make @@ match pat with
   | PVar id  -> GVar id
   | PEvar (evk,l) ->
       let filter (id, pat) = match pat with PVar id' -> Id.equal id id' | _ -> true in
-      let hyps = Evd.evar_filtered_context (Evd.find sigma evk) in
+      let EvarInfo evi = Evd.find sigma evk in
+      let hyps = Evd.evar_filtered_context evi in
       let map decl pat = NamedDecl.get_id decl, pat in
       let l = List.filter filter @@ List.map2 map hyps l in
       let id = match Evd.evar_ident evk sigma with

--- a/plugins/ssr/ssrview.ml
+++ b/plugins/ssr/ssrview.ml
@@ -307,7 +307,7 @@ Goal.enter_one ~__LOC__ begin fun g ->
   let sigma = Typeclasses.resolve_typeclasses ~fail:false ~filter env sigma in
   let _, sigma = Evd.pop_shelf sigma in
   let p = Reductionops.nf_evar sigma p in
-  let get_body = function Evd.Evar_defined x -> x | _ -> assert false in
+  let get_body : type a. a Evd.evar_body -> EConstr.t = function Evd.Evar_defined x -> x | Evd.Evar_empty -> assert false in
   let evars_of_econstr sigma t =
     Evarutil.undefined_evars_of_term sigma t in
   let rigid_of s =

--- a/plugins/ssr/ssrview.ml
+++ b/plugins/ssr/ssrview.ml
@@ -313,14 +313,15 @@ Goal.enter_one ~__LOC__ begin fun g ->
   let rigid_of s =
     List.fold_left (fun l k ->
       if Evd.is_defined sigma k then
-        let bo = get_body Evd.(evar_body (find sigma k)) in
+        let EvarInfo evi = Evd.find sigma k in
+        let bo = get_body (Evd.evar_body evi) in
           k :: l @ Evar.Set.elements (evars_of_econstr sigma bo)
       else l
     ) [] s in
   let env0 = Proofview.Goal.env s0 in
   let sigma0 = Proofview.Goal.sigma s0 in
   let und0 = (* Unassigned evars in the initial goal *)
-    let g0info = Evd.find sigma0 (Proofview.Goal.goal s0) in
+    let EvarInfo g0info = Evd.find sigma0 (Proofview.Goal.goal s0) in
     let g0 = Evd.evars_of_filtered_evar_info sigma0 g0info in
     List.filter (fun k -> Evar.Set.mem k g0)
       (List.map fst (Evar.Map.bindings (Evd.undefined_map sigma0))) in

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -232,7 +232,9 @@ let nf_open_term sigma0 ise c =
       s' := Evd.add !s' k (Evarutil.nf_evar_info ise (Evd.find_undefined ise k));
     mkEvar (k, a')
   | _ -> map ise nf c' in
-  let copy_def k _ () = match Evd.evar_body (Evd.find ise k) with
+  let copy_def k _ () =
+  let EvarInfo evi = Evd.find ise k in
+  match Evd.evar_body evi with
   | Evar_defined c' ->
     let c' = nf c' in
     s' := Evd.define k c' !s'
@@ -1080,7 +1082,8 @@ let interp_pattern ?wit_ssrpatternarg env sigma0 red redty =
       let name = ref None in
       try ignore(Context.Named.lookup x ctx); (name, fun k ->
         if !name = None then
-        let nctx = Evd.evar_context (Evd.find sigma k) in
+        let EvarInfo evi = Evd.find sigma k in
+        let nctx = Evd.evar_context evi in
         let nlen = Context.Named.length nctx in
         if nlen > len then begin
           name := Some (Context.Named.Declaration.get_id (List.nth nctx (nlen - len - 1)))
@@ -1193,7 +1196,7 @@ let eval_pattern ?raise_NoMatch env0 sigma0 concl0 pattern occ (do_subst : subst
   let rigid ev = Evd.mem sigma0 ev in
   let fs sigma x = Reductionops.nf_evar sigma x in
   let pop_evar sigma e p =
-    let e_def = Evd.find sigma e in
+    let EvarInfo e_def = Evd.find sigma e in
     let e_body = match Evd.evar_body e_def with Evar_defined c -> c
     | _ -> errorstrm (str "Matching the pattern " ++ pr_econstr_env env0 sigma0 p ++
           str " did not instantiate ?" ++ int (Evar.repr e) ++ spc () ++

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -1060,7 +1060,9 @@ let adjust_impossible_cases sigma pb pred tomatch submat =
        evar. See e.g. first definition of test for bug #3388. *)
     let pred = EConstr.Unsafe.to_constr pred in
     begin match Constr.kind pred with
-    | Evar (evk,_) when snd (Evd.evar_source (Evd.find sigma evk)) == Evar_kinds.ImpossibleCase ->
+    | Evar (evk, _) ->
+      let EvarInfo evi = Evd.find sigma evk in
+      if snd (Evd.evar_source evi) == Evar_kinds.ImpossibleCase then
         let sigma =
           if not (Evd.is_defined sigma evk) then
             let sigma, default = coq_unit_judge !!(pb.env) sigma in
@@ -1069,6 +1071,8 @@ let adjust_impossible_cases sigma pb pred tomatch submat =
           else sigma
         in
         sigma, add_assert_false_case pb tomatch
+      else
+        sigma, submat
     | _ ->
         sigma, submat
     end

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -1514,7 +1514,8 @@ let second_order_matching flags env_rhs evd (evk,args) (test,argoccs) rhs =
                 env_evar_unf evd evty
             else evd, evty in
           let (evd, evk) = new_pure_evar sign evd evty ~filter in
-          let instance = Evd.evar_identity_subst (Evd.find evd evk) in
+          let EvarInfo evi = Evd.find evd evk in
+          let instance = Evd.evar_identity_subst evi in
           let fixed = Evar.Set.add evk fixed in
           evsref := (evk,evty,inst,prefer_abstraction)::!evsref;
           evd, fixed, mkEvar (evk, instance)
@@ -1571,7 +1572,7 @@ let second_order_matching flags env_rhs evd (evk,args) (test,argoccs) rhs =
          let candidates = [inst; vid] in
            try
              let evd, ev = Evarutil.restrict_evar evd evk (Evd.evar_filter evi) (Some candidates) in
-             let evi = Evd.find evd ev in
+             let EvarInfo evi = Evd.find evd ev in
                (match evar_candidates evi with
                | Some [t] ->
                  if not (noccur_evar env_rhs evd ev t) then
@@ -1585,7 +1586,7 @@ let second_order_matching flags env_rhs evd (evk,args) (test,argoccs) rhs =
               user_err (Pp.str "Cannot find an instance.")
          else
            ((debug_ho_unification (fun () ->
-               let evi = Evd.find evd evk in
+               let EvarInfo evi = Evd.find evd evk in
                let env = Evd.evar_env env_rhs evi in
                Pp.(str"evar is defined: " ++
                  int (Evar.repr evk) ++ spc () ++
@@ -1601,7 +1602,7 @@ let second_order_matching flags env_rhs evd (evk,args) (test,argoccs) rhs =
            instantiate evk itself. *)
        (debug_ho_unification (fun () ->
           begin
-            let evi = Evd.find evd evk in
+            let EvarInfo evi = Evd.find evd evk in
             let evenv = evar_env env_rhs evi in
             let body = match evar_body evi with Evar_empty -> assert false | Evar_defined c -> c in
             Pp.(str"evar was defined already as: " ++ prc evenv evd body)
@@ -1749,7 +1750,7 @@ let check_problems_are_solved env evd =
   | (pbty,env,t1,t2) as pb::_ -> error_cannot_unify env evd pb t1 t2
   | _ -> ()
 
-exception MaxUndefined of (Evar.t * evar_info * EConstr.t list)
+exception MaxUndefined of (Evar.t * undefined evar_info * EConstr.t list)
 
 let max_undefined_with_candidates evd =
   let fold evk evi () = match Evd.evar_candidates evi with

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -412,7 +412,7 @@ and nf_predicate env sigma ind mip params pctx v pT =
     | _ -> assert false
 
 and nf_evar env sigma evk args =
-  let evi = try Evd.find sigma evk with Not_found -> assert false in
+  let EvarInfo evi = try Evd.find sigma evk with Not_found -> assert false in
   let hyps = EConstr.named_context_of_val (Evd.evar_filtered_hyps evi) in
   if List.is_empty hyps then begin
     assert (Array.is_empty args);

--- a/pretyping/patternops.ml
+++ b/pretyping/patternops.ml
@@ -179,7 +179,8 @@ let pattern_of_constr ~broken env sigma t =
         (match
           match kind f with
           | Evar (evk,args) ->
-            (match snd (Evd.evar_source (Evd.find sigma evk)) with
+            let EvarInfo evi = Evd.find sigma evk in
+            (match snd (Evd.evar_source evi) with
               Evar_kinds.MatchingVar (Evar_kinds.SecondOrderPatVar id) -> Some id
             | _ -> None)
           | _ -> None
@@ -192,7 +193,8 @@ let pattern_of_constr ~broken env sigma t =
     | Proj (p, c) ->
       pattern_of_constr env (EConstr.Unsafe.to_constr (Retyping.expand_projection env sigma p (EConstr.of_constr c) []))
     | Evar (evk,ctxt as ev) ->
-      (match snd (Evd.evar_source (Evd.find sigma evk)) with
+      let EvarInfo evi = Evd.find sigma evk in
+      (match snd (Evd.evar_source evi) with
       | Evar_kinds.MatchingVar (Evar_kinds.FirstOrderPatVar id) ->
         PMeta (Some id)
       | Evar_kinds.GoalEvar | Evar_kinds.VarInstance _ ->

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -209,7 +209,7 @@ type pretype_flags = {
    [sigma] by restriction, and the evars properly created in [sigma'] *)
 
 type frozen =
-| FrozenId of evar_info Evar.Map.t
+| FrozenId of undefined evar_info Evar.Map.t
   (** No pending evars. We do not put a set here not to reallocate like crazy,
       but the actual data of the map is not used, only keys matter. All
       functions operating on this type must have the same behaviour on
@@ -301,7 +301,8 @@ let check_evars env ?initial sigma c =
       (match initial with
        | Some initial when Evd.mem initial evk -> ()
        | _ ->
-         let (loc,k) = evar_source (Evd.find sigma evk) in
+        let EvarInfo evi = Evd.find sigma evk in
+         let (loc,k) = evar_source evi in
          begin match k with
            | Evar_kinds.ImplicitArg (gr, (i, id), false) -> ()
            | _ -> Pretype_errors.error_unsolvable_implicit ?loc env sigma evk None
@@ -348,7 +349,7 @@ let process_inference_flags flags env initial (sigma,c,cty) =
 let adjust_evar_source sigma na c =
   match na, kind sigma c with
   | Name id, Evar (evk,args) ->
-     let evi = Evd.find sigma evk in
+     let EvarInfo evi = Evd.find sigma evk in
      begin match Evd.evar_source evi with
      | loc, Evar_kinds.QuestionMark {
          Evar_kinds.qm_obligation=b;
@@ -655,7 +656,8 @@ struct
       let evk =
         try Evd.evar_key id sigma
         with Not_found -> error_evar_not_found ?loc:locid !!env sigma id in
-      let hyps = evar_filtered_context (Evd.find sigma evk) in
+      let EvarInfo evi = Evd.find sigma evk in
+      let hyps = evar_filtered_context evi in
       let sigma, args = pretype_instance self ~flags env sigma loc hyps evk inst in
       let c = mkLEvar sigma (evk, args) in
       let j = Retyping.get_judgment_of !!env sigma c in

--- a/pretyping/typeclasses.ml
+++ b/pretyping/typeclasses.ml
@@ -241,7 +241,7 @@ let has_typeclasses filter evd =
 
 let get_filtered_typeclass_evars filter evd =
   let tcs = get_typeclass_evars evd in
-  let check ev = filter ev (lazy (snd (Evd.evar_source (Evd.find evd ev)))) in
+  let check ev = filter ev (lazy (snd (Evd.evar_source (Evd.find_undefined evd ev)))) in
   Evar.Set.filter check tcs
 
 let solve_all_instances_hook = ref (fun env evd filter unique split fail -> assert false)

--- a/pretyping/typeclasses.mli
+++ b/pretyping/typeclasses.mli
@@ -116,7 +116,7 @@ val no_goals_or_obligations : evar_filter
 
 val make_unresolvables : (Evar.t -> bool) -> evar_map -> evar_map
 
-val is_class_evar : evar_map -> evar_info -> bool
+val is_class_evar : evar_map -> undefined evar_info -> bool
 val is_class_type : evar_map -> EConstr.types -> bool
 
 val resolve_typeclasses : ?filter:evar_filter -> ?unique:bool ->

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -70,7 +70,8 @@ let occur_meta_or_undefined_evar evd c =
   let rec occrec c = match Constr.kind c with
     | Meta _ -> raise Occur
     | Evar (ev,args) ->
-        (match evar_body (Evd.find evd ev) with
+      let EvarInfo evi = Evd.find evd ev in
+        (match evar_body evi with
         | Evar_defined c ->
             occrec (EConstr.Unsafe.to_constr c); SList.Skip.iter occrec args
         | Evar_empty -> raise Occur)

--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -214,7 +214,7 @@ and nf_univ_args ~nb_univs mk env sigma stk =
   nf_stk ~from:nb_univs env sigma t ty stk
 
 and nf_evar env sigma evk stk =
-  let evi = try Evd.find sigma evk with Not_found -> assert false in
+  let EvarInfo evi = try Evd.find sigma evk with Not_found -> assert false in
   let hyps = EConstr.named_context_of_val (Evd.evar_filtered_hyps evi) in
   if List.is_empty hyps then
     let concl = EConstr.to_constr ~abort_on_undefined_evars:false sigma @@ Evd.evar_concl evi in

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -526,7 +526,7 @@ let pr_concl n ?diffs sigma g =
   header ++ str " is:" ++ cut () ++ str" "  ++ pc
 
 (* display evar type: a context and a type *)
-let pr_evgl_sign env sigma evi =
+let pr_evgl_sign (type a) env sigma (evi : a evar_info) =
   let env = evar_env env evi in
   let ps = pr_named_context_of env sigma in
   let _, l = match Filter.repr (evar_filter evi) with

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -470,7 +470,7 @@ let pr_transparent_state ts =
         str"CONSTANTS: " ++ pr_cpred ts.TransparentState.tr_cst ++ fnl ())
 
 let goal_repr sigma g =
-  let evi = Evd.find sigma g in
+  let EvarInfo evi = Evd.find sigma g in
   Evd.evar_filtered_env (Global.env ()) evi, Evd.evar_concl evi
 
 (* display complete goal
@@ -576,13 +576,14 @@ let pr_evars_int sigma ~shelf ~given_up i evs =
     sigma i (Evar.Map.bindings evs)
 
 let pr_evars sigma evs =
-  pr_evars_int_hd (fun i evk evi -> pr_evar sigma (evk,evi)) sigma 1 (Evar.Map.bindings evs)
+  pr_evars_int_hd (fun i evk (EvarInfo evi) -> pr_evar sigma (evk,evi)) sigma 1 (Evar.Map.bindings evs)
 
 (* Display a list of evars given by their name, with a prefix *)
 let pr_ne_evar_set hd tl sigma l =
   if l != Evar.Set.empty then
     let l = Evar.Set.fold (fun ev ->
-      Evar.Map.add ev (Evarutil.nf_evar_info sigma (Evd.find sigma ev)))
+      let EvarInfo evi = Evd.find sigma ev in
+      Evar.Map.add ev (EvarInfo (Evarutil.nf_evar_info sigma evi)))
       l Evar.Map.empty in
     hd ++ pr_evars sigma l ++ tl
   else
@@ -677,7 +678,7 @@ let queue_term q is_dependent c =
   queue_set q is_dependent (evar_nodes_of_term c)
 
 let process_dependent_evar q acc evm is_dependent e =
-  let evi = Evd.find evm e in
+  let EvarInfo evi = Evd.find evm e in
   (* Queues evars appearing in the types of the goal (conclusion, then
      hypotheses), they are all dependent. *)
   queue_term q true (Evd.evar_concl evi);
@@ -726,7 +727,7 @@ let gather_dependent_evars evm l =
 
 let gather_dependent_evars_goal sigma goals =
   let map evk =
-    let evi = Evd.find sigma evk in
+    let EvarInfo evi = Evd.find sigma evk in
     EConstr.mkEvar (evk, Evd.evar_identity_subst evi)
   in
   gather_dependent_evars sigma (List.map map goals)

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -196,8 +196,8 @@ val pr_transparent_state   : TransparentState.t -> Pp.t
 *)
 val pr_open_subgoals       : ?quiet:bool -> ?diffs:Proof.t option -> Proof.t -> Pp.t
 val pr_nth_open_subgoal    : proof:Proof.t -> int -> Pp.t
-val pr_evar                : evar_map -> (Evar.t * evar_info) -> Pp.t
-val pr_evars_int           : evar_map -> shelf:Evar.t list -> given_up:Evar.t list -> int -> evar_info Evar.Map.t -> Pp.t
+val pr_evar                : evar_map -> (Evar.t * 'a evar_info) -> Pp.t
+val pr_evars_int           : evar_map -> shelf:Evar.t list -> given_up:Evar.t list -> int -> 'a evar_info Evar.Map.t -> Pp.t
 val pr_ne_evar_set         : Pp.t -> Pp.t -> evar_map ->
   Evar.Set.t -> Pp.t
 

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -243,7 +243,7 @@ let to_tuple : Constr.compacted_declaration -> (Names.Id.t Context.binder_annot 
     | LocalDef(idl,tdef,tm) -> (idl, Some (EConstr.of_constr tdef), EConstr.of_constr tm)
 
 let make_goal env sigma g =
-  let evi = Evd.find sigma g in
+  let EvarInfo evi = Evd.find sigma g in
   let env = Evd.evar_filtered_env env evi in
   let ty  = Evd.evar_concl evi in
   { ty; env; sigma }

--- a/stm/partac.ml
+++ b/stm/partac.ml
@@ -116,7 +116,8 @@ end = struct (* {{{ *)
             ComTactic.solve ~pstate
               Goal_select.SelectAll ~info:None tactic ~with_end_tac:false in
           let { Proof.sigma } = Declare.Proof.fold pstate ~f:Proof.data in
-          match Evd.(evar_body (find sigma r_goal)) with
+          let EvarInfo evi = Evd.find sigma r_goal in
+          match Evd.(evar_body evi) with
           | Evd.Evar_empty -> RespNoProgress
           | Evd.Evar_defined t ->
               let t = Evarutil.nf_evar sigma t in

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -383,9 +383,9 @@ let check_evars env sigma extsigma origsigma =
                           (Evar.Map.domain (Evd.undefined_map origsigma))) in
   let rec is_undefined_up_to_restriction sigma evk =
     if Evd.mem origsigma evk then None else
-    let evi = Evd.find sigma evk in
+    let EvarInfo evi = Evd.find sigma evk in
     match Evd.evar_body evi with
-    | Evd.Evar_empty -> Some (evk,evi)
+    | Evd.Evar_empty -> Some (evk, Evd.EvarInfo evi)
     | Evd.Evar_defined c -> match Constr.kind (EConstr.Unsafe.to_constr c) with
       | Evar (evk,l) -> is_undefined_up_to_restriction sigma evk
       | _ ->
@@ -407,7 +407,7 @@ let check_evars env sigma extsigma origsigma =
   in
   match rest with
   | [] -> ()
-  | (evk,evi) :: _ ->
+  | (evk, EvarInfo evi) :: _ ->
     let (loc,_) = Evd.evar_source evi in
     Pretype_errors.error_unsolvable_implicit ?loc env sigma evk None
 

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1378,7 +1378,7 @@ module Proof_ending = struct
     | End_equations of
         { hook : pm:Obls_.State.t -> Constant.t list -> Evd.evar_map -> Obls_.State.t
         ; i : Id.t
-        ; types : (Environ.env * Evar.t * Evd.evar_info * EConstr.named_context * Evd.econstr) list
+        ; types : (Environ.env * Evar.t * Evd.undefined Evd.evar_info * EConstr.named_context * Evd.econstr) list
         ; sigma : Evd.evar_map
         }
 

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -175,7 +175,7 @@ module Proof : sig
        name:Id.t
     -> info:Info.t
     -> hook:(pm:OblState.t -> Constant.t list -> Evd.evar_map -> OblState.t)
-    -> types:(Environ.env * Evar.t * Evd.evar_info * EConstr.named_context * Evd.econstr) list
+    -> types:(Environ.env * Evar.t * Evd.undefined Evd.evar_info * EConstr.named_context * Evd.econstr) list
     -> Evd.evar_map
     -> Proofview.telescope
     -> t

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -629,11 +629,11 @@ let rec explain_evar_kind env sigma evk ty =
       str " for the variable " ++ Id.print id
   | Evar_kinds.SubEvar (where,evk') ->
       let rec find_source evk =
-        let evi = Evd.find sigma evk in
+        let EvarInfo evi = Evd.find sigma evk in
         match snd (Evd.evar_source evi) with
         | Evar_kinds.SubEvar (_,evk) -> find_source evk
-        | src -> evi,src in
-      let evi,src = find_source evk' in
+        | src -> EvarInfo evi, src in
+      let EvarInfo evi, src = find_source evk' in
       let pc = match Evd.evar_body evi with
       | Evar_defined c -> pr_leconstr_env env sigma c
       | Evar_empty -> assert false in


### PR DESCRIPTION
For now this does not do anything in the implementation itself, it is just a matter of API. It will eventually allow having data that only exists in one case or the other.

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/418
- https://github.com/mattam82/Coq-Equations/pull/527
- https://github.com/Mtac2/Mtac2/pull/373
- https://github.com/ejgallego/coq-serapi/pull/302
- https://github.com/unicoq/unicoq/pull/78
- https://github.com/maximedenes/vscoq/pull/11