### PR TITLE
Fix "r <num>" and "r <string>" commands in coqtop Ltac debugger

### DIFF
--- a/doc/changelog/05-Ltac-language/18068-typed_debug_cmds.rst
+++ b/doc/changelog/05-Ltac-language/18068-typed_debug_cmds.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Fix broken "r <num>" and "r <string>" commands in the coqtop
+  Ltac debugger, which also affected the Proof General Ltac debugger
+  (`#18068 <https://github.com/coq/coq/pull/18068>`_,
+  fixes `#18067 <https://github.com/coq/coq/issues/18067>`_,
+  by Jim Fehrle).

--- a/ide/coqide/wg_MessageView.ml
+++ b/ide/coqide/wg_MessageView.ml
@@ -212,7 +212,8 @@ let message_view sid : message_view =
       end else if key_ev = return then begin
         let ins = buffer#get_iter_at_mark `INSERT in
         let cmd = buffer#get_text ~start:eoo ~stop:ins () in
-        add_msg (Fb (Feedback.Notice, Pp.str cmd));
+        (* save cmd but don't print a second time *)
+        msgs := (Fb (Feedback.Notice, Pp.str cmd), 0) :: !msgs;
         buffer#insert "\n";
         buffer#move_mark `INSERT ~where:buffer#end_iter;
         view#scroll_to_mark `INSERT; (* scroll to insertion point *)

--- a/plugins/ltac/tactic_debug.ml
+++ b/plugins/ltac/tactic_debug.ml
@@ -458,6 +458,7 @@ let goal_com tac varmap trace =
 let skipped = Proofview.NonLogical.run (Proofview.NonLogical.ref 0)
 let skip = Proofview.NonLogical.run (Proofview.NonLogical.ref 0)
 let idtac_breakpt = Proofview.NonLogical.run (Proofview.NonLogical.ref None)
+let idtac_bpt_stop = ref false
 
 let batch = ref false
 
@@ -478,7 +479,10 @@ let db_initialize is_tac =
       (fun _ -> set_break true));
   let open Proofview.NonLogical in
   let x = (skip:=0) >> (skipped:=0) >> (idtac_breakpt:=None) in
-  if is_tac then make Comm.init >> x else x
+  if is_tac then begin
+    idtac_bpt_stop.contents <- false;
+    make Comm.init >> x
+  end else x
 
 (* Prints the run counter *)
 let print_run_ctr print =
@@ -614,13 +618,19 @@ let debug_prompt lev tac f varmap trace =
       else if get_break () then begin
         set_break false;
         stop_here ()
+      end else if s = 1 then begin
+        Proofview.tclLIFT ((skip := 0) >> runprint) >=
+        (fun () -> stop_here ())
       end else if s > 0 then
         Proofview.tclLIFT ((skip := s-1) >>
           runprint >>
           !skip >>= fun new_skip ->
           (if new_skip = 0 then skipped := 0 else return ()) >>
           return (DebugOn (lev+1)))
-      else (* todo: move this block before skip logic? *)
+      else if idtac_bpt_stop.contents then begin
+        idtac_bpt_stop.contents <- false;
+        stop_here ()
+      end else
         Proofview.tclLIFT !idtac_breakpt >= fun idtac_breakpt ->
           if Option.has_some idtac_breakpt then
             Proofview.tclLIFT(runprint >> return (DebugOn (lev+1)))
@@ -641,6 +651,7 @@ let debug_prompt lev tac f varmap trace =
                             else if l_prev = 0 then false
                             else
                               StdList.nth st (l_cur - l_prev) != (StdList.hd st_prev)
+              | Skip | RunCnt _ | RunBreakpoint _ -> false (* handled elsewhere *)
               | _ -> failwith "action op"
             in
             if stop then begin
@@ -690,9 +701,10 @@ let db_breakpoint debug s =
   !idtac_breakpt >>= fun opt_breakpoint ->
   match debug with
   | DebugOn lev when not (CList.is_empty s) && is_breakpoint opt_breakpoint s ->
-      idtac_breakpt:=None
+    idtac_bpt_stop.contents <- true;
+    idtac_breakpt:=None
   | _ ->
-      return ()
+    return ()
 
 (** Extracting traces *)
 


### PR DESCRIPTION
Fixes / closes #18067

Also fixed:
- the "s" command also generated an `action op` failure.
- commands entered in the CoqIDE break were incorrectly echoed, showing the typed command twice (e.g. "r 2" would show as "r 2r 2")

Is this appropriate for 8.18.1 (if we do such a release) or should it go into 8.19?
