### PR TITLE
[gramlib] Move syntax errors to Grammar.

### DIFF
--- a/dev/ci/user-overlays/17136-ppedrot-stream_error_to_gramlib.sh
+++ b/dev/ci/user-overlays/17136-ppedrot-stream_error_to_gramlib.sh
@@ -1,0 +1,2 @@
+overlay elpi https://github.com/ppedrot/coq-elpi stream_error_to_gramlib 17136
+overlay vscoq https://github.com/ppedrot/vscoq stream_error_to_gramlib 17136

--- a/gramlib/grammar.mli
+++ b/gramlib/grammar.mli
@@ -8,6 +8,10 @@
     Grammars entries can be extended using the [EXTEND] statement,
     added by loading the Camlp5 [pa_extend.cmo] file. *)
 
+exception Error of string
+(** Raised by parsers when the first component of a stream pattern is
+   accepted, but one of the following components is rejected. *)
+
 (** {6 Functorial interface} *)
 
    (** Alternative for grammars use. Grammars are no more Ocaml values:

--- a/gramlib/stream.ml
+++ b/gramlib/stream.ml
@@ -24,7 +24,6 @@ and buffio =
   { ic : in_channel; buff : bytes; mutable len : int; mutable ind : int }
 
 exception Failure
-exception Error of string
 
 let count { count } = count
 

--- a/gramlib/stream.mli
+++ b/gramlib/stream.mli
@@ -20,13 +20,7 @@ type ('e,'a) t
     Producing a new value needs an environment ['e]. *)
 
 exception Failure
-(** Raised by parsers when none of the first components of the stream
-   patterns is accepted. *)
-
-exception Error of string
-(** Raised by parsers when the first component of a stream pattern is
-   accepted, but one of the following components is rejected. *)
-
+(** Raised by streams when trying to access beyond their end. *)
 
 (** {1 Stream builders} *)
 

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -585,7 +585,7 @@ let split_at_annot bl na =
         else
           aux (x :: acc) rest
       | CLocalPattern _ :: rest ->
-        Loc.raise ?loc (Gramlib.Stream.Error "pattern with quote not allowed after fix")
+        Loc.raise ?loc (Gramlib.Grammar.Error "pattern with quote not allowed after fix")
       | [] ->
         CErrors.user_err ?loc
           (str "No parameter named " ++ Id.print id ++ str".")

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -581,7 +581,7 @@ let glob_local_binder_of_extended = DAst.with_loc_val (fun ?loc -> function
       let t = DAst.make ?loc @@ GHole(Evar_kinds.BinderType na,IntroAnonymous) in
       (na,Explicit,Some c,t)
   | GLocalPattern (_,_,_,_) ->
-      Loc.raise ?loc (Gramlib.Stream.Error "pattern with quote not allowed here")
+      Loc.raise ?loc (Gramlib.Grammar.Error "pattern with quote not allowed here")
   )
 
 let intern_cases_pattern_fwd = ref (fun _ -> failwith "intern_cases_pattern_fwd")

--- a/parsing/cLexer.ml
+++ b/parsing/cLexer.ml
@@ -418,7 +418,7 @@ let rec comment loc bp s =
               Stream.junk () s;
               push_string "(*"; comment loc bp s
           | _ -> push_string "("; loc
-        with Stream.Failure -> raise (Stream.Error "")
+        with Stream.Failure -> raise (Gramlib.Grammar.Error "")
       in
       comment loc bp s
   | Some '*' ->
@@ -427,7 +427,7 @@ let rec comment loc bp s =
         match Stream.peek () s with
           Some ')' -> Stream.junk () s; push_string "*)"; loc
         | _ -> real_push_char '*'; comment loc bp s
-      with Stream.Failure -> raise (Stream.Error "")
+      with Stream.Failure -> raise (Gramlib.Grammar.Error "")
       end
   | Some '"' ->
       Stream.junk () s;
@@ -521,7 +521,7 @@ let parse_quotation loc bp s =
       let c = Stream.next () s in
       let len =
         try ident_tail loc (store 0 c) s with
-          Stream.Failure -> raise (Stream.Error "")
+          Stream.Failure -> raise (Gramlib.Grammar.Error "")
       in
       get_buff len, set_loc_pos loc bp (Stream.count s)
   | Delimited (lenmarker, bmarker, emarker) ->
@@ -651,7 +651,7 @@ let rec next_token ~diff_mode ttree loc s =
       Stream.junk () s;
       let t, newloc =
         try parse_after_dot ~diff_mode ttree loc c bp s with
-          Stream.Failure -> raise (Stream.Error "")
+          Stream.Failure -> raise (Gramlib.Grammar.Error "")
       in
       comment_stop bp;
       (* We enforce that "." should either be part of a larger keyword,
@@ -682,7 +682,7 @@ let rec next_token ~diff_mode ttree loc s =
       Stream.junk () s;
       let len =
         try ident_tail loc (store 0 c) s with
-          Stream.Failure -> raise (Stream.Error "")
+          Stream.Failure -> raise (Gramlib.Grammar.Error "")
       in
       let id = get_buff len in
       comment_stop bp;
@@ -701,7 +701,7 @@ let rec next_token ~diff_mode ttree loc s =
       Stream.junk () s;
       let (loc, len) =
         try string loc ~comm_level:None bp 0 s with
-          Stream.Failure -> raise (Stream.Error "")
+          Stream.Failure -> raise (Gramlib.Grammar.Error "")
       in
       let ep = Stream.count s in
       comment_stop bp;
@@ -723,7 +723,7 @@ let rec next_token ~diff_mode ttree loc s =
             push_string "(*";
             let loc = comment loc bp s in next_token ~diff_mode ttree loc s
         | _ -> let t = process_chars ~diff_mode ttree loc bp [c] s in comment_stop bp; t
-      with Stream.Failure -> raise (Stream.Error "")
+      with Stream.Failure -> raise (Gramlib.Grammar.Error "")
       end
   | Some ('{' | '}' as c) ->
       Stream.junk () s;

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -445,7 +445,7 @@ let check_param = function
 | CLocalAssum (nas, Default _, _) -> List.iter check_named nas
 | CLocalAssum (nas, Generalized _, _) -> ()
 | CLocalPattern {CAst.loc} ->
-    Loc.raise ?loc (Gramlib.Stream.Error "pattern with quote not allowed here")
+  Loc.raise ?loc (Gramlib.Grammar.Error "pattern with quote not allowed here")
 
 let restrict_inductive_universes sigma ctx_params arities constructors =
   let merge_universes_of_constr c =
@@ -723,7 +723,7 @@ let rec count_binder_expr = function
   | CLocalAssum(l,_,_) :: rest -> List.length l + count_binder_expr rest
   | CLocalDef _ :: rest -> 1 + count_binder_expr rest
   | CLocalPattern {CAst.loc} :: _ ->
-    Loc.raise ?loc (Gramlib.Stream.Error "pattern with quote not allowed here")
+    Loc.raise ?loc (Gramlib.Grammar.Error "pattern with quote not allowed here")
 
 let interp_mutual_inductive ~env ~template udecl indl ~cumulative ~poly ?typing_flags ~private_ind ~uniform finite =
   let indlocs = List.map (fun ((n,_,_,_),_) -> n.CAst.loc) indl in

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1556,7 +1556,7 @@ let wrap_unhandled f e =
 
 let explain_exn_default = function
   (* Basic interaction exceptions *)
-  | Gramlib.Stream.Error txt -> hov 0 (str "Syntax error: " ++ str txt ++ str ".")
+  | Gramlib.Grammar.Error txt -> hov 0 (str "Syntax error: " ++ str txt ++ str ".")
   | CLexer.Error.E err -> hov 0 (str (CLexer.Error.to_string err))
   | Sys_error msg -> hov 0 (str "System error: " ++ quote (str msg))
   | Out_of_memory -> hov 0 (str "Out of memory.")

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -100,7 +100,7 @@ let check_parameters_must_be_named = function
   | CLocalAssum (ls, bk, _ce) ->
     List.iter (error_parameters_must_be_named bk) ls
   | CLocalPattern {CAst.loc} ->
-    Loc.raise ?loc (Gramlib.Stream.Error "pattern with quote not allowed in record parameters")
+    Loc.raise ?loc (Gramlib.Grammar.Error "pattern with quote not allowed in record parameters")
 
 (** [DataI.t] contains the information used in record interpretation,
    it is a strict subset of [Ast.t] thus this should be


### PR DESCRIPTION
They don't belong in the `Stream` module anymore. This is pre-requisite to having an algebraic type of parsing errors.

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/534
- https://github.com/coq-community/vscoq/pull/685