### PR TITLE
[refman] Add link to the deprecation policy

### DIFF
--- a/doc/sphinx/biblio.bib
+++ b/doc/sphinx/biblio.bib
@@ -644,3 +644,15 @@ the Calculus of Inductive Constructions}},
   x-support = {actes_aux},
   x-cle-support = {ML}
 }
+
+@phdthesis{Zimmermann19,
+  author       = {Th{\'{e}}o Zimmermann},
+  title        = {Challenges in the collaborative evolution of a proof language and
+                  its ecosystem.},
+  school       = {Université de Paris, France},
+  year         = {2019},
+  url          = {https://tel.archives-ouvertes.fr/tel-02451322},
+  timestamp    = {Tue, 21 Jul 2020 00:40:54 +0200},
+  biburl       = {https://dblp.org/rec/phd/hal/Zimmermann19.bib},
+  bibsource    = {dblp computer science bibliography, https://dblp.org}
+}

--- a/doc/sphinx/using/libraries/writing.rst
+++ b/doc/sphinx/using/libraries/writing.rst
@@ -38,6 +38,21 @@ deprecated compatibility alias using :cmd:`Notation (abbreviation)`
       :n:`@string__since` is the version number, :n:`@string__note` is
       the note (usually explains the replacement).
 
+.. note::
+
+   Coq and its standard library follow this deprecation policy:
+
+   * it should always be possible for a project written in Coq to be
+     compatible with two successive major versions,
+   * features must be deprecated in one major version before removal,
+   * Coq developers should provide an estimate of the required effort
+     to fix a project with respect to a given change,
+   * breaking changes should be clearly documented in the public
+     release notes, along with recommendations on how to fix a project
+     if it breaks.
+
+   See :cite:`Zimmermann19`, Section 3.6.3, for more details.
+
 .. example:: Deprecating a tactic.
 
    .. coqtop:: all abort warn


### PR DESCRIPTION
Following this Zulip discussion https://coq.zulipchat.com/#narrow/stream/237977-Coq-users/topic/Backwards.20compatibility.20w.2Er.2Et.2E.20Div0.20without.20warnings

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
<!-- Fixes / closes #???? -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] ~Added / updated **test-suite**.~

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] ~Added **changelog**.~
- [x] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] ~Documented any new / changed **user messages**.~
  - [ ] ~Updated **documented syntax** by running `make doc_gram_rsts`.~

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] ~Opened **overlay** pull requests.~

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
