### PR TITLE
Expose APIs to make it possible to compile Ltac2 as a separate plugin

### DIFF
--- a/dev/ci/user-overlays/17696-SkySkimmer-tac2compile-plugin.sh
+++ b/dev/ci/user-overlays/17696-SkySkimmer-tac2compile-plugin.sh
@@ -1,0 +1,3 @@
+overlay serapi https://github.com/SkySkimmer/coq-serapi tac2compile-plugin 17696
+
+overlay coq_lsp https://github.com/SkySkimmer/coq-lsp tac2compile-plugin 17696

--- a/plugins/ltac2/tac2dyn.ml
+++ b/plugins/ltac2/tac2dyn.ml
@@ -16,6 +16,7 @@ struct
   let eq = DYN.eq
   let repr = DYN.repr
   let create = DYN.create
+  type glb = Glb : (_,'a) tag * 'a  -> glb
 end
 
 module type Param = sig type ('raw, 'glb) t end

--- a/plugins/ltac2/tac2dyn.mli
+++ b/plugins/ltac2/tac2dyn.mli
@@ -16,6 +16,7 @@ sig
   val create : string -> ('a, 'b) tag
   val eq : ('a1, 'b1) tag -> ('a2, 'b2) tag -> ('a1 * 'b1, 'a2 * 'b2) CSig.eq option
   val repr : ('a, 'b) tag -> string
+  type glb = Glb : (_,'a) tag * 'a  -> glb
 end
 (** Arguments that are part of an AST. *)
 

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -1008,19 +1008,24 @@ end
 
 (** Printing *)
 
-let print_constant ~print_def qid data =
+let print_constant ~print_def qid ?info data =
   let e = data.Tac2env.gdata_expr in
   let (_, t) = data.Tac2env.gdata_type in
   let name = int_name () in
   let def = if print_def then fnl () ++ hov 2 (pr_qualid qid ++ spc () ++ str ":=" ++ spc () ++ pr_glbexpr e) else mt() in
+  let info = match info with
+    | None -> mt()
+    | Some info -> fnl() ++ fnl() ++ hov 2 (str "Compiled as" ++ spc() ++ str info.Tac2env.source)
+  in
   hov 0 (
-    hov 2 (pr_qualid qid ++ spc () ++ str ":" ++ spc () ++ pr_glbtype name t) ++ def
+    hov 2 (pr_qualid qid ++ spc () ++ str ":" ++ spc () ++ pr_glbtype name t) ++ def ++ info
   )
 
 let print_tacref ~print_def qid = function
   | TacConstant kn ->
     let data = Tac2env.interp_global kn in
-    print_constant ~print_def qid data
+    let info = Option.map fst (Tac2env.get_compiled_global kn) in
+    print_constant ~print_def qid data ?info
   | TacAlias kn -> str "Alias to ..."
 
 let locatable_ltac2 = "Ltac2"

--- a/plugins/ltac2/tac2env.ml
+++ b/plugins/ltac2/tac2env.ml
@@ -57,7 +57,13 @@ let empty_state = {
   ltac_aliases = KNmap.empty;
 }
 
+type compile_info = {
+  source : string;
+}
+
 let ltac_state = Summary.ref empty_state ~name:"ltac2-state"
+
+let compiled_tacs = Summary.ref ~local:true ~name:"ltac2-compiled-state" KNmap.empty
 
 let ltac_notations = Summary.ref KNmap.empty ~stage:Summary.Stage.Synterp ~name:"ltac2-notations"
 
@@ -68,6 +74,12 @@ let define_global kn e =
 let interp_global kn =
   let data = KNmap.find kn ltac_state.contents.ltac_tactics in
   data
+
+let set_compiled_global kn info v =
+  assert (not (interp_global kn).gdata_mutable);
+  compiled_tacs := KNmap.add kn (info,v) !compiled_tacs
+
+let get_compiled_global kn = KNmap.find_opt kn !compiled_tacs
 
 let globals () = (!ltac_state).ltac_tactics
 

--- a/plugins/ltac2/tac2env.mli
+++ b/plugins/ltac2/tac2env.mli
@@ -29,6 +29,13 @@ type global_data = {
 val define_global : ltac_constant -> global_data -> unit
 val interp_global : ltac_constant -> global_data
 
+type compile_info = {
+  source : string;
+}
+
+val set_compiled_global : ltac_constant -> compile_info -> valexpr -> unit
+val get_compiled_global : ltac_constant -> (compile_info * valexpr) option
+
 val globals : unit -> global_data KNmap.t
 
 (** {5 Toplevel definition of types} *)

--- a/plugins/ltac2/tac2ffi.ml
+++ b/plugins/ltac2/tac2ffi.ml
@@ -429,6 +429,8 @@ let rec apply : type a. a arity -> _ -> a -> valexpr list -> valexpr Proofview.t
 
 let apply (MLTactic (arity, wrap, f)) args = apply arity wrap f args
 
+let apply_val v args = apply (to_closure v) args
+
 type n_closure =
 | NClosure : 'a arity * (valexpr list -> 'a) -> n_closure
 

--- a/plugins/ltac2/tac2ffi.mli
+++ b/plugins/ltac2/tac2ffi.mli
@@ -47,6 +47,7 @@ val arity_suc : 'a arity -> (valexpr -> 'a) arity
 
 val mk_closure : 'v arity -> 'v -> closure
 val mk_closure_val : 'v arity -> 'v -> valexpr
+(** Composition of [mk_closure] and [ValCls] *)
 
 val annotate_closure : Tac2expr.frame -> closure -> closure
 (** The closure must not be already annotated *)
@@ -228,6 +229,9 @@ val val_exn : Exninfo.iexn Tac2dyn.Val.tag
 val apply : closure -> valexpr list -> valexpr Proofview.tactic
 (** Given a closure, apply it to some arguments. Handling of argument mismatches
     is done automatically, i.e. in case of over or under-application. *)
+
+val apply_val : valexpr -> valexpr list -> valexpr Proofview.tactic
+(** Composition of [to_closure] and [apply] *)
 
 val abstract : int -> (valexpr list -> valexpr Proofview.tactic) -> closure
 (** Turn a fixed-arity function into a closure. The inner function is guaranteed

--- a/plugins/ltac2/tac2intern.mli
+++ b/plugins/ltac2/tac2intern.mli
@@ -21,6 +21,9 @@ val intern_open_type : raw_typexpr -> type_scheme
 (** Check that a term is a value. Only values are safe to marshall between
     processes. *)
 val is_value : glb_tacexpr -> bool
+
+val is_pure_constructor : type_constant -> bool
+
 val check_unit : ?loc:Loc.t -> type_scheme -> unit
 
 val check_subtype : type_scheme -> type_scheme -> bool

--- a/plugins/ltac2/tac2interp.ml
+++ b/plugins/ltac2/tac2interp.ml
@@ -38,9 +38,11 @@ type closure = {
   (** Global constant from which the closure originates *)
 }
 
+let push_id ist id v = { env_ist = Id.Map.add id v ist.env_ist }
+
 let push_name ist id v = match id with
 | Anonymous -> ist
-| Name id -> { env_ist = Id.Map.add id v ist.env_ist }
+| Name id -> push_id ist id v
 
 let get_var ist id =
   try Id.Map.find id ist.env_ist with Not_found ->
@@ -97,13 +99,21 @@ and match_pattern_against_or ist pats v =
     try match_pattern_against ist pat v
     with NoMatch -> match_pattern_against_or ist pats v
 
+let eval_glb_ext ist (Tac2dyn.Arg.Glb (tag,e)) =
+  let tpe = Tac2env.interp_ml_object tag in
+  with_frame (FrExtn (tag, e)) (tpe.Tac2env.ml_interp ist e)
+
 let rec interp (ist : environment) = function
 | GTacAtm (AtmInt n) -> return (Tac2ffi.of_int n)
 | GTacAtm (AtmStr s) -> return (Tac2ffi.of_string s)
 | GTacVar id -> return (get_var ist id)
 | GTacRef kn ->
-  let data = get_ref ist kn in
-  return (eval_pure Id.Map.empty (Some kn) data)
+  begin match Tac2env.get_compiled_global kn with
+  | Some (_info,v) -> return v
+  | None ->
+    let data = get_ref ist kn in
+    return (eval_pure Id.Map.empty (Some kn) data)
+  end
 | GTacFun (ids, e) ->
   let cls = { clos_ref = None; clos_env = ist.env_ist; clos_var = ids; clos_exp = e } in
   let f = interp_closure cls in
@@ -158,9 +168,7 @@ let rec interp (ist : environment) = function
   return (Tac2ffi.of_open (kn, Array.of_list el))
 | GTacPrm ml ->
   return (Tac2env.interp_primitive ml)
-| GTacExt (tag, e) ->
-  let tpe = Tac2env.interp_ml_object tag in
-  with_frame (FrExtn (tag, e)) (tpe.Tac2env.ml_interp ist e)
+| GTacExt (tag, e) -> eval_glb_ext ist (Glb (tag,e))
 
 and interp_closure f =
   let ans = fun args ->
@@ -217,11 +225,15 @@ and eval_pure bnd kn = function
 | GTacVar id -> Id.Map.get id bnd
 | GTacAtm (AtmInt n) -> Valexpr.make_int n
 | GTacRef kn ->
-  let { Tac2env.gdata_expr = e } =
-    try Tac2env.interp_global kn
-    with Not_found -> assert false
-  in
-  eval_pure bnd (Some kn) e
+  begin match Tac2env.get_compiled_global kn with
+  | Some (_info,v) -> v
+  | None ->
+    let { Tac2env.gdata_expr = e } =
+      try Tac2env.interp_global kn
+      with Not_found -> assert false
+    in
+    eval_pure bnd (Some kn) e
+  end
 | GTacFun (na, e) ->
   let cls = { clos_ref = kn; clos_env = bnd; clos_var = na; clos_exp = e } in
   interp_closure cls
@@ -255,6 +267,8 @@ and eval_pure_args bnd args =
 
 let interp_value ist tac =
   eval_pure ist.env_ist None tac
+
+let eval_global kn = eval_pure Id.Map.empty (Some kn) (Tac2env.interp_global kn).gdata_expr
 
 (** Cross-boundary hacks. *)
 

--- a/plugins/ltac2/tac2interp.mli
+++ b/plugins/ltac2/tac2interp.mli
@@ -21,6 +21,12 @@ val interp : environment -> glb_tacexpr -> valexpr Proofview.tactic
 val interp_value : environment -> glb_tacexpr -> valexpr
 (** Same as [interp] but assumes that the argument is a syntactic value. *)
 
+val eval_global : ltac_constant -> valexpr
+
+val eval_glb_ext : environment -> Tac2dyn.Arg.glb -> valexpr Proofview.tactic
+
+val push_id : environment -> Id.t -> valexpr -> environment
+
 (* val interp_app : closure -> ml_tactic *)
 
 (** {5 Cross-boundary encodings} *)

--- a/topbin/coqtop_byte_bin.ml
+++ b/topbin/coqtop_byte_bin.ml
@@ -30,12 +30,12 @@ let load_plugin fmt ps =
 
 let drop_setup () =
   let ppf = Format.std_formatter in
-  Mltop.(set_top
-           { load_plugin = load_plugin ppf
-           ; load_module = load_module ppf
-           ; add_dir  = Topdirs.dir_directory
-           ; ml_loop  = (fun () -> Toploop.loop ppf)
-           })
+  Mltop.set_top
+    { load_plugin = load_plugin ppf
+    ; load_module = load_module ppf
+    ; add_dir  = Topdirs.dir_directory
+    ; ml_loop  = (fun () -> Toploop.loop ppf)
+    }
 
 (* Main coqtop initialization *)
 let _ =

--- a/vernac/mltop.ml
+++ b/vernac/mltop.ml
@@ -251,6 +251,10 @@ let ml_load p =
   | WithoutTop ->
     PluginSpec.load p
 
+let load_module x = match !load with
+  | WithTop t -> t.load_module x
+  | WithoutTop -> ()
+
 (* Adds a path to the ML paths *)
 let add_ml_dir s =
   match !load with

--- a/vernac/mltop.mli
+++ b/vernac/mltop.mli
@@ -45,6 +45,8 @@ type toplevel =
 (** Sets and initializes a toplevel (if any) *)
 val set_top : toplevel -> unit
 
+val load_module : string -> unit
+
 (** Removes the toplevel (if any) *)
 val remove : unit -> unit
 


### PR DESCRIPTION
The core API makes it possible to register a `valexpr` for each `ltac_constant`.

For functional `ltac_constant` (the vast majority) this will be a closure, which in valexpr are represented as arbitrary OCaml closures. This allows arbitrary compilation schemes, eg
- dynlinked OCaml code as in https://github.com/coq/coq/pull/17521 (like native_compute)
- compiling to the VM eg `let code = compile expr in mk_closure arity (fun args -> interpret code args)`
- partially evaluating the tacexpr and sending it back to the normal evaluator `let e = partial_eval e in mk_closure arity (fun args -> interp (TacApp (e, args))`

and any other scheme someone might come up with.

We also expose some convenient APIs.

Overlays:
- https://github.com/ejgallego/coq-serapi/pull/336
- https://github.com/ejgallego/coq-lsp/pull/494