### PR TITLE
Make scope a required argument for do_fixpoint

### DIFF
--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -416,7 +416,7 @@ let register_struct is_rec fixpoint_exprl =
     in
     (None, evd, List.rev rev_pconstants)
   | _ ->
-    ComFixpoint.do_fixpoint ~poly:false fixpoint_exprl;
+    ComFixpoint.do_fixpoint ~scope:Locality.default_scope ~poly:false fixpoint_exprl;
     let evd, rev_pconstants =
       List.fold_left
         (fun (evd, l) {Vernacexpr.fname} ->

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -283,13 +283,13 @@ let declare_fixpoint_interactive_generic ?indexes ~scope ~poly ?typing_flags ((f
   List.iter (Metasyntax.add_notation_interpretation ~local:(scope=Locality.Discharge) (Global.env())) ntns;
   lemma
 
-let declare_fixpoint_generic ?indexes ?scope ~poly ?typing_flags ?using ((fixnames,fixrs,fixdefs,fixtypes),udecl,uctx,fiximps) ntns =
+let declare_fixpoint_generic ?indexes ~scope ~poly ?typing_flags ?using ((fixnames,fixrs,fixdefs,fixtypes),udecl,uctx,fiximps) ntns =
   (* We shortcut the proof process *)
   let fix_kind, cofix, fixitems = build_recthms ~indexes ?using fixnames fixtypes fiximps in
   let fixdefs = List.map Option.get fixdefs in
   let rec_declaration = prepare_recursive_declaration fixnames fixrs fixtypes fixdefs in
   let fix_kind = Decls.IsDefinition fix_kind in
-  let info = Declare.Info.make ?scope ~kind:fix_kind ~poly ~udecl ?typing_flags () in
+  let info = Declare.Info.make ~scope ~kind:fix_kind ~poly ~udecl ?typing_flags () in
   let cinfo = fixitems in
   let _ : GlobRef.t list =
     Declare.declare_mutually_recursive ~cinfo ~info ~opaque:false ~uctx
@@ -334,9 +334,9 @@ let do_fixpoint_interactive ~scope ~poly ?typing_flags l : Declare.Proof.t =
   let lemma = declare_fixpoint_interactive_generic ~indexes:possible_indexes ~scope ~poly ?typing_flags fix ntns in
   lemma
 
-let do_fixpoint ?scope ~poly ?typing_flags ?using l =
+let do_fixpoint ~scope ~poly ?typing_flags ?using l =
   let fixl, ntns, fix, possible_indexes = do_fixpoint_common ?typing_flags l in
-  declare_fixpoint_generic ~indexes:possible_indexes ?scope ~poly ?typing_flags ?using fix ntns
+  declare_fixpoint_generic ~indexes:possible_indexes ~scope ~poly ?typing_flags ?using fix ntns
 
 let do_cofixpoint_common (fixl : Vernacexpr.cofixpoint_expr list) =
   let fixl = List.map (fun fix -> {fix with Vernacexpr.rec_order = None}) fixl in

--- a/vernac/comFixpoint.mli
+++ b/vernac/comFixpoint.mli
@@ -23,15 +23,18 @@ val do_fixpoint_interactive
   -> Declare.Proof.t
 
 val do_fixpoint
-   : ?scope:Locality.definition_scope
+   : scope:Locality.definition_scope
   -> poly:bool
   -> ?typing_flags:Declarations.typing_flags
   -> ?using:Vernacexpr.section_subset_expr
   -> fixpoint_expr list
   -> unit
 
-val do_cofixpoint_interactive :
-  scope:Locality.definition_scope -> poly:bool -> cofixpoint_expr list -> Declare.Proof.t
+val do_cofixpoint_interactive
+  : scope:Locality.definition_scope
+  -> poly:bool
+  -> cofixpoint_expr list
+  -> Declare.Proof.t
 
 val do_cofixpoint
   : scope:Locality.definition_scope


### PR DESCRIPTION
It's better to be explicit about the scope.

We also reformat do_cofixpoint_interactive.
