### PR TITLE
A minor cleanup of extraction using `Array.init` and `List.init`

### DIFF
--- a/plugins/extraction/mlutil.ml
+++ b/plugins/extraction/mlutil.ml
@@ -1371,8 +1371,7 @@ let normalize a =
 (*S Special treatment of fixpoint for pretty-printing purpose. *)
 
 let general_optimize_fix f ids n args m c =
-  let v = Array.make n 0 in
-  for i=0 to (n-1) do v.(i)<-i done;
+  let v = Array.init n (fun i -> i) in
   let aux i = function
     | MLrel j when v.(j-1)>=0 ->
         if ast_occurs (j+1) c then raise Impossible else v.(j-1)<-(-i-1)

--- a/test-suite/success/extraction.v
+++ b/test-suite/success/extraction.v
@@ -649,7 +649,14 @@ Definition string_test2 (x: string) : unit :=
   | _ => tt
   end.
 
-Definition string_test := (string_test1, string_test2).
+Definition string_test3 (x : string) : string :=
+  String.string_of_list_ascii (String.list_ascii_of_string x).
+
+Definition string_test4 (x : string) : string :=
+  String.string_of_list_byte (String.list_byte_of_string x).
+
+Definition string_test :=
+  (string_test1, string_test2, string_test3, string_test4).
 
 (* Raw extraction of strings *)
 Extraction TestCompile string_test.

--- a/theories/extraction/ExtrOcamlNativeString.v
+++ b/theories/extraction/ExtrOcamlNativeString.v
@@ -58,15 +58,13 @@ Extract Inlined Constant String.string_of_list_ascii =>
       let a = Array.of_list l in
       String.init (Array.length a) (fun i -> a.(i)))".
 Extract Inlined Constant String.list_ascii_of_string =>
-  "(fun s ->
-      Array.to_list (Array.init (String.length s) (fun i -> s.[i])))".
+  "(fun s -> List.init (String.length s) (fun i -> s.[i]))".
 Extract Inlined Constant String.string_of_list_byte =>
   "(fun l ->
       let a = Array.of_list l in
       String.init (Array.length a) (fun i -> a.(i)))".
 Extract Inlined Constant String.list_byte_of_string =>
-  "(fun s ->
-      Array.to_list (Array.init (String.length s) (fun i -> s.[i])))".
+  "(fun s -> List.init (String.length s) (fun i -> s.[i]))".
 
 (* Other operations in module String (at the time of this writing):
       String.length


### PR DESCRIPTION
This should be just a trivial refactoring that preserves the behavior. One that uses `List.init` was [not possible](https://github.com/coq/coq/pull/10486#discussion_r364824348) at some point because it was introduced in OCaml 4.05, but now it should be possible.