### PR TITLE
Allow coq-core and coqide-server to be compiled in bytecode-only mode

### DIFF
--- a/ide/coqide/dune
+++ b/ide/coqide/dune
@@ -14,7 +14,7 @@
  (package coqide-server)
  (modules idetop)
  (libraries coq-core.toplevel coqide-server.protocol platform_specific)
- (modes native byte)
+ (modes exe byte)
  (link_flags -linkall))
 
 (install

--- a/topbin/dune
+++ b/topbin/dune
@@ -24,7 +24,7 @@
  (package coq-core)
  (modules coqc_bin)
  (libraries coq-core.toplevel findlib.dynload)
- (modes native byte))
+ (modes exe byte))
  ; Adding -ccopt -flto to links options could be interesting, however,
  ; it doesn't work on Windows
 
@@ -39,7 +39,7 @@
  (package coq-core)
  (modules coqnative_bin)
  (libraries coq-core.kernel)
- (modes native byte)
+ (modes exe byte)
  (link_flags -linkall))
 
 ; Workers


### PR DESCRIPTION
e.g. ppc64, x86_32, arm32 or s390x on OCaml 5.0

See https://github.com/ocaml/opam-repository/pull/23584#discussion_r1150586561