### PR TITLE
During substitution, do not discard canonical part of inlinable constants

### DIFF
--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -306,16 +306,10 @@ let subst_con0 subst cst =
   let mpu,mpc,resolve,user = subst_dual_mp subst mpu mpc in
   let knu = KerName.make mpu l in
   let knc = if mpu == mpc then knu else KerName.make mpc l in
-  match search_delta_inline resolve knu knc with
-    | Some t ->
-      (* In case of inlining, discard the canonical part (cf #2608) *)
-      Constant.make1 knu, Some t
-    | None ->
-      let knc' =
-        progress (kn_of_delta resolve) (if user then knu else knc) ~orelse:knc
-      in
-      let cst' = Constant.make knu knc' in
-      cst', None
+  let knc' =
+    progress (kn_of_delta resolve) (if user then knu else knc) ~orelse:knc in
+  let cst' = Constant.make knu knc' in
+  cst', search_delta_inline resolve knu knc
 
 let subst_con subst cst =
   try subst_con0 subst cst

--- a/test-suite/bugs/bug_17261.v
+++ b/test-suite/bugs/bug_17261.v
@@ -1,0 +1,27 @@
+Module M.
+  Definition t := nat.
+End M.
+
+Module Type T.
+  Parameter t : Type.
+End T.
+Module Type TInline.
+  Parameter Inline t : Type.
+End TInline.
+
+Module Make (X:T).
+  Include X.
+  Ltac x := unfold t.
+End Make.
+Module MakeInline (X:TInline).
+  Include X.
+  Ltac x := unfold t.
+End MakeInline.
+
+Module P := Make M.
+Module PInline := MakeInline M.
+
+Goal M.t = M.t.
+Succeed progress P.x.
+Succeed progress PInline.x.
+Abort.


### PR DESCRIPTION
Fixes #17261

This attempts to revert an old fix for #2608, which does not appear to be correct:
https://github.com/coq/coq/commit/63710768d32c5929aa6498aff5aae2f9e0058e9 The problem that occurs in #2608 no longer seems to exist because the code has been substantially rewritten, as can be seen from the succeeding test case in that commit.

I'm not entirely sure that what I'm doing here is correct. Somebody knowledgeable about the module system should take a closer look.

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.