### PR TITLE
Ltac2 multimatch: preserve backtracking error from last branch

### DIFF
--- a/doc/changelog/06-Ltac2-language/17597-ltac2-multimatch-fail.rst
+++ b/doc/changelog/06-Ltac2-language/17597-ltac2-multimatch-fail.rst
@@ -1,0 +1,10 @@
+- **Fixed:**
+  `multi_match!`, `multi_match! goal` and the underlying
+  `Ltac2.Pattern.multi_match0` and `Ltac2.Pattern.multi_goal_match0`
+  now preserve exceptions from backtracking after a branch succeeded
+  instead of replacing them with `Match_failure`
+  (e.g. `multi_match! constr:(tt) with tt => () end; Control.zero Not_found`
+  now fails with `Not_found` instead of `Match_failure`)
+  (`#17597 <https://github.com/coq/coq/pull/17597>`_,
+  fixes `#17594 <https://github.com/coq/coq/issues/17594>`_,
+  by Gaëtan Gilbert).

--- a/test-suite/output/bug_17594.out
+++ b/test-suite/output/bug_17594.out
@@ -1,0 +1,48 @@
+1
+3
+2
+3
+File "./output/bug_17594.v", line 8, characters 2-102:
+The command has indeed failed with message:
+The term "0" has type "nat" while it is expected to have type "True".
+1
+3
+2
+3
+File "./output/bug_17594.v", line 17, characters 26-27:
+The command has indeed failed with message:
+The term "0" has type "nat" while it is expected to have type "True".
+1
+3
+2
+3
+File "./output/bug_17594.v", line 19, characters 2-115:
+The command has indeed failed with message:
+The term "0" has type "nat" while it is expected to have type "True".
+1
+3
+2
+3
+File "./output/bug_17594.v", line 28, characters 26-27:
+The command has indeed failed with message:
+The term "0" has type "nat" while it is expected to have type "True".
+1
+3
+File "./output/bug_17594.v", line 31, characters 2-106:
+The command has indeed failed with message:
+Uncaught Ltac2 exception: Match_failure
+1
+3
+File "./output/bug_17594.v", line 37, characters 2-113:
+The command has indeed failed with message:
+No matching clauses for match.
+1
+3
+File "./output/bug_17594.v", line 42, characters 2-119:
+The command has indeed failed with message:
+No matching clauses for match.
+1
+3
+File "./output/bug_17594.v", line 48, characters 2-119:
+The command has indeed failed with message:
+No matching clauses for match.

--- a/test-suite/output/bug_17594.v
+++ b/test-suite/output/bug_17594.v
@@ -1,0 +1,53 @@
+From Ltac2 Require Import Ltac2.
+From Ltac2 Require Import Message.
+
+Ltac2 msg s := print (of_string s).
+
+Goal True.
+  (* should be the exact error *)
+  Fail multi_match! 'True with
+    | True => msg "1"
+    | _ => msg "2"
+    end;
+    msg "3"; exact 0.
+
+  Fail ltac1:(multimatch True with
+    | True => idtac "1"
+    | _ => idtac "2"
+    end; idtac "3"; exact 0).
+
+  Fail multi_match! goal with
+    | [ |- True ] => msg "1"
+    | [ |- _ ] => msg "2"
+    end;
+    msg "3"; exact 0.
+
+  Fail ltac1:(multimatch goal with
+    | |- True => idtac "1"
+    | |- _ => idtac "2"
+    end; idtac "3"; exact 0).
+
+  (* should be match error *)
+  Fail multi_match! 'True with
+    | True => msg "1"
+    | False => msg "2"
+    end;
+    msg "3"; exact 0.
+
+  Fail ltac1:(multimatch True with
+    | True => idtac "1"
+    | False => idtac "2"
+    end; idtac "3"; exact 0).
+
+  Fail multi_match! goal with
+    | [ |- True ] => msg "1"
+    | [ |- False ] => msg "2"
+    end;
+    msg "3"; exact 0.
+
+  Fail ltac1:(multimatch goal with
+    | |- True => idtac "1"
+    | |- False => idtac "2"
+    end; idtac "3"; exact 0).
+
+Abort.

--- a/user-contrib/Ltac2/Pattern.v
+++ b/user-contrib/Ltac2/Pattern.v
@@ -99,10 +99,10 @@ Ltac2 lazy_match0 t pats :=
   Control.once (fun () => interp pats) ().
 
 Ltac2 multi_match0 t pats :=
-  let rec interp m := match m with
-  | [] => Control.zero Match_failure
+  let rec interp e m := match m with
+  | [] => Control.zero e
   | p :: m =>
-    let next _ := interp m in
+    let next e := interp e m in
     let (knd, pat, f) := p in
     let p := match knd with
     | MatchPattern =>
@@ -117,7 +117,7 @@ Ltac2 multi_match0 t pats :=
     end in
     Control.plus p next
   end in
-  interp pats.
+  interp Match_failure pats.
 
 Ltac2 one_match0 t m := Control.once (fun _ => multi_match0 t m).
 
@@ -137,10 +137,10 @@ Ltac2 lazy_goal_match0 rev pats :=
   Control.once (fun () => interp pats) ().
 
 Ltac2 multi_goal_match0 rev pats :=
-  let rec interp m := match m with
-  | [] => Control.zero Match_failure
+  let rec interp e m := match m with
+  | [] => Control.zero e
   | p :: m =>
-    let next _ := interp m in
+    let next e := interp e m in
     let (pat, f) := p in
     let (phyps, pconcl) := pat in
     let cur _ :=
@@ -149,6 +149,6 @@ Ltac2 multi_goal_match0 rev pats :=
     in
     Control.plus cur next
   end in
-  interp pats.
+  interp Match_failure pats.
 
 Ltac2 one_goal_match0 rev pats := Control.once (fun _ => multi_goal_match0 rev pats).


### PR DESCRIPTION
Fix #17594

I think this is the same behaviour as Ltac1 (see test).

Not sure if lazy_match needs a similar change.
