### PR TITLE
Fixes #17071: appropriate error instead of anomaly in the presence of notations with constructors applied to too many arguments in pattern-matching

### DIFF
--- a/doc/changelog/03-notations/17892-master+fix17071-anomaly-notation-wrong-number-constructor-arguments.rst
+++ b/doc/changelog/03-notations/17892-master+fix17071-anomaly-notation-wrong-number-constructor-arguments.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  appropriate error instead of anomaly in the presence of notations
+  with constructors applied to too many arguments in pattern-matching
+  (`#17892 <https://github.com/coq/coq/pull/17892>`_,
+  fixes `#17071 <https://github.com/coq/coq/issues/17071>`_,
+  by Hugo Herbelin).

--- a/test-suite/output/Cases.out
+++ b/test-suite/output/Cases.out
@@ -260,3 +260,8 @@ silence this warning. [unused-pattern-matching-variable,default]
 File "./output/Cases.v", line 314, characters 3-4:
 Warning: Unused variable x might be a misspelled constructor. Use _ or _x to
 silence this warning. [unused-pattern-matching-variable,default]
+File "./output/Cases.v", line 325, characters 4-12:
+The command has indeed failed with message:
+Once notations are expanded, the resulting constructor true (in type bool) is
+expected to be applied to no arguments while it is actually applied to
+2 arguments.

--- a/test-suite/output/Cases.v
+++ b/test-suite/output/Cases.v
@@ -315,3 +315,14 @@ Definition c :=
  end.
 
 End Bug14207.
+
+Module Bug17071.
+
+Notation "x :||: l" := (true x l) (at level 51).
+
+Fail Check
+  match true with
+  | x :||: l => 0
+  end.
+
+End Bug17071.


### PR DESCRIPTION
A rather simple fix: turning the failure into a proper error message.

Fixes / closes #17071

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
