### PR TITLE
Constant_typing: add checks that declared hyps of body are valid +  slight reorganization

### DIFF
--- a/checker/checker.ml
+++ b/checker/checker.ml
@@ -294,6 +294,7 @@ let explain_exn = function
       | BadInvert -> str"BadInvert"
       | UndeclaredUniverse _ -> str"UndeclaredUniverse"
       | BadVariance _ -> str "BadVariance"
+      | UndeclaredUsedVariables _ -> str "UndeclaredUsedVariables"
       ))
 
   | InductiveError e ->

--- a/dev/ci/user-overlays/18007-herbelin-master+extra-checks-valid-declared-hyps.sh
+++ b/dev/ci/user-overlays/18007-herbelin-master+extra-checks-valid-declared-hyps.sh
@@ -1,0 +1,2 @@
+overlay vscoq https://github.com/herbelin/vscoq coq-master+adapt-coq-pr18007-extra-checks-proof-using 18007 master+extra-checks-valid-declared-hyps
+overlay elpi https://github.com/herbelin/coq-elpi coq-master+adapt-coq-pr18007-extra-checks-proof-using 18007 master+extra-checks-valid-declared-hyps

--- a/kernel/constant_typing.ml
+++ b/kernel/constant_typing.ml
@@ -27,7 +27,9 @@ module NamedDecl = Context.Named.Declaration
 (* Checks the section variables for the body.
    Returns the closure of the union with the variables in the type.
 *)
-let check_section_variables env declared_vars typ body =
+let check_section_variables env declared_vars body typ =
+  let env_ids = ids_of_named_context_val (named_context_val env) in
+  Id.Set.iter (fun id -> if not (Id.Set.mem id env_ids) then Type_errors.error_unbound_var env id) declared_vars;
   let tyvars = global_vars_set env typ in
   let declared_vars = Environ.really_needed env (Id.Set.union declared_vars tyvars) in
   let () = match body with
@@ -40,36 +42,24 @@ let check_section_variables env declared_vars typ body =
   in
   declared_vars
 
-let used_section_variables env hyps def typ =
+let compute_section_variables env body typ =
+  if List.is_empty (named_context env) then
+    (* Empty section context: optimization *)
+    Id.Set.empty
+  else
+    let ids =
+      Option.fold_right
+        (fun c -> Id.Set.union (global_vars_set env c))
+        body (global_vars_set env typ) in
+    Environ.really_needed env ids
+
+let used_section_variables env declared_hyps body typ =
   let hyps =
-    if List.is_empty (named_context env) then
-      (* Empty section context *)
-      let () = match hyps with
-        | None -> ()
-        | Some ids -> assert (Id.Set.is_empty ids)
-      in
-      Id.Set.empty
-    else match hyps with
-      | None ->
-        (* No declared section vars, and non-empty section context:
-             we must look at the body NOW, if any *)
-        let ids_typ = global_vars_set env typ in
-        let ids_def = match def with
-          | Undef _ | Primitive _ -> Id.Set.empty
-          | Def cs -> global_vars_set env cs
-          | OpaqueDef _ ->
-            (* Opaque definitions always come with their section variables *)
-            assert false
-        in
-        Environ.really_needed env (Id.Set.union ids_typ ids_def)
-      | Some declared ->
-        let body = match def with
-          | Undef _ -> None
-          | Primitive _ -> assert false (* not allowed in sections *)
-          | OpaqueDef _ -> None (* checked in check_delayed *)
-          | Def cs -> Some cs
-        in
-        check_section_variables env declared typ body in
+    match declared_hyps with
+    | None -> compute_section_variables env body typ
+    | Some declared -> check_section_variables env declared body typ
+  in
+  (* Order the variables *)
   List.filter (fun d -> Id.Set.mem (NamedDecl.get_id d) hyps) (Environ.named_context env)
 
 (* Insertion of constants and parameters in environment. *)
@@ -190,7 +180,7 @@ let infer_parameter ~sec_univs env entry =
   let r = Typeops.assumption_of_judgment env j in
   let typ = Vars.subst_univs_level_constr usubst j.uj_val in
   let undef = Undef entry.parameter_entry_inline_code in
-  let hyps = used_section_variables env entry.parameter_entry_secctx undef typ in
+  let hyps = used_section_variables env entry.parameter_entry_secctx None typ in
   let tps = Vmbytegen.compile_constant_body ~fail_on_error:false env univs undef in
   {
     const_hyps = hyps;
@@ -215,8 +205,9 @@ let infer_definition ~sec_univs env entry =
       let _ = Typeops.judge_of_cast env j DEFAULTcast tj in
       Vars.subst_univs_level_constr usubst tj.utj_val
   in
-  let def = Def (Vars.subst_univs_level_constr usubst j.uj_val) in
-  let hyps = used_section_variables env entry.const_entry_secctx def typ in
+  let body = Vars.subst_univs_level_constr usubst j.uj_val in
+  let def = Def body in
+  let hyps = used_section_variables env entry.const_entry_secctx (Some body) typ in
   let tps = Vmbytegen.compile_constant_body ~fail_on_error:false env univs def in
   {
     const_hyps = hyps;
@@ -242,7 +233,7 @@ let infer_opaque ~sec_univs env entry =
   let context = TyCtx (env, typj, entry.opaque_entry_secctx, usubst, univs) in
   let def = OpaqueDef () in
   let typ = Vars.subst_univs_level_constr usubst typj.utj_val in
-  let hyps = used_section_variables env (Some entry.opaque_entry_secctx) def typ in
+  let hyps = used_section_variables env (Some entry.opaque_entry_secctx) None typ in
   let tps = Vmbytegen.compile_constant_body ~fail_on_error:false env univs def in
   {
     const_hyps = hyps;
@@ -279,7 +270,7 @@ let check_delayed (type a) (handle : a effect_handler) tyenv (body : a proof_out
   let declared =
     Environ.really_needed env (Id.Set.union declared (global_vars_set env tyj.utj_val))
   in
-  let declared' = check_section_variables env declared tyj.utj_val (Some body) in
+  let declared' = check_section_variables env declared (Some body) tyj.utj_val in
   let () = assert (Id.Set.equal declared declared') in
   (* Note: non-trivial usubst only in polymorphic case *)
   let def = Vars.subst_univs_level_constr usubst j.uj_val in

--- a/kernel/type_errors.ml
+++ b/kernel/type_errors.ml
@@ -76,6 +76,7 @@ type ('constr, 'types) ptype_error =
   | BadCaseRelevance of Sorts.relevance * 'constr
   | BadInvert
   | BadVariance of { lev : Level.t; expected : Variance.t; actual : Variance.t }
+  | UndeclaredUsedVariables of { declared_vars : Id.Set.t; inferred_vars : Id.Set.t }
 
 type type_error = (constr, types) ptype_error
 
@@ -168,6 +169,9 @@ let error_bad_invert env =
 let error_bad_variance env ~lev ~expected ~actual =
   raise (TypeError (env, BadVariance {lev;expected;actual}))
 
+let error_undeclared_used_variables env ~declared_vars ~inferred_vars =
+  raise (TypeError (env, UndeclaredUsedVariables {declared_vars; inferred_vars}))
+
 let map_pfix_guard_error f = function
 | NotEnoughAbstractionInFixBody -> NotEnoughAbstractionInFixBody
 | RecursionNotOnInductiveType c -> RecursionNotOnInductiveType (f c)
@@ -195,7 +199,7 @@ let map_pguard_error f = function
 let map_ptype_error f = function
 | UnboundRel _ | UnboundVar _ | CaseOnPrivateInd _
 | UndeclaredUniverse _ | DisallowedSProp | UnsatisfiedConstraints _
-| ReferenceVariables _ | BadInvert | BadVariance _ as e -> e
+| ReferenceVariables _ | BadInvert | BadVariance _ | UndeclaredUsedVariables _ as e -> e
 | NotAType j -> NotAType (on_judgment f j)
 | BadAssumption j -> BadAssumption (on_judgment f j)
 | ElimArity (pi, c, ar) ->

--- a/kernel/type_errors.mli
+++ b/kernel/type_errors.mli
@@ -78,6 +78,7 @@ type ('constr, 'types) ptype_error =
   | BadCaseRelevance of Sorts.relevance * 'constr
   | BadInvert
   | BadVariance of { lev : Level.t; expected : Variance.t; actual : Variance.t }
+  | UndeclaredUsedVariables of { declared_vars : Id.Set.t; inferred_vars : Id.Set.t }
 
 type type_error = (constr, types) ptype_error
 
@@ -157,6 +158,8 @@ val error_bad_case_relevance : env -> Sorts.relevance -> Constr.case -> 'a
 val error_bad_invert : env -> 'a
 
 val error_bad_variance : env -> lev:Level.t -> expected:Variance.t -> actual:Variance.t -> 'a
+
+val error_undeclared_used_variables : env -> declared_vars:Id.Set.t -> inferred_vars:Id.Set.t -> 'a
 
 val map_pguard_error : ('c -> 'd) -> 'c pguard_error -> 'd pguard_error
 val map_ptype_error : ('c -> 'd) -> ('c, 'c) ptype_error -> ('d, 'd) ptype_error

--- a/test-suite/success/definition_using.v
+++ b/test-suite/success/definition_using.v
@@ -35,6 +35,20 @@ Fixpoint c7 (n : nat) {struct n} : bool :=
   | S p => c7 p
   end.
 
+Fail #[using="dummy", program]
+Fixpoint c7' (n : nat) {struct n} : bool :=
+  match n with
+  | O => true
+  | S p => c7' p
+  end.
+
+Fail #[using="c7'", program]
+Fixpoint c7' (n : nat) {struct n} : bool :=
+  match n with
+  | O => true
+  | S p => c7' p
+  end.
+
 End A.
 
 Check c1 : bogus -> bool.

--- a/vernac/comDefinition.ml
+++ b/vernac/comDefinition.ml
@@ -113,7 +113,7 @@ let interp_definition ~program_mode env evd impl_env bl red_option c ctypopt =
 
 let definition_using env evd ~body ~types ~using =
   let terms = Option.List.cons types [body] in
-  Option.map (fun using -> Proof_using.definition_using env evd ~using ~terms) using
+  Option.map (fun using -> Proof_using.definition_using env evd ~fixnames:[] ~using ~terms) using
 
 let do_definition ?hook ~name ?scope ?clearbody ~poly ?typing_flags ~kind ?using ?deprecation udecl bl red_option c ctypopt =
   let program_mode = false in

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -263,7 +263,7 @@ let build_recthms ~indexes ?using fixnames fixtypes fiximps =
         let env = Global.env() in
         let evd = Evd.from_env env in
         let terms = [EConstr.of_constr typ] in
-        let using = Option.map (fun using -> Proof_using.definition_using env evd ~using ~terms) using in
+        let using = Option.map (fun using -> Proof_using.definition_using env evd ~fixnames ~using ~terms) using in
         let args = List.map Context.Rel.Declaration.get_name ctx in
         Declare.CInfo.make ~name ~typ ~args ~impargs ?using ()
       ) fixnames fixtypes fiximps

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -265,7 +265,7 @@ let build_wellfounded pm (recname,pl,bl,arityc,body) poly ?typing_flags ?depreca
   in
   let using =
     let terms = List.map EConstr.of_constr [evars_def; evars_typ] in
-    Option.map (fun using -> Proof_using.definition_using env sigma ~using ~terms) using
+    Option.map (fun using -> Proof_using.definition_using env sigma ~fixnames:[] ~using ~terms) using
   in
   let uctx = Evd.evar_universe_context sigma in
   let cinfo = Declare.CInfo.make ~name:recname ~typ:evars_typ ?using () in
@@ -293,10 +293,11 @@ let do_program_recursive ~pm ~scope ?clearbody ~poly ?typing_flags ?deprecation 
   let evd = Typeclasses.resolve_typeclasses ~filter:Typeclasses.no_goals ~fail:true env evd in
     (* Solve remaining evars *)
   let evd = nf_evar_map_undefined evd in
+  let (fixnames,fixrs,fixdefs,fixtypes) = fix in
   let collect_evars name def typ impargs =
     (* Generalize by the recursive prototypes  *)
     let terms = [def; typ] in
-    let using = Option.map (fun using -> Proof_using.definition_using env evd ~using ~terms) using in
+    let using = Option.map (fun using -> Proof_using.definition_using env evd ~fixnames ~using ~terms) using in
     let def = nf_evar evd (EConstr.it_mkNamedLambda_or_LetIn evd def rec_sign) in
     let typ = nf_evar evd (EConstr.it_mkNamedProd_or_LetIn evd typ rec_sign) in
     let deps = collect_evars_of_term evd def typ in
@@ -306,7 +307,6 @@ let do_program_recursive ~pm ~scope ?clearbody ~poly ?typing_flags ?deprecation 
     let cinfo = Declare.CInfo.make ~name ~typ ~impargs ?using () in
     (cinfo, def, evars)
   in
-  let (fixnames,fixrs,fixdefs,fixtypes) = fix in
   let fiximps = List.map pi2 info in
   let fixdefs = List.map out_def fixdefs in
   let defs = List.map4 collect_evars fixnames fixdefs fixtypes fiximps in

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1646,6 +1646,11 @@ let start_mutual_with_initialization ~info ~cinfo ~mutual_info sigma snl =
 
 let get_used_variables pf = pf.using
 let get_universe_decl pf = pf.pinfo.Proof_info.info.Info.udecl
+let get_recnames pf =
+  if Option.has_some pf.pinfo.Proof_info.compute_guard then
+    List.map (fun c -> c.CInfo.name) pf.pinfo.Proof_info.cinfo
+  else
+    []
 
 let set_used_variables ps ~using =
   let open Context.Named.Declaration in

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -275,6 +275,9 @@ module Proof : sig
 
   val get_open_goals : t -> int
 
+  (** Gets the set of mutual theorem names being currently built, if any *)
+  val get_recnames : t -> Id.t list
+
   (** Helpers to obtain proof state when in an interactive proof *)
 
   (** [get_goal_context n] returns the context of the [n]th subgoal of

--- a/vernac/proof_using.ml
+++ b/vernac/proof_using.ml
@@ -36,13 +36,15 @@ let rec close_fwd env sigma s =
     in
   if Id.Set.equal s s' then s else close_fwd env sigma s'
 
-let set_of_type env sigma ty =
-  List.fold_left (fun acc ty ->
+let set_of_type env sigma fixnames ty =
+  List.fold_right Id.Set.remove fixnames
+  (List.fold_left (fun acc ty ->
       Id.Set.union (Termops.global_vars_set env sigma ty) acc)
-    Id.Set.empty ty
+    Id.Set.empty ty)
 
-let full_set env =
-  List.fold_right Id.Set.add (List.map NamedDecl.get_id (named_context env)) Id.Set.empty
+let full_set fixnames env =
+  let add id ids = if List.mem_f Id.equal id fixnames then ids else Id.Set.add id ids in
+  List.fold_right add (List.map NamedDecl.get_id (named_context env)) Id.Set.empty
 
 let warn_all_collection_precedence = CWarnings.create ~name:"all-collection-precedence" ~category:Deprecation.Version.v8_15
     Pp.(fun () -> str "Variable " ++ Id.print all_collection_id ++ str " is shadowed by Collection named " ++ Id.print all_collection_id ++ str " containing all variables.")
@@ -59,7 +61,7 @@ let warn_variable_shadowing = CWarnings.create ~name:"variable-shadowing" ~categ
 let err_redefine_all_collection () =
   CErrors.user_err Pp.(str "\"" ++ Id.print all_collection_id ++ str "\" is a predefined collection containing all variables. It can't be redefined.")
 
-let process_expr env sigma e v_ty =
+let process_expr env sigma fixnames e v_ty =
   let variable_exists id =
     try ignore (lookup_named id env); true with | Not_found -> false in
   let rec aux = function
@@ -68,14 +70,14 @@ let process_expr env sigma e v_ty =
     | SsSingl { CAst.v = id } -> set_of_id id
     | SsUnion(e1,e2) -> Id.Set.union (aux e1) (aux e2)
     | SsSubstr(e1,e2) -> Id.Set.diff (aux e1) (aux e2)
-    | SsCompl e -> Id.Set.diff (full_set env) (aux e)
+    | SsCompl e -> Id.Set.diff (full_set fixnames env) (aux e)
     | SsFwdClose e -> close_fwd env sigma (aux e)
   and set_of_id id =
     if Id.equal id all_collection_id then
       begin
         if variable_exists all_collection_id then
           warn_all_collection_precedence ();
-        full_set env
+        full_set fixnames env
       end
     else if is_known_name id then
       begin
@@ -83,20 +85,25 @@ let process_expr env sigma e v_ty =
           warn_collection_precedence id;
         aux (CList.assoc_f Id.equal id !known_names)
       end
-    else Id.Set.singleton id
+    else
+    if List.exists (Id.equal id) fixnames then
+      CErrors.user_err Pp.(str "Invalid recursive variable: " ++ Id.print id ++ str ".")
+    else if not (List.exists (NamedDecl.get_id %> Id.equal id) (named_context env)) then
+      CErrors.user_err Pp.(str "Unknown variable: " ++ Id.print id ++ str ".")
+    else
+      Id.Set.singleton id
   in
   aux e
 
-let process_expr env sigma e ty =
-  let v_ty = set_of_type env sigma ty in
-  let s = Id.Set.union v_ty (process_expr env sigma e v_ty) in
+let process_expr env sigma fixnames e ty =
+  let v_ty = set_of_type env sigma fixnames ty in
+  let s = Id.Set.union v_ty (process_expr env sigma fixnames e v_ty) in
   Id.Set.elements s
 
 type t = Names.Id.Set.t
 
 let definition_using env evd ~fixnames ~using ~terms =
-  let l = process_expr env evd using terms in
-  let l = List.fold_right (List.remove Names.Id.equal) fixnames l in
+  let l = process_expr env evd fixnames using terms in
   Names.Id.Set.(List.fold_right add l empty)
 
 let name_set id expr =

--- a/vernac/proof_using.ml
+++ b/vernac/proof_using.ml
@@ -94,8 +94,9 @@ let process_expr env sigma e ty =
 
 type t = Names.Id.Set.t
 
-let definition_using env evd ~using ~terms =
+let definition_using env evd ~fixnames ~using ~terms =
   let l = process_expr env evd using terms in
+  let l = List.fold_right (List.remove Names.Id.equal) fixnames l in
   Names.Id.Set.(List.fold_right add l empty)
 
 let name_set id expr =

--- a/vernac/proof_using.mli
+++ b/vernac/proof_using.mli
@@ -18,6 +18,7 @@ type t = Names.Id.Set.t
 val definition_using
   : Environ.env
   -> Evd.evar_map
+  -> fixnames:Names.Id.t list (* names of fixpoint occurring recursively, if any *)
   -> using:Vernacexpr.section_subset_expr
   -> terms:EConstr.constr list
   -> t

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -577,12 +577,6 @@ let vernac_set_used_variables ~pstate using : Declare.Proof.t =
   let initial_goals pf = Proofview.initial_goals Proof.((data pf).entry) in
   let terms = List.map pi3 (initial_goals (Declare.Proof.get pstate)) in
   let using = Proof_using.definition_using env sigma ~fixnames ~using ~terms in
-  let vars = Environ.named_context env in
-  Names.Id.Set.iter (fun id ->
-      if not (List.exists (NamedDecl.get_id %> Id.equal id) vars) then
-        user_err
-          (str "Unknown variable: " ++ Id.print id ++ str "."))
-    using;
   let _, pstate = Declare.Proof.set_used_variables pstate ~using in
   pstate
 

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -573,9 +573,10 @@ let program_inference_hook env sigma ev =
 let vernac_set_used_variables ~pstate using : Declare.Proof.t =
   let env = Global.env () in
   let sigma, _ = Declare.Proof.get_current_context pstate in
+  let fixnames = Declare.Proof.get_recnames pstate in
   let initial_goals pf = Proofview.initial_goals Proof.((data pf).entry) in
   let terms = List.map pi3 (initial_goals (Declare.Proof.get pstate)) in
-  let using = Proof_using.definition_using env sigma ~using ~terms in
+  let using = Proof_using.definition_using env sigma ~fixnames ~using ~terms in
   let vars = Environ.named_context env in
   Names.Id.Set.iter (fun id ->
       if not (List.exists (NamedDecl.get_id %> Id.equal id) vars) then


### PR DESCRIPTION
This is somehow a small continuation of #17929: we strengthen the check on declared hyps (checking that they have indeed valid names) and slightly reorganize the code.

Synchronous overlays:
- LPCIC/coq-elpi#513
- coq-community/vscoq#654