### PR TITLE
Fix #15933 and add misc test case for coqdoc legacy attrs

### DIFF
--- a/doc/changelog/09-cli-tools/17090-fix-coqdoc-g-omissions.rst
+++ b/doc/changelog/09-cli-tools/17090-fix-coqdoc-g-omissions.rst
@@ -1,0 +1,7 @@
+- **Fixed:**
+  properly process legacy attributes such as ``Global``
+  and ``Polymorphic`` in coqdoc to avoid omissions
+  when using the ``-g`` (Gallina only) option
+  (`#17090 <https://github.com/coq/coq/pull/17090>`_,
+  fixes `#15933 <https://github.com/coq/coq/issues/15933>`_,
+  by Karl Palmskog).

--- a/test-suite/misc/15933.html.out
+++ b/test-suite/misc/15933.html.out
@@ -1,0 +1,105 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<link href="coqdoc.css" rel="stylesheet" type="text/css" />
+<title>Coqdoc.test</title>
+</head>
+
+<body>
+
+<div id="page">
+
+<div id="header">
+</div>
+
+<div id="main">
+
+<h1 class="libtitle">Library Coqdoc.test</h1>
+
+<div class="code">
+<span class="id" title="keyword">Class</span> <a id="C" class="idref" href="#C"><span class="id" title="record">C</span></a> := {}.<br/>
+
+<br/>
+<span class="id" title="keyword">Global Declare Instance</span> <a id="I0" class="idref" href="#I0"><span class="id" title="instance">I0</span></a> : <a class="idref" href="Coqdoc.test.html#C"><span class="id" title="class">C</span></a>.<br/>
+<span class="id" title="keyword">Local Declare Instance</span> <a id="I1" class="idref" href="#I1"><span class="id" title="instance">I1</span></a> : <a class="idref" href="Coqdoc.test.html#C"><span class="id" title="class">C</span></a>.<br/>
+<span class="id" title="keyword">Global Polymorphic Declare Instance</span> <a id="I3" class="idref" href="#I3"><span class="id" title="instance">I3</span></a> : <a class="idref" href="Coqdoc.test.html#C"><span class="id" title="class">C</span></a>.<br/>
+<span class="id" title="keyword">Polymorphic Global Declare Instance</span> <a id="I4" class="idref" href="#I4"><span class="id" title="instance">I4</span></a> : <a class="idref" href="Coqdoc.test.html#C"><span class="id" title="class">C</span></a>.<br/>
+<span class="id" title="keyword">Local Polymorphic Declare Instance</span> <a id="I5" class="idref" href="#I5"><span class="id" title="instance">I5</span></a> : <a class="idref" href="Coqdoc.test.html#C"><span class="id" title="class">C</span></a>.<br/>
+<span class="id" title="keyword">Polymorphic Local Declare Instance</span> <a id="I6" class="idref" href="#I6"><span class="id" title="instance">I6</span></a> : <a class="idref" href="Coqdoc.test.html#C"><span class="id" title="class">C</span></a>.<br/>
+
+<br/>
+<span class="id" title="keyword">Global Program Instance</span> <a id="I7" class="idref" href="#I7"><span class="id" title="instance">I7</span></a> : <a class="idref" href="Coqdoc.test.html#C"><span class="id" title="class">C</span></a> := {}.<br/>
+<span class="id" title="keyword">Local Program Instance</span> <a id="I8" class="idref" href="#I8"><span class="id" title="instance">I8</span></a> : <a class="idref" href="Coqdoc.test.html#C"><span class="id" title="class">C</span></a> := {}.<br/>
+<span class="id" title="keyword">Program Global Instance</span> <a id="I9" class="idref" href="#I9"><span class="id" title="instance">I9</span></a> : <a class="idref" href="Coqdoc.test.html#C"><span class="id" title="class">C</span></a> := {}.<br/>
+<span class="id" title="keyword">Program Local Instance</span> <a id="I10" class="idref" href="#I10"><span class="id" title="instance">I10</span></a> : <a class="idref" href="Coqdoc.test.html#C"><span class="id" title="class">C</span></a> := {}.<br/>
+
+<br/>
+<span class="id" title="keyword">Polymorphic Program Global Instance</span> <a id="I11" class="idref" href="#I11"><span class="id" title="instance">I11</span></a> : <a class="idref" href="Coqdoc.test.html#C"><span class="id" title="class">C</span></a> := {}.<br/>
+<span class="id" title="keyword">Polymorphic Program Local Instance</span> <a id="I12" class="idref" href="#I12"><span class="id" title="instance">I12</span></a> : <a class="idref" href="Coqdoc.test.html#C"><span class="id" title="class">C</span></a> := {}.<br/>
+<span class="id" title="keyword">Program Global Polymorphic Instance</span> <a id="I13" class="idref" href="#I13"><span class="id" title="instance">I13</span></a> : <a class="idref" href="Coqdoc.test.html#C"><span class="id" title="class">C</span></a> := {}.<br/>
+<span class="id" title="keyword">Program Local Polymorphic Instance</span> <a id="I14" class="idref" href="#I14"><span class="id" title="instance">I14</span></a> : <a class="idref" href="Coqdoc.test.html#C"><span class="id" title="class">C</span></a> := {}.<br/>
+<span class="id" title="keyword">Global Program Polymorphic Instance</span> <a id="I15" class="idref" href="#I15"><span class="id" title="instance">I15</span></a> : <a class="idref" href="Coqdoc.test.html#C"><span class="id" title="class">C</span></a> := {}.<br/>
+<span class="id" title="keyword">Local Program Polymorphic Instance</span> <a id="I16" class="idref" href="#I16"><span class="id" title="instance">I16</span></a> : <a class="idref" href="Coqdoc.test.html#C"><span class="id" title="class">C</span></a> := {}.<br/>
+
+<br/>
+<span class="id" title="keyword">Global Notation</span> <a id="x0" class="idref" href="#x0"><span class="id" title="abbreviation">x0</span></a> := 0.<br/>
+<span class="id" title="keyword">Local Notation</span> <a id="x1" class="idref" href="#x1"><span class="id" title="abbreviation">x1</span></a> := 0.<br/>
+
+<br/>
+<span class="id" title="keyword">Global Definition</span> <a id="x2" class="idref" href="#x2"><span class="id" title="definition">x2</span></a> := 0.<br/>
+<span class="id" title="keyword">Local Definition</span> <a id="x3" class="idref" href="#x3"><span class="id" title="definition">x3</span></a> := 0.<br/>
+<span class="id" title="keyword">Polymorphic Definition</span> <a id="x4" class="idref" href="#x4"><span class="id" title="definition">x4</span></a> := 0.<br/>
+<span class="id" title="keyword">Polymorphic Global Definition</span> <a id="x5" class="idref" href="#x5"><span class="id" title="definition">x5</span></a> := 0.<br/>
+<span class="id" title="keyword">Polymorphic Local Definition</span> <a id="x6" class="idref" href="#x6"><span class="id" title="definition">x6</span></a> := 0.<br/>
+<span class="id" title="keyword">Global Polymorphic Definition</span> <a id="x7" class="idref" href="#x7"><span class="id" title="definition">x7</span></a> := 0.<br/>
+<span class="id" title="keyword">Local Polymorphic Definition</span> <a id="x8" class="idref" href="#x8"><span class="id" title="definition">x8</span></a> := 0.<br/>
+
+<br/>
+<span class="id" title="keyword">Polymorphic Inductive</span> <a id="y0" class="idref" href="#y0"><span class="id" title="inductive">y0</span></a> := <a id="z0" class="idref" href="#z0"><span class="id" title="constructor">z0</span></a>.<br/>
+<span class="id" title="keyword">Polymorphic Variant</span> <a id="y1" class="idref" href="#y1"><span class="id" title="inductive">y1</span></a> := <a id="z1" class="idref" href="#z1"><span class="id" title="constructor">z1</span></a>.<br/>
+
+<br/>
+<span class="id" title="keyword">Local Obligation</span> <span class="id" title="keyword">Tactic</span> := <span class="id" title="tactic">auto</span>.<br/>
+<span class="id" title="keyword">Global Obligation</span> <span class="id" title="keyword">Tactic</span> := <span class="id" title="tactic">auto</span>.<br/>
+
+<br/>
+<span class="id" title="keyword">Global Typeclasses Opaque</span> <span class="id" title="var">I7</span>.<br/>
+<span class="id" title="keyword">Local Typeclasses Opaque</span> <span class="id" title="var">I8</span>.<br/>
+
+<br/>
+<span class="id" title="keyword">Global Hint Extern</span> 10 (<span class="id" title="var">_</span> <a class="idref" href="http://coq.inria.fr/stdlib/Coq.Init.Peano.html#cb53cf0ee22c036a03b4a9281c68b5a3"><span class="id" title="notation">≤</span></a> <span class="id" title="var">_</span>) ⇒ <span class="id" title="tactic">auto</span> : <span class="id" title="var">arith</span>.<br/>
+<span class="id" title="keyword">Local Hint Extern</span> 10 (<span class="id" title="var">_</span> <a class="idref" href="http://coq.inria.fr/stdlib/Coq.Init.Peano.html#cb53cf0ee22c036a03b4a9281c68b5a3"><span class="id" title="notation">≤</span></a> <span class="id" title="var">_</span>) ⇒ <span class="id" title="tactic">auto</span> : <span class="id" title="var">arith</span>.<br/>
+
+<br/>
+<span class="id" title="keyword">Global Ltac</span> <span class="id" title="var">lt0</span> := <span class="id" title="tactic">auto</span>.<br/>
+<span class="id" title="keyword">Local Ltac</span> <span class="id" title="var">lt1</span> := <span class="id" title="tactic">auto</span>.<br/>
+
+<br/>
+<span class="id" title="keyword">Require</span> <a class="idref" href="http://coq.inria.fr/stdlib/Coq.Program.Tactics.html#"><span class="id" title="library">Coq.Program.Tactics</span></a>.<br/>
+
+<br/>
+<span class="id" title="keyword">Global Program Definition</span> <a id="x9" class="idref" href="#x9"><span class="id" title="definition">x9</span></a> := 0.<br/>
+<span class="id" title="keyword">Local Program Definition</span> <a id="x10" class="idref" href="#x10"><span class="id" title="definition">x10</span></a> := 0.<br/>
+<span class="id" title="keyword">Program Global Definition</span> <a id="x11" class="idref" href="#x11"><span class="id" title="definition">x11</span></a> := 0.<br/>
+<span class="id" title="keyword">Program Local Definition</span> <a id="x12" class="idref" href="#x12"><span class="id" title="definition">x12</span></a> := 0.<br/>
+
+<br/>
+<span class="id" title="keyword">Polymorphic Program Global Definition</span> <a id="x13" class="idref" href="#x13"><span class="id" title="definition">x13</span></a> := 0.<br/>
+<span class="id" title="keyword">Polymorphic Program Local Definition</span> <a id="x14" class="idref" href="#x14"><span class="id" title="definition">x14</span></a> := 0.<br/>
+<span class="id" title="keyword">Program Global Polymorphic Definition</span> <a id="x15" class="idref" href="#x15"><span class="id" title="definition">x15</span></a> := 0.<br/>
+<span class="id" title="keyword">Program Local Polymorphic Definition</span> <a id="x16" class="idref" href="#x16"><span class="id" title="definition">x16</span></a> := 0.<br/>
+<span class="id" title="keyword">Global Program Polymorphic Definition</span> <a id="x17" class="idref" href="#x17"><span class="id" title="definition">x17</span></a> := 0.<br/>
+<span class="id" title="keyword">Local Program Polymorphic Definition</span> <a id="x18" class="idref" href="#x18"><span class="id" title="definition">x18</span></a> := 0.<br/>
+</div>
+</div>
+
+<div id="footer">
+<hr/><a href="indexpage.html">Index</a><hr/>This page has been generated by <a href="http://coq.inria.fr/">coqdoc</a>
+</div>
+
+</div>
+
+</body>
+</html>

--- a/test-suite/misc/15933.sh
+++ b/test-suite/misc/15933.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+
+export COQBIN=$BIN
+export PATH=$COQBIN:$PATH
+
+cd misc/coqdoc-options/
+
+coq_makefile -f _CoqProject -o Makefile
+
+make clean
+
+make html
+
+diff -u --strip-trailing-cr html/Coqdoc.test.html ../15933.html.out

--- a/test-suite/misc/coqdoc-options/_CoqProject
+++ b/test-suite/misc/coqdoc-options/_CoqProject
@@ -1,5 +1,5 @@
 -R theories Coqdoc
 
-COQDOCFLAGS = "--index indexpage -g"
+COQDOCFLAGS = "--index indexpage -g -coqlib_url http://coq.inria.fr/stdlib --utf8"
 
 theories/test.v

--- a/test-suite/misc/coqdoc-options/theories/test.v
+++ b/test-suite/misc/coqdoc-options/theories/test.v
@@ -1,2 +1,60 @@
 Class C := {}.
-Local Program Declare Instance I : C.
+
+Global Declare Instance I0 : C.
+Local Declare Instance I1 : C.
+Global Polymorphic Declare Instance I3 : C.
+Polymorphic Global Declare Instance I4 : C.
+Local Polymorphic Declare Instance I5 : C.
+Polymorphic Local Declare Instance I6 : C.
+
+Global Program Instance I7 : C := {}.
+Local Program Instance I8 : C := {}.
+Program Global Instance I9 : C := {}.
+Program Local Instance I10 : C := {}.
+
+Polymorphic Program Global Instance I11 : C := {}.
+Polymorphic Program Local Instance I12 : C := {}.
+Program Global Polymorphic Instance I13 : C := {}.
+Program Local Polymorphic Instance I14 : C := {}.
+Global Program Polymorphic Instance I15 : C := {}.
+Local Program Polymorphic Instance I16 : C := {}.
+
+Global Notation x0 := 0.
+Local Notation x1 := 0.
+
+Global Definition x2 := 0.
+Local Definition x3 := 0.
+Polymorphic Definition x4 := 0.
+Polymorphic Global Definition x5 := 0.
+Polymorphic Local Definition x6 := 0.
+Global Polymorphic Definition x7 := 0.
+Local Polymorphic Definition x8 := 0.
+
+Polymorphic Inductive y0 := z0.
+Polymorphic Variant y1 := z1.
+
+Local Obligation Tactic := auto.
+Global Obligation Tactic := auto.
+
+Global Typeclasses Opaque I7.
+Local Typeclasses Opaque I8.
+
+Global Hint Extern 10 (_ <= _) => auto : arith.
+Local Hint Extern 10 (_ <= _) => auto : arith.
+
+Global Ltac lt0 := auto.
+Local Ltac lt1 := auto.
+
+Require Coq.Program.Tactics.
+
+Global Program Definition x9 := 0.
+Local Program Definition x10 := 0.
+Program Global Definition x11 := 0.
+Program Local Definition x12 := 0.
+
+Polymorphic Program Global Definition x13 := 0.
+Polymorphic Program Local Definition x14 := 0.
+Program Global Polymorphic Definition x15 := 0.
+Program Local Polymorphic Definition x16 := 0.
+Global Program Polymorphic Definition x17 := 0.
+Local Program Polymorphic Definition x18 := 0.

--- a/tools/coqdoc/cpretty.mll
+++ b/tools/coqdoc/cpretty.mll
@@ -373,7 +373,6 @@ let def_token =
   | "Instance"
   | "Existing" space+ ("Instance" | "Instances" | "Class")
   | "Declare" space+ "Instance"
-  | "Global" space+ "Instance"
   | "Functional" space+ "Scheme"
 
 let decl_token =
@@ -456,8 +455,17 @@ let extraction =
 
 let gallina_kw = thm_token | def_token | decl_token | gallina_ext | commands | extraction
 
+let legacy_attr_kw =
+  "Local"
+  | "Global"
+  | "Polymorphic"
+  | "Monomorphic"
+  | "Cumulative"
+  | "NonCumulative"
+  | "Private"
+
 let prog_kw =
-  "Program" space+ gallina_kw
+  "Program" space+ (legacy_attr_kw space+)* gallina_kw
   | "Obligation"
   | "Obligations"
   | "Solve"
@@ -473,7 +481,7 @@ let set_kw =
 let gallina_kw_to_hide =
     "Implicit" space+ "Arguments"
   | "Arguments"
-  | ("Local" space+)? "Ltac"
+  | "Ltac"
   | "From"
   | "Require"
   | "Import"
@@ -549,7 +557,7 @@ rule coq_bol = parse
   | space* end_details nl
       { new_lines 1 lexbuf;
         Output.end_coq (); end_details (); Output.start_coq (); coq_bol lexbuf }
-  | space* (("Local"|"Global") space+)? gallina_kw_to_hide
+  | space* (legacy_attr_kw space+)* gallina_kw_to_hide
       { let s = lexeme lexbuf in
           if !prefs.light && section_or_end s then
             let eol = skip_to_dot lexbuf in
@@ -560,7 +568,7 @@ rule coq_bol = parse
               let eol = body lexbuf in
               if eol then coq_bol lexbuf else coq lexbuf
             end }
-  | space* thm_token
+  | space* (legacy_attr_kw space+)* thm_token
       { let s = lexeme lexbuf in
           output_indented_keyword s lexbuf;
         let eol = body lexbuf in
@@ -584,21 +592,21 @@ rule coq_bol = parse
       in
         in_proof := None;
         if eol then coq_bol lexbuf else coq lexbuf }
-  | space* gallina_kw
+  | space* (legacy_attr_kw space+)* gallina_kw
       {
         in_proof := None;
         let s = lexeme lexbuf in
           output_indented_keyword s lexbuf;
         let eol= body lexbuf in
           if eol then coq_bol lexbuf else coq lexbuf }
-  | space* prog_kw
+  | space* (legacy_attr_kw space+)* prog_kw
       {
         in_proof := None;
         let s = lexeme lexbuf in
           output_indented_keyword s lexbuf;
         let eol= body lexbuf in
           if eol then coq_bol lexbuf else coq lexbuf }
-  | space* notation_kw
+  | space* (legacy_attr_kw space+)* notation_kw
       {	let s = lexeme lexbuf in
           output_indented_keyword s lexbuf;
         let eol= start_notation_string lexbuf in
@@ -683,7 +691,7 @@ and coq = parse
           end }
   | eof
       { () }
-  | (("Local"|"Global") space+)? gallina_kw_to_hide
+  | (legacy_attr_kw space+)* gallina_kw_to_hide
       { let s = lexeme lexbuf in
           if !prefs.light && section_or_end s then
             begin
@@ -718,17 +726,17 @@ and coq = parse
        in
         in_proof := None;
         if eol then coq_bol lexbuf else coq lexbuf }
-  | gallina_kw
+  | (legacy_attr_kw space+)* gallina_kw
       { let s = lexeme lexbuf in
           Output.ident s None;
         let eol = body lexbuf in
           if eol then coq_bol lexbuf else coq lexbuf }
-  | notation_kw
+  | (legacy_attr_kw space+)* notation_kw
       { let s = lexeme lexbuf in
           Output.ident s None;
         let eol= start_notation_string lexbuf in
           if eol then coq_bol lexbuf else coq lexbuf }
-  | prog_kw
+  | (legacy_attr_kw space+)* prog_kw
       { let s = lexeme lexbuf in
           Output.ident s None;
         let eol = body lexbuf in


### PR DESCRIPTION
<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes #15933

coqdoc already treats `Program` in a special way, so I can't treat it like any other legacy attr without doing large changes. Until such a larger future refactoring, this PR at least restores a lot of missing sentences in the Stdlib documentation.

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.