### PR TITLE
Intern: Do not allow explicitated arguments in the non-strict-mode fallback

### DIFF
--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -1379,11 +1379,11 @@ let intern_applied_reference ~isproj intern env namedctx (_, ntnvars as lvar) us
       res, args2
     with Not_found as exn ->
       (* Extra allowance for non globalizing functions *)
-      match env.strict_check with
-      | None | Some true ->
+      if Option.default true env.strict_check || List.exists (fun (_,e) -> Option.has_some e) args
+      then
         let _, info = Exninfo.capture exn in
         Nametab.error_global_not_found ~info qid
-      | Some false ->
+      else
         (* check_applied_projection ?? *)
         gvar (loc,qualid_basename qid) us, args
   else

--- a/test-suite/output/bug_17372.out
+++ b/test-suite/output/bug_17372.out
@@ -1,0 +1,3 @@
+File "./output/bug_17372.v", line 2, characters 13-16:
+The command has indeed failed with message:
+The reference bar was not found in the current environment.

--- a/test-suite/output/bug_17372.v
+++ b/test-suite/output/bug_17372.v
@@ -1,0 +1,3 @@
+Goal Prop.
+Fail refine (bar (A := nat)).
+Abort.


### PR DESCRIPTION
This produces a "ref not found" failure instead of "unknown argument" (AFAICT there is no case where it would have succeeded).

Fix #17372