### PR TITLE
[vernac] Remove LoadPath edition vernacular commands

### DIFF
--- a/dev/doc/xml-protocol.md
+++ b/dev/doc/xml-protocol.md
@@ -209,21 +209,18 @@ Moves current tip to `${stateId}`, such that commands may be added to the new st
 ```html
 <call val="Init"><option val="none"/></call>
 ```
-* With options. Looking at
-  [ide_slave.ml](https://github.com/coq/coq/blob/c5d0aa889fa80404f6c291000938e443d6200e5b/ide/ide_slave.ml#L355),
-  it seems that `options` is just the name of a script file, whose path
-  is added via `Add LoadPath` to the initial state.
+* With options:
 ```html
 <call val="Init">
   <option val="some">
-    <string>${options}</string>
+    <string>${v_file}.v</string>
   </option>
 </call>
 ```
-Providing the script file enables Coq to use .aux files created during
-compilation. Those file contain timing information that allow Coq to
-choose smartly between asynchronous and synchronous processing of
-proofs.
+Providing the script file `$v_file.v` enables Coq to use the `.$v_file.aux`
+file created during compilation. Those file contain timing information
+that allow Coq to choose smartly between asynchronous and synchronous
+processing of proofs.
 
 #### *Returns*
 * The initial stateId (not associated with a sentence)

--- a/doc/changelog/08-vernac-commands-and-options/17394-remove_vernac_loadpath.rst
+++ b/doc/changelog/08-vernac-commands-and-options/17394-remove_vernac_loadpath.rst
@@ -1,0 +1,7 @@
+- **Removed:**
+  The ``Add LoadPath``, ``Add Rec LoadPath``, ``Add ML Path``, and
+  ``Remove LoadPath`` have been removed following deprecation. Users
+  are encouraged to use the existing mechanisms in ``coq_makefile`` or
+  ``dune`` to configure workspaces of Coq theories.
+  (`#17394 <https://github.com/coq/coq/pull/17394>`_,
+  by Emilio Jesus Gallego Arias).

--- a/doc/sphinx/changes.rst
+++ b/doc/sphinx/changes.rst
@@ -1072,7 +1072,7 @@ Commands and options
   (`#15690 <https://github.com/coq/coq/pull/15690>`_,
   by Frédéric Besson).
 - **Deprecated:**
-  :cmd:`Add LoadPath` and :cmd:`Add Rec LoadPath`. If this command is an
+  ``Add LoadPath`` and ``Add Rec LoadPath``. If this command is an
   important feature for you, please open an issue on `GitHub <https://github.com/coq/coq/issues>`
   and explain your workflow
   (`#15652 <https://github.com/coq/coq/pull/15652>`_,
@@ -3710,7 +3710,7 @@ Commands and options
   (`#13339 <https://github.com/coq/coq/pull/13339>`_,
   by Théo Zimmermann).
 - **Added:**
-  Clarify in the documentation that :cmd:`Add ML Path` is not exported to compiled files
+  Clarify in the documentation that ``Add ML Path`` is not exported to compiled files
   (`#13345 <https://github.com/coq/coq/pull/13345>`_,
   fixes `#13344 <https://github.com/coq/coq/issues/13344>`_,
   by Hugo Herbelin).
@@ -4478,9 +4478,9 @@ Commands
   by Emilio Jesus Gallego Arias).
 - **Removed:**
   Recursive OCaml loadpaths are not supported anymore; the command
-  ``Add Rec ML Path`` has been removed; :cmd:`Add ML Path` is now the
+  ``Add Rec ML Path`` has been removed; ``Add ML Path`` is now the
   preferred one. We have also dropped support for the non-qualified
-  version of the :cmd:`Add LoadPath` command, that is to say,
+  version of the ``Add LoadPath`` command, that is to say,
   the ``Add LoadPath dir`` version; now,
   you must always specify a prefix now using ``Add Loadpath dir as Prefix``
   (`#11618 <https://github.com/coq/coq/pull/11618>`_,
@@ -5654,8 +5654,8 @@ Changes in 8.11+beta1
   (`#10494 <https://github.com/coq/coq/pull/10494>`_,
   by Jim Fehrle).
 - **Removed:** Legacy commands ``AddPath``, ``AddRecPath``, and ``DelPath``
-  which were undocumented, broken variants of :cmd:`Add LoadPath`,
-  :cmd:`Add Rec LoadPath`, and :cmd:`Remove LoadPath`
+  which were undocumented, broken variants of ``Add LoadPath``,
+  ``Add Rec LoadPath``, and ``Remove LoadPath``
   (`#11187 <https://github.com/coq/coq/pull/11187>`_,
   by Maxime Dénès and Théo Zimmermann).
 

--- a/doc/sphinx/practical-tools/coq-commands.rst
+++ b/doc/sphinx/practical-tools/coq-commands.rst
@@ -116,9 +116,6 @@ for example).
 ``-init-file file`` on the command line uses the specified file instead of a startup
 script from a configuration directory.  ``-q`` prevents the use of a startup script.
 
-The start up script may contain, for instance, :cmd:`Add LoadPath` commands to add
-directories to Coq's :term:`load path`.
-
 .. _customization-by-environment-variables:
 
 Environment variables

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -532,6 +532,11 @@ file is a particular case of a module called a *library file*.
 .. cmd:: {? From @dirpath } Require {? {| Import | Export } {? @import_categories } } {+ @filtered_import }
    :name: From … Require; Require; Require Import; Require Export
 
+   .. insertprodn dirpath dirpath
+
+   .. prodn::
+      dirpath ::= {* @ident . } @ident
+
    Loads compiled files into the Coq environment. For the first
    :n:`@qualid` in each :n:`@filtered_import`, the command looks in the
    :term:`load path` for a compiled file :n:`@ident.vo` whose
@@ -715,50 +720,10 @@ the toplevel, and using them in source files is discouraged.
 
    This command displays the current working directory.
 
-
 .. cmd:: Cd {? @string }
 
    If :n:`@string` is specified, changes the current directory according to :token:`string` which
    can be any valid path.  Otherwise, it displays the current directory.
-
-
-.. cmd:: Add LoadPath @string as @dirpath
-
-   .. deprecated:: 8.16
-
-      Use command line `-Q` or `-R` or put them in your `_CoqProject` file instead.
-
-      If this command is an important feature for you, please open an
-      issue at https://github.com/coq/coq/issues and explain your
-      workflow.
-
-   .. insertprodn dirpath dirpath
-
-   .. prodn::
-      dirpath ::= {* @ident . } @ident
-
-   This command is equivalent to the command line option
-   :n:`-Q @string @dirpath`. It adds a mapping to the :term:`load path` from
-   the logical name :n:`@dirpath` to the file system directory :n:`@string`.
-
-   * :n:`@dirpath` is a prefix of a module name.  The module name hierarchy
-     follows the file system hierarchy.  On Linux, for example, the prefix
-     `A.B.C` maps to the directory :n:`@string/B/C`.  Avoid using spaces after a `.` in the
-     path because the parser will interpret that as the end of a command or tactic.
-
-.. cmd:: Add Rec LoadPath @string as @dirpath
-
-   .. deprecated:: 8.16
-
-   This command is equivalent to the command line option
-   :n:`-R @string @dirpath`. It adds the directory specified by the
-   :n:`@string`` and all its subdirectories to the current Coq :term:`load path`.
-
-
-.. cmd:: Remove LoadPath @string
-
-   This command removes the path :n:`@string` from the current Coq :term:`load path`.
-
 
 .. cmd:: Print LoadPath {? @dirpath }
 
@@ -766,22 +731,11 @@ the toplevel, and using them in source files is discouraged.
    displays only the paths that extend that prefix.  In the output,
    the logical path `<>` represents an empty logical path.
 
-
-.. cmd:: Add ML Path @string
-
-   Equivalent to the :ref:`command line option <command-line-options>`
-   :n:`-I @string`.  Adds the path :n:`@string` to the current OCaml
-   loadpath (cf. :cmd:`Declare ML Module`). It is for
-   convenience, such as for use in an interactive session, and it
-   is not exported to compiled files. For separation of concerns with
-   respect to the relocability of files, we recommend using
-   :n:`-I @string`.
-
 .. cmd:: Print ML Path
 
-   Displays the current OCaml loadpath, as provided by
-   the :ref:`command line option <command-line-options>` :n:`-I @string` or by the command :cmd:`Add
-   ML Path` `@string` (cf. :cmd:`Declare ML Module`).
+   Displays the current OCaml loadpath, as provided by the
+   :ref:`command line option <command-line-options>` :n:`-I @string`
+   (cf. :cmd:`Declare ML Module`).
 
 .. _extra_dependencies:
 

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -533,9 +533,6 @@ command: [
 | "Load" [ "Verbose" | ] [ ne_string | IDENT ]
 | "Declare" "ML" "Module" LIST1 ne_string
 | "Locate" locatable
-| "Add" "LoadPath" ne_string "as" dirpath
-| "Add" "Rec" "LoadPath" ne_string "as" dirpath
-| "Remove" "LoadPath" ne_string
 | "Type" lconstr
 | "Print" printable
 | "Print" smart_global OPT univ_name_list
@@ -543,7 +540,6 @@ command: [
 | "Print" "Module" global
 | "Print" "Namespace" dirpath
 | "Inspect" natural
-| "Add" "ML" "Path" ne_string
 | "Set" setting_name option_setting
 | "Unset" setting_name
 | "Print" "Table" setting_name

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -720,9 +720,6 @@ command: [
 | "Locate" "Ltac" qualid
 | "Locate" "Library" qualid
 | "Locate" "File" string
-| "Add" "LoadPath" string "as" dirpath
-| "Add" "Rec" "LoadPath" string "as" dirpath
-| "Remove" "LoadPath" string
 | "Type" term
 | "Print" "All"
 | "Print" "Section" qualid
@@ -764,7 +761,6 @@ command: [
 | "Print" "Module" qualid
 | "Print" "Namespace" dirpath
 | "Inspect" natural
-| "Add" "ML" "Path" string
 | "Print" "Table" setting_name
 | "Add" setting_name LIST1 [ qualid | string ]
 | "Test" setting_name OPT ( "for" LIST1 [ qualid | string ] )

--- a/ide/coqide/coq_commands.ml
+++ b/ide/coqide/coq_commands.ml
@@ -13,14 +13,11 @@ let commands = [
    "Add Abstract Ring A Aplus Amult Aone Azero Ainv Aeq T.";
    "Add Abstract Semi Ring A Aplus Amult Aone Azero Aeq T.";
    "Add Field";
-   "Add LoadPath";
-   "Add ML Path";
    "Add Morphism";
    "Add Printing Constructor";
    "Add Printing If";
    "Add Printing Let";
    "Add Printing Record";
-   "Add Rec LoadPath";
    "Add Ring A Aplus Amult Aone Azero Ainv Aeq T [ c1 ... cn ]. ";
    "Add Semi Ring A Aplus Amult Aone Azero Aeq T [ c1 ... cn ].";
    "Add Relation";
@@ -94,7 +91,6 @@ let commands = [
   ["Read Module";
    "Record";
    "Remark";
-   "Remove LoadPath";
    "Remove Printing Constructor";
    "Remove Printing If";
    "Remove Printing Let";

--- a/test-suite/success/extra_dep.v
+++ b/test-suite/success/extra_dep.v
@@ -5,7 +5,3 @@ From TestSuite Extra Dependency "extra_dep.txt" as d1.
 Fail From TestSuite Extra Dependency "extra_dep.txt" as d1.
 
 From TestSuite Extra Dependency "extra_dep.txt" as d2.
-
-Add LoadPath "prerequisite/subdir" as TestSuite.
-Set Warnings "+ambiguous-extra-dep".
-Fail From TestSuite Extra Dependency "extra_dep.txt".

--- a/test-suite/success/extra_dep2.v
+++ b/test-suite/success/extra_dep2.v
@@ -1,0 +1,4 @@
+(* coq-prog-args: ("-Q" "prerequisite/subdir" "TestSuite") *)
+
+Set Warnings "+ambiguous-extra-dep".
+Fail From TestSuite Extra Dependency "extra_dep.txt".

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -941,15 +941,6 @@ GRAMMAR EXTEND Gram
 
       | IDENT "Locate"; l = locatable -> { VernacSynPure (VernacLocate l) }
 
-      (* Managing load paths *)
-      | IDENT "Add"; IDENT "LoadPath"; physical_path = ne_string; "as"; logical_path = dirpath ->
-          { VernacSynterp (VernacAddLoadPath { implicit = false; logical_path; physical_path }) }
-      | IDENT "Add"; IDENT "Rec"; IDENT "LoadPath"; physical_path = ne_string; "as"; logical_path = dirpath ->
-          { VernacSynterp (VernacAddLoadPath { implicit = true; logical_path; physical_path }) }
-
-      | IDENT "Remove"; IDENT "LoadPath"; dir = ne_string ->
-          { VernacSynterp (VernacRemoveLoadPath dir) }
-
       (* Type-Checking *)
       | "Type"; c = lconstr -> { VernacSynPure (VernacGlobalCheck c) }
 
@@ -963,9 +954,6 @@ GRAMMAR EXTEND Gram
       | IDENT "Print"; IDENT "Namespace" ; ns = dirpath ->
           { VernacSynPure (VernacPrint (PrintNamespace ns)) }
       | IDENT "Inspect"; n = natural -> { VernacSynPure (VernacPrint (PrintInspect n)) }
-
-      | IDENT "Add"; IDENT "ML"; IDENT "Path"; dir = ne_string ->
-          { VernacSynterp (VernacAddMLPath dir) }
 
       (* For acting on parameter tables *)
       | "Set"; table = setting_name; v = option_setting ->

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -1315,21 +1315,6 @@ let pr_synterp_vernac_expr v =
     )
 
   (* Auxiliary file and library management *)
-  | VernacAddLoadPath { implicit; physical_path; logical_path } ->
-    return (
-      hov 2
-        (keyword "Add" ++
-         (if implicit then spc () ++ keyword "Rec" ++ spc () else spc()) ++
-         keyword "LoadPath" ++ spc() ++ qs physical_path ++
-         spc() ++ keyword "as" ++ spc() ++ DirPath.print logical_path))
-  | VernacRemoveLoadPath s ->
-    return (keyword "Remove LoadPath" ++ qs s)
-  | VernacAddMLPath (s) ->
-    return (
-      keyword "Add"
-      ++ keyword "ML Path"
-      ++ qs s
-    )
   | VernacDeclareMLModule (l) ->
     return (
       hov 2 (keyword "Declare ML Module" ++ spc() ++ prlist_with_sep sep qs l)

--- a/vernac/synterp.ml
+++ b/vernac/synterp.ml
@@ -282,25 +282,6 @@ let synterp_require from export qidl =
 let expand filename =
   Envars.expand_path_macros ~warn:(fun x -> Feedback.msg_warning (str x)) filename
 
-let warn_add_loadpath = CWarnings.create ~name:"add-loadpath-deprecated" ~category:Deprecation.Version.v8_16
-    (fun () -> strbrk "Commands \"Add LoadPath\" and \"Add Rec LoadPath\" are deprecated." ++ spc () ++
-               strbrk "Use command-line \"-Q\" or \"-R\" or put them in your _CoqProject file instead." ++ spc () ++
-               strbrk "If \"Add [Rec] LoadPath\" is an important feature for you, please open an issue at" ++ spc () ++
-               strbrk "https://github.com/coq/coq/issues" ++ spc () ++ strbrk "and explain your workflow.")
-
-let synterp_add_loadpath ~implicit pdir coq_path =
-  let open Loadpath in
-  warn_add_loadpath ();
-  let pdir = expand pdir in
-  add_vo_path { unix_path = pdir; coq_path; has_ml = true; implicit; recursive = true }
-
-let synterp_remove_loadpath path =
-  Loadpath.remove_load_path (expand path)
-  (* Coq syntax for ML or system commands *)
-
-let synterp_add_ml_path path =
-  Mltop.add_ml_dir (expand path)
-
 let synterp_declare_ml_module ~local l =
   let local = Option.default false local in
   let l = List.map expand l in
@@ -454,18 +435,6 @@ let rec synterp ?loc ~atts v =
     | VernacImport (export,qidl) ->
       let export, mpl = synterp_import export qidl in
       EVernacImport (export,mpl)
-    | VernacAddLoadPath { implicit; physical_path; logical_path } ->
-      unsupported_attributes atts;
-      synterp_add_loadpath ~implicit physical_path logical_path;
-      EVernacNoop
-    | VernacRemoveLoadPath s ->
-      unsupported_attributes atts;
-      synterp_remove_loadpath s;
-      EVernacNoop
-    | VernacAddMLPath (s) ->
-      unsupported_attributes atts;
-      synterp_add_ml_path s;
-      EVernacNoop
     | VernacDeclareMLModule l ->
       with_locality ~atts synterp_declare_ml_module l;
       EVernacNoop

--- a/vernac/vernac_classifier.ml
+++ b/vernac/vernac_classifier.ml
@@ -60,7 +60,6 @@ let classify_vernac e =
         options_affecting_stm_scheduling ->
        VtSideff ([], VtNow)
     | VernacBeginSection {v=id} -> VtSideff ([id], VtLater)
-    | VernacAddLoadPath _ | VernacRemoveLoadPath _ | VernacAddMLPath _
     | VernacChdir _ | VernacExtraDependency _
     | VernacSetOption _ -> VtSideff ([], VtLater)
     (* (Local) Notations have to disappear *)

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -366,13 +366,6 @@ type synterp_vernac_expr =
   | VernacInclude of module_ast_inl list
 
   (* Auxiliary file and library management *)
-  | VernacAddLoadPath of { implicit : bool
-                         ; physical_path : CUnix.physical_path
-                         ; logical_path : DirPath.t
-                         }
-
-  | VernacRemoveLoadPath of string
-  | VernacAddMLPath of string
   | VernacDeclareMLModule of string list
   | VernacChdir of string option
   | VernacExtraDependency of qualid * string * Id.t option


### PR DESCRIPTION
Deprecated since 8.16, in general we prefer setting loadpaths outside of Coq documents.

This will allow us to provide to vernac mostly a read-only interface to the FS. We could indeed allow the documents to update this kind of state by setting the right write callbacks, however IMHO that's not worth it.

