### PR TITLE
Btauto: always print a counterexample

### DIFF
--- a/plugins/btauto/refl_btauto.ml
+++ b/plugins/btauto/refl_btauto.ml
@@ -190,18 +190,18 @@ module Btauto = struct
         in
         h ++ aux t
     in
-    try
-      let var = to_list var in
-      let assign = List.combine penv var in
-      let map_msg (key, v) =
-        let b = if v then str "true" else str "false" in
-        let term = Printer.pr_constr_env env sigma key in
-        term ++ spc () ++ str ":=" ++ spc () ++ b
-      in
-      let assign = List.map map_msg assign in
-      let l = str "[" ++ (concat (str ";" ++ spc ()) assign) ++ str "]" in
-      str "Not a tautology:" ++ spc () ++ l
-    with e when CErrors.noncritical e -> (str "Not a tautology")
+    let var = to_list var in
+    let len = List.length var in
+    let penv = CList.firstn len penv in
+    let assign = List.combine penv var in
+    let map_msg (key,v) =
+      let b = bool v in
+      let term = Printer.pr_constr_env env sigma key in
+      term ++ spc () ++ str ":=" ++ spc () ++ b
+    in
+    let assign = List.map map_msg assign in
+    let l = str "[" ++ (concat (str ";" ++ spc ()) assign) ++ str "]" in
+    str "Not a tautology:" ++ spc () ++ l
 
   let print_counterexample p penv =
   Proofview.Goal.enter begin fun gl ->

--- a/test-suite/output/btauto_counterexample.out
+++ b/test-suite/output/btauto_counterexample.out
@@ -1,0 +1,3 @@
+File "./output/btauto_counterexample.v", line 12, characters 7-13:
+The command has indeed failed with message:
+Tactic failure: Not a tautology: [combine := true].

--- a/test-suite/output/btauto_counterexample.v
+++ b/test-suite/output/btauto_counterexample.v
@@ -1,0 +1,13 @@
+
+Require Import Coq.btauto.Btauto.
+Local Open Scope bool_scope.
+
+Axiom unsigned : bool.
+Axiom combine : bool.
+
+Lemma foo
+  : (false &&  unsigned) || (false &&  combine) =
+      combine .
+Proof.
+  Fail btauto.
+Abort.


### PR DESCRIPTION
When the variable list produced is incomplete, it means the remaining variables don't matter.
