### PR TITLE
[library] Allow require to load libraries from memory.

### DIFF
--- a/dev/ci/user-overlays/17393-ejgallego-skip_vofile.sh
+++ b/dev/ci/user-overlays/17393-ejgallego-skip_vofile.sh
@@ -1,0 +1,3 @@
+overlay coq_lsp https://github.com/ejgallego/coq-lsp skip_vofile 17393
+
+overlay vscoq https://github.com/ejgallego/vscoq skip_vofile 17393

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -2236,7 +2236,8 @@ let new_doc { doc_type ; injections } =
     in
 
   (* Start this library and import initial libraries. *)
-  Coqinit.start_library ~top injections;
+  let intern = Vernacinterp.fs_intern in
+  Coqinit.start_library ~intern ~top injections;
 
   (* We record the state at this point! *)
   State.define ~doc ~cache:true ~redefine:true (fun () -> ()) Stateid.initial;

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -1035,7 +1035,9 @@ let stm_vernac_interp ?route id st { verbose; expr } : Vernacstate.t =
     (stm_pperr_endline Pp.(fun () -> str "ignoring " ++ Ppvernac.pr_vernac expr); st)
   else begin
     stm_pperr_endline Pp.(fun () -> str "interpreting " ++ Ppvernac.pr_vernac expr);
-    Vernacinterp.interp ?verbosely:(Some verbose) ~st expr
+    let lib_resolver = Loadpath.try_locate_absolute_library in
+    let intern = Library.intern_from_file ~lib_resolver in
+    Vernacinterp.interp ~intern ?verbosely:(Some verbose) ~st expr
   end
 
 (****************************** CRUFT *****************************************)

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -1035,9 +1035,7 @@ let stm_vernac_interp ?route id st { verbose; expr } : Vernacstate.t =
     (stm_pperr_endline Pp.(fun () -> str "ignoring " ++ Ppvernac.pr_vernac expr); st)
   else begin
     stm_pperr_endline Pp.(fun () -> str "interpreting " ++ Ppvernac.pr_vernac expr);
-    let lib_resolver = Loadpath.try_locate_absolute_library in
-    let intern = Library.intern_from_file ~lib_resolver in
-    Vernacinterp.interp ~intern ?verbosely:(Some verbose) ~st expr
+    Vernacinterp.(interp ~intern:fs_intern ?verbosely:(Some verbose) ~st expr)
   end
 
 (****************************** CRUFT *****************************************)

--- a/sysinit/coqinit.ml
+++ b/sysinit/coqinit.ml
@@ -182,11 +182,10 @@ let init_runtime opts =
   | Coqargs.Run ->
       injection_commands opts
 
-let require_file ~prefix ~lib ~export =
+let require_file ~intern ~prefix ~lib ~export =
   let mp = Libnames.qualid_of_string lib in
   let mfrom = Option.map Libnames.qualid_of_string prefix in
   let exp = Option.map (fun e -> e, None) export in
-  let intern = Vernacinterp.fs_intern in
   Flags.silently (Vernacentries.vernac_require ~intern mfrom exp) [mp,Vernacexpr.ImportAll]
 
 let warn_no_native_compiler =
@@ -201,14 +200,14 @@ let warn_deprecated_native_compiler =
           Pp.strbrk "The native-compiler option is deprecated. To compile native \
           files ahead of time, use the coqnative binary instead.")
 
-let handle_injection = let open Coqargs in function
-  | RequireInjection {lib;prefix;export} -> require_file ~lib ~prefix ~export
+let handle_injection ~intern = let open Coqargs in function
+  | RequireInjection {lib;prefix;export} -> require_file ~intern ~lib ~prefix ~export
   | OptionInjection o -> set_option o
   | WarnNoNative s -> warn_no_native_compiler s
   | WarnNativeDeprecated -> warn_deprecated_native_compiler ()
 
-let start_library ~top injections =
+let start_library ~intern ~top injections =
   Flags.verbosely Declaremods.start_library top;
   CWarnings.override_unknown_warning[@ocaml.warning "-3"] := true;
-  List.iter handle_injection injections;
+  List.iter (handle_injection ~intern) injections;
   CWarnings.override_unknown_warning[@ocaml.warning "-3"] := false

--- a/sysinit/coqinit.ml
+++ b/sysinit/coqinit.ml
@@ -186,8 +186,7 @@ let require_file ~prefix ~lib ~export =
   let mp = Libnames.qualid_of_string lib in
   let mfrom = Option.map Libnames.qualid_of_string prefix in
   let exp = Option.map (fun e -> e, None) export in
-  let lib_resolver = Loadpath.try_locate_absolute_library in
-  let intern = Library.intern_from_file ~lib_resolver in
+  let intern = Vernacinterp.fs_intern in
   Flags.silently (Vernacentries.vernac_require ~intern mfrom exp) [mp,Vernacexpr.ImportAll]
 
 let warn_no_native_compiler =

--- a/sysinit/coqinit.ml
+++ b/sysinit/coqinit.ml
@@ -186,7 +186,9 @@ let require_file ~prefix ~lib ~export =
   let mp = Libnames.qualid_of_string lib in
   let mfrom = Option.map Libnames.qualid_of_string prefix in
   let exp = Option.map (fun e -> e, None) export in
-  Flags.silently (Vernacentries.vernac_require mfrom exp) [mp,Vernacexpr.ImportAll]
+  let lib_resolver = Loadpath.try_locate_absolute_library in
+  let intern = Library.intern_from_file ~lib_resolver in
+  Flags.silently (Vernacentries.vernac_require ~intern mfrom exp) [mp,Vernacexpr.ImportAll]
 
 let warn_no_native_compiler =
   CWarnings.create_in Nativeconv.w_native_disabled

--- a/sysinit/coqinit.mli
+++ b/sysinit/coqinit.mli
@@ -55,4 +55,5 @@ val init_runtime : Coqargs.t -> Coqargs.injection_command list
     Given the logical name [top] of the current library and the set of initial
     options and required libraries, it starts its processing (see also
     Declaremods.start_library) *)
-val start_library : top:Names.DirPath.t -> Coqargs.injection_command list -> unit
+val start_library :
+  intern:Library.Intern.t -> top:Names.DirPath.t -> Coqargs.injection_command list -> unit

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -129,11 +129,12 @@ let loaded_native_libraries = Summary.ref DPset.empty ~stage:Summary.Stage.Inter
 (* various requests to the tables *)
 
 let find_library dir =
-  DPmap.find dir !libraries_table
+  DPmap.find_opt dir !libraries_table
 
 let try_find_library dir =
-  try find_library dir
-  with Not_found ->
+  match find_library dir with
+  | Some lib -> lib
+  | None ->
     user_err
       (str "Unknown library " ++ DirPath.print dir ++ str ".")
 
@@ -248,17 +249,17 @@ let mk_summary m = {
   libsum_info = m.library_info;
 }
 
-let mk_intern_library sum lib digest_lib proofs =
+let mk_intern_library sum lib digest_lib proofs vm =
   add_opaque_table sum.md_name (ToFetch proofs);
   let open Safe_typing in
-  mk_library sum lib (Dvo_or_vi digest_lib)
+  mk_library sum lib (Dvo_or_vi digest_lib) vm
 
 let summary_seg : seg_sum ObjFile.id = ObjFile.make_id "summary"
 let library_seg : seg_lib ObjFile.id = ObjFile.make_id "library"
 let opaques_seg : seg_proofs ObjFile.id = ObjFile.make_id "opaques"
 let vm_seg : seg_vm ObjFile.id = Vmlibrary.vm_segment
 
-let intern_from_file ?loc lib_resolver dir =
+let intern_from_file ?loc ~lib_resolver dir =
   let f = lib_resolver dir in
   Feedback.feedback(Feedback.FileDependency (Some f, DirPath.to_string dir));
   let ch = raw_intern_library f ?loc in
@@ -277,18 +278,23 @@ let intern_from_file ?loc lib_resolver dir =
        spc() ++ DirPath.print dir ++ str ".");
   Feedback.feedback (Feedback.FileLoaded(DirPath.to_string dir, f));
   Library_info.warn_library_info ~transitive:true lsd.md_name lsd.md_info;
-  lsd, lmd, digest_lmd, del_opaque, vmlib
+  (* lsd, lmd, digest_lmd, univs, digest_u, del_opaque, vmlib *)
+  mk_intern_library lsd lmd digest_lmd del_opaque vmlib
 
+(* Returns the digest of a library, checks both caches to see what is loaded *)
 let rec intern_library ~root ~intern (needed, contents as acc) dir =
   (* Look if in the current logical environment *)
-  try find_library dir, acc
-  with Not_found ->
-  (* Look if already listed and consequently its dependencies too *)
-  try mk_summary (DPmap.find dir contents), acc
-  with Not_found ->
-  let lsd, lmd, digest_lmd, del_opaque, vmlib = intern dir in
-  let m = mk_intern_library lsd lmd digest_lmd del_opaque vmlib in
-  mk_summary m, intern_library_deps ~root ~intern acc dir m
+  match find_library dir with
+  | Some loaded_lib -> loaded_lib, acc
+  | None ->
+    (* Look if already listed in the accumulator *)
+    match DPmap.find_opt dir contents with
+    | Some interned_lib ->
+      mk_summary interned_lib, acc
+    | None ->
+      (* We intern the library, and then intern the deps *)
+      let m = intern dir in
+      mk_summary m, intern_library_deps ~root ~intern acc dir m
 
 and intern_library_deps ~root ~intern libs dir m =
   let needed, contents =
@@ -309,8 +315,7 @@ and intern_mandatory_library ~intern caller libs (dir,d) =
   in
   libs
 
-let rec_intern_library ~lib_resolver libs (loc, dir) =
-  let intern dir = intern_from_file ?loc lib_resolver dir in
+let rec_intern_library ~intern libs (loc, dir) =
   let m, libs = intern_library ~root:true ~intern libs dir in
   Library_info.warn_library_info m.libsum_name m.libsum_info;
   libs
@@ -415,8 +420,8 @@ let require_library_from_dirpath needed =
   if Lib.is_module_or_modtype () then warn_require_in_module ();
   Lib.add_leaf (in_require needed)
 
-let require_library_syntax_from_dirpath ~lib_resolver modrefl =
-  let needed, contents = List.fold_left (rec_intern_library ~lib_resolver) ([], DPmap.empty) modrefl in
+let require_library_syntax_from_dirpath ~intern modrefl =
+  let needed, contents = List.fold_left (rec_intern_library ~intern) ([], DPmap.empty) modrefl in
   let needed = List.rev_map (fun (root, dir) -> root, DPmap.find dir contents) needed in
   Lib.add_leaf (in_require_syntax needed);
   List.map snd needed
@@ -488,6 +493,11 @@ let save_library_struct ~output_native_objects dir =
   if Array.exists (fun (d,_) -> DirPath.equal d dir) sd.md_deps then
     error_recursively_dependent_library dir;
   sd, md, vmlib, ast
+
+let save_library dir : library_t =
+  let sd, md, vmlib, _ast = save_library_struct ~output_native_objects:false dir in
+  let digest = Safe_typing.Dvo_or_vi (Digest.string "") in
+  mk_library sd md digest (Vmlibrary.inject vmlib)
 
 let save_library_to todo_proofs ~output_native_objects dir f =
   assert(

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -504,8 +504,11 @@ let save_library_struct ~output_native_objects dir =
 
 let save_library dir : library_t =
   let sd, md, vmlib, _ast = save_library_struct ~output_native_objects:false dir in
-  let digest = Safe_typing.Dvo_or_vi (Digest.string "") in
-  mk_library sd md digest (Vmlibrary.inject vmlib)
+  (* Digest for .vo files is on the md part, for now we also play it
+     safe when we work on-memory and compute the digest for the lib
+     part, even if that's slow. Better safe than sorry. *)
+  let digest = Marshal.to_string md [] |> Digest.string in
+  mk_library sd md (Dvo_or_vi digest) (Vmlibrary.inject vmlib)
 
 let save_library_to todo_proofs ~output_native_objects dir f =
   assert(

--- a/vernac/library.mli
+++ b/vernac/library.mli
@@ -25,8 +25,13 @@ type library_t
     Require = load in the environment *)
 val require_library_from_dirpath : library_t list -> unit
 
+(** Intern from a .vo file located by libresolver *)
+val intern_from_file :
+  ?loc:Loc.t ->
+  lib_resolver:(DirPath.t -> CUnix.physical_path) -> DirPath.t -> library_t
+
 val require_library_syntax_from_dirpath
-  :  lib_resolver:(DirPath.t -> CUnix.physical_path)
+  :  intern:(DirPath.t -> library_t)
   -> DirPath.t Loc.located list
   -> library_t list
 
@@ -52,6 +57,10 @@ val save_library_to :
   'document todo_proofs ->
   output_native_objects:bool ->
   DirPath.t -> string -> unit
+
+(** Save library to library_t format, that can be used later in
+    [require_library_syntax_from_dirpath] *)
+val save_library : DirPath.t -> library_t
 
 val save_library_raw : string -> seg_sum -> seg_lib -> seg_proofs -> seg_vm -> unit
 

--- a/vernac/library.mli
+++ b/vernac/library.mli
@@ -27,11 +27,19 @@ val require_library_from_dirpath : library_t list -> unit
 
 (** Intern from a .vo file located by libresolver *)
 val intern_from_file :
-  ?loc:Loc.t ->
-  lib_resolver:(DirPath.t -> CUnix.physical_path) -> DirPath.t -> library_t
+  CUnix.physical_path -> library_t
+
+module Intern : sig
+  module Provenance : sig
+    type t = string * string
+    (** A pair of [kind, object], for example ["file",
+        "/usr/local/foo.vo"], used for error messages. *)
+  end
+  type t = DirPath.t -> library_t * Provenance.t
+end
 
 val require_library_syntax_from_dirpath
-  :  intern:(DirPath.t -> library_t)
+  :  intern:Intern.t
   -> DirPath.t Loc.located list
   -> library_t list
 

--- a/vernac/synterp.mli
+++ b/vernac/synterp.mli
@@ -75,6 +75,7 @@ exception NotFoundLibrary of Names.DirPath.t option * Libnames.qualid
 (** [synterp_require] performs the syntactic interpretation phase of `Require`
     commands *)
 val synterp_require :
+  intern:(Names.DirPath.t -> Library.library_t) ->
   Libnames.qualid option ->
   Vernacexpr.export_with_cats option ->
   (Libnames.qualid * Vernacexpr.import_filter_expr) list ->
@@ -82,6 +83,7 @@ val synterp_require :
 
 (** [synterp_control] is the main entry point of the syntactic interpretation phase *)
 val synterp_control :
+  intern:(Names.DirPath.t -> Library.library_t) ->
   Vernacexpr.vernac_control ->
   vernac_control_entry
 

--- a/vernac/synterp.mli
+++ b/vernac/synterp.mli
@@ -75,7 +75,7 @@ exception NotFoundLibrary of Names.DirPath.t option * Libnames.qualid
 (** [synterp_require] performs the syntactic interpretation phase of `Require`
     commands *)
 val synterp_require :
-  intern:(Names.DirPath.t -> Library.library_t) ->
+  intern:Library.Intern.t ->
   Libnames.qualid option ->
   Vernacexpr.export_with_cats option ->
   (Libnames.qualid * Vernacexpr.import_filter_expr) list ->
@@ -83,7 +83,7 @@ val synterp_require :
 
 (** [synterp_control] is the main entry point of the syntactic interpretation phase *)
 val synterp_control :
-  intern:(Names.DirPath.t -> Library.library_t) ->
+  intern:Library.Intern.t ->
   Vernacexpr.vernac_control ->
   vernac_control_entry
 

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1450,8 +1450,8 @@ let vernac_require_interp needed modrefl export qidl =
         modrefl qidl)
     export
 
-let vernac_require from export qidl =
-  let needed, modrefl = Synterp.synterp_require from export qidl in
+let vernac_require ~intern from export qidl =
+  let needed, modrefl = Synterp.synterp_require ~intern from export qidl in
   vernac_require_interp needed modrefl export qidl
 
 (* Coercions and canonical structures *)

--- a/vernac/vernacentries.mli
+++ b/vernac/vernacentries.mli
@@ -24,7 +24,8 @@ val translate_vernac
 
 (** Vernacular require command, used by the command line *)
 val vernac_require
-  : Libnames.qualid option
+  : intern:(Names.DirPath.t -> Library.library_t)
+  -> Libnames.qualid option
   -> Vernacexpr.export_with_cats option
   -> (Libnames.qualid * Vernacexpr.import_filter_expr) list
   -> unit

--- a/vernac/vernacentries.mli
+++ b/vernac/vernacentries.mli
@@ -24,7 +24,7 @@ val translate_vernac
 
 (** Vernacular require command, used by the command line *)
 val vernac_require
-  : intern:(Names.DirPath.t -> Library.library_t)
+  : intern:Library.Intern.t
   -> Libnames.qualid option
   -> Vernacexpr.export_with_cats option
   -> (Libnames.qualid * Vernacexpr.import_filter_expr) list

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -215,12 +215,17 @@ let interp_entry ?(verbosely=true) ~st entry =
   Vernacstate.unfreeze_full_state st;
   interp_gen ~verbosely ~st ~interp_fn:interp_control entry
 
+let fs_intern dp =
+  let file = Loadpath.try_locate_absolute_library dp in
+  Feedback.feedback @@ Feedback.FileDependency (Some file, Names.DirPath.to_string dp);
+  let res = Library.intern_from_file file, ("file", file) in
+  Feedback.feedback @@ Feedback.FileLoaded (Names.DirPath.to_string dp, file);
+  res
+
 let interp_qed_delayed_proof ~proof ~st ~control (CAst.{loc; v = pe } as e) : Vernacstate.Interp.t =
   (* Synterp duplication of control handling bites us here... *)
-  let lib_resolver = Loadpath.try_locate_absolute_library in
-  let intern = Library.intern_from_file ~lib_resolver in
   let cmd = CAst.make ?loc { control; expr = VernacSynPure (VernacEndProof pe); attrs = [] } in
-  let CAst.{ loc; v = entry } = Synterp.synterp_control ~intern cmd in
+  let CAst.{ loc; v = entry } = Synterp.synterp_control ~intern:fs_intern cmd in
   let control = entry.control in
   NewProfile.profile "interp-delayed-qed" (fun () ->
       interp_gen ~verbosely:false ~st

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -204,10 +204,10 @@ let interp_gen ~verbosely ~st ~interp_fn cmd =
     Exninfo.iraise exn
 
 (* Regular interp *)
-let interp ?(verbosely=true) ~st cmd =
+let interp ~intern ?(verbosely=true) ~st cmd =
   Vernacstate.unfreeze_full_state st;
   vernac_pperr_endline Pp.(fun () -> str "interpreting: " ++ Ppvernac.pr_vernac_expr cmd.CAst.v.expr);
-  let entry = NewProfile.profile "synterp" (fun () -> Synterp.synterp_control cmd) () in
+  let entry = NewProfile.profile "synterp" (fun () -> Synterp.synterp_control ~intern cmd) () in
   let interp = NewProfile.profile "interp" (fun () -> interp_gen ~verbosely ~st ~interp_fn:interp_control entry) () in
   Vernacstate.{ synterp = Vernacstate.Synterp.freeze (); interp }
 
@@ -216,8 +216,11 @@ let interp_entry ?(verbosely=true) ~st entry =
   interp_gen ~verbosely ~st ~interp_fn:interp_control entry
 
 let interp_qed_delayed_proof ~proof ~st ~control (CAst.{loc; v = pe } as e) : Vernacstate.Interp.t =
+  (* Synterp duplication of control handling bites us here... *)
+  let lib_resolver = Loadpath.try_locate_absolute_library in
+  let intern = Library.intern_from_file ~lib_resolver in
   let cmd = CAst.make ?loc { control; expr = VernacSynPure (VernacEndProof pe); attrs = [] } in
-  let CAst.{ loc; v = entry } = Synterp.synterp_control cmd in
+  let CAst.{ loc; v = entry } = Synterp.synterp_control ~intern cmd in
   let control = entry.control in
   NewProfile.profile "interp-delayed-qed" (fun () ->
       interp_gen ~verbosely:false ~st

--- a/vernac/vernacinterp.mli
+++ b/vernac/vernacinterp.mli
@@ -10,7 +10,8 @@
 
 (** The main interpretation function of vernacular expressions *)
 val interp
-  : ?verbosely:bool
+  : intern:(Names.DirPath.t -> Library.library_t)
+  -> ?verbosely:bool
   -> st:Vernacstate.t
   -> Vernacexpr.vernac_control
   -> Vernacstate.t

--- a/vernac/vernacinterp.mli
+++ b/vernac/vernacinterp.mli
@@ -8,9 +8,12 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+(** Regular intern using the filesystem  *)
+val fs_intern : Library.Intern.t
+
 (** The main interpretation function of vernacular expressions *)
 val interp
-  : intern:(Names.DirPath.t -> Library.library_t)
+  : intern:Library.Intern.t
   -> ?verbosely:bool
   -> st:Vernacstate.t
   -> Vernacexpr.vernac_control


### PR DESCRIPTION
This is one more step in our quest to avoid saving / loading .vo files to disk when not needed.

Most changes are straightforward except for the extension of the command type to include an internalization function.

This is IMHO a good start to the goal of having the vernacular layer access all file-system by a parameterized structure to interpretation, so document managers can properly handle file-system access.

For example, a typical use case in jsCoq is to download a .vo file on Require, but there are many more possibilities.

Overlays:

- https://github.com/coq-community/vscoq/pull/775
- https://github.com/ejgallego/coq-lsp/pull/738

