### PR TITLE
make-library-index: use mktemp, general cleanup

### DIFF
--- a/doc/stdlib/make-library-index
+++ b/doc/stdlib/make-library-index
@@ -2,13 +2,17 @@
 
 # Instantiate links to library files in index template
 
+set -e
+
 FILE=$1
 HIDDEN=$2
+tmp=$(mktemp)
+tmp2=$(mktemp)
 
-cp -f $FILE.template tmp
+cp -f "$FILE.template" "$tmp"
 echo -n "Building file index-list.prehtml... "
 
-LIBDIRS=`find theories/* user-contrib/* -type d ! -name .coq-native`
+LIBDIRS=$(find theories/* user-contrib/* -type d ! -name .coq-native)
 
 for k in $LIBDIRS; do
     if [[ $k =~ "user-contrib" ]]; then
@@ -16,41 +20,37 @@ for k in $LIBDIRS; do
     else
         BASE_PREFIX="Coq."
     fi
-    d=`basename $k`
-      ls $k | grep -q \.v'$'
-      if [ $? = 0 ]; then
-	for j in $k/*.v; do
-	    b=`basename $j .v`
-	    rm -f tmp2
-	    grep -q $k/$b.v tmp
-	    a=$?
-	    grep -q $k/$b.v $HIDDEN
-	    h=$?
-	    if [ $a = 0 ]; then
-	        if [ $h = 0 ]; then
-                    echo Error: $FILE and $HIDDEN both mention $k/$b.v; exit 1
-                else
-		    p=`echo $k | sed 's:^[^/]*/::' | sed 's:/:.:g'`
-		    sed -e "s:$k/$b.v:<a href=\"$BASE_PREFIX$p.$b.html\">$b</a>:g" tmp > tmp2
-		    mv -f tmp2 tmp
-                fi
-	    else
-	        if [ $h = 0 ]; then
-		    # Skipping file from the index
-                    :
-                else
-                    echo Error: none of $FILE and $HIDDEN mention $k/$b.v
-                    exit 1
-	        fi
+    d=$(basename "$k")
+    for j in "$k"/*.v; do
+        if ! [ -e "$j" ]; then break; fi
+        b=$(basename "$j" .v)
 
+        a=0; grep -q "$k/$b.v" "$tmp" || a=$?
+        h=0; grep -q "$k/$b.v" "$HIDDEN" || h=$?
+        if [ $a = 0 ]; then
+            if [ $h = 0 ]; then
+                echo "Error: $FILE and $HIDDEN both mention $k/$b.v" >&2
+                exit 1
+            else
+                p=$(echo "$k" | sed 's:^[^/]*/::' | sed 's:/:.:g')
+                sed -e "s:$k/$b.v:<a href=\"$BASE_PREFIX$p.$b.html\">$b</a>:g" "$tmp" > "$tmp2"
+                mv -f "$tmp2" "$tmp"
             fi
-	done
-      fi
-    rm -f tmp2
-    sed -e "s/#$d#//" tmp > tmp2
-    mv -f tmp2 tmp
+        else
+            if [ $h = 0 ]; then
+                # Skipping file from the index
+                :
+            else
+                echo "Error: none of $FILE and $HIDDEN mention $k/$b.v" >&2
+                exit 1
+            fi
+
+        fi
+    done
+    sed -e "s/#$d#//" "$tmp" > "$tmp2"
+    mv -f "$tmp2" "$tmp"
 done
-a=`grep theories tmp`
-if [ $? = 0 ]; then echo Error: extra files:; echo $a; exit 1; fi
-mv tmp $FILE
+
+if a=$(grep theories "$tmp"); then echo Error: extra files: >&2; echo "$a" >&2; exit 1; fi
+mv "$tmp" "$FILE"
 echo Done


### PR DESCRIPTION
This fixes the "sed: can't read tmp" error on my machine, not that I understand why it happened.
