### PR TITLE
Fixes #17417: normalize hint modes and hint disjunctive paths

### DIFF
--- a/doc/changelog/04-tactics/17887-master+fixes17417-hint-paths-modes-redundancies.rst
+++ b/doc/changelog/04-tactics/17887-master+fixes17417-hint-paths-modes-redundancies.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Useless duplications with :cmd:`Hint Cut` and :cmd:`Hint Mode`
+  (`#17887 <https://github.com/coq/coq/pull/17887>`_,
+  fixes `#17417 <https://github.com/coq/coq/issues/17417>`_,
+  by Hugo Herbelin).

--- a/test-suite/output/HintLocality.out
+++ b/test-suite/output/HintLocality.out
@@ -73,10 +73,10 @@ This command does not support the global attribute in sections.
 Non-discriminated database
 Unfoldable variable definitions: all
 Unfoldable constant definitions: all except: id
-Cut: (_ | _)
+Cut: _
 For any goal ->   
 For nat ->   
-For S (modes !, !) ->   
+For S (modes !) ->   
 
 Non-discriminated database
 Unfoldable variable definitions: all


### PR DESCRIPTION
We add normalization of hint paths `(p|p)` into `p` as well as non-redundancy of hint modes.

We reorganize also the normalization of paths in passing.

Fixes / closes #17417

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
