### PR TITLE
`Try` control flag

### DIFF
--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -102,6 +102,8 @@ GRAMMAR EXTEND Gram
         { add_control_flag ~loc ~flag:ControlFail c }
       | IDENT "Succeed"; c = vernac_control ->
         { add_control_flag ~loc ~flag:ControlSucceed c }
+      | IDENT "Try"; c = vernac_control ->
+        { add_control_flag ~loc ~flag:ControlTry c }
       | v = decorated_vernac ->
         { let (attrs, expr) = v in CAst.make ~loc { control = []; attrs; expr = expr } } ]
     ]

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -1361,6 +1361,7 @@ let pr_control_flag (p : control_flag) =
     | ControlTimeout n -> keyword "Timeout " ++ int n
     | ControlFail -> keyword "Fail"
     | ControlSucceed -> keyword "Succeed"
+    | ControlTry -> keyword "Try"
   in
   w ++ spc ()
 

--- a/vernac/synterp.mli
+++ b/vernac/synterp.mli
@@ -30,6 +30,7 @@ type control_entry =
   | ControlTimeout of { remaining : float }
   | ControlFail of { st : Vernacstate.Synterp.t }
   | ControlSucceed of { st : Vernacstate.Synterp.t }
+  | ControlTry
 
 
 type synterp_entry =

--- a/vernac/vernac_classifier.ml
+++ b/vernac/vernac_classifier.ml
@@ -61,6 +61,12 @@ let classify_under_control_flag ?loc flag x = match flag with
     | VtQed _ -> VtProofStep { proof_block_detection = None }
     | VtStartProof _ | VtProofMode _ -> VtQuery
     end
+  | ControlTry ->
+    begin match x with
+    | VtQuery | VtProofStep _ | VtSideff _ as x -> x
+    | VtMeta | VtQed _ | VtStartProof _ | VtProofMode _ ->
+      CErrors.user_err Pp.(str "The STM cannot handle this command with Try.")
+    end
 
 let classify_under_control_flags ?loc flags x =
   List.fold_right (classify_under_control_flag ?loc) flags x

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -507,6 +507,7 @@ type control_flag =
   | ControlTimeout of int
   | ControlFail
   | ControlSucceed
+  | ControlTry
 
 type ('a, 'b) vernac_control_gen_r =
   { control : 'a list


### PR DESCRIPTION

When going through the STM only some classifications of the underlying
command are supported, for instance `Try Qed` is rejected as it cannot
be classified.

Close #15051
