### PR TITLE
Renaming: update env instead of postprocessing

### DIFF
--- a/dev/ci/user-overlays/17497-SkySkimmer-rename-update-env.sh
+++ b/dev/ci/user-overlays/17497-SkySkimmer-rename-update-env.sh
@@ -1,0 +1,3 @@
+overlay elpi https://github.com/SkySkimmer/coq-elpi rename-update-env 17497
+
+overlay category_theory https://github.com/SkySkimmer/category-theory rename-update-env 17497

--- a/doc/changelog/08-vernac-commands-and-options/17497-rename-update-env.rst
+++ b/doc/changelog/08-vernac-commands-and-options/17497-rename-update-env.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  arguments renamed by :cmd:`Arguments` (including anonymous arguments which can be renamed without using `: rename`)
+  are now applied more consistently. This may break proof scripts which rely on some tactic incorrectly using the original names
+  (`#17497 <https://github.com/coq/coq/pull/17497>`_,
+  by Gaëtan Gilbert).

--- a/interp/arguments_renaming.mli
+++ b/interp/arguments_renaming.mli
@@ -9,15 +9,13 @@
 (************************************************************************)
 
 open Names
-open Environ
-open Constr
 
-val rename_arguments : bool -> GlobRef.t -> Name.t list -> unit
+val rename_arguments : local:bool -> GlobRef.t -> Name.t list -> unit
 
-(** [Not_found] is raised if no names are defined for [r] *)
 val arguments_names : GlobRef.t -> Name.t list
+(** May raise [Not_found].
 
-val rename_type : types -> GlobRef.t -> types
-
-val rename_typing : env -> constr -> unsafe_judgment
-(** Typechecks using the kernel [Typeops.infer] *)
+    Used by arguments in a dubious way: suppose constant [c] has type
+   [foo] which reduces to [forall x, ...]. If we rename to [y], the
+   type is not affected but the implicit argument system is, for
+   instance [c (y:=0)] works and [c (x:=0)] stops working.*)

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -413,3 +413,6 @@ val no_link_info : link_info
 
 (** Primitives *)
 val set_retroknowledge : env -> Retroknowledge.retroknowledge -> env
+
+(** Renaming *)
+val rename_ref : GlobRef.t -> Name.t list -> env -> env

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1578,3 +1578,6 @@ Would this be correct with respect to undo's and stuff ?
 let set_strategy k l e = { e with env =
    (Environ.set_oracle e.env
       (Conv_oracle.set_strategy (Environ.oracle e.env) k l)) }
+
+let rename_ref r names senv =
+  { senv with env = Environ.rename_ref r names senv.env }

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -269,3 +269,12 @@ val register_inductive : inductive -> 'a CPrimitives.prim_ind -> safe_transforme
 
 val set_strategy :
   Names.Constant.t Names.tableKey -> Conv_oracle.level -> safe_transformer0
+
+
+(** Rename in the type of the reference.
+
+    For variables this will impact the type of the values after
+   discharge, including those declared before the rename.
+
+    Otherwise forgotten after section or module end. *)
+val rename_ref : GlobRef.t -> Name.t list -> safe_transformer0

--- a/library/global.ml
+++ b/library/global.ml
@@ -220,3 +220,5 @@ let set_share_reduction b =
 
 let set_VM b = globalize0 (Safe_typing.set_VM b)
 let set_native_compiler b = globalize0 (Safe_typing.set_native_compiler b)
+
+let rename_ref r names = globalize0 (Safe_typing.rename_ref r names)

--- a/library/global.mli
+++ b/library/global.mli
@@ -184,3 +184,5 @@ val current_dirpath : unit -> DirPath.t
 val with_global : (Environ.env -> DirPath.t -> 'a Univ.in_universe_context_set) -> 'a
 
 val global_env_summary_tag : Safe_typing.safe_environment Summary.Dyn.tag
+
+val rename_ref : GlobRef.t -> Name.t list -> unit

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -27,29 +27,27 @@ open Context.Rel.Declaration
 let type_of_inductive env (ind,u) =
  let (mib,_ as specif) = Inductive.lookup_mind_specif env ind in
  Typeops.check_hyps_inclusion env (GlobRef.IndRef ind) mib.mind_hyps;
- let t = Inductive.type_of_inductive (specif,u) in
- Arguments_renaming.rename_type t (IndRef ind)
+ Inductive.type_of_inductive (specif,u)
 
 let e_type_of_inductive env sigma (ind,u) =
  let (mib,_ as specif) = Inductive.lookup_mind_specif env ind in
  Reductionops.check_hyps_inclusion env sigma (GlobRef.IndRef ind) mib.mind_hyps;
  let t = Inductive.type_of_inductive (specif, EConstr.Unsafe.to_instance u) in
- EConstr.of_constr (Arguments_renaming.rename_type t (IndRef ind))
+ EConstr.of_constr t
 
 (* Return type as quoted by the user *)
 let type_of_constructor env (cstr,u) =
  let (mib,_ as specif) =
    Inductive.lookup_mind_specif env (inductive_of_constructor cstr) in
  Typeops.check_hyps_inclusion env (GlobRef.ConstructRef cstr) mib.mind_hyps;
- let t = Inductive.type_of_constructor (cstr,u) specif in
- Arguments_renaming.rename_type t (ConstructRef cstr)
+ Inductive.type_of_constructor (cstr,u) specif
 
 let e_type_of_constructor env sigma (cstr,u) =
  let (mib,_ as specif) =
    Inductive.lookup_mind_specif env (inductive_of_constructor cstr) in
  Reductionops.check_hyps_inclusion env sigma (GlobRef.ConstructRef cstr) mib.mind_hyps;
  let t = Inductive.type_of_constructor (cstr,EConstr.Unsafe.to_instance u) specif in
- EConstr.of_constr (Arguments_renaming.rename_type t (ConstructRef cstr))
+ EConstr.of_constr t
 
 (* Return constructor types in user form *)
 let type_of_constructors env (ind,u as indu) =

--- a/pretyping/retyping.ml
+++ b/pretyping/retyping.ml
@@ -24,7 +24,6 @@ open Environ
 open Termops
 open EConstr
 open Vars
-open Arguments_renaming
 open Context.Rel.Declaration
 
 module RelDecl = Context.Rel.Declaration
@@ -130,7 +129,7 @@ let type_of_constant env sigma (c,u) =
   let cb = lookup_constant c env in
   let () = check_hyps_inclusion env sigma (GlobRef.ConstRef c) cb.const_hyps in
   let ty = CVars.subst_instance_constr (EConstr.Unsafe.to_instance u) cb.const_type in
-  EConstr.of_constr (rename_type ty (GlobRef.ConstRef c))
+  EConstr.of_constr ty
 
 let retype ?(polyprop=true) sigma =
   let rec type_of env cstr =

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -23,7 +23,6 @@ open Reductionops
 open Inductive
 open Inductiveops
 open Typeops
-open Arguments_renaming
 open Pretype_errors
 open Context.Rel.Declaration
 
@@ -363,7 +362,7 @@ let type_of_constant env sigma (c,u) =
   let u = EInstance.kind sigma u in
   let ty, csts = Environ.constant_type env (c,u) in
   let sigma = Evd.add_constraints sigma csts in
-  sigma, (EConstr.of_constr (rename_type ty (GR.ConstRef c)))
+  sigma, (EConstr.of_constr ty)
 
 let type_of_inductive env sigma (ind,u) =
   let open Declarations in
@@ -372,7 +371,7 @@ let type_of_inductive env sigma (ind,u) =
   let u = EInstance.kind sigma u in
   let ty, csts = Inductive.constrained_type_of_inductive (specif,u) in
   let sigma = Evd.add_constraints sigma csts in
-  sigma, (EConstr.of_constr (rename_type ty (GR.IndRef ind)))
+  sigma, (EConstr.of_constr ty)
 
 let type_of_constructor env sigma ((ind,_ as ctor),u) =
   let open Declarations in
@@ -381,7 +380,7 @@ let type_of_constructor env sigma ((ind,_ as ctor),u) =
   let u = EInstance.kind sigma u in
   let ty, csts = Inductive.constrained_type_of_constructor (ctor,u) specif in
   let sigma = Evd.add_constraints sigma csts in
-  sigma, (EConstr.of_constr (rename_type ty (GR.ConstructRef ctor)))
+  sigma, (EConstr.of_constr ty)
 
 let judge_of_int env v =
   Environ.on_judgment EConstr.of_constr (judge_of_int env v)

--- a/test-suite/bugs/bug_17497_1.v
+++ b/test-suite/bugs/bug_17497_1.v
@@ -1,0 +1,41 @@
+
+Axiom proof_admitted : False.
+Tactic Notation "admit" := abstract case proof_admitted.
+Module Export Logic.
+
+  Set Universe Polymorphism.
+
+  Inductive Empty : Set :=.
+
+  Cumulative Inductive Id@{i} {A : Type@{i}} (a : A) : A -> Type@{i} :=
+    id_refl : Id a a.
+
+  Module Export Id_Notations.
+    Notation " x = y " := (@Id _ x y) : type_scope.
+  End Id_Notations.
+
+  Cumulative Inductive sum@{i} (X : Type@{i}) (B : Type@{i}) :=
+  | inl : X -> X + B
+  | inr : B -> X + B
+  where " A + B " := (sum A B) : type_scope.
+  Arguments inr{A} {B} _  : rename.
+
+End Logic.
+
+Class EqDec@{i|Set <= i} (A : Type@{i}) := eq_dec : forall x y : A, sum@{i} (x = y) (x = y -> Empty).
+Universe  i.
+Context {A : Type@{i}} `{EqDec A}.
+
+Variable x : A.
+Let nu {y:A} (u:x = y) : x = y.
+  admit.
+Defined.
+
+Let nu_constant : forall (y:A) (u v:x = y), nu u = nu v.
+  intros.
+  unfold nu in |- *.
+  case (eq_dec x y).
+  admit.
+  intros.
+  Check e : x=y -> Empty.
+Abort.

--- a/test-suite/coqchk/bug_17497_1.v
+++ b/test-suite/coqchk/bug_17497_1.v
@@ -1,0 +1,8 @@
+Set Primitive Projections.
+Section S.
+
+Record Foo := B { f : Type; g : f = f }.
+
+Global Arguments B c _ : rename.
+
+End S.

--- a/test-suite/output/Arguments_renaming.out
+++ b/test-suite/output/Arguments_renaming.out
@@ -41,7 +41,7 @@ fix myplus (T : Type) (t : T) (n m : nat) {struct n} : nat :=
   | 0 => m
   | S n' => S (myplus T t n' m)
   end
-     : forall T : Type, T -> nat -> nat -> nat
+     : forall Z : Type, Z -> nat -> nat -> nat
 
 Arguments myplus {Z}%type_scope !t (!n m)%nat_scope
   (where some original arguments have been renamed)
@@ -76,7 +76,7 @@ fix myplus (T : Type) (t : T) (n m : nat) {struct n} : nat :=
   | 0 => m
   | S n' => S (myplus T t n' m)
   end
-     : forall T : Type, T -> nat -> nat -> nat
+     : forall Z : Type, Z -> nat -> nat -> nat
 
 Arguments myplus {Z}%type_scope !t (!n m)%nat_scope
   (where some original arguments have been renamed)

--- a/theories/Init/Datatypes.v
+++ b/theories/Init/Datatypes.v
@@ -185,7 +185,7 @@ Inductive option (A:Type) : Type :=
   | Some : A -> option A
   | None : option A.
 
-Arguments Some {A} a.
+Arguments Some {A} _.
 Arguments None {A}.
 
 Register option as core.option.type.
@@ -293,7 +293,7 @@ Inductive list (A : Type) : Type :=
  | cons : A -> list A -> list A.
 
 Arguments nil {A}.
-Arguments cons {A} a l.
+Arguments cons {A} _ _.
 
 Declare Scope list_scope.
 Delimit Scope list_scope with list.

--- a/vernac/comArguments.ml
+++ b/vernac/comArguments.ml
@@ -271,7 +271,7 @@ let vernac_arguments ~section_local reference args more_implicits flags =
   (* Actions *)
 
   if renaming_specified then begin
-    Arguments_renaming.rename_arguments section_local sr names
+     Arguments_renaming.rename_arguments ~local:section_local sr names
   end;
 
   if scopes_specified || clear_scopes_flag then begin

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -64,7 +64,6 @@ let print_ref reduce ref udecl =
       let ctx,ccl = Reductionops.whd_decompose_prod_decls env sigma (EConstr.of_constr typ)
       in EConstr.to_constr sigma (EConstr.it_mkProd_or_LetIn ccl ctx)
     else typ in
-  let typ = Arguments_renaming.rename_type typ ref in
   let impargs = select_stronger_impargs (implicits_of_global ref) in
   let impargs = List.map binding_kind_of_status impargs in
   let variance = let open GlobRef in match ref with

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1875,7 +1875,7 @@ let check_may_eval env sigma redexp rc =
     else
       let c = EConstr.to_constr sigma c in
       (* OK to call kernel which does not support evars *)
-      Environ.on_judgment EConstr.of_constr (Arguments_renaming.rename_typing env c)
+      Environ.on_judgment EConstr.of_constr (Typeops.infer env c)
   in
   let sigma, c = match redexp with
     | None -> sigma, c


### PR DESCRIPTION
The basic idea of this PR is that names are already in the kernel, it makes no sense to have a second layer of renaming.

This means people can look at the result of lookup_constant or constant_type_in without worrying about getting incorrect names.

We also get to move arguments_renaming up to interp.

test suite broken: renaming an anonymous argument then making it implicit is accepted (with non-investigated consequences)
+ output changes as About now prints the renamed arguments, not the original

(Attempting https://github.com/coq/coq/pull/11298 again)

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/455
- https://github.com/jwiegley/category-theory/pull/125