### PR TITLE
Use main branch of Equations for CI

### DIFF
--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -202,7 +202,7 @@ project coq_lsp "https://github.com/ejgallego/coq-lsp" "main"
 ########################################################################
 # Equations
 ########################################################################
-project equations "https://github.com/mattam82/Coq-Equations" "master"
+project equations "https://github.com/mattam82/Coq-Equations" "main"
 
 ########################################################################
 # Elpi + Hierarchy Builder


### PR DESCRIPTION
Renaming from master to main and fixes in the HoTT variant which was failing for a while in the master build of Coq-Equations (not tested in this CI I think).