### PR TITLE
[CI] Use a lighter target in fiat-crypto-ocaml

### DIFF
--- a/dev/ci/ci-fiat_crypto_ocaml.sh
+++ b/dev/ci/ci-fiat_crypto_ocaml.sh
@@ -17,5 +17,5 @@ ulimit -s 131072
 make_args=(EXTERNAL_REWRITER=1 EXTERNAL_COQPRIME=1 OCAMLFIND=ocamlfind)
 
 ( cd "${CI_BUILD_DIR}/fiat_crypto"
-  make "${make_args[@]}" -j 2 standalone-ocaml lite-generated-files
+  make "${make_args[@]}" -j 2 standalone-ocaml lite-c-files
 )

--- a/dev/ci/ci-fiat_crypto_ocaml.sh
+++ b/dev/ci/ci-fiat_crypto_ocaml.sh
@@ -17,5 +17,5 @@ ulimit -s 131072
 make_args=(EXTERNAL_REWRITER=1 EXTERNAL_COQPRIME=1 OCAMLFIND=ocamlfind)
 
 ( cd "${CI_BUILD_DIR}/fiat_crypto"
-  make "${make_args[@]}" -j 1 standalone-ocaml lite-generated-files
+  make "${make_args[@]}" -j 2 standalone-ocaml lite-generated-files
 )

--- a/dev/ci/ci-fiat_crypto_ocaml.sh
+++ b/dev/ci/ci-fiat_crypto_ocaml.sh
@@ -17,5 +17,6 @@ ulimit -s 131072
 make_args=(EXTERNAL_REWRITER=1 EXTERNAL_COQPRIME=1 OCAMLFIND=ocamlfind)
 
 ( cd "${CI_BUILD_DIR}/fiat_crypto"
-  make "${make_args[@]}" -j 2 standalone-ocaml lite-c-files
+  make "${make_args[@]}" -j 1 standalone-ocaml
+  make "${make_args[@]}" -j 2 lite-c-files
 )

--- a/dev/ci/ci-fiat_crypto_ocaml.sh
+++ b/dev/ci/ci-fiat_crypto_ocaml.sh
@@ -17,6 +17,5 @@ ulimit -s 131072
 make_args=(EXTERNAL_REWRITER=1 EXTERNAL_COQPRIME=1 OCAMLFIND=ocamlfind)
 
 ( cd "${CI_BUILD_DIR}/fiat_crypto"
-  make "${make_args[@]}" -j 1 standalone-ocaml
-  make "${make_args[@]}" -j 2 lite-c-files
+  make "${make_args[@]}" -j 1 lite-c-files
 )


### PR DESCRIPTION
The targets in fiat-crypto-ocaml should (hopefully) not be so memory heavy that they OOM with -j2.  If they do, we should split `standalone-ocaml` (probably more memory-heavy, invoking ocamlopt) from `lite-generated-files` (probably less memory heavy), and run the latter with `-j2`.

Hopefully this will fix the time-outs, though I'm rather confused how a job made up mostly of targets taking less than 20 seconds ends up exceeding an hour.

