### PR TITLE
More uniform behaviour and implementation for Check and Eval

### DIFF
--- a/dev/ci/user-overlays/17274-SkySkimmer-check-eval.sh
+++ b/dev/ci/user-overlays/17274-SkySkimmer-check-eval.sh
@@ -1,0 +1,1 @@
+overlay fiat_crypto https://github.com/SkySkimmer/fiat-crypto check-eval 17274

--- a/doc/changelog/08-vernac-commands-and-options/17274-check-eval.rst
+++ b/doc/changelog/08-vernac-commands-and-options/17274-check-eval.rst
@@ -1,0 +1,4 @@
+- **Changed:**
+  :cmd:`Eval` prints information about existential variables like :cmd:`Check`
+  (`#17274 <https://github.com/coq/coq/pull/17274>`_,
+  by Gaëtan Gilbert).

--- a/test-suite/output/Notations5.out
+++ b/test-suite/output/Notations5.out
@@ -150,6 +150,8 @@ v 0
      : forall b : bool, 0 = 0 /\ b = b
      = ?n@{x:=v 0 (B:=bool)}
      : nat
+where
+?n : [x : forall b : bool, 0 = 0 /\ b = b |- nat]
 v
      : forall (a2 : nat) (B : Type) (b : B), 0 = a2 /\ b = b
 v 0
@@ -172,6 +174,8 @@ v 0
      : forall b : bool, 0 = 0 /\ b = b
      = ?n@{x:=v 0 (B:=bool)}
      : nat
+where
+?n : [x : forall b : bool, 0 = 0 /\ b = b |- nat]
 ##
      : forall (a1 a2 : ?A) (B : Type) (b : B), a1 = a2 /\ b = b
 where
@@ -202,6 +206,8 @@ where
      : forall b : bool, 0 = 0 /\ b = b
      = ?n@{x:=## 0 0 (B:=bool)}
      : nat
+where
+?n : [x : forall b : bool, 0 = 0 /\ b = b |- nat]
 ## ?A
      : forall (a1 a2 : ?A) (B : Type) (b : B), a1 = a2 /\ b = b
 where
@@ -242,6 +248,8 @@ where
      : forall b : bool, 0 = 0 /\ b = b
      = ?n@{x:=## 0 0 (B:=bool)}
      : nat
+where
+?n : [x : forall b : bool, 0 = 0 /\ b = b |- nat]
 ## 0 0 true
      : 0 = 0 /\ true = true
 ## 0 0 true
@@ -260,6 +268,8 @@ where
      : forall b : bool, 0 = 0 /\ b = b
      = ?n@{x:=## 0 0 (B:=bool)}
      : nat
+where
+?n : [x : forall b : bool, 0 = 0 /\ b = b |- nat]
 ## 0 0 true
      : 0 = 0 /\ true = true
 ## 0 0 true

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -42,7 +42,6 @@ type object_pr = {
   print_library_leaf       : env -> Evd.evar_map -> bool -> ModPath.t -> Libobject.t -> Pp.t option;
   print_context             : env -> Evd.evar_map -> bool -> int option -> Lib.library_segment -> Pp.t;
   print_typed_value_in_env  : Environ.env -> Evd.evar_map -> EConstr.constr * EConstr.types -> Pp.t;
-  print_eval                : Reductionops.reduction_function -> env -> Evd.evar_map -> Constrexpr.constr_expr -> EConstr.unsafe_judgment -> Pp.t;
 }
 
 let gallina_print_module mp = print_module ~with_body:true mp
@@ -774,10 +773,6 @@ let print_library_node = function
   | Lib.CompilingLibrary { Nametab.obj_dir; _ } ->
     str " >>>>>>> Library " ++ DirPath.print obj_dir
 
-let gallina_print_eval red_fun env sigma _ {uj_val=trm;uj_type=typ} =
-  let ntrm = red_fun env sigma trm in
-  (str "     = " ++ gallina_print_typed_value_in_env env sigma (ntrm,typ))
-
 (******************************************)
 (**** Printing abstraction layer          *)
 
@@ -792,7 +787,6 @@ let default_object_pr = {
   print_library_leaf        = gallina_print_library_leaf;
   print_context             = gallina_print_context;
   print_typed_value_in_env  = gallina_print_typed_value_in_env;
-  print_eval                = gallina_print_eval;
 }
 
 let object_pr = ref default_object_pr
@@ -808,7 +802,6 @@ let print_named_decl x = !object_pr.print_named_decl x
 let print_library_leaf x = !object_pr.print_library_leaf x
 let print_context x = !object_pr.print_context x
 let print_typed_value_in_env x = !object_pr.print_typed_value_in_env x
-let print_eval x = !object_pr.print_eval x
 
 (******************************************)
 (**** Printing declarations and judgments *)

--- a/vernac/prettyp.mli
+++ b/vernac/prettyp.mli
@@ -10,7 +10,6 @@
 
 open Names
 open Environ
-open Reductionops
 open Libnames
 open Globnames
 
@@ -40,9 +39,6 @@ val print_sec_context : env -> Evd.evar_map -> qualid -> Pp.t
 val print_sec_context_typ : env -> Evd.evar_map -> qualid -> Pp.t
 val print_judgment : env -> Evd.evar_map -> EConstr.unsafe_judgment -> Pp.t
 val print_safe_judgment : Safe_typing.judgment -> Pp.t
-val print_eval :
-  reduction_function -> env -> Evd.evar_map ->
-    Constrexpr.constr_expr -> EConstr.unsafe_judgment -> Pp.t
 
 val print_name : env -> Evd.evar_map
   -> qualid Constrexpr.or_by_notation
@@ -111,7 +107,6 @@ type object_pr = {
   print_library_leaf       : env -> Evd.evar_map -> bool -> ModPath.t -> Libobject.t -> Pp.t option;
   print_context             : env -> Evd.evar_map -> bool -> int option -> Lib.library_segment -> Pp.t;
   print_typed_value_in_env  : Environ.env -> Evd.evar_map -> EConstr.constr * EConstr.types -> Pp.t;
-  print_eval                : Reductionops.reduction_function -> env -> Evd.evar_map -> Constrexpr.constr_expr -> EConstr.unsafe_judgment -> Pp.t;
 }
 
 val set_object_pr : object_pr -> unit

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2053,7 +2053,7 @@ let check_may_eval env sigma redexp rc =
   let sigma = Evd.minimize_universes sigma in
   let uctx = Evd.universe_context_set sigma in
   let env = Environ.push_context_set uctx (Evarutil.nf_env_evar sigma env) in
-  let j =
+  let { Environ.uj_val=c; uj_type=ty; } =
     if Evarutil.has_undefined_evars sigma c then
       Evarutil.j_nf_evar sigma (Retyping.get_judgment_of env sigma c)
     else
@@ -2061,23 +2061,23 @@ let check_may_eval env sigma redexp rc =
       (* OK to call kernel which does not support evars *)
       Environ.on_judgment EConstr.of_constr (Arguments_renaming.rename_typing env c)
   in
-  let j = { j with Environ.uj_type = Reductionops.nf_betaiota env sigma j.Environ.uj_type } in
-  let pp = match redexp with
-    | None ->
-        let evars_of_term c = Evarutil.undefined_evars_of_term sigma c in
-        let l = Evar.Set.union (evars_of_term j.Environ.uj_val) (evars_of_term j.Environ.uj_type) in
-        Prettyp.print_judgment env sigma j ++
-        pr_ne_evar_set (fnl () ++ str "where" ++ fnl ()) (mt ()) sigma l
+  let sigma, c = match redexp with
+    | None -> sigma, c
     | Some r ->
-        let (sigma,r_interp) = Hook.get f_interp_redexp env sigma r in
-        let redfun env evm c =
-          let (redfun, _) = Redexpr.reduction_of_red_expr env r_interp in
-          let (_, c) = redfun env evm c in
-          c
-        in
-        Prettyp.print_eval redfun env sigma rc j
+      let sigma, r = Hook.get f_interp_redexp env sigma r in
+      let r, _ = Redexpr.reduction_of_red_expr env r in
+      let sigma, c = r env sigma c in
+      sigma, c
   in
-  pp ++ Printer.pr_universe_ctx_set sigma uctx
+  let pp =
+    let evars_of_term c = Evarutil.undefined_evars_of_term sigma c in
+    let l = Evar.Set.union (evars_of_term c) (evars_of_term ty) in
+    let j = { Environ.uj_val = c; uj_type = Reductionops.nf_betaiota env sigma ty } in
+    Prettyp.print_judgment env sigma j ++
+    pr_ne_evar_set (fnl () ++ str "where" ++ fnl ()) (mt ()) sigma l
+  in
+  let hdr = if Option.has_some redexp then str "     = " else mt() in
+  hdr ++ pp ++ Printer.pr_universe_ctx_set sigma uctx
 
 let vernac_check_may_eval ~pstate redexp glopt rc =
   let glopt = query_command_selector glopt in


### PR DESCRIPTION
User visible changes:

- Eval now prints info about remaining evars

- ~Eval prints the type inferred for the reduced term, not the original term (this could be changed back as we prefer)~

Overlays:
- https://github.com/mit-plv/fiat-crypto/pull/1564