### PR TITLE
Hide the lovecraftian horror of Program universe handling under an internal API

### DIFF
--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -1037,3 +1037,12 @@ let pr_universe_body = function
 let pr_universe_opt_subst = Univ.Level.Map.pr pr_universe_body
 
 let pr_sort_opt_subst uctx = QState.pr uctx.sort_variables
+
+module Internal =
+struct
+
+let reboot env uctx =
+  let uctx_global = from_env env in
+  { uctx_global with univ_variables = uctx.univ_variables; sort_variables = uctx.sort_variables }
+
+end

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -819,9 +819,6 @@ let merge ?loc ~sideff rigid uctx uctx' =
   { uctx with names; local; universes;
               initial_universes = initial }
 
-let merge_subst uctx s =
-  { uctx with univ_variables = Level.Map.subst_union uctx.univ_variables s }
-
 (* Check bug_4363 and bug_6323 when changing this code *)
 let demote_seff_univs univs uctx =
   let seff = Level.Set.union uctx.seff_univs univs in

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -253,3 +253,12 @@ val pr_weak : (Univ.Level.t -> Pp.t) -> t -> Pp.t
 
 val pr_universe_opt_subst : universe_opt_subst -> Pp.t
 val pr_sort_opt_subst : t -> Pp.t
+
+module Internal :
+sig
+
+val reboot : Environ.env -> t -> t
+(** Madness-inducing hack dedicated to the handling of universes of Program.
+    DO NOT USE OUTSIDE OF DEDICATED AREA. *)
+
+end

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -153,7 +153,6 @@ val univ_flexible : rigid
 val univ_flexible_alg : rigid
 
 val merge : ?loc:Loc.t -> sideff:bool -> rigid -> t -> Univ.ContextSet.t -> t
-val merge_subst : t -> UnivSubst.universe_opt_subst -> t
 val emit_side_effects : Safe_typing.private_constants -> t -> t
 
 val demote_global_univs : Environ.env -> t -> t

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1322,7 +1322,7 @@ let obligation_terminator ~pm ~entry ~uctx ~oinfo:{name; num; auto} =
          universes and constraints if any *)
       defined
     then
-      UState.from_env (Global.env ())
+      UState.Internal.reboot (Global.env ()) uctx
     else uctx
   in
   let pm =
@@ -1350,8 +1350,7 @@ let obligation_admitted_terminator ~pm {name; num; auto} uctx' dref =
     if not prg.prg_info.Info.poly (* Not polymorphic *) then
       (* The universe context was declared globally, we continue
          from the new global environment. *)
-      let uctx = UState.from_env (Global.env ()) in
-      let uctx' = UState.merge_subst uctx (UState.subst uctx') in
+      let uctx' = UState.Internal.reboot (Global.env ()) uctx' in
       (Univ.Instance.empty, uctx')
     else
       (* We get the right order somehow, but surely it could be enforced in a clearer way. *)
@@ -2285,8 +2284,7 @@ let solve_and_declare_by_tac prg obls i tac =
     obls.(i) <- obl';
     if def && not poly then (
       (* Declare the term constraints with the first obligation only *)
-      let uctx_global = UState.from_env (Global.env ()) in
-      let uctx = UState.merge_subst uctx_global (UState.subst uctx) in
+      let uctx = UState.Internal.reboot (Global.env ()) uctx in
       Some (ProgramDecl.Internal.set_uctx ~uctx prg))
     else Some prg
 


### PR DESCRIPTION
We introduce a dedicated function inside an Internal module to replace the unique call to the UState.merge_subst function. We also make the function respect the quality sort variables, which were otherwise dropped by multi-obligation Programs.
