### PR TITLE
Clean Elim internals

### DIFF
--- a/tactics/elim.ml
+++ b/tactics/elim.ml
@@ -21,10 +21,7 @@ open Clenv
 open Tactics
 
 type branch_args = {
-  branchnum  : int;         (* the branch number *)
   nassums    : int;         (* number of assumptions/letin to be introduced *)
-  branchsign : bool list;   (* the signature of the branch.
-                               true=assumption, false=let-in *)
   branchnames : Tactypes.intro_patterns}
 
 type elim_kind = Case of bool | Elim
@@ -74,10 +71,8 @@ let general_elim_then_using mk_elim
       | Some p -> clenv_unify ~flags Reduction.CONV (mkMeta pmv) p elimclause'
     in
     let after_tac i =
-      let ba = { branchsign = branchsigns.(i);
-                  branchnames = brnames.(i);
-                  nassums = List.length branchsigns.(i);
-                  branchnum = i+1; }
+      let ba = { branchnames = brnames.(i);
+                  nassums = List.length branchsigns.(i); }
       in
       tac ba
     in
@@ -123,7 +118,7 @@ let introElimAssumsThen tac ba =
 
 (* Supposed to be called with a non-recursive scheme *)
 let introCaseAssumsThen with_evars tac ba =
-  let n1 = List.length ba.branchsign in
+  let n1 = ba.nassums in
   let n2 = List.length ba.branchnames in
   let (l1,l2),l3 =
     if n1 < n2 then List.chop n1 ba.branchnames, []

--- a/tactics/elim.ml
+++ b/tactics/elim.ml
@@ -84,15 +84,12 @@ let general_elim_then_using mk_elim
 
 (* computing the case/elim combinators *)
 
-let make_elim_branch_assumptions ba hyps =
-  let assums =
-    try List.rev (List.firstn ba.nassums hyps)
-    with Failure _ -> CErrors.anomaly (Pp.str "make_elim_branch_assumptions.") in
-  assums
-
 let elim_on_ba tac ba =
   Proofview.Goal.enter begin fun gl ->
-  let branches = make_elim_branch_assumptions ba (Proofview.Goal.hyps gl) in
+  let branches =
+    try List.rev (List.firstn ba.nassums (Proofview.Goal.hyps gl))
+    with Failure _ -> CErrors.anomaly (Pp.str "make_elim_branch_assumptions.")
+  in
   tac branches
   end
 

--- a/tactics/elim.ml
+++ b/tactics/elim.ml
@@ -32,22 +32,22 @@ type elim_kind = Case of bool | Elim
 (* Find the right elimination suffix corresponding to the sort of the goal *)
 (* c should be of type A1->.. An->B with B an inductive definition *)
 let general_elim_then_using mk_elim
-    rec_flag allnames tac predicate (ind, u, args) id =
+    allnames tac predicate (ind, u, args) id =
   let open Pp in
   Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
     let sigma = Proofview.Goal.sigma gl in
     let sort = Retyping.get_sort_family_of env sigma (Proofview.Goal.concl gl) in
-    let sigma, elim, elimt = match mk_elim with
+    let sigma, elim, elimt, rec_flag = match mk_elim with
     | Case dep ->
       let u = EInstance.kind sigma u in
       let (sigma, c) = Indrec.build_case_analysis_scheme env sigma (ind, u) dep sort in
       let r, t = Indrec.eval_case_analysis c in
-      (sigma, r, t)
+      (sigma, r, t, false)
     | Elim ->
       let gr = Indrec.lookup_eliminator env ind sort in
       let sigma, r = Evd.fresh_global env sigma gr in
-      (sigma, r, Retyping.get_type_of env sigma r)
+      (sigma, r, Retyping.get_type_of env sigma r, true)
     in
     let is_case = match mk_elim with Elim -> false | Case _ -> true in
     (* applying elimination_scheme just a little modified *)
@@ -112,7 +112,7 @@ let elimination_then tac id =
     | NotRecord -> true, Elim
     | FakeRecord | PrimRecord _ -> false, Case true
   in
-  general_elim_then_using mkelim isrec None tac None (ind, u, args) id
+  general_elim_then_using mkelim None tac None (ind, u, args) id
   end
 
 (* Supposed to be called without as clause *)
@@ -134,7 +134,7 @@ let introCaseAssumsThen with_evars tac ba =
 
 let case_tac dep names tac elim ind c =
   let tac = introCaseAssumsThen false (* ApplyOn not supported by inversion *) tac in
-  general_elim_then_using (Case dep) false names tac (Some elim) ind c
+  general_elim_then_using (Case dep) names tac (Some elim) ind c
 
 (* The following tactic Decompose repeatedly applies the
    elimination(s) rule(s) of the types satisfying the predicate


### PR DESCRIPTION
We inline a lot of higher-order code that was only used once and we enforce additional static invariants in the internal function arguments used in the Elim module.