### PR TITLE
Fix documentation of add_top.

### DIFF
--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -1569,9 +1569,7 @@ Binding types or coercion classes to notation scopes
    :attr:`add_top` and :attr:`add_bottom` attributes.
 
    .. attr:: add_top
-      :undocumented:
-
-   .. attr:: add_bottom
+             add_bottom
 
       These :ref:`attributes <attribute>` allow adding additional
       bindings at the top or bottom of the stack of already declared


### PR DESCRIPTION
@proux01 FYI, this is how we document two commands at once. We should refrain from adding new calls to `:undocumented:` in the refman.