### PR TITLE
Make instance MSetPositive.PositiveSet.eq_equiv global instead of local

### DIFF
--- a/doc/changelog/11-standard-library/17682-global-instance-eq-equiv.rst
+++ b/doc/changelog/11-standard-library/17682-global-instance-eq-equiv.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  global typeclass instance `Coq.MSets.MSetPositive.PositiveSet.eq_equiv`
+  (`#17682 <https://github.com/coq/coq/pull/17682>`_,
+  fixes `#3138 <https://github.com/coq/coq/issues/3138>`_,
+  by Gaëtan Gilbert).

--- a/theories/MSets/MSetPositive.v
+++ b/theories/MSets/MSetPositive.v
@@ -314,7 +314,7 @@ Module PositiveSet <: S with Module E:=PositiveOrderedTypeBits.
 
   (** Specification of [eq] *)
 
-  Local Instance eq_equiv : Equivalence eq.
+  #[global] Instance eq_equiv : Equivalence eq.
   Proof. firstorder. Qed.
 
   (** Specification of [mem] *)


### PR DESCRIPTION
This matches the other MSets AFAICT.

Close #3138 