### PR TITLE
Add introduction to the section on variants and inductive types in the reference manual

### DIFF
--- a/doc/sphinx/language/core/basic.rst
+++ b/doc/sphinx/language/core/basic.rst
@@ -325,7 +325,7 @@ rest of the Coq manual: :term:`terms <term>` and :term:`types
      Intuitively, types may be viewed as sets containing terms.  We
      say that a type is :gdef:`inhabited` if it contains at least one
      term (i.e. if we can find a term which is associated with this
-     type).  We call such terms :gdef:`witnesses <witness>`.  Note that deciding
+     type).  We call such terms :gdef:`inhabitants <inhabitants>`.  Note that deciding
      whether a type is inhabited is `undecidable
      <https://en.wikipedia.org/wiki/Undecidable_problem>`_.
 

--- a/doc/sphinx/language/core/basic.rst
+++ b/doc/sphinx/language/core/basic.rst
@@ -325,7 +325,7 @@ rest of the Coq manual: :term:`terms <term>` and :term:`types
      Intuitively, types may be viewed as sets containing terms.  We
      say that a type is :gdef:`inhabited` if it contains at least one
      term (i.e. if we can find a term which is associated with this
-     type).  We call such terms :gdef:`inhabitants <inhabitants>`.  Note that deciding
+     type).  We call such terms :gdef:`inhabitants <inhabitant>`.  Note that deciding
      whether a type is inhabited is `undecidable
      <https://en.wikipedia.org/wiki/Undecidable_problem>`_.
 

--- a/doc/sphinx/language/core/inductive.rst
+++ b/doc/sphinx/language/core/inductive.rst
@@ -1,6 +1,23 @@
 Inductive types and recursive functions
 =======================================
 
+The :cmd:`Inductive` command allows defining types by cases on the form of the
+:term:`inhabitants <inhabitant>` of the type. These constructors can recursively
+have arguments in the type being defined.  In contrast, in types defined by the
+:cmd:`Variant` command, such recursive references are not permitted.
+Inductive types include natural numbers,
+lists and well-founded trees. Inhabitants of inductive types can
+recursively nest only a finite number of constructors. So, they are
+well-founded. This distinguishes them from :cmd:`CoInductive` types,
+such as streams, whose constructors can be infinitely nested. In Coq,
+:cmd:`Variant` types thus correspond to the common subset of inductive
+and coinductive types that are non-recursive.
+
+Due to the recursive structure of inductive types, functions on
+inductive types generally must be defined
+recursively using the :n:`fix` expression (see :n:`@term_fix`) or the
+:cmd:`Fixpoint` command.
+
 .. _gallina-inductive-definitions:
 
 Inductive types

--- a/doc/sphinx/language/core/sorts.rst
+++ b/doc/sphinx/language/core/sorts.rst
@@ -31,7 +31,7 @@ and :math:`\Set`.
 The sort :math:`\Prop` intends to be the type of logical propositions. If :math:`M` is a
 logical proposition then it denotes the class of terms representing
 proofs of :math:`M`. An object :math:`m` belonging to :math:`M`
-:term:`witnesses <witness>` the fact that :math:`M` is
+witnesses the fact that :math:`M` is
 provable. An object of type :math:`\Prop` is called a :gdef:`proposition`.
 We denote propositions by :n:`@form`.
 This constitutes a semantic subclass of the syntactic class :n:`@term`.

--- a/doc/sphinx/language/core/variants.rst
+++ b/doc/sphinx/language/core/variants.rst
@@ -6,11 +6,30 @@ Variants and the `match` construct
 Variants
 --------
 
+The :cmd:`Variant` command allows defining types by listing
+the :term:`inhabitants <inhabitant>` of the type.  Each inhabitant is
+specified by a :gdef:`constructor`.  For instance, Booleans have two
+constructors: :g:`true` and :g:`false`. Types can include enumerated types from
+programming languages, such as Booleans, characters or even the
+degenerate cases of the unit and empty types. Variant types more
+generally include enumerated types with arguments or even enumerated
+types with parametric arguments such as option types and sum types.
+It also includes predicates or type families defined by cases
+such as the Boolean reflection or equality predicates. Observing the
+form of the :term:`inhabitants <inhabitant>` of a variant type is done by case analysis
+using the `match` expression.
+
+When a constructor of a type takes an argument of that same type,
+the type becomes recursive, in which case it can be either
+:cmd:`Inductive` or :cmd:`CoInductive`. The keyword :cmd:`Variant`
+is reserved for non-recursive types. Natural numbers, lists or streams cannot
+be defined using :cmd:`Variant`.
+
 .. cmd:: Variant @ident_decl {* @binder } {? %| {* @binder } } {? : @type } := {? %| } {+| @constructor } {? @decl_notations }
 
-   The :cmd:`Variant` command is similar to the :cmd:`Inductive` command, except
-   that it disallows recursive definition of types (for instance, lists cannot
-   be defined using :cmd:`Variant`). No induction scheme is generated for
+   Defines a variant type named :n:`@ident` (in :n:`@ident_decl`)
+   with the given list of constructors.
+   No induction scheme is generated for
    this variant, unless the :flag:`Nonrecursive Elimination Schemes` flag is on.
 
    :n:`{? %| {* @binder } }`
@@ -23,6 +42,52 @@ Variants
 
    .. exn:: The @natural th argument of @ident must be @ident in @type.
       :undocumented:
+
+.. example::
+
+  The Booleans, the unit type and the empty type are respectively defined by:
+
+   .. coqtop:: none
+
+      Module FreshNameSpace.
+
+   .. coqtop:: in
+
+      Variant bool : Type := true : bool | false : bool.
+      Variant unit : Type := tt : unit.
+      Variant Empty_set : Type :=.
+
+  The option and sum types are defined by:
+
+   .. coqtop:: in
+
+      Variant option (A : Type) : Type := None : option A | Some : A -> option A.
+      Variant sum (A B : Type) : Type := inl : A -> sum A B | inr : B -> sum A B.
+
+  *Boolean reflection* is a relation reflecting under the form of a
+  Boolean value when a given proposition :n:`P` holds. It can be
+  defined as a two-constructor type family over :g:`bool`
+  parameterized by the proposition :n:`P`:
+
+  .. coqtop:: in
+
+     Variant reflect (P : Prop) : bool -> Set :=
+     | ReflectT : P -> reflect P true
+     | ReflectF : ~ P -> reflect P false.
+
+  .. coqtop:: none
+
+     End FreshNameSpace.
+
+  :term:`Leibniz equality` is another example of variant type.
+
+.. note::
+   The standard library commonly uses :cmd:`Inductive` in
+   place of :cmd:`Variant` even for non-recursive types in order to
+   automatically derive the schemes
+   :n:`@ident`\ ``_rect``, :n:`@ident`\ ``_ind``, :n:`@ident`\
+   ``_rec`` and :n:`@ident`\ ``_sind``.  (These schemes are also created
+   for :cmd:`Variant` if the :flag:`Nonrecursive Elimination Schemes` flag is set.)
 
 Private (matching) inductive types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/sphinx/language/extensions/evars.rst
+++ b/doc/sphinx/language/extensions/evars.rst
@@ -188,8 +188,8 @@ automatically as a side effect of other tactics.
       Unshelve. (* moves the shelved goals into focus--not needed and usually not done *)
       exact H1. (* resolves the first goal and by side effect ?x and ?m *)
 
-   The :n:`?x` and :n:`?m` goals ask for proof that :n:`nat` has a
-   :term:`witness`, i.e. it is not an empty type.  This can be proved directly
+   The :n:`?x` and :n:`?m` goals ask for proof that :n:`nat` has an
+   :term:`inhabitant`, i.e. it is not an empty type.  This can be proved directly
    by applying a constructor of :n:`nat`, which assigns values for :n:`?x` and
    :n:`?m`.  However if you choose poorly, you can end up with unprovable goals
    (in this case :n:`0 < 0`).  Like this:


### PR DESCRIPTION
This is a preliminary proposal to add an introductive header to the Variant and Inductive sections of the reference manual.

It is probably not ok as such. For instance, it should probably be decided first what comes first in the explanations between `Variant` and `Inductive`, where is the syntax given, or whether it is duplicated, or if the sections have to be both readable independently, etc. So, waiting for an opinion of the reference manual coordinators.

Fixes / closes #17786

- [x] Added / updated **documentation**.
