### PR TITLE
Add primitives for controlling reduction

### DIFF
--- a/checker/values.ml
+++ b/checker/values.ml
@@ -240,7 +240,7 @@ let v_template_universes =
   v_tuple "template_universes" [|List(Opt v_level);v_context_set|]
 
 let v_primitive =
-  v_enum "primitive" 55 (* Number of constructors of the CPrimitives.t type *)
+  v_enum "primitive" 58 (* Number of constructors of the CPrimitives.t type *)
 
 let v_cst_def =
   v_sum "constant_def" 0
@@ -329,7 +329,7 @@ let v_ind_pack = v_tuple "mutual_inductive_body"
 let v_prim_ind = v_enum "prim_ind" 6
 (* Number of "Register ... as kernel.ind_..." in PrimInt63.v and PrimFloat.v *)
 
-let v_prim_type = v_enum "prim_type" 3
+let v_prim_type = v_enum "prim_type" 4
 (* Number of constructors of prim_type in "kernel/cPrimitives.ml" *)
 
 let v_retro_action =

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -72,6 +72,8 @@ let get_current_context () =
 let envpp pp = let sigma,env = get_current_context () in pp env sigma
 let rawdebug = ref false
 let ppevar evk = pp (Evar.print evk)
+let pr_fconstr c =
+  ignore c; str "..." (* TODO *)
 let pr_constr t =
   let sigma, env = get_current_context () in
   Printer.pr_constr_env env sigma t
@@ -85,7 +87,7 @@ let ppconstr_univ x = Constrextern.with_universes ppconstr x
 let ppglob_constr = (fun x -> pp(with_env_evm pr_lglob_constr_env x))
 let pppattern = (fun x -> pp(envpp pr_constr_pattern_env x))
 let pptype = (fun x -> try pp(envpp (fun env evm t -> pr_ltype_env env evm t) x) with e -> pp (str (Printexc.to_string e)))
-let ppfconstr c = ppconstr (CClosure.term_of_fconstr c)
+let ppfconstr c = pp (pr_fconstr c)
 
 let ppuint63 i = pp (str (Uint63.to_string i))
 
@@ -95,14 +97,14 @@ let pp_parray pr a =
   pp (str "[|" ++ prlist_with_sep (fun () -> str ";" ++ spc()) pr a ++ spc() ++ str "|" ++ spc() ++ pr def ++ str "|]")
 
 let pp_constr_parray = pp_parray pr_constr
-let pp_fconstr_parray = pp_parray (fun f -> pr_constr (CClosure.term_of_fconstr f))
+let pp_fconstr_parray = pp_parray pr_fconstr
 
 let ppfsubst s =
   let (s, k) = Esubst.Internal.repr s in
   let sep () = str ";" ++ spc () in
   let pr = function
   | Esubst.Internal.REL n -> str "<#" ++ int n ++ str ">"
-  | Esubst.Internal.VAL (k, x) -> pr_constr (Vars.lift k (CClosure.term_of_fconstr x))
+  | Esubst.Internal.VAL (k, x) -> pr_fconstr (CClosure.lift_fconstr k x)
   in
   pp @@ str "[" ++ prlist_with_sep sep pr s ++ str "| " ++ int k ++ str "]"
 

--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -29,8 +29,8 @@ let whd_prod env sigma typ =
   let typ, stk = whd_stack infos tab typ [] in
   match fterm_of typ with
   | FProd (na, c1, c2, e) ->
-    let c1 = EConstr.of_constr @@ term_of_fconstr c1 in
-    let c2 = EConstr.of_constr @@ term_of_fconstr (mk_clos (CClosure.usubs_lift e) c2) in
+    let c1 = EConstr.of_constr @@ term_of_fconstr ~info:infos ~tab c1 in
+    let c2 = EConstr.of_constr @@ term_of_fconstr ~info:infos ~tab (mk_clos (CClosure.usubs_lift e) c2) in
     Some (na, c1, c2)
   | _ -> None
 

--- a/kernel/byterun/coq_interp.c
+++ b/kernel/byterun/coq_interp.c
@@ -1944,6 +1944,21 @@ value coq_interprete
         Next;
       }
 
+      Instruct(RUN) {
+        print_instr("RUN");
+        caml_failwith("Coq VM: RUN not implemented");
+      }
+
+      Instruct(BLOCK) {
+        print_instr("BLOCK");
+        caml_failwith("Coq VM: BLOCK not implemented");
+      }
+
+      Instruct(UNBLOCK) {
+        print_instr("UNBLOCK");
+        caml_failwith("Coq VM: UNBLOCK not implemented");
+      }
+
 /* Debugging and machine control */
 
       Instruct(STOP){

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -633,11 +633,18 @@ let mk_clos_vect ~mode env v =
 let klt_ref = ref (fun ~mode:_ _ _ _ _ -> assert false)
 let kl_ref = ref (fun _ _ _ -> assert false)
 
-type tcs = ((Esubst.lift * UVars.Instance.t) * fconstr * Constr.t Lazy.t) Esubst.subs
+type tcs = (RedState.mode * Constr.t Lazy.t) Esubst.subs
 type tcsu = tcs * UVars.Instance.t
 
+let _ =
+  ignore(subs_subs);
+  ignore(el_fconstr)
+
 let tcsu_to_usubs (t : tcsu) : usubs =
-  let f (elu, m, _) = mk_red (FLAZY (lazy (el_fconstr elu m))) in
+  let f (mode, v) =
+    let m = lazy (mk_clos ~mode ((Esubst.subs_id 0, UVars.Instance.empty)) (Lazy.force v)) in
+    mk_red (FLAZY m)
+  in
   Esubst.map_subst f (fst t), snd t
 
 (* let to_usubs ~mode : Constr.t lazy_t Esubst.subs * Univ.Instance.t -> usubs = fun (e, u) -> *)
@@ -673,7 +680,7 @@ let rec subst_constr ~mode info tab (subst,usubst as e) c =
 
   | Rel i ->
     begin match Esubst.expand_rel i subst with
-    | Inl (k, (_, _, lazy v)) -> Vars.lift k v
+    | Inl (k, (_, lazy v)) -> Vars.lift k v
     | Inr (m, _) -> mkRel m
     end
   | Const _ | Ind _ | Construct _ | Sort _ -> subst_instance_constr usubst c
@@ -860,9 +867,8 @@ and to_constr_case ~(info:clos_infos) ~(tab:clos_tab) ~mode (lfts,_ as ulfts) ci
 
 and comp_subs ~(info:clos_infos) ~(tab:clos_tab) (el,u) (s,u') =
   Esubst.lift_subst (fun el c ->
-      let elu = (el,u) in
-      let t = lazy (to_constr ~info ~tab elu c) in
-      (elu,c,t)
+      let t = lazy (to_constr ~info ~tab (el,u) c) in
+      (RedState.mode c.mark,t)
     ) el s, u'
 
 (* This function defines the correspondence between constr and

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -869,7 +869,19 @@ let rec to_constr ~(info:clos_infos) ~(tab:clos_tab) ((lfts, usubst) as ulfts) v
         let t = !klt_ref ~mode:identity info tab e t in
         Constr.mkApp (op, [|ty; t|])
 
-    | FUnblock _ | FRun _ -> assert false
+    | FUnblock (op, ty, m, e) ->
+      let m = to_constr ulfts m in
+      let subs = comp_subs ulfts e in
+      let ty = subst_constr subs ty in
+      Constr.mkApp (op, [|ty; m|])
+
+    | FRun (op, ty1, ty2, m, k, e) ->
+      let m = to_constr ulfts m in
+      let subs = comp_subs ulfts e in
+      let ty1 = subst_constr subs ty1 in
+      let ty2 = subst_constr subs ty2 in
+      let k = subst_constr subs k in
+      Constr.mkApp (op, [|ty1; ty2; m; k|])
 
     | FLAZY (lazy m) -> to_constr ulfts m
 

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -1677,7 +1677,7 @@ and knht_app ~mode ~lexical info e h args stk =
   | Const (c, _u) ->
     if not (TransparentState.is_transparent_constant (red_transparent mode info.i_flags) c) then
       let stk = append_stack (mk_clos_vect ~mode e args) stk in
-      knht ~mode info e h stk
+      (mk_clos ~mode e h, stk)
     else
     let nargs = Array.length args in
     if Constant.UserOrd.equal c block_constant then
@@ -1711,7 +1711,7 @@ and knht_app ~mode ~lexical info e h args stk =
         ({ mark = RedState.mk cstr mode; term = FEta((4-nargs), h, args, 0, e) }, stk)
     else
       let stk = append_stack (mk_clos_vect ~mode e args) stk in
-      knht ~mode info e h stk
+      (mk_clos ~mode e h, stk)
   | _ ->
     let stk = append_stack (mk_clos_vect ~mode e args) stk in
     knht ~mode info e h stk

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -315,235 +315,6 @@ type stack_member =
 
 and stack = stack_member list
 
-module Debug = struct
-  type 'a pp = Format.formatter -> 'a -> unit
-
-  let pp_table_key : table_key pp = fun ff k ->
-    let open Names in
-    match k with
-    | ConstKey (c, _) -> Format.pp_print_string ff (Constant.to_string c)
-    | VarKey i -> Format.fprintf ff "\"var:%s\"" (Id.to_string i)
-    | RelKey i -> Format.fprintf ff "\"rel:%i\"" i
-
-  let pp_name : Names.Name.t pp = fun ff n ->
-    match n with
-    | Names.Name.Anonymous -> Format.fprintf ff "_"
-    | Names.Name.Name id -> Format.pp_print_string ff (Id.to_string id)
-
-  let pp_list : 'a pp -> 'a list pp = fun pp ff l ->
-    let pp_sep ff () = Format.pp_print_string ff "; " in
-    Format.pp_print_string ff "[";
-    Format.pp_print_list ~pp_sep pp ff l;
-    Format.pp_print_string ff "]"
-
-  let pp_array : 'a pp -> 'a array pp = fun pp ff ar ->
-    let pp_sep ff () = Format.pp_print_string ff "; " in
-    Format.pp_print_string ff "[|";
-    Format.pp_print_list ~pp_sep pp ff (Array.to_list ar);
-    Format.pp_print_string ff "|]"
-
-  let pp_slist : 'a pp -> 'a SList.t pp = fun pp ff sl ->
-    let pp ff o =
-      match o with
-      | None -> Format.fprintf ff "None"
-      | Some e -> Format.fprintf ff "Some(%a)" pp e
-    in
-    pp_list pp ff (SList.to_list sl)
-
-  let pp_flags : RedFlags.reds pp = fun ff reds ->
-    let pp_flag f repr =
-      if RedFlags.red_set reds f then Format.pp_print_string ff repr
-    in
-    pp_flag RedFlags.fBETA "β";
-    pp_flag RedFlags.fDELTA "δ";
-    pp_flag RedFlags.fZETA "ζ";
-    pp_flag RedFlags.fMATCH "M";
-    pp_flag RedFlags.fFIX "F";
-    pp_flag RedFlags.fCOFIX "C"
-
-  let rec pp_constr : constr pp = fun ff c ->
-    let out fmt = Format.fprintf ff fmt in
-    let pp = pp_constr in
-    match kind c with
-    | Rel n ->
-        out "Rel(%i)" n
-    | Meta n ->
-        out "Meta(%i)" n
-    | Var id ->
-        out "Var(%s)" (Id.to_string id)
-    | Sort _ ->
-        out "Sort(_)"
-    | Cast (c,_, t) ->
-        out "Cast(%a, _, %a)" pp c pp t
-    | Prod (na,t,c) ->
-        out "Prod(%a, %a, %a)" pp_name na.binder_name pp t pp c
-    | Lambda (na,t,c) ->
-        out "Lambda(%a, %a, %a)" pp_name na.binder_name pp t pp c
-    | LetIn (na,b,t,c) ->
-        out "LetIn(%a, %a, %a, %a)" pp_name na.binder_name pp b pp t pp c
-    | App (c,l) ->
-        out "App(%a, [|%a|])" pp c (pp_array pp) l
-    | Evar (e,l) ->
-        out "Evar(%i, [%a])" (Evar.repr e) (pp_slist pp) l
-    | Const (c,_) ->
-        out "Const(%s, _)" (Constant.to_string c)
-    | Ind ((sp,i),_) ->
-        out "Ind((%s, %i), _)" (MutInd.to_string sp) i
-    | Construct (((sp,i),j),_) ->
-        out "Construct(((%s, %i), %i), _)" (MutInd.to_string sp) i j
-    | Proj (p,_,c) ->
-        out "Proj(%s, %a)" (Constant.to_string (Projection.constant p)) pp c
-    | Case (_,_,_,_,_,_,_) ->
-        out "Case(_, _, _, _, _, _, _)"
-    | Fix _ ->
-        out "Fix(_)"
-    | CoFix _ ->
-        out "CoFix(_)"
-    | Int i ->
-        out "Int(%s)" (Uint63.to_string i)
-    | Float f ->
-        out "Float(%s)" (Float64.to_string f)
-    | Array(_,t,def,ty) ->
-        out "Array(_, [|%a|], %a, %a)" (pp_array pp) t pp def pp ty
-
-  let pp_mark : red_state pp = fun ff m ->
-    Format.pp_print_string ff
-      (match m with _ when m == ntrl -> "ntrl" | _ when m == cstr -> "cstr" | _ -> assert (m == red); "red")
-
-  let pp_mode : mode pp = fun ff m ->
-    Format.pp_print_string ff (
-      match m with
-      | _ when m == normal_full -> "normal_full"
-      | _ when m == normal_whnf -> "normal_whnf"
-      | _ when m == identity -> "identity"
-      | _ -> assert (m == full); "full"
-    )
-
-  let rec pp_fterm : fterm pp = fun ff term ->
-    let out fmt = Format.fprintf ff fmt in
-    let pp = pp_fconstr in
-    match term with
-    | FRel i ->
-        out "FRel(%i)" i
-    | FAtom c ->
-        out "FAtom(%a)" pp_constr c
-    | FFlex k ->
-        out "FFlex(%a)" pp_table_key k
-    | FInd i ->
-        out "FInd((%s,%i))" ((Names.MutInd.debug_to_string (fst (fst i)))) (snd (fst i))
-    | FConstruct (((i,n),m),_) ->
-        out "FConstruct(%s,%i,%i)" (Names.MutInd.to_string i) n m
-    | FApp (h, args) ->
-        out "FApp(%a, %a)" pp h (pp_array pp) args
-    | FProj (p, _, c) ->
-        out "FProj(%s, %a)" (Constant.to_string (Projection.constant p)) pp c
-    | FFix (_, u) ->
-        out "FFix(_, %a)" pp_usubs u
-    | FCoFix (_, _) ->
-        out "FCoFix(_, _)"
-    | FCaseT (_, _, xs, _, t, bs, u) ->
-        out "FCaseT(_, _, %a, _, %a, %a, %a)"
-          (pp_array pp_constr) xs pp t
-          (pp_array (fun ff (_, c) -> pp_constr ff c)) bs pp_usubs u
-    | FCaseInvert (_, _, _, _, _, _, _, _) ->
-        out "FCaseInvert(_, _, _, _, _, _, _, _)"
-    | FLambda (_, nas, b, u) ->
-        out "FLambda(_, %a, %a, %a)"
-          (pp_list (fun ff (b, ty) -> Format.fprintf ff "(%a, %a)" pp_name
-            (Context.binder_name b) pp_constr ty)) nas pp_constr b pp_usubs u
-    | FProd (_, _, b, u) ->
-        out "FProd(_, _, %a, %a)" pp_constr b pp_usubs u
-    | FLetIn (_, a, b, c, u) ->
-        out "FLetIn(_, %a, %a, %a, %a)" pp a pp b pp_constr c pp_usubs u
-    | FEvar (_, _, _, _) ->
-        out "FEvar(_, _, _, _)"
-    | FInt i ->
-        out "FInt(%s)" (Uint63.to_string i)
-    | FFloat f ->
-        out "FFloat(%s)" (Float64.to_string f)
-    | FArray (_, _, _) ->
-        out "FArray(_, _, _)"
-    | FLIFT (i, c) ->
-        out "FLIFT(%i, %a)" i pp c
-    | FCLOS (c, u) ->
-        out "FCLOS(%a, %a)" pp_constr c pp_usubs u
-    | FEta (n, h, args, m, u) ->
-        out "FEta(%i, %a, %a, %i, %a)" n pp_constr h
-          (pp_array pp_constr) args m pp_usubs u
-    | FIrrelevant ->
-        out "FIrrelevant"
-    | FLOCKED ->
-        out "FLOCKED"
-    | FPrimitive (p, _, c, args) ->
-        out "FPrimitive(%s, _, %a, %a)" (CPrimitives.to_string p) pp c
-          (pp_array pp) args
-    | FBlock (c, ty, t, u) ->
-        out "FBlock(%a, %a, %a, %a)" pp_constr c pp_constr ty pp_constr t
-          pp_usubs u
-    | FLAZY m ->
-        if Lazy.is_val m then
-          out "FLAZY(%a)" pp (Lazy.force m)
-        else
-          out "FLAZY(<thunk>)"
-
-  and pp_usubs : usubs pp = fun ff u ->
-    let (ls, i) = Esubst.Internal.repr (fst u) in
-    let pp_elt ff v =
-      let open Esubst.Internal in
-      match v with
-      | REL i -> Format.fprintf ff "REL(%i)" i
-      | VAL (i, c) -> Format.fprintf ff "VAL(%i, %a)" i pp_fconstr c
-    in
-    Format.fprintf ff "(%a, %i)" (pp_list pp_elt) ls i
-
-  and pp_fconstr : fconstr pp = fun ff {mark; term} ->
-    Format.fprintf ff "{mark=%a; mode=%a; term=%a}"
-      pp_mark (RedState.red_state mark) pp_mode (RedState.mode mark) pp_fterm term
-
-  let pp_info : clos_infos pp = fun ff info ->
-    Format.fprintf ff "{i_flags=%a; _}" pp_flags (info_flags info)
-
-  let rec pp_stack : stack pp = fun ff s ->
-    let pp_member ff m =
-      let out fmt = Format.fprintf ff fmt in
-      match m with
-      | Zapp args ->
-          out "Zapp(%a)" (pp_array pp_fconstr) args
-      | ZcaseT (_,_,_,_,_,_,m) ->
-          out "ZcaseT(_, _, _, _, _, _, %a)" pp_mode m
-      | Zproj (_,_,m) ->
-          out "Zproj(_, %a)" pp_mode m
-      | Zfix (_, s) ->
-          out "Zfix(_, %a)" pp_stack s
-      | Zprimitive (op,_,_,_,_) ->
-          out "Zprimitive (%s, _, _, _, _)" (CPrimitives.to_string op)
-      | Zshift i ->
-          out "Zshift(%i)" i
-      | Zupdate _ ->
-          out "Zupdate(_)"
-      | Zunblock (_,_,_,f) ->
-          out "Zunblock (_, _, _, %a)" pp_mode f
-      | Zrun (_,_,_,_,_,f) ->
-          out "Zrun (_, _, _, _, _, %a)" pp_mode f
-    in
-    pp_list pp_member ff s
-
-  let debug_on : unit -> bool =
-    let (flag, _) = CDebug.create_full ~name:"lazy" () in
-    fun () -> CDebug.get_flag flag
-
-  let indentation = ref 0
-
-  let indent () = incr indentation
-  let dedent () = decr indentation
-
-  let line fmt =
-    let rec mk n = if n == 0 then [] else "⠀"::(mk (n-1)) in (* non breaking space *)
-    Format.eprintf "%s" (String.concat "" (mk !indentation));
-    Format.eprintf (fmt ^^ "\n%!")
-end
-
-open Debug
 
 let empty_stack = []
 let append_stack v s =
@@ -927,26 +698,12 @@ let rec subst_constr ~mode info tab (subst,usubst as e) c =
     let nargs = Array.length args in
     begin match [@ocaml.warning "-4"] Constr.kind h with
     | Const(kn, _) when nargs == 2 && Constant.UserOrd.equal kn block_constant ->
-      if debug_on () then Debug.line "subst_constr: (Block,subs)";
-      Debug.indent ();
       let e = tcsu_to_usubs e in
-      Debug.dedent ();
-      if debug_on () then Debug.line "subst_constr: (Block,klt)";
-      Debug.indent ();
       let res = !klt_ref ~mode info tab e c in
-      Debug.dedent ();
-      if debug_on () then Debug.line "subst_constr: (Block,res) %a" pp_constr res;
       res
     | Const(kn, _) when nargs >= 2 && Constant.UserOrd.equal kn unblock_constant ->
-      if debug_on () then Debug.line "subst_constr: (Unblock,subs)";
-      Debug.indent ();
       let e = tcsu_to_usubs e in
-      Debug.dedent ();
-      if debug_on () then Debug.line "subst_constr: (Unblock,klt)";
-      Debug.indent ();
       let res = !klt_ref ~mode info tab e c in
-      Debug.dedent ();
-      if debug_on () then Debug.line "subst_constr: (Unblock,res) %a" pp_constr res;
       res
     | _ -> Constr.map_with_binders usubs_lift subst_constr e c
     end
@@ -991,7 +748,6 @@ let eta_reduce m =
 (* The inverse of mk_clos: move back to constr *)
 (* XXX should there be universes in lfts???? *)
 let rec to_constr ~(info:clos_infos) ~(tab:clos_tab) ((lfts, usubst) as ulfts) v =
-  if debug_on () then Debug.line "to_constr: (%a) _ _ (%a)" pp_info info pp_fconstr v;
   let to_constr = to_constr ~info ~tab in
   let subst_constr = subst_constr ~mode:(RedState.mode v.mark) info tab in
   let comp_subs = comp_subs ~info ~tab in
@@ -1162,7 +918,6 @@ let rec fstrong unfreeze_fun lfts v =
 *)
 
 let zip m stk =
-  if debug_on () then Debug.line "zip: in %a %a" pp_fconstr m pp_stack stk;
   let rec zip m stk =
   match stk with
     | [] -> m
@@ -1204,12 +959,9 @@ let zip m stk =
       let m = { m with mark=RedState.set_ntrl m.mark } in
       zip {mark=RedState.mk ntrl mode; term=FApp (op, [|ty1; ty2; m; k|])} s
   in
-  let m = zip m stk in
-  if debug_on () then Debug.line "zip: out %a" pp_fconstr m;
-  m
+  zip m stk
 
 let fapp_stack (m,stk) =
-  if debug_on () then Debug.line "fapp_stack: %a %a" pp_fconstr m pp_stack stk;
   zip m stk
 
 let term_of_process ~info ~tab c stk = term_of_fconstr ~info ~tab (zip c stk)
@@ -1905,15 +1657,12 @@ let is_irrelevant_constructor infos ((ind,_),u) =
    constructor, cofix, letin, constant), or a neutral term (product,
    inductive) *)
 let rec knh info tab m stk =
-  if debug_on () then Debug.line "knh: %a _ (%a) (%a)" pp_info info pp_fconstr m pp_stack stk;
   match m.term with
     | FLIFT(k,a) -> knh info tab a (zshift k stk)
     | FCLOS(t,e) -> knht ~mode:(RedState.mode m.mark) info tab e t (zupdate info m stk)
     | FLOCKED -> assert false
     | FLAZY (l) ->
-      Debug.indent ();
       let (lazy m1) = l in
-      Debug.dedent ();
       knh info tab m1 (zupdate info m stk)
     | FApp(a,b) -> knh info tab a (append_stack b (zupdate info m stk))
     | FCaseT(ci,u,pms,(_,r as p),t,br,e) ->
@@ -1943,7 +1692,6 @@ let rec knh info tab m stk =
        FArray _|FPrimitive _ |FBlock _) -> (m, stk)
 
 and knht_app ~mode ~lexical info tab e h args stk =
-  if debug_on () then Debug.line "knht_app: %a lexical:%b %a _ (%a) %a %a (%a)" pp_mode mode lexical pp_info info pp_constr h (pp_array pp_constr) args pp_usubs e pp_stack stk;
   let default () =
     let stk = append_stack (mk_clos_vect ~mode e args) stk in
     knht ~mode info tab e h stk
@@ -1989,7 +1737,6 @@ and knht_app ~mode ~lexical info tab e h args stk =
 
 (* The same for pure terms *)
 and knht ~mode info tab (e : usubs) t stk : fconstr * stack =
-  if debug_on () then Debug.line "knht: %a %a _ (%a) %a (%a)" pp_mode mode pp_info info pp_constr t pp_usubs e pp_stack stk;
   match kind t with
     | App(h,args) -> knht_app ~mode ~lexical:true info tab e h args stk
     | Case(ci,u,pms,(_,r as p),NoInvert,t,br) ->
@@ -2049,7 +1796,6 @@ let set_conv f = conv := f
 
 (* Computes a weak head normal form from the result of knh. *)
 let rec knr info tab m stk =
-  if debug_on () then Debug.line "knr: %a _ (%a) (%a)" pp_info info pp_fconstr m pp_stack stk;
   let mode = RedState.mode m.mark in
   match m.term with
   | FEta(n,h,args,k,e) ->
@@ -2241,7 +1987,6 @@ let is_val v = match v.term with
 | FIrrelevant | FLOCKED -> assert false
 
 let rec kl info tab m =
-  if debug_on () then Debug.line "kl: %a _ (%a)" pp_info info pp_fconstr m;
   let share = info.i_cache.i_share in
   if is_val m then term_of_fconstr ~info ~tab m
   else
@@ -2250,7 +1995,6 @@ let rec kl info tab m =
     zip_term info tab (norm_head info tab nm) s
 
 and klt ~mode info tab (e : usubs) t =
-  if debug_on () then Debug.line "klt: %a %a _ (%a) %a" pp_mode mode pp_info info pp_constr t pp_usubs e;
   match kind t with
 | Rel i ->
   begin match Esubst.expand_rel i (fst e) with
@@ -2302,7 +2046,6 @@ and klt ~mode info tab (e : usubs) t =
 (* no redex: go up for atoms and already normalized terms, go down
    otherwise. *)
 and norm_head info tab m =
-  if debug_on () then Debug.line "norm_head: %a _ (%a)" pp_info info pp_fconstr m;
   if is_val m then term_of_fconstr ~info ~tab m else
     let mode = RedState.mode m.mark in
     match [@ocaml.warning "-4"] m.term with
@@ -2362,7 +2105,6 @@ and norm_head info tab m =
       | FPrimitive (_, _, _, _) -> assert false (* All other primitives should be fully reduced *)
 
 and zip_term info tab m stk =
-  if debug_on () then Debug.line "zip_term: %a _ (%a) %a" pp_info info pp_constr m pp_stack stk;
   match stk with
 | [] -> m
 | Zapp args :: s ->
@@ -2408,28 +2150,15 @@ and zip_term info tab m stk =
 
 (* Initialization and then normalization *)
 
-let whd_val_counter = ref 0
 (* weak reduction *)
 let whd_val info tab v =
-  let count = !whd_val_counter in incr whd_val_counter;
-  if debug_on () then Debug.line "whd_val: in {%i} %a _ (%a)" count pp_info info pp_fconstr v;
-  Debug.indent ();
-  let res = term_of_fconstr ~info ~tab (kh info tab v []) in
-  Debug.dedent ();
-  if debug_on () then Debug.line "whd_val: out {%i} %a _ (%a)" count pp_info info pp_constr res;
-  res
+  term_of_fconstr ~info ~tab (kh info tab v [])
 
 (* strong reduction *)
 let norm_val info tab v =
-  if debug_on () then Debug.line "norm_val: %a _ (%a)" pp_info info pp_fconstr v;
   kl info tab v
 let norm_term ?(mode=normal_full) info tab e t =
-  if debug_on () then Debug.line "norm_term: in %a %a _ (%a) %a" pp_mode mode pp_info info pp_constr t pp_usubs e;
-  Debug.indent ();
-  let res = klt ~mode info tab e t in
-  Debug.dedent ();
-  if debug_on () then Debug.line "norm_term: out %a)" pp_constr res;
-  res
+  klt ~mode info tab e t
 
 let rec set_mode ~mode (m : fconstr) =
   let set_mode = set_mode ~mode in
@@ -2479,27 +2208,19 @@ let rec set_mode ~mode (m : fconstr) =
 let eval_lazy ~mode info tab m =
   (* TODO: [mode] is ignored, only mode of [t] counts *)
   let m = set_mode ~mode m in
-  Debug.indent ();
   let t = kl info tab m in
-  Debug.dedent ();
   mk_clos ~mode (Esubst.subs_id 0, UVars.Instance.empty) t
 let _ = eval_lazy_ref := eval_lazy
 
 let _ = klt_ref := klt
 let _ = kl_ref := kl
 
-let whd_stack_counter = ref (-1)
 let whd_stack infos tab m stk =
-  let c = incr whd_stack_counter; !whd_stack_counter in
-  if debug_on () then Debug.line "whd_stack: {%i} %a _ (%a) (%a)" c pp_info infos pp_fconstr m pp_stack stk;
-  Debug.indent ();
   match m.mark with
 | _ when RedState.is_ntrl m.mark ->
   (** No need to perform [kni] nor to unlock updates because
       every head subterm of [m] is [ntrl] *)
   let k = knh infos tab m stk in
-  Debug.dedent ();
-  if debug_on () then Debug.line "whd_stack: {%i} output (NTRL): (%a) @@ (%a)" c pp_fconstr (fst k) pp_stack (snd k);
   k
 | _ ->
   let k = kni infos tab m stk in
@@ -2509,8 +2230,6 @@ let whd_stack infos tab m stk =
       let (m', stk') = k in
       if not (m == m' && stk == stk') then ignore (zip m' stk')
   in
-  Debug.dedent ();
-  if debug_on () then Debug.line "whd_stack: {%i} output: (%a) @@ (%a)" c pp_fconstr (fst k) pp_stack (snd k);
   k
 
 let create_infos i_mode ?univs ?evars i_flags i_env =
@@ -2529,7 +2248,6 @@ let infos_with_reds infos reds =
   { infos with i_flags = reds }
 
 let unfold_ref_with_args infos tab fl v =
-  if debug_on () then Debug.line "unfold_ref_with_args: %a _ (%a) %a" pp_info infos pp_table_key fl pp_stack v;
   match Table.lookup ~mode:normal_whnf infos tab fl with (* TODO mode *)
   | Def def -> Some (def, v)
   | Primitive op when check_native_args op v ->
@@ -2547,10 +2265,8 @@ let unfold_ref_with_args infos tab fl v =
         let args = mk_eta_args [||] (List.length rargs) in
         let h = mkConstU c in
         let e = usubs_consv (Array.rev_of_list rargs) (Esubst.subs_id 0, UVars.Instance.empty) in
-        Debug.indent ();
         let (m,stk) = knht_app ~mode ~lexical:true infos tab e h args v in
         let res = knr infos tab m stk in
-        Debug.dedent ();
         Some (res)
       | _ ->
       let m = {mark = RedState.mk cstr normal_whnf; term = FFlex fl } in (* TODO mode *)
@@ -2576,11 +2292,3 @@ let inject = inject ~mode:normal_whnf
 let unfold_projection = unfold_projection ~mode:normal_whnf
 let mk_clos = mk_clos ~mode:normal_whnf
 let mk_clos_vect = mk_clos_vect ~mode:normal_whnf
-
-let term_of_fconstr ~info ~tab m =
-  if debug_on () then Debug.line "term_of_fconstr: (in) %a _ %a" pp_info info pp_fconstr m;
-  Debug.indent ();
-  let res = term_of_fconstr ~info ~tab m in
-  Debug.dedent ();
-  if debug_on () then Debug.line "term_of_fconstr: (out) %a _ %a" pp_info info pp_constr res;
-  res

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -241,13 +241,7 @@ type clos_infos = {
   i_flags : reds;
   i_relevances : Sorts.relevance Range.t;
   i_cache : infos_cache;
-  i_hasdelta : bool;
 }
-
-let [@ocaml.inline always] red_set_delta mode info =
-  match mode with
-  | _ when is_normal mode -> info.i_hasdelta
-  | _ -> true
 
 let info_flags info = info.i_flags
 let info_env info = info.i_cache.i_env
@@ -1669,7 +1663,7 @@ let rec knh info m stk =
        FArray _|FPrimitive _ |FBlock _) -> (m, stk)
 
 and knht_app ~mode ~lexical info e h args stk =
-  if not ((red_set_delta[@ocaml.inlined always]) mode info) then
+  if not (red_set mode info.i_flags RedFlags.fDELTA) then
     let stk = append_stack (mk_clos_vect ~mode e args) stk in
     knht ~mode info e h stk
   else
@@ -2217,8 +2211,7 @@ let create_infos i_mode ?univs ?evars i_flags i_env =
   let i_univs = Option.default (Environ.universes i_env) univs in
   let i_share = (Environ.typing_flags i_env).Declarations.share_reduction in
   let i_cache = {i_env; i_sigma = evars; i_share; i_univs; i_mode} in
-  let i_hasdelta = RedFlags.red_set i_flags fDELTA in
-  {i_flags; i_relevances = Range.empty; i_cache; i_hasdelta}
+  {i_flags; i_relevances = Range.empty; i_cache}
 
 let create_conv_infos = create_infos Conversion
 let create_clos_infos = create_infos Reduction

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -2172,7 +2172,7 @@ and zip_term info tab m stk =
     let ty1 = klt ~mode info tab e ty1 in
     let ty2 = klt ~mode info tab e ty2 in
     let k = klt ~mode info tab e k in
-    let m = term_of_fconstr ~info ~tab (mk_clos ~mode:normal_whnf e m) in (* TODO mode? see [Zunblock] above *)
+    let m = term_of_fconstr ~info ~tab (inject ~mode:normal_whnf m) in (* TODO mode? see [Zunblock] above *)
     let op = subst_instance_constr (snd e) op in
     let h = Constr.mkApp (op, [|ty1; ty2; m; k|]) in
     zip_term info tab h s

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -873,6 +873,7 @@ let rec to_constr ~(info:clos_infos) ~(tab:clos_tab) ((lfts, usubst) as ulfts) v
       let m = to_constr ulfts m in
       let subs = comp_subs ulfts e in
       let ty = subst_constr subs ty in
+      let op = subst_instance_constr (snd e) op in
       Constr.mkApp (op, [|ty; m|])
 
     | FRun (op, ty1, ty2, m, k, e) ->
@@ -881,6 +882,7 @@ let rec to_constr ~(info:clos_infos) ~(tab:clos_tab) ((lfts, usubst) as ulfts) v
       let ty1 = subst_constr subs ty1 in
       let ty2 = subst_constr subs ty2 in
       let k = subst_constr subs k in
+      let op = subst_instance_constr (snd e) op in
       Constr.mkApp (op, [|ty1; ty2; m; k|])
 
     | FLAZY (lazy m) -> to_constr ulfts m
@@ -2163,6 +2165,7 @@ and zip_term info tab m stk =
     zip_term info tab h s
 | Zunblock (op, ty, e, mode)::s ->
     let ty = klt ~mode info tab e ty in
+    let op = subst_instance_constr (snd e) op in
     let h = Constr.mkApp (op, [|ty; m|]) in
     zip_term info tab h s
 | Zrun (op, ty1, ty2, k, e, mode)::s ->
@@ -2170,6 +2173,7 @@ and zip_term info tab m stk =
     let ty2 = klt ~mode info tab e ty2 in
     let k = klt ~mode info tab e k in
     let m = term_of_fconstr ~info ~tab (mk_clos ~mode:normal_whnf e m) in (* TODO mode? see [Zunblock] above *)
+    let op = subst_instance_constr (snd e) op in
     let h = Constr.mkApp (op, [|ty1; ty2; m; k|]) in
     zip_term info tab h s
 

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -140,7 +140,9 @@ let red_transparent =
       let l = List.map make_force_constant [(* "run"; *) "block"; "unblock"] in
       List.fold_right Cpred.add l Cpred.empty
     in
-    TransparentState.{tr_var = Names.Id.Pred.empty; tr_cst}
+    let tr_var = Names.Id.Pred.empty in
+    let tr_prj = Names.PRpred.empty in
+    TransparentState.{tr_var; tr_cst; tr_prj}
   in
   let red_transparent mode flags =
     match mode with

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -1720,7 +1720,7 @@ and knht_app ~mode ~lexical info e h args stk =
 (* The same for pure terms *)
 and knht ~mode info (e : usubs) t stk : fconstr * stack =
   match kind t with
-    | App(h,args) -> knht_app ~mode ~lexical:true info e h args stk
+    | App(h,args) -> (knht_app[@ocaml.unrolled 1]) ~mode ~lexical:true info e h args stk
     | Case(ci,u,pms,(_,r as p),NoInvert,t,br) ->
       if is_irrelevant info (usubst_relevance e r) then
         (mk_irrelevant, skip_irrelevant_stack info stk)

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -1685,7 +1685,7 @@ let rec knh info m stk =
        FArray _|FPrimitive _ |FBlock _) -> (m, stk)
 
 and knht_app ~mode ~lexical info e h args stk =
-  let check_enabled c =
+  let [@ocaml.inline always]check_enabled c =
     (red_set mode info fDELTA) &&
     (TransparentState.is_transparent_constant (red_transparent mode info) c)
   in

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -37,7 +37,7 @@ open RedFlags
 module RelDecl = Context.Rel.Declaration
 module NamedDecl = Context.Named.Declaration
 
-type mode = Conversion | Reduction
+type conv_or_red = Conversion | Reduction
 (* In conversion mode we can introduce FIrrelevant terms.
    Invariants of the conversion mode:
    - the only irrelevant terms as returned by [knr] are either [FIrrelevant],
@@ -60,24 +60,141 @@ type mode = Conversion | Reduction
  *    before the term is computed.
  *)
 
-(* Ntrl means the term is in βιδζ head normal form and cannot create a redex
+(* ntrl means the term is in βιδζ head normal form and cannot create a redex
      when substituted
-   Cstr means the term is in βιδζ head normal form and that it can
+   cstr means the term is in βιδζ head normal form and that it can
      create a redex when substituted (i.e. constructor, fix, lambda)
-   Red is used for terms that might be reduced
+   red is used for terms that might be reduced
 *)
-type red_state = Ntrl | Cstr | Red
+(* type red_state = ntrl | cstr | red *)
 
-let neutr = function Ntrl -> Ntrl | Red | Cstr -> Red
-let is_red = function Red -> true | Ntrl | Cstr -> false
+(* let neutr = function ntrl -> ntrl | red | cstr -> red *)
+(* let is_red = function red -> true | ntrl | cstr -> false *)
+
+module [@ocaml.warning "-32"] RedState : sig
+  type [@ocaml.immediate] t
+  type [@ocaml.immediate] mode
+  type [@ocaml.immediate] red_state
+
+
+  val ntrl : red_state
+  val cstr : red_state
+  val red  : red_state
+
+  val normal_whnf : mode
+  val normal_full : mode
+  val full        : mode
+  val identity    : mode
+
+  val neutr : t -> t
+
+  val mk : red_state -> mode -> t
+  val red_state : t -> red_state
+  val mode : t -> mode
+
+  val is_red : t -> bool
+  val is_cstr : t -> bool
+  val is_ntrl : t -> bool
+  val set_red : t -> t
+  val set_cstr : t -> t
+  val set_ntrl : t -> t
+  val neutr : t -> t
+  val is_normal_whnf : t -> bool
+  val is_normal_full : t -> bool
+  val is_full : t -> bool
+  val is_identity : t -> bool
+  val set_normal_whnf : t -> t
+  val set_normal_full : t -> t
+  val set_full : t -> t
+  val set_identity : t -> t
+  val copy_red : t -> t -> t
+  val copy_mode : t -> t -> t
+end = struct
+  type t = int
+  type red_state = int
+  type mode = int
+
+  let ntrl = 0b00
+  let cstr = 0b01
+  let red =  0b10
+
+  let normal_whnf = 0b0000
+  let normal_full = 0b0100
+  let full        = 0b1000
+  let identity    = 0b1100
+
+  let mk (r : red_state) (m : mode) =
+    r lor m
+
+  let [@ocaml.inline] red_state (i : t) = i land 0b0011
+
+  let [@ocaml.inline] mode (i : t) = i land 0b1100
+
+  let is_red  (i : t) = i land 0b0011 == red
+  let is_cstr (i : t) = i land 0b0011 == cstr
+  let is_ntrl (i : t) = i land 0b0011 == ntrl
+
+  let set_red  (i : t) = (i land 0b1100) lor red
+  let set_cstr (i : t) = (i land 0b1100) lor cstr
+  let set_ntrl (i : t) = (i land 0b1100) lor ntrl
+
+  let neutr (i : t) = if is_ntrl i then i else set_red i
+
+  let is_normal_whnf (i : t) = (i land 0b1100) == normal_whnf
+  let is_normal_full (i : t) = (i land 0b1100) == normal_full
+  let is_full        (i : t) = (i land 0b1100) == full
+  let is_identity    (i : t) = (i land 0b1100) == identity
+
+  let set_normal_whnf (i : t) = (i land 0b0011) lor normal_whnf
+  let set_normal_full (i : t) = (i land 0b0011) lor normal_full
+  let set_full        (i : t) = (i land 0b0011) lor full
+  let set_identity    (i : t) = (i land 0b0011) lor identity
+
+  let copy_red  (src : t) (tgt : t) = (tgt land 0b1100) lor (src land 0b0011)
+  let copy_mode (src : t) (tgt : t) = (tgt land 0b0011) lor (src land 0b1100)
+end
+
+open RedState
 
 type table_key = Constant.t UVars.puniverses tableKey
 
 type evar_repack = Evar.t * constr list -> constr
 
+
+let make_force_constant name =
+  let force_modpath =
+    let open Names in
+    let mp = List.rev_map Id.of_string ["Coq"; "Force"; "Force"] in
+    ModPath.MPfile (DirPath.make mp)
+  in
+  let kn = KerName.make force_modpath (Label.make name) in
+  hcons_con (Constant.make1 kn)
+
+let red_transparent =
+  let id_ts =
+    let tr_cst =
+      let open Names in
+      let l = List.map make_force_constant [(* "run"; *) "block"; "unblock"] in
+      List.fold_right Cpred.add l Cpred.empty
+    in
+    TransparentState.{tr_var = Names.Id.Pred.empty; tr_cst}
+  in
+  let red_transparent mode flags =
+    match mode with
+    | _ when mode == normal_full || mode == normal_whnf -> red_transparent flags
+    | _ when mode == identity -> id_ts
+    | _ -> assert (mode == full); TransparentState.full
+  in red_transparent
+
+let [@ocaml.inline always] red_set mode flags f =
+  match mode with
+  | _ when mode == normal_full || mode == normal_whnf -> red_set flags f
+  | _ when mode == identity -> f==fDELTA
+  | _ -> assert (mode == full); true
+
 type fconstr = {
-  mutable mark : red_state;
-  mutable term: fterm;
+  mutable mark : RedState.t;
+  mutable term : fterm;
 }
 
 and fterm =
@@ -103,18 +220,25 @@ and fterm =
   | FCLOS of constr * usubs
   | FIrrelevant
   | FLOCKED
+  | FPrimitive of CPrimitives.t * pconstant * fconstr * fconstr array
+    (* operator, constr def, primitive as an fconstr, full array of suitably evaluated arguments *)
+  | FBlock of constr * constr * constr * usubs
+    (* @block as a constr, its type as a constr, the contents of the block *)
+  | FEta of int * constr * constr array * int * usubs
+  (* [FEta (n, h, args, m, e)], represents [FCLOS (mkApp (h, Array.append args [|#1 ... #m|]), e)]. *)
+  | FLAZY of fconstr Lazy.t
 
 and usubs = fconstr subs UVars.puniverses
 
 and finvert = fconstr array
 
 let fterm_of v = v.term
-let set_ntrl v = v.mark <- Ntrl
+let set_ntrl v = v.mark <- RedState.set_ntrl v.mark
 
-let mk_atom c = {mark=Ntrl;term=FAtom c}
-let mk_red f = {mark=Red;term=f}
+let mk_atom c = {mark=RedState.mk ntrl normal_whnf;term=FAtom c}
+let mk_red f = {mark=RedState.mk red normal_whnf;term=f}
 
-(* Could issue a warning if no is still Red, pointing out that we loose
+(* Could issue a warning if no is still red, pointing out that we loose
    sharing. *)
 let update v1 mark t =
   v1.mark <- mark; v1.term <- t
@@ -145,13 +269,14 @@ type infos_cache = {
   i_sigma : constr evar_handler;
   i_share : bool;
   i_univs : UGraph.t;
-  i_mode : mode;
+  i_mode : conv_or_red;
 }
 
 type clos_infos = {
   i_flags : reds;
   i_relevances : Sorts.relevance Range.t;
-  i_cache : infos_cache }
+  i_cache : infos_cache;
+}
 
 let info_flags info = info.i_flags
 let info_env info = info.i_cache.i_env
@@ -176,22 +301,27 @@ type 'a next_native_args = (CPrimitives.arg_kind * 'a) list
 
 type stack_member =
   | Zapp of fconstr array
-  | ZcaseT of case_info * UVars.Instance.t * constr array * case_return * case_branch array * usubs
-  | Zproj of Projection.Repr.t * Sorts.relevance
+  | ZcaseT of case_info * UVars.Instance.t * constr array * case_return * case_branch array * usubs * mode
+  | Zproj of Projection.Repr.t * Sorts.relevance * mode
   | Zfix of fconstr * stack
-  | Zprimitive of CPrimitives.t * pconstant * fconstr list * fconstr next_native_args
-       (* operator, constr def, arguments already seen (in rev order), next arguments *)
+  | Zprimitive of CPrimitives.t * pconstant * fconstr * fconstr list * fconstr next_native_args
+       (* operator, constr def, primitive as an fconstr, arguments already seen (in rev order), next arguments *)
   | Zshift of int
   | Zupdate of fconstr
+  | Zunblock of constr * constr * usubs * mode
+  (* unblock as a constr, its type argument, the substitution for both constrs, saved reduction flags *)
+  | Zrun of constr * constr * constr * constr * usubs * mode
+  (* run as a constr, its type argument, its continuation, the substitution for all constrs, saved reduction flags *)
 
 and stack = stack_member list
+
 
 let empty_stack = []
 let append_stack v s =
   if Int.equal (Array.length v) 0 then s else
   match s with
   | Zapp l :: s -> Zapp (Array.append v l) :: s
-  | (ZcaseT _ | Zproj _ | Zfix _ | Zshift _ | Zupdate _ | Zprimitive _) :: _ | [] ->
+  | (ZcaseT _ | Zproj _ | Zfix _ | Zshift _ | Zupdate _ | Zprimitive _ | Zunblock _ | Zrun _) :: _ | [] ->
     Zapp v :: s
 
 (* Collapse the shifts in the stack *)
@@ -199,43 +329,139 @@ let zshift n s =
   match (n,s) with
       (0,_) -> s
     | (_,Zshift(k)::s) -> Zshift(n+k)::s
-    | (_,(ZcaseT _ | Zproj _ | Zfix _ | Zapp _ | Zupdate _ | Zprimitive _) :: _) | _,[] -> Zshift(n)::s
+    | (_,(ZcaseT _ | Zproj _ | Zfix _ | Zapp _ | Zupdate _ | Zprimitive _ | Zunblock _ | Zrun _) :: _) | _,[] -> Zshift(n)::s
 
 let rec stack_args_size = function
   | Zapp v :: s -> Array.length v + stack_args_size s
   | Zshift(_)::s -> stack_args_size s
   | Zupdate(_)::s -> stack_args_size s
-  | (ZcaseT _ | Zproj _ | Zfix _ | Zprimitive _) :: _ | [] -> 0
+  | (ZcaseT _ | Zproj _ | Zfix _ | Zprimitive _ | Zunblock _ | Zrun _) :: _ | [] -> 0
 
-let usubs_shft (n,(e,u)) = subs_shft (n, e), u
+let usubs_shft (n,(e,u)) = Esubst.subs_shft (n, e), u
 
-(* Lifting. Preserves sharing (useful only for cell with norm=Red).
+(* Lifting. Preserves sharing (useful only for cell with norm=red).
    lft_fconstr always create a new cell, while lift_fconstr avoids it
    when the lift is 0. *)
 let rec lft_fconstr n ft =
   match ft.term with
-    | (FInd _|FConstruct _|FFlex(ConstKey _|VarKey _)|FInt _|FFloat _|FIrrelevant) -> ft
-    | FRel i -> {mark=ft.mark;term=FRel(i+n)}
-    | FLambda(k,tys,f,e) -> {mark=Cstr; term=FLambda(k,tys,f,usubs_shft(n,e))}
+    | (FInd _|FConstruct _|FFlex((ConstKey _|VarKey _))|FInt _|FFloat _|FIrrelevant) -> ft
+    | FRel i -> {ft with term=FRel(i+n)}
+    | FLambda(k,tys,f,e) -> {mark=RedState.set_cstr ft.mark; term=FLambda(k,tys,f,usubs_shft(n,e))}
     | FFix(fx,e) ->
-      {mark=Cstr; term=FFix(fx,usubs_shft(n,e))}
+      {mark=RedState.set_cstr ft.mark; term=FFix(fx,usubs_shft(n,e))}
     | FCoFix(cfx,e) ->
-      {mark=Cstr; term=FCoFix(cfx,usubs_shft(n,e))}
+      {mark=RedState.set_cstr ft.mark; term=FCoFix(cfx,usubs_shft(n,e))}
     | FLIFT(k,m) -> lft_fconstr (n+k) m
     | FLOCKED -> assert false
     | FFlex (RelKey _) | FAtom _ | FApp _ | FProj _ | FCaseT _ | FCaseInvert _ | FProd _
-      | FLetIn _ | FEvar _ | FCLOS _ | FArray _ -> {mark=ft.mark; term=FLIFT(n,ft)}
+      | FLetIn _ | FEvar _ | FCLOS _ | FEta _ | FArray _ | FPrimitive _ | FBlock _ | FLAZY _ -> {ft with term=FLIFT(n,ft)}
 let lift_fconstr k f =
   if Int.equal k 0 then f else lft_fconstr k f
 let lift_fconstr_vect k v =
   if Int.equal k 0 then v else Array.Fun1.map lft_fconstr k v
 
-let clos_rel e i =
-  match expand_rel i e with
-    | Inl(n,mt) -> lift_fconstr n mt
-    | Inr(k,None) -> {mark=Ntrl; term= FRel k}
+let clos_rel ~mode ((e, _) : usubs) i =
+  (* TODO: account for info_lift here instead of in ref_value_cache *)
+  match Esubst.expand_rel i e with
+    | Inl(n,mt) ->
+      lift_fconstr n mt
+    | Inr(k,None) ->
+      {mark=RedState.mk ntrl mode; term= FRel k}
     | Inr(k,Some p) ->
-        lift_fconstr (k-p) {mark=Red;term=FFlex(RelKey p)}
+        lift_fconstr (k-p) {mark=RedState.mk red mode;term=FFlex(RelKey p)}
+
+(* Substitute in fconstr *)
+(* let rec subs_subs l ((e_new,u_new) : usubs) ((e_old,u_old) : usubs) = *)
+(*   let f _l m = *)
+(*     subs_fconstr m (e_new, u_new) *)
+(*   in *)
+(*   let e = Esubst.lift_subst f l e_old in *)
+(*   (e,Univ.subst_instance_instance u_new u_old) *)
+
+(* and subs_fconstr m (e : usubs) = *)
+(*   let subs_fconstr m = subs_fconstr m e in *)
+(*   match m.term with *)
+(*   | FRel i -> clos_rel ~mode:m.mode e i *)
+(*   | FAtom t -> {m with term=FAtom (subst_instance_constr (snd e) t)} *)
+(*   | FFlex _ -> m *)
+(*   | FInd (ind,u) -> {m with term=FInd(ind, Univ.subst_instance_instance (snd e) u)} *)
+(*   | FConstruct (cstr,u) -> {m with term=FConstruct(cstr, Univ.subst_instance_instance (snd e) u)} *)
+(*   | FApp (h, args) -> {m with term=FApp(subs_fconstr h, Array.map subs_fconstr args)} *)
+(*   | FProj (p, c) -> {m with term=FProj(p, subs_fconstr c)} *)
+(*   | FFix (f, e2) -> {m with term=FFix(f,subs_subs Esubst.el_id e e2)} *)
+(*   | FCoFix (f, e2) -> {m with term=FCoFix(f,subs_subs Esubst.el_id e e2)} *)
+(*   | FCaseT (a, b, c, d, f, g, e2) -> *)
+(*     {m with term=FCaseT(a,b,c,d,subs_fconstr f, g, subs_subs Esubst.el_id e e2)} *)
+(*   | FCaseInvert (a, b, c, d, f, g, h, e2) -> *)
+(*     {m with term=FCaseInvert (a, b, c, d, Array.map subs_fconstr f, subs_fconstr g, h, subs_subs Esubst.el_id e e2)} *)
+(*   | FLambda (n, tys, b, e2) -> *)
+(*     {m with term=FLambda(n, tys, b, subs_subs Esubst.el_id e e2)} *)
+(*   | FProd (na, ty, b, e2) -> *)
+(*     {m with term=FProd(na, subs_fconstr ty, b, subs_subs Esubst.el_id e e2)} *)
+(*   | FLetIn (na, ty, x, c, e2) -> *)
+(*     {m with term=FLetIn(na, subs_fconstr ty, subs_fconstr x, c, subs_subs Esubst.el_id e e2)} *)
+(*   | FEvar (v, i, e2, repack) -> *)
+(*     {m with term=FEvar(v, i, subs_subs Esubst.el_id e e2, repack)} *)
+(*   | FArray (u, ar, ty) -> *)
+(*     {m with term=FArray(Univ.subst_instance_instance (snd e )u, Parray.map subs_fconstr ar, subs_fconstr ty)} *)
+(*   | FLIFT (i, t) -> {m with term=FLIFT(i,subs_fconstr t)} *)
+(*   | FCLOS (t, e2) -> {m with term=FCLOS(t,subs_subs Esubst.el_id e e2)} *)
+(*   | FPrimitive (a, b, c, d) -> *)
+(*     {m with term=FPrimitive(a, (fst b, Univ.subst_instance_instance (snd e) (snd b)), subs_fconstr c, Array.map subs_fconstr d)} *)
+(*   | FBlock (a, b, c, e2) -> {m with term=FBlock(a, b, c, subs_subs Esubst.el_id e e2)} *)
+(*   | FEta (a, b, c, d, e2) -> {m with term=FEta(a, b, c, d, subs_subs Esubst.el_id e e2)} *)
+(*   | FLAZY t -> {m with term=FLAZY(lazy (subs_fconstr (Lazy.force t)))} *)
+(*   | FInt _ -> m *)
+(*   | FFloat _ -> m *)
+(*   | FIrrelevant -> m *)
+(*   | FLOCKED -> m *)
+
+
+let rec subs_subs (l,u) ((e_old,u_old) : usubs) =
+  let f l m =
+    mk_red (FLAZY (lazy (el_fconstr (l, u) m)))
+  in
+  let e = Esubst.lift_subst f l e_old in
+  (e,UVars.subst_instance_instance u u_old)
+
+and el_fconstr (e : Esubst.lift * UVars.Instance.t) m =
+  let el_fconstr = el_fconstr e in
+  match m.term with
+  | FRel i -> {m with term=FRel(Esubst.reloc_rel i (fst e))}
+  | FAtom t -> {m with term=FAtom (subst_instance_constr (snd e) t)}
+  | FFlex _ -> m
+  | FInd (ind,u) -> {m with term=FInd(ind, UVars.subst_instance_instance (snd e) u)}
+  | FConstruct (cstr,u) -> {m with term=FConstruct(cstr, UVars.subst_instance_instance (snd e) u)}
+  | FApp (h, args) -> {m with term=FApp(el_fconstr h, Array.map el_fconstr args)}
+  | FProj (p, r, c) -> {m with term=FProj(p, r, el_fconstr c)}
+  | FFix (f, e2) -> {m with term=FFix(f,subs_subs e e2)}
+  | FCoFix (f, e2) -> {m with term=FCoFix(f,subs_subs e e2)}
+  | FCaseT (a, b, c, d, f, g, e2) ->
+    {m with term=FCaseT(a,b,c,d,el_fconstr f, g, subs_subs e e2)}
+  | FCaseInvert (a, b, c, d, f, g, h, e2) ->
+    {m with term=FCaseInvert (a, b, c, d, Array.map el_fconstr f, el_fconstr g, h, subs_subs e e2)}
+  | FLambda (n, tys, b, e2) ->
+    {m with term=FLambda(n, tys, b, subs_subs e e2)}
+  | FProd (na, ty, b, e2) ->
+    {m with term=FProd(na, el_fconstr ty, b, subs_subs e e2)}
+  | FLetIn (na, ty, x, c, e2) ->
+    {m with term=FLetIn(na, el_fconstr ty, el_fconstr x, c, subs_subs e e2)}
+  | FEvar (v, i, e2, repack) ->
+    {m with term=FEvar(v, i, subs_subs e e2, repack)}
+  | FArray (u, ar, ty) ->
+    {m with term=FArray(UVars.subst_instance_instance (snd e )u, Parray.map el_fconstr ar, el_fconstr ty)}
+  | FLIFT (i, t) -> {m with term=FLIFT(i,el_fconstr t)}
+  | FCLOS (t, e2) -> {m with term=FCLOS(t,subs_subs e e2)}
+  | FPrimitive (a, b, c, d) ->
+    {m with term=FPrimitive(a, (fst b, UVars.subst_instance_instance (snd e) (snd b)), el_fconstr c, Array.map el_fconstr d)}
+  | FBlock (a, b, c, e2) -> {m with term=FBlock(a, b, c, subs_subs e e2)}
+  | FEta (a, b, c, d, e2) -> {m with term=FEta(a, b, c, d, subs_subs e e2)}
+  | FLAZY t -> {m with term=FLAZY(lazy (el_fconstr (Lazy.force t)))}
+  | FInt _ -> m
+  | FFloat _ -> m
+  | FIrrelevant -> m
+  | FLOCKED -> m
+
 
 (* since the head may be reducible, we might introduce lifts of 0 *)
 let compact_stack head stk =
@@ -248,14 +474,14 @@ let compact_stack head stk =
         (** The stack contains [Zupdate] marks only if in sharing mode *)
         let () = update m h'.mark h'.term in
         strip_rec depth s
-    | ((ZcaseT _ | Zproj _ | Zfix _ | Zapp _ | Zprimitive _) :: _ | []) as stk -> zshift depth stk
+    | ((ZcaseT _ | Zproj _ | Zfix _ | Zapp _ | Zprimitive _ | Zunblock _ | Zrun _) :: _ | []) as stk -> zshift depth stk
   in
   strip_rec 0 stk
 
 (* Put an update mark in the stack, only if needed *)
 let zupdate info m s =
   let share = info.i_cache.i_share in
-  if share && is_red m.mark then
+  if share && RedState.is_red m.mark then
     let s' = compact_stack m s in
     let _ = m.term <- FLOCKED in
     Zupdate(m)::s'
@@ -288,9 +514,9 @@ let mk_lambda env t =
   let (rvars,t') = Term.decompose_lambda t in
   FLambda(List.length rvars, List.rev rvars, t', env)
 
-let usubs_lift (e,u) = subs_lift e, u
+let usubs_lift (e,u) = Esubst.subs_lift e, u
 
-let usubs_liftn n (e,u) = subs_liftn n e, u
+let usubs_liftn n (e,u) = Esubst.subs_liftn n e, u
 
 (* t must be a FLambda and binding list cannot be empty *)
 let destFLambda clos_fun t =
@@ -303,27 +529,28 @@ let destFLambda clos_fun t =
 
 (* Optimization: do not enclose variables in a closure.
    Makes variable access much faster *)
-let mk_clos (e:usubs) t =
+let mk_clos ~mode (e:usubs) t =
   match kind t with
-    | Rel i -> clos_rel (fst e) i
-    | Var x -> {mark = Red; term = FFlex (VarKey x) }
-    | Const c -> {mark = Red; term = FFlex (ConstKey (usubst_punivs e c)) }
+    | Rel i -> clos_rel ~mode e i
+    | Var x -> {mark = RedState.mk red mode; term = FFlex (VarKey x)}
+    | Const c -> {mark = RedState.mk red mode; term = FFlex (ConstKey (usubst_punivs e c))}
     | Sort s ->
       let s = usubst_sort e s in
-      {mark = Ntrl; term = FAtom (mkSort s) }
-    | Meta _ -> {mark = Ntrl; term = FAtom t }
-    | Ind kn -> {mark = Ntrl; term = FInd (usubst_punivs e kn) }
-    | Construct kn -> {mark = Cstr; term = FConstruct (usubst_punivs e kn) }
-    | Int i -> {mark = Cstr; term = FInt i}
-    | Float f -> {mark = Cstr; term = FFloat f}
+      {mark = RedState.mk ntrl mode; term = FAtom (mkSort s)}
+    | Meta _ -> {mark = RedState.mk ntrl mode; term = FAtom t}
+    | Ind kn -> {mark = RedState.mk ntrl mode; term = FInd (usubst_punivs e kn)}
+    | Construct kn -> {mark = RedState.mk cstr mode; term = FConstruct (usubst_punivs e kn)}
+    | Int i -> {mark = RedState.mk cstr mode; term = FInt i}
+    | Float f -> {mark = RedState.mk cstr mode; term = FFloat f}
     | (CoFix _|Lambda _|Fix _|Prod _|Evar _|App _|Case _|Cast _|LetIn _|Proj _|Array _) ->
-        {mark = Red; term = FCLOS(t,e)}
+        {mark = RedState.mk red mode; term = FCLOS(t,e)}
 
-let injectu c u = mk_clos (subs_id 0, u) c
+let injectu ~mode c u =
+  mk_clos ~mode (Esubst.subs_id 0, u) c
 
-let inject c = injectu c UVars.Instance.empty
+let inject ~mode c = injectu ~mode c UVars.Instance.empty
 
-let mk_irrelevant = { mark = Cstr; term = FIrrelevant }
+let mk_irrelevant = { mark = RedState.mk cstr normal_whnf; term = FIrrelevant}
 
 let is_irrelevant info r = match info.i_cache.i_mode with
 | Reduction -> false
@@ -339,7 +566,7 @@ type table_val = (fconstr, Empty.t) constant_def
 module Table : sig
   type t
   val create : unit -> t
-  val lookup : clos_infos -> t -> table_key -> table_val
+  val lookup : mode:mode -> clos_infos -> t -> table_key -> table_val
 end = struct
   module Table = Hashtbl.Make(struct
     type t = table_key
@@ -347,27 +574,35 @@ end = struct
     let hash = hash_table_key (fun (c, _) -> Constant.UserOrd.hash c)
   end)
 
-  type t = table_val Table.t
+  type tab = table_val Table.t
+  type t = tab * tab * tab
 
-  let create () = Table.create 17
+  let tab_of mode (tab_def, tab_full, tab_id) =
+    match mode with
+    | _ when mode == normal_full || mode == normal_whnf -> tab_def
+    | _ when mode == identity -> tab_id
+    | _ -> assert (mode == full); tab_full
+
+  let create () =
+    (Table.create 17, Table.create 17, Table.create 17)
 
   exception Irrelevant
 
   let shortcut_irrelevant info r =
     if is_irrelevant info r then raise Irrelevant
 
-  let assoc_defined d =
+  let assoc_defined ~mode d =
     match d with
-    | NamedDecl.LocalDef (_, c, _) -> inject c
+    | NamedDecl.LocalDef (_, c, _) -> inject ~mode c
     | NamedDecl.LocalAssum (_, _) -> raise Not_found
 
-  let constant_value_in u = function
-    | Def b -> injectu b u
+  let constant_value_in ~mode u = function
+    | Def b -> injectu ~mode b u
     | OpaqueDef _ -> raise (NotEvaluableConst Opaque)
     | Undef _ -> raise (NotEvaluableConst NoBody)
     | Primitive p -> raise (NotEvaluableConst (IsPrimitive (u,p)))
 
-  let value_of info ref =
+  let value_of ~mode info ref =
     try
       let env = info.i_cache.i_env in
       match ref with
@@ -383,22 +618,22 @@ end = struct
           | RelDecl.LocalAssum _ -> raise Not_found
           | RelDecl.LocalDef (_, t, _) -> lift n t
         in
-        Def (inject body)
+        Def (inject ~mode body)
       | VarKey id ->
         let def = Environ.lookup_named id env in
         shortcut_irrelevant info
           (binder_relevance (NamedDecl.get_annot def));
-        let ts = RedFlags.red_transparent info.i_flags in
+        let ts = red_transparent mode info.i_flags in
         if TransparentState.is_transparent_variable ts id then
-          Def (assoc_defined def)
+          Def (assoc_defined ~mode def)
         else
           raise Not_found
       | ConstKey (cst,u) ->
         let cb = lookup_constant cst env in
         shortcut_irrelevant info (UVars.subst_instance_relevance u cb.const_relevance);
-        let ts = RedFlags.red_transparent info.i_flags in
+        let ts = red_transparent mode info.i_flags in
         if TransparentState.is_transparent_constant ts cst then
-          Def (constant_value_in u cb.const_body)
+          Def (constant_value_in ~mode u cb.const_body)
         else
           raise Not_found
     with
@@ -407,9 +642,10 @@ end = struct
     | Not_found (* List.assoc *)
     | NotEvaluableConst _ (* Const *) -> Undef None
 
-  let lookup info tab ref =
+  let lookup ~mode info tab ref =
+    let tab = tab_of mode tab in
     try Table.find tab ref with Not_found ->
-    let v = value_of info ref in
+    let v = value_of ~mode info ref in
     Table.add tab ref v; v
 end
 
@@ -421,54 +657,122 @@ let create_tab = Table.create
 
 (** Hand-unrolling of the map function to bypass the call to the generic array
     allocation *)
-let mk_clos_vect env v = match v with
+let mk_clos_vect ~mode env v =
+  let mk_clos = mk_clos ~mode in
+  match v with
 | [||] -> [||]
 | [|v0|] -> [|mk_clos env v0|]
 | [|v0; v1|] -> [|mk_clos env v0; mk_clos env v1|]
 | [|v0; v1; v2|] -> [|mk_clos env v0; mk_clos env v1; mk_clos env v2|]
-| [|v0; v1; v2; v3|] ->
-  [|mk_clos env v0; mk_clos env v1; mk_clos env v2; mk_clos env v3|]
+| [|v0; v1; v2; v3|] -> [|mk_clos env v0; mk_clos env v1; mk_clos env v2; mk_clos env v3|]
 | v -> Array.Fun1.map mk_clos env v
 
-let rec subst_constr (subst,usubst as e) c =
+let klt_ref = ref (fun ~mode:_ _ _ _ _ -> assert false)
+let kl_ref = ref (fun _ _ _ -> assert false)
+
+type tcs = (fconstr Lazy.t * Constr.t Lazy.t) Esubst.subs
+type tcsu = tcs * UVars.Instance.t
+
+let tcsu_to_usubs (t : tcsu) : usubs =
+  let f (m, _) = mk_red (FLAZY m) in
+  Esubst.map_subst f (fst t), snd t
+
+(* let to_usubs ~mode : Constr.t lazy_t Esubst.subs * Univ.Instance.t -> usubs = fun (e, u) -> *)
+(*   let f l cl = *)
+(*     let e = (Esubst.subs_of_lift l, Univ.Instance.empty) in *)
+(*     let m = lazy (mk_clos ~mode e ((Lazy.force cl))) in *)
+(*     {mark = red; term = FLAZY m; mode} *)
+(*   in *)
+(*   let e = Esubst.lift_subst f Esubst.el_id e in *)
+(*   (e, u) *)
+
+let block_constant = make_force_constant "block"
+let unblock_constant = make_force_constant "unblock"
+let run_constant = make_force_constant "run"
+
+let rec subst_constr ~mode info tab (subst,usubst as e) c =
   let c = Vars.map_constr_relevance (usubst_relevance e) c in
+  let subst_constr = subst_constr ~mode info tab in
   match [@ocaml.warning "-4"] Constr.kind c with
-| Rel i ->
-  begin match expand_rel i subst with
-  | Inl (k, lazy v) -> Vars.lift k v
-  | Inr (m, _) -> mkRel m
-  end
-| Const _ | Ind _ | Construct _ | Sort _ -> subst_instance_constr usubst c
-| Case (ci, u, pms, p, iv, discr, br) ->
-  let u' = usubst_instance e u in
-  let c = if u == u' then c else mkCase (ci, u', pms, p, iv, discr, br) in
-  Constr.map_with_binders usubs_lift subst_constr e c
-| Array (u,elems,def,ty) ->
-  let u' = usubst_instance e u in
-  let c = if u == u' then c else mkArray (u',elems,def,ty) in
-  Constr.map_with_binders usubs_lift subst_constr e c
-| _ ->
-  Constr.map_with_binders usubs_lift subst_constr e c
+  | App(h,args) ->
+    let nargs = Array.length args in
+    begin match [@ocaml.warning "-4"] Constr.kind h with
+    | Const(kn, _) when nargs == 2 && Constant.UserOrd.equal kn block_constant ->
+      let e = tcsu_to_usubs e in
+      let res = !klt_ref ~mode info tab e c in
+      res
+    | Const(kn, _) when nargs >= 2 && Constant.UserOrd.equal kn unblock_constant ->
+      let e = tcsu_to_usubs e in
+      let res = !klt_ref ~mode info tab e c in
+      res
+    | _ -> Constr.map_with_binders usubs_lift subst_constr e c
+    end
+
+  | Rel i ->
+    begin match Esubst.expand_rel i subst with
+    | Inl (k, (_, lazy v)) -> Vars.lift k v
+    | Inr (m, _) -> mkRel m
+    end
+  | Const _ | Ind _ | Construct _ | Sort _ -> subst_instance_constr usubst c
+  | Case (ci, u, pms, p, iv, discr, br) ->
+    let u' = usubst_instance e u in
+    let c = if u == u' then c else mkCase (ci, u', pms, p, iv, discr, br) in
+    Constr.map_with_binders usubs_lift subst_constr e c
+  | Array (u,elems,def,ty) ->
+    let u' = usubst_instance e u in
+    let c = if u == u' then c else mkArray (u',elems,def,ty) in
+    Constr.map_with_binders usubs_lift subst_constr e c
+  | _ ->
+    Constr.map_with_binders usubs_lift subst_constr e c
+
+
+let mk_eta_args args n =
+  let nargs = Array.length args in
+  Array.init
+    (nargs + n)
+    (fun i ->
+         if i < nargs then
+           args.(i)
+         else
+           mkRel (n-(i-nargs))
+    )
+
+let eta_reduce m =
+  match[@ocaml.warning "-4"] m.term with
+  | FEta(n,h,args,k,e) when n=1 ->
+    {m with term=FCLOS(mkApp(h,mk_eta_args args k),e)}
+  | FEta(n,h,args,k,e) when n>1 ->
+    {m with term=FEta(n-1,h,args,k,e)}
+  | _ -> assert false
 
 (* The inverse of mk_clos: move back to constr *)
 (* XXX should there be universes in lfts???? *)
-let rec to_constr (lfts, usubst as ulfts) v =
+let rec to_constr ~(info:clos_infos) ~(tab:clos_tab) ((lfts, usubst) as ulfts) v =
+  let to_constr = to_constr ~info ~tab in
+  let subst_constr = subst_constr ~mode:(RedState.mode v.mark) info tab in
+  let comp_subs = comp_subs ~info ~tab in
   let subst_us c = subst_instance_constr usubst c in
   match v.term with
-    | FRel i -> mkRel (reloc_rel i lfts)
-    | FFlex (RelKey p) -> mkRel (reloc_rel p lfts)
+    | _ when RedState.is_full v.mark ->
+      (* Terms with mode=full come from a forcing context and might occur
+         multiple times. We need to preserve sharing as much as possible
+         to avoid reducing the same term over and over. *)
+      v.mark <- RedState.set_normal_full v.mark;
+      !kl_ref info tab v
+    | FRel i -> mkRel (Esubst.reloc_rel i lfts)
+    | FFlex (RelKey p) -> mkRel (Esubst.reloc_rel p lfts)
     | FFlex (VarKey x) -> mkVar x
     | FAtom c -> subst_us (exliftn lfts c)
     | FFlex (ConstKey op) -> subst_us (mkConstU op)
     | FInd op -> subst_us (mkIndU op)
     | FConstruct op -> subst_us (mkConstructU op)
     | FCaseT (ci, u, pms, p, c, ve, env) ->
-      to_constr_case ulfts ci u pms p NoInvert c ve env
+      to_constr_case ~info ~tab ~mode:(RedState.mode v.mark) ulfts ci u pms p NoInvert c ve env
     | FCaseInvert (ci, u, pms, p, indices, c, ve, env) ->
       let iv = CaseInvert {indices=Array.Fun1.map to_constr ulfts indices} in
-      to_constr_case ulfts ci u pms p iv c ve env
+      to_constr_case ~info ~tab ~mode:(RedState.mode v.mark) ulfts ci u pms p iv c ve env
     | FFix ((op,(lna,tys,bds)) as fx, e) ->
-      if is_subs_id (fst e) && is_lift_id lfts then
+      if Esubst.is_subs_id (fst e) && Esubst.is_lift_id lfts then
         subst_instance_constr (usubst_instance ulfts (snd e)) (mkFix fx)
       else
         let n = Array.length bds in
@@ -479,7 +783,7 @@ let rec to_constr (lfts, usubst as ulfts) v =
         let bds = Array.Fun1.map subst_constr subs_bd bds in
         mkFix (op, (lna, tys, bds))
     | FCoFix ((op,(lna,tys,bds)) as cfx, e) ->
-      if is_subs_id (fst e) && is_lift_id lfts then
+      if Esubst.is_subs_id (fst e) && Esubst.is_lift_id lfts then
         subst_instance_constr (usubst_instance ulfts (snd e)) (mkCoFix cfx)
       else
         let n = Array.length bds in
@@ -496,7 +800,7 @@ let rec to_constr (lfts, usubst as ulfts) v =
         mkProj (p,usubst_relevance ulfts r,to_constr ulfts c)
 
     | FLambda (len, tys, f, e) ->
-      if is_subs_id (fst e) && is_lift_id lfts then
+      if Esubst.is_subs_id (fst e) && Esubst.is_lift_id lfts then
         subst_instance_constr (usubst_instance ulfts (snd e)) (Term.compose_lam (List.rev tys) f)
       else
         let subs = comp_subs ulfts e in
@@ -507,7 +811,7 @@ let rec to_constr (lfts, usubst as ulfts) v =
         let f = subst_constr (usubs_liftn len subs) f in
         Term.compose_lam (List.rev tys) f
     | FProd (n, t, c, e) ->
-      if is_subs_id (fst e) && is_lift_id lfts then
+      if Esubst.is_subs_id (fst e) && Esubst.is_lift_id lfts then
         mkProd (n, to_constr ulfts t, subst_instance_constr (usubst_instance ulfts (snd e)) c)
       else
         let subs' = comp_subs ulfts e in
@@ -523,7 +827,7 @@ let rec to_constr (lfts, usubst as ulfts) v =
     | FEvar (ev, args, env, repack) ->
       let subs = comp_subs ulfts env in
       repack (ev, List.map (fun a -> subst_constr subs a) args)
-    | FLIFT (k,a) -> to_constr (el_shft k lfts, usubst) a
+    | FLIFT (k,a) -> to_constr (Esubst.el_shft k lfts, usubst) a
 
     | FInt i ->
        Constr.mkInt i
@@ -540,42 +844,71 @@ let rec to_constr (lfts, usubst as ulfts) v =
       mkArray(u, t, def,ty)
 
     | FCLOS (t,env) ->
-      if is_subs_id (fst env) && is_lift_id lfts then
+      if Esubst.is_subs_id (fst env) && Esubst.is_lift_id lfts then
+        subst_instance_constr (usubst_instance ulfts (snd env)) t
+      else
+        let subs = comp_subs ulfts env in
+        subst_constr subs t
+    | FEta (_,h,args,m,env) ->
+      let args = mk_eta_args args m in
+      let t = mkApp (h, args) in
+      if Esubst.is_subs_id (fst env) && Esubst.is_lift_id lfts then
         subst_instance_constr (usubst_instance ulfts (snd env)) t
       else
         let subs = comp_subs ulfts env in
         subst_constr subs t
 
+    | FPrimitive (_, _, h, args) ->
+        mkApp (to_constr ulfts h, Array.map (to_constr ulfts) args)
+
+    | FBlock (op,ty,t,e) ->
+        let ty =
+          if Esubst.is_subs_id (fst e) && Esubst.is_lift_id lfts then
+            subst_instance_constr (usubst_instance ulfts (snd e)) ty
+          else
+            let subs = comp_subs ulfts e in
+            subst_constr subs ty
+        in
+        let t = !klt_ref ~mode:identity info tab e t in
+        Constr.mkApp (op, [|ty; t|])
+
+    | FLAZY (lazy m) -> to_constr ulfts m
+
     | FIrrelevant -> assert (!Flags.in_debugger); mkVar(Id.of_string"_IRRELEVANT_")
     | FLOCKED -> assert (!Flags.in_debugger); mkVar(Id.of_string"_LOCKED_")
 
-and to_constr_case (lfts,_ as ulfts) ci u pms (p,r) iv c ve env =
-  let subs = comp_subs ulfts env in
-  let r = usubst_relevance subs r in
+and to_constr_case ~(info:clos_infos) ~(tab:clos_tab) ~mode (lfts,_ as ulfts) ci u pms (p,r) iv c ve env =
+  let subs = comp_subs ~info ~tab ulfts env in
   if is_subs_id (fst env) && is_lift_id lfts then
-    mkCase (ci, usubst_instance subs u, pms, (p,r), iv, to_constr ulfts c, ve)
+    mkCase (ci, usubst_instance subs u, pms, (p,r), iv, to_constr ~info ~tab ulfts c, ve)
   else
     let f_ctx (nas, c) =
       let nas = Array.map (usubst_binder subs) nas in
-      let c = subst_constr (usubs_liftn (Array.length nas) subs) c in
+      let c = subst_constr ~mode info tab (usubs_liftn (Array.length nas) subs) c in
       (nas, c)
     in
     mkCase (ci,
             usubst_instance subs u,
-            Array.map (fun c -> subst_constr subs c) pms,
+            Array.map (fun c -> subst_constr ~mode info tab subs c) pms,
             (f_ctx p,r),
             iv,
-            to_constr ulfts c,
+            to_constr ~info ~tab ulfts c,
             Array.map f_ctx ve)
 
-and comp_subs (el,u) (s,u') =
-  Esubst.lift_subst (fun el c -> lazy (to_constr (el,u) c)) el s, u'
+and comp_subs ~(info:clos_infos) ~(tab:clos_tab) (el,u) (s,u') =
+  Esubst.lift_subst (fun el c ->
+      let elu = (el,u) in
+      let m = lazy (el_fconstr elu c) in
+      let t = lazy (to_constr ~info ~tab elu c) in
+      (m, t)
+    ) el s, u'
 
 (* This function defines the correspondence between constr and
    fconstr. When we find a closure whose substitution is the identity,
    then we directly return the constr to avoid possibly huge
    reallocation. *)
-let term_of_fconstr c = to_constr (el_id, UVars.Instance.empty) c
+let term_of_fconstr ~info ~tab c =
+  to_constr ~info ~tab (el_id, UVars.Instance.empty) c
 
 (* fstrong applies unfreeze_fun recursively on the (freeze) term and
  * yields a term.  Assumes that the unfreeze_fun never returns a
@@ -584,16 +917,19 @@ let rec fstrong unfreeze_fun lfts v =
   to_constr (fstrong unfreeze_fun) lfts (unfreeze_fun v)
 *)
 
-let rec zip m stk =
+let zip m stk =
+  let rec zip m stk =
   match stk with
     | [] -> m
-    | Zapp args :: s -> zip {mark=neutr m.mark; term=FApp(m, args)} s
-    | ZcaseT(ci, u, pms, p, br, e)::s ->
+    | Zapp args :: s -> zip {mark=RedState.neutr m.mark; term=FApp(m, args)} s
+    | ZcaseT(ci, u, pms, p, br, e, mode)::s ->
         let t = FCaseT(ci, u, pms, p, m, br, e) in
-        let mark = (neutr m.mark) in
+        let mark = (RedState.neutr m.mark) in
+        let mark = RedState.mk (RedState.red_state mark) mode in
         zip {mark; term=t} s
-    | Zproj (p,r) :: s ->
-        let mark = (neutr m.mark) in
+    | Zproj (p,r,mode) :: s ->
+        let mark = (RedState.neutr m.mark) in
+        let mark = RedState.mk (RedState.red_state mark) mode in
         zip {mark; term=FProj(Projection.make p true,r,m)} s
     | Zfix(fx,par)::s ->
         zip fx (par @ append_stack [|m|] s)
@@ -603,14 +939,32 @@ let rec zip m stk =
       (** The stack contains [Zupdate] marks only if in sharing mode *)
         let () = update rf m.mark m.term in
         zip rf s
-    | Zprimitive(_op,c,rargs,kargs)::s ->
+    | Zprimitive(_op,c,_,rargs,kargs)::s ->
+      let mode = RedState.mode m.mark in (* TODO mode? *)
       let args = List.rev_append rargs (m::List.map snd kargs) in
-      let f = {mark = Red; term = FFlex (ConstKey c)} in
-      zip {mark=(neutr m.mark); term = FApp (f, Array.of_list args)} s
+      let f = {mark = RedState.mk red mode; term = FFlex (ConstKey c)} in
+      zip {mark=RedState.neutr m.mark; term = FApp (f, Array.of_list args)} s
+    | Zunblock (op,ty,e,mode) :: s ->
+      let op = mk_clos ~mode e op in
+      op.mark <- RedState.set_ntrl op.mark;
+      let ty = mk_clos ~mode e ty in
+      let m = { m with mark=RedState.set_ntrl m.mark } in
+      zip {mark=RedState.mk ntrl mode; term=FApp (op, [|ty; m|])} s
+    | Zrun (op,ty1,ty2,k,e,mode) :: s ->
+      let op = mk_clos ~mode e op in
+      op.mark <- RedState.set_ntrl op.mark;
+      let ty1 = mk_clos ~mode e ty1 in
+      let ty2 = mk_clos ~mode e ty2 in
+      let k = mk_clos ~mode e k in
+      let m = { m with mark=RedState.set_ntrl m.mark } in
+      zip {mark=RedState.mk ntrl mode; term=FApp (op, [|ty1; ty2; m; k|])} s
+  in
+  zip m stk
 
-let fapp_stack (m,stk) = zip m stk
+let fapp_stack (m,stk) =
+  zip m stk
 
-let term_of_process c stk = term_of_fconstr (zip c stk)
+let term_of_process ~info ~tab c stk = term_of_fconstr ~info ~tab (zip c stk)
 
 (*********************************************************************)
 
@@ -620,28 +974,46 @@ let term_of_process c stk = term_of_fconstr (zip c stk)
    (strip_update_shift, through get_arg). *)
 
 (* optimised for the case where there are no shifts... *)
+let strip_update_shift_app_red_head head stk =
+  let rec strip_rec rstk h depth = function
+    | Zshift(k) as e :: s ->
+        strip_rec (e::rstk) (lift_fconstr k h) (depth+k) s
+    | (Zapp args :: s) ->
+        strip_rec (Zapp args :: rstk) {h with term=FApp(h,args)} depth s
+    | Zupdate(m)::s ->
+      (** The stack contains [Zupdate] marks only if in sharing mode *)
+        let () = update m h.mark h.term in
+        strip_rec rstk m depth s
+    | ((ZcaseT _ | Zproj _ | Zfix _ | Zprimitive _ | Zunblock _ | Zrun _) :: _ | []) as stk ->
+      (h, (depth,List.rev rstk, stk))
+  in
+  strip_rec [] head 0 stk
+
 let strip_update_shift_app_red head stk =
   let rec strip_rec rstk h depth = function
     | Zshift(k) as e :: s ->
         strip_rec (e::rstk) (lift_fconstr k h) (depth+k) s
     | (Zapp args :: s) ->
-        strip_rec (Zapp args :: rstk)
-          {mark=h.mark;term=FApp(h,args)} depth s
+        strip_rec (Zapp args :: rstk) {h with term=FApp(h,args)} depth s
     | Zupdate(m)::s ->
       (** The stack contains [Zupdate] marks only if in sharing mode *)
         let () = update m h.mark h.term in
         strip_rec rstk m depth s
-    | ((ZcaseT _ | Zproj _ | Zfix _ | Zprimitive _) :: _ | []) as stk ->
+    | ((ZcaseT _ | Zproj _ | Zfix _ | Zprimitive _ | Zunblock _ | Zrun _) :: _ | []) as stk ->
       (depth,List.rev rstk, stk)
   in
   strip_rec [] head 0 stk
 
 let strip_update_shift_app head stack =
-  assert (not (is_red head.mark));
+  assert (not (RedState.is_red head.mark));
   strip_update_shift_app_red head stack
 
+let strip_update_shift_app_head head stack =
+  assert (not (RedState.is_red head.mark));
+  strip_update_shift_app_red_head head stack
+
 let get_nth_arg head n stk =
-  assert (not (is_red head.mark));
+  assert (not (RedState.is_red head.mark));
   let rec strip_rec rstk h n = function
     | Zshift(k) as e :: s ->
         strip_rec (e::rstk) (lift_fconstr k h) n s
@@ -649,7 +1021,7 @@ let get_nth_arg head n stk =
         let q = Array.length args in
         if n >= q
         then
-          strip_rec (Zapp args::rstk) {mark=h.mark;term=FApp(h,args)} (n-q) s'
+          strip_rec (Zapp args::rstk) {h with term=FApp(h,args)} (n-q) s'
         else
           let bef = Array.sub args 0 n in
           let aft = Array.sub args (n+1) (q-n-1) in
@@ -660,14 +1032,14 @@ let get_nth_arg head n stk =
         (** The stack contains [Zupdate] mark only if in sharing mode *)
         let () = update m h.mark h.term in
         strip_rec rstk m n s
-    | ((ZcaseT _ | Zproj _ | Zfix _ | Zprimitive _) :: _ | []) as s -> (None, List.rev rstk @ s) in
+    | ((ZcaseT _ | Zproj _ | Zfix _ | Zprimitive _ | Zunblock _ | Zrun _) :: _ | []) as s -> (None, List.rev rstk @ s) in
   strip_rec [] head n stk
 
-let usubs_cons x (s,u) = subs_cons x s, u
+let usubs_cons x (s,u) = Esubst.subs_cons x s, u
 
 let rec subs_consn v i n s =
-  if Int.equal i n then s
-  else subs_consn v (i + 1) n (subs_cons v.(i) s)
+  if Int.equal i n then s else
+  subs_consn v (i + 1) n (Esubst.subs_cons v.(i) s)
 
 let usubs_consn v i n s = on_fst (subs_consn v i n) s
 
@@ -676,13 +1048,13 @@ let usubs_consv v s =
 
 (* Beta reduction: look for an applied argument in the stack.
    Since the encountered update marks are removed, h must be a whnf *)
-let rec get_args n tys f e = function
+let rec get_args mode n tys f e = function
     | Zupdate r :: s ->
         (** The stack contains [Zupdate] mark only if in sharing mode *)
-        let () = update r Cstr (FLambda(n,tys,f,e)) in
-        get_args n tys f e s
+        let () = update r (RedState.mk cstr mode) (FLambda(n,tys,f,e)) in
+        get_args mode n tys f e s
     | Zshift k :: s ->
-        get_args n tys f (usubs_shft (k,e)) s
+        get_args mode n tys f (usubs_shft (k,e)) s
     | Zapp l :: s ->
         let na = Array.length l in
         if n == na then (Inl (usubs_consn l 0 na e), s)
@@ -691,19 +1063,39 @@ let rec get_args n tys f e = function
           (Inl (usubs_consn l 0 n e), Zapp eargs :: s)
         else (* more lambdas *)
           let etys = List.skipn na tys in
-          get_args (n-na) etys f (usubs_consn l 0 na e) s
-    | ((ZcaseT _ | Zproj _ | Zfix _ | Zprimitive _) :: _ | []) as stk ->
-      (Inr {mark=Cstr; term=FLambda(n,tys,f,e)}, stk)
+          get_args mode (n-na) etys f (usubs_consn l 0 na e) s
+    | ((ZcaseT _ | Zproj _ | Zfix _ | Zprimitive _ | Zunblock _ | Zrun _) :: _ | []) as stk ->
+      (Inr {mark=RedState.mk cstr mode; term=FLambda(n,tys,f,e)}, stk)
+
+let rec get_eta_args mode n h args m e s =
+  match s with
+  | Zupdate r :: s ->
+      update r (RedState.mk cstr mode) (FEta(n,h,args,m,e));
+      get_eta_args mode n h args m e s
+  | Zshift k :: s ->
+      get_eta_args mode n h args m (usubs_shft (k,e)) s
+  | Zapp l :: s ->
+      let na = Array.length l in
+      if n == na then
+        (Inl (usubs_consn l 0 na e), s)
+      else if n < na then (* more arguments *)
+        let eargs = Array.sub l n (na-n) in
+        (Inl (usubs_consn l 0 n e), Zapp eargs :: s)
+      else (* more lambdas *)
+        get_eta_args mode (n-na) h args (m + na) (usubs_consn l 0 na e) s
+  | (ZcaseT _ | Zproj _ | Zfix _ | Zprimitive _ | Zunblock _ | Zrun _) :: _
+  | [] ->
+      (Inr {mark=RedState.mk cstr mode; term=FEta(n,h,args,m,e)}, s)
 
 (* Eta expansion: add a reference to implicit surrounding lambda at end of stack *)
 let rec eta_expand_stack info na = function
   | (Zapp _ | Zfix _ | ZcaseT _ | Zproj _
-        | Zshift _ | Zupdate _ | Zprimitive _ as e) :: s ->
+        | Zshift _ | Zupdate _ | Zprimitive _ | Zunblock _ | Zrun _ as e) :: s ->
       e :: eta_expand_stack info na s
   | [] ->
     let arg =
       if is_irrelevant info na.binder_relevance then mk_irrelevant
-      else {mark = Ntrl; term = FRel 1}
+      else {mark = RedState.mk ntrl normal_whnf; term = FRel 1}
     in
     [Zshift 1; Zapp [|arg|]]
 
@@ -715,7 +1107,7 @@ let rec skip_native_args rargs nargs =
       else skip_native_args (a::rargs) nargs'
   | [] -> rargs, []
 
-let get_native_args op c stk =
+let get_native_args ~mode op c stk =
   let kargs = CPrimitives.kind op in
   let rec get_args rnargs kargs args =
     match kargs, args with
@@ -733,20 +1125,13 @@ let get_native_args op c stk =
           (skip_native_args [] (List.rev rnargs),
            Zapp (Array.of_list eargs) :: s')
         | rnargs, kargs, _ ->
-          strip_rec rnargs {mark = h.mark;term=FApp(h, args)} depth kargs s'
+          strip_rec rnargs {h with term=FApp(h, args)} depth kargs s'
       end
     | Zupdate(m) :: s ->
       let () = update m h.mark h.term in
       strip_rec rnargs m depth  kargs s
-    | (Zprimitive _ | ZcaseT _ | Zproj _ | Zfix _) :: _ | [] -> assert false
-  in strip_rec [] {mark = Red; term = FFlex(ConstKey c)} 0 kargs stk
-
-let get_native_args1 op c stk =
-  match get_native_args op c stk with
-  | ((rargs, (kd,a):: nargs), stk) ->
-      assert (kd = CPrimitives.Kwhnf);
-      (rargs, a, nargs, stk)
-  | _ -> assert false
+    | (Zprimitive _ | ZcaseT _ | Zproj _ | Zfix _ | Zunblock _ | Zrun _) :: _ | [] -> assert false
+  in strip_rec [] {mark = RedState.mk red mode; term = FFlex(ConstKey c)} 0 kargs stk
 
 let check_native_args op stk =
   let nargs = CPrimitives.arity op in
@@ -760,7 +1145,7 @@ let rec reloc_rargs_rec depth = function
   | Zapp args :: s ->
     Zapp (lift_fconstr_vect depth args) :: reloc_rargs_rec depth s
   | Zshift(k)::s -> if Int.equal k depth then s else reloc_rargs_rec (depth-k) s
-  | ((ZcaseT _ | Zproj _ | Zfix _ | Zupdate _ | Zprimitive _) :: _ | []) as stk -> stk
+  | ((ZcaseT _ | Zproj _ | Zfix _ | Zupdate _ | Zprimitive _ | Zunblock _ | Zrun _) :: _ | []) as stk -> stk
 
 let reloc_rargs depth stk =
   if Int.equal depth 0 then stk else reloc_rargs_rec depth stk
@@ -777,7 +1162,7 @@ let rec try_drop_parameters depth n = function
     | [] ->
         if Int.equal n 0 then []
         else raise Not_found
-    | (ZcaseT _ | Zproj _ | Zfix _ | Zupdate _ | Zprimitive _) :: _ -> assert false
+    | (ZcaseT _ | Zproj _ | Zfix _ | Zupdate _ | Zprimitive _ | Zunblock _ | Zrun _) :: _ -> assert false
         (* strip_update_shift_app only produces Zapp and Zshift items *)
 
 let drop_parameters depth n argstk =
@@ -786,20 +1171,20 @@ let drop_parameters depth n argstk =
   (* we know that n < stack_args_size(argstk) (if well-typed term) *)
   anomaly (Pp.str "ill-typed term: found a match on a partially applied constructor.")
 
-let inductive_subst mib u pms =
+let inductive_subst ~mode mib u pms =
   let rec mk_pms i ctx = match ctx with
-  | [] -> subs_id 0
+  | [] -> Esubst.subs_id 0
   | RelDecl.LocalAssum _ :: ctx ->
     let subs = mk_pms (i - 1) ctx in
-    subs_cons pms.(i) subs
+    Esubst.subs_cons (pms.(i)) subs (* TODO mk_clos? *)
   | RelDecl.LocalDef (_, c, _) :: ctx ->
     let subs = mk_pms i ctx in
-    subs_cons (mk_clos (subs,u) c) subs
+    Esubst.subs_cons (mk_clos ~mode (subs,u) c) subs (* TODO no mk_clos? *)
   in
   mk_pms (Array.length pms - 1) mib.mind_params_ctxt, u
 
 (* Iota-reduction: feed the arguments of the constructor to the branch *)
-let get_branch infos depth ci pms ((ind, c), u) br e args =
+let get_branch ~mode infos depth ci pms ((ind, c), u) br (e : usubs)  args =
   let i = c - 1 in
   let args = drop_parameters depth ci.ci_npar args in
   let (_nas, br) = br.(i) in
@@ -809,7 +1194,7 @@ let get_branch infos depth ci pms ((ind, c), u) br e args =
     let rec push e stk = match stk with
     | [] -> e
     | Zapp v :: stk -> push (usubs_consv v e) stk
-    | (Zshift _ | ZcaseT _ | Zproj _ | Zfix _ | Zupdate _ | Zprimitive _) :: _ ->
+    | (Zshift _ | ZcaseT _ | Zproj _ | Zfix _ | Zupdate _ | Zprimitive _ | Zunblock _ | Zrun _) :: _ ->
       assert false
     in
     let e = push e args in
@@ -824,10 +1209,10 @@ let get_branch infos depth ci pms ((ind, c), u) br e args =
     let ctx, _ = List.chop mip.mind_consnrealdecls.(i) ctx in
     let map = function
     | Zapp args -> args
-    | Zshift _ | ZcaseT _ | Zproj _ | Zfix _ | Zupdate _ | Zprimitive _ ->
+    | Zshift _ | ZcaseT _ | Zproj _ | Zfix _ | Zupdate _ | Zprimitive _ | Zunblock _ | Zrun _ ->
       assert false
     in
-    let ind_subst = inductive_subst mib u (Array.map (mk_clos e) pms) in
+    let ind_subst = inductive_subst ~mode mib u (Array.map (mk_clos ~mode e) pms) in
     let args = Array.concat (List.map map args) in
     let rec push i e = function
     | [] -> []
@@ -839,7 +1224,7 @@ let get_branch infos depth ci pms ((ind, c), u) br e args =
       let b = subst_instance_constr u b in
       let s = Array.rev_of_list ans in
       let e = usubs_consv s ind_subst in
-      let v = mk_clos e b in
+      let v = mk_clos ~mode e b in
       v :: ans
     in
     let ext = push (Array.length args - 1) [] ctx in
@@ -869,7 +1254,7 @@ let eta_expand_ind_stack env (ind,u) m s (f, s') =
     (** Try to drop the params, might fail on partially applied constructors. *)
     let argss = try_drop_parameters depth pars args in
     let hstack = Array.map (fun (p,r) ->
-        { mark = Red; (* right can't be a constructor though *)
+        { mark = RedState.set_red m.mark; (* right can't be a constructor though *)
           term = FProj (Projection.make p true, UVars.subst_instance_relevance u r, right) })
         projs
     in
@@ -881,7 +1266,7 @@ let rec project_nth_arg n = function
       let q = Array.length args in
         if n >= q then project_nth_arg (n - q) s
         else (* n < q *) args.(n)
-  | (ZcaseT _ | Zproj _ | Zfix _ | Zupdate _ | Zshift _ | Zprimitive _) :: _ | [] -> assert false
+  | (ZcaseT _ | Zproj _ | Zfix _ | Zupdate _ | Zshift _ | Zprimitive _ | Zunblock _ | Zrun _) :: _ | [] -> assert false
       (* After drop_parameters we have a purely applicative stack *)
 
 (* Iota reduction: expansion of a fixpoint.
@@ -893,31 +1278,31 @@ let rec project_nth_arg n = function
  *    -> (S. FCLOS(F0,S) . ... . FCLOS(Fn-1,S), Ti)
  *)
 (* does not deal with FLIFT *)
-let contract_fix_vect fix =
+let contract_fix_vect ~mode fix =
   let (thisbody, make_body, env, nfix) =
     match [@ocaml.warning "-4"] fix with
       | FFix (((reci,i),(_,_,bds as rdcl)),env) ->
           (bds.(i),
-           (fun j -> { mark = Cstr;
+           (fun j -> { mark = RedState.mk cstr mode;
                        term = FFix (((reci,j),rdcl),env) }),
            env, Array.length bds)
       | FCoFix ((i,(_,_,bds as rdcl)),env) ->
           (bds.(i),
-           (fun j -> { mark = Cstr;
+           (fun j -> { mark = RedState.mk cstr mode;
                        term = FCoFix ((j,rdcl),env) }),
            env, Array.length bds)
       | _ -> assert false
   in
   let rec mk_subs env i =
     if Int.equal i nfix then env
-    else mk_subs (subs_cons (make_body i) env) (i + 1)
+    else mk_subs (Esubst.subs_cons (make_body i) env) (i + 1) (* FIXME *)
   in
   (on_fst (fun env -> mk_subs env 0) env, thisbody)
 
-let unfold_projection info p r =
+let unfold_projection ~mode info p r =
   if red_projection info.i_flags p
   then
-    Some (Zproj (Projection.repr p, r))
+    Some (Zproj (Projection.repr p, r, mode))
   else None
 
 (************************************************************************)
@@ -925,18 +1310,26 @@ let unfold_projection info p r =
 
 open Primred
 
+let eval_lazy_ref = ref (fun ~mode:_ _ _ _ -> assert false)
+
 module FNativeEntries =
   struct
     type elem = fconstr
     type args = fconstr array
     type evd = unit
+    type lazy_info = clos_infos * Table.t
     type uinstance = UVars.Instance.t
 
     let mk_construct c =
       (* All constructors used in primitive functions are relevant *)
-      { mark = Cstr; term = FConstruct (UVars.in_punivs c) }
+      { mark = RedState.mk cstr normal_whnf; term = FConstruct (UVars.in_punivs c) }
+      (* Mode is ignored here. *)
 
     let get = Array.get
+
+    let set args i e =
+      let args = Array.copy args in
+      Array.set args i e; args
 
     let get_int () e =
       match [@ocaml.warning "-4"] e.term with
@@ -953,7 +1346,10 @@ module FNativeEntries =
       | FArray (_u,t,_ty) -> t
       | _ -> assert false
 
-    let dummy = {mark = Ntrl; term = FRel 0}
+    let get_blocked _ _ _ = assert false
+
+
+    let dummy = {mark = RedState.mk ntrl normal_whnf; term = FRel 0}
 
     let current_retro = ref Retroknowledge.empty
     let defined_int = ref false
@@ -963,7 +1359,7 @@ module FNativeEntries =
       match retro.Retroknowledge.retro_int63 with
       | Some c ->
         defined_int := true;
-        fint := { mark = Ntrl; term = FFlex (ConstKey (UVars.in_punivs c)) }
+        fint := { mark = RedState.mk ntrl normal_whnf; term = FFlex (ConstKey (UVars.in_punivs c)) }
       | None -> defined_int := false
 
     let defined_float = ref false
@@ -973,7 +1369,7 @@ module FNativeEntries =
       match retro.Retroknowledge.retro_float64 with
       | Some c ->
         defined_float := true;
-        ffloat := { mark = Ntrl; term = FFlex (ConstKey (UVars.in_punivs c)) }
+        ffloat := { mark = RedState.mk ntrl normal_whnf; term = FFlex (ConstKey (UVars.in_punivs c)) }
       | None -> defined_float := false
 
     let defined_bool = ref false
@@ -1024,7 +1420,7 @@ module FNativeEntries =
         fLt := mk_construct cLt;
         fGt := mk_construct cGt;
         let (icmp, _) = cEq in
-        fcmp := { mark = Ntrl; term = FInd (UVars.in_punivs icmp) }
+        fcmp := { mark = RedState.mk ntrl normal_whnf; term = FInd (UVars.in_punivs icmp) }
       | None -> defined_cmp := false
 
     let defined_f_cmp = ref false
@@ -1128,11 +1524,11 @@ module FNativeEntries =
 
     let mkInt env i =
       check_int env;
-      { mark = Cstr; term = FInt i }
+      { mark = RedState.mk cstr normal_whnf; term = FInt i }
 
     let mkFloat env f =
       check_float env;
-      { mark = Cstr; term = FFloat f }
+      { mark = RedState.mk cstr normal_whnf; term = FFloat f }
 
     let mkBool env b =
       check_bool env;
@@ -1140,17 +1536,17 @@ module FNativeEntries =
 
     let mkCarry env b e =
       check_carry env;
-      {mark = Cstr;
+      {mark = RedState.mk cstr (assert false);
        term = FApp ((if b then !fC1 else !fC0),[|!fint;e|])}
 
     let mkIntPair env e1 e2 =
       check_pair env;
-      { mark = Cstr; term = FApp(!fPair, [|!fint;!fint;e1;e2|]) }
+      { mark = RedState.mk cstr (assert false); term = FApp(!fPair, [|!fint;!fint;e1;e2|]) }
 
     let mkFloatIntPair env f i =
       check_pair env;
       check_float env;
-      { mark = Cstr; term = FApp(!fPair, [|!ffloat;!fint;f;i|]) }
+      { mark = RedState.mk cstr (assert false); term = FApp(!fPair, [|!ffloat;!fint;f;i|]) }
 
     let mkLt env =
       check_cmp env;
@@ -1218,7 +1614,14 @@ module FNativeEntries =
 
     let mkArray env u t ty =
       check_array env;
-      { mark = Cstr; term = FArray (u,t,ty)}
+      { mark = RedState.mk cstr (assert false); term = FArray (u,t,ty) }
+
+    let eval_full_lazy _ _ = assert false
+
+    let eval_id_lazy _ _ = assert false
+
+    let mkApp t args =
+      { mark = RedState.mk red (assert false); term = FApp(t, args) }
 
   end
 
@@ -1230,11 +1633,13 @@ let rec skip_irrelevant_stack info stk = match stk with
 | (Zfix _ | Zproj _) :: s ->
   (* Typing rules ensure that fix / proj over SProp is irrelevant *)
   skip_irrelevant_stack info s
-| ZcaseT (_, _, _, (_,r), _, e) :: s ->
+| ZcaseT (_, _, _, (_,r), _, e, _) :: s ->
   let r = usubst_relevance e r in
   if is_irrelevant info r then skip_irrelevant_stack info s
   else stk
 | Zprimitive _ :: _ -> assert false (* no irrelevant primitives so far *)
+| Zunblock _ :: _ -> assert false
+| Zrun _ :: _ -> assert false
 | Zupdate m :: s ->
   (** The stack contains [Zupdate] marks only if in sharing mode *)
   let () = update m mk_irrelevant.mark mk_irrelevant.term in
@@ -1251,92 +1656,137 @@ let is_irrelevant_constructor infos ((ind,_),u) =
    atom or a subterm that may produce a redex (abstraction,
    constructor, cofix, letin, constant), or a neutral term (product,
    inductive) *)
-let rec knh info m stk =
+let rec knh info tab m stk =
   match m.term with
-    | FLIFT(k,a) -> knh info a (zshift k stk)
-    | FCLOS(t,e) -> knht info e t (zupdate info m stk)
+    | FLIFT(k,a) -> knh info tab a (zshift k stk)
+    | FCLOS(t,e) -> knht ~mode:(RedState.mode m.mark) info tab e t (zupdate info m stk)
     | FLOCKED -> assert false
-    | FApp(a,b) -> knh info a (append_stack b (zupdate info m stk))
+    | FLAZY (l) ->
+      let (lazy m1) = l in
+      knh info tab m1 (zupdate info m stk)
+    | FApp(a,b) -> knh info tab a (append_stack b (zupdate info m stk))
     | FCaseT(ci,u,pms,(_,r as p),t,br,e) ->
       let r' = usubst_relevance e r in
       if is_irrelevant info r' then
         (mk_irrelevant, skip_irrelevant_stack info stk)
       else
-        knh info t (ZcaseT(ci,u,pms,p,br,e)::zupdate info m stk)
+        knh info tab t (ZcaseT(ci,u,pms,p,br,e,RedState.mode m.mark)::zupdate info m stk)
     | FFix (((ri, n), (lna, _, _)), e) ->
       if is_irrelevant info (usubst_relevance e (lna.(n)).binder_relevance) then
         (mk_irrelevant, skip_irrelevant_stack info stk)
       else
         (match get_nth_arg m ri.(n) stk with
-             (Some(pars,arg),stk') -> knh info arg (Zfix(m,pars)::stk')
+             (Some(pars,arg),stk') -> knh info tab arg (Zfix(m,pars)::stk')
            | (None, stk') -> (m,stk'))
     | FProj (p,r,c) ->
       if is_irrelevant info r then
         (mk_irrelevant, skip_irrelevant_stack info stk)
       else
-      (match unfold_projection info p r with
+      (match unfold_projection ~mode:(RedState.mode m.mark) info p r with
        | None -> (m, stk)
-       | Some s -> knh info c (s :: zupdate info m stk))
+       | Some s -> knh info tab c (s :: zupdate info m stk))
 
 (* cases where knh stops *)
     | (FFlex _|FLetIn _|FConstruct _|FEvar _|FCaseInvert _|FIrrelevant|
-       FCoFix _|FLambda _|FRel _|FAtom _|FInd _|FProd _|FInt _|FFloat _|FArray _) ->
-        (m, stk)
+       FCoFix _|FLambda _|FEta _|FRel _|FAtom _|FInd _|FProd _|FInt _|FFloat _|
+       FArray _|FPrimitive _ |FBlock _) -> (m, stk)
+
+and knht_app ~mode ~lexical info tab e h args stk =
+  let default () =
+    let stk = append_stack (mk_clos_vect ~mode e args) stk in
+    knht ~mode info tab e h stk
+  in
+  let partial _op n =
+    ({ mark = RedState.mk cstr mode; term = FEta(n, h, args, 0, e) }, stk)
+  in
+  if not (red_set mode info.i_flags RedFlags.fDELTA) then default () else
+  match Constr.destConst h with
+  | exception DestKO -> default ()
+  | (c, _u) ->
+  if not (TransparentState.is_transparent_constant (red_transparent mode info.i_flags) c) then default () else
+  let nargs = Array.length args in
+  if Constant.UserOrd.equal c block_constant then
+    match[@ocaml.warning "-4"] args with
+    | [|ty; t|] ->
+      let mode = if lexical then identity else normal_whnf in
+      knh info tab { mark = RedState.mk cstr mode; term = FBlock (h, ty, t, e) } stk
+    | _ -> partial CPrimitives.Block (2-nargs)
+  else if Constant.UserOrd.equal c unblock_constant then
+    if nargs >= 2 then
+      let ty = args.(0) in
+      let t = args.(1) in
+      let args = Array.sub args 2 (nargs - 2) in
+      let mode_full = if lexical then full else normal_whnf  in
+      let stk = (append_stack (mk_clos_vect ~mode e args) stk) in
+      knht ~mode:mode_full info tab e t (Zunblock (h, ty, e, mode) :: stk)
+    else
+      partial CPrimitives.Unblock (2-nargs)
+  else if Constant.UserOrd.equal c run_constant then
+    if nargs >= 4 then
+      let ty1 = args.(0) in
+      let ty2 = args.(1) in
+      let t = args.(2) in
+      let k = args.(3) in
+      let args = Array.sub args 4 (nargs - 4) in
+      let mode_full = if lexical then full else normal_whnf  in
+      let stk = (append_stack (mk_clos_vect ~mode e args) stk) in
+      knht ~mode:mode_full info tab e t (Zrun (h, ty1, ty2, k, e, mode) :: stk)
+    else
+      partial CPrimitives.Run (4-nargs)
+  else default ()
 
 (* The same for pure terms *)
-and knht info e t stk =
+and knht ~mode info tab (e : usubs) t stk : fconstr * stack =
   match kind t with
-    | App(a,b) ->
-        knht info e a (append_stack (mk_clos_vect e b) stk)
+    | App(h,args) -> knht_app ~mode ~lexical:true info tab e h args stk
     | Case(ci,u,pms,(_,r as p),NoInvert,t,br) ->
       if is_irrelevant info (usubst_relevance e r) then
         (mk_irrelevant, skip_irrelevant_stack info stk)
       else
-        knht info e t (ZcaseT(ci, u, pms, p, br, e)::stk)
+        knht ~mode info tab e t (ZcaseT(ci, u, pms, p, br, e, mode)::stk)
     | Case(ci,u,pms,(_,r as p),CaseInvert{indices},t,br) ->
       if is_irrelevant info (usubst_relevance e r) then
         (mk_irrelevant, skip_irrelevant_stack info stk)
       else
-        let term = FCaseInvert (ci, u, pms, p, (Array.map (mk_clos e) indices), mk_clos e t, br, e) in
-        { mark = Red; term }, stk
+        let term = FCaseInvert (ci, u, pms, p, (Array.map (mk_clos ~mode e) indices), mk_clos ~mode e t, br, e) in
+        ({ mark = RedState.mk red mode; term }, stk)
     | Fix (((_, n), (lna, _, _)) as fx) ->
       if is_irrelevant info (usubst_relevance e (lna.(n)).binder_relevance) then
         (mk_irrelevant, skip_irrelevant_stack info stk)
       else
-        knh info { mark = Cstr; term = FFix (fx, e) } stk
-    | Cast(a,_,_) -> knht info e a stk
-    | Rel n -> knh info (clos_rel (fst e) n) stk
+        knh info tab { mark = RedState.mk cstr mode; term = FFix (fx, e) } stk
+    | Cast(a,_,_) -> knht ~mode info tab e a stk
+    | Rel n -> knh info tab (clos_rel ~mode e n) stk
     | Proj (p, r, c) ->
       let r = usubst_relevance e r in
       if is_irrelevant info r then
         (mk_irrelevant, skip_irrelevant_stack info stk)
       else
-        knh info { mark = Red; term = FProj (p, r, mk_clos e c) } stk
-    | (Ind _|Const _|Construct _|Var _|Meta _ | Sort _ | Int _|Float _) -> (mk_clos e t, stk)
-    | CoFix cfx ->
-      { mark = Cstr; term = FCoFix (cfx,e) }, stk
-    | Lambda _ -> { mark = Cstr ; term = mk_lambda e t }, stk
+        knh info tab { mark = RedState.mk red mode; term = FProj (p, r, mk_clos ~mode e c) } stk
+    | (Ind _|Const _|Construct _|Var _|Meta _ | Sort _ | Int _|Float _) -> (mk_clos ~mode e t, stk)
+    | CoFix cfx -> ({ mark = RedState.mk cstr mode; term = FCoFix (cfx,e) }, stk)
+    | Lambda _ -> ({ mark = RedState.mk cstr mode; term = mk_lambda e t }, stk)
     | Prod (n, t, c) ->
-      { mark = Ntrl; term = FProd (usubst_binder e n, mk_clos e t, c, e) }, stk
+      ({ mark = RedState.mk ntrl mode; term = FProd (usubst_binder e n, mk_clos ~mode e t, c, e) }, stk)
     | LetIn (n,b,t,c) ->
-      { mark = Red; term = FLetIn (usubst_binder e n, mk_clos e b, mk_clos e t, c, e) }, stk
+      ({ mark = RedState.mk red mode; term = FLetIn (usubst_binder e n, mk_clos ~mode e b, mk_clos ~mode e t, c, e) }, stk)
     | Evar ev ->
       begin match info.i_cache.i_sigma.evar_expand ev with
-      | EvarDefined c -> knht info e c stk
+      | EvarDefined c -> knht ~mode info tab e c stk
       | EvarUndefined (evk, args) ->
         assert (UVars.Instance.is_empty (snd e));
         if info.i_cache.i_sigma.evar_irrelevant ev then
           (mk_irrelevant, skip_irrelevant_stack info stk)
         else
           let repack = info.i_cache.i_sigma.evar_repack in
-          { mark = Ntrl; term = FEvar (evk, args, e, repack) }, stk
+          ({ mark = RedState.mk ntrl mode; term = FEvar (evk, args, e, repack) }, stk)
       end
     | Array(u,t,def,ty) ->
       let len = Array.length t in
-      let ty = mk_clos e ty in
-      let t = Parray.init (Uint63.of_int len) (fun i -> mk_clos e t.(i)) (mk_clos e def) in
+      let ty = mk_clos ~mode e ty in
+      let t = Parray.init (Uint63.of_int len) (fun i -> mk_clos ~mode e t.(i)) (mk_clos ~mode e def) in
       let term = FArray (u,t,ty) in
-      knh info { mark = Cstr; term } stk
+      knh info tab { mark = RedState.mk cstr mode; term } stk
 
 (************************************************************************)
 
@@ -1346,39 +1796,55 @@ let set_conv f = conv := f
 
 (* Computes a weak head normal form from the result of knh. *)
 let rec knr info tab m stk =
+  let mode = RedState.mode m.mark in
   match m.term with
-  | FLambda(n,tys,f,e) when red_set info.i_flags fBETA ->
-      (match get_args n tys f e stk with
-          Inl e', s -> knit info tab e' f s
+  | FEta(n,h,args,k,e) ->
+    (match get_eta_args mode n h args k e stk with
+     | Inl e', s ->
+         let args = mk_eta_args args (n + k) in
+         knit_nonlexical_app ~mode:mode info tab e' h args s
+     | Inr eta, s -> (eta,s))
+  | FLambda(n,tys,f,e) when red_set mode info.i_flags fBETA ->
+      (match get_args mode n tys f e stk with
+          Inl e', s -> knit ~mode:mode info tab e' f s
         | Inr lam, s -> (lam,s))
-  | FFlex fl when red_set info.i_flags fDELTA ->
-      (match Table.lookup info tab fl with
+  | FFlex fl when red_set mode info.i_flags fDELTA ->
+      (match Table.lookup ~mode:mode info tab fl with
         | Def v -> kni info tab v stk
         | Primitive op ->
+          (* if op = CPrimitives.Block then *)
+          (*   (\* TODO: ntrl? *\) *)
+          (*   (m, stk) *)
+          (* else *)
           if check_native_args op stk then
             let c = match fl with ConstKey c -> c | RelKey _ | VarKey _ -> assert false in
-            let rargs, a, nargs, stk = get_native_args1 op c stk in
-            kni info tab a (Zprimitive(op,c,rargs,nargs)::stk)
+            (* In our case, none of the instruciton arguments need evaluating!!! *)
+            match get_native_args ~mode:mode op c stk with
+            | ((rargs, (kd,a) :: nargs), stk) ->
+              assert (kd = CPrimitives.Kwhnf);
+              kni info tab a (Zprimitive(op,c,m,rargs,nargs)::stk)
+            | ((rargs, []), stk) ->
+              let args = Array.of_list (List.rev rargs) in
+              knr info tab {mark=m.mark; term=FPrimitive(op,c,{ mark = m.mark; term = FFlex (fl) },args)} stk
           else
-            (* Similarly to fix, partially applied primitives are not Ntrl! *)
+            (* Similarly to fix, partially applied primitives are not ntrl! *)
             (m, stk)
         | Undef _ | OpaqueDef _ -> (set_ntrl m; (m,stk)))
   | FConstruct c ->
-     let use_match = red_set info.i_flags fMATCH in
-     let use_fix = red_set info.i_flags fFIX in
-     if use_match || use_fix then
+     let use_match mode = red_set mode info.i_flags fMATCH in
+     let use_fix mode = red_set mode info.i_flags fFIX in
+     if use_match mode || use_fix mode then
       (match [@ocaml.warning "-4"] strip_update_shift_app m stk with
-        | (depth, args, ZcaseT(ci,_,pms,_,br,e)::s) when use_match ->
+        | (depth, args, ZcaseT(ci,_,pms,_,br,e,mode)::s) when use_match mode ->
             assert (ci.ci_npar>=0);
-            (* instance on the case and instance on the constructor are compatible by typing *)
-            let (br, e) = get_branch info depth ci pms c br e args in
-            knit info tab e br s
-        | (_, cargs, Zfix(fx,par)::s) when use_fix ->
+            let (br, e) = get_branch ~mode info depth ci pms c br e args in
+            knit ~mode info tab e br s
+        | (_, cargs, Zfix(fx,par)::s) when use_fix (RedState.mode fx.mark) ->
             let rarg = fapp_stack(m,cargs) in
             let stk' = par @ append_stack [|rarg|] s in
-            let (fxe,fxbd) = contract_fix_vect fx.term in
-            knit info tab fxe fxbd stk'
-        | (depth, args, Zproj (p,_)::s) when use_match ->
+            let (fxe,fxbd) = contract_fix_vect ~mode:(RedState.mode fx.mark) fx.term in
+            knit ~mode:(RedState.mode fx.mark) info tab fxe fxbd stk'
+        | (depth, args, Zproj (p,_,mode)::s) when use_match mode ->
             let rargs = drop_parameters depth (Projection.Repr.npars p) args in
             let rarg = project_nth_arg (Projection.Repr.arg p) rargs in
             kni info tab rarg s
@@ -1391,36 +1857,65 @@ let rec knr info tab m stk =
   | FCoFix ((i, (lna, _, _)), e) ->
     if is_irrelevant info (usubst_relevance e (lna.(i)).binder_relevance) then
       (mk_irrelevant, skip_irrelevant_stack info stk)
-    else if red_set info.i_flags fCOFIX then
+    else if red_set mode info.i_flags fCOFIX then
       (match strip_update_shift_app m stk with
-        | (_, args, (((ZcaseT _|Zproj _)::_) as stk')) ->
-            let (fxe,fxbd) = contract_fix_vect m.term in
-            knit info tab fxe fxbd (args@stk')
-        | (_,args, ((Zapp _ | Zfix _ | Zshift _ | Zupdate _ | Zprimitive _) :: _ | [] as s)) -> (m,args@s))
+        | (_, args, (((ZcaseT _|Zproj _)::_) as stk')) -> (* TODO: are blocked matches on the stack possible? *)
+            let (fxe,fxbd) = contract_fix_vect ~mode:mode m.term in
+            knit ~mode:mode info tab fxe fxbd (args@stk')
+        | (_,args, ((Zapp _ | Zfix _ | Zshift _ | Zupdate _ | Zprimitive _ | Zunblock _ | Zrun _) :: _ | [] as s)) -> (m,args@s))
     else (m, stk)
-  | FLetIn (_,v,_,bd,e) when red_set info.i_flags fZETA ->
-      knit info tab (on_fst (subs_cons v) e) bd stk
-  | FInt _ | FFloat _ | FArray _ ->
-    (match [@ocaml.warning "-4"] strip_update_shift_app m stk with
-     | (_, _, Zprimitive(op,(_,u as c),rargs,nargs)::s) ->
+  | FLetIn (_,v,_,bd,e) when red_set mode info.i_flags fZETA ->
+      knit ~mode:mode info tab (on_fst (Esubst.subs_cons v) e) bd stk
+  | FPrimitive (op, ((_,u) as pc), fc, args) when RedState.is_red m.mark ->
+    (match FredNative.red_prim (info_env info) () (info, tab) op u args with
+     | FredNative.Result m -> kni info tab m stk
+     | FredNative.Error -> assert false
+     | FredNative.Progress (_, args) ->
+         match[@ocaml.warning "-4"] (op, args) with
+         | (CPrimitives.Block, [|_; t|])  ->
+             m.mark <- RedState.set_cstr m.mark;
+             (match [@ocaml.warning "-4"] strip_update_shift_app m stk with
+              | (_, rargs, Zunblock (_,_,_,mode) :: stk) ->
+                  ignore mode; (* TODO partially applied block *)
+                  let s = List.rev_append rargs stk in
+                  kni info tab t s
+              | (_, rargs, stk) ->
+                  let stk = List.rev_append rargs stk in
+                  let m = { mark= RedState.mk cstr (RedState.mode m.mark); term=FPrimitive (op, pc, fc, args) } in
+                  knr info tab m stk)
+         | _ ->
+         let m = { mark= RedState.mk cstr mode; term=FPrimitive (op, pc, fc, args) } in
+         knr info tab m stk) (* TODO *)
+  | FInt _ | FFloat _ | FArray _ | FPrimitive _ ->
+    (match [@ocaml.warning "-4"] strip_update_shift_app_head m stk with
+     | (_, (_, _, Zprimitive(op,c,opm,rargs,nargs)::s)) ->
        let (rargs, nargs) = skip_native_args (m::rargs) nargs in
        begin match nargs with
          | [] ->
            let args = Array.of_list (List.rev rargs) in
-           begin match FredNative.red_prim (info_env info) () op u args with
-            | Some m -> kni info tab m s
-            | None -> assert false
-           end
+           knr info tab {mark=RedState.mk red mode; term=FPrimitive(op,c,opm,args) } s
          | (kd,a)::nargs ->
            assert (kd = CPrimitives.Kwhnf);
-           kni info tab a (Zprimitive(op,c,rargs,nargs)::s)
-             end
-     | (_, _, s) -> (m, s))
-  | FCaseInvert (ci, u, pms, _p,iv,_c,v,env) when red_set info.i_flags fMATCH ->
-    let pms = mk_clos_vect env pms in
+           kni info tab a (Zprimitive(op,c,opm,rargs,nargs)::s)
+       end
+     | (head, (_, _, s)) -> (head, s))
+  | FBlock (_, _, t, e) ->
+    (match [@ocaml.warning "-4"] strip_update_shift_app m stk with
+     | (_, rargs, Zunblock (_,_,_,mode) :: stk) ->
+         let stk = List.rev_append rargs stk in
+         knit ~mode info tab e t stk
+     | (_, rargs, Zrun (_,_,_,k,ek,mode) :: stk) ->
+         let stk = List.rev_append rargs stk in
+         let k = mk_clos ~mode ek k in
+         let t = mk_clos ~mode e t in
+         let term = FApp(k,[|t|]) in
+         kni info tab {mark=RedState.mk red mode; term} stk
+     | (_, rargs, stk) -> (m, List.rev_append rargs stk))
+  | FCaseInvert (ci, u, pms, _p,iv,_c,v,env) when red_set mode info.i_flags fMATCH ->
+    let pms = mk_clos_vect ~mode:mode env pms in
     let u = usubst_instance env u in
-    begin match case_inversion info tab ci u pms iv v with
-      | Some c -> knit info tab env c stk
+    begin match case_inversion ~mode:mode info tab ci u pms iv v with
+      | Some c -> knit ~mode:mode info tab env c stk
       | None -> (m, stk)
     end
   | FIrrelevant ->
@@ -1431,19 +1926,23 @@ let rec knr info tab m stk =
   | FLambda _ | FFlex _ | FRel _ (* irrelevance handled by conversion *)
   | FLetIn _ (* only happens in reduction mode *) ->
     (m, stk)
-  | FLOCKED | FCLOS _ | FApp _ | FCaseT _ | FLIFT _ ->
+  | FLOCKED | FCLOS _ | FApp _ | FCaseT _ | FLIFT _ | FLAZY _ ->
     (* ruled out by knh(t) *)
     assert false
 
 (* Computes the weak head normal form of a term *)
 and kni info tab m stk =
-  let (hm,s) = knh info m stk in
+  let (hm,s) = knh info tab m stk in
   knr info tab hm s
-and knit info tab e t stk =
-  let (ht,s) = knht info e t stk in
+and knit ~mode info tab (e : usubs) t stk =
+  let (ht,s) = knht ~mode info tab e t stk in
   knr info tab ht s
 
-and case_inversion info tab ci u params indices v =
+and knit_nonlexical_app ~mode info tab (e : usubs) h args stk =
+  let (ht,s) = knht_app ~mode ~lexical:false info tab e h args stk in
+  knr info tab ht s
+
+and case_inversion ~mode info tab ci u params indices v =
   let open Declarations in
   (* No binders / lets at all in the unique branch *)
   let v = match v with
@@ -1454,7 +1953,7 @@ and case_inversion info tab ci u params indices v =
   else
     let env = info_env info in
     let ind = ci.ci_ind in
-    let psubst = subs_consn params 0 ci.ci_npar (subs_id 0) in
+    let psubst = subs_consn params 0 ci.ci_npar (Esubst.subs_id 0) in
     let mib = Environ.lookup_mind (fst ind) env in
     let mip = mib.mind_packets.(snd ind) in
     (* indtyping enforces 1 ctor with no letins in the context *)
@@ -1464,7 +1963,7 @@ and case_inversion info tab ci u params indices v =
     let info = {info with i_cache = { info.i_cache with i_mode = Conversion}; i_flags=all} in
     let check_index i index =
       let expected = expect_args.(ci.ci_npar + i) in
-      let expected = mk_clos (psubst,u) expected in
+      let expected = mk_clos ~mode (psubst,u) expected in
       !conv info tab expected index
     in
     if Array.for_all_i check_index 0 indices
@@ -1480,58 +1979,66 @@ let kh info tab v stk = fapp_stack(kni info tab v stk)
       calls itself recursively. *)
 
 let is_val v = match v.term with
-| FAtom _ | FRel _   | FInd _ | FConstruct _ | FInt _ | FFloat _ -> true
-| FFlex _ -> v.mark == Ntrl
-| FApp _ | FProj _ | FFix _ | FCoFix _ | FCaseT _ | FCaseInvert _ | FLambda _
-| FProd _ | FLetIn _ | FEvar _ | FArray _ | FLIFT _ | FCLOS _ -> false
+| FAtom _ | FRel _   | FInd _ | FConstruct _ | FInt _ | FFloat _ | FBlock _ -> true
+| FFlex _ -> RedState.is_ntrl v.mark
+(* | FPrimitive _ -> v.mark == cstr *)
+| FApp _ | FProj _ | FFix _ | FCoFix _ | FCaseT _ | FCaseInvert _ | FLambda _ | FEta _
+| FProd _ | FLetIn _ | FEvar _ | FArray _ | FLIFT _ | FCLOS _ | FPrimitive _ | FLAZY _ -> false
 | FIrrelevant | FLOCKED -> assert false
 
 let rec kl info tab m =
   let share = info.i_cache.i_share in
-  if is_val m then term_of_fconstr m
+  if is_val m then term_of_fconstr ~info ~tab m
   else
     let (nm,s) = kni info tab m [] in
     let () = if share then ignore (fapp_stack (nm, s)) in (* to unlock Zupdates! *)
     zip_term info tab (norm_head info tab nm) s
 
-and klt info tab e t = match kind t with
+and klt ~mode info tab (e : usubs) t =
+  match kind t with
 | Rel i ->
-  begin match expand_rel i (fst e) with
-  | Inl (n, mt) -> kl info tab @@ lift_fconstr n mt
+  begin match Esubst.expand_rel i (fst e) with
+  | Inl (n, mt) ->
+    let m = lift_fconstr n mt in
+    (* [klt] is only called with [identity] when reducing under [block].
+       This means we are no longer reducing in head position.
+       Terms from a [normal_whnf] context need to be treated as inert. *)
+    if RedState.is_normal_whnf m.mark && mode == identity then m.mark <- RedState.mk (RedState.red_state m.mark) mode;
+    kl info tab m
   | Inr (k, None) -> if Int.equal k i then t else mkRel k
-  | Inr (k, Some p) -> kl info tab @@ lift_fconstr (k-p) {mark=Red;term=FFlex(RelKey p)}
+  | Inr (k, Some p) -> kl info tab @@ lift_fconstr (k-p) {mark=RedState.mk red mode;term=FFlex(RelKey p)}
   end
 | App (hd, args) ->
   begin match kind hd with
   | Ind _ | Construct _ ->
-    let args' = Array.Smart.map (fun c -> klt info tab e c) args in
+    let args' = Array.Smart.map (fun c -> klt ~mode info tab e c) args in
     let hd' = subst_instance_constr (snd e) hd in
     if hd' == hd && args' == args then t
     else mkApp (hd', args')
   | Var _ | Const _ | CoFix _ | Lambda _ | Fix _ | Prod _ | Evar _ | Case _
   | Cast _ | LetIn _ | Proj _ | Array _ | Rel _ | Meta _ | Sort _ | Int _ | Float _ ->
     let share = info.i_cache.i_share in
-    let (nm,s) = knit info tab e t [] in
+    let (nm,s) = knit ~mode info tab e t [] in
     let () = if share then ignore (fapp_stack (nm, s)) in (* to unlock Zupdates! *)
     zip_term info tab (norm_head info tab nm) s
   | App _ -> assert false
   end
 | Lambda (na, u, c) ->
   let na' = usubst_binder e na in
-  let u' = klt info tab e u in
-  let c' = klt (push_relevance info na') tab (usubs_lift e) c in
+  let u' = klt ~mode info tab e u in
+  let c' = klt ~mode (push_relevance info na') tab (usubs_lift e) c in
   if na' == na && u' == u && c' == c then t
   else mkLambda (na', u', c')
 | Prod (na, u, v) ->
   let na' = usubst_binder e na in
-  let u' = klt info tab e u in
-  let v' = klt (push_relevance info na') tab (usubs_lift e) v in
+  let u' = klt ~mode info tab e u in
+  let v' = klt ~mode (push_relevance info na') tab (usubs_lift e) v in
   if na' == na && u' == u && v' == v then t
   else mkProd (na', u', v')
-| Cast (t, _, _) -> klt info tab e t
+| Cast (t, _, _) -> klt ~mode info tab e t
 | Var _ | Const _ | CoFix _ | Fix _ | Evar _ | Case _ | LetIn _ | Proj _ | Array _ ->
   let share = info.i_cache.i_share in
-  let (nm,s) = knit info tab e t [] in
+  let (nm,s) = knit ~mode info tab e t [] in
   let () = if share then ignore (fapp_stack (nm, s)) in (* to unlock Zupdates! *)
   zip_term info tab (norm_head info tab nm) s
 | Meta _ | Sort _ | Ind _ | Construct _ | Int _ | Float _ -> subst_instance_constr (snd e) t
@@ -1539,40 +2046,46 @@ and klt info tab e t = match kind t with
 (* no redex: go up for atoms and already normalized terms, go down
    otherwise. *)
 and norm_head info tab m =
-  if is_val m then term_of_fconstr m else
-    match m.term with
+  if is_val m then term_of_fconstr ~info ~tab m else
+    let mode = RedState.mode m.mark in
+    match [@ocaml.warning "-4"] m.term with
+      | FEta(_,h,args,k,e) ->
+        let args = mk_eta_args args k in
+        mkApp(h, Array.map (klt ~mode:(RedState.mode m.mark) info tab e) args)
       | FLambda(_n,tys,f,e) ->
         let fold (e, info, ctxt) (na, ty) =
           let na = usubst_binder e na in
-          let ty = klt info tab e ty in
+          let ty = klt ~mode info tab e ty in
           let info = push_relevance info na in
           (usubs_lift e, info, (na, ty) :: ctxt)
         in
         let (e', info, rvtys) = List.fold_left fold (e,info,[]) tys in
-        let bd = klt info tab e' f in
+        let bd = klt ~mode:mode info tab e' f in
         List.fold_left (fun b (na,ty) -> mkLambda(na,ty,b)) bd rvtys
       | FLetIn(na,a,b,f,e) ->
           let na = usubst_binder e na in
-          let c = klt (push_relevance info na) tab (usubs_lift e) f in
+          let c = klt ~mode (push_relevance info na) tab (usubs_lift e) f in
           mkLetIn(na, kl info tab a, kl info tab b, c)
       | FProd(na,dom,rng,e) ->
         let na = usubst_binder e na in
-        let rng = klt (push_relevance info na) tab (usubs_lift e) rng in
+        let rng = klt ~mode (push_relevance info na) tab (usubs_lift e) rng in
           mkProd(na, kl info tab dom, rng)
       | FCoFix((n,(na,tys,bds)),e) ->
           let na = Array.Smart.map (usubst_binder e) na in
+          let num = (Array.length na) in
           let infobd = push_relevances info na in
-          let ftys = Array.map (fun ty -> klt info tab e ty) tys in
-          let fbds = Array.map (fun bd -> klt infobd tab (usubs_liftn (Array.length na) e) bd) bds in
+          let ftys = Array.map (fun ty -> klt ~mode:mode info tab e ty) tys in
+          let fbds = Array.map (fun bd -> klt ~mode:mode infobd tab (usubs_liftn num e) bd) bds in
           mkCoFix (n, (na, ftys, fbds))
       | FFix((n,(na,tys,bds)),e) ->
           let na = Array.Smart.map (usubst_binder e) na in
+          let num = (Array.length na) in
           let infobd = push_relevances info na in
-          let ftys = Array.map (fun ty -> klt info tab e ty) tys in
-          let fbds = Array.map (fun bd -> klt infobd tab (usubs_liftn (Array.length na) e) bd) bds in
+          let ftys = Array.map (fun ty -> klt ~mode:mode info tab e ty) tys in
+          let fbds = Array.map (fun bd -> klt ~mode:mode infobd tab (usubs_liftn num e) bd) bds in
           mkFix (n, (na, ftys, fbds))
       | FEvar(ev, args, env, repack) ->
-          repack (ev, List.map (fun a -> klt info tab env a) args)
+          repack (ev, List.map (fun a -> klt ~mode info tab env a) args)
       | FProj (p,r,c) ->
         mkProj (p, r, kl info tab c)
       | FArray (u, a, ty) ->
@@ -1581,27 +2094,33 @@ and norm_head info tab m =
         let def = kl info tab def in
         let ty = kl info tab ty in
         mkArray (u, a, def, ty)
+      | FPrimitive ((CPrimitives.Unblock | CPrimitives.Block | CPrimitives.Run), c, _, args) ->
+        mkApp (mkConstU c,
+               Array.mapi (fun i m -> if i <> 1 then kl info tab m else term_of_fconstr ~info ~tab m) args)
       | FLOCKED | FRel _ | FAtom _ | FFlex _ | FInd _ | FConstruct _
       | FApp _ | FCaseT _ | FCaseInvert _ | FLIFT _ | FCLOS _ | FInt _
-      | FFloat _ -> term_of_fconstr m
+      | FFloat _ | FBlock _ -> term_of_fconstr ~info ~tab m
+      | FLAZY _ -> assert false
       | FIrrelevant -> assert false (* only introduced when converting *)
+      | FPrimitive (_, _, _, _) -> assert false (* All other primitives should be fully reduced *)
 
-and zip_term info tab m stk = match stk with
+and zip_term info tab m stk =
+  match stk with
 | [] -> m
 | Zapp args :: s ->
     zip_term info tab (mkApp(m, Array.map (kl info tab) args)) s
-| ZcaseT(ci, u, pms, (p,r), br, e) :: s ->
+| ZcaseT(ci, u, pms, (p,r), br, e, mode) :: s ->
   let zip_ctx (nas, c) =
       let nas = Array.map (usubst_binder e) nas in
       let e = usubs_liftn (Array.length nas) e in
-      (nas, klt info tab e c)
+      (nas, klt ~mode info tab e c)
     in
     let r = usubst_relevance e r in
     let u = usubst_instance e u in
-    let t = mkCase(ci, u, Array.map (fun c -> klt info tab e c) pms, (zip_ctx p, r),
+    let t = mkCase(ci, u, Array.map (fun c -> klt ~mode info tab e c) pms, (zip_ctx p, r),
       NoInvert, m, Array.map zip_ctx br) in
     zip_term info tab t s
-| Zproj (p,r)::s ->
+| Zproj (p,r,_)::s ->
     let t = mkProj (Projection.make p true, r, m) in
     zip_term info tab t s
 | Zfix(fx,par)::s ->
@@ -1611,28 +2130,99 @@ and zip_term info tab m stk = match stk with
     zip_term info tab (lift n m) s
 | Zupdate(_rf)::s ->
     zip_term info tab m s
-| Zprimitive(_,c,rargs, kargs)::s ->
+| Zprimitive(_,c,_,rargs, kargs)::s ->
     let kargs = List.map (fun (_,a) -> kl info tab a) kargs in
     let args =
       List.fold_left (fun args a -> kl info tab a ::args) (m::kargs) rargs in
     let h = mkApp (mkConstU c, Array.of_list args) in
     zip_term info tab h s
+| Zunblock (op, ty, e, mode)::s ->
+    let ty = klt ~mode info tab e ty in
+    let h = Constr.mkApp (op, [|ty; m|]) in
+    zip_term info tab h s
+| Zrun (op, ty1, ty2, k, e, mode)::s ->
+    let ty1 = klt ~mode info tab e ty1 in
+    let ty2 = klt ~mode info tab e ty2 in
+    let k = klt ~mode info tab e k in
+    let m = term_of_fconstr ~info ~tab (mk_clos ~mode:normal_whnf e m) in (* TODO mode? see [Zunblock] above *)
+    let h = Constr.mkApp (op, [|ty1; ty2; m; k|]) in
+    zip_term info tab h s
 
 (* Initialization and then normalization *)
 
 (* weak reduction *)
-let whd_val info tab v = term_of_fconstr (kh info tab v [])
+let whd_val info tab v =
+  term_of_fconstr ~info ~tab (kh info tab v [])
 
 (* strong reduction *)
-let norm_val info tab v = kl info tab v
-let norm_term info tab e t = klt info tab e t
+let norm_val info tab v =
+  kl info tab v
+let norm_term ?(mode=normal_full) info tab e t =
+  klt ~mode info tab e t
 
-let whd_stack infos tab m stk = match m.mark with
-| Ntrl ->
+let rec set_mode ~mode (m : fconstr) =
+  let set_mode = set_mode ~mode in
+  let set_arr = Array.map set_mode in
+  let make term = { mark=RedState.mk (RedState.red_state m.mark) mode; term } in
+  match m.term with
+  | FRel _
+  | FAtom _
+  | FFlex _
+  | FInd _
+  | FConstruct _
+  | FLambda _
+  | FFix (_, _)
+  | FCoFix (_, _)
+  | FEvar (_, _, _, _)
+  | FInt _
+  | FFloat _
+  | FCLOS (_, _)
+  | FIrrelevant
+  | FLOCKED
+  | FBlock (_, _, _, _)
+  | FEta (_, _, _, _, _) -> { m with mark=RedState.mk (RedState.red_state m.mark) mode }
+
+  | FApp (h, args) ->
+    make (FApp(set_mode h, set_arr args))
+  | FProj (p, r, t) -> make (FProj(p, r, set_mode t))
+  | FCaseT (a, b, c, d, e, f, g) ->
+    let term = FCaseT(a,b,c,d,set_mode e,f,g) in
+    make term
+  | FCaseInvert (a, b, c, d, e, f, g, h) ->
+    let term = FCaseInvert(a,b,c,d,e,set_mode f,g,h) in
+    make term
+  | FProd (na, ty, bd, e) ->
+    make (FProd(na, set_mode ty, bd, e))
+  | FLetIn (na, ty, t, k, e) ->
+    make (FLetIn(na, set_mode ty, set_mode t, k, e))
+  | FArray (u, a, b) ->
+    make (FArray(u, Parray.map set_mode a, set_mode b))
+  | FLIFT (i, m) ->
+    make (FLIFT(i, set_mode m))
+  | FLAZY m ->
+    make (FLAZY (lazy (set_mode (Lazy.force m))))
+  | FPrimitive (_, _, _, _) ->
+    assert false
+
+
+let eval_lazy ~mode info tab m =
+  (* TODO: [mode] is ignored, only mode of [t] counts *)
+  let m = set_mode ~mode m in
+  let t = kl info tab m in
+  mk_clos ~mode (Esubst.subs_id 0, UVars.Instance.empty) t
+let _ = eval_lazy_ref := eval_lazy
+
+let _ = klt_ref := klt
+let _ = kl_ref := kl
+
+let whd_stack infos tab m stk =
+  match m.mark with
+| _ when RedState.is_ntrl m.mark ->
   (** No need to perform [kni] nor to unlock updates because
-      every head subterm of [m] is [Ntrl] *)
-  knh infos m stk
-| Red | Cstr ->
+      every head subterm of [m] is [ntrl] *)
+  let k = knh infos tab m stk in
+  k
+| _ ->
   let k = kni infos tab m stk in
   let () =
     if infos.i_cache.i_share then
@@ -1658,10 +2248,47 @@ let infos_with_reds infos reds =
   { infos with i_flags = reds }
 
 let unfold_ref_with_args infos tab fl v =
-  match Table.lookup infos tab fl with
+  match Table.lookup ~mode:normal_whnf infos tab fl with (* TODO mode *)
   | Def def -> Some (def, v)
   | Primitive op when check_native_args op v ->
-    let c = match [@ocaml.warning "-4"] fl with ConstKey c -> c | _ -> assert false in
-    let rargs, a, nargs, v = get_native_args1 op c v in
-    Some (a, (Zupdate a::(Zprimitive(op,c,rargs,nargs)::v)))
+    begin
+      let c = match [@ocaml.warning "-4"] fl with ConstKey c -> c | _ -> assert false in
+      match[@ocaml.warning "-4"] op with
+      | CPrimitives.Unblock | CPrimitives.Run | CPrimitives.Block ->
+        let (rargs, v) = match get_native_args ~mode:normal_whnf op c v with (* TODO mode *)
+          | ((rargs, nargs), v) ->
+            assert (nargs = []);
+            (rargs, v)
+        in
+        let mode = if op == CPrimitives.Block then identity else full in
+        let rargs = List.map (set_mode ~mode) rargs in
+        let args = mk_eta_args [||] (List.length rargs) in
+        let h = mkConstU c in
+        let e = usubs_consv (Array.rev_of_list rargs) (Esubst.subs_id 0, UVars.Instance.empty) in
+        let (m,stk) = knht_app ~mode ~lexical:true infos tab e h args v in
+        let res = knr infos tab m stk in
+        Some (res)
+      | _ ->
+      let m = {mark = RedState.mk cstr normal_whnf; term = FFlex fl } in (* TODO mode *)
+      match get_native_args ~mode:normal_whnf op c v with (* TODO mode *)
+      | ((rargs, (kd,a):: nargs), v) ->
+          assert (kd = CPrimitives.Kwhnf);
+          (* We must not use [zupdate] here since that puts [FLOCKED] into [a],
+             leading to assertion failures as soon as the term hits [knh]. *)
+          Some (a, (Zupdate a::(Zprimitive(op,c,m,rargs,nargs)::v)))
+      | ((rargs, []), v) ->
+          let args = Array.of_list (List.rev rargs) in
+          let (_,u) = c in
+          match FredNative.red_prim (info_env infos) () (infos, tab) op u args with
+          | FredNative.Result m -> Some (m, v)
+          | FredNative.Error -> assert false
+          | FredNative.Progress (_, args) ->
+          Some ({mark = RedState.mk red normal_whnf; term = FPrimitive(op,c,m,args) }, v) (* TODO mode *)
+    end
   | Undef _ | OpaqueDef _ | Primitive _ -> None
+
+let inductive_subst = inductive_subst ~mode:normal_whnf
+let inject = inject ~mode:normal_whnf
+let unfold_projection = unfold_projection ~mode:normal_whnf
+let mk_clos = mk_clos ~mode:normal_whnf
+let mk_clos_vect = mk_clos_vect ~mode:normal_whnf

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -59,6 +59,10 @@ type fterm =
     (* operator, constr def, primitive as an fconstr, full array of suitably evaluated arguments *)
   | FBlock of constr * constr * constr * usubs
     (* @block as a constr, its type as a constr, the contents of the block *)
+  | FUnblock of constr * constr * fconstr * usubs
+  (* [{term=Funblock(op, ty, m, e);mode=mode}] is a representation of [Zunblock(op,ty,e,mode)] zipped with [m] *)
+  | FRun of constr * constr * constr * fconstr * constr * usubs
+  (* [{term=FRun(op, ty1, ty2, m, cnt, e);mode=mode}] is a representation of [Zrun(op,ty1,ty2,cnt,e,mode)] zipped with [m] *)
   | FEta of int * constr * constr array * int * usubs
   (* [FEta (n, h, args, m, e)], represents [FCLOS (mkApp (h, Array.append args [|#1 ... #m|]), e)]. *)
   | FLAZY of fconstr Lazy.t

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -73,7 +73,6 @@ module [@ocaml.warning "-32"] RedState : sig
   type [@ocaml.immediate] mode
   type [@ocaml.immediate] red_state
 
-
   val ntrl : red_state
   val cstr : red_state
   val red  : red_state
@@ -82,30 +81,6 @@ module [@ocaml.warning "-32"] RedState : sig
   val normal_full : mode
   val full        : mode
   val identity    : mode
-
-  val neutr : t -> t
-
-  val mk : red_state -> mode -> t
-  val red_state : t -> red_state
-  val mode : t -> mode
-
-  val is_red : t -> bool
-  val is_cstr : t -> bool
-  val is_ntrl : t -> bool
-  val set_red : t -> t
-  val set_cstr : t -> t
-  val set_ntrl : t -> t
-  val neutr : t -> t
-  val is_normal_whnf : t -> bool
-  val is_normal_full : t -> bool
-  val is_full : t -> bool
-  val is_identity : t -> bool
-  val set_normal_whnf : t -> t
-  val set_normal_full : t -> t
-  val set_full : t -> t
-  val set_identity : t -> t
-  val copy_red : t -> t -> t
-  val copy_mode : t -> t -> t
 end
 
 open RedState

--- a/kernel/cPrimitives.mli
+++ b/kernel/cPrimitives.mli
@@ -64,6 +64,9 @@ type t =
   | Arrayset
   | Arraycopy
   | Arraylength
+  | Run
+  | Block
+  | Unblock
 
 (** Can raise [Not_found].
     Beware that this is not exactly the reverse of [to_string] below. *)
@@ -99,6 +102,7 @@ type 'a prim_type =
   | PT_int63 : unit prim_type
   | PT_float64 : unit prim_type
   | PT_array : (UVars.Instance.t * ind_or_type) prim_type
+  | PT_blocked : (UVars.Instance.t * ind_or_type) prim_type
 
 and 'a prim_ind =
   | PIT_bool : unit prim_ind
@@ -111,7 +115,8 @@ and 'a prim_ind =
 and ind_or_type =
   | PITT_ind : 'a prim_ind * 'a -> ind_or_type
   | PITT_type : 'a prim_type * 'a -> ind_or_type
-  | PITT_param : int -> ind_or_type (* DeBruijn index referring to prenex type quantifiers *)
+  | PITT_param : int * int list -> ind_or_type (* DeBruijn index of prenex type quantifier applied to variables (given by their index as well). *)
+  | PITT_prod : Names.Name.t Context.binder_annot * ind_or_type * ind_or_type -> ind_or_type (* Dependent product *)
 
 val typ_univs : 'a prim_type -> UVars.AbstractContext.t
 
@@ -141,7 +146,7 @@ val parse_op_or_type : ?loc:Loc.t -> string -> op_or_type
 
 val univs : t -> UVars.AbstractContext.t
 
-val types : t -> Constr.rel_context * ind_or_type list * ind_or_type
+val types : t -> Constr.rel_context * (Names.Name.t Context.binder_annot * ind_or_type) list * ind_or_type
 (** Parameters * Reduction relevant arguments * output type
 
   XXX we could reify universes in ind_or_type (currently polymorphic types

--- a/kernel/conversion.ml
+++ b/kernel/conversion.ml
@@ -796,7 +796,8 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
      (* Should not happen because both (hd1,v1) and (hd2,v2) are in whnf *)
      | ( (FLetIn _, _) | (FCaseT _,_) | (FApp _,_) | (FCLOS _,_) | (FLIFT _,_)
        | (_, FLetIn _) | (_,FCaseT _) | (_,FApp _) | (_,FCLOS _) | (_,FLIFT _)
-       | (FLOCKED,_) | (_,FLOCKED) | (FLAZY _, _) | (_, FLAZY _)) -> assert false
+       | (FLOCKED,_) | (_,FLOCKED) | (FLAZY _, _) | (_, FLAZY _)
+       | (FUnblock _,_) | (_,FUnblock _) | (FRun _, _) | (_, FRun _)) -> assert false
 
      | (FRel _ | FAtom _ | FInd _ | FFix _ | FCoFix _ | FCaseInvert _
        | FProd _ | FEvar _ | FInt _ | FFloat _ | FArray _ | FIrrelevant

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -576,10 +576,18 @@ let is_array_type env c =
   | None -> false
   | Some c' -> Constant.CanOrd.equal c c'
 
+let is_blocked_type env c =
+  match env.retroknowledge.Retroknowledge.retro_blocked with
+  | None -> false
+  | Some c' -> Constant.CanOrd.equal c c'
+
 let is_primitive_type env c =
   (* dummy match to force an update if we add a primitive type *)
-  let _ = function CPrimitives.(PTE(PT_int63)) | CPrimitives.(PTE(PT_float64)) | CPrimitives.(PTE(PT_array)) -> () in
-  is_int63_type env c || is_float64_type env c || is_array_type env c
+  let _ =
+    let open CPrimitives in
+    function PTE(PT_int63) | PTE(PT_float64) | PTE(PT_array) | PTE(PT_blocked) -> ()
+  in
+  is_int63_type env c || is_float64_type env c || is_array_type env c || is_blocked_type env c
 
 let polymorphic_constant cst env =
   Declareops.constant_is_polymorphic (lookup_constant cst env)

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -238,6 +238,7 @@ val constant_opt_value_in : env -> Constant.t puniverses -> constr option
 val is_primitive : env -> Constant.t -> bool
 val get_primitive : env -> Constant.t -> CPrimitives.t option
 
+val is_blocked_type : env -> Constant.t -> bool
 val is_array_type : env -> Constant.t -> bool
 val is_int63_type : env -> Constant.t -> bool
 val is_float64_type : env -> Constant.t -> bool

--- a/kernel/esubst.ml
+++ b/kernel/esubst.ml
@@ -260,6 +260,24 @@ let rec lift_subst mk e s = match s with
   let rem = lift_subst mk e rem in
   Cons (h, t, rem)
 
+let rec subs_of_lift (l : lift) : 'a subs =
+  match l with
+  | ELID -> Nil (0, 0)
+  | ELSHFT (l, n) -> subs_shft (n, (subs_of_lift l))
+  | ELLFT (n, l) -> subs_liftn n (subs_of_lift l)
+
+let rec map_subst (f : 'a -> 'b) (s : 'a subs) : 'b subs =
+  match s with
+  | Nil (n, m) -> Nil (n, m)
+  | Cons (n, t, s) -> Cons (n, tree_map f t, map_subst f s)
+and tree_map (f : 'a -> 'b) (t : 'a tree) : 'b tree =
+  match t with
+  | Leaf (n, Arg (a)) -> Leaf (n, Arg (f a))
+  | Leaf (n, Var (k)) -> Leaf (n, Var (k))
+  | Node (i, av, l, r, j) ->
+    let av = match av with | Arg (a) -> Arg (f a) | Var (k) -> Var (k) in
+    Node (i, av, tree_map f l, tree_map f r, j)
+
 module Internal =
 struct
 

--- a/kernel/esubst.mli
+++ b/kernel/esubst.mli
@@ -106,6 +106,10 @@ val is_lift_id : lift -> bool
 *)
 val lift_subst : (lift -> 'a -> 'b) -> lift -> 'a subs -> 'b subs
 
+val map_subst : ('a -> 'b) -> 'a subs -> 'b subs
+
+val subs_of_lift : lift -> 'a subs
+
 val eq_lift : lift -> lift -> bool
 (** Equality for lifts *)
 

--- a/kernel/genOpcodeFiles.ml
+++ b/kernel/genOpcodeFiles.ml
@@ -155,6 +155,9 @@ let opcodes =
     "CHECKCAMLCALL1", 2;
     "CHECKCAMLCALL2", 2;
     "CHECKCAMLCALL3_1", 2;
+    "RUN", 2;
+    "BLOCK", 1;
+    "UNBLOCK", 1;
     "STOP", 0
   |]
 

--- a/kernel/inferCumulativity.ml
+++ b/kernel/inferCumulativity.ml
@@ -265,7 +265,8 @@ let rec infer_fterm cv_pb infos variances hd stk =
   | FBlock _ -> assert false (* TODO *)
 
   (* Removed by whnf *)
-  | FLOCKED | FCaseT _ | FLetIn _ | FApp _ | FLIFT _ | FCLOS _ | FEta _ | FLAZY _ -> assert false
+  | FLOCKED | FCaseT _ | FLetIn _ | FApp _ | FLIFT _ | FCLOS _ | FEta _
+  | FUnblock _ | FRun _ | FLAZY _ -> assert false
   | FIrrelevant -> assert false (* TODO: use create_conv_infos below and use it? *)
 
 and infer_stack infos variances (stk:CClosure.stack) =

--- a/kernel/nativecode.ml
+++ b/kernel/nativecode.ml
@@ -1088,7 +1088,7 @@ let extract_prim env ml_of l =
   let cond = ref [] in
   let type_args p =
     let params, args_ty, _ = CPrimitives.types p in
-    List.length params, Array.of_list args_ty in
+    List.length params, Array.of_list (List.map snd args_ty) in
   let rec aux l =
     match l with
     | Lprim (kn, p, args) ->
@@ -1173,6 +1173,7 @@ let compile_prim env decl cond paux =
           | CPrimitives.PT_float64 -> Is_float
           | CPrimitives.PT_array -> Is_parray
           | CPrimitives.PT_int63 -> assert false
+          | CPrimitives.PT_blocked -> assert false (* FIXME? *)
           in
            List.fold_left
              (fun ml (_, c) -> app_prim MLand [| ml; app_prim check [|c|]|])

--- a/kernel/redFlags.mli
+++ b/kernel/redFlags.mli
@@ -55,6 +55,7 @@ val mkflags : red_kind list -> reds
 
 (** Tests if a reduction kind is set *)
 val red_set : reds -> red_kind -> bool
+[@ocaml.inline always]
 
 (** This tests if the projection is in unfolded state already or is unfodable
     due to delta. *)

--- a/kernel/retroknowledge.ml
+++ b/kernel/retroknowledge.ml
@@ -20,6 +20,7 @@ type retroknowledge = {
     retro_int63 : Constant.t option;
     retro_float64 : Constant.t option;
     retro_array : Constant.t option;
+    retro_blocked : Constant.t option;
     retro_bool : (constructor * constructor) option; (* true, false *)
     retro_carry : (constructor * constructor) option; (* C0, C1 *)
     retro_pair : constructor option;
@@ -41,6 +42,7 @@ let empty = {
     retro_int63 = None;
     retro_float64 = None;
     retro_array = None;
+    retro_blocked = None;
     retro_bool = None;
     retro_carry = None;
     retro_pair = None;

--- a/kernel/retroknowledge.mli
+++ b/kernel/retroknowledge.mli
@@ -14,6 +14,7 @@ type retroknowledge = {
     retro_int63 : Constant.t option;
     retro_float64 : Constant.t option;
     retro_array : Constant.t option;
+    retro_blocked : Constant.t option;
     retro_bool : (constructor * constructor) option; (* true, false *)
     retro_carry : (constructor * constructor) option; (* C0, C1 *)
     retro_pair : constructor option;

--- a/kernel/typeops.mli
+++ b/kernel/typeops.mli
@@ -118,6 +118,9 @@ val judge_of_float : env -> Float64.t -> unsafe_judgment
 val type_of_array : env -> UVars.Instance.t -> types
 val judge_of_array : env -> UVars.Instance.t -> unsafe_judgment array -> unsafe_judgment -> unsafe_judgment
 
+val type_of_blocked : env -> UVars.Instance.t -> types
+(*val judge_of_blocked : env -> Univ.Instance.t -> unsafe_judgment -> unsafe_judgment*)
+
 val type_of_prim_type : env -> UVars.Instance.t -> 'a CPrimitives.prim_type -> types
 val type_of_prim : env -> UVars.Instance.t -> CPrimitives.t -> types
 val type_of_prim_or_type : env -> UVars.Instance.t -> CPrimitives.op_or_type -> types

--- a/kernel/vmemitcodes.ml
+++ b/kernel/vmemitcodes.ml
@@ -303,6 +303,9 @@ let check_prim_op = function
   | Float64next_down  -> opCHECKNEXTDOWNFLOAT
   | Arraymake | Arrayget | Arrayset | Arraydefault | Arraycopy | Arraylength ->
     assert false
+  | Run -> opRUN
+  | Block -> opBLOCK
+  | Unblock -> opUNBLOCK
 
 let check_caml_prim_op = function
 | CAML_Arraymake -> opCHECKCAMLCALL2_1

--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -22,8 +22,11 @@ exception Elimconst
 val debug_RAKAM : CDebug.t
 
 module CredNative : Primred.RedNative with
-  type elem = EConstr.t and type args = EConstr.t array and type evd = Evd.evar_map
-  and type uinstance = EInstance.t
+  type elem = EConstr.t and
+  type args = EConstr.t array and
+  type evd = Evd.evar_map and
+  type lazy_info = Environ.env * Evd.evar_map * RedFlags.reds and
+  type uinstance = EInstance.t
 
 (** Machinery to customize the behavior of the reduction *)
 module ReductionBehaviour : sig

--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -351,7 +351,7 @@ and nf_telescope env sigma len f typ =
     match fterm_of typ with
     | FProd (na, dom, codom, e) ->
       let arg = f i in
-      let dom = term_of_fconstr dom in
+      let dom = term_of_fconstr ~info:infos ~tab dom in
       let arg = nf_val env sigma arg dom in
       let () = t := mk_clos (CClosure.usubs_cons (inject arg) e) codom in
       arg
@@ -364,7 +364,9 @@ and nf_args env sigma vargs ?from:(f=0) t =
   let len = nargs vargs - f in
   let fargs i = arg vargs (f + i) in
   let typ, args = nf_telescope env sigma len fargs t in
-  CClosure.term_of_fconstr typ, args
+  let info = Evarutil.create_clos_infos env sigma RedFlags.all in
+  let tab = CClosure.create_tab () in
+  CClosure.term_of_fconstr ~info ~tab typ, args
 
 and nf_bargs env sigma b ofs t =
   let len = bsize b - ofs in

--- a/test-suite/success/bench_reduction.v
+++ b/test-suite/success/bench_reduction.v
@@ -1,0 +1,327 @@
+(** * One-Step Reduction *)
+(** We have the following criteria:
+
+   - Performance Criterion: 1-step delta on k constants should
+     Õ(output term size)
+
+   - Performance Criterion: 1-step iota should be Õ(output term size)
+
+   - Performance Criterion: 1-step beta on k arguments of the same
+     application node where each argument is mentioned multiple times
+     should be Õ(input term size + output term size) *)
+
+(** These are quite hard to benchmark.  Ultimately this is because Coq
+    doesn't expose a satisfactory one-step reduction. (But maybe you
+    claim the thing to do is to just bench the version that we can
+    hack up in Coq, even when we know most of the time isn't spent in
+    the single step of reduction?) I think it's hard to construct them
+    in a way where you're actually benching the single step. If we do
+    it via Ltac match + constr hacks, I expect we incur overhead in
+    retypechecking and Ltac matching (I suppose I might be wrong, but
+    we'd have to be dealing with truly enormous terms before we expect
+    one-step reduction to take more than 0.0004 seconds (Coq can only
+    measure down to 0.001). Alternatively, we could do a non-one-step
+    reduction when there's only one step to do, but it's not clear to
+    me to what extent this is benching what we want to
+    bench. Alternatively we could try to bench a conversion problem
+    where there's just one step of reduction to do, but again I think
+    we'll end up just measuring the conversation overhead. *)
+
+Notation "'subst!' v 'for' x 'in' f" := (match v with x => f end) (only parsing, at level 200).
+
+Ltac uconstr_beta1 term :=
+  lazymatch term with
+  | ((fun x => ?f) ?v) => uconstr:(subst! v for x in f)
+  end.
+
+Ltac uconstr_zeta1 term :=
+  lazymatch term with
+  | (let x := ?v in ?f) => uconstr:(subst! v for x in f)
+  end.
+
+Ltac beta1 term :=
+  lazymatch term with
+  | ((fun x => ?f) ?v) => constr:(subst! v for x in f)
+  end.
+
+Ltac zeta1 term :=
+  lazymatch term with
+  | (let x := ?v in ?f) => constr:(subst! v for x in f)
+  end.
+
+(** The easiest thing to do is to check conversion problems, and check
+    full β/ι/ζ/δ in cases where there's only one step to do. *)
+
+(** We can construct a term that is expensive to typecheck, and use it
+    in places where we want to see whether or not we're incuring
+    retypechecking. *)
+
+Fixpoint fact (n : nat) := match n with 0 => 1 | S n' => n * fact n' end.
+Fixpoint walk (n : nat) : unit := match n with 0 => tt | S n => walk n end.
+Definition skip (n : nat) : unit := tt.
+Inductive value := the (A : Type) (_ : A).
+Arguments the : clear implicits.
+Notation slown n := (the (walk (fact n) = tt) (eq_refl tt)) (only parsing).
+Time Definition slow := slown 9.
+(* Finished transaction in 1.069 secs (1.052u,0.016s) (successful) *)
+Notation fastn n := (the (skip (fact n) = tt) (eq_refl tt)) (only parsing).
+Definition fast := fastn 9.
+Axiom Ax_fst : forall {A B}, A * B -> A.
+Axiom Ax_snd : forall {A B}, A * B -> B.
+Fixpoint big_tree {A} (v : A) (n : nat) : A
+  := match n with
+     | 0 => Ax_fst (v, v)
+     | S n => big_tree (Ax_fst (v, v)) n
+     end.
+Definition big_slow (n : nat) := Eval cbv [big_tree] in big_tree slow n.
+Definition big_fast (n : nat) := Eval cbv [big_tree] in big_tree fast n.
+(** Tell conversion to unfold [slow] and [fast] early, so that we
+    don't run the risk of trying to unfold [fact] during conversion
+    when we don't want to. *)
+Strategy -10 [slow fast].
+
+Ltac test_slow with_abstract n :=
+  optimize_heap;
+  let v := (eval cbv [big_slow] in (big_slow n)) in
+  restart_timer;
+  let v2 := (eval cbv delta [slow] in v) in
+  finish_timing ("Tactic call δ-1-slow");
+  time "unify-slow" unify v v2;
+  lazymatch with_abstract with
+  | true => let __ := constr:(ltac:(time "abstract-unify-slow" abstract exact_no_check (eq_refl v)) : v = v2) in
+            idtac
+  | false => idtac
+  end.
+
+Ltac test_fast with_abstract n :=
+  optimize_heap;
+  let v := (eval cbv [big_fast] in (big_fast n)) in
+  restart_timer;
+  let v2 := (eval cbv delta [fast] in v) in
+  finish_timing ("Tactic call δ-1-fast");
+  time "unify-fast" unify v v2;
+  lazymatch with_abstract with
+  | true => let __ := constr:(ltac:(time "abstract-unify-fast" abstract exact_no_check (eq_refl v)) : v = v2) in
+            idtac
+  | false => idtac
+  end.
+(* Goal True. *)
+(*   idtac 1; test_slow true 1; test_fast true 1; *)
+(*     idtac 2; test_slow true 2; test_fast true 2; *)
+(*       idtac 14; test_slow false 14; test_fast false 14; *)
+(*         idtac 15; test_slow false 15; test_fast false 15. *)
+(* Abort. *)
+(* 1
+Tactic call δ-1-slow ran for 0. secs (0.u,0.s)
+Tactic call unify-slow ran for 0. secs (0.u,0.s) (success)
+Tactic call abstract-unify-slow ran for 2.003 secs (2.003u,0.s) (success)
+Tactic call δ-1-fast ran for 0. secs (0.u,0.s)
+Tactic call unify-fast ran for 0. secs (0.u,0.s) (success)
+Tactic call abstract-unify-fast ran for 0. secs (0.u,0.s) (success)
+2
+Tactic call δ-1-slow ran for 0. secs (0.u,0.s)
+Tactic call unify-slow ran for 0. secs (0.u,0.s) (success)
+Tactic call abstract-unify-slow ran for 4.125 secs (4.125u,0.s) (success)
+Tactic call δ-1-fast ran for 0. secs (0.u,0.s)
+Tactic call unify-fast ran for 0. secs (0.u,0.s) (success)
+Tactic call abstract-unify-fast ran for 0. secs (0.u,0.s) (success)
+14
+Tactic call δ-1-slow ran for 0.051 secs (0.051u,0.s)
+Tactic call unify-slow ran for 0.579 secs (0.579u,0.s) (success)
+Tactic call δ-1-fast ran for 0.051 secs (0.051u,0.s)
+Tactic call unify-fast ran for 0.594 secs (0.594u,0.s) (success)
+15
+Tactic call δ-1-slow ran for 0.106 secs (0.106u,0.s)
+Tactic call unify-slow ran for 1.326 secs (1.302u,0.023s) (success)
+Tactic call δ-1-fast ran for 0.106 secs (0.107u,0.s)
+Tactic call unify-fast ran for 1.364 secs (1.356u,0.007s) (success)
+*)
+
+(** Now we set up a similar test for β reduction, using variants with
+    1 and 2 arguments. *)
+Fixpoint big_tree2 (n : nat) {A} (v1 v2 : A) : A
+  := match n with
+     | 0 => Ax_fst (v1, v2)
+     | S n => big_tree2 n (Ax_fst (v1, v2)) (Ax_snd (v1, v2))
+     end.
+Definition big_slow_beta1 (n : nat) := Eval cbv [big_tree2 slow] in id (fun v => big_tree2 n v v) slow.
+Definition big_fast_beta1 (n : nat) := Eval cbv [big_tree2 fast] in id (fun v => big_tree2 n v v) fast.
+Definition big_slow_beta2 (n : nat) := Eval cbv [big_tree2 slow] in id (big_tree2 n) slow slow.
+Definition big_fast_beta2 (n : nat) := Eval cbv [big_tree2 fast] in id (big_tree2 n) fast fast.
+
+Ltac beta_id v :=
+  lazymatch v with
+  | id ?f ?x => constr:(f x)
+  | id ?f ?x ?y => constr:(f x y)
+  end.
+
+Ltac test_slow1 with_abstract n :=
+  optimize_heap;
+  let v := (eval cbv [big_slow_beta1] in (big_slow_beta1 n)) in
+  let v := beta_id v in
+  restart_timer;
+  let v2 := (eval cbv beta in v) in
+  finish_timing ("Tactic call β-1-slow1");
+  time "unify-slow1" unify v v2;
+  lazymatch with_abstract with
+  | true => let __ := constr:(ltac:(time "abstract-unify-slow1" abstract exact_no_check (eq_refl v)) : v = v2) in
+            idtac
+  | false => idtac
+  end.
+
+Ltac test_slow2 with_abstract n :=
+  optimize_heap;
+  let v := (eval cbv [big_slow_beta2] in (big_slow_beta2 n)) in
+  let v := beta_id v in
+  restart_timer;
+  let v2 := (eval cbv beta in v) in
+  finish_timing ("Tactic call β-1-slow2");
+  time "unify-slow2" unify v v2;
+  lazymatch with_abstract with
+  | true => let __ := constr:(ltac:(time "abstract-unify-slow2" abstract exact_no_check (eq_refl v)) : v = v2) in
+            idtac
+  | false => idtac
+  end.
+
+Ltac test_fast1 with_abstract n :=
+  optimize_heap;
+  let v := (eval cbv [big_fast_beta1] in (big_fast_beta1 n)) in
+  let v := beta_id v in
+  restart_timer;
+  let v2 := (eval cbv beta in v) in
+  finish_timing ("Tactic call β-1-fast1");
+  time "unify-fast1" unify v v2;
+  lazymatch with_abstract with
+  | true => let __ := constr:(ltac:(time "abstract-unify-fast1" abstract exact_no_check (eq_refl v)) : v = v2) in
+            idtac
+  | false => idtac
+  end.
+
+Ltac test_fast2 with_abstract n :=
+  optimize_heap;
+  let v := (eval cbv [big_fast_beta2] in (big_fast_beta2 n)) in
+  let v := beta_id v in
+  restart_timer;
+  let v2 := (eval cbv beta in v) in
+  finish_timing ("Tactic call β-1-fast2");
+  time "unify-fast2" unify v v2;
+  lazymatch with_abstract with
+  | true => let __ := constr:(ltac:(time "abstract-unify-fast2" abstract exact_no_check (eq_refl v)) : v = v2) in
+            idtac
+  | false => idtac
+  end.
+(* Goal True. *)
+(*   idtac 1; test_slow1 true 1; test_fast1 true 1; test_slow2 true 1; test_fast2 true 1; *)
+(*     idtac 2; test_slow1 true 2; test_fast1 true 2; test_slow2 true 2; test_fast2 true 2; *)
+(*       idtac 14; test_slow1 false 14; test_fast1 false 14; test_slow2 false 14; test_fast2 false 14; *)
+(*         idtac 15; test_slow1 false 15; test_fast1 false 15; test_slow2 false 15; test_fast2 false 15. *)
+(* Abort. *)
+(* 1
+Tactic call β-1-slow1 ran for 0. secs (0.u,0.s)
+Tactic call unify-slow1 ran for 0. secs (0.u,0.s) (success)
+Tactic call abstract-unify-slow1 ran for 3.062 secs (3.062u,0.s) (success)
+Tactic call β-1-fast1 ran for 0. secs (0.u,0.s)
+Tactic call unify-fast1 ran for 0. secs (0.u,0.s) (success)
+Tactic call abstract-unify-fast1 ran for 0. secs (0.u,0.s) (success)
+Tactic call β-1-slow2 ran for 0. secs (0.u,0.s)
+Tactic call unify-slow2 ran for 0. secs (0.u,0.s) (success)
+Tactic call abstract-unify-slow2 ran for 4.096 secs (4.096u,0.s) (success)
+Tactic call β-1-fast2 ran for 0. secs (0.u,0.s)
+Tactic call unify-fast2 ran for 0. secs (0.u,0.s) (success)
+Tactic call abstract-unify-fast2 ran for 0. secs (0.u,0.s) (success)
+2
+Tactic call β-1-slow1 ran for 0. secs (0.u,0.s)
+Tactic call unify-slow1 ran for 0. secs (0.u,0.s) (success)
+Tactic call abstract-unify-slow1 ran for 5.15 secs (5.15u,0.s) (success)
+Tactic call β-1-fast1 ran for 0. secs (0.u,0.s)
+Tactic call unify-fast1 ran for 0. secs (0.u,0.s) (success)
+Tactic call abstract-unify-fast1 ran for 0. secs (0.u,0.s) (success)
+Tactic call β-1-slow2 ran for 0. secs (0.u,0.s)
+Tactic call unify-slow2 ran for 0. secs (0.u,0.s) (success)
+Tactic call abstract-unify-slow2 ran for 6.177 secs (6.173u,0.003s) (success)
+Tactic call β-1-fast2 ran for 0. secs (0.u,0.s)
+Tactic call unify-fast2 ran for 0. secs (0.u,0.s) (success)
+Tactic call abstract-unify-fast2 ran for 0.001 secs (0.001u,0.s) (success)
+14
+Tactic call β-1-slow1 ran for 0.046 secs (0.046u,0.s)
+Tactic call unify-slow1 ran for 0.576 secs (0.576u,0.s) (success)
+Tactic call β-1-fast1 ran for 0.046 secs (0.046u,0.s)
+Tactic call unify-fast1 ran for 0.592 secs (0.592u,0.s) (success)
+Tactic call β-1-slow2 ran for 0.047 secs (0.047u,0.s)
+Tactic call unify-slow2 ran for 0.589 secs (0.589u,0.s) (success)
+Tactic call β-1-fast2 ran for 0.049 secs (0.049u,0.s)
+Tactic call unify-fast2 ran for 0.624 secs (0.624u,0.s) (success)
+15
+Tactic call β-1-slow1 ran for 0.097 secs (0.097u,0.s)
+Tactic call unify-slow1 ran for 1.319 secs (1.303u,0.015s) (success)
+Tactic call β-1-fast1 ran for 0.098 secs (0.098u,0.s)
+Tactic call unify-fast1 ran for 1.322 secs (1.306u,0.016s) (success)
+Tactic call β-1-slow2 ran for 0.098 secs (0.098u,0.s)
+Tactic call unify-slow2 ran for 1.331 secs (1.327u,0.003s) (success)
+Tactic call β-1-fast2 ran for 0.098 secs (0.098u,0.s)
+Tactic call unify-fast2 ran for 1.348 secs (1.348u,0.s) (success)
+*)
+
+(** Now we set up a similar test for ζ reduction, using variants with
+    1 and 2 arguments. *)
+Definition big_slow_zeta1 (n : nat) := Eval cbv beta iota delta [big_tree2 slow] in let v := slow in big_tree2 n v v.
+Definition big_fast_zeta1 (n : nat) := Eval cbv beta iota delta [big_tree2 fast] in let v := fast in big_tree2 n v v.
+Definition big_slow_zeta2 (n : nat) := Eval cbv beta iota delta [big_tree2 slow] in let v1 := slow in let v2 := slow in big_tree2 n v1 v2.
+Definition big_fast_zeta2 (n : nat) := Eval cbv beta iota delta [big_tree2 fast] in let v1 := fast in let v2 := fast in big_tree2 n v1 v2.
+
+Ltac test_slow_zeta1 with_abstract n :=
+  optimize_heap;
+  let v := (eval cbv beta iota delta [big_slow_zeta1] in (big_slow_zeta1 n)) in
+  restart_timer;
+  let v2 := (eval cbv zeta in v) in
+  finish_timing ("Tactic call ζ-1-slow1");
+  time "unify-slow1" unify v v2;
+  lazymatch with_abstract with
+  | true => let __ := constr:(ltac:(time "abstract-unify-slow1" abstract exact_no_check (eq_refl v)) : v = v2) in
+            idtac
+  | false => idtac
+  end.
+
+Ltac test_slow_zeta2 with_abstract n :=
+  optimize_heap;
+  let v := (eval cbv beta iota delta [big_slow_zeta2] in (big_slow_zeta2 n)) in
+  restart_timer;
+  let v2 := (eval cbv zeta in v) in
+  finish_timing ("Tactic call ζ-2-slow2");
+  time "unify-slow2" unify v v2;
+  lazymatch with_abstract with
+  | true => let __ := constr:(ltac:(time "abstract-unify-slow2" abstract exact_no_check (eq_refl v)) : v = v2) in
+            idtac
+  | false => idtac
+  end.
+
+Ltac test_fast_zeta1 with_abstract n :=
+  optimize_heap;
+  let v := (eval cbv beta iota delta [big_fast_zeta1] in (big_fast_zeta1 n)) in
+  restart_timer;
+  let v2 := (eval cbv zeta in v) in
+  finish_timing ("Tactic call ζ-1-fast1");
+  time "unify-fast1" unify v v2;
+  lazymatch with_abstract with
+  | true => let __ := constr:(ltac:(time "abstract-unify-fast1" abstract exact_no_check (eq_refl v)) : v = v2) in
+            idtac
+  | false => idtac
+  end.
+
+Ltac test_fast_zeta2 with_abstract n :=
+  optimize_heap;
+  let v := (eval cbv beta iota delta [big_fast_zeta2] in (big_fast_zeta2 n)) in
+  restart_timer;
+  let v2 := (eval cbv zeta in v) in
+  finish_timing ("Tactic call ζ-2-fast2");
+  time "unify-fast2" unify v v2;
+  lazymatch with_abstract with
+  | true => let __ := constr:(ltac:(time "abstract-unify-fast2" abstract exact_no_check (eq_refl v)) : v = v2) in
+            idtac
+  | false => idtac
+  end.
+
+Goal True.
+  Optimize Heap.
+  Instructions idtac 4; test_slow_zeta1 true 4; test_fast_zeta1 true 4; test_slow_zeta2 true 4; test_fast_zeta2 true 4.
+Abort.

--- a/test-suite/success/bench_to_constr.v
+++ b/test-suite/success/bench_to_constr.v
@@ -1,0 +1,20 @@
+From Coq Require Import Nat.
+Fixpoint fac (n : nat) : nat :=
+  match n return nat with
+  | O | S O => n
+  | S n => mult (S n) (fac n)
+  end.
+
+From Ltac2 Require Import Ltac2.
+Ltac2 red_flags_all : Std.red_flags := {
+  Std.rBeta  := true;
+  Std.rDelta := true;
+  Std.rMatch := true;
+  Std.rFix   := true;
+  Std.rCofix := true;
+  Std.rZeta  := true;
+  Std.rConst := []
+}.
+Optimize Heap.
+Instructions Ltac2 Eval
+  let t := Std.eval_lazy_whnf red_flags_all '(fac 3) in ().

--- a/test-suite/success/bench_to_constr.v
+++ b/test-suite/success/bench_to_constr.v
@@ -13,8 +13,9 @@ Ltac2 red_flags_all : Std.red_flags := {
   Std.rFix   := true;
   Std.rCofix := true;
   Std.rZeta  := true;
-  Std.rConst := []
+  Std.rConst := [];
+  Std.rStrength := Std.Head;
 }.
 Optimize Heap.
 Instructions Ltac2 Eval
-  let t := Std.eval_lazy_whnf red_flags_all '(fac 3) in ().
+  let t := Std.eval_lazy red_flags_all '(fac 3) in ().

--- a/test-suite/success/force.v
+++ b/test-suite/success/force.v
@@ -13,7 +13,7 @@ Definition check_unblock@{u} : forall (T : Type@{u}), Blocked@{u} T -> T := @unb
 
 Ltac syn_refl := lazymatch goal with |- ?t = ?t => exact eq_refl end.
 Notation LAZY t := (ltac:(let x := eval lazy in t in exact x)) (only parsing).
-Notation WHNF t := (ltac:(let x := eval lazywhnf  in t in exact x)) (only parsing).
+Notation WHNF t := (ltac:(let x := eval lazy head in t in exact x)) (only parsing).
 
 Goal LAZY (@block) = @block.
 Proof. syn_refl. Qed.
@@ -263,7 +263,7 @@ Module FunctionTypes.
   Inductive D := | d.
   Inductive R := | r (b: D).
   Definition id (x:Set) := x.
-  Eval lazywhnf in @unblock R (let f := (fun x : id (id R) => block x) in @block R (@unblock R (f (r d)))).
+  Eval lazy head in @unblock R (let f := (fun x : id (id R) => block x) in @block R (@unblock R (f (r d)))).
 End FunctionTypes.
 
 Module Conversion.

--- a/test-suite/success/force.v
+++ b/test-suite/success/force.v
@@ -1,0 +1,288 @@
+(* To run: [dune build theories/Force && dune exec -- dev/shim/coqc test.v] *)
+
+Require Import Force.Force.
+
+(**** UNIVERSES ****)
+
+Definition check_run@{u1 u2} : forall (T : Type@{u1}) (K : Type@{u2}), Blocked T -> (T -> K) -> K := @run.
+Definition check_Blocked@{u} : Type@{u} -> Type@{u} := Blocked.
+Definition check_block@{u} : forall (T : Type@{u}), T -> Blocked@{u} T := @block.
+Definition check_unblock@{u} : forall (T : Type@{u}), Blocked@{u} T -> T := @unblock.
+
+(**** EVALUATION ****)
+
+Ltac syn_refl := lazymatch goal with |- ?t = ?t => exact eq_refl end.
+Notation LAZY t := (ltac:(let x := eval lazy in t in exact x)) (only parsing).
+Notation WHNF t := (ltac:(let x := eval lazywhnf  in t in exact x)) (only parsing).
+
+Goal LAZY (@block) = @block.
+Proof. syn_refl. Qed.
+
+Goal WHNF (@block) = @block.
+Proof. syn_refl. Qed.
+
+Goal LAZY (@block nat) = @block nat.
+Proof. syn_refl. Qed.
+
+Goal WHNF (@block nat) = @block nat.
+Proof. syn_refl. Qed.
+
+Goal WHNF (@block (id nat)) = @block (id nat).
+Proof. syn_refl. Qed.
+
+Goal LAZY (@block (id nat)) = @block nat.
+Proof. syn_refl. Qed.
+
+Goal WHNF (block 0) = block 0.
+Proof. syn_refl. Qed.
+
+Goal LAZY (block 0) = block 0.
+Proof. syn_refl. Qed.
+
+Goal WHNF (block (0 + 0)) = block (0 + 0).
+Proof. syn_refl. Qed.
+
+Goal LAZY (block (0 + 0)) = block (0 + 0).
+Proof. syn_refl. Qed.
+
+Goal WHNF (id (block (0 + 0))) = block (0 + 0).
+Proof. syn_refl. Qed.
+
+Goal LAZY (id (block (0 + 0))) = block (0 + 0).
+Proof. syn_refl. Qed.
+
+Goal WHNF (block (unblock (let x := 0 + 0 in block x))) = block 0.
+Proof. syn_refl. Qed.
+
+(* ... *)
+
+Goal LAZY ((fun f => f (1 + 1)) block) = block 2.
+Proof. syn_refl. Qed.
+
+Goal LAZY ((fun f => f (1 + 1)) (fun x => block x)) = block 2.
+Proof. syn_refl. Qed.
+
+Goal WHNF ((fun f => f (1 + 1)) block) = block (1+1).
+Proof. syn_refl. Qed.
+
+Goal WHNF ((fun f => f (1 + 1)) (fun x => block x)) = block (1 + 1).
+Proof. syn_refl. Qed.
+
+Inductive True := I.
+Definition id : True -> True := fun x => x.
+
+Definition g := fun x:True => x.
+Definition h := fun x:True => x.
+Axiom and : True -> True -> True.
+Axiom Pr : True -> Prop.
+
+(* Non-lexical unblock is just a "projection" *)
+Goal WHNF ((fun f => f (block (id I = id I))) unblock) = (id I = id I).
+Proof. syn_refl. Qed.
+
+(* Non-lexical run is just a "projection" *)
+Goal WHNF ((fun f => f (block (id I = id I)) (fun x => x)) run) = (id I = id I).
+Proof. syn_refl. Qed.
+
+Goal WHNF (block (unblock (let x := (and (g I) (h I)) in block x))) = (block (and I I)).
+Proof. syn_refl. Qed.
+
+Goal WHNF (unblock (let x := (fun x : id I = I => True) in block x)) = (fun x : I = I => True).
+Proof. syn_refl. Qed.
+
+Goal WHNF (unblock (let x := forall x : id I = I, True in block x)) = (forall x : I = I, True).
+Proof. syn_refl. Qed.
+
+Goal WHNF (unblock (let x := id I in block (forall u:unit, x = x))) = (forall (u:unit), I = I).
+Proof. syn_refl. Qed.
+
+Goal WHNF (unblock (let x := 1 + 1 in block x)) = 2.
+Proof. syn_refl. Qed.
+
+Goal WHNF (run (block (1+1)) (fun x => x)) = WHNF (match 1 + 1 with S x => S x | 0 => 0 end).
+Proof. syn_refl. Qed.
+
+Goal WHNF (block (run (let n := I in block n) (fun x : True => x)))
+        = (block (run (let n := I in block n) (fun x : True => x))).
+Proof. syn_refl. Qed.
+
+Goal WHNF (block (run (let x := (fun x => x) tt in block x) (fun x => x)))
+        = (block (run (let x := (fun x => x) tt in block x) (fun x => x))).
+Proof. syn_refl. Qed.
+
+Goal WHNF (block (unblock (let x := (fun x => x) tt in block x))) = block tt.
+Proof. syn_refl. Qed.
+
+(*
+block (unblock (let x := (fun x => x) tt in block x)) @ ε | ∅ --{whnf}-->
+block @ (unblock (let x := (fun x => x) tt in block x)) . ε | ∅ --{whnf}-->
+
+  unblock (let x := (fun x => x) tt in block x) @ ε | ∅ --{id}-->
+  unblock @ (let x := (fun x => x) tt in block x) . ε | ∅ --{id}-->
+
+    let x := (fun x => x) tt in block x @ ε | ∅ --{full}-->
+    block x @ ε | ∅[x{full} := <(fun x => x) tt, ∅>] --{full}-->
+
+      x @ ε | ∅[x{full} := <(fun x => x) tt, ∅>] --{id}-->
+
+        (λ x => x) tt @ ε | ∅ --{full}-->
+        λ x => x @ tt . ε | ∅ --{full}-->
+        x @ ε | ∅[x{full} := <tt, ∅>] --{full}-->
+
+          tt @ ε | ∅ --{full}--> (value)
+
+        tt @ ε | ∅[x{full} := <tt, ∅>] --{full}--> (value)
+
+      tt @ ε | ∅[x{full} := <tt, ∅>] --{id}--> (value, updated closure)
+
+    block tt @ ε | ∅[x{full} := <tt, ∅>] --{full}-->
+
+  unblock @ block tt . ε | ∅ --{id}-->
+  tt @ ε | ∅ --{id}-->
+
+block @ tt . ε | ∅ --{whnf}--> (done)
+*)
+
+Goal WHNF (block (run (let n := 2 + 2 in block n) (fun x : nat => 2 * 1)))
+        = (block (run (let n := 2 + 2 in block n) (fun x : nat => 2 * 1))).
+        (* = (block ((fun _ : nat => 2 * 1) 4)). *)
+Proof. syn_refl. Qed.
+
+Goal WHNF (block (run ((fun n => block n) (2 + 2)) (fun x : nat => 2 * 1)))
+        = (block (run ((fun n => block n) (2 + 2)) (fun x : nat => 2 * 1))).
+        (* = (block ((fun _ : nat => 2 * 1) 4)). *)
+Proof. syn_refl. Qed.
+
+Inductive n := N | O.
+Definition a (x y : n) :=
+  match x with
+  | N => y
+  | O => O
+  end.
+Goal WHNF (block (unblock ((fun x => block (a x O)) (a N N)))) = block (a N O).
+Proof. syn_refl. Qed.
+
+Goal WHNF (block (unblock ((fun x => block x) (a N N)))) = block (N).
+Proof. syn_refl. Qed.
+
+Goal WHNF (block (run ((fun n => block (n + 1)) (2 + 2)) (fun x : nat => 2 * 1)))
+        = (block (run ((fun n => block (n + 1)) (2 + 2)) (fun x : nat => 2 * 1))).
+        (* = (block ((fun _ : nat => 2 * 1) (4 + 1))). *)
+Proof. syn_refl. Qed.
+
+Goal WHNF (block (unblock (let n := 0 + 0 in block (n + n))))
+        = block (0 + 0).
+Proof. syn_refl. Qed.
+
+Goal WHNF (block (unblock (let n := 0 + 0 in block (1 + unblock (let m := 0 + 0 in block (1 + m))))))
+        = block (1 + (1 + 0)).
+Proof. syn_refl. Qed.
+
+Goal WHNF (block (unblock (
+                      let n := 0 + 0 in
+                      block (1 + n + unblock (
+                                     let m := 2 + 2 in
+                                     block (1 + m + unblock (
+                                                        let k := 3 + 3 in
+                                                        block (1 + n + m + k))))))))
+        = block (1 + 0 + (1 + 4 + (1 + 0 + 4 + 6))).
+Proof. syn_refl. Qed.
+
+Goal LAZY (run (block (1 + 1)) (fun x => x + x)) = 4.
+Proof. syn_refl. Qed.
+
+Goal LAZY (run (block (1 + 1)) (fun x => x + x)) = 4.
+Proof. syn_refl. Qed.
+
+Goal LAZY (run (block (1 + 1)) (fun x => x + x)) = 4.
+Proof. syn_refl. Qed.
+
+Goal LAZY (block (2 + 2)) = block (2 + 2).
+Proof. syn_refl. Qed.
+
+Goal LAZY (unblock (block 42)) = 42.
+Proof. syn_refl. Qed.
+
+Goal LAZY (unblock (block (2 + 2))) = 4.
+Proof. syn_refl. Qed.
+
+Goal LAZY (unblock ((fun _ => block (2 + 2)) tt)) = 4.
+Proof. syn_refl. Qed.
+
+Goal LAZY (block (fun x => (2 + 2) + x)) = block (fun x => (2 + 2) + x).
+Proof. syn_refl. Qed.
+
+Goal LAZY (unblock (block (fun x => (2 + 2) + x))) = fun x => S (S (S (S x))).
+Proof. syn_refl. Qed.
+
+Goal WHNF (run (let x := 1 + 1 in block (x + 1)) (fun x => forall y, y = x))
+        = forall y, y = 2 + 1.
+Proof. syn_refl. Qed.
+
+Set Printing Width 1000.
+Section AllArgs.
+  Context (b : Blocked (nat -> nat)).
+
+  Goal LAZY (unblock b 0) = unblock b 0.
+  Proof. syn_refl. Qed.
+
+  Goal WHNF (unblock b 0) = unblock b 0.
+  Proof. syn_refl. Qed.
+
+  Goal LAZY (run b (fun x n => n) 0) = run b (fun x n => n) 0.
+  Proof. syn_refl. Qed.
+
+  Goal WHNF (run b (fun x n => n) 0) = run b (fun x n => n) 0.
+  Proof. syn_refl. Qed.
+End AllArgs.
+
+Goal LAZY (unblock (block (fun x => block x)) (0 + 0)) = block (0).
+Proof. syn_refl. Qed.
+
+Goal WHNF (unblock (block (fun x => block x)) (0 + 0)) = block (0 + 0).
+Proof. syn_refl. Qed.
+
+Goal LAZY (run (block (fun x => block x)) (fun f x => f x) (0 + 0)) = block (0).
+Proof. syn_refl. Qed.
+
+Goal WHNF (run (block (fun x => block x)) (fun f x => f x) (0 + 0)) = block (0 + 0).
+Proof. syn_refl. Qed.
+
+Axiom F : run (let x := id I in block (id x)) (fun x => forall y, y = x).
+Goal I=I.
+  Succeed refine (F I).
+  Succeed apply (F I).
+  Succeed eapply (F I).
+  Succeed exact (F I).
+  Succeed eexact (F I).
+  exact (F I).
+Qed.
+
+Module FunctionTypes.
+  (* The example below should not call reduction on [id id R] _at all_! *)
+  Inductive D := | d.
+  Inductive R := | r (b: D).
+  Definition id (x:Set) := x.
+  Eval lazywhnf in @unblock R (let f := (fun x : id (id R) => block x) in @block R (@unblock R (f (r d)))).
+End FunctionTypes.
+
+Module Conversion.
+  Axiom not : Prop -> Prop.
+  Axiom TODO: forall {A:Prop}, A.
+
+  Lemma test p :
+    (forall _ : True, @unblock Prop (block (not p))).
+    exact (@TODO (forall _ : True, not p)).
+  Qed.
+End Conversion.
+
+Module Bla.
+  Inductive prop :=.
+  Axiom TODO: forall {A}, A.
+  Definition reflect (p:prop) : Blocked Prop := match p with end.
+  Lemma simplify_ok (p : prop) : False <-> unblock (reflect p).
+  Proof.
+    lazy.                       (* Used to fail *)
+    destruct p.
+  Qed.
+End Bla.

--- a/test-suite/success/force.v
+++ b/test-suite/success/force.v
@@ -286,3 +286,19 @@ Module Bla.
     destruct p.
   Qed.
 End Bla.
+
+(* Double substitution due to [Zrun] *)
+Module Ind.
+  Axiom P : nat -> Blocked Prop.
+  Axiom x : nat.
+  Axiom nat_ind_2 : forall P : nat -> Prop, (forall n : nat, True -> P (S n)) -> forall n : nat, P n.
+
+  Goal forall n, (run (P n) (fun p => p)).
+  Proof.
+    refine (@nat_ind_2 (fun n => run (P n) (fun p => p)) _).
+    intros n IHn.
+    (* [Zrun]'s substitution was re-applied to the head in [zip_term] leading to wrong [REL]s. *)
+    Fail lazymatch goal with |- context [P (S IHn)] => idtac end.
+    lazymatch goal with |- context [P (S n)] => idtac end.
+  Abort.
+End Ind.

--- a/test-suite/success/realsimpl.v
+++ b/test-suite/success/realsimpl.v
@@ -291,24 +291,22 @@ Proof.
   - (* Z *)
     reflexivity.
   - (* unary *)
-    simpl. rewrite IHa. reflexivity. (* FIXME should use lazy *)
+    simpl. fold interpret_R. rewrite IHa. reflexivity. (* FIXME should use lazy *)
   - (* binary *)
-    simpl. rewrite IHa, IHb. reflexivity. (* FIXME should use lazy *)
-  - (* pow *) simpl; rewrite IHa; reflexivity. (* FIXME should use lazy *)
+    simpl. fold interpret_R. rewrite IHa, IHb. reflexivity. (* FIXME should use lazy *)
+  - (* pow *) simpl; fold interpret_R. rewrite IHa; reflexivity. (* FIXME should use lazy *)
 Qed.
 
 (** The interpretation of a term before and after simplification is equal in ℝ *)
-
 Lemma simplify_R_correct: forall (e : Expr_R),
   interpret_R e = interpret_R (simplify_R e).
 Proof.
   intros e; induction e as [q|r|z|f a IHa|f a IHa b IHb|a IHa b].
   - (* Q *) reflexivity.
   - (* R *) reflexivity.
-  - (* Z *) lazy; unfold Q2R; f_equal; cbn; ltac1:(lra).
+  - (* Z *) lazy. f_equal; (progress (unfold Q2R)); f_equal; cbn; ltac1:(lra).
   - (* unary *) cbn.
-    destruct (simplify_R a); rewrite IHa; try reflexivity.
-    cbn.
+    destruct (simplify_R a); fold interpret_R; rewrite IHa; cbn; try reflexivity.
     destruct f; cbn; lazy [block unblock].
     + rewrite Qreals.Q2R_opp; reflexivity.
     + destruct (Z.eqb_spec (Qnum q) 0) as [Heq|Hneq]; cbn; lazy [block unblock].
@@ -318,8 +316,8 @@ Proof.
         unfold Qeq; cbn.
         ltac1:(lia).
   - (* binary *) cbn.
-    destruct (simplify_R a) as [qa| | | | |]; rewrite IHa;
-    destruct (simplify_R b) as [qb| | | | |]; rewrite IHb; try reflexivity.
+    destruct (simplify_R a) as [qa| | | | |]; fold interpret_R; rewrite IHa;
+    destruct (simplify_R b) as [qb| | | | |]; fold interpret_R; rewrite IHb; cbn; try reflexivity.
     cbn; lazy [block unblock].
     destruct f; cbn; lazy [block unblock].
     + rewrite Qreals.Q2R_plus; reflexivity.
@@ -334,7 +332,7 @@ Proof.
     + rewrite Q2R_max; reflexivity.
     + rewrite Q2R_min; reflexivity.
   - (* Pow *) cbn.
-    destruct (simplify_R a); rewrite IHa; try reflexivity.
+    destruct (simplify_R a); fold interpret_R; rewrite IHa; try reflexivity.
     destruct b; cbn; lazy [block unblock]; try reflexivity.
     f_equal.
     apply Q2R_pow.

--- a/test-suite/success/realsimpl.v
+++ b/test-suite/success/realsimpl.v
@@ -1,0 +1,463 @@
+(* Contents copied and adapted from
+   https://github.com/coq-community/metaprogramming-rosetta-stone/blob/48e92067d6c8170a996c42ed88b221bd7ab4ebbd/real_simplifier/ltac2_reflexive/theories/RealSimpl.v
+*)
+
+
+
+(** * Reflexive tactic to compute real expressions using Q arithmetic *)
+
+(** This is similar to field_simplify, but
+    - it handles min and max
+    - it is easier to extend with additional functions which are computable in Q (like modulus)
+    - it does not change the term structure except for computation (which can be an advantage or disadvantage)
+
+    A few notes:
+    - this is a reflexive tactic, which means the relevant context (a ℝ term) is converted to a gallina data structure and the
+      majority of the work (the simplification and computation) is done by gallina functions
+    - the advantage of reflexive tactics is that one can prove upfront that the transformations done by gallina functions are correct
+    - in this case this means the equality of the original and simplified term is proven by application of a generic lemma
+    - this is much faster than constructing and type checking equality lemmas for individual cases
+    - reflexive tactics typically have these components:
+      - a reification tactic which converts the relevant context to an AST in gallina
+      - an interpretation tactic which converts the AST back to the original term (the inverse of reification)
+      - some processing function on the AST (written in gallina)
+      - a proof that the processing function has certain properties (in this case preserves equality in ℝ of the interpretation of the AST)
+      - a wrapper tactic, which does the reification, posts the above proof, computes in the type of the proof and applies this in some form
+    - this specific instance of a reflexive tactic takes a short cut:
+      - terms which are not "understood" by the tactic, say variables or unknown functions are copied literally
+      - not converting the handled terms fully to an AST type and relying on computation with explicit delta lists is "quick and dirty" but quite effective
+      - the correctness proofs tend to be substantially more complicated if some form of context management is required
+      - the down side of this method is that if the user supplied term or context does contain symbols of the domain the tactic computes in (ℚ, ℤ, pos in this case)
+        the terms can blow up
+      - to avoid this one option is to copy the Q, Z and Pos functions used and use these copies (assuming that these copies do not occur in the user supplied term)
+
+    Caveats:
+    - this tactic does ℚ, ℤ and Pos computation on parts of the supplied term
+    - if the term includes computations with variables in these domains, the term might explode
+*)
+
+Require Import Reals.
+Require Import ZArith.
+Require Import QArith.
+Require Import Lra.
+Require Import Lia.
+Require Import Ltac2.Ltac2.
+Require Import Ltac2.Printf.
+Require Import Ltac2.Bool.
+Require Import Force.Force.
+
+(** ** Definition of the AST *)
+
+Inductive Expr_UnaryOp :=
+  | EU_Opp
+  | EU_Inv
+.
+
+Inductive Expr_BinaryOp :=
+  | EB_Add
+  | EB_Sub
+  | EB_Mul
+  | EB_Div
+  | EB_Max
+  | EB_Min
+.
+
+(** For a nat value we need only two variants - something we can compute and something we can't (like a variable) *)
+
+Inductive Expr_N : Set :=
+  | EN_lit  : nat -> Expr_N (* This is used for everything we can evaluate *)
+  | EN_gen  : Blocked nat -> Expr_N (* This is used for everything we cannot evaluate *)
+.
+
+Inductive Expr_R : Set :=
+  | ER_Q      : Q -> Expr_R (* This is used for everything we can evaluate *)
+  | ER_R      : Blocked R -> Expr_R (* This is used for everything we cannot evaluate *)
+  | ER_Z      : Z -> Expr_R (* We could use Q for Z, but then interpretation would not be an inverse of reification *)
+  | ER_Unary  : Expr_UnaryOp -> Expr_R -> Expr_R
+  | ER_Binary : Expr_BinaryOp -> Expr_R -> Expr_R -> Expr_R
+  | ER_Pow    : Expr_R -> Expr_N -> Expr_R
+.
+
+(** ** Interpretation and simplification functions for ℕ *)
+
+(** For ℕ this is trivial, since it anyway computes *)
+
+Definition interpret_N (e : Expr_N) : Blocked nat :=
+  match e with
+  | EN_lit n => block n
+  | EN_gen n => n
+  end.
+
+(** ** Interpretation and simplification functions for ℝ *)
+
+(** Return the ℝ function corresponding to an unary operator *)
+
+Definition unary_fun_R (f : Expr_UnaryOp) : Blocked (R->R) :=
+  match f with
+  | EU_Opp => block Ropp
+  | EU_Inv => block Rinv
+  end.
+
+(** Return the ℝ function corresponding to a binary operator *)
+
+Definition binary_fun_R (f : Expr_BinaryOp) : Blocked (R->R->R) :=
+  match f with
+  | EB_Add => block Rplus
+  | EB_Sub => block Rminus
+  | EB_Mul => block Rmult
+  | EB_Div => block Rdiv
+  | EB_Max => block Rmax
+  | EB_Min => block Rmin
+  end.
+
+(** Return the ℚ function corresponding to an unary operator *)
+
+Definition unary_fun_Q (f : Expr_UnaryOp) : Blocked (Q->Q) :=
+  match f with
+  | EU_Opp => block Qopp
+  | EU_Inv => block Qinv
+  end.
+
+(** Return the ℚ function corresponding to a binary operator *)
+
+Definition binary_fun_Q (f : Expr_BinaryOp) : Blocked (Q->Q->Q) :=
+  match f with
+  | EB_Add => block Qplus
+  | EB_Sub => block Qminus
+  | EB_Mul => block Qmult
+  | EB_Div => block Qdiv
+  | EB_Max => block Qminmax.Qmax
+  | EB_Min => block Qminmax.Qmin
+  end.
+
+(** Check if the argument of an unary operator is valid (that is not inversion of 0) *)
+
+Definition unary_check_args_Q (f : Expr_UnaryOp) (a : Q) : bool :=
+  match f with
+  | EU_Inv => negb ((Qnum a) =? 0)%Z
+  | _ => true
+  end.
+
+(** Check if the arguments of a binary operator are valid (that is not division by 0) *)
+
+Definition binary_check_args_Q (f : Expr_BinaryOp) (a b : Q) : bool :=
+  match f with
+  | EB_Div => negb ((Qnum b) =? 0)%Z
+  | _ => true
+  end.
+
+(** Interpret an AST, that is convert it back to a ℝ term - this function and the reification tactic must be inverse *)
+
+Fixpoint interpret_R (e : Expr_R) : Blocked R :=
+  match e with
+  | ER_Q q => block (Q2R q)
+  | ER_R r => r
+  | ER_Z z => block (IZR z)
+  | ER_Unary f a => block ((unblock (unary_fun_R f)) (unblock (interpret_R a)))
+  | ER_Binary f a b => block ((unblock (binary_fun_R f)) (unblock (interpret_R a)) (unblock (interpret_R b)))
+  | ER_Pow a b => block (pow (unblock (interpret_R a)) (unblock (interpret_N b)))
+  end.
+
+(** Simplify an AST by computation using ℚ arithmetic *)
+
+Fixpoint simplify_R (e : Expr_R) : Expr_R :=
+  match e with
+  | ER_Q q => ER_Q q
+  | ER_R r => ER_R r
+  | ER_Z z => ER_Q (z#1)
+  | ER_Unary f a =>
+    let a':=simplify_R a in
+    match a' with
+    | ER_Q aq =>
+      if unary_check_args_Q f aq
+      then ER_Q (unblock (unary_fun_Q f) aq)
+      else ER_Unary f a'
+    | _ => ER_Unary f a'
+    end
+  | ER_Binary f a b =>
+    let a':=simplify_R a in
+    let b':=simplify_R b in
+    match a', b' with
+    | ER_Q aq, ER_Q bq =>
+      if binary_check_args_Q f aq bq
+      then ER_Q (unblock (binary_fun_Q f) aq bq)
+      else ER_Binary f a' b'
+    | _, _ => ER_Binary f a' b'
+    end
+  | ER_Pow a b =>
+    let a':=simplify_R a in
+    match a', b with
+    | ER_Q aq, EN_lit bn => ER_Q (Qpower aq (Z.of_nat bn))
+    | _, _ => ER_Pow a' b
+    end
+end.
+
+(** Convert resulting "Q2R (n#d)" terms to quotients of integers in ℝ - or an integer if the denominator is 1 *)
+
+(* ToDo: do reduction of Q as well *)
+
+Fixpoint cleanup_R (e : Expr_R) : Expr_R :=
+  match e with
+  | ER_Q (z # 1) => ER_Z z
+  | ER_Q (n # d) => ER_Binary EB_Div (ER_Z n) (ER_Z (Z.pos d))
+  | ER_R r => e
+  | ER_Z z => e
+  | ER_Unary f a => ER_Unary f (cleanup_R a)
+  | ER_Binary f a b => ER_Binary f (cleanup_R a) (cleanup_R b)
+  | ER_Pow a b => ER_Pow (cleanup_R a) b
+  end.
+
+(** ** Proofs that the simplification and cleanup functions are correct *)
+
+(** *** ℚ ℝ arithmetic equivalence lemmas missing in the standard library *)
+
+Lemma Q2R_max: forall x y : Q,
+  Q2R (Qminmax.Qmax x y) = Rmax (Q2R x) (Q2R y).
+Proof.
+  intros x y.
+  destruct (Qlt_le_dec x y) as [Hlt|Hle].
+  - rewrite Qminmax.Q.max_r, Rmax_right.
+    + reflexivity.
+    + apply Qreals.Qle_Rle, Qlt_le_weak, Hlt.
+    + apply Qlt_le_weak, Hlt. (* Not sure why lra doesn't work here *)
+  - rewrite Qminmax.Q.max_l, Rmax_left.
+    + reflexivity.
+    + apply Qreals.Qle_Rle, Hle.
+    + apply Hle.
+Qed.
+
+Lemma Q2R_min: forall x y : Q,
+  Q2R (Qminmax.Qmin x y) = Rmin (Q2R x) (Q2R y).
+Proof.
+  intros x y.
+  destruct (Qlt_le_dec x y) as [Hlt|Hle].
+  - rewrite Qminmax.Q.min_l, Rmin_left.
+    + reflexivity.
+    + apply Qreals.Qle_Rle, Qlt_le_weak, Hlt.
+    + apply Qlt_le_weak, Hlt.
+  - rewrite Qminmax.Q.min_r, Rmin_right.
+    + reflexivity.
+    + apply Qreals.Qle_Rle, Hle.
+    + apply Hle.
+Qed.
+
+Lemma Qpower_nat_succ: forall (x : Q) (n : nat),
+  Qpower x (Z.of_nat (S n)) = x * Qpower x (Z.of_nat n).
+Proof.
+  (* This is a bit tedious because most lemmas about Q use == instead of =, but we want = here *)
+  intros x n.
+  induction n.
+  - cbn. unfold Qmult. cbn.
+    rewrite Z.mul_1_r, Pos.mul_1_r.
+    destruct x as [n d].
+    reflexivity.
+  - cbn.
+    unfold Qpower_positive.
+    rewrite pow_pos_succ.
+    + reflexivity.
+    + apply Eqsth.
+    + unfold Proper, respectful; intros; subst; reflexivity.
+    + intros a b c. unfold Qmult. destruct a, b, c. cbn.
+      rewrite Z.mul_assoc.
+      rewrite Pos.mul_assoc.
+      reflexivity.
+Qed.
+
+Lemma Q2R_pow: forall (x : Q) (n : nat),
+  (Q2R x ^ n)%R = Q2R (x ^ Z.of_nat n).
+Proof.
+  intros x n.
+  induction n.
+  - cbn. unfold Q2R. cbn. ltac1:(lra).
+  - rewrite Qpower_nat_succ. cbn.
+    rewrite Qreals.Q2R_mult.
+    rewrite IHn.
+    reflexivity.
+Qed.
+
+(** *** Correctness lemmas for ℝ*)
+
+(** The interpretation of a term before and after cleanup_R is equal in ℝ *)
+
+Lemma cleanup_R_correct: forall (e : Expr_R),
+  unblock (interpret_R e) = unblock (interpret_R (cleanup_R e)).
+Proof.
+  intros e; induction e as [q|r|z|f a IHa|f a IHa b IHb|a IHa b].
+  - (* Q *)
+    destruct q as [n d]; destruct d; try (lazy; reflexivity).
+    unfold Q2R; lazy; ltac1:(lra).
+  - (* R *)
+    reflexivity.
+  - (* Z *)
+    reflexivity.
+  - (* unary *)
+    simpl. rewrite IHa. reflexivity. (* FIXME should use lazy *)
+  - (* binary *)
+    simpl. rewrite IHa, IHb. reflexivity. (* FIXME should use lazy *)
+  - (* pow *) simpl; rewrite IHa; reflexivity. (* FIXME should use lazy *)
+Qed.
+
+(** The interpretation of a term before and after simplification is equal in ℝ *)
+
+Lemma simplify_R_correct: forall (e : Expr_R),
+  interpret_R e = interpret_R (simplify_R e).
+Proof.
+  intros e; induction e as [q|r|z|f a IHa|f a IHa b IHb|a IHa b].
+  - (* Q *) reflexivity.
+  - (* R *) reflexivity.
+  - (* Z *) lazy; unfold Q2R; f_equal; cbn; ltac1:(lra).
+  - (* unary *) cbn.
+    destruct (simplify_R a); rewrite IHa; try reflexivity.
+    cbn.
+    destruct f; cbn; lazy [block unblock].
+    + rewrite Qreals.Q2R_opp; reflexivity.
+    + destruct (Z.eqb_spec (Qnum q) 0) as [Heq|Hneq]; cbn; lazy [block unblock].
+      * reflexivity.
+      * rewrite Qreals.Q2R_inv.
+        1: reflexivity.
+        unfold Qeq; cbn.
+        ltac1:(lia).
+  - (* binary *) cbn.
+    destruct (simplify_R a) as [qa| | | | |]; rewrite IHa;
+    destruct (simplify_R b) as [qb| | | | |]; rewrite IHb; try reflexivity.
+    cbn; lazy [block unblock].
+    destruct f; cbn; lazy [block unblock].
+    + rewrite Qreals.Q2R_plus; reflexivity.
+    + rewrite Qreals.Q2R_minus; reflexivity.
+    + rewrite Qreals.Q2R_mult; reflexivity.
+    + destruct (Z.eqb_spec (Qnum qb) 0) as [Heq|Hneq]; cbn; lazy [block unblock].
+      * reflexivity.
+      * rewrite Qreals.Q2R_div.
+        1: reflexivity.
+        unfold Qeq; cbn; lazy [block unblock].
+        ltac1:(lia).
+    + rewrite Q2R_max; reflexivity.
+    + rewrite Q2R_min; reflexivity.
+  - (* Pow *) cbn.
+    destruct (simplify_R a); rewrite IHa; try reflexivity.
+    destruct b; cbn; lazy [block unblock]; try reflexivity.
+    f_equal.
+    apply Q2R_pow.
+Qed.
+
+(** The interpretation of a term before and after simplification and cleanup_R is equal in ℝ *)
+
+Lemma cleanup_simplify_R_correct: forall (e : Expr_R),
+  run (block (unblock (interpret_R e) = unblock (interpret_R (cleanup_R (simplify_R e))))) (fun x => x).
+Proof.
+  intros e.
+  rewrite <- cleanup_R_correct.
+  rewrite <- simplify_R_correct.
+  reflexivity.
+Qed.
+
+(** ** Reification and main tactic *)
+
+(** *** Debugging *)
+
+(** These notations are intended to wrap printf and can be defined to t() or () to enable / disable the prints.
+    dbg1 is for low verbosity output, dbg2 for high verbosity output *)
+
+Ltac2 Notation "dbg1" t(thunk(tactic(6))) := ().
+Ltac2 Notation "dbg2" t(thunk(tactic(6))) := ().
+
+(** *** Term classification *)
+
+(** Check if "val" is a literal positive *)
+
+Ltac2 rec is_literal_positive (val : constr) : bool :=
+  lazy_match! val with
+  | xI ?sub => is_literal_positive sub
+  | xO ?sub => is_literal_positive sub
+  | xH => true
+  | _ => false
+  end.
+
+(** Check if "val" is a literal ℤ *)
+
+Ltac2 is_literal_Z (val : constr) : bool :=
+  lazy_match! val with
+  | Z0 => true
+  | Zpos ?pos => is_literal_positive pos
+  | Zneg ?pos => is_literal_positive pos
+  | _ => false
+  end.
+
+(** Check if "val" is a literal ℚ *)
+
+Ltac2 is_literal_Q (val : constr) : bool :=
+  lazy_match! val with
+  | (?n # ?d)%Q => is_literal_Z n && is_literal_positive d
+  | _ => false
+  end.
+
+(** Check if "val" is a computable nat *)
+
+Ltac2 rec is_computable_nat (val : constr) : bool :=
+  lazy_match! val with
+  | (?a + ?b)%nat => is_computable_nat a && is_computable_nat b
+  | (?a - ?b)%nat => is_computable_nat a && is_computable_nat b
+  | (?a * ?b)%nat => is_computable_nat a && is_computable_nat b
+  | S ?a => is_computable_nat a
+  | O => true
+  | _ => false
+  end.
+
+(** *** Reification *)
+
+(** This converts a term in ℝ to a Expr_R AST structure - this tactic and "interpret_R" must be inverse to each other *)
+
+(** Note: we can't prove that the tactic and "interpret_R" are inverses - if they are not the tactic will fail when trying to unify the term in the goal with the interpreted AST.
+    Probably if the reification would be done in MetaCoq, one could prove this. *)
+
+Ltac2 rec reify_Expr_N (e : constr) : constr :=
+  (dbg2 printf "=> reify_Expr_N %t" e);
+  let res := lazy_match! e with
+  | Z.to_nat ?z => if is_literal_Z z then '(EN_lit $e) else '(EN_gen (block $e))
+  | ?n          => if is_computable_nat n then '(EN_lit $n) else '(EN_gen (block $n))
+  end in
+  (dbg2 printf "<= reify_Expr_N %t" res);
+  res.
+
+Ltac2 rec reify_Expr_R (e : constr) : constr :=
+  (dbg2 printf "=> reify_Expr_R %t" e);
+  let res := lazy_match! e with
+  | IZR ?z      => if is_literal_Z z then '(ER_Z $z) else '(ER_R $e)
+  | Q2R ?q      => if is_literal_Q q then '(ER_Q $q) else '(ER_R $e)
+  | (- ?a)%R    => let a':=reify_Expr_R a in '(ER_Unary EU_Opp $a')
+  | (/ ?a)%R    => let a':=reify_Expr_R a in '(ER_Unary EU_Inv $a')
+  | (?a + ?b)%R => let a':=reify_Expr_R a in let b':=reify_Expr_R b in '(ER_Binary EB_Add $a' $b')
+  | (?a - ?b)%R => let a':=reify_Expr_R a in let b':=reify_Expr_R b in '(ER_Binary EB_Sub $a' $b')
+  | (?a * ?b)%R => let a':=reify_Expr_R a in let b':=reify_Expr_R b in '(ER_Binary EB_Mul $a' $b')
+  | (?a / ?b)%R => let a':=reify_Expr_R a in let b':=reify_Expr_R b in '(ER_Binary EB_Div $a' $b')
+  | Rmax ?a ?b  => let a':=reify_Expr_R a in let b':=reify_Expr_R b in '(ER_Binary EB_Max $a' $b')
+  | Rmin ?a ?b  => let a':=reify_Expr_R a in let b':=reify_Expr_R b in '(ER_Binary EB_Min $a' $b')
+  | (?a ^ ?b)%R => let a':=reify_Expr_R a in let b':=reify_Expr_N b in '(ER_Pow $a' $b')
+  | ?a          => '(ER_R (block $a))
+  end in
+  (dbg2 printf "<= reify_Expr_R %t" res);
+  res.
+
+(** *** Main tactic "real_simplify" *)
+
+Ltac2 real_simplify (term : constr) : unit :=
+  let reified := reify_Expr_R term in
+  let p := '(cleanup_simplify_R_correct $reified) in
+  rewrite $p.
+
+(** An Ltac1 wrapper for the tactic *)
+
+Ltac real_simplify := ltac2:(term |- real_simplify (Option.get (Ltac1.to_constr term))).
+
+(** ** Tests *)
+
+Section Test.
+Variable x : R.
+Open Scope R.
+
+Goal (x+(Rmax ((3*4+5^2-6)/7) (1/2)) = x + 31/7).
+  lazy_match! goal with [ |- (?t = _) ] => real_simplify t end.
+  reflexivity.
+Qed.
+
+End Test.

--- a/test-suite/success/truelysimpl.v
+++ b/test-suite/success/truelysimpl.v
@@ -1,0 +1,122 @@
+Require Import Setoid.
+Require Import Force.Force.
+Require Import Ltac2.Ltac2.
+
+Set Default Proof Mode "Classic".
+
+Module Logic.
+  Lemma iff_trivial (P : Prop) : P <-> P.
+  Proof. split; intros H; exact H. Qed.
+
+  Lemma and_comm (P1 P2 : Prop) : P1 /\ P2 <-> P2 /\ P1.
+  Proof.
+    split.
+    - intros [H1 H2]; split; [exact H2 | exact H1].
+    - intros [H2 H1]; split; [exact H1 | exact H2].
+  Qed.
+
+  Lemma and_true (P : Prop) : P /\ True <-> P.
+  Proof.
+    split.
+    - intros [HP _]. exact HP.
+    - intros HP. split; [exact HP| exact I].
+  Qed.
+
+  Lemma true_and (P : Prop) : True /\ P <-> P.
+  Proof. rewrite and_comm. rewrite and_true. apply iff_trivial. Qed.
+
+  Lemma and_false (P : Prop) : P /\ False <-> False.
+  Proof.
+    split.
+    - intros [_ HF]. exact HF.
+    - intros HF. exfalso. exact HF.
+  Qed.
+
+  Lemma false_and (P : Prop) : False /\ P <-> False.
+  Proof. rewrite and_comm. rewrite and_false. apply iff_trivial. Qed.
+End Logic.
+
+Inductive prop :=
+  | conj  : prop -> prop -> prop
+  | true  : prop
+  | false : prop
+  | inj   : Blocked Prop -> prop.
+
+Fixpoint reflect (p : prop) : Blocked Prop :=
+  match p with
+  | conj p1 p2 => block ((unblock (reflect p1)) /\ (unblock (reflect p2)))
+  | true       => block True
+  | false      => block False
+  | inj P      => P
+  end.
+
+Eval lazy in reflect (conj true (inj (block (1 + 1 = 2)))).
+
+Ltac2 rec reify (p : constr) : constr :=
+  lazy_match! p with
+  | ?p1 /\ ?p2 => let p1 := reify p1 in let p2 := reify p2 in '(conj $p1 $p2)
+  | True       => '(true)
+  | False      => '(false)
+  | ?p         => '(inj (block $p))
+  end.
+
+Fixpoint simplify (p : prop) : prop :=
+  match p with
+  | conj p1 p2 =>
+      match simplify p1 with
+      | true  => simplify p2
+      | false => false
+      | p1    =>
+          match simplify p2 with
+          | true  => p1
+          | false => false
+          | p2    => conj p1 p2
+          end
+      end
+  | _ => p
+  end.
+
+Lemma simplify_ok (p : prop) : unblock (reflect (simplify p)) <-> unblock (reflect p).
+Proof.
+  induction p; lazy -[iff]; fold simplify reflect.
+  - rewrite <-IHp1; clear IHp1.
+    rewrite <-IHp2; clear IHp2.
+    destruct (simplify p1); lazy -[iff]; fold simplify reflect.
+    + destruct (simplify p2); lazy -[iff]; fold simplify reflect.
+      * apply Logic.iff_trivial.
+      * rewrite Logic.and_true. apply Logic.iff_trivial.
+      * rewrite Logic.and_false. apply Logic.iff_trivial.
+      * apply Logic.iff_trivial.
+    + rewrite Logic.true_and. apply Logic.iff_trivial.
+    + rewrite Logic.false_and. apply Logic.iff_trivial.
+    + destruct (simplify p2); lazy -[iff]; fold simplify reflect.
+      * apply Logic.iff_trivial.
+      * rewrite Logic.and_true. apply Logic.iff_trivial.
+      * rewrite Logic.and_false. apply Logic.iff_trivial.
+      * apply Logic.iff_trivial.
+  - apply Logic.iff_trivial.
+  - apply Logic.iff_trivial.
+  - apply Logic.iff_trivial.
+Qed.
+
+Lemma simplify_ok_run (p : prop) :
+  run (block (unblock (reflect (simplify p)) -> unblock (reflect p))) (fun x => x).
+Proof. lazy; fold reflect simplify. apply simplify_ok. Qed.
+
+Ltac2 truely_simplify (p : constr) : unit :=
+  let reified := reify p in
+  let p := '(simplify_ok_run $reified _) in
+  refine p.
+
+Ltac truely_simplify :=
+  let truely_simplify :=
+    ltac2:(p |- truely_simplify (Option.get (Ltac1.to_constr p)))
+  in
+  lazymatch goal with |- ?p => unshelve truely_simplify p end.
+
+Goal True /\ (True /\ 1 + 1 = 2) /\ (True /\ True /\ 2 + 1 = 3).
+Proof.
+  truely_simplify.
+  lazymatch goal with |- 1 + 1 = 2 /\ 2 + 1 = 3 => idtac | _ => fail "Error" end.
+  split; reflexivity.
+Qed.

--- a/test-suite/success/truelysimpl.v
+++ b/test-suite/success/truelysimpl.v
@@ -1,9 +1,18 @@
+(* This file showcases the use of the [run], [block] and [unblock] primitives,
+   in the context of proof by reflection.
+
+   Proof by reflection is a common, and generally very efficient technique for
+   proving that a proposition from some limited domain is equivalent to (or is
+   entailed by) a simpler proposition. Here, our domain will be [Prop], and we
+   will restrict to conjunctions ([_ /\ _]), [True], and [False]. Our ultimate
+   goal will be to provide an efficient tactic to simplify propositions by:
+   - removing [True] conjuncts,
+   - collapsing to [False] if any conjunct is [False].
+
+   To make this example more self-contained, the [Logic] module below provides
+   the lemmas we will need to later prove simplification correct. *)
+
 Require Import Setoid.
-Require Import Force.Force.
-Require Import Ltac2.Ltac2.
-
-Set Default Proof Mode "Classic".
-
 Module Logic.
   Lemma iff_trivial (P : Prop) : P <-> P.
   Proof. split; intros H; exact H. Qed.
@@ -36,11 +45,56 @@ Module Logic.
   Proof. rewrite and_comm. rewrite and_false. apply iff_trivial. Qed.
 End Logic.
 
+(* Proof by reflection typically involves four components:
+   1) a //reification// of the supported domain of propositions as a datatype,
+   2) a meta-program used to //reify// a proposition into said datatype,
+   3) a //denotation// (or //reflection//) function interpreting said datatype
+      as a proposition,
+   4) a //correct// simplification procedure defined on the datatype.
+
+   Here, we follow exactly these steps, starting with defining the type [prop]
+   of reified propositions. *)
+
+Require Import Force.Force.
+
 Inductive prop :=
   | conj  : prop -> prop -> prop
   | true  : prop
   | false : prop
   | inj   : Blocked Prop -> prop.
+
+(* This type has four constructors, the first three of which correspond to the
+   connectives that our simplification procedure will handle (i.e., [conj _ _]
+   for [_ /\ _], [true] for [True], and [false] for [False]). The last [inj _]
+   constructor is meant to represent "user-terms": propositions that are meant
+   to be left untouched by our simplification procedure, as we do not have any
+   way do deal with them.
+
+   In a usual setting, without the new primitives, the type of the argument of
+   [inj _] would be [Prop]. Here however, we rely on the new type [Blocked _],
+   taken from the [Force.Force] module declaring the primitives, to explicitly
+   mark the term as "blocked" for (kernel) reduction.
+
+   To build a term of type [Block Prop], one must rely on primitive [block].
+
+     block : forall {T : Type}, T -> Blocked T
+
+   We rely on it to define our Ltac2 reification function below. Note that the
+   reification process is otherwise straight-forward, and usual. *)
+
+Require Import Ltac2.Ltac2.
+Set Default Proof Mode "Classic".
+
+Ltac2 rec reify (p : constr) : constr :=
+  lazy_match! p with
+  | ?p1 /\ ?p2 => let p1 := reify p1 in let p2 := reify p2 in '(conj $p1 $p2)
+  | True       => '(true)
+  | False      => '(false)
+  | ?p         => '(inj (block $p))
+  end.
+
+(* We now turn to the reflection function, whose role is to interpret a [prop]
+   into a proposition, or more precisely, a blocked proposition. *)
 
 Fixpoint reflect (p : prop) : Blocked Prop :=
   match p with
@@ -50,15 +104,31 @@ Fixpoint reflect (p : prop) : Blocked Prop :=
   | inj P      => P
   end.
 
-Eval lazy in reflect (conj true (inj (block (1 + 1 = 2)))).
+(* The use of a [Blocked Prop] (as apposed to the more usual [Prop]) allows us
+   to safely force the reduction of [reflect _], while making sure that [Prop]
+   connectives like [_ /\ _] will not be reduced themselves. This matters more
+   in settings where the connectives can actually reduce, which is typically a
+   problem in embedded logics like Iris.
 
-Ltac2 rec reify (p : constr) : constr :=
-  lazy_match! p with
-  | ?p1 /\ ?p2 => let p1 := reify p1 in let p2 := reify p2 in '(conj $p1 $p2)
-  | True       => '(true)
-  | False      => '(false)
-  | ?p         => '(inj (block $p))
-  end.
+   The implementation of [reflect] is straight-forward following the types:
+   - In the [true]/[false] cases, a [block] must be used to protect [True] and
+     [False], since they have type [Prop], and we expect a [Blocked Prop].
+   - In the [inj P] case, [P] is already blocked so we just take it.
+   - In the [conj p1 p2] case, we use [block] around [_ /\ _], but need to use
+     the [unblock] function to turn the recursive calls into propositions.
+
+   The [unblock] primitive is basically a destructor for the [Blocked _] type,
+   similarly to how [block _] can be seen as a constructor.
+
+     unblock : forall {T : Type}, Blocked T -> T
+
+   In terms of reduction, the combination of [block] and [unblock] is slightly
+   more subtle. In particular, an [unblock] withing a [block] will trigger the
+   reduction of its argument, even if the whole term is "blocked". This has to
+   do with the fact that the semantics of the new primitives rely on full lazy
+   reduction, not just weak-head normalization.
+
+   Let us now turn to the last building block of our example: [simplify]. *)
 
 Fixpoint simplify (p : prop) : prop :=
   match p with
@@ -76,7 +146,13 @@ Fixpoint simplify (p : prop) : prop :=
   | _ => p
   end.
 
-Lemma simplify_ok (p : prop) : unblock (reflect (simplify p)) <-> unblock (reflect p).
+(* The simplification function is usual as it operates on [prop]. However, its
+   correctness lemma involves [unblock] since the return value of [reflect] is
+   a blocked proposition. Nonetheless, the proof remains fairly usual since we
+   can use [lazy] to evaluate [unblock (block p)] into [p]. *)
+
+Lemma simplify_ok (p : prop) :
+  unblock (reflect (simplify p)) <-> unblock (reflect p).
 Proof.
   induction p; lazy -[iff]; fold simplify reflect.
   - rewrite <-IHp1; clear IHp1.
@@ -99,14 +175,46 @@ Proof.
   - apply Logic.iff_trivial.
 Qed.
 
+(* Note that the proof requires a bit of manual refolding, due to [lazy] being
+   too eager when unfolding fixpoints, but that's an independent issue.
+
+   Now that we have all the necessary pieces, we need to setup our tactic. The
+   first step is to turn our correctness lemma into a proof term that actually
+   triggers the forcing of reduction, using the [run] primitive.
+
+     run : forall {T K : Type}, Blocked T -> (T -> K) -> K
+   
+   The [run] primitive forces the full evaluation of the blocked term it takes
+   as first (non-implicit) argument, respecting the blocked terms it contains,
+   and it then feeds the result to its second (non-implicit) argument. *)
+
 Lemma simplify_ok_run (p : prop) :
-  run (block (unblock (reflect (simplify p)) -> unblock (reflect p))) (fun x => x).
+  run (block (unblock (reflect (simplify p)) -> unblock (reflect p))) id.
 Proof. lazy; fold reflect simplify. apply simplify_ok. Qed.
+
+(* The proof of [simplify_ok_run] trivially follows from [simplify_ok].
+
+   Note that we again need a few [block] and [unblock] to make the types work.
+   Said otherwise, we need to "protect" [_ -> _] similarly to what we did with
+   [_ /\ _] in [reflect] earlier.
+
+   Note also that it is essential that the type of [simplify_ok_run] is of the
+   form [run _ _]. Indeed, we need [run] to get in the way of the type-checker
+   when [simplify_of_run] is applied to a reified proposition, and its type is
+   reduced to a (non-dependent) product.
+
+   We can now implement our tactic by combining [simplify_ok_run] with [reify]
+   in a simple Ltac2 function. *)
 
 Ltac2 truely_simplify (p : constr) : unit :=
   let reified := reify p in
   let p := '(simplify_ok_run $reified _) in
   refine p.
+
+(* It takes as input a term [p] representing the proposition from the goal.
+
+   A simple Ltac wrapper can then be defined to match on the goal and call the
+   [truely_simplify] Ltac2 function. *)
 
 Ltac truely_simplify :=
   let truely_simplify :=
@@ -114,9 +222,11 @@ Ltac truely_simplify :=
   in
   lazymatch goal with |- ?p => unshelve truely_simplify p end.
 
+(* Testing the tactic on the following goal yields the expected result. *)
+
 Goal True /\ (True /\ 1 + 1 = 2) /\ (True /\ True /\ 2 + 1 = 3).
 Proof.
   truely_simplify.
-  lazymatch goal with |- 1 + 1 = 2 /\ 2 + 1 = 3 => idtac | _ => fail "Error" end.
+  lazymatch goal with |- 1 + 1 = 2 /\ 2 + 1 = 3 => idtac | _ => fail "?!" end.
   split; reflexivity.
 Qed.

--- a/theories/Force/Force.v
+++ b/theories/Force/Force.v
@@ -1,0 +1,10 @@
+Primitive Blocked := #blocked_type.
+
+Primitive block : forall (T : Type), T -> Blocked T := #block.
+Primitive unblock : forall (T : Type), Blocked T -> T := #unblock.
+
+Primitive run : forall (T K : Type), Blocked T -> (T -> K) -> K := #run.
+
+Arguments block {_} _.
+Arguments unblock {_} _.
+Arguments run {_ _} _ _.


### PR DESCRIPTION
TODO:
- [ ] `to_constr` may miss `unblock`/`block` because of the shortcuts for identity substitutions/liftings. It calls `Vars.subst_instance_constr` which doesn't have any code for finding our primitives.

Version 2 (new)
---------------------

This version relies on the following primitives, the main difference with the previous version being that:
- `run` (previously called `let_lazy`) now takes a `Blocked T` instead of a `T` as first argument,
- and `run` also does not have a dependent type anymore currently (its type uses a primitive type now, so there is a bit of code to write in primitive support to handle this).
```coq
Primitive Blocked := #blocked_type.

Primitive block : forall (T : Type), T -> Blocked T := #block.
Primitive unblock : forall (T : Type), Blocked T -> T := #unblock.

Primitive run : forall (T K : Type), Blocked T -> (T -> K) -> K := #run.

Arguments block {_} _.
Arguments unblock {_} _.
Arguments run {_ _} _ _.
```
What really changed since the previous version is the semantics of the primitives, which intuitively is now:
```
  e  --{full reduction with all flags}--> block v
 ------------------------------------------------- (f and e not reduced prior to running the primitive)
              run e f  --{whnf}->  f v

  e  --{full reduction with all flags}--> v        v not "block _"
 ------------------------------------------------------------------ (f and e not reduced prior to running the primitive)
                  run e f  --{whnf}->  run v f

  e  --{full reduction with all flags}--> block v
 ------------------------------------------------- (e not reduced prior to running the primitive)
            unblock e  --{whnf}->  v
            
  e  --{full reduction with all flags}--> v        v not "block _"
 ------------------------------------------------------------------ (e not reduced prior to running the primitive)
                unblock e  --{whnf}->  unblock v
            
  e  --{full reduction witout flags}--> v
 ----------------------------------------- (e not reduced prior to running the primitive)
       block e  --{whnf}->  block v
```
In the above, it is assumed that full reduction (whatever the flags) is implemented by first deducing to weak-head normal form, and then recursively fully evaluating under the head (and its arguments if any).

Basically, this allows for the following behaviour:
```
block (unblock (let n := 1 + 1 in block (n + n)))   --{whnf}--> block (2 + 2).
```
Here, even inside a `block`, code that is `unblock`-ed is fully evaluated until a `block` is reached. So, evaluating this expression proceeds by fully evaluating `unblock (let n := 1 + 1 in block (n + n))` with empty flags (only `block` and `unblock` being transparent). Since the head is `unblock`, its argument `let n := 1 + 1 in block (n + n)` is then fully evaluated with full flags, so this proceeds by extending the ambient substitution with a binding `(n := 1 + 1)`, additionally marked as coming from a "forced" context. Then, the term `block (n + n)` is reached, and its evaluation proceeds again by fully evaluating `n + n` with empty flags, which traverses the term and substitutes `n` with the fully evaluated form of `1 + 1` (since the value of `n` was marked as coming form a forced context in the substitution). So, now we have `unblock (block (2 + 2))`, and it is reduced to just `2 + 2` according the the reduction rule of `unblock`. Hence, we finally end up with `block (2 + 2)`, where the `block` is the outer one from the term we started with.

Version 1 (old)
-------------------

(The initial design was discussed with @ppedrot, @Janno and @gmalecha, and later also during the [Coq Call on 11/07/2023](https://github.com/coq/coq/wiki/Coq-Call-2023-07-11).)

**Edited with further documentation.**

This PR adds new primitives that are intended to be used to get finer-grained control on kernel reduction.
```coq
Primitive let_lazy : forall (T : Type) (K : T -> Type) (e : T), (forall v : T, K v) -> K e := #let_lazy.

Primitive Blocked := #blocked_type.
Primitive block : forall (T : Type), T -> Blocked T := #block.
Primitive unblock : forall (T : Type), Blocked T -> T := #unblock.

Arguments let_lazy {_ _} _ _.
Arguments block {_} _.
Arguments unblock {_} _.
```

The reduction rules for the primitives are the following:
```
  e  --{lazy}-->  v
 -------------------------
  let_lazy e f  --->  f v       (the arguments of [let_lazy] are not reduced before running the primitive)

 ----------------------------
  unblock (block e)  --->  e    (the argument of [unblock] is reduced before running the primitive)

 --------------
  block e -/->                  (the argument of [block] is not reduced, [block e] is stuck)
```

With these rules, we have the following properties:
- For all `T`, the canonical forms for type `Blocked T` are of the form `@block T e`, where `e` is any term.
- A term of the form `let_lazy f e` is definitionally equal to `f e`. The reason this is true is that `lazy` is compatible with the reduction engine used by weak-head normalization and conversion, and so `f v` remains convertible to `f e`.


**Note:** nothing here is specific to `lazy`, and it could be implemented for any reduction strategy, provided it is compatible with conversion / weak-head normalization. We went with `lazy` since it is already fully in the kernel.

**Note:** as noted by @SkySkimmer, we could implement `let_lazy` via a flag on the let-binding constructor in the AST. Although that option would definitely work, the change would be somewhat more invasive.