### PR TITLE
Ltac2: warning when defining named type variables

### DIFF
--- a/doc/changelog/06-Ltac2-language/18118-ltac2-rigid-typ-var.rst
+++ b/doc/changelog/06-Ltac2-language/18118-ltac2-rigid-typ-var.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  explicit type variables are rigid, such that annotations like
+  `Ltac2 id (x:'a) := ...` ensure that `id` will be polymorphic.
+  Previously for instance `Ltac2 bad_id (x:'a) : 'b := x.` would be accepted
+  (`#18118 <https://github.com/coq/coq/pull/18118>`_,
+  by Gaëtan Gilbert).

--- a/test-suite/ltac2/typing.v
+++ b/test-suite/ltac2/typing.v
@@ -77,3 +77,10 @@ Ltac2 rec loop : 'a -> 'b := fun x => loop x.
 Fail Ltac2 rec loop2 : bool -> bool := fun x => if x then loop2 false else 0.
 
 Fail Ltac2 rec not_a_fun := ().
+
+(** Warning when defining Named type variables. *)
+
+Set Warnings "+ltac2-defined-named-type-variable".
+
+Fail Ltac2 foo (x:'a) : 'b := x.
+Fail Ltac2 foo (x:'a) : int := x.


### PR DESCRIPTION
If we want to build doc from code we need the annotated types to be accurate.

Notice how in the stdlib we had a couple less than accurate type annotations.

This differs from how ocaml does things but TBH I strongly dislike how ocaml does things in this case.

Overlays:
- https://github.com/mit-plv/coqutil/pull/96