### PR TITLE
UnivSubst.level_subst_of: assert that we are never called on an algebraic

### DIFF
--- a/engine/univSubst.ml
+++ b/engine/univSubst.ml
@@ -154,7 +154,7 @@ let level_subst_of f =
   | None  -> l
   | Some u ->
     match Universe.level u with
-    | None -> l
+    | None -> assert false
     | Some l -> l
 
 let normalize_univ_variable ~find =

--- a/engine/univSubst.mli
+++ b/engine/univSubst.mli
@@ -17,6 +17,8 @@ type universe_subst_fn = Level.t -> Universe.t option
 type universe_level_subst_fn = Level.t -> Level.t
 
 val level_subst_of : universe_subst_fn -> universe_level_subst_fn
+(** The resulting function must never be called on a level which would produce an algebraic. *)
+
 val subst_univs_constraints : universe_subst_fn -> Constraints.t -> Constraints.t
 val subst_instance : universe_level_subst_fn -> Instance.t -> Instance.t
 


### PR DESCRIPTION


This relies on correctly tracking which univ variables may be set to an algebraic in ustate.
