### PR TITLE
Update CI branch for metacoq

### DIFF
--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -298,7 +298,7 @@ project perennial "https://github.com/mit-pdos/perennial" "coq/tested"
 ########################################################################
 # metacoq
 ########################################################################
-project metacoq "https://github.com/MetaCoq/metacoq" "master"
+project metacoq "https://github.com/MetaCoq/metacoq" "main"
 
 ########################################################################
 # SF suite


### PR DESCRIPTION
This now points to MetaCoq's "main" branch which has been updated to the latest 1.2 release of MetaCoq.
Probably takes a bit more time than the previous (1 year old) master branch.