### PR TITLE
Minor fixes of relevance around evar-generating code

### DIFF
--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -444,7 +444,8 @@ let new_evar ?src ?filter ?relevance ?abstract_arguments ?candidates ?(naming = 
 
 let new_type_evar ?src ?filter ?naming ?principal ?hypnaming env evd rigid =
   let (evd', s) = new_sort_variable rigid evd in
-  let (evd', e) = new_evar env evd' ?src ?filter ?naming ~typeclass_candidate:false ?principal ?hypnaming (EConstr.mkSort s) in
+  let relevance = Sorts.relevance_of_sort (EConstr.ESorts.kind evd s) in
+  let (evd', e) = new_evar env evd' ?src ?filter ~relevance ?naming ~typeclass_candidate:false ?principal ?hypnaming (EConstr.mkSort s) in
   evd', (e, s)
 
 let new_Type ?(rigid=Evd.univ_flexible) evd =

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -420,7 +420,7 @@ let next_evar_name sigma naming = match naming with
 
 (* [new_evar] declares a new existential in an env env with type typ *)
 (* Converting the env into the sign of the evar to define *)
-let new_evar ?src ?filter ?abstract_arguments ?candidates ?(naming = IntroAnonymous) ?typeclass_candidate
+let new_evar ?src ?filter ?relevance ?abstract_arguments ?candidates ?(naming = IntroAnonymous) ?typeclass_candidate
     ?principal ?hypnaming env evd typ =
   let name = next_evar_name evd naming in
   let hypnaming = match hypnaming with
@@ -434,7 +434,10 @@ let new_evar ?src ?filter ?abstract_arguments ?candidates ?(naming = IntroAnonym
     match filter with
     | None -> instance
     | Some filter -> Filter.filter_slist filter instance in
-  let relevance = Sorts.Relevant in (* FIXME: relevant_of_type not defined yet *)
+  let relevance = match relevance with
+  | Some r -> r
+  | None -> Sorts.Relevant (* FIXME: relevant_of_type not defined yet *)
+  in
   let (evd, evk) = new_pure_evar sign evd typ' ?src ?filter ~relevance ?abstract_arguments ?candidates ?name
     ?typeclass_candidate ?principal in
   (evd, EConstr.mkEvar (evk, instance))

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -41,6 +41,7 @@ type naming_mode =
 
 val new_evar :
   ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
+  ?relevance:Sorts.relevance ->
   ?abstract_arguments:Abstraction.t -> ?candidates:constr list ->
   ?naming:intro_pattern_naming_expr ->
   ?typeclass_candidate:bool ->

--- a/pretyping/evardefine.ml
+++ b/pretyping/evardefine.ml
@@ -83,7 +83,7 @@ let define_pure_evar_as_product env evd evk =
   let evd1,(dom,u1) =
     new_type_evar evenv evd univ_flexible_alg ~src ~filter:(evar_filter evi)
   in
-  let rdom = Sorts.Relevant in (* TODO relevance *)
+  let rdom = Sorts.relevance_of_sort (ESorts.kind evd1 u1) in
   let evd2,rng =
     let newenv = push_named (LocalAssum (make_annot id rdom, dom)) evenv in
     let src = subterm_source evk ~where:Codomain evksrc in


### PR DESCRIPTION
A small step on the long road towards full-SProp compliance.

Overlays:
- https://github.com/damien-pous/relation-algebra/pull/37 (backwards compatible)