### PR TITLE
[build] [doc] Fix coq-doc package

### DIFF
--- a/doc/changelog/12-infrastructure-and-dependencies/17808-coq-doc-pkg.rst
+++ b/doc/changelog/12-infrastructure-and-dependencies/17808-coq-doc-pkg.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  The `coq-doc` opam / Dune package will now build and install Coq's
+  documentation (`#17808 <https://github.com/coq/coq/pull/17808>`_, by
+  Emilio Jesus Gallego Arias).

--- a/doc/dune
+++ b/doc/dune
@@ -21,7 +21,8 @@
   (env_var SPHINXWARNOPT)))
 
 (rule
- (targets refman-html)
+ (targets
+  (dir refman-html))
  (alias refman-html)
  (package coq-doc)
  ; Cannot use this deps alias because of ocaml/dune#3415
@@ -39,7 +40,8 @@
   (run env sphinx-build -q %{env:SPHINXWARNOPT=-W} -b html sphinx %{targets})))
 
 (rule
- (targets refman-pdf)
+ (targets
+  (dir refman-pdf))
  (alias refman-pdf)
  (package coq-doc)
  ; Cannot use this deps alias because of ocaml/dune#3415
@@ -57,13 +59,10 @@
    (run env sphinx-build -q %{env:SPHINXWARNOPT=-W} -b latex sphinx %{targets})
    (chdir %{targets} (run make LATEXMKOPTS=-silent)))))
 
-; Installable directories are not yet fully supported by Dune.  See
-; ocaml/dune#1868.  Yet, this makes coq-doc.install a valid target to
-; generate the whole Coq documentation.  And the result under
-; _build/install/default/doc/coq-doc looks just right!
-
 (install
- (files (refman-html as html/refman) (refman-pdf as pdf/refman))
+ (dirs
+  (refman-html as html/refman)
+  (refman-pdf as pdf/refman))
  (section doc)
  (package coq-doc))
 

--- a/doc/stdlib/dune
+++ b/doc/stdlib/dune
@@ -12,7 +12,7 @@
    (bash "doc/stdlib/make-library-index doc/stdlib/index-list.html doc/stdlib/hidden-files"))))
 
 (rule
-  (targets html)
+  (targets (dir html))
   (alias stdlib-html)
   (package coq-doc)
   (deps
@@ -40,6 +40,6 @@
 ; _build/install/default/doc/coq-doc looks just right!
 
 (install
- (files (html as html/stdlib))
+ (dirs (html as html/stdlib))
  (section doc)
  (package coq-doc))

--- a/dune-project
+++ b/dune-project
@@ -1,5 +1,10 @@
 (lang dune 3.6)
 (name coq)
+
+; We use directory targets in documentation
+(using directory-targets 0.1)
+
+; We need this due to `(coq.pp )` declarations
 (using coq 0.3)
 
 (formatting


### PR DESCRIPTION
This uses Dune 3.5 support for installing directories to make the opam
package workable.

I have tried with these two scenarios:

- `dune build coq-doc.install # dev build`
- `dune build -p coq-doc`     # opam build`

and they do work (TM).