### PR TITLE
Addresses #17316: "only parsing" expects a parsing rule

### DIFF
--- a/doc/changelog/03-notations/17318-master+wish17316-only-parsing-expects-a-parsing-rule.rst
+++ b/doc/changelog/03-notations/17318-master+wish17316-only-parsing-expects-a-parsing-rule.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Ensure in all cases that a parsing rule is declared when the :n:`only parsing` flag is given
+  (`#17318 <https://github.com/coq/coq/pull/17317>`_,
+  fixes `#17316 <https://github.com/coq/coq/issues/17316>`_,
+  by Hugo Herbelin).

--- a/test-suite/output/wish_17316.out
+++ b/test-suite/output/wish_17316.out
@@ -1,0 +1,2 @@
+Notation "%" := 0 (default interpretation) (only printing)
+Notation "%" := 0 (default interpretation) (only parsing)

--- a/test-suite/output/wish_17316.v
+++ b/test-suite/output/wish_17316.v
@@ -1,0 +1,3 @@
+Notation "%" := 0 (only printing).
+Notation "%" := 0 (only parsing).
+Locate "%".

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1709,7 +1709,7 @@ let make_notation_interpretation ~local main_data notation_symbols ntn syntax_ru
     | PrimTokenSyntax -> None, [], main_data, None
     | SpecificSyntax sy ->
     (* If the only printing flag has been explicitly requested, put it back *)
-    let main_data = { main_data with onlyprinting = main_data.onlyprinting || sy.synext_notgram = None } in
+    let main_data = { main_data with onlyprinting = main_data.onlyprinting || (sy.synext_notgram = None && not main_data.onlyparsing) } in
     Some sy.synext_level, List.combine mainvars sy.synext_nottyps, main_data, sy.synext_notprint
   in
   (* Declare interpretation *)


### PR DESCRIPTION
This is one way to address #17316 (solution 3 among the solutions proposed in this [comment](https://github.com/coq/coq/issues/17316#issuecomment-1450080458)).

Closes #17316

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
