### PR TITLE
Produce correct error paths when compiling stdlib

### DIFF
--- a/tools/dune_rule_gen/coq_rules.ml
+++ b/tools/dune_rule_gen/coq_rules.ml
@@ -210,6 +210,17 @@ let boot_module_setup ~cctx coq_module =
     [ Path.relative stdlib prelude_path]
   | Regular None -> [], []
 
+(* in stdlib for ocaml >= 4.13 *)
+let starts_with ~prefix s =
+  let open String in
+  let len_s = length s
+  and len_pre = length prefix in
+  let rec aux i =
+    if i = len_pre then true
+    else if unsafe_get s i <> unsafe_get prefix i then false
+    else aux (i + 1)
+  in len_s >= len_pre && aux 0
+
 (* rule generation for a module *)
 let module_rule ~(cctx : Context.t) coq_module =
   let tname, rule = cctx.tname, cctx.rule in
@@ -229,7 +240,13 @@ let module_rule ~(cctx : Context.t) coq_module =
   let deps = cctx.async_deps @ deps in
   (* Build rule *)
   let vfile_base = Path.basename vfile in
-  let action = Format.asprintf "(run coqc %s %%{dep:%s})" flags vfile_base in
+  let fake_source =
+    let file = Path.to_string vfile in
+    let file = if starts_with ~prefix:"./" file then String.sub file 2 (String.length file - 2)
+      else file
+    in
+    "-fake-source "^cctx.package ^ "/" ^ file in
+  let action = Format.asprintf "(run coqc %s %s %%{dep:%s})" flags fake_source vfile_base in
   let targets = Coq_module.obj_files ~tname ~rule coq_module in
   let alias = if rule = Coq_module.Rule_type.Quick then Some "vio" else None in
   { Dune_file.Rule.targets; deps; action; alias }

--- a/toplevel/ccompile.ml
+++ b/toplevel/ccompile.ml
@@ -20,6 +20,11 @@ let create_empty_file filename =
   let f = open_out filename in
   close_out f
 
+let source copts ldir file = Loc.InFile {
+    dirpath=Some (Names.DirPath.to_string ldir);
+    file = Option.default file copts.fake_source;
+  }
+
 (* Compile a vernac file *)
 let compile opts stm_options injections copts ~echo ~f_in ~f_out =
   let open Vernac.State in
@@ -61,7 +66,8 @@ let compile opts stm_options injections copts ~echo ~f_in ~f_out =
 
       let wall_clock1 = Unix.gettimeofday () in
       let check = Stm.AsyncOpts.(stm_options.async_proofs_mode = APoff) in
-      let state = Vernac.load_vernac ~echo ~check ~interactive:false ~state ~ldir long_f_dot_in in
+      let source = source copts ldir long_f_dot_in in
+      let state = Vernac.load_vernac ~echo ~check ~interactive:false ~state ~source long_f_dot_in in
       let state = Stm.join ~doc:state.doc in
       let wall_clock2 = Unix.gettimeofday () in
       ensure_no_pending_proofs ~filename:long_f_dot_in state;
@@ -89,7 +95,8 @@ let compile opts stm_options injections copts ~echo ~f_in ~f_out =
       let state = { doc; sid; proof = None; time = opts.config.time } in
       let state = Load.load_init_vernaculars opts ~state in
       let ldir = Stm.get_ldir ~doc:state.doc in
-      let state = Vernac.load_vernac ~echo ~check:false ~interactive:false ~state long_f_dot_in in
+      let source = source copts ldir long_f_dot_in in
+      let state = Vernac.load_vernac ~echo ~check:false ~interactive:false ~source ~state long_f_dot_in in
       let state = Stm.finish ~doc:state.doc in
       ensure_no_pending_proofs state ~filename:long_f_dot_in;
       let create_vos = (mode = BuildVos) in

--- a/toplevel/coqcargs.ml
+++ b/toplevel/coqcargs.ml
@@ -15,6 +15,7 @@ type t =
 
   ; compile_file: (string * bool) option  (* bool is verbosity  *)
   ; compilation_output_name : string option
+  ; fake_source : string option
 
   ; vio_checking : bool
   ; vio_tasks    : (int list * string) list
@@ -33,6 +34,7 @@ let default =
 
   ; compile_file = None
   ; compilation_output_name = None
+  ; fake_source = None
 
   ; vio_checking = false
   ; vio_tasks    = []
@@ -169,6 +171,8 @@ let parse arglist : t =
         (* Output filename *)
         | "-o" ->
           { oval with compilation_output_name = Some (next ()) }
+        | "-fake-source" ->
+          { oval with fake_source = Some (next ()) }
         | "-quick" ->
           warn_deprecated_quick();
           set_compilation_mode oval BuildVio

--- a/toplevel/coqcargs.mli
+++ b/toplevel/coqcargs.mli
@@ -29,6 +29,7 @@ type t =
 
   ; compile_file: (string * bool) option  (* bool is verbosity  *)
   ; compilation_output_name : string option
+  ; fake_source : string option
 
   ; vio_checking : bool
   ; vio_tasks    : (int list * string) list

--- a/toplevel/vernac.mli
+++ b/toplevel/vernac.mli
@@ -30,4 +30,4 @@ val process_expr : state:State.t -> Vernacexpr.vernac_control -> State.t
     echo the commands if [echo] is set. Callers are expected to handle
     and print errors in form of exceptions. *)
 val load_vernac : echo:bool -> check:bool -> interactive:bool ->
-  state:State.t -> ?ldir:Names.DirPath.t -> string -> State.t
+  state:State.t -> ?source:Loc.source -> string -> State.t


### PR DESCRIPTION
I tried to figure out how to get dune to run from the right directory to get nice paths but couldn't.

Therefore instead I made a way to get coq to report a different path.
