### PR TITLE
Fix various issues around recarg computation

### DIFF
--- a/interp/constrexpr_ops.mli
+++ b/interp/constrexpr_ops.mli
@@ -124,8 +124,6 @@ val occur_var_constr_expr : Id.t -> constr_expr -> bool
 (** Return all (non-qualified) names treating binders as names *)
 val names_of_constr_expr : constr_expr -> Id.Set.t
 
-val split_at_annot : local_binder_expr list -> lident option -> local_binder_expr list * local_binder_expr list
-
 val ntn_loc : ?loc:Loc.t -> constr_notation_substitution -> notation -> (int * int) list
 val patntn_loc : ?loc:Loc.t -> cases_pattern_notation_substitution -> notation -> (int * int) list
 

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -813,7 +813,7 @@ struct
             Array.to_list (Array.mapi
                              (fun i annot -> match annot with
                              | Some n -> [n]
-                             | None -> List.map_i (fun i _ -> i) 0 ctxtv.(i))
+                             | None -> List.interval 0 (Context.Rel.nhyps ctxtv.(i) - 1))
            vn)
           in
           let fixdecls = (names,ftys,fdefs) in

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -93,6 +93,9 @@ let search_guard ?loc env possible_indexes fixdefs =
     indexes
   else
     (* we now search recursively among all combinations *)
+    let combinations = List.combinations possible_indexes in
+    if List.is_empty combinations then
+      user_err ?loc (Pp.str "A fixpoint needs at least one parameter.");
     (try
        List.iter
          (fun l ->
@@ -109,7 +112,7 @@ let search_guard ?loc env possible_indexes fixdefs =
               let env = Environ.set_typing_flags flags env in
               check_fix env fix; raise (Found indexes)
             with TypeError _ -> ())
-         (List.combinations possible_indexes);
+          combinations;
        let errmsg = "Cannot guess decreasing argument of fix." in
          user_err ?loc (Pp.str errmsg)
      with Found indexes -> indexes)

--- a/test-suite/bugs/bug_18215.v
+++ b/test-suite/bugs/bug_18215.v
@@ -1,2 +1,5 @@
 Fail Definition a := fix f {struct unbound} :=
   fun (t : unit) => tt.
+
+Generalizable Variable A.
+Fixpoint fails `(l : list A) {struct l} : unit := tt.

--- a/test-suite/bugs/bug_18215.v
+++ b/test-suite/bugs/bug_18215.v
@@ -1,0 +1,2 @@
+Fail Definition a := fix f {struct unbound} :=
+  fun (t : unit) => tt.


### PR DESCRIPTION
Fixes #18215

It's missing a fix for the last part (#13151 for Fixpoint) but I don't know what to do of `split_at_annot` and whether I can factor its replacement.

I also don't know what's the global opinion on fixpoints whose bodies aren't lambdas : this would patch one way to construct them from the external syntax, leaving none to my knowledge; they are also eta-expanded on printing, yet they are not explicitly refused by the type-checker and can apprently be constructed using alternate methods


- [x] Added / updated **test-suite**.
- [ ] Added **changelog**.
- [ ] Documented any new / changed **user messages**.
