### PR TITLE
Refactor VM error handling and catch error from generating too large code

### DIFF
--- a/kernel/vconv.ml
+++ b/kernel/vconv.ml
@@ -194,7 +194,7 @@ let vm_conv_gen cv_pb sigma env univs t1 t2 =
     let v1 = val_of_constr env sigma t1 in
     let v2 = val_of_constr env sigma t2 in
     fst (conv_val env cv_pb (nb_rel env) v1 v2 univs)
-  with Not_found | Invalid_argument _ ->
+  with Not_found | Invalid_argument _ | Vmerrors.CompileError _ ->
     warn_bytecode_compiler_failed ();
     Conversion.generic_conv cv_pb ~l2r:false sigma.Genlambda.evars_val
       TransparentState.full env univs t1 t2

--- a/kernel/vmemitcodes.ml
+++ b/kernel/vmemitcodes.ml
@@ -166,7 +166,7 @@ let out_word env b1 b2 b3 b4 =
     else
       let new_len = min (Sys.max_string_length) (2 * len) in
       (* Not the right exception... *)
-      let () = if not (p + 3 < new_len) then invalid_arg "String.create" in
+      let () = if not (p + 3 < new_len) then Vmerrors.too_large_code() in
       let new_buffer = Bytes.create new_len in
       let () = Bytes.blit env.out_buffer 0 new_buffer 0 len in
       let () = env.out_buffer <- new_buffer in

--- a/kernel/vmerrors.ml
+++ b/kernel/vmerrors.ml
@@ -1,0 +1,47 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Pp
+
+type error =
+  | TooLargeInductive of Names.Id.t
+  | TooLargeCode
+
+
+exception CompileError of error
+
+let too_large_code () = raise (CompileError TooLargeCode)
+
+(* Limit needed to make SWITCH work. The specific limit is
+   arbitrary but nobody needs more than 0x1000000 constructors. *)
+
+let max_nb_const = 0x1000000
+let max_nb_block = 0x1000000 + Obj.last_non_constant_constructor_tag - 1
+
+let str_max_constructors =
+  Format.sprintf
+    " which has more than %i constant constructors or more than %i non-constant constructors" max_nb_const max_nb_block
+
+(* NB: Declarations depends on Vmemitcodes which depends on
+   too_large_code so we can't use Declarations.one_inductive_body
+   here. Instead we pass the needed fields. *)
+let check_compilable_ind ~name ~mind_nb_args ~mind_nb_constant =
+  if not (mind_nb_args <= max_nb_block && mind_nb_constant <= max_nb_const) then
+    raise (CompileError (TooLargeInductive name))
+
+let pr_error = function
+  | TooLargeCode -> str "Cannot compile code for virtual machine as it exceeds string size limits."
+  | TooLargeInductive name ->
+    str "Cannot compile code for virtual machine as it uses inductive " ++
+    Names.Id.print name ++ str str_max_constructors
+
+let () = CErrors.register_handler (function
+    | CompileError e -> Some (pr_error e)
+    | _ -> None)

--- a/kernel/vmerrors.mli
+++ b/kernel/vmerrors.mli
@@ -8,12 +8,12 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open Vmvalues
-open Environ
+type error
 
-type lambda = structured_values Genlambda.lambda
+val pr_error : error -> Pp.t
 
-val lambda_of_constr : optimize:bool -> env -> Genlambda.evars -> Constr.t -> lambda
+val too_large_code : unit -> 'a
 
-(** Dump the VM lambda code after compilation (for debugging purposes) *)
-val dump_lambda : bool ref
+val check_compilable_ind : name:Names.Id.t -> mind_nb_args:int -> mind_nb_constant:int -> unit
+
+exception CompileError of error


### PR DESCRIPTION

Fix #17749 (untested)

Also use cwarnings when compilation fails instead of raw msg_warning
