### PR TITLE
Put version info in OCaml defined deprecation warnings

### DIFF
--- a/dev/ci/user-overlays/17664-SkySkimmer-depr-versions.sh
+++ b/dev/ci/user-overlays/17664-SkySkimmer-depr-versions.sh
@@ -1,0 +1,19 @@
+overlay elpi https://github.com/SkySkimmer/coq-elpi depr-versions 17664
+
+overlay equations https://github.com/SkySkimmer/Coq-Equations depr-versions 17664
+
+overlay metacoq https://github.com/SkySkimmer/metacoq depr-versions 17664
+
+overlay itauto https://github.com/SkySkimmer/https://gitlab.inria.fr/fbesson/itauto depr-versions 17664
+
+overlay lean_importer https://github.com/SkySkimmer/coq-lean-import depr-versions 17664
+
+overlay unicoq https://github.com/SkySkimmer/unicoq depr-versions 17664
+
+overlay paramcoq https://github.com/SkySkimmer/paramcoq depr-versions 17664
+
+overlay serapi https://github.com/SkySkimmer/coq-serapi depr-versions 17664
+
+overlay tactician https://github.com/SkySkimmer/coq-tactician depr-versions 17664
+
+overlay coqhammer https://github.com/SkySkimmer/coqhammer depr-versions 17664

--- a/engine/namegen.ml
+++ b/engine/namegen.ml
@@ -215,24 +215,20 @@ let it_mkLambda_or_LetIn_name env sigma b hyps =
    to test dependence of scripts on auto-generated names.
    We also supply a version which only adds a prefix. *)
 
-let get_mangle_names =
+let { Goptions.get = get_mangle_names } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Mangle";"Names"]
     ~value:false
+    ()
 
-let get_mangle_names_light =
+let { Goptions.get = get_mangle_names_light } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Mangle";"Names";"Light"]
     ~value:false
+    ()
 
-let mangle_names_prefix =
+let { Goptions.get = mangle_names_prefix } =
   Goptions.declare_interpreted_string_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Mangle";"Names";"Prefix"]
     ~value:("_")
     (fun x ->
@@ -245,6 +241,7 @@ let mangle_names_prefix =
       )
     )
     (fun x -> x)
+    ()
 
 (** The name "foo" becomes "_0" if we get_mangle_names and "_foo" if
     get_mangle_names_light is also set. Otherwise it is left alone. *)

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -334,12 +334,11 @@ let instantiate_variable l (b : Universe.t) v =
 
 exception UniversesDiffer
 
-let drop_weak_constraints =
+let { Goptions.get = drop_weak_constraints } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Cumulativity";"Weak";"Constraints"]
     ~value:false
+    ()
 
 let level_inconsistency cst l r =
   let mk u = Sorts.sort_of_univ @@ Universe.make u in

--- a/engine/univMinim.ml
+++ b/engine/univMinim.ml
@@ -12,12 +12,11 @@ open Univ
 open UnivSubst
 
 (* To disallow minimization to Set *)
-let get_set_minimization =
+let { Goptions.get = get_set_minimization } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Universe";"Minimization";"ToSet"]
     ~value:true
+    ()
 
 (** Simplification *)
 

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -387,7 +387,7 @@ let import_option_value = function
 
 let export_option_state s = {
   Interface.opt_sync  = true;
-  Interface.opt_depr  = s.Goptions.opt_depr;
+  Interface.opt_depr  = Option.has_some s.Goptions.opt_depr;
   Interface.opt_value = export_option_value s.Goptions.opt_value;
 }
 

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -64,12 +64,11 @@ let print_universes = Detyping.print_universes
 let print_no_symbol = ref false
 
 (* This tells to skip types if a variable has this type by default *)
-let print_use_implicit_types =
+let { Goptions.get = print_use_implicit_types } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Printing";"Use";"Implicit";"Types"]
     ~value:true
+    ()
 
 (* Print primitive tokens, like strings *)
 let print_raw_literal = ref false
@@ -104,12 +103,11 @@ let without_symbols f = Flags.with_option print_no_symbol f
 (* Control printing of records *)
 
 (* Set Record Printing flag *)
-let get_record_print =
+let { Goptions.get = get_record_print } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Printing";"Records"]
     ~value:true
+    ()
 
 let is_record indsp =
   try

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -1682,11 +1682,11 @@ let is_non_zero_pat c = match c with
   | { CAst.v = CPatPrim (Number p) } -> not (NumTok.Signed.is_zero p)
   | _ -> false
 
-let get_asymmetric_patterns = Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
+let { Goptions.get = get_asymmetric_patterns } =
+  Goptions.declare_bool_option_and_ref
     ~key:["Asymmetric";"Patterns"]
     ~value:false
+    ()
 
 type global_reference_test = {
   for_ind : bool;

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -950,11 +950,11 @@ let bigint_of_coqpos_neg_int63 c =
       | _ -> raise NotAValidPrimToken)
   | _ -> raise NotAValidPrimToken
 
-let get_printing_float = Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
+let { Goptions.get = get_printing_float } =
+  Goptions.declare_bool_option_and_ref
     ~key:["Printing";"Float"]
     ~value:true
+    ()
 
 let uninterp_float64 c =
   match Constr.kind c with

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -122,7 +122,7 @@ let init_scope_map () =
 (* Operations on scopes *)
 
 let warn_undeclared_scope =
-  CWarnings.create ~name:"undeclared-scope" ~category:CWarnings.CoreCategories.deprecated
+  CWarnings.create ~name:"undeclared-scope" ~category:Deprecation.Version.v8_10
                    (fun (scope) ->
                     strbrk "Declaring a scope implicitly is deprecated; use in advance an explicit "
                     ++ str "\"Declare Scope " ++ str scope ++ str ".\".")

--- a/lib/deprecation.ml
+++ b/lib/deprecation.ml
@@ -59,3 +59,18 @@ let create_warning ~object_name ~warning_name_if_no_since pp =
           w
     in
     w ?loc (v,info)
+
+module Version = struct
+
+  let v8_3 = get_generic_cat "8.3"
+  let v8_5 = get_generic_cat "8.5"
+  let v8_8 = get_generic_cat "8.8"
+  let v8_10 = get_generic_cat "8.10"
+  let v8_11 = get_generic_cat "8.11"
+  let v8_14 = get_generic_cat "8.14"
+  let v8_15 = get_generic_cat "8.15"
+  let v8_16 = get_generic_cat "8.16"
+  let v8_17 = get_generic_cat "8.17"
+  let v8_18 = get_generic_cat "8.18"
+
+end

--- a/lib/deprecation.mli
+++ b/lib/deprecation.mli
@@ -14,3 +14,16 @@ val make : ?since:string -> ?note:string -> unit -> t
 
 val create_warning : object_name:string -> warning_name_if_no_since:string ->
   ('b -> Pp.t) -> ?loc:Loc.t -> 'b * t -> unit
+
+module Version : sig
+  val v8_3 : CWarnings.category
+  val v8_5 : CWarnings.category
+  val v8_8 : CWarnings.category
+  val v8_10 : CWarnings.category
+  val v8_11 : CWarnings.category
+  val v8_14 : CWarnings.category
+  val v8_15 : CWarnings.category
+  val v8_16 : CWarnings.category
+  val v8_17 : CWarnings.category
+  val v8_18 : CWarnings.category
+end

--- a/library/goptions.ml
+++ b/library/goptions.ml
@@ -26,7 +26,7 @@ type table_value =
 
 (** Summary of an option status *)
 type option_state = {
-  opt_depr  : bool;
+  opt_depr  : Deprecation.t option;
   opt_value : option_value;
 }
 
@@ -217,7 +217,7 @@ let iter_table env f key lv =
 
 type 'a option_sig = {
   optstage : Summary.Stage.t;
-  optdepr  : bool;
+  optdepr  : Deprecation.t option;
   optkey   : option_name;
   optread  : unit -> 'a;
   optwrite : 'a -> unit }
@@ -253,15 +253,15 @@ with Not_found ->
 open Libobject
 
 let warn_deprecated_option =
-  CWarnings.create ~name:"deprecated-option" ~category:CWarnings.CoreCategories.deprecated (fun key ->
-    Pp.(str "Option" ++ spc () ++ str (nickname key) ++ strbrk " is deprecated"))
+  Deprecation.create_warning ~object_name:"Option" ~warning_name_if_no_since:"deprecated-option"
+    (fun key -> Pp.str (nickname key))
 
 let declare_option cast uncast append ?(preprocess = fun x -> x)
   { optstage=stage; optdepr=depr; optkey=key; optread=read; optwrite=write } =
   check_key key;
   let default = read() in
   let change =
-      let _ = Summary.declare_summary (nickname key)
+      let () = Summary.declare_summary (nickname key)
         { stage;
           Summary.freeze_function = (fun ~marshallable -> read ());
           Summary.unfreeze_function = write;
@@ -301,7 +301,7 @@ let declare_option cast uncast append ?(preprocess = fun x -> x)
             classify_function = classify_options } in
       (fun l m v -> let v = preprocess v in Lib.add_leaf (options (l, m, v)))
   in
-  let warn () = if depr then warn_deprecated_option key in
+  let warn () = depr |> Option.iter (fun depr -> warn_deprecated_option (key,depr)) in
   let cread () = cast (read ()) in
   let cwrite l v = warn (); change l OptSet (uncast v) in
   let cappend l v = warn (); change l OptAppend (uncast v) in
@@ -331,9 +331,9 @@ let declare_stringopt_option =
 
 type 'a getter = { get : unit -> 'a }
 
-type 'a opt_decl = ?stage:Summary.Stage.t -> ?depr:bool -> key:option_name -> value:'a -> unit -> 'a getter
+type 'a opt_decl = ?stage:Summary.Stage.t -> ?depr:Deprecation.t -> key:option_name -> value:'a -> unit -> 'a getter
 
-let declare_int_option_and_ref ?(stage=Interp) ?(depr=false) ~key ~(value:int) () =
+let declare_int_option_and_ref ?(stage=Interp) ?depr ~key ~(value:int) () =
   let r_opt = ref value in
   let optwrite v = r_opt := Option.default value v in
   let optread () = Some !r_opt in
@@ -346,7 +346,7 @@ let declare_int_option_and_ref ?(stage=Interp) ?(depr=false) ~key ~(value:int) (
     } in
   { get = fun () -> !r_opt }
 
-let declare_intopt_option_and_ref ?(stage=Interp) ?(depr=false) ~key ~value () =
+let declare_intopt_option_and_ref ?(stage=Interp) ?depr ~key ~value () =
   let r_opt = ref value in
   let optwrite v = r_opt := v in
   let optread () = !r_opt in
@@ -358,7 +358,7 @@ let declare_intopt_option_and_ref ?(stage=Interp) ?(depr=false) ~key ~value () =
     } in
   { get = optread }
 
-let declare_nat_option_and_ref ?(stage=Interp) ?(depr=false) ~key ~(value:int) () =
+let declare_nat_option_and_ref ?(stage=Interp) ?depr ~key ~(value:int) () =
   assert (value >= 0);
   let r_opt = ref value in
   let optwrite v =
@@ -376,7 +376,7 @@ let declare_nat_option_and_ref ?(stage=Interp) ?(depr=false) ~key ~(value:int) (
     } in
   { get = fun () -> !r_opt }
 
-let declare_bool_option_and_ref ?(stage=Interp) ?(depr=false) ~key ~(value:bool) () =
+let declare_bool_option_and_ref ?(stage=Interp) ?depr ~key ~(value:bool) () =
   let r_opt = ref value in
   let optwrite v = r_opt := v in
   let optread () = !r_opt in
@@ -388,7 +388,7 @@ let declare_bool_option_and_ref ?(stage=Interp) ?(depr=false) ~key ~(value:bool)
     } in
   { get = optread }
 
-let declare_string_option_and_ref ?(stage=Interp) ?(depr=false) ~key ~(value:string) () =
+let declare_string_option_and_ref ?(stage=Interp) ?depr ~key ~(value:string) () =
   let r_opt = ref value in
   let optwrite v = r_opt := Option.default value v in
   let optread () = Some !r_opt in
@@ -400,7 +400,7 @@ let declare_string_option_and_ref ?(stage=Interp) ?(depr=false) ~key ~(value:str
     } in
   { get = fun () -> !r_opt }
 
-let declare_stringopt_option_and_ref ?(stage=Interp) ?(depr=false) ~key ~value () =
+let declare_stringopt_option_and_ref ?(stage=Interp) ?depr ~key ~value () =
   let r_opt = ref value in
   let optwrite v = r_opt := v in
   let optread () = !r_opt in
@@ -412,7 +412,7 @@ let declare_stringopt_option_and_ref ?(stage=Interp) ?(depr=false) ~key ~value (
     } in
   { get = optread }
 
-let declare_interpreted_string_option_and_ref from_string to_string ?(stage=Interp) ?(depr=false) ~key ~(value:'a) () =
+let declare_interpreted_string_option_and_ref from_string to_string ?(stage=Interp) ?depr ~key ~(value:'a) () =
   let r_opt = ref value in
   let optwrite v = r_opt := Option.default value @@ Option.map from_string v in
   let optread () = Some (to_string !r_opt) in
@@ -546,8 +546,15 @@ let print_tables () =
   let open Pp in
   let print_option key value depr =
     let msg = str "  " ++ str (nickname key) ++ str ": " ++ msg_option_value value in
-    if depr then msg ++ str " [DEPRECATED]" ++ fnl ()
-    else msg ++ fnl ()
+    let depr = pr_opt (fun depr ->
+        hov 2
+          (str "[DEPRECATED" ++
+           pr_opt (fun since -> str "since " ++ str since) depr.Deprecation.since ++
+           pr_opt str depr.Deprecation.note ++
+           str "]"))
+        depr
+    in
+    msg ++ depr ++ fnl()
   in
   str "Options:" ++ fnl () ++
     OptionMap.fold

--- a/library/goptions.mli
+++ b/library/goptions.mli
@@ -114,7 +114,7 @@ end
 
 type 'a option_sig = {
   optstage   : Summary.Stage.t;
-  optdepr    : bool;
+  optdepr    : Deprecation.t option;
   (** whether the option is DEPRECATED *)
   optkey     : option_name;
   (** the low-level name of this option *)
@@ -144,7 +144,7 @@ val declare_stringopt_option: ?preprocess:(string option -> string option) ->
     at toplevel from the calls to read the option value. *)
 type 'a getter = { get : unit -> 'a }
 
-type 'a opt_decl = ?stage:Summary.Stage.t -> ?depr:bool -> key:option_name -> value:'a -> unit -> 'a getter
+type 'a opt_decl = ?stage:Summary.Stage.t -> ?depr:Deprecation.t -> key:option_name -> value:'a -> unit -> 'a getter
 
 val declare_int_option_and_ref : int opt_decl
 val declare_intopt_option_and_ref : int option opt_decl
@@ -208,7 +208,7 @@ val set_option_value : ?locality:option_locality -> ?stage:Summary.Stage.t ->
 
 (** Summary of an option status *)
 type option_state = {
-  opt_depr  : bool;
+  opt_depr  : Deprecation.t option;
   opt_value : option_value;
 }
 

--- a/library/goptions.mli
+++ b/library/goptions.mli
@@ -138,18 +138,21 @@ val declare_string_option: ?preprocess:(string -> string) ->
 val declare_stringopt_option: ?preprocess:(string option -> string option) ->
                               string option option_sig -> unit
 
-(** Helpers to declare a reference controlled by an option. Read-only
-   as to avoid races. *)
-type 'a opt_decl = stage:Summary.Stage.t -> depr:bool -> key:option_name -> 'a
+(** Helpers to declare a reference controlled by an option. *)
 
-val declare_int_option_and_ref : (value:int -> (unit -> int)) opt_decl
-val declare_intopt_option_and_ref : (unit -> int option) opt_decl
-val declare_nat_option_and_ref : (value:int -> (unit -> int)) opt_decl
-val declare_bool_option_and_ref : (value:bool -> (unit -> bool)) opt_decl
-val declare_string_option_and_ref : (value:string -> (unit -> string)) opt_decl
-val declare_stringopt_option_and_ref : (unit -> string option) opt_decl
-val declare_interpreted_string_option_and_ref :
-  (value:'a -> (string -> 'a) -> ('a -> string) -> (unit -> 'a)) opt_decl
+(** Wrapper type to separate the function calls to register the option
+    at toplevel from the calls to read the option value. *)
+type 'a getter = { get : unit -> 'a }
+
+type 'a opt_decl = ?stage:Summary.Stage.t -> ?depr:bool -> key:option_name -> value:'a -> unit -> 'a getter
+
+val declare_int_option_and_ref : int opt_decl
+val declare_intopt_option_and_ref : int option opt_decl
+val declare_nat_option_and_ref : int opt_decl
+val declare_bool_option_and_ref : bool opt_decl
+val declare_string_option_and_ref : string opt_decl
+val declare_stringopt_option_and_ref : string option opt_decl
+val declare_interpreted_string_option_and_ref : (string -> 'a) -> ('a -> string) -> 'a opt_decl
 
 (** {6 Special functions supposed to be used only in vernacentries.ml } *)
 

--- a/library/nametab.ml
+++ b/library/nametab.ml
@@ -102,7 +102,7 @@ module type NAMETREE = sig
 end
 
 let masking_absolute = CWarnings.create_warning
-    ~from:[CWarnings.CoreCategories.deprecated] ~name:"masking-absolute-name" ()
+    ~from:[Deprecation.Version.v8_8] ~name:"masking-absolute-name" ()
 
 module Make (U : UserName) (E : EqualityType) : NAMETREE
   with type user_name = U.t and type elt = E.t =

--- a/parsing/pcoq.ml
+++ b/parsing/pcoq.ml
@@ -261,8 +261,7 @@ end
 module Grammar = Register(GrammarObj)
 
 let warn_deprecated_intropattern =
-  let open CWarnings in
-  create ~name:"deprecated-intropattern-entry" ~category:CWarnings.CoreCategories.deprecated
+  CWarnings.create ~name:"deprecated-intropattern-entry" ~category:Deprecation.Version.v8_11
   (fun () -> Pp.strbrk "Entry name intropattern has been renamed in order \
   to be consistent with the documented grammar of tactics. Use \
   \"simple_intropattern\" instead.")

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -573,14 +573,14 @@ let optims () = !opt_flag_ref
 
 let () = declare_bool_option
           {optstage = Summary.Stage.Interp;
-           optdepr = false;
+           optdepr = None;
            optkey = ["Extraction"; "Optimize"];
            optread = (fun () -> not (Int.equal !int_flag_ref 0));
            optwrite = (fun b -> chg_flag (if b then int_flag_init else 0))}
 
 let () = declare_int_option
           { optstage = Summary.Stage.Interp;
-            optdepr = false;
+            optdepr = None;
             optkey = ["Extraction";"Flag"];
             optread = (fun _ -> Some !int_flag_ref);
             optwrite = (function

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -500,11 +500,13 @@ let info_file f =
    so we register them to coq save/undo mechanism. *)
 
 let my_bool_option name value =
-  declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
+  let { Goptions.get } =
+    declare_bool_option_and_ref
     ~key:["Extraction"; name]
     ~value
+    ()
+  in
+  get
 
 (*s Extraction AccessOpaque *)
 
@@ -587,20 +589,18 @@ let () = declare_int_option
 
 (* This option controls whether "dummy lambda" are removed when a
    toplevel constant is defined. *)
-let conservative_types =
+let { Goptions.get = conservative_types } =
   declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Extraction"; "Conservative"; "Types"]
     ~value:false
+    ()
 
 (* Allows to print a comment at the beginning of the output files *)
-let file_comment =
+let { Goptions.get = file_comment } =
   declare_string_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Extraction"; "File"; "Comment"]
     ~value:""
+    ()
 
 (*s Extraction Lang *)
 

--- a/plugins/firstorder/g_ground.mlg
+++ b/plugins/firstorder/g_ground.mlg
@@ -29,12 +29,11 @@ DECLARE PLUGIN "coq-core.plugins.firstorder"
 
 {
 
-let ground_depth =
+let { Goptions.get = ground_depth } =
   declare_nat_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Firstorder";"Depth"]
     ~value:3
+    ()
 
 let default_intuition_tac =
   let tac _ _ = Auto.h_auto None [] (Some []) in

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -301,19 +301,17 @@ let pr_table env sigma = pr_table env sigma !from_function
 (*********************************)
 (* Debugging *)
 
-let do_rewrite_dependent =
+let { Goptions.get = do_rewrite_dependent } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Functional"; "Induction"; "Rewrite"; "Dependent"]
     ~value:true
+    ()
 
-let do_observe =
+let { Goptions.get = do_observe } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Function_debug"]
     ~value:false
+    ()
 
 let observe strm = if do_observe () then Feedback.msg_debug strm else ()
 let debug_queue = Stack.create ()
@@ -356,12 +354,11 @@ let do_observe_tac ~header s tac =
 let observe_tac ~header s tac =
   if do_observe () then do_observe_tac ~header s tac else tac
 
-let is_strict_tcc =
+let { Goptions.get = is_strict_tcc } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Function_raw_tcc"]
     ~value:false
+    ()
 
 exception Building_graph of exn
 exception Defining_principle of exn

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -193,13 +193,12 @@ let merge_occurrences loc cl = function
 
 let deprecated_conversion_at_with =
   CWarnings.create
-    ~name:"conversion_at_with" ~category:CWarnings.CoreCategories.deprecated
+    ~name:"conversion_at_with" ~category:Deprecation.Version.v8_14
     (fun () -> Pp.str "The syntax [at ... with ...] is deprecated. Use [with ... at ...] instead.")
 
-(* 8.17 *)
 let deprecated_clear_modifier =
   CWarnings.create
-    ~name:"deprecated-clear-modifier" ~category:CWarnings.CoreCategories.deprecated
+    ~name:"deprecated-clear-modifier" ~category:Deprecation.Version.v8_17
     (fun () -> Pp.strbrk "The undocumented clear modifier \">\" is deprecated. Open an issue at https://github.com/coq/coq/issues/new if you actually depend on this feature in your work.")
 
 (* Auxiliary grammar rules *)

--- a/plugins/ltac/profile_ltac.ml
+++ b/plugins/ltac/profile_ltac.ml
@@ -458,7 +458,7 @@ let () =
   let open Goptions in
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Ltac"; "Profiling"];
       optread  = get_profiling;
       optwrite = set_profiling }

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -2202,7 +2202,7 @@ let () =
   let open Goptions in
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Ltac";"Debug"];
       optread  = (fun () -> get_debug () != Tactic_debug.DebugOff);
       optwrite = vernac_debug }
@@ -2211,7 +2211,7 @@ let () =
   let open Goptions in
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Ltac"; "Backtrace"];
       optread  = (fun () -> !log_trace);
       optwrite = (fun b -> log_trace := b) }

--- a/plugins/ltac/tactic_debug.ml
+++ b/plugins/ltac/tactic_debug.ml
@@ -466,7 +466,7 @@ open Goptions
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Ltac";"Batch";"Debug"];
       optread  = (fun () -> !batch);
       optwrite = (fun x -> batch := x) }

--- a/plugins/ltac/tactic_option.ml
+++ b/plugins/ltac/tactic_option.ml
@@ -34,7 +34,7 @@ let tac_option_locality =
   | None, Some (), Some () -> return GlobalAndExport
 
 let warn_default_locality =
-  CWarnings.create ~name:"deprecated-tacopt-without-locality" ~category:CWarnings.CoreCategories.deprecated Pp.(fun () ->
+  CWarnings.create ~name:"deprecated-tacopt-without-locality" ~category:Deprecation.Version.v8_17 Pp.(fun () ->
       strbrk
         "The default and global localities for this command outside \
          sections are currently equivalent to the combination of the \

--- a/plugins/ltac/tauto.ml
+++ b/plugins/ltac/tauto.ml
@@ -256,7 +256,7 @@ let with_flags flags _ ist =
   let ist = { ist with lfun = Id.Map.add x.CAst.v arg ist.lfun } in
   eval_tactic_ist ist (CAst.make @@ TacArg (TacCall (CAst.make (Locus.ArgVar f, [Reference (Locus.ArgVar x)]))))
 
-let warn_auto_with_star = CWarnings.create ~name:"intuition-auto-with-star" ~category:CWarnings.CoreCategories.deprecated
+let warn_auto_with_star = CWarnings.create ~name:"intuition-auto-with-star" ~category:Deprecation.Version.v8_17
     Pp.(fun () ->
         str "\"auto with *\" was used through the default \"intuition_solver\" tactic."
         ++ spc() ++ str "This will be replaced by just \"auto\" in the future.")

--- a/plugins/ltac/tauto.ml
+++ b/plugins/ltac/tauto.ml
@@ -70,7 +70,7 @@ open Goptions
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Intuition";"Negation";"Unfolding"];
       optread  = (fun () -> !negation_unfolding);
       optwrite = (:=) negation_unfolding }

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -961,7 +961,7 @@ let register_struct atts str = match str with
 
 let () = Goptions.declare_bool_option {
   Goptions.optstage = Summary.Stage.Interp;
-  Goptions.optdepr = false;
+  Goptions.optdepr = None;
   Goptions.optkey = ["Ltac2"; "Backtrace"];
   Goptions.optread = (fun () -> !Tac2bt.print_ltac2_backtrace);
   Goptions.optwrite = (fun b -> Tac2bt.print_ltac2_backtrace := b);

--- a/plugins/micromega/certificate.ml
+++ b/plugins/micromega/certificate.ml
@@ -29,8 +29,11 @@ open Mutils
 
 (* If set to some [file], arithmetic goals are dumped in [file].v *)
 
-let dump_file =
-  Goptions.declare_stringopt_option_and_ref ~stage:Summary.Stage.Interp ~depr:false ~key:["Dump"; "Arith"]
+let { Goptions.get = dump_file } =
+  Goptions.declare_stringopt_option_and_ref
+    ~key:["Dump"; "Arith"]
+    ~value:None
+    ()
 
 type ('prf, 'model) res = Prf of 'prf | Model of 'model | Unknown
 type zres = (Mc.zArithProof, int * Mc.z list) res

--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -37,10 +37,12 @@ let debug = false
 
 let max_depth = max_int
 
+let since_8_14 = Deprecation.make ~since:"8.14" ()
+
 (* Search limit for provers over Q R *)
 let { Goptions.get = lra_proof_depth } =
   declare_int_option_and_ref
-    ~depr:true
+    ~depr:since_8_14
     ~key:["Lra"; "Depth"]
     ~value:max_depth
     ()
@@ -48,14 +50,14 @@ let { Goptions.get = lra_proof_depth } =
 (* Search limit for provers over Z *)
 let { Goptions.get = lia_enum } =
   declare_bool_option_and_ref
-    ~depr:true
+    ~depr:since_8_14
     ~key:["Lia"; "Enum"]
     ~value:true
     ()
 
 let { Goptions.get = lia_proof_depth } =
   declare_int_option_and_ref
-    ~depr:true
+    ~depr:since_8_14
     ~key:["Lia"; "Depth"]
     ~value:max_depth
     ()

--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -38,29 +38,50 @@ let debug = false
 let max_depth = max_int
 
 (* Search limit for provers over Q R *)
-let lra_proof_depth =
-  declare_int_option_and_ref ~stage:Summary.Stage.Interp ~depr:true ~key:["Lra"; "Depth"] ~value:max_depth
+let { Goptions.get = lra_proof_depth } =
+  declare_int_option_and_ref
+    ~depr:true
+    ~key:["Lra"; "Depth"]
+    ~value:max_depth
+    ()
 
 (* Search limit for provers over Z *)
-let lia_enum =
-  declare_bool_option_and_ref ~stage:Summary.Stage.Interp ~depr:true ~key:["Lia"; "Enum"] ~value:true
+let { Goptions.get = lia_enum } =
+  declare_bool_option_and_ref
+    ~depr:true
+    ~key:["Lia"; "Enum"]
+    ~value:true
+    ()
 
-let lia_proof_depth =
-  declare_int_option_and_ref ~stage:Summary.Stage.Interp ~depr:true ~key:["Lia"; "Depth"] ~value:max_depth
+let { Goptions.get = lia_proof_depth } =
+  declare_int_option_and_ref
+    ~depr:true
+    ~key:["Lia"; "Depth"]
+    ~value:max_depth
+    ()
 
 let get_lia_option () =
   (true, lia_enum (), lia_proof_depth ())
 
 (* Enable/disable caches *)
 
-let use_lia_cache =
-  declare_bool_option_and_ref ~stage:Summary.Stage.Interp ~depr:false ~key:["Lia"; "Cache"] ~value:true
+let { Goptions.get = use_lia_cache } =
+  declare_bool_option_and_ref
+    ~key:["Lia"; "Cache"]
+    ~value:true
+    ()
 
-let use_nia_cache =
-  declare_bool_option_and_ref ~stage:Summary.Stage.Interp ~depr:false ~key:["Nia"; "Cache"] ~value:true
+let { Goptions.get = use_nia_cache } =
+  declare_bool_option_and_ref
+    ~key:["Nia"; "Cache"]
+    ~value:true
+    ()
 
-let use_nra_cache =
-  declare_bool_option_and_ref ~stage:Summary.Stage.Interp ~depr:false ~key:["Nra"; "Cache"] ~value:true
+let { Goptions.get = use_nra_cache } =
+  declare_bool_option_and_ref
+    ~key:["Nra"; "Cache"]
+    ~value:true
+    ()
 
 let use_csdp_cache () = true
 

--- a/plugins/rtauto/proof_search.ml
+++ b/plugins/rtauto/proof_search.ml
@@ -45,12 +45,11 @@ let reset_info () =
      s_info.branch_successes <- 0;
      s_info.nd_branching     <- 0
 
-let pruning =
+let { Goptions.get = pruning } =
   declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Rtauto";"Pruning"]
     ~value:true
+    ()
 
 type form=
     Atom of int

--- a/plugins/rtauto/refl_tauto.ml
+++ b/plugins/rtauto/refl_tauto.ml
@@ -252,19 +252,17 @@ let build_env gamma=
                      mkApp(force node_count l_push,[|mkProp;p;e|]))
     gamma.env (mkApp (force node_count l_empty,[|mkProp|]))
 
-let verbose =
+let { Goptions.get = verbose } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Rtauto";"Verbose"]
     ~value:false
+    ()
 
-let check =
+let { Goptions.get = check } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Rtauto";"Check"]
     ~value:false
+    ()
 
 open Pp
 

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -35,7 +35,7 @@ let () =
     { optstage = Summary.Stage.Interp;
       optkey   = ["SsrOldRewriteGoalsOrder"];
       optread  = (fun _ -> !ssroldreworder);
-      optdepr  = false;
+      optdepr  = None;
       optwrite = (fun b -> ssroldreworder := b) })
 
 (** The "simpl" tactic *)

--- a/plugins/ssr/ssrfwd.ml
+++ b/plugins/ssr/ssrfwd.ml
@@ -89,7 +89,7 @@ let () =
     { optstage = Summary.Stage.Interp;
       optkey   = ["SsrHave";"NoTCResolution"];
       optread  = (fun _ -> !ssrhaveNOtcresolution);
-      optdepr  = false;
+      optdepr  = None;
       optwrite = (fun b -> ssrhaveNOtcresolution := b);
     })
 

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -1648,7 +1648,7 @@ let () =
   Goptions.(declare_bool_option
     { optstage = Summary.Stage.Synterp;
       optkey   = ["SsrIdents"];
-      optdepr  = false;
+      optdepr  = None;
       optread  = (fun _ -> !ssr_reserved_ids);
       optwrite = (fun b -> ssr_reserved_ids := b)
     })

--- a/plugins/ssr/ssrtacs.mlg
+++ b/plugins/ssr/ssrtacs.mlg
@@ -749,7 +749,7 @@ let () =
     { optstage = Summary.Stage.Synterp;
       optkey   = ["SsrRewrite"];
       optread  = (fun _ -> !ssr_rw_syntax);
-      optdepr  = false;
+      optdepr  = None;
       optwrite = (fun b -> ssr_rw_syntax := b) })
 
 let lbrace = Char.chr 123

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -52,7 +52,7 @@ let _ =
   Goptions.declare_bool_option
     { Goptions.optstage = Summary.Stage.Interp;
       Goptions.optkey   = ["Debug";"SsrMatching"];
-      Goptions.optdepr  = false;
+      Goptions.optdepr  = None;
       Goptions.optread  = (fun _ -> !pp_ref == ssr_pp);
       Goptions.optwrite = debug }
 let pp s = !pp_ref s

--- a/pretyping/coercion.ml
+++ b/pretyping/coercion.ml
@@ -34,12 +34,11 @@ open Evarconv
 open Evd
 open Globnames
 
-let get_use_typeclasses_for_conversion =
+let { Goptions.get = get_use_typeclasses_for_conversion } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Typeclass"; "Resolution"; "For"; "Conversion"]
     ~value:true
+    ()
 
 (* Typing operations dealing with coercions *)
 exception NoCoercion

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -198,12 +198,11 @@ type _ delay =
 let print_universes = ref false
 
 (** Should we print hidden sort quality variables? *)
-let print_sort_quality =
+let { Goptions.get = print_sort_quality } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Printing";"Sort";"Qualities"]
     ~value:false
+    ()
 
 (** If true, prints local context of evars, whatever print_arguments *)
 let print_evar_arguments = ref false
@@ -300,54 +299,47 @@ module PrintingLet = Goptions.MakeRefTable(PrintingCasesLet)
 
 (* Flags.for printing or not wildcard and synthetisable types *)
 
-let force_wildcard =
+let { Goptions.get = force_wildcard } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Printing";"Wildcard"]
     ~value:true
+    ()
 
-let fast_name_generation =
+let { Goptions.get = fast_name_generation } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Fast";"Name";"Printing"]
     ~value:false
+    ()
 
-let synthetize_type =
+let { Goptions.get = synthetize_type } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Printing";"Synth"]
     ~value:true
+    ()
 
-let reverse_matching =
+let { Goptions.get = reverse_matching } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Printing";"Matching"]
     ~value:true
+    ()
 
-let print_primproj_params =
+let { Goptions.get = print_primproj_params } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Printing";"Primitive";"Projection";"Parameters"]
     ~value:false
+    ()
 
-let print_unfolded_primproj_asmatch =
+let { Goptions.get = print_unfolded_primproj_asmatch } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Printing";"Unfolded";"Projection";"As";"Match"]
     ~value:false
+    ()
 
-let print_match_paramunivs =
+let { Goptions.get = print_match_paramunivs } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Printing";"Match";"All";"Subterms"]
     ~value:false
+    ()
 
 (* Auxiliary function for MutCase printing *)
 (* [computable] tries to tell if the predicate typing the result is inferable*)
@@ -408,21 +400,19 @@ let lookup_index_as_renamed env sigma t n =
 (**********************************************************************)
 (* Factorization of match patterns *)
 
-let print_factorize_match_patterns =
+let { Goptions.get = print_factorize_match_patterns } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Printing";"Factorizable";"Match";"Patterns"]
     ~value:true
+    ()
 
 let print_allow_match_default_opt_name =
   ["Printing";"Allow";"Match";"Default";"Clause"]
-let print_allow_match_default_clause =
+let { Goptions.get = print_allow_match_default_clause } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:print_allow_match_default_opt_name
     ~value:true
+    ()
 
 let rec join_eqns (ids,rhs as x) patll = function
   | ({CAst.loc; v=(ids',patl',rhs')} as eqn')::rest ->

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -211,7 +211,7 @@ let () =
   let open Goptions in
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Printing";"Existential";"Instances"];
       optread  = (fun () -> !print_evar_arguments);
       optwrite = (:=) print_evar_arguments }

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -29,21 +29,19 @@ exception Find_at of int
 
 (* timing *)
 
-let get_timing_enabled =
+let { Goptions.get = get_timing_enabled } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["NativeCompute"; "Timing"]
     ~value:false
+    ()
 
 (* profiling *)
 
-let get_profiling_enabled =
+let { Goptions.get = get_profiling_enabled } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["NativeCompute"; "Profiling"]
     ~value:false
+    ()
 
 (* for supported platforms, filename for profiler results *)
 
@@ -57,12 +55,11 @@ let profiler_platform () =
   | "Win32" -> "Windows (Win32)"
   | "Cygwin" -> "Windows (Cygwin)"
 
-let get_profile_filename =
+let { Goptions.get = get_profile_filename } =
   Goptions.declare_string_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["NativeCompute"; "Profile"; "Filename"]
     ~value:"native_compute_profile.data"
+    ()
 
 (* find unused profile filename *)
 let get_available_profile_filename () =

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -122,12 +122,11 @@ let esearch_guard ?loc env sigma indexes fix =
 
 (* To force universe name declaration before use *)
 
-let is_strict_universe_declarations =
+let { Goptions.get = is_strict_universe_declarations } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Strict";"Universe";"Declaration"]
     ~value:true
+    ()
 
 (** Miscellaneous interpretation functions *)
 

--- a/pretyping/program.ml
+++ b/pretyping/program.ml
@@ -77,7 +77,7 @@ open Goptions
 let () =
   declare_bool_option
   { optstage = Summary.Stage.Interp;
-    optdepr  = false;
+    optdepr  = None;
     optkey   = ["Transparent";"Obligations"];
     optread  = get_proofs_transparency;
     optwrite = set_proofs_transparency; }
@@ -85,7 +85,7 @@ let () =
 let () =
   declare_bool_option
   { optstage = Summary.Stage.Interp;
-    optdepr  = false;
+    optdepr  = None;
     optkey   = ["Program";"Cases"];
     optread  = (fun () -> !program_cases);
     optwrite = (:=) program_cases }
@@ -93,7 +93,7 @@ let () =
 let () =
   declare_bool_option
   { optstage = Summary.Stage.Interp;
-    optdepr  = false;
+    optdepr  = None;
     optkey   = ["Program";"Generalized";"Coercion"];
     optread  = (fun () -> !program_generalized_coercion);
     optwrite = (:=) program_generalized_coercion }

--- a/pretyping/typeclasses.ml
+++ b/pretyping/typeclasses.ml
@@ -26,12 +26,11 @@ type 'a hint_info_gen =
 
 type hint_info = (Id.Set.t * Pattern.constr_pattern) hint_info_gen
 
-let get_typeclasses_unique_solutions =
+let { Goptions.get = get_typeclasses_unique_solutions } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Typeclasses";"Unique";"Solutions"]
     ~value:false
+    ()
 
 let solve_one_instance = ref (fun env evm t unique -> assert false)
 

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -42,12 +42,11 @@ type subst0 =
 module RelDecl = Context.Rel.Declaration
 module NamedDecl = Context.Named.Declaration
 
-let is_keyed_unification =
+let { Goptions.get = is_keyed_unification } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Keyed";"Unification"]
     ~value:false
+    ()
 
 let debug_tactic_unification = CDebug.create ~name:"tactic-unification" ()
 

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -27,26 +27,23 @@ module CompactedDecl = Context.Compacted.Declaration
 (* This is set on by proofgeneral proof-tree mode. But may be used for
    other purposes *)
 let print_goal_tag_opt_name = ["Printing";"Goal";"Tags"]
-let should_tag =
+let { Goptions.get = should_tag } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:print_goal_tag_opt_name
     ~value:false
+    ()
 
-let should_unfoc =
+let { Goptions.get = should_unfoc } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Printing";"Unfocused"]
     ~value:false
+    ()
 
-let should_gname =
+let { Goptions.get = should_gname } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Printing";"Goal";"Names"]
     ~value:false
+    ()
 
 let print_goal_names = should_gname (* for export *)
 
@@ -450,11 +447,11 @@ let pr_context_limit_compact ?n env sigma =
 
 (* The number of printed hypothesis in a goal *)
 (* If [None], no limit *)
-let print_hyps_limit =
+let { Goptions.get = print_hyps_limit } =
   Goptions.declare_intopt_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Hyps";"Limit"]
+    ~value:None
+    ()
 
 let pr_context_of env sigma = match print_hyps_limit () with
   | None -> hv 0 (pr_context_limit_compact env sigma)
@@ -677,12 +674,11 @@ let print_evar_constraints gl sigma =
         str" with candidates:" ++ fnl () ++ hov 0 ppcandidates
     else mt ()
 
-let should_print_dependent_evars =
+let { Goptions.get = should_print_dependent_evars } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Printing";"Dependent";"Evars";"Line"]
     ~value:false
+    ()
 
 let evar_nodes_of_term c =
   let rec evrec acc c =

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -67,14 +67,13 @@ let string_to_diffs = function
 
 let opt_name = ["Diffs"]
 
-let diff_option =
+let { Goptions.get = diff_option } =
   Goptions.declare_interpreted_string_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:opt_name
     ~value:DiffOff
     string_to_diffs
     diffs_to_string
+    ()
 
 let show_diffs () = match diff_option () with DiffOff -> false | _ -> true
 let show_removed () = match diff_option () with DiffRemoved -> true | _ -> false

--- a/proofs/goal_select.ml
+++ b/proofs/goal_select.ml
@@ -50,14 +50,13 @@ let parse_goal_selector = function
 
 (* Default goal selector: selector chosen when a tactic is applied
    without an explicit selector. *)
-let get_default_goal_selector =
+let { Goptions.get = get_default_goal_selector } =
   Goptions.declare_interpreted_string_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
-    ~key:["Default";"Goal";"Selector"]
-    ~value:(SelectNth 1)
     parse_goal_selector
     (fun v -> Pp.string_of_ppcmds @@ pr_goal_selector v)
+    ~key:["Default";"Goal";"Selector"]
+    ~value:(SelectNth 1)
+    ()
 
 (* Select a subset of the goals *)
 let tclSELECT ?nosuchgoal g tac = match g with

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -467,12 +467,11 @@ let pr_proof p =
     str "]"
   )
 
-let use_unification_heuristics =
+let { Goptions.get = use_unification_heuristics } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Solve";"Unification";"Constraints"]
     ~value:true
+    ()
 
 exception SuggestNoSuchGoals of int * t
 

--- a/proofs/proof_bullet.ml
+++ b/proofs/proof_bullet.ml
@@ -174,10 +174,8 @@ module Strict = struct
 end
 
 (* Current bullet behavior, controlled by the option *)
-let current_behavior =
+let { Goptions.get = current_behavior } =
   Goptions.declare_interpreted_string_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Bullet";"Behavior"]
     ~value:Strict.strict
     (fun n ->
@@ -185,6 +183,7 @@ let current_behavior =
       with Not_found ->
         CErrors.user_err Pp.(str ("Unknown bullet behavior: \"" ^ n ^ "\".")))
     (fun v -> v.name)
+    ()
 
 let put p b =
   (current_behavior ()).put p b

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -2587,12 +2587,11 @@ let process_back_meta_command ~newtip ~head oid aast =
     VCS.checkout_shallowest_proof_branch ();
     Backtrack.record (); Ok
 
-let get_allow_nested_proofs =
+let { Goptions.get = get_allow_nested_proofs } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:Vernac_classifier.stm_allow_nested_proofs_option_name
     ~value:false
+    ()
 
 (** [process_transaction] adds a node in the document *)
 let process_transaction ~doc ?(newtip=Stateid.fresh ()) x c =

--- a/sysinit/coqinit.ml
+++ b/sysinit/coqinit.ml
@@ -181,7 +181,7 @@ let warn_no_native_compiler =
                    strbrk " option ignored.")
 
 let warn_deprecated_native_compiler =
-  CWarnings.create ~name:"deprecated-native-compiler-option" ~category:CWarnings.CoreCategories.deprecated
+  CWarnings.create ~name:"deprecated-native-compiler-option" ~category:Deprecation.Version.v8_14
          (fun () ->
           Pp.strbrk "The native-compiler option is deprecated. To compile native \
           files ahead of time, use the coqnative binary instead.")

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -144,7 +144,7 @@ let global_info_auto = ref false
 let add_option ls refe =
   Goptions.(declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ls;
       optread  = (fun () -> !refe);
       optwrite = (:=) refe })

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -84,7 +84,7 @@ end = struct
     let open Goptions in
     declare_bool_option
       { optstage = Summary.Stage.Interp;
-        optdepr  = false;
+        optdepr  = None;
         optkey   = ["Typeclasses";"Debug"];
         optread  = get_typeclasses_debug;
         optwrite = set_typeclasses_debug; }
@@ -93,7 +93,7 @@ end = struct
     let open Goptions in
     declare_int_option
       { optstage = Summary.Stage.Interp;
-        optdepr  = false;
+        optdepr  = None;
         optkey   = ["Typeclasses";"Debug";"Verbosity"];
         optread  = get_typeclasses_verbose;
         optwrite = set_typeclasses_verbose; }

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -30,11 +30,11 @@ let typeclasses_db = "typeclass_instances"
 (** Options handling *)
 
 let typeclasses_depth_opt_name = ["Typeclasses";"Depth"]
-let get_typeclasses_depth =
+let { Goptions.get = get_typeclasses_depth } =
   Goptions.declare_intopt_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:typeclasses_depth_opt_name
+    ~value:None
+    ()
 
 let set_typeclasses_depth =
   Goptions.set_int_option_value typeclasses_depth_opt_name
@@ -43,27 +43,24 @@ let set_typeclasses_depth =
     useless introductions. This is no longer useful since we have eta, but is
     here for compatibility purposes. Another compatibility issues is that the
     cost (in terms of search depth) can differ. *)
-let get_typeclasses_limit_intros =
+let { Goptions.get = get_typeclasses_limit_intros } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Typeclasses";"Limit";"Intros"]
     ~value:true
+    ()
 
-let get_typeclasses_dependency_order =
+let { Goptions.get = get_typeclasses_dependency_order } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Typeclasses";"Dependency";"Order"]
     ~value:false
+    ()
 
 let iterative_deepening_opt_name = ["Typeclasses";"Iterative";"Deepening"]
-let get_typeclasses_iterative_deepening =
+let { Goptions.get = get_typeclasses_iterative_deepening } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:iterative_deepening_opt_name
     ~value:false
+    ()
 
 module Debug : sig
   val ppdebug : int -> (unit -> Pp.t) -> unit

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -297,7 +297,7 @@ let global_info_eauto = ref false
 let () =
   Goptions.(declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Debug";"Eauto"];
       optread  = (fun () -> !global_debug_eauto);
       optwrite = (:=) global_debug_eauto })
@@ -305,7 +305,7 @@ let () =
 let () =
   Goptions.(declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Info";"Eauto"];
       optread  = (fun () -> !global_info_eauto);
       optwrite = (:=) global_info_eauto })

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -718,7 +718,7 @@ let keep_proof_equalities_for_injection = ref false
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Keep";"Proof";"Equalities"];
       optread  = (fun () -> !keep_proof_equalities_for_injection) ;
       optwrite = (fun b -> keep_proof_equalities_for_injection := b) }

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -1705,7 +1705,7 @@ let cutSubstClause l2r eqn cls =
     | Some id -> cutSubstInHyp l2r eqn id
 
 let warn_deprecated_cutrewrite =
-  CWarnings.create ~name:"deprecated-cutrewrite" ~category:CWarnings.CoreCategories.deprecated
+  CWarnings.create ~name:"deprecated-cutrewrite" ~category:Deprecation.Version.v8_5
     (fun () -> strbrk"\"cutrewrite\" is deprecated. Use \"replace\" instead.")
 
 let cutRewriteClause l2r eqn cls =
@@ -1876,7 +1876,7 @@ let default_subst_tactic_flags =
   { only_leibniz = false; rewrite_dependent_proof = true }
 
 let warn_deprecated_simple_subst =
-  CWarnings.create ~name:"deprecated-simple-subst" ~category:CWarnings.CoreCategories.deprecated
+  CWarnings.create ~name:"deprecated-simple-subst" ~category:Deprecation.Version.v8_8
     (fun () -> strbrk"\"simple subst\" is deprecated")
 
 let subst_all ?(flags=default_subst_tactic_flags) () =

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -61,12 +61,11 @@ let use_injection_pattern_l2r_order = function
   | None -> true
   | Some flags -> flags.injection_pattern_l2r_order
 
-let injection_in_context_flag =
+let { Goptions.get = injection_in_context_flag } =
   declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Structural";"Injection"]
     ~value:false
+    ()
 
 (* Rewriting tactics *)
 

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -199,14 +199,13 @@ let string_to_warn_hint = function
 | "Strict" -> HintStrict
 | _ -> user_err Pp.(str "Only the following values are accepted: Lax, Warn, Strict.")
 
-let warn_hint =
+let { Goptions.get = warn_hint } =
   Goptions.declare_interpreted_string_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Loose"; "Hint"; "Behavior"]
     ~value:HintLax
     string_to_warn_hint
     warn_hint_to_string
+    ()
 
 let fresh_key =
   let id = Summary.ref ~name:"HINT-COUNTER" 0 in

--- a/tactics/redexpr.ml
+++ b/tactics/redexpr.ml
@@ -52,12 +52,11 @@ let cbv_native env sigma c =
 
 let whd_cbn = Cbn.whd_cbn
 
-let simplIsCbn =
+let { Goptions.get = simplIsCbn } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["SimplIsCbn"]
     ~value:false
+    ()
 
 let set_strategy_one ref l  =
   let k =

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -68,7 +68,7 @@ let use_clear_hyp_by_default () = !clear_hyp_by_default
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Default";"Clearing";"Used";"Hypotheses"];
       optread  = (fun () -> !clear_hyp_by_default) ;
       optwrite = (fun b -> clear_hyp_by_default := b) }

--- a/test-suite/output/ProofUsingClashWarning.out
+++ b/test-suite/output/ProofUsingClashWarning.out
@@ -1,21 +1,21 @@
 File "./output/ProofUsingClashWarning.v", line 3, characters 2-39:
 Warning:
 clashing_name was already a defined Variable, the name clashing_name will refer to Collection when executing "Proof using" command.
-[variable-shadowing,deprecated,default]
+[variable-shadowing,deprecated-since-8.15,deprecated,default]
 File "./output/ProofUsingClashWarning.v", line 6, characters 2-39:
 Warning: New Collection definition of redefined_col shadows the previous one.
-[collection-redefinition,deprecated,default]
+[collection-redefinition,deprecated-since-8.15,deprecated,default]
 File "./output/ProofUsingClashWarning.v", line 8, characters 2-34:
 The command has indeed failed with message:
 "All" is a predefined collection containing all variables. It can't be redefined.
 File "./output/ProofUsingClashWarning.v", line 11, characters 2-28:
 Warning:
 clashing_name is both name of a Collection and Variable, Collection clashing_name takes precedence over Variable.
-[collection-precedence,deprecated,default]
+[collection-precedence,deprecated-since-8.15,deprecated,default]
 File "./output/ProofUsingClashWarning.v", line 16, characters 2-18:
 Warning:
 Variable All is shadowed by Collection named All containing all variables.
-[all-collection-precedence,deprecated,default]
+[all-collection-precedence,deprecated-since-8.15,deprecated,default]
 foo : bool -> True
      : bool -> True
 bar : bool -> nat -> unit -> True

--- a/test-suite/output/bug_16224.out
+++ b/test-suite/output/bug_16224.out
@@ -5,7 +5,8 @@ use '#[global] Existing Instance field.' for compatibility with Coq < 8.17).
 Beware that the default locality for '::' is #[export], as opposed to
 #[global] for ':>' currently. Add an explicit #[global] attribute to the
 field if you need to keep the current behavior. For example: "Class foo := {
-#[global] field :: bar }." [future-coercion-class-field,deprecated,default]
+#[global] field :: bar }."
+[future-coercion-class-field,deprecated-since-8.17,deprecated,default]
 [rc] : Rc >-> A (reversible)
 [ric] : Ric >-> A (reversible)
 ric : Ric -> A

--- a/toplevel/coqcargs.ml
+++ b/toplevel/coqcargs.ml
@@ -127,7 +127,7 @@ let rec add_vio_args peek next oval =
   else oval
 
 let warn_deprecated_quick =
-  CWarnings.create ~name:"deprecated-quick" ~category:CWarnings.CoreCategories.deprecated
+  CWarnings.create ~name:"deprecated-quick" ~category:Deprecation.Version.v8_11
          (fun () ->
           Pp.strbrk "The -quick option is renamed -vio. Please consider using the -vos feature instead.")
 

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -397,13 +397,12 @@ let top_goal_print ~doc c oldp newp =
     TopErr.print_error_for_buffer ?loc Feedback.Error msg top_buffer
   [@@ocaml.warning "-3"]
 
-let exit_on_error =
+let { Goptions.get = exit_on_error } =
   let open Goptions in
   declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Coqtop";"Exit";"On";"Error"]
     ~value:false
+    ()
 
 let show_proof_diff_cmd ~state diff_opt =
   let open Vernac.State in

--- a/vernac/attributes.ml
+++ b/vernac/attributes.ml
@@ -209,7 +209,7 @@ let program_mode = ref false
 let () = let open Goptions in
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = program_mode_option_name;
       optread  = (fun () -> !program_mode);
       optwrite = (fun b -> program_mode:=b) }
@@ -261,7 +261,7 @@ let is_universe_polymorphism =
   let () = let open Goptions in
     declare_bool_option
       { optstage = Summary.Stage.Interp;
-        optdepr  = false;
+        optdepr  = None;
         optkey   = universe_polymorphism_option_name;
         optread  = (fun () -> !b);
         optwrite = ((:=) b) }

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -31,7 +31,7 @@ let set_typeclass_transparency ~locality c b =
     (Hints.HintsTransparencyEntry (Hints.HintsReferences c, b))
 
 let warn_deprecated_tc_transparency_without_locality =
-  CWarnings.create ~name:"deprecated-typeclasses-transparency-without-locality" ~category:CWarnings.CoreCategories.deprecated
+  CWarnings.create ~name:"deprecated-typeclasses-transparency-without-locality" ~category:Deprecation.Version.v8_15
     Pp.(fun () -> strbrk
   "The default value for Typeclasses Opaque and Typeclasses \
    Transparent locality is currently \"local\" in a section and \

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -40,7 +40,7 @@ let should_auto_template =
   let auto = ref true in
   let () = declare_bool_option
       { optstage = Summary.Stage.Interp;
-        optdepr  = false;
+        optdepr  = None;
         optkey   = ["Auto";"Template";"Polymorphism"];
         optread  = (fun () -> !auto);
         optwrite = (fun b -> auto := b); }

--- a/vernac/comSearch.ml
+++ b/vernac/comSearch.ml
@@ -109,7 +109,7 @@ let search_output_name_only = ref false
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Search";"Output";"Name";"Only"];
       optread  = (fun () -> !search_output_name_only);
       optwrite = (:=) search_output_name_only }

--- a/vernac/comTactic.ml
+++ b/vernac/comTactic.ml
@@ -36,11 +36,11 @@ type parallel_solver =
   with_end_tac:bool ->
   Declare.Proof.t
 
-let print_info_trace =
+let { Goptions.get = print_info_trace } =
   declare_intopt_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Info" ; "Level"]
+    ~value:None
+    ()
 
 let solve_core ~pstate n ~info t ~with_end_tac:b =
   let pstate, status = Declare.Proof.map_fold_endline ~f:(fun etac p ->

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1688,12 +1688,11 @@ type proof_object =
 
 let get_po_name { name } = name
 
-let private_poly_univs =
+let { Goptions.get = private_poly_univs } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Private";"Polymorphic";"Universes"]
     ~value:true
+    ()
 
 (* XXX: This is still separate from close_proof below due to drop_pt in the STM *)
 (* XXX: Unsafe_typ:true is needed by vio files, see bf0499bc507d5a39c3d5e3bf1f69191339270729 *)
@@ -2060,12 +2059,11 @@ end
 (************************************************************************)
 
 (* Admitted *)
-let get_keep_admitted_vars =
+let { Goptions.get = get_keep_admitted_vars } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Keep"; "Admitted"; "Variables"]
     ~value:true
+    ()
 
 let compute_proof_using_for_admitted proof typ iproof =
   if not (get_keep_admitted_vars ()) || not (Lib.sections_are_opened()) then None

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -486,7 +486,7 @@ let objVariable : Id.t Libobject.Dyn.tag =
 
 let inVariable v = Libobject.Dyn.Easy.inj v objVariable
 
-let warn_opaque_let = CWarnings.create ~name:"opaque-let" ~category:CWarnings.CoreCategories.deprecated
+let warn_opaque_let = CWarnings.create ~name:"opaque-let" ~category:Deprecation.Version.v8_18
   Pp.(fun name ->
     Id.print name ++
     strbrk " is declared opaque (Qed) but this is not fully respected" ++

--- a/vernac/g_proofs.mlg
+++ b/vernac/g_proofs.mlg
@@ -26,7 +26,7 @@ let thm_token = G_vernac.thm_token
 let hint = Entry.make "hint"
 
 let warn_deprecated_focus =
-  CWarnings.create ~name:"deprecated-focus" ~category:CWarnings.CoreCategories.deprecated
+  CWarnings.create ~name:"deprecated-focus" ~category:Deprecation.Version.v8_8
     Pp.(function
       | None ->
         strbrk "The Focus command is deprecated; use bullets or focusing brackets instead."
@@ -39,7 +39,7 @@ let warn_deprecated_focus_n ?loc n = warn_deprecated_focus ?loc (Some n)
 let warn_deprecated_focus ?loc () = warn_deprecated_focus ?loc None
 
 let warn_deprecated_unfocus =
-  CWarnings.create ~name:"deprecated-unfocus" ~category:CWarnings.CoreCategories.deprecated
+  CWarnings.create ~name:"deprecated-unfocus" ~category:Deprecation.Version.v8_8
          (fun () -> Pp.strbrk "The Unfocus command is deprecated")
 
 }

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -556,11 +556,11 @@ let starredidentreflist_to_expr l =
   | x :: xs -> List.fold_right (fun i acc -> SsUnion(i,acc)) xs x
 
 let warn_deprecated_include_type =
-  CWarnings.create ~name:"deprecated-include-type" ~category:CWarnings.CoreCategories.deprecated
+  CWarnings.create ~name:"deprecated-include-type" ~category:Deprecation.Version.v8_3
          (fun () -> strbrk "Include Type is deprecated; use Include instead")
 
 let warn_deprecated_as_ident_kind =
-  CWarnings.create ~name:"deprecated-as-ident-kind" ~category:CWarnings.CoreCategories.deprecated
+  CWarnings.create ~name:"deprecated-as-ident-kind" ~category:Deprecation.Version.v8_14
          (fun () -> strbrk "grammar kind \"as ident\" no longer accepts \"_\"; use \"as name\" instead to accept \"_\", too, or silence the warning if you actually intended to accept only identifiers.")
 
 }

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -41,7 +41,7 @@ let elim_flag = ref true
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Elimination";"Schemes"];
       optread  = (fun () -> !elim_flag) ;
       optwrite = (fun b -> elim_flag := b) }
@@ -50,7 +50,7 @@ let bifinite_elim_flag = ref false
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Nonrecursive";"Elimination";"Schemes"];
       optread  = (fun () -> !bifinite_elim_flag) ;
       optwrite = (fun b -> bifinite_elim_flag := b) }
@@ -59,7 +59,7 @@ let case_flag = ref false
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Case";"Analysis";"Schemes"];
       optread  = (fun () -> !case_flag) ;
       optwrite = (fun b -> case_flag := b) }
@@ -68,7 +68,7 @@ let eq_flag = ref false
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Boolean";"Equality";"Schemes"];
       optread  = (fun () -> !eq_flag) ;
       optwrite = (fun b -> eq_flag := b) }
@@ -79,7 +79,7 @@ let eq_dec_flag = ref false
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Decidable";"Equality";"Schemes"];
       optread  = (fun () -> !eq_dec_flag) ;
       optwrite = (fun b -> eq_dec_flag := b) }
@@ -88,7 +88,7 @@ let rewriting_flag = ref false
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Rewriting";"Schemes"];
       optread  = (fun () -> !rewriting_flag) ;
       optwrite = (fun b -> rewriting_flag := b) }

--- a/vernac/printmod.ml
+++ b/vernac/printmod.ml
@@ -43,7 +43,7 @@ let short = ref false
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Short";"Module";"Printing"];
       optread  = (fun () -> !short) ;
       optwrite = ((:=) short) }

--- a/vernac/proof_using.ml
+++ b/vernac/proof_using.ml
@@ -44,16 +44,16 @@ let set_of_type env sigma ty =
 let full_set env =
   List.fold_right Id.Set.add (List.map NamedDecl.get_id (named_context env)) Id.Set.empty
 
-let warn_all_collection_precedence = CWarnings.create ~name:"all-collection-precedence" ~category:CWarnings.CoreCategories.deprecated
+let warn_all_collection_precedence = CWarnings.create ~name:"all-collection-precedence" ~category:Deprecation.Version.v8_15
     Pp.(fun () -> str "Variable " ++ Id.print all_collection_id ++ str " is shadowed by Collection named " ++ Id.print all_collection_id ++ str " containing all variables.")
 
-let warn_collection_precedence = CWarnings.create ~name:"collection-precedence" ~category:CWarnings.CoreCategories.deprecated
+let warn_collection_precedence = CWarnings.create ~name:"collection-precedence" ~category:Deprecation.Version.v8_15
     Pp.(fun id -> Id.print id ++ str " is both name of a Collection and Variable, Collection " ++ Id.print id ++ str " takes precedence over Variable.")
 
-let warn_redefine_collection = CWarnings.create ~name:"collection-redefinition" ~category:CWarnings.CoreCategories.deprecated
+let warn_redefine_collection = CWarnings.create ~name:"collection-redefinition" ~category:Deprecation.Version.v8_15
     Pp.(fun id -> str "New Collection definition of " ++ Id.print id ++ str " shadows the previous one.")
 
-let warn_variable_shadowing = CWarnings.create ~name:"variable-shadowing" ~category:CWarnings.CoreCategories.deprecated
+let warn_variable_shadowing = CWarnings.create ~name:"variable-shadowing" ~category:Deprecation.Version.v8_15
     Pp.(fun id -> Id.print id ++ str " was already a defined Variable, the name " ++ Id.print id ++ str " will refer to Collection when executing \"Proof using\" command.")
 
 let err_redefine_all_collection () =

--- a/vernac/proof_using.ml
+++ b/vernac/proof_using.ml
@@ -178,7 +178,7 @@ let suggest_proof_using = ref false
 let () =
   Goptions.(declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Suggest";"Proof";"Using"];
       optread  = (fun () -> !suggest_proof_using);
       optwrite = ((:=) suggest_proof_using) })
@@ -216,7 +216,7 @@ let proof_using_opt_name = ["Default";"Proof";"Using"]
 let () =
   Goptions.(declare_stringopt_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = proof_using_opt_name;
       optread  = (fun () -> Option.map using_to_string !value);
       optwrite = (fun b -> value := Option.map using_from_string b);

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -28,19 +28,17 @@ module RelDecl = Context.Rel.Declaration
 
 (********** definition d'un record (structure) **************)
 
-let typeclasses_strict =
+let { Goptions.get = typeclasses_strict } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Typeclasses";"Strict";"Resolution"]
     ~value:false
+    ()
 
-let typeclasses_unique =
+let { Goptions.get = typeclasses_unique } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Typeclasses";"Unique";"Instances"]
     ~value:false
+    ()
 
 let interp_fields_evars env sigma ~ninds ~nparams impls_env nots l =
   let _, sigma, impls, newfs, _ =

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -636,14 +636,15 @@ let implicits_of_context ctx =
 (* deprecated in 8.16, to be removed at the end of the deprecation phase
    (c.f., https://github.com/coq/coq/pull/15802 ) *)
 let warn_future_coercion_class_constructor =
-  CWarnings.create ~name:"future-coercion-class-constructor" ~category:CWarnings.CoreCategories.deprecated
+  CWarnings.create ~name:"future-coercion-class-constructor" ~category:Deprecation.Version.v8_16
     ~default:CWarnings.AsError
     Pp.(fun () -> str "'Class >' currently does nothing. Use 'Class' instead.")
 
 (* deprecated in 8.17, to be removed at the end of the deprecation phase
    (c.f., https://github.com/coq/coq/pull/16230 ) *)
 let warn_future_coercion_class_field =
-  CWarnings.create ~name:"future-coercion-class-field" ~category:CWarnings.CoreCategories.deprecated Pp.(fun definitional ->
+  CWarnings.create ~name:"future-coercion-class-field" ~category:Deprecation.Version.v8_17
+    Pp.(fun definitional ->
     strbrk "A coercion will be introduced instead of an instance in future versions when using ':>' in 'Class' declarations. "
     ++ strbrk "Replace ':>' with '::' (or use '#[global] Existing Instance field.' for compatibility with Coq < 8.17). Beware that the default locality for '::' is #[export], as opposed to #[global] for ':>' currently."
     ++ strbrk (if definitional then "" else " Add an explicit #[global] attribute to the field if you need to keep the current behavior. For example: \"Class foo := { #[global] field :: bar }.\""))

--- a/vernac/synterp.ml
+++ b/vernac/synterp.ml
@@ -45,7 +45,7 @@ let with_module_locality ~atts f =
   f ~module_local
 
 let warn_legacy_export_set =
-  CWarnings.create ~name:"legacy-export-set" ~category:CWarnings.CoreCategories.deprecated
+  CWarnings.create ~name:"legacy-export-set" ~category:Deprecation.Version.v8_18
     Pp.(fun () -> strbrk "Syntax \"Export Set\" is deprecated, use the attribute syntax \"#[export] Set\" instead.")
 
 type module_entry = Modintern.module_struct_expr * Names.ModPath.t * Modintern.module_kind * Entries.inline
@@ -283,7 +283,7 @@ let synterp_require from export qidl =
 let expand filename =
   Envars.expand_path_macros ~warn:(fun x -> Feedback.msg_warning (str x)) filename
 
-let warn_add_loadpath = CWarnings.create ~name:"add-loadpath-deprecated" ~category:CWarnings.CoreCategories.deprecated
+let warn_add_loadpath = CWarnings.create ~name:"add-loadpath-deprecated" ~category:Deprecation.Version.v8_16
     (fun () -> strbrk "Commands \"Add LoadPath\" and \"Add Rec LoadPath\" are deprecated." ++ spc () ++
                strbrk "Use command-line \"-Q\" or \"-R\" or put them in your _CoqProject file instead." ++ spc () ++
                strbrk "If \"Add [Rec] LoadPath\" is an important feature for you, please open an issue at" ++ spc () ++

--- a/vernac/synterp.ml
+++ b/vernac/synterp.ml
@@ -22,17 +22,16 @@ open Attributes
    programs that cannot be statically classified. *)
 let proof_mode_opt_name = ["Default";"Proof";"Mode"]
 
-let get_default_proof_mode =
+let { Goptions.get = get_default_proof_mode } =
   Goptions.declare_interpreted_string_option_and_ref
     ~stage:Summary.Stage.Synterp
-    ~depr:false
     ~key:proof_mode_opt_name
     ~value:(Pvernac.register_proof_mode "Noedit" Pvernac.Vernac_.noedit_mode)
     (fun name -> match Pvernac.lookup_proof_mode name with
     | Some pm -> pm
     | None -> CErrors.user_err Pp.(str (Format.sprintf "No proof mode named \"%s\"." name)))
     Pvernac.proof_mode_to_string
-
+    ()
 
 let module_locality = Attributes.Notations.(locality >>= fun l -> return (make_module_locality l))
 

--- a/vernac/synterp.ml
+++ b/vernac/synterp.ml
@@ -343,7 +343,7 @@ let check_timeout n =
 let () = let open Goptions in
   declare_int_option
     { optstage = Summary.Stage.Synterp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Default";"Timeout"];
       optread  = (fun () -> !default_timeout);
       optwrite = (fun n -> Option.iter check_timeout n; default_timeout := n) }

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -756,12 +756,11 @@ let vernac_assumption ~atts discharge kind l nl =
     Attributes.unsupported_attributes [CAst.make ("using",VernacFlagEmpty)];
   ComAssumption.do_assumptions ~poly:atts.polymorphic ~program_mode:atts.program ~scope ~kind ?deprecation:atts.deprecated nl l
 
-let is_polymorphic_inductive_cumulativity =
+let { Goptions.get = is_polymorphic_inductive_cumulativity } =
   declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
-    ~value:false
     ~key:["Polymorphic";"Inductive";"Cumulativity"]
+    ~value:false
+    ()
 
 let polymorphic_cumulative ~is_defclass =
   let error_poly_context () =
@@ -799,12 +798,11 @@ let polymorphic_cumulative ~is_defclass =
      else
        return (false, false)
 
-let get_uniform_inductive_parameters =
+let { Goptions.get = get_uniform_inductive_parameters } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Uniform"; "Inductive"; "Parameters"]
     ~value:false
+    ()
 
 let should_treat_as_uniform () =
   if get_uniform_inductive_parameters ()
@@ -856,12 +854,11 @@ let private_ind =
   | None -> return false
 
 (** Flag governing use of primitive projections. Disabled by default. *)
-let primitive_flag =
+let { Goptions.get = primitive_flag } =
   Goptions.declare_bool_option_and_ref
-    ~stage:Summary.Stage.Interp
-    ~depr:false
     ~key:["Primitive";"Projections"]
     ~value:false
+    ()
 
 let primitive_proj =
   let open Attributes in

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1546,7 +1546,7 @@ let allow_sprop_opt_name = ["Allow";"StrictProp"]
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = allow_sprop_opt_name;
       optread  = (fun () -> Global.sprop_allowed());
       optwrite = Global.set_allow_sprop }
@@ -1554,7 +1554,7 @@ let () =
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Silent"];
       optread  = (fun () -> !Flags.quiet);
       optwrite = ((:=) Flags.quiet) }
@@ -1562,7 +1562,7 @@ let () =
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Implicit";"Arguments"];
       optread  = Impargs.is_implicit_args;
       optwrite = Impargs.make_implicit_args }
@@ -1570,7 +1570,7 @@ let () =
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Strict";"Implicit"];
       optread  = Impargs.is_strict_implicit_args;
       optwrite = Impargs.make_strict_implicit_args }
@@ -1578,7 +1578,7 @@ let () =
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Strongly";"Strict";"Implicit"];
       optread  = Impargs.is_strongly_strict_implicit_args;
       optwrite = Impargs.make_strongly_strict_implicit_args }
@@ -1586,7 +1586,7 @@ let () =
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Contextual";"Implicit"];
       optread  = Impargs.is_contextual_implicit_args;
       optwrite = Impargs.make_contextual_implicit_args }
@@ -1594,7 +1594,7 @@ let () =
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Reversible";"Pattern";"Implicit"];
       optread  = Impargs.is_reversible_pattern_implicit_args;
       optwrite = Impargs.make_reversible_pattern_implicit_args }
@@ -1602,7 +1602,7 @@ let () =
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Maximal";"Implicit";"Insertion"];
       optread  = Impargs.is_maximal_implicit_args;
       optwrite = Impargs.make_maximal_implicit_args }
@@ -1610,7 +1610,7 @@ let () =
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Printing";"Coercions"];
       optread  = (fun () -> !Constrextern.print_coercions);
       optwrite = (fun b ->  Constrextern.print_coercions := b) }
@@ -1618,7 +1618,7 @@ let () =
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Printing";"Parentheses"];
       optread  = (fun () -> !Constrextern.print_parentheses);
       optwrite = (fun b ->  Constrextern.print_parentheses := b) }
@@ -1626,7 +1626,7 @@ let () =
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Printing";"Implicit"];
       optread  = (fun () -> !Constrextern.print_implicits);
       optwrite = (fun b ->  Constrextern.print_implicits := b) }
@@ -1634,7 +1634,7 @@ let () =
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Printing";"Implicit";"Defensive"];
       optread  = (fun () -> !Constrextern.print_implicits_defensive);
       optwrite = (fun b ->  Constrextern.print_implicits_defensive := b) }
@@ -1642,7 +1642,7 @@ let () =
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Printing";"Projections"];
       optread  = (fun () -> !Constrextern.print_projections);
       optwrite = (fun b ->  Constrextern.print_projections := b) }
@@ -1650,7 +1650,7 @@ let () =
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Printing";"Notations"];
       optread  = (fun () -> not !Constrextern.print_no_symbol);
       optwrite = (fun b ->  Constrextern.print_no_symbol := not b) }
@@ -1658,7 +1658,7 @@ let () =
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Printing";"Raw";"Literals"];
       optread  = (fun () -> !Constrextern.print_raw_literal);
       optwrite = (fun b ->  Constrextern.print_raw_literal := b) }
@@ -1666,7 +1666,7 @@ let () =
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Printing";"All"];
       optread  = (fun () -> !Flags.raw_print);
       optwrite = (fun b -> Flags.raw_print := b) }
@@ -1674,7 +1674,7 @@ let () =
 let () =
   declare_int_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Inline";"Level"];
       optread  = (fun () -> Some (Flags.get_inline_level ()));
       optwrite = (fun o ->
@@ -1684,7 +1684,7 @@ let () =
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Kernel"; "Term"; "Sharing"];
       optread  = (fun () -> (Global.typing_flags ()).Declarations.share_reduction);
       optwrite = Global.set_share_reduction }
@@ -1692,7 +1692,7 @@ let () =
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Printing";"Compact";"Contexts"];
       optread  = (fun () -> Printer.get_compact_context());
       optwrite = (fun b -> Printer.set_compact_context b) }
@@ -1700,7 +1700,7 @@ let () =
 let () =
   declare_int_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Printing";"Depth"];
       optread  = Topfmt.get_depth_boxes;
       optwrite = Topfmt.set_depth_boxes }
@@ -1708,7 +1708,7 @@ let () =
 let () =
   declare_int_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Printing";"Width"];
       optread  = Topfmt.get_margin;
       optwrite = Topfmt.set_margin }
@@ -1716,7 +1716,7 @@ let () =
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Printing";"Universes"];
       optread  = (fun () -> !Constrextern.print_universes);
       optwrite = (fun b -> Constrextern.print_universes:=b) }
@@ -1724,7 +1724,7 @@ let () =
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Dump";"Bytecode"];
       optread  = (fun () -> !Vmbytegen.dump_bytecode);
       optwrite = (:=) Vmbytegen.dump_bytecode }
@@ -1732,7 +1732,7 @@ let () =
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Dump";"Lambda"];
       optread  = (fun () -> !Vmlambda.dump_lambda);
       optwrite = (:=) Vmlambda.dump_lambda }
@@ -1740,7 +1740,7 @@ let () =
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Parsing";"Explicit"];
       optread  = (fun () -> !Constrintern.parsing_explicit);
       optwrite = (fun b ->  Constrintern.parsing_explicit := b) }
@@ -1748,7 +1748,7 @@ let () =
 let () =
   declare_string_option ~preprocess:CWarnings.normalize_flags_string
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Warnings"];
       optread  = CWarnings.get_flags;
       optwrite = CWarnings.set_flags }
@@ -1756,7 +1756,7 @@ let () =
 let () =
   declare_string_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Debug"];
       optread  = CDebug.get_flags;
       optwrite = CDebug.set_flags }
@@ -1764,7 +1764,7 @@ let () =
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Guard"; "Checking"];
       optread  = (fun () -> (Global.typing_flags ()).Declarations.check_guarded);
       optwrite = (fun b -> Global.set_check_guarded b) }
@@ -1772,7 +1772,7 @@ let () =
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Positivity"; "Checking"];
       optread  = (fun () -> (Global.typing_flags ()).Declarations.check_positive);
       optwrite = (fun b -> Global.set_check_positive b) }
@@ -1780,7 +1780,7 @@ let () =
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Universe"; "Checking"];
       optread  = (fun () -> (Global.typing_flags ()).Declarations.check_universes);
       optwrite = (fun b -> Global.set_check_universes b) }
@@ -1788,7 +1788,7 @@ let () =
 let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
-      optdepr  = false;
+      optdepr  = None;
       optkey   = ["Definitional"; "UIP"];
       optread  = (fun () -> (Global.typing_flags ()).Declarations.allow_uip);
       optwrite = (fun b -> Global.set_typing_flags

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1495,7 +1495,7 @@ let vernac_create_hintdb ~module_local id b =
   Hints.create_hint_db module_local id TransparentState.full b
 
 let warn_implicit_core_hint_db =
-  CWarnings.create ~name:"implicit-core-hint-db" ~category:CWarnings.CoreCategories.deprecated
+  CWarnings.create ~name:"implicit-core-hint-db" ~category:Deprecation.Version.v8_10
          (fun () -> strbrk "Adding and removing hints in the core database implicitly is deprecated. "
              ++ strbrk"Please specify a hint database.")
 


### PR DESCRIPTION
This leaves everything using null `since` and the mlg COMMAND EXTEND DEPRECATED commands as the only users of the generic `deprecated` category.

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/466
- https://github.com/mattam82/Coq-Equations/pull/551
- https://github.com/MetaCoq/metacoq/pull/968
- https://gitlab.inria.fr/fbesson/itauto/-/merge_requests/11
- https://github.com/SkySkimmer/coq-lean-import/pull/10
- https://github.com/unicoq/unicoq/pull/84
- https://github.com/coq-community/paramcoq/pull/110
- https://github.com/ejgallego/coq-serapi/pull/335
- https://github.com/coq-tactician/coq-tactician/pull/63
- https://github.com/lukaszcz/coqhammer/pull/159