### PR TITLE
bench plotter: set max host connections (avoid spamming gitlab)

### DIFF
--- a/dev/bench/plotter
+++ b/dev/bench/plotter
@@ -60,6 +60,8 @@ os.makedirs(cachedir, exist_ok=True)
 print ('Downloading job logs.')
 
 m = pycurl.CurlMulti()
+m.setopt(pycurl.M_MAX_HOST_CONNECTIONS, 8)
+
 files=[]
 
 for _, job in benches:


### PR DESCRIPTION
I also need to fix this script to stop assuming gitlab.com