### PR TITLE
Detect linux better for the perf library.

### DIFF
--- a/perf/dune
+++ b/perf/dune
@@ -4,4 +4,11 @@
  (public_name coq-core.perf)
  (wrapped false)
  (foreign_stubs (language c) (names perf))
- (enabled_if (= %{system} linux)))
+ ; Just "linux" is not enough, see https://github.com/ocaml/dune/issues/4895.
+ (enabled_if
+  (or
+   (= %{system} "linux")
+   (= %{system} "linux_eabi")
+   (= %{system} "linux_eabihf")
+   (= %{system} "linux_elf")
+   (= %{system} "elf"))))


### PR DESCRIPTION
This fixes #18257 following the recommendations given in ocaml/dune#4895.

Starting with OCaml 5.2, testing "linux" will be enough thanks to ocaml/ocaml#12405.