### PR TITLE
Ltac2: add primitive APIs for projections

### DIFF
--- a/user-contrib/Ltac2/Ind.v
+++ b/user-contrib/Ltac2/Ind.v
@@ -43,3 +43,8 @@ Ltac2 @ external get_block : data -> int -> data := "coq-core.plugins.ltac2" "in
 Ltac2 @ external get_constructor : data -> int -> constructor := "coq-core.plugins.ltac2" "ind_get_constructor".
 (** Returns the nth constructor of the inductive type. Index must range between
     [0] and [nconstructors data - 1], otherwise the function panics. *)
+
+Ltac2 @ external get_projections : data -> projection array option
+  := "coq-core.plugins.ltac2" "ind_get_projections".
+(** Returns the list of projections for a primitive record,
+    or [None] if the inductive is not a primitive record. *)

--- a/user-contrib/Ltac2/Proj.v
+++ b/user-contrib/Ltac2/Proj.v
@@ -11,7 +11,32 @@
 Require Import Ltac2.Init.
 
 Ltac2 Type t := projection.
+(** Type of primitive projections. This includes the unfolding boolean. *)
 
 Ltac2 @ external equal : t -> t -> bool := "coq-core.plugins.ltac2" "projection_equal".
 (** Projections obtained through module aliases or Include are not
     considered equal by this function. The unfolding boolean is not ignored. *)
+
+Ltac2 @ external ind : t -> inductive := "coq-core.plugins.ltac2" "projection_ind".
+(** Get the inductive to which the projectin belongs. *)
+
+Ltac2 @ external index : t -> int := "coq-core.plugins.ltac2" "projection_index".
+(** The index of the projection indicates which field it projects. *)
+
+Ltac2 @ external unfolded : t -> bool := "coq-core.plugins.ltac2" "projection_unfolded".
+(** Get the unfolding boolean. *)
+
+Ltac2 @ external set_unfolded : t -> bool -> t
+  := "coq-core.plugins.ltac2" "projection_set_unfolded".
+(** Set the unfolding boolean. *)
+
+Ltac2 @ external of_constant : constant -> t option
+  := "coq-core.plugins.ltac2" "projection_of_constant".
+(** Get the primitive projection associated to the constant.
+    The returned projection is folded.
+    Returns [None] when the constant is not associated to a primitive projection. *)
+
+Ltac2 @ external to_constant : t -> constant option
+  := "coq-core.plugins.ltac2" "projection_to_constant".
+(** Get the constant associated to the primitive projection.
+    Currently always returns [Some] but this may change in the future. *)


### PR DESCRIPTION
Should we also add Projection.nparams? It can be gotten by going through the inductive at the cost of an environment access.
