### PR TITLE
Fix sort quality variables with async workers

### DIFF
--- a/dev/ci/user-overlays/17662-SkySkimmer-fix-async-qvar-union.sh
+++ b/dev/ci/user-overlays/17662-SkySkimmer-fix-async-qvar-union.sh
@@ -1,0 +1,1 @@
+overlay serapi https://github.com/SkySkimmer/coq-serapi fix-async-qvar-union 17662

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -383,7 +383,7 @@ let constr_display csr =
     | Prop -> "Prop"
     | Type u -> univ_display u;
         "Type("^(string_of_int !cnt)^")"
-    | QSort (q, u) -> univ_display u; Printf.sprintf "QSort(%i, %i)" (Sorts.QVar.repr q) !cnt
+    | QSort (q, u) -> univ_display u; Printf.sprintf "QSort(%s, %i)" (Sorts.QVar.to_string q) !cnt
 
   and universes_display l =
     Array.fold_right (fun x i -> level_display x; (string_of_int !cnt)^(if not(i="")
@@ -535,7 +535,7 @@ let print_pure_constr csr =
     | Type u -> open_hbox();
         print_string "Type("; pp (Universe.raw_pr u); print_string ")"; close_box()
     | QSort (q, u) -> open_hbox();
-        print_string "QSort("; pp (int @@ QVar.repr q); print_string ", "; pp (Universe.raw_pr u); print_string ")"; close_box()
+        print_string "QSort("; pp (QVar.pr q); print_string ", "; pp (Universe.raw_pr u); print_string ")"; close_box()
 
   and name_display x = match x.binder_name with
     | Name id -> print_string (Id.to_string id)

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -121,6 +121,10 @@ let unify_quality ~fail c q1 q2 local = match q1, q2 with
 | (QSProp, (QType | QProp)) -> fail ()
 | (QProp, QSProp) -> fail ()
 
+let nf_quality m = function
+  | QSProp | QProp | QType as q -> q
+  | QVar q -> repr q m
+
 let union ~fail s1 s2 =
   let extra = ref [] in
   let qmap = QMap.union (fun qk q1 q2 ->
@@ -140,7 +144,11 @@ let union ~fail s1 s2 =
   in
   let above = QSet.filter filter @@ QSet.union s1.above s2.above in
   let s = { qmap; above } in
-  List.fold_left (fun s (q1,q2) -> unify_quality ~fail:(fun () -> fail s q1 q2) CONV q1 q2 s) s extra
+  List.fold_left (fun s (q1,q2) ->
+      let q1 = nf_quality s q1 and q2 = nf_quality s q2 in
+      unify_quality ~fail:(fun () -> fail s q1 q2) CONV q1 q2 s)
+    s
+    extra
 
 let add q m = { qmap = QMap.add q None m.qmap; above = m.above }
 

--- a/engine/univGen.ml
+++ b/engine/univGen.ml
@@ -44,7 +44,8 @@ let new_sort_id =
   fun () -> incr cnt; !cnt
 
 let new_sort_global () =
-  Sorts.QVar.make (new_sort_id ())
+  let s = if Flags.async_proofs_is_worker() then !Flags.async_proofs_worker_id else "" in
+  Sorts.QVar.make s (new_sort_id ())
 
 let fresh_instance auctx =
   let inst = Array.init (AbstractContext.size auctx) (fun _ -> fresh_level()) in

--- a/kernel/sorts.mli
+++ b/kernel/sorts.mli
@@ -17,10 +17,11 @@ val all_families : family list
 module QVar :
 sig
   type t
-  val make : int -> t
-  val repr : t -> int
+  val make : string -> int -> t
+  val repr : t -> string * int
   val equal : t -> t -> bool
   val compare : t -> t -> int
+  val to_string : t -> string
   val pr : t -> Pp.t
 end
 

--- a/kernel/univ.ml
+++ b/kernel/univ.ml
@@ -60,6 +60,12 @@ module UGlobal = struct
       let c = DirPath.compare u1.library u2.library in
       if c <> 0 then c
       else String.compare u1.process u2.process
+
+  let to_string { library = d; process = s; uid = n } =
+    DirPath.to_string d ^
+    (if CString.is_empty s then "" else "." ^ s) ^
+    "." ^ string_of_int n
+
 end
 
 module RawLevel =
@@ -173,10 +179,7 @@ module Level = struct
   let to_string x =
     match data x with
     | Set -> "Set"
-    | UGlobal.(Level { library = d; process = s; uid = n }) ->
-      Names.DirPath.to_string d ^
-      (if CString.is_empty s then "" else "." ^ s) ^
-      "." ^ string_of_int n
+    | Level l -> UGlobal.to_string l
     | Var n -> "Var(" ^ string_of_int n ^ ")"
 
   let raw_pr u = str (to_string u)

--- a/kernel/univ.mli
+++ b/kernel/univ.mli
@@ -19,6 +19,7 @@ sig
   val equal : t -> t -> bool
   val hash : t -> int
   val compare : t -> t -> int
+  val to_string : t -> string
 
 end
 

--- a/kernel/vmvalues.ml
+++ b/kernel/vmvalues.ml
@@ -140,7 +140,7 @@ let pp_sort s =
   | Prop -> Pp.str "Prop"
   | Set -> Pp.str "Set"
   | Type u -> Pp.(str "Type@{" ++ Univ.Universe.raw_pr u ++ str "}")
-  | QSort (q, u) -> Pp.(str "QSort@{" ++ (int @@ Sorts.QVar.repr q) ++ str ", " ++ Univ.Universe.raw_pr u ++ str "}")
+  | QSort (q, u) -> Pp.(str "QSort@{" ++ Sorts.QVar.pr q ++ str ", " ++ Univ.Universe.raw_pr u ++ str "}")
 
 let pp_struct_const = function
   | Const_sort s -> pp_sort s

--- a/test-suite/bugs/bug_17661.v
+++ b/test-suite/bugs/bug_17661.v
@@ -1,0 +1,6 @@
+
+Lemma foo : Prop.
+Proof.
+  assert SProp.
+  par: exact (forall P, P).
+Qed.


### PR DESCRIPTION
Same as with univ levels, we include the worker name to ensure
unicity.

Unlike univ levels, quality variables don't survive the proof so no
need to include the dirpath.

Fix #17661

Overlays:
- https://github.com/ejgallego/coq-serapi/pull/334