### PR TITLE
Fix #17073: guard checking in the presence of "match" with inaccessible branches

### DIFF
--- a/doc/changelog/01-kernel/17116-master+fix17073-guard-checking-inaccessible-branch.rst
+++ b/doc/changelog/01-kernel/17116-master+fix17073-guard-checking-inaccessible-branch.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Unexpected anomaly when checking termination of fixpoints
+  containing :g:`match` expressions with inaccessible branches
+  (`#17116 <https://github.com/coq/coq/pull/17116>`_,
+  fixes `#17073 <https://github.com/coq/coq/issues/17073>`_,
+  by Hugo Herbelin).

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -1256,7 +1256,9 @@ let check_one_fix renv recpos trees def =
             end
 
         | Prod (x,a,u) ->
-            let () = assert (List.is_empty stack) in
+            (* Note: we cannot ensure that the stack is empty because
+               non-accessible branches of "match" expressions can have
+               arbitrary types (see #17073) *)
             let rs = check_inert_subterm_rec_call renv rs a in
             (* Note: can recursive calls on [x] be else than inert "dead code"? *)
             check_rec_call_stack (push_var_renv renv (redex_level rs) (x,a)) [] rs u
@@ -1318,10 +1320,11 @@ let check_one_fix renv recpos trees def =
             rs
 
         | Sort _ | Int _ | Float _ ->
-            assert (List.is_empty stack); rs
+            (* See [Prod]: we cannot ensure that the stack is empty *)
+            rs
 
         | Array (_u,t,def,ty) ->
-            assert (List.is_empty stack);
+            (* See [Prod]: we cannot ensure that the stack is empty *)
             let rs = Array.fold_left (check_inert_subterm_rec_call renv) rs t in
             let rs = check_inert_subterm_rec_call renv rs def in
             let rs = check_inert_subterm_rec_call renv rs ty in

--- a/test-suite/bugs/bug_17073.v
+++ b/test-suite/bugs/bug_17073.v
@@ -1,0 +1,25 @@
+Inductive vector : nat -> Type :=
+  | vector_Nil : vector 0
+  | vector_Cons n : vector n -> vector (S n).
+
+Fixpoint bv_and {n} (bv1 bv2 : vector n) : vector n :=
+  match bv1 with
+  | vector_Nil => fun _ => vector_Nil
+  | vector_Cons n1' bv1' => fun bv2 =>
+    match (bv2 : vector (S n1')) in (vector n2) return
+      (match n2 with 0 => Type | S n2' => (vector n2' -> vector n1') -> vector (S n1') end) with
+    | vector_Nil => Type
+    | vector_Cons _ bv2' => fun cast => vector_Cons _ (bv_and bv1' (cast bv2'))
+    end (fun x => x)
+  end bv2.
+
+Fixpoint bv_and2 {n} (bv1 bv2 : vector n) : vector n :=
+  match bv1 with
+  | vector_Nil => fun _ => vector_Nil
+  | vector_Cons n1' bv1' => fun bv2 =>
+    match (bv2 : vector (S n1')) in (vector n2) return
+      (match n2 with 0 => Type | S n2' => (vector n2' -> vector n1') -> vector (S n1') end) with
+    | vector_Nil => True -> True
+    | vector_Cons _ bv2' => fun cast => vector_Cons _ (bv_and2 bv1' (cast bv2'))
+    end (fun x => x)
+  end bv2.


### PR DESCRIPTION
This fixes a bug of the new strong guard checking in #15434: we cannot expect an inaccessible `match` branch to have a type compatible with the external type of the `match`. In particular, if there is a stack of arguments to apply to the whole `match`, the inaccessible branch is not necessarily able to grab them.

Fixes / closes #17073

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
