### PR TITLE
Correctly normalize relevances in various forgotten places.

### DIFF
--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -18,7 +18,7 @@ open Constr
 open Vars
 open Environ
 
-(* module RelDecl = Context.Rel.Declaration *)
+module RelDecl = Context.Rel.Declaration
 module NamedDecl = Context.Named.Declaration
 
 type econstr = constr
@@ -1711,7 +1711,13 @@ module MiniEConstr = struct
   let unsafe_to_named_decl d = d
   let of_rel_decl d = d
   let unsafe_to_rel_decl d = d
-  let to_rel_decl sigma d = Context.Rel.Declaration.map_constr (to_constr sigma) d
+  let to_rel_decl sigma d = match d with
+  | RelDecl.LocalAssum (na, t) ->
+    let na = UnivSubst.nf_binder_annot (fun r -> UState.nf_relevance sigma.universes r) na in
+    RelDecl.LocalAssum (na, to_constr sigma t)
+  | RelDecl.LocalDef (na, c, t) ->
+    let na = UnivSubst.nf_binder_annot (fun r -> UState.nf_relevance sigma.universes r) na in
+    RelDecl.LocalDef (na, to_constr sigma c, to_constr sigma t)
 
   let of_named_context d = d
   let of_rel_context d = d

--- a/engine/univSubst.mli
+++ b/engine/univSubst.mli
@@ -33,6 +33,9 @@ val normalize_universe_opt_subst : universe_opt_subst ->
 
 val normalize_opt_subst : universe_opt_subst -> universe_opt_subst
 
+val nf_binder_annot : (Sorts.relevance -> Sorts.relevance) ->
+  'a Context.binder_annot -> 'a Context.binder_annot
+
 (** Full universes substitutions into terms *)
 
 val nf_evars_and_universes_opt_subst :

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -540,7 +540,7 @@ let interp_mutual_inductive_constr ~sigma ~template ~udecl ~variances ~ctx_param
   let nf = Evarutil.nf_evars_universes sigma in
   let arities = List.map nf arities in
   let constructors = List.map (on_snd (List.map nf)) constructors in
-  let ctx_params = List.map Termops.(map_rel_decl (EConstr.to_constr sigma)) ctx_params in
+  let ctx_params = List.map (fun d -> EConstr.to_rel_decl sigma d) ctx_params in
   let arityconcl = List.map (Option.map (fun (_anon, s) -> EConstr.ESorts.kind sigma s)) arityconcl in
   let sigma = restrict_inductive_universes sigma ctx_params arities constructors in
   let univ_entry, binders = Evd.check_univ_decl ~poly sigma udecl in

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -234,9 +234,14 @@ let typecheck_params_and_fields def poly udecl ps (records : DataI.t list) : tc_
   let (sigma, typs) = List.fold_left2_map fold sigma typs data in
   (* TODO: Have this use Declaredef.prepare_definition *)
   let sigma, (newps, ans) = Evarutil.finalize sigma (fun nf ->
-      let newps = List.map (RelDecl.map_constr_het nf) newps in
+      let nf_rel r = Evarutil.nf_relevance sigma r in
+      let map_decl = function
+      | LocalAssum (na, t) -> LocalAssum (UnivSubst.nf_binder_annot nf_rel na, nf t)
+      | LocalDef (na, c, t) -> LocalDef (UnivSubst.nf_binder_annot nf_rel na, nf c, nf t)
+      in
+      let newps = List.map map_decl newps in
       let map (implfs, fields) (min_univ, typ) =
-        let fields = List.map (RelDecl.map_constr_het nf) fields in
+        let fields = List.map map_decl fields in
         let arity = nf typ in
         { DataR.min_univ; arity; implfs; fields }
       in


### PR DESCRIPTION
We normalize parameters and fields of records, parameters of inductive types, and the fixpoint-building process of Program blocks. The code is not pretty because it needs to handle the quirks of broken universe handling in the upper layers.

Subset of #17125 that shouldn't break Equations.