### PR TITLE
Make sure to use fresh intro names in Lqa and Lra (fix #17423).

### DIFF
--- a/test-suite/bugs/bug_17423.v
+++ b/test-suite/bugs/bug_17423.v
@@ -1,0 +1,11 @@
+Require Import Reals Lra.
+
+Open Scope R_scope.
+
+Set Mangle Names.
+
+Lemma div2mult05_0 : forall r, r / 2 = r * 0.5.
+Proof.
+  intros r.
+  lra.
+Qed.

--- a/theories/micromega/Lqa.v
+++ b/theories/micromega/Lqa.v
@@ -23,7 +23,10 @@ Require Coq.micromega.Tauto.
 Declare ML Module "micromega_plugin:coq-core.plugins.micromega".
 
 Ltac rchange :=
-  intros ?__wit ?__varmap ?__ff ;
+  let __wit := fresh "__wit" in
+  let __varmap := fresh "__varmap" in
+  let __ff := fresh "__ff" in
+  intros __wit __varmap __ff ;
   change (Tauto.eval_bf (Qeval_formula (@find Q 0%Q __varmap)) __ff) ;
   apply (QTautoChecker_sound __ff __wit).
 

--- a/theories/micromega/Lra.v
+++ b/theories/micromega/Lra.v
@@ -24,7 +24,10 @@ Require Import Rregisternames.
 Declare ML Module "micromega_plugin:coq-core.plugins.micromega".
 
 Ltac rchange :=
-  intros ?__wit ?__varmap ?__ff ;
+  let __wit := fresh "__wit" in
+  let __varmap := fresh "__varmap" in
+  let __ff := fresh "__ff" in
+  intros __wit __varmap __ff ;
   change (Tauto.eval_bf (Reval_formula (@find R 0%R __varmap)) __ff) ;
   apply (RTautoChecker_sound __ff __wit).
 


### PR DESCRIPTION
This affects Lqa.lra, Lqa.nra, Lqa.psatz, Lra.lra, Lra.nra, Lra.psatz.

This bug had already been fixed for Lia in #12913.

Fixes / closes #17423