### PR TITLE
Fixing syntax error reporting in the presence of token lookahead

### DIFF
--- a/test-suite/output-coqtop/LookaheadErrors.out
+++ b/test-suite/output-coqtop/LookaheadErrors.out
@@ -1,0 +1,9 @@
+
+Coq < 
+Coq < 
+Coq < Toplevel input, characters 9-11:
+> Check ## [].
+>          ^^
+Error: Syntax error: '##' or [term] expected after '##' (in [term]).
+
+Coq < 

--- a/test-suite/output-coqtop/LookaheadErrors.out
+++ b/test-suite/output-coqtop/LookaheadErrors.out
@@ -6,4 +6,11 @@ Coq < Toplevel input, characters 9-11:
 >          ^^
 Error: Syntax error: '##' or [term] expected after '##' (in [term]).
 
+Coq < Coq < 
+Coq < 
+Coq < Toplevel input, characters 9-11:
+> Check ## [].
+>          ^^
+Error: Syntax error: '##' or [term] expected after '##' (in [term]).
+
 Coq < 

--- a/test-suite/output-coqtop/LookaheadErrors.v
+++ b/test-suite/output-coqtop/LookaheadErrors.v
@@ -1,0 +1,3 @@
+Notation "## x" := (S x) (at level 0).
+Notation "## ##" := 0 (at level 0).
+Check ## [].

--- a/test-suite/output-coqtop/LookaheadErrors.v
+++ b/test-suite/output-coqtop/LookaheadErrors.v
@@ -1,3 +1,7 @@
 Notation "## x" := (S x) (at level 0).
 Notation "## ##" := 0 (at level 0).
 Check ## [].
+
+Notation "## x" := (S x) (at level 0).
+Notation "## ## ##" := 0 (at level 0).
+Check ## [].


### PR DESCRIPTION
**Kind**: between fix and enhancement

A first commit changes the syntax error message in the following case:
```coq
Notation "## x" := (S x) (at level 0).
Notation "## ##" := 0 (at level 0).
Check ## [].
```
Before: `Syntax error: [term] expected after '##' (in [term])`.
After: `Syntax error: '##' or [term] expected after '##' (in [term])`.

A second commit refines the situation further so that it works also in the presence of several tokens ahead:
```coq
Notation "## x" := (S x) (at level 0).
Notation "## ## ##" := 0 (at level 0).
Check ## [].
```
Before: `Syntax error: [term] expected after '##' (in [term])`.
With only the first commit: `Syntax error: '##' '##' expected after '##' (in [term]).`
After: `Syntax error: '##' '##' or [term] expected after '##' (in [term]).`

The first problem was that the error was reported on the last applicable rule rather than on the list of all applicable rules at this stage. The second problem was that in the presence of multiple tokens ahead, the alternative rules were omitted.

***Note: I rewrote the header in a more concise and comprehensive way, compared to the initial version, also fixing the initial PR and adding a new fix.***
