### PR TITLE
Use vm to speedup printing of numeral notations

### DIFF
--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -443,12 +443,15 @@ module PrimTokenNotation = struct
     https://github.com/coq/coq/issues/9840 for details on what goes
     wrong if this does not happen, e.g., from using the vm rather than
     cbv.
+
+    Using a combination of vm and cbv gives a factor 10 speedup though.
 *)
 
 let eval_constr env sigma (c : Constr.t) =
   let c = EConstr.of_constr c in
-  let sigma, _ = Typing.type_of env sigma c in
-  let c' = Tacred.compute env sigma c in
+  let sigma, t = Typing.type_of env sigma c in
+  let c' = if (Environ.typing_flags env).enable_VM then Vnorm.cbv_vm env sigma c t else c in
+  let c' = Tacred.compute env sigma c' in
   EConstr.Unsafe.to_constr c'
 
 let eval_constr_app env sigma c1 c2 =


### PR DESCRIPTION
@MSoegtropIMC gave the following example of slowness on [Zulip](https://coq.zulipchat.com/#narrow/stream/237662-VsCoq-devs-.26-users/topic/VSCoq.20vs.20CoqIDE.20speed.20on.20large.20terms/near/374910660):

```coq
Require Import ZArith.
Open Scope Z.
Goal 2^17000 <> 0.
Time cbv. (* milliseconds to compute but 15s to display *)
```

Translation to decimal was using cbv (see `Notation.eval_constr`, which is the cause of the slowness, as identified by @ejgallego in the discussion). Using vm alone is not enough because it needs to reduce in types. By using a combination of vm and cbv, we get however a 10x speedup.

Adfditionally, for numbers higher than roughly 2^44000, `Typing.type_of` is a bottleneck. By using retyping instead, we can go until 2^58000 before getting a stack overflow.