### PR TITLE
Static invariants on the environment module from Micromega.

### DIFF
--- a/plugins/micromega/certificate.ml
+++ b/plugins/micromega/certificate.ml
@@ -539,7 +539,7 @@ let nlinear_prover prfdepth sys =
       (fun acc (_, r) -> max acc (ProofFormat.pr_rule_max_hyp r))
       0 sys
   in
-  let env = ProofFormat.Env.of_list  (CList.interval 0 id) in
+  let env = ProofFormat.Env.make (id + 1) in
   match linear_prover_cstr sys with
   | None -> Unknown
   | Some cert -> Prf (ProofFormat.cmpl_prf_rule Mc.normQ CamlToCoq.q env cert)
@@ -553,7 +553,7 @@ let linear_prover_with_cert prfdepth sys =
   | Some cert ->
     Prf
       (ProofFormat.cmpl_prf_rule Mc.normQ CamlToCoq.q
-         (ProofFormat.Env.of_listi sys)
+         (ProofFormat.Env.make (List.length sys))
          cert)
 
 (* The prover is (probably) incomplete --
@@ -867,8 +867,7 @@ let xlia env red sys =
           (fun acc (_, r) -> max acc (ProofFormat.pr_rule_max_hyp r))
           0 sys
     in
-    let env = CList.interval 0 (id - 1) in
-    Prf (compile_proof env prf)
+    Prf (compile_proof (Env.make id) prf)
   in
   try
     let sys = red sys in

--- a/plugins/micromega/mutils.ml
+++ b/plugins/micromega/mutils.ml
@@ -22,21 +22,14 @@
 open NumCompat
 module Z_ = NumCompat.Z
 
-module Int = struct
-  type t = int
-
-  let compare : int -> int -> int = compare
-  let equal : int -> int -> bool = ( = )
-end
-
 module ISet = struct
-  include Set.Make (Int)
+  include Int.Set
 
   let pp o s = iter (fun i -> Printf.fprintf o "%i " i) s
 end
 
 module IMap = struct
-  include Map.Make (Int)
+  include Int.Map
 
   let from k m =
     let _, _, r = split (k - 1) m in

--- a/plugins/micromega/mutils.mli
+++ b/plugins/micromega/mutils.mli
@@ -10,21 +10,14 @@
 
 open NumCompat
 
-module Int : sig
-  type t = int
-
-  val compare : int -> int -> int
-  val equal : int -> int -> bool
-end
-
 module ISet : sig
-  include Set.S with type elt = int
+  include CSet.S with type elt = int
 
   val pp : out_channel -> t -> unit
 end
 
 module IMap : sig
-  include Map.S with type key = int
+  include CMap.ExtS with type key = int and module Set := ISet
 
   (** [from k  m] returns the submap of [m] with keys greater or equal k *)
   val from : key -> 'elt t -> 'elt t

--- a/plugins/micromega/polynomial.mli
+++ b/plugins/micromega/polynomial.mli
@@ -272,13 +272,13 @@ module ProofFormat : sig
   val add_proof : prf_rule -> prf_rule -> prf_rule
   val mul_cst_proof : Q.t -> prf_rule -> prf_rule
   val mul_proof : prf_rule -> prf_rule -> prf_rule
-  val compile_proof : int list -> proof -> Micromega.zArithProof
 
   module Env: sig
     type t
-    val of_list : int list -> t
-    val of_listi : 'a list -> t
+    val make : int -> t
   end
+
+  val compile_proof : Env.t -> proof -> Micromega.zArithProof
 
   val cmpl_prf_rule :
        ('a Micromega.pExpr -> 'a Micromega.pol)


### PR DESCRIPTION
We ensure that the environment only contains Def and Hyp nodes in this precise order, and we simplify the API so that it is clear that only the number of variables matters for
 creation.

This should also be more algorithmically efficient although I don't think it matters in practice.