### PR TITLE
Bump the MetaCoq CI timeout to 1h30.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -883,6 +883,7 @@ plugin:ci-metacoq:
   needs:
   - build:base
   - plugin:ci-equations
+  timeout: 1h 30min
 
 plugin:ci-mtac2:
   extends: .ci-template


### PR DESCRIPTION
This job was right on the limit these days, triggering a timeout quite often.