### PR TITLE
remove internal add_instance from typeclasses API

### DIFF
--- a/plugins/ltac/comRewrite.ml
+++ b/plugins/ltac/comRewrite.ml
@@ -32,13 +32,18 @@ let init_setoid () =
   if is_dirpath_prefix_of classes_dirpath (Lib.cwd ()) then ()
   else Coqlib.check_required_library ["Coq";"Setoids";"Setoid"]
 
-type rewrite_attributes = { polymorphic : bool; global : bool }
+type rewrite_attributes = {
+  polymorphic : bool;
+  locality : Hints.hint_locality;
+}
 
 let rewrite_attributes =
   let open Attributes.Notations in
   Attributes.(polymorphic ++ locality) >>= fun (polymorphic, locality) ->
-  let global = not (Locality.make_section_locality locality) in
-  Attributes.Notations.return { polymorphic; global }
+  let locality =
+    if Locality.make_section_locality locality then Hints.Local else SuperGlobal
+  in
+  Attributes.Notations.return { polymorphic; locality }
 
 (** Utility functions *)
 
@@ -63,7 +68,6 @@ module PropGlobal = struct
   let proper_proj env sigma =
     mkConst (Option.get (List.hd (proper_class env sigma).TC.cl_projs).TC.meth_const)
 
-
 end
 
 (* By default the strategy for "rewrite_db" is top-down *)
@@ -76,13 +80,10 @@ let declare_an_instance n s args =
 
 let declare_instance a aeq n s = declare_an_instance n s [a;aeq]
 
-let get_locality b = if b then Hints.SuperGlobal else Hints.Local
-
 let anew_instance atts binders (name,t) fields =
-  let locality = get_locality atts.global in
   let _id = Classes.new_instance ~poly:atts.polymorphic
       name binders t (true, CAst.make @@ CRecord (fields))
-      ~locality Hints.empty_hint_info
+      ~locality:atts.locality Hints.empty_hint_info
   in
   ()
 
@@ -212,8 +213,7 @@ let add_morphism_as_parameter atts m n : unit =
   let evd, pe = Declare.prepare_parameter ~poly ~udecl ~types evd in
   let cst = Declare.declare_constant ~name:instance_id ~kind (Declare.ParameterEntry pe) in
   let cst = GlobRef.ConstRef cst in
-  Classes.Internal.add_instance
-    (PropGlobal.proper_class env evd) Hints.empty_hint_info atts.global cst;
+  Classes.declare_instance env evd (Some Hints.empty_hint_info) atts.locality cst;
   declare_projection n instance_id cst
 
 let add_morphism_interactive atts ~tactic m n : Declare.Proof.t =
@@ -226,8 +226,7 @@ let add_morphism_interactive atts ~tactic m n : Declare.Proof.t =
   let kind = Decls.(IsDefinition Instance) in
   let hook { Declare.Hook.S.dref; _ } = dref |> function
     | GlobRef.ConstRef cst ->
-      Classes.Internal.add_instance (PropGlobal.proper_class env evd) Hints.empty_hint_info
-        atts.global (GlobRef.ConstRef cst);
+      Classes.declare_instance env evd (Some Hints.empty_hint_info) atts.locality (GlobRef.ConstRef cst);
       declare_projection n instance_id (GlobRef.ConstRef cst)
     | _ -> assert false
   in
@@ -248,9 +247,8 @@ let add_morphism atts ~tactic binders m s n =
       ((Libnames.qualid_of_string "Coq.Classes.Morphisms.Proper",None),
        [cHole; s; m])
   in
-  let locality = get_locality atts.global in
   let _id, lemma = Classes.new_instance_interactive
-      ~locality ~poly:atts.polymorphic
+      ~locality:atts.locality ~poly:atts.polymorphic
       instance_name binders instance_t
       ~tac:tactic ~hook:(declare_projection n instance_id)
       Hints.empty_hint_info None

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -590,10 +590,3 @@ let refine_att =
   attribute_of_list ["refine",single_key_parser ~name:"refine" ~key:"refine" ()] >>= function
   | None -> return false
   | Some () -> return true
-
-module Internal =
-struct
-let add_instance cl info glob r =
-  let glob = if glob then SuperGlobal else Local in
-  add_instance cl info glob r
-end

--- a/vernac/classes.mli
+++ b/vernac/classes.mli
@@ -16,8 +16,14 @@ open Libnames
 
 (** Instance declaration *)
 
-val declare_instance : ?warn:bool -> env -> Evd.evar_map ->
-                       hint_info option -> Hints.hint_locality -> GlobRef.t -> unit
+val declare_instance
+  : ?warn:bool
+  -> env
+  -> Evd.evar_map
+  -> hint_info option
+  -> Hints.hint_locality
+  -> GlobRef.t
+  -> unit
 (** Declares the given global reference as an instance of its type.
     Does nothing — or emit a “not-a-class” warning if the [warn] argument is set —
     when said type is not a registered type class. *)
@@ -95,9 +101,3 @@ val id_of_class : typeclass -> Id.t
 val refine_att : bool Attributes.attribute
 
 val instance_locality : Hints.hint_locality Attributes.attribute
-
-(** {6 Low level interface used by Add Morphism, do not use } *)
-module Internal :
-sig
-val add_instance : typeclass -> hint_info -> bool -> GlobRef.t -> unit
-end


### PR DESCRIPTION
We remove an exposed internal function from classes.ml which was intended for use in comRewrite. The use there wasn't really doing much so we use the publicly available declare_instance instead.
