### PR TITLE
coq_makefile: Properly delay variable expansion in combined glob/vo rule

### DIFF
--- a/doc/changelog/09-cli-tools/18077-delayed-globvo.rst
+++ b/doc/changelog/09-cli-tools/18077-delayed-globvo.rst
@@ -1,0 +1,7 @@
+- **Fixed:**
+  properly delayed variable expansion when `coq_makefile` uses
+  the combined rule for `.vo` and `.glob` targets,
+  i.e. on GNU Make 4.4 and later.
+  (`#18077 <https://github.com/coq/coq/pull/18077>`_,
+  fixes `#18076 <https://github.com/coq/coq/issues/18076>`_,
+  by Gaëtan Gilbert).

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -816,12 +816,12 @@ ifneq (,$(filter grouped-target,$(.FEATURES)))
 define globvorule=
 
 # take care to $$ variables using $< etc
-  $(1).vo $(1).glob &: $(1).v | $(VDFILE)
-	$(SHOW)COQC $(1).v
-	$(HIDE)$$(TIMER) $(COQC) $(COQDEBUG) $$(TIMING_ARG) $$(PROFILE_ARG) $(COQFLAGS) $(COQLIBS) $(1).v
+  $(1).vo $(1).glob &: $(1).v | $$(VDFILE)
+	$$(SHOW)COQC $(1).v
+	$$(HIDE)$$(TIMER) $$(COQC) $$(COQDEBUG) $$(TIMING_ARG) $$(PROFILE_ARG) $$(COQFLAGS) $$(COQLIBS) $(1).v
 ifeq ($(COQDONATIVE), "yes")
-	$(SHOW)COQNATIVE $(1).vo
-	$(HIDE)$(call TIMER,$(1).vo.native) $(COQNATIVE) $(COQLIBS) $(1).vo
+	$$(SHOW)COQNATIVE $(1).vo
+	$$(HIDE)$$(call TIMER,$(1).vo.native) $$(COQNATIVE) $$(COQLIBS) $(1).vo
 endif
 
 endef


### PR DESCRIPTION
Fix #18076
