### PR TITLE
exposing interp_search_restriction

### DIFF
--- a/vernac/comSearch.mli
+++ b/vernac/comSearch.mli
@@ -10,6 +10,8 @@
 
 (* Interpretation of search commands *)
 
+val interp_search_restriction : Vernacexpr.search_restriction -> Names.DirPath.t list * Vernacexpr.verbose_flag
+
 val interp_search_request :
   Environ.env ->
   Evd.evar_map ->


### PR DESCRIPTION
This PR exposes the function that interprets Search restrictions. It is needed for the Search Panel of VSCoq2. 