### PR TITLE
Ltac2: use preterm in exact / eexact

### DIFF
--- a/doc/changelog/06-Ltac2-language/18157-ltac2-exact-preterm.rst
+++ b/doc/changelog/06-Ltac2-language/18157-ltac2-exact-preterm.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  Ltac2 `exact` and `eexact` elaborate their argument using the type of the goal as expected type,
+  instead of elaborating with no expected type then unifying the resulting type with the goal
+  (`#18157 <https://github.com/coq/coq/pull/18157>`_,
+  fixes `#12827 <https://github.com/coq/coq/issues/12827>`_,
+  by Gaëtan Gilbert).

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -32,6 +32,18 @@ let constr_flags =
     polymorphic = false;
   }
 
+let open_constr_use_classes_flags =
+  let open Pretyping in
+  {
+  use_coercions = true;
+  use_typeclasses = Pretyping.UseTC;
+  solve_unification_constraints = true;
+  fail_evar = false;
+  expand_evars = true;
+  program_mode = false;
+  polymorphic = false;
+  }
+
 let open_constr_no_classes_flags =
   let open Pretyping in
   {
@@ -738,23 +750,22 @@ let () =
     throw err_notfocussed
 
 (** preterm -> constr *)
+let () = define "constr_flags" (ret (repr_ext val_pretype_flags)) constr_flags
+
+let () = define "open_constr_flags" (ret (repr_ext val_pretype_flags)) open_constr_use_classes_flags
+
+let () = define "expected_istype" (ret (repr_ext val_expected_type)) IsType
+
+let () = define "expected_oftype" (constr @-> ret (repr_ext val_expected_type)) @@ fun c ->
+  OfType c
+
+let () = define "expected_without_type_constraint" (ret (repr_ext val_expected_type))
+    WithoutTypeConstraint
+
 let () =
-  define "constr_pretype" (repr_ext val_preterm @-> tac constr) @@ fun c ->
-  let open Pretyping in
-  let open Ltac_pretype in
+  define "constr_pretype" (repr_ext val_pretype_flags @-> repr_ext val_expected_type @-> repr_ext val_preterm @-> tac constr) @@ fun flags expected_type c ->
   let pretype env sigma =
-    (* For now there are no primitives to create preterms with a non-empty
-       closure. I do not know whether [closed_glob_constr] is really the type
-       we want but it does not hurt in the meantime. *)
-    let { closure; term } = c in
-    let vars = {
-      ltac_constrs = closure.typed;
-      ltac_uconstrs = closure.untyped;
-      ltac_idents = closure.idents;
-      ltac_genargs = closure.genargs;
-    } in
-    let flags = constr_flags in
-    let sigma, t = understand_ltac flags env sigma vars WithoutTypeConstraint term in
+    let sigma, t = Pretyping.understand_uconstr ~flags ~expected_type env sigma c in
     Proofview.Unsafe.tclEVARS sigma <*> Proofview.tclUNIT t
   in
   pf_apply ~catch_exceptions:true pretype

--- a/plugins/ltac2/tac2ffi.ml
+++ b/plugins/ltac2/tac2ffi.ml
@@ -118,6 +118,8 @@ let val_uint63 = Val.create "uint63"
 let val_float = Val.create "float"
 let val_ind_data : (Names.Ind.t * Declarations.mutual_inductive_body) Val.tag = Val.create "ind_data"
 let val_transparent_state : TransparentState.t Val.tag = Val.create "transparent_state"
+let val_pretype_flags = Val.create "pretype_flags"
+let val_expected_type = Val.create "expected_type"
 
 let extract_val (type a) (type b) (tag : a Val.tag) (tag' : b Val.tag) (v : b) : a =
 match Val.eq tag tag' with

--- a/plugins/ltac2/tac2ffi.mli
+++ b/plugins/ltac2/tac2ffi.mli
@@ -227,6 +227,8 @@ val val_free : Id.Set.t Val.tag
 val val_uint63 : Uint63.t Val.tag
 val val_float : Float64.t Val.tag
 val val_ltac1 : Geninterp.Val.t Val.tag
+val val_pretype_flags : Pretyping.inference_flags Val.tag
+val val_expected_type : Pretyping.typing_constraint Val.tag
 
 val val_ind_data : (Names.Ind.t * Declarations.mutual_inductive_body) Val.tag
 val val_transparent_state : TransparentState.t Val.tag

--- a/test-suite/bugs/bug_12827.v
+++ b/test-suite/bugs/bug_12827.v
@@ -1,0 +1,17 @@
+Existing Class True.
+Existing Instance I.
+
+(* ltac1 exact works *)
+Goal True.
+  exact _.
+Qed.
+
+Require Import Ltac2.Ltac2.
+Require Import Ltac2.Notations.
+
+Goal True.
+  exact _.
+  (* was: Error: Cannot infer this placeholder of type "True" (no type class instance
+found).
+   *)
+Qed.

--- a/test-suite/bugs/bug_17233.v
+++ b/test-suite/bugs/bug_17233.v
@@ -1,5 +1,10 @@
 Require Import Ltac2.Ltac2.
 
+(* exact0 at the time of the bug, with eexact part removed for simplicity *)
+Ltac2 exact0 c :=
+  Control.enter (fun _ =>
+      Control.with_holes c (fun c => Control.refine (fun _ => c))).
+
 Ltac2 Eval
   let x := constr:(0) in
   Constr.pretype preterm:($x).
@@ -7,9 +12,9 @@ Ltac2 Eval
 
 Ltac2 Eval
   let x := constr:(0) in
-  Constr.pretype preterm:(ltac2:(let y () := x in exact0 false y)).
+  Constr.pretype preterm:(ltac2:(let y () := x in exact0 y)).
 (* (* anomaly unbound variable x *) *)
 
-Notation "[ x ]" := ltac2:(exact0 false (fun ()  => Constr.pretype x)).
+Notation "[ x ]" := ltac2:(exact0 (fun ()  => Constr.pretype x)).
 
-Check ltac2:(let y := constr:(0) in exact0 false (fun () => open_constr:([ $y ]))).
+Check ltac2:(let y := constr:(0) in exact0 (fun () => open_constr:([ $y ]))).

--- a/test-suite/output/PrintGenarg.out
+++ b/test-suite/output/PrintGenarg.out
@@ -4,7 +4,6 @@ Ltac foo := let x := open_constr:(ltac:(exact 0)) in
 Ltac2 bar : unit -> unit
       bar :=
         fun _ =>
-        let x :=
-          open_constr:(ltac2:(let c := fun _ => open_constr:(0) in
-                              exact0 false c)) in
+        let x := open_constr:(ltac2:(let c := preterm:(0) in exact1 false c))
+          in
         ()

--- a/test-suite/output/bug_17594.out
+++ b/test-suite/output/bug_17594.out
@@ -2,7 +2,7 @@
 3
 2
 3
-File "./output/bug_17594.v", line 8, characters 2-102:
+File "./output/bug_17594.v", line 12, characters 19-20:
 The command has indeed failed with message:
 The term "0" has type "nat" while it is expected to have type "True".
 1
@@ -16,7 +16,7 @@ The term "0" has type "nat" while it is expected to have type "True".
 3
 2
 3
-File "./output/bug_17594.v", line 19, characters 2-115:
+File "./output/bug_17594.v", line 23, characters 19-20:
 The command has indeed failed with message:
 The term "0" has type "nat" while it is expected to have type "True".
 1

--- a/user-contrib/Ltac2/Constr.v
+++ b/user-contrib/Ltac2/Constr.v
@@ -140,7 +140,35 @@ Ltac2 @ external in_context : ident -> constr -> (unit -> unit) -> constr := "co
     focused goal [Γ, id : c ⊢ ?X] and returns [fun (id : c) => t] where [t] is
     the proof built by the tactic. *)
 
-Ltac2 @ external pretype : preterm -> constr := "coq-core.plugins.ltac2" "constr_pretype".
+Module Pretype.
+  Module Flags.
+    Ltac2 Type t.
+
+    Ltac2 @ external constr_flags : t := "coq-core.plugins.ltac2" "constr_flags".
+    (** Does not allow new unsolved evars. *)
+
+    Ltac2 @ external open_constr_flags : t := "coq-core.plugins.ltac2" "open_constr_flags".
+    (** Allows new unsolved evars. *)
+  End Flags.
+
+  Ltac2 Type expected_type.
+
+  Ltac2 @ external expected_istype : expected_type
+    := "coq-core.plugins.ltac2" "expected_istype".
+
+  Ltac2 @ external expected_oftype : constr -> expected_type
+    := "coq-core.plugins.ltac2" "expected_oftype".
+
+  Ltac2 @ external expected_without_type_constraint : expected_type
+    := "coq-core.plugins.ltac2" "expected_without_type_constraint".
+
+  Ltac2 @ external pretype : Flags.t -> expected_type -> preterm -> constr
+    := "coq-core.plugins.ltac2" "constr_pretype".
+  (** Pretype the provided preterm. Assumes the goal to be focussed. *)
+End Pretype.
+
+Ltac2 pretype (c : preterm) : constr :=
+  Pretype.pretype Pretype.Flags.constr_flags Pretype.expected_without_type_constraint c.
 (** Pretype the provided preterm. Assumes the goal to be focussed. *)
 
 


### PR DESCRIPTION
Fix #12827

The implementation uses a generalization of Constr.pretype which takes flags (an opaque type) and a typing constraint.

Changing `refine` is left to the future as the notation takes a tactic thunk at constr type so would be backwards incompatible.

Overlays:
- https://github.com/JasonGross/neural-net-coq-interp/pull/5 (backwards compatible)