### PR TITLE
Fix incorrect env variable in render_line_results

### DIFF
--- a/dev/bench/render_line_results.ml
+++ b/dev/bench/render_line_results.ml
@@ -72,7 +72,7 @@ type html_data = { link_prefix : string }
 let get_html_data () =
   match Sys.getenv_opt "CI_PROJECT_NAMESPACE",
         Sys.getenv_opt "CI_PROJECT_NAME",
-        Sys.getenv_opt "CI_BUILD_ID" with
+        Sys.getenv_opt "CI_JOB_ID" with
   | Some ns, Some project, Some id ->
     Some { link_prefix =
              Printf.sprintf "https://%s.gitlab.io/-/%s/-/jobs/%s/artifacts/_bench/html/"


### PR DESCRIPTION
I don't know why CI_BUILD_ID existed in
https://github.com/coq/coq/pull/17559 but JOB_ID is the documented one.
