### PR TITLE
fix Arg syntax for coqdoc --index option

### DIFF
--- a/test-suite/misc/17072.sh
+++ b/test-suite/misc/17072.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+export COQBIN=$BIN
+export PATH=$COQBIN:$PATH
+
+cd misc/coqdoc-options/
+
+coq_makefile -f _CoqProject -o Makefile
+
+make clean
+
+make html

--- a/test-suite/misc/coqdoc-options/.gitignore
+++ b/test-suite/misc/coqdoc-options/.gitignore
@@ -1,0 +1,2 @@
+/Makefile*
+/html/

--- a/test-suite/misc/coqdoc-options/_CoqProject
+++ b/test-suite/misc/coqdoc-options/_CoqProject
@@ -1,0 +1,5 @@
+-R theories Coqdoc
+
+COQDOCFLAGS = "--index indexpage -g"
+
+theories/test.v

--- a/test-suite/misc/coqdoc-options/theories/test.v
+++ b/test-suite/misc/coqdoc-options/theories/test.v
@@ -1,0 +1,2 @@
+Class C := {}.
+Local Program Declare Instance I : C.

--- a/tools/coqdoc/cmdArgs.ml
+++ b/tools/coqdoc/cmdArgs.ml
@@ -150,8 +150,8 @@ let args_options = Arg.align [
   " Include variable binders in index";
   "--multi-index", arg_set (fun p -> { p with multi_index = true }),
   " Index split in multiple files";
-  "--index <string>", arg_string (fun p s -> { p with index_name = s }),
-  " Set index name (default is index)";
+  "--index", arg_string (fun p s -> { p with index_name = s }),
+  "<string> Set index name to <string> (default is index)";
   "--toc", arg_set (fun p -> { p with toc = true }),
   " Output a table of contents";
   "--table-of-contents", arg_set (fun p -> { p with toc = true }),


### PR DESCRIPTION
Re-enable the `--index` option for coqdoc.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes #17072 

Since this is a recent regression, I don't think it needs a changelog. There is no obvious way to add a test case for this, since the test-suite has no way to control coqdoc options on a case-by-case basis.