### PR TITLE
Stop implicitly adding template inductive types to Keep Equality table.

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/17718-no-template-keep-inj-equality.rst
+++ b/doc/changelog/08-vernac-commands-and-options/17718-no-template-keep-inj-equality.rst
@@ -1,0 +1,7 @@
+- **Changed:**
+  :attr:`Template polymorphic <universes(template)>` inductive types are
+  not implicitly added to the :table:`Keep Equalities` table anymore when
+  defined. This may change the behavior of equality-related tactics on
+  such types
+  (`#17718 <https://github.com/coq/coq/pull/17718>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/proofs/writing-proofs/reasoning-inductives.rst
+++ b/doc/sphinx/proofs/writing-proofs/reasoning-inductives.rst
@@ -710,8 +710,6 @@ This section describes some special purpose tactics to work with
       This :term:`table` specifies a set of inductive types for which proof
       equalities are always kept by :tacn:`injection`. This overrides the
       :flag:`Keep Proof Equalities` flag for those inductive types.
-      :attr:`Template polymorphic <universes(template)>` inductive types are
-      implicitly added to this table when defined.
       Use the :cmd:`Add` and :cmd:`Remove` commands to update this set manually.
 
 .. tacn:: simplify_eq {? @induction_arg }

--- a/test-suite/bugs/bug_3125.v
+++ b/test-suite/bugs/bug_3125.v
@@ -3,7 +3,11 @@
 
 (* This is also #4560 and #6273 *)
 
+#[universes(template)]
+#[warnings="-no-template-universe"]
 Inductive foo := foo_1.
+
+Add Keep Equalities foo.
 
 Goal forall (a b : foo), Some a = Some b -> a = b.
 Proof.

--- a/vernac/declareInd.ml
+++ b/vernac/declareInd.ml
@@ -164,7 +164,6 @@ let declare_mutual_inductive_with_eliminations ?(primitive_expected=false) ?typi
   end;
   let names = List.map (fun e -> e.mind_entry_typename) mie.mind_entry_inds in
   let mind, prim = declare_mind ?typing_flags mie in
-  let is_template = match mie.mind_entry_universes with Template_ind_entry _ -> true | _ -> false in
   if primitive_expected && not prim then warn_non_primitive_record (mind,0);
   DeclareUniv.declare_univ_binders (GlobRef.IndRef (mind,0)) ubinders;
   List.iteri (fun i (indimpls, constrimpls) ->
@@ -178,8 +177,6 @@ let declare_mutual_inductive_with_eliminations ?(primitive_expected=false) ?typi
         constrimpls)
     impls;
   Flags.if_verbose Feedback.msg_info (minductive_message names);
-  if is_template then
-    List.iteri (fun i _ -> Equality.set_keep_equality (mind, i) true) mie.mind_entry_inds;
   let locmap = Ind_tables.Locmap.make mind indlocs in
   if mie.mind_entry_private == None
   then Indschemes.declare_default_schemes mind ~locmap;


### PR DESCRIPTION
The reason why the flag was introduced was precisely to be able to desynchronize the template status from the equality keeping behaviour. Since the Keep Equality flag has been around since 8.15 it is now time to perform this change.