### PR TITLE
Ensure that About on a section name do not fail with an anomaly

### DIFF
--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -285,6 +285,8 @@ module ModPath = struct
     | MPbound uid -> MBId.to_string uid
     | MPdot (mp,l) -> to_string mp ^ "." ^ Label.to_string l
 
+  let print mp = str (to_string mp)
+
   let rec debug_to_string = function
     | MPfile sl -> DirPath.to_string sl
     | MPbound uid -> MBId.debug_to_string uid

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -264,7 +264,10 @@ sig
   val dp : t -> DirPath.t
 
   val to_string : t -> string
-  (** Encode as a string (not to be used for user-facing messages). *)
+  (** Converts a identifier into an string. *)
+
+  val print : t -> Pp.t
+  (** Pretty-printer. *)
 
   val debug_to_string : t -> string
   (** Same as [to_string], but outputs extra information related to debug. *)

--- a/test-suite/output/Nametab.out
+++ b/test-suite/output/Nametab.out
@@ -37,3 +37,5 @@ Module Nametab.Q.N
 Module Nametab.Q.N (shorter name to refer to it in current context is Q.N)
 Module Nametab.Q
 Module Nametab.Q (shorter name to refer to it in current context is Q)
+No object of basename T
+Open Section Nametab.T

--- a/test-suite/output/Nametab.v
+++ b/test-suite/output/Nametab.v
@@ -46,3 +46,9 @@ Import Q.N.
 
 (* OK  *) Locate Module Q.
 (* OK  *) Locate Module Nametab.Q.
+
+(* A slightly different request *)
+Section T.
+Locate T.
+About T.
+End T.

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -450,11 +450,11 @@ let pr_located_qualid = function
       let s,mp =
         let open Nametab in
         let open GlobDirRef in match dir with
-        | DirOpenModule mp -> "Open Module", mp
-        | DirOpenModtype mp -> "Open Module Type", mp
-        | DirOpenSection _ -> anomaly (Pp.str"Sections are not locatable")
+        | DirOpenModule mp -> "Open Module", ModPath.print mp
+        | DirOpenModtype mp -> "Open Module Type", ModPath.print mp
+        | DirOpenSection dir -> "Open Section", DirPath.print dir
       in
-      str s ++ spc () ++ str (ModPath.to_string mp)
+      str s ++ spc () ++ mp
   | Module mp ->
     str "Module" ++ spc () ++ DirPath.print (Nametab.dirpath_of_module mp)
   | ModuleType mp ->


### PR DESCRIPTION
This was failing badly.
```
Section T.
About T.
(* Anomaly "Sections are not locatable" *)
```

We could either answer `S not a defined object` or `Open Section S`, on the model of `Open Module T` in the situation
```
Module T.
About T.
(* Open Module Top.T *)
```

We opt for the second one.

- [X] Added / updated **test-suite**.
