### PR TITLE
Exclude ssr from doc_grammar processing; report missing/extra commands and tactics 

### DIFF
--- a/doc/Makefile.docgram
+++ b/doc/Makefile.docgram
@@ -29,17 +29,23 @@ DOC_MLGS := \
 	plugins/nsatz/g_nsatz.mlg \
 	plugins/ring/g_ring.mlg \
 	plugins/rtauto/g_rtauto.mlg \
-	plugins/ssr/ssrparser.mlg plugins/ssr/ssrtacs.mlg plugins/ssr/ssrvernac.mlg \
-	plugins/ssrmatching/g_ssrmatching.mlg \
 	plugins/syntax/g_number_string.mlg \
 	plugins/ltac2/g_ltac2.mlg
 DOC_EDIT_MLGS := $(wildcard doc/tools/docgram/*.edit_mlg)
 DOC_RSTS := $(wildcard doc/sphinx/*/*.rst) $(wildcard doc/sphinx/*/*/*.rst)
 
 REAL_DOC_MLGS := $(wildcard */*.mlg plugins/*/*.mlg)
+# omit SSR MLGS and chapter for now
+SSR_MLGS := \
+	plugins/ssr/ssrparser.mlg plugins/ssr/ssrtacs.mlg plugins/ssr/ssrvernac.mlg \
+  plugins/ssrmatching/g_ssrmatching.mlg
+REAL_DOC_MLGS := $(filter-out $(SSR_MLGS),$(REAL_DOC_MLGS))
+SSR_RSTS := doc/sphinx/proof-engine/ssreflect-proof-language.rst
+DOC_RSTS := $(filter-out $(SSR_RSTS),$(DOC_RSTS))
+
 ifneq ($(sort $(DOC_MLGS)),$(sort $(REAL_DOC_MLGS)))
 missing_mlgs := $(filter-out $(REAL_DOC_MLGS),$(DOC_MLGS))
-extra_mlgs := $(filter-out $(DOC_MLGS),$(REAL_DOC_MLGS))
+extra_mlgs := $(filter-out $(DOC_MLGS),$(SSR_MLGS),$(REAL_DOC_MLGS))
 $(error mlg file list mismatch in Makefile.doc: $(if $(missing_mlgs),$(missing_mlgs) not found) $(if $(extra_mlgs),$(extra_mlgs) not listed))
 endif
 

--- a/doc/Makefile.docgram
+++ b/doc/Makefile.docgram
@@ -68,7 +68,7 @@ doc_gram: doc/tools/docgram/fullGrammar
 
 doc_gram_verify: $(DOC_GRAM) $(DOC_MLGS)
 	$(SHOW)'DOC_GRAM_VERIFY'
-	$(HIDE)$(DOC_GRAM) -no-warn -verify $(DOC_MLGS) $(DOC_RSTS)
+	$(HIDE)$(DOC_GRAM) -no-warn -verify -check-cmds -check-tacs $(DOC_MLGS) $(DOC_RSTS)
 
 doc_gram_rsts: doc/tools/docgram/updated_rsts
 

--- a/doc/sphinx/language/core/basic.rst
+++ b/doc/sphinx/language/core/basic.rst
@@ -114,8 +114,8 @@ Identifiers
 Numbers
   Numbers are sequences of digits with an optional fractional part
   and exponent, optionally preceded by a minus sign. Hexadecimal numbers
-  start with ``0x`` or ``0X``. :n:`@bigint` are integers;
-  numbers without fractional nor exponent parts. :n:`@bignat` are non-negative
+  start with ``0x`` or ``0X``. :n:`@integer`\s are signed
+  numbers without fraction or exponent parts. :n:`@natural`\s are non-negative
   integers.  Underscores embedded in the digits are ignored, for example
   ``1_000_000`` is the same as ``1000000``.
 
@@ -124,9 +124,9 @@ Numbers
   .. prodn::
      number ::= {? - } @decnat {? . {+ {| @digit | _ } } } {? {| e | E } {? {| + | - } } @decnat }
      | {? - } @hexnat {? . {+ {| @hexdigit | _ } } } {? {| p | P } {? {| + | - } } @decnat }
-     integer ::= {? - } @natural
-     natural ::= @bignat
+     integer ::= @bigint
      bigint ::= {? - } @bignat
+     natural ::= @bignat
      bignat ::= {| @decnat | @hexnat }
      decnat ::= @digit {* {| @digit | _ } }
      digit ::= 0 .. 9

--- a/doc/sphinx/proof-engine/ltac.rst
+++ b/doc/sphinx/proof-engine/ltac.rst
@@ -707,10 +707,22 @@ First tactic to succeed
 In some cases backtracking may be too expensive.
 
 .. tacn:: first [ {*| @ltac_expr } ]
+          first @ident
+   :name: first; _
 
-   For each focused goal, independently apply the first :token:`ltac_expr` that succeeds.
-   The :n:`@ltac_expr`\s must evaluate to tactic values.
-   Failures in tactics after the :tacn:`first` won't cause backtracking.
+   In the first form: for each focused goal, independently apply the first tactic
+   (:token:`ltac_expr`) that succeeds.
+
+   In the second form: :n:`@ident` represents a list
+   of tactics passed to :n:`first` in a :cmd:`Tactic Notation` command (see example
+   :ref:`here <taclist_in_first>`).
+
+   :tacn:`first` is an :token:`l1_tactic`.
+
+   .. exn:: No applicable tactic.
+      :undocumented:
+
+   Failures in tactics won't cause backtracking.
    (To allow backtracking, use the :tacn:`+<+ (backtracking branching)>`
    construct above instead.)
 
@@ -736,56 +748,35 @@ In some cases backtracking may be too expensive.
 
        assert_fails (first [ (idtac "1A" + idtac "1B" + fail) | idtac "2" ]; fail).
 
-   :tacn:`first` is an :token:`l1_tactic`.
+.. _taclist_in_first:
 
-   .. exn:: No applicable tactic.
-      :undocumented:
+   .. example:: Referring to a list of tactics in :cmd:`Tactic Notation`
 
-   .. todo the following is not accepted as a regular tactic but it does seem to do something
-      see https://github.com/coq/coq/pull/12103#discussion_r422249862.
-      Probably the same thing as for the :tacn:`solve` below.
-      The code is in Coretactics.initial_tacticals
+      This works similarly for the :tacn:`solve` tactic.
 
-   .. tacn:: first [ {*| @ltac_expr } ]
+    .. coqtop:: reset all
 
-      This is an |Ltac| alias that gives a primitive access to the first
-      tactical as an |Ltac| definition without going through a parsing rule. It
-      expects to be given a list of tactics through a :cmd:`Tactic Notation` command,
-      permitting notations with the following form to be written:
-
-      .. example::
-
-         .. coqtop:: in
-
-            Tactic Notation "foo" tactic_list(tacs) := first tacs.
+       Tactic Notation "myfirst" "[" tactic_list_sep(tacl,"|") "]" := first tacl.
+       Goal True.
+       myfirst [ auto | apply I ].
 
 Solving
 ~~~~~~~
 
-Selects and applies the first tactic that solves each goal (i.e. leaves no subgoal)
-in a series of alternative tactics:
-
 .. tacn:: solve [ {*| @ltac_expr__i } ]
+          solve @ident
+   :name: solve; _
 
-   For each current subgoal: evaluates and applies each :n:`@ltac_expr` in order
-   until one is found that solves the subgoal.
+   In the first form: for each focused goal, independently apply the first tactic
+   (:n:`@ltac_expr`) that solves the goal.
 
-   If any of the subgoals are not solved, then the overall :tacn:`solve` fails.
+   In the second form: :n:`@ident` represents a list
+   of tactics passed to :n:`solve` in a :cmd:`Tactic Notation` command (see example
+   :ref:`here <taclist_in_first>`).
 
-   .. note:: In :tacn:`solve` and :tacn:`first`, :n:`@ltac_expr`\s that don't
-      evaluate to tactic values are ignored.  So :tacn:`solve` `[ () | 1 |` :tacn:`constructor` `]`
-      is equivalent to :tacn:`solve` `[` :tacn:`constructor` `]`.
-      This may make it harder to debug scripts that inadvertently include non-tactic values.
-
-   .. todo check the behavior of other constructs
-      see https://github.com/coq/coq/pull/12103#discussion_r436320430
+   If any of the goals are not solved, then the overall :tacn:`solve` fails.
 
    :tacn:`solve` is an :token:`l1_tactic`.
-
-   .. tacn:: solve [ {*| @ltac_expr } ]
-
-      This is an |Ltac| alias that gives a primitive access to the :tacn:`solve`
-      tactic. See the :tacn:`first` tactic for more information.
 
 First tactic to make progress: ||
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -285,7 +285,7 @@ There is dedicated syntax for list and array literals.
    | @string
    | @qualid
    | @ @ident
-   | & @lident
+   | & @ident
    | ' @term
    | @ltac2_quotations
 
@@ -571,7 +571,7 @@ Built-in quotations
 .. insertprodn ltac2_quotations ltac1_expr_in_env
 
 .. prodn::
-   ltac2_quotations ::= ident : ( @lident )
+   ltac2_quotations ::= ident : ( @ident )
    | constr : ( @term )
    | open_constr : ( @term )
    | preterm : ( @term )
@@ -1161,7 +1161,7 @@ Match on values
       | @qualid
       | @tac2pat0 :: @tac2pat0
       | @tac2pat0 %| {+| @tac2pat1 }
-      | @tac2pat0 as @lident
+      | @tac2pat0 as @ident
       | @tac2pat0
       tac2pat0 ::= _
       | ()
@@ -1283,7 +1283,7 @@ Notations
 Abbreviations
 ~~~~~~~~~~~~~
 
-.. cmd:: Ltac2 Notation {| @string | @lident } := @ltac2_expr
+.. cmd:: Ltac2 Notation {| @string | @ident } := @ltac2_expr
    :name: Ltac2 Notation (abbreviation)
 
    Introduces a special kind of notation, called an abbreviation,
@@ -1577,8 +1577,8 @@ Here is the syntax for the :n:`q_*` nonterminals:
    | _
    | @ltac2_or_and_intropattern
    | @ltac2_equality_intropattern
-   ltac2_naming_intropattern ::= ? @lident
-   | ?$ @lident
+   ltac2_naming_intropattern ::= ?@ident
+   | ?$ @ident
    | ?
    | @ident_or_anti
    ltac2_or_and_intropattern ::= [ {+| @ltac2_intropatterns } ]
@@ -1592,14 +1592,14 @@ Here is the syntax for the :n:`q_*` nonterminals:
 .. insertprodn ident_or_anti ident_or_anti
 
 .. prodn::
-   ident_or_anti ::= @lident
+   ident_or_anti ::= @ident
    | $ @ident
 
 .. insertprodn 	ltac2_destruction_arg ltac2_constr_with_bindings
 
 .. prodn::
    ltac2_destruction_arg ::= @natural
-   | @lident
+   | @ident
    | @ltac2_constr_with_bindings
    ltac2_constr_with_bindings ::= @term {? with @ltac2_bindings }
 
@@ -1612,7 +1612,7 @@ Here is the syntax for the :n:`q_*` nonterminals:
    ltac2_simple_binding ::= ( @qhyp := @term )
    qhyp ::= $ @ident
    | @natural
-   | @lident
+   | @ident
 
 .. insertprodn ltac2_reductions ltac2_delta_reductions
 

--- a/doc/sphinx/proofs/automatic-tactics/logic.rst
+++ b/doc/sphinx/proofs/automatic-tactics/logic.rst
@@ -97,9 +97,6 @@ Solvers for logic and equality
       This :term:`flag` controls whether :tacn:`intuition` unfolds inner negations which do not need
       to be unfolded. It is on by default.
 
-.. tacn:: gintuition {? @ltac_expr }
-   :undocumented:
-
 .. tacn:: rtauto
 
    Solves propositional tautologies similarly to

--- a/doc/sphinx/proofs/writing-proofs/proof-mode.rst
+++ b/doc/sphinx/proofs/writing-proofs/proof-mode.rst
@@ -578,7 +578,7 @@ Curly braces
 
    Note that when a focused goal is proved a message is displayed
    together with a suggestion about the right bullet or ``}`` to unfocus it
-   or focus the next one.
+   or focus the next goal.
 
    :n:`@natural:`
      Focuses on the :token:`natural`\-th goal to prove.
@@ -652,17 +652,12 @@ same bullet ``b``. See the example below.
 
 Different bullets can be used to nest levels. The scope of each bullet
 is limited to the enclosing ``{`` and ``}``, so bullets can be reused as further
-nesting levels provided they are delimited by curly braces. Bullets are made from
-``-``, ``+`` or ``*`` characters (with no spaces and no period afterward):
+nesting levels provided they are delimited by curly braces.  A :production:`bullet`
+is made from ``-``, ``+`` or ``*`` characters (with no spaces and no period afterward):
 
-.. tacn:: @bullet
+.. tacn:: {| {+ - } | {+ + } | {+ * } }
    :undocumented:
-   :name: bullet
-
-   .. insertprodn bullet bullet
-
-   .. prodn::
-      bullet ::= {| {+ - } | {+ + } | {+ * } }
+   :name: bullet (- + *)
 
 When a focused goal is proved, Coq displays a message suggesting use of
 ``}`` or the correct matching bullet to unfocus the goal or focus the next subgoal.

--- a/doc/tools/docgram/README.md
+++ b/doc/tools/docgram/README.md
@@ -1,7 +1,7 @@
 # Grammar extraction tool for documentation
 
 `doc_grammar` extracts Coq's grammar from `.mlg` files, edits it and inserts it
-into `.rst` files.  The tool inserts `prodn` directives for  grammar productions.
+into `.rst` files.  The tool inserts `prodn` directives for grammar productions.
 It also updates `tacn` and `cmd` directives when they can be unambiguously matched to
 productions of the grammar (in practice, that's probably almost always).
 `tacv` and `cmdv` directives are not updated because matching them appears to require
@@ -33,7 +33,7 @@ for documentation purposes:
 
 ## What the tool does
 
-1.  The tool reads all the `mlg` files and generates `fullGrammar`, which includes
+1. The tool reads all the `mlg` files and generates `fullGrammar`, which includes
     all the grammar without the actions for each production or the OCaml code.  This
     file is provided as a convenience to make it easier to examine the (mostly)
     unprocessed grammar of the mlg files with less clutter.  This step includes two
@@ -68,7 +68,10 @@ for documentation purposes:
 
     References to renamed symbols are updated with the modified names.
 
-2.  The tool applies grammar editing operations specified by `common.edit_mlg` to
+    Note: the 4 SSR mlgs and ssreflect-proof-language.rst are currently excluded
+    from processing (hard coded).
+
+2. The tool applies grammar editing operations specified by `common.edit_mlg` to
     generate `editedGrammar`.
 
 3. `orderedGrammar` gives the desired order for nonterminals and individual productions
@@ -82,17 +85,18 @@ for documentation purposes:
     The update process removes manually-added comments from `orderedGrammar` while
     automatically-generated comments will be regenerated.
 
-4.  The tool updates the `.rst` files.  Comments in the form
+4. The tool updates the `.rst` files.  Comments in the form
     `.. insertprodn <first nt> <last nt>` indicate inserting the productions for a
-    range of nonterminals.  `.. cmd::` and `.. tacn::` directives are updated using
+    range of nonterminals (in `orderedGrammar` order).  `.. cmd::` and `.. tacn::`
+    directives are updated using
     prefixes in the form `[a-zA-Z0-9_ ]+` from the directive and the
     grammar.  If there is unique match in the grammar, the directive is updated, if needed.
     Multiple matches or no match gives an error message.
 
-5.  For reference, the tool generates `prodnGrammar`, which has the entire grammar in the form of `prodns`.
+5. For reference, the tool generates `prodnGrammar`, which has the entire grammar in the form of `prodns`.
 
-6.  If requested by command-line arguments, the tool generates `prodnCommands`
-    (for commands) and `prodnTactics` (for tactics).
+6. If requested by command-line arguments `-check-cmds` or `-check-tacs`,
+    the tool generates `prodnCommands` (for commands) and `prodnTactics` (for tactics).
     The former lists all commands that are under `command` in `orderedGrammar` and
     compares it to the `:cmd:` and `:cmdv:` given in the rst files.  The latter
     lists all tactics that are under `simple_tactic` in the grammar and compares it
@@ -103,6 +107,9 @@ for documentation purposes:
     - `+` - an rst entry that doesn't match a grammar production
     - `v` - the rst entry is a `:cmdv:` or `:tacv:`
     - `?` - the match between the grammar and the rst files is not unique
+
+    These command line arguments also generate error messages for commands and
+    tactics that are in the grammar but not the documentation and vice versa.
 
 ## How to use the tool
 
@@ -115,13 +122,13 @@ for documentation purposes:
 
 * `make doc_gram_rsts DOCGRAMWARN=1` will additionally print warnings.
 
-Changes to `fullGrammar`, `orderedGrammar` and the `.rsts` should be checked in to git.
+Changes to `fullGrammar`, `orderedGrammar` and `*.rst` should be checked in to git.
 The `prodn*` and other `*Grammar` files should not.
 
 ### Command line arguments
 
 The executable takes a list of `.mlg` and `.rst` files as arguments.  The tool
-inserts the grammar into the `.rsts` as specified by comments in those files.
+inserts the grammar into the `*.rst` as specified by comments in those files.
 The order of the `.mlg` files affects the order of nonterminals and productions in
 `fullGrammar`.  The order doesn't matter for the `.rst` files.
 
@@ -177,8 +184,9 @@ uses of `LEFTQMARK` anywhere in the grammar with its productions and removing th
 non-terminal.  The combined effect of these two is to replace all uses of
 `LEFTQMARK` with `"?"`.
 
-Here are the current operations.  They are likely to be refined as we learn
-what operations are most useful while we update the mlg files and documentation:
+
+
+Here are the current operations:
 
 ### Global edits
 
@@ -196,6 +204,12 @@ as a separate production.  (Doesn't work recursively; splicing for both
 
 `OPTINREF` - applies the local `OPTINREF` edit to every nonterminal
 
+`REACHABLE` - suppresses the "Unreachable symbol" warning for the listed nonterminals
+and any symbols reachable from them.
+
+`NOTINRSTS` - suppresses the "Nonterminal <NT> not included in .rst files" messages for
+the listed nonterminals.
+
 ### Local edits
 
 `DELETE <production>` - removes the specified production from the grammar
@@ -203,7 +217,7 @@ as a separate production.  (Doesn't work recursively; splicing for both
 `EDIT <production>` - modifies the specified production using the following tags
 that appear in the specified production:
 
-* `USE_NT <name>` LIST* - extracts LIST* as new nonterminal with the specified
+* `USE_NT <name>` LIST* - extracts LIST* as a new nonterminal with the specified
   new non-terminal name
 
 * `ADD_OPT <grammar symbol>` - looks for a production that matches the specified

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -469,6 +469,15 @@ closed_binder: [
 | MOVETO generalizing_binder "`[" LIST1 typeclass_constraint SEP "," "]"
 ]
 
+(* next two used internally  for declaring notations *)
+one_closed_binder: [
+| DELETENT
+]
+
+one_open_binder: [
+| DELETENT
+]
+
 name_colon: [
 | name ":"
 ]
@@ -583,6 +592,14 @@ finite_token: [
 ]
 
 inductive_token: [
+| DELETENT
+]
+
+inductive_or_record_definition: [
+| DELETENT
+]
+
+constructors_or_record: [
 | DELETENT
 ]
 
@@ -758,11 +775,6 @@ hexnat: [
 bignat: [
 | REPLACE NUMBER
 | WITH [ decnat | hexnat ]
-]
-
-integer: [
-| REPLACE bigint
-| WITH OPT "-" natural
 ]
 
 number: [
@@ -1508,17 +1520,6 @@ type_cstr: [
 | WITH ":" type
 ]
 
-(* note that constructor -> identref constructor_type *)
-constructors_or_record: [
-| DELETE "|" LIST1 constructor SEP "|"
-| REPLACE identref constructor_type "|" LIST1 constructor SEP "|"
-| WITH OPT "|" LIST1 constructor SEP "|"
-| DELETE identref constructor_type
-| REPLACE identref "{" record_fields "}" default_inhabitant_ident
-| WITH OPT identref "{" record_fields "}" default_inhabitant_ident
-| DELETE "{" record_fields "}" default_inhabitant_ident
-]
-
 record_binder: [
 | REPLACE name field_body
 | WITH name OPT field_body
@@ -1745,9 +1746,8 @@ tactic_mode: [
 | WITH OPT ( [ natural | "[" ident "]" ] ":" ) "{"
 | MOVETO simple_tactic OPT ( [ natural | "[" ident "]" ] ":" ) "{"
 | DELETE simple_tactic
+| DELETENT
 ]
-
-tactic_mode: [ | DELETENT ]
 
 ltac2_scope: [
 | REPLACE syn_node      (* Ltac2 plugin *)
@@ -1757,7 +1757,12 @@ ltac2_scope: [
 ]
 
 tac2mode: [
-| DELETE "par" ":" ltac2_expr6 ltac_use_default
+| DELETENT
+]
+
+(* not sure how this is used *)
+tac2expr_in_env: [
+| DELETENT
 ]
 
 syn_node: [ | DELETENT ]
@@ -1795,6 +1800,8 @@ vernac_aux: [
 | DELETE gallina_ext "."
 | DELETE syntax "."
 | DELETE command_entry
+| DELETE subprf
+| DELETENT
 ]
 
 command: [
@@ -2147,6 +2154,10 @@ subprf: [
 | "{" (* should be removed.  See https://github.com/coq/coq/issues/12004 *)
 ]
 
+subprf: [
+| DELETENT
+]
+
 ltac2_expr: [
 | DELETE _ltac2_expr
 ]
@@ -2432,6 +2443,7 @@ SPLICE: [
 | enable_notation_interpretation
 | enable_notation_flags
 | opt_scope
+| lident
 ] (* end SPLICE *)
 
 RENAME: [
@@ -2504,6 +2516,7 @@ SPLICE: [
 | ltac2_constructs
 | ltac_defined_tactics
 | tactic_notation_tactics
+| bullet
 ]
 
 REACHABLE: [
@@ -2512,7 +2525,11 @@ REACHABLE: [
 ]
 
 NOTINRSTS: [
+| command
+| control_command
+| query_command
 | simple_tactic
+| hints_regexp (* manually inserted *)
 | REACHABLE
 | NOTINRSTS
 | l1_tactic
@@ -2542,8 +2559,6 @@ NOTINRSTS: [
 | q_assert
 | q_constr_matching
 | q_goal_matching
-
-
 ]
 
 REACHABLE: [

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -99,7 +99,6 @@ RENAME: [
 | G_LTAC2_as_ipat ltac2_as_ipat
 | G_LTAC2_by_tactic ltac2_by_tactic
 | G_LTAC2_match_list ltac2_match_list
-| G_SSRMATCHING_cpattern ssr_one_term_pattern
 ]
 
 (* Renames to eliminate qualified names.
@@ -122,9 +121,6 @@ RENAME: [
 | Tactic.tactic tactic
 | Pltac.ltac_expr ltac_expr5
 
-  (* SSR *)
-| Pcoq.Constr.constr term
-| Prim.identref ident
 (*
 | G_vernac.def_body def_body
 | Prim.by_notation by_notation
@@ -167,28 +163,6 @@ DELETE: [
 | test_variance_ident
 | test_ident_with_or_lpar_or_rbrac
 | test_leftsquarebracket_equal
-
-  (* SSR *)
-| ssr_null_entry
-| ssrtermkind  (* todo: rename as "test..." *)
-| ssrdoarg  (* todo: this and the next one should be removed from the grammar? *)
-| ssrseqdir
-| ssrindex
-| ssrintrosarg
-| ssrtclarg
-| term_annotation  (* todo: what is this? *)
-| test_idcomma
-| test_ident_no_do
-| test_nohidden
-| test_not_ssrslashnum
-| test_ssr_rw_syntax
-| test_ssreqid
-| test_ssrfwdid
-| test_ssrseqvar
-| test_ssrslashnum00
-| test_ssrslashnum01
-| test_ssrslashnum10
-| test_ssrslashnum11
 
 (* unused *)
 | constr_comma_sequence'
@@ -282,18 +256,7 @@ binder_constr: [
 | DELETE "forall" open_binders "," term200
 | MOVETO term_forall_or_fun "fun" open_binders "=>" term200
 | MOVETO term_let "let" name binders let_type_cstr ":=" term200 "in" term200
-(*| MOVETO term_let "let" ":" ssr_mpat ":=" lconstr "in" lconstr  TAG SSR *)
-| DELETE "let" ":" ssr_mpat ":=" lconstr "in" lconstr  TAG SSR (* todo: restore for ssr *)
-| REPLACE "let" ":" ssr_mpat "in" pattern200 ":=" lconstr ssr_rtype "in" lconstr      (* ssr plugin *)
-| WITH "let" ":" ssr_mpat OPT ( "in" pattern200 ) ":=" lconstr ssr_rtype "in" lconstr  TAG SSR
-| DELETE "let" ":" ssr_mpat ":=" lconstr ssr_rtype "in" lconstr      (* SSR plugin *)
-| DELETE "let" ":" ssr_mpat OPT ( "in" pattern200 ) ":=" lconstr ssr_rtype "in" lconstr  TAG SSR  (* todo: restore for SSR *)
-(*| MOVETO term_let "let" ":" ssr_mpat OPT ( "in" pattern200 ) ":=" lconstr ssr_rtype "in" lconstr      TAG SSR*)
 | MOVETO term_if "if" term200 as_return_type "then" term200 "else" term200
-| REPLACE "if" term200 "is" ssr_dthen ssr_else
-| WITH "if" term200 [ "is" | "isn't" ] ssr_dthen ssr_else  TAG SSR
-| DELETE "if" term200 "isn't" ssr_dthen ssr_else
-| DELETE "if" term200 [ "is" | "isn't" ] ssr_dthen ssr_else  TAG SSR  (* todo: restore as "MOVETO term_if" for SSR *)
 | MOVETO term_fix "let" "fix" fix_decl "in" term200
 | MOVETO term_cofix "let" "cofix" cofix_body "in" term200
 | MOVETO term_let "let" [ "(" LIST0 name SEP "," ")" | "()" ] as_return_type ":=" term200 "in" term200
@@ -340,7 +303,6 @@ atomic_constr: [
 ltac_expr0: [
 | REPLACE "[" ">" for_each_goal "]"
 | WITH "[>" for_each_goal "]"
-| DELETE ssrparentacarg
 ]
 
 (* lexer token *)
@@ -505,7 +467,6 @@ closed_binder: [
 | MOVETO generalizing_binder "`(" LIST1 typeclass_constraint SEP "," ")"
 | MOVETO generalizing_binder "`{" LIST1 typeclass_constraint SEP "," "}"
 | MOVETO generalizing_binder "`[" LIST1 typeclass_constraint SEP "," "]"
-| DELETE [ "of" | "&" ] term99  (* todo: remove for SSR *)
 ]
 
 name_colon: [
@@ -825,7 +786,6 @@ subsequent_letter: [
 
 ident: [
 | DELETE IDENT
-| DELETE IDENT (* 2nd copy from SSR *)
 | first_letter LIST0 subsequent_letter
 ]
 
@@ -881,10 +841,6 @@ ltac_expr4: [
 | REPLACE ltac_expr3 ";" binder_tactic
 | WITH ltac_expr3 ";" [ ltac_expr3 | binder_tactic ]
 | DELETE ltac_expr3 ";" ltac_expr3
-| MOVETO simple_tactic ltac_expr5 ";" "first" ssr_first_else      TAG SSR
-| MOVETO simple_tactic ltac_expr5 ";" "first" ssrseqarg      TAG SSR
-| MOVETO simple_tactic ltac_expr5 ";" "last" ssrseqarg      TAG SSR
-| DELETE simple_tactic
 ]
 
 l3_tactic: [ ]
@@ -894,10 +850,6 @@ ltac_expr3: [
 | REPLACE "abstract" ltac_expr2 "using" ident
 | WITH "abstract" ltac_expr2 OPT ( "using" ident )
 | l3_tactic
-(* | EDIT "do" ADD_OPT nat_or_var ssrmmod ssrdotac ssrclauses  TAG SSR *)
-| DELETE "do" ssrmmod ssrdotac ssrclauses      (* SSR plugin *)
-| DELETE "do" ssrortacarg ssrclauses      (* SSR plugin *)
-| DELETE "do" nat_or_var ssrmmod ssrdotac ssrclauses      (* SSR plugin *)
 | MOVEALLBUT ltac_builtins
 | l3_tactic
 | ltac_expr2
@@ -1213,48 +1165,13 @@ simple_tactic: [
 | DELETE "typeclasses" "eauto" "dfs" OPT nat_or_var
 | DELETE "typeclasses" "eauto" "bfs" OPT nat_or_var "with" LIST1 preident
 | DELETE "typeclasses" "eauto" "bfs" OPT nat_or_var
+| DELETE "typeclasses" "eauto" "best_effort" OPT nat_or_var "with" LIST1 preident
+| DELETE "typeclasses" "eauto" "best_effort" OPT nat_or_var
 | DELETE "typeclasses" "eauto" OPT nat_or_var "with" LIST1 preident
 | DELETE "typeclasses" "eauto" OPT nat_or_var
 (* in Tactic Notation: *)
 | "setoid_replace" constr "with" constr OPT ( "using" "relation" constr ) OPT ( "in" hyp )
        OPT ( "at" LIST1 int_or_var ) OPT ( "by" ltac_expr3 )
-| REPLACE "apply" ssrapplyarg      (* SSR plugin *)
-| WITH "apply" OPT ssrapplyarg      TAG SSR
-| DELETE "apply"
-| REPLACE "elim" ssrarg ssrclauses      (* SSR plugin *)
-| WITH "elim" OPT ( ssrarg ssrclauses )  TAG SSR
-| DELETE "elim"      (* SSR plugin *)
-| REPLACE "case" ssrcasearg ssrclauses      (* SSR plugin *)
-| WITH "case" OPT ( ssrcasearg ssrclauses ) TAG SSR
-| DELETE "case"      (* SSR plugin *)
-| REPLACE "under" ssrrwarg ssrintros_ne "do" ssrhint3arg      (* SSR plugin *)
-| WITH "under" ssrrwarg OPT ssrintros_ne OPT ( "do" ssrhint3arg )  TAG SSR
-| DELETE "under" ssrrwarg      (* SSR plugin *)
-| DELETE "under" ssrrwarg ssrintros_ne      (* SSR plugin *)
-| DELETE "under" ssrrwarg "do" ssrhint3arg      (* SSR plugin *)
-| REPLACE "move" ssrmovearg ssrrpat      (* SSR plugin *)
-| WITH "move" OPT ( OPT ssrmovearg ssrrpat )   TAG SSR
-| DELETE "move" ssrrpat      (* SSR plugin *)
-| DELETE "move"      (* SSR plugin *)
-| REPLACE "suff" "have" ssrhpats_nobs ssrhavefwd      (* SSR plugin *)
-| WITH [ "suff" | "suffices" ] OPT ( "have" ssrhpats_nobs ) ssrhavefwd      TAG SSR
-| DELETE "suffices" "have" ssrhpats_nobs ssrhavefwd      (* SSR plugin *)
-| REPLACE "suff" ssrsufffwd      (* SSR plugin *)
-| WITH [ "suff" | "suffices" ] ssrsufffwd      TAG SSR
-| DELETE "suffices" ssrsufffwd      (* SSR plugin *)
-| REPLACE "have" "suff" ssrhpats_nobs ssrhavefwd      (* SSR plugin *)
-| WITH "have" [ "suff" | "suffices" ] ssrhpats_nobs ssrhavefwd      TAG SSR
-| DELETE "have" "suffices" ssrhpats_nobs ssrhavefwd      (* SSR plugin *)
-| REPLACE "gen" "have" ssrclear ssr_idcomma ssrhpats_nobs ssrwlogfwd ssrhint      (* SSR plugin *)
-| WITH [ "gen" | "generally" ] "have" ssrclear ssr_idcomma ssrhpats_nobs ssrwlogfwd ssrhint      TAG SSR
-| DELETE "generally" "have" ssrclear ssr_idcomma ssrhpats_nobs ssrwlogfwd ssrhint      (* SSR plugin *)
-| REPLACE "wlog" "suff" ssrhpats_nobs ssrwlogfwd ssrhint      (* SSR plugin *)
-| WITH [ "wlog" | "without loss" ] OPT [ "suff" | "suffices" ] ssrhpats_nobs ssrwlogfwd ssrhint      TAG SSR
-| DELETE "wlog" "suffices" ssrhpats_nobs ssrwlogfwd ssrhint      (* SSR plugin *)
-| DELETE "wlog" ssrhpats_nobs ssrwlogfwd ssrhint      (* SSR plugin *)
-| DELETE "without" "loss" ssrhpats_nobs ssrwlogfwd ssrhint      (* SSR plugin *)
-| DELETE "without" "loss" "suff" ssrhpats_nobs ssrwlogfwd ssrhint      (* SSR plugin *)
-| DELETE "without" "loss" "suffices" ssrhpats_nobs ssrwlogfwd ssrhint      (* SSR plugin *)
 ]
 
 (* todo: don't use DELETENT for this *)
@@ -1921,7 +1838,6 @@ ltac_defined_tactics: [
 | "nia"
 | "now_show" one_type
 | "nra"
-| "over"  TAG SSR
 | "rapply" constr
 | "split_Rabs"
 | "split_Rmult"
@@ -1953,7 +1869,6 @@ tactic_notation_tactics: [
 
 (* defined in OCaml outside of mlgs *)
 tactic_value: [
-| "uconstr" ":" "(" term200 ")"
 | MOVEALLBUT simple_tactic
 ]
 
@@ -2253,238 +2168,8 @@ cofixdecl: [
 | WITH "(" ident LIST0 simple_binder ":" type ")"
 ]
 
-ssrfwdview: [
-| REPLACE "/" ast_closure_term ssrfwdview      (* SSR plugin *)
-| WITH LIST1 ( "/" ast_closure_term )  TAG SSR
-| DELETE "/" ast_closure_term      (* SSR plugin *)
-]
-
-ssrfwd: [
-| REPLACE ":" ast_closure_lterm ":=" ast_closure_lterm      (* SSR plugin *)
-| WITH OPT ( ":" ast_closure_lterm ) ":=" ast_closure_lterm      TAG SSR
-| DELETE ":=" ast_closure_lterm      (* SSR plugin *)
-]
-
-ssrsetfwd: [
-| REPLACE ":" ast_closure_lterm ":=" "{" ssrocc "}" cpattern      (* SSR plugin *)
-| WITH OPT ( ":" ast_closure_lterm ) ":=" [ "{" ssrocc "}" cpattern | lcpattern ]      TAG SSR
-| DELETE ":" ast_closure_lterm ":=" lcpattern      (* SSR plugin *)
-| DELETE ":=" "{" ssrocc "}" cpattern      (* SSR plugin *)
-| DELETE ":=" lcpattern      (* SSR plugin *)
-]
-
-
-(* per @gares *)
-ssrdgens: [
-| REPLACE ":" ssrgen ssrdgens_tl      (* SSR plugin *)
-| WITH ":" ssrgen OPT ( "/" ssrgen )      TAG SSR
-]
-
-ssrdgens_tl: [ | DELETENT ]
-
-ssrgen: [
-| REPLACE ssrdocc cpattern      (* SSR plugin *)
-| WITH cpattern LIST0 [ LIST1 ident | cpattern ]    TAG SSR
-| DELETE cpattern      (* SSR plugin *)
-]
 
 OPTINREF: [ ]
-
-ssrortacs: [
-| EDIT ssrtacarg "|" ADD_OPT ssrortacs      (* ssr plugin *)
-| EDIT "|" ADD_OPT ssrortacs      (* ssr plugin *)
-| EDIT ADD_OPT ssrtacarg "|" OPT ssrortacs
-]
-
-ssrocc: [
-| REPLACE natural LIST0 natural      (* SSR plugin *)
-| WITH [ natural | "+" | "-" ] LIST0 natural      TAG SSR
-| DELETE "-" LIST0 natural      (* SSR plugin *)
-| DELETE "+" LIST0 natural      (* SSR plugin *)
-]
-
-ssripat: [
-| DELETE ssrdocc "->"      (* SSR plugin *)
-| DELETE ssrdocc "<-"      (* SSR plugin *)
-| REPLACE ssrdocc      (* SSR plugin *)
-| WITH ssrdocc OPT [ "->" | "<-" ]      TAG SSR
-| DELETE "->"      (* SSR plugin *)
-| DELETE "<-"      (* SSR plugin *)
-| DELETE "-/" "="      (* SSR plugin *)
-| DELETE "-/" "/"      (* SSR plugin *)
-| DELETE "-/" integer "/"      (* SSR plugin *)
-| DELETE "-/" integer "/="      (* SSR plugin *)
-| REPLACE "-/" integer "/" integer "="      (* SSR plugin *)
-| WITH "-/" integer [ "/=" | "/" | "/" integer "=" ]     TAG SSR
-| DELETE "-/" "/="      (* SSR plugin *)
-| DELETE "-//" "="      (* SSR plugin *)
-| DELETE "[" ":" LIST0 ident "]"      (* SSR plugin *)
-]
-
-ssrsimpl_ne: [
-| DELETE "/" natural "/" "="      (* SSR plugin *)
-(* parsed but not supported per @gares *)
-| DELETE "/" natural "/"      (* SSR plugin *)
-| DELETE "/" natural "="      (* SSR plugin *)
-| DELETE "//" natural "="      (* SSR plugin *)
-]
-
-hat: [
-| DELETE "^" "~" ident      (* SSR plugin *)
-| DELETE "^" "~" natural      (* SSR plugin *)
-]
-
-ssrcpat: [
-| REPLACE "[" "=" ssriorpat "]"
-| WITH    "[=" ssriorpat "]"
-]
-
-ssriorpat: [
-| ssripats OPT ( [ "|" | "|-" ] ssriorpat )   TAG SSR
-| DELETE OPT ssripats "|" ssriorpat      (* SSR plugin *)
-| DELETE OPT ssripats "|-" ">" ssriorpat      (* SSR plugin *)
-| DELETE OPT ssripats "|-" ssriorpat      (* SSR plugin *)
-(* "|->" | "||" | "|||" | "||||" are parsing hacks *)
-| DELETE OPT ssripats "|->" ssriorpat      (* SSR plugin *)
-| DELETE OPT ssripats "||" ssriorpat      (* SSR plugin *)
-| DELETE OPT ssripats "|||" ssriorpat      (* SSR plugin *)
-| DELETE OPT ssripats "||||" ssriorpat      (* SSR plugin *)
-| DELETE OPT ssripats      (* SSR plugin *)
-]
-
-ssrbinder: [
-| REPLACE "(" ssrbvar LIST1 ssrbvar ":" lconstr ")"      (* SSR plugin *)
-| WITH "(" LIST1 ssrbvar ":" lconstr ")"      TAG SSR
-| REPLACE "(" ssrbvar ":" lconstr ":=" lconstr ")"      (* SSR plugin *)
-| WITH "(" ssrbvar OPT ( ":" lconstr ) OPT ( ":=" lconstr ) ")"      TAG SSR
-| DELETE "(" ssrbvar ")"      (* SSR plugin *)
-| DELETE "(" ssrbvar ":" lconstr ")"      (* SSR plugin *)
-| DELETE "(" ssrbvar ":=" lconstr ")"      (* SSR plugin *)
-]
-
-ssrhavefwd: [
-| REPLACE ":" ast_closure_lterm ":=" ast_closure_lterm      (* SSR plugin *)
-| WITH ":" ast_closure_lterm ":=" OPT ast_closure_lterm     TAG SSR
-| DELETE ":" ast_closure_lterm ":="      (* SSR plugin *)
-| DELETE ":=" ast_closure_lterm      (* SSR plugin *)
-]
-
-ssrmult_ne: [
-| EDIT ADD_OPT natural ssrmmod      TAG SSR
-]
-
-rpattern: [
-| REPLACE lconstr "in" lconstr "in" lconstr      (* SSR plugin *)
-| WITH OPT ( OPT ( OPT ( OPT lconstr "in" ) lconstr ) "in" ) lconstr     TAG SSR
-| DELETE lconstr      (* SSR plugin *)
-| DELETE "in" lconstr      (* SSR plugin *)
-| DELETE lconstr "in" lconstr      (* SSR plugin *)
-| DELETE "in" lconstr "in" lconstr      (* SSR plugin *)
-]
-
-ssrrule_ne: [
-| DELETE ssrsimpl_ne      (* SSR plugin *)
-| REPLACE [ "/" ssrterm | ssrterm | ssrsimpl_ne ]      (* SSR plugin *)
-| WITH [ OPT "/" ssrterm  | ssrsimpl_ne ]      TAG SSR
-]
-
-ssrunlockarg: [
-| REPLACE "{" ssrocc "}" ssrterm      (* SSR plugin *)
-| WITH OPT ( "{" ssrocc "}" ) ssrterm      TAG SSR
-| DELETE ssrterm      (* SSR plugin *)
-]
-
-ssrclauses: [
-| REPLACE "in" ssrclausehyps "|-" "*"      (* SSR plugin *)
-| WITH "in" ssrclausehyps OPT "|-" OPT "*"      TAG SSR
-| DELETE "in" ssrclausehyps "|-"      (* SSR plugin *)
-| DELETE "in" ssrclausehyps "*"      (* SSR plugin *)
-| DELETE "in" ssrclausehyps      (* SSR plugin *)
-| REPLACE "in" "|-" "*"      (* SSR plugin *)
-| WITH "in" [ "*" | "*" "|-" | "|-" "*" ]     TAG SSR
-| DELETE "in" "*"      (* SSR plugin *)
-| DELETE "in" "*" "|-"      (* SSR plugin *)
-]
-
-ssrclausehyps: [
-| REPLACE ssrwgen "," ssrclausehyps      (* SSR plugin *)
-| WITH ssrwgen LIST0 ( OPT "," ssrwgen )     TAG SSR
-| DELETE ssrwgen ssrclausehyps      (* SSR plugin *)
-| DELETE ssrwgen      (* SSR plugin *)
-]
-
-ssrwgen: [
-| DELETE ssrhoi_hyp      (* SSR plugin *)
-| REPLACE "@" ssrhoi_hyp      (* SSR plugin *)
-| WITH OPT "@" ssrhoi_hyp      TAG SSR
-| REPLACE "(" ssrhoi_id ":=" lcpattern ")"      (* SSR plugin *)
-| WITH "(" ssrhoi_id OPT ( ":=" lcpattern ) ")"      TAG SSR
-| DELETE "(" ssrhoi_id ")"      (* SSR plugin *)
-| DELETE "(" "@" ssrhoi_id ":=" lcpattern ")"      (* SSR plugin *)
-]
-
-ssrcongrarg: [
-| REPLACE natural constr ssrdgens      (* SSR plugin *)
-| WITH OPT natural constr OPT ssrdgens      TAG SSR
-| DELETE natural constr      (* SSR plugin *)
-| DELETE constr ssrdgens      (* SSR plugin *)
-| DELETE constr      (* SSR plugin *)
-]
-
-ssrviewpos: [
-| DELETE "for" "apply" "/" "/"      (* SSR plugin *)
-]
-
-ssrhintref: [
-| REPLACE constr "|" natural      (* SSR plugin *)
-| WITH constr OPT ( "|" natural )     TAG SSR
-| DELETE constr      (* SSR plugin *)
-]
-
-ssrmmod: [
-| DELETE LEFTQMARK      (* SSR plugin *)  (* duplicate *)
-]
-
-clear_switch: [
-| "{" LIST0 ident "}"
-]
-
-ssrrwocc: [
-| REPLACE "{" LIST0 ssrhyp "}"      (* SSR plugin *)
-| WITH clear_switch
-]
-
-ssrrwarg: [
-| EDIT "{" ADD_OPT ssrocc "}" OPT ssrpattern_squarep ssrrule_ne      TAG SSR
-| REPLACE "{" LIST1 ssrhyp "}" ssrpattern_ne_squarep ssrrule_ne      (* SSR plugin *)
-| WITH OPT ( OPT ( "{" LIST1 ssrhyp "}" ) ssrpattern_ne_squarep ) ssrrule_ne      TAG SSR
-| DELETE ssrpattern_ne_squarep ssrrule_ne      (* SSR plugin *)
-| DELETE ssrrule_ne      (* SSR plugin *)
-]
-
-ssrpattern_squarep: [  (* fix inconsistency *)
-| REPLACE "[" rpattern "]"      (* SSR plugin *)
-| WITH ssrpattern_ne_squarep   TAG SSR
-]
-
-ssripats_ne: [
-| REPLACE ssripat OPT ssripats      (* SSR plugin *)
-| WITH LIST1 ssripat      TAG SSR
-]
-
-ssripats: [  (* fix inconsistency *)
-| REPLACE ssripat OPT ssripats      (* SSR plugin *)
-| WITH ssripats_ne     TAG SSR
-]
-
-lcpattern: [
-(* per @gares *)
-| DELETE "Qed" lconstr
-]
-
-ssrapplyarg: [
-| EDIT ADD_OPT ssrbwdview ":" ssragen OPT ssragens OPT ssrintros      TAG SSR
-]
 
 constr_with_bindings_arg: [
 | DELETE ">" constr_with_bindings
@@ -2492,57 +2177,6 @@ constr_with_bindings_arg: [
 
 destruction_arg: [
 | DELETE constr_with_bindings
-]
-
-ssrhintarg: [
-| EDIT "[" ADD_OPT ssrortacs "]"      TAG SSR
-]
-
-
-ssrhint3arg: [
-| EDIT "[" ADD_OPT ssrortacs "]"      TAG SSR
-]
-
-
-ssr_first: [
-| DELETE ssr_first ssrintros_ne      (* SSR plugin *)
-| REPLACE "[" LIST0 ltac_expr5 SEP "|" "]"      (* SSR plugin *)
-| WITH "[" LIST0 ltac_expr5 SEP "|" "]" LIST0 ssrintros_ne     TAG SSR
-]
-
-ssr_first_else: [
-| EDIT ssr_first ADD_OPT ssrorelse      TAG SSR
-]
-
-ssrseqarg: [
-| EDIT ADD_OPT ssrseqidx ssrswap      TAG SSR
-]
-
-ssr_dpat: [
-| REPLACE ssr_mpat "in" pattern200 ssr_rtype      (* SSR plugin *)
-| WITH ssr_mpat OPT ( OPT ( "in" pattern200 ) ssr_rtype )      TAG SSR
-| DELETE ssr_mpat ssr_rtype      (* SSR plugin *)
-| DELETE ssr_mpat      (* SSR plugin *)
-]
-
-ssr_one_term_pattern: [
-| DELETE "Qed" constr
-]
-
-ssrarg: [
-| EDIT ADD_OPT ssrfwdview OPT ssreqid ssrdgens OPT ssrintros      (* SSR plugin *)
-]
-
-ssragen: [
-| REPLACE "{" LIST1 ssrhyp "}" ssrterm      (* SSR plugin *)
-| WITH OPT ( "{" LIST1 ssrhyp "}" ) ssrterm      TAG SSR
-| DELETE ssrterm      (* SSR plugin *)
-]
-
-ssrbinder: [
-| REPLACE [ "of" | "&" ] term99      (* SSR plugin *)
-| WITH "of" term99      TAG SSR
-| "&" term99      TAG SSR
 ]
 
 firstorder_rhs: [
@@ -2554,12 +2188,6 @@ firstorder_rhs: [
 
 attribute: [
 | DELETE "using" OPT attr_value
-]
-
-hypident: [
-(* todo: restore for SSR *)
-| DELETE "(" "type" "of" ident ")"      (* SSR plugin *)
-| DELETE "(" "value" "of" ident ")"      (* SSR plugin *)
 ]
 
 ref_or_pattern_occ: [
@@ -2650,53 +2278,6 @@ SPLICE: [
 | bar_cbrace
 | lconstr
 
-(* SSR *)
-| ast_closure_term
-| ast_closure_lterm
-| ident_no_do
-| ssrterm
-| ssrtacarg
-| ssrtac3arg
-| ssrhyp
-| ssrhoi_hyp
-| ssrhoi_id
-| ssrhpats
-| ssrhpats_nobs
-| ssrfwdid
-| ssrmovearg
-| ssrcasearg
-| ssrrwargs
-| ssrviewposspc
-| ssrpatternarg
-| ssr_elsepat
-| ssr_mpat
-| ssrunlockargs
-| ssrcofixfwd
-| ssrfixfwd
-| ssrhavefwdwbinders
-| ssrparentacarg
-| ssrposefwd
-| ssrstruct
-| ssrrpat
-| ssrhint
-| ssrpattern_squarep
-| ssrhintref
-| ssrexactarg
-| ssrclear
-| ssrmult
-| ssripats
-| ssrintros
-| ssrrule
-| ssrcongrarg
-| ssrdotac
-| ssrunlockarg
-| ssrortacarg
-| ssrsetfwd
-| ssr_idcomma
-| ssr_dthen
-| ssr_else
-| ssr_rtype
-| ssreqid
 | preident
 | lpar_id_coloneq
 | binders
@@ -2883,22 +2464,6 @@ RENAME: [
 | ltac2_type5 ltac2_type
 | ltac2_expr6 ltac2_expr
 | starredidentref starred_ident_ref
-| ssrocc ssr_occurrences
-| ssrsimpl_ne s_item
-| ssrclear_ne ssrclear
-| ssrmult_ne mult
-| ssripats_ne ssripats
-| ssrrule_ne r_item
-| ssrintros_ne ssrintros
-| ssrpattern_ne_squarep ssrpattern_squarep
-| ssrrwarg rewrite_item
-| ssrrwocc occ_or_clear
-| rpattern rewrite_pattern
-| ssripat i_item
-| ssrwgen gen_item
-| ssrfwd ssrdefbody
-| ssrclauses ssr_in
-| ssrcpat ssrblockpat
 | constr_pattern one_pattern
 | hints_path hints_regexp
 | clause_dft_concl occurrences
@@ -2940,7 +2505,6 @@ SPLICE: [
 | ltac_defined_tactics
 | tactic_notation_tactics
 ]
-(* todo: ssrreflect*.rst ref to fix_decl is incorrect *)
 
 REACHABLE: [
 | command

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1181,6 +1181,9 @@ simple_tactic: [
 | DELETE "typeclasses" "eauto" "best_effort" OPT nat_or_var
 | DELETE "typeclasses" "eauto" OPT nat_or_var "with" LIST1 preident
 | DELETE "typeclasses" "eauto" OPT nat_or_var
+(* first/solve variants defined with register_list_tactical in coretactics.mlg *)
+| "first" ident
+| "solve" ident
 (* in Tactic Notation: *)
 | "setoid_replace" constr "with" constr OPT ( "using" "relation" constr ) OPT ( "in" hyp )
        OPT ( "at" LIST1 int_or_var ) OPT ( "by" ltac_expr3 )

--- a/doc/tools/docgram/doc_grammar.ml
+++ b/doc/tools/docgram/doc_grammar.ml
@@ -1750,14 +1750,9 @@ let process_rst g file args seen tac_prods cmd_prods =
     end
   in
 
-  let cmd_exclude_files = [
-    "doc/sphinx/proof-engine/ssreflect-proof-language.rst";
-  ]
-  in
-
   let save_n_get_more direc pfx first_rhs seen_map prods =
     let replace rhs prods =
-      if StringSet.is_empty prods || (List.mem file cmd_exclude_files) then
+      if StringSet.is_empty prods then
         rhs (* no change *)
       else
         let mtch, multi, best = find_longest_match prods rhs in
@@ -1788,17 +1783,19 @@ let process_rst g file args seen tac_prods cmd_prods =
 
     map := NTMap.add (remove_subscrs first_rhs) (file, !linenum) !map;
     while
-      let nextline = getline() in
-      ignore (Str.string_match contin_regex nextline 0);
-      let indent = Str.matched_group 1 nextline in
-      let rhs = Str.matched_group 2 nextline in
-      let replaceable = rhs <> "" && rhs.[0] <> ':' in
-      let upd_rhs = if replaceable then (replace rhs prods) else rhs in
-      fprintf new_rst "%s%s\n" indent upd_rhs;
-      if replaceable then begin
-        map := NTMap.add rhs (file, !linenum) !map
-      end;
-      rhs <> ""
+      try
+        let nextline = getline() in
+        ignore (Str.string_match contin_regex nextline 0);
+        let indent = Str.matched_group 1 nextline in
+        let rhs = Str.matched_group 2 nextline in
+        let replaceable = rhs <> "" && rhs.[0] <> ':' in
+        let upd_rhs = if replaceable then (replace rhs prods) else rhs in
+        fprintf new_rst "%s%s\n" indent upd_rhs;
+        if replaceable then begin
+          map := NTMap.add (remove_subscrs rhs) (file, !linenum) !map
+        end;
+        rhs <> ""
+      with End_of_file -> false
     do
       ()
     done;
@@ -1930,15 +1927,8 @@ let process_grammar args =
       let out = open_out (dir "updated_rsts") in
       close_out out;
 
-(*
-      if args.check_tacs then
-        report_omitted_prods tac_list !seen.tacs "Tactic" "\n                 ";
-      if args.check_cmds then
-        report_omitted_prods cmd_list !seen.cmds "Command" "\n                  ";
-*)
-
       (* generate report on cmds or tacs *)
-      let cmdReport outfile cmdStr cmd_nts cmds cmdvs =
+      let cmdReport outfile cmdStr itemName cmd_nts cmds cmdvs =
         let rstCmds = StringSet.of_list (List.map (fun b -> let c, _ = b in c) (NTMap.bindings cmds)) in
         let rstCmdvs = StringSet.of_list (List.map (fun b -> let c, _ = b in c) (NTMap.bindings cmdvs)) in
         let gramCmds = List.fold_left (fun set nt ->
@@ -1950,8 +1940,8 @@ let process_grammar args =
             let rsts = StringSet.mem c rstCmds in
             let gram = StringSet.mem c gramCmds in
             let pfx = match rsts, gram with
-            | true, false -> "+"
-            | false, true -> "-"
+            | true, false -> error "%s not in grammar: %s\n" itemName c; "+"
+            | false, true -> error "%s not in doc: %s\n" itemName c; "-"
             | false, false -> "?"
             | _, _ -> " "
             in
@@ -1966,11 +1956,11 @@ let process_grammar args =
       let cmd_nts = ["command"] in
       (* TODO: need to handle tactic_mode (overlaps with query_command) and subprf *)
       if args.check_cmds then
-        cmdReport "prodnCommands" "cmds" cmd_nts !seen.cmds !seen.cmdvs;
+        cmdReport "prodnCommands" "cmds" "Command" cmd_nts !seen.cmds !seen.cmdvs;
 
       let tac_nts = ["simple_tactic"] in
       if args.check_tacs then
-        cmdReport "prodnTactics" "tacs" tac_nts !seen.tacs !seen.tacvs;
+        cmdReport "prodnTactics" "tacs" "Tactic" tac_nts !seen.tacs !seen.tacvs;
 
       (* generate prodnGrammar for reference *)
       if not args.verify then begin

--- a/doc/tools/docgram/doc_grammar.ml
+++ b/doc/tools/docgram/doc_grammar.ml
@@ -303,6 +303,8 @@ module DocGram = struct
 end
 open DocGram
 
+let remove_Sedit2 p =
+  List.filter (fun sym -> match sym with | Sedit2 _ -> false | _ -> true) p
 
 let rec output_prodn = function
   | Sterm s ->
@@ -356,7 +358,7 @@ and prod_to_prodn_r prod =
   | p :: tl -> (output_prodn p) :: (prod_to_prodn_r tl)
   | [] -> []
 
-and prod_to_prodn prod = String.concat " " (prod_to_prodn_r prod)
+and prod_to_prodn prod = String.concat " " (prod_to_prodn_r (remove_Sedit2 prod))
 
 let get_tag file prod =
   List.fold_left (fun rv sym ->
@@ -925,6 +927,7 @@ let global_repl g pat repl =
 (*** splice: replace a reference to a nonterminal with its definition ***)
 
 (* todo: create a better splice routine *)
+(* todo: remove extraneous "(* ltac2 plugin *)" in Ltac2 Notation cmd *)
 let apply_splice g edit_map =
   List.iter (fun b ->
       let (nt0, prods0) = b in

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -156,11 +156,6 @@ binder_constr: [
 | "if" term200 as_return_type "then" term200 "else" term200
 | "fix" fix_decls
 | "cofix" cofix_decls
-| "if" term200 "is" ssr_dthen ssr_else      (* SSR plugin *)
-| "if" term200 "isn't" ssr_dthen ssr_else      (* SSR plugin *)
-| "let" ":" ssr_mpat ":=" lconstr "in" lconstr      (* SSR plugin *)
-| "let" ":" ssr_mpat ":=" lconstr ssr_rtype "in" lconstr      (* SSR plugin *)
-| "let" ":" ssr_mpat "in" pattern200 ":=" lconstr ssr_rtype "in" lconstr      (* SSR plugin *)
 ]
 
 arg: [
@@ -341,7 +336,6 @@ closed_binder: [
 | "`{" LIST1 typeclass_constraint SEP "," "}"
 | "`[" LIST1 typeclass_constraint SEP "," "]"
 | "'" pattern0
-| [ "of" | "&" ] term99      (* SSR plugin *)
 ]
 
 one_open_binder: [
@@ -694,9 +688,6 @@ command: [
 | "Print" "Rings"      (* ring plugin *)
 | "Add" "Field" identref ":" constr OPT field_mods      (* ring plugin *)
 | "Print" "Fields"      (* ring plugin *)
-| "Prenex" "Implicits" LIST1 global      (* SSR plugin *)
-| "Print" "Hint" "View" ssrviewpos      (* SSR plugin *)
-| "Hint" "View" ssrviewposspc LIST1 ssrhintref      (* SSR plugin *)
 | "Number" "Notation" reference reference reference OPT number_options ":" preident
 | "String" "Notation" reference reference reference OPT string_option ":" preident
 | "Ltac2" ltac2_entry      (* ltac2 plugin *)
@@ -1080,7 +1071,6 @@ gallina_ext: [
 | "Generalizable" [ "All" "Variables" | "No" "Variables" | [ "Variable" | "Variables" ] LIST1 identref ]
 | "Export" "Set" setting_name option_setting
 | "Export" "Unset" setting_name
-| "Import" "Prenex" "Implicits"      (* SSR plugin *)
 ]
 
 import_categories: [
@@ -1846,50 +1836,6 @@ simple_tactic: [
 | "ring_lookup" tactic0 "[" LIST0 constr "]" LIST1 constr      (* ring plugin *)
 | "field_lookup" tactic "[" LIST0 constr "]" LIST1 constr      (* ring plugin *)
 | "rtauto"
-| "by" ssrhintarg      (* SSR plugin *)
-| "clear" natural      (* SSR plugin *)
-| "move" ssrmovearg ssrrpat      (* SSR plugin *)
-| "move" ssrmovearg ssrclauses      (* SSR plugin *)
-| "move" ssrrpat      (* SSR plugin *)
-| "move"      (* SSR plugin *)
-| "case" ssrcasearg ssrclauses      (* SSR plugin *)
-| "case"      (* SSR plugin *)
-| "elim" ssrarg ssrclauses      (* SSR plugin *)
-| "elim"      (* SSR plugin *)
-| "apply" ssrapplyarg      (* SSR plugin *)
-| "apply"      (* SSR plugin *)
-| "exact" ssrexactarg      (* SSR plugin *)
-| "exact"      (* SSR plugin *)
-| "exact" "<:" lconstr      (* SSR plugin *)
-| "congr" ssrcongrarg      (* SSR plugin *)
-| "ssrinstancesofruleL2R" ssrterm      (* SSR plugin *)
-| "ssrinstancesofruleR2L" ssrterm      (* SSR plugin *)
-| "rewrite" ssrrwargs ssrclauses      (* SSR plugin *)
-| "unlock" ssrunlockargs ssrclauses      (* SSR plugin *)
-| "pose" ssrfixfwd      (* SSR plugin *)
-| "pose" ssrcofixfwd      (* SSR plugin *)
-| "pose" ssrfwdid ssrposefwd      (* SSR plugin *)
-| "set" ssrfwdid ssrsetfwd ssrclauses      (* SSR plugin *)
-| "have" ssrhavefwdwbinders      (* SSR plugin *)
-| "have" "suff" ssrhpats_nobs ssrhavefwd      (* SSR plugin *)
-| "have" "suffices" ssrhpats_nobs ssrhavefwd      (* SSR plugin *)
-| "suff" "have" ssrhpats_nobs ssrhavefwd      (* SSR plugin *)
-| "suffices" "have" ssrhpats_nobs ssrhavefwd      (* SSR plugin *)
-| "suff" ssrsufffwd      (* SSR plugin *)
-| "suffices" ssrsufffwd      (* SSR plugin *)
-| "wlog" ssrhpats_nobs ssrwlogfwd ssrhint      (* SSR plugin *)
-| "wlog" "suff" ssrhpats_nobs ssrwlogfwd ssrhint      (* SSR plugin *)
-| "wlog" "suffices" ssrhpats_nobs ssrwlogfwd ssrhint      (* SSR plugin *)
-| "without" "loss" ssrhpats_nobs ssrwlogfwd ssrhint      (* SSR plugin *)
-| "without" "loss" "suff" ssrhpats_nobs ssrwlogfwd ssrhint      (* SSR plugin *)
-| "without" "loss" "suffices" ssrhpats_nobs ssrwlogfwd ssrhint      (* SSR plugin *)
-| "gen" "have" ssrclear ssr_idcomma ssrhpats_nobs ssrwlogfwd ssrhint      (* SSR plugin *)
-| "generally" "have" ssrclear ssr_idcomma ssrhpats_nobs ssrwlogfwd ssrhint      (* SSR plugin *)
-| "under" ssrrwarg      (* SSR plugin *)
-| "under" ssrrwarg ssrintros_ne      (* SSR plugin *)
-| "under" ssrrwarg ssrintros_ne "do" ssrhint3arg      (* SSR plugin *)
-| "under" ssrrwarg "do" ssrhint3arg      (* SSR plugin *)
-| "ssrinstancesoftpat" G_SSRMATCHING_cpattern      (* SSR plugin *)
 ]
 
 mlname: [
@@ -2094,9 +2040,6 @@ ltac_expr4: [
 | ltac_expr3 ";" ltac_expr3
 | ltac_expr3 ";" tactic_then_locality for_each_goal "]"
 | ltac_expr3
-| ltac_expr5 ";" "first" ssr_first_else      (* SSR plugin *)
-| ltac_expr5 ";" "first" ssrseqarg      (* SSR plugin *)
-| ltac_expr5 ";" "last" ssrseqarg      (* SSR plugin *)
 ]
 
 ltac_expr3: [
@@ -2112,10 +2055,6 @@ ltac_expr3: [
 | "abstract" ltac_expr2 "using" ident
 | "only" selector ":" ltac_expr3
 | ltac_expr2
-| "do" ssrmmod ssrdotac ssrclauses      (* SSR plugin *)
-| "do" ssrortacarg ssrclauses      (* SSR plugin *)
-| "do" nat_or_var ssrmmod ssrdotac ssrclauses      (* SSR plugin *)
-| "abstract" ssrdgens      (* SSR plugin *)
 ]
 
 ltac_expr2: [
@@ -2139,14 +2078,12 @@ ltac_expr1: [
 | tactic_value
 | reference LIST0 tactic_arg
 | ltac_expr0
-| ltac_expr5 ssrintros_ne      (* SSR plugin *)
 ]
 
 ltac_expr0: [
 | "(" ltac_expr5 ")"
 | "[" ">" for_each_goal "]"
 | tactic_atom
-| ssrparentacarg      (* SSR plugin *)
 ]
 
 failkw: [
@@ -2533,8 +2470,6 @@ hypident: [
 | id_or_meta
 | "(" "type" "of" id_or_meta ")"
 | "(" "value" "of" id_or_meta ")"
-| "(" "type" "of" Prim.identref ")"      (* SSR plugin *)
-| "(" "value" "of" Prim.identref ")"      (* SSR plugin *)
 ]
 
 hypident_occ: [
@@ -2683,579 +2618,6 @@ field_mod: [
 
 field_mods: [
 | "(" LIST1 field_mod SEP "," ")"      (* ring plugin *)
-]
-
-ssrtacarg: [
-| ltac_expr5      (* SSR plugin *)
-]
-
-ssrtac3arg: [
-| ltac_expr3      (* SSR plugin *)
-]
-
-ssrtclarg: [
-| ssrtacarg      (* SSR plugin *)
-]
-
-ssrhyp: [
-| ident      (* SSR plugin *)
-]
-
-ssrhoi_hyp: [
-| ident      (* SSR plugin *)
-]
-
-ssrhoi_id: [
-| ident      (* SSR plugin *)
-]
-
-ssrsimpl_ne: [
-| "//="      (* SSR plugin *)
-| "/="      (* SSR plugin *)
-| test_ssrslashnum11 "/" natural "/" natural "="      (* SSR plugin *)
-| test_ssrslashnum10 "/" natural "/"      (* SSR plugin *)
-| test_ssrslashnum10 "/" natural "="      (* SSR plugin *)
-| test_ssrslashnum10 "/" natural "/="      (* SSR plugin *)
-| test_ssrslashnum10 "/" natural "/" "="      (* SSR plugin *)
-| test_ssrslashnum01 "//" natural "="      (* SSR plugin *)
-| test_ssrslashnum00 "//"      (* SSR plugin *)
-]
-
-ssrclear_ne: [
-| "{" LIST1 ssrhyp "}"      (* SSR plugin *)
-]
-
-ssrclear: [
-| ssrclear_ne      (* SSR plugin *)
-|      (* SSR plugin *)
-]
-
-ssrindex: [
-]
-
-ssrocc: [
-| natural LIST0 natural      (* SSR plugin *)
-| "-" LIST0 natural      (* SSR plugin *)
-| "+" LIST0 natural      (* SSR plugin *)
-]
-
-ssrmmod: [
-| "!"      (* SSR plugin *)
-| LEFTQMARK      (* SSR plugin *)
-| "?"      (* SSR plugin *)
-]
-
-ssrmult_ne: [
-| natural ssrmmod      (* SSR plugin *)
-| ssrmmod      (* SSR plugin *)
-]
-
-ssrmult: [
-| ssrmult_ne      (* SSR plugin *)
-|      (* SSR plugin *)
-]
-
-ssrdocc: [
-| "{" ssrocc "}"      (* SSR plugin *)
-| "{" LIST0 ssrhyp "}"      (* SSR plugin *)
-]
-
-ssrterm: [
-| ssrtermkind Pcoq.Constr.constr      (* SSR plugin *)
-]
-
-ast_closure_term: [
-| term_annotation constr      (* SSR plugin *)
-]
-
-ast_closure_lterm: [
-| term_annotation lconstr      (* SSR plugin *)
-]
-
-ssrbwdview: [
-| test_not_ssrslashnum "/" Pcoq.Constr.constr      (* SSR plugin *)
-| test_not_ssrslashnum "/" Pcoq.Constr.constr ssrbwdview      (* SSR plugin *)
-]
-
-ssrfwdview: [
-| test_not_ssrslashnum "/" ast_closure_term      (* SSR plugin *)
-| test_not_ssrslashnum "/" ast_closure_term ssrfwdview      (* SSR plugin *)
-]
-
-ident_no_do: [
-| test_ident_no_do IDENT      (* SSR plugin *)
-]
-
-ssripat: [
-| "_"      (* SSR plugin *)
-| "*"      (* SSR plugin *)
-| ">"      (* SSR plugin *)
-| ident_no_do      (* SSR plugin *)
-| "?"      (* SSR plugin *)
-| "+"      (* SSR plugin *)
-| "++"      (* SSR plugin *)
-| ssrsimpl_ne      (* SSR plugin *)
-| ssrdocc "->"      (* SSR plugin *)
-| ssrdocc "<-"      (* SSR plugin *)
-| ssrdocc      (* SSR plugin *)
-| "->"      (* SSR plugin *)
-| "<-"      (* SSR plugin *)
-| "-"      (* SSR plugin *)
-| "-/" "="      (* SSR plugin *)
-| "-/="      (* SSR plugin *)
-| "-/" "/"      (* SSR plugin *)
-| "-//"      (* SSR plugin *)
-| "-/" integer "/"      (* SSR plugin *)
-| "-/" "/="      (* SSR plugin *)
-| "-//" "="      (* SSR plugin *)
-| "-//="      (* SSR plugin *)
-| "-/" integer "/="      (* SSR plugin *)
-| "-/" integer "/" integer "="      (* SSR plugin *)
-| ssrfwdview      (* SSR plugin *)
-| "[" ":" LIST0 ident "]"      (* SSR plugin *)
-| "[:" LIST0 ident "]"      (* SSR plugin *)
-| ssrcpat      (* SSR plugin *)
-]
-
-ssripats: [
-| ssripat ssripats      (* SSR plugin *)
-|      (* SSR plugin *)
-]
-
-ssriorpat: [
-| ssripats "|" ssriorpat      (* SSR plugin *)
-| ssripats "|-" ">" ssriorpat      (* SSR plugin *)
-| ssripats "|-" ssriorpat      (* SSR plugin *)
-| ssripats "|->" ssriorpat      (* SSR plugin *)
-| ssripats "||" ssriorpat      (* SSR plugin *)
-| ssripats "|||" ssriorpat      (* SSR plugin *)
-| ssripats "||||" ssriorpat      (* SSR plugin *)
-| ssripats      (* SSR plugin *)
-]
-
-ssrcpat: [
-| test_leftsquarebracket_equal test_nohidden "[" "=" ssriorpat "]"      (* SSR plugin *)
-| test_nohidden "[" hat "]"      (* SSR plugin *)
-| test_nohidden "[" ssriorpat "]"      (* SSR plugin *)
-]
-
-hat: [
-| "^" ident      (* SSR plugin *)
-| "^" "~" ident      (* SSR plugin *)
-| "^" "~" natural      (* SSR plugin *)
-| "^~" ident      (* SSR plugin *)
-| "^~" natural      (* SSR plugin *)
-]
-
-ssripats_ne: [
-| ssripat ssripats      (* SSR plugin *)
-]
-
-ssrhpats: [
-| ssripats      (* SSR plugin *)
-]
-
-ssrhpats_wtransp: [
-| ssripats      (* SSR plugin *)
-| ssripats "@" ssripats      (* SSR plugin *)
-]
-
-ssrhpats_nobs: [
-| ssripats      (* SSR plugin *)
-]
-
-ssrrpat: [
-| "->"      (* SSR plugin *)
-| "<-"      (* SSR plugin *)
-]
-
-ssrintros_ne: [
-| "=>" ssripats_ne      (* SSR plugin *)
-]
-
-ssrintros: [
-| ssrintros_ne      (* SSR plugin *)
-|      (* SSR plugin *)
-]
-
-ssrintrosarg: [
-]
-
-ssrfwdid: [
-| test_ssrfwdid Prim.ident      (* SSR plugin *)
-]
-
-ssrortacs: [
-| ssrtacarg "|" ssrortacs      (* SSR plugin *)
-| ssrtacarg "|"      (* SSR plugin *)
-| ssrtacarg      (* SSR plugin *)
-| "|" ssrortacs      (* SSR plugin *)
-| "|"      (* SSR plugin *)
-]
-
-ssrhintarg: [
-| "[" "]"      (* SSR plugin *)
-| "[" ssrortacs "]"      (* SSR plugin *)
-| ssrtacarg      (* SSR plugin *)
-]
-
-ssrhint3arg: [
-| "[" "]"      (* SSR plugin *)
-| "[" ssrortacs "]"      (* SSR plugin *)
-| ssrtac3arg      (* SSR plugin *)
-]
-
-ssrortacarg: [
-| "[" ssrortacs "]"      (* SSR plugin *)
-]
-
-ssrhint: [
-|      (* SSR plugin *)
-| "by" ssrhintarg      (* SSR plugin *)
-]
-
-ssrwgen: [
-| ssrclear_ne      (* SSR plugin *)
-| ssrhoi_hyp      (* SSR plugin *)
-| "@" ssrhoi_hyp      (* SSR plugin *)
-| "(" ssrhoi_id ":=" lcpattern ")"      (* SSR plugin *)
-| "(" ssrhoi_id ")"      (* SSR plugin *)
-| "(@" ssrhoi_id ":=" lcpattern ")"      (* SSR plugin *)
-| "(" "@" ssrhoi_id ":=" lcpattern ")"      (* SSR plugin *)
-]
-
-ssrclausehyps: [
-| ssrwgen "," ssrclausehyps      (* SSR plugin *)
-| ssrwgen ssrclausehyps      (* SSR plugin *)
-| ssrwgen      (* SSR plugin *)
-]
-
-ssrclauses: [
-| "in" ssrclausehyps "|-" "*"      (* SSR plugin *)
-| "in" ssrclausehyps "|-"      (* SSR plugin *)
-| "in" ssrclausehyps "*"      (* SSR plugin *)
-| "in" ssrclausehyps      (* SSR plugin *)
-| "in" "|-" "*"      (* SSR plugin *)
-| "in" "*"      (* SSR plugin *)
-| "in" "*" "|-"      (* SSR plugin *)
-|      (* SSR plugin *)
-]
-
-ssrfwd: [
-| ":=" ast_closure_lterm      (* SSR plugin *)
-| ":" ast_closure_lterm ":=" ast_closure_lterm      (* SSR plugin *)
-]
-
-ssrbvar: [
-| ident      (* SSR plugin *)
-| "_"      (* SSR plugin *)
-]
-
-ssrbinder: [
-| ssrbvar      (* SSR plugin *)
-| "(" ssrbvar ")"      (* SSR plugin *)
-| "(" ssrbvar ":" lconstr ")"      (* SSR plugin *)
-| "(" ssrbvar LIST1 ssrbvar ":" lconstr ")"      (* SSR plugin *)
-| "(" ssrbvar ":" lconstr ":=" lconstr ")"      (* SSR plugin *)
-| "(" ssrbvar ":=" lconstr ")"      (* SSR plugin *)
-| [ "of" | "&" ] term99      (* SSR plugin *)
-]
-
-ssrstruct: [
-| "{" "struct" ident "}"      (* SSR plugin *)
-|      (* SSR plugin *)
-]
-
-ssrposefwd: [
-| LIST0 ssrbinder ssrfwd      (* SSR plugin *)
-]
-
-ssrfixfwd: [
-| "fix" ssrbvar LIST0 ssrbinder ssrstruct ssrfwd      (* SSR plugin *)
-]
-
-ssrcofixfwd: [
-| "cofix" ssrbvar LIST0 ssrbinder ssrfwd      (* SSR plugin *)
-]
-
-ssrsetfwd: [
-| ":" ast_closure_lterm ":=" "{" ssrocc "}" cpattern      (* SSR plugin *)
-| ":" ast_closure_lterm ":=" lcpattern      (* SSR plugin *)
-| ":=" "{" ssrocc "}" cpattern      (* SSR plugin *)
-| ":=" lcpattern      (* SSR plugin *)
-]
-
-ssrhavefwd: [
-| ":" ast_closure_lterm ssrhint      (* SSR plugin *)
-| ":" ast_closure_lterm ":=" ast_closure_lterm      (* SSR plugin *)
-| ":" ast_closure_lterm ":="      (* SSR plugin *)
-| ":=" ast_closure_lterm      (* SSR plugin *)
-]
-
-ssrhavefwdwbinders: [
-| ssrhpats_wtransp LIST0 ssrbinder ssrhavefwd      (* SSR plugin *)
-]
-
-ssrdoarg: [
-]
-
-ssrseqarg: [
-| ssrswap      (* SSR plugin *)
-| ssrseqidx ssrortacarg OPT ssrorelse      (* SSR plugin *)
-| ssrseqidx ssrswap      (* SSR plugin *)
-| ltac_expr3      (* SSR plugin *)
-]
-
-ssrseqidx: [
-| test_ssrseqvar Prim.ident      (* SSR plugin *)
-| Prim.natural      (* SSR plugin *)
-]
-
-ssrswap: [
-| "first"      (* SSR plugin *)
-| "last"      (* SSR plugin *)
-]
-
-ssrorelse: [
-| "||" ltac_expr2      (* SSR plugin *)
-]
-
-Prim.ident: [
-| IDENT ssr_null_entry      (* SSR plugin *)
-]
-
-ssrparentacarg: [
-| "(" ltac_expr5 ")"      (* SSR plugin *)
-]
-
-ssrdotac: [
-| ltac_expr3      (* SSR plugin *)
-| ssrortacarg      (* SSR plugin *)
-]
-
-ssrseqdir: [
-]
-
-ssr_first: [
-| ssr_first ssrintros_ne      (* SSR plugin *)
-| "[" LIST0 ltac_expr5 SEP "|" "]"      (* SSR plugin *)
-]
-
-ssr_first_else: [
-| ssr_first ssrorelse      (* SSR plugin *)
-| ssr_first      (* SSR plugin *)
-]
-
-ssrgen: [
-| ssrdocc cpattern      (* SSR plugin *)
-| cpattern      (* SSR plugin *)
-]
-
-ssrdgens_tl: [
-| "{" LIST1 ssrhyp "}" cpattern ssrdgens_tl      (* SSR plugin *)
-| "{" LIST1 ssrhyp "}"      (* SSR plugin *)
-| "{" ssrocc "}" cpattern ssrdgens_tl      (* SSR plugin *)
-| "/" ssrdgens_tl      (* SSR plugin *)
-| cpattern ssrdgens_tl      (* SSR plugin *)
-|      (* SSR plugin *)
-]
-
-ssrdgens: [
-| ":" ssrgen ssrdgens_tl      (* SSR plugin *)
-]
-
-ssreqid: [
-| test_ssreqid ssreqpat      (* SSR plugin *)
-| test_ssreqid      (* SSR plugin *)
-]
-
-ssreqpat: [
-| Prim.ident      (* SSR plugin *)
-| "_"      (* SSR plugin *)
-| "?"      (* SSR plugin *)
-| "+"      (* SSR plugin *)
-| ssrdocc "->"      (* SSR plugin *)
-| ssrdocc "<-"      (* SSR plugin *)
-| "->"      (* SSR plugin *)
-| "<-"      (* SSR plugin *)
-]
-
-ssrarg: [
-| ssrfwdview ssreqid ssrdgens ssrintros      (* SSR plugin *)
-| ssrfwdview ssrclear ssrintros      (* SSR plugin *)
-| ssreqid ssrdgens ssrintros      (* SSR plugin *)
-| ssrclear_ne ssrintros      (* SSR plugin *)
-| ssrintros_ne      (* SSR plugin *)
-]
-
-ssrmovearg: [
-| ssrarg      (* SSR plugin *)
-]
-
-ssrcasearg: [
-| ssrarg      (* SSR plugin *)
-]
-
-ssragen: [
-| "{" LIST1 ssrhyp "}" ssrterm      (* SSR plugin *)
-| ssrterm      (* SSR plugin *)
-]
-
-ssragens: [
-| "{" LIST1 ssrhyp "}" ssrterm ssragens      (* SSR plugin *)
-| "{" LIST1 ssrhyp "}"      (* SSR plugin *)
-| ssrterm ssragens      (* SSR plugin *)
-|      (* SSR plugin *)
-]
-
-ssrapplyarg: [
-| ":" ssragen ssragens ssrintros      (* SSR plugin *)
-| ssrclear_ne ssrintros      (* SSR plugin *)
-| ssrintros_ne      (* SSR plugin *)
-| ssrbwdview ":" ssragen ssragens ssrintros      (* SSR plugin *)
-| ssrbwdview ssrclear ssrintros      (* SSR plugin *)
-]
-
-ssrexactarg: [
-| ":" ssragen ssragens      (* SSR plugin *)
-| ssrbwdview ssrclear      (* SSR plugin *)
-| ssrclear_ne      (* SSR plugin *)
-]
-
-ssrcongrarg: [
-| natural constr ssrdgens      (* SSR plugin *)
-| natural constr      (* SSR plugin *)
-| constr ssrdgens      (* SSR plugin *)
-| constr      (* SSR plugin *)
-]
-
-ssrrwocc: [
-| "{" LIST0 ssrhyp "}"      (* SSR plugin *)
-| "{" ssrocc "}"      (* SSR plugin *)
-|      (* SSR plugin *)
-]
-
-ssrrule_ne: [
-| test_not_ssrslashnum [ "/" ssrterm | ssrterm | ssrsimpl_ne ]      (* SSR plugin *)
-| ssrsimpl_ne      (* SSR plugin *)
-]
-
-ssrrule: [
-| ssrrule_ne      (* SSR plugin *)
-|      (* SSR plugin *)
-]
-
-ssrpattern_squarep: [
-| "[" rpattern "]"      (* SSR plugin *)
-|      (* SSR plugin *)
-]
-
-ssrpattern_ne_squarep: [
-| "[" rpattern "]"      (* SSR plugin *)
-]
-
-ssrrwarg: [
-| "-" ssrmult ssrrwocc ssrpattern_squarep ssrrule_ne      (* SSR plugin *)
-| "-/" ssrterm      (* SSR plugin *)
-| ssrmult_ne ssrrwocc ssrpattern_squarep ssrrule_ne      (* SSR plugin *)
-| "{" LIST1 ssrhyp "}" ssrpattern_ne_squarep ssrrule_ne      (* SSR plugin *)
-| "{" LIST1 ssrhyp "}" ssrrule      (* SSR plugin *)
-| "{" ssrocc "}" ssrpattern_squarep ssrrule_ne      (* SSR plugin *)
-| "{" "}" ssrpattern_squarep ssrrule_ne      (* SSR plugin *)
-| ssrpattern_ne_squarep ssrrule_ne      (* SSR plugin *)
-| ssrrule_ne      (* SSR plugin *)
-]
-
-ssrrwargs: [
-| test_ssr_rw_syntax LIST1 ssrrwarg      (* SSR plugin *)
-]
-
-ssrunlockarg: [
-| "{" ssrocc "}" ssrterm      (* SSR plugin *)
-| ssrterm      (* SSR plugin *)
-]
-
-ssrunlockargs: [
-| LIST0 ssrunlockarg      (* SSR plugin *)
-]
-
-ssrsufffwd: [
-| ssrhpats LIST0 ssrbinder ":" ast_closure_lterm ssrhint      (* SSR plugin *)
-]
-
-ssrwlogfwd: [
-| ":" LIST0 ssrwgen "/" ast_closure_lterm      (* SSR plugin *)
-]
-
-ssr_idcomma: [
-|      (* SSR plugin *)
-| test_idcomma [ IDENT | "_" ] ","      (* SSR plugin *)
-]
-
-ssr_rtype: [
-| "return" term100      (* SSR plugin *)
-]
-
-ssr_mpat: [
-| pattern200      (* SSR plugin *)
-]
-
-ssr_dpat: [
-| ssr_mpat "in" pattern200 ssr_rtype      (* SSR plugin *)
-| ssr_mpat ssr_rtype      (* SSR plugin *)
-| ssr_mpat      (* SSR plugin *)
-]
-
-ssr_dthen: [
-| ssr_dpat "then" lconstr      (* SSR plugin *)
-]
-
-ssr_elsepat: [
-| "else"      (* SSR plugin *)
-]
-
-ssr_else: [
-| ssr_elsepat lconstr      (* SSR plugin *)
-]
-
-ssrhintref: [
-| constr      (* SSR plugin *)
-| constr "|" natural      (* SSR plugin *)
-]
-
-ssrviewpos: [
-| "for" "move" "/"      (* SSR plugin *)
-| "for" "apply" "/"      (* SSR plugin *)
-| "for" "apply" "/" "/"      (* SSR plugin *)
-| "for" "apply" "//"      (* SSR plugin *)
-|      (* SSR plugin *)
-]
-
-ssrviewposspc: [
-| ssrviewpos      (* SSR plugin *)
-]
-
-rpattern: [
-| lconstr      (* SSR plugin *)
-| "in" lconstr      (* SSR plugin *)
-| lconstr "in" lconstr      (* SSR plugin *)
-| "in" lconstr "in" lconstr      (* SSR plugin *)
-| lconstr "in" lconstr "in" lconstr      (* SSR plugin *)
-| lconstr "as" lconstr "in" lconstr      (* SSR plugin *)
-]
-
-G_SSRMATCHING_cpattern: [
-| "Qed" constr      (* SSR plugin *)
-| ssrtermkind constr      (* SSR plugin *)
-]
-
-lcpattern: [
-| "Qed" lconstr      (* SSR plugin *)
-| ssrtermkind lconstr      (* SSR plugin *)
-]
-
-ssrpatternarg: [
-| rpattern      (* SSR plugin *)
 ]
 
 number_string_mapping: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -175,131 +175,6 @@ subsequent_letter: [
 | [ first_letter | digit | "'" | unicode_id_part ]
 ]
 
-ssrarg: [
-| OPT ssrfwdview OPT ssreqpat ssrdgens OPT ssrintros
-| ssrfwdview OPT ssrclear OPT ssrintros      (* SSR plugin *)
-| ssrclear OPT ssrintros      (* SSR plugin *)
-| ssrintros      (* SSR plugin *)
-]
-
-ssreqpat: [
-| ident      (* SSR plugin *)
-| "_"      (* SSR plugin *)
-| "?"      (* SSR plugin *)
-| "+"      (* SSR plugin *)
-| ssrdocc "->"      (* SSR plugin *)
-| ssrdocc "<-"      (* SSR plugin *)
-| "->"      (* SSR plugin *)
-| "<-"      (* SSR plugin *)
-]
-
-ssrapplyarg: [
-| ssrclear OPT ssrintros      (* SSR plugin *)
-| ssrintros      (* SSR plugin *)
-| OPT ssrbwdview ":" ssragen OPT ssragens OPT ssrintros      (* SSR plugin *)
-| ssrbwdview OPT ssrclear OPT ssrintros      (* SSR plugin *)
-]
-
-ssragen: [
-| OPT ( "{" LIST1 ident "}" ) term      (* SSR plugin *)
-]
-
-ssragens: [
-| "{" LIST1 ident "}" term OPT ssragens      (* SSR plugin *)
-| "{" LIST1 ident "}"      (* SSR plugin *)
-| term OPT ssragens      (* SSR plugin *)
-]
-
-ssrintros: [
-| "=>" ssripats      (* SSR plugin *)
-]
-
-ssrbwdview: [
-| "/" term      (* SSR plugin *)
-| "/" term ssrbwdview      (* SSR plugin *)
-]
-
-ssrdgens: [
-| ":" ssrgen OPT ( "/" ssrgen )      (* SSR plugin *)
-]
-
-ssrgen: [
-| cpattern LIST0 [ LIST1 ident | cpattern ]      (* SSR plugin *)
-]
-
-rewrite_item: [
-| "-" OPT mult OPT occ_or_clear OPT ssrpattern_squarep r_item      (* SSR plugin *)
-| mult OPT occ_or_clear OPT ssrpattern_squarep r_item      (* SSR plugin *)
-| "-/" term      (* SSR plugin *)
-| OPT ( OPT ( "{" LIST1 ident "}" ) ssrpattern_squarep ) r_item      (* SSR plugin *)
-| "{" LIST1 ident "}" OPT r_item      (* SSR plugin *)
-| "{" OPT ssr_occurrences "}" OPT ssrpattern_squarep r_item      (* SSR plugin *)
-]
-
-occ_or_clear: [
-| clear_switch
-| "{" ssr_occurrences "}"      (* SSR plugin *)
-]
-
-clear_switch: [
-| "{" LIST0 ident "}"
-]
-
-ssr_occurrences: [
-| [ natural | "+" | "-" ] LIST0 natural      (* SSR plugin *)
-]
-
-r_item: [
-| [ OPT "/" term | s_item ]      (* SSR plugin *)
-]
-
-ssrpattern_squarep: [
-| "[" rewrite_pattern "]"      (* SSR plugin *)
-]
-
-rewrite_pattern: [
-| OPT ( OPT ( OPT ( OPT term "in" ) term ) "in" ) term      (* SSR plugin *)
-| term "as" term "in" term      (* SSR plugin *)
-]
-
-ssr_in: [
-| "in" ssrclausehyps OPT "|-" OPT "*"      (* SSR plugin *)
-| "in" [ "*" | "*" "|-" | "|-" "*" ]      (* SSR plugin *)
-]
-
-ssrclausehyps: [
-| gen_item LIST0 ( OPT "," gen_item )      (* SSR plugin *)
-]
-
-gen_item: [
-| ssrclear      (* SSR plugin *)
-| OPT "@" ident      (* SSR plugin *)
-| "(" ident OPT ( ":=" lcpattern ) ")"      (* SSR plugin *)
-| "(@" ident ":=" lcpattern ")"      (* SSR plugin *)
-]
-
-ssrclear: [
-| "{" LIST1 ident "}"      (* SSR plugin *)
-]
-
-lcpattern: [
-| term
-]
-
-ssrsufffwd: [
-| OPT ssripats LIST0 ssrbinder ":" term OPT ( "by" ssrhintarg )      (* SSR plugin *)
-]
-
-ssrviewpos: [
-| "for" "move" "/"      (* SSR plugin *)
-| "for" "apply" "/"      (* SSR plugin *)
-| "for" "apply" "//"      (* SSR plugin *)
-]
-
-ssr_one_term_pattern: [
-| one_term      (* SSR plugin *)
-]
-
 where: [
 | "at" "top"
 | "at" "bottom"
@@ -470,10 +345,6 @@ cofix_body: [
 
 term_if: [
 | "if" term OPT [ OPT [ "as" name ] "return" term100 ] "then" term "else" term
-]
-
-ssr_dpat: [
-| pattern OPT ( OPT ( "in" pattern ) "return" term100 )      (* SSR plugin *)
 ]
 
 term_let: [
@@ -1014,9 +885,6 @@ command: [
 | "Add" "Field" ident ":" one_term OPT ( "(" LIST1 field_mod SEP "," ")" )      (* ring plugin *)
 | "Print" "Fields"      (* ring plugin *)
 | "Hint" "Cut" "[" hints_regexp "]" OPT ( ":" LIST1 ident )
-| "Prenex" "Implicits" LIST1 qualid      (* SSR plugin *)
-| "Print" "Hint" "View" OPT ssrviewpos      (* SSR plugin *)
-| "Hint" "View" OPT ssrviewpos LIST1 ( one_term OPT ( "|" natural ) )      (* SSR plugin *)
 | "Typeclasses" "Transparent" LIST1 qualid
 | "Typeclasses" "Opaque" LIST1 qualid
 | "Typeclasses" "eauto" ":=" OPT "debug" OPT ( "(" [ "bfs" | "dfs" ] ")" ) OPT natural
@@ -1097,7 +965,6 @@ command: [
 | "Generalizable" [ [ "Variable" | "Variables" ] LIST1 ident | "All" "Variables" | "No" "Variables" ]
 | "Set" setting_name OPT [ integer | string ]
 | "Unset" setting_name
-| "Import" "Prenex" "Implicits"      (* SSR plugin *)
 | "Open" "Scope" scope
 | "Close" "Scope" scope
 | "Delimit" "Scope" scope_name "with" scope_key
@@ -1408,118 +1275,6 @@ field_mod: [
 | "completeness" one_term      (* ring plugin *)
 ]
 
-ssrmmod: [
-| "!"      (* SSR plugin *)
-| "?"      (* SSR plugin *)
-]
-
-mult: [
-| OPT natural ssrmmod      (* SSR plugin *)
-]
-
-ssrwlogfwd: [
-| ":" LIST0 gen_item "/" term      (* SSR plugin *)
-]
-
-ssrhintarg: [
-| "[" OPT ssrortacs "]"      (* SSR plugin *)
-| ltac_expr      (* SSR plugin *)
-]
-
-ssrortacs: [
-| OPT ltac_expr "|" OPT ssrortacs
-| ltac_expr      (* SSR plugin *)
-]
-
-ssrhint3arg: [
-| "[" OPT ssrortacs "]"      (* SSR plugin *)
-| ltac_expr3      (* SSR plugin *)
-]
-
-ssrdefbody: [
-| OPT ( ":" term ) ":=" term      (* SSR plugin *)
-]
-
-i_item: [
-| "_"      (* SSR plugin *)
-| "*"      (* SSR plugin *)
-| ">"      (* SSR plugin *)
-| ident
-| "?"      (* SSR plugin *)
-| "+"      (* SSR plugin *)
-| "++"      (* SSR plugin *)
-| s_item      (* SSR plugin *)
-| ssrdocc OPT [ "->" | "<-" ]      (* SSR plugin *)
-| "-"      (* SSR plugin *)
-| "-/="      (* SSR plugin *)
-| "-//"      (* SSR plugin *)
-| "-//="      (* SSR plugin *)
-| "-/" integer [ "/=" | "/" | "/" integer "=" ]      (* SSR plugin *)
-| ssrfwdview      (* SSR plugin *)
-| "[:" LIST0 ident "]"      (* SSR plugin *)
-| ssrblockpat      (* SSR plugin *)
-]
-
-ssrhpats_wtransp: [
-| OPT ssripats      (* SSR plugin *)
-| OPT ssripats "@" OPT ssripats      (* SSR plugin *)
-]
-
-ssripats: [
-| LIST1 i_item      (* SSR plugin *)
-]
-
-s_item: [
-| "//"      (* SSR plugin *)
-| "/="      (* SSR plugin *)
-| "//="      (* SSR plugin *)
-| "/" natural "/" natural "="      (* SSR plugin *)
-| "/" natural "/="      (* SSR plugin *)
-]
-
-ssrdocc: [
-| "{" ssr_occurrences "}"      (* SSR plugin *)
-| "{" LIST0 ident "}"      (* SSR plugin *)
-]
-
-ssrfwdview: [
-| LIST1 ( "/" one_term )      (* SSR plugin *)
-]
-
-hat: [
-| "^" ident      (* SSR plugin *)
-| "^~" ident      (* SSR plugin *)
-| "^~" natural      (* SSR plugin *)
-]
-
-ssriorpat: [
-| ssripats OPT ( [ "|" | "|-" ] ssriorpat )      (* SSR plugin *)
-]
-
-ssrblockpat: [
-| "[" hat "]"      (* SSR plugin *)
-| "[" ssriorpat "]"      (* SSR plugin *)
-| "[=" ssriorpat "]"
-]
-
-ssrbinder: [
-| ssrbvar      (* SSR plugin *)
-| "(" LIST1 ssrbvar ":" term ")"      (* SSR plugin *)
-| "(" ssrbvar OPT ( ":" term ) OPT ( ":=" term ) ")"      (* SSR plugin *)
-| "of" term10      (* SSR plugin *)
-| "&" term10      (* SSR plugin *)
-]
-
-ssrbvar: [
-| ident      (* SSR plugin *)
-| "_"      (* SSR plugin *)
-]
-
-ssrhavefwd: [
-| ":" term OPT ( "by" ssrhintarg )      (* SSR plugin *)
-| ":" term ":=" OPT term      (* SSR plugin *)
-]
-
 number_modifier: [
 | "warning" "after" bignat
 | "abstract" "after" bignat
@@ -1658,7 +1413,6 @@ simple_tactic: [
 | "solve" "[" LIST0 ltac_expr SEP "|" "]"
 | "idtac" LIST0 [ ident | string | natural ]
 | [ "fail" | "gfail" ] OPT nat_or_var LIST0 [ ident | string | natural ]
-| ltac_expr ssrintros      (* SSR plugin *)
 | "fun" LIST1 name "=>" ltac_expr
 | "eval" red_expr "in" term
 | "context" ident "[" term "]"
@@ -1666,7 +1420,6 @@ simple_tactic: [
 | "fresh" LIST0 [ string | qualid ]
 | "type_term" one_term
 | "numgoals"
-| "uconstr" ":" "(" term ")"
 | "fun" LIST1 name "=>" ltac_expr
 | "let" OPT "rec" let_clause LIST0 ( "with" let_clause ) "in" ltac_expr
 | ltac_expr3 ";" [ ltac_expr3 | binder_tactic ]
@@ -1748,8 +1501,6 @@ simple_tactic: [
 | "autounfold" OPT hintbases OPT simple_occurrences
 | "autounfold_one" OPT hintbases OPT ( "in" ident )
 | "unify" one_term one_term OPT ( "with" ident )
-| "typeclasses" "eauto" "best_effort" OPT nat_or_var "with" LIST1 ident
-| "typeclasses" "eauto" "best_effort" OPT nat_or_var
 | "head_of_constr" ident one_term
 | "not_evar" one_term
 | "is_ground" one_term
@@ -1870,37 +1621,6 @@ simple_tactic: [
 | "field_lookup" ltac_expr "[" LIST0 one_term "]" LIST1 one_term      (* ring plugin *)
 | "ring_lookup" ltac_expr0 "[" LIST0 one_term "]" LIST1 one_term      (* ring plugin *)
 | "field_lookup" ltac_expr "[" LIST0 one_term "]" LIST1 one_term      (* ring plugin *)
-| "by" ssrhintarg      (* SSR plugin *)
-| "clear" natural      (* SSR plugin *)
-| "move" OPT ( OPT ssrarg [ "->" | "<-" ] )      (* SSR plugin *)
-| "move" ssrarg OPT ssr_in      (* SSR plugin *)
-| "case" OPT ( ssrarg OPT ssr_in )      (* SSR plugin *)
-| "elim" OPT ( ssrarg OPT ssr_in )      (* SSR plugin *)
-| "apply" OPT ssrapplyarg      (* SSR plugin *)
-| "exact" [ ":" ssragen OPT ssragens | ssrbwdview OPT ssrclear | ssrclear ]      (* SSR plugin *)
-| "exact"      (* SSR plugin *)
-| "exact" "<:" term      (* SSR plugin *)
-| "congr" OPT natural one_term OPT ssrdgens      (* SSR plugin *)
-| "ssrinstancesofruleL2R" term      (* SSR plugin *)
-| "ssrinstancesofruleR2L" term      (* SSR plugin *)
-| "rewrite" LIST1 rewrite_item OPT ssr_in      (* SSR plugin *)
-| "unlock" LIST0 ( OPT ( "{" ssr_occurrences "}" ) term ) OPT ssr_in      (* SSR plugin *)
-| "pose" "fix" ssrbvar LIST0 ssrbinder OPT ( "{" "struct" ident "}" ) ssrdefbody      (* SSR plugin *)
-| "pose" "cofix" ssrbvar LIST0 ssrbinder ssrdefbody      (* SSR plugin *)
-| "pose" ident LIST0 ssrbinder ssrdefbody      (* SSR plugin *)
-| "set" ident OPT ( ":" term ) ":=" [ "{" ssr_occurrences "}" cpattern | lcpattern ] OPT ssr_in      (* SSR plugin *)
-| "abstract" ssrdgens      (* SSR plugin *)
-| "have" ssrhpats_wtransp LIST0 ssrbinder ssrhavefwd      (* SSR plugin *)
-| "have" [ "suff" | "suffices" ] OPT ssripats ssrhavefwd      (* SSR plugin *)
-| [ "suff" | "suffices" ] OPT ( "have" OPT ssripats ) ssrhavefwd      (* SSR plugin *)
-| [ "suff" | "suffices" ] ssrsufffwd      (* SSR plugin *)
-| [ "wlog" | "without loss" ] OPT [ "suff" | "suffices" ] OPT ssripats ssrwlogfwd OPT ( "by" ssrhintarg )      (* SSR plugin *)
-| [ "gen" | "generally" ] "have" OPT ssrclear OPT ( [ ident | "_" ] "," ) OPT ssripats ssrwlogfwd OPT ( "by" ssrhintarg )      (* SSR plugin *)
-| "under" rewrite_item OPT ssrintros OPT ( "do" ssrhint3arg )      (* SSR plugin *)
-| "ssrinstancesoftpat" ssr_one_term_pattern      (* SSR plugin *)
-| ltac_expr ";" "first" ssr_first_else      (* SSR plugin *)
-| ltac_expr ";" "first" ssrseqarg      (* SSR plugin *)
-| ltac_expr ";" "last" ssrseqarg      (* SSR plugin *)
 | match_key OPT "reverse" "goal" "with" OPT "|" LIST1 ( goal_pattern "=>" ltac_expr ) SEP "|" "end"
 | match_key ltac_expr "with" OPT "|" LIST1 ( match_pattern "=>" ltac_expr ) SEP "|" "end"
 | "dependent" "inversion" [ ident | natural ] OPT ( "as" or_and_intropattern ) OPT [ "with" one_term ]
@@ -1920,7 +1640,6 @@ simple_tactic: [
 | "nia"
 | "now_show" one_type
 | "nra"
-| "over"      (* SSR plugin *)
 | "rapply" one_term
 | "split_Rabs"
 | "split_Rmult"
@@ -2547,34 +2266,6 @@ tactic_atom: [
 | integer
 | qualid
 | "()"
-]
-
-ssrseqarg: [
-| ssrseqidx "[" ssrortacs "]" OPT ssrorelse      (* SSR plugin *)
-| OPT ssrseqidx ssrswap      (* SSR plugin *)
-| ltac_expr3      (* SSR plugin *)
-]
-
-ssrseqidx: [
-| ident      (* SSR plugin *)
-| natural      (* SSR plugin *)
-]
-
-ssrorelse: [
-| "||" ltac_expr2      (* SSR plugin *)
-]
-
-ssrswap: [
-| "first"      (* SSR plugin *)
-| "last"      (* SSR plugin *)
-]
-
-ssr_first_else: [
-| ssr_first OPT ssrorelse      (* SSR plugin *)
-]
-
-ssr_first: [
-| "[" LIST0 ltac_expr SEP "|" "]" LIST0 ssrintros      (* SSR plugin *)
 ]
 
 let_clause: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1371,7 +1371,9 @@ simple_tactic: [
 | "only" selector ":" ltac_expr3
 | "tryif" ltac_expr "then" ltac_expr "else" ltac_expr2
 | "first" "[" LIST0 ltac_expr SEP "|" "]"
+| "first" ident
 | "solve" "[" LIST0 ltac_expr SEP "|" "]"
+| "solve" ident
 | "idtac" LIST0 [ ident | string | natural ]
 | [ "fail" | "gfail" ] OPT nat_or_var LIST0 [ ident | string | natural ]
 | "fun" LIST1 name "=>" ltac_expr

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -132,15 +132,15 @@ number: [
 ]
 
 integer: [
-| OPT "-" natural
-]
-
-natural: [
-| bignat
+| bigint
 ]
 
 bigint: [
 | OPT "-" bignat
+]
+
+natural: [
+| bignat
 ]
 
 bignat: [
@@ -198,7 +198,11 @@ REACHABLE: [
 ]
 
 NOTINRSTS: [
+| command
+| control_command
+| query_command
 | simple_tactic
+| hints_regexp
 | REACHABLE
 | NOTINRSTS
 | l1_tactic
@@ -384,21 +388,6 @@ binder: [
 | "'" pattern0
 ]
 
-one_open_binder: [
-| name
-| name ":" term
-| one_closed_binder
-]
-
-one_closed_binder: [
-| "(" name ":" term ")"
-| "{" name "}"
-| "{" name ":" term "}"
-| "[" name "]"
-| "[" name ":" term "]"
-| "'" pattern0
-]
-
 implicit_binders: [
 | "{" LIST1 name OPT ( ":" type ) "}"
 | "[" LIST1 name OPT ( ":" type ) "]"
@@ -463,16 +452,6 @@ pattern0: [
 | "(" LIST1 pattern SEP "|" ")"
 | number
 | string
-]
-
-vernac_aux: [
-| command "."
-| tactic_mode "."
-| subprf
-]
-
-subprf: [
-| "{"
 ]
 
 fix_definition: [
@@ -565,15 +544,6 @@ term_record: [
 
 field_val: [
 | qualid LIST0 binder ":=" term
-]
-
-inductive_or_record_definition: [
-| OPT ">" ident OPT cumul_univ_decl LIST0 binder OPT [ "|" LIST0 binder ] OPT [ ":" term ] OPT ( ":=" OPT constructors_or_record ) OPT decl_notations
-]
-
-constructors_or_record: [
-| OPT "|" LIST1 constructor SEP "|"
-| OPT ident "{" LIST0 record_field SEP ";" OPT ";" "}" OPT ( "as" ident )
 ]
 
 inductive_definition: [
@@ -988,7 +958,7 @@ command: [
 | "Ltac2" "@" "external" ident ":" ltac2_type ":=" string string
 | "Ltac2" "Notation" LIST1 ltac2_scope OPT ( ":" natural ) ":=" ltac2_expr      (* ltac2 plugin *)
 | "Ltac2" "Set" qualid OPT [ "as" ident ] ":=" ltac2_expr
-| "Ltac2" "Notation" [ string | lident ] ":=" ltac2_expr      (* Ltac2 plugin *)
+| "Ltac2" "Notation" [ string | ident      (* ltac2 plugin *) ] ":=" ltac2_expr      (* Ltac2 plugin *)
 | "Ltac2" "Eval" ltac2_expr      (* ltac2 plugin *)
 | "Print" "Ltac2" qualid      (* ltac2 plugin *)
 | "Locate" "Ltac2" qualid      (* ltac2 plugin *)
@@ -1084,11 +1054,6 @@ ltac_production_item: [
 | ident OPT ( "(" ident OPT ( "," string ) ")" )
 ]
 
-tac2expr_in_env: [
-| LIST0 ident "|-" ltac2_expr      (* ltac2 plugin *)
-| ltac2_expr      (* ltac2 plugin *)
-]
-
 ltac2_type: [
 | ltac2_type2 "->" ltac2_type      (* ltac2 plugin *)
 | ltac2_type2      (* ltac2 plugin *)
@@ -1113,10 +1078,6 @@ ltac2_type0: [
 
 ltac2_typevar: [
 | "'" ident      (* ltac2 plugin *)
-]
-
-lident: [
-| ident      (* ltac2 plugin *)
 ]
 
 occurrences: [
@@ -1183,8 +1144,8 @@ ltac2_simple_intropattern: [
 ]
 
 ltac2_naming_intropattern: [
-| "?" lident      (* ltac2 plugin *)
-| "?$" lident      (* ltac2 plugin *)
+| "?" ident      (* ltac2 plugin *)
+| "?$" ident      (* ltac2 plugin *)
 | "?"      (* ltac2 plugin *)
 | ident_or_anti      (* ltac2 plugin *)
 ]
@@ -1207,7 +1168,7 @@ q_ident: [
 ]
 
 ident_or_anti: [
-| lident      (* ltac2 plugin *)
+| ident      (* ltac2 plugin *)
 | "$" ident      (* ltac2 plugin *)
 ]
 
@@ -1217,7 +1178,7 @@ q_destruction_arg: [
 
 ltac2_destruction_arg: [
 | natural      (* ltac2 plugin *)
-| lident      (* ltac2 plugin *)
+| ident      (* ltac2 plugin *)
 | ltac2_constr_with_bindings      (* ltac2 plugin *)
 ]
 
@@ -1245,7 +1206,7 @@ ltac2_simple_binding: [
 qhyp: [
 | "$" ident      (* ltac2 plugin *)
 | natural      (* ltac2 plugin *)
-| lident      (* ltac2 plugin *)
+| ident      (* ltac2 plugin *)
 ]
 
 language: [
@@ -1396,7 +1357,7 @@ simple_tactic: [
 | "typeclasses" "eauto" OPT [ "bfs" | "dfs" | "best_effort" ] OPT nat_or_var OPT ( "with" LIST1 ident )
 | "setoid_replace" one_term "with" one_term OPT ( "using" "relation" one_term ) OPT ( "in" ident ) OPT ( "at" LIST1 int_or_var ) OPT ( "by" ltac_expr3 )
 | OPT ( [ natural | "[" ident "]" ] ":" ) "{"
-| bullet
+| [ LIST1 "-" | LIST1 "+" | LIST1 "*" ]
 | "}"
 | "try" ltac_expr3
 | "do" nat_or_var ltac_expr3
@@ -1697,10 +1658,6 @@ induction_arg: [
 
 induction_principle: [
 | "using" one_term_with_bindings OPT occurrences
-]
-
-bullet: [
-| [ LIST1 "-" | LIST1 "+" | LIST1 "*" ]
 ]
 
 auto_using: [
@@ -2101,13 +2058,13 @@ ltac2_tactic_atom: [
 | string      (* ltac2 plugin *)
 | qualid      (* ltac2 plugin *)
 | "@" ident      (* ltac2 plugin *)
-| "&" lident      (* ltac2 plugin *)
+| "&" ident      (* ltac2 plugin *)
 | "'" term      (* ltac2 plugin *)
 | ltac2_quotations
 ]
 
 ltac2_quotations: [
-| "ident" ":" "(" lident ")"
+| "ident" ":" "(" ident ")"
 | "constr" ":" "(" term ")"
 | "open_constr" ":" "(" term ")"
 | "preterm" ":" "(" term ")"
@@ -2131,7 +2088,7 @@ tac2pat1: [
 | qualid      (* ltac2 plugin *)
 | tac2pat0 "::" tac2pat0      (* ltac2 plugin *)
 | tac2pat0 "|" LIST1 tac2pat1 SEP "|"      (* ltac2 plugin *)
-| tac2pat0 "as" lident      (* ltac2 plugin *)
+| tac2pat0 "as" ident      (* ltac2 plugin *)
 | tac2pat0      (* ltac2 plugin *)
 ]
 
@@ -2150,17 +2107,6 @@ atomic_tac2pat: [
 | tac2pat1 ":" ltac2_type      (* ltac2 plugin *)
 | tac2pat1 "," LIST0 tac2pat1 SEP ","      (* ltac2 plugin *)
 | tac2pat1      (* ltac2 plugin *)
-]
-
-tac2mode: [
-| OPT ( toplevel_selector ":" ) ltac2_expr [ "." | "..." ]      (* ltac2 plugin *)
-| "Eval" red_expr "in" term
-| "Compute" term
-| "Check" term
-| "About" reference OPT univ_name_list
-| "SearchPattern" one_pattern OPT ( [ "inside" | "in" | "outside" ] LIST1 qualid )
-| "SearchRewrite" one_pattern OPT ( [ "inside" | "in" | "outside" ] LIST1 qualid )
-| "Search" LIST1 ( search_query ) OPT ( [ "inside" | "in" | "outside" ] LIST1 qualid )
 ]
 
 func_scheme_def: [


### PR DESCRIPTION
Disables any processing of the SSR mlgs and rst file by doc_grammar (hard coded).
Adds error messages for commands and tactics that are in the grammar but not the doc and vice versa.

Now `make doc_gram_rsts` gives only 3 warnings.  Please advise where `dangling_pattern_extension_rule` should be added into the doc and what to say about it.  I think the other one should stay.

```
Warning: plugins/ltac2/g_ltac2.mlg: Duplicate production 'lident: Prim.ident      (* ltac2 plugin *)'
Warning: editedGrammar: Unreachable symbol 'dangling_pattern_extension_rule'
Warning: Nonterminal dangling_pattern_extension_rule not included in .rst files
```

See also #16652