### PR TITLE
Clarifying the logic of levels in custom and constr entry rules (reopening of #13025)

### DIFF
--- a/dev/ci/user-overlays/17117-master+fix-printing-custom-no-level.sh
+++ b/dev/ci/user-overlays/17117-master+fix-printing-custom-no-level.sh
@@ -1,0 +1,2 @@
+overlay elpi https://github.com/herbelin/coq-elpi coq-master+adapt-coq-pr13025-fix-custom-entry-no-level-printing 17117 master+fix-printing-custom-no-level
+overlay serapi https://github.com/herbelin/coq-serapi main+adapt-coq-pr17117-renamings 17117 master+fix-printing-custom-no-level

--- a/dev/doc/changes.md
+++ b/dev/doc/changes.md
@@ -144,6 +144,15 @@ deprecation warning tells what to do.
   defined level with the provided rules. Note that this differs from FIRST,
   which creates a new level and prepends it to the list of levels of the entry.
 
+### Notations:
+
+- The type `notation_entry_level` has been split into two: the name
+  `notation_entry_level` still exists and is used to characterize the
+  level and custom entry name (if any) where a grammar rule lives; the
+  new `notation_subentry_level` is to characterize the level (possibly
+  none) and custom entry name associated to the variables (=
+  non-terminal subentries) of the grammar rule.
+
 ## Changes between Coq 8.12 and Coq 8.13
 
 ### Code formatting

--- a/doc/changelog/03-notations/17117-master+fix-printing-custom-no-level.rst
+++ b/doc/changelog/03-notations/17117-master+fix-printing-custom-no-level.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Support for :flag:`Printing Parentheses` in custom notations
+  (`#17117 <https://github.com/coq/coq/pull/17117>`_, by Hugo
+  Herbelin).

--- a/interp/constrexpr.mli
+++ b/interp/constrexpr.mli
@@ -42,21 +42,13 @@ type entry_level = int
 type entry_relative_level = LevelLt of entry_level | LevelLe of entry_level | LevelSome
 
 (* The entry in which a notation is declared *)
-type notation_entry =
-  | InConstrEntry
-  | InCustomEntry of string
+type notation_entry = InConstrEntry | InCustomEntry of string
 
 (* A notation entry with the level where the notation lives *)
-(* Note: the level is hard-wired in the printer for constr *)
-type notation_entry_level =
-  | InConstrEntrySomeLevel
-  | InCustomEntryLevel of string * entry_level
+type notation_entry_level = notation_entry * entry_level
 
 (* Notation subentries, to be associated to the variables of the notation *)
-(* Note: the level is hard-wired in the printer for constr *)
-type notation_entry_relative_level =
-  | InConstrEntrySomeRelativeLevel
-  | InCustomEntryRelativeLevel of string * (entry_relative_level * side option)
+type notation_entry_relative_level = notation_entry * (entry_relative_level * side option)
 
 type notation_key = string
 

--- a/interp/constrexpr.mli
+++ b/interp/constrexpr.mli
@@ -37,11 +37,27 @@ type name_decl = lname * universe_decl_expr option
 
 type notation_with_optional_scope = LastLonelyNotation | NotationInScope of string
 
+type side = Left | Right
 type entry_level = int
 type entry_relative_level = LevelLt of entry_level | LevelLe of entry_level | LevelSome
 
-type notation_entry = InConstrEntry | InCustomEntry of string
-type notation_entry_level = InConstrEntrySomeLevel | InCustomEntryLevel of string * entry_level
+(* The entry in which a notation is declared *)
+type notation_entry =
+  | InConstrEntry
+  | InCustomEntry of string
+
+(* A notation entry with the level where the notation lives *)
+(* Note: the level is hard-wired in the printer for constr *)
+type notation_entry_level =
+  | InConstrEntrySomeLevel
+  | InCustomEntryLevel of string * entry_level
+
+(* Notation subentries, to be associated to the variables of the notation *)
+(* Note: the level is hard-wired in the printer for constr *)
+type notation_entry_relative_level =
+  | InConstrEntrySomeRelativeLevel
+  | InCustomEntryRelativeLevel of string * (entry_relative_level * side option)
+
 type notation_key = string
 
 (* A notation associated to a given parsing rule *)

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -15,7 +15,7 @@ open Nameops
 open Libnames
 open Namegen
 open Glob_term
-open Notation
+open Notationextern
 open Constrexpr
 
 (***********)

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1564,11 +1564,13 @@ let sublevel_ord lev lev' =
   | LevelLt n, LevelLe n' -> n < n'
   | LevelLe n, LevelLt n' -> n <= n'-1
 
-let notation_entry_relative_entry_level_lt s1 s2 = match (s1,s2) with
-| InConstrEntrySomeRelativeLevel, InConstrEntrySomeLevel -> true
-| InCustomEntryRelativeLevel (s1,(n1,_)), InCustomEntryLevel (s2,n2) ->
-  String.equal s1 s2 && not (entry_relative_level_le (Some n2) n1)
-| (InConstrEntrySomeRelativeLevel | InCustomEntryRelativeLevel _), _ -> false
+let is_coercion s1 s2 = match (s1,s2) with
+| InConstrEntrySomeLevel, InConstrEntrySomeRelativeLevel -> false (* only hard-wired coercions in constr *)
+|  InCustomEntryLevel (s1,n1), InCustomEntryRelativeLevel (s2,(n2,_)) when String.equal s1 s2 ->
+  (match n2 with
+  | LevelLt n2 | LevelLe n2 -> n1 < n2
+  | LevelSome -> true (* unless n2 is the entry top level but we shall know it only dynamically *))
+| (InConstrEntrySomeLevel | InCustomEntryLevel _), _ -> true
 
 let notation_entry_entry_relative_level_le s1 s2 = match (s1,s2) with
 | InConstrEntrySomeLevel, InConstrEntrySomeRelativeLevel -> true

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -274,7 +274,6 @@ let level_eq (s1, l1, t1) (s2, l2, t2) =
   notation_entry_eq s1 s2 && Int.equal l1 l2 && List.equal entry_relative_level_eq t1 t2
 
 let notation_level_map = Summary.ref ~stage:Summary.Stage.Synterp ~name:"notation_level_map" NotationMap.empty
-  (* in a separate summary, because Synterp *)
 
 let declare_notation_level ntn level =
   try

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -349,8 +349,6 @@ val locate_notation : (glob_constr -> Pp.t) -> notation_key ->
 
 val pr_visibility: (glob_constr -> Pp.t) -> scope_name option -> Pp.t
 
-val make_notation_entry_level : notation_entry -> entry_level -> notation_entry_level
-
 (** Coercions between entries *)
 
 val is_coercion : notation_entry_level -> notation_entry_relative_level -> bool
@@ -372,14 +370,6 @@ val declare_custom_entry_has_ident : string -> int -> unit
 
 val entry_has_global : notation_entry_relative_level -> bool
 val entry_has_ident : notation_entry_relative_level -> bool
-
-(** Dealing with precedences *)
-
-type level = notation_entry * entry_level * entry_relative_level list
-  (* first argument is InCustomEntry s for custom entries *)
-
-val level_eq : level -> level -> bool
-val entry_relative_level_eq : entry_relative_level -> entry_relative_level -> bool
 
 (** {6 Declare and test the level of a (possibly uninterpreted) notation } *)
 

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -22,14 +22,6 @@ val notation_cat : Libobject.category
 val pr_notation : notation -> Pp.t
 (** Printing *)
 
-val notation_entry_eq : notation_entry -> notation_entry -> bool
-(** Equality on [notation_entry]. *)
-
-val notation_with_optional_scope_eq : notation_with_optional_scope -> notation_with_optional_scope -> bool
-
-val notation_eq : notation -> notation -> bool
-(** Equality on [notation]. *)
-
 module NotationSet : Set.S with type elt = notation
 module NotationMap : CMap.ExtS with type key = notation and module Set := NotationSet
 module SpecificNotationSet : Set.S with type elt = specific_notation
@@ -252,7 +244,7 @@ val availability_of_prim_token :
 (** {6 Declare and interpret back and forth a notation } *)
 
 type entry_coercion_kind =
-  | IsEntryCoercion of notation_entry_level
+  | IsEntryCoercion of notation_entry_level * notation_entry_relative_level
   | IsEntryGlobal of string * int
   | IsEntryIdent of string * int
 
@@ -360,14 +352,14 @@ val pr_visibility: (glob_constr -> Pp.t) -> scope_name option -> Pp.t
 val make_notation_entry_level : notation_entry -> entry_level -> notation_entry_level
 
 type entry_coercion = (notation_with_optional_scope * notation) list
-val declare_entry_coercion : specific_notation -> entry_level option -> notation_entry_level -> unit
-val availability_of_entry_coercion : notation_entry_level -> notation_entry_level -> entry_coercion option
+val declare_entry_coercion : specific_notation -> notation_entry_level -> notation_entry_relative_level -> unit
+val availability_of_entry_coercion : notation_entry_relative_level -> notation_entry_level -> entry_coercion option
 
 val declare_custom_entry_has_global : string -> int -> unit
 val declare_custom_entry_has_ident : string -> int -> unit
 
-val entry_has_global : notation_entry_level -> bool
-val entry_has_ident : notation_entry_level -> bool
+val entry_has_global : notation_entry_relative_level -> bool
+val entry_has_ident : notation_entry_relative_level -> bool
 
 (** Dealing with precedences *)
 
@@ -376,6 +368,8 @@ type level = notation_entry * entry_level * entry_relative_level list
 
 val level_eq : level -> level -> bool
 val entry_relative_level_eq : entry_relative_level -> entry_relative_level -> bool
+
+val notation_entry_relative_entry_level_lt : notation_entry_relative_level -> notation_entry_level -> bool
 
 (** {6 Declare and test the level of a (possibly uninterpreted) notation } *)
 

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -351,9 +351,21 @@ val pr_visibility: (glob_constr -> Pp.t) -> scope_name option -> Pp.t
 
 val make_notation_entry_level : notation_entry -> entry_level -> notation_entry_level
 
-type entry_coercion = (notation_with_optional_scope * notation) list
+(** Coercions between entries *)
+
+val is_coercion : notation_entry_level -> notation_entry_relative_level -> bool
+  (** For a rule of the form
+      "Notation string := x (in some-entry, x at some-relative-entry)",
+      tell if going from some-entry to some-relative-entry is coercing *)
+
 val declare_entry_coercion : specific_notation -> notation_entry_level -> notation_entry_relative_level -> unit
+  (** Add a coercion from some-entry to some-relative-entry *)
+
+type entry_coercion = (notation_with_optional_scope * notation) list
 val availability_of_entry_coercion : notation_entry_relative_level -> notation_entry_level -> entry_coercion option
+  (** Return a coercion path from some-relative-entry to some-entry if there is one *)
+
+(** Special properties of entries *)
 
 val declare_custom_entry_has_global : string -> int -> unit
 val declare_custom_entry_has_ident : string -> int -> unit
@@ -368,8 +380,6 @@ type level = notation_entry * entry_level * entry_relative_level list
 
 val level_eq : level -> level -> bool
 val entry_relative_level_eq : entry_relative_level -> entry_relative_level -> bool
-
-val notation_entry_relative_entry_level_lt : notation_entry_relative_level -> notation_entry_level -> bool
 
 (** {6 Declare and test the level of a (possibly uninterpreted) notation } *)
 

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -1309,9 +1309,11 @@ let remove_sigma x (terms,termlists,binders,binderlists) =
 let remove_bindinglist_sigma x (terms,termlists,binders,binderlists) =
   (terms,termlists,binders,Id.List.remove_assoc x binderlists)
 
-let add_ldots_var metas = (ldots_var,((Constrexpr.InConstrEntrySomeRelativeLevel,([],[])),NtnTypeConstr))::metas
+let default_constr_entry_relative_level = Constrexpr.(InConstrEntry,(LevelSome,None))
 
-let add_meta_bindinglist x metas = (x,((Constrexpr.InConstrEntrySomeRelativeLevel,([],[])),NtnTypeBinderList (*arbitrary:*) NtnBinderParsedAsBinder))::metas
+let add_ldots_var metas = (ldots_var,((default_constr_entry_relative_level,([],[])),NtnTypeConstr))::metas
+
+let add_meta_bindinglist x metas = (x,((default_constr_entry_relative_level,([],[])),NtnTypeBinderList (*arbitrary:*) NtnBinderParsedAsBinder))::metas
 
 (* This tells if letins in the middle of binders should be included in
    the sequence of binders *)
@@ -1357,7 +1359,7 @@ let match_binderlist match_iter_fun match_termin_fun alp metas sigma rest x y it
   let alp,sigma = bind_bindinglist_env alp sigma x bl in
   match_termin_fun alp metas sigma rest termin
 
-let add_meta_term x metas = (x,((Constrexpr.InConstrEntrySomeRelativeLevel,([],[])),NtnTypeConstr))::metas (* Should reuse the scope of the partner of x! *)
+let add_meta_term x metas = (x,((default_constr_entry_relative_level,([],[])),NtnTypeConstr))::metas (* Should reuse the scope of the partner of x! *)
 
 let match_termlist match_fun alp metas sigma rest x y iter termin revert =
   let rec aux alp sigma acc rest =

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -1309,9 +1309,9 @@ let remove_sigma x (terms,termlists,binders,binderlists) =
 let remove_bindinglist_sigma x (terms,termlists,binders,binderlists) =
   (terms,termlists,binders,Id.List.remove_assoc x binderlists)
 
-let add_ldots_var metas = (ldots_var,((Constrexpr.InConstrEntrySomeLevel,([],[])),NtnTypeConstr))::metas
+let add_ldots_var metas = (ldots_var,((Constrexpr.InConstrEntrySomeRelativeLevel,([],[])),NtnTypeConstr))::metas
 
-let add_meta_bindinglist x metas = (x,((Constrexpr.InConstrEntrySomeLevel,([],[])),NtnTypeBinderList (*arbitrary:*) NtnBinderParsedAsBinder))::metas
+let add_meta_bindinglist x metas = (x,((Constrexpr.InConstrEntrySomeRelativeLevel,([],[])),NtnTypeBinderList (*arbitrary:*) NtnBinderParsedAsBinder))::metas
 
 (* This tells if letins in the middle of binders should be included in
    the sequence of binders *)
@@ -1357,7 +1357,7 @@ let match_binderlist match_iter_fun match_termin_fun alp metas sigma rest x y it
   let alp,sigma = bind_bindinglist_env alp sigma x bl in
   match_termin_fun alp metas sigma rest termin
 
-let add_meta_term x metas = (x,((Constrexpr.InConstrEntrySomeLevel,([],[])),NtnTypeConstr))::metas (* Should reuse the scope of the partner of x! *)
+let add_meta_term x metas = (x,((Constrexpr.InConstrEntrySomeRelativeLevel,([],[])),NtnTypeConstr))::metas (* Should reuse the scope of the partner of x! *)
 
 let match_termlist match_fun alp metas sigma rest x y iter termin revert =
   let rec aux alp sigma acc rest =

--- a/interp/notation_ops.mli
+++ b/interp/notation_ops.mli
@@ -89,6 +89,3 @@ val match_notation_constr_ind_pattern :
   inductive -> 'a cases_pattern_g list -> interpretation ->
   (('a cases_pattern_g * extended_subscopes) list * ('a cases_pattern_g list * extended_subscopes) list) *
     (bool * int * 'a cases_pattern_g list)
-
-(** {5 Matching a notation pattern against a [glob_constr]} *)
-

--- a/interp/notation_term.mli
+++ b/interp/notation_term.mli
@@ -62,7 +62,7 @@ type tmp_scope_name = scope_name
 
 type subscopes = tmp_scope_name list * scope_name list
 
-type extended_subscopes = Constrexpr.notation_entry_level * subscopes
+type extended_subscopes = Constrexpr.notation_entry_relative_level * subscopes
 
 (** Type of the meta-variables of an notation_constr: in a recursive pattern x..y,
     x carries the sequence of objects bound to the list x..y  *)

--- a/interp/notationextern.ml
+++ b/interp/notationextern.ml
@@ -21,24 +21,26 @@ open Glob_term
 (*i*)
 
 let notation_with_optional_scope_eq inscope1 inscope2 = match (inscope1,inscope2) with
- | LastLonelyNotation, LastLonelyNotation -> true
- | NotationInScope s1, NotationInScope s2 -> String.equal s1 s2
- | (LastLonelyNotation | NotationInScope _), _ -> false
+  | LastLonelyNotation, LastLonelyNotation -> true
+  | NotationInScope s1, NotationInScope s2 -> String.equal s1 s2
+  | (LastLonelyNotation | NotationInScope _), _ -> false
+
+let entry_relative_level_eq t1 t2 = match t1, t2 with
+  | LevelLt n1, LevelLt n2 -> Int.equal n1 n2
+  | LevelLe n1, LevelLe n2 -> Int.equal n1 n2
+  | LevelSome, LevelSome -> true
+  | (LevelLt _ | LevelLe _ | LevelSome), _ -> false
 
 let notation_entry_eq s1 s2 = match (s1,s2) with
-| InConstrEntry, InConstrEntry -> true
-| InCustomEntry s1, InCustomEntry s2 -> String.equal s1 s2
-| (InConstrEntry | InCustomEntry _), _ -> false
+  | InConstrEntry, InConstrEntry -> true
+  | InCustomEntry s1, InCustomEntry s2 -> String.equal s1 s2
+  | (InConstrEntry | InCustomEntry _), _ -> false
 
-let notation_entry_level_eq s1 s2 = match (s1,s2) with
-| InConstrEntrySomeLevel, InConstrEntrySomeLevel -> true
-| InCustomEntryLevel (s1,n1), InCustomEntryLevel (s2,n2) -> String.equal s1 s2 && n1 = n2
-| (InConstrEntrySomeLevel | InCustomEntryLevel _), _ -> false
+let notation_entry_level_eq (e1,n1) (e2,n2) =
+  notation_entry_eq e1 e2 && Int.equal n1 n2
 
-let notation_entry_relative_level_eq s1 s2 = match (s1,s2) with
-| InConstrEntrySomeRelativeLevel, InConstrEntrySomeRelativeLevel -> true
-| InCustomEntryRelativeLevel (s1,n1), InCustomEntryRelativeLevel (s2,n2) -> String.equal s1 s2 && n1 = n2
-| (InConstrEntrySomeRelativeLevel | InCustomEntryRelativeLevel _), _ -> false
+let notation_entry_relative_level_eq (e1,(n1,s1)) (e2,(n2,s2)) =
+  notation_entry_eq e1 e2 && entry_relative_level_eq n1 n2 && s1 = s2
 
 let notation_eq (from1,ntn1) (from2,ntn2) =
   notation_entry_eq from1 from2 && String.equal ntn1 ntn2
@@ -74,6 +76,12 @@ let interpretation_eq (vars1, t1 as x1) (vars2, t2 as x2) =
   x1 == x2 ||
   List.equal var_attributes_eq vars1 vars2 &&
   Notation_ops.eq_notation_constr (List.map fst vars1, List.map fst vars2) t1 t2
+
+type level = notation_entry * entry_level * entry_relative_level list
+  (* first argument is InCustomEntry s for custom entries *)
+
+let level_eq (s1, l1, t1) (s2, l2, t2) =
+  notation_entry_eq s1 s2 && Int.equal l1 l2 && List.equal entry_relative_level_eq t1 t2
 
 (* Uninterpretation tables *)
 

--- a/interp/notationextern.ml
+++ b/interp/notationextern.ml
@@ -20,10 +20,28 @@ open Notation_term
 open Glob_term
 (*i*)
 
+let notation_with_optional_scope_eq inscope1 inscope2 = match (inscope1,inscope2) with
+ | LastLonelyNotation, LastLonelyNotation -> true
+ | NotationInScope s1, NotationInScope s2 -> String.equal s1 s2
+ | (LastLonelyNotation | NotationInScope _), _ -> false
+
+let notation_entry_eq s1 s2 = match (s1,s2) with
+| InConstrEntry, InConstrEntry -> true
+| InCustomEntry s1, InCustomEntry s2 -> String.equal s1 s2
+| (InConstrEntry | InCustomEntry _), _ -> false
+
 let notation_entry_level_eq s1 s2 = match (s1,s2) with
 | InConstrEntrySomeLevel, InConstrEntrySomeLevel -> true
 | InCustomEntryLevel (s1,n1), InCustomEntryLevel (s2,n2) -> String.equal s1 s2 && n1 = n2
 | (InConstrEntrySomeLevel | InCustomEntryLevel _), _ -> false
+
+let notation_entry_relative_level_eq s1 s2 = match (s1,s2) with
+| InConstrEntrySomeRelativeLevel, InConstrEntrySomeRelativeLevel -> true
+| InCustomEntryRelativeLevel (s1,n1), InCustomEntryRelativeLevel (s2,n2) -> String.equal s1 s2 && n1 = n2
+| (InConstrEntrySomeRelativeLevel | InCustomEntryRelativeLevel _), _ -> false
+
+let notation_eq (from1,ntn1) (from2,ntn2) =
+  notation_entry_eq from1 from2 && String.equal ntn1 ntn2
 
 let pair_eq f g (x1, y1) (x2, y2) = f x1 x2 && g y1 y2
 
@@ -48,7 +66,7 @@ let ntpe_eq t1 t2 = match t1, t2 with
 | (NtnTypeConstr | NtnTypeBinder _ | NtnTypeConstrList | NtnTypeBinderList _), _ -> false
 
 let var_attributes_eq (_, ((entry1, sc1), tp1)) (_, ((entry2, sc2), tp2)) =
-  notation_entry_level_eq entry1 entry2 &&
+  notation_entry_relative_level_eq entry1 entry2 &&
   pair_eq (List.equal String.equal) (List.equal String.equal) sc1 sc2 &&
   ntpe_eq tp1 tp2
 

--- a/interp/notationextern.mli
+++ b/interp/notationextern.mli
@@ -16,6 +16,14 @@ open Constrexpr
 open Glob_term
 open Notation_term
 
+val notation_entry_eq : notation_entry -> notation_entry -> bool
+(** Equality on [notation_entry]. *)
+
+val notation_with_optional_scope_eq : notation_with_optional_scope -> notation_with_optional_scope -> bool
+
+val notation_eq : notation -> notation -> bool
+(** Equality on [notation]. *)
+
 val interpretation_eq : interpretation -> interpretation -> bool
 (** Equality on [interpretation]. *)
 

--- a/interp/notationextern.mli
+++ b/interp/notationextern.mli
@@ -30,6 +30,15 @@ val interpretation_eq : interpretation -> interpretation -> bool
 val notation_entry_level_eq : notation_entry_level -> notation_entry_level -> bool
 (** Equality on [notation_entry_level]. *)
 
+type level = notation_entry * entry_level * entry_relative_level list
+  (* first argument is InCustomEntry s for custom entries *)
+
+val level_eq : level -> level -> bool
+(** Equality on [level]. *)
+
+val entry_relative_level_eq : entry_relative_level -> entry_relative_level -> bool
+(** Equality on [entry_relative_level]. *)
+
 (** Binds a notation in a given scope to an interpretation *)
 type 'a interp_rule_gen =
   | NotationRule of Constrexpr.specific_notation

--- a/parsing/extend.ml
+++ b/parsing/extend.ml
@@ -70,9 +70,9 @@ and constr_prod_entry_key =
   | ETProdGlobal          (* Parsed as a global reference *)
   | ETProdBigint          (* Parsed as an (unbounded) integer *)
   | ETProdOneBinder of bool (* Parsed as name, or name:type or 'pattern, possibly in closed form *)
-  | ETProdConstr of Constrexpr.notation_entry * (production_level * production_position) (* Parsed as constr or pattern, or a subentry of those *)
+  | ETProdConstr of Constrexpr.notation_entry * (production_level * production_position) (* Parsed as constr or custom when extending a constr or custom entry; parsed as pattern or custom pattern when extending a pattern or custom pattern entry *)
   | ETProdPattern of int  (* Parsed as pattern as a binder (as subpart of a constr) *)
-  | ETProdConstrList of Constrexpr.notation_entry * (production_level * production_position) * (bool * string) list (* Parsed as non-empty list of constr, or subentries of those *)
+  | ETProdConstrList of Constrexpr.notation_entry * (production_level * production_position) * (bool * string) list (* Parsed as a non-empty list of constr or custom entry *)
   | ETProdBinderList of binder_entry_kind  (* Parsed as non-empty list of local binders *)
 
 (** {5 AST for user-provided entries} *)

--- a/parsing/extend.ml
+++ b/parsing/extend.ml
@@ -10,10 +10,8 @@
 
 (** Entry keys for constr notations *)
 
-type side = Left | Right
-
 type production_position =
-  | BorderProd of side * Gramlib.Gramext.g_assoc option
+  | BorderProd of Constrexpr.side * Gramlib.Gramext.g_assoc option
   | InternalProd
 
 type production_level =
@@ -46,7 +44,7 @@ let constr_entry_key_eq v1 v2 = match v1, v2 with
   | ETBigint, ETBigint -> true
   | ETBinder b1, ETBinder b2 -> b1 == b2
   | ETConstr (s1,bko1,_lev1), ETConstr (s2,bko2,_lev2) ->
-    Notation.notation_entry_eq s1 s2 && Option.equal (=) bko1 bko2
+    Notationextern.notation_entry_eq s1 s2 && Option.equal (=) bko1 bko2
   | ETPattern (b1,n1), ETPattern (b2,n2) -> b1 = b2 && Option.equal Int.equal n1 n2
   | (ETIdent | ETName | ETGlobal | ETBigint | ETBinder _ | ETConstr _ | ETPattern _), _ -> false
 

--- a/parsing/extend.mli
+++ b/parsing/extend.mli
@@ -10,10 +10,8 @@
 
 (** Entry keys for constr notations *)
 
-type side = Left | Right
-
 type production_position =
-  | BorderProd of side * Gramlib.Gramext.g_assoc option
+  | BorderProd of Constrexpr.side * Gramlib.Gramext.g_assoc option
   | InternalProd
 
 type production_level =

--- a/parsing/notation_gram.mli
+++ b/parsing/notation_gram.mli
@@ -21,7 +21,7 @@ type grammar_constr_prod_item =
 (** Grammar rules for a notation *)
 
 type one_notation_grammar = {
-  notgram_level : Notation.level;
+  notgram_level : Notationextern.level;
   notgram_assoc : Gramlib.Gramext.g_assoc option;
   notgram_notation : Constrexpr.notation;
   notgram_prods : grammar_constr_prod_item list list;

--- a/parsing/notgram_ops.ml
+++ b/parsing/notgram_ops.ml
@@ -28,17 +28,17 @@ let declare_notation_grammar ntn rule =
 let grammar_of_notation ntn =
   NotationMap.find ntn !notation_grammar_map
 
-let notation_subentries_map = Summary.ref ~stage:Summary.Stage.Synterp ~name:"notation_subentries_map" NotationMap.empty
+let notation_non_terminals_map = Summary.ref ~stage:Summary.Stage.Synterp ~name:"notation_non_terminals_map" NotationMap.empty
 
-let declare_notation_subentries ntn entries =
+let declare_notation_non_terminals ntn entries =
   try
     let _ = NotationMap.find ntn !notation_grammar_map in
     anomaly (str "Notation " ++ pr_notation ntn ++ str " is already assigned a grammar.")
   with Not_found ->
-  notation_subentries_map := NotationMap.add ntn entries !notation_subentries_map
+  notation_non_terminals_map := NotationMap.add ntn entries !notation_non_terminals_map
 
-let subentries_of_notation ntn =
-  NotationMap.find ntn !notation_subentries_map
+let non_terminals_of_notation ntn =
+  NotationMap.find ntn !notation_non_terminals_map
 
 let get_defined_notations () =
   NotationSet.elements @@ NotationMap.domain !notation_grammar_map

--- a/parsing/notgram_ops.mli
+++ b/parsing/notgram_ops.mli
@@ -18,8 +18,8 @@ val declare_notation_grammar : notation -> notation_grammar -> unit
 val grammar_of_notation : notation -> notation_grammar
   (** raise [Not_found] if not declared *)
 
-val declare_notation_subentries : notation -> Extend.constr_entry_key list -> unit
-val subentries_of_notation : notation -> Extend.constr_entry_key list
+val declare_notation_non_terminals : notation -> Extend.constr_entry_key list -> unit
+val non_terminals_of_notation : notation -> Extend.constr_entry_key list
 
 (** Returns notations with defined parsing/printing rules *)
 val get_defined_notations : unit -> notation list

--- a/printing/ppextend.ml
+++ b/printing/ppextend.ml
@@ -10,6 +10,7 @@
 
 open Util
 open Pp
+open Notationextern
 open Notation
 open Constrexpr
 

--- a/printing/ppextend.ml
+++ b/printing/ppextend.ml
@@ -38,9 +38,9 @@ let ppcmd_of_cut = function
 type pattern_quote_style = QuotedPattern | NotQuotedPattern
 
 type unparsing =
-  | UnpMetaVar of entry_relative_level * Extend.side option
+  | UnpMetaVar of entry_relative_level * side option
   | UnpBinderMetaVar of entry_relative_level * pattern_quote_style
-  | UnpListMetaVar of entry_relative_level * unparsing list * Extend.side option
+  | UnpListMetaVar of entry_relative_level * unparsing list * side option
   | UnpBinderListMetaVar of
       bool (* true if open binder *) *
       bool (* true if printed with a quote *) *

--- a/printing/ppextend.mli
+++ b/printing/ppextend.mli
@@ -32,9 +32,9 @@ type pattern_quote_style = QuotedPattern | NotQuotedPattern
 
 (** Declare and look for the printing rule for symbolic notations *)
 type unparsing =
-  | UnpMetaVar of entry_relative_level * Extend.side option
+  | UnpMetaVar of entry_relative_level * side option
   | UnpBinderMetaVar of entry_relative_level * pattern_quote_style
-  | UnpListMetaVar of entry_relative_level * unparsing list * Extend.side option
+  | UnpListMetaVar of entry_relative_level * unparsing list * side option
   | UnpBinderListMetaVar of
       bool (* true if open binder *) *
       bool (* true if printed with a quote *) *

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -18,6 +18,9 @@ Entry custom:myconstr is
      : nat
 fun a : nat => [a + a]
      : nat -> nat
+File "./output/Notations4.v", line 36, characters 0-88:
+Warning: This notation will not be used for printing as it is bound to a
+single variable. [notation-bound-to-variable,parsing,default]
 [1 {f 1}]
      : Expr
 fun (x : nat) (y z : Expr) => [1 + y z + {f x}]
@@ -59,16 +62,16 @@ where
       |- Type] (pat, p0, p cannot be used)
 fun '{| |} => true
      : R -> bool
-File "./output/Notations4.v", line 139, characters 82-85:
+File "./output/Notations4.v", line 147, characters 82-85:
 The command has indeed failed with message:
 The format is not the same on the right- and left-hand sides of the special token "..".
-File "./output/Notations4.v", line 143, characters 76-78:
+File "./output/Notations4.v", line 151, characters 76-78:
 The command has indeed failed with message:
 The format is not the same on the right- and left-hand sides of the special token "..".
-File "./output/Notations4.v", line 147, characters 78-81:
+File "./output/Notations4.v", line 155, characters 78-81:
 The command has indeed failed with message:
 The format is not the same on the right- and left-hand sides of the special token "..".
-File "./output/Notations4.v", line 151, characters 52-55:
+File "./output/Notations4.v", line 159, characters 52-55:
 The command has indeed failed with message:
 The format is not the same on the right- and left-hand sides of the special token "..".
 Entry custom:expr is
@@ -83,18 +86,18 @@ fun x : nat => [x]
      : nat -> nat
 ∀ x : nat, x = x
      : Prop
-File "./output/Notations4.v", line 185, characters 0-160:
+File "./output/Notations4.v", line 193, characters 0-160:
 Warning: Notation "∀ _ .. _ , _" was already defined with a different format
 in scope type_scope. [notation-incompatible-format,parsing,default]
 ∀x : nat,x = x
      : Prop
-File "./output/Notations4.v", line 198, characters 0-60:
+File "./output/Notations4.v", line 206, characters 0-60:
 Warning: Notation "_ %%% _" was already defined with a different format.
 [notation-incompatible-format,parsing,default]
-File "./output/Notations4.v", line 202, characters 0-64:
+File "./output/Notations4.v", line 210, characters 0-64:
 Warning: Notation "_ %%% _" was already defined with a different format.
 [notation-incompatible-format,parsing,default]
-File "./output/Notations4.v", line 207, characters 0-62:
+File "./output/Notations4.v", line 215, characters 0-62:
 Warning: Lonely notation "_ %%%% _" was already defined with a different
 format. [notation-incompatible-format,parsing,default]
 3  %%  4
@@ -103,10 +106,10 @@ format. [notation-incompatible-format,parsing,default]
      : nat
 3   %%   4
      : nat
-File "./output/Notations4.v", line 235, characters 47-59:
+File "./output/Notations4.v", line 243, characters 47-59:
 Warning: The format modifier is irrelevant for only-parsing rules.
 [irrelevant-format-only-parsing,parsing,default]
-File "./output/Notations4.v", line 239, characters 36-48:
+File "./output/Notations4.v", line 247, characters 36-48:
 Warning: The only parsing modifier has no effect in Reserved Notation.
 [irrelevant-reserved-notation-only-parsing,parsing,default]
 fun x : nat => U (S x)
@@ -117,7 +120,7 @@ fun x : nat => V x
      : forall x : nat, nat * (?T -> ?T)
 where
 ?T : [x : nat  x0 : ?T |- Type] (x0 cannot be used)
-File "./output/Notations4.v", line 256, characters 0-30:
+File "./output/Notations4.v", line 264, characters 0-30:
 Warning: Notation "_ :=: _" was already used.
 [notation-overridden,parsing,default]
 0 :=: 0
@@ -134,49 +137,49 @@ exists p : nat, ▢_p (p >= 1)
      : Prop
 ▢_n (n >= 1)
      : Prop
-File "./output/Notations4.v", line 326, characters 17-20:
+File "./output/Notations4.v", line 334, characters 17-20:
 The command has indeed failed with message:
 Found an inductive type while a variable name was expected.
-File "./output/Notations4.v", line 327, characters 17-18:
+File "./output/Notations4.v", line 335, characters 17-18:
 The command has indeed failed with message:
 Found a constructor while a variable name was expected.
-File "./output/Notations4.v", line 329, characters 17-18:
+File "./output/Notations4.v", line 337, characters 17-18:
 The command has indeed failed with message:
 Found a constant while a variable name was expected.
 exists x y : nat, ▢_(x, y) (x >= 1 /\ y >= 2)
      : Prop
 ▢_n (n >= 1)
      : Prop
-File "./output/Notations4.v", line 342, characters 17-20:
+File "./output/Notations4.v", line 350, characters 17-20:
 The command has indeed failed with message:
 Found an inductive type while a pattern was expected.
 ▢_tt (tt = tt)
      : Prop
-File "./output/Notations4.v", line 345, characters 17-18:
+File "./output/Notations4.v", line 353, characters 17-18:
 The command has indeed failed with message:
 Found a constant while a pattern was expected.
 exists x y : nat, ▢_(x, y) (x >= 1 /\ y >= 2)
      : Prop
 pseudo_force n (fun n : nat => n >= 1)
      : Prop
-File "./output/Notations4.v", line 358, characters 17-20:
+File "./output/Notations4.v", line 366, characters 17-20:
 The command has indeed failed with message:
 Found an inductive type while a pattern was expected.
 ▢_tt (tt = tt)
      : Prop
-File "./output/Notations4.v", line 361, characters 17-18:
+File "./output/Notations4.v", line 369, characters 17-18:
 The command has indeed failed with message:
 Found a constant while a pattern was expected.
 exists x y : nat, myforce (x, y) (x >= 1 /\ y >= 2)
      : Prop
 myforce n (n >= 1)
      : Prop
-File "./output/Notations4.v", line 373, characters 21-24:
+File "./output/Notations4.v", line 381, characters 21-24:
 The command has indeed failed with message:
 Found an inductive type while a pattern was expected.
 myforce tt (tt = tt)
      : Prop
-File "./output/Notations4.v", line 376, characters 21-22:
+File "./output/Notations4.v", line 384, characters 21-22:
 The command has indeed failed with message:
 Found a constant while a pattern was expected.
 id nat
@@ -185,7 +188,7 @@ fun a : bool => id a
      : bool -> bool
 fun nat : bool => id nat
      : bool -> bool
-File "./output/Notations4.v", line 388, characters 17-20:
+File "./output/Notations4.v", line 396, characters 17-20:
 The command has indeed failed with message:
 Found an inductive type while a pattern was expected.
 !! nat, nat = true
@@ -214,7 +217,7 @@ Found an inductive type while a pattern was expected.
      : Type
 ## (x, _) (x = 0)
      : Prop
-File "./output/Notations4.v", line 484, characters 21-30:
+File "./output/Notations4.v", line 492, characters 21-30:
 The command has indeed failed with message:
 Unexpected type constraint in notation already providing a type constraint.
 ## '(x, y) (x + y = 0)
@@ -247,12 +250,12 @@ where
 ?A : [ |- Type]
 0
      : nat
-File "./output/Notations4.v", line 534, characters 0-78:
+File "./output/Notations4.v", line 542, characters 0-78:
 The command has indeed failed with message:
 Notation "func _ .. _ , _" is already defined at level 200 with arguments
 binder, constr at next level while it is now required to be at level 200
 with arguments constr, constr at next level.
-File "./output/Notations4.v", line 539, characters 0-57:
+File "./output/Notations4.v", line 547, characters 0-57:
 The command has indeed failed with message:
 Notation "[[ _ ]]" is already defined at level 0 with arguments custom foo
 while it is now required to be at level 0 with arguments custom bar.

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -18,7 +18,7 @@ Entry custom:myconstr is
      : nat
 fun a : nat => [a + a]
      : nat -> nat
-File "./output/Notations4.v", line 36, characters 0-88:
+File "./output/Notations4.v", line 38, characters 0-88:
 Warning: This notation will not be used for printing as it is bound to a
 single variable. [notation-bound-to-variable,parsing,default]
 [1 {f 1}]
@@ -62,16 +62,16 @@ where
       |- Type] (pat, p0, p cannot be used)
 fun '{| |} => true
      : R -> bool
-File "./output/Notations4.v", line 147, characters 82-85:
+File "./output/Notations4.v", line 149, characters 82-85:
 The command has indeed failed with message:
 The format is not the same on the right- and left-hand sides of the special token "..".
-File "./output/Notations4.v", line 151, characters 76-78:
+File "./output/Notations4.v", line 153, characters 76-78:
 The command has indeed failed with message:
 The format is not the same on the right- and left-hand sides of the special token "..".
-File "./output/Notations4.v", line 155, characters 78-81:
+File "./output/Notations4.v", line 157, characters 78-81:
 The command has indeed failed with message:
 The format is not the same on the right- and left-hand sides of the special token "..".
-File "./output/Notations4.v", line 159, characters 52-55:
+File "./output/Notations4.v", line 161, characters 52-55:
 The command has indeed failed with message:
 The format is not the same on the right- and left-hand sides of the special token "..".
 Entry custom:expr is
@@ -86,18 +86,18 @@ fun x : nat => [x]
      : nat -> nat
 ∀ x : nat, x = x
      : Prop
-File "./output/Notations4.v", line 193, characters 0-160:
+File "./output/Notations4.v", line 195, characters 0-160:
 Warning: Notation "∀ _ .. _ , _" was already defined with a different format
 in scope type_scope. [notation-incompatible-format,parsing,default]
 ∀x : nat,x = x
      : Prop
-File "./output/Notations4.v", line 206, characters 0-60:
+File "./output/Notations4.v", line 208, characters 0-60:
 Warning: Notation "_ %%% _" was already defined with a different format.
 [notation-incompatible-format,parsing,default]
-File "./output/Notations4.v", line 210, characters 0-64:
+File "./output/Notations4.v", line 212, characters 0-64:
 Warning: Notation "_ %%% _" was already defined with a different format.
 [notation-incompatible-format,parsing,default]
-File "./output/Notations4.v", line 215, characters 0-62:
+File "./output/Notations4.v", line 217, characters 0-62:
 Warning: Lonely notation "_ %%%% _" was already defined with a different
 format. [notation-incompatible-format,parsing,default]
 3  %%  4
@@ -106,10 +106,10 @@ format. [notation-incompatible-format,parsing,default]
      : nat
 3   %%   4
      : nat
-File "./output/Notations4.v", line 243, characters 47-59:
+File "./output/Notations4.v", line 245, characters 47-59:
 Warning: The format modifier is irrelevant for only-parsing rules.
 [irrelevant-format-only-parsing,parsing,default]
-File "./output/Notations4.v", line 247, characters 36-48:
+File "./output/Notations4.v", line 249, characters 36-48:
 Warning: The only parsing modifier has no effect in Reserved Notation.
 [irrelevant-reserved-notation-only-parsing,parsing,default]
 fun x : nat => U (S x)
@@ -120,7 +120,7 @@ fun x : nat => V x
      : forall x : nat, nat * (?T -> ?T)
 where
 ?T : [x : nat  x0 : ?T |- Type] (x0 cannot be used)
-File "./output/Notations4.v", line 264, characters 0-30:
+File "./output/Notations4.v", line 266, characters 0-30:
 Warning: Notation "_ :=: _" was already used.
 [notation-overridden,parsing,default]
 0 :=: 0
@@ -137,49 +137,49 @@ exists p : nat, ▢_p (p >= 1)
      : Prop
 ▢_n (n >= 1)
      : Prop
-File "./output/Notations4.v", line 334, characters 17-20:
+File "./output/Notations4.v", line 336, characters 17-20:
 The command has indeed failed with message:
 Found an inductive type while a variable name was expected.
-File "./output/Notations4.v", line 335, characters 17-18:
+File "./output/Notations4.v", line 337, characters 17-18:
 The command has indeed failed with message:
 Found a constructor while a variable name was expected.
-File "./output/Notations4.v", line 337, characters 17-18:
+File "./output/Notations4.v", line 339, characters 17-18:
 The command has indeed failed with message:
 Found a constant while a variable name was expected.
 exists x y : nat, ▢_(x, y) (x >= 1 /\ y >= 2)
      : Prop
 ▢_n (n >= 1)
      : Prop
-File "./output/Notations4.v", line 350, characters 17-20:
+File "./output/Notations4.v", line 352, characters 17-20:
 The command has indeed failed with message:
 Found an inductive type while a pattern was expected.
 ▢_tt (tt = tt)
      : Prop
-File "./output/Notations4.v", line 353, characters 17-18:
+File "./output/Notations4.v", line 355, characters 17-18:
 The command has indeed failed with message:
 Found a constant while a pattern was expected.
 exists x y : nat, ▢_(x, y) (x >= 1 /\ y >= 2)
      : Prop
 pseudo_force n (fun n : nat => n >= 1)
      : Prop
-File "./output/Notations4.v", line 366, characters 17-20:
+File "./output/Notations4.v", line 368, characters 17-20:
 The command has indeed failed with message:
 Found an inductive type while a pattern was expected.
 ▢_tt (tt = tt)
      : Prop
-File "./output/Notations4.v", line 369, characters 17-18:
+File "./output/Notations4.v", line 371, characters 17-18:
 The command has indeed failed with message:
 Found a constant while a pattern was expected.
 exists x y : nat, myforce (x, y) (x >= 1 /\ y >= 2)
      : Prop
 myforce n (n >= 1)
      : Prop
-File "./output/Notations4.v", line 381, characters 21-24:
+File "./output/Notations4.v", line 383, characters 21-24:
 The command has indeed failed with message:
 Found an inductive type while a pattern was expected.
 myforce tt (tt = tt)
      : Prop
-File "./output/Notations4.v", line 384, characters 21-22:
+File "./output/Notations4.v", line 386, characters 21-22:
 The command has indeed failed with message:
 Found a constant while a pattern was expected.
 id nat
@@ -188,7 +188,7 @@ fun a : bool => id a
      : bool -> bool
 fun nat : bool => id nat
      : bool -> bool
-File "./output/Notations4.v", line 396, characters 17-20:
+File "./output/Notations4.v", line 398, characters 17-20:
 The command has indeed failed with message:
 Found an inductive type while a pattern was expected.
 !! nat, nat = true
@@ -217,7 +217,7 @@ Found an inductive type while a pattern was expected.
      : Type
 ## (x, _) (x = 0)
      : Prop
-File "./output/Notations4.v", line 492, characters 21-30:
+File "./output/Notations4.v", line 494, characters 21-30:
 The command has indeed failed with message:
 Unexpected type constraint in notation already providing a type constraint.
 ## '(x, y) (x + y = 0)
@@ -250,12 +250,12 @@ where
 ?A : [ |- Type]
 0
      : nat
-File "./output/Notations4.v", line 542, characters 0-78:
+File "./output/Notations4.v", line 544, characters 0-78:
 The command has indeed failed with message:
 Notation "func _ .. _ , _" is already defined at level 200 with arguments
 binder, constr at next level while it is now required to be at level 200
 with arguments constr, constr at next level.
-File "./output/Notations4.v", line 547, characters 0-57:
+File "./output/Notations4.v", line 549, characters 0-57:
 The command has indeed failed with message:
 Notation "[[ _ ]]" is already defined at level 0 with arguments custom foo
 while it is now required to be at level 0 with arguments custom bar.

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -29,6 +29,14 @@ Notation "x" := x (in custom myconstr at level 0, x global).
 Check [ b + c ].
 Check fun a => [ a + a ].
 
+Module NonCoercions.
+
+(* Check invalid coercions (thus not used for printing) *)
+Notation "[[ x ]]" := x (at level 0, x at level 42).
+Notation "[[[ x ]]]" := x (in custom myconstr at level 5, x custom myconstr at level 5).
+
+End NonCoercions.
+
 End A.
 
 Module B.

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -31,8 +31,10 @@ Check fun a => [ a + a ].
 
 Module NonCoercions.
 
-(* Check invalid coercions (thus not used for printing) *)
+(* Should we forbid extra coercions in constr (knowing the "( x )" is hard-wiree)? *)
 Notation "[[ x ]]" := x (at level 0, x at level 42).
+
+(* Check invalid coercions (thus not used for printing) *)
 Notation "[[[ x ]]]" := x (in custom myconstr at level 5, x custom myconstr at level 5).
 
 End NonCoercions.
@@ -487,7 +489,7 @@ End MorePrecise3.
 
 Module TypedPattern.
 
-Notation "## x P" := (forall x:nat*nat, P) (x pattern, at level 0).
+Notation "## x P" := (forall x:nat*nat, P) (x pattern, at level 1).
 Check ## (x,y) (x=0).
 Fail Check ## ((x,y):bool*bool) (x=y).
 
@@ -495,7 +497,7 @@ End TypedPattern.
 
 Module SingleBinder.
 
-Notation "## x P" := (forall x, x = x -> P) (x binder, at level 0).
+Notation "## x P" := (forall x, x = x -> P) (x binder, at level 1).
 Check ## '(x,y) (x+y=0).
 Check ## (x:nat) (x=0).
 Check ## '((x,y):nat*nat) (x=0).

--- a/test-suite/output/PrintingParentheses.out
+++ b/test-suite/output/PrintingParentheses.out
@@ -35,3 +35,7 @@ Arguments mult_n_Sm (n m)%nat_scope
      : list nat
 {0 = 1} + {2 <= (4 + 5)}
      : Set
+forall x y z : nat, [(x + y) + z] = [x + y + z]
+     : Prop
+forall x y z : nat, [(x + y) + z] = [x + (y + z)]
+     : Prop

--- a/test-suite/output/PrintingParentheses.v
+++ b/test-suite/output/PrintingParentheses.v
@@ -1,10 +1,39 @@
+Module Test1.
+
 Set Printing Parentheses.
 
 Check (1+2*3,4,5).
 Print mult_n_Sm.
 
+End Test1.
+
 Require Import List.
+
+Module Test2.
+
+Set Printing Parentheses.
+
 Import ListNotations.
 Check [1;2;3;4].
 
 Check {0=1}+{2<=4+5}.
+
+End Test2.
+
+(* A test with custom entries *)
+
+Module CustomEntry.
+
+Declare Custom Entry myconstr.
+
+Notation "[ x ]" := x (x custom myconstr at level 6).
+Notation "x + y" := (Nat.add x y) (in custom myconstr at level 5, right associativity).
+Notation "( x )" := x (in custom myconstr at level 0).
+Notation "x" := x (in custom myconstr at level 0, x ident).
+
+Unset Printing Parentheses.
+Check forall x y z : nat, [ (x + y) + z ] = [ x + (y + z) ].
+Set Printing Parentheses.
+Check forall x y z : nat, [ (x + y) + z ] = [ x + (y + z) ].
+
+End CustomEntry.

--- a/vernac/egramcoq.ml
+++ b/vernac/egramcoq.ml
@@ -14,6 +14,7 @@ open Names
 open Libnames
 open Constrexpr
 open Extend
+open Notationextern
 open Notation_gram
 open Pcoq
 
@@ -214,12 +215,12 @@ let assoc_eq al ar =
      NumLevel n = constr LEVEL n *)
 let adjust_level custom assoc (custom',from) p = let open Gramlib.Gramext in match p with
 (* If a level in a different grammar, no other choice than denoting it by absolute level *)
-  | (NumLevel n,_) when not (Notation.notation_entry_eq custom custom') -> NumLevel n
+  | (NumLevel n,_) when not (notation_entry_eq custom custom') -> NumLevel n
 (* If a default level in a different grammar, the entry name is ok *)
   | (DefaultLevel,InternalProd) ->
-    if Notation.notation_entry_eq custom InConstrEntry then NumLevel 200 else DefaultLevel
-  | (DefaultLevel,BorderProd _) when not (Notation.notation_entry_eq custom custom') ->
-    if Notation.notation_entry_eq custom InConstrEntry then NumLevel 200 else DefaultLevel
+    if notation_entry_eq custom InConstrEntry then NumLevel 200 else DefaultLevel
+  | (DefaultLevel,BorderProd _) when not (notation_entry_eq custom custom') ->
+    if notation_entry_eq custom InConstrEntry then NumLevel 200 else DefaultLevel
 (* Associativity is None means force the level *)
   | (NumLevel n,BorderProd (_,None)) -> NumLevel n
   | (DefaultLevel,BorderProd (_,None)) -> assert false
@@ -239,7 +240,7 @@ let adjust_level custom assoc (custom',from) p = let open Gramlib.Gramext in mat
   | (NumLevel n,BorderProd (Left,Some LeftA)) -> NumLevel n
   | ((NumLevel _ | DefaultLevel),BorderProd (Left,Some _)) -> NextLevel
   (* None means NEXT *)
-  | (NextLevel,_) -> assert (Notation.notation_entry_eq custom custom'); NextLevel
+  | (NextLevel,_) -> assert (notation_entry_eq custom custom'); NextLevel
 (* Compute production name elsewhere *)
   | (NumLevel n,InternalProd) ->
     if from = n + 1 then NextLevel else NumLevel n
@@ -322,7 +323,7 @@ let target_entry : type s. notation_entry -> s target -> s Entry.t = function
    | ForConstr -> entry_for_constr
    | ForPattern -> entry_for_patttern
 
-let is_self custom (custom',from) e = Notation.notation_entry_eq custom custom' && match e with
+let is_self custom (custom',from) e = notation_entry_eq custom custom' && match e with
 | (NumLevel n, BorderProd (Right, _ (* Some(NonA|LeftA) *))) -> false
 | (NumLevel n, BorderProd (Left, _)) -> Int.equal from n
 | _ -> false
@@ -557,7 +558,7 @@ let prepare_empty_levels forpat (where,(pos,p4assoc,name,reinit)) =
 let different_levels (custom,opt_level) (custom',string_level) =
   match opt_level with
   | None -> true
-  | Some level -> not (Notation.notation_entry_eq custom custom') || level <> int_of_string string_level
+  | Some level -> not (notation_entry_eq custom custom') || level <> int_of_string string_level
 
 let rec pure_sublevels' assoc from forpat level = function
 | [] -> []

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -319,7 +319,7 @@ let precedence_of_position_and_level from_level = function
   | NextLevel, _ -> LevelLt from_level, None
   | DefaultLevel, _ -> LevelSome, None
 
-(** Computing precedences of subentries for parsing *)
+(** Computing precedences of non-terminals for parsing *)
 let precedence_of_entry_type (from_custom,from_level) = function
   | ETConstr (custom,_,x) when notation_entry_eq custom from_custom ->
     fst (precedence_of_position_and_level from_level x)
@@ -870,7 +870,7 @@ let check_and_extend_constr_grammar ntn rule =
         Some (Notgram_ops.grammar_of_notation ntn_for_grammar)
       with Not_found -> None
     in
-    let oldtyps = Notgram_ops.subentries_of_notation ntn_for_grammar in
+    let oldtyps = Notgram_ops.non_terminals_of_notation ntn_for_grammar in
     if not (Notation.level_eq prec oldprec) && oldparsing <> None then
       error_parsing_incompatible_level ntn ntn_for_grammar oldprec oldtyps prec typs;
     if oldparsing = None then raise Not_found
@@ -888,7 +888,7 @@ let cache_one_syntax_extension (ntn,synext) =
           Some (Notgram_ops.grammar_of_notation ntn)
         with Not_found -> None
       in
-      let oldtyps = Notgram_ops.subentries_of_notation ntn in
+      let oldtyps = Notgram_ops.non_terminals_of_notation ntn in
       if not (Notation.level_eq prec oldprec && List.for_all2 Extend.constr_entry_key_eq synext.synext_nottyps oldtyps) &&
          (oldparsing <> None || synext.synext_notgram = None) then
         error_incompatible_level ntn oldprec oldtyps prec synext.synext_nottyps;
@@ -896,7 +896,7 @@ let cache_one_syntax_extension (ntn,synext) =
     with Not_found ->
       (* Declare the level and the precomputed parsing rule *)
       let () = Notation.declare_notation_level ntn prec in
-      let () = Notgram_ops.declare_notation_subentries ntn synext.synext_nottyps in
+      let () = Notgram_ops.declare_notation_non_terminals ntn synext.synext_nottyps in
       let () = Option.iter (Notgram_ops.declare_notation_grammar ntn) synext.synext_notgram in
       None in
   (* Declare the parsing rule *)
@@ -1573,7 +1573,7 @@ exception NoSyntaxRule
 let recover_notation_syntax ntn =
   try
     let prec = Notation.level_of_notation ntn in
-    let pa_typs = Notgram_ops.subentries_of_notation ntn in
+    let pa_typs = Notgram_ops.non_terminals_of_notation ntn in
     let pa_rule = try Some (Notgram_ops.grammar_of_notation ntn) with Not_found -> None in
     let pp_rule = try Some (find_generic_notation_printing_rule ntn) with Not_found -> None in
     {

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1247,8 +1247,10 @@ let is_coercion level typs =
      | ETConstr _, _ ->
          let entry = make_notation_entry_level custom n in
          let entry_relative = entry_relative_level_of_constr_prod_entry (custom,n) e in
-         if notation_entry_relative_entry_level_lt entry_relative entry then None
-         else Some (IsEntryCoercion (entry,entry_relative))
+         if is_coercion entry entry_relative then
+           Some (IsEntryCoercion (entry,entry_relative))
+         else
+           None
      | ETGlobal, InCustomEntry s -> Some (IsEntryGlobal (s,n))
      | ETIdent, InCustomEntry s -> Some (IsEntryIdent (s,n))
      | _ -> None)

--- a/vernac/metasyntax.mli
+++ b/vernac/metasyntax.mli
@@ -82,5 +82,5 @@ val declare_custom_entry : locality_flag -> string -> unit
 val check_custom_entry : string -> unit
 (** Check that the given string is a valid custom entry that has been declared *)
 
-val pr_level : Constrexpr.notation -> Notation.level -> Extend.constr_entry_key list -> Pp.t
+val pr_level : Constrexpr.notation -> Notationextern.level -> Extend.constr_entry_key list -> Pp.t
 (** Pretty print level information of a notation and all of its arguments *)

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -943,7 +943,7 @@ let print_notation env sigma entry raw_ntn =
   let ntn = (entry, interp_ntn) in
   try
     let lvl = Notation.level_of_notation ntn in
-    let args = Notgram_ops.subentries_of_notation ntn in
+    let args = Notgram_ops.non_terminals_of_notation ntn in
     let pplvl = Metasyntax.pr_level ntn lvl args in
     Pp.(str "Notation \"" ++ str interp_ntn ++ str "\"" ++ spc ()
       ++ pplvl ++ pr_comma () ++ print_notation_grammar env sigma ntn


### PR DESCRIPTION
**Kind:** cleanup + small enhancements (reopening of #13025)

Note: This PR was originally to fix #13018 and #12775 but those were finally fixed by #13073. This PR is thus now about small enhancements and a more principled code. The header has been updated.

- We introduce a type `notation_subentry_level` to preserve more informations about the subentries: we remember whether we are at any level, at the next level or at the self level. 
- We take into account option `Printing Parentheses` in custom entries
- We provide a more principled fix to #13018 and #12775 which subsumes the quicker fix done in #13073 (the loss of the `any level` information was the cause of the bug; #13073 hackily fixed it by using `max_int` as the default possible highest level in a custom entry)
- We warn about coercions not used for printing

- [X] Added / updated test-suite
- [X] Documented API change
- [X] Change log (though it is rather anecdotical, observationally)


Synchronous overlay 
- LPCIC/coq-elpi#184
- https://github.com/ejgallego/coq-serapi/pull/313