### PR TITLE
Remove useless poly argument in add_coercion and cie.

### DIFF
--- a/dev/ci/user-overlays/18253-herbelin-master+useless-poly-flag-coercion.sh
+++ b/dev/ci/user-overlays/18253-herbelin-master+useless-poly-flag-coercion.sh
@@ -1,2 +1,2 @@
 overlay mtac2 https://github.com/herbelin/Mtac2 master+adapt-coq-pr18253-no-poly-for-coercion 18253 master+useless-poly-flag-coercion
-overlay elpi https://github.com/herbelin/coq-elpi coq-master+adapt-coq-pr18253-no-poly-for-coercion master+useless-poly-flag-coercion
+overlay elpi https://github.com/herbelin/coq-elpi coq-master+adapt-coq-pr18253-no-poly-for-coercion 18253 master+useless-poly-flag-coercion

--- a/dev/ci/user-overlays/18253-herbelin-master+useless-poly-flag-coercion.sh
+++ b/dev/ci/user-overlays/18253-herbelin-master+useless-poly-flag-coercion.sh
@@ -1,0 +1,2 @@
+overlay mtac2 https://github.com/herbelin/Mtac2 master+adapt-coq-pr18253-no-poly-for-coercion 18253 master+useless-poly-flag-coercion
+overlay elpi https://github.com/herbelin/coq-elpi coq-master+adapt-coq-pr18253-no-poly-for-coercion master+useless-poly-flag-coercion

--- a/test-suite/bugs/HoTT_coq_014.v
+++ b/test-suite/bugs/HoTT_coq_014.v
@@ -27,7 +27,7 @@ Polymorphic Definition GeneralizeCategory `(C : @SpecializedCategory obj) : Cate
   refine {| CObject := C.(Object) |}; auto.
 Defined.
 
-Polymorphic Coercion GeneralizeCategory : SpecializedCategory >-> Category.
+Coercion GeneralizeCategory : SpecializedCategory >-> Category.
 
 
 
@@ -46,7 +46,7 @@ Section SpecializedFunctor.
   }.
 End SpecializedFunctor.
 
-Global Polymorphic Coercion ObjectOf' : SpecializedFunctor >-> Funclass.
+Global Coercion ObjectOf' : SpecializedFunctor >-> Funclass.
 Set Universe Polymorphism.
 Section Functor.
   Variable C D : Category.
@@ -57,7 +57,7 @@ Unset Universe Polymorphism.
 
 Polymorphic Identity Coercion Functor_SpecializedFunctor_Id : Functor >-> SpecializedFunctor.
 Polymorphic Definition GeneralizeFunctor objC C objD D (F : @SpecializedFunctor objC C objD D) : Functor C D := F.
-Polymorphic Coercion GeneralizeFunctor : SpecializedFunctor >-> Functor.
+Coercion GeneralizeFunctor : SpecializedFunctor >-> Functor.
 
 Arguments SpecializedFunctor {objC} C {objD} D.
 
@@ -72,7 +72,7 @@ Polymorphic Definition GeneralizeSmallCategory `(C : @SmallSpecializedCategory o
   refine {| SObject := obj |}; destruct C; econstructor; eassumption.
 Defined.
 
-Polymorphic Coercion GeneralizeSmallCategory : SmallSpecializedCategory >-> SmallCategory.
+Coercion GeneralizeSmallCategory : SmallSpecializedCategory >-> SmallCategory.
 
 Bind Scope category_scope with SmallCategory.
 

--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -32,14 +32,14 @@ let declare_variable is_coe ~kind typ univs imps impl {CAst.v=name} =
   let () =
     if is_coe = Vernacexpr.AddCoercion then
       ComCoercion.try_add_new_coercion
-        r ~local:true ~poly:false ~reversible:true in
+        r ~local:true ~reversible:true in
   ()
 
 let instance_of_univ_entry = function
   | UState.Polymorphic_entry univs -> Univ.UContext.instance univs
   | UState.Monomorphic_entry _ -> Univ.Instance.empty
 
-let declare_axiom is_coe ~poly ~local ~kind ?deprecation typ (univs, ubinders) imps nl {CAst.v=name} =
+let declare_axiom is_coe ~local ~kind ?deprecation typ (univs, ubinders) imps nl {CAst.v=name} =
   let inl = let open Declaremods in match nl with
     | NoInline -> None
     | DefaultInline -> Some (Flags.get_inline_level())
@@ -59,7 +59,7 @@ let declare_axiom is_coe ~poly ~local ~kind ?deprecation typ (univs, ubinders) i
   let () =
     if is_coe = Vernacexpr.AddCoercion then
       ComCoercion.try_add_new_coercion
-        gr ~local ~poly ~reversible:true in
+        gr ~local ~reversible:true in
   let inst = instance_of_univ_entry univs in
   (gr,inst)
 
@@ -85,7 +85,7 @@ let clear_univs scope univ =
   | _, (UState.Monomorphic_entry _, _) -> empty_univ_entry ~poly:false
   | Locality.Discharge, (UState.Polymorphic_entry _, _) -> empty_univ_entry ~poly:true
 
-let declare_assumptions ~poly ~scope ~kind ?deprecation univs nl l =
+let declare_assumptions ~scope ~kind ?deprecation univs nl l =
   let _, _ = List.fold_left (fun (subst,univs) ((is_coe,idl),typ,imps) ->
       (* NB: here univs are ignored when scope=Discharge *)
       let typ = replace_vars subst typ in
@@ -96,7 +96,7 @@ let declare_assumptions ~poly ~scope ~kind ?deprecation univs nl l =
                 declare_variable is_coe ~kind typ univs imps Glob_term.Explicit id;
                 GlobRef.VarRef id.CAst.v, Univ.Instance.empty
               | Locality.Global local ->
-                declare_axiom is_coe ~local ~poly ~kind ?deprecation typ univs imps nl id
+                declare_axiom is_coe ~local ~kind ?deprecation typ univs imps nl id
             in
             clear_univs scope univs, (id.CAst.v, Constr.mkRef refu))
           univs idl
@@ -174,7 +174,7 @@ let do_assumptions ~program_mode ~poly ~scope ~kind ?deprecation nl l =
      this case too. *)
   let sigma = Evd.restrict_universe_context sigma uvars in
   let univs = Evd.check_univ_decl ~poly sigma udecl in
-  declare_assumptions ~poly ~scope ~kind ?deprecation univs nl l
+  declare_assumptions ~scope ~kind ?deprecation univs nl l
 
 let context_subst subst (name,b,t,impl) =
   name, Option.map (Vars.substl subst) b, Vars.substl subst t, impl

--- a/vernac/comAssumption.mli
+++ b/vernac/comAssumption.mli
@@ -45,7 +45,6 @@ val declare_variable
 
 val declare_axiom
   : coercion_flag
-  -> poly:bool
   -> local:Locality.import_status
   -> kind:Decls.assumption_object_kind
   -> ?deprecation:Deprecation.t

--- a/vernac/comCoercion.ml
+++ b/vernac/comCoercion.ml
@@ -301,7 +301,7 @@ let warn_uniform_inheritance =
           Printer.pr_global g ++
             strbrk" does not respect the uniform inheritance condition.")
 
-let add_new_coercion_core coef stre poly ~reversible source target isid : unit =
+let add_new_coercion_core coef stre ~reversible source target isid : unit =
   check_source source;
   let env = Global.env () in
   let t, _ = Typeops.type_of_global_in_context env coef in
@@ -335,44 +335,44 @@ let add_new_coercion_core coef stre poly ~reversible source target isid : unit =
   let params = List.length (Context.Rel.instance_list EConstr.mkRel 0 ctx) in
   declare_coercion coef t ~local ~reversible ~isid ~src:cls ~target:clt ~params ()
 
-let try_add_new_coercion_core ref ~local c ~reversible d e f =
-  try add_new_coercion_core ref (loc_of_bool local) c ~reversible d e f
+let try_add_new_coercion_core ref ~local c ~reversible d e =
+  try add_new_coercion_core ref (loc_of_bool local) c ~reversible d e
   with CoercionError e ->
       user_err
         (explain_coercion_error ref e ++ str ".")
 
-let try_add_new_coercion ref ~local ~poly ~reversible =
-  try_add_new_coercion_core ref ~local poly ~reversible None None false
+let try_add_new_coercion ref ~local ~reversible =
+  try_add_new_coercion_core ref ~local ~reversible None None false
 
 let try_add_new_coercion_subclass cl ~local ~poly ~reversible =
   let coe_ref = build_id_coercion None cl poly in
-  try_add_new_coercion_core coe_ref ~local poly ~reversible (Some cl) None true
+  try_add_new_coercion_core coe_ref ~local ~reversible (Some cl) None true
 
-let try_add_new_coercion_with_target ref ~local ~poly ~reversible ~source ~target =
-  try_add_new_coercion_core ref ~local poly ~reversible
+let try_add_new_coercion_with_target ref ~local ~reversible ~source ~target =
+  try_add_new_coercion_core ref ~local ~reversible
     (Some source) (Some target) false
 
 let try_add_new_identity_coercion id ~local ~poly ~source ~target =
   let ref = build_id_coercion (Some id) source poly in
-  try_add_new_coercion_core ref ~local poly ~reversible:true
+  try_add_new_coercion_core ref ~local ~reversible:true
     (Some source) (Some target) true
 
-let try_add_new_coercion_with_source ref ~local ~poly ~reversible ~source =
-  try_add_new_coercion_core ref ~local poly ~reversible (Some source) None false
+let try_add_new_coercion_with_source ref ~local ~reversible ~source =
+  try_add_new_coercion_core ref ~local ~reversible (Some source) None false
 
-let add_coercion_hook poly reversible { Declare.Hook.S.scope; dref; _ } =
+let add_coercion_hook reversible { Declare.Hook.S.scope; dref; _ } =
   let open Locality in
   let local = match scope with
   | Discharge -> assert false (* Local Coercion in section behaves like Local Definition *)
   | Global ImportNeedQualified -> true
   | Global ImportDefaultBehavior -> false
   in
-  let () = try_add_new_coercion dref ~local ~poly ~reversible in
+  let () = try_add_new_coercion dref ~local ~reversible in
   let msg = Nametab.pr_global_env Id.Set.empty dref ++ str " is now a coercion" in
   Flags.if_verbose Feedback.msg_info msg
 
-let add_coercion_hook ~poly ~reversible =
-  Declare.Hook.make (add_coercion_hook poly reversible)
+let add_coercion_hook ~reversible =
+  Declare.Hook.make (add_coercion_hook reversible)
 
 let add_subclass_hook ~poly { Declare.Hook.S.scope; dref; _ } =
   let open Locality in

--- a/vernac/comCoercion.mli
+++ b/vernac/comCoercion.mli
@@ -18,7 +18,6 @@ open Coercionops
 val try_add_new_coercion_with_target
   :  GlobRef.t
   -> local:bool
-  -> poly:bool
   -> reversible:bool
   -> source:cl_typ
   -> target:cl_typ
@@ -26,7 +25,7 @@ val try_add_new_coercion_with_target
 
 (** [try_add_new_coercion ref s] declares [ref], assumed to be of type
    [(x1:T1)...(xn:Tn)src->tg], as a coercion from [src] to [tg] *)
-val try_add_new_coercion : GlobRef.t -> local:bool -> poly:bool ->
+val try_add_new_coercion : GlobRef.t -> local:bool ->
   reversible:bool -> unit
 
 (** [try_add_new_coercion_subclass cst s] expects that [cst] denotes a
@@ -39,7 +38,7 @@ val try_add_new_coercion_subclass : cl_typ -> local:bool -> poly:bool ->
 (** [try_add_new_coercion_with_source ref s src] declares [ref] as a coercion
    from [src] to [tg] where the target is inferred from the type of [ref] *)
 val try_add_new_coercion_with_source : GlobRef.t -> local:bool ->
-  poly:bool -> reversible:bool -> source:cl_typ -> unit
+  reversible:bool -> source:cl_typ -> unit
 
 (** [try_add_new_identity_coercion id s src tg] enriches the
    environment with a new definition of name [id] declared as an
@@ -49,7 +48,7 @@ val try_add_new_identity_coercion
   -> local:bool
   -> poly:bool -> source:cl_typ -> target:cl_typ -> unit
 
-val add_coercion_hook : poly:bool -> reversible:bool -> Declare.Hook.t
+val add_coercion_hook : reversible:bool -> Declare.Hook.t
 
 val add_subclass_hook : poly:bool -> reversible:bool -> Declare.Hook.t
 

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -744,7 +744,7 @@ let do_mutual_inductive ~template udecl indl ~cumulative ~poly ?typing_flags ~pr
   (* Declare the possible notations of inductive types *)
   List.iter (Metasyntax.add_notation_interpretation ~local:false (Global.env ())) where_notations;
   (* Declare the coercions *)
-  List.iter (fun qid -> ComCoercion.try_add_new_coercion (Nametab.locate qid) ~local:false ~poly ~reversible:true) coercions
+  List.iter (fun qid -> ComCoercion.try_add_new_coercion (Nametab.locate qid) ~local:false ~reversible:true) coercions
 
 (** Prepare a "match" template for a given inductive type.
     For each branch of the match, we list the constructor name

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -359,11 +359,11 @@ let instantiate_possibly_recursive_type ind u ntypes paramdecls fields =
    or a typeclass instance according to [flags]. *)
 (* remove the last argument (it will become alway true) after deprecation phase
    (started in 8.17, c.f. https://github.com/coq/coq/pull/16230) *)
-let declare_proj_coercion_instance ~flags ref from ~poly ~with_coercion =
+let declare_proj_coercion_instance ~flags ref from ~with_coercion =
   if with_coercion && flags.Data.pf_coercion then begin
     let cl = ComCoercion.class_of_global from in
     let local = flags.Data.pf_locality = Goptions.OptLocal in
-    ComCoercion.try_add_new_coercion_with_source ref ~local ~poly ~reversible:flags.Data.pf_reversible ~source:cl
+    ComCoercion.try_add_new_coercion_with_source ref ~local ~reversible:flags.Data.pf_reversible ~source:cl
   end;
   if flags.Data.pf_instance then begin
     let env = Global.env () in
@@ -437,7 +437,7 @@ let build_named_proj ~primitive ~flags ~poly ~univs ~uinstance ~kind env paramde
   in
   let refi = GlobRef.ConstRef kn in
   Impargs.maybe_declare_manual_implicits false refi impls;
-  declare_proj_coercion_instance ~flags refi (GlobRef.IndRef indsp) ~poly ~with_coercion:true;
+  declare_proj_coercion_instance ~flags refi (GlobRef.IndRef indsp) ~with_coercion:true;
   let i = if is_local_assum decl then i+1 else i in
   (Some kn, i, Projection term::subst)
 
@@ -828,7 +828,7 @@ let declare_structure { Record_decl.mie; primitive_proj; impls; globnames; globa
     let cstr = (rsp, 1) in
     let projections = declare_projections rsp (projunivs,ubinders) ~kind:projections_kind inhabitant_id proj_flags implfs fields in
     let build = GlobRef.ConstructRef cstr in
-    let () = if is_coercion then ComCoercion.try_add_new_coercion build ~local:false ~poly ~reversible:true in
+    let () = if is_coercion then ComCoercion.try_add_new_coercion build ~local:false ~reversible:true in
     let struc = Structure.make (Global.env ()) rsp projections in
     let () = declare_structure_entry struc in
     GlobRef.IndRef rsp
@@ -882,9 +882,7 @@ let declare_class_constant ~univs paramimpls params data =
   Classes.set_typeclass_transparency ~locality:Hints.SuperGlobal
     [Tacred.EvalConstRef cst] false;
   let () =
-    let csb = Global.lookup_constant cst in
-    let poly = Declareops.constant_is_polymorphic csb in
-    declare_proj_coercion_instance ~flags:proj_flags (GlobRef.ConstRef proj_cst) cref ~poly ~with_coercion:false in
+    declare_proj_coercion_instance ~flags:proj_flags (GlobRef.ConstRef proj_cst) cref ~with_coercion:false in
   let m = {
     meth_name = Name proj_name;
     meth_info = None;

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -640,7 +640,7 @@ let start_lemma_com ~typing_flags ~program_mode ~poly ~scope ?clearbody ~kind ~d
 
 let vernac_definition_hook ~canonical_instance ~local ~poly ~reversible = let open Decls in function
 | Coercion ->
-  Some (ComCoercion.add_coercion_hook ~poly ~reversible)
+  Some (ComCoercion.add_coercion_hook ~reversible)
 | CanonicalStructure ->
   Some (Declare.Hook.(make (fun { S.dref } -> Canonical.declare_canonical_structure ?local dref)))
 | SubClass ->
@@ -1420,13 +1420,13 @@ let vernac_coercion ~atts ref qidst =
   let ref' = smart_global ref in
   match qidst with
   | Some (qids, qidt) ->
-     let (local, poly), reversible =
-       Attributes.parse Notations.(locality ++ polymorphic ++ reversible) atts in
+     let local, reversible =
+       Attributes.parse Notations.(locality ++ reversible) atts in
      let local = enforce_locality local in
      let reversible = Option.default false reversible in
      let target = cl_of_qualid qidt in
      let source = cl_of_qualid qids in
-     ComCoercion.try_add_new_coercion_with_target ref' ~local ~poly ~reversible
+     ComCoercion.try_add_new_coercion_with_target ref' ~local ~reversible
        ~source ~target;
      Flags.if_verbose Feedback.msg_info (pr_global ref' ++ str " is now a coercion")
   | None ->


### PR DESCRIPTION
The flag was actually irrelevant since 2014 (only identity coercions declare a new constant).

Let's see how many often `Polymorphic Coercion f : c >-> c'` is used with `Polymorphic` being effectless.

Synchronous overlays:
- LPCIC/coq-elpi#533
- Mtac2/Mtac2#395