### PR TITLE
Remove Names API deprecated in Coq 8.13.

### DIFF
--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -716,37 +716,10 @@ type inductive = Ind.t
 (** Designation of a (particular) constructor of a (particular) inductive type. *)
 type constructor = Construct.t
 
-let ind_modpath = Ind.modpath
-let constr_modpath = Construct.modpath
-
 let ith_mutual_inductive (mind, _) i = (mind, i)
 let ith_constructor_of_inductive ind i = (ind, i)
 let inductive_of_constructor (ind, _i) = ind
 let index_of_constructor (_ind, i) = i
-
-let eq_ind = Ind.CanOrd.equal
-let eq_user_ind = Ind.UserOrd.equal
-let eq_syntactic_ind = Ind.SyntacticOrd.equal
-
-let ind_ord = Ind.CanOrd.compare
-let ind_user_ord = Ind.UserOrd.compare
-let ind_syntactic_ord = Ind.SyntacticOrd.compare
-
-let ind_hash = Ind.CanOrd.hash
-let ind_user_hash = Ind.UserOrd.hash
-let ind_syntactic_hash = Ind.SyntacticOrd.hash
-
-let eq_constructor = Construct.CanOrd.equal
-let eq_user_constructor = Construct.UserOrd.equal
-let eq_syntactic_constructor = Construct.SyntacticOrd.equal
-
-let constructor_ord = Construct.CanOrd.compare
-let constructor_user_ord = Construct.UserOrd.compare
-let constructor_syntactic_ord = Construct.SyntacticOrd.compare
-
-let constructor_hash = Construct.CanOrd.hash
-let constructor_user_hash = Construct.UserOrd.hash
-let constructor_syntactic_hash = Construct.SyntacticOrd.hash
 
 module Indset = Set.Make(Ind.CanOrd)
 module Indset_env = Set.Make(Ind.UserOrd)
@@ -766,7 +739,7 @@ module Hind = Hashcons.Make(
     type u = MutInd.t -> MutInd.t
     let hashcons hmind (mind, i) = (hmind mind, i)
     let eq (mind1,i1) (mind2,i2) = mind1 == mind2 && Int.equal i1 i2
-    let hash = ind_hash
+    let hash = Ind.CanOrd.hash
   end)
 
 module Hconstruct = Hashcons.Make(
@@ -775,7 +748,7 @@ module Hconstruct = Hashcons.Make(
     type u = inductive -> inductive
     let hashcons hind (ind, j) = (hind ind, j)
     let eq (ind1, j1) (ind2, j2) = ind1 == ind2 && Int.equal j1 j2
-    let hash = constructor_hash
+    let hash = Construct.CanOrd.hash
   end)
 
 let hcons_con = Constant.hcons
@@ -854,7 +827,7 @@ struct
     let relevant c = c.proj_relevant
 
     let hash p =
-      Hashset.Combine.combinesmall p.proj_arg (ind_hash p.proj_ind)
+      Hashset.Combine.combinesmall p.proj_arg (Ind.CanOrd.hash p.proj_ind)
 
     let bcomp b1 b2 = match b1, b2 with
     | true, true | false, false -> 0
@@ -876,40 +849,40 @@ struct
       type nonrec t = t
 
       let compare a b =
-        let c = ind_syntactic_ord a.proj_ind b.proj_ind in
+        let c = Ind.SyntacticOrd.compare a.proj_ind b.proj_ind in
         if c <> 0 then c
         else compare_gen a b
 
       let equal a b = compare a b == 0
 
       let hash p =
-        Hashset.Combine.combinesmall p.proj_arg (ind_hash p.proj_ind)
+        Hashset.Combine.combinesmall p.proj_arg (Ind.CanOrd.hash p.proj_ind)
     end
     module CanOrd = struct
       type nonrec t = t
 
       let compare a b =
-        let c = ind_ord a.proj_ind b.proj_ind in
+        let c = Ind.CanOrd.compare a.proj_ind b.proj_ind in
         if c <> 0 then c
         else compare_gen a b
 
       let equal a b = compare a b == 0
 
       let hash p =
-        Hashset.Combine.combinesmall p.proj_arg (ind_hash p.proj_ind)
+        Hashset.Combine.combinesmall p.proj_arg (Ind.CanOrd.hash p.proj_ind)
     end
     module UserOrd = struct
       type nonrec t = t
 
       let compare a b =
-        let c = ind_user_ord a.proj_ind b.proj_ind in
+        let c = Ind.UserOrd.compare a.proj_ind b.proj_ind in
         if c <> 0 then c
         else compare_gen a b
 
       let equal a b = compare a b == 0
 
       let hash p =
-        Hashset.Combine.combinesmall p.proj_arg (ind_user_hash p.proj_ind)
+        Hashset.Combine.combinesmall p.proj_arg (Ind.UserOrd.hash p.proj_ind)
     end
 
     let equal = CanOrd.equal
@@ -1034,8 +1007,8 @@ module GlobRefInternal = struct
   let equal gr1 gr2 =
     gr1 == gr2 || match gr1,gr2 with
     | ConstRef con1, ConstRef con2 -> Constant.equal con1 con2
-    | IndRef kn1, IndRef kn2 -> eq_ind kn1 kn2
-    | ConstructRef kn1, ConstructRef kn2 -> eq_constructor kn1 kn2
+    | IndRef kn1, IndRef kn2 -> Ind.CanOrd.equal kn1 kn2
+    | ConstructRef kn1, ConstructRef kn2 -> Construct.CanOrd.equal kn1 kn2
     | VarRef v1, VarRef v2 -> Id.equal v1 v2
     | (ConstRef _ | IndRef _ | ConstructRef _ | VarRef _), _ -> false
 

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -534,52 +534,10 @@ module Constrmap : CMap.ExtS with type key = constructor and module Set := Const
 module Indmap_env : CMap.ExtS with type key = inductive and module Set := Indset_env
 module Constrmap_env : CMap.ExtS with type key = constructor and module Set := Constrset_env
 
-val ind_modpath : inductive -> ModPath.t
-[@@ocaml.deprecated "Use the Ind module"]
-
-val constr_modpath : constructor -> ModPath.t
-[@@ocaml.deprecated "Use the Construct module"]
-
 val ith_mutual_inductive : inductive -> int -> inductive
 val ith_constructor_of_inductive : inductive -> int -> constructor
 val inductive_of_constructor : constructor -> inductive
 val index_of_constructor : constructor -> int
-val eq_ind : inductive -> inductive -> bool
-[@@ocaml.deprecated "Use the Ind module"]
-val eq_user_ind : inductive -> inductive -> bool
-[@@ocaml.deprecated "Use the Ind module"]
-val eq_syntactic_ind : inductive -> inductive -> bool
-[@@ocaml.deprecated "Use the Ind module"]
-val ind_ord : inductive -> inductive -> int
-[@@ocaml.deprecated "Use the Ind module"]
-val ind_hash : inductive -> int
-[@@ocaml.deprecated "Use the Ind module"]
-val ind_user_ord : inductive -> inductive -> int
-[@@ocaml.deprecated "Use the Ind module"]
-val ind_user_hash : inductive -> int
-[@@ocaml.deprecated "Use the Ind module"]
-val ind_syntactic_ord : inductive -> inductive -> int
-[@@ocaml.deprecated "Use the Ind module"]
-val ind_syntactic_hash : inductive -> int
-[@@ocaml.deprecated "Use the Ind module"]
-val eq_constructor : constructor -> constructor -> bool
-[@@ocaml.deprecated "Use the Construct module"]
-val eq_user_constructor : constructor -> constructor -> bool
-[@@ocaml.deprecated "Use the Construct module"]
-val eq_syntactic_constructor : constructor -> constructor -> bool
-[@@ocaml.deprecated "Use the Construct module"]
-val constructor_ord : constructor -> constructor -> int
-[@@ocaml.deprecated "Use the Construct module"]
-val constructor_hash : constructor -> int
-[@@ocaml.deprecated "Use the Construct module"]
-val constructor_user_ord : constructor -> constructor -> int
-[@@ocaml.deprecated "Use the Construct module"]
-val constructor_user_hash : constructor -> int
-[@@ocaml.deprecated "Use the Construct module"]
-val constructor_syntactic_ord : constructor -> constructor -> int
-[@@ocaml.deprecated "Use the Construct module"]
-val constructor_syntactic_hash : constructor -> int
-[@@ocaml.deprecated "Use the Construct module"]
 
 (** {6 Hash-consing } *)
 


### PR DESCRIPTION
Backwards compatible overlays:
- https://github.com/unicoq/unicoq/pull/88