### PR TITLE
CList.find_map: return option instead of raising Not_found

### DIFF
--- a/clib/cList.ml
+++ b/clib/cList.ml
@@ -553,11 +553,16 @@ let insert p v l =
   insrec l
 
 let rec find_map f = function
-  | [] -> raise Not_found
+  | [] -> None
   | x :: l ->
     match f x with
     | None -> find_map f l
-    | Some y -> y
+    | Some _ as y -> y
+
+let find_map_exn f l =
+  match find_map f l with
+  | Some v -> v
+  | None -> raise Not_found
 
 (* FIXME: again, generic hash function *)
 

--- a/clib/cList.mli
+++ b/clib/cList.mli
@@ -215,9 +215,16 @@ val extract_first : ('a -> bool) -> 'a list -> 'a list * 'a
 (** Remove and return the first element satisfying a predicate,
     or raise [Not_found] *)
 
-val find_map : ('a -> 'b option) -> 'a list -> 'b
-(** Returns the first element that is mapped to [Some _]. Raise [Not_found] if
-    there is none. *)
+val find_map : ('a -> 'b option) -> 'a list -> 'b option
+(** [find_map f l] applies [f] to the elements of [l] in order,
+    and returns the first result of the form [Some v], or [None]
+    if none exist.
+
+    In stdlib since OCaml 4.10.0
+*)
+
+val find_map_exn : ('a -> 'b option) -> 'a list -> 'b
+(** Like [find_map] but raises [Not_found] instead of returning [None]. *)
 
 exception IndexOutOfRange
 val goto: int -> 'a list -> 'a list * 'a list

--- a/dev/ci/user-overlays/17265-SkySkimmer-find-map.sh
+++ b/dev/ci/user-overlays/17265-SkySkimmer-find-map.sh
@@ -1,0 +1,3 @@
+overlay elpi https://github.com/SkySkimmer/coq-elpi find-map 17265
+
+overlay equations https://github.com/SkySkimmer/Coq-Equations find-map 17265

--- a/ide/coqide/document.ml
+++ b/ide/coqide/document.ml
@@ -120,9 +120,9 @@ let find d f =
 
 let find_map d f =
   let a, s, b = to_lists d in
-  try CList.find_map (flat f false) a with Not_found ->
-  try CList.find_map (flat f true)  s with Not_found ->
-      CList.find_map (flat f false) b
+  try CList.find_map_exn (flat f false) a with Not_found ->
+  try CList.find_map_exn (flat f true)  s with Not_found ->
+      CList.find_map_exn (flat f false) b
 
 let is_empty = function
   | { stack = []; context = None } -> true
@@ -165,9 +165,9 @@ let find_id d f =
   let pred = function
     | { state_id = Some id; data } when f id data -> Some id
     | _ -> None in
-  try CList.find_map pred top, true with Not_found ->
-  try CList.find_map pred focus, false with Not_found ->
-      CList.find_map pred bot, true
+  try CList.find_map_exn pred top, true with Not_found ->
+  try CList.find_map_exn pred focus, false with Not_found ->
+      CList.find_map_exn pred bot, true
 
 let before_tip d =
   let _, focused, rest = to_lists d in

--- a/interp/modintern.ml
+++ b/interp/modintern.ml
@@ -85,7 +85,7 @@ let lookup_polymorphism env base kind fqid =
         | true, SFBmind mind -> Some (Declareops.inductive_is_polymorphic mind)
         | true, SFBconst const -> Some (Declareops.constant_is_polymorphic const)
       in
-      (try CList.find_map test m with Not_found -> false (* error later *))
+      (match CList.find_map test m with Some v -> v | None -> false (* error later *))
     | id::rem ->
       let next = function
         | MoreFunctor _ -> false (* error later *)
@@ -98,7 +98,7 @@ let lookup_polymorphism env base kind fqid =
         | true, SFBmodtype body ->  (* XXX is this valid? If not error later *)
           Some (next body.mod_type)
       in
-      (try CList.find_map test m with Not_found -> false (* error later *))
+      (match CList.find_map test m with Some v -> v | None -> false (* error later *))
   in
   aux (defunctor m) fqid
 

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1700,7 +1700,7 @@ let availability_of_prim_token n printer_scope local_scopes =
 
 let rec find_uninterpretation need_delim def find = function
   | [] ->
-      List.find_map
+      CList.find_map_exn
         (fun (sc,_,_) -> try Some (find need_delim sc) with Not_found -> None)
         def
   | OpenScopeItem scope :: scopes ->

--- a/plugins/ltac2/tac2quote.ml
+++ b/plugins/ltac2/tac2quote.ml
@@ -260,7 +260,7 @@ let abstract_vars loc ?typ vars tac =
   | Name id -> Some (CAst.make ?loc:na.CAst.loc id)
   | Anonymous -> None
   in
-  let def = try Some (List.find_map get_name vars) with Not_found -> None in
+  let def = List.find_map get_name vars in
   let na, tac = match def with
   | None -> (Anonymous, tac)
   | Some id0 ->

--- a/plugins/ssr/ssrelim.ml
+++ b/plugins/ssr/ssrelim.ml
@@ -162,7 +162,7 @@ let unif_redex env sigma0 nsigma p t = (* t is a hint for the redex of p *)
     with e when CErrors.noncritical e -> p
 
 let get_nth_arg n args =
-  List.find_map (fun (i, x, _) -> if Int.equal i n then Some x else None) args
+  List.find_map_exn (fun (i, x, _) -> if Int.equal i n then Some x else None) args
 
 let find_eliminator env sigma ~concl ~is_case ?elim oc c_gen =
   match elim with

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -158,7 +158,7 @@ let newssrcongrtac arg ist =
   Proofview.Unsafe.tclEVARS sigma <*>
   tclMATCH_GOAL env sigma' equality
   (fun sigma' ->
-    let x = List.find_map (fun (n, x, _) -> if n = 0 then Some x else None) eq_args in
+    let x = List.find_map_exn (fun (n, x, _) -> if n = 0 then Some x else None) eq_args in
     let ty = fs sigma' x in
     congrtac (arg, Detyping.detype Detyping.Now Id.Set.empty env sigma ty) ist)
   (fun () ->

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -372,7 +372,7 @@ let adjust_meta_source evd mv = function
           | None -> None)
         | _ -> None
       else None in
-    let id = try List.find_map f (Evd.Metamap.bindings (Evd.meta_list evd)) with Not_found -> id in
+    let id = Option.default id (List.find_map f (Evd.Metamap.bindings (Evd.meta_list evd))) in
     loc,Evar_kinds.VarInstance id
   | src -> src
 

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -634,8 +634,7 @@ struct
   let matches_modes sigma args modes =
     if List.is_empty modes then Some NoMode
     else
-      try Some (WithMode (List.find_map (matches_mode sigma args) modes))
-      with Not_found -> None
+      Option.map (fun x -> WithMode x) (List.find_map (matches_mode sigma args) modes)
 
   let merge_entry secvars db nopat pat =
     let h = List.sort pri_order_int db.hintdb_nopat in

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1996,8 +1996,9 @@ let progress_with_clause env flags (id, t) clause mvs =
     in
     find innerclause
   in
-  try List.find_map f mvs
-  with Not_found -> raise UnableToApply
+  match List.find_map f mvs with
+  | Some v -> v
+  | None -> raise UnableToApply
 
 let apply_in_once_main flags (id, t) env sigma (loc,d,lbind) =
   let thm = nf_betaiota env sigma (Retyping.get_type_of env sigma d) in

--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -255,7 +255,7 @@ let interp_context env sigma l =
           Some (if max then MaxImplicit else NonMaxImplicit)
         | _ -> None
         in
-        try CList.find_map search impls with Not_found -> Explicit
+        Option.default Explicit (CList.find_map search impls)
       in
       name,b,t,impl)
       ctx


### PR DESCRIPTION
This matches what `Stdlib.List.find_map` (needs OCaml >= 4.10) does.

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/434
- https://github.com/mattam82/Coq-Equations/pull/539