### PR TITLE
add ATBR plugin to CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -839,6 +839,9 @@ library:ci-coq_library_undecidability:
 plugin:ci-aac_tactics:
   extends: .ci-template-flambda
 
+plugin:ci-atbr:
+  extends: .ci-template-flambda
+
 plugin:ci-itauto:
   extends: .ci-template
 

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -12,6 +12,7 @@ CI_TARGETS= \
     ci-itauto \
     ci-aac_tactics \
     ci-argosy \
+    ci-atbr \
     ci-autosubst \
     ci-bbv \
     ci-bedrock2 \

--- a/dev/ci/ci-atbr.sh
+++ b/dev/ci/ci-atbr.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+git_download atbr
+
+if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
+
+( cd "${CI_BUILD_DIR}/atbr"
+  make
+  make install
+)

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -306,6 +306,11 @@ project stdlib2 "https://github.com/coq/stdlib2" "master"
 project argosy "https://github.com/mit-pdos/argosy" "master"
 
 ########################################################################
+# ATBR
+########################################################################
+project atbr "https://github.com/coq-community/atbr" "master"
+
+########################################################################
 # perennial
 ########################################################################
 project perennial "https://github.com/mit-pdos/perennial" "coq/tested"


### PR DESCRIPTION
[ATBR](https://github.com/coq-community/atbr) is a plugin and library with "Algebraic tools for binary relations", maintained as part of Coq-community.

It is hoped that if ATBR is maintained, it may be possible to reclaim some valuable [old results](https://lmcs.episciences.org/718/) depending on a previous version.