### PR TITLE
Deprecate tactic "revert dependent" (alias of "generalize dependent")

### DIFF
--- a/doc/changelog/04-tactics/17669-inject-eqdep.rst
+++ b/doc/changelog/04-tactics/17669-inject-eqdep.rst
@@ -1,0 +1,4 @@
+- **Deprecated:**
+  `revert dependent`, which is a misleadingly named alias of :tacn:`generalize dependent`
+  (`#17669 <https://github.com/coq/coq/pull/17669>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -1302,7 +1302,9 @@ Managing the local context
 
    .. tacn:: revert dependent @ident
 
-      Moves the named hypothesis and all the hypotheses that depend on it to the goal.
+      .. deprecated:: 8.18
+
+      An alias for :tacn:`generalize dependent`.
 
 .. tacn:: move @ident__from @where
 

--- a/theories/Init/Tactics.v
+++ b/theories/Init/Tactics.v
@@ -234,6 +234,7 @@ Tactic Notation "clear" "dependent" hyp(h) :=
 (** Revert an hypothesis and its dependencies :
     this is actually generalize dependent... *)
 
+#[deprecated(note="Use ""generalize dependent"" instead (""revert dependent"" is currently an alias)", since="8.18")]
 Tactic Notation "revert" "dependent" hyp(h) :=
  generalize dependent h.
 


### PR DESCRIPTION
This being a generalize alias is confusing as seen in #3967

Close #3967
