### PR TITLE
Statically eta-expand VERNAC actions in coqpp.

### DIFF
--- a/vernac/vernacextend.mli
+++ b/vernac/vernacextend.mli
@@ -123,7 +123,7 @@ type typed_vernac =
       run : pm:'inprog -> proof:'inproof -> 'outprog * 'outproof;
     } -> typed_vernac
 
-(** Some convenient typed_vernac constructors *)
+(** Some convenient typed_vernac constructors. Keep in sync with coqpp. *)
 
 val vtdefault : (unit -> unit) -> typed_vernac
 val vtnoproof : (unit -> unit) -> typed_vernac


### PR DESCRIPTION
This ensures that actions cannot trigger toplevel effects and are handled as opaque code. See coq-community/vscoq#581 for the issue this patch is solving.