### PR TITLE
Generalize the deprecation machinery to other forms of comments

### DIFF
--- a/dev/ci/user-overlays/18248-herbelin-master-extend-deprecation.sh
+++ b/dev/ci/user-overlays/18248-herbelin-master-extend-deprecation.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/proux01/coq-elpi coq_18248 18248

--- a/doc/changelog/08-vernac-commands-and-options/18248-user_warn.rst
+++ b/doc/changelog/08-vernac-commands-and-options/18248-user_warn.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  :attr:`warn` attribute generalizing the deprecation
+  machinery to other forms of comments
+  (`#18248 <https://github.com/coq/coq/pull/18248>`_,
+  by Hugo Herbelin and Pierre Roux).

--- a/doc/sphinx/language/core/assumptions.rst
+++ b/doc/sphinx/language/core/assumptions.rst
@@ -170,8 +170,8 @@ has type :n:`@type`.
 
    These commands bind one or more :n:`@ident`\(s) to specified :n:`@type`\(s) as their specifications in
    the global environment. The fact asserted by :n:`@type` (or, equivalently, the existence
-   of an object of this type) is accepted as a postulate.  They accept the :attr:`program`
-   and :attr:`deprecated` attributes.
+   of an object of this type) is accepted as a postulate.  They accept the :attr:`program`,
+   :attr:`deprecated` and :attr:`warn` attributes.
 
    :cmd:`Axiom`, :cmd:`Conjecture`, :cmd:`Parameter` and their plural forms
    are equivalent.  They can take the :attr:`local` :term:`attribute`,

--- a/doc/sphinx/language/core/basic.rst
+++ b/doc/sphinx/language/core/basic.rst
@@ -512,7 +512,8 @@ Document-level attributes
    document. When compiled with ``coqc`` (see Section
    :ref:`thecoqcommands`), the attributes are associated with the
    compiled file and may have an effect when the file is loaded with
-   :cmd:`Require`. Supported attributes include :attr:`deprecated`.
+   :cmd:`Require`. Supported attributes include :attr:`deprecated`
+   and :attr:`warn`.
 
 .. _flags-options-tables:
 

--- a/doc/sphinx/language/core/definitions.rst
+++ b/doc/sphinx/language/core/definitions.rst
@@ -100,8 +100,8 @@ Section :ref:`typing-rules`.
 
    These commands also support the :attr:`universes(polymorphic)`,
    :attr:`program` (see :ref:`program_definition`), :attr:`canonical`,
-   :attr:`bypass_check(universes)`, :attr:`bypass_check(guard)`, :attr:`deprecated` and
-   :attr:`using` attributes.
+   :attr:`bypass_check(universes)`, :attr:`bypass_check(guard)`, :attr:`deprecated`,
+   :attr:`warn` and :attr:`using` attributes.
 
    If :n:`@term` is omitted, :n:`@type` is required and Coq enters proof mode.
    This can be used to define a term incrementally, in particular by relying on the :tacn:`refine` tactic.
@@ -174,7 +174,7 @@ The basic assertion command is:
    command :cmd:`Guarded`.
 
    This command accepts the :attr:`bypass_check(universes)`,
-   :attr:`bypass_check(guard)`, :attr:`deprecated`, and :attr:`using` attributes.
+   :attr:`bypass_check(guard)`, :attr:`deprecated`, :attr:`warn`, and :attr:`using` attributes.
 
    .. exn:: The term @term has type @type which should be Set, Prop or Type.
       :undocumented:

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -952,6 +952,7 @@ Controlling display
    `ssr`,
    `syntax`,
    `tactics`,
+   `user-warn`,
    `vernacular`.
 
    .. This list is from lib/cWarnings.ml

--- a/doc/sphinx/using/libraries/writing.rst
+++ b/doc/sphinx/using/libraries/writing.rst
@@ -84,7 +84,7 @@ notation, definition, axiom, theorem or file.
    may appear first and they must be separated by a comma.
 
    This attribute is supported by the following commands:
-   :cmd:`Definition`, :cmd:`Theorem`,
+   :cmd:`Notation`, :cmd:`Infix`, :cmd:`Definition`, :cmd:`Theorem`,
    and similar commands.
 
    It can trigger the following warning:

--- a/doc/sphinx/using/libraries/writing.rst
+++ b/doc/sphinx/using/libraries/writing.rst
@@ -21,7 +21,7 @@ deprecated compatibility alias using :cmd:`Notation (abbreviation)`
    are present, either one may appear first and they must be separated
    by a comma. If they are present, they will be used in the warning
    message, and :n:`since` will also be used in the warning name and
-   categories.
+   categories. Spaces inside :n:`since` are changed to hyphens.
 
    This attribute is supported by the following commands: :cmd:`Ltac`,
    :cmd:`Tactic Notation`, :cmd:`Notation`, :cmd:`Infix`, :cmd:`Ltac2`,
@@ -66,6 +66,33 @@ deprecated compatibility alias using :cmd:`Notation (abbreviation)`
      if it breaks.
 
    See :cite:`Zimmermann19`, Section 3.6.3, for more details.
+
+Triggering warning for library objects or library files
+-------------------------------------------------------
+
+You may use the following :term:`attribute` to trigger a warning on a
+notation, definition, axiom, theorem or file.
+
+.. attr:: warn ( note = @string , {? cats = @string } )
+   :name: warn
+
+   The :n:`note` field will be used as the warning message, and
+   :n:`cats` is a comma separated list of categories to be used in the
+   warning name and categories. Leading and trailing spaces in each
+   category are trimmed, whereas internal spaces are changed to
+   hyphens. If both :n:`note` and :n:`cats` are present, either one
+   may appear first and they must be separated by a comma.
+
+   This attribute is supported by the following commands:
+   :cmd:`Definition`, :cmd:`Theorem`,
+   and similar commands.
+
+   It can trigger the following warning:
+
+   .. warn:: @string__note
+
+      :n:`@string__note` is the note. It's common practice to start it
+      with a capital and end it with a period.
 
 .. example:: Deprecating a tactic.
 

--- a/doc/sphinx/using/libraries/writing.rst
+++ b/doc/sphinx/using/libraries/writing.rst
@@ -85,7 +85,8 @@ notation, definition, axiom, theorem or file.
 
    This attribute is supported by the following commands:
    :cmd:`Notation`, :cmd:`Infix`, :cmd:`Definition`, :cmd:`Theorem`,
-   and similar commands.
+   and similar commands. To attach it to a compiled library file, use
+   :cmd:`Attributes`.
 
    It can trigger the following warning:
 
@@ -93,6 +94,15 @@ notation, definition, axiom, theorem or file.
 
       :n:`@string__note` is the note. It's common practice to start it
       with a capital and end it with a period.
+
+      Explicitly :cmd:`Require`\ing a file that has a warn message set
+      using the :cmd:`Attributes` command, triggers a
+      ``warn-library-file`` warning. Requiring such a file, even
+      indirectly through a chain of :cmd:`Require`\s, will produce a
+      ``warn-transitive-library-file`` warning if the :opt:`Warnings`
+      option "warn-transitive-library-file" is set (it is
+      "-warn-transitive-library-file" by default, silencing the
+      warning).
 
 .. example:: Deprecating a tactic.
 

--- a/interp/abbreviation.ml
+++ b/interp/abbreviation.ml
@@ -22,7 +22,7 @@ open Notationextern
 type abbreviation =
   { abbrev_pattern : interpretation;
     abbrev_onlyparsing : bool;
-    abbrev_deprecation : Deprecation.t option;
+    abbrev_user_warns : UserWarn.t option;
     abbrev_activated : bool; (* Not really necessary in practice *)
   }
 
@@ -43,7 +43,7 @@ let toggle_abbreviation ~on ~use kn =
       | OnlyParsing | ParsingAndPrinting ->
          if on then
            begin
-             Nametab.push_abbreviation ?deprecated:data.abbrev_deprecation (Nametab.Until 1) sp kn;
+             Nametab.push_abbreviation ?user_warns:data.abbrev_user_warns (Nametab.Until 1) sp kn;
              Nametab.push_abbreviation (Nametab.Exactly 1) sp kn
            end
          else
@@ -60,7 +60,7 @@ let load_abbreviation i ((sp,kn),(_local,abbrev)) =
     user_err
       (Id.print (basename sp) ++ str " already exists.");
   add_abbreviation kn sp abbrev;
-  Nametab.push_abbreviation ?deprecated:abbrev.abbrev_deprecation (Nametab.Until i) sp kn
+  Nametab.push_abbreviation ?user_warns:abbrev.abbrev_user_warns (Nametab.Until i) sp kn
 
 let is_alias_of_already_visible_name sp = function
   | _,NRef (ref,None) ->
@@ -102,11 +102,11 @@ let inAbbreviation : Id.t -> (bool * abbreviation) -> obj =
     subst_function = subst_abbreviation;
     classify_function = classify_abbreviation }
 
-let declare_abbreviation ~local deprecation id ~onlyparsing pat =
+let declare_abbreviation ~local user_warns id ~onlyparsing pat =
   let abbrev =
     { abbrev_pattern = pat;
       abbrev_onlyparsing = onlyparsing;
-      abbrev_deprecation = deprecation;
+      abbrev_user_warns = user_warns;
       abbrev_activated = true;
     }
   in

--- a/interp/abbreviation.mli
+++ b/interp/abbreviation.mli
@@ -15,7 +15,7 @@ open Globnames
 
 (** Abbreviations. *)
 
-val declare_abbreviation : local:bool -> Deprecation.t option -> Id.t ->
+val declare_abbreviation : local:bool -> UserWarn.t option -> Id.t ->
   onlyparsing:bool -> interpretation -> unit
 
 val search_abbreviation : abbreviation -> interpretation

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -1383,7 +1383,7 @@ let intern_qualid_for_pattern test_global intern_not qid pats =
   match Nametab.locate_extended_nowarn qid with
   | TrueGlobal g as xref ->
     test_global g;
-    Nametab.is_deprecated_xref xref |> Option.iter (fun depr -> Nametab.warn_deprecated_xref ?loc:qid.loc depr (TrueGlobal g));
+    Nametab.is_warned_xref xref |> Option.iter (fun warn -> Nametab.warn_user_warn_xref ?loc:qid.loc warn (TrueGlobal g));
     dump_extended_global qid.loc (TrueGlobal g);
     (g, false, Some [], pats)
   | Abbrev kn as xref ->
@@ -1410,8 +1410,8 @@ let intern_qualid_for_pattern test_global intern_not qid pats =
       | _ -> None in
     match Abbreviation.search_filtered_abbreviation filter kn with
     | Some (g, pats1, pats2) ->
-      Nametab.is_deprecated_xref xref
-      |> Option.iter (fun depr -> Nametab.warn_deprecated_xref ?loc:qid.loc depr (Abbrev kn));
+      Nametab.is_warned_xref xref
+      |> Option.iter (fun warn -> Nametab.warn_user_warn_xref ?loc:qid.loc warn (Abbrev kn));
       dump_extended_global qid.loc (Abbrev kn);
       (g, true, pats1, pats2)
     | None -> raise Not_found

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -251,7 +251,7 @@ type entry_coercion_kind =
 val declare_notation : notation_with_optional_scope * notation ->
   interpretation -> notation_location -> use:notation_use ->
   entry_coercion_kind option ->
-  Deprecation.t option -> unit
+  UserWarn.t option -> unit
 
 
 (** Return the interpretation bound to a notation *)

--- a/lib/cWarnings.ml
+++ b/lib/cWarnings.ml
@@ -432,6 +432,7 @@ module CoreCategories = struct
   let ssr = make "ssr"
   let syntax = make "syntax"
   let tactics = make "tactics"
+  let user_warn = make "user-warn"
   let vernacular = make "vernacular"
 
 end

--- a/lib/cWarnings.mli
+++ b/lib/cWarnings.mli
@@ -121,6 +121,7 @@ module CoreCategories : sig
   val ssr : category
   val syntax : category
   val tactics : category
+  val user_warn : category
   val vernacular : category
 
 end

--- a/lib/userWarn.ml
+++ b/lib/userWarn.ml
@@ -1,0 +1,58 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** This is about warnings triggered from user .v code ("warn" attibute).
+    See cWarnings.mli for the generic warning interface. *)
+
+type warn = { note : string; cats : string }
+(** note and comma separated list of categories *)
+
+type t = { depr : Deprecation.t option; warn : warn list }
+
+let empty = { depr = None; warn = [] }
+
+let make_warn ~note ?cats () =
+  let l = String.split_on_char ',' (Option.default "" cats) in
+  let l =
+    List.map String.(fun s -> map (function ' ' -> '-' | c -> c) (trim s)) l in
+  let l = List.sort String.compare l in
+  { note; cats = String.concat "," l }
+
+let user_warn_cat = CWarnings.CoreCategories.user_warn
+
+let warn_cats = ref CString.Map.empty
+
+let get_generic_cat cat =
+  match CString.Map.find_opt cat !warn_cats with
+  | Some c -> c
+  | None ->
+    let c = CWarnings.create_category ~from:[user_warn_cat] ~name:cat () in
+    warn_cats := CString.Map.add cat c !warn_cats;
+    c
+
+let create_warning ?default ~warning_name_if_no_cats () =
+  let main_cat, main_w = CWarnings.create_hybrid ?default ~name:warning_name_if_no_cats ~from:[user_warn_cat] () in
+  let main_w = CWarnings.create_in main_w Pp.strbrk in
+  let warnings = ref CString.Map.empty in
+  fun ?loc {note;cats} ->
+    let w =
+      if cats = "" then main_w else
+        match CString.Map.find_opt cats !warnings with
+        | Some w -> w
+        | None ->
+           let l = String.split_on_char ',' cats in
+           let generic_cats = List.map get_generic_cat l in
+           let w = CWarnings.create_warning ?default ~from:(main_cat :: generic_cats)
+               ~name:(String.concat "-" (warning_name_if_no_cats :: l)) () in
+           let w = CWarnings.create_in w Pp.strbrk in
+           warnings := CString.Map.add cats w !warnings;
+           w
+    in
+    w ?loc note

--- a/lib/userWarn.mli
+++ b/lib/userWarn.mli
@@ -1,0 +1,24 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** This is about warnings triggered from user .v code ("warn" attibute).
+    See cWarnings.mli for the generic warning interface. *)
+
+type warn = private { note : string; cats : string }
+(** note and comma separated list of categories *)
+
+type t = { depr : Deprecation.t option; warn : warn list }
+
+val empty : t
+
+val make_warn : note:string -> ?cats:string -> unit -> warn
+
+val create_warning : ?default:CWarnings.status -> warning_name_if_no_cats:string ->
+  unit -> ?loc:Loc.t -> warn -> unit

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -139,7 +139,7 @@ module type StagedLibS = sig
   (** Keep only the libobject structure, not the objects themselves *)
   val drop_objects : frozen -> frozen
 
-  val declare_info : Library_info.t list -> unit
+  val declare_info : Library_info.t -> unit
 
 end
 
@@ -155,7 +155,7 @@ val start_compilation : DirPath.t -> ModPath.t -> unit
 
 (** Finalize the compilation of a library and return respectively the library
     prefix, the regular objects, and the syntax-related objects. *)
-val end_compilation : DirPath.t -> Nametab.object_prefix * Library_info.t list * Interp.classified_objects * Synterp.classified_objects
+val end_compilation : DirPath.t -> Nametab.object_prefix * Library_info.t * Interp.classified_objects * Synterp.classified_objects
 
 (** The function [library_dp] returns the [DirPath.t] of the current
    compiling library (or [default_library]) *)

--- a/library/library_info.mli
+++ b/library/library_info.mli
@@ -12,6 +12,6 @@
 
 open Names
 
-type t = Deprecation of Deprecation.t
+type t = UserWarn.t
 
-val warn_library_info : ?loc:Loc.t -> ?transitive:bool -> DirPath.t * t -> unit
+val warn_library_info : ?loc:Loc.t -> ?transitive:bool -> DirPath.t -> t -> unit

--- a/library/nametab.ml
+++ b/library/nametab.ml
@@ -459,9 +459,7 @@ let push_cci ?user_warns visibility sp ref =
   push_xref ?user_warns visibility sp (TrueGlobal ref)
 
 (* This is for Syntactic Definitions *)
-let push_abbreviation ?deprecated visibility sp kn =
-  let user_warns = deprecated |>
-    Option.map (fun depr -> UserWarn.{ depr = deprecated; warn = [] }) in
+let push_abbreviation ?user_warns visibility sp kn =
   push_xref ?user_warns visibility sp (Abbrev kn)
 
 let remove_abbreviation sp kn =
@@ -584,10 +582,6 @@ let warn_deprecated_xref ?loc depr = function
 
 let warn_user_warn =
   UserWarn.create_warning ~warning_name_if_no_cats:"warn-reference" ()
-
-let is_deprecated_xref xref : Deprecation.t option =
-  Option.bind (Globnames.ExtRefMap.find_opt xref !the_globwarntab)
-    (fun w -> w.UserWarn.depr)
 
 let is_warned_xref xref : UserWarn.t option = Globnames.ExtRefMap.find_opt xref !the_globwarntab
 

--- a/library/nametab.ml
+++ b/library/nametab.ml
@@ -393,7 +393,7 @@ type globrevtab = full_path Globnames.ExtRefMap.t
 let the_globrevtab =
   Summary.ref ~name:"globrevtab" (Globnames.ExtRefMap.empty : globrevtab)
 
-let the_globdeprtab = Summary.ref ~name:"globdeprtag" Globnames.ExtRefMap.empty
+let the_globwarntab = Summary.ref ~name:"globwarntag" Globnames.ExtRefMap.empty
 
 type mprevtab = DirPath.t MPmap.t
 
@@ -437,30 +437,32 @@ end
    possibly limited visibility, i.e. Theorem, Lemma, Definition, Axiom,
    Parameter but also Remark and Fact) *)
 
-let push_xref ?deprecated visibility sp xref =
+let push_xref ?user_warns visibility sp xref =
   match visibility with
     | Until _ ->
         the_ccitab := ExtRefTab.push visibility sp xref !the_ccitab;
         the_globrevtab := Globnames.ExtRefMap.add xref sp !the_globrevtab;
-        deprecated |> Option.iter (fun depr ->
-            the_globdeprtab := Globnames.ExtRefMap.add xref depr !the_globdeprtab)
+        user_warns |> Option.iter (fun warn ->
+            the_globwarntab := Globnames.ExtRefMap.add xref warn !the_globwarntab)
     | Exactly _ ->
       begin
-        assert (Option.is_empty deprecated);
+        assert (Option.is_empty user_warns);
         the_ccitab := ExtRefTab.push visibility sp xref !the_ccitab
       end
 
 let remove_xref sp xref =
   the_ccitab := ExtRefTab.remove sp !the_ccitab;
   the_globrevtab := Globnames.ExtRefMap.remove xref !the_globrevtab;
-  the_globdeprtab := Globnames.ExtRefMap.remove xref !the_globdeprtab
+  the_globwarntab := Globnames.ExtRefMap.remove xref !the_globwarntab
 
-let push_cci ?deprecated visibility sp ref =
-  push_xref ?deprecated visibility sp (TrueGlobal ref)
+let push_cci ?user_warns visibility sp ref =
+  push_xref ?user_warns visibility sp (TrueGlobal ref)
 
 (* This is for Syntactic Definitions *)
 let push_abbreviation ?deprecated visibility sp kn =
-  push_xref ?deprecated visibility sp (Abbrev kn)
+  let user_warns = deprecated |>
+    Option.map (fun depr -> UserWarn.{ depr = deprecated; warn = [] }) in
+  push_xref ?user_warns visibility sp (Abbrev kn)
 
 let remove_abbreviation sp kn =
   remove_xref sp (Abbrev kn)
@@ -580,7 +582,19 @@ let warn_deprecated_xref ?loc depr = function
   | Globnames.TrueGlobal ref -> warn_deprecated_ref ?loc (ref, depr)
   | Abbrev a -> warn_deprecated_abbreviation ?loc (a, depr)
 
-let is_deprecated_xref xref = Globnames.ExtRefMap.find_opt xref !the_globdeprtab
+let warn_user_warn =
+  UserWarn.create_warning ~warning_name_if_no_cats:"warn-reference" ()
+
+let is_deprecated_xref xref : Deprecation.t option =
+  Option.bind (Globnames.ExtRefMap.find_opt xref !the_globwarntab)
+    (fun w -> w.UserWarn.depr)
+
+let is_warned_xref xref : UserWarn.t option = Globnames.ExtRefMap.find_opt xref !the_globwarntab
+
+let warn_user_warn_xref ?loc user_warns xref =
+  user_warns.UserWarn.depr
+    |> Option.iter (fun depr -> warn_deprecated_xref ?loc depr xref);
+  user_warns.UserWarn.warn |> List.iter (warn_user_warn ?loc)
 
 let locate_extended_nowarn qid =
   let xref = ExtRefTab.locate qid !the_ccitab in
@@ -589,10 +603,9 @@ let locate_extended_nowarn qid =
 (* This should be used when abbreviations are allowed *)
 let locate_extended qid =
   let xref = locate_extended_nowarn qid in
-  let depr = is_deprecated_xref xref in
-  let () = depr |> Option.iter (fun depr ->
-      warn_deprecated_xref ?loc:qid.loc depr xref)
-  in
+  let warn = is_warned_xref xref in
+  let () = warn |> Option.iter (fun warn ->
+      warn_user_warn_xref ?loc:qid.loc warn xref) in
   xref
 
 (* This should be used when no abbreviations are expected *)

--- a/library/nametab.mli
+++ b/library/nametab.mli
@@ -104,7 +104,7 @@ type visibility = Until of int | Exactly of int
 
 val map_visibility : (int -> int) -> visibility -> visibility
 
-val push : ?deprecated:Deprecation.t -> visibility -> full_path -> GlobRef.t -> unit
+val push : ?user_warns:UserWarn.t -> visibility -> full_path -> GlobRef.t -> unit
 val push_modtype : visibility -> full_path -> ModPath.t -> unit
 val push_module : visibility -> DirPath.t -> ModPath.t -> unit
 val push_dir : visibility -> DirPath.t -> GlobDirRef.t -> unit
@@ -117,6 +117,12 @@ val push_universe : visibility -> full_path -> Univ.UGlobal.t -> unit
 val is_deprecated_xref : Globnames.extended_global_reference -> Deprecation.t option
 
 val warn_deprecated_xref : ?loc:Loc.t -> Deprecation.t -> Globnames.extended_global_reference -> unit
+
+(** Deprecation and user warn info *)
+
+val is_warned_xref : Globnames.extended_global_reference -> UserWarn.t option
+
+val warn_user_warn_xref : ?loc:Loc.t -> UserWarn.t -> Globnames.extended_global_reference -> unit
 
 (** {6 The following functions perform globalization of qualified names } *)
 

--- a/library/nametab.mli
+++ b/library/nametab.mli
@@ -108,15 +108,9 @@ val push : ?user_warns:UserWarn.t -> visibility -> full_path -> GlobRef.t -> uni
 val push_modtype : visibility -> full_path -> ModPath.t -> unit
 val push_module : visibility -> DirPath.t -> ModPath.t -> unit
 val push_dir : visibility -> DirPath.t -> GlobDirRef.t -> unit
-val push_abbreviation : ?deprecated:Deprecation.t -> visibility -> full_path -> Globnames.abbreviation -> unit
+val push_abbreviation : ?user_warns:UserWarn.t -> visibility -> full_path -> Globnames.abbreviation -> unit
 
 val push_universe : visibility -> full_path -> Univ.UGlobal.t -> unit
-
-(** Deprecation info *)
-
-val is_deprecated_xref : Globnames.extended_global_reference -> Deprecation.t option
-
-val warn_deprecated_xref : ?loc:Loc.t -> Deprecation.t -> Globnames.extended_global_reference -> unit
 
 (** Deprecation and user warn info *)
 

--- a/test-suite/output/deprecation_definition.out
+++ b/test-suite/output/deprecation_definition.out
@@ -28,3 +28,14 @@ Warning: Reference depr6 is deprecated. deprecable
 [deprecated-reference,deprecated,default]
 depr6
      : nat -> nat
+File "./output/deprecation_definition.v", line 38, characters 6-11:
+Warning: Reference depr7 is deprecated. deprecable
+[deprecated-reference,deprecated,default]
+File "./output/deprecation_definition.v", line 38, characters 6-11:
+Warning: be careful
+[warn-reference-be-careful-careful,careful,be-careful,warn-reference,user-warn,default]
+File "./output/deprecation_definition.v", line 38, characters 6-11:
+Warning: also about bla
+[warn-reference-careful-careful-bla,careful-bla,careful,warn-reference,user-warn,default]
+depr7
+     : Prop

--- a/test-suite/output/deprecation_definition.v
+++ b/test-suite/output/deprecation_definition.v
@@ -30,3 +30,9 @@ Check depr3.
 Check depr4.
 Check depr5.
 Check depr6.
+
+#[deprecated(note="deprecable"),
+  warn(note="be careful", cats="careful, be careful"),
+  warn(note="also about bla", cats="careful, careful bla")]
+Definition depr7 := True.
+Check depr7.

--- a/test-suite/output/library_attributes.out
+++ b/test-suite/output/library_attributes.out
@@ -8,3 +8,6 @@ A library attribute should be at toplevel of the library.
 File "./output/library_attributes.v", line 11, characters 0-69:
 The command has indeed failed with message:
 A library attribute should be at toplevel of the library.
+File "./output/library_attributes.v", line 14, characters 0-71:
+The command has indeed failed with message:
+Library file is already deprecated.

--- a/test-suite/output/library_attributes.v
+++ b/test-suite/output/library_attributes.v
@@ -10,3 +10,7 @@ End Sec.
 Module Mod.
 Fail Attributes deprecated(note="No library attributes in modules.").
 End Mod.
+
+Fail Attributes deprecated(note="This library is already deprecated.").
+Attributes warn(note="This library is dangerous.", cats="dangerous library").
+Attributes warn(note="This library is tricky.", cats="dangerous library, tricky library").

--- a/test-suite/output/library_attributes_require.out
+++ b/test-suite/output/library_attributes_require.out
@@ -2,3 +2,9 @@ File "./output/library_attributes_require.v", line 1, characters 0-37:
 Warning: Library File TestSuite.deprecated_library is deprecated since XX YY.
 This library is useless.
 [deprecated-library-file-since-XX-YY,deprecated-since-XX-YY,deprecated-library-file,deprecated,default]
+File "./output/library_attributes_require.v", line 1, characters 0-37:
+Warning: This library is dangerous.
+[warn-library-file-dangerous-library,dangerous-library,warn-library-file,user-warn,default]
+File "./output/library_attributes_require.v", line 1, characters 0-37:
+Warning: This library is tricky.
+[warn-library-file-dangerous-library-tricky-library,tricky-library,dangerous-library,warn-library-file,user-warn,default]

--- a/test-suite/output/library_attributes_require_transitive.out
+++ b/test-suite/output/library_attributes_require_transitive.out
@@ -2,7 +2,19 @@ File "./output/library_attributes_require_transitive.v", line 5, characters 0-37
 Warning: Library File TestSuite.deprecated_library is deprecated since XX YY.
 This library is useless.
 [deprecated-library-file-since-XX-YY,deprecated-since-XX-YY,deprecated-library-file,deprecated,default]
-File "./output/library_attributes_require_transitive.v", line 11, characters 0-46:
+File "./output/library_attributes_require_transitive.v", line 5, characters 0-37:
+Warning: This library is dangerous.
+[warn-library-file-dangerous-library,dangerous-library,warn-library-file,user-warn,default]
+File "./output/library_attributes_require_transitive.v", line 5, characters 0-37:
+Warning: This library is tricky.
+[warn-library-file-dangerous-library-tricky-library,tricky-library,dangerous-library,warn-library-file,user-warn,default]
+File "./output/library_attributes_require_transitive.v", line 12, characters 0-46:
 Warning: Library File (transitively required) TestSuite.deprecated_library is
 deprecated since XX YY. This library is useless.
 [deprecated-transitive-library-file-since-XX-YY,deprecated-since-XX-YY,deprecated-transitive-library-file,deprecated]
+File "./output/library_attributes_require_transitive.v", line 12, characters 0-46:
+Warning: This library is dangerous.
+[warn-transitive-library-file-dangerous-library,dangerous-library,warn-transitive-library-file,user-warn]
+File "./output/library_attributes_require_transitive.v", line 12, characters 0-46:
+Warning: This library is tricky.
+[warn-transitive-library-file-dangerous-library-tricky-library,tricky-library,dangerous-library,warn-transitive-library-file,user-warn]

--- a/test-suite/output/library_attributes_require_transitive.v
+++ b/test-suite/output/library_attributes_require_transitive.v
@@ -8,4 +8,5 @@ Require TestSuite.deprecated_library.
    that always triggers (even on transitive requires) *)
 Reset Initial.
 Set Warnings "deprecated-transitive-library-file".
+Set Warnings "warn-transitive-library-file".
 Require TestSuite.requires_deprecated_library.

--- a/test-suite/prerequisite/deprecated_library.v
+++ b/test-suite/prerequisite/deprecated_library.v
@@ -1,1 +1,3 @@
 Attributes deprecated(note="This library is useless.", since="XX YY").
+Attributes warn(note="This library is dangerous.", cats="dangerous library").
+Attributes warn(note="This library is tricky.", cats="dangerous library, tricky library").

--- a/test-suite/success/NotationDeprecation.v
+++ b/test-suite/success/NotationDeprecation.v
@@ -3,6 +3,11 @@ Module Syndefs.
 #[deprecated(since = "8.9", note = "Do not use.")]
 Notation foo := Prop.
 
+Fail
+#[deprecated(since = "8.9", note = "Do not use."),
+  deprecated(since = "8.10", note = "Duplicated deprecation.")]
+Notation foo := Prop.
+
 Check foo.
 
 Set Warnings "+deprecated".

--- a/vernac/attributes.mli
+++ b/vernac/attributes.mli
@@ -57,6 +57,8 @@ val template : bool option attribute
 val locality : bool option attribute
 val option_locality : Goptions.option_locality attribute
 val deprecation : Deprecation.t option attribute
+val user_warn_warn : UserWarn.warn list attribute
+val user_warns : UserWarn.t option attribute
 val reversible : bool option attribute
 val canonical_field : bool attribute
 val canonical_instance : bool attribute

--- a/vernac/comAssumption.mli
+++ b/vernac/comAssumption.mli
@@ -28,7 +28,7 @@ val do_assumptions
   -> poly:bool
   -> scope:Locality.definition_scope
   -> kind:Decls.assumption_object_kind
-  -> ?deprecation:Deprecation.t
+  -> ?user_warns:UserWarn.t
   -> Declaremods.inline
   -> (ident_decl list * constr_expr) with_coercion list
   -> unit
@@ -47,7 +47,7 @@ val declare_axiom
   : coercion_flag
   -> local:Locality.import_status
   -> kind:Decls.assumption_object_kind
-  -> ?deprecation:Deprecation.t
+  -> ?user_warns:UserWarn.t
   -> Constr.types
   -> UState.named_universes_entry
   -> Impargs.manual_implicits

--- a/vernac/comDefinition.ml
+++ b/vernac/comDefinition.ml
@@ -115,7 +115,7 @@ let definition_using env evd ~body ~types ~using =
   let terms = Option.List.cons types [body] in
   Option.map (fun using -> Proof_using.definition_using env evd ~fixnames:[] ~using ~terms) using
 
-let do_definition ?hook ~name ?scope ?clearbody ~poly ?typing_flags ~kind ?using ?deprecation udecl bl red_option c ctypopt =
+let do_definition ?hook ~name ?scope ?clearbody ~poly ?typing_flags ~kind ?using ?user_warns udecl bl red_option c ctypopt =
   let program_mode = false in
   let env = Global.env() in
   let env = Environ.update_typing_flags ?typing_flags env in
@@ -127,12 +127,12 @@ let do_definition ?hook ~name ?scope ?clearbody ~poly ?typing_flags ~kind ?using
   let using = definition_using env evd ~body ~types ~using in
   let kind = Decls.IsDefinition kind in
   let cinfo = Declare.CInfo.make ~name ~impargs ~typ:types ?using () in
-  let info = Declare.Info.make ?scope ?clearbody ~kind ?hook ~udecl ~poly ?typing_flags ?deprecation () in
+  let info = Declare.Info.make ?scope ?clearbody ~kind ?hook ~udecl ~poly ?typing_flags ?user_warns () in
   let _ : Names.GlobRef.t =
     Declare.declare_definition ~info ~cinfo ~opaque:false ~body evd
   in ()
 
-let do_definition_program ?hook ~pm ~name ~scope ?clearbody ~poly ?typing_flags ~kind ?using ?deprecation udecl bl red_option c ctypopt =
+let do_definition_program ?hook ~pm ~name ~scope ?clearbody ~poly ?typing_flags ~kind ?using ?user_warns udecl bl red_option c ctypopt =
   let () = if not poly then udecl |> Option.iter (fun udecl ->
       if not udecl.UState.univdecl_extensible_instance
       || not udecl.UState.univdecl_extensible_constraints
@@ -152,6 +152,6 @@ let do_definition_program ?hook ~pm ~name ~scope ?clearbody ~poly ?typing_flags 
   let term, typ, uctx, obls = Declare.Obls.prepare_obligation ~name ~body ~types evd in
   let pm, _ =
     let cinfo = Declare.CInfo.make ~name ~typ ~impargs ?using () in
-    let info = Declare.Info.make ~udecl ~scope ?clearbody ~poly ~kind ?hook ?typing_flags ?deprecation () in
+    let info = Declare.Info.make ~udecl ~scope ?clearbody ~poly ~kind ?hook ?typing_flags ?user_warns () in
     Declare.Obls.add_definition ~pm ~cinfo ~info ~term ~uctx obls
   in pm

--- a/vernac/comDefinition.mli
+++ b/vernac/comDefinition.mli
@@ -34,7 +34,7 @@ val do_definition
   -> ?typing_flags:Declarations.typing_flags
   -> kind:Decls.definition_object_kind
   -> ?using:Vernacexpr.section_subset_expr
-  -> ?deprecation:Deprecation.t
+  -> ?user_warns:UserWarn.t
   -> universe_decl_expr option
   -> local_binder_expr list
   -> red_expr option
@@ -52,7 +52,7 @@ val do_definition_program
   -> ?typing_flags:Declarations.typing_flags
   -> kind:Decls.logical_kind
   -> ?using:Vernacexpr.section_subset_expr
-  -> ?deprecation:Deprecation.t
+  -> ?user_warns:UserWarn.t
   -> universe_decl_expr option
   -> local_binder_expr list
   -> red_expr option

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -284,12 +284,12 @@ let build_recthms ~indexes ?using fixnames fixtypes fiximps =
   in
   fix_kind, cofix, thms
 
-let declare_fixpoint_interactive_generic ?indexes ~scope ?clearbody ~poly ?typing_flags ?deprecation ((fixnames,_fixrs,fixdefs,fixtypes),udecl,ctx,fiximps) ntns =
+let declare_fixpoint_interactive_generic ?indexes ~scope ?clearbody ~poly ?typing_flags ?user_warns ((fixnames,_fixrs,fixdefs,fixtypes),udecl,ctx,fiximps) ntns =
   let fix_kind, cofix, thms = build_recthms ~indexes fixnames fixtypes fiximps in
   let indexes = Option.default [] indexes in
   let init_terms = Some fixdefs in
   let evd = Evd.from_ctx ctx in
-  let info = Declare.Info.make ~poly ~scope ?clearbody ~kind:(Decls.IsDefinition fix_kind) ~udecl ?typing_flags ?deprecation () in
+  let info = Declare.Info.make ~poly ~scope ?clearbody ~kind:(Decls.IsDefinition fix_kind) ~udecl ?typing_flags ?user_warns () in
   let lemma =
     Declare.Proof.start_mutual_with_initialization ~info
       evd ~mutual_info:(cofix,indexes,init_terms) ~cinfo:thms None in
@@ -297,13 +297,13 @@ let declare_fixpoint_interactive_generic ?indexes ~scope ?clearbody ~poly ?typin
   List.iter (Metasyntax.add_notation_interpretation ~local:(scope=Locality.Discharge) (Global.env())) ntns;
   lemma
 
-let declare_fixpoint_generic ?indexes ?scope ?clearbody ~poly ?typing_flags ?deprecation ?using ((fixnames,fixrs,fixdefs,fixtypes),udecl,uctx,fiximps) ntns =
+let declare_fixpoint_generic ?indexes ?scope ?clearbody ~poly ?typing_flags ?user_warns ?using ((fixnames,fixrs,fixdefs,fixtypes),udecl,uctx,fiximps) ntns =
   (* We shortcut the proof process *)
   let fix_kind, cofix, fixitems = build_recthms ~indexes ?using fixnames fixtypes fiximps in
   let fixdefs = List.map Option.get fixdefs in
   let rec_declaration = prepare_recursive_declaration fixnames fixrs fixtypes fixdefs in
   let fix_kind = Decls.IsDefinition fix_kind in
-  let info = Declare.Info.make ?scope ?clearbody ~kind:fix_kind ~poly ~udecl ?typing_flags ?deprecation () in
+  let info = Declare.Info.make ?scope ?clearbody ~kind:fix_kind ~poly ~udecl ?typing_flags ?user_warns () in
   let cinfo = fixitems in
   let _ : GlobRef.t list =
     Declare.declare_mutually_recursive ~cinfo ~info ~opaque:false ~uctx
@@ -343,25 +343,25 @@ let do_fixpoint_common ?typing_flags (fixl : Vernacexpr.fixpoint_expr list) =
   let (_, _, _, info as fix) = interp_fixpoint ~cofix:false ?typing_flags fixl in
   fixl, ntns, fix, List.map compute_possible_guardness_evidences info
 
-let do_fixpoint_interactive ~scope ?clearbody ~poly ?typing_flags ?deprecation l : Declare.Proof.t =
+let do_fixpoint_interactive ~scope ?clearbody ~poly ?typing_flags ?user_warns l : Declare.Proof.t =
   let fixl, ntns, fix, possible_indexes = do_fixpoint_common ?typing_flags l in
-  let lemma = declare_fixpoint_interactive_generic ~indexes:possible_indexes ~scope ?clearbody ~poly ?typing_flags ?deprecation fix ntns in
+  let lemma = declare_fixpoint_interactive_generic ~indexes:possible_indexes ~scope ?clearbody ~poly ?typing_flags ?user_warns fix ntns in
   lemma
 
-let do_fixpoint ?scope ?clearbody ~poly ?typing_flags ?deprecation ?using l =
+let do_fixpoint ?scope ?clearbody ~poly ?typing_flags ?user_warns ?using l =
   let fixl, ntns, fix, possible_indexes = do_fixpoint_common ?typing_flags l in
-  declare_fixpoint_generic ~indexes:possible_indexes ?scope ?clearbody ~poly ?typing_flags ?deprecation ?using fix ntns
+  declare_fixpoint_generic ~indexes:possible_indexes ?scope ?clearbody ~poly ?typing_flags ?user_warns ?using fix ntns
 
 let do_cofixpoint_common (fixl : Vernacexpr.cofixpoint_expr list) =
   let fixl = List.map (fun fix -> {fix with Vernacexpr.rec_order = None}) fixl in
   let ntns = List.map_append (fun { Vernacexpr.notations } -> List.map Metasyntax.prepare_where_notation notations ) fixl in
   interp_fixpoint ~cofix:true fixl, ntns
 
-let do_cofixpoint_interactive ~scope ~poly ?deprecation l =
+let do_cofixpoint_interactive ~scope ~poly ?user_warns l =
   let cofix, ntns = do_cofixpoint_common l in
-  let lemma = declare_fixpoint_interactive_generic ~scope ~poly ?deprecation cofix ntns in
+  let lemma = declare_fixpoint_interactive_generic ~scope ~poly ?user_warns cofix ntns in
   lemma
 
-let do_cofixpoint ~scope ~poly ?deprecation ?using l =
+let do_cofixpoint ~scope ~poly ?user_warns ?using l =
   let cofix, ntns = do_cofixpoint_common l in
-  declare_fixpoint_generic ~scope ~poly ?deprecation ?using cofix ntns
+  declare_fixpoint_generic ~scope ~poly ?user_warns ?using cofix ntns

--- a/vernac/comFixpoint.mli
+++ b/vernac/comFixpoint.mli
@@ -20,7 +20,7 @@ val do_fixpoint_interactive
   -> ?clearbody:bool
   -> poly:bool
   -> ?typing_flags:Declarations.typing_flags
-  -> ?deprecation:Deprecation.t
+  -> ?user_warns:UserWarn.t
   -> fixpoint_expr list
   -> Declare.Proof.t
 
@@ -29,7 +29,7 @@ val do_fixpoint
    -> ?clearbody:bool
   -> poly:bool
   -> ?typing_flags:Declarations.typing_flags
-  -> ?deprecation:Deprecation.t
+  -> ?user_warns:UserWarn.t
   -> ?using:Vernacexpr.section_subset_expr
   -> fixpoint_expr list
   -> unit
@@ -37,14 +37,14 @@ val do_fixpoint
 val do_cofixpoint_interactive
   : scope:Locality.definition_scope
   -> poly:bool
-  -> ?deprecation:Deprecation.t
+  -> ?user_warns:UserWarn.t
   -> cofixpoint_expr list
   -> Declare.Proof.t
 
 val do_cofixpoint
   : scope:Locality.definition_scope
   -> poly:bool
-  -> ?deprecation:Deprecation.t
+  -> ?user_warns:UserWarn.t
   -> ?using:Vernacexpr.section_subset_expr
   -> cofixpoint_expr list
   -> unit

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -114,7 +114,7 @@ let nf_evar_context sigma ctx =
   in
   List.map map ctx
 
-let build_wellfounded pm (recname,pl,bl,arityc,body) poly ?typing_flags ?deprecation ?using r measure notation =
+let build_wellfounded pm (recname,pl,bl,arityc,body) poly ?typing_flags ?user_warns ?using r measure notation =
   let open EConstr in
   let open Vars in
   let fix_sub_ref, measure_on_R_ref = try fix_sub_ref (), measure_on_R_ref ()
@@ -278,7 +278,7 @@ let build_wellfounded pm (recname,pl,bl,arityc,body) poly ?typing_flags ?depreca
   in
   let uctx = Evd.evar_universe_context sigma in
   let cinfo = Declare.CInfo.make ~name:recname ~typ:evars_typ ?using () in
-  let info = Declare.Info.make ~udecl ~poly ~hook ?typing_flags ?deprecation () in
+  let info = Declare.Info.make ~udecl ~poly ~hook ?typing_flags ?user_warns () in
   let pm, _ =
     Declare.Obls.add_definition ~pm ~cinfo ~info ~term:evars_def ~uctx evars in
   pm
@@ -290,7 +290,7 @@ let out_def = function
 let collect_evars_of_term evd c ty =
   Evar.Set.union (Evd.evars_of_term evd c) (Evd.evars_of_term evd ty)
 
-let do_program_recursive ~pm ~scope ?clearbody ~poly ?typing_flags ?deprecation ?using fixkind fixl =
+let do_program_recursive ~pm ~scope ?clearbody ~poly ?typing_flags ?user_warns ?using fixkind fixl =
   let cofix = fixkind = Declare.Obls.IsCoFixpoint in
   let (env, rec_sign, udecl, evd), fix, info =
     let env = Global.env () in
@@ -345,16 +345,16 @@ let do_program_recursive ~pm ~scope ?clearbody ~poly ?typing_flags ?deprecation 
   | Declare.Obls.IsCoFixpoint -> Decls.(IsDefinition CoFixpoint)
   in
   let ntns = List.map_append (fun { Vernacexpr.notations } -> List.map Metasyntax.prepare_where_notation notations ) fixl in
-  let info = Declare.Info.make ~poly ~scope ?clearbody ~kind ~udecl ?typing_flags ?deprecation () in
+  let info = Declare.Info.make ~poly ~scope ?clearbody ~kind ~udecl ?typing_flags ?user_warns () in
   Declare.Obls.add_mutual_definitions ~pm defs ~info ~uctx ~ntns fixkind
 
-let do_fixpoint ~pm ~scope ?clearbody ~poly ?typing_flags ?deprecation ?using l =
+let do_fixpoint ~pm ~scope ?clearbody ~poly ?typing_flags ?user_warns ?using l =
   let g = List.map (fun { Vernacexpr.rec_order } -> rec_order) l in
     match g, l with
     | [Some { CAst.v = CWfRec (n,r) }],
       [ Vernacexpr.{fname={CAst.v=id}; univs; binders; rtype; body_def; notations} ] ->
         let recarg = mkIdentC n.CAst.v in
-        build_wellfounded pm (id, univs, binders, rtype, out_def body_def) poly ?typing_flags ?deprecation ?using r recarg notations
+        build_wellfounded pm (id, univs, binders, rtype, out_def body_def) poly ?typing_flags ?user_warns ?using r recarg notations
 
     | [Some { CAst.v = CMeasureRec (n, m, r) }],
       [Vernacexpr.{fname={CAst.v=id}; univs; binders; rtype; body_def; notations }] ->
@@ -380,6 +380,6 @@ let do_fixpoint ~pm ~scope ?clearbody ~poly ?typing_flags ?deprecation ?using l 
       CErrors.user_err
         (str "Well-founded fixpoints not allowed in mutually recursive blocks.")
 
-let do_cofixpoint ~pm ~scope ~poly ?deprecation ?using fixl =
+let do_cofixpoint ~pm ~scope ~poly ?user_warns ?using fixl =
   let fixl = List.map (fun fix -> { fix with Vernacexpr.rec_order = None }) fixl in
-  do_program_recursive ~pm ~scope ~poly ?deprecation ?using Declare.Obls.IsCoFixpoint fixl
+  do_program_recursive ~pm ~scope ~poly ?user_warns ?using Declare.Obls.IsCoFixpoint fixl

--- a/vernac/comProgramFixpoint.mli
+++ b/vernac/comProgramFixpoint.mli
@@ -17,7 +17,7 @@ val do_fixpoint :
   -> ?clearbody:bool
   -> poly:bool
   -> ?typing_flags:Declarations.typing_flags
-  -> ?deprecation:Deprecation.t
+  -> ?user_warns:UserWarn.t
   -> ?using:Vernacexpr.section_subset_expr
   -> fixpoint_expr list
   -> Declare.OblState.t
@@ -26,7 +26,7 @@ val do_cofixpoint :
      pm:Declare.OblState.t
   -> scope:Locality.definition_scope
   -> poly:bool
-  -> ?deprecation:Deprecation.t
+  -> ?user_warns:UserWarn.t
   -> ?using:Vernacexpr.section_subset_expr
   -> cofixpoint_expr list
   -> Declare.OblState.t

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -111,7 +111,7 @@ module Info : sig
     -> ?hook : Hook.t
     (** Callback to be executed after saving the constant *)
     -> ?typing_flags:Declarations.typing_flags
-    -> ?deprecation : Deprecation.t
+    -> ?user_warns : UserWarn.t
     -> unit
     -> t
 
@@ -377,7 +377,7 @@ val declare_entry
   :  name:Id.t
   -> ?scope:Locality.definition_scope
   -> kind:Decls.logical_kind
-  -> ?deprecation:Deprecation.t
+  -> ?user_warns:UserWarn.t
   -> ?hook:Hook.t
   -> impargs:Impargs.manual_implicits
   -> uctx:UState.t
@@ -424,7 +424,7 @@ val declare_constant
   -> name:Id.t
   -> kind:Decls.logical_kind
   -> ?typing_flags:Declarations.typing_flags
-  -> ?deprecation: Deprecation.t
+  -> ?user_warns:UserWarn.t
   -> constant_entry
   -> Constant.t
 

--- a/vernac/declaremods.mli
+++ b/vernac/declaremods.mli
@@ -155,7 +155,7 @@ val start_library : library_name -> unit
 
 val end_library :
   output_native_objects:bool -> library_name ->
-  Safe_typing.compiled_library * library_objects * library_objects * Nativelib.native_library * Library_info.t list
+  Safe_typing.compiled_library * library_objects * library_objects * Nativelib.native_library * Library_info.t
 
 (** append a function to be executed at end_library *)
 val append_end_library_hook : (unit -> unit) -> unit

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -90,7 +90,7 @@ type summary_disk = {
   md_name : compilation_unit_name;
   md_deps : (compilation_unit_name * Safe_typing.vodigest) array;
   md_ocaml : string;
-  md_info : Library_info.t list;
+  md_info : Library_info.t;
 }
 
 (*s Modules loaded in memory contain the following informations. They are
@@ -102,13 +102,13 @@ type library_t = {
   library_deps : (compilation_unit_name * Safe_typing.vodigest) array;
   library_digests : Safe_typing.vodigest;
   library_extra_univs : Univ.ContextSet.t;
-  library_info : Library_info.t list;
+  library_info : Library_info.t;
 }
 
 type library_summary = {
   libsum_name : compilation_unit_name;
   libsum_digests : Safe_typing.vodigest;
-  libsum_info : Library_info.t list;
+  libsum_info : Library_info.t;
 }
 
 (* This is a map from names to loaded libraries *)
@@ -285,9 +285,7 @@ let intern_from_file lib_resolver dir =
        DirPath.print lsd.md_name ++ spc () ++ str "and not library" ++
        spc() ++ DirPath.print dir ++ str ".");
   Feedback.feedback (Feedback.FileLoaded(DirPath.to_string dir, f));
-  List.iter (fun info ->
-      Library_info.warn_library_info ~transitive:true (lsd.md_name,info))
-    lsd.md_info;
+  Library_info.warn_library_info ~transitive:true lsd.md_name lsd.md_info;
   lsd, lmd, digest_lmd, univs, digest_u, del_opaque
 
 let rec intern_library ~intern (needed, contents as acc) dir =
@@ -323,8 +321,7 @@ and intern_mandatory_library ~intern caller libs (dir,d) =
 let rec_intern_library ~lib_resolver libs dir =
   let intern dir = intern_from_file lib_resolver dir in
   let m, libs = intern_library ~intern libs dir in
-  List.iter (fun info -> Library_info.warn_library_info (m.libsum_name,info))
-    m.libsum_info;
+  Library_info.warn_library_info m.libsum_name m.libsum_info;
   libs
 
 let native_name_from_filename f =

--- a/vernac/metasyntax.mli
+++ b/vernac/metasyntax.mli
@@ -26,7 +26,7 @@ type notation_interpretation_decl
 val add_notation_syntax :
   local:bool ->
   infix:bool ->
-  Deprecation.t option ->
+  UserWarn.t option ->
   notation_declaration ->
   notation_interpretation_decl
 (** Add syntax rules for a (constr) notation in the environment *)
@@ -63,7 +63,7 @@ val add_reserved_notation :
 
 (** Add a syntactic definition (as in "Notation f := ...") *)
 
-val add_abbreviation : local:bool -> Deprecation.t option -> env ->
+val add_abbreviation : local:bool -> UserWarn.t option -> env ->
   Id.t -> Id.t list * constr_expr -> syntax_modifier CAst.t list -> unit
 
 (** Print the Camlp5 state of a grammar *)

--- a/vernac/synterp.ml
+++ b/vernac/synterp.ml
@@ -443,8 +443,8 @@ let rec synterp ?loc ~atts v =
       with_module_locality ~atts synterp_reserved_notation ~infix sl;
       EVernacNoop
     | VernacNotation (infix,ntn_decl) ->
-      let local, deprecation = Attributes.(parse Notations.(module_locality ++ deprecation) atts) in
-      let decl = Metasyntax.add_notation_syntax ~local ~infix deprecation ntn_decl in
+      let local, user_warns = Attributes.(parse Notations.(module_locality ++ user_warns) atts) in
+      let decl = Metasyntax.add_notation_syntax ~local ~infix user_warns ntn_decl in
       EVernacNotation { local; decl }
     | VernacDeclareCustomEntry s ->
       with_module_locality ~atts synterp_custom_entry s;

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1537,9 +1537,9 @@ let vernac_hints ~atts dbnames h =
   Hints.add_hints ~locality dbnames (ComHints.interp_hints ~poly h)
 
 let vernac_abbreviation ~atts lid x only_parsing =
-  let module_local, deprecation = Attributes.(parse Notations.(module_locality ++ deprecation) atts) in
+  let module_local, user_warns = Attributes.(parse Notations.(module_locality ++ user_warns) atts) in
   Dumpglob.dump_definition lid false "abbrev";
-  Metasyntax.add_abbreviation ~local:module_local deprecation (Global.env()) lid.v x only_parsing
+  Metasyntax.add_abbreviation ~local:module_local user_warns (Global.env()) lid.v x only_parsing
 
 let default_env () = {
   Notation_term.ninterp_var_type = Id.Map.empty;

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -56,7 +56,7 @@ module DefAttributes = struct
     locality : bool option;
     polymorphic : bool;
     program : bool;
-    deprecated : Deprecation.t option;
+    user_warns : UserWarn.t option;
     canonical_instance : bool;
     typing_flags : Declarations.typing_flags option;
     using : Vernacexpr.section_subset_expr option;
@@ -77,10 +77,10 @@ module DefAttributes = struct
 
   let parse ?(coercion=false) ?(discharge=NoDischarge) f =
     let clearbody = match discharge with DoDischarge -> clearbody | NoDischarge -> return None in
-    let (((((((locality, deprecated), polymorphic), program),
+    let (((((((locality, user_warns), polymorphic), program),
          canonical_instance), typing_flags), using),
          reversible), clearbody =
-      parse (locality ++ deprecation ++ polymorphic ++ program ++
+      parse (locality ++ user_warns ++ polymorphic ++ program ++
              canonical_instance ++ typing_flags ++ using ++
              reversible ++ clearbody)
         f
@@ -90,7 +90,7 @@ module DefAttributes = struct
     let () = if Option.has_some clearbody && not (Lib.sections_are_opened())
       then CErrors.user_err Pp.(str "Cannot use attribute clearbody outside sections.")
     in
-    { polymorphic; program; locality; deprecated; canonical_instance; typing_flags; using; reversible; clearbody }
+    { polymorphic; program; locality; user_warns; canonical_instance; typing_flags; using; reversible; clearbody }
 end
 
 let with_def_attributes ?coercion ?discharge ~atts f =
@@ -625,7 +625,7 @@ let post_check_evd ~udecl ~poly evd =
   else (* We fix the variables to ensure they won't be lowered to Set *)
     Evd.fix_undefined_variables evd
 
-let start_lemma_com ~typing_flags ~program_mode ~poly ~scope ?clearbody ~kind ~deprecation ?using ?hook thms =
+let start_lemma_com ~typing_flags ~program_mode ~poly ~scope ?clearbody ~kind ?user_warns ?using ?hook thms =
   let env0 = Global.env () in
   let env0 = Environ.update_typing_flags ?typing_flags env0 in
   let flags = Pretyping.{ all_no_fail_flags with program_mode } in
@@ -634,7 +634,7 @@ let start_lemma_com ~typing_flags ~program_mode ~poly ~scope ?clearbody ~kind ~d
   let evd, thms = interp_lemma ~program_mode ~flags ~scope env0 evd thms in
   let mut_analysis = RecLemmas.look_for_possibly_mutual_statements evd thms in
   let evd = Evd.minimize_universes evd in
-  let info = Declare.Info.make ?hook ~poly ~scope ?clearbody ~kind ~udecl ?typing_flags ?deprecation () in
+  let info = Declare.Info.make ?hook ~poly ~scope ?clearbody ~kind ~udecl ?typing_flags ?user_warns () in
   begin
     match mut_analysis with
     | RecLemmas.NonMutual thm ->
@@ -687,10 +687,10 @@ let vernac_definition_interactive ~atts (discharge, kind) (lid, pl) bl t =
   let program_mode = atts.program in
   let poly = atts.polymorphic in
   let typing_flags = atts.typing_flags in
-  let deprecation = atts.deprecated in
+  let user_warns = atts.user_warns in
   let name = vernac_definition_name lid local in
   start_lemma_com ~typing_flags ~program_mode ~poly ~scope:local ?clearbody:atts.clearbody
-    ~kind:(Decls.IsDefinition kind) ~deprecation ?using:atts.using ?hook [(name, pl), (bl, t)]
+    ~kind:(Decls.IsDefinition kind) ?user_warns ?using:atts.using ?hook [(name, pl), (bl, t)]
 
 let vernac_definition ~atts ~pm (discharge, kind) (lid, pl) bl red_option c typ_opt =
   let open DefAttributes in
@@ -709,12 +709,12 @@ let vernac_definition ~atts ~pm (discharge, kind) (lid, pl) bl red_option c typ_
     let kind = Decls.IsDefinition kind in
     ComDefinition.do_definition_program ~pm ~name:name.v
       ?clearbody:atts.clearbody ~poly:atts.polymorphic ?typing_flags ~scope ~kind
-      ?deprecation:atts.deprecated pl bl red_option c typ_opt ?hook
+      ?user_warns:atts.user_warns pl bl red_option c typ_opt ?hook
   else
     let () =
       ComDefinition.do_definition ~name:name.v
         ?clearbody:atts.clearbody ~poly:atts.polymorphic ?typing_flags ~scope ~kind ?using:atts.using
-        ?deprecation:atts.deprecated pl bl red_option c typ_opt ?hook in
+        ?user_warns:atts.user_warns pl bl red_option c typ_opt ?hook in
     pm
 
 (* NB: pstate argument to use combinators easily *)
@@ -727,7 +727,7 @@ let vernac_start_proof ~atts kind l =
     ~typing_flags:atts.typing_flags
     ~program_mode:atts.program
     ~poly:atts.polymorphic
-    ~scope ~kind:(Decls.IsProof kind) ~deprecation:atts.deprecated ?using:atts.using l
+    ~scope ~kind:(Decls.IsProof kind) ?user_warns:atts.user_warns ?using:atts.using l
 
 let vernac_end_proof ~lemma ~pm = let open Vernacexpr in function
   | Admitted ->
@@ -757,7 +757,7 @@ let vernac_assumption ~atts discharge kind l nl =
             | Discharge -> Dumpglob.dump_definition lid true "var") idl) l;
   if Option.has_some atts.using then
     Attributes.unsupported_attributes [CAst.make ("using",VernacFlagEmpty)];
-  ComAssumption.do_assumptions ~poly:atts.polymorphic ~program_mode:atts.program ~scope ~kind ?deprecation:atts.deprecated nl l
+  ComAssumption.do_assumptions ~poly:atts.polymorphic ~program_mode:atts.program ~scope ~kind ?user_warns:atts.user_warns nl l
 
 let { Goptions.get = is_polymorphic_inductive_cumulativity } =
   declare_bool_option_and_ref
@@ -1066,7 +1066,7 @@ let vernac_fixpoint_interactive ~atts discharge l =
   if atts.program then
     CErrors.user_err Pp.(str"Program Fixpoint requires a body.");
   let typing_flags = atts.typing_flags in
-  ComFixpoint.do_fixpoint_interactive ~scope ?clearbody:atts.clearbody ~poly:atts.polymorphic ?typing_flags ?deprecation:atts.deprecated l
+  ComFixpoint.do_fixpoint_interactive ~scope ?clearbody:atts.clearbody ~poly:atts.polymorphic ?typing_flags ?user_warns:atts.user_warns l
   |> vernac_set_used_variables_opt ?using:atts.using
 
 let vernac_fixpoint ~atts ~pm discharge l =
@@ -1076,10 +1076,10 @@ let vernac_fixpoint ~atts ~pm discharge l =
   if atts.program then
     (* XXX: Switch to the attribute system and match on ~atts *)
     ComProgramFixpoint.do_fixpoint ~pm ~scope ?clearbody:atts.clearbody ~poly:atts.polymorphic
-      ?typing_flags ?deprecation:atts.deprecated ?using:atts.using l
+      ?typing_flags ?user_warns:atts.user_warns ?using:atts.using l
   else
     let () = ComFixpoint.do_fixpoint ~scope ?clearbody:atts.clearbody ~poly:atts.polymorphic
-      ?typing_flags ?deprecation:atts.deprecated ?using:atts.using l in
+      ?typing_flags ?user_warns:atts.user_warns ?using:atts.using l in
     pm
 
 let vernac_cofixpoint_common ~atts discharge l =

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -69,12 +69,6 @@ module DefAttributes = struct
 
   let clearbody = bool_attribute ~name:"clearbody"
 
-  let make_information deprecated =
-    let open Library_info in
-    match deprecated with
-    | Some depr -> [Deprecation depr]
-    | None -> []
-
   let parse ?(coercion=false) ?(discharge=NoDischarge) f =
     let clearbody = match discharge with DoDischarge -> clearbody | NoDischarge -> return None in
     let (((((((locality, user_warns), polymorphic), program),
@@ -2094,8 +2088,9 @@ let vernac_register qid r =
 
 let vernac_library_attributes atts =
   if Global.is_curmod_library () && not (Lib.sections_are_opened ()) then
-    let deprecated = Attributes.parse deprecation atts in
-    Lib.Synterp.declare_info (DefAttributes.make_information deprecated)
+    let user_warns = Attributes.parse user_warns atts in
+    let user_warns = Option.default UserWarn.empty user_warns in
+    Lib.Synterp.declare_info user_warns
   else
     user_err (Pp.str "A library attribute should be at toplevel of the library.")
 


### PR DESCRIPTION
Add a new attribute `warn(note="message", cats="cata,catb,catc")` that is automatically displayed at the time of use of the corresponding object (via the nametab, as for the deprecation) as a warning with message `message` and categories `cata`, `catb` and `catc`. This works for various kinds of objects (at the current time, mostly logical declarations and library files, but it could be extended to Ltac, Ltac2, notations, ...).

Examples:
```coq
#[warn(note="I'm a constant number", cats="constant-number-message")] Definition a := 0.
Check a.
Toplevel input, characters 6-7:
> Check a.
>       ^
Warning: I'm a constant number [warn-reference-constant-number-message,warn-reference,constant-number-message,user-warn,default]
```
In file Foo.v:
```coq
Attributes warn(note="I'm the file Foo"), deprecated(note="use Bar").
```
Then at loading time:
```coq
> Require Foo.
> ^^^^^^^^^^^^
Warning: ...
```

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
- [x] Added / updated **documentation**.

#### Overlays (to be merged in sync with the PR)

- https://github.com/LPCIC/coq-elpi/pull/589