### PR TITLE
Stop considering Warnings experimental and add more cross-links.

### DIFF
--- a/doc/sphinx/appendix/indexes/index.rst
+++ b/doc/sphinx/appendix/indexes/index.rst
@@ -24,4 +24,4 @@ For reference, here are direct links to the documentation of:
 - :ref:`attributes`
 - :ref:`flags-options-tables`;
 - controlling the display of warning messages with the :opt:`Warnings`
-  option;
+  option or the :attr:`warnings` attribute;

--- a/doc/sphinx/language/core/basic.rst
+++ b/doc/sphinx/language/core/basic.rst
@@ -491,7 +491,8 @@ The following attribute is supported by every command:
    Consequently, using this attribute around an :cmd:`Import` command
    will prevent it from changing the warning state.
 
-   See also :opt:`Warnings`.
+   See also :opt:`Warnings` for the concrete syntax to use inside the
+   quoted string.
 
 .. attr:: warning = @string
    :name: warning

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -967,13 +967,47 @@ Controlling display
 
 .. opt:: Warnings "{+, {? {| - | + } } @ident }"
 
-   This :term:`option` configures the display of warnings. It is experimental, and
-   expects, between quotes, a comma-separated list of warning names or
-   categories. Adding - in front of a warning or category disables it, adding +
-   makes it an error. It is possible to use the special categories all and
-   default, the latter containing the warnings enabled by default. The flags are
+   This :term:`option` configures the display of warnings. The :n:`@ident`\s
+   are warning or category names. Adding `-` in front of a warning or category
+   disables it, adding `+` makes it an error.
+
+   Warning name and categories are printed between brackets when the warning
+   is displayed (the warning name appears first). Warnings can belong to
+   multiple categories. The special category `all` contains all warnings, and
+   the special category `default` contains the warnings enabled by default.
+
+   Coq defines a set of core warning categories, which may be extended by
+   plugins, so this list is not exhaustive. The core categories are:
+   `automation`,
+   `bytecode-compiler`,
+   `coercions`,
+   `deprecated`,
+   `extraction`,
+   `filesystem`,
+   `fixpoints`,
+   `fragile`,
+   `funind`,
+   `implicits`,
+   `ltac`,
+   `ltac2`,
+   `native-compiler`,
+   `numbers`,
+   `parsing`,
+   `pedantic`,
+   `records`,
+   `ssr`,
+   `syntax`,
+   `tactics`,
+   `vernacular`.
+
+   .. This list is from lib/cWarnings.ml
+
+   The flags are
    interpreted from left to right, so in case of an overlap, the flags on the
    right have higher priority, meaning that `A,-A` is equivalent to `-A`.
+
+   See also the :attr:`warnings` attribute, which can be used to
+   configure the display of warnings for a single command.
 
 .. opt:: Debug "{+, {? - } @ident }"
 

--- a/lib/cWarnings.ml
+++ b/lib/cWarnings.ml
@@ -386,6 +386,10 @@ module CoreCategories = struct
 
   let make name = create_category ~name ()
 
+  (* Update the list of core categories in
+     doc/sphinx/proof-engine/vernacular-commands.rst
+     when adding a new category here. *)
+
   let automation = make "automation"
   let bytecode_compiler = make "bytecode-compiler"
   let coercions = make "coercions"


### PR DESCRIPTION
This follows the recent introduction of the `warnings` attribute.