### PR TITLE
Turn "algebraic on the right" error into regular univ inconsistency

### DIFF
--- a/dev/ci/user-overlays/17505-SkySkimmer-alg-on-right.sh
+++ b/dev/ci/user-overlays/17505-SkySkimmer-alg-on-right.sh
@@ -1,0 +1,1 @@
+overlay serapi https://github.com/SkySkimmer/coq-serapi alg-on-right 17505

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -285,8 +285,9 @@ let drop_weak_constraints =
     ~key:["Cumulativity";"Weak";"Constraints"]
     ~value:false
 
-let sort_inconsistency cst l r =
-  raise (UGraph.UniverseInconsistency (cst, l, r, None))
+let sort_inconsistency ?explain cst l r =
+  let explain = Option.map (fun p -> UGraph.Other p) explain in
+  raise (UGraph.UniverseInconsistency (cst, l, r, explain))
 
 let level_inconsistency cst l r =
   let mk u = Sorts.sort_of_univ @@ Universe.make u in
@@ -490,7 +491,9 @@ let process_universe_constraints uctx cstrs =
       begin match classify r with
       | UAlgebraic _ | UMax _ ->
         if UGraph.check_leq_sort univs l r then local
-        else user_err Pp.(str "Algebraic universe on the right")
+        else
+          sort_inconsistency Le l r
+            ~explain:(Pp.str "(cannot handle algebraic on the right)")
       | USmall r' ->
         (* Invariant: there are no universes u <= Set in the graph. Except for
            template levels, Set <= u anyways. Otherwise, for template

--- a/kernel/uGraph.mli
+++ b/kernel/uGraph.mli
@@ -43,7 +43,11 @@ val check_eq_instances : Instance.t check_function
   universes graph. It raises the exception [UniverseInconsistency] if the
   constraints are not satisfiable. *)
 
-type explanation
+type path_explanation
+
+type explanation =
+  | Path of path_explanation
+  | Other of Pp.t
 
 type univ_inconsistency = constraint_type * Sorts.t * Sorts.t * explanation option
 


### PR DESCRIPTION
The error message will say something like "cannot enforce x <= y+1" which is true.

Fix #17464

Overlays:
- https://github.com/ejgallego/coq-serapi/pull/330