### PR TITLE
[zify] use the current injection to guide the transformation.

### DIFF
--- a/plugins/micromega/zify.ml
+++ b/plugins/micromega/zify.ml
@@ -163,6 +163,11 @@ module EInjT = struct
       pred : EConstr.t
     ; (* T -> Prop *)
       cstr : EConstr.t option (* forall x, pred (inj x) *) }
+
+  let eq_inj evd i1 i2 =
+    i1.isid = i2.isid && EConstr.eq_constr evd i1.inj i2.inj
+
+
 end
 
 (** [classify_op] classify injected operators and detect special cases. *)
@@ -350,6 +355,13 @@ type decl_kind =
   | Saturate of ESatT.t decl
   | UnOpSpec of ESpecT.t decl
   | BinOpSpec of ESpecT.t decl
+
+let target_inj d =
+  match d with
+  | BinOp d -> Some d.deriv.EBinOpT.inj3
+  | UnOp d  -> Some d.deriv.EUnOpT.inj2_t
+  | CstOp d -> Some d.deriv.inj
+  |  _      -> None
 
 type term_kind = Application of EConstr.constr | OtherTerm of EConstr.constr
 
@@ -995,12 +1007,6 @@ let app_binop env evd src binop arg1 prf1 arg2 prf2 =
 
 type typed_constr = {constr : EConstr.t; typ : EConstr.t; inj : EInjT.t}
 
-let get_injection env evd t =
-  try
-    match snd (ConstrMap.find evd t !table_cache) with
-    | InjTyp i -> i
-    | _ -> raise Not_found
-  with DestKO -> raise Not_found
 
 (* [arrow] is the term (fun (x:Prop) (y : Prop) => x -> y) *)
 let arrow =
@@ -1089,18 +1095,29 @@ let classify_prop env evd e =
     | _ -> OTHEROP (c, a) )
   | _ -> OTHEROP (e, [||])
 
-(** [match_operator env evd hd arg (t,d)]
+
+let check_target_inj evd inj d =
+  match inj , target_inj d with
+  | None , _ -> true
+  | Some _ , None -> false
+  | Some i1 , Some i2 -> EInjT.eq_inj evd i1 i2
+
+
+(** [match_operator env evd hd arg inj (t,d)]
      - hd is head operator of t
      - If t = OtherTerm _, then t = hd
      - If t = Application _, then
        we extract the relevant number of arguments from arg
        and check for convertibility *)
-let match_operator env evd hd args (t, d) =
+let match_operator env evd hd args inj (t, d) =
   let decomp t i =
     let n = Array.length args in
     let t' = EConstr.mkApp (hd, Array.sub args 0 (n - i)) in
     if is_convertible env evd t' t then Some (d, t) else None
   in
+
+  if check_target_inj evd inj d
+  then
   match t with
   | OtherTerm t -> Some (d, t)
   | Application t -> (
@@ -1112,10 +1129,10 @@ let match_operator env evd hd args (t, d) =
     | PropOp _ -> decomp t 2
     | PropUnOp _ -> decomp t 1
     | _ -> None )
+  else None
 
 let pp_trans_expr env evd e res =
-  let {deriv = inj} = get_injection env evd e.typ in
-  debug_zify (fun () -> Pp.(str "\ntrans_expr " ++ pp_prf evd inj e.constr res));
+  debug_zify (fun () -> Pp.(str "\ntrans_expr " ++ pp_prf evd e.inj e.constr res));
   res
 
 let rec trans_expr env evd e =
@@ -1127,7 +1144,7 @@ let rec trans_expr env evd e =
     else
       let k, t =
         find_option
-          (match_operator env evd c a)
+          (match_operator env evd c a (Some inj))
           (ConstrMap.find_all evd c !table_cache)
       in
       let n = Array.length a in
@@ -1271,7 +1288,7 @@ let rec trans_prop env evd e =
     try
       let k, t =
         find_option
-          (match_operator env evd c a)
+          (match_operator env evd c a None)
           (ConstrMap.find_all evd c !table_cache)
       in
       let n = Array.length a in
@@ -1363,16 +1380,6 @@ let trans_concl prfp =
 let tclTHENOpt e tac tac' =
   match e with None -> tac' | Some e' -> Tacticals.tclTHEN (tac e') tac'
 
-let assert_inj t =
-  init_cache ();
-  Proofview.Goal.enter (fun gl ->
-      let env = Tacmach.pf_env gl in
-      let evd = Tacmach.project gl in
-      try
-        ignore (get_injection env evd t);
-        Tacticals.tclIDTAC
-      with Not_found ->
-        Tacticals.tclFAIL (Pp.str " InjTyp does not exist"))
 
 let elim_binding x t ty =
   Proofview.Goal.enter (fun gl ->
@@ -1397,7 +1404,7 @@ let do_let tac (h : Constr.named_declaration) =
             (let eq = Lazy.force eq in
              find_option
                (match_operator env evd eq
-                  [|EConstr.of_constr ty; EConstr.mkVar x; EConstr.of_constr t|])
+                  [|EConstr.of_constr ty; EConstr.mkVar x; EConstr.of_constr t|] None)
                (ConstrMap.find_all evd eq !table_cache));
           tac x (EConstr.of_constr t) (EConstr.of_constr ty)
         with Not_found -> Tacticals.tclIDTAC)

--- a/plugins/micromega/zify.mli
+++ b/plugins/micromega/zify.mli
@@ -27,6 +27,5 @@ module Saturate : S
 val zify_tac : unit Proofview.tactic
 val saturate : unit Proofview.tactic
 val iter_specs : unit Proofview.tactic
-val assert_inj : EConstr.constr -> unit Proofview.tactic
 val iter_let : Ltac_plugin.Tacinterp.Value.t -> unit Proofview.tactic
 val elim_let : unit Proofview.tactic

--- a/test-suite/bugs/bug_17983.v
+++ b/test-suite/bugs/bug_17983.v
@@ -1,0 +1,11 @@
+From Coq Require Import Zify ZifyUint63 ZifySint63 Sint63 Uint63 ZArith Lia.
+
+Lemma boom : False.
+Proof.
+  assert (sint_bad : forall y z : int, Sint63.to_Z (y / z) = Uint63.to_Z (y / z)).
+  { zify. Fail reflexivity.
+  (*}
+  specialize (sint_bad (-1)%sint63 1%uint63).
+  vm_compute in sint_bad. (* sint_bad : (-1)%Z = 9223372036854775807%Z *)
+  congruence. *)
+Abort.


### PR DESCRIPTION
This avoids generated ill-typed terms when there are several possible injections for the same operator.
Fixes #17983 

- [x] Added / updated **test-suite**.

