### PR TITLE
Inline internals of the case_pf tactic

### DIFF
--- a/pretyping/indrec.ml
+++ b/pretyping/indrec.ml
@@ -610,6 +610,10 @@ let is_in_prop mip =
   | InProp -> true
   | _ -> false
 
+let default_case_analysis_dependence env ind =
+  let _, mip as specif = lookup_mind_specif env ind in
+  not (is_in_prop mip || not (Inductiveops.has_dependent_elim specif))
+
 let build_case_analysis_scheme_default env sigma pity kind =
   let _, mip as specif = lookup_mind_specif env (fst pity) in
   let dep = not (is_in_prop mip || not (Inductiveops.has_dependent_elim specif)) in

--- a/pretyping/indrec.ml
+++ b/pretyping/indrec.ml
@@ -159,7 +159,6 @@ let mis_make_case_tac dep env sigma (ind, u as pind) params pred (mib, mip) kind
   let constrs = get_constructors env indf in
   let projs = get_projections env ind in
   let relevance = Sorts.relevance_of_sort_family kind in
-  let () = check_valid_elimination env pind kind in
   let ndepar = mip.mind_nrealdecls + 1 in
 
   let pnas, deparsign =

--- a/pretyping/indrec.ml
+++ b/pretyping/indrec.ml
@@ -618,9 +618,8 @@ let default_case_analysis_dependence env ind =
   not (is_in_prop mip || not (Inductiveops.has_dependent_elim specif))
 
 let build_case_analysis_scheme_default env sigma pity kind =
-  let _, mip as specif = lookup_mind_specif env (fst pity) in
-  let dep = not (is_in_prop mip || not (Inductiveops.has_dependent_elim specif)) in
-  mis_make_case_com dep env sigma pity specif kind
+  let dep = default_case_analysis_dependence env (fst pity) in
+  build_case_analysis_scheme env sigma pity dep kind
 
 (**********************************************************************)
 (* [modify_sort_scheme s rec] replaces the sort of the scheme

--- a/pretyping/indrec.ml
+++ b/pretyping/indrec.ml
@@ -114,6 +114,14 @@ type case_analysis = {
   case_type : EConstr.t;
 }
 
+type case_analysis0 = {
+  case0_params : EConstr.rel_context;
+  case0_pred : EConstr.types;
+  case0_branches : EConstr.t array;
+  case0_arity : EConstr.rel_context;
+  case0_body : EConstr.t;
+}
+
 let eval_case_analysis case =
   let open EConstr in
   let body = it_mkLambda_or_LetIn case.case_body case.case_arity in
@@ -137,6 +145,100 @@ let build_branch_type env sigma dep p cs =
       (List.map (fun d -> Termops.map_rel_decl EConstr.of_constr d) cs.cs_args))
   else
     Term.it_mkProd_or_LetIn base cs.cs_args
+
+let mis_make_case_tac dep env sigma (ind, u as pind) (mib,mip as specif) kind =
+  let lnamespar = Vars.subst_instance_context u mib.mind_params_ctxt in
+  let indf = make_ind_family(pind, Context.Rel.instance_list mkRel 0 lnamespar) in
+  let constrs = get_constructors env indf in
+  let projs = get_projections env ind in
+  let relevance = Sorts.relevance_of_sort_family kind in
+  let () = if Option.is_empty projs then check_privacy_block specif in
+  let () =
+    if not (Sorts.family_leq kind (elim_sort specif)) && not (kind == InQSort) then
+      raise
+        (RecursionSchemeError
+           (env, NotAllowedCaseAnalysis (false, fst (UnivGen.fresh_sort_in_family kind), pind)))
+  in
+  let ndepar = mip.mind_nrealdecls + 1 in
+  let env = RelEnv.make env in
+  let env' = RelEnv.push_rel_context lnamespar env in
+  let (sigma, s) = Evd.fresh_sort_in_family ~rigid:Evd.univ_flexible_alg sigma kind in
+
+  let pnas, deparsign =
+    let arsign, sort = get_arity !!env' indf in
+    let r = Sorts.relevance_of_sort_family sort in
+    let depind = build_dependent_inductive !!env indf in
+    let deparsign = LocalAssum (make_annot Anonymous r,depind)::arsign in
+    let pctx =
+      let deparsign = set_names env' deparsign in
+      if dep then deparsign
+      else LocalAssum (make_annot Anonymous r, depind) :: List.tl deparsign
+    in
+    let pnas = Array.of_list (List.rev_map get_annot pctx) in
+    pnas, deparsign
+  in
+
+  let typP = make_arity !!env' sigma dep indf s in
+  let typP = EConstr.Unsafe.to_constr typP in
+  let nameP = make_annot Anonymous Sorts.Relevant in
+  let env' = RelEnv.push_rel (LocalAssum (nameP, typP)) env' in
+
+  let get_branch i =
+    let cs = lift_constructor 1 constrs.(i) in
+    let base = appvect (lift cs.cs_nargs (mkRel 1), cs.cs_concl_realargs) in
+    if dep then
+      let argctx = Namegen.name_context !!env' sigma (EConstr.of_rel_context cs.cs_args) in
+      let argctx = EConstr.Unsafe.to_rel_context argctx in
+      Term.it_mkProd_or_LetIn (applist (base, [build_dependent_constructor cs])) argctx
+    else
+      Term.it_mkProd_or_LetIn base cs.cs_args
+  in
+  let branches = Array.init (Array.length mip.mind_consnames) get_branch in
+
+  let body = match projs with
+  | None ->
+    let nbprod = Array.length mip.mind_consnames + 1 in
+    let ci = make_case_info !!env' (fst pind) relevance RegularStyle in
+    let pbody =
+      appvect
+        (mkRel (ndepar + nbprod),
+          if dep then Context.Rel.instance mkRel 0 deparsign
+          else Context.Rel.instance mkRel 1 (List.tl deparsign)) in
+    let pms = Context.Rel.instance mkRel (ndepar + nbprod) lnamespar in
+    let iv =
+      if Typeops.should_invert_case !!env' ci then
+        CaseInvert { indices = Context.Rel.instance mkRel 1 (List.tl deparsign) }
+      else NoInvert
+    in
+    let ncons = Array.length mip.mind_consnames in
+    let mk_branch i =
+      (* we need that to get the generated names for the branch *)
+      let (ctx, _) = decompose_prod_decls branches.(i) in
+      let brnas = Array.of_list (List.rev_map get_annot ctx) in
+      let n = mkRel (List.length ctx + ndepar + ncons - i) in
+      let args = Context.Rel.instance mkRel 0 ctx in
+      (brnas, mkApp (n, args))
+    in
+    let br = Array.init ncons mk_branch in
+    mkCase (ci, u, pms, (pnas, liftn ndepar (ndepar + 1) pbody), iv, mkRel 1, br)
+  | Some ps ->
+    let args = Array.map (fun p -> mkProj (Projection.make p true, mkRel 1)) ps in
+    mkApp (mkRel 2, args)
+  in
+  let case = {
+    case0_params = EConstr.of_rel_context lnamespar;
+    case0_pred = EConstr.of_constr typP;
+    case0_branches = EConstr.of_constr_array branches;
+    case0_arity = EConstr.of_rel_context deparsign;
+    case0_body = EConstr.of_constr body;
+  } in
+  (sigma, case)
+
+let build_case_analysis env sigma pity dep kind =
+  let specif = lookup_mind_specif env (fst pity) in
+  if dep && not (Inductiveops.has_dependent_elim specif) then
+    raise (RecursionSchemeError (env, NotAllowedDependentAnalysis (false, fst pity)));
+  mis_make_case_tac dep env sigma pity specif kind
 
 let mis_make_case_com dep env sigma (ind, u as pind) (mib,mip as specif) kind =
   let lnamespar = Vars.subst_instance_context u mib.mind_params_ctxt in

--- a/pretyping/indrec.mli
+++ b/pretyping/indrec.mli
@@ -44,6 +44,8 @@ type case_analysis0 = private {
   case0_body : EConstr.t;
 }
 
+val check_valid_elimination : env -> pinductive -> Sorts.family -> unit
+
 val eval_case_analysis : case_analysis -> EConstr.t * EConstr.types
 
 val default_case_analysis_dependence : env -> inductive -> bool

--- a/pretyping/indrec.mli
+++ b/pretyping/indrec.mli
@@ -37,12 +37,23 @@ type case_analysis = private {
   case_type : EConstr.t;
 }
 
+type case_analysis0 = private {
+  case0_params : EConstr.rel_context;
+  case0_pred : EConstr.types;
+  case0_branches : EConstr.types array;
+  case0_arity : EConstr.rel_context;
+  case0_body : EConstr.t;
+}
+
 val eval_case_analysis : case_analysis -> EConstr.t * EConstr.types
 
 val default_case_analysis_dependence : env -> inductive -> bool
 
+val build_case_analysis : env -> Evd.evar_map -> pinductive ->
+  dep_flag -> Sorts.family -> evar_map * case_analysis0
+
 val build_case_analysis_scheme : env -> Evd.evar_map -> pinductive ->
-      dep_flag -> Sorts.family -> evar_map * case_analysis
+  dep_flag -> Sorts.family -> evar_map * case_analysis
 
 (** Build a dependent case elimination predicate unless type is in Prop
    or is a recursive record with primitive projections. *)

--- a/pretyping/indrec.mli
+++ b/pretyping/indrec.mli
@@ -37,20 +37,11 @@ type case_analysis = private {
   case_type : EConstr.t;
 }
 
-type case_analysis0 = private {
-  case0_branches : EConstr.types array;
-  case0_body : EConstr.t;
-}
-
 val check_valid_elimination : env -> pinductive -> dep:bool -> Sorts.family -> unit
 
 val eval_case_analysis : case_analysis -> EConstr.t * EConstr.types
 
 val default_case_analysis_dependence : env -> inductive -> bool
-
-val build_case_analysis : env -> Evd.evar_map -> pinductive ->
-  EConstr.t array -> EConstr.types -> EConstr.t array -> EConstr.t ->
-  dep_flag -> Sorts.family -> case_analysis0
 
 val build_case_analysis_scheme : env -> Evd.evar_map -> pinductive ->
   dep_flag -> Sorts.family -> evar_map * case_analysis

--- a/pretyping/indrec.mli
+++ b/pretyping/indrec.mli
@@ -42,7 +42,7 @@ type case_analysis0 = private {
   case0_body : EConstr.t;
 }
 
-val check_valid_elimination : env -> pinductive -> Sorts.family -> unit
+val check_valid_elimination : env -> pinductive -> dep:bool -> Sorts.family -> unit
 
 val eval_case_analysis : case_analysis -> EConstr.t * EConstr.types
 

--- a/pretyping/indrec.mli
+++ b/pretyping/indrec.mli
@@ -38,7 +38,6 @@ type case_analysis = private {
 }
 
 type case_analysis0 = private {
-  case0_params : EConstr.rel_context;
   case0_pred : EConstr.types;
   case0_branches : EConstr.types array;
   case0_arity : EConstr.rel_context;
@@ -49,7 +48,7 @@ val eval_case_analysis : case_analysis -> EConstr.t * EConstr.types
 
 val default_case_analysis_dependence : env -> inductive -> bool
 
-val build_case_analysis : env -> Evd.evar_map -> pinductive ->
+val build_case_analysis : env -> Evd.evar_map -> pinductive -> EConstr.t array ->
   dep_flag -> Sorts.family -> evar_map * case_analysis0
 
 val build_case_analysis_scheme : env -> Evd.evar_map -> pinductive ->

--- a/pretyping/indrec.mli
+++ b/pretyping/indrec.mli
@@ -39,7 +39,6 @@ type case_analysis = private {
 
 type case_analysis0 = private {
   case0_branches : EConstr.types array;
-  case0_arity : EConstr.rel_context;
   case0_body : EConstr.t;
 }
 
@@ -50,7 +49,7 @@ val eval_case_analysis : case_analysis -> EConstr.t * EConstr.types
 val default_case_analysis_dependence : env -> inductive -> bool
 
 val build_case_analysis : env -> Evd.evar_map -> pinductive ->
-  EConstr.t array -> EConstr.t ->
+  EConstr.t array -> EConstr.types -> EConstr.t array -> EConstr.t ->
   dep_flag -> Sorts.family -> case_analysis0
 
 val build_case_analysis_scheme : env -> Evd.evar_map -> pinductive ->

--- a/pretyping/indrec.mli
+++ b/pretyping/indrec.mli
@@ -38,7 +38,6 @@ type case_analysis = private {
 }
 
 type case_analysis0 = private {
-  case0_pred : EConstr.types;
   case0_branches : EConstr.types array;
   case0_arity : EConstr.rel_context;
   case0_body : EConstr.t;
@@ -50,8 +49,9 @@ val eval_case_analysis : case_analysis -> EConstr.t * EConstr.types
 
 val default_case_analysis_dependence : env -> inductive -> bool
 
-val build_case_analysis : env -> Evd.evar_map -> pinductive -> EConstr.t array ->
-  dep_flag -> Sorts.family -> evar_map * case_analysis0
+val build_case_analysis : env -> Evd.evar_map -> pinductive ->
+  EConstr.t array -> EConstr.t ->
+  dep_flag -> Sorts.family -> case_analysis0
 
 val build_case_analysis_scheme : env -> Evd.evar_map -> pinductive ->
   dep_flag -> Sorts.family -> evar_map * case_analysis

--- a/pretyping/indrec.mli
+++ b/pretyping/indrec.mli
@@ -39,6 +39,8 @@ type case_analysis = private {
 
 val eval_case_analysis : case_analysis -> EConstr.t * EConstr.types
 
+val default_case_analysis_dependence : env -> inductive -> bool
+
 val build_case_analysis_scheme : env -> Evd.evar_map -> pinductive ->
       dep_flag -> Sorts.family -> evar_map * case_analysis
 

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -920,13 +920,16 @@ let res_pf ?with_evars ?with_classes ?flags clenv =
 
 module RelDecl = Context.Rel.Declaration
 
-let case_pf ?with_evars ?with_classes ?submetas case (indarg, typ) =
+let case_pf ?with_evars ?with_classes ?submetas ~dep (indarg, typ) =
   let open Indrec in
   Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
   let sigma = Proofview.Goal.sigma gl in
+  let concl = Proofview.Goal.concl gl in
   let hd, args = decompose_app_vect sigma typ in
   let ind, u = destInd sigma hd in
+  let s = Retyping.get_sort_family_of env sigma concl in
+  let (sigma, case) = build_case_analysis_scheme env sigma (ind, EInstance.kind sigma u) dep s in
   let (mib, mip) = Inductive.lookup_mind_specif env ind in
   let params, indices = Array.chop mib.mind_nparams args in
   let sigma = clear_metas sigma in

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -950,15 +950,13 @@ let case_pf ?(with_evars=false) ?(with_classes=true) ?submetas ~dep (indarg, typ
   let pred = meta_instance env (create_meta_instance_subst sigma) (mk_freelisted (mkMeta mvP)) in
 
   (* Build the case node proper *)
-  let case = build_case_analysis env sigma (ind, u) params pred dep s in
+  let case = build_case_analysis env sigma (ind, u) params pred indices indarg dep s in
   let fold (sigma, subst, metas) t =
     let mv = new_meta () in
     let sigma = meta_declare mv t sigma in
     (sigma, mkMeta mv :: subst, mv :: metas)
   in
   let (sigma, subst, args) = Array.fold_left fold (sigma, [], []) case.case0_branches in
-  let indexsubst = subst_of_rel_context_instance case.case0_arity depargs in
-  let subst = indexsubst @ subst in
   let templval = Vars.substl subst case.case0_body in
   let metaset = Metaset.of_list (mvP :: args) in
 

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -913,12 +913,6 @@ let case_pf ?with_evars ?with_classes ?submetas ~dep (indarg, typ) =
   let env = Proofview.Goal.env gl in
   let sigma = Proofview.Goal.sigma gl in
   let concl = Proofview.Goal.concl gl in
-  let hd, args = decompose_app_vect sigma typ in
-  let ind, u = destInd sigma hd in
-  let s = Retyping.get_sort_family_of env sigma concl in
-  let (mib, mip) = Inductive.lookup_mind_specif env ind in
-  let params, indices = Array.chop mib.mind_nparams args in
-  let (sigma, case) = build_case_analysis env sigma (ind, EInstance.kind sigma u) params dep s in
   let sigma = clear_metas sigma in
   let sigma, indarg = match submetas with
   | None -> sigma, indarg
@@ -927,19 +921,30 @@ let case_pf ?with_evars ?with_classes ?submetas ~dep (indarg, typ) =
     let indarg = applist (indarg, List.map (fun (m, _) -> mkMeta m) metas) in
     sigma, indarg
   in
+  let hd, args = decompose_app_vect sigma typ in
   (* Workaround to #5645: reduce_to_atomic_ind produces ill-typed terms *)
   let sigma, _ = Typing.checked_appvect env sigma hd args in
-  let typP = case.case0_pred in
+  let ind, u = destInd sigma hd in
+  let u = EInstance.kind sigma u in
+  let s = Retyping.get_sort_family_of env sigma concl in
+  let (mib, mip) = Inductive.lookup_mind_specif env ind in
+  let params, indices = Array.chop mib.mind_nparams args in
+  let sigma, typP =
+    let (sigma, s) = Evd.fresh_sort_in_family ~rigid:Evd.univ_flexible_alg sigma s in
+    let params = EConstr.Unsafe.to_constr_array params in
+    let indf = Inductiveops.make_ind_family ((ind, u), Array.to_list params) in
+    let typP = Inductiveops.make_arity env sigma dep indf s in
+    sigma, typP
+  in
   let mvP = new_meta () in
   let sigma = meta_declare mvP typP sigma in
-  let subst0 = [mkMeta mvP] in
+  let case = build_case_analysis env sigma (ind, u) params (mkMeta mvP) dep s in
   let fold (sigma, subst, metas) t =
     let mv = new_meta () in
-    let t = substl subst0 t in
     let sigma = meta_declare mv t sigma in
     (sigma, mkMeta mv :: subst, mv :: metas)
   in
-  let (sigma, subst, args) = Array.fold_left fold (sigma, subst0, []) case.case0_branches in
+  let (sigma, subst, args) = Array.fold_left fold (sigma, [], []) case.case0_branches in
   let depargs = Array.append indices [|indarg|] in
   let indexsubst = subst_of_rel_context_instance case.case0_arity depargs in
   let subst = indexsubst @ subst in

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -880,7 +880,7 @@ let build_case_analysis env sigma (ind, u) params pred indices indarg branches d
   (* Assumes that the arguments do not contain free rels *)
   let indf = make_ind_family ((ind, EConstr.Unsafe.to_instance u), Array.map_to_list EConstr.Unsafe.to_constr params) in
   let projs = get_projections env ind in
-  let relevance = Sorts.relevance_of_sort_family knd in
+  let relevance = Sorts.relevance_of_sort knd in
 
   let pnas, deparsign =
     let arsign, sort = get_arity env indf in
@@ -951,11 +951,11 @@ let case_pf ?(with_evars=false) ?(with_classes=true) ?submetas ~dep (indarg, typ
   let sigma, _ = Typing.checked_appvect env sigma hd args in
   let ind, u = destInd sigma hd in
   let u0 = EInstance.kind sigma u in
-  let s = Retyping.get_sort_family_of env sigma concl in
+  let s = ESorts.kind sigma @@ Retyping.get_sort_of env sigma concl in
   let (mib, mip) = Inductive.lookup_mind_specif env ind in
   let params, indices = Array.chop mib.mind_nparams args in
 
-  let () = Indrec.check_valid_elimination env (ind, u0) ~dep s in
+  let () = Indrec.check_valid_elimination env (ind, u0) ~dep (Sorts.family s) in
 
   let indf =
     let params = EConstr.Unsafe.to_constr_array params in
@@ -963,8 +963,7 @@ let case_pf ?(with_evars=false) ?(with_classes=true) ?submetas ~dep (indarg, typ
   in
 
   (* Extract the return clause using unification with the conclusion *)
-  let (sigma, sort) = Evd.fresh_sort_in_family ~rigid:Evd.univ_flexible_alg sigma s in
-  let typP = Inductiveops.make_arity env sigma dep indf sort in
+  let typP = Inductiveops.make_arity env sigma dep indf (ESorts.make s) in
   let mvP = new_meta () in
   let sigma = meta_declare mvP typP sigma in
   let depargs = Array.append indices [|indarg|] in

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -795,7 +795,20 @@ let std_refine env sigma cl r =
 (* find appropriate names for pattern variables. Useful in the Case
    and Inversion (case_then_using et case_nodep_then_using) tactics. *)
 
-let is_predicate_explicitly_dep pnas =
+let set_pattern_names env sigma ind brv =
+  let (mib,mip) = Inductive.lookup_mind_specif env ind in
+  let set_names i brty =
+    let open EConstr in
+    let (ctxt, cl) = decompose_prod_n_decls sigma mip.mind_consnrealdecls.(i) brty in
+    Namegen.it_mkProd_or_LetIn_name env sigma cl ctxt
+  in
+  Array.mapi set_names brv
+
+let type_case_branches_with_names env sigma ~dep (ind, u) pms (pnas, p) =
+  let specif = Inductive.lookup_mind_specif env ind in
+  let pctx = Inductive.expand_arity specif (ind, u) pms pnas in
+  let lbrty = Inductive.build_branches_type (ind, u) specif (Array.to_list pms) (Term.it_mkLambda_or_LetIn p pctx) in
+  let lbrty = Array.map EConstr.of_constr lbrty in
   (* The following code has an impact on the introduction names
     given by the tactics "case" and "inversion": when the
     elimination is not dependent, "case" uses Anonymous for
@@ -807,45 +820,16 @@ let is_predicate_explicitly_dep pnas =
     whether the predicate created in Indrec.make_case_com had a
     dependent arity or not. To avoid different predicates
     printed the same in v8, all predicates built in indrec.ml
-    got a dependent arity (Aug 2004). The new way to decide
-    whether names have to be created or not is to use an
-    Anonymous or Named variable to enforce the expected
-    dependency status (of course, Anonymous implies non
-    dependent, but not conversely).
+    got a dependent arity (Aug 2004). *)
+  if dep then set_pattern_names env sigma ind lbrty else lbrty
 
-    From Coq > 8.2, using or not the effective dependency of
-    the predicate is parametrable! *)
-    let na = Array.last pnas in
-    match na.binder_name with
-    | Anonymous -> false
-    | Name _ -> true
-
-let set_pattern_names env sigma ind brv =
-  let (mib,mip) = Inductive.lookup_mind_specif env ind in
-  let set_names i brty =
-    let open EConstr in
-    let (ctxt, cl) = decompose_prod_n_decls sigma mip.mind_consnrealdecls.(i) brty in
-    Namegen.it_mkProd_or_LetIn_name env sigma cl ctxt
-  in
-  Array.mapi set_names brv
-
-let type_case_branches_with_names env sigma (ind, u) pms (pnas, p) =
-  let specif = Inductive.lookup_mind_specif env ind in
-  let pctx = Inductive.expand_arity specif (ind, u) pms pnas in
-  let lbrty = Inductive.build_branches_type (ind, u) specif (Array.to_list pms) (Term.it_mkLambda_or_LetIn p pctx) in
-  let lbrty = Array.map EConstr.of_constr lbrty in
-  (* Adjust names *)
-  if is_predicate_explicitly_dep pnas then
-    (set_pattern_names env sigma ind lbrty)
-  else lbrty
-
-let case_refine env sigma cl r = match Constr.kind (EConstr.Unsafe.to_constr r) with
+let case_refine env sigma ~dep cl r = match Constr.kind (EConstr.Unsafe.to_constr r) with
 | Case (ci, u, pms, p, iv, c, lf) ->
   let indu = (ci.ci_ind, u) in
   let c = make_proof env sigma (EConstr.of_constr c) in
   let () = if Array.exists (fun c -> occur_meta sigma (EConstr.of_constr c)) pms then error_unsupported_deep_meta () in
   let (acc',ct,sigma,c') = mk_refgoals env sigma [] None c in
-  let lbrty = type_case_branches_with_names env sigma indu pms p in
+  let lbrty = type_case_branches_with_names env sigma ~dep indu pms p in
   let (acc'',sigma,rbranches) = treat_case env sigma ci lbrty lf acc' in
   let lf' = Array.rev_of_list rbranches in
   let ans = mkCase (ci, u, pms, p, iv, EConstr.Unsafe.to_constr c', lf') in
@@ -856,20 +840,25 @@ let case_refine env sigma cl r = match Constr.kind (EConstr.Unsafe.to_constr r) 
      - Or when the case node reduced because its scrutinee was a constructor *)
   std_refine env sigma cl r
 
+type refiner_kind =
+| Std
+| Case of bool
+
 let refiner_gen is_case clenv =
   let open Proofview.Notations in
-  let r = clenv_value clenv in
   Proofview.Goal.enter begin fun gl ->
   let sigma = Proofview.Goal.sigma gl in
   let env = Proofview.Goal.env gl in
   let st = Proofview.Goal.state gl in
   let cl = Proofview.Goal.concl gl in
   let sigma = Evd.meta_merge (Evd.meta_list clenv.evd) sigma in
-  let (sigma, sgl, c) =
-    if is_case then
-      case_refine env sigma cl r
-    else
-      std_refine env sigma cl r
+  let (sigma, sgl, c) = match is_case with
+  | Case dep ->
+    let r = clenv_value clenv in
+    case_refine env sigma ~dep cl r
+  | Std ->
+    let r = clenv_value clenv in
+    std_refine env sigma cl r
   in
   let sigma = Evd.clear_metas sigma in
   let map gl = Proofview.goal_with_state gl st in
@@ -885,7 +874,7 @@ let refiner_gen is_case clenv =
   Proofview.Unsafe.tclSETGOALS sgl
   end
 
-let refiner clenv = refiner_gen false clenv
+let refiner clenv = refiner_gen Std clenv
 
 end
 
@@ -916,7 +905,7 @@ let res_pf_gen is_case ?(with_evars=false) ?(with_classes=true) ?(flags=dft ()) 
   end
 
 let res_pf ?with_evars ?with_classes ?flags clenv =
-  res_pf_gen false ?with_evars ?with_classes ?flags clenv
+  res_pf_gen Std ?with_evars ?with_classes ?flags clenv
 
 let case_pf ?with_evars ?with_classes ?submetas ~dep (indarg, typ) =
   let open Indrec in
@@ -966,7 +955,7 @@ let case_pf ?with_evars ?with_classes ?submetas ~dep (indarg, typ) =
     metas = [];
     cache = create_meta_instance_subst sigma;
   } in
-  res_pf_gen true ?with_evars ?with_classes ~flags:(elim_flags ()) clenv
+  res_pf_gen (Case dep) ?with_evars ?with_classes ~flags:(elim_flags ()) clenv
   end
 
 (* [unifyTerms] et [unify] ne semble pas gérer les Meta, en

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -931,7 +931,7 @@ let case_pf ?(with_evars=false) ?(with_classes=true) ?submetas ~dep (indarg, typ
   let (mib, mip) = Inductive.lookup_mind_specif env ind in
   let params, indices = Array.chop mib.mind_nparams args in
 
-  let () = check_valid_elimination env (ind, u) s in
+  let () = check_valid_elimination env (ind, u) ~dep s in
 
   (* Extract the return clause using unification with the conclusion *)
   let (sigma, sort) = Evd.fresh_sort_in_family ~rigid:Evd.univ_flexible_alg sigma s in

--- a/proofs/clenv.mli
+++ b/proofs/clenv.mli
@@ -85,7 +85,7 @@ val unify : ?flags:unify_flags -> constr -> unit Proofview.tactic
 val res_pf : ?with_evars:bool -> ?with_classes:bool -> ?flags:unify_flags -> clausenv -> unit Proofview.tactic
 val case_pf : ?with_evars:bool -> ?with_classes:bool ->
   ?submetas:(metavariable * clbinding) list ->
-  Indrec.case_analysis -> (constr * types) -> unit Proofview.tactic
+  dep:bool -> (constr * types) -> unit Proofview.tactic
 
 val clenv_pose_dependent_evars : ?with_evars:bool -> clausenv -> clausenv
 

--- a/tactics/elim.ml
+++ b/tactics/elim.ml
@@ -18,7 +18,6 @@ open Tacmach
 open Tacticals
 open Clenv
 open Tactics
-open Proofview.Notations
 
 type elim_kind = Case of bool | Elim
 
@@ -32,10 +31,7 @@ let general_elim_using mk_elim (ind, u, args) id =
     let flags = Unification.elim_flags () in
     match mk_elim with
     | Case dep ->
-      let u_ = EInstance.kind sigma u in
-      let (sigma, c) = Indrec.build_case_analysis_scheme env sigma (ind, u_) dep sort in
-      Proofview.Unsafe.tclEVARS sigma <*>
-      Clenv.case_pf c (mkVar id, mkApp (mkIndU (ind, u), args))
+      Clenv.case_pf ~dep (mkVar id, mkApp (mkIndU (ind, u), args))
     | Elim ->
       let gr = Indrec.lookup_eliminator env ind sort in
       let sigma, elim = Evd.fresh_global env sigma gr in

--- a/tactics/elim.ml
+++ b/tactics/elim.ml
@@ -23,24 +23,23 @@ type elim_kind = Case of bool | Elim
 
 (* Find the right elimination suffix corresponding to the sort of the goal *)
 (* c should be of type A1->.. An->B with B an inductive definition *)
-let general_elim_using mk_elim (ind, u, args) id =
+let general_elim_using mk_elim (ind, u, args) id = match mk_elim with
+| Case dep ->
+  Clenv.case_pf ~dep (mkVar id, mkApp (mkIndU (ind, u), args))
+| Elim ->
   Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
     let sigma = Proofview.Goal.sigma gl in
     let sort = Retyping.get_sort_family_of env sigma (Proofview.Goal.concl gl) in
     let flags = Unification.elim_flags () in
-    match mk_elim with
-    | Case dep ->
-      Clenv.case_pf ~dep (mkVar id, mkApp (mkIndU (ind, u), args))
-    | Elim ->
-      let gr = Indrec.lookup_eliminator env ind sort in
-      let sigma, elim = Evd.fresh_global env sigma gr in
-      let elimt = Retyping.get_type_of env sigma elim in
-      (* applying elimination_scheme just a little modified *)
-      let elimclause = mk_clenv_from env sigma (elim, elimt) in
-      let indmv = List.last (clenv_arguments elimclause) in
-      let elimclause = clenv_instantiate indmv elimclause (mkVar id, mkApp (mkIndU (ind, u), args)) in
-      Clenv.res_pf ~flags elimclause
+    let gr = Indrec.lookup_eliminator env ind sort in
+    let sigma, elim = Evd.fresh_global env sigma gr in
+    let elimt = Retyping.get_type_of env sigma elim in
+    (* applying elimination_scheme just a little modified *)
+    let elimclause = mk_clenv_from env sigma (elim, elimt) in
+    let indmv = List.last (clenv_arguments elimclause) in
+    let elimclause = clenv_instantiate indmv elimclause (mkVar id, mkApp (mkIndU (ind, u), args)) in
+    Clenv.res_pf ~flags elimclause
   end
 
 (* computing the case/elim combinators *)

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1648,14 +1648,11 @@ let general_case_analysis_in_context with_evars clear_flag (c,lbindc) =
   let env = Proofview.Goal.env gl in
   let concl = Proofview.Goal.concl gl in
   let ct = Retyping.get_type_of env sigma c in
-  let mind, t = reduce_to_quantified_ind env sigma ct in
-  let sort = Tacticals.elimination_sort_of_goal gl in
-  let mind = on_snd (fun u -> EInstance.kind sigma u) mind in
-  let (sigma, case) =
-    if dependent sigma c concl then
-      build_case_analysis_scheme env sigma mind true sort
-    else
-      build_case_analysis_scheme_default env sigma mind sort in
+  let (mind, _), t = reduce_to_quantified_ind env sigma ct in
+  let dep =
+    if dependent sigma c concl then true
+    else default_case_analysis_dependence env mind
+  in
   let id = try Some (destVar sigma c) with DestKO -> None in
   let indclause = make_clenv_binding env sigma (c, t) lbindc in
   let metas = Evd.meta_list (clenv_evd indclause) in
@@ -1663,7 +1660,7 @@ let general_case_analysis_in_context with_evars clear_flag (c,lbindc) =
   let sigma = Evd.clear_metas (clenv_evd indclause) in
   Tacticals.tclTHENLIST [
     Proofview.Unsafe.tclEVARS sigma;
-    Clenv.case_pf ~with_evars ~with_classes:true ~submetas case (c, clenv_type indclause);
+    Clenv.case_pf ~with_evars ~with_classes:true ~submetas ~dep (c, clenv_type indclause);
     apply_clear_request clear_flag (use_clear_hyp_by_default ()) id;
   ]
   end
@@ -4549,11 +4546,11 @@ let induction_tac with_evars params indvars (elim, elimt) =
   Clenv.res_pf ~with_evars ~flags:(elim_flags ()) elimclause
   end
 
-let destruct_tac with_evars indvar case =
+let destruct_tac with_evars indvar dep =
   Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
   let ty = Typing.type_of_variable env indvar in
-  Clenv.case_pf ~with_evars case (mkVar indvar, ty)
+  Clenv.case_pf ~with_evars ~dep (mkVar indvar, ty)
   end
 
 (* Apply induction "in place" taking into account dependent
@@ -4581,11 +4578,9 @@ let apply_induction_in_context with_evars inhyps elim indvars names =
     | CaseOver (id, (mind, u)) ->
       let dep_in_concl = occur_var env sigma id concl in
       let dep = dep_in_hyps || dep_in_concl in
-      let u = EInstance.kind sigma u in
       let dep = dep || default_case_analysis_dependence env mind in
-      let (sigma, case) = build_case_analysis_scheme env sigma (mind, u) dep s in
       let indsign = compute_case_signature env mind dep id in
-      let tac = destruct_tac with_evars id case in
+      let tac = destruct_tac with_evars id dep in
       sigma, false, tac, indsign
     | ElimOver (isrec, id, (mind, u)) ->
       let sigma, ind = find_ind_eliminator env sigma mind s in
@@ -5055,12 +5050,9 @@ let case_type t =
   let sigma = Proofview.Goal.sigma gl in
   let env = Tacmach.pf_env gl in
   let ((ind, u), t) = reduce_to_atomic_ind env sigma t in
-  let u = EInstance.kind sigma u in
-  let s = Tacticals.elimination_sort_of_goal gl in
-  let (evd, elim) = build_case_analysis_scheme_default env sigma (ind, u) s in
+  let dep = default_case_analysis_dependence env ind in
   tclTHENLIST [
-    Proofview.Unsafe.tclEVARS evd;
-    Clenv.case_pf ~with_evars:false elim (mkVar id, t);
+    Clenv.case_pf ~with_evars:false ~dep (mkVar id, t);
     clear [id];
   ]
   end

--- a/test-suite/bugs/bug_17487_1.v
+++ b/test-suite/bugs/bug_17487_1.v
@@ -1,0 +1,32 @@
+Section Definitions.
+
+Variable A : Type.
+
+Fixpoint vector (n:nat) {struct n} : Type :=
+match n with
+| 0  => A
+| S n => (A * (vector n))%type
+end.
+
+End Definitions.
+
+Module Test.
+
+Parameter A : Type.
+
+Definition vectorA : nat -> Type.
+Proof.
+apply (vector A).
+Defined.
+
+(** Check that head normalization of vectorA to an inductive with refolding
+    correctly keeps universe constraints. See also #5645. *)
+Goal forall dim (v : vectorA (S dim)), True.
+Proof.
+intros dim.
+intros [a v].
+constructor.
+Qed. (* The 2nd term has type "Type@{vector.u0}" which should be coercible to "Type@{prod.u1}". *)
+
+
+End Test.

--- a/test-suite/bugs/bug_17487_2.v
+++ b/test-suite/bugs/bug_17487_2.v
@@ -1,0 +1,66 @@
+(* Potpourri of inconsistencies between intros [] and destruct and fringe behaviours w.r.t. dependent metas *)
+
+Goal forall (f : nat -> bool), True.
+Proof.
+intros [].
++ match goal with [ |- nat ] => exact 0 end.
++ match goal with [ |- True ] => exact I end.
++ match goal with [ |- True ] => exact I end.
+Qed.
+
+Goal forall (f : nat -> bool), True.
+Proof.
+intros f; destruct f.
++ match goal with [ |- nat ] => exact 0 end.
++ match goal with [ |- True ] => exact I end.
++ match goal with [ |- True ] => exact I end.
+Qed.
+
+
+Goal forall (f : nat -> bool), f = f.
+Proof.
+Fail intros [].
+Abort.
+
+Goal forall (f : nat -> bool), f = f.
+Proof.
+intros f; destruct f.
++ match goal with [ |- nat ] => exact 0 end.
++ match goal with [ |- f = f ] => reflexivity end.
++ match goal with [ |- f = f ] => reflexivity end.
+Qed.
+
+
+Goal forall (f : forall n : nat, 0 = n), True.
+Proof.
+intros [].
++ match goal with [ |- nat ] => exact 0 end.
++ match goal with [ |- True ] => exact I end.
+Qed.
+
+Goal forall (f : forall n : nat, 0 = n), True.
+Proof.
+Fail intros f; destruct f.
+Abort.
+
+
+Goal forall (f : forall n : nat, 0 = n), f = f.
+Proof.
+Fail intros [].
+Abort.
+
+Goal forall (f : forall n : nat, 0 = n), f = f.
+Proof.
+Fail intros f; destruct f.
+Abort.
+
+
+Goal forall (f : forall n : nat, n = 0), True.
+Proof.
+Fail intros [].
+Abort.
+
+Goal forall (f : forall n : nat, n = 0), True.
+Proof.
+Fail intros f; destruct f.
+Abort.

--- a/test-suite/output/PrintingParentheses.out
+++ b/test-suite/output/PrintingParentheses.out
@@ -6,7 +6,7 @@ nat_ind (fun n0 : nat => ((n0 * m) + n0) = (n0 * (S m)))
   (eq_refl : ((0 * m) + 0) = (0 * (S m)))
   (fun (p : nat) (H : ((p * m) + p) = (p * (S m))) =>
    (let n0 := p * (S m) in
-    match H in (_ = a) return (((m + (p * m)) + (S p)) = (S (m + a))) with
+    match H in (_ = n1) return (((m + (p * m)) + (S p)) = (S (m + n1))) with
     | eq_refl =>
         eq_ind (S ((m + (p * m)) + p))
           (fun n1 : nat => n1 = (S (m + ((p * m) + p))))


### PR DESCRIPTION
This makes explicit several hidden facts, like e.g. that we only depend on unification of the return clause.

Some fringe changes include:
- Name generation for anonymous bound variables in the return clause now rely on the type of the arity after substitution of parameters rather than with abstract parameters. This changes some names, but this shouldn't matter in practice apart from printing differences. (There is an output test that catches this in the test-suite).
- ~~Slight change of heuristics to decide when a meta in the scrutinee is dependent. This is a rarely used feature (i.e. case / destruct with ...) and the discrepancies should be even rarer.~~ No, this happens in practice through `intros []`, so I left it as is, but the current heuristic is concentrated nonsense. I'll tweak it in a different PR.