### PR TITLE
Ltac depends on vernac not stm

### DIFF
--- a/plugins/ltac/dune
+++ b/plugins/ltac/dune
@@ -3,7 +3,7 @@
  (public_name coq-core.plugins.ltac)
  (synopsis "Coq's LTAC tactic language")
  (modules :standard \ tauto)
- (libraries coq-core.stm))
+ (libraries coq-core.vernac))
 
 (library
  (name tauto_plugin)


### PR DESCRIPTION
At some point it used to depend on something from STM but I guess that changed.

Overlays:
- https://github.com/coq-tactician/coq-tactician/pull/61 (backwards compatible)
