### PR TITLE
Use a set instead of a list in pattern internalization.

### DIFF
--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -142,7 +142,7 @@ val interp_type_evars_impls : ?flags:inference_flags -> env -> evar_map ->
 (** Without typing *)
 val intern_constr_pattern :
   env -> evar_map -> ?as_type:bool -> ?strict_check:bool -> ?ltacvars:ltac_sign ->
-    constr_pattern_expr -> patvar list * constr_pattern
+    constr_pattern_expr -> Id.Set.t * constr_pattern
 
 (** Returns None if it's an abbreviation not bound to a name, raises an error
     if not existing *)

--- a/pretyping/patternops.ml
+++ b/pretyping/patternops.ml
@@ -368,11 +368,11 @@ let warn_cast_in_pattern =
     (fun () -> Pp.strbrk "Cast types are ignored in patterns")
 
 type meta_accu =
-  | Metas of Id.t list ref
+  | Metas of Id.Set.t ref
   | InCastType of Loc.t option
 
 let push_meta metas n = match metas with
-  | Metas metas -> metas := n::!metas
+  | Metas metas -> metas := Id.Set.add n !metas
   | InCastType loc ->
     CErrors.user_err ?loc
       Pp.(str "Cannot bind pattern variable in cast type:"
@@ -557,6 +557,6 @@ and pats_of_glob_branches loc metas vars ind brs =
   get_pat Int.Set.empty brs
 
 let pattern_of_glob_constr c =
-  let metas = ref [] in
+  let metas = ref Id.Set.empty in
   let p = pat_of_raw (Metas metas) [] c in
-  (!metas,p)
+  (!metas, p)

--- a/pretyping/patternops.mli
+++ b/pretyping/patternops.mli
@@ -50,7 +50,7 @@ val legacy_bad_pattern_of_constr : Environ.env -> Evd.evar_map -> EConstr.constr
     are bound *)
 
 val pattern_of_glob_constr : glob_constr ->
-      patvar list * constr_pattern
+      Id.Set.t * constr_pattern
 
 val map_pattern_with_binders : (Name.t -> 'a -> 'a) ->
   ('a -> constr_pattern -> constr_pattern) -> 'a -> constr_pattern -> constr_pattern

--- a/pretyping/typeclasses.ml
+++ b/pretyping/typeclasses.ml
@@ -24,7 +24,7 @@ type 'a hint_info_gen =
     { hint_priority : int option;
       hint_pattern : 'a option }
 
-type hint_info = (Pattern.patvar list * Pattern.constr_pattern) hint_info_gen
+type hint_info = (Id.Set.t * Pattern.constr_pattern) hint_info_gen
 
 let get_typeclasses_unique_solutions =
   Goptions.declare_bool_option_and_ref

--- a/pretyping/typeclasses.mli
+++ b/pretyping/typeclasses.mli
@@ -18,7 +18,7 @@ type 'a hint_info_gen =
     { hint_priority : int option;
       hint_pattern : 'a option }
 
-type hint_info = (Pattern.patvar list * Pattern.constr_pattern) hint_info_gen
+type hint_info = (Id.Set.t * Pattern.constr_pattern) hint_info_gen
 
 type class_method = {
   meth_name : Name.t;

--- a/vernac/comHints.ml
+++ b/vernac/comHints.ml
@@ -157,10 +157,7 @@ let interp_hints ~poly h =
     HintsResolveEntry (List.flatten (List.map constr_hints_of_ind lqid))
   | HintsExtern (pri, patcom, tacexp) ->
     let pat = Option.map (fp sigma) patcom in
-    let l = match pat with None -> [] | Some (l, _) -> l in
-    let ltacvars =
-      List.fold_left (fun accu x -> Id.Set.add x accu) Id.Set.empty l
-    in
+    let ltacvars = match pat with None -> Id.Set.empty | Some (l, _) -> l in
     let env = Genintern.{(empty_glob_sign ~strict:true env) with ltacvars} in
     let _, tacexp = Genintern.generic_intern env tacexp in
     HintsExternEntry


### PR DESCRIPTION
We never rely on the order or duplicity, so there is no point in exposing these details.