### PR TITLE
Removing special declaration of instances with `Context` outside sections in `Module Type`

### DIFF
--- a/doc/changelog/02-specification-language/18254-master+def-in-context-instance-in-modtype.rst
+++ b/doc/changelog/02-specification-language/18254-master+def-in-context-instance-in-modtype.rst
@@ -1,0 +1,8 @@
+- **Changed:**
+  Declarations of the form :g:`(id := body)` in :cmd:`Context` outside a
+  section in a :cmd:`Module Type` do not any more try to declare a class
+  instance. Assumptions whose type is a class and declared using
+  :cmd:`Context` outside a section in a :cmd:`Module Type` are now
+  declared as global, instead of local
+  (`#18254 <https://github.com/coq/coq/pull/18254>`_,
+  by Hugo Herbelin).

--- a/test-suite/success/Assumptions.v
+++ b/test-suite/success/Assumptions.v
@@ -1,0 +1,13 @@
+(* Test about assumptions *)
+
+(* Test instances *)
+
+Module Instances.
+
+Class C' := { f' : unit }.
+Class D := { g : unit }.
+
+Module Type T. Context (c':={|f':=tt|}). Fail Definition a'' := _ : C'. End T. (* Not instance *)
+Module Type U. Definition d':={|g:=tt|}. Fail Definition b'' := _ : D. End U.  (* Not instance *)
+
+End Instances.

--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -225,10 +225,8 @@ let context_nosection sigma ~poly ctx =
     let cst = Declare.declare_constant ~name ~kind ~local decl in
     let () = Declare.assumption_message name in
     let env = Global.env () in
-    (* why local when is_modtype? *)
-    let locality = if Lib.is_modtype () then Hints.Local else Hints.SuperGlobal in
-    let () = if Lib.is_modtype() || Option.is_empty b then
-        Classes.declare_instance env sigma None locality (GlobRef.ConstRef cst)
+    let () = if Option.is_empty b then
+        Classes.declare_instance env sigma None Hints.SuperGlobal (GlobRef.ConstRef cst)
     in
     Constr.mkConstU (cst,instance_of_univ_entry univ_entry) :: subst
   in


### PR DESCRIPTION
So as to hopefully simplify the implementation, the PR experiments removing the special treatment of instances with `Context` outside sections in `Module Type`.
    
This means:
- Context outside section does not declare defined _instances_ anymore in Module Type.
- Context outside section does not declare axiomatic _instances_ anymore with a local flag in Module Type.
    
Note: Declarations themselves made by Context outside sections in `Module Type` remain exceptionally "Global" while they are "Local" otherwise (not visible w/o qualifications). See #10888. It seems difficult to change this behavior in one way or the other.

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
