### PR TITLE
Exporting a version of pr_constr_expr/pr_lconstr_expr ensured not to be overriden

### DIFF
--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -798,18 +798,22 @@ let tag_var = tag Tag.variable
   let pr_expr env sigma lev_after prec c =
     pr lev_after prec (transf env sigma c)
 
-  let pr_simpleconstr env sigma = pr_expr env sigma no_after lsimpleconstr
+  let pr_simpleconstr_env env sigma = pr_expr env sigma no_after lsimpleconstr
+  let pr_top_env env sigma = pr_expr env sigma no_after ltop
 
   let default_term_pr = {
-    pr_constr_expr   = pr_simpleconstr;
-    pr_lconstr_expr  = (fun env sigma -> pr_expr env sigma no_after ltop);
-    pr_constr_pattern_expr  = pr_simpleconstr;
-    pr_lconstr_pattern_expr = (fun env sigma -> pr_expr env sigma no_after ltop)
+    pr_constr_expr   = pr_simpleconstr_env;
+    pr_lconstr_expr  = pr_top_env;
+    pr_constr_pattern_expr  = pr_simpleconstr_env;
+    pr_lconstr_pattern_expr = pr_top_env;
   }
 
   let term_pr = ref default_term_pr
 
   let set_term_pr = (:=) term_pr
+
+  let pr_simpleconstr = pr no_after lsimpleconstr
+  let pr_top = pr no_after ltop
 
   let pr_constr_expr_n n c = pr_expr n c no_after
   let pr_constr_expr c   = !term_pr.pr_constr_expr   c

--- a/printing/ppconstr.mli
+++ b/printing/ppconstr.mli
@@ -76,6 +76,15 @@ val default_term_pr : term_pr
 
 val lsimpleconstr : entry_relative_level
 val ltop : entry_relative_level
+
+(* Print at level "simpleconstr"  (applications are surrounded with parentheses)
+   ensured not to be overriden, on the contrary of pr_constr_expr *)
+val pr_simpleconstr : constr_expr -> Pp.t
+
+(* Print at level "top" (no parentheses)
+   ensured not to be overriden, on the contrary of pr_lconstr_expr *)
+val pr_top : constr_expr -> Pp.t
+
 val modular_constr_pr :
   ((unit->Pp.t) -> int option -> entry_relative_level -> constr_expr -> Pp.t) ->
   (unit->Pp.t) -> int option -> entry_relative_level -> constr_expr -> Pp.t


### PR DESCRIPTION
This is mostly for the purpose of smtcoq ([`src/trace/smtMisc.ml`](https://github.com/smtcoq/smtcoq/blob/b48d748f0062ce8e8b42e39412aab24cf7b9567e/src/trace/smtMisc.ml#L35)), which currently fails on CI, so that it does not need to rely on the more complex and low-level `modular_constr_pr`.

Remark: it is not yet clear though whether smtcoq could not use the possibly-overriden versions of pr_constr_expr/pr_lconstr_expr.