### PR TITLE
Avoid writing eta expansions for primitives

### DIFF
--- a/plugins/ltac2/tac2bt.ml
+++ b/plugins/ltac2/tac2bt.ml
@@ -1,0 +1,48 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Tac2expr
+open Proofview.Notations
+
+let backtrace : backtrace Evd.Store.field = Evd.Store.field ()
+
+let print_ltac2_backtrace = ref false
+
+let get_backtrace =
+  Proofview.tclEVARMAP >>= fun sigma ->
+  match Evd.Store.get (Evd.get_extra_data sigma) backtrace with
+  | None -> Proofview.tclUNIT []
+  | Some bt -> Proofview.tclUNIT bt
+
+let set_backtrace bt =
+  Proofview.tclEVARMAP >>= fun sigma ->
+  let store = Evd.get_extra_data sigma in
+  let store = Evd.Store.set store backtrace bt in
+  let sigma = Evd.set_extra_data store sigma in
+  Proofview.Unsafe.tclEVARS sigma
+
+let pr_frame = let open Pp in function
+  | FrAnon e -> str "<fun " ++ Tac2print.pr_glbexpr e ++ str ">"
+  | FrLtac kn -> Tac2print.pr_tacref kn
+  | FrPrim ml -> str "<" ++ str ml.mltac_plugin ++ str ":" ++ str ml.mltac_tactic ++ str ">"
+  | FrExtn (tag,_) -> str "<extn:" ++ str (Tac2dyn.Arg.repr tag) ++ str ">"
+
+let with_frame frame tac =
+  let tac =
+    if !print_ltac2_backtrace then
+      get_backtrace >>= fun bt ->
+      set_backtrace (frame :: bt) >>= fun () ->
+      tac >>= fun ans ->
+      set_backtrace bt >>= fun () ->
+      Proofview.tclUNIT ans
+    else tac
+  in
+  let pr_frame f = Some (pr_frame f) in
+  Ltac_plugin.Profile_ltac.do_profile_gen pr_frame frame ~count_call:true tac

--- a/plugins/ltac2/tac2bt.ml
+++ b/plugins/ltac2/tac2bt.ml
@@ -28,11 +28,7 @@ let set_backtrace bt =
   let sigma = Evd.set_extra_data store sigma in
   Proofview.Unsafe.tclEVARS sigma
 
-let pr_frame = let open Pp in function
-  | FrAnon e -> str "<fun " ++ Tac2print.pr_glbexpr e ++ str ">"
-  | FrLtac kn -> Tac2print.pr_tacref kn
-  | FrPrim ml -> str "<" ++ str ml.mltac_plugin ++ str ":" ++ str ml.mltac_tactic ++ str ">"
-  | FrExtn (tag,_) -> str "<extn:" ++ str (Tac2dyn.Arg.repr tag) ++ str ">"
+let pr_frame, pr_frame_hook = Hook.make ()
 
 let with_frame frame tac =
   let tac =
@@ -44,5 +40,5 @@ let with_frame frame tac =
       Proofview.tclUNIT ans
     else tac
   in
-  let pr_frame f = Some (pr_frame f) in
+  let pr_frame f = Some (Hook.get pr_frame f) in
   Ltac_plugin.Profile_ltac.do_profile_gen pr_frame frame ~count_call:true tac

--- a/plugins/ltac2/tac2bt.mli
+++ b/plugins/ltac2/tac2bt.mli
@@ -8,27 +8,12 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open Names
 open Tac2expr
-open Tac2ffi
 
-type environment = Tac2env.environment
+(** {5 Backtrace} *)
 
-val empty_environment : environment
+val get_backtrace : backtrace Proofview.tactic
 
-val interp : environment -> glb_tacexpr -> valexpr Proofview.tactic
+val with_frame : frame -> 'a Proofview.tactic -> 'a Proofview.tactic
 
-val interp_value : environment -> glb_tacexpr -> valexpr
-(** Same as [interp] but assumes that the argument is a syntactic value. *)
-
-(* val interp_app : closure -> ml_tactic *)
-
-(** {5 Cross-boundary encodings} *)
-
-val get_env : Ltac_pretype.unbound_ltac_var_map -> environment
-val set_env : environment -> Ltac_pretype.unbound_ltac_var_map -> Ltac_pretype.unbound_ltac_var_map
-
-(** {5 Exceptions} *)
-
-exception LtacError of KerName.t * valexpr array
-(** Ltac2-defined exceptions seen from OCaml side *)
+val print_ltac2_backtrace : bool ref

--- a/plugins/ltac2/tac2bt.mli
+++ b/plugins/ltac2/tac2bt.mli
@@ -17,3 +17,5 @@ val get_backtrace : backtrace Proofview.tactic
 val with_frame : frame -> 'a Proofview.tactic -> 'a Proofview.tactic
 
 val print_ltac2_backtrace : bool ref
+
+val pr_frame_hook : (frame -> Pp.t) Hook.t

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -171,8 +171,8 @@ let has_fatal_flag info = match Exninfo.get info fatal_flag with
   | Some () -> true
 
 let set_bt info =
-  if !Tac2interp.print_ltac2_backtrace then
-    Tac2interp.get_backtrace >>= fun bt ->
+  if !Tac2bt.print_ltac2_backtrace then
+    Tac2bt.get_backtrace >>= fun bt ->
     Proofview.tclUNIT (Exninfo.add info Tac2entries.backtrace bt)
   else Proofview.tclUNIT info
 

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -477,11 +477,7 @@ let register_primitive ?deprecation ?(local = false) {loc;v=id} t ml =
       user_err ?loc (str "Unregistered primitive " ++
         quote (str ml.mltac_plugin) ++ spc () ++ quote (str ml.mltac_tactic))
   in
-  let init i = Id.of_string (Printf.sprintf "x%i" i) in
-  let names = List.init arrows init in
-  let bnd = List.map (fun id -> Name id) names in
-  let arg = List.map (fun id -> GTacVar id) names in
-  let e = GTacFun (bnd, GTacPrm (ml, arg)) in
+  let e = GTacPrm ml in
   let def = {
     tacdef_local = local;
     tacdef_mutable = false;

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -970,12 +970,12 @@ let register_struct atts str = match str with
 
 (** Toplevel exception *)
 
-let _ = Goptions.declare_bool_option {
+let () = Goptions.declare_bool_option {
   Goptions.optstage = Summary.Stage.Interp;
   Goptions.optdepr = false;
   Goptions.optkey = ["Ltac2"; "Backtrace"];
-  Goptions.optread = (fun () -> !Tac2interp.print_ltac2_backtrace);
-  Goptions.optwrite = (fun b -> Tac2interp.print_ltac2_backtrace := b);
+  Goptions.optread = (fun () -> !Tac2bt.print_ltac2_backtrace);
+  Goptions.optwrite = (fun b -> Tac2bt.print_ltac2_backtrace := b);
 }
 
 let backtrace : backtrace Exninfo.t = Exninfo.make ()
@@ -1004,7 +1004,7 @@ let () = register_handler begin function
 end
 
 let () = CErrors.register_additional_error_info begin fun info ->
-  if !Tac2interp.print_ltac2_backtrace then
+  if !Tac2bt.print_ltac2_backtrace then
     let bt = Exninfo.get info backtrace in
     let bt = match bt with
     | Some bt -> List.rev bt

--- a/plugins/ltac2/tac2env.ml
+++ b/plugins/ltac2/tac2env.ml
@@ -114,7 +114,9 @@ module MLMap = Map.Make(ML)
 
 let primitive_map = ref MLMap.empty
 
-let define_primitive name f = primitive_map := MLMap.add name f !primitive_map
+let define_primitive name f =
+  let f = annotate_closure (FrPrim name) f in
+  primitive_map := MLMap.add name f !primitive_map
 let interp_primitive name = MLMap.find name !primitive_map
 
 (** Name management *)

--- a/plugins/ltac2/tac2expr.mli
+++ b/plugins/ltac2/tac2expr.mli
@@ -178,7 +178,7 @@ type glb_tacexpr =
 | GTacWth of glb_tacexpr open_match
 | GTacFullMatch of glb_tacexpr * (glb_pat * glb_tacexpr) list
 | GTacExt : (_, 'a) Tac2dyn.Arg.tag * 'a -> glb_tacexpr
-| GTacPrm of ml_tactic_name * glb_tacexpr list
+| GTacPrm of ml_tactic_name
 
 (** {5 Parsing & Printing} *)
 

--- a/plugins/ltac2/tac2ffi.mli
+++ b/plugins/ltac2/tac2ffi.mli
@@ -51,6 +51,9 @@ val arity_suc : 'a arity -> (valexpr -> 'a) arity
 
 val mk_closure : 'v arity -> 'v -> closure
 
+val annotate_closure : Tac2expr.frame -> closure -> closure
+(** The closure must not be already annotated *)
+
 module Valexpr :
 sig
   type t = valexpr

--- a/plugins/ltac2/tac2interp.ml
+++ b/plugins/ltac2/tac2interp.ml
@@ -15,44 +15,9 @@ open Names
 open Proofview.Notations
 open Tac2expr
 open Tac2ffi
+open Tac2bt
 
 exception LtacError = Tac2ffi.LtacError
-
-let backtrace : backtrace Evd.Store.field = Evd.Store.field ()
-
-let print_ltac2_backtrace = ref false
-
-let get_backtrace =
-  Proofview.tclEVARMAP >>= fun sigma ->
-  match Evd.Store.get (Evd.get_extra_data sigma) backtrace with
-  | None -> Proofview.tclUNIT []
-  | Some bt -> Proofview.tclUNIT bt
-
-let set_backtrace bt =
-  Proofview.tclEVARMAP >>= fun sigma ->
-  let store = Evd.get_extra_data sigma in
-  let store = Evd.Store.set store backtrace bt in
-  let sigma = Evd.set_extra_data store sigma in
-  Proofview.Unsafe.tclEVARS sigma
-
-let pr_frame = function
-  | FrAnon e -> str "<fun " ++ Tac2print.pr_glbexpr e ++ str ">"
-  | FrLtac kn -> Tac2print.pr_tacref kn
-  | FrPrim ml -> str "<" ++ str ml.mltac_plugin ++ str ":" ++ str ml.mltac_tactic ++ str ">"
-  | FrExtn (tag,_) -> str "<extn:" ++ str (Tac2dyn.Arg.repr tag) ++ str ">"
-
-let with_frame frame tac =
-  let tac =
-    if !print_ltac2_backtrace then
-      get_backtrace >>= fun bt ->
-      set_backtrace (frame :: bt) >>= fun () ->
-      tac >>= fun ans ->
-      set_backtrace bt >>= fun () ->
-      Proofview.tclUNIT ans
-    else tac
-  in
-  let pr_frame f = Some (pr_frame f) in
-  Ltac_plugin.Profile_ltac.do_profile_gen pr_frame frame ~count_call:true tac
 
 type environment = Tac2env.environment = {
   env_ist : valexpr Id.Map.t;

--- a/plugins/ltac2/tac2interp.ml
+++ b/plugins/ltac2/tac2interp.ml
@@ -156,9 +156,8 @@ let rec interp (ist : environment) = function
 | GTacOpn (kn, el) ->
   Proofview.Monad.List.map (fun e -> interp ist e) el >>= fun el ->
   return (Tac2ffi.of_open (kn, Array.of_list el))
-| GTacPrm (ml, el) ->
-  Proofview.Monad.List.map (fun e -> interp ist e) el >>= fun el ->
-  with_frame (FrPrim ml) (Tac2ffi.apply (Tac2env.interp_primitive ml) el)
+| GTacPrm ml ->
+  return (of_closure (Tac2env.interp_primitive ml))
 | GTacExt (tag, e) ->
   let tpe = Tac2env.interp_ml_object tag in
   with_frame (FrExtn (tag, e)) (tpe.Tac2env.ml_interp ist e)
@@ -242,9 +241,11 @@ and eval_pure bnd kn = function
   let bnd = List.fold_left fold bnd vals in
   eval_pure bnd kn body
 
+| GTacPrm ml -> of_closure (Tac2env.interp_primitive ml)
+
 | GTacAtm (AtmStr _) | GTacSet _
 | GTacApp _ | GTacCse _ | GTacPrj _
-| GTacPrm _ | GTacExt _ | GTacWth _
+| GTacExt _ | GTacWth _
 | GTacFullMatch _ ->
   anomaly (Pp.str "Term is not a syntactical value")
 

--- a/plugins/ltac2/tac2print.ml
+++ b/plugins/ltac2/tac2print.ml
@@ -646,3 +646,12 @@ let parse_format (s : string) : format list =
     | _ -> raise InvalidFormat
   in
   parse 0 []
+
+
+let pr_profile_frame = let open Pp in function
+  | FrAnon e -> str "<fun " ++ pr_glbexpr e ++ str ">"
+  | FrLtac kn -> pr_tacref kn
+  | FrPrim ml -> str "<" ++ str ml.mltac_plugin ++ str ":" ++ str ml.mltac_tactic ++ str ">"
+  | FrExtn (tag,_) -> str "<extn:" ++ str (Tac2dyn.Arg.repr tag) ++ str ">"
+
+let () = Hook.set Tac2bt.pr_frame_hook pr_profile_frame

--- a/plugins/ltac2/tac2print.ml
+++ b/plugins/ltac2/tac2print.ml
@@ -404,13 +404,9 @@ let pr_glbexpr_gen lvl c =
     let env = Global.env() in
     let sigma = Evd.from_env env in
     hov 0 (tpe.ml_print env sigma arg) (* FIXME *)
-  | GTacPrm (prm, args) ->
-    let args = match args with
-    | [] -> mt ()
-    | _ -> spc () ++ pr_sequence (pr_glbexpr E0) args
-    in
+  | GTacPrm prm ->
     hov 0 (str "@external" ++ spc () ++ qstring prm.mltac_plugin ++ spc () ++
-      qstring prm.mltac_tactic ++ args)
+      qstring prm.mltac_tactic)
   and pr_applied_constructor lvl tpe n cl =
     let factorized =
       if KerName.equal tpe t_list then

--- a/test-suite/output/bug_17155.out
+++ b/test-suite/output/bug_17155.out
@@ -6,7 +6,6 @@ The command has indeed failed with message:
 Backtrace:
 Call M.g
 Call bug_17155.M.f (* local *)
-Call Control.throw
 Prim <coq-core.plugins.ltac2:throw>
 Uncaught Ltac2 exception: Invalid_argument (None)
 Ltac2 M.g : unit -> 'a

--- a/test-suite/output/ltac2_anomaly_backtrace.out
+++ b/test-suite/output/ltac2_anomaly_backtrace.out
@@ -2,7 +2,6 @@ File "./output/ltac2_anomaly_backtrace.v", line 9, characters 0-18:
 Error:
 Backtrace:
 Call foo
-Call Std.eval_hnf
 Prim <coq-core.plugins.ltac2:eval_hnf>
 Anomaly "Uncaught exception Not_found."
 Please report at http://coq.inria.fr/bugs/.

--- a/test-suite/output/ltac2_printabout.out
+++ b/test-suite/output/ltac2_printabout.out
@@ -1,5 +1,5 @@
 type : constr -> constr
 Ltac2 type : constr -> constr
-      type := fun x0 => @external "coq-core.plugins.ltac2" "constr_type" x0
+      type := @external "coq-core.plugins.ltac2" "constr_type"
 Ltac2 ltac2_printabout.type
 Ltac2 type : constr -> constr


### PR DESCRIPTION
This takes the example in
https://github.com/coq/coq/issues/10107#issuecomment-1511450521
from 0.15s to 0.12s (-20%)

We need to modify the closure representation to provide backtraces and
profile stacks for primitives.
