### PR TITLE
Partially fixing #17137 on pattern-matching clauses lost when matching a constructor from a singleton type requiring a coercion

### DIFF
--- a/doc/changelog/02-specification-language/17138-master+partial-fix17137-coercions-on-constructors-in-singleton-types.rst
+++ b/doc/changelog/02-specification-language/17138-master+partial-fix17137-coercions-on-constructors-in-singleton-types.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Pattern-matching clauses were possibly lost when matching over a
+  constructor from a singleton inductive type in the presence of
+  implicit coercions (`#17138 <https://github.com/coq/coq/pull/17138>`_,
+  fixes `#17137 <https://github.com/coq/coq/issues/17137>`_, by Hugo
+  Herbelin).

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -1248,7 +1248,7 @@ let rec irrefutable env pat = match DAst.get pat with
       one_constr && List.for_all (irrefutable env) args
 
 let first_clause_irrefutable env = function
-  | eqn::mat -> List.for_all (irrefutable env) eqn.patterns
+  | {patterns=pat::patl}::mat -> (match DAst.get pat with PatVar _ -> List.for_all (irrefutable env) patl | _ -> false)
   | _ -> false
 
 let group_equations pb ind current cstrs mat =

--- a/test-suite/bugs/bug_17137.v
+++ b/test-suite/bugs/bug_17137.v
@@ -1,0 +1,23 @@
+Inductive Num : Type :=
+| pos :> Pos -> Num
+| neg :> Neg -> Num
+with Pos : Type :=
+| a : Pos
+with Neg : Type :=
+| b : Neg.
+
+Definition name (x : Num) : nat :=
+  match x with
+  | a => 0
+  | b => 1
+  end.
+
+(* Note that the following should be accepted but is not. The reason
+   it that it is assumed that the first line is irrefutable so that
+   the split on a and b in the first row is dropped. *)
+
+Fail Check fun x y : Num => match x, y with
+| x, a => 0
+| a, b => 1
+| b, b => 2
+end.


### PR DESCRIPTION
This PR fixes the common cases of issue #17137 about coercions not inserted when pattern-matching over constructors belonging to singleton inductive types.

More precisely in `match t, t' with x, pat1' => ... | pat2, pat2' => ... end`, one should be able to know if the second line is necessary, so that, if not necessary, no split on the first row is needed.

Before the PR, the strategy was to check whether the first line of patterns, say `pat1, pat1'`, was an irrefutable line. In particular, in the situation of #17137 with no `pat1'` and `pat1` a pattern in a singleton type, the first line was considered irrefutable and the next lines were thrown away.

The problem is that this test of irrefutability ignores coercions. This is wrong because coercions can lift a pattern belonging to a singleton type (thus looking irrefutable) to a pattern in a non-singleton type (where it is not anymore irrefutable).

The PR does not solve the issue that irrefutability ignores coercions but it refines the test so that it applies only when really needed, that is when `pat1` is a variable. In the absence of coercions, this does not matter, because ignoring the next lines would be done anyway when `pat1` is irrefutable, but in the presence of coercions, wrongly detecting the irrefutability status of `pat1` can uselessly lead to wrongly drop the next lines of the pattern-matching problem.

Fixes / closes #17137

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
