### PR TITLE
The kernel does not care about whether a subtype of an inductive type is nested or not

### DIFF
--- a/checker/checkInductive.ml
+++ b/checker/checkInductive.ml
@@ -122,17 +122,15 @@ let check_squashed orig generated = match orig, generated with
 (* Use [eq_ind_chk] because when we rebuild the recargs we have lost
    the knowledge of who is the canonical version.
    Try with to see test-suite/coqchk/include.v *)
-let eq_nested_types ty1 ty2 = match ty1, ty2 with
-| NestedInd ind1, NestedInd ind2 -> eq_ind_chk ind1 ind2
-| NestedInd _, _ -> false
-| NestedPrimitive c1, NestedPrimitive c2 -> Names.Constant.CanOrd.equal c1 c2
-| NestedPrimitive _, _ -> false
+let eq_recarg_type ty1 ty2 = match ty1, ty2 with
+  | RecArgInd ind1, RecArgInd ind2 -> eq_ind_chk ind1 ind2
+  | RecArgPrim c1, RecArgPrim c2 -> Names.Constant.CanOrd.equal c1 c2
+  | (RecArgInd _ | RecArgPrim _), _ -> false
 
-let eq_recarg a1 a2 = match a1, a2 with
+let eq_recarg r1 r2 = match r1, r2 with
   | Norec, Norec -> true
-  | Mrec i1, Mrec i2 -> eq_ind_chk i1 i2
-  | Nested ty1, Nested ty2 -> eq_nested_types ty1 ty2
-  | (Norec | Mrec _ | Nested _), _ -> false
+  | Mrec ty1, Mrec ty2 -> eq_recarg_type ty1 ty2
+  | (Norec | Mrec _), _ -> false
 
 let eq_reloc_tbl = Array.equal (fun x y -> Int.equal (fst x) (fst y) && Int.equal (snd x) (snd y))
 

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -263,11 +263,11 @@ let v_cb = v_tuple "constant_body"
     v_bool;
     v_typing_flags|]
 
-let v_nested = v_sum "nested" 0
-  [|[|v_ind|] (* NestedInd *);[|v_cst|] (* NestedPrimitive *)|]
+let v_recarg_type = v_sum "recarg_type" 0
+  [|[|v_ind|] (* Mrec *);[|v_cst|] (* NestedPrimitive *)|]
 
 let v_recarg = v_sum "recarg" 1 (* Norec *)
-  [|[|v_ind|] (* Mrec *);[|v_nested|] (* Nested *)|]
+  [|[|v_recarg_type|] (* Mrec *)|]
 
 let rec v_wfp = Sum ("wf_paths",0,
     [|[|Int;Int|]; (* Rtree.Param *)

--- a/dev/ci/user-overlays/18229-herbelin-master+guard-merging-rec-nested.sh
+++ b/dev/ci/user-overlays/18229-herbelin-master+guard-merging-rec-nested.sh
@@ -1,0 +1,1 @@
+overlay serapi https://github.com/herbelin/coq-serapi main+adapt-coq-pr18129-nested-ind 18229 master+guard-merging-rec-nested

--- a/kernel/declarations.mli
+++ b/kernel/declarations.mli
@@ -120,14 +120,14 @@ type 'opaque pconstant_body = {
 type constant_body = Opaqueproof.opaque pconstant_body
 
 (** {6 Representation of mutual inductive types in the kernel } *)
-type nested_type =
-| NestedInd of inductive
-| NestedPrimitive of Constant.t
+
+type recarg_type =
+| RecArgInd of inductive
+| RecArgPrim of Constant.t
 
 type recarg =
 | Norec
-| Mrec of inductive
-| Nested of nested_type
+| Mrec of recarg_type
 
 type wf_paths = recarg Rtree.t
 

--- a/kernel/indtypes.ml
+++ b/kernel/indtypes.ml
@@ -219,7 +219,8 @@ let check_positivity_one ~chkpos recursive (env,_,ntypes,_ as ienv) paramsctxt (
               | Some b ->
                   check_strict_positivity (ienv_push_var ienv (na, b, mk_norec)) nmr d)
         | Rel k ->
-            (try let (ra,rarg) = List.nth ra_env (k-1) in
+            (match List.nth_opt ra_env (k-1) with
+            | Some (ra,rarg) ->
             let largs = List.map (whd_all env) largs in
             let nmr1 =
               (match ra with
@@ -233,7 +234,7 @@ let check_positivity_one ~chkpos recursive (env,_,ntypes,_ as ienv) paramsctxt (
                  not (List.for_all (noccur_between n ntypes) largs)
               then failwith_non_pos_list n ntypes largs
               else (nmr1,rarg)
-             with Failure _ | Invalid_argument _ -> (nmr,mk_norec))
+            | None -> (nmr,mk_norec))
         | Ind ind_kn ->
             (** If one of the inductives of the mutually inductive
                 block being defined appears in a parameter, then we

--- a/kernel/indtypes.ml
+++ b/kernel/indtypes.ml
@@ -165,7 +165,7 @@ let ienv_push_inductive (env, n, ntypes, ra_env) ((mi,u),lrecparams) =
     let decl = LocalAssum (anon, hnf_prod_applist env ty lrecparams) in
     push_rel decl env in
   let ra_env' =
-    (Nested (NestedInd mi),(Rtree.mk_rec_calls 1).(0)) ::
+    (Mrec (RecArgInd mi),(Rtree.mk_rec_calls 1).(0)) ::
     List.map (fun (r,t) -> (r,Rtree.lift 1 t)) ra_env in
   (* New index of the inductive types *)
   let newidx = n + auxntyp in
@@ -195,7 +195,7 @@ let array_min nmr a = if Int.equal nmr 0 then 0 else
     If [chkpos] is [false] then positivity is assumed, and
     [check_positivity_one] computes the subterms occurrences in a
     best-effort fashion. *)
-let check_positivity_one ~chkpos recursive (env,_,ntypes,_ as ienv) paramsctxt (_,i as ind) nnonrecargs lcnames indlc =
+let check_positivity_one ~chkpos recursive (env,_,ntypes,_ as ienv) paramsctxt (mind,i as ind) nnonrecargs lcnames indlc =
   let nparamsctxt = Context.Rel.length paramsctxt in
   let nmr = Context.Rel.nhyps paramsctxt in
   (** Positivity of one argument [c] of a constructor (i.e. the
@@ -224,8 +224,12 @@ let check_positivity_one ~chkpos recursive (env,_,ntypes,_ as ienv) paramsctxt (
             let largs = List.map (whd_all env) largs in
             let nmr1 =
               (match ra with
-                  Mrec _ -> compute_rec_par ienv paramsctxt nmr largs
-                |  _ -> nmr)
+                (* Are we referring to the original block of mutual inductive types? *)
+                | Mrec (RecArgInd (mind',_)) ->
+                  if Names.MutInd.CanOrd.equal mind mind'
+                  then compute_rec_par ienv paramsctxt nmr largs
+                  else nmr
+                | Norec | Mrec (RecArgPrim _) -> nmr)
             in
               (** The case where one of the inductives of the mutually
                   inductive block occurs as an argument of another is not
@@ -302,7 +306,7 @@ let check_positivity_one ~chkpos recursive (env,_,ntypes,_ as ienv) paramsctxt (
         let irecargs = Array.map snd irecargs_nmr
         and nmr' = array_min nmr irecargs_nmr
         in
-          (nmr',(Rtree.mk_rec [|mk_paths (Nested (NestedInd ind)) irecargs|]).(0))
+          (nmr',(Rtree.mk_rec [|mk_paths (Mrec (RecArgInd ind)) irecargs|]).(0))
 
   and check_positivity_nested_primitive (env,n,ntypes,ra_env) nmr (c, largs) =
     (* We model the primitive type c X1 ... Xn as if it had one constructor
@@ -311,7 +315,7 @@ let check_positivity_one ~chkpos recursive (env,_,ntypes,_ as ienv) paramsctxt (
     let ra_env = List.map (fun (r,t) -> (r,Rtree.lift 1 t)) ra_env in
     let ienv = (env,n,ntypes,ra_env) in
     let nmr',recargs = List.fold_left_map (check_strict_positivity ienv) nmr largs in
-    (nmr', (Rtree.mk_rec [| mk_paths (Nested (NestedPrimitive c)) [| recargs |] |]).(0))
+    (nmr', (Rtree.mk_rec [| mk_paths (Mrec (RecArgPrim c)) [| recargs |] |]).(0))
 
   (** [check_constructors ienv check_head nmr c] checks the positivity
       condition in the type [c] of a constructor (i.e. that recursive
@@ -361,7 +365,7 @@ let check_positivity_one ~chkpos recursive (env,_,ntypes,_ as ienv) paramsctxt (
   in
   let irecargs = Array.map snd irecargs_nmr
   and nmr' = array_min nmr irecargs_nmr
-  in (nmr', mk_paths (Mrec ind) irecargs)
+  in (nmr', mk_paths (Mrec (RecArgInd ind)) irecargs)
 
 (** [check_positivity ~chkpos kn env_ar paramsctxt inds] checks that the mutually
     inductive block [inds] is strictly positive.
@@ -373,7 +377,7 @@ let check_positivity ~chkpos kn names env_ar_par paramsctxt finite inds =
   let ntypes = Array.length inds in
   let recursive = finite != BiFinite in
   if not recursive && Array.length inds <> 1 then raise (InductiveError Type_errors.BadEntry);
-  let rc = Array.mapi (fun j t -> (Mrec (kn,j),t)) (Rtree.mk_rec_calls ntypes) in
+  let rc = Array.mapi (fun j t -> (Mrec (RecArgInd (kn,j)),t)) (Rtree.mk_rec_calls ntypes) in
   let ra_env_ar = Array.rev_to_list rc in
   let nparamsctxt = Context.Rel.length paramsctxt in
   let nmr = Context.Rel.nhyps paramsctxt in

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -107,13 +107,13 @@ let mis_is_recursive_subset listind rarg =
     List.exists
       (fun ra ->
         match dest_recarg ra with
-          | Mrec (_,i) -> Int.List.mem i listind
-          | _ -> false) rvec
+          | Mrec (RecArgInd ind) -> List.exists (Names.Ind.CanOrd.equal ind) listind
+          | Mrec (RecArgPrim _) | Norec -> false) rvec
   in
   Array.exists one_is_rec (dest_subterms rarg)
 
-let mis_is_recursive (ind,mib,mip) =
-  mis_is_recursive_subset (List.interval 0 (mib.mind_ntypes - 1))
+let mis_is_recursive ((ind,_),mib,mip) =
+  mis_is_recursive_subset (List.init mib.mind_ntypes (fun i -> (ind,i)))
     mip.mind_recargs
 
 let mis_nf_constructor_type ((_,j),u) (mib,mip) =

--- a/pretyping/inductiveops.mli
+++ b/pretyping/inductiveops.mli
@@ -58,7 +58,7 @@ val ind_of_ind_type : inductive_type -> inductive
 val relevance_of_inductive_type : env -> inductive_type -> Sorts.relevance
 
 val mkAppliedInd : inductive_type -> EConstr.constr
-val mis_is_recursive_subset : int list -> wf_paths -> bool
+val mis_is_recursive_subset : inductive list -> wf_paths -> bool
 val mis_is_recursive :
   inductive * mutual_inductive_body * one_inductive_body -> bool
 val mis_nf_constructor_type :

--- a/tactics/elimschemes.ml
+++ b/tactics/elimschemes.ml
@@ -40,7 +40,7 @@ let optimize_non_type_induction_scheme kind dep sort env _handle ind =
     let npars =
       (* if a constructor of [ind] contains a recursive call, the scheme
          is generalized only wrt recursively uniform parameters *)
-      if (Inductiveops.mis_is_recursive_subset [snd ind] mip.mind_recargs)
+      if (Inductiveops.mis_is_recursive_subset [ind] mip.mind_recargs)
       then
         mib.mind_nparams_rec
       else

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -117,9 +117,9 @@ let compute_constructor_signatures env ~rec_flag ((_,k as ity),u) =
     | RelDecl.LocalAssum _ :: c, recarg::rest ->
         let rest = analrec c rest in
         begin match Declareops.dest_recarg recarg with
-        | Norec | Nested _  -> true :: rest
-        | Mrec (_,j)  ->
-            if rec_flag && Int.equal j k then true :: true :: rest
+        | Norec | Mrec (RecArgPrim _)  -> true :: rest
+        | Mrec (RecArgInd ind) ->
+            if rec_flag && Names.Ind.CanOrd.equal ity ind then true :: true :: rest
             else true :: rest
         end
     | RelDecl.LocalDef _ :: c, rest -> false :: analrec c rest

--- a/test-suite/success/NestedInd.v
+++ b/test-suite/success/NestedInd.v
@@ -1,0 +1,188 @@
+Require Import Utf8.
+Unset Elimination Schemes.
+
+Definition Decision (P : Prop) := {P} + {¬ P}.
+
+Definition RelDecision {A B : Type} (R : A → B → Prop) :=
+   ∀ (x : A) (y : B), Decision (R x y) : Type.
+
+Inductive gmap_dep_ne (A : Type) : Type :=
+    GNode001 : gmap_dep_ne A → gmap_dep_ne A
+  | GNode010 : A → gmap_dep_ne A
+  | GNode011 : A → gmap_dep_ne A → gmap_dep_ne A
+  | GNode100 : gmap_dep_ne A → gmap_dep_ne A
+  | GNode101 : gmap_dep_ne A → gmap_dep_ne A → gmap_dep_ne A
+  | GNode110 : gmap_dep_ne A → A → gmap_dep_ne A
+  | GNode111 : gmap_dep_ne A → A → gmap_dep_ne A → gmap_dep_ne A.
+
+Variant gmap_dep (A : Type) : Type :=
+    GEmpty : gmap_dep A | GNodes : gmap_dep_ne A → gmap_dep A.
+
+Arguments GEmpty {A}.
+Arguments GNodes {A}.
+
+Record gmap {K : Type} (EqDecision0 : RelDecision (@eq K))
+  (A : Type) : Type := GMap { gmap_car : gmap_dep A }.
+
+Inductive gtest {K : Type} (H : RelDecision (@eq K)) := GTest : gmap H (gtest H) → gtest H.
+Arguments GTest {_ _} _.
+
+Definition option_union_with (A : Type) (f : A → A → option A) (mx my : option A) :=
+  match mx with
+  | Some x => match my with
+              | Some y => f x y
+              | None => Some x
+              end
+  | None => match my with
+            | Some y => Some y
+            | None => None
+            end
+  end.
+
+Definition gmap_dep_ne_case (A : Type) (B : Type) (t : gmap_dep_ne A)
+  (f : gmap_dep A → option A → gmap_dep A → B) :=
+  match t with
+  | GNode001 _ r => f GEmpty None (GNodes r)
+  | GNode010 _ x => f GEmpty (Some (x)) GEmpty
+  | GNode011 _ x r => f GEmpty (Some (x)) (GNodes r)
+  | GNode100 _ l => f (GNodes l) None GEmpty
+  | GNode101 _ l r => f (GNodes l) None (GNodes r)
+  | GNode110 _ l x => f (GNodes l) (Some (x)) GEmpty
+  | GNode111 _ l x r => f (GNodes l) (Some (x)) (GNodes r)
+  end.
+
+Definition gmap_dep_omap_aux {A B : Type} (go : gmap_dep_ne A → gmap_dep B)
+  (tm : gmap_dep A) :=
+  match tm with
+  | GEmpty => GEmpty
+  | GNodes t' => go t'
+  end.
+
+Definition option_bind {A B : Type} (f : A → option B) (mx : option A) :=
+  match mx with
+  | Some x => f x
+  | None => None
+  end.
+
+Definition GNode (A : Type)
+  (ml : gmap_dep A)
+  (mx : option (A))
+  (mr : gmap_dep A) :=
+  match ml with
+  | GEmpty =>
+      match mx with
+      | Some x =>
+          match mr with
+          | GEmpty => GNodes (GNode010 _ x)
+          | GNodes r => GNodes (GNode011 _ x r)
+          end
+      | None =>
+          match mr with
+          | GEmpty => GEmpty
+          | GNodes r => GNodes (GNode001 _ r)
+          end
+      end
+  | GNodes l =>
+      match mx with
+      | Some (x) =>
+          match mr with
+          | GEmpty => GNodes (GNode110 _ l x)
+          | GNodes r => GNodes (GNode111 _ l x r)
+          end
+      | None =>
+          match mr with
+          | GEmpty => GNodes (GNode100 _ l)
+          | GNodes r => GNodes (GNode101 _ l r)
+          end
+      end
+  end.
+
+Definition gmap_dep_ne_omap (A B : Type) (f : A → option B) :=
+  fix go (t : gmap_dep_ne A) {struct t} : gmap_dep B :=
+    gmap_dep_ne_case _ _ t
+      (λ (ml : gmap_dep A) (mx : option A) (mr : gmap_dep A),
+         GNode _
+           (gmap_dep_omap_aux (go) ml)
+           (option_bind f mx)
+           (gmap_dep_omap_aux (go) mr)).
+
+Definition gmap_merge_aux (A B C : Type) (go : gmap_dep_ne A
+                                             → gmap_dep_ne B → gmap_dep C)
+  (f : option A → option B → option C) (mt1 : gmap_dep A)
+  (mt2 : gmap_dep B) :=
+  match mt1 with
+  | GEmpty =>
+      match mt2 with
+      | GEmpty => GEmpty
+      | GNodes t2' => gmap_dep_ne_omap _ _ (λ x : B, f None (Some x)) t2'
+      end
+  | GNodes t1' =>
+      match mt2 with
+      | GEmpty => gmap_dep_ne_omap _ _ (λ x : A, f (Some x) None) t1'
+      | GNodes t2' => go t1' t2'
+      end
+  end.
+
+Definition diag_None' {A B C : Type} (f : option A → option B → option C)
+  (mx : option (A)) (my : option (B)) :=
+  match mx with
+  | Some (x) =>
+      match my with
+      | Some (y) => f (Some x) (Some y)
+      | None => f (Some x) None
+      end
+  | None =>
+      match my with
+      | Some (y) => f None (Some y)
+      | None => None
+      end
+  end.
+
+Definition gmap_dep_ne_merge {A B C : Type} (f : option A → option B → option C) :=
+  fix go
+   (t1 : gmap_dep_ne A) (t2 : gmap_dep_ne B)
+    {struct t1} : gmap_dep C :=
+    gmap_dep_ne_case _ _ t1
+      (λ (ml1 : gmap_dep A)
+         (mx1 : option (A)) (mr1 : gmap_dep A) ,
+         gmap_dep_ne_case _ _ t2
+           (λ (ml2 : gmap_dep B)
+              (mx2 : option (B)) (mr2 : gmap_dep B),
+              GNode _
+                (gmap_merge_aux _ _ _ go
+                   f ml1 ml2) (diag_None' f mx1 mx2)
+                (gmap_merge_aux _ _ _ go
+                   f mr1 mr2))).
+
+Definition gmap_dep_merge {A B C : Type}
+  (f : option A → option B → option C) :=
+  gmap_merge_aux _ _ _ (gmap_dep_ne_merge f) f
+     : gmap_dep A → gmap_dep B → gmap_dep C.
+
+Definition gmap_merge (K : Type) (H : RelDecision (@eq K))
+  (A B C : Type) (f : option A → option B → option C) := (fun '{| gmap_car := mt1 |} '{| gmap_car := mt2 |} =>
+  {| gmap_car := gmap_dep_merge f mt1 mt2 |})
+     : (gmap H A) -> (gmap H B) -> (gmap H C).
+
+Fixpoint gtest_merge {K : Type} (H : RelDecision (@eq K)) (t1 t2 : gtest H) {struct t1} : gtest H :=
+  match t1, t2 with
+  | GTest ts1, GTest ts2 =>
+     GTest (gmap_merge K H _ _ _ (@option_union_with _ (λ t1 t2, Some (gtest_merge H t1 t2))) ts1 ts2)
+  end.
+
+(* An example from metacoq (simplified) *)
+
+Notation "x .π2" := (projT2 x) (at level 0).
+
+Parameter term : Type.
+
+Inductive All (P :  term -> Type) : Type :=
+  | All_cons : {x:term & P x} -> All P -> All P.
+
+Inductive inferring  (Σ : unit) : term -> Type :=
+| infer x : All (inferring Σ) -> inferring Σ x.
+
+Fixpoint inferring_size  {Σ t} (d : inferring Σ t) {struct d} : nat :=
+  match d with
+  | infer _ _ (All_cons _ p _) => inferring_size p.π2
+  end.

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -673,7 +673,7 @@ let build_beq_scheme env handle kn =
   let nb_ind = Array.length mib.mind_packets in
   let truly_recursive =
     let open Declarations in
-    let is_rec ra = match Declareops.dest_recarg ra with Mrec _ | Nested _ -> true | Norec -> false in
+    let is_rec ra = match Declareops.dest_recarg ra with Mrec _ -> true | Norec -> false in
     Array.exists
       (fun mip -> Array.exists (List.exists is_rec) (Declareops.dest_subterms mip.mind_recargs))
       mib.mind_packets in


### PR DESCRIPTION
So as to simplify the kernel (especially `Inductive.inter_recarg`), we merge the `Mrec` and `Nested(NestedInd)` recursive arguments as they behave the same.

Outside kernel, induction schemes skip nested types, so the difference matters but we compensate by checking the name of the inductive type.

This is a byproduct of #17950.

Overlay: ejgallego/coq-serapi/pull/379