### PR TITLE
[CI] Remove fake dependency of VST on Flocq

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -799,6 +799,8 @@ library:ci-vst:
   needs:
   - build:edge+flambda
   - library:ci-flocq
+  - library:ci-menhir
+  - library:ci-compcert
   timeout: 2h
 
 library:ci-deriving:

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -157,7 +157,7 @@ ci-equations_test: ci-equations
 
 ci-metacoq: ci-equations
 
-ci-vst: ci-flocq
+ci-vst: ci-compcert
 
 ci-compcert: ci-menhir ci-flocq
 

--- a/dev/ci/ci-compcert.sh
+++ b/dev/ci/ci-compcert.sh
@@ -9,9 +9,12 @@ git_download compcert
 
 if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
 
+# CompCert does compile with -native-compiler yes
+# but with excessive memory requirements
 export COQCOPTS='-native-compiler no -w -undeclared-scope -w -omega-is-deprecated'
 ( cd "${CI_BUILD_DIR}/compcert"
-  [ -e Makefile.config ] || ./configure -ignore-coq-version x86_32-linux -use-external-MenhirLib -use-external-Flocq
+  [ -e Makefile.config ] || ./configure -ignore-coq-version x86_32-linux -install-coqdev -clightgen -use-external-MenhirLib -use-external-Flocq -prefix ${CI_INSTALL_DIR} -coqdevdir ${CI_INSTALL_DIR}/lib/coq/user-contrib/compcert
   make
   make check-proof COQCHK='"$(COQBIN)coqchk" -silent -o $(COQINCLUDES)'
+  make install
 )

--- a/dev/ci/ci-vst.sh
+++ b/dev/ci/ci-vst.sh
@@ -9,11 +9,13 @@ git_download vst
 
 if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
 
-export COMPCERT=bundled
+# sometimes (rarely) CompCert master can break VST and it can take
+# weeks or months for VST to catch up, in this case, just uncomment
+# the line below to use the compcert version bundled in VST
+# export COMPCERT=bundled
 
-ulimit -s
-ulimit -s 65536
-ulimit -s
+# See ci-compcert.sh
+export COQEXTRAFLAGS='-native-compiler no'
 ( cd "${CI_BUILD_DIR}/vst"
-  make IGNORECOQVERSION=true
+  make IGNORECOQVERSION=true IGNORECOMPCERTVERSION=true
 )

--- a/dev/ci/user-overlays/18039-proux01-vst.sh
+++ b/dev/ci/user-overlays/18039-proux01-vst.sh
@@ -1,0 +1,1 @@
+overlay vst https://github.com/proux01/VST depflags 18039


### PR DESCRIPTION
VST was recompiling part of CompCert (bundled), this PR makes it use the CompCert already compiled by the CI.
C.f.: https://coq.zulipchat.com/#narrow/stream/250632-Coq-Platform-devs-.26-users/topic/coq-native/near/390515403

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
<!-- Fixes / closes #???? -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] ~Added / updated **test-suite**.~

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] ~Added **changelog**. ~
- [ ] ~Added / updated **documentation**.~
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] ~Documented any new / changed **user messages**.~
  - [ ] ~Updated **documented syntax** by running `make doc_gram_rsts`.~

<!-- If this breaks external libraries or plugins in CI: -->
- [x] ~Opened **overlay** pull requests.~

#### Overlays (to be merged *before* the current PR)

- [x] https://github.com/PrincetonUniversity/VST/pull/726

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
