### PR TITLE
Support for deprecating a file

### DIFF
--- a/checker/values.ml
+++ b/checker/values.ml
@@ -435,8 +435,14 @@ let v_stm_seg = v_pair v_tasks v_counters
 
 (** Toplevel structures in a vo (see Cic.mli) *)
 
+let v_deprecation =
+  v_pair (Opt String) (Opt String)
+
+let v_library_info =
+  v_sum "library_info" 0 [|[|String|];[|v_deprecation|]|]
+
 let v_libsum =
-  Tuple ("summary", [|v_dp;v_deps;String|])
+  Tuple ("summary", [|v_dp;v_deps;String;List v_library_info|])
 
 let v_lib =
   Tuple ("library",[|v_compiled_lib;v_librarysyntaxobjs;v_libraryobjs|])

--- a/doc/changelog/08-vernac-commands-and-options/18193-master+docstring.rst
+++ b/doc/changelog/08-vernac-commands-and-options/18193-master+docstring.rst
@@ -1,0 +1,6 @@
+- **Added:**
+  New command :cmd:`Attributes` to assign attributes such as
+  :attr:`deprecated` to a library file
+  (`#18193 <https://github.com/coq/coq/pull/18193>`_,
+  fixes `#8032 <https://github.com/coq/coq/issues/8032>`_,
+  by Hugo Herbelin).

--- a/doc/sphinx/language/core/basic.rst
+++ b/doc/sphinx/language/core/basic.rst
@@ -391,8 +391,9 @@ Settings
 --------
 
 There are several mechanisms for changing the behavior of Coq.  The
-:term:`attribute` mechanism is used to modify the behavior of a single
-:term:`sentence`.  The :term:`flag`, :term:`option` and :term:`table`
+:term:`attribute` mechanism is used to modify the default behavior of a
+:term:`sentence` or to attach information to Coq objects.
+The :term:`flag`, :term:`option` and :term:`table`
 mechanisms are used to modify the behavior of Coq more globally in a
 document or project.
 
@@ -401,11 +402,13 @@ document or project.
 Attributes
 ~~~~~~~~~~
 
-An :gdef:`attribute` modifies the behavior of a single sentence.
+An :gdef:`attribute` is used to modify the default behavior of a
+sentence or to attach information to a Coq object.
 Syntactically, most commands and tactics can be decorated with
 attributes (cf. :n:`@sentence`), but attributes not supported by the
 command or tactic will trigger :warn:`This command does not support
-this attribute`.
+this attribute`. There is also a command :cmd:`Attributes` to
+assign attributes to a whole document.
 
 .. insertprodn attributes legacy_attr
 
@@ -414,7 +417,7 @@ this attribute`.
    attribute ::= @ident {? @attr_value }
    attr_value ::= = @string
    | = @ident
-   | ( {*, @attribute } )
+   | ( {+, @attribute } )
    legacy_attr ::= {| Local | Global }
    | {| Polymorphic | Monomorphic }
    | {| Cumulative | NonCumulative }
@@ -498,6 +501,18 @@ The following attribute is supported by every command:
    :name: warning
 
    Alias of :attr:`warnings`.
+
+Document-level attributes
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. cmd:: Attributes {+, @attribute }
+   :name: Attributes
+
+   Associates attributes with the
+   document. When compiled with ``coqc`` (see Section
+   :ref:`thecoqcommands`), the attributes are associated with the
+   compiled file and may have an effect when the file is loaded with
+   :cmd:`Require`. Supported attributes include :attr:`deprecated`.
 
 .. _flags-options-tables:
 

--- a/doc/sphinx/language/core/inductive.rst
+++ b/doc/sphinx/language/core/inductive.rst
@@ -30,7 +30,7 @@ Inductive types
 
    .. prodn::
       inductive_definition ::= @ident {? @cumul_univ_decl } {* @binder } {? %| {* @binder } } {? : @type } := {? %| } {+| @constructor } {? @decl_notations }
-      constructor ::= {* #[ {*, @attribute } ] } @ident {* @binder } {? @of_type_inst }
+      constructor ::= {* #[ {+, @attribute } ] } @ident {* @binder } {? @of_type_inst }
 
    Defines one or more
    inductive types and its constructors.  Coq generates

--- a/doc/sphinx/language/core/records.rst
+++ b/doc/sphinx/language/core/records.rst
@@ -22,7 +22,7 @@ Defining record types
 
    .. prodn::
       record_definition ::= {? > } @ident_decl {* @binder } {? : @sort } {? := {? @ident } %{ {*; @record_field } {? ; } %} {? as @ident } }
-      record_field ::= {* #[ {*, @attribute } ] } @name {? @field_spec } {? %| @natural }
+      record_field ::= {* #[ {+, @attribute } ] } @name {? @field_spec } {? %| @natural }
       field_spec ::= {* @binder } @of_type_inst
       | {* @binder } := @term
       | {* @binder } @of_type_inst := @term

--- a/doc/sphinx/using/libraries/writing.rst
+++ b/doc/sphinx/using/libraries/writing.rst
@@ -6,11 +6,11 @@ to library and plugin authors.  A tutorial for writing Coq plugins is
 available in the Coq repository in `doc/plugin_tutorial
 <https://github.com/coq/coq/tree/master/doc/plugin_tutorial>`_.
 
-Deprecating library objects or tactics
---------------------------------------
+Deprecating library objects, tactics or library files
+-----------------------------------------------------
 
 You may use the following :term:`attribute` to deprecate a notation,
-tactic, definition, axiom or theorem.  When renaming a definition or theorem, you can introduce a
+tactic, definition, axiom, theorem or file.  When renaming a definition or theorem, you can introduce a
 deprecated compatibility alias using :cmd:`Notation (abbreviation)`
 (see :ref:`the example below <compatibility-alias>`).
 
@@ -25,7 +25,8 @@ deprecated compatibility alias using :cmd:`Notation (abbreviation)`
 
    This attribute is supported by the following commands: :cmd:`Ltac`,
    :cmd:`Tactic Notation`, :cmd:`Notation`, :cmd:`Infix`, :cmd:`Ltac2`,
-   :cmd:`Ltac2 Notation`, :cmd:`Ltac2 external`.
+   :cmd:`Ltac2 Notation`, :cmd:`Ltac2 external`. To attach it to a
+   compiled library file, use :cmd:`Attributes`.
 
    It can trigger the following warnings:
 

--- a/doc/sphinx/using/libraries/writing.rst
+++ b/doc/sphinx/using/libraries/writing.rst
@@ -25,7 +25,8 @@ deprecated compatibility alias using :cmd:`Notation (abbreviation)`
 
    This attribute is supported by the following commands: :cmd:`Ltac`,
    :cmd:`Tactic Notation`, :cmd:`Notation`, :cmd:`Infix`, :cmd:`Ltac2`,
-   :cmd:`Ltac2 Notation`, :cmd:`Ltac2 external`. To attach it to a
+   :cmd:`Ltac2 Notation`, :cmd:`Ltac2 external`, :cmd:`Definition`,
+   :cmd:`Theorem`, and similar commands. To attach it to a
    compiled library file, use :cmd:`Attributes`.
 
    It can trigger the following warnings:

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -528,6 +528,7 @@ command: [
 | "Remove" "Hints" LIST1 global opt_hintbases
 | "Hint" hint opt_hintbases
 | "Comments" LIST0 comment
+| "Attributes" attribute_list
 | "Declare" "Instance" ident_decl binders ":" term200 hint_info
 | "Declare" "Scope" IDENT
 | "Pwd"
@@ -751,7 +752,7 @@ quoted_attributes: [
 ]
 
 attribute_list: [
-| LIST0 attribute SEP ","
+| LIST1 attribute SEP ","
 ]
 
 attribute: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -264,7 +264,7 @@ attribute: [
 attr_value: [
 | "=" string
 | "=" ident
-| "(" LIST0 attribute SEP "," ")"
+| "(" LIST1 attribute SEP "," ")"
 ]
 
 legacy_attr: [
@@ -533,7 +533,7 @@ record_definition: [
 ]
 
 record_field: [
-| LIST0 [ "#[" LIST0 attribute SEP "," "]" ] name OPT field_spec OPT [ "|" natural ]
+| LIST0 [ "#[" LIST1 attribute SEP "," "]" ] name OPT field_spec OPT [ "|" natural ]
 ]
 
 field_spec: [
@@ -559,7 +559,7 @@ inductive_definition: [
 ]
 
 constructor: [
-| LIST0 [ "#[" LIST0 attribute SEP "," "]" ] ident LIST0 binder OPT of_type_inst
+| LIST0 [ "#[" LIST1 attribute SEP "," "]" ] ident LIST0 binder OPT of_type_inst
 ]
 
 import_categories: [
@@ -826,6 +826,7 @@ command: [
 | "Create" "HintDb" ident OPT "discriminated"
 | "Remove" "Hints" LIST1 qualid OPT ( ":" LIST1 ident )
 | "Comments" LIST0 [ one_term | string | natural ]
+| "Attributes" LIST1 attribute SEP ","
 | "Declare" "Instance" ident_decl LIST0 binder ":" term OPT hint_info
 | "Declare" "Scope" scope_name
 | "Obligation" natural OPT ( "of" ident ) OPT ( ":" type OPT ( "with" ltac_expr ) )

--- a/library/global.ml
+++ b/library/global.ml
@@ -20,6 +20,7 @@ module GlobalSafeEnv : sig
   val safe_env : unit -> Safe_typing.safe_environment
   val set_safe_env : Safe_typing.safe_environment -> unit
   val is_joined_environment : unit -> bool
+  val is_curmod_library : unit -> bool
   val global_env_summary_tag : Safe_typing.safe_environment Summary.Dyn.tag
 
 end = struct
@@ -29,6 +30,9 @@ let global_env, global_env_summary_tag =
 
 let is_joined_environment () =
   Safe_typing.is_joined_environment !global_env
+
+let is_curmod_library () =
+  Safe_typing.is_curmod_library !global_env
 
 let assert_not_synterp () =
   if !Flags.in_synterp_phase then
@@ -45,6 +49,7 @@ let global_env_summary_tag = GlobalSafeEnv.global_env_summary_tag
 
 let safe_env = GlobalSafeEnv.safe_env
 let is_joined_environment = GlobalSafeEnv.is_joined_environment
+let is_curmod_library = GlobalSafeEnv.is_curmod_library
 
 let env () = Safe_typing.env_of_safe_env (safe_env ())
 

--- a/library/global.mli
+++ b/library/global.mli
@@ -152,6 +152,7 @@ val import :
 val env_of_context : Environ.named_context_val -> Environ.env
 
 val is_joined_environment : unit -> bool
+val is_curmod_library : unit -> bool
 
 val is_polymorphic : GlobRef.t -> bool
 val is_template_polymorphic : GlobRef.t -> bool

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -139,6 +139,8 @@ module type StagedLibS = sig
   (** Keep only the libobject structure, not the objects themselves *)
   val drop_objects : frozen -> frozen
 
+  val declare_info : Library_info.t list -> unit
+
 end
 
 (** We provide two instances of [StagedLibS], corresponding to the Synterp and
@@ -153,7 +155,7 @@ val start_compilation : DirPath.t -> ModPath.t -> unit
 
 (** Finalize the compilation of a library and return respectively the library
     prefix, the regular objects, and the syntax-related objects. *)
-val end_compilation : DirPath.t -> Nametab.object_prefix * Interp.classified_objects * Synterp.classified_objects
+val end_compilation : DirPath.t -> Nametab.object_prefix * Library_info.t list * Interp.classified_objects * Synterp.classified_objects
 
 (** The function [library_dp] returns the [DirPath.t] of the current
    compiling library (or [default_library]) *)

--- a/library/library_info.ml
+++ b/library/library_info.ml
@@ -1,0 +1,26 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(* This handles attributes associated to a library file *)
+
+(*i*)
+open Names
+(*i*)
+
+type t = Deprecation of Deprecation.t
+
+let warn_library_deprecated =
+  Deprecation.create_warning ~object_name:"Library File"
+    ~warning_name_if_no_since:"deprecated-library-file"
+    (fun dp -> DirPath.print dp)
+
+let warn_library_info ?loc (dp,infos) =
+  match infos with
+  | Deprecation t -> warn_library_deprecated ?loc (dp, t)

--- a/library/library_info.mli
+++ b/library/library_info.mli
@@ -1,0 +1,17 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(* This handles attributes associated to a library file *)
+
+open Names
+
+type t = Deprecation of Deprecation.t
+
+val warn_library_info : ?loc:Loc.t -> DirPath.t * t -> unit

--- a/test-suite/output/library_attributes.out
+++ b/test-suite/output/library_attributes.out
@@ -1,0 +1,10 @@
+File "./output/library_attributes.v", line 4, characters 16-21:
+The command has indeed failed with message:
+This command does not support this attribute: local.
+[unsupported-attributes,parsing,default]
+File "./output/library_attributes.v", line 7, characters 0-70:
+The command has indeed failed with message:
+A library attribute should be at toplevel of the library.
+File "./output/library_attributes.v", line 11, characters 0-69:
+The command has indeed failed with message:
+A library attribute should be at toplevel of the library.

--- a/test-suite/output/library_attributes.v
+++ b/test-suite/output/library_attributes.v
@@ -1,0 +1,12 @@
+Attributes deprecated(note="This library is useless.", since="XX YY").
+
+(* unsupported attributes *)
+Fail Attributes local.
+
+Section Sec.
+Fail Attributes deprecated(note="No library attributes in sections.").
+End Sec.
+
+Module Mod.
+Fail Attributes deprecated(note="No library attributes in modules.").
+End Mod.

--- a/test-suite/output/library_attributes_require.out
+++ b/test-suite/output/library_attributes_require.out
@@ -1,0 +1,4 @@
+File "./output/library_attributes_require.v", line 1, characters 0-37:
+Warning: Library File TestSuite.library_attributes is deprecated since XX YY.
+This library is useless.
+[deprecated-library-file-since-XX-YY,deprecated-since-XX-YY,deprecated-library-file,deprecated,default]

--- a/test-suite/output/library_attributes_require.v
+++ b/test-suite/output/library_attributes_require.v
@@ -1,0 +1,1 @@
+Require TestSuite.library_attributes.

--- a/test-suite/prerequisite/library_attributes.v
+++ b/test-suite/prerequisite/library_attributes.v
@@ -1,0 +1,1 @@
+../output/library_attributes.v

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -1579,12 +1579,12 @@ let end_library_hook () =
 
 let end_library ~output_native_objects dir =
   end_library_hook();
-  let prefix, lib_stack, lib_stack_syntax = Lib.end_compilation dir in
+  let prefix, info, lib_stack, lib_stack_syntax = Lib.end_compilation dir in
   let mp,cenv,ast = Global.export ~output_native_objects dir in
   assert (ModPath.equal mp (MPfile dir));
   let {Lib.Interp.substobjs = substitute; keepobjs = keep; anticipateobjs = _; } = lib_stack in
   let {Lib.Synterp.substobjs = substitute_syntax; keepobjs = keep_syntax; anticipateobjs = _; } = lib_stack_syntax in
-  cenv,(substitute,keep),(substitute_syntax,keep_syntax),ast
+  cenv,(substitute,keep),(substitute_syntax,keep_syntax),ast,info
 
 (** {6 Iterators} *)
 

--- a/vernac/declaremods.mli
+++ b/vernac/declaremods.mli
@@ -155,7 +155,7 @@ val start_library : library_name -> unit
 
 val end_library :
   output_native_objects:bool -> library_name ->
-  Safe_typing.compiled_library * library_objects * library_objects * Nativelib.native_library
+  Safe_typing.compiled_library * library_objects * library_objects * Nativelib.native_library * Library_info.t list
 
 (** append a function to be executed at end_library *)
 val append_end_library_hook : (unit -> unit) -> unit

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -43,6 +43,7 @@ let search_queries = Entry.make "search_queries"
 let subprf = Entry.make "subprf"
 
 let quoted_attributes = Entry.make "quoted_attributes"
+let attribute_list = Entry.make "attribute_list"
 let coercion_class = Entry.make "coercion_class"
 let thm_token = Entry.make "thm_token"
 let def_token = Entry.make "def_token"
@@ -89,7 +90,7 @@ let test_id_colon =
 }
 
 GRAMMAR EXTEND Gram
-  GLOBAL: vernac_control quoted_attributes gallina_ext noedit_mode subprf;
+  GLOBAL: vernac_control quoted_attributes attribute_list gallina_ext noedit_mode subprf;
   vernac_control: FIRST
     [ [ IDENT "Time"; c = vernac_control ->
         { add_control_flag ~loc ~flag:ControlTime c }
@@ -116,7 +117,7 @@ GRAMMAR EXTEND Gram
     ]
   ;
   attribute_list:
-    [ [ a = LIST0 attribute SEP "," -> { a } ]
+    [ [ a = LIST1 attribute SEP "," -> { a } ]
     ]
   ;
   attribute:
@@ -955,6 +956,9 @@ GRAMMAR EXTEND Gram
 
   command:
     [ [ IDENT "Comments"; l = LIST0 comment -> { VernacSynPure (VernacComments l) }
+
+      | IDENT "Attributes"; attr = attribute_list ->
+        { VernacSynPure (VernacAttributes attr) }
 
       (* Hack! Should be in grammar_ext, but camlp5 factorizes badly *)
       | IDENT "Declare"; IDENT "Instance"; id = ident_decl; bl = binders; ":";

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -90,6 +90,7 @@ type summary_disk = {
   md_name : compilation_unit_name;
   md_deps : (compilation_unit_name * Safe_typing.vodigest) array;
   md_ocaml : string;
+  md_info : Library_info.t list;
 }
 
 (*s Modules loaded in memory contain the following informations. They are
@@ -280,6 +281,7 @@ let intern_from_file lib_resolver dir =
        DirPath.print lsd.md_name ++ spc () ++ str "and not library" ++
        spc() ++ DirPath.print dir ++ str ".");
   Feedback.feedback (Feedback.FileLoaded(DirPath.to_string dir, f));
+  List.iter (fun info -> Library_info.warn_library_info (lsd.md_name,info)) lsd.md_info;
   lsd, lmd, digest_lmd, univs, digest_u, del_opaque
 
 let rec intern_library ~intern (needed, contents as acc) dir =
@@ -488,12 +490,13 @@ let save_library_base f sum lib univs tasks proofs =
 
 (* This is the basic vo save structure *)
 let save_library_struct ~output_native_objects dir =
-  let md_compiled, md_objects, md_syntax_objects, ast =
+  let md_compiled, md_objects, md_syntax_objects, ast, info =
     Declaremods.end_library ~output_native_objects dir in
   let sd =
     { md_name = dir
     ; md_deps = Array.of_list (current_deps ())
     ; md_ocaml = Coq_config.caml_version
+    ; md_info = info
     } in
   let md =
     { md_compiled

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -1226,7 +1226,12 @@ let pr_synpure_vernac_expr v =
         (keyword "Comments" ++ spc()
          ++ prlist_with_sep sep (pr_comment pr_constr) l)
     )
-
+  | VernacAttributes attrs ->
+    return (
+      hov 2
+        (keyword "Attributes" ++ spc () ++
+         pr_vernac_attributes attrs)
+    )
   | VernacProof (None, None) ->
     return (keyword "Proof")
   | VernacProof (None, Some e) ->

--- a/vernac/vernac_classifier.ml
+++ b/vernac/vernac_classifier.ml
@@ -176,6 +176,7 @@ let classify_vernac e =
     | VernacRegister _
     | VernacNameSectionHypSet _
     | VernacComments _
+    | VernacAttributes _
     | VernacSchemeEquality _
     | VernacDeclareInstance _ -> VtSideff ([], VtLater)
     (* Who knows *)

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -474,6 +474,7 @@ type nonrec synpure_vernac_expr =
   | VernacRegister of qualid * register_kind
   | VernacPrimitive of ident_decl * CPrimitives.op_or_type * constr_expr option
   | VernacComments of comment list
+  | VernacAttributes of Attributes.vernac_flags
 
   (* Proof management *)
   | VernacAbort


### PR DESCRIPTION
~~This is an experimental support for associating comments or warnings to global names.~~
This provides support for associating warnings or deprecation to a library file.

~~As an example, two commands `Library Comment string.` and `Library Warning string.` are~~
A command `Library Attributes #[...]` is provided, with the idea that it could be used to warn about the status of some files (as e.g. for #18032, w/o requiring the indirection of an abbreviation, nor to rely on the deprecation system).

The supported attributes are `deprecated(...)` and `information="..."`.

Fixes: #8032 

- [x] Added **changelog**.
- [X] Added / updated **documentation**.