### PR TITLE
Change Menhir branch target in ci-basic_overlay.sh

### DIFF
--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -249,7 +249,7 @@ project reduction_effects "https://github.com/coq-community/reduction-effects" "
 # menhirlib
 ########################################################################
 # Note: menhirlib is now in subfolder coq-menhirlib of menhir
-project menhirlib "https://gitlab.inria.fr/fpottier/menhir" "20220210"
+project menhirlib "https://gitlab.inria.fr/fpottier/menhir" "master"
 
 ########################################################################
 # coq-neural-net-interp

--- a/dev/ci/ci-menhir.sh
+++ b/dev/ci/ci-menhir.sh
@@ -10,6 +10,8 @@ git_download menhirlib
 if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
 
 ( cd "${CI_BUILD_DIR}/menhirlib"
+  sed -i.bak "s/unreleased/$(date +%Y%m%d)/" dune-project
+  echo "Definition require_$(date +%Y%m%d) := tt." > coq-menhirlib/src/Version.v
   dune build @install -p menhirLib,menhirSdk,menhir
   dune install -p menhirLib,menhirSdk,menhir menhir menhirSdk menhirLib --prefix="$CI_INSTALL_DIR"
 


### PR DESCRIPTION
The previous target for menhir in CI was actually a tag (20220210). I changed it to "master" which is the default branch here: https://gitlab.inria.fr/fpottier/menhir