### PR TITLE
Expose `interp_search_request` in API

### DIFF
--- a/vernac/comSearch.mli
+++ b/vernac/comSearch.mli
@@ -10,5 +10,11 @@
 
 (* Interpretation of search commands *)
 
+val interp_search_request :
+  Environ.env ->
+  Evd.evar_map ->
+  bool * Vernacexpr.search_request ->
+  bool * Search.glob_search_request
+
 val interp_search : Environ.env -> Evd.evar_map ->
   Vernacexpr.searchable -> Vernacexpr.search_restriction -> unit


### PR DESCRIPTION
Exposing this bit of API makes it possible for IDEs to construct search patterns without going through the parser.