### PR TITLE
Add CMap.ExtS.symmetric_diff

### DIFF
--- a/clib/cMap.ml
+++ b/clib/cMap.ml
@@ -37,9 +37,8 @@ sig
   val height : 'a t -> int
   val filter_range : (key -> int) -> 'a t -> 'a t
   val of_list : (key * 'a) list -> 'a t
-  val symmetric_diff :
-    eq:('a -> 'a -> bool) ->
-    (key -> [ `Left of 'a | `Right of 'a | `Unequal of 'a * 'a ] -> 'b -> 'b) ->
+  val symmetric_diff_fold :
+    (key -> 'a option -> 'a option -> 'b -> 'b) ->
     'a t -> 'a t -> 'b -> 'b
   module Smart :
   sig
@@ -66,9 +65,8 @@ sig
   val fold_right : (M.t -> 'a -> 'b -> 'b) -> 'a map -> 'b -> 'b
   val height : 'a map -> int
   val filter_range : (M.t -> int) -> 'a map -> 'a map
-  val symmetric_diff :
-    eq:('a -> 'a -> bool) ->
-    (M.t -> [ `Left of 'a | `Right of 'a | `Unequal of 'a * 'a ] -> 'b -> 'b) ->
+  val symmetric_diff_fold :
+    (M.t -> 'a option -> 'a option -> 'b -> 'b) ->
     'a map -> 'a map -> 'b -> 'b
   val of_list : (M.t * 'a) list -> 'a map
   module Smart :
@@ -230,21 +228,21 @@ struct
       else
         symmetric_cons (move_to_acc l) r
 
-  let symmetric_diff ~eq f lm rm acc =
+  let symmetric_diff_fold f lm rm acc =
     let rec aux s acc =
       match s with
-      | End, rs -> fold_seq (fun k v -> f k (`Right v)) acc rs
-      | ls, End -> fold_seq (fun k v -> f k (`Left v)) acc ls
+      | End, rs -> fold_seq (fun k v -> f k None (Some v)) acc rs
+      | ls, End -> fold_seq (fun k v -> f k (Some v) None) acc ls
       | (More (kl, vl, tl, rl) as ls), (More (kr, vr, tr, rr) as rs) ->
         let cmp = M.compare kl kr in
         if cmp == 0 then
           let rem = aux (symmetric_cons (tl, rl) (tr, rr)) acc in
-          if eq vl vr then rem
-          else f kl (`Unequal (vl, vr)) rem
+          if vl == vr then rem
+          else f kl (Some vl) (Some vr) rem
         else if cmp < 0 then
-          f kl (`Left vl) @@ aux (seq_cons tl rl, rs) acc
+          f kl (Some vl) None @@ aux (seq_cons tl rl, rs) acc
         else
-          f kr (`Right vr) @@ aux (ls, seq_cons tr rr) acc
+          f kr None (Some vr) @@ aux (ls, seq_cons tr rr) acc
     in aux (symmetric_cons (lm, End) (rm, End)) acc
 
   module Smart =

--- a/clib/cMap.mli
+++ b/clib/cMap.mli
@@ -69,16 +69,14 @@ sig
   val of_list : (key * 'a) list -> 'a t
   (** Turns an association list into a map *)
 
-  val symmetric_diff :
-    eq:('a -> 'a -> bool) ->
-    (key -> [ `Left of 'a | `Right of 'a | `Unequal of 'a * 'a ] -> 'b -> 'b) ->
+  val symmetric_diff_fold :
+    (key -> 'a option -> 'a option -> 'b -> 'b) ->
     'a t -> 'a t -> 'b -> 'b
-  (** [symmetric_diff ~eq f ml mr acc] will efficiently fold over the difference
+  (** [symmetric_diff f ml mr acc] will efficiently fold over the difference
       between [ml] and [mr], assumed that they share most of their internal
-      structure. For any key [k] in [ml] with value [v] that is not in [mr],
-      the fold contains [`Left v]. [`Right v] will be folded for the opposite
-      condition. When [k] exists in [ml] with value [vl] and exists in [mr] with
-      value [vr], such that [not (eq vl vr)], the fold contains [`Unequal (vl, vr)]. *)
+      structure. A call to [f k vl vr] means that if [vl] is [Some], then [k] exists
+      in [ml]. Similarly, if [vr] is [Some], then [k] exists in [mr]. If both [vl]
+      and [vr] are [Some], then [vl != vr]. *)
 
   module Smart :
   sig

--- a/clib/cMap.mli
+++ b/clib/cMap.mli
@@ -69,6 +69,17 @@ sig
   val of_list : (key * 'a) list -> 'a t
   (** Turns an association list into a map *)
 
+  val symmetric_diff :
+    eq:('a -> 'a -> bool) ->
+    (key -> [ `Left of 'a | `Right of 'a | `Unequal of 'a * 'a ] -> 'b -> 'b) ->
+    'a t -> 'a t -> 'b -> 'b
+  (** [symmetric_diff ~eq f ml mr acc] will efficiently fold over the difference
+      between [ml] and [mr], assumed that they share most of their internal
+      structure. For any key [k] in [ml] with value [v] that is not in [mr],
+      the fold contains [`Left v]. [`Right v] will be folded for the opposite
+      condition. When [k] exists in [ml] with value [vl] and exists in [mr] with
+      value [vr], such that [not (eq vl vr)], the fold contains [`Unequal (vl, vr)]. *)
+
   module Smart :
   sig
     val map : ('a -> 'a) -> 'a t -> 'a t

--- a/clib/hMap.ml
+++ b/clib/hMap.ml
@@ -444,4 +444,12 @@ struct
     let fold_right _ _ _ = assert false
   end
 
+  let symmetric_diff ~eq f lm rm acc =
+    Int.Map.symmetric_diff ~eq:(Map.equal eq)
+      (fun _ s acc -> match s with
+         | `Left v -> Map.fold (fun k v acc -> f k (`Left v) acc) v acc
+         | `Right v -> Map.fold (fun k v acc -> f k (`Right v) acc) v acc
+         | `Unequal (lm, rm) -> Map.symmetric_diff ~eq f lm rm acc)
+      lm rm acc
+
 end

--- a/clib/hMap.ml
+++ b/clib/hMap.ml
@@ -444,12 +444,13 @@ struct
     let fold_right _ _ _ = assert false
   end
 
-  let symmetric_diff ~eq f lm rm acc =
-    Int.Map.symmetric_diff ~eq:(Map.equal eq)
-      (fun _ s acc -> match s with
-         | `Left v -> Map.fold (fun k v acc -> f k (`Left v) acc) v acc
-         | `Right v -> Map.fold (fun k v acc -> f k (`Right v) acc) v acc
-         | `Unequal (lm, rm) -> Map.symmetric_diff ~eq f lm rm acc)
+  let symmetric_diff_fold f lm rm acc =
+    Int.Map.symmetric_diff_fold
+      (fun _ l r -> match l, r with
+         | Some m, None -> Map.fold (fun k v acc -> f k (Some v) None acc) m
+         | None, Some m -> Map.fold (fun k v acc -> f k None (Some v) acc) m
+         | Some lm, Some rm -> Map.symmetric_diff_fold f lm rm
+         | None, None -> assert false)
       lm rm acc
 
 end


### PR DESCRIPTION
`symmetric_diff` efficiently calculates the difference between two maps when they share most of their internal structure.

Note that this cannot be implemented on top of the public interface of CMap, as it relies on the internal implementation details. To implement this, Tactician currently accesses the Coq internals through `Obj.magic`, and Coq in turn accesses the OCaml internals through `Obj.magic`, which seems somewhat risky. So I'm hoping that this code can find a home here. But eventually I feel that the whole `CMap` extension to OCaml's map should be upstreamed there...