### PR TITLE
Fixes #5481: support for unification of universe variables in congruence and f_equal

### DIFF
--- a/doc/changelog/04-tactics/18106-master+fix5481-congruence-polyuniv.rst
+++ b/doc/changelog/04-tactics/18106-master+fix5481-congruence-polyuniv.rst
@@ -1,0 +1,7 @@
+- **Fixed:**
+  support for reasoning up to polymorphic universe variables in
+  :tacn:`congruence` and :tacn:`f_equal`
+  (`#18106 <https://github.com/coq/coq/pull/18106>`_,
+  fixes `#5481 <https://github.com/coq/coq/issues/5481>`_
+  and `#9979 <https://github.com/coq/coq/issues/9979>`_,
+  by Hugo Herbelin).

--- a/plugins/cc/ccproof.ml
+++ b/plugins/cc/ccproof.ml
@@ -152,6 +152,3 @@ let build_proof env sigma uf=
   function
   | `Prove (i,j) -> equal_proof env sigma uf i j
   | `Discr (i,ci,j,cj)-> ind_proof env sigma uf i ci j cj
-
-
-

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -331,13 +331,11 @@ let convert_gen pb x y =
   Proofview.Goal.enter begin fun gl ->
     match Tacmach.pf_apply (Reductionops.infer_conv ~pb) gl x y with
     | Some sigma -> Proofview.Unsafe.tclEVARS sigma
-    | None ->
-      let info = Exninfo.reify () in
-      Tacticals.tclFAIL ~info (str "Not convertible")
+    | None -> error NotConvertible
     | exception e when CErrors.noncritical e ->
       let _, info = Exninfo.capture e in
       (* FIXME: Sometimes an anomaly is raised from conversion *)
-      Tacticals.tclFAIL ~info (str "Not convertible")
+      error ?loc:(Loc.get_loc info) NotConvertible
 end
 
 let convert x y = convert_gen Conversion.CONV x y

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -31,6 +31,8 @@ val is_quantified_hypothesis : Id.t -> Proofview.Goal.t -> bool
 
 (** {6 Primitive tactics. } *)
 
+exception NotConvertible
+
 val introduction    : Id.t -> unit Proofview.tactic
 val convert_concl   : cast:bool -> check:bool -> types -> cast_kind -> unit Proofview.tactic
 val convert_hyp     : check:bool -> reorder:bool -> named_declaration -> unit Proofview.tactic

--- a/test-suite/bugs/bug_5481.v
+++ b/test-suite/bugs/bug_5481.v
@@ -1,0 +1,46 @@
+(* Bug #5481 *)
+
+Set Universe Polymorphism.
+
+Parameter P : Type -> Type -> Prop.
+Parameter A : Type.
+Lemma foo (B : Type) (H : P A B) : P A B.
+Proof.
+  congruence.
+Qed.
+
+(* An example with types hidden behind "match" *)
+
+Parameter b : unit.
+Lemma foo2 (B : Type) (H : (let () := b in P) A B) : (let () := b in P) A B.
+Proof.
+  congruence.
+Qed.
+
+(* Bug #9979, with f_equal *)
+
+Record Map(K V: Type) := {
+  rep: Type;
+  put: rep -> K -> V -> rep;
+}.
+
+Section Test.
+  Universes u1 u2 u3 u4 u5 u6.
+
+  Goal forall K V (M: Map K V) (k: K) (v: V) (m: rep K V M),
+      put@{u1 u2 u3} K V M m k v = put@{u4 u5 u6} K V M m k v.
+  Proof.
+    intros.
+    f_equal.
+  Qed.
+
+End Test.
+
+(* An example with unification of monomorphic universe levels *)
+
+Unset Universe Polymorphism.
+
+Lemma foo3 (B : Type) : Type.
+Proof.
+  congruence.
+Qed.

--- a/test-suite/output/unifconstraints.out
+++ b/test-suite/output/unifconstraints.out
@@ -68,3 +68,6 @@ h : P x
 Unable to unify "P x" with "?P x"
 (unable to find a well-typed instantiation for "?P": cannot ensure that
 "nat -> Type" is a subtype of "nat -> Prop").
+File "./output/unifconstraints.v", line 37, characters 5-15:
+The command has indeed failed with message:
+Tactic failure: congruence failed (cannot build a well-typed proof).

--- a/test-suite/output/unifconstraints.v
+++ b/test-suite/output/unifconstraints.v
@@ -27,3 +27,13 @@ Unset Printing Existential Instances.
    improve though and succeed) *)
 
 Fail Check fun (P : _ -> Type) (x:nat) (h:P x) => exist _ x (h : P x).
+
+(* A test about universe level unification in congruence *)
+
+Set Universe Polymorphism.
+Section S.
+Polymorphic Universes i j.
+Goal Type@{i} -> (Type@{j} : Type@{i}).
+Fail congruence.
+Abort.
+End S.


### PR DESCRIPTION
We hash declarations without their universe instances while the universe constraints are (anyway) reinferred at the time of building the proof.

Giving two arguments to `Ccalgo.Symb` as I did is a bit hackish. The alternative would be to have a hash-consing function that discards universes but I did not find one.

Fixes #5481
Fixes #9979

Now also added: unification of universe levels so that `congruence` works on e.g. `Type -> Type`, the same way as it works for any non-Type `T -> T`.

- [X] Added / updated **test-suite**.
- [x] Added **changelog**.
