### PR TITLE
[xml protocol] Use complete Loc.t in fail case

### DIFF
--- a/dev/doc/changes.md
+++ b/dev/doc/changes.md
@@ -1,3 +1,12 @@
+## Changes between Coq 8.17 and Coq 8.18
+
+### XML protocol
+
+Version 20230413, see xml-protocol.md for details.
+
+- Coq locations are now fully transmitted, including line and column
+  information vs the previous start/end offset.
+
 ## Changes between Coq 8.15 and Coq 8.16
 
 ### Plugin Interface

--- a/dev/doc/xml-protocol.md
+++ b/dev/doc/xml-protocol.md
@@ -926,13 +926,19 @@ Ex: `status = "Idle"` or `status = "proof: myLemmaName"` or `status = "Dead"`
   </feedback_content>
 </feedback>
 ```
+* <a name="location">Location</a>, a Coq location:
+```xml
+   <loc start="${start_offset}" stop="${stop_offset}
+        line_nb="${start_line}" bol_pos="${begin_of_start_line_offset}"
+        line_nb_last="${end_line}" bol_pos_last="${begin_of_end_line_offset}"
+```
 
-* <a name="feedback-custom">Custom</a>. A feedback message that Coq plugins can use to return structured results, including results from Ltac profiling. Optionally, `startPos` and `stopPos` define a range of offsets in the document that the message refers to; otherwise, they will be 0. `customTag` is intended as a unique string that identifies what kind of payload is contained in `customXML`.
+* <a name="feedback-custom">Custom</a>. A feedback message that Coq plugins can use to return structured results, including results from Ltac profiling. `customTag` is intended as a unique string that identifies what kind of payload is contained in `customXML`. An optional location may be attached if present in the message.
 ```xml
 <feedback object="state" route="0">
   <state_id val="${stateId}"/>
   <feedback_content val="custom">
-    <loc start="${startPos}" stop="${stopPos}"/>
+    <option val="none|some">${loc}</option>
     <string>${customTag}</string>
     ${customXML}
   </feedback_content>

--- a/doc/changelog/10-coqide/17382-xmlprotocol_fulllocs.rst
+++ b/doc/changelog/10-coqide/17382-xmlprotocol_fulllocs.rst
@@ -1,0 +1,8 @@
+- **Changed:**
+  XML Protocol now sends (and expects) full Coq locations, including
+  line and column information. This makes some IDE operations (such as
+  UTF-8 decoding) more efficient. Clients of the XML protocol can just
+  ignore the new fields if they are not useful for them.
+  (`#17382 <https://github.com/coq/coq/pull/17382>`_,
+  fixes `#17023 <https://github.com/coq/coq/issues/17023>`_,
+  by Emilio Jesus Gallego Arias).

--- a/ide/coqide/coqOps.ml
+++ b/ide/coqide/coqOps.ml
@@ -60,8 +60,8 @@ module SentenceId : sig
   val start_iter : GText.buffer -> sentence -> GText.iter
   val start_stop_iters : GText.buffer -> sentence -> GText.iter * GText.iter
 
-  (** [ofsset_compensation] Drift of a sentence over its original
-      location, in offset. May be needed to compensage Coq locations. *)
+  (** [offset_compensation] Drift of a sentence over its original
+      location, in offset. Needed to repair outdated Coq locations *)
   val offset_compensation : GText.buffer -> sentence -> int
 
   val phrase : GText.buffer -> sentence -> string

--- a/ide/coqide/coqOps.ml
+++ b/ide/coqide/coqOps.ml
@@ -817,7 +817,6 @@ object(self)
                   if Queue.is_empty queue then loop tip []
                   else loop tip (List.rev topstack)
               | Fail (id, loc, msg) ->
-                  let loc = Option.map Loc.make_loc loc in
                   let sentence = Doc.pop document in
                   self#process_interp_error ?loc queue sentence msg tip id in
             Coq.bind coq_query handle_answer
@@ -976,7 +975,7 @@ object(self)
     self#backtrack_until ?move_insert until
 
   method private handle_failure_aux
-    ?(move_insert=false) (safe_id, (loc : (int * int) option), msg)
+    ?(move_insert=false) (safe_id, (loc : Loc.t option), msg)
   =
     messages#default_route#push Feedback.Error msg;
     if Stateid.equal safe_id Stateid.dummy then Coq.lift (fun () -> ())

--- a/ide/coqide/coqOps.ml
+++ b/ide/coqide/coqOps.ml
@@ -141,8 +141,8 @@ open SentenceId
 (* Given a Coq loc, convert it to a pair of iterators start / end in
    the buffer. *)
 let coq_loc_to_gtk_offset (buffer : GText.buffer) loc =
-  buffer#get_iter_at_byte ~line:loc.Loc.line_nb (loc.bp - loc.bol_pos),
-  buffer#get_iter_at_byte ~line:loc.Loc.line_nb_last (loc.ep - loc.bol_pos_last)
+  buffer#get_iter_at_byte ~line:(loc.Loc.line_nb - 1) (loc.bp - loc.bol_pos),
+  buffer#get_iter_at_byte ~line:(loc.Loc.line_nb_last - 1) (loc.ep - loc.bol_pos_last)
 
 (** increase [uni_off] by the number of bytes until [s_uni] This can
     be used to convert a character offset to byte offset if we know a

--- a/ide/coqide/coqOps.ml
+++ b/ide/coqide/coqOps.ml
@@ -194,10 +194,10 @@ let coq_loc_from_gtk_offset cached buffer sentence =
   (* Coq lines start at 1, GTK lines at 0 *)
   let line = start#line + 1 in
   (* [line_index] already returns byte offsets *)
-  let bol = start#line_index in
+  let bol_pos = bp - start#line_index in
   (*  *)
   let new_cached = bp, start#offset in
-  bp, line, bol, new_cached
+  bp, line, bol_pos, new_cached
 
 let log msg : unit task =
   Coq.lift (fun () -> Minilib.log msg)

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -91,9 +91,14 @@ let set_doc doc = ide_doc := Some doc
 let add ((((s,eid),(sid,verbose)),off),(line_nb,bol_pos)) =
   let doc = get_doc () in
   let open Loc in
-  (* note: this won't yield correct values for bol_pos_last,
-     but the debugger doesn't use that *)
-  let loc = { (initial ToplevelInput) with bp=off; line_nb; bol_pos } in
+  (* This needs to be akin to what CLexer.after does *)
+  let loc = { (initial ToplevelInput) with
+              bp=off
+            ; line_nb
+            ; bol_pos
+            ; ep=off
+            ; line_nb_last=line_nb
+            ; bol_pos_last=bol_pos } in
   let r_stream = Gramlib.Stream.of_string ~offset:off s in
   let pa = Pcoq.Parsable.make ~loc r_stream in
   match Stm.parse_sentence ~doc sid ~entry:Pvernac.main_entry pa with

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -461,9 +461,7 @@ let about () = {
 
 let handle_exn (e, info) =
   let dummy = Stateid.dummy in
-  let loc_of e = match Loc.get_loc e with
-    | Some loc -> Some (Loc.unloc loc)
-    | _        -> None in
+  let loc_of e = Loc.get_loc e in
   let mk_msg () = CErrors.iprint (e,info) in
   match e with
   | e ->

--- a/ide/coqide/protocol/interface.ml
+++ b/ide/coqide/protocol/interface.ml
@@ -133,7 +133,6 @@ type db_continue_opt =
 
 (** Calls result *)
 
-type location = (int * int) option (* start and end of the error *)
 type state_id = Stateid.t
 type route_id = Feedback.route_id
 
@@ -144,7 +143,7 @@ type edit_id  = int
    should probably retract to that point *)
 type 'a value =
   | Good of 'a
-  | Fail of (state_id * location * Pp.t)
+  | Fail of (state_id * Loc.t option * Pp.t)
 
 type ('a, 'b) union = ('a, 'b) Util.union
 
@@ -267,7 +266,7 @@ type about_sty = unit
 type about_rty = coq_info
 
 type handle_exn_sty = Exninfo.iexn
-type handle_exn_rty = state_id * location * Pp.t
+type handle_exn_rty = state_id * Loc.t option * Pp.t
 
 (* Retrocompatibility stuff *)
 type interp_sty = (raw * verbose) * string

--- a/ide/coqide/protocol/serialize.ml
+++ b/ide/coqide/protocol/serialize.ml
@@ -110,16 +110,44 @@ let to_edit_id = function
   | x -> raise (Marshal_error("edit_id",x))
 
 let of_loc loc =
-  let start, stop = Loc.unloc loc in
-  Element ("loc",[("start",string_of_int start);("stop",string_of_int stop)],[])
+  let {
+    Loc.fname
+  ; line_nb
+  ; bol_pos
+  ; line_nb_last
+  ; bol_pos_last
+  ; bp
+  ; ep
+  } = loc in
+  Element ("loc",
+           [ ("line_nb", string_of_int line_nb)
+           ; ("bol_pos", string_of_int bol_pos)
+           ; ("line_nb_last", string_of_int line_nb_last)
+           ; ("bol_pos_last", string_of_int bol_pos_last)
+           ; ("start", string_of_int bp)
+           ; ("stop", string_of_int ep )
+           ],
+           [])
+
 let to_loc xml =
   match xml with
-  | Element ("loc", l,[]) ->
-      let start = massoc "start" l in
-      let stop = massoc "stop" l in
-      (try
-        Loc.make_loc (int_of_string start, int_of_string stop)
-      with Not_found | Invalid_argument _ -> raise (Marshal_error("loc",PCData(start^":"^stop))))
+  | Element ("loc", l,[]) as x ->
+    (try
+       let line_nb = massoc "line_nb" l |> int_of_string in
+       let bol_pos = massoc "bol_pos" l |> int_of_string in
+       let line_nb_last = massoc "line_nb_last" l |> int_of_string in
+       let bol_pos_last = massoc "bol_pos_last" l |> int_of_string in
+       let bp = massoc "start" l |> int_of_string in
+       let ep = massoc "stop" l |> int_of_string in
+       { Loc.fname = ToplevelInput
+       ; line_nb
+       ; bol_pos
+       ; line_nb_last
+       ; bol_pos_last
+       ; bp
+       ; ep }
+     with Not_found | Invalid_argument _ ->
+       raise (Marshal_error("loc",x)))
   | x -> raise (Marshal_error("loc",x))
 
 let of_xml x = Element ("xml", [], [x])

--- a/ide/coqide/protocol/xmlprotocol.ml
+++ b/ide/coqide/protocol/xmlprotocol.ml
@@ -176,27 +176,19 @@ let to_dbcontinue_opt opt =
 
 let of_value f = function
 | Good x -> Element ("value", ["val", "good"], [f x])
-| Fail (id,loc, msg) ->
-  let loc = match loc with
-  | None -> []
-  | Some (s, e) -> [("loc_s", string_of_int s); ("loc_e", string_of_int e)] in
+| Fail (id, loc, msg) ->
+  let loc = of_option of_loc loc in
   let id = of_stateid id in
-  Element ("value", ["val", "fail"] @ loc, [id; of_pp msg])
+  Element ("value", ["val", "fail"], [id; loc; of_pp msg])
 
 let to_value f = function
 | Element ("value", attrs, l) ->
   let ans = massoc "val" attrs in
   if ans = "good" then Good (f (singleton l))
   else if ans = "fail" then
-    let loc =
-      try
-        let loc_s = int_of_string (Serialize.massoc "loc_s" attrs) in
-        let loc_e = int_of_string (Serialize.massoc "loc_e" attrs) in
-        Some (loc_s, loc_e)
-      with Marshal_error _ | Failure _ -> None
-    in
-    let (id, msg) = match l with [id; msg] -> (id, msg) | _ -> raise (Marshal_error("val",PCData "no id attribute")) in
+    let (id, loc, msg) = match l with [id; loc; msg] -> (id, loc, msg) | _ -> raise (Marshal_error("val",PCData "no id attribute")) in
     let id = to_stateid id in
+    let loc = to_option to_loc loc in
     let msg = to_pp msg    in
     Fail (id, loc, msg)
   else raise (Marshal_error("good or fail",PCData ans))
@@ -947,9 +939,9 @@ let to_call : xml -> unknown_call =
 let pr_value_gen pr = function
   | Good v -> "GOOD " ^ pr v
   | Fail (id,None,str) -> "FAIL "^Stateid.to_string id^" ["^ Pp.string_of_ppcmds str ^ "]"
-  | Fail (id,Some(i,j),str) ->
+  | Fail (id,Some loc,str) ->
       "FAIL "^Stateid.to_string id^
-        " ("^string_of_int i^","^string_of_int j^")["^Pp.string_of_ppcmds str^"]"
+        " ("^ (Loc.pr loc |> Pp.string_of_ppcmds) ^")["^Pp.string_of_ppcmds str^"]"
 let pr_value v = pr_value_gen (fun _ -> "FIXME") v
 let pr_full_value : type a. a call -> a value -> string = fun call value -> match call with
   | Add _        -> pr_value_gen (print add_rty_t        ) value
@@ -1023,7 +1015,7 @@ let document to_string_fmt =
     (to_string_fmt (of_value (fun _ -> PCData "b") (Good ())));
   Printf.printf "or:\n\n%s\n\nwhere the attributes loc_s and loc_c are optional.\n"
     (to_string_fmt (of_value (fun _ -> PCData "b")
-      (Fail (Stateid.initial,Some (15,34), Pp.str "error message"))));
+      (Fail (Stateid.initial,None, Pp.str "error message"))));
   document_type_encoding to_string_fmt
 
 (* Moved from feedback.mli : This is IDE specific and we don't want to

--- a/ide/coqide/protocol/xmlprotocol.ml
+++ b/ide/coqide/protocol/xmlprotocol.ml
@@ -9,7 +9,7 @@
 (************************************************************************)
 
 (** Protocol version of this file. This is the date of the last modification. *)
-let protocol_version = "20220205"
+let protocol_version = "20230413"
 
 (** See xml-protocol.md for a description of the protocol. *)
 (** UPDATE xml-protocol.md WHEN YOU UPDATE THE PROTOCOL *)

--- a/test-suite/interactive/tooltips.v
+++ b/test-suite/interactive/tooltips.v
@@ -1,0 +1,16 @@
+Ltac wait n := match n with 0 => idtac | S ?n => wait n; wait n end.
+
+#[deprecated(since="8.16")] Notation tt0 := tt.
+
+Goal True.
+Proof.
+fail.
+Qed.
+
+Variable (n : nat).
+
+Goal True.
+Proof.
+wait 15.
+elim tt0.
+Qed.


### PR DESCRIPTION
This removes uses of partial locations in the protocol.

