### PR TITLE
Remove an outdated comment from kernel/cClosure.ml

### DIFF
--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -165,20 +165,6 @@ let delta = mkfullflags [fDELTA]
 let zeta = mkflags [fZETA]
 let nored = no_red
 
-(* Flags of reduction and cache of constants: 'a is a type that may be
- * mapped to constr. 'a infos implements a cache for constants and
- * abstractions, storing a representation (of type 'a) of the body of
- * this constant or abstraction.
- *  * i_tab is the cache table of the results
- *
- * ref_value_cache searches in the tab, otherwise uses i_repr to
- * compute the result and store it in the table. If the constant can't
- * be unfolded, returns None, but does not store this failure.  * This
- * doesn't take the RESET into account. You mustn't keep such a table
- * after a Reset.  * This type is not exported. Only its two
- * instantiations (cbv or lazy) are.
- *)
-
 type table_key = Constant.t Univ.puniverses tableKey
 
 let eq_pconstant_key (c,u) (c',u') =


### PR DESCRIPTION
This PR removes an outdated comment from `kernel/cClosure.ml` and that's it. The comment in question was introduced a bit less than 24 years ago (9eabd9dce9f6541099394f0492aeb669a1005ee9) and was related to the `infos` structure, which evolved into `infos_cache` over the years. It has been partially updated 5 years ago (e2141cc741c2a77f05dabd9a8b48d9051d6d6cd4) but it is mostly a source of confusion as of today.
 
