### PR TITLE
[time] [coqc] Print time for document setup and end.

### DIFF
--- a/dev/bench/bench.sh
+++ b/dev/bench/bench.sh
@@ -74,8 +74,8 @@ check_variable () {
 new_ocaml_switch=ocaml-base-compiler.$new_ocaml_version
 old_ocaml_switch=ocaml-base-compiler.$old_ocaml_version
 
-new_coq_commit=$(git rev-parse HEAD^2)
-old_coq_commit=$(git merge-base HEAD^1 $new_coq_commit)
+new_coq_commit=7eccc646c2863c68858b77fae526435561d6f4fe
+old_coq_commit=7eccc646c2863c68858b77fae526435561d6f4fe
 
 if echo "$num_of_iterations" | grep '^[1-9][0-9]*$' 2> /dev/null > /dev/null; then
     :

--- a/dev/bench/timelog2html.ml
+++ b/dev/bench/timelog2html.ml
@@ -94,6 +94,13 @@ let count_newlines s = str_fold_left (fun n c -> if c = '\n' then n+1 else n) 0 
 
 let is_white_char = function ' '|'\n'|'\t' -> true | _ -> false
 
+(* Set to true when benching with Coq versions that don't output the header / end timing *)
+let bench_with_old_version = false
+
+let is_start_end_header l =
+  Str.(string_match (regexp "Comments~\"Document Start\"") l 0)
+  || Str.(string_match (regexp "Comments~\"Document End\"") l 0)
+
 let rec file_loop filech ~last_end ~lines acc : measure one_command array =
   match input_line filech with
   | exception End_of_file ->
@@ -108,6 +115,9 @@ let rec file_loop filech ~last_end ~lines acc : measure one_command array =
     in
     CArray.rev_of_list acc
   | l ->
+    if bench_with_old_version && is_start_end_header l then
+      file_loop filech ~last_end ~lines acc
+    else
     if not (Str.string_match time_regex l 0) then
       file_loop filech ~last_end ~lines acc
     else

--- a/doc/changelog/09-cli-tools/17150-time_require_import.rst
+++ b/doc/changelog/09-cli-tools/17150-time_require_import.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  ``coqc -time`` will now also report times of document creation and
+  ``.vo`` saving.
+  (`#17150 <https://github.com/coq/coq/pull/17150>`_,
+  by Emilio Jesus Gallego Arias).

--- a/test-suite/coq-makefile/timing/per-file-after/A.v.timing.diff.desired
+++ b/test-suite/coq-makefile/timing/per-file-after/A.v.timing.diff.desired
@@ -4,6 +4,8 @@
 ----------------------------------------------------------------------------------------------------
 0m14.578s | Chars 163 - 208 [Definition~foo1~:=~Eval~comp~i...] | 0m00.356s || +0m14.22s | +3994.94%
 0m00.284s | Chars 069 - 162 [Definition~foo0~:=~Eval~comp~i...] | 0m00.225s || +0m00.05s |   +26.22%
- 0m00.14s | Chars 000 - 026 [Require~Coq.ZArith.BinInt.]        | 0m00.139s || +0m00.00s |    +0.71%
+0m00.140s | Chars 000 - 026 [Require~Coq.ZArith.BinInt.]        | 0m00.139s || +0m00.00s |    +0.71%
+0m00.024s | Chars 000 - 000 [Document~Start]        | 0m00.026s || -0m00.00s |   -7.69%
+0m00.004s | Chars 209 - 210 [Document~End]          | 0m00.004s || +0m00.00s |   +0.00%
    0m00.s | Chars 027 - 068 [Declare~Reduction~comp~:=~nati...] |    N/A    || +0m00.00s |    N/A   
    N/A    | Chars 027 - 068 [Declare~Reduction~comp~:=~vm_c...] |    0m00.s || +0m00.00s |    N/A   

--- a/test-suite/coq-makefile/timing/per-file-after/A.v.timing.diff.desired
+++ b/test-suite/coq-makefile/timing/per-file-after/A.v.timing.diff.desired
@@ -5,7 +5,7 @@
 0m14.578s | Chars 163 - 208 [Definition~foo1~:=~Eval~comp~i...] | 0m00.356s || +0m14.22s | +3994.94%
 0m00.284s | Chars 069 - 162 [Definition~foo0~:=~Eval~comp~i...] | 0m00.225s || +0m00.05s |   +26.22%
 0m00.140s | Chars 000 - 026 [Require~Coq.ZArith.BinInt.]        | 0m00.139s || +0m00.00s |    +0.71%
-0m00.024s | Chars 000 - 000 [Document~Start]        | 0m00.026s || -0m00.00s |   -7.69%
-0m00.004s | Chars 209 - 210 [Document~End]          | 0m00.004s || +0m00.00s |   +0.00%
+0m00.024s | Chars 000 - 000 [Comments~"Document~Start"]         | 0m00.026s || -0m00.00s |   -7.69%
+0m00.004s | Chars 209 - 210 [Comments~"Document~End"]           | 0m00.004s || +0m00.00s |   +0.00%
    0m00.s | Chars 027 - 068 [Declare~Reduction~comp~:=~nati...] |    N/A    || +0m00.00s |    N/A   
    N/A    | Chars 027 - 068 [Declare~Reduction~comp~:=~vm_c...] |    0m00.s || +0m00.00s |    N/A   

--- a/test-suite/misc/qed-time.sh
+++ b/test-suite/misc/qed-time.sh
@@ -13,7 +13,7 @@ cd misc/qed-time/
 # command gets 1 time line, but because output-modulo-time normalizes
 # times to 0 it can't check that the replayed command is not ignored
 
-coqc -time file.v | sed "$d" > out
+coqc -time file.v | sed '$d' > out
 
 last=$(tail -n 1 out)
 

--- a/test-suite/misc/qed-time.sh
+++ b/test-suite/misc/qed-time.sh
@@ -13,7 +13,7 @@ cd misc/qed-time/
 # command gets 1 time line, but because output-modulo-time normalizes
 # times to 0 it can't check that the replayed command is not ignored
 
-coqc -time file.v > out
+coqc -time file.v | sed "$d" > out
 
 last=$(tail -n 1 out)
 

--- a/test-suite/output-modulo-time/abort.out
+++ b/test-suite/output-modulo-time/abort.out
@@ -1,5 +1,5 @@
-Chars 0 - 0 [Comments "Document~Start".] 0. secs (0.u,0.s)
+Chars 0 - 0 [Comments~"Document~Start".] 0. secs (0.u,0.s)
 Chars 40 - 50 [Goal~_~True.] 0. secs (0.u,0.s)
 Chars 51 - 57 [Abort.] 0. secs (0.u,0.s)
-Chars 71 - 72 [Comments "Document~End".] 0. secs (0.u,0.s)
+Chars 71 - 72 [Comments~"Document~End".] 0. secs (0.u,0.s)
 ] 0. secs (0.u,0.s)

--- a/test-suite/output-modulo-time/abort.out
+++ b/test-suite/output-modulo-time/abort.out
@@ -1,2 +1,5 @@
-Chars 40 - 50 [Goal~True.] 0. secs (0.u,0.s)
+Chars 0 - 0 [Comments "Document~Start".] 0. secs (0.u,0.s)
+Chars 40 - 50 [Goal~_~True.] 0. secs (0.u,0.s)
 Chars 51 - 57 [Abort.] 0. secs (0.u,0.s)
+Chars 71 - 72 [Comments "Document~End".] 0. secs (0.u,0.s)
+] 0. secs (0.u,0.s)

--- a/test-suite/output-modulo-time/qed_time.out
+++ b/test-suite/output-modulo-time/qed_time.out
@@ -1,5 +1,8 @@
+Chars 0 - 0 [Comments~"Document~Start".]secs (u,s)
 Chars 40 - 57 [Lemma~foo~:~True.] 0. secs (0.u,0.s)
 Chars 58 - 64 [Proof.] 0. secs (0.u,0.s)
 Chars 67 - 81 [Axiom~(X~:~nat).] 0. secs (0.u,0.s)
 Chars 84 - 92 [exact~I.] 0. secs (0.u,0.s)
 Chars 93 - 97 [Qed.] 0. secs (0.u,0.s)
+Chars 98 - 99 [Comments~"Document~End".]secs (u,s)
+

--- a/toplevel/coqrc.ml
+++ b/toplevel/coqrc.ml
@@ -21,7 +21,7 @@ let load_rcfile ~rcfile ~state =
       match rcfile with
       | Some rcfile ->
         if CUnix.file_readable_p rcfile then
-          Vernac.load_vernac ~echo:false ~interactive:false ~check:true ~state rcfile
+          Vernac.load_vernac ~echo:false ~interactive:false ~check:true ~state rcfile |> fst
         else raise (Sys_error ("Cannot read rcfile: "^ rcfile))
       | None ->
         try
@@ -32,7 +32,7 @@ let load_rcfile ~rcfile ~state =
             Envars.home ~warn / "."^rcdefaultname^"."^Coq_config.version;
             Envars.home ~warn / "."^rcdefaultname
           ] in
-          Vernac.load_vernac ~echo:false ~interactive:false ~check:true ~state inferedrc
+          Vernac.load_vernac ~echo:false ~interactive:false ~check:true ~state inferedrc |> fst
         with Not_found -> state
         (*
         Flags.if_verbose

--- a/toplevel/load.ml
+++ b/toplevel/load.ml
@@ -29,7 +29,7 @@ let load_vernacular opts ~state =
     (fun state (f_in, echo) ->
       let s = Loadpath.locate_file f_in in
       (* Should make the beautify logic clearer *)
-      let load_vernac f = Vernac.load_vernac ~echo ~interactive:false ~check:true ~state f in
+      let load_vernac f = Vernac.load_vernac ~echo ~interactive:false ~check:true ~state f |> fst in
       if !Flags.beautify
       then Flags.with_option Flags.beautify_file load_vernac f_in
       else load_vernac s

--- a/toplevel/vernac.ml
+++ b/toplevel/vernac.ml
@@ -126,7 +126,7 @@ let load_vernac_core ~echo ~check ~interactive ~state ?source file =
     with
     | None ->
       input_cleanup ();
-      state, ids, Pcoq.Parsable.comments in_pa
+      state, ids, Pcoq.Parsable.comments in_pa, Pcoq.Parsable.loc in_pa
     | Some ast ->
       (* Printing of AST for -compile-verbose *)
       Option.iter (vernac_echo ?loc:ast.CAst.loc) in_echo;
@@ -194,8 +194,8 @@ let beautify_pass ~doc ~comments ~ids ~filename =
 (* Main driver for file loading. For now, we only do one beautify
    pass. *)
 let load_vernac ~echo ~check ~interactive ~state ?source filename =
-  let ostate, ids, comments = load_vernac_core ~echo ~check ~interactive ~state ?source filename in
+  let ostate, ids, comments, loc = load_vernac_core ~echo ~check ~interactive ~state filename in
   (* Pass for beautify *)
   if !Flags.beautify then beautify_pass ~doc:ostate.State.doc ~comments ~ids:(List.rev ids) ~filename;
   (* End pass *)
-  ostate
+  ostate, loc

--- a/toplevel/vernac.mli
+++ b/toplevel/vernac.mli
@@ -34,4 +34,8 @@ val process_expr : state:State.t -> Vernacexpr.vernac_control -> State.t
     echo the commands if [echo] is set. Callers are expected to handle
     and print errors in form of exceptions. *)
 val load_vernac : echo:bool -> check:bool -> interactive:bool ->
-  state:State.t -> ?source:Loc.source -> string -> State.t
+  state:State.t -> ?source:Loc.source -> string -> State.t * Loc.t
+
+(** [emit_time st cmd before after] Prints timing information *)
+val emit_time :
+  State.t -> Vernacexpr.vernac_control -> System.time -> System.time -> unit

--- a/vernac/topfmt.ml
+++ b/vernac/topfmt.ml
@@ -428,7 +428,7 @@ let with_output_to_file fname func input =
 (* For coqtop -time, we display the position in the file,
    and a glimpse of the executed command *)
 
-let pr_cmd_header com =
+let pr_header ?loc com =
   let shorten s =
     if Unicode.utf8_length s > 33 then (Unicode.utf8_sub s 0 30) ^ "..." else s
   in
@@ -438,10 +438,11 @@ let pr_cmd_header com =
         | x -> x
       ) s
   in
-  let (start,stop) = Option.cata Loc.unloc (0,0) com.CAst.loc in
-  let safe_pr_vernac x =
-    try Ppvernac.pr_vernac x
-    with e -> str (Printexc.to_string e) in
-  let cmd = noblank (shorten (string_of_ppcmds (safe_pr_vernac com)))
+  let (start,stop) = Option.cata Loc.unloc (0,0) loc in
+  let cmd = noblank (shorten (string_of_ppcmds com))
   in str "Chars " ++ int start ++ str " - " ++ int stop ++
      str " [" ++ str cmd ++ str "] "
+
+let pr_cmd_header com =
+  let compp = try Ppvernac.pr_vernac com with e -> str (Printexc.to_string e) in
+  pr_header ?loc:com.CAst.loc compp

--- a/vernac/topfmt.mli
+++ b/vernac/topfmt.mli
@@ -72,4 +72,5 @@ val print_err_exn : exn -> unit
     redirected to a file [file] *)
 val with_output_to_file : string -> ('a -> 'b) -> 'a -> 'b
 
+val pr_header : ?loc:Loc.t -> Pp.t -> Pp.t
 val pr_cmd_header : Vernacexpr.vernac_control -> Pp.t


### PR DESCRIPTION
This can be useful when benchmarking.

As header in the time output, we use a special marker with a Coq
comment so it is still valid .v syntax: "(* Document Start / End *)"


