### PR TITLE
Stop mentioning Local, Export, Global prefixes for Set.

### DIFF
--- a/doc/sphinx/language/core/basic.rst
+++ b/doc/sphinx/language/core/basic.rst
@@ -607,7 +607,7 @@ Locality attributes supported by :cmd:`Set` and :cmd:`Unset`
 
 The :cmd:`Set` and :cmd:`Unset` commands support the mutually
 exclusive :attr:`local`, :attr:`export` and :attr:`global` locality
-attributes (or the ``Local``, ``Export`` or ``Global`` prefixes).
+attributes.
 
 If no attribute is specified, the original value of the flag or option
 is restored at the end of the current module but it is *not* restored


### PR DESCRIPTION
Follow-up of the deprecation of the Export prefix in #17333.

The documentation for local and global already mention the Local and Global prefix alternatives.