### PR TITLE
More appropriately moving PropExt->ProofIrrel to file PropExtensionalityFact.v

### DIFF
--- a/doc/stdlib/index-list.html.template
+++ b/doc/stdlib/index-list.html.template
@@ -34,6 +34,7 @@ through the <tt>Require Import</tt> command.</p>
       Classical logic, dependent equality, extensionality, choice axioms
   </dt>
   <dd>
+    theories/Logic/LogicalPrinciples.v
     theories/Logic/SetIsType.v
     theories/Logic/StrictProp.v
     theories/Logic/Classical_Pred_Type.v

--- a/doc/stdlib/index-list.html.template
+++ b/doc/stdlib/index-list.html.template
@@ -56,6 +56,7 @@ through the <tt>Require Import</tt> command.</p>
     theories/Logic/Berardi.v
     theories/Logic/Diaconescu.v
     theories/Logic/Hurkens.v
+    theories/Logic/LawvereFixpoint.v
     theories/Logic/ProofIrrelevance.v
     theories/Logic/ProofIrrelevanceFacts.v
     theories/Logic/ConstructiveEpsilon.v

--- a/theories/Logic/Diaconescu.v
+++ b/theories/Logic/Diaconescu.v
@@ -42,10 +42,12 @@
    [[Carlström04]] Jesper Carlström, EM + Ext_ + AC_int is equivalent
    to AC_ext, Mathematical Logic Quaterly, vol 50(3), pp 236-240, 2004.
 *)
-Require ClassicalFacts ChoiceFacts.
+Require PropExtensionalityFacts ChoiceFacts.
 
 (**********************************************************************)
 (** * Pred. Ext. + Rel. Axiom of Choice -> Excluded-Middle       *)
+
+Import PropExtensionalityFacts.
 
 Section PredExt_RelChoice_imp_EM.
 

--- a/theories/Logic/LawvereFixpoint.v
+++ b/theories/Logic/LawvereFixpoint.v
@@ -1,0 +1,49 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** A proof of Lawvere's fixpoint theorem, namely that a retract from
+    [A] to [A->B] implies that [B] has a fixpoint. This is the core of
+    several theorems by diagonalization: Cantor's theorem, halting
+    problem, incompleteness theorem, Curry's Y fixpoint, ... *)
+
+Local Set Primitive Projections.
+
+Set Warnings "-future-coercion-class-field".
+
+Class IsRetract {A B} (f : A -> B) := {
+    retract_inv : B -> A;
+    risretr : forall x:B, f (retract_inv x) = x;
+  }.
+Record Retract A B := { retract_fun :> A -> B ; retract_isretract :> IsRetract retract_fun }.
+
+Class IsFix {A} (Fix : (A -> A) -> A) := isfix : forall f : A -> A, Fix f = f (Fix f).
+Class HasFix A := { Fix : (A -> A) -> A ; Fix_eq : IsFix Fix }.
+
+#[global] Arguments retract_fun {A B} _.
+#[global] Arguments retract_isretract {A B} _.
+
+Section fixpoint.
+  Context {A B} (ϕ : A -> (A -> B)) (ψ : (A -> B) -> A).
+
+  Definition fixpt (f : B -> B) : B
+    := let q := fun a => f (ϕ a a) in
+       let p := ψ q in
+       ϕ p p.
+End fixpoint.
+
+Section lawvere.
+  Context A B (retract : Retract A (A -> B)).
+
+  Instance fixpt_eq : IsFix (fixpt retract retract.(retract_inv))
+    := fun f => f_equal (fun f => f _) (retract.(risretr) _).
+
+  Instance has_fixpt : HasFix B
+    := { Fix := _ ; Fix_eq := fixpt_eq }.
+End lawvere.

--- a/theories/Logic/LogicalPrinciples.v
+++ b/theories/Logic/LogicalPrinciples.v
@@ -1,0 +1,124 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+Import EqNotations.
+
+(** * Extensionality principles *)
+
+Definition FunctionalExtensionality :=
+  forall A (B : A -> Type), forall (f g : forall x : A, B x),
+    (forall x, f x = g x) -> f = g.
+
+Definition PropExtensionality :=
+  forall (P Q : Prop), (P <-> Q) -> P = Q.
+
+(** * Identification principles *)
+
+(** ** Identity of proofs *)
+
+Definition PropDegeneracy :=
+  forall P : Prop, P = True \/ P = False.
+
+Definition ProofIrrelevance :=
+  forall (P : Prop) (p1 p2 : P), p1 = p2.
+
+(** ** Identity of equality proofs *)
+
+Definition UniquenessIdentityProofs :=
+  forall (A : Type) (x y : A) (e1 : x = y) (e2 : x = y), e1 = e2.
+
+Definition UniquenessReflexiveIdentityProofs :=
+  forall (A : Type) (x : A) (e : x = x), e = eq_refl.
+
+Definition ReflexiveTransport :=
+  forall (A : Type) (x : A) (P : A -> Type) (p : P x) (e : x = x), p = rew [P] e in p.
+
+(** * Choice principles *)
+
+(** ** Non-choice principles *)
+
+Definition UniqueChoice := (** Also known as no-choice principle *)
+  forall (A B : Type) (R : A -> B -> Prop),
+    (forall x : A, exists! y : B, R x y) -> exists f : A -> B, forall x : A, R x (f x).
+
+Definition DependentUniqueChoice :=
+  forall (A : Type) (B : A -> Type) (R : forall x : A, B x -> Prop),
+    (forall x : A, exists! y : B x, R x y) -> exists f : (forall x : A, B x), forall x : A, R x (f x).
+
+(** ** Basic choice principles *)
+
+Definition FunctionalChoice :=
+ forall (A B : Type) (R : A -> B -> Prop),
+ (forall x : A, exists y : B, R x y) -> exists f : A -> B, forall x : A, R x (f x).
+
+Definition DependentFunctionalChoice :=
+  forall (A : Type) (B : A -> Type) (R : forall x : A, B x -> Prop),
+  (forall x : A, exists y : B x, R x y) -> exists f : (forall x : A, B x), forall x : A, R x (f x).
+
+Definition FunctionalCountableChoice :=
+  forall (A : Type) (R : nat -> A -> Prop),
+  (forall n, exists y : A, R n y) -> exists f : nat -> A, forall n, R n (f n).
+
+Definition DependentChoice :=
+  forall (A : Type) (R : A -> A -> Prop),
+  (forall x : A, exists y, R x y) -> forall x : A, exists f : nat -> A, (f 0 = x /\ forall n, R (f n) (f (S n))).
+
+(** ** Description principles *)
+
+Definition ConstructiveDefiniteDescription :=
+  forall (A : Type) (P : A->Prop), (exists! x, P x) -> { x : A | P x }.
+
+Definition ConstructiveIndefiniteDescription :=
+  forall (A : Type) (P : A->Prop), (exists x, P x) -> { x : A | P x }.
+
+Local Notation inhabited A := A (only parsing).
+
+Definition ClassicalDefiniteDescription := (** Also known as Church's iota *)
+  forall (A : Type) (P : A->Prop), inhabited A -> { x : A | (exists! x, P x) -> P x }.
+
+Definition ClassicalIndefiniteDescription := (** Also known as Hilbert's epsilon *)
+  forall (A : Type) (P : A->Prop), inhabited A -> { x : A | (exists x, P x) -> P x }.
+
+(** * Classical principles *)
+
+(** ** Purely logical classical principles *)
+
+Definition DoubleNegationElimination :=
+  forall P : Prop, ~ ~ P -> P.
+
+Definition DoubleNegationShift := (** Also known as Kuroda principle *)
+  forall (A : Type) (P : A -> Prop), (forall x : A, ~ ~ P x) -> ~ ~ (forall x, P x).
+
+Definition PeirceLaw :=
+  forall P Q : Prop, ((P -> Q) -> P) -> P.
+
+Definition ExcludedMiddle :=
+  forall P : Prop, P \/ ~ P.
+
+Definition WeakExcludedMiddle :=
+  forall P : Prop, ~ P \/ ~ ~ P.
+
+Definition ClassicalDeMorganLaw :=
+  forall P Q : Prop, ~ (P /\ Q) -> ~ P \/ ~ Q.
+
+Definition GödelDummett :=
+  forall P Q : Prop, (P -> Q) \/ (Q -> P).
+
+(** ** Arithmetical classical principles *)
+
+Definition MarkovPrinciple :=
+  forall f : nat -> bool, ~ ~ (exists n, f n = true) -> exists n, f n = true.
+
+Definition LimitedPrincipleOmniscience :=
+  forall f : nat -> bool, (exists n, f n = true) \/ (forall n, f n <> true).
+
+Definition LesserLimitedPrincipleOmniscience :=
+  forall f g : nat -> bool,
+  ~ ((exists n, f n = true) /\ (exists n, g n = true)) -> (forall n, f n <> true) \/ (forall n, g n <> true).

--- a/theories/Logic/PropExtensionality.v
+++ b/theories/Logic/PropExtensionality.v
@@ -14,7 +14,7 @@
 Axiom propositional_extensionality :
   forall (P Q : Prop), (P <-> Q) -> P = Q.
 
-Require Import ClassicalFacts.
+Require Import PropExtensionalityFacts.
 
 Theorem proof_irrelevance : forall (P:Prop) (p1 p2:P), p1 = p2.
 Proof.

--- a/theories/Logic/PropExtensionalityFacts.v
+++ b/theories/Logic/PropExtensionalityFacts.v
@@ -10,20 +10,20 @@
 
 (** Some facts and definitions about propositional and predicate extensionality
 
-We investigate the relations between the following extensionality principles
-
-- Proposition extensionality
-- Predicate extensionality
-- Propositional functional extensionality
-- Provable-proposition extensionality
-- Refutable-proposition extensionality
-- Extensional proposition representatives
-- Extensional predicate representatives
-- Extensional propositional function representatives
-
 Table of contents
 
 1. Definitions
+
+2. Relations between the following extensionality principles
+
+   - Proposition extensionality
+   - Predicate extensionality
+   - Propositional functional extensionality
+   - Provable-proposition extensionality
+   - Refutable-proposition extensionality
+   - Extensional proposition representatives
+   - Extensional predicate representatives
+   - Extensional propositional function representatives
 
 2.1 Predicate extensionality <-> Proposition extensionality + Propositional functional extensionality
 
@@ -31,9 +31,20 @@ Table of contents
 
 2.3 Propositional extensionality -> Refutable propositional extensionality
 
+3. Propositional extensionality and proof-irrelevance
+
+3.1. CC |- prop. ext. + A inhabited -> (A = A->A) -> A has fixpoint
+
+3.2. CC |- prop. ext. + dep elim on bool -> proof-irrelevance
+
+3.3. CIC |- prop. ext. -> proof-irrelevance
+
 *)
 
 Set Implicit Arguments.
+
+(************************************************************************)
+(** * Relations between different forms of propositional extensionality *)
 
 (**********************************************************************)
 (** * Definitions *)
@@ -109,3 +120,179 @@ Lemma PropExt_imp_RefutPropExt : PropositionalExtensionality -> RefutableProposi
 Proof.
   intros Ext A Ha; apply Ext; split; easy.
 Qed.
+
+
+(************************************************************************)
+(** * Propositional extensionality and proof-irrelevance *)
+
+(************************************************************************)
+(** ** CC |- prop ext + A inhabited -> (A = A->A) -> A has fixpoint *)
+
+(** We successively show that:
+
+   [PropositionalExtensionality]
+     implies equality of [A] and [A->A] for inhabited [A], which
+     implies the existence of a (trivial) retract from [A->A] to [A]
+        (just take the identity), which
+     implies the existence of a fixpoint operator in [A]
+        (e.g. take the Y combinator of lambda-calculus)
+
+*)
+
+Unset Implicit Arguments.
+
+Local Notation inhabited A := A (only parsing).
+
+Lemma prop_ext_A_eq_A_imp_A :
+  PropositionalExtensionality -> forall A:Prop, inhabited A -> (A -> A) = A.
+Proof.
+  intros Ext A a.
+  apply (Ext (A -> A) A); split; [ exact (fun _ => a) | exact (fun _ _ => a) ].
+Qed.
+
+Require Import LawvereFixpoint.
+
+Lemma prop_ext_retract_A_A_imp_A :
+  PropositionalExtensionality -> forall A:Prop, inhabited A -> Retract A (A -> A).
+Proof.
+  intros Ext A a.
+  rewrite (prop_ext_A_eq_A_imp_A Ext A a).
+  exists (fun x:A => x), (fun x:A => x).
+  reflexivity.
+Qed.
+
+Lemma ext_prop_fixpoint :
+  PropositionalExtensionality -> forall A:Prop, inhabited A -> HasFix A.
+Proof.
+  intros Ext A a.
+  case (prop_ext_retract_A_A_imp_A Ext A a); intros g1 (g2, g1_o_g2).
+  exists (fun f => (fun x:A => f (g1 x x)) (g2 (fun x => f (g1 x x)))).
+  intro f.
+  pattern (g1 (g2 (fun x:A => f (g1 x x)))) at 1.
+  rewrite (g1_o_g2 (fun x:A => f (g1 x x))).
+  reflexivity.
+Qed.
+
+(** Remark: [PropositionalExtensionality] can be replaced in lemma [ext_prop_fixpoint]
+    by the weakest property [provable_PropositionalExtensionality].
+*)
+
+(************************************************************************)
+(** ** CC |- prop_ext /\ dep elim on bool -> proof-irrelevance  *)
+
+(** [proof_irrelevance] asserts equality of all proofs of a given formula *)
+Definition ProofIrrelevance := forall (P:Prop) (p1 p2:P), p1 = p2.
+
+(** Assume that we have booleans with the property that there is at most 2
+    booleans (which is equivalent to dependent case analysis). Consider
+    the fixpoint of the negation function: it is either true or false by
+    dependent case analysis, but also the opposite by fixpoint. Hence
+    proof-irrelevance.
+
+    We then map equality of boolean proofs to proof irrelevance in all
+    propositions.
+*)
+
+Section Proof_irrelevance_gen.
+
+  Variable bool : Prop.
+  Variable true : bool.
+  Variable false : bool.
+  Hypothesis bool_elim : forall C:Prop, C -> C -> bool -> C.
+  Hypothesis
+    bool_elim_redl : forall (C:Prop) (c1 c2:C), c1 = bool_elim C c1 c2 true.
+  Hypothesis
+    bool_elim_redr : forall (C:Prop) (c1 c2:C), c2 = bool_elim C c1 c2 false.
+  Let bool_dep_induction :=
+  forall P:bool -> Prop, P true -> P false -> forall b:bool, P b.
+
+  Lemma aux : PropositionalExtensionality -> bool_dep_induction -> true = false.
+  Proof.
+    intros Ext Ind.
+    case (ext_prop_fixpoint Ext bool true); intros G Gfix.
+    set (neg := fun b:bool => bool_elim bool false true b).
+    generalize (eq_refl (G neg)).
+    pattern (G neg) at 1.
+    apply Ind with (b := G neg); intro Heq.
+    - rewrite (bool_elim_redl bool false true).
+      change (true = neg true); rewrite Heq; apply Gfix.
+    - rewrite (bool_elim_redr bool false true).
+      change (neg false = false); rewrite Heq; symmetry ;
+        apply Gfix.
+  Qed.
+
+  Lemma ext_prop_dep_proof_irrel_gen :
+    PropositionalExtensionality -> bool_dep_induction -> ProofIrrelevance.
+  Proof.
+    intros Ext Ind A a1 a2.
+    set (f := fun b:bool => bool_elim A a1 a2 b).
+    rewrite (bool_elim_redl A a1 a2).
+    change (f true = a2).
+    rewrite (bool_elim_redr A a1 a2).
+    change (f true = f false).
+    rewrite (aux Ext Ind).
+    reflexivity.
+  Qed.
+
+End Proof_irrelevance_gen.
+
+(** In the pure Calculus of Constructions, we can define the boolean
+    proposition [bool = forall C:Prop, C->C->C] but we cannot prove that it has at
+    most 2 elements.
+*)
+
+Section Proof_irrelevance_Prop_Ext_CC.
+
+  Definition BoolP := forall C:Prop, C -> C -> C.
+  Definition TrueP : BoolP := fun C c1 c2 => c1.
+  Definition FalseP : BoolP := fun C c1 c2 => c2.
+  Definition BoolP_elim C c1 c2 (b:BoolP) := b C c1 c2.
+  Definition BoolP_elim_redl (C:Prop) (c1 c2:C) :
+    c1 = BoolP_elim C c1 c2 TrueP := eq_refl c1.
+  Definition BoolP_elim_redr (C:Prop) (c1 c2:C) :
+    c2 = BoolP_elim C c1 c2 FalseP := eq_refl c2.
+
+  Definition BoolP_dep_induction :=
+    forall P:BoolP -> Prop, P TrueP -> P FalseP -> forall b:BoolP, P b.
+
+  Lemma ext_prop_dep_proof_irrel_cc :
+    PropositionalExtensionality -> BoolP_dep_induction -> ProofIrrelevance.
+  Proof.
+    exact (ext_prop_dep_proof_irrel_gen BoolP TrueP FalseP BoolP_elim BoolP_elim_redl
+      BoolP_elim_redr).
+  Qed.
+
+End Proof_irrelevance_Prop_Ext_CC.
+
+(** Remark: [PropositionalExtensionality] can be replaced in lemma
+    [ext_prop_dep_proof_irrel_gen] by the weakest property
+    [provable_PropositionalExtensionality].
+*)
+
+(************************************************************************)
+(** ** CIC |- prop. ext. -> proof-irrelevance                   *)
+
+(** In the Calculus of Inductive Constructions, inductively defined booleans
+    enjoy dependent case analysis, hence directly proof-irrelevance from
+    propositional extensionality.
+*)
+
+Section Proof_irrelevance_CIC.
+
+  Inductive boolP : Prop :=
+    | trueP : boolP
+    | falseP : boolP.
+  Definition boolP_elim_redl (C:Prop) (c1 c2:C) :
+    c1 = boolP_ind C c1 c2 trueP := eq_refl c1.
+  Definition boolP_elim_redr (C:Prop) (c1 c2:C) :
+    c2 = boolP_ind C c1 c2 falseP := eq_refl c2.
+  Scheme boolP_indd := Induction for boolP Sort Prop.
+
+  Lemma ext_prop_dep_proof_irrel_cic : PropositionalExtensionality -> ProofIrrelevance.
+  Proof.
+    exact (fun pe =>
+      ext_prop_dep_proof_irrel_gen boolP trueP falseP boolP_ind boolP_elim_redl
+      boolP_elim_redr pe boolP_indd).
+  Qed.
+
+End Proof_irrelevance_CIC.


### PR DESCRIPTION
The proof that extensionality of propositions + dependent propositional boolean elimination implies proof-irrelevance was historically in file ClassicalFacts (because at some time, propositional extensionality was thought as "classical mathematics"). But it actually pertains more accuratedly to PropExtensionalityFact.v.

The Logic library is probably worth a cleanup phase, e.g. to uniformize the notations, as well as worth many extensions, but we leave it as future work. But see #18671 on which this PR now depends.