### PR TITLE
Bump Sphinx to 4.5.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,7 +35,7 @@ variables:
   # $DATE is so we can tell what's what in the image list
   # The $hash is the first 10 characters of the md5 of the Dockerfile. e.g.
   # echo $(md5sum dev/ci/docker/bionic_coq/Dockerfile | head -c 10)
-  CACHEKEY: "bionic_coq-V2023-06-07-de28eea879"
+  CACHEKEY: "bionic_coq-V2023-06-28-f4996be80f"
   IMAGE: "$CI_REGISTRY_IMAGE:$CACHEKEY"
 
   # By default, jobs run in the base switch; override to select another switch

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,7 +35,7 @@ variables:
   # $DATE is so we can tell what's what in the image list
   # The $hash is the first 10 characters of the md5 of the Dockerfile. e.g.
   # echo $(md5sum dev/ci/docker/bionic_coq/Dockerfile | head -c 10)
-  CACHEKEY: "bionic_coq-V2023-06-28-f4996be80f"
+  CACHEKEY: "bionic_coq-V2023-06-29-2b9dca3152"
   IMAGE: "$CI_REGISTRY_IMAGE:$CACHEKEY"
 
   # By default, jobs run in the base switch; override to select another switch

--- a/dev/ci/docker/bionic_coq/Dockerfile
+++ b/dev/ci/docker/bionic_coq/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update -qq && apt-get install --no-install-recommends -y -qq \
         wdiff
 
 # More dependencies of the sphinx doc, pytest for coqtail
-RUN pip3 install docutils==0.16 sphinx==4.5.0 sphinx_rtd_theme==0.4.3 \
+RUN pip3 install docutils==0.17.1 sphinx==4.5.0 sphinx_rtd_theme==1.0.0 \
         antlr4-python3-runtime==4.7.1 sphinxcontrib-bibtex==0.4.2 \
         pytest==5.4.3
 

--- a/dev/ci/docker/bionic_coq/Dockerfile
+++ b/dev/ci/docker/bionic_coq/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update -qq && apt-get install --no-install-recommends -y -qq \
         wdiff
 
 # More dependencies of the sphinx doc, pytest for coqtail
-RUN pip3 install docutils==0.16 sphinx==3.0.2 sphinx_rtd_theme==0.4.3 \
+RUN pip3 install docutils==0.16 sphinx==4.5.0 sphinx_rtd_theme==0.4.3 \
         antlr4-python3-runtime==4.7.1 sphinxcontrib-bibtex==0.4.2 \
         pytest==5.4.3
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -30,7 +30,7 @@ To produce the complete documentation in HTML, you will need Coq dependencies
 listed in [`INSTALL.md`](../INSTALL.md). Additionally, the Sphinx-based
 reference manual requires Python 3, and the following Python packages:
 
-  - sphinx >= 3.0.2
+  - sphinx >= 4.5.0
   - sphinx_rtd_theme >= 0.4.3
   - beautifulsoup4 >= 4.0.6
   - antlr4-python3-runtime >= 4.7.1

--- a/doc/README.md
+++ b/doc/README.md
@@ -31,7 +31,7 @@ listed in [`INSTALL.md`](../INSTALL.md). Additionally, the Sphinx-based
 reference manual requires Python 3, and the following Python packages:
 
   - sphinx >= 4.5.0
-  - sphinx_rtd_theme >= 0.4.3
+  - sphinx_rtd_theme >= 1.0.0
   - beautifulsoup4 >= 4.0.6
   - antlr4-python3-runtime >= 4.7.1
   - pexpect >= 4.2.1

--- a/doc/changelog/12-infrastructure-and-dependencies/17772-bump-sphinx.rst
+++ b/doc/changelog/12-infrastructure-and-dependencies/17772-bump-sphinx.rst
@@ -1,0 +1,7 @@
+- **Changed:**
+  Sphinx 4.5.0 or above is now required to build the reference manual, so now /
+  can be used as a quick search shortcut and Esc as a shortcut to remove search
+  highlighting
+  (`#17772 <https://github.com/coq/coq/pull/17772>`_,
+  fixes `#15778 <https://github.com/coq/coq/issues/15778>`_,
+  by Ana Borges).

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -50,7 +50,7 @@ with open("refman-preamble.rst") as s:
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = '3.0.2'
+needs_sphinx = '4.5.0'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom


### PR DESCRIPTION
To obtain `/` as a quick search shortcut and `Esc` as a shortcut to remove search highlighting.
Sphinx 4.5.0 was released in March 2022.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #15778


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- ~~[ ] Added / updated **test-suite**.~~

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - ~~[ ] Documented any new / changed **user messages**.~~
  - ~~[ ] Updated **documented syntax** by running `make doc_gram_rsts`.~~

<!-- If this breaks external libraries or plugins in CI: -->
- ~~[ ] Opened **overlay** pull requests.~~

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
