### PR TITLE
Do not use the legacy pattern_of_constr for variables from typed patterns

### DIFF
--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -717,7 +717,7 @@ let interp_closed_typed_pattern_with_occurrences ist env sigma (occs, a) =
       try Inl (coerce_to_evaluable_ref env sigma x)
       with CannotCoerceTo _ ->
         let c = coerce_to_closed_constr env x in
-        Inr (legacy_bad_pattern_of_constr env sigma c) in
+        Inr (pattern_of_constr env sigma c) in
     (try try_interp_ltac_var coerce_eval_ref_or_constr ist (Some (env,sigma)) (CAst.make ?loc id)
      with Not_found as exn ->
        let _, info = Exninfo.capture exn in


### PR DESCRIPTION
This call comes from the expansion of variables bound to a term in reduction tactics, e.g. writing something along the lines of `let x := ... in simpl x`.

I think that replacing the broken variant with the regular one should not matter, since there is virtually no way to exploit pattern variables in the term being bound. Most of the time this would result in an error at constr interpretation time. This is not tested anyway in the test-suite, let us try with the CI.