### PR TITLE
[declare] API for obligation display from Users Interfaces

### DIFF
--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1068,6 +1068,42 @@ module State = struct
 
   let all pm = ProgMap.bindings pm |> List.map (fun (_,v) -> CEphemeron.get v)
   let find m t = ProgMap.find_opt t m |> Option.map CEphemeron.get
+
+  module View = struct
+    module Obl = struct
+      type t =
+        { name : Id.t
+        ; loc : Loc.t option
+        ; status : bool * Evar_kinds.obligation_definition_status
+        ; solved : bool
+        }
+
+      let make (o : Obligation.t) =
+        let { obl_name; obl_location; obl_status; obl_body; _ } = o in
+        { name = obl_name
+        ; loc = fst obl_location
+        ; status = obl_status
+        ; solved = Option.has_some obl_body
+        }
+    end
+
+    type t =
+      { opaque : bool
+      ; remaining : int
+      ; obligations : Obl.t array
+      }
+
+    let make { prg_opaque; prg_obligations; _ } =
+      { opaque = prg_opaque
+      ; remaining = prg_obligations.remaining
+      ; obligations = Array.map Obl.make prg_obligations.obls
+      }
+
+    let make eph = CEphemeron.get eph |> make
+  end
+
+  let view s = Id.Map.map View.make s
+
 end
 
 (* In all cases, the use of the map is read-only so we don't expose the ref *)

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -145,8 +145,29 @@ val declare_mutually_recursive
 (** [save] / [save_admitted] can update obligations state, so we need
    to expose the state here *)
 module OblState : sig
+
   type t
   val empty : t
+
+  module View : sig
+    module Obl : sig
+      type t = private
+        { name : Id.t
+        ; loc : Loc.t option
+        ; status : bool * Evar_kinds.obligation_definition_status
+        ; solved : bool
+        }
+    end
+
+    type t = private
+      { opaque : bool
+      ; remaining : int
+      ; obligations : Obl.t array
+      }
+  end
+
+  val view : t -> View.t Id.Map.t
+
 end
 
 (** [Declare.Proof.t] Construction of constants using interactive proofs. *)


### PR DESCRIPTION
As of today, the only interface to explore obligations is `show_obligations` which is far from optimal for anything not display-based.

We introduce a preliminary view on the obligation state, that UI can use.

This has been tested on https://github.com/ejgallego/coq-lsp/pull/262

Next commits will push the toplevel-specific `show_obligations` code to the command interpretation.

