### PR TITLE
Factor `rewstrategy` into levels for clearer parsing

### DIFF
--- a/doc/changelog/04-tactics/18093-stratfactoring.rst
+++ b/doc/changelog/04-tactics/18093-stratfactoring.rst
@@ -1,0 +1,8 @@
+- **Changed:**
+  The ``rewstrategy`` argument to ``rewrite_strat`` has been factored into
+  levels to make parsing precedence clearer.  As a result, ambiguous syntax
+  such as ``rewrite_strat topdown choice id id repeat choice choice id id
+  repeat id id`` will no longer parse, instead requiring parentheses to
+  disambiguate
+  (`#18093 <https://github.com/coq/coq/pull/18093>`_,
+  by Jason Gross).

--- a/doc/sphinx/addendum/generalized-rewriting.rst
+++ b/doc/sphinx/addendum/generalized-rewriting.rst
@@ -813,29 +813,7 @@ are applied using the tactic :n:`rewrite_strat @rewstrategy`.
 .. insertprodn rewstrategy rewstrategy
 
 .. prodn::
-   rewstrategy ::= @one_term
-   | <- @one_term
-   | fail
-   | id
-   | refl
-   | progress @rewstrategy
-   | try @rewstrategy
-   | @rewstrategy ; @rewstrategy
-   | choice {+ @rewstrategy }
-   | repeat @rewstrategy
-   | any @rewstrategy
-   | subterm @rewstrategy
-   | subterms @rewstrategy
-   | innermost @rewstrategy
-   | outermost @rewstrategy
-   | bottomup @rewstrategy
-   | topdown @rewstrategy
-   | hints @ident
-   | terms {* @one_term }
-   | eval @red_expr
-   | fold @one_term
-   | ( @rewstrategy )
-   | old_hints @ident
+   rewstrategy ::= @rewstrategy3
 
 :n:`@one_term`
    lemma, left to right

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -2266,30 +2266,42 @@ glob_constr_with_bindings: [
 | constr_with_bindings
 ]
 
-rewstrategy: [
+rewstrategy0: [
 | glob
-| "<-" constr
-| "subterms" rewstrategy
-| "subterm" rewstrategy
-| "innermost" rewstrategy
-| "outermost" rewstrategy
-| "bottomup" rewstrategy
-| "topdown" rewstrategy
 | "id"
 | "fail"
 | "refl"
-| "progress" rewstrategy
-| "try" rewstrategy
-| "any" rewstrategy
-| "repeat" rewstrategy
-| rewstrategy ";" rewstrategy
 | "(" rewstrategy ")"
-| "choice" LIST1 rewstrategy
+]
+
+rewstrategy1: [
+| rewstrategy0
+| "<-" constr
+| "subterms" rewstrategy1
+| "subterm" rewstrategy1
+| "innermost" rewstrategy1
+| "outermost" rewstrategy1
+| "bottomup" rewstrategy1
+| "topdown" rewstrategy1
+| "progress" rewstrategy1
+| "try" rewstrategy1
+| "any" rewstrategy1
+| "repeat" rewstrategy1
+| "choice" LIST1 rewstrategy0
 | "old_hints" preident
 | "hints" preident
 | "terms" LIST0 constr
 | "eval" red_expr
 | "fold" constr
+]
+
+rewstrategy2: [
+| rewstrategy1
+| rewstrategy2 ";" rewstrategy2
+]
+
+rewstrategy: [
+| rewstrategy3
 ]
 
 int_or_var: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -393,6 +393,40 @@ implicit_binders: [
 | "[" LIST1 name OPT ( ":" type ) "]"
 ]
 
+rewstrategy0: [
+| one_term
+| "id"
+| "fail"
+| "refl"
+| "(" rewstrategy ")"
+]
+
+rewstrategy1: [
+| rewstrategy0
+| "<-" one_term
+| "subterms" rewstrategy1
+| "subterm" rewstrategy1
+| "innermost" rewstrategy1
+| "outermost" rewstrategy1
+| "bottomup" rewstrategy1
+| "topdown" rewstrategy1
+| "progress" rewstrategy1
+| "try" rewstrategy1
+| "any" rewstrategy1
+| "repeat" rewstrategy1
+| "choice" LIST1 rewstrategy0
+| "old_hints" ident
+| "hints" ident
+| "terms" LIST0 one_term
+| "eval" red_expr
+| "fold" one_term
+]
+
+rewstrategy2: [
+| rewstrategy1
+| rewstrategy2 ";" rewstrategy2
+]
+
 generalizing_binder: [
 | "`(" LIST1 typeclass_constraint SEP "," ")"
 | "`{" LIST1 typeclass_constraint SEP "," "}"
@@ -2116,29 +2150,7 @@ rewrite_occs: [
 ]
 
 rewstrategy: [
-| one_term
-| "<-" one_term
-| "fail"
-| "id"
-| "refl"
-| "progress" rewstrategy
-| "try" rewstrategy
-| rewstrategy ";" rewstrategy
-| "choice" LIST1 rewstrategy
-| "repeat" rewstrategy
-| "any" rewstrategy
-| "subterm" rewstrategy
-| "subterms" rewstrategy
-| "innermost" rewstrategy
-| "outermost" rewstrategy
-| "bottomup" rewstrategy
-| "topdown" rewstrategy
-| "hints" ident
-| "terms" LIST0 one_term
-| "eval" red_expr
-| "fold" one_term
-| "(" rewstrategy ")"
-| "old_hints" ident
+| rewstrategy3
 ]
 
 l3_tactic: [

--- a/plugins/ltac/g_rewrite.mlg
+++ b/plugins/ltac/g_rewrite.mlg
@@ -90,7 +90,8 @@ let pr_glob_strategy env sigma prc prlc _ (s : glob_strategy) =
 
 }
 
-ARGUMENT EXTEND rewstrategy
+(* rewstrategy0 holds rewrite strategies that don't have to be parenthesized as arguments to choice *)
+ARGUMENT EXTEND rewstrategy0
     PRINTED BY { pr_strategy }
 
     INTERPRETED BY { interp_strategy }
@@ -101,28 +102,71 @@ ARGUMENT EXTEND rewstrategy
     GLOB_PRINTED BY { pr_glob_strategy env sigma }
 
   | [ glob(c) ] -> { StratConstr (c, true) }
-  | [ "<-" constr(c) ] -> { StratConstr (c, false) }
-  | [ "subterms" rewstrategy(h) ] -> { StratUnary (Subterms, h) }
-  | [ "subterm" rewstrategy(h) ] -> { StratUnary (Subterm, h) }
-  | [ "innermost" rewstrategy(h) ] -> { StratUnary(Innermost, h) }
-  | [ "outermost" rewstrategy(h) ] -> { StratUnary(Outermost, h) }
-  | [ "bottomup" rewstrategy(h) ] -> { StratUnary(Bottomup, h) }
-  | [ "topdown" rewstrategy(h) ] -> { StratUnary(Topdown, h) }
   | [ "id" ] -> { StratId }
   | [ "fail" ] -> { StratFail }
   | [ "refl" ] -> { StratRefl }
-  | [ "progress" rewstrategy(h) ] -> { StratUnary (Progress, h) }
-  | [ "try" rewstrategy(h) ] -> { StratUnary (Try, h) }
-  | [ "any" rewstrategy(h) ] -> { StratUnary (Any, h) }
-  | [ "repeat" rewstrategy(h) ] -> { StratUnary (Repeat, h) }
-  | [ rewstrategy(h) ";" rewstrategy(h') ] -> { StratBinary (Compose, h, h') }
   | [ "(" rewstrategy(h) ")" ] -> { h }
-  | [ "choice" ne_rewstrategy_list(h) ] -> { StratNAry (Choice, h) }
+END
+
+(* rewstrategy1 holds choice and operators like choice which take arguments but bind more tightly than ; *)
+(* rewstrategy1 is morally right associative *)
+ARGUMENT EXTEND rewstrategy1
+    PRINTED BY { pr_strategy }
+
+    INTERPRETED BY { interp_strategy }
+    GLOBALIZED BY { glob_strategy }
+    SUBSTITUTED BY { subst_strategy }
+
+    RAW_PRINTED BY { pr_raw_strategy env sigma }
+    GLOB_PRINTED BY { pr_glob_strategy env sigma }
+
+  | [ rewstrategy0(h) ] -> { h }
+  | [ "<-" constr(c) ] -> { StratConstr (c, false) }
+  | [ "subterms" rewstrategy1(h) ] -> { StratUnary (Subterms, h) }
+  | [ "subterm" rewstrategy1(h) ] -> { StratUnary (Subterm, h) }
+  | [ "innermost" rewstrategy1(h) ] -> { StratUnary(Innermost, h) }
+  | [ "outermost" rewstrategy1(h) ] -> { StratUnary(Outermost, h) }
+  | [ "bottomup" rewstrategy1(h) ] -> { StratUnary(Bottomup, h) }
+  | [ "topdown" rewstrategy1(h) ] -> { StratUnary(Topdown, h) }
+  | [ "progress" rewstrategy1(h) ] -> { StratUnary (Progress, h) }
+  | [ "try" rewstrategy1(h) ] -> { StratUnary (Try, h) }
+  | [ "any" rewstrategy1(h) ] -> { StratUnary (Any, h) }
+  | [ "repeat" rewstrategy1(h) ] -> { StratUnary (Repeat, h) }
+  | [ "choice" ne_rewstrategy0_list(h) ] -> { StratNAry (Choice, h) }
   | [ "old_hints" preident(h) ] -> { StratHints (true, h) }
   | [ "hints" preident(h) ] -> { StratHints (false, h) }
   | [ "terms" constr_list(h) ] -> { StratTerms h }
   | [ "eval" red_expr(r) ] -> { StratEval r }
   | [ "fold" constr(c) ] -> { StratFold c }
+END
+
+(* rewstrategy2 holds ; and operations that commute with ; *)
+ARGUMENT EXTEND rewstrategy2
+    PRINTED BY { pr_strategy }
+
+    INTERPRETED BY { interp_strategy }
+    GLOBALIZED BY { glob_strategy }
+    SUBSTITUTED BY { subst_strategy }
+
+    RAW_PRINTED BY { pr_raw_strategy env sigma }
+    GLOB_PRINTED BY { pr_glob_strategy env sigma }
+
+  | [ rewstrategy1(h) ] -> { h }
+  | [ rewstrategy2(h) ";" rewstrategy2(h') ] -> { StratBinary (Compose, h, h') }
+END
+
+(* rewstrategy holds just the single entry with the loosest-binding rewstrategy *)
+ARGUMENT EXTEND rewstrategy
+    PRINTED BY { pr_strategy }
+
+    INTERPRETED BY { interp_strategy }
+    GLOBALIZED BY { glob_strategy }
+    SUBSTITUTED BY { subst_strategy }
+
+    RAW_PRINTED BY { pr_raw_strategy env sigma }
+    GLOB_PRINTED BY { pr_glob_strategy env sigma }
+
+  | [ rewstrategy3(h) ] -> { h }
 END
 
 (* By default the strategy for "rewrite_db" is top-down *)


### PR DESCRIPTION
To make #17509 easier.  Can some expert from @coq/parsing-maintainers tell me if this is the right way to go about this / what I should change, and some expert from @coq/doc-maintainers tell me how to set up the rst so that `make doc_gram_rsts` doesn't delete all the entries?

- [] Added / updated **test-suite**. (is this needed?)
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  - [x] Updated **documented syntax** by running `make doc_gram_rsts`.
- [] Opened **overlay** pull requests.