### PR TITLE
Code cleanup in notations: use records instead of tuples for entries and subentries

### DIFF
--- a/dev/ci/user-overlays/17823-herbelin-record-notation.sh
+++ b/dev/ci/user-overlays/17823-herbelin-record-notation.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/proux01/coq-elpi coq_17823 17823

--- a/interp/constrexpr.mli
+++ b/interp/constrexpr.mli
@@ -45,10 +45,17 @@ type entry_relative_level = LevelLt of entry_level | LevelLe of entry_level | Le
 type notation_entry = InConstrEntry | InCustomEntry of string
 
 (* A notation entry with the level where the notation lives *)
-type notation_entry_level = notation_entry * entry_level
+type notation_entry_level = {
+  notation_entry : notation_entry;
+  notation_level : entry_level;
+}
 
 (* Notation subentries, to be associated to the variables of the notation *)
-type notation_entry_relative_level = notation_entry * (entry_relative_level * side option)
+type notation_entry_relative_level = {
+  notation_subentry : notation_entry;
+  notation_relative_level : entry_relative_level;
+  notation_position : side option;
+}
 
 type notation_key = string
 

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -21,6 +21,14 @@ open Glob_ops
 open Mod_subst
 open Notation_term
 
+(** Constr default entry *)
+
+let constr_lowest_level =
+  Constrexpr.{notation_entry = InConstrEntry; notation_level = 0}
+
+let constr_some_level =
+  Constrexpr.{notation_subentry = InConstrEntry; notation_relative_level = LevelSome; notation_position = None}
+
 (**********************************************************************)
 (* Utilities                                                          *)
 
@@ -1309,11 +1317,9 @@ let remove_sigma x (terms,termlists,binders,binderlists) =
 let remove_bindinglist_sigma x (terms,termlists,binders,binderlists) =
   (terms,termlists,binders,Id.List.remove_assoc x binderlists)
 
-let default_constr_entry_relative_level = Constrexpr.(InConstrEntry,(LevelSome,None))
+let add_ldots_var metas = (ldots_var,((constr_some_level,([],[])),NtnTypeConstr))::metas
 
-let add_ldots_var metas = (ldots_var,((default_constr_entry_relative_level,([],[])),NtnTypeConstr))::metas
-
-let add_meta_bindinglist x metas = (x,((default_constr_entry_relative_level,([],[])),NtnTypeBinderList (*arbitrary:*) NtnBinderParsedAsBinder))::metas
+let add_meta_bindinglist x metas = (x,((constr_some_level,([],[])),NtnTypeBinderList (*arbitrary:*) NtnBinderParsedAsBinder))::metas
 
 (* This tells if letins in the middle of binders should be included in
    the sequence of binders *)
@@ -1359,7 +1365,7 @@ let match_binderlist match_iter_fun match_termin_fun alp metas sigma rest x y it
   let alp,sigma = bind_bindinglist_env alp sigma x bl in
   match_termin_fun alp metas sigma rest termin
 
-let add_meta_term x metas = (x,((default_constr_entry_relative_level,([],[])),NtnTypeConstr))::metas (* Should reuse the scope of the partner of x! *)
+let add_meta_term x metas = (x,((constr_some_level,([],[])),NtnTypeConstr))::metas (* Should reuse the scope of the partner of x! *)
 
 let match_termlist match_fun alp metas sigma rest x y iter termin revert =
   let rec aux alp sigma acc rest =

--- a/interp/notation_ops.mli
+++ b/interp/notation_ops.mli
@@ -12,6 +12,14 @@ open Names
 open Notation_term
 open Glob_term
 
+(** Constr default entries *)
+
+(* Equivalent to an entry "in constr at level 0"; used for coercion to constr *)
+val constr_lowest_level : Constrexpr.notation_entry_level
+
+(* Equivalent to "x constr" in a subentry, at highest level *)
+val constr_some_level : Constrexpr.notation_entry_relative_level
+
 (** {5 Utilities about [notation_constr]} *)
 
 val eq_notation_constr : Id.t list * Id.t list -> notation_constr -> notation_constr -> bool

--- a/interp/notationextern.ml
+++ b/interp/notationextern.ml
@@ -36,10 +36,14 @@ let notation_entry_eq s1 s2 = match (s1,s2) with
   | InCustomEntry s1, InCustomEntry s2 -> String.equal s1 s2
   | (InConstrEntry | InCustomEntry _), _ -> false
 
-let notation_entry_level_eq (e1,n1) (e2,n2) =
+let notation_entry_level_eq
+    { notation_entry = e1; notation_level = n1 }
+    { notation_entry = e2; notation_level = n2 } =
   notation_entry_eq e1 e2 && Int.equal n1 n2
 
-let notation_entry_relative_level_eq (e1,(n1,s1)) (e2,(n2,s2)) =
+let notation_entry_relative_level_eq
+    { notation_subentry = e1; notation_relative_level = n1; notation_position = s1 }
+    { notation_subentry = e2; notation_relative_level = n2; notation_position = s2 } =
   notation_entry_eq e1 e2 && entry_relative_level_eq n1 n2 && s1 = s2
 
 let notation_eq (from1,ntn1) (from2,ntn2) =
@@ -77,13 +81,12 @@ let interpretation_eq (vars1, t1 as x1) (vars2, t2 as x2) =
   List.equal var_attributes_eq vars1 vars2 &&
   Notation_ops.eq_notation_constr (List.map fst vars1, List.map fst vars2) t1 t2
 
-type level = notation_entry * entry_level * entry_relative_level list
-  (* first argument is InCustomEntry s for custom entries *)
+type level = notation_entry_level * entry_relative_level list
 
-let level_eq (s1, l1, t1) (s2, l2, t2) =
+let level_eq ({ notation_entry = s1; notation_level = l1}, t1) ({ notation_entry = s2; notation_level = l2}, t2) =
   notation_entry_eq s1 s2 && Int.equal l1 l2 && List.equal entry_relative_level_eq t1 t2
 
-(* Uninterpretation tables *)
+(** Uninterpretation tables *)
 
 type 'a interp_rule_gen =
   | NotationRule of Constrexpr.specific_notation

--- a/interp/notationextern.mli
+++ b/interp/notationextern.mli
@@ -30,8 +30,8 @@ val interpretation_eq : interpretation -> interpretation -> bool
 val notation_entry_level_eq : notation_entry_level -> notation_entry_level -> bool
 (** Equality on [notation_entry_level]. *)
 
-type level = notation_entry * entry_level * entry_relative_level list
-  (* first argument is InCustomEntry s for custom entries *)
+type level = notation_entry_level * entry_relative_level list
+(** The "signature" of a rule: its level together with the levels of its subentries *)
 
 val level_eq : level -> level -> bool
 (** Equality on [level]. *)


### PR DESCRIPTION
This was suggested by @proux01 in this [comment](https://github.com/coq/coq/pull/17117#discussion_r1107287149) of #17117 and this makes explicit when entries (equivalent of `in entry at level  nn`) and subentries (equivalent of `id entry at level nn`) matter in the code.

No semantic change.

### Overlay:

- [ ] https://github.com/LPCIC/coq-elpi/pull/479
