### PR TITLE
Fixes anomaly #17860: missing a recursive check in notations with multiple nested occurrences of a recursive-binder variable

### DIFF
--- a/doc/changelog/03-notations/17861-master+fix17860-anomaly-isnone-notation-recursive-binders.rst
+++ b/doc/changelog/03-notations/17861-master+fix17860-anomaly-isnone-notation-recursive-binders.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  anomaly when a notation variable denoting a binder occurs nested
+  more than once in a recursive pattern (`#17861
+  <https://github.com/coq/coq/pull/17861>`_, fixes `#17860
+  <https://github.com/coq/coq/issues/17860>`_, by Hugo Herbelin).

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -591,13 +591,13 @@ let compare_recursive_parts recvars found f f' (iterator,subc) =
         aux c term
       | Some (x', y', RecursiveBinders revert') ->
         check_pair_matching ?loc:c1.CAst.loc x y x' y' revert revert';
-        true
+        aux c term
       | Some (x', y', RecursiveTerms revert') ->
         (* Recursive binders have precedence: they can be coerced to
            terms but not reciprocally *)
         check_pair_matching ?loc:c1.CAst.loc x y x' y' revert revert';
         let () = diff := Some (x, y, RecursiveBinders revert) in
-        true
+        aux c term
       end
   | _ ->
       mk_glob_constr_eq aux c1 c2 in

--- a/test-suite/bugs/bug_17860.v
+++ b/test-suite/bugs/bug_17860.v
@@ -1,0 +1,7 @@
+Axiom Reduction_sum : forall {A}, nat -> nat -> nat -> (nat -> A) -> A.
+#[local] Notation "'einsum_partλ0' s => body"
+  := (fun s => Reduction_sum 0 s 1 (fun s => body))
+       (at level 200, s binder, only parsing).
+#[local] Notation "'einsum_partλ' s1 .. sn => body"
+  := (einsum_partλ0 s1 => .. (einsum_partλ0 sn => body) .. )
+       (at level 200, s1 binder, sn binder, only parsing).


### PR DESCRIPTION
Fixes / closes #17860

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
