### PR TITLE
Document the roughness of the Floats library

### DIFF
--- a/doc/sphinx/language/coq-library.rst
+++ b/doc/sphinx/language/coq-library.rst
@@ -989,6 +989,15 @@ Notation    Interpretation  Precedence  Associativity
 Floats library
 ~~~~~~~~~~~~~~
 
+The standard library has a small ``Floats`` module for accessing
+processor floating-point operations through the Coq kernel.
+However, while this module supports computation and has a bit-level
+specification, it doesn't include elaborate theorems, such as a link
+to real arithmetic or various error bounds. To do proofs by
+reflection, use ``Floats`` in conjunction with the complementary
+`Flocq <https://flocq.gitlabpages.inria.fr/>`_ library, which provides
+many such theorems.
+
 The library of primitive floating-point arithmetic can be loaded by
 requiring module ``Floats``:
 

--- a/theories/Floats/Floats.v
+++ b/theories/Floats/Floats.v
@@ -17,7 +17,11 @@
 - FloatLemmas: prove a few results involving Z.frexp and Z.ldexp
 
 For a brief overview of the Floats library,
-see {{https://coq.inria.fr/distrib/current/refman/language/coq-library.html#floats-library}} *)
+see {{https://coq.inria.fr/distrib/current/refman/language/coq-library.html#floats-library}}
+
+N.B.: This library only offers a bit-level specification of floating-point
+arithmetic. For a more complete set of theorems, including links with real
+arithmetic, see the Flocq library {{https://flocq.gitlabpages.inria.fr/}} *)
 
 Require Export FloatClass.
 Require Export PrimFloat.


### PR DESCRIPTION
It seems some user are expecting more from the `Floats` module of the stdlib than what it actually provides. Documenting these limitations may help.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
<!-- Fixes / closes #???? -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] ~Added / updated **test-suite**.~

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] ~Added **changelog**.~
- [x] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] ~Documented any new / changed **user messages**.~
  - [ ] ~Updated **documented syntax** by running `make doc_gram_rsts`.~

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] ~Opened **overlay** pull requests.~

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
