### PR TITLE
Slight tweak to the sort computation of the return predicate of case nodes

### DIFF
--- a/test-suite/bugs/bug_17093.v
+++ b/test-suite/bugs/bug_17093.v
@@ -1,0 +1,11 @@
+Unset Elaboration StrictProp Cumulativity.
+
+Inductive sTrue : SProp := sI.
+
+(* Singleton Prop to SProp *)
+Definition elim0 (x : False) : sTrue := match x return sTrue with end.
+Definition elim0' (x : False) : sTrue := match x with end.
+
+(* Non-singleton Prop to SProp *)
+Definition elim1 (x : inhabited nat) : sTrue := match x return sTrue with inhabits _ => sI end.
+Definition elim1' (x : inhabited nat) : sTrue := match x with inhabits _ => sI end.


### PR DESCRIPTION
Instead of generating a sort based on the inductive type upfront for the return clause of a case, we generate a fresh sort variable. In a second time we check the sort for eliminability and make non-canonical choices if it is underspecified.

Fixes #17093.