### PR TITLE
Haskell extraction: use block comments where line wrapping may occur

### DIFF
--- a/plugins/extraction/haskell.ml
+++ b/plugins/extraction/haskell.ml
@@ -277,9 +277,9 @@ and pp_function env f t =
 (*s Pretty-printing of inductive types declaration. *)
 
 let pp_logical_ind packet =
-  pp_comment (Id.print packet.ip_typename ++ str " : logical inductive") ++
-  pp_comment (str "with constructors : " ++
-              prvect_with_sep spc Id.print packet.ip_consnames)
+  pp_bracket_comment
+    (Id.print packet.ip_typename ++ str " : logical inductive" ++ fnl () ++
+     str "with constructors : " ++ prvect_with_sep spc Id.print packet.ip_consnames)
 
 let pp_singleton kn packet =
   let name = pp_global Type (GlobRef.IndRef (kn,0)) in

--- a/test-suite/output/bug_17369.out
+++ b/test-suite/output/bug_17369.out
@@ -1,0 +1,3 @@
+{- my_inductive_prop : logical inductive
+   with constructors : constr_1 constr_2 constr_3 constr_4
+   constr_5 constr_6 constr_7 -}

--- a/test-suite/output/bug_17369.v
+++ b/test-suite/output/bug_17369.v
@@ -1,0 +1,13 @@
+(* Ensure that 'logical inductive' comments in extracted Haskell
+ * do not get uncommented by line wrapping *)
+
+From Coq Require Import Extraction.
+
+Set Printing Width 60.
+
+Inductive my_inductive_prop : Prop :=
+  constr_1 | constr_2 | constr_3 | constr_4 | constr_5 | constr_6 | constr_7
+.
+
+Extraction Language Haskell.
+Extraction my_inductive_prop.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

Currently, Haskell extraction of logical inductives generates single-line Haskell comments which may later get wrapped, resulting in invalid Haskell.

```coq
From Coq Require Import Extraction.

Inductive my_inductive_prop : Prop :=
  constr_1 | constr_2 | constr_3 | constr_4 | constr_5 | constr_6 | constr_7
.

Extraction Language Haskell.
Extraction my_inductive_prop.
```

`my_inductive_prop` currently extracts to:
```haskell
-- my_inductive_prop : logical inductive
-- with constructors : constr_1 constr_2 constr_3 constr_4 constr_5 constr_6
constr_7
```

With this change it's:
```haskell
{- my_inductive_prop : logical inductive
   with constructors : constr_1 constr_2 constr_3 constr_4 constr_5 constr_6
   constr_7 -}
````

Alternatively, the list of constructors could be made non-wrappable (i.e. using `str " "` instead of `spc ()` as the separator), but that could result in very long lines. I've had a quick look at the other places where single line comments are used and I think they should be safe from this as they all use `str " "` directly instead of `spc ()`.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #17369

<!-- Remove anything that doesn't apply in the following checklist. -->