### PR TITLE
Fixes #11237: support constructor with parameters in primitive notations for patterns

### DIFF
--- a/doc/changelog/03-notations/17902-master+fix11237-constructor-parameters-in-prim-notation-for-pattern.rst
+++ b/doc/changelog/03-notations/17902-master+fix11237-constructor-parameters-in-prim-notation-for-pattern.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  support constructors with parameters in number or string notations for patterns
+  (`#17902 <https://github.com/coq/coq/pull/17902>`_,
+  fixes `#11237 <https://github.com/coq/coq/issues/11237>`_,
+  by Hugo Herbelin).

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1449,19 +1449,8 @@ let interp_prim_token_gen ?loc g p local_scopes =
 let interp_prim_token ?loc =
   interp_prim_token_gen ?loc (fun _ -> ())
 
-let rec check_allowed_ref_in_pat looked_for = DAst.(with_val (function
-  | GVar _ | GHole _ -> ()
-  | GRef (g,_) -> looked_for g
-  | GApp (f, l) ->
-    begin match DAst.get f with
-    | GRef (g, _) ->
-      looked_for g; List.iter (check_allowed_ref_in_pat looked_for) l
-    | _ -> raise Not_found
-    end
-  | _ -> raise Not_found))
-
-let interp_prim_token_cases_pattern_expr ?loc looked_for p =
-  interp_prim_token_gen ?loc (check_allowed_ref_in_pat looked_for) p
+let interp_prim_token_cases_pattern_expr ?loc check_allowed p =
+  interp_prim_token_gen ?loc check_allowed p
 
 let warn_deprecated_notation =
   Deprecation.create_warning ~object_name:"Notation" ~warning_name_if_no_since:"deprecated-notation"

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -227,7 +227,7 @@ val declare_string_interpreter : ?local:bool -> scope_name -> required_module ->
 val interp_prim_token : ?loc:Loc.t -> prim_token -> subscopes ->
   glob_constr * scope_name option
 (* This function returns a glob_const representing a pattern *)
-val interp_prim_token_cases_pattern_expr : ?loc:Loc.t -> (GlobRef.t -> unit) -> prim_token ->
+val interp_prim_token_cases_pattern_expr : ?loc:Loc.t -> (Glob_term.glob_constr -> unit) -> prim_token ->
   subscopes -> glob_constr * scope_name option
 
 (** Return the primitive token associated to a [term]/[cases_pattern];

--- a/test-suite/output/StringSyntaxPrimitive.v
+++ b/test-suite/output/StringSyntaxPrimitive.v
@@ -137,3 +137,22 @@ Module Test4.
   Definition float' := float.
   Check mk_floatList (@cons float' 1 [0; 0])%float%list.
 End Test4.
+
+Module Bug11237.
+
+Inductive bytes := wrap_bytes { unwrap_bytes : list byte }.
+
+Delimit Scope bytes_scope with bytes.
+Bind Scope bytes_scope with bytes.
+String Notation bytes wrap_bytes unwrap_bytes : bytes_scope.
+
+Open Scope bytes_scope.
+
+Example test_match :=
+  match "foo" with
+  | "foo" => "bar"
+  | "bar" => "foo"
+  | x => x
+  end.
+
+End Bug11237.

--- a/test-suite/output/StringSyntaxPrimitive.v
+++ b/test-suite/output/StringSyntaxPrimitive.v
@@ -142,6 +142,7 @@ Module Bug11237.
 
 Inductive bytes := wrap_bytes { unwrap_bytes : list byte }.
 
+Declare Scope bytes_scope.
 Delimit Scope bytes_scope with bytes.
 Bind Scope bytes_scope with bytes.
 String Notation bytes wrap_bytes unwrap_bytes : bytes_scope.

--- a/test-suite/success/Notations2.v
+++ b/test-suite/success/Notations2.v
@@ -229,3 +229,10 @@ Fail Notation "[ x ]" := (id x) (x custom doesntexist, only printing).
 Fail Notation "# x" := (id x) (in custom doesntexist, only printing).
 
 End TestNonExistentCustomOnlyPrinting.
+
+Module NotationClauseIn.
+
+Notation "1" := unit.
+Check fun x => match x in 1 with tt => 0 end.
+
+End NotationClauseIn.


### PR DESCRIPTION
This is fixed by forcing the parameters of the constructors to be `_` when coming from a notation.

We also provide support for a notation at the head of an "in" clause of "match".

Fixes / closes #11237

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
