### PR TITLE
Clean the Clenv internals

### DIFF
--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -748,6 +748,127 @@ let mk_goal evars hyps concl =
   let ev = EConstr.mkEvar (evk,inst) in
   (evk, ev, evars)
 
+module StdRefiner =
+struct
+
+let rec mk_refgoals env sigma goalacc conclty trm =
+  let hyps = Environ.named_context_val env in
+    if not (occur_meta sigma (EConstr.of_constr trm)) then
+      let t'ty = Retyping.get_type_of env sigma (EConstr.of_constr trm) in
+      let t'ty = EConstr.Unsafe.to_constr t'ty in
+        (goalacc,t'ty,sigma,trm)
+    else
+      match kind trm with
+      | Meta _ ->
+        let conclty = nf_betaiota env sigma conclty in
+          let (gl,ev,sigma) = mk_goal sigma hyps conclty in
+          let ev = EConstr.Unsafe.to_constr ev in
+          let conclty = EConstr.Unsafe.to_constr conclty in
+          gl::goalacc, conclty, sigma, ev
+
+      | Cast (t,k, ty) ->
+        let res = mk_refgoals env sigma goalacc (EConstr.of_constr ty) t in
+        (* we keep the casts (in particular VMcast and NATIVEcast) except
+           when they are annotating metas *)
+        if isMeta t then begin
+          assert (k != VMcast && k != NATIVEcast);
+          res
+        end else
+          let (gls,cty,sigma,ans) = res in
+          let ans = if ans == t then trm else mkCast(ans,k,ty) in
+          (gls,cty,sigma,ans)
+
+      | App (f,l) ->
+        let (acc',hdty,sigma,applicand) =
+          if Termops.is_template_polymorphic_ind env sigma (EConstr.of_constr f) then
+            let ty =
+              (* Template polymorphism of definitions and inductive types *)
+              let firstmeta = Array.findi (fun i x -> occur_meta sigma (EConstr.of_constr x)) l in
+              let args, _ = Option.cata (fun i -> CArray.chop i l) (l, [||]) firstmeta in
+                type_of_global_reference_knowing_parameters env sigma (EConstr.of_constr f) (Array.map EConstr.of_constr args)
+            in
+            let ty = EConstr.Unsafe.to_constr ty in
+              goalacc, ty, sigma, f
+          else
+            mk_hdgoals env sigma goalacc f
+        in
+        let ((acc'',conclty',sigma), args) = mk_arggoals env sigma acc' hdty l in
+        let ans = if applicand == f && args == l then trm else mkApp (applicand, args) in
+        (acc'',conclty',sigma, ans)
+
+      | Proj (p,c) ->
+        let (acc',cty,sigma,c') = mk_hdgoals env sigma goalacc c in
+        let c = mkProj (p, c') in
+        let ty = get_type_of env sigma (EConstr.of_constr c) in
+        let ty = EConstr.Unsafe.to_constr ty in
+          (acc',ty,sigma,c)
+
+      | _ ->
+        if occur_meta sigma (EConstr.of_constr trm) then
+          anomaly (Pp.str "refiner called with a meta in non app/case subterm.");
+        let (sigma, t'ty) = goal_type_of env sigma trm in
+          (goalacc,t'ty,sigma, trm)
+
+(* Same as mkREFGOALS but without knowing the type of the term. Therefore,
+ * Metas should be casted. *)
+
+and mk_hdgoals env sigma goalacc trm =
+  let hyps = Environ.named_context_val env in
+  match kind trm with
+    | Cast (c,_, ty) when isMeta c ->
+        let (gl,ev,sigma) = mk_goal sigma hyps (nf_betaiota env sigma (EConstr.of_constr ty)) in
+        let ev = EConstr.Unsafe.to_constr ev in
+        gl::goalacc,ty,sigma,ev
+
+    | Cast (t,_, ty) ->
+        mk_refgoals env sigma goalacc (EConstr.of_constr ty) t
+
+    | App (f,l) ->
+        let (acc',hdty,sigma,applicand) =
+          if Termops.is_template_polymorphic_ind env sigma (EConstr.of_constr f)
+          then
+            let l' = meta_free_prefix sigma l in
+           (goalacc,EConstr.Unsafe.to_constr (type_of_global_reference_knowing_parameters env sigma (EConstr.of_constr f) l'),sigma,f)
+          else mk_hdgoals env sigma goalacc f
+        in
+        let ((acc'',conclty',sigma), args) = mk_arggoals env sigma acc' hdty l in
+        let ans = if applicand == f && args == l then trm else mkApp (applicand, args) in
+        (acc'',conclty',sigma, ans)
+
+    | Proj (p,c) ->
+         let (acc',cty,sigma,c') = mk_hdgoals env sigma goalacc c in
+         let c = mkProj (p, c') in
+         let ty = get_type_of env sigma (EConstr.of_constr c) in
+         let ty = EConstr.Unsafe.to_constr ty in
+           (acc',ty,sigma,c)
+
+    | _ ->
+        let (sigma, ty) = goal_type_of env sigma trm in
+        goalacc, ty, sigma, trm
+
+and mk_arggoals env sigma goalacc funty allargs =
+  let foldmap (goalacc, funty, sigma) harg =
+    let t = whd_all env sigma (EConstr.of_constr funty) in
+    let t = EConstr.Unsafe.to_constr t in
+    let rec collapse t = match kind t with
+    | LetIn (_, c1, _, b) -> collapse (subst1 c1 b)
+    | _ -> t
+    in
+    let t = collapse t in
+    match kind t with
+    | Prod (_, c1, b) ->
+      let (acc, hargty, sigma, arg) = mk_refgoals env sigma goalacc (EConstr.of_constr c1) harg in
+      (acc, subst1 harg b, sigma), arg
+    | _ ->
+      raise (RefinerError (env,sigma,CannotApply (t, harg)))
+  in
+  Array.Smart.fold_left_map foldmap (goalacc, funty, sigma) allargs
+
+end
+
+module CaseRefiner =
+struct
+
 let rec mk_refgoals env sigma goalacc conclty trm =
   let hyps = Environ.named_context_val env in
     if not (occur_meta sigma (EConstr.of_constr trm)) then
@@ -931,7 +1052,9 @@ and treat_case env sigma ci lbrty lf acc' =
           (lacc,sigma,fi::bacc))
     (acc',sigma,[]) lbrty lf ci.ci_cstr_ndecls
 
-let refiner clenv =
+end
+
+let refiner_gen is_case clenv =
   let open Proofview.Notations in
   let r = EConstr.Unsafe.to_constr (clenv_cast_meta clenv @@ clenv_value clenv) in
   Proofview.Goal.enter begin fun gl ->
@@ -940,7 +1063,12 @@ let refiner clenv =
   let st = Proofview.Goal.state gl in
   let cl = Proofview.Goal.concl gl in
   check_meta_variables env sigma r;
-  let (sgl,cl',sigma,oterm) = mk_refgoals env sigma [] cl r in
+  let (sgl,cl',sigma,oterm) =
+    if is_case then
+      CaseRefiner.mk_refgoals env sigma [] cl r
+    else
+      StdRefiner.mk_refgoals env sigma [] cl r
+  in
   let map gl = Proofview.goal_with_state gl st in
   let sgl = List.rev_map map sgl in
   let evk = Proofview.Goal.goal gl in
@@ -954,13 +1082,16 @@ let refiner clenv =
   Proofview.Unsafe.tclEVARS sigma <*>
   Proofview.Unsafe.tclSETGOALS sgl
   end
+
+let refiner clenv = refiner_gen false clenv
+
 end
 
 open Unification
 
 let dft = default_unify_flags
 
-let res_pf ?(with_evars=false) ?(with_classes=true) ?(flags=dft ()) clenv =
+let res_pf_gen is_case ?(with_evars=false) ?(with_classes=true) ?(flags=dft ()) clenv =
   Proofview.Goal.enter begin fun gl ->
     let concl = Proofview.Goal.concl gl in
     let clenv = clenv_unique_resolver ~flags clenv concl in
@@ -979,8 +1110,14 @@ let res_pf ?(with_evars=false) ?(with_classes=true) ?(flags=dft ()) clenv =
     let clenv = update_clenv_evd clenv evd' in
     Proofview.tclTHEN
       (Proofview.Unsafe.tclEVARS (Evd.clear_metas evd'))
-      (Internal.refiner clenv)
+      (Internal.refiner_gen is_case clenv)
   end
+
+let res_pf ?with_evars ?with_classes ?flags clenv =
+  res_pf_gen false ?with_evars ?with_classes ?flags clenv
+
+let case_pf ?with_evars ?with_classes ?flags clenv =
+  res_pf_gen true ?with_evars ?with_classes ?flags clenv
 
 (* [unifyTerms] et [unify] ne semble pas gérer les Meta, en
    particulier ne semblent pas vérifier que des instances différentes

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -107,10 +107,6 @@ let clenv_meta_type clenv mv =
 let clenv_value clenv = meta_instance clenv.env clenv.cache clenv.templval
 let clenv_type clenv = meta_instance clenv.env clenv.cache clenv.templtyp
 
-let clenv_hnf_constr ce t = hnf_constr (cl_env ce) (clenv_evd ce) t
-
-let clenv_get_type_of ce c = Retyping.get_type_of (cl_env ce) (clenv_evd ce) c
-
 let clenv_push_prod cl =
   let typ = whd_all (cl_env cl) (clenv_evd cl) (clenv_type cl) in
   let rec clrec typ = match EConstr.kind cl.evd typ with
@@ -598,8 +594,8 @@ let clenv_unify_binding_type clenv c t u =
           TypeNotProcessed, clenv, c
 
 let clenv_assign_binding clenv k c =
-  let k_typ = clenv_hnf_constr clenv (clenv_meta_type clenv k) in
-  let c_typ = nf_betaiota clenv.env clenv.evd (clenv_get_type_of clenv c) in
+  let k_typ = hnf_constr clenv.env clenv.evd (clenv_meta_type clenv k) in
+  let c_typ = nf_betaiota clenv.env clenv.evd (Retyping.get_type_of clenv.env clenv.evd c) in
   let status,clenv',c = clenv_unify_binding_type clenv c c_typ k_typ in
   update_clenv_evd clenv' (meta_assign k (c,(Conv,status)) clenv'.evd)
 

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -74,7 +74,12 @@ let clenv_refresh env sigma ctx clenv =
 
 let cl_env ce = ce.env
 let clenv_evd ce =  ce.evd
-let clenv_templtyp c = c.templtyp
+let clenv_type_head_meta c =
+  let hd, _ = decompose_app c.evd c.templtyp.rebus in
+  match EConstr.kind c.evd hd with
+  | Meta p -> Some p
+  | _ -> None
+
 let clenv_arguments c = List.map fst c.metas
 
 let clenv_meta_type clenv mv =

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -456,11 +456,12 @@ let fchain_flags () =
     allow_K_in_toplevel_higher_order_unification = true }
 
 let clenv_instantiate ?(flags=fchain_flags ()) ?submetas mv clenv (c, ty) =
-  let clenv = match submetas with
-  | None -> clenv
+  let clenv, c = match submetas with
+  | None -> clenv, c
   | Some metas ->
     let evd = meta_merge (Metamap.of_list metas) clenv.evd in
     let clenv = update_clenv_evd clenv evd in
+    let c = applist (c, List.map (fun (mv, _) -> mkMeta mv) metas) in
     let map (mv0, submetas0 as arg) =
       if Int.equal mv mv0 then
         (* we never chain more than 2 clenvs *)
@@ -469,7 +470,7 @@ let clenv_instantiate ?(flags=fchain_flags ()) ?submetas mv clenv (c, ty) =
       else arg
     in
     let metas = List.map map clenv.metas in
-    { clenv with metas = metas }
+    { clenv with metas = metas }, c
   in
   (* unify the type of the template of [nextclenv] with the type of [mv] *)
   let clenv = clenv_unify ~flags CUMUL ty (clenv_meta_type clenv mv) clenv in

--- a/proofs/clenv.mli
+++ b/proofs/clenv.mli
@@ -23,7 +23,7 @@ open Tactypes
 type clausenv
 
 val clenv_evd : clausenv -> Evd.evar_map
-val clenv_templtyp : clausenv -> constr freelisted
+val clenv_type_head_meta : clausenv -> metavariable option
 
 (* Ad-hoc primitives *)
 val update_clenv_evd : clausenv -> evar_map -> clausenv

--- a/proofs/clenv.mli
+++ b/proofs/clenv.mli
@@ -27,7 +27,7 @@ val clenv_type_head_meta : clausenv -> metavariable option
 
 (* Ad-hoc primitives *)
 val update_clenv_evd : clausenv -> evar_map -> clausenv
-val clenv_convert_val : (env -> evar_map -> econstr -> econstr) -> clausenv -> clausenv
+val clenv_strip_proj_params : clausenv -> clausenv
 val clenv_refresh : env -> evar_map -> Univ.ContextSet.t option -> clausenv -> clausenv
 val clenv_arguments : clausenv -> metavariable list
 

--- a/proofs/clenv.mli
+++ b/proofs/clenv.mli
@@ -83,6 +83,7 @@ val clenv_push_prod : clausenv -> (metavariable * bool * clausenv) option
 
 val unify : ?flags:unify_flags -> constr -> unit Proofview.tactic
 val res_pf : ?with_evars:bool -> ?with_classes:bool -> ?flags:unify_flags -> clausenv -> unit Proofview.tactic
+val case_pf : ?with_evars:bool -> ?with_classes:bool -> ?flags:unify_flags -> clausenv -> unit Proofview.tactic
 
 val clenv_pose_dependent_evars : ?with_evars:bool -> clausenv -> clausenv
 

--- a/proofs/clenv.mli
+++ b/proofs/clenv.mli
@@ -45,7 +45,8 @@ val mk_clenv_from_n : env -> evar_map -> int -> EConstr.constr * EConstr.types -
 
 (** {6 linking of clenvs } *)
 
-val clenv_instantiate : ?flags:unify_flags -> metavariable -> clausenv -> (constr * types) -> clausenv
+val clenv_instantiate : ?flags:unify_flags -> ?submetas:(metavariable * clbinding) list ->
+  metavariable -> clausenv -> (constr * types) -> clausenv
 
 (** {6 Unification with clenvs } *)
 

--- a/tactics/elim.ml
+++ b/tactics/elim.ml
@@ -49,6 +49,7 @@ let general_elim_then_using mk_elim
       let sigma, r = Evd.fresh_global env sigma gr in
       (sigma, r, Retyping.get_type_of env sigma r)
     in
+    let is_case = match mk_elim with Elim -> false | Case _ -> true in
     (* applying elimination_scheme just a little modified *)
     let elimclause = mk_clenv_from env sigma (elim, elimt) in
     let indmv = List.last (clenv_arguments elimclause) in
@@ -82,7 +83,7 @@ let general_elim_then_using mk_elim
     in
     let branchtacs = List.init (Array.length branchsigns) after_tac in
     Proofview.tclTHEN
-      (Clenv.res_pf ~flags elimclause')
+      (if is_case then Clenv.case_pf ~flags elimclause' else Clenv.res_pf ~flags elimclause')
       (Proofview.tclEXTEND [] tclIDTAC branchtacs)
   end
 

--- a/tactics/elim.ml
+++ b/tactics/elim.ml
@@ -52,18 +52,16 @@ let general_elim_then_using mk_elim
     (* applying elimination_scheme just a little modified *)
     let elimclause = mk_clenv_from env sigma (elim, elimt) in
     let indmv = List.last (clenv_arguments elimclause) in
-    let pmv =
-      let p, _ = decompose_app sigma (clenv_templtyp elimclause).Evd.rebus in
-      match EConstr.kind sigma p with
-      | Meta p -> p
-      | _ ->
-          let name_elim =
-            match EConstr.kind sigma elim with
-            | Const _ | Var _ -> str " " ++ Printer.pr_econstr_env env sigma elim
-            | _ -> mt ()
-          in
-          CErrors.user_err
-            (str "The elimination combinator " ++ name_elim ++ str " is unknown.")
+    let pmv = match Clenv.clenv_type_head_meta elimclause with
+    | Some p -> p
+    | None ->
+      let name_elim =
+        match EConstr.kind sigma elim with
+        | Const _ | Var _ -> str " " ++ Printer.pr_econstr_env env sigma elim
+        | _ -> mt ()
+      in
+      CErrors.user_err
+        (str "The elimination combinator " ++ name_elim ++ str " is unknown.")
     in
     let elimclause' = clenv_instantiate indmv elimclause (mkVar id, mkApp (mkIndU (ind, u), args)) in
     let branchsigns = Tacticals.compute_constructor_signatures env ~rec_flag (ind, u) in

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -262,7 +262,9 @@ let general_elim_clause with_evars frzevars tac cls c (ctx, eqn, args) l l2r eli
       (* we would have to take the clenv_value *)
       let newevars = lazy (Evarutil.undefined_evars_of_term sigma (Clenv.clenv_type rew)) in
       let flags = make_flags frzevars sigma flags newevars in
-      general_elim_clause with_evars flags cls (Evd.meta_list (Clenv.clenv_evd rew), Clenv.clenv_value rew, Clenv.clenv_type rew) elim
+      let metas = Evd.meta_list (Clenv.clenv_evd rew) in
+      let submetas = List.map (fun mv -> mv, Evd.Metamap.find mv metas) (Clenv.clenv_arguments rew) in
+      general_elim_clause with_evars flags cls (submetas, Clenv.clenv_value rew, Clenv.clenv_type rew) elim
       end
     in
     Proofview.Unsafe.tclEVARS (Evd.clear_metas (Clenv.clenv_evd rew)) <*>

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -264,7 +264,7 @@ let general_elim_clause with_evars frzevars tac cls c (ctx, eqn, args) l l2r eli
       let flags = make_flags frzevars sigma flags newevars in
       let metas = Evd.meta_list (Clenv.clenv_evd rew) in
       let submetas = List.map (fun mv -> mv, Evd.Metamap.find mv metas) (Clenv.clenv_arguments rew) in
-      general_elim_clause with_evars flags cls (submetas, Clenv.clenv_value rew, Clenv.clenv_type rew) elim
+      general_elim_clause with_evars flags cls (submetas, c, Clenv.clenv_type rew) elim
       end
     in
     Proofview.Unsafe.tclEVARS (Evd.clear_metas (Clenv.clenv_evd rew)) <*>

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -335,23 +335,6 @@ let lookup_tacs env sigma concl se =
   let sl' = List.stable_sort pri_order_int l' in
   List.merge pri_order_int se.sentry_nopat sl'
 
-let strip_params env sigma c =
-  match EConstr.kind sigma c with
-  | App (f, args) ->
-    (match EConstr.kind sigma f with
-    | Const (cst,_) ->
-      (match Structures.PrimitiveProjections.find_opt cst with
-       | Some p ->
-         let p = Projection.make p false in
-         let npars = Projection.npars p in
-         if Array.length args > npars then
-           mkApp (mkProj (p, args.(npars)),
-                  Array.sub args (npars+1) (Array.length args - (npars + 1)))
-         else c
-       | None -> c)
-    | _ -> c)
-  | _ -> c
-
 let merge_context_set_opt sigma ctx = match ctx with
 | None -> sigma
 | Some ctx -> Evd.merge_context_set Evd.univ_flexible sigma ctx
@@ -360,7 +343,7 @@ let instantiate_hint env sigma p =
   let mk_clenv { rhint_term = c; rhint_type = cty; rhint_uctx = ctx; rhint_arty = ar } =
     let sigma = merge_context_set_opt sigma ctx in
     let cl = mk_clenv_from env sigma (c,cty) in
-    let cl = clenv_convert_val strip_params cl in
+    let cl = clenv_strip_proj_params cl in
     { hint_term = c; hint_type = cty; hint_uctx = ctx; hint_clnv = cl; hint_arty = ar }
   in
   let code = match p.code.obj with

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1641,7 +1641,7 @@ let general_elim with_evars clear_flag (c, lbindc) elim =
   let submetas = List.map (fun mv -> mv, Metamap.find mv metas) (clenv_arguments indclause) in
   Proofview.Unsafe.tclEVARS (Evd.clear_metas (clenv_evd indclause)) <*>
   Tacticals.tclTHEN
-    (general_elim_clause0 with_evars flags (submetas, clenv_value indclause, clenv_type indclause) elim)
+    (general_elim_clause0 with_evars flags (submetas, c, clenv_type indclause) elim)
     (apply_clear_request clear_flag (use_clear_hyp_by_default ()) id)
   end
 
@@ -1986,7 +1986,7 @@ let progress_with_clause env flags (id, t) clause mvs =
       let metas = Evd.meta_list (clenv_evd innerclause) in
       let submetas = List.map (fun mv -> mv, Metamap.find mv metas) (clenv_arguments innerclause) in
       try
-        Some (clenv_instantiate mv ~flags ~submetas clause (clenv_value innerclause, clenv_type innerclause))
+        Some (clenv_instantiate mv ~flags ~submetas clause (mkVar id, clenv_type innerclause))
       with e when noncritical e ->
       match clenv_push_prod innerclause with
       | Some (_, _, innerclause) -> find innerclause

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -276,7 +276,7 @@ type elim_scheme = {
 val compute_elim_sig : evar_map -> types -> elim_scheme
 
 val general_elim_clause : evars_flag -> unify_flags -> Id.t option ->
-  (Evd.clbinding Evd.Metamap.t * EConstr.t * EConstr.types) -> Constant.t -> unit Proofview.tactic
+  ((metavariable * Evd.clbinding) list * EConstr.t * EConstr.types) -> Constant.t -> unit Proofview.tactic
 
 val default_elim  : evars_flag -> clear_flag -> constr with_bindings ->
   unit Proofview.tactic


### PR DESCRIPTION
This is a series of clean-ups of the Clenv module that should probably help with unifall. It's a step towards a more rigid implementation of the refinement process where we stop normalizing the refined proof terms. In particular we introduce a variant of res_pf dedicated to the implementation of case / destruct and remove support for case nodes from the original code.