### PR TITLE
eqschemes: Catch errors from `lib_ref` in the logic monad

### DIFF
--- a/tactics/eqschemes.ml
+++ b/tactics/eqschemes.ml
@@ -101,7 +101,6 @@ let my_it_mkLambda_or_LetIn_name env s c =
 
 let get_coq_eq env ctx =
   let eq = Globnames.destIndRef (Coqlib.lib_ref "core.eq.type") in
-  (* Do not force the lazy if they are not defined *)
   let eq, ctx = with_context_set ctx
       (UnivGen.fresh_inductive_instance env eq) in
   mkIndU eq, mkConstructUi (eq,1), ctx

--- a/tactics/eqschemes.ml
+++ b/tactics/eqschemes.ml
@@ -100,14 +100,11 @@ let my_it_mkLambda_or_LetIn_name env s c =
   List.fold_left (fun c d -> mkLambda_or_LetIn_name d c) c s
 
 let get_coq_eq env ctx =
-  try
-    let eq = Globnames.destIndRef (Coqlib.lib_ref "core.eq.type") in
-    (* Do not force the lazy if they are not defined *)
-    let eq, ctx = with_context_set ctx
+  let eq = Globnames.destIndRef (Coqlib.lib_ref "core.eq.type") in
+  (* Do not force the lazy if they are not defined *)
+  let eq, ctx = with_context_set ctx
       (UnivGen.fresh_inductive_instance env eq) in
-      mkIndU eq, mkConstructUi (eq,1), ctx
-  with Not_found ->
-    user_err Pp.(str "eq not found.")
+  mkIndU eq, mkConstructUi (eq,1), ctx
 
 let univ_of_eq env eq =
   let open EConstr in

--- a/test-suite/bugs/bug_17687.v
+++ b/test-suite/bugs/bug_17687.v
@@ -1,0 +1,11 @@
+(* -*- coq-prog-args: ("-noinit"); -*- *)
+
+Declare ML Module "ltac_plugin".
+Global Set Default Proof Mode "Classic".
+
+Inductive paths {A : Type} (a : A) : forall _:A, Type := idpath : paths a a.
+Axiom transport : forall {A : Type} (x : A) (p : paths x x), paths x x.
+Lemma t (x : Type) (eq : paths x x) : paths (transport x eq) (transport x eq).
+Fail rewrite eq.
+Succeed try rewrite eq.
+Abort.


### PR DESCRIPTION
In `-noinit` mode, when no proper alternatives for the usual equality are registered, `lib_ref` errors out. This can, in turn, crash the `rewrite` tactic. We feed the errors into the logic monad instead.

Testcase:
```
Declare ML Module "ltac_plugin".
Global Set Default Proof Mode "Classic".

Inductive paths {A : Type} (a : A) : forall _:A, Type := idpath : paths a a.
Axiom transport : forall {A : Type} (x : A) (p : paths x x), paths x x.
Lemma t (x : Type) (eq : paths x x) : paths (transport x eq) (transport x eq).
Fail rewrite eq.
Succeed try rewrite eq.
Abort.
```

Related: #6623, which can probably be closed

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.
