### PR TITLE
Don't leave an open proof in implicit-arguments.rst

### DIFF
--- a/doc/sphinx/language/extensions/implicit-arguments.rst
+++ b/doc/sphinx/language/extensions/implicit-arguments.rst
@@ -180,7 +180,7 @@ declares the argument `A` of `id` as a maximally
 inserted implicit argument. `A` may be omitted
 in applications of `id` but may be specified if needed:
 
-.. coqtop:: all
+.. coqtop:: all abort
 
    Definition compose {A B C} (g : B -> C) (f : A -> B) := fun x => g (f x).
 


### PR DESCRIPTION
Fix #17596
