### PR TITLE
[configure] Fix "local layout" install for Windows

### DIFF
--- a/tools/configure/configure.ml
+++ b/tools/configure/configure.ml
@@ -235,11 +235,11 @@ end
 
 let install prefs =
   [ InstallDir.make "COQPREFIX" "Coq" prefs.prefix (Relative "") (Relative "")
-  ; InstallDir.make "COQLIBINSTALL" "the Coq library" prefs.libdir (Relative "lib") (Relative "lib/coq")
+  ; InstallDir.make "COQLIBINSTALL" "the Coq library" prefs.libdir (Relative "lib/coq") (Relative "lib/coq")
   ; InstallDir.make "CONFIGDIR" "the Coqide configuration files" prefs.configdir (Relative "config") (Absolute "/etc/xdg/coq")
-  ; InstallDir.make "DATADIR" "the Coqide data files" prefs.datadir (Relative "share") (Relative "share/coq")
-  ; InstallDir.make "MANDIR" "the Coq man pages" prefs.mandir (Relative "man") (Relative "share/man")
-  ; InstallDir.make "DOCDIR" "documentation prefix path for all Coq packages" prefs.docdir (Relative "doc") (Relative "share/doc")
+  ; InstallDir.make "DATADIR" "the Coqide data files" prefs.datadir (Relative "share/coq") (Relative "share/coq")
+  ; InstallDir.make "MANDIR" "the Coq man pages" prefs.mandir (Relative "share/man") (Relative "share/man")
+  ; InstallDir.make "DOCDIR" "documentation prefix path for all Coq packages" prefs.docdir (Relative "share/doc") (Relative "share/doc")
   ]
 
 let strip_trailing_slash_if_any p =


### PR DESCRIPTION
These are some leftovers of the "local" layout that went away some time ago. But in Windows, since 8.17 we will generate bad paths for example for `coqlib`, as Dune will install in `C:\coq\lib\coq` not on `C:\coq\lib` like before.

We could special case these, but IMHO not a good thing.

This bugs was not observed because opam packages then to set `--libdir` manually anyways.

Note that still users have to be careful to pass the same install paths to configure and to `dune install`

