### PR TITLE
Faster number printing algorithm

### DIFF
--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -435,6 +435,10 @@ and nf_array env sigma t typ =
 let evars_of_evar_map sigma =
   { Genlambda.evars_val = Evd.evar_handler sigma }
 
+let reify_vm env sigma v typ =
+  let typ = EConstr.Unsafe.to_constr typ in
+  EConstr.of_constr (nf_val env sigma v typ)
+
 let cbv_vm env sigma c t  =
   if not (Environ.typing_flags env).enable_VM then
     CErrors.user_err Pp.(str "vm_compute reduction has been disabled.");
@@ -442,6 +446,5 @@ let cbv_vm env sigma c t  =
     CErrors.user_err Pp.(str "vm_compute does not support metas.");
   (* This evar-normalizes terms beforehand *)
   let c = EConstr.Unsafe.to_constr c in
-  let t = EConstr.Unsafe.to_constr t in
   let v = Vmsymtable.val_of_constr env (evars_of_evar_map sigma) c in
-  EConstr.of_constr (nf_val env sigma v t)
+  reify_vm env sigma v t

--- a/pretyping/vnorm.mli
+++ b/pretyping/vnorm.mli
@@ -13,3 +13,5 @@ open Environ
 
 (** {6 Reduction functions } *)
 val cbv_vm : env -> Evd.evar_map -> constr -> types -> constr
+
+val reify_vm : env -> Evd.evar_map -> Vmvalues.values -> types -> constr


### PR DESCRIPTION
POC for a variant of / an alternative to #17862. Instead of mixing cbv with the vm to normalize inductive parameters, we do it directly during reification.

- The first commit is standalone and should probably be integrated regardless of the solution taken. It provides an abstraction over the Constr.t type to manipulate first-order values used by the printing algorithm, allowing to destructure them in a lazy way (i.e. we just need head normalization).
- The second one is an ad-hoc implementation of VM reification to produce such first-order tokens. Quite ugly and code-duplicating but this is just a POC, maybe we can do better.