### PR TITLE
Remove extra dependency compat syntax

### DIFF
--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -806,10 +806,6 @@ When :n:`@ident` is provided, that name can be used by OCaml code, typically
 in a plugin, to access the full path of the external file via the API
 ``ComExtraDeps.query_extra_dep``.
 
-This command has been available through the :cmd:`Comments` command,
-e.g. :n:`Comments From … Dependency …`.  The :n:`Comments` form is deprecated
-in Coq 8.16.
-
    .. warn:: File ... found twice in ...
 
       The file is found in more than once in the top directories

--- a/test-suite/success/extra_dep.v
+++ b/test-suite/success/extra_dep.v
@@ -1,5 +1,4 @@
 From TestSuite Extra Dependency "extra_dep.txt".
-Comments From TestSuite Extra Dependency "extra_dep.txt".
 
 From TestSuite Extra Dependency "extra_dep.txt" as d1.
 
@@ -10,4 +9,3 @@ From TestSuite Extra Dependency "extra_dep.txt" as d2.
 Add LoadPath "prerequisite/subdir" as TestSuite.
 Set Warnings "+ambiguous-extra-dep".
 Fail From TestSuite Extra Dependency "extra_dep.txt".
-Fail Comments From TestSuite Extra Dependency "extra_dep.txt".

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1459,31 +1459,6 @@ let vernac_extra_dep ?loc from file id =
   let from = Libnames.add_dirpath_suffix hd tl in
   ComExtraDeps.declare_extra_dep ?loc ~from ~file id
 
-let constrexpr_is_string s = function
-  | { CAst.v = Constrexpr.CRef(x,None) } -> string_of_qualid x = s
-  | _ -> false
-
-let warn_comments_extra_dep =
-  CWarnings.create ~name:"extra-dep-in-comments" ~category:"deprecated"
-    (fun () ->
-      strbrk "The command \"From .. Extra Dependency ..\" is "++
-      strbrk "available since Coq 8.16, if you don't need to compile the "++
-      strbrk "file with order version of Coq please remove \"Comments\".")
-
-let forward_compat_extra_dependency ?loc = function
-  | [ CommentConstr from_str;
-      CommentConstr { CAst.v = Constrexpr.CRef(from,None) };
-      CommentConstr extra_str;
-      CommentConstr dependency_str;
-      CommentString file ] when
-        constrexpr_is_string "From" from_str&&
-        constrexpr_is_string "Extra" extra_str &&
-        constrexpr_is_string "Dependency" dependency_str
-      ->
-      warn_comments_extra_dep ();
-      vernac_extra_dep ?loc from file None
-  | _ -> ()
-
 (* Libraries *)
 
 let warn_require_in_section =
@@ -2639,7 +2614,6 @@ let translate_vernac ?loc ~atts v = let open Vernacextend in match v with
   | VernacComments l ->
     vtdefault(fun () ->
         unsupported_attributes atts;
-        forward_compat_extra_dependency ?loc l;
         Flags.if_verbose Feedback.msg_info (str "Comments ok\n"))
   (* Proof management *)
   | VernacFocus n ->


### PR DESCRIPTION
The implementation was fairly hackish and induces even more hacks for execution / parsing separation. The syntax has been deprecated since 8.16.