### PR TITLE
Use correct DECLARE PLUGIN in non-marshalable-state test

### DIFF
--- a/test-suite/misc/non-marshalable-state/src/evil.mlg
+++ b/test-suite/misc/non-marshalable-state/src/evil.mlg
@@ -1,4 +1,4 @@
-DECLARE PLUGIN "coq-core.plugins.evil"
+DECLARE PLUGIN "coq-test-suite.evil"
 
 {
 

--- a/test-suite/misc/non-marshalable-state/src/good.mlg
+++ b/test-suite/misc/non-marshalable-state/src/good.mlg
@@ -1,4 +1,4 @@
-DECLARE PLUGIN "coq-core.plugins.good"
+DECLARE PLUGIN "coq-test-suite.good"
 
 {
 


### PR DESCRIPTION
It should match the ones in the .v Declare ML Module.
