### PR TITLE
Ltac2: expose Tac2core.throw

### DIFF
--- a/plugins/ltac2/tac2core.mli
+++ b/plugins/ltac2/tac2core.mli
@@ -30,6 +30,8 @@ val c_false : ltac_constructor
 
 end
 
+val throw : ?info:Exninfo.info -> exn -> 'a Proofview.tactic
+
 val pf_apply : ?catch_exceptions:bool -> (Environ.env -> Evd.evar_map -> 'a Proofview.tactic) -> 'a Proofview.tactic
 
 module type MapType = sig


### PR DESCRIPTION
Otherwise plugins can't do it as they don't have access to the fatal_flag.
