### PR TITLE
[coqidetop] Fix print depth setting for Richpp clients

### DIFF
--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -570,7 +570,8 @@ let slave_feeder fmt xml_oc msg =
 
 let msg_format = ref (fun () ->
     let width = Option.default 72 (Topfmt.get_margin ()) in
-    Xmlprotocol.Richpp { width; depth = max_int }
+    let depth = Option.default max_int (Topfmt.get_depth_boxes ()) in
+    Xmlprotocol.Richpp { width; depth }
   )
 
 (* The loop ignores the command line arguments as the current model delegates


### PR DESCRIPTION
cc: #13971  #11710

This doesn't solve the bug above in full, as some clients like CoqIDE do client-side rendering.

These need to either query Coq for the depth setting at a particular doc position, or use their own, client-side setting.

Note that the problem of querying Coq for depth setting is that it can vary for particular document points, and it is not the case that IDE queries do necessarily refer to a particular doc point.

