### PR TITLE
Improve warning for nonuniform coercions

### DIFF
--- a/doc/sphinx/addendum/implicit-coercions.rst
+++ b/doc/sphinx/addendum/implicit-coercions.rst
@@ -205,7 +205,7 @@ Coercion Classes
 
      The inferred target class of the coercion differs from the one specified.
 
-  .. warn:: @qualid does not respect the uniform inheritance condition.
+  .. warn:: @qualid does not respect the uniform inheritance condition. Use the '#[nonuniform]' attribute to silence this warning (available since Coq 8.16.0).
 
      The :ref:`test for ambiguous coercion paths <ambiguous-paths>`
      may yield false positives involving the coercion :token:`qualid`.

--- a/test-suite/output/bug_5222.out
+++ b/test-suite/output/bug_5222.out
@@ -3,8 +3,9 @@
   ============================
   True = (nil : T1 nat)
 File "./output/bug_5222.v", line 16, characters 2-40:
-Warning: C2 does not respect the uniform inheritance condition.
-[uniform-inheritance,coercions,default]
+Warning: C2 does not respect the uniform inheritance condition. Use the
+'#[nonuniform]' attribute to silence this warning (available since Coq
+8.16.0). [uniform-inheritance,coercions,default]
 1 goal
   
   ============================

--- a/test-suite/output/coercions_nonuniform.out
+++ b/test-suite/output/coercions_nonuniform.out
@@ -1,9 +1,11 @@
 File "./output/coercions_nonuniform.v", line 22, characters 0-21:
-Warning: f does not respect the uniform inheritance condition.
-[uniform-inheritance,coercions,default]
+Warning: f does not respect the uniform inheritance condition. Use the
+'#[nonuniform]' attribute to silence this warning (available since Coq
+8.16.0). [uniform-inheritance,coercions,default]
 File "./output/coercions_nonuniform.v", line 55, characters 0-17:
-Warning: f' does not respect the uniform inheritance condition.
-[uniform-inheritance,coercions,default]
+Warning: f' does not respect the uniform inheritance condition. Use the
+'#[nonuniform]' attribute to silence this warning (available since Coq
+8.16.0). [uniform-inheritance,coercions,default]
 File "./output/coercions_nonuniform.v", line 71, characters 7-17:
 The command has indeed failed with message:
 This command does not support this attribute: nonuniform.

--- a/vernac/comCoercion.ml
+++ b/vernac/comCoercion.ml
@@ -299,7 +299,9 @@ let warn_uniform_inheritance =
   CWarnings.create ~name:"uniform-inheritance" ~category:CWarnings.CoreCategories.coercions
          (fun g ->
           Printer.pr_global g ++
-            strbrk" does not respect the uniform inheritance condition.")
+            strbrk" does not respect the uniform inheritance condition. \
+                   Use the '#[nonuniform]' attribute to silence this warning \
+                   (available since Coq 8.16.0).")
 
 let add_new_coercion_core coef stre poly ~nonuniform ~reversible source target isid : unit =
   check_source source;


### PR DESCRIPTION
So as to better advertize the attribute introduced in https://github.com/coq/coq/pull/15853

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
<!-- Fixes / closes #???? -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] ~Added **changelog**.~
- [x] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [x] Documented any new / changed **user messages**.
  - [ ] ~Updated **documented syntax** by running `make doc_gram_rsts`.~

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] ~Opened **overlay** pull requests.~

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
