### PR TITLE
[coqdep] give relative paths to META and .cmxs files.

### DIFF
--- a/tools/coqdep/lib/common.ml
+++ b/tools/coqdep/lib/common.ml
@@ -195,11 +195,16 @@ let rec find_dependencies st basename =
             let s = basename_noext str in
             if not (StrSet.mem s !visited_ml) then begin
                 visited_ml := StrSet.add s !visited_ml;
+                let pick_mldir mldir =
+                  match meta_file with
+                  | None -> mldir
+                  | Some _ -> Some(Filename.dirname str)
+                in
                 match Loadpath.search_mllib_known st s with
-                | Some mldir -> declare ".cma" mldir s
+                | Some mldir -> declare ".cma" (pick_mldir mldir) s
                 | None ->
                   match Loadpath.search_mlpack_known st s with
-                  | Some mldir -> declare ".cmo" mldir s
+                  | Some mldir -> declare ".cmo" (pick_mldir mldir) s
                   | None -> warning_declare f str
               end
           in

--- a/tools/coqdep/lib/fl.mli
+++ b/tools/coqdep/lib/fl.mli
@@ -8,17 +8,17 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(** [findlib_resolve meta_files file package plugin_name] tries to
-   locate a [.cmxs] for a given [package.plugin_name]
+(** [findlib_resolve ~meta_files ~file ~package ~plugin_name] tries to locate
+    a [.cmxs] for a given [package.plugin_name].
 
-    If a [META] file for [package] is found, it will try to use it to
-   resolve the path to the [.cmxs], and return both. If not, it
-   errors.
+    If a [META] file for [package] is found, it will try to use it to resolve
+    the path to the [.cmxs], and return a relative path to both. If not, it
+    errors.
 
-    The [META] file for [package] is search among the list of
-   [meta_files] first, then using [Findlib.package_meta_file]. note
-   that coqdep doesn't initialize findlib so that function performs
-   implicity initialization.  *)
+    The [META] file for [package] is first searched in the [meta_files] list,
+    and if it is not found then [Findlib.package_meta_file] is used. Note that
+    coqdep does not initialize findlib, so that function performs implicity
+    initialization. *)
 val findlib_resolve
   : meta_files:string list
   -> file:string


### PR DESCRIPTION
This is an attempt to fix #16571.