### PR TITLE
More positive messages in CoqIde's proof view

### DIFF
--- a/ide/coqide/wg_ProofView.ml
+++ b/ide/coqide/wg_ProofView.ml
@@ -151,10 +151,10 @@ let display mode (view : #GText.view_skel) goals hints =
   | NoFocusGoals { bg; shelved; given_up } ->
     begin match (bg, shelved, given_up) with
     | [], [], [] ->
-      view#buffer#insert "No more goals."
+      view#buffer#insert "All goals completed."
     | [], [], _ ->
       (* The proof is finished, with the exception of given up goals. *)
-      view#buffer#insert "No more goals, but there are some goals you gave up:\n\n";
+      view#buffer#insert "All goals completed except some admitted goals:\n\n";
       let iter goal =
         insert_xml view#buffer (Richpp.richpp_of_pp ~width goal.Interface.goal_ccl);
         view#buffer#insert "\n"


### PR DESCRIPTION
This is probably one of the tiniest PR ever. It concerns CoqIde.
- "No more goals" changed to "All goals completed"
- "No more goals, but there are goals you gave up" changed to "All goals completed except some admitted goals"

Rationale: "No more goals" is too depressing, "gave up" is too negative.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->

<!-- If this is a feature pull request / breaks compatibility: -->

  <!-- Check if the following applies, otherwise remove these lines. -->


<!-- If this breaks external libraries or plugins in CI: -->


<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
![All_goals_completed](https://github.com/coq/coq/assets/119015057/1b2a10f0-1834-4b58-bba7-357e41eb760a)
![All_goals_completed_except](https://github.com/coq/coq/assets/119015057/82a793e2-4541-40d3-82a7-86e1248eaa83)
