### PR TITLE
Notation bug?

### DIFF
--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -150,6 +150,9 @@ GRAMMAR EXTEND Gram
     [ [ c = term LEVEL "8" -> { c }
       | "@"; f=global; i = univ_annot -> { CAst.make ~loc @@ CAppExpl((f,i),[]) } ] ]
   ;
+  scope_key:
+    [ [ s = IDENT -> { s } ] ]
+  ;
   term:
     [ "200" RIGHTA
       [ c = binder_constr -> { c } ]
@@ -179,7 +182,7 @@ GRAMMAR EXTEND Gram
       | c = term; ".("; "@"; f = global; i = univ_annot;
         args = LIST0 (term LEVEL "9"); ")" ->
         { CAst.make ~loc @@ CProj(true, (f,i), List.map (fun a -> (a,None)) args, c) }
-      | c = term; "%"; key = IDENT -> { CAst.make ~loc @@ CDelimiters (key,c) } ]
+      | c = term; "%"; key = scope_key -> { CAst.make ~loc @@ CDelimiters (key,c) } ]
     | "0"
       [ c = atomic_constr -> { c }
       | c = term_match -> { c }


### PR DESCRIPTION
If I run [RelUtil.v](https://github.com/fblanqui/color/blob/master/Util/Relation/RelUtil.v) from `ci-color` with this PR, this line (line 511):

`Global Instance rc_refl A (R : rel A) : Reflexive (R%).`

Gives the error  `Syntax error: [scope_key] expected after '%' (in [term]).`

I see this notation on line 501 that would be used to handle the `R%` in the failing line

`Notation "x %" := (clos_refl x) (at level 35) : relation_scope.`

But that shouldn't match the modified `term` level 1 production `"%" scope_key` at all nor generate any error.  Is this a fixable bug in the notations or the parser or just some strange behavior we have to live with?  @herbelin, do you have any thoughts?
