### PR TITLE
Notation wish #17845: add support for notations with recursive binders involving "let" and "match"

### DIFF
--- a/doc/changelog/03-notations/17856-master+more-general-form-binders-recursive-notation.rst
+++ b/doc/changelog/03-notations/17856-master+more-general-form-binders-recursive-notation.rst
@@ -1,0 +1,7 @@
+- **Added:**
+  Parsing support for notations with recursive binders involving not only
+  variables bound by :n:`fun` or :n:`forall` but also by :n:`let` or
+  :n:`match`
+  (`#17856 <https://github.com/coq/coq/pull/17856>`_,
+  fixes `#17845 <https://github.com/coq/coq/issues/17845>`_,
+  by Hugo Herbelin).

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -620,7 +620,8 @@ let intern_cases_pattern_as_binder intern test_kind ntnvars env bk (CAst.{v=p;lo
     | None -> CAst.make ?loc @@ CHole (Some (GBinderType na.v)) in
   let _, bl' = intern_assumption intern ntnvars env [na] (Default bk) t in
   let {v=(_,bk,t)} = List.hd bl' in
-  env,((disjpat,il),id),na,bk,t
+  let il = List.map (fun id -> id.v) il in
+  env,((disjpat,il),id),bk,t
 
 let intern_local_binder_aux intern ntnvars (env,bl) = function
   | CLocalAssum(nal,bk,ty) ->
@@ -631,8 +632,8 @@ let intern_local_binder_aux intern ntnvars (env,bl) = function
      let env,(na,def,ty) = intern_letin_binder intern ntnvars env (locna,def,ty) in
      env, (DAst.make ?loc @@ GLocalDef (na,def,ty)) :: bl
   | CLocalPattern p ->
-      let env, ((disjpat,il),id),na,bk,t = intern_cases_pattern_as_binder intern test_kind_tolerant ntnvars env Explicit p in
-      (env, (DAst.make ?loc:p.CAst.loc @@ GLocalPattern((disjpat,List.map (fun x -> x.v) il),id,bk,t)) :: bl)
+      let env, ((disjpat,il),id),bk,t = intern_cases_pattern_as_binder intern test_kind_tolerant ntnvars env Explicit p in
+      (env, (DAst.make ?loc:p.CAst.loc @@ GLocalPattern((disjpat,il),id,bk,t)) :: bl)
 
 let intern_generalization intern env ntnvars loc bk c =
   let c = intern {env with strict_check = Some false} c in
@@ -742,20 +743,24 @@ let set_type ty1 ty2 =
     (* An explicitly typed meta-binding binder, not supposed to be a pattern; checked in interp_notation *)
     user_err ?loc:t2.CAst.loc Pp.(str "Unexpected type constraint in notation already providing a type constraint.")
 
+let cook_pattern ((disjpat, ids), id) =
+  let store,get = set_temporary_memory () in
+  let pat, na = match disjpat with
+    | [pat] when is_patvar_store store pat -> let na = get () in None, na.v
+    | _ -> Some ((ids,disjpat),id), Name id in
+  pat, na
+
 let traverse_binder intern_pat ntnvars (terms,_,binders,_ as subst) avoid (renaming,env) na ty =
   match na with
   | Anonymous -> (renaming,env), None, Anonymous, Explicit, set_type ty None
   | Name id ->
-  let store,get = set_temporary_memory () in
   let test_kind = test_kind_tolerant in
   try
     (* We instantiate binder name with patterns which may be parsed as terms *)
     let pat = coerce_to_cases_pattern_expr (fst (Id.Map.find id terms)) in
-    let env,((disjpat,ids),id),na,bk,t = intern_pat test_kind ntnvars env Explicit pat in
-    let pat, na = match disjpat with
-    | [pat] when is_patvar_store store pat -> let na = get () in None, na
-    | _ -> Some ((List.map (fun x -> x.v) ids,disjpat),id), na in
-    (renaming,env), pat, na.v, bk, set_type ty (Some t)
+    let env,pat,bk,t = intern_pat test_kind ntnvars env Explicit pat in
+    let pat, na = cook_pattern pat in
+    (renaming,env), pat, na, bk, set_type ty (Some t)
   with Not_found ->
   try
     (* Trying to associate a pattern *)
@@ -769,12 +774,9 @@ let traverse_binder intern_pat ntnvars (terms,_,binders,_ as subst) avoid (renam
       (renaming,env), None, na.v, bk, set_type ty (Some ty')
     else
       (* Interpret as a pattern *)
-      let env,((disjpat,ids),id),na,bk,t = intern_pat test_kind ntnvars env bk pat in
-      let pat, na =
-        match disjpat with
-        | [pat] when is_patvar_store store pat -> let na = get () in None, na
-        | _ -> Some ((List.map (fun x -> x.v) ids,disjpat),id), na in
-      (renaming,env), pat, na.v, bk, set_type ty (Some t)
+      let env,pat,bk,t = intern_pat test_kind ntnvars env bk pat in
+      let pat, na = cook_pattern pat in
+      (renaming,env), pat, na, bk, set_type ty (Some t)
   with Not_found ->
     (* Binders not bound in the notation do not capture variables *)
     (* outside the notation (i.e. in the substitution) *)
@@ -927,7 +929,7 @@ let instantiate_notation_constr loc intern intern_pat ntnvars subst infos c =
         let test_kind =
           if onlyident then test_kind_ident_in_notation
           else test_kind_pattern_in_notation in
-        let _,((disjpat,_),_),_,_,_ty = intern_pat test_kind ntnvars nenv Explicit c in
+        let _,((disjpat,_),_),_,_ty = intern_pat test_kind ntnvars nenv Explicit c in
         (* TODO: use cast? *)
         match disjpat with
         | [pat] -> (glob_constr_of_cases_pattern (Global.env()) pat)
@@ -974,7 +976,7 @@ let instantiate_notation_constr loc intern intern_pat ntnvars subst infos c =
       let test_kind =
         if onlyident then test_kind_ident_in_notation
         else test_kind_pattern_in_notation in
-      let env,((disjpat,ids),id),na,bk,_ty = intern_pat test_kind ntnvars env bk pat in
+      let env,((disjpat,ids),id),bk,_ty = intern_pat test_kind ntnvars env bk pat in
       (* TODO: use cast? *)
       match disjpat with
       | [pat] -> glob_constr_of_cases_pattern (Global.env()) pat

--- a/pretyping/glob_ops.ml
+++ b/pretyping/glob_ops.ml
@@ -111,10 +111,10 @@ let case_style_eq s1 s2 = let open Constr in match s1, s2 with
   | RegularStyle, RegularStyle -> true
   | (LetStyle | IfStyle | LetPatternStyle | MatchStyle | RegularStyle), _ -> false
 
-let rec cases_pattern_eq p1 p2 = match DAst.get p1, DAst.get p2 with
-  | PatVar na1, PatVar na2 -> Name.equal na1 na2
+let rec mk_cases_pattern_eq g p1 p2 = match DAst.get p1, DAst.get p2 with
+  | PatVar na1, PatVar na2 -> g na1 na2
   | PatCstr (c1, pl1, na1), PatCstr (c2, pl2, na2) ->
-    Construct.CanOrd.equal c1 c2 && List.equal cases_pattern_eq pl1 pl2 &&
+    Construct.CanOrd.equal c1 c2 && List.equal (mk_cases_pattern_eq g) pl1 pl2 &&
       Name.equal na1 na2
   | (PatVar _ | PatCstr _), _ -> false
 
@@ -136,8 +136,9 @@ let tomatch_tuple_eq f (c1, p1) (c2, p2) =
   let eq_pred (n1, o1) (n2, o2) = Name.equal n1 n2 && Option.equal eqp o1 o2 in
   f c1 c2 && eq_pred p1 p2
 
-and cases_clause_eq f {CAst.v=(id1, p1, c1)} {CAst.v=(id2, p2, c2)} =
-  List.equal Id.equal id1 id2 && List.equal cases_pattern_eq p1 p2 && f c1 c2
+and cases_clause_eq f g {CAst.v=(id1, p1, c1)} {CAst.v=(id2, p2, c2)} =
+  (* In principle, id1 and id2 canonically derive from p1 and p2 *)
+  List.equal (mk_cases_pattern_eq g) p1 p2 && f c1 c2
 
 let glob_decl_eq f (na1, bk1, c1, t1) (na2, bk2, c2, t2) =
   Name.equal na1 na2 && binding_kind_eq bk1 bk2 &&
@@ -167,16 +168,16 @@ let mk_glob_constr_eq f g c1 c2 = match DAst.get c1, DAst.get c2 with
   | GProd (na1, bk1, t1, c1), GProd (na2, bk2, t2, c2) ->
     g na1 na2 (Some t1) (Some t2) && binding_kind_eq bk1 bk2 && f t1 t2 && f c1 c2
   | GLetIn (na1, b1, t1, c1), GLetIn (na2, b2, t2, c2) ->
-    Name.equal na1 na2 && f b1 b2 && Option.equal f t1 t2 && f c1 c2
+    g na1 na2 t1 t2 && f b1 b2 && Option.equal f t1 t2 && f c1 c2
   | GCases (st1, c1, tp1, cl1), GCases (st2, c2, tp2, cl2) ->
     case_style_eq st1 st2 && Option.equal f c1 c2 &&
     List.equal (tomatch_tuple_eq f) tp1 tp2 &&
-    List.equal (cases_clause_eq f) cl1 cl2
+    List.equal (cases_clause_eq f (fun na1 na2 -> g na1 na2 None None)) cl1 cl2
   | GLetTuple (na1, (n1, p1), c1, t1), GLetTuple (na2, (n2, p2), c2, t2) ->
-    List.equal Name.equal na1 na2 && Name.equal n1 n2 &&
+    List.equal (fun na1 na2 -> g na1 na2 None None) na1 na2 && g n1 n2 None None &&
     Option.equal f p1 p2 && f c1 c2 && f t1 t2
   | GIf (m1, (pat1, p1), c1, t1), GIf (m2, (pat2, p2), c2, t2) ->
-    f m1 m2 && Name.equal pat1 pat2 &&
+    f m1 m2 && g pat1 pat2 None None &&
     Option.equal f p1 p2 && f c1 c2 && f t1 t2
   | GRec (kn1, id1, decl1, t1, c1), GRec (kn2, id2, decl2, t2, c2) ->
     fix_kind_eq kn1 kn2 && Array.equal Id.equal id1 id2 &&
@@ -204,7 +205,23 @@ let mk_glob_constr_eq f g c1 c2 = match DAst.get c1, DAst.get c2 with
 
 let rec glob_constr_eq c = mk_glob_constr_eq glob_constr_eq (fun na1 na2 _ _ -> Name.equal na1 na2) c
 
-let map_glob_constr_left_to_right f = DAst.map (function
+let cases_pattern_eq c = mk_cases_pattern_eq Name.equal c
+
+let rec map_case_pattern_binders f = DAst.map (function
+  | PatVar na as x ->
+      let r = f na in
+      if r == na then x
+      else PatVar r
+  | PatCstr (c,ps,na) as x ->
+      let rna = f na in
+      let rps =
+        CList.Smart.map (fun p -> map_case_pattern_binders f p) ps
+      in
+      if rna == na && rps == ps then x
+      else PatCstr(c,rps,rna)
+  )
+
+let map_glob_constr_left_to_right_with_names f g = DAst.map (function
   | GApp (g,args) ->
       let comp1 = f g in
       let comp2 = Util.List.map_left f args in
@@ -212,36 +229,37 @@ let map_glob_constr_left_to_right f = DAst.map (function
   | GLambda (na,bk,ty,c) ->
       let comp1 = f ty in
       let comp2 = f c in
-      GLambda (na,bk,comp1,comp2)
+      GLambda (g na,bk,comp1,comp2)
   | GProd (na,bk,ty,c) ->
       let comp1 = f ty in
       let comp2 = f c in
-      GProd (na,bk,comp1,comp2)
+      GProd (g na,bk,comp1,comp2)
   | GLetIn (na,b,t,c) ->
       let comp1 = f b in
       let compt = Option.map f t in
       let comp2 = f c in
-      GLetIn (na,comp1,compt,comp2)
+      GLetIn (g na,comp1,compt,comp2)
   | GCases (sty,rtntypopt,tml,pl) ->
       let comp1 = Option.map f rtntypopt in
-      let comp2 = Util.List.map_left (fun (tm,x) -> (f tm,x)) tml in
-      let comp3 = Util.List.map_left (CAst.map (fun (idl,p,c) -> (idl,p,f c))) pl in
+      let comp2 = Util.List.map_left (fun (tm,(x,indxl)) -> (f tm,(g x,Option.map (CAst.map (fun (ind,xl) -> (ind,List.map g xl))) indxl))) tml in
+      let comp3 = Util.List.map_left (CAst.map (fun (idl,p,c) -> (List.map (fun id -> Name.get_id (g (Name id))) idl,List.map (map_case_pattern_binders g) p,f c))) pl in
       GCases (sty,comp1,comp2,comp3)
   | GLetTuple (nal,(na,po),b,c) ->
       let comp1 = Option.map f po in
       let comp2 = f b in
       let comp3 = f c in
-      GLetTuple (nal,(na,comp1),comp2,comp3)
+      GLetTuple (List.map g nal,(g na,comp1),comp2,comp3)
   | GIf (c,(na,po),b1,b2) ->
       let comp1 = Option.map f po in
       let comp2 = f b1 in
       let comp3 = f b2 in
-      GIf (f c,(na,comp1),comp2,comp3)
+      GIf (f c,(g na,comp1),comp2,comp3)
   | GRec (fk,idl,bl,tyl,bv) ->
       let comp1 = Array.map (Util.List.map_left (map_glob_decl_left_to_right f)) bl in
       let comp2 = Array.map f tyl in
       let comp3 = Array.map f bv in
-      GRec (fk,idl,comp1,comp2,comp3)
+      let g id = Name.get_id (g (Name id)) in
+      GRec (fk,Array.map g idl,comp1,comp2,comp3)
   | GCast (c,k,t) ->
       let c = f c in
       let t = f t in
@@ -257,6 +275,8 @@ let map_glob_constr_left_to_right f = DAst.map (function
       GArray (u,comp1,comp2,comp3)
   | (GVar _ | GSort _ | GHole _ | GGenarg _ | GRef _ | GEvar _ | GPatVar _ | GInt _ | GFloat _) as x -> x
   )
+
+let map_glob_constr_left_to_right f = map_glob_constr_left_to_right_with_names f (fun na -> na)
 
 let map_glob_constr = map_glob_constr_left_to_right
 
@@ -406,20 +426,6 @@ let map_tomatch_binders f ((c,(na,inp)) as x) : tomatch_tuple =
   let r = Option.Smart.map (fun p -> map_inpattern_binders f p) inp in
   if r == inp then x
   else c,(f na, r)
-
-let rec map_case_pattern_binders f = DAst.map (function
-  | PatVar na as x ->
-      let r = f na in
-      if r == na then x
-      else PatVar r
-  | PatCstr (c,ps,na) as x ->
-      let rna = f na in
-      let rps =
-        CList.Smart.map (fun p -> map_case_pattern_binders f p) ps
-      in
-      if rna == na && rps == ps then x
-      else PatCstr(c,rps,rna)
-  )
 
 let map_cases_branch_binders f ({CAst.loc;v=(il,cll,rhs)} as x) : cases_clause =
   (* spiwack: not sure if I must do something with the list of idents.

--- a/pretyping/glob_ops.ml
+++ b/pretyping/glob_ops.ml
@@ -152,7 +152,7 @@ let fix_kind_eq k1 k2 = match k1, k2 with
 let evar_instance_eq f (x1,c1) (x2,c2) =
   Id.equal x1.CAst.v x2.CAst.v && f c1 c2
 
-let mk_glob_constr_eq f c1 c2 = match DAst.get c1, DAst.get c2 with
+let mk_glob_constr_eq f g c1 c2 = match DAst.get c1, DAst.get c2 with
   | GRef (gr1, u1), GRef (gr2, u2) ->
     GlobRef.CanOrd.equal gr1 gr2 &&
     Option.equal instance_eq u1 u2
@@ -163,9 +163,9 @@ let mk_glob_constr_eq f c1 c2 = match DAst.get c1, DAst.get c2 with
   | GApp (f1, arg1), GApp (f2, arg2) ->
     f f1 f2 && List.equal f arg1 arg2
   | GLambda (na1, bk1, t1, c1), GLambda (na2, bk2, t2, c2) ->
-    Name.equal na1 na2 && binding_kind_eq bk1 bk2 && f t1 t2 && f c1 c2
+    g na1 na2 (Some t1) (Some t2) && binding_kind_eq bk1 bk2 && f t1 t2 && f c1 c2
   | GProd (na1, bk1, t1, c1), GProd (na2, bk2, t2, c2) ->
-    Name.equal na1 na2 && binding_kind_eq bk1 bk2 && f t1 t2 && f c1 c2
+    g na1 na2 (Some t1) (Some t2) && binding_kind_eq bk1 bk2 && f t1 t2 && f c1 c2
   | GLetIn (na1, b1, t1, c1), GLetIn (na2, b2, t2, c2) ->
     Name.equal na1 na2 && f b1 b2 && Option.equal f t1 t2 && f c1 c2
   | GCases (st1, c1, tp1, cl1), GCases (st2, c2, tp2, cl2) ->
@@ -202,7 +202,7 @@ let mk_glob_constr_eq f c1 c2 = match DAst.get c1, DAst.get c2 with
      GCases _ | GLetTuple _ | GIf _ | GRec _ | GSort _ | GHole _ | GGenarg _ | GCast _ | GProj _ |
      GInt _ | GFloat _ | GArray _), _ -> false
 
-let rec glob_constr_eq c = mk_glob_constr_eq glob_constr_eq c
+let rec glob_constr_eq c = mk_glob_constr_eq glob_constr_eq (fun na1 na2 _ _ -> Name.equal na1 na2) c
 
 let map_glob_constr_left_to_right f = DAst.map (function
   | GApp (g,args) ->

--- a/pretyping/glob_ops.mli
+++ b/pretyping/glob_ops.mli
@@ -62,6 +62,7 @@ val map_glob_constr_left_to_right :
 val warn_variable_collision : ?loc:Loc.t -> Id.t -> unit
 
 val mk_glob_constr_eq : (glob_constr -> glob_constr -> bool) ->
+  (Name.t -> Name.t -> glob_constr option -> glob_constr option -> bool) ->
   glob_constr -> glob_constr -> bool
 
 val fold_glob_constr : ('a -> glob_constr -> 'a) -> 'a -> glob_constr -> 'a

--- a/pretyping/glob_ops.mli
+++ b/pretyping/glob_ops.mli
@@ -59,6 +59,9 @@ val binding_kind_eq : binding_kind -> binding_kind -> bool
 val map_glob_constr_left_to_right :
   (glob_constr -> glob_constr) -> glob_constr -> glob_constr
 
+val map_glob_constr_left_to_right_with_names :
+  (glob_constr -> glob_constr) -> (Name.t -> Name.t) -> glob_constr -> glob_constr
+
 val warn_variable_collision : ?loc:Loc.t -> Id.t -> unit
 
 val mk_glob_constr_eq : (glob_constr -> glob_constr -> bool) ->

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -267,3 +267,32 @@ fun z : nat => (z, 1, z, 2)
      : nat -> nat * nat * nat * nat
 fun z : nat => [(!!z) + z]
      : nat -> nat * nat * nat * nat * nat
+uncurryλ a b c => a + b + c
+     : unit * nat * nat * nat -> nat
+fun x : unit * nat * (nat * nat) =>
+match x with
+| (x0, y) =>
+    match y with
+    | (a, b) =>
+        let d := 1 in
+        match x0 with
+        | (x1, c) => let 'tt := x1 in a + b + c + d
+        end
+    end
+end
+     : unit * nat * (nat * nat) -> nat
+fun x : unit * nat * (nat * nat) =>
+match x with
+| (x0, (a, b)) => let d := 1 in match x0 with
+                                | (tt, c) => a + b + c + d
+                                end
+end
+     : unit * nat * (nat * nat) -> nat
+uncurryλ '(a, b) => a + b
+     : unit * (nat * nat) -> nat
+lets a b c := 0 in a + b + c
+     : nat
+let
+'(a, b) := (0, 0) in
+ lets d := 1 in let '(c, e) := (0, 0) in a + b + c + d + e
+     : nat

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -588,3 +588,36 @@ Notation "( x )" := x (in custom myconstr2 at level 0, x at level 2).
 Check fun z:nat => [(!! z) + z].
 
 End CustomCyclicNotations.
+
+Module RecursivePatternsInMatch.
+
+Remove Printing Let prod.
+Unset Printing Matching.
+
+Notation "'uncurryλ' x1 .. xn => body"
+  := (fun x => match x with (pair x x1) => .. (match x with (pair x xn) => let 'tt := x in body end) .. end)
+     (at level 200, x1 binder, xn binder, right associativity).
+
+Check uncurryλ a b c => a + b + c.
+
+(* Check other forms of binders, but too complex interaction
+    with pattern-matching compaction for printing *)
+Check uncurryλ '(a,b) (d:=1) c => a + b + c + d.
+
+Set Printing Matching.
+Check uncurryλ '(a,b) (d:=1) c => a + b + c + d.
+
+(* This is a case where printing is easy though, relying on pattern-matching compaction *)
+Check uncurryλ '(a,b) => a + b.
+
+Notation "'lets' x1 .. xn := c 'in' body"
+  := (let x1 := c in .. (let xn := c in body) ..)
+     (at level 200, x1 binder, xn binder, right associativity).
+
+Check lets a b c := 0 in a + b + c.
+
+(* Check other forms of binders, but too complex interaction
+    with pattern-matching factorization for printing *)
+Check lets '(a,b) (d:=1) '(c,e) := (0,0) in a + b + c + d + e.
+
+End RecursivePatternsInMatch.


### PR DESCRIPTION
This seems to work for parsing.

Recognizing instances of the recursive pattern of the notations for printing is more aleatory: it interacts with pattern-matching decompilation (done earlier in detyping) in ways difficult to control.

Fixes #17845

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
