### PR TITLE
Bench: use --no-print-directory

### DIFF
--- a/dev/bench/bench.sh
+++ b/dev/bench/bench.sh
@@ -34,9 +34,9 @@ number_of_processors=$(cat /proc/cpuinfo | grep '^processor *' | wc -l)
 
 program_name="$0"
 program_path=$(readlink -f "${program_name%/*}")
-render_results="dune exec --root $program_path/../.. -- dev/bench/render_results.exe"
-render_line_results="dune exec --root $program_path/../.. -- dev/bench/render_line_results.exe"
-timelog2html="dune exec --root $program_path/../.. -- dev/bench/timelog2html.exe"
+render_results="dune exec --no-print-directory --root $program_path/../.. -- dev/bench/render_results.exe"
+render_line_results="dune exec --no-print-directory --root $program_path/../.. -- dev/bench/render_line_results.exe"
+timelog2html="dune exec --no-print-directory --root $program_path/../.. -- dev/bench/timelog2html.exe"
 
 coqbot_url_prefix="https://coqbot.herokuapp.com/pendulum/"
 


### PR DESCRIPTION
It gets really spammy with all the invocations of timelog2html, and the output is not useful for anything AFAICT.
