### PR TITLE
Avoid generating empty letin in ltac in notation

### DIFF
--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -818,6 +818,7 @@ let notation_subst _avoid bindings tac =
   (* This is theoretically not correct due to potential variable
      capture, but Ltac has no true variables so one cannot simply
      substitute *)
-  CAst.make (TacLetIn (false, bindings, tac))
+  if List.is_empty bindings then tac
+  else CAst.make (TacLetIn (false, bindings, tac))
 
 let () = Genintern.register_ntn_subst0 wit_tactic notation_subst

--- a/test-suite/output/bug_17708.out
+++ b/test-suite/output/bug_17708.out
@@ -1,0 +1,4 @@
+File "./output/bug_17708.v", line 1, characters 0-35:
+Warning: This notation contains Ltac expressions: it will not be used for
+printing. [non-reversible-notation,parsing,default]
+Ltac foo := exact ltac:(exact 0)

--- a/test-suite/output/bug_17708.v
+++ b/test-suite/output/bug_17708.v
@@ -1,0 +1,3 @@
+Notation zero := (ltac: (exact 0)).
+Ltac foo := exact zero.
+Print foo.


### PR DESCRIPTION
Fix #17708