### PR TITLE
No special treatment of holes in pretype_type

### DIFF
--- a/test-suite/bugs/bug_10029.v
+++ b/test-suite/bugs/bug_10029.v
@@ -1,0 +1,8 @@
+Theorem foo : Set.
+pose (b := True).
+Fail let a := b in refine (?[a] -> ?[a] = 1).
+(* only [a]: exact nat. *)
+(* only [b]: exact 3. *)
+(* Qed. *)
+(* Print foo. *)
+(* (* foo = let b := True in nat -> 3 = 1 : Set *) *)


### PR DESCRIPTION
AFAICT we only create an evar when there's a valcon for the sake of broken pattern_of_constr and similar.

Fix #10029