### PR TITLE
CI: split test suite runs to separate jobs for elpi and equations

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -843,6 +843,12 @@ plugin:ci-hb_test:
 plugin:ci-equations:
   extends: .ci-template
 
+plugin:ci-equations_test:
+  extends: .ci-template
+  needs:
+  - build:base
+  - plugin:ci-equations
+
 plugin:ci-fiat_parsers:
   extends: .ci-template
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -753,7 +753,7 @@ library:ci-analysis:
   - library:ci-mathcomp
   - library:ci-finmap
   - library:ci-bigenough
-  - plugin:ci-elpi  # for Hierarchy Builder
+  - plugin:ci-elpi_hb  # for Hierarchy Builder
 
 library:ci-paco:
   extends: .ci-template
@@ -825,8 +825,20 @@ plugin:ci-coq_dpdgraph:
 plugin:ci-coqhammer:
   extends: .ci-template-flambda
 
-plugin:ci-elpi:
+plugin:ci-elpi_hb:
   extends: .ci-template-flambda
+
+plugin:ci-elpi_test:
+  extends: .ci-template-flambda
+  needs:
+  - build:edge+flambda
+  - plugin:ci-elpi_hb
+
+plugin:ci-hb_test:
+  extends: .ci-template-flambda
+  needs:
+  - build:edge+flambda
+  - plugin:ci-elpi_hb
 
 plugin:ci-equations:
   extends: .ci-template

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -36,6 +36,7 @@ CI_TARGETS= \
     ci-engine_bench \
     ci-ext_lib \
     ci-equations \
+    ci-equations_test \
     ci-fcsl_pcm \
     ci-fiat_crypto \
     ci-fiat_crypto_legacy \
@@ -129,6 +130,8 @@ ci-geocoq: ci-mathcomp
 
 ci-simple_io: ci-ext_lib
 ci-quickchick: ci-ext_lib ci-simple_io ci-mathcomp
+
+ci-equations_test: ci-equations
 
 ci-metacoq: ci-equations
 

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -30,7 +30,9 @@ CI_TARGETS= \
     ci-coq_tools \
     ci-coqprime \
     ci-deriving \
-    ci-elpi \
+    ci-elpi_hb \
+    ci-elpi_test \
+    ci-hb_test \
     ci-engine_bench \
     ci-ext_lib \
     ci-equations \
@@ -114,7 +116,10 @@ ci-mathcomp_test: ci-mathcomp
 ci-mathcomp_word: ci-mathcomp
 ci-finmap: ci-mathcomp
 ci-bigenough: ci-mathcomp
-ci-analysis: ci-elpi ci-finmap ci-bigenough
+ci-analysis: ci-elpi_hb ci-finmap ci-bigenough
+
+ci-elpi_test: ci-elpi_hb
+ci-hb_test: ci-elpi_hb
 
 ci-jasmin: ci-mathcomp_word
 

--- a/dev/ci/ci-elpi_hb.sh
+++ b/dev/ci/ci-elpi_hb.sh
@@ -11,11 +11,13 @@ git_download hierarchy_builder
 if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
 
 ( cd "${CI_BUILD_DIR}/elpi"
-  make
+  make build-core
+  make build-apps
   make install
 )
 
 ( cd "${CI_BUILD_DIR}/hierarchy_builder"
-  make
+  make config
+  make build
   make install
 )

--- a/dev/ci/ci-elpi_test.sh
+++ b/dev/ci/ci-elpi_test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
+
+( cd "${CI_BUILD_DIR}/elpi"
+  make test-core examples test-apps
+)

--- a/dev/ci/ci-equations_test.sh
+++ b/dev/ci/ci-equations_test.sh
@@ -5,13 +5,9 @@ set -e
 ci_dir="$(dirname "$0")"
 . "${ci_dir}/ci-common.sh"
 
-git_download equations
-
 if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
 
 export COQEXTRAFLAGS='-native-compiler no'
 ( cd "${CI_BUILD_DIR}/equations"
-  [ -e Makefile.coq ] || ./configure.sh coq
-  make
-  make install
+  make test-suite examples
 )

--- a/dev/ci/ci-hb_test.sh
+++ b/dev/ci/ci-hb_test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
+
+( cd "${CI_BUILD_DIR}/hierarchy_builder"
+  make test-suite
+)


### PR DESCRIPTION
The HB build is fast enough that there is probably no benefit to building elpi and HB in separate jobs.

Typically this means if there's an overlay needed for metacoq we don't need to run the equations tests before working on it.