### PR TITLE
Bidirectionality in Ltac2 typechecking + type annotations for goal/constr_matching scopes

### DIFF
--- a/plugins/ltac2/tac2quote.ml
+++ b/plugins/ltac2/tac2quote.ml
@@ -440,7 +440,11 @@ let of_constr_matching {loc;v=m} =
     let pat = inj_wit ?loc:ploc wit_pattern pat in
     of_tuple [knd; pat; e]
   in
-  of_list ?loc map m
+  let e = of_list ?loc map m in
+  let tykn = pattern_core "constr_matching" in
+  let ty = CAst.make ?loc (CTypRef (AbsKn (Other tykn),[CAst.make ?loc (CTypVar Anonymous)])) in
+  CAst.make ?loc (CTacCnv (e, ty))
+
 
 (** From the patterns and the body of the branch, generate:
     - a goal pattern: (constr_match list * constr_match)
@@ -503,7 +507,10 @@ let of_goal_matching {loc;v=gm} =
     let tac = abstract_vars loc hyps tac in
     of_tuple ?loc [pat; tac]
   in
-  of_list ?loc map gm
+  let e = of_list ?loc map gm in
+  let tykn = pattern_core "goal_matching" in
+  let ty = CAst.make ?loc (CTypRef (AbsKn (Other tykn),[CAst.make ?loc (CTypVar Anonymous)])) in
+  CAst.make ?loc (CTacCnv (e, ty))
 
 let of_move_location {loc;v=mv} = match mv with
 | QMoveAfter id -> std_constructor ?loc "MoveAfter" [of_anti of_ident id]

--- a/plugins/ltac2/tac2typing_env.ml
+++ b/plugins/ltac2/tac2typing_env.ml
@@ -298,8 +298,8 @@ let eq_or_tuple eq t1 t2 = match t1, t2 with
 | _ -> false
 
 let rec unify0 env t1 t2 = match kind env t1, kind env t2 with
-| GTypVar id, t | t, GTypVar id ->
-  unify_var env id t
+| GTypVar id, _ -> unify_var env id t2
+| _, GTypVar id -> unify_var env id t1
 | GTypArrow (t1, u1), GTypArrow (t2, u2) ->
   let () = unify0 env t1 t2 in
   unify0 env u1 u2

--- a/user-contrib/Ltac2/Pattern.v
+++ b/user-contrib/Ltac2/Pattern.v
@@ -77,7 +77,9 @@ Ltac2 @ external instantiate : context -> constr -> constr :=
 
 (** Implementation of Ltac matching over terms and goals *)
 
-Ltac2 lazy_match0 t pats :=
+Ltac2 Type 'a constr_matching := (match_kind * t * (context -> constr array -> 'a)) list.
+
+Ltac2 lazy_match0 t (pats:'a constr_matching) :=
   let rec interp m := match m with
   | [] => Control.zero Match_failure
   | p :: m =>
@@ -98,7 +100,7 @@ Ltac2 lazy_match0 t pats :=
   end in
   Control.once (fun () => interp pats) ().
 
-Ltac2 multi_match0 t pats :=
+Ltac2 multi_match0 t (pats:'a constr_matching) :=
   let rec interp e m := match m with
   | [] => Control.zero e
   | p :: m =>
@@ -121,7 +123,11 @@ Ltac2 multi_match0 t pats :=
 
 Ltac2 one_match0 t m := Control.once (fun _ => multi_match0 t m).
 
-Ltac2 lazy_goal_match0 rev pats :=
+Ltac2 Type 'a goal_matching :=
+  ((((match_kind * t) option * (match_kind * t)) list * (match_kind * t)) *
+     (ident array -> context array -> context array -> constr array -> context -> 'a)) list.
+
+Ltac2 lazy_goal_match0 rev (pats:'a goal_matching) :=
   let rec interp m := match m with
   | [] => Control.zero Match_failure
   | p :: m =>
@@ -136,7 +142,7 @@ Ltac2 lazy_goal_match0 rev pats :=
   end in
   Control.once (fun () => interp pats) ().
 
-Ltac2 multi_goal_match0 rev pats :=
+Ltac2 multi_goal_match0 rev (pats:'a goal_matching) :=
   let rec interp e m := match m with
   | [] => Control.zero e
   | p :: m =>


### PR DESCRIPTION
We also annotate the core definitions in Pattern.v, this should
keep the type definition in sync with its usage.

With this, #17869 produces a precise type error.

The annotation is a bit adhoc (only these 2 scopes get it), not
sure what the best API is. Maybe Tac2core.add_expr_scope should take
an additional raw_typexpr argument and it would get threaded around
until CTacSyn is turned into CTacLet and typechecked?
