### PR TITLE
Fix inverted logic in `Summary.ref ~local:true`

### DIFF
--- a/dev/ci/user-overlays/17605-SkySkimmer-summary-local.sh
+++ b/dev/ci/user-overlays/17605-SkySkimmer-summary-local.sh
@@ -1,0 +1,5 @@
+overlay coq_lsp https://github.com/SkySkimmer/coq-lsp summary-local 17605
+
+overlay elpi https://github.com/SkySkimmer/coq-elpi summary-local 17605
+
+overlay lean_importer https://github.com/SkySkimmer/coq-lean-import summary-local 17605

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -2548,7 +2548,7 @@ let toggle_notations ~on ~all prglob ntn_pattern =
 (**********************************************************************)
 (* Synchronisation with reset *)
 
-let freeze ~marshallable =
+let freeze () =
  (!scope_map, !scope_stack, !arguments_scope,
   !delimiters_map, !scope_class_map,
   !prim_token_interp_infos, !prim_token_uninterp_infos,
@@ -2582,7 +2582,7 @@ let _ =
       Summary.init_function = init }
 
 let with_notation_protection f x =
-  let fs = freeze ~marshallable:false in
+  let fs = freeze () in
   try let a = with_notation_uninterpretation_protection f x in unfreeze fs; a
   with reraise ->
     let reraise = Exninfo.capture reraise in

--- a/interp/notationextern.ml
+++ b/interp/notationextern.ml
@@ -172,7 +172,7 @@ let declare_uninterpretation ?(also_in_cases_pattern=true) rule (metas,c as pat)
   let (key,n) = notation_constr_key c in
   notations_key_table := keymap_add key (also_in_cases_pattern,(rule,pat,n)) !notations_key_table
 
-let freeze ~marshallable =
+let freeze () =
   !notations_key_table
 
 let unfreeze fkm =
@@ -189,7 +189,7 @@ let () =
       Summary.init_function = init }
 
 let with_notation_uninterpretation_protection f x =
-  let fs = freeze ~marshallable:false in
+  let fs = freeze () in
   try let a = f x in unfreeze fs; a
   with reraise ->
     let reraise = Exninfo.capture reraise in

--- a/library/goptions.ml
+++ b/library/goptions.ml
@@ -262,7 +262,7 @@ let declare_option cast uncast append ?(preprocess = fun x -> x)
   let change =
       let _ = Summary.declare_summary (nickname key)
         { stage;
-          Summary.freeze_function = (fun ~marshallable -> read ());
+          Summary.freeze_function = read;
           Summary.unfreeze_function = write;
           Summary.init_function = (fun () -> write default) } in
       let cache_options (l,m,v) =

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -402,7 +402,7 @@ module SynterpActions : LibActions with type summary = Summary.Synterp.frozen = 
     let obj_dir = Libnames.add_dirpath_suffix opp.Nametab.obj_dir id in
     let prefix = Nametab.{ obj_dir; obj_mp=opp.obj_mp; } in
     check_section_fresh obj_dir id;
-    let fs = Summary.Synterp.freeze_summaries ~marshallable:false in
+    let fs = Summary.Synterp.freeze_summaries () in
     add_entry (OpenedSection (prefix, fs));
     (*Pushed for the lifetime of the section: removed by unfreezing the summary*)
     push_section_name obj_dir;
@@ -473,7 +473,7 @@ module InterpActions : LibActions with type summary = Summary.Interp.frozen = st
   let open_section id =
     Global.open_section ();
     let prefix = !synterp_state.path_prefix in
-    let fs = Summary.Interp.freeze_summaries ~marshallable:false in
+    let fs = Summary.Interp.freeze_summaries () in
     add_entry (OpenedSection (prefix, fs))
 
   let pop_path_prefix () = ()

--- a/library/summary.ml
+++ b/library/summary.ml
@@ -25,18 +25,22 @@ end
 
 type 'a summary_declaration = {
   stage : Stage.t;
-  freeze_function : marshallable:bool -> 'a;
+  freeze_function : unit -> 'a;
   unfreeze_function : 'a -> unit;
   init_function : unit -> unit }
 
 module Decl = struct type 'a t = 'a summary_declaration end
 module DynMap = Dyn.Map(Decl)
 
+module MarshMap = Dyn.Map(struct type 'a t = 'a -> 'a end)
+
 type ml_modules = (string option * string) list
 
 let sum_mod : ml_modules summary_declaration option ref = ref None
 let sum_map_synterp = ref DynMap.empty
 let sum_map_interp = ref DynMap.empty
+let sum_marsh_synterp = ref MarshMap.empty
+let sum_marsh_interp = ref MarshMap.empty
 
 let mangle id = id ^ "-SUMMARY"
 
@@ -50,19 +54,26 @@ let check_name sumname = match Dyn.name sumname with
     Pp.(str "Colliding summary names: " ++ str sumname
       ++ str " vs. " ++ str (Dyn.repr t) ++ str ".")
 
-let declare_summary_tag sumname decl =
+let declare_summary_tag sumname ?make_marshallable decl =
   let () = check_name (mangle sumname) in
   let tag = Dyn.create (mangle sumname) in
-  let sum_map = match decl.stage with Synterp -> sum_map_synterp | Interp -> sum_map_interp in
+  let sum_map, marsh_map = match decl.stage with
+    | Synterp -> sum_map_synterp, sum_marsh_synterp
+    | Interp -> sum_map_interp, sum_marsh_interp
+  in
   let () = sum_map := DynMap.add tag decl !sum_map in
+  let () = make_marshallable |> Option.iter (fun f ->
+      marsh_map := MarshMap.add tag f !marsh_map)
+  in
   tag
 
-let declare_summary sumname decl =
-  ignore(declare_summary_tag sumname decl)
+let declare_summary sumname ?make_marshallable decl =
+  ignore(declare_summary_tag sumname ?make_marshallable decl)
 
 module ID = struct type 'a t = 'a end
 module Frozen = Dyn.Map(ID)
 module HMap = Dyn.HMap(Decl)(ID)
+
 
 module type FrozenStage = sig
 
@@ -72,15 +83,23 @@ module type FrozenStage = sig
   type frozen
 
   val empty_frozen : frozen
-  val freeze_summaries : marshallable:bool -> frozen
+  val freeze_summaries : unit -> frozen
+  val make_marshallable : frozen -> frozen
   val unfreeze_summaries : ?partial:bool -> frozen -> unit
   val init_summaries : unit -> unit
 
 end
 
-let freeze_summaries ~marshallable sum_map =
-  let map = { HMap.map = fun tag decl -> decl.freeze_function ~marshallable } in
+let freeze_summaries sum_map =
+  let map = { HMap.map = fun tag decl -> decl.freeze_function () } in
   HMap.map map sum_map
+
+let make_marshallable marsh_map summaries =
+  let map = { Frozen.map = fun tag v -> match MarshMap.find tag marsh_map with
+      | exception Not_found -> v
+      | f -> f v }
+  in
+  Frozen.map map summaries
 
 let warn_summary_out_of_scope =
   let name = "summary-out-of-scope" in
@@ -119,9 +138,13 @@ module Synterp = struct
 
   let empty_frozen = { summaries = Frozen.empty; ml_module = None }
 
-  let freeze_summaries ~marshallable =
-    let summaries = freeze_summaries ~marshallable !sum_map_synterp in
-    { summaries; ml_module = Option.map (fun decl -> decl.freeze_function ~marshallable) !sum_mod }
+  let freeze_summaries () =
+    let summaries = freeze_summaries !sum_map_synterp in
+    { summaries; ml_module = Option.map (fun decl -> decl.freeze_function ()) !sum_mod }
+
+  let make_marshallable { summaries; ml_module } =
+    { summaries = make_marshallable !sum_marsh_synterp summaries;
+      ml_module }
 
   let unfreeze_summaries ?(partial=false) { summaries; ml_module } =
     (* The unfreezing of [ml_modules_summary] has to be anticipated since it
@@ -143,8 +166,10 @@ type frozen = Frozen.t
 
 let empty_frozen = Frozen.empty
 
-  let freeze_summaries ~marshallable =
-    freeze_summaries ~marshallable !sum_map_interp
+  let freeze_summaries () =
+    freeze_summaries !sum_map_interp
+
+  let make_marshallable summaries = make_marshallable !sum_marsh_interp summaries
 
   let unfreeze_summaries ?(partial=false) summaries =
     unfreeze_summaries ~partial !sum_map_interp summaries
@@ -177,7 +202,7 @@ let ref_tag ?(stage=Stage.Interp) ~name x =
   let r = ref x in
   let tag = declare_summary_tag name
     { stage;
-      freeze_function = (fun ~marshallable:_ -> !r);
+      freeze_function = (fun () -> !r);
       unfreeze_function = ((:=) r);
       init_function = (fun () -> r := x) } in
   r, tag
@@ -187,8 +212,9 @@ let ref ?(stage=Stage.Interp) ?(local=false) ~name x =
   else
     let r = ref x in
     let () = declare_summary name
+        ~make_marshallable:(fun _ -> None)
         { stage;
-          freeze_function = (fun ~marshallable -> if marshallable then Some !r else None);
+          freeze_function = (fun () -> Some !r);
           unfreeze_function = (function Some v -> r := v | None -> r := x);
           init_function = (fun () -> r := x); }
     in

--- a/library/summary.mli
+++ b/library/summary.mli
@@ -26,9 +26,7 @@ end
     the standard OCaml marshalling function. *)
 type 'a summary_declaration = {
   stage : Stage.t;
-  freeze_function : marshallable:bool -> 'a;
-  (** freeze_function [true] is for marshalling to disk.
-   *  e.g. lazy must be forced *)
+  freeze_function : unit -> 'a;
   unfreeze_function : 'a -> unit;
   init_function : unit -> unit }
 
@@ -43,13 +41,13 @@ type 'a summary_declaration = {
     the responsibility of plugins to initialize themselves properly.
 *)
 
-val declare_summary : string -> 'a summary_declaration -> unit
+val declare_summary : string -> ?make_marshallable:('a -> 'a) -> 'a summary_declaration -> unit
 
 (** We provide safe projection from the summary to the types stored in
    it.*)
 module Dyn : Dyn.S
 
-val declare_summary_tag : string -> 'a summary_declaration -> 'a Dyn.tag
+val declare_summary_tag : string -> ?make_marshallable:('a -> 'a) -> 'a summary_declaration -> 'a Dyn.tag
 
 (** All-in-one reference declaration + summary registration.
     It behaves just as OCaml's standard [ref] function, except
@@ -100,7 +98,8 @@ module type FrozenStage = sig
   type frozen
 
   val empty_frozen : frozen
-  val freeze_summaries : marshallable:bool -> frozen
+  val freeze_summaries : unit -> frozen
+  val make_marshallable : frozen -> frozen
   val unfreeze_summaries : ?partial:bool -> frozen -> unit
   val init_summaries : unit -> unit
 

--- a/parsing/pcoq.ml
+++ b/parsing/pcoq.ml
@@ -485,7 +485,7 @@ type frozen_t =
   (grammar_entry * GramState.t) list *
   CLexer.keyword_state
 
-let freeze ~marshallable : frozen_t =
+let freeze () : frozen_t =
   (!grammar_stack, !keyword_state)
 
 let eq_grams (g1, _) (g2, _) = match g1, g2 with
@@ -536,7 +536,7 @@ let parser_summary_tag =
       Summary.init_function = Summary.nop }
 
 let with_grammar_rule_protection f x =
-  let fs = freeze ~marshallable:false in
+  let fs = freeze () in
   try let a = f x in unfreeze fs; a
   with reraise ->
     let reraise = Exninfo.capture reraise in

--- a/parsing/pcoq.mli
+++ b/parsing/pcoq.mli
@@ -291,7 +291,7 @@ val register_grammars_by_name : string -> Entry.any_t list -> unit
 val find_grammars_by_name : string -> Entry.any_t list
 
 (** Parsing state handling *)
-val freeze : marshallable:bool -> frozen_t
+val freeze : unit -> frozen_t
 val unfreeze : frozen_t -> unit
 
 val get_keyword_state : unit -> CLexer.keyword_state

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -467,7 +467,7 @@ type tcc_lemma_value = Undefined | Value of constr | Not_needed
 
 (* We only "purify" on exceptions. XXX: What is this doing here? *)
 let funind_purify f x =
-  let st = Vernacstate.freeze_full_state ~marshallable:false in
+  let st = Vernacstate.freeze_full_state () in
   try f x
   with e ->
     let e = Exninfo.capture e in

--- a/stm/partac.ml
+++ b/stm/partac.ml
@@ -185,7 +185,8 @@ let get_results res =
 
 let enable_par ~nworkers = ComTactic.set_par_implementation
   (fun ~pstate ~info t_ast ~abstract ~with_end_tac ->
-    let t_state = Vernacstate.freeze_full_state ~marshallable:true in
+    let t_state = Vernacstate.freeze_full_state () in
+    let t_state = Vernacstate.Stm.make_shallow t_state in
     TaskQueue.with_n_workers nworkers CoqworkmgrApi.High (fun queue ->
     Declare.Proof.map pstate ~f:(fun p ->
     let open TacTask in

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -776,7 +776,7 @@ let start_module_core id args res =
   mp, res_entry_o, mbids, sign, args
 
 let start_module export id args res =
-  let fs = Summary.Synterp.freeze_summaries ~marshallable:false in
+  let fs = Summary.Synterp.freeze_summaries () in
   let mp, res_entry_o, mbids, sign, args = start_module_core id args res in
   set_openmod_syntax_info { cur_mp = mp; cur_typ = res_entry_o; cur_mbids = mbids };
   let prefix = Lib.Synterp.start_module export id mp fs in
@@ -837,7 +837,7 @@ let get_functor_sobjs is_mod inl (mbids,mexpr) =
   (mbids @ mbids0, aobjs)
 
 let declare_module id args res mexpr_o =
-  let fs = Summary.Synterp.freeze_summaries ~marshallable:false in
+  let fs = Summary.Synterp.freeze_summaries () in
   (* We simulate the beginning of an interactive module,
      then we adds the module parameters to the global env. *)
   let mp = ModPath.MPdot((openmod_syntax_info ()).cur_mp, Label.of_id id) in
@@ -997,7 +997,7 @@ let start_module_core id args res =
   mp, res_entry_o, subtyps, params, Univ.ContextSet.union ctx ctx'
 
 let start_module export id args res =
-  let fs = Summary.Interp.freeze_summaries ~marshallable:false in
+  let fs = Summary.Interp.freeze_summaries () in
   let mp, res_entry_o, subtyps, _, _ = start_module_core id args res in
   openmod_info := { cur_typ = res_entry_o; cur_typs = subtyps };
   let _ : Nametab.object_prefix = Lib.Interp.start_module export id mp fs in
@@ -1062,7 +1062,7 @@ let get_functor_sobjs is_mod env inl (params,mexpr) =
 
 (* TODO cleanup push universes directly to global env *)
 let declare_module id args res mexpr_o =
-  let fs = Summary.Interp.freeze_summaries ~marshallable:false in
+  let fs = Summary.Interp.freeze_summaries () in
   (* We simulate the beginning of an interactive module,
      then we adds the module parameters to the global env. *)
   let mp, mty_entry_o, subs, params, ctx = start_module_core id args res in
@@ -1127,7 +1127,7 @@ let start_modtype_core id cur_mp args mtys =
   mp, mbids, args, sub_mty_l
 
 let start_modtype id args mtys =
-  let fs = Summary.Synterp.freeze_summaries ~marshallable:false in
+  let fs = Summary.Synterp.freeze_summaries () in
   let mp, mbids, args, sub_mty_l = start_modtype_core id (openmod_syntax_info ()).cur_mp args mtys in
   set_openmod_syntax_info { cur_mp = mp; cur_typ = None; cur_mbids = mbids };
   let prefix = Lib.Synterp.start_modtype id mp fs in
@@ -1148,7 +1148,7 @@ let end_modtype () =
   (openmod_syntax_info ()).cur_mp
 
 let declare_modtype id args mtys (mty,ann) =
-  let fs = Summary.Synterp.freeze_summaries ~marshallable:false in
+  let fs = Summary.Synterp.freeze_summaries () in
   let inl = inl2intopt ann in
   (* We simulate the beginning of an interactive module,
      then we adds the module parameters to the global env. *)
@@ -1182,7 +1182,7 @@ let start_modtype_core id args mtys =
   mp, params, sub_mty_l, Univ.ContextSet.union params_ctx sub_mty_ctx
 
 let start_modtype id args mtys =
-  let fs = Summary.Interp.freeze_summaries ~marshallable:false in
+  let fs = Summary.Interp.freeze_summaries () in
   let mp, _, sub_mty_l, _ = start_modtype_core id args mtys in
   openmodtype_info := sub_mty_l;
   let prefix = Lib.Interp.start_modtype id mp fs in
@@ -1209,7 +1209,7 @@ let end_modtype () =
   mp
 
 let declare_modtype id args mtys (mte,base,kind,inl) =
-  let fs = Summary.Interp.freeze_summaries ~marshallable:false in
+  let fs = Summary.Interp.freeze_summaries () in
   (* We simulate the beginning of an interactive module,
      then we adds the module parameters to the global env. *)
   let mp, params, sub_mty_l, ctx = start_modtype_core id args mtys in
@@ -1400,7 +1400,7 @@ let end_module = RawModOps.Synterp.end_module
 Typically used for `Module M := N <+ P`.
 *)
 let declare_module_includes id args res mexpr_l =
-  let fs = Summary.Synterp.freeze_summaries ~marshallable:false in
+  let fs = Summary.Synterp.freeze_summaries () in
   let mp, res_entry_o, mbids, sign, args = RawModOps.Synterp.start_module_core id args res in
   let mod_info = { cur_mp = mp; cur_typ = res_entry_o; cur_mbids = mbids } in
   let includes = List.map_left (RawIncludeOps.Synterp.declare_one_include_core mp) mexpr_l in
@@ -1419,7 +1419,7 @@ let declare_module_includes id args res mexpr_l =
 Typically used for `Module Type M := N <+ P`.
 *)
 let declare_modtype_includes id args res mexpr_l =
-  let fs = Summary.Synterp.freeze_summaries ~marshallable:false in
+  let fs = Summary.Synterp.freeze_summaries () in
   let mp, mbids, args, subtyps = RawModTypeOps.Synterp.start_modtype_core id (openmod_syntax_info ()).cur_mp args res in
   let includes = List.map_left (RawIncludeOps.Synterp.declare_one_include_core mp) mexpr_l in
   let bodies, incl_objs = List.split includes in
@@ -1488,7 +1488,7 @@ let end_module = RawModOps.Interp.end_module
 Typically used for `Module M := N <+ P`.
 *)
 let declare_module_includes id args res mexpr_l =
-  let fs = Summary.Interp.freeze_summaries ~marshallable:false in
+  let fs = Summary.Interp.freeze_summaries () in
   let mp, res_entry_o, subtyps, _, _ = RawModOps.Interp.start_module_core id args res in
   let mod_info = { cur_typ = res_entry_o; cur_typs = subtyps } in
   let incl_objs = List.map_left (fun x -> IncludeObject (RawIncludeOps.Interp.declare_one_include_core x)) mexpr_l in
@@ -1505,7 +1505,7 @@ let declare_module_includes id args res mexpr_l =
 Typically used for `Module Type M := N <+ P`.
 *)
 let declare_modtype_includes id args res mexpr_l =
-  let fs = Summary.Interp.freeze_summaries ~marshallable:false in
+  let fs = Summary.Interp.freeze_summaries () in
   let mp, _, subtyps, _ = RawModTypeOps.Interp.start_modtype_core id args res in
   let incl_objs = List.map_left (fun x -> IncludeObject (RawIncludeOps.Interp.declare_one_include_core x)) mexpr_l in
   let objects = Lib.Interp.{

--- a/vernac/mltop.ml
+++ b/vernac/mltop.ml
@@ -395,7 +395,7 @@ let unfreeze_ml_modules x =
 let () =
   Summary.declare_ml_modules_summary
     { stage = Summary.Stage.Synterp
-    ; Summary.freeze_function = (fun ~marshallable ->
+    ; Summary.freeze_function = (fun () ->
           get_loaded_modules () |> List.map PluginSpec.repr)
     ; Summary.unfreeze_function = unfreeze_ml_modules
     ; Summary.init_function = reset_loaded_modules }

--- a/vernac/opaques.mli
+++ b/vernac/opaques.mli
@@ -28,7 +28,7 @@ module Summary :
 sig
   type t
   val init : unit -> unit
-  val freeze : marshallable:bool -> t
+  val freeze : unit -> t
   val unfreeze : t -> unit
   val join : ?except:Future.UUIDSet.t -> unit -> unit
 end

--- a/vernac/synterp.ml
+++ b/vernac/synterp.ml
@@ -382,9 +382,9 @@ let real_error_loc ~cmdloc ~eloc =
   else cmdloc
 
 let with_fail ~loc f =
-  let st = Vernacstate.Synterp.freeze ~marshallable:false in
+  let st = Vernacstate.Synterp.freeze () in
   let res = with_fail f in
-  let transient_st = Vernacstate.Synterp.freeze ~marshallable:false in
+  let transient_st = Vernacstate.Synterp.freeze () in
   Vernacstate.Synterp.unfreeze st;
   match res with
   | Error (ctrl, v) ->
@@ -396,9 +396,9 @@ let with_fail ~loc f =
     [], VernacSynterp EVernacNoop
 
 let with_succeed f =
-  let st = Vernacstate.Synterp.freeze ~marshallable:false in
+  let st = Vernacstate.Synterp.freeze () in
   let (ctrl, v) = f () in
-  let transient_st = Vernacstate.Synterp.freeze ~marshallable:false in
+  let transient_st = Vernacstate.Synterp.freeze () in
   Vernacstate.Synterp.unfreeze st;
   ControlSucceed { st = transient_st } :: ctrl, v
 
@@ -531,7 +531,7 @@ and synterp_load verbosely fname =
     | None -> entries
     | Some cmd ->
       let entry = v_mod synterp_control cmd in
-      let st = Vernacstate.Synterp.freeze ~marshallable:false in
+      let st = Vernacstate.Synterp.freeze () in
       (load_loop [@ocaml.tailcall]) ((entry,st)::entries)
   in
   let entries = List.rev @@ load_loop [] in

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -147,7 +147,7 @@ let rec interp_expr ?loc ~atts ~st c =
 
 and vernac_load ~verbosely entries =
   (* Note that no proof should be open here, so the state here is just token for now *)
-  let st = Vernacstate.freeze_full_state ~marshallable:false in
+  let st = Vernacstate.freeze_full_state () in
   let v_mod = if verbosely then Flags.verbosely else Flags.silently in
   let interp_entry (stack, pm) (CAst.{ loc; v = cmd }, synterp_st) =
     Vernacstate.Synterp.unfreeze synterp_st;
@@ -216,7 +216,7 @@ let interp_gen ~verbosely ~st ~interp_fn cmd =
     let v_mod = if verbosely then Flags.verbosely else Flags.silently in
     let ontop = v_mod (interp_fn ~st) cmd in
     Vernacstate.Declare.set ontop [@ocaml.warning "-3"];
-    Vernacstate.Interp.freeze_interp_state ~marshallable:false
+    Vernacstate.Interp.freeze_interp_state ()
   with exn ->
     let exn = Exninfo.capture exn in
     let exn = locate_if_not_already ?loc:cmd.CAst.loc exn in
@@ -229,7 +229,7 @@ let interp ?(verbosely=true) ~st cmd =
   vernac_pperr_endline Pp.(fun () -> str "interpreting: " ++ Ppvernac.pr_vernac_expr cmd.CAst.v.expr);
   let entry = Synterp.synterp_control cmd in
   let interp = interp_gen ~verbosely ~st ~interp_fn:interp_control entry in
-  Vernacstate.{ synterp = Vernacstate.Synterp.freeze ~marshallable:false; interp }
+  Vernacstate.{ synterp = Vernacstate.Synterp.freeze (); interp }
 
 let interp_entry ?(verbosely=true) ~st entry =
   Vernacstate.unfreeze_full_state st;

--- a/vernac/vernacstate.mli
+++ b/vernac/vernacstate.mli
@@ -49,7 +49,7 @@ module Synterp : sig
     }
 
   val init : unit -> t
-  val freeze : marshallable:bool -> t
+  val freeze : unit -> t
   val unfreeze : t -> unit
 
 end
@@ -81,11 +81,9 @@ type t =
   (** program mode table. One per open module/section including the toplevel module. *)
   ; opaques : Opaques.Summary.t
   (** qed-terminated proofs *)
-  ; shallow : bool
-  (** is the state trimmed down (libstack) *)
   }
 
-val freeze_interp_state : marshallable:bool -> t
+val freeze_interp_state : unit -> t
 val unfreeze_interp_state : t -> unit
 
 (* WARNING: Do not use, it will go away in future releases *)
@@ -98,7 +96,7 @@ type t =
   ; interp: Interp.t
   }
 
-val freeze_full_state : marshallable:bool -> t
+val freeze_full_state : unit -> t
 val unfreeze_full_state : t -> unit
 
 (** STM-specific state handling *)


### PR DESCRIPTION
We want to keep the value when `marshallable` is `false` not `true`.

Fixing the logic reveals a bug where the state sent to proof workers
was produced with marshallable:false, so instead we redesign the API.

Now freeze_function is unit -> 'a, and summaries may be declared with
an optional make_marshallable:'a -> 'a.

Also fix #17610

Overlays:
- https://github.com/ejgallego/coq-lsp/pull/493
- https://github.com/LPCIC/coq-elpi/pull/462
- https://github.com/SkySkimmer/coq-lean-import/pull/8