### PR TITLE
Enforce that Clenv.case_pf takes a case eliminator by typing

### DIFF
--- a/dev/ci/user-overlays/17458-ppedrot-case-pf-ensure-shape.sh
+++ b/dev/ci/user-overlays/17458-ppedrot-case-pf-ensure-shape.sh
@@ -1,0 +1,1 @@
+overlay coq_dpdgraph https://github.com/ppedrot/coq-dpdgraph case-pf-ensure-shape 17458

--- a/proofs/clenv.mli
+++ b/proofs/clenv.mli
@@ -83,7 +83,9 @@ val clenv_push_prod : clausenv -> (metavariable * bool * clausenv) option
 
 val unify : ?flags:unify_flags -> constr -> unit Proofview.tactic
 val res_pf : ?with_evars:bool -> ?with_classes:bool -> ?flags:unify_flags -> clausenv -> unit Proofview.tactic
-val case_pf : ?with_evars:bool -> ?with_classes:bool -> ?flags:unify_flags -> clausenv -> unit Proofview.tactic
+val case_pf : ?with_evars:bool -> ?with_classes:bool ->
+  ?submetas:(metavariable * clbinding) list ->
+  Indrec.case_analysis -> (constr * types) -> unit Proofview.tactic
 
 val clenv_pose_dependent_evars : ?with_evars:bool -> clausenv -> clausenv
 

--- a/tactics/elim.ml
+++ b/tactics/elim.ml
@@ -19,7 +19,7 @@ open Tacticals
 open Clenv
 open Tactics
 
-type elim_kind = Case of bool * constr option | Elim
+type elim_kind = Case of bool | Elim
 
 (* Find the right elimination suffix corresponding to the sort of the goal *)
 (* c should be of type A1->.. An->B with B an inductive definition *)
@@ -30,7 +30,7 @@ let general_elim_using mk_elim (ind, u, args) id =
     let sort = Retyping.get_sort_family_of env sigma (Proofview.Goal.concl gl) in
     let flags = Unification.elim_flags () in
     match mk_elim with
-    | Case (dep, pred) ->
+    | Case dep ->
       let u_ = EInstance.kind sigma u in
       let (sigma, c) = Indrec.build_case_analysis_scheme env sigma (ind, u_) dep sort in
       let elim, elimt = Indrec.eval_case_analysis c in
@@ -38,13 +38,6 @@ let general_elim_using mk_elim (ind, u, args) id =
       let elimclause = mk_clenv_from env sigma (elim, elimt) in
       let indmv = List.last (clenv_arguments elimclause) in
       let elimclause = clenv_instantiate indmv elimclause (mkVar id, mkApp (mkIndU (ind, u), args)) in
-      let elimclause = match pred with
-      | None -> elimclause
-      | Some p ->
-        (* Option.get is statically ensured to succeed *)
-        let pmv = Option.get (Clenv.clenv_type_head_meta elimclause) in
-        clenv_unify ~flags Reduction.CONV (mkMeta pmv) p elimclause
-      in
       Clenv.case_pf ~flags elimclause
     | Elim ->
       let gr = Indrec.lookup_eliminator env ind sort in
@@ -68,7 +61,7 @@ let elim_on_ba tac nassums =
   tac branches
   end
 
-let case_tac dep names tac elim (ind, u, args as spec) c =
+let case_tac dep names tac (ind, u, args as spec) c =
   let open Proofview.Notations in
   Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
@@ -84,7 +77,7 @@ let case_tac dep names tac elim (ind, u, args as spec) c =
       (intro_patterns false l1) <*> (intros_clearing l3) <*> (elim_on_ba (tac l2) n1)
     in
     let branchtacs = List.init (Array.length branchsigns) after_tac in
-    general_elim_using (Case (dep, Some elim)) spec c <*>
+    general_elim_using (Case dep) spec c <*>
     (Proofview.tclEXTEND [] tclIDTAC branchtacs)
   end
 
@@ -116,7 +109,7 @@ let rec general_decompose_aux recognizer id =
   let rec_flag, mkelim =
     match (Environ.lookup_mind (fst ind) env).mind_record with
     | NotRecord -> true, Elim
-    | FakeRecord | PrimRecord _ -> false, Case (true, None)
+    | FakeRecord | PrimRecord _ -> false, Case true
   in
   let branchsigns = Tacticals.compute_constructor_signatures env ~rec_flag (ind, u) in
   let next_tac bas =

--- a/tactics/elim.mli
+++ b/tactics/elim.mli
@@ -16,7 +16,7 @@ open Tactypes
 
 val case_tac : bool -> or_and_intro_pattern option ->
   (intro_patterns -> named_context -> unit Proofview.tactic) ->
-  constr -> inductive * EInstance.t * EConstr.t array -> Id.t -> unit Proofview.tactic
+  inductive * EInstance.t * EConstr.t array -> Id.t -> unit Proofview.tactic
 
 val h_decompose       : inductive list -> constr -> unit Proofview.tactic
 val h_decompose_or    : constr -> unit Proofview.tactic

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1542,12 +1542,6 @@ let index_of_ind_arg sigma t =
       | None -> error CannotFindInductiveArgument
   in aux None 0 t
 
-let rec contract_letin_in_lam_header sigma c =
-  match EConstr.kind sigma c with
-  | Lambda (x,t,c)  -> mkLambda (x,t,contract_letin_in_lam_header sigma c)
-  | LetIn (x,b,t,c) -> contract_letin_in_lam_header sigma (subst1 b c)
-  | _ -> c
-
 (*
  * Elimination tactic with bindings and using an arbitrary
  * elimination constant called elimc. This constant should end
@@ -1574,7 +1568,6 @@ let general_elim_clause0 with_evars flags (submetas, c, ty) elim =
     (elimc, elimt), NoBindings, Some i
   | ElimClause (elimc, lbindelimc) ->
     let elimt = Retyping.get_type_of env sigma elimc in
-    let elimc = contract_letin_in_lam_header sigma elimc in
     (elimc, elimt), lbindelimc, None
   in
   let elimclause = make_clenv_binding env sigma clause bindings in
@@ -4526,7 +4519,6 @@ let induction_tac with_evars params indvars (elim, elimt) =
     let i = index_of_ind_arg sigma elimt in
     (mkConstU c, elimt), NoBindings, Some i
   | ElimClause (elimc, lbindelimc) ->
-    let elimc = contract_letin_in_lam_header sigma elimc in
     (elimc, elimt), lbindelimc, None
   in
   (* elimclause contains this: (elimc ?i ?j ?k...?l) *)

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -3465,6 +3465,13 @@ let safe_dest_intro_patterns with_evars avoid thin dest pat tac =
 
 type elim_arg_kind = RecArg | IndArg | OtherArg
 
+type branch_argument = {
+  ba_kind : elim_arg_kind;
+  ba_assum : bool;
+  ba_dep : bool;
+  ba_name : Id.t;
+}
+
 type recarg_position =
   | AfterFixedPosition of Id.t option (* None = top of context *)
 
@@ -3495,43 +3502,42 @@ let induct_discharge with_evars dests avoid' tac (avoid,ra) names =
   let avoid = Id.Set.union avoid' (Id.Set.union avoid (explicit_intro_names names)) in
   let rec peel_tac ra dests names thin =
     match ra with
-    | (RecArg,_,deprec,recvarname) ::
-        (IndArg,_,depind,hyprecname) :: ra' ->
+    | ({ ba_kind = RecArg } as rarg) :: ({ ba_kind = IndArg } as iarg) :: ra' ->
         Proofview.Goal.enter begin fun gl ->
         let (recpat,names) = match names with
           | [{CAst.loc;v=IntroNaming (IntroIdentifier id)} as pat] ->
               let id' = new_fresh_id avoid (add_prefix "IH" id) gl in
               (pat, [CAst.make @@ IntroNaming (IntroIdentifier id')])
-          | _ -> consume_pattern avoid (Name recvarname) deprec gl names in
+          | _ -> consume_pattern avoid (Name rarg.ba_name) rarg.ba_dep gl names in
         let dest = get_recarg_dest dests in
         dest_intro_patterns with_evars avoid thin dest [recpat] (fun ids thin ->
         Proofview.Goal.enter begin fun gl ->
           let (hyprec,names) =
-            consume_pattern avoid (Name hyprecname) depind gl names
+            consume_pattern avoid (Name iarg.ba_name) iarg.ba_dep gl names
           in
           dest_intro_patterns with_evars avoid thin MoveLast [hyprec] (fun ids' thin ->
             peel_tac ra' (update_dest dests ids') names thin)
                              end)
         end
-    | (IndArg,_,dep,hyprecname) :: ra' ->
+    | ({ ba_kind = IndArg } as iarg) :: ra' ->
         Proofview.Goal.enter begin fun gl ->
         (* Rem: does not happen in Coq schemes, only in user-defined schemes *)
         let pat,names =
-          consume_pattern avoid (Name hyprecname) dep gl names in
+          consume_pattern avoid (Name iarg.ba_name) iarg.ba_dep gl names in
         dest_intro_patterns with_evars avoid thin MoveLast [pat] (fun ids thin ->
         peel_tac ra' (update_dest dests ids) names thin)
         end
-    | (RecArg,_,dep,recvarname) :: ra' ->
+    | ({ ba_kind = RecArg } as rarg) :: ra' ->
         Proofview.Goal.enter begin fun gl ->
         let (pat,names) =
-          consume_pattern avoid (Name recvarname) dep gl names in
+          consume_pattern avoid (Name rarg.ba_name) rarg.ba_dep gl names in
         let dest = get_recarg_dest dests in
         dest_intro_patterns with_evars avoid thin dest [pat] (fun ids thin ->
         peel_tac ra' dests names thin)
         end
-    | (OtherArg,_,dep,_) :: ra' ->
+    | ({ ba_kind = OtherArg } as oarg) :: ra' ->
         Proofview.Goal.enter begin fun gl ->
-        let (pat,names) = consume_pattern avoid Anonymous dep gl names in
+        let (pat,names) = consume_pattern avoid Anonymous oarg.ba_dep gl names in
         let dest = get_recarg_dest dests in
         safe_dest_intro_patterns with_evars avoid thin dest [pat] (fun ids thin ->
         peel_tac ra' dests names thin)
@@ -4370,18 +4376,20 @@ let compute_scheme_signature evd scheme names_info ind_type_guess =
   let rec find_branches p lbrch =
     match lbrch with
       | LocalAssum (_,t) :: brs ->
-        (try
-           let lchck_brch = check_branch p t in
-           let n = List.fold_left
-             (fun n (b,_,_) -> if b == RecArg then n+1 else n) 0 lchck_brch in
-           let recvarname, hyprecname, avoid =
-             make_up_names n scheme.indref names_info in
-           let namesign =
-             List.map (fun (b,is_assum,dep) ->
-               (b,is_assum,dep,if b == IndArg then hyprecname else recvarname))
-               lchck_brch in
-           (avoid,namesign) :: find_branches (p+1) brs
-         with Exit-> error_ind_scheme "the branches of")
+        begin match check_branch p t with
+        | lchck_brch ->
+          let n = List.count (fun (b, _, _) -> b == RecArg) lchck_brch in
+          let recvarname, hyprecname, avoid = make_up_names n scheme.indref names_info in
+          let map (b, is_assum, dep) = {
+            ba_kind = b;
+            ba_assum = is_assum;
+            ba_dep = dep;
+            ba_name = if b == IndArg then hyprecname else recvarname;
+          } in
+          let namesign = List.map map lchck_brch in
+          (avoid, namesign) :: find_branches (p+1) brs
+        | exception Exit -> error_ind_scheme "the branches of"
+        end
       | LocalDef _ :: _ -> error_ind_scheme "the branches of"
       | [] -> check_concl is_pred p; []
   in
@@ -4404,9 +4412,15 @@ let compute_case_signature env evd mind case names_info =
   let find_branches lbrch = match lbrch with
   | LocalAssum (_, t) ->
     let lchck_brch = check_branch t in
-    let n = List.fold_left (fun n (b,_,_) -> if b == RecArg then n+1 else n) 0 lchck_brch in
+    let n = List.count (fun (b, _, _) -> b == RecArg) lchck_brch in
     let recvarname, hyprecname, avoid = make_up_names n (Some indref) names_info in
-    let namesign = List.map (fun (b,is_assum,dep) -> (b,is_assum,dep,recvarname)) lchck_brch in
+    let map (b, is_assum, dep) = {
+      ba_kind = b;
+      ba_assum = is_assum;
+      ba_dep = dep;
+      ba_name = recvarname;
+    } in
+    let namesign = List.map map lchck_brch in
     (avoid, namesign)
   | LocalDef _ -> assert false
   in
@@ -4448,8 +4462,7 @@ let given_elim env sigma hyp0 (elimc,lbind as e) =
   let sigma, elimt = Typing.type_of env sigma elimc in
   sigma, (e, elimt), ind_type_guess
 
-type scheme_signature =
-    (Id.Set.t * (elim_arg_kind * bool * bool * Id.t) list) array
+type scheme_signature = (Id.Set.t * branch_argument list) array
 
 type eliminator_source =
   | CaseOver of Id.t * (inductive * EInstance.t)
@@ -4592,7 +4605,7 @@ let apply_induction_in_context with_evars inhyps elim indvars names =
       sigma, (* bugged, should be computed *) true, tac, indsign
     in
     let branchletsigns =
-      let f (_,is_not_let,_,_) = is_not_let in
+      let f ba = ba.ba_assum in
       Array.map (fun (_,l) -> List.map f l) indsign in
     let names = compute_induction_names true branchletsigns names in
     let () = Array.iter (check_name_unicity env toclear []) names in


### PR DESCRIPTION
This is a series of cleanups that simplify the few calls to the Clenv.case_pf tactic. All the clenv-manipulation functions are moved into this call and we only expose the eliminator and scrutinee arguments.

Overlays:
- https://github.com/coq-community/coq-dpdgraph/pull/117