### PR TITLE
Fixing confusion about idempotency of abs

### DIFF
--- a/theories/Numbers/Integer/Abstract/ZSgnAbs.v
+++ b/theories/Numbers/Integer/Abstract/ZSgnAbs.v
@@ -143,10 +143,13 @@ Proof.
  intros n. destruct_max n; rewrite ? opp_involutive; auto with relations.
 Qed.
 
-Lemma abs_involutive : forall n, abs (abs n) == abs n.
+Lemma abs_idemp : forall n, abs (abs n) == abs n.
 Proof.
  intros. apply abs_eq. apply abs_nonneg.
 Qed.
+
+#[deprecated(since="8.19", note="Use abs_idemp")]
+Notation abs_involutive := abs_idemp.
 
 Lemma abs_spec : forall n,
   (0 <= n /\ abs n == n) \/ (n < 0 /\ abs n == -n).


### PR DESCRIPTION
Fixing a confusion about the name `Z.abs_involutive` which is actually about idempotency.

- [ ] Added **changelog**.

I reused the word `idemp` which can be found in other `Zarith` names such as `Z.add_mod_idemp_r` (even if probably disputable). Outside`ZArith`, one can find e.g. ` Operators_Properties.clos_rst_idempotent` and `ssrfun.idempotent`.