### PR TITLE
Correctly check relevance of recursive declarations in kernel.

### DIFF
--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -82,6 +82,9 @@ let jv_nf_evar sigma = Array.map (j_nf_evar sigma)
 let tj_nf_evar sigma {utj_val=v;utj_type=t} =
   {utj_val=nf_evar sigma v;utj_type=t}
 
+let nf_relevance sigma r =
+  UState.nf_relevance (Evd.evar_universe_context sigma) r
+
 let nf_named_context_evar sigma ctx =
   Context.Named.map (nf_evars_universes sigma) ctx
 

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -140,6 +140,7 @@ val nf_env_evar : evar_map -> env -> env
 val nf_evar_info : evar_map -> 'a evar_info -> 'a evar_info
 val nf_evar_map : evar_map -> evar_map
 val nf_evar_map_undefined : evar_map -> evar_map
+val nf_relevance : evar_map -> Sorts.relevance -> Sorts.relevance
 
 (** Presenting terms without solved evars *)
 

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -69,6 +69,10 @@ let warn_bad_relevance ?loc x = warn_bad_relevance ?loc (Some x)
 
 let check_assumption env x t ty =
   let r = x.binder_relevance in
+  let () = match r with
+  | Sorts.Relevant | Sorts.Irrelevant -> ()
+  | Sorts.RelevanceVar _ -> anomaly Pp.(str "the kernel does not support sort variables")
+  in
   let r' = infer_assumption env t ty in
   let x = if Sorts.relevance_equal r r'
     then x

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -500,12 +500,12 @@ let type_of_case env (mib, mip) ci u pms (pctx, p, pt) iv c ct _lf lft =
     error_elim_arity env (ind, u') c None
   in
   let rp = Sorts.relevance_of_sort sp in
-  let ci = if ci.ci_relevance == rp then ci
-    else (warn_bad_relevance_ci (); {ci with ci_relevance=rp})
-  in
   let () = match ci.ci_relevance with
   | Sorts.Relevant | Sorts.Irrelevant -> ()
   | Sorts.RelevanceVar _ -> anomaly Pp.(str "the kernel does not support sort variables")
+  in
+  let ci = if ci.ci_relevance == rp then ci
+    else (warn_bad_relevance_ci (); {ci with ci_relevance=rp})
   in
   let () = check_case_info env (ind, u') rp ci in
   let () =

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -235,6 +235,7 @@ let check_recursive ~isfix env evd (fixnames,_,fixdefs,_) =
 
 let ground_fixpoint env evd (fixnames,fixrs,fixdefs,fixtypes) =
   Pretyping.check_evars_are_solved ~program_mode:false env evd;
+  let fixrs = List.map (fun r -> Evarutil.nf_relevance evd r) fixrs in
   let fixdefs = List.map (fun c -> Option.map EConstr.(to_constr evd) c) fixdefs in
   let fixtypes = List.map EConstr.(to_constr evd) fixtypes in
   Evd.evar_universe_context evd, (fixnames,fixrs,fixdefs,fixtypes)


### PR DESCRIPTION
We were silently ignoring sort variables appearing in (co)fixpoints. This was not problematic because the relevance was fixed right afterwards, but it is cleaner, safer and future-proof to check it explicitly.