### PR TITLE
Make interpretation of references with maximal implicit arguments in Ltac functions the same in strict and non-strict mode

### DIFF
--- a/theories/Classes/Init.v
+++ b/theories/Classes/Init.v
@@ -23,7 +23,7 @@ Global Typeclasses Opaque id const flip compose arrow impl iff not all.
 
 (** Apply using the same opacity information as typeclass proof search. *)
 
-Ltac class_apply c := autoapply c with typeclass_instances.
+Tactic Notation "class_apply" open_constr(c) := autoapply c with typeclass_instances.
 
 (** The unconvertible typeclass, to test that two objects of the same type are
    actually different. *)


### PR DESCRIPTION
As shown in #16935, the interpretation of references in Ltac functions happens to be different in strict mode (i.e., in practice, non interactively) and in non-strict mode (i.e., in practice, interactively) regarding the insertion or not of maximal implicit arguments.

This [comment](https://github.com/coq/coq/pull/16935#issuecomment-1337069639) at #16935 suggested to align the strict mode on the non-strict mode and this is what the PR does.

In particular, this ensures than in a configuration such as:
```coq
Class T.
Local Instance t : T := {}.
Parameter a : forall {t:T}, True.
Ltac f x := exact x.
Ltac g := f a.
Goal True.
g.
```
where `g` evaluates an Ltac function applied to a reference in strict mode and this reference has inferable maximal implicit arguments, the implicit arguments are indeed inserted, as if `f a` had been given directly.

I did not find other cases where the change of semantics is observable (i.e. the maximal implicit arguments need to be solvable by type class inference, otherwise it fails with an unresolved implicit arguments anyway). In the stdlib, the only occurrence of such pattern is `class_apply` (which plays the role of `f` above) and the compatibility can be preserved by turning `class_apply` into a tactic definition.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
