### PR TITLE
Introduce relevance variables in the conversion engine.

### DIFF
--- a/dev/ci/user-overlays/17091-ppedrot-cclosure-relevance-quality-var.sh
+++ b/dev/ci/user-overlays/17091-ppedrot-cclosure-relevance-quality-var.sh
@@ -1,0 +1,1 @@
+overlay metacoq https://github.com/ppedrot/metacoq cclosure-relevance-quality-var 17091

--- a/doc/sphinx/addendum/sprop.rst
+++ b/doc/sphinx/addendum/sprop.rst
@@ -289,32 +289,13 @@ This means that some errors will be delayed until ``Qed``:
 The implementation of proof irrelevance uses inferred "relevance"
 marks on binders to determine which variables are irrelevant. Together
 with non-cumulativity this allows us to avoid retyping during
-conversion. However during elaboration cumulativity is allowed and so
-the algorithm may miss some irrelevance:
-
-.. coqtop:: all
-
-  Fail Definition late_mark := fun (A:SProp) (P:A -> Prop) x y (v:P x) => v : P y.
-
-The binders for ``x`` and ``y`` are created before their type is known
-to be ``A``, so they're not marked irrelevant. This can be avoided
-with sufficient annotation of binders (see ``irrelevance`` at the
-beginning of this chapter) or by bypassing the conversion check in
-tactics.
-
-.. coqdoc::
-
-   Definition late_mark := fun (A:SProp) (P:A -> Prop) x y (v:P x) =>
-     ltac:(exact_no_check v) : P y.
-
-The kernel will re-infer the marks on the fully elaborated term, and
-so correctly converts ``x`` and ``y``.
+conversion.
 
 .. warn:: Bad relevance
 
   This is a developer warning, disabled by default. It is emitted by
   the kernel when it is passed a term with incorrect relevance marks.
-  To avoid conversion issues as in ``late_mark`` you may wish to use
+  To avoid conversion issues you may wish to use
   it to find when your tactics are producing incorrect marks.
 
 .. flag:: Cumulative StrictProp

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -71,7 +71,8 @@ let nf_evar sigma c =
     UnivSubst.level_subst_of (fun l -> UnivSubst.normalize_univ_variable_opt_subst lsubst l) l
   in
   let sort_value s = UState.nf_sort (Evd.evar_universe_context sigma) s in
-  EConstr.of_constr @@ UnivSubst.nf_evars_and_universes_opt_subst evar_value level_value sort_value (EConstr.Unsafe.to_constr c)
+  let rel_value r = UState.nf_relevance (Evd.evar_universe_context sigma) r in
+  EConstr.of_constr @@ UnivSubst.nf_evars_and_universes_opt_subst evar_value level_value sort_value rel_value (EConstr.Unsafe.to_constr c)
 
 let j_nf_evar sigma j =
   { uj_val = nf_evar sigma j.uj_val;

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -101,6 +101,9 @@ val nf_qvar : t -> Sorts.QVar.t -> quality
 val nf_sort : t -> Sorts.t -> Sorts.t
 (** Returns the normal form of the sort. *)
 
+val nf_relevance : t -> Sorts.relevance -> Sorts.relevance
+(** Returns the normal form of the relevance. *)
+
 (** {5 Constraints handling} *)
 
 val add_constraints : t -> Univ.Constraints.t -> t

--- a/engine/univSubst.mli
+++ b/engine/univSubst.mli
@@ -39,6 +39,7 @@ val nf_evars_and_universes_opt_subst :
   (existential -> constr option) ->
   (Level.t -> Level.t) ->
   (Sorts.t -> Sorts.t) ->
+  (Sorts.relevance -> Sorts.relevance) ->
   constr -> constr
 
 val subst_univs_universe : (Level.t -> Universe.t) -> Universe.t -> Universe.t

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -10,7 +10,6 @@
 
 open Names
 open Constr
-open Declarations
 open Environ
 open Esubst
 
@@ -145,8 +144,6 @@ val get_native_args1 : CPrimitives.t -> pconstant -> stack ->
   fconstr list * fconstr * fconstr next_native_args * stack
 
 val stack_args_size : stack -> int
-val eta_expand_stack : Name.t Context.binder_annot -> stack -> stack
-val skip_irrelevant_stack : stack -> stack
 
 val inductive_subst : Declarations.mutual_inductive_body
   -> Univ.Instance.t
@@ -217,6 +214,10 @@ val whd_val : clos_infos -> clos_tab -> fconstr -> constr
 val whd_stack :
   clos_infos -> clos_tab -> fconstr -> stack -> fconstr * stack
 
+val skip_irrelevant_stack : clos_infos -> stack -> stack
+
+val eta_expand_stack : clos_infos -> Name.t Context.binder_annot -> stack -> stack
+
 (** [eta_expand_ind_stack env ind c s t] computes stacks corresponding
     to the conversion of the eta expansion of t, considered as an inhabitant
     of ind, and the Constructor c of this inductive type applied to arguments
@@ -230,11 +231,6 @@ val eta_expand_ind_stack : env -> inductive -> fconstr -> stack ->
    (fconstr * stack) -> stack * stack
 
 (** Conversion auxiliary functions to do step by step normalisation *)
-
-(** [unfold_reference] unfolds references in a [fconstr]. Produces a
-    [FIrrelevant] when the reference is irrelevant. *)
-val unfold_reference : Environ.env -> TransparentState.t ->
-  clos_tab -> table_key -> (fconstr, Util.Empty.t) constant_def
 
 (** Like [unfold_reference], but handles primitives: if there are not
     enough arguments, return [None]. Otherwise return [Some] with

--- a/kernel/constr.ml
+++ b/kernel/constr.ml
@@ -1471,13 +1471,15 @@ type 'a evar_expansion =
 type 'constr evar_handler = {
   evar_expand : 'constr pexistential -> 'constr evar_expansion;
   evar_repack : Evar.t * 'constr list -> 'constr;
-  evar_relevance : 'constr pexistential -> Sorts.relevance;
+  evar_relevant : 'constr pexistential -> bool;
+  qvar_relevant : Sorts.QVar.t -> bool;
 }
 
 let default_evar_handler = {
   evar_expand = (fun _ -> assert false);
   evar_repack = (fun _ -> assert false);
-  evar_relevance = (fun _ -> assert false);
+  evar_relevant = (fun _ -> assert false);
+  qvar_relevant = (fun _ -> assert false);
 }
 
 (** Minimalistic constr printer, typically for debugging *)

--- a/kernel/constr.mli
+++ b/kernel/constr.mli
@@ -621,7 +621,8 @@ type 'a evar_expansion =
 type 'constr evar_handler = {
   evar_expand : 'constr pexistential -> 'constr evar_expansion;
   evar_repack : Evar.t * 'constr list -> 'constr;
-  evar_relevance : 'constr pexistential -> Sorts.relevance;
+  evar_relevant : 'constr pexistential -> bool;
+  qvar_relevant : Sorts.QVar.t -> bool;
 }
 
 val default_evar_handler : 'constr evar_handler

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -308,6 +308,7 @@ let inductive_make_projection ind mib ~proj_arg =
     let proj_relevant = match relevances.(proj_arg) with
     | Sorts.Irrelevant -> false
     | Sorts.Relevant -> true
+    | Sorts.RelevanceVar _ -> assert false
     in
     if proj_arg < 0 || Array.length labs <= proj_arg
     then CErrors.anomaly Pp.(str "inductive_make_projection: invalid proj_arg.");
@@ -326,6 +327,7 @@ let inductive_make_projections ind mib =
         let proj_relevant = match relevances.(proj_arg) with
         | Sorts.Irrelevant -> false
         | Sorts.Relevant -> true
+        | Sorts.RelevanceVar _ -> assert false
         in
         Names.Projection.Repr.make ind ~proj_relevant ~proj_npars:mib.mind_nparams ~proj_arg lab)
         labs

--- a/kernel/indtypes.ml
+++ b/kernel/indtypes.ml
@@ -454,7 +454,11 @@ let compute_projections (_, i as ind) mib =
       | Name id ->
         let r = na.Context.binder_relevance in
         let lab = Label.of_id id in
-        let proj_relevant = match r with Sorts.Irrelevant -> false | Sorts.Relevant -> true in
+        let proj_relevant = match r with
+        | Sorts.Irrelevant -> false
+        | Sorts.Relevant -> true
+        | Sorts.RelevanceVar _ -> assert false
+        in
         let kn = Projection.Repr.make ind ~proj_relevant ~proj_npars:mib.mind_nparams ~proj_arg:i lab in
         (* from [params, field1,..,fieldj |- t(params,field1,..,fieldj)]
            to [params, x:I, field1,..,fieldj |- t(params,field1,..,fieldj] *)

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -403,8 +403,8 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
         let rn = Range.get (info_relevances infos.cnv_inf) (n - 1) in
         let rm = Range.get (info_relevances infos.cnv_inf) (m - 1) in
         if rn == Sorts.Irrelevant && rm == Sorts.Irrelevant then
-          let v1 = CClosure.skip_irrelevant_stack v2 in
-          let v2 = CClosure.skip_irrelevant_stack v2 in
+          let v1 = CClosure.skip_irrelevant_stack infos.cnv_inf v2 in
+          let v2 = CClosure.skip_irrelevant_stack infos.cnv_inf v2 in
           convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
         else if Int.equal n m then
           convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
@@ -526,7 +526,7 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
         let (x1,_ty1,bd1) = destFLambda mk_clos hd1 in
         let infos = push_relevance infos x1 in
         eqappr CONV l2r infos
-          (el_lift lft1, (bd1, [])) (el_lift lft2, (hd2, eta_expand_stack x1 v2)) cuniv
+          (el_lift lft1, (bd1, [])) (el_lift lft2, (hd2, eta_expand_stack infos.cnv_inf x1 v2)) cuniv
     | (_, FLambda _) ->
         let () = match v2 with
         | [] -> ()
@@ -536,7 +536,7 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
         let (x2,_ty2,bd2) = destFLambda mk_clos hd2 in
         let infos = push_relevance infos x2 in
         eqappr CONV l2r infos
-          (el_lift lft1, (hd1, eta_expand_stack x2 v1)) (el_lift lft2, (bd2, [])) cuniv
+          (el_lift lft1, (hd1, eta_expand_stack infos.cnv_inf x2 v1)) (el_lift lft2, (bd2, [])) cuniv
 
     (* only one constant, defined var or defined rel *)
     | (FFlex fl1, c2)      ->
@@ -707,7 +707,7 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
       let n1 = reloc_rel n1 (el_stack lft1 v1) in
       let r1 = Range.get (info_relevances infos.cnv_inf) (n1 - 1) in
       if r1 == Sorts.Irrelevant then
-        let v1 = CClosure.skip_irrelevant_stack v1 in
+        let v1 = CClosure.skip_irrelevant_stack infos.cnv_inf v1 in
         convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
       else raise NotConvertible
 
@@ -715,7 +715,7 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
       let n2 = reloc_rel n2 (el_stack lft2 v2) in
       let r2 = Range.get (info_relevances infos.cnv_inf) (n2 - 1) in
       if r2 == Sorts.Irrelevant then
-        let v2 = CClosure.skip_irrelevant_stack v2 in
+        let v2 = CClosure.skip_irrelevant_stack infos.cnv_inf v2 in
         convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
       else raise NotConvertible
 

--- a/kernel/sorts.ml
+++ b/kernel/sorts.ml
@@ -153,11 +153,12 @@ module Hsorts =
 let hcons = Hashcons.simple_hcons Hsorts.generate Hsorts.hcons hcons_univ
 
 (** On binders: is this variable proof relevant *)
-type relevance = Relevant | Irrelevant
+type relevance = Relevant | Irrelevant | RelevanceVar of QVar.t
 
 let relevance_equal r1 r2 = match r1,r2 with
   | Relevant, Relevant | Irrelevant, Irrelevant -> true
-  | (Relevant | Irrelevant), _ -> false
+  | RelevanceVar q1, RelevanceVar q2 -> QVar.equal q1 q2
+  | (Relevant | Irrelevant | RelevanceVar _), _ -> false
 
 let relevance_of_sort_family = function
   | InSProp -> Irrelevant
@@ -166,10 +167,12 @@ let relevance_of_sort_family = function
 let relevance_hash = function
   | Relevant -> 0
   | Irrelevant -> 1
+  | RelevanceVar q -> Hashset.Combine.combinesmall 2 (Int.hash (QVar.repr q))
 
 let relevance_of_sort = function
   | SProp -> Irrelevant
-  | _ -> Relevant
+  | Prop | Set | Type _ -> Relevant
+  | QSort (q, _) -> RelevanceVar q
 
 let debug_print = function
   | SProp -> Pp.(str "SProp")

--- a/kernel/sorts.mli
+++ b/kernel/sorts.mli
@@ -60,7 +60,7 @@ val levels : t -> Univ.Level.Set.t
 val super : t -> t
 
 (** On binders: is this variable proof relevant *)
-type relevance = Relevant | Irrelevant
+type relevance = Relevant | Irrelevant | RelevanceVar of QVar.t
 
 val relevance_hash : relevance -> int
 

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -499,6 +499,10 @@ let type_of_case env (mib, mip) ci u pms (pctx, p, pt) iv c ct _lf lft =
   let ci = if ci.ci_relevance == rp then ci
     else (warn_bad_relevance_ci (); {ci with ci_relevance=rp})
   in
+  let () = match ci.ci_relevance with
+  | Sorts.Relevant | Sorts.Irrelevant -> ()
+  | Sorts.RelevanceVar _ -> anomaly Pp.(str "the kernel does not support sort variables")
+  in
   let () = check_case_info env (ind, u') rp ci in
   let () =
     let is_inversion = match iv with
@@ -575,6 +579,10 @@ let type_of_global_in_context env r =
 
 let check_binder_annot s x =
   let r = x.binder_relevance in
+  let () = match r with
+  | Sorts.Relevant | Sorts.Irrelevant -> ()
+  | Sorts.RelevanceVar _ -> anomaly Pp.(str "the kernel does not support sort variables")
+  in
   let r' = Sorts.relevance_of_sort s in
   if r' == r
   then x

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -1064,7 +1064,11 @@ let fake_match_projection env p =
       let ty = Vars.substl subst (liftn 1 j ty) in
       if arg != proj_arg then
         let lab = match na.binder_name with Name id -> Label.of_id id | Anonymous -> assert false in
-        let proj_relevant = match na.binder_relevance with Sorts.Irrelevant -> false | Sorts.Relevant -> true in
+        let proj_relevant = match na.binder_relevance with
+        | Sorts.Irrelevant -> false
+        | Sorts.Relevant -> true
+        | Sorts.RelevanceVar _ -> assert false
+        in
         let kn = Projection.Repr.make ind ~proj_relevant ~proj_npars:mib.mind_nparams ~proj_arg:arg lab in
         fold (arg+1) (j+1) (mkProj (Projection.make kn false, mkRel 1)::subst) rem
       else

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -91,6 +91,7 @@ let v_blk = Valexpr.make_block
 let of_relevance = function
   | Sorts.Relevant -> ValInt 0
   | Sorts.Irrelevant -> ValInt 1
+  | Sorts.RelevanceVar q -> ValInt 0 (* FIXME ? *)
 
 let to_relevance = function
   | ValInt 0 -> Sorts.Relevant

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -515,7 +515,11 @@ let compute_projections env (kn, i as ind) =
       match na.binder_name with
       | Name id ->
         let lab = Label.of_id id in
-        let proj_relevant = match na.binder_relevance with Sorts.Irrelevant -> false | Sorts.Relevant -> true in
+        let proj_relevant = match na.binder_relevance with
+        | Sorts.Irrelevant -> false
+        | Sorts.Relevant -> true
+        | Sorts.RelevanceVar _ -> assert false
+        in
         let kn = Projection.Repr.make ind ~proj_relevant ~proj_npars:mib.mind_nparams ~proj_arg lab in
         (* from [params, field1,..,fieldj |- t(params,field1,..,fieldj)]
            to [params, x:I, field1,..,fieldj |- t(params,field1,..,fieldj] *)

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -380,7 +380,10 @@ let judge_of_array env sigma u tj defj tyj =
   sigma, j
 
 let check_binder_annot sigma s n =
-  check_binder_annot (ESorts.kind sigma s) n
+  (* TODO: get rid of this *)
+  let r = n.binder_relevance in
+  let r' = Sorts.relevance_of_sort (ESorts.kind sigma s) in
+  if r' == r then n else { n with binder_relevance = r' }
 
 (* cstr must be in n.f. w.r.t. evars and execute returns a judgement
    where both the term and type are in n.f. *)

--- a/test-suite/bugs/bug_17091.v
+++ b/test-suite/bugs/bug_17091.v
@@ -1,0 +1,46 @@
+Require Program.Tactics.
+
+Axiom admit : False.
+
+Axiom V : Type.
+Axiom VSet : Type.
+Axiom VSet_mem : V -> VSet -> bool.
+
+Axiom DisjointAdd : V -> VSet -> VSet -> Prop.
+Axiom EdgeOf : V -> V -> Set.
+
+Inductive PathOf : V -> V -> Type :=
+| pathOf_refl x : PathOf x x
+| pathOf_step x y z : EdgeOf x y -> PathOf y z -> PathOf x z.
+
+Arguments pathOf_step {x y z} e p.
+
+Axiom nodes : forall {x y} (p : PathOf x y), VSet.
+
+Inductive SPath : VSet -> V -> V -> Type :=
+| spath_refl s x : SPath s x x
+| spath_step s s' x y z : DisjointAdd x s s' -> EdgeOf x y
+                           -> SPath s y z -> SPath s' x z.
+
+Fixpoint is_simple {x y} (p : PathOf x y) :=
+  match p with
+  | pathOf_refl x => true
+  | @pathOf_step x y z e p => andb (negb (VSet_mem x (nodes p))) (is_simple p)
+  end.
+
+Program Definition to_simple : forall {x y} (p : PathOf x y),
+    is_simple p = true -> SPath (nodes p) x y
+  := fix to_simple {x y} p (Hp : is_simple p = true) {struct p} :=
+       match
+         p in PathOf t t0
+         return is_simple p = true -> SPath (nodes p) t t0
+       with
+       | pathOf_refl x =>
+         fun _ => spath_refl (nodes (pathOf_refl x)) x
+       | @pathOf_step x y z e p0 =>
+         fun Hp0 => @spath_step _ _ _ _ _ _ e (to_simple p0 _)
+       end Hp.
+Next Obligation.
+elim admit.
+Defined.
+Admit Obligations.

--- a/test-suite/success/sprop.v
+++ b/test-suite/success/sprop.v
@@ -169,7 +169,11 @@ End sFix.
 
 (** Relevance repairs *)
 
-Fail Definition fix_relevance : _ -> nat := fun _ : iUnit => 0.
+Definition fix_relevance : _ -> nat := fun _ : iUnit => 0.
+Definition relevance_unfixed := fun (A:SProp) (P:A -> Prop) x y (v:P x) => v : P y.
+(* The kernel is fine *)
+Definition relevance_unfixed_bypass := fun (A:SProp) (P:A -> Prop) x y (v:P x) =>
+                                  ltac:(exact_no_check v) : P y.
 
 (* Check that VM/native properly keep the relevance of the predicate in the case info
    (bad-relevance warning as error otherwise) *)
@@ -182,13 +186,3 @@ Proof.
   move=> T +.
   intros X;exact I.
 Qed.
-
-Set Warnings "-bad-relevance".
-Definition fix_relevance : _ -> nat := fun _ : iUnit => 0.
-
-(* relevance isn't fixed when checking P x == P y *)
-Fail Definition relevance_unfixed := fun (A:SProp) (P:A -> Prop) x y (v:P x) => v : P y.
-
-(* but the kernel is fine *)
-Definition relevance_unfixed := fun (A:SProp) (P:A -> Prop) x y (v:P x) =>
-                                  ltac:(exact_no_check v) : P y.

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -367,7 +367,11 @@ let build_named_proj ~primitive ~flags ~poly ~univs ~uinstance ~kind env paramde
       (* [ccl] is defined in context [params;x:rp] *)
       (* [ccl'] is defined in context [params;x:rp;x:rp] *)
       if primitive then
-        let proj_relevant = match rci with Sorts.Irrelevant -> false | Sorts.Relevant -> true in
+        let proj_relevant = match rci with
+        | Sorts.Irrelevant -> false
+        | Sorts.Relevant -> true
+        | Sorts.RelevanceVar _ -> assert false
+        in
         let p = Projection.Repr.make indsp
             ~proj_relevant ~proj_npars:mib.mind_nparams ~proj_arg:i (Label.of_id fid) in
         mkProj (Projection.make p true, mkRel 1), Some p


### PR DESCRIPTION
We generalize the Sorts.relevance type to also contain references to sort quality variables. This allows delaying the choice of a relevance until the variable is defined. Conversion now uses the same kind of structure for qualities as for evars, and handles undefined qualities as relevant for soundness.

This PR makes the days of the `Cumulative StrictProp` flag numbered.

Depends on #17092 as metacoq reveals a hidden bug.

Overlays:
- https://github.com/MetaCoq/metacoq/pull/827