### PR TITLE
Add test of disabling abbreviation which shadows something else

### DIFF
--- a/test-suite/output/activation.out
+++ b/test-suite/output/activation.out
@@ -58,3 +58,13 @@ a
      : Type
 a
      : Type
+0
+     : nat
+The following notations have been disabled:
+Notation activation.Abbrev.x := 0
+x
+     : bool
+The following notations have been enabled:
+Notation activation.Abbrev.x := 0
+0
+     : nat

--- a/test-suite/output/activation.v
+++ b/test-suite/output/activation.v
@@ -26,4 +26,14 @@ Check Prop.
 Enable Notation a (all). (* Note: reactivation is not necessarily in the same order as it was earlier *)
 Check a.
 Check Prop.
+
+Module Shadowed. Notation x := true. End Shadowed.
+Import Shadowed.
+Notation x := 0.
+Check x.
+Disable Notation Abbrev.x.
+Check x.
+Enable Notation x.
+Check x.
+
 End Abbrev.


### PR DESCRIPTION
AFAICT this behaviour is the only reason why we have 
~~~ocaml
type nametree =
  { path : path_status list;
    map : nametree ModIdmap.t }
~~~
instead of `path : path_status option`.
