### PR TITLE
Don't fail when printing a ltac2 name local to another module

### DIFF
--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -983,7 +983,7 @@ let backtrace : backtrace Exninfo.t = Exninfo.make ()
 let pr_frame = function
 | FrAnon e -> str "Call {" ++ pr_glbexpr e ++ str "}"
 | FrLtac kn ->
-  str "Call " ++ Libnames.pr_qualid (Tac2env.shortest_qualid_of_ltac (TacConstant kn))
+  str "Call " ++ pr_tacref kn
 | FrPrim ml ->
   str "Prim <" ++ str ml.mltac_plugin ++ str ":" ++ str ml.mltac_tactic ++ str ">"
 | FrExtn (tag, arg) ->

--- a/plugins/ltac2/tac2print.ml
+++ b/plugins/ltac2/tac2print.ml
@@ -15,6 +15,13 @@ open Tac2expr
 open Tac2env
 open Tac2ffi
 
+let pr_tacref kn =
+  try Libnames.pr_qualid (Tac2env.shortest_qualid_of_ltac (TacConstant kn))
+  with Not_found when KNmap.mem kn (Tac2env.globals()) ->
+    str (ModPath.to_string (KerName.modpath kn))
+    ++ str"." ++ Label.print (KerName.label kn)
+    ++ str " (* local *)"
+
 (** Utils *)
 
 let change_kn_label kn id =
@@ -271,9 +278,7 @@ let pr_glbexpr_gen lvl c =
   let rec pr_glbexpr lvl = function
   | GTacAtm atm -> pr_atom atm
   | GTacVar id -> Id.print id
-  | GTacRef gr ->
-    let qid = shortest_qualid_of_ltac (TacConstant gr) in
-    Libnames.pr_qualid qid
+  | GTacRef gr -> pr_tacref gr
   | GTacFun (nas, c) ->
     let nas = pr_sequence pr_name nas in
     let paren = match lvl with

--- a/plugins/ltac2/tac2print.mli
+++ b/plugins/ltac2/tac2print.mli
@@ -11,6 +11,11 @@
 open Tac2expr
 open Tac2ffi
 
+val pr_tacref : ltac_constant -> Pp.t
+(** Prints the shortest name for the constant. Also works for
+    constants not in the nametab (because they're local to another
+    module). *)
+
 (** {5 Printing types} *)
 
 type typ_level =

--- a/test-suite/output/bug_17155.out
+++ b/test-suite/output/bug_17155.out
@@ -1,0 +1,13 @@
+File "./output/bug_17155.v", line 6, characters 0-23:
+The command has indeed failed with message:
+Uncaught Ltac2 exception: Invalid_argument (None)
+File "./output/bug_17155.v", line 8, characters 0-23:
+The command has indeed failed with message:
+Backtrace:
+Call M.g
+Call bug_17155.M.f (* local *)
+Call Control.throw
+Prim <coq-core.plugins.ltac2:throw>
+Uncaught Ltac2 exception: Invalid_argument (None)
+Ltac2 M.g : unit -> 'a
+      M.g := fun _ => bug_17155.M.f (* local *) ()

--- a/test-suite/output/bug_17155.v
+++ b/test-suite/output/bug_17155.v
@@ -1,0 +1,9 @@
+From Ltac2 Require Import Ltac2.
+Module M.
+  #[local] Ltac2 f () := Control.throw (Invalid_argument None).
+  Ltac2 g () := f ().
+End M.
+Fail Ltac2 Eval M.g ().         (* Fails, as expected. *)
+Set Ltac2 Backtrace.
+Fail Ltac2 Eval M.g ().         (* Anomaly "Uncaught exception Not_found." *)
+Print M.g.


### PR DESCRIPTION
Fix #17155
