### PR TITLE
Remove Prettyp.set_object_pr indirection

### DIFF
--- a/dev/ci/user-overlays/17460-SkySkimmer-no-object-pr.sh
+++ b/dev/ci/user-overlays/17460-SkySkimmer-no-object-pr.sh
@@ -1,0 +1,1 @@
+overlay coq_lsp https://github.com/SkySkimmer/coq-lsp no-object-pr 17460

--- a/vernac/prettyp.mli
+++ b/vernac/prettyp.mli
@@ -11,7 +11,6 @@
 open Names
 open Environ
 open Libnames
-open Globnames
 
 (** A Pretty-Printer for the Calculus of Inductive Constructions. *)
 
@@ -94,19 +93,3 @@ val print_located_qualid : qualid -> Pp.t
 val print_located_term : qualid -> Pp.t
 val print_located_module : qualid -> Pp.t
 val print_located_other : string -> qualid -> Pp.t
-
-type object_pr = {
-  print_inductive           : MutInd.t -> UnivNames.univ_name_list option -> Pp.t;
-  print_constant_with_infos : Constant.t -> UnivNames.univ_name_list option -> Pp.t;
-  print_section_variable    : env -> Evd.evar_map -> variable -> Pp.t;
-  print_abbreviation        : env -> abbreviation -> Pp.t;
-  print_module              : ModPath.t -> Pp.t;
-  print_modtype             : ModPath.t -> Pp.t;
-  print_named_decl          : env -> Evd.evar_map -> Constr.named_declaration -> Pp.t;
-  print_library_leaf       : env -> Evd.evar_map -> bool -> ModPath.t -> Libobject.t -> Pp.t option;
-  print_context             : 'summary. env -> Evd.evar_map -> bool -> int option -> 'summary Lib.library_segment -> Pp.t;
-  print_typed_value_in_env  : Environ.env -> Evd.evar_map -> EConstr.constr * EConstr.types -> Pp.t;
-}
-
-val set_object_pr : object_pr -> unit
-val default_object_pr : object_pr

--- a/vernac/prettyp.mli
+++ b/vernac/prettyp.mli
@@ -47,6 +47,9 @@ val print_notation : env -> Evd.evar_map
   -> Constrexpr.notation_entry
   -> string
   -> Pp.t
+
+val print_abbreviation : env -> KerName.t -> Pp.t
+
 val print_about : env -> Evd.evar_map -> qualid Constrexpr.or_by_notation ->
   UnivNames.univ_name_list option -> Pp.t
 val print_impargs : qualid Constrexpr.or_by_notation -> Pp.t


### PR DESCRIPTION
Nobody uses this and it keeps getting in the way (more indirections when debugging, jumping to definition)

Overlays:
- https://github.com/ejgallego/coq-lsp/pull/477 (lsp used the default_object_pr to get at non-exposed print_abbreviation)