### PR TITLE
Clean up a bit more in `Z.euclidean_division_equations_cleanup`

### DIFF
--- a/doc/changelog/04-tactics/17984-zify-cleanup-more.rst
+++ b/doc/changelog/04-tactics/17984-zify-cleanup-more.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  ``Z.euclidean_division_equations_cleanup`` now breaks up hypotheses of the
+  form `0 <= _ < _` for better cleanup in ``zify``
+  (`#17984 <https://github.com/coq/coq/pull/17984>`_,
+  by Jason Gross).

--- a/theories/omega/PreOmega.v
+++ b/theories/omega/PreOmega.v
@@ -122,6 +122,7 @@ Module Z.
            | [ H : ?x = ?y -> _, H' : ?y < ?x |- _ ] => clear H
            | [ H : ?A -> ?x = ?y -> _, H' : ?x < ?y |- _ ] => clear H
            | [ H : ?A -> ?x = ?y -> _, H' : ?y < ?x |- _ ] => clear H
+           | [ H : 0 <= ?x < _ |- _ ] => destruct H
            end.
   Ltac div_mod_to_equations := div_mod_to_equations'; euclidean_division_equations_cleanup.
   Ltac quot_rem_to_equations := quot_rem_to_equations'; euclidean_division_equations_cleanup.


### PR DESCRIPTION
Unsigned primitive integer zification results in hypotheses such as `0 <= φ y < 9223372036854775808`.  We break up such hypotheses so we can clear out hypotheses which assume `φ y < 0`.

This may have minor compatibility impacts, but I don't expect anything major.  It may also speed up `lia` and `nia` slightly, but mostly this makes it easier to deal with goals after `zify`.

On top of #17937