### PR TITLE
Fixes #15322: support Set Printing Parentheses for non-standard way to set associativity

### DIFF
--- a/doc/changelog/03-notations/17844-master+fix15322-set-printing-parenthesis-hole.rst
+++ b/doc/changelog/03-notations/17844-master+fix15322-set-printing-parenthesis-hole.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  :flag:`Printing Parentheses` now works also when an explicit level is
+  set for the right-hand side of a right-open notation
+  (`#17844 <https://github.com/coq/coq/pull/17844>`_,
+  fixes `#15322 <https://github.com/coq/coq/issues/15322>`_,
+  by Hugo Herbelin).

--- a/test-suite/output/PrintingParentheses.out
+++ b/test-suite/output/PrintingParentheses.out
@@ -21,7 +21,7 @@ nat_ind (fun n0 : nat => ((n0 * m) + n0) = (n0 * (S m)))
                  :
                  forall n1 : nat,
                  (((n1 + (p * m)) + p) = (n1 + ((p * m) + p))) ->
-                 (((S n1) + (p * m)) + p) = ((S n1) + ((p * m) + p))) m
+                 ((((S n1) + (p * m)) + p) = ((S n1) + ((p * m) + p)))) m
               :
               ((m + (p * m)) + p) = (m + ((p * m) + p))))
           ((m + (p * m)) + (S p)) (plus_n_Sm (m + (p * m)) p)

--- a/test-suite/output/bug_15322.out
+++ b/test-suite/output/bug_15322.out
@@ -1,0 +1,8 @@
+x `+ (y `+ z)
+     : nat
+[x `+ (y `+ z)]
+     : nat
+fun x y z : nat => [x `+ (y `+ z)]
+     : nat -> (nat -> (nat -> nat))
+fun x y z : nat => [x `+ (y `+ z)]
+     : nat -> (nat -> (nat -> nat))

--- a/test-suite/output/bug_15322.v
+++ b/test-suite/output/bug_15322.v
@@ -1,0 +1,27 @@
+Set Printing Parentheses.
+
+Module Constr.
+Parameters x y z : nat.
+Notation "a `+ b" := (a + b) (at level 50, b at level 50, left associativity).
+Check (x `+ y `+ z).
+End Constr.
+
+Module CustomGlobal.
+Declare Custom Entry foo.
+Notation "a `+ b" := (a + b) (in custom foo at level 50, b at level 50).
+Notation "x" := x  (in custom foo at level 0, x global).
+Notation "( x )" := x  (in custom foo at level 0).
+Notation "[ a ]" := a (a custom foo).
+Parameters x y z : nat.
+Check [x `+ y `+ z].
+Check fun x y z => [x `+ y `+ z].
+End CustomGlobal.
+
+Module CustomIdent.
+Declare Custom Entry bar.
+Notation "a `+ b" := (a + b) (in custom bar at level 50, b at level 50).
+Notation "x" := x  (in custom bar at level 0, x ident).
+Notation "( x )" := x  (in custom bar at level 0).
+Notation "[ a ]" := a (a custom bar).
+Check fun x y z => [x `+ y `+ z].
+End CustomIdent.

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -306,6 +306,10 @@ let pr_notation_entry = function
   | InConstrEntry -> str "constr"
   | InCustomEntry s -> str "custom " ++ str s
 
+let side = function
+  | BorderProd (b,_) -> Some b
+  | _ -> None
+
 let precedence_of_position_and_level from_level = function
   | NumLevel n, BorderProd (b,Some a) ->
     (let open Gramlib.Gramext in
@@ -315,9 +319,9 @@ let precedence_of_position_and_level from_level = function
      | LeftA, Left -> LevelLe n
      | LeftA, Right -> LevelLt n
      | NonA, _ -> LevelLt n), Some b
-  | NumLevel n, _ -> LevelLe n, None
-  | NextLevel, _ -> LevelLt from_level, None
-  | DefaultLevel, _ -> LevelSome, None
+  | NumLevel n, b -> LevelLe n, side b
+  | NextLevel, b -> LevelLt from_level, side b
+  | DefaultLevel, b -> LevelSome, side b
 
 (** Computing precedences of non-terminals for parsing *)
 let precedence_of_entry_type (from_custom,from_level) = function
@@ -341,11 +345,11 @@ let unparsing_precedence_of_entry_type from_level = function
        with precedence in a constr entry is managed using [prec_less]
        in [ppconstr.ml] *)
     precedence_of_position_and_level from_level x
-  | ETConstr (custom,_,_) ->
+  | ETConstr (custom,_,(_,x)) ->
     (* Precedence of printing for a custom entry is managed using
        explicit insertion of entry coercions at the time of building
        a [constr_expr] *)
-    LevelSome, None
+    LevelSome, side x
   | ETPattern (_,n) -> (* in constr *) LevelLe (pattern_entry_level n), None
   | _ -> LevelSome, None (* should not matter *)
 


### PR DESCRIPTION
We were previously assuming that notations with an open side did not have the level at the border set explicitly. In the PR, we also treat this case.

Fixes / closes #15322.

This incidentally also fixes the missing parentheses when printing `A->B->C` with `Set Printing Parentheses` on.

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
