### PR TITLE
Set geocoq job to allow_failure

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -722,6 +722,7 @@ library:ci-geocoq:
   needs:
   - build:edge+flambda
   - library:ci-mathcomp
+  allow_failure: true
 
 library:ci-hott:
   extends: .ci-template


### PR DESCRIPTION
It seems they have no CI upstream and ended up breaking our CI, eg https://gitlab.com/coq/coq/-/jobs/4463388843.

By our policy if this doesn't change they will be removed from CI 30 days after we contact them.
