### PR TITLE
For arguments scopes, statically know the list of available scopes (technical PR)

### DIFF
--- a/clib/cMap.ml
+++ b/clib/cMap.ml
@@ -36,6 +36,7 @@ sig
   val fold_right : (key -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
   val height : 'a t -> int
   val filter_range : (key -> int) -> 'a t -> 'a t
+  val filter_map: (key -> 'a -> 'b option) -> 'a t -> 'b t (* in OCaml 4.11 *)
   val of_list : (key * 'a) list -> 'a t
   val symmetric_diff_fold :
     (key -> 'a option -> 'a option -> 'b -> 'b) ->
@@ -66,6 +67,7 @@ sig
   val fold_right : (M.t -> 'a -> 'b -> 'b) -> 'a map -> 'b -> 'b
   val height : 'a map -> int
   val filter_range : (M.t -> int) -> 'a map -> 'a map
+  val filter_map: (M.t -> 'a -> 'b option) -> 'a map -> 'b map (* in OCaml 4.11 *)
   val symmetric_diff_fold :
     (M.t -> 'a option -> 'a option -> 'b -> 'b) ->
     'a map -> 'a map -> 'b -> 'b
@@ -196,6 +198,13 @@ struct
           let m = aux m (map_prj r) in
           F.add v d m
     in aux F.empty (map_prj m)
+
+  let filter_map f m = (* Waiting for the optimized version in OCaml >= 4.11 *)
+    F.fold (fun k v accu ->
+        match f k v with
+        | None -> accu
+        | Some v' -> F.add k v' accu)
+      m F.empty
 
   let of_list l =
     let fold accu (x, v) = F.add x v accu in

--- a/clib/cMap.mli
+++ b/clib/cMap.mli
@@ -66,6 +66,9 @@ sig
       [filter_range] returns the submap of [m] whose keys are in
       range. Note that [in_range] has to define a continouous range. *)
 
+  val filter_map: (key -> 'a -> 'b option) -> 'a t -> 'b t (* in OCaml 4.11 *)
+  (** Like [map] but keeping only bindings mapped to [Some] *)
+
   val of_list : (key * 'a) list -> 'a t
   (** Turns an association list into a map *)
 

--- a/clib/hMap.ml
+++ b/clib/hMap.ml
@@ -319,6 +319,11 @@ struct
     let s = Int.Map.map ff s in
     Int.Map.filter (fun _ m -> not (Map.is_empty m)) s
 
+  let filter_map f s =
+    let ff m = Map.filter_map f m in
+    let s = Int.Map.map ff s in
+    Int.Map.filter (fun _ m -> not (Map.is_empty m)) s
+
   let partition f s =
     let fold h m (sl, sr) =
       let (ml, mr) = Map.partition f m in

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -303,7 +303,7 @@ val subst_scope_class :
 
 type add_scope_where = AddScopeTop | AddScopeBottom
 (** add new scope at top or bottom of existing stack (default is reset) *)
-val declare_scope_class : scope_name -> ?where:add_scope_where -> scope_class -> unit
+val declare_scope_class : (* local: *) bool -> scope_name -> ?where:add_scope_where -> scope_class -> unit
 val declare_ref_arguments_scope : GlobRef.t -> unit
 
 val compute_arguments_scope : Environ.env -> Evd.evar_map -> EConstr.types -> scope_name list list

--- a/test-suite/output/ArgumentsScope.out
+++ b/test-suite/output/ArgumentsScope.out
@@ -112,3 +112,23 @@ g'' is not universe polymorphic
 Arguments g'' x%B_scope
 g'' is transparent
 Expands to: Constant ArgumentsScope.g''
+f : A -> B -> A
+
+f is not universe polymorphic
+Arguments f _%X _%Y
+f is transparent
+Expands to: Constant ArgumentsScope.SectionTest1.S.f
+f : A -> B -> A
+
+f is not universe polymorphic
+f is transparent
+Expands to: Constant ArgumentsScope.SectionTest1.f
+N.f : A -> A
+
+N.f is not universe polymorphic
+Arguments N.f _%X
+Expands to: Constant ArgumentsScope.SectionTest2.N.f
+g : A -> A
+
+g is not universe polymorphic
+Expands to: Constant ArgumentsScope.SectionTest2.g

--- a/test-suite/output/ArgumentsScope.v
+++ b/test-suite/output/ArgumentsScope.v
@@ -78,3 +78,44 @@ Bind Scope B_scope with unit.  (* default: reset *)
 Definition g'' (x : unit) := x.
 
 About g''.
+
+Module SectionTest1.
+
+  Inductive A:Type :=.
+  Inductive B:Type :=.
+  Declare Scope X.
+  Section S.
+    Declare Scope Y.
+    Bind Scope X with A.
+    Bind Scope Y with B.
+    Definition f : A -> B -> A := fun x _ => x.
+    About f.
+  End S.
+  (* In section, Bind Scope do not survive the section nor have a persistent effect:
+     outside the section, f does not know any more about X and Y, even thoug X exists outside the section *)
+  About f.
+
+End SectionTest1.
+
+Module SectionTest2.
+
+  Inductive A:Type :=.
+  Module M.
+    Declare Scope X.
+    Bind Scope X with A.
+  End M.
+  Module N.
+    Import M.
+    Section S.
+      Axiom f : A -> A.
+    End S.
+  End N.
+  (* In modules, Bind Scope has a persistent effect even if not imported:
+     f knows about X even if M not imported *)
+  About N.f.
+  Axiom g : A -> A.
+  (* Without the Import, Bind Scope has however no effect on declarations not
+     already aware of this binding *)
+  About g.
+
+End SectionTest2.


### PR DESCRIPTION
This allows to rebuild the scopes knowing only the discharged data, that is to have `rebuild_discharge_scope` not requiring the current state to be dynamically built.

Before, an argument scope at some level was dynamically dependent on which `Bind Scope` were registered in the current section level.

This is a technical step in the direction of supporting discharge on the fly (#17888), probably worth to be separated as it happened while working on #17888 that developments are quite sensitive on it.

In passing:
- I ensure that `update_scope` is monotone when new scopes are added in front or at the end (even though this is probably useless in practice)
- I made more local the trick of passing an integer from discharge to rebuild (eventually, they may get merge in #17888 and the trick could be removed)

I also added some comments but the semantics of updating arguments scopes remains complicated to understand. E.g.:
- new `Bind Scope` are dynamically taken into account for all declarations
-`Bind Scope`s do not survive sections and the corresponding argument scopes disappear (even if the scope is from outside the section)
- the argument scopes of a declaration activated by a `Bind Scope` in a module remain active in other modules where the declaration is used even  if the `Bind Scope` is not imported nor even required (that is: on declarations with an existing argument scope, an `Import` of the module declaring the corresponding `Bind Scope` is enough to activate, but to have an impact on declarations without the corresponding argument scope activated yet, an `Import` is needed)

- [x] Added / updated **test-suite**.
