### PR TITLE
Fixes #17583: regression using numerals in the syntax of tactic notations

### DIFF
--- a/doc/changelog/03-notations/17589-master+fix17583-regression-using-numerals-in-tactic-notation.rst
+++ b/doc/changelog/03-notations/17589-master+fix17583-regression-using-numerals-in-tactic-notation.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Regression in using numerals in the syntax of tactic notations
+  (`#17589 <https://github.com/coq/coq/pull/17589>`_,
+  fixes `#17583 <https://github.com/coq/coq/issues/17583>`_,
+  by Hugo Herbelin).

--- a/test-suite/bugs/bug_17583.v
+++ b/test-suite/bugs/bug_17583.v
@@ -1,0 +1,3 @@
+(*"2" should not break the parsing of commands referring to "2" *)
+Tactic Notation "foo" "2" := idtac.
+Global Hint Extern 2 (True) => exact I : core.

--- a/test-suite/bugs/bug_17583.v
+++ b/test-suite/bugs/bug_17583.v
@@ -1,3 +1,7 @@
 (*"2" should not break the parsing of commands referring to "2" *)
 Tactic Notation "foo" "2" := idtac.
 Global Hint Extern 2 (True) => exact I : core.
+
+Require Import Ltac2.Ltac2.
+Ltac2 Notation "foo" "2" := intros.
+Global Hint Extern 2 (True) => exact I : core.

--- a/vernac/egramml.ml
+++ b/vernac/egramml.ml
@@ -35,9 +35,9 @@ let rec ty_rule_of_gram = function
 | [] -> AnyTyRule TyStop
 | GramTerminal s :: rem ->
   let AnyTyRule rem = ty_rule_of_gram rem in
-  let tok = Pcoq.Symbol.token (Pcoq.terminal s) in
-  let r = TyNext (rem, tok, None) in
-  AnyTyRule r
+  (match NumTok.Unsigned.parse_string s with
+  | Some n -> AnyTyRule (TyNext (rem, Pcoq.Symbol.token (Tok.PNUMBER (Some n)), None))
+  | None -> AnyTyRule (TyNext (rem, Pcoq.Symbol.token (Pcoq.terminal s), None)))
 | GramNonTerminal (_, (t, tok)) :: rem ->
   let AnyTyRule rem = ty_rule_of_gram rem in
   let inj = Some (fun obj -> Genarg.in_gen t obj) in


### PR DESCRIPTION
Fixes / closes #17583.

We are a bit less eager to define every terminal of a `Tactic Notation` as a keyword, following what we already did for `Notation`.

We make a patch also for `Ltac2 Notation` which had the same limitation (Ltac2 developers: tell if this is ok).

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
