### PR TITLE
Remove unused `overwrite` optional argument of tactic_extend

### DIFF
--- a/plugins/ltac/tacenv.ml
+++ b/plugins/ltac/tacenv.ml
@@ -91,13 +91,10 @@ let pr_tacname t =
 
 let tac_tab = ref MLTacMap.empty
 
-let register_ml_tactic ?(overwrite = false) s (t : ml_tactic array) =
+let register_ml_tactic s (t : ml_tactic array) =
   let () =
     if MLTacMap.mem s !tac_tab then
-      if overwrite then
-        tac_tab := MLTacMap.remove s !tac_tab
-      else
-        CErrors.anomaly (str "Cannot redeclare tactic " ++ pr_tacname s ++ str ".")
+      CErrors.anomaly (str "Cannot redeclare tactic " ++ pr_tacname s ++ str ".")
   in
   tac_tab := MLTacMap.add s t !tac_tab
 

--- a/plugins/ltac/tacenv.mli
+++ b/plugins/ltac/tacenv.mli
@@ -90,7 +90,7 @@ type ml_tactic =
   Val.t list -> Geninterp.interp_sign -> unit Proofview.tactic
 (** Type of external tactics, used by [TacML]. *)
 
-val register_ml_tactic : ?overwrite:bool -> ml_tactic_name -> ml_tactic array -> unit
+val register_ml_tactic : ml_tactic_name -> ml_tactic array -> unit
 (** Register an external tactic. *)
 
 val interp_ml_tactic : ml_tactic_entry -> ml_tactic


### PR DESCRIPTION
May be unused since its ancestors from before 2000 AFAICT