### PR TITLE
Rebuild case info in nativenorm

### DIFF
--- a/kernel/nativecode.ml
+++ b/kernel/nativecode.ml
@@ -1187,7 +1187,6 @@ let compile_prim env decl cond paux =
       let annot =
         let (ci, tbl, knd) = annot in {
           asw_ind = ci.ci_ind;
-          asw_ci = ci;
           asw_reloc = tbl;
           asw_finite = knd <> CoFinite;
           asw_prefix = env.env_mind_prefix (fst ci.ci_ind);
@@ -2081,15 +2080,10 @@ let compile_mind mb mind stack =
       (* FIXME: pass universes here *)
       Glet(name, MLprimitive (Mk_ind, args))
     in
-    let nparams = mb.mind_nparams in
     let add_proj proj_arg acc _pb =
       let tbl = ob.mind_reloc_tbl in
       (* Building info *)
-      let ci = { ci_ind = ind; ci_npar = nparams;
-                 ci_cstr_nargs = [|0|]; ci_relevance = ob.mind_relevance;
-                 ci_cstr_ndecls = [||] (*FIXME*);
-                 ci_pp_info = { ind_tags = []; cstr_tags = [||] (*FIXME*); style = RegularStyle } } in
-      let asw = { asw_ind = ind; asw_prefix = ""; asw_ci = ci;
+      let asw = { asw_ind = ind; asw_prefix = "";
                   asw_reloc = tbl; asw_finite = true } in
       let c_uid = fresh_lname Anonymous in
       let cf_uid = fresh_lname Anonymous in

--- a/kernel/nativevalues.ml
+++ b/kernel/nativevalues.ml
@@ -60,7 +60,6 @@ type reloc_table = (tag * arity) array
 
 type annot_sw = {
     asw_ind : inductive;
-    asw_ci : case_info;
     asw_reloc : reloc_table;
     asw_finite : bool;
     asw_prefix : string

--- a/kernel/nativevalues.mli
+++ b/kernel/nativevalues.mli
@@ -35,7 +35,6 @@ type reloc_table = (tag * arity) array
 
 type annot_sw = {
     asw_ind : inductive;
-    asw_ci : case_info;
     asw_reloc : reloc_table;
     asw_finite : bool;
     asw_prefix : string


### PR DESCRIPTION
We need to do this because native compute doesn't substitute in the ci_relevance so the result will be wrong with sort poly.

VM already does this rebuild since 675b23d