### PR TITLE
Printing for genargs in constr

### DIFF
--- a/doc/changelog/02-specification-language/17221-ppgenarg.rst
+++ b/doc/changelog/02-specification-language/17221-ppgenarg.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  when printing uninterpreted terms (for instance through :cmd:`Print Ltac` on `Ltac foo := exact some_term`),
+  extensions to the term language (for instance :ref:`tactics-in-terms`) are now printed correctly instead of as holes (`_`)
+  (`#17221 <https://github.com/coq/coq/pull/17221>`_,
+  by Gaëtan Gilbert).

--- a/interp/constrexpr.ml
+++ b/interp/constrexpr.ml
@@ -124,6 +124,10 @@ and constr_expr_r =
          * constr_expr * constr_expr
   | CHole   of Evar_kinds.t option * Namegen.intro_pattern_naming_expr
   | CGenarg of Genarg.raw_generic_argument
+
+  (* because print for genargs wants to print directly the glob without an extern phase (??) *)
+  | CGenargGlob of Genarg.glob_generic_argument
+
   | CPatVar of Pattern.patvar
   | CEvar   of Glob_term.existential_name CAst.t * (lident * constr_expr) list
   | CSort   of sort_expr

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -230,7 +230,7 @@ module EqGen (A:sig val constr_expr_eq : constr_expr -> constr_expr -> bool end)
         constr_expr_eq t1 t2 &&
         constr_expr_eq f1 f2
       | CHole _, CHole _ -> true
-      | CGenarg _, CGenarg _ -> true
+      | (CGenarg _ | CGenargGlob _), (CGenarg _ | CGenargGlob _) -> true
       | CPatVar i1, CPatVar i2 ->
         Id.equal i1 i2
       | CEvar (id1, c1), CEvar (id2, c2) ->
@@ -256,7 +256,8 @@ module EqGen (A:sig val constr_expr_eq : constr_expr -> constr_expr -> bool end)
         constr_expr_eq def1 def2 && constr_expr_eq ty1 ty2 &&
         eq_universes u1 u2
       | (CRef _ | CFix _ | CCoFix _ | CProdN _ | CLambdaN _ | CLetIn _ | CAppExpl _
-        | CApp _ | CProj _ | CRecord _ | CCases _ | CLetTuple _ | CIf _ | CHole _ | CGenarg _
+        | CApp _ | CProj _ | CRecord _ | CCases _ | CLetTuple _ | CIf _ | CHole _
+        | CGenarg _ | CGenargGlob _
         | CPatVar _ | CEvar _ | CSort _ | CCast _ | CNotation _ | CPrim _
         | CGeneralization _ | CDelimiters _ | CArray _), _ -> false
 
@@ -381,7 +382,7 @@ let fold_constr_expr_with_binders g f n acc = CAst.with_val (function
     | CCoFix (_,_) ->
       Feedback.msg_warning (strbrk "Capture check in multiple binders not done"); acc
     | CArray (_u,t,def,ty) -> f n (f n (Array.fold_left (f n) acc t) def) ty
-    | CHole _ | CGenarg _ | CEvar _ | CPatVar _ | CSort _ | CPrim _ | CRef _ ->
+    | CHole _ | CGenarg _ | CGenargGlob _ | CEvar _ | CPatVar _ | CSort _ | CPrim _ | CRef _ ->
       acc
   )
 
@@ -503,7 +504,7 @@ let map_constr_expr_with_binders g f e = CAst.map (function
           (id,bl',t',d')) dl)
     | CArray (u, t, def, ty) ->
       CArray (u, Array.map (f e) t, f e def, f e ty)
-    | CHole _ | CGenarg _ | CEvar _ | CPatVar _ | CSort _
+    | CHole _ | CGenarg _ | CGenargGlob _ | CEvar _ | CPatVar _ | CSort _
     | CPrim _ | CRef _ as x -> x
   )
 

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -1032,7 +1032,7 @@ let rec extern inctx ?impargs scopes vars r =
 
   | GHole (e,naming) -> CHole (Some e, naming)
 
-  | GGenarg _ -> CHole (None, IntroAnonymous) (* TODO: extern tactics. *)
+  | GGenarg arg -> CGenargGlob arg
 
   | GCast (c, k, c') ->
     CCast (sub_extern true scopes vars c, k, extern_typ scopes vars c')

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -2302,6 +2302,7 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
         in
         DAst.make ?loc @@
         GHole (k, naming)
+    | CGenargGlob gen -> DAst.make ?loc @@ GGenarg gen
     | CGenarg gen ->
         let (ltacvars, ntnvars) = lvar in
         (* Preventively declare notation variables in ltac as non-bindings *)

--- a/plugins/firstorder/sequent.ml
+++ b/plugins/firstorder/sequent.ml
@@ -233,11 +233,10 @@ let _print_cmap map=
   let print_entry c l s=
     let env = Global.env () in
     let sigma = Evd.from_env env in
-    let xc=Constrextern.extern_constr env sigma (EConstr.of_constr c) in
       str "| " ++
       prlist Printer.pr_global l ++
       str " : " ++
-      Ppconstr.pr_constr_expr env sigma xc ++
+      Printer.pr_constr_env env sigma c ++
       cut () ++
       s in
     (v 0

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -2014,7 +2014,7 @@ let rec add_args id new_args =
         , (na, Option.map (add_args id new_args) b_option)
         , add_args id new_args b2
         , add_args id new_args b3 )
-    | (CHole _ | CGenarg _ | CPatVar _ | CEvar _ | CPrim _ | CSort _) as b -> b
+    | (CHole _ | CGenarg _ | CGenargGlob _ | CPatVar _ | CEvar _ | CPrim _ | CSort _) as b -> b
     | CCast (b1, k, b2) ->
       CCast (add_args id new_args b1, k, add_args id new_args b2)
     | CRecord pars ->

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -1768,6 +1768,19 @@ let () =
   let pr_top x = Util.Empty.abort x in
   Genprint.register_print0 wit_ltac2 pr_raw pr_glb pr_top
 
+let () =
+  let pr_raw _ = Genprint.PrinterBasic (fun _env _sigma -> assert false) in
+  let pr_glb (ids, e) =
+    let ids =
+      let ids = Id.Set.elements ids in
+      if List.is_empty ids then mt ()
+      else pr_sequence Id.print ids ++ str " |- "
+    in
+    Genprint.PrinterBasic Pp.(fun _env _sigma -> ids ++ Tac2print.pr_glbexpr e)
+  in
+  let pr_top e = Util.Empty.abort e in
+  Genprint.register_print0 wit_ltac2_constr pr_raw pr_glb pr_top
+
 (** Built-in notation scopes *)
 
 let add_scope s f =

--- a/plugins/ltac2/tac2env.ml
+++ b/plugins/ltac2/tac2env.ml
@@ -308,6 +308,7 @@ let wit_ltac2_val = Genarg.make0 "ltac2:value"
 let wit_ltac2_constr = Genarg.make0 "ltac2:in-constr"
 let wit_ltac2_quotation = Genarg.make0 "ltac2:quotation"
 let () = Geninterp.register_val0 wit_ltac2 None
+let () = Geninterp.register_val0 wit_ltac2_constr None
 let () = Geninterp.register_val0 wit_ltac2_quotation None
 
 let is_constructor_id id =

--- a/plugins/syntax/number.ml
+++ b/plugins/syntax/number.ml
@@ -153,14 +153,10 @@ let error_missing c =
   CErrors.user_err
     (str "Missing mapping for constructor " ++ Printer.pr_global c ++ str ".")
 
-let pr_constr env sigma c =
-  let c = Constrextern.extern_constr env sigma (EConstr.of_constr c) in
-  Ppconstr.pr_constr_expr env sigma c
-
 let warn_via_remapping =
   CWarnings.create ~name:"via-type-remapping" ~category:"numbers"
     (fun (env, sigma, ty, ty', ty'') ->
-      let constr = pr_constr env sigma in
+      let constr = Printer.pr_constr_env env sigma in
       constr ty ++ str " was already mapped to" ++ spc () ++ constr ty'
       ++ str ", mapping it also to" ++ spc () ++ constr ty''
       ++ str " might yield ill typed terms when using the notation.")
@@ -168,7 +164,7 @@ let warn_via_remapping =
 let warn_via_type_mismatch =
   CWarnings.create ~name:"via-type-mismatch" ~category:"numbers"
     (fun (env, sigma, g, g', exp, actual) ->
-      let constr = pr_constr env sigma in
+      let constr = Printer.pr_constr_env env sigma in
       str "Type of" ++ spc() ++ Printer.pr_global g
       ++ str " seems incompatible with the type of" ++ spc ()
       ++ Printer.pr_global g' ++ str "." ++ spc ()

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -528,6 +528,41 @@ let tag_var = tag Tag.variable
     | VMcast-> str "<:"
     | NATIVEcast -> str "<<:"
 
+  type raw_or_glob_genarg =
+  | Rawarg of Genarg.raw_generic_argument
+  | Globarg of Genarg.glob_generic_argument
+
+  let pr_genarg return arg =
+    (* In principle this may use the env/sigma, in practice not sure if it
+       does except through pr_constr_expr in beautify mode. *)
+    let env = Global.env() in
+    let sigma = Evd.from_env env in
+    let name, parg = let open Genarg in
+      match arg with
+      | Globarg arg ->
+        let GenArg (Glbwit tag, _) = arg in
+        begin match tag with
+        | ExtraArg tag -> ArgT.repr tag, Pputils.pr_glb_generic env sigma arg
+        | _ -> assert false
+        end
+      | Rawarg arg ->
+        let GenArg (Rawwit tag, _) = arg in
+        begin match tag with
+        | ExtraArg tag -> ArgT.repr tag, Pputils.pr_raw_generic env sigma arg
+        | _ -> assert false
+        end
+    in
+    let name =
+      (* cheat the name system
+         there should be a better way to handle this *)
+      if String.equal name "tactic" then "ltac"
+      else if String.equal name "ltac2:in-constr" then "ltac2"
+      else if String.equal name "ltac2:quotation" then ""
+      else name
+    in
+    let pp = if String.is_empty name then parg else str name ++ str ":" ++ surround parg in
+    return (pp, latom)
+
   let pr pr sep inherited a =
     let return (cmds, prec) = (tag_constr_expr a cmds, prec) in
     let (strm, prec) = match CAst.(a.v) with
@@ -656,25 +691,8 @@ let tag_var = tag Tag.variable
       | CHole (_,IntroFresh id) ->
         return (str "?[?" ++ pr_id id ++ str "]", latom)
       | CHole _ -> return (str "_", latom)
-      | CGenarg arg ->
-        (* In principle this may use the env/sigma, in practice not sure if it
-           does except through pr_constr_expr in beautify mode. *)
-        let env = Global.env() in
-        let sigma = Evd.from_env env in
-        let name = let open Genarg in
-          let GenArg (Rawwit tag, _) = arg in
-          match tag with
-          | ExtraArg tag -> ArgT.repr tag
-          | _ -> assert false
-        in
-        let name =
-          (* cheat the name system
-             there should be a better way to handle this *)
-          if String.equal name "tactic" then "ltac"
-          else if String.equal name "ltac2:in-constr" then "ltac2"
-          else name
-        in
-        return (str name ++ str ":" ++ surround (Pputils.pr_raw_generic env sigma arg), latom)
+      | CGenarg arg -> pr_genarg return (Rawarg arg)
+      | CGenargGlob arg -> pr_genarg return (Globarg arg)
       | CEvar (n,l) ->
         return (pr_evar (pr mt) n l, latom)
       | CPatVar p ->

--- a/test-suite/output/PrintGenarg.out
+++ b/test-suite/output/PrintGenarg.out
@@ -1,3 +1,10 @@
 Ltac foo := let x := open_constr:(ltac:(exact 0)) in
             idtac
             x
+Ltac2 bar : unit -> unit
+      bar :=
+        fun _ =>
+        let x :=
+          open_constr:(ltac2:(let c := fun _ => open_constr:(0) in
+                              exact0 false c)) in
+        ()

--- a/test-suite/output/PrintGenarg.out
+++ b/test-suite/output/PrintGenarg.out
@@ -1,0 +1,3 @@
+Ltac foo := let x := open_constr:(ltac:(exact 0)) in
+            idtac
+            x

--- a/test-suite/output/PrintGenarg.v
+++ b/test-suite/output/PrintGenarg.v
@@ -3,3 +3,11 @@ Ltac foo :=
   idtac x.
 
 Print foo.
+
+Require Import Ltac2.Ltac2.
+
+Ltac2 bar () :=
+  let x := open_constr:(ltac2:(exact 0)) in
+  ().
+
+Print bar.

--- a/test-suite/output/PrintGenarg.v
+++ b/test-suite/output/PrintGenarg.v
@@ -1,0 +1,5 @@
+Ltac foo :=
+  let x := open_constr:(ltac:(exact 0)) in
+  idtac x.
+
+Print foo.


### PR DESCRIPTION
eg for internalized but not executed `ltac2:(exact 0)`, see test

Depends on https://github.com/coq/coq/pull/17220