### PR TITLE
Stop handling evars as free variables in the VM.

### DIFF
--- a/dev/ci/user-overlays/17719-ppedrot-vm-evar-global.sh
+++ b/dev/ci/user-overlays/17719-ppedrot-vm-evar-global.sh
@@ -1,0 +1,1 @@
+overlay serapi https://github.com/ppedrot/coq-serapi vm-evar-global 17719

--- a/kernel/vmbytecodes.ml
+++ b/kernel/vmbytecodes.ml
@@ -77,7 +77,6 @@ type fv_elem =
   | FVnamed of Id.t
   | FVrel of int
   | FVuniv_var of int
-  | FVevar of Evar.t
 
 type fv = fv_elem array
 
@@ -99,7 +98,6 @@ let pp_fv_elem = function
   | FVnamed id -> str "FVnamed(" ++ Id.print id ++ str ")"
   | FVrel i -> str "Rel(" ++ int i ++ str ")"
   | FVuniv_var v -> str "FVuniv(" ++ int v ++ str ")"
-  | FVevar e -> str "FVevar(" ++ int (Evar.repr e) ++ str ")"
 
 let rec pp_instr i =
   match i with

--- a/kernel/vmbytecodes.mli
+++ b/kernel/vmbytecodes.mli
@@ -78,7 +78,6 @@ type fv_elem =
   FVnamed of Id.t
 | FVrel of int
 | FVuniv_var of int
-| FVevar of Evar.t
 
 type fv = fv_elem array
 

--- a/kernel/vmemitcodes.ml
+++ b/kernel/vmemitcodes.ml
@@ -476,7 +476,7 @@ type to_patch = emitcodes * patches
 let subst_strcst s sc =
   match sc with
   | Const_sort _ | Const_b0 _ | Const_univ_level _ | Const_val _ | Const_uint _
-  | Const_float _ -> sc
+  | Const_float _ | Const_evar _ -> sc
   | Const_ind ind -> let kn,i = ind in Const_ind (subst_mind s kn, i)
 
 let subst_annot _ (a : annot_switch) = a

--- a/kernel/vmsymtable.ml
+++ b/kernel/vmsymtable.ml
@@ -298,7 +298,6 @@ and slot_for_fv env sigma fv envcache table =
         cache_rel envcache i v; v
       | Some v -> v
       end
-  | FVevar evk -> val_of_evar evk
   | FVuniv_var _idu ->
     assert false
 

--- a/kernel/vmvalues.mli
+++ b/kernel/vmvalues.mli
@@ -37,6 +37,7 @@ val cofix_evaluated_tag : tag
 type structured_constant =
   | Const_sort of Sorts.t
   | Const_ind of inductive
+  | Const_evar of Evar.t
   | Const_b0 of tag
   | Const_univ_level of Univ.Level.t
   | Const_val of structured_values


### PR DESCRIPTION
Instead we rely on the structured constant mechanism, which globally allocates them. This is more efficient as it does not require to carry along evar values in closures.