### PR TITLE
Filter out `H` from env while unifying in `setoid_rewrite X in H`

### DIFF
--- a/test-suite/bugs/bug_17295.v
+++ b/test-suite/bugs/bug_17295.v
@@ -1,0 +1,24 @@
+Require Import Setoid.
+
+Set Printing Existential Instances.
+
+Axiom A : Type.
+Axiom i : A.
+Axiom Equal : A -> A -> Prop.
+Axiom P : A -> Prop.
+
+Axiom everything_equal : forall (j : A), Equal i j.
+
+Instance b : Morphisms.Proper (Equal ==> Basics.impl) P. Admitted.
+
+Axiom forget : P i -> A.
+
+Lemma blah (H : P i) : True.
+unshelve rewrite everything_equal in H.
+Fail exact (forget H).
+Abort.
+
+Lemma blah (H : P i) : True.
+unshelve setoid_rewrite everything_equal in H.
+Fail exact (forget H).
+Abort.


### PR DESCRIPTION
Fix #17295

This is technically speaking probably a breaking change. But I'd expect the damage to be minimal.

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.