### PR TITLE
Restore the FullHint.pattern function.

### DIFF
--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1742,6 +1742,10 @@ struct
   type t = full_hint
   let priority (h : t) = h.pri
   let database (h : t) = h.db
+  let pattern (h : t) = match h.pat with
+  | None -> None
+  | Some (ConstrPattern p) -> Some p
+  | Some DefaultPattern -> None
   let run (h : t) k = run_hint h.code k
   let print env sigma (h : t) = pr_hint env sigma h.code
   let name (h : t) = h.name

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -56,6 +56,7 @@ module FullHint :
 sig
   type t
   val priority : t -> int
+  val pattern : t -> Pattern.constr_pattern option
   val database : t -> string option
   val run : t -> (hint hint_ast -> 'r Proofview.tactic) -> 'r Proofview.tactic
   val name : t -> hints_path_atom


### PR DESCRIPTION
Despite not being used in our CI, it's still used in privately-developped plugins.