### PR TITLE
Arith: fix doc typos

### DIFF
--- a/theories/NArith/Nnat.v
+++ b/theories/NArith/Nnat.v
@@ -15,7 +15,7 @@ Require Import BinPos BinNat PeanoNat Pnat.
 Module N2Nat.
 
 (** [N.to_nat] is a bijection between [N] and [nat],
-    with [Pos.of_nat] as reciprocal.
+    with [N.of_nat] as reciprocal.
     See [Nat2N.id] below for the dual equation. *)
 
 Lemma id a : N.of_nat (N.to_nat a) = a.
@@ -174,7 +174,7 @@ Global Hint Rewrite N2Nat.inj_div N2Nat.inj_mod N2Nat.inj_pow
 Module Nat2N.
 
 (** [N.of_nat] is an bijection between [nat] and [N],
-    with [Pos.to_nat] as reciprocal.
+    with [N.to_nat] as reciprocal.
     See [N2Nat.id] above for the dual equation. *)
 
 Lemma id n : N.to_nat (N.of_nat n) = n.

--- a/theories/ZArith/Znat.v
+++ b/theories/ZArith/Znat.v
@@ -296,7 +296,7 @@ End N2Z.
 Module Z2N.
 
 (** [Z.to_N] is a bijection between non-negative [Z] and [N],
-    with [Pos.of_N] as reciprocal.
+    with [Z.of_N] as reciprocal.
     See [N2Z.id] above for the dual equation. *)
 
 Lemma id n : 0<=n -> Z.of_N (Z.to_N n) = n.
@@ -773,8 +773,8 @@ End Nat2Z.
 Module Z2Nat.
 
 (** [Z.to_nat] is a bijection between non-negative [Z] and [nat],
-    with [Pos.of_nat] as reciprocal.
-    See [nat2Z.id] above for the dual equation. *)
+    with [Z.of_nat] as reciprocal.
+    See [Nat2Z.id] above for the dual equation. *)
 
 Lemma id n : 0<=n -> Z.of_nat (Z.to_nat n) = n.
 Proof.


### PR DESCRIPTION
The reciprocal of `Z.to_N` isn't `Pos.of_N` but  `Z.of_N` (and so on).

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added / updated **documentation**.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
