### PR TITLE
Add instruction counting support.

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/17744-instruction-counting.rst
+++ b/doc/changelog/08-vernac-commands-and-options/17744-instruction-counting.rst
@@ -1,0 +1,11 @@
+- **Added:**
+  new command modifier :cmd:`Instructions` that executes the given command and
+  displays the number of CPU instructions it took to execute it. This command
+  is currently only supported on Linux systems, but it does not fail on other
+  systems, where it simply shows an error message instead of the count.
+  (`#17744 <https://github.com/coq/coq/pull/17744>`_,
+  by Rodolphe Lepigre).
+- **Added:**
+  support for instruction counts to the `-profile` option.
+  (`#17744 <https://github.com/coq/coq/pull/17744>`_,
+  by Rodolphe Lepigre).

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -860,6 +860,14 @@ Quitting and debugging
    time needed to execute it.
 
 
+.. cmd:: Instructions @sentence
+
+   Executes :n:`@sentence` and displays the number of CPU instructions needed
+   to execute it. This command is currently only supported on Linux systems,
+   but does not fail on unsupported sustems, where it instead prints an error
+   message in the place of the instruction count.
+
+
 .. cmd:: Redirect @string @sentence
 
    Executes :n:`@sentence`, redirecting its

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1560,6 +1560,8 @@ vernac_control: [
    cover this the descriptions of these commands *)
 | REPLACE "Time" vernac_control
 | WITH "Time" sentence
+| REPLACE "Instructions" vernac_control
+| WITH "Instructions" sentence
 | REPLACE "Redirect" ne_string vernac_control
 | WITH "Redirect" ne_string sentence
 | REPLACE "Timeout" natural vernac_control

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -727,6 +727,7 @@ mode: [
 
 vernac_control: [
 | "Time" vernac_control
+| "Instructions" vernac_control
 | "Redirect" ne_string vernac_control
 | "Timeout" natural vernac_control
 | "Fail" vernac_control

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -970,6 +970,7 @@ command: [
 | "Hint" "Constructors" LIST1 qualid OPT ( ":" LIST1 ident )
 | "Hint" "Extern" natural OPT one_pattern "=>" ltac_expr OPT ( ":" LIST1 ident )
 | "Time" sentence
+| "Instructions" sentence
 | "Redirect" string sentence
 | "Timeout" natural sentence
 | "Fail" sentence

--- a/lib/dune
+++ b/lib/dune
@@ -4,4 +4,6 @@
  (public_name coq-core.lib)
  (wrapped false)
  (modules_without_implementation xml_datatype)
- (libraries coq-core.boot coq-core.clib coq-core.config))
+ (libraries
+  coq-core.boot coq-core.clib coq-core.config
+  (select instr.ml from (!perf -> instr.noperf.ml) (perf -> instr.perf.ml))))

--- a/lib/instr.mli
+++ b/lib/instr.mli
@@ -1,0 +1,18 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** Platform-specific Implementation of a global instruction counter. *)
+
+(** [read_counter ()] returns the current value of the instruction counter, or
+    an error message indicating why it could not be obtained. Note that counts
+    returned by this function are not meaningful in absolute terms. To measure
+    how many instructions it takes to run a piece of code, read the counter at
+    the start and at the end, and compute the difference. *)
+val read_counter : unit -> (Int64.t, string) Result.t

--- a/lib/instr.noperf.ml
+++ b/lib/instr.noperf.ml
@@ -1,0 +1,12 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+let read_counter : unit -> (Int64.t, string) Result.t = fun _ ->
+  Error("not supported")

--- a/lib/instr.perf.ml
+++ b/lib/instr.perf.ml
@@ -1,0 +1,17 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+let read_counter : unit -> (Int64.t, string) Result.t =
+  let drop () = try Perf.drop () with Failure(_) -> () in
+  try
+    Perf.init (); at_exit drop;
+    fun () -> try Ok(Perf.peek ()) with Failure(msg) -> Error(msg)
+  with Failure(msg) ->
+    fun () -> Error(msg)

--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -114,6 +114,7 @@ let spc   () = Ppcmd_print_break (1,0)
 let cut   () = Ppcmd_print_break (0,0)
 let align () = Ppcmd_print_break (0,0)
 let int   n  = str (string_of_int n)
+let int64 n  = str (Int64.to_string n)
 let real  r  = str (string_of_float r)
 let bool  b  = str (string_of_bool b)
 

--- a/lib/pp.mli
+++ b/lib/pp.mli
@@ -91,6 +91,7 @@ val spc : unit -> t
 val cut : unit -> t
 val align : unit -> t
 val int : int -> t
+val int64 : Int64.t -> t
 val real : float -> t
 val bool : bool -> t
 val qstring : string -> t

--- a/lib/system.mli
+++ b/lib/system.mli
@@ -126,6 +126,20 @@ type 'a transaction_result = (('a * duration), (Exninfo.iexn * duration)) Result
 val measure_duration : ('a -> 'b) -> 'a -> 'b transaction_result
 val fmt_transaction_result : 'a transaction_result -> Pp.t
 
+(** {6 Instruction count.} *)
+
+type instruction_count = (Int64.t, string) Result.t
+
+val instructions_between : c_start:instruction_count -> c_end:instruction_count -> instruction_count
+val instruction_count_add : instruction_count -> instruction_count -> instruction_count
+
+type 'a instructions_result =
+  (('a * instruction_count), (Exninfo.iexn * instruction_count)) Result.t
+
+val count_instructions : ('a -> 'b) -> 'a -> 'b instructions_result
+
+val fmt_instructions_result : 'a instructions_result -> Pp.t
+
 (** [get_toplevel_path program] builds a complete path to the
    executable denoted by [program]. This involves:
 

--- a/perf/dune
+++ b/perf/dune
@@ -1,0 +1,7 @@
+(library
+ (name perf)
+ (synopsis "Instruction count using Linux perf.")
+ (public_name coq-core.perf)
+ (wrapped false)
+ (foreign_stubs (language c) (names perf))
+ (enabled_if (= %{system} linux)))

--- a/perf/perf.c
+++ b/perf/perf.c
@@ -1,0 +1,107 @@
+/************************************************************************/
+/*         *   The Coq Proof Assistant / The Coq Development Team       */
+/*  v      *         Copyright INRIA, CNRS and contributors             */
+/* <O___,, * (see version control and CREDITS file for authors & dates) */
+/*   \VV/  **************************************************************/
+/*    //   *    This file is distributed under the terms of the         */
+/*         *     GNU Lesser General Public License Version 2.1          */
+/*         *     (see LICENSE file for the text of the license)         */
+/************************************************************************/
+
+#include <linux/perf_event.h>
+#include <sys/syscall.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include <errno.h>
+#include <string.h>
+
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/alloc.h>
+#include <caml/fail.h>
+
+static int perf_event_open(struct perf_event_attr *hw_event, pid_t pid,
+                           int cpu, int group_fd, unsigned long flags) {
+  return syscall(SYS_perf_event_open, hw_event, pid, cpu, group_fd, flags);
+}
+
+#define NOT_INITIALIZED (-2)
+
+int fd = NOT_INITIALIZED;
+
+CAMLprim value CAML_init(value unit) {
+  CAMLparam1(unit);
+
+  if (fd != NOT_INITIALIZED) {
+    caml_failwith("counter already initialized");
+  }
+
+  struct perf_event_attr pe;
+  memset(&pe, 0, sizeof(pe));
+
+  pe.type = PERF_TYPE_HARDWARE;
+  pe.size = sizeof(pe);
+  pe.config = PERF_COUNT_HW_INSTRUCTIONS;
+  pe.disabled = 1;
+  pe.exclude_kernel = 1;
+  pe.exclude_hv = 1;
+
+  fd = perf_event_open(&pe, 0, -1, -1, 0);
+  if (fd == -1) {
+    fd = NOT_INITIALIZED;
+    caml_failwith("initialisation failure");
+  }
+
+  if (ioctl(fd, PERF_EVENT_IOC_RESET , 0) == -1) {
+    close(fd);
+    fd = NOT_INITIALIZED;
+    caml_failwith("could not initially reset counter");
+  }
+
+  if (ioctl(fd, PERF_EVENT_IOC_ENABLE, 0) == -1) {
+    close(fd);
+    fd = NOT_INITIALIZED;
+    caml_failwith("could not initailly enable counter");
+  }
+
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value CAML_drop(value unit) {
+  CAMLparam1(unit);
+
+  if (fd == NOT_INITIALIZED) {
+    caml_failwith("counter not initialized");
+  }
+
+  close(fd);
+  fd = NOT_INITIALIZED;
+
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value CAML_peek(value unit) {
+  CAMLparam1(unit);
+
+  if (fd == NOT_INITIALIZED) caml_failwith("counter not initialized");
+
+  if (ioctl(fd, PERF_EVENT_IOC_DISABLE, 0) == -1) {
+    caml_failwith("could not disable counter");
+  }
+
+  int64_t count = 0;
+  size_t n = read(fd, &count, sizeof(count));
+
+  if (n != sizeof(count)) {
+    caml_failwith("could not retrieve counter");
+  }
+
+  value ret = caml_copy_int64(count);
+
+  if (ioctl(fd, PERF_EVENT_IOC_ENABLE, 0) == -1) {
+    caml_failwith("could not enable counter");
+  }
+
+  CAMLreturn(ret);
+}

--- a/perf/perf.ml
+++ b/perf/perf.ml
@@ -1,0 +1,13 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+external init : unit -> unit = "CAML_init"
+external drop : unit -> unit = "CAML_drop"
+external peek : unit -> Int64.t = "CAML_peek"

--- a/perf/perf.mli
+++ b/perf/perf.mli
@@ -1,0 +1,28 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** Global CPU instruction counter. *)
+
+(** [init ()] initialises, resets to 0, and starts the instruction counter. In
+    case of an error, the [Failure] exception is raised, and the counter state
+    is fully re-initialised so that [init] may be called again. Initialization
+    is required prior to calling the [drop] and [peek] functions. *)
+val init : unit -> unit
+
+(** [drop ()] undoes the effect of [init], and frees all resources used by the
+    internal state of the instruction counter. Note that the counter must have
+    been initialised before calling [drop], otherwise [Failure] is raised. *)
+val drop : unit -> unit
+
+(** [peek ()] reads the value of the instruction counter, which corresponds to
+    the number of instructions run by the CPU since the last (successful) call
+    to [init]. Note that [Failure] is raised in case of an error, including if
+    the function is called while the counter is not initialised. *)
+val peek : unit -> Int64.t

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -94,6 +94,8 @@ GRAMMAR EXTEND Gram
   vernac_control: FIRST
     [ [ IDENT "Time"; c = vernac_control ->
         { add_control_flag ~loc ~flag:ControlTime c }
+      | IDENT "Instructions"; c = vernac_control ->
+        { add_control_flag ~loc ~flag:ControlInstructions c }
       | IDENT "Redirect"; s = ne_string; c = vernac_control ->
         { add_control_flag ~loc ~flag:(ControlRedirect s) c }
       | IDENT "Timeout"; n = natural; c = vernac_control ->

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -1350,6 +1350,7 @@ let pr_synterp_vernac_expr v =
 let pr_control_flag (p : control_flag) =
   let w = match p with
     | ControlTime -> keyword "Time"
+    | ControlInstructions -> keyword "Instructions"
     | ControlRedirect s -> keyword "Redirect" ++ spc() ++ qs s
     | ControlTimeout n -> keyword "Timeout " ++ int n
     | ControlFail -> keyword "Fail"

--- a/vernac/synterp.mli
+++ b/vernac/synterp.mli
@@ -29,6 +29,7 @@ type module_entry = Modintern.module_struct_expr * Names.ModPath.t * Modintern.m
 
 type control_entry =
   | ControlTime of { synterp_duration: System.duration }
+  | ControlInstructions of { synterp_instructions: System.instruction_count }
   | ControlRedirect of string
   | ControlTimeout of { remaining : float }
   | ControlFail of { st : Vernacstate.Synterp.t }

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -504,6 +504,7 @@ type vernac_expr = synterp_vernac_expr vernac_expr_gen
 
 type control_flag =
   | ControlTime
+  | ControlInstructions
   | ControlRedirect of string
   | ControlTimeout of int
   | ControlFail

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -101,6 +101,14 @@ let interp_control_entry ~loc (f : control_entry) ~st
     | Ok (v,_) -> v
     | Error (exn, _) -> Exninfo.iraise exn
     end
+  | ControlInstructions { synterp_instructions } ->
+    let result = System.count_instructions (fun () -> fn ~st) () in
+    let result = Result.map (fun (v,d) -> v, System.instruction_count_add d synterp_instructions) result in
+    Feedback.msg_notice @@ System.fmt_instructions_result result;
+    begin match result with
+    | Ok (v,_) -> v
+    | Error (exn, _) -> Exninfo.iraise exn
+    end
   | ControlRedirect s ->
     Topfmt.with_output_to_file s (fun () -> fn ~st) ()
 


### PR DESCRIPTION
This PR adds the following features to Coq:
- A new `Instructions` control vernacular similar to `Time`, but that reports an instruction count.
- ~~A new `-instr` command-line flag that reports instruction counts for each toplevel command of the processed file.~~
- ~~A new `-instr-file <file>` command-line flag that is similar, but outputs to the given file.~~
- Support for instruction counts in the profiler introduced in https://github.com/coq/coq/pull/17702.

These features are only implemented on Linux, via the `linux/perf_event.h` interface, with code following `man 2 perf_event_open`.

~~**Limitation:** for simplicity, there is a single global instruction counter, so if one does `Instructions Instructions Check 42` then the inner instruction count will report an error instead. Similarly, if one uses the `-instr` flag, all `Instructions` command modifiers will show an error message instead of the instruction count.~~

~~**Limitation:** even on Linux, instruction counts easily overflow OCaml integers on 32-bit systems, so we don't support them. We could lift that restriction using an `Int64.t` instead, but do we care?~~

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - ~~Documented any new / changed **user messages**.~~
  - [x] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
