### PR TITLE
Micromega: avoid generating duplicate pivots in fourier_small

### DIFF
--- a/test-suite/bugs/bug_17960.v
+++ b/test-suite/bugs/bug_17960.v
@@ -1,0 +1,67 @@
+Require Import ZArith.
+Require Import Lia.
+
+Open Scope Z_scope.
+
+Parameter Znth : Z -> list Z -> Z.
+Parameter Zlength : list Z -> Z.
+Parameter max_unsigned : Z.
+
+Goal forall j r N M row_ptr,
+  Zlength row_ptr = N + 1 ->
+  0 <= r ->
+  r <= Znth 0 row_ptr ->
+  Znth (N + 1 - 1) row_ptr <= max_unsigned ->
+  0 <= j < N ->
+  0 <= M ->
+  0 <= N + 1 ->
+  0 <= j + 1 < N + 1 ->
+  0 <= j + 1 < N + 1 ->
+  j + 1 <= j + 1 + 0 ->
+  Znth (j + 1) row_ptr <= Znth (j + 1) row_ptr ->
+  0 <= j + 1 < N + 1 ->
+  0 <= j < N + 1 ->
+  j + 0 < j + 1 ->
+  0 <= j + 1 < N + 1 ->
+  0 <= N < N + 1 ->
+  j + 1 <= N + 0 -> Znth (j + 1) row_ptr <= M -> 0 <= j + 1 < N + 1 ->
+  0 <= 0 < N + 1 ->
+  0 + 0 < j + 1 ->
+  0 <= j + 1 < N + 1 ->
+  0 <= N + 1 - 1 < N + 1 ->
+  j + 1 <= N + 1 - 1 + 0 ->
+  Znth (j + 1) row_ptr <= Znth (N + 1 - 1) row_ptr ->
+  0 <= j < N + 1 ->
+  0 <= j < N + 1 ->
+  j <= j + 0 ->
+  Znth j row_ptr <= Znth j row_ptr ->
+  0 <= j < N + 1 ->
+  0 <= N < N + 1 ->
+  j <= N + 0 ->
+  Znth j row_ptr <= M ->
+  0 <= j < N + 1 ->
+  0 <= 0 < N + 1 ->
+  j <= 0 + 0 ->
+  Znth j row_ptr <= Znth 0 row_ptr -> 0 <= j < N + 1 -> 0 <= N + 1 - 1 < N + 1 ->
+  j <= N + 1 - 1 + 0 ->
+  Znth j row_ptr <= Znth (N + 1 - 1) row_ptr ->
+  0 <= j < N + 1 ->
+  0 <= j + 1 < N + 1 ->
+  j <= j + 1 + 0 ->
+  Znth j row_ptr <= Znth (j + 1) row_ptr ->
+  0 <= N < N + 1 ->
+  0 <= N < N + 1 ->
+  N <= N + 0 ->
+  M <= M ->
+  0 <= N < N + 1 ->
+  0 <= 0 < N + 1 ->
+  0 + 0 < N ->
+  0 <= N < N + 1 ->
+  0 <= N + 1 - 1 < N + 1 ->
+  N <= N + 1 - 1 + 0 ->
+  M <= Znth (N + 1 - 1) row_ptr ->
+  0 <= N < N + 1 -> 0 <= j + 1 < N + 1 -> j + 1 + 0 < N ->
+  False.
+Proof.
+  Timeout 1 Fail lia. (* lia crashes. *)
+Abort.


### PR DESCRIPTION
Fix #17960

On that example, we would have in pre_process
~~~ocaml
  let pbnd1 = fourier_small sys1 in
  let sys2 = elim_redundant (List.rev_append pbnd1 sys1) in
~~~
`List.length sys1` = 87
`List.length pbnd1` = 11539957 (11.5 million)
`List.length sys2` = 16

The example would usually stack overflow (because of the concatenation
`acc @ l'`) and if given unlimited stack fail with "cannot find
witness" after consuming a few seconds and 5GB RAM.

After the patch we have `List.length pbnd1` = 2 (length of `sys2`
stays the same at 16) and the example fails with "cannot find witness"
very fast with negliglible RAM consumption.
