### PR TITLE
Update base Ubuntu image in Dockerfile.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,11 +31,11 @@ stages:
 
 # some default values
 variables:
-  # Format: bionic_coq-V$DATE-$hash
+  # Format: ubuntu_coq-V$DATE-$hash
   # $DATE is so we can tell what's what in the image list
   # The $hash is the first 10 characters of the md5 of the Dockerfile. e.g.
-  # echo $(md5sum dev/ci/docker/bionic_coq/Dockerfile | head -c 10)
-  CACHEKEY: "bionic_coq-V2023-06-07-de28eea879"
+  # echo $(md5sum dev/ci/docker/Dockerfile | head -c 10)
+  CACHEKEY: "ubuntu_coq-V2023-06-29-7de9f3967d"
   IMAGE: "$CI_REGISTRY_IMAGE:$CACHEKEY"
 
   # By default, jobs run in the base switch; override to select another switch
@@ -284,7 +284,7 @@ docker-boot:
   script:
     - dev/tools/check-cachekey.sh
     - docker login -u gitlab-ci-token -p "$CI_JOB_TOKEN" "$CI_REGISTRY"
-    - cd dev/ci/docker/bionic_coq/
+    - cd dev/ci/docker/
     - if docker pull "$IMAGE"; then echo "Image prebuilt!"; exit 0; fi
     - docker build -t "$IMAGE" .
     - docker push "$IMAGE"

--- a/dev/ci/README-users.md
+++ b/dev/ci/README-users.md
@@ -108,7 +108,7 @@ Some important points:
   The second one uses the highest version of OCaml supported by Coq,
   with flambda enabled (currently it actually uses OCaml 4.14.1 as 5.0
   has significant performance issues). See also the
-  [`Dockerfile`](docker/bionic_coq/Dockerfile) to find out what
+  [`Dockerfile`](docker/Dockerfile) to find out what
   specific packages are available in each switch.
 
   If your job depends on other jobs, you must use the same opam

--- a/dev/ci/docker/Dockerfile
+++ b/dev/ci/docker/Dockerfile
@@ -1,6 +1,6 @@
 # Update CACHEKEY in the .gitlab-ci.yml when modifying this file.
 
-FROM ubuntu:bionic
+FROM ubuntu:20.04
 LABEL maintainer="e@x80.org"
 
 ENV DEBIAN_FRONTEND="noninteractive"
@@ -16,7 +16,7 @@ RUN apt-get update -qq && apt-get install --no-install-recommends -y -qq \
         # Dependencies of lablgtk (for CoqIDE)
         libgtksourceview-3.0-dev \
         # Dependencies of Gappa
-        libboost1.65-all-dev libmpfr-dev autoconf-archive bison flex \
+        libboost1.67-all-dev libmpfr-dev autoconf-archive bison flex \
         # Dependencies of stdlib and sphinx doc
         texlive-latex-extra texlive-fonts-recommended texlive-xetex latexmk \
         python3-pip python3-setuptools python3-pexpect python3-bs4 fonts-freefont-otf \

--- a/dev/ci/docker/README.md
+++ b/dev/ci/docker/README.md
@@ -1,7 +1,7 @@
 ## Overall Docker Setup for Coq's CI.
 
-This directory provides Docker images to be used by Coq's CI. The
-images do support Docker autobuild on `hub.docker.com` and Gitlab's
+This directory provides the Docker image used by Coq's CI. The
+image supports Docker autobuild on `hub.docker.com` and Gitlab's
 private registry.
 
 The Gitlab CI will build a Docker image unless the CI environment variable

--- a/dev/doc/release-process.md
+++ b/dev/doc/release-process.md
@@ -37,7 +37,7 @@
 - [ ] Ping the development coordinator (`@mattam82`) to get him started on writing the release summary.
   The [`dev/tools/list-contributors.sh`](../tools/list-contributors.sh) script computes the number and list of contributors between Coq revisions. Typically used with `VX.X+alpha..vX.X` to check the contributors of version `VX.X`.
   Note that this script relies on [`.mailmap`](../../.mailmap) to merge multiple identities.  If you notice anything incorrect while using it, use the opportunity to fix the `.mailmap` file.  Same thing if you want to have the full name of a contributor shown instead of a pseudonym.
-- [ ] Put the branch name in CACHEKEY in [`.gitlab-ci.yml`](../../.gitlab-ci.yml) (for instance ``bionic_coq-V2022-05-20-c34331afa5`` to ``"bionic_coq-v8.16-V2022-05-20-c34331afa5``) to indicate that it shouldn't be cleaned up even once it gets old. This should be done after all PRs touching CACHEKEY have been merged.
+- [ ] Put the branch name in CACHEKEY in [`.gitlab-ci.yml`](../../.gitlab-ci.yml) (for instance ``ubuntu_coq-V2022-05-20-c34331afa5`` to ``"ubuntu_coq-v8.16-V2022-05-20-c34331afa5``) to indicate that it shouldn't be cleaned up even once it gets old. This should be done after all PRs touching CACHEKEY have been merged.
 
 ## For each release (preview, final, patch-level) ##
 

--- a/dev/tools/check-cachekey.sh
+++ b/dev/tools/check-cachekey.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-hash=$(md5sum dev/ci/docker/bionic_coq/Dockerfile | head -c 10)
+hash=$(md5sum dev/ci/docker/Dockerfile | head -c 10)
 key=$(grep CACHEKEY: .gitlab-ci.yml)
 keyhash=${key%\"}
 keyhash=${keyhash##*-}


### PR DESCRIPTION
Ubuntu Bionic (18.04) is EOL in June 2023, so we bump the base Ubuntu image in the Dockerfile to the latest LTS : 22.04. We also make the infrastructure more agnostic to the exact version of Ubuntu being used and use the date-based tag in the Dockerfile to make it clearer when we are very outdated.