### PR TITLE
coq_makefile: make .filestoinstall during the rule needing it

### DIFF
--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -598,17 +598,14 @@ beautify: $(BEAUTYFILES)
 $(file >.hasfile,1)
 HASFILE:=$(shell if [ -e .hasfile ]; then echo 1; rm .hasfile; fi)
 
-.filestoinstall:
-	@:$(if $(HASFILE),$(file >$@,$(FILESTOINSTALL)),\
-	  $(shell rm -f $@) \
-	  $(foreach x,$(FILESTOINSTALL),$(shell printf '%s\n' "$x" >> $@)))
-
-
-.PHONY: .filestoinstall
+MKFILESTOINSTALL= $(if $(HASFILE),$(file >.filestoinstall,$(FILESTOINSTALL)),\
+  $(shell rm -f .filestoinstall) \
+  $(foreach x,$(FILESTOINSTALL),$(shell printf '%s\n' "$x" >> .filestoinstall)))
 
 # findlib needs the package to not be installed, so we remove it before
 # installing it (see the call to findlib_remove)
-install: META .filestoinstall
+install: META
+	@$(MKFILESTOINSTALL)
 	$(HIDE)code=0; for f in $$(cat .filestoinstall); do\
 	 if ! [ -f "$$f" ]; then >&2 echo $$f does not exist; code=1; fi \
 	done; exit $$code
@@ -625,6 +622,7 @@ install: META .filestoinstall
 	$(call findlib_remove)
 	$(call findlib_install, META $(FINDLIBFILESTOINSTALL))
 	$(HIDE)$(MAKE) install-extra -f "$(SELF)"
+	@rm -f .filestoinstall
 install-extra::
 	@# Extension point
 .PHONY: install install-extra
@@ -654,8 +652,9 @@ install-doc:: html mlihtml
 	done
 .PHONY: install-doc
 
-uninstall:: .filestoinstall
+uninstall::
 	@# Extension point
+	@$(MKFILESTOINSTALL)
 	$(call findlib_remove)
 	$(HIDE)for f in $$(cat .filestoinstall); do \
 	 df="`$(COQMKFILE) -destination-of "$$f" $(COQLIBS)`" &&\
@@ -668,6 +667,7 @@ uninstall:: .filestoinstall
 	 echo RMDIR "$(COQLIBINSTALL)/$$df/" &&\
 	 (rmdir "$(COQLIBINSTALL)/$$df/" 2>/dev/null || true); \
 	done
+	@rm -f .filestoinstall
 
 .PHONY: uninstall
 


### PR DESCRIPTION
This lets us cleanup at the end of the rule, which avoids needing to add .filestoinstall to everyone's gitignore.
