### PR TITLE
Store VM bytecode in a dedicated vo segment

### DIFF
--- a/checker/check.ml
+++ b/checker/check.ml
@@ -60,7 +60,9 @@ type library_t = {
   library_opaques : seg_proofs;
   library_deps : (compilation_unit_name * Safe_typing.vodigest) array;
   library_digest : Safe_typing.vodigest;
-  library_extra_univs : Univ.ContextSet.t }
+  library_extra_univs : Univ.ContextSet.t;
+  library_vm : Vmlibrary.on_disk;
+}
 
 module LibraryOrdered =
   struct
@@ -124,12 +126,12 @@ let check_one_lib admit senv (dir,m) =
     if LibrarySet.mem dir admit then
       (Flags.if_verbose Feedback.msg_notice
          (str "Admitting library: " ++ pr_dirpath dir);
-       Safe_checking.unsafe_import (fst senv) md m.library_extra_univs dig),
+       Safe_checking.unsafe_import (fst senv) md m.library_extra_univs m.library_vm dig),
       (snd senv)
     else
       (Flags.if_verbose Feedback.msg_notice
          (str "Checking library: " ++ pr_dirpath dir);
-       Safe_checking.import (fst senv) (snd senv) md m.library_extra_univs dig)
+       Safe_checking.import (fst senv) (snd senv) md m.library_extra_univs  m.library_vm dig)
   in
     register_loaded_library m; senv
 
@@ -284,14 +286,16 @@ type library_disk = {
   md_objects : library_objects;
 }
 
-let mk_library sd md f table digest cst = {
+let mk_library sd md f table digest cst vm = {
   library_name = sd.md_name;
   library_filename = f;
   library_compiled = md.md_compiled;
   library_opaques = table;
   library_deps = sd.md_deps;
   library_digest = digest;
-  library_extra_univs = cst }
+  library_extra_univs = cst;
+  library_vm = vm;
+}
 
 let name_clash_message dir mdir f =
   str ("The file " ^ f ^ " contains library") ++ spc () ++
@@ -326,11 +330,12 @@ let library_seg : library_disk ObjFile.id = ObjFile.make_id "library"
 let universes_seg : seg_univ option ObjFile.id = ObjFile.make_id "universes"
 let tasks_seg : Obj.t option ObjFile.id = ObjFile.make_id "tasks"
 let opaques_seg : seg_proofs ObjFile.id = ObjFile.make_id "opaques"
+let vm_seg : Vmlibrary.on_disk ObjFile.id = ObjFile.make_id "vmlibrary"
 
 let intern_from_file ~intern_mode (dir, f) =
   let validate = intern_mode <> Dep in
   Flags.if_verbose chk_pp (str"[intern "++str f++str" ...");
-  let (sd,md,table,opaque_csts,digest) =
+  let (sd,md,table,opaque_csts,vmlib,digest) =
     try
       (* First pass to read the metadata of the file *)
       let ch = System.with_magic_number_check raw_intern_library f in
@@ -339,6 +344,7 @@ let intern_from_file ~intern_mode (dir, f) =
       let seg_univs = ObjFile.get_segment ch ~segment:universes_seg in
       let seg_tasks = ObjFile.get_segment ch ~segment:tasks_seg in
       let seg_opaque = ObjFile.get_segment ch ~segment:opaques_seg in
+      let seg_vmlib = ObjFile.get_segment ch ~segment:vm_seg in
       let () = ObjFile.close_in ch in
       (* Actually read the data *)
       let ch = open_in_bin f in
@@ -348,6 +354,7 @@ let intern_from_file ~intern_mode (dir, f) =
       let opaque_csts = marshal_in_segment ~validate ~value:Values.v_univopaques ~segment:seg_univs f ch in
       let tasks = marshal_in_segment ~validate ~value:Values.(Opt Any) ~segment:seg_tasks f ch in
       let table = marshal_in_segment ~validate ~value:Values.v_opaquetable ~segment:seg_opaque f ch in
+      let vmlib = marshal_in_segment ~validate ~value:Any ~segment:seg_vmlib f ch in
       (* Verification of the final checksum *)
       let () = close_in ch in
       let ch = open_in_bin f in
@@ -371,14 +378,14 @@ let intern_from_file ~intern_mode (dir, f) =
         let open ObjFile in
         if opaque_csts <> None then Safe_typing.Dvivo (seg_md.hash, seg_univs.hash)
         else (Safe_typing.Dvo_or_vi seg_md.hash) in
-      sd,md,table,opaque_csts,digest
+      sd,md,table,opaque_csts,vmlib,digest
     with e -> Flags.if_verbose chk_pp (str" failed!]" ++ fnl ()); raise e in
   depgraph := LibraryMap.add sd.md_name sd.md_deps !depgraph;
   opaque_tables := LibraryMap.add sd.md_name table !opaque_tables;
   let extra_cst =
     Option.default Univ.ContextSet.empty
       (Option.map (fun (cs,_) -> cs) opaque_csts) in
-  mk_library sd md f table digest extra_cst
+  mk_library sd md f table digest extra_cst vmlib
 
 let get_deps (dir, f) =
   try LibraryMap.find dir !depgraph

--- a/checker/check.ml
+++ b/checker/check.ml
@@ -330,7 +330,7 @@ let library_seg : library_disk ObjFile.id = ObjFile.make_id "library"
 let universes_seg : seg_univ option ObjFile.id = ObjFile.make_id "universes"
 let tasks_seg : Obj.t option ObjFile.id = ObjFile.make_id "tasks"
 let opaques_seg : seg_proofs ObjFile.id = ObjFile.make_id "opaques"
-let vm_seg : Vmlibrary.on_disk ObjFile.id = ObjFile.make_id "vmlibrary"
+let vm_seg = Vmlibrary.vm_segment
 
 let intern_from_file ~intern_mode (dir, f) =
   let validate = intern_mode <> Dep in
@@ -385,7 +385,7 @@ let intern_from_file ~intern_mode (dir, f) =
   let extra_cst =
     Option.default Univ.ContextSet.empty
       (Option.map (fun (cs,_) -> cs) opaque_csts) in
-  mk_library sd md f table digest extra_cst vmlib
+  mk_library sd md f table digest extra_cst (Vmlibrary.inject vmlib)
 
 let get_deps (dir, f) =
   try LibraryMap.find dir !depgraph

--- a/checker/safe_checking.ml
+++ b/checker/safe_checking.ml
@@ -11,7 +11,7 @@
 open Declarations
 open Environ
 
-let import senv opac clib univs digest =
+let import senv opac clib univs vmtab digest =
   let senv = Safe_typing.check_flags_for_library clib senv in
   let mb = Safe_typing.module_of_library clib in
   let env = Safe_typing.env_of_safe_env senv in
@@ -19,7 +19,7 @@ let import senv opac clib univs digest =
   let env = push_context_set ~strict:true univs env in
   let env = Modops.add_retroknowledge mb.mod_retroknowledge env in
   let opac = Mod_checking.check_module env opac mb.mod_mp mb in
-  let (_,senv) = Safe_typing.import clib univs digest senv in senv, opac
+  let (_,senv) = Safe_typing.import clib univs vmtab digest senv in senv, opac
 
-let unsafe_import senv clib univs digest =
-  let (_,senv) = Safe_typing.import clib univs digest senv in senv
+let unsafe_import senv clib univs vmtab digest =
+  let (_,senv) = Safe_typing.import clib univs vmtab digest senv in senv

--- a/checker/safe_checking.mli
+++ b/checker/safe_checking.mli
@@ -12,5 +12,5 @@
 open Safe_typing
 (*i*)
 
-val import : safe_environment -> Names.Cset.t Names.Cmap.t -> compiled_library -> Univ.ContextSet.t -> vodigest -> safe_environment * Names.Cset.t Names.Cmap.t
-val unsafe_import : safe_environment -> compiled_library -> Univ.ContextSet.t -> vodigest -> safe_environment
+val import : safe_environment -> Names.Cset.t Names.Cmap.t -> compiled_library -> Univ.ContextSet.t -> Vmlibrary.on_disk -> vodigest -> safe_environment * Names.Cset.t Names.Cmap.t
+val unsafe_import : safe_environment -> compiled_library -> Univ.ContextSet.t -> Vmlibrary.on_disk -> vodigest -> safe_environment

--- a/dev/ci/user-overlays/17674-ppedrot-vm-split-bytecode.sh
+++ b/dev/ci/user-overlays/17674-ppedrot-vm-split-bytecode.sh
@@ -1,0 +1,1 @@
+overlay serapi https://github.com/ppedrot/coq-serapi vm-split-bytecode 17674

--- a/kernel/constant_typing.ml
+++ b/kernel/constant_typing.ml
@@ -158,13 +158,12 @@ let infer_primitive env { prim_entry_type = utyp; prim_entry_content = p; } =
   in
   (* Primitives not allowed in sections (checked in safe_typing) *)
   assert (List.is_empty (named_context env));
-  let tps = Vmbytegen.compile_constant_body ~fail_on_error:false env univs body in
   {
     const_hyps = [];
     const_univ_hyps = Instance.empty;
     const_body = body;
     const_type = typ;
-    const_body_code = tps;
+    const_body_code = ();
     const_universes = univs;
     const_relevance = Sorts.Relevant;
     const_inline_code = false;
@@ -181,7 +180,7 @@ let infer_symbol env { symb_entry_universes; symb_entry_unfold_fix; symb_entry_t
     const_univ_hyps = Instance.empty;
     const_body = Symbol symb_entry_unfold_fix;
     const_type = t;
-    const_body_code = None;
+    const_body_code = ();
     const_universes = univs;
     const_relevance = UVars.subst_sort_level_relevance usubst r;
     const_inline_code = false;
@@ -200,13 +199,12 @@ let infer_parameter ~sec_univs env entry =
   let typ = Vars.subst_univs_level_constr usubst j.uj_val in
   let undef = Undef entry.parameter_entry_inline_code in
   let hyps = used_section_variables env entry.parameter_entry_secctx None typ in
-  let tps = Vmbytegen.compile_constant_body ~fail_on_error:false env univs undef in
   {
     const_hyps = hyps;
     const_univ_hyps = make_univ_hyps sec_univs;
     const_body = undef;
     const_type = typ;
-    const_body_code = tps;
+    const_body_code = ();
     const_universes = univs;
     const_relevance = UVars.subst_sort_level_relevance usubst r;
     const_inline_code = false;
@@ -227,13 +225,12 @@ let infer_definition ~sec_univs env entry =
   let body = Vars.subst_univs_level_constr usubst j.uj_val in
   let def = Def body in
   let hyps = used_section_variables env entry.const_entry_secctx (Some body) typ in
-  let tps = Vmbytegen.compile_constant_body ~fail_on_error:false env univs def in
   {
     const_hyps = hyps;
     const_univ_hyps = make_univ_hyps sec_univs;
     const_body = def;
     const_type = typ;
-    const_body_code = tps;
+    const_body_code = ();
     const_universes = univs;
     const_relevance = Relevanceops.relevance_of_term env body;
     const_inline_code = entry.const_entry_inline_code;
@@ -254,13 +251,12 @@ let infer_opaque ~sec_univs env entry =
   let def = OpaqueDef () in
   let typ = Vars.subst_univs_level_constr usubst typj.utj_val in
   let hyps = used_section_variables env (Some entry.opaque_entry_secctx) None typ in
-  let tps = Vmbytegen.compile_constant_body ~fail_on_error:false env univs def in
   {
     const_hyps = hyps;
     const_univ_hyps = make_univ_hyps sec_univs;
     const_body = def;
     const_type = typ;
-    const_body_code = tps;
+    const_body_code = ();
     const_universes = univs;
     const_relevance = UVars.subst_sort_level_relevance usubst @@ Sorts.relevance_of_sort typj.utj_type;
     const_inline_code = false;

--- a/kernel/constant_typing.mli
+++ b/kernel/constant_typing.mli
@@ -31,10 +31,10 @@ val infer_local_assum : env -> types -> types * Sorts.relevance
 
 val infer_constant :
   sec_univs:UVars.Instance.t option -> env -> constant_entry ->
-    ('a, Vmemitcodes.body_code option) pconstant_body
+    ('a, unit) pconstant_body
 
 val infer_opaque :
   sec_univs:UVars.Instance.t option -> env -> 'a opaque_entry ->
-    (unit, Vmemitcodes.body_code option) pconstant_body * typing_context
+    (unit, unit) pconstant_body * typing_context
 
 val check_delayed : 'a effect_handler -> typing_context -> 'a proof_output -> (Constr.t * Univ.ContextSet.t Opaqueproof.delayed_universes)

--- a/kernel/constant_typing.mli
+++ b/kernel/constant_typing.mli
@@ -31,10 +31,10 @@ val infer_local_assum : env -> types -> types * Sorts.relevance
 
 val infer_constant :
   sec_univs:UVars.Instance.t option -> env -> constant_entry ->
-    'a pconstant_body
+    ('a, Vmemitcodes.body_code option) pconstant_body
 
 val infer_opaque :
   sec_univs:UVars.Instance.t option -> env -> 'a opaque_entry ->
-    unit pconstant_body * typing_context
+    (unit, Vmemitcodes.body_code option) pconstant_body * typing_context
 
 val check_delayed : 'a effect_handler -> typing_context -> 'a proof_output -> (Constr.t * Univ.ContextSet.t Opaqueproof.delayed_universes)

--- a/kernel/declarations.mli
+++ b/kernel/declarations.mli
@@ -104,14 +104,14 @@ type typing_flags = {
 
 (* some contraints are in constant_constraints, some other may be in
  * the OpaqueDef *)
-type 'opaque pconstant_body = {
+type ('opaque, 'bytecode) pconstant_body = {
     const_hyps : Constr.named_context; (** younger hyp at top *)
     const_univ_hyps : UVars.Instance.t;
     const_body : (Constr.t, 'opaque, bool) constant_def;
                     (** [bool] is for [unfold_fix] in symbols *)
     const_type : types;
     const_relevance : Sorts.relevance;
-    const_body_code : Vmemitcodes.body_code option;
+    const_body_code : 'bytecode;
     const_universes : universes;
     const_inline_code : bool;
     const_typing_flags : typing_flags; (** The typing options which
@@ -119,7 +119,7 @@ type 'opaque pconstant_body = {
                                            type-checking. *)
 }
 
-type constant_body = Opaqueproof.opaque pconstant_body
+type constant_body = (Opaqueproof.opaque, Vmemitcodes.body_code option) pconstant_body
 
 (** {6 Representation of mutual inductive types in the kernel } *)
 

--- a/kernel/declarations.mli
+++ b/kernel/declarations.mli
@@ -119,7 +119,7 @@ type ('opaque, 'bytecode) pconstant_body = {
                                            type-checking. *)
 }
 
-type constant_body = (Opaqueproof.opaque, Vmemitcodes.body_code option) pconstant_body
+type constant_body = (Opaqueproof.opaque, Vmlibrary.indirect_code option) pconstant_body
 
 (** {6 Representation of mutual inductive types in the kernel } *)
 

--- a/kernel/declareops.mli
+++ b/kernel/declareops.mli
@@ -30,17 +30,17 @@ val subst_const_body : substitution -> constant_body -> constant_body
 
 (** Is there a actual body in const_body ? *)
 
-val constant_has_body : 'a pconstant_body -> bool
+val constant_has_body : ('a, 'b) pconstant_body -> bool
 
-val constant_polymorphic_context : 'a pconstant_body -> AbstractContext.t
+val constant_polymorphic_context : ('a, 'b) pconstant_body -> AbstractContext.t
 
 (** Is the constant polymorphic? *)
-val constant_is_polymorphic : 'a pconstant_body -> bool
+val constant_is_polymorphic : ('a, 'b) pconstant_body -> bool
 
 (** Return the universe context, in case the definition is polymorphic, otherwise
     the context is empty. *)
 
-val is_opaque : 'a pconstant_body -> bool
+val is_opaque : ('a, 'b) pconstant_body -> bool
 
 (** {6 Inductive types} *)
 
@@ -88,7 +88,7 @@ val safe_flags : Conv_oracle.oracle -> typing_flags
     of the structure, but simply hash-cons all inner constr
     and other known elements *)
 
-val hcons_const_body : 'a pconstant_body -> 'a pconstant_body
+val hcons_const_body : ('a, 'b) pconstant_body -> ('a, 'b) pconstant_body
 val hcons_mind : mutual_inductive_body -> mutual_inductive_body
 val hcons_module_body : module_body -> module_body
 val hcons_module_type : module_type_body -> module_type_body

--- a/kernel/discharge.ml
+++ b/kernel/discharge.ml
@@ -56,7 +56,7 @@ let cook_opaque_proofterm info c =
 (********************************)
 (* Discharging constant         *)
 
-let cook_constant env info cb =
+let cook_constant _env info cb =
   (* Adjust the info so that it is meaningful under the block of quantified universe binders *)
   let info, univ_hyps, univs = lift_univs info cb.const_univ_hyps cb.const_universes in
   let cache = create_cache info in
@@ -69,7 +69,6 @@ let cook_constant env info cb =
   | Primitive _ -> CErrors.anomaly (Pp.str "Primitives cannot be cooked")
   | Symbol _ -> CErrors.anomaly (Pp.str "Symbols cannot be cooked")
   in
-  let tps = Vmbytegen.compile_constant_body ~fail_on_error:false env univs body in
   let typ = abstract_as_type cache cb.const_type in
   let names = names_info info in
   let hyps = List.filter (fun d -> not (Id.Set.mem (NamedDecl.get_id d) names)) cb.const_hyps in
@@ -78,7 +77,7 @@ let cook_constant env info cb =
     const_univ_hyps = univ_hyps;
     const_body = body;
     const_type = typ;
-    const_body_code = tps;
+    const_body_code = ();
     const_universes = univs;
     const_relevance = cb.const_relevance;
     const_inline_code = cb.const_inline_code;

--- a/kernel/discharge.mli
+++ b/kernel/discharge.mli
@@ -16,7 +16,7 @@ val cook_opaque_proofterm : cooking_info list ->
   Opaqueproof.opaque_proofterm -> Opaqueproof.opaque_proofterm
 
 val cook_constant :
-  Environ.env -> cooking_info -> constant_body -> constant_body
+  Environ.env -> cooking_info -> constant_body -> (Opaqueproof.opaque, unit) pconstant_body
 
 val cook_inductive :
   cooking_info -> mutual_inductive_body -> mutual_inductive_body

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -86,6 +86,7 @@ type env = {
   irr_inds : Sorts.relevance Indmap_env.t;
   symb_pats: rewrite_rule list Cmap_env.t;
   env_typing_flags  : typing_flags;
+  vm_library : Vmlibrary.t;
   retroknowledge : Retroknowledge.retroknowledge;
   rewrite_rules_allowed: bool;
 }
@@ -120,6 +121,7 @@ let empty_env = {
   irr_inds = Indmap_env.empty;
   symb_pats = Cmap_env.empty;
   env_typing_flags = Declareops.safe_flags Conv_oracle.empty;
+  vm_library = Vmlibrary.empty;
   retroknowledge = Retroknowledge.empty;
   rewrite_rules_allowed = false;
 }
@@ -946,6 +948,18 @@ let is_type_in_type env r =
   | ConstRef c -> type_in_type_constant c env
   | IndRef ind -> type_in_type_ind ind env
   | ConstructRef cstr -> type_in_type_ind (inductive_of_constructor cstr) env
+
+let vm_library env = env.vm_library
+
+let set_vm_library lib env =
+  { env with vm_library = lib }
+
+let link_vm_library lib env =
+  let vm_library = Vmlibrary.link lib env.vm_library in
+  { env with vm_library }
+
+let lookup_vm_code idx env =
+  Vmlibrary.resolve idx env.vm_library
 
 let set_retroknowledge env r = { env with retroknowledge = r }
 

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -81,6 +81,7 @@ type env = private {
 (** [irr_inds] is a cache of the relevances which are not Relevant. cf [irr_constants]. *);
   symb_pats : rewrite_rule list Cmap_env.t;
   env_typing_flags  : typing_flags;
+  vm_library : Vmlibrary.t;
   retroknowledge : Retroknowledge.retroknowledge;
   rewrite_rules_allowed : bool;
   (** Allow rewrite rules (breaks e.g. SR) *)
@@ -443,6 +444,13 @@ val is_polymorphic : env -> Names.GlobRef.t -> bool
 val is_template_polymorphic : env -> GlobRef.t -> bool
 val get_template_polymorphic_variables : env -> GlobRef.t -> Level.t list
 val is_type_in_type : env -> GlobRef.t -> bool
+
+(** {5 VM and native} *)
+
+val vm_library : env -> Vmlibrary.t
+val set_vm_library : Vmlibrary.t -> env -> env
+val link_vm_library : Vmlibrary.on_disk -> env -> env
+val lookup_vm_code : Vmlibrary.index -> env -> Vmemitcodes.to_patch
 
 (** Native compiler *)
 val no_link_info : link_info

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -60,7 +60,7 @@ let infer_gen_conv_leq state env c1 c2 =
 type with_body = {
   w_def : Constr.t;
   w_univs : universes;
-  w_bytecode : Vmemitcodes.body_code option;
+  w_bytecode : Vmlibrary.indirect_code option;
 }
 
 let rec check_with_def (cst, ustate) env struc (idl, wth) mp reso =
@@ -227,7 +227,7 @@ let rec check_with_mod (cst, ustate) env struc (idl,new_mp) mp reso =
   | Not_found -> error_no_such_label lab mp
   | Conversion.NotConvertible -> error_incorrect_with_constraint lab
 
-type 'a vm_handler = { vm_handler : env -> universes -> Constr.t -> 'a -> 'a * Vmemitcodes.body_code option }
+type 'a vm_handler = { vm_handler : env -> universes -> Constr.t -> 'a -> 'a * Vmlibrary.indirect_code option }
 type 'a vm_state = 'a * 'a vm_handler
 
 let check_with ustate vmstate env mp (sign,reso,cst,vm) = function

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -227,24 +227,27 @@ let rec check_with_mod (cst, ustate) env struc (idl,new_mp) mp reso =
   | Not_found -> error_no_such_label lab mp
   | Conversion.NotConvertible -> error_incorrect_with_constraint lab
 
-let check_with ustate env mp (sign,reso,cst) = function
+type 'a vm_handler = { vm_handler : env -> universes -> Constr.t -> 'a -> 'a * Vmemitcodes.body_code option }
+type 'a vm_state = 'a * 'a vm_handler
+
+let check_with ustate vmstate env mp (sign,reso,cst,vm) = function
   | WithDef(idl, (c, ctx)) ->
     let struc = destr_nofunctor mp sign in
     let univs = match ctx with None -> Monomorphic | Some uctx -> Polymorphic uctx in
-    let bcode = Vmbytegen.compile_constant_body ~fail_on_error:false env univs (Def c) in
+    let vm, bcode = vmstate.vm_handler env univs c vm in
     let body = { w_def = c; w_univs = univs; w_bytecode = bcode } in
     let struc', cst = check_with_def (cst, ustate) env struc (idl, body) mp reso in
-    NoFunctor struc', reso, cst
+    NoFunctor struc', reso, cst, vm
   | WithMod(idl,new_mp) ->
     let struc = destr_nofunctor mp sign in
     let struc',reso',cst = check_with_mod (cst, ustate) env struc (idl,new_mp) mp reso in
-    NoFunctor struc', reso', cst
+    NoFunctor struc', reso', cst, vm
 
-let check_with_alg ustate env mp (sign,alg,reso,cst) wd =
-  let struc, reso, cst = check_with ustate env mp (sign, reso, cst) wd in
-  struc, MEwith (alg, wd), reso, cst
+let check_with_alg ustate vmstate env mp (sign, alg, reso, cst, vm) wd =
+  let struc, reso, cst, vm = check_with ustate vmstate env mp (sign, reso, cst, vm) wd in
+  struc, MEwith (alg, wd), reso, cst, vm
 
-let translate_apply ustate env inl (sign,alg,reso,cst) mp1 mkalg =
+let translate_apply ustate env inl (sign,alg,reso,cst,vm) mp1 mkalg =
   let farg_id, farg_b, fbody_b = destr_functor sign in
   let mtb = module_type_of_module (lookup_module mp1 env) in
   let cst = Subtyping.check_subtypes (cst, ustate) env mtb farg_b in
@@ -254,7 +257,7 @@ let translate_apply ustate env inl (sign,alg,reso,cst) mp1 mkalg =
   let body = subst_signature subst fbody_b in
   let alg' = mkalg alg mp1 in
   let reso' = subst_codom_delta_resolver subst reso in
-  body, alg', reso', cst
+  body, alg', reso', cst, vm
 
 (** Translation of a module struct entry :
     - We translate to a module when a [module_path] is given,
@@ -265,7 +268,7 @@ let translate_apply ustate env inl (sign,alg,reso,cst) mp1 mkalg =
 
 let mk_alg_app alg arg = MEapply (alg,arg)
 
-let rec translate_mse (cst, ustate) env mpo inl = function
+let rec translate_mse (cst, ustate) (vm, vmstate) env mpo inl = function
   | MEident mp1 as me ->
     let mb = match mpo with
       | Some mp -> strengthen_and_subst_module_body (lookup_module mp1 env) mp false
@@ -273,13 +276,13 @@ let rec translate_mse (cst, ustate) env mpo inl = function
         let mt = lookup_modtype mp1 env in
         module_body_of_type mt.mod_mp mt
     in
-    mb.mod_type, me, mb.mod_delta, cst
+    mb.mod_type, me, mb.mod_delta, cst, vm
   | MEapply (fe,mp1) ->
-    translate_apply ustate env inl (translate_mse (cst, ustate) env mpo inl fe) mp1 mk_alg_app
+    translate_apply ustate env inl (translate_mse (cst, ustate) (vm, vmstate) env mpo inl fe) mp1 mk_alg_app
   |MEwith(me, with_decl) ->
     assert (Option.is_empty mpo); (* No 'with' syntax for modules *)
     let mp = mp_from_mexpr me in
-    check_with_alg ustate env mp (translate_mse (cst, ustate) env None inl me) with_decl
+    check_with_alg ustate vmstate env mp (translate_mse (cst, ustate) (vm, vmstate) env None inl me) with_decl
 
 let mk_mod mp e ty reso =
   { mod_mp = mp;
@@ -293,36 +296,36 @@ let mk_modtype mp ty reso =
   let mb = mk_mod mp Abstract ty reso in
   { mb with mod_expr = (); mod_retroknowledge = ModTypeRK }
 
-let rec translate_mse_funct (cst, ustate) env ~is_mod mp inl mse = function
+let rec translate_mse_funct (cst, ustate) (vm, vmstate) env ~is_mod mp inl mse = function
   |[] ->
-    let sign,alg,reso,cst = translate_mse (cst, ustate) env (if is_mod then Some mp else None) inl mse in
+    let sign,alg,reso,cst,vm = translate_mse (cst, ustate) (vm, vmstate) env (if is_mod then Some mp else None) inl mse in
     let sign,reso =
       if is_mod then sign,reso
       else subst_modtype_signature_and_resolver (mp_from_mexpr mse) mp sign reso in
-    sign, MENoFunctor alg, reso, cst
+    sign, MENoFunctor alg, reso, cst, vm
   |(mbid, ty, ty_inl) :: params ->
     let mp_id = MPbound mbid in
-    let mtb, cst = translate_modtype (cst, ustate) env mp_id ty_inl ([],ty) in
+    let mtb, cst, vm = translate_modtype (cst, ustate) (vm, vmstate) env mp_id ty_inl ([],ty) in
     let env' = add_module_type mp_id mtb env in
-    let sign,alg,reso,cst = translate_mse_funct (cst, ustate) env' ~is_mod mp inl mse params in
+    let sign,alg,reso,cst,vm = translate_mse_funct (cst, ustate) (vm, vmstate) env' ~is_mod mp inl mse params in
     let alg' = MEMoreFunctor alg in
-    MoreFunctor (mbid, mtb, sign), alg',reso, cst
+    MoreFunctor (mbid, mtb, sign), alg',reso, cst, vm
 
-and translate_modtype state env mp inl (params,mte) =
-  let sign,alg,reso,cst = translate_mse_funct state env ~is_mod:false mp inl mte params in
+and translate_modtype state vmstate env mp inl (params,mte) =
+  let sign,alg,reso,cst,vm = translate_mse_funct state vmstate env ~is_mod:false mp inl mte params in
   let mtb = mk_modtype mp sign reso in
-  { mtb with mod_type_alg = Some alg }, cst
+  { mtb with mod_type_alg = Some alg }, cst, vm
 
 (** [finalize_module] :
     from an already-translated (or interactive) implementation and
     an (optional) signature entry, produces a final [module_body] *)
 
-let finalize_module_alg (cst, ustate) env mp (sign,alg,reso) restype = match restype with
+let finalize_module_alg (cst, ustate) (vm, vmstate) env mp (sign,alg,reso) restype = match restype with
   | None ->
     let impl = match alg with Some e -> Algebraic e | None -> FullStruct in
-    mk_mod mp impl sign reso, cst
+    mk_mod mp impl sign reso, cst, vm
   | Some (params_mte,inl) ->
-    let res_mtb, cst = translate_modtype (cst, ustate) env mp inl params_mte in
+    let res_mtb, cst, vm = translate_modtype (cst, ustate) (vm, vmstate) env mp inl params_mte in
     let auto_mtb = mk_modtype mp sign reso in
     let cst = Subtyping.check_subtypes (cst, ustate) env auto_mtb res_mtb in
     let impl = match alg with
@@ -340,19 +343,20 @@ let finalize_module_alg (cst, ustate) env mp (sign,alg,reso) restype = match res
       mod_retroknowledge = ModBodyRK [];
     },
     (** constraints from module body typing + subtyping + module type. *)
-    cst
+    cst,
+    vm
 
-let finalize_module univs env mp (sign, reso) typ =
-  finalize_module_alg univs env mp (sign, None, reso) typ
+let finalize_module univs vm env mp (sign, reso) typ =
+  finalize_module_alg univs vm env mp (sign, None, reso) typ
 
-let translate_module (cst, ustate) env mp inl = function
+let translate_module (cst, ustate) (vm, vmstate) env mp inl = function
   | MType (params,ty) ->
-    let mtb, cst = translate_modtype (cst, ustate) env mp inl (params,ty) in
-    module_body_of_type mp mtb, cst
+    let mtb, cst, vm = translate_modtype (cst, ustate) (vm, vmstate) env mp inl (params,ty) in
+    module_body_of_type mp mtb, cst, vm
   |MExpr (params,mse,oty) ->
-    let (sg,alg,reso,cst) = translate_mse_funct (cst, ustate) env ~is_mod:true mp inl mse params in
+    let (sg,alg,reso,cst,vm) = translate_mse_funct (cst, ustate) (vm, vmstate) env ~is_mod:true mp inl mse params in
     let restype = Option.map (fun ty -> ((params,ty),inl)) oty in
-    finalize_module_alg (cst, ustate) env mp (sg,Some alg,reso) restype
+    finalize_module_alg (cst, ustate) (vm, vmstate) env mp (sg,Some alg,reso) restype
 
 (** We now forbid any Include of functors with restricted signatures.
     Otherwise, we could end with the creation of undesired axioms
@@ -377,21 +381,21 @@ let rec forbid_incl_signed_functor env = function
       forbid_incl_signed_functor env (unfunct me)
     |_ -> ()
 
-let rec translate_mse_include_module (cst, ustate) env mp inl = function
+let rec translate_mse_include_module (cst, ustate) (vm, vmstate) env mp inl = function
   | MEident mp1 ->
     let mb = strengthen_and_subst_module_body (lookup_module mp1 env) mp true in
     let sign = clean_bounded_mod_expr mb.mod_type in
-    sign,(),mb.mod_delta,cst
+    sign,(),mb.mod_delta,cst,vm
   | MEapply (fe,arg) ->
-    let ftrans = translate_mse_include_module (cst, ustate) env mp inl fe in
+    let ftrans = translate_mse_include_module (cst, ustate) (vm, vmstate) env mp inl fe in
     translate_apply ustate env inl ftrans arg (fun _ _ -> ())
   | MEwith _ -> assert false (* No 'with' syntax for modules *)
 
-let translate_mse_include is_mod (cst, ustate) env mp inl me =
+let translate_mse_include is_mod (cst, ustate) (vm, vmstate) env mp inl me =
   if is_mod then
     let () = forbid_incl_signed_functor env me in
-    translate_mse_include_module (cst, ustate) env mp inl me
+    translate_mse_include_module (cst, ustate) (vm, vmstate) env mp inl me
   else
-    let mtb, cst = translate_modtype (cst, ustate) env mp inl ([],me) in
+    let mtb, cst, vm = translate_modtype (cst, ustate) (vm, vmstate) env mp inl ([],me) in
     let sign = clean_bounded_mod_expr mtb.mod_type in
-    sign, (), mtb.mod_delta, cst
+    sign, (), mtb.mod_delta, cst, vm

--- a/kernel/mod_typing.mli
+++ b/kernel/mod_typing.mli
@@ -16,6 +16,9 @@ open Names
 
 (** Main functions for translating module entries *)
 
+type 'a vm_handler = { vm_handler : env -> universes -> Constr.t -> 'a -> 'a * Vmemitcodes.body_code option }
+type 'a vm_state = 'a * 'a vm_handler
+
 (** [translate_module] produces a [module_body] out of a [module_entry].
     In the output fields:
     - [mod_expr] is [Abstract] for a [MType] entry, or [Algebraic] for [MExpr].
@@ -24,27 +27,30 @@ open Names
 
 val translate_module :
   'a Conversion.universe_state ->
-  env -> ModPath.t -> inline -> module_entry -> module_body * 'a
+  'b vm_state ->
+  env -> ModPath.t -> inline -> module_entry -> module_body * 'a * 'b
 
 (** [translate_modtype] produces a [module_type_body] whose [mod_type_alg]
     cannot be [None] (and of course [mod_expr] is [Abstract]). *)
 
 val translate_modtype :
   'a Conversion.universe_state ->
-  env -> ModPath.t -> inline -> module_type_entry -> module_type_body * 'a
+  'b vm_state ->
+  env -> ModPath.t -> inline -> module_type_entry -> module_type_body * 'a * 'b
 
 (** From an already-translated (or interactive) implementation and
     an (optional) signature entry, produces a final [module_body] *)
 
 val finalize_module :
   'a Conversion.universe_state ->
+  'b vm_state ->
   env -> ModPath.t -> module_signature * delta_resolver ->
   (module_type_entry * inline) option ->
-  module_body * 'a
+  module_body * 'a * 'b
 
 (** [translate_mse_incl] translate the mse of a module or
     module type given to an Include *)
 
 val translate_mse_include :
-  bool -> 'a Conversion.universe_state -> Environ.env -> ModPath.t -> inline ->
-  module_struct_entry -> module_signature * unit * delta_resolver * 'a
+  bool -> 'a Conversion.universe_state -> 'b vm_state -> Environ.env -> ModPath.t -> inline ->
+  module_struct_entry -> module_signature * unit * delta_resolver * 'a * 'b

--- a/kernel/mod_typing.mli
+++ b/kernel/mod_typing.mli
@@ -16,7 +16,7 @@ open Names
 
 (** Main functions for translating module entries *)
 
-type 'a vm_handler = { vm_handler : env -> universes -> Constr.t -> 'a -> 'a * Vmemitcodes.body_code option }
+type 'a vm_handler = { vm_handler : env -> universes -> Constr.t -> 'a -> 'a * Vmlibrary.indirect_code option }
 type 'a vm_state = 'a * 'a vm_handler
 
 (** [translate_module] produces a [module_body] out of a [module_entry].

--- a/kernel/nativecode.mli
+++ b/kernel/nativecode.mli
@@ -62,7 +62,7 @@ val register_native_file : string -> unit
 val is_loaded_native_file : string -> bool
 
 val compile_constant_field : env -> Constant.t ->
-  global list -> 'a pconstant_body -> global list
+  global list -> ('a, 'b) pconstant_body -> global list
 
 val compile_mind_field : ModPath.t -> Label.t ->
   global list -> mutual_inductive_body -> global list

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -333,7 +333,7 @@ end
 type side_effect = {
   seff_certif : Certificate.t CEphemeron.key;
   seff_constant : Constant.t;
-  seff_body : Constr.t Declarations.pconstant_body;
+  seff_body : (Constr.t, Vmemitcodes.body_code option) Declarations.pconstant_body;
   seff_univs : Univ.ContextSet.t;
 }
 (* Invariant: For any senv, if [Certificate.check senv seff_certif] then

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -242,7 +242,7 @@ val start_library : DirPath.t -> ModPath.t safe_transformer
 val export :
   output_native_objects:bool ->
   safe_environment -> DirPath.t ->
-    ModPath.t * compiled_library * Vmlibrary.on_disk * Nativelib.native_library
+    ModPath.t * compiled_library * Vmlibrary.compiled_library * Nativelib.native_library
 
 (* Constraints are non empty iff the file is a vi2vo *)
 val import : compiled_library -> Univ.ContextSet.t -> Vmlibrary.on_disk -> vodigest ->

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -242,10 +242,10 @@ val start_library : DirPath.t -> ModPath.t safe_transformer
 val export :
   output_native_objects:bool ->
   safe_environment -> DirPath.t ->
-    ModPath.t * compiled_library * Nativelib.native_library
+    ModPath.t * compiled_library * Vmlibrary.on_disk * Nativelib.native_library
 
 (* Constraints are non empty iff the file is a vi2vo *)
-val import : compiled_library -> Univ.ContextSet.t -> vodigest ->
+val import : compiled_library -> Univ.ContextSet.t -> Vmlibrary.on_disk -> vodigest ->
   ModPath.t safe_transformer
 
 (** {6 Safe typing judgments } *)

--- a/kernel/vmbytegen.ml
+++ b/kernel/vmbytegen.ml
@@ -926,7 +926,7 @@ let compile ?universes:(universes=(0,0)) env sigma c =
     (if !dump_bytecode then
       Feedback.msg_debug (dump_bytecodes init_code fun_code fv)) ;
     let res = init_code @ fun_code in
-    (to_memory res, Array.of_list fv)
+    to_memory (Array.of_list fv) res
 
 let warn_compile_error =
   CWarnings.create ~name:"bytecode-compiler-failed-compilation" ~category:CWarnings.CoreCategories.bytecode_compiler
@@ -964,7 +964,7 @@ let compile_constant_body ~fail_on_error env univs = function
       | Some kn -> Some (BCalias kn)
       | _ ->
           let res = compile ~fail_on_error ~universes:instance_size env (empty_evars env) body in
-          Option.map (fun (code, fv) -> BCdefined (code, fv)) res
+          Option.map (fun code -> BCdefined code) res
 
 (* Shortcut of the previous function used during module strengthening *)
 

--- a/kernel/vmbytegen.mli
+++ b/kernel/vmbytegen.mli
@@ -25,7 +25,7 @@ val compile_constant_body : fail_on_error:bool ->
 
 (** Shortcut of the previous function used during module strengthening *)
 
-val compile_alias : Names.Constant.t -> body_code
+val compile_alias : Names.Constant.t -> 'a pbody_code
 
 (** Dump the bytecode after compilation (for debugging purposes) *)
 val dump_bytecode : bool ref

--- a/kernel/vmbytegen.mli
+++ b/kernel/vmbytegen.mli
@@ -8,7 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open Vmbytecodes
 open Vmemitcodes
 open Constr
 open Declarations
@@ -18,8 +17,7 @@ open Environ
 val compile :
   fail_on_error:bool -> ?universes:int*int ->
   env -> Genlambda.evars -> constr ->
-  (to_patch * fv) option
-(** init, fun, fv *)
+  (to_patch * patches) option
 
 val compile_constant_body : fail_on_error:bool ->
   env -> universes -> (Constr.t, 'opaque, 'symb) constant_def ->

--- a/kernel/vmemitcodes.mli
+++ b/kernel/vmemitcodes.mli
@@ -18,15 +18,17 @@ type reloc_info =
   | Reloc_caml_prim of caml_prim
 
 type to_patch
+type patches
 
-val patch : to_patch -> (reloc_info -> int) -> Vmvalues.tcode
+val patch : (to_patch * patches) -> (reloc_info -> int) -> Vmvalues.tcode * fv
 
-type body_code =
-  | BCdefined of to_patch * fv
+type 'a pbody_code =
+  | BCdefined of ('a * patches)
   | BCalias of Constant.t
   | BCconstant
 
+type body_code = to_patch pbody_code
 
 val subst_body_code : Mod_subst.substitution -> body_code -> body_code
 
-val to_memory : bytecodes -> to_patch
+val to_memory : fv -> bytecodes -> to_patch * patches

--- a/kernel/vmlibrary.ml
+++ b/kernel/vmlibrary.ml
@@ -1,0 +1,92 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Names
+open Vmemitcodes
+
+module VmTable =
+struct
+
+type t = {
+  table_len : int;
+  table_dir : DirPath.t;
+  table_val : to_patch Int.Map.t;
+}
+
+type index = DirPath.t * int
+
+let empty = {
+  table_len = 0;
+  table_dir = DirPath.dummy;
+  table_val = Int.Map.empty;
+}
+
+let set_path dp tab =
+  let () = assert (DirPath.equal tab.table_dir DirPath.dummy) in
+  { tab with table_dir = dp }
+
+let create code tab =
+  let id = tab.table_len in
+  let dp = tab.table_dir in
+  let () = assert (not @@ DirPath.equal dp DirPath.dummy) in
+  let table_val = Int.Map.add id code tab.table_val in
+  let ntab = { table_dir = dp; table_len = id + 1; table_val } in
+  ntab, (dp, id)
+
+end
+
+type t = {
+  local : VmTable.t;
+  foreign : VmTable.t DPmap.t;
+}
+
+type index = VmTable.index
+
+type indirect_code = VmTable.index pbody_code
+
+type on_disk = VmTable.t
+
+let empty = {
+  local = VmTable.empty;
+  foreign = DPmap.empty;
+}
+
+let set_path dp lib =
+  let local = VmTable.set_path dp lib.local in
+  { lib with local }
+
+let add code lib =
+  let tab, idx = VmTable.create code lib.local in
+  let lib = { lib with local = tab } in
+  lib, idx
+
+let link m libs =
+  let dp = m.VmTable.table_dir in
+  let () = assert (not @@ DPmap.mem dp libs.foreign) in
+  { libs with foreign = DPmap.add dp m libs.foreign }
+
+let resolve (dp, i) libs =
+  let tab =
+    if DirPath.equal dp libs.local.VmTable.table_dir then
+      libs.local
+    else match DPmap.find dp libs.foreign with
+    | tab -> tab
+    | exception Not_found ->
+      CErrors.anomaly Pp.(str "Missing VM table for library " ++
+        DirPath.print dp)
+  in
+  match Int.Map.find i tab.VmTable.table_val with
+  | v -> v
+  | exception Not_found ->
+    CErrors.anomaly Pp.(str "Missing VM index " ++ int i ++
+      str " in library " ++ DirPath.print dp)
+
+let export lib =
+  lib.local

--- a/kernel/vmlibrary.mli
+++ b/kernel/vmlibrary.mli
@@ -7,28 +7,27 @@
 (*         *     GNU Lesser General Public License Version 2.1          *)
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
+
 open Names
-open Vmvalues
-open Vmbytecodes
+open Vmemitcodes
 
-type reloc_info =
-  | Reloc_annot of annot_switch
-  | Reloc_const of structured_constant
-  | Reloc_getglobal of Constant.t
-  | Reloc_caml_prim of caml_prim
+type t
+(** Type of VM libraries. *)
 
-type to_patch
-type patches
+type index
 
-val patch : (to_patch * patches) -> (reloc_info -> int) -> Vmvalues.tcode * fv
+type indirect_code = index pbody_code
 
-type 'a pbody_code =
-  | BCdefined of ('a * patches)
-  | BCalias of Constant.t
-  | BCconstant
+type on_disk
 
-type body_code = to_patch pbody_code
+val empty : t
 
-val subst_body_code : Mod_subst.substitution -> 'a pbody_code -> 'a pbody_code
+val set_path : DirPath.t -> t -> t
 
-val to_memory : fv -> bytecodes -> to_patch * patches
+val add : to_patch -> t -> t * index
+
+val link : on_disk -> t -> t
+
+val resolve : index -> t -> to_patch
+
+val export : t -> on_disk

--- a/kernel/vmlibrary.mli
+++ b/kernel/vmlibrary.mli
@@ -18,7 +18,10 @@ type index
 
 type indirect_code = index pbody_code
 
+type compiled_library
 type on_disk
+
+val vm_segment : compiled_library ObjFile.id
 
 val empty : t
 
@@ -26,8 +29,12 @@ val set_path : DirPath.t -> t -> t
 
 val add : to_patch -> t -> t * index
 
+val load : DirPath.t -> file:string -> ObjFile.in_handle -> on_disk
+
 val link : on_disk -> t -> t
+
+val inject : compiled_library -> on_disk
 
 val resolve : index -> t -> to_patch
 
-val export : t -> on_disk
+val export : t -> compiled_library

--- a/kernel/vmsymtable.ml
+++ b/kernel/vmsymtable.ml
@@ -263,7 +263,9 @@ let rec slot_for_getglobal env sigma kn envcache table =
       | None -> set_global (val_of_constant kn) table
       | Some code ->
         match code with
-        | BCdefined code ->
+        | BCdefined (index, patches) ->
+           let code = Environ.lookup_vm_code index env in
+           let code = (code, patches) in
            let v = eval_to_patch env sigma code envcache table in
            set_global v table
         | BCalias kn' -> slot_for_getglobal env sigma kn' envcache table

--- a/kernel/vmsymtable.ml
+++ b/kernel/vmsymtable.ml
@@ -263,8 +263,8 @@ let rec slot_for_getglobal env sigma kn envcache table =
       | None -> set_global (val_of_constant kn) table
       | Some code ->
         match code with
-        | BCdefined (code, fv) ->
-           let v = eval_to_patch env sigma (code, fv) envcache table in
+        | BCdefined code ->
+           let v = eval_to_patch env sigma code envcache table in
            set_global v table
         | BCalias kn' -> slot_for_getglobal env sigma kn' envcache table
         | BCconstant -> set_global (val_of_constant kn) table
@@ -299,14 +299,14 @@ and slot_for_fv env sigma fv envcache table =
       | Some v -> v
       end
 
-and eval_to_patch env sigma (code, fv) envcache table =
+and eval_to_patch env sigma code envcache table =
   let slots = function
     | Reloc_annot a -> slot_for_annot a table
     | Reloc_const sc -> slot_for_str_cst sc table
     | Reloc_getglobal kn -> slot_for_getglobal env sigma kn envcache table
     | Reloc_caml_prim op -> slot_for_caml_prim op table
   in
-  let tc = patch code slots in
+  let tc, fv = patch code slots in
   let vm_env =
     (* Environment should look like a closure, so free variables start at slot 2. *)
     let a = Array.make (Array.length fv + 2) crazy_val in

--- a/library/global.ml
+++ b/library/global.ml
@@ -181,7 +181,7 @@ let mind_of_delta_kn kn =
 let start_library dir = globalize (Safe_typing.start_library dir)
 let export ~output_native_objects s =
   Safe_typing.export ~output_native_objects (safe_env ()) s
-let import c u d = globalize (Safe_typing.import c u d)
+let import c u t d = globalize (Safe_typing.import c u t d)
 
 
 (** Function to get an environment from the constants part of the global

--- a/library/global.mli
+++ b/library/global.mli
@@ -142,7 +142,7 @@ val body_of_constant_body : indirect_accessor ->
 
 val start_library : DirPath.t -> ModPath.t
 val export : output_native_objects:bool -> DirPath.t ->
-  ModPath.t * Safe_typing.compiled_library * Vmlibrary.on_disk * Nativelib.native_library
+  ModPath.t * Safe_typing.compiled_library * Vmlibrary.compiled_library * Nativelib.native_library
 val import :
   Safe_typing.compiled_library -> Univ.ContextSet.t -> Vmlibrary.on_disk -> Safe_typing.vodigest ->
   ModPath.t

--- a/library/global.mli
+++ b/library/global.mli
@@ -142,9 +142,9 @@ val body_of_constant_body : indirect_accessor ->
 
 val start_library : DirPath.t -> ModPath.t
 val export : output_native_objects:bool -> DirPath.t ->
-  ModPath.t * Safe_typing.compiled_library * Nativelib.native_library
+  ModPath.t * Safe_typing.compiled_library * Vmlibrary.on_disk * Nativelib.native_library
 val import :
-  Safe_typing.compiled_library -> Univ.ContextSet.t -> Safe_typing.vodigest ->
+  Safe_typing.compiled_library -> Univ.ContextSet.t -> Vmlibrary.on_disk -> Safe_typing.vodigest ->
   ModPath.t
 
 (** {6 Misc } *)

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -158,16 +158,21 @@ let factor_fix env sg l cb msb =
     (hack proposed by Elie)
 *)
 
+let vm_state =
+  (* VM bytecode is not needed here *)
+  let vm_handler _ _ _ () = (), None in
+  ((), { Mod_typing.vm_handler })
+
 let expand_mexpr env mp me =
   let inl = Some (Flags.get_inline_level()) in
   let state = ((Environ.universes env, Univ.Constraints.empty), Reductionops.inferred_universes) in
-  let mb, (_, cst) = Mod_typing.translate_module state env mp inl (MExpr ([], me, None)) in
+  let mb, (_, cst), _ = Mod_typing.translate_module state vm_state env mp inl (MExpr ([], me, None)) in
   mb.mod_type, mb.mod_delta
 
 let expand_modtype env mp me =
   let inl = Some (Flags.get_inline_level()) in
   let state = ((Environ.universes env, Univ.Constraints.empty), Reductionops.inferred_universes) in
-  let mtb, _cst = Mod_typing.translate_modtype state env mp inl ([],me) in
+  let mtb, _cst, _ = Mod_typing.translate_modtype state vm_state env mp inl ([],me) in
   mtb
 
 let no_delta = Mod_subst.empty_delta_resolver

--- a/plugins/extraction/extraction.mli
+++ b/plugins/extraction/extraction.mli
@@ -18,7 +18,7 @@ open Miniml
 
 val extract_constant : env -> Constant.t -> constant_body -> ml_decl
 
-val extract_constant_spec : env -> Constant.t -> 'a pconstant_body -> ml_spec
+val extract_constant_spec : env -> Constant.t -> ('a, 'b) pconstant_body -> ml_spec
 
 (** For extracting "module ... with ..." declaration *)
 

--- a/stm/vio_checking.ml
+++ b/stm/vio_checking.ml
@@ -11,7 +11,7 @@
 open Util
 
 let check_vio (ts,f_in) =
-  let _, _, _, tasks, _ = Library.load_library_todo f_in in
+  let _, _, _, tasks, _, _ = Library.load_library_todo f_in in
   Stm.set_compilation_hints f_in;
   List.fold_left (fun acc ids -> Stm.check_task f_in tasks ids && acc) true ts
 
@@ -28,7 +28,7 @@ let schedule_vio_checking j fs =
   if j < 1 then CErrors.user_err Pp.(str "The number of workers must be bigger than 0");
   let jobs = ref [] in
   List.iter (fun long_f_dot_vio ->
-    let _,_,_, tasks, _ = Library.load_library_todo long_f_dot_vio in
+    let _,_,_, tasks, _, _ = Library.load_library_todo long_f_dot_vio in
     Stm.set_compilation_hints long_f_dot_vio;
     let infos = Stm.info_tasks tasks in
     let eta = List.fold_left (fun a (_,t,_) -> a +. t) 0.0 infos in

--- a/topbin/coqnative_bin.ml
+++ b/topbin/coqnative_bin.ml
@@ -111,6 +111,7 @@ type library_t = {
   library_deps : (compilation_unit_name * Safe_typing.vodigest) array;
   library_digests : Safe_typing.vodigest;
   library_extra_univs : Univ.ContextSet.t;
+  library_vm : Vmlibrary.on_disk;
 }
 
 let libraries_table : string DPmap.t ref = ref DPmap.empty
@@ -122,7 +123,7 @@ let register_loaded_library senv libname file =
   let () = Nativecode.register_native_file prefix in
   senv
 
-let mk_library sd f md digests univs =
+let mk_library sd f md digests univs vm =
   {
     library_name     = sd.md_name;
     library_file     = f;
@@ -130,26 +131,29 @@ let mk_library sd f md digests univs =
     library_deps     = sd.md_deps;
     library_digests  = digests;
     library_extra_univs = univs;
+    library_vm = vm;
   }
 
 let summary_seg : summary_disk ObjFile.id = ObjFile.make_id "summary"
 let library_seg : library_disk ObjFile.id = ObjFile.make_id "library"
 let universes_seg : (Univ.ContextSet.t * bool) option ObjFile.id = ObjFile.make_id "universes"
+let vm_seg : Vmlibrary.on_disk ObjFile.id = ObjFile.make_id "vmlibrary"
 
 let intern_from_file f =
   let ch = System.with_magic_number_check (fun file -> ObjFile.open_in ~file) f in
   let lsd, digest_lsd = ObjFile.marshal_in_segment ch ~segment:summary_seg in
   let lmd, digest_lmd = ObjFile.marshal_in_segment ch ~segment:library_seg in
   let univs, digest_u = ObjFile.marshal_in_segment ch ~segment:universes_seg in
+  let vmlib, _digest_vm = ObjFile.marshal_in_segment ch ~segment:vm_seg in
   ObjFile.close_in ch;
   System.check_caml_version ~caml:lsd.md_ocaml ~file:f;
   let open Safe_typing in
   match univs with
-  | None -> mk_library lsd f lmd.md_compiled (Dvo_or_vi digest_lmd) Univ.ContextSet.empty
+  | None -> mk_library lsd f lmd.md_compiled (Dvo_or_vi digest_lmd) Univ.ContextSet.empty vmlib
   | Some (uall,true) ->
-      mk_library lsd f lmd.md_compiled (Dvivo (digest_lmd,digest_u)) uall
+      mk_library lsd f lmd.md_compiled (Dvivo (digest_lmd,digest_u)) uall vmlib
   | Some (_,false) ->
-      mk_library lsd f lmd.md_compiled (Dvo_or_vi digest_lmd) Univ.ContextSet.empty
+      mk_library lsd f lmd.md_compiled (Dvo_or_vi digest_lmd) Univ.ContextSet.empty vmlib
 
 let rec intern_library (needed, contents) dir =
   (* Look if already listed and consequently its dependencies too *)
@@ -179,7 +183,7 @@ and intern_mandatory_library caller from libs (dir,d) =
 
 let register_library senv m =
   let mp = MPfile m.library_name in
-  let mp', senv = Safe_typing.import m.library_data m.library_extra_univs m.library_digests senv in
+  let mp', senv = Safe_typing.import m.library_data m.library_extra_univs m.library_vm m.library_digests senv in
   let () =
     if not (ModPath.equal mp mp') then
       anomaly (Pp.str "Unexpected disk module name.")

--- a/topbin/coqnative_bin.ml
+++ b/topbin/coqnative_bin.ml
@@ -137,14 +137,13 @@ let mk_library sd f md digests univs vm =
 let summary_seg : summary_disk ObjFile.id = ObjFile.make_id "summary"
 let library_seg : library_disk ObjFile.id = ObjFile.make_id "library"
 let universes_seg : (Univ.ContextSet.t * bool) option ObjFile.id = ObjFile.make_id "universes"
-let vm_seg : Vmlibrary.on_disk ObjFile.id = ObjFile.make_id "vmlibrary"
 
 let intern_from_file f =
   let ch = System.with_magic_number_check (fun file -> ObjFile.open_in ~file) f in
   let lsd, digest_lsd = ObjFile.marshal_in_segment ch ~segment:summary_seg in
   let lmd, digest_lmd = ObjFile.marshal_in_segment ch ~segment:library_seg in
   let univs, digest_u = ObjFile.marshal_in_segment ch ~segment:universes_seg in
-  let vmlib, _digest_vm = ObjFile.marshal_in_segment ch ~segment:vm_seg in
+  let vmlib = Vmlibrary.load ~file:f lsd.md_name ch in
   ObjFile.close_in ch;
   System.check_caml_version ~caml:lsd.md_ocaml ~file:f;
   let open Safe_typing in

--- a/toplevel/ccompile.ml
+++ b/toplevel/ccompile.ml
@@ -113,10 +113,10 @@ let compile opts stm_options injections copts ~echo ~f_in ~f_out =
 
   | Vio2Vo ->
       Flags.async_proofs_worker_id := "Vio2Vo";
-      let sum, lib, univs, tasks, proofs =
+      let sum, lib, univs, tasks, proofs, vmlib =
         Library.load_library_todo long_f_dot_in in
       let univs, proofs = Stm.finish_tasks long_f_dot_out univs proofs tasks in
-      Library.save_library_raw long_f_dot_out sum lib univs proofs;
+      Library.save_library_raw long_f_dot_out sum lib univs proofs vmlib;
       (* Like in direct .vo production, dump an empty .vok file and an empty .vos file. *)
       dump_empty_vos();
       create_empty_file (long_f_dot_out ^ "k")

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -1547,7 +1547,7 @@ let declare_include me_asts =
   RawIncludeOps.Interp.declare_include me_asts
 
 (** For the native compiler, we cache the library values *)
-let register_library dir cenv (objs:library_objects) digest univ =
+let register_library dir cenv (objs:library_objects) digest univ vmtab =
   let mp = MPfile dir in
   let () =
     try
@@ -1556,7 +1556,7 @@ let register_library dir cenv (objs:library_objects) digest univ =
     with Not_found ->
       begin
       (* If not, let's do it now ... *)
-      let mp' = Global.import cenv univ digest in
+      let mp' = Global.import cenv univ vmtab digest in
       if not (ModPath.equal mp mp') then
         anomaly (Pp.str "Unexpected disk module name.")
       end
@@ -1588,11 +1588,11 @@ let end_library_hook () =
 let end_library ~output_native_objects dir =
   end_library_hook();
   let prefix, info, lib_stack, lib_stack_syntax = Lib.end_compilation dir in
-  let mp,cenv,ast = Global.export ~output_native_objects dir in
+  let mp,cenv,vmlib,ast = Global.export ~output_native_objects dir in
   assert (ModPath.equal mp (MPfile dir));
   let {Lib.Interp.substobjs = substitute; keepobjs = keep; anticipateobjs = _; } = lib_stack in
   let {Lib.Synterp.substobjs = substitute_syntax; keepobjs = keep_syntax; anticipateobjs = _; } = lib_stack_syntax in
-  cenv,(substitute,keep),(substitute_syntax,keep_syntax),ast,info
+  cenv,(substitute,keep),(substitute_syntax,keep_syntax),vmlib,ast,info
 
 (** {6 Iterators} *)
 

--- a/vernac/declaremods.mli
+++ b/vernac/declaremods.mli
@@ -155,7 +155,7 @@ val start_library : library_name -> unit
 
 val end_library :
   output_native_objects:bool -> library_name ->
-  Safe_typing.compiled_library * library_objects * library_objects * Vmlibrary.on_disk * Nativelib.native_library * Library_info.t
+  Safe_typing.compiled_library * library_objects * library_objects * Vmlibrary.compiled_library * Nativelib.native_library * Library_info.t
 
 (** append a function to be executed at end_library *)
 val append_end_library_hook : (unit -> unit) -> unit

--- a/vernac/declaremods.mli
+++ b/vernac/declaremods.mli
@@ -130,7 +130,7 @@ val end_modtype : unit -> ModPath.t
 val register_library :
   library_name ->
   Safe_typing.compiled_library -> library_objects -> Safe_typing.vodigest ->
-  Univ.ContextSet.t ->
+  Univ.ContextSet.t -> Vmlibrary.on_disk ->
   unit
 
 (** [import_module export mp] imports the module [mp].
@@ -155,7 +155,7 @@ val start_library : library_name -> unit
 
 val end_library :
   output_native_objects:bool -> library_name ->
-  Safe_typing.compiled_library * library_objects * library_objects * Nativelib.native_library * Library_info.t
+  Safe_typing.compiled_library * library_objects * library_objects * Vmlibrary.on_disk * Nativelib.native_library * Library_info.t
 
 (** append a function to be executed at end_library *)
 val append_end_library_hook : (unit -> unit) -> unit

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -233,7 +233,7 @@ type seg_lib = library_disk
 type seg_univ = (* true = vivo, false = vi *)
   Univ.ContextSet.t * bool
 type seg_proofs = Opaques.opaque_disk
-type seg_vm = Vmlibrary.on_disk
+type seg_vm = Vmlibrary.compiled_library
 
 let mk_library sd md digests univs vm =
   {
@@ -269,7 +269,7 @@ let library_seg : seg_lib ObjFile.id = ObjFile.make_id "library"
 let universes_seg : seg_univ option ObjFile.id = ObjFile.make_id "universes"
 let tasks_seg () : (Opaqueproof.opaque_handle option, 'doc) tasks option ObjFile.id = ObjFile.make_id "tasks"
 let opaques_seg : seg_proofs ObjFile.id = ObjFile.make_id "opaques"
-let vm_seg : seg_vm ObjFile.id = ObjFile.make_id "vmlibrary"
+let vm_seg : seg_vm ObjFile.id = Vmlibrary.vm_segment
 
 let intern_from_file lib_resolver dir =
   let f = lib_resolver dir in
@@ -279,7 +279,7 @@ let intern_from_file lib_resolver dir =
   let lmd, digest_lmd = ObjFile.marshal_in_segment ch ~segment:library_seg in
   let univs, digest_u = ObjFile.marshal_in_segment ch ~segment:universes_seg in
   let del_opaque, _ = in_delayed f ch ~segment:opaques_seg in
-  let vmlib, _ = ObjFile.marshal_in_segment ch ~segment:vm_seg in
+  let vmlib = Vmlibrary.load dir ~file:f ch in
   ObjFile.close_in ch;
   System.check_caml_version ~caml:lsd.md_ocaml ~file:f;
   register_library_filename lsd.md_name f;

--- a/vernac/library.mli
+++ b/vernac/library.mli
@@ -38,7 +38,7 @@ type seg_lib
 type seg_univ = (* all_cst, finished? *)
   Univ.ContextSet.t * bool
 type seg_proofs = Opaques.opaque_disk
-type seg_vm = Vmlibrary.on_disk
+type seg_vm = Vmlibrary.compiled_library
 
 (** End the compilation of a library and save it to a ".vo" file,
     a ".vio" file, or a ".vos" file, depending on the todo_proofs

--- a/vernac/library.mli
+++ b/vernac/library.mli
@@ -38,6 +38,7 @@ type seg_lib
 type seg_univ = (* all_cst, finished? *)
   Univ.ContextSet.t * bool
 type seg_proofs = Opaques.opaque_disk
+type seg_vm = Vmlibrary.on_disk
 
 (** End the compilation of a library and save it to a ".vo" file,
     a ".vio" file, or a ".vos" file, depending on the todo_proofs
@@ -58,9 +59,9 @@ val save_library_to :
 
 val load_library_todo
   :  CUnix.physical_path
-  -> seg_sum * seg_lib * seg_univ * (Opaqueproof.opaque_handle option, 'doc) tasks * seg_proofs
+  -> seg_sum * seg_lib * seg_univ * (Opaqueproof.opaque_handle option, 'doc) tasks * seg_proofs * seg_vm
 
-val save_library_raw : string -> seg_sum -> seg_lib -> seg_univ -> seg_proofs -> unit
+val save_library_raw : string -> seg_sum -> seg_lib -> seg_univ -> seg_proofs -> seg_vm -> unit
 
 (** {6 Interrogate the status of libraries } *)
 


### PR DESCRIPTION
We store the VM bytecode in a separate segment in vo files, by introducing an indirection in constant bodies. This allows delayed loading of the bytecode and potentially reduced memory footprint.

Overlays:
- https://github.com/ejgallego/coq-serapi/pull/389