### PR TITLE
Stronger invariants in Clenv refiner

### DIFF
--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -760,10 +760,7 @@ let rec mk_refgoals env sigma goalacc conclty trm =
           (acc',ty,sigma,c)
 
       | _ ->
-        if occur_meta sigma (EConstr.of_constr trm) then
-          anomaly (Pp.str "refiner called with a meta in non app/case subterm.");
-        let (sigma, t'ty) = goal_type_of env sigma trm in
-          (goalacc,t'ty,sigma, trm)
+        anomaly (Pp.str "refiner called with a meta in non app subterm.")
 
 (* Same as mkREFGOALS but without knowing the type of the term. Therefore,
  * Metas should be casted. *)

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -754,11 +754,6 @@ let rec mk_refgoals env sigma goalacc conclty trm =
 and mk_arggoals env sigma goalacc funty allargs =
   let foldmap (goalacc, funty, sigma) harg =
     let t = whd_all env sigma funty in
-    let rec collapse t = match EConstr.kind sigma t with
-    | LetIn (_, c1, _, b) -> collapse (EConstr.Vars.subst1 c1 b)
-    | _ -> t
-    in
-    let t = collapse t in
     match EConstr.kind sigma t with
     | Prod (_, c1, b) ->
       let (acc, hargty, sigma, arg) = mk_refgoals env sigma goalacc (Some c1) harg in

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -726,22 +726,6 @@ let rec mk_refgoals env sigma goalacc conclty trm =
           let ev = EConstr.Unsafe.to_constr ev in
           gl::goalacc, conclty, sigma, ev
 
-      | Cast (t,k, ty) ->
-        if Option.is_empty conclty then
-          mk_refgoals env sigma goalacc (Some (EConstr.of_constr ty)) t
-        else
-
-        let res = mk_refgoals env sigma goalacc (Some (EConstr.of_constr ty)) t in
-        (* we keep the casts (in particular VMcast and NATIVEcast) except
-           when they are annotating metas *)
-        if isMeta t then begin
-          assert (k != VMcast && k != NATIVEcast);
-          res
-        end else
-          let (gls,cty,sigma,ans) = res in
-          let ans = if ans == t then trm else mkCast(ans,k,ty) in
-          (gls,cty,sigma,ans)
-
       | App (f,l) ->
         let (acc',hdty,sigma,applicand) =
           if Termops.is_template_polymorphic_ind env sigma (EConstr.of_constr f) then

--- a/proofs/logic.ml
+++ b/proofs/logic.ml
@@ -26,7 +26,7 @@ type refiner_error =
   | BadType of constr * constr * EConstr.t
   | UnresolvedBindings of Name.t list
   | CannotApply of EConstr.t * EConstr.t
-  | NonLinearProof of constr
+  | NonLinearProof of EConstr.t
   | MetaInType of EConstr.constr
 
   (* Errors raised by the tactics *)

--- a/proofs/logic.mli
+++ b/proofs/logic.mli
@@ -32,7 +32,7 @@ type refiner_error =
   | BadType of constr * constr * EConstr.t
   | UnresolvedBindings of Name.t list
   | CannotApply of EConstr.t * EConstr.t
-  | NonLinearProof of constr
+  | NonLinearProof of EConstr.t
   | MetaInType of EConstr.constr
 
   (*i Errors raised by the tactics i*)

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1203,7 +1203,7 @@ let explain_intro_needs_product () =
   str "Introduction tactics needs products."
 
 let explain_non_linear_proof env sigma c =
-  str "Cannot refine with term" ++ brk(1,1) ++ pr_lconstr_env env sigma c ++
+  str "Cannot refine with term" ++ brk(1,1) ++ pr_leconstr_env env sigma c ++
   spc () ++ str "because a metavariable has several occurrences."
 
 let explain_meta_in_type env sigma c =


### PR DESCRIPTION
We factorize the refiner code and expose an explicit representation of the shape of legacy proofs. This makes clear the expected invariants for the input terms and probably removes some anomalies that were actually reachable.