### PR TITLE
Don't complain about reregistering a hook afte backtracking

### DIFF
--- a/pretyping/coercion.ml
+++ b/pretyping/coercion.ml
@@ -627,13 +627,16 @@ type hook = env -> evar_map -> flags:Evarconv.unify_flags -> constr ->
 
 let all_hooks = ref (CString.Map.empty : hook CString.Map.t)
 
+let registered_hooks = Summary.ref ~name:"coercion_hooks" CString.Set.empty
+
 let register_hook ~name ?(override=false) h =
-  if not override && CString.Map.mem name !all_hooks then
+  if not override && CString.Set.mem name !registered_hooks then
     CErrors.anomaly ~label:"Coercion.register_hook"
       Pp.(str "Hook already registered: \"" ++ str name ++ str "\".");
+  registered_hooks := CString.Set.add name !registered_hooks;
   all_hooks := CString.Map.add name h !all_hooks
 
-let active_hooks = Summary.ref ~name:"coercion_hooks" ([] : string list)
+let active_hooks = Summary.ref ~name:"coercion_hooks_active" ([] : string list)
 
 let deactivate_hook ~name =
   active_hooks := List.filter (fun s -> not (String.equal s name)) !active_hooks


### PR DESCRIPTION
When doing the following since #17794 

```Coq
Declare ML Module "module-declaring-a-coercion-hook".
(* <backtrack> *)
(* <reexecute previous command> *)
```

Coq complained about "Hook already registered". To avoid that, this commit puts the set of registered hooks under a summary.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
<!-- Fixes / closes #???? -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] ~Added / updated **test-suite**.~ (requires an OCaml module to reproduce)

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] ~Added **changelog**.~ (bug not yet released)
- [ ] ~Added / updated **documentation**.~
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] ~Documented any new / changed **user messages**.~
  - [ ] ~Updated **documented syntax** by running `make doc_gram_rsts`.~

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] ~Opened **overlay** pull requests.~

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
