### PR TITLE
Ltac2 precomputed values

### DIFF
--- a/plugins/ltac2/tac2entries.mli
+++ b/plugins/ltac2/tac2entries.mli
@@ -14,7 +14,7 @@ open Tac2expr
 
 (** {5 Toplevel definitions} *)
 
-val register_ltac : ?deprecation:Deprecation.t -> ?local:bool -> ?mut:bool -> rec_flag ->
+val register_ltac : ?deprecation:Deprecation.t -> ?local:bool -> ?precompute:bool -> ?mut:bool -> rec_flag ->
   (Names.lname * raw_tacexpr) list -> unit
 
 val register_type : ?local:bool -> rec_flag ->
@@ -103,3 +103,7 @@ val q_move_location : move_location Pcoq.Entry.t
 val q_pose : pose Pcoq.Entry.t
 val q_assert : assertion Pcoq.Entry.t
 end
+
+type pure_val_checker = { pure_val_checker : 'a. Tac2ffi.valexpr -> 'a glb_typexpr list -> unit }
+
+val register_pure_val_checker : type_constant -> pure_val_checker -> unit

--- a/plugins/ltac2/tac2env.ml
+++ b/plugins/ltac2/tac2env.ml
@@ -14,8 +14,12 @@ open Libnames
 open Tac2expr
 open Tac2ffi
 
+type 'a or_glb_tacexpr =
+| GlbVal of 'a
+| GlbTacexpr of glb_tacexpr
+
 type global_data = {
-  gdata_expr : glb_tacexpr;
+  gdata_expr : valexpr or_glb_tacexpr;
   gdata_type : type_scheme;
   gdata_mutable : bool;
   gdata_deprecation : Deprecation.t option;
@@ -253,10 +257,6 @@ let shortest_qualid_of_projection kn =
   let tab = !nametab in
   let sp = KNmap.find kn tab.tab_proj_rev in
   KnTab.shortest_qualid Id.Set.empty sp tab.tab_proj
-
-type 'a or_glb_tacexpr =
-| GlbVal of 'a
-| GlbTacexpr of glb_tacexpr
 
 type environment = {
   env_ist : valexpr Id.Map.t;

--- a/plugins/ltac2/tac2env.mli
+++ b/plugins/ltac2/tac2env.mli
@@ -19,8 +19,12 @@ open Tac2ffi
 
 (** {5 Toplevel definition of values} *)
 
+type 'a or_glb_tacexpr =
+| GlbVal of 'a
+| GlbTacexpr of glb_tacexpr
+
 type global_data = {
-  gdata_expr : glb_tacexpr;
+  gdata_expr : valexpr or_glb_tacexpr;
   gdata_type : type_scheme;
   gdata_mutable : bool;
   gdata_deprecation : Deprecation.t option;
@@ -121,10 +125,6 @@ val define_primitive : ml_tactic_name -> closure -> unit
 val interp_primitive : ml_tactic_name -> closure
 
 (** {5 ML primitive types} *)
-
-type 'a or_glb_tacexpr =
-| GlbVal of 'a
-| GlbTacexpr of glb_tacexpr
 
 type ('a, 'b, 'r) intern_fun = Genintern.glob_sign -> 'a -> 'b * 'r glb_typexpr
 

--- a/plugins/ltac2/tac2print.ml
+++ b/plugins/ltac2/tac2print.ml
@@ -453,12 +453,12 @@ let unfold kn args =
     Some (subst_type args def)
   | _ -> None
 
-let rec kind t = match t with
+let rec type_kind t = match t with
 | GTypVar id -> GTypVar id
 | GTypRef (Other kn, tl) ->
   begin match unfold kn tl with
   | None -> t
-  | Some t -> kind t
+  | Some t -> type_kind t
   end
 | GTypArrow _ | GTypRef (Tuple _, _) -> t
 
@@ -472,7 +472,7 @@ let register_val_printer kn pr =
 
 open Tac2ffi
 
-let rec pr_valexpr env sigma v t = match kind t with
+let rec pr_valexpr env sigma v t = match type_kind t with
 | GTypVar _ -> str "<poly>"
 | GTypRef (Other kn, params) ->
   let pr = try Some (KNmap.find kn !printers) with Not_found -> None in
@@ -485,7 +485,7 @@ let rec pr_valexpr env sigma v t = match kind t with
     else match repr with
     | GTydDef None -> str "<abstr>"
     | GTydDef (Some _) ->
-      (* Shouldn't happen thanks to kind *)
+      (* Shouldn't happen thanks to type_kind *)
       assert false
     | GTydAlg alg ->
       if Valexpr.is_int v then

--- a/plugins/ltac2/tac2print.mli
+++ b/plugins/ltac2/tac2print.mli
@@ -71,3 +71,11 @@ val val_format : format list Tac2dyn.Val.tag
 exception InvalidFormat
 
 val parse_format : string -> format list
+
+val type_kind : 'a glb_typexpr -> 'a glb_typexpr
+(** Unfold global type definitions. Type variables are all rigid.*)
+
+val find_constructor : Int.t -> bool -> (uid * int glb_typexpr list) list -> uid * int glb_typexpr list
+
+val subst_type : 'a Tac2expr.glb_typexpr array ->
+  int Tac2expr.glb_typexpr -> 'a Tac2expr.glb_typexpr

--- a/test-suite/ltac2/precompute.v
+++ b/test-suite/ltac2/precompute.v
@@ -1,0 +1,14 @@
+Require Import Ltac2.Ltac2.
+
+Ltac2 rec fact n :=
+  if Int.le n 1 then 1
+  else Int.add (fact (Int.sub n 1)) (fact (Int.sub n 2)).
+
+Ltac2 test val := List.init 50 (fun _ => val()).
+
+Fail Timeout 1 Ltac2 Eval test (fun () => fact 25).
+
+Time #[precompute] Ltac2 val := fact 25.
+(* 0.5s *)
+
+Timeout 1 Ltac2 Eval test (fun () => val).

--- a/vernac/attributes.mli
+++ b/vernac/attributes.mli
@@ -112,6 +112,9 @@ val payload_attribute : ?cat:(string -> string -> string) -> name:string -> stri
    attribute may only be set once for a command. *)
 val bool_attribute : name:string -> bool option attribute
 
+val enable_attribute : key:string -> default:(unit -> bool) -> bool attribute
+(** Attribute [key] produces [true] if present, [default()] otherwise. *)
+
 val qualify_attribute : string -> 'a attribute -> 'a attribute
 (** [qualified_attribute qual att] treats [#[qual(atts)]] like [att]
    treats [atts]. *)


### PR DESCRIPTION
See for instance the added test.

Precomputed values need to be marshallable as they are saved to files, sent to workers etc. This means no functions.

Precomputed values need to be pure (no mutation) as the backtracking mechanism is not aware of ltac2 mutations. Notably this means no closures as the closed data may contain mutable data. (so closures are doubly forbidden) 

Values in abstract types are checked by adhoc checkers which may implement arbitrary restrictions, for instance constrs may forbid the presence of evars (currently no checker is implemented for constr so they are forbidden in precomputed values).

Currently module substitution fails (not implemented, low priority) on precomputed values, so doing `Module Foo := Bar`, `Include Bar`, `Module Foo := F Bar` etc with `Bar` containing precomputed values is forbidden.