### PR TITLE
Ltac2: mutable references are not values

### DIFF
--- a/dev/ci/user-overlays/18082-SkySkimmer-tac2pure.sh
+++ b/dev/ci/user-overlays/18082-SkySkimmer-tac2pure.sh
@@ -1,0 +1,1 @@
+overlay rewriter https://github.com/SkySkimmer/rewriter tac2pure 18082

--- a/doc/changelog/06-Ltac2-language/18082-tac2pure.rst
+++ b/doc/changelog/06-Ltac2-language/18082-tac2pure.rst
@@ -1,0 +1,4 @@
+- **Fixed:**
+  Ltac2 mutable references are not considered values anymore
+  (`#18082 <https://github.com/coq/coq/pull/18082>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -320,10 +320,10 @@ Ltac2 Definitions
       .. coqtop:: all
 
          Ltac2 mutable x := true.
-         Ltac2 y := x.
-         Ltac2 Eval y.
+         Ltac2 y () := x.
+         Ltac2 Eval y ().
          Ltac2 Set x := false.
-         Ltac2 Eval y.
+         Ltac2 Eval y ().
 
    .. example:: Interaction with recursive calls
 
@@ -336,9 +336,11 @@ Ltac2 Definitions
          Ltac2 Eval (f false).
 
       In the definition, the `f` in the body is resolved statically
-      because the definition is marked recursive. In the first re-definition,
-      the `f` in the body is resolved dynamically. This is witnessed by
-      the second re-definition.
+      because the definition is marked recursive. It is equivalent to
+      `Ltac2 mutable f x := let rec g b := if b then 0 else g true in g x`
+      (alpha renaming the internal `f` to `g` to make the behavior clearer).
+      In the first re-definition, the `f` in the body is resolved dynamically.
+      This is witnessed by the second re-definition.
 
 Printing Ltac2 tactics
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/plugins/ltac2/tac2intern.ml
+++ b/plugins/ltac2/tac2intern.ml
@@ -115,8 +115,9 @@ let is_pure_constructor kn =
   | GTydDef _ -> assert false (** Type definitions have no constructors *)
 
 let rec is_value = function
-| GTacAtm (AtmInt _) | GTacVar _ | GTacRef _ | GTacFun _ -> true
+| GTacAtm (AtmInt _) | GTacVar _ | GTacFun _ -> true
 | GTacAtm (AtmStr _) | GTacApp _ | GTacLet (true, _, _) -> false
+| GTacRef kn -> not (Tac2env.interp_global kn).gdata_mutable
 | GTacCst (Tuple _, _, el) -> List.for_all is_value el
 | GTacCst (_, _, []) -> true
 | GTacOpn (_, el) -> List.for_all is_value el

--- a/test-suite/ltac2/rebind.v
+++ b/test-suite/ltac2/rebind.v
@@ -32,10 +32,10 @@ Ltac2 assert_eq n m :=
   | false => Control.throw Assertion_failure end.
 
 Ltac2 mutable x := O.
-Ltac2 y := x.
-Ltac2 Eval (assert_eq y O).
+Ltac2 y () := x.
+Ltac2 Eval (assert_eq (y()) O).
 Ltac2 Set x := (S O).
-Ltac2 Eval (assert_eq y (S O)).
+Ltac2 Eval (assert_eq (y()) (S O)).
 
 Ltac2 mutable quw := fun (n : nat) => O.
 Ltac2 Set quw := fun n =>


### PR DESCRIPTION
Overlays:
- https://github.com/mit-plv/rewriter/pull/115 (backwards compatible)