### PR TITLE
Moving general-purpose rapply from Programs to Init

### DIFF
--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -995,9 +995,6 @@ Applying theorems
       :n:`@one_term` to arbitrarily many arguments without getting a type
       error, :tacn:`rapply` will loop.
 
-      Note that you must :n:`Require Import Coq.Program.Tactics` to
-      use :tacn:`rapply`.
-
    .. tacn:: simple apply {+, @one_term_with_bindings } {? @in_hyp_as }
 
       Behaves like :tacn:`apply` but it reasons modulo conversion only on subterms

--- a/theories/Init/Tactics.v
+++ b/theories/Init/Tactics.v
@@ -339,3 +339,11 @@ Create HintDb rewrite discriminated.
 #[global]
 Hint Variables Opaque : rewrite.
 Create HintDb typeclass_instances discriminated.
+
+(** A variant of [apply] using [refine], doing as much conversion as necessary. *)
+
+Ltac rapply p :=
+  (** before we try to add more underscores, first ensure that adding such underscores is valid *)
+  (assert_succeeds (idtac; let __ := open_constr:(p _) in idtac);
+   rapply uconstr:(p _))
+  || refine p.

--- a/theories/Program/Tactics.v
+++ b/theories/Program/Tactics.v
@@ -170,14 +170,6 @@ Ltac on_application f tac T :=
     | context [f ?x] => tac (f x)
   end.
 
-(** A variant of [apply] using [refine], doing as much conversion as necessary. *)
-
-Ltac rapply p :=
-  (** before we try to add more underscores, first ensure that adding such underscores is valid *)
-  (assert_succeeds (idtac; let __ := open_constr:(p _) in idtac);
-   rapply uconstr:(p _))
-  || refine p.
-
 (** Tactical [on_call f tac] applies [tac] on any application of [f] in the hypothesis or goal. *)
 
 Ltac on_call f tac :=


### PR DESCRIPTION
Who has experience with `rapply`? Shouldn't it be at some time the default `apply` (or, at least, unifall would lead to identify apply and rapply, right?)?

There is an alternative definition of `rapply` in TLC (and Software Foundations) which seems currently broken. Since there is a version of `rapply` already in Coq, maybe should we just rely on this one??

- [ ] Added **changelog** (?)
- [x] Updated **documentation**.
