### PR TITLE
Followup of #17993, fixes #18239: anomaly on triggering conditions for simpl on encapsulated mutual fixpoints

### DIFF
--- a/doc/changelog/04-tactics/18243-master+fix18239-followup-17993-simpl-triggering-condition.rst
+++ b/doc/changelog/04-tactics/18243-master+fix18239-followup-17993-simpl-triggering-condition.rst
@@ -1,0 +1,10 @@
+- **Fixed:**
+  Anomaly of :tacn:`simpl` on partially applied named mutual fixpoints
+  (`#18243 <https://github.com/coq/coq/pull/18243>`_,
+  fixes `#18239 <https://github.com/coq/coq/issues/18239>`_,
+  by Hugo Herbelin).
+
+- **Changed:**
+  :tacn:`simpl` tries to reduce named mutual fixpoints also when they return functions
+  (`#18243 <https://github.com/coq/coq/pull/18243>`_,
+  by Hugo Herbelin).

--- a/test-suite/success/simpl.v
+++ b/test-suite/success/simpl.v
@@ -189,3 +189,78 @@ match goal with [ |- g a c n = g a c n ] => idtac end.
 Abort.
 
 End WithLetMutual.
+
+Module IotaTrigger1.
+
+Definition a x := match x with true => tt | false => tt end.
+Definition b x (y : unit) := a x.
+Definition c x := b x tt.
+Goal a true = tt. simpl. match goal with [ |- tt = tt ] => idtac end. Abort.
+Goal b true = fun _ => tt. simpl. match goal with [ |- b true = _ ] => idtac end. Abort.
+Goal c true = tt. simpl. match goal with [ |- tt = tt ] => idtac end. Abort.
+
+End IotaTrigger1.
+
+Module IotaTrigger2.
+
+Definition a x := match x with true => fun _ => tt | false => fun _ => tt end tt.
+Definition b x (y : unit) := a x.
+Definition c x := b x tt.
+Goal a true = tt. simpl. match goal with [ |- tt = tt ] => idtac end. Abort.
+Goal b true = fun _ => tt. simpl. match goal with [ |- b true = _ ] => idtac end. Abort.
+Goal c true = tt. simpl. match goal with [ |- tt = tt ] => idtac end. Abort.
+
+End IotaTrigger2.
+
+Module IotaTrigger3.
+
+Fixpoint f_fix_fun n := match n with 0 => fun _ : unit => true | S n => f_fix_fun n end.
+Definition test_fix_fun n := f_fix_fun n.
+Goal test_fix_fun 2 = fun _ => true. simpl. match goal with [ |- (fun _ => true) = _ ] => idtac end. Abort.
+Goal forall x, test_fix_fun (S x) = fun _ => true. intro. simpl. match goal with [ |- test_fix_fun x = _ ] => idtac end. Abort.
+(* REDUCED *)
+
+Definition test_fix_fun_partial n (x:unit) := f_fix_fun n.
+Goal test_fix_fun_partial 2 = fun _ _ => true. simpl. match goal with [ |- test_fix_fun_partial 2 = _ ] => idtac end. Abort.
+Goal forall x, test_fix_fun_partial (S x) = fun _ _ => true. intro. simpl. match goal with [ |- test_fix_fun_partial (S x) = _ ] => idtac end. Abort.
+(* NOT REDUCED: design choice that it is not enough fully applied to trigger the reduction *)
+(* remark: the presence of an inner "fun" does not matter *)
+
+Fixpoint f_fix n := match n with 0 => fun _ : unit => true | S n => f_fix n end.
+Definition test_fix n := f_fix n tt.
+Goal test_fix 2 = true. simpl. match goal with [ |- test_fix 2 = _ ] => idtac end. Abort.
+Goal forall x, test_fix (S x) = true. intro. simpl. match goal with [ |- test_fix (S x) = _ ] => idtac end. Abort.
+(* NOT REDUCED: design choice that we couldn't refold to test_fix after reduction *)
+
+Fixpoint f_mutual_fix n := match n with 0 => true | S n => g n end
+with g n := match n with 0 => true | S n => f_mutual_fix n end.
+Definition test_mutual_fix n := f_mutual_fix n.
+Goal test_mutual_fix 2 = true. simpl. match goal with [ |- true = _ ] => idtac end. Abort.
+Goal forall x, test_mutual_fix (S x) = true. intro. simpl. match goal with [ |- g x = _ ] => idtac end. Abort.
+(* REDUCED: design choice that mutual fixpoints refold to last encapsulating name *)
+
+Definition test_mutual_fix_partial n (x:unit) := f_mutual_fix n.
+Goal test_mutual_fix_partial 2 = fun _ => true. simpl. match goal with [ |- test_mutual_fix_partial 2 = _ ] => idtac end. Abort.
+Goal forall x, test_mutual_fix_partial (S x) = fun _ => true. intro. simpl. match goal with [ |- test_mutual_fix_partial (S x) = _ ] => idtac end. Abort.
+(* NOT REDUCED: design choice that it is not enough fully applied to trigger the reduction *)
+(* Moreover, was failing between #17993 and #18243 (see #18239) *)
+
+Fixpoint f_mutual_fix_cut n := match n with 0 => fun _ : unit => true | S n => g_cut n end
+with g_cut n := match n with 0 => fun _ : unit => true | S n => f_mutual_fix_cut n end.
+Definition test_mutual_fix_cut n := f_mutual_fix_cut n tt.
+Goal test_mutual_fix_cut 2 = true. simpl. match goal with [ |- true = _ ] => idtac end. Abort.
+Goal forall x, test_mutual_fix_cut (S x) = true. intro. simpl. match goal with [ |- g_cut x tt = _ ] => idtac end. Abort.
+(* REDUCED: by consistency with test_mutual_fix, which itself already differs from the case of a unary fix (new behavior from #18243) *)
+
+Definition test_mutual_fix_cut_partial n (x:unit) := f_mutual_fix_cut n x.
+Goal test_mutual_fix_cut_partial 2 = fun _ => true. simpl. match goal with [ |- test_mutual_fix_cut_partial 2 = _ ] => idtac end. Abort.
+Goal forall x, test_mutual_fix_cut_partial (S x) = fun _ => true. intro. simpl. match goal with [ |- test_mutual_fix_cut_partial (S x) = _ ] => idtac end. Abort.
+(* NOT REDUCED: by consistency with test_fix_fun_partial and test_mutual_fix_cut_partial *)
+(* Moreover was failing before #18243 (see #18239) *)
+
+Definition f_case n := match n with 0 => fun _ : unit => true | S n => fun _ => true end.
+Definition test_case n := f_case n tt.
+Goal test_case 2 = true. simpl. match goal with [ |- true = _ ] => idtac end. Abort.
+(* REDUCED *)
+
+End IotaTrigger3.


### PR DESCRIPTION
We ensure that there are enough arguments in the original applied constant, in addition to ensuring enough arguments in the constant that immediately surrounds a global mutual fixpoint.

In addition to fixing bug #18239, introduced in #17993, this fixes also a similar bug anterior to #17993.

Fixes #18239

- [x] Added / updated **test-suite**.
