### PR TITLE
create_overlays: don't produce double end of file newline

### DIFF
--- a/dev/tools/create_overlays.sh
+++ b/dev/tools/create_overlays.sh
@@ -73,7 +73,7 @@ do
     setup_contrib_git $_CONTRIB_DIR $_CONTRIB_GITPUSHURL
 
     echo "overlay ${_CONTRIB_NAME} $_CONTRIB_GITURL $OVERLAY_BRANCH $PR_NUMBER" >> $OVERLAY_FILE
-    echo "" >> $OVERLAY_FILE
+    if [ $# -gt 0 ]; then echo "" >> $OVERLAY_FILE; fi
 done
 
 # Copy to overlays folder.


### PR DESCRIPTION
This helps overlay writers not need the pre-commit hook