### PR TITLE
Supporting debugging in extraction plugin by default

### DIFF
--- a/dev/dune-dbg.in
+++ b/dev/dune-dbg.in
@@ -45,4 +45,4 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-ocamldebug "${opts[@]}" $(ocamlfind query -recursive -i-format coq-core.top_printers) -I +threads -I dev $exe "$@"
+ocamldebug "${opts[@]}" $(ocamlfind query -recursive -i-format coq-core.top_printers) $(ocamlfind query -i-format -descendants coq-core.vernac) -I +threads -I dev $exe "$@"


### PR DESCRIPTION
We add extraction directory and plugin to the call to ocamldebug.

Not sure all three incantations are necessary, but it allows printing (though setting breakpoints still fails, but this is an ocamldebug bug with packed modules, afaik).