### PR TITLE
Understand type-in-type when checking (ie not infer) constraints

### DIFF
--- a/kernel/uGraph.ml
+++ b/kernel/uGraph.ml
@@ -103,8 +103,9 @@ let enforce_constraint cst g = match enforce_constraint0 cst g with
 
 let merge_constraints csts g = Constraints.fold enforce_constraint csts g
 
-let check_constraint { graph = g; _ } (u,d,v) =
-  match d with
+let check_constraint { graph = g; type_in_type } (u,d,v) =
+  type_in_type
+  || match d with
   | Le -> G.check_leq g u v
   | Lt -> G.check_lt g u v
   | Eq -> G.check_eq g u v

--- a/test-suite/bugs/bug_17355.v
+++ b/test-suite/bugs/bug_17355.v
@@ -1,0 +1,11 @@
+
+Polymorphic Axiom foo@{u v | u < v} : Type@{v}.
+
+Unset Universe Checking.
+Type foo@{Set Set}.
+
+Polymorphic Definition castU@{u v |}(t: Type@{u}): Type@{v} := t.
+
+Set Universe Checking.
+
+Polymorphic Definition bar@{u v|} : Type@{u} -> Type@{v} := castU@{u v}.


### PR DESCRIPTION
Fix #17355
Fix https://github.com/coq/coq/issues/17361

We also refactor the checking of universe declarations in ustate so that when given non extensible constraints we return them instead of returning the inferred constraints.
