### PR TITLE
CI: adjust Windows CI to changes in Coq Platform (folder name)

### DIFF
--- a/dev/ci/platform/coq-pf-04-installer.bat
+++ b/dev/ci/platform/coq-pf-04-installer.bat
@@ -10,14 +10,14 @@ SET BASH=%CYGROOT%\bin\bash
 
 MKDIR %GITHUB_WORKSPACE%\artifacts
 
-%BASH% --login -c "pwd && ls -la && cd coq-platform && windows/create_installer_windows.sh" || GOTO ErrorExit
+%BASH% --login -c "pwd && ls -la && cd platform && windows/create_installer_windows.sh" || GOTO ErrorExit
 
 REM Output is in cygwin home; in general the script has a bit of a
 REM mess in terms of using the GITHUB_WORKSPACE sometimes, and the
 REM CYGWIN home some others. I use the path here directly as to avoid
 REM issues with quoting, which in the previous script required some
 REM really obscure code.
-COPY /v /b %CYGROOT%\home\runneradmin\coq-platform\windows_installer\*.exe %GITHUB_WORKSPACE%\artifacts || GOTO ErrorExit
+COPY /v /b %CYGROOT%\home\runneradmin\platform\windows_installer\*.exe %GITHUB_WORKSPACE%\artifacts || GOTO ErrorExit
 
 GOTO :EOF
 


### PR DESCRIPTION
This PR adjusts Coq's CI to changes in Coq Platform. The Coq Platform coq-ci branch recently had to be updated to adjust to changes in Cygwin and this brought in a change in folder names, to which Coq's CI needs to be adjusted.

@SkySkimmer : FYI