### PR TITLE
Stop reimplementing our own Pervasives shim in Util.

### DIFF
--- a/engine/logic_monad.ml
+++ b/engine/logic_monad.ml
@@ -69,7 +69,7 @@ struct
     let map f a = (); fun () -> f (a ())
   end)
 
-  type 'a ref = 'a Util.pervasives_ref
+  type 'a ref = 'a Stdlib.ref
 
   let ignore a = (); fun () -> ignore (a ())
 

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -57,7 +57,7 @@ let pr_notation (from,ntn) = qstring ntn ++ match from with InConstrEntry -> mt 
 module NotationOrd =
   struct
     type t = notation
-    let compare = pervasives_compare
+    let compare = Stdlib.compare
   end
 
 module NotationSet = Set.Make(NotationOrd)
@@ -66,7 +66,7 @@ module NotationMap = CMap.Make(NotationOrd)
 module SpecificNotationOrd =
   struct
     type t = specific_notation
-    let compare = pervasives_compare
+    let compare = Stdlib.compare
   end
 
 module SpecificNotationSet = Set.Make(SpecificNotationOrd)
@@ -1526,7 +1526,7 @@ type entry_coercion = (notation_with_optional_scope * notation) list
 module EntryCoercionOrd =
  struct
   type t = notation_entry * notation_entry
-   let compare = pervasives_compare
+   let compare = Stdlib.compare
  end
 
 module EntryCoercionMap = Map.Make(EntryCoercionOrd)

--- a/interp/numTok.ml
+++ b/interp/numTok.ml
@@ -48,7 +48,7 @@ struct
       try
         for i = 0 to d-1 do if s.[i] != '0' then raise (Comp 1) done;
         for i = d to l-1 do
-          let c = Util.pervasives_compare s.[i] s'.[i-d] in
+          let c = Stdlib.compare s.[i] s'.[i-d] in
           if c != 0 then raise (Comp c)
         done;
         0

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -8,13 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-type 'a pervasives_ref = 'a ref
-let pervasives_ref = ref
-let pervasives_compare = compare
-let (!) = (!)
-let (+) = (+)
-let (-) = (-)
-
 (* Mapping under pairs *)
 
 let on_fst f (a,b) = (f a,b)

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -8,13 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-type 'a pervasives_ref = 'a ref
-val pervasives_ref : 'a -> 'a ref
-val pervasives_compare : 'a -> 'a -> int
-val (!) : 'a ref -> 'a
-val (+) : int -> int -> int
-val (-) : int -> int -> int
-
 (** This module contains numerous utility functions on strings, lists,
    arrays, etc. *)
 

--- a/parsing/notgram_ops.ml
+++ b/parsing/notgram_ops.ml
@@ -10,7 +10,6 @@
 
 open Pp
 open CErrors
-open Util
 open Notation
 
 (* Register the grammar of notation for parsing and printing

--- a/plugins/extraction/common.ml
+++ b/plugins/extraction/common.ml
@@ -128,7 +128,7 @@ module KOrd =
 struct
   type t = kind * string
   let compare (k1, s1) (k2, s2) =
-    let c = pervasives_compare k1 k2 (* OK *) in
+    let c = Stdlib.compare k1 k2 (* OK *) in
     if c = 0 then String.compare s1 s2
     else c
 end

--- a/plugins/ltac/tactic_debug.ml
+++ b/plugins/ltac/tactic_debug.ml
@@ -497,11 +497,11 @@ let print_run_ctr print =
 let rec prompt level =
   let runnoprint = print_run_ctr false in
     let open Proofview.NonLogical in
-    let nl = if Util.(!batch) then "\n" else "" in
+    let nl = if Stdlib.(!batch) then "\n" else "" in
     Comm.print_deferred () >>
     Comm.prompt (tag "message.prompt"
                    @@ fnl () ++ str "TcDebug (" ++ int level ++ str (") > " ^ nl)) >>
-    if Util.(!batch) && Comm.isTerminal () then return (DebugOn (level+1)) else
+    if Stdlib.(!batch) && Comm.isTerminal () then return (DebugOn (level+1)) else
     let exit = (skip:=0) >> (skipped:=0) >> raise (Sys.Break, Exninfo.null) in
     Comm.read >>= fun inst ->
     let open DebugHook.Action in

--- a/plugins/ssr/ssrview.ml
+++ b/plugins/ssr/ssrview.ml
@@ -26,7 +26,7 @@ module AdaptorDb = struct
 
   module AdaptorKind = struct
     type t = kind
-    let compare = pervasives_compare
+    let compare = Stdlib.compare
   end
   module AdaptorMap = Map.Make(AdaptorKind)
 

--- a/pretyping/coercionops.ml
+++ b/pretyping/coercionops.ml
@@ -35,7 +35,7 @@ let cl_typ_ord t1 t2 = match t1, t2 with
   | CL_CONST c1, CL_CONST c2 -> Constant.CanOrd.compare c1 c2
   | CL_PROJ c1, CL_PROJ c2 -> Projection.Repr.CanOrd.compare c1 c2
   | CL_IND i1, CL_IND i2 -> Ind.CanOrd.compare i1 i2
-  | _ -> pervasives_compare t1 t2 (** OK *)
+  | _ -> Stdlib.compare t1 t2 (** OK *)
 
 let cl_typ_eq t1 t2 = Int.equal (cl_typ_ord t1 t2) 0
 

--- a/pretyping/find_subterm.ml
+++ b/pretyping/find_subterm.ml
@@ -9,7 +9,6 @@
 (************************************************************************)
 
 open Pp
-open Util
 open CErrors
 open Names
 open Locus

--- a/pretyping/structures.ml
+++ b/pretyping/structures.ml
@@ -161,7 +161,7 @@ let compare p1 p2 = match p1, p2 with
   | Prod_cs, Prod_cs -> 0
   | Sort_cs s1, Sort_cs s2 -> Sorts.family_compare s1 s2
   | Default_cs, Default_cs -> 0
-  | _ -> pervasives_compare p1 p2
+  | _ -> Stdlib.compare p1 p2
 
 let rec of_constr env t =
   match kind t with

--- a/tactics/btermdn.ml
+++ b/tactics/btermdn.ml
@@ -27,7 +27,7 @@ type term_label =
 
 let compare_term_label t1 t2 = match t1, t2 with
 | GRLabel gr1, GRLabel gr2 -> GlobRef.CanOrd.compare gr1 gr2
-| _ -> pervasives_compare t1 t2 (** OK *)
+| _ -> Stdlib.compare t1 t2 (** OK *)
 
 type 'res lookup_res = 'res Dn.lookup_res = Label of 'res | Nothing | Everything
 

--- a/vernac/search.ml
+++ b/vernac/search.ml
@@ -147,7 +147,7 @@ module ConstrPriority = struct
     -(3*(num_symbols t) + size t)
 
   let compare (_,_,_,_,p1) (_,_,_,_,p2) =
-    pervasives_compare p1 p2
+    Stdlib.compare p1 p2
 end
 
 module PriorityQueue = Heap.Functional(ConstrPriority)


### PR DESCRIPTION
Since the bump of the minimal supported version of OCaml to 4.09, these workarounds were not necessary anymore. We can now safely rely directly on Stdlib. As such, this is functionally a (partial) revert of #10471.