### PR TITLE
Fixes #18004: linearity check before inner disjunctive patterns

### DIFF
--- a/doc/changelog/02-specification-language/17857-master+fix17854-too-late-duplicate-var-check-pattern-matching.rst
+++ b/doc/changelog/02-specification-language/17857-master+fix17854-too-late-duplicate-var-check-pattern-matching.rst
@@ -1,5 +1,5 @@
 - **Fixed:**
   Anomaly in the presence of duplicate variables within a disjunctive pattern
-  (`#17857 <https://github.com/coq/coq/pull/17857>`_,
-  fixes `#17854 <https://github.com/coq/coq/issues/17854>`_,
+  (`#17857 <https://github.com/coq/coq/pull/17857>`_ and `#18005 <https://github.com/coq/coq/pull/18005>`_,
+  fixes `#17854 <https://github.com/coq/coq/issues/17854>`_ and `#18004 <https://github.com/coq/coq/issues/18004>`_,
   by Hugo Herbelin).

--- a/test-suite/output/bug_17854.out
+++ b/test-suite/output/bug_17854.out
@@ -4,3 +4,6 @@ The variable a is bound several times in pattern.
 File "./output/bug_17854.v", line 9, characters 11-31:
 The command has indeed failed with message:
 The variable a is bound several times in pattern.
+File "./output/bug_17854.v", line 27, characters 12-21:
+The command has indeed failed with message:
+The variable n is bound several times in pattern.

--- a/test-suite/output/bug_17854.v
+++ b/test-suite/output/bug_17854.v
@@ -15,3 +15,17 @@ Definition f b :=
          | true as a as a, true as b => true
          | _, _ => false
          end.
+
+Module Bug18002.
+
+(* Non linearity to be checked first also at the level of inner
+   disjunctive patterns *)
+
+Inductive U := p :nat->nat->U.
+
+Fail Check  match p 1 2 with
+ | (p n 0 | p n (S n)) => 0
+ | _ => 1
+ end.
+
+End Bug18002.


### PR DESCRIPTION
This was another instance of a problem partially fixed in #17857 (here in the case of an internal disjunctive pattern).

Fixes / closes #18004

- [x] Added / updated **test-suite**.
- [x] **changelog** for #17857 modified
