### PR TITLE
Fix calls to partial summary unfreeze

### DIFF
--- a/library/global.ml
+++ b/library/global.ml
@@ -57,12 +57,12 @@ let globalize f =
 
 let globalize0_with_summary fs f =
   let env = f (safe_env ()) in
-  Summary.Interp.unfreeze_summaries ~partial:true fs;
+  Summary.Interp.unfreeze_summaries fs;
   GlobalSafeEnv.set_safe_env env
 
 let globalize_with_summary fs f =
   let res,env = f (safe_env ()) in
-  Summary.Interp.unfreeze_summaries ~partial:true fs;
+  Summary.Interp.unfreeze_summaries fs;
   GlobalSafeEnv.set_safe_env env;
   res
 

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -368,7 +368,7 @@ module SynterpActions : LibActions with type summary = Summary.Synterp.frozen = 
   let push_section_name obj_dir =
     Nametab.(push_dir (Until 1) obj_dir (GlobDirRef.DirOpenSection obj_dir))
 
-  let close_section fs = Summary.Synterp.unfreeze_summaries ~partial:true fs
+  let close_section fs = Summary.Synterp.unfreeze_summaries fs
 
   let add_entry node =
     synterp_state := { !synterp_state with lib_stk = (node,[]) :: !synterp_state.lib_stk }

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -792,7 +792,7 @@ let end_module_core id (m_info : current_module_syntax_info) objects fs =
     | Some (mty, inline) ->
       SynterpVisitor.get_module_sobjs false () inline mty, [], []
   in
-  Summary.Synterp.unfreeze_summaries ~partial:true fs;
+  Summary.Synterp.unfreeze_summaries fs;
   let sobjs = let (ms,objs) = sobjs0 in (m_info.cur_mbids@ms,objs) in
 
   (* We substitute objects if the module is sealed by a signature *)
@@ -865,7 +865,7 @@ let declare_module id args res mexpr_o =
   in
   (* Undo the simulated interactive building of the module
      and declare the module as a whole *)
-  Summary.Synterp.unfreeze_summaries ~partial:true fs;
+  Summary.Synterp.unfreeze_summaries fs;
 
   (* We can use an empty delta resolver on syntax objects *)
   let sobjs = subst_sobjs (map_mp mp0 mp empty_delta_resolver) sobjs in
@@ -1088,7 +1088,7 @@ let declare_module id args res mexpr_o =
   in
   (* Undo the simulated interactive building of the module
      and declare the module as a whole *)
-  Summary.Interp.unfreeze_summaries ~partial:true fs;
+  Summary.Interp.unfreeze_summaries fs;
   let inl = match inl_expr with
   | None -> None
   | _ -> inl_res
@@ -1136,7 +1136,7 @@ let start_modtype id args mtys =
 
 let end_modtype_core id mbids objects fs =
   let {Lib.Synterp.substobjs = substitute; keepobjs = _; anticipateobjs = special; } = objects in
-  Summary.Synterp.unfreeze_summaries ~partial:true fs;
+  Summary.Synterp.unfreeze_summaries fs;
   let modtypeobjs = (mbids, Objs substitute) in
   (special@[ModuleTypeObject (id,modtypeobjs)])
 
@@ -1161,7 +1161,7 @@ let declare_modtype id args mtys (mty,ann) =
 
   (* Undo the simulated interactive building of the module type
      and declare the module type as a whole *)
-  Summary.Synterp.unfreeze_summaries ~partial:true fs;
+  Summary.Synterp.unfreeze_summaries fs;
   ignore (SynterpVisitor.add_leaf (ModuleTypeObject (id,sobjs)));
   mp, args, (mte, base, kind, inl), sub_mty_l
 
@@ -1229,7 +1229,7 @@ let declare_modtype id args mtys (mte,base,kind,inl) =
 
   (* Undo the simulated interactive building of the module type
      and declare the module type as a whole *)
-  Summary.Interp.unfreeze_summaries ~partial:true fs;
+  Summary.Interp.unfreeze_summaries fs;
 
   (* We enrich the global environment *)
   let () = Global.push_context_set ~strict:true ctx in


### PR DESCRIPTION
These calls were introduced in #16578, but are no longer necessary since we now properly distinguish synterp and interp summaries.

`partial:true` should be restricted to some internal STM hacks