### PR TITLE
Turn "overwriting previous delimiting key" and "hiding binding of key" messages into warnings

### DIFF
--- a/test-suite/output/FloatNumberSyntax.out
+++ b/test-suite/output/FloatNumberSyntax.out
@@ -78,8 +78,17 @@ neg_infinity
      : nat
 2%float
      : float
+File "./output/FloatNumberSyntax.v", line 47, characters 0-35:
+Warning: Overwriting previous delimiting key float in scope float_scope
+[overwriting-delimiting-key,parsing,default]
 t = 2%flt
      : float
+File "./output/FloatNumberSyntax.v", line 50, characters 0-35:
+Warning: Overwriting previous delimiting key nat in scope nat_scope
+[overwriting-delimiting-key,parsing,default]
+File "./output/FloatNumberSyntax.v", line 50, characters 0-35:
+Warning: Hiding binding of key float to float_scope
+[hiding-delimiting-key,parsing,default]
 t = 2%flt
      : float
 2

--- a/test-suite/output/Int63NumberSyntax.out
+++ b/test-suite/output/Int63NumberSyntax.out
@@ -50,14 +50,29 @@ Overflow in int63 literal: 9223372036854775808.
      : nat
 2%uint63
      : int
+File "./output/Int63NumberSyntax.v", line 31, characters 0-37:
+Warning: Overwriting previous delimiting key uint63 in scope uint63_scope
+[overwriting-delimiting-key,parsing,default]
 t = 2%ui63
      : int
+File "./output/Int63NumberSyntax.v", line 34, characters 0-36:
+Warning: Overwriting previous delimiting key nat in scope nat_scope
+[overwriting-delimiting-key,parsing,default]
+File "./output/Int63NumberSyntax.v", line 34, characters 0-36:
+Warning: Hiding binding of key uint63 to uint63_scope
+[hiding-delimiting-key,parsing,default]
 t = 2%ui63
      : int
 2
      : nat
 2
      : int
+File "./output/Int63NumberSyntax.v", line 41, characters 0-22:
+Warning: Overwriting previous delimiting key ui63 in scope uint63_scope
+[overwriting-delimiting-key,parsing,default]
+File "./output/Int63NumberSyntax.v", line 41, characters 0-22:
+Warning: Hiding binding of key uint63 to nat_scope
+[hiding-delimiting-key,parsing,default]
 (2 + 2)%uint63
      : int
 2 + 2

--- a/test-suite/output/Sint63NumberSyntax.out
+++ b/test-suite/output/Sint63NumberSyntax.out
@@ -56,14 +56,29 @@ Cannot interpret this number as a value of type int
      : nat
 2%sint63
      : int
+File "./output/Sint63NumberSyntax.v", line 34, characters 0-37:
+Warning: Overwriting previous delimiting key sint63 in scope sint63_scope
+[overwriting-delimiting-key,parsing,default]
 t = 2%si63
      : int
+File "./output/Sint63NumberSyntax.v", line 37, characters 0-36:
+Warning: Overwriting previous delimiting key nat in scope nat_scope
+[overwriting-delimiting-key,parsing,default]
+File "./output/Sint63NumberSyntax.v", line 37, characters 0-36:
+Warning: Hiding binding of key sint63 to sint63_scope
+[hiding-delimiting-key,parsing,default]
 t = 2%si63
      : int
 2
      : nat
 2
      : int
+File "./output/Sint63NumberSyntax.v", line 43, characters 0-39:
+Warning: Overwriting previous delimiting key si63 in scope sint63_scope
+[overwriting-delimiting-key,parsing,default]
+File "./output/Sint63NumberSyntax.v", line 43, characters 0-39:
+Warning: Hiding binding of key sint63 to nat_scope
+[hiding-delimiting-key,parsing,default]
 (2 + 2)%sint63
      : int
 2 + 2

--- a/theories/ssr/ssrbool.v
+++ b/theories/ssr/ssrbool.v
@@ -15,6 +15,8 @@
 Require Bool.
 Require Import ssreflect ssrfun.
 
+#[export] Set Warnings "-overwriting-delimiting-key".
+
 (**
  A theory of boolean predicates and operators. A large part of this file is
  concerned with boolean reflection.


### PR DESCRIPTION

Close #8207
