### PR TITLE
Cleanup: removing obsolete declaration of notation "{ _ }" in g_constr.mlg

### DIFF
--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -381,8 +381,6 @@ term1: [
 term0: [
 | DELETE ident univ_annot
 | DELETE ident Prim.fields univ_annot
-(* @Zimmi48: This rule is a hack, according to Hugo, and should not be shown in the manual. *)
-| DELETE "{" binder_constr "}"
 | REPLACE "{|" record_declaration bar_cbrace
 | WITH "{|" LIST0 field_def SEP ";" OPT ";" bar_cbrace
 | MOVETO number_or_string NUMBER

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -118,7 +118,6 @@ term0: [
 | NUMBER
 | "(" term200 ")"
 | "{|" record_declaration bar_cbrace
-| "{" binder_constr "}"
 | "`{" term200 "}"
 | test_array_opening "[" "|" array_elems "|" lconstr type_cstr test_array_closing "|" "]" univ_annot
 | "`(" term200 ")"

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -190,8 +190,6 @@ GRAMMAR EXTEND Gram
                 CAst.make ~loc @@ CNotation(None,(InConstrEntry,"( _ )"),([c],[],[],[]))
             | _ -> c) }
       | "{|"; c = record_declaration; bar_cbrace -> { c }
-      | "{"; c = binder_constr ; "}" ->
-        { CAst.make ~loc @@ CNotation(None,(InConstrEntry,"{ _ }"),([c],[],[],[])) }
       | "`{"; c = term LEVEL "200"; "}" ->
         { CAst.make ~loc @@ CGeneralization (MaxImplicit, c) }
       | test_array_opening; "["; "|"; ls = array_elems; "|"; def = lconstr; ty = type_cstr; test_array_closing; "|"; "]"; u = univ_annot ->

--- a/test-suite/output/PrintGrammar.out
+++ b/test-suite/output/PrintGrammar.out
@@ -100,13 +100,7 @@ Entry term is
   | SELF; ".("; global; univ_annot; LIST0 arg; ")"
   | SELF; "%"; IDENT ]
 | "0" LEFTA
-  [ IDENT "ltac"; ":"; "("; ltac_expr; ")"
-  | "("; term LEVEL "200"; ","; term LEVEL "200"; ","; LIST1 (term LEVEL
-    "200") SEP ","; ")"
-  | "("; term LEVEL "200"; ","; term LEVEL "200"; ")"
-  | "("; term LEVEL "200"; ")"
-  | "{|"; record_declaration; '|}'
-  | "{"; "'"; pattern LEVEL "0"; "&"; term LEVEL "200"; "&"; term LEVEL
+  [ "{"; "'"; pattern LEVEL "0"; "&"; term LEVEL "200"; "&"; term LEVEL
     "200"; "}"
   | "{"; "'"; pattern LEVEL "0"; "&"; term LEVEL "200"; "}"
   | "{"; "'"; pattern LEVEL "0"; ":"; term LEVEL "200"; "&"; term LEVEL
@@ -131,7 +125,12 @@ Entry term is
   | "{"; term LEVEL "99"; "|"; term LEVEL "200"; "&"; term LEVEL "200"; "}"
   | "{"; term LEVEL "99"; "|"; term LEVEL "200"; "}"
   | "{"; term LEVEL "99"; "}"
-  | "{"; binder_constr; "}"
+  | IDENT "ltac"; ":"; "("; ltac_expr; ")"
+  | "("; term LEVEL "200"; ","; term LEVEL "200"; ","; LIST1 (term LEVEL
+    "200") SEP ","; ")"
+  | "("; term LEVEL "200"; ","; term LEVEL "200"; ")"
+  | "("; term LEVEL "200"; ")"
+  | "{|"; record_declaration; '|}'
   | "`{"; term LEVEL "200"; "}"
   | "`("; term LEVEL "200"; ")"
   | NUMBER

--- a/test-suite/output/PrintGrammarConstr.out
+++ b/test-suite/output/PrintGrammarConstr.out
@@ -58,7 +58,6 @@ Entry term is
   | "["; term LEVEL "10"; "|"; term LEVEL "200"; "]"
   | "("; term LEVEL "200"; ")"
   | "{|"; record_declaration; '|}'
-  | "{"; binder_constr; "}"
   | "`{"; term LEVEL "200"; "}"
   | "`("; term LEVEL "200"; ")"
   | NUMBER


### PR DESCRIPTION
This was done in `Notations.v` for a long time already, and apparently, the removal indeed does not break anything.
