### PR TITLE
Fix CODEOWNERS for doc/stdlib.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -124,6 +124,7 @@
 ########## Standard library and plugins ##########
 
 /theories/         @coq/stdlib-maintainers
+/doc/stdlib/       @coq/stdlib-maintainers
 
 /theories/Classes/ @coq/typeclasses-maintainers
 


### PR DESCRIPTION
It never made much sense to have the code owners for this directory be the doc-maintainers while the actual content of the stdlib documentation is written within the .v files. In practice, this has just meant that doc-maintainers get a review request when adding or removing a file in the stdlib, which is a bit absurd.