### PR TITLE
[stdlib] several NoDup lemmas

### DIFF
--- a/doc/changelog/11-standard-library/18172-NoDup_lemmas.rst
+++ b/doc/changelog/11-standard-library/18172-NoDup_lemmas.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  lemmas :g:`NoDup_app`, :g:`NoDup_iff_ForallOrdPairs`, :g:`NoDup_map_NoDup_ForallPairs` and :g:`NoDup_concat`
+  (`#18172 <https://github.com/coq/coq/pull/18172>`_,
+  by Stefan Haani and Andrej Dudenhefner).

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -3177,6 +3177,7 @@ Proof.
   apply not_iff_compat, in_flat_map_Exists.
 Qed.
 
+
 Section Forall2.
 
   (** [Forall2]: stating that elements of two lists are pairwise related. *)
@@ -3323,21 +3324,21 @@ Section ForallPairs.
   Qed.
 End ForallPairs.
 
-Lemma ForallOrdPairs_NoDup [A] (l: list A):
-  ForallOrdPairs (fun a b => a <> b) l <-> NoDup l.
+Lemma NoDup_iff_ForallOrdPairs [A] (l: list A):
+  NoDup l <-> ForallOrdPairs (fun a b => a <> b) l.
 Proof.
   split; intro H.
-  - induction H as [|a l H1 H2]; constructor.
-    + rewrite Forall_forall in H1. intro E.
-      contradiction (H1 a E). reflexivity.
-    + assumption.
   - induction H; constructor.
     + apply Forall_forall.
       intros y Hy ->. contradiction.
     + assumption.
+  - induction H as [|a l H1 H2]; constructor.
+    + rewrite Forall_forall in H1. intro E.
+      contradiction (H1 a E). reflexivity.
+    + assumption.
 Qed.
 
-Lemma ForallPairs_inj_map_NoDup [A B] (f: A->B) (l: list A) :
+Lemma NoDup_map_NoDup_ForallPairs [A B] (f: A->B) (l: list A) :
   ForallPairs (fun x y => f x = f y -> x = y) l -> NoDup l -> NoDup (map f l).
 Proof.
   intros Hinj Hl.

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -3177,29 +3177,6 @@ Proof.
   apply not_iff_compat, in_flat_map_Exists.
 Qed.
 
-(** A stronger version of FinFun.Injective_map_NoDup *)
-
-Definition InjectiveOn [A B] (P: A -> Prop) (f: A->B) :=
-  forall x y: A, P x -> P y -> f x = f y -> x = y.
-
-Lemma InjectiveOn_map_NoDup [A B] (P: A->Prop) (f: A->B) (l: list A) :
- InjectiveOn P f -> Forall P l -> NoDup l -> NoDup (map f l).
-Proof.
- intros HInj Pl Hl.
- induction Hl as [|x l H1 H2 IH]; [constructor|].
- cbn. constructor.
- - intros Hf. apply H1.
-   apply in_map_iff in Hf as [y [Heq Hy]].
-   enough (x = y) as H.
-   + rewrite H. assumption.
-   + apply HInj.
-     * apply Forall_inv in Pl. assumption.
-     * apply Forall_inv_tail in Pl. rewrite Forall_forall in Pl.
-       apply Pl. assumption.
-     * symmetry. assumption.
- - apply IH. apply Forall_inv_tail in Pl. assumption.
-Qed.
-
 Section Forall2.
 
   (** [Forall2]: stating that elements of two lists are pairwise related. *)
@@ -3358,6 +3335,18 @@ Proof.
     + apply Forall_forall.
       intros y Hy ->. contradiction.
     + assumption.
+Qed.
+
+Lemma ForallPairs_inj_map_NoDup [A B] (f: A->B) (l: list A) :
+  ForallPairs (fun x y => f x = f y -> x = y) l -> NoDup l -> NoDup (map f l).
+Proof.
+  intros Hinj Hl.
+  induction Hl as [|x ?? _ IH]; cbn; constructor.
+  - intros [y [??]]%in_map_iff.
+    destruct (Hinj y x); cbn; auto.
+  - apply IH.
+    intros x' y' Hx' Hy'.
+    now apply Hinj; right.
 Qed.
 
 Lemma NoDup_concat [A] (L: list (list A)):


### PR DESCRIPTION
This PR adds following lemmas about `NoDup`:
```coq
NoDup_app: NoDup l1 -> NoDup l2 -> (forall a, In a l1 -> ~ In a l2) -> NoDup (l1 ++ l2).
InjectiveOn_map_NoDup: InjectiveOn P f -> Forall P l -> NoDup l -> NoDup (map f l).
ForallOrdPairs_NoDup: ForallOrdPairs (fun a b => a <> b) l <-> NoDup l.
NoDup_concat: Forall NoDup A L -> ForallOrdPairs (fun l1 l2 => forall a, In a l1 -> ~ In a l2) L -> NoDup (concat L).
```
The last lemma was useful to me for arguing about `NoDup (flat_map ...)` using `flat_map_concat_map`.