### PR TITLE
explain_unification_error: reinfer universe inconsistencies

### DIFF
--- a/kernel/type_errors.ml
+++ b/kernel/type_errors.ml
@@ -45,6 +45,9 @@ type fix_guard_error = constr pfix_guard_error
 type cofix_guard_error = constr pcofix_guard_error
 type guard_error = constr pguard_error
 
+type ('constr, 'types) pcant_apply_bad_type =
+  (int * 'constr * 'constr) * ('constr, 'types) punsafe_judgment * ('constr, 'types) punsafe_judgment array
+
 type ('constr, 'types) ptype_error =
   | UnboundRel of int
   | UnboundVar of variable
@@ -60,8 +63,7 @@ type ('constr, 'types) ptype_error =
   | Generalization of (Name.t * 'types) * ('constr, 'types) punsafe_judgment
   | ActualType of ('constr, 'types) punsafe_judgment * 'types
   | IncorrectPrimitive of (CPrimitives.op_or_type,'types) punsafe_judgment * 'types
-  | CantApplyBadType of
-      (int * 'constr * 'constr) * ('constr, 'types) punsafe_judgment * ('constr, 'types) punsafe_judgment array
+  | CantApplyBadType of ('constr, 'types) pcant_apply_bad_type
   | CantApplyNonFunctional of ('constr, 'types) punsafe_judgment * ('constr, 'types) punsafe_judgment array
   | IllFormedRecBody of 'constr pguard_error * Name.t Context.binder_annot array * int * env * ('constr, 'types) punsafe_judgment array
   | IllTypedRecBody of

--- a/kernel/type_errors.mli
+++ b/kernel/type_errors.mli
@@ -47,6 +47,9 @@ type fix_guard_error = constr pfix_guard_error
 type cofix_guard_error = constr pcofix_guard_error
 type guard_error = constr pguard_error
 
+type ('constr, 'types) pcant_apply_bad_type =
+  (int * 'constr * 'constr) * ('constr, 'types) punsafe_judgment * ('constr, 'types) punsafe_judgment array
+
 type ('constr, 'types) ptype_error =
   | UnboundRel of int
   | UnboundVar of variable
@@ -62,8 +65,7 @@ type ('constr, 'types) ptype_error =
   | Generalization of (Name.t * 'types) * ('constr, 'types) punsafe_judgment
   | ActualType of ('constr, 'types) punsafe_judgment * 'types
   | IncorrectPrimitive of (CPrimitives.op_or_type,'types) punsafe_judgment * 'types
-  | CantApplyBadType of
-      (int * 'constr * 'constr) * ('constr, 'types) punsafe_judgment * ('constr, 'types) punsafe_judgment array
+  | CantApplyBadType of ('constr, 'types) pcant_apply_bad_type
   | CantApplyNonFunctional of ('constr, 'types) punsafe_judgment * ('constr, 'types) punsafe_judgment array
   | IllFormedRecBody of 'constr pguard_error * Name.t Context.binder_annot array * int * env * ('constr, 'types) punsafe_judgment array
   | IllTypedRecBody of

--- a/pretyping/pretype_errors.ml
+++ b/pretyping/pretype_errors.ml
@@ -59,6 +59,7 @@ type pretype_error =
   | UnexpectedType of constr * constr * unification_error
   | NotProduct of constr
   | TypingError of type_error
+  | CantApplyBadTypeExplained of (constr,types) pcant_apply_bad_type * unification_error
   | CannotUnifyOccurrences of subterm_unification_error
   | UnsatisfiableConstraints of
     (Evar.t * Evar_kinds.t) option * Evar.Set.t
@@ -93,10 +94,14 @@ let error_cant_apply_not_functional ?loc env sigma rator randl =
   raise_type_error ?loc
     (env, sigma, CantApplyNonFunctional (rator, randl))
 
-let error_cant_apply_bad_type ?loc env sigma (n,c,t) rator randl =
-  raise_type_error ?loc
-    (env, sigma,
-       CantApplyBadType ((n,c,t), rator, randl))
+let error_cant_apply_bad_type ?loc env sigma ?error (n,c,t) rator randl =
+  let v = ((n,c,t), rator, randl) in
+  match error with
+  | None ->
+    raise_type_error ?loc
+      (env, sigma,
+       CantApplyBadType v)
+  | Some e -> raise_pretype_error ?loc (env,sigma, CantApplyBadTypeExplained (v, e))
 
 let error_ill_formed_branch ?loc env sigma c i actty expty =
   raise_type_error

--- a/pretyping/pretype_errors.mli
+++ b/pretyping/pretype_errors.mli
@@ -65,6 +65,7 @@ type pretype_error =
   | UnexpectedType of constr * constr * unification_error
   | NotProduct of constr
   | TypingError of type_error
+  | CantApplyBadTypeExplained of (constr,types) pcant_apply_bad_type * unification_error
   | CannotUnifyOccurrences of subterm_unification_error
   | UnsatisfiableConstraints of
     (Evar.t * Evar_kinds.t) option * Evar.Set.t
@@ -88,8 +89,9 @@ val error_cant_apply_not_functional :
       unsafe_judgment -> unsafe_judgment array -> 'b
 
 val error_cant_apply_bad_type :
-  ?loc:Loc.t -> env -> Evd.evar_map -> int * constr * constr ->
-      unsafe_judgment -> unsafe_judgment array -> 'b
+  ?loc:Loc.t -> env -> Evd.evar_map -> ?error:unification_error ->
+  int * constr * constr ->
+  unsafe_judgment -> unsafe_judgment array -> 'b
 
 val error_case_not_inductive :
   ?loc:Loc.t -> env -> Evd.evar_map -> unsafe_judgment -> 'b

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -100,8 +100,8 @@ let judge_of_apply env sigma funj argjv =
     match Evarconv.unify_leq_delay env sigma hj.uj_type c1 with
     | sigma ->
       apply_rec sigma (n+1) subs c2 restjl
-    | exception Evarconv.UnableToUnify _ ->
-      error_cant_apply_bad_type env sigma (n, c1, hj.uj_type) funj argjv
+    | exception Evarconv.UnableToUnify (sigma,error) ->
+      error_cant_apply_bad_type env sigma ~error (n, c1, hj.uj_type) funj argjv
   in
   apply_rec sigma 1 (Esubst.subs_id 0) funj.uj_type (Array.to_list argjv)
 
@@ -607,15 +607,15 @@ let judge_of_apply_against env sigma changedf funj argjv =
         match Evarconv.unify_leq_delay env sigma hj.uj_type c1 with
         | sigma ->
           apply_rec sigma (Changed {bodyonly=lazy false}) (n+1) subs c2 restjl
-        | exception Evarconv.UnableToUnify _ ->
-          error_cant_apply_bad_type env sigma (n, c1, hj.uj_type) funj (Array.map snd argjv)
+        | exception Evarconv.UnableToUnify (sigma,error) ->
+          error_cant_apply_bad_type env sigma ~error (n, c1, hj.uj_type) funj (Array.map snd argjv)
     end
     else
       match Evarconv.unify_leq_delay env sigma hj.uj_type c1 with
       | sigma ->
         apply_rec sigma changedf (n+1) subs c2 restjl
-      | exception Evarconv.UnableToUnify _ ->
-        error_cant_apply_bad_type env sigma (n, c1, hj.uj_type) funj (Array.map snd argjv)
+      | exception Evarconv.UnableToUnify (sigma,error) ->
+        error_cant_apply_bad_type env sigma ~error (n, c1, hj.uj_type) funj (Array.map snd argjv)
   in
   apply_rec sigma changedf 1 (Esubst.subs_id 0) funj.uj_type (Array.to_list argjv)
 

--- a/test-suite/output/CantApplyBadType.out
+++ b/test-suite/output/CantApplyBadType.out
@@ -4,15 +4,23 @@ The term "Type" has type "Type@{u+1}" while it is expected to have type
  "Type@{u1}" (universe inconsistency: Cannot enforce u < u1 because u1 <= u).
 File "./output/CantApplyBadType.v", line 15, characters 0-58:
 The command has indeed failed with message:
-Illegal application: 
+Illegal application:
 The term "idu1" of type "Type -> Type"
 cannot be applied to the term
  "Type" : "Type"
 This term has type "Type@{u+1}" which should be a subtype of 
-"Type@{u1}".
-File "./output/CantApplyBadType.v", line 27, characters 2-108:
+"Type@{u1}". (Cannot enforce u < u1 because u1 <= u)
+File "./output/CantApplyBadType.v", line 26, characters 0-54:
 The command has indeed failed with message:
-Illegal application: 
+Illegal application:
+The term "idu1" of type "Type -> Type"
+cannot be applied to the term
+ "Type" : "Type"
+This term has type "Type@{CantApplyBadType.8+1}" which should be a subtype of
+ "Type@{u1}". (missing universe constraints: CantApplyBadType.8 < u1)
+File "./output/CantApplyBadType.v", line 30, characters 2-108:
+The command has indeed failed with message:
+Illegal application:
 The term "idu1" of type "Type -> Type"
 cannot be applied to the term
  "Type" : "Type"

--- a/test-suite/output/CantApplyBadType.out
+++ b/test-suite/output/CantApplyBadType.out
@@ -17,4 +17,4 @@ The term "idu1" of type "Type -> Type"
 cannot be applied to the term
  "Type" : "Type"
 This term has type "Type@{u+1}" which should be a subtype of 
-"Type@{u1}".
+"Type@{u1}". (universe inconsistency: Cannot enforce u < u1 because u1 <= u)

--- a/test-suite/output/CantApplyBadType.out
+++ b/test-suite/output/CantApplyBadType.out
@@ -1,0 +1,20 @@
+File "./output/CantApplyBadType.v", line 8, characters 16-24:
+The command has indeed failed with message:
+The term "Type" has type "Type@{u+1}" while it is expected to have type
+ "Type@{u1}" (universe inconsistency: Cannot enforce u < u1 because u1 <= u).
+File "./output/CantApplyBadType.v", line 15, characters 0-58:
+The command has indeed failed with message:
+Illegal application: 
+The term "idu1" of type "Type -> Type"
+cannot be applied to the term
+ "Type" : "Type"
+This term has type "Type@{u+1}" which should be a subtype of 
+"Type@{u1}".
+File "./output/CantApplyBadType.v", line 27, characters 2-108:
+The command has indeed failed with message:
+Illegal application: 
+The term "idu1" of type "Type -> Type"
+cannot be applied to the term
+ "Type" : "Type"
+This term has type "Type@{u+1}" which should be a subtype of 
+"Type@{u1}".

--- a/test-suite/output/CantApplyBadType.v
+++ b/test-suite/output/CantApplyBadType.v
@@ -1,0 +1,31 @@
+Universes u0 u1.
+Constraint u1 <= u0.
+Axiom idu1 : Type@{u1} -> Type@{u1}.
+Universe u.
+Constraint u = u0.
+
+(* pretyping error *)
+Fail Check idu1 Type@{u}.
+(* The command has indeed failed with message:
+The term "Type" has type "Type@{u+1}" while it is expected to have type
+"Type@{u1}" (universe inconsistency: Cannot enforce u < u1 because u1 <= u0 = u).
+ *)
+
+(* kernel error *)
+Fail Type ltac:(refine (idu1 _); exact_no_check Type@{u}).
+(* The command has indeed failed with message:
+Illegal application:
+The term "idu1" of type "Type -> Type"
+cannot be applied to the term
+ "Type" : "Type"
+This term has type "Type@{u+1}" which should be coercible to
+"Type@{u1}".
+*)
+
+(* typing.ml error *)
+Goal True.
+  Fail let c := constr:(ltac:(refine (idu1 _); exact_no_check Type@{u})) in
+  let _ := type of c in
+  idtac.
+  (* same as kernel *)
+Abort.

--- a/test-suite/output/CantApplyBadType.v
+++ b/test-suite/output/CantApplyBadType.v
@@ -11,7 +11,7 @@ The term "Type" has type "Type@{u+1}" while it is expected to have type
 "Type@{u1}" (universe inconsistency: Cannot enforce u < u1 because u1 <= u0 = u).
  *)
 
-(* kernel error *)
+(* kernel error because of impossible constraints *)
 Fail Type ltac:(refine (idu1 _); exact_no_check Type@{u}).
 (* The command has indeed failed with message:
 Illegal application:
@@ -21,6 +21,9 @@ cannot be applied to the term
 This term has type "Type@{u+1}" which should be coercible to
 "Type@{u1}".
 *)
+
+(* kernel error because of missing constraints *)
+Fail Type ltac:(refine (idu1 _); exact_no_check Type).
 
 (* typing.ml error *)
 Goal True.

--- a/test-suite/output/Errors.out
+++ b/test-suite/output/Errors.out
@@ -30,11 +30,11 @@ The first term has type "nat" while the second term has incompatible type
 "bool".
 File "./output/Errors.v", line 49, characters 2-25:
 The command has indeed failed with message:
-Replacement would lead to an ill-typed term: Illegal application: 
+Replacement would lead to an ill-typed term: Illegal application:
 The term "@eq" of type "forall A : Type, A -> A -> Prop"
 cannot be applied to the terms
  "Set" : "Type"
  "n" : "Type"
  "n" : "Type"
-The 2nd term has type "Type" which should be coercible to 
-"Set".
+The 2nd term has type "Type" which should be a subtype of 
+"Set". (universe inconsistency: Cannot enforce Errors.28 <= Set)

--- a/test-suite/output/bug_13266.out
+++ b/test-suite/output/bug_13266.out
@@ -3,11 +3,11 @@ The command has indeed failed with message:
 Abstracting over the terms "S", "p" and "u" leads to a term
 fun (S0 : Type) (p0 : proc S0) (_ : S0) => p0 = Tick -> True
 which is ill-typed.
-Reason is: Illegal application: 
+Reason is: Illegal application:
 The term "@eq" of type "forall A : Type, A -> A -> Prop"
 cannot be applied to the terms
  "proc S0" : "Prop"
  "p0" : "proc S0"
  "Tick" : "proc unit"
-The 3rd term has type "proc unit" which should be coercible to 
+The 3rd term has type "proc unit" which should be a subtype of 
 "proc S0".

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -429,7 +429,7 @@ let explain_cant_apply_bad_type env sigma (n,exptyp,actualtyp) rator randl =
   str "cannot be applied to the " ++ term_string1 ++ fnl () ++
   str " " ++ v 0 appl ++ fnl () ++ term_string2 ++ str " has type" ++
   brk(1,1) ++ actualtyp ++ spc () ++
-  str "which should be coercible to" ++ brk(1,1) ++
+  str "which should be a subtype of" ++ brk(1,1) ++
   exptyp ++ str "."
 
 let explain_cant_apply_not_functional env sigma rator randl =

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -406,10 +406,11 @@ let explain_incorrect_primitive env sigma j exp =
   str "has type" ++ brk(1,1) ++ pct ++ spc () ++
   str "while it is expected to have type" ++ brk(1,1) ++ pt ++ str ".")
 
-let explain_cant_apply_bad_type env sigma (n,exptyp,actualtyp) rator randl =
+let explain_cant_apply_bad_type env sigma ?error (n,exptyp,actualtyp) rator randl =
   let randl = jv_nf_betaiotaevar env sigma randl in
   let actualtyp = Reductionops.nf_betaiota env sigma actualtyp in
   let env = make_all_name_different env sigma in
+  let error = explain_unification_error env sigma actualtyp exptyp error in
   let actualtyp, exptyp = pr_explicit env sigma actualtyp exptyp in
   let nargs = Array.length randl in
 (*  let pe = pr_ne_context_of (str "in environment") env sigma in*)
@@ -430,7 +431,7 @@ let explain_cant_apply_bad_type env sigma (n,exptyp,actualtyp) rator randl =
   str " " ++ v 0 appl ++ fnl () ++ term_string2 ++ str " has type" ++
   brk(1,1) ++ actualtyp ++ spc () ++
   str "which should be a subtype of" ++ brk(1,1) ++
-  exptyp ++ str "."
+  exptyp ++ str "." ++ error
 
 let explain_cant_apply_not_functional env sigma rator randl =
   let env = make_all_name_different env sigma in
@@ -965,6 +966,8 @@ let rec explain_pretype_error env sigma err =
   | AbstractionOverMeta (m,n) -> explain_abstraction_over_meta env m n
   | NonLinearUnification (m,c) -> explain_non_linear_unification env sigma m c
   | TypingError t -> explain_type_error env sigma t
+  | CantApplyBadTypeExplained ((t, rator, randl),error) ->
+    explain_cant_apply_bad_type env sigma ~error t rator randl
   | CannotUnifyOccurrences (b,c1,c2,e) -> explain_cannot_unify_occurrences env sigma b c1 c2 e
   | UnsatisfiableConstraints (c,comp) -> explain_unsatisfiable_constraints env sigma c comp
   | DisallowedSProp -> explain_disallowed_sprop ()


### PR DESCRIPTION
and missing constraints.

We also make cant_explain_bad_type from typing.ml carry the unification error.

Fix #17420

I'm a bit worried about perf for this.
The bench probably wouldn't tell us since this is about failures.
