### PR TITLE
Fix reduction marks of some primitives in CClosure.

### DIFF
--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -1037,17 +1037,17 @@ module FNativeEntries =
     let get_int () e =
       match [@ocaml.warning "-4"] e.term with
       | FInt i -> i
-      | _ -> raise Primred.NativeDestKO
+      | _ -> assert false
 
     let get_float () e =
       match [@ocaml.warning "-4"] e.term with
       | FFloat f -> f
-      | _ -> raise Primred.NativeDestKO
+      | _ -> assert false
 
     let get_parray () e =
       match [@ocaml.warning "-4"] e.term with
       | FArray (_u,t,_ty) -> t
-      | _ -> raise Not_found
+      | _ -> assert false
 
     let dummy = {mark = Ntrl; term = FRel 0}
 
@@ -1498,12 +1498,8 @@ let rec knr info tab m stk =
          | [] ->
            let args = Array.of_list (List.rev rargs) in
            begin match FredNative.red_prim (info_env info) () op u args with
-             | Some m ->
-             kni info tab m s
-             | None ->
-               let f = {mark = Cstr; term = FFlex (ConstKey c)} in
-               let m = {mark = Cstr; term = FApp(f,args)} in
-               (m,s)
+            | Some m -> kni info tab m s
+            | None -> assert false
            end
          | (kd,a)::nargs ->
            assert (kd = CPrimitives.Kwhnf);

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -1314,7 +1314,7 @@ module FNativeEntries =
 
     let mkArray env u t ty =
       check_array env;
-      { mark = Whnf; term = FArray (u,t,ty)}
+      { mark = Cstr; term = FArray (u,t,ty)}
 
   end
 
@@ -1501,8 +1501,8 @@ let rec knr info tab m stk =
              | Some m ->
              kni info tab m s
              | None ->
-               let f = {mark = Whnf; term = FFlex (ConstKey c)} in
-               let m = {mark = Whnf; term = FApp(f,args)} in
+               let f = {mark = Cstr; term = FFlex (ConstKey c)} in
+               let m = {mark = Cstr; term = FApp(f,args)} in
                (m,s)
            end
          | (kd,a)::nargs ->


### PR DESCRIPTION
These primitives were erroneously classified as Whnf, which actually means neutral i.e. they cannot trigger reduction when they are put in a larger context.

(I am not sure how to exploit this.)