### PR TITLE
Do not create bytecode aliases for primitive operations (fix #17663).

### DIFF
--- a/test-suite/bugs/bug_17663.v
+++ b/test-suite/bugs/bug_17663.v
@@ -1,0 +1,18 @@
+From Coq Require Import Uint63.
+
+Module Type T.
+  Parameter eq : int -> int -> bool.
+End T.
+
+Module M (S : T).
+  Definition do x y := S.eq x y.
+End M.
+
+Module N.
+  Definition eq := eqb.
+End N.
+
+Module P := M N.
+
+Check (eq_refl true <: P.do 0 0 = true).
+Check (eq_refl true <<: P.do 0 0 = true).


### PR DESCRIPTION
When dynamically linking the bytecode from an instantiated functor, the kernel expects all the symbols to have some associated bytecode (or to be axioms), so that it can relocate them. Aliases to primitive symbols, however, have no bytecode and were thus wrongfully considered as axioms.

This commit forces the creation of bytecode in place of aliases for primitive operations.

Fixes / closes #17663