### PR TITLE
Correctly compute sort relevance in Retyping.

### DIFF
--- a/pretyping/retyping.ml
+++ b/pretyping/retyping.ml
@@ -323,8 +323,8 @@ let relevance_of_term env sigma c =
   else Sorts.Relevant
 
 let relevance_of_type env sigma t =
-  let s = get_sort_family_of env sigma t in
-  Sorts.relevance_of_sort_family s
+  let s = get_sort_of env sigma t in
+  Sorts.relevance_of_sort (ESorts.kind sigma s)
 
 let relevance_of_sort s = Sorts.relevance_of_sort (EConstr.Unsafe.to_sorts s)
 

--- a/test-suite/bugs/bug_17124.v
+++ b/test-suite/bugs/bug_17124.v
@@ -1,0 +1,10 @@
+Set Warnings "+bad-relevance".
+
+Axiom P : SProp.
+Axiom Q : P -> Type.
+Axiom admit : False.
+
+Lemma foo p : Q p.
+Proof.
+elim admit.
+Qed.


### PR DESCRIPTION
Instead of relying on the sort family, which lacks the necessary data to return a variable relevance, we extract directly the relevance from the corresponding sort.

We should probably review seriously all calls to Sorts.relevance_of_sort_family, but for the time being let us do this piecewise.

Fixes #17124.