### PR TITLE
Clean the internals of the Indrec modules

### DIFF
--- a/pretyping/indrec.ml
+++ b/pretyping/indrec.ml
@@ -56,8 +56,11 @@ let mkProd_name env (n,a,b) = mkProd_or_LetIn_name env (LocalAssum (n,a)) b
 
 let set_names env_for_named_hd env_for_next_ident_away l =
   let ids = Id.Set.of_list (Termops.ids_of_rel_context (rel_context env_for_next_ident_away)) in
-  snd (List.fold_right (fun d (ids,l) ->
-      let id = ident_hd env_for_named_hd ids (get_type d) (get_name d) in (Id.Set.add id ids, set_name (Name id) d :: l)) l (ids,[]))
+  let fold d (ids, l) =
+    let id = ident_hd env_for_named_hd ids (get_type d) (get_name d) in
+    (Id.Set.add id ids, set_name (Name id) d :: l)
+  in
+  snd (List.fold_right fold l (ids,[]))
 let it_mkLambda_or_LetIn_name env b l = it_mkLambda_or_LetIn b (set_names env env l)
 let it_mkProd_or_LetIn_name env b l = it_mkProd_or_LetIn b (set_names env env l)
 

--- a/pretyping/indrec.ml
+++ b/pretyping/indrec.ml
@@ -106,6 +106,16 @@ let eval_case_analysis case =
   let cT = it_mkProd_or_LetIn bodyT case.case_params in
   (c, cT)
 
+(* [p] is the predicate and [cs] a constructor summary *)
+let build_branch_type env sigma dep p cs =
+  let base = appvect (lift cs.cs_nargs p, cs.cs_concl_realargs) in
+  if dep then
+    EConstr.Unsafe.to_constr (Namegen.it_mkProd_or_LetIn_name env sigma
+      (EConstr.of_constr (applist (base,[build_dependent_constructor cs])))
+      (List.map (fun d -> Termops.map_rel_decl EConstr.of_constr d) cs.cs_args))
+  else
+    Term.it_mkProd_or_LetIn base cs.cs_args
+
 let mis_make_case_com dep env sigma (ind, u as pind) (mib,mip as specif) kind =
   let lnamespar = Vars.subst_instance_context u mib.mind_params_ctxt in
   let indf = make_ind_family(pind, Context.Rel.instance_list mkRel 0 lnamespar) in

--- a/pretyping/indrec.ml
+++ b/pretyping/indrec.ml
@@ -182,8 +182,11 @@ let mis_make_case_com dep env sigma (ind, u as pind) (mib,mip as specif) kind =
       match projs with
       | None ->
         let pms = Context.Rel.instance mkRel (ndepar + nbprod) lnamespar in
-        let iv = make_case_invert env (find_rectype env sigma (EConstr.of_constr (lift 1 depind))) ci in
-        let iv = EConstr.Unsafe.to_case_invert iv in
+        let iv =
+          if Typeops.should_invert_case env ci then
+            CaseInvert { indices = Context.Rel.instance mkRel 1 arsign }
+          else NoInvert
+        in
         let ncons = Array.length mip.mind_consnames in
         let mk_branch i =
           (* we need that to get the generated names for the branch *)

--- a/pretyping/indrec.ml
+++ b/pretyping/indrec.ml
@@ -173,10 +173,11 @@ let mis_make_case_com dep env sigma (ind, u as pind) (mib,mip as specif) kind =
         (mkRel (ndepar + nbprod),
           if dep then Context.Rel.instance mkRel 0 deparsign
           else Context.Rel.instance mkRel 1 arsign) in
-    let pself = LocalAssum (make_annot Anonymous r, depind) in
-    (* FIXME: the environment for pself is clearly wrong *)
-    let pctx = (if dep then name_assumption env pself else pself) :: set_names env env arsign in
     let deparsign = set_names env env deparsign in
+    let pctx =
+      if dep then deparsign
+      else LocalAssum (make_annot Anonymous r, depind) :: List.tl deparsign
+    in
     let sigma, obj, objT =
       match projs with
       | None ->

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -474,16 +474,6 @@ let make_arity env sigma dep indf s =
   let open EConstr in
   it_mkProd_or_LetIn (mkSort s) (make_arity_signature env sigma dep indf)
 
-(* [p] is the predicate and [cs] a constructor summary *)
-let build_branch_type env sigma dep p cs =
-  let base = appvect (lift cs.cs_nargs p, cs.cs_concl_realargs) in
-  if dep then
-    EConstr.Unsafe.to_constr (Namegen.it_mkProd_or_LetIn_name env sigma
-      (EConstr.of_constr (applist (base,[build_dependent_constructor cs])))
-      (List.map (fun d -> Termops.map_rel_decl EConstr.of_constr d) cs.cs_args))
-  else
-    Term.it_mkProd_or_LetIn base cs.cs_args
-
 (**************************************************)
 
 (** From a rel context describing the constructor arguments,

--- a/pretyping/inductiveops.mli
+++ b/pretyping/inductiveops.mli
@@ -182,7 +182,6 @@ val build_dependent_constructor : constructor_summary -> constr
 val build_dependent_inductive   : env -> inductive_family -> constr
 val make_arity_signature : env -> evar_map -> bool -> inductive_family -> EConstr.rel_context
 val make_arity : env -> evar_map -> bool -> inductive_family -> EConstr.ESorts.t -> EConstr.types
-val build_branch_type : env -> evar_map -> bool -> constr -> constructor_summary -> types
 
 (** Raise [Not_found] if not given a valid inductive type *)
 val extract_mrectype : evar_map -> EConstr.t -> (inductive * EConstr.EInstance.t) * EConstr.constr list


### PR DESCRIPTION
Several cleanups in the case-generating function in Indrec:
- we stop relying on case expansion
- we fix a few obvious bugs in the code
- some performance improvement like keeping a list of avoided variables for name generation