### PR TITLE
Simplify the handling of metas in Clenv refiner

### DIFF
--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -678,15 +678,13 @@ let type_case_branches_with_names env sigma indspec p c =
   let args = List.map EConstr.Unsafe.to_constr args in
   let (mib,mip as specif) = Inductive.lookup_mind_specif env (fst ind) in
   let nparams = mib.mind_nparams in
-  let (params,realargs) = List.chop nparams args in
+  let (params, _) = List.chop nparams args in
   let lbrty = Inductive.build_branches_type ind specif params p in
   let lbrty = Array.map EConstr.of_constr lbrty in
-  (* Build case type *)
-  let conclty = lambda_appvect_decls (mip.mind_nrealdecls+1) p (Array.of_list (realargs@[c])) in
   (* Adjust names *)
   if is_elim_predicate_explicitly_dependent env sigma p (ind,params) then
-    (set_pattern_names env sigma (fst ind) lbrty, conclty)
-  else (lbrty, conclty)
+    (set_pattern_names env sigma (fst ind) lbrty)
+  else lbrty
 
 (* Type of Case predicates *)
 let arity_of_case_predicate env (ind,params) dep k =

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -16,7 +16,6 @@ open Term
 open Constr
 open Vars
 open Context
-open Termops
 open Declarations
 open Declareops
 open Environ
@@ -614,77 +613,6 @@ let find_coinductive env sigma c =
         (ind, l)
     | _ -> raise Not_found
 
-
-(***********************************************)
-(* find appropriate names for pattern variables. Useful in the Case
-   and Inversion (case_then_using et case_nodep_then_using) tactics. *)
-
-let is_predicate_explicitly_dep env sigma pred arsign =
-  let rec srec env pval arsign =
-    let pv' = whd_all env sigma pval in
-    match EConstr.kind sigma pv', arsign with
-      | Lambda (na,t,b), (LocalAssum _)::arsign ->
-          srec (push_rel_assum (na, t) env) b arsign
-      | Lambda (na,_,t), _ ->
-
-       (* The following code has an impact on the introduction names
-          given by the tactics "case" and "inversion": when the
-          elimination is not dependent, "case" uses Anonymous for
-          inductive types in Prop and names created by mkProd_name for
-          inductive types in Set/Type while "inversion" uses anonymous
-          for inductive types both in Prop and Set/Type !!
-
-          Previously, whether names were created or not relied on
-          whether the predicate created in Indrec.make_case_com had a
-          dependent arity or not. To avoid different predicates
-          printed the same in v8, all predicates built in indrec.ml
-          got a dependent arity (Aug 2004). The new way to decide
-          whether names have to be created or not is to use an
-          Anonymous or Named variable to enforce the expected
-          dependency status (of course, Anonymous implies non
-          dependent, but not conversely).
-
-          From Coq > 8.2, using or not the effective dependency of
-          the predicate is parametrable! *)
-
-          begin match na.binder_name with
-          | Anonymous -> false
-          | Name _ -> true
-          end
-
-      | _ -> anomaly (Pp.str "Non eta-expanded dep-expanded \"match\" predicate.")
-  in
-  srec env (EConstr.of_constr pred) arsign
-
-let is_elim_predicate_explicitly_dependent env sigma pred indf =
-  let arsign,_ = get_arity env indf in
-  is_predicate_explicitly_dep env sigma pred arsign
-
-let set_names env sigma n brty =
-  let open EConstr in
-  let (ctxt,cl) = decompose_prod_n_decls sigma n brty in
-  Namegen.it_mkProd_or_LetIn_name env sigma cl ctxt
-
-let set_pattern_names env sigma ind brv =
-  let (mib,mip) = Inductive.lookup_mind_specif env ind in
-  let arities =
-    Array.map
-      (fun (d, _) -> List.length d - mib.mind_nparams)
-      mip.mind_nf_lc in
-  Array.map2 (set_names env sigma) arities brv
-
-let type_case_branches_with_names env sigma indspec p c =
-  let (ind,args) = indspec in
-  let args = List.map EConstr.Unsafe.to_constr args in
-  let (mib,mip as specif) = Inductive.lookup_mind_specif env (fst ind) in
-  let nparams = mib.mind_nparams in
-  let (params, _) = List.chop nparams args in
-  let lbrty = Inductive.build_branches_type ind specif params p in
-  let lbrty = Array.map EConstr.of_constr lbrty in
-  (* Adjust names *)
-  if is_elim_predicate_explicitly_dependent env sigma p (ind,params) then
-    (set_pattern_names env sigma (fst ind) lbrty)
-  else lbrty
 
 (* Type of Case predicates *)
 let arity_of_case_predicate env (ind,params) dep k =

--- a/pretyping/inductiveops.mli
+++ b/pretyping/inductiveops.mli
@@ -202,9 +202,6 @@ val instantiate_constructor_params : pconstructor -> mind_specif -> constr list 
 val arity_of_case_predicate :
   env -> inductive_family -> bool -> Sorts.t -> types
 
-val type_case_branches_with_names :
-  env -> evar_map -> pinductive * EConstr.constr list -> constr -> constr -> EConstr.types array
-
 (** Annotation for cases *)
 val make_case_info : env -> inductive -> Sorts.relevance -> case_style -> case_info
 

--- a/pretyping/inductiveops.mli
+++ b/pretyping/inductiveops.mli
@@ -203,7 +203,7 @@ val arity_of_case_predicate :
   env -> inductive_family -> bool -> Sorts.t -> types
 
 val type_case_branches_with_names :
-  env -> evar_map -> pinductive * EConstr.constr list -> constr -> constr -> EConstr.types array * types
+  env -> evar_map -> pinductive * EConstr.constr list -> constr -> constr -> EConstr.types array
 
 (** Annotation for cases *)
 val make_case_info : env -> inductive -> Sorts.relevance -> case_style -> case_info

--- a/proofs/logic.ml
+++ b/proofs/logic.ml
@@ -25,7 +25,7 @@ type refiner_error =
   (* Errors raised by the refiner *)
   | BadType of constr * constr * EConstr.t
   | UnresolvedBindings of Name.t list
-  | CannotApply of constr * constr
+  | CannotApply of EConstr.t * EConstr.t
   | NonLinearProof of constr
   | MetaInType of EConstr.constr
 

--- a/proofs/logic.mli
+++ b/proofs/logic.mli
@@ -31,7 +31,7 @@ type refiner_error =
   (*i Errors raised by the refiner i*)
   | BadType of constr * constr * EConstr.t
   | UnresolvedBindings of Name.t list
-  | CannotApply of constr * constr
+  | CannotApply of EConstr.t * EConstr.t
   | NonLinearProof of constr
   | MetaInType of EConstr.constr
 

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -4502,7 +4502,6 @@ let induction_tac with_evars params indvars (elim, elimt) =
     let elimc = mkConstU c in
     let i = index_of_ind_arg sigma elimt in
     (* elimclause contains this: (elimc ?i ?j ?k...?l) *)
-    let elimc = mkCast (elimc, DEFAULTcast, elimt) in
     let elimclause = mk_clenv_from env sigma (elimc, elimt) in
     (* elimclause' is built from elimclause by instantiating all args and params. *)
     let elimclause = recolle_clenv (Some i) params indvars elimclause gl in
@@ -4513,7 +4512,6 @@ let induction_tac with_evars params indvars (elim, elimt) =
     let i = index_of_ind_arg sigma elimt in
     (* elimclause contains this: (elimc ?i ?j ?k...?l) *)
     let elimc = contract_letin_in_lam_header sigma elimc in
-    let elimc = mkCast (elimc, DEFAULTcast, elimt) in
     let elimclause = Tacmach.pf_apply mk_clenv_from gl (elimc, elimt) in
     (* elimclause' is built from elimclause by instantiating all args and params. *)
     let elimclause = recolle_clenv (Some i) params indvars elimclause gl in
@@ -4521,7 +4519,6 @@ let induction_tac with_evars params indvars (elim, elimt) =
   | ElimClause (elimc, lbindelimc) ->
     (* elimclause contains this: (elimc ?i ?j ?k...?l) *)
     let elimc = contract_letin_in_lam_header sigma elimc in
-    let elimc = mkCast (elimc, DEFAULTcast, elimt) in
     let elimclause = Tacmach.pf_apply make_clenv_binding gl (elimc,elimt) lbindelimc in
     (* elimclause' is built from elimclause by instantiating all args and params. *)
     let elimclause = recolle_clenv None params indvars elimclause gl in

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1196,8 +1196,8 @@ let explain_refiner_unresolved_bindings l =
 
 let explain_refiner_cannot_apply env sigma t harg =
   str "In refiner, a term of type" ++ brk(1,1) ++
-  pr_lconstr_env env sigma t ++ spc () ++ str "could not be applied to" ++ brk(1,1) ++
-  pr_lconstr_env env sigma harg ++ str "."
+  pr_leconstr_env env sigma t ++ spc () ++ str "could not be applied to" ++ brk(1,1) ++
+  pr_leconstr_env env sigma harg ++ str "."
 
 let explain_intro_needs_product () =
   str "Introduction tactics needs products."


### PR DESCRIPTION
We remove a lot of boilerplate that shouldn't be there anymore since the switch to the new engine.
- A lot of code was performing a weird belly dance with casts but it turns out that this was useless.
- We simplify the meta instance function into a simple meta-aware nf_betaiota.
- We reduce the cruft of the legacy case refiner.

This might introduce very subtle backwards incompatibilities but hopefully it won't. Also I'm a bit concerned about potential performance issues so a bench is in order.