### PR TITLE
Declaration of Ltac2 primitives using a GADT-based mechanism

### DIFF
--- a/plugins/ltac2/tac2externals.ml
+++ b/plugins/ltac2/tac2externals.ml
@@ -1,0 +1,89 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Proofview
+open Tac2ffi
+
+(* Local shortcuts. *)
+type v = Tac2ffi.valexpr
+type 'r of_v = v -> 'r
+type 'r to_v = 'r -> v
+type 'a with_env = Environ.env -> Evd.evar_map -> 'a
+
+(* We use two levels of GADT to get rid of the third type parameter, which has
+   to be give for this type definition to be accepted. If we remove it, we get
+   an error: "a type variable cannot be deduced from the type parameters". *)
+type (_, _, _) spec_aux =
+  | T : 'r to_v -> (v tactic, 'r tactic, 'r) spec_aux
+  | V : 'r to_v -> (v tactic, 'r, 'r) spec_aux
+  | E : 'r to_v -> (v tactic, 'r with_env, 'r) spec_aux
+  | G : 'r to_v -> (v tactic, Goal.t -> 'r, 'r) spec_aux
+  | F : 'a of_v * ('t, 'f, 'r) spec_aux -> (v -> 't , 'a -> 'f, 'r) spec_aux
+
+type (_,_) spec = S : ('v,'f,'r) spec_aux -> ('v,'f) spec [@@unboxed]
+
+let tac : type r. r repr -> (v tactic, r tactic) spec = fun r ->
+  S (T (repr_of r))
+
+let tac': type r. r to_v -> (v tactic, r tactic) spec = fun tr ->
+  S (T tr)
+
+let ret : type r. r repr -> (v tactic, r) spec = fun r ->
+  S (V (repr_of r))
+
+let ret': type r. r to_v -> (v tactic, r) spec = fun tr ->
+  S (V tr)
+
+let eret : type r. r repr -> (v tactic, r with_env) spec = fun r ->
+  S (E (repr_of r))
+
+let eret': type r. r to_v -> (v tactic, r with_env) spec = fun tr ->
+  S (E tr)
+
+let gret : type r. r repr -> (v tactic, Goal.t -> r) spec = fun r ->
+  S (G (repr_of r))
+
+let gret': type r. r to_v -> (v tactic, Goal.t -> r) spec = fun tr ->
+  S (G tr)
+
+let (@->) : type a t f. a repr -> (t,f) spec -> (v -> t, a -> f) spec =
+  fun r (S ar) -> S (F (repr_to r, ar))
+
+let (@-->): type a t f. a of_v -> (t,f) spec -> (v -> t, a -> f) spec =
+  fun of_v (S ar) -> S (F (of_v, ar))
+
+let rec interp_spec : type v f. (v,f) spec -> f -> v = fun (S ar) f ->
+  let open Proofview.Notations in
+  match ar with
+  | T tr -> f >>= fun v -> tclUNIT (tr v)
+  | V tr -> tclUNIT (tr f)
+  | E tr -> tclENV >>= fun e -> tclEVARMAP >>= fun s -> tclUNIT (tr (f e s))
+  | G tr -> Goal.enter_one @@ fun g -> tclUNIT (tr (f g))
+  | F (tr,ar) -> fun v -> interp_spec (S ar) (f (tr v))
+
+let rec arity_of : type v f. (v,f) spec -> v Tac2ffi.arity = fun (S ar) ->
+  match ar with
+  | F (_, T _) -> Tac2ffi.arity_one
+  | F (_, V _) -> Tac2ffi.arity_one
+  | F (_, E _) -> Tac2ffi.arity_one
+  | F (_, G _) -> Tac2ffi.arity_one
+  | F (_, ar) -> Tac2ffi.arity_suc (arity_of (S ar))
+  | _ -> invalid_arg "Tac2def.arity_of: not a function spec"
+
+let define : type v f. _ -> (v,f) spec -> f -> unit = fun n ar v ->
+  let v =
+    match ar with
+    | S (V tr) -> tr v
+    | S (F _) ->
+        let cl = Tac2ffi.mk_closure (arity_of ar) (interp_spec ar v) in
+        Tac2ffi.of_closure cl
+    | _ -> invalid_arg "Tac2def.define: not a pure value"
+  in
+  Tac2env.define_primitive n v

--- a/plugins/ltac2/tac2externals.mli
+++ b/plugins/ltac2/tac2externals.mli
@@ -1,0 +1,89 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Proofview
+open Tac2ffi
+
+(** Interface for defining external tactics via a high-level spec. *)
+
+(** Type [('v,'f) spec] represents a high-level Ltac2 tactic specification. It
+    indicates how to turn a value of type ['f] into an Ltac2 tactic, which may
+    involve converting between OCaml and Ltac2 value representations, and also
+    lifting a pure function to the tactic monad. The type parameter ['v] gives
+    the type of value produced by interpreting the specification. *)
+type (_, _) spec
+
+(** [tac r] is the specification of a tactic (in the tactic monad sense) whose
+    return type is specified (and converted into an Ltac2 value) via [r]. *)
+val tac :
+  'r repr ->
+  (valexpr tactic, 'r tactic) spec
+
+(** [tac'] is similar to [tac], but only needs a conversion function. *)
+val tac' :
+  ('r -> valexpr) ->
+  (valexpr tactic, 'r tactic) spec
+
+(** [ret r] is the specification of a pure tactic (i.e., a tactic defined as a
+    pure OCaml value, not needing the tactic monad) whose return type is given
+    by [r] (see [tac]). *)
+val ret :
+  'r repr ->
+  (valexpr tactic, 'r) spec
+
+(** [ret'] is similar to [ret], but only needs a conversion function. *)
+val ret' :
+  ('r -> valexpr) ->
+  (valexpr tactic, 'r) spec
+
+(** [eret] is similar to [ret], but for tactics that can be implemented with a
+    pure OCaml value, provided extra arguments [env] and [sigma], computed via
+    [tclENV] and [tclEVARMAP]. *)
+val eret :
+  'r repr ->
+  (valexpr tactic, Environ.env -> Evd.evar_map -> 'r) spec
+
+(** [eret'] is similar to [eret], but only needs a conversion function. *)
+val eret' :
+  ('r -> valexpr) ->
+  (valexpr tactic, Environ.env -> Evd.evar_map -> 'r) spec
+
+(** [gret] is similar to [ret], but for tactics that can be implemented with a
+    pure OCaml value, provided the current goal [g] as extra argument. A fatal
+    error is produced when there is not exactly one goal in focus at the point
+    of using an Ltac2 value defined with this specification. Indeed, the value
+    of [g] is computed using [Goal.enter_one]. *)
+val gret :
+  'r repr ->
+  (valexpr tactic, Goal.t -> 'r) spec
+
+(** [gret'] is similar to [gret], but only needs a conversion function. *)
+val gret' :
+  ('r -> valexpr) ->
+  (valexpr tactic, Goal.t -> 'r) spec
+
+(** [r @-> s] extends the specification [s] with a closure argument whose type
+    is specified by (and converted from an Ltac2 value via) [r]. *)
+val (@->) :
+  'a repr ->
+  ('t,'f) spec ->
+  (valexpr -> 't, 'a -> 'f) spec
+
+(** [(@-->)] is similar to [(@->)], but only needs a conversion function. *)
+val (@-->) :
+  (valexpr -> 'a) ->
+  ('t,'f) spec ->
+  (valexpr -> 't, 'a -> 'f) spec
+
+(** [define tac s f] defines an external tactic [tac] by interpreting [f] with
+    the specification [s]. The [Invalid_argument] exception is raised when the
+    given [s] does not produce a "pure" tactic, that is, something that can be
+    turned into an Ltac2 value (i.e., a closure, or a pure value). *)
+val define : Tac2expr.ml_tactic_name -> (_, 'f) spec -> 'f -> unit


### PR DESCRIPTION
This makes it more convenient to write Ltac2 primitive.

Basically, this lets you do things like:
```
let () = define "add_int" (int @-> int @-> ret int) (+)
```
using infix notations that look like a type (similar to what is used in, e.g., the `ctypes` OCaml library).

The idea is that you give a specification that looks like a type, and all the value conversions are taken care of for you. There are several variations of the `ret` function:
- `ret` specifies that the computation does not happen in the tactic monad at all,
- `tac` is the tactic monad variation of `ret`,
- `eret` is similar to `ret`, but the function also receives `env` (from `tclENV`) and `sigma` (from `tclSIGMA`) as additional arguments.
- `gret` is similar to `eret`, but the function receives instead the goal.

The last two are probably not exactly the right thing: I think we might want a single-goal version of `eret`, that fails when there are more than one goal, uses the `env` and `sigma` from the goal if there is exactly one, and falls back to `tclENV` / `tclSIGMA` if there are no goals.

Note that I have ported most of the Ltac2 functions to this new mechanism.

- [x] Decide on the exact variants of `ret`/`tac` we want.
- [x] Add documentation to `plugins/ltac2/tac2def.mli`.
- [x] ~~Added **changelog**.~~
