### PR TITLE
Deprecate List.Forall2_refl (it has a bad type)

### DIFF
--- a/doc/changelog/11-standard-library/17646-forall2-refl.rst
+++ b/doc/changelog/11-standard-library/17646-forall2-refl.rst
@@ -1,0 +1,4 @@
+- **Deprecated:**
+  `Coq.Lists.List.Forall2_refl` (`Coq.Lists.List.Forall2_nil` has the same type)
+  (`#17646 <https://github.com/coq/coq/pull/17646>`_,
+  by Gaëtan Gilbert).

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -3121,6 +3121,9 @@ Section Forall2.
   #[local]
   Hint Constructors Forall2 : core.
 
+  (* NB: when deprecation phase ends, instead of removing prove "Reflexive R -> Reflexive Forall2"
+     and close #6131 *)
+  #[deprecated(since = "8.18", note = "Use Forall2_nil instead.")]
   Theorem Forall2_refl : Forall2 [] [].
   Proof. intros; apply Forall2_nil. Qed.
 


### PR DESCRIPTION
cf coq/stdlib#56 (close after the deprecation phase)