### PR TITLE
Remove unused kernel reduction API

### DIFF
--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -121,17 +121,6 @@ let pure_stack lfts stk =
 (*                   Reduction Functions                                    *)
 (****************************************************************************)
 
-let whd_betaiota env t =
-  match kind t with
-    | (Sort _|Var _|Meta _|Evar _|Const _|Ind _|Construct _|
-       Prod _|Lambda _|Fix _|CoFix _) -> t
-    | App (c, _) ->
-      begin match kind c with
-      | Ind _ | Construct _ | Evar _ | Meta _ | Const _ | LetIn _ -> t
-      | _ -> whd_val (create_clos_infos betaiota env) (create_tab ()) (inject t)
-      end
-    | _ -> whd_val (create_clos_infos betaiota env) (create_tab ()) (inject t)
-
 let whd_all env t =
   match kind t with
     | (Sort _|Meta _|Evar _|Ind _|Construct _|

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -132,20 +132,6 @@ let whd_betaiota env t =
       end
     | _ -> whd_val (create_clos_infos betaiota env) (create_tab ()) (inject t)
 
-let whd_betaiotazeta env x =
-  match kind x with
-  | (Sort _|Var _|Meta _|Evar _|Const _|Ind _|Construct _|
-       Prod _|Lambda _|Fix _|CoFix _|Int _|Float _|Array _) -> x
-    | App (c, _) ->
-      begin match kind c with
-      | Ind _ | Construct _ | Evar _ | Meta _ | Const _ | Int _ | Float _ | Array _ -> x
-      | Sort _ | Rel _ | Var _ | Cast _ | Prod _ | Lambda _ | LetIn _ | App _
-        | Case _ | Fix _ | CoFix _ | Proj _ ->
-         whd_val (create_clos_infos betaiotazeta env) (create_tab ()) (inject x)
-      end
-    | Rel _ | Cast _ | LetIn _ | Case _ | Proj _ ->
-        whd_val (create_clos_infos betaiotazeta env) (create_tab ()) (inject x)
-
 let whd_all env t =
   match kind t with
     | (Sort _|Meta _|Evar _|Ind _|Construct _|

--- a/kernel/reduction.mli
+++ b/kernel/reduction.mli
@@ -19,8 +19,6 @@ open Environ
 val whd_all                 : env -> constr -> constr
 val whd_allnolet : env -> constr -> constr
 
-val whd_betaiota     : env -> constr -> constr
-
 (***********************************************************************
   s conversion functions *)
 

--- a/kernel/reduction.mli
+++ b/kernel/reduction.mli
@@ -16,7 +16,6 @@ open Environ
 
 (* None of these functions do eta reduction *)
 
-val whd_betaiotazeta        : env -> constr -> constr
 val whd_all                 : env -> constr -> constr
 val whd_allnolet : env -> constr -> constr
 


### PR DESCRIPTION
The kernel only really cares about full weak head, and we still (ab)use the nolet variant in VM / native reduction.