### PR TITLE
Build stdlib with per line timings + bench stdlib with -j1

### DIFF
--- a/dev/bench/bench.sh
+++ b/dev/bench/bench.sh
@@ -378,8 +378,13 @@ create_opam() {
     for package in coq-core coq-stdlib coqide-server coq; do
         export COQ_OPAM_PACKAGE=$package
         export COQ_ITERATION=1
+
+        # build stdlib with -j 1 to get nicer timings
+        local this_nproc=$number_of_processors
+        if [ "$package" = coq-stdlib ]; then this_nproc=1; fi
+
         _RES=0
-        opam pin add -y -b -j "$number_of_processors" --kind=path $package.dev . \
+        opam pin add -y -b -j "$this_nproc" --kind=path $package.dev . \
              3>$log_dir/$package.$RUNNER.opam_install.1.stdout.log 1>&3 \
              4>$log_dir/$package.$RUNNER.opam_install.1.stderr.log 2>&4 || \
             _RES=$?

--- a/dev/bench/bench.sh
+++ b/dev/bench/bench.sh
@@ -418,6 +418,28 @@ rendered_results="$($render_results "$log_dir" $num_of_iterations $new_coq_commi
 echo "${rendered_results}"
 zulip_edit "Benching continues..."
 
+# HTML for stdlib
+# NB: unlike coq_makefile packages, stdlib produces foo.timing not foo.v.timing
+new_base_path=$new_opam_root/ocaml-NEW/.opam-switch/build/coq-stdlib.dev/_build/default/theories/
+old_base_path=$old_opam_root/ocaml-OLD/.opam-switch/build/coq-stdlib.dev/_build/default/theories/
+for vo in $(cd $new_base_path/; find . -name '*.vo'); do
+    if [ -e $old_base_path/$vo ]; then
+        echo "$coq_opam_package/$vo $(stat -c%s $old_base_path/$vo) $(stat -c%s $new_base_path/$vo)" >> "$log_dir/vosize.log"
+    fi
+    if [ -e $old_base_path/${vo%%.vo}.timing ] && \
+           [ -e $new_base_path/${vo%%.vo}.timing ]; then
+        mkdir -p $working_dir/html/coq-stdlib/$(dirname $vo)/
+        # NB: sometimes randomly fails
+        $timelog2html $new_base_path/${vo%%o} \
+                      $old_base_path/${vo%%.vo}.timing \
+                      $new_base_path/${vo%%.vo}.timing > \
+                      $working_dir/html/coq-stdlib/${vo%%o}.html ||
+            echo "Failed (code $?):" $timelog2html $new_base_path/${vo%%o} \
+                 $old_base_path/${vo%%.vo}.timing \
+                 $new_base_path/${vo%%.vo}.timing
+    fi
+done
+
 # --------------------------------------------------------------------------------
 # Measure the compilation times of the specified OPAM packages in both switches
 

--- a/tools/dune_rule_gen/coq_module.ml
+++ b/tools/dune_rule_gen/coq_module.ml
@@ -7,6 +7,8 @@
 (* Written by: Rudi Grinberg                                            *)
 (************************************************************************)
 
+let with_timing = true
+
 type t =
   { source : Path.t
   ; prefix : string list
@@ -63,7 +65,8 @@ let base_obj_files ~rule coq_module =
 let obj_files ~tname ~rule coq_module =
   let native = Rule_type.native_coqc rule in
   let native_objs = if native then native_obj_files ~tname ~install:false coq_module else [] in
-  native_objs @ base_obj_files ~rule coq_module
+  let timing_objs = if with_timing then [ mod_to_obj coq_module ~ext:".timing" ] else [] in
+  timing_objs @ native_objs @ base_obj_files ~rule coq_module
 
 let prefix_to_dir = String.concat Filename.dir_sep
 

--- a/tools/dune_rule_gen/coq_module.mli
+++ b/tools/dune_rule_gen/coq_module.mli
@@ -46,3 +46,5 @@ val install_files :
   -> (string * string) list
 
 val pp : Format.formatter -> t -> unit
+
+val with_timing : bool


### PR DESCRIPTION
We introduce an option -timef to output the time data to a file instead of having to redirect stdout

Depends 
- https://github.com/coq/coq/pull/17430