### PR TITLE
Drop ltac2 environment when internalizing preterm:() quotations

### DIFF
--- a/doc/changelog/06-Ltac2-language/17234-preterm-no-tac2env.rst
+++ b/doc/changelog/06-Ltac2-language/17234-preterm-no-tac2env.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  `preterm` quotations are internalized without access to the Ltac2 environment, which matches the runtime behaviour and provides correct errors when referring to Ltac2 values instead of producing anomalies
+  (`#17234 <https://github.com/coq/coq/pull/17234>`_,
+  fixes `#17233 <https://github.com/coq/coq/issues/17233>`_,
+  by Gaëtan Gilbert).

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -1431,6 +1431,8 @@ let () =
 
 let () =
   let intern self ist c =
+    let extra = Tac2intern.drop_ltac2_env ist.Genintern.extra in
+    let ist = { ist with extra } in
     let (_, (c, _)) = Genintern.intern Stdarg.wit_constr ist c in
     (GlbVal c, gtypref t_preterm)
   in

--- a/test-suite/bugs/bug_17233.v
+++ b/test-suite/bugs/bug_17233.v
@@ -1,0 +1,11 @@
+Require Import Ltac2.Ltac2.
+
+Fail Ltac2 Eval
+  let x := constr:(0) in
+  Constr.pretype preterm:($x).
+(* uncaught Not_found *)
+
+Fail Ltac2 Eval
+  let x := constr:(0) in
+  Constr.pretype preterm:(ltac2:(let y () := x in exact0 false y)).
+(* anomaly unbound variable x *)


### PR DESCRIPTION
Fix #17233

Eventually I think we will want to have syntax to close over a subset of the env but for now we can do this simple fix.