### PR TITLE
Add waterproof to ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -956,3 +956,6 @@ plugin:ci-stalmarck:
 
 plugin:ci-tactician:
   extends: .ci-template-flambda
+
+plugin:ci-waterproof:
+  extends: .ci-template-flambda

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -84,7 +84,8 @@ CI_TARGETS= \
     ci-unicoq \
     ci-verdi_raft \
     ci-vscoq \
-    ci-vst
+    ci-vst \
+    ci-waterproof
 
 .PHONY: ci-all $(CI_TARGETS)
 

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -394,3 +394,8 @@ project tactician "https://github.com/coq-tactician/coq-tactician" "coqdev"
 # Ltac2 compiler
 ########################################################################
 project ltac2_compiler "https://github.com/SkySkimmer/coq-ltac2-compiler" "main"
+
+########################################################################
+# Waterproof
+########################################################################
+project waterproof "https://github.com/impermeable/coq-waterproof" "coq-master"

--- a/dev/ci/ci-waterproof.sh
+++ b/dev/ci/ci-waterproof.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env/ bash
+
+set -e
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+git_download waterproof
+
+if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
+
+( cd "${CI_BUILD_DIR}/waterproof"
+  dune build -p coq-waterproof
+  dune install -p coq-waterproof --prefix=$CI_INSTALL_DIR
+)


### PR DESCRIPTION
We would like to have our plugin "Waterproof" https://github.com/impermeable/coq-waterproof added to the CI for Coq. We have tried to follow the instructions from https://github.com/coq/coq/blob/master/dev/ci/README-users.md . It can be that we made some mistakes, but would like to take you up on the offer on that page for help finishing the pull request. 
