### PR TITLE
Support for weak cbv

### DIFF
--- a/dev/ci/user-overlays/18190-herbelin-master+weak-cbv.sh
+++ b/dev/ci/user-overlays/18190-herbelin-master+weak-cbv.sh
@@ -1,0 +1,2 @@
+overlay elpi https://github.com/herbelin/coq-elpi coq-master+adapt-coq-pr18190-whd-cbv 18190 master+weak-cbv
+overlay equations https://github.com/herbelin/Coq-Equations master+adapt-coq-pr18190-whd-cbv 18190 master+weak-cbv

--- a/doc/changelog/04-tactics/17503-redexpr.rst
+++ b/doc/changelog/04-tactics/17503-redexpr.rst
@@ -1,6 +1,7 @@
 - **Added:**
-  :tacn:`lazy`, :tacn:`simpl` and :tacn:`cbn` and the associated :cmd:`Eval` and :tacn:`eval` reductions
-  learnt to do head reduction when given flag `head`
+  :tacn:`lazy`, :tacn:`simpl`, :tacn:`cbn` and :tacn:`cbv` and the associated :cmd:`Eval`
+  and :tacn:`eval` reductions learned to do head reduction when given flag `head`
   (eg `Eval lazy head in (fun x => Some ((fun y => y) x)) 0` produces `Some ((fun y => y) 0)`)
   (`#17503 <https://github.com/coq/coq/pull/17503>`_,
-  by Gaëtan Gilbert).
+  by Gaëtan Gilbert; :tacn:`cbv` case added in `#18190 <https://github.com/coq/coq/pull/18190>`_,
+  by Hugo Herbelin).

--- a/doc/sphinx/proofs/writing-proofs/equality.rst
+++ b/doc/sphinx/proofs/writing-proofs/equality.rst
@@ -493,9 +493,9 @@ which reduction engine to use.  See :ref:`type-cast`.)  For example:
    .. prodn::
       reductions ::= {+ @reduction }
       | {? head } @delta_reductions
-      reduction ::= beta
+      reduction ::= head
+      | beta
       | delta {? @delta_reductions }
-      | head
       | match
       | fix
       | cofix
@@ -508,8 +508,8 @@ which reduction engine to use.  See :ref:`type-cast`.)  For example:
    then only the named reductions are applied.  The reductions include:
 
    `head`
-     Do only head reduction, without going under binders.  Only
-     supported by :tacn:`simpl`, :tacn:`cbn` and :tacn:`lazy`.
+     Do only head reduction, without going under binders.
+     Supported by :tacn:`simpl`, :tacn:`cbv`, :tacn:`cbn` and :tacn:`lazy`.
      If this is the only specified reduction, all other reductions are applied.
 
    `beta`

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -506,9 +506,9 @@ reductions: [
 ]
 
 reduction: [
+| "head"
 | "beta"
 | "delta" OPT delta_reductions
-| "head"
 | "match"
 | "fix"
 | "cofix"

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -999,7 +999,7 @@ let prove_princ_for_struct (evd : Evd.evar_map ref) interactive_proof fun_num
         match body.Declarations.const_body with
         | Def body ->
           let sigma = Evd.from_env env in
-          Tacred.cbv_norm_flags
+          Tacred.cbv_norm_flags ~strong:true
             (RedFlags.mkflags [RedFlags.fZETA])
             env sigma (EConstr.of_constr body)
         | Undef _ | Primitive _ | OpaqueDef _ -> user_err Pp.(str "Cannot define a principle over an axiom ")

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -1223,7 +1223,7 @@ let get_funs_constant mp =
       match body.Declarations.const_body with
       | Def body ->
         let body =
-          Tacred.cbv_norm_flags
+          Tacred.cbv_norm_flags ~strong:true
             (RedFlags.mkflags [RedFlags.fZETA])
             env
             (Evd.from_env env)

--- a/pretyping/cbv.mli
+++ b/pretyping/cbv.mli
@@ -17,5 +17,5 @@ open Environ
 (** Entry point for cbv normalization of a constr *)
 type cbv_infos
 
-val create_cbv_infos : RedFlags.reds -> env -> Evd.evar_map -> cbv_infos
+val create_cbv_infos : RedFlags.reds -> strong:bool -> env -> Evd.evar_map -> cbv_infos
 val cbv_norm         : cbv_infos -> constr -> constr

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -1185,8 +1185,10 @@ let cbv_norm_flags flags ~strong env sigma t =
 let cbv_beta = cbv_norm_flags RedFlags.beta ~strong:true
 let cbv_betaiota = cbv_norm_flags RedFlags.betaiota ~strong:true
 let cbv_betadeltaiota env sigma = cbv_norm_flags RedFlags.all env sigma ~strong:true
+let whd_cbv_betadeltaiota env sigma = cbv_norm_flags RedFlags.all env sigma ~strong:false
 
-let compute env sigma t = cbv_betadeltaiota env sigma t
+let whd_compute = whd_cbv_betadeltaiota
+let compute = cbv_betadeltaiota
 
 (* Pattern *)
 

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -1179,14 +1179,14 @@ let fold_commands cl env sigma c =
 
 
 (* call by value reduction functions *)
-let cbv_norm_flags flags env sigma t =
-  Cbv.(cbv_norm (create_cbv_infos flags env sigma) t)
+let cbv_norm_flags flags ~strong env sigma t =
+  Cbv.(cbv_norm (create_cbv_infos flags ~strong env sigma) t)
 
-let cbv_beta = cbv_norm_flags RedFlags.beta
-let cbv_betaiota = cbv_norm_flags RedFlags.betaiota
-let cbv_betadeltaiota env sigma = cbv_norm_flags RedFlags.all env sigma
+let cbv_beta = cbv_norm_flags RedFlags.beta ~strong:true
+let cbv_betaiota = cbv_norm_flags RedFlags.betaiota ~strong:true
+let cbv_betadeltaiota env sigma = cbv_norm_flags RedFlags.all env sigma ~strong:true
 
-let compute = cbv_betadeltaiota
+let compute env sigma t = cbv_betadeltaiota env sigma t
 
 (* Pattern *)
 

--- a/pretyping/tacred.mli
+++ b/pretyping/tacred.mli
@@ -81,7 +81,7 @@ val pattern_occs : (occurrences * constr) list -> e_reduction_function
 (** Rem: Lazy strategies are defined in Reduction *)
 
 (** Call by value strategy (uses Closures) *)
-val cbv_norm_flags : RedFlags.reds ->  reduction_function
+val cbv_norm_flags : RedFlags.reds -> strong:bool -> reduction_function
   val cbv_beta : reduction_function
   val cbv_betaiota : reduction_function
   val cbv_betadeltaiota :  reduction_function

--- a/pretyping/tacred.mli
+++ b/pretyping/tacred.mli
@@ -85,6 +85,7 @@ val cbv_norm_flags : RedFlags.reds -> strong:bool -> reduction_function
   val cbv_beta : reduction_function
   val cbv_betaiota : reduction_function
   val cbv_betadeltaiota :  reduction_function
+  val whd_compute :  reduction_function
   val compute :  reduction_function  (** = [cbv_betadeltaiota] *)
 
 (** [reduce_to_atomic_ind env sigma t] puts [t] in the form [t'=(I args)]

--- a/proofs/tacmach.ml
+++ b/proofs/tacmach.ml
@@ -87,6 +87,7 @@ let pf_hnf_type_of gl t =
   pf_whd_all gl (pf_get_type_of gl t)
 
 let pf_compute gl t = pf_apply compute gl t
+let pf_whd_compute gl t = pf_apply whd_compute gl t
 
 let pf_nf_evar gl t = nf_evar (project gl) t
 

--- a/proofs/tacmach.mli
+++ b/proofs/tacmach.mli
@@ -48,6 +48,7 @@ val pf_hnf_constr : Proofview.Goal.t -> constr -> types
 val pf_hnf_type_of : Proofview.Goal.t -> constr -> types
 
 val pf_compute : Proofview.Goal.t -> constr -> constr
+val pf_whd_compute : Proofview.Goal.t -> constr -> constr
 
 val pf_nf_evar : Proofview.Goal.t -> constr -> constr
 

--- a/tactics/eqdecide.ml
+++ b/tactics/eqdecide.ml
@@ -273,7 +273,7 @@ let decideGralEquality =
         let env = Proofview.Goal.env gl in
         let sigma = project gl in
         match_eqdec env sigma concl >>= fun (dty, c1, c2, typ as data) ->
-        let headtyp = hd_app sigma (pf_compute gl typ) in
+        let headtyp = hd_app sigma (pf_whd_compute gl typ) in
         begin match EConstr.kind sigma headtyp with
         | Ind (mi,_) -> Proofview.tclUNIT mi
         | _ -> tclZEROMSG (Pp.str"This decision procedure only works for inductive objects.")

--- a/tactics/redexpr.ml
+++ b/tactics/redexpr.ml
@@ -254,7 +254,7 @@ let reduction_of_red_expr_val = function
       | Head, false -> whd_simpl
     in
      (contextualize am o,DEFAULTcast)
-  | Cbv (Norm, f) -> (e_red (cbv_norm_flags f),DEFAULTcast)
+  | Cbv (Norm, f) -> (e_red (cbv_norm_flags ~strong:true f),DEFAULTcast)
   | Cbv (Head, _) -> CErrors.user_err Pp.(str "cbv does not support head-only reduction.")
   | Cbn (w,f) ->
     let cbn = match w with Norm -> Cbn.norm_cbn | Head -> Cbn.whd_cbn in

--- a/tactics/redexpr.ml
+++ b/tactics/redexpr.ml
@@ -255,7 +255,7 @@ let reduction_of_red_expr_val = function
     in
      (contextualize am o,DEFAULTcast)
   | Cbv (Norm, f) -> (e_red (cbv_norm_flags ~strong:true f),DEFAULTcast)
-  | Cbv (Head, _) -> CErrors.user_err Pp.(str "cbv does not support head-only reduction.")
+  | Cbv (Head, f) -> (e_red (cbv_norm_flags ~strong:false f),DEFAULTcast)
   | Cbn (w,f) ->
     let cbn = match w with Norm -> Cbn.norm_cbn | Head -> Cbn.whd_cbn in
      (e_red (cbn f), DEFAULTcast)

--- a/test-suite/output/reduction.out
+++ b/test-suite/output/reduction.out
@@ -13,6 +13,8 @@
              | S p => S (add p m)
              end) 1 2)
      : nat
+     = 4
+     : nat
      = (fix add (n m : nat) {struct n} : nat :=
           match n with
           | 0 => m
@@ -23,6 +25,10 @@
      : nat
      = S (1 + 2 + 2)
      : nat
+     = 6
+     : nat
+     = ignore (fun x : nat => 1 + x)
+     : unit
      = ignore (fun x : nat => 1 + x)
      : unit
      = ignore (fun x : nat => 1 + x)
@@ -31,3 +37,26 @@
      : unit
 - : constr = constr:(4)
 - : constr = constr:(2 + 2)
+     = let x := 2 in 2 + 2
+     : nat
+     = let x := 2 in 4
+     : nat
+     = (let x := 2 in fun x0 : nat => 1 + x0) 2
+     : nat
+     = match n with
+       | 0 => 1 + 1
+       | S n => 1 + n
+       end
+     : nat
+     = fix f (n : nat) : nat :=
+         match 0 + n with
+         | 0 => 1 + 1
+         | S n0 => 1 + f n0
+         end
+     : nat -> nat
+     = 4%uint63
+     : int
+     = (2 + x)%uint63
+     : int
+     = 1%float
+     : float

--- a/test-suite/output/reduction.v
+++ b/test-suite/output/reduction.v
@@ -14,6 +14,7 @@ Eval hnf in match (plus (S n) O) with S n => n | _ => O end.
 Eval simpl head in 2 + 2.
 Eval cbn head in 2 + 2.
 Eval lazy head in 2 + 2.
+Eval cbv head in 2 + 2.
 
 Eval lazy head delta in 2 + 2.
 
@@ -21,12 +22,31 @@ Eval simpl head in 2 + (2 + 2).
 
 Eval simpl head in (2 + 2) + 2.
 
+Eval cbv head in (2 + 2) + 2.
+
 Axiom ignore : forall {T}, T -> unit.
 Eval simpl head in ignore (fun x => 1 + x).
 Eval cbn head in ignore (fun x => 1 + x).
 Eval lazy head in ignore (fun x => 1 + x).
+Eval cbv head in ignore (fun x => 1 + x).
 
 Require Import Ltac2.Ltac2.
 
 Ltac2 Eval eval lazy in (2 + 2).
 Ltac2 Eval eval lazy head in (2 + 2).
+
+(* Cbv examples *)
+
+Eval cbv head beta delta iota in let x := 1 + 1 in 2 + 2. (* not fully clear what head w/o zeta should be *)
+Eval cbv beta delta iota in let x := 1 + 1 in 2 + 2. (* not fully clear what head w/o zeta should be *)
+Eval cbv head beta delta iota in (let x := 1 + 1 in fun x => 1 + x) 2. (* not fully clear whether we should apply commutative cuts or not *)
+Eval cbv head in match 0 + n with 0 => 1 + 1 | S n => 1 + n end.
+Eval cbv head in fix f n := match 0 + n with 0 => 1 + 1 | S n => 1 + f n end.
+
+Require Import Uint63.
+Eval cbv head in (2+2)%uint63.
+Parameter x:int.
+Eval cbv head in (2+x)%uint63.
+
+Require Import Floats.
+Eval cbv head in (0x1p+0)%float.


### PR DESCRIPTION
This is a variant of @maximedenes' weak-cbv branch providing a weak cbv strategy of reduction of the CIC call-by-name theory. In there, free variables are considered as "constructors", so that `x t` evaluates to `x t'` where `t'` is the weak-head normal form of `t`.

It should be useful for #17503 (give access to the "weak" form of reduction strategies).

- [x] Updated **test-suite**
- [x] Updated **changelog** (originally from #17503)

- [x] Overlays: LPCIC/coq-elpi#528 and mattam82/Coq-Equations#566 