### PR TITLE
[CI] Test MathComp 2 in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,7 @@ variables:
   # echo $(md5sum dev/ci/docker/old_ubuntu_lts/Dockerfile | head -c 10)
   # echo $(md5sum dev/ci/docker/edge_ubuntu/Dockerfile | head -c 10)
   BASE_CACHEKEY: "old_ubuntu_lts-V2023-06-30-8ca33f9dfd"
-  EDGE_CACHEKEY: "edge_ubuntu-V2023-08-09-59f73e4e82"
+  EDGE_CACHEKEY: "edge_ubuntu-V2023-08-28-93124ee272"
   BASE_IMAGE: "$CI_REGISTRY_IMAGE:$BASE_CACHEKEY"
   EDGE_IMAGE: "$CI_REGISTRY_IMAGE:$EDGE_CACHEKEY"
 
@@ -647,7 +647,7 @@ library:ci-fcsl_pcm:
   extends: .ci-template-flambda
   needs:
   - build:edge+flambda
-  - library:ci-mathcomp
+  - library:ci-mathcomp_1
 
 library:ci-fiat_crypto:
   extends: .ci-template-flambda
@@ -689,12 +689,14 @@ library:ci-oddorder:
   extends: .ci-template-flambda
   needs:
   - build:edge+flambda
+  - plugin:ci-elpi_hb
   - library:ci-mathcomp
 
 library:ci-fourcolor:
   extends: .ci-template-flambda
   needs:
   - build:edge+flambda
+  - plugin:ci-elpi_hb
   - library:ci-mathcomp
 
 library:ci-corn:
@@ -721,36 +723,44 @@ library:ci-math_classes:
 
 library:ci-mathcomp:
   extends: .ci-template-flambda
+  needs:
+  - build:edge+flambda
+  - plugin:ci-elpi_hb  # for Hierarchy Builder
+
+library:ci-mathcomp_1:
+  extends: .ci-template-flambda
 
 library:ci-mathcomp_test:
   extends: .ci-template-flambda
   needs:
   - build:edge+flambda
+  - plugin:ci-elpi_hb
   - library:ci-mathcomp
 
 library:ci-mczify:
   extends: .ci-template-flambda
   needs:
   - build:edge+flambda
+  - plugin:ci-elpi_hb
   - library:ci-mathcomp
 
 library:ci-finmap:
   extends: .ci-template-flambda
   needs:
   - build:edge+flambda
-  - library:ci-mathcomp
+  - library:ci-mathcomp_1
 
 library:ci-bigenough:
   extends: .ci-template-flambda
   needs:
   - build:edge+flambda
-  - library:ci-mathcomp
+  - library:ci-mathcomp_1
 
 library:ci-analysis:
   extends: .ci-template-flambda
   needs:
   - build:edge+flambda
-  - library:ci-mathcomp
+  - library:ci-mathcomp_1
   - library:ci-finmap
   - library:ci-bigenough
   - plugin:ci-elpi_hb  # for Hierarchy Builder
@@ -792,19 +802,19 @@ library:ci-deriving:
   extends: .ci-template-flambda
   needs:
   - build:edge+flambda
-  - library:ci-mathcomp
+  - library:ci-mathcomp_1
 
 library:ci-mathcomp_word:
   extends: .ci-template-flambda
   needs:
   - build:edge+flambda
-  - library:ci-mathcomp
+  - library:ci-mathcomp_1
 
 library:ci-jasmin:
   extends: .ci-template-flambda
   needs:
   - build:edge+flambda
-  - library:ci-mathcomp
+  - library:ci-mathcomp_1
   - library:ci-mathcomp_word
 
 library:ci-coq_library_undecidability:
@@ -847,6 +857,8 @@ plugin:ci-coqhammer:
 
 plugin:ci-elpi_hb:
   extends: .ci-template-flambda
+  needs:
+  - build:edge+flambda
 
 plugin:ci-elpi_test:
   extends: .ci-template-flambda
@@ -905,7 +917,7 @@ plugin:ci-quickchick:
   extends: .ci-template-flambda
   needs:
   - build:edge+flambda
-  - library:ci-mathcomp
+  - library:ci-mathcomp_1
 
 plugin:ci-quickchick_test:
   extends: .ci-template-flambda
@@ -920,8 +932,9 @@ plugin:ci-relation_algebra:
   extends: .ci-template-flambda
   needs:
   - build:edge+flambda
-  - plugin:ci-aac_tactics
+  - plugin:ci-elpi_hb
   - library:ci-mathcomp
+  - plugin:ci-aac_tactics
 
 plugin:ci-rewriter:
   extends: .ci-template-flambda
@@ -933,7 +946,8 @@ plugin:ci-serapi_test:
   extends: .ci-template-flambda
   needs:
   - build:edge+flambda
-  - library:ci-mathcomp
+  - plugin:ci-elpi_hb
+  - library:ci-mathcomp_1
   - plugin:ci-serapi
 
 plugin:ci-coq_lsp:

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -59,6 +59,7 @@ CI_TARGETS= \
     ci-lean_importer \
     ci-ltac2_compiler \
     ci-math_classes \
+    ci-mathcomp_1 \
     ci-mathcomp \
     ci-mathcomp_test \
     ci-mathcomp_word \
@@ -107,9 +108,11 @@ ci-category_theory: ci-equations
 
 ci-color: ci-bignums
 
+ci-mathcomp: ci-elpi_hb
+
 ci-coqprime: ci-bignums
 ci-coquelicot: ci-mathcomp
-ci-deriving: ci-mathcomp
+ci-deriving: ci-mathcomp_1
 ci-math_classes: ci-bignums
 
 ci-corn: ci-math_classes
@@ -123,12 +126,12 @@ ci-fiat_crypto_ocaml: ci-fiat_crypto
 
 ci-fourcolor: ci-mathcomp
 ci-oddorder: ci-mathcomp
-ci-fcsl_pcm: ci-mathcomp
+ci-fcsl_pcm: ci-mathcomp_1
 ci-mczify: ci-mathcomp
 ci-mathcomp_test: ci-mathcomp
-ci-mathcomp_word: ci-mathcomp
-ci-finmap: ci-mathcomp
-ci-bigenough: ci-mathcomp
+ci-mathcomp_word: ci-mathcomp_1
+ci-finmap: ci-mathcomp_1
+ci-bigenough: ci-mathcomp_1
 ci-analysis: ci-elpi_hb ci-finmap ci-bigenough
 
 ci-elpi_test: ci-elpi_hb
@@ -139,7 +142,7 @@ ci-jasmin: ci-mathcomp_word
 ci-iris: ci-autosubst
 
 ci-simple_io: ci-ext_lib
-ci-quickchick: ci-ext_lib ci-simple_io ci-mathcomp
+ci-quickchick: ci-ext_lib ci-simple_io ci-mathcomp_1
 ci-quickchick_test: ci-quickchick
 ci-itree: ci-ext_lib ci-paco
 ci-itree_io: ci-itree ci-simple_io
@@ -159,7 +162,7 @@ ci-compcert: ci-menhir ci-flocq
 
 ci-relation_algebra: ci-aac_tactics ci-mathcomp
 
-ci-serapi_test: ci-mathcomp ci-serapi
+ci-serapi_test: ci-mathcomp_1 ci-serapi
 
 ci-coq_lsp: ci-serapi
 

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -42,29 +42,23 @@ function project {
 ########################################################################
 # MathComp
 ########################################################################
-project mathcomp "https://github.com/math-comp/math-comp" "mathcomp-1"
+project mathcomp "https://github.com/math-comp/math-comp" "master"
 
-project fourcolor "https://github.com/math-comp/fourcolor" "e831b0b00e264285f91938917a0a5ef64ec1a829"
-# put back master when testing MathComp 2
-# project fourcolor "https://github.com/math-comp/fourcolor" "master"
+project mathcomp_1 "https://github.com/math-comp/math-comp" "mathcomp-1"
 
-project oddorder "https://github.com/math-comp/odd-order" "2c03794e64eef467442a4ea2ef1430b13b0faa97"
-# put back master when testing MathComp 2
-# project oddorder "https://github.com/math-comp/odd-order" "master"
+project fourcolor "https://github.com/math-comp/fourcolor" "master"
 
-project mczify "https://github.com/math-comp/mczify" "2046446984f7b8c8f5102df4df6076b60874e688"
-# put back master when testing MathComp 2
-# project mczify "https://github.com/math-comp/mczify" "master"
+project oddorder "https://github.com/math-comp/odd-order" "master"
+
+project mczify "https://github.com/math-comp/mczify" "master"
 
 project finmap "https://github.com/math-comp/finmap" "cea9f088c9cddea1173bc2f7c4c7ebda35081b60"
-# put back master when testing MathComp 2
+# put back master when Analysis master moves to MathComp 2
 # project finmap "https://github.com/math-comp/finmap" "master"
 
 project bigenough "https://github.com/math-comp/bigenough" "master"
 
-project analysis "https://github.com/math-comp/analysis" "9193f4a1278409cc13a1de739adf3620aa24a638"
-# put back master when testing MathComp 2
-# project analysis "https://github.com/math-comp/analysis" "master"
+project analysis "https://github.com/math-comp/analysis" "master"
 
 ########################################################################
 # UniMath
@@ -219,7 +213,7 @@ project equations "https://github.com/mattam82/Coq-Equations" "main"
 ########################################################################
 project elpi "https://github.com/LPCIC/coq-elpi" "coq-master"
 
-project hierarchy_builder "https://github.com/math-comp/hierarchy-builder" "coq-master"
+project hierarchy_builder "https://github.com/math-comp/hierarchy-builder" "master"
 
 ########################################################################
 # Engine-Bench

--- a/dev/ci/ci-mathcomp_1.sh
+++ b/dev/ci/ci-mathcomp_1.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+git_download mathcomp_1
+
+if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
+
+( cd "${CI_BUILD_DIR}/mathcomp_1/mathcomp"
+  make
+  make install
+)

--- a/dev/ci/docker/edge_ubuntu/Dockerfile
+++ b/dev/ci/docker/edge_ubuntu/Dockerfile
@@ -41,7 +41,7 @@ ENV COMPILER="4.14.1" \
     BASE_OPAM="zarith.1.11 ounit2.2.2.6" \
     CI_OPAM="ocamlgraph.2.0.0 cppo.1.6.9" \
     BASE_OPAM_EDGE="dune.3.6.1 dune-build-info.3.6.1 dune-release.1.6.2 ocamlfind.1.9.5 odoc.2.1.1" \
-    CI_OPAM_EDGE="elpi.1.16.5 ppx_import.1.10.0 cmdliner.1.1.1 sexplib.v0.15.1 ppx_sexp_conv.v0.15.1 ppx_hash.v0.15.0 ppx_compare.v0.15.0 ppx_deriving_yojson.3.7.0 yojson.1.7.0 uri.4.2.0 ppx_yojson_conv.v0.15.1 ppx_inline_test.v0.15.1 ppx_assert.v0.15.0 lsp.1.16.2" \
+    CI_OPAM_EDGE="elpi.1.17.0 ppx_import.1.10.0 cmdliner.1.1.1 sexplib.v0.15.1 ppx_sexp_conv.v0.15.1 ppx_hash.v0.15.0 ppx_compare.v0.15.0 ppx_deriving_yojson.3.7.0 yojson.2.1.0 uri.4.2.0 ppx_yojson_conv.v0.15.1 ppx_inline_test.v0.15.1 ppx_assert.v0.15.0 lsp.1.16.2" \
     COQIDE_OPAM_EDGE="lablgtk3-sourceview3.3.1.3"
 
 # EDGE+flambda switch, we install CI_OPAM as to be able to use


### PR DESCRIPTION
Keep a mathcomp_1 target for targets that are not (yet) ported to MC2: analysis, deriving, fcsl_pcm, mathcomp_word, jasmin and serapi_test

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
<!-- Fixes / closes #???? -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] ~Added / updated **test-suite**.~

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] ~Added **changelog**.~
- [ ] ~Added / updated **documentation**.~
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] ~Documented any new / changed **user messages**.~
  - [ ] ~Updated **documented syntax** by running `make doc_gram_rsts`.~

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] ~Opened **overlay** pull requests.~

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
