### PR TITLE
Use list ref for end_library_hook

### DIFF
--- a/plugins/ltac/profile_ltac.ml
+++ b/plugins/ltac/profile_ltac.ml
@@ -453,7 +453,7 @@ let print_results_tactic tactic =
 let do_print_results_at_close () =
   if get_profiling () then print_results ~cutoff:!Flags.profile_ltac_cutoff
 
-let _ = Declaremods.append_end_library_hook do_print_results_at_close
+let () = Declaremods.append_end_library_hook do_print_results_at_close
 
 let () =
   let open Goptions in

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -1580,13 +1580,15 @@ let import_module f ~export mp =
 
 end
 
-let end_library_hook = ref ignore
+let end_library_hook = ref []
 let append_end_library_hook f =
-  let old_f = !end_library_hook in
-  end_library_hook := fun () -> old_f(); f ()
+  end_library_hook := f :: !end_library_hook
+
+let end_library_hook () =
+  List.iter (fun f -> f ()) (List.rev !end_library_hook)
 
 let end_library ~output_native_objects dir =
-  !end_library_hook();
+  end_library_hook();
   let prefix, lib_stack, lib_stack_syntax = Lib.end_compilation dir in
   let mp,cenv,ast = Global.export ~output_native_objects dir in
   assert (ModPath.equal mp (MPfile dir));


### PR DESCRIPTION
This produces nicer backtraces than nesting closures.

In practice not likely to matter as adding to this hook is uncommon but the cost is also low.
