### PR TITLE
Track which variables are used in GTacExt

### DIFF
--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -1645,7 +1645,8 @@ let () =
   let subs avoid globs (ids, tac) =
     (* Let-bind the notation terms inside the tactic *)
     let fold id c (rem, accu) =
-      let c = GTacExt (Tac2quote.wit_preterm, (avoid, c)) in
+      (* XXX can we be less redundant with the avoid? *)
+      let c = GTacExt (avoid, Tac2quote.wit_preterm, (avoid, c)) in
       let rem = Id.Set.remove id rem in
       rem, (Name id, c) :: accu
     in

--- a/plugins/ltac2/tac2expr.mli
+++ b/plugins/ltac2/tac2expr.mli
@@ -177,7 +177,7 @@ type glb_tacexpr =
 | GTacOpn of ltac_constructor * glb_tacexpr list
 | GTacWth of glb_tacexpr open_match
 | GTacFullMatch of glb_tacexpr * (glb_pat * glb_tacexpr) list
-| GTacExt : (_, 'a) Tac2dyn.Arg.tag * 'a -> glb_tacexpr
+| GTacExt : Id.Set.t * (_, 'a) Tac2dyn.Arg.tag * 'a -> glb_tacexpr
 | GTacPrm of ml_tactic_name * glb_tacexpr list
 
 (** {5 Parsing & Printing} *)

--- a/plugins/ltac2/tac2intern.ml
+++ b/plugins/ltac2/tac2intern.ml
@@ -1249,14 +1249,17 @@ let rec intern_rec env {loc;v=e} = match e with
     intern_rec env e
   in
   let obj = interp_ml_object tag in
-  (* External objects do not have access to the named context because this is
-     not stable by dynamic semantics. *)
-  let genv = Global.env_of_context Environ.empty_named_context_val in
-  let ist = empty_glob_sign ~strict:(env_strict env) genv in
-  let ist = { ist with extra = Store.set ist.extra ltac2_env env } in
-  let arg, tpe = obj.ml_intern self ist arg in
+  let used, (arg, tpe) =
+    with_used_vars env (fun env ->
+        (* External objects do not have access to the named context because this is
+           not stable by dynamic semantics. *)
+        let genv = Global.env_of_context Environ.empty_named_context_val in
+        let ist = empty_glob_sign ~strict:(env_strict env) genv in
+        let ist = { ist with extra = Store.set ist.extra ltac2_env env } in
+        obj.ml_intern self ist arg)
+  in
   let e = match arg with
-  | GlbVal arg -> GTacExt (tag, arg)
+  | GlbVal arg -> GTacExt (used, tag, arg)
   | GlbTacexpr e -> e
   in
   (e, tpe)
@@ -1660,10 +1663,10 @@ let rec subst_expr subst e = match e with
   let e' = subst_expr subst e in
   let r' = subst_expr subst r in
   if kn' == kn && e' == e && r' == r then e0 else GTacSet (kn', e', p, r')
-| GTacExt (tag, arg) ->
+| GTacExt (used, tag, arg) ->
   let tpe = interp_ml_object tag in
   let arg' = tpe.ml_subst subst arg in
-  if arg' == arg then e else GTacExt (tag, arg')
+  if arg' == arg then e else GTacExt (used, tag, arg')
 | GTacOpn (kn, el) as e0 ->
   let kn' = subst_kn subst kn in
   let el' = List.Smart.map (fun e -> subst_expr subst e) el in

--- a/plugins/ltac2/tac2interp.ml
+++ b/plugins/ltac2/tac2interp.ml
@@ -194,7 +194,7 @@ let rec interp (ist : environment) = function
 | GTacPrm (ml, el) ->
   Proofview.Monad.List.map (fun e -> interp ist e) el >>= fun el ->
   with_frame (FrPrim ml) (Tac2ffi.apply (Tac2env.interp_primitive ml) el)
-| GTacExt (tag, e) ->
+| GTacExt (_ids, tag, e) ->
   let tpe = Tac2env.interp_ml_object tag in
   with_frame (FrExtn (tag, e)) (tpe.Tac2env.ml_interp ist e)
 

--- a/plugins/ltac2/tac2typing_env.mli
+++ b/plugins/ltac2/tac2typing_env.mli
@@ -50,6 +50,8 @@ val find_var : Id.t -> t -> mix_type_scheme
 
 val bound_vars : t -> Id.Set.t
 
+val with_used_vars : t -> (t -> 'a) -> Id.Set.t * 'a
+
 val get_variable0 : (Id.t -> bool) -> tacref or_relid -> tacref Locus.or_var
 
 val get_variable : t -> tacref or_relid -> tacref Locus.or_var

--- a/test-suite/output/ltac2_ext_used_variables.out
+++ b/test-suite/output/ltac2_ext_used_variables.out
@@ -1,0 +1,10 @@
+Ltac2 foo : constr -> constr -> constr -> constr
+      foo :=
+        fun x y z =>
+        let a := (* x y *) constr:($x + ltac:(exact $y)) in
+        (* a z *)
+        constr:($a +
+                ltac2:(let y := z in
+                       let c := fun _ => (* y *) open_constr:($y) in
+                       exact0 false c))
+- : constr = constr:(0 + 1 + 2)

--- a/test-suite/output/ltac2_ext_used_variables.v
+++ b/test-suite/output/ltac2_ext_used_variables.v
@@ -1,0 +1,11 @@
+Require Import Ltac2.Ltac2.
+
+Ltac2 foo x y z :=
+  let a := constr:($x + ltac:(exact $y)) in
+  constr:($a + ltac2:(let y := z in exact $y)).
+
+Set Printing Ltac2 Extension Used Variables.
+
+Print foo.
+
+Ltac2 Eval foo constr:(0) constr:(1) constr:(2).


### PR DESCRIPTION
This will be useful for compilation, because it will need to rebuild the interpretation env to interp extensions.
