### PR TITLE
test-suite/complexity/constructor: -native-compiler no

### DIFF
--- a/test-suite/complexity/constructor.v
+++ b/test-suite/complexity/constructor.v
@@ -1,3 +1,5 @@
+(* -*- coq-prog-args: ("-native-compiler" "no"); -*- *)
+
 (* Checks that constructor does not repeat the reduction of the conclusion *)
 (* Expected time < 3.00s *)
 


### PR DESCRIPTION
ocamlopt allocates gigabytes and takes a long time on this 1001 constructors inductive.
