### PR TITLE
More compact on-file representation for global anonymous universes.

### DIFF
--- a/vernac/declareUniv.ml
+++ b/vernac/declareUniv.ml
@@ -27,7 +27,11 @@ type universe_source =
   | QualifiedUniv of Id.t (* global universe introduced by some global value *)
   | UnqualifiedUniv (* other global universe *)
 
-type universe_name_decl = universe_source * (Id.t * Univ.UGlobal.t) list
+type universe_name_decl = {
+  udecl_src : universe_source;
+  udecl_named : (Id.t * Univ.UGlobal.t) list;
+  udecl_anon : Univ.UGlobal.t list;
+}
 
 let check_exists_universe sp =
   if Nametab.exists_universe sp then
@@ -47,20 +51,38 @@ let do_univ_name ~check i dp src (id,univ) =
   if check then check_exists_universe sp;
   Nametab.push_universe i sp univ
 
-let cache_univ_names (prefix, (src, univs)) =
+let get_names decl =
+  let fold accu (id, _) = Id.Set.add id accu in
+  let names = List.fold_left fold Id.Set.empty decl.udecl_named in
+  (* create fresh names for anonymous universes *)
+  let fold u ((names, cnt), accu) =
+    let rec aux i =
+      let na = Id.of_string ("u"^(string_of_int i)) in
+      if Id.Set.mem na names then aux (i+1) else (na, i)
+    in
+    let (id, cnt) = aux cnt in
+    ((Id.Set.add id names, cnt + 1), ((id, u) :: accu))
+  in
+  let _, univs = List.fold_right fold decl.udecl_anon ((names, 0), decl.udecl_named) in
+  univs
+
+let cache_univ_names (prefix, decl) =
   let depth = Lib.sections_depth () in
   let dp = Libnames.pop_dirpath_n depth prefix.Nametab.obj_dir in
-  List.iter (do_univ_name ~check:true (Nametab.Until 1) dp src) univs
+  let names = get_names decl in
+  List.iter (do_univ_name ~check:true (Nametab.Until 1) dp decl.udecl_src) names
 
-let load_univ_names i (prefix, (src, univs)) =
-  List.iter (do_univ_name ~check:false (Nametab.Until i) prefix.Nametab.obj_dir src) univs
+let load_univ_names i (prefix, decl) =
+  let names = get_names decl in
+  List.iter (do_univ_name ~check:false (Nametab.Until i) prefix.Nametab.obj_dir decl.udecl_src) names
 
-let open_univ_names i (prefix, (src, univs)) =
-  List.iter (do_univ_name ~check:false (Nametab.Exactly i) prefix.Nametab.obj_dir src) univs
+let open_univ_names i (prefix, decl) =
+  let names = get_names decl in
+  List.iter (do_univ_name ~check:false (Nametab.Exactly i) prefix.Nametab.obj_dir decl.udecl_src) names
 
-let discharge_univ_names = function
-  | BoundUniv, _ -> None
-  | (QualifiedUniv _ | UnqualifiedUniv), _ as x -> Some x
+let discharge_univ_names decl = match decl.udecl_src with
+  | BoundUniv -> None
+  | (QualifiedUniv _ | UnqualifiedUniv) -> Some decl
 
 let input_univ_names : universe_name_decl -> Libobject.obj =
   let open Libobject in
@@ -73,17 +95,9 @@ let input_univ_names : universe_name_decl -> Libobject.obj =
       subst_function = (fun (subst, a) -> (* Actually the name is generated once and for all. *) a);
       classify_function = (fun a -> Substitute) }
 
-let input_univ_names (src, l) =
-  if CList.is_empty l then ()
-  else Lib.add_leaf (input_univ_names (src, l))
-
-let invent_name (named,cnt) u =
-  let rec aux i =
-    let na = Id.of_string ("u"^(string_of_int i)) in
-    if Id.Map.mem na named then aux (i+1)
-    else na, (Id.Map.add na u named, i+1)
-  in
-  aux cnt
+let input_univ_names (src, l, a) =
+  if CList.is_empty l && CList.is_empty a then ()
+  else Lib.add_leaf (input_univ_names { udecl_src = src; udecl_named = l; udecl_anon = a })
 
 let label_of = let open GlobRef in function
 | ConstRef c -> Label.to_id @@ Constant.label c
@@ -108,14 +122,10 @@ let declare_univ_binders gr (univs, pl) =
         named, univs)
         pl (Level.Set.empty,[])
     in
-    (* then invent names for the rest *)
-    let _, univs = Level.Set.fold (fun univ (aux,univs) ->
-        let id, aux = invent_name aux univ in
-        let univ = Option.get (Level.name univ) in
-        aux, (id,univ) :: univs)
-        (Level.Set.diff levels named) ((pl,0),univs)
-    in
-    input_univ_names (QualifiedUniv l, univs)
+    (* then keep the anonymous ones *)
+    let fold u accu = Option.get (Level.name u) :: accu in
+    let anonymous = Level.Set.fold fold (Level.Set.diff levels named) [] in
+    input_univ_names (QualifiedUniv l, univs, anonymous)
 
 let do_universe ~poly l =
   let in_section = Lib.sections_are_opened () in
@@ -129,7 +139,7 @@ let do_universe ~poly l =
       Univ.Level.Set.empty l, Univ.Constraints.empty
   in
   let src = if poly then BoundUniv else UnqualifiedUniv in
-  let () = input_univ_names (src, l) in
+  let () = input_univ_names (src, l, []) in
   DeclareUctx.declare_universe_context ~poly ctx
 
 let do_constraint ~poly l =


### PR DESCRIPTION
We simply store the list of anonymous universes and generate their names on the fly, instead of precomputing them and storing them on disk.