### PR TITLE
Markup EQ as code.

### DIFF
--- a/doc/sphinx/language/extensions/canonical.rst
+++ b/doc/sphinx/language/extensions/canonical.rst
@@ -213,7 +213,7 @@ Note that in practice the user may want to declare ``EQ.obj`` as a
 coercion, but we will not do that here.
 
 The following line tests that, when we assume a type ``e`` that is in
-theEQ class, we can relate two of its objects with ``==``.
+the ``EQ`` class, we can relate two of its objects with ``==``.
 
 .. coqtop:: all
 


### PR DESCRIPTION
I found a typo in canonical.rst.
