### PR TITLE
Discharge on the fly

### DIFF
--- a/dev/ci/user-overlays/17888-herbelin-master+discharge-on-the-fly.sh
+++ b/dev/ci/user-overlays/17888-herbelin-master+discharge-on-the-fly.sh
@@ -1,0 +1,3 @@
+overlay equations https://github.com/herbelin/Coq-Equations main+discharge+plug-set_strategy-on-section-mechanism 17888 master+discharge-on-the-fly
+overlay hott https://github.com/herbelin/HoTT master+qualifying-idtoiso 17888 master+discharge-on-the-fly
+overlay metacoq https://github.com/herbelin/template-coq main+compatibility-reduce_stack_full_unfold-transparent 17888 master+discharge-on-the-fly

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1911,13 +1911,12 @@ let discharge_available_scopes map =
       if List.is_empty ltop && List.is_empty lbot then None else Some (ltop, lbot)) map
 
 let discharge_arguments_scope (req,r,scs,_cls,available_scopes) =
-  if req == ArgsScopeNoDischarge || (isVarRef r && Lib.is_in_section r) then None
+  if req == ArgsScopeNoDischarge then None
   else
-    let n =
-      try
-        Array.length (Lib.section_instance r)
-      with
-        Not_found (* Not a ref defined in this section *) -> 0 in
+    match Lib.discharge_global_reference_with_instance r with
+    | None -> None
+    | Some (r, inst) ->
+    let n = Array.length inst in
     let available_scopes = discharge_available_scopes available_scopes in
     (* Hack: use list cls to encode an integer to pass to rebuild for Manual case *)
     (* since cls is anyway recomputed in rebuild *)

--- a/kernel/cooking.mli
+++ b/kernel/cooking.mli
@@ -58,6 +58,9 @@ val create_cache : cooking_info -> cooking_cache
 val instance_of_cooking_cache : cooking_cache -> Constr.t array
 val rel_context_of_cooking_cache : cooking_cache -> rel_context
 
+val discharge_inductive : cooking_cache -> Ind.t -> Ind.t
+val discharge_constant : cooking_cache -> Constant.t -> Constant.t
+
 val abstract_as_type : cooking_cache -> types -> types
 
 val abstract_as_body : cooking_cache -> constr -> constr

--- a/kernel/discharge.ml
+++ b/kernel/discharge.ml
@@ -111,6 +111,15 @@ let cook_projection cache ~params t =
   let _, t = decompose_prod_n_decls (Context.Rel.length params + 1 + nrels) t in
   t
 
+let cook_nested_type cache = function
+  | NestedInd ind -> NestedInd (Cooking.discharge_inductive cache ind)
+  | NestedPrimitive cst -> NestedPrimitive (Cooking.discharge_constant cache cst)
+
+let cook_recargs cache = function
+  | Mrec ind -> Mrec (Ind.pop ind)
+  | Norec -> Norec
+  | Nested t -> Nested (cook_nested_type cache t)
+
 let cook_one_ind cache ~ntypes mip =
   let mind_arity = match mip.mind_arity with
     | RegularArity {mind_user_arity=arity;mind_sort=sort} ->
@@ -139,7 +148,7 @@ let cook_one_ind cache ~ntypes mip =
     mind_nf_lc;
     mind_consnrealargs = mip.mind_consnrealargs;
     mind_consnrealdecls = mip.mind_consnrealdecls;
-    mind_recargs = mip.mind_recargs;
+    mind_recargs = Rtree.Smart.map (cook_recargs cache) mip.mind_recargs;
     mind_relevance = mip.mind_relevance;
     mind_nb_constant = mip.mind_nb_constant;
     mind_nb_args = mip.mind_nb_args;

--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -381,6 +381,12 @@ module KerName = struct
   let modpath kn = kn.modpath
   let label kn = kn.knlabel
 
+  let pop kn =
+    let mp = match kn.modpath with
+    | ModPath.MPdot (mp,_) -> mp
+    | _ -> CErrors.anomaly (str "No field to pop.") in
+    make mp kn.knlabel
+
   let to_string_gen mp_to_string kn =
     mp_to_string kn.modpath ^ "." ^ Label.to_string kn.knlabel
 
@@ -514,6 +520,10 @@ module KerPair = struct
       if mp1 == mp2 then same kn
       else make kn (KerName.make mp2 lbl)
 
+  let pop = function
+    | Same kn -> Same (KerName.pop kn)
+    | Dual (knu,knc) -> Dual (KerName.pop knu, KerName.pop knc)
+
   let to_string kp = KerName.to_string (user kp)
   let print kp = str (to_string kp)
 
@@ -625,6 +635,8 @@ struct
                                     BEWARE: indexing starts from 0. *)
   let modpath (mind, _) = MutInd.modpath mind
 
+  let pop (mind,i) = (MutInd.pop mind, i)
+
   module CanOrd =
   struct
     type nonrec t = t
@@ -672,6 +684,8 @@ struct
                                     BEWARE: indexing starts from 1. *)
 
   let modpath (ind, _) = Ind.modpath ind
+
+  let pop (ind,i) = (Ind.pop ind, i)
 
   module CanOrd =
   struct

--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -860,6 +860,8 @@ struct
 
     let relevant c = c.proj_relevant
 
+    let pop p = { p with proj_ind = Ind.pop p.proj_ind }
+
     let hash p =
       Hashset.Combine.combinesmall p.proj_arg (ind_hash p.proj_ind)
 
@@ -967,6 +969,7 @@ struct
   let repr = fst
   let unfolded = snd
   let unfold (c, b as p) = if b then p else (c, true)
+  let pop (p,b) = (Repr.pop p, b)
 
   let equal (c, b) (c', b') = Repr.equal c c' && b == b'
 

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -646,6 +646,7 @@ module Projection : sig
     val arg : t -> int
     val label : t -> Label.t
     val relevant : t -> bool
+    val pop : t -> t
 
     val equal : t -> t -> bool [@@ocaml.deprecated "Use QProjection.equal"]
     val hash : t -> int [@@ocaml.deprecated "Use QProjection.hash"]
@@ -676,6 +677,7 @@ module Projection : sig
   val label : t -> Label.t
   val unfolded : t -> bool
   val unfold : t -> t
+  val pop : t -> t
 
   val equal : t -> t -> bool
   [@@ocaml.deprecated "Use QProjection.equal"]

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -291,6 +291,9 @@ sig
   val modpath : t -> ModPath.t
   val label : t -> Label.t
 
+  (** Remove the last modpath segment *)
+  val pop : t -> t
+
   val to_string : t -> string
   (** Encode as a string (not to be used for user-facing messages). *)
 
@@ -395,6 +398,9 @@ sig
   val label : t -> Label.t
   (** Shortcut for [KerName.label (user ...)] *)
 
+  (** Remove the last modpath segment *)
+  val pop : t -> t
+
   (** Comparisons *)
 
   include QNameS with type t := t
@@ -466,6 +472,9 @@ sig
   val label : t -> Label.t
   (** Shortcut for [KerName.label (user ...)] *)
 
+  (** Remove the last modpath segment *)
+  val pop : t -> t
+
   (** Comparisons *)
 
   include QNameS with type t := t
@@ -504,6 +513,9 @@ sig
                                     BEWARE: indexing starts from 0. *)
   val modpath : t -> ModPath.t
 
+  (** Remove the last modpath segment *)
+  val pop : t -> t
+
   include QNameS with type t := t
 
 end
@@ -518,6 +530,9 @@ sig
                                     BEWARE: indexing starts from 1. *)
 
   val modpath : t -> ModPath.t
+
+  (** Remove the last modpath segment *)
+  val pop : t -> t
 
   include QNameS with type t := t
 

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -988,9 +988,7 @@ let check_mind mie lab =
     assert (Id.equal (Label.to_id lab) oie.mind_entry_typename)
 
 let add_checked_mind kn mib senv =
-  let mib =
-    match mib.mind_hyps with [] -> Declareops.hcons_mind mib | _ -> mib
-  in
+  let mib = if sections_are_opened senv then mib else Declareops.hcons_mind mib in
   add_field (MutInd.label kn,SFBmind mib) (I kn) senv
 
 let add_mind l mie senv =

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -168,7 +168,7 @@ val set_allow_sprop : bool -> safe_transformer0
 
 (** {6 Interactive section functions } *)
 
-val open_section : safe_transformer0
+val open_section : Id.t -> safe_transformer0
 
 val close_section : safe_transformer0
 

--- a/kernel/section.ml
+++ b/kernel/section.ml
@@ -97,6 +97,10 @@ let open_section ~custom prev =
 let close_section sec =
   sec.prev, sec.entries, sec.mono_universes, sec.custom
 
+let on_previous_section f sec =
+  let e, prev = f sec.prev in
+  e, { sec with prev }
+
 let push_local d sec =
   { sec with context = d :: sec.context }
 

--- a/kernel/section.ml
+++ b/kernel/section.ml
@@ -22,8 +22,6 @@ type section_entry =
 type 'a t = {
   prev : 'a t option;
   (** Section surrounding the current one *)
-  entries : section_entry list;
-  (** Global declarations introduced in the section *)
   context : Constr.named_context;
   (** Declarations local to the section, intended to be interleaved
       with global declarations *)
@@ -42,7 +40,9 @@ type 'a t = {
   custom : 'a;
 }
 
-let rec depth sec = 1 + match sec.prev with None -> 0 | Some prev -> depth prev
+let rec depth = function
+  | None -> 0
+  | Some sec -> 1 + depth sec.prev
 
 let has_poly_univs sec = sec.has_poly_univs
 
@@ -77,7 +77,7 @@ let push_constraints uctx sec =
   then CErrors.user_err
       Pp.(str "Cannot add monomorphic constraints which refer to section polymorphic universes.");
   let uctx' = sec.mono_universes in
-  let mono_universes =  (ContextSet.union uctx uctx') in
+  let mono_universes = ContextSet.union uctx uctx' in
   { sec with mono_universes }
 
 let open_section ~custom prev =
@@ -88,14 +88,13 @@ let open_section ~custom prev =
     poly_universes = UContext.empty;
     all_poly_univs = Option.cata (fun sec -> sec.all_poly_univs) [| |] prev;
     has_poly_univs = Option.cata has_poly_univs false prev;
-    entries = [];
     expand_info_map = (Cmap.empty, Mindmap.empty);
     cooking_info_map = (Cmap.empty, Mindmap.empty);
     custom = custom;
   }
 
 let close_section sec =
-  sec.prev, sec.entries, sec.mono_universes, sec.custom
+  sec.prev, sec.mono_universes, sec.custom
 
 let on_previous_section f sec =
   let e, prev = f sec.prev in
@@ -108,11 +107,7 @@ let extract_hyps vars used =
   (* Only keep the part that is used by the declaration *)
   List.filter (fun d -> Id.Set.mem (NamedDecl.get_id d) used) vars
 
-let segment_of_entry env e uctx sec =
-  let hyps = match e with
-  | SecDefinition con -> (Environ.lookup_constant con env).Declarations.const_hyps
-  | SecInductive mind -> (Environ.lookup_mind mind env).Declarations.mind_hyps
-  in
+let segment_of_entry e hyps uctx sec =
   let hyps = Context.Named.to_vars hyps in
   (* [sec.context] are the named hypotheses, [hyps] the subset that is
      declared by the global *)
@@ -125,19 +120,22 @@ let segment_of_entry env e uctx sec =
   in
   Cooking.make_cooking_info ~recursive sec.expand_info_map ctx uctx
 
-let push_global env ~poly e sec =
+let push_global ~poly e hyps sec =
   if has_poly_univs sec && not poly
   then CErrors.user_err
       Pp.(str "Cannot add a universe monomorphic declaration when \
                section polymorphic universes are present.")
   else
-    let cooking_info, abstr_inst_info = segment_of_entry env e sec.poly_universes sec in
+    let cooking_info, abstr_inst_info = segment_of_entry e hyps sec.poly_universes sec in
     let cooking_info_map = add_emap e cooking_info sec.cooking_info_map in
     let expand_info_map = add_emap e abstr_inst_info sec.expand_info_map in
-    { sec with entries = e :: sec.entries; expand_info_map; cooking_info_map }
+    { sec with expand_info_map; cooking_info_map }
 
-let segment_of_constant con sec = Cmap.find con (fst sec.cooking_info_map)
-let segment_of_inductive con sec = Mindmap.find con (snd sec.cooking_info_map)
+let segment_of_constant con sec =
+  Cmap.find con (fst sec.cooking_info_map)
+
+let segment_of_inductive mind sec =
+  Mindmap.find mind (snd sec.cooking_info_map)
 
 let is_in_section _env gr sec =
   let open GlobRef in

--- a/kernel/section.mli
+++ b/kernel/section.mli
@@ -17,7 +17,7 @@ open Cooking
 type 'a t
 (** Type of sections with additional data ['a] *)
 
-val depth : 'a t -> int
+val depth : 'a t option -> int
 (** Number of nested sections. *)
 
 val map_custom : ('a -> 'a) -> 'a t -> 'a t
@@ -35,7 +35,7 @@ val open_section : custom:'a -> 'a t option -> 'a t
     inside a monomorphic one. A custom data can be attached to this section,
     that will be returned by {!close_section}. *)
 
-val close_section : 'a t -> 'a t option * section_entry list * ContextSet.t * 'a
+val close_section : 'a t -> 'a t option * ContextSet.t * 'a
 (** Close the current section and returns the entries defined inside, the set
     of global monomorphic constraints added in this section, and the custom data
     provided at the opening of the section. *)
@@ -56,7 +56,7 @@ val push_constraints : ContextSet.t -> 'a t -> 'a t
 (** Extend the current section with a global universe context.
     Assumes that the last opened section is monomorphic. *)
 
-val push_global : Environ.env -> poly:bool -> section_entry -> 'a t -> 'a t
+val push_global : poly:bool -> section_entry -> Constr.named_context -> 'a t -> 'a t
 (** Push a global entry in this section. *)
 
 (** {6 Retrieving section data} *)

--- a/kernel/section.mli
+++ b/kernel/section.mli
@@ -40,6 +40,9 @@ val close_section : 'a t -> 'a t option * section_entry list * ContextSet.t * 'a
     of global monomorphic constraints added in this section, and the custom data
     provided at the opening of the section. *)
 
+val on_previous_section : ('a t option -> 'b * 'a t option) -> 'a t -> 'b * 'a t
+(** Apply an action on the prev segment of the section *)
+
 (** {6 Extending sections} *)
 
 val push_local : Constr.named_declaration -> 'a t -> 'a t

--- a/library/coqlib.ml
+++ b/library/coqlib.ml
@@ -64,6 +64,11 @@ let add_ref s c =
 let cache_ref (s,c) =
   add_ref s c
 
+let discharge_ref (s,gr) =
+  match Lib.discharge_global_reference gr with
+  | None -> None
+  | Some gr -> Some (s,gr)
+
 let (inCoqlibRef : string * GlobRef.t -> Libobject.obj) =
   let open Libobject in
   declare_object { (default_object "COQLIBREF") with
@@ -71,7 +76,7 @@ let (inCoqlibRef : string * GlobRef.t -> Libobject.obj) =
     load_function = (fun _ x -> cache_ref x);
     classify_function = (fun _ -> Substitute);
     subst_function = ident_subst_function;
-    discharge_function = (fun sc -> Some sc); }
+    discharge_function = discharge_ref; }
 
 (** Replaces a binding ! *)
 let register_ref s c =

--- a/library/global.ml
+++ b/library/global.ml
@@ -66,6 +66,15 @@ let globalize_with_summary fs f =
   GlobalSafeEnv.set_safe_env env;
   res
 
+let in_lower_section f () =
+  if !Flags.in_synterp_phase then f ()
+  else
+    let env = safe_env () in
+    let env' = Safe_typing.close_section env in
+    GlobalSafeEnv.set_safe_env env';
+    try let a = f () in GlobalSafeEnv.set_safe_env env; a
+    with e -> GlobalSafeEnv.set_safe_env env; raise e
+
 (** [Safe_typing] operations, now operating on the global environment *)
 
 let i2l = Label.of_id
@@ -94,7 +103,7 @@ let add_modtype id me inl = globalize (Safe_typing.add_modtype (i2l id) me inl)
 let add_module id me inl = globalize (Safe_typing.add_module (i2l id) me inl)
 let add_include me ismod inl = globalize (Safe_typing.add_include me ismod inl)
 
-let open_section () = globalize0 Safe_typing.open_section
+let open_section id = globalize0 (Safe_typing.open_section id)
 let close_section fs = globalize0_with_summary fs Safe_typing.close_section
 let sections_are_opened () = Safe_typing.sections_are_opened (safe_env())
 

--- a/library/global.mli
+++ b/library/global.mli
@@ -77,7 +77,7 @@ val add_include :
 
 (** Sections *)
 
-val open_section : unit -> unit
+val open_section : Id.t -> unit
 (** [poly] is true when the section should be universe polymorphic *)
 
 val close_section : Summary.Interp.frozen -> unit
@@ -183,3 +183,5 @@ val current_dirpath : unit -> DirPath.t
 val with_global : (Environ.env -> DirPath.t -> 'a Univ.in_universe_context_set) -> 'a
 
 val global_env_summary_tag : Safe_typing.safe_environment Summary.Dyn.tag
+
+val in_lower_section : (unit -> 'a) -> unit -> 'a

--- a/library/globnames.ml
+++ b/library/globnames.ml
@@ -53,6 +53,12 @@ let canonical_gr = function
   | ConstructRef ((kn,i),j )-> ConstructRef((MutInd.make1(MutInd.canonical kn),i),j)
   | VarRef id -> VarRef id
 
+let pop_global_reference = function
+  | ConstRef cst -> ConstRef (Constant.pop cst)
+  | IndRef ind -> IndRef (Ind.pop ind)
+  | ConstructRef cstr -> ConstructRef (Construct.pop cstr)
+  | VarRef id -> VarRef id
+
 (* Extended global references *)
 
 type abbreviation = KerName.t

--- a/library/globnames.mli
+++ b/library/globnames.mli
@@ -27,6 +27,9 @@ val destConstructRef : GlobRef.t -> constructor
 val subst_global : substitution -> GlobRef.t -> GlobRef.t * constr Univ.univ_abstracted option
 val subst_global_reference : substitution -> GlobRef.t -> GlobRef.t
 
+(** Remove the last modpath segment *)
+val pop_global_reference : GlobRef.t -> GlobRef.t
+
 (** {6 Extended global references } *)
 
 type abbreviation = KerName.t

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -285,6 +285,20 @@ let is_in_section ref = match sections () with
 let section_instance ref =
   Cooking.instance_of_cooking_info (section_segment_of_reference ref)
 
+let discharge_mind mind = mind
+
+let discharge_inductive ind = ind
+
+let discharge_constant cst = cst
+
+let discharge_global_reference ref = Some ref
+
+let discharge_global_reference_with_instance ref =
+  if is_in_section ref then
+    if Globnames.isVarRef ref then None
+    else Some (ref, section_instance ref)
+  else Some (ref, [||])
+
 let discharge_item = Libobject.(function
   | ModuleObject _ | ModuleTypeObject _ | IncludeObject _ | KeepObject _
   | ExportObject _ -> None

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -22,12 +22,11 @@ type export = (export_flag * Libobject.open_filter) option (* None for a Module 
 
 val make_oname : Nametab.object_prefix -> Names.Id.t -> Libobject.object_name
 val make_foname : Names.Id.t -> Libobject.object_name
-val oname_prefix : Libobject.object_name -> Nametab.object_prefix
 
 type 'summary node =
   | CompilingLibrary of Nametab.object_prefix
   | OpenedModule of is_type * export * Nametab.object_prefix * 'summary
-  | OpenedSection of Nametab.object_prefix * 'summary
+  | OpenedSection of Nametab.object_prefix * 'summary * (bool * Nametab.object_prefix * Libobject.t) list
 
 (** Extract the [object_prefix] component. Note that it is the prefix
    of the objects *inside* this node, eg in [Module M.] we have

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -171,6 +171,12 @@ val section_segment_of_reference : GlobRef.t -> Cooking.cooking_info
 val section_instance : GlobRef.t -> Constr.t array
 val is_in_section : GlobRef.t -> bool
 
+val discharge_mind : MutInd.t -> MutInd.t
+val discharge_inductive : Ind.t -> Ind.t
+val discharge_constant : Constant.t -> Constant.t
+val discharge_global_reference : GlobRef.t -> GlobRef.t option
+val discharge_global_reference_with_instance : GlobRef.t -> (GlobRef.t * Constr.t array) option
+
 (** {6 Discharge: decrease the section level if in the current section } *)
 
 val discharge_proj_repr : Projection.Repr.t -> Projection.Repr.t

--- a/library/libobject.mli
+++ b/library/libobject.mli
@@ -74,9 +74,12 @@ type object_name = Libnames.full_path * KerName.t
 
 type open_filter
 
+type section_level = Innermost | Outermost | AllLevels
+
 type ('a,'b) object_declaration = {
   object_name : string;
   object_stage : Summary.Stage.t;
+  object_level : section_level;
   cache_function : 'b -> unit;
   load_function : int -> 'b -> unit;
   open_function : open_filter -> int -> 'b -> unit;
@@ -179,7 +182,7 @@ val declare_named_object :
 val declare_named_object_gen :
   ('a,object_prefix * 'a) object_declaration -> ('a -> obj)
 
-val cache_object : object_prefix * obj -> unit
+val cache_object : (* discharged: *) bool * object_prefix * obj -> unit
 val load_object : int -> object_prefix * obj -> unit
 val open_object : open_filter -> int -> object_prefix * obj -> unit
 val subst_object : substitution * obj -> obj

--- a/library/nametab.ml
+++ b/library/nametab.ml
@@ -14,6 +14,7 @@ open Libnames
 type object_prefix = {
   obj_dir : DirPath.t;
   obj_mp  : ModPath.t;
+  section_depth : int;
 }
 
 let eq_op op1 op2 =

--- a/library/nametab.mli
+++ b/library/nametab.mli
@@ -72,6 +72,7 @@ open Libnames
 type object_prefix = {
   obj_dir : DirPath.t;
   obj_mp  : ModPath.t;
+  section_depth : int;
 }
 
 val eq_op : object_prefix -> object_prefix -> bool

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -207,7 +207,19 @@ let subst_Function (subst, finfos) =
     ; sprop_lemma = sprop_lemma'
     ; is_general = finfos.is_general }
 
-let discharge_Function finfos = Some finfos
+let discharge_Function finfos =
+  Some {
+    function_constant = Lib.discharge_constant finfos.function_constant;
+    graph_ind = Lib.discharge_inductive finfos.graph_ind;
+    equation_lemma = Option.map Lib.discharge_constant finfos.equation_lemma;
+    correctness_lemma =  Option.map Lib.discharge_constant finfos.correctness_lemma;
+    completeness_lemma =  Option.map Lib.discharge_constant finfos.completeness_lemma;
+    rect_lemma =  Option.map Lib.discharge_constant finfos.rect_lemma;
+    rec_lemma =  Option.map Lib.discharge_constant finfos.rec_lemma;
+    prop_lemma =  Option.map Lib.discharge_constant finfos.prop_lemma;
+    sprop_lemma =  Option.map Lib.discharge_constant finfos.sprop_lemma;
+    is_general = finfos.is_general
+  }
 
 let pr_ocst env sigma c =
   Option.fold_right

--- a/pretyping/arguments_renaming.ml
+++ b/pretyping/arguments_renaming.ml
@@ -42,13 +42,14 @@ let subst_rename_args (subst, (_, (r, names as orig))) =
   if r==r' then orig else (r', names)
 
 let discharge_rename_args = function
-  | ReqGlobal (c, names), _ as req when not (isVarRef c && Lib.is_in_section c) ->
-     (try
-       let var_names = Array.map_to_list (fun c -> Name (destVar c)) (Lib.section_instance c) in
+  | ReqLocal, _ -> None
+  | ReqGlobal (c, names), _ ->
+    match Lib.discharge_global_reference_with_instance c with
+    | None -> None
+    | Some (c, inst) ->
+       let var_names = Array.map_to_list (fun c -> Name (destVar c)) inst in
        let names' = var_names @ names in
        Some (ReqGlobal (c, names), (c, names'))
-     with Not_found -> Some req)
-  | _ -> None
 
 let rebuild_rename_args x = x
 

--- a/pretyping/coercionops.ml
+++ b/pretyping/coercionops.ml
@@ -39,6 +39,12 @@ let cl_typ_ord t1 t2 = match t1, t2 with
 
 let cl_typ_eq t1 t2 = Int.equal (cl_typ_ord t1 t2) 0
 
+let discharge_coercion_class = function
+  | CL_SORT | CL_FUN | CL_SECVAR _ as x -> x
+  | CL_CONST cst -> CL_CONST (Lib.discharge_constant cst)
+  | CL_IND ind -> CL_IND (Lib.discharge_inductive ind)
+  | CL_PROJ p -> CL_PROJ (Lib.discharge_proj_repr p)
+
 module ClTyp = struct
   type t = cl_typ
   let compare = cl_typ_ord

--- a/pretyping/coercionops.mli
+++ b/pretyping/coercionops.mli
@@ -31,6 +31,8 @@ val subst_cl_typ : env -> substitution -> cl_typ -> cl_typ
 (** Comparison of [cl_typ] *)
 val cl_typ_ord : cl_typ -> cl_typ -> int
 
+val discharge_coercion_class : cl_typ -> cl_typ
+
 (** This is the type of coercion kinds *)
 type coe_typ = GlobRef.t
 

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -123,17 +123,12 @@ module ReductionBehaviour = struct
     let r' = subst_global_reference subst r in if r==r' then orig
     else (local,(r',o))
 
-  let discharge = function
-    | false, (gr, b) ->
-      let b =
-        if Lib.is_in_section gr then
-          let vars = Lib.section_instance gr in
-          let extra = Array.length vars in
-          more_args extra b
-        else b
-      in
+  let discharge (local, (gr, b)) =
+    match Lib.discharge_global_reference_with_instance gr with
+    | Some (gr,inst) when not local ->
+      let b = more_args (Array.length inst) b in
       Some (false, (gr, b))
-    | true, _ -> None
+    | _ -> None
 
   let rebuild = function
     | req, (GlobRef.ConstRef c, _ as x) -> req, x

--- a/pretyping/structures.ml
+++ b/pretyping/structures.ml
@@ -80,6 +80,15 @@ let subst subst ({ name; projections; nparams } as s) =
   then s
   else { name; projections; nparams }
 
+let discharge_projection projs =
+  { projs with proj_body = Option.map Lib.discharge_constant projs.proj_body }
+
+let discharge { name; projections; nparams } =
+  Some
+    { name = Lib.discharge_inductive name;
+      projections = List.map discharge_projection projections;
+      nparams }
+
 let rebuild env s =
   let mib = Environ.lookup_mind (fst s.name) env in
   let nparams = mib.Declarations.mind_nparams in
@@ -324,6 +333,11 @@ let register ~warn env sigma o =
           let hd_val = ValuePattern.print cs_pat in
           warn_redundant_canonical_projection (hd_val, prj, new_can_s, old_can_s)
       )
+
+let discharge (ref,ind) =
+  match Lib.discharge_global_reference ref with
+  | None -> None
+  | Some ref -> Some (ref, Lib.discharge_inductive ind)
 
 end
 

--- a/pretyping/structures.ml
+++ b/pretyping/structures.ml
@@ -331,7 +331,7 @@ let register ~warn env sigma o =
           let new_can_s = Termops.Internal.print_constr_env env sigma (EConstr.of_constr s.o_DEF) in
           let prj = Nametab.pr_global_env Id.Set.empty proj in
           let hd_val = ValuePattern.print cs_pat in
-          warn_redundant_canonical_projection (hd_val, prj, new_can_s, old_can_s)
+          warn_redundant_canonical_projection (hd_val, prj, new_can_s, old_can_s);
       )
 
 let discharge (ref,ind) =

--- a/pretyping/structures.mli
+++ b/pretyping/structures.mli
@@ -32,6 +32,8 @@ val make : Environ.env -> Names.inductive -> projection list -> t
 val register : t -> unit
 val subst : Mod_subst.substitution -> t -> t
 
+val discharge : t -> t option
+
 (** refreshes nparams, e.g. after section discharging *)
 val rebuild : Environ.env -> t -> t
 
@@ -71,6 +73,8 @@ val register : warn:bool -> Environ.env -> Evd.evar_map -> t -> unit
 
 val subst : Mod_subst.substitution -> t -> t
 val repr : t -> Names.GlobRef.t
+
+val discharge : t -> t option
 
 end
 

--- a/tactics/declareScheme.ml
+++ b/tactics/declareScheme.ml
@@ -27,7 +27,7 @@ let subst_scheme (subst,(kind,l)) =
   (kind, CArray.Smart.map (subst_one_scheme subst) l)
 
 let discharge_scheme (kind,l) =
-  Some (kind, l)
+  Some (kind, Array.map (fun (c,i) -> (Lib.discharge_inductive c, Lib.discharge_constant i)) l)
 
 let inScheme : string * (inductive * Constant.t) array -> Libobject.obj =
   let open Libobject in

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1231,10 +1231,10 @@ let discharge_autohint obj =
       | HintsVariables | HintsConstants -> grefs
       | HintsReferences grs ->
         let filter = function
-        | EvalConstRef c -> true
-        | EvalVarRef id -> not @@ Lib.is_in_section (GlobRef.VarRef id)
+        | EvalConstRef c -> Some (EvalConstRef (Lib.discharge_constant c))
+        | EvalVarRef id as x -> if not @@ Lib.is_in_section (GlobRef.VarRef id) then Some x else None
         in
-        let grs = List.filter filter grs in
+        let grs = List.filter_map filter grs in
         HintsReferences grs
       in
       AddTransparency { grefs; state }
@@ -1244,14 +1244,12 @@ let discharge_autohint obj =
     | AddCut path ->
       if is_section_path path then AddHints [] (* dummy *) else obj.hint_action
     | AddMode { gref; mode } ->
-      if Lib.is_in_section gref then
-        if isVarRef gref then AddHints [] (* dummy *)
-        else
-          let inst = Lib.section_instance gref in
+      (match Lib.discharge_global_reference_with_instance gref with
+       | None -> AddHints [] (* dummy *)
+       | Some (gref, inst) ->
           (* Default mode for discharged parameters is output *)
           let mode = Array.append (Array.make (Array.length inst) ModeOutput) mode in
-          AddMode { gref; mode }
-      else obj.hint_action
+          AddMode { gref; mode })
     in
     if is_trivial_action action then None
     else Some { obj with hint_action = action }

--- a/tactics/redexpr.ml
+++ b/tactics/redexpr.ml
@@ -104,7 +104,7 @@ let classify_strategy (local,_) =
 
 let disch_ref ref =
   match ref with
-      EvalConstRef c -> Some ref
+      EvalConstRef c -> Some (EvalConstRef (Lib.discharge_constant c))
     | EvalVarRef id -> if Lib.is_in_section (GlobRef.VarRef id) then None else Some ref
 
 let discharge_strategy (local,obj) =

--- a/test-suite/output/Projections.out
+++ b/test-suite/output/Projections.out
@@ -15,3 +15,9 @@ fun A : Type => let B := A in fun (C : Type) (u : U A C) => b _ _ u
        forall (C : Type) (u : U A C), (A, B, C, c _ _ u) = (A, B, C, c _ _ u)
 
 Arguments b (A C)%type_scope u
+1 goal
+  
+  A : Type
+  x : foo A
+  ============================
+  x.(bar A) = x.(bar _)

--- a/test-suite/output/Projections.v
+++ b/test-suite/output/Projections.v
@@ -19,3 +19,17 @@ Print a.
 Print b.
 
 End LocalDefUnfolding.
+
+Module Discharge.
+
+Section A.
+Record foo A := { bar : A}.
+End A.
+Definition bar' := bar.
+Lemma f A x : bar' A x = bar A x.
+unfold bar'.
+Show. (* second should be the primitive construct *)
+reflexivity.
+Qed.
+
+End Discharge.

--- a/test-suite/prerequisite/ssr_mini_mathcomp.v
+++ b/test-suite/prerequisite/ssr_mini_mathcomp.v
@@ -67,6 +67,7 @@ Lemma eqP T : Equality.axiom (@eq_op T).
 Proof. by case: T => ? []. Qed.
 Arguments eqP {T x y}.
 
+Declare Scope eq_scope.
 Delimit Scope eq_scope with EQ.
 Open Scope eq_scope.
 
@@ -91,7 +92,7 @@ Notation eqxx := eq_refl.
 Lemma eq_sym (T : eqType) (x y : T) : (x == y) = (y == x).
 Proof. exact/eqP/eqP. Qed.
 
-#[global] Hint Resolve eq_refl eq_sym.
+#[global] Hint Resolve eq_refl eq_sym : core.
 
 
 Definition eqb b := addb (~~ b).
@@ -395,6 +396,10 @@ Fixpoint odd n := if n is n'.+1 then ~~ odd n' else false.
 
 Lemma oddb (b : bool) : odd b = b. Proof. by case: b. Qed.
 
+Declare Scope nat_rec_scope.
+
+Set Warnings "-notation-overridden".
+
 Definition subn_rec := minus.
 Notation "m - n" := (subn_rec m n) : nat_rec_scope.
 
@@ -422,7 +427,7 @@ Lemma leq0n n : 0 <= n.                 Proof. by []. Qed.
 Lemma ltn0Sn n : 0 < n.+1.              Proof. by []. Qed.
 Lemma ltn0 n : n < 0 = false.           Proof. by []. Qed.
 Lemma leqnn n : n <= n.                 Proof. by elim: n. Qed.
-#[global] Hint Resolve leqnn.
+#[global] Hint Resolve leqnn : core.
 Lemma leqnSn n : n <= n.+1.             Proof. by elim: n. Qed.
 
 Lemma leq_trans n m p : m <= n -> n <= p -> m <= p.
@@ -431,10 +436,10 @@ Lemma leq_ltn_trans n m p : m <= n -> n < p -> m < p.
 Admitted.
 Lemma leqW m n : m <= n -> m <= n.+1.
 Admitted.
-#[global] Hint Resolve leqnSn.
+#[global] Hint Resolve leqnSn : core.
 Lemma ltnW m n : m < n -> m <= n.
 Proof. exact: leq_trans. Qed.
-#[global] Hint Resolve ltnW.
+#[global] Hint Resolve ltnW : core.
 
 Definition addn_rec := plus.
 Notation "m + n" := (addn_rec m n) : nat_rec_scope.
@@ -507,6 +512,7 @@ Proof. by move=> m n p q; rewrite -!mulnA (mulnCA n). Qed.
 
 (* seq ------------------------------------------------------------- *)
 
+Declare Scope seq_scope.
 Delimit Scope seq_scope with SEQ.
 Open Scope seq_scope.
 
@@ -1283,6 +1289,7 @@ Canonical addn_addoid := AddLaw mulnDl mulnDr.
 Canonical cat_monoid T := Law (@catA T) (@cat0s T) (@cats0 T).
 
 End PervasiveMonoids.
+Declare Scope big_scope.
 Delimit Scope big_scope with BIG.
 Open Scope big_scope.
 
@@ -1323,7 +1330,7 @@ Admitted.
 Lemma mem_index_enum T i : i \in index_enum T.
 Admitted.
 
-#[global] Hint Resolve mem_index_enum.
+#[global] Hint Resolve mem_index_enum : core.
 
 (*
 Lemma filter_index_enum T P : filter P (index_enum T) = enum P.

--- a/test-suite/success/discharge.v
+++ b/test-suite/success/discharge.v
@@ -1,0 +1,9 @@
+Section S.
+Context {A:Type}.
+Inductive option := None | Some (a:A).
+Definition map {B} (f : A -> B) (o : option) :=
+  match o with
+  | None => discharge.None
+  | Some a => discharge.Some (f a)
+  end.
+End S.

--- a/vernac/canonical.ml
+++ b/vernac/canonical.ml
@@ -21,9 +21,10 @@ let cache_canonical_structure (o,_) =
   Instance.register ~warn:true env sigma o
 
 let discharge_canonical_structure (x, local) =
-  let gref = Instance.repr x in
-  if local || (Globnames.isVarRef gref && Lib.is_in_section gref) then None
-  else Some (x, local)
+  if local then None else
+    match Instance.discharge x with
+    | Some x -> Some (x, local)
+    | None -> None
 
 let canon_cat = create_category "canonicals"
 

--- a/vernac/canonical.ml
+++ b/vernac/canonical.ml
@@ -30,6 +30,7 @@ let canon_cat = create_category "canonicals"
 
 let inCanonStruc : Instance.t * bool -> obj =
   declare_object {(default_object "CANONICAL-STRUCTURE") with
+                  object_level = Innermost;
                   open_function = simple_open ~cat:canon_cat open_canonical_structure;
                   cache_function = cache_canonical_structure;
                   subst_function = (fun (subst,(c,local)) -> Instance.subst subst c, local);

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -136,6 +136,7 @@ let classify_instance inst = match inst.locality with
 let instance_input : instance -> obj =
   declare_object
     { (default_object "type classes instances state") with
+      object_level = Innermost;
       cache_function = cache_instance;
       load_function = load_instance;
       open_function = simple_open ~cat:Hints.hint_cat open_instance;

--- a/vernac/comArguments.ml
+++ b/vernac/comArguments.ml
@@ -31,10 +31,10 @@ let subst_bidi_hints (subst, (gr, ohint as orig)) =
   if gr == gr' then orig else (gr', ohint)
 
 let discharge_bidi_hints (gr, ohint) =
-  if Globnames.isVarRef gr && Lib.is_in_section gr then None
-  else
-    let vars = Lib.section_instance gr in
-    let n = Array.length vars in
+  match Lib.discharge_global_reference_with_instance gr with
+  | None -> None
+  | Some (gr, inst) ->
+    let n = Array.length inst in
     Some (gr, Option.map ((+) n) ohint)
 
 let inBidiHints =

--- a/vernac/comCoercion.ml
+++ b/vernac/comCoercion.ml
@@ -238,13 +238,16 @@ let open_coercion i o =
 let discharge_coercion c =
   if c.coe_local then None
   else
-    let n =
-      try Array.length (Lib.section_instance c.coe_value)
-      with Not_found -> 0
-    in
+    match Lib.discharge_global_reference_with_instance c.coe_value with
+    | None -> None
+    | Some (v, inst) ->
+    let n = Array.length inst in
     let nc = { c with
       coe_param = n + c.coe_param;
       coe_is_projection = Option.map Lib.discharge_proj_repr c.coe_is_projection;
+      coe_value = v;
+      coe_source = discharge_coercion_class c.coe_source;
+      coe_target = discharge_coercion_class c.coe_target;
     } in
     Some nc
 

--- a/vernac/comCoercion.ml
+++ b/vernac/comCoercion.ml
@@ -261,6 +261,7 @@ let coe_cat = create_category "coercions"
 
 let inCoercion : coe_info_typ -> obj =
   declare_object {(default_object "COERCION") with
+    object_level = Innermost;
     open_function = simple_open ~cat:coe_cat open_coercion;
     cache_function = cache_coercion;
     subst_function = (fun (subst,c) -> subst_coercion subst c);

--- a/vernac/declareInd.ml
+++ b/vernac/declareInd.ml
@@ -76,7 +76,7 @@ let load_prim _ p = cache_prim p
 
 let subst_prim (subst,(p,c)) = Mod_subst.subst_proj_repr subst p, Mod_subst.subst_constant subst c
 
-let discharge_prim (p,c) = Some (Lib.discharge_proj_repr p, c)
+let discharge_prim (p,c) = Some (Lib.discharge_proj_repr p, Lib.discharge_constant c)
 
 let inPrim : (Projection.Repr.t * Constant.t) -> Libobject.obj =
   let open Libobject in

--- a/vernac/declareUniv.ml
+++ b/vernac/declareUniv.ml
@@ -67,10 +67,13 @@ let get_names decl =
   univs
 
 let cache_univ_names (prefix, decl) =
-  let depth = Lib.sections_depth () in
-  let dp = Libnames.pop_dirpath_n depth prefix.Nametab.obj_dir in
-  let names = get_names decl in
-  List.iter (do_univ_name ~check:true (Nametab.Until 1) dp decl.udecl_src) names
+  let ok = match decl.udecl_src with
+  | BoundUniv -> true
+  | QualifiedUniv _ | UnqualifiedUniv -> prefix.Nametab.section_depth = 0 in
+  if ok then
+    let dp = prefix.Nametab.obj_dir in
+    let names = get_names decl in
+    List.iter (do_univ_name ~check:true (Nametab.Until 1) dp decl.udecl_src) names
 
 let load_univ_names i (prefix, decl) =
   let names = get_names decl in

--- a/vernac/declareUniv.ml
+++ b/vernac/declareUniv.ml
@@ -84,7 +84,7 @@ let discharge_univ_names decl = match decl.udecl_src with
   | BoundUniv -> None
   | (QualifiedUniv _ | UnqualifiedUniv) -> Some decl
 
-let input_univ_names : universe_name_decl -> Libobject.obj =
+let inUnivNames : universe_name_decl -> Libobject.obj =
   let open Libobject in
   declare_named_object_gen
     { (default_object "Global universe name state") with
@@ -97,7 +97,7 @@ let input_univ_names : universe_name_decl -> Libobject.obj =
 
 let input_univ_names (src, l, a) =
   if CList.is_empty l && CList.is_empty a then ()
-  else Lib.add_leaf (input_univ_names { udecl_src = src; udecl_named = l; udecl_anon = a })
+  else Lib.add_leaf (inUnivNames { udecl_src = src; udecl_named = l; udecl_anon = a })
 
 let label_of = let open GlobRef in function
 | ConstRef c -> Label.to_id @@ Constant.label c

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -359,7 +359,7 @@ module ModObjs :
 (** Iterate some function [iter_objects] on all components of a module *)
 
 let do_module iter_objects i obj_dir obj_mp sobjs kobjs =
-  let prefix = Nametab.{ obj_dir ; obj_mp; } in
+  let prefix = Nametab.{ obj_dir ; obj_mp; section_depth = 0; } in
   Actions.enter_module obj_mp obj_dir i;
   ModSubstObjs.set obj_mp sobjs;
   (* If we're not a functor, let's iter on the internal components *)
@@ -420,7 +420,7 @@ and load_include i (prefix, aobjs) =
 and load_keep i ((sp,kn),kobjs) =
   (* Invariant : seg isn't empty *)
   let obj_dir = dir_of_sp sp and obj_mp  = mp_of_kn kn in
-  let prefix = Nametab.{ obj_dir ; obj_mp; } in
+  let prefix = Nametab.{ obj_dir ; obj_mp; section_depth = 0; } in
   let modobjs =
     try ModObjs.get obj_mp
     with Not_found -> assert false (* a substobjs should already be loaded *)
@@ -533,7 +533,7 @@ and open_export f i mpl =
 
 and open_keep f i ((sp,kn),kobjs) =
   let obj_dir = dir_of_sp sp and obj_mp = mp_of_kn kn in
-  let prefix = Nametab.{ obj_dir; obj_mp; } in
+  let prefix = Nametab.{ obj_dir; obj_mp; section_depth = 0; } in
   open_objects f i prefix kobjs
 
 let cache_include (prefix, aobjs) =
@@ -546,7 +546,7 @@ and cache_keep ((sp,kn),kobjs) =
 
 let cache_object (prefix, obj) =
   match obj with
-  | AtomicObject o -> Libobject.cache_object (prefix, o)
+  | AtomicObject o -> Libobject.cache_object (false, prefix, o)
   | ModuleObject (id,sobjs) ->
     let name = Lib.make_oname prefix id in
     do_module' load_objects 1 (name, sobjs)

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -375,6 +375,7 @@ type require_obj = library_t list
 let in_require : require_obj -> obj =
   declare_object
     {(default_object "REQUIRE") with
+     object_level = Outermost;
      cache_function = cache_require;
      load_function = load_require;
      open_function = (fun _ _ -> assert false);
@@ -396,6 +397,7 @@ type require_obj_syntax = library_t list
 let in_require_syntax : require_obj_syntax -> obj =
   declare_object
     {(default_object "REQUIRE-SYNTAX") with
+     object_level = Outermost;
      object_stage = Summary.Stage.Synterp;
      cache_function = cache_require_syntax;
      load_function = load_require_syntax;

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -751,7 +751,7 @@ let print_context env sigma with_values =
 let pr_prefix_name prefix = Id.print (snd (split_dirpath prefix.Nametab.obj_dir))
 
 let print_library_node = function
-  | Lib.OpenedSection (prefix, _) ->
+  | Lib.OpenedSection (prefix, _, _) ->
     str " >>>>>>> Section " ++ pr_prefix_name prefix
   | Lib.OpenedModule (_,_,prefix,_) ->
     str " >>>>>>> Module " ++ pr_prefix_name prefix
@@ -856,7 +856,7 @@ let read_sec_context qid =
     with Not_found ->
       user_err ?loc:qid.loc (str "Unknown section.") in
   let rec get_cxt in_cxt = function
-    | (Lib.OpenedSection ({Nametab.obj_dir;_},_), _ as hd)::rest ->
+    | (Lib.OpenedSection ({Nametab.obj_dir;_},_,_), _ as hd)::rest ->
         if DirPath.equal dir obj_dir then (hd::in_cxt) else get_cxt (hd::in_cxt) rest
     | [] -> []
     | hd::rest -> get_cxt (hd::in_cxt) rest

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -482,7 +482,7 @@ let cache_structure o = load_structure 1 o
 
 let subst_structure (subst, obj) = Structure.subst subst obj
 
-let discharge_structure x = Some x
+let discharge_structure x = Structure.discharge x
 
 let rebuild_structure s = Structure.rebuild (Global.env()) s
 


### PR DESCRIPTION
This is a proof of concept for discharge on the fly, that is for being able to access all generalizations of a declaration in a section at the time of declaration.

Example:
```coq
Section S.
Context {A B:Type}.
Inductive option := None | Some (a:A).
Definition map (f : A -> B) (o : option) :=
  match o with
  | None => Top.None
  | Some a => Top.Some (f a)
  end.
End S.
```

The new model is basically the following:
- one declaration in a nested sequence of sections S1, ..., Sn induces n+1 declarations, corresponding to the original declaration and its n generalizations
- at the time of closing Si, we morally just drop the copy of the declaration in Si (even if, technically, we reset and replay the i generalizations from level 0 to i-1)
 
There is basically one main change of structure:
- kernel names include a section path in their name (encoded using MPdot)

The changes are otherwise dispatched into three parts:
- in the kernel (safe_typing.ml): add all generalizations of a declaration at declaration time
- in library (lib.ml): add all discharges of objects at declaration time
- adapt all discharge functions to take into account that names now include a section segment and that all discharges virtually live together in the section

This raises questions about the levels at which a declaration has to be done:
- most declarations, starting with definitions and inductive types, as well as their attributes (implicit arguments, scopes, etc.) have to be done at all levels, i.e., for the example above, in section `S`, both `option` and `Top.option` have to be defined
- some declarations should be done only in one level, e.g. for `Require`, or (mono) `Universe` only the copy living at the toplevel has to be registered
- for some declarations, such as coercions and canonical structures, it is unclear: do we want to have all discharged version available from section i (even if it is somehow redundant) or only the version discharged at level i?

Incidentally, since the discharge functions have to be adapted anyway, that might be a right time to change the type of Libobject functions (e.g. so that they take an environment and a summary as arguments?).

I open the PR as draft to get some first comments.

Current status: PRs #18062 (preliminatory work on discharge) and #18065 (discharge on the fly in the kernel) have been made out of this PR, which now depends on them.

- [x] Added / updated **test-suite**.
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.

Related discussion: Future of sections #6254 and coq/ceps#72.