### PR TITLE
Reformulating the grammar of rewstrategy with GRAMMAR EXTEND

### DIFF
--- a/dev/ci/user-overlays/17832-herbelin-master+rewstrategy-explicit-assoc.sh
+++ b/dev/ci/user-overlays/17832-herbelin-master+rewstrategy-explicit-assoc.sh
@@ -1,0 +1,1 @@
+overlay math_classes https://github.com/herbelin/math-classes master+adapting-coq-pr17832-choice-stronger-precedence-rewstrategy 17832 master+rewstrategy-explicit-assoc

--- a/doc/changelog/04-tactics/17832-master+rewstrategy-explicit-assoc.rst
+++ b/doc/changelog/04-tactics/17832-master+rewstrategy-explicit-assoc.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  In :tacn:`rewrite_strat`, the syntax for the :g:`choice` strategy has
+  changed slightly.  You may need to add parentheses around its arguments
+  (one such case found in our continuous integration tests)
+  (`#17832 <https://github.com/coq/coq/pull/17832>`_,
+  by Hugo Herbelin, Jim Fehrle and Jason Gross).

--- a/doc/sphinx/addendum/generalized-rewriting.rst
+++ b/doc/sphinx/addendum/generalized-rewriting.rst
@@ -810,18 +810,14 @@ on the programmable rewriting strategies with generic traversals by Visser et al
 the Stratego transformation language :cite:`Visser01`. Rewriting strategies
 are applied using the :tacn:`rewrite_strat` tactic`.
 
-.. insertprodn rewstrategy rewstrategy
+.. insertprodn rewstrategy rewstrategy0
 
 .. prodn::
-   rewstrategy ::= @one_term
-   | <- @one_term
-   | fail
-   | id
-   | refl
+   rewstrategy ::= <- @one_term
    | progress @rewstrategy
    | try @rewstrategy
+   | choice {+ @rewstrategy0 }
    | repeat @rewstrategy
-   | choice {+ {| @rewstrategy | {+; @rewstrategy } } }
    | any @rewstrategy
    | subterm @rewstrategy
    | subterms @rewstrategy
@@ -833,8 +829,13 @@ are applied using the :tacn:`rewrite_strat` tactic`.
    | terms {* @one_term }
    | eval @red_expr
    | fold @one_term
-   | ( {| @rewstrategy | {+; @rewstrategy } } )
+   | @rewstrategy0
    | old_hints @ident
+   rewstrategy0 ::= @one_term
+   | fail
+   | id
+   | refl
+   | ( {| @rewstrategy | {+; @rewstrategy } } )
 
 :n:`@one_term`
    lemma, left to right
@@ -860,7 +861,7 @@ are applied using the :tacn:`rewrite_strat` tactic`.
 :n:`@rewstrategy ; @rewstrategy`
    composition
 
-:n:`choice {+ {+; @rewstrategy } }`
+:n:`choice {+ @rewstrategy0 }`
    first successful strategy
 
 :n:`repeat @rewstrategy`

--- a/doc/sphinx/addendum/generalized-rewriting.rst
+++ b/doc/sphinx/addendum/generalized-rewriting.rst
@@ -774,10 +774,10 @@ Strategies for rewriting
 Usage
 ~~~~~
 
-.. tacn:: rewrite_strat @rewstrategy {? in @ident }
+.. tacn:: rewrite_strat {| @rewstrategy | {+; @rewstrategy } } {? in @ident }
    :name: rewrite_strat
 
-   Rewrite using :n:`@rewstrategy` in the conclusion or in the hypothesis :n:`@ident`.
+   Rewrite using the specified :n:`@rewstrategy`s in the conclusion or in the hypothesis :n:`@ident`.
 
    .. exn:: Nothing to rewrite.
 
@@ -808,34 +808,32 @@ combined to create custom rewriting procedures. Its set of strategies is based
 on the programmable rewriting strategies with generic traversals by Visser et al.
 :cite:`Luttik97specificationof` :cite:`Visser98`, which formed the core of
 the Stratego transformation language :cite:`Visser01`. Rewriting strategies
-are applied using the tactic :n:`rewrite_strat @rewstrategy`.
+are applied using the :tacn:`rewrite_strat` tactic`.
 
-.. insertprodn rewstrategy rewstrategy0
+.. insertprodn rewstrategy rewstrategy
 
 .. prodn::
-   rewstrategy ::= @rewstrategy ; @rewstrategy_atom
-   | @rewstrategy_atom
-   rewstrategy_atom ::= @one_term
+   rewstrategy ::= @one_term
    | <- @one_term
    | fail
    | id
    | refl
-   | progress @rewstrategy_atom
-   | try @rewstrategy_atom
-   | choice {+ @rewstrategy }
-   | repeat @rewstrategy_atom
-   | any @rewstrategy_atom
-   | subterm @rewstrategy_atom
-   | subterms @rewstrategy_atom
-   | innermost @rewstrategy_atom
-   | outermost @rewstrategy_atom
-   | bottomup @rewstrategy_atom
-   | topdown @rewstrategy_atom
+   | progress @rewstrategy
+   | try @rewstrategy
+   | repeat @rewstrategy
+   | choice {+ {| @rewstrategy | {+; @rewstrategy } } }
+   | any @rewstrategy
+   | subterm @rewstrategy
+   | subterms @rewstrategy
+   | innermost @rewstrategy
+   | outermost @rewstrategy
+   | bottomup @rewstrategy
+   | topdown @rewstrategy
    | hints @ident
    | terms {* @one_term }
    | eval @red_expr
    | fold @one_term
-   | ( @rewstrategy )
+   | ( {| @rewstrategy | {+; @rewstrategy } } )
    | old_hints @ident
 
 :n:`@one_term`
@@ -862,7 +860,7 @@ are applied using the tactic :n:`rewrite_strat @rewstrategy`.
 :n:`@rewstrategy ; @rewstrategy`
    composition
 
-:n:`choice {+ @rewstrategy }`
+:n:`choice {+ {+; @rewstrategy } }`
    first successful strategy
 
 :n:`repeat @rewstrategy`
@@ -936,7 +934,7 @@ succeeds, making progress using a reflexivity proof of rewriting.
 ``progress`` tests progress of the argument :n:`@rewstrategy` and
 fails if no progress was made, while ``try`` always succeeds, catching
 failures. ``choice`` uses the first successful strategy in the list of
-@rewstrategy. One can iterate a strategy at least 1 time using
+:n:`@rewstrategy`s. One can iterate a strategy at least 1 time using
 ``repeat`` and at least 0 times using ``any``.
 
 The ``subterm`` and ``subterms`` strategies apply their argument :n:`@rewstrategy` to

--- a/doc/sphinx/addendum/generalized-rewriting.rst
+++ b/doc/sphinx/addendum/generalized-rewriting.rst
@@ -955,6 +955,15 @@ if it reduces the subterm under consideration. The ``fold`` strategy takes
 a :token:`term` and tries to *unify* it to the current subterm, converting it to :token:`term`
 on success. It is stronger than the tactic ``fold``.
 
+.. note::
+   The symbol ';' is used to separate sequences of tactics as well as
+   sequences of rewriting strategies.
+   `rewrite_strat s; fail` is interpreted as `rewrite_strat (s; fail)`,
+   in which `fail` is a rewriting strategy.
+   Use `(rewrite_strat s); fail` to make `fail` a tactic.
+   `rewrite_strat s; apply I` gives a syntax error (`apply` is not
+   a valid rewrite strategy).
+
 .. _rewrite_strat_innermost_outermost:
 
 .. example:: :n:`innermost` and :n:`outermost`

--- a/doc/sphinx/addendum/generalized-rewriting.rst
+++ b/doc/sphinx/addendum/generalized-rewriting.rst
@@ -810,26 +810,27 @@ on the programmable rewriting strategies with generic traversals by Visser et al
 the Stratego transformation language :cite:`Visser01`. Rewriting strategies
 are applied using the tactic :n:`rewrite_strat @rewstrategy`.
 
-.. insertprodn rewstrategy rewstrategy
+.. insertprodn rewstrategy rewstrategy0
 
 .. prodn::
-   rewstrategy ::= @one_term
+   rewstrategy ::= @rewstrategy ; @rewstrategy_atom
+   | @rewstrategy_atom
+   rewstrategy_atom ::= @one_term
    | <- @one_term
    | fail
    | id
    | refl
-   | progress @rewstrategy
-   | try @rewstrategy
-   | @rewstrategy ; @rewstrategy
+   | progress @rewstrategy_atom
+   | try @rewstrategy_atom
    | choice {+ @rewstrategy }
-   | repeat @rewstrategy
-   | any @rewstrategy
-   | subterm @rewstrategy
-   | subterms @rewstrategy
-   | innermost @rewstrategy
-   | outermost @rewstrategy
-   | bottomup @rewstrategy
-   | topdown @rewstrategy
+   | repeat @rewstrategy_atom
+   | any @rewstrategy_atom
+   | subterm @rewstrategy_atom
+   | subterms @rewstrategy_atom
+   | innermost @rewstrategy_atom
+   | outermost @rewstrategy_atom
+   | bottomup @rewstrategy_atom
+   | topdown @rewstrategy_atom
    | hints @ident
    | terms {* @one_term }
    | eval @red_expr

--- a/doc/sphinx/addendum/generalized-rewriting.rst
+++ b/doc/sphinx/addendum/generalized-rewriting.rst
@@ -774,10 +774,10 @@ Strategies for rewriting
 Usage
 ~~~~~
 
-.. tacn:: rewrite_strat {| @rewstrategy | {+; @rewstrategy } } {? in @ident }
+.. tacn:: rewrite_strat @rewstrategy {? in @ident }
    :name: rewrite_strat
 
-   Rewrite using the specified :n:`@rewstrategy`s in the conclusion or in the hypothesis :n:`@ident`.
+   Rewrite using :n:`@rewstrategy` in the conclusion or in the hypothesis :n:`@ident`.
 
    .. exn:: Nothing to rewrite.
 
@@ -808,23 +808,24 @@ combined to create custom rewriting procedures. Its set of strategies is based
 on the programmable rewriting strategies with generic traversals by Visser et al.
 :cite:`Luttik97specificationof` :cite:`Visser98`, which formed the core of
 the Stratego transformation language :cite:`Visser01`. Rewriting strategies
-are applied using the :tacn:`rewrite_strat` tactic`.
+are applied using the :tacn:`rewrite_strat` tactic.
 
 .. insertprodn rewstrategy rewstrategy0
 
 .. prodn::
-   rewstrategy ::= <- @one_term
-   | progress @rewstrategy
-   | try @rewstrategy
+   rewstrategy ::= {+; @rewstrategy1 }
+   rewstrategy1 ::= <- @one_term
+   | progress @rewstrategy1
+   | try @rewstrategy1
    | choice {+ @rewstrategy0 }
-   | repeat @rewstrategy
-   | any @rewstrategy
-   | subterm @rewstrategy
-   | subterms @rewstrategy
-   | innermost @rewstrategy
-   | outermost @rewstrategy
-   | bottomup @rewstrategy
-   | topdown @rewstrategy
+   | repeat @rewstrategy1
+   | any @rewstrategy1
+   | subterm @rewstrategy1
+   | subterms @rewstrategy1
+   | innermost @rewstrategy1
+   | outermost @rewstrategy1
+   | bottomup @rewstrategy1
+   | topdown @rewstrategy1
    | hints @ident
    | terms {* @one_term }
    | eval @red_expr
@@ -835,13 +836,10 @@ are applied using the :tacn:`rewrite_strat` tactic`.
    | fail
    | id
    | refl
-   | ( {| @rewstrategy | {+; @rewstrategy } } )
+   | ( @rewstrategy )
 
 :n:`@one_term`
    lemma, left to right
-
-:n:`<- @one_term`
-   lemma, right to left
 
 :n:`fail`
    failure
@@ -852,46 +850,49 @@ are applied using the :tacn:`rewrite_strat` tactic`.
 :n:`refl`
    reflexivity
 
-:n:`progress @rewstrategy`
+:n:`<- @one_term`
+   lemma, right to left
+
+:n:`progress @rewstrategy1`
    progress
 
-:n:`try @rewstrategy`
+:n:`try @rewstrategy1`
    try catch
 
-:n:`@rewstrategy ; @rewstrategy`
+:n:`@rewstrategy ; @rewstrategy1`
    composition
 
 :n:`choice {+ @rewstrategy0 }`
    first successful strategy
 
-:n:`repeat @rewstrategy`
+:n:`repeat @rewstrategy1`
    one or more
 
-:n:`any @rewstrategy`
+:n:`any @rewstrategy1`
    zero or more
 
-:n:`subterm @rewstrategy`
+:n:`subterm @rewstrategy1`
    one subterm
 
-:n:`subterms @rewstrategy`
+:n:`subterms @rewstrategy1`
    all subterms
 
-:n:`innermost @rewstrategy`
+:n:`innermost @rewstrategy1`
    Innermost first.
    When there are multiple nested matches in a subterm, the innermost subterm
    is rewritten.  For :ref:`example <rewrite_strat_innermost_outermost>`,
    rewriting :n:`(a + b) + c` with Nat.add_comm gives :n:`(b + a) + c`.
 
-:n:`outermost @rewstrategy`
+:n:`outermost @rewstrategy1`
    Outermost first.
    When there are multiple nested matches in a subterm, the outermost subterm
    is rewritten.  For :ref:`example <rewrite_strat_innermost_outermost>`,
    rewriting :n:`(a + b) + c` with Nat.add_comm gives :n:`c + (a + b)`.
 
-:n:`bottomup @rewstrategy`
+:n:`bottomup @rewstrategy1`
    bottom-up
 
-:n:`topdown @rewstrategy`
+:n:`topdown @rewstrategy1`
    top-down
 
 :n:`hints @ident`
@@ -916,13 +917,13 @@ are applied using the :tacn:`rewrite_strat` tactic`.
 Conceptually, a few of these are defined in terms of the others using a
 primitive fixpoint operator `fix`, which the tactic doesn't currently support:
 
-- :n:`try @rewstrategy := choice @rewstrategy id`
-- :n:`any @rewstrategy := fix @ident. try (@rewstrategy ; @ident)`
-- :n:`repeat @rewstrategy := @rewstrategy; any @rewstrategy`
-- :n:`bottomup @rewstrategy := fix @ident. (choice (progress (subterms @ident)) @rewstrategy) ; try @ident`
-- :n:`topdown @rewstrategy := fix @ident. (choice @rewstrategy (progress (subterms @ident))) ; try @ident`
-- :n:`innermost @rewstrategy := fix @ident. (choice (subterm @ident) @rewstrategy)`
-- :n:`outermost @rewstrategy := fix @ident. (choice @rewstrategy (subterm @ident))`
+- :n:`try @rewstrategy1 := choice (@rewstrategy1) id`
+- :n:`any @rewstrategy1 := fix @ident. try (@rewstrategy1 ; @ident)`
+- :n:`repeat @rewstrategy1 := @rewstrategy1; any @rewstrategy1`
+- :n:`bottomup @rewstrategy1 := fix @ident. (choice (progress (subterms @ident)) @rewstrategy1) ; try @ident`
+- :n:`topdown @rewstrategy1 := fix @ident. (choice (@rewstrategy1) (progress (subterms @ident))) ; try @ident`
+- :n:`innermost @rewstrategy1 := fix @ident. (choice (subterm @ident) (@rewstrategy1))`
+- :n:`outermost @rewstrategy1 := fix @ident. (choice (@rewstrategy1) (subterm @ident))`
 
 The basic control strategy semantics are straightforward: strategies
 are applied to subterms of the term to rewrite, starting from the root
@@ -932,18 +933,18 @@ hand-side. Composition can be used to continue rewriting on the
 current subterm. The ``fail`` strategy always fails while the identity
 strategy succeeds without making progress. The reflexivity strategy
 succeeds, making progress using a reflexivity proof of rewriting.
-``progress`` tests progress of the argument :n:`@rewstrategy` and
+``progress`` tests progress of the argument :n:`@rewstrategy1` and
 fails if no progress was made, while ``try`` always succeeds, catching
 failures. ``choice`` uses the first successful strategy in the list of
-:n:`@rewstrategy`s. One can iterate a strategy at least 1 time using
+:n:`@rewstrategy0`s. One can iterate a strategy at least 1 time using
 ``repeat`` and at least 0 times using ``any``.
 
-The ``subterm`` and ``subterms`` strategies apply their argument :n:`@rewstrategy` to
+The ``subterm`` and ``subterms`` strategies apply their argument :n:`@rewstrategy1` to
 respectively one or all subterms of the current term under
 consideration, left-to-right. ``subterm`` stops at the first subterm for
-which :n:`@rewstrategy` made progress. The composite strategies ``innermost`` and ``outermost``
+which :n:`@rewstrategy1` made progress. The composite strategies ``innermost`` and ``outermost``
 perform a single innermost or outermost rewrite using their argument
-:n:`@rewstrategy`. Their counterparts ``bottomup`` and ``topdown`` perform as many
+:n:`@rewstrategy1`. Their counterparts ``bottomup`` and ``topdown`` perform as many
 rewritings as possible, starting from the bottom or the top of the
 term.
 

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -2436,6 +2436,7 @@ SPLICE: [
 
 RENAME: [
 | occurrences rewrite_occs
+| rewstrategy1 rewstrategy
 ]
 
 RENAME: [

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -2242,6 +2242,11 @@ as_or_and_ipat: [
 | "as" or_and_intropattern
 ]
 
+rewstrategy: [
+| DELETE rewstrategy ";" rewstrategy_prefix_op
+| LIST1 rewstrategy_prefix_op SEP ";"
+]
+
 SPLICE: [
 | clause
 | noedit_mode
@@ -2432,11 +2437,11 @@ SPLICE: [
 | enable_notation_flags
 | opt_scope
 | lident
+| rewstrategy
 ] (* end SPLICE *)
 
 RENAME: [
 | occurrences rewrite_occs
-| rewstrategy1 rewstrategy
 ]
 
 RENAME: [
@@ -2482,6 +2487,7 @@ RENAME: [
 | field_body field_spec
 | field_def field_val
 | bindings_with_parameters alias_definition
+| rewstrategy_atom rewstrategy
 ]
 
 bullet: [

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -2243,8 +2243,8 @@ as_or_and_ipat: [
 ]
 
 rewstrategy: [
-| DELETE rewstrategy ";" rewstrategy_prefix_op
-| LIST1 rewstrategy_prefix_op SEP ";"
+| DELETE rewstrategy ";" rewstrategy1
+| LIST1 rewstrategy1 SEP ";"
 ]
 
 SPLICE: [
@@ -2487,7 +2487,7 @@ RENAME: [
 | field_body field_spec
 | field_def field_val
 | bindings_with_parameters alias_definition
-| rewstrategy_atom rewstrategy
+| rewstrategy1 rewstrategy
 ]
 
 bullet: [

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -2243,6 +2243,7 @@ as_or_and_ipat: [
 ]
 
 rewstrategy: [
+| DELETE rewstrategy1
 | DELETE rewstrategy ";" rewstrategy1
 | LIST1 rewstrategy1 SEP ";"
 ]
@@ -2437,7 +2438,6 @@ SPLICE: [
 | enable_notation_flags
 | opt_scope
 | lident
-| rewstrategy
 ] (* end SPLICE *)
 
 RENAME: [
@@ -2487,7 +2487,6 @@ RENAME: [
 | field_body field_spec
 | field_def field_val
 | bindings_with_parameters alias_definition
-| rewstrategy1 rewstrategy
 ]
 
 bullet: [

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -2303,7 +2303,7 @@ rewstrategy1: [
 ]
 
 rewstrategy0: [
-| glob
+| constr
 | "id"
 | "fail"
 | "refl"

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -2277,32 +2277,36 @@ glob_constr_with_bindings: [
 ]
 
 rewstrategy: [
-| rewstrategy ";" rewstrategy_atom
-| rewstrategy_atom
+| rewstrategy ";" rewstrategy1
+| rewstrategy1
 ]
 
-rewstrategy_atom: [
-| glob
+rewstrategy1: [
 | "<-" constr
-| "subterms" rewstrategy_atom
-| "subterm" rewstrategy_atom
-| "innermost" rewstrategy_atom
-| "outermost" rewstrategy_atom
-| "bottomup" rewstrategy_atom
-| "topdown" rewstrategy_atom
-| "id"
-| "fail"
-| "refl"
-| "progress" rewstrategy_atom
-| "try" rewstrategy_atom
-| "any" rewstrategy_atom
-| "repeat" rewstrategy_atom
-| "choice" LIST1 rewstrategy
+| "subterms" rewstrategy1
+| "subterm" rewstrategy1
+| "innermost" rewstrategy1
+| "outermost" rewstrategy1
+| "bottomup" rewstrategy1
+| "topdown" rewstrategy1
+| "progress" rewstrategy1
+| "try" rewstrategy1
+| "any" rewstrategy1
+| "repeat" rewstrategy1
+| "choice" LIST1 rewstrategy0
 | "old_hints" preident
 | "hints" preident
 | "terms" LIST0 constr
 | "eval" red_expr
 | "fold" constr
+| rewstrategy0
+]
+
+rewstrategy0: [
+| glob
+| "id"
+| "fail"
+| "refl"
 | "(" rewstrategy ")"
 ]
 

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -2277,9 +2277,6 @@ glob_constr_with_bindings: [
 ]
 
 rewstrategy: [
-]
-
-rewstrategy: [
 | rewstrategy ";" rewstrategy_atom
 | rewstrategy_atom
 ]

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -2277,29 +2277,36 @@ glob_constr_with_bindings: [
 ]
 
 rewstrategy: [
+]
+
+rewstrategy: [
+| rewstrategy ";" rewstrategy_atom
+| rewstrategy_atom
+]
+
+rewstrategy_atom: [
 | glob
 | "<-" constr
-| "subterms" rewstrategy
-| "subterm" rewstrategy
-| "innermost" rewstrategy
-| "outermost" rewstrategy
-| "bottomup" rewstrategy
-| "topdown" rewstrategy
+| "subterms" rewstrategy_atom
+| "subterm" rewstrategy_atom
+| "innermost" rewstrategy_atom
+| "outermost" rewstrategy_atom
+| "bottomup" rewstrategy_atom
+| "topdown" rewstrategy_atom
 | "id"
 | "fail"
 | "refl"
-| "progress" rewstrategy
-| "try" rewstrategy
-| "any" rewstrategy
-| "repeat" rewstrategy
-| rewstrategy ";" rewstrategy
-| "(" rewstrategy ")"
+| "progress" rewstrategy_atom
+| "try" rewstrategy_atom
+| "any" rewstrategy_atom
+| "repeat" rewstrategy_atom
 | "choice" LIST1 rewstrategy
 | "old_hints" preident
 | "hints" preident
 | "terms" LIST0 constr
 | "eval" red_expr
 | "fold" constr
+| "(" rewstrategy ")"
 ]
 
 int_or_var: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1472,6 +1472,7 @@ simple_tactic: [
 | "not_evar" one_term
 | "is_ground" one_term
 | "autoapply" one_term "with" ident
+| "rewrite_strat" [ rewstrategy | LIST1 rewstrategy SEP ";" ] OPT ( "in" ident )
 | "rewrite_db" ident OPT ( "in" ident )
 | "substitute" OPT [ "->" | "<-" ] one_term_with_bindings
 | "setoid_rewrite" OPT [ "->" | "<-" ] one_term_with_bindings OPT ( "at" rewrite_occs ) OPT ( "in" ident )
@@ -1484,7 +1485,6 @@ simple_tactic: [
 | "eintros" LIST0 intropattern
 | "decide" "equality"
 | "compare" one_term one_term
-| "rewrite_strat" [ rewstrategy | LIST1 rewstrategy SEP ";" ] OPT ( "in" ident )
 | "apply" LIST1 one_term_with_bindings SEP "," OPT in_hyp_as
 | "eapply" LIST1 one_term_with_bindings SEP "," OPT in_hyp_as
 | "simple" "apply" LIST1 one_term_with_bindings SEP "," OPT in_hyp_as
@@ -2129,15 +2129,11 @@ rewrite_occs: [
 ]
 
 rewstrategy: [
-| one_term
 | "<-" one_term
-| "fail"
-| "id"
-| "refl"
 | "progress" rewstrategy
 | "try" rewstrategy
+| "choice" LIST1 rewstrategy0
 | "repeat" rewstrategy
-| "choice" LIST1 [ rewstrategy | LIST1 rewstrategy SEP ";" ]
 | "any" rewstrategy
 | "subterm" rewstrategy
 | "subterms" rewstrategy
@@ -2149,8 +2145,16 @@ rewstrategy: [
 | "terms" LIST0 one_term
 | "eval" red_expr
 | "fold" one_term
-| "(" [ rewstrategy | LIST1 rewstrategy SEP ";" ] ")"
+| rewstrategy0
 | "old_hints" ident
+]
+
+rewstrategy0: [
+| one_term
+| "fail"
+| "id"
+| "refl"
+| "(" [ rewstrategy | LIST1 rewstrategy SEP ";" ] ")"
 ]
 
 l3_tactic: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1484,7 +1484,7 @@ simple_tactic: [
 | "eintros" LIST0 intropattern
 | "decide" "equality"
 | "compare" one_term one_term
-| "rewrite_strat" rewstrategy OPT ( "in" ident )
+| "rewrite_strat" [ rewstrategy | LIST1 rewstrategy SEP ";" ] OPT ( "in" ident )
 | "apply" LIST1 one_term_with_bindings SEP "," OPT in_hyp_as
 | "eapply" LIST1 one_term_with_bindings SEP "," OPT in_hyp_as
 | "simple" "apply" LIST1 one_term_with_bindings SEP "," OPT in_hyp_as
@@ -2129,32 +2129,27 @@ rewrite_occs: [
 ]
 
 rewstrategy: [
-| rewstrategy0 ";" rewstrategy0
-| rewstrategy0
-]
-
-rewstrategy0: [
 | one_term
 | "<-" one_term
 | "fail"
 | "id"
 | "refl"
-| "progress" rewstrategy0
-| "try" rewstrategy0
-| "choice" LIST1 rewstrategy
-| "repeat" rewstrategy0
-| "any" rewstrategy0
-| "subterm" rewstrategy0
-| "subterms" rewstrategy0
-| "innermost" rewstrategy0
-| "outermost" rewstrategy0
-| "bottomup" rewstrategy0
-| "topdown" rewstrategy0
+| "progress" rewstrategy
+| "try" rewstrategy
+| "repeat" rewstrategy
+| "choice" LIST1 [ rewstrategy | LIST1 rewstrategy SEP ";" ]
+| "any" rewstrategy
+| "subterm" rewstrategy
+| "subterms" rewstrategy
+| "innermost" rewstrategy
+| "outermost" rewstrategy
+| "bottomup" rewstrategy
+| "topdown" rewstrategy
 | "hints" ident
 | "terms" LIST0 one_term
 | "eval" red_expr
 | "fold" one_term
-| "(" rewstrategy ")"
+| "(" [ rewstrategy | LIST1 rewstrategy SEP ";" ] ")"
 | "old_hints" ident
 ]
 

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1472,7 +1472,6 @@ simple_tactic: [
 | "not_evar" one_term
 | "is_ground" one_term
 | "autoapply" one_term "with" ident
-| "rewrite_strat" rewstrategy OPT ( "in" ident )
 | "rewrite_db" ident OPT ( "in" ident )
 | "substitute" OPT [ "->" | "<-" ] one_term_with_bindings
 | "setoid_rewrite" OPT [ "->" | "<-" ] one_term_with_bindings OPT ( "at" rewrite_occs ) OPT ( "in" ident )
@@ -1485,6 +1484,7 @@ simple_tactic: [
 | "eintros" LIST0 intropattern
 | "decide" "equality"
 | "compare" one_term one_term
+| "rewrite_strat" rewstrategy OPT ( "in" ident )
 | "apply" LIST1 one_term_with_bindings SEP "," OPT in_hyp_as
 | "eapply" LIST1 one_term_with_bindings SEP "," OPT in_hyp_as
 | "simple" "apply" LIST1 one_term_with_bindings SEP "," OPT in_hyp_as
@@ -2129,23 +2129,27 @@ rewrite_occs: [
 ]
 
 rewstrategy: [
+| rewstrategy0 ";" rewstrategy0
+| rewstrategy0
+]
+
+rewstrategy0: [
 | one_term
 | "<-" one_term
 | "fail"
 | "id"
 | "refl"
-| "progress" rewstrategy
-| "try" rewstrategy
-| rewstrategy ";" rewstrategy
+| "progress" rewstrategy0
+| "try" rewstrategy0
 | "choice" LIST1 rewstrategy
-| "repeat" rewstrategy
-| "any" rewstrategy
-| "subterm" rewstrategy
-| "subterms" rewstrategy
-| "innermost" rewstrategy
-| "outermost" rewstrategy
-| "bottomup" rewstrategy
-| "topdown" rewstrategy
+| "repeat" rewstrategy0
+| "any" rewstrategy0
+| "subterm" rewstrategy0
+| "subterms" rewstrategy0
+| "innermost" rewstrategy0
+| "outermost" rewstrategy0
+| "bottomup" rewstrategy0
+| "topdown" rewstrategy0
 | "hints" ident
 | "terms" LIST0 one_term
 | "eval" red_expr

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1472,7 +1472,7 @@ simple_tactic: [
 | "not_evar" one_term
 | "is_ground" one_term
 | "autoapply" one_term "with" ident
-| "rewrite_strat" [ rewstrategy | LIST1 rewstrategy SEP ";" ] OPT ( "in" ident )
+| "rewrite_strat" rewstrategy OPT ( "in" ident )
 | "rewrite_db" ident OPT ( "in" ident )
 | "substitute" OPT [ "->" | "<-" ] one_term_with_bindings
 | "setoid_rewrite" OPT [ "->" | "<-" ] one_term_with_bindings OPT ( "at" rewrite_occs ) OPT ( "in" ident )
@@ -2129,18 +2129,22 @@ rewrite_occs: [
 ]
 
 rewstrategy: [
+| LIST1 rewstrategy1 SEP ";"
+]
+
+rewstrategy1: [
 | "<-" one_term
-| "progress" rewstrategy
-| "try" rewstrategy
+| "progress" rewstrategy1
+| "try" rewstrategy1
 | "choice" LIST1 rewstrategy0
-| "repeat" rewstrategy
-| "any" rewstrategy
-| "subterm" rewstrategy
-| "subterms" rewstrategy
-| "innermost" rewstrategy
-| "outermost" rewstrategy
-| "bottomup" rewstrategy
-| "topdown" rewstrategy
+| "repeat" rewstrategy1
+| "any" rewstrategy1
+| "subterm" rewstrategy1
+| "subterms" rewstrategy1
+| "innermost" rewstrategy1
+| "outermost" rewstrategy1
+| "bottomup" rewstrategy1
+| "topdown" rewstrategy1
 | "hints" ident
 | "terms" LIST0 one_term
 | "eval" red_expr
@@ -2154,7 +2158,7 @@ rewstrategy0: [
 | "fail"
 | "id"
 | "refl"
-| "(" [ rewstrategy | LIST1 rewstrategy SEP ";" ] ")"
+| "(" rewstrategy ")"
 ]
 
 l3_tactic: [

--- a/plugins/ltac/g_rewrite.mlg
+++ b/plugins/ltac/g_rewrite.mlg
@@ -99,30 +99,40 @@ ARGUMENT EXTEND rewstrategy
 
     RAW_PRINTED BY { pr_raw_strategy env sigma }
     GLOB_PRINTED BY { pr_glob_strategy env sigma }
+END
 
-  | [ glob(c) ] -> { StratConstr (c, true) }
-  | [ "<-" constr(c) ] -> { StratConstr (c, false) }
-  | [ "subterms" rewstrategy(h) ] -> { StratUnary (Subterms, h) }
-  | [ "subterm" rewstrategy(h) ] -> { StratUnary (Subterm, h) }
-  | [ "innermost" rewstrategy(h) ] -> { StratUnary(Innermost, h) }
-  | [ "outermost" rewstrategy(h) ] -> { StratUnary(Outermost, h) }
-  | [ "bottomup" rewstrategy(h) ] -> { StratUnary(Bottomup, h) }
-  | [ "topdown" rewstrategy(h) ] -> { StratUnary(Topdown, h) }
-  | [ "id" ] -> { StratId }
-  | [ "fail" ] -> { StratFail }
-  | [ "refl" ] -> { StratRefl }
-  | [ "progress" rewstrategy(h) ] -> { StratUnary (Progress, h) }
-  | [ "try" rewstrategy(h) ] -> { StratUnary (Try, h) }
-  | [ "any" rewstrategy(h) ] -> { StratUnary (Any, h) }
-  | [ "repeat" rewstrategy(h) ] -> { StratUnary (Repeat, h) }
-  | [ rewstrategy(h) ";" rewstrategy(h') ] -> { StratBinary (Compose, h, h') }
-  | [ "(" rewstrategy(h) ")" ] -> { h }
-  | [ "choice" ne_rewstrategy_list(h) ] -> { StratNAry (Choice, h) }
-  | [ "old_hints" preident(h) ] -> { StratHints (true, h) }
-  | [ "hints" preident(h) ] -> { StratHints (false, h) }
-  | [ "terms" constr_list(h) ] -> { StratTerms h }
-  | [ "eval" red_expr(r) ] -> { StratEval r }
-  | [ "fold" constr(c) ] -> { StratFold c }
+GRAMMAR EXTEND Gram
+  GLOBAL: rewstrategy;
+  rewstrategy:
+    [ LEFTA
+      [ h = SELF; ";"; h' = rewstrategy_atom -> { StratBinary (Compose, h, h') }
+      | h = rewstrategy_atom -> { h } ] ]
+  ;
+  rewstrategy_atom:
+    [ RIGHTA
+      [ c = glob -> { StratConstr (c, true) }
+      | "<-"; c = constr -> { StratConstr (c, false) }
+      | IDENT "subterms"; h = SELF -> { StratUnary (Subterms, h) }
+      | IDENT "subterm"; h = SELF -> { StratUnary (Subterm, h) }
+      | IDENT "innermost"; h = SELF -> { StratUnary(Innermost, h) }
+      | IDENT "outermost"; h = SELF -> { StratUnary(Outermost, h) }
+      | IDENT "bottomup"; h = SELF -> { StratUnary(Bottomup, h) }
+      | IDENT "topdown"; h = SELF -> { StratUnary(Topdown, h) }
+      | IDENT "id" -> { StratId }
+      | IDENT "fail" -> { StratFail }
+      | IDENT "refl" -> { StratRefl }
+      | IDENT "progress"; h = SELF -> { StratUnary (Progress, h) }
+      | IDENT "try"; h = SELF -> { StratUnary (Try, h) }
+      | IDENT "any"; h = SELF -> { StratUnary (Any, h) }
+      | IDENT "repeat"; h = SELF -> { StratUnary (Repeat, h) }
+      | IDENT "choice"; h = LIST1 rewstrategy -> { StratNAry (Choice, h) }
+      | IDENT "old_hints"; h = preident -> { StratHints (true, h) }
+      | IDENT "hints"; h = preident -> { StratHints (false, h) }
+      | IDENT "terms"; h = LIST0 constr -> { StratTerms h }
+      | IDENT "eval"; r = red_expr -> { StratEval r }
+      | IDENT "fold"; c = constr -> { StratFold c }
+      | "("; h = rewstrategy; ")" -> { h } ] ]
+  ;
 END
 
 (* By default the strategy for "rewrite_db" is top-down *)

--- a/plugins/ltac/g_rewrite.mlg
+++ b/plugins/ltac/g_rewrite.mlg
@@ -131,7 +131,7 @@ GRAMMAR EXTEND Gram
   ;
   rewstrategy0:
     [ NONA
-      [ c = glob -> { StratConstr (c, true) }
+      [ c = constr -> { StratConstr (c, true) }
       | IDENT "id" -> { StratId }
       | IDENT "fail" -> { StratFail }
       | IDENT "refl" -> { StratRefl }

--- a/plugins/ltac/g_rewrite.mlg
+++ b/plugins/ltac/g_rewrite.mlg
@@ -105,32 +105,36 @@ GRAMMAR EXTEND Gram
   GLOBAL: rewstrategy;
   rewstrategy:
     [ LEFTA
-      [ h = SELF; ";"; h' = rewstrategy_atom -> { StratBinary (Compose, h, h') }
-      | h = rewstrategy_atom -> { h } ] ]
+      [ h = SELF; ";"; h' = rewstrategy1 -> { StratBinary (Compose, h, h') }
+      | h = rewstrategy1 -> { h } ] ]
   ;
-  rewstrategy_atom:
+  rewstrategy1:
     [ RIGHTA
-      [ c = glob -> { StratConstr (c, true) }
-      | "<-"; c = constr -> { StratConstr (c, false) }
+      [ "<-"; c = constr -> { StratConstr (c, false) }
       | IDENT "subterms"; h = SELF -> { StratUnary (Subterms, h) }
       | IDENT "subterm"; h = SELF -> { StratUnary (Subterm, h) }
       | IDENT "innermost"; h = SELF -> { StratUnary(Innermost, h) }
       | IDENT "outermost"; h = SELF -> { StratUnary(Outermost, h) }
       | IDENT "bottomup"; h = SELF -> { StratUnary(Bottomup, h) }
       | IDENT "topdown"; h = SELF -> { StratUnary(Topdown, h) }
-      | IDENT "id" -> { StratId }
-      | IDENT "fail" -> { StratFail }
-      | IDENT "refl" -> { StratRefl }
       | IDENT "progress"; h = SELF -> { StratUnary (Progress, h) }
       | IDENT "try"; h = SELF -> { StratUnary (Try, h) }
       | IDENT "any"; h = SELF -> { StratUnary (Any, h) }
       | IDENT "repeat"; h = SELF -> { StratUnary (Repeat, h) }
-      | IDENT "choice"; h = LIST1 rewstrategy -> { StratNAry (Choice, h) }
+      | IDENT "choice"; h = LIST1 rewstrategy0 -> { StratNAry (Choice, h) }
       | IDENT "old_hints"; h = preident -> { StratHints (true, h) }
       | IDENT "hints"; h = preident -> { StratHints (false, h) }
       | IDENT "terms"; h = LIST0 constr -> { StratTerms h }
       | IDENT "eval"; r = red_expr -> { StratEval r }
       | IDENT "fold"; c = constr -> { StratFold c }
+      | h = rewstrategy0 -> { h } ] ]
+  ;
+  rewstrategy0:
+    [ NONA
+      [ c = glob -> { StratConstr (c, true) }
+      | IDENT "id" -> { StratId }
+      | IDENT "fail" -> { StratFail }
+      | IDENT "refl" -> { StratRefl }
       | "("; h = rewstrategy; ")" -> { h } ] ]
   ;
 END

--- a/test-suite/output/rewrite_strat.out
+++ b/test-suite/output/rewrite_strat.out
@@ -1,0 +1,9 @@
+Ltac k1 := rewrite_strat subterms id; (choice subterm fail fail); fail
+Ltac k2 := rewrite_strat subterms id; (choice subterm fail fail); fail
+Ltac k3 := rewrite_strat subterms id; ((choice subterm fail fail); fail)
+Ltac k4 := rewrite_strat subterms (id; choice subterm fail fail; fail)
+Ltac k5 :=
+  rewrite_strat
+  subterms subterms fail;
+  subterms subterms fail;
+  choice subterms try fail; subterms repeat fail

--- a/test-suite/output/rewrite_strat.out
+++ b/test-suite/output/rewrite_strat.out
@@ -1,9 +1,9 @@
-Ltac k1 := rewrite_strat subterms id; (choice subterm fail fail); fail
-Ltac k2 := rewrite_strat subterms id; (choice subterm fail fail); fail
-Ltac k3 := rewrite_strat subterms id; ((choice subterm fail fail); fail)
-Ltac k4 := rewrite_strat subterms (id; choice subterm fail fail; fail)
+Ltac k1 := rewrite_strat subterms id; choice (subterm fail) fail; fail
+Ltac k2 := rewrite_strat subterms id; choice (subterm fail) fail; fail
+Ltac k3 := rewrite_strat subterms id; (choice (subterm fail) fail; fail)
+Ltac k4 := rewrite_strat subterms (id; choice (subterm fail) fail; fail)
 Ltac k5 :=
   rewrite_strat
   subterms subterms fail;
   subterms subterms fail;
-  choice subterms try fail; subterms repeat fail
+  choice (subterms try fail; subterms repeat fail)

--- a/test-suite/output/rewrite_strat.v
+++ b/test-suite/output/rewrite_strat.v
@@ -1,0 +1,5 @@
+Ltac k1 := rewrite_strat (subterms id; (choice subterm fail fail)); fail. Print Ltac k1.
+Ltac k2 := rewrite_strat subterms id; (choice subterm fail fail); fail. Print Ltac k2.
+Ltac k3 := rewrite_strat subterms id; ((choice subterm fail fail); fail). Print Ltac k3.
+Ltac k4 := rewrite_strat subterms (id; choice subterm fail fail; fail). Print Ltac k4.
+Ltac k5 := rewrite_strat (subterms subterms fail; subterms subterms fail); choice (subterms try fail; subterms repeat fail). Print Ltac k5.

--- a/test-suite/output/rewrite_strat.v
+++ b/test-suite/output/rewrite_strat.v
@@ -1,5 +1,5 @@
-Ltac k1 := rewrite_strat (subterms id; (choice subterm fail fail)); fail. Print Ltac k1.
-Ltac k2 := rewrite_strat subterms id; (choice subterm fail fail); fail. Print Ltac k2.
-Ltac k3 := rewrite_strat subterms id; ((choice subterm fail fail); fail). Print Ltac k3.
-Ltac k4 := rewrite_strat subterms (id; choice subterm fail fail; fail). Print Ltac k4.
+Ltac k1 := rewrite_strat (subterms id; (choice (subterm fail) fail)); fail. Print Ltac k1.
+Ltac k2 := rewrite_strat subterms id; (choice (subterm fail) fail); fail. Print Ltac k2.
+Ltac k3 := rewrite_strat subterms id; ((choice (subterm fail) fail); fail). Print Ltac k3.
+Ltac k4 := rewrite_strat subterms (id; choice (subterm fail) fail; fail). Print Ltac k4.
 Ltac k5 := rewrite_strat (subterms subterms fail; subterms subterms fail); choice (subterms try fail; subterms repeat fail). Print Ltac k5.


### PR DESCRIPTION
The grammar of rewstrategy is complex (I don't know how to present it using levels with clear associativity).

The PR does the following:
- rewrite the grammar from ARGUMENT EXTEND to GRAMMAR EXTEND, so that we can make the levels explicit (even if a circularity remains); this is an alternative to #12743 to make progresses on a more flexible use of associativity in gramlib and notations
- improve the printer by using boxes and saving parentheses where not needed

See commit message and test-suite for more details.

Note: ~~if it is clear that we do want to definitively freeze this a bit non intuitive grammar of rewstrategy, the refman should also clarify what binds stronger (namely that all prefix keywords of the grammar bind narrower than ";" except "choice" which binds wider than ";").~~ reference manual automatically updated thanks to doc_gram.

- [x] Added / updated **test-suite**.
