### PR TITLE
Fix #17077: Native compute does not handle sort quality variables.

### DIFF
--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -124,7 +124,7 @@ let type_of_type u =
 let type_of_sort = function
   | SProp | Prop | Set -> type1
   | Type u -> type_of_type u
-  | QSort _ -> anomaly Pp.(str "the kernel does not support sort variables")
+  | QSort (_, u) -> type_of_type u
 
 (*s Type of a de Bruijn index. *)
 
@@ -575,9 +575,11 @@ let rec execute env cstr =
   match kind cstr with
     (* Atomic terms *)
     | Sort s ->
-      (match s with
-       | SProp -> if not (Environ.sprop_allowed env) then error_disallowed_sprop env
-       | _ -> ());
+      let () = match s with
+      | SProp -> if not (Environ.sprop_allowed env) then error_disallowed_sprop env
+      | QSort _ -> anomaly Pp.(str "the kernel does not support sort variables")
+      | Prop | Set | Type _ -> ()
+      in
       cstr, type_of_sort s
 
     | Rel n ->

--- a/test-suite/bugs/bug_17077.v
+++ b/test-suite/bugs/bug_17077.v
@@ -1,0 +1,6 @@
+Goal True.
+Proof.
+pose (T := forall A, A).
+native_compute in T.
+(* Anomaly "the kernel does not support sort variables" *)
+Abort.


### PR DESCRIPTION
The reification function was wrongly using the kernel sort typing function, which rejects quality variables in sorts. We move the check to the execute function.

Fixes #17077.