### PR TITLE
congruence: avoid dropping evar map after type_and_refresh

### DIFF
--- a/test-suite/bugs/bug_17415.v
+++ b/test-suite/bugs/bug_17415.v
@@ -1,0 +1,10 @@
+Inductive free := Par (A1:Type).
+
+Lemma foo
+  (A0 : Type@{free.u0})
+  A1
+  (H1 : Par A0 = Par A1)
+  : A0 = A1.
+Proof.
+  congruence.
+Qed.


### PR DESCRIPTION
Fix #17415
