### PR TITLE
Trying to recompute the inductive structure of the main (co)-inductive types when checking the guard condition

### DIFF
--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -1321,6 +1321,7 @@ and knht info e t stk =
     | LetIn (n,b,t,c) ->
       { mark = Red; term = FLetIn (usubst_binder e n, mk_clos e b, mk_clos e t, c, e) }, stk
     | Evar ev ->
+(try
       begin match info.i_cache.i_sigma.evar_expand ev with
       | EvarDefined c -> knht info e c stk
       | EvarUndefined (evk, args) ->
@@ -1331,6 +1332,8 @@ and knht info e t stk =
           let repack = info.i_cache.i_sigma.evar_repack in
           { mark = Ntrl; term = FEvar (evk, args, e, repack) }, stk
       end
+with Assert_failure _ ->
+          { mark = Ntrl; term = FAtom t }, stk)
     | Array(u,t,def,ty) ->
       let len = Array.length t in
       let ty = mk_clos e ty in

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -207,6 +207,8 @@ let mk_paths r recargs =
 
 let dest_recarg p = fst (Rtree.dest_node p)
 
+let is_norec r = eq_recarg (dest_recarg r) Norec
+
 (* dest_subterms returns the sizes of each argument of each constructor of
    an inductive object of size [p]. This should never be done for Norec,
    because the number of sons does not correspond to the number of

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -166,7 +166,7 @@ let eq_nested_type t1 t2 = match t1, t2 with
 let eq_recarg r1 r2 = match r1, r2 with
 | Norec, Norec -> true
 | Norec, _ -> false
-| Mrec i1, Mrec i2 -> Names.Ind.CanOrd.equal i1 i2
+| (Mrec i1 | Nested (NestedInd i1)), (Mrec i2 | Nested (NestedInd i2)) -> Names.Ind.CanOrd.equal i1 i2
 | Mrec _, _ -> false
 | Nested ty1, Nested ty2 -> eq_nested_type ty1 ty2
 | Nested _, _ -> false

--- a/kernel/declareops.mli
+++ b/kernel/declareops.mli
@@ -56,6 +56,7 @@ val mk_paths : recarg -> wf_paths list array -> wf_paths
 val dest_recarg : wf_paths -> recarg
 val dest_subterms : wf_paths -> wf_paths list array
 val recarg_length : wf_paths -> int -> int
+val is_norec : wf_paths -> bool
 
 val subst_wf_paths : substitution -> wf_paths -> wf_paths
 

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -1537,7 +1537,7 @@ let rec codomain_is_coind env c =
           raise (CoFixGuardError (env, CodomainNotInductiveType b)))
 
 let check_one_cofix env nbfix def deftype =
-  let rec check_rec_call env alreadygrd n tree vlra  t =
+  let rec check_rec_call env alreadygrd n tree vlra t =
     if not (noccur_with_meta n nbfix t) then
       let c,args = decompose_app_list (whd_all env t) in
       match kind c with

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -588,8 +588,6 @@ type subterm_spec =
   | Not_subterm
   | Internally_bound_subterm of Int.Set.t
 
-let eq_wf_paths = Rtree.equal Declareops.eq_recarg
-
 let inter_recarg r1 r2 = match r1, r2 with
 | Norec, Norec -> Some r1
 | Norec, _ -> None
@@ -608,7 +606,7 @@ let inter_wf_paths = Rtree.inter Declareops.eq_recarg inter_recarg Norec
 let incl_wf_paths = Rtree.incl Declareops.eq_recarg inter_recarg Norec
 
 let spec_of_tree t =
-  if eq_wf_paths t mk_norec
+  if Declareops.is_norec t
   then Not_subterm
   else Subterm (Int.Set.empty, Strict, t)
 
@@ -857,7 +855,7 @@ let get_recargs_approx env tree ind args =
 
   and build_recargs_nested (env,_ra_env as ienv) tree (((mind,i),u), largs) =
     (* If the inferred tree already disallows recursion, no need to go further *)
-    if eq_wf_paths tree mk_norec then tree
+    if Declareops.is_norec tree then tree
     else
     let mib = Environ.lookup_mind mind env in
     let auxnpar = mib.mind_nparams_rec in
@@ -893,7 +891,7 @@ let get_recargs_approx env tree ind args =
     (Rtree.mk_rec irecargs).(i)
 
   and build_recargs_nested_primitive (env, ra_env) tree (c, largs) =
-    if eq_wf_paths tree mk_norec then tree
+    if Declareops.is_norec tree then tree
     else
     let ntypes = 1 in (* Primitive types are modelled by non-mutual inductive types *)
     let ra_env = List.map (fun (r,t) -> (r,Rtree.lift ntypes t)) ra_env in
@@ -1555,7 +1553,7 @@ let check_one_cofix env nbfix def deftype =
             let realargs = List.skipn mib.mind_nparams args in
             let rec process_args_of_constr = function
               | (t::lr), (rar::lrar) ->
-                  if eq_wf_paths rar mk_norec then
+                  if Declareops.is_norec rar then
                     if noccur_with_meta n nbfix t
                     then process_args_of_constr (lr, lrar)
                     else raise (CoFixGuardError

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -107,6 +107,18 @@ let whd_decompose_prod env =
   in
   decrec env Context.Rel.empty
 
+let whd_decompose_prod_n env i =
+  let rec decrec env i m c =
+    let t = whd_all env c in
+    if i = 0 then m,t else
+    match kind t with
+      | Prod (n,a,c0) ->
+          let d = LocalAssum (n,a) in
+          decrec (push_rel d env) (i-1) (Context.Rel.add d m) c0
+      | _ -> m,t
+  in
+  decrec env i Context.Rel.empty
+
 let whd_decompose_lambda env =
   let rec decrec env m c =
     let t = whd_all env c in

--- a/kernel/reduction.mli
+++ b/kernel/reduction.mli
@@ -45,6 +45,7 @@ val betazeta_appvect : int -> constr -> constr array -> constr
   s Recognizing products and arities modulo reduction *)
 
 val whd_decompose_prod         : env -> types -> Constr.rel_context * types
+val whd_decompose_prod_n       : env -> int -> types -> Constr.rel_context * types
 val whd_decompose_prod_decls   : env -> types -> Constr.rel_context * types
 val whd_decompose_lambda       : env -> constr -> Constr.rel_context * constr
 val whd_decompose_lambda_decls : env -> constr -> Constr.rel_context * constr

--- a/lib/rtree.ml
+++ b/lib/rtree.ml
@@ -27,6 +27,7 @@ type 'a t =
   | Rec of int * 'a t array
 
 (* Building trees *)
+let mk_rec_call i j = Var(i,j)
 let mk_rec_calls i = Array.init i (fun j -> Var(0,j))
 let mk_node lab sons = Node (lab, sons)
 
@@ -97,6 +98,11 @@ let dest_node t =
   match expand t with
       Node (l,sons) -> (l,sons)
     | _ -> failwith "Rtree.dest_node"
+
+let is_param t =
+  match expand t with
+      Var _ -> true
+    | _ -> false
 
 let is_node t =
   match expand t with
@@ -209,6 +215,13 @@ let is_infinite cmp t =
     | _ -> false
   in
   is_inf [] t
+
+let is_recursive t =
+  let rec aux k = function
+    Var (i,j) -> i >= k
+  | Node (_,sons) -> Array.exists (Array.exists (aux k)) sons
+  | Rec (j,defs) -> Array.exists (aux (k+1)) defs in
+  aux 0 t
 
 (* Pretty-print a tree (not so pretty) *)
 open Pp

--- a/lib/rtree.ml
+++ b/lib/rtree.ml
@@ -18,7 +18,7 @@ open Util
    - Node denotes the usual tree node, labelled with 'a, to the
      exception that it takes an array of arrays as argument
    - Rec(j,v1..vn) introduces infinite tree. It denotes
-     v(j+1) with parameters 0..n-1 replaced by
+     v(j+1) with variables 0..n-1 replaced by
      Rec(0,v1..vn)..Rec(n-1,v1..vn) respectively.
  *)
 type 'a t =
@@ -53,16 +53,16 @@ let rec subst_rtree_rec depth sub = function
 let subst_rtree sub t = subst_rtree_rec 0 sub t
 
 (* To avoid looping, we must check that every body introduces a node
-   or a parameter *)
+   or a variable *)
 let rec expand = function
   | Rec(j,defs) ->
       expand (subst_rtree defs defs.(j))
   | t -> t
 
 (* Given a vector of n bodies, builds the n mutual recursive trees.
-   Recursive calls are made with parameters (0,0) to (0,n-1). We check
+   Recursive calls are made with variables (0,0) to (0,n-1). We check
    the bodies actually build something by checking it is not
-   directly one of the parameters of depth 0. Some care is taken to
+   directly one of the variables of depth 0. Some care is taken to
    accept definitions like  rec X=Y and Y=f(X,Y) *)
 let mk_rec defs =
   let rec check histo d = match expand d with
@@ -120,7 +120,7 @@ struct
 
 end
 
-(** Structural equality test, parametrized by an equality on elements *)
+(** Structural equality test, parameterized by an equality on elements *)
 
 let rec raw_eq cmp t t' = match t, t' with
   | Var (i,j), Var (i',j') -> Int.equal i i' && Int.equal j j'
@@ -130,7 +130,7 @@ let rec raw_eq cmp t t' = match t, t' with
 
 let raw_eq2 cmp (t,u) (t',u') = raw_eq cmp t t' && raw_eq cmp u u'
 
-(** Equivalence test on expanded trees. It is parametrized by two
+(** Equivalence test on expanded trees. It is parameterized by two
     equalities on elements:
     - [cmp] is used when checking for already seen trees
     - [cmp'] is used when comparing node labels. *)

--- a/lib/rtree.ml
+++ b/lib/rtree.ml
@@ -231,4 +231,4 @@ let rec pr_tree prl t =
           hv 2 (str"Rec{"++pr_tree prl v.(0)++str"}")
         else
           hv 2 (str"Rec{"++int i++str","++brk(1,0)++
-                 prvect_with_sep pr_comma (pr_tree prl) v++str"}")
+                prvect_with_sep pr_comma (fun t -> str"("++pr_tree prl t++str")") v++str"}")

--- a/lib/rtree.mli
+++ b/lib/rtree.mli
@@ -42,6 +42,7 @@ val mk_node  : 'a -> 'a t array array -> 'a t
   let [|y|] = mk_rec[|mk_node b [|[|x;vy;vy|]|]|]
   (note the lift so that Y links to the "rec Y" skipping the "rec X")
  *)
+val mk_rec_call : int -> int -> 'a t
 val mk_rec_calls : int -> 'a t array
 val mk_rec   : 'a t array -> 'a t array
 
@@ -49,6 +50,7 @@ val mk_rec   : 'a t array -> 'a t array
    to avoid captures when a tree appears under [mk_rec] *)
 val lift : int -> 'a t -> 'a t
 
+val is_param : 'a t -> bool
 val is_node : 'a t -> bool
 
 (** Destructors (recursive calls are expanded) *)
@@ -60,6 +62,8 @@ val dest_var : 'a t -> int * int
 (** Tells if a tree has an infinite branch. The first arg is a comparison
     used to detect already seen elements, hence loops *)
 val is_infinite : ('a -> 'a -> bool) -> 'a t -> bool
+
+val is_recursive : 'a t -> bool
 
 (** [Rtree.equiv eq eqlab t1 t2] compares t1 t2 (top-down).
    If t1 and t2 are both nodes, [eqlab] is called on their labels,

--- a/lib/rtree.mli
+++ b/lib/rtree.mli
@@ -45,7 +45,7 @@ val mk_node  : 'a -> 'a t array array -> 'a t
 val mk_rec_calls : int -> 'a t array
 val mk_rec   : 'a t array -> 'a t array
 
-(** [lift k t] increases of [k] the free parameters of [t]. Needed
+(** [lift k t] increases of [k] the free variables of [t]. Needed
    to avoid captures when a tree appears under [mk_rec] *)
 val lift : int -> 'a t -> 'a t
 
@@ -64,7 +64,7 @@ val is_infinite : ('a -> 'a -> bool) -> 'a t -> bool
 (** [Rtree.equiv eq eqlab t1 t2] compares t1 t2 (top-down).
    If t1 and t2 are both nodes, [eqlab] is called on their labels,
    in case of success deeper nodes are examined.
-   In case of loop (detected via structural equality parametrized
+   In case of loop (detected via structural equality parameterized
    by [eq]), then the comparison is successful. *)
 val equiv :
   ('a -> 'a -> bool) -> ('a -> 'a -> bool) -> 'a t -> 'a t -> bool

--- a/test-suite/success/Fixpoint.v
+++ b/test-suite/success/Fixpoint.v
@@ -406,3 +406,25 @@ Fixpoint f (n : nat) :=
   end.
 
 End WithLateCaseReduction.
+
+Module HighlyNested.
+
+Inductive T A := E : A * list A * list (list A) -> T A.
+Inductive U := H : T (T U) -> U.
+
+Definition map {A B : Type} (f : A -> B) :=
+  fix map (l : list A) : list B :=
+  match l with
+  | nil => nil
+  | cons a t => cons (f a) (map t)
+  end.
+
+Definition mapT {A B} (f:A -> B) t :=
+  match t with E _ (a, l, ll) => E _ (f a, map f l, map (map f) ll) end.
+
+Fixpoint mapU (f:U->U) u :=
+  match u with
+  | H t => H (mapT (mapT (mapU f)) t)
+  end.
+
+End HighlyNested.

--- a/test-suite/success/fix.v
+++ b/test-suite/success/fix.v
@@ -96,3 +96,171 @@ assumption.
 apply bcons.
 assumption.
 Qed.
+
+Module Wish9045.
+
+Inductive Wrapper (T : Type) :=
+  | Wrap : T -> Wrapper T
+  .
+Inductive Unwrapper :=
+  | Empty : Unwrapper
+  | Unwrap : Wrapper Unwrapper -> Unwrapper
+  .
+
+Fixpoint Unwrapper_size (u : Unwrapper) {struct u} : nat :=
+  match u with
+  | Empty => O
+  | Unwrap w => Wrapper_size w
+  end
+
+with Wrapper_size (w : Wrapper Unwrapper) {struct w} : nat :=
+  match w with
+  | Wrap _ t => Unwrapper_size t
+  end.
+
+End Wish9045.
+
+Module Wish12781.
+
+Inductive tree :=
+| Foo : list tree -> tree.
+
+Fixpoint f (l : list tree) {struct l} :=
+  match l with
+  | nil => 0
+  | cons (Foo l') _ => f l'
+  end.
+
+End Wish12781.
+
+Module Wish13855.
+
+Open Scope nat_scope.
+
+Inductive exp :=
+  | If : list exp -> exp.
+
+Fixpoint c_exps_notc (z : exp) : nat :=
+  match z with
+  | If l0 =>
+    let fix c_exps (zs : list exp) : nat :=
+       match zs with
+       | nil => 0
+       | cons e zs1 => c_exps_notc e
+       end
+    in c_exps l0
+  end.
+
+Fixpoint c_exps (zs : list exp) : nat :=
+  match zs as l return nat with
+  | nil => 0
+  | cons e zs1 =>
+    (let fix c_exp_notc (z : exp) : nat :=
+     match z return nat with
+      | If l0 => (c_exps l0)
+      end in
+    c_exp_notc) e
+  end.
+
+End Wish13855.
+
+Module Wish15932.
+
+Inductive A (B : Set) (par : bool) : Set :=
+  | A0 : A B par
+  | A1 : B -> A B par.
+
+Inductive B : Set :=
+  | B0 : B
+  | B1 : forall (par : bool) (a : A B par), B.
+
+Fixpoint testB (x : B) {struct x}: unit :=
+  match x with
+  | B0 => tt
+  | B1 p a => testA p a
+  end
+
+with testA (par : bool) (y : A B par) {struct y}: unit :=
+  match y with
+  | A0 _ _ => tt
+  | A1 _ _ b => testB b
+  end.
+
+End Wish15932.
+
+Module MutualCoFix.
+
+(* An example sent on Coq-Club 29 Aug 2023 *)
+
+CoInductive stream (A: Type): Type :=
+      | nils : stream A
+      | conss: A -> stream A -> stream A.
+
+Arguments nils {_}.
+Arguments conss {_} _ _.
+
+CoInductive T: Type :=
+  | c1: T
+  | c2: list T -> T.
+
+CoInductive U: Type :=
+  | c3: U
+  | c4: stream U -> U.
+
+CoFixpoint T2U (s: T): stream U :=
+  match s with
+    | c1   =>  conss c3 nils
+    | c2 l =>
+      let cofix next l :=
+        match l with
+          | nil       => nils
+          | cons u xs => conss (c4 (T2U u)) (next xs)
+        end
+      in next l
+  end.
+
+End MutualCoFix.
+
+Module MutualWithDependentParameter.
+
+Inductive list (b : bool) A B :=
+| nil : list b A B
+| cons : (if b then A else B) -> list b A B -> list b A B.
+
+Inductive tree := Foo : list true tree unit -> tree.
+
+Fixpoint f (l : list true tree unit) {struct l} :=
+  match l with
+  | nil _ _ _ => 0
+  | cons _ _ _ (Foo l') _ => f l'
+  end.
+
+End MutualWithDependentParameter.
+
+(** Extracted from coq_performance_tests *)
+
+Require Import Coq.QArith.QArith Coq.QArith.Qround Coq.Lists.List.
+
+Module InnerMatch.
+
+Import ListNotations.
+
+Local Coercion N.of_nat : nat >-> N.
+Local Coercion N.to_nat : N >-> nat.
+Local Coercion Z.of_N : N >-> Z.
+Local Coercion inject_Z : Z >-> Q.
+
+Fixpoint take_uniform_n' {T} (ls : list T) (len : nat) (n : nat) : list T
+  := match n, ls, List.rev ls with
+     | 0%nat, _, _ => []
+     | _, [], _ => []
+     | _, _, [] => []
+     | 1%nat, x::_, _ => [x]
+     | 2%nat, [x], _ => [x]
+     | 2%nat, x::_, y::_ => [x; y]
+     | S n', x::xs, _
+       => let skip := Z.to_nat (Qfloor (1/2 + len / n - 1)) in
+          x :: take_uniform_n' (skipn skip xs) (len - 1 - skip) n'
+     end.
+
+End InnerMatch.


### PR DESCRIPTION
This should have been done for a very long time already: we recompute dynamically the recursive structure of the decreasing argument of fixpoints.

We could have introduced a notion of parametric recursive structure (precomputed "recarg") and instantiate the parameter dynamically (this is what we made in a first attempt of the PR actually), however we would have failed to support examples requiring a computation after instantiation of the parameters as in:

```coq
Inductive list (b : bool) A B :=
| nil : list b A B
| cons : (if b then A else B) -> list b A B -> list b A B.

Inductive tree := Foo : list true tree unit -> tree.

Fixpoint f (l : list true tree unit) {struct l} :=
  match l with
  | nil _ _ _ => 0
  | cons _ _ _ (Foo l') _ => f l'
  end.
```

Closes #9045, #12781, #13855, #15932.

- [x] Added / updated **test-suite**.
- [ ] Added **changelog**.

Depends on #18229 and #18242.

To do:
- double-check that we are not doing something wrong
- check performance, possibly compute recargs lazily
- decide if precomputation of recargs is still useful
