### PR TITLE
Adding "assumption id" to tell explicitly which assumption to use

### DIFF
--- a/plugins/ltac/coretactics.mlg
+++ b/plugins/ltac/coretactics.mlg
@@ -36,6 +36,7 @@ END
 
 TACTIC EXTEND assumption
 | [ "assumption" ] -> { Tactics.assumption }
+| [ "assumption" ident(id) ] -> { Tactics.exact_check (EConstr.mkVar id) }
 END
 
 TACTIC EXTEND etransitivity


### PR DESCRIPTION
This is motivated by teaching (e.g. in classes which identify the axiom rule with `assumption`). It seems also rather natural. It also useful to tell explicitly which hypotheses to use when there are several of them, w/o having to switch to the concept of `exact`.

Internally, it is however interpreted as `exact id`.

- [ ] Added / updated **test-suite**.
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
