### PR TITLE
Take benefit of eta to remove an old complex refolding circumvention in simpl

### DIFF
--- a/doc/changelog/05-Ltac-language/17991-master+simpl-and-eta-conversion.rst
+++ b/doc/changelog/05-Ltac-language/17991-master+simpl-and-eta-conversion.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  :tacn:`simpl` now refolds applied constants unfolding to reducible
+  fixpoints into the original constant even when this constant
+  would become partially applied
+  (`#17991 <https://github.com/coq/coq/pull/17991>`_,
+  by Hugo Herbelin).

--- a/test-suite/success/simpl.v
+++ b/test-suite/success/simpl.v
@@ -22,7 +22,7 @@ with copy_of_compute_size_tree (t:tree) : nat :=
 Eval simpl in (copy_of_compute_size_forest leaf).
 
 
-(* Another interesting case: Hrec has to occurrences: one cannot be folded
+(* Another interesting case: Hrec has two occurrences: one cannot be folded
    back to f while the second can. *)
 Parameter g : (nat->nat)->nat->nat->nat.
 
@@ -35,15 +35,18 @@ Definition f (n n':nat) :=
 Goal forall a b, f (S a) b = b.
 intros.
 simpl.
+match goal with [ |- g (f a) (f a a) b = b ] => idtac end.
 admit.
-Qed. (* Qed will fail if simpl performs eta-expansion *)
+Qed.
 
 (* Yet another example. *)
 
 Require Import List.
 
 Goal forall A B (a:A) l f (i:B), fold_right f i ((a :: l))=i.
+intros.
 simpl.
+match goal with [ |- f0 a (fold_right f0 i l) = i ] => idtac end.
 admit.
 Qed. (* Qed will fail if simplification is incorrect (de Bruijn!) *)
 


### PR DESCRIPTION
In particular, in addition to greatly simplifying code, this allows to refold `fix`s in situations where eta is needed.

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.

There is a slight change of behavior as shown in this example:
```coq
Parameter g : (nat->nat)->nat->nat->nat.

Definition f (n n':nat) :=
  nat_rec (fun _ => nat -> nat) 
    (fun x => x)
    (fun k Hrec => g Hrec (Hrec k)) 
    n n'. 

Goal forall a b, f (S a) b = b. 
intros. simpl.
(* before:
a, b : nat
______________________________________
g ((fix F (n : nat) : nat -> nat :=
        match n with
        | 0 => fun x : nat => x
        | S n0 => g (F n0) (F n0 n0)
        end) a) (f a a) b = b

after:
a, b : nat
______________________________________
g (f a) (f a a) b = b
*)
```
