### PR TITLE
Reject Timeout 0, correctly handle when synterp takes longer than the timeout without getting a signal.

### DIFF
--- a/test-suite/output/bug_17579.out
+++ b/test-suite/output/bug_17579.out
@@ -1,0 +1,9 @@
+File "./output/bug_17579.v", line 2, characters 0-26:
+The command has indeed failed with message:
+Timeout must be > 0.
+File "./output/bug_17579.v", line 5, characters 8-9:
+Error:
+Syntax error: [natural] expected after 'Timeout' (in [vernac_control]).
+
+
+coqc exited with code 1

--- a/test-suite/output/bug_17579.v
+++ b/test-suite/output/bug_17579.v
@@ -1,0 +1,5 @@
+
+Fail Timeout 0 Check True.
+
+(* parse error *)
+Timeout -1 Check True.

--- a/vernac/synterp.mli
+++ b/vernac/synterp.mli
@@ -27,7 +27,7 @@ type module_entry = Modintern.module_struct_expr * Names.ModPath.t * Modintern.m
 type control_entry =
   | ControlTime of { synterp_duration: System.duration }
   | ControlRedirect of string
-  | ControlTimeout of { synterp_duration : System.duration; limit: int }
+  | ControlTimeout of { remaining : float }
   | ControlFail of { st : Vernacstate.Synterp.t }
   | ControlSucceed of { st : Vernacstate.Synterp.t }
 

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -91,9 +91,8 @@ let interp_control_entry ~loc (f : control_entry) ~st
   | ControlSucceed { st = synterp_st } ->
     with_succeed ~st (fun () -> Vernacstate.Synterp.unfreeze synterp_st; fn ~st);
     st.Vernacstate.interp.lemmas, st.Vernacstate.interp.program
-  | ControlTimeout { synterp_duration; limit } ->
-    let timeout = float_of_int limit -. System.duration_real synterp_duration in
-    vernac_timeout ~timeout (fun () -> fn ~st) ()
+  | ControlTimeout { remaining } ->
+    vernac_timeout ~timeout:remaining (fun () -> fn ~st) ()
   | ControlTime { synterp_duration } ->
     let result = System.measure_duration (fun () -> fn ~st) () in
     let result = Result.map (fun (v,d) -> v, System.duration_add d synterp_duration) result in


### PR DESCRIPTION


Fix #17579
