### PR TITLE
Only keep projection index in Kproj VM bytecode.

### DIFF
--- a/kernel/vmbytecodes.ml
+++ b/kernel/vmbytecodes.ml
@@ -65,7 +65,7 @@ type instruction =
   | Ksetfield of int
   | Kstop
   | Ksequence of bytecodes
-  | Kproj of Projection.Repr.t
+  | Kproj of int
   | Kensurestackcapacity of int
   | Kbranch of Label.t                  (* jump to label *)
   | Kprim of CPrimitives.t * pconstant
@@ -156,7 +156,7 @@ let rec pp_instr i =
 
   | Kbranch lbl -> str "branch " ++ pp_lbl lbl
 
-  | Kproj p -> str "proj " ++ Projection.Repr.print p
+  | Kproj p -> str "proj " ++ int p
 
   | Kensurestackcapacity size -> str "growstack " ++ int size
 

--- a/kernel/vmbytecodes.mli
+++ b/kernel/vmbytecodes.mli
@@ -63,7 +63,7 @@ type instruction =
   | Ksetfield of int                    (** accu[n] = sp[0] ; sp = pop sp *)
   | Kstop
   | Ksequence of bytecodes
-  | Kproj of Projection.Repr.t
+  | Kproj of int
   | Kensurestackcapacity of int
 
   | Kbranch of Label.t                  (** jump to label, is it needed ? *)

--- a/kernel/vmbytegen.ml
+++ b/kernel/vmbytegen.ml
@@ -525,7 +525,7 @@ let rec compile_lam env cenv lam sz cont =
   | Lfloat f -> compile_structured_constant cenv (Const_float f) sz cont
 
   | Lproj (p,arg) ->
-     compile_lam env cenv arg sz (Kproj p :: cont)
+     compile_lam env cenv arg sz (Kproj (Projection.Repr.arg p) :: cont)
 
   | Lvar id -> pos_named id cenv :: cont
 

--- a/kernel/vmemitcodes.ml
+++ b/kernel/vmemitcodes.ml
@@ -404,7 +404,7 @@ let emit_instr env = function
   | Ksetfield n ->
       out env opSETFIELD; out_int env n
   | Ksequence _ -> invalid_arg "Vmemitcodes.emit_instr"
-  | Kproj p -> out env opPROJ; out_int env (Projection.Repr.arg p)
+  | Kproj p -> out env opPROJ; out_int env p
   | Kensurestackcapacity size -> out env opENSURESTACKCAPACITY; out_int env size
   | Kbranch lbl -> out env opBRANCH; out_label env lbl
   | Kprim (op, (q,_u)) ->


### PR DESCRIPTION
Tiny cleanup. We only ever care about the projection index in Kproj VM bytecode node, so let's enforce it statically.