### PR TITLE
Add coq-tactician to CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -920,3 +920,6 @@ plugin:ci-smtcoq:
 
 plugin:ci-stalmarck:
   extends: .ci-template
+
+plugin:ci-tactician:
+  extends: .ci-template-flambda

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -76,6 +76,7 @@ CI_TARGETS= \
     ci-smtcoq \
     ci-stalmarck \
     ci-stdlib2 \
+    ci-tactician \
     ci-tlc \
     ci-unimath \
     ci-unicoq \

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -364,3 +364,8 @@ project stalmarck "https://github.com/coq-community/stalmarck" "master"
 # coq-library-undecidability
 ########################################################################
 project coq_library_undecidability "https://github.com/uds-psl/coq-library-undecidability" "master"
+
+########################################################################
+# Tactician
+########################################################################
+project tactician "https://github.com/coq-tactician/coq-tactician" "coqdev"

--- a/dev/ci/ci-tactician.sh
+++ b/dev/ci/ci-tactician.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+git_download tactician
+
+if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
+
+( cd "${CI_BUILD_DIR}/tactician"
+  dune build --root . --only-packages=coq-tactician @install
+)

--- a/dev/ci/ci-tactician.sh
+++ b/dev/ci/ci-tactician.sh
@@ -10,5 +10,5 @@ git_download tactician
 if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
 
 ( cd "${CI_BUILD_DIR}/tactician"
-  dune build --root . --only-packages=coq-tactician @install
+  dune build --root . theories/Ltac1.vo
 )


### PR DESCRIPTION
I'd like to revisit #13571. Unfortunately, some of the hacky workarounds in Tactician that were discussed there have not yet been resolved. But always chasing after upstream changes is also not great. So I'd like to gauge again how many objections there are regarding inclusion from the core devs.