### PR TITLE
SSR: don't assert false in saturate given a sort

### DIFF
--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -789,7 +789,7 @@ let saturate ?(beta=false) ?(bi_types=false) env sigma c ?(ty=Retyping.get_type_
       loop (EConstr.Vars.subst1 x tgt) ((m - n,x,argty) :: args) sigma (n-1)
   | CastType (t, _) -> loop t args sigma n
   | LetInType (_, v, _, t) -> loop (EConstr.Vars.subst1 v t) args sigma n
-  | SortType _ -> assert false
+  | SortType _ -> raise NotEnoughProducts
   | AtomicType _ ->
       let ty =  (* FIXME *)
         (Reductionops.whd_all env sigma) ty in

--- a/test-suite/bugs/bug_17186.v
+++ b/test-suite/bugs/bug_17186.v
@@ -1,0 +1,10 @@
+From Coq Require Import ssreflect.
+
+Axiom blah : forall (P : unit -> Type) (n : unit), P n.
+
+Lemma t (r := True): True.
+Fail elim /blah: r.
+(* Anomaly
+"File "plugins/ssr/ssrcommon.ml", line 792, characters 18-24: Assertion failed."
+Please report at http://coq.inria.fr/bugs/. *)
+Abort.


### PR DESCRIPTION
Fix #17186
