### PR TITLE
Stop using the unsafe API for Evarsolve.occur_evar_upto_types.

### DIFF
--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -1554,19 +1554,16 @@ let solve_candidates unify flags env evd (evk,argsv) rhs =
       | l, [] -> evd
 
 let occur_evar_upto_types sigma n c =
-  let c = EConstr.Unsafe.to_constr c in
   let seen = ref Evar.Set.empty in
-  (* FIXME: Is that supposed to be evar-insensitive? *)
-  let rec occur_rec c = match Constr.kind c with
+  let rec occur_rec c = match EConstr.kind sigma c with
     | Evar (sp,_) when Evar.equal sp n -> raise Occur
     | Evar (sp,args as e) ->
        if Evar.Set.mem sp !seen then
          SList.Skip.iter occur_rec args
        else (
          seen := Evar.Set.add sp !seen;
-         Option.iter occur_rec (existential_opt_value0 sigma e);
-         occur_rec (Evd.existential_type0 sigma e))
-    | _ -> Constr.iter occur_rec c
+         occur_rec (Evd.existential_type sigma e))
+    | _ -> EConstr.iter sigma occur_rec c
   in
   try occur_rec c; false with Occur -> true
 


### PR DESCRIPTION
This function does not seem to make sense, but at the very least it should not break the abstraction barrier.