### PR TITLE
Pass bound universes directly as an instance in the VM.

### DIFF
--- a/kernel/univ.ml
+++ b/kernel/univ.ml
@@ -993,20 +993,6 @@ let abstract_universes uctx =
   let ctx = (nas, cstrs) in
   instance, ctx
 
-let rec compact_univ s vars i u =
-  match u with
-  | [] -> (s, List.rev vars)
-  | (lvl, _) :: u ->
-    match Level.var_index lvl with
-    | Some k when not (Level.Map.mem lvl s) ->
-      let lvl' = Level.var i in
-      compact_univ (Level.Map.add lvl lvl' s) (k :: vars) (i+1) u
-    | _ -> compact_univ s vars i u
-
-let compact_univ u =
-  let (s, s') = compact_univ Level.Map.empty [] 0 u in
-  (subst_univs_level_universe s u, s')
-
 (** Pretty-printing *)
 
 let pr_constraints prl = Constraints.pr prl

--- a/kernel/univ.mli
+++ b/kernel/univ.mli
@@ -415,13 +415,6 @@ val abstract_universes : UContext.t -> Instance.t * AbstractContext.t
 
 val make_abstract_instance : AbstractContext.t -> Instance.t
 
-(** [compact_univ u] remaps local variables in [u] such that their indices become
-     consecutive. It returns the new universe and the mapping.
-     Example: compact_univ [(Var 0, i); (Prop, 0); (Var 2; j))] =
-       [(Var 0,i); (Prop, 0); (Var 1; j)], [0; 2]
-*)
-val compact_univ : Universe.t -> Universe.t * int list
-
 (** {6 Pretty-printing of universes. } *)
 
 val pr_constraint_type : constraint_type -> Pp.t

--- a/kernel/vconv.ml
+++ b/kernel/vconv.ml
@@ -1,5 +1,4 @@
 open Util
-open Names
 open Environ
 open Conversion
 open Vm
@@ -8,6 +7,12 @@ open Vmvalues
 open Vmsymtable
 
 (* Test la structure des piles *)
+
+let table_key_instance env = function
+| ConstKey cst ->
+  let ctx = Environ.constant_context env cst in
+  Univ.AbstractContext.size ctx
+| RelKey _ | VarKey _ | EvarKey _ -> 0
 
 let compare_zipper z1 z2 =
   match z1, z2 with
@@ -90,28 +95,39 @@ and conv_atom env pb k a1 stk1 a2 stk2 cu =
 (*  Pp.(msg_debug (str "conv_atom(" ++ pr_atom a1 ++ str ", " ++ pr_atom a2 ++ str ")")) ; *)
   match a1, a2 with
   | Aind ((mi,_i) as ind1) , Aind ind2 ->
-    if Ind.CanOrd.equal ind1 ind2 && compare_stack stk1 stk2 then
+    if Names.Ind.CanOrd.equal ind1 ind2 && compare_stack stk1 stk2 then
       let ulen = Univ.AbstractContext.size (Environ.mind_context env mi) in
       if ulen = 0 then
         conv_stack env k stk1 stk2 cu
       else
         match stk1 , stk2 with
         | Zapp args1 :: stk1' , Zapp args2 :: stk2' ->
-          assert (ulen <= nargs args1);
-          assert (ulen <= nargs args2);
-          let u1 = Array.init ulen (fun i -> uni_lvl_val (arg args1 i)) in
-          let u2 = Array.init ulen (fun i -> uni_lvl_val (arg args2 i)) in
-          let u1 = Univ.Instance.of_array u1 in
-          let u2 = Univ.Instance.of_array u2 in
+          assert (0 < nargs args1);
+          assert (0 < nargs args2);
+          let u1 = uni_instance (arg args1 0) in
+          let u2 = uni_instance (arg args2 0) in
           let cu = convert_instances ~flex:false u1 u2 cu in
-          conv_arguments env ~from:ulen k args1 args2
+          conv_arguments env ~from:1 k args1 args2
             (conv_stack env k stk1' stk2' cu)
         | _, _ -> assert false (* Should not happen if problem is well typed *)
     else raise NotConvertible
   | Aid ik1, Aid ik2 ->
     if Vmvalues.eq_id_key ik1 ik2 && compare_stack stk1 stk2 then
+      let ulen = table_key_instance env ik1 in
+      if ulen = 0 then
         conv_stack env k stk1 stk2 cu
-      else raise NotConvertible
+      else
+        match stk1 , stk2 with
+        | Zapp args1 :: stk1' , Zapp args2 :: stk2' ->
+          assert (0 < nargs args1);
+          assert (0 < nargs args2);
+          let u1 = uni_instance (arg args1 0) in
+          let u2 = uni_instance (arg args2 0) in
+          let cu = convert_instances ~flex:false u1 u2 cu in
+          conv_arguments env ~from:1 k args1 args2
+            (conv_stack env k stk1' stk2' cu)
+        | _, _ -> assert false (* Should not happen if problem is well typed *)
+    else raise NotConvertible
   | Asort s1, Asort s2 ->
     sort_cmp_universes env pb s1 s2 cu
   | Asort _ , _ | Aind _, _ | Aid _, _ -> raise NotConvertible

--- a/kernel/vmbytecodes.ml
+++ b/kernel/vmbytecodes.ml
@@ -76,7 +76,6 @@ and bytecodes = instruction list
 type fv_elem =
   | FVnamed of Id.t
   | FVrel of int
-  | FVuniv_var of int
 
 type fv = fv_elem array
 
@@ -97,7 +96,6 @@ let pp_lbl lbl = str "L" ++ int lbl
 let pp_fv_elem = function
   | FVnamed id -> str "FVnamed(" ++ Id.print id ++ str ")"
   | FVrel i -> str "Rel(" ++ int i ++ str ")"
-  | FVuniv_var v -> str "FVuniv(" ++ int v ++ str ")"
 
 let rec pp_instr i =
   match i with

--- a/kernel/vmbytecodes.mli
+++ b/kernel/vmbytecodes.mli
@@ -77,7 +77,6 @@ val pp_bytecodes : bytecodes -> Pp.t
 type fv_elem =
   FVnamed of Id.t
 | FVrel of int
-| FVuniv_var of int
 
 type fv = fv_elem array
 

--- a/kernel/vmbytegen.ml
+++ b/kernel/vmbytegen.ml
@@ -103,29 +103,31 @@ type t = fv_elem
 
 let compare e1 e2 = match e1, e2 with
 | FVnamed id1, FVnamed id2 -> Id.compare id1 id2
-| FVnamed _, (FVrel _ | FVuniv_var _) -> -1
+| FVnamed _, (FVrel _) -> -1
 | FVrel _, FVnamed _ -> 1
 | FVrel r1, FVrel r2 -> Int.compare r1 r2
-| FVrel _, (FVuniv_var _) -> -1
-| FVuniv_var i1, FVuniv_var i2 -> Int.compare i1 i2
-| FVuniv_var _, (FVnamed _ | FVrel _) -> 1
 
 end
 
 module FvMap = Map.Make(Fv_elem)
 
+type fv_or_univ =
+| FUniv
+| FV of fv_elem
+
 (*spiwack: both type have been moved from Vmbytegen because I needed then
   for the retroknowledge *)
 type vm_env = {
-    size : int;              (* longueur de la liste [n] *)
-    fv_rev : fv_elem list;   (* [fvn; ... ;fv1] *)
-    fv_fwd : int FvMap.t;    (* reverse mapping *)
+    size : int;               (* longueur de la liste [n] *)
+    fv_rev : fv_or_univ list; (* [fvn; ... ;fv1] *)
+    fv_fwd : int FvMap.t;     (* reverse mapping *)
+    fv_unv : int option;      (* position of the universe instance *)
   }
 
 
 type comp_env = {
     arity : int;                 (* arity of the current function, 0 if none *)
-    nb_uni_stack : int ;         (* number of universes on the stack,      *)
+    toplevel_univs : bool;       (* is the toplevel instance on the stack  *)
                                  (* universes are always at the bottom.    *)
     nb_stack : int;              (* number of variables on the stack       *)
     in_stack : int Range.t;      (* position in the stack                  *)
@@ -150,20 +152,21 @@ module Config = struct
   let stack_safety_margin = 15
 end
 
-type argument = ArgLambda of lambda | ArgUniv of Univ.Level.t
+type argument = ArgLambda of lambda | ArgInstance of Univ.Instance.t
 
-let empty_fv = { size= 0;  fv_rev = []; fv_fwd = FvMap.empty }
+let empty_fv = { size= 0;  fv_rev = []; fv_fwd = FvMap.empty; fv_unv = None }
 let push_fv d e = {
   size = e.size + 1;
-  fv_rev = d :: e.fv_rev;
+  fv_rev = (FV d) :: e.fv_rev;
   fv_fwd = FvMap.add d e.size e.fv_fwd;
+  fv_unv = e.fv_unv;
 }
 
 let fv r = !(r.in_env)
 
 let empty_comp_env ()=
   { arity = 0;
-    nb_uni_stack = 0;
+    toplevel_univs = false;
     nb_stack = 0;
     in_stack = Range.empty;
     pos_rec = [||];
@@ -189,9 +192,9 @@ let ensure_stack_capacity (cenv : comp_env) code =
 let rec add_param n sz l =
   if Int.equal n 0 then l else add_param (n - 1) sz (Range.cons (n+sz) l)
 
-let comp_env_fun ?(univs=0) arity =
+let comp_env_fun ?(univs=false) arity =
   { arity;
-    nb_uni_stack = univs ;
+    toplevel_univs = univs;
     nb_stack = arity;
     in_stack = add_param arity 0 Range.empty;
     pos_rec = [||];
@@ -203,7 +206,7 @@ let comp_env_fun ?(univs=0) arity =
 
 let comp_env_fix_type  rfv =
   { arity = 0;
-    nb_uni_stack = 0;
+    toplevel_univs = false;
     nb_stack = 0;
     in_stack = Range.empty;
     pos_rec = [||];
@@ -214,7 +217,7 @@ let comp_env_fix_type  rfv =
 
 let comp_env_fix ndef arity rfv =
    { arity;
-     nb_uni_stack = 0;
+     toplevel_univs = false;
      nb_stack = arity;
      in_stack = add_param arity 0 Range.empty;
      pos_rec = Array.init ndef (fun i -> Koffsetclosure i);
@@ -225,7 +228,7 @@ let comp_env_fix ndef arity rfv =
 
 let comp_env_cofix_type ndef rfv =
   { arity = 0;
-    nb_uni_stack = 0;
+    toplevel_univs = false;
     nb_stack = 0;
     in_stack = Range.empty;
     pos_rec = [||];
@@ -236,7 +239,7 @@ let comp_env_cofix_type ndef rfv =
 
 let comp_env_cofix ndef arity rfv =
    { arity;
-     nb_uni_stack = 0;
+     toplevel_univs = false;
      nb_stack = arity;
      in_stack = add_param arity 0 Range.empty;
      pos_rec = Array.init ndef (fun i -> Kenvacc (ndef - 1 - i));
@@ -287,24 +290,33 @@ let pos_rel i r sz =
         r.in_env := push_fv db env;
         Kenvacc(r.offset + pos)
 
-let pos_universe_var i r sz =
+let pos_instance r sz =
   (* Compilation of a universe variable can happen either at toplevel (the
   current closure correspond to a constant and has local universes) or in a
   local closure (which has no local universes). *)
-  if r.nb_uni_stack != 0 then
+  if r.toplevel_univs then
     (* Universe variables are represented by De Bruijn levels (not indices),
-    starting at 0. The shape of the stack will be [v1|..|vn|u1..up|arg1..argq]
-    with size = n + p + q, and q = r.arity. So Kacc (sz - r.arity - 1) will access
-    the last universe. *)
-    Kacc (sz - r.arity - (r.nb_uni_stack - i))
+    starting at 0. The shape of the stack will be [v1|..|vn|inst|arg1..argp]
+    with size = n + p + 1, and p = r.arity. So Kacc (sz - r.arity - 1) will access
+    the instance. *)
+    Kacc (sz - r.arity - 1)
   else
     let env = !(r.in_env) in
-    let db = FVuniv_var i in
-    try Kenvacc (r.offset + find_at db env)
-    with Not_found ->
+    let pos = match env.fv_unv with
+    | None ->
       let pos = env.size in
-      r.in_env := push_fv db env;
-      Kenvacc(r.offset + pos)
+      let env = {
+        size = pos + 1;
+        fv_rev = FUniv :: env.fv_rev;
+        fv_fwd = env.fv_fwd;
+        fv_unv = Some pos;
+      }
+      in
+      let () = r.in_env := env in
+      pos
+    | Some p -> p
+    in
+    Kenvacc (r.offset + pos)
 
 (*i  Examination of the continuation *)
 
@@ -464,9 +476,9 @@ let comp_app comp_fun comp_arg cenv f args sz cont =
 
 let compile_fv_elem cenv fv sz cont =
   match fv with
-  | FVrel i -> pos_rel i cenv sz :: cont
-  | FVnamed id -> pos_named id cenv :: cont
-  | FVuniv_var i -> pos_universe_var i cenv sz :: cont
+  | FV (FVrel i) -> pos_rel i cenv sz :: cont
+  | FV (FVnamed id) -> pos_named id cenv :: cont
+  | FUniv -> pos_instance cenv sz :: cont
 
 let rec compile_fv cenv l sz cont =
   match l with
@@ -535,8 +547,8 @@ let rec compile_lam env cenv lam sz cont =
   | Lind (ind,u) ->
     if Univ.Instance.is_empty u then
       compile_structured_constant cenv (Const_ind ind) sz cont
-    else comp_app compile_structured_constant compile_universe cenv
-        (Const_ind ind) (Univ.Instance.to_array u) sz cont
+    else comp_app compile_structured_constant compile_instance cenv
+        (Const_ind ind) [|u|] sz cont
 
   | Lsort s ->
     (* We represent universes as a global constant with local universes
@@ -553,7 +565,7 @@ let rec compile_lam env cenv lam sz cont =
     in
     let compile_get_univ cenv idx sz cont =
       let () = set_max_stack_size cenv sz in
-      compile_fv_elem cenv (FVuniv_var idx) sz cont
+      pos_instance cenv sz :: Kfield idx :: cont
     in
     if List.is_empty subs then
       compile_structured_constant cenv (Const_sort s) sz cont
@@ -794,13 +806,17 @@ and compile_get_global cenv (kn,u) sz cont =
     Kgetglobal kn :: cont
   else
     comp_app (fun _ _ _ cont -> Kgetglobal kn :: cont)
-      compile_universe cenv () (Univ.Instance.to_array u) sz cont
+      compile_instance cenv () [|u|] sz cont
 
-and compile_universe cenv uni sz cont =
+and compile_instance cenv (u : Univ.Instance.t) sz cont =
   let () = set_max_stack_size cenv sz in
-  match Univ.Level.var_index uni with
-  | None -> compile_structured_constant cenv (Const_univ_level uni) sz cont
-  | Some idx -> pos_universe_var idx cenv sz :: cont
+  let len = Univ.Instance.length u in
+  let comp_univ cenv l sz cont = match Univ.Level.var_index l with
+  | None -> compile_structured_constant cenv (Const_univ_level l) sz cont
+  | Some idx -> pos_instance cenv sz :: Kfield idx :: cont
+  in
+  let u = Univ.Instance.to_array u in
+  comp_args comp_univ cenv u sz (Kmakeblock (len, 0) :: cont)
 
 and compile_constant env cenv kn u args sz cont =
   let () = set_max_stack_size cenv sz in
@@ -813,13 +829,11 @@ and compile_constant env cenv kn u args sz cont =
     let compile_arg cenv constr_or_uni sz cont =
       match constr_or_uni with
       | ArgLambda t -> compile_lam env cenv t sz cont
-      | ArgUniv uni -> compile_universe cenv uni sz cont
+      | ArgInstance u -> compile_instance cenv u sz cont
     in
-    let u = Univ.Instance.to_array u in
-    let lu = Array.length u in
     let all =
-      Array.init (lu + Array.length args)
-        (fun i -> if i < lu then ArgUniv u.(i) else ArgLambda args.(i-lu))
+      Array.init (Array.length args + 1)
+        (fun i -> if Int.equal i 0 then ArgInstance u else ArgLambda args.(i - 1))
     in
     comp_app (fun _ _ _ cont -> Kgetglobal kn :: cont)
       compile_arg cenv () all sz cont
@@ -866,8 +880,8 @@ let compile ?universes:(universes=0) env sigma c =
         let params, body = decompose_Llam lam in
         let arity = Array.length params in
         let cenv = empty_comp_env () in
-        let full_arity = arity + universes in
-        let r_fun = comp_env_fun ~univs:universes arity in
+        let full_arity = arity + 1 in
+        let r_fun = comp_env_fun ~univs:true arity in
         let lbl_fun = Label.create () in
         let env = { env; fun_code = [] } in
         let cont_fun = compile_lam env r_fun body full_arity [Kreturn full_arity] in
@@ -878,7 +892,11 @@ let compile ?universes:(universes=0) env sigma c =
         let init_code = ensure_stack_capacity cenv init_code in
         cenv, init_code, env.fun_code
     in
-    let fv = List.rev (!(cenv.in_env).fv_rev) in
+    let map_fv = function
+    | FV fv -> fv
+    | FUniv -> assert false
+    in
+    let fv = List.rev_map map_fv (!(cenv.in_env).fv_rev) in
     (if !dump_bytecode then
       Feedback.msg_debug (dump_bytecodes init_code fun_code fv)) ;
     let res = init_code @ fun_code in

--- a/kernel/vmbytegen.ml
+++ b/kernel/vmbytegen.ml
@@ -820,6 +820,7 @@ and compile_instance env cenv u0 sz cont =
     (* Optimization: allocate closed instances globally *)
     compile_structured_constant cenv (Const_univ_instance u0) sz cont
   else
+    let () = set_max_stack_size cenv (sz + len - 1) in
     let comp_univ cenv l sz cont = match Univ.Level.var_index l with
     | None -> compile_structured_constant cenv (Const_univ_level l) sz cont
     | Some idx -> pos_instance cenv sz :: Kfield idx :: cont

--- a/kernel/vmemitcodes.ml
+++ b/kernel/vmemitcodes.ml
@@ -475,8 +475,8 @@ type to_patch = emitcodes * patches
 (* Substitution *)
 let subst_strcst s sc =
   match sc with
-  | Const_sort _ | Const_b0 _ | Const_univ_level _ | Const_val _ | Const_uint _
-  | Const_float _ | Const_evar _ -> sc
+  | Const_sort _ | Const_b0 _ | Const_univ_level _ | Const_univ_instance _
+  | Const_val _ | Const_uint _ | Const_float _ | Const_evar _ -> sc
   | Const_ind ind -> let kn,i = ind in Const_ind (subst_mind s kn, i)
 
 let subst_annot _ (a : annot_switch) = a

--- a/kernel/vmsymtable.ml
+++ b/kernel/vmsymtable.ml
@@ -298,8 +298,6 @@ and slot_for_fv env sigma fv envcache table =
         cache_rel envcache i v; v
       | Some v -> v
       end
-  | FVuniv_var _idu ->
-    assert false
 
 and eval_to_patch env sigma (code, fv) envcache table =
   let slots = function

--- a/kernel/vmvalues.ml
+++ b/kernel/vmvalues.ml
@@ -295,6 +295,7 @@ let arg args i =
 (*************************************************)
 
 let uni_lvl_val (v : values) : Univ.Level.t = Obj.magic v
+let uni_instance (v : values) : Univ.Instance.t = Obj.magic v
 
 let rec whd_accu a stk =
   let stk =

--- a/kernel/vmvalues.ml
+++ b/kernel/vmvalues.ml
@@ -8,7 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 open Names
-open Univ
 open Values
 
 (********************************************)
@@ -294,7 +293,6 @@ let arg args i =
 (* Destructors ***********************************)
 (*************************************************)
 
-let uni_lvl_val (v : values) : Univ.Level.t = Obj.magic v
 let uni_instance (v : values) : Univ.Instance.t = Obj.magic v
 
 let rec whd_accu a stk =
@@ -307,11 +305,11 @@ let rec whd_accu a stk =
      begin match stk with
      | [] -> Vaccu (Obj.magic at, stk)
      | [Zapp args] ->
-        let args = Array.init (nargs args) (arg args) in
+        let () = assert (Int.equal (nargs args) 1) in
+        let inst = uni_instance (arg args 0) in
         let s = Obj.obj (Obj.field at 0) in
         begin match s with
         | Sorts.Type u ->
-          let inst = Instance.of_array (Array.map uni_lvl_val args) in
           let u = Univ.subst_instance_universe inst u in
           Vaccu (Asort (Sorts.sort_of_univ u), [])
         | _ -> assert false

--- a/kernel/vmvalues.ml
+++ b/kernel/vmvalues.ml
@@ -53,6 +53,7 @@ type structured_constant =
   | Const_evar of Evar.t
   | Const_b0 of tag
   | Const_univ_level of Univ.Level.t
+  | Const_univ_instance of Univ.Instance.t
   | Const_val of structured_values
   | Const_uint of Uint63.t
   | Const_float of Float64.t
@@ -105,6 +106,8 @@ let eq_structured_constant c1 c2 = match c1, c2 with
 | Const_b0 _, _ -> false
 | Const_univ_level l1 , Const_univ_level l2 -> Univ.Level.equal l1 l2
 | Const_univ_level _ , _ -> false
+| Const_univ_instance u1 , Const_univ_instance u2 -> Univ.Instance.equal u1 u2
+| Const_univ_instance _ , _ -> false
 | Const_val v1, Const_val v2 -> eq_structured_values v1 v2
 | Const_val _, _ -> false
 | Const_uint i1, Const_uint i2 -> Uint63.equal i1 i2
@@ -120,9 +123,10 @@ let hash_structured_constant c =
   | Const_evar e -> combinesmall 3 (Evar.hash e)
   | Const_b0 t -> combinesmall 4 (Int.hash t)
   | Const_univ_level l -> combinesmall 5 (Univ.Level.hash l)
-  | Const_val v -> combinesmall 6 (hash_structured_values v)
-  | Const_uint i -> combinesmall 7 (Uint63.hash i)
-  | Const_float f -> combinesmall 8 (Float64.hash f)
+  | Const_univ_instance u -> combinesmall 6 (Univ.Instance.hash u)
+  | Const_val v -> combinesmall 7 (hash_structured_values v)
+  | Const_uint i -> combinesmall 8 (Uint63.hash i)
+  | Const_float f -> combinesmall 9 (Float64.hash f)
 
 let eq_annot_switch asw1 asw2 =
   let eq_rlc (i1, j1) (i2, j2) = Int.equal i1 i2 && Int.equal j1 j2 in
@@ -151,6 +155,7 @@ let pp_struct_const = function
   | Const_evar e -> Pp.( str "Evar(" ++ int (Evar.repr e) ++ str ")")
   | Const_b0 i -> Pp.int i
   | Const_univ_level l -> Univ.Level.raw_pr l
+  | Const_univ_instance u -> Univ.Instance.pr Univ.Level.raw_pr u
   | Const_val _ -> Pp.str "(value)"
   | Const_uint i -> Pp.str (Uint63.to_string i)
   | Const_float f -> Pp.str (Float64.to_string f)
@@ -406,6 +411,7 @@ let obj_of_str_const str =
   | Const_evar e -> obj_of_atom (Aid (EvarKey e))
   | Const_b0 tag -> Obj.repr tag
   | Const_univ_level l -> Obj.repr l
+  | Const_univ_instance u -> Obj.repr u
   | Const_val v -> Obj.repr v
   | Const_uint i -> Obj.repr i
   | Const_float f -> Obj.repr f

--- a/kernel/vmvalues.mli
+++ b/kernel/vmvalues.mli
@@ -144,7 +144,7 @@ external val_of_annot_switch : annot_switch -> values = "%identity"
 (** Destructors *)
 
 val whd_val : values -> kind
-val uni_lvl_val : values -> Univ.Level.t
+val uni_instance : values -> Univ.Instance.t
 
 (** Arguments *)
 

--- a/kernel/vmvalues.mli
+++ b/kernel/vmvalues.mli
@@ -40,6 +40,7 @@ type structured_constant =
   | Const_evar of Evar.t
   | Const_b0 of tag
   | Const_univ_level of Univ.Level.t
+  | Const_univ_instance of Univ.Instance.t
   | Const_val of structured_values
   | Const_uint of Uint63.t
   | Const_float of Float64.t

--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -203,14 +203,15 @@ and nf_univ_args ~nb_univs mk env sigma stk =
     if Int.equal nb_univs 0 then Univ.Instance.empty
     else match stk with
     | Zapp args :: _ ->
-       let inst =
-         Array.init nb_univs (fun i -> uni_lvl_val (arg args i))
-       in
-       Univ.Instance.of_array inst
+      let inst = arg args 0 in
+      let inst = uni_instance inst in
+      let () = assert (Int.equal (Univ.Instance.length inst) nb_univs) in
+      inst
     | _ -> assert false
   in
   let (t,ty) = mk u in
-  nf_stk ~from:nb_univs env sigma t ty stk
+  let from = if Int.equal nb_univs 0 then 0 else 1 in
+  nf_stk ~from env sigma t ty stk
 
 and nf_evar env sigma evk stk =
   let evi = try Evd.find_undefined sigma evk with Not_found -> assert false in


### PR DESCRIPTION
This makes the VM compilation scheme of bound universe variables closer to the one of the native compiler. It also reduces the amount of free variables in closures containing bound universe levels.

We also remove a suspect but not outright incorrect piece of code in Vconv. For polymorphic constants with a non-empty instance, the previous code used to call VM conversion on the universe levels of the instances. This is fine because 1. opaque constants are invariant for instance cumulativity and 2. the level representation is a first-order datatype for which structural equality and semantic equality coincide, so VM conversion behaves the same as Level.equal. Nonetheless, this is a very fragile piece of code, so we replace it with the same code used for inductive instance comparison with the flex flag switched on.