### PR TITLE
Improve printing of reverse coercions

### DIFF
--- a/doc/changelog/03-notations/17484-rev_coerce.rst
+++ b/doc/changelog/03-notations/17484-rev_coerce.rst
@@ -1,0 +1,8 @@
+- **Added:**
+  Improve printing of reverse coercions. When a term :g:`x`
+  is elaborated to :g:`x'` through a reverse coercion,
+  return the term :g:`reverse_coercion x' x` that is convertible
+  to :g:`x'` but displayed :g:`x` thanks to the coercion
+  :g:`reverse_coercion`
+  (`#17484 <https://github.com/coq/coq/pull/17484>`_,
+  by Pierre Roux).

--- a/test-suite/output/bug_16224.out
+++ b/test-suite/output/bug_16224.out
@@ -7,6 +7,7 @@ Beware that the default locality for '::' is #[export], as opposed to
 field if you need to keep the current behavior. For example: "Class foo := {
 #[global] field :: bar }."
 [future-coercion-class-field,deprecated-since-8.17,deprecated,default]
+[reverse_coercion] : ReverseCoercionSource >-> ReverseCoercionTarget
 [rc] : Rc >-> A (reversible)
 [ric] : Ric >-> A (reversible)
 ric : Ric -> A

--- a/test-suite/output/relaxed_ambiguous_paths.out
+++ b/test-suite/output/relaxed_ambiguous_paths.out
@@ -18,6 +18,7 @@ New coercion path [h1; f3] : B >-> C' is ambiguous with existing
 [f2; h2] : B >-> C'
 [h2] : B' >-> C'
 [f3] : C >-> C'
+[reverse_coercion] : ReverseCoercionSource >-> ReverseCoercionTarget
 File "./output/relaxed_ambiguous_paths.v", line 33, characters 0-28:
 Warning:
 New coercion path [ab; bc] : A >-> C is ambiguous with existing 
@@ -28,6 +29,7 @@ New coercion path [ab; bc] : A >-> C is ambiguous with existing
 [bc] : B >-> C
 [bc; cd] : B >-> D
 [cd] : C >-> D
+[reverse_coercion] : ReverseCoercionSource >-> ReverseCoercionTarget
 File "./output/relaxed_ambiguous_paths.v", line 50, characters 0-28:
 Warning:
 New coercion path [ab; bc] : A >-> C is ambiguous with existing 
@@ -41,12 +43,15 @@ New coercion path [ab; ba] : A >-> A is not definitionally an identity function.
 [ac] : A >-> C
 [ba] : B >-> A
 [bc] : B >-> C
+[reverse_coercion] : ReverseCoercionSource >-> ReverseCoercionTarget
+[reverse_coercion] : ReverseCoercionSource >-> ReverseCoercionTarget
 [B_A] : B >-> A
 [C_A] : C >-> A
 [D_A] : D >-> A
 [D_B] : D >-> B (reversible)
 [D_C] : D >-> C (reversible)
 [A'_A] : A' >-> A (reversible)
+[reverse_coercion] : ReverseCoercionSource >-> ReverseCoercionTarget
 [B_A'; A'_A] : B >-> A
 [B_A'] : B >-> A'
 [C_A'; A'_A] : C >-> A
@@ -59,6 +64,7 @@ File "./output/relaxed_ambiguous_paths.v", line 147, characters 0-86:
 Warning:
 New coercion path [D_C; C_A'] : D >-> A' is ambiguous with existing 
 [D_B; B_A'] : D >-> A'. [ambiguous-paths,coercions,default]
+[reverse_coercion] : ReverseCoercionSource >-> ReverseCoercionTarget
 [A'_A] : A' >-> A
 [B_A'; A'_A] : B >-> A
 [B_A'] : B >-> A'

--- a/test-suite/output/reverse_coercions.out
+++ b/test-suite/output/reverse_coercions.out
@@ -1,0 +1,6 @@
+nat : S
+     : S
+reverse_coercion S_nat nat : S
+     : S
+@reverse_coercion S Set S_nat nat : S
+     : S

--- a/test-suite/output/reverse_coercions.v
+++ b/test-suite/output/reverse_coercions.v
@@ -1,0 +1,16 @@
+Structure S := {
+  ssort :> Type;
+  sstuff : ssort;
+}.
+
+Canonical Structure S_nat := {| ssort := nat; sstuff := 0; |}.
+
+Check nat : S.
+
+Set Printing Coercions.
+
+Check nat : S.
+
+Set Printing All.
+
+Check nat : S.

--- a/theories/Init/Prelude.v
+++ b/theories/Init/Prelude.v
@@ -54,3 +54,14 @@ Export Byte.ByteSyntaxNotations.
 
 (* Default substrings not considered by queries like Search *)
 Add Search Blacklist "_subproof" "_subterm" "Private_".
+
+(* Dummy coercion used by the elaborator to leave a trace in its
+   result. When [x] is (reversible) coerced to [x'], the result
+   [reverse_coercion x' x], convertible to [x'] will still be displayed [x]
+   thanks to the reverse_coercion coercion. *)
+#[universes(polymorphic=yes)] Definition ReverseCoercionSource (T : Type) := T.
+#[universes(polymorphic=yes)] Definition ReverseCoercionTarget (T : Type) := T.
+#[warning="-uniform-inheritance", reversible=no, universes(polymorphic=yes)]
+Coercion reverse_coercion {T' T} (x' : T') (x : ReverseCoercionSource T)
+  : ReverseCoercionTarget T' := x'.
+Register reverse_coercion as core.coercion.reverse_coercion.


### PR DESCRIPTION
When a a term [x] is elaborated into [x'] through a reverse coercion, return the term [rev_coerce x' x] that is convertible to [x'] but printed [x], thanks to the coercion [rev_coerce]. Previously, the returned term was directly [x'].

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
<!-- Fixes / closes #???? -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [x] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] ~Documented any new / changed **user messages**.~
  - [ ] ~Updated **documented syntax** by running `make doc_gram_rsts`.~

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
