### PR TITLE
Ltac2: use ValExt for uint63 and float64

### DIFF
--- a/plugins/ltac2/tac2ffi.mli
+++ b/plugins/ltac2/tac2ffi.mli
@@ -39,10 +39,6 @@ type valexpr =
   (** Open constructors *)
 | ValExt : 'a Tac2dyn.Val.tag * 'a -> valexpr
   (** Arbitrary data *)
-| ValUint63 of Uint63.t
-  (** Primitive integers *)
-| ValFloat of Float64.t
-  (** Primitive floats *)
 
 type 'a arity
 
@@ -213,7 +209,10 @@ val val_case : Constr.case_info Val.tag
 val val_binder : (Name.t Context.binder_annot * types) Val.tag
 val val_univ : Univ.Level.t Val.tag
 val val_free : Id.Set.t Val.tag
+val val_uint63 : Uint63.t Val.tag
+val val_float : Float64.t Val.tag
 val val_ltac1 : Geninterp.Val.t Val.tag
+
 val val_ind_data : (Names.Ind.t * Declarations.mutual_inductive_body) Val.tag
 
 val val_exn : Exninfo.iexn Tac2dyn.Val.tag

--- a/plugins/ltac2/tac2interp.ml
+++ b/plugins/ltac2/tac2interp.ml
@@ -72,7 +72,7 @@ let match_ctor_against ctor v =
     if Int.equal i i' then vs
     else raise NoMatch
   | { cindx = Closed _ }, ValOpn _ -> assert false
-  | _, (ValStr _ | ValCls _ | ValExt _ | ValUint63 _ | ValFloat _) -> assert false
+  | _, (ValStr _ | ValCls _ | ValExt _) -> assert false
 
 let check_atom_against atm v =
   match atm, v with


### PR DESCRIPTION
There does not seem to be a reason to have dedicated constructors for these datatypes.
