### PR TITLE
Catch NotConvertible from checking case parameters in typeops

### DIFF
--- a/checker/checker.ml
+++ b/checker/checker.ml
@@ -263,6 +263,7 @@ let explain_exn = function
       | WrongCaseInfo _ -> str"WrongCaseInfo"
       | NumberBranches _ -> str"NumberBranches"
       | IllFormedBranch _ -> str"IllFormedBranch"
+      | IllFormedCaseParams -> str "IllFormedCaseParams"
       | Generalization _ -> str"Generalization"
       | ActualType _ -> str"ActualType"
       | IncorrectPrimitive _ -> str"IncorrectPrimitive"

--- a/kernel/type_errors.ml
+++ b/kernel/type_errors.ml
@@ -60,6 +60,7 @@ type ('constr, 'types) ptype_error =
   | CaseOnPrivateInd of inductive
   | WrongCaseInfo of pinductive * case_info
   | NumberBranches of ('constr, 'types) punsafe_judgment * int
+  | IllFormedCaseParams
   | IllFormedBranch of 'constr * pconstructor * 'constr * 'constr
   | Generalization of (Name.t * 'types) * ('constr, 'types) punsafe_judgment
   | ActualType of ('constr, 'types) punsafe_judgment * 'types
@@ -197,7 +198,7 @@ let map_pguard_error f = function
 | CoFixGuardError e -> CoFixGuardError (map_pcofix_guard_error f e)
 
 let map_ptype_error f = function
-| UnboundRel _ | UnboundVar _ | CaseOnPrivateInd _
+| UnboundRel _ | UnboundVar _ | CaseOnPrivateInd _ | IllFormedCaseParams
 | UndeclaredUniverse _ | DisallowedSProp | UnsatisfiedConstraints _
 | ReferenceVariables _ | BadInvert | BadVariance _ | UndeclaredUsedVariables _ as e -> e
 | NotAType j -> NotAType (on_judgment f j)

--- a/kernel/type_errors.mli
+++ b/kernel/type_errors.mli
@@ -62,6 +62,7 @@ type ('constr, 'types) ptype_error =
   | CaseOnPrivateInd of inductive
   | WrongCaseInfo of pinductive * case_info
   | NumberBranches of ('constr, 'types) punsafe_judgment * int
+  | IllFormedCaseParams
   | IllFormedBranch of 'constr * pconstructor * 'constr * 'constr
   | Generalization of (Name.t * 'types) * ('constr, 'types) punsafe_judgment
   | ActualType of ('constr, 'types) punsafe_judgment * 'types

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -507,7 +507,9 @@ let should_invert_case env ci =
 let type_case_scrutinee env (mib, _mip) (u', largs) u pms (pctx, p) c =
   let (params, realargs) = List.chop mib.mind_nparams largs in
   (* Check that the type of the scrutinee is <= the expected argument type *)
-  let () = Array.iter2 (fun p1 p2 -> Conversion.conv ~l2r:true env p1 p2) (Array.of_list params) pms in
+  let () = try Array.iter2 (fun p1 p2 -> Conversion.conv ~l2r:true env p1 p2) (Array.of_list params) pms
+    with NotConvertible -> raise Type_errors.(TypeError (env,IllFormedCaseParams))
+  in
   (* We use l2r:true for compat with old versions which used CONV with arguments
      flipped. It is relevant for performance eg in bedrock / Kami. *)
   let cst = match mib.mind_variance with

--- a/test-suite/bugs/bug_16954.v
+++ b/test-suite/bugs/bug_16954.v
@@ -1,0 +1,6 @@
+Fail Type
+  match ltac:(exact_no_check (Some true)) with
+  | None => None
+  | Some x => Some (x+1)
+  end.
+(* Anomaly "Uncaught exception Reduction.NotConvertible." *)

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -290,6 +290,9 @@ let explain_number_branches env sigma cj expn =
   str "of type" ++ brk(1,1) ++ pct ++ spc () ++
   str "expects " ++  int expn ++ str " branches."
 
+let explain_ill_formed_case_params env sigma =
+  str "Ill formed case parameters (bugged tactic?)."
+
 let explain_ill_formed_branch env sigma c ci actty expty =
   let simp t = Reductionops.nf_betaiota env sigma t in
   let env = make_all_name_different env sigma in
@@ -870,6 +873,7 @@ let explain_type_error env sigma err =
   | CaseOnPrivateInd ind -> explain_case_on_private_ind env sigma ind
   | NumberBranches (cj, n) ->
       explain_number_branches env sigma cj n
+  | IllFormedCaseParams -> explain_ill_formed_case_params env sigma
   | IllFormedBranch (c, i, actty, expty) ->
       explain_ill_formed_branch env sigma c i actty expty
   | Generalization (nvar, c) ->


### PR DESCRIPTION
Fix #16954

AFAICT this error can only be gotten from a bug or unsafe tactic so I'm not making a detailed error message.
