### PR TITLE
[CI] Add coq-neural-net-interp

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -765,6 +765,9 @@ library:ci-analysis:
   - library:ci-bigenough
   - plugin:ci-elpi_hb  # for Hierarchy Builder
 
+library:ci-neural_net_interp:
+  extends: .ci-template
+
 library:ci-paco:
   extends: .ci-template-flambda
 

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -70,6 +70,7 @@ CI_TARGETS= \
     ci-menhir \
     ci-metacoq \
     ci-mtac2 \
+    ci-neural_net_interp \
     ci-oddorder \
     ci-paco \
     ci-paramcoq \

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -252,6 +252,11 @@ project reduction_effects "https://github.com/coq-community/reduction-effects" "
 project menhirlib "https://gitlab.inria.fr/fpottier/menhir" "20220210"
 
 ########################################################################
+# coq-neural-net-interp
+########################################################################
+project neural_net_interp "https://github.com/JasonGross/neural-net-coq-interp" "tested"
+
+########################################################################
 # aac_tactics
 ########################################################################
 project aac_tactics "https://github.com/coq-community/aac-tactics" "master"

--- a/dev/ci/ci-neural_net_interp.sh
+++ b/dev/ci/ci-neural_net_interp.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+git_download neural_net_interp
+
+if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
+
+( cd "${CI_BUILD_DIR}/neural_net_interp"
+  make coq-ci-target
+)


### PR DESCRIPTION
Tests:
- typeclasses
- notations
- Ltac2
- primitive ints
- primitive floats
- primitive arrays

Should be a pretty quick build, in part because most of the proofs depend on a long chain of deps including MathComp, VST, Interval, and vcfloat, which are not all on Coq's CI yet.

If we want to test `native_compute` on the CI, we can add the `computed` target to the list of built targets.  But this will probably add about 10+ minutes to the CI for no particularly good reason.

- [x] Repo has a CI testing this exact target with Coq master
- [x] Branch is only pushed to when the CI builds (I've set up a `tested` branch which I plan on not pushing to, the CI automatically pushes to it whenever the build succeeds)