### PR TITLE
Fix #17871 (inconsistency with native_compute and primitive floats)

### DIFF
--- a/dev/doc/critical-bugs
+++ b/dev/doc/critical-bugs
@@ -601,6 +601,16 @@ Conflicts with axioms in library
   GH_issue_number: #16096
   risk: proof of false when using the axioms in Floats.Axioms.
 
+  component: primitive floating-points + "native" conversion machine (translation to OCaml which compiles to native code)
+  summary: nativenorm reading back closures as arbitrary floating-point values
+  introduced: 8.11
+  impacted released versions: 8.11.0-8.17.1
+  impacted coqchk versions: none (no native computation in coqchk)
+  fixed in: 8.18.0
+  found by: Jason Gross
+  GH issue number: #17871
+  risk: proof of false when using primitive floats and native_compute
+
 There were otherwise several bugs in beta-releases, from memory, bugs with beta versions of primitive projections or template polymorphism or native compilation or guard (e7fc96366, 2a4d714a1).
 
 There were otherwise maybe unexploitable kernel bugs, e.g. 2df88d83 (Require overloading), 0adf0838 ("Univs: uncovered bug in strengthening of opaque polymorphic definitions."), 5122a398 (#3746 about functors), #4346 (casts in VM), a14bef4 (guard condition in 8.1), 6ed40a8 ("Georges' bug" with ill-typed lazy machine), and various other bugs in 8.0 or 8.1 w/o knowing if they are critical.

--- a/doc/changelog/01-kernel/17872-fix_17871.rst
+++ b/doc/changelog/01-kernel/17872-fix_17871.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  a bug enabling :tacn:`native_compute` to yield arbitrary floating-point values
+  (`#17872 <https://github.com/coq/coq/pull/17872>`_,
+  fixes `#17871 <https://github.com/coq/coq/issues/17871>`_,
+  by Guillaume Melquiond and Pierre Roux, bug found by Jason Gross).

--- a/kernel/nativeconv.ml
+++ b/kernel/nativeconv.ml
@@ -70,7 +70,7 @@ and conv_accu env pb lvl k1 k2 cu =
     conv_atom env pb lvl (atom_of_accu k1) (atom_of_accu k2) cu
   else
     let cu = conv_atom env pb lvl (atom_of_accu k1) (atom_of_accu k2) cu in
-    Array.fold_right2 (conv_val env CONV lvl) (args_of_accu k1) (args_of_accu k2) cu
+    List.fold_right2 (conv_val env CONV lvl) (args_of_accu k1) (args_of_accu k2) cu
 
 and conv_atom env pb lvl a1 a2 cu =
   if a1 == a2 then cu

--- a/kernel/nativevalues.mli
+++ b/kernel/nativevalues.mli
@@ -117,7 +117,7 @@ val napply : t -> t array -> t
 
 val dummy_value : unit -> t
 val atom_of_accu : accumulator -> atom
-val args_of_accu : accumulator -> t array
+val args_of_accu : accumulator -> t list
 val accu_nargs : accumulator -> int
 
 val cast_accu : t -> accumulator

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -260,7 +260,7 @@ and nf_args env sigma args t =
     let c = nf_val env sigma arg dom in
     (subst1 c codom, c::l)
   in
-  let t,l = Array.fold_right aux args (t,[]) in
+  let t,l = List.fold_right aux args (t,[]) in
   t, List.rev l
 
 and nf_bargs env sigma b t =
@@ -406,7 +406,7 @@ and nf_evar env sigma evk args =
     let fold accu d = EConstr.mkNamedProd_or_LetIn sigma d accu in
     let t = List.fold_left fold ty hyps in
     let t = EConstr.to_constr ~abort_on_undefined_evars:false sigma t in
-    let ty, args = nf_args env sigma args t in
+    let ty, args = nf_args env sigma (Array.to_list args) t in
     (* nf_args takes arguments in the reverse order but produces them
        in the correct one, so we have to reverse them again for the
        evar node *)

--- a/test-suite/bugs/bug_17871.v
+++ b/test-suite/bugs/bug_17871.v
@@ -1,0 +1,21 @@
+From Coq Require Import PrimFloat.
+
+Definition foo : { x : float | x = 1%float }.
+Proof.
+eexists.
+Set Printing All.
+native_compute.
+(* was giving
+@eq 0x0.05555897461p-1022%float 0x0.05555897461p-1022%float 0x1p+0%float *)
+Abort.
+
+Definition foo x y : ((x =? 0.0) = (y =? 0.0))%float.
+Proof.
+native_cast_no_check (eq_refl (x =? 0.0))%float.
+Fail Defined.
+Abort.
+
+(* the above was succeeding allowing
+Goal False.
+Proof. now generalize (foo 0.0 1.0). Qed.
+*)


### PR DESCRIPTION
The Array.of_list in Nativevalues.args_of_accu could result in an OCaml double array when some argument was a primitive float, making all other argument sometimes wrongfully appear as float themselves.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #17871


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**. (I guess we have to update the cirtical bugs file)
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] ~Documented any new / changed **user messages**.~
  - [ ] ~Updated **documented syntax** by running `make doc_gram_rsts`.~

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] ~Opened **overlay** pull requests.~

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
