### PR TITLE
Disable async proofs for output test #17579

### DIFF
--- a/test-suite/output/bug_17579.out
+++ b/test-suite/output/bug_17579.out
@@ -1,7 +1,7 @@
-File "./output/bug_17579.v", line 2, characters 0-26:
+File "./output/bug_17579.v", line 4, characters 0-26:
 The command has indeed failed with message:
 Timeout must be > 0.
-File "./output/bug_17579.v", line 5, characters 8-9:
+File "./output/bug_17579.v", line 7, characters 8-9:
 Error:
 Syntax error: [natural] expected after 'Timeout' (in [vernac_control]).
 

--- a/test-suite/output/bug_17579.v
+++ b/test-suite/output/bug_17579.v
@@ -1,3 +1,5 @@
+(* -*- coq-prog-args: ("-async-proofs" "no"); -*- *)
+(* disable async proofs because they get the parse error before running the Fail *)
 
 Fail Timeout 0 Check True.
 


### PR DESCRIPTION
example failure https://gitlab.com/coq/coq/-/jobs/4334625916