### PR TITLE
Improve fatal locality warning message.

### DIFF
--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -539,11 +539,13 @@ let find_applied_relation ?loc env sigma c left2right =
 let warn_deprecated_hint_rewrite_without_locality =
   CWarnings.create ~name:"deprecated-hint-rewrite-without-locality" ~category:"deprecated"
     ~default:CWarnings.AsError
-    (fun () -> strbrk "The default value for rewriting hint locality is currently \
-    \"local\" in a section and \"global\" otherwise, but is scheduled to change \
-    in a future release. For the time being, adding rewriting hints outside of sections \
-    without specifying an explicit locality attribute is therefore deprecated. It is \
-    recommended to use \"export\" whenever possible. Use the attributes \
+    (fun () -> strbrk "The default value for rewriting hint locality is \
+    currently \"global\" outside sections, but is scheduled to change to \
+    \"export\" in the next release (Coq 8.18). In Coq 8.17, not providing \
+    an explicit locality outside sections triggers a fatal warning, to \
+    ensure that hint localities are made explicit before the upcoming \
+    change in the default value. It is recommended to use \"export\" \
+    whenever possible. Use the attributes \
     #[local], #[global] and #[export] depending on your choice. For example: \
     \"#[export] Hint Rewrite foo : bar.\" This is supported since Coq 8.14.")
 

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1300,11 +1300,13 @@ let make_hint ~locality name action =
 let warn_deprecated_hint_without_locality =
   CWarnings.create ~name:"deprecated-hint-without-locality" ~category:"deprecated"
     ~default:CWarnings.AsError
-    (fun () -> strbrk "The default value for hint locality is currently \
-    \"local\" in a section and \"global\" otherwise, but is scheduled to change \
-    in a future release. For the time being, adding hints outside of sections \
-    without specifying an explicit locality attribute is therefore deprecated. It is \
-    recommended to use \"export\" whenever possible. Use the attributes \
+    (fun () -> strbrk "The default value for hint locality is \
+    currently \"global\" outside sections, but is scheduled to change to \
+    \"export\" in the next release (Coq 8.18). In Coq 8.17, not providing \
+    an explicit locality outside sections triggers a fatal warning, to \
+    ensure that hint localities are made explicit before the upcoming \
+    change in the default value. It is recommended to use \"export\" \
+    whenever possible. Use the attributes \
     #[local], #[global] and #[export] depending on your choice. For example: \
     \"#[export] Hint Unfold foo : bar.\"")
 


### PR DESCRIPTION
Fixes / closes #17309.

@MSoegtropIMC Can you check if this solves the issue you were reporting?

The new message is:

>The default value for [rewriting] hint locality is currently "global" outside sections, but is scheduled to
change to "export" in the next release (Coq 8.18). In Coq 8.17, not providing an explicit locality
outside sections triggers a fatal warning, to ensure that hint localities are made explicit before
the upcoming change in the default value. It is recommended to use "export" whenever possible. Use
the attributes #[local], #[global] and #[export] depending on your choice. For example: "#[export]
Hint Unfold foo : bar." [deprecated-hint-without-locality,deprecated]