### PR TITLE
Stop reducing case analyses when the head is a constructor in case_pf.

### DIFF
--- a/doc/changelog/04-tactics/17541-case-pf-no-red-head.rst
+++ b/doc/changelog/04-tactics/17541-case-pf-no-red-head.rst
@@ -1,0 +1,9 @@
+- **Changed:**
+  the :tacn:`case` tactic and its variants always generate a
+  pattern-matching node, regardless of their argument. In
+  particular, they are now guaranteed to generate as many goals
+  as there are constructors in the inductive type. Previously,
+  they used to reduce to the corresponding branch when the argument
+  βι-normalized to a constructor, resulting in a single goal
+  (`#17541 <https://github.com/coq/coq/pull/17541>`_,
+  by Pierre-Marie Pédrot).

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -761,19 +761,19 @@ and mk_arggoals env sigma goalacc funty allargs =
   List.fold_left_map foldmap (goalacc, funty, sigma) allargs
 
 let treat_case env sigma ci lbrty lf acc' =
+  let open EConstr in
   let fold (lacc, sigma, bacc) ty (brctx, br) =
-    let head, args = match kind br with
+    let head, args = match kind sigma br with
     | App (f, cl) -> f, cl
     | _ -> (br, [||])
     in
-    let () = assert (isMeta head) in
-    let () = assert (CArray.for_all isRel args) in
+    let () = assert (isMeta sigma head) in
+    let () = assert (CArray.for_all (fun c -> isRel sigma c) args) in
     let (r, s, head'') =
       (* TODO: tweak this to prevent dummy β-cuts *)
       let ty = nf_betaiota env sigma ty in
       let hyps = Environ.named_context_val env in
       let (gl,ev,sigma) = mk_goal sigma hyps ty in
-      let ev = EConstr.Unsafe.to_constr ev in
       gl::lacc, sigma, ev
     in
     let br' = mkApp (head'', args) in
@@ -790,24 +790,21 @@ let std_refine env sigma cl r =
 (* find appropriate names for pattern variables. Useful in the Case
    and Inversion (case_then_using et case_nodep_then_using) tactics. *)
 
-let case_refine env sigma ~branches cl r = match Constr.kind (EConstr.Unsafe.to_constr r) with
-| Case (ci, u, pms, p, iv, c, lf) ->
-  let c = make_proof env sigma (EConstr.of_constr c) in
-  let () = if Array.exists (fun c -> occur_meta sigma (EConstr.of_constr c)) pms then error_unsupported_deep_meta () in
+let case_refine env sigma ~branches (ci, u, pms, p, iv, c, lf) =
+  let c = make_proof env sigma c in
+  let () = if Array.exists (fun c -> occur_meta sigma c) pms then error_unsupported_deep_meta () in
   let (acc',ct,sigma,c') = mk_refgoals env sigma [] None c in
   let (acc'',sigma,rbranches) = treat_case env sigma ci branches lf acc' in
   let lf' = Array.rev_of_list rbranches in
-  let ans = mkCase (ci, u, pms, p, iv, EConstr.Unsafe.to_constr c', lf') in
-  (sigma, acc'', EConstr.of_constr ans)
-| _ ->
-  (* This can happen in two cases:
-     - Either when emulating elimination for primitive records
-     - Or when the case node reduced because its scrutinee was a constructor *)
-  std_refine env sigma cl r
+  let ans = EConstr.mkCase (ci, u, pms, p, iv, c', lf') in
+  (sigma, acc'', ans)
 
 type refiner_kind =
 | Std of clbinding Metamap.t * EConstr.t
-| Case of clbinding Metamap.t * EConstr.t * EConstr.t array
+| Case of
+  clbinding Metamap.t *
+  (case_info * EInstance.t * EConstr.t array * EConstr.case_return * EConstr.case_invert * EConstr.t * EConstr.case_branch array) *
+  EConstr.t array
 
 let refiner_gen is_case =
   let open Proofview.Notations in
@@ -819,7 +816,7 @@ let refiner_gen is_case =
   let (sigma, sgl, c) = match is_case with
   | Case (metas, r, branches) ->
     let sigma = Evd.meta_merge metas sigma in
-    case_refine env sigma ~branches cl r
+    case_refine env sigma ~branches r
   | Std (metas, r) ->
     let sigma = Evd.meta_merge metas sigma in
     std_refine env sigma cl r
@@ -873,6 +870,10 @@ let res_pf ?(with_evars=false) ?(with_classes=true) ?(flags=dft ()) clenv =
       (Internal.refiner_gen (Std (metas, r)))
   end
 
+type case_analysis =
+| RealCase of EConstr.case
+| PrimitiveEta of metavariable * EConstr.t array
+
 let build_case_analysis env sigma (ind, u) params pred indices indarg branches dep knd =
   let open Inductiveops in
   let open Context.Rel.Declaration in
@@ -925,11 +926,11 @@ let build_case_analysis env sigma (ind, u) params pred indices indarg branches d
       (brnas, mkApp (mkMeta mv, args))
     in
     let br = Array.mapi mk_branch branches in
-    mkCase (ci, u, params, (pnas, pbody), iv, indarg, br)
+    RealCase (ci, u, params, (pnas, pbody), iv, indarg, br)
   | Some ps ->
     let (mv, _, _) = branches.(0) in
     let args = Array.map (fun p -> mkProj (Projection.make p true, indarg)) ps in
-    mkApp (mkMeta mv, args)
+    PrimitiveEta (mv, args)
 
 let case_pf ?(with_evars=false) ?submetas ~dep (indarg, typ) =
   Proofview.Goal.enter begin fun gl ->
@@ -1013,12 +1014,20 @@ let case_pf ?(with_evars=false) ?submetas ~dep (indarg, typ) =
   let sigma = Typeclasses.make_unresolvables (fun x -> true) sigma in
   (* Call the legacy refiner on the result *)
   let metas = Evd.meta_list sigma in
+  (* Note that the environment rel context does matter for meta_instance *)
   let nf_metas c = meta_instance env sigma { rebus = c; freemetas = metaset } in
   let branches = Array.map (fun (_, ctx, t) -> nf_metas (it_mkProd_or_LetIn t ctx)) branches in
-  let r = nf_metas body in
+  let arg = match body with
+  | RealCase (ci, u, pms, p, iv, c, lf) ->
+    let c = nf_metas c in
+    let pms = Array.map nf_metas pms in
+    let p = on_snd nf_metas p in
+    Internal.Case (metas, (ci, u, pms, p, iv, c, lf), branches)
+  | PrimitiveEta (mv, args) -> Internal.Std (metas, mkApp (mkMeta mv, Array.map nf_metas args))
+  in
   Proofview.tclTHEN
     (Proofview.Unsafe.tclEVARS (Evd.clear_metas sigma))
-    (Internal.refiner_gen (Case (metas, r, branches)))
+    (Internal.refiner_gen arg)
   end
 
 (* [unifyTerms] et [unify] ne semble pas gérer les Meta, en

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -645,6 +645,8 @@ let clenv_pose_dependent_evars ?with_evars clenv =
   let sigma = pose_dependent_evars ?with_evars clenv.env clenv.evd (clenv_type clenv) in
   update_clenv_evd clenv sigma
 
+type case_node = (case_info * EInstance.t * EConstr.t array * EConstr.case_return * EConstr.case_invert * EConstr.t)
+
 module Internal =
 struct
 
@@ -760,26 +762,20 @@ and mk_arggoals env sigma goalacc funty allargs =
   in
   List.fold_left_map foldmap (goalacc, funty, sigma) allargs
 
-let treat_case env sigma ci lbrty lf acc' =
+let treat_case env sigma ci lbrty accu =
   let open EConstr in
-  let fold (lacc, sigma, bacc) ty (brctx, br) =
-    let head, args = match kind sigma br with
-    | App (f, cl) -> f, cl
-    | _ -> (br, [||])
-    in
-    let () = assert (isMeta sigma head) in
-    let () = assert (CArray.for_all (fun c -> isRel sigma c) args) in
-    let (r, s, head'') =
-      (* TODO: tweak this to prevent dummy β-cuts *)
-      let ty = nf_betaiota env sigma ty in
-      let hyps = Environ.named_context_val env in
-      let (gl,ev,sigma) = mk_goal sigma hyps ty in
-      gl::lacc, sigma, ev
-    in
-    let br' = mkApp (head'', args) in
-    (r,s, (brctx, br') :: bacc)
+  let fold (sigma, accu) (ctx, ty) =
+    let open Context.Rel.Declaration in
+    let brctx = Array.of_list (List.rev_map get_annot ctx) in
+    let args = Context.Rel.instance mkRel 0 ctx in
+    (* TODO: tweak this to prevent dummy β-cuts *)
+    let ty = nf_betaiota env sigma (it_mkProd_or_LetIn ty ctx) in
+    let hyps = Environ.named_context_val env in
+    let (gl, ev, sigma) = mk_goal sigma hyps ty in
+    let br' = mkApp (ev, args) in
+    (sigma, gl :: accu), (brctx, br')
   in
-  Array.fold_left2 fold (acc', sigma, []) lbrty lf
+  Array.fold_left_map fold (sigma, accu) lbrty
 
 let std_refine env sigma cl r =
   let r = make_proof env sigma r in
@@ -790,21 +786,17 @@ let std_refine env sigma cl r =
 (* find appropriate names for pattern variables. Useful in the Case
    and Inversion (case_then_using et case_nodep_then_using) tactics. *)
 
-let case_refine env sigma ~branches (ci, u, pms, p, iv, c, lf) =
+let case_refine env sigma ~branches (ci, u, pms, p, iv, c) =
   let c = make_proof env sigma c in
   let () = if Array.exists (fun c -> occur_meta sigma c) pms then error_unsupported_deep_meta () in
   let (acc',ct,sigma,c') = mk_refgoals env sigma [] None c in
-  let (acc'',sigma,rbranches) = treat_case env sigma ci branches lf acc' in
-  let lf' = Array.rev_of_list rbranches in
-  let ans = EConstr.mkCase (ci, u, pms, p, iv, c', lf') in
+  let ((sigma, acc''), lf) = treat_case env sigma ci branches acc' in
+  let ans = EConstr.mkCase (ci, u, pms, p, iv, c', lf) in
   (sigma, acc'', ans)
 
 type refiner_kind =
 | Std of clbinding Metamap.t * EConstr.t
-| Case of
-  clbinding Metamap.t *
-  (case_info * EInstance.t * EConstr.t array * EConstr.case_return * EConstr.case_invert * EConstr.t * EConstr.case_branch array) *
-  EConstr.t array
+| Case of clbinding Metamap.t * case_node * (EConstr.rel_context * EConstr.t) array
 
 let refiner_gen is_case =
   let open Proofview.Notations in
@@ -871,10 +863,10 @@ let res_pf ?(with_evars=false) ?(with_classes=true) ?(flags=dft ()) clenv =
   end
 
 type case_analysis =
-| RealCase of EConstr.case
-| PrimitiveEta of metavariable * EConstr.t array
+| RealCase of case_node
+| PrimitiveEta of EConstr.t array
 
-let build_case_analysis env sigma (ind, u) params pred indices indarg branches dep knd =
+let build_case_analysis env sigma (ind, u) params pred indices indarg dep knd =
   let open Inductiveops in
   let open Context.Rel.Declaration in
   (* Assumes that the arguments do not contain free rels *)
@@ -919,18 +911,10 @@ let build_case_analysis env sigma (ind, u) params pred indices indarg branches d
       if Typeops.should_invert_case env ci then CaseInvert { indices = indices }
       else NoInvert
     in
-    let mk_branch i (mv, ctx, _) =
-      (* get the generated names for the branch *)
-      let brnas = Array.of_list (List.rev_map get_annot ctx) in
-      let args = Context.Rel.instance mkRel 0 ctx in
-      (brnas, mkApp (mkMeta mv, args))
-    in
-    let br = Array.mapi mk_branch branches in
-    RealCase (ci, u, params, (pnas, pbody), iv, indarg, br)
+    RealCase (ci, u, params, (pnas, pbody), iv, indarg)
   | Some ps ->
-    let (mv, _, _) = branches.(0) in
     let args = Array.map (fun p -> mkProj (Projection.make p true, indarg)) ps in
-    PrimitiveEta (mv, args)
+    PrimitiveEta args
 
 let case_pf ?(with_evars=false) ?submetas ~dep (indarg, typ) =
   Proofview.Goal.enter begin fun gl ->
@@ -1003,7 +987,7 @@ let case_pf ?(with_evars=false) ?submetas ~dep (indarg, typ) =
   let sigma = pose_dependent_evars ~with_evars env sigma (meta_instance env sigma (mk_freelisted templtyp)) in
 
   (* Build the case node proper *)
-  let body = build_case_analysis env sigma (ind, u) params pred indices indarg branches dep s in
+  let body = build_case_analysis env sigma (ind, u) params pred indices indarg dep s in
 
   (* After an apply, all the subgoals including those dependent shelved ones are in
     the hands of the user and resolution won't be called implicitely on them. *)
@@ -1016,14 +1000,17 @@ let case_pf ?(with_evars=false) ?submetas ~dep (indarg, typ) =
   let metas = Evd.meta_list sigma in
   (* Note that the environment rel context does matter for meta_instance *)
   let nf_metas c = meta_instance env sigma { rebus = c; freemetas = metaset } in
-  let branches = Array.map (fun (_, ctx, t) -> nf_metas (it_mkProd_or_LetIn t ctx)) branches in
   let arg = match body with
-  | RealCase (ci, u, pms, p, iv, c, lf) ->
+  | RealCase (ci, u, pms, p, iv, c) ->
     let c = nf_metas c in
     let pms = Array.map nf_metas pms in
     let p = on_snd nf_metas p in
-    Internal.Case (metas, (ci, u, pms, p, iv, c, lf), branches)
-  | PrimitiveEta (mv, args) -> Internal.Std (metas, mkApp (mkMeta mv, Array.map nf_metas args))
+    let map (_, ctx, t) = (Context.Rel.map nf_metas ctx, nf_metas t) in
+    let branches = Array.map map branches in
+    Internal.Case (metas, (ci, u, pms, p, iv, c), branches)
+  | PrimitiveEta args ->
+    let (mv, _, _) = branches.(0) in
+    Internal.Std (metas, mkApp (mkMeta mv, Array.map nf_metas args))
   in
   Proofview.tclTHEN
     (Proofview.Unsafe.tclEVARS (Evd.clear_metas sigma))

--- a/test-suite/bugs/bug_17541.v
+++ b/test-suite/bugs/bug_17541.v
@@ -1,0 +1,8 @@
+(* Check that the case tactic does not reduce on constructors *)
+Goal True.
+Proof.
+case 0.
++ exact I.
++ match goal with [ |- nat -> True ] => idtac end.
+  intro; exact I.
+Qed.


### PR DESCRIPTION
This is a very weird corner case of the case tactics and its variants. If the argument βι-normalizes to a constructor, the case node will disappear as it is also reduced by the same reduction strategy. This is specific to case-like tactics because destruct and friends internally only apply to Var arguments which are left untouched by βι-reduction.

After this patch we treat the argument in a fully rigid way, so that a call to e.g. case 0 with generate two subgoals and not only one. I doubt that it really happens in the wild, barring some arcane design pattern I have not forecast.