### PR TITLE
Change refine so that it shelves all unknown variables dependent in the type of the proof term

### DIFF
--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -1047,7 +1047,7 @@ let () =
 (** (unit -> constr) -> unit *)
 let () =
   define "refine" (closure @-> tac unit) @@ fun c ->
-  let c = thaw c >>= fun c -> Proofview.tclUNIT ((), Tac2ffi.to_constr c) in
+  let c = thaw c >>= fun c -> Proofview.tclUNIT ((), [], Tac2ffi.to_constr c) in
   Proofview.Goal.enter @@ fun gl ->
   Refine.generic_refine ~typecheck:true c gl
 

--- a/proofs/refine.mli
+++ b/proofs/refine.mli
@@ -28,7 +28,9 @@ val refine : typecheck:bool -> (Evd.evar_map -> Evd.evar_map * EConstr.t) -> uni
     tactic failures. If [typecheck] is [true] [t] is type-checked beforehand.
     Shelved evars and goals are all marked as unresolvable for typeclasses. *)
 
-val generic_refine : typecheck:bool -> ('a * EConstr.t) tactic ->
+val refine_with_shelf : typecheck:bool -> (Evd.evar_map -> Evd.evar_map * Evar.t list * EConstr.t) -> unit tactic
+
+val generic_refine : typecheck:bool -> ('a * Evar.t list * EConstr.t) tactic ->
   Proofview.Goal.t -> 'a tactic
 (** The general version of refine. *)
 

--- a/test-suite/bugs/bug_15521.v
+++ b/test-suite/bugs/bug_15521.v
@@ -1,0 +1,9 @@
+(* apply vs rapply *)
+
+Axiom f : forall x y, x = 0 -> x + y = 0.
+Goal exists x, x = 0 /\ x = 0.
+  eexists. split.
+  refine (f _ _ _). (* core of rapply *)
+  - reflexivity.
+  - reflexivity.
+Qed.

--- a/test-suite/output/unifconstraints.out
+++ b/test-suite/output/unifconstraints.out
@@ -1,61 +1,65 @@
-3 focused goals (shelved: 1)
+2 focused goals (shelved: 2)
   
   ============================
-  ?Goal 0
+  ?P 0
 
 goal 2 is:
- forall n : nat, ?Goal n -> ?Goal (S n)
-goal 3 is:
- nat
+ forall n : nat, ?P n -> ?P (S n)
 unification constraint:
- ?Goal ?Goal2 <=
+ ?P ?n <=
    True /\ True /\ True \/
    veeryyyyyyyyyyyyloooooooooooooonggidentifier =
    veeryyyyyyyyyyyyloooooooooooooonggidentifier
-3 focused goals (shelved: 1)
+4 goals
   
   n, m : nat
   ============================
-  ?Goal@{n:=n; m:=m} 0
+  nat -> Type
 
 goal 2 is:
- forall n0 : nat, ?Goal@{n:=n; m:=m} n0 -> ?Goal@{n:=n; m:=m} (S n0)
+ ?P@{n:=n; m:=m} 0
 goal 3 is:
+ forall n0 : nat, ?P@{n:=n; m:=m} n0 -> ?P@{n:=n; m:=m} (S n0)
+goal 4 is:
  nat
 unification constraint:
- ?Goal@{n:=n; m:=m} ?Goal2@{n:=n; m:=m} <=
+ ?P@{n:=n; m:=m} ?n@{n:=n; m:=m} <=
    True /\ True /\ True \/
    veeryyyyyyyyyyyyloooooooooooooonggidentifier =
    veeryyyyyyyyyyyyloooooooooooooonggidentifier
-3 focused goals (shelved: 1)
+4 focused goals (shelved: 1)
   
   m : nat
   ============================
-  ?Goal1@{m:=m} 0
+  nat -> Type
 
 goal 2 is:
- forall n0 : nat, ?Goal1@{m:=m} n0 -> ?Goal1@{m:=m} (S n0)
+ ?P@{m:=m} 0
 goal 3 is:
+ forall n0 : nat, ?P@{m:=m} n0 -> ?P@{m:=m} (S n0)
+goal 4 is:
  nat
 unification constraint:
  
- n, m : nat |- ?Goal1@{m:=m} ?Goal0@{n:=n; m:=m} <=
+ n, m : nat |- ?P@{m:=m} ?n@{n:=n; m:=m} <=
    True /\ True /\ True \/
    veeryyyyyyyyyyyyloooooooooooooonggidentifier =
    veeryyyyyyyyyyyyloooooooooooooonggidentifier
-3 focused goals (shelved: 1)
+4 focused goals (shelved: 1)
   
   m : nat
   ============================
-  ?Goal0@{m:=m} 0
+  nat -> Type
 
 goal 2 is:
- forall n0 : nat, ?Goal0@{m:=m} n0 -> ?Goal0@{m:=m} (S n0)
+ ?P@{m:=m} 0
 goal 3 is:
+ forall n0 : nat, ?P@{m:=m} n0 -> ?P@{m:=m} (S n0)
+goal 4 is:
  nat
 unification constraint:
  
- n, m : nat |- ?Goal0@{m:=m} ?Goal2@{n:=n} <=
+ n, m : nat |- ?P@{m:=m} ?Goal0@{n:=n} <=
    True /\ True /\ True \/
    veeryyyyyyyyyyyyloooooooooooooonggidentifier =
    veeryyyyyyyyyyyyloooooooooooooonggidentifier

--- a/test-suite/output/unifconstraints.v
+++ b/test-suite/output/unifconstraints.v
@@ -14,11 +14,11 @@ Goal forall n m : nat, True /\ True /\ True \/
                         veeryyyyyyyyyyyyloooooooooooooonggidentifier =
                         veeryyyyyyyyyyyyloooooooooooooonggidentifier.
   intros.
-  refine (nat_rect _ _ _ _).
+  simple refine (nat_rect _ _ _ _).
   Show.
-  clear n. 
+  2:clear n.
   Show.
-  3:clear m.
+  4:clear m.
   Show.
 Admitted.
 Unset Printing Existential Instances.

--- a/theories/Logic/Hurkens.v
+++ b/theories/Logic/Hurkens.v
@@ -210,11 +210,11 @@ Definition I (x:El1 U) : U0 :=
 
 Lemma Omega : El0 (∀₀¹ i:U⟶₁u0, induct i ⟶₀ i ·₁ WF).
 Proof.
-  refine (λ₀¹ i, λ₀ y, _).
-  refine (y·₀[_]·₀_).
+  simple refine (λ₀¹ i, λ₀ y, _).
+  simple refine (y·₀[_]·₀_).
   unfold le,WF,induct. simplify.
   refine (λ₀¹ x, λ₀ h0, _). simplify.
-  refine (y·₀[_]·₀_).
+  simple refine (y·₀[_]·₀_).
   unfold le. simplify.
   unfold sb at 1. simplify.
   unfold le' at 1. simplify.
@@ -230,12 +230,12 @@ Proof.
   { generalize (q·₀[λ₁ u, I u]·₀p). simplify.
     intros q'.
     exact q'. }
-  refine (h·₀_).
+  simple refine (h·₀_).
   refine (λ₀¹ i,_).
   refine (λ₀ h', _).
   generalize (q·₀[λ₁ y, i ·₁ (λ₁ v, (sb v)·₁[U] ·₁ le' ·₁ y)]). simplify.
   intros q'.
-  refine (q'·₀_). clear q'.
+  simple refine (q'·₀_). clear q'.
   unfold le at 1 in h'. simplify_in h'.
   unfold sb at 1 in h'. simplify_in h'.
   unfold le' at 1 in h'. simplify_in h'.
@@ -244,16 +244,16 @@ Qed.
 
 Lemma lemma2 : El0 ((∀₀¹i:U⟶₁u0, induct i ⟶₀ i·₁WF) ⟶₀ F).
 Proof.
-  refine (λ₀ x, _).
+  simple refine (λ₀ x, _).
   assert (El0 (I WF)) as h.
   { generalize (x·₀[λ₁ u, I u]·₀lemma1). simplify.
     intros q.
     exact q. }
-  refine (h·₀_). clear h.
+  simple refine (h·₀_). clear h.
   refine (λ₀¹ i, λ₀ h0, _).
   generalize (x·₀[λ₁ y, i·₁(λ₁ v, (sb v)·₁[U]·₁le'·₁y)]). simplify.
   intros q.
-  refine (q·₀_). clear q.
+  simple refine (q·₀_). clear q.
   unfold le in h0. simplify_in h0.
   unfold WF in h0. simplify_in h0.
   exact h0.


### PR DESCRIPTION
This is an attempt to make `apply` and `rapply` more interchangeable, see #15521.

- [ ] Added / updated **test-suite**.
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
