### PR TITLE
CClosure: Add LRU cache to lazy `to_constr` calls 

### DIFF
--- a/dev/bench/bench.sh
+++ b/dev/bench/bench.sh
@@ -312,7 +312,7 @@ git clone -q --depth 1 -b "$old_coq_opam_archive_git_branch" "$old_coq_opam_arch
 new_coq_opam_archive_dir="$working_dir/new_coq_opam_archive"
 git clone -q --depth 1 -b "$new_coq_opam_archive_git_branch" "$new_coq_opam_archive_git_uri" "$new_coq_opam_archive_dir"
 
-initial_opam_packages="num ocamlfind dune"
+initial_opam_packages="num ocamlfind dune lru"
 
 # Create an opam root and install Coq
 # $1 = root_name {ex: NEW / OLD}

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -550,6 +550,7 @@ and comp_subs (el,u) (s,u') =
       | Some l -> l
       | None ->
         let l = lazy (to_constr (el,u) c) in
+        Cache.trim Cache.cache;
         Cache.add elem l Cache.cache;
         l
     ) el s, u'

--- a/kernel/dune
+++ b/kernel/dune
@@ -5,7 +5,7 @@
  (wrapped false)
  (modules_without_implementation values declarations entries)
  (modules (:standard \ genOpcodeFiles uint63_31 uint63_63 float64_31 float64_63))
- (libraries boot lib coqrun dynlink))
+ (libraries boot lib coqrun dynlink lru))
 
 (executable
   (name genOpcodeFiles)

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -154,14 +154,14 @@ let rec n_x_id ids n =
 
 let simpl_iter clause =
   reduce
-    (Lazy
+    (Lazy (true,
        { rBeta = true
        ; rMatch = true
        ; rFix = true
        ; rCofix = true
        ; rZeta = true
        ; rDelta = false
-       ; rConst = [EvalConstRef (const_of_ref (delayed_force iter_ref))] })
+       ; rConst = [EvalConstRef (const_of_ref (delayed_force iter_ref))] }))
     clause
 
 (* Others ugly things ... *)

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -367,7 +367,8 @@ GRAMMAR EXTEND Gram
       | IDENT "simpl"; d = delta_flag; po = OPT ref_or_pattern_occ -> { Simpl (all_with d,po) }
       | IDENT "cbv"; s = strategy_flag -> { Cbv s }
       | IDENT "cbn"; s = strategy_flag -> { Cbn s }
-      | IDENT "lazy"; s = strategy_flag -> { Lazy s }
+      | IDENT "lazy"; s = strategy_flag -> { Lazy (true, s) }
+      | IDENT "lazywhnf"; s = strategy_flag -> { Lazy (false, s) }
       | IDENT "compute"; delta = delta_flag -> { Cbv (all_with delta) }
       | IDENT "vm_compute"; po = OPT ref_or_pattern_occ -> { CbvVm po }
       | IDENT "native_compute"; po = OPT ref_or_pattern_occ -> { CbvNative po }
@@ -684,7 +685,9 @@ GRAMMAR EXTEND Gram
       | IDENT "cbn"; s = strategy_flag; cl = clause_dft_concl ->
           { CAst.make ~loc @@ TacAtom (TacReduce (Cbn s, cl)) }
       | IDENT "lazy"; s = strategy_flag; cl = clause_dft_concl ->
-          { CAst.make ~loc @@ TacAtom (TacReduce (Lazy s, cl)) }
+          { CAst.make ~loc @@ TacAtom (TacReduce (Lazy (true, s), cl)) }
+      | IDENT "lazywhnf"; s = strategy_flag; cl = clause_dft_concl ->
+          { CAst.make ~loc @@ TacAtom (TacReduce (Lazy (false, s), cl)) }
       | IDENT "compute"; delta = delta_flag; cl = clause_dft_concl ->
           { CAst.make ~loc @@ TacAtom (TacReduce (Cbv (all_with delta), cl)) }
       | IDENT "vm_compute"; po = OPT ref_or_pattern_occ; cl = clause_dft_concl ->

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -426,7 +426,7 @@ let intern_red_expr ist = function
   | Fold l -> Fold (List.map (intern_constr ist) l)
   | Cbv f -> Cbv (intern_flag ist f)
   | Cbn f -> Cbn (intern_flag ist f)
-  | Lazy f -> Lazy (intern_flag ist f)
+  | Lazy (b, f) -> Lazy (b, intern_flag ist f)
   | Pattern l -> Pattern (List.map (intern_constr_with_occurrences ist) l)
   | Simpl (f,o) ->
     Simpl (intern_flag ist f,

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -760,7 +760,7 @@ let interp_red_expr ist env sigma = function
     sigma , Fold l_interp
   | Cbv f -> sigma , Cbv (interp_flag ist env sigma f)
   | Cbn f -> sigma , Cbn (interp_flag ist env sigma f)
-  | Lazy f -> sigma , Lazy (interp_flag ist env sigma f)
+  | Lazy (b, f) -> sigma , Lazy (b, interp_flag ist env sigma f)
   | Pattern l ->
       let (sigma,l_interp) =
         Evd.MonadR.List.map_right

--- a/plugins/ltac2/tac2stdlib.ml
+++ b/plugins/ltac2/tac2stdlib.ml
@@ -315,7 +315,12 @@ let () =
   define "tac_cbn" (red_flags @-> clause @-> tac unit) Tac2tactics.cbn
 
 let () =
-  define "tac_lazy" (red_flags @-> clause @-> tac unit) Tac2tactics.lazy_
+  define "tac_lazy" (red_flags @-> clause @-> tac unit)
+    (Tac2tactics.lazy_ true)
+
+let () =
+  define "tac_lazy_whnf" (red_flags @-> clause @-> tac unit)
+    (Tac2tactics.lazy_ false)
 
 let () =
   define "tac_unfold"
@@ -360,7 +365,12 @@ let () =
   define "eval_cbn" (red_flags @-> constr @-> tac constr) Tac2tactics.eval_cbn
 
 let () =
-  define "eval_lazy" (red_flags @-> constr @-> tac constr) Tac2tactics.eval_lazy
+  define "eval_lazy" (red_flags @-> constr @-> tac constr)
+    (Tac2tactics.eval_lazy true)
+
+let () =
+  define "eval_lazy_whnf" (red_flags @-> constr @-> tac constr)
+    (Tac2tactics.eval_lazy false)
 
 let () =
   define "eval_unfold"

--- a/plugins/ltac2/tac2tactics.ml
+++ b/plugins/ltac2/tac2tactics.ml
@@ -242,11 +242,11 @@ let cbn flags cl =
   let flags = { flags with rConst } in
   Tactics.reduce (Cbn flags) cl
 
-let lazy_ flags cl =
+let lazy_ full flags cl =
   let cl = mk_clause cl in
   Proofview.Monad.List.map get_evaluable_reference flags.rConst >>= fun rConst ->
   let flags = { flags with rConst } in
-  Tactics.reduce (Lazy flags) cl
+  Tactics.reduce (Lazy (full, flags)) cl
 
 let unfold occs cl =
   let cl = mk_clause cl in
@@ -302,10 +302,10 @@ let eval_cbn flags c =
   let flags = { flags with rConst } in
   eval_fun (Cbn flags) c
 
-let eval_lazy flags c =
+let eval_lazy full flags c =
   Proofview.Monad.List.map get_evaluable_reference flags.rConst >>= fun rConst ->
   let flags = { flags with rConst } in
-  eval_fun (Lazy flags) c
+  eval_fun (Lazy (full, flags)) c
 
 let eval_unfold occs c =
   let map (gr, occ) =

--- a/plugins/ltac2/tac2tactics.mli
+++ b/plugins/ltac2/tac2tactics.mli
@@ -65,7 +65,7 @@ val cbv : GlobRef.t glob_red_flag -> clause -> unit tactic
 
 val cbn : GlobRef.t glob_red_flag -> clause -> unit tactic
 
-val lazy_ : GlobRef.t glob_red_flag -> clause -> unit tactic
+val lazy_ : bool -> GlobRef.t glob_red_flag -> clause -> unit tactic
 
 val unfold : (GlobRef.t * occurrences) list -> clause -> unit tactic
 
@@ -86,7 +86,7 @@ val eval_cbv : GlobRef.t glob_red_flag -> constr -> constr tactic
 
 val eval_cbn : GlobRef.t glob_red_flag -> constr -> constr tactic
 
-val eval_lazy : GlobRef.t glob_red_flag -> constr -> constr tactic
+val eval_lazy : bool -> GlobRef.t glob_red_flag -> constr -> constr tactic
 
 val eval_unfold : (GlobRef.t * occurrences) list -> constr -> constr tactic
 

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -1192,9 +1192,9 @@ let rec decompose_assum env sigma orig_goal =
 
 let tclFULL_BETAIOTA = Goal.enter begin fun gl ->
   let r, _ = Redexpr.reduction_of_red_expr (Goal.env gl)
-    Genredexpr.(Lazy {
+    Genredexpr.(Lazy (true, {
       rBeta=true; rMatch=true; rFix=true; rCofix=true;
-      rZeta=false; rDelta=false; rConst=[]}) in
+      rZeta=false; rDelta=false; rConst=[]})) in
   Tactics.e_reduct_in_concl ~cast:false ~check:false (r,Constr.DEFAULTcast)
 end
 

--- a/tactics/genredexpr.mli
+++ b/tactics/genredexpr.mli
@@ -41,7 +41,7 @@ type ('a, 'b, 'c, 'flags) red_expr_gen0 =
   | Simpl of 'flags * ('b, 'c) Util.union Locus.with_occurrences option
   | Cbv of 'flags
   | Cbn of 'flags
-  | Lazy of 'flags
+  | Lazy of bool * 'flags (* true = full, false = whnf *)
   | Unfold of 'b Locus.with_occurrences list
   | Fold of 'a list
   | Pattern of 'a Locus.with_occurrences list

--- a/tactics/ppred.ml
+++ b/tactics/ppred.ml
@@ -59,8 +59,10 @@ let pr_red_expr (pr_constr,pr_lconstr,pr_ref,pr_pattern) keyword = function
       keyword "compute"
     else
       hov 1 (keyword "cbv" ++ pr_red_flag pr_ref f)
-  | Lazy f ->
+  | Lazy (true, f) ->
     hov 1 (keyword "lazy" ++ pr_red_flag pr_ref f)
+  | Lazy (false, f) ->
+    hov 1 (keyword "lazywhnf" ++ pr_red_flag pr_ref f)
   | Cbn f ->
     hov 1 (keyword "cbn" ++ pr_red_flag pr_ref f)
   | Unfold l ->

--- a/tactics/redexpr.ml
+++ b/tactics/redexpr.ml
@@ -236,7 +236,7 @@ let rec eval_red_expr env = function
   Simpl (f, o)
 | Cbv f -> Cbv (make_flag env f)
 | Cbn f -> Cbn (make_flag env f)
-| Lazy f -> Lazy (make_flag env f)
+| Lazy (b, f) -> Lazy (b, make_flag env f)
 | ExtraRedExpr s ->
   begin match String.Map.find s !red_expr_tab with
   | e -> eval_red_expr env e
@@ -256,7 +256,8 @@ let reduction_of_red_expr_val = function
   | Cbv f -> (e_red (cbv_norm_flags f),DEFAULTcast)
   | Cbn f ->
      (e_red (Cbn.norm_cbn f), DEFAULTcast)
-  | Lazy f -> (e_red (clos_norm_flags f),DEFAULTcast)
+  | Lazy (true, f) -> (e_red (clos_norm_flags f),DEFAULTcast)
+  | Lazy (false, f) -> (e_red (clos_whd_flags f),DEFAULTcast)
   | Unfold ubinds -> (e_red (unfoldn (List.map out_with_occurrences ubinds)),DEFAULTcast)
   | Fold cl -> (e_red (fold_commands cl),DEFAULTcast)
   | Pattern lp -> (pattern_occs (List.map out_with_occurrences lp),DEFAULTcast)

--- a/tactics/redops.ml
+++ b/tactics/redops.ml
@@ -57,7 +57,7 @@ let map_red_expr_gen f g h = function
      Simpl (map_flags g flags, Option.map (map_occs (Util.map_union g h)) occs_o)
   | Unfold occs_l -> Unfold (List.map (map_occs g) occs_l)
   | Cbv flags -> Cbv (map_flags g flags)
-  | Lazy flags -> Lazy (map_flags g flags)
+  | Lazy (b, flags) -> Lazy (b, map_flags g flags)
   | CbvVm occs_o -> CbvVm (Option.map (map_occs (Util.map_union g h)) occs_o)
   | CbvNative occs_o -> CbvNative (Option.map (map_occs (Util.map_union g h)) occs_o)
   | Cbn flags -> Cbn (map_flags g flags)

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -999,7 +999,7 @@ let reduce redexp cl =
   let check = match redexp with Fold _ | Pattern _ -> true | _ -> false in
   let reorder = match redexp with
   | Fold _ | Pattern _ -> AnyHypConv
-  | Simpl (flags, _) | Cbv flags | Cbn flags | Lazy flags ->
+  | Simpl (flags, _) | Cbv flags | Cbn flags | Lazy (_, flags) ->
     if is_local_flag env flags then LocalHypConv else StableHypConv
   | Unfold flags ->
     if is_local_unfold env flags then LocalHypConv else StableHypConv

--- a/user-contrib/Ltac2/Std.v
+++ b/user-contrib/Ltac2/Std.v
@@ -158,6 +158,7 @@ Ltac2 @ external simpl : red_flags -> (pattern * occurrences) option -> clause -
 Ltac2 @ external cbv : red_flags -> clause -> unit := "coq-core.plugins.ltac2" "tac_cbv".
 Ltac2 @ external cbn : red_flags -> clause -> unit := "coq-core.plugins.ltac2" "tac_cbn".
 Ltac2 @ external lazy : red_flags -> clause -> unit := "coq-core.plugins.ltac2" "tac_lazy".
+Ltac2 @ external lazy_whnf : red_flags -> clause -> unit := "coq-core.plugins.ltac2" "tac_lazy_whnf".
 Ltac2 @ external unfold : (reference * occurrences) list -> clause -> unit := "coq-core.plugins.ltac2" "tac_unfold".
 Ltac2 @ external fold : constr list -> clause -> unit := "coq-core.plugins.ltac2" "tac_fold".
 Ltac2 @ external pattern : (constr * occurrences) list -> clause -> unit := "coq-core.plugins.ltac2" "tac_pattern".
@@ -171,6 +172,7 @@ Ltac2 @ external eval_simpl : red_flags -> (pattern * occurrences) option -> con
 Ltac2 @ external eval_cbv : red_flags -> constr -> constr := "coq-core.plugins.ltac2" "eval_cbv".
 Ltac2 @ external eval_cbn : red_flags -> constr -> constr := "coq-core.plugins.ltac2" "eval_cbn".
 Ltac2 @ external eval_lazy : red_flags -> constr -> constr := "coq-core.plugins.ltac2" "eval_lazy".
+Ltac2 @ external eval_lazy_whnf : red_flags -> constr -> constr := "coq-core.plugins.ltac2" "eval_lazy_whnf".
 Ltac2 @ external eval_unfold : (reference * occurrences) list -> constr -> constr := "coq-core.plugins.ltac2" "eval_unfold".
 Ltac2 @ external eval_fold : constr list -> constr -> constr := "coq-core.plugins.ltac2" "eval_fold".
 Ltac2 @ external eval_pattern : (constr * occurrences) list -> constr -> constr := "coq-core.plugins.ltac2" "eval_pattern".


### PR DESCRIPTION
The idea is that most terms appear in multiple closures and it is very likely that the lift and universe substitution are the same. Consider, for example, an `FApp` node that has plenty of `FCLOS` arguments which very likely share a big part of the items in their substitutions.

The MR currently includes an unrelated commit from #17839 that exposes a weak head version of `lazy` which is great for constructing pathological examples that require lots of work when reflecting from `fconstr` to `constr`. I've been using this example here:

```coq
From Coq Require Import Nat.
Fixpoint fac (n : nat) : nat :=
  match n return nat with
  | O | S O => n
  | S n => mult (S n) (fac n)
  end.

From Ltac2 Require Import Ltac2.
Ltac2 red_flags_all : Std.red_flags := {
  Std.rBeta  := true;
  Std.rDelta := true;
  Std.rMatch := true;
  Std.rFix   := true;
  Std.rCofix := true;
  Std.rZeta  := true;
  Std.rConst := []
}.
Optimize Heap.
Instructions Ltac2 Eval
  let t := Std.eval_lazy_whnf red_flags_all '(fac 3) in ().
```

For `fac 3` this MR demonstrates a 1/3 speedup, i.e. it takes about 0.6 times the the instructions that master takes. For `fac 22` this MR takes 0.00007 times the instructions that master takes. 