### PR TITLE
 Distinguish deprecation warnings on the "since" field

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/17489-deprecations.rst
+++ b/doc/changelog/08-vernac-commands-and-options/17489-deprecations.rst
@@ -1,0 +1,9 @@
+- **Changed:**
+  The names of deprecation warnings now depend on the version
+  in which they were introduced, using their "since" field.
+  This enables deprecation warnings to be selectively enabled,
+  disabled, or treated as an error, according to the version number
+  provided in the :attr:`deprecated` attribute
+  (`#17489 <https://github.com/coq/coq/pull/17489>`_,
+  fixes `#16287 <https://github.com/coq/coq/issues/16287>`_,
+  by Pierre Roux, reviewed by Ali Caglayan, Théo Zimmermann and Gaëtan Gilbert).

--- a/doc/sphinx/using/libraries/writing.rst
+++ b/doc/sphinx/using/libraries/writing.rst
@@ -19,7 +19,7 @@ deprecated compatibility alias using :cmd:`Notation (abbreviation)`
 
    At least one of :n:`since` or :n:`note` must be present.  If both
    are present, either one may appear first and they must be separated
-   by a comma.
+   by a comma. If :n:`since` is present, it will be used in the warning name.
 
    This attribute is supported by the following commands: :cmd:`Ltac`,
    :cmd:`Tactic Notation`, :cmd:`Notation`, :cmd:`Infix`, :cmd:`Ltac2`,
@@ -27,12 +27,12 @@ deprecated compatibility alias using :cmd:`Notation (abbreviation)`
 
    It can trigger the following warnings:
 
-   .. warn:: Tactic @qualid is deprecated since @string__since. @string__note.
-             Tactic Notation @qualid is deprecated since @string__since. @string__note.
-             Notation @string is deprecated since @string__since. @string__note.
-             Ltac2 definition @qualid is deprecated since @string__since. @string__note.
-             Ltac2 alias @qualid is deprecated since @string__since. @string__note.
-             Ltac2 notation {+ @ltac2_scope } is deprecated since @string__since. @string__note.
+   .. warn:: Tactic @qualid is deprecated since @string__since. @string__note
+             Tactic Notation @qualid is deprecated since @string__since. @string__note
+             Notation @string is deprecated since @string__since. @string__note
+             Ltac2 definition @qualid is deprecated since @string__since. @string__note
+             Ltac2 alias @qualid is deprecated since @string__since. @string__note
+             Ltac2 notation {+ @ltac2_scope } is deprecated since @string__since. @string__note
 
       :n:`@qualid` or :n:`@string` is the notation,
       :n:`@string__since` is the version number, :n:`@string__note` is

--- a/interp/abbreviation.ml
+++ b/interp/abbreviation.ml
@@ -117,7 +117,7 @@ let declare_abbreviation ~local ?(also_in_cases_pattern=true) deprecation id ~on
 let pr_abbreviation kn = pr_qualid (Nametab.shortest_qualid_of_abbreviation Id.Set.empty kn)
 
 let warn_deprecated_abbreviation =
-  Deprecation.create_warning ~object_name:"Notation" ~warning_name:"deprecated-syntactic-definition"
+  Deprecation.create_warning ~object_name:"Notation" ~warning_name_if_no_since:"deprecated-syntactic-definition"
     pr_abbreviation
 
 (* Remark: do not check for activation (if not activated, it is already not supposed to be located) *)

--- a/interp/deprecation.ml
+++ b/interp/deprecation.ml
@@ -12,10 +12,26 @@ type t = { since : string option ; note : string option }
 
 let make ?since ?note () = { since ; note }
 
-let create_warning ~object_name ~warning_name name_printer =
+let warn_deprecated ~object_name ~warning_name_if_no_since since name_printer =
   let open Pp in
-  CWarnings.create ~name:warning_name ~category:"deprecated"
-    (fun (qid,depr) -> str object_name ++ spc () ++ name_printer qid ++
+  let name =
+    let space_dash s = String.map (function ' ' -> '-' | c -> c) s in
+    Option.cata (fun s -> "deprecated-since-" ^ space_dash s)
+      warning_name_if_no_since since in
+  CWarnings.create ~name ~category:"deprecated"
+    (fun (qid, note) -> str object_name ++ spc () ++ name_printer qid ++
       strbrk " is deprecated" ++
-      pr_opt (fun since -> str "since " ++ str since) depr.since ++
-      str "." ++ pr_opt (fun note -> str note) depr.note)
+      pr_opt (fun since -> str "since " ++ str since) since ++
+      str "." ++ pr_opt (fun note -> str note) note)
+
+let create_warning ~object_name ~warning_name_if_no_since name_printer =
+  let h = Hashtbl.create 19 in
+  fun ?loc (qid, { since; note }) ->
+    let w =
+      try Hashtbl.find h since
+      with Not_found ->
+        let w = warn_deprecated ~object_name ~warning_name_if_no_since since
+                  name_printer in
+        Hashtbl.add h since w;
+        w in
+    w ?loc (qid, note)

--- a/interp/deprecation.mli
+++ b/interp/deprecation.mli
@@ -12,5 +12,5 @@ type t = { since : string option ; note : string option }
 
 val make : ?since:string -> ?note:string -> unit -> t
 
-val create_warning : object_name:string -> warning_name:string ->
+val create_warning : object_name:string -> warning_name_if_no_since:string ->
   ('b -> Pp.t) -> ?loc:Loc.t -> 'b * t -> unit

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1479,7 +1479,7 @@ let interp_prim_token_cases_pattern_expr ?loc looked_for p =
   interp_prim_token_gen ?loc (check_allowed_ref_in_pat looked_for) p
 
 let warn_deprecated_notation =
-  Deprecation.create_warning ~object_name:"Notation" ~warning_name:"deprecated-notation"
+  Deprecation.create_warning ~object_name:"Notation" ~warning_name_if_no_since:"deprecated-notation"
     pr_notation
 
 let interp_notation ?loc ntn local_scopes =

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -127,12 +127,13 @@ let intern_constr_reference strict ist qid =
 (* Internalize an isolated reference in position of tactic *)
 
 let warn_deprecated_tactic =
-  Deprecation.create_warning ~object_name:"Tactic" ~warning_name:"deprecated-tactic"
+  Deprecation.create_warning ~object_name:"Tactic"
+    ~warning_name_if_no_since:"deprecated-tactic"
     pr_qualid
 
 let warn_deprecated_alias =
   Deprecation.create_warning ~object_name:"Tactic Notation"
-    ~warning_name:"deprecated-tactic-notation"
+    ~warning_name_if_no_since:"deprecated-tactic-notation"
     Pptactic.pr_alias_key
 
 let intern_isolated_global_tactic_reference qid =

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -656,7 +656,7 @@ let rec get_rule (tok : scope_rule token list) : krule = match tok with
 let deprecated_ltac2_notation =
   Deprecation.create_warning
     ~object_name:"Ltac2 notation"
-    ~warning_name:"deprecated-ltac2-notation"
+    ~warning_name_if_no_since:"deprecated-ltac2-notation"
     (fun (toks : sexpr list) -> pr_sequence ParseToken.print_token toks)
 
 (* This is a hack to preserve the level 4 entry which is initially empty. The

--- a/plugins/ltac2/tac2intern.ml
+++ b/plugins/ltac2/tac2intern.ml
@@ -282,13 +282,13 @@ let is_user_name qid = match qid with
 let deprecated_ltac2_alias =
   Deprecation.create_warning
     ~object_name:"Ltac2 alias"
-    ~warning_name:"deprecated-ltac2-alias"
+    ~warning_name_if_no_since:"deprecated-ltac2-alias"
     (fun kn -> pr_qualid (Tac2env.shortest_qualid_of_ltac (TacAlias kn)))
 
 let deprecated_ltac2_def =
   Deprecation.create_warning
     ~object_name:"Ltac2 definition"
-    ~warning_name:"deprecated-ltac2-definition"
+    ~warning_name_if_no_since:"deprecated-ltac2-definition"
     (fun kn -> pr_qualid (Tac2env.shortest_qualid_of_ltac (TacConstant kn)))
 
 let check_deprecated_ltac2 ?loc qid def =

--- a/test-suite/output/Deprecation.out
+++ b/test-suite/output/Deprecation.out
@@ -1,3 +1,10 @@
 File "./output/Deprecation.v", line 5, characters 0-3:
 Warning: Tactic foo is deprecated since X.Y. Use idtac instead.
-[deprecated-tactic,deprecated]
+[deprecated-since-X.Y,deprecated]
+File "./output/Deprecation.v", line 17, characters 5-8:
+The command has indeed failed with message:
+Tactic foo is deprecated since X.Y. Use idtac instead.
+[deprecated-since-X.Y,deprecated]
+File "./output/Deprecation.v", line 24, characters 0-3:
+Warning: Tactic bar is deprecated since library X.Y. Use baz instead.
+[deprecated-since-library-X.Y,deprecated]

--- a/test-suite/output/Deprecation.v
+++ b/test-suite/output/Deprecation.v
@@ -4,3 +4,22 @@
 Goal True.
 foo.
 Abort.
+
+Set Warnings "-deprecated-since-X.Y".
+
+Goal True.
+foo.
+Abort.
+
+Set Warnings "+deprecated-since-X.Y".
+
+Goal True.
+Fail foo.
+Abort.
+
+#[deprecated(since = "library X.Y", note = "Use baz instead.")]
+ Ltac bar := idtac.
+
+Goal True.
+bar.
+Abort.


### PR DESCRIPTION
This was discussed in https://github.com/coq/coq/issues/16287 and is pretty convenient when handling deprecation warnings (usually one only wants to adress the deprecations corresponding to a specific version of a library when dropping support for that version, it is then convenient to turn only the warning for that version into errors and ignore the more recent warnings).

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes #16287  
<!-- Remove anything that doesn't apply in the following checklist. -->
<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [ ] ~Added / updated **documentation**.~
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] ~Documented any new / changed **user messages**.~
  - [ ] ~Updated **documented syntax** by running `make doc_gram_rsts`.~

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
