### PR TITLE
Bench: add per line info for major and minor word gc stats

### DIFF
--- a/dev/bench/bench.sh
+++ b/dev/bench/bench.sh
@@ -638,12 +638,7 @@ if [ -d "$working_dir/html" ]; then # might not exist if all jobs failed
 cd "$working_dir/html"
 $render_line_results
 # Move line timing files to timings folder (they will become artifacts)
-mv fast_table slow_table timings_table $timings
-
-# html tables don't get generated if the bench is run locally ie without CI variables
-for f in fast_table.html slow_table.html timings_table.html; do
-    if [ -f "$f" ]; then mv "$f" $timings; fi
-done
+mv ./*_table* $timings
 fi
 
 echo "INFO: workspace = ${CI_JOB_URL}/artifacts/browse/${bench_dirname}"

--- a/dev/bench/render_line_results.ml
+++ b/dev/bench/render_line_results.ml
@@ -21,8 +21,121 @@ let list_html_files dir =
 
 exception UnableToParse
 
+let parse_time_line l =
+  (* we have floats written with s so with split that too *)
+  match Str.split (Str.regexp "[ s]") l with
+  | _ :: str :: _ -> float_of_string str
+  | _ -> raise @@ UnableToParse
+
+let parse_mem_line l =
+  (* memory stats are written as Major/Minor: xx.xxMw *)
+  match Str.split (Str.regexp "[ M]") l with
+  | _ :: str :: _ -> float_of_string str
+  | _ -> raise @@ UnableToParse
+
+type diff_kind =
+  { name : string
+  ; table_name : string
+  }
+
+module DiffTupleCore : sig
+  (** Lists with length exactly the length of diff_kinds.
+
+     We use a separate type to make it easier to understand what's
+     going on when we get a [_ list DiffTuple.t] (which would
+     otherwise be [_ list list] and hard to tell which list is
+     arbitrary length). *)
+  type 'a t = private 'a list
+
+  val diff_kinds : diff_kind t
+
+  val map : ('a -> 'b) -> 'a t -> 'b t
+
+  val mapi : (int -> 'a -> 'b) -> 'a t -> 'b t
+
+  val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
+
+  val iter2 : ('a -> 'b -> unit) -> 'a t -> 'b t -> unit
+
+  val make : 'a -> 'a t
+
+  val of_list : 'a list -> 'a t
+
+end = struct
+
+  type 'a t = 'a list
+
+  let map = CList.map
+
+  let mapi = CList.mapi
+
+  let map2 = CList.map2
+
+  let iter2 = List.iter2
+
+  let diff_kinds = [
+    { name = "time";
+      table_name = "timings"; };
+    { name = "major alloc";
+      table_name = "majors"; };
+    { name = "minor_allocs";
+      table_name = "minors"; };
+  ]
+
+  let len = List.length diff_kinds
+
+  let make x = CList.make len x
+
+  let of_list l = assert (List.length l = len); l
+
+end
+
+module DiffTuple : sig
+  include module type of DiffTupleCore
+
+  val split : 'a t list -> 'a list t
+end = struct
+  include DiffTupleCore
+
+  let rec split_rec acc = function
+    | [] -> map List.rev acc
+    | hd :: tl ->
+      let acc = map2 (fun hd acc -> hd :: acc) hd acc in
+      split_rec acc tl
+
+  let split l = split_rec (make []) l
+
+end
+
+type one_diff =
+  { v1 : float
+  ; v2 : float
+  ; diff : float
+  ; pdiff : float
+  ; line_num : int
+  ; file : string
+  }
+
+(* We accumulate the data in a tuple if the difference is non-zero *)
+(* We also check that values are not too small (tolerence is trial and error) *)
+let add_if_nonnegligible ~line_num ~file v1 v2 acc =
+  let diff = v2 -. v1 in
+  let pdiff = if v1 <> 0.0 then (diff *. 100.0) /. v1 else Float.infinity in
+  if Float.abs diff <= 1e-4 then acc
+  else {v1; v2; diff; pdiff; line_num; file} :: acc
+
+let multi_add ~line_num ~file vs acc =
+  DiffTuple.map2 (fun (v1,v2) acc -> add_if_nonnegligible ~line_num ~file v1 v2 acc) vs acc
+
+let add_just_time ~line_num ~file (v1,v2) acc =
+  DiffTuple.mapi (fun i acc ->
+      if i = 0 then add_if_nonnegligible ~line_num ~file v1 v2 acc else acc)
+    acc
+
 (** Read all the lines of a file into a list *)
-let read_timing_lines file =
+(* TODO we should really be reading from something nicer than comments
+   in a generated html file... *)
+let read_lines file =
   let ic = open_in file in
   (* We tail recursively read lines in the file discarding the uninteresting ones *)
   let rec read_lines_aux acc =
@@ -36,32 +149,38 @@ let read_timing_lines file =
           in
           (* Second line is empty *)
           let _ = input_line ic in
-          (* Time1 - we have floats written with s so with split that too *)
-          let time1 = match Str.split (Str.regexp "[ s]") (input_line ic) with
-            | _ :: time1_str :: _ -> float_of_string time1_str
-            | _ -> raise @@ UnableToParse
+          (* Time1 *)
+          let time1 = parse_time_line (input_line ic) in
+          let next = input_line ic in
+          let acc = if CString.is_prefix "Major1" next then
+              let major1 = parse_mem_line next in
+              let minor1 = parse_mem_line (input_line ic) in
+              (* Time2 *)
+              let time2 = parse_time_line (input_line ic) in
+              let next = input_line ic in
+              if CString.is_prefix "Major2" next then
+                let major2 = parse_mem_line next in
+                let minor2 = parse_mem_line (input_line ic) in
+                multi_add ~line_num ~file
+                  (DiffTuple.of_list [(time1,time2); (major1,major2); (minor1,minor2)])
+                  acc
+              else
+                (* support files produced with old Coq without mem stats
+                   NB: here the first run had mem stats but not the second *)
+                add_just_time ~line_num ~file (time1,time2) acc
+            else
+              (* support files produced with old Coq without mem stats
+                 NB: it's possible that the second run had mem stats but we just skip them *)
+              let time2 = parse_time_line next in
+              add_just_time ~line_num ~file (time1,time2) acc
           in
-          (* Time2 *)
-          let time2 = match Str.split (Str.regexp "[ s]") (input_line ic) with
-            | _ :: time2_str :: _ -> float_of_string time2_str
-            | _ -> raise @@ UnableToParse
-          in
-          (* Difference *)
-          let diff = time2 -. time1 in
-          (* Percentage diff *)
-          let pdiff = if time1 <> 0.0 then (diff *. 100.0) /. time1 else Float.infinity in
-          (* We accumulate the timing data in a tuple if the difference is non-zero *)
-          (* We also check that timed values are not too small (tolerence is trial and error) *)
-          if Float.abs diff <= 1e-4 then
-            acc |> read_lines_aux
-          else
-            (time1, time2, diff, pdiff, line_num, file) :: acc |> read_lines_aux
+          read_lines_aux acc
         else
           read_lines_aux acc
     | exception End_of_file -> acc
   in
   let lines =
-    try Some (read_lines_aux [])
+    try Some (read_lines_aux (DiffTuple.map (fun _ -> []) DiffTuple.diff_kinds))
     with End_of_file ->
       Printf.eprintf "*** Error: Could not read file %s.\n" file; None
   in
@@ -86,7 +205,7 @@ let html_str ?html lnum s = match html with
     let s = Printf.sprintf "<a href=\"%s%s#L%d\">%s</a>" html.link_prefix s lnum s in
     { Table.str = s; size }
 
-let list_timing_data ?html (time1, time2, diff, pdiff, line_num, file) =
+let list_timing_data ?html {v1=time1; v2=time2; diff; pdiff; line_num; file} =
   let str_time1 = Printf.sprintf "%.4f" time1 in
   let str_time2 = Printf.sprintf "%.4f" time2 in
   let str_diff  = Printf.sprintf "%.4f" diff in
@@ -103,56 +222,58 @@ let render_table ?(reverse=false) title num table =
   let align_top = [[Middle; Middle; Middle; Middle; Middle; MidLeft]] in
   let align_rows = [[Right; Right; Right; Right; Right; Left]] in
   (if reverse then CList.rev table else table)
-  |> CList.firstn num
+  |> (match num with Some num -> CList.firstn num | None -> fun x -> x)
   |> fun x -> Table.print headers top x ~align_top ~align_rows ()
 
 let to_file fname fmt =
   Printf.kfprintf close_out (open_out fname) fmt
+
+let sort_table table =
+  table
+  |> CList.flatten
+  (* Do we want to do a unique sort? *)
+  (* |> CList.sort_uniq ... *)
+  |> CList.sort (fun x y -> Float.compare x.diff y.diff)
+
+let render_and_print ?html data =
+  let tables =
+    data |> DiffTuple.map (fun data ->
+        data
+        |> CList.map (list_timing_data ?html)
+        |> CList.map (fun x -> [ x ]))
+  in
+  let times = List.hd (tables : _ DiffTuple.t :> _ list) in
+  (* What is a good number to choose? *)
+  let num = 25 in
+  let num = min num (CList.length times) in
+  let slow_table = render_table (Printf.sprintf "TOP %d SLOW DOWNS" num) ~reverse:true (Some num) times in
+  let fast_table = render_table (Printf.sprintf "TOP %d SPEED UPS" num) (Some num) times in
+  let () = if Option.is_empty html then Printf.printf "%s\n%s\n" slow_table fast_table in
+  let () = DiffTuple.iter2 (fun kind table ->
+      let title = Printf.sprintf "Significant %s changes in bench" kind.name in
+      let table = render_table title None table in
+      let fext, fmt = if Option.is_empty html then "", ("%s\n" : _ format)
+        else ".html", ("<pre>%s</pre>\n" : _ format)
+      in
+      let fname = Printf.sprintf "%s_table%s" kind.table_name fext in
+      to_file fname fmt table)
+      DiffTuple.diff_kinds tables
+  in
+  ()
 
 let main () =
   let () = Printexc.record_backtrace true in
   let data =
     Unix.getcwd ()
     |> list_html_files
-    |> CList.filter_map read_timing_lines
-    |> CList.flatten
-    (* Do we want to do a unique sort? *)
-    (* |> CList.sort_uniq (fun (_,_,x,_,_,_) (_,_,y,_,_,_) -> Float.compare x y) *)
-    |> CList.sort (fun (_,_,x,_,_,_) (_,_,y,_,_,_) -> Float.compare x y)
+    |> CList.filter_map read_lines
+    |> DiffTuple.split
+    |> DiffTuple.map sort_table
   in
-  let table =
-    data
-    |> CList.map list_timing_data
-    |> CList.map (fun x -> [ x ])
-  in
-  (* What is a good number to choose? *)
-  let num = 25 in
-  let num = min num (CList.length table) in
-  let slow_table = render_table (Printf.sprintf "TOP %d SLOW DOWNS" num) ~reverse:true num table in
-  let fast_table = render_table (Printf.sprintf "TOP %d SPEED UPS" num) num table in
-  let timings_table = render_table "Significant line time changes in bench" (CList.length table) table in
-  (* Print tables to stdout *)
-  Printf.printf "%s\n%s\n" slow_table fast_table;
-  (* Print tables to files *)
-  to_file "slow_table" "%s\n" slow_table;
-  to_file "fast_table" "%s\n" fast_table;
-  to_file "timings_table" "%s\n" timings_table;
+  render_and_print data;
   (* html tables *)
   match get_html_data () with
   | None -> ()
-  | Some html ->
-    let table =
-      data
-      |> CList.map (list_timing_data ~html)
-      |> CList.map (fun x -> [ x ])
-    in
-    let slow_table = render_table (Printf.sprintf "TOP %d SLOW DOWNS" num) ~reverse:true num table in
-    let fast_table = render_table (Printf.sprintf "TOP %d SPEED UPS" num) num table in
-    let timings_table = render_table "Significant line time changes in bench" (CList.length table) table in
-    to_file "slow_table.html" "<pre>%s</pre>\n" slow_table;
-    to_file "fast_table.html" "<pre>%s</pre>\n" fast_table;
-    to_file "timings_table.html" "<pre>%s</pre>\n" timings_table;
-    ()
-
+  | Some html -> render_and_print ~html data
 
 let () = main ()

--- a/lib/system.ml
+++ b/lib/system.ml
@@ -330,6 +330,10 @@ let fmt_duration { real = treal; user; system } =
 let fmt_time_difference start stop =
   fmt_duration (duration_between ~start ~stop)
 
+let fmt_mem_difference (start:Gc.stat) (stop:Gc.stat) =
+  real (round ((stop.major_words -. start.major_words) /. 1000000.)) ++ str " major Mw, " ++
+  real (round ((stop.minor_words -. start.minor_words) /. 1000000.)) ++ str " minor Mw"
+
 type 'a transaction_result = (('a * duration), (Exninfo.iexn * duration)) Result.t
 
 let measure_duration f x =

--- a/lib/system.mli
+++ b/lib/system.mli
@@ -118,6 +118,7 @@ val duration_add : duration -> duration -> duration
 val duration_real : duration -> float
 
 val fmt_time_difference : time -> time -> Pp.t
+val fmt_mem_difference : Gc.stat -> Gc.stat -> Pp.t
 val fmt_duration : duration -> Pp.t
 
 type 'a transaction_result = (('a * duration), (Exninfo.iexn * duration)) Result.t

--- a/test-suite/coq-makefile/timing/precomputed-time-tests/004-per-file-fuzz/foo-real.v.timing.diff.expected
+++ b/test-suite/coq-makefile/timing/precomputed-time-tests/004-per-file-fuzz/foo-real.v.timing.diff.expected
@@ -1,29 +1,29 @@
     After | Code                                                        |    Before ||    Change | % Change
 -----------------------------------------------------------------------------------------------------------
- 0m01.23s | Total                                                       |  0m01.28s || -0m00.04s |   -3.50%
+ 0m00.57s | Total                                                       |  0m00.57s || +0m00.00s |   +0.87%
 -----------------------------------------------------------------------------------------------------------
- 0m00.53s | Chars 260-284 ~ 280-304 [(vm_compute;~reflexivity).]        | 0m00.566s || -0m00.03s |   -6.36%
-  0m00.4s | Chars 285-289 ~ 305-309 [Qed.]                              | 0m00.411s || -0m00.01s |   -2.67%
-0m00.194s | Chars 031-064 ~ 031-064 [Require~Import~Coq.ZArith.ZArith.] | 0m00.192s || +0m00.00s |   +1.04%
-0m00.114s | Chars 000-030 ~ 000-030 [Require~Import~Coq.Lists.List.]    | 0m00.114s || +0m00.00s |   +0.00%
-   0m00.s | Chars 065-075 ~ 065-075 [Goal~_~True.]                      |    0m00.s || +0m00.00s |   N/A   
+ 0m00.26s | Chars 260-284 ~ 280-304 [(vm_compute;~reflexivity).]        | 0m00.257s || +0m00.00s |   +1.16%
+0m00.184s | Chars 285-289 ~ 305-309 [Qed.]                              | 0m00.185s || -0m00.00s |   -0.54%
+0m00.098s | Chars 031-064 ~ 031-064 [Require~Import~Coq.ZArith.ZArith.] | 0m00.095s || +0m00.00s |   +3.15%
+0m00.036s | Chars 000-030 ~ 000-030 [Require~Import~Coq.Lists.List.]    | 0m00.036s || +0m00.00s |   +0.00%
+   0m00.s | Chars 065-075 ~ 065-075 [Goal~True.]                        |    0m00.s || +0m00.00s |   N/A   
    0m00.s | Chars 078-086 ~ 078-086 [exact~I.]                          |    N/A    || +0m00.00s |   N/A   
    N/A    | Chars 078-090 ~ 078-090 [constructor.]                      |    0m00.s || +0m00.00s |   N/A   
    0m00.s | Chars 087-091 ~ 091-095 [Qed.]                              |    0m00.s || +0m00.00s |   N/A   
-   0m00.s | Chars 092-102 ~ 096-106 [Goal~_~True.]                      |    0m00.s || +0m00.00s |   N/A   
+   0m00.s | Chars 092-102 ~ 096-106 [Goal~True.]                        |    0m00.s || +0m00.00s |   N/A   
    0m00.s | Chars 105-113 ~ 109-117 [exact~I.]                          |    N/A    || +0m00.00s |   N/A   
    N/A    | Chars 105-117 ~ 109-121 [constructor.]                      |    0m00.s || +0m00.00s |   N/A   
    0m00.s | Chars 114-118 ~ 122-126 [Qed.]                              |    0m00.s || +0m00.00s |   N/A   
-   0m00.s | Chars 119-129 ~ 127-137 [Goal~_~True.]                      |    0m00.s || +0m00.00s |   N/A   
+   0m00.s | Chars 119-129 ~ 127-137 [Goal~True.]                        |    0m00.s || +0m00.00s |   N/A   
    0m00.s | Chars 132-140 ~ 140-148 [exact~I.]                          |    N/A    || +0m00.00s |   N/A   
    N/A    | Chars 132-144 ~ 140-152 [constructor.]                      |    0m00.s || +0m00.00s |   N/A   
    0m00.s | Chars 141-145 ~ 153-157 [Qed.]                              |    0m00.s || +0m00.00s |   N/A   
-   0m00.s | Chars 146-156 ~ 158-168 [Goal~_~True.]                      |    0m00.s || +0m00.00s |   N/A   
+   0m00.s | Chars 146-156 ~ 158-168 [Goal~True.]                        |    0m00.s || +0m00.00s |   N/A   
    0m00.s | Chars 159-167 ~ 171-179 [exact~I.]                          |    N/A    || +0m00.00s |   N/A   
    N/A    | Chars 159-171 ~ 171-183 [constructor.]                      |    0m00.s || +0m00.00s |   N/A   
    0m00.s | Chars 168-172 ~ 184-188 [Qed.]                              |    0m00.s || +0m00.00s |   N/A   
-   0m00.s | Chars 173-183 ~ 189-199 [Goal~_~True.]                      |    0m00.s || +0m00.00s |   N/A   
+   0m00.s | Chars 173-183 ~ 189-199 [Goal~True.]                        |    0m00.s || +0m00.00s |   N/A   
    0m00.s | Chars 186-194 ~ 202-210 [exact~I.]                          |    N/A    || +0m00.00s |   N/A   
    N/A    | Chars 186-198 ~ 202-214 [constructor.]                      |    0m00.s || +0m00.00s |   N/A   
    0m00.s | Chars 195-199 ~ 215-219 [Qed.]                              |    0m00.s || +0m00.00s |   N/A   
-   0m00.s | Chars 200-257 ~ 220-277 [Goal~_~List.repeat~Z.div_eucl~...] |    0m00.s || +0m00.00s |   N/A   
+   0m00.s | Chars 200-257 ~ 220-277 [Goal~List.repeat~Z.div_eucl~5~...] |    0m00.s || +0m00.00s |   N/A   

--- a/test-suite/coq-makefile/timing/precomputed-time-tests/004-per-file-fuzz/foo-user.v.timing.diff.expected
+++ b/test-suite/coq-makefile/timing/precomputed-time-tests/004-per-file-fuzz/foo-user.v.timing.diff.expected
@@ -1,29 +1,29 @@
     After | Code                                                        |    Before ||    Change | % Change
 -----------------------------------------------------------------------------------------------------------
- 0m01.14s | Total                                                       |  0m01.15s || -0m00.00s |   -0.77%
+ 0m00.52s | Total                                                       |  0m00.52s || +0m00.00s |   +0.19%
 -----------------------------------------------------------------------------------------------------------
-0m00.504s | Chars 260-284 ~ 280-304 [(vm_compute;~reflexivity).]        | 0m00.528s || -0m00.02s |   -4.54%
-0m00.384s | Chars 285-289 ~ 305-309 [Qed.]                              |   0m00.4s || -0m00.01s |   -4.00%
-0m00.172s | Chars 031-064 ~ 031-064 [Require~Import~Coq.ZArith.ZArith.] | 0m00.156s || +0m00.01s |  +10.25%
-0m00.083s | Chars 000-030 ~ 000-030 [Require~Import~Coq.Lists.List.]    | 0m00.072s || +0m00.01s |  +15.27%
-0m00.004s | Chars 200-257 ~ 220-277 [Goal~_~List.repeat~Z.div_eucl~...] |    0m00.s || +0m00.00s |        ∞
-   0m00.s | Chars 065-075 ~ 065-075 [Goal~_~True.]                      |    0m00.s || +0m00.00s |   N/A   
+0m00.236s | Chars 260-284 ~ 280-304 [(vm_compute;~reflexivity).]        | 0m00.242s || -0m00.00s |   -2.47%
+0m00.184s | Chars 285-289 ~ 305-309 [Qed.]                              | 0m00.181s || +0m00.00s |   +1.65%
+0m00.083s | Chars 031-064 ~ 031-064 [Require~Import~Coq.ZArith.ZArith.] | 0m00.067s || +0m00.01s |  +23.88%
+0m00.024s | Chars 000-030 ~ 000-030 [Require~Import~Coq.Lists.List.]    | 0m00.036s || -0m00.01s |  -33.33%
+   0m00.s | Chars 065-075 ~ 065-075 [Goal~True.]                        |    0m00.s || +0m00.00s |   N/A   
    0m00.s | Chars 078-086 ~ 078-086 [exact~I.]                          |    N/A    || +0m00.00s |   N/A   
    N/A    | Chars 078-090 ~ 078-090 [constructor.]                      |    0m00.s || +0m00.00s |   N/A   
    0m00.s | Chars 087-091 ~ 091-095 [Qed.]                              |    0m00.s || +0m00.00s |   N/A   
-   0m00.s | Chars 092-102 ~ 096-106 [Goal~_~True.]                      |    0m00.s || +0m00.00s |   N/A   
+   0m00.s | Chars 092-102 ~ 096-106 [Goal~True.]                        |    0m00.s || +0m00.00s |   N/A   
    0m00.s | Chars 105-113 ~ 109-117 [exact~I.]                          |    N/A    || +0m00.00s |   N/A   
    N/A    | Chars 105-117 ~ 109-121 [constructor.]                      |    0m00.s || +0m00.00s |   N/A   
    0m00.s | Chars 114-118 ~ 122-126 [Qed.]                              |    0m00.s || +0m00.00s |   N/A   
-   0m00.s | Chars 119-129 ~ 127-137 [Goal~_~True.]                      |    0m00.s || +0m00.00s |   N/A   
+   0m00.s | Chars 119-129 ~ 127-137 [Goal~True.]                        |    0m00.s || +0m00.00s |   N/A   
    0m00.s | Chars 132-140 ~ 140-148 [exact~I.]                          |    N/A    || +0m00.00s |   N/A   
    N/A    | Chars 132-144 ~ 140-152 [constructor.]                      |    0m00.s || +0m00.00s |   N/A   
    0m00.s | Chars 141-145 ~ 153-157 [Qed.]                              |    0m00.s || +0m00.00s |   N/A   
-   0m00.s | Chars 146-156 ~ 158-168 [Goal~_~True.]                      |    0m00.s || +0m00.00s |   N/A   
+   0m00.s | Chars 146-156 ~ 158-168 [Goal~True.]                        |    0m00.s || +0m00.00s |   N/A   
    0m00.s | Chars 159-167 ~ 171-179 [exact~I.]                          |    N/A    || +0m00.00s |   N/A   
    N/A    | Chars 159-171 ~ 171-183 [constructor.]                      |    0m00.s || +0m00.00s |   N/A   
    0m00.s | Chars 168-172 ~ 184-188 [Qed.]                              |    0m00.s || +0m00.00s |   N/A   
-   0m00.s | Chars 173-183 ~ 189-199 [Goal~_~True.]                      |    0m00.s || +0m00.00s |   N/A   
+   0m00.s | Chars 173-183 ~ 189-199 [Goal~True.]                        |    0m00.s || +0m00.00s |   N/A   
    0m00.s | Chars 186-194 ~ 202-210 [exact~I.]                          |    N/A    || +0m00.00s |   N/A   
    N/A    | Chars 186-198 ~ 202-214 [constructor.]                      |    0m00.s || +0m00.00s |   N/A   
    0m00.s | Chars 195-199 ~ 215-219 [Qed.]                              |    0m00.s || +0m00.00s |   N/A   
+   0m00.s | Chars 200-257 ~ 220-277 [Goal~List.repeat~Z.div_eucl~5~...] |    0m00.s || +0m00.00s |   N/A   

--- a/test-suite/coq-makefile/timing/precomputed-time-tests/004-per-file-fuzz/foo.v.after-timing.in
+++ b/test-suite/coq-makefile/timing/precomputed-time-tests/004-per-file-fuzz/foo.v.after-timing.in
@@ -1,20 +1,20 @@
-Chars 0 - 30 [Require~Import~Coq.Lists.List.] 0.114 secs (0.083u,0.032s)
-Chars 31 - 64 [Require~Import~Coq.ZArith.ZArith.] 0.194 secs (0.172u,0.023s)
-Chars 65 - 75 [Goal~_~True.] 0. secs (0.u,0.s)
-Chars 78 - 86 [exact~I.] 0. secs (0.u,0.s)
-Chars 87 - 91 [Qed.] 0. secs (0.u,0.s)
-Chars 92 - 102 [Goal~_~True.] 0. secs (0.u,0.s)
-Chars 105 - 113 [exact~I.] 0. secs (0.u,0.s)
-Chars 114 - 118 [Qed.] 0. secs (0.u,0.s)
-Chars 119 - 129 [Goal~_~True.] 0. secs (0.u,0.s)
-Chars 132 - 140 [exact~I.] 0. secs (0.u,0.s)
-Chars 141 - 145 [Qed.] 0. secs (0.u,0.s)
-Chars 146 - 156 [Goal~_~True.] 0. secs (0.u,0.s)
-Chars 159 - 167 [exact~I.] 0. secs (0.u,0.s)
-Chars 168 - 172 [Qed.] 0. secs (0.u,0.s)
-Chars 173 - 183 [Goal~_~True.] 0. secs (0.u,0.s)
-Chars 186 - 194 [exact~I.] 0. secs (0.u,0.s)
-Chars 195 - 199 [Qed.] 0. secs (0.u,0.s)
-Chars 200 - 257 [Goal~_~List.repeat~Z.div_eucl~...] 0. secs (0.004u,0.s)
-Chars 260 - 284 [(vm_compute;~reflexivity).] 0.53 secs (0.504u,0.024s)
-Chars 285 - 289 [Qed.] 0.4 secs (0.384u,0.016s)
+Chars 0 - 30 [Require~Import~Coq.Lists.List.] 0.036 secs (0.024u,0.012s) 4.933 major Mw, 4.232 minor Mw
+Chars 31 - 64 [Require~Import~Coq.ZArith.ZArith.] 0.098 secs (0.083u,0.015s) 5.629 major Mw, 15.49 minor Mw
+Chars 65 - 75 [Goal~True.] 0. secs (0.u,0.s) 0. major Mw, 0.008 minor Mw
+Chars 78 - 86 [exact~I.] 0. secs (0.u,0.s) 0. major Mw, 0.011 minor Mw
+Chars 87 - 91 [Qed.] 0. secs (0.u,0.s) 0. major Mw, 0.011 minor Mw
+Chars 92 - 102 [Goal~True.] 0. secs (0.u,0.s) 0. major Mw, 0.008 minor Mw
+Chars 105 - 113 [exact~I.] 0. secs (0.u,0.s) 0. major Mw, 0.011 minor Mw
+Chars 114 - 118 [Qed.] 0. secs (0.u,0.s) 0. major Mw, 0.011 minor Mw
+Chars 119 - 129 [Goal~True.] 0. secs (0.u,0.s) 0. major Mw, 0.009 minor Mw
+Chars 132 - 140 [exact~I.] 0. secs (0.u,0.s) 0. major Mw, 0.011 minor Mw
+Chars 141 - 145 [Qed.] 0. secs (0.u,0.s) 0. major Mw, 0.011 minor Mw
+Chars 146 - 156 [Goal~True.] 0. secs (0.u,0.s) 0. major Mw, 0.009 minor Mw
+Chars 159 - 167 [exact~I.] 0. secs (0.u,0.s) 0. major Mw, 0.011 minor Mw
+Chars 168 - 172 [Qed.] 0. secs (0.u,0.s) 0. major Mw, 0.011 minor Mw
+Chars 173 - 183 [Goal~True.] 0. secs (0.u,0.s) 0. major Mw, 0.009 minor Mw
+Chars 186 - 194 [exact~I.] 0. secs (0.u,0.s) 0. major Mw, 0.011 minor Mw
+Chars 195 - 199 [Qed.] 0. secs (0.u,0.s) 0. major Mw, 0.011 minor Mw
+Chars 200 - 257 [Goal~List.repeat~Z.div_eucl~5~...] 0. secs (0.u,0.s) 0. major Mw, 0.046 minor Mw
+Chars 260 - 284 [(vm_compute;~reflexivity).] 0.26 secs (0.236u,0.023s) 6.278 major Mw, 85.018 minor Mw
+Chars 285 - 289 [Qed.] 0.184 secs (0.184u,0.s) 3.424 major Mw, 75.84 minor Mw

--- a/test-suite/coq-makefile/timing/precomputed-time-tests/004-per-file-fuzz/foo.v.before-timing.in
+++ b/test-suite/coq-makefile/timing/precomputed-time-tests/004-per-file-fuzz/foo.v.before-timing.in
@@ -1,20 +1,20 @@
-Chars 0 - 30 [Require~Import~Coq.Lists.List.] 0.114 secs (0.072u,0.044s)
-Chars 31 - 64 [Require~Import~Coq.ZArith.ZArith.] 0.192 secs (0.156u,0.035s)
-Chars 65 - 75 [Goal~_~True.] 0. secs (0.u,0.s)
-Chars 78 - 90 [constructor.] 0. secs (0.u,0.s)
-Chars 91 - 95 [Qed.] 0. secs (0.u,0.s)
-Chars 96 - 106 [Goal~_~True.] 0. secs (0.u,0.s)
-Chars 109 - 121 [constructor.] 0. secs (0.u,0.s)
-Chars 122 - 126 [Qed.] 0. secs (0.u,0.s)
-Chars 127 - 137 [Goal~_~True.] 0. secs (0.u,0.s)
-Chars 140 - 152 [constructor.] 0. secs (0.u,0.004s)
-Chars 153 - 157 [Qed.] 0. secs (0.u,0.s)
-Chars 158 - 168 [Goal~_~True.] 0. secs (0.u,0.s)
-Chars 171 - 183 [constructor.] 0. secs (0.u,0.s)
-Chars 184 - 188 [Qed.] 0. secs (0.u,0.s)
-Chars 189 - 199 [Goal~_~True.] 0. secs (0.u,0.s)
-Chars 202 - 214 [constructor.] 0. secs (0.u,0.s)
-Chars 215 - 219 [Qed.] 0. secs (0.u,0.s)
-Chars 220 - 277 [Goal~_~List.repeat~Z.div_eucl~...] 0. secs (0.u,0.s)
-Chars 280 - 304 [(vm_compute;~reflexivity).] 0.566 secs (0.528u,0.039s)
-Chars 305 - 309 [Qed.] 0.411 secs (0.4u,0.008s)
+Chars 0 - 30 [Require~Import~Coq.Lists.List.] 0.036 secs (0.036u,0.s) 4.934 major Mw, 4.232 minor Mw
+Chars 31 - 64 [Require~Import~Coq.ZArith.ZArith.] 0.095 secs (0.067u,0.027s) 5.629 major Mw, 15.49 minor Mw
+Chars 65 - 75 [Goal~True.] 0. secs (0.u,0.s) 0. major Mw, 0.008 minor Mw
+Chars 78 - 90 [constructor.] 0. secs (0.u,0.s) 0. major Mw, 0.012 minor Mw
+Chars 91 - 95 [Qed.] 0. secs (0.u,0.s) 0. major Mw, 0.011 minor Mw
+Chars 96 - 106 [Goal~True.] 0. secs (0.u,0.s) 0. major Mw, 0.008 minor Mw
+Chars 109 - 121 [constructor.] 0. secs (0.u,0.s) 0. major Mw, 0.012 minor Mw
+Chars 122 - 126 [Qed.] 0. secs (0.u,0.s) 0. major Mw, 0.011 minor Mw
+Chars 127 - 137 [Goal~True.] 0. secs (0.u,0.s) 0. major Mw, 0.009 minor Mw
+Chars 140 - 152 [constructor.] 0. secs (0.u,0.s) 0. major Mw, 0.012 minor Mw
+Chars 153 - 157 [Qed.] 0. secs (0.u,0.s) 0. major Mw, 0.011 minor Mw
+Chars 158 - 168 [Goal~True.] 0. secs (0.u,0.s) 0. major Mw, 0.009 minor Mw
+Chars 171 - 183 [constructor.] 0. secs (0.u,0.s) 0. major Mw, 0.012 minor Mw
+Chars 184 - 188 [Qed.] 0. secs (0.u,0.s) 0. major Mw, 0.011 minor Mw
+Chars 189 - 199 [Goal~True.] 0. secs (0.u,0.s) 0. major Mw, 0.009 minor Mw
+Chars 202 - 214 [constructor.] 0. secs (0.u,0.s) 0. major Mw, 0.012 minor Mw
+Chars 215 - 219 [Qed.] 0. secs (0.u,0.s) 0. major Mw, 0.011 minor Mw
+Chars 220 - 277 [Goal~List.repeat~Z.div_eucl~5~...] 0. secs (0.u,0.s) 0. major Mw, 0.046 minor Mw
+Chars 280 - 304 [(vm_compute;~reflexivity).] 0.257 secs (0.242u,0.015s) 6.277 major Mw, 85.018 minor Mw
+Chars 305 - 309 [Qed.] 0.185 secs (0.181u,0.004s) 3.424 major Mw, 75.84 minor Mw

--- a/test-suite/misc/bench-render.sh
+++ b/test-suite/misc/bench-render.sh
@@ -9,20 +9,48 @@ export LC_ALL=C
 
 cd misc/bench-render
 
+######## Backwards compatible support
+
+cd nomem/
+
+coqtimelog2html ../foo.v foo.v.time1 foo.v.time2 > result.html.real
+
+diff -u result.html result.html.real
+
+if coqtimelog2html ../foo.v foo.v.time1 foo.v.time3 > bad1v3.html.real 2>stderr1v3.real
+then >&2 echo "Should have failed!"; exit 1
+fi
+
+diff -u /dev/null bad1v3.html.real
+diff -u stderr1v3 stderr1v3.real
+
+if coqtimelog2html ../foo.v foo.v.time1 foo.v.time4 > bad1v4.html.real 2>stderr1v4.real
+then >&2 echo "Should have failed!"; exit 1
+fi
+
+diff -u /dev/null bad1v4.html.real
+diff -u stderr1v4 stderr1v4.real
+
+cd ../
+
+coqtimelog2html foo.v foo.v.time1 nomem/foo.v.time2 > result1vnomem2.html.real
+
+diff -u result1vnomem2.html result1vnomem2.html.real
+
 coqtimelog2html foo.v foo.v.time1 foo.v.time2 > result.html.real
 
-diff result.html result.html.real
+diff -u result.html result.html.real
 
 if coqtimelog2html foo.v foo.v.time1 foo.v.time3 > bad1v3.html.real 2>stderr1v3.real
 then >&2 echo "Should have failed!"; exit 1
 fi
 
-diff /dev/null bad1v3.html.real
-diff stderr1v3 stderr1v3.real
+diff -u /dev/null bad1v3.html.real
+diff -u stderr1v3 stderr1v3.real
 
 if coqtimelog2html foo.v foo.v.time1 foo.v.time4 > bad1v4.html.real 2>stderr1v4.real
 then >&2 echo "Should have failed!"; exit 1
 fi
 
-diff /dev/null bad1v4.html.real
-diff stderr1v4 stderr1v4.real
+diff -u /dev/null bad1v4.html.real
+diff -u stderr1v4 stderr1v4.real

--- a/test-suite/misc/bench-render/foo.v.time1
+++ b/test-suite/misc/bench-render/foo.v.time1
@@ -1,4 +1,4 @@
-Chars 54 - 72 [Definition~a~:=~1.] 2. secs (0.u,0.s)
-Chars 74 - 94 [Definition~b~:=~2.] 1. secs (0.u,0.s)
-Chars 96 - 114 [Definition~c~:=~3.] 0. secs (0.u,0.s)
-Chars 127 - 145 [Definition~d~:=~4.] 0. secs (0.u,0.s)
+Chars 54 - 72 [Definition~a~:=~1.] 2. secs (0.u,0.s) 0.1 major Mw, 2. minor Mw
+Chars 74 - 94 [Definition~b~:=~2.] 1. secs (0.u,0.s) 0. major Mw, 1. minor Mw
+Chars 96 - 114 [Definition~c~:=~3.] 0. secs (0.u,0.s) 0. major Mw, 0.5 minor Mw
+Chars 127 - 145 [Definition~d~:=~4.] 0. secs (0.u,0.s) 0. major Mw, 0. minor Mw

--- a/test-suite/misc/bench-render/foo.v.time2
+++ b/test-suite/misc/bench-render/foo.v.time2
@@ -1,4 +1,4 @@
-Chars 54 - 72 [Definition~a~:=~1.] 0. secs (0.u,0.s)
-Chars 74 - 94 [Definition~b~:=~2.] 1. secs (0.u,0.s)
-Chars 96 - 114 [Definition~c~:=~3.] 1.5 secs (0.u,0.s)
-Chars 127 - 145 [Definition~d~:=~4.] 0. secs (0.u,0.s)
+Chars 54 - 72 [Definition~a~:=~1.] 0. secs (0.u,0.s) 0. major Mw, 0. minor Mw
+Chars 74 - 94 [Definition~b~:=~2.] 1. secs (0.u,0.s) 0.1 major Mw, 1.1 minor Mw
+Chars 96 - 114 [Definition~c~:=~3.] 1.5 secs (0.u,0.s) 2. major Mw, 0. minor Mw
+Chars 127 - 145 [Definition~d~:=~4.] 0. secs (0.u,0.s) 0. major Mw, 0. minor Mw

--- a/test-suite/misc/bench-render/foo.v.time3
+++ b/test-suite/misc/bench-render/foo.v.time3
@@ -1,5 +1,5 @@
-Chars 54 - 72 [Definition~a~:=~1.] 0. secs (0.u,0.s)
-Chars 74 - 94 [Definition~b~:=~2.] 1. secs (0.u,0.s)
-Chars 96 - 114 [Definition~c~:=~3.] 1.5 secs (0.u,0.s)
-Chars 127 - 145 [Definition~d~:=~4.] 0. secs (0.u,0.s)
-Chars 127 - 145 [SURPRISE~BUG] 0. secs (0.u,0.s)
+Chars 54 - 72 [Definition~a~:=~1.] 0. secs (0.u,0.s) 0. major Mw, 0. minor Mw
+Chars 74 - 94 [Definition~b~:=~2.] 1. secs (0.u,0.s) 0.1 major Mw, 1.1 minor Mw
+Chars 96 - 114 [Definition~c~:=~3.] 1.5 secs (0.u,0.s) 2. major Mw, 0. minor Mw
+Chars 127 - 145 [Definition~d~:=~4.] 0. secs (0.u,0.s) 0. major Mw, 0. minor Mw
+Chars 127 - 145 [SURPRISE~BUG] 0. secs (0.u,0.s) 0. major Mw, 0. minor Mw

--- a/test-suite/misc/bench-render/foo.v.time4
+++ b/test-suite/misc/bench-render/foo.v.time4
@@ -1,4 +1,4 @@
-Chars 54 - 73 [Definition~a~:=~1.] 2. secs (0.u,0.s)
-Chars 74 - 94 [Definition~b~:=~2.] 1. secs (0.u,0.s)
-Chars 96 - 114 [Definition~c~:=~3.] 0. secs (0.u,0.s)
-Chars 127 - 145 [Definition~d~:=~4.] 0. secs (0.u,0.s)
+Chars 54 - 73 [Definition~a~:=~1.] 2. secs (0.u,0.s) 0.1 major Mw, 2. minor Mw
+Chars 74 - 94 [Definition~b~:=~2.] 1. secs (0.u,0.s) 0. major Mw, 1. minor Mw
+Chars 96 - 114 [Definition~c~:=~3.] 0. secs (0.u,0.s) 0. major Mw, 0.5 minor Mw
+Chars 127 - 145 [Definition~d~:=~4.] 0. secs (0.u,0.s) 0. major Mw, 0. minor Mw

--- a/test-suite/misc/bench-render/nomem/foo.v.time1
+++ b/test-suite/misc/bench-render/nomem/foo.v.time1
@@ -1,0 +1,4 @@
+Chars 54 - 72 [Definition~a~:=~1.] 2. secs (0.u,0.s)
+Chars 74 - 94 [Definition~b~:=~2.] 1. secs (0.u,0.s)
+Chars 96 - 114 [Definition~c~:=~3.] 0. secs (0.u,0.s)
+Chars 127 - 145 [Definition~d~:=~4.] 0. secs (0.u,0.s)

--- a/test-suite/misc/bench-render/nomem/foo.v.time2
+++ b/test-suite/misc/bench-render/nomem/foo.v.time2
@@ -1,0 +1,4 @@
+Chars 54 - 72 [Definition~a~:=~1.] 0. secs (0.u,0.s)
+Chars 74 - 94 [Definition~b~:=~2.] 1. secs (0.u,0.s)
+Chars 96 - 114 [Definition~c~:=~3.] 1.5 secs (0.u,0.s)
+Chars 127 - 145 [Definition~d~:=~4.] 0. secs (0.u,0.s)

--- a/test-suite/misc/bench-render/nomem/foo.v.time3
+++ b/test-suite/misc/bench-render/nomem/foo.v.time3
@@ -1,0 +1,5 @@
+Chars 54 - 72 [Definition~a~:=~1.] 0. secs (0.u,0.s)
+Chars 74 - 94 [Definition~b~:=~2.] 1. secs (0.u,0.s)
+Chars 96 - 114 [Definition~c~:=~3.] 1.5 secs (0.u,0.s)
+Chars 127 - 145 [Definition~d~:=~4.] 0. secs (0.u,0.s)
+Chars 127 - 145 [SURPRISE~BUG] 0. secs (0.u,0.s)

--- a/test-suite/misc/bench-render/nomem/foo.v.time4
+++ b/test-suite/misc/bench-render/nomem/foo.v.time4
@@ -1,0 +1,4 @@
+Chars 54 - 73 [Definition~a~:=~1.] 2. secs (0.u,0.s)
+Chars 74 - 94 [Definition~b~:=~2.] 1. secs (0.u,0.s)
+Chars 96 - 114 [Definition~c~:=~3.] 0. secs (0.u,0.s)
+Chars 127 - 145 [Definition~d~:=~4.] 0. secs (0.u,0.s)

--- a/test-suite/misc/bench-render/nomem/result.html
+++ b/test-suite/misc/bench-render/nomem/result.html
@@ -44,11 +44,7 @@ code::before {
 </head>
 <body>
 <h1>Timings for foo.v</h1>
-
-<input type="radio" name="toggles" checked=true id="time"><label for="time">Time</label>
-<input type="radio" name="toggles" id="major"><label for="major">Major</label>
-<input type="radio" name="toggles" id="minor"><label for="minor">Minor</label>
-<ol>
+<input type="radio" name="toggles" checked=true id="time" style="display: none"><ol>
 <li style="background-color: #F08080">foo.v.time1</li>
 <li style="background-color: #EEE8AA">foo.v.time2</li>
 </ol>
@@ -69,34 +65,22 @@ Time2: 0s
 Line: 9
 
 Time1: 2.s
-Major1: 0.1Mw
-Minor1: 2.Mw
 Time2: 0.s
-Major2: 0.Mw
-Minor2: 0.Mw
-"><div class="time1" style="width: 100.000000%"></div><div class="major1" style="width: 5.000000%"></div><div class="minor1" style="width: 100.000000%"></div><div class="time2" style="width: 0.000000%"></div><div class="major2" style="width: 0.000000%"></div><div class="minor2" style="width: 0.000000%"></div><code id="L9" data-line="9">Definition a := 1.</code>
+"><div class="time1" style="width: 100.000000%"></div><div class="time2" style="width: 0.000000%"></div><code id="L9" data-line="9">Definition a := 1.</code>
 </div><div class="code" title="File: foo.v
 Line: 10
 
 Time1: 1.s
-Major1: 0.Mw
-Minor1: 1.Mw
 Time2: 1.s
-Major2: 0.1Mw
-Minor2: 1.1Mw
-"><div class="time1" style="width: 50.000000%"></div><div class="major1" style="width: 0.000000%"></div><div class="minor1" style="width: 50.000000%"></div><div class="time2" style="width: 50.000000%"></div><div class="major2" style="width: 5.000000%"></div><div class="minor2" style="width: 55.000000%"></div><code id="L10" data-line="10"></code>
+"><div class="time1" style="width: 50.000000%"></div><div class="time2" style="width: 50.000000%"></div><code id="L10" data-line="10"></code>
 <code id="L11" data-line="11">Definition b :=</code>
 <code id="L12" data-line="12">  2.</code>
 </div><div class="code" title="File: foo.v
 Line: 13
 
 Time1: 0.s
-Major1: 0.Mw
-Minor1: 0.5Mw
 Time2: 1.5s
-Major2: 2.Mw
-Minor2: 0.Mw
-"><div class="time1" style="width: 0.000000%"></div><div class="major1" style="width: 0.000000%"></div><div class="minor1" style="width: 25.000000%"></div><div class="time2" style="width: 75.000000%"></div><div class="major2" style="width: 100.000000%"></div><div class="minor2" style="width: 0.000000%"></div><code id="L13" data-line="13"></code>
+"><div class="time1" style="width: 0.000000%"></div><div class="time2" style="width: 75.000000%"></div><code id="L13" data-line="13"></code>
 <code id="L14" data-line="14">Definition c := 3.</code>
 </div><div class="code" title="File: foo.v
 Line: 14
@@ -108,12 +92,8 @@ Time2: 0s
 Line: 14
 
 Time1: 0.s
-Major1: 0.Mw
-Minor1: 0.Mw
 Time2: 0.s
-Major2: 0.Mw
-Minor2: 0.Mw
-"><div class="time1" style="width: 0.000000%"></div><div class="major1" style="width: 0.000000%"></div><div class="minor1" style="width: 0.000000%"></div><div class="time2" style="width: 0.000000%"></div><div class="major2" style="width: 0.000000%"></div><div class="minor2" style="width: 0.000000%"></div><code data-line="14"> Definition d := 4.</code>
+"><div class="time1" style="width: 0.000000%"></div><div class="time2" style="width: 0.000000%"></div><code data-line="14"> Definition d := 4.</code>
 </div><div class="code" title="File: foo.v
 Line: 15
 

--- a/test-suite/misc/bench-render/nomem/stderr1v3
+++ b/test-suite/misc/bench-render/nomem/stderr1v3
@@ -1,0 +1,1 @@
+Mismatch between foo.v.time1 and foo.v.time3: different measurement counts

--- a/test-suite/misc/bench-render/nomem/stderr1v4
+++ b/test-suite/misc/bench-render/nomem/stderr1v4
@@ -1,0 +1,1 @@
+Mismatch between foo.v.time1 and foo.v.time4 at line 2

--- a/test-suite/misc/bench-render/result1vnomem2.html
+++ b/test-suite/misc/bench-render/result1vnomem2.html
@@ -50,7 +50,7 @@ code::before {
 <input type="radio" name="toggles" id="minor"><label for="minor">Minor</label>
 <ol>
 <li style="background-color: #F08080">foo.v.time1</li>
-<li style="background-color: #EEE8AA">foo.v.time2</li>
+<li style="background-color: #EEE8AA">nomem/foo.v.time2</li>
 </ol>
 <pre><div class="code" title="File: foo.v
 Line: 1
@@ -72,9 +72,7 @@ Time1: 2.s
 Major1: 0.1Mw
 Minor1: 2.Mw
 Time2: 0.s
-Major2: 0.Mw
-Minor2: 0.Mw
-"><div class="time1" style="width: 100.000000%"></div><div class="major1" style="width: 5.000000%"></div><div class="minor1" style="width: 100.000000%"></div><div class="time2" style="width: 0.000000%"></div><div class="major2" style="width: 0.000000%"></div><div class="minor2" style="width: 0.000000%"></div><code id="L9" data-line="9">Definition a := 1.</code>
+"><div class="time1" style="width: 100.000000%"></div><div class="major1" style="width: 100.000000%"></div><div class="minor1" style="width: 100.000000%"></div><div class="time2" style="width: 0.000000%"></div><code id="L9" data-line="9">Definition a := 1.</code>
 </div><div class="code" title="File: foo.v
 Line: 10
 
@@ -82,9 +80,7 @@ Time1: 1.s
 Major1: 0.Mw
 Minor1: 1.Mw
 Time2: 1.s
-Major2: 0.1Mw
-Minor2: 1.1Mw
-"><div class="time1" style="width: 50.000000%"></div><div class="major1" style="width: 0.000000%"></div><div class="minor1" style="width: 50.000000%"></div><div class="time2" style="width: 50.000000%"></div><div class="major2" style="width: 5.000000%"></div><div class="minor2" style="width: 55.000000%"></div><code id="L10" data-line="10"></code>
+"><div class="time1" style="width: 50.000000%"></div><div class="major1" style="width: 0.000000%"></div><div class="minor1" style="width: 50.000000%"></div><div class="time2" style="width: 50.000000%"></div><code id="L10" data-line="10"></code>
 <code id="L11" data-line="11">Definition b :=</code>
 <code id="L12" data-line="12">  2.</code>
 </div><div class="code" title="File: foo.v
@@ -94,9 +90,7 @@ Time1: 0.s
 Major1: 0.Mw
 Minor1: 0.5Mw
 Time2: 1.5s
-Major2: 2.Mw
-Minor2: 0.Mw
-"><div class="time1" style="width: 0.000000%"></div><div class="major1" style="width: 0.000000%"></div><div class="minor1" style="width: 25.000000%"></div><div class="time2" style="width: 75.000000%"></div><div class="major2" style="width: 100.000000%"></div><div class="minor2" style="width: 0.000000%"></div><code id="L13" data-line="13"></code>
+"><div class="time1" style="width: 0.000000%"></div><div class="major1" style="width: 0.000000%"></div><div class="minor1" style="width: 25.000000%"></div><div class="time2" style="width: 75.000000%"></div><code id="L13" data-line="13"></code>
 <code id="L14" data-line="14">Definition c := 3.</code>
 </div><div class="code" title="File: foo.v
 Line: 14
@@ -111,9 +105,7 @@ Time1: 0.s
 Major1: 0.Mw
 Minor1: 0.Mw
 Time2: 0.s
-Major2: 0.Mw
-Minor2: 0.Mw
-"><div class="time1" style="width: 0.000000%"></div><div class="major1" style="width: 0.000000%"></div><div class="minor1" style="width: 0.000000%"></div><div class="time2" style="width: 0.000000%"></div><div class="major2" style="width: 0.000000%"></div><div class="minor2" style="width: 0.000000%"></div><code data-line="14"> Definition d := 4.</code>
+"><div class="time1" style="width: 0.000000%"></div><div class="major1" style="width: 0.000000%"></div><div class="minor1" style="width: 0.000000%"></div><div class="time2" style="width: 0.000000%"></div><code data-line="14"> Definition d := 4.</code>
 </div><div class="code" title="File: foo.v
 Line: 15
 

--- a/test-suite/output-modulo-time/abort.out
+++ b/test-suite/output-modulo-time/abort.out
@@ -1,2 +1,2 @@
-Chars 40 - 50 [Goal~True.] 0. secs (0.u,0.s)
-Chars 51 - 57 [Abort.] 0. secs (0.u,0.s)
+Chars 40 - 50 [Goal~True.] 0. secs (0.u,0.s) 0. major Mw, 0. minor Mw
+Chars 51 - 57 [Abort.] 0. secs (0.u,0.s) 0. major Mw, 0. minor Mw

--- a/test-suite/output-modulo-time/qed_time.out
+++ b/test-suite/output-modulo-time/qed_time.out
@@ -1,5 +1,5 @@
-Chars 40 - 57 [Lemma~foo~:~True.] 0. secs (0.u,0.s)
-Chars 58 - 64 [Proof.] 0. secs (0.u,0.s)
-Chars 67 - 81 [Axiom~(X~:~nat).] 0. secs (0.u,0.s)
-Chars 84 - 92 [exact~I.] 0. secs (0.u,0.s)
-Chars 93 - 97 [Qed.] 0. secs (0.u,0.s)
+Chars 40 - 57 [Lemma~foo~:~True.] 0. secs (0.u,0.s) 0. major Mw, 0. minor Mw
+Chars 58 - 64 [Proof.] 0. secs (0.u,0.s) 0. major Mw, 0. minor Mw
+Chars 67 - 81 [Axiom~(X~:~nat).] 0. secs (0.u,0.s) 0. major Mw, 0. minor Mw
+Chars 84 - 92 [exact~I.] 0. secs (0.u,0.s) 0. major Mw, 0. minor Mw
+Chars 93 - 97 [Qed.] 0. secs (0.u,0.s) 0. major Mw, 0. minor Mw

--- a/tools/TimeFileMaker.py
+++ b/tools/TimeFileMaker.py
@@ -68,7 +68,7 @@ FILE_NAME (...user: NUMBER_IN_SECONDS...mem: NUMBER ko...)
 If --real is passed, then the lines are instead expected in the format:
 FILE_NAME (...real: NUMBER_IN_SECONDS...mem: NUMBER ko...)''' if not single_timing else
 '''The input is expected to contain lines in the format:
-Chars START - END COMMAND NUMBER secs (NUMBERu...)''')))
+Chars START - END COMMAND NUMBER secs (NUMBERu...) NUMBER major Mw, NUMBER minor Mw''')))
 
 def add_user(parser, single_timing=False):
     return parser.add_argument(
@@ -80,7 +80,7 @@ FILE_NAME (...real: NUMBER_IN_SECONDS...mem: NUMBER ko...)
 If --user is passed, then the lines are instead expected in the format:
 FILE_NAME (...user: NUMBER_IN_SECONDS...mem: NUMBER ko...)''' if not single_timing else
 '''The input is expected to contain lines in the format:
-Chars START - END COMMAND NUMBER secs (NUMBERu...)''')))
+Chars START - END COMMAND NUMBER secs (NUMBERu...) NUMBER major Mw, NUMBER minor Mw''')))
 
 def add_include_mem(parser):
     return parser.add_argument(
@@ -192,7 +192,7 @@ def get_single_file_times(file_name, use_real=False):
     to compile durations, as strings.
     '''
     lines = get_file(file_name)
-    reg = re.compile(r'^Chars ([0-9]+) - ([0-9]+) ([^ ]+) ([0-9\.]+) secs \(([0-9\.]+)u(.*)\)$', re.MULTILINE)
+    reg = re.compile(r'^Chars ([0-9]+) - ([0-9]+) ([^ ]+) ([0-9\.]+) secs \(([0-9\.]+)u(.*)\)( [0-9\.]+ major Mw, [0-9\.]+ minor Mw)?$', re.MULTILINE)
     times = reg.findall(lines)
     if len(times) == 0: return dict()
     longest = max(max((len(start), len(stop))) for start, stop, name, real, user, extra in times)


### PR DESCRIPTION
TODO should probably figure out a nicer format than just sticking new measurements at the end of the line