### PR TITLE
add Coinduction plugin to Coq's CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -848,6 +848,9 @@ plugin:ci-itauto:
 plugin:ci-bignums:
   extends: .ci-template-flambda
 
+plugin:ci-coinduction:
+  extends: .ci-template-flambda
+
 plugin:ci-coq_dpdgraph:
   extends: .ci-template
 

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -18,6 +18,7 @@ CI_TARGETS= \
     ci-bedrock2 \
     ci-bignums \
     ci-category_theory \
+    ci-coinduction \
     ci-color \
     ci-compcert \
     ci-coq_dpdgraph \

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -205,6 +205,11 @@ project bbv "https://github.com/mit-plv/bbv" "master"
 project bedrock2 "https://github.com/mit-plv/bedrock2" "tested"
 
 ########################################################################
+# Coinduction
+########################################################################
+project coinduction "https://github.com/damien-pous/coinduction" "master"
+
+########################################################################
 # coq-lsp
 ########################################################################
 project coq_lsp "https://github.com/ejgallego/coq-lsp" "main"

--- a/dev/ci/ci-coinduction.sh
+++ b/dev/ci/ci-coinduction.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+git_download coinduction
+
+if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
+
+( cd "${CI_BUILD_DIR}/coinduction"
+  make
+  make install
+)


### PR DESCRIPTION
[Coinduction](https://github.com/damien-pous/coinduction) is a plugin and library for reasoning about coinductive relations (not necessarily using coinductive data defined by `CoInductive`).

As per [this issue](https://github.com/damien-pous/coinduction/issues/10) I submit Coinduction for inclusion in Coq's CI on behalf of the author, @damien-pous.