### PR TITLE
Remove the hackish call to whd_all_nolet from VM and native reduction.

### DIFF
--- a/kernel/inductive.mli
+++ b/kernel/inductive.mli
@@ -87,6 +87,13 @@ val abstract_constructor_type_relatively_to_inductive_types_context :
 
 val inductive_params : mind_specif -> int
 
+(** Given an inductive type and its parameters, builds the context of the return
+    clause, including the inductive being eliminated. The additional binder
+    array is only used to set the names of the context variables, we use the
+    less general type to make it easy to use this function on Case nodes. *)
+val expand_arity : mind_specif -> pinductive -> constr array ->
+  Name.t Context.binder_annot array -> rel_context
+
 (** Given a pattern-matching represented compactly, expands it so as to produce
     lambda and let abstractions in front of the return clause and the pattern
     branches. *)

--- a/kernel/reduction.mli
+++ b/kernel/reduction.mli
@@ -17,7 +17,6 @@ open Environ
 (* None of these functions do eta reduction *)
 
 val whd_all                 : env -> constr -> constr
-val whd_allnolet : env -> constr -> constr
 
 (***********************************************************************
   s conversion functions *)

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -322,18 +322,9 @@ and nf_atom_type env sigma atom =
       let nparams = mib.mind_nparams in
       let params,realargs = Array.chop nparams allargs in
       let pctx =
-        let paramdecl = Vars.subst_instance_context u mib.mind_params_ctxt in
-        let params = Vars.subst_of_rel_context_instance paramdecl params in
         let realdecls, _ = List.chop mip.mind_nrealdecls mip.mind_arity_ctxt in
-        let self =
-          let u = Univ.(Instance.of_array (Array.init (Instance.length u) Level.var)) in
-          let args = Context.Rel.instance mkRel 0 mip.mind_arity_ctxt in
-          mkApp (mkIndU (ind, u), args)
-        in
-        let na = Context.make_annot (Name (Id.of_string "c")) mip.mind_relevance in
-        let realdecls = LocalAssum (na, self) :: realdecls in
-        let nas = Array.of_list @@ List.rev_map get_annot realdecls in
-        instantiate_context u params nas realdecls
+        let nas = List.rev_map get_annot realdecls @ [nameR (Id.of_string "c")] in
+        expand_arity (mib, mip) (ind, u) params (Array.of_list nas)
       in
       let p = nf_predicate env sigma ind mip params p pctx in
       (* Calcul du type des branches *)

--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -283,18 +283,9 @@ and nf_stk ?from:(from=0) env sigma c t stk  =
       let nparams = mib.mind_nparams in
       let params,realargs = Util.Array.chop nparams allargs in
       let pctx =
-        let paramdecl = Vars.subst_instance_context u mib.mind_params_ctxt in
-        let params = Vars.subst_of_rel_context_instance paramdecl params in
         let realdecls, _ = List.chop mip.mind_nrealdecls mip.mind_arity_ctxt in
-        let self =
-          let u = Univ.(Instance.of_array (Array.init (Instance.length u) Level.var)) in
-          let args = Context.Rel.instance mkRel 0 mip.mind_arity_ctxt in
-          mkApp (mkIndU (ind, u), args)
-        in
-        let na = Context.make_annot (Name (Id.of_string "c")) mip.mind_relevance in
-        let realdecls = LocalAssum (na, self) :: realdecls in
-        let nas = Array.of_list @@ List.rev_map RelDecl.get_annot realdecls in
-        instantiate_context u params nas realdecls
+        let nas = List.rev_map RelDecl.get_annot realdecls @ [nameR (Id.of_string "c")] in
+        expand_arity (mib, mip) (ind, u) params (Array.of_list nas)
       in
       let p, relevance = nf_predicate env sigma (ind,u) mip params (type_of_switch sw) pctx in
       (* Calcul du type des branches *)

--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -282,10 +282,21 @@ and nf_stk ?from:(from=0) env sigma c t stk  =
       let (mib,mip) = Inductive.lookup_mind_specif env ind in
       let nparams = mib.mind_nparams in
       let params,realargs = Util.Array.chop nparams allargs in
-      let nparamdecls = Context.Rel.length (Inductive.inductive_paramdecls (mib,u)) in
-      let pT =
-        hnf_prod_applist_decls env nparamdecls (type_of_ind env (ind,u)) (Array.to_list params) in
-      let pctx, p, relevance = nf_predicate env sigma (ind,u) mip params [] (type_of_switch sw) pT in
+      let pctx =
+        let paramdecl = Vars.subst_instance_context u mib.mind_params_ctxt in
+        let params = Vars.subst_of_rel_context_instance paramdecl params in
+        let realdecls, _ = List.chop mip.mind_nrealdecls mip.mind_arity_ctxt in
+        let self =
+          let u = Univ.(Instance.of_array (Array.init (Instance.length u) Level.var)) in
+          let args = Context.Rel.instance mkRel 0 mip.mind_arity_ctxt in
+          mkApp (mkIndU (ind, u), args)
+        in
+        let na = Context.make_annot (Name (Id.of_string "c")) mip.mind_relevance in
+        let realdecls = LocalAssum (na, self) :: realdecls in
+        let nas = Array.of_list @@ List.rev_map RelDecl.get_annot realdecls in
+        instantiate_context u params nas realdecls
+      in
+      let p, relevance = nf_predicate env sigma (ind,u) mip params (type_of_switch sw) pctx in
       (* Calcul du type des branches *)
       let btypes = build_branches_type env sigma ind mib mip u params (pctx, p) in
       (* calcul des branches *)
@@ -322,38 +333,20 @@ and nf_stk ?from:(from=0) env sigma c t stk  =
     let p = Projection.make p true in
     nf_stk env sigma (mkProj (p, c)) ty stk
 
-and nf_predicate env sigma ind mip params pctx v pT =
-  match kind (whd_allnolet env pT) with
-  | LetIn (name,b,t,pT) ->
-    let decl = LocalDef (name, b, t) in
-    nf_predicate (push_rel decl env) sigma ind mip params (decl :: pctx) v pT
-  | Prod (name,dom,codom) -> begin
+and nf_predicate env sigma ind mip params v pctx =
+  (* TODO: we should expose some variant of Vm.mkrel_vstack *)
+  let fold decl (k, v) = match decl with
+  | LocalDef _ -> (k + 1, v)
+  | LocalAssum _ ->
     match whd_val v with
-    | Vfun f ->
-      let k = nb_rel env in
-      let vb = reduce_fun k f in
-      let decl = LocalAssum (name, dom) in
-      nf_predicate (push_rel decl env) sigma ind mip params (decl :: pctx) vb codom
+    | Vfun f -> (k + 1, reduce_fun k f)
     | _ -> assert false
-    end
-  | _ ->
-    match whd_val v with
-    | Vfun f ->
-      let k = nb_rel env in
-      let vb = reduce_fun k f in
-      let name = Name (Id.of_string "c") in
-      let n = mip.mind_nrealargs in
-      let rargs = Array.init n (fun i -> mkRel (n-i)) in
-      let params = if Int.equal n 0 then params else Array.map (lift n) params in
-      let dom = mkApp(mkIndU ind,Array.append params rargs) in
-      let r = Inductive.relevance_of_inductive env (fst ind) in
-      let name = make_annot name r in
-      let decl = LocalAssum (name, dom) in
-      let env = push_rel decl env in
-      let body = nf_vtype env sigma vb in
-      let rel = Retyping.relevance_of_type env sigma (EConstr.of_constr body) in
-      decl :: pctx, body, rel
-    | _ -> assert false
+  in
+  let (_, v) = List.fold_right fold pctx (nb_rel env, v) in
+  let env = push_rel_context pctx env in
+  let body = nf_vtype env sigma v in
+  let rel = Retyping.relevance_of_type env sigma (EConstr.of_constr body) in
+  body, rel
 
 and nf_args env sigma vargs ?from:(f=0) t =
   let t = ref t in


### PR DESCRIPTION
We simply reuse the data coming from the inductive block instead.