### PR TITLE
 New API for error registration using tags / polymorphic maps 

### DIFF
--- a/checker/checker.ml
+++ b/checker/checker.ml
@@ -72,7 +72,7 @@ let add_path ~unix_path:dir ~coq_root:coq_dirpath =
 
 let convert_string d =
   try Id.of_string d
-  with CErrors.UserError _ ->
+  with CErrors.CoqError _ ->
     Flags.if_verbose Feedback.msg_warning
       (str "Directory " ++ str d ++ str " cannot be used as a Coq identifier (skipped)");
     raise_notrace Exit
@@ -223,7 +223,7 @@ let guill s = str "\"" ++ str s ++ str "\""
 let explain_exn = function
   | Sys_error msg ->
       hov 0 (anomaly_string () ++ str "uncaught exception Sys_error " ++ guill msg ++ report() )
-  | UserError pps ->
+  | CoqError (UserError, pps) ->
       hov 1 (str "User error: " ++ pps)
   | Out_of_memory ->
       hov 0 (str "Out of memory")

--- a/checker/checker.ml
+++ b/checker/checker.ml
@@ -249,7 +249,7 @@ let explain_exn = function
       else
         mt() in
       hov 0 (str "Error: Universe inconsistency" ++ msg ++ str ".")
-  | TypeError(ctx,te) ->
+  | CoqError (TypeError, (ctx,te)) ->
       hov 0 (str "Type error: " ++
       (match te with
       | UnboundRel i -> str"UnboundRel " ++ int i
@@ -295,7 +295,7 @@ let explain_exn = function
       | BadVariance _ -> str "BadVariance"
       ))
 
-  | InductiveError e ->
+  | CoqError (InductiveError, e) ->
       hov 0 (str "Error related to inductive types")
 (*      let ctx = Check.get_env() in
       hov 0

--- a/checker/checker.ml
+++ b/checker/checker.ml
@@ -241,7 +241,7 @@ let explain_exn = function
       hov 0 (anomaly_string () ++ str "uncaught exception Invalid_argument " ++ guill s ++ report ())
   | Sys.Break ->
     hov 0 (fnl () ++ str "User interrupt.")
-  | UGraph.UniverseInconsistency i ->
+  | CoqError (UGraph.UniverseInconsistency, i) ->
     let msg =
       if CDebug.(get_flag misc) then
         str "." ++ spc() ++

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -61,7 +61,7 @@ let ppwf_paths x = pp (Declareops.pp_wf_paths x)
 
 let get_current_context () =
   try Vernacstate.Declare.get_current_context ()
-  with Vernacstate.Declare.NoCurrentProof ->
+  with CErrors.CoqError (Vernacstate.Declare.NoCurrentProof, ()) ->
     let env = Global.env() in
     Evd.from_env env, env
   [@@ocaml.warning "-3"]

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -772,7 +772,7 @@ let compare_cumulative_instances cv_pb variances u u' sigma =
   match Evd.add_constraints sigma cstrs with
   | sigma ->
     Inl (Evd.add_universe_constraints sigma soft)
-  | exception UGraph.UniverseInconsistency p -> Inr p
+  | exception CoqError (UGraph.UniverseInconsistency, p) -> Inr (p:UGraph.univ_inconsistency)
 
 let compare_constructor_instances evd u u' =
   let open UnivProblem in
@@ -802,7 +802,7 @@ let eq_constr_univs_test ~evd ~extended_evd t u =
     if Sorts.equal s1 s2 then true
     else
       try sigma := add_universe_constraints !sigma UnivProblem.(Set.singleton (UEq (s1, s2))); true
-      with UGraph.UniverseInconsistency _ | UniversesDiffer -> false
+      with CoqError (UGraph.UniverseInconsistency, _) | UniversesDiffer -> false
   in
   let eq_existential eq e1 e2 =
     let eq c1 c2 = eq 0 (EConstr.Unsafe.to_constr c1) (EConstr.Unsafe.to_constr c2) in

--- a/engine/logic_monad.ml
+++ b/engine/logic_monad.ml
@@ -51,10 +51,12 @@ let () = CErrors.register (module struct
     let pp e = CErrors.print e
   end)
 
+let tac_timeout_msg = Pp.str "[Proofview.tclTIMEOUT] Tactic timeout!"
+
 let () = CErrors.register (module struct
     type e = unit
     type _ CErrors.tag += T = Tac_Timeout
-    let pp () = Pp.str "[Proofview.tclTIMEOUT] Tactic timeout!"
+    let pp () = tac_timeout_msg
   end)
 
 (** {6 Non-logical layer} *)

--- a/engine/logic_monad.mli
+++ b/engine/logic_monad.mli
@@ -37,6 +37,8 @@ type _ CErrors.tag += TacticFailure : exn CErrors.tag
 (** This exception is used to signal abortion in [timeout] functions. *)
 type _ CErrors.tag += Tac_Timeout : unit CErrors.tag
 
+val tac_timeout_msg : Pp.t
+
 (** {6 Non-logical layer} *)
 
 (** The non-logical monad is a simple [unit -> 'a] (i/o) monad. The

--- a/engine/logic_monad.mli
+++ b/engine/logic_monad.mli
@@ -27,16 +27,15 @@
     interrupts. Also used in [Proofview] to avoid capturing exception
     from the IO monad ([Proofview] catches errors in its compatibility
     layer, and when lifting goal-level expressions). *)
-exception Exception of exn
-
-(** This exception is used to signal abortion in [timeout] functions. *)
-exception Tac_Timeout
+type _ CErrors.tag += Exception : exn CErrors.tag
 
 (** This exception is used by the tactics to signal failure by lack of
     successes, rather than some other exceptions (like system
     interrupts). *)
-exception TacticFailure of exn
+type _ CErrors.tag += TacticFailure : exn CErrors.tag
 
+(** This exception is used to signal abortion in [timeout] functions. *)
+type _ CErrors.tag += Tac_Timeout : unit CErrors.tag
 
 (** {6 Non-logical layer} *)
 

--- a/engine/namegen.ml
+++ b/engine/namegen.ml
@@ -240,7 +240,7 @@ let mangle_names_prefix =
       (try
          Id.of_string x
        with
-       | CErrors.UserError _ ->
+       | CErrors.(CoqError (UserError, _)) ->
          CErrors.user_err Pp.(str ("Not a valid identifier: \"" ^ x ^ "\"."))
       )
     )

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -190,6 +190,8 @@ module Monad : Monad.S with type +'a t = 'a tactic
     Exception is supposed to be non critical *)
 val tclZERO : ?info:Exninfo.info -> exn -> 'a tactic
 
+val tclERROR : ?info:Exninfo.info -> 'e CErrors.tag -> 'e -> 'a tactic
+
 (** [tclOR t1 t2] behaves like [t1] as long as [t1] succeeds. Whenever
     the successes of [t1] have been depleted and it failed with [e],
     then it behaves as [t2 e]. In other words, [tclOR] inserts a
@@ -222,7 +224,7 @@ val tclONCE : 'a tactic -> 'a tactic
     [tclEXACTLY_ONCE e t] succeeds with the first success of
     [t]. Notice that the choice of [e] is relevant, as the presence of
     further successes may depend on [e] (see {!tclOR}). *)
-exception MoreThanOneSuccess
+type _ CErrors.tag += MoreThanOneSuccess : unit CErrors.tag
 val tclEXACTLY_ONCE : exn -> 'a tactic -> 'a tactic
 
 (** [tclCASE t] splits [t] into its first success and a
@@ -249,7 +251,7 @@ val tclBREAK : (Exninfo.iexn -> Exninfo.iexn option) -> 'a tactic -> 'a tactic
     existing goals, fails with the [nosuchgoal] argument, by default
     raising [NoSuchGoals] (a user error). This exception is caught at
     toplevel with a default message. *)
-exception NoSuchGoals of int
+type _ CErrors.tag += NoSuchGoals : int CErrors.tag
 
 val tclFOCUS : ?nosuchgoal:'a tactic -> int -> int -> 'a tactic -> 'a tactic
 
@@ -291,7 +293,7 @@ val tclTRYFOCUS : int -> int -> unit tactic -> unit tactic
     When the length of the tactic list is not the number of goal,
     raises [SizeMismatch (g,t)] where [g] is the number of available
     goals, and [t] the number of tactics passed. *)
-exception SizeMismatch of int*int
+type _ CErrors.tag += SizeMismatch : (int*int) CErrors.tag
 val tclDISPATCH : unit tactic list -> unit tactic
 val tclDISPATCHL : 'a tactic list -> 'a list tactic
 

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -284,11 +284,11 @@ let drop_weak_constraints =
     ~value:false
 
 let sort_inconsistency cst l r =
-  raise (UGraph.UniverseInconsistency (cst, l, r, None))
+  CErrors.coq_error UGraph.UniverseInconsistency (cst, l, r, None)
 
 let level_inconsistency cst l r =
   let mk u = Sorts.sort_of_univ @@ Universe.make u in
-  raise (UGraph.UniverseInconsistency (cst, mk l, mk r, None))
+  CErrors.coq_error UGraph.UniverseInconsistency (cst, mk l, mk r, None)
 
 let subst_univs_sort normalize qnormalize s = match s with
 | Sorts.Set | Sorts.Prop | Sorts.SProp -> s
@@ -558,7 +558,7 @@ let process_universe_constraints uctx cstrs =
   in
   let unify_universes cst local =
     if not (UGraph.type_in_type univs) then unify_universes cst local
-    else try unify_universes cst local with UGraph.UniverseInconsistency _ -> local
+    else try unify_universes cst local with CoqError (UGraph.UniverseInconsistency, _) -> local
   in
   let local = {
     local_cst = Constraints.empty;

--- a/engine/univGen.mli
+++ b/engine/univGen.mli
@@ -17,9 +17,8 @@ type univ_length_mismatch = {
   actual : int ;
   expect : int ;
 }
-(* Due to an OCaml bug ocaml/ocaml#10027 inlining this record will cause
-compliation with -rectypes to crash. *)
-exception UniverseLengthMismatch of univ_length_mismatch
+
+type _ CErrors.tag += UniverseLengthMismatch : univ_length_mismatch CErrors.tag
 
 (** Side-effecting functions creating new universe levels. *)
 

--- a/engine/univSubst.ml
+++ b/engine/univSubst.ml
@@ -89,42 +89,42 @@ let enforce_eq_sort s1 s2 cst = match s1, s2 with
 | (SProp, SProp) | (Prop, Prop) | (Set, Set) -> cst
 | (((Prop | Set | Type _ | QSort _) as s1), (Prop | SProp as s2))
 | ((Prop | SProp as s1), ((Prop | Set | Type _ | QSort _) as s2)) ->
-  raise (UGraph.UniverseInconsistency (Eq, s1, s2, None))
+  CErrors.coq_error UGraph.UniverseInconsistency (Eq, s1, s2, None)
 | (Set | Type _), (Set | Type _) ->
   enforce_eq (get_algebraic s1) (get_algebraic s2) cst
 | QSort (q1, u1), QSort (q2, u2) ->
   if QVar.equal q1 q2 then enforce_eq u1 u2 cst
-  else raise (UGraph.UniverseInconsistency (Eq, s1, s2, None))
+  else CErrors.coq_error UGraph.UniverseInconsistency (Eq, s1, s2, None)
 | (QSort _, (Set | Type _)) | ((Set | Type _), QSort _) ->
-  raise (UGraph.UniverseInconsistency (Eq, s1, s2, None))
+  CErrors.coq_error UGraph.UniverseInconsistency (Eq, s1, s2, None)
 
 let enforce_leq_sort s1 s2 cst = match s1, s2 with
 | (SProp, SProp) | (Prop, Prop) | (Set, Set) -> cst
 | (Prop, (Set | Type _)) -> cst
 | (((Prop | Set | Type _ | QSort _) as s1), (Prop | SProp as s2))
 | ((SProp as s1), ((Prop | Set | Type _ | QSort _) as s2)) ->
-  raise (UGraph.UniverseInconsistency (Le, s1, s2, None))
+  CErrors.coq_error UGraph.UniverseInconsistency (Le, s1, s2, None)
 | (Set | Type _), (Set | Type _) ->
   enforce_leq (get_algebraic s1) (get_algebraic s2) cst
 | QSort (q1, u1), QSort (q2, u2) ->
   if QVar.equal q1 q2 then enforce_leq u1 u2 cst
-  else raise (UGraph.UniverseInconsistency (Eq, s1, s2, None))
+  else CErrors.coq_error UGraph.UniverseInconsistency (Eq, s1, s2, None)
 | (QSort _, (Set | Type _)) | ((Prop | Set | Type _), QSort _) ->
-  raise (UGraph.UniverseInconsistency (Eq, s1, s2, None))
+  CErrors.coq_error UGraph.UniverseInconsistency (Eq, s1, s2, None)
 
 let enforce_leq_alg_sort s1 s2 g = match s1, s2 with
 | (SProp, SProp) | (Prop, Prop) | (Set, Set) -> Constraints.empty, g
 | (Prop, (Set | Type _)) -> Constraints.empty, g
 | (((Prop | Set | Type _ | QSort _) as s1), (Prop | SProp as s2))
 | ((SProp as s1), ((Prop | Set | Type _ | QSort _) as s2)) ->
-  raise (UGraph.UniverseInconsistency (Le, s1, s2, None))
+  CErrors.coq_error UGraph.UniverseInconsistency (Le, s1, s2, None)
 | (Set | Type _), (Set | Type _) ->
   UGraph.enforce_leq_alg (get_algebraic s1) (get_algebraic s2) g
 | QSort (q1, u1), QSort (q2, u2) ->
   if QVar.equal q1 q2 then UGraph.enforce_leq_alg u1 u2 g
-  else raise (UGraph.UniverseInconsistency (Eq, s1, s2, None))
+  else CErrors.coq_error UGraph.UniverseInconsistency (Eq, s1, s2, None)
 | (QSort _, (Set | Type _)) | ((Prop | Set | Type _), QSort _) ->
-  raise (UGraph.UniverseInconsistency (Eq, s1, s2, None))
+  CErrors.coq_error UGraph.UniverseInconsistency (Eq, s1, s2, None)
 
 let enforce_univ_constraint (u,d,v) =
   match d with

--- a/gramlib/grammar.mli
+++ b/gramlib/grammar.mli
@@ -173,3 +173,5 @@ module GMake (L : Plexing.S) : ExtS
   with type keyword_state := L.keyword_state
    and type te := L.te
    and type 'c pattern := 'c L.pattern
+
+type _ CErrors.tag += Error : string CErrors.tag

--- a/gramlib/stream.ml
+++ b/gramlib/stream.ml
@@ -24,7 +24,6 @@ and buffio =
   { ic : in_channel; buff : bytes; mutable len : int; mutable ind : int }
 
 exception Failure
-exception Error of string
 
 let count { count } = count
 

--- a/gramlib/stream.mli
+++ b/gramlib/stream.mli
@@ -23,7 +23,7 @@ exception Failure
 (** Raised by parsers when none of the first components of the stream
    patterns is accepted. *)
 
-exception Error of string
+(* exception Error of string *)
 (** Raised by parsers when the first component of a stream pattern is
    accepted, but one of the following components is rejected. *)
 

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -259,7 +259,7 @@ let subgoals flags =
          Some (export_pre_goals flags Proof.(data newp) (process_goal short)))
     end else
       Some (export_pre_goals flags Proof.(data newp) (process_goal short))
-  with Vernacstate.Declare.NoCurrentProof -> None
+  with CErrors.CoqError (Vernacstate.Declare.NoCurrentProof, ()) -> None
   [@@ocaml.warning "-3"]
 
 let goals () =
@@ -277,7 +277,7 @@ let evars () =
     let map_evar ev = { Interface.evar_info = string_of_ppcmds (pr_evar sigma ev); } in
     let el = List.map map_evar exl in
     Some el
-  with Vernacstate.Declare.NoCurrentProof -> None
+  with CErrors.CoqError (Vernacstate.Declare.NoCurrentProof, ()) -> None
   [@@ocaml.warning "-3"]
 
 let hints () =
@@ -291,7 +291,7 @@ let hints () =
       let get_hint_hyp env d accu = hyp_next_tac sigma env d :: accu in
       let hint_hyps = List.rev (Environ.fold_named_context get_hint_hyp env ~init: []) in
       Some (hint_hyps, concl_next_tac)
-  with Vernacstate.Declare.NoCurrentProof -> None
+  with CErrors.CoqError (Vernacstate.Declare.NoCurrentProof, ()) -> None
   [@@ocaml.warning "-3"]
 
 (** Other API calls *)
@@ -313,7 +313,7 @@ let status force =
   in
   let proof =
     try Some (Names.Id.to_string (Vernacstate.Declare.get_current_proof_name ()))
-    with Vernacstate.Declare.NoCurrentProof -> None
+    with CErrors.CoqError (Vernacstate.Declare.NoCurrentProof, ()) -> None
   in
   let allproofs =
     let l = Vernacstate.Declare.get_all_proof_names () in

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -574,7 +574,7 @@ let split_at_annot bl na =
         else
           aux (x :: acc) rest
       | CLocalPattern _ :: rest ->
-        Loc.raise ?loc (Gramlib.Stream.Error "pattern with quote not allowed after fix")
+        CErrors.coq_error ?loc Gramlib.Grammar.Error "pattern with quote not allowed after fix"
       | [] ->
         CErrors.user_err ?loc
           (str "No parameter named " ++ Id.print id ++ str".")

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -912,7 +912,7 @@ let instantiate_notation_constr loc intern intern_pat ntnvars subst infos c =
           try
             let gc = intern nenv c in
             Id.Map.add id (gc, None) map
-          with Nametab.GlobalizationError _ -> map
+          with CoqError (Nametab.GlobalizationError, _) -> map
         in
         let mk_env' ((c,_bk), (onlyident,(tmp_scope,subscopes))) =
           let nenv = {env with tmp_scope; scopes = subscopes @ env.scopes} in
@@ -2846,7 +2846,7 @@ let interp_univ_constraints env evd cstrs =
     try
       let evd = Evd.add_constraints evd (Univ.Constraints.singleton cstr) in
       evd, Univ.Constraints.add cstr cstrs
-    with UGraph.UniverseInconsistency e as exn ->
+    with CoqError (UGraph.UniverseInconsistency, e) as exn ->
       let _, info = Exninfo.capture exn in
       CErrors.user_err ~info
         (UGraph.explain_universe_inconsistency (Termops.pr_evd_level evd) e)

--- a/interp/modintern.ml
+++ b/interp/modintern.ml
@@ -20,7 +20,7 @@ type module_internalization_error =
   | IncorrectWithInModule
   | IncorrectModuleApplication
 
-exception ModuleInternalizationError of module_internalization_error
+type _ CErrors.tag += ModuleInternalizationError : module_internalization_error CErrors.tag
 
 type module_kind = Module | ModType | ModAny
 
@@ -33,13 +33,13 @@ let error_not_a_module_loc ~info kind loc qid =
     | ModAny -> NotAModuleNorModtype qid
   in
   let info = Option.cata (Loc.add_loc info) info loc in
-  Exninfo.iraise (ModuleInternalizationError e,info)
+  Exninfo.iraise (CErrors.CoqError (ModuleInternalizationError, e),info)
 
 let error_incorrect_with_in_module loc =
-  Loc.raise ?loc (ModuleInternalizationError IncorrectWithInModule)
+  CErrors.coq_error ?loc ModuleInternalizationError IncorrectWithInModule
 
 let error_application_to_module_type loc =
-  Loc.raise ?loc (ModuleInternalizationError IncorrectModuleApplication)
+  CErrors.coq_error ?loc ModuleInternalizationError IncorrectModuleApplication
 
 (** Searching for a module name in the Nametab.
 

--- a/interp/modintern.mli
+++ b/interp/modintern.mli
@@ -23,7 +23,7 @@ type module_internalization_error =
   | IncorrectWithInModule
   | IncorrectModuleApplication
 
-exception ModuleInternalizationError of module_internalization_error
+type _ CErrors.tag += ModuleInternalizationError : module_internalization_error CErrors.tag
 
 (** Module expressions and module types are interpreted relatively to
    possible functor or functor signature arguments. When the input kind

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -681,7 +681,7 @@ let uninterp to_raw o n =
     let c = if snd o.of_kind == Direct then c else uninterp_option c in
     Some (to_raw (fst o.of_kind, c))
   with
-  | CoqError (Type_errors.TypeError, _) | Pretype_errors.PretypeError _ -> None (* cf. eval_constr_app *)
+  | CoqError ((Type_errors.TypeError | Pretype_errors.PretypeError), _) -> None (* cf. eval_constr_app *)
   | NotAValidPrimToken -> None (* all other functions except NumTok.Signed.of_bigint *)
 
 end

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -681,7 +681,7 @@ let uninterp to_raw o n =
     let c = if snd o.of_kind == Direct then c else uninterp_option c in
     Some (to_raw (fst o.of_kind, c))
   with
-  | Type_errors.TypeError _ | Pretype_errors.PretypeError _ -> None (* cf. eval_constr_app *)
+  | CoqError (Type_errors.TypeError, _) | Pretype_errors.PretypeError _ -> None (* cf. eval_constr_app *)
   | NotAValidPrimToken -> None (* all other functions except NumTok.Signed.of_bigint *)
 
 end

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -110,11 +110,13 @@ val register_string_interpretation :
 
 (** * Number notation *)
 
-type prim_token_notation_error =
-  | UnexpectedTerm of Constr.t
-  | UnexpectedNonOptionTerm of Constr.t
+type prim_token_notation_error
 
-exception PrimTokenNotationError of string * Environ.env * Evd.evar_map * prim_token_notation_error
+val explain_prim_token_notation_error
+  : (Environ.env -> Evd.evar_map -> Constr.t -> Pp.t)
+  -> prim_token_notation_error -> Pp.t
+
+type _ CErrors.tag += PrimTokenNotationError : prim_token_notation_error CErrors.tag
 
 type numnot_option =
   | Nop

--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -32,7 +32,7 @@ let check_constructors_names =
     | [] -> idset
     | c::cl ->
         if Id.Set.mem c idset then
-          raise (InductiveError (SameNamesConstructors c))
+          CErrors.coq_error InductiveError (SameNamesConstructors c)
         else
           check (Id.Set.add c idset) cl
   in
@@ -49,7 +49,7 @@ let mind_check_names mie =
         let id = ind.mind_entry_typename in
         let cl = ind.mind_entry_consnames in
         if Id.Set.mem id indset then
-          raise (InductiveError (SameNamesTypes id))
+          CErrors.coq_error InductiveError (SameNamesTypes id)
         else
           let cstset' = check_constructors_names cstset cl in
           check (Id.Set.add id indset) cstset' inds
@@ -248,7 +248,7 @@ let get_template univs ~env_params ~env_ar_par ~params entries =
 
 let abstract_packets usubst ((arity,lc),(indices,splayed_lc),univ_info) =
   if not (List.is_empty univ_info.missing)
-  then raise (InductiveError (MissingConstraints (univ_info.missing,univ_info.ind_univ)));
+  then CErrors.coq_error InductiveError (MissingConstraints (univ_info.missing,univ_info.ind_univ));
   let arity = Vars.subst_univs_level_constr usubst arity in
   let lc = Array.map (Vars.subst_univs_level_constr usubst) lc in
   let indices = Vars.subst_univs_level_context usubst indices in

--- a/kernel/indtypes.ml
+++ b/kernel/indtypes.ml
@@ -49,7 +49,7 @@ let weaker_noccur_between env x nvars t =
 (************************************************************************)
 (* Various well-formedness check for inductive declarations            *)
 
-exception InductiveError = Type_errors.InductiveError
+let inderror e = CErrors.coq_error Type_errors.InductiveError e
 
 (************************************************************************)
 (************************************************************************)
@@ -74,18 +74,15 @@ let explain_ind_err id ntyp env nparamsctxt c err =
   let (_lparams,c') = mind_extract_params nparamsctxt c in
   match err with
     | LocalNonPos kt ->
-        raise (InductiveError (NonPos (env,c',mkRel (kt+nparamsctxt))))
+        inderror (NonPos (env,c',mkRel (kt+nparamsctxt)))
     | LocalNotEnoughArgs kt ->
-        raise (InductiveError
-                 (NotEnoughArgs (env,c',mkRel (kt+nparamsctxt))))
+        inderror (NotEnoughArgs (env,c',mkRel (kt+nparamsctxt)))
     | LocalNotConstructor (paramsctxt,nargs)->
         let nparams = Context.Rel.nhyps paramsctxt in
-        raise (InductiveError
-                 (NotConstructor (env,id,c',mkRel (ntyp+nparamsctxt),
-                                  nparams,nargs)))
+        inderror (NotConstructor (env,id,c',mkRel (ntyp+nparamsctxt),
+                                  nparams,nargs))
     | LocalNonPar (n,i,l) ->
-        raise (InductiveError
-                 (NonPar (env,c',n,mkRel i,mkRel (l+nparamsctxt))))
+        inderror (NonPar (env,c',n,mkRel i,mkRel (l+nparamsctxt)))
 
 let failwith_non_pos n ntypes c =
   for k = n to n + ntypes - 1 do
@@ -328,7 +325,7 @@ let check_positivity_one ~chkpos recursive (env,_,ntypes,_ as ienv) paramsctxt (
           | Prod (na,b,d) ->
               let () = assert (List.is_empty largs) in
               if not recursive && not (noccur_between n ntypes b) then
-                raise (InductiveError Type_errors.BadEntry);
+                inderror Type_errors.BadEntry;
               let nmr',recarg = check_strict_positivity ienv nmr b in
               let ienv' = ienv_push_var ienv (na,b,mk_norec) in
                 check_constr_rec ienv' nmr' (recarg::lrec) d
@@ -371,7 +368,7 @@ let check_positivity_one ~chkpos recursive (env,_,ntypes,_ as ienv) paramsctxt (
 let check_positivity ~chkpos kn names env_ar_par paramsctxt finite inds =
   let ntypes = Array.length inds in
   let recursive = finite != BiFinite in
-  if not recursive && Array.length inds <> 1 then raise (InductiveError Type_errors.BadEntry);
+  if not recursive && Array.length inds <> 1 then inderror Type_errors.BadEntry;
   let rc = Array.mapi (fun j t -> (Mrec (kn,j),t)) (Rtree.mk_rec_calls ntypes) in
   let ra_env_ar = Array.rev_to_list rc in
   let nparamsctxt = Context.Rel.length paramsctxt in

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -434,7 +434,7 @@ let check_case_info env (indsp,u) r ci =
     not (Array.equal Int.equal mip.mind_consnrealargs ci.ci_cstr_nargs) ||
     not (ci.ci_relevance == r) ||
     is_primitive_record spec
-  then raise (TypeError(env,WrongCaseInfo((indsp,u),ci)))
+  then CErrors.coq_error TypeError (env,WrongCaseInfo((indsp,u),ci))
 
 
 (************************************************************************)

--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -67,46 +67,48 @@ type module_typing_error =
   | LabelMissing of Label.t * string
   | IncludeRestrictedFunctor of ModPath.t
 
-exception ModuleTypingError of module_typing_error
+type _ CErrors.tag += ModuleTypingError : module_typing_error CErrors.tag
+
+let raise e = CErrors.coq_error ModuleTypingError e
 
 let error_existing_label l =
-  raise (ModuleTypingError (LabelAlreadyDeclared l))
+  raise (LabelAlreadyDeclared l)
 
 let error_not_a_functor () =
-  raise (ModuleTypingError NotAFunctor)
+  raise NotAFunctor
 
 let error_is_a_functor mp =
-  raise (ModuleTypingError (IsAFunctor mp))
+  raise (IsAFunctor mp)
 
 let error_incompatible_modtypes mexpr1 mexpr2 =
-  raise (ModuleTypingError (IncompatibleModuleTypes (mexpr1,mexpr2)))
+  raise (IncompatibleModuleTypes (mexpr1,mexpr2))
 
 let error_not_equal_modpaths mp1 mp2 =
-  raise (ModuleTypingError (NotEqualModulePaths (mp1,mp2)))
+  raise (NotEqualModulePaths (mp1,mp2))
 
 let error_signature_mismatch l spec why =
-  raise (ModuleTypingError (SignatureMismatch (l,spec,why)))
+  raise (SignatureMismatch (l,spec,why))
 
 let error_no_such_label l mp =
-  raise (ModuleTypingError (NoSuchLabel (l,mp)))
+  raise (NoSuchLabel (l,mp))
 
 let error_not_a_module_label s =
-  raise (ModuleTypingError (NotAModuleLabel s))
+  raise (NotAModuleLabel s)
 
 let error_not_a_constant l =
-  raise (ModuleTypingError (NotAConstant l))
+  raise (NotAConstant l)
 
 let error_incorrect_with_constraint l =
-  raise (ModuleTypingError (IncorrectWithConstraint l))
+  raise (IncorrectWithConstraint l)
 
 let error_generative_module_expected l =
-  raise (ModuleTypingError (GenerativeModuleExpected l))
+  raise (GenerativeModuleExpected l)
 
 let error_no_such_label_sub l l1 =
-  raise (ModuleTypingError (LabelMissing (l,l1)))
+  raise (LabelMissing (l,l1))
 
 let error_include_restricted_functor mp =
-  raise (ModuleTypingError (IncludeRestrictedFunctor mp))
+  raise (IncludeRestrictedFunctor mp)
 
 (** {6 Operations on functors } *)
 

--- a/kernel/modops.mli
+++ b/kernel/modops.mli
@@ -131,7 +131,7 @@ type module_typing_error =
   | LabelMissing of Label.t * string
   | IncludeRestrictedFunctor of ModPath.t
 
-exception ModuleTypingError of module_typing_error
+type _ CErrors.tag += ModuleTypingError : module_typing_error CErrors.tag
 
 val error_existing_label : Label.t -> 'a
 

--- a/kernel/primred.ml
+++ b/kernel/primred.ml
@@ -9,15 +9,17 @@ type _ action_kind =
   | IncompatTypes : _ prim_type -> Constant.t action_kind
   | IncompatInd : _ prim_ind -> inductive action_kind
 
-type exn += IncompatibleDeclarations : 'a action_kind * 'a * 'a -> exn
+type incompatible_decl_error = Incompatible : 'a action_kind * 'a * 'a -> incompatible_decl_error
+
+type _ CErrors.tag += IncompatibleDeclarations : incompatible_decl_error CErrors.tag
 
 let check_same_types typ c1 c2 =
   if not (Constant.CanOrd.equal c1 c2)
-  then raise (IncompatibleDeclarations (IncompatTypes typ, c1, c2))
+  then CErrors.coq_error IncompatibleDeclarations (Incompatible (IncompatTypes typ, c1, c2))
 
 let check_same_inds ind i1 i2 =
   if not (Ind.CanOrd.equal i1 i2)
-  then raise (IncompatibleDeclarations (IncompatInd ind, i1, i2))
+  then CErrors.coq_error IncompatibleDeclarations (Incompatible (IncompatInd ind, i1, i2))
 
 let add_retroknowledge retro action =
   match action with

--- a/kernel/primred.mli
+++ b/kernel/primred.mli
@@ -6,9 +6,11 @@ type _ action_kind =
   | IncompatTypes : _ CPrimitives.prim_type -> Constant.t action_kind
   | IncompatInd : _ CPrimitives.prim_ind -> inductive action_kind
 
-type exn += IncompatibleDeclarations : 'a action_kind * 'a * 'a -> exn
+type incompatible_decl_error = Incompatible : 'a action_kind * 'a * 'a -> incompatible_decl_error
 
-(** May raise [IncomtibleDeclarations] *)
+type _ CErrors.tag += IncompatibleDeclarations : incompatible_decl_error CErrors.tag
+
+(** May raise [IncompatibleDeclarations] *)
 val add_retroknowledge : env -> Retroknowledge.action -> env
 
 val get_int_type : env -> Constant.t

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -418,7 +418,7 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
          let cuniv = conv_table_key infos.cnv_inf ~nargs fl1 fl2 cuniv in
          let () = if irr_flex (info_env infos.cnv_inf) fl1 then raise NotConvertible (* trigger the fallback *) in
          convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
-       with NotConvertible | UGraph.UniverseInconsistency _ ->
+       with NotConvertible | CErrors.CoqError (UGraph.UniverseInconsistency, _) ->
         let r1 = unfold_ref_with_args infos.cnv_inf infos.lft_tab fl1 v1 in
         let r2 = unfold_ref_with_args infos.cnv_inf infos.rgt_tab fl2 v2 in
         match r1, r2 with

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -92,7 +92,7 @@ let check_conv_error error why state poly pb env a1 a2 =
     else
       Reduction.generic_conv pb ~l2r:false default_evar_handler TransparentState.full env state a1 a2
   with NotConvertible -> error why
-     | UGraph.UniverseInconsistency e -> error (IncompatibleUniverses e)
+     | CErrors.CoqError (UGraph.UniverseInconsistency, e) -> error (IncompatibleUniverses e)
 
 let check_universes error env u1 u2 =
   match u1, u2 with

--- a/kernel/type_errors.ml
+++ b/kernel/type_errors.ml
@@ -76,7 +76,7 @@ type ('constr, 'types) ptype_error =
 
 type type_error = (constr, types) ptype_error
 
-exception TypeError of env * type_error
+type _ CErrors.tag += TypeError : (env * type_error) CErrors.tag
 
 type inductive_error =
   | NonPos of env * constr * constr
@@ -91,76 +91,78 @@ type inductive_error =
   | LargeNonPropInductiveNotInType
   | MissingConstraints of (Sorts.t list * Sorts.t)
 
-exception InductiveError of inductive_error
+type _ CErrors.tag += InductiveError : inductive_error CErrors.tag
+
+let raise e = raise (CErrors.CoqError (TypeError, e))
 
 let error_unbound_rel env n =
-  raise (TypeError (env, UnboundRel n))
+  raise (env, UnboundRel n)
 
 let error_unbound_var env v =
-  raise (TypeError (env, UnboundVar v))
+  raise (env, UnboundVar v)
 
 let error_not_type env j =
-  raise (TypeError (env, NotAType j))
+  raise (env, NotAType j)
 
 let error_assumption env j =
-  raise (TypeError (env, BadAssumption j))
+  raise (env, BadAssumption j)
 
 let error_reference_variables env id c =
-  raise (TypeError (env, ReferenceVariables (id,c)))
+  raise (env, ReferenceVariables (id,c))
 
 let error_elim_arity env ind c okinds =
-  raise (TypeError (env, ElimArity (ind, c, okinds)))
+  raise (env, ElimArity (ind, c, okinds))
 
 let error_case_not_inductive env j =
-  raise (TypeError (env, CaseNotInductive j))
+  raise (env, CaseNotInductive j)
 
 let error_number_branches env cj expn =
-  raise (TypeError (env, NumberBranches (cj, expn)))
+  raise (env, NumberBranches (cj, expn))
 
 let error_ill_formed_branch env c i actty expty =
-  raise (TypeError (env, IllFormedBranch (c, i, actty, expty)))
+  raise (env, IllFormedBranch (c, i, actty, expty))
 
 let error_generalization env nvar c =
-  raise (TypeError (env, Generalization (nvar,c)))
+  raise (env, Generalization (nvar,c))
 
 let error_actual_type env j expty =
-  raise (TypeError (env, ActualType (j,expty)))
+  raise (env, ActualType (j,expty))
 
 let error_incorrect_primitive env p t =
-  raise (TypeError (env, IncorrectPrimitive (p, t)))
+  raise (env, IncorrectPrimitive (p, t))
 
 let error_cant_apply_not_functional env rator randl =
-  raise (TypeError (env, CantApplyNonFunctional (rator,randl)))
+  raise (env, CantApplyNonFunctional (rator,randl))
 
 let error_cant_apply_bad_type env t rator randl =
-  raise (TypeError (env, CantApplyBadType (t,rator,randl)))
+  raise (env, CantApplyBadType (t,rator,randl))
 
 let error_ill_formed_rec_body env why lna i fixenv vdefj =
-  raise (TypeError (env, IllFormedRecBody (why,lna,i,fixenv,vdefj)))
+  raise (env, IllFormedRecBody (why,lna,i,fixenv,vdefj))
 
 let error_ill_typed_rec_body env i lna vdefj vargs =
-  raise (TypeError (env, IllTypedRecBody (i,lna,vdefj,vargs)))
+  raise (env, IllTypedRecBody (i,lna,vdefj,vargs))
 
 let error_unsatisfied_constraints env c =
-  raise (TypeError (env, UnsatisfiedConstraints c))
+  raise (env, UnsatisfiedConstraints c)
 
 let error_undeclared_universe env l =
-  raise (TypeError (env, UndeclaredUniverse l))
+  raise (env, UndeclaredUniverse l)
 
 let error_disallowed_sprop env =
-  raise (TypeError (env, DisallowedSProp))
+  raise (env, DisallowedSProp)
 
 let error_bad_binder_relevance env rlv decl =
-  raise (TypeError (env, BadBinderRelevance (rlv, decl)))
+  raise (env, BadBinderRelevance (rlv, decl))
 
 let error_bad_case_relevance env rlv case =
-  raise (TypeError (env, BadCaseRelevance (rlv, mkCase case)))
+  raise (env, BadCaseRelevance (rlv, mkCase case))
 
 let error_bad_invert env =
-  raise (TypeError (env, BadInvert))
+  raise (env, BadInvert)
 
 let error_bad_variance env ~lev ~expected ~actual =
-  raise (TypeError (env, BadVariance {lev;expected;actual}))
+  raise (env, BadVariance {lev;expected;actual})
 
 let map_pfix_guard_error f = function
 | NotEnoughAbstractionInFixBody -> NotEnoughAbstractionInFixBody

--- a/kernel/type_errors.mli
+++ b/kernel/type_errors.mli
@@ -78,7 +78,7 @@ type ('constr, 'types) ptype_error =
 
 type type_error = (constr, types) ptype_error
 
-exception TypeError of env * type_error
+type _ CErrors.tag += TypeError : (env * type_error) CErrors.tag
 
 (** The different kinds of errors that may result of a malformed inductive
     definition. *)
@@ -96,7 +96,7 @@ type inductive_error =
   | MissingConstraints of (Sorts.t list * Sorts.t)
   (* each universe in the set should have been <= the other one *)
 
-exception InductiveError of inductive_error
+type _ CErrors.tag += InductiveError : inductive_error CErrors.tag
 
 (** Raising functions *)
 

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -54,7 +54,7 @@ let infer_assumption env t ty =
   try
     let s = check_type env t ty in
     Sorts.relevance_of_sort s
-  with TypeError _ ->
+  with CoqError (TypeError, _) ->
     error_assumption env (make_judge t ty)
 
 type bad_relevance =

--- a/kernel/uGraph.ml
+++ b/kernel/uGraph.ml
@@ -36,7 +36,7 @@ type explanation = G.explanation Lazy.t
 
 type univ_inconsistency = constraint_type * Sorts.t * Sorts.t * explanation option
 
-exception UniverseInconsistency of univ_inconsistency
+type _ CErrors.tag += UniverseInconsistency : univ_inconsistency CErrors.tag
 
 type 'a check_function = t -> 'a -> 'a -> bool
 
@@ -97,7 +97,7 @@ let enforce_constraint cst g = match enforce_constraint0 cst g with
     let (u, c, v) = cst in
     let e = lazy (G.get_explanation cst g.graph) in
     let mk u = Sorts.sort_of_univ @@ Universe.make u in
-    raise (UniverseInconsistency (c, mk u, mk v, Some e))
+    CErrors.coq_error UniverseInconsistency (c, mk u, mk v, Some e)
   else g
 | Some g -> g
 
@@ -146,8 +146,7 @@ let enforce_leq_alg u v g =
   | Inr ((u, c, v), g) ->
     let e = lazy (G.get_explanation (u, c, v) g.graph) in
     let mk u = Sorts.sort_of_univ @@ Universe.make u in
-    let e = UniverseInconsistency (c, mk u, mk v, Some e) in
-    raise e
+    CErrors.coq_error UniverseInconsistency (c, mk u, mk v, Some e)
 
 module Bound =
 struct

--- a/kernel/uGraph.mli
+++ b/kernel/uGraph.mli
@@ -47,7 +47,7 @@ type explanation
 
 type univ_inconsistency = constraint_type * Sorts.t * Sorts.t * explanation option
 
-exception UniverseInconsistency of univ_inconsistency
+type _ CErrors.tag += UniverseInconsistency : univ_inconsistency CErrors.tag
 
 val enforce_constraint : univ_constraint -> t -> t
 

--- a/lib/cErrors.ml
+++ b/lib/cErrors.ml
@@ -30,8 +30,6 @@ let anomaly ?loc ?info ?label pp =
   let info = Option.cata (Loc.add_loc info) info loc in
   Exninfo.iraise (Anomaly (label, pp), info)
 
-exception Timeout = Control.Timeout
-
 (** Only anomalies should reach the bottom of the handler stack.
     In usual situation, the [handle_stack] is treated as it if was always
     non-empty with [print_anomaly] as its bottom handler. *)

--- a/lib/cErrors.ml
+++ b/lib/cErrors.ml
@@ -97,7 +97,7 @@ let register_handler h = handle_stack := h::!handle_stack
 (* Keep in sync with print_gen below *)
 let is_handled e =
   match e with
-  | CoqError (e, _) -> EMap.mem e !handlers
+  | CoqError (e, _) -> true
 
   (* Exceptions not defined by Coq *)
   | Sys_error _ -> true

--- a/lib/cErrors.mli
+++ b/lib/cErrors.mli
@@ -38,8 +38,6 @@ val user_err : ?loc:Loc.t -> ?info:Exninfo.info -> Pp.t -> 'a
 (** Main error raising primitive. [user_err ?loc pp] signals an
     error [pp] with optional header and location [loc] *)
 
-exception Timeout
-
 (** [register_handler h] registers [h] as a handler.
     When an expression is printed with [print e], it
     goes through all registered handles (the most

--- a/lib/cErrors.mli
+++ b/lib/cErrors.mli
@@ -30,19 +30,19 @@ val is_anomaly : exn -> bool
     This is mostly provided for compatibility. Please avoid doing specific
     tricks with anomalies thanks to it. See rather [noncritical] below. *)
 
-exception UserError of Pp.t
-
 type _ tag = ..
 
 type exn += CoqError : 'e tag * 'e -> exn
+
+type _ tag += UserError : Pp.t tag
+(** Main error signaling exception.*)
 
 val coq_error : ?loc:Loc.t -> ?info:Exninfo.info -> 'e tag -> 'e -> 'a
 (** Main error raising primitive. [coq_error ?loc e v] signals an
     error [e] with payload [v] and location [loc]. *)
 
 val user_err : ?loc:Loc.t -> ?info:Exninfo.info -> Pp.t -> 'a
-(** Main error raising primitive. [user_err ?loc pp] signals an
-    error [pp] with optional header and location [loc] *)
+(** Raise a generic UserError. *)
 
 (** [register_handler h] registers [h] as a handler.
     When an expression is printed with [print e], it

--- a/lib/cErrors.mli
+++ b/lib/cErrors.mli
@@ -31,8 +31,14 @@ val is_anomaly : exn -> bool
     tricks with anomalies thanks to it. See rather [noncritical] below. *)
 
 exception UserError of Pp.t
-(** Main error signaling exception. It carries a header plus a pretty printing
-    doc *)
+
+type _ tag = ..
+
+type exn += CoqError : 'e tag * 'e -> exn
+
+val coq_error : ?loc:Loc.t -> ?info:Exninfo.info -> 'e tag -> 'e -> 'a
+(** Main error raising primitive. [coq_error ?loc e v] signals an
+    error [e] with payload [v] and location [loc]. *)
 
 val user_err : ?loc:Loc.t -> ?info:Exninfo.info -> Pp.t -> 'a
 (** Main error raising primitive. [user_err ?loc pp] signals an
@@ -50,6 +56,15 @@ val user_err : ?loc:Loc.t -> ?info:Exninfo.info -> Pp.t -> 'a
     Exceptions that are considered anomalies should not be
     handled by registered handlers.
 *)
+
+module type Register = sig
+  type e
+  type _ tag += T : e tag
+  val pp : e -> Pp.t
+end
+
+
+val register : (module Register) -> unit
 
 val register_handler : (exn -> Pp.t option) -> unit
 

--- a/library/nametab.mli
+++ b/library/nametab.mli
@@ -85,7 +85,7 @@ module GlobDirRef : sig
   val equal : t -> t -> bool
 end
 
-exception GlobalizationError of qualid
+type _ CErrors.tag += GlobalizationError : qualid CErrors.tag
 
 (** Raises a globalization error *)
 val error_global_not_found : info:Exninfo.info -> qualid -> 'a

--- a/parsing/cLexer.mli
+++ b/parsing/cLexer.mli
@@ -77,8 +77,7 @@ module Lexer :
 
 module Error : sig
   type t
-  exception E of t
-  val to_string : t -> string
+  type _ CErrors.tag += E : t CErrors.tag
 end
 
 (** LexerDiff ensures that, ignoring white space, the concatenated

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -582,7 +582,8 @@ let f_equal =
       | _ -> Proofview.tclUNIT ()
       end
       begin function (e, info) -> match e with
-        | Pretype_errors.PretypeError _ | Type_errors.TypeError _ -> Proofview.tclUNIT ()
+        | Pretype_errors.PretypeError _ | CErrors.CoqError (Type_errors.TypeError, _) ->
+          Proofview.tclUNIT ()
         | e -> Proofview.tclZERO ~info e
       end
   end

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -582,7 +582,7 @@ let f_equal =
       | _ -> Proofview.tclUNIT ()
       end
       begin function (e, info) -> match e with
-        | Pretype_errors.PretypeError _ | CErrors.CoqError (Type_errors.TypeError, _) ->
+        | CErrors.CoqError ((Pretype_errors.PretypeError | Type_errors.TypeError), _) ->
           Proofview.tclUNIT ()
         | e -> Proofview.tclZERO ~info e
       end

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -586,7 +586,7 @@ let rec locate_ref = function
       let mpo = try Some (Nametab.locate_module qid) with Not_found -> None
       and ro =
         try Some (Smartlocate.global_with_alias qid)
-        with Nametab.GlobalizationError _ | CoqError (UserError, _) -> None
+        with CoqError ((Nametab.GlobalizationError | UserError), _) -> None
       in
       match mpo, ro with
         | None, None -> Nametab.error_global_not_found ~info:Exninfo.null qid

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -440,7 +440,7 @@ let mono_filename f =
           if lang () != Haskell then default_id
           else
             try Id.of_string (Filename.basename f)
-            with UserError _ ->
+            with CoqError (UserError, _) ->
               user_err Pp.(str "Extraction: provided filename is not a valid identifier")
         in
         Some (f^d.file_suffix), Option.map ((^) f) d.sig_suffix, id
@@ -586,7 +586,7 @@ let rec locate_ref = function
       let mpo = try Some (Nametab.locate_module qid) with Not_found -> None
       and ro =
         try Some (Smartlocate.global_with_alias qid)
-        with Nametab.GlobalizationError _ | UserError _ -> None
+        with Nametab.GlobalizationError _ | CoqError (UserError, _) -> None
       in
       match mpo, ro with
         | None, None -> Nametab.error_global_not_found ~info:Exninfo.null qid

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -1525,7 +1525,7 @@ let do_build_inductive evd (funconstants : pconstant list)
             ~uniform:ComInductive.NonUniformParameters))
       Declarations.Finite
   with
-  | UserError msg as e ->
+  | CoqError (UserError, msg) as e ->
     let _time3 = System.get_time () in
     (* 	Pp.msgnl (str "error : "++ str (string_of_float (System.time_difference time2 time3))); *)
     let repacked_rel_inds =

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -301,7 +301,7 @@ let check_not_nested env sigma forbidden e =
     | CoFix _ -> user_err Pp.(str "check_not_nested : Fix")
   in
   try check_not_nested e
-  with UserError p ->
+  with CoqError (UserError, p) ->
     user_err
       (str "on expr : " ++ Printer.pr_leconstr_env env sigma e ++ str " " ++ p ++ str ".")
 

--- a/plugins/ltac/comRewrite.ml
+++ b/plugins/ltac/comRewrite.ml
@@ -16,13 +16,6 @@ open Constrexpr
 open EConstr
 open Libnames
 
-let () = CErrors.register_handler begin function
-| Rewrite.RewriteFailure (env, sigma, e) ->
-  let e = Himsg.explain_pretype_error env sigma e in
-  Some Pp.(str"setoid rewrite failed: " ++ e)
-| _ -> None
-end
-
 module TC = Typeclasses
 
 let classes_dirpath =

--- a/plugins/ltac/extraargs.mlg
+++ b/plugins/ltac/extraargs.mlg
@@ -341,7 +341,7 @@ let interp_strategy ist env sigma = function
   in
   let v =
     try Tacinterp.Value.cast (Genarg.topwit wit_strategy_level) v
-    with CErrors.UserError _ -> Taccoerce.error_ltac_variable ?loc id None v "a strategy_level"
+    with CErrors.(CoqError (UserError, _)) -> Taccoerce.error_ltac_variable ?loc id None v "a strategy_level"
   in
   v
 

--- a/plugins/ltac/leminv.ml
+++ b/plugins/ltac/leminv.ml
@@ -269,7 +269,7 @@ let lemInv id c =
     let clause = clenv_instantiate mv clause (EConstr.mkVar id, Typing.type_of_variable env id) in
     Clenv.res_pf clause ~flags:(Unification.elim_flags ()) ~with_evars:false
   with
-    | Failure _ | UserError _ ->
+    | Failure _ | CoqError (UserError, _) ->
          user_err
            (str "Cannot refine current goal with the lemma " ++
               pr_leconstr_env (pf_env gls) (project gls) c ++ str ".")

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -1507,8 +1507,8 @@ and interp_match_successes lz ist s =
    let general =
      let open Tacticals in
      let break (e, info) = match e with
-       | FailError (0, _) -> None
-       | FailError (n, s) -> Some (FailError (pred n, s), info)
+       | CoqError (FailError, (0, _)) -> None
+       | CoqError (FailError, (n, s)) -> Some (CoqError (FailError, (pred n, s)), info)
        | _ -> None
      in
      Proofview.tclBREAK break s >>= fun ans -> interp_match_success ist ans

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -410,7 +410,7 @@ let interp_hyp ist env sigma ({loc;v=id} as locid) =
   with Not_found ->
   (* Then look if bound in the proof context at calling time *)
   if is_variable env id then id
-  else Loc.raise ?loc (Logic.RefinerError (env, sigma, Logic.NoSuchHyp id))
+  else CErrors.coq_error ?loc Logic.RefinerError (env, sigma, Logic.NoSuchHyp id)
 
 let interp_hyp_list_as_list ist env sigma ({loc;v=id} as x) =
   try coerce_to_hyp_list env sigma (Id.Map.find id ist.lfun)

--- a/plugins/ltac/tactic_matching.ml
+++ b/plugins/ltac/tactic_matching.ml
@@ -108,7 +108,7 @@ let verify_metas_coherence env sigma (ln1,lcm) (ln,lm) =
   (merged, Id.Map.merge merge lcm lm)
 
 let matching_error =
-  CErrors.UserError Pp.(str "No matching clauses for match.")
+  CErrors.(CoqError (UserError, Pp.str "No matching clauses for match."))
 
 let imatching_error = (matching_error, Exninfo.null)
 

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -146,19 +146,19 @@ let of_result f = function
 (** Stdlib exceptions *)
 
 let err_notfocussed =
-  Tac2interp.LtacError (coq_core "Not_focussed", [||])
+  CErrors.CoqError (Tac2ffi.LtacError, (coq_core "Not_focussed", [||]))
 
 let err_outofbounds =
-  Tac2interp.LtacError (coq_core "Out_of_bounds", [||])
+  CErrors.CoqError (Tac2ffi.LtacError, (coq_core "Out_of_bounds", [||]))
 
 let err_notfound =
-  Tac2interp.LtacError (coq_core "Not_found", [||])
+  CErrors.CoqError (Tac2ffi.LtacError, (coq_core "Not_found", [||]))
 
 let err_matchfailure =
-  Tac2interp.LtacError (coq_core "Match_failure", [||])
+  CErrors.CoqError (Tac2ffi.LtacError, (coq_core "Match_failure", [||]))
 
 let err_division_by_zero =
-  Tac2interp.LtacError (coq_core "Division_by_zero", [||])
+  CErrors.CoqError (Tac2ffi.LtacError, (coq_core "Division_by_zero", [||]))
 
 (** Helper functions *)
 
@@ -195,7 +195,7 @@ let wrap_unit f =
   return () >>= fun () -> f (); return v_unit
 
 let catchable_exception = function
-  | Logic_monad.Exception _ -> false
+  | CErrors.CoqError (Logic_monad.Exception, _) -> false
   | e -> CErrors.noncritical e
 
 (* Adds ltac2 backtrace
@@ -855,7 +855,7 @@ let () = define2 "constr_binder_make" (option ident) constr begin fun na ty ->
       return (Value.of_ext val_binder (Context.make_annot na rel, ty))
     | exception (Retyping.RetypeError _ as e) ->
       let e, info = Exninfo.capture e in
-      fail ~info (CErrors.UserError Pp.(str "Not a type."))
+      fail ~info (CErrors.(CoqError (UserError, Pp.(str "Not a type."))))
   end
 end
 

--- a/plugins/ltac2/tac2ffi.ml
+++ b/plugins/ltac2/tac2ffi.ml
@@ -121,7 +121,7 @@ match Val.eq tag tag' with
 
 (** Exception *)
 
-exception LtacError of KerName.t * valexpr array
+type _ CErrors.tag += LtacError : (KerName.t * valexpr array) CErrors.tag
 
 (** Conversion functions *)
 
@@ -262,7 +262,7 @@ let internal_err =
 
 (** FIXME: handle backtrace in Ltac2 exceptions *)
 let of_exn c = match fst c with
-| LtacError (kn, c) -> ValOpn (kn, c)
+| CErrors.CoqError (LtacError, (kn, c)) -> ValOpn (kn, c)
 | _ -> ValOpn (internal_err, [|of_ext val_exn c|])
 
 let to_exn c = match c with
@@ -270,7 +270,7 @@ let to_exn c = match c with
   if Names.KerName.equal kn internal_err then
     to_ext val_exn c.(0)
   else
-    (LtacError (kn, c), Exninfo.null)
+    (CErrors.CoqError (LtacError, (kn, c)), Exninfo.null)
 | _ -> assert false
 
 let exn = {

--- a/plugins/ltac2/tac2ffi.mli
+++ b/plugins/ltac2/tac2ffi.mli
@@ -219,5 +219,5 @@ val abstract : int -> (valexpr list -> valexpr Proofview.tactic) -> closure
 
 (** Exception *)
 
-exception LtacError of KerName.t * valexpr array
+type _ CErrors.tag += LtacError : (KerName.t * valexpr array) CErrors.tag
 (** Ltac2-defined exceptions seen from OCaml side *)

--- a/plugins/ltac2/tac2interp.ml
+++ b/plugins/ltac2/tac2interp.ml
@@ -16,8 +16,6 @@ open Proofview.Notations
 open Tac2expr
 open Tac2ffi
 
-exception LtacError = Tac2ffi.LtacError
-
 let backtrace : backtrace Evd.Store.field = Evd.Store.field ()
 
 let print_ltac2_backtrace = ref false

--- a/plugins/ltac2/tac2interp.mli
+++ b/plugins/ltac2/tac2interp.mli
@@ -8,7 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open Names
 open Tac2expr
 open Tac2ffi
 
@@ -27,11 +26,6 @@ val interp_value : environment -> glb_tacexpr -> valexpr
 
 val get_env : Ltac_pretype.unbound_ltac_var_map -> environment
 val set_env : environment -> Ltac_pretype.unbound_ltac_var_map -> Ltac_pretype.unbound_ltac_var_map
-
-(** {5 Exceptions} *)
-
-exception LtacError of KerName.t * valexpr array
-(** Ltac2-defined exceptions seen from OCaml side *)
 
 (** {5 Backtrace} *)
 

--- a/plugins/ltac2/tac2match.ml
+++ b/plugins/ltac2/tac2match.ml
@@ -69,7 +69,7 @@ let verify_metas_coherence env sigma s1 s2 =
   Id.Map.merge merge s1 s2
 
 let matching_error =
-  CErrors.UserError Pp.(str "No matching clauses for match.")
+  CErrors.(CoqError (UserError, Pp.str "No matching clauses for match."))
 
 let imatching_error = (matching_error, Exninfo.null)
 

--- a/plugins/ltac2/tac2tactics.ml
+++ b/plugins/ltac2/tac2tactics.ml
@@ -217,7 +217,7 @@ let map_pattern_with_occs (pat, occ) = match pat with
 let get_evaluable_reference = function
 | GlobRef.VarRef id -> Proofview.tclUNIT (Tacred.EvalVarRef id)
 | GlobRef.ConstRef cst -> Proofview.tclUNIT (Tacred.EvalConstRef cst)
-| r -> Proofview.tclZERO (Tacred.NotEvaluableRef r)
+| r -> Proofview.tclERROR Tacred.NotEvaluableRef r
 
 let reduce r cl =
   let cl = mk_clause cl in

--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -667,7 +667,7 @@ module Env = struct
       let csts = UnivProblem.Set.force csts in
       match Evd.add_universe_constraints sigma csts with
       | sigma -> Some (env, sigma)
-      | exception UGraph.UniverseInconsistency _ -> None )
+      | exception CErrors.CoqError (UGraph.UniverseInconsistency, _) -> None )
     | None -> None
 
   let compute_rank_add env v is_prop =

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -1002,7 +1002,7 @@ let cleartac clr = Proofview.tclTHEN (pf_check_hyps_uniq [] clr) (Tactics.clear 
 
 let get_hyp env sigma id =
   try EConstr.of_named_decl (Environ.lookup_named id env)
-  with Not_found -> raise (Logic.RefinerError (env, sigma, Logic.NoSuchHyp id))
+  with Not_found -> CErrors.coq_error Logic.RefinerError (env, sigma, Logic.NoSuchHyp id)
 
 (** Generalize tactic *)
 

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -455,7 +455,7 @@ let call_on_evar env sigma tac e =
     let (gs, final) = Proofview.proofview final in
     let () = if (gs <> []) then errorstrm (str "Should we tell the user?") in
     final
-  with Logic_monad.TacticFailure e as src ->
+  with CErrors.CoqError (Logic_monad.TacticFailure, e) as src ->
     let (_, info) = Exninfo.capture src in
     Exninfo.iraise (e, info)
 
@@ -970,8 +970,8 @@ let tclDO n tac =
   let tac_err_at i =
     Proofview.Goal.enter begin fun gl ->
       Proofview.tclORELSE tac begin function
-      | (CErrors.UserError s, info) ->
-        let e' = CErrors.UserError (prefix i ++ s) in
+      | (CErrors.(CoqError (UserError, s)), info) ->
+        let e' = CErrors.(CoqError (UserError, (prefix i ++ s))) in
         Proofview.tclZERO ~info e'
       | (e, info) -> Proofview.tclZERO ~info e
       end

--- a/plugins/ssr/ssrelim.ml
+++ b/plugins/ssr/ssrelim.ml
@@ -547,7 +547,7 @@ let nothing_to_inject =
 let equality_inj l b id c = Proofview.Goal.enter begin fun gl ->
   Proofview.tclORELSE (Equality.inj None ~injection_in_context:false l b None c)
     (function
-    | (Equality.NothingToInject,_) ->
+    | (CErrors.CoqError (Equality.NothingToInject, ()),_) ->
         let open Proofview.Notations in
         Ssrcommon.tacTYPEOF (EConstr.mkVar id) >>= fun ty ->
         nothing_to_inject (Proofview.Goal.sigma gl, Proofview.Goal.env gl, ty);

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -419,7 +419,9 @@ let pirrel_rewrite ?(under=false) ?(map_redex=id_map_redex) pred rdx rdx_ty new_
       let sigma = Typing.check env sigma pred tP in
       sigma
     with
-    | Pretype_errors.PretypeError (env, sigma, te) -> raise (PRtype_error (Some (env, sigma, te)))
+    | CErrors.CoqError (Pretype_errors.PretypeError, (env, sigma, te)) as exn ->
+      let _, info = Exninfo.capture exn in
+      Exninfo.iraise (PRtype_error (Some (env, sigma, te)), info)
     | e when CErrors.noncritical e -> raise (PRtype_error None)
   in
   let proof = EConstr.mkApp (elim, [| rdx_ty; new_rdx; pred; p; rdx; c |]) in

--- a/plugins/syntax/number.ml
+++ b/plugins/syntax/number.ml
@@ -123,7 +123,7 @@ let has_type env sigma f ty =
   let c = mkCastC (mkRefC f, Constr.DEFAULTcast, ty) in
   let flags = Pretyping.{ all_and_fail_flags with use_coercions = false } in
   try let _ = Constrintern.interp_constr ~flags env sigma c in true
-  with Pretype_errors.PretypeError _ -> false
+  with CErrors.CoqError (Pretype_errors.PretypeError, _) -> false
 
 let type_error_to f ty =
   CErrors.user_err

--- a/plugins/syntax/string_notation.ml
+++ b/plugins/syntax/string_notation.ml
@@ -28,7 +28,7 @@ let q_byte () = qualid_of_ref "core.byte.type"
 let has_type env sigma f ty =
   let c = mkCastC (mkRefC f, Constr.DEFAULTcast, ty) in
   try let _ = Constrintern.interp_constr env sigma c in true
-  with Pretype_errors.PretypeError _ -> false
+  with CErrors.CoqError (Pretype_errors.PretypeError, _) -> false
 
 let type_error_to f ty =
   CErrors.user_err

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -54,10 +54,10 @@ type pattern_matching_error =
   | NonExhaustive of cases_pattern list
   | CannotInferPredicate of (constr * types) array
 
-exception PatternMatchingError of env * evar_map * pattern_matching_error
+type _ CErrors.tag += PatternMatchingError : (env * evar_map * pattern_matching_error) CErrors.tag
 
 let raise_pattern_matching_error ?loc (env,sigma,te) =
-  Loc.raise ?loc (PatternMatchingError(env,sigma,te))
+  CErrors.coq_error ?loc PatternMatchingError(env,sigma,te)
 
 let error_bad_pattern ?loc env sigma cstr ind =
   raise_pattern_matching_error ?loc
@@ -80,7 +80,7 @@ let list_try_compile f l =
   | [] -> if errors = [] then anomaly (str "try_find_f.") else Exninfo.iraise (List.last errors)
   | h::t ->
       try f h
-      with CoqError ((UserError | TypeError), _) | PretypeError _ | PatternMatchingError _ as e ->
+      with CoqError ((UserError | TypeError | PatternMatchingError | PretypeError), _) as e ->
             let e = Exninfo.capture e in
             aux (e::errors) t in
   aux [] l

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -80,7 +80,7 @@ let list_try_compile f l =
   | [] -> if errors = [] then anomaly (str "try_find_f.") else Exninfo.iraise (List.last errors)
   | h::t ->
       try f h
-      with UserError _ | TypeError _ | PretypeError _ | PatternMatchingError _ as e ->
+      with CoqError (UserError, _) | TypeError _ | PretypeError _ | PatternMatchingError _ as e ->
             let e = Exninfo.capture e in
             aux (e::errors) t in
   aux [] l

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -80,7 +80,7 @@ let list_try_compile f l =
   | [] -> if errors = [] then anomaly (str "try_find_f.") else Exninfo.iraise (List.last errors)
   | h::t ->
       try f h
-      with CoqError (UserError, _) | TypeError _ | PretypeError _ | PatternMatchingError _ as e ->
+      with CoqError ((UserError | TypeError), _) | PretypeError _ | PatternMatchingError _ as e ->
             let e = Exninfo.capture e in
             aux (e::errors) t in
   aux [] l

--- a/pretyping/cases.mli
+++ b/pretyping/cases.mli
@@ -31,7 +31,7 @@ type pattern_matching_error =
   | NonExhaustive of cases_pattern list
   | CannotInferPredicate of (constr * types) array
 
-exception PatternMatchingError of env * evar_map * pattern_matching_error
+type _ CErrors.tag += PatternMatchingError : (env * evar_map * pattern_matching_error) CErrors.tag
 
 val error_wrong_numarg_constructor :
   ?loc:Loc.t -> env -> cstr:constructor -> expanded:bool -> nargs:int -> expected_nassums:int -> expected_ndecls:int -> 'a

--- a/pretyping/coercion.ml
+++ b/pretyping/coercion.ml
@@ -462,7 +462,7 @@ let unify_product env sigma typ =
     let prod = mkProd (Context.anonR, domain_hole, codomain_hole) in
     (* NB: unification needs the un-reduced type to do heuristics like canonical structures *)
     try Inl (Evarconv.unify env sigma Reduction.CUMUL typ prod)
-    with PretypeError _ -> Inr t (* return the reduced type to avoid double reducing *)
+    with CoqError (PretypeError, _) -> Inr t (* return the reduced type to avoid double reducing *)
 
 (* Invariant: if [proj] is [Some] then [args_len < npars]
      (and always [args_len = length rev_args + length args in head]) *)

--- a/pretyping/find_subterm.ml
+++ b/pretyping/find_subterm.ml
@@ -135,7 +135,10 @@ let make_eq_univs_test env evd c =
     | None -> raise (NotUnifiable None)
     | Some cst ->
         try Evd.add_universe_constraints evd cst
-        with Evd.UniversesDiffer | UGraph.UniverseInconsistency _ -> raise (NotUnifiable None)
+        with
+        | Evd.UniversesDiffer
+        | CErrors.CoqError (UGraph.UniverseInconsistency, _) ->
+          raise (NotUnifiable None)
     );
   merge_fun = (fun evd _ -> evd);
   testing_state = evd;

--- a/pretyping/indrec.mli
+++ b/pretyping/indrec.mli
@@ -20,7 +20,7 @@ type recursion_scheme_error =
   | NotMutualInScheme of inductive * inductive
   | NotAllowedDependentAnalysis of (*isrec:*) bool * inductive
 
-exception RecursionSchemeError of env * recursion_scheme_error
+type _ CErrors.tag += RecursionSchemeError : (env * recursion_scheme_error) CErrors.tag
 
 (** Eliminations *)
 

--- a/pretyping/pretype_errors.ml
+++ b/pretyping/pretype_errors.ml
@@ -67,7 +67,7 @@ type pretype_error =
 exception PretypeError of env * Evd.evar_map * pretype_error
 
 let precatchable_exception = function
-  | CErrors.UserError _ | TypeError _ | PretypeError _
+  | CErrors.(CoqError (UserError, _)) | TypeError _ | PretypeError _
   | Nametab.GlobalizationError _ -> true
   | _ -> false
 

--- a/pretyping/pretype_errors.ml
+++ b/pretyping/pretype_errors.ml
@@ -67,8 +67,8 @@ type pretype_error =
 exception PretypeError of env * Evd.evar_map * pretype_error
 
 let precatchable_exception = function
-  | CErrors.(CoqError (UserError, _)) | TypeError _ | PretypeError _
-  | Nametab.GlobalizationError _ -> true
+  | CErrors.(CoqError ((UserError | Nametab.GlobalizationError), _)) | TypeError _ | PretypeError _
+    -> true
   | _ -> false
 
 let raise_pretype_error ?loc ?info (env,sigma,te) =

--- a/pretyping/pretype_errors.ml
+++ b/pretyping/pretype_errors.ml
@@ -67,7 +67,7 @@ type pretype_error =
 exception PretypeError of env * Evd.evar_map * pretype_error
 
 let precatchable_exception = function
-  | CErrors.(CoqError ((UserError | Nametab.GlobalizationError), _)) | TypeError _ | PretypeError _
+  | CErrors.(CoqError ((UserError | Nametab.GlobalizationError | TypeError), _)) | PretypeError _
     -> true
   | _ -> false
 

--- a/pretyping/pretype_errors.mli
+++ b/pretyping/pretype_errors.mli
@@ -71,7 +71,7 @@ type pretype_error =
     (** unresolvable evar, connex component *)
   | DisallowedSProp
 
-exception PretypeError of env * Evd.evar_map * pretype_error
+type _ CErrors.tag += PretypeError : (env * Evd.evar_map * pretype_error) CErrors.tag
 
 val precatchable_exception : exn -> bool
 

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -108,7 +108,7 @@ let search_guard ?loc env possible_indexes fixdefs =
               let flags = { (typing_flags env) with Declarations.check_guarded = true } in
               let env = Environ.set_typing_flags flags env in
               check_fix env fix; raise (Found indexes)
-            with TypeError _ -> ())
+            with CoqError (TypeError, _) -> ())
          (List.combinations possible_indexes);
        let errmsg = "Cannot guess decreasing argument of fix." in
          user_err ?loc (Pp.str errmsg)
@@ -117,7 +117,7 @@ let search_guard ?loc env possible_indexes fixdefs =
 let esearch_guard ?loc env sigma indexes fix =
   let fix = nf_fix sigma fix in
   try search_guard ?loc env indexes fix
-  with TypeError (env,err) ->
+  with CoqError (TypeError, (env,err)) ->
     raise (PretypeError (env,sigma,TypingError (map_ptype_error of_constr err)))
 
 (* To force universe name declaration before use *)
@@ -1010,7 +1010,7 @@ struct
     let resj =
       try
         judge_of_product !!env sigma name j j'
-      with TypeError _ as e ->
+      with CoqError (TypeError, _) as e ->
         let (e, info) = Exninfo.capture e in
         let info = Option.cata (Loc.add_loc info) info loc in
         Exninfo.iraise (e, info) in

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -445,10 +445,10 @@ let pretype_ref ?loc sigma env ref us =
         | None | Some [] -> ()
         | Some us ->
             let open UnivGen in
-            Loc.raise ?loc (UniverseLengthMismatch {
+            CErrors.coq_error ?loc UniverseLengthMismatch {
               actual = List.length us;
               expect = 0;
-            }));
+            });
        sigma, make_judge (mkVar id) ty
        with Not_found ->
          (* This may happen if env is a goal env and section variables have
@@ -1317,10 +1317,10 @@ let pretype_type self c ?loc ~flags valcon (env : GlobEnv.t) sigma = match DAst.
         sigma, Some u
       | Some u ->
           let open UnivGen in
-          Loc.raise ?loc (UniverseLengthMismatch {
+          CErrors.coq_error ?loc UniverseLengthMismatch {
             actual = List.length u;
             expect = 1;
-          })
+          }
     in
     let sigma, tycon' = split_as_array !!env sigma tycon in
     let sigma, jty = eval_type_pretyper self ~flags tycon' env sigma ty in

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1083,7 +1083,7 @@ let sigma_compare_sorts env pb s0 s1 sigma =
 let sigma_compare_instances ~flex i0 i1 sigma =
   try Evd.set_eq_instances ~flex sigma i0 i1
   with Evd.UniversesDiffer
-     | UGraph.UniverseInconsistency _ ->
+     | CoqError (UGraph.UniverseInconsistency, _) ->
         raise Reduction.NotConvertible
 
 let sigma_check_inductive_instances cv_pb variance u1 u2 sigma =
@@ -1138,7 +1138,7 @@ let infer_conv_gen conv_fun ?(catch_incon=true) ?(pb=Reduction.CUMUL)
       | None -> None
       | Some cstr ->
         try Some (Evd.add_universe_constraints sigma cstr)
-        with UGraph.UniverseInconsistency _ | Evd.UniversesDiffer -> None
+        with CoqError (UGraph.UniverseInconsistency, _) | Evd.UniversesDiffer -> None
       in
       match ans with
       | Some sigma -> ans
@@ -1152,7 +1152,7 @@ let infer_conv_gen conv_fun ?(catch_incon=true) ?(pb=Reduction.CUMUL)
         Some sigma'
   with
   | Reduction.NotConvertible -> None
-  | UGraph.UniverseInconsistency _ when catch_incon -> None
+  | CoqError (UGraph.UniverseInconsistency, _) when catch_incon -> None
 
 let infer_conv = infer_conv_gen (fun pb ~l2r sigma ->
       Reduction.generic_conv pb ~l2r (Evd.evar_handler sigma))
@@ -1178,7 +1178,7 @@ let infer_conv_ustate ?(catch_incon=true) ?(pb=Reduction.CUMUL)
         Some cstr
   with
   | Reduction.NotConvertible -> None
-  | UGraph.UniverseInconsistency _ when catch_incon -> None
+  | CoqError (UGraph.UniverseInconsistency, _) when catch_incon -> None
 
 let evars_of_evar_map sigma =
   { Genlambda.evars_val = Evd.evar_handler sigma }

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -27,7 +27,7 @@ module NamedDecl = Context.Named.Declaration
 type reduction_tactic_error =
     InvalidAbstraction of env * Evd.evar_map * EConstr.constr * (env * Type_errors.type_error)
 
-exception ReductionTacticError of reduction_tactic_error
+type _ CErrors.tag += ReductionTacticError : reduction_tactic_error CErrors.tag
 
 (* Evaluable reference *)
 
@@ -1253,7 +1253,7 @@ let pattern_occs loccs_trm = begin fun env sigma c ->
     let sigma, _ = Typing.type_of env sigma abstr_trm in
     (sigma, applist(abstr_trm, List.map snd loccs_trm))
   with CoqError (Type_errors.TypeError, (env',t)) ->
-    raise (ReductionTacticError (InvalidAbstraction (env,sigma,abstr_trm,(env',t))))
+    CErrors.coq_error ReductionTacticError (InvalidAbstraction (env,sigma,abstr_trm,(env',t)))
   end
 
 (* Used in several tactics. *)

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -1252,7 +1252,7 @@ let pattern_occs loccs_trm = begin fun env sigma c ->
   try
     let sigma, _ = Typing.type_of env sigma abstr_trm in
     (sigma, applist(abstr_trm, List.map snd loccs_trm))
-  with Type_errors.TypeError (env',t) ->
+  with CoqError (Type_errors.TypeError, (env',t)) ->
     raise (ReductionTacticError (InvalidAbstraction (env,sigma,abstr_trm,(env',t))))
   end
 

--- a/pretyping/tacred.mli
+++ b/pretyping/tacred.mli
@@ -35,7 +35,7 @@ val subst_evaluable_reference :
 type reduction_tactic_error =
     InvalidAbstraction of env * evar_map * constr * (env * Type_errors.type_error)
 
-exception ReductionTacticError of reduction_tactic_error
+type _ CErrors.tag += ReductionTacticError : reduction_tactic_error CErrors.tag
 
 (** {6 Reduction functions associated to tactics. } *)
 

--- a/pretyping/tacred.mli
+++ b/pretyping/tacred.mli
@@ -43,7 +43,7 @@ exception ReductionTacticError of reduction_tactic_error
 
 val is_evaluable : Environ.env -> evaluable_global_reference -> bool
 
-exception NotEvaluableRef of GlobRef.t
+type _ CErrors.tag += NotEvaluableRef : GlobRef.t CErrors.tag
 val error_not_evaluable : GlobRef.t -> 'a
 
 val evaluable_of_global_reference :

--- a/pretyping/typeclasses_errors.ml
+++ b/pretyping/typeclasses_errors.ml
@@ -16,10 +16,23 @@ type typeclass_error =
     | NotATypeclass of constr
     | UnboundMethod of GlobRef.t * lident (* Class name, method *)
 
-exception TypeClassError of env * Evd.evar_map * typeclass_error
+type _ CErrors.tag += TypeClassError : (env * Evd.evar_map * typeclass_error) CErrors.tag
 
-let typeclass_error env sigma err = raise (TypeClassError (env, sigma, err))
+let typeclass_error env sigma err = CErrors.coq_error TypeClassError (env, sigma, err)
 
 let not_a_class env sigma c = typeclass_error env sigma (NotATypeclass c)
 
 let unbound_method env sigma cid id = typeclass_error env sigma (UnboundMethod (cid, id))
+
+open Pp
+
+let explain_not_a_class prc env sigma c =
+  prc env sigma c ++ str" is not a declared type class."
+
+let explain_unbound_method env sigma cid { CAst.v = id } =
+  str "Unbound method name " ++ Id.print (id) ++ spc () ++
+  str"of class" ++ spc () ++ Nametab.pr_global_env Id.Set.empty cid ++ str "."
+
+let explain_typeclass_error prc env sigma = function
+  | NotATypeclass c -> explain_not_a_class prc env sigma c
+  | UnboundMethod (cid, id) -> explain_unbound_method env sigma cid id

--- a/pretyping/typeclasses_errors.ml
+++ b/pretyping/typeclasses_errors.ml
@@ -13,13 +13,13 @@ open EConstr
 open Environ
 
 type typeclass_error =
-    | NotAClass of constr
+    | NotATypeclass of constr
     | UnboundMethod of GlobRef.t * lident (* Class name, method *)
 
 exception TypeClassError of env * Evd.evar_map * typeclass_error
 
 let typeclass_error env sigma err = raise (TypeClassError (env, sigma, err))
 
-let not_a_class env sigma c = typeclass_error env sigma (NotAClass c)
+let not_a_class env sigma c = typeclass_error env sigma (NotATypeclass c)
 
 let unbound_method env sigma cid id = typeclass_error env sigma (UnboundMethod (cid, id))

--- a/pretyping/typeclasses_errors.mli
+++ b/pretyping/typeclasses_errors.mli
@@ -13,7 +13,7 @@ open EConstr
 open Environ
 
 type typeclass_error =
-  | NotAClass of constr
+  | NotATypeclass of constr
   | UnboundMethod of GlobRef.t * lident (** Class name, method *)
 
 exception TypeClassError of env * Evd.evar_map * typeclass_error

--- a/pretyping/typeclasses_errors.mli
+++ b/pretyping/typeclasses_errors.mli
@@ -16,10 +16,14 @@ type typeclass_error =
   | NotATypeclass of constr
   | UnboundMethod of GlobRef.t * lident (** Class name, method *)
 
-exception TypeClassError of env * Evd.evar_map * typeclass_error
+type _ CErrors.tag += TypeClassError : (env * Evd.evar_map * typeclass_error) CErrors.tag
 
 val typeclass_error : env -> Evd.evar_map -> typeclass_error -> 'a
 
 val not_a_class : env -> Evd.evar_map -> constr -> 'a
 
 val unbound_method : env -> Evd.evar_map -> GlobRef.t -> lident -> 'a
+
+val explain_typeclass_error
+  : (env -> Evd.evar_map -> EConstr.constr -> Pp.t)
+  -> env -> Evd.evar_map -> typeclass_error -> Pp.t

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -69,7 +69,7 @@ let assumption_of_judgment env sigma j =
   try
     let sigma, j = type_judgment env sigma j in
     sigma, j.utj_val
-  with CoqError (Type_errors.TypeError, _) | PretypeError _ ->
+  with CoqError ((Type_errors.TypeError | PretypeError), _) ->
     error_assumption env sigma j
 
 let judge_of_apply env sigma funj argjv =

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -69,7 +69,7 @@ let assumption_of_judgment env sigma j =
   try
     let sigma, j = type_judgment env sigma j in
     sigma, j.utj_val
-  with Type_errors.TypeError _ | PretypeError _ ->
+  with CoqError (Type_errors.TypeError, _) | PretypeError _ ->
     error_assumption env sigma j
 
 let judge_of_apply env sigma funj argjv =

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -131,7 +131,7 @@ let abstract_list_all env evd typ c l =
     with
     | CoqError (UserError, _) ->
         error_cannot_find_well_typed_abstraction env evd p l None
-    | Type_errors.TypeError (env',x) ->
+    | CoqError (Type_errors.TypeError, (env',x)) ->
         (* FIXME: plug back the typing information *)
         error_cannot_find_well_typed_abstraction env evd p l None
     | Pretype_errors.PretypeError (env',evd,e) ->

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -147,7 +147,7 @@ let occurrence_test env sigma c1 c2 =
   | None -> false, sigma
   | Some cstr ->
      try true, Evd.add_universe_constraints sigma cstr
-     with UniversesDiffer | UGraph.UniverseInconsistency _ -> false, sigma
+     with UniversesDiffer | CoqError (UGraph.UniverseInconsistency, _) -> false, sigma
 
 let abstract_list_all_with_dependencies env evd typ c l =
   let (evd, ev) = new_evar env evd typ in
@@ -588,11 +588,11 @@ let constr_cmp pb env sigma flags ?nargs t u =
   match cstrs with
   | Some cstrs ->
       begin try Some (Evd.add_universe_constraints sigma cstrs)
-      with UGraph.UniverseInconsistency _ -> None
+      with CoqError (UGraph.UniverseInconsistency, _) -> None
       | Evd.UniversesDiffer ->
         if is_rigid_head sigma flags t then
           try Some (Evd.add_universe_constraints sigma (force_eqs cstrs))
-          with UGraph.UniverseInconsistency _ -> None
+          with CoqError (UGraph.UniverseInconsistency, _) -> None
         else None
       end
   | None ->
@@ -1079,7 +1079,7 @@ let rec unify_0_with_initial_metas (sigma,ms,es as subst : subst0) conv_at_top e
           let uprob = UnivProblem.Set.union uprob uprob' in
           begin match Evd.add_universe_constraints sigma uprob with
           | sigma -> Some (sigma, metasubst, evarsubst)
-          | exception (UGraph.UniverseInconsistency _ | UniversesDiffer) -> None
+          | exception (CoqError (UGraph.UniverseInconsistency, _) | UniversesDiffer) -> None
           end
         | None ->
           if is_ground_term sigma m1 && is_ground_term sigma n1 then

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -2190,9 +2190,7 @@ let w_unify env evd cv_pb ?(flags=default_unify_flags ()) ty1 ty2 =
           (try
               w_typed_unify_array env evd flags hd1 l1 hd2 l2
             with ex when precatchable_exception ex ->
-              try
-                w_unify2 env evd flags false cv_pb ty1 ty2
-              with PretypeError (env,_,NoOccurrenceFound _) as e -> raise e)
+              w_unify2 env evd flags false cv_pb ty1 ty2)
 
       (* Second order case *)
       | (Meta _, true, _, _ | _, _, Meta _, true) ->

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -129,7 +129,7 @@ let abstract_list_all env evd typ c l =
       let c = EConstr.it_mkLambda_or_LetIn (EConstr.Vars.lift (List.length ctxt) c) ctxt in
       Typing.recheck_against env evd c p
     with
-    | UserError _ ->
+    | CoqError (UserError, _) ->
         error_cannot_find_well_typed_abstraction env evd p l None
     | Type_errors.TypeError (env',x) ->
         (* FIXME: plug back the typing information *)

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -196,10 +196,10 @@ let universe_binders_with_opt_names orig names =
           | Name id -> Name id) orig udecl
     with Invalid_argument _ ->
       let open UnivGen in
-      raise (UniverseLengthMismatch {
-          actual = List.length orig;
-          expect = List.length udecl;
-        })
+      CErrors.coq_error UniverseLengthMismatch {
+        actual = List.length orig;
+        expect = List.length udecl;
+      }
   in
   let fold_named i (ubind,revubind as o) = function
     | Name id -> let ui = Level.var i in

--- a/proofs/goal_select.ml
+++ b/proofs/goal_select.ml
@@ -70,9 +70,11 @@ let tclSELECT ?nosuchgoal g tac = match g with
     Proofview.numgoals >>= fun n ->
     if n == 1 then tac
     else
-      let e = CErrors.UserError
-          Pp.(str "Expected a single focused goal but " ++
-              int n ++ str " goals are focused.")
+      let e = let open CErrors in
+        (CoqError
+           (UserError,
+            Pp.(str "Expected a single focused goal but " ++
+                int n ++ str " goals are focused.")))
       in
       let info = Exninfo.reify () in
       Proofview.tclZERO ~info e

--- a/proofs/logic.ml
+++ b/proofs/logic.ml
@@ -33,10 +33,9 @@ type refiner_error =
   | IntroNeedsProduct
   | NoSuchHyp of Id.t
 
-exception RefinerError of Environ.env * Evd.evar_map * refiner_error
+type _ CErrors.tag += RefinerError : (Environ.env * Evd.evar_map * refiner_error) CErrors.tag
 
-
-let error_no_such_hypothesis env sigma id = raise (RefinerError (env, sigma, NoSuchHyp id))
+let error_no_such_hypothesis env sigma id = CErrors.coq_error RefinerError (env, sigma, NoSuchHyp id)
 
 (************************************************************************)
 (************************************************************************)

--- a/proofs/logic.mli
+++ b/proofs/logic.mli
@@ -58,7 +58,7 @@ val convert_hyp : check:bool -> reorder:bool -> Environ.env -> evar_map ->
   EConstr.named_declaration -> Environ.named_context_val
 
 type cannot_move_hyp
-exception CannotMoveHyp of cannot_move_hyp
+type _ CErrors.tag += CannotMoveHyp : cannot_move_hyp CErrors.tag
 
 val move_hyp_in_named_context : Environ.env -> Evd.evar_map -> Id.t -> Id.t move_location ->
   Environ.named_context_val -> Environ.named_context_val

--- a/proofs/logic.mli
+++ b/proofs/logic.mli
@@ -39,7 +39,7 @@ type refiner_error =
   | IntroNeedsProduct
   | NoSuchHyp of Id.t
 
-exception RefinerError of Environ.env * evar_map * refiner_error
+type _ CErrors.tag += RefinerError : (Environ.env * Evd.evar_map * refiner_error) CErrors.tag
 
 val error_no_such_hypothesis : Environ.env -> evar_map -> Id.t -> 'a
 

--- a/proofs/proof.mli
+++ b/proofs/proof.mli
@@ -87,7 +87,7 @@ type open_error_reason =
   | UnfinishedProof
   | HasGivenUpGoals
 
-exception OpenProof of Names.Id.t option * open_error_reason
+type _ CErrors.tag += OpenProof : (Names.Id.t option * open_error_reason) CErrors.tag
 
 val return : ?pid:Names.Id.t -> t -> Evd.evar_map
 
@@ -134,17 +134,17 @@ val focus : 'a focus_condition -> 'a -> int -> t -> t
 (* focus on goal named id *)
 val focus_id : 'a focus_condition -> 'a -> Names.Id.t -> t -> t
 
-exception FullyUnfocused
-exception CannotUnfocusThisWay
+type _ CErrors.tag += FullyUnfocused : unit CErrors.tag
+type _ CErrors.tag += CannotUnfocusThisWay : unit CErrors.tag
 
 (* This is raised when trying to focus on non-existing subgoals. It is
    handled by an error message but one may need to catch it and
    settle a better error message in some case (suggesting a better
    bullet for example), see proof_global.ml function Bullet.pop and
    Bullet.push. *)
-exception NoSuchGoals of int * int
+type _ CErrors.tag += NoSuchGoals : (int * int) CErrors.tag
 
-exception NoSuchGoal of Names.Id.t option
+type _ CErrors.tag += NoSuchGoal : Names.Id.t option CErrors.tag
 
 (* Unfocusing command.
    Raises [FullyUnfocused] if the proof is not focused.
@@ -224,7 +224,7 @@ val refine_by_tactic
     occur. Ideally all code using this function should be rewritten in the
     monad. *)
 
-exception SuggestNoSuchGoals of int * t
+type _ CErrors.tag += SuggestNoSuchGoals : (int * t) CErrors.tag
 
 (** {6 Helpers to obtain proof state when in an interactive proof } *)
 val get_goal_context_gen : t -> int -> Evd.evar_map * Environ.env

--- a/proofs/tacmach.ml
+++ b/proofs/tacmach.ml
@@ -54,7 +54,7 @@ let pf_get_hyp id gl =
   let sigma = project gl in
   let sign =
     try EConstr.lookup_named id hyps
-    with Not_found -> raise (RefinerError (hyps, sigma, NoSuchHyp id))
+    with Not_found -> CErrors.coq_error RefinerError (hyps, sigma, NoSuchHyp id)
   in
   sign
 

--- a/stm/asyncTaskQueue.ml
+++ b/stm/asyncTaskQueue.ml
@@ -358,7 +358,9 @@ end
 module MakeQueue(T : Task) () = struct include Make(T) () end
 module MakeWorker(T : Task) () = struct include Make(T) () end
 
-exception RemoteException of Pp.t
-let _ = CErrors.register_handler (function
-  | RemoteException ppcmd -> Some ppcmd
-  | _ -> None)
+type _ CErrors.tag += RemoteException : Pp.t CErrors.tag
+let () = CErrors.register (module struct
+    type e = Pp.t
+    type _ CErrors.tag += T = RemoteException
+    let pp ppcmd = ppcmd
+  end)

--- a/stm/asyncTaskQueue.mli
+++ b/stm/asyncTaskQueue.mli
@@ -222,4 +222,4 @@ module MakeWorker(T : Task) () : sig
 end
 
 (** convenience exception to marshall to master *)
-exception RemoteException of Pp.t
+type _ CErrors.tag += RemoteException : Pp.t CErrors.tag

--- a/stm/partac.ml
+++ b/stm/partac.ml
@@ -170,7 +170,7 @@ let get_results res =
       | Some RespNoProgress -> None
       | Some (RespKilled goalno) -> killed := goalno :: !killed; None
       | Some (RespError (noncrt, msg)) ->
-        if noncrt then raise (AsyncTaskQueue.RemoteException msg)
+        if noncrt then CErrors.coq_error AsyncTaskQueue.RemoteException msg
         else CErrors.anomaly msg)
       res
   in

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -707,7 +707,7 @@ module Search = struct
             in
             let msg =
               match fst ie with
-              | Pretype_errors.PretypeError (env, evd, Pretype_errors.CannotUnify (x,y,_)) ->
+              | CErrors.CoqError (Pretype_errors.PretypeError, (env, evd, CannotUnify (x,y,_))) ->
                 str"Cannot unify " ++
                 Printer.pr_econstr_env env evd x ++ str" and " ++
                 Printer.pr_econstr_env env evd y

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -530,12 +530,6 @@ module Search = struct
     else
       tclUNIT ()
 
-  let _ = CErrors.register_handler begin function
-    | NonStuckFailure -> Some (str "NonStuckFailure")
-    | NoApplicableHint -> Some (str "NoApplicableHint")
-    | _ -> None
-    end
-
   (**
     For each success of tac1 try tac2.
     If tac2 raises NonStuckFailure, try the next success of tac1 until depleted.

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -1257,7 +1257,7 @@ let resolve_one_typeclass env ?(sigma=Evd.from_env env) concl unique =
     let name = Names.Id.of_string "legacy_pe" in
     match Proofview.apply ~name ~poly:false (Global.env ()) tac pv with
     | (_, final, _, _) -> final
-    | exception CErrors.CoqError (Logic_monad.TacticFailure, (Tacticals.FailError _)) ->
+    | exception CErrors.(CoqError (Logic_monad.TacticFailure, (CoqError (Tacticals.FailError, _)))) ->
       raise Not_found
   in
   let evd = Proofview.return pv in

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -243,8 +243,8 @@ let elim_wrapper cls rwtac =
     | Some _ -> rwtac
     end
     begin function (e, info) -> match e with
-    | PretypeError (env, evd, NoOccurrenceFound (c', _)) ->
-      Proofview.tclZERO ~info (PretypeError (env, evd, NoOccurrenceFound (c', cls)))
+    | CoqError (PretypeError, (env, evd, NoOccurrenceFound (c', _))) ->
+      Proofview.tclERROR ~info PretypeError (env, evd, NoOccurrenceFound (c', cls))
     | e ->
       Proofview.tclZERO ~info e
     end
@@ -1079,7 +1079,7 @@ let onEquality with_evars tac (c,lbindc) =
   if not with_evars && List.exists (fun h -> h.Clenv.hole_deps) eq_clause.Clenv.cl_holes then
     let filter h = if h.Clenv.hole_deps then Some h.Clenv.hole_name else None in
     let bindings = List.map_filter filter eq_clause.Clenv.cl_holes in
-    Proofview.tclZERO  (RefinerError (env, sigma, UnresolvedBindings bindings))
+    Proofview.tclERROR RefinerError (env, sigma, UnresolvedBindings bindings)
   else
   let filter h =
     if h.Clenv.hole_deps then None
@@ -1473,7 +1473,7 @@ let injEqThen keep_proofs tac l2r eql =
 let get_previous_hyp_position id gl =
   let env, sigma = Proofview.Goal.(env gl, sigma gl) in
   let rec aux dest = function
-  | [] -> raise (RefinerError (env, sigma, NoSuchHyp id))
+  | [] -> CErrors.coq_error RefinerError (env, sigma, NoSuchHyp id)
   | d :: right ->
     let hyp = Context.Named.Declaration.get_id d in
     if Id.equal hyp id then dest else aux (MoveAfter hyp) right

--- a/tactics/equality.mli
+++ b/tactics/equality.mli
@@ -72,7 +72,7 @@ val discr_tac    : evars_flag ->
   constr with_bindings Tactics.destruction_arg option -> unit Proofview.tactic
 
 (* Below, if flag is [None], it takes the value from the dynamic value of the option *)
-exception NothingToInject
+type _ CErrors.tag += NothingToInject : unit CErrors.tag
 val inj          : inj_flags option -> ?injection_in_context:bool -> intro_patterns option -> evars_flag ->
   clear_flag -> constr with_bindings -> unit Proofview.tactic
 val injClause    : inj_flags option -> ?injection_in_context:bool -> intro_patterns option -> evars_flag ->

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1753,7 +1753,7 @@ let run_hint tac k = match warn_hint () with
   if is_imported tac then k tac.obj
   else
     let info = Exninfo.reify () in
-    Proofview.tclZERO ~info (UserError (str "Tactic failure."))
+    Proofview.tclERROR ~info UserError (str "Tactic failure.")
 
 module FullHint =
 struct

--- a/tactics/hipattern.ml
+++ b/tactics/hipattern.ml
@@ -315,7 +315,7 @@ let match_with_equation env sigma t =
              None, hdapp, HeterogenousEq(args.(0),args.(1),args.(2),args.(3))
            else raise NoEquationFound
          else raise NoEquationFound
-     with UserError _ ->
+     with CoqError (UserError, _) ->
        raise NoEquationFound)
   | _ -> raise NoEquationFound
 

--- a/tactics/inv.ml
+++ b/tactics/inv.ml
@@ -119,9 +119,9 @@ let make_inv_predicate env evd indf realargs id status concl =
    In any case, we carry along the rest of pairs *)
   let eqdata =
     try Coqlib.build_coq_eq_data ()
-    with UserError _ ->
+    with CoqError (UserError, _) ->
     try Coqlib.build_coq_identity_data ()
-    with UserError _ -> user_err (str "No registered equality.") in
+    with CoqError (UserError, _) -> user_err (str "No registered equality.") in
   let rec build_concl eqns args n = function
     | [] -> it_mkProd concl eqns, Array.rev_of_list args
     | ai :: restlist ->
@@ -473,7 +473,7 @@ let raw_inversion inv_kind id status names =
     let c = mkVar id in
     let ((ind, u), t) =
       try pf_apply Tacred.reduce_to_atomic_ind gl (pf_get_type_of gl c)
-      with UserError _ ->
+      with CoqError (UserError, _) ->
         let msg = str "The type of " ++ Id.print id ++ str " is not inductive." in
         CErrors.user_err  msg
     in

--- a/tactics/inv.ml
+++ b/tactics/inv.ml
@@ -12,7 +12,6 @@ open Pp
 open CErrors
 open Util
 open Names
-open Term
 open Termops
 open Constr
 open Context
@@ -505,8 +504,9 @@ let raw_inversion inv_kind id status names =
 
 (* Error messages of the inversion tactics *)
 let wrap_inv_error id = function (e, info) -> match e with
-  | Indrec.RecursionSchemeError
-      (_, Indrec.NotAllowedCaseAnalysis (_,(Type _ | Set as k),i)) ->
+  | CoqError
+      (Indrec.RecursionSchemeError,
+       (_, Indrec.NotAllowedCaseAnalysis (_,k,i))) ->
       Proofview.tclENV >>= fun env ->
       Proofview.tclEVARMAP >>= fun sigma ->
       tclZEROMSG (

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -1560,7 +1560,7 @@ let assert_replacing id newt tac =
 
 let newfail n s =
   let info = Exninfo.reify () in
-  Proofview.tclZERO ~info (Tacticals.FailError (n, lazy s))
+  Proofview.tclZERO ~info (Tacticals.FailError (n, s))
 
 let cl_rewrite_clause_newtac ?abs ?origsigma ~progress strat clause =
   let open Proofview.Notations in
@@ -1651,7 +1651,7 @@ let cl_rewrite_clause_strat progress strat clause =
       (cl_rewrite_clause_newtac ~progress strat clause)
       (fun (e, info) -> match e with
        | Tacticals.FailError (n, pp) ->
-         tclFAILn ~info n (str"setoid rewrite failed: " ++ Lazy.force pp)
+         tclFAILn ~info n (str"setoid rewrite failed: " ++ pp)
        | e ->
          Proofview.tclZERO ~info e))
 

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -1560,7 +1560,7 @@ let assert_replacing id newt tac =
 
 let newfail n s =
   let info = Exninfo.reify () in
-  Proofview.tclZERO ~info (Tacticals.FailError (n, s))
+  Proofview.tclERROR ~info Tacticals.FailError (n, s)
 
 let cl_rewrite_clause_newtac ?abs ?origsigma ~progress strat clause =
   let open Proofview.Notations in
@@ -1650,7 +1650,7 @@ let cl_rewrite_clause_strat progress strat clause =
    (Proofview.tclOR
       (cl_rewrite_clause_newtac ~progress strat clause)
       (fun (e, info) -> match e with
-       | Tacticals.FailError (n, pp) ->
+       | CoqError (Tacticals.FailError, (n, pp)) ->
          tclFAILn ~info n (str"setoid rewrite failed: " ++ pp)
        | e ->
          Proofview.tclZERO ~info e))

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -1634,8 +1634,9 @@ let cl_rewrite_clause_newtac ?abs ?origsigma ~progress strat clause =
       (* For compatibility *)
       beta <*> Proofview.shelve_unifiable
     with
-    | PretypeError (env, evd, (UnsatisfiableConstraints _ as e)) ->
-      CErrors.coq_error RewriteFailure (env, evd, e)
+    | CoqError (PretypeError, (env, evd, (UnsatisfiableConstraints _ as e))) as exn ->
+      let _, info = Exninfo.capture exn in
+      CErrors.coq_error ~info RewriteFailure (env, evd, e)
   end
 
 let tactic_init_setoid () =

--- a/tactics/rewrite.mli
+++ b/tactics/rewrite.mli
@@ -16,7 +16,8 @@ open Tactypes
 
 (** TODO: document and clean me! *)
 
-exception RewriteFailure of Environ.env * Evd.evar_map * Pretype_errors.pretype_error
+type rewrite_failure = Environ.env * Evd.evar_map * Pretype_errors.pretype_error
+type _ CErrors.tag += RewriteFailure : rewrite_failure CErrors.tag
 
 type unary_strategy =
     Subterms | Subterm | Innermost | Outermost

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -24,7 +24,7 @@ module NamedDecl = Context.Named.Declaration
 (*   Tacticals       *)
 (*********************)
 
-exception FailError of int * Pp.t Lazy.t
+exception FailError of int * Pp.t
 
 let catch_failerror (e, info) =
   match e with
@@ -143,7 +143,7 @@ let tclFAILn ?info lvl msg =
     | None -> Exninfo.reify ()
     | Some info -> info
   in
-  tclZERO ~info (FailError (lvl,lazy msg))
+  tclZERO ~info (FailError (lvl, msg))
 
 let tclFAIL ?info msg = tclFAILn ?info 0 msg
 
@@ -193,7 +193,7 @@ let tclORD t1 t2 =
 
 let tclONCE = Proofview.tclONCE
 
-let tclEXACTLY_ONCE t = Proofview.tclEXACTLY_ONCE (FailError(0,lazy (assert false))) t
+let tclEXACTLY_ONCE t = Proofview.tclEXACTLY_ONCE (FailError(0, Pp.str "should not be seen")) t
 
 let tclIFCATCH t tt te =
   tclINDEPENDENT begin
@@ -467,9 +467,9 @@ let tclTIMEOUT n t =
   Proofview.tclOR
     (Proofview.tclTIMEOUT n t)
     begin function (e, info) -> match e with
-      | CErrors.CoqError (Logic_monad.Tac_Timeout, ()) as e ->
+      | CErrors.CoqError (Logic_monad.Tac_Timeout, ()) ->
         let info = Exninfo.reify () in
-        Proofview.tclZERO ~info (FailError (0,lazy (CErrors.print e)))
+        Proofview.tclZERO ~info (FailError (0, Logic_monad.tac_timeout_msg))
       | e -> Proofview.tclZERO ~info e
     end
 

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -158,8 +158,7 @@ let tclZEROMSG ?info ?loc msg =
   | None -> info
   | Some loc -> Loc.add_loc info loc
   in
-  let err = UserError msg in
-  tclZERO ~info err
+  tclERROR ~info UserError msg
 
 let catch_failerror e =
   try
@@ -230,7 +229,7 @@ let tclTHENS3PARTS t1 l1 repeat l2 =
       Proofview.tclORELSE (* converts the [SizeMismatch] error into an ltac error *)
         begin tclEXTEND (Array.to_list l1) repeat (Array.to_list l2) end
         begin function (e, info) -> match e with
-          | SizeMismatch (i,_)->
+          | CErrors.CoqError (SizeMismatch, (i,_))->
               let errmsg =
                 str"Incorrect number of goals" ++ spc() ++
                 str"(expected "++int i++str(String.plural i " tactic") ++ str")"
@@ -283,7 +282,7 @@ let tclTHENS t l =
     t <*>Proofview.tclORELSE (* converts the [SizeMismatch] error into an ltac error *)
         begin tclDISPATCH l end
         begin function (e, info) -> match e with
-          | SizeMismatch (i,_)->
+          | CErrors.CoqError (SizeMismatch, (i,_))->
               let errmsg =
                 str"Incorrect number of goals" ++ spc() ++
                 str"(expected "++int i++str(String.plural i " tactic") ++ str")"
@@ -468,7 +467,7 @@ let tclTIMEOUT n t =
   Proofview.tclOR
     (Proofview.tclTIMEOUT n t)
     begin function (e, info) -> match e with
-      | Logic_monad.Tac_Timeout as e ->
+      | CErrors.CoqError (Logic_monad.Tac_Timeout, ()) as e ->
         let info = Exninfo.reify () in
         Proofview.tclZERO ~info (FailError (0,lazy (CErrors.print e)))
       | e -> Proofview.tclZERO ~info e

--- a/tactics/tacticals.mli
+++ b/tactics/tacticals.mli
@@ -15,7 +15,7 @@ open Locus
 open Tactypes
 
 (** A special exception for levels for the Fail tactic *)
-exception FailError of int * Pp.t
+type _ CErrors.tag += FailError : (int * Pp.t) CErrors.tag
 
 (** Tacticals defined directly in term of Proofview *)
 

--- a/tactics/tacticals.mli
+++ b/tactics/tacticals.mli
@@ -15,7 +15,7 @@ open Locus
 open Tactypes
 
 (** A special exception for levels for the Fail tactic *)
-exception FailError of int * Pp.t Lazy.t
+exception FailError of int * Pp.t
 
 (** Tacticals defined directly in term of Proofview *)
 

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -5223,7 +5223,7 @@ let constr_eq ~strict x y =
         let csts = UnivProblem.Set.force csts in
         begin match Evd.add_universe_constraints evd csts with
            | evd -> Proofview.Unsafe.tclEVARS evd
-           | exception (UGraph.UniverseInconsistency _ as e) ->
+           | exception (CoqError (UGraph.UniverseInconsistency, _) as e) ->
              let _, info = Exninfo.capture e in
              fail_universes ~info
         end

--- a/topbin/coqnative_bin.ml
+++ b/topbin/coqnative_bin.ml
@@ -204,7 +204,7 @@ let add_path ~unix_path:dir ~coq_root:coq_dirpath =
 
 let convert_string d =
   try Id.of_string d
-  with CErrors.UserError _ ->
+  with CErrors.(CoqError (UserError, _)) ->
     Flags.if_verbose Feedback.msg_warning
       (str "Directory " ++ str d ++ str " cannot be used as a Coq identifier (skipped)");
     raise_notrace Exit

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -192,7 +192,7 @@ end
 let make_prompt () =
   try
     (Names.Id.to_string (Vernacstate.Declare.get_current_proof_name ())) ^ " < "
-  with Vernacstate.Declare.NoCurrentProof ->
+  with CErrors.CoqError (Vernacstate.Declare.NoCurrentProof, ()) ->
     "Coq < "
   [@@ocaml.warning "-3"]
 
@@ -257,7 +257,7 @@ let rec discard_to_dot () =
   try
     Pcoq.Entry.parse parse_to_dot top_buffer.tokens
   with
-    | CLexer.Error.E _ -> (* Lexer failed *) discard_to_dot ()
+    | CErrors.CoqError (CLexer.Error.E, _) -> (* Lexer failed *) discard_to_dot ()
     | e when CErrors.noncritical e -> ()
 
 let read_sentence ~state input =

--- a/toplevel/vernac.ml
+++ b/toplevel/vernac.ml
@@ -75,7 +75,7 @@ let interp_vernac ~check ~interactive ~state ({CAst.loc;_} as com) =
       let reraise = if interactive then begin
           (* Exceptions don't carry enough state to print themselves (typically missing the nametab)
              so we need to print before resetting to an older state. See eg #16745 *)
-          let reraise = UserError (CErrors.print reraise) in
+          let reraise = CoqError (UserError, (CErrors.print reraise)) in
           ignore(Stm.edit_at ~doc:state.doc state.sid);
           reraise
         end

--- a/vernac/comArguments.ml
+++ b/vernac/comArguments.ml
@@ -267,7 +267,7 @@ let vernac_arguments ~section_local reference args more_implicits flags =
   if scopes_specified || clear_scopes_flag then begin
     let scopes = List.map (List.map (fun {loc;v=k} ->
         try ignore (Notation.find_scope k); k
-        with CErrors.UserError _ ->
+        with CErrors.(CoqError (UserError, _)) ->
           Notation.find_delimiters_scope ?loc k)) scopes
     in
     Notation.declare_arguments_scope section_local (smart_global reference) scopes

--- a/vernac/comCoercion.ml
+++ b/vernac/comCoercion.ml
@@ -34,7 +34,7 @@ type coercion_error_kind =
   | ForbiddenSourceClass of cl_typ
   | NoTarget
   | WrongTarget of cl_typ * cl_typ
-  | NotAClass of GlobRef.t
+  | NotACoercionClass of GlobRef.t
 
 exception CoercionError of coercion_error_kind
 
@@ -55,7 +55,7 @@ let explain_coercion_error g = function
   | WrongTarget (clt,cl) ->
       (str"Found target class " ++ pr_class cl ++
        str " instead of " ++ pr_class clt)
-  | NotAClass ref ->
+  | NotACoercionClass ref ->
       (str "Type of " ++ Printer.pr_global ref ++
          str " does not end with a sort")
 
@@ -65,7 +65,7 @@ let check_reference_arity ref =
   let env = Global.env () in
   let c, _ = Typeops.type_of_global_in_context env ref in
   if not (Reductionops.is_arity env (Evd.from_env env) (EConstr.of_constr c)) (* FIXME *) then
-    raise (CoercionError (NotAClass ref))
+    raise (CoercionError (NotACoercionClass ref))
 
 let check_arity = function
   | CL_FUN | CL_SORT -> ()

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -73,15 +73,15 @@ let check_all_names_different indl =
   let cstr_names = List.map_append (fun ind -> List.map fst ind.ind_lc) indl in
   let ind_names = match elements ind_names with
   | s -> s
-  | exception (Same t) -> raise (InductiveError (SameNamesTypes t))
+  | exception (Same t) -> CErrors.coq_error InductiveError (SameNamesTypes t)
   in
   let cstr_names = match elements cstr_names with
   | s -> s
-  | exception (Same c) -> raise (InductiveError (SameNamesConstructors c))
+  | exception (Same c) -> CErrors.coq_error InductiveError (SameNamesConstructors c)
   in
   let l = Id.Set.inter ind_names cstr_names in
   if not (Id.Set.is_empty l) then
-    raise (InductiveError (SameNamesOverlap (Id.Set.elements l)))
+    CErrors.coq_error InductiveError (SameNamesOverlap (Id.Set.elements l))
 
 (** Make the arity conclusion flexible to avoid generating an upper bound universe now,
     only if the universe does not appear anywhere else.
@@ -336,7 +336,7 @@ let inductive_levels env evd arities inds =
         let evd =
           if Sorts.is_set du then
             if not (Evd.check_leq evd cu (EConstr.ESorts.make Sorts.set)) then
-              raise (InductiveError LargeNonPropInductiveNotInType)
+              CErrors.coq_error InductiveError LargeNonPropInductiveNotInType
             else evd
           else evd
         in

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -498,7 +498,7 @@ let check_param = function
 | CLocalAssum (nas, Default _, _) -> List.iter check_named nas
 | CLocalAssum (nas, Generalized _, _) -> ()
 | CLocalPattern {CAst.loc} ->
-    Loc.raise ?loc (Gramlib.Stream.Error "pattern with quote not allowed here")
+    CErrors.coq_error ?loc Gramlib.Grammar.Error "pattern with quote not allowed here"
 
 let restrict_inductive_universes sigma ctx_params arities constructors =
   let merge_universes_of_constr c =
@@ -774,7 +774,7 @@ let rec count_binder_expr = function
   | CLocalAssum(l,_,_) :: rest -> List.length l + count_binder_expr rest
   | CLocalDef _ :: rest -> 1 + count_binder_expr rest
   | CLocalPattern {CAst.loc} :: _ ->
-    Loc.raise ?loc (Gramlib.Stream.Error "pattern with quote not allowed here")
+    CErrors.coq_error ?loc Gramlib.Grammar.Error "pattern with quote not allowed here"
 
 let interp_mutual_inductive ~env ~template udecl indl ~cumulative ~poly ?typing_flags ~private_ind ~uniform finite =
   let (params,indl),coercions,ntns = extract_mutual_inductive_declaration_components indl in

--- a/vernac/comPrimitive.ml
+++ b/vernac/comPrimitive.ml
@@ -42,8 +42,8 @@ let do_primitive id udecl prim typopt =
     let evd = try Evarconv.unify_delay env evd typ expected_typ
       with Evarconv.UnableToUnify (evd,e) as exn ->
         let _, info = Exninfo.capture exn in
-        Exninfo.iraise (Pretype_errors.(
-            PretypeError (env,evd,CannotUnify (typ,expected_typ,Some e)),info))
+        CErrors.coq_error ~info Pretype_errors.PretypeError
+          (env,evd,CannotUnify (typ,expected_typ,Some e))
     in
     Pretyping.check_evars_are_solved ~program_mode:false env evd;
     let evd = Evd.minimize_universes evd in

--- a/vernac/comSearch.ml
+++ b/vernac/comSearch.ml
@@ -73,7 +73,7 @@ let interp_search_item env sigma =
           Notation.interp_notation_as_global_reference
             ~head:false (fun _ -> true) s sc in
         GlobSearchSubPattern (where,head,Pattern.PRef ref)
-      with UserError _ ->
+      with CoqError (UserError, _) ->
         user_err
           (str "Unable to interpret " ++ quote (str s) ++ str " as a reference."))
   | SearchKind k ->

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -2254,7 +2254,7 @@ let solve_by_tac prg obls i tac =
     Inductiveops.control_only_guard env (Evd.from_ctx uctx) (EConstr.of_constr body);
     Some (body, types, uctx)
   with
-  | Tacticals.FailError (_, s) as exn ->
+  | CErrors.CoqError (Tacticals.FailError, (_, s)) as exn ->
     let _ = Exninfo.capture exn in
     let loc = fst obl.obl_location in
     CErrors.user_err ?loc s

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -2257,7 +2257,7 @@ let solve_by_tac prg obls i tac =
   | Tacticals.FailError (_, s) as exn ->
     let _ = Exninfo.capture exn in
     let loc = fst obl.obl_location in
-    CErrors.user_err ?loc (Lazy.force s)
+    CErrors.user_err ?loc s
   (* If the proof is open we absorb the error and leave the obligation open *)
   | CErrors.CoqError (Proof_.OpenProof, _) ->
     None

--- a/vernac/declareUniv.mli
+++ b/vernac/declareUniv.mli
@@ -10,9 +10,9 @@
 
 open Names
 
-(** Also used by [Declare] for constants, [DeclareInd] for inductives, etc.
-    Containts [object_kind , id]. *)
-exception AlreadyDeclared of (string option * Id.t)
+(** Also used by [Declare] for constants, [DeclareInd] for inductives, etc. *)
+type already_declared = { kind : string option; id : Id.t }
+type _ CErrors.tag += AlreadyDeclared : already_declared CErrors.tag
 
 (** Internally used to declare names of universes from monomorphic
    constants/inductives. Noop on polymorphic references. *)

--- a/vernac/future.mli
+++ b/vernac/future.mli
@@ -35,8 +35,6 @@ end
 module UUIDMap : Map.S with type key = UUID.t
 module UUIDSet : Set.S with type elt = UUID.t
 
-exception NotReady of string
-
 type 'a computation
 type 'a value = [ `Val of 'a | `Exn of Exninfo.iexn ]
 

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1480,7 +1480,7 @@ let explain_exn_default = function
 
 let _ = CErrors.register_handler (wrap_unhandled explain_exn_default)
 
-let rec vernac_interp_error_handler = function
+let vernac_interp_error_handler = function
   | UGraph.UniverseInconsistency i ->
     str "Universe inconsistency." ++ spc() ++
     UGraph.explain_universe_inconsistency UnivNames.(pr_with_global_universes empty_binders) i ++ str "."
@@ -1518,8 +1518,6 @@ let rec vernac_interp_error_handler = function
     str "Tactic failure" ++
     (if Pp.ismt s then s else str ": " ++ s) ++
     if Int.equal i 0 then str "." else str " (level " ++ int i ++ str")."
-  | Logic_monad.TacticFailure e ->
-    vernac_interp_error_handler e
   | _ ->
     raise Unhandled
 

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1475,11 +1475,6 @@ let explain_exn_default = function
   (* Basic interaction exceptions *)
   | Gramlib.Stream.Error txt -> hov 0 (str "Syntax error: " ++ str txt ++ str ".")
   | CLexer.Error.E err -> hov 0 (str (CLexer.Error.to_string err))
-  | Sys_error msg -> hov 0 (str "System error: " ++ quote (str msg))
-  | Out_of_memory -> hov 0 (str "Out of memory.")
-  | Stack_overflow -> hov 0 (str "Stack overflow.")
-  | Control.Timeout -> hov 0 (str "Timeout!")
-  | Sys.Break -> hov 0 (str "User interrupt.")
   (* Otherwise, not handled here *)
   | _ -> raise Unhandled
 

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1505,7 +1505,6 @@ let vernac_interp_error_handler = function
     spc () ++ str "was not found" ++
     spc () ++ str "in the current" ++ spc () ++ str "environment."
   | Tacticals.FailError (i,s) ->
-    let s = Lazy.force s in
     str "Tactic failure" ++
     (if Pp.ismt s then s else str ": " ++ s) ++
     if Int.equal i 0 then str "." else str " (level " ++ int i ++ str")."

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1478,7 +1478,7 @@ let explain_exn_default = function
   | Sys_error msg -> hov 0 (str "System error: " ++ quote (str msg))
   | Out_of_memory -> hov 0 (str "Out of memory.")
   | Stack_overflow -> hov 0 (str "Stack overflow.")
-  | CErrors.Timeout -> hov 0 (str "Timeout!")
+  | Control.Timeout -> hov 0 (str "Timeout!")
   | Sys.Break -> hov 0 (str "User interrupt.")
   (* Otherwise, not handled here *)
   | _ -> raise Unhandled

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1173,7 +1173,7 @@ let explain_unbound_method env sigma cid { CAst.v = id } =
   str"of class" ++ spc () ++ pr_global cid ++ str "."
 
 let explain_typeclass_error env sigma = function
-  | NotAClass c -> explain_not_a_class env sigma c
+  | NotATypeclass c -> explain_not_a_class env sigma c
   | UnboundMethod (cid, id) -> explain_unbound_method env sigma cid id
 
 (* Refiner errors *)

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1462,15 +1462,10 @@ let wrap_unhandled f e =
   with Unhandled -> None
 
 let vernac_interp_error_handler = function
-  | TypeError(ctx,te) ->
-    let te = map_ptype_error EConstr.of_constr te in
-    explain_type_error ctx Evd.empty te
   | PretypeError(ctx,sigma,te) ->
     explain_pretype_error ctx sigma te
   | Typeclasses_errors.TypeClassError(env, sigma, te) ->
     explain_typeclass_error env sigma te
-  | InductiveError e ->
-    explain_inductive_error e
   | Primred.IncompatibleDeclarations (act,x,y) ->
     explain_incompatible_prim_declarations act x y
   | Modops.ModuleTypingError e ->
@@ -1511,4 +1506,18 @@ let () = CErrors.register (module struct
     type e = Notation.prim_token_notation_error
     type _ CErrors.tag += T = Notation.PrimTokenNotationError
     let pp e = Notation.explain_prim_token_notation_error pr_constr_env e
+  end)
+
+let () = CErrors.register (module struct
+    type e = Environ.env * Type_errors.type_error
+    type _ CErrors.tag += T = Type_errors.TypeError
+    let pp (env,te) =
+      let te = map_ptype_error EConstr.of_constr te in
+      explain_type_error env (Evd.from_env env) te
+  end)
+
+let () = CErrors.register (module struct
+    type e = Type_errors.inductive_error
+    type _ CErrors.tag += T = Type_errors.InductiveError
+    let pp = explain_inductive_error
   end)

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -120,7 +120,7 @@ let try_declare_scheme what f internal names kn =
   try f names kn
   with e ->
   let e = Exninfo.capture e in
-  let rec extract_exn = function Logic_monad.TacticFailure e -> extract_exn e | e -> e in
+  let rec extract_exn = function CErrors.CoqError (Logic_monad.TacticFailure, e) -> extract_exn e | e -> e in
   let msg = match extract_exn (fst e) with
     | ParameterWithoutEquality cst ->
         alarm what internal
@@ -144,7 +144,7 @@ let try_declare_scheme what f internal names kn =
     | UndefinedCst s ->
         alarm what internal
           (strbrk "Required constant " ++ str s ++ str " undefined.")
-    | DeclareUniv.AlreadyDeclared (kind, id) as exn ->
+    | CErrors.CoqError (DeclareUniv.AlreadyDeclared, _) as exn ->
       let msg = CErrors.print exn in
       alarm what internal msg
     | DecidabilityMutualNotSupported ->
@@ -174,7 +174,7 @@ let try_declare_scheme what f internal names kn =
   in
   match msg with
   | None -> ()
-  | Some msg -> Exninfo.iraise (CErrors.UserError msg, snd e)
+  | Some msg -> CErrors.user_err ~info:(snd e) msg
 
 let beq_scheme_msg mind =
   let mib = Global.lookup_mind mind in

--- a/vernac/loadpath.ml
+++ b/vernac/loadpath.ml
@@ -323,7 +323,7 @@ let warn_cannot_use_directory =
 let convert_string d =
   try Names.Id.of_string d
   with
-  | CErrors.UserError _ ->
+  | CErrors.(CoqError (UserError, _)) ->
     let d = Unicode.escaped_if_non_utf8 d in
     warn_cannot_use_directory d;
     raise_notrace Exit

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -936,15 +936,17 @@ let default = {
 
 end
 
-exception UnknownCustomEntry of string
+type _ CErrors.tag += UnknownCustomEntry : string CErrors.tag
 
-let () = CErrors.register_handler @@ function
-  | UnknownCustomEntry entry -> Some Pp.(str "Unknown custom entry: " ++ str entry ++ str ".")
-  | _ -> None
+let () = CErrors.register (module struct
+    type e = string
+    type _ CErrors.tag += T = UnknownCustomEntry
+    let pp entry = Pp.(str "Unknown custom entry: " ++ str entry ++ str ".")
+  end)
 
 let check_custom_entry entry =
   if not (Egramcoq.exists_custom_entry entry) then
-    raise @@ UnknownCustomEntry entry
+    CErrors.coq_error UnknownCustomEntry entry
 
 let check_entry_type = function
   | ETConstr (InCustomEntry entry,_,_) -> check_custom_entry entry

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -102,7 +102,7 @@ let check_parameters_must_be_named = function
   | CLocalAssum (ls, bk, _ce) ->
     List.iter (error_parameters_must_be_named bk) ls
   | CLocalPattern {CAst.loc} ->
-    Loc.raise ?loc (Gramlib.Stream.Error "pattern with quote not allowed in record parameters")
+    CErrors.coq_error ?loc Gramlib.Grammar.Error "pattern with quote not allowed in record parameters"
 
 (** [DataI.t] contains the information used in record interpretation,
    it is a strict subset of [Ast.t] thus this should be

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -399,7 +399,7 @@ let build_named_proj ~primitive ~flags ~poly ~univs ~uinstance ~kind env paramde
   let kind = Decls.IsDefinition kind in
   let kn =
     try Declare.declare_constant ~name:fid ~kind (Declare.DefinitionEntry entry)
-    with Type_errors.TypeError (ctx,te) as exn when not primitive ->
+    with CoqError (Type_errors.TypeError, (ctx,te)) as exn when not primitive ->
       let _, info = Exninfo.capture exn in
       Exninfo.iraise (NotDefinable (BadTypedProj (fid,ctx,te)),info)
   in

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -59,7 +59,7 @@ let vernac_timeout ?timeout (f : 'a -> 'b) (x : 'a) : 'b =
   | _, Some n
   | Some n, None ->
     (match Control.timeout (float_of_int n) f x with
-    | None -> Exninfo.iraise (Exninfo.capture CErrors.Timeout)
+    | None -> Exninfo.iraise (Exninfo.capture Control.Timeout)
     | Some x -> x)
   | None, None ->
     f x
@@ -77,7 +77,7 @@ let with_fail f : (Loc.t option * Pp.t, unit) result =
   | e ->
     (* The error has to be printed in the failing state *)
     let _, info as exn = Exninfo.capture e in
-    if CErrors.is_anomaly e && e != CErrors.Timeout then Exninfo.iraise exn;
+    if CErrors.is_anomaly e && e != Control.Timeout then Exninfo.iraise exn;
     Ok (Loc.get_loc info, CErrors.iprint exn)
 
 let real_error_loc ~cmdloc ~eloc =

--- a/vernac/vernacstate.mli
+++ b/vernac/vernacstate.mli
@@ -88,7 +88,7 @@ end
 (* Compatibility module: Do Not Use *)
 module Declare : sig
 
-  exception NoCurrentProof
+  type _ CErrors.tag += NoCurrentProof : unit CErrors.tag
 
   val there_are_pending_proofs : unit -> bool
   val get_open_goals : unit -> int


### PR DESCRIPTION
There are still a couple users of the old registration mechanism:
- mltop for `Dynlink.Error` and `Fl_package_base.No_such_package`
- coqtop_byte_bin for `Symtable.Error`

Typical diff:
~~~diff
modified   plugins/ltac/taccoerce.ml
@@ -442,15 +442,17 @@ let (wit_tacvalue : (Empty.t, tacvalue, tacvalue) Genarg.genarg_type) =
   let () = Genprint.register_val_print0 (base_val_typ wit) pr in
   wit
 
-exception CoercionError of Id.t * (Environ.env * Evd.evar_map) option * Val.t * string
+type coercion_error = Id.t * (Environ.env * Evd.evar_map) option * Val.t * string
+type _ CErrors.tag += TacCoercionError : coercion_error CErrors.tag
 
-let () = CErrors.register_handler begin function
-| CoercionError (id, env, v, s) ->
-  Some (str "Ltac variable " ++ Id.print id ++
-   strbrk " is bound to" ++ spc () ++ pr_value env v ++ spc () ++
-   strbrk "which cannot be coerced to " ++ str s ++ str".")
-| _ -> None
-end
+let () = CErrors.register (module struct
+    type e = coercion_error
+    type _ CErrors.tag += T = TacCoercionError
+    let pp (id, env, v, s) =
+      str "Ltac variable " ++ Id.print id ++
+      strbrk " is bound to" ++ spc () ++ pr_value env v ++ spc () ++
+      strbrk "which cannot be coerced to " ++ str s ++ str"."
+  end)
 
 let error_ltac_variable ?loc id env v s =
-  Loc.raise ?loc (CoercionError (id, env, v, s))
+  CErrors.coq_error ?loc TacCoercionError (id, env, v, s)
~~~