### PR TITLE
univ.ml: Add assertion that all univs in the ucontext instance are globals

### DIFF
--- a/kernel/univ.ml
+++ b/kernel/univ.ml
@@ -798,6 +798,7 @@ struct
 
   let make names (univs, _ as x) =
     assert (Array.length names = Array.length univs);
+    assert (Array.for_all (fun u -> not (Level.is_small u)) univs);
     (names, x)
 
   (** Universe contexts (variables as a list) *)

--- a/kernel/univ.mli
+++ b/kernel/univ.mli
@@ -268,6 +268,8 @@ sig
   type t
 
   val make : Names.Name.t array -> Instance.t constrained -> t
+  (** The name array must be the same length as the instance, and the
+      instance must not contain constant levels (ie no Set). *)
 
   val empty : t
   val is_empty : t -> bool


### PR DESCRIPTION
There might also be vars in practice but let's see.