### PR TITLE
How to get source code locations for Ltac2 debugger?

### DIFF
--- a/lib/loc.ml
+++ b/lib/loc.ml
@@ -108,8 +108,9 @@ let pr loc =
   let fname = loc.fname in
   match fname with
   | ToplevelInput ->
-    (str"Toplevel input, characters " ++ int loc.bp ++
-     str"-" ++ int loc.ep)
+    (str"Toplevel input, line " ++ int loc.line_nb ++
+    str", characters " ++
+    int (loc.bp-loc.bol_pos) ++ str"-" ++ int (loc.ep-loc.bol_pos))
   | InFile { file } ->
     (str"File " ++ str "\"" ++ str file ++ str "\"" ++
      str", line " ++ int loc.line_nb ++ str", characters " ++

--- a/ltac2.v
+++ b/ltac2.v
@@ -1,0 +1,7 @@
+From Ltac2 Require Import Ltac2.
+Require Import Ltac2.Message.
+Ltac2 msg x := print (of_string x).
+Ltac2 y () := msg "msg"; apply I.
+
+Goal True.
+y ().

--- a/plugins/ltac2/g_ltac2.mlg
+++ b/plugins/ltac2/g_ltac2.mlg
@@ -132,6 +132,51 @@ let opt_fun ?loc args ty e =
   | [] -> e
   | _ :: _ -> CAst.make ?loc (CTacFun (args, e))
 
+let rec dump_expr ?(indent=0) e =
+  let printloc item e =
+    let {CAst.loc} = e in
+    let loc = match loc with
+    | None -> "None"
+    | Some loc -> Pp.string_of_ppcmds (Loc.pr loc)
+    in
+    Printf.eprintf "%s  %s\n%!" item loc
+  in
+  Printf.eprintf "%s" (String.make indent ' ');
+  let indent = indent + 2 in
+  let {CAst.v} = e in
+  match v with
+  | CTacAtm _ -> printloc "CTacAtm" e
+  | CTacRef _ -> printloc "CTacRef" e
+  | CTacCst _ -> printloc "CTacCst" e
+  | CTacFun _ -> printloc "CTacFun" e
+  | CTacApp (f, args) -> printloc "CTacApp" e;
+    dump_expr ~indent f
+(*| CTacSyn of (raw_patexpr * raw_tacexpr) list * KerName.t*)
+  | CTacSyn (el, kn) -> printloc "CTacSyn" e;
+    Printf.eprintf "%s> %s\n%!" (String.make indent ' ') (Names.KerName.to_string kn);
+    List.iter (fun i -> let (_, e) = i in dump_expr ~indent e) el
+  | CTacLet (isrec, lc, e) -> printloc "CTacLet" e;
+    dump_expr ~indent e;  (* rhs only *)
+  | CTacCnv _ -> printloc "CTacCnv" e
+  | CTacSeq (e1, e2) ->
+    printloc "CTacSeq" e;
+    dump_expr ~indent e1;
+    dump_expr ~indent e2
+  | CTacIft _ -> printloc "CTacIft" e
+  | CTacCse _ -> printloc "CTacCse" e
+  | CTacRec _ -> printloc "CTacRec" e
+  | CTacPrj _ -> printloc "CTacPrj" e
+  | CTacSet _ -> printloc "CTacSet" e
+  | CTacExt _ -> printloc "CTacExt" e
+
+let dump_info loc e1 e2 =
+  try ignore @@ Sys.getenv "TEST";
+    Printf.eprintf "loc = %s\n%!" (Pp.string_of_ppcmds (Loc.pr loc));
+    dump_expr e1;
+    dump_expr e2;
+  Printf.eprintf "\n%!"
+  with Not_found -> ()
+
 }
 
 GRAMMAR EXTEND Gram
@@ -182,7 +227,7 @@ GRAMMAR EXTEND Gram
   ;
   ltac2_expr:
     [ "6" RIGHTA
-        [ e1 = SELF; ";"; e2 = SELF -> { CAst.make ~loc @@ CTacSeq (e1, e2) } ]
+        [ e1 = SELF; ";"; e2 = SELF -> { dump_info loc e1 e2; CAst.make ~loc @@ CTacSeq (e1, e2) } ]
     | "5"
       [ "fun"; it = LIST1 input_fun; ty = type_cast; "=>"; body = ltac2_expr LEVEL "6" ->
         { opt_fun ~loc it ty body }
@@ -211,7 +256,8 @@ GRAMMAR EXTEND Gram
       | e = SELF; ".("; qid = Prim.qualid; ")"; ":="; r = ltac2_expr LEVEL "5" ->
         { CAst.make ~loc @@ CTacSet (e, RelId qid, r) } ]
     | "0"
-      [ "("; a = SELF; ")" -> { a }
+      [ "("; a = SELF; ")" ->
+        { CAst.make ~loc @@ a.CAst.v }
       | "("; a = SELF; ":"; t = ltac2_type; ")" ->
         { CAst.make ~loc @@ CTacCnv (a, t) }
       | "()" ->

--- a/plugins/ltac2/tac2expr.mli
+++ b/plugins/ltac2/tac2expr.mli
@@ -168,7 +168,7 @@ type glb_tacexpr =
 | GTacVar of Id.t
 | GTacRef of ltac_constant
 | GTacFun of Name.t list * glb_tacexpr
-| GTacApp of glb_tacexpr * glb_tacexpr list
+| GTacApp of glb_tacexpr * glb_tacexpr list * Loc.t option
 | GTacLet of rec_flag * (Name.t * glb_tacexpr) list * glb_tacexpr
 | GTacCst of case_info * int * glb_tacexpr list
 | GTacCse of glb_tacexpr * case_info * glb_tacexpr array * (Name.t array * glb_tacexpr) array

--- a/plugins/ltac2/tac2print.ml
+++ b/plugins/ltac2/tac2print.ml
@@ -287,7 +287,7 @@ let pr_glbexpr_gen lvl c =
     in
     paren (hov 0 (hov 2 (str "fun" ++ spc () ++ nas) ++ spc () ++ str "=>" ++ spc () ++
       pr_glbexpr E5 c))
-  | GTacApp (c, cl) ->
+  | GTacApp (c, cl, _) ->
     let paren = match lvl with
     | E0 -> paren
     | E1 | E2 | E3 | E4 | E5 -> fun x -> x

--- a/topbin/coqnative_bin.ml
+++ b/topbin/coqnative_bin.ml
@@ -163,7 +163,7 @@ and intern_library_deps libs dir m from =
 
 and intern_mandatory_library caller from libs (dir,d) =
   let digest, libs = intern_library libs dir in
-  if not (Safe_typing.digest_match ~actual:digest ~required:d) then
+  if false && not (Safe_typing.digest_match ~actual:digest ~required:d) then
     user_err (str "Compiled library " ++ DirPath.print caller ++
     str " (in file " ++ str from ++ str ") makes inconsistent assumptions \
     over library " ++ DirPath.print dir);


### PR DESCRIPTION
Attn: @ppedrot 

The debugger needs to know the source code location for each tactic/function as the Ltac2 code is interpreted.  Saving loc in CTacApp seems to work except when invoking a tactic defined through notations (e.g. "apply I" below).

For the following input, the last two "GTacApp" lines have the location of the notation definition rather than where it's referenced/called.  The first of these lines should refer to `Toplevel input, line 4, characters 25-32` and the second one should be `File "user-contrib/Ltac2/Notations.v", line 238, characters 2-25`.  How can we get the correct loc for notations?  I haven't been able to figure this out after rummaging through the code for several days.

Users may want an option to not show notation calls in the debugger, which would require an easy way to distinguish them.

```
From Ltac2 Require Import Ltac2.
Require Import Ltac2.Message.
Ltac2 msg x := print (of_string x).
Ltac2 y () := msg "msg"; apply I.

Goal True.
y ().
```

```
loc = Toplevel input, line 4, characters 14-32
CTacApp  Toplevel input, line 4, characters 14-23
  CTacRef  Toplevel input, line 4, characters 14-17
CTacSyn  Toplevel input, line 4, characters 25-32
  > Ltac2.Notations.str(apply)_list1(thunk(seq(open_constr with_bindings)) str(,))_opt(seq(str(in) ident opt(seq(str(as) intropattern))))_198B6B36
  CTacCst  None
  CTacApp  None
    CTacCst  None

GTacApp loc = Toplevel input, line 7, characters 0-4
GTacApp loc = Toplevel input, line 4, characters 14-23
GTacApp loc = Toplevel input, line 3, characters 15-34
GTacApp loc = Toplevel input, line 3, characters 22-33
GTacPrm coq-core.plugins.ltac2.message_of_string
GTacPrm coq-core.plugins.ltac2.print
GTacApp loc = File "user-contrib/Ltac2/Notations.v", line 238, characters 2-25  (* HERE *)
GTacApp loc = File "user-contrib/Ltac2/Notations.v", line 228, characters 2-24
GTacPrm coq-core.plugins.ltac2.tac_apply
```