### PR TITLE
In Ltac, interpret constr arguments of an Ltac definition by default as open constr (with type classes inference)

### DIFF
--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -806,7 +806,7 @@ let interp_may_eval f ist env sigma = function
 let interp_constr_may_eval ist env sigma c =
   let (sigma,csr) =
     try
-      interp_may_eval interp_constr ist env sigma c
+      interp_may_eval interp_open_constr_with_classes ist env sigma c
     with reraise ->
       let reraise = Exninfo.capture reraise in
       (* spiwack: to avoid unnecessary modifications of tacinterp, as this


### PR DESCRIPTION
This is an experience, initially suggested by the compatibility in #17084.

- [ ] Added / updated **test-suite**.
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
