### PR TITLE
Support extraction of template-polymorphism types in Prop by means of coercions 

### DIFF
--- a/kernel/inductive.mli
+++ b/kernel/inductive.mli
@@ -59,7 +59,7 @@ val relevance_of_inductive : env -> inductive -> Sorts.relevance
 val type_of_inductive : mind_specif puniverses -> types
 
 val type_of_inductive_knowing_parameters :
-  ?polyprop:bool -> mind_specif puniverses -> param_univs -> types
+  mind_specif puniverses -> param_univs -> types
 
 val elim_sort : mind_specif -> Sorts.family
 
@@ -139,14 +139,5 @@ val check_fix : env -> fixpoint -> unit
 val check_cofix : env -> cofixpoint -> unit
 
 (** {6 Support for sort-polymorphic inductive types } *)
-
-(** The "polyprop" optional argument below controls
-    the "Prop-polymorphism". By default, it is allowed.
-    But when "polyprop=false", the following exception is raised
-    when a polymorphic singleton inductive type becomes Prop due to
-    parameter instantiation. This is used by the Ocaml extraction,
-    which cannot handle (yet?) Prop-polymorphism. *)
-
-exception SingletonInductiveBecomesProp of Id.t
 
 val abstract_mind_lc : int -> int -> MutInd.t -> (rel_context * constr) array -> constr array

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -672,11 +672,7 @@ let rec extract_term env sg mle mlt c args =
     | Evar _ | Meta _ -> MLaxiom
     | Var v ->
        (* Only during Show Extraction *)
-       let open Context.Named.Declaration in
-       let ty = match EConstr.lookup_named v env with
-         | LocalAssum (_,ty) -> ty
-         | LocalDef (_,_,ty) -> ty
-       in
+       let ty = Context.Named.Declaration.get_type (EConstr.lookup_named v env) in
        let vty = extract_type env sg [] 0 ty [] in
        let extract_var mlt = put_magic (mlt,vty) (MLglob (GlobRef.VarRef v)) in
        extract_app env sg mle mlt extract_var args
@@ -1186,7 +1182,7 @@ let extract_with_type env sg c =
         let db = db_from_sign s in
         let t = extract_type_scheme env sg db c (List.length s) in
         Some (vl, t)
-    | _ -> None
+    | (Info, Default) | (Logic, _) -> None
   with SingletonInductiveBecomesProp id ->
     error_singleton_become_prop id None
 

--- a/plugins/extraction/mlutil.ml
+++ b/plugins/extraction/mlutil.ml
@@ -161,7 +161,7 @@ module Mlenv = struct
 
   let empty = { env = []; free = Metaset.empty }
 
-  (* [get] returns a instantiated copy of the n-th most recently added
+  (* [get] returns an instantiated copy of the n-th most recently added
      type in the environment. *)
 
   let get mle n =

--- a/pretyping/retyping.mli
+++ b/pretyping/retyping.mli
@@ -18,9 +18,6 @@ open EConstr
    either produces a wrong result or raise an anomaly. Use with care.
    It doesn't handle predicative universes too. *)
 
-(** The "polyprop" optional argument is used by the extraction to
-    disable "Prop-polymorphism", cf comment in [inductive.ml] *)
-
 (** The "lax" optional argument provides a relaxed version of
     [get_type_of] that won't raise any anomaly but RetypeError instead *)
 
@@ -28,17 +25,17 @@ type retype_error
 exception RetypeError of retype_error
 
 val get_type_of :
-  ?polyprop:bool -> ?lax:bool -> env -> evar_map -> constr -> types
+  ?lax:bool -> env -> evar_map -> constr -> types
 
 (** No-evar version of [get_type_of] *)
-val get_type_of_constr : ?polyprop:bool -> ?lax:bool
+val get_type_of_constr : ?lax:bool
   -> env -> ?uctx:UState.t -> Constr.t -> Constr.types
 
 val get_sort_of :
-  ?polyprop:bool -> env -> evar_map -> types -> ESorts.t
+  env -> evar_map -> types -> ESorts.t
 
 val get_sort_family_of :
-  ?polyprop:bool -> env -> evar_map -> types -> Sorts.family
+  env -> evar_map -> types -> Sorts.family
 
 (** Makes an unsafe judgment from a constr *)
 val get_judgment_of : env -> evar_map -> constr -> unsafe_judgment

--- a/test-suite/success/extraction_polyprop.v
+++ b/test-suite/success/extraction_polyprop.v
@@ -1,13 +1,90 @@
-(* The current extraction cannot handle this situation,
-   and shouldn't try, otherwise it might produce some Ocaml
-   code that segfaults. See Table.error_singleton_become_prop
-   or S. Glondu's thesis for more details. *)
+(* Inserting coercions in the presence of sort polymorphism *)
 
 Require Coq.extraction.Extraction.
 
 Definition f {X} (p : (nat -> X) * True) : X * nat :=
   (fst p 0, 0).
-
 Definition f_prop := f ((fun _ => I),I).
+Extraction f_prop.
 
-Fail Extraction f_prop.
+Definition h (x : nat * nat) := match x with (y,z) => (I,I) end.
+Extraction h.
+
+Module A.
+Definition foo (P : Prop) (p : P) (f : P -> nat) := f p.
+Definition bar A B (f : A -> nat) (p : A * B) := f (fst p).
+Definition baz1 := foo (True * True) ((I, I) : True * True : Prop) (bar True True (fun _ => 0)).
+Definition baz2 := foo (True * True) ((I, I) : True * True : Prop) (fun x => bar True True (fun _ => 0) x).
+End A.
+Recursive Extraction A.baz1.
+Extraction TestCompile A.baz1.
+Recursive Extraction A.baz2.
+Extraction TestCompile A.baz2.
+
+Module B.
+Definition foo (P Q : Prop) (p : P) (f : P -> Q * nat) := f p.
+Definition bar A B (f : A -> (True * True) * nat) (p : A * B) := f (fst p).
+Definition baz1 := foo (True * True) (True * True) ((I, I) : True * True : Prop) (bar True True (fun x => ((x,x),0))).
+Definition baz2 := foo (True * True) (True * True) ((I, I) : True * True : Prop) (fun x => bar True True (fun x => ((x,x),0)) x).
+End B.
+Recursive Extraction B.baz1.
+Extraction TestCompile B.baz1.
+Recursive Extraction B.baz2.
+Extraction TestCompile B.baz2.
+
+Module C.
+Definition foo (P Q : Prop) (p : P) (f : P -> Q * nat) := f p.
+Definition bar A B (f : A -> True *  nat) (p : A * B) := f (fst p).
+Definition baz1 := foo (True * True) True ((I, I) : True * True : Prop) (bar True True (fun x => (x,0))).
+Definition baz2 := foo (True * True) True ((I, I) : True * True : Prop) (fun x => bar True True (fun x => (x,0)) x).
+End C.
+Recursive Extraction C.baz1.
+Extraction TestCompile C.baz1.
+Recursive Extraction C.baz2.
+Extraction TestCompile C.baz2.
+
+Module E.
+Definition foo (P : Prop) (p : P) (f : P -> nat) := f p.
+Definition bar A B (p : A * B) := let x := fst p in 0.
+Definition baz1 := foo (True * True) (I, I) (bar True True).
+Definition baz2 := foo (True * True) (I, I) (fun x => bar True True x).
+End E.
+Recursive Extraction E.baz1.
+Extraction TestCompile E.baz1.
+Recursive Extraction E.baz2.
+Extraction TestCompile E.baz2.
+
+(** Example with a constructor already partially in Prop *)
+Module F.
+Definition foo (P : Prop) (p : P) (f : P -> nat) := f p.
+Definition bar A B (f : A->nat) (p : {a:A | B}) := f (proj1_sig p).
+Definition baz1 := foo {a:True | True} (exist _ I I) (bar True True (fun _ => 0)).
+Definition baz2 := foo {a:True | True} (exist _ I I) (fun x => bar True True (fun _ => 0) x).
+End F.
+Recursive Extraction F.baz1.
+Extraction TestCompile F.baz1.
+Recursive Extraction F.baz2.
+Extraction TestCompile F.baz2.
+
+(** Examples with nested sort-polymorphic types *)
+Module G.
+Definition foo (P : Prop) (p : P) (f : P -> nat) := f p.
+Definition bar A B C (f : B -> nat) (p : A * B * C) := f (snd (fst p)).
+Definition baz1 := foo (True * True * True) ((I, I, I) : True * True * True : Prop) (bar True True True (fun _ => 0)).
+Definition baz2 := foo (True * True * True) ((I, I, I) : True * True * True : Prop) (fun x => bar True True True (fun _ => 0) x).
+End G.
+Recursive Extraction G.baz1.
+Extraction TestCompile G.baz1.
+Recursive Extraction G.baz2.
+Extraction TestCompile G.baz2.
+
+(** Examples with universe subtyping *)
+Module H.
+Definition map (X Y:Type) (f : X -> Y) (g : Y -> bool) (x:X) := g (f x).
+Definition use1 := map True True (fun x => x) (fun _ => true) I.
+Definition use2 := map (True*True) True (fun x => fst x) (fun _ => true) (I,I).
+End H.
+Recursive Extraction H.use1.
+Extraction TestCompile H.use1.
+Recursive Extraction H.use2.
+Extraction TestCompile H.use2.


### PR DESCRIPTION
A template polymorphic inductive type over the types `True` or `False` is itself only isomorphic to `True` or `False`and this used to break extraction. This PR is an attempt to make explicit the underlying isomorphisms in the extracted code.

In particular, it allows to get rid of the "sort-polymorphic singleton inductive type" limitation of extraction, as described e.g. in coq/coq#20034. It also fixes some cases of ill-typed extraction involving (undetected) template polymorphism such as described in [this](https://github.com/coq/coq/issues/20034) comment of coq/coq#20034.

Fixes coq/coq#20034.

Current status:
- the code is rather empirical: it modifies some places and adds new ones where the type of an extracted terms is checked against the expected type; I suspect that if some cases are ever missing, it is not worse than the detection of when an `Obj.magic` needs to be inserted;
- the code has some redundancies: sometimes the ML type of the extracted term is known and we can compare ML types; in other places, only the Coq type of the extracted term is known; to factorize the two codes one would need to be able to recompute an ML type as wanted, but for that, we would need to pass a map called `db` that maps Coq type variables to ML type variables; I did not make this step;
- Insertion of Obj.magic does not seem optimal yet;
- compilation of the extracted code does not ensure the absence of segmentation fault (the test should be changed to also run the code);
- in the presence of `Prop`<`Type` subtyping, (at least some) Obj.magic coercions between `True -> True` and `True` are replaced by "typed" coercions such as `(fun _ -> __)`; in some sense, this gives an alternative to the trick of defining `__` as the fixpoint `let rec __ _ = __`.
- plan for a possible principled approach:
  - instead of extracting a Coq term against an ML type in `extract_term`, one could extract a Coq term against a closure made of the expected Coq type in its environment and a substitution which tells how the callers instantiates the variables of the type of the callee, i.e.:
    - `extract_term : env -> evar_map -> constr -> constr list -> env * types * substl -> ml_ast`
    - `extract_maybe_subterm : env -> evar_map -> constr -> env * types * substl -> ml_ast`

    the advantage is that the Coq type is more informative:
    -  we know when a `match` over types is done, while it is a `__` when turned into an ML type
    - we don't need to use a reallocation of Coq variables indices into ML variables indices
  - we do the following in `extract_maybe_subterm`:
    - any time the expected type (w/o substitution) is in `Prop`, we return a `MLdummy Kprop` (i.e. `__`)
    - any time the expected type (w/o substitution) is a type scheme, we return a `MLdummy Ktype` (i.e. `__` also)
    - we call `extract_subterm` otherwise (a priori, no need for the eta-expansion done in the PR in `extract_maybe_subterm`)
  - we compute the actual type (with the substitution) and do the following in `extract_subterm`:
    - if the head of the term is a variable, we call eta-expansion for possible insertion of a coercion
    - in `Lambda`, if the expected type (w/o substitution) is a variable, we insert a magic
  - in eta-expansion:
    - we follow recursively the expected and actual type structure when it matches (eta-expanding for Prod, positive Ind, negative Ind; returning the identity if a Sort or a Rel not instantiated by the substitution), using a covariant and a contravariant eta-expansion
    - if a type built  by a Case with at least two branches, mimick the Case and follow the structure (so as to possibly add template-polymorphic coercions) + add an Obj.magic because ML does not know about types built by cases
    - in both the covariant and contravariant eta-expansion, when the expected type is a(n applied) variable and the actual type not a(n applied) variable, we coerce with:
      - `fun _ => MLdummy Kprop` if the actual type is of type Prop
      -  `fun _ => MLdummy Ktype` if the actual type is a sort
      - an Obj.magic if the actual type is a Prod, a Case with at least two branches, or an Ind (because ML does not know about types built by cases) + go recursively on the actual and now substituted types
    - eta-expansion w/o insertion of coercions are optimized by eta-contracting back

  so, shortly: add an Obj.magic when going outside ML typing system, add a __ when a type of type Prop or a sort, optimize when there is no coercions inserted
- the same idea can be applied to module subtyping:
  - when calling `extract_constant`, we pass also the expected type in the signature and:
    - e.g. if the expected type is a type variable and the term is itself a type (thus `__` as type), as in the initial example of coq/coq#5795, we nevertheless see this type as a value (thus `__` of type `__`)
    - e.g. when removing lambdas in Prop, we verify that the expected type of the lambda is a type in Prop and not a variable in Type instantiated by a type in Prop (as in the last example of coq/coq#5795)
    - e.g. if the expected type is built by case analysis (and extracted to `__`), as in coq/coq#1957, we insert an Obj.magic around the extracted term (as in the eta-expansion above)

- [x] Added / updated **test-suite**.
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
