### PR TITLE
Use a simpler definition of xorb.

### DIFF
--- a/doc/changelog/11-standard-library/17427-xorb.rst
+++ b/doc/changelog/11-standard-library/17427-xorb.rst
@@ -1,0 +1,4 @@
+- **Changed:**
+  :g:`xorb` to a simpler definition
+  (`#17427 <https://github.com/coq/coq/pull/17427>`_,
+  by Guillaume Melquiond).

--- a/theories/Init/Datatypes.v
+++ b/theories/Init/Datatypes.v
@@ -59,12 +59,9 @@ Definition orb (b1 b2:bool) : bool := if b1 then true else b2.
 Definition implb (b1 b2:bool) : bool := if b1 then b2 else true.
 
 Definition xorb (b1 b2:bool) : bool :=
-  match b1, b2 with
-    | true, true => false
-    | true, false => true
-    | false, true => true
-    | false, false => false
-  end.
+  if b1 then
+    if b2 then false else true
+  else b2.
 
 Definition negb (b:bool) := if b then false else true.
 

--- a/theories/NArith/BinNat.v
+++ b/theories/NArith/BinNat.v
@@ -830,7 +830,6 @@ Lemma lxor_spec a a' n :
 Proof.
  destruct a, a'; simpl; trivial.
  - now destruct Pos.testbit.
- - now destruct Pos.testbit.
  - apply pos_lxor_spec.
 Qed.
 

--- a/theories/btauto/Algebra.v
+++ b/theories/btauto/Algebra.v
@@ -400,9 +400,7 @@ Lemma poly_mul_mon_compat : forall i p var,
   eval var (poly_mul_mon i p) = (list_nth i var false && eval var p).
 Proof.
 intros i p var; induction p; simpl; case_decide; simpl; try_rewrite; try ring.
-- inversion H; ring.
-- match goal with [ |- ?u = ?t ] => set (x := t); destruct x; reflexivity end.
-- match goal with [ |- ?u = ?t ] => set (x := t); destruct x; reflexivity end.
+inversion H; ring.
 Qed.
 
 Lemma poly_mul_compat : forall pl pr var, eval var (poly_mul pl pr) = andb (eval var pl) (eval var pr).

--- a/theories/btauto/Reflect.v
+++ b/theories/btauto/Reflect.v
@@ -249,9 +249,6 @@ intros k p Hl Hp; induction Hl; simpl.
 - destruct c; [reflexivity|elim Hp; now constructor].
 - case_decide.
   + rewrite eval_null_zero; [|assumption]; rewrite list_replace_nth_2; simpl.
-    match goal with [ |- (if ?b then true else false) = true ] =>
-                      assert (Hrw : b = true); [|rewrite Hrw; reflexivity]
-    end.
     erewrite eval_suffix_compat; [now eauto| |now apply linear_valid_incl; eauto].
     now intros j Hd; apply list_replace_nth_1; lia.
   + rewrite list_replace_nth_2, xorb_false_r.


### PR DESCRIPTION
The old definition was

```coq
Definition xorb b1 b2 :=
   if b1 then ...
   else if b2 then true else false.
```

The last line had some adverse consequences:
- the extracted code was ugly;
- `xorb false b` was not convertible to `b`.

- [X] Added **changelog**.
- [ ] Opened **overlay** pull requests.