### PR TITLE
tclFOCUSID: when used on a shelved goal, shelve all produced goals

### DIFF
--- a/test-suite/bugs/bug_16513.v
+++ b/test-suite/bugs/bug_16513.v
@@ -1,0 +1,12 @@
+Goal True.
+Proof.
+  assert nat;clear.
+  refine ?[foo].
+  [foo]:shelve.
+  exact I.
+
+  [foo]: refine (_ + _).
+
+  Unshelve.
+  1,2: exact 0.
+Qed.


### PR DESCRIPTION
Fix #16513
