### PR TITLE
Don't specialize dep hyps in zify

### DIFF
--- a/dev/ci/user-overlays/17937-JasonGross-zify-no-dep-specialize.sh
+++ b/dev/ci/user-overlays/17937-JasonGross-zify-no-dep-specialize.sh
@@ -1,0 +1,1 @@
+overlay fiat_crypto https://github.com/mit-plv/fiat-crypto dependabot/submodules/rupicola-1c6bef7 17937

--- a/doc/changelog/04-tactics/17935-zify-no-dep-specialize.rst
+++ b/doc/changelog/04-tactics/17935-zify-no-dep-specialize.rst
@@ -1,0 +1,9 @@
+- **Fixed:**
+  `zify` / `Z.euclidean_division_equations_cleanup` now no longer instantiates
+  dependent hypotheses.  This will by necessity make
+  `Z.to_euclidean_division_equations` a bit weaker, but the previous behavior
+  was overly sensitive to hypothesis ordering.  See `#17935
+  <https://github.com/coq/coq/pull/17935>`_ for a recipe to recapture the power
+  of the previous behavior in a more robust albeit slower way (`#17935
+  <https://github.com/coq/coq/pull/17935>`_, fixes `#17936
+  <https://github.com/coq/coq/issues/17936>`_, by Jason Gross).

--- a/test-suite/bugs/bug_17936.v
+++ b/test-suite/bugs/bug_17936.v
@@ -1,0 +1,51 @@
+From Coq Require Import Lia ZArith Zify PreOmega.
+Open Scope Z_scope.
+
+Goal forall m n, n * m = 1 -> n = 1 \/ n = -1.
+  pose proof Z.mul_eq_1; intros.
+  Z.to_euclidean_division_equations.
+  Fail assumption. (* was previously succeeding *)
+  let T := type of Z.mul_eq_1 in
+  lazymatch goal with
+  | [ H : T |- _ ] => idtac
+  | _ => fail 0 "Z.to_euclidean_division_equations should not mangle dependent quantifiers"
+  end.
+Abort.
+(* swapped n m order *)
+Goal forall n m, n * m = 1 -> n = 1 \/ n = -1.
+  pose proof Z.mul_eq_1; intros.
+  Z.to_euclidean_division_equations.
+  Fail assumption. (* correctly does not succeed *)
+  let T := type of Z.mul_eq_1 in
+  lazymatch goal with
+  | [ H : T |- _ ] => idtac
+  | _ => fail 0 "Z.to_euclidean_division_equations should not mangle dependent quantifiers"
+  end.
+Abort.
+
+(* Test that the commit message suggestion in fact works to restore behavior *)
+Ltac saturate :=
+  let unique_pose_proof lem :=
+    let ty := type of lem in
+    lazymatch goal with
+    | [ H : ty |- _ ] => fail
+    | _ => pose proof lem
+    end in
+  repeat match goal with
+    | [ H : forall x : ?T, _, H' : ?T |- _ ] => unique_pose_proof (H H')
+    | [ H : forall a (x : ?T), _, H' : ?T |- _ ] => unique_pose_proof (fun a => H a H')
+    end.
+Ltac Zify.zify_internal_to_euclidean_division_equations ::= Z.to_euclidean_division_equations; saturate.
+Ltac Zify.zify_post_hook ::= Z.to_euclidean_division_equations; saturate.
+Goal forall m n, n * m = 1 -> n = 1 \/ n = -1.
+  pose proof Z.mul_eq_1; intros.
+  zify.
+  assumption.
+Qed.
+
+(* swapped n m order *)
+Goal forall n m, n * m = 1 -> n = 1 \/ n = -1.
+  pose proof Z.mul_eq_1; intros.
+  zify.
+  assumption.
+Qed.

--- a/theories/Compat/Coq818.v
+++ b/theories/Compat/Coq818.v
@@ -11,3 +11,47 @@
 (** Compatibility file for making Coq act similar to Coq v8.18 *)
 
 Require Export Coq.Compat.Coq819.
+
+(* Restore broken behavior of [zify] reported in COQBUG(https://github.com/coq/coq/issues/17936) *)
+From Coq Require Import Arith BinInt BinNat Znat Nnat PreOmega.
+
+#[local] Open Scope Z_scope.
+Ltac Z.euclidean_division_equations_cleanup ::=
+  repeat match goal with
+         | [ H : ?x = ?x -> _ |- _ ] => specialize (H eq_refl)
+         | [ H : ?x <> ?x -> _ |- _ ] => clear H
+         | [ H : ?x < ?x -> _ |- _ ] => clear H
+         | [ H : ?T -> _, H' : ?T |- _ ] => specialize (H H')
+         | [ H : ?T -> _, H' : ~?T |- _ ] => clear H
+         | [ H : ~?T -> _, H' : ?T |- _ ] => clear H
+         | [ H : ?A -> ?x = ?x -> _ |- _ ] => specialize (fun a => H a eq_refl)
+         | [ H : ?A -> ?x <> ?x -> _ |- _ ] => clear H
+         | [ H : ?A -> ?x < ?x -> _ |- _ ] => clear H
+         | [ H : ?A -> ?B -> _, H' : ?B |- _ ] => specialize (fun a => H a H')
+         | [ H : ?A -> ?B -> _, H' : ~?B |- _ ] => clear H
+         | [ H : ?A -> ~?B -> _, H' : ?B |- _ ] => clear H
+         | [ H : 0 < ?x -> _, H' : ?x < 0 |- _ ] => clear H
+         | [ H : ?x < 0 -> _, H' : 0 < ?x |- _ ] => clear H
+         | [ H : ?A -> 0 < ?x -> _, H' : ?x < 0 |- _ ] => clear H
+         | [ H : ?A -> ?x < 0 -> _, H' : 0 < ?x |- _ ] => clear H
+         | [ H : 0 <= ?x -> _, H' : ?x < 0 |- _ ] => clear H
+         | [ H : ?x <= 0 -> _, H' : 0 < ?x |- _ ] => clear H
+         | [ H : ?A -> 0 <= ?x -> _, H' : ?x < 0 |- _ ] => clear H
+         | [ H : ?A -> ?x <= 0 -> _, H' : 0 < ?x |- _ ] => clear H
+         | [ H : 0 < ?x -> _, H' : ?x <= 0 |- _ ] => clear H
+         | [ H : ?x < 0 -> _, H' : 0 <= ?x |- _ ] => clear H
+         | [ H : ?A -> 0 < ?x -> _, H' : ?x <= 0 |- _ ] => clear H
+         | [ H : ?A -> ?x < 0 -> _, H' : 0 <= ?x |- _ ] => clear H
+         | [ H : 0 <= ?x -> _, H' : ?x <= 0 |- _ ] => specialize (fun pf => H (@Z.eq_le_incl 0 x (eq_sym pf)))
+         | [ H : ?A -> 0 <= ?x -> _, H' : ?x <= 0 |- _ ] => specialize (fun a pf => H a (@Z.eq_le_incl 0 x (eq_sym pf)))
+         | [ H : ?x <= 0 -> _, H' : 0 <= ?x |- _ ] => specialize (fun pf => H (@Z.eq_le_incl 0 x pf))
+         | [ H : ?A -> ?x <= 0 -> _, H' : 0 <= ?x |- _ ] => specialize (fun a pf => H a (@Z.eq_le_incl x 0 pf))
+         | [ H : ?x < ?y -> _, H' : ?x = ?y |- _ ] => clear H
+         | [ H : ?x < ?y -> _, H' : ?y = ?x |- _ ] => clear H
+         | [ H : ?A -> ?x < ?y -> _, H' : ?x = ?y |- _ ] => clear H
+         | [ H : ?A -> ?x < ?y -> _, H' : ?y = ?x |- _ ] => clear H
+         | [ H : ?x = ?y -> _, H' : ?x < ?y |- _ ] => clear H
+         | [ H : ?x = ?y -> _, H' : ?y < ?x |- _ ] => clear H
+         | [ H : ?A -> ?x = ?y -> _, H' : ?x < ?y |- _ ] => clear H
+         | [ H : ?A -> ?x = ?y -> _, H' : ?y < ?x |- _ ] => clear H
+         end.

--- a/theories/omega/PreOmega.v
+++ b/theories/omega/PreOmega.v
@@ -86,16 +86,16 @@ Module Z.
   Ltac quot_rem_to_equations' := repeat quot_rem_to_equations_step.
   Ltac euclidean_division_equations_cleanup :=
     repeat match goal with
-           | [ H : ?x = ?x -> _ |- _ ] => specialize (H eq_refl)
+           | [ H : ?x = ?x -> ?Q |- _ ] => specialize (H eq_refl)
            | [ H : ?x <> ?x -> _ |- _ ] => clear H
            | [ H : ?x < ?x -> _ |- _ ] => clear H
-           | [ H : ?T -> _, H' : ?T |- _ ] => specialize (H H')
+           | [ H : ?T -> ?Q, H' : ?T |- _ ] => specialize (H H')
            | [ H : ?T -> _, H' : ~?T |- _ ] => clear H
            | [ H : ~?T -> _, H' : ?T |- _ ] => clear H
-           | [ H : ?A -> ?x = ?x -> _ |- _ ] => specialize (fun a => H a eq_refl)
+           | [ H : ?A -> ?x = ?x -> ?Q |- _ ] => specialize (fun a => H a eq_refl)
            | [ H : ?A -> ?x <> ?x -> _ |- _ ] => clear H
            | [ H : ?A -> ?x < ?x -> _ |- _ ] => clear H
-           | [ H : ?A -> ?B -> _, H' : ?B |- _ ] => specialize (fun a => H a H')
+           | [ H : ?A -> ?B -> ?Q, H' : ?B |- _ ] => specialize (fun a => H a H')
            | [ H : ?A -> ?B -> _, H' : ~?B |- _ ] => clear H
            | [ H : ?A -> ~?B -> _, H' : ?B |- _ ] => clear H
            | [ H : 0 < ?x -> _, H' : ?x < 0 |- _ ] => clear H
@@ -110,10 +110,10 @@ Module Z.
            | [ H : ?x < 0 -> _, H' : 0 <= ?x |- _ ] => clear H
            | [ H : ?A -> 0 < ?x -> _, H' : ?x <= 0 |- _ ] => clear H
            | [ H : ?A -> ?x < 0 -> _, H' : 0 <= ?x |- _ ] => clear H
-           | [ H : 0 <= ?x -> _, H' : ?x <= 0 |- _ ] => specialize (fun pf => H (@Z.eq_le_incl 0 x (eq_sym pf)))
-           | [ H : ?A -> 0 <= ?x -> _, H' : ?x <= 0 |- _ ] => specialize (fun a pf => H a (@Z.eq_le_incl 0 x (eq_sym pf)))
-           | [ H : ?x <= 0 -> _, H' : 0 <= ?x |- _ ] => specialize (fun pf => H (@Z.eq_le_incl 0 x pf))
-           | [ H : ?A -> ?x <= 0 -> _, H' : 0 <= ?x |- _ ] => specialize (fun a pf => H a (@Z.eq_le_incl x 0 pf))
+           | [ H : 0 <= ?x -> ?Q, H' : ?x <= 0 |- _ ] => specialize (fun pf => H (@Z.eq_le_incl 0 x (eq_sym pf)))
+           | [ H : ?A -> 0 <= ?x -> ?Q, H' : ?x <= 0 |- _ ] => specialize (fun a pf => H a (@Z.eq_le_incl 0 x (eq_sym pf)))
+           | [ H : ?x <= 0 -> ?Q, H' : 0 <= ?x |- _ ] => specialize (fun pf => H (@Z.eq_le_incl 0 x pf))
+           | [ H : ?A -> ?x <= 0 -> ?Q, H' : 0 <= ?x |- _ ] => specialize (fun a pf => H a (@Z.eq_le_incl x 0 pf))
            | [ H : ?x < ?y -> _, H' : ?x = ?y |- _ ] => clear H
            | [ H : ?x < ?y -> _, H' : ?y = ?x |- _ ] => clear H
            | [ H : ?A -> ?x < ?y -> _, H' : ?x = ?y |- _ ] => clear H


### PR DESCRIPTION
`zify` / `Z.euclidean_division_equations_cleanup` now no longer instantiates dependent hypotheses.

This will by necessity make `Z.to_euclidean_division_equations` a bit weaker, but the previous behavior was overly sensitive to hypothesis ordering.  Users wishing to reclaim the previous power (and then some) may use this alternative:
```coq
Ltac saturate_at :=
  let unique_pose_proof lem :=
    let ty := type of lem in
    lazymatch goal with
    | [ H : ty |- _ ] => fail
    | _ => pose proof lem
    end in
  repeat match goal with
    | [ H : forall x : ?T, _, H' : ?T |- _ ] => unique_pose_proof (H H')
    | [ H : forall a (x : ?T), _, H' : ?T |- _ ] => unique_pose_proof (fun a => H a H')
    end.
Ltac Zify.zify_internal_to_euclidean_division_equations ::= Z.to_euclidean_division_equations; saturate.
Ltac Zify.zify_post_hook ::= Z.to_euclidean_division_equations; saturate.
```

Users who were overly sensitive to the previous behavior can replace `unique_pose_proof` with `specialize` to more closely match the previous fragile behavior.

Advanced users who were relying on `zify` to instantiate hypotheses *dependently* quantifying over proofs of `?x = ?x`, `?x <= 0`, and/or `0 <= ?x` and for some reason wish to continue relying on this behavior, may feel free to make the questionable decision of adding the following cases to `saturate`:
```coq
    | [ H : forall pf : ?x = ?x, _ |- _ ] => unique_pose_proof (H eq_refl)
    | [ H : forall a (pf : ?x = ?x), _ |- _ ] => unique_pose_proof (fun a => H a eq_refl)
    | [ H : 0 <= ?x -> _, H' : ?x <= 0 |- _ ] => unique_pose_proof (fun pf => H (@Z.eq_le_incl 0 x (eq_sym pf)))
    | [ H : ?A -> 0 <= ?x -> _, H' : ?x <= 0 |- _ ] => unique_pose_proof (fun a pf => H a (@Z.eq_le_incl 0 x (eq_sym pf)))
    | [ H : ?x <= 0 -> _, H' : 0 <= ?x |- _ ] => unique_pose_proof (fun pf => H (@Z.eq_le_incl 0 x pf))
    | [ H : ?A -> ?x <= 0 -> _, H' : 0 <= ?x |- _ ] => unique_pose_proof (fun a pf => H a (@Z.eq_le_incl x 0 pf))
```

Fixes #17936

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
- [x] Opened **overlay** pull requests. (fingers crossed, hopefully none)
