### PR TITLE
[boot] env initialization cleanup

### DIFF
--- a/boot/env.ml
+++ b/boot/env.ml
@@ -33,9 +33,13 @@ let fail_msg =
 let fail s = Format.eprintf "%s@\n%!" fail_msg; exit 1
 
 (* This code needs to be refactored, for now it is just what used to be in envvars  *)
+
+let theories_dir = "theories"
+let plugins_dir = "plugins"
+let prelude = Filename.concat theories_dir "Init/Prelude.vo"
+
 let guess_coqlib () =
   Util.getenv_else "COQLIB" (fun () ->
-  let prelude = "theories/Init/Prelude.vo" in
   Util.check_file_else
     ~dir:Coq_config.coqlibsuffix
     ~file:prelude
@@ -46,9 +50,32 @@ let guess_coqlib () =
 
 (* Build layout uses coqlib = coqcorelib *)
 let guess_coqcorelib lib =
-  if Sys.file_exists (Path.relative lib "plugins")
+  if Sys.file_exists (Path.relative lib plugins_dir)
   then lib
   else Path.relative lib "../coq-core"
+
+let fail_lib lib =
+  let open Printf in
+  eprintf "File not found: %s\n" lib;
+  eprintf "The path for Coq libraries is wrong.\n";
+  eprintf "Coq libraries are shipped in the coq-stdlib package.\n";
+  eprintf "Please check the COQLIB env variable or the -coqlib option.\n";
+  exit 1
+
+let fail_core plugin =
+  let open Printf in
+  eprintf "File not found: %s\n" plugin;
+  eprintf "The path for Coq plugins is wrong.\n";
+  eprintf "Coq plugins are shipped in the coq-core package.\n";
+  eprintf "Please check the COQCORELIB env variable.\n";
+  exit 1
+
+let validate_env ({ core; lib } as env) =
+  let lib = Filename.concat lib prelude in
+  if not (Sys.file_exists lib) then fail_lib lib;
+  let plugin = Filename.concat core plugins_dir in
+  if not (Sys.file_exists plugin) then fail_core plugin;
+  env
 
 (* Should we fail on double initialization? That seems a way to avoid
    mis-use for example when we pass command line arguments *)
@@ -56,13 +83,7 @@ let init () =
   let lib = guess_coqlib () in
   let core = Util.getenv_else "COQCORELIB"
       (fun () -> guess_coqcorelib lib) in
-  { core ; lib }
-
-let init () =
-  let { core; lib } = init () in
-  (* debug *)
-  if false then Format.eprintf "core = %s@\n lib = %s@\n%!" core lib;
-  { core; lib }
+  validate_env { core ; lib }
 
 let env_ref = ref None
 
@@ -74,13 +95,13 @@ let init () =
   | Some env -> env
 
 let set_coqlib lib =
-  let env = { lib; core = guess_coqcorelib lib } in
+  let env = validate_env { lib; core = guess_coqcorelib lib } in
   env_ref := Some env
 
 let coqlib { lib; _ } = lib
 let corelib { core; _ } = core
-let plugins { core; _ } = Path.relative core "plugins"
-let stdlib { lib; _ } = Path.relative lib "theories"
+let plugins { core; _ } = Path.relative core plugins_dir
+let stdlib { lib; _ } = Path.relative lib theories_dir
 let user_contrib { lib; _ } = Path.relative lib "user-contrib"
 let tool { core; _ } tool = Path.(relative (relative core "tools") tool)
 let revision { core; _ } = Path.relative core "revision"

--- a/sysinit/coqinit.ml
+++ b/sysinit/coqinit.ml
@@ -85,7 +85,7 @@ let init_coqlib opts = match opts.Coqargs.config.Coqargs.coqlib with
   | Some s ->
     Boot.Env.set_coqlib s
 
-let print_query opts = let open Coqargs in function
+let print_query = let open Coqargs in function
   | PrintVersion -> Boot.Usage.version ()
   | PrintMachineReadableVersion -> Boot.Usage.machine_readable_version ()
   | PrintWhere ->
@@ -94,7 +94,6 @@ let print_query opts = let open Coqargs in function
     print_endline coqlib
   | PrintHelp h -> Boot.Usage.print_usage stderr h
   | PrintConfig ->
-    let () = init_coqlib opts in
     Envars.print_config stdout
 
 let parse_arguments ~parse_extra ~usage ?(initial_args=Coqargs.default) () =
@@ -107,9 +106,7 @@ let parse_arguments ~parse_extra ~usage ?(initial_args=Coqargs.default) () =
     prerr_endline "See -help for the list of supported options";
     exit 1
     end;
-  match opts.Coqargs.main with
-  | Coqargs.Queries q -> List.iter (print_query opts) q; exit 0
-  | Coqargs.Run -> opts, customopts
+  opts, customopts
 
 let print_memory_stat () =
   let open Pp in
@@ -166,7 +163,10 @@ let init_runtime opts =
   (* Paths for loading stuff *)
   init_load_paths opts;
 
-  injection_commands opts
+  match opts.Coqargs.main with
+  | Coqargs.Queries q -> List.iter print_query q; exit 0
+  | Coqargs.Run ->
+      injection_commands opts
 
 let require_file (dir, from, exp) =
   let mp = Libnames.qualid_of_string dir in

--- a/test-suite/misc/coq_environment.sh
+++ b/test-suite/misc/coq_environment.sh
@@ -5,6 +5,10 @@ export PATH=$COQBIN:$PATH
 
 TMP=`mktemp -d`
 cd $TMP
+mkdir -p overridden/theories/Init/
+
+mkdir overridden/plugins
+touch overridden/theories/Init/Prelude.vo
 
 cat > coq_environment.txt <<EOT
 # we override COQLIB because we can
@@ -40,8 +44,13 @@ if [ $N -ne 1 ]; then
   exit 1
 fi
 
-export COQLIB="/overridden2"
-N=`./coqc -config | grep COQLIB | grep /overridden2 | wc -l`
+mkdir -p overridden2/theories/Init/
+
+mkdir overridden2/plugins
+touch overridden2/theories/Init/Prelude.vo
+
+export COQLIB="$PWD/overridden2"
+N=`./coqc -config | grep COQLIB | grep overridden2 | wc -l`
 if [ $N -ne 1 ]; then
   echo COQLIB not overridden by COQLIB when coq_environment present
   coqc -config


### PR DESCRIPTION
This PR makes it so that:
- command line arguments classified as queries are run after initialization, namely
  `coqc -where -coqlib foo` takes the second option into account before printing anything
- env initialization (eg coqlib and coqcorelib values) is followed by a validation, that is
  `coqc -coqlib broken/path` raises an intelligible error, rather than silently accepting the setting but then not working

It turns out the other query, `-config`, was running an ad-hoc initialization (in order to be able to print values which were up to date), which is now unnecessary since queries are run after initialization.
