### PR TITLE
Deprecate syntax "Export Set" in favour of the attribute

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/17333-depr-export-set.rst
+++ b/doc/changelog/08-vernac-commands-and-options/17333-depr-export-set.rst
@@ -1,0 +1,4 @@
+- **Deprecated:**
+  `Export` modifier for :cmd:`Set`. Use attribute :attr:`export` instead.
+  (`#17333 <https://github.com/coq/coq/pull/17333>`_,
+  by Gaëtan Gilbert).

--- a/theories/Init/Ltac.v
+++ b/theories/Init/Ltac.v
@@ -10,4 +10,4 @@
 
 Declare ML Module "ltac_plugin:coq-core.plugins.ltac".
 
-Export Set Default Proof Mode "Classic".
+#[export] Set Default Proof Mode "Classic".


### PR DESCRIPTION
"Export" cannot become a generic legacy atrribute like Local because it conflicts with the "Export" command so for uniformity let's remove it.
