### PR TITLE
(8.17) Fix "tip not cached" anomaly when there are open proofs at file end

### DIFF
--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -312,7 +312,7 @@ let status force =
      and display the other parts (opened sections and modules) *)
   set_doc (fst @@ Stm.finish ~doc:(get_doc ()));
   if force then
-    set_doc (fst @@ Stm.join ~doc:(get_doc ()));
+    set_doc (Stm.join ~doc:(get_doc ()));
   let path =
     let l = Names.DirPath.repr (Lib.cwd ()) in
     List.rev_map Names.Id.to_string l

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -2423,7 +2423,7 @@ let finish ~doc =
   let doc = observe ~doc (VCS.get_branch_pos head) in
   let tip = VCS.cur_tip () in
   if not (State.is_cached ~cache:true tip) then
-    CErrors.anomaly Pp.(str "Stm.join: tip not cached");
+    CErrors.anomaly Pp.(str "Stm.finish: tip not cached");
   VCS.print ();
   doc, State.get_cached tip
 
@@ -2469,7 +2469,7 @@ let join ~doc =
   if not (State.is_cached ~cache:true tip) then
     CErrors.anomaly Pp.(str "Stm.join: tip not cached");
   VCS.print ();
-  doc, State.get_cached tip
+  doc
 
 type tasks = Opaqueproof.opaque_handle option Slaves.tasks
 let check_task name tasks i =

--- a/stm/stm.mli
+++ b/stm/stm.mli
@@ -136,7 +136,7 @@ val wait : doc:doc -> doc
 val stop_worker : string -> unit
 
 (* Joins the entire document.  Implies finish, but also checks proofs *)
-val join : doc:doc -> doc * Vernacstate.t
+val join : doc:doc -> doc
 
 (* Saves on the disk a .vio corresponding to the current status:
    - if the worker pool is empty, all tasks are saved

--- a/test-suite/output/bug_16335.out
+++ b/test-suite/output/bug_16335.out
@@ -1,0 +1,3 @@
+Error: There are pending proofs in file ./output/bug_16335.v: foo.
+
+coqc exited with code 1

--- a/test-suite/output/bug_16335.v
+++ b/test-suite/output/bug_16335.v
@@ -1,0 +1,2 @@
+Lemma foo: True.
+Proof.

--- a/toplevel/ccompile.ml
+++ b/toplevel/ccompile.ml
@@ -62,9 +62,10 @@ let compile opts stm_options injections copts ~echo ~f_in ~f_out =
       let wall_clock1 = Unix.gettimeofday () in
       let check = Stm.AsyncOpts.(stm_options.async_proofs_mode = APoff) in
       let state = Vernac.load_vernac ~echo ~check ~interactive:false ~state ~ldir long_f_dot_in in
-      let doc, state = Stm.join ~doc:state.doc in
+      let doc, fullstate = Stm.finish ~doc:state.doc in
+      ensure_no_pending_proofs ~filename:long_f_dot_in fullstate;
+      let _ = Stm.join ~doc:state.doc in
       let wall_clock2 = Unix.gettimeofday () in
-      ensure_no_pending_proofs ~filename:long_f_dot_in state;
       (* In .vo production, dump a complete .vo file. *)
       if mode = BuildVo
         then Library.save_library_to ~output_native_objects Library.ProofsTodoNone ldir long_f_dot_out;


### PR DESCRIPTION
Fix #16335

(cherry picked from commit 2a81292cd772ec04e395295579fef5a9017089a8)
