### PR TITLE
Make detyping of projections parameter recovery more robust

### DIFF
--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -919,12 +919,15 @@ let evar_handler sigma =
   let evar_repack ev = mkLEvar sigma ev in
   { evar_expand; evar_relevant; evar_repack; qvar_relevant }
 
-let existential_type d (n, args) =
-  let info =
-    try find_undefined d n
-    with Not_found ->
-      anomaly (str "Evar " ++ str (string_of_existential n) ++ str " was not declared.") in
-  instantiate_evar_array d info (evar_concl info) args
+let existential_type_opt d (n, args) =
+  match find_undefined d n with
+  | exception Not_found -> None
+  | info ->
+    Some (instantiate_evar_array d info (evar_concl info) args)
+
+let existential_type d n = match existential_type_opt d n with
+  | Some t -> t
+  | None -> anomaly (str "Evar " ++ str (string_of_existential (fst n)) ++ str " was not declared.")
 
 let existential_type0 = existential_type
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -286,6 +286,8 @@ val existential_value : evar_map -> econstr pexistential -> econstr
 
 val existential_value0 : evar_map -> existential -> constr
 
+val existential_type_opt : evar_map -> econstr pexistential -> etypes option
+
 val existential_type : evar_map -> econstr pexistential -> etypes
 
 val existential_type0 : evar_map -> existential -> types

--- a/test-suite/output/bug_16716.out
+++ b/test-suite/output/bug_16716.out
@@ -1,0 +1,3 @@
+File "./output/bug_16716.v", line 11, characters 0-55:
+The command has indeed failed with message:
+Uncaught Ltac2 exception: E (constr:(?X4.(r _)))

--- a/test-suite/output/bug_16716.v
+++ b/test-suite/output/bug_16716.v
@@ -1,0 +1,12 @@
+Require Import Ltac2.Ltac2.
+
+Set Primitive Projections.
+Record R A := mkR { r : A }.
+
+Ltac2 Type exn ::= [ E (constr) ].
+
+Set Printing Projections.
+Set Printing Primitive Projection Parameters.
+
+Fail Ltac2 Eval Control.zero (E open_constr:(_.(r _))).
+(* Error: Uncaught Ltac2 exception: E (constr:(...)) *)


### PR DESCRIPTION
If we have a bad evar map retyping can fail with anomalies, eg the one from Evd.existential_type

Close #16716
