### PR TITLE
Fix #[warnings] attribute in synterp phase

### DIFF
--- a/test-suite/bugs/bug_17982.v
+++ b/test-suite/bugs/bug_17982.v
@@ -1,0 +1,8 @@
+
+Set Warnings "+notation-overridden".
+
+Fail Infix "+" := Nat.mul : nat_scope.
+
+#[warnings="-notation-overridden"] Infix "+" := Nat.mul : nat_scope.
+(* Warning: This command does not support this attribute: warnings.
+[unsupported-attributes,parsing,default] *)

--- a/vernac/synterp.mli
+++ b/vernac/synterp.mli
@@ -15,12 +15,15 @@ vernacexpr into a [vernac_control_entry]. *)
 open Names
 open Libnames
 
-val module_locality : bool Attributes.Notations.t
+val module_locality : bool Attributes.attribute
 
 val with_locality : atts:Attributes.vernac_flags -> (local:bool option -> 'a) -> 'a
 
 val with_module_locality :
   atts:Attributes.vernac_flags -> (module_local:bool -> 'a) -> 'a
+
+val with_generic_atts :
+  check:bool -> Attributes.vernac_flags -> (atts:Attributes.vernac_flags -> 'a) -> 'a
 
 type module_entry = Modintern.module_struct_expr * Names.ModPath.t * Modintern.module_kind * Entries.inline
 

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -908,7 +908,7 @@ let preprocess_inductive_decl ~atts kind indl =
   in
   (* We only allow the #[projections(primitive)] attribute
      for records. *)
-  let prim_proj_attr : bool Attributes.Notations.t =
+  let prim_proj_attr : bool Attributes.attribute =
     if List.for_all is_record indl then primitive_proj
     else Notations.return false
   in


### PR DESCRIPTION
Fix #17982

@gares I'd like to have this in 8.18.0 so we don't have a version with the bug

Overlays: (not needed anymore)
- https://github.com/coq-community/vscoq/pull/610
- https://github.com/ejgallego/coq-serapi/pull/355