### PR TITLE
coqpp: do not print line annotation when loc is dummy

### DIFF
--- a/coqpp/coqpp_ast.mli
+++ b/coqpp/coqpp_ast.mli
@@ -13,7 +13,7 @@ type loc = {
   loc_end : Lexing.position;
 }
 
-type code = { code : string; loc : loc; }
+type code = { code : string; loc : loc option; }
 
 type user_symbol =
 | Ulist1 of user_symbol

--- a/coqpp/coqpp_lex.mll
+++ b/coqpp/coqpp_lex.mll
@@ -73,7 +73,7 @@ let end_ocaml lexbuf =
   else if !num_braces = 0 then
     let s = Buffer.contents ocaml_buf in
     let () = Buffer.reset ocaml_buf in
-    let loc = {
+    let loc = Some {
       Coqpp_ast.loc_start = !ocaml_start_pos;
       Coqpp_ast.loc_end = lexeme_end_p lexbuf
     } in

--- a/coqpp/coqpp_main.ml
+++ b/coqpp/coqpp_main.ml
@@ -17,14 +17,14 @@ let fatal msg =
   let () = Format.eprintf "Error: %s@\n%!" msg in
   exit 1
 
-let dummy_loc = { loc_start = Lexing.dummy_pos; loc_end = Lexing.dummy_pos }
-let mk_code s = { code = s; loc = dummy_loc }
+let mk_code s = { code = s; loc = None }
 
 let print_code fmt c =
-  let loc = c.loc.loc_start in
-  if loc.pos_fname = "" then fprintf fmt "%s" c.code
-  else
+  match c.loc with
+  | None -> fprintf fmt "%s" c.code
+  | Some loc ->
     (* Print the line location as a source annotation *)
+    let loc = loc.loc_start in
     let padding = String.make (loc.pos_cnum - loc.pos_bol + 1) ' ' in
     let code_insert = asprintf "\n# %i \"%s\"\n%s%s" loc.pos_lnum loc.pos_fname padding c.code in
     fprintf fmt "@[@<0>%s@]@\n" code_insert

--- a/coqpp/coqpp_main.ml
+++ b/coqpp/coqpp_main.ml
@@ -22,10 +22,12 @@ let mk_code s = { code = s; loc = dummy_loc }
 
 let print_code fmt c =
   let loc = c.loc.loc_start in
-  (* Print the line location as a source annotation *)
-  let padding = String.make (loc.pos_cnum - loc.pos_bol + 1) ' ' in
-  let code_insert = asprintf "\n# %i \"%s\"\n%s%s" loc.pos_lnum loc.pos_fname padding c.code in
-  fprintf fmt "@[@<0>%s@]@\n" code_insert
+  if loc.pos_fname = "" then fprintf fmt "%s" c.code
+  else
+    (* Print the line location as a source annotation *)
+    let padding = String.make (loc.pos_cnum - loc.pos_bol + 1) ' ' in
+    let code_insert = asprintf "\n# %i \"%s\"\n%s%s" loc.pos_lnum loc.pos_fname padding c.code in
+    fprintf fmt "@[@<0>%s@]@\n" code_insert
 
 module StringSet = Set.Make(String)
 

--- a/coqpp/coqpp_parse.mly
+++ b/coqpp/coqpp_parse.mly
@@ -57,7 +57,7 @@ let parse_user_entry s sep =
   in
   parse s sep table
 
-let no_code = { code = ""; loc = { loc_start=Lexing.dummy_pos; loc_end=Lexing.dummy_pos} }
+let no_code = { code = ""; loc = None }
 
 %}
 


### PR DESCRIPTION
These code values are built internally with mk_code, eg `mk_code "()"` in `print_anonymized_symbol`.

Fix #17336
