### PR TITLE
[ci] quick fix for MC 2.0 release

### DIFF
--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -42,19 +42,29 @@ function project {
 ########################################################################
 # MathComp
 ########################################################################
-project mathcomp "https://github.com/math-comp/math-comp" "master"
+project mathcomp "https://github.com/math-comp/math-comp" "mathcomp-1"
 
-project fourcolor "https://github.com/math-comp/fourcolor" "master"
+project fourcolor "https://github.com/math-comp/fourcolor" "e831b0b00e264285f91938917a0a5ef64ec1a829"
+# put back master when testing MathComp 2
+# project fourcolor "https://github.com/math-comp/fourcolor" "master"
 
-project oddorder "https://github.com/math-comp/odd-order" "master"
+project oddorder "https://github.com/math-comp/odd-order" "2c03794e64eef467442a4ea2ef1430b13b0faa97"
+# put back master when testing MathComp 2
+# project oddorder "https://github.com/math-comp/odd-order" "master"
 
-project mczify "https://github.com/math-comp/mczify" "master"
+project mczify "https://github.com/math-comp/mczify" "2046446984f7b8c8f5102df4df6076b60874e688"
+# put back master when testing MathComp 2
+# project mczify "https://github.com/math-comp/mczify" "master"
 
-project finmap "https://github.com/math-comp/finmap" "master"
+project finmap "https://github.com/math-comp/finmap" "cea9f088c9cddea1173bc2f7c4c7ebda35081b60"
+# put back master when testing MathComp 2
+# project finmap "https://github.com/math-comp/finmap" "master"
 
 project bigenough "https://github.com/math-comp/bigenough" "master"
 
-project analysis "https://github.com/math-comp/analysis" "master"
+project analysis "https://github.com/math-comp/analysis" "9193f4a1278409cc13a1de739adf3620aa24a638"
+# put back master when testing MathComp 2
+# project analysis "https://github.com/math-comp/analysis" "master"
 
 ########################################################################
 # UniMath


### PR DESCRIPTION
MathComp master now points to mathcomp 2.0.
For now we stay on mathcomp 1