### PR TITLE
Add coercion hook

### DIFF
--- a/doc/changelog/13-misc/17794-coercion_hook.rst
+++ b/doc/changelog/13-misc/17794-coercion_hook.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  a hook in the coercion mechanism to enable programming coercions in
+  external metalanguages such as Ltac, Ltac2, Elpi or OCaml plugins
+  (`#17794 <https://github.com/coq/coq/pull/17794>`_,
+  by Pierre Roux).

--- a/pretyping/coercion.mli
+++ b/pretyping/coercion.mli
@@ -58,6 +58,25 @@ val inh_conv_coerce_rigid_to : ?loc:Loc.t -> program_mode:bool -> resolve_tc:boo
 val inh_pattern_coerce_to :
   ?loc:Loc.t -> env -> cases_pattern -> inductive -> inductive -> cases_pattern
 
+type hook = env -> evar_map -> flags:Evarconv.unify_flags -> constr ->
+  inferred:types -> expected:types -> (evar_map * constr) option
+
+(** A plugin can override the coercion mechanism by registering a hook here.
+    Note that these hooks will only be trigerred when no direct or reversible
+    coercion applies.
+    Newly registered hooks are not active by default, see [activate_hook] below.
+    The same hook cannot be registered twice, except if [override] is [true].
+    Beware that this addition is not persistent, it is up to the plugin to use
+    libobject if needed. *)
+val register_hook : name:string -> ?override:bool -> hook -> unit
+
+(** Activate a previously registered hook.
+    Most recently activated hooks are tried first. *)
+val activate_hook : name:string -> unit
+
+(** Deactivate a hook. If the hook wasn't registered/active,
+    this does nothing. *)
+val deactivate_hook : name:string -> unit
 
 type delayed_app_body
 


### PR DESCRIPTION
This adds a hook in `pretyping/coercion.ml` to enable programming more elaborate coercions in an external metalanguage (Ltac, Ltac2, Elpi,...). This was developped during CUDW 2023 along with a coq-elpi interface: https://github.com/proux01/coq-elpi/tree/coercion_hook

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] ~Added / updated **test-suite**.~

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [ ] ~Added / updated **documentation**.~
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] ~Documented any new / changed **user messages**.~
  - [ ] ~Updated **documented syntax** by running `make doc_gram_rsts`.~

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] ~Opened **overlay** pull requests.~

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
