### PR TITLE
[xml protocol] [coqide] Alternative PR fixing some loc problems in master.

### DIFF
--- a/dev/doc/changes.md
+++ b/dev/doc/changes.md
@@ -1,3 +1,12 @@
+## Changes between Coq 8.17 and Coq 8.18
+
+### XML protocol
+
+Version 20230413, see xml-protocol.md for details.
+
+- Coq locations are now fully transmitted, including line and column
+  information vs the previous start/end offset.
+
 ## Changes between Coq 8.15 and Coq 8.16
 
 ### Plugin Interface

--- a/dev/doc/xml-protocol.md
+++ b/dev/doc/xml-protocol.md
@@ -926,13 +926,19 @@ Ex: `status = "Idle"` or `status = "proof: myLemmaName"` or `status = "Dead"`
   </feedback_content>
 </feedback>
 ```
+* <a name="location">Location</a>, a Coq location:
+```xml
+   <loc start="${start_offset}" stop="${stop_offset}
+        line_nb="${start_line}" bol_pos="${begin_of_start_line_offset}"
+        line_nb_last="${end_line}" bol_pos_last="${begin_of_end_line_offset}"
+```
 
-* <a name="feedback-custom">Custom</a>. A feedback message that Coq plugins can use to return structured results, including results from Ltac profiling. Optionally, `startPos` and `stopPos` define a range of offsets in the document that the message refers to; otherwise, they will be 0. `customTag` is intended as a unique string that identifies what kind of payload is contained in `customXML`.
+* <a name="feedback-custom">Custom</a>. A feedback message that Coq plugins can use to return structured results, including results from Ltac profiling. `customTag` is intended as a unique string that identifies what kind of payload is contained in `customXML`. An optional location may be attached if present in the message.
 ```xml
 <feedback object="state" route="0">
   <state_id val="${stateId}"/>
   <feedback_content val="custom">
-    <loc start="${startPos}" stop="${stopPos}"/>
+    <option val="none|some">${loc}</option>
     <string>${customTag}</string>
     ${customXML}
   </feedback_content>

--- a/doc/changelog/10-coqide/17382-xmlprotocol_fulllocs.rst
+++ b/doc/changelog/10-coqide/17382-xmlprotocol_fulllocs.rst
@@ -1,0 +1,8 @@
+- **Changed:**
+  XML Protocol now sends (and expects) full Coq locations, including
+  line and column information. This makes some IDE operations (such as
+  UTF-8 decoding) more efficient. Clients of the XML protocol can just
+  ignore the new fields if they are not useful for them.
+  (`#17382 <https://github.com/coq/coq/pull/17382>`_,
+  fixes `#17023 <https://github.com/coq/coq/issues/17023>`_,
+  by Emilio Jesus Gallego Arias).

--- a/ide/coqide/coqOps.ml
+++ b/ide/coqide/coqOps.ml
@@ -60,8 +60,8 @@ module SentenceId : sig
   val start_iter : GText.buffer -> sentence -> GText.iter
   val start_stop_iters : GText.buffer -> sentence -> GText.iter * GText.iter
 
-  (** [ofsset_compensation] Drift of a sentence over its original
-      location, in offset. May be needed to compensage Coq locations. *)
+  (** [offset_compensation] Drift of a sentence over its original
+      location, in offset. Needed to repair outdated Coq locations *)
   val offset_compensation : GText.buffer -> sentence -> int
 
   val phrase : GText.buffer -> sentence -> string

--- a/ide/coqide/coqOps.ml
+++ b/ide/coqide/coqOps.ml
@@ -141,8 +141,8 @@ open SentenceId
 (* Given a Coq loc, convert it to a pair of iterators start / end in
    the buffer. *)
 let coq_loc_to_gtk_offset (buffer : GText.buffer) loc =
-  buffer#get_iter_at_byte ~line:loc.Loc.line_nb (loc.bp - loc.bol_pos),
-  buffer#get_iter_at_byte ~line:loc.Loc.line_nb_last (loc.ep - loc.bol_pos_last)
+  buffer#get_iter_at_byte ~line:(loc.Loc.line_nb - 1) (loc.bp - loc.bol_pos),
+  buffer#get_iter_at_byte ~line:(loc.Loc.line_nb_last - 1) (loc.ep - loc.bol_pos_last)
 
 (** increase [uni_off] by the number of bytes until [s_uni] This can
     be used to convert a character offset to byte offset if we know a

--- a/ide/coqide/coqOps.ml
+++ b/ide/coqide/coqOps.ml
@@ -194,10 +194,10 @@ let coq_loc_from_gtk_offset cached buffer sentence =
   (* Coq lines start at 1, GTK lines at 0 *)
   let line = start#line + 1 in
   (* [line_index] already returns byte offsets *)
-  let bol = start#line_index in
+  let bol_pos = bp - start#line_index in
   (*  *)
   let new_cached = bp, start#offset in
-  bp, line, bol, new_cached
+  bp, line, bol_pos, new_cached
 
 let log msg : unit task =
   Coq.lift (fun () -> Minilib.log msg)

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -91,9 +91,14 @@ let set_doc doc = ide_doc := Some doc
 let add ((((s,eid),(sid,verbose)),off),(line_nb,bol_pos)) =
   let doc = get_doc () in
   let open Loc in
-  (* note: this won't yield correct values for bol_pos_last,
-     but the debugger doesn't use that *)
-  let loc = { (initial ToplevelInput) with bp=off; line_nb; bol_pos } in
+  (* This needs to be akin to what CLexer.after does *)
+  let loc = { (initial ToplevelInput) with
+              bp=off
+            ; line_nb
+            ; bol_pos
+            ; ep=off
+            ; line_nb_last=line_nb
+            ; bol_pos_last=bol_pos } in
   let r_stream = Gramlib.Stream.of_string ~offset:off s in
   let pa = Pcoq.Parsable.make ~loc r_stream in
   match Stm.parse_sentence ~doc sid ~entry:Pvernac.main_entry pa with

--- a/ide/coqide/protocol/serialize.ml
+++ b/ide/coqide/protocol/serialize.ml
@@ -110,16 +110,44 @@ let to_edit_id = function
   | x -> raise (Marshal_error("edit_id",x))
 
 let of_loc loc =
-  let start, stop = Loc.unloc loc in
-  Element ("loc",[("start",string_of_int start);("stop",string_of_int stop)],[])
+  let {
+    Loc.fname
+  ; line_nb
+  ; bol_pos
+  ; line_nb_last
+  ; bol_pos_last
+  ; bp
+  ; ep
+  } = loc in
+  Element ("loc",
+           [ ("line_nb", string_of_int line_nb)
+           ; ("bol_pos", string_of_int bol_pos)
+           ; ("line_nb_last", string_of_int line_nb_last)
+           ; ("bol_pos_last", string_of_int bol_pos_last)
+           ; ("start", string_of_int bp)
+           ; ("stop", string_of_int ep )
+           ],
+           [])
+
 let to_loc xml =
   match xml with
-  | Element ("loc", l,[]) ->
-      let start = massoc "start" l in
-      let stop = massoc "stop" l in
-      (try
-        Loc.make_loc (int_of_string start, int_of_string stop)
-      with Not_found | Invalid_argument _ -> raise (Marshal_error("loc",PCData(start^":"^stop))))
+  | Element ("loc", l,[]) as x ->
+    (try
+       let line_nb = massoc "line_nb" l |> int_of_string in
+       let bol_pos = massoc "bol_pos" l |> int_of_string in
+       let line_nb_last = massoc "line_nb_last" l |> int_of_string in
+       let bol_pos_last = massoc "bol_pos_last" l |> int_of_string in
+       let bp = massoc "start" l |> int_of_string in
+       let ep = massoc "stop" l |> int_of_string in
+       { Loc.fname = ToplevelInput
+       ; line_nb
+       ; bol_pos
+       ; line_nb_last
+       ; bol_pos_last
+       ; bp
+       ; ep }
+     with Not_found | Invalid_argument _ ->
+       raise (Marshal_error("loc",x)))
   | x -> raise (Marshal_error("loc",x))
 
 let of_xml x = Element ("xml", [], [x])

--- a/ide/coqide/protocol/xmlprotocol.ml
+++ b/ide/coqide/protocol/xmlprotocol.ml
@@ -9,7 +9,7 @@
 (************************************************************************)
 
 (** Protocol version of this file. This is the date of the last modification. *)
-let protocol_version = "20220205"
+let protocol_version = "20230413"
 
 (** See xml-protocol.md for a description of the protocol. *)
 (** UPDATE xml-protocol.md WHEN YOU UPDATE THE PROTOCOL *)

--- a/test-suite/interactive/tooltips.v
+++ b/test-suite/interactive/tooltips.v
@@ -1,0 +1,16 @@
+Ltac wait n := match n with 0 => idtac | S ?n => wait n; wait n end.
+
+#[deprecated(since="8.16")] Notation tt0 := tt.
+
+Goal True.
+Proof.
+fail.
+Qed.
+
+Variable (n : nat).
+
+Goal True.
+Proof.
+wait 15.
+elim tt0.
+Qed.

--- a/test-suite/interactive/tooltips.v
+++ b/test-suite/interactive/tooltips.v
@@ -11,6 +11,6 @@ Variable (n : nat).
 
 Goal True.
 Proof.
-wait 15.
+wait 18.
 elim tt0.
 Qed.


### PR DESCRIPTION
@herbelin suggested to have a look at the current status of Coq master problems, so indeed, the main source of pain on what we could see is just that the locations are not fully serialized, in particular missing line number on the protocol wire impedes us to properly handle Coq locations effectively (and without hacks).

We also fix a off-by-one error we hand't spot due to the missing line info.

We have verified that this PR seems to fix the loc part of #17023 , modulo the 8.16 behavior, which as noted by Théo is:

> however, in Coq 8.15-8.16, the displayed warning is associated to a (correctly located) underline, but the tooltip is broken, and if we undo and redo the last line, it does not show at all (exactly as described for the Foo command in this issue),

Not sure about the `idtac` display and we didn't get CoqIDE to display it, neither in 8.16.

We submit this PR for testing against #17348 , as to see if `master` revert to 8.16 vs `master` + this fix has more bugs.

Fixes #17023 fixes #16987