### PR TITLE
[stdlib] well-founded list extension

### DIFF
--- a/doc/changelog/11-standard-library/18183-lt_list.rst
+++ b/doc/changelog/11-standard-library/18183-lt_list.rst
@@ -1,0 +1,6 @@
+- **Added:**
+  well-founded list extension ``list_ext`` of a well-founded relation in ``Coq.Wellfounded.List_Extension``, including infrastructure lemmas.
+  It can be used for well-foundedness proofs such as ``wf_lex_exp`` in ``Coq.Wellfounded.Lexicographic_Exponentiation``.
+  Also added lemma ``Acc_simulation`` and ``wf_simulation`` to ``Coq.Wellfounded.Inverse_Image``, and lemma ``clos_t_clos_rt`` to ``Coq.Relations.Operators_Properties``
+  (`#18183 <https://github.com/coq/coq/pull/18183>`_,
+  by Andrej Dudenhefner).

--- a/doc/stdlib/index-list.html.template
+++ b/doc/stdlib/index-list.html.template
@@ -449,6 +449,7 @@ through the <tt>Require Import</tt> command.</p>
     theories/Wellfounded/Inverse_Image.v
     theories/Wellfounded/Lexicographic_Exponentiation.v
     theories/Wellfounded/Lexicographic_Product.v
+    theories/Wellfounded/List_Extension.v
     theories/Wellfounded/Transitive_Closure.v
     theories/Wellfounded/Union.v
     theories/Wellfounded/Wellfounded.v

--- a/theories/Relations/Operators_Properties.v
+++ b/theories/Relations/Operators_Properties.v
@@ -85,6 +85,14 @@ Section Properties.
       - constructor 2.
     Qed.
 
+    Lemma clos_t_clos_rt :
+      inclusion (clos_trans R) (clos_refl_trans R).
+    Proof.
+      induction 1 as [? ?| ].
+      - constructor. auto.
+      - econstructor 3; eassumption.
+    Qed.
+
     Lemma clos_rt_t : forall x y z,
       clos_refl_trans R x y -> clos_trans R y z ->
       clos_trans R x z.

--- a/theories/Wellfounded/List_Extension.v
+++ b/theories/Wellfounded/List_Extension.v
@@ -1,0 +1,137 @@
+Require Import List.
+Require Import Relation_Operators Operators_Properties.
+Import ListNotations.
+
+(** Author: Andrej Dudenhefner *)
+
+Section WfList_Extension.
+
+  Variable A : Type.
+  Variable ltA : A -> A -> Prop.
+
+  (*
+    List extension of the relation ltA
+    see relation ">_red" [1] for which the transitive closure is the multiset ordering [1, Lemma 2]
+
+    [1] Solange Coupet-Grimal, William Delobel:
+        An effective proof of the well-foundedness of the multiset path ordering.
+        Applicable Algebra in Engineering, Communication and Computing 17(6): 453-469 (2006)
+
+    Intuition: to reduce a list, replace one element with zero or more smaller elements.
+        For example, with Nat.lt, [2, 2] > [1, 1, 0, 2] > [1, 1, 0] > [1, 0] > [0, 0, 0] > [0, 0] > [0] > [].
+  *)
+  Inductive list_ext : list A -> list A -> Prop :=
+    | list_ext_intro a (bs : list A) l1 l2 :
+        Forall (fun b => ltA b a) bs -> list_ext (l1 ++ bs ++ l2) (l1 ++ a :: l2).
+
+  Lemma list_ext_inv l l' : list_ext l l' ->
+    exists a bs l1 l2, l = l1 ++ bs ++ l2 /\ l' = l1 ++ a :: l2 /\ Forall (fun b => ltA b a) bs.
+  Proof.
+    intros H. destruct H.
+    now repeat econstructor.
+  Qed.
+
+  Lemma list_ext_nil_r l : not (list_ext l []).
+  Proof.
+    now intros [? [? [[|??] [? [? [? ?]]]]]]%list_ext_inv.
+  Qed.
+
+  Lemma Acc_list_ext_app l1 l2 : Acc list_ext l1 -> Acc list_ext l2 -> Acc list_ext (l1 ++ l2).
+  Proof.
+    intros H. revert l2. induction H as [l1 _ IH1].
+    intros l2 H. induction H as [l2 Hl2 IH2].
+    constructor. intros l [a [bs [l'1 [l'2 [? [E ?]]]]]]%list_ext_inv.
+    apply app_eq_app in E as [l'' [[? Hl'']|[? ?]]]; subst.
+    - destruct l'' as [|??]; cbn in Hl''.
+      + rewrite app_nil_r in IH2.
+        apply IH2. subst.
+        now apply (list_ext_intro a bs nil).
+      + injection Hl'' as [=? ?]. subst.
+        rewrite !app_assoc. apply IH1.
+        * rewrite <- !app_assoc. now constructor.
+        * constructor. now apply Hl2.
+    - rewrite <- !app_assoc.
+      apply IH2. now constructor.
+  Defined.
+
+  Lemma Acc_list_ext l : Forall (Acc ltA) l -> Acc list_ext l.
+  Proof.
+    intros H. induction H as [|a l Ha ??].
+    - constructor. now intros ? ?%list_ext_nil_r.
+    - apply (Acc_list_ext_app [_]); [|assumption].
+      clear -Ha. induction Ha as [a _ IH].
+      constructor. intros l H%list_ext_inv.
+      destruct H as [a' [bs [[|? [|? ?]] [[|??] [E1 [E2 Hbs]]]]]]; [|easy..].
+      cbn in *. injection E2 as [= E2]. subst.
+      rewrite app_nil_r. induction Hbs.
+      + constructor. now intros ? ?%list_ext_nil_r.
+      + now apply (Acc_list_ext_app [_]); [apply IH|].
+  Defined.
+
+  Theorem wf_list_ext : well_founded ltA -> well_founded list_ext.
+  Proof.
+    intros H l. apply Acc_list_ext.
+    apply Forall_forall. intros. now apply H.
+  Defined.
+
+  (* Transitive closure of list extension *)
+  #[local] Notation "list_ext ^+" := (clos_trans (list A) list_ext).
+  (* Reflexive transitive closure of list extension *)
+  #[local] Notation "list_ext ^*" := (clos_refl_trans (list A) list_ext).
+
+  Lemma clos_trans_list_ext_nil_l l : l <> [] -> list_ext ^+ [] l.
+  Proof.
+    induction l as [|a l IH]; [easy|].
+    intros _. destruct l as [|a' l].
+    - apply t_step. now apply (list_ext_intro a [] []).
+    - eapply t_trans.
+      + now apply IH.
+      + apply t_step.
+        now apply (list_ext_intro a [] [] (_ :: _)).
+  Qed.
+
+  Lemma list_ext_app_r l1 l2 l : list_ext l1 l2 -> list_ext (l1 ++ l) (l2 ++ l).
+  Proof.
+    intros [] *. rewrite <- !app_assoc. now constructor.
+  Qed.
+
+  Lemma list_ext_app_l l l1 l2 : list_ext l1 l2 -> list_ext (l ++ l1) (l ++ l2).
+  Proof.
+    intros [a bs l'1 l'2 H]. rewrite !(app_assoc l l'1). now constructor.
+  Qed.
+
+  Lemma clos_refl_trans_list_ext_app_r l1 l2 l : list_ext ^* l1 l2 -> list_ext ^* (l1 ++ l) (l2 ++ l).
+  Proof.
+    intros H. induction H; intros.
+    - apply rt_step. now apply list_ext_app_r.
+    - now constructor.
+    - eapply rt_trans; eassumption.
+  Qed.
+
+  Lemma clos_refl_trans_list_ext_app_l l l1 l2 : list_ext ^* l1 l2 -> list_ext ^* (l ++ l1) (l ++ l2).
+  Proof.
+    intros H. induction H; intros.
+    - apply rt_step. now apply list_ext_app_l.
+    - now constructor.
+    - eapply rt_trans; eassumption.
+  Qed.
+
+  Lemma clos_trans_list_ext_app_l l1 l2 l3 l4 : list_ext ^+ l1 l3 -> list_ext ^* l2 l4 -> list_ext ^+ (l1 ++ l2) (l3 ++ l4).
+  Proof.
+    intros H ?. eapply clos_rt_t.
+    - apply clos_refl_trans_list_ext_app_l. eassumption.
+    - induction H; intros.
+      + apply t_step. now apply list_ext_app_r.
+      + eapply t_trans; eassumption.
+  Qed.
+
+  Lemma clos_trans_list_ext_app_r l1 l2 l3 l4 : list_ext ^* l1 l3 -> list_ext ^+ l2 l4 -> list_ext ^+(l1 ++ l2) (l3 ++ l4).
+  Proof.
+    intros ? H. eapply clos_rt_t.
+    - apply clos_refl_trans_list_ext_app_r. eassumption.
+    - induction H; intros.
+      + apply t_step. now apply list_ext_app_l.
+      + eapply t_trans; eassumption.
+  Qed.
+
+End WfList_Extension.

--- a/theories/Wellfounded/Wellfounded.v
+++ b/theories/Wellfounded/Wellfounded.v
@@ -13,7 +13,7 @@ Require Export Inclusion.
 Require Export Inverse_Image.
 Require Export Lexicographic_Exponentiation.
 Require Export Lexicographic_Product.
+Require Export List_Extension.
 Require Export Transitive_Closure.
 Require Export Union.
 Require Export Well_Ordering.
-


### PR DESCRIPTION
Added the following results
- well-founded list extension `list_ext` of a well-founded relation (lemma `wf_list_ext`)
- infrastructure lemmas `list_ext_inv`, `list_ext_nil_r`, `list_ext_Acc_app`, `Acc_list_ext`, `clos_trans_list_ext_nil_l`, `list_ext_app_l`, `list_ext_app_r`, `clos_refl_trans_list_ext_app_l`, `clos_refl_trans_list_ext_app_r`, `clos_trans_list_ext_app_l`, `clos_trans_list_ext_app_r` 
- lemma `wf_clos_trans_inverse_rel` for well-foundedness proofs
- lemma `clos_t_clos_rt` showing inclusion of transitive closure in reflexive, transitive closure

List extension is a list-variant of the finite multiset extension.
It is easy to use the general results `wf_clos_trans_inverse_rel` and `wf_list_ext` for further well-foundedness results.
One example is the now simplified well-foundedness proof `wf_lex_exp` of lexicographic exponentiation.
Parts of [coq-library-undecidability](https://github.com/uds-psl/coq-library-undecidability/blob/d295433e9f9bf5501e17736c1263b0e4b77007c6/theories/MinskyMachines/Deciders/MPM2_HALT_dec.v#L402) would also profit from this.
Of course, applications of finite multiset extension can use list extension.

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.

<!-- If this breaks external libraries or plugins in CI: -->
<!-- - [ ] Opened **overlay** pull requests. -->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
