### PR TITLE
Refman debug mode

### DIFF
--- a/doc/tools/coqrst/notations/parsing.py
+++ b/doc/tools/coqrst/notations/parsing.py
@@ -14,12 +14,14 @@ from antlr4 import CommonTokenStream, InputStream
 from antlr4.error.ErrorListener import ErrorListener
 from antlr4.Recognizer import Recognizer
 
+import os
+
 # Only print ANTLR version warning once
 checked_version = False
 check_version = Recognizer.checkVersion
 def checkVersion_once(*args, **kwargs):
     global checked_version
-    if not checked_version:
+    if not checked_version and os.getenv ("COQ_DEBUG_REFMAN"):
         # Using "Recognizer.checkVersion" would cause endless recursion
         check_version(*args, **kwargs)
         checked_version = True


### PR DESCRIPTION
When COQ_DEBUG_REFMAN is defined in the environment, duplicate everything we send to coqtop to a file /tmp/coqdomainXXXX.v

This spams many files so not enabled by default.

Also disable the antlr version check when the environment variable is set as I couldn't figure out how to install the right version on my machine (it seems to work fine with 4.9.1 instead of 4.7.2).

The temporary file is put explicitly in /tmp instead of the automatic tmpdir as otherwise it goes in some /tmp/ subdirectory created by dune and deleted by dune. If we can disable the deletion that could be nicer.
