### PR TITLE
Validate Proof command: runs typing.ml on the current proof

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/17467-validate-proof.rst
+++ b/doc/changelog/08-vernac-commands-and-options/17467-validate-proof.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  :cmd:`Validate Proof` runs the type checker on the current proof,
+  complementary with :cmd:`Guarded` which runs the guard checker.
+  (`#17467 <https://github.com/coq/coq/pull/17467>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/language/core/variants.rst
+++ b/doc/sphinx/language/core/variants.rst
@@ -39,6 +39,11 @@ Private (matching) inductive types
    quotient types / higher-order inductive types in projects such as
    the `HoTT library <https://github.com/HoTT/HoTT>`_.
 
+   Reducing definitions from the inductive's module can expose
+   :g:`match` constructs to unification, which may result in invalid proof terms.
+   Errors from such terms are delayed until proof completion (i.e. on the :cmd:`Qed`). Use
+   :cmd:`Validate Proof` to identify which tactic produced the problematic term.
+
 .. example::
 
    .. coqtop:: all

--- a/doc/sphinx/proofs/writing-proofs/proof-mode.rst
+++ b/doc/sphinx/proofs/writing-proofs/proof-mode.rst
@@ -1023,6 +1023,13 @@ Requesting information
    fixpoint and cofixpoint is violated at some time of the construction
    of the proof without having to wait the completion of the proof.
 
+.. cmd:: Validate Proof
+
+   Checks that the current partial proof is well-typed.
+   It is useful for finding tactic bugs since without it, such errors will only be detected at :cmd:`Qed` time.
+
+   It does not check the guard condition.  Use :cmd:`Guarded` for that.
+
 .. _showing_diffs:
 
 Showing differences between proof steps

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -520,6 +520,7 @@ command: [
 | "Show" "Intros"
 | "Show" "Match" reference
 | "Guarded"
+| "Validate" "Proof"
 | "Create" "HintDb" IDENT; [ "discriminated" | ]
 | "Remove" "Hints" LIST1 global opt_hintbases
 | "Hint" hint opt_hintbases

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -818,6 +818,7 @@ command: [
 | "Show" "Intros"
 | "Show" "Match" qualid
 | "Guarded"
+| "Validate" "Proof"
 | "Create" "HintDb" ident OPT "discriminated"
 | "Remove" "Hints" LIST1 qualid OPT ( ":" LIST1 ident )
 | "Comments" LIST0 [ one_term | string | natural ]

--- a/test-suite/success/ValidateProof.v
+++ b/test-suite/success/ValidateProof.v
@@ -1,0 +1,22 @@
+
+Module M.
+  Private Inductive foo := .
+
+  Definition to_nat (f:foo) : nat := match f with end.
+End M.
+
+Lemma bar : False.
+Proof.
+  exact_no_check I.
+  Fail Validate Proof.
+Abort.
+
+Lemma bar f : M.to_nat f = 0.
+Proof.
+  Validate Proof.
+
+  cbv.
+
+  Fail Validate Proof.
+
+Abort.

--- a/vernac/g_proofs.mlg
+++ b/vernac/g_proofs.mlg
@@ -95,6 +95,7 @@ GRAMMAR EXTEND Gram
       | IDENT "Show"; IDENT "Intros" -> { VernacSynPure (VernacShow (ShowIntros true)) }
       | IDENT "Show"; IDENT "Match"; id = reference -> { VernacSynPure (VernacShow (ShowMatch id)) }
       | IDENT "Guarded" -> { VernacSynPure VernacCheckGuard }
+      | IDENT "Validate"; IDENT "Proof" -> { VernacSynPure VernacValidateProof }
       (* Hints for Auto and EAuto *)
       | IDENT "Create"; IDENT "HintDb" ;
           id = IDENT ; b = [ IDENT "discriminated" -> { true } | -> { false } ] ->

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -724,6 +724,8 @@ let pr_synpure_vernac_expr v =
   | VernacCheckGuard ->
     return (keyword "Guarded")
 
+  | VernacValidateProof -> return (keyword "Validate Proof")
+
   (* Resetting *)
   | VernacResetName id ->
     return (keyword "Reset" ++ spc() ++ pr_lident id)

--- a/vernac/vernac_classifier.ml
+++ b/vernac/vernac_classifier.ml
@@ -100,7 +100,7 @@ let classify_vernac e =
     | VernacProof _
     | VernacFocus _ | VernacUnfocus
     | VernacSubproof _
-    | VernacCheckGuard
+    | VernacCheckGuard | VernacValidateProof
     | VernacUnfocused
     | VernacBullet _ ->
         VtProofStep { proof_block_detection = Some "bullet" }

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2151,16 +2151,11 @@ let vernac_show ~pstate =
 let vernac_check_guard ~pstate =
   let pts = Declare.Proof.get pstate in
   let pfterm = List.hd (Proof.partial_proof pts) in
-  let message =
-    try
-      let { Proof.entry; Proof.sigma } = Proof.data pts in
-      let hyps, _, _ = List.hd (Proofview.initial_goals entry) in
-      let env = Environ.reset_with_named_context hyps (Global.env ()) in
-      Inductiveops.control_only_guard env sigma pfterm;
-      (str "The condition holds up to here")
-    with UserError s ->
-      (str ("Condition violated: ") ++ s ++ str ".")
-  in message
+  let { Proof.entry; Proof.sigma } = Proof.data pts in
+  let hyps, _, _ = List.hd (Proofview.initial_goals entry) in
+  let env = Environ.reset_with_named_context hyps (Global.env ()) in
+  Inductiveops.control_only_guard env sigma pfterm;
+  str "The condition holds up to here."
 
 let translate_vernac_synterp ?loc ~atts v = let open Vernacextend in match v with
   | EVernacNotation { local; decl } ->

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -486,6 +486,7 @@ type nonrec synpure_vernac_expr =
   | VernacEndSubproof
   | VernacShow of showable
   | VernacCheckGuard
+  | VernacValidateProof
   | VernacProof of Genarg.raw_generic_argument option * section_subset_expr option
 
   | VernacAddOption of Goptions.option_name * Goptions.table_value list


### PR DESCRIPTION
cf some discussion in https://github.com/coq/coq/pull/17452

Close https://github.com/coq/coq/issues/9911

~Depends https://github.com/coq/coq/pull/17466~ removed dependency