### PR TITLE
rewrite strategies: expose fixpoint operator (take 2)

### DIFF
--- a/dev/ci/user-overlays/18094-JasonGross-stratfix.sh
+++ b/dev/ci/user-overlays/18094-JasonGross-stratfix.sh
@@ -1,0 +1,3 @@
+overlay serapi https://github.com/JasonGross/coq-serapi stratfix 18094
+
+overlay tactician https://github.com/JasonGross/coq-tactician stratfix 18094

--- a/doc/changelog/05-Ltac-language/18094-stratfix.rst
+++ b/doc/changelog/05-Ltac-language/18094-stratfix.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  In :tacn:`rewrite_strat`, :n:`@rewstrategy` now supports the fixpoint operator :n:`fix @ident := @rewstrategy1`
+  (`#18094 <https://github.com/coq/coq/pull/18094>`_,
+  fixes `#13702 <https://github.com/coq/coq/issues/13702>`_,
+  by Jason Gross and Gaëtan Gilbert).

--- a/doc/changelog/05-Ltac-language/18094-stratfix.rst
+++ b/doc/changelog/05-Ltac-language/18094-stratfix.rst
@@ -3,3 +3,8 @@
   (`#18094 <https://github.com/coq/coq/pull/18094>`_,
   fixes `#13702 <https://github.com/coq/coq/issues/13702>`_,
   by Jason Gross and Gaëtan Gilbert).
+- **Fixed:**
+  :tacn:`rewrite_strat` now works inside module functors
+  (`#18094 <https://github.com/coq/coq/pull/18094>`_,
+  fixes `#18463 <https://github.com/coq/coq/issues/18463>`_,
+  by Jason Gross).

--- a/doc/sphinx/addendum/generalized-rewriting.rst
+++ b/doc/sphinx/addendum/generalized-rewriting.rst
@@ -815,10 +815,7 @@ are applied using the :tacn:`rewrite_strat` tactic.
 .. prodn::
    rewstrategy ::= fix @ident := @rewstrategy1
    | {+; @rewstrategy1 }
-   rewstrategy2 ::= @rewstrategy2 ; @rewstrategy1
-   | @rewstrategy1
    rewstrategy1 ::= <- @one_term
-   | using @ident
    | progress @rewstrategy1
    | try @rewstrategy1
    | choice {+ @rewstrategy0 }
@@ -911,14 +908,9 @@ are applied using the :tacn:`rewrite_strat` tactic.
 :n:`fold @term`
    unify
 
-:n:`using @ident`
-   run a strategy bound by `fix` to the :n:`@ident`
-
 :n:`fix @ident := @rewstrategy1`
    fixpoint operator, where :math:`\texttt{fix }f := v` evaluates to
-   :math:`\subst{v}{\texttt{using }f}{(\texttt{fix }f := v)}`.
-   Note that the bound :n:`ident` must be used through `using`,
-   i.e. `fix x := x` is the same as `x` interpreted as a :n:`@one_term`.
+   :math:`\subst{v}{f}{(\texttt{fix }f := v)}`
 
 :n:`( @rewstrategy )`
    to be documented
@@ -930,12 +922,12 @@ are applied using the :tacn:`rewrite_strat` tactic.
 Conceptually, a few of these are defined in terms of the others:
 
 - :n:`try @rewstrategy1 := choice (@rewstrategy1) id`
-- :n:`any @rewstrategy1 := fix @ident := try (@rewstrategy1 ; using @ident)`
+- :n:`any @rewstrategy1 := fix @ident := try (@rewstrategy1 ; @ident)`
 - :n:`repeat @rewstrategy1 := @rewstrategy1; any @rewstrategy1`
-- :n:`bottomup @rewstrategy1 := fix @ident := (choice (progress subterms using @ident) (@rewstrategy1) ; try using @ident)`
-- :n:`topdown @rewstrategy1 := fix @ident := (choice (@rewstrategy1) (progress subterms using @ident) ; try using @ident)`
-- :n:`innermost @rewstrategy1 := fix @ident := choice (subterm using @ident) (@rewstrategy1)`
-- :n:`outermost @rewstrategy1 := fix @ident := choice (@rewstrategy1) (subterm using @ident)`
+- :n:`bottomup @rewstrategy1 := fix @ident := (choice (progress subterms @ident) (@rewstrategy1) ; try @ident)`
+- :n:`topdown @rewstrategy1 := fix @ident := (choice (@rewstrategy1) (progress subterms @ident) ; try @ident)`
+- :n:`innermost @rewstrategy1 := fix @ident := choice (subterm @ident) (@rewstrategy1)`
+- :n:`outermost @rewstrategy1 := fix @ident := choice (@rewstrategy1) (subterm @ident)`
 
 The basic control strategy semantics are straightforward: strategies
 are applied to subterms of the term to rewrite, starting from the root

--- a/doc/sphinx/addendum/generalized-rewriting.rst
+++ b/doc/sphinx/addendum/generalized-rewriting.rst
@@ -813,8 +813,12 @@ are applied using the :tacn:`rewrite_strat` tactic.
 .. insertprodn rewstrategy rewstrategy0
 
 .. prodn::
-   rewstrategy ::= {+; @rewstrategy1 }
+   rewstrategy ::= fix @ident := @rewstrategy1
+   | {+; @rewstrategy1 }
+   rewstrategy2 ::= @rewstrategy2 ; @rewstrategy1
+   | @rewstrategy1
    rewstrategy1 ::= <- @one_term
+   | using @ident
    | progress @rewstrategy1
    | try @rewstrategy1
    | choice {+ @rewstrategy0 }
@@ -907,6 +911,15 @@ are applied using the :tacn:`rewrite_strat` tactic.
 :n:`fold @term`
    unify
 
+:n:`using @ident`
+   run a strategy bound by `fix` to the :n:`@ident`
+
+:n:`fix @ident := @rewstrategy1`
+   fixpoint operator, where :math:`\texttt{fix }f := v` evaluates to
+   :math:`\subst{v}{\texttt{using }f}{(\texttt{fix }f := v)}`.
+   Note that the bound :n:`ident` must be used through `using`,
+   i.e. `fix x := x` is the same as `x` interpreted as a :n:`@one_term`.
+
 :n:`( @rewstrategy )`
    to be documented
 
@@ -914,16 +927,15 @@ are applied using the :tacn:`rewrite_strat` tactic.
    to be documented
 
 
-Conceptually, a few of these are defined in terms of the others using a
-primitive fixpoint operator `fix`, which the tactic doesn't currently support:
+Conceptually, a few of these are defined in terms of the others:
 
 - :n:`try @rewstrategy1 := choice (@rewstrategy1) id`
-- :n:`any @rewstrategy1 := fix @ident. try (@rewstrategy1 ; @ident)`
+- :n:`any @rewstrategy1 := fix @ident := try (@rewstrategy1 ; using @ident)`
 - :n:`repeat @rewstrategy1 := @rewstrategy1; any @rewstrategy1`
-- :n:`bottomup @rewstrategy1 := fix @ident. (choice (progress (subterms @ident)) @rewstrategy1) ; try @ident`
-- :n:`topdown @rewstrategy1 := fix @ident. (choice (@rewstrategy1) (progress (subterms @ident))) ; try @ident`
-- :n:`innermost @rewstrategy1 := fix @ident. (choice (subterm @ident) (@rewstrategy1))`
-- :n:`outermost @rewstrategy1 := fix @ident. (choice (@rewstrategy1) (subterm @ident))`
+- :n:`bottomup @rewstrategy1 := fix @ident := (choice (progress subterms using @ident) (@rewstrategy1) ; try using @ident)`
+- :n:`topdown @rewstrategy1 := fix @ident := (choice (@rewstrategy1) (progress subterms using @ident) ; try using @ident)`
+- :n:`innermost @rewstrategy1 := fix @ident := choice (subterm using @ident) (@rewstrategy1)`
+- :n:`outermost @rewstrategy1 := fix @ident := choice (@rewstrategy1) (subterm using @ident)`
 
 The basic control strategy semantics are straightforward: strategies
 are applied to subterms of the term to rewrite, starting from the root

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -2244,14 +2244,14 @@ as_or_and_ipat: [
 | "as" or_and_intropattern
 ]
 
-ne_rewstrategy1_list: [
+ne_rewstrategy1_list_sep_semicolon: [
 | DELETE rewstrategy1
-| REPLACE ne_rewstrategy1_list ";" rewstrategy1
+| REPLACE ne_rewstrategy1_list_sep_semicolon ";" rewstrategy1
 | WITH LIST1 rewstrategy1 SEP ";"
 ]
 
 SPLICE: [
-| ne_rewstrategy1_list
+| ne_rewstrategy1_list_sep_semicolon
 | clause
 | noedit_mode
 | match_list

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -2244,14 +2244,14 @@ as_or_and_ipat: [
 | "as" or_and_intropattern
 ]
 
-rewstrategy2: [
+ne_rewstrategy1_list: [
 | DELETE rewstrategy1
-| REPLACE rewstrategy2 ";" rewstrategy1
+| REPLACE ne_rewstrategy1_list ";" rewstrategy1
 | WITH LIST1 rewstrategy1 SEP ";"
 ]
 
 SPLICE: [
-| rewstrategy2
+| ne_rewstrategy1_list
 | clause
 | noedit_mode
 | match_list

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -2244,12 +2244,14 @@ as_or_and_ipat: [
 | "as" or_and_intropattern
 ]
 
-rewstrategy: [
-| REPLACE rewstrategy2
+rewstrategy2: [
+| DELETE rewstrategy1
+| REPLACE rewstrategy2 ";" rewstrategy1
 | WITH LIST1 rewstrategy1 SEP ";"
 ]
 
 SPLICE: [
+| rewstrategy2
 | clause
 | noedit_mode
 | match_list

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -2245,9 +2245,8 @@ as_or_and_ipat: [
 ]
 
 rewstrategy: [
-| DELETE rewstrategy1
-| DELETE rewstrategy ";" rewstrategy1
-| LIST1 rewstrategy1 SEP ";"
+| REPLACE rewstrategy2
+| WITH LIST1 rewstrategy1 SEP ";"
 ]
 
 SPLICE: [

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -2279,11 +2279,11 @@ glob_constr_with_bindings: [
 
 rewstrategy: [
 | "fix" identref ":=" rewstrategy1
-| ne_rewstrategy1_list
+| ne_rewstrategy1_list_sep_semicolon
 ]
 
-ne_rewstrategy1_list: [
-| ne_rewstrategy1_list ";" rewstrategy1
+ne_rewstrategy1_list_sep_semicolon: [
+| ne_rewstrategy1_list_sep_semicolon ";" rewstrategy1
 | rewstrategy1
 ]
 

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -2289,7 +2289,6 @@ rewstrategy2: [
 
 rewstrategy1: [
 | "<-" constr
-| "using" identref
 | "subterms" rewstrategy1
 | "subterm" rewstrategy1
 | "innermost" rewstrategy1

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -2278,12 +2278,18 @@ glob_constr_with_bindings: [
 ]
 
 rewstrategy: [
-| rewstrategy ";" rewstrategy1
+| "fix" identref ":=" rewstrategy1
+| rewstrategy2
+]
+
+rewstrategy2: [
+| rewstrategy2 ";" rewstrategy1
 | rewstrategy1
 ]
 
 rewstrategy1: [
 | "<-" constr
+| "using" identref
 | "subterms" rewstrategy1
 | "subterm" rewstrategy1
 | "innermost" rewstrategy1

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -2279,11 +2279,11 @@ glob_constr_with_bindings: [
 
 rewstrategy: [
 | "fix" identref ":=" rewstrategy1
-| rewstrategy2
+| ne_rewstrategy1_list
 ]
 
-rewstrategy2: [
-| rewstrategy2 ";" rewstrategy1
+ne_rewstrategy1_list: [
+| ne_rewstrategy1_list ";" rewstrategy1
 | rewstrategy1
 ]
 

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -2134,11 +2134,18 @@ rewrite_occs: [
 ]
 
 rewstrategy: [
+| "fix" ident ":=" rewstrategy1
 | LIST1 rewstrategy1 SEP ";"
+]
+
+rewstrategy2: [
+| rewstrategy2 ";" rewstrategy1
+| rewstrategy1
 ]
 
 rewstrategy1: [
 | "<-" one_term
+| "using" ident
 | "progress" rewstrategy1
 | "try" rewstrategy1
 | "choice" LIST1 rewstrategy0

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -2138,14 +2138,8 @@ rewstrategy: [
 | LIST1 rewstrategy1 SEP ";"
 ]
 
-rewstrategy2: [
-| rewstrategy2 ";" rewstrategy1
-| rewstrategy1
-]
-
 rewstrategy1: [
 | "<-" one_term
-| "using" ident
 | "progress" rewstrategy1
 | "try" rewstrategy1
 | "choice" LIST1 rewstrategy0

--- a/plugins/ltac/g_rewrite.mlg
+++ b/plugins/ltac/g_rewrite.mlg
@@ -66,35 +66,26 @@ END
 
 {
 
-type raw_strategy = (constr_expr, Genredexpr.raw_red_expr) strategy_ast
-type glob_strategy = (glob_constr_and_expr, Genredexpr.glob_red_expr) strategy_ast
-
-let interp_strategy ist env sigma s =
-  let interp_redexpr r = fun env sigma -> Tacinterp.interp_red_expr ist env sigma r in
-  let interp_constr c = (fst c, fun env sigma -> Tacinterp.interp_open_constr ist env sigma c) in
-  let s = map_strategy interp_constr interp_redexpr s in
-  strategy_of_ast s
-
-let glob_strategy ist s = map_strategy (Tacintern.intern_constr ist) (Tacintern.intern_red_expr ist) s
+(** XXX this seems incorrect? *)
 let subst_strategy s str = str
 
 let pr_strategy _ _ _ (s : strategy) = Pp.str "<strategy>"
-let pr_raw_strategy env sigma prc prlc _ (s : raw_strategy) =
+let pr_raw_strategy env sigma prc prlc _ (s : Tacexpr.raw_strategy) =
   let prr = Pptactic.pr_red_expr env sigma (prc, prlc, Pputils.pr_or_by_notation Libnames.pr_qualid, prc) in
-  Rewrite.pr_strategy (prc env sigma) prr s
-let pr_glob_strategy env sigma prc prlc _ (s : glob_strategy) =
+  Rewrite.pr_strategy (prc env sigma) prr Pputils.pr_lident s
+let pr_glob_strategy env sigma prc prlc _ (s : Tacexpr.glob_strategy) =
   let prpat env sigma (_,c,_) = prc env sigma c in
   let prcst = Pputils.pr_or_var Pptactic.(pr_and_short_name (pr_evaluable_reference_env env)) in
   let prr = Pptactic.pr_red_expr env sigma (prc, prlc, prcst, prpat) in
-  Rewrite.pr_strategy (prc env sigma) prr s
+  Rewrite.pr_strategy (prc env sigma) prr Id.print s
 
 }
 
 ARGUMENT EXTEND rewstrategy
     PRINTED BY { pr_strategy }
 
-    INTERPRETED BY { interp_strategy }
-    GLOBALIZED BY { glob_strategy }
+    INTERPRETED BY { Tacinterp.interp_strategy }
+    GLOBALIZED BY { Tacintern.intern_strategy }
     SUBSTITUTED BY { subst_strategy }
 
     RAW_PRINTED BY { pr_raw_strategy env sigma }
@@ -104,6 +95,11 @@ END
 GRAMMAR EXTEND Gram
   GLOBAL: rewstrategy;
   rewstrategy:
+    [ NONA
+      [ IDENT "fix"; id = identref; ":="; s = rewstrategy1 -> { StratFix (id, s) }
+      | h = rewstrategy2 -> { h } ] ]
+  ;
+  rewstrategy2:
     [ LEFTA
       [ h = SELF; ";"; h' = rewstrategy1 -> { StratBinary (Compose, h, h') }
       | h = rewstrategy1 -> { h } ] ]
@@ -111,6 +107,7 @@ GRAMMAR EXTEND Gram
   rewstrategy1:
     [ RIGHTA
       [ "<-"; c = constr -> { StratConstr (c, false) }
+      | IDENT "using"; id = identref -> { StratVar id }
       | IDENT "subterms"; h = SELF -> { StratUnary (Subterms, h) }
       | IDENT "subterm"; h = SELF -> { StratUnary (Subterm, h) }
       | IDENT "innermost"; h = SELF -> { StratUnary(Innermost, h) }

--- a/plugins/ltac/g_rewrite.mlg
+++ b/plugins/ltac/g_rewrite.mlg
@@ -99,9 +99,9 @@ GRAMMAR EXTEND Gram
   rewstrategy:
     [ NONA
       [ IDENT "fix"; id = identref; ":="; s = rewstrategy1 -> { StratFix (id, s) }
-      | h = ne_rewstrategy1_list -> { h } ] ]
+      | h = ne_rewstrategy1_list_sep_semicolon -> { h } ] ]
   ;
-  ne_rewstrategy1_list:
+  ne_rewstrategy1_list_sep_semicolon:
     [ LEFTA
       [ h = SELF; ";"; h' = rewstrategy1 -> { StratBinary (Compose, h, h') }
       | h = rewstrategy1 -> { h } ] ]

--- a/plugins/ltac/g_rewrite.mlg
+++ b/plugins/ltac/g_rewrite.mlg
@@ -66,8 +66,10 @@ END
 
 {
 
-(** XXX this seems incorrect? *)
-let subst_strategy s str = str
+let subst_strategy sub = map_strategy
+    (Tacsubst.subst_glob_constr_and_expr sub)
+    (Tacsubst.subst_redexp sub)
+    (fun x -> x)
 
 let pr_strategy _ _ _ (s : strategy) = Pp.str "<strategy>"
 let pr_raw_strategy env sigma prc prlc _ (s : Tacexpr.raw_strategy) =
@@ -97,9 +99,9 @@ GRAMMAR EXTEND Gram
   rewstrategy:
     [ NONA
       [ IDENT "fix"; id = identref; ":="; s = rewstrategy1 -> { StratFix (id, s) }
-      | h = rewstrategy2 -> { h } ] ]
+      | h = ne_rewstrategy1_list -> { h } ] ]
   ;
-  rewstrategy2:
+  ne_rewstrategy1_list:
     [ LEFTA
       [ h = SELF; ";"; h' = rewstrategy1 -> { StratBinary (Compose, h, h') }
       | h = rewstrategy1 -> { h } ] ]

--- a/plugins/ltac/g_rewrite.mlg
+++ b/plugins/ltac/g_rewrite.mlg
@@ -107,7 +107,6 @@ GRAMMAR EXTEND Gram
   rewstrategy1:
     [ RIGHTA
       [ "<-"; c = constr -> { StratConstr (c, false) }
-      | IDENT "using"; id = identref -> { StratVar id }
       | IDENT "subterms"; h = SELF -> { StratUnary (Subterms, h) }
       | IDENT "subterm"; h = SELF -> { StratUnary (Subterm, h) }
       | IDENT "innermost"; h = SELF -> { StratUnary(Innermost, h) }

--- a/plugins/ltac/g_rewrite.mlg
+++ b/plugins/ltac/g_rewrite.mlg
@@ -68,7 +68,7 @@ END
 
 let subst_strategy sub = map_strategy
     (Tacsubst.subst_glob_constr_and_expr sub)
-    (Tacsubst.subst_redexp sub)
+    (Tacsubst.subst_glob_red_expr sub)
     (fun x -> x)
 
 let pr_strategy _ _ _ (s : strategy) = Pp.str "<strategy>"

--- a/plugins/ltac/g_rewrite.mli
+++ b/plugins/ltac/g_rewrite.mli
@@ -27,18 +27,10 @@ val wit_glob_constr_with_bindings :
 val glob_constr_with_bindings :
   constr_expr_with_bindings Pcoq.Entry.t
 
-type raw_strategy =
-    (Constrexpr.constr_expr, Genredexpr.raw_red_expr)
-    Rewrite.strategy_ast
-
-type glob_strategy =
-    (Genintern.glob_constr_and_expr, Genredexpr.glob_red_expr)
-    Rewrite.strategy_ast
-
 val wit_rewstrategy :
-  (raw_strategy, glob_strategy, Rewrite.strategy) Genarg.genarg_type
+  (Tacexpr.raw_strategy, Tacexpr.glob_strategy, Rewrite.strategy) Genarg.genarg_type
 
-val rewstrategy : raw_strategy Pcoq.Entry.t
+val rewstrategy : Tacexpr.raw_strategy Pcoq.Entry.t
 
 type binders_argtype = Constrexpr.local_binder_expr list
 

--- a/plugins/ltac/pptactic.mli
+++ b/plugins/ltac/pptactic.mli
@@ -156,7 +156,6 @@ val pr_match_rule : bool -> ('a -> Pp.t) -> ('b -> Pp.t) ->
 
 val pr_value : entry_relative_level -> Val.t -> Pp.t
 
-
 val ltop : entry_relative_level
 
 val make_constr_printer : (env -> Evd.evar_map -> entry_relative_level -> 'a -> Pp.t) ->

--- a/plugins/ltac/tacexpr.ml
+++ b/plugins/ltac/tacexpr.ml
@@ -351,6 +351,11 @@ type t_dispatch =  <
 type atomic_tactic_expr =
     t_dispatch gen_atomic_tactic_expr
 
+(** Misc *)
+
+type raw_strategy = (constr_expr, Genredexpr.raw_red_expr, lident) Rewrite.strategy_ast
+type glob_strategy = (Genintern.glob_constr_and_expr, Genredexpr.glob_red_expr, Id.t) Rewrite.strategy_ast
+
 (** Traces *)
 
 type ltac_call_kind =

--- a/plugins/ltac/tacexpr.mli
+++ b/plugins/ltac/tacexpr.mli
@@ -351,6 +351,11 @@ type t_dispatch =  <
 type atomic_tactic_expr =
     t_dispatch gen_atomic_tactic_expr
 
+(** Misc *)
+
+type raw_strategy = (constr_expr, Genredexpr.raw_red_expr, lident) Rewrite.strategy_ast
+type glob_strategy = (Genintern.glob_constr_and_expr, Genredexpr.glob_red_expr, Id.t) Rewrite.strategy_ast
+
 (** Traces *)
 
 type ltac_call_kind =

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -760,16 +760,19 @@ let glob_tactic_env l env x =
 let intern_strategy ist s =
   let rec aux stratvars = function
     | Rewrite.StratVar x ->
+      (* We could make this whole branch assert false, since it's
+         unreachable except from plugins. But maybe it's useful if any
+         plug-in wants to craft a strategy by hand. *)
       if Id.Set.mem x.v stratvars then Rewrite.StratVar x.v
       else CErrors.user_err ?loc:x.loc Pp.(str "Unbound strategy" ++ spc() ++ Id.print x.v)
     | StratConstr ({ v = CRef (qid, None) }, true) when idset_mem_qualid qid stratvars ->
       let (_, x) = repr_qualid qid in Rewrite.StratVar x
+    | StratConstr (c, b) -> StratConstr (intern_constr ist c, b)
     | StratFix (x, s) -> StratFix (x.v, aux (Id.Set.add x.v stratvars) s)
     | StratId | StratFail | StratRefl as s -> s
     | StratUnary (s, str) -> StratUnary (s, aux stratvars str)
     | StratBinary (s, str, str') -> StratBinary (s, aux stratvars str, aux stratvars str')
     | StratNAry (s, strs) -> StratNAry (s, List.map (aux stratvars) strs)
-    | StratConstr (c, b) -> StratConstr (intern_constr ist c, b)
     | StratTerms l -> StratTerms (List.map (intern_constr ist) l)
     | StratHints (b, id) -> StratHints (b, id)
     | StratEval r -> StratEval (intern_red_expr ist r)

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -762,6 +762,8 @@ let intern_strategy ist s =
     | Rewrite.StratVar x ->
       if Id.Set.mem x.v stratvars then Rewrite.StratVar x.v
       else CErrors.user_err ?loc:x.loc Pp.(str "Unbound strategy" ++ spc() ++ Id.print x.v)
+    | StratConstr ({ v = CRef (qid, None) }, true) when idset_mem_qualid qid stratvars ->
+      let (_, x) = repr_qualid qid in Rewrite.StratVar x
     | StratFix (x, s) -> StratFix (x.v, aux (Id.Set.add x.v stratvars) s)
     | StratId | StratFail | StratRefl as s -> s
     | StratUnary (s, str) -> StratUnary (s, aux stratvars str)

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -757,6 +757,24 @@ let glob_tactic_env l env x =
     List.fold_left (fun accu x -> Id.Set.add x accu) Id.Set.empty l in
   intern_pure_tactic { (Genintern.empty_glob_sign ~strict:true env) with ltacvars } x
 
+let intern_strategy ist s =
+  let rec aux stratvars = function
+    | Rewrite.StratVar x ->
+      if Id.Set.mem x.v stratvars then Rewrite.StratVar x.v
+      else CErrors.user_err ?loc:x.loc Pp.(str "Unbound strategy" ++ spc() ++ Id.print x.v)
+    | StratFix (x, s) -> StratFix (x.v, aux (Id.Set.add x.v stratvars) s)
+    | StratId | StratFail | StratRefl as s -> s
+    | StratUnary (s, str) -> StratUnary (s, aux stratvars str)
+    | StratBinary (s, str, str') -> StratBinary (s, aux stratvars str, aux stratvars str')
+    | StratNAry (s, strs) -> StratNAry (s, List.map (aux stratvars) strs)
+    | StratConstr (c, b) -> StratConstr (intern_constr ist c, b)
+    | StratTerms l -> StratTerms (List.map (intern_constr ist) l)
+    | StratHints (b, id) -> StratHints (b, id)
+    | StratEval r -> StratEval (intern_red_expr ist r)
+    | StratFold c -> StratFold (intern_constr ist c)
+  in
+  aux Id.Set.empty s
+
 (** Registering *)
 
 let lift intern = (); fun ist x -> (ist, intern ist x)

--- a/plugins/ltac/tacintern.mli
+++ b/plugins/ltac/tacintern.mli
@@ -59,3 +59,5 @@ val intern_genarg : glob_sign -> raw_generic_argument -> glob_generic_argument
 (** Reduction expressions *)
 
 val intern_red_expr : glob_sign -> Genredexpr.raw_red_expr -> Genredexpr.glob_red_expr
+
+val intern_strategy : glob_sign -> raw_strategy -> glob_strategy

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -759,6 +759,12 @@ let interp_red_expr ist env sigma = function
     sigma , CbvNative (Option.map (interp_closed_typed_pattern_with_occurrences ist env sigma) o)
   | (Red |  Hnf | ExtraRedExpr _ as r) -> sigma , r
 
+let interp_strategy ist _env _sigma s =
+  let interp_redexpr r = fun env sigma -> interp_red_expr ist env sigma r in
+  let interp_constr c = (fst c, fun env sigma -> interp_open_constr ist env sigma c) in
+  let s = Rewrite.map_strategy interp_constr interp_redexpr (fun x -> x) s in
+  Rewrite.strategy_of_ast s
+
 let interp_may_eval f ist env sigma = function
   | ConstrEval (r,c) ->
       let (sigma,redexp) = interp_red_expr ist env sigma r in

--- a/plugins/ltac/tacinterp.mli
+++ b/plugins/ltac/tacinterp.mli
@@ -82,6 +82,8 @@ val interp_red_expr : interp_sign -> Environ.env -> Evd.evar_map -> Genredexpr.g
 (** Interprets redexp arguments from a raw one *)
 val interp_redexp : Environ.env -> Evd.evar_map -> Genredexpr.raw_red_expr -> Evd.evar_map * red_expr
 
+val interp_strategy : interp_sign -> Environ.env -> Evd.evar_map -> glob_strategy -> Rewrite.strategy
+
 (** Interprets tactic expressions *)
 
 val interp_hyp : interp_sign -> Environ.env -> Evd.evar_map ->

--- a/plugins/ltac/tacsubst.ml
+++ b/plugins/ltac/tacsubst.ml
@@ -99,14 +99,14 @@ let subst_glob_constr_or_pattern subst (bvars,c,p) =
   let sigma = Evd.from_env env in
   (bvars,subst_glob_constr subst c,subst_pattern env sigma subst p)
 
-let subst_redexp subst =
+let subst_glob_red_expr subst =
   Redops.map_red_expr_gen
     (subst_glob_constr subst)
     (subst_evaluable subst)
     (subst_glob_constr_or_pattern subst)
 
 let subst_raw_may_eval subst = function
-  | ConstrEval (r,c) -> ConstrEval (subst_redexp subst r,subst_glob_constr subst c)
+  | ConstrEval (r,c) -> ConstrEval (subst_glob_red_expr subst r,subst_glob_constr subst c)
   | ConstrContext (locid,c) -> ConstrContext (locid,subst_glob_constr subst c)
   | ConstrTypeOf c -> ConstrTypeOf (subst_glob_constr subst c)
   | ConstrTerm c -> ConstrTerm (subst_glob_constr subst c)
@@ -154,7 +154,7 @@ let rec subst_atomic subst (t:glob_atomic_tactic_expr) = match t with
       TacInductionDestruct (isrec,ev,(l',el'))
 
   (* Conversion *)
-  | TacReduce (r,cl) -> TacReduce (subst_redexp subst r, cl)
+  | TacReduce (r,cl) -> TacReduce (subst_glob_red_expr subst r, cl)
   | TacChange (check,op,c,cl) ->
       TacChange (check,Option.map (subst_glob_constr_or_pattern subst) op,
         subst_glob_constr subst c, cl)
@@ -292,7 +292,7 @@ let () =
   Gensubst.register_subst0 wit_clause_dft_concl (fun _ v -> v);
   Gensubst.register_subst0 wit_uconstr (fun subst c -> subst_glob_constr subst c);
   Gensubst.register_subst0 wit_open_constr (fun subst c -> subst_glob_constr subst c);
-  Gensubst.register_subst0 Redexpr.wit_red_expr subst_redexp;
+  Gensubst.register_subst0 Redexpr.wit_red_expr subst_glob_red_expr;
   Gensubst.register_subst0 wit_quant_hyp subst_declared_or_quantified_hypothesis;
   Gensubst.register_subst0 wit_bindings subst_bindings;
   Gensubst.register_subst0 wit_constr_with_bindings subst_glob_with_bindings;

--- a/plugins/ltac/tacsubst.mli
+++ b/plugins/ltac/tacsubst.mli
@@ -32,4 +32,4 @@ val subst_glob_with_bindings : substitution ->
   glob_constr_and_expr with_bindings ->
   glob_constr_and_expr with_bindings
 
-val subst_redexp : substitution -> Genredexpr.glob_red_expr -> Genredexpr.glob_red_expr
+val subst_glob_red_expr : substitution -> Genredexpr.glob_red_expr -> Genredexpr.glob_red_expr

--- a/plugins/ltac/tacsubst.mli
+++ b/plugins/ltac/tacsubst.mli
@@ -31,3 +31,5 @@ val subst_glob_constr_and_expr :
 val subst_glob_with_bindings : substitution ->
   glob_constr_and_expr with_bindings ->
   glob_constr_and_expr with_bindings
+
+val subst_redexp : substitution -> Genredexpr.glob_red_expr -> Genredexpr.glob_red_expr

--- a/tactics/redexpr.mli
+++ b/tactics/redexpr.mli
@@ -54,6 +54,10 @@ val set_strategy :
 (** call by value normalisation function using the virtual machine *)
 val cbv_vm : reduction_function
 
+(** [subst_red_expr sub c] performs the substitution [sub] on all kernel
+   names appearing in [c] *)
+val subst_red_expr : Mod_subst.substitution -> red_expr -> red_expr
+
 open Constrexpr
 open Libnames
 

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -1714,7 +1714,7 @@ and pr_strategy1 prc prr prid = function
   str "choice" ++ brk (1,2) ++ prlist_with_sep spc (fun str -> hov 0 (pr_strategy0 prc prr prid str)) strs
 | StratConstr (c, true) -> prc c
 | StratConstr (c, false) -> str "<-" ++ spc () ++ prc c
-| StratVar id -> str "using" ++ spc() ++ prid id
+| StratVar id -> prid id
 | StratTerms cl -> str "terms" ++ spc () ++ pr_sequence prc cl
 | StratHints (old, id) ->
   let cmd = if old then "old_hints" else "hints" in

--- a/tactics/rewrite.mli
+++ b/tactics/rewrite.mli
@@ -27,17 +27,19 @@ type binary_strategy =
 
 type nary_strategy = Choice
 
-type ('constr,'redexpr) strategy_ast =
+type ('constr,'redexpr,'id) strategy_ast =
   | StratId | StratFail | StratRefl
-  | StratUnary of unary_strategy * ('constr,'redexpr) strategy_ast
+  | StratUnary of unary_strategy * ('constr,'redexpr,'id) strategy_ast
   | StratBinary of
-      binary_strategy * ('constr,'redexpr) strategy_ast * ('constr,'redexpr) strategy_ast
-  | StratNAry of nary_strategy * ('constr,'redexpr) strategy_ast list
+      binary_strategy * ('constr,'redexpr,'id) strategy_ast * ('constr,'redexpr,'id) strategy_ast
+  | StratNAry of nary_strategy * ('constr,'redexpr,'id) strategy_ast list
   | StratConstr of 'constr * bool
   | StratTerms of 'constr list
   | StratHints of bool * string
   | StratEval of 'redexpr
   | StratFold of 'constr
+  | StratVar of 'id
+  | StratFix of 'id * ('constr,'redexpr,'id) strategy_ast
 
 type rewrite_proof =
   | RewPrf of constr * constr
@@ -60,13 +62,13 @@ type rewrite_result =
 
 type strategy
 
-val strategy_of_ast : (Glob_term.glob_constr * constr delayed_open, Redexpr.red_expr delayed_open) strategy_ast -> strategy
+val strategy_of_ast : (Glob_term.glob_constr * constr delayed_open, Redexpr.red_expr delayed_open, Id.t) strategy_ast -> strategy
 
-val map_strategy : ('a -> 'b) -> ('c -> 'd) ->
-  ('a, 'c) strategy_ast -> ('b, 'd) strategy_ast
+val map_strategy : ('a -> 'b) -> ('c -> 'd) -> ('e -> 'f) ->
+  ('a, 'c, 'e) strategy_ast -> ('b, 'd, 'f) strategy_ast
 
-val pr_strategy : ('a -> Pp.t) -> ('b -> Pp.t) ->
-  ('a, 'b) strategy_ast -> Pp.t
+val pr_strategy : ('a -> Pp.t) -> ('b -> Pp.t) -> ('c -> Pp.t) ->
+  ('a, 'b, 'c) strategy_ast -> Pp.t
 
 (** Entry point for user-level "rewrite_strat" *)
 val cl_rewrite_clause_strat : strategy -> Id.t option -> unit Proofview.tactic

--- a/test-suite/bugs/bug_18463.v
+++ b/test-suite/bugs/bug_18463.v
@@ -1,0 +1,38 @@
+From Coq Require Import Setoid.
+
+Module Type Nop. End Nop.
+Module nop. End nop.
+
+Module RewriteStratSubstTestF (Nop : Nop).
+  Axiom X : Set.
+
+  Axiom f : X -> X.
+  Axiom g : X -> X -> X.
+  Axiom h : nat -> X -> X.
+
+  Axiom lem0 : forall x, f (f x) = f x.
+  Axiom lem1 : forall x, g x x = f x.
+  Axiom lem2 : forall n x, h (S n) x = g (h n x) (h n x).
+  Axiom lem3 : forall x, h 0 x = x.
+  Definition idnat := @id nat.
+
+  Ltac rs1 := rewrite_strat topdown lem2.
+  Ltac rs2 := rewrite_strat try fold idnat.
+  Ltac rs3 := rewrite_strat try subterms lem2.
+  Ltac rs4 := rewrite_strat eval cbv delta [idnat].
+End RewriteStratSubstTestF.
+
+Module RewriteStratSubstTest := RewriteStratSubstTestF nop.
+
+Goal forall x, RewriteStratSubstTest.h 6 x = RewriteStratSubstTest.f x /\ RewriteStratSubstTest.idnat 5 = id 5.
+  intros.
+  Print Ltac RewriteStratSubstTest.rs1. (* Ltac RewriteStratSubstTest.rs1 := Coq.Init.Ltac.rewrite_strat_#_521927FC _ (* Generic printer *) *)
+  RewriteStratSubstTest.rs1. (* Error: Anomaly "Constant rewrite_strat.RewriteStratSubstTestF.lem2 does not appear in the environment."
+Please report at http://coq.inria.fr/bugs/. *)
+Undo 1.
+  RewriteStratSubstTest.rs2.
+Undo 1.
+  RewriteStratSubstTest.rs3.
+Undo 1.
+  RewriteStratSubstTest.rs4.
+Admitted.

--- a/test-suite/output/rewrite_strat.out
+++ b/test-suite/output/rewrite_strat.out
@@ -7,3 +7,35 @@ Ltac k5 :=
   subterms subterms fail;
   subterms subterms fail;
   choice (subterms try fail; subterms repeat fail)
+Ltac mytry rewstrategy1 := rewrite_strat choice (rewstrategy1) id
+Ltac myany rewstrategy1 :=
+  rewrite_strat
+  fix
+  fixident
+  :=
+  try (rewstrategy1; fixident)
+Ltac myrepeat rewstrategy1 := rewrite_strat rewstrategy1; any rewstrategy1
+Ltac mybottomup rewstrategy1 :=
+  rewrite_strat
+  fix
+  fixident
+  :=
+  (choice (progress subterms fixident) (rewstrategy1); try fixident)
+Ltac mytopdown rewstrategy1 :=
+  rewrite_strat
+  fix
+  fixident
+  :=
+  (choice (rewstrategy1) (progress subterms fixident); try fixident)
+Ltac myinnermost rewstrategy1 :=
+  rewrite_strat
+  fix
+  fixident
+  :=
+  choice (subterm fixident) (rewstrategy1)
+Ltac myoutermost rewstrategy1 :=
+  rewrite_strat
+  fix
+  fixident
+  :=
+  choice (rewstrategy1) (subterm fixident)

--- a/test-suite/output/rewrite_strat.v
+++ b/test-suite/output/rewrite_strat.v
@@ -3,3 +3,10 @@ Ltac k2 := rewrite_strat subterms id; (choice (subterm fail) fail); fail. Print 
 Ltac k3 := rewrite_strat subterms id; ((choice (subterm fail) fail); fail). Print Ltac k3.
 Ltac k4 := rewrite_strat subterms (id; choice (subterm fail) fail; fail). Print Ltac k4.
 Ltac k5 := rewrite_strat (subterms subterms fail; subterms subterms fail); choice (subterms try fail; subterms repeat fail). Print Ltac k5.
+Ltac mytry rewstrategy1 := rewrite_strat choice (rewstrategy1) id. Print Ltac mytry.
+Ltac myany rewstrategy1 := rewrite_strat fix fixident := try (rewstrategy1 ; fixident). Print Ltac myany.
+Ltac myrepeat rewstrategy1 := rewrite_strat (rewstrategy1; any rewstrategy1). Print Ltac myrepeat.
+Ltac mybottomup rewstrategy1 := rewrite_strat fix fixident := (choice (progress subterms fixident) (rewstrategy1) ; try fixident). Print Ltac mybottomup.
+Ltac mytopdown rewstrategy1 := rewrite_strat fix fixident := (choice (rewstrategy1) (progress subterms fixident) ; try fixident). Print Ltac mytopdown.
+Ltac myinnermost rewstrategy1 := rewrite_strat fix fixident := choice (subterm fixident) (rewstrategy1). Print Ltac myinnermost.
+Ltac myoutermost rewstrategy1 := rewrite_strat fix fixident := choice (rewstrategy1) (subterm fixident). Print Ltac myoutermost.

--- a/test-suite/success/rewrite_strat.v
+++ b/test-suite/success/rewrite_strat.v
@@ -1,4 +1,4 @@
-Require Import Setoid. 
+Require Import Setoid.
 
 Variable X : Set.
 
@@ -14,7 +14,7 @@ Variable lem3 : forall x, h 0 x = x.
 #[export] Hint Rewrite lem0 lem1 lem2 lem3 : rew.
 
 Goal forall x, h 10 x = f x.
-Proof. 
+Proof.
   intros.
   Time autorewrite with rew. (* 0.586 *)
   reflexivity.
@@ -31,22 +31,25 @@ Undo 5.
   Time rewrite_strat topdown (choice lem2 lem1).
   Time rewrite_strat topdown (choice lem0 lem3).
   reflexivity.
-Undo 3. 
+Undo 3.
   Time rewrite_strat (topdown (choice lem2 lem1); topdown (choice lem0 lem3)).
   reflexivity.
 Undo 2.
-  Time rewrite_strat (topdown (choice lem2 (choice lem1 (choice lem0 lem3)))). 
-  reflexivity.  
+  Time rewrite_strat (topdown (choice lem2 (choice lem1 (choice lem0 lem3)))).
+  reflexivity.
 Undo 2.
   Time rewrite_strat (topdown (choice lem2 (choice lem1 (choice lem0 lem3)))).
   reflexivity.
 Undo 2.
   Time rewrite_strat (topdown (choice lem2 lem1 lem0 lem3)).
   reflexivity.
+Undo 2.
+  Time rewrite_strat fix f := (choice lem2 lem1 lem0 lem3 (progress subterms f) ; try f).
+  reflexivity.
 Qed.
 
 Goal forall x, h 10 x = f x.
-Proof. 
+Proof.
   intros.
   Time rewrite_strat topdown (hints rew). (* 0.38 *)
   reflexivity.


### PR DESCRIPTION
I am adopting https://github.com/coq/coq/pull/17509

<strike>Currently blocked on #17832; I will rebase and adapt after that.  Opened as draft so I don't lose track of this.</strike> <strike>Needs to be rebased on #17832</strike>

<strike>To avoid conflicting with the StratConstr syntax, strategy variables are accessed with `using`,
ie `any foo := fix any_foo := try (foo; using any_foo) end` `fix` syntax uses `end` because otherwise the parser interprets `fix foo := bla; bli` as `(fix foo := bla); bli` which may confuse the user.

I'm planning to lift both of these limitations, most likely.</strike>

Fixes #13702
Fixes #18463

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  - [x] Updated **documented syntax** by running `make doc_gram_rsts`.
- [x] Created overlays
  - https://github.com/ejgallego/coq-serapi/pull/380
  - https://github.com/coq-tactician/coq-tactician/pull/74
