### PR TITLE
Remove grammar entry "deprecated_number_modifier"

### DIFF
--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -3256,12 +3256,6 @@ ssrpatternarg: [
 | rpattern      (* SSR plugin *)
 ]
 
-deprecated_number_modifier: [
-|
-| "(" "warning" "after" bignat ")"
-| "(" "abstract" "after" bignat ")"
-]
-
 number_string_mapping: [
 | reference "=>" reference
 | "[" reference "]" "=>" reference

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1518,11 +1518,6 @@ ssrhavefwd: [
 | ":" term ":=" OPT term      (* SSR plugin *)
 ]
 
-deprecated_number_modifier: [
-| "(" "warning" "after" bignat ")"
-| "(" "abstract" "after" bignat ")"
-]
-
 number_modifier: [
 | "warning" "after" bignat
 | "abstract" "after" bignat

--- a/plugins/syntax/g_number_string.mlg
+++ b/plugins/syntax/g_number_string.mlg
@@ -24,8 +24,6 @@ let pr_number_after = function
   | Warning n -> str "warning after " ++ NumTok.UnsignedNat.print n
   | Abstract n -> str "abstract after " ++ NumTok.UnsignedNat.print n
 
-let pr_deprecated_number_modifier m = str "(" ++ pr_number_after m ++ str ")"
-
 let pr_number_string_mapping (b, n, n') =
   if b then
     str "[" ++ Libnames.pr_qualid n ++ str "]" ++ spc () ++ str "=>" ++ spc ()
@@ -49,13 +47,6 @@ let pr_string_option l =
   str "(" ++ pr_number_string_via l ++ str ")"
 
 }
-
-VERNAC ARGUMENT EXTEND deprecated_number_modifier
-  PRINTED BY { pr_deprecated_number_modifier }
-| [ ] -> { Nop }
-| [ "(" "warning" "after" bignat(waft) ")" ] -> { Warning (NumTok.UnsignedNat.of_string waft) }
-| [ "(" "abstract" "after" bignat(n) ")" ] -> { Abstract (NumTok.UnsignedNat.of_string n) }
-END
 
 VERNAC ARGUMENT EXTEND number_string_mapping
   PRINTED BY { pr_number_string_mapping }


### PR DESCRIPTION
Should have been removed when becoming unused in https://github.com/coq/coq/pull/14819 as noted by Jim in https://github.com/coq/coq/issues/17218

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand.
Fixes / closes #???? -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- ~[ ] Added / updated **test-suite**.~

<!-- If this is a feature pull request / breaks compatibility: -->
- ~[ ] Added **changelog**.~
- [x] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - ~[ ] Documented any new / changed **user messages**.~
  - [x] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- ~[ ] Opened **overlay** pull requests.~

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
