### PR TITLE
Slightly safer API for segment marshalling.

### DIFF
--- a/lib/objFile.mli
+++ b/lib/objFile.mli
@@ -10,26 +10,31 @@
 
 val magic_number : int32
 
-type segment = {
+type 'a segment = private {
   name : string;
   pos : int64;
   len : int64;
   hash : Digest.t;
 }
 
+type 'a id = private { id : string }
+(** Private to ensure the phantom tag is injective *)
+
 type in_handle
 type out_handle
 
+val make_id : string -> 'a id
+
 val open_in : file:string -> in_handle
 val close_in : in_handle -> unit
-val marshal_in_segment : in_handle -> segment:string -> 'a * Digest.t
-val get_segment : in_handle -> segment:string -> segment
-val segments : in_handle -> segment CString.Map.t
+val marshal_in_segment : in_handle -> segment:'a id -> 'a * Digest.t
+val get_segment : in_handle -> segment:'a id -> 'a segment
+val segments : in_handle -> Obj.t segment CString.Map.t
 
 val open_out : file:string -> out_handle
 val close_out : out_handle -> unit
-val marshal_out_segment : out_handle -> segment:string -> 'a -> unit
-val marshal_out_binary : out_handle -> segment:string -> out_channel * (unit -> unit)
+val marshal_out_segment : out_handle -> segment:'a id -> 'a -> unit
+val marshal_out_binary : out_handle -> segment:'a id -> out_channel * (unit -> unit)
 (** [marshal_out_binary oh segment] is a low level, stateful, API returning
     [oc, stop]. Once called no other API can be used on the same [oh] and only
     [Stdlib.output_*] APIs should be used on [oc]. [stop ()] must be invoked in

--- a/topbin/coqnative_bin.ml
+++ b/topbin/coqnative_bin.ml
@@ -128,11 +128,15 @@ let mk_library sd f md digests univs =
     library_extra_univs = univs;
   }
 
+let summary_seg : summary_disk ObjFile.id = ObjFile.make_id "summary"
+let library_seg : library_disk ObjFile.id = ObjFile.make_id "library"
+let universes_seg : (Univ.ContextSet.t * bool) option ObjFile.id = ObjFile.make_id "universes"
+
 let intern_from_file f =
   let ch = System.with_magic_number_check (fun file -> ObjFile.open_in ~file) f in
-  let (lsd : summary_disk), digest_lsd = ObjFile.marshal_in_segment ch ~segment:"summary" in
-  let ((lmd : library_disk), digest_lmd) = ObjFile.marshal_in_segment ch ~segment:"library" in
-  let (univs : (Univ.ContextSet.t * bool) option), digest_u = ObjFile.marshal_in_segment ch ~segment:"universes" in
+  let lsd, digest_lsd = ObjFile.marshal_in_segment ch ~segment:summary_seg in
+  let lmd, digest_lmd = ObjFile.marshal_in_segment ch ~segment:library_seg in
+  let univs, digest_u = ObjFile.marshal_in_segment ch ~segment:universes_seg in
   ObjFile.close_in ch;
   System.check_caml_version ~caml:lsd.md_ocaml ~file:f;
   let open Safe_typing in


### PR DESCRIPTION
We centralize the definition of segments and wrap them with a phantom type to ensure that the types are synchronized.
