### PR TITLE
Kernel: preserve univ info in conversion errors

### DIFF
--- a/checker/checker.ml
+++ b/checker/checker.ml
@@ -266,7 +266,7 @@ let explain_exn = function
       | Generalization _ -> str"Generalization"
       | ActualType _ -> str"ActualType"
       | IncorrectPrimitive _ -> str"IncorrectPrimitive"
-      | CantApplyBadType ((n,a,b),{uj_val = hd; uj_type = hdty},args) ->
+      | CantApplyBadType ((n,a,b,_),{uj_val = hd; uj_type = hdty},args) ->
         let pp_arg i judge =
           hv 1 (str"arg " ++ int (i+1) ++ str"= " ++
                 Constr.debug_print judge.uj_val ++

--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -66,7 +66,7 @@ let check_constant_declaration env opac kn cb opacify =
     | Some bd ->
       let j = infer env bd in
       (try conv_leq env j.uj_type ty
-       with NotConvertible -> Type_errors.error_actual_type env j ty)
+       with NotConvertible e -> Type_errors.error_actual_type env j ty e)
     | None -> ()
   in
   match body with

--- a/kernel/conversion.mli
+++ b/kernel/conversion.mli
@@ -14,15 +14,19 @@ open Environ
 (***********************************************************************
   s conversion functions *)
 
-exception NotConvertible
+type conv_pb = CONV | CUMUL
+
+type univ_error =
+  | MissingConstraint of { left : Sorts.t; kind : conv_pb; right : Sorts.t }
+  | Inconsistency of UGraph.univ_inconsistency
+
+exception NotConvertible of univ_error option
 
 type 'a kernel_conversion_function = env -> 'a -> 'a -> unit
 type 'a extended_conversion_function =
   ?l2r:bool -> ?reds:TransparentState.t -> env ->
   ?evars:constr evar_handler ->
   'a -> 'a -> unit
-
-type conv_pb = CONV | CUMUL
 
 type 'a universe_compare = {
   (* Might raise NotConvertible *)

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -108,12 +108,12 @@ let rec check_with_def (cst, ustate) env struc (idl,(c,ctx)) mp reso =
               let typ = cb.const_type in
               begin
                 try Conversion.conv_leq env' j.uj_type typ
-                with Conversion.NotConvertible -> error_incorrect_with_constraint lab
+                with Conversion.NotConvertible _ -> error_incorrect_with_constraint lab
               end
             | Def c' ->
               begin
                 try Conversion.conv env' c c'
-                with Conversion.NotConvertible -> error_incorrect_with_constraint lab
+                with Conversion.NotConvertible _ -> error_incorrect_with_constraint lab
               end
             | Primitive _ ->
               error_incorrect_with_constraint lab
@@ -152,7 +152,7 @@ let rec check_with_def (cst, ustate) env struc (idl,(c,ctx)) mp reso =
       end
   with
   | Not_found -> error_no_such_label lab mp
-  | Conversion.NotConvertible -> error_incorrect_with_constraint lab
+  | Conversion.NotConvertible _ -> error_incorrect_with_constraint lab
 
 let rec check_with_mod (cst, ustate) env struc (idl,new_mp) mp reso =
   let lab,idl = match idl with
@@ -225,7 +225,7 @@ let rec check_with_mod (cst, ustate) env struc (idl,new_mp) mp reso =
       end
   with
   | Not_found -> error_no_such_label lab mp
-  | Conversion.NotConvertible -> error_incorrect_with_constraint lab
+  | Conversion.NotConvertible _ -> error_incorrect_with_constraint lab
 
 let check_with ustate env mp (sign,reso,cst) = function
   | WithDef(idl, (c, ctx)) ->

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -88,10 +88,10 @@ let check_conv_error error why state poly pb env a1 a2 =
       try
         let () = Conversion.default_conv pb env a1 a2 in
         fst state
-      with NotConvertible -> error (IncompatiblePolymorphism (env, a1, a2))
+      with NotConvertible _ -> error (IncompatiblePolymorphism (env, a1, a2))
     else
       Conversion.generic_conv pb ~l2r:false default_evar_handler TransparentState.full env state a1 a2
-  with NotConvertible -> error why
+  with NotConvertible _ -> error why
      | UGraph.UniverseInconsistency e -> error (IncompatibleUniverses e)
 
 let check_universes error env u1 u2 =

--- a/kernel/term_typing.ml
+++ b/kernel/term_typing.ml
@@ -87,7 +87,7 @@ let process_universes env = function
 let check_primitive_type env op_t u t =
   let inft = Typeops.type_of_prim_or_type env u op_t in
   try Conversion.default_conv Conversion.CONV env inft t
-  with Conversion.NotConvertible ->
+  with Conversion.NotConvertible _ ->
     Type_errors.error_incorrect_primitive env (make_judge op_t inft) t
 
 let adjust_primitive_univ_entry p auctx = function

--- a/kernel/type_errors.mli
+++ b/kernel/type_errors.mli
@@ -61,10 +61,12 @@ type ('constr, 'types) ptype_error =
   | NumberBranches of ('constr, 'types) punsafe_judgment * int
   | IllFormedBranch of 'constr * pconstructor * 'constr * 'constr
   | Generalization of (Name.t * 'types) * ('constr, 'types) punsafe_judgment
-  | ActualType of ('constr, 'types) punsafe_judgment * 'types
+  | ActualType of ('constr, 'types) punsafe_judgment * 'types * Conversion.univ_error option
   | IncorrectPrimitive of (CPrimitives.op_or_type,'types) punsafe_judgment * 'types
   | CantApplyBadType of
-      (int * 'constr * 'constr) * ('constr, 'types) punsafe_judgment * ('constr, 'types) punsafe_judgment array
+      (int * 'constr * 'constr * Conversion.univ_error option)
+      * ('constr, 'types) punsafe_judgment
+      * ('constr, 'types) punsafe_judgment array
   | CantApplyNonFunctional of ('constr, 'types) punsafe_judgment * ('constr, 'types) punsafe_judgment array
   | IllFormedRecBody of 'constr pguard_error * Name.t Context.binder_annot array * int * env * ('constr, 'types) punsafe_judgment array
   | IllTypedRecBody of
@@ -125,7 +127,7 @@ val error_ill_formed_branch : env -> constr -> pconstructor -> constr -> constr 
 
 val error_generalization : env -> Name.t * types -> unsafe_judgment -> 'a
 
-val error_actual_type : env -> unsafe_judgment -> types -> 'a
+val error_actual_type : env -> unsafe_judgment -> types -> Conversion.univ_error option -> 'a
 
 val error_incorrect_primitive : env -> (CPrimitives.op_or_type,types) punsafe_judgment -> types -> 'a
 
@@ -133,7 +135,7 @@ val error_cant_apply_not_functional :
   env -> unsafe_judgment -> unsafe_judgment array -> 'a
 
 val error_cant_apply_bad_type :
-  env -> int * constr * constr ->
+  env -> int * constr * constr * Conversion.univ_error option ->
       unsafe_judgment -> unsafe_judgment array -> 'a
 
 val error_ill_formed_rec_body :

--- a/pretyping/pretype_errors.ml
+++ b/pretyping/pretype_errors.ml
@@ -84,19 +84,19 @@ let error_actual_type ?loc ?info env sigma {uj_val=c;uj_type=actty} expty reason
   raise_pretype_error ?loc ?info
     (env, sigma, ActualTypeNotCoercible (j, expty, reason))
 
-let error_actual_type_core ?loc env sigma {uj_val=c;uj_type=actty} expty =
+let error_actual_type_core ?loc env sigma {uj_val=c;uj_type=actty} expty e =
   let j = {uj_val=c;uj_type=actty} in
   raise_type_error ?loc
-    (env, sigma, ActualType (j, expty))
+    (env, sigma, ActualType (j, expty, e))
 
 let error_cant_apply_not_functional ?loc env sigma rator randl =
   raise_type_error ?loc
     (env, sigma, CantApplyNonFunctional (rator, randl))
 
-let error_cant_apply_bad_type ?loc env sigma (n,c,t) rator randl =
+let error_cant_apply_bad_type ?loc env sigma (n,c,t) rator randl e =
   raise_type_error ?loc
     (env, sigma,
-       CantApplyBadType ((n,c,t), rator, randl))
+       CantApplyBadType ((n,c,t,e), rator, randl))
 
 let error_ill_formed_branch ?loc env sigma c i actty expty =
   raise_type_error

--- a/pretyping/pretype_errors.mli
+++ b/pretyping/pretype_errors.mli
@@ -81,7 +81,7 @@ val error_actual_type :
       unification_error -> 'b
 
 val error_actual_type_core :
-  ?loc:Loc.t -> env -> Evd.evar_map -> unsafe_judgment -> constr -> 'b
+  ?loc:Loc.t -> env -> Evd.evar_map -> unsafe_judgment -> constr -> Conversion.univ_error option -> 'b
 
 val error_cant_apply_not_functional :
   ?loc:Loc.t -> env -> Evd.evar_map ->
@@ -89,7 +89,7 @@ val error_cant_apply_not_functional :
 
 val error_cant_apply_bad_type :
   ?loc:Loc.t -> env -> Evd.evar_map -> int * constr * constr ->
-      unsafe_judgment -> unsafe_judgment array -> 'b
+      unsafe_judgment -> unsafe_judgment array ->  Conversion.univ_error option -> 'b
 
 val error_case_not_inductive :
   ?loc:Loc.t -> env -> Evd.evar_map -> unsafe_judgment -> 'b

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -46,6 +46,7 @@ let make_param_univs env sigma indu spec jl =
           (i+1, mkType (Univ.Universe.make expected), j.uj_type)
           (make_judge (mkIndU indu) indty)
           jl
+          None
       | Sorts.Prop -> TemplateProp
       | Sorts.Set -> TemplateUniv Univ.Universe.type0
       | Sorts.Type u | Sorts.QSort (_, u) -> TemplateUniv u)
@@ -101,7 +102,7 @@ let judge_of_apply env sigma funj argjv =
     | sigma ->
       apply_rec sigma (n+1) subs c2 restjl
     | exception Evarconv.UnableToUnify _ ->
-      error_cant_apply_bad_type env sigma (n, c1, hj.uj_type) funj argjv
+      error_cant_apply_bad_type env sigma (n, c1, hj.uj_type) funj argjv None
   in
   apply_rec sigma 1 (Esubst.subs_id 0) funj.uj_type (Array.to_list argjv)
 
@@ -604,14 +605,14 @@ let judge_of_apply_against env sigma changedf funj argjv =
         | sigma ->
           apply_rec sigma (Changed {bodyonly=lazy false}) (n+1) subs c2 restjl
         | exception Evarconv.UnableToUnify _ ->
-          error_cant_apply_bad_type env sigma (n, c1, hj.uj_type) funj (Array.map snd argjv)
+          error_cant_apply_bad_type env sigma (n, c1, hj.uj_type) funj (Array.map snd argjv) None
     end
     else
       match Evarconv.unify_leq_delay env sigma hj.uj_type c1 with
       | sigma ->
         apply_rec sigma changedf (n+1) subs c2 restjl
       | exception Evarconv.UnableToUnify _ ->
-        error_cant_apply_bad_type env sigma (n, c1, hj.uj_type) funj (Array.map snd argjv)
+        error_cant_apply_bad_type env sigma (n, c1, hj.uj_type) funj (Array.map snd argjv) None
   in
   apply_rec sigma changedf 1 (Esubst.subs_id 0) funj.uj_type (Array.to_list argjv)
 


### PR DESCRIPTION
We discussed doing this in a recent coq call. Let's see if there's perf impact.

Alternative to #17432
