### PR TITLE
Interpret "abstract after N" in Number Notation as > N, not >= N

### DIFF
--- a/doc/changelog/03-notations/17478-master.rst
+++ b/doc/changelog/03-notations/17478-master.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  In :cmd:`Number Notation`, "abstract after N" was applied when number >= N.
+  Now it is applied when number > N
+  (`#17478 <https://github.com/coq/coq/pull/17478>`_,
+  by Jim Fehrle).

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -2041,7 +2041,7 @@ Number notations
 
       :n:`abstract after @bignat`
          returns :n:`(@qualid__parse m)` when parsing a literal
-         :n:`m` that's greater than or equal to :n:`@bignat` rather than reducing
+         :n:`m` that's greater than :n:`@bignat` rather than reducing
          it to a normal form.  Here :g:`m` will be a
          :g:`Number.int`, :g:`Number.uint`, :g:`Z` or :g:`Number.number`, depending on the
          type of the parsing function :n:`@qualid__parse`. This allows for a

--- a/interp/numTok.ml
+++ b/interp/numTok.ml
@@ -307,7 +307,7 @@ struct
     of_int_frac_and_exponent (SignedNat.of_bigint c i) None e
 
   let is_bigger_int_than (s, { int; frac; exp }) i =
-    frac = "" && exp = "" && UnsignedNat.compare int i >= 0
+    frac = "" && exp = "" && UnsignedNat.compare int i > 0
 
   let classify (_, n) = Unsigned.classify n
 end

--- a/test-suite/output/NumberNotations.v
+++ b/test-suite/output/NumberNotations.v
@@ -83,7 +83,7 @@ Module Test4.
 
   Polymorphic Definition pto_punits := pto_punit_all@{Set}.
   Polymorphic Definition pof_punits := pof_punit@{Set}.
-  Number Notation punit pto_punits pof_punits (abstract after 1) : ppps.
+  Number Notation punit pto_punits pof_punits (abstract after 0) : ppps.
   Delimit Scope ppps with ppps.
   Universe u.
   Constraint Set < u.
@@ -121,7 +121,7 @@ Module Test6.
   End Scopes.
   Module Export Notations.
     Export Scopes.
-    Number Notation wnat of_uint to_uint (abstract after 5000) : wnat_scope.
+    Number Notation wnat of_uint to_uint (abstract after 4999) : wnat_scope.
   End Notations.
   Set Printing Coercions.
   Check let v := 0%wnat in v : wnat.
@@ -200,12 +200,12 @@ Module Test10.
   Declare Scope unit2_scope.
   Delimit Scope unit_scope with unit.
   Delimit Scope unit2_scope with unit2.
-  Number Notation unit of_uint to_uint (abstract after 1) : unit_scope.
+  Number Notation unit of_uint to_uint (abstract after 0) : unit_scope.
   Local Set Warnings Append "+abstract-large-number-no-op".
   (* Check that there is actually a warning here *)
-  Fail Number Notation unit of_uint to_uint (abstract after 1) : unit2_scope.
+  Fail Number Notation unit of_uint to_uint (abstract after 0) : unit2_scope.
   (* Check that there is no warning here *)
-  Number Notation unit of_any_uint to_uint (abstract after 1) : unit2_scope.
+  Number Notation unit of_any_uint to_uint (abstract after 0) : unit2_scope.
 End Test10.
 
 Module Test12.
@@ -588,7 +588,7 @@ Number Notation nSet of_uint to_uint (via I
 (* incompatibility with abstract (but warning is fine) *)
 Fail Number Notation nSet of_uint to_uint (via I
   mapping [Empty_set => Iempty, unit => Iunit, sum => Isum],
-  abstract after 12)
+  abstract after 11)
   : type_scope.
 Number Notation nSet of_uint to_uint (via I
   mapping [Empty_set => Iempty, unit => Iunit, sum => Isum],

--- a/theories/Init/Prelude.v
+++ b/theories/Init/Prelude.v
@@ -46,8 +46,8 @@ Number Notation Number.int Number.int_of_int Number.int_of_int
   : dec_int_scope.
 
 (* Parsing / printing of [nat] numbers *)
-Number Notation nat Nat.of_num_uint Nat.to_num_hex_uint (abstract after 5001) : hex_nat_scope.
-Number Notation nat Nat.of_num_uint Nat.to_num_uint (abstract after 5001) : nat_scope.
+Number Notation nat Nat.of_num_uint Nat.to_num_hex_uint (abstract after 5000) : hex_nat_scope.
+Number Notation nat Nat.of_num_uint Nat.to_num_uint (abstract after 5000) : nat_scope.
 
 (* Printing/Parsing of bytes *)
 Export Byte.ByteSyntaxNotations.


### PR DESCRIPTION
`abstract after N` in `Number Notation` should generate a warning for `N+1` but not for `N`.

Prelude.v has `Number Notation nat Nat.of_num_uint Nat.to_num_hex_uint (abstract after 5001) : hex_nat_scope.`, which incorrectly gives a warning for 5001:

```
Compute 5001.  (* To avoid stack overflow, large numbers in nat are interpreted
                  as applications of Nat.of_num_uint. [abstract-large-number,numbers]
```

~~Needs prior merge of #17406 and a documentation tweak~~


<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

