### PR TITLE
Stop automatically using `assumption` in `replace by tac`

### DIFF
--- a/dev/ci/user-overlays/17964-SkySkimmer-replace-assum.sh
+++ b/dev/ci/user-overlays/17964-SkySkimmer-replace-assum.sh
@@ -1,0 +1,1 @@
+overlay fiat_crypto https://github.com/SkySkimmer/fiat-crypto replace-assum 17964

--- a/doc/changelog/04-tactics/17964-replace-assum.rst
+++ b/doc/changelog/04-tactics/17964-replace-assum.rst
@@ -1,0 +1,8 @@
+- **Changed:**
+  :tacn:`replace` with `by tac` does not automatically attempt to solve
+  the generated equality subgoal using the hypotheses.
+  Use `by first [assumption | symmetry;assumption | tac]`
+  if you need the previous behaviour
+  (`#17964 <https://github.com/coq/coq/pull/17964>`_,
+  fixes `#17959 <https://github.com/coq/coq/issues/17959>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/proofs/writing-proofs/equality.rst
+++ b/doc/sphinx/proofs/writing-proofs/equality.rst
@@ -248,8 +248,8 @@ Rewriting with Leibniz and setoid equality
    as a subgoal. (Note the generated equality is reversed with respect
    to the order of the two terms in the tactic syntax; see
    issue `#13480 <https://github.com/coq/coq/issues/13480>`_.)
-   This equality is automatically solved if it occurs among
-   the hypotheses, or if its symmetric form occurs.
+   When :n:`by @ltac_expr3` is not present, this equality is automatically solved
+   if it occurs among the hypotheses, or if its symmetric form occurs.
 
    The second form, with `->` or no arrow, replaces :n:`@one_term__from`
    with :n:`@term__to` using


### PR DESCRIPTION
Close #17959

Overlays (should be backwards compatible):
- https://github.com/mit-plv/bedrock2/pull/371
- https://github.com/coq-community/bignums/pull/79
- https://github.com/mit-plv/fiat-crypto/pull/1657
