### PR TITLE
Fatal warnings for duplicate objects in Coq refman.

### DIFF
--- a/doc/sphinx/addendum/extraction.rst
+++ b/doc/sphinx/addendum/extraction.rst
@@ -32,28 +32,25 @@ Generating ML Code
   can be used to refer to any kind of Coq global "object" : :term:`constant`,
   inductive type, inductive constructor or module name.
 
-The next two commands are meant to be used for rapid preview of
-extraction. They both display extracted term(s) inside Coq.
-
 .. cmd:: Extraction @qualid
+         Recursive Extraction {+ @qualid }
+         Extraction @string {+ @qualid }
 
-   Extraction of the mentioned object in the Coq toplevel.
+   The first two forms display the extracted term(s) in Coq as a convenient preview
+   of the extracted term(s):
 
-.. cmd:: Recursive Extraction {+ @qualid }
+   - the first form extracts :n:`@qualid` and displays the resulting term;
+   - the second form extracts the listed :n:`@qualid`\s and all their
+     dependencies, and displays the resulting terms.
 
-   Recursive extraction of all the mentioned objects and
-   all their dependencies in the Coq toplevel.
+   The third form produces a single extraction file named :n:`@string`
+   for all the specified objects and all of their dependencies.
 
-All the following commands produce real ML files. User can choose to
-produce one monolithic file or one file per Coq library.
-
-.. cmd:: Extraction @string {+ @qualid }
-
-   Recursive extraction of all the mentioned objects and all
-   their dependencies in one monolithic file :token:`string`.
-   Global and local identifiers are renamed according to the chosen ML
-   language to fulfill its syntactic conventions, keeping original
+   Global and local identifiers are renamed as needed to fulfill the syntactic
+   requirements of the target language, keeping original
    names as much as possible.
+
+The following commands also generate file(s).
   
 .. cmd:: Extraction Library @ident
 

--- a/doc/sphinx/proof-engine/ltac.rst
+++ b/doc/sphinx/proof-engine/ltac.rst
@@ -1577,19 +1577,13 @@ succeeds, and results in an error otherwise.
    .. exn:: Not equal (due to universes).
       :undocumented:
 
-.. tacn:: constr_eq @one_term @one_term
+   .. tacn:: constr_eq @one_term @one_term
 
-   Like :tacn:`constr_eq_strict`, but may add constraints to make universes equal.
+      Like :tacn:`constr_eq_strict`, but may add constraints to make universes equal.
 
-   .. exn:: Not equal.
-      :undocumented:
+   .. tacn:: constr_eq_nounivs @one_term @one_term
 
-   .. exn:: Not equal (due to universes).
-      :undocumented:
-
-.. tacn:: constr_eq_nounivs @one_term @one_term
-
-   Like :tacn:`constr_eq_strict`, but all universes are considered equal.
+      Like :tacn:`constr_eq_strict`, but all universes are considered equal.
 
 .. tacn:: unify @one_term @one_term {? with @ident }
 

--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -1297,9 +1297,6 @@ Managing the local context
    to the goal, if this respects dependencies. This is
    the inverse of :tacn:`intro`.
 
-   .. exn:: @ident__1 is used in the hypothesis @ident__2.
-      :undocumented:
-
    .. tacn:: revert dependent @ident
 
       Moves the named hypothesis and all the hypotheses that depend on it to the goal.
@@ -1375,9 +1372,6 @@ Managing the local context
    Renaming is done simultaneously, which permits swapping the names of 2 hypotheses.
    (Note that the renaming is applied in the context and the existential
    variables, but the proof term doesn't change.)
-
-   .. exn:: @ident is already used.
-      :undocumented:
 
 .. tacn:: set @alias_definition {? @occurrences }
           set @one_term {? @as_name } {? @occurrences }

--- a/doc/sphinx/proofs/writing-proofs/proof-mode.rst
+++ b/doc/sphinx/proofs/writing-proofs/proof-mode.rst
@@ -246,9 +246,6 @@ When the proof is completed, you can exit proof mode with commands such as
    :n:`All`
      Aborts all current proofs.
 
-   .. exn:: No focused proof (No proof-editing in progress).
-      :undocumented:
-
 .. cmd:: Proof @term
    :name: Proof `term`
 

--- a/doc/sphinx/proofs/writing-proofs/reasoning-inductives.rst
+++ b/doc/sphinx/proofs/writing-proofs/reasoning-inductives.rst
@@ -332,9 +332,6 @@ Induction
      that was automatically generated when the inductive type was declared based
      on the sort of the goal.
 
-   .. exn:: Not an inductive product.
-      :undocumented:
-
    .. exn:: Cannot recognize a statement based on @reference.
 
       The type of the :n:`@induction_arg` (in an :n:`@induction_clause`) must reduce to the
@@ -665,9 +662,6 @@ This section describes some special purpose tactics to work with
       the use of a sigma type is avoided.
 
    .. exn:: No information can be deduced from this equality and the injectivity of constructors. This may be because the terms are convertible, or due to pattern matching restrictions in the sort Prop. You can try to use option Set Keep Proof Equalities.
-      :undocumented:
-
-   .. exn:: No primitive equality found.
       :undocumented:
 
    .. exn:: Not a negated primitive equality

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -640,11 +640,6 @@ Displaying information about notations
    .. exn:: @string cannot be interpreted as a known notation in @ident entry. Make sure that symbols are surrounded by spaces and that holes are explicitly denoted by "_".
       :undocumented:
 
-   .. exn:: Unknown custom entry: @ident.
-
-      Occurs when :cmd:`Print Notation` can't find the custom entry given by the
-      user.
-
 .. seealso::
 
     :cmd:`Locate` for information on the definitions and scopes associated with
@@ -1427,7 +1422,7 @@ Note that `_` by itself is a valid :n:`@name` but is not a valid :n:`@ident`.
 
 .. exn:: Unknown custom entry: @ident.
 
-   Occurs when :cmd:`Notation` can't find the custom entry given by the user.
+   Occurs when :cmd:`Notation` or :cmd:`Print Notation` can't find the custom entry given by the user.
 
 .. _Scopes:
 

--- a/doc/tools/coqrst/coqdomain.py
+++ b/doc/tools/coqrst/coqdomain.py
@@ -233,12 +233,11 @@ class CoqObject(ObjectDescription):
             signode['first'] = (not self.names)
             self._record_name(name, targetid, signode)
         else:
-            # todo: make the following a real error or warning
-            # todo: then maybe the above "if" is not needed
-            names_in_subdomain = self.subdomain_data()
-            if name in names_in_subdomain:
-                print("Duplicate", self.subdomain, "name: ", name)
-            # self._warn_if_duplicate_name(names_in_subdomain, name, signode)
+            # We don't warn for duplicates in the SSReflect chapter, because
+            # it's the style of this chapter to repeat all the defined
+            # objects at the end.
+            if self.env.docname != 'proof-engine/ssreflect-proof-language':
+                self._warn_if_duplicate_name(self.subdomain_data(), name, signode)
         return targetid
 
     def _add_index_entry(self, name, target):


### PR DESCRIPTION
Hardcode exception for SSReflect chapter, which doesn't follow the style of the rest of the manual.