### PR TITLE
Safe_typing.judgment is self contained

### DIFF
--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1401,12 +1401,18 @@ let close_section senv =
 
 (** {6 Safe typing } *)
 
-type judgment = Environ.unsafe_judgment
+type judgment = {
+  jdg_env : safe_environment;
+  jdg_val : constr;
+  jdg_type : types;
+}
 
-let j_val j = j.Environ.uj_val
-let j_type j = j.Environ.uj_type
-
-let typing senv = Typeops.infer (env_of_senv senv)
+let typing senv c =
+  let j = Typeops.infer (env_of_senv senv) c in
+  { jdg_env = senv;
+    jdg_val = j.Environ.uj_val;
+    jdg_type = j.Environ.uj_type;
+  }
 
 (** {6 Retroknowledge / native compiler } *)
 

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -241,10 +241,11 @@ val import : compiled_library -> Univ.ContextSet.t -> vodigest ->
 
 (** {6 Safe typing judgments } *)
 
-type judgment
-
-val j_val : judgment -> Constr.constr
-val j_type : judgment -> Constr.constr
+type judgment = private {
+  jdg_env : safe_environment;
+  jdg_val : Constr.constr;
+  jdg_type : Constr.types;
+}
 
 (** The safe typing of a term returns a typing judgment. *)
 val typing : safe_environment -> Constr.constr -> judgment

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -817,9 +817,9 @@ let print_eval x = !object_pr.print_eval x
 let print_judgment env sigma {uj_val=trm;uj_type=typ} =
   print_typed_value_in_env env sigma (trm, typ)
 
-let print_safe_judgment env sigma j =
-  let trm = Safe_typing.j_val j in
-  let typ = Safe_typing.j_type j in
+let print_safe_judgment {Safe_typing.jdg_env=senv; jdg_val=trm; jdg_type=typ} =
+  let env = Safe_typing.env_of_safe_env senv in
+  let sigma = Evd.from_env env in
   let trm = EConstr.of_constr trm in
   let typ = EConstr.of_constr typ in
   print_typed_value_in_env env sigma (trm, typ)

--- a/vernac/prettyp.mli
+++ b/vernac/prettyp.mli
@@ -39,7 +39,7 @@ val print_full_pure_context : env -> Evd.evar_map -> Pp.t
 val print_sec_context : env -> Evd.evar_map -> qualid -> Pp.t
 val print_sec_context_typ : env -> Evd.evar_map -> qualid -> Pp.t
 val print_judgment : env -> Evd.evar_map -> EConstr.unsafe_judgment -> Pp.t
-val print_safe_judgment : env -> Evd.evar_map -> Safe_typing.judgment -> Pp.t
+val print_safe_judgment : Safe_typing.judgment -> Pp.t
 val print_eval :
   reduction_function -> env -> Evd.evar_map ->
     Constrexpr.constr_expr -> EConstr.unsafe_judgment -> Pp.t

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2098,8 +2098,7 @@ let vernac_global_check c =
   let senv = Safe_typing.push_context_set ~strict:false uctx senv in
   let c = EConstr.to_constr sigma c in
   let j = Safe_typing.typing senv c in
-  let env = Safe_typing.env_of_safe_env senv in
-  Prettyp.print_safe_judgment env sigma j ++
+  Prettyp.print_safe_judgment j ++
   pr_universe_ctx_set sigma uctx
 
 


### PR DESCRIPTION
This should make it actually safe instead of depending on some unknown safe env.
