### PR TITLE
Support quotations (genargs) in patterns

### DIFF
--- a/dev/ci/user-overlays/17667-SkySkimmer-pattern-quotations.sh
+++ b/dev/ci/user-overlays/17667-SkySkimmer-pattern-quotations.sh
@@ -1,0 +1,7 @@
+overlay elpi https://github.com/SkySkimmer/coq-elpi pattern-quotations 17667
+
+overlay equations https://github.com/SkySkimmer/Coq-Equations pattern-quotations 17667
+
+overlay serapi https://github.com/SkySkimmer/coq-serapi pattern-quotations 17667
+
+overlay tactician https://github.com/SkySkimmer/coq-tactician pattern-quotations 17667

--- a/doc/changelog/06-Ltac2-language/17667-pattern-quotations.rst
+++ b/doc/changelog/06-Ltac2-language/17667-pattern-quotations.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  Ltac2 supports pattern quotations when building `pattern` values.
+  This allows building dynamic patterns, eg `Ltac2 eq_pattern a b := pattern:($pattern:a = $pattern:b)`
+  (`#17667 <https://github.com/coq/coq/pull/17667>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -777,6 +777,15 @@ Similarly variables of type `preterm` have an antiquotation
 
 It is equivalent to pretyping the preterm with the appropriate typing constraint.
 
+Variables of type `pattern` have an antiquotation
+
+.. prodn:: term += $pattern:@lident
+
+Its use is only allowed when producing a pattern, i.e.
+`pattern:($pattern:x -> True)` is allowed but
+`constr:($pattern:x -> True)` is not allowed. Conversely `constr` and `preterm`
+antiquotations are not allowed when producing a pattern.
+
 Match over terms
 ~~~~~~~~~~~~~~~~
 

--- a/interp/constrextern.mli
+++ b/interp/constrextern.mli
@@ -29,7 +29,7 @@ val extern_cases_pattern : Id.Set.t -> 'a cases_pattern_g -> cases_pattern_expr
 val extern_glob_constr : extern_env -> 'a glob_constr_g -> constr_expr
 val extern_glob_type : ?impargs:Glob_term.binding_kind list -> extern_env -> 'a glob_constr_g -> constr_expr
 val extern_constr_pattern : names_context -> Evd.evar_map ->
-  constr_pattern -> constr_expr
+  _ constr_pattern_r -> constr_expr
 val extern_closed_glob : ?goal_concl_style:bool -> ?inctx:bool -> ?scope:scope_name ->
   env -> Evd.evar_map -> closed_glob_constr -> constr_expr
 

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -2400,7 +2400,11 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
           intern_sign;
           strict_check = match env.strict_check with None -> false | Some b -> b;
         } in
-        let (_, glb) = Genintern.generic_intern ist gen in
+        let intern = if pattern_mode
+          then Genintern.generic_intern_pat ?loc
+          else Genintern.generic_intern
+        in
+        let (_, glb) = intern ist gen in
         DAst.make ?loc @@
         GGenarg glb
     (* Parsing pattern variables *)
@@ -2739,6 +2743,11 @@ let intern_constr_pattern env sigma ?(as_type=false) ?strict_check ?(ltacvars=em
   let c = intern_gen (if as_type then IsType else WithoutTypeConstraint)
             ?strict_check ~pattern_mode:true ~ltacvars env sigma c in
   pattern_of_glob_constr c
+
+let intern_uninstantiated_constr_pattern env sigma ?(as_type=false) ?strict_check ?(ltacvars=empty_ltac_sign) c =
+  let c = intern_gen (if as_type then IsType else WithoutTypeConstraint)
+            ?strict_check ~pattern_mode:true ~ltacvars env sigma c in
+  uninstantiated_pattern_of_glob_constr c
 
 let intern_core kind env sigma ?strict_check ?(pattern_mode=false) ?(ltacvars=empty_ltac_sign)
       { Genintern.intern_ids = ids; Genintern.notation_variable_status = vl } c =

--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -144,6 +144,10 @@ val intern_constr_pattern :
   env -> evar_map -> ?as_type:bool -> ?strict_check:bool -> ?ltacvars:ltac_sign ->
     constr_pattern_expr -> Id.Set.t * constr_pattern
 
+val intern_uninstantiated_constr_pattern :
+  env -> evar_map -> ?as_type:bool -> ?strict_check:bool -> ?ltacvars:ltac_sign ->
+    constr_pattern_expr -> Id.Set.t * [`uninstantiated] constr_pattern_r
+
 (** Returns None if it's an abbreviation not bound to a name, raises an error
     if not existing *)
 val intern_reference : qualid -> GlobRef.t option

--- a/interp/genintern.ml
+++ b/interp/genintern.ml
@@ -9,7 +9,6 @@
 (************************************************************************)
 
 open Names
-open Mod_subst
 open Genarg
 
 module Store = Store.Make ()
@@ -50,20 +49,12 @@ type glob_constr_and_expr = Glob_term.glob_constr * Constrexpr.constr_expr optio
 type glob_constr_pattern_and_expr = Id.Set.t * glob_constr_and_expr * Pattern.constr_pattern
 
 type ('raw, 'glb) intern_fun = glob_sign -> 'raw -> glob_sign * 'glb
-type 'glb subst_fun = substitution -> 'glb -> 'glb
 type 'glb ntn_subst_fun = Id.Set.t -> Glob_term.glob_constr Id.Map.t -> 'glb -> 'glb
 
 module InternObj =
 struct
   type ('raw, 'glb, 'top) obj = ('raw, 'glb) intern_fun
   let name = "intern"
-  let default _ = None
-end
-
-module SubstObj =
-struct
-  type ('raw, 'glb, 'top) obj = 'glb subst_fun
-  let name = "subst"
   let default _ = None
 end
 
@@ -75,7 +66,6 @@ struct
 end
 
 module Intern = Register (InternObj)
-module Subst = Register (SubstObj)
 module NtnSubst = Register (NtnSubstObj)
 
 let intern = Intern.obj
@@ -84,16 +74,6 @@ let register_intern0 = Intern.register0
 let generic_intern ist (GenArg (Rawwit wit, v)) =
   let (ist, v) = intern wit ist v in
   (ist, in_gen (glbwit wit) v)
-
-(** Substitution functions *)
-
-let substitute = Subst.obj
-let register_subst0 = Subst.register0
-
-let generic_substitute subs (GenArg (Glbwit wit, v)) =
-  in_gen (glbwit wit) (substitute wit subs v)
-
-let () = Hook.set Detyping.subst_genarg_hook generic_substitute
 
 (** Notation substitution *)
 

--- a/interp/genintern.ml
+++ b/interp/genintern.ml
@@ -75,6 +75,27 @@ let generic_intern ist (GenArg (Rawwit wit, v)) =
   let (ist, v) = intern wit ist v in
   (ist, in_gen (glbwit wit) v)
 
+type ('raw,'glb) intern_pat_fun = ?loc:Loc.t -> ('raw,'glb) intern_fun
+
+module InternPatObj = struct
+  type ('raw, 'glb, 'top) obj = ('raw, 'glb) intern_pat_fun
+  let name = "intern_pat"
+  let default tag =
+    Some (fun ?loc ->
+        let name = Genarg.(ArgT.repr (get_arg_tag tag)) in
+        CErrors.user_err ?loc Pp.(str "This quotation is not supported in tactic patterns (" ++ str name ++ str ")"))
+end
+
+module InternPat = Register (InternPatObj)
+
+let intern_pat = InternPat.obj
+
+let register_intern_pat = InternPat.register0
+
+let generic_intern_pat ?loc ist (GenArg (Rawwit wit, v)) =
+  let (ist, v) = intern_pat wit ?loc ist v in
+  (ist, in_gen (glbwit wit) v)
+
 (** Notation substitution *)
 
 let substitute_notation = NtnSubst.obj

--- a/interp/genintern.mli
+++ b/interp/genintern.mli
@@ -9,7 +9,6 @@
 (************************************************************************)
 
 open Names
-open Mod_subst
 open Genarg
 
 module Store : Store.S
@@ -47,15 +46,6 @@ val intern : ('raw, 'glb, 'top) genarg_type -> ('raw, 'glb) intern_fun
 
 val generic_intern : (raw_generic_argument, glob_generic_argument) intern_fun
 
-(** {5 Substitution functions} *)
-
-type 'glb subst_fun = substitution -> 'glb -> 'glb
-(** The type of functions used for substituting generic arguments. *)
-
-val substitute : ('raw, 'glb, 'top) genarg_type -> 'glb subst_fun
-
-val generic_substitute : glob_generic_argument subst_fun
-
 (** {5 Notation functions} *)
 
 type 'glb ntn_subst_fun = Id.Set.t -> Glob_term.glob_constr Id.Map.t -> 'glb -> 'glb
@@ -68,9 +58,6 @@ val generic_substitute_notation : glob_generic_argument ntn_subst_fun
 
 val register_intern0 : ('raw, 'glb, 'top) genarg_type ->
   ('raw, 'glb) intern_fun -> unit
-
-val register_subst0 : ('raw, 'glb, 'top) genarg_type ->
-  'glb subst_fun -> unit
 
 val register_ntn_subst0 : ('raw, 'glb, 'top) genarg_type ->
   'glb ntn_subst_fun -> unit

--- a/interp/genintern.mli
+++ b/interp/genintern.mli
@@ -46,6 +46,14 @@ val intern : ('raw, 'glb, 'top) genarg_type -> ('raw, 'glb) intern_fun
 
 val generic_intern : (raw_generic_argument, glob_generic_argument) intern_fun
 
+(** {5 Internalization in tactic patterns} *)
+
+type ('raw,'glb) intern_pat_fun = ?loc:Loc.t -> ('raw,'glb) intern_fun
+
+val intern_pat : ('raw, 'glb, 'top) genarg_type -> ('raw, 'glb) intern_pat_fun
+
+val generic_intern_pat : (raw_generic_argument, glob_generic_argument) intern_pat_fun
+
 (** {5 Notation functions} *)
 
 type 'glb ntn_subst_fun = Id.Set.t -> Glob_term.glob_constr Id.Map.t -> 'glb -> 'glb
@@ -58,6 +66,10 @@ val generic_substitute_notation : glob_generic_argument ntn_subst_fun
 
 val register_intern0 : ('raw, 'glb, 'top) genarg_type ->
   ('raw, 'glb) intern_fun -> unit
+
+val register_intern_pat : ('raw, 'glb, 'top) genarg_type ->
+  ('raw, 'glb) intern_pat_fun -> unit
+
 
 val register_ntn_subst0 : ('raw, 'glb, 'top) genarg_type ->
   'glb ntn_subst_fun -> unit

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -920,7 +920,7 @@ let rec subst_notation_constr subst bound raw =
     else NHole (nknd, naming)
 
   | NGenarg arg ->
-    let arg' = Genintern.generic_substitute subst arg in
+    let arg' = Gensubst.generic_substitute subst arg in
     if arg' == arg then raw
     else NGenarg arg'
 

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -830,7 +830,7 @@ let in_tacval =
   let intern_fun _ e = Empty.abort e in
   let subst_fun s v = v in
   let () = Genintern.register_intern0 wit intern_fun in
-  let () = Genintern.register_subst0 wit subst_fun in
+  let () = Gensubst.register_subst0 wit subst_fun in
   (* No need to register a value tag for it via register_val0 since we will
      never access this genarg directly. *)
   let interp_fun ist tac =
@@ -871,7 +871,7 @@ type ('a, 'b) argument_intern =
 | ArgInternWit : ('a, 'b, 'c) Genarg.genarg_type -> ('a, 'b) argument_intern
 
 type 'b argument_subst =
-| ArgSubstFun : 'b Genintern.subst_fun -> 'b argument_subst
+| ArgSubstFun : 'b Gensubst.subst_fun -> 'b argument_subst
 | ArgSubstWit : ('a, 'b, 'c) Genarg.genarg_type -> 'b argument_subst
 
 type ('b, 'c) argument_interp =
@@ -898,7 +898,7 @@ match arg.arg_intern with
     let ans = Genarg.out_gen (glbwit wit) (Tacintern.intern_genarg ist (Genarg.in_gen (rawwit wit) v)) in
     (ist, ans)
 
-let subst_fun (type a b c) (arg : (a, b, c) tactic_argument) : b Genintern.subst_fun =
+let subst_fun (type a b c) (arg : (a, b, c) tactic_argument) : b Gensubst.subst_fun =
 match arg.arg_subst with
 | ArgSubstFun f -> f
 | ArgSubstWit wit ->
@@ -923,7 +923,7 @@ match arg.arg_interp with
 let argument_extend (type a b c) ~plugin ~name (arg : (a, b, c) tactic_argument) =
   let wit = Genarg.create_arg name in
   let () = Genintern.register_intern0 wit (intern_fun name arg) in
-  let () = Genintern.register_subst0 wit (subst_fun arg) in
+  let () = Gensubst.register_subst0 wit (subst_fun arg) in
   let tag = match arg.arg_tag with
   | None ->
     let () = register_val0 wit None in

--- a/plugins/ltac/tacentries.mli
+++ b/plugins/ltac/tacentries.mli
@@ -156,7 +156,7 @@ type ('a, 'b) argument_intern =
 | ArgInternWit : ('a, 'b, 'c) Genarg.genarg_type -> ('a, 'b) argument_intern
 
 type 'b argument_subst =
-| ArgSubstFun : 'b Genintern.subst_fun -> 'b argument_subst
+| ArgSubstFun : 'b Gensubst.subst_fun -> 'b argument_subst
 | ArgSubstWit : ('a, 'b, 'c) Genarg.genarg_type -> 'b argument_subst
 
 type ('b, 'c) argument_interp =

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -2061,7 +2061,7 @@ let def_interp ist x = Ftactic.return x
 
 let declare_uniform t =
   Genintern.register_intern0 t def_intern;
-  Genintern.register_subst0 t def_subst;
+  Gensubst.register_subst0 t def_subst;
   register_interp0 t def_interp
 
 let () =

--- a/plugins/ltac/tacsubst.ml
+++ b/plugins/ltac/tacsubst.ml
@@ -272,29 +272,29 @@ and subst_genarg subst (GenArg (Glbwit wit, x)) =
     let q = out_gen (glbwit wit2) (subst_genarg subst (in_gen (glbwit wit2) q)) in
     in_gen (glbwit (wit_pair wit1 wit2)) (p, q)
   | ExtraArg s ->
-      Genintern.generic_substitute subst (in_gen (glbwit wit) x)
+      Gensubst.generic_substitute subst (in_gen (glbwit wit) x)
 
 (** Registering *)
 
 let () =
-  Genintern.register_subst0 wit_int_or_var (fun _ v -> v);
-  Genintern.register_subst0 wit_nat_or_var (fun _ v -> v);
-  Genintern.register_subst0 wit_ref subst_global_reference;
-  Genintern.register_subst0 wit_smart_global subst_global_reference;
-  Genintern.register_subst0 wit_pre_ident (fun _ v -> v);
-  Genintern.register_subst0 wit_ident (fun _ v -> v);
-  Genintern.register_subst0 wit_hyp (fun _ v -> v);
-  Genintern.register_subst0 wit_intropattern subst_intro_pattern [@warning "-3"];
-  Genintern.register_subst0 wit_simple_intropattern subst_intro_pattern;
-  Genintern.register_subst0 wit_tactic subst_tactic;
-  Genintern.register_subst0 wit_ltac subst_tactic;
-  Genintern.register_subst0 wit_constr subst_glob_constr;
-  Genintern.register_subst0 wit_clause_dft_concl (fun _ v -> v);
-  Genintern.register_subst0 wit_uconstr (fun subst c -> subst_glob_constr subst c);
-  Genintern.register_subst0 wit_open_constr (fun subst c -> subst_glob_constr subst c);
-  Genintern.register_subst0 Redexpr.wit_red_expr subst_redexp;
-  Genintern.register_subst0 wit_quant_hyp subst_declared_or_quantified_hypothesis;
-  Genintern.register_subst0 wit_bindings subst_bindings;
-  Genintern.register_subst0 wit_constr_with_bindings subst_glob_with_bindings;
-  Genintern.register_subst0 wit_destruction_arg subst_destruction_arg;
+  Gensubst.register_subst0 wit_int_or_var (fun _ v -> v);
+  Gensubst.register_subst0 wit_nat_or_var (fun _ v -> v);
+  Gensubst.register_subst0 wit_ref subst_global_reference;
+  Gensubst.register_subst0 wit_smart_global subst_global_reference;
+  Gensubst.register_subst0 wit_pre_ident (fun _ v -> v);
+  Gensubst.register_subst0 wit_ident (fun _ v -> v);
+  Gensubst.register_subst0 wit_hyp (fun _ v -> v);
+  Gensubst.register_subst0 wit_intropattern subst_intro_pattern [@warning "-3"];
+  Gensubst.register_subst0 wit_simple_intropattern subst_intro_pattern;
+  Gensubst.register_subst0 wit_tactic subst_tactic;
+  Gensubst.register_subst0 wit_ltac subst_tactic;
+  Gensubst.register_subst0 wit_constr subst_glob_constr;
+  Gensubst.register_subst0 wit_clause_dft_concl (fun _ v -> v);
+  Gensubst.register_subst0 wit_uconstr (fun subst c -> subst_glob_constr subst c);
+  Gensubst.register_subst0 wit_open_constr (fun subst c -> subst_glob_constr subst c);
+  Gensubst.register_subst0 Redexpr.wit_red_expr subst_redexp;
+  Gensubst.register_subst0 wit_quant_hyp subst_declared_or_quantified_hypothesis;
+  Gensubst.register_subst0 wit_bindings subst_bindings;
+  Gensubst.register_subst0 wit_constr_with_bindings subst_glob_with_bindings;
+  Gensubst.register_subst0 wit_destruction_arg subst_destruction_arg;
   ()

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -1773,7 +1773,7 @@ let () =
     else
       return (Tac2ffi.of_closure (Tac2ffi.abstract len clos))
   in
-  let subst s (ids, tac) = (ids, Genintern.substitute Ltac_plugin.Tacarg.wit_tactic s tac) in
+  let subst s (ids, tac) = (ids, Gensubst.substitute Ltac_plugin.Tacarg.wit_tactic s tac) in
   let print env sigma (ids, tac) =
     let ids =
       if List.is_empty ids then mt ()
@@ -1830,7 +1830,7 @@ let () =
     else
       return (Tac2ffi.of_closure (Tac2ffi.abstract len clos))
   in
-  let subst s (ids, tac) = (ids, Genintern.substitute Tacarg.wit_tactic s tac) in
+  let subst s (ids, tac) = (ids, Gensubst.substitute Tacarg.wit_tactic s tac) in
   let print env sigma (ids, tac) =
     let ids =
       if List.is_empty ids then mt ()
@@ -2007,7 +2007,7 @@ let () =
   let intern_fun _ e = Empty.abort e in
   let subst_fun s v = v in
   let () = Genintern.register_intern0 wit_ltac2_val intern_fun in
-  let () = Genintern.register_subst0 wit_ltac2_val subst_fun in
+  let () = Gensubst.register_subst0 wit_ltac2_val subst_fun in
   (* These are bound names and not relevant *)
   let tac_id = Id.of_string "F" in
   let arg_id = Id.of_string "X" in

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -1642,11 +1642,15 @@ let () =
   define_ml_object Tac2quote.wit_ident obj
 
 let () =
-  let intern self ist c =
-    let env = ist.Genintern.genv in
+  let intern self {Genintern.ltacvars=lfun; genv=env; extra; intern_sign=_; strict_check} c =
     let sigma = Evd.from_env env in
-    let strict_check = ist.Genintern.strict_check in
-    let _, pat = Constrintern.intern_constr_pattern env sigma ~strict_check ~as_type:false c in
+    let ltacvars = {
+      Constrintern.ltac_vars = lfun;
+      ltac_bound = Id.Set.empty;
+      ltac_extra = extra;
+    }
+    in
+    let _, pat = Constrintern.intern_uninstantiated_constr_pattern env sigma ~strict_check ~as_type:false ~ltacvars c in
     GlbVal pat, gtypref t_pattern
   in
   let subst subst c =
@@ -1656,7 +1660,13 @@ let () =
   in
   let print env sigma pat = str "pat:(" ++ Printer.pr_lconstr_pattern_env env sigma pat ++ str ")" in
   let raw_print env sigma pat = str "pat:(" ++ Ppconstr.pr_constr_pattern_expr env sigma pat ++ str ")" in
-  let interp _ c = return (Tac2ffi.of_pattern c) in
+  let interp env c =
+    let ist = to_lvar env in
+    pf_apply ~catch_exceptions:true begin fun env sigma ->
+      let c = Patternops.interp_pattern env sigma ist c in
+      return (Tac2ffi.of_pattern c)
+    end
+  in
   let obj = {
     ml_intern = intern;
     ml_interp = interp;
@@ -1917,10 +1927,25 @@ let () =
     let f = match kind with
       | ConstrVar -> interp_constr_var_as_constr
       | PretermVar -> interp_preterm_var_as_constr
+      | PatternVar -> assert false
     in
     f ?loc env sigma tycon id
   in
   GlobEnv.register_constr_interp0 wit_ltac2_var_quotation interp
+
+let () =
+  let interp env sigma ist (kind,id) =
+    let () = match kind with
+      | ConstrVar -> assert false (* checked at intern time *)
+      | PretermVar -> assert false
+      | PatternVar -> ()
+    in
+    let ist = Tac2interp.get_env ist.Ltac_pretype.ltac_genargs in
+    let c = Id.Map.find id ist.env_ist in
+    let c = Tac2ffi.to_pattern c in
+    c
+  in
+  Patternops.register_interp_pat wit_ltac2_var_quotation interp
 
 let () =
   let pr_raw (kind,id) = Genprint.PrinterBasic (fun _env _sigma ->
@@ -1935,6 +1960,7 @@ let () =
       let ppkind = match kind with
         | ConstrVar -> mt()
         | PretermVar -> str "preterm:"
+        | PatternVar -> str "pattern:"
       in
       str "$" ++ ppkind ++ Id.print id) in
   let pr_top x = Util.Empty.abort x in

--- a/plugins/ltac2/tac2env.ml
+++ b/plugins/ltac2/tac2env.ml
@@ -329,6 +329,7 @@ let ltac1_prefix =
 type var_quotation_kind =
   | ConstrVar
   | PretermVar
+  | PatternVar
 
 let wit_ltac2in1 = Genarg.make0 "ltac2in1"
 let wit_ltac2in1_val = Genarg.make0 "ltac2in1val"

--- a/plugins/ltac2/tac2env.mli
+++ b/plugins/ltac2/tac2env.mli
@@ -180,6 +180,7 @@ val wit_ltac2_constr : (raw_tacexpr, Id.Set.t * glb_tacexpr, Util.Empty.t) genar
 type var_quotation_kind =
   | ConstrVar
   | PretermVar
+  | PatternVar
 
 val wit_ltac2_var_quotation : (lident option * lident, var_quotation_kind * Id.t, Util.Empty.t) genarg_type
 (** Ltac2 quotations for variables "$x" or "$kind:foo" in Gallina terms.

--- a/plugins/ltac2/tac2intern.ml
+++ b/plugins/ltac2/tac2intern.ml
@@ -1992,9 +1992,9 @@ let () =
   in
   Genintern.register_intern0 wit_ltac2_constr intern
 
-let () = Genintern.register_subst0 wit_ltac2in1 (fun s (ids, e) -> ids, subst_expr s e)
-let () = Genintern.register_subst0 wit_ltac2in1_val subst_expr
-let () = Genintern.register_subst0 wit_ltac2_constr (fun s (ids, e) -> ids, subst_expr s e)
+let () = Gensubst.register_subst0 wit_ltac2in1 (fun s (ids, e) -> ids, subst_expr s e)
+let () = Gensubst.register_subst0 wit_ltac2in1_val subst_expr
+let () = Gensubst.register_subst0 wit_ltac2_constr (fun s (ids, e) -> ids, subst_expr s e)
 
 let intern_var_quotation ist (kind, { CAst.v = id; loc }) =
   let open Genintern in
@@ -2034,4 +2034,4 @@ let intern_var_quotation ist (kind, { CAst.v = id; loc }) =
 
 let () = Genintern.register_intern0 wit_ltac2_var_quotation intern_var_quotation
 
-let () = Genintern.register_subst0 wit_ltac2_var_quotation (fun _ v -> v)
+let () = Gensubst.register_subst0 wit_ltac2_var_quotation (fun _ v -> v)

--- a/plugins/ltac2/tac2quote.mli
+++ b/plugins/ltac2/tac2quote.mli
@@ -95,7 +95,7 @@ val of_format : lstring -> raw_tacexpr
 
 (** {5 Generic arguments} *)
 
-val wit_pattern : (Constrexpr.constr_expr, Pattern.constr_pattern) Arg.tag
+val wit_pattern : (Constrexpr.constr_expr, [`uninstantiated] Pattern.constr_pattern_r) Arg.tag
 
 val wit_ident : (Id.t, Id.t) Arg.tag
 

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -166,7 +166,7 @@ let add_genarg tag pr =
   let interp ist x = Ftactic.return (Geninterp.Val.Dyn (tag, x)) in
   let gen_pr env sigma _ _ _ = pr env sigma in
   let () = Genintern.register_intern0 wit glob in
-  let () = Genintern.register_subst0 wit subst in
+  let () = Gensubst.register_subst0 wit subst in
   let () = Geninterp.register_interp0 wit interp in
   let () = Geninterp.register_val0 wit (Some (Geninterp.Val.Base tag)) in
   Pptactic.declare_extra_genarg_pprule wit gen_pr gen_pr gen_pr;

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -111,7 +111,7 @@ let add_genarg tag pr =
   let interp ist x = Ftactic.return (Geninterp.Val.Dyn (tag, x)) in
   let gen_pr env sigma _ _ _ = pr env sigma in
   let () = Genintern.register_intern0 wit glob in
-  let () = Genintern.register_subst0 wit subst in
+  let () = Gensubst.register_subst0 wit subst in
   let () = Geninterp.register_interp0 wit interp in
   let () = Geninterp.register_val0 wit (Some (Geninterp.Val.Base tag)) in
   Pptactic.declare_extra_genarg_pprule wit gen_pr gen_pr gen_pr;

--- a/pretyping/constr_matching.ml
+++ b/pretyping/constr_matching.ml
@@ -285,7 +285,7 @@ let matches_core env sigma allow_bound_rels
     | ConstructRef c, Construct (c',u) -> Environ.QConstruct.equal env c c'
     | _, _ -> false
   in
-  let rec sorec ctx env subst p t =
+  let rec sorec ctx env subst (p:constr_pattern) t =
     let cT = strip_outer_cast sigma t in
     match p, EConstr.kind sigma cT with
       | PSoApp (n,args),m ->
@@ -478,6 +478,8 @@ let matches_core env sigma allow_bound_rels
       | (PRef _ | PVar _ | PRel _ | PApp _ | PProj _ | PLambda _
          | PProd _ | PLetIn _ | PSort _ | PIf _ | PCase _
          | PFix _ | PCoFix _| PEvar _ | PInt _ | PFloat _ | PArray _), _ -> raise PatternMatchingFailure
+
+      | PUninstantiated _, _ -> .
 
   in
   sorec [] env ((Id.Map.empty,Id.Set.empty), Id.Map.empty) pat c

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -1138,8 +1138,6 @@ let rec subst_cases_pattern subst = DAst.map (function
           PatCstr (((kn',i),j),cpl',n)
   )
 
-let (f_subst_genarg, subst_genarg_hook) = Hook.make ()
-
 let rec subst_glob_constr env subst = DAst.map (function
   | GRef (ref,u) as raw ->
     let ref',t = subst_global subst ref in
@@ -1250,7 +1248,7 @@ let rec subst_glob_constr env subst = DAst.map (function
     else GHole (nknd, naming)
 
   | GGenarg arg as raw ->
-    let arg' = Hook.get f_subst_genarg subst arg in
+    let arg' = Gensubst.generic_substitute subst arg in
     if arg' == arg then raw
     else GGenarg arg'
 

--- a/pretyping/detyping.mli
+++ b/pretyping/detyping.mli
@@ -70,9 +70,6 @@ val lookup_index_as_renamed : env -> evar_map -> constr -> int -> int option
 val force_wildcard : unit -> bool
 val synthetize_type : unit -> bool
 
-val subst_genarg_hook :
-  (substitution -> Genarg.glob_generic_argument -> Genarg.glob_generic_argument) Hook.t
-
 module PrintingInductiveMake :
   functor (Test : sig
     val encode : Environ.env -> Libnames.qualid -> Names.inductive

--- a/pretyping/detyping.mli
+++ b/pretyping/detyping.mli
@@ -55,10 +55,10 @@ val detype_rel_context : 'a delay -> constr option -> Id.Set.t -> (names_context
   evar_map -> rel_context -> 'a glob_decl_g list
 
 val share_pattern_names :
-  (Id.Set.t -> names_context -> 'c -> Pattern.constr_pattern -> 'a) -> int ->
+  (Id.Set.t -> names_context -> 'c -> 'd Pattern.constr_pattern_r -> 'a) -> int ->
   (Name.t * binding_kind * 'b option * 'a) list ->
-  Id.Set.t -> names_context -> 'c -> Pattern.constr_pattern ->
-  Pattern.constr_pattern ->
+  Id.Set.t -> names_context -> 'c -> 'd Pattern.constr_pattern_r ->
+  'd Pattern.constr_pattern_r ->
   (Name.t * binding_kind * 'b option * 'a) list * 'a * 'a
 
 val detype_closed_glob :  ?isgoal:bool -> Id.Set.t -> env -> evar_map -> closed_glob_constr -> glob_constr

--- a/pretyping/genarg.ml
+++ b/pretyping/genarg.ml
@@ -206,8 +206,30 @@ struct
       to an extra argument type, otherwise, it will badly fail. *)
   let obj t = get_obj0 @@ get_arg_tag t
 
+  let mem t =
+    let t = get_arg_tag t in
+    GenMap.mem t !arg0_map
+
   (** NB: we need the [Pack] pattern to get [tag]
       from [_ ArgT.DYN.tag] to [(_ * _ * _) ArgT.DYN.tag] *)
   let fold_keys f acc = GenMap.fold (fun (Any (tag,Pack _)) acc -> f (ArgT.Any tag) acc) !arg0_map acc
 
 end
+
+(** Substitution functions *)
+type 'glb subst_fun = Mod_subst.substitution -> 'glb -> 'glb
+
+module SubstObj =
+struct
+  type ('raw, 'glb, 'top) obj = 'glb subst_fun
+  let name = "subst"
+  let default _ = None
+end
+
+module Subst = Register (SubstObj)
+
+let substitute = Subst.obj
+let register_subst0 = Subst.register0
+
+let generic_substitute subs (GenArg (Glbwit wit, v)) =
+  in_gen (glbwit wit) (substitute wit subs v)

--- a/pretyping/genarg.mli
+++ b/pretyping/genarg.mli
@@ -187,10 +187,25 @@ sig
   val obj : ('raw, 'glb, 'top) genarg_type -> ('raw, 'glb, 'top) M.obj
   (** Recover a manipulation function at a given type. *)
 
+  val mem : _ genarg_type -> bool
+  (** Is this type registered? *)
+
   val fold_keys : (ArgT.any -> 'acc -> 'acc) -> 'acc -> 'acc
   (** Fold over the registered keys. *)
 
 end
+
+(** {5 Substitution functions} *)
+
+type 'glb subst_fun = Mod_subst.substitution -> 'glb -> 'glb
+(** The type of functions used for substituting generic arguments. *)
+
+val substitute : ('raw, 'glb, 'top) genarg_type -> 'glb subst_fun
+
+val generic_substitute : glob_generic_argument subst_fun
+
+val register_subst0 : ('raw, 'glb, 'top) genarg_type ->
+  'glb subst_fun -> unit
 
 (** {5 Compatibility layer}
 

--- a/pretyping/gensubst.ml
+++ b/pretyping/gensubst.ml
@@ -1,0 +1,29 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Genarg
+
+(** Substitution functions *)
+type 'glb subst_fun = Mod_subst.substitution -> 'glb -> 'glb
+
+module SubstObj =
+struct
+  type ('raw, 'glb, 'top) obj = 'glb subst_fun
+  let name = "subst"
+  let default _ = None
+end
+
+module Subst = Register (SubstObj)
+
+let substitute = Subst.obj
+let register_subst0 = Subst.register0
+
+let generic_substitute subs (GenArg (Glbwit wit, v)) =
+  in_gen (glbwit wit) (substitute wit subs v)

--- a/pretyping/gensubst.mli
+++ b/pretyping/gensubst.mli
@@ -1,0 +1,23 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Genarg
+
+(** {5 Substitution functions} *)
+
+type 'glb subst_fun = Mod_subst.substitution -> 'glb -> 'glb
+(** The type of functions used for substituting generic arguments. *)
+
+val substitute : ('raw, 'glb, 'top) genarg_type -> 'glb subst_fun
+
+val generic_substitute : glob_generic_argument subst_fun
+
+val register_subst0 : ('raw, 'glb, 'top) genarg_type ->
+  'glb subst_fun -> unit

--- a/pretyping/pattern.mli
+++ b/pretyping/pattern.mli
@@ -20,27 +20,37 @@ type case_info_pattern =
       cip_ind : inductive option;
       cip_extensible : bool (** does this match end with _ => _ ? *) }
 
-type constr_pattern =
+type 'i uninstantiated_pattern =
+  | PGenarg : Genarg.glob_generic_argument -> [ `uninstantiated ] uninstantiated_pattern
+
+type 'i constr_pattern_r =
   | PRef of GlobRef.t
   | PVar of Id.t
-  | PEvar of (Evar.t * constr_pattern list)
+  | PEvar of (Evar.t * 'i constr_pattern_r list)
   | PRel of int
-  | PApp of constr_pattern * constr_pattern array
-  | PSoApp of patvar * constr_pattern list
-  | PProj of Projection.t * constr_pattern
-  | PLambda of Name.t * constr_pattern * constr_pattern
-  | PProd of Name.t * constr_pattern * constr_pattern
-  | PLetIn of Name.t * constr_pattern * constr_pattern option * constr_pattern
+  | PApp of 'i constr_pattern_r * 'i constr_pattern_r array
+  | PSoApp of patvar * 'i constr_pattern_r list
+  | PProj of Projection.t * 'i constr_pattern_r
+  | PLambda of Name.t * 'i constr_pattern_r * 'i constr_pattern_r
+  | PProd of Name.t * 'i constr_pattern_r * 'i constr_pattern_r
+  | PLetIn of Name.t * 'i constr_pattern_r * 'i constr_pattern_r option * 'i constr_pattern_r
   | PSort of Sorts.family
   | PMeta of patvar option
-  | PIf of constr_pattern * constr_pattern * constr_pattern
-  | PCase of case_info_pattern * (Name.t array * constr_pattern) option * constr_pattern *
-      (int * Name.t array * constr_pattern) list (** index of constructor, nb of args *)
-  | PFix of (int array * int) * (Name.t array * constr_pattern array * constr_pattern array)
-  | PCoFix of int * (Name.t array * constr_pattern array * constr_pattern array)
+  | PIf of 'i constr_pattern_r * 'i constr_pattern_r * 'i constr_pattern_r
+  | PCase of case_info_pattern * (Name.t array * 'i constr_pattern_r) option * 'i constr_pattern_r *
+      (int * Name.t array * 'i constr_pattern_r) list (** index of constructor, nb of args *)
+  | PFix of (int array * int) * (Name.t array * 'i constr_pattern_r array * 'i constr_pattern_r array)
+  | PCoFix of int * (Name.t array * 'i constr_pattern_r array * 'i constr_pattern_r array)
   | PInt of Uint63.t
   | PFloat of Float64.t
-  | PArray of constr_pattern array * constr_pattern * constr_pattern
+  | PArray of 'i constr_pattern_r array * 'i constr_pattern_r * 'i constr_pattern_r
+  | PUninstantiated of 'i uninstantiated_pattern
+
+type constr_pattern = [ `any ] constr_pattern_r
 
 (** Nota : in a [PCase], the array of branches might be shorter than
     expected, denoting the use of a final "_ => _" branch *)
+
+type _ pattern_kind =
+  | Any
+  | Uninstantiated : [`uninstantiated] pattern_kind

--- a/pretyping/patternops.mli
+++ b/pretyping/patternops.mli
@@ -18,9 +18,9 @@ open EConstr
 
 val constr_pattern_eq : constr_pattern -> constr_pattern -> bool
 
-val subst_pattern : Environ.env -> Evd.evar_map -> substitution -> constr_pattern -> constr_pattern
+val subst_pattern : Environ.env -> Evd.evar_map -> substitution -> 'i constr_pattern_r -> 'i constr_pattern_r
 
-val noccurn_pattern : int -> constr_pattern -> bool
+val noccurn_pattern : int -> _ constr_pattern_r -> bool
 
 exception BoundPattern
 
@@ -49,10 +49,20 @@ val legacy_bad_pattern_of_constr : Environ.env -> Evd.evar_map -> EConstr.constr
    a pattern; variables bound in [l] are replaced by the pattern to which they
     are bound *)
 
-val pattern_of_glob_constr : glob_constr ->
-      Id.Set.t * constr_pattern
+val pattern_of_glob_constr : glob_constr -> Id.Set.t * constr_pattern
+
+val uninstantiated_pattern_of_glob_constr : glob_constr -> Id.Set.t * [`uninstantiated] constr_pattern_r
 
 val map_pattern_with_binders : (Name.t -> 'a -> 'a) ->
-  ('a -> constr_pattern -> constr_pattern) -> 'a -> constr_pattern -> constr_pattern
+  ('a -> 'i constr_pattern_r -> 'i constr_pattern_r) -> 'a -> 'i constr_pattern_r -> 'i constr_pattern_r
 
-val lift_pattern : int -> constr_pattern -> constr_pattern
+val lift_pattern : int -> 'i constr_pattern_r -> 'i constr_pattern_r
+
+(** Interp genargs *)
+
+type 'a pat_interp_fun = Environ.env -> Evd.evar_map -> Ltac_pretype.ltac_var_map
+  -> 'a -> Pattern.constr_pattern
+
+val interp_pattern : [`uninstantiated] constr_pattern_r pat_interp_fun
+
+val register_interp_pat : (_, 'g, _) Genarg.genarg_type -> 'g pat_interp_fun -> unit

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -109,9 +109,9 @@ val pr_lglob_constr_env    : env -> evar_map -> 'a glob_constr_g -> Pp.t
 
 val pr_glob_constr_env     : env -> evar_map -> 'a glob_constr_g -> Pp.t
 
-val pr_lconstr_pattern_env : env -> evar_map -> constr_pattern -> Pp.t
+val pr_lconstr_pattern_env : env -> evar_map -> _ constr_pattern_r -> Pp.t
 
-val pr_constr_pattern_env  : env -> evar_map -> constr_pattern -> Pp.t
+val pr_constr_pattern_env  : env -> evar_map -> _ constr_pattern_r -> Pp.t
 
 val pr_cases_pattern       : cases_pattern -> Pp.t
 

--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -479,7 +479,7 @@ let subst_hintrewrite (subst,(rbase,list as node)) =
     let cst' = subst_mps subst hint.rew_lemma in
     let typ' = subst_mps subst hint.rew_type in
     let pat' = subst_mps subst hint.rew_pat in
-    let t' = Option.Smart.map (Genintern.generic_substitute subst) hint.rew_tac in
+    let t' = Option.Smart.map (Gensubst.generic_substitute subst) hint.rew_tac in
       if hint.rew_id == id' && hint.rew_lemma == cst' && hint.rew_type == typ' &&
          hint.rew_tac == t' && hint.rew_pat == pat' then hint else
         { hint with

--- a/tactics/btermdn.ml
+++ b/tactics/btermdn.ml
@@ -35,7 +35,7 @@ let eta_reduce = Reductionops.shrink_eta
 
 (* TODO: instead of doing that on patterns we should try to perform it on terms
    before translating them into patterns in Hints. *)
-let rec eta_reduce_pat p = match p with
+let rec eta_reduce_pat (p:constr_pattern) = match p with
 | PLambda (_, _, q) ->
   let f, cl = match eta_reduce_pat q with
   | PApp (f, cl) -> f, cl
@@ -54,6 +54,7 @@ let rec eta_reduce_pat p = match p with
 | PRef _ | PVar _ | PEvar _ | PRel _ | PApp _ | PSoApp _ | PProj _ | PProd _
 | PLetIn _ | PSort _ | PMeta _ | PIf _ | PCase _ | PFix _ | PCoFix _ | PInt _
 | PFloat _ | PArray _ -> p
+| PUninstantiated _ -> .
 
 let decomp_pat p =
   let rec decrec acc = function

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1183,7 +1183,7 @@ let subst_autohint (subst, obj) =
           if ref==ref' then data.code.obj else Unfold_nth ref'
       | Extern (pat, tac) ->
           let pat' = Option.Smart.map (subst_pattern env sigma subst) pat in
-          let tac' = Genintern.generic_substitute subst tac in
+          let tac' = Gensubst.generic_substitute subst tac in
           if pat==pat' && tac==tac' then data.code.obj else Extern (pat', tac')
     in
     let name' = Option.Smart.map (subst_global_reference subst) data.name in

--- a/test-suite/bugs/bug_11641.v
+++ b/test-suite/bugs/bug_11641.v
@@ -1,0 +1,28 @@
+Require Import Ltac2.Ltac2.
+
+Fail Ltac2 my_change1 (a : constr) (b : constr) :=
+  change $a with $b.
+
+Fail Ltac2 my_change2 (a:preterm) (b:constr) :=
+  change $preterm:a with $b.
+
+(* This is pretty bad, maybe $x should mean $pattern:x in patterns?
+   Main question is if we allow preterm in pattern, is
+   "fun x => let y := preterm:($x) in pattern:($preterm:y)"
+   going to be confusing? (x must be constr, and we error at runtime??)
+
+   Instead don't allow preterms, instead expose "pattern_of_preterm : preterm -> pattern",
+   having runtime errors there seems more sensible than with the quotation.
+ *)
+Ltac2 my_change3 (a:pattern) (b:constr) :=
+  change $pattern:a with $b.
+
+Fail Ltac2 dummy x := preterm:($pattern:x).
+
+Goal id True -> False.
+  Fail match! goal with [ |- True -> False ] => () end.
+  my_change3 pat:(id True) constr:(True).
+  match! goal with [ |- True -> False ] => () end.
+
+  Fail let a := preterm:(id True) in change $preterm:a with True.
+Abort.


### PR DESCRIPTION
For #11641

`constr_pattern` is split in 2 types, one is allowed to contain genargs and the other not.
To share code this uses a GADT `'i constr_pattern_r`, with genargs allowed instantiated to `` [`uninstantiated] constr_pattern_r ``, without genargs instantiated to `` constr_pattern = [`any] constr_pattern_r ``.

Ltac2 instantiates the genargs in the `ml_interp` for the TacExt ie a pattern expression is interned to `` [`uninstantiated] constr_pattern_r `` then interped to `constr_pattern`.

Most code (basically everything except ltac2) uses only the no-genarg version (TODO change this? but currently we have no non-ltac2 genargs handled).

For now I just have it handling `$pattern:x` quotations.

We probably don't want to have `$constr:x` in patterns, if we really want the functionality we could expose pattern_of_constr as a `constr -> pattern` (also a `preterm -> pattern` function).

Then do we want to interpret `$x` as `$pattern:x` in patterns?
But if we have a `preterm -> pattern` we will need to consider what happens to a `$x` in the preterm and that could get confusing.

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/500
- https://github.com/mattam82/Coq-Equations/pull/560
- https://github.com/ejgallego/coq-serapi/pull/359
- https://github.com/coq-tactician/coq-tactician/pull/66