### PR TITLE
Fixes #17963: wrong evar map for Search when in a goal

### DIFF
--- a/dev/ci/user-overlays/17987-herbelin-master+fix17963-search-anomaly-with-evars.sh
+++ b/dev/ci/user-overlays/17987-herbelin-master+fix17963-search-anomaly-with-evars.sh
@@ -1,0 +1,4 @@
+overlay coq_dpdgraph https://github.com/herbelin/coq-dpdgraph coq-master+adapt-coq-pr17987-search-pass-sigma 17987
+overlay coqhammer https://github.com/herbelin/coqhammer master+adapt-coq-pr17987-search-pass-sigma 17987
+overlay serapi https://github.com/herbelin/coq-serapi main+adapt-coq-pr17987-search-pass-sigma 17987
+overlay vscoq https://github.com/herbelin/vscoq coq-master+adapt-coq-pr17987-search-pass-sigma 17987

--- a/doc/changelog/08-vernac-commands-and-options/17987-master+fix17963-search-anomaly-with-evars.rst
+++ b/doc/changelog/08-vernac-commands-and-options/17987-master+fix17963-search-anomaly-with-evars.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Anomaly with :cmd:`Search` in the context of a goal
+  (`#17987 <https://github.com/coq/coq/pull/17987>`_,
+  fixes `#17963 <https://github.com/coq/coq/issues/17963>`_,
+  by Hugo Herbelin).

--- a/test-suite/output/Search.out
+++ b/test-suite/output/Search.out
@@ -479,3 +479,4 @@ partition_cons1:
   forall [A : Type] (f : A -> bool) (a : A) (l : list A) [l1 l2 : list A],
   partition f l = (l1, l2) ->
   f a = true -> partition f (a :: l) = (a :: l1, l2)
+H: Some ?y = Some ?y

--- a/test-suite/output/Search.v
+++ b/test-suite/output/Search.v
@@ -102,3 +102,12 @@ Require Import List.
 Module Wish13349.
 Search partition "1" inside List.
 End Wish13349.
+
+Reset Initial.
+
+Module Bug17963.
+Goal exists y, Some y = Some y :> option nat -> True.
+eexists. intro H.
+Search Some eq.
+Abort.
+End Bug17963.

--- a/vernac/comSearch.ml
+++ b/vernac/comSearch.ml
@@ -118,7 +118,7 @@ let interp_search env sigma s r =
   let r = interp_search_restriction r in
   let get_pattern c = snd (Constrintern.intern_constr_pattern env sigma c) in
   let warnlist = ref [] in
-  let pr_search ref kind env c =
+  let pr_search ref kind env sigma c =
     let pr = pr_global ref in
     let pp = if !search_output_name_only
       then pr
@@ -129,9 +129,9 @@ let interp_search env sigma s r =
         let impargs = List.map binding_kind_of_status impargs in
         if List.length impls > 1 ||
            List.exists Glob_term.(function Explicit -> false | MaxImplicit | NonMaxImplicit -> true)
-             (List.skipn_at_least (Termops.nb_prod_modulo_zeta Evd.(from_env env) (EConstr.of_constr c)) impargs)
+             (List.skipn_at_least (Termops.nb_prod_modulo_zeta sigma (EConstr.of_constr c)) impargs)
           then warnlist := pr :: !warnlist;
-        let pc = pr_ltype_env env Evd.(from_env env) ~impargs c in
+        let pc = pr_ltype_env env sigma ~impargs c in
         hov 2 (pr ++ str":" ++ spc () ++ pc)
       end
     in Feedback.msg_notice pp

--- a/vernac/search.mli
+++ b/vernac/search.mli
@@ -29,7 +29,7 @@ type glob_search_request =
 type filter_function =
   GlobRef.t -> Decls.logical_kind option -> env -> Evd.evar_map -> constr -> bool
 type display_function =
-  GlobRef.t -> Decls.logical_kind option -> env -> constr -> unit
+  GlobRef.t -> Decls.logical_kind option -> env -> Evd.evar_map -> constr -> unit
 
 (** {6 Generic filter functions} *)
 
@@ -76,7 +76,7 @@ val interface_search : env -> Evd.evar_map -> (search_constraint * bool) list ->
 
 (** {6 Generic search function} *)
 
-val generic_search : env -> display_function -> unit
+val generic_search : env -> Evd.evar_map -> display_function -> unit
 (** This function iterates over all hypothesis of the goal numbered
     [glnum] (if present) and all known declarations. *)
 


### PR DESCRIPTION
We decide to pass sigma everywhere env is already passed. This is probably overkill, since most of the time, env and sigma do not change, but since env is already passed everywhere, we imitate.

Fixes #17963

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.

Synchronous overlays:
- coq-community/coq-dpdgraph#122
- ejgallego/coq-serapi#354
- lukaszcz/coqhammer#162
- coq-community/vscoq#601