### PR TITLE
Keep anticipate synterp objects even for sealed modules

### DIFF
--- a/test-suite/coqchk/bug_17570.v
+++ b/test-suite/coqchk/bug_17570.v
@@ -1,0 +1,8 @@
+Module Type T.
+
+End T.
+
+Module M : T.
+  Require Import BinNums.
+  Definition f := @positive.
+End M.

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -790,7 +790,7 @@ let end_module_core id (m_info : current_module_syntax_info) objects fs =
   let sobjs0, keep, special = match m_info.cur_typ with
     | None -> ([], Objs substitute), keep, special
     | Some (mty, inline) ->
-      SynterpVisitor.get_module_sobjs false () inline mty, [], []
+      SynterpVisitor.get_module_sobjs false () inline mty, [], special
   in
   Summary.Synterp.unfreeze_summaries ~partial:true fs;
   let sobjs = let (ms,objs) = sobjs0 in (m_info.cur_mbids@ms,objs) in


### PR DESCRIPTION
Fix #17570
