### PR TITLE
Expose some rel_context_val manipulation APIs in Environ

### DIFF
--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -150,6 +150,11 @@ let env_of_rel n env =
     env_nb_rel = env.env_nb_rel - n
   }
 
+let set_rel_context_val v env =
+  { env with
+    env_rel_context = v;
+    env_nb_rel = Range.length v.env_rel_map; }
+
 (* Named context *)
 
 let push_named_context_val d ctxt =

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -113,6 +113,10 @@ val push_rel         : Constr.rel_declaration -> env -> env
 val push_rel_context : Constr.rel_context -> env -> env
 val push_rec_types   : rec_declaration -> env -> env
 
+val push_rel_context_val : Constr.rel_declaration -> rel_context_val -> rel_context_val
+val set_rel_context_val : rel_context_val -> env -> env
+val empty_rel_context_val : rel_context_val
+
 (** Looks up in the context of local vars referred by indice ([rel_context])
    raises [Not_found] if the index points out of the context *)
 val lookup_rel    : int -> env -> Constr.rel_declaration


### PR DESCRIPTION
Taken from https://github.com/coq/coq/pull/17172 to allow merging the lean-importer overlay before that PR