### PR TITLE
Ignore test-suite files produced by extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,10 @@ test-suite/oUnit-anon.cache
 test-suite/redirect_test.out
 test-suite/unit-tests/**/*.test
 test-suite/ide/fake_ide.exe
+test-suite/Datatypes.ml
+test-suite/Datatypes.mli
+test-suite/bug_10796.ml
+test-suite/bug_10796.mli
 
 # documentation
 


### PR DESCRIPTION
The question was [raised](https://github.com/coq/coq/pull/17344#discussion_r1254445336) by @skyskimmer: is there a way to avoid `Separate Extraction` to write files in the test-suite directory. This PR implements the easy solution of adding yet an extra lines to .gitignore.

Don't know if so important for 8.18: it would be so that it provides a "clean" repository after compilation.