### PR TITLE
Don't reduce in Class_tactics.make_resolve_hyp

### DIFF
--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -412,16 +412,12 @@ let evars_to_goals p evm =
 let make_resolve_hyp env sigma st only_classes decl db =
   let id = NamedDecl.get_id decl in
   let cty = Evarutil.nf_evar sigma (NamedDecl.get_type decl) in
-  let rec iscl env ty =
+  let iscl env ty =
     let ctx, ar = decompose_prod_decls sigma ty in
       match EConstr.kind sigma (fst (decompose_app sigma ar)) with
       | Const (c,_) -> is_class (GlobRef.ConstRef c)
       | Ind (i,_) -> is_class (GlobRef.IndRef i)
-      | _ ->
-          let env' = push_rel_context ctx env in
-          let ty' = Reductionops.whd_all env' sigma ar in
-               if not (EConstr.eq_constr sigma ty' ar) then iscl env' ty'
-               else false
+      | _ -> false
   in
   let is_class = iscl env cty in
   let keep = not only_classes || is_class in


### PR DESCRIPTION
I have no idea why we reduced there. Isn't class hint matching syntactic?

Speeds up the apply from
https://github.com/HoTT/Coq-HoTT/pull/1779/files/47d19c5f895888b9f77927c0689efa4bcadf81ad#diff-6bf76176342d2eb14bca2f6d53a393d62a0b7fd3f414e21af791b6b05c5c08b9
(from 0.2s to not detectable)

Using kernel reduction while avoiding the reification back to constr
provides the same speedup AFAICT but why reduce when we don't have to?
