### PR TITLE
Code simplification and bug fix around universes in simpl tactic

### DIFF
--- a/test-suite/success/simpl.v
+++ b/test-suite/success/simpl.v
@@ -117,3 +117,14 @@ simpl u.
 match goal with |- 0 = 0 => idtac end. (* Check that it reduced *)
 Abort.
 End FurtherAppliedPrimitiveProjections.
+
+Module BugUniverseMutualFix.
+Set Universe Polymorphism.
+Fixpoint foo1@{u v} (A : Type@{u}) n : Type@{v} := match n with 0 => A | S n => (foo2 A n * A)%type end
+with foo2@{u v} (A : Type@{u}) n : Type@{v} := match n with 0 => A | S n => (foo1 A n * A)%type end.
+Set Printing Universes.
+Definition bar@{u} (A : Type@{u}) n := foo1@{u u} A n.
+Goal forall n, bar unit (S n) = unit.
+simpl.
+Abort.
+End BugUniverseMutualFix.


### PR DESCRIPTION
We get rid of a detour via a universe-unsafe function to get the body of a reference.

The motivation is mostly code simplification but it also fixes the following bug:

```coq
Set Universe Polymorphism.
Fixpoint foo1@{u v} (A : Type@{u}) n : Type@{v} :=
  match n with 0 => A | S n => (foo2 A n * A)%type end
with foo2@{u v} (A : Type@{u}) n : Type@{v} :=
  match n with 0 => A | S n => (foo1 A n * A)%type end.
Set Printing Universes.
Definition bar@{u} (A : Type@{u}) n := foo1@{u u} A n.
Goal forall n, bar unit (S n) = unit.
simpl.
(* Anomaly "Uncaught exception Invalid_argument("index out of bounds")."*)
```

Technically depends on merging first #17991 (merged), but it could also be made independent at little cost if needed.