### PR TITLE
Simplify the encoding of the recursive disjunctive-conjunctive structure of (co)inductive types in rtree.ml by taking nodes of arrays of arrays

### DIFF
--- a/checker/values.ml
+++ b/checker/values.ml
@@ -266,7 +266,7 @@ let v_recarg = v_sum "recarg" 1 (* Norec *)
 
 let rec v_wfp = Sum ("wf_paths",0,
     [|[|Int;Int|]; (* Rtree.Param *)
-      [|v_recarg;Array v_wfp|]; (* Rtree.Node *)
+      [|v_recarg;Array (Array v_wfp)|]; (* Rtree.Node *)
       [|Int;Array v_wfp|] (* Rtree.Rec *)
     |])
 

--- a/dev/base_include
+++ b/dev/base_include
@@ -17,6 +17,7 @@
 #install_printer  (* constant *) ppcon;;
 #install_printer  (* projection *) ppproj;;
 #install_printer  (* projection *) ppprojrepr;;
+#install_printer  (* recarg *)  pprecarg;;
 #install_printer  (* recarg Rtree.t *)  ppwf_paths;;
 #install_printer  (* constr *)  print_pure_constr;;
 #install_printer  (* patch *) ppripos;;

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -57,8 +57,8 @@ let ppsp sp = pp(pr_path sp)
 let ppqualid qid = pp(pr_qualid qid)
 let ppscheme k = pp (Ind_tables.pr_scheme_kind k)
 
-let prrecarg = Declareops.pp_recarg
-let ppwf_paths x = pp (Declareops.pp_wf_paths x)
+let pprecarg = Declareops.pr_recarg
+let ppwf_paths x = pp (Declareops.pr_wf_paths x)
 
 let get_current_context () =
   try Vernacstate.Declare.get_current_context ()

--- a/dev/top_printers.mli
+++ b/dev/top_printers.mli
@@ -34,7 +34,7 @@ val ppqualid : Libnames.qualid -> unit
 
 val ppscheme : 'a Ind_tables.scheme_kind -> unit
 
-val prrecarg : Declarations.recarg -> Pp.t
+val pprecarg : Declarations.recarg -> Pp.t
 val ppwf_paths : Declarations.recarg Rtree.t -> unit
 
 val pr_evar : Evar.t -> Pp.t

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -171,8 +171,8 @@ let eq_recarg r1 r2 = match r1, r2 with
 | Nested ty1, Nested ty2 -> eq_nested_type ty1 ty2
 | Nested _, _ -> false
 
-let pp_recarg = let open Pp in function
-  | Declarations.Norec -> str "Norec"
+let pr_recarg = let open Pp in function
+  | Declarations.Norec -> Pp.str "Norec"
   | Declarations.Mrec (mind,i) ->
      str "Mrec[" ++ Names.MutInd.print mind ++ pr_comma () ++ int i ++ str "]"
   | Declarations.(Nested (NestedInd (mind,i))) ->
@@ -180,7 +180,7 @@ let pp_recarg = let open Pp in function
   | Declarations.(Nested (NestedPrimitive c)) ->
      str "Nested[" ++ Names.Constant.print c ++ str "]"
 
-let pp_wf_paths x = Rtree.pp_tree pp_recarg x
+let pr_wf_paths x = Rtree.pr_tree pr_recarg x
 
 let subst_nested_type subst ty = match ty with
 | NestedInd (kn,i) ->
@@ -203,7 +203,7 @@ let mk_norec = Rtree.mk_node Norec [||]
 
 let mk_paths r recargs =
   Rtree.mk_node r
-    (Array.map (fun l -> Rtree.mk_node Norec (Array.of_list l)) recargs)
+    (Array.map Array.of_list recargs)
 
 let dest_recarg p = fst (Rtree.dest_node p)
 
@@ -215,11 +215,11 @@ let dest_recarg p = fst (Rtree.dest_node p)
 let dest_subterms p =
   let (ra,cstrs) = Rtree.dest_node p in
   assert (match ra with Norec -> false | _ -> true);
-  Array.map (fun t -> Array.to_list (snd (Rtree.dest_node t))) cstrs
+  Array.map Array.to_list cstrs
 
 let recarg_length p j =
   let (_,cstrs) = Rtree.dest_node p in
-  Array.length (snd (Rtree.dest_node cstrs.(j-1)))
+  Array.length cstrs.(j-1)
 
 let subst_wf_paths subst p = Rtree.Smart.map (subst_recarg subst) p
 

--- a/kernel/declareops.mli
+++ b/kernel/declareops.mli
@@ -46,8 +46,8 @@ val is_opaque : 'a pconstant_body -> bool
 
 val eq_recarg : recarg -> recarg -> bool
 
-val pp_recarg : recarg -> Pp.t
-val pp_wf_paths : wf_paths -> Pp.t
+val pr_recarg : recarg -> Pp.t
+val pr_wf_paths : wf_paths -> Pp.t
 
 val subst_recarg : substitution -> recarg -> recarg
 

--- a/lib/rtree.mli
+++ b/lib/rtree.mli
@@ -10,13 +10,19 @@
 
 (** Type of regular tree with nodes labelled by values of type 'a
    The implementation uses de Bruijn indices, so binding capture
-   is avoided by the lift operator (see example below) *)
+   is avoided by the lift operator (see example below).
+
+   Note that it differs from standard regular trees by accepting
+   vectors of vectors in nodes, which is useful for encoding
+   disjunctive-conjunctive recursive trees such as inductive types.
+   Standard regular trees can however easily be simulated by using
+   singletons of vectors *)
 type 'a t
 
 (** Building trees *)
 
-(** build a node given a label and the vector of sons *)
-val mk_node  : 'a -> 'a t array -> 'a t
+(** Build a node given a label and a vector of vectors of sons *)
+val mk_node  : 'a -> 'a t array array -> 'a t
 
 (** Build mutually recursive trees:
     X_1 = f_1(X_1,..,X_n) ... X_n = f_n(X_1,..,X_n)
@@ -27,14 +33,14 @@ val mk_node  : 'a -> 'a t array -> 'a t
 
   First example: build  rec X = a(X,Y) and Y = b(X,Y,Y)
   let [|vx;vy|] = mk_rec_calls 2 in
-  let [|x;y|] = mk_rec [|mk_node a [|vx;vy|]; mk_node b [|vx;vy;vy|]|]
+  let [|x;y|] = mk_rec [|mk_node a [|[|vx;vy|]|]; mk_node b [|[|vx;vy;vy|]|]|]
 
   Another example: nested recursive trees rec Y = b(rec X = a(X,Y),Y,Y)
   let [|vy|] = mk_rec_calls 1 in
   let [|vx|] = mk_rec_calls 1 in
-  let [|x|] = mk_rec[|mk_node a vx;lift 1 vy|]
-  let [|y|] = mk_rec[|mk_node b x;vy;vy|]
-  (note the lift to avoid
+  let [|x|] = mk_rec[|mk_node a [|[|vx;lift 1 vy|]|]|]
+  let [|y|] = mk_rec[|mk_node b [|[|x;vy;vy|]|]|]
+  (note the lift so that Y links to the "rec Y" skipping the "rec X")
  *)
 val mk_rec_calls : int -> 'a t array
 val mk_rec   : 'a t array -> 'a t array
@@ -46,10 +52,10 @@ val lift : int -> 'a t -> 'a t
 val is_node : 'a t -> bool
 
 (** Destructors (recursive calls are expanded) *)
-val dest_node  : 'a t -> 'a * 'a t array
+val dest_node  : 'a t -> 'a * 'a t array array
 
-(** dest_param is not needed for closed trees (i.e. with no free variable) *)
-val dest_param : 'a t -> int * int
+(** dest_var is not needed for closed trees (i.e. with no free variable) *)
+val dest_var : 'a t -> int * int
 
 (** Tells if a tree has an infinite branch. The first arg is a comparison
     used to detect already seen elements, hence loops *)
@@ -77,8 +83,8 @@ val incl : ('a -> 'a -> bool) -> ('a -> 'a -> 'a option) -> 'a -> 'a t -> 'a t -
 (** See also [Smart.map] *)
 val map : ('a -> 'b) -> 'a t -> 'b t
 
-(** A rather simple minded pretty-printer *)
-val pp_tree : ('a -> Pp.t) -> 'a t -> Pp.t
+(** Pretty-printer *)
+val pr_tree : ('a -> Pp.t) -> 'a t -> Pp.t
 
 module Smart :
 sig


### PR DESCRIPTION
Recursive trees (rtree.ml) were used to encode the algebraic structure of (co)inductive types. The latters have a disjunctive-conjunctive structure which was trickily encoded using an artificial `Norec` node in `rtree.ml`. The encoding had bad side effects, such as:
- decoding the printing of trees was difficult, having to distinguish the fake `Norec`'s from the regular ones
- a function like `Rtree.inter` was not able to know the difference between the two uses of `Norec`, making its parametrization over an equality of tags suboptimal
    
The PR hard-wires a two-level of arrays in rtree.ml so as to avoid the encoding. Writing a printer of wf_paths is for example much more direct. In particular the PR fully subsumes #18233.

Notes: 
- While the first commit clearly simplifies things, there is a second lesser readable commit, for saving a few conversions between arrays and lists.
- In passing, we also rename an internal rtree.ml name called `Param` into `Var` to prevent a confusion with parameter in the sense of parameter of an inductive type.