### PR TITLE
Avoid unicode subscripts in documentation

### DIFF
--- a/doc/sphinx/addendum/implicit-coercions.rst
+++ b/doc/sphinx/addendum/implicit-coercions.rst
@@ -61,12 +61,12 @@ A name ``f`` can be declared as a coercion between a source user-defined class
 conditions holds:
 
  * ``D`` is a user-defined class, then the type of ``f`` must have the form
-   :g:`forall (x₁:A₁)..(xₖ:Aₖ)(y:C v₁..vₙ), D u₁..uₘ` where :math:`m`
+   :n:`forall (x__1:A__1)..(x__k:A__k)(y:C v__1..v__n), D u__1..u__m` where :math:`m`
    is the number of parameters of ``D``.
  * ``D`` is ``Funclass``, then the type of ``f`` must have the form
-   :g:`forall (x₁:A₁)..(xₖ:Aₖ)(y:C v₁..vₙ)(x:A), B`.
+   :n:`forall (x__1:A__1)..(x__k:A__k)(y:C v__1..v__n)(x:A), B`.
  * ``D`` is ``Sortclass``, then the type of ``f`` must have the form
-   :g:`forall (x₁:A₁)..(xₖ:Aₖ)(y:C v₁..vₙ), s` with ``s`` a sort.
+   :n:`forall (x__1:A__1)..(x__k:A__k)(y:C v__1..v__n), s` with ``s`` a sort.
 
 We then write :g:`f : C >-> D`.
 
@@ -74,8 +74,8 @@ We then write :g:`f : C >-> D`.
 
 When you declare a new coercion (e.g. with :cmd:`Coercion`), new coercion
 paths with the same classes as existing ones are ignored. Coq will generate
-a warning when the two paths may be non convertible. When the :g:`x₁..xₖ` are exactly
-the :g:`v₁..vₙ` (in the same order), the coercion is said to satisfy
+a warning when the two paths may be non convertible. When the :n:`x__1..x__k` are exactly
+the :n:`v__1..v__n` (in the same order), the coercion is said to satisfy
 the :gdef:`uniform inheritance condition`. When possible, we recommend
 using coercions that satisfy this condition. This guarantees that
 no spurious warning will be generated.
@@ -83,7 +83,7 @@ no spurious warning will be generated.
 .. note:: The built-in class ``Sortclass`` can be used as a source class, but
           the built-in class ``Funclass`` cannot.
 
-To coerce an object :g:`t:C t₁..tₙ` of ``C`` towards ``D``, we have to
+To coerce an object :n:`t:C t__1..t__n` of ``C`` towards ``D``, we have to
 apply the coercion ``f`` to it; the obtained term :g:`f _.._ t` is
 then an object of ``D``.
 
@@ -137,8 +137,8 @@ the *oldest* one is valid and the others are ignored. So the order
 of declaration of coercions is important.
 
 We extend notations for coercions to coercion paths. For instance
-:g:`[f₁;..;fₖ] : C >-> D` is the coercion path composed
-by the coercions ``f₁..fₖ``.  The application of a coercion path to a
+:n:`[f__1;..;f__k] : C >-> D` is the coercion path composed
+by the coercions :n:`f__1..f__k`.  The application of a coercion path to a
 term consists of the successive application of its coercions.
 
 
@@ -219,7 +219,7 @@ Coercion Classes
 
      The check for :ref:`ambiguous paths <ambiguous-paths>` failed.
      The paths for which this check fails are displayed by a warning
-     in the form :g:`[f₁;..;fₙ] : C >-> D`.
+     in the form :n:`[f__1;..;f__n] : C >-> D`.
 
      The convertibility checking procedure for coercion paths is complete for
      paths consisting of coercions satisfying the :term:`uniform inheritance condition`,
@@ -244,9 +244,9 @@ type of the assumption to do so.  See :n:`@of_type`.
 
 
    Checks that :n:`@coercion_class__src` is a :term:`constant` with a :term:`body` of the form
-   :n:`fun (x₁:T₁)..(xₙ:Tₙ) => @coercion_class__dest t₁..tₘ` where `m` is the
+   :n:`fun (x__1:T__1)..(x__n:T__n) => @coercion_class__dest t__1..t__m` where `m` is the
    number of parameters of :n:`@coercion_class__dest`.  Then we define an identity
-   function with type :g:`forall (x₁:T₁)..(xₙ:Tₙ)(y:C x₁..xₙ),D t₁..tₘ`,
+   function with type :n:`forall (x__1:T__1)..(x__n:T__n)(y:C x__1..x__n),D t__1..t__m`,
    and we declare it as an identity coercion between ``C`` and ``D``.
    See below for an :ref:`example <example-identity-coercion>`.
 

--- a/doc/sphinx/language/extensions/match.rst
+++ b/doc/sphinx/language/extensions/match.rst
@@ -132,17 +132,11 @@ pattern can either be done using :g:`match` or the :g:`let` construction
 If term inhabits an inductive type with one constructor `C`, we have an
 equivalence between
 
-::
-
-   let (ident₁, …, identₙ) [dep_ret_type] := term in term'
+:n:`let (ident__1, …, ident__n) [dep_ret_type] := term in term'`
 
 and
 
-::
-
-   match term [dep_ret_type] with
-   C ident₁ … identₙ => term'
-   end
+:n:`match term [dep_ret_type] with C ident__1 …  ident__n => term' end`
 
 
 Second destructuring let syntax

--- a/doc/sphinx/practical-tools/coq-commands.rst
+++ b/doc/sphinx/practical-tools/coq-commands.rst
@@ -361,7 +361,7 @@ and ``coqtop``, unless stated otherwise:
 :-vok: Indicate Coq to check a file completely, to load ``.vos`` files instead
   of ``.vo`` files when interpreting :cmd:`Require` commands, and to output an empty
   ``.vok`` files upon success instead of writing a ``.vo`` file.
-:-w (all|none|w₁,…,wₙ): Configure the display of warnings. This
+:-w (all|none|\ *w1*,…,\ *wn*): Configure the display of warnings. This
   option expects all, none or a comma-separated list of warning names or
   categories (see Section :ref:`controlling-display`).
 :-color (on|off|auto): *Coqtop only*.  Enable or disable color output.

--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -357,15 +357,13 @@ Reduction
 
 We use the usual ML call-by-value reduction, with an otherwise unspecified
 evaluation order. This is a design choice making it compatible with OCaml,
-if ever we implement native compilation. The expected equations are as follows::
+if ever we implement native compilation. The expected equations are as follows:
 
-  (fun x => t) V ≡ t{x := V} (βv)
+- :n:`(fun x => t) V ≡ t{x := V}` (βv)
+- :n:`let x := V in t ≡ t{x := V}` (let)
+- :n:`match C V__0 ... V__n with ... | C x__0 ... x__n  => t | ... end ≡ t {x__i := V__i}` (ι)
 
-  let x := V in t ≡ t{x := V} (let)
-
-  match C V₀ ... Vₙ with ... | C x₀ ... xₙ  => t | ... end ≡ t {xᵢ := Vᵢ} (ι)
-
-  (t any term, V values, C constructor)
+(:n:`t` any term, :n:`V` values, :n:`C` constructor)
 
 Note that call-by-value reduction is already a departure from Ltac1 which uses
 heuristics to decide when to evaluate an expression. For instance, the following


### PR DESCRIPTION
Fixes #17603

I removed Unicode subscript characters from doc directory.
They are not shown well in PDF (and HTML on Android).

I used :n: to describe subscripts without the characters.

I converted subscripts to italics in "-w (all|none|w1,…,wn)" in coq-commands.rst
because I couldn't find a way to specify subscripts without Unicode.
