### PR TITLE
ObjFile.open_trapping_failure: don't discard sub exception

### DIFF
--- a/lib/objFile.ml
+++ b/lib/objFile.ml
@@ -19,7 +19,7 @@ let error_corrupted file s =
 let open_trapping_failure name =
   try open_out_bin name
   with e when CErrors.noncritical e ->
-    CErrors.user_err (str "Can't open " ++ str name ++ str ".")
+    CErrors.user_err (str "Can't open " ++ str name ++ spc() ++ str "(" ++ CErrors.print e ++ str ").")
 
 (*
 


### PR DESCRIPTION
It may have been useful in understanding an error in https://github.com/ocaml/opam-repository/pull/24378
