### PR TITLE
CI: Set fiat_crypto allow_failure

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -659,6 +659,7 @@ library:ci-fiat_crypto:
   - plugin:ci-bignums
   - plugin:ci-rewriter
   timeout: 3h
+  allow_failure: true
 
 library:ci-fiat_crypto_legacy:
   extends: .ci-template-flambda


### PR DESCRIPTION
3h is already a long timeout, for the sake of not making CI take even longer and to avoid making overlay writing more painful I am strongly against making it longer.
