### PR TITLE
Fixing shadowing of record fields in extraction to OCaml

### DIFF
--- a/doc/changelog/13-misc/17324-master+fix14843-extraction-collision-record-field.rst
+++ b/doc/changelog/13-misc/17324-master+fix14843-extraction-collision-record-field.rst
@@ -1,0 +1,7 @@
+- **Fixed:**
+  Shadowing of record fields in extraction to OCaml
+  (`#17324 <https://github.com/coq/coq/pull/17324>`_,
+  fixes `#12813 <https://github.com/coq/coq/issues/12813>`_
+  and `#14843 <https://github.com/coq/coq/issues/14843>`_
+  and `#16677 <https://github.com/coq/coq/issues/16677>`_,
+  by Hugo Herbelin).

--- a/plugins/extraction/common.ml
+++ b/plugins/extraction/common.ml
@@ -587,11 +587,11 @@ let pp_haskell_gen k mp rls = match rls with
 
 (* Main name printing function for a reference *)
 
-let pp_global k r =
+let pp_global_with_key k key r =
   let ls = ref_renaming (k,r) in
   assert (List.length ls > 1);
   let s = List.hd ls in
-  let mp,l = repr_of_r r in
+  let mp,l = KerName.repr key in
   if ModPath.equal mp (top_visible_mp ()) then
     (* simplest situation: definition of r (or use in the same context) *)
     (* we update the visible environment *)
@@ -603,6 +603,9 @@ let pp_global k r =
       | JSON -> dottify (List.map unquote rls)
       | Haskell -> if modular () then pp_haskell_gen k mp rls else s
       | Ocaml -> pp_ocaml_gen k mp rls (Some l)
+
+let pp_global k r =
+  pp_global_with_key k (repr_of_r r) r
 
 (* Main name printing function for declaring a reference *)
 

--- a/plugins/extraction/common.mli
+++ b/plugins/extraction/common.mli
@@ -54,6 +54,7 @@ val opened_libraries : unit -> ModPath.t list
 
 type kind = Term | Type | Cons | Mod
 
+val pp_global_with_key : kind -> KerName.t -> GlobRef.t -> string
 val pp_global : kind -> GlobRef.t -> string
 val pp_global_name : kind -> GlobRef.t -> string
 val pp_module : ModPath.t -> string

--- a/plugins/extraction/ocaml.ml
+++ b/plugins/extraction/ocaml.ml
@@ -94,8 +94,12 @@ let sig_preamble _ comment used_modules usf =
    below should not be altered since they force evaluation order.
 *)
 
-let str_global k r =
-  if is_inline_custom r then find_custom r else Common.pp_global k r
+let str_global_with_key k key r =
+  if is_inline_custom r then find_custom r else Common.pp_global_with_key k key r
+
+let str_global k r = str_global_with_key k (repr_of_r r) r
+
+let pp_global_with_key k key r = str (str_global_with_key k key r)
 
 let pp_global k r = str (str_global k r)
 
@@ -148,8 +152,12 @@ let get_ind = let open GlobRef in function
   | ConstructRef (ind,_) -> IndRef ind
   | _ -> assert false
 
+let kn_of_ind = let open GlobRef in function
+  | IndRef (kn,_) -> MutInd.user kn
+  | _ -> assert false
+
 let pp_one_field r i = function
-  | Some r -> pp_global Term r
+  | Some r' -> pp_global_with_key Term (kn_of_ind (get_ind r)) r'
   | None -> pp_global Type (get_ind r) ++ str "__" ++ int i
 
 let pp_field r fields i = pp_one_field r i (List.nth fields i)

--- a/plugins/extraction/ocaml.ml
+++ b/plugins/extraction/ocaml.ml
@@ -710,7 +710,7 @@ let rec pp_structure_elem = function
      (match Common.get_duplicate (top_visible_mp ()) l with
       | None -> pp_decl d
       | Some ren ->
-         hov 1 (str ("module "^ren^" = struct") ++ fnl () ++ pp_decl d) ++
+         v 1 (str ("module "^ren^" = struct") ++ fnl () ++ pp_decl d) ++
          fnl () ++ str "end" ++ fnl () ++ str ("include "^ren))
   | (l,SEmodule m) ->
       let typ =

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -35,17 +35,19 @@ let occur_kn_in_ref kn = let open GlobRef in function
   | ConstructRef ((kn',_),_) -> MutInd.CanOrd.equal kn kn'
   | ConstRef _ | VarRef _ -> false
 
+(* Return the "canonical" name used for declaring a name *)
+
 let repr_of_r = let open GlobRef in function
-  | ConstRef kn -> KerName.repr (Constant.user kn)
+  | ConstRef kn -> Constant.user kn
   | IndRef (kn,_)
-  | ConstructRef ((kn,_),_) -> KerName.repr (MutInd.user kn)
-  | VarRef v -> KerName.repr (Lib.make_kn v)
+  | ConstructRef ((kn,_),_) -> MutInd.user kn
+  | VarRef v -> Lib.make_kn v
 
 let modpath_of_r r =
-  let mp,_ = repr_of_r r in mp
+  KerName.modpath (repr_of_r r)
 
 let label_of_r r =
-  let _,l = repr_of_r r in l
+  KerName.label (repr_of_r r)
 
 let rec base_mp = function
   | MPdot (mp,l) -> base_mp mp
@@ -94,7 +96,7 @@ let rec parse_labels2 ll mp1 = function
 
 let labels_of_ref r =
   let mp_top = Lib.current_mp () in
-  let mp,l = repr_of_r r in
+  let mp,l = KerName.repr (repr_of_r r) in
   parse_labels2 [l] mp_top mp
 
 

--- a/plugins/extraction/table.mli
+++ b/plugins/extraction/table.mli
@@ -46,7 +46,7 @@ val info_file : string -> unit
 (*s utilities about [module_path] and [kernel_names] and [GlobRef.t] *)
 
 val occur_kn_in_ref : MutInd.t -> GlobRef.t -> bool
-val repr_of_r : GlobRef.t -> ModPath.t * Label.t
+val repr_of_r : GlobRef.t -> KerName.t
 val modpath_of_r : GlobRef.t -> ModPath.t
 val label_of_r : GlobRef.t -> Label.t
 val base_mp : ModPath.t -> ModPath.t

--- a/plugins/micromega/micromega.ml
+++ b/plugins/micromega/micromega.ml
@@ -49,6 +49,7 @@ let compOpp = function
 
 module Coq__1 = struct
  (** val add : nat -> nat -> nat **)
+
  let rec add n0 m =
    match n0 with
    | O -> m

--- a/test-suite/bugs/bug_14843.v
+++ b/test-suite/bugs/bug_14843.v
@@ -1,0 +1,21 @@
+(* f1 was renamed into Coq__1.f1 but Coq__1 was not defined *)
+(* similar to #12813, #16677 *)
+
+Record r : Type := mk { f1 : unit -> unit; f2: unit -> unit }.
+Set Primitive Projections.
+Record r' : Type := mk' { f1' : unit -> unit; f2': unit -> unit }.
+Unset Primitive Projections.
+
+Module M.
+Definition f1 (ti:unit) : unit := tt.
+Definition f2 (ti:unit) : unit := tt.
+Definition cf := mk f1 f2.
+
+Definition f1' (ti:unit) : unit := tt.
+Definition f2' (ti:unit) : unit := tt.
+Definition cf' := mk' f1' f2'.
+End M.
+
+Require Import Coq.extraction.Extraction.
+Recursive Extraction M.cf M.cf'.
+Extraction TestCompile M.cf M.cf'.


### PR DESCRIPTION
It was enough to bind the field names to the name of the corresponding inductive type declaration, rather than doing as if there were declarations on their own.

Fixes #3846
Fixes #12813
Fixes #14843 
Fixes #16677

Subsumes #12821

~~Depends on #17321 for the correctness of the added test.~~

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
