### PR TITLE
Fixes a minor printing bug of tactic notations

### DIFF
--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -335,7 +335,7 @@ let string_of_genarg_arg (ArgumentType arg) =
   let pr_targ prtac symb arg = match symb with
   | Extend.Uentry tag when is_genarg tag (ArgumentType wit_tactic) ->
     prtac LevelSome arg
-  | Extend.Uentryl (_, l) -> prtac LevelSome arg
+  | Extend.Uentryl (_, l) -> prtac (LevelLe l) arg
   | _ ->
     match arg with
     | TacGeneric (isquot,arg) ->

--- a/test-suite/output/bug_17829.out
+++ b/test-suite/output/bug_17829.out
@@ -1,0 +1,1 @@
+Ltac f := foo (foo idtac)

--- a/test-suite/output/bug_17829.v
+++ b/test-suite/output/bug_17829.v
@@ -1,0 +1,3 @@
+Tactic Notation (at level 3) "foo" tactic2(tac) := intro; tac.
+Ltac f := foo (foo idtac).
+Print Ltac f.


### PR DESCRIPTION
A  minor printing bug in ltac notations.

```coq
Tactic Notation (at level 3) "foo" tactic2(tac) := tac.
Ltac f := foo (foo idtac).
Print Ltac f.
(* was printing "Ltac f := foo foo idtac" instead of "Ltac f := foo (foo idtac)" *)
```

More should be double-checked about precedences in pptactic.ml in general...