### PR TITLE
Scheme Equality: ensure universe polymorphism constraints of statements are collected

### DIFF
--- a/test-suite/success/SchemeEquality.v
+++ b/test-suite/success/SchemeEquality.v
@@ -32,6 +32,9 @@ End C.
 (* Universe polymorphism *)
 Module D.
   Set Universe Polymorphism.
+  Inductive unit := tt.
+  Scheme Equality for unit.
+
   Inductive prod (A B:Type) := pair : A -> B -> prod A B.
   Scheme Equality for prod.
 

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -1167,6 +1167,7 @@ let make_bl_scheme env handle mind =
   let bl_goal = compute_bl_goal env handle (ind,u) lnamesparrec nparrec in
   let bl_goal = EConstr.of_constr bl_goal in
   let poly = Declareops.inductive_is_polymorphic mib in
+  let uctx = if poly then Evd.evar_universe_context (fst (Typing.sort_of env (Evd.from_ctx uctx) bl_goal)) else uctx in
   let (ans, _, _, _, uctx) = Declare.build_by_tactic ~poly env ~uctx ~typ:bl_goal
     (compute_bl_tact handle (ind, EConstr.EInstance.make u) lnamesparrec nparrec)
   in
@@ -1297,6 +1298,7 @@ let make_lb_scheme env handle mind =
   let lb_goal = compute_lb_goal env handle (ind,u) lnamesparrec nparrec in
   let lb_goal = EConstr.of_constr lb_goal in
   let poly = Declareops.inductive_is_polymorphic mib in
+  let uctx = if poly then Evd.evar_universe_context (fst (Typing.sort_of env (Evd.from_ctx uctx) lb_goal)) else uctx in
   let (ans, _, _, _, ctx) = Declare.build_by_tactic ~poly env ~uctx ~typ:lb_goal
     (compute_lb_tact handle ind lnamesparrec nparrec)
   in
@@ -1480,10 +1482,11 @@ let make_eq_decidability env handle mind =
 
   let lnonparrec,lnamesparrec =
     Inductive.inductive_nonrec_rec_paramdecls (mib,u) in
+  let dec_goal = EConstr.of_constr (compute_dec_goal env (ind,u) lnamesparrec nparrec) in
   let poly = Declareops.inductive_is_polymorphic mib in
+  let uctx = if poly then Evd.evar_universe_context (fst (Typing.sort_of env (Evd.from_ctx uctx) dec_goal)) else uctx in
   let (ans, _, _, _, ctx) = Declare.build_by_tactic ~poly env ~uctx
-      ~typ:(EConstr.of_constr (compute_dec_goal env (ind,u) lnamesparrec nparrec))
-      (compute_dec_tact handle (ind,u) lnamesparrec nparrec)
+      ~typ:dec_goal (compute_dec_tact handle (ind,u) lnamesparrec nparrec)
   in
   ([|ans|], ctx)
 


### PR DESCRIPTION
The PR #15525 on compatibility of `Scheme Equality` with universe polymorphism was missing the case of constraints occurring only in the type, as in:

```coq
Set Universe Polymorphism.
Inductive unit := tt.
Scheme Equality for unit. (*Illegal application of eq to unit *)
```

We fix it by retyping the statements.

- [X] Added / updated **test-suite**.
- [ ] Added **changelog**.
