### PR TITLE
Reimplement the specialize with tactic using evar clauses.

### DIFF
--- a/doc/changelog/04-tactics/17322-specialize-evar-clause.rst
+++ b/doc/changelog/04-tactics/17322-specialize-evar-clause.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  in the fringe case where the ``with`` clause of a call to :tacn:`specialize`
+  depends on a variable bound in the type, the tactic will now fail instead of
+  silently producing a shelved evar
+  (`#17322 <https://github.com/coq/coq/pull/17322>`_,
+  by Pierre-Marie Pédrot).

--- a/tactics/eClause.mli
+++ b/tactics/eClause.mli
@@ -68,3 +68,9 @@ val solve_evar_clause : env -> evar_map -> bool -> clause -> EConstr.constr bind
     consider arguments to be dependent only when they appear in hypotheses and
     not in the conclusion. This boolean is only used when [bl] is of the form
     [ImplicitBindings _]. *)
+
+val check_bindings : 'a explicit_bindings -> unit
+
+val explain_no_such_bound_variable : Id.t list -> Id.t CAst.t -> 'a
+
+val error_not_right_number_missing_arguments : int -> 'a


### PR DESCRIPTION
Instead of relying on the legacy meta mechanism and ad-hoc combinators, we use instead an evar-based approach that is more principled and in particular type-safe.
