### PR TITLE
Fixing #17173: protect about partially-defined lists of implicit arguments

### DIFF
--- a/doc/changelog/02-specification-language/17174-master+fix17173-protect-partially-defined-implicit-arguments-list.rst
+++ b/doc/changelog/02-specification-language/17174-master+fix17173-protect-partially-defined-implicit-arguments-list.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Possible anomaly when using syntax :g:`term.(proj)` with projections defined in sections
+  (`#17174 <https://github.com/coq/coq/pull/17174>`_,
+  fixes `#17173 <https://github.com/coq/coq/issues/17173>`_,
+  by Hugo Herbelin).

--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -772,6 +772,12 @@ let rec drop_first_implicits p l =
       let n = if is_status_implicit imp then n-1 else n in
       drop_first_implicits (p-1) (LessArgsThan n,impls)
 
+let rec chop_and_adjust n l1 l2 =
+  if n = 0 then (List.rev l1, l2) else
+    match l2 with
+    | [] -> chop_and_adjust (n-1) (None :: l1) []
+    | a::l2 -> chop_and_adjust (n-1) (a :: l1) l2
+
 let rec select_impargs_size n = function
   | [] -> [] (* Tolerance for (DefaultImpArgs,[]) *)
   | [_, impls] | (DefaultImpArgs, impls)::_ -> impls
@@ -785,7 +791,7 @@ let select_stronger_impargs = function
 let select_impargs_size_for_proj ~nexpectedparams ~ngivenparams ~nextraargs impls =
   let split_implicit_params imps =
     if List.is_empty imps then (nexpectedparams, [], []) else
-    let imps1, imps2 = List.chop nexpectedparams imps in
+    let imps1, imps2 = chop_and_adjust nexpectedparams [] imps in
     let imp, imps2 = match imps2 with imp :: imps2 -> [imp],imps2 | _ -> [], [] in
     let nimps1 = nexpectedparams - List.count is_status_implicit imps1 in
     (* Force the main argument to be explicit *)

--- a/test-suite/bugs/bug_17173.v
+++ b/test-suite/bugs/bug_17173.v
@@ -1,0 +1,5 @@
+Section Foo.
+Variable A : Type.
+Inductive I (n:nat) := { it : A }.
+End Foo.
+Fail Check fun x => x.(it). (* expect 2 arguments, shouldn't raise an anomaly *)


### PR DESCRIPTION
The invariant that a list of implicit arguments is either degenerate (empty list, in case there is no implicit arguments at all) or full (in case there is at least one implicit argument) was broken by section discharge. We relax the invariant.

Fixes / closes #17173

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
