### PR TITLE
Tagged runner system

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,14 @@ include:
     rules:
       - if: $CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH !~ /^v.*\..*$/
 
+  - local: "/dev/ci/gitlab-modes/tagged-runners.yml"
+    rules:
+      - if: $TAGGED_RUNNERS
+
+  - local: "/dev/ci/gitlab-modes/untagged-runners.yml"
+    rules:
+      - if: $TAGGED_RUNNERS == null
+
   - local: '/dev/bench/gitlab-bench.yml'
 
 stages:
@@ -56,6 +64,7 @@ before_script:
 .build-template:
   stage: build
   interruptible: true
+  extends: .auto-use-tags
   variables:
     COQIDE: "opt"
   artifacts:
@@ -93,6 +102,7 @@ before_script:
 .build-template:dev:
   stage: build
   interruptible: true
+  extends: .auto-use-tags
   script:
     # flambda can be pretty stack hungry, specially with -O3
     # See also https://github.com/ocaml/ocaml/issues/7842#issuecomment-596863244
@@ -118,6 +128,7 @@ before_script:
 .dev-ci-template:
   stage: build
   interruptible: true
+  extends: .auto-use-tags
   needs:
     - build:edge+flambda:dev
   script:
@@ -140,6 +151,7 @@ before_script:
 .test-suite-template:
   stage: build
   interruptible: true
+  extends: .auto-use-tags
   needs:
     - not-a-real-job
   script:
@@ -162,6 +174,7 @@ before_script:
 .validate-template:
   stage: build
   interruptible: true
+  extends: .auto-use-tags
   needs:
     - not-a-real-job
   script:
@@ -184,6 +197,7 @@ before_script:
 .ci-template:
   stage: build
   interruptible: true
+  extends: .auto-use-tags
   script:
     - ulimit -S -s 16384           # For flambda + native
     - make -f Makefile.ci -j "$NJOBS" "${CI_JOB_NAME#*:}"
@@ -208,6 +222,7 @@ before_script:
 
 .deploy-template:
   stage: deploy
+  extends: .auto-use-tags
   before_script:
     - which ssh-agent || ( apt-get update -y && apt-get install openssh-client -y )
     - eval $(ssh-agent -s)
@@ -220,6 +235,7 @@ before_script:
 .pkg:opam-template:
   stage: build
   interruptible: true
+  extends: .auto-use-tags
   # OPAM will build out-of-tree so no point in importing artifacts
   script:
     - opam pin add --kind=path coq-core.dev .
@@ -236,6 +252,7 @@ before_script:
   needs: []
   interruptible: true
   image: nixos/nix:latest
+  extends: .auto-use-tags
   variables:
     GIT_STRATEGY: none # Required because we don't have git
     USER: root # Variable required by Cachix
@@ -346,6 +363,7 @@ build:vio:
 lint:
   stage: build
   script: dev/lint-repository.sh
+  extends: .auto-use-tags
   variables:
     GIT_DEPTH: "" # we need an unknown amount of history for per-commit linting
     OPAM_SWITCH: "edge"
@@ -494,6 +512,7 @@ test-suite:edge+flambda:
 test-suite:edge:dev:
   stage: build
   interruptible: true
+  extends: .auto-use-tags
   needs:
     - build:edge+flambda:dev
   script:
@@ -873,6 +892,7 @@ plugin:ci-perennial:
 plugin:plugin-tutorial:
   stage: build
   interruptible: true
+  extends: .auto-use-tags
   script:
     - ./configure -prefix "$(pwd)/_install_ci" -warn-error yes
     - make -j "$NJOBS" plugin-tutorial

--- a/dev/ci/gitlab-modes/normal-mode.yml
+++ b/dev/ci/gitlab-modes/normal-mode.yml
@@ -2,3 +2,5 @@
 default:
   interruptible: true
   timeout: 1h
+  tags:
+    - not-a-real-tag

--- a/dev/ci/gitlab-modes/protected-mode.yml
+++ b/dev/ci/gitlab-modes/protected-mode.yml
@@ -2,3 +2,5 @@
 default:
   interruptible: false
   timeout: 1h
+  tags:
+    - not-a-real-tag

--- a/dev/ci/gitlab-modes/tagged-runners.yml
+++ b/dev/ci/gitlab-modes/tagged-runners.yml
@@ -1,0 +1,3 @@
+.auto-use-tags:
+  tags:
+    - $TAGGED_RUNNERS

--- a/dev/ci/gitlab-modes/untagged-runners.yml
+++ b/dev/ci/gitlab-modes/untagged-runners.yml
@@ -1,0 +1,2 @@
+.auto-use-tags:
+  tags: []


### PR DESCRIPTION
This allows us to set the variable TAGGED_RUNNERS to run most jobs on runners with some tags (exceptions: the bench, the docker job).

Then we can enable shared runners permanently for the docker job without them being enabled for other jobs.
