### PR TITLE
Statically enforce that hint paths are single references for instances.

### DIFF
--- a/dev/ci/user-overlays/17955-ppedrot-hint-cut-static-globref.sh
+++ b/dev/ci/user-overlays/17955-ppedrot-hint-cut-static-globref.sh
@@ -1,0 +1,5 @@
+overlay elpi https://github.com/ppedrot/coq-elpi hint-cut-static-globref 17955
+
+overlay equations https://github.com/ppedrot/Coq-Equations hint-cut-static-globref 17955
+
+overlay fiat_parsers https://github.com/ppedrot/fiat hint-cut-static-globref 17955

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -700,7 +700,11 @@ module Search = struct
     let idx = ref 1 in
     let foundone = ref false in
     let rec onetac e (tac, pat, b, name, pp) tl =
-      let derivs = path_derivate info.search_cut name in
+      let path = match name with
+      | None -> PathAny
+      | Some gr -> PathHints [gr]
+      in
+      let derivs = path_derivate info.search_cut path in
       let pr_error ie =
         ppdebug 1 (fun () ->
             let idx = if fst ie == NoApplicableHint then pred !idx else !idx in

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -59,7 +59,7 @@ sig
   val pattern : t -> Pattern.constr_pattern option
   val database : t -> string option
   val run : t -> (hint hint_ast -> 'r Proofview.tactic) -> 'r Proofview.tactic
-  val name : t -> hints_path_atom
+  val name : t -> GlobRef.t option
   val print : env -> evar_map -> t -> Pp.t
   val subgoals : t -> int option
 
@@ -162,8 +162,8 @@ type hnf = bool
 type hint_term
 
 type hints_entry =
-  | HintsResolveEntry of (hint_info * hnf * hints_path_atom * hint_term) list
-  | HintsImmediateEntry of (hints_path_atom * hint_term) list
+  | HintsResolveEntry of (hint_info * hnf * hint_term) list
+  | HintsImmediateEntry of hint_term list
   | HintsCutEntry of hints_path
   | HintsUnfoldEntry of Tacred.evaluable_global_reference list
   | HintsTransparencyEntry of Tacred.evaluable_global_reference hints_transparency_target * bool

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -60,11 +60,12 @@ let set_typeclass_transparency_com ~locality refs b =
   in
   set_typeclass_transparency ~locality refs b
 
-let add_instance_hint inst path ~locality info =
+let add_instance_hint gr ~locality info =
+  let inst = Hints.hint_globref gr in
      Flags.silently (fun () ->
        Hints.add_hints ~locality [typeclasses_db]
           (Hints.HintsResolveEntry
-             [info, false, Hints.PathHints path, inst])) ()
+             [info, false, inst])) ()
 
 (* short names without opening all Hints *)
 type locality = Hints.hint_locality = Local | Export | SuperGlobal
@@ -92,7 +93,7 @@ let add_instance_base inst =
     if Lib.sections_are_opened () then Local
     else Export
   in
-  add_instance_hint (Hints.hint_globref inst.instance) [inst.instance] ~locality
+  add_instance_hint inst.instance ~locality
     inst.info
 
 (*

--- a/vernac/comHints.ml
+++ b/vernac/comHints.ml
@@ -62,7 +62,7 @@ let project_hint ~poly pri l2r r =
       cb
   in
   let info = {Typeclasses.hint_priority = pri; hint_pattern = None} in
-  (info, true, Hints.PathAny, Hints.hint_globref (GlobRef.ConstRef c))
+  (info, true, Hints.hint_globref (GlobRef.ConstRef c))
 
 let warn_deprecated_hint_constr =
   CWarnings.create ~name:"fragile-hint-constr" ~category:CWarnings.CoreCategories.automation
@@ -97,7 +97,7 @@ let interp_hints ~poly h =
     match c with
     | HintsReference c ->
       let gr = Smartlocate.global_with_alias c in
-      (PathHints [gr], hint_globref gr)
+      (hint_globref gr)
     | HintsConstr c ->
       let () = warn_deprecated_hint_constr () in
       let env = Global.env () in
@@ -112,17 +112,17 @@ let interp_hints ~poly h =
           let () = DeclareUctx.declare_universe_context ~poly:false diff in
           (c, None)
       in
-      (PathAny, Hints.hint_constr c) [@ocaml.warning "-3"]
+      (Hints.hint_constr c) [@ocaml.warning "-3"]
   in
   let fp = Constrintern.intern_constr_pattern env sigma in
   let fres (info, b, r) =
-    let path, gr = fi r in
+    let gr = fi r in
     let info =
       { info with
         Typeclasses.hint_pattern = Option.map fp info.Typeclasses.hint_pattern
       }
     in
-    (info, b, path, gr)
+    (info, b, gr)
   in
   let open Hints in
   let open Vernacexpr in
@@ -151,7 +151,6 @@ let interp_hints ~poly h =
           let gr = GlobRef.ConstructRef c in
           ( empty_hint_info
           , true
-          , PathHints [gr]
           , hint_globref gr ))
     in
     HintsResolveEntry (List.flatten (List.map constr_hints_of_ind lqid))


### PR DESCRIPTION
These references are always instantiated to the one used to create the hint itself, so we also simplify the API so that this holds by construction.

Overlays:
- https://github.com/mit-plv/fiat/pull/93
- https://github.com/LPCIC/coq-elpi/pull/494
- https://github.com/mattam82/Coq-Equations/pull/557