### PR TITLE
Experiment: use debruijn instead of ids for the ltac2 interp env

### DIFF
--- a/plugins/ltac2/tac2env.ml
+++ b/plugins/ltac2/tac2env.ml
@@ -259,18 +259,18 @@ let shortest_qualid_of_projection kn =
   let sp = KNmap.find kn tab.tab_proj_rev in
   KnTab.shortest_qualid Id.Set.empty sp tab.tab_proj
 
-type 'a or_glb_tacexpr =
+type 'a or_glb_tacexpr_ids =
 | GlbVal of 'a
-| GlbTacexpr of glb_tacexpr
+| GlbTacexpr of glb_tacexpr_ids
 
 type environment = {
-  env_ist : valexpr Id.Map.t;
+  env_ist : valexpr Range.t;
 }
 
 type ('a, 'b, 'r) intern_fun = Genintern.glob_sign -> 'a -> 'b * 'r glb_typexpr
 
 type ('a, 'b) ml_object = {
-  ml_intern : 'r. (raw_tacexpr, glb_tacexpr, 'r) intern_fun -> ('a, 'b or_glb_tacexpr, 'r) intern_fun;
+  ml_intern : 'r. (raw_tacexpr, glb_tacexpr_ids, 'r) intern_fun -> ('a, 'b or_glb_tacexpr_ids, 'r) intern_fun;
   ml_subst : Mod_subst.substitution -> 'b -> 'b;
   ml_interp : environment -> 'b -> valexpr Proofview.tactic;
   ml_print : Environ.env -> Evd.evar_map -> 'b -> Pp.t;

--- a/plugins/ltac2/tac2env.mli
+++ b/plugins/ltac2/tac2env.mli
@@ -122,19 +122,18 @@ val interp_primitive : ml_tactic_name -> valexpr
 
 (** {5 ML primitive types} *)
 
-type 'a or_glb_tacexpr =
+type 'a or_glb_tacexpr_ids =
 | GlbVal of 'a
-| GlbTacexpr of glb_tacexpr
+| GlbTacexpr of glb_tacexpr_ids
 
 type ('a, 'b, 'r) intern_fun = Genintern.glob_sign -> 'a -> 'b * 'r glb_typexpr
 
 type environment = {
-  env_ist : valexpr Id.Map.t;
+  env_ist : valexpr Range.t;
 }
 
 type ('a, 'b) ml_object = {
-  ml_intern : 'r. (raw_tacexpr, glb_tacexpr, 'r) intern_fun -> ('a, 'b or_glb_tacexpr, 'r) intern_fun;
-  ml_subst : Mod_subst.substitution -> 'b -> 'b;
+  ml_intern : 'r. (raw_tacexpr, glb_tacexpr_ids, 'r) intern_fun -> ('a, 'b or_glb_tacexpr_ids, 'r) intern_fun;  ml_subst : Mod_subst.substitution -> 'b -> 'b;
   ml_interp : environment -> 'b -> valexpr Proofview.tactic;
   ml_print : Environ.env -> Evd.evar_map -> 'b -> Pp.t;
 }
@@ -165,7 +164,7 @@ val wit_ltac2_val : (Util.Empty.t, unit, Util.Empty.t) genarg_type
 val wit_ltac2_constr : (raw_tacexpr, Id.Set.t * glb_tacexpr, Util.Empty.t) genarg_type
 (** Ltac2 quotations in Gallina terms *)
 
-val wit_ltac2_quotation : (Id.t Loc.located, Id.t, Util.Empty.t) genarg_type
+val wit_ltac2_quotation : (Id.t Loc.located, int * Id.t, Util.Empty.t) genarg_type
 (** Ltac2 quotations for variables "$x" in Gallina terms *)
 
 (** {5 Helper functions} *)

--- a/plugins/ltac2/tac2expr.mli
+++ b/plugins/ltac2/tac2expr.mli
@@ -163,22 +163,26 @@ type 'a open_match = {
   opn_default : Name.t * 'a;
 }
 
-type glb_tacexpr =
+(* Anonymous binders don't bind (so "fun x _ => x" refers to "x" with "Var 0") *)
+type ('var,'patvars) glb_tacexpr_g =
 | GTacAtm of atom
-| GTacVar of Id.t
+| GTacVar of 'var
 | GTacRef of ltac_constant
-| GTacFun of Name.t list * glb_tacexpr
-| GTacApp of glb_tacexpr * glb_tacexpr list
-| GTacLet of rec_flag * (Name.t * glb_tacexpr) list * glb_tacexpr
-| GTacCst of case_info * int * glb_tacexpr list
-| GTacCse of glb_tacexpr * case_info * glb_tacexpr array * (Name.t array * glb_tacexpr) array
-| GTacPrj of type_constant * glb_tacexpr * int
-| GTacSet of type_constant * glb_tacexpr * int * glb_tacexpr
-| GTacOpn of ltac_constructor * glb_tacexpr list
-| GTacWth of glb_tacexpr open_match
-| GTacFullMatch of glb_tacexpr * (glb_pat * glb_tacexpr) list
-| GTacExt : (_, 'a) Tac2dyn.Arg.tag * 'a -> glb_tacexpr
+| GTacFun of Name.t list * ('var,'patvars) glb_tacexpr_g
+| GTacApp of('var,'patvars) glb_tacexpr_g *('var,'patvars) glb_tacexpr_g list
+| GTacLet of rec_flag * (Name.t *('var,'patvars) glb_tacexpr_g) list *('var,'patvars) glb_tacexpr_g
+| GTacCst of case_info * int *('var,'patvars) glb_tacexpr_g list
+| GTacCse of('var,'patvars) glb_tacexpr_g * case_info *('var,'patvars) glb_tacexpr_g array * (Name.t array *('var,'patvars) glb_tacexpr_g) array
+| GTacPrj of type_constant *('var,'patvars) glb_tacexpr_g * int
+| GTacSet of type_constant *('var,'patvars) glb_tacexpr_g * int *('var,'patvars) glb_tacexpr_g
+| GTacOpn of ltac_constructor *('var,'patvars) glb_tacexpr_g list
+| GTacWth of('var,'patvars) glb_tacexpr_g open_match
+| GTacFullMatch of('var,'patvars) glb_tacexpr_g * ('patvars * glb_pat *('var,'patvars) glb_tacexpr_g) list
+| GTacExt : (_, 'a) Tac2dyn.Arg.tag * 'a ->('var,'patvars) glb_tacexpr_g
 | GTacPrm of ml_tactic_name
+
+type glb_tacexpr_ids = (Id.t, unit) glb_tacexpr_g
+type glb_tacexpr = (int,Id.t list) glb_tacexpr_g
 
 (** {5 Parsing & Printing} *)
 

--- a/plugins/ltac2/tac2print.ml
+++ b/plugins/ltac2/tac2print.ml
@@ -277,7 +277,7 @@ let pr_glb_pat pat = pr_partial_pat (partial_pat_of_glb_pat pat)
 let pr_glbexpr_gen lvl c =
   let rec pr_glbexpr lvl = function
   | GTacAtm atm -> pr_atom atm
-  | GTacVar id -> Id.print id
+  | GTacVar id -> str "VAR" ++ Pp.int id
   | GTacRef gr -> pr_tacref gr
   | GTacFun (nas, c) ->
     let nas = pr_sequence pr_name nas in
@@ -365,7 +365,7 @@ let pr_glbexpr_gen lvl c =
     v 0 (hv 0 (str "match" ++ spc () ++ e ++ spc () ++ str "with") ++ spc () ++ br ++ str "end")
   | GTacFullMatch (e, brs) ->
     let e = pr_glbexpr E5 e in
-    let pr_one_branch (pat,br) =
+    let pr_one_branch (_,pat,br) =
       hov 4 (str "|" ++ spc() ++ hov 0 (pr_glb_pat pat ++ spc() ++ str "=>") ++ spc() ++
              hov 2 (pr_glbexpr E5 br))
     in

--- a/user-contrib/Ltac2/String.v
+++ b/user-contrib/Ltac2/String.v
@@ -21,4 +21,4 @@ Ltac2 @external app : string -> string := "coq-core.plugins.ltac2" "string_app".
 Ltac2 @external equal : string -> string -> bool := "coq-core.plugins.ltac2" "string_equal".
 Ltac2 @external compare : string -> string -> int := "coq-core.plugins.ltac2" "string_compare".
 
-Ltac2 is_empty s := match s with "" => true | _ => false end.
+(* Ltac2 is_empty s := match s with "" => true | _ => false end. *)


### PR DESCRIPTION
I'm not sure how easy it is to get the quotations to work though (currently the intern functions are commented so they error)

fullmatch also has some of its implem commented out, but this is more laziness than real difficulty IMO

On https://github.com/coq/coq/issues/10107#issuecomment-1511450521 there is maybe a small (<10%) speedup
