### PR TITLE
Remove deprecated API from Inductiveops.

### DIFF
--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -128,17 +128,11 @@ let nconstructors env ind =
   let (_,mip) = Inductive.lookup_mind_specif env ind in
   Array.length mip.mind_consnames
 
-let nconstructors_env env ind = nconstructors env ind
-[@@ocaml.deprecated "Alias for Inductiveops.nconstructors"]
-
 (* Arity of constructors excluding parameters, excluding local defs *)
 
 let constructors_nrealargs env ind =
   let (_,mip) = Inductive.lookup_mind_specif env ind in
   mip.mind_consnrealargs
-
-let constructors_nrealargs_env env ind = constructors_nrealargs env ind
-[@@ocaml.deprecated "Alias for Inductiveops.constructors_nrealargs"]
 
 (* Arity of constructors excluding parameters, including local defs *)
 
@@ -146,17 +140,11 @@ let constructors_nrealdecls env ind =
   let (_,mip) = Inductive.lookup_mind_specif env ind in
   mip.mind_consnrealdecls
 
-let constructors_nrealdecls_env env ind = constructors_nrealdecls env ind
-[@@ocaml.deprecated "Alias for Inductiveops.constructors_nrealdecls"]
-
 (* Arity of constructors including parameters, excluding local defs *)
 
 let constructor_nallargs env (ind,j) =
   let (mib,mip) = Inductive.lookup_mind_specif env ind in
   mip.mind_consnrealargs.(j-1) + mib.mind_nparams
-
-let constructor_nallargs_env env (indsp,j) = constructor_nallargs env (indsp,j)
-[@@ocaml.deprecated "Alias for Inductiveops.constructor_nallargs"]
 
 (* Arity of constructors including params, including local defs *)
 
@@ -164,17 +152,11 @@ let constructor_nalldecls env (ind,j) = (* TOCHANGE en decls *)
   let (mib,mip) = Inductive.lookup_mind_specif env ind in
   mip.mind_consnrealdecls.(j-1) + Context.Rel.length (mib.mind_params_ctxt)
 
-let constructor_nalldecls_env env (indsp,j) = constructor_nalldecls env (indsp,j)
-[@@ocaml.deprecated "Alias for Inductiveops.constructor_nalldecls"]
-
 (* Arity of constructors excluding params, excluding local defs *)
 
 let constructor_nrealargs env (ind,j) =
   let (_,mip) = Inductive.lookup_mind_specif env ind in
   mip.mind_consnrealargs.(j-1)
-
-let constructor_nrealargs_env env (ind,j) = constructor_nrealargs env (ind,j)
-[@@ocaml.deprecated "Alias for Inductiveops.constructor_nrealargs"]
 
 (* Arity of constructors excluding params, including local defs *)
 
@@ -182,17 +164,11 @@ let constructor_nrealdecls env (ind,j) = (* TOCHANGE en decls *)
   let (_,mip) = Inductive.lookup_mind_specif env ind in
   mip.mind_consnrealdecls.(j-1)
 
-let constructor_nrealdecls_env env (ind,j) = constructor_nrealdecls env (ind,j)
-[@@ocaml.deprecated "Alias for Inductiveops.constructor_nrealdecls"]
-
 (* Length of arity, excluding params, excluding local defs *)
 
 let inductive_nrealargs env ind =
   let (_,mip) = Inductive.lookup_mind_specif env ind in
   mip.mind_nrealargs
-
-let inductive_nrealargs_env env ind = inductive_nrealargs env ind
-[@@ocaml.deprecated "Alias for Inductiveops.inductive_nrealargs"]
 
 (* Length of arity, excluding params, including local defs *)
 
@@ -200,17 +176,11 @@ let inductive_nrealdecls env ind =
   let (_,mip) = Inductive.lookup_mind_specif env ind in
   mip.mind_nrealdecls
 
-let inductive_nrealdecls_env env ind = inductive_nrealdecls env ind
-[@@ocaml.deprecated "Alias for Inductiveops.inductive_nrealdecls"]
-
 (* Full length of arity (w/o local defs) *)
 
 let inductive_nallargs env ind =
   let (mib,mip) = Inductive.lookup_mind_specif env ind in
   mib.mind_nparams + mip.mind_nrealargs
-
-let inductive_nallargs_env env ind = inductive_nallargs env ind
-[@@ocaml.deprecated "Alias for Inductiveops.inductive_nallargs"]
 
 (* Length of arity (w/o local defs) *)
 
@@ -218,17 +188,11 @@ let inductive_nparams env ind =
   let (mib,mip) = Inductive.lookup_mind_specif env ind in
   mib.mind_nparams
 
-let inductive_nparams_env env ind = inductive_nparams env ind
-[@@ocaml.deprecated "Alias for Inductiveops.inductive_nparams"]
-
 (* Length of arity (with local defs) *)
 
 let inductive_nparamdecls env ind =
   let (mib,mip) = Inductive.lookup_mind_specif env ind in
   Context.Rel.length mib.mind_params_ctxt
-
-let inductive_nparamdecls_env env ind = inductive_nparamdecls env ind
-[@@ocaml.deprecated "Alias for Inductiveops.inductive_nparamsdecls"]
 
 (* Full length of arity (with local defs) *)
 
@@ -236,24 +200,15 @@ let inductive_nalldecls env ind =
   let (mib,mip) = Inductive.lookup_mind_specif env ind in
   Context.Rel.length (mib.mind_params_ctxt) + mip.mind_nrealdecls
 
-let inductive_nalldecls_env env ind = inductive_nalldecls env ind
-[@@ocaml.deprecated "Alias for Inductiveops.inductive_nalldecls"]
-
 (* Others *)
 
 let inductive_paramdecls env (ind,u) =
   let (mib,mip) = Inductive.lookup_mind_specif env ind in
     Inductive.inductive_paramdecls (mib,u)
 
-let inductive_paramdecls_env env (ind,u) = inductive_paramdecls env (ind,u)
-[@@ocaml.deprecated "Alias for Inductiveops.inductive_paramsdecls"]
-
 let inductive_alldecls env (ind,u) =
   let (mib,mip) = Inductive.lookup_mind_specif env ind in
     Vars.subst_instance_context u mip.mind_arity_ctxt
-
-let inductive_alldecls_env env (ind,u) = inductive_alldecls env (ind,u)
-[@@ocaml.deprecated "Alias for Inductiveops.inductive_alldecls"]
 
 let inductive_alltags env ind =
   let (mib,mip) = Inductive.lookup_mind_specif env ind in

--- a/pretyping/inductiveops.mli
+++ b/pretyping/inductiveops.mli
@@ -68,80 +68,50 @@ val mis_nf_constructor_type :
 
 (** @return number of constructors *)
 val nconstructors : env -> inductive -> int
-val nconstructors_env : env -> inductive -> int
-[@@ocaml.deprecated "Alias for Inductiveops.nconstructors"]
 
 (** @return arity of constructors excluding parameters, excluding local defs *)
 val constructors_nrealargs : env -> inductive -> int array
-val constructors_nrealargs_env : env -> inductive -> int array
-[@@ocaml.deprecated "Alias for Inductiveops.constructors_nrealargs"]
 
 (** @return arity of constructors excluding parameters, including local defs *)
 val constructors_nrealdecls : env -> inductive -> int array
-val constructors_nrealdecls_env : env -> inductive -> int array
-[@@ocaml.deprecated "Alias for Inductiveops.constructors_nrealdecls"]
 
 (** @return the arity, excluding params, excluding local defs *)
 val inductive_nrealargs : env -> inductive -> int
-val inductive_nrealargs_env : env -> inductive -> int
-[@@ocaml.deprecated "Alias for Inductiveops.inductive_nrealargs"]
 
 (** @return the arity, excluding params, including local defs *)
 val inductive_nrealdecls : env -> inductive -> int
-val inductive_nrealdecls_env : env -> inductive -> int
-[@@ocaml.deprecated "Alias for Inductiveops.inductive_nrealdecls"]
 
 (** @return the arity, including params, excluding local defs *)
 val inductive_nallargs : env -> inductive -> int
-val inductive_nallargs_env : env -> inductive -> int
-[@@ocaml.deprecated "Alias for Inductiveops.inductive_nallargs"]
 
 (** @return the arity, including params, including local defs *)
 val inductive_nalldecls : env -> inductive -> int
-val inductive_nalldecls_env : env -> inductive -> int
-[@@ocaml.deprecated "Alias for Inductiveops.inductive_nalldecls"]
 
 (** @return nb of params without local defs *)
 val inductive_nparams : env -> inductive -> int
-val inductive_nparams_env : env -> inductive -> int
-[@@ocaml.deprecated "Alias for Inductiveops.inductive_nparams"]
 
 (** @return nb of params with local defs *)
 val inductive_nparamdecls : env -> inductive -> int
-val inductive_nparamdecls_env : env -> inductive -> int
-[@@ocaml.deprecated "Alias for Inductiveops.inductive_nparamsdecls"]
 
 (** @return params context *)
 val inductive_paramdecls : env -> pinductive -> Constr.rel_context
-val inductive_paramdecls_env : env -> pinductive -> Constr.rel_context
-[@@ocaml.deprecated "Alias for Inductiveops.inductive_paramsdecl"]
 
 (** @return full arity context, hence with letin *)
 val inductive_alldecls : env -> pinductive -> Constr.rel_context
-val inductive_alldecls_env : env -> pinductive -> Constr.rel_context
-[@@ocaml.deprecated "Alias for Inductiveops.inductive_alldecls"]
 
 (** {7 Extract information from a constructor name} *)
 
 (** @return param + args without letin *)
 val constructor_nallargs : env -> constructor -> int
-val constructor_nallargs_env : env -> constructor -> int
-[@@ocaml.deprecated "Alias for Inductiveops.constructor_nallargs"]
 
 (** @return param + args with letin *)
 val constructor_nalldecls : env -> constructor -> int
-val constructor_nalldecls_env : env -> constructor -> int
-[@@ocaml.deprecated "Alias for Inductiveops.constructor_nalldecls"]
 
 (** @return args without letin *)
 val constructor_nrealargs : env -> constructor -> int
-val constructor_nrealargs_env : env -> constructor -> int
-[@@ocaml.deprecated "Alias for Inductiveops.constructor_nrealargs"]
 
 (** @return args with letin *)
 val constructor_nrealdecls : env -> constructor -> int
-val constructor_nrealdecls_env : env -> constructor -> int
-[@@ocaml.deprecated "Alias for Inductiveops.constructor_nrealdecls"]
 
 (** @return tags of all decls: true = assumption, false = letin *)
 val inductive_alltags : env -> inductive -> bool list


### PR DESCRIPTION
This was deprecated since Coq 8.11.