### PR TITLE
Add attribution for `Acc_intro_generator`.

### DIFF
--- a/theories/Init/Wf.v
+++ b/theories/Init/Wf.v
@@ -160,7 +160,11 @@ Notation Acc_iter_2 := Fix_F_2 (only parsing). (* compatibility *)
 
 
 
-(* Added by Julien Forest on 13/11/20 *)
+(* Added by Julien Forest on 13/11/20
+
+This construction is originally by Georges Gonthier, see
+https://sympa.inria.fr/sympa/arc/coq-club/2007-07/msg00013.html *)
+
 Section Acc_generator.
   Variable A : Type.
   Variable R : A -> A -> Prop.


### PR DESCRIPTION
This message gives the proper credits for the lemma `Acc_intro_generator`.

Mukesh Tiwari found out in  "Re: [Coq-Club] Finding the opaque terms in a definition", 10/9/21, 03:16, that @ggonthier is the original author. I think it's good to document that.