### PR TITLE
docs: :memo: Fix typo

### DIFF
--- a/doc/sphinx/language/coq-library.rst
+++ b/doc/sphinx/language/coq-library.rst
@@ -80,7 +80,7 @@ Notation          Precedence    Associativity
 ``_ || _``        50            left
 ``_ - _``         50            left
 ``_ * _``         40            left
-``_      _``      40            left
+``_ && _``        40            left
 ``_ / _``         40            left
 ``- _``           35            right
 ``/ _``           35            right


### PR DESCRIPTION
Fix typo of the `&&` notation on table of the main notations.

https://github.com/coq/coq/blob/master/theories/Init/Notations.v#L56

Co-authored-by: spinylobster <spinylobster@outlook.com>
