### PR TITLE
Extraction: extend pruning of unused declarations after inlining to modules

### DIFF
--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -319,13 +319,13 @@ let rec extract_structure env mp reso ~all = function
       let mp = MPdot (mp,l) in
       let all' = all || Visit.needed_mp_all mp in
       if all' || Visit.needed_mp mp then
-        (l,SEmodule (extract_module env mp ~all:all' mb)) :: ms
+        (l,SEmodule (mp, extract_module env mp ~all:all' mb)) :: ms
       else ms
   | (l,SFBmodtype mtb) :: struc ->
       let ms = extract_structure env mp reso ~all struc in
       let mp = MPdot (mp,l) in
       if all || Visit.needed_mp mp then
-        (l,SEmodtype (extract_mbody_spec env mp mtb)) :: ms
+        (l,SEmodtype (mp, extract_mbody_spec env mp mtb)) :: ms
       else ms
 
 (* From [module_expr] and [module_expression] to implementations *)
@@ -691,7 +691,7 @@ let flatten_structure struc =
   let rec flatten_elem (lab,elem) = match elem with
     |SEdecl d -> [d]
     |SEmodtype _ -> []
-    |SEmodule m -> match m.ml_mod_expr with
+    |SEmodule (_,m) -> match m.ml_mod_expr with
       |MEfunctor _ -> []
       |MEident _ | MEapply _ -> assert false (* should be expanded *)
       |MEstruct (_,elems) -> flatten_elems elems

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -395,8 +395,8 @@ and extract_module env mp ~all mb =
   let typ = match mb.mod_expr with
     | FullStruct ->
       assert (Option.is_empty mb.mod_type_alg);
-      mtyp_of_mexpr impl
-    | _ -> extract_mbody_spec env mp mb
+      None
+    | _ -> Some (extract_mbody_spec env mp mb)
   in
   { ml_mod_expr = impl;
     ml_mod_type = typ }

--- a/plugins/extraction/haskell.ml
+++ b/plugins/extraction/haskell.ml
@@ -278,8 +278,8 @@ and pp_function env f t =
 
 let pp_logical_ind packet =
   pp_bracket_comment
-    (Id.print packet.ip_typename ++ str " : logical inductive" ++ fnl () ++
-     str "with constructors : " ++ prvect_with_sep spc Id.print packet.ip_consnames)
+    (Id.print packet.ip_typename ++ str ": logical inductive" ++ fnl () ++
+     str "with constructors: " ++ prvect_with_sep spc Id.print packet.ip_consnames)
 
 let pp_singleton kn packet =
   let name = pp_global Type (GlobRef.IndRef (kn,0)) in

--- a/plugins/extraction/haskell.ml
+++ b/plugins/extraction/haskell.ml
@@ -377,8 +377,8 @@ let pp_decl = function
 
 let rec pp_structure_elem = function
   | (l,SEdecl d) -> pp_decl d
-  | (l,SEmodule m) -> pp_module_expr m.ml_mod_expr
-  | (l,SEmodtype m) -> mt ()
+  | (l,SEmodule (_,m)) -> pp_module_expr m.ml_mod_expr
+  | (l,SEmodtype (_,m)) -> mt ()
       (* for the moment we simply discard module type *)
 
 and pp_module_expr = function

--- a/plugins/extraction/json.ml
+++ b/plugins/extraction/json.ml
@@ -251,8 +251,8 @@ let pp_decl = function
 
 let rec pp_structure_elem = function
   | (l,SEdecl d) -> [ pp_decl d ]
-  | (l,SEmodule m) -> pp_module_expr m.ml_mod_expr
-  | (l,SEmodtype m) -> []
+  | (l,SEmodule (_,m)) -> pp_module_expr m.ml_mod_expr
+  | (l,SEmodtype (_,m)) -> []
       (* for the moment we simply discard module type *)
 
 and pp_module_expr = function

--- a/plugins/extraction/miniml.ml
+++ b/plugins/extraction/miniml.ml
@@ -169,8 +169,8 @@ and ml_module_sig = (Label.t * ml_specif) list
 
 type ml_structure_elem =
   | SEdecl of ml_decl
-  | SEmodule of ml_module
-  | SEmodtype of ml_module_type
+  | SEmodule of ModPath.t * ml_module
+  | SEmodtype of ModPath.t * ml_module_type
 
 and ml_module_expr =
   | MEident of ModPath.t

--- a/plugins/extraction/miniml.ml
+++ b/plugins/extraction/miniml.ml
@@ -182,7 +182,7 @@ and ml_module_structure = (Label.t * ml_structure_elem) list
 
 and ml_module =
     { ml_mod_expr : ml_module_expr;
-      ml_mod_type : ml_module_type }
+      ml_mod_type : ml_module_type option }
 
 (* NB: we do not translate the [mod_equiv] field, since [mod_equiv = mp]
    implies that [mod_expr = MEBident mp]. Same with [msb_equiv]. *)

--- a/plugins/extraction/miniml.mli
+++ b/plugins/extraction/miniml.mli
@@ -169,8 +169,8 @@ and ml_module_sig = (Label.t * ml_specif) list
 
 type ml_structure_elem =
   | SEdecl of ml_decl
-  | SEmodule of ml_module
-  | SEmodtype of ml_module_type
+  | SEmodule of ModPath.t * ml_module
+  | SEmodtype of ModPath.t * ml_module_type
 
 and ml_module_expr =
   | MEident of ModPath.t

--- a/plugins/extraction/miniml.mli
+++ b/plugins/extraction/miniml.mli
@@ -182,7 +182,7 @@ and ml_module_structure = (Label.t * ml_structure_elem) list
 
 and ml_module =
     { ml_mod_expr : ml_module_expr;
-      ml_mod_type : ml_module_type }
+      ml_mod_type : ml_module_type option }
 
 (* NB: we do not translate the [mod_equiv] field, since [mod_equiv = mp]
    implies that [mod_expr = MEBident mp]. Same with [msb_equiv]. *)

--- a/plugins/extraction/modutil.ml
+++ b/plugins/extraction/modutil.ml
@@ -57,9 +57,9 @@ let se_iter do_decl do_spec do_mp =
   in
   let rec se_iter = function
     | (_,SEdecl d) -> do_decl d
-    | (_,SEmodule m) ->
+    | (_,SEmodule (_,m)) ->
         me_iter m.ml_mod_expr; mt_iter m.ml_mod_type
-    | (_,SEmodtype m) -> mt_iter m
+    | (_,SEmodtype (_,m)) -> mt_iter m
   and me_iter = function
     | MEident mp -> do_mp mp
     | MEfunctor (_,mt,me) -> me_iter me; mt_iter mt
@@ -193,8 +193,8 @@ let rec msig_of_ms = function
         msig := (l,Spec (Sval (rv.(i),tv.(i))))::!msig
       done;
       !msig
-  | (l,SEmodule m) :: ms -> (l,Smodule m.ml_mod_type) :: (msig_of_ms ms)
-  | (l,SEmodtype m) :: ms -> (l,Smodtype m) :: (msig_of_ms ms)
+  | (l,SEmodule (_,m)) :: ms -> (l,Smodule m.ml_mod_type) :: (msig_of_ms ms)
+  | (l,SEmodtype (_,m)) :: ms -> (l,Smodtype m) :: (msig_of_ms ms)
 
 let signature_of_structure s =
   List.map (fun (mp,ms) -> mp,msig_of_ms ms) s
@@ -226,8 +226,8 @@ let get_decl_in_structure r struc =
       | l :: ll ->
           match search_structure l (not (List.is_empty ll)) sel with
             | SEdecl d -> d
-            | SEmodtype m -> assert false
-            | SEmodule m ->
+            | SEmodtype (_,m) -> assert false
+            | SEmodule (_,m) ->
                 let rec aux = function
                   | MEstruct (_,sel) -> go ll sel
                   | MEfunctor (_,_,sel) -> aux sel
@@ -290,9 +290,9 @@ let rec optim_se to_appear s = function
       done;
       let av' = Array.map dump_unused_vars av in
       (l,SEdecl (Dfix (rv, av', tv))) :: (optim_se to_appear s lse)
-  | (l,SEmodule m) :: lse ->
+  | (l,SEmodule (mp,m)) :: lse ->
       let m = { m with ml_mod_expr = optim_me to_appear s m.ml_mod_expr}
-      in (l,SEmodule m) :: (optim_se to_appear s lse)
+      in (l,SEmodule (mp,m)) :: (optim_se to_appear s lse)
   | se :: lse -> se :: (optim_se to_appear s lse)
 
 and optim_me to_appear s = function

--- a/plugins/extraction/modutil.ml
+++ b/plugins/extraction/modutil.ml
@@ -43,12 +43,7 @@ let mt_iter do_decl do_spec do_mp do_mp_type =
         in
         let r = GlobRef.ConstRef (Constant.make2 mp_w (Label.of_id l')) in
         mt_iter mt; do_spec (Stype(r,l,Some t))
-    | MTwith (mt,ML_With_module(idl,mp))->
-        let mp_mt = msid_of_mt mt in
-        let mp_w =
-          List.fold_left (fun mp l -> MPdot(mp,Label.of_id l)) mp_mt idl
-        in
-        mt_iter mt; do_mp_type mp_w; do_mp mp
+    | MTwith (mt,ML_With_module(idl,mp))-> mt_iter mt; do_mp mp
     | MTsig (_, sign) -> List.iter spec_iter sign
   and spec_iter = function
     | (_,Spec s) -> do_spec s

--- a/plugins/extraction/modutil.ml
+++ b/plugins/extraction/modutil.ml
@@ -77,10 +77,6 @@ let struct_iter do_decl do_spec do_mp s =
 
 type do_ref = GlobRef.t -> unit
 
-let record_iter_references do_term = function
-  | Record l -> List.iter (Option.iter do_term) l
-  | _ -> ()
-
 let type_iter_references do_type t =
   let rec iter = function
     | Tglob (r,l) -> do_type r; List.iter iter l
@@ -121,7 +117,6 @@ let ind_iter_references do_term do_cons do_type kn ind =
          | _ -> ());
     Array.iteri (fun j -> cons_iter (ip,j+1)) p.ip_types
   in
-  if lang () == Ocaml then record_iter_references do_term ind.ind_kind;
     Array.iteri (fun i -> packet_iter (kn,i)) ind.ind_packets
 
 let decl_iter_references do_term do_cons do_type =

--- a/plugins/extraction/ocaml.ml
+++ b/plugins/extraction/ocaml.ml
@@ -507,9 +507,9 @@ let pp_one_ind prefix ip_equiv pl name cnames ctyps =
   else fnl () ++ v 0 (prvecti pp_constructor ctyps)
 
 let pp_logical_ind packet =
-  pp_comment (Id.print packet.ip_typename ++ str " : logical inductive") ++
+  pp_comment (Id.print packet.ip_typename ++ str ": logical inductive") ++
   fnl () ++
-  pp_comment (str "with constructors : " ++
+  pp_comment (str "with constructors: " ++
               prvect_with_sep spc Id.print packet.ip_consnames) ++
   fnl ()
 

--- a/plugins/extraction/ocaml.ml
+++ b/plugins/extraction/ocaml.ml
@@ -715,7 +715,10 @@ let rec pp_structure_elem = function
   | (l,SEmodule (_,m)) ->
       let typ =
         (* virtual printing of the type, in order to have a correct mli later*)
-        if Common.get_phase () == Pre then str ": " ++ pp_module_type [] m.ml_mod_type
+        if Common.get_phase () == Pre then
+          match m.ml_mod_type with
+          | None -> mt ()
+          | Some mt -> str ": " ++ pp_module_type [] mt
         else mt ()
       in
       let def = pp_module_expr [] m.ml_mod_expr in

--- a/plugins/extraction/ocaml.ml
+++ b/plugins/extraction/ocaml.ml
@@ -712,11 +712,10 @@ let rec pp_structure_elem = function
       | Some ren ->
          v 1 (str ("module "^ren^" = struct") ++ fnl () ++ pp_decl d) ++
          fnl () ++ str "end" ++ fnl () ++ str ("include "^ren))
-  | (l,SEmodule m) ->
+  | (l,SEmodule (_,m)) ->
       let typ =
         (* virtual printing of the type, in order to have a correct mli later*)
-        if Common.get_phase () == Pre then
-          str ": " ++ pp_module_type [] m.ml_mod_type
+        if Common.get_phase () == Pre then str ": " ++ pp_module_type [] m.ml_mod_type
         else mt ()
       in
       let def = pp_module_expr [] m.ml_mod_expr in
@@ -727,7 +726,7 @@ let rec pp_structure_elem = function
       (match Common.get_duplicate (top_visible_mp ()) l with
        | Some ren -> fnl () ++ str ("module "^ren^" = ") ++ name
        | None -> mt ())
-  | (l,SEmodtype m) ->
+  | (l,SEmodtype (_,m)) ->
       let def = pp_module_type [] m in
       let name = pp_modname (MPdot (top_visible_mp (), l)) in
       hov 1 (str "module type " ++ name ++ str " =" ++ fnl () ++ def) ++

--- a/plugins/extraction/scheme.ml
+++ b/plugins/extraction/scheme.ml
@@ -208,8 +208,8 @@ let pp_decl = function
 
 let rec pp_structure_elem = function
   | (l,SEdecl d) -> pp_decl d
-  | (l,SEmodule m) -> pp_module_expr m.ml_mod_expr
-  | (l,SEmodtype m) -> mt ()
+  | (l,SEmodule (_,m)) -> pp_module_expr m.ml_mod_expr
+  | (l,SEmodtype (_,m)) -> mt ()
       (* for the moment we simply discard module type *)
 
 and pp_module_expr = function

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -334,13 +334,13 @@ let warning_axioms () =
 let warn_extraction_opaque_accessed =
   CWarnings.create ~name:"extraction-opaque-accessed" ~category:CWarnings.CoreCategories.extraction
     (fun lst -> strbrk "The extraction is currently set to bypass opacity, " ++
-                  strbrk "the following opaque constant bodies have been accessed :" ++
+                  strbrk "the following opaque constant bodies have been accessed:" ++
                   lst ++ str "." ++ fnl ())
 
 let warn_extraction_opaque_as_axiom =
   CWarnings.create ~name:"extraction-opaque-as-axiom" ~category:CWarnings.CoreCategories.extraction
     (fun lst -> strbrk "The extraction now honors the opacity constraints by default, " ++
-         strbrk "the following opaque constants have been extracted as axioms :" ++
+         strbrk "the following opaque constants have been extracted as axioms:" ++
          lst ++ str "." ++ fnl () ++
          strbrk "If necessary, use \"Set Extraction AccessOpaque\" to change this."
          ++ fnl ())
@@ -451,14 +451,14 @@ let msg_of_implicit = function
 
 let error_remaining_implicit k =
   let s = msg_of_implicit k in
-  err (str ("An implicit occurs after extraction : "^s^".") ++ fnl () ++
+  err (str ("An implicit occurs after extraction: "^s^".") ++ fnl () ++
        str "Please check your Extraction Implicit declarations." ++ fnl() ++
        str "You might also try Unset Extraction SafeImplicits to force" ++
        fnl() ++ str "the extraction of unsafe code and review it manually.")
 
 let warn_extraction_remaining_implicit =
   CWarnings.create ~name:"extraction-remaining-implicit" ~category:CWarnings.CoreCategories.extraction
-    (fun s -> strbrk ("At least an implicit occurs after extraction : "^s^".") ++ fnl () ++
+    (fun s -> strbrk ("At least an implicit occurs after extraction: "^s^".") ++ fnl () ++
      strbrk "Extraction SafeImplicits is unset, extracting nonetheless,"
      ++ strbrk "but this code is potentially unsafe, please review it manually.")
 

--- a/test-suite/output/bug7348.out
+++ b/test-suite/output/bug7348.out
@@ -13,11 +13,6 @@ module Case1 =
  struct
   type coq_rec = { f : bool }
 
-  (** val f : bool -> coq_rec -> bool **)
-
-  let f _ r =
-    r.f
-
   (** val silly : bool -> coq_rec -> __ **)
 
   let silly x b =
@@ -29,11 +24,6 @@ module Case1 =
 module Case2 =
  struct
   type coq_rec = { f : (bool -> bool) }
-
-  (** val f : bool -> coq_rec -> bool -> bool **)
-
-  let f _ r =
-    r.f
 
   (** val silly : bool -> coq_rec -> __ **)
 


### PR DESCRIPTION
Pruning of unused declarations after inlining was limited to the toplevel. We extend it to proper modules.

For sealed modules, or modules that are arguments of a functor, or modules that are argument of a `with`, or functors, we expect extraction of all the declarations of the module.

Fixes / closes #4650

- [x] Added / updated **test-suite**.
- [ ] Added **changelog**.
