### PR TITLE
Fix universe constraint inference for module subtyping

### DIFF
--- a/doc/changelog/02-specification-language/17305-fix-infer-univs.rst
+++ b/doc/changelog/02-specification-language/17305-fix-infer-univs.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  universe constraint inference in module subtyping can trigger constant unfoldings
+  (`#17305 <https://github.com/coq/coq/pull/17305>`_,
+  fixes `#17303 <https://github.com/coq/coq/issues/17303>`_,
+  by Gaëtan Gilbert).

--- a/test-suite/bugs/bug_17303.v
+++ b/test-suite/bugs/bug_17303.v
@@ -1,0 +1,3 @@
+
+Module Type C.  Axiom a : @id Type nat. End C.
+Module Type A <: C.  Axiom a : @id Set nat. End A.

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -877,10 +877,10 @@ module Interp = struct
 (** {6 Auxiliary functions concerning subtyping checks} *)
 
 let check_sub mtb sub_mtb_l =
-  let fold sub_mtb (ocst, env) =
-    let state = ((Environ.universes env, Univ.Constraints.empty), Reductionops.inferred_universes) in
-    let _, cst = Subtyping.check_subtypes state env mtb sub_mtb in
-    (Univ.Constraints.union ocst cst, Environ.add_constraints cst env)
+  let fold sub_mtb (cst, env) =
+    let state = ((Environ.universes env, cst), Reductionops.inferred_universes) in
+    let graph, cst = Subtyping.check_subtypes state env mtb sub_mtb in
+    (cst, Environ.set_universes graph env)
   in
   let cst, _ = List.fold_right fold sub_mtb_l (Univ.Constraints.empty, Global.env ()) in
   Global.add_constraints cst


### PR DESCRIPTION
We need to check the constraints we infer while we're still inside conversion to trigger unfoldings.

Fix #17303
