### PR TITLE
Add printer support for grammar entries with non-necessary-lower level on their right-hand side

### DIFF
--- a/dev/ci/user-overlays/17875-herbelin-printer-support-for-entries-arbitrary-level-on-right.sh
+++ b/dev/ci/user-overlays/17875-herbelin-printer-support-for-entries-arbitrary-level-on-right.sh
@@ -1,0 +1,2 @@
+overlay serapi https://github.com/proux01/coq-serapi coq_17875 17875
+overlay smtcoq https://github.com/proux01/smtcoq coq-master 17875

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -212,6 +212,7 @@ let extern_reference ?loc vars l = !my_extern_reference vars l
 (* utilities                                                          *)
 
 let rec fill_arg_scopes args subscopes (entry,(_,scopes) as all) =
+  assert (args = [] || notation_entry_eq (fst entry).notation_subentry InConstrEntry);
   match args, subscopes with
   | [], _ -> []
   | a :: args, scopt :: subscopes ->
@@ -219,11 +220,22 @@ let rec fill_arg_scopes args subscopes (entry,(_,scopes) as all) =
   | a :: args, [] ->
     (a, (entry, ([], scopes))) :: fill_arg_scopes args [] all
 
-let update_with_subscope (entry,(scopt,scl)) scopes =
+let overlap_right_left lev_after (typs,_) =
+  List.exists (fun (_id,(({notation_relative_level = lev; notation_position = side},_),_)) ->
+      match side with
+      | Some Right -> may_capture_cont_after lev_after lev
+      | _ -> false) typs
+
+let update_with_subscope from_entry (entry,(scopt,scl)) lev_after closed scopes =
   let {notation_subentry = entry; notation_relative_level = lev; notation_position = side} = entry in
   let lev = if !print_parentheses && side <> None then LevelLe 0 (* min level *) else lev in
+  let lev_after =
+    match side with
+    | Some Left -> Some from_entry.notation_level
+    | Some Right  -> if closed then None else lev_after
+    | None -> None in
   let subentry' = {notation_subentry = entry; notation_relative_level = lev; notation_position = side} in
-  (subentry',(scopt,scl@scopes))
+  ((subentry',lev_after),(scopt,scl@scopes))
 
 (**********************************************************************)
 (* mapping patterns to cases_pattern_expr                                *)
@@ -342,7 +354,7 @@ let extern_record_pattern cstrsp args =
     Not_found | No_match | Exit -> None
 
 (* Better to use extern_glob_constr composed with injection/retraction ?? *)
-let rec extern_cases_pattern_in_scope (custom,scopes as allscopes) vars pat =
+let rec extern_cases_pattern_in_scope ((custom,(lev_after:int option)),scopes as allscopes) vars pat =
   try
     if !Flags.in_debugger || !Flags.raw_print || !print_raw_literal then raise No_match;
     let (na,p,key) = uninterp_prim_token_cases_pattern pat scopes in
@@ -366,7 +378,7 @@ let rec extern_cases_pattern_in_scope (custom,scopes as allscopes) vars pat =
     match availability_of_entry_coercion custom constr_lowest_level with
     | None -> raise No_match
     | Some coercion ->
-      let allscopes = (constr_some_level,scopes) in
+      let allscopes = ((constr_some_level,None),scopes) in
       let pat = match pat with
         | PatVar (Name id) -> CAst.make ?loc (CPatAtom (Some (qualid_of_ident ?loc id)))
         | PatVar (Anonymous) -> CAst.make ?loc (CPatAtom None)
@@ -392,14 +404,17 @@ let rec extern_cases_pattern_in_scope (custom,scopes as allscopes) vars pat =
       insert_pat_coercion coercion pat
 
 and apply_notation_to_pattern ?loc gr ((terms,termlists,binders),(no_implicit,nb_to_drop,more_args))
-    (custom, (tmp_scope, scopes) as allscopes) vars rule =
+    ((custom, lev_after), (tmp_scope, scopes) as allscopes) vars pat rule =
+  let lev_after = if List.is_empty more_args then lev_after else Some Notation.app_level in
   match rule with
     | NotationRule (_,ntn as specific_ntn) ->
       begin
         let entry = fst (Notation.level_of_notation ntn) in
+        let entry = if overlap_right_left lev_after pat then {entry with notation_level = max_int} else entry in
         match availability_of_entry_coercion custom entry with
         | None -> raise No_match
         | Some coercion ->
+        let closed = not (List.is_empty coercion) in
         match availability_of_notation specific_ntn (tmp_scope,scopes) with
           (* Uninterpretation is not allowed in current context *)
           | None -> raise No_match
@@ -408,17 +423,17 @@ and apply_notation_to_pattern ?loc gr ((terms,termlists,binders),(no_implicit,nb
             let scopes' = Option.List.cons scopt scopes in
             let l =
               List.map (fun (c,subscope) ->
-                let scopes = update_with_subscope subscope scopes' in
+                let scopes = update_with_subscope entry subscope lev_after closed scopes' in
                 extern_cases_pattern_in_scope scopes vars c)
                 terms in
             let ll =
               List.map (fun (c,subscope) ->
-                let scopes = update_with_subscope subscope scopes' in
+                let scopes = update_with_subscope entry subscope lev_after closed scopes' in
                 List.map (extern_cases_pattern_in_scope scopes vars) c)
                 termlists in
             let bl =
               List.map (fun (c,subscope) ->
-                let scopes = update_with_subscope subscope scopes' in
+                let scopes = update_with_subscope entry subscope lev_after closed scopes' in
                 (extern_cases_pattern_in_scope scopes vars c, Explicit))
                 binders
             in
@@ -444,7 +459,7 @@ and apply_notation_to_pattern ?loc gr ((terms,termlists,binders),(no_implicit,nb
       let qid = Nametab.shortest_qualid_of_abbreviation ?loc vars kn in
       let l1 =
         List.rev_map (fun (c,(subentry,(scopt,scl))) ->
-          extern_cases_pattern_in_scope (subentry,(scopt,scl@scopes)) vars c)
+          extern_cases_pattern_in_scope ((subentry,lev_after),(scopt,scl@scopes)) vars c)
           terms in
       let subscopes = find_arguments_scope gr in
       let more_args_scopes = try List.skipn nb_to_drop subscopes with Failure _ -> [] in
@@ -470,7 +485,7 @@ and extern_notation_pattern allscopes vars t = function
         | PatCstr (cstr,args,na) ->
           let t = if na = Anonymous then t else DAst.make ?loc (PatCstr (cstr,args,Anonymous)) in
           let p = apply_notation_to_pattern ?loc (GlobRef.ConstructRef cstr)
-            (match_notation_constr_cases_pattern t pat) allscopes vars keyrule in
+            (match_notation_constr_cases_pattern t pat) allscopes vars pat keyrule in
           insert_pat_alias ?loc p na
         | PatVar Anonymous -> CAst.make ?loc @@ CPatAtom None
         | PatVar (Name id) -> CAst.make ?loc @@ CPatAtom (Some (qualid_of_ident ?loc id))
@@ -483,7 +498,7 @@ let rec extern_notation_ind_pattern allscopes vars ind args = function
     try
       if is_printing_inactive_rule keyrule pat then raise No_match;
       apply_notation_to_pattern (GlobRef.IndRef ind)
-        (match_notation_constr_ind_pattern ind args pat) allscopes vars keyrule
+        (match_notation_constr_ind_pattern ind args pat) allscopes vars pat keyrule
     with
         No_match -> extern_notation_ind_pattern allscopes vars ind args rules
 
@@ -507,7 +522,7 @@ let extern_ind_pattern_in_scope (custom,scopes as allscopes) vars ind args =
            |None           -> CAst.make @@ CPatCstr (c, Some args, [])
 
 let extern_cases_pattern vars p =
-  extern_cases_pattern_in_scope (constr_some_level,([],[])) vars p
+  extern_cases_pattern_in_scope ((constr_some_level,None),([],[])) vars p
 
 (**********************************************************************)
 (* Externalising applications *)
@@ -760,7 +775,7 @@ let same_binder_type ty nal c =
 (* mapping glob_constr to numerals (in presence of coercions, choose the *)
 (* one with no delimiter if possible)                                 *)
 
-let extern_possible_prim_token (custom,scopes) r =
+let extern_possible_prim_token ((custom,_),scopes) r =
    if !print_raw_literal then raise No_match;
    let (n,key) = uninterp_prim_token r scopes in
    match availability_of_entry_coercion custom constr_lowest_level with
@@ -896,18 +911,18 @@ let rec extern inctx ?impargs scopes vars r =
 
   let loc = r.CAst.loc in
   match DAst.get r with
-  | GRef (ref,us) when entry_has_global (fst scopes) -> CAst.make ?loc (extern_ref vars ref us)
+  | GRef (ref,us) when entry_has_global (fst (fst scopes)) -> CAst.make ?loc (extern_ref vars ref us)
 
-  | GVar id when entry_has_global (fst scopes) || entry_has_ident (fst scopes) ->
+  | GVar id when entry_has_global (fst (fst scopes)) || entry_has_ident (fst (fst scopes)) ->
       CAst.make ?loc (extern_var ?loc id)
 
   | c ->
 
-  match availability_of_entry_coercion (fst scopes) constr_lowest_level with
+  match availability_of_entry_coercion (fst (fst scopes)) constr_lowest_level with
   | None -> raise No_match
   | Some coercion ->
 
-  let scopes = (constr_some_level, snd scopes) in
+  let scopes = ((constr_some_level, None), snd scopes) in
   let c = match c with
 
   (* The remaining cases are only for the constr entry *)
@@ -1190,7 +1205,7 @@ and extern_notations inctx scopes vars nargs t =
     let t = flatten_application t in
     extern_notation inctx scopes vars t (filter_enough_applied nargs (uninterp_notations t))
 
-and extern_notation inctx (custom,scopes as allscopes) vars t rules =
+and extern_notation inctx ((custom,(lev_after: int option)),scopes as allscopes) vars t rules =
   match rules with
   | [] -> raise No_match
   | (keyrule,pat,n as _rule)::rules ->
@@ -1233,11 +1248,13 @@ and extern_notation inctx (custom,scopes as allscopes) vars t rules =
         let vars, uvars = vars in
         let terms,termlists,binders,binderlists =
           match_notation_constr ~print_univ:(!print_universes) t ~vars pat in
+        let lev_after = if List.is_empty args then lev_after else Some Notation.app_level in
         (* Try availability of interpretation ... *)
         match keyrule with
           | NotationRule (_,ntn as specific_ntn) ->
             let entry = fst (Notation.level_of_notation ntn) in
-             (match availability_of_entry_coercion custom entry with
+            let non_empty = overlap_right_left lev_after pat in
+             (match availability_of_entry_coercion ~non_empty custom entry with
              | None -> raise No_match
              | Some coercion ->
                match availability_of_notation specific_ntn scopes with
@@ -1245,22 +1262,23 @@ and extern_notation inctx (custom,scopes as allscopes) vars t rules =
               | None -> raise No_match
                   (* Uninterpretation is allowed in current context *)
               | Some (scopt,key) ->
+                  let closed = not (List.is_empty coercion) in
                   let scopes' = Option.List.cons scopt (snd scopes) in
                   let l =
                     List.map (fun ((vars,c),subscope) ->
-                      let scopes = update_with_subscope subscope scopes' in
+                      let scopes = update_with_subscope entry subscope lev_after closed scopes' in
                       extern (* assuming no overloading: *) true scopes (vars,uvars) c)
                       terms
                   in
                   let ll =
                     List.map (fun ((vars,l),subscope) ->
-                      let scopes = update_with_subscope subscope scopes' in
+                      let scopes = update_with_subscope entry subscope lev_after closed scopes' in
                       List.map (extern true scopes (vars,uvars)) l)
                       termlists
                   in
                   let bl =
                     List.map (fun ((vars,bl),subscope) ->
-                      let scopes = update_with_subscope subscope scopes' in
+                      let scopes = update_with_subscope entry subscope lev_after closed scopes' in
                         (mkCPatOr (List.map
                                      (extern_cases_pattern_in_scope scopes vars) bl)),
                         Explicit)
@@ -1268,7 +1286,7 @@ and extern_notation inctx (custom,scopes as allscopes) vars t rules =
                   in
                   let bll =
                     List.map (fun ((vars,bl),subscope) ->
-                      let scopes = update_with_subscope subscope scopes' in
+                      let scopes = update_with_subscope entry subscope lev_after closed scopes' in
                       pi3 (extern_local_binder scopes (vars,uvars) bl))
                       binderlists
                   in
@@ -1280,7 +1298,7 @@ and extern_notation inctx (custom,scopes as allscopes) vars t rules =
           | AbbrevRule kn ->
               let l =
                 List.map (fun ((vars,c),(subentry,(scopt,scl))) ->
-                  extern true (subentry,(scopt,scl@snd scopes)) (vars,uvars) c)
+                  extern true ((subentry,lev_after),(scopt,scl@snd scopes)) (vars,uvars) c)
                   terms
               in
               let cf = Nametab.shortest_qualid_of_abbreviation ?loc vars kn in
@@ -1308,10 +1326,10 @@ and extern_applied_proj inctx scopes vars (cst,us) params c extraargs =
   extern_projection inctx (f,us) nparams args imps
 
 let extern_glob_constr vars c =
-  extern false (constr_some_level,([],[])) vars c
+  extern false ((constr_some_level,None),([],[])) vars c
 
 let extern_glob_type ?impargs vars c =
-  extern_typ ?impargs (constr_some_level,([],[])) vars c
+  extern_typ ?impargs ((constr_some_level,None),([],[])) vars c
 
 (******************************************************************)
 (* Main translation function from constr -> constr_expr *)
@@ -1320,7 +1338,7 @@ let extern_constr ?(inctx=false) ?scope env sigma t =
   let r = Detyping.detype Detyping.Later Id.Set.empty env sigma t in
   let vars = extern_env env sigma in
   let scope = Option.cata (fun x -> [x]) [] scope in
-  extern inctx (constr_some_level,(scope,[])) vars r
+  extern inctx ((constr_some_level,None),(scope,[])) vars r
 
 let extern_constr_in_scope ?inctx scope env sigma t =
   extern_constr ?inctx ~scope env sigma t
@@ -1346,7 +1364,7 @@ let extern_closed_glob ?(goal_concl_style=false) ?(inctx=false) ?scope env sigma
   in
   let vars = extern_env env sigma in
   let scope = Option.cata (fun x -> [x]) [] scope in
-  extern inctx (constr_some_level,(scope,[])) vars r
+  extern inctx ((constr_some_level,None),(scope,[])) vars r
 
 (******************************************************************)
 (* Main translation function from pattern -> constr_expr *)
@@ -1488,7 +1506,7 @@ and glob_of_pat_under_context avoid env sigma (nas, pat) =
   (Array.rev_of_list nas, pat)
 
 let extern_constr_pattern env sigma pat =
-  extern true (constr_some_level,([],[]))
+  extern true ((constr_some_level,None),([],[]))
     (* XXX no vars? *)
     (Id.Set.empty, Evd.universe_binders sigma)
     (glob_of_pat Id.Set.empty env sigma pat)
@@ -1497,4 +1515,4 @@ let extern_rel_context where env sigma sign =
   let a = detype_rel_context Detyping.Later where Id.Set.empty (names_of_rel_context env,env) sigma sign in
   let vars = extern_env env sigma in
   let a = List.map (extended_glob_local_binder_of_decl) a in
-  pi3 (extern_local_binder (constr_some_level,([],[])) vars a)
+  pi3 (extern_local_binder ((constr_some_level,None),([],[])) vars a)

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1652,6 +1652,11 @@ let prec_less child = function
   | LevelLe parent -> child <= parent
   | LevelSome -> true
 
+let may_capture_cont_after child parent =
+  match child with
+  | None -> false
+  | Some lev_after -> prec_less lev_after parent
+
 type entry_coercion_kind =
   | IsEntryCoercion of notation_entry_level * notation_entry_relative_level
   | IsEntryGlobal of string * int

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1561,10 +1561,10 @@ let rec search nfrom nto = function
   | ((pfrom,pto),coe)::l ->
     if entry_relative_level_le pfrom nfrom && entry_relative_level_le nto pto then coe else search nfrom nto l
 
-let availability_of_entry_coercion
+let availability_of_entry_coercion ?(non_empty=false)
     ({ notation_subentry = entry; notation_relative_level = sublev } as entry_sublev)
     ({ notation_entry = entry'; notation_level = lev' } as entry_lev) =
-  if included entry_lev entry_sublev then
+  if included entry_lev entry_sublev && not non_empty then
     (* [entry] is by default included in [relative_entry] *)
     Some []
   else

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1645,6 +1645,13 @@ let entry_has_ident { notation_subentry = entry; notation_relative_level = n } =
   | InCustomEntry s ->
      try entry_relative_level_le (String.Map.find s !entry_has_ident_map) n with Not_found -> false
 
+let app_level = 10
+
+let prec_less child = function
+  | LevelLt parent -> child < parent
+  | LevelLe parent -> child <= parent
+  | LevelSome -> true
+
 type entry_coercion_kind =
   | IsEntryCoercion of notation_entry_level * notation_entry_relative_level
   | IsEntryGlobal of string * int

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -376,6 +376,7 @@ val entry_has_ident : notation_entry_relative_level -> bool
 val app_level : int
 
 val prec_less : entry_level -> entry_relative_level -> bool
+val may_capture_cont_after : entry_level option -> entry_relative_level -> bool
 
 (** {6 Declare and test the level of a (possibly uninterpreted) notation } *)
 

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -362,7 +362,7 @@ val declare_entry_coercion : specific_notation -> notation_entry_level -> notati
   (** Add a coercion from some-entry to some-relative-entry *)
 
 type entry_coercion = (notation_with_optional_scope * notation) list
-val availability_of_entry_coercion : notation_entry_relative_level -> notation_entry_level -> entry_coercion option
+val availability_of_entry_coercion : ?non_empty:bool -> notation_entry_relative_level -> notation_entry_level -> entry_coercion option
   (** Return a coercion path from some-relative-entry to some-entry if there is one *)
 
 (** Special properties of entries *)

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -373,6 +373,10 @@ val declare_custom_entry_has_ident : string -> int -> unit
 val entry_has_global : notation_entry_relative_level -> bool
 val entry_has_ident : notation_entry_relative_level -> bool
 
+val app_level : int
+
+val prec_less : entry_level -> entry_relative_level -> bool
+
 (** {6 Declare and test the level of a (possibly uninterpreted) notation } *)
 
 val declare_notation_level : notation -> level -> unit

--- a/interp/notationextern.mli
+++ b/interp/notationextern.mli
@@ -30,6 +30,9 @@ val interpretation_eq : interpretation -> interpretation -> bool
 val notation_entry_level_eq : notation_entry_level -> notation_entry_level -> bool
 (** Equality on [notation_entry_level]. *)
 
+val notation_entry_relative_level_eq : notation_entry_relative_level -> notation_entry_relative_level -> bool
+(** Equality on [notation_entry_relative_level]. *)
+
 type level = notation_entry_level * entry_relative_level list
 (** The "signature" of a rule: its level together with the levels of its subentries *)
 

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -1060,7 +1060,7 @@ let pr_goal_selector ~toplevel s =
               pr_with_comments ?loc (pr.pr_alias (level_of inherited) kn l), latom
           )
           in
-          if prec_less prec inherited then strm
+          if Notation.prec_less prec inherited then strm
           else str"(" ++ strm ++ str")"
 
         and pr_tacarg = function

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -69,18 +69,19 @@ let tag_var = tag Tag.variable
   let ldelim = 1
   let lsimpleconstr = LevelLe 8
   let lsimplepatt = LevelLe 1
+  let no_after = None
 
   let prec_of_prim_token = function
     | Number (NumTok.SPlus,_) -> lposint
     | Number (NumTok.SMinus,_) -> lnegint
     | String _ -> latom
 
-  let adjust_level side prec =
+  let adjust_level side lev_after l_not prec =
     match side with
-    | Some _ when !Constrextern.print_parentheses -> LevelLe 0
-    | _ -> prec (* should we care about the separator being possibly empty? *)
+    | Some _ when !Constrextern.print_parentheses -> lev_after, LevelLe 0
+    | _ -> lev_after,prec (* should we care about the separator being possibly empty? *)
 
-  let print_hunks l_not pr pr_patt pr_binders (terms, termlists, binders, binderlists) unps =
+  let print_hunks l_not lev_after pr pr_patt pr_binders (terms, termlists, binders, binderlists) unps =
     let env = ref terms and envlist = ref termlists and bl = ref binders and bll = ref binderlists in
     let pop r = let a = List.hd !r in r := List.tl !r; a in
     let return unp pp1 pp2 = (tag_unparsing unp pp1) ++ pp2 in
@@ -94,8 +95,8 @@ let tag_var = tag Tag.variable
       | UnpMetaVar {notation_relative_level = prec; notation_position = side} as unp :: l ->
         let c = pop env in
         let pp2 = aux l in
-        let prec = adjust_level side prec in
-        let pp1 = pr prec c in
+        let lev_after, prec = adjust_level side lev_after l_not prec in
+        let pp1 = pr lev_after prec c in
         return unp pp1 pp2
       | UnpBinderMetaVar (subentry,style) as unp :: l ->
         let c,bk = pop bl in
@@ -103,9 +104,16 @@ let tag_var = tag Tag.variable
         let pp1 = pr_patt subentry.notation_relative_level style bk c in
         return unp pp1 pp2
       | UnpListMetaVar ({notation_relative_level = prec; notation_position = side}, sl) as unp :: l ->
-        let cl = pop envlist in
-        let prec' = adjust_level side prec in
-        let pp1 = prlist_with_sep (fun () -> aux sl) (pr prec') cl in
+        let lev_after', prec' = adjust_level side lev_after l_not prec in
+        let pp1 =
+          match pop envlist with
+          | [] -> assert false
+          | [c] -> pr lev_after' prec' c
+          | c1::cl ->
+            let cn, cl = List.sep_last cl in
+            pr lev_after' prec c1 ++
+            prlist (fun c -> aux sl ++ pr (if List.is_empty sl then Some l_not else no_after) prec c) cl ++
+            aux sl ++ pr lev_after prec' cn in
         let pp2 = aux l in
         return unp pp1 pp2
       | UnpBinderListMetaVar (isopen, withquote, sl) as unp :: l ->
@@ -128,9 +136,9 @@ let tag_var = tag Tag.variable
     in
     aux unps
 
-  let pr_notation pr pr_patt pr_binders which s env =
+  let pr_notation lev_after pr pr_patt pr_binders which s env =
     let { notation_printing_unparsing = unpl; notation_printing_level = level } = find_notation_printing_rule which s in
-    print_hunks level pr pr_patt pr_binders env unpl
+    print_hunks level lev_after pr pr_patt pr_binders env unpl
 
   let pr_delimiters key strm =
     strm ++ str ("%"^key)
@@ -215,18 +223,18 @@ let tag_var = tag Tag.variable
   let pr_cref ref us =
     pr_reference ref ++ pr_universe_instance us
 
-  let pr_expl_args pr (a,expl) =
+  let pr_expl_args pr lev_after (a,expl) =
     match expl with
-      | None -> pr (LevelLt lapp) a
+      | None -> pr lev_after (LevelLt lapp) a
       | Some {v=pos} ->
         let pr_pos = function
           | ExplByName id -> pr_id id
           | ExplByPos p -> int p in
-        str "(" ++ pr_pos pos ++ str ":=" ++ pr ltop a ++ str ")"
+        str "(" ++ pr_pos pos ++ str ":=" ++ pr no_after ltop a ++ str ")"
 
   let pr_opt_type_spc pr = function
     | { CAst.v = CHole (_,IntroAnonymous) } -> mt ()
-    | t ->  str " :" ++ pr_sep_com (fun()->brk(1,4)) (pr ltop) t
+    | t ->  str " :" ++ pr_sep_com (fun()->brk(1,4)) (pr no_after ltop) t
 
   let pr_prim_token = function
     | Number n -> NumTok.Signed.print n
@@ -238,7 +246,7 @@ let tag_var = tag Tag.variable
         (match l with
           | [] -> mt()
           | l ->
-            let f (id,c) = pr_lident id ++ str ":=" ++ pr ltop c in
+            let f (id,c) = pr_lident id ++ str ":=" ++ pr no_after ltop c in
             str"@{" ++ hov 0 (prlist_with_sep pr_semicolon f (List.rev l)) ++ str"}"))
 
   (* Assuming "{" and "}" brackets, prints
@@ -283,81 +291,83 @@ let tag_var = tag Tag.variable
   let lpatcast = LevelLe 100
   let lpattop = LevelLe 200
 
-  let rec pr_patt_args pr args =
+  let rec pr_patt_args pr lev_after args =
     match args with
     | [] -> mt ()
     | args ->
       let last, args = List.sep_last args in
-      prlist (pr_patt spc pr (LevelLt lapp)) args ++ pr_patt spc pr (LevelLt lapp) last
+      prlist (pr_patt spc pr (Some lapp) (LevelLt lapp)) args ++ pr_patt spc pr lev_after (LevelLt lapp) last
 
-  and pr_patt sep pr inh p =
-    let return pp prec =
+  and pr_patt sep pr lev_after inh p =
+    let return cmds prec =
       let no_surround = Notation.prec_less prec inh in
+      let pp = cmds lev_after in
       let pp = if no_surround then pp else surround pp in
       pr_with_comments ?loc:p.CAst.loc (sep() ++ pp) in
     match CAst.(p.v) with
       | CPatRecord l ->
-        return (pr_record_body "{|" "|}" (pr_patt spc pr lpattop) l) lpatrec
+        return (fun lev_after -> pr_record_body "{|" "|}" (pr_patt spc pr no_after lpattop) l) lpatrec
 
       | CPatAlias (p, na) ->
-        return (pr_patt mt pr (LevelLe las) p ++ str " as " ++ pr_lname na) las
+        return (fun lev_after -> pr_patt mt pr lev_after (LevelLe las) p ++ str " as " ++ pr_lname na) las
 
       | CPatCstr (c, None, []) ->
-        return (pr_reference c) latom
+        return (fun lev_after -> pr_reference c) latom
 
       | CPatCstr (c, None, args) ->
-        return (pr_reference c ++ pr_patt_args pr args) lapp
+        return (fun lev_after -> pr_reference c ++ pr_patt_args pr lev_after args) lapp
 
       | CPatCstr (c, Some args, []) ->
-        return (str "@" ++ pr_reference c ++ pr_patt_args pr args) lapp
+        return (fun lev_after -> str "@" ++ pr_reference c ++ pr_patt_args pr lev_after args) lapp
 
       | CPatCstr (c, Some expl_args, extra_args) ->
-        return (
-            surround (str "@" ++ pr_reference c ++ pr_patt_args pr expl_args)
-            ++ pr_patt_args pr extra_args) lapp
+        return (fun lev_after ->
+            surround (str "@" ++ pr_reference c ++ pr_patt_args pr lev_after expl_args)
+            ++ pr_patt_args pr lev_after extra_args) lapp
 
       | CPatAtom (None) ->
-        return (str "_") latom
+        return (fun lev_after -> str "_") latom
 
       | CPatAtom (Some r) ->
-        return (pr_reference r) latom
+        return (fun lev_after -> pr_reference r) latom
 
       | CPatOr pl ->
-        return (
-            let pp p = hov 0 (pr_patt mt pr lpattop p) in
+        return (fun lev_after ->
+            let pp p = hov 0 (pr_patt mt pr lev_after lpattop p) in
             surround (hov 0 (prlist_with_sep pr_spcbar pp pl))) lpator
 
       | CPatNotation (_,(_,"( _ )"),([p],[],[]),[]) ->
-        return (pr_patt (fun()->str"(") pr lpattop p ++ str")") latom
+        return (fun lev_after -> pr_patt (fun()->str"(") pr no_after lpattop p ++ str")") latom
 
       | CPatNotation (which,s,(l,ll,bl),args) ->
         let l_not = (find_notation_printing_rule which s).notation_printing_level in
         let no_inner_surrounding = List.is_empty args || Notation.prec_less l_not (LevelLt lapp) in
-        return (
-            let strm_not = pr_notation (pr_patt mt pr) (pr_patt_binder pr) (fun _ _ _ _ -> mt()) which s (l,ll,bl,[]) in
+        return (fun lev_after ->
+            let lev_after' = if no_inner_surrounding then lev_after else no_after in
+            let strm_not = pr_notation lev_after (pr_patt mt pr) (pr_patt_binder pr) (fun _ _ _ _ -> mt()) which s (l,ll,bl,[]) in
             (if List.is_empty args then strm_not else
             if Notation.prec_less l_not (LevelLt lapp) then strm_not else
               surround strm_not)
-            ++ pr_patt_args pr args)
+            ++ pr_patt_args pr lev_after' args)
           (if not (List.is_empty args) then lapp else if no_inner_surrounding then l_not else latom)
 
       | CPatPrim p ->
-        return (pr_prim_token p) latom
+        return (fun lev_after -> pr_prim_token p) latom
 
       | CPatDelimiters (k,p) ->
-        return (pr_delimiters k (pr_patt mt pr lsimplepatt p)) 1
+        return (fun lev_after -> pr_delimiters k (pr_patt mt pr (Some 1) lsimplepatt p)) 1
 
       | CPatCast (p,t) ->
-        return (pr_patt mt pr lpatcast p ++ spc () ++ str ":" ++ ws 1 ++ pr t) 1
+        return (fun lev_after -> pr_patt mt pr (Some 1) lpatcast p ++ spc () ++ str ":" ++ ws 1 ++ pr t) 1
 
   and pr_patt_binder pr prec style bk c =
     match bk with
-    | MaxImplicit -> str "{" ++ pr_patt mt pr lpattop c ++ str "}"
-    | NonMaxImplicit -> str "[" ++ pr_patt mt pr lpattop c ++ str "]"
+    | MaxImplicit -> str "{" ++ pr_patt mt pr no_after lpattop c ++ str "}"
+    | NonMaxImplicit -> str "[" ++ pr_patt mt pr no_after lpattop c ++ str "]"
     | Explicit ->
       match style, c with
-      | NotQuotedPattern, _ | _, {v=CPatAtom _} -> pr_patt mt pr prec c
-      | QuotedPattern, _ -> str "'" ++ pr_patt mt pr prec c
+      | NotQuotedPattern, _ | _, {v=CPatAtom _} -> pr_patt mt pr no_after prec c
+      | QuotedPattern, _ -> str "'" ++ pr_patt mt pr no_after prec c
 
   let pr_patt = pr_patt mt
 
@@ -366,9 +376,9 @@ let tag_var = tag Tag.variable
       (pr_with_comments ?loc
          (str "| " ++
             hov 0 (prlist_with_sep pr_spcbar
-                     (fun p -> hov 0 (prlist_with_sep sep_v (pr_patt (pr ltop) ltop) p)) pl
+                     (fun p -> hov 0 (prlist_with_sep sep_v (pr_patt (pr no_after ltop) no_after ltop) p)) pl
                    ++ str " =>") ++
-            pr_sep_com spc (pr ltop) rhs))
+            pr_sep_com spc (pr no_after ltop) rhs))
 
   let begin_of_binder l_bi =
     let b_loc l = fst (Option.cata Loc.unloc (0,0) l) in
@@ -424,7 +434,7 @@ let tag_var = tag Tag.variable
                 pr_opt_no_spc (fun t -> str " :" ++ ws 1 ++ pr_c t) topt ++
                 str" :=" ++ spc() ++ pr_c c)
     | CLocalPattern p ->
-      str (if withquote then "'" else "") ++ pr_patt pr_c lsimplepatt p
+      str (if withquote then "'" else "") ++ pr_patt pr_c no_after lsimplepatt p
 
   let pr_undelimited_binders sep withquote pr_c =
     prlist_with_sep sep (pr_binder_among_many withquote pr_c)
@@ -442,13 +452,13 @@ let tag_var = tag Tag.variable
     if is_open then pr_delimited_binders pr_com_at sep withquote pr_c
     else pr_undelimited_binders sep withquote pr_c
 
-  let pr_recursive_decl pr pr_dangling kw dangling_with_for id bl annot t c =
+  let pr_recursive_decl pr pr_dangling lev_after kw dangling_with_for id bl annot t c =
     let pr_body =
       if dangling_with_for then pr_dangling else pr in
     hov 0 (str kw ++ brk(1,2) ++ pr_id id ++ (if bl = [] then mt () else brk(1,2)) ++
-      hov 0 (pr_undelimited_binders spc true (pr ltop) bl ++ annot) ++
+      hov 0 (pr_undelimited_binders spc true (pr no_after ltop) bl ++ annot) ++
       pr_opt_type_spc pr t ++ str " :=") ++
-      pr_sep_com (fun () -> brk(1,2)) (pr_body ltop) c
+      pr_sep_com (fun () -> brk(1,2)) (pr_body lev_after ltop) c
 
   let pr_guard_annot pr_aux bl ro =
     match ro with
@@ -471,20 +481,20 @@ let tag_var = tag Tag.variable
             match id with None -> mt() | Some id -> brk (1,1) ++ pr_lident id ++
               (match r with None -> mt() | Some r -> str" on " ++ pr_aux r) ++ str"}"
 
-  let pr_fixdecl pr prd kw dangling_with_for ({v=id},ro,bl,t,c) =
-    let annot = pr_guard_annot (pr lsimpleconstr) bl ro in
-    pr_recursive_decl pr prd kw dangling_with_for id bl annot t c
+  let pr_fixdecl pr prd lev_after kw dangling_with_for ({v=id},ro,bl,t,c) =
+    let annot = pr_guard_annot (pr no_after lsimpleconstr) bl ro in
+    pr_recursive_decl pr prd lev_after kw dangling_with_for id bl annot t c
 
-  let pr_cofixdecl pr prd kw dangling_with_for ({v=id},bl,t,c) =
-    pr_recursive_decl pr prd kw dangling_with_for id bl (mt()) t c
+  let pr_cofixdecl pr prd lev_after kw dangling_with_for ({v=id},bl,t,c) =
+    pr_recursive_decl pr prd lev_after kw dangling_with_for id bl (mt()) t c
 
-  let pr_recursive kw pr_decl id = function
+  let pr_recursive lev_after kw pr_decl id = function
     | [] -> anomaly (Pp.str "(co)fixpoint with no definition.")
-    | [d1] -> pr_decl kw false d1
+    | [d1] -> pr_decl lev_after kw false d1
     | d1::dl ->
-      pr_decl kw true d1 ++ fnl() ++
+      pr_decl no_after kw true d1 ++ fnl() ++
       prlist_with_sep (fun () -> fnl())
-        (pr_decl "with" true) dl ++
+        (pr_decl no_after "with" true) dl ++
         fnl() ++ keyword "for" ++ spc () ++ pr_id id
 
   let pr_as_in pr na indnalopt =
@@ -493,16 +503,16 @@ let tag_var = tag Tag.variable
       | None -> mt ()) ++
       (match indnalopt with
         | None -> mt ()
-        | Some t -> spc () ++ keyword "in" ++ spc () ++ pr_patt pr lsimplepatt t)
+        | Some t -> spc () ++ keyword "in" ++ spc () ++ pr_patt pr no_after lsimplepatt t)
 
   let pr_case_item pr (tm,as_clause, in_clause) =
-    hov 0 (pr (LevelLe lcast) tm ++ pr_as_in (pr ltop) as_clause in_clause)
+    hov 0 (pr no_after (LevelLe lcast) tm ++ pr_as_in (pr no_after ltop) as_clause in_clause)
 
   let pr_case_type pr po =
     match po with
       | None | Some { CAst.v = CHole (_,IntroAnonymous) } -> mt()
       | Some p ->
-        spc() ++ hov 2 (keyword "return" ++ pr_sep_com spc (pr lsimpleconstr) p)
+        spc() ++ hov 2 (keyword "return" ++ pr_sep_com spc (pr no_after lsimpleconstr) p)
 
   let pr_simple_return_type pr na po =
     (match na with
@@ -512,27 +522,27 @@ let tag_var = tag Tag.variable
       pr_case_type pr po
 
   let pr_proj pr pr_app a f l =
-    hov 0 (pr (LevelLe lproj) a ++ cut() ++ str ".(" ++ pr_app pr f l ++ str ")")
+    hov 0 (pr (Some lproj) (LevelLe lproj) a ++ cut() ++ str ".(" ++ pr_app pr no_after f l ++ str ")")
 
-  let pr_appexpl pr (f,us) l =
+  let pr_appexpl pr lev_after (f,us) l =
     let pargs = match l with
     | [] -> mt ()
     | args ->
       let last, l = List.sep_last l in
-      prlist (pr_sep_com spc (pr (LevelLt lapp))) l ++
-      pr_sep_com spc (pr (LevelLt lapp)) last in
+      prlist (pr_sep_com spc (pr (Some lapp) (LevelLt lapp))) l ++
+      pr_sep_com spc (pr lev_after (LevelLt lapp)) last in
     hov 2 (
       str "@" ++ pr_reference f ++
         pr_universe_instance us ++ pargs)
 
-  let pr_app pr a l =
+  let pr_app pr lev_after a l =
     let pargs = match l with
     | [] -> mt ()
     | args ->
       let last, l = List.sep_last l in
-      prlist (fun a -> spc () ++ pr_expl_args pr a) l ++
-      spc () ++ pr_expl_args pr last in
-    hov 2 (pr (LevelLt lapp) a ++ pargs)
+      prlist (fun a -> spc () ++ pr_expl_args pr (Some lapp) a) l ++
+      spc () ++ pr_expl_args pr lev_after last in
+    hov 2 (pr (Some lapp) (LevelLt lapp) a ++ pargs)
 
   let pr_forall n = keyword "forall" ++ pr_com_at n ++ spc ()
 
@@ -540,12 +550,12 @@ let tag_var = tag Tag.variable
 
   let pr_fun_sep = spc () ++ str "=>"
 
-  let pr_dangling_with_for sep pr inherited a =
+  let pr_dangling_with_for sep pr lev_after inherited a =
     match a.v with
       | (CFix (_,[_])|CCoFix(_,[_])) ->
-        pr sep (LevelLe latom) a
+        pr sep lev_after (LevelLe latom) a
       | _ ->
-        pr sep inherited a
+        pr sep lev_after inherited a
 
   let pr_cast = let open Constr in function
     | Some DEFAULTcast -> str ":"
@@ -586,89 +596,89 @@ let tag_var = tag Tag.variable
       else name
     in
     let pp = if String.is_empty name then parg else str name ++ str ":" ++ surround parg in
-    return pp latom
+    return (fun _ -> pp) latom
 
-  let pr pr sep inherited a =
+  let pr pr sep lev_after inherited a =
     let return cmds prec =
       let no_surround = Notation.prec_less prec inherited in
-      let pp = tag_constr_expr a (cmds) in
+      let pp = tag_constr_expr a (cmds lev_after) in
       let pp = if no_surround then pp else surround pp in
       pr_with_comments ?loc:a.CAst.loc (sep() ++ pp) in
     match CAst.(a.v) with
       | CRef (r, us) ->
-        return (pr_cref r us) latom
+        return (fun _ -> pr_cref r us) latom
       | CFix (id,fix) ->
-        return (
-          hv 0 (pr_recursive "fix"
+        return (fun lev_after ->
+          hv 0 (pr_recursive lev_after "fix"
                    (pr_fixdecl (pr mt) (pr_dangling_with_for mt pr)) id.v fix))
           lfix
       | CCoFix (id,cofix) ->
-        return (
-          hv 0 (pr_recursive "cofix"
+        return (fun lev_after ->
+          hv 0 (pr_recursive lev_after "cofix"
                    (pr_cofixdecl (pr mt) (pr_dangling_with_for mt pr)) id.v cofix))
           lfix
       | CProdN (bl,a) ->
-        return (
+        return (fun lev_after ->
           hov 0 (
             hov 2 (pr_delimited_binders pr_forall spc true
-                     (pr mt ltop) bl) ++
-              str "," ++ pr spc ltop a))
+                     (pr mt no_after ltop) bl) ++
+              str "," ++ pr spc lev_after ltop a))
           lprod
       | CLambdaN (bl,a) ->
-        return (
+        return (fun lev_after ->
           hov 0 (
             hov 2 (pr_delimited_binders pr_fun spc true
-                     (pr mt ltop) bl) ++
-              pr_fun_sep ++ pr spc ltop a))
+                     (pr mt no_after ltop) bl) ++
+              pr_fun_sep ++ pr spc lev_after ltop a))
           llambda
       | CLetIn ({v=Name x}, ({ v = CFix({v=x'},[_])}
                           |  { v = CCoFix({v=x'},[_]) } as fx), t, b)
           when Id.equal x x' ->
-        return (
+        return (fun lev_after ->
           hv 0 (
-            hov 2 (keyword "let" ++ spc () ++ pr mt ltop fx
+            hov 2 (keyword "let" ++ spc () ++ pr mt no_after ltop fx
                    ++ spc ()
                    ++ keyword "in") ++
-              pr spc ltop b))
+              pr spc lev_after ltop b))
           lletin
       | CLetIn (x,a,t,b) ->
-        return (
+        return (fun lev_after ->
           hv 0 (
             hov 2 (keyword "let" ++ spc () ++ pr_lname x
-                   ++ pr_opt_no_spc (fun t -> str " :" ++ ws 1 ++ pr mt ltop t) t
-                   ++ str " :=" ++ pr spc ltop a ++ spc ()
+                   ++ pr_opt_no_spc (fun t -> str " :" ++ ws 1 ++ pr mt no_after ltop t) t
+                   ++ str " :=" ++ pr spc no_after ltop a ++ spc ()
                    ++ keyword "in") ++
-              pr spc ltop b))
+              pr spc lev_after ltop b))
           lletin
       | CProj (true,(f,us),l,c) ->
         let l = List.map (function (c,None) -> c | _ -> assert false) l in
-        return (pr_proj (pr mt) pr_appexpl c (f,us) l) lproj
+        return (fun lev_after -> pr_proj (pr mt) pr_appexpl c (f,us) l) lproj
       | CProj (false,(f,us),l,c) ->
-        return (pr_proj (pr mt) pr_app c (CAst.make (CRef (f,us))) l) lproj
+        return (fun lev_after -> pr_proj (pr mt) pr_app c (CAst.make (CRef (f,us))) l) lproj
       | CAppExpl ((qid,us),[t])
       | CApp ({v = CRef(qid,us)},[t,None])
           when qualid_is_ident qid && Id.equal (qualid_basename qid) Notation_ops.ldots_var ->
-        return (
-          hov 0 (str ".." ++ pr spc (LevelLe latom) t ++ spc () ++ str ".."))
+        return (fun lev_after ->
+          hov 0 (str ".." ++ pr spc no_after (LevelLe latom) t ++ spc () ++ str ".."))
           larg
       | CAppExpl ((f,us),l) ->
-        return (pr_appexpl (pr mt) (f,us) l) lapp
+        return (fun lev_after -> pr_appexpl (pr mt) lev_after (f,us) l) lapp
       | CApp (a,l) ->
-        return (pr_app (pr mt) a l) lapp
+        return (fun lev_after -> pr_app (pr mt) lev_after a l) lapp
       | CRecord l ->
-        return (pr_record_body "{|" "|}" (pr spc ltop) l) latom
+        return (fun lev_after -> pr_record_body "{|" "|}" (pr spc no_after ltop) l) latom
       | CCases (Constr.LetPatternStyle,rtntypopt,[c,as_clause,in_clause],[{v=([[p]],b)}]) ->
-        return (
+        return (fun lev_after ->
           hv 0 (
             keyword "let" ++ spc () ++ str"'" ++
-              hov 0 (pr_patt (pr mt ltop) ltop p ++
-                       pr_as_in (pr mt ltop) as_clause in_clause ++
-                       str " :=" ++ pr spc ltop c ++
+              hov 0 (pr_patt (pr mt no_after ltop) no_after ltop p ++
+                       pr_as_in (pr mt no_after ltop) as_clause in_clause ++
+                       str " :=" ++ pr spc no_after ltop c ++
                        pr_case_type (pr_dangling_with_for mt pr) rtntypopt ++
-                       spc () ++ keyword "in" ++ pr spc ltop b)))
+                       spc () ++ keyword "in" ++ pr spc lev_after ltop b)))
           lletpattern
       | CCases(_,rtntypopt,c,eqns) ->
-        return (
+        return (fun lev_after ->
           v 0
             (hv 0 (keyword "match" ++ brk (1,2) ++
                      hov 0 (
@@ -680,62 +690,62 @@ let tag_var = tag Tag.variable
              ++ keyword "end"))
           latom
       | CLetTuple (nal,(na,po),c,b) ->
-        return (
+        return (fun lev_after ->
           hv 0 (
             hov 2 (keyword "let" ++ spc () ++
               hov 1 (str "(" ++
                        prlist_with_sep sep_v pr_lname nal ++
                        str ")" ++
                        pr_simple_return_type (pr mt) na po ++ str " :=") ++
-                       pr spc ltop c
+                       pr spc no_after ltop c
                      ++ keyword " in") ++
-              pr spc ltop b))
+              pr spc lev_after ltop b))
           lletin
       | CIf (c,(na,po),b1,b2) ->
       (* On force les parenthèses autour d'un "if" sous-terme (même si le
          parsing est lui plus tolérant) *)
-        return (
+        return (fun lev_after ->
           hv 0 (
-            hov 1 (keyword "if" ++ spc () ++ pr mt ltop c
+            hov 1 (keyword "if" ++ spc () ++ pr mt no_after ltop c
                    ++ pr_simple_return_type (pr mt) na po) ++
               spc () ++
               hov 0 (keyword "then"
-                     ++ pr (fun () -> brk (1,1)) ltop b1) ++ spc () ++
-              hov 0 (keyword "else" ++ pr (fun () -> brk (1,1)) ltop b2)))
+                     ++ pr (fun () -> brk (1,1)) no_after ltop b1) ++ spc () ++
+              hov 0 (keyword "else" ++ pr (fun () -> brk (1,1)) lev_after ltop b2)))
         lif
       | CHole (_,IntroIdentifier id) ->
-        return (str "?[" ++ pr_id id ++ str "]") latom
+        return (fun lev_after -> str "?[" ++ pr_id id ++ str "]") latom
       | CHole (_,IntroFresh id) ->
-        return (str "?[?" ++ pr_id id ++ str "]") latom
-      | CHole _ -> return (str "_") latom
+        return (fun lev_after -> str "?[?" ++ pr_id id ++ str "]") latom
+      | CHole _ -> return (fun lev_after -> str "_") latom
       | CGenarg arg -> pr_genarg return (Rawarg arg)
       | CGenargGlob arg -> pr_genarg return (Globarg arg)
       | CEvar (n,l) ->
-        return (pr_evar (pr mt) n l) latom
+        return (fun lev_after -> pr_evar (pr mt) n l) latom
       | CPatVar p ->
-        return (str "@?" ++ pr_patvar p) latom
+        return (fun lev_after -> str "@?" ++ pr_patvar p) latom
       | CSort s ->
-        return (pr_sort_expr s) latom
+        return (fun lev_after -> pr_sort_expr s) latom
       | CCast (a,k,b) ->
-        return (
-          hv 0 (pr mt (LevelLt lcast) a ++ spc () ++
-                (pr_cast k) ++ ws 1 ++ pr mt (LevelLe lprod) b))
+        return (fun lev_after ->
+          hv 0 (pr mt no_after (LevelLt lcast) a ++ spc () ++
+                (pr_cast k) ++ ws 1 ++ pr mt lev_after (LevelLe lprod) b))
           lcast
       | CNotation (_,(_,"( _ )"),([t],[],[],[])) ->
-        return (pr (fun()->str"(") ltop t ++ str")") latom
+        return (fun lev_after -> pr (fun()->str"(") no_after ltop t ++ str")") latom
       | CNotation (which,s,env) ->
         let l_not = (find_notation_printing_rule which s).notation_printing_level in
-        return (pr_notation (pr mt) (pr_patt_binder (pr mt ltop)) (pr_binders_gen (pr mt ltop)) which s env) l_not
+        return (fun lev_after -> pr_notation lev_after (pr mt) (pr_patt_binder (pr mt no_after ltop)) (pr_binders_gen (pr mt no_after ltop)) which s env) l_not
       | CGeneralization (bk,c) ->
-        return (pr_generalization bk (pr mt ltop c)) latom
+        return (fun lev_after -> pr_generalization bk (pr mt no_after ltop c)) latom
       | CPrim p ->
-        return (pr_prim_token p) (prec_of_prim_token p)
+        return (fun lev_after ->pr_prim_token p) (prec_of_prim_token p)
       | CDelimiters (sc,a) ->
-        return (pr_delimiters sc (pr mt (LevelLe ldelim) a)) ldelim
+        return (fun lev_after -> pr_delimiters sc (pr mt (Some ldelim) (LevelLe ldelim) a)) ldelim
       | CArray(u, t,def,ty) ->
-        return (hov 0 (str "[| " ++ prvect_with_sep (fun () -> str "; ") (pr mt ltop) t ++
+        return (fun lev_after -> hov 0 (str "[| " ++ prvect_with_sep (fun () -> str "; ") (pr mt no_after ltop) t ++
                (if not (Array.is_empty t) then str " " else mt()) ++
-               str "|" ++ spc() ++ pr mt ltop def ++ pr_opt_type_spc (pr mt) ty ++
+               str "|" ++ spc() ++ pr mt no_after ltop def ++ pr_opt_type_spc (pr mt) ty ++
                str " |]" ++ pr_universe_instance u)) 0
 
   type term_pr = {
@@ -749,13 +759,13 @@ let tag_var = tag Tag.variable
   let rec fix rf x = rf (fix rf) x
   let pr = fix modular_constr_pr mt
 
-  let pr prec = function
+  let pr lev_after prec = function
     (* A toplevel printer hack mimicking parsing, incidentally meaning
        that we cannot use [pr] correctly anymore in a recursive loop
        if the current expr is followed by other exprs which would be
        interpreted as arguments *)
     | { CAst.v = CAppExpl ((f,us),[]) } -> str "@" ++ pr_cref f us
-    | c -> pr prec c
+    | c -> pr lev_after prec c
 
   let transf env sigma c =
     if !Flags.beautify_file then
@@ -763,28 +773,28 @@ let tag_var = tag Tag.variable
       Constrextern.(extern_glob_constr (extern_env env sigma)) r
     else c
 
-  let pr_expr env sigma prec c =
-    pr prec (transf env sigma c)
+  let pr_expr env sigma lev_after prec c =
+    pr lev_after prec (transf env sigma c)
 
-  let pr_simpleconstr env sigma = pr_expr env sigma lsimpleconstr
+  let pr_simpleconstr env sigma = pr_expr env sigma no_after lsimpleconstr
 
   let default_term_pr = {
     pr_constr_expr   = pr_simpleconstr;
-    pr_lconstr_expr  = (fun env sigma -> pr_expr env sigma ltop);
+    pr_lconstr_expr  = (fun env sigma -> pr_expr env sigma no_after ltop);
     pr_constr_pattern_expr  = pr_simpleconstr;
-    pr_lconstr_pattern_expr = (fun env sigma -> pr_expr env sigma ltop)
+    pr_lconstr_pattern_expr = (fun env sigma -> pr_expr env sigma no_after ltop)
   }
 
   let term_pr = ref default_term_pr
 
   let set_term_pr = (:=) term_pr
 
-  let pr_constr_expr_n n c = pr_expr n c
+  let pr_constr_expr_n n c = pr_expr n c no_after
   let pr_constr_expr c   = !term_pr.pr_constr_expr   c
   let pr_lconstr_expr c  = !term_pr.pr_lconstr_expr  c
   let pr_constr_pattern_expr c  = !term_pr.pr_constr_pattern_expr  c
   let pr_lconstr_pattern_expr c = !term_pr.pr_lconstr_pattern_expr c
 
-  let pr_cases_pattern_expr = pr_patt (pr ltop) ltop
+  let pr_cases_pattern_expr = pr_patt (pr no_after ltop) no_after ltop
 
-  let pr_binders env sigma = pr_undelimited_binders spc true (pr_expr env sigma ltop)
+  let pr_binders env sigma = pr_undelimited_binders spc true (pr_expr env sigma no_after ltop)

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -93,17 +93,17 @@ let tag_var = tag Tag.variable
     let rec aux = function
       | [] ->
         mt ()
-      | UnpMetaVar (prec, side) as unp :: l ->
+      | UnpMetaVar {notation_relative_level = prec; notation_position = side} as unp :: l ->
         let c = pop env in
         let pp2 = aux l in
         let pp1 = pr (if parens && side <> None then LevelLe 0 else prec) c in
         return unp pp1 pp2
-      | UnpBinderMetaVar (prec,style) as unp :: l ->
+      | UnpBinderMetaVar (subentry,style) as unp :: l ->
         let c,bk = pop bl in
         let pp2 = aux l in
-        let pp1 = pr_patt prec style bk c in
+        let pp1 = pr_patt subentry.notation_relative_level style bk c in
         return unp pp1 pp2
-      | UnpListMetaVar (prec, sl, side) as unp :: l ->
+      | UnpListMetaVar ({notation_relative_level = prec; notation_position = side}, sl) as unp :: l ->
         let cl = pop envlist in
         let pp1 = prlist_with_sep (fun () -> aux sl) (pr (if parens && side <> None then LevelLe 0 else prec)) cl in
         let pp2 = aux l in

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -62,7 +62,7 @@ let tag_var = tag Tag.variable
   let lfix = 200
   let lcast = 100
   let larg = 9
-  let lapp = 10
+  let lapp = Notation.app_level
   let lposint = 0
   let lnegint = 35 (* must be consistent with Notation "- x" *)
   let ltop = LevelLe 200
@@ -70,11 +70,6 @@ let tag_var = tag Tag.variable
   let ldelim = 1
   let lsimpleconstr = LevelLe 8
   let lsimplepatt = LevelLe 1
-
-  let prec_less child = function
-    | LevelLt parent -> (<) child parent
-    | LevelLe parent -> if parent < 0 && Int.equal child lprod then true else child <= abs parent
-    | LevelSome -> true
 
   let prec_of_prim_token = function
     | Number (NumTok.SPlus,_) -> lposint
@@ -319,7 +314,7 @@ let tag_var = tag Tag.variable
 
       | CPatNotation (which,s,(l,ll,bl),args) ->
         let strm_not, l_not = pr_notation (pr_patt mt pr) (pr_patt_binder pr) (fun _ _ _ -> mt) which s (l,ll,bl,[]) in
-        (if List.is_empty args||prec_less l_not (LevelLt lapp) then strm_not else surround strm_not)
+        (if List.is_empty args||Notation.prec_less l_not (LevelLt lapp) then strm_not else surround strm_not)
         ++ prlist (pr_patt spc pr (LevelLt lapp)) args, if not (List.is_empty args) then lapp else l_not
 
       | CPatPrim p ->
@@ -333,7 +328,7 @@ let tag_var = tag Tag.variable
     in
     let loc = p.CAst.loc in
     pr_with_comments ?loc
-      (sep() ++ if prec_less prec inh then strm else surround strm)
+      (sep() ++ if Notation.prec_less prec inh then strm else surround strm)
 
   and pr_patt_binder pr prec style bk c =
     match bk with
@@ -724,7 +719,7 @@ let tag_var = tag Tag.variable
     in
     let loc = constr_loc a in
     pr_with_comments ?loc
-      (sep() ++ if prec_less prec inherited then strm else surround strm)
+      (sep() ++ if Notation.prec_less prec inherited then strm else surround strm)
 
   type term_pr = {
     pr_constr_expr   : Environ.env -> Evd.evar_map -> constr_expr -> Pp.t;

--- a/printing/ppconstr.mli
+++ b/printing/ppconstr.mli
@@ -16,8 +16,6 @@ open Libnames
 open Constrexpr
 open Names
 
-val prec_less : entry_level -> entry_relative_level -> bool
-
 val pr_tight_coma : unit -> Pp.t
 
 val pr_with_comments : ?loc:Loc.t -> Pp.t -> Pp.t

--- a/printing/ppconstr.mli
+++ b/printing/ppconstr.mli
@@ -77,5 +77,5 @@ val default_term_pr : term_pr
 val lsimpleconstr : entry_relative_level
 val ltop : entry_relative_level
 val modular_constr_pr :
-  ((unit->Pp.t) -> entry_relative_level -> constr_expr -> Pp.t) ->
-  (unit->Pp.t) -> entry_relative_level -> constr_expr -> Pp.t
+  ((unit->Pp.t) -> int option -> entry_relative_level -> constr_expr -> Pp.t) ->
+  (unit->Pp.t) -> int option -> entry_relative_level -> constr_expr -> Pp.t

--- a/printing/ppextend.ml
+++ b/printing/ppextend.ml
@@ -39,9 +39,9 @@ let ppcmd_of_cut = function
 type pattern_quote_style = QuotedPattern | NotQuotedPattern
 
 type unparsing =
-  | UnpMetaVar of entry_relative_level * side option
-  | UnpBinderMetaVar of entry_relative_level * pattern_quote_style
-  | UnpListMetaVar of entry_relative_level * unparsing list * side option
+  | UnpMetaVar of notation_entry_relative_level
+  | UnpBinderMetaVar of notation_entry_relative_level * pattern_quote_style
+  | UnpListMetaVar of notation_entry_relative_level * unparsing list
   | UnpBinderListMetaVar of
       bool (* true if open binder *) *
       bool (* true if printed with a quote *) *
@@ -53,9 +53,9 @@ type unparsing =
 type unparsing_rule = unparsing list
 
 let rec unparsing_eq unp1 unp2 = match (unp1,unp2) with
-  | UnpMetaVar (p1,s1), UnpMetaVar (p2,s2) -> entry_relative_level_eq p1 p2 && s1 = s2
-  | UnpBinderMetaVar (p1,s1), UnpBinderMetaVar (p2,s2) -> entry_relative_level_eq p1 p2 && s1 = s2
-  | UnpListMetaVar (p1,l1,s1), UnpListMetaVar (p2,l2,s2) -> entry_relative_level_eq p1 p2 && List.for_all2eq unparsing_eq l1 l2 && s1 = s2
+  | UnpMetaVar subentry1, UnpMetaVar subentry2 -> notation_entry_relative_level_eq subentry1 subentry2
+  | UnpBinderMetaVar (subentry1,s1), UnpBinderMetaVar (subentry2,s2) -> notation_entry_relative_level_eq subentry1 subentry2 && s1 = s2
+  | UnpListMetaVar (subentry1,l1), UnpListMetaVar (subentry2,l2) -> notation_entry_relative_level_eq subentry1 subentry2 && List.for_all2eq unparsing_eq l1 l2
   | UnpBinderListMetaVar (b1,q1,l1), UnpBinderListMetaVar (b2,q2,l2) -> b1 = b2 && q1 = q2 && List.for_all2eq unparsing_eq l1 l2
   | UnpTerminal s1, UnpTerminal s2 -> String.equal s1 s2
   | UnpBox (b1,l1), UnpBox (b2,l2) -> b1 = b2 && List.for_all2eq unparsing_eq (List.map snd l1) (List.map snd l2)

--- a/printing/ppextend.mli
+++ b/printing/ppextend.mli
@@ -32,9 +32,9 @@ type pattern_quote_style = QuotedPattern | NotQuotedPattern
 
 (** Declare and look for the printing rule for symbolic notations *)
 type unparsing =
-  | UnpMetaVar of entry_relative_level * side option
-  | UnpBinderMetaVar of entry_relative_level * pattern_quote_style
-  | UnpListMetaVar of entry_relative_level * unparsing list * side option
+  | UnpMetaVar of notation_entry_relative_level
+  | UnpBinderMetaVar of notation_entry_relative_level * pattern_quote_style
+  | UnpListMetaVar of notation_entry_relative_level * unparsing list
   | UnpBinderListMetaVar of
       bool (* true if open binder *) *
       bool (* true if printed with a quote *) *

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -263,3 +263,7 @@ lambda x y : nat, x + y = 0
      : nat -> nat -> Prop
 ((!!nat) + bool)%type
      : Set
+fun z : nat => (z, 1, z, 2)
+     : nat -> nat * nat * nat * nat
+fun z : nat => [(!!z) + z]
+     : nat -> nat * nat * nat * nat * nat

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -261,3 +261,5 @@ Notation "[[ _ ]]" is already defined at level 0 with arguments custom foo
 while it is now required to be at level 0 with arguments custom bar.
 lambda x y : nat, x + y = 0
      : nat -> nat -> Prop
+((!!nat) + bool)%type
+     : Set

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -568,3 +568,23 @@ Notation "! x" := (list x) (at level 0, x at level 50, right associativity, form
 Check ((!!nat) + bool)%type.
 
 End CyclicNotations.
+
+Module CustomCyclicNotations.
+
+Declare Custom Entry myconstr2.
+Notation "[ x ]" := x (x custom myconstr2 at level 6).
+Notation "! x" := (x,1) (in custom myconstr2 at level 0, x at level 2, format "! x").
+Notation "x + y" := (x,y,2) (in custom myconstr2 at level 2, left associativity).
+Notation "x" := x (in custom myconstr2 at level 0, x ident).
+
+(* Check that the custom notation is not used, because parentheses are
+    missing in the entry *)
+Check fun z:nat => ((z,1),z,2).
+
+Notation "( x )" := x (in custom myconstr2 at level 0, x at level 2).
+
+(* Check that parentheses are preserved when an entry refers on the
+   right on a higher level than where it is *)
+Check fun z:nat => [(!! z) + z].
+
+End CustomCyclicNotations.

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -561,3 +561,10 @@ Notation "'lambda' x .. y , t" := (λ x .. y, t) (at level 200, x binder, y bind
 Check lambda x y, x+y=0.
 
 End RecursivePatternsArgumentsInRecursiveNotations.
+
+Module CyclicNotations.
+
+Notation "! x" := (list x) (at level 0, x at level 50, right associativity, format "! x").
+Check ((!!nat) + bool)%type.
+
+End CyclicNotations.


### PR DESCRIPTION
This fixes bugs such as:
```coq
Notation "! x" := (x+1) (at level 10, x at level 50, right associativity, format "! x").
Check (!0) + 0.
(* before: wrongly "!0 + 0" (that parses again as "!(0+0)"); after: "(!0) + 0" *)
```

We use the same trick as in #17832, that is to pass the right-hand side continuation of the expression being printed, so that a collision of level can be detected and protected by parentheses (see message of main commit for more details).

In the case of custom notations, it is the same except that the protection is done using the "parsing coercions" provided by the user for the corresponding custom entry.

Note: in theory, the management of levels in ppconstr.ml could be removed and plugged on the generic mechanism used for custom notations. The gain would then be to have only mechanism. The drawback (in some sense) is that the insertion of parentheses would then be done at externing time (at the time of going from glob_constr to constr_expr) rather than at printing time (at the time of going from constr_expr to Pp.t), which would be a slight change of point of view on the role of printing.

The PR would also allow to move prefix rules with high-level right-hand side (such as binder_constr) to a lower level without breaking the printing.

 [x] Added / updated **test-suite**.

#### Overlays

- [x] https://github.com/ejgallego/coq-serapi/pull/352
- [x] https://github.com/smtcoq/smtcoq/pull/125