### PR TITLE
Don't emit deprecated warnings in name generation

### DIFF
--- a/engine/namegen.ml
+++ b/engine/namegen.ml
@@ -80,7 +80,7 @@ let is_imported_ref = let open GlobRef in function
       let mp = Constant.modpath kn in is_imported_modpath mp
 
 let locate id =
-  match fst (Nametab.locate_extended_nowarn (qualid_of_ident id)) with
+  match Nametab.locate_extended_nowarn (qualid_of_ident id) with
   | TrueGlobal r -> r
   | Abbrev _ -> raise Not_found
 

--- a/engine/namegen.ml
+++ b/engine/namegen.ml
@@ -79,16 +79,21 @@ let is_imported_ref = let open GlobRef in function
   | ConstRef kn ->
       let mp = Constant.modpath kn in is_imported_modpath mp
 
+let locate id =
+  match fst (Nametab.locate_extended_nowarn (qualid_of_ident id)) with
+  | TrueGlobal r -> r
+  | Abbrev _ -> raise Not_found
+
 let is_global id =
   try
-    let ref = Nametab.locate (qualid_of_ident id) in
+    let ref = locate id in
     not (is_imported_ref ref)
   with Not_found ->
     false
 
 let is_constructor id =
   try
-    match Nametab.locate (qualid_of_ident id) with
+    match locate id with
       | GlobRef.ConstructRef _ -> true
       | _ -> false
   with Not_found ->

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -1336,12 +1336,12 @@ let intern_qualid ?(no_secvar=false) qid intern env ntnvars us args =
 
 let intern_qualid_for_pattern test_global intern_not qid pats =
   match Nametab.locate_extended_nowarn qid with
-  | TrueGlobal g, depr ->
+  | TrueGlobal g as xref ->
     test_global g;
-    depr |> Option.iter (fun depr -> Nametab.warn_deprecated_xref ?loc:qid.loc depr (TrueGlobal g));
+    Nametab.is_deprecated_xref xref |> Option.iter (fun depr -> Nametab.warn_deprecated_xref ?loc:qid.loc depr (TrueGlobal g));
     dump_extended_global qid.loc (TrueGlobal g);
     (g, false, Some [], pats)
-  | Abbrev kn, depr ->
+  | Abbrev kn as xref ->
     let filter (vars,a) =
       match a with
       | NRef (g,_) ->
@@ -1365,7 +1365,8 @@ let intern_qualid_for_pattern test_global intern_not qid pats =
       | _ -> None in
     match Abbreviation.search_filtered_abbreviation filter kn with
     | Some (g, pats1, pats2) ->
-      depr |> Option.iter (fun depr -> Nametab.warn_deprecated_xref ?loc:qid.loc depr (Abbrev kn));
+      Nametab.is_deprecated_xref xref
+      |> Option.iter (fun depr -> Nametab.warn_deprecated_xref ?loc:qid.loc depr (Abbrev kn));
       dump_extended_global qid.loc (Abbrev kn);
       (g, true, pats1, pats2)
     | None -> raise Not_found

--- a/library/nametab.ml
+++ b/library/nametab.ml
@@ -596,12 +596,12 @@ let is_deprecated_xref xref = Globnames.ExtRefMap.find_opt xref !the_globdeprtab
 
 let locate_extended_nowarn qid =
   let xref = ExtRefTab.locate qid !the_ccitab in
-  let depr = is_deprecated_xref xref in
-  xref, depr
+  xref
 
 (* This should be used when abbreviations are allowed *)
 let locate_extended qid =
-  let xref, depr = locate_extended_nowarn qid in
+  let xref = locate_extended_nowarn qid in
+  let depr = is_deprecated_xref xref in
   let () = depr |> Option.iter (fun depr ->
       warn_deprecated_xref ?loc:qid.loc depr xref)
   in

--- a/library/nametab.mli
+++ b/library/nametab.mli
@@ -135,7 +135,7 @@ val locate_module : qualid -> ModPath.t
 val locate_section : qualid -> DirPath.t
 val locate_universe : qualid -> Univ.UGlobal.t
 
-val locate_extended_nowarn : qualid -> Globnames.extended_global_reference * Deprecation.t option
+val locate_extended_nowarn : qualid -> Globnames.extended_global_reference
 
 (** Remove the binding to an abbreviation *)
 

--- a/test-suite/bugs/bug_18133.v
+++ b/test-suite/bugs/bug_18133.v
@@ -1,0 +1,12 @@
+Set Warnings "+all".
+#[deprecated(since="1")] Notation a := id.
+
+Goal False.
+Proof.
+let x := fresh "a" in
+idtac.
+(* In 8.18.0, it was:
+Warning: Notation a is deprecated since 1.
+[deprecated-syntactic-definition-since-1,deprecated-since-1,deprecated-syntactic-definition,deprecated,default]
+*)
+Abort.


### PR DESCRIPTION
Fix #18133   

First commit is backportable.