### PR TITLE
Avoid using Evd.empty in a few places

### DIFF
--- a/dev/ci/user-overlays/17436-SkySkimmer-rtauto-evd-empty.sh
+++ b/dev/ci/user-overlays/17436-SkySkimmer-rtauto-evd-empty.sh
@@ -1,0 +1,1 @@
+overlay equations https://github.com/SkySkimmer/Coq-Equations rtauto-evd-empty 17436

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1955,8 +1955,9 @@ let find_arguments_scope r =
       scl'
   with Not_found -> []
 
-let declare_ref_arguments_scope sigma ref =
+let declare_ref_arguments_scope ref =
   let env = Global.env () in (* FIXME? *)
+  let sigma = Evd.from_env env in
   let typ = EConstr.of_constr @@ fst @@ Typeops.type_of_global_in_context env ref in
   let (scs,cls as o) = compute_arguments_scope_full env sigma typ in
   declare_arguments_scope_gen ArgsScopeAuto ref (List.length scs) o

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -306,7 +306,7 @@ val subst_scope_class :
 type add_scope_where = AddScopeTop | AddScopeBottom
 (** add new scope at top or bottom of existing stack (default is reset) *)
 val declare_scope_class : scope_name -> ?where:add_scope_where -> scope_class -> unit
-val declare_ref_arguments_scope : Evd.evar_map -> GlobRef.t -> unit
+val declare_ref_arguments_scope : GlobRef.t -> unit
 
 val compute_arguments_scope : Environ.env -> Evd.evar_map -> EConstr.types -> scope_name list list
 val compute_type_scope : Environ.env -> Evd.evar_map -> EConstr.types -> scope_name list

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -1813,7 +1813,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
             (TacLetTac(ev,na,c,clp,b,eqpat))
             (Tacticals.tclWITHHOLES ev
                (let_pat_tac b (interp_name ist env sigma na)
-                  (sigma,c) clp eqpat) sigma')
+                  (Some sigma,c) clp eqpat) sigma')
       end
 
   (* Derived basic tactics *)

--- a/plugins/ltac2/tac2stdlib.ml
+++ b/plugins/ltac2/tac2stdlib.ml
@@ -279,7 +279,7 @@ end
 let () = define_prim3 "tac_set" bool (thunk (pair name constr)) clause begin fun ev p cl ->
   Proofview.tclEVARMAP >>= fun sigma ->
   thaw (pair name constr) p >>= fun (na, c) ->
-  Tac2tactics.letin_pat_tac ev None na (sigma, c) cl
+  Tac2tactics.letin_pat_tac ev None na (Some sigma, c) cl
 end
 
 let () = define_prim5 "tac_remember" bool name (thunk constr) (option intro_pattern) clause begin fun ev na c eqpat cl ->
@@ -288,7 +288,7 @@ let () = define_prim5 "tac_remember" bool name (thunk constr) (option intro_patt
   | IntroNaming eqpat ->
     Proofview.tclEVARMAP >>= fun sigma ->
     thaw constr c >>= fun c ->
-    Tac2tactics.letin_pat_tac ev (Some (true, eqpat)) na (sigma, c) cl
+    Tac2tactics.letin_pat_tac ev (Some (true, eqpat)) na (Some sigma, c) cl
   | _ ->
     Tacticals.tclZEROMSG (Pp.str "Invalid pattern for remember")
 end

--- a/plugins/ltac2/tac2tactics.ml
+++ b/plugins/ltac2/tac2tactics.ml
@@ -343,7 +343,7 @@ let on_destruction_arg tac ev arg =
       let lbind = mk_bindings lbind in
       Proofview.tclEVARMAP >>= fun sigma' ->
       let flags = tactic_infer_flags ev in
-      let (sigma', c) = Tactics.finish_evar_resolution ~flags env sigma' (sigma, c) in
+      let (sigma', c) = Tactics.finish_evar_resolution ~flags env sigma' (Some sigma, c) in
       Proofview.tclUNIT (Some sigma', Tactics.ElimOnConstr (c, lbind))
     | ElimOnIdent id -> Proofview.tclUNIT (None, Tactics.ElimOnIdent CAst.(make id))
     | ElimOnAnonHyp n -> Proofview.tclUNIT (None, Tactics.ElimOnAnonHyp n)

--- a/plugins/ltac2/tac2tactics.mli
+++ b/plugins/ltac2/tac2tactics.mli
@@ -54,7 +54,7 @@ val forward : bool -> unit tactic option option ->
 val assert_ : assertion -> unit tactic
 
 val letin_pat_tac : evars_flag -> (bool * intro_pattern_naming) option ->
-  Name.t -> (Evd.evar_map * constr) -> clause -> unit tactic
+  Name.t -> (Evd.evar_map option * constr) -> clause -> unit tactic
 
 val reduce : Redexpr.red_expr -> clause -> unit tactic
 

--- a/plugins/rtauto/refl_tauto.ml
+++ b/plugins/rtauto/refl_tauto.ml
@@ -159,7 +159,7 @@ let rec make_hyps env sigma atom_env lenv = function
   | LocalAssum (id,typ)::rest ->
     let hrec=
       make_hyps env sigma atom_env (typ::lenv) rest in
-    if List.exists (fun c -> Termops.local_occur_var Evd.empty (* FIXME *) id.binder_name c) lenv ||
+    if List.exists (fun c -> Termops.local_occur_var sigma id.binder_name c) lenv ||
        (Retyping.get_sort_family_of env sigma typ != InProp)
     then
       hrec

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1661,11 +1661,11 @@ exception PatternNotFound
 let make_pattern_test from_prefix_of_ind is_correct_type env sigma (pending,c) =
   let flags =
     if from_prefix_of_ind then
-      let flags = default_matching_flags pending in
+      let flags = default_matching_flags (Option.default Evd.empty pending) in
       { flags with core_unify_flags = { flags.core_unify_flags with
         modulo_conv_on_closed_terms = Some TransparentState.full;
         restrict_conv_on_strict_subterms = true } }
-    else default_matching_flags pending in
+    else default_matching_flags (Option.default Evd.empty pending) in
   let n = Array.length (snd (decompose_app_vect sigma c)) in
   let cgnd = if occur_meta_or_undefined_evar sigma c then NotGround else Ground in
   let matching_fun _ t =
@@ -1792,7 +1792,7 @@ let make_abstraction_core name (test,out) env sigma c ty occs check_occs concl =
 type prefix_of_inductive_support_flag = bool
 
 type abstraction_request =
-| AbstractPattern of prefix_of_inductive_support_flag * (types -> bool) * Name.t * (evar_map * constr) * clause * bool
+| AbstractPattern of prefix_of_inductive_support_flag * (types -> bool) * Name.t * (evar_map option * constr) * clause * bool
 | AbstractExact of Name.t * constr * types option * clause * bool
 
 type 'r abstraction_result =

--- a/pretyping/unification.mli
+++ b/pretyping/unification.mli
@@ -74,7 +74,7 @@ exception PatternNotFound
 type prefix_of_inductive_support_flag = bool
 
 type abstraction_request =
-| AbstractPattern of prefix_of_inductive_support_flag * (types -> bool) * Names.Name.t * (evar_map * constr) * Locus.clause * bool
+| AbstractPattern of prefix_of_inductive_support_flag * (types -> bool) * Names.Name.t * (evar_map option * constr) * Locus.clause * bool
 | AbstractExact of Names.Name.t * constr * types option * Locus.clause * bool
 
 type 'r abstraction_result =

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -113,7 +113,7 @@ val force_destruction_arg : evars_flag -> env -> evar_map ->
     evar_map * constr with_bindings destruction_arg
 
 val finish_evar_resolution : ?flags:Pretyping.inference_flags ->
-  env -> evar_map -> (evar_map * constr) -> evar_map * constr
+  env -> evar_map -> (evar_map option * constr) -> evar_map * constr
 
 (** Tell if a used hypothesis should be cleared by default or not *)
 
@@ -386,7 +386,7 @@ val letin_tac : (bool * intro_pattern_naming) option ->
 (** Common entry point for user-level "set", "pose" and "remember" *)
 
 val letin_pat_tac : evars_flag -> (bool * intro_pattern_naming) option ->
-  Name.t -> (evar_map * constr) -> clause -> unit Proofview.tactic
+  Name.t -> (evar_map option * constr) -> clause -> unit Proofview.tactic
 
 (** {6 Generalize tactics. } *)
 

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -217,7 +217,7 @@ let inConstant v = Libobject.Dyn.Easy.inj v objConstant
 
 let update_tables c =
   Impargs.declare_constant_implicits c;
-  Notation.declare_ref_arguments_scope Evd.empty (GlobRef.ConstRef c)
+  Notation.declare_ref_arguments_scope (GlobRef.ConstRef c)
 
 let register_constant kn kind local =
   let id = Label.to_id (Constant.label kn) in
@@ -522,7 +522,7 @@ let declare_variable_core ~name ~kind d =
   Decls.(add_variable_data name {opaque;kind});
   Lib.add_leaf (inVariable name);
   Impargs.declare_var_implicits ~impl name;
-  Notation.declare_ref_arguments_scope Evd.empty (GlobRef.VarRef name)
+  Notation.declare_ref_arguments_scope (GlobRef.VarRef name)
 
 let declare_variable ~name ~kind ~typ ~impl ~univs =
   declare_variable_core ~name ~kind (SectionLocalAssum { typ; impl; univs })

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1200,9 +1200,8 @@ let compute_possible_guardness_evidences n fixbody fixtype =
          but doing it properly involves delta-reduction, and it finally
          doesn't seem to worth the effort (except for huge mutual
          fixpoints ?) *)
-    let m = Termops.nb_prod Evd.empty (EConstr.of_constr fixtype) (* FIXME *) in
-    let ctx = fst (Term.decompose_prod_n_decls m fixtype) in
-    List.map_i (fun i _ -> i) 0 ctx
+    let ctx, _ = Term.decompose_prod fixtype in
+    List.mapi (fun i _ -> i) ctx
 
 let declare_mutual_definition ~pm l =
   let len = List.length l in

--- a/vernac/declareInd.ml
+++ b/vernac/declareInd.ml
@@ -14,9 +14,9 @@ open Entries
 (** Declaration of inductive blocks *)
 let declare_inductive_argument_scopes kn mie =
   List.iteri (fun i {mind_entry_consnames=lc} ->
-    Notation.declare_ref_arguments_scope Evd.empty (GlobRef.IndRef (kn,i));
+    Notation.declare_ref_arguments_scope (GlobRef.IndRef (kn,i));
     for j=1 to List.length lc do
-      Notation.declare_ref_arguments_scope Evd.empty (GlobRef.ConstructRef ((kn,i),j));
+      Notation.declare_ref_arguments_scope (GlobRef.ConstructRef ((kn,i),j));
     done) mie.mind_entry_inds
 
 type inductive_obj = {

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1503,9 +1503,9 @@ let rec vernac_interp_error_handler = function
   | UGraph.UniverseInconsistency i ->
     str "Universe inconsistency." ++ spc() ++
     UGraph.explain_universe_inconsistency UnivNames.pr_with_global_universes i ++ str "."
-  | TypeError(ctx,te) ->
+  | TypeError(env,te) ->
     let te = map_ptype_error EConstr.of_constr te in
-    explain_type_error ctx Evd.empty te
+    explain_type_error env (Evd.from_env env) te
   | PretypeError(ctx,sigma,te) ->
     explain_pretype_error ctx sigma te
   | Notation.PrimTokenNotationError(kind,ctx,sigma,te) ->

--- a/vernac/recLemmas.ml
+++ b/vernac/recLemmas.ml
@@ -34,7 +34,7 @@ let find_mutually_recursive_statements sigma thms =
               []) 0 (List.rev (List.filter Context.Rel.Declaration.is_local_assum whnf_hyp_hds))) in
       let ind_ccl =
         let cclenv = EConstr.push_rel_context hyps (Global.env()) in
-        let whnf_ccl,_ = Reductionops.whd_all_stack cclenv Evd.empty ccl in
+        let whnf_ccl,_ = Reductionops.whd_all_stack cclenv sigma ccl in
         match EConstr.kind sigma whnf_ccl with
         | Ind ((kn,_ as ind),u) when
               let mind = Global.lookup_mind kn in


### PR DESCRIPTION
The rtauto change fixes the geocoq error (uncaught Not_found hidden by `try`) in https://github.com/coq/coq/pull/17346
Not sure if it's possible to get the error without that change, the geocoq code is fairly big so I'm not minimizing.

Overlays:
- https://github.com/mattam82/Coq-Equations/pull/543