### PR TITLE
An attempt to make the result of the wf_paths printer more readable

### DIFF
--- a/dev/base_include
+++ b/dev/base_include
@@ -17,6 +17,7 @@
 #install_printer  (* constant *) ppcon;;
 #install_printer  (* projection *) ppproj;;
 #install_printer  (* projection *) ppprojrepr;;
+#install_printer  (* recarg *)  pprecargs;;
 #install_printer  (* recarg Rtree.t *)  ppwf_paths;;
 #install_printer  (* constr *)  print_pure_constr;;
 #install_printer  (* patch *) ppripos;;

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -57,8 +57,8 @@ let ppsp sp = pp(pr_path sp)
 let ppqualid qid = pp(pr_qualid qid)
 let ppscheme k = pp (Ind_tables.pr_scheme_kind k)
 
-let prrecarg = Declareops.pp_recarg
-let ppwf_paths x = pp (Declareops.pp_wf_paths x)
+let pprecarg = Declareops.pr_recarg
+let ppwf_paths x = pp (Declareops.pr_wf_paths x)
 
 let get_current_context () =
   try Vernacstate.Declare.get_current_context ()

--- a/dev/top_printers.mli
+++ b/dev/top_printers.mli
@@ -34,7 +34,7 @@ val ppqualid : Libnames.qualid -> unit
 
 val ppscheme : 'a Ind_tables.scheme_kind -> unit
 
-val prrecarg : Declarations.recarg -> Pp.t
+val pprecarg : Declarations.recarg -> Pp.t
 val ppwf_paths : Declarations.recarg Rtree.t -> unit
 
 val pr_evar : Evar.t -> Pp.t

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -171,16 +171,18 @@ let eq_recarg r1 r2 = match r1, r2 with
 | Nested ty1, Nested ty2 -> eq_nested_type ty1 ty2
 | Nested _, _ -> false
 
-let pp_recarg = let open Pp in function
-  | Declarations.Norec -> str "Norec"
+let pr_recarg_internal b = let open Pp in function
+  | Declarations.Norec -> if b then Some (Pp.str "Norec") else None
   | Declarations.Mrec (mind,i) ->
-     str "Mrec[" ++ Names.MutInd.print mind ++ pr_comma () ++ int i ++ str "]"
+     Some (str "Mrec[" ++ Names.MutInd.print mind ++ pr_comma () ++ int i ++ str "]")
   | Declarations.(Nested (NestedInd (mind,i))) ->
-     str "Nested[" ++ Names.MutInd.print mind ++ pr_comma () ++ int i ++ str "]"
+     Some (str "Nested[" ++ Names.MutInd.print mind ++ pr_comma () ++ int i ++ str "]")
   | Declarations.(Nested (NestedPrimitive c)) ->
-     str "Nested[" ++ Names.Constant.print c ++ str "]"
+     Some (str "Nested[" ++ Names.Constant.print c ++ str "]")
 
-let pp_wf_paths x = Rtree.pp_tree pp_recarg x
+let pr_wf_paths x = Rtree.pr_alternating_tree pr_recarg_internal x
+
+let pr_recarg x = match pr_recarg_internal false x with None -> Pp.str "Norec" | Some p -> p
 
 let subst_nested_type subst ty = match ty with
 | NestedInd (kn,i) ->

--- a/kernel/declareops.mli
+++ b/kernel/declareops.mli
@@ -46,8 +46,8 @@ val is_opaque : 'a pconstant_body -> bool
 
 val eq_recarg : recarg -> recarg -> bool
 
-val pp_recarg : recarg -> Pp.t
-val pp_wf_paths : wf_paths -> Pp.t
+val pr_recarg : recarg -> Pp.t
+val pr_wf_paths : wf_paths -> Pp.t
 
 val subst_recarg : substitution -> recarg -> recarg
 

--- a/lib/rtree.ml
+++ b/lib/rtree.ml
@@ -195,17 +195,22 @@ let is_infinite cmp t =
 (* Pretty-print a tree (not so pretty) *)
 open Pp
 
-let rec pp_tree prl t =
-  match t with
-      Param (i,j) -> str"#"++int i++str","++int j
-    | Node(lab,[||]) -> hov 2 (str"("++prl lab++str")")
+let pr_alternating_tree prl t =
+  let rec aux b = function
+    | Param (i,j) -> str"#"++int i++str":"++int j
     | Node(lab,v) ->
-        hov 2 (str"("++prl lab++str","++brk(1,0)++
-               prvect_with_sep pr_comma (pp_tree prl) v++str")")
+      let p' = prvect_with_sep pr_comma (aux (not b)) v in
+      let paren p = if b then str"["++hv 0 p'++str"]" else str"("++hv 0 p'++str")" in
+      hov 0
+          (match prl b lab with
+          | None -> paren (mt())
+          | Some p -> if Array.length v = 0 then p else (p++str","++spc()++paren p'))
     | Rec(i,v) ->
         if Int.equal (Array.length v) 0 then str"Rec{}"
         else if Int.equal (Array.length v) 1 then
-          hov 2 (str"Rec{"++pp_tree prl v.(0)++str"}")
+          hv 2 (str"Rec{"++aux b v.(0)++str"}")
         else
-          hov 2 (str"Rec{"++int i++str","++brk(1,0)++
-                 prvect_with_sep pr_comma (pp_tree prl) v++str"}")
+          hv 2 (str"Rec{"++int i++str","++brk(1,0)++
+                 prvect_with_sep pr_comma (aux b) v++str"}")
+  in
+  aux true t

--- a/lib/rtree.mli
+++ b/lib/rtree.mli
@@ -77,8 +77,8 @@ val incl : ('a -> 'a -> bool) -> ('a -> 'a -> 'a option) -> 'a -> 'a t -> 'a t -
 (** See also [Smart.map] *)
 val map : ('a -> 'b) -> 'a t -> 'b t
 
-(** A rather simple minded pretty-printer *)
-val pp_tree : ('a -> Pp.t) -> 'a t -> Pp.t
+(** A rather simple-minded pretty-printer *)
+val pr_alternating_tree : (bool -> 'a -> Pp.t option) -> 'a t -> Pp.t
 
 module Smart :
 sig


### PR DESCRIPTION
*This is subsumed by #18241*

The `Rtree.t` structure is a generic structure to encore (possibly mutual) fixpoints. It is used to encode the recursive structure of (co)inductive types for the guard condition.

The encoding is of the following form:
- encoding of inductive types
  ```ocaml
  Rec(0,
    [|Node (Mrec(name-of-ind),
      [|Node (Norec,wf_paths-of-arguments-of-constructor_1);
        ...
        Node (Norec,wf_paths-of-arguments-of-constructor_n)|] |]
  ```
  which stands for `μX.[T11 ⨯ ... T1n_1 | ... | Tp1 ⨯ ... Tpn_p]` where the Tij is the j argument of the i-th constructor, and where `name-of-ind` is an annotation to remember which inductive type we are talking about
- encoding of non-recursive types:
  ```ocaml
  Node (Norec,[||])
  ```
- encoding of recursive calls
  ```ocaml
  Param (n,0)
  ```
  for a reference to the n-th `Rec` binder (counting à la de Bruijn, from 0)

and, more generally,
```ocaml
Rec(i,[|Node (Mrec(name-of-ind,0) ...); ...; Node (Mrec(name-of-ind,q) ...)|])
```
for q-mutual inductive types, with `Param(n,i)` referring to the i-th among the q.

The polysemic use of `Norec` in the encoding is disturbing, and this PR tries to print wf_paths in a more intuitive way. For instance, for vectors of nat, the proposed printing is:
```ocaml
Rec{Mrec[Top.vector, 0],
      [(),
       (Norec, Rec{Nested[Coq.Init.Datatypes.nat, 0], [(), (#0:0)]}, #0:0)]}
```
while it was before:
```ocaml
Rec{(Mrec[Top.vector, 0], (Norec),
      (Norec, (Norec),
        Rec{(Nested[Coq.Init.Datatypes.nat, 0], (Norec), (Norec, #0,0))}, #0,0))}
```

Note that I kept numeric indices. An alternative could be to use the name (here `Fixpoint.vector, 0`) but I felt that it would be too verbose.

An alternative would have been to use generated names as in:
```ocaml
Rec{X/Mrec[Fixpoint.vector, 0],
      [(),
       (Norec, Rec{Y/Nested[Coq.Init.Datatypes.nat, 0], [(), (Y)]}, X)]}
```

Note: in passing, we align to the convention that pr_ means to Pp.t and pp_ means to string.

