### PR TITLE
Addresses #18096: more informative message when a notation cannot be intepreted as a reference 

### DIFF
--- a/doc/changelog/03-notations/18104-master+address18096-print-notation-non-strict-ref.rst
+++ b/doc/changelog/03-notations/18104-master+address18096-print-notation-non-strict-ref.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  More informative message when a notation cannot be intepreted as a reference
+  (`#18104 <https://github.com/coq/coq/pull/18104>`_,
+  addresses `#18096 <https://github.com/coq/coq/issues/18096>`_,
+  by Hugo Herbelin).

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -2099,10 +2099,6 @@ let pr_scope_classes sc =
     hov 0 (str "Bound to class" ++ opt_s ++
       spc() ++ prlist_with_sep spc pr_scope_class l)
 
-let pr_notation_info prglob ntn c =
-  str (String.quote_coq_string ntn) ++ str " :=" ++ brk (1,2) ++
-  prglob (Notation_ops.glob_constr_of_notation_constr c)
-
 let pr_notation_status on_parsing on_printing =
   let disabled b = if b then [] else ["disabled"] in
   let l = match on_parsing, on_printing with
@@ -2121,7 +2117,7 @@ let pr_non_empty spc pp =
   if pp = mt () then mt () else spc ++ pp
 
 let pr_notation_data prglob (on_parsing,on_printing,{ not_interp  = (_, r); not_location = (_, df) }) =
-  hov 0 (pr_notation_info prglob df r ++ pr_non_empty (brk(1,2)) (pr_notation_status on_parsing on_printing))
+  hov 0 (Notation_ops.pr_notation_info prglob df r ++ pr_non_empty (brk(1,2)) (pr_notation_status on_parsing on_printing))
 
 let extract_notation_data (main,extra) =
   let main = match main with
@@ -2414,7 +2410,7 @@ let locate_notation prglob ntn scope =
         (fun (sc,(on_parsing,on_printing,{ not_interp  = (_, r); not_location = (_, df) })) ->
           hov 0 (
             str "Notation" ++ brk (1,2) ++
-            pr_notation_info prglob df r ++
+            Notation_ops.pr_notation_info prglob df r ++
             (if String.equal sc default_scope then mt ()
              else (brk (1,2) ++ str ": " ++ str sc)) ++
             (if Option.equal String.equal (Some sc) scope

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -2367,13 +2367,17 @@ let global_reference_of_notation ~head test (ntn,sc,(on_parsing,on_printing,{not
       Some (on_parsing,on_printing,ntn,sc,ref)
   | _ -> None
 
-let error_ambiguous_notation ?loc _ntn =
-  user_err ?loc (str "Ambiguous notation.")
+type notation_as_reference_error =
+  | AmbiguousNotationAsReference of notation_key
+  | NotationNotReference of notation_key
+
+exception NotationAsReferenceError of notation_as_reference_error
+
+let error_ambiguous_notation ?loc ntn =
+  Loc.raise ?loc (NotationAsReferenceError (AmbiguousNotationAsReference ntn))
 
 let error_notation_not_reference ?loc ntn =
-  user_err ?loc
-   (str "Unable to interpret " ++ quote (str ntn) ++
-    str " as a reference.")
+  Loc.raise ?loc (NotationAsReferenceError (NotationNotReference ntn))
 
 let interp_notation_as_global_reference ?loc ~head test ntn sc =
   let scopes = match sc with

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -285,7 +285,7 @@ val interpret_notation_string : string -> string
 
 type notation_as_reference_error =
   | AmbiguousNotationAsReference of notation_key
-  | NotationNotReference of notation_key
+  | NotationNotReference of Environ.env * Evd.evar_map * notation_key * (notation_key * notation_constr) list
 
 exception NotationAsReferenceError of notation_as_reference_error
 

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -283,9 +283,16 @@ val toggle_notations : on:bool -> all:bool -> (glob_constr -> Pp.t) -> notation_
 (** Take a notation string and turn it into a notation key. eg. ["x +  y"] becomes ["_ + _"]. *)
 val interpret_notation_string : string -> string
 
-(** If head is true, also allows applied global references. *)
-val interp_notation_as_global_reference : ?loc:Loc.t -> head:bool -> (GlobRef.t -> bool) ->
-      notation_key -> delimiters option -> GlobRef.t
+type notation_as_reference_error =
+  | AmbiguousNotationAsReference of notation_key
+  | NotationNotReference of notation_key
+
+exception NotationAsReferenceError of notation_as_reference_error
+
+(** If head is true, also allows applied global references.
+    Raise NotationAsReferenceError if not resolvable as a global reference *)
+val interp_notation_as_global_reference : ?loc:Loc.t -> head:bool ->
+      (GlobRef.t -> bool) -> notation_key -> delimiters option -> GlobRef.t
 
 (** Declares and looks for scopes associated to arguments of a global ref *)
 val declare_arguments_scope :

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -470,6 +470,10 @@ let glob_constr_of_notation_constr ?loc x =
     glob_constr_of_notation_constr_with_binders ?loc (fun () id t -> ((),None,id,Explicit,t)) aux () x
   in aux () x
 
+let pr_notation_info prglob ntn c =
+  str (String.quote_coq_string ntn) ++ str " :=" ++ brk (1,2) ++
+  prglob (glob_constr_of_notation_constr c)
+
 (******************************************************************************)
 (* Translating a glob_constr into a notation, interpreting recursive patterns *)
 

--- a/interp/notation_ops.mli
+++ b/interp/notation_ops.mli
@@ -73,6 +73,9 @@ val glob_constr_of_notation_constr_with_binders : ?loc:Loc.t ->
 
 val glob_constr_of_notation_constr : ?loc:Loc.t -> notation_constr -> glob_constr
 
+val pr_notation_info :
+  (Glob_term.glob_constr -> Pp.t) -> Constrexpr.notation_key -> Notation_term.notation_constr -> Pp.t
+
 (** {5 Matching a notation pattern against a [glob_constr]} *)
 
 (** [match_notation_constr] matches a [glob_constr] against a notation

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -281,6 +281,13 @@ let pr_pconstructor = pr_puniverses pr_constructor
 let pr_evaluable_reference ref =
   pr_global (Tacred.global_of_evaluable_reference ref)
 
+let pr_notation_interpretation_env env sigma c =
+  Constrextern.without_symbols (pr_glob_constr_env env sigma) c
+
+let pr_notation_interpretation c =
+  let env = Global.env () in
+  pr_notation_interpretation_env env (Evd.from_env env) c
+
 (*let pr_glob_constr t =
   pr_lconstr (Constrextern.extern_glob_constr Id.Set.empty t)*)
 

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -158,6 +158,8 @@ val pr_pconstant : env -> evar_map -> pconstant -> Pp.t
 val pr_pinductive : env -> evar_map -> pinductive -> Pp.t
 val pr_pconstructor : env -> evar_map -> pconstructor -> Pp.t
 
+val pr_notation_interpretation_env : env -> evar_map -> glob_constr -> Pp.t
+val pr_notation_interpretation : glob_constr -> Pp.t
 
 (** Contexts *)
 

--- a/test-suite/output/smartlocate.out
+++ b/test-suite/output/smartlocate.out
@@ -1,0 +1,7 @@
+File "./output/smartlocate.v", line 1, characters 11-15:
+The command has indeed failed with message:
+Unable to unambiguously interpret "<>" as a reference. Found:
+Notation "x <> y" := (not (eq x y))
+File "./output/smartlocate.v", line 2, characters 11-26:
+The command has indeed failed with message:
+Unable to interpret "'nonexistent'" as a reference.

--- a/test-suite/output/smartlocate.v
+++ b/test-suite/output/smartlocate.v
@@ -1,0 +1,2 @@
+Fail Print "<>".
+Fail Print "'nonexistent'".

--- a/vernac/comSearch.ml
+++ b/vernac/comSearch.ml
@@ -76,14 +76,10 @@ let interp_search_item env sigma =
       when Id.is_valid_ident_part s && String.equal (String.drop_simple_quotes s) s ->
       GlobSearchString s
   | SearchString ((where,head),s,sc) ->
-      (try
-        let ref =
-          Notation.interp_notation_as_global_reference
-            ~head:false (fun _ -> true) s sc in
-        GlobSearchSubPattern (where,head,Pattern.PRef ref)
-      with UserError _ ->
-        user_err
-          (str "Unable to interpret " ++ quote (str s) ++ str " as a reference."))
+      let ref =
+        Notation.interp_notation_as_global_reference
+          ~head:false (fun _ -> true) s sc in
+      GlobSearchSubPattern (where,head,Pattern.PRef ref)
   | SearchKind k ->
      match kind_searcher k with
      | Inl k -> GlobSearchKind k

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1593,8 +1593,16 @@ let _ = CErrors.register_handler (wrap_unhandled vernac_interp_error_handler)
 let explain_notation_not_reference = function
   | Notation.AmbiguousNotationAsReference _ ->
     str "Ambiguous notation."
-  | Notation.NotationNotReference ntn ->
-    str "Unable to interpret " ++ quote (str ntn) ++ str " as a reference."
+  | Notation.NotationNotReference (env,sigma,ntn,ntns) ->
+    match ntns with
+    | [] -> str "Unable to interpret " ++ quote (str ntn) ++ str " as a reference."
+    | ntns ->
+      let f (df, r) =
+        str "Notation" ++ brk (1,2) ++
+        Notation_ops.pr_notation_info (Printer.pr_notation_interpretation_env env sigma) df r in
+      str "Unable to unambiguously interpret " ++ quote (str ntn) ++
+      str " as a reference. Found:" ++ fnl () ++
+      v 0 (hov 0 (prlist_with_sep spc f ntns))
 
 let _ = CErrors.register_handler (function
     | Notation.NotationAsReferenceError e -> Some (explain_notation_not_reference e)

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1587,3 +1587,15 @@ let rec vernac_interp_error_handler = function
     raise Unhandled
 
 let _ = CErrors.register_handler (wrap_unhandled vernac_interp_error_handler)
+
+(* Locating errors *)
+
+let explain_notation_not_reference = function
+  | Notation.AmbiguousNotationAsReference _ ->
+    str "Ambiguous notation."
+  | Notation.NotationNotReference ntn ->
+    str "Unable to interpret " ++ quote (str ntn) ++ str " as a reference."
+
+let _ = CErrors.register_handler (function
+    | Notation.NotationAsReferenceError e -> Some (explain_notation_not_reference e)
+    | _ -> None)


### PR DESCRIPTION
Examples:
```coq
Print "<>"
(* before: Unable to interpret "<>" as a reference. *)
(* after:
Unable to non-ambiguously interpret "<>" as a reference. Found:
Notation "x <> y" := (not (eq x y))
*)
```
Somehow, we could also write:
```
Unable to non-ambiguously interpret "<>" as a reference. Found:
Notation "x <> y" := (~ x = y)
```
Don't know which one is best.

Closes #18096

- [x] Added / updated **test-suite**.
- [x] Added **changelog**. (worth??)
