### PR TITLE
Set the bad-relevance warning default to AsError.

### DIFF
--- a/dev/doc/SProp.md
+++ b/dev/doc/SProp.md
@@ -31,9 +31,6 @@ functions from `Context` (eg `annotR x = make_annot x Relevant`), also
 `mkArrowR` from `Constr`/`EConstr` which has the signature of the old
 `mkArrow`.
 
-You can enable the debug warning `bad-relevance` to help find places
-where you generate incorrect annotations.
-
 Relevance can be inferred from a well-typed term using functions in
 `Retypeops` (for `Constr`) and `Retyping` (for `EConstr`). For `x` a
 term, note the difference between its relevance as a term (is `x :

--- a/doc/changelog/01-kernel/17172-relevance-fix-default-error.rst
+++ b/doc/changelog/01-kernel/17172-relevance-fix-default-error.rst
@@ -1,0 +1,4 @@
+- **Changed:**
+  the `bad-relevance` warning is now an error by default
+  (`#17172 <https://github.com/coq/coq/pull/17172>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/addendum/sprop.rst
+++ b/doc/sphinx/addendum/sprop.rst
@@ -247,7 +247,9 @@ ill-typed terms to the kernel, which will fail with anomalies at `Qed`.
 
 .. warn:: Bad relevance
 
-  This is a developer warning, disabled by default. It is emitted by
-  the kernel when it is passed a term with incorrect relevance marks.
-  To avoid conversion issues you may wish to use
-  it to find when your tactics are producing incorrect marks.
+  This is a developer warning, which is treated as an error by default. It is
+  emitted by the kernel when it is passed a term with incorrect relevance marks.
+  This is always caused by a bug in Coq, which should thus be reported and
+  fixed. In order to allow the user to work around such bugs, we leave the
+  ability to unset the ``bad-relevance`` warning for the time being, so that the
+  kernel will silently repair the proof term instead of failing.

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -63,7 +63,7 @@ type bad_relevance =
 
 let warn_bad_relevance_name = "bad-relevance"
 let warn_bad_relevance =
-  CWarnings.create ~name:warn_bad_relevance_name ~category:"debug" ~default:CWarnings.Disabled
+  CWarnings.create ~name:warn_bad_relevance_name ~category:"debug" ~default:CWarnings.AsError
     Pp.(function
         | BadRelevanceCase _ ->  str "Bad relevance in case annotation."
         | BadRelevanceBinder (_, na) -> str "Bad relevance for binder " ++ Name.print (RelDecl.get_name na) ++ str ".")


### PR DESCRIPTION
This will allow catching more bugs with SProp without impeding the progress of SProp hegemony.