### PR TITLE
rewrite strategies: expose fixpoint operator

### DIFF
--- a/doc/sphinx/addendum/generalized-rewriting.rst
+++ b/doc/sphinx/addendum/generalized-rewriting.rst
@@ -835,6 +835,8 @@ are applied using the tactic :n:`rewrite_strat @rewstrategy`.
    | terms {* @one_term }
    | eval @red_expr
    | fold @one_term
+   | using @ident
+   | fix @ident := @rewstrategy end
    | ( @rewstrategy )
    | old_hints @ident
 
@@ -907,6 +909,13 @@ are applied using the tactic :n:`rewrite_strat @rewstrategy`.
 :n:`fold @term`
    unify
 
+:n:`using @ident`
+   run a strategy bound by `fix` to the :n:`@ident`
+
+:n:`fix @ident := @rewstrategy end`
+   fixpoint operator. Note that the bound :n:`ident` must be used through `using`,
+   i.e. `fix x := x end` is the same as `x` interpreted as a :n:`@one_term`.
+
 :n:`( @rewstrategy )`
    to be documented
 
@@ -914,16 +923,15 @@ are applied using the tactic :n:`rewrite_strat @rewstrategy`.
    to be documented
 
 
-Conceptually, a few of these are defined in terms of the others using a
-primitive fixpoint operator `fix`, which the tactic doesn't currently support:
+Conceptually, a few of these are defined in terms of the others:
 
 - :n:`try @rewstrategy := choice @rewstrategy id`
-- :n:`any @rewstrategy := fix @ident. try (@rewstrategy ; @ident)`
+- :n:`any @rewstrategy := fix @ident := try (@rewstrategy ; using @ident)`
 - :n:`repeat @rewstrategy := @rewstrategy; any @rewstrategy`
-- :n:`bottomup @rewstrategy := fix @ident. (choice (progress (subterms @ident)) @rewstrategy) ; try @ident`
-- :n:`topdown @rewstrategy := fix @ident. (choice @rewstrategy (progress (subterms @ident))) ; try @ident`
-- :n:`innermost @rewstrategy := fix @ident. (choice (subterm @ident) @rewstrategy)`
-- :n:`outermost @rewstrategy := fix @ident. (choice @rewstrategy (subterm @ident))`
+- :n:`bottomup @rewstrategy := fix @ident := (choice (progress (subterms (using @ident))) @rewstrategy) ; try (using @ident)`
+- :n:`topdown @rewstrategy := fix @ident := (choice @rewstrategy (progress (subterms (using @ident)))) ; try (using @ident)`
+- :n:`innermost @rewstrategy := fix @ident := (choice (subterm (using @ident)) @rewstrategy)`
+- :n:`outermost @rewstrategy := fix @ident := (choice @rewstrategy (subterm (using @ident)))`
 
 The basic control strategy semantics are straightforward: strategies
 are applied to subterms of the term to rewrite, starting from the root

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -2296,6 +2296,8 @@ rewstrategy: [
 | "terms" LIST0 constr
 | "eval" red_expr
 | "fold" constr
+| "using" identref
+| "fix" identref ":=" rewstrategy "end"
 ]
 
 int_or_var: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -2142,6 +2142,8 @@ rewstrategy: [
 | "terms" LIST0 one_term
 | "eval" red_expr
 | "fold" one_term
+| "using" ident
+| "fix" ident ":=" rewstrategy "end"
 | "(" rewstrategy ")"
 | "old_hints" ident
 ]

--- a/plugins/ltac/g_rewrite.mlg
+++ b/plugins/ltac/g_rewrite.mlg
@@ -66,35 +66,26 @@ END
 
 {
 
-type raw_strategy = (constr_expr, Tacexpr.raw_red_expr) strategy_ast
-type glob_strategy = (glob_constr_and_expr, Tacexpr.glob_red_expr) strategy_ast
-
-let interp_strategy ist env sigma s =
-  let interp_redexpr r = fun env sigma -> Tacinterp.interp_red_expr ist env sigma r in
-  let interp_constr c = (fst c, fun env sigma -> Tacinterp.interp_open_constr ist env sigma c) in
-  let s = map_strategy interp_constr interp_redexpr s in
-  strategy_of_ast s
-
-let glob_strategy ist s = map_strategy (Tacintern.intern_constr ist) (Tacintern.intern_red_expr ist) s
+(** XXX this seems incorrect? *)
 let subst_strategy s str = str
 
 let pr_strategy _ _ _ (s : strategy) = Pp.str "<strategy>"
-let pr_raw_strategy env sigma prc prlc _ (s : raw_strategy) =
+let pr_raw_strategy env sigma prc prlc _ (s : Tacexpr.raw_strategy) =
   let prr = Pptactic.pr_red_expr env sigma (prc, prlc, Pputils.pr_or_by_notation Libnames.pr_qualid, prc) in
-  Rewrite.pr_strategy (prc env sigma) prr s
-let pr_glob_strategy env sigma prc prlc _ (s : glob_strategy) =
+  Rewrite.pr_strategy (prc env sigma) prr Pputils.pr_lident s
+let pr_glob_strategy env sigma prc prlc _ (s : Tacexpr.glob_strategy) =
   let prpat env sigma (_,c,_) = prc env sigma c in
   let prcst = Pputils.pr_or_var Pptactic.(pr_and_short_name (pr_evaluable_reference_env env)) in
   let prr = Pptactic.pr_red_expr env sigma (prc, prlc, prcst, prpat) in
-  Rewrite.pr_strategy (prc env sigma) prr s
+  Rewrite.pr_strategy (prc env sigma) prr Id.print s
 
 }
 
 ARGUMENT EXTEND rewstrategy
     PRINTED BY { pr_strategy }
 
-    INTERPRETED BY { interp_strategy }
-    GLOBALIZED BY { glob_strategy }
+    INTERPRETED BY { Tacinterp.interp_strategy }
+    GLOBALIZED BY { Tacintern.intern_strategy }
     SUBSTITUTED BY { subst_strategy }
 
     RAW_PRINTED BY { pr_raw_strategy env sigma }
@@ -123,6 +114,8 @@ ARGUMENT EXTEND rewstrategy
   | [ "terms" constr_list(h) ] -> { StratTerms h }
   | [ "eval" red_expr(r) ] -> { StratEval r }
   | [ "fold" constr(c) ] -> { StratFold c }
+  | [ "using" identref(id) ] -> { StratVar id }
+  | [ "fix" identref(id) ":=" rewstrategy(s) "end" ] -> { StratFix (id,s) }
 END
 
 (* By default the strategy for "rewrite_db" is top-down *)

--- a/plugins/ltac/g_rewrite.mli
+++ b/plugins/ltac/g_rewrite.mli
@@ -27,18 +27,10 @@ val wit_glob_constr_with_bindings :
 val glob_constr_with_bindings :
   constr_expr_with_bindings Pcoq.Entry.t
 
-type raw_strategy =
-    (Constrexpr.constr_expr, Tacexpr.raw_red_expr)
-    Rewrite.strategy_ast
-
-type glob_strategy =
-    (Genintern.glob_constr_and_expr, Tacexpr.glob_red_expr)
-    Rewrite.strategy_ast
-
 val wit_rewstrategy :
-  (raw_strategy, glob_strategy, Rewrite.strategy) Genarg.genarg_type
+  (Tacexpr.raw_strategy, Tacexpr.glob_strategy, Rewrite.strategy) Genarg.genarg_type
 
-val rewstrategy : raw_strategy Pcoq.Entry.t
+val rewstrategy : Tacexpr.raw_strategy Pcoq.Entry.t
 
 type binders_argtype = Constrexpr.local_binder_expr list
 

--- a/plugins/ltac/pptactic.mli
+++ b/plugins/ltac/pptactic.mli
@@ -156,7 +156,6 @@ val pr_match_rule : bool -> ('a -> Pp.t) -> ('b -> Pp.t) ->
 
 val pr_value : entry_relative_level -> Val.t -> Pp.t
 
-
 val ltop : entry_relative_level
 
 val make_constr_printer : (env -> Evd.evar_map -> entry_relative_level -> 'a -> Pp.t) ->

--- a/plugins/ltac/tacexpr.ml
+++ b/plugins/ltac/tacexpr.ml
@@ -357,6 +357,9 @@ type atomic_tactic_expr =
 type raw_red_expr = (r_trm, r_cst, r_pat) red_expr_gen
 type glob_red_expr = (g_trm, g_cst, g_pat) red_expr_gen
 
+type raw_strategy = (constr_expr, raw_red_expr, lident) Rewrite.strategy_ast
+type glob_strategy = (Genintern.glob_constr_and_expr, glob_red_expr, Id.t) Rewrite.strategy_ast
+
 (** Traces *)
 
 type ltac_call_kind =

--- a/plugins/ltac/tacexpr.mli
+++ b/plugins/ltac/tacexpr.mli
@@ -357,6 +357,9 @@ type atomic_tactic_expr =
 type raw_red_expr = (r_trm, r_cst, r_pat) red_expr_gen
 type glob_red_expr = (g_trm, g_cst, g_pat) red_expr_gen
 
+type raw_strategy = (constr_expr, raw_red_expr, lident) Rewrite.strategy_ast
+type glob_strategy = (Genintern.glob_constr_and_expr, glob_red_expr, Id.t) Rewrite.strategy_ast
+
 (** Traces *)
 
 type ltac_call_kind =

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -757,6 +757,24 @@ let glob_tactic_env l env x =
     List.fold_left (fun accu x -> Id.Set.add x accu) Id.Set.empty l in
   intern_pure_tactic { (Genintern.empty_glob_sign ~strict:true env) with ltacvars } x
 
+let intern_strategy ist s =
+  let rec aux stratvars = function
+    | Rewrite.StratVar x ->
+      if Id.Set.mem x.v stratvars then Rewrite.StratVar x.v
+      else CErrors.user_err ?loc:x.loc Pp.(str "Unbound strategy" ++ spc() ++ Id.print x.v)
+    | StratFix (x, s) -> StratFix (x.v, aux (Id.Set.add x.v stratvars) s)
+    | StratId | StratFail | StratRefl as s -> s
+    | StratUnary (s, str) -> StratUnary (s, aux stratvars str)
+    | StratBinary (s, str, str') -> StratBinary (s, aux stratvars str, aux stratvars str')
+    | StratNAry (s, strs) -> StratNAry (s, List.map (aux stratvars) strs)
+    | StratConstr (c, b) -> StratConstr (intern_constr ist c, b)
+    | StratTerms l -> StratTerms (List.map (intern_constr ist) l)
+    | StratHints (b, id) -> StratHints (b, id)
+    | StratEval r -> StratEval (intern_red_expr ist r)
+    | StratFold c -> StratFold (intern_constr ist c)
+  in
+  aux Id.Set.empty s
+
 (** Registering *)
 
 let lift intern = (); fun ist x -> (ist, intern ist x)

--- a/plugins/ltac/tacintern.mli
+++ b/plugins/ltac/tacintern.mli
@@ -59,3 +59,5 @@ val intern_genarg : glob_sign -> raw_generic_argument -> glob_generic_argument
 (** Reduction expressions *)
 
 val intern_red_expr : glob_sign -> raw_red_expr -> glob_red_expr
+
+val intern_strategy : glob_sign -> raw_strategy -> glob_strategy

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -771,6 +771,12 @@ let interp_red_expr ist env sigma = function
     sigma , CbvNative (Option.map (interp_closed_typed_pattern_with_occurrences ist env sigma) o)
   | (Red _ |  Hnf | ExtraRedExpr _ as r) -> sigma , r
 
+let interp_strategy ist _env _sigma s =
+  let interp_redexpr r = fun env sigma -> interp_red_expr ist env sigma r in
+  let interp_constr c = (fst c, fun env sigma -> interp_open_constr ist env sigma c) in
+  let s = Rewrite.map_strategy interp_constr interp_redexpr (fun x -> x) s in
+  Rewrite.strategy_of_ast s
+
 let interp_may_eval f ist env sigma = function
   | ConstrEval (r,c) ->
       let (sigma,redexp) = interp_red_expr ist env sigma r in

--- a/plugins/ltac/tacinterp.mli
+++ b/plugins/ltac/tacinterp.mli
@@ -82,6 +82,8 @@ val interp_red_expr : interp_sign -> Environ.env -> Evd.evar_map -> glob_red_exp
 (** Interprets redexp arguments from a raw one *)
 val interp_redexp : Environ.env -> Evd.evar_map -> raw_red_expr -> Evd.evar_map * red_expr
 
+val interp_strategy : interp_sign -> Environ.env -> Evd.evar_map -> glob_strategy -> Rewrite.strategy
+
 (** Interprets tactic expressions *)
 
 val interp_hyp : interp_sign -> Environ.env -> Evd.evar_map ->

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -1656,28 +1656,32 @@ type binary_strategy =
 
 type nary_strategy = Choice
 
-type ('constr,'redexpr) strategy_ast =
+type ('constr,'redexpr,'id) strategy_ast =
   | StratId | StratFail | StratRefl
-  | StratUnary of unary_strategy * ('constr,'redexpr) strategy_ast
+  | StratUnary of unary_strategy * ('constr,'redexpr,'id) strategy_ast
   | StratBinary of
-      binary_strategy * ('constr,'redexpr) strategy_ast * ('constr,'redexpr) strategy_ast
-  | StratNAry of nary_strategy * ('constr,'redexpr) strategy_ast list
+      binary_strategy * ('constr,'redexpr,'id) strategy_ast * ('constr,'redexpr,'id) strategy_ast
+  | StratNAry of nary_strategy * ('constr,'redexpr,'id) strategy_ast list
   | StratConstr of 'constr * bool
   | StratTerms of 'constr list
   | StratHints of bool * string
   | StratEval of 'redexpr
   | StratFold of 'constr
+  | StratVar of 'id
+  | StratFix of 'id * ('constr,'redexpr,'id) strategy_ast
 
-let rec map_strategy (f : 'a -> 'a2) (g : 'b -> 'b2) : ('a,'b) strategy_ast -> ('a2,'b2) strategy_ast = function
+let rec map_strategy f g h = function
   | StratId | StratFail | StratRefl as s -> s
-  | StratUnary (s, str) -> StratUnary (s, map_strategy f g str)
-  | StratBinary (s, str, str') -> StratBinary (s, map_strategy f g str, map_strategy f g str')
-  | StratNAry (s, strs) -> StratNAry (s, List.map (map_strategy f g) strs)
+  | StratUnary (s, str) -> StratUnary (s, map_strategy f g h str)
+  | StratBinary (s, str, str') -> StratBinary (s, map_strategy f g h str, map_strategy f g h str')
+  | StratNAry (s, strs) -> StratNAry (s, List.map (map_strategy f g h) strs)
   | StratConstr (c, b) -> StratConstr (f c, b)
   | StratTerms l -> StratTerms (List.map f l)
   | StratHints (b, id) -> StratHints (b, id)
   | StratEval r -> StratEval (g r)
   | StratFold c -> StratFold (f c)
+  | StratVar id -> StratVar (h id)
+  | StratFix (id, s) -> StratFix (h id, map_strategy f g h s)
 
 let pr_ustrategy = function
 | Subterms -> str "subterms"
@@ -1693,16 +1697,16 @@ let pr_ustrategy = function
 
 let paren p = str "(" ++ p ++ str ")"
 
-let rec pr_strategy prc prr = function
+let rec pr_strategy prc prr prid = function
 | StratId -> str "id"
 | StratFail -> str "fail"
 | StratRefl -> str "refl"
 | StratUnary (s, str) ->
-  pr_ustrategy s ++ spc () ++ paren (pr_strategy prc prr str)
+  pr_ustrategy s ++ spc () ++ paren (pr_strategy prc prr prid str)
 | StratNAry (Choice, strs) ->
-  str "choice" ++ spc () ++ prlist_with_sep spc (fun str -> paren (pr_strategy prc prr str)) strs
+  str "choice" ++ spc () ++ prlist_with_sep spc (fun str -> paren (pr_strategy prc prr prid str)) strs
 | StratBinary (Compose, str1, str2) ->
-  pr_strategy prc prr str1 ++ str ";" ++ spc () ++ pr_strategy prc prr str2
+  pr_strategy prc prr prid str1 ++ str ";" ++ spc () ++ pr_strategy prc prr prid str2
 | StratConstr (c, true) -> prc c
 | StratConstr (c, false) -> str "<-" ++ spc () ++ prc c
 | StratTerms cl -> str "terms" ++ spc () ++ pr_sequence prc cl
@@ -1711,13 +1715,15 @@ let rec pr_strategy prc prr = function
   str cmd ++ spc () ++ str id
 | StratEval r -> str "eval" ++ spc () ++ prr r
 | StratFold c -> str "fold" ++ spc () ++ prc c
+| StratVar id -> str "using" ++ spc() ++ prid id
+| StratFix (id,s) -> str "fix" ++ spc() ++ prid id ++ spc() ++ str ":=" ++ spc() ++ pr_strategy prc prr prid s ++ spc() ++ str"end"
 
-let rec strategy_of_ast = function
+let rec strategy_of_ast bindings = function
   | StratId -> Strategies.id
   | StratFail -> Strategies.fail
   | StratRefl -> Strategies.refl
   | StratUnary (f, s) ->
-    let s' = strategy_of_ast s in
+    let s' = strategy_of_ast bindings s in
     let f' = match f with
       | Subterms -> all_subterms
       | Subterm -> one_subterm
@@ -1731,13 +1737,13 @@ let rec strategy_of_ast = function
       | Repeat -> Strategies.repeat
     in f' s'
   | StratBinary (f, s, t) ->
-    let s' = strategy_of_ast s in
-    let t' = strategy_of_ast t in
+    let s' = strategy_of_ast bindings s in
+    let t' = strategy_of_ast bindings t in
     let f' = match f with
       | Compose -> Strategies.seq
     in f' s' t'
   | StratNAry (Choice, strs) ->
-    let strs = List.map (strategy_of_ast) strs in
+    let strs = List.map (strategy_of_ast bindings) strs in
     begin match strs with
       | [] -> assert false
       | s::strs -> List.fold_left Strategies.choice s strs
@@ -1755,6 +1761,12 @@ let rec strategy_of_ast = function
      (Strategies.reduce r_interp).strategy { input with
                                              evars = (sigma,cstrevars evars) }) }
   | StratFold c -> Strategies.fold_glob (fst c)
+
+  | StratVar id -> Id.Map.get id bindings
+
+  | StratFix (id, s) -> Strategies.fix (fun self -> strategy_of_ast (Id.Map.add id self bindings) s)
+
+let strategy_of_ast s = strategy_of_ast Id.Map.empty s
 
 let proper_projection sigma r ty =
   let rel_vect n m = Array.init m (fun i -> mkRel(n+m-i)) in

--- a/tactics/rewrite.mli
+++ b/tactics/rewrite.mli
@@ -27,17 +27,19 @@ type binary_strategy =
 
 type nary_strategy = Choice
 
-type ('constr,'redexpr) strategy_ast =
+type ('constr,'redexpr,'id) strategy_ast =
   | StratId | StratFail | StratRefl
-  | StratUnary of unary_strategy * ('constr,'redexpr) strategy_ast
+  | StratUnary of unary_strategy * ('constr,'redexpr,'id) strategy_ast
   | StratBinary of
-      binary_strategy * ('constr,'redexpr) strategy_ast * ('constr,'redexpr) strategy_ast
-  | StratNAry of nary_strategy * ('constr,'redexpr) strategy_ast list
+      binary_strategy * ('constr,'redexpr,'id) strategy_ast * ('constr,'redexpr,'id) strategy_ast
+  | StratNAry of nary_strategy * ('constr,'redexpr,'id) strategy_ast list
   | StratConstr of 'constr * bool
   | StratTerms of 'constr list
   | StratHints of bool * string
   | StratEval of 'redexpr
   | StratFold of 'constr
+  | StratVar of 'id
+  | StratFix of 'id * ('constr,'redexpr,'id) strategy_ast
 
 type rewrite_proof =
   | RewPrf of constr * constr
@@ -60,13 +62,13 @@ type rewrite_result =
 
 type strategy
 
-val strategy_of_ast : (Glob_term.glob_constr * constr delayed_open, Redexpr.red_expr delayed_open) strategy_ast -> strategy
+val strategy_of_ast : (Glob_term.glob_constr * constr delayed_open, Redexpr.red_expr delayed_open, Id.t) strategy_ast -> strategy
 
-val map_strategy : ('a -> 'b) -> ('c -> 'd) ->
-  ('a, 'c) strategy_ast -> ('b, 'd) strategy_ast
+val map_strategy : ('a -> 'b) -> ('c -> 'd) -> ('e -> 'f) ->
+  ('a, 'c, 'e) strategy_ast -> ('b, 'd, 'f) strategy_ast
 
-val pr_strategy : ('a -> Pp.t) -> ('b -> Pp.t) ->
-  ('a, 'b) strategy_ast -> Pp.t
+val pr_strategy : ('a -> Pp.t) -> ('b -> Pp.t) -> ('c -> Pp.t) ->
+  ('a, 'b, 'c) strategy_ast -> Pp.t
 
 (** Entry point for user-level "rewrite_strat" *)
 val cl_rewrite_clause_strat : strategy -> Id.t option -> unit Proofview.tactic


### PR DESCRIPTION
To avoid conflicting with the StratConstr syntax, strategy variables are accessed with `using`,
ie `any foo := fix any_foo := try (foo; using any_foo) end`
 `fix` syntax uses `end` because otherwise the parser interprets `fix foo := bla; bli` as `(fix foo := bla); bli` which may confuse the user.

Fix https://github.com/coq/coq/issues/13702