### PR TITLE
Produce profiles in google trace format

### DIFF
--- a/dev/bench/bench.sh
+++ b/dev/bench/bench.sh
@@ -458,6 +458,7 @@ skipped_packages=
 
 # Generate per line timing info in devs that use coq_makefile
 export TIMING=1
+export PROFILING=1
 
 for coq_opam_package in $sorted_coq_opam_packages; do
 

--- a/dev/bench/bench.sh
+++ b/dev/bench/bench.sh
@@ -459,6 +459,7 @@ skipped_packages=
 # Generate per line timing info in devs that use coq_makefile
 export TIMING=1
 export PROFILING=1
+export COQ_PROFILE_COMPONENTS=command,parse_command
 
 for coq_opam_package in $sorted_coq_opam_packages; do
 

--- a/dev/bench/gitlab-bench.yml
+++ b/dev/bench/gitlab-bench.yml
@@ -19,8 +19,10 @@ bench:
       - _bench/files.listing
       - _bench/opam.NEW/**/*.log
       - _bench/opam.NEW/**/*.timing
+      - _bench/opam.NEW/**/*.prof.json.gz
       - _bench/opam.OLD/**/*.log
       - _bench/opam.OLD/**/*.timing
+      - _bench/opam.OLD/**/*.prof.json.gz
     when: always
     expire_in: 1 year
   environment: bench

--- a/doc/changelog/08-vernac-commands-and-options/17702-trace.rst
+++ b/doc/changelog/08-vernac-commands-and-options/17702-trace.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  `-profile` command line argument and `PROFILE` variable in `coq_makefile` to control a new :ref:`profiling` system
+  (`#17702 <https://github.com/coq/coq/pull/17702>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/practical-tools/coq-commands.rst
+++ b/doc/sphinx/practical-tools/coq-commands.rst
@@ -170,13 +170,13 @@ except that ``space_overhead`` is set to 120 and ``minor_heap_size`` is set to 3
 
 .. _COQ_PROFILE_COMPONENTS:
 
-Control which components produce events when using the
-:ref:`profiling` system. It should be a comma separated list of
-components.
+Specifies which components produce events when using the
+:ref:`profiling` system. It is a comma separated list of
+component names.
 
 If the variable is not set, all components produce events.
 
-Components are internally defined, but `command` which corresponds to
+Component names are internally defined, but `command` which corresponds to
 the interpretation of one command is particularly notable.
 
 .. _command-line-options:
@@ -452,19 +452,19 @@ and ``coqtop``, unless stated otherwise:
 Profiling
 ---------
 
-Using the `coqc` command line argument `-profile` or the environment
-variable `PROFILE` with `coq_makefile`, profiling information is produced in
+Use the `coqc` command line argument `-profile` or the environment
+variable `PROFILE` in `coq_makefile`, to generate profiling information in
 `Google trace format <https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/edit>`.
 
-The output consists of duration events for the execution of various
+The output gives the duration and event counts for the execution of
 components of Coq (for instance `process` for the whole file,
 `command` for each command, `pretyping` for elaboration).
 
-Environment variable `COQ_PROFILE_COMPONENTS` can be used to filter
-the components which produce events. This may be needed to reduce the
-size of the produced file.
+Environment variable :ref:`COQ_PROFILE_COMPONENTS <COQ_PROFILE_COMPONENTS>` can be used to filter
+which components produce events. This may be needed to reduce the
+size of the generated file.
 
-The produced file can be visualized for instance in
+The generated file can be visualized with
 <https://ui.perfetto.dev> (which can directly load the `.gz`
 compressed file produced by `coq_makefile`) or processed using any
 JSON-capable system.
@@ -475,8 +475,8 @@ Events are annotated with additional information in the `args` field
 - `major` and `minor` indicate how many major and minor words were allocated during the event.
 
 - `subtimes` indicates how much time was spent in sub-components and
-  how many times each sub-component was profiled during the event
-  (including sub-components which do not appear in
+  how many times each subcomponent was profiled during the event
+  (including subcomponents which do not appear in
   `COQ_PROFILE_COMPONENTS`).
 
 - for the `command` event, `cmd` displays the precise location of the

--- a/doc/sphinx/practical-tools/coq-commands.rst
+++ b/doc/sphinx/practical-tools/coq-commands.rst
@@ -168,6 +168,17 @@ except that ``space_overhead`` is set to 120 and ``minor_heap_size`` is set to 3
 
 .. todo how about COQLIB, COQCORELIB, DOCDIR
 
+.. _COQ_PROFILE_COMPONENTS:
+
+Control which components produce events when using the
+:ref:`profiling` system. It should be a comma separated list of
+components.
+
+If the variable is not set, all components produce events.
+
+Components are internally defined, but `command` which corresponds to
+the interpretation of one command is particularly notable.
+
 .. _command-line-options:
 
 Command line options
@@ -432,7 +443,45 @@ and ``coqtop``, unless stated otherwise:
 :-list-tags: Print the highlight tags known by Coq as well as their
   currently associated color and exit.
 :-h, --help: Print a short usage and exit.
+:-time: Output timing information for each command to standard output.
+:-time-file *file*: Output timing information for each command to the given file.
+:-profile *file*: Output :ref:`profiling` information to the given file.
 
+.. _profiling:
+
+Profiling
+---------
+
+Using the `coqc` command line argument `-profile` or the environment
+variable `PROFILE` with `coq_makefile`, profiling information is produced in
+`Google trace format <https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/edit>`.
+
+The output consists of duration events for the execution of various
+components of Coq (for instance `process` for the whole file,
+`command` for each command, `pretyping` for elaboration).
+
+Environment variable `COQ_PROFILE_COMPONENTS` can be used to filter
+the components which produce events. This may be needed to reduce the
+size of the produced file.
+
+The produced file can be visualized for instance in
+<https://ui.perfetto.dev> (which can directly load the `.gz`
+compressed file produced by `coq_makefile`) or processed using any
+JSON-capable system.
+
+Events are annotated with additional information in the `args` field
+(either on the beginning `B` or end `E` event):
+
+- `major` and `minor` indicate how many major and minor words were allocated during the event.
+
+- `subtimes` indicates how much time was spent in sub-components and
+  how many times each sub-component was profiled during the event
+  (including sub-components which do not appear in
+  `COQ_PROFILE_COMPONENTS`).
+
+- for the `command` event, `cmd` displays the precise location of the
+  command and a compressed representation of it (like the `-time` header),
+  and `line` is the start line of the command.
 
 .. _compiled-interfaces:
 

--- a/doc/sphinx/practical-tools/utilities.rst
+++ b/doc/sphinx/practical-tools/utilities.rst
@@ -734,8 +734,10 @@ variables are already accessible in recipes for rules added in
 Timing targets and performance testing
 ++++++++++++++++++++++++++++++++++++++
 
-The generated ``Makefile`` supports the generation of two kinds of timing
-data: per-file build-times, and per-line times for an individual file.
+The generated ``Makefile`` supports the generation of three kinds of
+timing data: per-file build-times, per-line times for an individual
+file, and profiling data in Google trace format for an individual
+file.
 
 The following targets and Makefile variables allow collection of per-
 file timing data:
@@ -875,7 +877,7 @@ line timing data:
 
 
 + ``TIMING=1``
-    passing this variable will cause ``make`` to use ``coqc -time`` to
+    passing this variable will cause ``make`` to use ``coqc -time-file`` to
     write to a ``.v.timing`` file for each ``.v`` file compiled, which contains
     line-by-line timing information.
 
@@ -972,6 +974,13 @@ line timing data:
     .. note::
       This target requires python to build the table.
 
++ ``PROFILE=1``
+  passing this variable or setting it in the environment will cause
+  ``make`` to use ``coqc -profile`` to write to a ``.v.prof.json``
+  file for each ``.v`` file compiled, which contains :ref:`profiling`
+  information.
+
+  The ``.v.prof.json`` is then compressed by ``gzip`` to a ``.v.prof.json.gz``.
 
 Building a subset of the targets with ``-j``
 ++++++++++++++++++++++++++++++++++++++++++++

--- a/doc/sphinx/practical-tools/utilities.rst
+++ b/doc/sphinx/practical-tools/utilities.rst
@@ -735,9 +735,9 @@ Timing targets and performance testing
 ++++++++++++++++++++++++++++++++++++++
 
 The generated ``Makefile`` supports the generation of three kinds of
-timing data: per-file build-times, per-line times for an individual
-file, and profiling data in Google trace format for an individual
-file.
+timing data: per-file build-times, per-line times for individual
+files, and profiling data in Google trace format for individual
+files.
 
 The following targets and Makefile variables allow collection of per-
 file timing data:

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -2585,7 +2585,9 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
       a :: (intern_args env subscopes args)
 
   in
-  intern env c
+  NewProfile.profile "intern" (fun () ->
+      intern env c)
+    ()
 
 (**************************************************************************)
 (* Functions to translate constr_expr into glob_constr                    *)

--- a/kernel/conversion.ml
+++ b/kernel/conversion.ml
@@ -864,15 +864,16 @@ and convert_list l2r infos lft1 lft2 v1 v2 cuniv = match v1, v2 with
 | _, _ -> raise NotConvertible
 
 let clos_gen_conv trans cv_pb l2r evars env graph univs t1 t2 =
-  let reds = CClosure.RedFlags.red_add_transparent betaiotazeta trans in
-  let infos = create_conv_infos ~univs:graph ~evars reds env in
-  let infos = {
-    cnv_inf = infos;
-    lft_tab = create_tab ();
-    rgt_tab = create_tab ();
-  } in
-  ccnv cv_pb l2r infos el_id el_id (inject t1) (inject t2) univs
-
+  NewProfile.profile "Conversion" (fun () ->
+      let reds = CClosure.RedFlags.red_add_transparent betaiotazeta trans in
+      let infos = create_conv_infos ~univs:graph ~evars reds env in
+      let infos = {
+        cnv_inf = infos;
+        lft_tab = create_tab ();
+        rgt_tab = create_tab ();
+      } in
+      ccnv cv_pb l2r infos el_id el_id (inject t1) (inject t2) univs)
+    ()
 
 let check_eq univs u u' =
   if not (UGraph.check_eq_sort univs u u') then raise NotConvertible

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -853,6 +853,9 @@ and execute_array env cs =
   let cs = Array.Smart.map_i (fun i c -> let c, ty = execute env c in tys.(i) <- ty; c) cs in
   cs, tys
 
+let execute env c =
+  NewProfile.profile "Typeops.infer" (fun () -> execute env c) ()
+
 (* Derived functions *)
 
 let check_wellformed_universes env c =
@@ -860,6 +863,9 @@ let check_wellformed_universes env c =
   try UGraph.check_declared_universes (universes env) univs
   with UGraph.UndeclaredLevel u ->
     error_undeclared_universe env u
+
+let check_wellformed_universes env c =
+  NewProfile.profile "check-wf-univs" (fun () -> check_wellformed_universes env c) ()
 
 let infer env constr =
   let () = check_wellformed_universes env constr in

--- a/kernel/vars.ml
+++ b/kernel/vars.ml
@@ -409,3 +409,8 @@ let universes_of_constr c =
       Constr.fold aux s c
     | _ -> Constr.fold aux s c
   in aux Level.Set.empty c
+
+let universes_of_constr c =
+  NewProfile.profile "universes_of_constr" (fun () ->
+      universes_of_constr c)
+    ()

--- a/kernel/vconv.ml
+++ b/kernel/vconv.ml
@@ -223,4 +223,9 @@ let vm_conv cv_pb env t1 t2 =
   in
   if not b then
     let state = (univs, checked_universes) in
-    let _ = vm_conv_gen cv_pb Genlambda.empty_evars env state t1 t2 in ()
+    let _ : UGraph.t =
+      NewProfile.profile "vm_conv" (fun () ->
+          vm_conv_gen cv_pb Genlambda.empty_evars env state t1 t2)
+        ()
+    in
+    ()

--- a/lib/newProfile.ml
+++ b/lib/newProfile.ml
@@ -1,0 +1,136 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+type settings =
+  { file : string
+  }
+
+type accu =
+  | No
+  | File of out_channel
+
+let accu = ref No
+
+let pid = Unix.getpid()
+
+let is_profiling () = !accu <> No
+
+let f fmt = match !accu with
+  | No -> assert false
+  | File ch -> Printf.fprintf ch fmt
+
+module MiniJson = struct
+  type t =
+    | String of string
+    | Int of string (* string not int so that we can have large ints *)
+    | Record of (string * t) list
+    | Array of t list
+
+  let rec pr ch = function
+    | String s ->
+      let s = String.split_on_char '"' s in
+      let s = String.concat "\\\"" s in
+      Printf.fprintf ch "\"%s\"" s
+    | Int s -> Printf.fprintf ch "%s" s
+    | Record elts ->
+      Printf.fprintf ch "{ %a }" prrecord elts
+    | Array elts ->
+      Printf.fprintf ch "[\n%a\n]" prarray elts
+
+  and prrecord ch = function
+    | [] -> ()
+    | [(x,v)] -> Printf.fprintf ch "\"%s\": %a" x pr v
+    | (x,v) :: l -> Printf.fprintf ch "\"%s\": %a, %a" x pr v prrecord l
+
+  and prarray ch = function
+    | [] -> ()
+    | [x] -> pr ch x
+    | x :: l -> Printf.fprintf ch "%a,\n%a" pr x prarray l
+
+
+  let pids = string_of_int pid
+  let base = [("pid", Int pids); ("tid", Int pids)]
+
+  let duration ~name ~ph ~ts ?args () =
+    let l = ("name", String name) :: ("ph", String ph) :: ("ts", Int ts) :: base in
+    let l = match args with
+      | None -> l
+      | Some args -> ("args", args) :: l
+    in
+    Record l
+end
+
+let prtime () =
+  let t = Unix.gettimeofday() in
+  Printf.sprintf "%.0f" (t *. 1E6)
+
+let global_start = prtime()
+let global_start_stat = Gc.quick_stat()
+
+let duration_gen ?time name ph ?args last () =
+  let time = match time with None -> prtime() | Some t -> t in
+  f "%a%s\n" MiniJson.pr (MiniJson.duration ~name ~ph ~ts:time ?args ()) last
+
+let duration ?time name ph ?args () = duration_gen ?time name ph ?args "," ()
+let enter ?time name ?args () = duration ?time name "B" ?args  ()
+let leave ?time name ?args () = duration ?time name "E" ?args ()
+
+let make_mem_diff ~(mstart:Gc.stat) ~(mend:Gc.stat) =
+  (* XXX we could use memprof to get sampling stats instead?
+     eg stats about how much of the allocation was collected
+     in the same span vs how much survived it *)
+  let major = mend.major_words -. mstart.major_words in
+  let minor = mend.minor_words -. mstart.minor_words in
+  let pp tdiff = MiniJson.String (Printf.sprintf "%.3G w" tdiff) in
+  MiniJson.Record [("major",pp major); ("minor", pp minor)]
+
+let profile name ?args f () =
+  if not (is_profiling ()) then f ()
+  else begin
+    let args = Option.map (fun f -> f()) args in
+    enter name ?args ();
+    let mstart = Gc.quick_stat () in
+    let v = try f ()
+      with e ->
+        let e = Exninfo.capture e in
+        let mend = Gc.quick_stat () in
+        let args = make_mem_diff ~mstart ~mend in
+        leave name ~args ();
+        Exninfo.iraise e
+    in
+    let mend = Gc.quick_stat () in
+    let args = make_mem_diff ~mstart ~mend in
+    leave name ~args ();
+    v
+  end
+
+let init opts =
+  let () = assert (not (is_profiling())) in
+  match opts with
+  | None ->
+    accu := No
+  | Some { file } ->
+    let ch = open_out file in
+    accu := File ch;
+    f "{ \"traceEvents\": [\n";
+    enter ~time:global_start "process" ();
+    enter ~time:global_start "init" ();
+    leave "init" ~args:(make_mem_diff ~mstart:global_start_stat ~mend:(Gc.quick_stat())) ()
+
+let finish () = match !accu with
+  | No -> ()
+  | File ch ->
+    duration_gen "process" "E" ""
+      ~args:(make_mem_diff ~mstart:global_start_stat ~mend:(Gc.quick_stat()))
+      ();
+    Printf.fprintf ch "],\n\"displayTimeUnit\": \"us\" }";
+    close_out ch
+
+let () = at_exit finish

--- a/lib/newProfile.mli
+++ b/lib/newProfile.mli
@@ -19,6 +19,11 @@ module MiniJson : sig
 end
 
 val profile : string -> ?args:(unit -> (string * MiniJson.t) list) -> (unit -> 'a) -> unit -> 'a
+(** Profile the given function.
+
+    [args] is called only if profiling is active, it is used to
+    produce additional annotations.
+*)
 
 val is_profiling : unit -> bool
 
@@ -27,5 +32,20 @@ type settings =
   }
 
 val init : settings -> unit
+(** Profiling must not be active.
+    Activates profiling with a fresh state. *)
 
 val finish : unit -> unit
+(** Profiling must be active.
+    Deactivates profiling. *)
+
+type accu
+(** Profiling state accumulator. *)
+
+val pause : unit -> accu option
+(** Returns [None] if profiling is inactive.
+    Deactivates profiling if it is active, returning the current state. *)
+
+val resume : accu -> unit
+(** Profiling must not be active.
+    Activates profiling with the given state. *)

--- a/lib/newProfile.mli
+++ b/lib/newProfile.mli
@@ -9,11 +9,13 @@
 (************************************************************************)
 
 module MiniJson : sig
-  type t =
-    | String of string
-    | Int of string (* string not int so that we can have large ints *)
-    | Record of (string * t) list
-    | Array of t list
+  (** Subtype of Yojson.Safe.t *)
+  type t = [
+    | `Intlit of string
+    | `String of string
+    | `Assoc of (string * t) list
+    | `List of t list
+  ]
 end
 
 val profile : string -> ?args:(unit -> (string * MiniJson.t) list) -> (unit -> 'a) -> unit -> 'a

--- a/lib/newProfile.mli
+++ b/lib/newProfile.mli
@@ -1,0 +1,27 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+module MiniJson : sig
+  type t =
+    | String of string
+    | Int of string (* string not int so that we can have large ints *)
+    | Record of (string * t) list
+    | Array of t list
+end
+
+val profile : string -> ?args:(unit -> MiniJson.t) -> (unit -> 'a) -> unit -> 'a
+
+val is_profiling : unit -> bool
+
+type settings =
+  { file : string
+  }
+
+val init : settings option -> unit

--- a/lib/newProfile.mli
+++ b/lib/newProfile.mli
@@ -16,7 +16,7 @@ module MiniJson : sig
     | Array of t list
 end
 
-val profile : string -> ?args:(unit -> MiniJson.t) -> (unit -> 'a) -> unit -> 'a
+val profile : string -> ?args:(unit -> (string * MiniJson.t) list) -> (unit -> 'a) -> unit -> 'a
 
 val is_profiling : unit -> bool
 

--- a/lib/newProfile.mli
+++ b/lib/newProfile.mli
@@ -23,7 +23,9 @@ val profile : string -> ?args:(unit -> (string * MiniJson.t) list) -> (unit -> '
 val is_profiling : unit -> bool
 
 type settings =
-  { file : string
+  { output : Format.formatter
   }
 
-val init : settings option -> unit
+val init : settings -> unit
+
+val finish : unit -> unit

--- a/library/global.ml
+++ b/library/global.ml
@@ -50,18 +50,23 @@ let env () = Safe_typing.env_of_safe_env (safe_env ())
 
 (** Turn ops over the safe_environment state monad to ops on the global env *)
 
-let globalize0 f = GlobalSafeEnv.set_safe_env (f (safe_env ()))
+let prof f () =
+  NewProfile.profile "kernel" f ()
+
+let globalize0 f = prof (fun () -> GlobalSafeEnv.set_safe_env (f (safe_env ()))) ()
 
 let globalize f =
-  let res,env = f (safe_env ()) in GlobalSafeEnv.set_safe_env env; res
+  prof (fun () ->
+      let res,env = f (safe_env ()) in GlobalSafeEnv.set_safe_env env; res)
+    ()
 
 let globalize0_with_summary fs f =
-  let env = f (safe_env ()) in
+  let env = prof (fun () -> f (safe_env ())) () in
   Summary.Interp.unfreeze_summaries fs;
   GlobalSafeEnv.set_safe_env env
 
 let globalize_with_summary fs f =
-  let res,env = f (safe_env ()) in
+  let res,env = prof (fun () -> f (safe_env ())) () in
   Summary.Interp.unfreeze_summaries fs;
   GlobalSafeEnv.set_safe_env env;
   res

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -1859,6 +1859,11 @@ let solve_unif_constraints_with_heuristics env
 
 exception UnableToUnify of evar_map * unification_error
 
+let evar_conv_x flags env evd pb x1 x2 : unification_result =
+  NewProfile.profile "unification" (fun () ->
+      evar_conv_x flags env evd pb x1 x2)
+    ()
+
 let unify_delay ?flags env evd t1 t2 =
   let flags =
     match flags with

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -1407,6 +1407,11 @@ let ise_pretype_gen (flags : inference_flags) env sigma lvar kind c =
   in
   process_inference_flags flags !!env sigma (sigma',c',c'_ty)
 
+let ise_pretype_gen flags env sigma lvar kind c : _ * _ * _ =
+  NewProfile.profile "pretyping" (fun () ->
+      ise_pretype_gen flags env sigma lvar kind c)
+    ()
+
 let default_inference_flags fail = {
   use_coercions = true;
   use_typeclasses = UseTC;

--- a/sysinit/coqargs.ml
+++ b/sysinit/coqargs.ml
@@ -66,6 +66,7 @@ type coqargs_config = {
   native_output_dir : CUnix.physical_path;
   native_include_dirs : CUnix.physical_path list;
   time        : time_config option;
+  profile : string option;
   print_emacs : bool;
 }
 
@@ -121,6 +122,7 @@ let default_config = {
   native_output_dir = ".coq-native";
   native_include_dirs = [];
   time         = None;
+  profile = None;
   print_emacs  = false;
 
   (* Quiet / verbosity options should be here *)
@@ -408,6 +410,7 @@ let parse_args ~usage ~init arglist : t * string list =
       oval
     |"-time" -> { oval with config = { oval.config with time = Some ToFeedback }}
     |"-time-file" -> { oval with config = { oval.config with time = Some (ToFile (next())) }}
+    | "-profile" -> { oval with config = { oval.config with profile = Some (next()) } }
     |"-type-in-type" -> set_logic (fun o -> { o with type_in_type = true }) oval
     |"-unicode" -> add_vo_require oval "Utf8_core" None (Some Lib.Import)
     |"-where" -> set_query oval PrintWhere

--- a/sysinit/coqargs.mli
+++ b/sysinit/coqargs.mli
@@ -58,6 +58,7 @@ type coqargs_config = {
   native_output_dir : CUnix.physical_path;
   native_include_dirs : CUnix.physical_path list;
   time        : time_config option;
+  profile : string option;
   print_emacs : bool;
 }
 

--- a/sysinit/coqinit.ml
+++ b/sysinit/coqinit.ml
@@ -146,6 +146,7 @@ let init_load_paths opts =
 let init_runtime opts =
   let open Coqargs in
   Vernacextend.static_linking_done ();
+  NewProfile.init (Option.map (fun file -> { NewProfile.file }) opts.config.profile);
   Lib.init ();
   init_coqlib opts;
   if opts.post.memory_stat then at_exit print_memory_stat;

--- a/sysinit/coqinit.ml
+++ b/sysinit/coqinit.ml
@@ -143,10 +143,17 @@ let init_load_paths opts =
   let env_ocamlpath = String.concat ocamlpathsep env_ocamlpath in
   Findlib.init ~env_ocamlpath ()
 
+let init_profile ~file =
+  let ch = open_out file in
+  NewProfile.init { output = Format.formatter_of_out_channel ch };
+  at_exit (fun () ->
+      NewProfile.finish ();
+      close_out ch)
+
 let init_runtime opts =
   let open Coqargs in
   Vernacextend.static_linking_done ();
-  NewProfile.init (Option.map (fun file -> { NewProfile.file }) opts.config.profile);
+  Option.iter (fun file -> init_profile ~file) opts.config.profile;
   Lib.init ();
   init_coqlib opts;
   if opts.post.memory_stat then at_exit print_memory_stat;

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -1065,11 +1065,13 @@ module Search = struct
       ~depth ~dep:(unique || dep) hints in
     run_on_evars env evd p eauto_tac
 
-  let typeclasses_eauto env evd ?depth unique ~best_effort st hints p =
-    evars_eauto env evd depth true ~best_effort unique false st hints p
   (** Typeclasses eauto is an eauto which tries to resolve only
       goals of typeclass type, and assumes that the initially selected
       evars in evd are independent of the rest of the evars *)
+  let typeclasses_eauto env evd ?depth unique ~best_effort st hints p =
+    NewProfile.profile "typeclass search" (fun () ->
+        evars_eauto env evd depth true ~best_effort unique false st hints p)
+      ()
 
   let typeclasses_resolve env evd depth unique ~best_effort p =
     let db = searchtable_map typeclasses_db in

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -307,6 +307,14 @@ else
   TIMING_ARG=
 endif
 
+ifneq (,$(PROFILING))
+  PROFILE_ARG=-profile $<.prof.json
+  PROFILE_ZIP=gzip $<.prof.json
+else
+  PROFILE_ARG=
+  PROFILE_ZIP=true
+endif
+
 # Files #######################################################################
 #
 # We here define a bunch of variables about the files being part of the
@@ -810,7 +818,7 @@ define globvorule=
 # take care to $$ variables using $< etc
   $(1).vo $(1).glob &: $(1).v | $(VDFILE)
 	$(SHOW)COQC $(1).v
-	$(HIDE)$$(TIMER) $(COQC) $(COQDEBUG) $$(TIMING_ARG) $(COQFLAGS) $(COQLIBS) $(1).v
+	$(HIDE)$$(TIMER) $(COQC) $(COQDEBUG) $$(TIMING_ARG) $$(PROFILE_ARG) $(COQFLAGS) $(COQLIBS) $(1).v
 ifeq ($(COQDONATIVE), "yes")
 	$(SHOW)COQNATIVE $(1).vo
 	$(HIDE)$(call TIMER,$(1).vo.native) $(COQNATIVE) $(COQLIBS) $(1).vo
@@ -821,7 +829,8 @@ else
 
 $(VOFILES): %.vo: %.v | $(VDFILE)
 	$(SHOW)COQC $<
-	$(HIDE)$(TIMER) $(COQC) $(COQDEBUG) $(TIMING_ARG) $(COQFLAGS) $(COQLIBS) $<
+	$(HIDE)$(TIMER) $(COQC) $(COQDEBUG) $(TIMING_ARG) $(PROFILE_ARG) $(COQFLAGS) $(COQLIBS) $<
+	$(HIDE)$(PROFILE_ZIP)
 ifeq ($(COQDONATIVE), "yes")
 	$(SHOW)COQNATIVE $@
 	$(HIDE)$(call TIMER,$@.native) $(COQNATIVE) $(COQLIBS) $@

--- a/toplevel/vernac.ml
+++ b/toplevel/vernac.ml
@@ -128,8 +128,8 @@ let load_vernac_core ~echo ~check ~state ?source file =
                      | None -> "unknown"
                      | Some loc -> string_of_int loc.line_nb
                    in
-                   [("cmd", String (Pp.string_of_ppcmds (Topfmt.pr_cmd_header ast)));
-                    ("line", String lnum)])
+                   [("cmd", `String (Pp.string_of_ppcmds (Topfmt.pr_cmd_header ast)));
+                    ("line", `String lnum)])
                (fun () ->
              Flags.silently (interp_vernac ~check ~state) ast) ())
           ()

--- a/toplevel/vernac.ml
+++ b/toplevel/vernac.ml
@@ -124,7 +124,12 @@ let load_vernac_core ~echo ~check ~state ?source file =
           (fun () ->
              NewProfile.profile "command"
                ~args:(fun () ->
-                   [("cmd", String (Pp.string_of_ppcmds (Topfmt.pr_cmd_header ast)))])
+                   let lnum = match ast.loc with
+                     | None -> "unknown"
+                     | Some loc -> string_of_int loc.line_nb
+                   in
+                   [("cmd", String (Pp.string_of_ppcmds (Topfmt.pr_cmd_header ast)));
+                    ("line", String lnum)])
                (fun () ->
              Flags.silently (interp_vernac ~check ~state) ast) ())
           ()

--- a/toplevel/vernac.ml
+++ b/toplevel/vernac.ml
@@ -124,7 +124,7 @@ let load_vernac_core ~echo ~check ~state ?source file =
           (fun () ->
              NewProfile.profile "command"
                ~args:(fun () ->
-                   Record [("cmd", String (Pp.string_of_ppcmds (Topfmt.pr_cmd_header ast)))])
+                   [("cmd", String (Pp.string_of_ppcmds (Topfmt.pr_cmd_header ast)))])
                (fun () ->
              Flags.silently (interp_vernac ~check ~state) ast) ())
           ()

--- a/vernac/vernacstate.ml
+++ b/vernac/vernacstate.ml
@@ -198,8 +198,10 @@ let freeze_full_state () =
   }
 
 let unfreeze_full_state st =
-  Synterp.unfreeze st.synterp;
-  Interp.unfreeze_interp_state st.interp
+  NewProfile.profile "unfreeze_full_state" (fun () ->
+      Synterp.unfreeze st.synterp;
+      Interp.unfreeze_interp_state st.interp)
+    ()
 
 (* Compatibility module *)
 module Declare_ = struct
@@ -257,10 +259,14 @@ module Declare_ = struct
   let return_partial_proof () = cc Declare.Proof.return_partial_proof
 
   let close_future_proof ~feedback_id pf =
-    cc (fun pt -> Declare.Proof.close_future_proof ~feedback_id pt pf)
+    NewProfile.profile "close_future_proof" (fun () ->
+        cc (fun pt -> Declare.Proof.close_future_proof ~feedback_id pt pf))
+      ()
 
   let close_proof ~opaque ~keep_body_ucst_separate =
-    cc (fun pt -> Declare.Proof.close_proof ~opaque ~keep_body_ucst_separate pt)
+    NewProfile.profile "close_proof" (fun () ->
+        cc (fun pt -> Declare.Proof.close_proof ~opaque ~keep_body_ucst_separate pt))
+      ()
 
   let discard_all () = s_lemmas := None
   let update_sigma_univs ugraph = dd (Declare.Proof.update_sigma_univs ugraph)


### PR DESCRIPTION
(trace format doc: https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/edit)

display using https://profiler.firefox.com/
or https://ui.perfetto.dev/
(or in chrome's builtin display but I didn't test it)

Example visualization (in perfetto):

- peano_naturals from HoTT (1MB gzipped)
![peano_nats](https://github.com/coq/coq/assets/2461932/6990ce40-06af-432a-ba5c-00926a649a13)

- hurkens from stdlib (3MB uncompressed, 170KB gzipped)
![hurkens](https://github.com/coq/coq/assets/2461932/8869fd3c-704e-46bf-b28d-0928c193e7b9)

- example from https://github.com/coq/coq/issues/13977 (120MB uncompressed, 4MB gzipped)
![bad](https://github.com/coq/coq/assets/2461932/bd36ee7d-0ca0-4ba5-b596-4654bdaa9ea7)
