### PR TITLE
Make quotations in terms (e.g. ltac:(), ltac2:(), ...) at the first level of interpretation now strict by default

### DIFF
--- a/doc/changelog/05-Ltac-language/16935-master+functional-strict_check.rst
+++ b/doc/changelog/05-Ltac-language/16935-master+functional-strict_check.rst
@@ -1,0 +1,9 @@
+- **Changed:**
+  In toplevel declarations referring to a quotation, such as
+  `ltac:(tac)` or `ltac2:(tac)`, the check that term variables present
+  in the tactic have to be bound is now done at declaration time
+  rather than execution time; this is a possible source of
+  incompatibility, for instance, an expression of the form
+  `ltac:(intro H; apply H)` should now be replaced by an expression of
+  the form `ltac:(let H := fresh in intro H; apply H)`, etc. (`#16935
+  <https://github.com/coq/coq/pull/16935>`_, by Hugo Herbelin).

--- a/test-suite/success/ltac.v
+++ b/test-suite/success/ltac.v
@@ -470,3 +470,10 @@ Abort.
 Fail Ltac bad := exact x. (* was wrongly accepted *)
 
 End StrictModeConfusion.
+
+Module StrictCheck.
+
+Fail Definition a : forall n : nat, n = n := ltac:(destruct n; auto).
+Fail Notation f := ltac:(exact n).
+
+End StrictCheck.


### PR DESCRIPTION
This was originally in #16935 but #16935 is now split into three parts:
- #16935 is now only passing `strict_check` functionally (no change of semantics a priori).
- #17085 (this PR) changes the interpretation of quotations in terms (e.g. ltac:(), ltac2:(), ...) at the first level of interpretation to strict by default.
- #17084 is preliminary uniformization of semantics between the strict and non-strict mode so that the change made in this PR does not break libraries tested in CI.

Depends on #16935 (merged) and #17084.

Typical changes of semantics include:
```coq
Definition a : forall n : nat, n = n := ltac:(destruct n; auto). (* now fails with n unbound *)
Notation f := ltac:(exact n). (* now fails with n unbound *)
```

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
