### PR TITLE
injection: do not force Eqdep_dec to be required when equality scheme exists

### DIFF
--- a/doc/changelog/04-tactics/17670-inject-eqdep.rst
+++ b/doc/changelog/04-tactics/17670-inject-eqdep.rst
@@ -1,0 +1,4 @@
+- **Changed:**
+  :tacn:`injection` continues working using sigma types when `Eqdep_dec` has not been required even if an equality scheme was found, instead of failing
+  (`#17670 <https://github.com/coq/coq/pull/17670>`_,
+  by Gaëtan Gilbert).


### PR DESCRIPTION


Close #4961
