### PR TITLE
Drop the abstract argument field from defined evars.

### DIFF
--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -221,7 +221,7 @@ type 'a evar_info = {
   evar_hyps : named_context_val;
   evar_body : 'a evar_body;
   evar_filter : Filter.t;
-  evar_abstract_arguments : Abstraction.t;
+  evar_abstract_arguments : ('a, Abstraction.t) when_undefined;
   evar_source : Evar_kinds.t Loc.located;
   evar_candidates : ('a, constr list option) when_undefined; (* if not None, list of allowed instances *)
   evar_relevance: Sorts.relevance;
@@ -247,7 +247,8 @@ let evar_filtered_context evi =
 let evar_candidates evi = match evi.evar_candidates with
 | Undefined c -> c
 
-let evar_abstract_arguments evi = evi.evar_abstract_arguments
+let evar_abstract_arguments evi = match evi.evar_abstract_arguments with
+| Undefined c -> c
 
 let evar_relevance evi = evi.evar_relevance
 
@@ -834,6 +835,7 @@ let undefine sigma e concl =
     evar_body = Evar_empty;
     evar_concl = Undefined concl;
     evar_candidates = Undefined None;
+    evar_abstract_arguments = Undefined Abstraction.identity;
   } in
   add (remove sigma e) e evi
 
@@ -1328,7 +1330,7 @@ let new_pure_evar ?(src=default_source) ?(filter = Filter.identity) ?(relevance 
     evar_concl = Undefined typ;
     evar_body = Evar_empty;
     evar_filter = filter;
-    evar_abstract_arguments = abstract_arguments;
+    evar_abstract_arguments = Undefined abstract_arguments;
     evar_source = src;
     evar_candidates = Undefined candidates;
     evar_relevance = relevance;
@@ -1357,6 +1359,7 @@ let define_aux def undef evk body =
     evar_body = Evar_defined body;
     evar_concl = Defined;
     evar_candidates = Defined;
+    evar_abstract_arguments = Defined;
   } in
   EvMap.add evk newinfo def, EvMap.remove evk undef
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -130,7 +130,7 @@ val evar_filter : 'a evar_info -> Filter.t
     When filtered out, the corresponding variable is not allowed to occur
     in the solution *)
 
-val evar_abstract_arguments : 'a evar_info -> Abstraction.t
+val evar_abstract_arguments : undefined evar_info -> Abstraction.t
 (** Boolean information over {!evar_hyps}, telling if an hypothesis instance
     can be imitated or should stay abstract in HO unification problems
     and inversion (see [second_order_matching_with_args] for its use). *)


### PR DESCRIPTION
Yet another step to reduce whatever we put in defined evar infos.