### PR TITLE
ssrbool: reenable overwriting-delimiting-key

### DIFF
--- a/theories/ssr/ssrbool.v
+++ b/theories/ssr/ssrbool.v
@@ -15,8 +15,6 @@
 Require Bool.
 Require Import ssreflect ssrfun.
 
-#[export] Set Warnings "-overwriting-delimiting-key".
-
 (**
  A theory of boolean predicates and operators. A large part of this file is
  concerned with boolean reflection.
@@ -468,7 +466,9 @@ Reserved Notation "[ ==> b1 , b2 , .. , bn => c ]" (at level 0, format
   "'[hv' [ ==> '['  b1 , '/'  b2 , '/'  .. , '/'  bn ']' '/'  =>  c ] ']'").
 
 (**  Shorter delimiter  **)
+#[export] Set Warnings "-overwriting-delimiting-key".
 Delimit Scope bool_scope with B.
+#[export] Set Warnings "overwriting-delimiting-key".
 Open Scope bool_scope.
 
 (**  An alternative to xorb that behaves somewhat better wrt simplification. **)


### PR DESCRIPTION
https://github.com/coq/coq/pull/17758 changed the behavior of `From Coq.ssr Require Import ssrbool` to suppress "overwriting previous delimiting key", probably not intentionally.  While Coq doesn't currently support a way to disable a warning only from the result of a particular vernacular, and doesn't support saving the current warning state, we can do a bit better, and reenable the warning non-fatally.  I think this behavior is a bit better, though it means that developments passing `-w -hiding-delimiting-key` globally will need to re-suppress this warning if they `Require Import ssrbool`.

- [ ] Added **changelog**. (not needed if this makes it into 8.18)
