### PR TITLE
[ssr] Rm cast notation

### DIFF
--- a/theories/ssr/ssreflect.v
+++ b/theories/ssr/ssreflect.v
@@ -111,8 +111,6 @@ Reserved Notation "'if' c 'return' R 'then' vT 'else' vF" (at level 200,
 Reserved Notation "'if' c 'as' x 'return' R 'then' vT 'else' vF" (at level 200,
   c, R, vT, vF at level 200, x name).
 
-Reserved Notation "x : T" (at level 100, right associativity,
-  format "'[hv' x '/ '  :  T ']'").
 Reserved Notation "T : 'Type'" (at level 100, format "T  :  'Type'").
 Reserved Notation "P : 'Prop'" (at level 100, format "P  :  'Prop'").
 
@@ -183,14 +181,6 @@ Open Scope boolean_if_scope.
 Declare Scope form_scope.
 Delimit Scope form_scope with FORM.
 Open Scope form_scope.
-
-(**
- Allow overloading of the cast (x : T) syntax, put whitespace around the
- ":" symbol to avoid lexical clashes (and for consistency with the parsing
- precedence of the notation, which binds less tightly than application),
- and put printing boxes that print the type of a long definition on a
- separate line rather than force-fit it at the right margin.                 **)
-Notation "x : T" := (CoqCast x T) : core_scope.
 
 (**
  Allow the casual use of notations like nat * nat for explicit Type


### PR DESCRIPTION
To enable https://github.com/coq/coq/pull/18014 via #6134 

Replaces #6133 

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
<!-- Fixes / closes #???? -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] ~Added / updated **test-suite**.~

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] ~Added / updated **documentation**.~
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] ~Documented any new / changed **user messages**.~
  - [ ] ~Updated **documented syntax** by running `make doc_gram_rsts`.~

<!-- If this breaks external libraries or plugins in CI: -->
- [x] Opened **overlay** pull requests.

#### Overlays (to be merged before the current PR

- [x] https://github.com/coq/stdlib2/pull/28
- [x] https://github.com/math-comp/math-comp/pull/1070
- [x] https://github.com/math-comp/math-comp/pull/1071

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
