### PR TITLE
Support for string constant tokens in notations

### DIFF
--- a/clib/cString.ml
+++ b/clib/cString.ml
@@ -18,6 +18,8 @@ sig
   val explode : string -> string list
   val implode : string list -> string
   val drop_simple_quotes : string -> string
+  val quote_coq_string : string -> string
+  val unquote_coq_string : string -> string option
   val string_index_from : string -> int -> string -> int
   val string_contains : where:string -> what:string -> bool
   val plural : int -> string -> string
@@ -61,6 +63,32 @@ let is_empty s = String.length s = 0
 let drop_simple_quotes s =
   let n = String.length s in
   if n > 2 && s.[0] = '\'' && s.[n-1] = '\'' then String.sub s 1 (n-2) else s
+
+let quote_coq_string s =
+  let b = Buffer.create (String.length s + 2) in
+  Buffer.add_char b '"';
+  for i = 0 to String.length s - 1 do
+    Buffer.add_char b s.[i];
+    if s.[i] = '"' then Buffer.add_char b s.[i];
+  done;
+  Buffer.add_char b '"';
+  Buffer.contents b
+
+let unquote_coq_string s =
+  let b = Buffer.create (String.length s) in
+  let n = String.length s in
+  if n < 2 || s.[0] <> '"' || s.[n-1] <> '"' then None else
+    let i = ref 1 in
+    try
+      while !i < n - 1 do
+        Buffer.add_char b s.[!i];
+        if s.[!i] = '"' then
+          if !i < n - 2 && s.[!i+1] = '"' then incr i
+          else raise Exit;
+        incr i
+      done;
+      Some (Buffer.contents b)
+    with Exit -> None
 
 (* substring searching... *)
 

--- a/clib/cString.mli
+++ b/clib/cString.mli
@@ -33,6 +33,15 @@ sig
   val drop_simple_quotes : string -> string
   (** Remove the eventual first surrounding simple quotes of a string. *)
 
+  val quote_coq_string : string -> string
+  (** Quote a string according to Coq conventions (i.e. doubling
+      double quotes and surrounding by double quotes) *)
+
+  val unquote_coq_string : string -> string option
+  (** Unquote a quoted string according to Coq conventions
+      (i.e. removing surrounding double quotes and undoubling double
+      quotes); returns [None] if not a quoted string *)
+
   val string_index_from : string -> int -> string -> int
   (** As [index_from], but takes a string instead of a char as pattern argument *)
 

--- a/doc/changelog/03-notations/17123-master+support-for-string-constant-tokens-in-notations.rst
+++ b/doc/changelog/03-notations/17123-master+support-for-string-constant-tokens-in-notations.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  Quoted strings can be used as tokens in notations; double quotes can be
+  used in symbols in :g:`only printing` notations; see :ref:`Basic notations <BasicNotations>`
+  for details (`#17123 <https://github.com/coq/coq/pull/17123>`_, by Hugo
+  Herbelin).

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -26,6 +26,7 @@ The main command to provide custom notations for tactics is :cmd:`Tactic Notatio
 Notations
 ---------
 
+.. _BasicNotations:
 
 Basic notations
 ~~~~~~~~~~~~~~~
@@ -74,8 +75,21 @@ lose their role as parameters. For example:
 
    Notation "'IF' c1 'then' c2 'else' c3" := (c1 /\ c2 \/ ~ c1 /\ c3) (at level 200, right associativity).
 
-Symbols that start with a single quote with 3 or more characters must be single quoted.
-For example, the symbol `'ab` is represented by `''ab'` in the notation string.
+Symbols that start with a single quote followed by at least 2
+characters must be single quoted.  For example, the symbol `'ab` is
+represented by `''ab'` in the notation string. Quoted strings can be used in
+notations: they must begin and end with two double quotes.
+Embedded spaces in these strings are
+part of the string and do not contribute to the separation
+between notation tokens. To embed double quotes in these strings, use four
+double quotes (e.g. the notation :g:`"A ""I'm an """"infix"""" string symbol"" B"`
+defines an infix notation whose infix symbol is the string
+:g:`"I'm an ""infix"" string symbol"`). Symbols may contain
+double quotes without being strings themselves (as e.g. in symbol :g:`|"|`) but notations with such symbols can be
+used only for printing (see :ref:`Use of notations for printing <UseOfNotationsForPrinting>`).
+In this case, no spaces are allowed in the symbol.  Also, if the
+symbol starts with a double quote, it must be surrounded with single
+quotes to prevent confusion with the beginning of a string symbol.
 
 A notation binds a syntactic expression to a term. Unless the parser
 and pretty-printer of Coq already know how to deal with the syntactic
@@ -90,6 +104,20 @@ associativity rules have to be given.
    <ImplicitArguments>` and other notations are resolved at the
    time of the declaration of the notation. The right-hand side is
    currently typed only at use time but this may change in the future.
+
+.. exn:: Unterminated string in notation
+
+   Occurs when the notation string contains an unterminated quoted
+   string, as e.g. in :g:`Reserved Notation "A ""an unended string B"`, for which the
+   user may instead mean :g:`Reserved Notation "A ""an ended string"" B`.
+
+.. exn:: End of quoted string not followed by a space in notation.
+
+   Occurs when the notation string contains a quoted string which
+   contains a double quote not ending the quoted string, as e.g. in
+   :g:`Reserved Notation "A ""string""! B"` or `Reserved Notation "A ""string""!"" B"`, for which
+   the user may instead mean :g:`Reserved Notation "A ""string"""" ! B`,
+   :g:`Reserved Notation "A ""string""""!"" B`, or :g:`Reserved Notation "A '""string""!' B`.
 
 Precedences and associativity
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -216,6 +244,8 @@ For the sake of factorization with Coq predefined rules, simple rules
 have to be observed for notations starting with a symbol, e.g., rules
 starting with “\ ``{``\ ” or “\ ``(``\ ” should be put at level 0. The list
 of Coq predefined notations can be found in the chapter on :ref:`thecoqlibrary`.
+
+.. _UseOfNotationsForPrinting:
 
 Use of notations for printing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -288,8 +288,6 @@ qualid_annotated: [
 
 atomic_constr: [
 | qualid_annotated
-| MOVETO number_or_string string
-| DELETE number_or_string
 | MOVETO term_evar "_"
 | REPLACE "?" "[" identref "]"
 | WITH "?[" identref "]"
@@ -386,6 +384,7 @@ term0: [
 | REPLACE "{|" record_declaration bar_cbrace
 | WITH "{|" LIST0 field_def SEP ";" OPT ";" bar_cbrace
 | MOVETO number_or_string NUMBER
+| MOVETO number_or_string string
 | MOVETO term_record "{|" LIST0 field_def SEP ";" OPT ";" bar_cbrace
 | MOVETO term_generalizing "`{" term200 "}"
 | MOVETO term_generalizing "`(" term200 ")"

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -116,6 +116,7 @@ term0: [
 | ident Prim.fields univ_annot
 | ident univ_annot
 | NUMBER
+| string
 | "(" term200 ")"
 | "{|" record_declaration bar_cbrace
 | "{" binder_constr "}"
@@ -166,7 +167,6 @@ arg: [
 
 atomic_constr: [
 | sort
-| string
 | "_"
 | "?" "[" identref "]"
 | "?" "[" pattern_ident "]"

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -265,13 +265,16 @@ let make_notation_gen loc ntn mknot mkprim destprim l bl =
         mknot (loc,ntn,([mknot (loc,(InConstrEntry,"( _ )"),l,[])]),[])
     | _ ->
         match decompose_notation_key ntn, l with
+        | (InConstrEntry,[Terminal x]), [] ->
+           begin match String.unquote_coq_string x with
+           | Some s -> mkprim (loc, String s)
+           | None ->
+           match NumTok.Unsigned.parse_string x with
+           | Some n -> mkprim (loc, Number (NumTok.SPlus,n))
+           | None -> mknot (loc,ntn,l,bl) end
         | (InConstrEntry,[Terminal "-"; Terminal x]), [] ->
            begin match NumTok.Unsigned.parse_string x with
            | Some n -> mkprim (loc, Number (NumTok.SMinus,n))
-           | None -> mknot (loc,ntn,l,bl) end
-        | (InConstrEntry,[Terminal x]), [] ->
-           begin match NumTok.Unsigned.parse_string x with
-           | Some n -> mkprim (loc, Number (NumTok.SPlus,n))
            | None -> mknot (loc,ntn,l,bl) end
         | _ -> mknot (loc,ntn,l,bl)
 

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -2065,7 +2065,7 @@ let pr_named_scope prglob (scope,sc) =
  (if String.equal scope default_scope then
    match NotationMap.cardinal sc.notations with
      | 0 -> str "No lonely notation"
-     | n -> str "Lonely notation" ++ (if Int.equal n 1 then mt() else str"s")
+     | n -> str (String.plural n "Lonely notation")
   else
     str "Scope " ++ str scope ++ fnl () ++ pr_delimiters_info sc.delimiters)
   ++ pr_non_empty (fnl ()) (pr_scope_classes scope)
@@ -2365,7 +2365,7 @@ let pr_visible_in_scope prglob (scope,ntns) =
       (fun d strm -> pr_notation_data prglob d ++ fnl () ++ strm)
       ntns (mt ()) in
   (if String.equal scope default_scope then
-     str "Lonely notation" ++ (match ntns with [_] -> mt () | _ -> str "s")
+     str (String.plural (List.length ntns) "Lonely notation")
    else
      str "Visible in scope " ++ str scope)
   ++ fnl () ++ strm

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -2028,7 +2028,7 @@ let pr_scope_classes sc =
       spc() ++ prlist_with_sep spc pr_scope_class l)
 
 let pr_notation_info prglob ntn c =
-  str "\"" ++ str ntn ++ str "\" :=" ++ brk (1,2) ++
+  str (String.quote_coq_string ntn) ++ str " :=" ++ brk (1,2) ++
   prglob (Notation_ops.glob_constr_of_notation_constr c)
 
 let pr_notation_status on_parsing on_printing =

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -335,6 +335,9 @@ type notation_symbols = {
   symbols : symbol list; (* the decomposition of the notation into terminals and nonterminals *)
 }
 
+val is_prim_token_constant_in_constr :
+  notation_entry * symbol list -> bool
+
 (** Decompose a notation of the form "a 'U' b" together with the lists
     of pairs of recursive variables and the list of all variables
     binding in the notation *)

--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -139,17 +139,7 @@ let hov n s = Ppcmd_box(Pp_hovbox n,s)
 (* Opening and closing of tags *)
 let tag t s = Ppcmd_tag(t,s)
 
-(* In new syntax only double quote char is escaped by repeating it *)
-let escape_string s =
-  let rec escape_at s i =
-    if i<0 then s
-    else if s.[i] == '"' then
-      let s' = String.sub s 0 i^"\""^String.sub s i (String.length s - i) in
-      escape_at s' (i-1)
-    else escape_at s (i-1) in
-  escape_at s (String.length s - 1)
-
-let qstring s = str "\"" ++ str (escape_string s) ++ str "\""
+let qstring s = str (CString.quote_coq_string s)
 let qs = qstring
 let quote s = h (str "\"" ++ s ++ str "\"")
 

--- a/parsing/cLexer.ml
+++ b/parsing/cLexer.ml
@@ -212,7 +212,7 @@ let unlocated f x =
 
 let check_keyword str =
   let rec loop_symb s = match Stream.peek () s with
-    | Some (' ' | '\n' | '\r' | '\t' | '"') ->
+    | Some (' ' | '\n' | '\r' | '\t') ->
         Stream.junk () s;
         bad_token str
     | _ ->
@@ -705,7 +705,10 @@ let rec next_token ~diff_mode ttree loc s =
       in
       let ep = Stream.count s in
       comment_stop bp;
-      (STRING (get_buff len), set_loc_pos loc bp ep)
+      let str = get_buff len in
+      begin try find_keyword ttree loc (CString.quote_coq_string str) bp s
+      with Not_found ->
+      (STRING str, set_loc_pos loc bp ep) end
   | Some ('(' as c) ->
       Stream.junk () s;
       begin try

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -182,6 +182,7 @@ GRAMMAR EXTEND Gram
       | id = ident; i = univ_annot ->
         { CAst.make ~loc @@ CRef (qualid_of_ident ~loc id, i) }
       | n = NUMBER-> { CAst.make ~loc @@ CPrim (Number (NumTok.SPlus,n)) }
+      | s = string -> { CAst.make ~loc @@ CPrim (String s) }
       | "("; c = term LEVEL "200"; ")" ->
         { (* Preserve parentheses around numbers so that constrintern does not
              collapse -(3) into the number -3. *)
@@ -268,7 +269,6 @@ GRAMMAR EXTEND Gram
   ;
   atomic_constr:
     [ [ s = sort   -> { CAst.make ~loc @@ CSort s }
-      | s = string -> { CAst.make ~loc @@ CPrim (String s) }
       | "_"      -> { CAst.make ~loc @@ CHole (None, IntroAnonymous) }
       | "?"; "["; id = identref; "]"  -> { CAst.make ~loc @@  CHole (None, IntroIdentifier id.CAst.v) }
       | "?"; "["; id = pattern_ident; "]"  -> { CAst.make ~loc @@  CHole (None, IntroFresh id.CAst.v) }

--- a/parsing/tok.ml
+++ b/parsing/tok.ml
@@ -144,7 +144,10 @@ let match_pattern (type c) (p : c p) : t -> c =
   let err () = raise Gramlib.Stream.Failure in
   let seq = string_equal in
   match p with
-  | PKEYWORD s -> (function KEYWORD s' when seq s s' -> s' | NUMBER n when seq s (NumTok.Unsigned.sprint n) -> s | _ -> err ())
+  | PKEYWORD s -> (function KEYWORD s' when seq s s' -> s'
+                          | NUMBER n when seq s (NumTok.Unsigned.sprint n) -> s
+                          | STRING s' when seq s (CString.quote_coq_string s') -> s
+                          | _ -> err ())
   | PIDENT None -> (function IDENT s' -> s' | _ -> err ())
   | PIDENT (Some s) -> (function (IDENT s' | KEYWORD s') when seq s s' -> s' | _ -> err ())
   | PPATTERNIDENT None -> (function PATTERNIDENT s -> s | _ -> err ())

--- a/test-suite/output/NotationSyntax.out
+++ b/test-suite/output/NotationSyntax.out
@@ -11,10 +11,38 @@ File "./output/NotationSyntax.v", line 5, characters 33-43:
 Warning: The format modifier is irrelevant for only-parsing rules.
 [irrelevant-format-only-parsing,parsing,default]
 File "./output/NotationSyntax.v", line 8, characters 20-30:
-Warning: Notations for numbers are primitive; skipping this modifier.
+Warning:
+Notations for numbers or strings are primitive; skipping this modifier.
 [primitive-token-modifier,parsing,default]
 1%nat
      : nat
 File "./output/NotationSyntax.v", line 10, characters 23-26:
 The command has indeed failed with message:
-Notations for numbers are primitive and need not be reserved.
+Notations for numbers or strings are primitive and need not be reserved.
+File "./output/NotationSyntax.v", line 12, characters 25-35:
+Warning:
+Notations for numbers or strings are primitive; skipping this modifier.
+[primitive-token-modifier,parsing,default]
+"tt"
+     : unit
+"tt"%string
+     : string
+File "./output/NotationSyntax.v", line 16, characters 23-31:
+The command has indeed failed with message:
+Notations for numbers or strings are primitive and need not be reserved.
+"t""t"
+     : unit
+# "|" true
+     : option bool
+"|"%string
+     : string
+2 "|" 4
+     : nat * nat
+"I'm true"
+     : bool
+""
+     : bool
+symbolwith"doublequote
+     : bool
+"
+     : bool

--- a/test-suite/output/NotationSyntax.v
+++ b/test-suite/output/NotationSyntax.v
@@ -8,3 +8,46 @@ Notation "#" := 0 (only parsing, format "#").
 Notation "1" := tt (at level 3).
 Check 1%nat.
 Fail Reserved Notation "1".
+
+Notation """tt""" := tt (at level 2).
+Check "tt".
+Require Import String.
+Check "tt"%string.
+Fail Reserved Notation """tt""".
+
+(* Test string literals themselves with double quotes *)
+Notation """t""""t""" := tt.
+Check "t""t".
+
+Module A.
+
+(* Not forced to be a keyword *)
+Notation "# ""|"" a" := (Some a) (at level 0, a at level 0).
+Check # "|" true.
+Check "|"%string.
+
+(* Now forced to be a keyword *)
+Notation "a ""|"" b" := (a, b) (at level 50).
+Check 2 "|" 4.
+
+End A.
+
+Module B.
+
+Notation " ""I'm true"" " := true.
+Check "I'm true".
+
+Notation """""" := false. (* Empty string *)
+Check "".
+
+End B.
+
+Module C.
+
+Notation "symbolwith""doublequote" := true (only printing).
+Check true.
+
+Notation "'""'" := false (only printing). (* double quote *)
+Check false.
+
+End C.

--- a/test-suite/output/PrintGrammar.out
+++ b/test-suite/output/PrintGrammar.out
@@ -139,6 +139,7 @@ Entry term is
   | term_match
   | ident; fields; univ_annot
   | ident; univ_annot
+  | string
   | test_array_opening; "["; "|"; array_elems; "|"; lconstr; type_cstr;
     test_array_closing; "|"; "]"; univ_annot ] ]
 

--- a/test-suite/output/PrintGrammarConstr.out
+++ b/test-suite/output/PrintGrammarConstr.out
@@ -66,6 +66,7 @@ Entry term is
   | term_match
   | ident; fields; univ_annot
   | ident; univ_annot
+  | string
   | test_array_opening; "["; "|"; array_elems; "|"; lconstr; type_cstr;
     test_array_closing; "|"; "]"; univ_annot ] ]
 

--- a/vernac/egramcoq.ml
+++ b/vernac/egramcoq.ml
@@ -337,6 +337,9 @@ let make_pattern (keyword,s) =
    if keyword then TPattern (Tok.PKEYWORD s) else
      match NumTok.Unsigned.parse_string s with
      | Some n -> TPattern (Tok.PNUMBER (Some n))
+     | None ->
+     match String.unquote_coq_string s with
+     | Some s -> TPattern (Tok.PSTRING (Some s))
      | None -> TPattern (Tok.PIDENT (Some s))
 
 let make_sep_rules tkl =


### PR DESCRIPTION
By uniformity with numerals, we allow string constant terminals in notations, as in:

```coq
Notation " ""I'm true"" " := true.
Check "I'm true".
```

It is unclear whether this would be really used in practice but the uniformity of treatment between numerals and strings is nice, and a step towards a more generic treatment of them.

- [x] Added / updated **test-suite**.
- [x] Added **changelog**
- [x] Added documentation