### PR TITLE
Fix memory issue with MathComp 2

### DIFF
--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -239,7 +239,7 @@ let export_pre_goals flags Proof.{ sigma; goals; stack } process =
 
 let subgoals flags =
   let doc = get_doc () in
-  ignore (Stm.finish ~doc : Vernacstate.t);
+  ignore (Stm.finish ~doc);
   let short = match flags.Interface.gf_mode with
   | "short" -> true
   | _ -> false
@@ -270,7 +270,7 @@ let goals () =
 let evars () =
   try
     let doc = get_doc () in
-    ignore (Stm.finish ~doc : Vernacstate.t);
+    ignore (Stm.finish ~doc);
     let pfts = Vernacstate.Declare.give_me_the_proof () in
     let Proof.{ sigma } = Proof.data pfts in
     let exl = Evar.Map.bindings (Evd.undefined_map sigma) in
@@ -304,7 +304,7 @@ let status force =
   (* We remove the initial part of the current [DirPath.t]
      (usually Top in an interactive session, cf "coqtop -top"),
      and display the other parts (opened sections and modules) *)
-  ignore (Stm.finish ~doc:(get_doc ()) : Vernacstate.t);
+  ignore (Stm.finish ~doc:(get_doc ()));
   if force then Stm.join ~doc:(get_doc ());
   let path =
     let l = Names.DirPath.repr (Lib.cwd ()) in
@@ -477,7 +477,7 @@ let init =
            get_doc (), init_sid, `NewTip in
          if Filename.check_suffix file ".v" then
            Stm.set_compilation_hints file;
-         ignore (Stm.finish ~doc : Vernacstate.t);
+         ignore (Stm.finish ~doc);
          initial_id
    end
 

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -2432,11 +2432,7 @@ let observe ~doc id =
 let finish ~doc =
   let head = VCS.current_branch () in
   let () = observe ~doc (VCS.get_branch_pos head) in
-  let tip = VCS.cur_tip () in
-  if not (State.is_cached ~cache:true tip) then
-    CErrors.anomaly Pp.(str "Stm.finish: tip not cached");
-  VCS.print ();
-  State.get_cached tip
+  VCS.print ()
 
 let wait ~doc =
   let () = observe ~doc (VCS.get_branch_pos VCS.Branch.master) in
@@ -2542,7 +2538,7 @@ let handle_failure (e, info) vcs =
   Exninfo.iraise (e, info)
 
 let snapshot_vio ~create_vos ~doc ~output_native_objects ldir long_f_dot_vo =
-  let _ : Vernacstate.t = finish ~doc in
+  let () = finish ~doc in
   if List.length (VCS.branches ()) > 1 then
     CErrors.user_err (str"Cannot dump a vio with open proofs.");
   (* LATER: when create_vos is true, it could be more efficient to not allocate the futures; but for now it seems useful for synchronization of the workers,

--- a/stm/stm.mli
+++ b/stm/stm.mli
@@ -128,7 +128,7 @@ val edit_at : doc:doc -> Stateid.t -> doc * edit_focus
 val observe : doc:doc -> Stateid.t -> unit
 
 (* [finish doc] Fully checks a document up to the "current" tip. *)
-val finish : doc:doc -> Vernacstate.t
+val finish : doc:doc -> unit
 
 (* Internal use (fake_ide) only, do not use *)
 val wait : doc:doc -> unit

--- a/toplevel/common_compile.ml
+++ b/toplevel/common_compile.ml
@@ -53,17 +53,3 @@ let ensure_exists_with_prefix ~src ~tgt:f_out ~src_ext ~tgt_ext =
     | None -> safe_chop_extension long_f_dot_src ^ tgt_ext
     | Some f -> ensure ~ext:tgt_ext ~src:long_f_dot_src ~tgt:f in
   long_f_dot_src, long_f_dot_tgt
-
-let ensure_no_pending_proofs ~filename s =
-  match s.Vernacstate.interp.lemmas with
-  | Some lemmas ->
-      let pfs = Vernacstate.LemmaStack.get_all_proof_names lemmas in
-      fatal_error (str "There are pending proofs in file " ++ str filename ++ str": "
-                    ++ (pfs
-                        |> List.rev
-                        |> prlist_with_sep pr_comma Names.Id.print)
-                    ++ str ".");
-  | None ->
-    let pm = s.Vernacstate.interp.program in
-    let what_for = Pp.str ("file " ^ filename) in
-    NeList.iter (fun pm -> Declare.Obls.check_solved_obligations ~what_for ~pm) pm

--- a/toplevel/common_compile.mli
+++ b/toplevel/common_compile.mli
@@ -28,7 +28,3 @@ val ensure_exists_with_prefix : src:string -> tgt:string option -> src_ext:strin
 
 (* [chop_extension f] is like Filename.chop_extension but fail safe *)
 val safe_chop_extension : string -> string
-
-(* [ensure_no_pending_proofs ~filename] checks that no proof or obligation
-   is open *)
-val ensure_no_pending_proofs : filename:string -> Vernacstate.t -> unit


### PR DESCRIPTION
Revert https://github.com/coq/coq/commit/de2d78235556d79b4de1b79c90fe6df68d31630a in order to fix the memory issue experienced with MathComp 2 since 8.17 (peak memory use almost doubled).
Not sure this is the fix we want, but at least it does fix the issue.

Cc @gares 

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
<!-- Fixes / closes #???? -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] ~Added / updated **test-suite**.~ (although this should enable to add MC2 in the CI #17722 , which should act as a crude test)

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] ~Added **changelog**.~
- [ ] ~Added / updated **documentation**.~
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] ~Documented any new / changed **user messages**.~
  - [ ] ~Updated **documented syntax** by running `make doc_gram_rsts`.~

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] ~Opened **overlay** pull requests.~

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
