### PR TITLE
Cache set of undefined impossible case evars in evar_flags

### DIFF
--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -497,12 +497,12 @@ let filter_effective_candidates evd evi filter candidates =
   let ids = set_of_evctx (Filter.filter_list filter (evar_context evi)) in
   List.filter (fun a -> Id.Set.subset (collect_vars evd a) ids) candidates
 
-let restrict_evar evd evk filter ?src candidates =
+let restrict_evar evd evk filter candidates =
   let evar_info = Evd.find_undefined evd evk in
   let candidates = Option.map (filter_effective_candidates evd evar_info filter) candidates in
   match candidates with
   | Some [] -> raise (ClearDependencyError (*FIXME*)(Id.of_string "blah", (NoCandidatesLeft evk), None))
-  | _ -> Evd.restrict evk filter ?candidates ?src evd
+  | _ -> Evd.restrict evk filter ?candidates evd
 
 let rec check_and_clear_in_constr ~is_section_variable env evdref err ids ~global c =
   (* returns a new constr where all the evars have been 'cleaned'

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -225,7 +225,7 @@ exception ClearDependencyError of Id.t * clear_dependency_error * GlobRef.t opti
     into an empty list. *)
 
 val restrict_evar : evar_map -> Evar.t -> Filter.t ->
-  ?src:Evar_kinds.t Loc.located -> constr list option -> evar_map * Evar.t
+  constr list option -> evar_map * Evar.t
 
 val clear_hyps_in_evi : env -> evar_map -> named_context_val -> types ->
   Id.Set.t -> evar_map * named_context_val * types

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1438,9 +1438,8 @@ let restrict evk filter ?candidates ?src evd =
   (evd, evk')
 
 let update_source evd evk src =
-  let evar_info = EvMap.find evk evd.undf_evars in
-  let evar_info' = { evar_info with evar_source = src } in
-  { evd with undf_evars = EvMap.add evk evar_info' evd.undf_evars }
+  let modify _ info = { info with evar_source = src } in
+  { evd with undf_evars = EvMap.modify evk modify evd.undf_evars }
 
 (**********************************************************)
 (* Accessing metas *)

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -359,6 +359,9 @@ val set_obligation_evar : evar_map -> Evar.t -> evar_map
 val is_obligation_evar : evar_map -> Evar.t -> bool
 (** Is the evar declared as an obligation *)
 
+val get_impossible_case_evars : evar_map -> Evar.Set.t
+(** Set of undefined evars with ImpossibleCase evar source. *)
+
 val downcast : Evar.t-> etypes -> evar_map -> evar_map
 (** Change the type of an undefined evar to a new type assumed to be a
     subtype of its current type; subtyping must be ensured by caller *)

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -1818,14 +1818,14 @@ let rec solve_unconstrained_evars_with_candidates flags env evd =
       solve_unconstrained_evars_with_candidates flags env evd
 
 let solve_unconstrained_impossible_cases env evd =
-  Evd.fold_undefined (fun evk ev_info evd' ->
-    match Evd.evar_source ev_info with
-    | loc,Evar_kinds.ImpossibleCase ->
+  Evar.Set.fold (fun evk evd' ->
       let evd', j = coq_unit_judge env evd' in
       let ty = j_type j in
       let flags = default_flags env in
       instantiate_evar evar_unify flags env evd' evk ty (* should we protect from raising IllTypedInstance? *)
-    | _ -> evd') evd evd
+    )
+    (Evd.get_impossible_case_evars evd)
+    evd
 
 let solve_unif_constraints_with_heuristics env
     ?(flags=default_flags env) ?(with_ho=false) evd =

--- a/test-suite/bugs/bug_18260_1.v
+++ b/test-suite/bugs/bug_18260_1.v
@@ -1,0 +1,106 @@
+Require Coq.Init.Byte Coq.Strings.Byte Coq.ZArith.ZArith.
+
+Axiom proof_admitted : False.
+Tactic Notation "admit" := abstract case proof_admitted.
+
+Import Byte.
+
+Module Export word.
+  Class word {width : BinInt.Z} := {
+      rep : Type;
+    }.
+  Arguments word : clear implicits.
+
+End word.
+Notation word := word.word.
+Global Coercion word.rep : word >-> Sortclass.
+
+
+
+Module map.
+  Class map {key value:Type} := mk {
+                                    rep : Type;
+                                  }.
+  Arguments map : clear implicits.
+  Global Coercion rep : map >-> Sortclass.
+
+End map.
+Local Notation map := map.map.
+Global Coercion map.rep : map >-> Sortclass.
+
+Definition SuchThat(R: Type)(P: R -> Prop) := R.
+Existing Class SuchThat.
+
+Notation "'annotate!' x T" := (match x return T with b => b end)
+                                (at level 10, x at level 0, T at level 0, only parsing).
+
+Notation "'infer!' P" :=
+  (match _ as ResType return ResType with
+   | ResType =>
+       match P with
+       | Fun => annotate! (annotate! _ (SuchThat ResType Fun)) ResType
+       end
+   end)
+    (at level 0, P at level 100, only parsing).
+
+Global Hint Extern 1 (SuchThat ?RRef ?FRef) =>
+         let R := eval cbv delta [RRef] in RRef in
+           let r := open_constr:(_ : R) in
+           let G := eval cbv beta delta [RRef FRef] in (FRef r) in
+             let t := open_constr:(ltac:(cbv beta; typeclasses eauto) : G) in
+             match r with
+             | ?y => exact y
+             end
+               : typeclass_instances.
+
+Class Multiplication{A B R: Type}(a: A)(b: B)(r: R) := {}.
+Notation "a * b" := (infer! Multiplication a b) (only parsing) : oo_scope.
+
+
+Import map.
+
+Section Sep.
+  Context  {map : Type}.
+  Definition sep (p q : map -> Prop) (m:map) : Prop. Admitted.
+
+End Sep.
+
+Import Coq.ZArith.ZArith.
+
+Section Scalars.
+  Context {width : Z} {word : word width}.
+
+  Context {mem : map.map word byte}.
+  Definition scalar : word -> word -> mem -> Prop. Admitted.
+
+End Scalars.
+
+#[export] Instance MulSepClause{K V: Type}{M: map.map K V}(a b: @map.rep K V M -> Prop)
+  : Multiplication a b (sep a b) | 10 := {}.
+
+
+Class PointsTo{width: Z}{word: word.word width}{mem: map.map word Byte.byte}{V: Type}
+  (addr: word)(val: V)(pred: mem -> Prop) := {}.
+Global Hint Mode PointsTo + + + + + + - : typeclass_instances.
+
+Class PointsToPredicate{width}{word: word.word width}{mem: Type}
+  (V: Type)(pred: word -> V -> mem -> Prop) := {}.
+
+#[export] Instance PointsToPredicate_to_PointsTo
+  {width}{word: word.word width}{mem: map.map word Byte.byte}{V: Type}
+  (pred: word -> V -> mem -> Prop){p: PointsToPredicate V pred}
+  (a: word)(v: V): PointsTo a v (pred a v) := {}.
+
+#[export] Instance PointsToScalarPredicate
+  {width}{word: word.word width}{mem: map.map word Byte.byte}:
+  PointsToPredicate word scalar := {}.
+
+Section TestNotations.
+  Context {width: Z} {word: word.word width} {mem: map.map word Byte.byte}.
+  Local Open Scope oo_scope.
+  Set Printing All.
+  Typeclasses eauto := debug.
+  Goal forall (a1 a2 ofs sz v1 v2: word) (R: mem -> Prop) (m: mem),
+      (infer! Multiplication R (infer! PointsTo a1 v1)) m.
+  Abort.
+End TestNotations.


### PR DESCRIPTION
This avoids a fold_undefined in evarconv, significantly improving perf
on the cases with ma,y undefined evars in
https://github.com/coq/coq/issues/8233#issuecomment-1792508252

0 defined evars + 20k undefined evars: 1.6s -> 0.11s

60k defined evars + 20k undefined evars: 4.1s -> 0.75s

Close #8233