### PR TITLE
Replace anomaly in ssr `rewrite` by its underlying `refine` error

### DIFF
--- a/test-suite/bugs/bug_16804.v
+++ b/test-suite/bugs/bug_16804.v
@@ -1,0 +1,11 @@
+From Coq Require Import ssreflect.
+Definition f (x : unit) := True.
+Goal exists (x : unit), forall (y : True = f x), True.
+eexists ?[x]. intros.
+Succeed rewrite y.
+Succeed rewrite (y : _).
+Succeed rewrite (y : True = _).
+Succeed rewrite (y : True = f ?x).
+Fail rewrite (y : True = f _).
+Fail rewrite (_ : True = f _).
+Abort.


### PR DESCRIPTION
Fixes #6804
Fixes #17182

Testcases:
```
From Coq Require Import ssreflect.
Definition f (x : unit) := True.
Goal exists (x : unit), forall (y : True = f x), True.
eexists ?[x]. intros.
Succeed rewrite y.
Succeed rewrite (y : _).
Succeed rewrite (y : True = _).
Succeed rewrite (y : True = f ?x).
Fail rewrite (y : True = f _).
Fail rewrite (_ : True = f _).
Abort.
```
Note that the failing commands fail due to a unification problem. This could actually be resolved, by enabling `~with_evars` in `refine_with`. I'm not sure if this is a good idea and what it's ramifications would be.

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.