### PR TITLE
Remove the only calls to side-effect fiddling variants of build_by_tactic

### DIFF
--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -1167,7 +1167,7 @@ let make_bl_scheme env handle mind =
   let bl_goal = compute_bl_goal env handle (ind,u) lnamesparrec nparrec in
   let bl_goal = EConstr.of_constr bl_goal in
   let poly = Declareops.inductive_is_polymorphic mib in
-  let (ans, _, _, _, uctx) = Declare.build_by_tactic ~poly ~side_eff:false env ~uctx ~typ:bl_goal
+  let (ans, _, _, _, uctx) = Declare.build_by_tactic ~poly env ~uctx ~typ:bl_goal
     (compute_bl_tact handle (ind, EConstr.EInstance.make u) lnamesparrec nparrec)
   in
   ([|ans|], uctx)
@@ -1297,7 +1297,7 @@ let make_lb_scheme env handle mind =
   let lb_goal = compute_lb_goal env handle (ind,u) lnamesparrec nparrec in
   let lb_goal = EConstr.of_constr lb_goal in
   let poly = Declareops.inductive_is_polymorphic mib in
-  let (ans, _, _, _, ctx) = Declare.build_by_tactic ~poly ~side_eff:false env ~uctx ~typ:lb_goal
+  let (ans, _, _, _, ctx) = Declare.build_by_tactic ~poly env ~uctx ~typ:lb_goal
     (compute_lb_tact handle ind lnamesparrec nparrec)
   in
   ([|ans|], ctx)
@@ -1481,7 +1481,7 @@ let make_eq_decidability env handle mind =
   let lnonparrec,lnamesparrec =
     Inductive.inductive_nonrec_rec_paramdecls (mib,u) in
   let poly = Declareops.inductive_is_polymorphic mib in
-  let (ans, _, _, _, ctx) = Declare.build_by_tactic ~poly ~side_eff:false env ~uctx
+  let (ans, _, _, _, ctx) = Declare.build_by_tactic ~poly env ~uctx
       ~typ:(EConstr.of_constr (compute_dec_goal env (ind,u) lnamesparrec nparrec))
       (compute_dec_tact handle (ind,u) lnamesparrec nparrec)
   in

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1792,17 +1792,11 @@ let build_constant_by_tactic ~name ?(opaque=Vernacexpr.Transparent) ~uctx ~sign 
   | _ ->
     CErrors.anomaly Pp.(str "[build_constant_by_tactic] close_proof returned more than one proof term")
 
-let build_by_tactic ?(side_eff=true) env ~uctx ~poly ~typ tac =
+let build_by_tactic env ~uctx ~poly ~typ tac =
   let name = Id.of_string ("temporary_proof"^string_of_int (next())) in
   let sign = Environ.(val_of_named_context (named_context env)) in
   let ce, status, uctx = build_constant_by_tactic ~name ~uctx ~sign ~poly typ tac in
-  let cb, uctx =
-    if side_eff then inline_private_constants ~uctx env ce
-    else
-      (* GG: side effects won't get reset: no need to treat their universes specially *)
-      let (cb, ctx), _eff = ce.proof_entry_body in
-      cb, UState.merge ~sideff:false Evd.univ_rigid uctx ctx
-  in
+  let cb, uctx = inline_private_constants ~uctx env ce in
   cb, ce.proof_entry_type, ce.proof_entry_universes, status, uctx
 
 let declare_abstract ~name ~poly ~kind ~sign ~secsign ~opaque ~solve_tac sigma concl =

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -408,8 +408,7 @@ val check_exists : Id.t -> unit
 
 (** Semantics of this function is a bit dubious, use with care *)
 val build_by_tactic
-  :  ?side_eff:bool
-  -> Environ.env
+  :  Environ.env
   -> uctx:UState.t
   -> poly:bool
   -> typ:EConstr.types


### PR DESCRIPTION
Since we require the subschemes to be already defined in auto_ind_decl, we are guaranteed that the tactic calls cannot generate side-effects.