### PR TITLE
Catch univ inconsistency in Abstract.interpretable_as_section_decl

### DIFF
--- a/tactics/abstract.ml
+++ b/tactics/abstract.ml
@@ -27,7 +27,7 @@ let interpretable_as_section_decl env sigma d1 d2 =
       try
         let _sigma = Evd.add_universe_constraints sigma cstr in
         true
-      with UState.UniversesDiffer -> false
+      with UGraph.UniverseInconsistency _ | UState.UniversesDiffer -> false
   in
   match d2, d1 with
   | LocalDef _, LocalAssum _ -> false

--- a/test-suite/bugs/bug_17727.v
+++ b/test-suite/bugs/bug_17727.v
@@ -1,0 +1,13 @@
+Universes u v.
+Constraint u < v.
+
+Section S.
+  Variable T : Type@{u}.
+
+  Lemma foo : True.
+  Proof.
+    clear T.
+    assert (T : Type@{v}) by exact nat.
+    abstract exact I.
+  Qed.
+End S.


### PR DESCRIPTION
Fix #17727
