### PR TITLE
Moving binder_constr at level 10 in anticipation of removing gramlib fallback

### DIFF
--- a/dev/ci/user-overlays/18014-herbelin-binder-constr.sh
+++ b/dev/ci/user-overlays/18014-herbelin-binder-constr.sh
@@ -1,0 +1,1 @@
+overlay equations https://github.com/proux01/Coq-Equations coq_18014 18014

--- a/doc/changelog/02-specification-language/18014-master+binder_constr-level10.rst
+++ b/doc/changelog/02-specification-language/18014-master+binder_constr-level10.rst
@@ -1,0 +1,8 @@
+- **Changed:**
+  :token:`term_forall_or_fun`, :token:`term_let`, :token:`term_fix`,
+  :token:`term_cofix` and :token:`term_if` from :token:`term` at level 200
+  to :token:`term10` at level 10. This is a first step towards getting rid
+  of the recovery mechanism of camlp5/coqpp. The impact will mostly be
+  limited to rare cases of additional parentheses around the above
+  (`#18014 <https://github.com/coq/coq/pull/18014>`_,
+  by Hugo Herbelin).

--- a/doc/sphinx/language/core/basic.rst
+++ b/doc/sphinx/language/core/basic.rst
@@ -259,15 +259,15 @@ rest of the Coq manual: :term:`terms <term>` and :term:`types
      .. insertprodn term qualid_annotated
 
      .. prodn::
-        term ::= @term_forall_or_fun
-        | @term_let
-        | @term_if
-        | @term_fix
-        | @term_cofix
-        | @term100
+        term ::= @term100
         term100 ::= @term_cast
         | @term10
         term10 ::= @term_application
+        | @term_forall_or_fun
+        | @term_let
+        | @term_fix
+        | @term_cofix
+        | @term_if
         | @one_term
         one_term ::= @term_explicit
         | @term1

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -67,7 +67,6 @@ constr: [
 ]
 
 term200: [
-| binder_constr
 | term100
 ]
 
@@ -91,6 +90,7 @@ term10: [
 | term9 LIST1 arg
 | "@" global univ_annot LIST0 term9
 | "@" pattern_ident LIST1 identref
+| binder_constr
 | term9
 ]
 

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -4,11 +4,6 @@ to match editedGrammar, which will remove comments.  Not compiled into Coq *)
 DOC_GRAMMAR
 
 term: [
-| term_forall_or_fun
-| term_let
-| term_if
-| term_fix
-| term_cofix
 | term100
 ]
 
@@ -19,6 +14,11 @@ term100: [
 
 term10: [
 | term_application
+| term_forall_or_fun
+| term_let
+| term_fix
+| term_cofix
+| term_if
 | one_term
 ]
 

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -143,8 +143,7 @@ GRAMMAR EXTEND Gram
       | "@"; f=global; i = univ_annot -> { CAst.make ~loc @@ CAppExpl((f,i),[]) } ] ]
   ;
   term:
-    [ "200" RIGHTA
-      [ c = binder_constr -> { c } ]
+    [ "200" RIGHTA [ ]
     | "100" RIGHTA
       [ c1 = term; "<:"; c2 = term LEVEL "200" ->
                  { CAst.make ~loc @@ CCast(c1, Some VMcast, c2) }
@@ -162,7 +161,8 @@ GRAMMAR EXTEND Gram
       | "@"; lid = pattern_ident; args = LIST1 identref ->
         { let { CAst.loc = locid; v = id } = lid in
           let args = List.map (fun x -> CAst.make @@ CRef (qualid_of_ident ?loc:x.CAst.loc x.CAst.v, None), None) args in
-          CAst.make ~loc @@ CApp(CAst.make ?loc:locid @@ CPatVar id,args) } ]
+          CAst.make ~loc @@ CApp(CAst.make ?loc:locid @@ CPatVar id,args) }
+      | c = binder_constr -> { c } ]
     | "9"
       [ ".."; c = term LEVEL "0"; ".." ->
         { CAst.make ~loc @@ CAppExpl ((qualid_of_ident ~loc ldots_var, None),[c]) } ]

--- a/test-suite/bugs/bug_5161.v
+++ b/test-suite/bugs/bug_5161.v
@@ -12,7 +12,7 @@ Definition FORALL {T : Type} (f : T → Prop) : Prop := ∀ x, f x.
 
 Notation "∀ x .. y , P" :=
   (FORALL (λ x, .. (FORALL (λ y, P)) ..)%I)
-  (at level 200, x binder, y binder, right associativity) : uPred_scope.
+  (at level 10, x binder, y binder, P at level 200) : uPred_scope.
 Infix "∧" := and : uPred_scope.
 
 (* The next command fails with

--- a/test-suite/output/PrintGrammar.out
+++ b/test-suite/output/PrintGrammar.out
@@ -39,7 +39,7 @@ Entry lconstr is
 
 Entry term is
 [ "200" RIGHTA
-  [ binder_constr ]
+  [  ]
 | "100" RIGHTA
   [ SELF; "<:"; term LEVEL "200"
   | SELF; "<<:"; term LEVEL "200"
@@ -90,7 +90,8 @@ Entry term is
 | "10" LEFTA
   [ SELF; LIST1 arg
   | "@"; global; univ_annot; LIST0 NEXT
-  | "@"; pattern_ident; LIST1 identref ]
+  | "@"; pattern_ident; LIST1 identref
+  | binder_constr ]
 | "9" LEFTA
   [ ".."; term LEVEL "0"; ".." ]
 | "8" LEFTA

--- a/test-suite/output/PrintGrammarConstr.out
+++ b/test-suite/output/PrintGrammarConstr.out
@@ -30,7 +30,7 @@ Entry lconstr is
 
 Entry term is
 [ "200" RIGHTA
-  [ binder_constr ]
+  [  ]
 | "100" RIGHTA
   [ SELF; "<:"; term LEVEL "200"
   | SELF; "<<:"; term LEVEL "200"
@@ -43,7 +43,8 @@ Entry term is
 | "10" LEFTA
   [ SELF; LIST1 arg
   | "@"; global; univ_annot; LIST0 NEXT
-  | "@"; pattern_ident; LIST1 identref ]
+  | "@"; pattern_ident; LIST1 identref
+  | binder_constr ]
 | "9" LEFTA
   [ ".."; term LEVEL "0"; ".." ]
 | "8" LEFTA

--- a/theories/Unicode/Utf8_core.v
+++ b/theories/Unicode/Utf8_core.v
@@ -13,10 +13,10 @@
 
 (* Logic *)
 Notation "∀ x .. y , P" := (forall x, .. (forall y, P) ..)
-  (at level 200, x binder, y binder, right associativity,
+  (at level 10, x binder, y binder, P at level 200,
   format "'[  ' '[  ' ∀  x  ..  y ']' ,  '/' P ']'") : type_scope.
 Notation "∃ x .. y , P" := (exists x, .. (exists y, P) ..)
-  (at level 200, x binder, y binder, right associativity,
+  (at level 10, x binder, y binder, P at level 200,
   format "'[  ' '[  ' ∃  x  ..  y ']' ,  '/' P ']'") : type_scope.
 
 Notation "x ∨ y" := (x \/ y) (at level 85, right associativity) : type_scope.
@@ -30,5 +30,5 @@ Notation "x ≠ y" := (x <> y) (at level 70) : type_scope.
 
 (* Abstraction *)
 Notation "'λ' x .. y , t" := (fun x => .. (fun y => t) ..)
-  (at level 200, x binder, y binder, right associativity,
+  (at level 10, x binder, y binder, t at level 200,
   format "'[  ' '[  ' 'λ'  x  ..  y ']' ,  '/' t ']'").

--- a/vernac/egramcoq.ml
+++ b/vernac/egramcoq.ml
@@ -34,7 +34,7 @@ open Pcoq
 let constr_level = string_of_int
 
 let default_levels =
-  [200,Gramlib.Gramext.RightA,false;
+  [200,Gramlib.Gramext.RightA,true;
    100,Gramlib.Gramext.RightA,false;
    99,Gramlib.Gramext.RightA,true;
    90,Gramlib.Gramext.RightA,true;


### PR DESCRIPTION
This CI experiment is part of #9008 and coq/ceps#71. It uses #17875.

#### Overlays (to be merged before the current PR)

- [x] https://github.com/math-comp/analysis/pull/1059
- [x] https://gitlab.mpi-sws.org/iris/iris/-/merge_requests/1009 , https://gitlab.mpi-sws.org/iris/iris/-/merge_requests/1011 , https://gitlab.mpi-sws.org/iris/iris/-/merge_requests/1014 , https://gitlab.mpi-sws.org/iris/examples/-/merge_requests/63

#### Overlays (to be merged in sync with the current PR)

- [x] https://github.com/mattam82/Coq-Equations/pull/564
