### PR TITLE
Update nixpkgs and document upper bound on ANTLR compatibility.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     hostname
-    python3
+    python311
     # coq-makefile timing tools
     time
     dune_3
@@ -54,10 +54,10 @@ stdenv.mkDerivation rec {
   ]
   ++ optionals buildDoc [
     # Sphinx doc dependencies
-    pkg-config (python3.withPackages
+    pkg-config (python311.withPackages
       (ps: [ ps.sphinx ps.sphinx_rtd_theme ps.pexpect ps.beautifulsoup4
-             ps.antlr4-python3-runtime ps.sphinxcontrib-bibtex ]))
-    antlr4
+             (ps.antlr4-python3-runtime.override {antlr4 = pkgs.antlr4_9;}) ps.sphinxcontrib-bibtex ]))
+    antlr4_9
     ocamlPackages.odoc
   ]
   ++ optionals doInstallCheck [

--- a/dev/nixpkgs.nix
+++ b/dev/nixpkgs.nix
@@ -1,4 +1,4 @@
 import (fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/5b9b93b9be4234aaf9cd53e3247a927225095514.tar.gz";
-  sha256 = "0wz4xr43rg1p2sqgi6zg3s02jfaxhl15slz747fh6h825i4cz9bb";
+  url = "https://github.com/NixOS/nixpkgs/archive/a565059a348422af5af9026b5174dc5c0dcefdae.tar.gz";
+  sha256 = "1spgz981x8p2ix9nsrkfw7a4n5wx35mf4v0bsjqfpjy360jb5rix";
 })

--- a/doc/README.md
+++ b/doc/README.md
@@ -32,7 +32,7 @@ reference manual requires Python 3, and the following Python packages:
 
   - sphinx >= 4.5.0
   - sphinx_rtd_theme >= 1.0.0
-  - beautifulsoup4 >= 4.0.6
+  - beautifulsoup4 >= 4.6.0
   - antlr4-python3-runtime >= 4.7.1 & <= 4.9.3
   - pexpect >= 4.2.1
   - sphinxcontrib-bibtex >= 0.4.2

--- a/doc/README.md
+++ b/doc/README.md
@@ -33,7 +33,7 @@ reference manual requires Python 3, and the following Python packages:
   - sphinx >= 4.5.0
   - sphinx_rtd_theme >= 1.0.0
   - beautifulsoup4 >= 4.0.6
-  - antlr4-python3-runtime >= 4.7.1
+  - antlr4-python3-runtime >= 4.7.1 & <= 4.9.3
   - pexpect >= 4.2.1
   - sphinxcontrib-bibtex >= 0.4.2
 


### PR DESCRIPTION
As part of our attempts with @ana-borges to figure out some combination of Python package versions that would solve the issue we are seeing in #17772, I updated the nixpkgs pin to use more recent versions of the dependencies. During this process, we discovered that the refman build will fail with recent versions of the ANTLR runtime, so this PR documents this upper bound. With intermediate versions (> 4.7.1 & <= 4.9.3) we just get the warning:

```
ANTLR runtime and generated code versions disagree: 4.9.3!=4.7.2
```

If we want to be compatible with recent ANTLR versions, we would have to regenerate the code.

FWIW, ANTLR 4.10, which is named "Major feature, code clean up, and bug fix release" [on GitHub](https://github.com/antlr/antlr4/releases/tag/4.10), was released in April 2022.

cc @cpitclaudel FYI