### PR TITLE
gen_rules improvements: remove -fake-source, allow cross dependencies between theories/ and Ltac2/

### DIFF
--- a/stm/asyncTaskQueue.ml
+++ b/stm/asyncTaskQueue.ml
@@ -120,7 +120,7 @@ module Make(T : Task) () = struct
         | ( "-async-proofs" | "-vio2vo" | "-o"
           | "-load-vernac-source" | "-l" | "-load-vernac-source-verbose" | "-lv"
           | "-require-import" | "-require-export" | "-ri" | "-re"
-          | "-load-vernac-object" | "-fake-source"
+          | "-load-vernac-object"
           | "-set" | "-unset" | "-compat" | "-mangle-names" | "-diffs"
           | "-async-proofs-cache" | "-async-proofs-j" | "-async-proofs-tac-j"
           | "-async-proofs-private-flags" | "-async-proofs-tactic-error-resilience"

--- a/tools/dune_rule_gen/coq_rules.ml
+++ b/tools/dune_rule_gen/coq_rules.ml
@@ -21,17 +21,17 @@ let _debug = false
 
 module FlagUtil = struct
 
-  let read_plugin_dir ~root_lvl =
-    let plugins_dir = Path.(make "plugins" |> adjust ~lvl:root_lvl) in
+  let read_plugin_dir () =
+    let plugins_dir = Path.make "plugins" in
     Sys.readdir (Path.to_string plugins_dir) |> Array.to_list
 
   (* XXX: This should go away once we fully use findlib in coqdep;
      for that, we must depend on the META file and pass -m to coqdep.
      Left for a future PR.
    *)
-  let local_plugin_flags ~root_lvl =
-    let plugins_dir = Path.(make "plugins" |> adjust ~lvl:root_lvl) in
-    read_plugin_dir ~root_lvl
+  let local_plugin_flags () =
+    let plugins_dir = Path.make "plugins" in
+    read_plugin_dir ()
     |> List.map (Path.relative plugins_dir)
     |> Util.list_concat_map (fun p -> [Arg.A "-I"; Arg.Path p])
 
@@ -42,35 +42,35 @@ module FlagUtil = struct
   (* This can also go when the -I flags are gone, by passing the meta
      file for coq-core *)
   (* Use non-local libs for split build *)
-  let findlib_plugin_flags ~root_lvl =
+  let findlib_plugin_flags () =
     let () = Findlib.init () in
-    read_plugin_dir ~root_lvl
+    read_plugin_dir ()
     |> findlib_plugin_fixup
     |> List.map (fun p -> Findlib.package_directory ("coq-core.plugins."^p))
     |> Util.list_concat_map (fun p -> [Arg.A "-I"; Arg.Path (Path.make p)])
 
-  let findlib_plugin_flags ~root_lvl =
-    try findlib_plugin_flags ~root_lvl
+  let findlib_plugin_flags () =
+    try findlib_plugin_flags ()
     with
       Fl_package_base.No_such_package (p,_) ->
       raise (Invalid_argument ("failed to locate Coq plugins in split build mode: " ^ p))
 
-  let plugin_flags ~split =
-    if split then findlib_plugin_flags else local_plugin_flags
+  let plugin_flags ~split () =
+    if split then findlib_plugin_flags () else local_plugin_flags ()
 
   (* Native flag *)
-  let findlib_native_dir ~root_lvl =
+  let findlib_native_dir () =
     try
-      Findlib.package_directory ("coq-core.kernel") |> Path.make |> Path.adjust ~lvl:root_lvl
+      Findlib.package_directory ("coq-core.kernel") |> Path.make
     with
       Fl_package_base.No_such_package (p,_) ->
       raise (Invalid_argument ("failed to locate Coq kernel package in split build mode: " ^ p))
 
-  let local_native_dir ~root_lvl =
-    Path.make "kernel/.kernel.objs/byte" |> Path.adjust ~lvl:root_lvl
+  let local_native_dir =
+    Path.make "kernel/.kernel.objs/byte"
 
-  let kernel_cmi_dir ~split =
-    if split then findlib_native_dir else local_native_dir
+  let kernel_cmi_dir ~split () =
+    if split then findlib_native_dir () else local_native_dir
 
 end
 
@@ -139,10 +139,11 @@ module Context = struct
     ; dep_info : Dep_info.t
     ; async_deps : string list  (* whether coqc needs the workers *)
     ; package : string          (* installation path under lib/coq *)
+    ; root_lvl : int
     }
 
-  let native_common ~root_lvl ~split =
-    let path_coq_kernel_cmi = FlagUtil.kernel_cmi_dir ~root_lvl ~split in
+  let native_common ~split () =
+    let path_coq_kernel_cmi = FlagUtil.kernel_cmi_dir ~split () in
     [ Arg.A "-nI"; Path path_coq_kernel_cmi
     ; A "-native-output-dir"; A "."
     ]
@@ -168,15 +169,15 @@ module Context = struct
 
       (* both coqdep and coqc need the -I flags, coqc otherwise
          doesn't use the legacy plugin resolution method *)
-      let plugin_flags = FlagUtil.plugin_flags ~root_lvl ~split in
+      let plugin_flags = FlagUtil.plugin_flags ~split () in
 
       let loadpath =
         Arg.[ A "-boot"; A "-R"
-            ; Path (Path.make "."); A (String.concat "." tname)
+            ; Path (Path.make package); A (String.concat "." tname)
             ]
         @ plugin_flags
       in
-      let native_common = native_common ~root_lvl ~split in
+      let native_common = native_common ~split () in
       let native_coqc = native_coqc ~native_common ~native:(Coq_module.Rule_type.native_coqc rule) in
       let common = Arg.[ A "-w"; A "+default"; A "-q" ] in
 
@@ -187,7 +188,7 @@ module Context = struct
     let dep_info = build_dep_info ~coqdep_args dir_info in
 
     let async_deps = if async then build_async_deps else [] in
-    { tname; flags; rule; boot; dep_info; async_deps;  package }
+    { tname; flags; rule; boot; dep_info; async_deps;  package; root_lvl }
 
 end
 
@@ -203,7 +204,7 @@ let boot_module_setup ~cctx coq_module =
   | Stdlib ->
     (match Coq_module.prefix coq_module with
      | ["Init"] -> [ Arg.A "-noinit" ], []
-     | _ -> [ ], [ Path.make prelude_path ]
+     | _ -> [ ], [ Path.relative (Path.make "theories") prelude_path ]
     )
   | Regular (Some stdlib) ->
     [ Arg.A "-R"; Arg.Path stdlib; Arg.A "Coq" ],
@@ -233,7 +234,7 @@ let module_rule ~(cctx : Context.t) coq_module =
   let coqc_flags = cctx.flags.loadpath @ cctx.flags.user @ cctx.flags.common @ cctx.flags.native_coqc in
   let vfile_deps, flags = boot_deps @ vfile_deps, boot_flags @ coqc_flags in
   (* Adjust paths *)
-  let lvl = Coq_module.prefix coq_module |> List.length in
+  let lvl = cctx.root_lvl + (Coq_module.prefix coq_module |> List.length) in
   let flags = List.map (Arg.adjust ~lvl) flags |> Arg.List.to_string in
   let deps = List.map (Path.adjust ~lvl) vfile_deps |> List.map Path.to_string in
   (* Depend on the workers if async *)
@@ -245,14 +246,13 @@ let module_rule ~(cctx : Context.t) coq_module =
     let file = if starts_with ~prefix:"./" file then String.sub file 2 (String.length file - 2)
       else file
     in
-    "-fake-source "^cctx.package ^ "/" ^ file in
+    "-fake-source " ^ file in
   let action = Format.asprintf "(run coqc %s %s %%{dep:%s})" flags fake_source vfile_base in
   let targets = Coq_module.obj_files ~tname ~rule coq_module in
   let alias = if rule = Coq_module.Rule_type.Quick then Some "vio" else None in
   { Dune_file.Rule.targets; deps; action; alias }
 
 let vio2vo_rule ~(cctx : Context.t) coq_module =
-  let _ = cctx in
   let vfile = Coq_module.source coq_module in
   let viofile = Path.replace_ext ~ext:".vio" vfile in
 
@@ -274,7 +274,7 @@ let vio2vo_rule ~(cctx : Context.t) coq_module =
   *)
   let viofile_deps = [viofile] in
   (* Adjust paths *)
-  let lvl = Coq_module.prefix coq_module |> List.length in
+  let lvl = cctx.root_lvl + (Coq_module.prefix coq_module |> List.length) in
   let flags = List.map (Arg.adjust ~lvl) flags |> Arg.List.to_string in
   let deps = List.map (Path.adjust ~lvl) viofile_deps |> List.map Path.to_string in
   (* vio2vo doesn't follow normal convention... so we can't use Coq_module.obj_files *)
@@ -315,7 +315,7 @@ let coqnative_module_rule ~(cctx: Context.t) coq_module =
   let flags = boot_flags @ cctx.flags.loadpath @ cctx.flags.native_common in
   let vofile_deps = boot_deps @ vofile_deps in
   (* Adjust paths *)
-  let lvl = Coq_module.prefix coq_module |> List.length in
+  let lvl = cctx.root_lvl + (Coq_module.prefix coq_module |> List.length) in
   let flags = List.map (Arg.adjust ~lvl) flags |> Arg.List.to_string in
   let deps = List.map (Path.adjust ~lvl) vofile_deps |> List.map Path.to_string in
   (* Build rule *)

--- a/tools/dune_rule_gen/gen_rules.ml
+++ b/tools/dune_rule_gen/gen_rules.ml
@@ -62,12 +62,11 @@ let main () =
 
   let boot = if tname = ["Coq"]
     then Coq_rules.Boot_type.Stdlib
-    else Coq_rules.Boot_type.Regular (Some (Path.(adjust ~lvl:root_lvl (make "theories"))))
+    else Coq_rules.Boot_type.Regular (Some (Path.make "theories"))
   in
 
   (* Rule generation *)
-  Unix.chdir base_dir;
-  let dir_info = Dir_info.scan ~prefix:[] "." in
+  let dir_info = Dir_info.scan ~prefix:[] base_dir in
   let package = base_dir in
   let cctx = Coq_rules.Context.make ~root_lvl ~tname ~user_flags ~rule ~boot ~dir_info ~async ~package ~split in
   let vo_rules = Coq_rules.vo_rules ~dir_info ~cctx in

--- a/toplevel/ccompile.ml
+++ b/toplevel/ccompile.ml
@@ -20,9 +20,9 @@ let create_empty_file filename =
   let f = open_out filename in
   close_out f
 
-let source copts ldir file = Loc.InFile {
+let source ldir file = Loc.InFile {
     dirpath=Some (Names.DirPath.to_string ldir);
-    file = Option.default file copts.fake_source;
+    file = file;
   }
 
 (* Compile a vernac file *)
@@ -66,7 +66,7 @@ let compile opts stm_options injections copts ~echo ~f_in ~f_out =
 
       let wall_clock1 = Unix.gettimeofday () in
       let check = Stm.AsyncOpts.(stm_options.async_proofs_mode = APoff) in
-      let source = source copts ldir long_f_dot_in in
+      let source = source ldir long_f_dot_in in
       let state = Vernac.load_vernac ~echo ~check ~state ~source long_f_dot_in in
       let fullstate = Stm.finish ~doc:state.doc in
       ensure_no_pending_proofs ~filename:long_f_dot_in fullstate;
@@ -96,7 +96,7 @@ let compile opts stm_options injections copts ~echo ~f_in ~f_out =
       let state = { doc; sid; proof = None; time = Option.map Vernac.make_time_output opts.config.time } in
       let state = Load.load_init_vernaculars opts ~state in
       let ldir = Stm.get_ldir ~doc:state.doc in
-      let source = source copts ldir long_f_dot_in in
+      let source = source ldir long_f_dot_in in
       let state = Vernac.load_vernac ~echo ~check:false ~source ~state long_f_dot_in in
       let state = Stm.finish ~doc:state.doc in
       ensure_no_pending_proofs state ~filename:long_f_dot_in;

--- a/toplevel/coqcargs.ml
+++ b/toplevel/coqcargs.ml
@@ -15,7 +15,6 @@ type t =
 
   ; compile_file: (string * bool) option  (* bool is verbosity  *)
   ; compilation_output_name : string option
-  ; fake_source : string option
 
   ; vio_checking : bool
   ; vio_tasks    : (int list * string) list
@@ -34,7 +33,6 @@ let default =
 
   ; compile_file = None
   ; compilation_output_name = None
-  ; fake_source = None
 
   ; vio_checking = false
   ; vio_tasks    = []
@@ -171,8 +169,6 @@ let parse arglist : t =
         (* Output filename *)
         | "-o" ->
           { oval with compilation_output_name = Some (next ()) }
-        | "-fake-source" ->
-          { oval with fake_source = Some (next ()) }
         | "-quick" ->
           warn_deprecated_quick();
           set_compilation_mode oval BuildVio

--- a/toplevel/coqcargs.mli
+++ b/toplevel/coqcargs.mli
@@ -29,7 +29,6 @@ type t =
 
   ; compile_file: (string * bool) option  (* bool is verbosity  *)
   ; compilation_output_name : string option
-  ; fake_source : string option
 
   ; vio_checking : bool
   ; vio_tasks    : (int list * string) list


### PR DESCRIPTION
fake-source is unreleased 8.18-only (https://github.com/coq/coq/pull/17334) so no need for a changelog or deprecation to remove it.