### PR TITLE
Fix FFi usage in coq_interp.c

### DIFF
--- a/kernel/byterun/coq_interp.c
+++ b/kernel/byterun/coq_interp.c
@@ -2006,8 +2006,9 @@ value  coq_interprete_ml(value tcode, value a, value t, value g, value e, value 
   // Registering the other arguments w.r.t. the OCaml GC is done by coq_interprete
   CAMLparam1(tcode);
   print_instr("coq_interprete");
-  CAMLreturn (coq_interprete(Code_val(tcode), a, t, g, e, Long_val(ea)));
+  value res = coq_interprete(Code_val(tcode), a, t, g, e, Long_val(ea));
   print_instr("end coq_interprete");
+  CAMLreturn(res);
 }
 
 value coq_interprete_byte(value* argv, int argn){


### PR DESCRIPTION
The code in question is very suspicious and the fix seems straightforward, although I doubt anyone suffered from a bug there.