### PR TITLE
[stdlib] add lemmas list_power_length, concat_length, flat_map_length

### DIFF
--- a/doc/changelog/11-standard-library/17082-list_power_length.rst
+++ b/doc/changelog/11-standard-library/17082-list_power_length.rst
@@ -1,0 +1,4 @@
+- **Added:** lemmas :g:`concat_length`, :g:`flat_map_length`,
+  :g:`flat_map_constant_length`, :g:`list_power_length` to `Lists.List`
+  (`#17082 <https://github.com/coq/coq/pull/17082>`_,
+  by Stefan Haan with help from Olivier Laurent).

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -3420,6 +3420,38 @@ simpl; rewrite IHl1.
 apply Nat.add_assoc.
 Qed.
 
+Lemma concat_length A l:
+  length (concat l) = list_sum (map (@length A) l).
+Proof.
+  induction l; [reflexivity|].
+  simpl. rewrite app_length.
+  f_equal. assumption.
+Qed.
+
+Lemma flat_map_length A B (f: A -> list B) l:
+  length (flat_map f l) = list_sum (map (fun x => length (f x)) l).
+Proof.
+  rewrite flat_map_concat_map, concat_length, map_map. reflexivity.
+Qed.
+
+Corollary flat_map_constant_length A B c (f: A -> list B) l:
+  (forall x, In x l -> length (f x) = c) -> length (flat_map f l) = (length l) * c.
+Proof.
+  intro H. rewrite flat_map_length.
+  induction l as [ | a l IHl ]; [reflexivity|].
+  simpl. rewrite IHl, H; [reflexivity | left; reflexivity | ].
+  intros x Hx. apply H. right. assumption.
+Qed.
+
+Lemma list_power_length (A B:Type)(l:list A) (l':list B):
+    length (list_power l l') = (length l')^(length l).
+Proof.
+  induction l as [ | a m IH ]; [reflexivity|].
+  cbn. rewrite flat_map_constant_length with (c := length l').
+  - rewrite IH. apply Nat.mul_comm.
+  - intros x H. apply map_length.
+Qed.
+
 (** Max of elements of a list of [nat]: [list_max] *)
 
 Definition list_max l := fold_right max 0 l.


### PR DESCRIPTION
This PR adds following lemmas:
* `list_power_length: length (list_power l l') = (length l')^(length l)`.
* `concat_length: length (concat l) = list_sum (map (@length A) l)`.
* `flat_map_length: length (flat_map f l) = list_sum (map (fun x => length (f x)) l)`.
* `flat_map_constant_length:  (forall x, length (f x) = c) -> length (flat_map f l) = (length l) * c`.