### PR TITLE
Slightly tweak the heuristic to pose dependent metas in case_pf.

### DIFF
--- a/doc/changelog/04-tactics/17564-case-pf-pose-dependent-metas.rst
+++ b/doc/changelog/04-tactics/17564-case-pf-pose-dependent-metas.rst
@@ -1,0 +1,12 @@
+- **Fixed:**
+  intropatterns destructing a term whose type is a product
+  cannot silently create shelved evars anymore. Instead, it
+  fails with an unsolvable variable. This can be fixed in a
+  backwards compatible way by using the e-variant of the parent
+  tactic
+  (`#17564 <https://github.com/coq/coq/pull/17564>`_,
+  by Pierre-Marie Pédrot).
+- **Changed:**
+  the unification heuristics for implicit arguments of the :tacn:`case` tactic.
+  We unconditionally recommend using :tacn:`destruct` instead, and even more so
+  in case of incompatibility.

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -1019,10 +1019,11 @@ module Unsafe = struct
   let tclEVARS evd =
     Pv.modify (fun ps -> { ps with solution = evd })
 
-  let tclNEWGOALS gls =
+  let tclNEWGOALS ?(before = false) gls =
     Pv.modify begin fun step ->
       let gls = undefined step.solution gls in
-      { step with comb = step.comb @ gls }
+      let comb = if before then gls @ step.comb else step.comb @ gls in
+      { step with comb }
     end
 
   let tclNEWSHELVED gls =

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -449,10 +449,11 @@ module Unsafe : sig
   (** Set the global environment of the tactic *)
   val tclSETENV : Environ.env -> unit tactic
 
-  (** [tclNEWGOALS gls] adds the goals [gls] to the ones currently
-      being proved, appending them to the list of focused goals. If a
-      goal is already solved, it is not added. *)
-  val tclNEWGOALS : Proofview_monad.goal_with_state list -> unit tactic
+  (** [tclNEWGOALS ~before gls] adds the goals [gls] to the ones currently
+      being proved. If [before] is true, it prepends them to the list of focused
+      goals, otherwise it appends them (default). If a goal is already
+      solved, it is not added. *)
+  val tclNEWGOALS : ?before:bool -> Proofview_monad.goal_with_state list -> unit tactic
 
   (** [tclNEWSHELVED gls] adds the goals [gls] to the shelf. If a
       goal is already solved, it is not added. *)

--- a/proofs/clenv.mli
+++ b/proofs/clenv.mli
@@ -78,7 +78,6 @@ val clenv_push_prod : clausenv -> (metavariable * bool * clausenv) option
 val unify : ?flags:unify_flags -> constr -> unit Proofview.tactic
 val res_pf : ?with_evars:bool -> ?with_classes:bool -> ?flags:unify_flags -> clausenv -> unit Proofview.tactic
 val case_pf : ?with_evars:bool ->
-  ?submetas:(metavariable * clbinding) list ->
   dep:bool -> (constr * types) -> unit Proofview.tactic
 
 val clenv_pose_dependent_evars : ?with_evars:bool -> clausenv -> clausenv

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1651,12 +1651,12 @@ let general_case_analysis_in_context with_evars clear_flag (c,lbindc) =
   in
   let id = try Some (destVar sigma c) with DestKO -> None in
   let indclause = make_clenv_binding env sigma (c, t) lbindc in
+  let indclause = Clenv.clenv_pose_dependent_evars ~with_evars:true indclause in
   let metas = Evd.meta_list (clenv_evd indclause) in
   let submetas = List.map (fun mv -> mv, Metamap.find mv metas) (clenv_arguments indclause) in
   let sigma = Evd.clear_metas (clenv_evd indclause) in
   Tacticals.tclTHENLIST [
-    Proofview.Unsafe.tclEVARS sigma;
-    Clenv.case_pf ~with_evars ~submetas ~dep (c, clenv_type indclause);
+    Tacticals.tclWITHHOLES with_evars (Clenv.case_pf ~with_evars ~submetas ~dep (c, clenv_type indclause)) sigma;
     apply_clear_request clear_flag (use_clear_hyp_by_default ()) id;
   ]
   end

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -2449,8 +2449,9 @@ let intro_or_and_pattern ?loc with_evars ll thin tac id =
   let nv_with_let = Array.map List.length branchsigns in
   let ll = fix_empty_or_and_pattern (Array.length branchsigns) ll in
   let ll = get_and_check_or_and_pattern ?loc ll branchsigns in
+  let case = if with_evars then simplest_ecase else simplest_case in
   Tacticals.tclTHENLASTn
-    (Tacticals.tclTHEN (simplest_ecase c) (clear [id]))
+    (Tacticals.tclTHEN (case c) (clear [id]))
     (Array.map2 (fun n l -> tac thin (Some n) l)
        nv_with_let ll)
   end

--- a/test-suite/bugs/bug_17487_2.v
+++ b/test-suite/bugs/bug_17487_2.v
@@ -33,10 +33,8 @@ Qed.
 
 Goal forall (f : forall n : nat, 0 = n), True.
 Proof.
-intros [].
-+ match goal with [ |- nat ] => exact 0 end.
-+ match goal with [ |- True ] => exact I end.
-Qed.
+Fail intros [].
+Abort.
 
 Goal forall (f : forall n : nat, 0 = n), True.
 Proof.


### PR DESCRIPTION
We refine the case scrutinee before calling the case_pf function proper, and rely on tclWITHHOLES instead of the legacy refiner to check that holes are correctly solved rather than turned into shelved evars.

As a side-effect, this fixes a bug with intropatterns that silently introduced shelved evars even though the toplevel tactic should have forbidden them. A trivial fix is to turn the offending tactic into its e-variant.