### PR TITLE
More careful handling of possibly universe polymorphic globrefs 

### DIFF
--- a/dev/ci/user-overlays/17283-SkySkimmer-unsafe-mono.sh
+++ b/dev/ci/user-overlays/17283-SkySkimmer-unsafe-mono.sh
@@ -1,0 +1,7 @@
+overlay elpi https://github.com/SkySkimmer/coq-elpi unsafe-mono 17283
+
+overlay equations https://github.com/SkySkimmer/Coq-Equations unsafe-mono 17283
+
+overlay unicoq https://github.com/SkySkimmer/unicoq unsafe-mono 17283
+
+overlay metacoq https://github.com/SkySkimmer/metacoq unsafe-mono 17283

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -1040,6 +1040,12 @@ let to_case_invert = unsafe_to_case_invert
 let eq = unsafe_eq
 end
 
+module UnsafeMonomorphic = struct
+  let mkConst c = of_kind (Const (in_punivs c))
+  let mkInd i = of_kind (Ind (in_punivs i))
+  let mkConstruct c = of_kind (Construct (in_punivs c))
+end
+
 (* deprecated *)
 
 let decompose_lambda_assum = decompose_lambda_decls

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -87,11 +87,8 @@ let mkLambda (na, t, c) = of_kind (Lambda (na, t, c))
 let mkLetIn (na, b, t, c) = of_kind (LetIn (na, b, t, c))
 let mkApp (f, arg) = of_kind (App (f, arg))
 let mkConstU pc = of_kind (Const pc)
-let mkConst c = of_kind (Const (in_punivs c))
 let mkIndU pi = of_kind (Ind pi)
-let mkInd i = of_kind (Ind (in_punivs i))
 let mkConstructU pc = of_kind (Construct pc)
-let mkConstruct c = of_kind (Construct (in_punivs c))
 let mkConstructUi ((ind,u),i) = of_kind (Construct ((ind,i),u))
 let mkCase (ci, u, pms, c, iv, r, p) = of_kind (Case (ci, u, pms, c, iv, r, p))
 let mkFix f = of_kind (Fix f)
@@ -1056,3 +1053,5 @@ let decompose_lam = decompose_lambda
 let decompose_lam_n_assum = decompose_lambda_n_assum
 let decompose_lam_n_decls = decompose_lambda_n_decls
 let decompose_lam_assum = decompose_lambda_assum
+
+include UnsafeMonomorphic

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -143,12 +143,9 @@ val mkProd : Name.t Context.binder_annot * t * t -> t
 val mkLambda : Name.t Context.binder_annot * t * t -> t
 val mkLetIn : Name.t Context.binder_annot * t * t * t -> t
 val mkApp : t * t array -> t
-val mkConst : Constant.t -> t
 val mkConstU : Constant.t * EInstance.t -> t
 val mkProj : (Projection.t * t) -> t
-val mkInd : inductive -> t
 val mkIndU : inductive * EInstance.t -> t
-val mkConstruct : constructor -> t
 val mkConstructU : constructor * EInstance.t -> t
 val mkConstructUi : (inductive * EInstance.t) * int -> t
 val mkCase : case -> t
@@ -165,6 +162,15 @@ module UnsafeMonomorphic : sig
   val mkInd : inductive -> t
   val mkConstruct : constructor -> t
 end
+
+val mkConst : Constant.t -> t
+[@@deprecated "Use [mkConstU] or if truly needed [UnsafeMonomorphic.mkConst]"]
+
+val mkInd : inductive -> t
+[@@deprecated "Use [mkIndU] or if truly needed [UnsafeMonomorphic.mkInd]"]
+
+val mkConstruct : constructor -> t
+[@@deprecated "Use [mkConstructU] or if truly needed [UnsafeMonomorphic.mkConstruct]"]
 
 val mkRef : GlobRef.t * EInstance.t -> t
 

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -160,6 +160,12 @@ val mkInt : Uint63.t -> t
 val mkFloat : Float64.t -> t
 val mkArray : EInstance.t * t array * t * t -> t
 
+module UnsafeMonomorphic : sig
+  val mkConst : Constant.t -> t
+  val mkInd : inductive -> t
+  val mkConstruct : constructor -> t
+end
+
 val mkRef : GlobRef.t * EInstance.t -> t
 
 val type1 : t

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -25,9 +25,9 @@ module CompactedDecl = Context.Compacted.Declaration
 
 module Internal = struct
 
-let debug_print_constr c = Constr.debug_print EConstr.Unsafe.(to_constr c)
-let debug_print_constr_env env sigma c = Constr.debug_print EConstr.(to_constr sigma c)
-let term_printer = ref debug_print_constr_env
+let debug_print_constr sigma c = Constr.debug_print (EConstr.to_constr sigma c)
+let fallback_printer _env sigma c = debug_print_constr sigma c
+let term_printer = ref fallback_printer
 
 let print_constr_env env sigma t = !term_printer (env:env) sigma (t:Evd.econstr)
 let set_print_constr f = term_printer := f

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -25,75 +25,75 @@ module CompactedDecl = Context.Compacted.Declaration
 
 module Internal = struct
 
-let debug_print_constr sigma c = Constr.debug_print (EConstr.to_constr sigma c)
-let fallback_printer _env sigma c = debug_print_constr sigma c
-let term_printer = ref fallback_printer
+  let debug_print_constr sigma c = Constr.debug_print (EConstr.to_constr sigma c)
+  let fallback_printer _env sigma c = debug_print_constr sigma c
+  let term_printer = ref fallback_printer
 
-let print_constr_env env sigma t = !term_printer (env:env) sigma (t:Evd.econstr)
-let set_print_constr f = term_printer := f
+  let print_constr_env env sigma t = !term_printer (env:env) sigma (t:Evd.econstr)
+  let set_print_constr f = term_printer := f
 
-let pr_var_decl env decl =
-  let open NamedDecl in
-  let sigma = Evd.from_env env in
-  let pbody = match decl with
-    | LocalAssum _ ->  mt ()
-    | LocalDef (_,c,_) ->
+  let pr_var_decl env decl =
+    let open NamedDecl in
+    let sigma = Evd.from_env env in
+    let pbody = match decl with
+      | LocalAssum _ ->  mt ()
+      | LocalDef (_,c,_) ->
         (* Force evaluation *)
         let c = EConstr.of_constr c in
         let pb = print_constr_env env sigma c in
-          (str" := " ++ pb ++ cut () ) in
-  let pt = print_constr_env env sigma (EConstr.of_constr (get_type decl)) in
-  let ptyp = (str" : " ++ pt) in
+        (str" := " ++ pb ++ cut () ) in
+    let pt = print_constr_env env sigma (EConstr.of_constr (get_type decl)) in
+    let ptyp = (str" : " ++ pt) in
     (Id.print (get_id decl) ++ hov 0 (pbody ++ ptyp))
 
-let pr_rel_decl env decl =
-  let open RelDecl in
-  let sigma = Evd.from_env env in
-  let pbody = match decl with
-    | LocalAssum _ -> mt ()
-    | LocalDef (_,c,_) ->
+  let pr_rel_decl env decl =
+    let open RelDecl in
+    let sigma = Evd.from_env env in
+    let pbody = match decl with
+      | LocalAssum _ -> mt ()
+      | LocalDef (_,c,_) ->
         (* Force evaluation *)
         let c = EConstr.of_constr c in
         let pb = print_constr_env env sigma c in
-          (str":=" ++ spc () ++ pb ++ spc ()) in
-  let ptyp = print_constr_env env sigma (EConstr.of_constr (get_type decl)) in
+        (str":=" ++ spc () ++ pb ++ spc ()) in
+    let ptyp = print_constr_env env sigma (EConstr.of_constr (get_type decl)) in
     match get_name decl with
-      | Anonymous -> hov 0 (str"<>" ++ spc () ++ pbody ++ str":" ++ spc () ++ ptyp)
-      | Name id -> hov 0 (Id.print id ++ spc () ++ pbody ++ str":" ++ spc () ++ ptyp)
+    | Anonymous -> hov 0 (str"<>" ++ spc () ++ pbody ++ str":" ++ spc () ++ ptyp)
+    | Name id -> hov 0 (Id.print id ++ spc () ++ pbody ++ str":" ++ spc () ++ ptyp)
 
-let print_named_context env =
-  hv 0 (fold_named_context
-          (fun env d pps ->
-            pps ++ ws 2 ++ pr_var_decl env d)
-          env ~init:(mt ()))
+  let print_named_context env =
+    hv 0 (fold_named_context
+            (fun env d pps ->
+               pps ++ ws 2 ++ pr_var_decl env d)
+            env ~init:(mt ()))
 
-let print_rel_context env =
-  hv 0 (fold_rel_context
-          (fun env d pps -> pps ++ ws 2 ++ pr_rel_decl env d)
-          env ~init:(mt ()))
+  let print_rel_context env =
+    hv 0 (fold_rel_context
+            (fun env d pps -> pps ++ ws 2 ++ pr_rel_decl env d)
+            env ~init:(mt ()))
 
-let print_env env =
-  let sign_env =
-    fold_named_context
-      (fun env d pps ->
-         let pidt =  pr_var_decl env d in
-         (pps ++ fnl () ++ pidt))
-      env ~init:(mt ())
-  in
-  let db_env =
-    fold_rel_context
-      (fun env d pps ->
-         let pnat = pr_rel_decl env d in (pps ++ fnl () ++ pnat))
-      env ~init:(mt ())
-  in
+  let print_env env =
+    let sign_env =
+      fold_named_context
+        (fun env d pps ->
+           let pidt =  pr_var_decl env d in
+           (pps ++ fnl () ++ pidt))
+        env ~init:(mt ())
+    in
+    let db_env =
+      fold_rel_context
+        (fun env d pps ->
+           let pnat = pr_rel_decl env d in (pps ++ fnl () ++ pnat))
+        env ~init:(mt ())
+    in
     (sign_env ++ db_env)
 
-let protect f x =
-  try f x
-  with e -> str "EXCEPTION: " ++ str (Printexc.to_string e)
+  let protect f x =
+    try f x
+    with e -> str "EXCEPTION: " ++ str (Printexc.to_string e)
 
-let print_kconstr env sigma a =
-  protect (fun c -> print_constr_env env sigma c) a
+  let print_kconstr env sigma a =
+    protect (fun c -> print_constr_env env sigma c) a
 
 end
 

--- a/engine/termops.mli
+++ b/engine/termops.mli
@@ -281,6 +281,8 @@ val reference_of_level : Evd.evar_map -> Univ.Level.t -> Libnames.qualid option
 
 open Evd
 
+val pr_global_env : env -> GlobRef.t -> Pp.t
+
 val pr_existential_key : env -> evar_map -> Evar.t -> Pp.t
 
 val evar_suggested_name : env -> evar_map -> Evar.t -> Id.t

--- a/engine/termops.mli
+++ b/engine/termops.mli
@@ -299,10 +299,8 @@ module Internal : sig
 (** NOTE: to print terms you always want to use functions in
    Printer, not these ones which are for very special cases. *)
 
-(** debug printers: print raw form for terms, both with
-   evar-substitution and without.  *)
-val debug_print_constr : constr -> Pp.t
-val debug_print_constr_env : env -> evar_map -> constr -> Pp.t
+(** debug printers: print raw form for terms with evar-substitution.  *)
+val debug_print_constr : evar_map -> constr -> Pp.t
 
 (** Pretty-printer hook: [print_constr_env env sigma c] will pretty
    print c if the pretty printing layer has been linked into the Coq

--- a/interp/implicit_quantifiers.ml
+++ b/interp/implicit_quantifiers.ml
@@ -189,16 +189,13 @@ let implicit_application env ty =
       if Libnames.idset_mem_qualid qid env then None
       else
         let gr = Nametab.locate qid in
-        if Typeclasses.is_class gr then Some (clapp, gr) else None
+        Option.map (fun cl -> cl, clapp) (Typeclasses.class_info gr)
     with Not_found -> None
   in
   match is_class with
   | None -> ty, env
-  | Some ({CAst.loc;v=(id, par, inst)}, gr) ->
+  | Some (c, {CAst.loc;v=(id, par, inst)}) ->
     let avoid = Id.Set.union env (Id.Set.of_list (free_vars_of_constr_expr ty ~bound:env [])) in
-    let env = Global.env () in
-    let sigma = Evd.from_env env in
-    let c = class_info env sigma gr in
     let args, avoid = combine_params avoid par (List.rev c.cl_context) in
     CAst.make ?loc @@ CAppExpl ((id, inst), args), avoid
 

--- a/kernel/constr.ml
+++ b/kernel/constr.ml
@@ -285,6 +285,12 @@ let mkArray (u,t,def,ty) = of_kind @@ Array (u,t,def,ty)
 (* Constructs a primitive float number *)
 let mkFloat f = of_kind @@ Float f
 
+module UnsafeMonomorphic = struct
+  let mkConst = mkConst
+  let mkInd = mkInd
+  let mkConstruct = mkConstruct
+end
+
 (**********************************************************************)
 (*          Non primitive term destructors                            *)
 (**********************************************************************)

--- a/kernel/constr.mli
+++ b/kernel/constr.mli
@@ -129,7 +129,6 @@ val mkApp : constr * constr array -> constr
 val map_puniverses : ('a -> 'b) -> 'a Univ.puniverses -> 'b Univ.puniverses
 
 (** Constructs a Constant.t *)
-val mkConst : Constant.t -> constr
 val mkConstU : pconstant -> constr
 
 (** Constructs a projection application *)
@@ -138,12 +137,10 @@ val mkProj : (Projection.t * constr) -> constr
 (** Inductive types *)
 
 (** Constructs the ith (co)inductive type of the block named kn *)
-val mkInd : inductive -> constr
 val mkIndU : pinductive -> constr
 
 (** Constructs the jth constructor of the ith (co)inductive type of the
    block named kn. *)
-val mkConstruct : constructor -> constr
 val mkConstructU : pconstructor -> constr
 val mkConstructUi : pinductive * int -> constr
 
@@ -644,3 +641,12 @@ val hcons : constr -> constr
 
 val debug_print : constr -> Pp.t
 val debug_print_fix : ('a -> Pp.t) -> ('a, 'a) pfixpoint -> Pp.t
+
+val mkConst : Constant.t -> constr
+[@@deprecated "Use [mkConstU] or if truly needed [UnsafeMonomorphic.mkConst]"]
+
+val mkInd : inductive -> constr
+[@@deprecated "Use [mkIndU] or if truly needed [UnsafeMonomorphic.mkInd]"]
+
+val mkConstruct : constructor -> constr
+[@@deprecated "Use [mkConstructU] or if truly needed [UnsafeMonomorphic.mkConstruct]"]

--- a/kernel/constr.mli
+++ b/kernel/constr.mli
@@ -150,6 +150,12 @@ val mkConstructUi : pinductive * int -> constr
 (** Make a constant, inductive, constructor or variable. *)
 val mkRef : GlobRef.t Univ.puniverses -> constr
 
+module UnsafeMonomorphic : sig
+  val mkConst : Constant.t -> constr
+  val mkInd : inductive -> constr
+  val mkConstruct : constructor -> constr
+end
+
 (** Constructs a destructor of inductive type.
 
     [mkCase ci params p c ac] stand for match [c] as [x] in [I args] return [p] with [ac]

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -303,12 +303,12 @@ let type_of_prim_type _env u (type a) (prim : a CPrimitives.prim_type) = match p
 
 let type_of_int env =
   match env.retroknowledge.Retroknowledge.retro_int63 with
-  | Some c -> mkConst c
+  | Some c -> UnsafeMonomorphic.mkConst c
   | None -> CErrors.user_err Pp.(str"The type int must be registered before this construction can be typechecked.")
 
 let type_of_float env =
   match env.retroknowledge.Retroknowledge.retro_float64 with
-  | Some c -> mkConst c
+  | Some c -> UnsafeMonomorphic.mkConst c
   | None -> CErrors.user_err Pp.(str"The type float must be registered before this construction can be typechecked.")
 
 let type_of_array env u =
@@ -937,37 +937,38 @@ let type_of_prim_const env _u c =
     int_ty ()
 
 let type_of_prim env u t =
+  let open UnsafeMonomorphic in
   let int_ty () = type_of_int env in
   let float_ty () = type_of_float env in
   let array_ty u a = mkApp(type_of_array env u, [|a|]) in
   let bool_ty () =
     match env.retroknowledge.Retroknowledge.retro_bool with
-    | Some ((ind,_),_) -> Constr.mkInd ind
+    | Some ((ind,_),_) -> mkInd ind
     | None -> CErrors.user_err Pp.(str"The type bool must be registered before this primitive.")
   in
   let compare_ty () =
     match env.retroknowledge.Retroknowledge.retro_cmp with
-    | Some ((ind,_),_,_) -> Constr.mkInd ind
+    | Some ((ind,_),_,_) -> mkInd ind
     | None -> CErrors.user_err Pp.(str"The type compare must be registered before this primitive.")
   in
   let f_compare_ty () =
     match env.retroknowledge.Retroknowledge.retro_f_cmp with
-    | Some ((ind,_),_,_,_) -> Constr.mkInd ind
+    | Some ((ind,_),_,_,_) -> mkInd ind
     | None -> CErrors.user_err Pp.(str"The type float_comparison must be registered before this primitive.")
   in
   let f_class_ty () =
     match env.retroknowledge.Retroknowledge.retro_f_class with
-    | Some ((ind,_),_,_,_,_,_,_,_,_) -> Constr.mkInd ind
+    | Some ((ind,_),_,_,_,_,_,_,_,_) -> mkInd ind
     | None -> CErrors.user_err Pp.(str"The type float_class must be registered before this primitive.")
   in
   let pair_ty fst_ty snd_ty =
     match env.retroknowledge.Retroknowledge.retro_pair with
-    | Some (ind,_) -> Constr.mkApp(Constr.mkInd ind, [|fst_ty;snd_ty|])
+    | Some (ind,_) -> Constr.mkApp(mkInd ind, [|fst_ty;snd_ty|])
     | None -> CErrors.user_err Pp.(str"The type pair must be registered before this primitive.")
   in
   let carry_ty int_ty =
     match env.retroknowledge.Retroknowledge.retro_carry with
-    | Some ((ind,_),_) -> Constr.mkApp(Constr.mkInd ind, [|int_ty|])
+    | Some ((ind,_),_) -> Constr.mkApp(mkInd ind, [|int_ty|])
     | None -> CErrors.user_err Pp.(str"The type carry must be registered before this primitive.")
   in
   let open CPrimitives in

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -937,38 +937,38 @@ let type_of_prim_const env _u c =
     int_ty ()
 
 let type_of_prim env u t =
-  let open UnsafeMonomorphic in
+  let module UM = UnsafeMonomorphic in
   let int_ty () = type_of_int env in
   let float_ty () = type_of_float env in
   let array_ty u a = mkApp(type_of_array env u, [|a|]) in
   let bool_ty () =
     match env.retroknowledge.Retroknowledge.retro_bool with
-    | Some ((ind,_),_) -> mkInd ind
+    | Some ((ind,_),_) -> UM.mkInd ind
     | None -> CErrors.user_err Pp.(str"The type bool must be registered before this primitive.")
   in
   let compare_ty () =
     match env.retroknowledge.Retroknowledge.retro_cmp with
-    | Some ((ind,_),_,_) -> mkInd ind
+    | Some ((ind,_),_,_) -> UM.mkInd ind
     | None -> CErrors.user_err Pp.(str"The type compare must be registered before this primitive.")
   in
   let f_compare_ty () =
     match env.retroknowledge.Retroknowledge.retro_f_cmp with
-    | Some ((ind,_),_,_,_) -> mkInd ind
+    | Some ((ind,_),_,_,_) -> UM.mkInd ind
     | None -> CErrors.user_err Pp.(str"The type float_comparison must be registered before this primitive.")
   in
   let f_class_ty () =
     match env.retroknowledge.Retroknowledge.retro_f_class with
-    | Some ((ind,_),_,_,_,_,_,_,_,_) -> mkInd ind
+    | Some ((ind,_),_,_,_,_,_,_,_,_) -> UM.mkInd ind
     | None -> CErrors.user_err Pp.(str"The type float_class must be registered before this primitive.")
   in
   let pair_ty fst_ty snd_ty =
     match env.retroknowledge.Retroknowledge.retro_pair with
-    | Some (ind,_) -> Constr.mkApp(mkInd ind, [|fst_ty;snd_ty|])
+    | Some (ind,_) -> Constr.mkApp(UM.mkInd ind, [|fst_ty;snd_ty|])
     | None -> CErrors.user_err Pp.(str"The type pair must be registered before this primitive.")
   in
   let carry_ty int_ty =
     match env.retroknowledge.Retroknowledge.retro_carry with
-    | Some ((ind,_),_) -> Constr.mkApp(mkInd ind, [|int_ty|])
+    | Some ((ind,_),_) -> Constr.mkApp(UM.mkInd ind, [|int_ty|])
     | None -> CErrors.user_err Pp.(str"The type carry must be registered before this primitive.")
   in
   let open CPrimitives in

--- a/library/globnames.ml
+++ b/library/globnames.ml
@@ -9,7 +9,6 @@
 (************************************************************************)
 
 open Names
-open Constr
 
 open GlobRef
 
@@ -53,12 +52,6 @@ let canonical_gr = function
   | IndRef (kn,i) -> IndRef(MutInd.make1(MutInd.canonical kn),i)
   | ConstructRef ((kn,i),j )-> ConstructRef((MutInd.make1(MutInd.canonical kn),i),j)
   | VarRef id -> VarRef id
-
-let printable_constr_of_global = function
-  | VarRef id -> mkVar id
-  | ConstRef sp -> mkConst sp
-  | ConstructRef sp -> mkConstruct sp
-  | IndRef sp -> mkInd sp
 
 (* Extended global references *)
 

--- a/library/globnames.mli
+++ b/library/globnames.mli
@@ -27,10 +27,6 @@ val destConstructRef : GlobRef.t -> constructor
 val subst_global : substitution -> GlobRef.t -> GlobRef.t * constr Univ.univ_abstracted option
 val subst_global_reference : substitution -> GlobRef.t -> GlobRef.t
 
-(** This constr is not safe to be typechecked, universe polymorphism is not
-    handled here: just use for printing *)
-val printable_constr_of_global : GlobRef.t -> constr
-
 (** {6 Extended global references } *)
 
 type abbreviation = KerName.t

--- a/plugins/derive/derive.ml
+++ b/plugins/derive/derive.ml
@@ -19,7 +19,6 @@ let start_deriving f suchthat name : Declare.Proof.t =
 
   let env = Global.env () in
   let sigma = Evd.from_env env in
-  let poly = false in
   let kind = Decls.(IsDefinition Definition) in
 
   (* create a sort variable for the type of [f] *)
@@ -40,7 +39,7 @@ let start_deriving f suchthat name : Declare.Proof.t =
                 TNil sigma))))))
   in
 
-  let info = Declare.Info.make ~poly ~kind () in
+  let info = Declare.Info.make ~poly:false ~kind () in
   let lemma = Declare.Proof.start_derive ~name ~f ~info goals in
   Declare.Proof.map lemma ~f:(fun p ->
       Util.pi1 @@ Proof.run_tactic env Proofview.(tclFOCUS 1 2 shelve) p)

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -1010,7 +1010,11 @@ let extract_fixpoint env sg vkn (fi,ti,ci) =
   let kns = Array.to_list vkn in
   current_fixpoints := kns;
   (* for replacing recursive calls [Rel ..] by the corresponding [Const]: *)
-  let sub = List.rev_map EConstr.mkConst kns in
+  let sg, sub = CList.fold_left_map (fun sg con ->
+      Evd.fresh_global env sg (ConstRef con))
+      sg
+      (List.rev kns)
+  in
   for i = 0 to n-1 do
     if info_of_family (sort_of env sg ti.(i)) != Logic then
       try

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -25,6 +25,9 @@ open Libnames
 open Context.Rel.Declaration
 module RelDecl = Context.Rel.Declaration
 
+(* funind does not support univ poly *)
+open UnsafeMonomorphic
+
 let list_chop ?(msg = "") n l =
   try List.chop n l with Failure msg' -> failwith (msg ^ msg')
 

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -2054,7 +2054,7 @@ let make_graph (f_ref : GlobRef.t) =
         CErrors.user_err
           Pp.(
             str "Cannot find "
-            ++ Printer.pr_leconstr_env env sigma (EConstr.mkConst c))
+            ++ Termops.pr_global_env env (ConstRef c))
     | _ -> CErrors.user_err Pp.(str "Not a function reference")
   in
   match Global.body_of_constant_body Library.indirect_accessor c_body with

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -1133,7 +1133,7 @@ let prove_fun_complete funcs graphs schemes lemmas_types_infos i :
               in
               tclTHENLIST
                 [ tclMAP Simple.intro ids
-                ; Equality.rewriteLR (mkConst eq_lemma)
+                ; Equality.rewriteLR (UnsafeMonomorphic.mkConst eq_lemma)
                 ; (* Don't forget to $\zeta$ normlize the term since the principles
                      have been $\zeta$-normalized *)
                   reduce
@@ -1444,7 +1444,7 @@ let derive_correctness (funs : Constr.pconstant list) (graphs : inductive list)
     (fun () ->
       let env = Global.env () in
       let evd = ref (Evd.from_env env) in
-      let graphs_constr = Array.map mkInd graphs in
+      let graphs_constr = Array.map UnsafeMonomorphic.mkInd graphs in
       let lemmas_types_infos =
         Util.Array.map2_i
           (fun i f_constr graph ->

--- a/plugins/funind/indfun.ml
+++ b/plugins/funind/indfun.ml
@@ -57,7 +57,7 @@ let functional_induction with_clean c princl pat =
               | None ->
                 user_err
                   ( str "Cannot find induction information on "
-                  ++ Printer.pr_leconstr_env (pf_env gl) sigma (mkConst c') )
+                  ++ Termops.pr_global_env (pf_env gl) (ConstRef c') )
             in
             match elimination_sort_of_goal gl with
             | InSProp -> finfo.sprop_lemma
@@ -88,7 +88,7 @@ let functional_induction with_clean c princl pat =
                 | None ->
                   user_err
                     ( str "Cannot find induction principle for "
-                    ++ Printer.pr_leconstr_env (pf_env gl) sigma (mkConst c') )
+                    ++ Termops.pr_global_env (pf_env gl) (ConstRef c') )
               in
               Evd.fresh_global (pf_env gl) (project gl) princ_ref
           in

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -211,12 +211,12 @@ let discharge_Function finfos = Some finfos
 
 let pr_ocst env sigma c =
   Option.fold_right
-    (fun v acc -> Printer.pr_lconstr_env env sigma (mkConst v))
+    (fun v acc -> Printer.pr_global_env (Termops.vars_of_env env) (ConstRef v))
     c (mt ())
 
 let pr_info env sigma f_info =
   str "function_constant := "
-  ++ Printer.pr_lconstr_env env sigma (mkConst f_info.function_constant)
+  ++ Printer.pr_global_env (Termops.vars_of_env env) (ConstRef f_info.function_constant)
   ++ fnl ()
   ++ str "function_constant_type := "
   ++ ( try
@@ -240,7 +240,7 @@ let pr_info env sigma f_info =
   ++ fnl () ++ str "prop_lemma := "
   ++ pr_ocst env sigma f_info.prop_lemma
   ++ fnl () ++ str "graph_ind := "
-  ++ Printer.pr_lconstr_env env sigma (mkInd f_info.graph_ind)
+  ++ Printer.pr_global_env (Termops.vars_of_env env) (IndRef f_info.graph_ind)
   ++ fnl ()
 
 let pr_table env sigma tb =

--- a/plugins/funind/invfun.ml
+++ b/plugins/funind/invfun.ml
@@ -17,6 +17,9 @@ open Tactics
 open Tacticals
 open Indfun_common
 
+(* funind doesn't support univ poly *)
+open UnsafeMonomorphic
+
 (***********************************************)
 
 (* [revert_graph kn post_tac hid] transforme an hypothesis [hid] having type Ind(kn,num) t1 ... tn res

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -1438,7 +1438,8 @@ let open_new_goal ~lemma build_proof sigma using_lemmas ref_ goal_name
       | GlobRef.ConstRef c -> is_opaque_constant c
       | _ -> anomaly ~label:"equation_lemma" (Pp.str "not a constant.")
     in
-    let lemma = mkConst (Names.Constant.make1 (Lib.make_kn na)) in
+    (* funind does not support univ poly *)
+    let lemma = UnsafeMonomorphic.mkConst (Names.Constant.make1 (Lib.make_kn na)) in
     ref_ := Value (EConstr.Unsafe.to_constr lemma);
     let lid = ref [] in
     let h_num = ref (-1) in

--- a/plugins/ltac/comRewrite.ml
+++ b/plugins/ltac/comRewrite.ml
@@ -66,7 +66,7 @@ module PropGlobal = struct
     fun () -> Option.get (TC.class_info (Lazy.force r))
 
   let proper_proj () =
-    mkConst (Option.get (List.hd (proper_class ()).TC.cl_projs).TC.meth_const)
+    UnsafeMonomorphic.mkConst (Option.get (List.hd (proper_class ()).TC.cl_projs).TC.meth_const)
 
 end
 

--- a/plugins/ltac/comRewrite.ml
+++ b/plugins/ltac/comRewrite.ml
@@ -63,10 +63,10 @@ module PropGlobal = struct
 
   let proper_class =
     let r = lazy (find_reference morphisms "Proper") in
-    fun env sigma -> TC.class_info env sigma (Lazy.force r)
+    fun () -> Option.get (TC.class_info (Lazy.force r))
 
-  let proper_proj env sigma =
-    mkConst (Option.get (List.hd (proper_class env sigma).TC.cl_projs).TC.meth_const)
+  let proper_proj () =
+    mkConst (Option.get (List.hd (proper_class ()).TC.cl_projs).TC.meth_const)
 
 end
 
@@ -148,7 +148,7 @@ let proper_projection env sigma r ty =
   let ctx, inst = decompose_prod_decls sigma ty in
   let mor, args = destApp sigma inst in
   let instarg = mkApp (r, rel_vect 0 (List.length ctx)) in
-  let app = mkApp (PropGlobal.proper_proj env sigma,
+  let app = mkApp (PropGlobal.proper_proj (),
                   Array.append args [| instarg |]) in
     it_mkLambda_or_LetIn app ctx
 
@@ -214,7 +214,7 @@ let add_morphism_as_parameter atts m n : unit =
   let cst = Declare.declare_constant ~name:instance_id ~kind (Declare.ParameterEntry pe) in
   let cst = GlobRef.ConstRef cst in
   Classes.Internal.add_instance
-    (PropGlobal.proper_class env evd) Hints.empty_hint_info atts.locality cst;
+    (PropGlobal.proper_class ()) Hints.empty_hint_info atts.locality cst;
   declare_projection n instance_id cst
 
 let add_morphism_interactive atts ~tactic m n : Declare.Proof.t =
@@ -227,7 +227,7 @@ let add_morphism_interactive atts ~tactic m n : Declare.Proof.t =
   let kind = Decls.(IsDefinition Instance) in
   let hook { Declare.Hook.S.dref; _ } = dref |> function
     | GlobRef.ConstRef cst ->
-      Classes.Internal.add_instance (PropGlobal.proper_class env evd) Hints.empty_hint_info
+      Classes.Internal.add_instance (PropGlobal.proper_class ()) Hints.empty_hint_info
         atts.locality (GlobRef.ConstRef cst);
       declare_projection n instance_id (GlobRef.ConstRef cst)
     | _ -> assert false

--- a/plugins/ring/ring.ml
+++ b/plugins/ring/ring.ml
@@ -149,9 +149,11 @@ let decl_constant name univs c =
   let () = DeclareUctx.declare_universe_context ~poly:false univs in
   let types = (Typeops.infer (Global.env ()) c).uj_type in
   let univs = UState.Monomorphic_entry Univ.ContextSet.empty, UnivNames.empty_binders in
-  mkConst(declare_constant ~name
-            ~kind:Decls.(IsProof Lemma)
-            (DefinitionEntry (definition_entry ~opaque:true ~types ~univs c)))
+  (* UnsafeMonomorphic: we always do poly:false *)
+  UnsafeMonomorphic.mkConst
+    (declare_constant ~name
+       ~kind:Decls.(IsProof Lemma)
+       (DefinitionEntry (definition_entry ~opaque:true ~types ~univs c)))
 
 let decl_constant na suff univs c =
   let na = Namegen.next_global_ident_away (Nameops.add_suffix na suff) Id.Set.empty in

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -402,7 +402,7 @@ let pirrel_rewrite ?(under=false) ?(map_redex=id_map_redex) pred rdx rdx_ty new_
       let mp,l = KerName.repr (Constant.canonical elim) in
       let l' = Label.of_id (Nameops.add_suffix (Label.to_id l) "_r")  in
       let c1' = Global.constant_of_delta_kn (Constant.canonical (Constant.make2 mp l')) in
-      sigma, EConstr.of_constr (mkConst c1')
+      Evd.fresh_global env sigma (ConstRef c1')
   in
   (* We check the proof is well typed. We assume that the type of [elim] is of
      the form [forall (A : Type) (x : A) (P : A -> Type@{s}), T] s.t. the only

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -503,7 +503,7 @@ let filter_upat_FO env sigma i0 f n u fpats =
   | KpatLet -> isLetIn sigma f
   | KpatLam -> isLambda sigma f
   | KpatRigid -> isRigid sigma f
-  | KpatProj pc -> eq_constr sigma f (mkConst pc) || eq_prim_proj env sigma pc f
+  | KpatProj pc -> isRefX env sigma (ConstRef pc) f || eq_prim_proj env sigma pc f
   | KpatFlex -> i0 := n; true in
   if ok then begin if !i0 < np then i0 := np; (u, np) :: fpats end else fpats
 

--- a/pretyping/cbv.ml
+++ b/pretyping/cbv.ml
@@ -257,9 +257,9 @@ module VNativeEntries =
       let (ct,cf) = get_bool_constructors env in
       CONSTR(Univ.in_punivs (if b then ct else cf), [||])
 
-    let int_ty env = VAL(0, mkConst @@ get_int_type env)
+    let int_ty env = VAL(0, UnsafeMonomorphic.mkConst @@ get_int_type env)
 
-    let float_ty env = VAL(0, mkConst @@ get_float_type env)
+    let float_ty env = VAL(0, UnsafeMonomorphic.mkConst @@ get_float_type env)
 
     let mkCarry env b e =
       let (c0,c1) = get_carry_constructors env in

--- a/pretyping/coercionops.ml
+++ b/pretyping/coercionops.ml
@@ -269,18 +269,14 @@ let lookup_path_to_fun_from env sigma s =
 let lookup_path_to_sort_from env sigma s =
   apply_on_class_of env sigma s lookup_path_to_sort_from_class
 
-let mkNamed = let open GlobRef in function
-  | ConstRef c -> EConstr.mkConst c
-  | VarRef v -> EConstr.mkVar v
-  | ConstructRef c -> EConstr.mkConstruct c
-  | IndRef i -> EConstr.mkInd i
-
 let get_coercion_constructor env coe =
   let evd = Evd.from_env env in
-  let red x = fst (Reductionops.whd_all_stack env evd x) in
-  match EConstr.kind evd (red (mkNamed coe.coe_value)) with
+  let evd, c = Evd.fresh_global env evd coe.coe_value in
+  let c = fst (Reductionops.whd_all_stack env evd c) in
+  match EConstr.kind evd c with
   | Constr.Construct (c, _) ->
-      c, Inductiveops.constructor_nrealargs env c -1
+    (* we don't return the modified evd as we drop the universes *)
+    c, Inductiveops.constructor_nrealargs env c -1
   | _ -> raise Not_found
 
 let lookup_pattern_path_between env (s,t) =

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -356,7 +356,7 @@ let make_project env sigma ind pred c branches ps =
          not (has_dependent_elim specif) then
       user_err
         Pp.(str"Dependent case analysis not allowed" ++
-              str" on inductive type " ++ Termops.Internal.print_constr_env env sigma (mkInd ind) ++ str ".")
+              str" on inductive type " ++ Termops.pr_global_env env (IndRef ind) ++ str ".")
   in
   let branch = branches.(0) in
   let ctx, br = decompose_lambda_n_decls sigma mip.mind_consnrealdecls.(0) branch in

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -548,6 +548,8 @@ open Primred
 module CNativeEntries =
 struct
 
+  open UnsafeMonomorphic
+
   type elem = EConstr.t
   type args = EConstr.t array
   type evd = evar_map

--- a/pretyping/structures.ml
+++ b/pretyping/structures.ml
@@ -302,7 +302,7 @@ let make env sigma ref =
     try Structure.find indsp
     with Not_found ->
       error_not_structure ref
-        (str "Could not find the record or structure " ++ Termops.Internal.print_constr_env env sigma (EConstr.mkInd indsp)) in
+        (str "Could not find the record or structure " ++ Termops.pr_global_env env (IndRef indsp)) in
   let ntrue_projs = List.count (fun { Structure.proj_true = x } -> x) s.Structure.projections in
   if s.Structure.nparams + ntrue_projs > Array.length args then
     error_not_structure ref (str "Got too few arguments to the record or structure constructor");

--- a/pretyping/typeclasses.mli
+++ b/pretyping/typeclasses.mli
@@ -63,7 +63,12 @@ type instance = {
   is_impl: GlobRef.t;
 }
 
-val instances : env -> evar_map -> GlobRef.t -> instance list
+val instances : GlobRef.t -> instance list option
+(** [None] if not a class *)
+
+val instances_exn : env -> evar_map -> GlobRef.t -> instance list
+(** raise [TypeClassError] if not a class *)
+
 val typeclasses : unit -> typeclass list
 val all_instances : unit -> instance list
 
@@ -72,8 +77,11 @@ val load_class : typeclass -> unit
 val load_instance : instance -> unit
 val remove_instance : instance -> unit
 
-val class_info : env -> evar_map -> GlobRef.t -> typeclass (** raises a UserError if not a class *)
+val class_info : GlobRef.t -> typeclass option
+(** [None] if not a class *)
 
+val class_info_exn : env -> evar_map -> GlobRef.t -> typeclass
+(** raise [TypeClassError] if not a class *)
 
 (** These raise a UserError if not a class.
     Caution: the typeclass structures is not instantiated w.r.t. the universe instance.

--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -201,7 +201,10 @@ struct
       let a = ca.(len - 1) in
       let ca = Array.sub ca 0 (len - 1) in
       Some (DApp, [mkApp (f, ca); a])
-    | Proj (p,c) -> pat_of_constr (mkApp (mkConst (Projection.constant p), [|c|]))
+    | Proj (p,c) ->
+      (* UnsafeMonomorphic is fine because the term will only be used
+         by pat_of_constr which ignores universes *)
+      pat_of_constr (mkApp (UnsafeMonomorphic.mkConst (Projection.constant p), [|c|]))
     | Int i -> Some (DInt i, [])
     | Float f -> Some (DFloat f, [])
     | Array (_u,t,def,ty) ->

--- a/tactics/btermdn.ml
+++ b/tactics/btermdn.ml
@@ -73,7 +73,8 @@ let decomp sigma t =
       (* Hack: fake evar to generate [Everything] in the functions below *)
       let hole = mkEvar (Evar.unsafe_of_int (-1), SList.empty) in
       let params = List.make (Projection.npars p) hole in
-      (mkConst (Projection.constant p), params @ c :: acc)
+      (* UnsafeMonomorphic: universes are ignored by the only user *)
+      (UnsafeMonomorphic.mkConst (Projection.constant p), params @ c :: acc)
     | Cast (c1,_,_) -> decrec acc c1
     | _ -> (c,acc)
   in

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -260,17 +260,21 @@ and e_my_find_search db_list local_db secvars hdc complete only_classes env sigm
   let prods, concl = EConstr.decompose_prod_decls sigma concl0 in
   let nprods = List.length prods in
   let allowed_evars =
+    let all = Evarsolve.AllowedEvars.all in
     try
       match hdc with
       | Some (hd,_) when only_classes ->
-         let cl = Typeclasses.class_info env sigma hd in
-         if cl.cl_strict then
-          let undefined = lazy (Evarutil.undefined_evars_of_term sigma concl) in
-          let allowed evk = not (Evar.Set.mem evk (Lazy.force undefined)) in
-          Evarsolve.AllowedEvars.from_pred allowed
-         else Evarsolve.AllowedEvars.all
-      | _ -> Evarsolve.AllowedEvars.all
-    with e when CErrors.noncritical e -> Evarsolve.AllowedEvars.all
+        begin match Typeclasses.class_info hd with
+        | Some cl ->
+          if cl.cl_strict then
+            let undefined = lazy (Evarutil.undefined_evars_of_term sigma concl) in
+            let allowed evk = not (Evar.Set.mem evk (Lazy.force undefined)) in
+            Evarsolve.AllowedEvars.from_pred allowed
+          else all
+        | None -> all
+        end
+      | _ -> all
+    with e when CErrors.noncritical e -> all
   in
   let tac_of_hint =
     fun (flags, h) ->

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -1381,6 +1381,10 @@ let inject_if_homogenous_dependent_pair ty =
     let new_eq_args = [|pf_get_type_of gl ar1.(3);ar1.(3);ar2.(3)|] in
     let inj2 = lib_ref "core.eqdep_dec.inj_pair2" in
     find_scheme (!eq_dec_scheme_kind_name()) ind >>= fun c ->
+    let c = if Global.is_polymorphic (ConstRef c)
+      then CErrors.anomaly Pp.(str "Unexpected univ poly in inject_if_homogenous_dependent_pair")
+      else UnsafeMonomorphic.mkConst c
+    in
     (* cut with the good equality and prove the requested goal *)
     tclTHENLIST
       [
@@ -1391,7 +1395,7 @@ let inject_if_homogenous_dependent_pair ty =
           [clear [destVar sigma hyp];
            Tacticals.pf_constr_of_global inj2 >>= fun inj2 ->
            Tactics.exact_check
-             (mkApp(inj2,[|ar1.(0);mkConst c;ar1.(1);ar1.(2);ar1.(3);ar2.(3);hyp|]))
+             (mkApp(inj2,[|ar1.(0);c;ar1.(1);ar1.(2);ar1.(3);ar2.(3);hyp|]))
           ])]
   with Exit ->
     Proofview.tclUNIT ()

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -265,7 +265,7 @@ end) = struct
     fun () -> Option.get (TC.class_info (Lazy.force r))
 
   let proper_proj () =
-    mkConst (Option.get (List.hd (proper_class ()).TC.cl_projs).TC.meth_const)
+    UnsafeMonomorphic.mkConst (Option.get (List.hd (proper_class ()).TC.cl_projs).TC.meth_const)
 
   let proper_type env (sigma,cstrs) =
     let l = (proper_class ()).TC.cl_impl in
@@ -966,10 +966,14 @@ let fold_match ?(force=false) env sigma c =
       raise Not_found
   in
   let app =
+    let sk = if Global.is_polymorphic (ConstRef sk)
+      then CErrors.anomaly Pp.(str "Unexpected univ poly in Rewrite.fold_match")
+      else UnsafeMonomorphic.mkConst sk
+    in
     let ind, args = Inductiveops.find_mrectype env sigma cty in
     let pars, args = List.chop ci.ci_npar args in
     let meths = Array.to_list brs in
-      applist (mkConst sk, pars @ [pred] @ meths @ args @ [c])
+      applist (sk, pars @ [pred] @ meths @ args @ [c])
   in
     sk, app
 

--- a/test-suite/output/NumberNotationsUnivPoly.out
+++ b/test-suite/output/NumberNotationsUnivPoly.out
@@ -1,0 +1,19 @@
+0
+     : B ?a
+where
+?a : [ |- A]
+1
+     : B ?a
+where
+?a : [ |- A]
+2
+     : B ?a
+where
+?a : [ |- A]
+foo@{v v'} =
+fun (v : A@{v}) (v' : A@{v'}) => (0 : B@{v} v, 1 : B@{v'} v')
+     : forall (v : A@{v}) (v' : A@{v'}), B@{v} v * B@{v'} v'
+(* v v' |= v <= prod.u0
+           v' <= prod.u1 *)
+
+Arguments foo v v'

--- a/test-suite/output/NumberNotationsUnivPoly.v
+++ b/test-suite/output/NumberNotationsUnivPoly.v
@@ -1,0 +1,21 @@
+Set Universe Polymorphism.
+Axiom A : Type.
+
+Inductive B : A -> Type :=
+| x {a} : B a
+| y {a} : B a -> B a
+.
+
+Number Notation B Nat.of_num_uint Nat.to_num_uint
+  (via nat mapping [[x] => O, [y] => S]) : nat_scope.
+
+Check 0.
+Check 1.
+Check 2.
+
+(* check it generates independent univs *)
+Definition foo@{v v' | v <= prod.u0, v' <= prod.u1} :=
+  fun (v:A@{v}) (v':A@{v'}) => (x : B v, y x : B v').
+
+Set Printing Universes.
+Print foo.

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1004,7 +1004,7 @@ let declare_obligation prg obl ~uctx ~types ~body =
         Some
           (TermObl
              (it_mkLambda_or_LetIn_or_clean
-                (mkApp (mkConst constant, args))
+                (mkApp (UnsafeMonomorphic.mkConst constant, args))
                 ctx))
     in
     (true, {obl with obl_body = body}, [GlobRef.ConstRef constant])

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -2108,7 +2108,9 @@ let finish_derived ~f ~name ~entries =
   let f_kind = Decls.(IsDefinition Definition) in
   let f_def = DefinitionEntry f_def in
   let f_kn = declare_constant ~name:f ~kind:f_kind f_def ~typing_flags:None in
-  let f_kn_term = Constr.mkConst f_kn in
+  (* Derive does not support univ poly *)
+  let () = assert (not (Global.is_polymorphic (ConstRef f_kn))) in
+  let f_kn_term = Constr.UnsafeMonomorphic.mkConst f_kn in
   (* In the type and body of the proof of [suchthat] there can be
      references to the variable [f]. It needs to be replaced by
      references to the constant [f] declared above. This substitution

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1985,7 +1985,7 @@ end = struct
     | _ ->
       CErrors.anomaly
         Pp.(str "Not a proof by induction: " ++
-            Termops.Internal.debug_print_constr (EConstr.of_constr t) ++ str ".")
+            Constr.debug_print t ++ str ".")
 
   let declare_mutdef ~uctx ~pinfo pe i CInfo.{ name; impargs; typ; _} =
     let { Proof_info.info; compute_guard; _ } = pinfo in

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -304,8 +304,7 @@ let warn_cannot_build_congruence =
 
 let declare_congr_scheme ind =
   let env = Global.env () in
-  let sigma = Evd.from_env env in
-  if Hipattern.is_equality_type env sigma (EConstr.of_constr (Constr.mkInd ind)) (* FIXME *) then begin
+  if Hipattern.is_inductive_equality env ind then begin
     if
       try Coqlib.check_required_library Coqlib.logic_module_name; true
       with e when CErrors.noncritical e -> false

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -1127,6 +1127,5 @@ let print_all_instances () =
 
 let print_instances r =
   let env = Global.env () in
-  let sigma = Evd.from_env env in
-  let inst = instances env sigma r in
-    prlist_with_sep fnl (pr_instance env) inst
+  let inst = instances_exn env (Evd.from_env env) r in
+  prlist_with_sep fnl (pr_instance env) inst

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -1002,25 +1002,6 @@ let print_notation env sigma entry raw_ntn =
       ++ str ".")
   with Not_found -> error_print_notation_not_found entry raw_ntn
 
-let print_opaque_name env sigma qid =
-  let open GlobRef in
-  match Nametab.global qid with
-    | ConstRef cst ->
-      let cb = Global.lookup_constant cst in
-      if Declareops.constant_has_body cb then
-        print_constant_with_infos cst None
-      else
-        user_err Pp.(str "Not a defined constant.")
-    | IndRef (sp,_) ->
-      print_inductive sp None
-    | ConstructRef cstr as gr ->
-      let ty, ctx = Typeops.type_of_global_in_context env gr in
-      let ty = EConstr.of_constr ty in
-      let open EConstr in
-      print_typed_value_in_env env sigma (mkConstruct cstr, ty)
-    | VarRef id ->
-      env |> lookup_named id |> print_named_decl env sigma
-
 let print_about_any ?loc env sigma k udecl =
   maybe_error_reject_univ_decl k udecl;
   match k with

--- a/vernac/prettyp.mli
+++ b/vernac/prettyp.mli
@@ -52,7 +52,6 @@ val print_notation : env -> Evd.evar_map
   -> Constrexpr.notation_entry
   -> string
   -> Pp.t
-val print_opaque_name : env -> Evd.evar_map -> qualid -> Pp.t
 val print_about : env -> Evd.evar_map -> qualid Constrexpr.or_by_notation ->
   UnivNames.univ_name_list option -> Pp.t
 val print_impargs : qualid Constrexpr.or_by_notation -> Pp.t

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2181,10 +2181,11 @@ let vernac_print ~pstate =
     dump_global qid;
     Prettyp.print_impargs qid
   | PrintAssumptions (o,t,r) ->
-      (* Prints all the axioms and section variables used by a term *)
+    (* Prints all the axioms and section variables used by a term *)
+      let env = Global.env () in
       let gr = smart_global r in
-      let cstr = Globnames.printable_constr_of_global gr in
-      let st = Conv_oracle.get_transp_state (Environ.oracle (Global.env())) in
+      let cstr, _ = UnivGen.fresh_global_instance env gr in
+      let st = Conv_oracle.get_transp_state (Environ.oracle env) in
       let nassums =
         Assumptions.assumptions st ~add_opaque:o ~add_transparent:t gr cstr in
       Printer.pr_assumptionset env sigma nassums


### PR DESCRIPTION
Mainly:
- deprecate `Constr.mkInd` `EConstr.mkConst` etc in favour of more explicit `Constr.UnsafeMonomorphic.mkInd` etc 
- avoid using the UnsafeMonomorphic functions when reasonably easy to do
- fix https://github.com/coq/coq/issues/17225 (number notations vs univ poly)

Note that changing `print_constr (mkConst foo)` to `pr_global (ConstRef foo)` can change the printing if there is a notation, eg printing `O` instead of `0`. If we care we can write a `pr_global_as_constr` which avoids generating bad constrs by going directly to glob_constr.

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/435
- https://github.com/mattam82/Coq-Equations/pull/540

Backwards compatible:
- https://github.com/unicoq/unicoq/pull/80
- https://github.com/coq-community/paramcoq/pull/107
- https://github.com/ejgallego/coq-serapi/pull/322
- https://github.com/MetaCoq/metacoq/pull/861