### PR TITLE
Discharge on the fly in the kernel

### DIFF
--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1911,13 +1911,12 @@ let discharge_available_scopes map =
       if List.is_empty ltop && List.is_empty lbot then None else Some (ltop, lbot)) map
 
 let discharge_arguments_scope (req,r,scs,_cls,available_scopes) =
-  if req == ArgsScopeNoDischarge || (isVarRef r && Lib.is_in_section r) then None
+  if req == ArgsScopeNoDischarge then None
   else
-    let n =
-      try
-        Array.length (Lib.section_instance r)
-      with
-        Not_found (* Not a ref defined in this section *) -> 0 in
+    match Lib.discharge_global_reference_with_instance r with
+    | None -> None
+    | Some (r, inst) ->
+    let n = Array.length inst in
     let available_scopes = discharge_available_scopes available_scopes in
     (* Hack: use list cls to encode an integer to pass to rebuild for Manual case *)
     (* since cls is anyway recomputed in rebuild *)

--- a/kernel/cooking.mli
+++ b/kernel/cooking.mli
@@ -58,6 +58,9 @@ val create_cache : cooking_info -> cooking_cache
 val instance_of_cooking_cache : cooking_cache -> Constr.t array
 val rel_context_of_cooking_cache : cooking_cache -> rel_context
 
+val discharge_inductive : cooking_cache -> Ind.t -> Ind.t
+val discharge_constant : cooking_cache -> Constant.t -> Constant.t
+
 val abstract_as_type : cooking_cache -> types -> types
 
 val abstract_as_body : cooking_cache -> constr -> constr

--- a/kernel/discharge.ml
+++ b/kernel/discharge.ml
@@ -111,6 +111,15 @@ let cook_projection cache ~params t =
   let _, t = decompose_prod_n_decls (Context.Rel.length params + 1 + nrels) t in
   t
 
+let cook_nested_type cache = function
+  | NestedInd ind -> NestedInd (Cooking.discharge_inductive cache ind)
+  | NestedPrimitive cst -> NestedPrimitive (Cooking.discharge_constant cache cst)
+
+let cook_recargs cache = function
+  | Mrec ind -> Mrec (Ind.pop ind)
+  | Norec -> Norec
+  | Nested t -> Nested (cook_nested_type cache t)
+
 let cook_one_ind cache ~ntypes mip =
   let mind_arity = match mip.mind_arity with
     | RegularArity {mind_user_arity=arity;mind_sort=sort} ->
@@ -139,7 +148,7 @@ let cook_one_ind cache ~ntypes mip =
     mind_nf_lc;
     mind_consnrealargs = mip.mind_consnrealargs;
     mind_consnrealdecls = mip.mind_consnrealdecls;
-    mind_recargs = mip.mind_recargs;
+    mind_recargs = Rtree.Smart.map (cook_recargs cache) mip.mind_recargs;
     mind_relevance = mip.mind_relevance;
     mind_nb_constant = mip.mind_nb_constant;
     mind_nb_args = mip.mind_nb_args;

--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -867,6 +867,8 @@ struct
 
     let relevant c = c.proj_relevant
 
+    let pop p = { p with proj_ind = Ind.pop p.proj_ind }
+
     let hash p =
       Hashset.Combine.combinesmall p.proj_arg (ind_hash p.proj_ind)
 
@@ -974,6 +976,7 @@ struct
   let repr = fst
   let unfolded = snd
   let unfold (c, b as p) = if b then p else (c, true)
+  let pop (p,b) = (Repr.pop p, b)
 
   let equal (c, b) (c', b') = Repr.equal c c' && b == b'
 

--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -381,6 +381,12 @@ module KerName = struct
   let modpath kn = kn.modpath
   let label kn = kn.knlabel
 
+  let pop kn =
+    let mp = match kn.modpath with
+    | ModPath.MPdot (mp,_) -> mp
+    | _ -> CErrors.anomaly (str "No field to pop.") in
+    make mp kn.knlabel
+
   let to_string_gen mp_to_string kn =
     mp_to_string kn.modpath ^ "." ^ Label.to_string kn.knlabel
 
@@ -514,6 +520,10 @@ module KerPair = struct
       if mp1 == mp2 then same kn
       else make kn (KerName.make mp2 lbl)
 
+  let pop = function
+    | Same kn -> Same (KerName.pop kn)
+    | Dual (knu,knc) -> Dual (KerName.pop knu, KerName.pop knc)
+
   let to_string kp = KerName.to_string (user kp)
   let print kp = str (to_string kp)
 
@@ -625,6 +635,8 @@ struct
                                     BEWARE: indexing starts from 0. *)
   let modpath (mind, _) = MutInd.modpath mind
 
+  let pop (mind,i) = (MutInd.pop mind, i)
+
   module CanOrd =
   struct
     type nonrec t = t
@@ -672,6 +684,8 @@ struct
                                     BEWARE: indexing starts from 1. *)
 
   let modpath (ind, _) = Ind.modpath ind
+
+  let pop (ind,i) = (Ind.pop ind, i)
 
   module CanOrd =
   struct

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -291,6 +291,9 @@ sig
   val modpath : t -> ModPath.t
   val label : t -> Label.t
 
+  (** Remove the last modpath segment *)
+  val pop : t -> t
+
   val to_string : t -> string
   (** Encode as a string (not to be used for user-facing messages). *)
 
@@ -395,6 +398,9 @@ sig
   val label : t -> Label.t
   (** Shortcut for [KerName.label (user ...)] *)
 
+  (** Remove the last modpath segment *)
+  val pop : t -> t
+
   (** Comparisons *)
 
   include QNameS with type t := t
@@ -466,6 +472,9 @@ sig
   val label : t -> Label.t
   (** Shortcut for [KerName.label (user ...)] *)
 
+  (** Remove the last modpath segment *)
+  val pop : t -> t
+
   (** Comparisons *)
 
   include QNameS with type t := t
@@ -504,6 +513,9 @@ sig
                                     BEWARE: indexing starts from 0. *)
   val modpath : t -> ModPath.t
 
+  (** Remove the last modpath segment *)
+  val pop : t -> t
+
   include QNameS with type t := t
 
 end
@@ -518,6 +530,9 @@ sig
                                     BEWARE: indexing starts from 1. *)
 
   val modpath : t -> ModPath.t
+
+  (** Remove the last modpath segment *)
+  val pop : t -> t
 
   include QNameS with type t := t
 

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -647,6 +647,7 @@ module Projection : sig
     val arg : t -> int
     val label : t -> Label.t
     val relevant : t -> bool
+    val pop : t -> t
 
     val equal : t -> t -> bool [@@ocaml.deprecated "Use QProjection.equal"]
     val hash : t -> int [@@ocaml.deprecated "Use QProjection.hash"]
@@ -677,6 +678,7 @@ module Projection : sig
   val label : t -> Label.t
   val unfolded : t -> bool
   val unfold : t -> t
+  val pop : t -> t
 
   val equal : t -> t -> bool
   [@@ocaml.deprecated "Use QProjection.equal"]

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -988,9 +988,7 @@ let check_mind mie lab =
     assert (Id.equal (Label.to_id lab) oie.mind_entry_typename)
 
 let add_checked_mind kn mib senv =
-  let mib =
-    match mib.mind_hyps with [] -> Declareops.hcons_mind mib | _ -> mib
-  in
+  let mib = if sections_are_opened senv then mib else Declareops.hcons_mind mib in
   add_field (MutInd.label kn,SFBmind mib) (I kn) senv
 
 let add_mind l mie senv =

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -168,7 +168,7 @@ val set_allow_sprop : bool -> safe_transformer0
 
 (** {6 Interactive section functions } *)
 
-val open_section : safe_transformer0
+val open_section : Id.t -> safe_transformer0
 
 val close_section : safe_transformer0
 

--- a/kernel/section.ml
+++ b/kernel/section.ml
@@ -97,6 +97,10 @@ let open_section ~custom prev =
 let close_section sec =
   sec.prev, sec.entries, sec.mono_universes, sec.custom
 
+let on_previous_section f sec =
+  let e, prev = f sec.prev in
+  e, { sec with prev }
+
 let push_local d sec =
   { sec with context = d :: sec.context }
 

--- a/kernel/section.ml
+++ b/kernel/section.ml
@@ -22,8 +22,6 @@ type section_entry =
 type 'a t = {
   prev : 'a t option;
   (** Section surrounding the current one *)
-  entries : section_entry list;
-  (** Global declarations introduced in the section *)
   context : Constr.named_context;
   (** Declarations local to the section, intended to be interleaved
       with global declarations *)
@@ -42,7 +40,9 @@ type 'a t = {
   custom : 'a;
 }
 
-let rec depth sec = 1 + match sec.prev with None -> 0 | Some prev -> depth prev
+let rec depth = function
+  | None -> 0
+  | Some sec -> 1 + depth sec.prev
 
 let has_poly_univs sec = sec.has_poly_univs
 
@@ -77,7 +77,7 @@ let push_constraints uctx sec =
   then CErrors.user_err
       Pp.(str "Cannot add monomorphic constraints which refer to section polymorphic universes.");
   let uctx' = sec.mono_universes in
-  let mono_universes =  (ContextSet.union uctx uctx') in
+  let mono_universes = ContextSet.union uctx uctx' in
   { sec with mono_universes }
 
 let open_section ~custom prev =
@@ -88,14 +88,13 @@ let open_section ~custom prev =
     poly_universes = UContext.empty;
     all_poly_univs = Option.cata (fun sec -> sec.all_poly_univs) [| |] prev;
     has_poly_univs = Option.cata has_poly_univs false prev;
-    entries = [];
     expand_info_map = (Cmap.empty, Mindmap.empty);
     cooking_info_map = (Cmap.empty, Mindmap.empty);
     custom = custom;
   }
 
 let close_section sec =
-  sec.prev, sec.entries, sec.mono_universes, sec.custom
+  sec.prev, sec.mono_universes, sec.custom
 
 let on_previous_section f sec =
   let e, prev = f sec.prev in
@@ -108,11 +107,7 @@ let extract_hyps vars used =
   (* Only keep the part that is used by the declaration *)
   List.filter (fun d -> Id.Set.mem (NamedDecl.get_id d) used) vars
 
-let segment_of_entry env e uctx sec =
-  let hyps = match e with
-  | SecDefinition con -> (Environ.lookup_constant con env).Declarations.const_hyps
-  | SecInductive mind -> (Environ.lookup_mind mind env).Declarations.mind_hyps
-  in
+let segment_of_entry e hyps uctx sec =
   let hyps = Context.Named.to_vars hyps in
   (* [sec.context] are the named hypotheses, [hyps] the subset that is
      declared by the global *)
@@ -125,19 +120,22 @@ let segment_of_entry env e uctx sec =
   in
   Cooking.make_cooking_info ~recursive sec.expand_info_map ctx uctx
 
-let push_global env ~poly e sec =
+let push_global ~poly e hyps sec =
   if has_poly_univs sec && not poly
   then CErrors.user_err
       Pp.(str "Cannot add a universe monomorphic declaration when \
                section polymorphic universes are present.")
   else
-    let cooking_info, abstr_inst_info = segment_of_entry env e sec.poly_universes sec in
+    let cooking_info, abstr_inst_info = segment_of_entry e hyps sec.poly_universes sec in
     let cooking_info_map = add_emap e cooking_info sec.cooking_info_map in
     let expand_info_map = add_emap e abstr_inst_info sec.expand_info_map in
-    { sec with entries = e :: sec.entries; expand_info_map; cooking_info_map }
+    { sec with expand_info_map; cooking_info_map }
 
-let segment_of_constant con sec = Cmap.find con (fst sec.cooking_info_map)
-let segment_of_inductive con sec = Mindmap.find con (snd sec.cooking_info_map)
+let segment_of_constant con sec =
+  Cmap.find con (fst sec.cooking_info_map)
+
+let segment_of_inductive mind sec =
+  Mindmap.find mind (snd sec.cooking_info_map)
 
 let is_in_section _env gr sec =
   let open GlobRef in

--- a/kernel/section.mli
+++ b/kernel/section.mli
@@ -17,7 +17,7 @@ open Cooking
 type 'a t
 (** Type of sections with additional data ['a] *)
 
-val depth : 'a t -> int
+val depth : 'a t option -> int
 (** Number of nested sections. *)
 
 val map_custom : ('a -> 'a) -> 'a t -> 'a t
@@ -35,7 +35,7 @@ val open_section : custom:'a -> 'a t option -> 'a t
     inside a monomorphic one. A custom data can be attached to this section,
     that will be returned by {!close_section}. *)
 
-val close_section : 'a t -> 'a t option * section_entry list * ContextSet.t * 'a
+val close_section : 'a t -> 'a t option * ContextSet.t * 'a
 (** Close the current section and returns the entries defined inside, the set
     of global monomorphic constraints added in this section, and the custom data
     provided at the opening of the section. *)
@@ -56,7 +56,7 @@ val push_constraints : ContextSet.t -> 'a t -> 'a t
 (** Extend the current section with a global universe context.
     Assumes that the last opened section is monomorphic. *)
 
-val push_global : Environ.env -> poly:bool -> section_entry -> 'a t -> 'a t
+val push_global : poly:bool -> section_entry -> Constr.named_context -> 'a t -> 'a t
 (** Push a global entry in this section. *)
 
 (** {6 Retrieving section data} *)

--- a/kernel/section.mli
+++ b/kernel/section.mli
@@ -40,6 +40,9 @@ val close_section : 'a t -> 'a t option * section_entry list * ContextSet.t * 'a
     of global monomorphic constraints added in this section, and the custom data
     provided at the opening of the section. *)
 
+val on_previous_section : ('a t option -> 'b * 'a t option) -> 'a t -> 'b * 'a t
+(** Apply an action on the prev segment of the section *)
+
 (** {6 Extending sections} *)
 
 val push_local : Constr.named_declaration -> 'a t -> 'a t

--- a/library/coqlib.ml
+++ b/library/coqlib.ml
@@ -64,6 +64,11 @@ let add_ref s c =
 let cache_ref (s,c) =
   add_ref s c
 
+let discharge_ref (s,gr) =
+  match Lib.discharge_global_reference gr with
+  | None -> None
+  | Some gr -> Some (s,gr)
+
 let (inCoqlibRef : string * GlobRef.t -> Libobject.obj) =
   let open Libobject in
   declare_object { (default_object "COQLIBREF") with
@@ -71,7 +76,7 @@ let (inCoqlibRef : string * GlobRef.t -> Libobject.obj) =
     load_function = (fun _ x -> cache_ref x);
     classify_function = (fun _ -> Substitute);
     subst_function = ident_subst_function;
-    discharge_function = (fun sc -> Some sc); }
+    discharge_function = discharge_ref; }
 
 (** Replaces a binding ! *)
 let register_ref s c =

--- a/library/global.ml
+++ b/library/global.ml
@@ -99,7 +99,7 @@ let add_modtype id me inl = globalize (Safe_typing.add_modtype (i2l id) me inl)
 let add_module id me inl = globalize (Safe_typing.add_module (i2l id) me inl)
 let add_include me ismod inl = globalize (Safe_typing.add_include me ismod inl)
 
-let open_section () = globalize0 Safe_typing.open_section
+let open_section id = globalize0 (Safe_typing.open_section id)
 let close_section fs = globalize0_with_summary fs Safe_typing.close_section
 let sections_are_opened () = Safe_typing.sections_are_opened (safe_env())
 

--- a/library/global.mli
+++ b/library/global.mli
@@ -77,7 +77,7 @@ val add_include :
 
 (** Sections *)
 
-val open_section : unit -> unit
+val open_section : Id.t -> unit
 (** [poly] is true when the section should be universe polymorphic *)
 
 val close_section : Summary.Interp.frozen -> unit

--- a/library/globnames.ml
+++ b/library/globnames.ml
@@ -53,6 +53,12 @@ let canonical_gr = function
   | ConstructRef ((kn,i),j )-> ConstructRef((MutInd.make1(MutInd.canonical kn),i),j)
   | VarRef id -> VarRef id
 
+let pop_global_reference = function
+  | ConstRef cst -> ConstRef (Constant.pop cst)
+  | IndRef ind -> IndRef (Ind.pop ind)
+  | ConstructRef cstr -> ConstructRef (Construct.pop cstr)
+  | VarRef id -> VarRef id
+
 (* Extended global references *)
 
 type abbreviation = KerName.t

--- a/library/globnames.mli
+++ b/library/globnames.mli
@@ -27,6 +27,9 @@ val destConstructRef : GlobRef.t -> constructor
 val subst_global : substitution -> GlobRef.t -> GlobRef.t * constr Univ.univ_abstracted option
 val subst_global_reference : substitution -> GlobRef.t -> GlobRef.t
 
+(** Remove the last modpath segment *)
+val pop_global_reference : GlobRef.t -> GlobRef.t
+
 (** {6 Extended global references } *)
 
 type abbreviation = KerName.t

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -285,6 +285,20 @@ let is_in_section ref = match sections () with
 let section_instance ref =
   Cooking.instance_of_cooking_info (section_segment_of_reference ref)
 
+let discharge_mind mind = mind
+
+let discharge_inductive ind = ind
+
+let discharge_constant cst = cst
+
+let discharge_global_reference ref = Some ref
+
+let discharge_global_reference_with_instance ref =
+  if is_in_section ref then
+    if Globnames.isVarRef ref then None
+    else Some (ref, section_instance ref)
+  else Some (ref, [||])
+
 let discharge_item = Libobject.(function
   | ModuleObject _ | ModuleTypeObject _ | IncludeObject _ | KeepObject _
   | ExportObject _ -> None

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -171,6 +171,12 @@ val section_segment_of_reference : GlobRef.t -> Cooking.cooking_info
 val section_instance : GlobRef.t -> Constr.t array
 val is_in_section : GlobRef.t -> bool
 
+val discharge_mind : MutInd.t -> MutInd.t
+val discharge_inductive : Ind.t -> Ind.t
+val discharge_constant : Constant.t -> Constant.t
+val discharge_global_reference : GlobRef.t -> GlobRef.t option
+val discharge_global_reference_with_instance : GlobRef.t -> (GlobRef.t * Constr.t array) option
+
 (** {6 Discharge: decrease the section level if in the current section } *)
 
 val discharge_proj_repr : Projection.Repr.t -> Projection.Repr.t

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -207,7 +207,19 @@ let subst_Function (subst, finfos) =
     ; sprop_lemma = sprop_lemma'
     ; is_general = finfos.is_general }
 
-let discharge_Function finfos = Some finfos
+let discharge_Function finfos =
+  Some {
+    function_constant = Lib.discharge_constant finfos.function_constant;
+    graph_ind = Lib.discharge_inductive finfos.graph_ind;
+    equation_lemma = Option.map Lib.discharge_constant finfos.equation_lemma;
+    correctness_lemma =  Option.map Lib.discharge_constant finfos.correctness_lemma;
+    completeness_lemma =  Option.map Lib.discharge_constant finfos.completeness_lemma;
+    rect_lemma =  Option.map Lib.discharge_constant finfos.rect_lemma;
+    rec_lemma =  Option.map Lib.discharge_constant finfos.rec_lemma;
+    prop_lemma =  Option.map Lib.discharge_constant finfos.prop_lemma;
+    sprop_lemma =  Option.map Lib.discharge_constant finfos.sprop_lemma;
+    is_general = finfos.is_general
+  }
 
 let pr_ocst env sigma c =
   Option.fold_right

--- a/pretyping/arguments_renaming.ml
+++ b/pretyping/arguments_renaming.ml
@@ -42,13 +42,14 @@ let subst_rename_args (subst, (_, (r, names as orig))) =
   if r==r' then orig else (r', names)
 
 let discharge_rename_args = function
-  | ReqGlobal (c, names), _ as req when not (isVarRef c && Lib.is_in_section c) ->
-     (try
-       let var_names = Array.map_to_list (fun c -> Name (destVar c)) (Lib.section_instance c) in
+  | ReqLocal, _ -> None
+  | ReqGlobal (c, names), _ ->
+    match Lib.discharge_global_reference_with_instance c with
+    | None -> None
+    | Some (c, inst) ->
+       let var_names = Array.map_to_list (fun c -> Name (destVar c)) inst in
        let names' = var_names @ names in
        Some (ReqGlobal (c, names), (c, names'))
-     with Not_found -> Some req)
-  | _ -> None
 
 let rebuild_rename_args x = x
 

--- a/pretyping/coercionops.ml
+++ b/pretyping/coercionops.ml
@@ -39,6 +39,12 @@ let cl_typ_ord t1 t2 = match t1, t2 with
 
 let cl_typ_eq t1 t2 = Int.equal (cl_typ_ord t1 t2) 0
 
+let discharge_coercion_class = function
+  | CL_SORT | CL_FUN | CL_SECVAR _ as x -> x
+  | CL_CONST cst -> CL_CONST (Lib.discharge_constant cst)
+  | CL_IND ind -> CL_IND (Lib.discharge_inductive ind)
+  | CL_PROJ p -> CL_PROJ (Lib.discharge_proj_repr p)
+
 module ClTyp = struct
   type t = cl_typ
   let compare = cl_typ_ord

--- a/pretyping/coercionops.mli
+++ b/pretyping/coercionops.mli
@@ -31,6 +31,8 @@ val subst_cl_typ : env -> substitution -> cl_typ -> cl_typ
 (** Comparison of [cl_typ] *)
 val cl_typ_ord : cl_typ -> cl_typ -> int
 
+val discharge_coercion_class : cl_typ -> cl_typ
+
 (** This is the type of coercion kinds *)
 type coe_typ = GlobRef.t
 

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -123,17 +123,12 @@ module ReductionBehaviour = struct
     let r' = subst_global_reference subst r in if r==r' then orig
     else (local,(r',o))
 
-  let discharge = function
-    | false, (gr, b) ->
-      let b =
-        if Lib.is_in_section gr then
-          let vars = Lib.section_instance gr in
-          let extra = Array.length vars in
-          more_args extra b
-        else b
-      in
+  let discharge (local, (gr, b)) =
+    match Lib.discharge_global_reference_with_instance gr with
+    | Some (gr,inst) when not local ->
+      let b = more_args (Array.length inst) b in
       Some (false, (gr, b))
-    | true, _ -> None
+    | _ -> None
 
   let rebuild = function
     | req, (GlobRef.ConstRef c, _ as x) -> req, x

--- a/pretyping/structures.ml
+++ b/pretyping/structures.ml
@@ -80,6 +80,15 @@ let subst subst ({ name; projections; nparams } as s) =
   then s
   else { name; projections; nparams }
 
+let discharge_projection projs =
+  { projs with proj_body = Option.map Lib.discharge_constant projs.proj_body }
+
+let discharge { name; projections; nparams } =
+  Some
+    { name = Lib.discharge_inductive name;
+      projections = List.map discharge_projection projections;
+      nparams }
+
 let rebuild env s =
   let mib = Environ.lookup_mind (fst s.name) env in
   let nparams = mib.Declarations.mind_nparams in
@@ -324,6 +333,11 @@ let register ~warn env sigma o =
           let hd_val = ValuePattern.print cs_pat in
           warn_redundant_canonical_projection (hd_val, prj, new_can_s, old_can_s)
       )
+
+let discharge (ref,ind) =
+  match Lib.discharge_global_reference ref with
+  | None -> None
+  | Some ref -> Some (ref, Lib.discharge_inductive ind)
 
 end
 

--- a/pretyping/structures.mli
+++ b/pretyping/structures.mli
@@ -32,6 +32,8 @@ val make : Environ.env -> Names.inductive -> projection list -> t
 val register : t -> unit
 val subst : Mod_subst.substitution -> t -> t
 
+val discharge : t -> t option
+
 (** refreshes nparams, e.g. after section discharging *)
 val rebuild : Environ.env -> t -> t
 
@@ -71,6 +73,8 @@ val register : warn:bool -> Environ.env -> Evd.evar_map -> t -> unit
 
 val subst : Mod_subst.substitution -> t -> t
 val repr : t -> Names.GlobRef.t
+
+val discharge : t -> t option
 
 end
 

--- a/tactics/declareScheme.ml
+++ b/tactics/declareScheme.ml
@@ -27,7 +27,7 @@ let subst_scheme (subst,(kind,l)) =
   (kind, CArray.Smart.map (subst_one_scheme subst) l)
 
 let discharge_scheme (kind,l) =
-  Some (kind, l)
+  Some (kind, Array.map (fun (c,i) -> (Lib.discharge_inductive c, Lib.discharge_constant i)) l)
 
 let inScheme : string * (inductive * Constant.t) array -> Libobject.obj =
   let open Libobject in

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1237,10 +1237,10 @@ let discharge_autohint obj =
       | HintsVariables | HintsConstants -> grefs
       | HintsReferences grs ->
         let filter = function
-        | EvalConstRef c -> true
-        | EvalVarRef id -> not @@ Lib.is_in_section (GlobRef.VarRef id)
+        | EvalConstRef c -> Some (EvalConstRef (Lib.discharge_constant c))
+        | EvalVarRef id as x -> if not @@ Lib.is_in_section (GlobRef.VarRef id) then Some x else None
         in
-        let grs = List.filter filter grs in
+        let grs = List.filter_map filter grs in
         HintsReferences grs
       in
       AddTransparency { grefs; state }
@@ -1250,14 +1250,12 @@ let discharge_autohint obj =
     | AddCut path ->
       if is_section_path path then AddHints [] (* dummy *) else obj.hint_action
     | AddMode { gref; mode } ->
-      if Lib.is_in_section gref then
-        if isVarRef gref then AddHints [] (* dummy *)
-        else
-          let inst = Lib.section_instance gref in
+      (match Lib.discharge_global_reference_with_instance gref with
+       | None -> AddHints [] (* dummy *)
+       | Some (gref, inst) ->
           (* Default mode for discharged parameters is output *)
           let mode = Array.append (Array.make (Array.length inst) ModeOutput) mode in
-          AddMode { gref; mode }
-      else obj.hint_action
+          AddMode { gref; mode })
     in
     if is_trivial_action action then None
     else Some { obj with hint_action = action }

--- a/tactics/redexpr.ml
+++ b/tactics/redexpr.ml
@@ -103,7 +103,7 @@ let classify_strategy (local,_) =
 
 let disch_ref ref =
   match ref with
-      EvalConstRef c -> Some ref
+      EvalConstRef c -> Some (EvalConstRef (Lib.discharge_constant c))
     | EvalVarRef id -> if Lib.is_in_section (GlobRef.VarRef id) then None else Some ref
 
 let discharge_strategy (local,obj) =

--- a/vernac/canonical.ml
+++ b/vernac/canonical.ml
@@ -21,9 +21,10 @@ let cache_canonical_structure (o,_) =
   Instance.register ~warn:true env sigma o
 
 let discharge_canonical_structure (x, local) =
-  let gref = Instance.repr x in
-  if local || (Globnames.isVarRef gref && Lib.is_in_section gref) then None
-  else Some (x, local)
+  if local then None else
+    match Instance.discharge x with
+    | Some x -> Some (x, local)
+    | None -> None
 
 let canon_cat = create_category "canonicals"
 

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -126,8 +126,9 @@ let discharge_instance inst =
   match inst.locality with
   | Local -> None
   | SuperGlobal | Export ->
-    assert (not (isVarRef inst.instance));
-    Some inst
+    match Lib.discharge_global_reference inst.class_name, Lib.discharge_global_reference inst.instance with
+    | Some class_name, Some instance -> Some { inst with instance; class_name }
+    | _ -> None
 
 let classify_instance inst = match inst.locality with
 | Local -> Dispose
@@ -248,22 +249,27 @@ let subst_class (subst,cl) =
     cl_unique = cl.cl_unique }
 
 let discharge_class cl =
-  try
-    let info = Lib.section_segment_of_reference cl.cl_impl in
-    let info, _, cl_univs' = Cooking.lift_poly_univs info cl.cl_univs in
-    let nprops = List.length cl.cl_props in
-    let props, context = List.chop nprops (Discharge.cook_rel_context info (cl.cl_props @ cl.cl_context)) in
-    let discharge_proj x = x in
-    { cl_univs = cl_univs';
-      cl_impl = cl.cl_impl;
-      cl_context = context;
-      cl_props = props;
-      cl_projs = List.Smart.map discharge_proj cl.cl_projs;
-      cl_strict = cl.cl_strict;
-      cl_unique = cl.cl_unique
-    }
-  with Not_found -> (* not defined in the current section *)
-    cl
+  match Lib.discharge_global_reference cl.cl_impl with
+  | None -> None
+  | Some cl_impl ->
+    if Lib.is_in_section cl.cl_impl then
+      let info = Lib.section_segment_of_reference cl.cl_impl in
+      let info, _, cl_univs = Cooking.lift_poly_univs info cl.cl_univs in
+      let nprops = List.length cl.cl_props in
+      let cl_props, cl_context = List.chop nprops (Discharge.cook_rel_context info (cl.cl_props @ cl.cl_context)) in
+      let discharge_proj x =
+        { x with meth_const = Option.map Lib.discharge_constant x.meth_const } in
+      Some {
+        cl_univs;
+        cl_impl;
+        cl_context;
+        cl_props;
+        cl_projs = List.Smart.map discharge_proj cl.cl_projs;
+        cl_strict = cl.cl_strict;
+        cl_unique = cl.cl_unique;
+      }
+    else
+      Some cl
 
 let rebuild_class cl =
   try
@@ -277,7 +283,7 @@ let class_input : typeclass -> obj =
       cache_function = cache_class;
       load_function = (fun _ -> cache_class);
       classify_function = (fun x -> Substitute);
-      discharge_function = (fun a -> Some (discharge_class a));
+      discharge_function = discharge_class;
       rebuild_function = rebuild_class;
       subst_function = subst_class }
 

--- a/vernac/comArguments.ml
+++ b/vernac/comArguments.ml
@@ -31,10 +31,10 @@ let subst_bidi_hints (subst, (gr, ohint as orig)) =
   if gr == gr' then orig else (gr', ohint)
 
 let discharge_bidi_hints (gr, ohint) =
-  if Globnames.isVarRef gr && Lib.is_in_section gr then None
-  else
-    let vars = Lib.section_instance gr in
-    let n = Array.length vars in
+  match Lib.discharge_global_reference_with_instance gr with
+  | None -> None
+  | Some (gr, inst) ->
+    let n = Array.length inst in
     Some (gr, Option.map ((+) n) ohint)
 
 let inBidiHints =

--- a/vernac/comCoercion.ml
+++ b/vernac/comCoercion.ml
@@ -238,13 +238,16 @@ let open_coercion i o =
 let discharge_coercion c =
   if c.coe_local then None
   else
-    let n =
-      try Array.length (Lib.section_instance c.coe_value)
-      with Not_found -> 0
-    in
+    match Lib.discharge_global_reference_with_instance c.coe_value with
+    | None -> None
+    | Some (v, inst) ->
+    let n = Array.length inst in
     let nc = { c with
       coe_param = n + c.coe_param;
       coe_is_projection = Option.map Lib.discharge_proj_repr c.coe_is_projection;
+      coe_value = v;
+      coe_source = discharge_coercion_class c.coe_source;
+      coe_target = discharge_coercion_class c.coe_target;
     } in
     Some nc
 

--- a/vernac/declareInd.ml
+++ b/vernac/declareInd.ml
@@ -76,7 +76,7 @@ let load_prim _ p = cache_prim p
 
 let subst_prim (subst,(p,c)) = Mod_subst.subst_proj_repr subst p, Mod_subst.subst_constant subst c
 
-let discharge_prim (p,c) = Some (Lib.discharge_proj_repr p, c)
+let discharge_prim (p,c) = Some (Lib.discharge_proj_repr p, Lib.discharge_constant c)
 
 let inPrim : (Projection.Repr.t * Constant.t) -> Libobject.obj =
   let open Libobject in

--- a/vernac/declareUniv.ml
+++ b/vernac/declareUniv.ml
@@ -84,7 +84,7 @@ let discharge_univ_names decl = match decl.udecl_src with
   | BoundUniv -> None
   | (QualifiedUniv _ | UnqualifiedUniv) -> Some decl
 
-let input_univ_names : universe_name_decl -> Libobject.obj =
+let inUnivNames : universe_name_decl -> Libobject.obj =
   let open Libobject in
   declare_named_object_gen
     { (default_object "Global universe name state") with
@@ -97,7 +97,7 @@ let input_univ_names : universe_name_decl -> Libobject.obj =
 
 let input_univ_names (src, l, a) =
   if CList.is_empty l && CList.is_empty a then ()
-  else Lib.add_leaf (input_univ_names { udecl_src = src; udecl_named = l; udecl_anon = a })
+  else Lib.add_leaf (inUnivNames { udecl_src = src; udecl_named = l; udecl_anon = a })
 
 let label_of = let open GlobRef in function
 | ConstRef c -> Label.to_id @@ Constant.label c

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -504,7 +504,7 @@ let cache_structure o = load_structure 1 o
 
 let subst_structure (subst, obj) = Structure.subst subst obj
 
-let discharge_structure x = Some x
+let discharge_structure x = Structure.discharge x
 
 let rebuild_structure s = Structure.rebuild (Global.env()) s
 


### PR DESCRIPTION
Since #14727, the kernel has all the information to support discharging of declarations at the time of declaration. This was experimented in #17888 and this PR is the internal kernel part of #17888.

It implements the following:
- kernel names include a section path in their name (encoded using `MPdot`)
- in `safe_typing.ml`: add all generalisations of a declaration at the time of the declaration rather than at the end of the section

No user-level changes if I'm not mistaken.

Depends on #18062.
    
TODO: double-check what really needs to be in Safe_typing.section_data