### PR TITLE
Clearer documentation of `coqdoc`'s `--lib-subtitles`

### DIFF
--- a/doc/sphinx/using/tools/coqdoc.rst
+++ b/doc/sphinx/using/tools/coqdoc.rst
@@ -395,7 +395,7 @@ Command line options
      titles. For example “Chapter” and “Module” are reasonable choices.
   :--no-lib-name: Print just “Foo” instead of “Library Foo” in titles.
   :--lib-subtitles: Look for library subtitles. When enabled, the
-     beginning of each file is checked for a comment of the form:
+     first line of each file is checked for a comment of the form:
 
      ::
 


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

The documentation of `coqdoc`'s option `--lib-subtitles` in the reference manual reads
> When enabled, the beginning of each file is checked for a comment of the form:

which is unclear as to the fact that only *the first line* of a file is checked. The command-line documentation of `coqdoc` instead reads the much clearer

> first line comments of the form (** * ModuleName : text *) will be interpreted as subtitles

This PR clarifies the reference manual.
