### PR TITLE
Adding options -require, -r, -require-from in addition to -rfrom

### DIFF
--- a/boot/usage.ml
+++ b/boot/usage.ml
@@ -40,21 +40,24 @@ let print_usage_common co command =
 \n  -l f                   (idem)\
 \n  -load-vernac-source-verbose f  load Coq file f.v (Load Verbose \"f\".)\
 \n  -lv f	           (idem)\
-\n  -load-vernac-object lib\
+\n  -require lib, -r lib\
 \n                         load Coq library lib (Require lib)\
-\n  -rfrom root lib        load Coq library lib (From root Require lib.)\
 \n  -require-import lib, -ri lib\
 \n                         load and import Coq library lib\
 \n                         (equivalent to Require Import lib.)\
 \n  -require-export lib, -re lib\
 \n                         load and transitively import Coq library lib\
 \n                         (equivalent to Require Export lib.)\
+\n  -require-from root lib, -rfrom root lib
+\n                         load Coq library lib (From root Require lib.)\
 \n  -require-import-from root lib, -rifrom root lib\
 \n                         load and import Coq library lib\
 \n                         (equivalent to From root Require Import lib.)\
 \n  -require-export-from root lib, -refrom root lib\
 \n                         load and transitively import Coq library lib\
 \n                         (equivalent to From root Require Export lib.)\
+\n  -load-vernac-object lib\
+\n                         (obsolete synonym of -require lib)\
 \n\
 \n  -where                 print Coq's standard library location and exit\
 \n  -config, --config      print Coq's configuration information and exit\

--- a/boot/usage.ml
+++ b/boot/usage.ml
@@ -40,8 +40,7 @@ let print_usage_common co command =
 \n  -l f                   (idem)\
 \n  -load-vernac-source-verbose f  load Coq file f.v (Load Verbose \"f\".)\
 \n  -lv f	           (idem)\
-\n  -require lib, -r lib\
-\n                         load Coq library lib (Require lib)\
+\n  -require lib           load Coq library lib (Require lib)\
 \n  -require-import lib, -ri lib\
 \n                         load and import Coq library lib\
 \n                         (equivalent to Require Import lib.)\

--- a/doc/changelog/09-cli-tools/17364-master+add-command-line-option-require.rst
+++ b/doc/changelog/09-cli-tools/17364-master+add-command-line-option-require.rst
@@ -1,0 +1,6 @@
+- **Added:**
+  Command line options :n:`-require lib` (replacing
+  :n:`-load-vernac-object lib`) and :n:`-require-from root lib`
+  respectively equivalent to vernacular commands :n:`Require lib` and
+  :n:`From root Require lib`
+  (`#17364 <https://github.com/coq/coq/pull/17364>`_, by Hugo Herbelin).

--- a/doc/sphinx/practical-tools/coq-commands.rst
+++ b/doc/sphinx/practical-tools/coq-commands.rst
@@ -236,31 +236,31 @@ and ``coqtop``, unless stated otherwise:
 :-lv *file*, -load-vernac-source-verbose *file*: Load and execute the
   Coq script from *file.v*. Write its contents to the standard output as
   it is executed.
-:-load-vernac-object *qualid*: Load Coq compiled library :n:`@qualid`. This
-  is equivalent to running :cmd:`Require` :n:`@qualid`.
+:-r *qualid*, -require *qualid*: Load Coq compiled library :n:`@qualid`.
+  This is equivalent to running :cmd:`Require` :n:`@qualid`.
 
   .. _interleave-command-line:
 
   .. note::
 
      Note that the relative order of this command-line option and its
-     variants (`-rfrom`, `-ri`, `-re`, etc.)  and of the `-set` and
+     variants (`-ri`, `-re`, `-rfrom`, `-refrom`, `-rifrom`)  and of the `-set` and
      `-unset` options matters since the various :cmd:`Require`,
      :cmd:`Require Import`, :cmd:`Require Export`, :cmd:`Set` and
      :cmd:`Unset` commands will be executed in the order specified on
      the command-line.
 
-:-rfrom *dirpath qualid*: Load Coq compiled library :n:`@qualid`.
-  This is equivalent to running :cmd:`From <From … Require>`
-  :n:`@dirpath` :cmd:`Require <From … Require>` :n:`@qualid`.
-  See the :ref:`note above <interleave-command-line>` regarding the order
-  of command-line options.
 :-ri *qualid*, -require-import *qualid*: Load Coq compiled library :n:`@qualid` and import it.
   This is equivalent to running :cmd:`Require Import` :n:`@qualid`.
   See the :ref:`note above <interleave-command-line>` regarding the order
   of command-line options.
 :-re *qualid*, -require-export *qualid*: Load Coq compiled library :n:`@qualid` and transitively import it.
   This is equivalent to running :cmd:`Require Export` :n:`@qualid`.
+  See the :ref:`note above <interleave-command-line>` regarding the order
+  of command-line options.
+:-rfrom *dirpath qualid*, -require-from *dirpath qualid*: Load Coq compiled library :n:`@qualid`.
+  This is equivalent to running :cmd:`From <From … Require>`
+  :n:`@dirpath` :cmd:`Require <From … Require>` :n:`@qualid`.
   See the :ref:`note above <interleave-command-line>` regarding the order
   of command-line options.
 :-rifrom *dirpath qualid*, -require-import-from *dirpath qualid*:
@@ -275,6 +275,7 @@ and ``coqtop``, unless stated otherwise:
   :n:`@dirpath` :cmd:`Require Export <From … Require>` :n:`@qualid`.
   See the :ref:`note above <interleave-command-line>` regarding the
   order of command-line options.
+:-load-vernac-object *qualid*: Obsolete synonym of :n:`-require qualid`.
 :-batch: Exit just after argument parsing. Available for ``coqtop`` only.
 :-verbose: Output the content of the input file as it is compiled.
   This option is available for ``coqc`` only.

--- a/doc/sphinx/practical-tools/coq-commands.rst
+++ b/doc/sphinx/practical-tools/coq-commands.rst
@@ -236,8 +236,10 @@ and ``coqtop``, unless stated otherwise:
 :-lv *file*, -load-vernac-source-verbose *file*: Load and execute the
   Coq script from *file.v*. Write its contents to the standard output as
   it is executed.
-:-r *qualid*, -require *qualid*: Load Coq compiled library :n:`@qualid`.
-  This is equivalent to running :cmd:`Require` :n:`@qualid`.
+:-require *qualid*: Load Coq compiled library :n:`@qualid`.
+  This is equivalent to running :cmd:`Require` :n:`@qualid`
+  (note: the short form `-r *qualid*` is intentionally not provided to
+  prevent the risk of collision with `-R`).
 
   .. _interleave-command-line:
 

--- a/man/coqtop.1
+++ b/man/coqtop.1
@@ -73,7 +73,7 @@ load verbosely Coq file
 (Load Verbose filename.)
 
 .TP
-.BI \-require \ lib, \ \-r \ lib
+.BI \-require \ lib
 load Coq library
 .I lib
 (Require lib.)

--- a/man/coqtop.1
+++ b/man/coqtop.1
@@ -51,14 +51,14 @@ instead of Top
 start with an empty initial state
 
 .TP
-.BI \-load\-ml\-object \ filename
-load ML object file
-.I filenname
-
-.TP
 .BI \-load\-ml\-source \ filename
 load ML file
 .I filename
+
+.TP
+.BI \-load\-ml\-object \ filename
+load ML object file
+.I filenname
 
 .TP
 .BI \-load\-vernac\-source \ filename, \ \-l \ filename
@@ -73,16 +73,45 @@ load verbosely Coq file
 (Load Verbose filename.)
 
 .TP
-.BI \-load\-vernac\-object \ path
+.BI \-require \ lib, \ \-r \ lib
 load Coq library
-.I path
-(Require path.)
+.I lib
+(Require lib.)
 
 .TP
-.BI \-require-import \ path
+.BI \-require-import \ lib, \ \-ri \ lib
 load Coq library
-.I path
-and import it (Require Import path.)
+.I lib
+and import it (Require Import lib.)
+
+.TP
+.BI \-require-export \ lib, \ \-re \ lib
+load Coq library
+.I lib
+and transitively import it (Require Export lib.)
+
+.TP
+.BI \-require-from \ root\ lib, \ \-rfrom \ root\ lib
+load Coq library
+.I lib
+(From root Require lib.)
+
+.TP
+.BI \-require-import-from \ root\ lib, \ \-rifrom \ root\ lib
+load Coq library
+.I lib
+and import it (From root Require Import lib.)
+
+.TP
+.BI \-require-export-from \ root\ lib, \ \-refrom \ root\ lib
+load Coq library
+.I lib
+and transitively import it (From root Require Export lib.)
+
+.TP
+.BI \-load\-vernac\-object \ lib
+obsolete synonym of
+.BI \-require \ lib
 
 .TP
 .B \-where

--- a/sysinit/coqargs.ml
+++ b/sysinit/coqargs.ml
@@ -306,9 +306,6 @@ let parse_args ~usage ~init arglist : t * string list =
     |"-init-file" ->
       { oval with config = { oval.config with rcfile = Some (next ()); }}
 
-    |"-load-vernac-object" ->
-      add_vo_require oval (next ()) None None
-
     |"-load-vernac-source"|"-l" ->
       add_load_vernacular oval false (next ())
 
@@ -324,12 +321,15 @@ let parse_args ~usage ~init arglist : t * string list =
       Flags.profile_ltac_cutoff := get_float ~opt (next ());
       oval
 
-    |"-rfrom" ->
-      let from = next () in add_vo_require oval (next ()) (Some from) None
+    |"-load-vernac-object"|"-require"|"-r" ->
+      add_vo_require oval (next ()) None None
 
     |"-require-import" | "-ri" -> add_vo_require oval (next ()) None (Some Lib.Import)
 
     |"-require-export" | "-re" -> add_vo_require oval (next ()) None (Some Lib.Export)
+
+    |"-require-from"|"-rfrom" ->
+      let from = next () in add_vo_require oval (next ()) (Some from) None
 
     |"-require-import-from" | "-rifrom" ->
       let from = next () in add_vo_require oval (next ()) (Some from) (Some Lib.Import)

--- a/sysinit/coqargs.ml
+++ b/sysinit/coqargs.ml
@@ -321,7 +321,7 @@ let parse_args ~usage ~init arglist : t * string list =
       Flags.profile_ltac_cutoff := get_float ~opt (next ());
       oval
 
-    |"-load-vernac-object"|"-require"|"-r" ->
+    |"-load-vernac-object"|"-require" ->
       add_vo_require oval (next ()) None None
 
     |"-require-import" | "-ri" -> add_vo_require oval (next ()) None (Some Lib.Import)


### PR DESCRIPTION
These command line options had misleading semantics and were removed in 8.12 (#10245, #12005). They were planned to be reintroduced with the expected semantics in 8.13, but this was not done yet. This PR does it.