### PR TITLE
add RM release item about propagating opam package changes

### DIFF
--- a/dev/doc/release-process.md
+++ b/dev/doc/release-process.md
@@ -56,6 +56,7 @@
 - [ ] Make sure to cc `@erikmd` to request that he prepares the necessary configuration for the Docker release in [`coqorg/coq`](https://hub.docker.com/r/coqorg/coq) (namely, he'll need to make sure a `coq-bignums` opam package is available in [`extra-dev`](https://github.com/coq/opam-coq-archive/tree/master/extra-dev), respectively
   [`released`](https://github.com/coq/opam-coq-archive/tree/master/released), so the Docker image gathering `coq` and `coq-bignums` can be built).
 - [ ] Publish a release on GitHub with the PDF version of the reference manual attached. The PDF can be recovered from the artifacts of the `doc:refman-pdf` job from continuous integration.
+- [ ] If pinged by opam package providers in pull requests to [ocaml/opam-repository](https://github.com/ocaml/opam-repository), transfer any changes to opam packages required by opam-repository CI (such as missing dependencies) to the corresponding package definitions in the Coq repository.
 
 ## For the first release candidate release ##
 


### PR DESCRIPTION
As discussed [on Zulip](https://coq.zulipchat.com/#narrow/stream/237656-Coq-devs-.26-plugin-devs/topic/Coq.208.2E17.2E1), the submission of opam packages for a Coq release to [opam-repository](https://github.com/ocaml/opam-repository) is currently done by volunteers outside core.

However, the nitpicky CI in opam-repository has often found missing dependencies and inaccurate dependency bounds in Coq-related opam packages. Here, I add an explicit item for RMs to propagate these important changes in opam packages to the Coq repo - but *only* if they are aware of these packages being submitted.

This item should be removed if #16071 becomes addressed in the future.

cc: @Zimmi48 @ejgallego 

Related: #17790 #17362