### PR TITLE
Uniformizing the treatment of notations for terms and notations for "match"-patterns

### DIFF
--- a/dev/ci/user-overlays/17115-herbelin-master+unify-CPatNotation-CNotation-partial-fix17094.sh
+++ b/dev/ci/user-overlays/17115-herbelin-master+unify-CPatNotation-CNotation-partial-fix17094.sh
@@ -1,0 +1,1 @@
+overlay tactician https://github.com/herbelin/coq-tactician master+adapt-coq-pr17115 17115

--- a/doc/changelog/03-notations/17115-master+unify-CPatNotation-CNotation-partial-fix17094.rst
+++ b/doc/changelog/03-notations/17115-master+unify-CPatNotation-CNotation-partial-fix17094.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Various bugs and limitations to using custom binders in non-recursive and recursive notations
+  (`#17115 <https://github.com/coq/coq/pull/17115>`_,
+  fixes parts of `#17094 <https://github.com/coq/coq/issues/17094>`_,
+  by Hugo Herbelin).

--- a/interp/abbreviation.ml
+++ b/interp/abbreviation.ml
@@ -23,7 +23,6 @@ type abbreviation =
   { abbrev_pattern : interpretation;
     abbrev_onlyparsing : bool;
     abbrev_deprecation : Deprecation.t option;
-    abbrev_also_in_cases_pattern : bool;
     abbrev_activated : bool; (* Not really necessary in practice *)
   }
 
@@ -77,7 +76,7 @@ let open_abbreviation i ((sp,kn),(_local,abbrev)) =
     if not abbrev.abbrev_onlyparsing then
       (* Redeclare it to be used as (short) name in case an other (distfix)
          notation was declared in between *)
-      Notationextern.declare_uninterpretation ~also_in_cases_pattern:abbrev.abbrev_also_in_cases_pattern (AbbrevRule kn) pat
+      Notationextern.declare_uninterpretation (AbbrevRule kn) pat
   end
 
 let import_abbreviation i sp kn =
@@ -103,12 +102,11 @@ let inAbbreviation : Id.t -> (bool * abbreviation) -> obj =
     subst_function = subst_abbreviation;
     classify_function = classify_abbreviation }
 
-let declare_abbreviation ~local ?(also_in_cases_pattern=true) deprecation id ~onlyparsing pat =
+let declare_abbreviation ~local deprecation id ~onlyparsing pat =
   let abbrev =
     { abbrev_pattern = pat;
       abbrev_onlyparsing = onlyparsing;
       abbrev_deprecation = deprecation;
-      abbrev_also_in_cases_pattern = also_in_cases_pattern;
       abbrev_activated = true;
     }
   in

--- a/interp/abbreviation.mli
+++ b/interp/abbreviation.mli
@@ -15,7 +15,7 @@ open Globnames
 
 (** Abbreviations. *)
 
-val declare_abbreviation : local:bool -> ?also_in_cases_pattern:bool -> Deprecation.t option -> Id.t ->
+val declare_abbreviation : local:bool -> Deprecation.t option -> Id.t ->
   onlyparsing:bool -> interpretation -> unit
 
 val search_abbreviation : abbreviation -> interpretation

--- a/interp/constrexpr.mli
+++ b/interp/constrexpr.mli
@@ -104,8 +104,9 @@ and cases_pattern_expr = cases_pattern_expr_r CAst.t
 and kinded_cases_pattern_expr = cases_pattern_expr * Glob_term.binding_kind
 
 and cases_pattern_notation_substitution =
-    cases_pattern_expr list *     (* for constr subterms *)
-    cases_pattern_expr list list  (* for recursive notations *)
+    cases_pattern_expr list *      (* for cases_pattern subterms parsed as terms *)
+    cases_pattern_expr list list * (* for recursive notations parsed as terms*)
+    kinded_cases_pattern_expr list (* for cases_pattern subterms parsed as binders *)
 
 and constr_expr_r =
   | CRef     of qualid * instance_expr option

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -170,7 +170,7 @@ let rec insert_entry_coercion ?loc l c = match l with
 
 let rec insert_pat_coercion ?loc l c = match l with
   | [] -> c
-  | (inscope,ntn)::l -> CAst.make ?loc @@ CPatNotation (Some inscope,ntn,([insert_pat_coercion ?loc l c],[]),[])
+  | (inscope,ntn)::l -> CAst.make ?loc @@ CPatNotation (Some inscope,ntn,([insert_pat_coercion ?loc l c],[],[]),[])
 
 (**********************************************************************)
 (* conversion of references                                           *)
@@ -284,10 +284,12 @@ let make_notation loc (inscope,ntn) (terms,termlists,binders,binderlists as subs
       (fun (loc,p) -> CAst.make ?loc @@ CPrim p)
       destPrim terms binders
 
-let make_pat_notation ?loc (inscope,ntn) (terms,termlists as subst) args =
-  if not (List.is_empty termlists) then (CAst.make ?loc @@ CPatNotation (Some inscope,ntn,subst,args)) else
+let make_pat_notation ?loc (inscope,ntn) (terms,termlists,binders as subst) args =
+  if not (List.is_empty termlists && List.is_empty binders) then
+    (CAst.make ?loc @@ CPatNotation (Some inscope,ntn,subst,args))
+  else
   make_notation_gen loc ntn
-    (fun (loc,ntn,l,_) -> CAst.make ?loc @@ CPatNotation (Some inscope,ntn,(l,[]),args))
+    (fun (loc,ntn,l,_) -> CAst.make ?loc @@ CPatNotation (Some inscope,ntn,(l,[],[]),args))
     (fun (loc,p)     -> CAst.make ?loc @@ CPatPrim p)
     destPatPrim terms []
 
@@ -384,7 +386,7 @@ let rec extern_cases_pattern_in_scope (custom,scopes as allscopes) vars pat =
       in
       insert_pat_coercion coercion pat
 
-and apply_notation_to_pattern ?loc gr ((subst,substlist),(no_implicit,nb_to_drop,more_args))
+and apply_notation_to_pattern ?loc gr ((terms,termlists,binders),(no_implicit,nb_to_drop,more_args))
     (custom, (tmp_scope, scopes) as allscopes) vars rule =
   match rule with
     | NotationRule (_,ntn as specific_ntn) ->
@@ -403,12 +405,18 @@ and apply_notation_to_pattern ?loc gr ((subst,substlist),(no_implicit,nb_to_drop
               List.map (fun (c,subscope) ->
                 let scopes = update_with_subscope subscope scopes' in
                 extern_cases_pattern_in_scope scopes vars c)
-                subst in
+                terms in
             let ll =
               List.map (fun (c,subscope) ->
                 let scopes = update_with_subscope subscope scopes' in
                 List.map (extern_cases_pattern_in_scope scopes vars) c)
-                substlist in
+                termlists in
+            let bl =
+              List.map (fun (c,subscope) ->
+                let scopes = update_with_subscope subscope scopes' in
+                (extern_cases_pattern_in_scope scopes vars c, Explicit))
+                binders
+            in
             let subscopes = find_arguments_scope gr in
             let more_args_scopes = try List.skipn nb_to_drop subscopes with Failure _ -> [] in
             let more_args = fill_arg_scopes more_args more_args_scopes allscopes in
@@ -422,7 +430,7 @@ and apply_notation_to_pattern ?loc gr ((subst,substlist),(no_implicit,nb_to_drop
             in
             insert_pat_coercion coercion
               (insert_pat_delimiters ?loc
-                 (make_pat_notation ?loc specific_ntn (l,ll) l2') key)
+                 (make_pat_notation ?loc specific_ntn (l,ll,bl) l2') key)
       end
     | AbbrevRule kn ->
       match availability_of_entry_coercion custom (InConstrEntry, 0) with
@@ -432,7 +440,7 @@ and apply_notation_to_pattern ?loc gr ((subst,substlist),(no_implicit,nb_to_drop
       let l1 =
         List.rev_map (fun (c,(subentry,(scopt,scl))) ->
           extern_cases_pattern_in_scope (subentry,(scopt,scl@scopes)) vars c)
-          subst in
+          terms in
       let subscopes = find_arguments_scope gr in
       let more_args_scopes = try List.skipn nb_to_drop subscopes with Failure _ -> [] in
       let more_args = fill_arg_scopes more_args more_args_scopes allscopes in
@@ -444,7 +452,8 @@ and apply_notation_to_pattern ?loc gr ((subst,substlist),(no_implicit,nb_to_drop
             |Some true_args -> true_args
             |None -> raise No_match
       in
-      assert (List.is_empty substlist);
+      assert (List.is_empty termlists);
+      assert (List.is_empty binders);
       insert_pat_coercion ?loc coercion (mkPat ?loc qid (List.rev_append l1 l2'))
 and extern_notation_pattern allscopes vars t = function
   | [] -> raise No_match

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1640,7 +1640,7 @@ type entry_coercion_kind =
   | IsEntryGlobal of string * int
   | IsEntryIdent of string * int
 
-let declare_notation (scopt,ntn) pat df ~use ~also_in_cases_pattern coe deprecation =
+let declare_notation (scopt,ntn) pat df ~use coe deprecation =
   (* Register the interpretation *)
   let scope = match scopt with NotationInScope s -> s | LastLonelyNotation -> default_scope in
   let sc = find_scope scope in
@@ -1668,7 +1668,7 @@ let declare_notation (scopt,ntn) pat df ~use ~also_in_cases_pattern coe deprecat
      | Some pat -> remove_uninterpretation (NotationRule (scopt,ntn)) pat
      | None -> ()
      end;
-     declare_uninterpretation ~also_in_cases_pattern (NotationRule (scopt,ntn)) pat
+     declare_uninterpretation (NotationRule (scopt,ntn)) pat
   end
 
 let availability_of_prim_token n printer_scope local_scopes =

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -250,7 +250,6 @@ type entry_coercion_kind =
 
 val declare_notation : notation_with_optional_scope * notation ->
   interpretation -> notation_location -> use:notation_use ->
-  also_in_cases_pattern:bool ->
   entry_coercion_kind option ->
   Deprecation.t option -> unit
 

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -528,9 +528,7 @@ let check_pair_matching ?loc x y x' y' revert revert' =
        strbrk " while " ++ Id.print x' ++ strbrk " matching " ++ Id.print y' ++
        strbrk " was first found.")
 
-let pair_equal eq1 eq2 (a,b) (a',b') = eq1 a a' && eq2 b b'
-
-let mem_recursive_pair (x,y) l = List.mem_f (pair_equal Id.equal Id.equal) (x,y) l
+let mem_recursive_pair (x,y) l = List.mem_f (eq_pair Id.equal Id.equal) (x,y) l
 
 type recursive_pattern_kind =
 | RecursiveTerms of bool (* in reverse order *)
@@ -608,14 +606,14 @@ let compare_recursive_parts recvars found f f' (iterator,subc) =
           f' (if revert then iterator else subst_glob_vars [x, DAst.make @@ GVar y] iterator) in
         (* found variables have been collected by compare_constr *)
         found := { !found with vars = List.remove Id.equal y (!found).vars;
-                               recursive_term_vars = List.add_set (pair_equal Id.equal Id.equal) (x,y) (!found).recursive_term_vars };
+                               recursive_term_vars = List.add_set (eq_pair Id.equal Id.equal) (x,y) (!found).recursive_term_vars };
         NList (x,y,iterator,f (Option.get !terminator),revert)
     | Some (x,y,RecursiveBinders revert) ->
         let iterator =
           f' (if revert then iterator else subst_glob_vars [x, DAst.make @@ GVar y] iterator) in
         (* found have been collected by compare_constr *)
         found := { !found with vars = List.remove Id.equal y (!found).vars;
-                               recursive_binders_vars = List.add_set (pair_equal Id.equal Id.equal) (x,y) (!found).recursive_binders_vars };
+                               recursive_binders_vars = List.add_set (eq_pair Id.equal Id.equal) (x,y) (!found).recursive_binders_vars };
         NBinderList (x,y,iterator,f (Option.get !terminator),revert)
   else
     raise Not_found

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -1729,12 +1729,14 @@ let match_ind_pattern metas sigma ind pats a2 =
   |_ -> raise No_match
 
 let reorder_canonically_substitution terms termlists metas =
-  List.fold_right (fun (x,(scl,typ)) (terms',termlists') ->
+  List.fold_right (fun (x,(scl,typ)) (terms',termlists',binders') ->
     match typ with
-      | NtnTypeConstr -> ((Id.List.assoc x terms, scl)::terms',termlists')
-      | NtnTypeConstrList -> (terms',(Id.List.assoc x termlists,scl)::termlists')
-      | NtnTypeBinder _ | NtnTypeBinderList _ -> anomaly (str "Unexpected binder in pattern notation."))
-    metas ([],[])
+      | NtnTypeConstr | NtnTypeBinder (NtnBinderParsedAsConstr _) -> ((Id.List.assoc x terms, scl)::terms',termlists',binders')
+      | NtnTypeConstrList -> (terms',(Id.List.assoc x termlists,scl)::termlists',binders')
+      | NtnTypeBinder (NtnBinderParsedAsBinder | NtnBinderParsedAsSomeBinderKind _) ->
+         (terms',termlists',(Id.List.assoc x terms, scl)::binders')
+      | NtnTypeBinderList _ -> anomaly (str "Unexpected binder in pattern notation."))
+    metas ([],[],[])
 
 let match_notation_constr_cases_pattern c (metas,pat) =
   let (terms,termlists,(),()),more_args = match_cases_pattern metas ([],[],(),()) c pat in

--- a/interp/notation_ops.mli
+++ b/interp/notation_ops.mli
@@ -82,10 +82,14 @@ val match_notation_constr : print_univ:bool -> 'a glob_constr_g -> vars:Id.Set.t
 
 val match_notation_constr_cases_pattern :
   'a cases_pattern_g -> interpretation ->
-  (('a cases_pattern_g * extended_subscopes) list * ('a cases_pattern_g list * extended_subscopes) list) *
+  (('a cases_pattern_g * extended_subscopes) list *
+   ('a cases_pattern_g list * extended_subscopes) list *
+   ('a cases_pattern_g * extended_subscopes) list) *
     (bool * int * 'a cases_pattern_g list)
 
 val match_notation_constr_ind_pattern :
   inductive -> 'a cases_pattern_g list -> interpretation ->
-  (('a cases_pattern_g * extended_subscopes) list * ('a cases_pattern_g list * extended_subscopes) list) *
+  (('a cases_pattern_g * extended_subscopes) list *
+   ('a cases_pattern_g list * extended_subscopes) list *
+   ('a cases_pattern_g * extended_subscopes) list) *
     (bool * int * 'a cases_pattern_g list)

--- a/interp/notationextern.ml
+++ b/interp/notationextern.ml
@@ -117,7 +117,7 @@ type notation_rule = interp_rule * interpretation * notation_applicative_status
 let notation_rule_eq (rule1,pat1,s1 as x1) (rule2,pat2,s2 as x2) =
   x1 == x2 || (rule1 = rule2 && interpretation_eq pat1 pat2 && s1 = s2)
 
-let strictly_finer_interpretation_than (_,(_,interp1,_)) (_,(_,interp2,_)) =
+let strictly_finer_interpretation_than (_,interp1,_) (_,interp2,_) =
   Notation_ops.strictly_finer_interpretation_than interp1 interp2
 
 let keymap_add key interp map =
@@ -128,15 +128,14 @@ let keymap_add key interp map =
 
 let keymap_remove key interp map =
   let old = try KeyMap.find key map with Not_found -> [] in
-  KeyMap.add key (List.remove_first (fun (_,rule) -> notation_rule_eq interp rule) old) map
+  KeyMap.add key (List.remove_first (fun rule -> notation_rule_eq interp rule) old) map
 
 let keymap_find key map =
   try KeyMap.find key map
   with Not_found -> []
 
 (* Scopes table : interpretation -> scope_name *)
-(* Boolean = for cases pattern also *)
-let notations_key_table = ref (KeyMap.empty : (bool * notation_rule) list KeyMap.t)
+let notations_key_table = ref (KeyMap.empty : notation_rule list KeyMap.t)
 
 let glob_prim_constr_key c = match DAst.get c with
   | GRef (ref, _) -> Some (canonical_gr ref)
@@ -178,25 +177,22 @@ let notation_constr_key = function (* Rem: NApp(NRef ref,[]) stands for @ref *)
   | _ -> Oth, NotAppNotation
 
 let uninterp_notations c =
-  List.map_append (fun key -> List.map snd (keymap_find key !notations_key_table))
+  List.map_append (fun key -> keymap_find key !notations_key_table)
     (glob_constr_keys c)
 
-let filter_also_for_pattern =
-  List.map_filter (function (true,x) -> Some x | _ -> None)
-
 let uninterp_cases_pattern_notations c =
-  filter_also_for_pattern (keymap_find (cases_pattern_key c) !notations_key_table)
+  keymap_find (cases_pattern_key c) !notations_key_table
 
 let uninterp_ind_pattern_notations ind =
-  filter_also_for_pattern (keymap_find (RefKey (canonical_gr (GlobRef.IndRef ind))) !notations_key_table)
+  keymap_find (RefKey (canonical_gr (GlobRef.IndRef ind))) !notations_key_table
 
 let remove_uninterpretation rule (metas,c as pat) =
   let (key,n) = notation_constr_key c in
   notations_key_table := keymap_remove key ((rule,pat,n)) !notations_key_table
 
-let declare_uninterpretation ?(also_in_cases_pattern=true) rule (metas,c as pat) =
+let declare_uninterpretation rule (metas,c as pat) =
   let (key,n) = notation_constr_key c in
-  notations_key_table := keymap_add key (also_in_cases_pattern,(rule,pat,n)) !notations_key_table
+  notations_key_table := keymap_add key (rule,pat,n) !notations_key_table
 
 let freeze () =
   !notations_key_table

--- a/interp/notationextern.mli
+++ b/interp/notationextern.mli
@@ -47,7 +47,7 @@ type 'a interp_rule_gen =
 type interp_rule = KerName.t interp_rule_gen
 
 val remove_uninterpretation : interp_rule -> interpretation -> unit
-val declare_uninterpretation : ?also_in_cases_pattern:bool -> interp_rule -> interpretation -> unit
+val declare_uninterpretation : interp_rule -> interpretation -> unit
 
 type notation_applicative_status =
   | AppBoundedNotation of int

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -21,6 +21,15 @@ let on_fst f (a,b) = (f a,b)
 let on_snd f (a,b) = (a,f b)
 let map_pair f (a,b) = (f a,f b)
 
+(* Folding under pairs *)
+
+let fold_fst f acc (a,b) = let acc, a = f acc a in acc, (a, b)
+let fold_snd f acc (a,b) = let acc, b = f acc b in acc, (a, b)
+
+(* Equality on pairs *)
+
+let eq_pair eq1 eq2 (a,b) (a',b') = eq1 a a' && eq2 b b'
+
 (* Mapping under triplets *)
 
 let on_pi1 f (a,b,c) = (f a,b,c)

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -24,6 +24,15 @@ val on_fst : ('a -> 'b) -> 'a * 'c -> 'b * 'c
 val on_snd : ('a -> 'b) -> 'c * 'a -> 'c * 'b
 val map_pair : ('a -> 'b) -> 'a * 'a -> 'b * 'b
 
+(** Folding under pairs *)
+
+val fold_fst : ('c -> 'a -> 'c * 'a) -> 'c -> 'a * 'b -> 'c * ('a * 'b)
+val fold_snd : ('c -> 'b -> 'c * 'b) -> 'c -> 'a * 'b -> 'c * ('a * 'b)
+
+(** Equality on pairs *)
+
+val eq_pair : ('a -> 'a -> bool) -> ('b -> 'b -> bool) -> ('a * 'b -> 'a * 'b -> bool)
+
 (** Mapping under triplets *)
 
 val on_pi1 : ('a -> 'b) -> 'a * 'c * 'd -> 'b * 'c * 'd

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -375,7 +375,7 @@ GRAMMAR EXTEND Gram
              collapse -(3) into the number -3. *)
           match p.CAst.v with
           | CPatPrim (Number (NumTok.SPlus,n)) ->
-              CAst.make ~loc @@ CPatNotation(None,(InConstrEntry,"( _ )"),([p],[]),[])
+              CAst.make ~loc @@ CPatNotation(None,(InConstrEntry,"( _ )"),([p],[],[]),[])
           | _ -> p }
       | "("; p = pattern LEVEL "200"; "|" ; pl = LIST1 pattern LEVEL "200" SEP "|"; ")" ->
         { CAst.make ~loc @@ CPatOr (p::pl) }

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -314,11 +314,11 @@ let tag_var = tag Tag.variable
         let pp p = hov 0 (pr_patt mt pr lpattop p) in
         surround (hov 0 (prlist_with_sep pr_spcbar pp pl)), lpator
 
-      | CPatNotation (_,(_,"( _ )"),([p],[]),[]) ->
+      | CPatNotation (_,(_,"( _ )"),([p],[],[]),[]) ->
         pr_patt (fun()->str"(") pr lpattop p ++ str")", latom
 
-      | CPatNotation (which,s,(l,ll),args) ->
-        let strm_not, l_not = pr_notation (pr_patt mt pr) (fun _ _ _ _ -> mt ()) (fun _ _ _ _ -> mt()) which s (l,ll,[],[]) in
+      | CPatNotation (which,s,(l,ll,bl),args) ->
+        let strm_not, l_not = pr_notation (pr_patt mt pr) (pr_patt_binder pr) (fun _ _ _ -> mt) which s (l,ll,bl,[]) in
         (if List.is_empty args||prec_less l_not (LevelLt lapp) then strm_not else surround strm_not)
         ++ prlist (pr_patt spc pr (LevelLt lapp)) args, if not (List.is_empty args) then lapp else l_not
 
@@ -335,16 +335,16 @@ let tag_var = tag Tag.variable
     pr_with_comments ?loc
       (sep() ++ if prec_less prec inh then strm else surround strm)
 
-  let pr_patt = pr_patt mt
-
-  let pr_patt_binder pr prec style bk c =
+  and pr_patt_binder pr prec style bk c =
     match bk with
-    | MaxImplicit -> str "{" ++ pr_patt pr lpattop c ++ str "}"
-    | NonMaxImplicit -> str "[" ++ pr_patt pr lpattop c ++ str "]"
+    | MaxImplicit -> str "{" ++ pr_patt mt pr lpattop c ++ str "}"
+    | NonMaxImplicit -> str "[" ++ pr_patt mt pr lpattop c ++ str "]"
     | Explicit ->
       match style, c with
-      | NotQuotedPattern, _ | _, {v=CPatAtom _} -> pr_patt pr prec c
-      | QuotedPattern, _ -> str "'" ++ pr_patt pr prec c
+      | NotQuotedPattern, _ | _, {v=CPatAtom _} -> pr_patt mt pr prec c
+      | QuotedPattern, _ -> str "'" ++ pr_patt mt pr prec c
+
+  let pr_patt = pr_patt mt
 
   let pr_eqn pr {loc;v=(pl,rhs)} =
     spc() ++ hov 4

--- a/test-suite/output/Notations3.out
+++ b/test-suite/output/Notations3.out
@@ -264,3 +264,8 @@ FORALL [[a, b]], a - b = 0
      : Prop
 ∀ a b : nat, a - b = 0
      : Prop
+fun x : option unit => match x with
+                       | # tt & => # tt &
+                       | None => None
+                       end
+     : option unit -> option unit

--- a/test-suite/output/Notations3.out
+++ b/test-suite/output/Notations3.out
@@ -260,3 +260,7 @@ FORALL [[a, b]], a - b = 0
 ∀ (A : TypTerm) (B : ◻ A -> TypTerm),
 (∀ a : ◻ A, ◻ {B a}) -> ◻ (∀' {a : ◻ A}, {B a})
      : Type
+FORALL [[a, b]], a - b = 0
+     : Prop
+∀ a b : nat, a - b = 0
+     : Prop

--- a/test-suite/output/Notations3.v
+++ b/test-suite/output/Notations3.v
@@ -499,3 +499,11 @@ Notation "'FORALL' x .. y , P" := (forall x , .. (forall y , P) .. )
 Check FORALL a b, a - b = 0.
 
 End PartOfIssue17094Ident.
+
+Module BetterFix13078.
+
+(* We now support referring to ident and pattern in notations for pattern *)
+Notation "# x &" := (Some x) (at level 0, x pattern).
+Check fun (x : option unit) => match x with | None => None | # tt & => # tt & end.
+
+End BetterFix13078.

--- a/test-suite/output/Notations3.v
+++ b/test-suite/output/Notations3.v
@@ -472,3 +472,30 @@ Notation "∀' x .. y , P" := (FORALL (fun x => .. (FORALL (fun y => P)) .. ))
 Check ∀ A (B : ValTerm A -> TypTerm), (∀ (a : ◻A), ◻{B a}) -> ◻(∀' {a}, {B a}).
 
 End PartOfIssue17094PrintingAssumption.
+
+Module PartOfIssue17094Pattern.
+
+(* The same but referring this time to a pattern *)
+
+Notation "'FORALL' x .. y , P" := (forall x , .. (forall y , P) .. )
+  (at level 200, x constr at level 8 as pattern, right associativity,
+      format "'[  ' '[  ' 'FORALL'  x  ..  y ']' ,  '/' P ']'") : type_scope.
+Notation "[[ x , y ]]" := (x,y) (x pattern, y pattern).
+Check FORALL [[a , b]], a - b = 0.
+
+End PartOfIssue17094Pattern.
+
+Module PartOfIssue17094Ident.
+
+(* A variant with custom entries and referring this time to a ident *)
+
+Declare Custom Entry quoted_binder'.
+Notation "x" := x (in custom quoted_binder' at level 0, x ident).
+Notation "'FORALL' x .. y , P" := (forall x , .. (forall y , P) .. )
+  (at level 200, x custom quoted_binder' as pattern, right associativity,
+   format "'[  ' '[  ' 'FORALL'  x  ..  y ']' ,  '/' P ']'") : type_scope.
+
+(* Note: notation not used for printing because no rule to print "a:nat" and "b:nat" *)
+Check FORALL a b, a - b = 0.
+
+End PartOfIssue17094Ident.

--- a/vernac/egramcoq.ml
+++ b/vernac/egramcoq.ml
@@ -254,8 +254,8 @@ type prod_info = production_level * production_position
 type (_, _) entry =
 | TTIdent : ('self, lident) entry
 | TTName : ('self, lname) entry
-| TTGlobal : ('self, qualid) entry
-| TTBigint : ('self, string) entry
+| TTGlobal : ('r, qualid) entry
+| TTBigint : ('r, string) entry
 | TTBinder : bool -> ('self, kinded_cases_pattern_expr) entry
 | TTConstr : notation_entry * prod_info * 'r target -> ('r, 'r) entry
 | TTConstrList : notation_entry * prod_info * (bool * string) list * 'r target -> ('r, 'r list) entry
@@ -423,21 +423,9 @@ let push_constr subst v = { subst with constrs = v :: subst.constrs }
 let push_item : type s r. s target -> (s, r) entry -> s env -> r -> s env = fun forpat e subst v ->
 match e with
 | TTConstr _ -> push_constr subst v
-| TTIdent ->
-  begin match forpat with
-  | ForConstr -> { subst with binders = (cases_pattern_expr_of_id v, Glob_term.Explicit) :: subst.binders }
-  | ForPattern -> push_constr subst (cases_pattern_expr_of_id v)
-  end
-| TTName ->
-  begin match forpat with
-  | ForConstr -> { subst with binders = (cases_pattern_expr_of_name v, Glob_term.Explicit) :: subst.binders }
-  | ForPattern -> push_constr subst (cases_pattern_expr_of_name v)
-  end
-| TTPattern _ ->
-  begin match forpat with
-  | ForConstr -> { subst with binders = (v, Glob_term.Explicit) :: subst.binders }
-  | ForPattern -> push_constr subst v
-  end
+| TTIdent -> { subst with binders = (cases_pattern_expr_of_id v, Glob_term.Explicit) :: subst.binders }
+| TTName -> { subst with binders = (cases_pattern_expr_of_name v, Glob_term.Explicit) :: subst.binders }
+| TTPattern _ -> { subst with binders = (v, Glob_term.Explicit) :: subst.binders }
 | TTBinder o -> { subst with binders = v :: subst.binders }
 | TTOpenBinderList -> { subst with binderlists = v :: subst.binderlists }
 | TTClosedBinderListPure _ -> { subst with binderlists = List.flatten v :: subst.binderlists }
@@ -585,7 +573,7 @@ let make_act : type r. r target -> _ -> r gen_eval = function
   let env = (env.constrs, env.constrlists, env.binders, env.binderlists) in
   CAst.make ~loc @@ CNotation (None, notation, env)
 | ForPattern -> fun notation loc env ->
-  let env = (env.constrs, env.constrlists) in
+  let env = (env.constrs, env.constrlists, env.binders) in
   CAst.make ~loc @@ CPatNotation (None, notation, env, [])
 
 let extend_constr state forpat ng =

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1107,13 +1107,6 @@ let interp_non_syntax_modifiers ~reserved ~infix ~abbrev deprecation mods =
   in
   List.fold_left set (main_data,[]) mods
 
-(* Check if an interpretation can be used for printing a cases printing *)
-let has_no_binders_type =
-  List.for_all (fun (_,(_,typ)) ->
-  match typ with
-  | NtnTypeBinder _ | NtnTypeBinderList _ -> false
-  | NtnTypeConstr | NtnTypeConstrList -> true)
-
 (* Compute precedences from modifiers (or find default ones) *)
 
 let set_entry_type from n etyps (x,typ) =
@@ -1462,7 +1455,6 @@ type notation_obj = {
   notobj_deprecation : Deprecation.t option;
   notobj_notation : notation * notation_location;
   notobj_specific_pp_rules : notation_printing_rules option;
-  notobj_also_in_cases_pattern : bool;
 }
 
 let load_notation_common silently_define_scope_if_undefined _ nobj =
@@ -1720,7 +1712,6 @@ let make_notation_interpretation ~local main_data notation_symbols ntn syntax_ru
   let interp = make_interpretation_vars recvars acvars plevel i_typs in
   let map (x, _) = try Some (x, Id.Map.find x interp) with Not_found -> None in
   let vars = List.map_filter map i_vars in (* Order of elements is important here! *)
-  let also_in_cases_pattern = has_no_binders_type vars in
   let onlyparsing,coe = printability level i_typs vars main_data.onlyparsing reversibility ac in
   let main_data = { main_data with onlyparsing } in
   let use = make_use false onlyparsing main_data.onlyprinting in
@@ -1733,7 +1724,6 @@ let make_notation_interpretation ~local main_data notation_symbols ntn syntax_ru
     notobj_deprecation = main_data.deprecation;
     notobj_notation = df';
     notobj_specific_pp_rules = sy_pp_rules;
-    notobj_also_in_cases_pattern = also_in_cases_pattern;
   }
 
 (* Notations without interpretation (Reserved Notation) *)

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1485,10 +1485,9 @@ let open_notation i nobj =
     let pat = nobj.notobj_interp in
     let deprecation = nobj.notobj_deprecation in
     let scope = match scope with None -> LastLonelyNotation | Some sc -> NotationInScope sc in
-    let also_in_cases_pattern = nobj.notobj_also_in_cases_pattern in
     (* Declare the notation *)
     (match nobj.notobj_use with
-    | Some use -> Notation.declare_notation (scope,ntn) pat df ~use ~also_in_cases_pattern nobj.notobj_coercion deprecation
+    | Some use -> Notation.declare_notation (scope,ntn) pat df ~use nobj.notobj_coercion deprecation
     | None -> ());
     (* Declare specific format if any *)
     (match nobj.notobj_specific_pp_rules with
@@ -1925,9 +1924,8 @@ let add_abbreviation ~local deprecation env ident (vars,c) modl =
   let level = (InConstrEntry,0,[]) in
   let interp = make_interpretation_vars ~default_if_binding:AsAnyPattern [] acvars level (List.map in_pat vars) in
   let vars = List.map (fun (x,_) -> (x, Id.Map.find x interp)) vars in
-  let also_in_cases_pattern = has_no_binders_type vars in
   let onlyparsing = only_parsing || fst (printability None [] vars false reversibility pat) in
-  Abbreviation.declare_abbreviation ~local ~also_in_cases_pattern deprecation ident ~onlyparsing (vars,pat)
+  Abbreviation.declare_abbreviation ~local deprecation ident ~onlyparsing (vars,pat)
 
 (**********************************************************************)
 (* Activating/deactivating notations                                  *)


### PR DESCRIPTION
In notations for `match` patterns, we keep the `binder` category of notations variables as it is rather than merging it with the category of notation variables parsed as terms (even though both are eventually interpreted as `match` patterns). This makes the mutual translation between terms and patterns easier with two applications:
- this fixes one part of #17094, namely the examples there that involve notations with a subentry parsed as an `ident` or `pattern`,
- this provides with a less restrictive and simpler fix of (the third example of) #13078.

Depends on #16937 (merged).

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
- [x] Synchronous overlay: coq-tactician/coq-tactician#60

Note: the change log could possibly be merged with the one of #16937 since, after all, they both address limitations and bugs of referring to binders in notations.
