### PR TITLE
Remove the hack relying on evar sources for glob constr pretyping in funind.

### DIFF
--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -1318,7 +1318,7 @@ let do_build_inductive evd (funconstants : pconstant list)
           Typing.type_of env evd
             (EConstr.of_constr (mkConstU (Array.of_list funconstants).(i)))
         in
-        resolve_and_replace_implicits ~expected_type:(Pretyping.OfType t) env
+        resolve_and_replace_implicits t env
           evd rt)
       rta
   in

--- a/plugins/funind/glob_termops.mli
+++ b/plugins/funind/glob_termops.mli
@@ -100,8 +100,7 @@ val expand_as : glob_constr -> glob_constr
 (* [resolve_and_replace_implicits ?expected_type env sigma rt] solves implicits of [rt] w.r.t. [env] and [sigma] and then replace them by their solution
  *)
 val resolve_and_replace_implicits :
-     ?flags:Pretyping.inference_flags
-  -> ?expected_type:Pretyping.typing_constraint
+     EConstr.types
   -> Environ.env
   -> Evd.evar_map
   -> glob_constr


### PR DESCRIPTION
This is still a revolting hack, but it is slightly more principled insofar as it plugs right into the pretyper to register the evar associated to a syntactic hole. This is precisely why the open recursion was introduced, so at least it gives a reason to its existence.