### PR TITLE
Generate opam files using Dune.

### DIFF
--- a/coq-core.opam
+++ b/coq-core.opam
@@ -32,10 +32,12 @@ depends: [
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}
   "ounit2" {with-test}
+  "odoc" {with-doc}
 ]
+depopts: ["coq-native"]
+dev-repo: "git+https://github.com/coq/coq.git"
 build: [
-  # Requires dune 2.8 due to https://github.com/ocaml/dune/issues/3219
-  # ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [ "./configure"
     "-prefix" prefix
     "-mandir" man
@@ -49,10 +51,10 @@ build: [
     name
     "-j"
     jobs
+    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["dune" "install" "-p" name "--create-install-files" name]
 ]
-dev-repo: "git+https://github.com/coq/coq.git"
-depopts: ["coq-native"]

--- a/coq-core.opam.template
+++ b/coq-core.opam.template
@@ -1,0 +1,22 @@
+build: [
+  ["dune" "subst"] {dev}
+  [ "./configure"
+    "-prefix" prefix
+    "-mandir" man
+    "-libdir" "%{lib}%/coq"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
+  ]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]

--- a/coq-doc.opam
+++ b/coq-doc.opam
@@ -19,10 +19,10 @@ depends: [
   "dune" {>= "2.9"}
   "conf-python-3" {build}
   "coq" {build & = version}
+  "odoc" {with-doc}
 ]
 build: [
-  # Requires dune 2.8 due to https://github.com/ocaml/dune/issues/3219
-  # ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"
@@ -30,9 +30,11 @@ build: [
     name
     "-j"
     jobs
+    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/coq/coq.git"

--- a/coq-stdlib.opam
+++ b/coq-stdlib.opam
@@ -25,12 +25,13 @@ bug-reports: "https://github.com/coq/coq/issues"
 depends: [
   "dune" {>= "2.9"}
   "coq-core" {= version}
+  "odoc" {with-doc}
 ]
+depopts: ["coq-native"]
+dev-repo: "git+https://github.com/coq/coq.git"
 build: [
-  # Requires dune 2.8 due to https://github.com/ocaml/dune/issues/3219
-  # ["dune" "subst"] {pinned}
-  #
-  # XXX need to run configure as in coq-core, or else dunestrap will
+  ["dune" "subst"] {dev}
+  # need to run configure as in coq-core, or else dunestrap will
   # use the default rule in config
   [ "./configure"
     "-prefix" prefix
@@ -46,10 +47,10 @@ build: [
     name
     "-j"
     jobs
+    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["dune" "install" "-p" name "--create-install-files" name]
 ]
-dev-repo: "git+https://github.com/coq/coq.git"
-depopts: ["coq-native"]

--- a/coq-stdlib.opam.template
+++ b/coq-stdlib.opam.template
@@ -1,0 +1,25 @@
+build: [
+  ["dune" "subst"] {dev}
+  # need to run configure as in coq-core, or else dunestrap will
+  # use the default rule in config
+  [ "./configure"
+    "-prefix" prefix
+    "-mandir" man
+    "-libdir" "%{lib}%/coq"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
+  ]
+  [ make "dunestrap" "COQ_DUNE_EXTRA_OPT=-split" ]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]

--- a/coq.opam
+++ b/coq.opam
@@ -24,9 +24,10 @@ depends: [
   "coq-core" {= version}
   "coq-stdlib" {= version}
   "coqide-server" {= version}
+  "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"
@@ -34,9 +35,11 @@ build: [
     name
     "-j"
     jobs
+    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/coq/coq.git"

--- a/coqide-server.opam
+++ b/coqide-server.opam
@@ -21,10 +21,10 @@ bug-reports: "https://github.com/coq/coq/issues"
 depends: [
   "dune" {>= "2.9"}
   "coq-core" {= version}
+  "odoc" {with-doc}
 ]
 build: [
-  # Requires dune 2.8 due to https://github.com/ocaml/dune/issues/3219
-  # ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"
@@ -32,9 +32,11 @@ build: [
     name
     "-j"
     jobs
+    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/coq/coq.git"

--- a/coqide.opam
+++ b/coqide.opam
@@ -24,10 +24,10 @@ depends: [
   "coqide-server" {= version}
   "cairo2" {>= "0.6.4"}
   "lablgtk3-sourceview3" {>= "3.1.2"}
+  "odoc" {with-doc}
 ]
 build: [
-  # Requires dune 2.8 due to https://github.com/ocaml/dune/issues/3219
-  # ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"
@@ -35,9 +35,11 @@ build: [
     name
     "-j"
     jobs
+    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/coq/coq.git"

--- a/dune-project
+++ b/dune-project
@@ -5,8 +5,7 @@
 (formatting
  (enabled_for ocaml))
 
-; After Dune 2.8 we can use this, but let's wait for the build consolidation PR
-; (generate_opam_files true)
+(generate_opam_files true)
 
 (license LGPL-2.1-only)
 (maintainers "The Coq development team <coqdev@inria.fr>")


### PR DESCRIPTION
Fixes / closes #16071.

On top of #17790.

The requirements described in #16071 have been satisfied for a while now, so I don't know what has stopped us from fixing this issue. This PR does it, but if we are still not ready to generate these files, then we should remove the outdated comments from them (and `dune-project`).

The two `.opam.template` files are necessary to be able to run the `configure` step (and the `dunestrap` step in the `coq-stdlib` case). Here is the diff if we remove them and regenerate the opam files (I don't know why `dev-repo` moves around, but this seems irrelevant):

```diff
diff --git a/coq-core.opam b/coq-core.opam
index 17581cad9b..e382ec9f20 100644
--- a/coq-core.opam
+++ b/coq-core.opam
@@ -35,15 +35,8 @@ depends: [
   "odoc" {with-doc}
 ]
 depopts: ["coq-native"]
-dev-repo: "git+https://github.com/coq/coq.git"
 build: [
   ["dune" "subst"] {dev}
-  [ "./configure"
-    "-prefix" prefix
-    "-mandir" man
-    "-libdir" "%{lib}%/coq"
-    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
-  ]
   [
     "dune"
     "build"
@@ -58,3 +51,4 @@ build: [
   ]
   ["dune" "install" "-p" name "--create-install-files" name]
 ]
+dev-repo: "git+https://github.com/coq/coq.git"
diff --git a/coq-stdlib.opam b/coq-stdlib.opam
index 3cb83999c0..ed70a251ae 100644
--- a/coq-stdlib.opam
+++ b/coq-stdlib.opam
@@ -28,18 +28,8 @@ depends: [
   "odoc" {with-doc}
 ]
 depopts: ["coq-native"]
-dev-repo: "git+https://github.com/coq/coq.git"
 build: [
   ["dune" "subst"] {dev}
-  # need to run configure as in coq-core, or else dunestrap will
-  # use the default rule in config
-  [ "./configure"
-    "-prefix" prefix
-    "-mandir" man
-    "-libdir" "%{lib}%/coq"
-    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
-  ]
-  [ make "dunestrap" "COQ_DUNE_EXTRA_OPT=-split" ]
   [
     "dune"
     "build"
@@ -54,3 +44,4 @@ build: [
   ]
   ["dune" "install" "-p" name "--create-install-files" name]
 ]
+dev-repo: "git+https://github.com/coq/coq.git"
```

Up to the 8.18 RMs to decide whether this should be in 8.18 or 8.19.