### PR TITLE
Declaremods: do not protect summaries 

### DIFF
--- a/test-suite/output/ModuleSubtyping.out
+++ b/test-suite/output/ModuleSubtyping.out
@@ -1,16 +1,16 @@
-File "./output/ModuleSubtyping.v", line 5, characters 0-39:
+File "./output/ModuleSubtyping.v", line 8, characters 2-41:
 The command has indeed failed with message:
 Signature components for field x do not match:
 the body of definitions differs.
-File "./output/ModuleSubtyping.v", line 11, characters 0-28:
+File "./output/ModuleSubtyping.v", line 14, characters 2-30:
 The command has indeed failed with message:
 Signature components for field B.C.x do not match:
 the body of definitions differs.
-File "./output/ModuleSubtyping.v", line 17, characters 0-29:
+File "./output/ModuleSubtyping.v", line 20, characters 2-31:
 The command has indeed failed with message:
 Signature components for field B.C.x in the 1st functor argument do not match:
 the body of definitions differs.
-File "./output/ModuleSubtyping.v", line 27, characters 0-32:
+File "./output/ModuleSubtyping.v", line 30, characters 2-34:
 The command has indeed failed with message:
 Signature components for field B.C.x in the 1st functor argument
 of F do not match: the body of definitions differs.

--- a/test-suite/output/ModuleSubtyping.out
+++ b/test-suite/output/ModuleSubtyping.out
@@ -14,3 +14,7 @@ File "./output/ModuleSubtyping.v", line 30, characters 2-34:
 The command has indeed failed with message:
 Signature components for field B.C.x in the 1st functor argument
 of F do not match: the body of definitions differs.
+File "./output/ModuleSubtyping.v", line 46, characters 2-38:
+The command has indeed failed with message:
+Signature components for field v do not match: expected type 
+"A1.t -> A1.t" but found type "A1.t -> Prop".

--- a/test-suite/output/ModuleSubtyping.v
+++ b/test-suite/output/ModuleSubtyping.v
@@ -29,3 +29,19 @@ Module Qualification.
 
   Fail Module FXtest <: FXT := FX.
 End Qualification.
+
+Module PrintBound.
+  (* printing an inductive from a bound module in an error from the
+   command where the bound module is introduced *)
+  Module Type E. End E.
+
+  Module Type T. Inductive t : Prop := . Parameter v : t -> t. End T.
+
+  Module Type FE(A:E). Inductive t : Prop :=. Parameter v : t -> Prop. End FE.
+
+  Module Type FT(A:T). End FT.
+
+  Module VE. End VE.
+
+  Fail Module F (A1:FE VE) (A2:FT A1).
+End PrintBound.

--- a/test-suite/output/ModuleSubtyping.v
+++ b/test-suite/output/ModuleSubtyping.v
@@ -1,27 +1,31 @@
 
-Module Type EasyT. Definition x := O. End EasyT.
-Module EasyM. Definition x := S O. End EasyM.
+Module Qualification.
+  (* test that field mismatch errors print the qualified fields *)
 
-Fail Module Easytest <: EasyT := EasyM.
+  Module Type EasyT. Definition x := O. End EasyT.
+  Module EasyM. Definition x := S O. End EasyM.
 
-Module Type A. Module B. Module C. Definition x := O. End C. End B. End A.
-Module Type A'. Module B. Module C. Definition x := S O. End C. End B. End A'.
-Module Av. Include A'. End Av.
+  Fail Module Easytest <: EasyT := EasyM.
 
-Fail Module test <: A := Av.
-(* was Error: Signature components for field C do not match: the body of definitions differs. *)
+  Module Type A. Module B. Module C. Definition x := O. End C. End B. End A.
+  Module Type A'. Module B. Module C. Definition x := S O. End C. End B. End A'.
+  Module Av. Include A'. End Av.
 
-Module Type FT (X:A). End FT.
-Module F (X:A'). End F.
+  Fail Module test <: A := Av.
+  (* was Error: Signature components for field C do not match: the body of definitions differs. *)
 
-Fail Module Ftest <: FT := F.
-
-Module Type FXT.
-  Module F (X:A). End F.
-End FXT.
-
-Module FX.
+  Module Type FT (X:A). End FT.
   Module F (X:A'). End F.
-End FX.
 
-Fail Module FXtest <: FXT := FX.
+  Fail Module Ftest <: FT := F.
+
+  Module Type FXT.
+    Module F (X:A). End F.
+  End FXT.
+
+  Module FX.
+    Module F (X:A'). End F.
+  End FX.
+
+  Fail Module FXtest <: FXT := FX.
+End Qualification.


### PR DESCRIPTION
Resetting the summary when an exception is raised is useless here, the
higher layers will handle it.

By not resetting the summary errors can be correctly printed since we
have the correct nametab (the added test used to print
`expected type "A1.<inductive:t:0> -> A1.<inductive:t:0>"` etc).