### PR TITLE
Let with Qed: produce really-Qed side definition

### DIFF
--- a/dev/ci/user-overlays/17576-SkySkimmer-let-abstract.sh
+++ b/dev/ci/user-overlays/17576-SkySkimmer-let-abstract.sh
@@ -1,0 +1,1 @@
+overlay metacoq https://github.com/SkySkimmer/metacoq let-abstract 17576

--- a/doc/changelog/08-vernac-commands-and-options/17576-let-abstract.rst
+++ b/doc/changelog/08-vernac-commands-and-options/17576-let-abstract.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  :cmd:`Let` with :cmd:`Qed` produces an opaque side definition
+  instead of being treated as a transparent `let` after the section is closed.
+  The previous behaviour can be recovered using :attr:`clearbody` and :cmd:`Defined`
+  (`#17576 <https://github.com/coq/coq/pull/17576>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/language/core/sections.rst
+++ b/doc/sphinx/language/core/sections.rst
@@ -75,10 +75,15 @@ usable outside the section as shown in this :ref:`example <section_local_declara
    clears the body of the definition in the proof context of following proofs.
    The kernel will still use the body when checking.
 
-.. warn:: @ident is declared opaque but this is not fully respected inside the section and not at all outside the section.
+.. note::
 
-   Terminating the proof for a :cmd:`Let` with :cmd:`Qed` is deprecated.
-   It has the same behavior as :attr:`clearbody` with :cmd:`Defined`.
+   Terminating the proof for a :cmd:`Let` with :cmd:`Qed` produces an opaque side definition.
+   `Let foo : T. tactics. Qed.` is equivalent to
+
+   .. coqdoc::
+
+      Lemma foo_subproof : T. tactics. Qed.
+      #[clearbody] Let foo := foo_subproof.
 
 .. cmd:: Context {+ @binder }
 

--- a/test-suite/bugs/bug_17576_1.v
+++ b/test-suite/bugs/bug_17576_1.v
@@ -1,0 +1,32 @@
+(* Let doesn't respect (default) Proof using *)
+
+(* Maybe we will want to change this behaviour someday
+   but keep in mind that if we do then "bar'" should get 2 A arguments.
+*)
+
+Set Default Proof Using "Type".
+Set Warnings "-opaque-let".
+
+Section S.
+
+  Variable A : Type.
+  Variable a : A.
+
+  Let foo : A.
+  Proof. exact a. Qed.
+
+  Definition bar := foo.
+
+  Variable b : A.
+
+  Let foo' : A.
+  Proof using a b.
+    exact b.
+  Qed.
+
+  Definition bar' := foo'.
+
+End S.
+
+Check bar : forall A, A -> A.
+Check bar' : forall A, A -> A.

--- a/test-suite/bugs/bug_17576_1.v
+++ b/test-suite/bugs/bug_17576_1.v
@@ -13,14 +13,16 @@ Section S.
   Variable a : A.
 
   Let foo : A.
-  Proof. exact a. Qed.
+  Proof. (* Default Proof Using silently ignored *)
+    exact a.
+  Qed.
 
   Definition bar := foo.
 
   Variable b : A.
 
   Let foo' : A.
-  Proof using a b.
+  Fail Proof using a b.
     exact b.
   Qed.
 

--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -22,7 +22,7 @@ module RelDecl = Context.Rel.Declaration
 
 let declare_variable is_coe ~kind typ univs imps impl {CAst.v=name} =
   let kind = Decls.IsAssumption kind in
-  let () = Declare.declare_variable ~name ~kind ~typ ~impl ~univs in
+  let () = Declare.declare_variable ~name ~kind ~typing_flags:None ~typ ~impl ~univs in
   let () = Declare.assumption_message name in
   let r = GlobRef.VarRef name in
   let () = maybe_declare_manual_implicits true r imps in

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1664,6 +1664,8 @@ let get_recnames pf =
   else
     []
 
+let definition_scope ps = ps.pinfo.info.scope
+
 let set_used_variables ps ~using =
   let open Context.Named.Declaration in
   let env = Global.env () in

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -256,6 +256,8 @@ module Proof : sig
   (** Sets the tactic to be used when a tactic line is closed with [...] *)
   val set_endline_tactic : Genarg.glob_generic_argument -> t -> t
 
+  val definition_scope : t -> Locality.definition_scope
+
   (** Sets the section variables assumed by the proof, returns its closure
    * (w.r.t. type dependencies and let-ins covered by it) *)
   val set_used_variables : t -> using:Proof_using.t -> Constr.named_context * t

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -386,6 +386,7 @@ val declare_entry
 val declare_variable
   :  name:variable
   -> kind:Decls.logical_kind
+  -> typing_flags:Declarations.typing_flags option
   -> typ:Constr.types
   -> impl:Glob_term.binding_kind
   -> univs:UState.named_universes_entry


### PR DESCRIPTION
cf discussion in https://github.com/coq/coq/pull/17544

This does have a tradeoff as the side definition still exists after the section is closed unlike usual.

#### Overlays:

##### To be merged before the PR

- https://github.com/math-comp/math-comp/pull/1114
- https://github.com/math-comp/math-comp/pull/1115
- https://github.com/uds-psl/coq-library-undecidability/pull/215
- https://github.com/mit-plv/fiat-crypto/pull/1698

##### To be merged in sync

- https://github.com/MetaCoq/metacoq/pull/1005
