### PR TITLE
Simplifying the internals of the "hnf" tactic

### DIFF
--- a/dev/ci/user-overlays/18279-ppedrot-tacred-factor-red-product.sh
+++ b/dev/ci/user-overlays/18279-ppedrot-tacred-factor-red-product.sh
@@ -1,0 +1,1 @@
+overlay coqhammer https://github.com/ppedrot/coqhammer tacred-factor-red-product 18279

--- a/plugins/ltac/coretactics.mlg
+++ b/plugins/ltac/coretactics.mlg
@@ -308,7 +308,7 @@ let initial_atomic () =
     Tacenv.register_ltac false false (Names.Id.of_string s) body
   in
   let () = List.iter iter
-      [ "red", TacReduce(Red false,nocl);
+      [ "red", TacReduce (Red, nocl);
         "hnf", TacReduce(Hnf,nocl);
         "simpl", TacReduce(Simpl (Redops.all_flags,None),nocl);
         "compute", TacReduce(Cbv Redops.all_flags,nocl);

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -365,7 +365,7 @@ GRAMMAR EXTEND Gram
     ] ]
   ;
   red_expr:
-    [ [ IDENT "red" -> { Red false }
+    [ [ IDENT "red" -> { Red }
       | IDENT "hnf" -> { Hnf }
       | IDENT "simpl"; h = OPT [ IDENT "head" -> { () } ];
         d = delta_flag; po = OPT ref_or_pattern_occ -> { Simpl (all_with ~head:(Option.has_some h) d,po) }
@@ -678,7 +678,7 @@ GRAMMAR EXTEND Gram
 
       (* Conversion *)
       | IDENT "red"; cl = clause_dft_concl ->
-          { CAst.make ~loc @@ TacAtom (TacReduce (Red false, cl)) }
+          { CAst.make ~loc @@ TacAtom (TacReduce (Red, cl)) }
       | IDENT "hnf"; cl = clause_dft_concl ->
           { CAst.make ~loc @@ TacAtom (TacReduce (Hnf, cl)) }
       | IDENT "simpl"; h = OPT [ IDENT "head" -> { () } ]; d = delta_flag;

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -433,7 +433,7 @@ let intern_red_expr ist = function
            Option.map (intern_typed_pattern_or_ref_with_occurrences ist) o)
   | CbvVm o -> CbvVm (Option.map (intern_typed_pattern_or_ref_with_occurrences ist) o)
   | CbvNative o -> CbvNative (Option.map (intern_typed_pattern_or_ref_with_occurrences ist) o)
-  | (Red _ | Hnf | ExtraRedExpr _ as r ) -> r
+  | (Red | Hnf | ExtraRedExpr _ as r ) -> r
 
 let intern_hyp_list ist = List.map (intern_hyp ist)
 

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -757,7 +757,7 @@ let interp_red_expr ist env sigma = function
     sigma , CbvVm (Option.map (interp_closed_typed_pattern_with_occurrences ist env sigma) o)
   | CbvNative o ->
     sigma , CbvNative (Option.map (interp_closed_typed_pattern_with_occurrences ist env sigma) o)
-  | (Red _ |  Hnf | ExtraRedExpr _ as r) -> sigma , r
+  | (Red |  Hnf | ExtraRedExpr _ as r) -> sigma , r
 
 let interp_may_eval f ist env sigma = function
   | ConstrEval (r,c) ->

--- a/plugins/ltac2/tac2stdlib.ml
+++ b/plugins/ltac2/tac2stdlib.ml
@@ -299,7 +299,7 @@ let () =
     (Tac2tactics.induction_destruct true)
 
 let () =
-  define "tac_red" (clause @-> tac unit) (Tac2tactics.reduce (Red false))
+  define "tac_red" (clause @-> tac unit) (Tac2tactics.reduce Red)
 
 let () =
   define "tac_hnf" (clause @-> tac unit) (Tac2tactics.reduce Hnf)

--- a/plugins/ltac2/tac2tactics.ml
+++ b/plugins/ltac2/tac2tactics.ml
@@ -286,7 +286,7 @@ let eval_fun red c =
   end
 
 let eval_red c =
-  eval_fun (Red false) c
+  eval_fun Red c
 
 let eval_hnf c =
   eval_fun Hnf c

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -353,7 +353,7 @@ let is_id_constr sigma c = match EConstr.kind sigma c with
 
 let red_product_skip_id env sigma c = match EConstr.kind sigma c with
   | App(hd,args) when Array.length args = 1 && is_id_constr sigma hd -> args.(0)
-  | _ -> try Tacred.red_product env sigma c with e when CErrors.noncritical e -> c
+  | _ -> match Tacred.red_product env sigma c with Some c -> c | None -> c
 
 let ssrevaltac ist gtac = Tacinterp.tactic_of_value ist gtac
 

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -908,8 +908,8 @@ let try_red_product env sigma c =
   in redrec env c
 
 let red_product env sigma c = match try_red_product env sigma c with
-| Reduced c -> c
-| NotReducible -> user_err Pp.(str "No head constant to reduce.")
+| Reduced c -> Some c
+| NotReducible -> None
 
 (*
 (* This old version of hnf uses betadeltaiota instead of itself (resp
@@ -1158,7 +1158,10 @@ let unfoldn loccname env sigma c =
 
 (* Re-folding constants tactics: refold com in term c *)
 let fold_one_com com env sigma c =
-  let rcom = red_product env sigma com in
+  let rcom = match red_product env sigma com with
+  | None -> user_err Pp.(str "No head constant to reduce.")
+  | Some c -> c
+  in
   (* Reason first on the beta-iota-zeta normal form of the constant as
      unfold produces it, so that the "unfold f; fold f" configuration works
      to refold fix expressions *)
@@ -1360,9 +1363,3 @@ let reduce_to_ref_gen allow_failure allow_product env sigma ref t =
 
 let reduce_to_quantified_ref ?(allow_failure=false) = reduce_to_ref_gen allow_failure true
 let reduce_to_atomic_ref ?(allow_failure=false) = reduce_to_ref_gen allow_failure false
-
-exception Redelimination
-
-let try_red_product env sigma c = match try_red_product env sigma c with
-| Reduced c -> c
-| NotReducible -> raise Redelimination

--- a/pretyping/tacred.mli
+++ b/pretyping/tacred.mli
@@ -52,13 +52,8 @@ val evaluable_of_global_reference :
 val global_of_evaluable_reference :
   evaluable_global_reference -> GlobRef.t
 
-exception Redelimination
-
-(** Red (raise user error if nothing reducible) *)
-val red_product : reduction_function
-
-(** Red (raise Redelimination if nothing reducible) *)
-val try_red_product : reduction_function
+(** Red (returns None if nothing reducible) *)
+val red_product : env -> evar_map -> constr -> constr option
 
 (** Simpl *)
 val simpl : reduction_function

--- a/tactics/genredexpr.mli
+++ b/tactics/genredexpr.mli
@@ -41,7 +41,7 @@ type 'a glob_red_flag = {
 (** Generic kinds of reductions *)
 
 type ('a, 'b, 'c, 'flags) red_expr_gen0 =
-  | Red of bool
+  | Red
   | Hnf
   | Simpl of 'flags * ('b, 'c) Util.union Locus.with_occurrences option
   | Cbv of 'flags

--- a/tactics/induction.ml
+++ b/tactics/induction.ml
@@ -1297,8 +1297,10 @@ let use_bindings env sigma elim must_be_closed (c,lbind) typ =
       let sigma, typ = pose_all_metas_as_evars env sigma (clenv_type indclause) in
       sigma, term, typ
     with e when noncritical e ->
-    try find_clause (try_red_product env sigma typ)
-    with Redelimination -> raise e in
+    match red_product env sigma typ with
+    | None -> raise e
+    | Some typ -> find_clause typ
+  in
   find_clause typ
 
 let check_expected_type env sigma (elimc,bl) elimt =

--- a/tactics/ppred.ml
+++ b/tactics/ppred.ml
@@ -49,7 +49,7 @@ let pr_union pr1 pr2 = function
   | Inr b -> pr2 b
 
 let pr_red_expr (pr_constr,pr_lconstr,pr_ref,pr_pattern) keyword = function
-  | Red false -> keyword "red"
+  | Red -> keyword "red"
   | Hnf -> keyword "hnf"
   | Simpl (f,o) -> keyword "simpl" ++ (pr_short_red_flag pr_ref f)
                     ++ pr_opt (pr_with_occurrences (pr_union pr_ref pr_pattern) keyword) o
@@ -71,8 +71,6 @@ let pr_red_expr (pr_constr,pr_lconstr,pr_ref,pr_pattern) keyword = function
     hov 1 (keyword "pattern" ++
               pr_arg (prlist_with_sep pr_comma (pr_with_occurrences pr_constr keyword)) l)
 
-  | Red true ->
-    CErrors.user_err Pp.(str "Shouldn't be accessible from user.")
   | ExtraRedExpr s ->
     str s
   | CbvVm o ->

--- a/tactics/redexpr.ml
+++ b/tactics/redexpr.ml
@@ -237,12 +237,10 @@ let rec eval_red_expr env = function
   | e -> eval_red_expr env e
   | exception Not_found -> ExtraRedExpr s (* delay to runtime interpretation *)
   end
-| (Red _ | Hnf | Unfold _ | Fold _ | Pattern _ | CbvVm _ | CbvNative _) as e -> e
+| (Red | Hnf | Unfold _ | Fold _ | Pattern _ | CbvVm _ | CbvNative _) as e -> e
 
 let reduction_of_red_expr_val = function
-  | Red internal ->
-      if internal then (e_red try_red_product,DEFAULTcast)
-      else (e_red red_product,DEFAULTcast)
+  | Red -> (e_red red_product, DEFAULTcast)
   | Hnf -> (e_red hnf_constr,DEFAULTcast)
   | Simpl ((w,f),o) ->
     let am = match w, simplIsCbn () with
@@ -332,7 +330,7 @@ let bind_red_expr_occurrences occs nbcl redexp =
           error_illegal_clause ()
         else
           CbvNative (Some (occs,c))
-    | Red _ | Hnf | Cbv _ | Lazy _ | Cbn _
+    | Red | Hnf | Cbv _ | Lazy _ | Cbn _
     | ExtraRedExpr _ | Fold _ | Simpl (_,None) | CbvVm None | CbvNative None ->
         error_at_in_occurrences_not_supported ()
     | Unfold [] | Pattern [] ->

--- a/tactics/redexpr.ml
+++ b/tactics/redexpr.ml
@@ -239,8 +239,12 @@ let rec eval_red_expr env = function
   end
 | (Red | Hnf | Unfold _ | Fold _ | Pattern _ | CbvVm _ | CbvNative _) as e -> e
 
+let red_product_exn env sigma c = match red_product env sigma c with
+  | None -> user_err Pp.(str "No head constant to reduce.")
+  | Some c -> c
+
 let reduction_of_red_expr_val = function
-  | Red -> (e_red red_product, DEFAULTcast)
+  | Red -> (e_red red_product_exn, DEFAULTcast)
   | Hnf -> (e_red hnf_constr,DEFAULTcast)
   | Simpl ((w,f),o) ->
     let am = match w, simplIsCbn () with

--- a/tactics/redops.ml
+++ b/tactics/redops.ml
@@ -66,4 +66,4 @@ let map_red_expr_gen f g h = function
   | CbvVm occs_o -> CbvVm (Option.map (map_occs (Util.map_union g h)) occs_o)
   | CbvNative occs_o -> CbvNative (Option.map (map_occs (Util.map_union g h)) occs_o)
   | Cbn flags -> Cbn (map_flags g flags)
-  | ExtraRedExpr _ | Red _ | Hnf as x -> x
+  | ExtraRedExpr _ | Red | Hnf as x -> x

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -1413,10 +1413,9 @@ module Strategies =
       fun { state ; env ; term1 = t ; ty1 = ty ; cstr ; evars } ->
 (*         let sigma, (c,_) = Tacinterp.interp_open_constr_with_bindings is env (goalevars evars) c in *)
         let sigma, c = Pretyping.understand_tcc env (goalevars evars) c in
-        let unfolded =
-          try Tacred.try_red_product env sigma c
-          with e when CErrors.noncritical e ->
-            user_err Pp.(str "fold: the term is not unfoldable!")
+        let unfolded = match Tacred.red_product env sigma c with
+        | None -> user_err Pp.(str "fold: the term is not unfoldable!")
+        | Some c -> c
         in
           try
             let sigma = Unification.w_unify env sigma CONV ~flags:(Unification.elim_flags ()) unfolded t in

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1001,7 +1001,7 @@ let reduce redexp cl =
     if is_local_flag env flags then LocalHypConv else StableHypConv
   | Unfold flags ->
     if is_local_unfold env flags then LocalHypConv else StableHypConv
-  | Red _ | Hnf | CbvVm _ | CbvNative _ -> StableHypConv
+  | Red | Hnf | CbvVm _ | CbvNative _ -> StableHypConv
   | ExtraRedExpr _ -> StableHypConv (* Should we be that lenient ?*)
   in
   let redexp = Redexpr.eval_red_expr env redexp in
@@ -1270,8 +1270,7 @@ let lookup_hypothesis_as_renamed_gen red h gl =
   let rec aux ccl =
     match lookup_hypothesis_as_renamed env (Tacmach.project gl) ccl h with
       | None when red ->
-        let (redfun, _) = Redexpr.reduction_of_red_expr env (Red true) in
-        let (_, c) = redfun env (Proofview.Goal.sigma gl) ccl in
+        let c = Tacred.try_red_product env (Proofview.Goal.sigma gl) ccl in
         aux c
       | x -> x
   in


### PR DESCRIPTION
We stop exposing an internal variant in the redexpr AST and an exception-raising API mostly used functionally.

Overlays:
- https://github.com/lukaszcz/coqhammer/pull/169