### PR TITLE
Notations: collecting the notation variables binding in a given notation variable

### DIFF
--- a/dev/ci/user-overlays/17827-herbelin-master+collecting-ntn-vars-binding-in-ntn-var.sh
+++ b/dev/ci/user-overlays/17827-herbelin-master+collecting-ntn-vars-binding-in-ntn-var.sh
@@ -1,0 +1,1 @@
+overlay serapi https://github.com/herbelin/coq-serapi main+adapt-coq-pr17827-var-binders 17827

--- a/dev/ci/user-overlays/17827-herbelin-master+collecting-ntn-vars-binding-in-ntn-var.sh
+++ b/dev/ci/user-overlays/17827-herbelin-master+collecting-ntn-vars-binding-in-ntn-var.sh
@@ -1,1 +1,2 @@
 overlay serapi https://github.com/herbelin/coq-serapi main+adapt-coq-pr17827-var-binders 17827
+overlay elpi https://github.com/proux01/coq-elpi coq_17827 17827

--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -186,7 +186,7 @@ val is_global : Id.t -> bool
     guaranteed to have the same domain as the input one. *)
 val interp_notation_constr : env -> ?impls:internalization_env ->
   notation_interp_env -> constr_expr ->
-  (bool * subscopes) Id.Map.t * notation_constr * reversibility_status
+  (bool * subscopes * Id.Set.t) Id.Map.t * notation_constr * reversibility_status
 
 (** Idem but to glob_constr (weaker check of binders) *)
 

--- a/interp/genintern.ml
+++ b/interp/genintern.ml
@@ -17,7 +17,7 @@ module Store = Store.Make ()
 type intern_variable_status = {
   intern_ids : Id.Set.t;
   notation_variable_status :
-    (bool ref * Notation_term.subscopes option ref *
+    (bool ref * Notation_term.subscopes option ref * Notation_term.notation_var_binders option ref *
        Notation_term.notation_var_internalization_type)
       Id.Map.t
 }

--- a/interp/genintern.mli
+++ b/interp/genintern.mli
@@ -17,7 +17,7 @@ module Store : Store.S
 type intern_variable_status = {
   intern_ids : Id.Set.t;
   notation_variable_status :
-    (bool ref * Notation_term.subscopes option ref *
+    (bool ref * Notation_term.subscopes option ref * Notation_term.notation_var_binders option ref *
        Notation_term.notation_var_internalization_type)
       Id.Map.t
 }

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -1628,7 +1628,7 @@ and match_disjunctive_equations u alp metas sigma {CAst.v=(ids,disjpatl1,rhs1)} 
    substitution based on entry production: indeed some binders may
    have to be seen as terms from the parsing/printing point of view *)
 let group_by_type ids (terms,termlists,binders,binderlists) =
-  List.fold_right (fun (x,(scl,typ)) (terms',termlists',binders',binderlists') ->
+  List.fold_right (fun (x,(scl,_,typ)) (terms',termlists',binders',binderlists') ->
     match typ with
     | NtnTypeConstr ->
        (* term -> term *)
@@ -1667,7 +1667,7 @@ let group_by_type ids (terms,termlists,binders,binderlists) =
     ids ([],[],[],[])
 
 let match_notation_constr ~print_univ c ~vars (metas,pat) =
-  let metatyps = List.map (fun (id,(_,typ)) -> (id,typ)) metas in
+  let metatyps = List.map (fun (id,(_,_,typ)) -> (id,typ)) metas in
   let subst = match_ false print_univ {actualvars=vars;staticbinders=[];renaming=[]} metatyps ([],[],[],[]) c pat in
   group_by_type metas subst
 
@@ -1741,7 +1741,7 @@ let match_ind_pattern metas sigma ind pats a2 =
   |_ -> raise No_match
 
 let reorder_canonically_substitution terms termlists metas =
-  List.fold_right (fun (x,(scl,typ)) (terms',termlists',binders') ->
+  List.fold_right (fun (x,(scl,_,typ)) (terms',termlists',binders') ->
     match typ with
       | NtnTypeConstr | NtnTypeBinder (NtnBinderParsedAsConstr _) -> ((Id.List.assoc x terms, scl)::terms',termlists',binders')
       | NtnTypeConstrList -> (terms',(Id.List.assoc x termlists,scl)::termlists',binders')
@@ -1751,11 +1751,11 @@ let reorder_canonically_substitution terms termlists metas =
     metas ([],[],[])
 
 let match_notation_constr_cases_pattern c (metas,pat) =
-  let metatyps = List.map (fun (id,(_,typ)) -> (id,typ)) metas in
+  let metatyps = List.map (fun (id,(_,_,typ)) -> (id,typ)) metas in
   let (terms,termlists,(),()),more_args = match_cases_pattern metatyps ([],[],(),()) c pat in
   reorder_canonically_substitution terms termlists metas, more_args
 
 let match_notation_constr_ind_pattern ind args (metas,pat) =
-  let metatyps = List.map (fun (id,(_,typ)) -> (id,typ)) metas in
+  let metatyps = List.map (fun (id,(_,_,typ)) -> (id,typ)) metas in
   let (terms,termlists,(),()),more_args = match_ind_pattern metatyps ([],[],(),()) ind args pat in
   reorder_canonically_substitution terms termlists metas, more_args

--- a/interp/notation_term.mli
+++ b/interp/notation_term.mli
@@ -98,9 +98,16 @@ type notation_var_internalization_type =
   | NtnInternTypeAny of scope_name option
   | NtnInternTypeOnlyBinder
 
+(** The set of other notation variables that are bound to a binder or
+    binder list and that bind the given notation variable, for
+    instance, in ["{ x | P }" := (sigT (fun x => P)], "x" is under an
+    empty set of binders and "P" is under the binders bound to "x",
+    that is, its notation_var_binders set is "x" *)
+type notation_var_binders = Id.Set.t
+
 (** This characterizes to what a notation is interpreted to *)
 type interpretation =
-    (Id.t * (extended_subscopes * notation_var_instance_type)) list *
+    (Id.t * (extended_subscopes * notation_var_binders * notation_var_instance_type)) list *
     notation_constr
 
 type reversibility_status = APrioriReversible | HasLtac | NonInjective of Id.t list

--- a/interp/notationextern.ml
+++ b/interp/notationextern.ml
@@ -71,9 +71,10 @@ let ntpe_eq t1 t2 = match t1, t2 with
 | NtnTypeBinderList s1, NtnTypeBinderList s2 -> notation_binder_source_eq s1 s2
 | (NtnTypeConstr | NtnTypeBinder _ | NtnTypeConstrList | NtnTypeBinderList _), _ -> false
 
-let var_attributes_eq (_, ((entry1, sc1), tp1)) (_, ((entry2, sc2), tp2)) =
+let var_attributes_eq (_, ((entry1, sc1), binders1, tp1)) (_, ((entry2, sc2), binders2, tp2)) =
   notation_entry_relative_level_eq entry1 entry2 &&
   pair_eq (List.equal String.equal) (List.equal String.equal) sc1 sc2 &&
+  Id.Set.equal binders1 binders2 &&
   ntpe_eq tp1 tp2
 
 let interpretation_eq (vars1, t1 as x1) (vars2, t2 as x2) =

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1199,17 +1199,21 @@ let make_interpretation_vars
     List.equal String.equal l1 l2
   in
   let check (x, y) =
-    let (_,scope1) = Id.Map.find x allvars in
-    let (_,scope2) = Id.Map.find y allvars in
+    let (_,scope1,_ntn_binding_ids1) = Id.Map.find x allvars in
+    let (_,scope2,_ntn_binding_ids2) = Id.Map.find y allvars in
     if not (eq_subscope scope1 scope2) then error_not_same_scope x y
+    (* Note: binding_ids should currently be the same, and even with
+      eventually more complex notations, such as e.g.
+        Notation "!! x .. y , P .. Q" := (fun x => (P, .. (fun y => (Q, True)) ..)).
+      each occurrence of the recursive notation variables may have its own binders *)
   in
   let () = List.iter check recvars in
   let useless_recvars = List.map snd recvars in
   let mainvars =
     Id.Map.filter (fun x _ -> not (Id.List.mem x useless_recvars)) allvars in
-  Id.Map.mapi (fun x (isonlybinding, sc) ->
+  Id.Map.mapi (fun x (isonlybinding, sc, ntn_binding_ids) ->
     let typ = Id.List.assoc x typs in
-    ((entry_relative_level_of_constr_prod_entry entry typ,sc),
+    ((entry_relative_level_of_constr_prod_entry entry typ, sc), ntn_binding_ids,
      make_interpretation_type (Id.List.mem_assoc x recvars) isonlybinding default_if_binding typ)) mainvars
 
 let check_rule_productivity l =


### PR DESCRIPTION
In `constrintern.ml`, we collect for each notation variable the (other) notation variables bound to a binder that binds in the positions of the given notation variable. E.g. in
```coq
Notation "{ x | P }" := (sigT (fun x => P).
```
the set of notation variables bound to a binder that binds in `P` is the  singleton set made of `x`.

This is in preparation of:
- making [`Constrexpr_ops.fold_constr_expr_with_binders`](https://github.com/coq/coq/blob/c7b14d0c800697f94845b14943ab281c5478adbb/interp/constrexpr_ops.ml#L356-L357) (and `map_constr_expr_with_binders`) correct at the time of  traversing the `CNotation` node
- getting rid of the ad hoc hack about `CNotation (... "{ _ : _ | _ }" ...)` in [`Implicit_quantifiers.free_vars_of_constr_expr`](https://github.com/coq/coq/blob/c7b14d0c800697f94845b14943ab281c5478adbb/interp/implicit_quantifiers.ml#L95-L97).

In the PR, the collected notation variables are not used. This will be used at the occasion of another PR that supports a larger variety of types in substitutions for notations, which itself is one step towards supporting wish #7959.

It is done on top of #17823 (merged) for simplicity, but it could be made separate to relatively little cost.

* [x] Overlay for serapi: ejgallego/coq-serapi#347
* [x] Overlay for elpi: https://github.com/LPCIC/coq-elpi/pull/490