### PR TITLE
Remove codeowners entry for test-suite/complexity

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -272,8 +272,6 @@
 /test-suite/report.sh       @coq/test-suite-maintainers
 /test-suite/unit-tests/src/ @coq/test-suite-maintainers
 
-/test-suite/complexity/ @herbelin
-
 /test-suite/success/Compat*.v @coq/compat-maintainers
 
 ########## Developer tools ##########


### PR DESCRIPTION
There doesn't seem to be a reason to treat it differently from other tests.

