### PR TITLE
More lenient quality unification for Prop ⊆ α constraints.

### DIFF
--- a/test-suite/success/CaseCumul.v
+++ b/test-suite/success/CaseCumul.v
@@ -1,0 +1,10 @@
+Inductive boolε : bool -> Type :=
+| trueε : boolε true
+| falseε : boolε false.
+
+(* Check branch sort inference with implicit Prop ⊆ Type cumulativity *)
+Definition test (x : boolε true) :=
+match x with
+| trueε => I
+| falseε => tt
+end.


### PR DESCRIPTION
We add an additional set of qualities known to be either Prop or Type in the universe unification state, and delay the unification of problems of the form Prop ≤ QSort(α, u) by remembering the constraint instead.

This restores the old behaviour for case nodes with branches in different sorts.