### PR TITLE
Fix documentation after #17394 (removal of `Add LoadPath`).

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/17394-remove_vernac_loadpath.rst
+++ b/doc/changelog/08-vernac-commands-and-options/17394-remove_vernac_loadpath.rst
@@ -1,6 +1,6 @@
 - **Removed:**
   The ``Add LoadPath``, ``Add Rec LoadPath``, ``Add ML Path``, and
-  ``Remove LoadPath`` have been removed following deprecation. Users
+  ``Remove LoadPath`` commands have been removed following deprecation. Users
   are encouraged to use the existing mechanisms in ``coq_makefile`` or
   ``dune`` to configure workspaces of Coq theories.
   (`#17394 <https://github.com/coq/coq/pull/17394>`_,

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -710,11 +710,11 @@ file is a particular case of a module called a *library file*.
 Load paths
 ----------
 
-:term:`Load paths <load path>` are preferably managed using Coq command line options (see
-Section :ref:`logical-paths-load-path`), but there are also commands
-to manage them within Coq. These commands are only meant to be issued in
-the toplevel, and using them in source files is discouraged.
+.. versionchanged:: 8.18
 
+   Commands to manage :term:`load paths <load path>` within Coq have been
+   removed. Load paths can be managed using Coq command line options or
+   enviroment variables (see :ref:`logical-paths-load-path`).
 
 .. cmd:: Pwd
 


### PR DESCRIPTION
Fix documentation after #17394.

BTW, should `Cd` and `Pwd` be deprecated? What remaining purpose do they serve?