### PR TITLE
Experiment to preserve information from typeclass failures

### DIFF
--- a/pretyping/pretype_errors.ml
+++ b/pretyping/pretype_errors.ml
@@ -64,7 +64,7 @@ type pretype_error =
   | CantApplyBadTypeExplained of (constr,types) pcant_apply_bad_type * unification_error
   | CannotUnifyOccurrences of subterm_unification_error
   | UnsatisfiableConstraints of
-    (Evar.t * Evar_kinds.t) option * Evar.Set.t
+    (Evar.t * Evar_kinds.t) option * Evar.Set.t * exn option
   | DisallowedSProp
 
 exception PretypeError of env * Evd.evar_map * pretype_error
@@ -192,14 +192,14 @@ let error_disallowed_sprop env sigma  =
 
 (*s Typeclass errors *)
 
-let unsatisfiable_constraints env evd ev comp =
+let unsatisfiable_constraints env evd ev ?err comp =
   match ev with
   | None ->
-    let err = UnsatisfiableConstraints (None, comp) in
+    let err = UnsatisfiableConstraints (None, comp, err) in
     raise (PretypeError (env,evd,err))
   | Some ev ->
     let loc, kind = Evd.evar_source (Evd.find_undefined evd ev) in
-    let err = UnsatisfiableConstraints (Some (ev, kind), comp) in
+    let err = UnsatisfiableConstraints (Some (ev, kind), comp, err) in
     Loc.raise ?loc (PretypeError (env,evd,err))
 
 let unsatisfiable_exception exn =

--- a/pretyping/pretype_errors.mli
+++ b/pretyping/pretype_errors.mli
@@ -70,7 +70,7 @@ type pretype_error =
   | CantApplyBadTypeExplained of (constr,types) pcant_apply_bad_type * unification_error
   | CannotUnifyOccurrences of subterm_unification_error
   | UnsatisfiableConstraints of
-    (Evar.t * Evar_kinds.t) option * Evar.Set.t
+    (Evar.t * Evar_kinds.t) option * Evar.Set.t * exn option
     (** unresolvable evar, connex component *)
   | DisallowedSProp
 
@@ -174,7 +174,7 @@ val error_disallowed_sprop : env -> Evd.evar_map -> 'a
 (** {6 Typeclass errors } *)
 
 val unsatisfiable_constraints : env -> Evd.evar_map -> Evar.t option ->
-  Evar.Set.t -> 'a
+  ?err:exn -> Evar.Set.t -> 'a
 
 val unsatisfiable_exception : exn -> bool
 

--- a/pretyping/typeclasses.ml
+++ b/pretyping/typeclasses.ml
@@ -253,14 +253,17 @@ let solve_all_instances env evd filter unique fail =
 
 let set_solve_all_instances f = solve_all_instances_hook := f
 
-let resolve_typeclasses ?(filter=no_goals) ?(unique=get_typeclasses_unique_solutions ())
+let resolve_typeclasses_keep_err ?(filter=no_goals) ?(unique=get_typeclasses_unique_solutions ())
     ?(fail=true) env evd =
-  if not (has_typeclasses filter evd) then evd
+  if not (has_typeclasses filter evd) then evd, None
   else solve_all_instances env evd filter unique fail
+
+let resolve_typeclasses ?filter ?unique ?fail env evd =
+  fst (resolve_typeclasses_keep_err ?filter ?unique ?fail env evd)
 
 (** In case of unsatisfiable constraints, build a nice error message *)
 
-let error_unresolvable env evd comp =
+let error_unresolvable env evd ?err comp =
   let exception MultipleFound in
   let fold ev accu =
     let evi = Evd.find_undefined evd ev in
@@ -271,7 +274,7 @@ let error_unresolvable env evd comp =
     else (Some ev)
   in
   let ev = try Evar.Set.fold fold comp None with MultipleFound -> None in
-  Pretype_errors.unsatisfiable_constraints env evd ev comp
+  Pretype_errors.unsatisfiable_constraints env evd ev ?err comp
 
 (** Deprecated *)
 

--- a/pretyping/typeclasses.mli
+++ b/pretyping/typeclasses.mli
@@ -129,15 +129,17 @@ val is_class_type : evar_map -> EConstr.types -> bool
 
 val resolve_typeclasses : ?filter:evar_filter -> ?unique:bool ->
   ?fail:bool -> env -> evar_map -> evar_map
+val resolve_typeclasses_keep_err : ?filter:evar_filter -> ?unique:bool ->
+  ?fail:bool -> env -> evar_map -> evar_map * exn option
 
 val get_filtered_typeclass_evars : evar_filter -> evar_map -> Evar.Set.t
 
-val error_unresolvable : env -> evar_map -> Evar.Set.t -> 'a
+val error_unresolvable : env -> evar_map -> ?err:exn -> Evar.Set.t -> 'a
 
 (** A plugin can override the TC resolution engine by calling these two APIs.
     Beware this action is not registed in the summary (the Undo system) so
     it is up to the plugin to do so. *)
-val set_solve_all_instances : (env -> evar_map -> evar_filter -> bool -> bool -> evar_map) -> unit
+val set_solve_all_instances : (env -> evar_map -> evar_filter -> bool -> bool -> evar_map * exn option) -> unit
 
 val get_typeclasses_unique_solutions : unit -> bool
 

--- a/tactics/class_tactics.mli
+++ b/tactics/class_tactics.mli
@@ -67,7 +67,7 @@ type solver = { solver :
   unique:bool ->
   best_effort:bool ->
   goals:Evar.t list ->
-  (bool * Evd.evar_map)
+  ((bool * Evd.evar_map),exn) Util.union
 }
 
 


### PR DESCRIPTION
This adds
~~~
(resolution failed with Tactic failure: Proof search failed on goal (Equiv (gmap nat Term)).)
~~~
to the message from
https://github.com/coq/coq/issues/16598#issuecomment-1265247434

The code probably should be cleaned up before merge, and the
formulation of the message improved.

See also https://github.com/coq/coq/issues/4748
