### PR TITLE
Explain stack overflow for nat, number examples

### DIFF
--- a/doc/sphinx/language/coq-library.rst
+++ b/doc/sphinx/language/coq-library.rst
@@ -520,7 +520,8 @@ numbers, together with the definitions of predecessor, addition and
 multiplication, in module ``Peano.v``. It also
 provides a scope ``nat_scope`` gathering standard notations for
 common operations (``+``, ``*``) and a decimal notation for
-numbers, allowing for instance to write ``3`` for :g:`S (S (S O)))`. This also works on
+numbers, allowing, for instance, writing ``3`` for :g:`S (S (S O))`.
+This also works on
 the left hand side of a ``match`` expression (see for example
 section :tacn:`refine`). This scope is opened by default.
 

--- a/doc/sphinx/language/core/basic.rst
+++ b/doc/sphinx/language/core/basic.rst
@@ -133,9 +133,11 @@ Numbers
      hexnat ::= {| 0x | 0X } @hexdigit {* {| @hexdigit | _ } }
      hexdigit ::= {| 0 .. 9 | a .. f | A .. F }
 
-  :n:`@integer` and :n:`@natural` are limited to the range that fits
+  :n:`number`, :n:`@bigint` and :n:`@bignat`, which are used in :token:`term`\s,
+  generally have no range limitation.
+  :n:`@integer` and :n:`@natural`, which are used as arguments in tactics
+  and commands, are limited to the range that fits
   into an OCaml integer (63-bit integers on most architectures).
-  :n:`@bigint` and :n:`@bignat` have no range limitation.
 
   The :ref:`standard library <thecoqlibrary>` provides a few
   :ref:`interpretations <notation-scopes>` for :n:`@number`.
@@ -143,8 +145,30 @@ Numbers
   for decimal numbers, for example ``5.02e-6`` means 5.02×10\ :sup:`-6`;
   and base 2 exponential notation for hexadecimal numbers denoted by
   ``p`` or ``P``, for example ``0xAp12`` means 10×2\ :sup:`12`.
-  The :cmd:`Number Notation` mechanism offers the user
-  a way to define custom parsers and printers for :n:`@number`.
+  The :cmd:`Number Notation` mechanism lets the user
+  define custom parsers and printers for :n:`@number`.
+
+  By default, numbers are interpreted as :n:`nat`\s, which is a unary
+  representation.  For example, :n:`3` is represented as `S (S (S O))`.  While
+  this is a convenient representation for doing proofs, computing with large
+  :n:`nat`\s can lead to stack overflows or running out of memory.  You can
+  explicitly specify a different interpretation to avoid this problem.  For
+  example, :n:`1000000%Z` is a more efficient binary representation of
+  that number as an integer.  See :ref:`Scopes` and :n:`@term_scope`.
+
+   .. example:: Stack overflow with :n:`nat`
+
+      .. coqtop:: all reset
+
+         Fail Eval compute in 100000 + 100000.  (* gives a stack overflow (not shown) *)
+
+      .. coqtop:: in
+
+         Require Import ZArith.  (* for definition of Z *)
+
+      .. coqtop:: all
+
+         Eval compute in (1000000000000000000000000000000000 + 1)%Z.
 
 Strings
   Strings begin and end with ``"`` (double quote).  Use ``""`` to represent
@@ -252,7 +276,7 @@ rest of the Coq manual: :term:`terms <term>` and :term:`types
         | @term0
         term0 ::= @qualid_annotated
         | @sort
-        | @primitive_notations
+        | @number_or_string
         | @term_evar
         | @term_match
         | @term_record

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -1898,15 +1898,15 @@ Abbreviations
 Numbers and strings
 -------------------
 
-.. insertprodn primitive_notations primitive_notations
+.. insertprodn number_or_string number_or_string
 
 .. prodn::
-   primitive_notations ::= @number
+   number_or_string ::= @number
    | @string
 
 Numbers and strings have no predefined semantics in the calculus. They are
 merely notations that can be bound to objects through the notation mechanism.
-Initially, numbers are bound to Peano’s representation of natural
+Initially, numbers are bound to :n:`nat`, Peano’s representation of natural
 numbers (see :ref:`datatypes`).
 
 .. note::
@@ -1929,8 +1929,8 @@ Number notations
       | @number_string_via
       number_string_via ::= via @qualid mapping [ {+, {| @qualid => @qualid | [ @qualid ] => @qualid } } ]
 
-   This command allows the user to customize the way number literals
-   are parsed and printed.
+   Customizes the way number literals are parsed and printed within the current
+   :term:`notation scope`.
 
       :n:`@qualid__type`
          the name of an inductive type,
@@ -2041,8 +2041,8 @@ Number notations
 
       :n:`abstract after @bignat`
          returns :n:`(@qualid__parse m)` when parsing a literal
-         :n:`m` that's greater than :n:`@bignat` rather than reducing it to a normal form.
-         Here :g:`m` will be a
+         :n:`m` that's greater than or equal to :n:`@bignat` rather than reducing
+         it to a normal form.  Here :g:`m` will be a
          :g:`Number.int`, :g:`Number.uint`, :g:`Z` or :g:`Number.number`, depending on the
          type of the parsing function :n:`@qualid__parse`. This allows for a
          more compact representation of literals in types such as :g:`nat`,

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -325,8 +325,8 @@ qualid_annotated: [
 
 atomic_constr: [
 | qualid_annotated
-| MOVETO primitive_notations string
-| DELETE primitive_notations
+| MOVETO number_or_string string
+| DELETE number_or_string
 | MOVETO term_evar "_"
 | REPLACE "?" "[" identref "]"
 | WITH "?[" identref "]"
@@ -423,7 +423,7 @@ term0: [
 | DELETE "{" binder_constr "}"
 | REPLACE "{|" record_declaration bar_cbrace
 | WITH "{|" LIST0 field_def SEP ";" OPT ";" bar_cbrace
-| MOVETO primitive_notations NUMBER
+| MOVETO number_or_string NUMBER
 | MOVETO term_record "{|" LIST0 field_def SEP ";" OPT ";" bar_cbrace
 | MOVETO term_generalizing "`{" term200 "}"
 | MOVETO term_generalizing "`(" term200 ")"

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -36,7 +36,7 @@ term1: [
 term0: [
 | qualid_annotated
 | sort
-| primitive_notations
+| number_or_string
 | term_evar
 | term_match
 | term_record
@@ -89,7 +89,7 @@ term_explicit: [
 | "@" qualid_annotated
 ]
 
-primitive_notations: [
+number_or_string: [
 | number
 | string
 ]


### PR DESCRIPTION
See Discourse [Compute 121393+121393 causes stack overflow](https://coq.discourse.group/t/compute-121393-121393-causes-stack-overflow/1904)

Would someone give me a good example when the 63-bit limitation is relevant?  Or I will drop this text.

![image](https://user-images.githubusercontent.com/1253341/226210106-c553c695-8565-4e83-b064-d8515fcfdd18.png)

