### PR TITLE
Fix canonical instance matching `match` terms in evarconv

### DIFF
--- a/doc/changelog/02-specification-language/17206-evarconv-canon-match.rst
+++ b/doc/changelog/02-specification-language/17206-evarconv-canon-match.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  canonical instance matching `match` terms
+  (`#17206 <https://github.com/coq/coq/pull/17206>`_,
+  fixes `#17079 <https://github.com/coq/coq/issues/17079>`_,
+  by Gaëtan Gilbert).

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -279,9 +279,11 @@ let check_conv_record env sigma (t1,sk1) (t2,sk2) =
       | None -> raise Not_found
       | Some (l',el,s') -> ((Option.get @@ Stack.list_of_app_stack l') @ [el],s') in
   let h, _ = decompose_app_vect sigma solution.body in
-    sigma,(h, t2),solution.constant,solution.abstractions_ty,(solution.params,params1),
+  let t2 = Stack.zip sigma (t2,sk2) in
+  let h2, _ = decompose_app_vect sigma t2 in
+    sigma,(h, h2),solution.constant,solution.abstractions_ty,(solution.params,params1),
     (solution.cvalue_arguments,us2),(extra_args1,extra_args2),c1,
-    (solution.cvalue_abstraction, Stack.zip sigma (t2,sk2))
+    (solution.cvalue_abstraction, t2)
 
 (* Precondition: one of the terms of the pb is an uninstantiated evar,
  * possibly applied to arguments. *)


### PR DESCRIPTION
Fix #17079

This patch was generated by looking at the process in ocamldebug and guessing what it should be doing, so I'm not very confident in it.
