### PR TITLE
Remove ASSUM-DEF rule from the module document.

### DIFF
--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -712,13 +712,6 @@ Structure element subtyping rules:
    --------------------------
    \WS{E}{(c:=t:T_1)}{(c:T_2)}
 
-.. inference:: ASSUM-DEF
-
-   E[] ⊢ T_1 ≤_{βδιζη} T_2
-   E[] ⊢ c =_{βδιζη} t_2
-   --------------------------
-   \WS{E}{(c:T_1)}{(c:=t_2:T_2)}
-
 .. inference:: DEF-DEF
 
    E[] ⊢ T_1 ≤_{βδιζη} T_2


### PR DESCRIPTION
This PR removes the ASSUM-DEF inference rule from modules.rst.

I think ASSUM-DEF cannot be used.

ASSUM-DEF is a subtyping rule for a structure element that the element in the subtype is an assumption (c:T1) and the element in the supertype is a definition (c:=t2:T2).

An example of this situation as follows.
SIG is supertype.
M is subtype.

```
Module Type SIG.
Definition n := 0.
End SIG.

Module F (X : SIG).
End F.

Module M.
Parameter n : nat.
End M.

Fail Module M2 := F M.
(* Signature components for field n do not match: the body of definitions differs. *)
```

The premise of ASSUM-DEF requires that c and t2 are convertible. But they cannot be convertible.

The global context, E, contains the structure elements of the subtype because of MSUB-STR.
(This is bit curious but understandable: the definitions are convertible between subtype and supertype because of DEF-DEF.)
It means that c in E is an assumption, (c:T1).
Thus, c is a normal form.  (delta-reduction is not possible.)

t2 cannot refer c because t2 is the definition of c in the supertype.
Coq prohibits recursion via a global constant.
(A recursion in Coq must use a fixpoint.)
Thus, the normal form of t2 cannot be c.

Therefore c and t2 never be convertible and ASSUM-DEF is not applicable.