### PR TITLE
Move relevance outside of case_info

### DIFF
--- a/checker/values.ml
+++ b/checker/values.ml
@@ -128,7 +128,7 @@ let v_boollist = List v_bool
 let v_caseinfo =
   let v_cstyle = v_enum "case_style" 5 in
   let v_cprint = v_tuple "case_printing" [|v_boollist;Array v_boollist;v_cstyle|] in
-  v_tuple "case_info" [|v_ind;Int;Array Int;Array Int;v_relevance;v_cprint|]
+  v_tuple "case_info" [|v_ind;Int;Array Int;Array Int;v_cprint|]
 
 let v_cast = v_enum "cast_kind" 3
 
@@ -170,7 +170,7 @@ and v_case_invert = Sum ("case_inversion", 1, [|[|Array v_constr|]|])
 
 and v_case_branch = Tuple ("case_branch", [|Array (v_binder_annot v_name); v_constr|])
 
-and v_case_return = Tuple ("case_return", [|Array (v_binder_annot v_name); v_constr|])
+and v_case_return = Tuple ("case_return", [|Tuple ("case_return'", [|Array (v_binder_annot v_name); v_constr|]); v_relevance|])
 
 let v_rdecl = v_sum "rel_declaration" 0
     [| [|v_binder_annot v_name; v_constr|];               (* LocalAssum *)

--- a/dev/ci/user-overlays/18280-SkySkimmer-ci-relevance.sh
+++ b/dev/ci/user-overlays/18280-SkySkimmer-ci-relevance.sh
@@ -1,0 +1,23 @@
+overlay rewriter https://github.com/SkySkimmer/rewriter ci-relevance 18280
+
+overlay coqhammer https://github.com/SkySkimmer/coqhammer ci-relevance 18280
+
+overlay elpi https://github.com/SkySkimmer/coq-elpi ci-relevance 18280
+
+overlay equations https://github.com/SkySkimmer/Coq-Equations ci-relevance 18280
+
+overlay metacoq https://github.com/SkySkimmer/metacoq ci-relevance 18280
+
+overlay unicoq https://github.com/SkySkimmer/unicoq ci-relevance 18280
+
+overlay mtac2 https://github.com/SkySkimmer/Mtac2 ci-relevance 18280
+
+overlay paramcoq https://github.com/SkySkimmer/paramcoq ci-relevance 18280
+
+overlay serapi https://github.com/SkySkimmer/coq-serapi ci-relevance 18280
+
+overlay tactician https://github.com/SkySkimmer/coq-tactician ci-relevance 18280
+
+overlay waterproof https://github.com/SkySkimmer/coq-waterproof ci-relevance 18280
+
+overlay fiat_crypto https://github.com/SkySkimmer/fiat-crypto ci-relevance 18280

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -348,7 +348,7 @@ let constr_display csr =
       "MutConstruct(("^(MutInd.to_string sp)^","^(string_of_int i)^"),"
       ^","^(universes_display u)^(string_of_int j)^")"
   | Proj (p, r, c) -> "Proj("^(Constant.to_string (Projection.constant p))^","^term_display c ^")"
-  | Case (ci,u,pms,(_,p),iv,c,bl) ->
+  | Case (ci,u,pms,((_,p),_),iv,c,bl) ->
       "MutCase(<abs>,"^(term_display p)^","^(term_display c)^","
       ^(array_display (Array.map snd bl))^")"
   | Fix ((t,i),(lna,tl,bl)) ->
@@ -473,7 +473,7 @@ let print_pure_constr csr =
       print_int i; print_string ","; print_int j;
       print_string ","; universes_display u;
       print_string ")"
-  | Case (ci,u,pms,p,iv,c,bl) ->
+  | Case (ci,u,pms,(p,_),iv,c,bl) ->
       let pr_ctx (nas, c) =
         Array.iter (fun na -> print_cut (); name_display na) nas;
         print_string " |- ";

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -428,10 +428,10 @@ val is_global : Environ.env -> Evd.evar_map -> GlobRef.t -> t -> bool
 [@@ocaml.deprecated "Use [EConstr.isRefX] instead."]
 
 val expand_case : Environ.env -> Evd.evar_map ->
-  case -> (case_info * t * case_invert * t * t array)
+  case -> (t,t) Inductive.pexpanded_case
 
 val annotate_case : Environ.env -> Evd.evar_map -> case ->
-  case_info * EInstance.t * t array * (rel_context * t) * case_invert * t * (rel_context * t) array
+  case_info * EInstance.t * t array * ((rel_context * t) * Sorts.relevance) * case_invert * t * (rel_context * t) array
 (** Same as above, but doesn't turn contexts into binders *)
 
 val expand_branch : Environ.env -> Evd.evar_map ->
@@ -440,7 +440,7 @@ val expand_branch : Environ.env -> Evd.evar_map ->
     constructs the typed context in which the branch lives. *)
 
 val contract_case : Environ.env -> Evd.evar_map ->
-  (case_info * t * case_invert * t * t array) -> case
+  (t,t) Inductive.pexpanded_case -> case
 
 (** {5 Extra} *)
 

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -649,8 +649,8 @@ let map_constr_with_binders_left_to_right env sigma g f l c =
   | Evar ev ->
     let ev' = EConstr.map_existential sigma (fun c -> f l c) ev in
     if ev' == ev then c else mkEvar ev'
-  | Case (ci,u,pms,p,iv,b,bl) ->
-      let (ci, _, pms, p0, _, b, bl0) = annotate_case env sigma (ci, u, pms, p, iv, b, bl) in
+  | Case (ci,u,pms,(p,r),iv,b,bl) ->
+      let (ci, _, pms, (p0,_), _, b, bl0) = annotate_case env sigma (ci, u, pms, (p,r), iv, b, bl) in
       let f_ctx (nas, _ as r) (ctx, c) =
         let c' = f (List.fold_right g ctx l) c in
         if c' == c then r else (nas, c')
@@ -662,7 +662,7 @@ let map_constr_with_binders_left_to_right env sigma g f l c =
       let iv' = map_invert (f l) iv in
       let bl' = Array.map_left (fun (c, c0) -> f_ctx c c0) (Array.map2 (fun x y -> (x, y)) bl bl0) in
         if b' == b && pms' == pms && p' == p && iv' == iv && bl' == bl then c
-        else mkCase (ci, u, pms', p', iv', b', bl')
+        else mkCase (ci, u, pms', (p',r), iv', b', bl')
   | Fix (ln,(lna,tl,bl as fx)) ->
       let l' = fold_rec_types g fx l in
       let (tl', bl') = map_left2 (f l) tl (f l') bl in
@@ -715,8 +715,8 @@ let map_constr_with_full_binders env sigma g f l cstr =
   | Evar ev ->
     let ev' = EConstr.map_existential sigma (fun c -> f l c) ev in
     if ev' == ev then cstr else mkEvar ev'
-  | Case (ci, u, pms, p, iv, c, bl) ->
-      let (ci, _, pms, p0, _, c, bl0) = annotate_case env sigma (ci, u, pms, p, iv, c, bl) in
+  | Case (ci, u, pms, (p,r), iv, c, bl) ->
+      let (ci, _, pms, (p0,_), _, c, bl0) = annotate_case env sigma (ci, u, pms, (p,r), iv, c, bl) in
       let f_ctx (nas, _ as r) (ctx, c) =
         let c' = f (List.fold_right g ctx l) c in
         if c' == c then r else (nas, c')
@@ -727,7 +727,7 @@ let map_constr_with_full_binders env sigma g f l cstr =
       let c' = f l c in
       let bl' = Array.map2 f_ctx bl bl0 in
       if pms==pms' && p==p' && iv'==iv && c==c' && Array.for_all2 (==) bl bl' then cstr else
-        mkCase (ci, u, pms', p', iv', c', bl')
+        mkCase (ci, u, pms', (p',r), iv', c', bl')
   | Fix (ln,(lna,tl,bl as fx)) ->
       let tl' = Array.map (f l) tl in
       let l' = fold_rec_types g fx l in
@@ -770,7 +770,7 @@ let fold_constr_with_full_binders env sigma g f n acc c =
     let args = Evd.expand_existential sigma ev in
     List.fold_left (fun c -> f n c) acc args
   | Case (ci, u, pms, p, iv, c, bl) ->
-    let (ci, _, pms, p, _, c, bl) = EConstr.annotate_case env sigma (ci, u, pms, p, iv, c, bl) in
+    let (ci, _, pms, (p,_), _, c, bl) = EConstr.annotate_case env sigma (ci, u, pms, p, iv, c, bl) in
     let f_ctx acc (ctx, c) = f (List.fold_right g ctx n) acc c in
     Array.fold_left f_ctx (f n (fold_invert (f n) (f_ctx (Array.fold_left (f n) acc pms) p) iv) c) bl
   | Fix (_,(lna,tl,bl)) ->

--- a/engine/univSubst.ml
+++ b/engine/univSubst.ml
@@ -190,19 +190,16 @@ let nf_evars_and_universes_opt_subst fevar fqual funiv c =
     | Sort s ->
       let s' = Sorts.subst_fn (fqual, subst_univs_universe funiv) s in
       if s' == s then c else mkSort s'
-    | Case (ci,u,pms,p,iv,t,br) ->
+    | Case (ci,u,pms,(p,rel),iv,t,br) ->
       let u' = Instance.subst_fn flevel u in
-      let ci' =
-        let rel' = frel ci.ci_relevance in
-        if rel' == ci.ci_relevance then ci else { ci with ci_relevance = rel' }
-      in
+      let rel' = frel rel in
       let pms' = Array.Smart.map aux pms in
       let p' = aux_ctx p in
       let iv' = map_invert aux iv in
       let t' = aux t in
       let br' = Array.Smart.map aux_ctx br in
-      if ci' == ci && u' == u && pms' == pms && p' == p && iv' == iv && t' == t && br' == br then c
-      else mkCase (ci', u', pms', p', iv', t', br')
+      if rel' == rel && u' == u && pms' == pms && p' == p && iv' == iv && t' == t && br' == br then c
+      else mkCase (ci, u', pms', (p',rel'), iv', t', br')
     | Array (u,elems,def,ty) ->
       let u' = Instance.subst_fn flevel u in
       let elems' = CArray.Smart.map aux elems in

--- a/kernel/constr.mli
+++ b/kernel/constr.mli
@@ -45,17 +45,8 @@ type case_info =
                                        in addition to the parameters of the related inductive type
                                        NOTE: "lets" are therefore excluded from the count
                                        NOTE: parameters of the inductive type are also excluded from the count *)
-    ci_relevance : Sorts.relevance; (* relevance of the predicate (not of the inductive!) *)
     ci_pp_info    : case_printing   (* not interpreted by the kernel *)
   }
-
-type 'constr pcase_invert =
-  | NoInvert
-  (** Normal reduction: match when the scrutinee is a constructor. *)
-
-  | CaseInvert of { indices : 'constr array; }
-  (** Reduce when the indices match those of the unique constructor.
-      (SProp to non SProp only) *)
 
 (** {6 The type of constructions } *)
 
@@ -165,10 +156,18 @@ end
     {e construct_args |- case_term } *)
 
 type 'constr pcase_branch = Name.t Context.binder_annot array * 'constr
+(** Names bound by matching the constructor for this branch. *)
+
+type 'types pcase_return = (Name.t Context.binder_annot array * 'types) * Sorts.relevance
 (** Names of the indices + name of self *)
 
-type 'types pcase_return = Name.t Context.binder_annot array * 'types
-(** Names of the branches *)
+type 'constr pcase_invert =
+  | NoInvert
+  (** Normal reduction: match when the scrutinee is a constructor. *)
+
+  | CaseInvert of { indices : 'constr array; }
+  (** Reduce when the indices match those of the unique constructor.
+      (SProp to non SProp only) *)
 
 type ('constr, 'types, 'univs) pcase =
   case_info * 'univs * 'constr array * 'types pcase_return * 'constr pcase_invert * 'constr * 'constr pcase_branch array

--- a/kernel/conversion.ml
+++ b/kernel/conversion.ml
@@ -844,7 +844,7 @@ and convert_return_clause mib mip l2r infos e1 e2 l1 l2 u1 u2 pms1 pms2 p1 p2 cu
       let ctx = LocalAssum (Context.anonR, dummy) :: ctx in
       Some (ctx, u1, u2, pms1, pms2)
   in
-  convert_under_context l2r infos e1 e2 l1 l2 ctx p1 p2 cu
+  convert_under_context l2r infos e1 e2 l1 l2 ctx (fst p1) (fst p2) cu
 
 and convert_branches mib mip l2r infos e1 e2 lft1 lft2 u1 u2 pms1 pms2 br1 br2 cuniv =
   let fold i (ctx, _) cuniv =

--- a/kernel/genlambda.ml
+++ b/kernel/genlambda.ml
@@ -636,7 +636,7 @@ let rec lambda_of_constr cache env sigma c =
     Lproj (Projection.repr p, c)
 
   | Case (ci, u, pms, t, iv, a, br) -> (* XXX handle iv *)
-    let (ci, t, _iv, a, branches) = Inductive.expand_case env (ci, u, pms, t, iv, a, br) in
+    let (ci, (t,_), _iv, a, branches) = Inductive.expand_case env (ci, u, pms, t, iv, a, br) in
     let (mind, i) = ci.ci_ind in
     let mib = lookup_mind mind env in
     let oib = mib.mind_packets.(i) in

--- a/kernel/inductive.mli
+++ b/kernel/inductive.mli
@@ -95,16 +95,21 @@ val inductive_params : mind_specif -> int
 val expand_arity : mind_specif -> pinductive -> constr array ->
   Name.t Context.binder_annot array -> rel_context
 
+type ('constr,'types) pexpanded_case =
+  (case_info * ('constr * Sorts.relevance) * 'constr pcase_invert * 'constr * 'constr array)
+
+type expanded_case = (constr,types) pexpanded_case
+
 (** Given a pattern-matching represented compactly, expands it so as to produce
     lambda and let abstractions in front of the return clause and the pattern
     branches. *)
-val expand_case : env -> case -> (case_info * constr * case_invert * constr * constr array)
+val expand_case : env -> case -> expanded_case
 
-val expand_case_specif : mutual_inductive_body -> case -> (case_info * constr * case_invert * constr * constr array)
+val expand_case_specif : mutual_inductive_body -> case -> expanded_case
 
 (** Dual operation of the above. Fails if the return clause or branch has not
     the expected form. *)
-val contract_case : env -> (case_info * constr * case_invert * constr * constr array) -> case
+val contract_case : env -> expanded_case -> case
 
 (** [instantiate_context u subst nas ctx] applies both [u] and [subst]
     to [ctx] while replacing names using [nas] (order reversed). In particular,
@@ -123,7 +128,7 @@ val inductive_sort_family : one_inductive_body -> Sorts.family
 
 (** Check a [case_info] actually correspond to a Case expression on the
    given inductive type. *)
-val check_case_info : env -> pinductive -> Sorts.relevance -> case_info -> unit
+val check_case_info : env -> pinductive -> case_info -> unit
 
 (** {6 Guard conditions for fix and cofix-points. } *)
 

--- a/kernel/inferCumulativity.ml
+++ b/kernel/inferCumulativity.ml
@@ -252,7 +252,9 @@ let rec infer_fterm cv_pb infos variances hd stk =
 
   | FCaseInvert (ci, u, pms, p, _, _, br, e) ->
     let mib = Environ.lookup_mind (fst ci.ci_ind) (info_env (fst infos)) in
-    let (_, p, _, _, br) = Inductive.expand_case_specif mib (ci, u, pms, p, NoInvert, mkProp, br) in
+    let (_, (p, _), _, _, br) =
+      Inductive.expand_case_specif mib (ci, u, pms, p, NoInvert, mkProp, br)
+    in
     let infer c variances = infer_fterm CONV infos variances (mk_clos e c) [] in
     let variances = infer p variances in
     Array.fold_right infer br variances
@@ -275,7 +277,7 @@ and infer_stack infos variances (stk:CClosure.stack) =
       | ZcaseT (ci,u,pms,p,br,e) ->
         let dummy = mkProp in
         let case = (ci, u, pms, p, NoInvert, dummy, br) in
-        let (_, p, _, _, br) = Inductive.expand_case (info_env (fst infos)) case in
+        let (_, (p, _), _, _, br) = Inductive.expand_case (info_env (fst infos)) case in
         let variances = infer_fterm CONV infos variances (mk_clos e p) [] in
         infer_vect infos variances (Array.map (mk_clos e) br)
       | Zshift _ -> variances

--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -355,7 +355,7 @@ let rec map_kn f f' c =
       | Construct (((kn,i),j),u) ->
           let kn' = f kn in
           if kn'==kn then c else mkConstructU (((kn',i),j),u)
-      | Case (ci,u,pms,p,iv,ct,l) ->
+      | Case (ci,u,pms,(p,r),iv,ct,l) ->
           let ci_ind =
             let (kn,i) = ci.ci_ind in
             let kn' = f kn in
@@ -374,7 +374,7 @@ let rec map_kn f f' c =
                 && l'==l && ct'==ct)then c
             else
               mkCase ({ci with ci_ind = ci_ind}, u,
-                      pms',p',iv',ct', l')
+                      pms',(p',r),iv',ct', l')
       | Cast (ct,k,t) ->
           let ct' = func ct in
           let t'= func t in

--- a/kernel/relevanceops.ml
+++ b/kernel/relevanceops.ml
@@ -61,7 +61,7 @@ let rec relevance_of_term_extra env extra lft c =
   | App (c, _) -> relevance_of_term_extra env extra lft c
   | Const c -> relevance_of_constant env c
   | Construct c -> relevance_of_constructor env c
-  | Case (ci, _, _, _, _, _, _) -> ci.ci_relevance
+  | Case (_, _, _, (_, r), _, _, _) -> r
   | Fix ((_,i),(lna,_,_)) -> (lna.(i)).binder_relevance
   | CoFix (i,(lna,_,_)) -> (lna.(i)).binder_relevance
   | Proj (_, r, _) -> r

--- a/kernel/typeops.mli
+++ b/kernel/typeops.mli
@@ -135,6 +135,6 @@ type ('constr,'types) bad_relevance =
 val bad_relevance_msg : (env * (constr,types) bad_relevance) CWarnings.msg
 (** Used by the higher layers to register a nicer printer than the default. *)
 
-val should_invert_case : env -> case_info -> bool
+val should_invert_case : env -> Sorts.relevance -> case_info -> bool
 (** We have case inversion exactly when going from irrelevant nonempty
    (ie 1 constructor) inductive to relevant type. *)

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -1075,10 +1075,10 @@ let fake_match_projection env p =
     ci_npar = mib.mind_nparams;
     ci_cstr_ndecls = mip.mind_consnrealdecls;
     ci_cstr_nargs = mip.mind_consnrealargs;
-    ci_relevance = relevance_of_projection_repr mib p;
     ci_pp_info;
   }
   in
+  let relevance = relevance_of_projection_repr mib p in
   let x = match mib.mind_record with
     | NotRecord | FakeRecord -> assert false
     | PrimRecord info ->
@@ -1101,7 +1101,7 @@ let fake_match_projection env p =
           (nas, mkRel (List.length ctx - (j - 1)))
         in
         let params = Context.Rel.instance mkRel 1 paramslet in
-        let body = mkCase (ci, u, params, p, NoInvert, mkRel 1, [|branch|]) in
+        let body = mkCase (ci, u, params, (p,relevance), NoInvert, mkRel 1, [|branch|]) in
         it_mkLambda_or_LetIn (mkLambda (x,indty,body)) mib.mind_params_ctxt
     | LocalDef (_,c,t) :: rem ->
       let c = liftn 1 j c in

--- a/plugins/firstorder/unify.ml
+++ b/plugins/firstorder/unify.ml
@@ -69,8 +69,8 @@ let unif env evd t1 t2=
               Queue.add (a,c) bige;Queue.add (pop b,pop d) bige
           | Case (cia,ua,pmsa,pa,iva,ca,va),Case (cib,ub,pmsb,pb,ivb,cb,vb)->
             let env = Global.env () in
-            let (cia,pa,iva,ca,va) = EConstr.expand_case env evd (cia,ua,pmsa,pa,iva,ca,va) in
-            let (cib,pb,iva,cb,vb) = EConstr.expand_case env evd (cib,ub,pmsb,pb,ivb,cb,vb) in
+            let (cia,(pa,_),iva,ca,va) = EConstr.expand_case env evd (cia,ua,pmsa,pa,iva,ca,va) in
+            let (cib,(pb,_),iva,cb,vb) = EConstr.expand_case env evd (cib,ub,pmsb,pb,ivb,cb,vb) in
               Queue.add (pa,pb) bige;
               Queue.add (ca,cb) bige;
               let l=Array.length va in

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -293,7 +293,7 @@ let check_not_nested env sigma forbidden e =
     | Const _ -> ()
     | Ind _ -> ()
     | Construct _ -> ()
-    | Case (_, _, pms, (_, t), _, e, a) ->
+    | Case (_, _, pms, ((_, t), _), _, e, a) ->
       Array.iter check_not_nested pms;
       check_not_nested t;
       check_not_nested e;
@@ -359,7 +359,7 @@ type journey_info =
           -> constr infos
           -> unit Proofview.tactic)
       -> ( case_info
-           * constr
+           * (constr * Sorts.relevance)
            * case_invert
            * constr
            * constr array
@@ -766,7 +766,7 @@ let terminate_case next_step (ci, a, iv, t, l) expr_info continuation_tac infos
         try
           check_not_nested env sigma
             (expr_info.f_id :: expr_info.forbidden_ids)
-            a;
+            (fst a);
           false
         with e when CErrors.noncritical e -> true
       in

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -526,7 +526,7 @@ let () =
     let (ci, c, iv, t, bl) = EConstr.expand_case env sigma (ci, u, pms, c, iv, t, bl) in
     v_blk 13 [|
       Tac2ffi.of_ext Tac2ffi.val_case ci;
-      Tac2ffi.of_constr c;
+      Tac2ffi.(of_pair of_constr of_relevance c);
       of_case_invert iv;
       Tac2ffi.of_constr t;
       Tac2ffi.of_array Tac2ffi.of_constr bl;
@@ -619,7 +619,7 @@ let () =
     EConstr.mkConstructU (cstr, u)
   | (13, [|ci; c; iv; t; bl|]) ->
     let ci = Tac2ffi.to_ext Tac2ffi.val_case ci in
-    let c = Tac2ffi.to_constr c in
+    let c = Tac2ffi.(to_pair to_constr to_relevance c) in
     let iv = to_case_invert iv in
     let t = Tac2ffi.to_constr t in
     let bl = Tac2ffi.to_array Tac2ffi.to_constr bl in
@@ -691,7 +691,7 @@ let () =
   define "constr_case" (inductive @-> tac valexpr) @@ fun ind ->
   Proofview.tclENV >>= fun env ->
   try
-    let ans = Inductiveops.make_case_info env ind Sorts.Relevant Constr.RegularStyle in
+    let ans = Inductiveops.make_case_info env ind Constr.RegularStyle in
     return (Tac2ffi.of_ext Tac2ffi.val_case ans)
   with e when CErrors.noncritical e ->
     throw err_notfound
@@ -804,8 +804,7 @@ let () =
 let () =
   let ty = repr_ext val_case in
   define "constr_case_equal" (ty @-> ty @-> ret bool) @@ fun x y ->
-  Ind.UserOrd.equal x.ci_ind y.ci_ind &&
-  Sorts.relevance_equal x.ci_relevance y.ci_relevance
+  Ind.UserOrd.equal x.ci_ind y.ci_ind
 let () =
   let ty = repr_ext val_constructor in
   define "constructor_equal" (ty @-> ty @-> ret bool) Construct.UserOrd.equal

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -272,7 +272,7 @@ let iter_constr_LR sigma f c = match EConstr.kind sigma c with
   | Prod (_, t, b) | Lambda (_, t, b)  -> f t; f b
   | LetIn (_, v, t, b) -> f v; f t; f b
   | App (cf, a) -> f cf; Array.iter f a
-  | Case (_, _, pms, (_, p), iv, v, b) ->
+  | Case (_, _, pms, ((_, p), _), iv, v, b) ->
     f v; Array.iter f pms; f p; iter_invert f iv; Array.iter (fun (_, c) -> f c) b
   | Fix (_, (_, t, b)) | CoFix (_, (_, t, b)) ->
     for i = 0 to Array.length t - 1 do f t.(i); f b.(i) done

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -1162,7 +1162,7 @@ let rec ungeneralize sigma n ng body =
   | LetIn (na,b,t,c) ->
       (* We traverse an alias *)
       mkLetIn (na,b,t,ungeneralize sigma (n+1) ng c)
-  | Case (ci,u,pms,p,iv,c,brs) ->
+  | Case (ci,u,pms,(p,rp),iv,c,brs) ->
       (* We traverse a split *)
       let p =
         let (nas, p) = p in
@@ -1171,7 +1171,7 @@ let rec ungeneralize sigma n ng body =
         nas, it_mkProd_or_LetIn p sign2
       in
       let map (nas, br) = nas, ungeneralize sigma (n + Array.length nas) ng br in
-      mkCase (ci, u, pms, p, iv, c, Array.map map brs)
+      mkCase (ci, u, pms, (p,rp), iv, c, Array.map map brs)
   | App (f,args) ->
       (* We traverse an inner generalization *)
       assert (isCase sigma f);
@@ -1479,9 +1479,9 @@ let compile ~program_mode sigma pb =
                 pred current indt (names,dep) tomatch
             in
             let rci = Typing.check_allowed_sort !!(pb.env) sigma mind current pred in
-            let ci = make_case_info !!(pb.env) (fst mind) rci pb.casestyle in
+            let ci = make_case_info !!(pb.env) (fst mind) pb.casestyle in
             let pred = nf_betaiota !!(pb.env) sigma pred in
-            let case = make_case_or_project !!(pb.env) sigma indt ci pred current brvals in
+            let case = make_case_or_project !!(pb.env) sigma indt ci (pred,rci) current brvals in
             let sigma, _ = Typing.type_of !!(pb.env) sigma pred in
             let used = List.flatten (Array.to_list used) in
             used, sigma, { uj_val = applist (case, inst);

--- a/pretyping/cbv.ml
+++ b/pretyping/cbv.ml
@@ -692,7 +692,7 @@ let rec apply_stack info t = function
       apply_stack info (mkApp(t,Array.map_of_list (cbv_norm_value info) args)) st
   | CASE (u,pms,ty,br,iv,ci,env,st) ->
     (* FIXME: Prevent this expansion by caching whether an inductive contains let-bindings *)
-    let (_, ty, _, _, br) = Inductive.expand_case info.env (ci, u, pms, ty, iv, mkProp, br) in
+    let (_, (ty,r), _, _, br) = Inductive.expand_case info.env (ci, u, pms, ty, iv, mkProp, br) in
     let ty =
       let (_, mip) = Inductive.lookup_mind_specif info.env ci.ci_ind in
       Term.decompose_lambda_n_decls (mip.Declarations.mind_nrealdecls + 1) ty
@@ -713,7 +713,7 @@ let rec apply_stack info t = function
       (nas, cbv_norm_term info env c)
     in
       apply_stack info
-        (mkCase (ci, u, Array.map (cbv_norm_term info env) pms, map_ctx ty, iv, t,
+        (mkCase (ci, u, Array.map (cbv_norm_term info env) pms, (map_ctx ty,r), iv, t,
                     Array.map map_ctx br))
         st
   | PROJ (p, r, st) ->

--- a/pretyping/constr_matching.ml
+++ b/pretyping/constr_matching.ml
@@ -405,7 +405,7 @@ let matches_core env sigma allow_bound_rels
             raise PatternMatchingFailure
 
       | PCase (ci1, p1, a1, br1), Case (ci2, u2, pms2, p2, iv, a2, br2) ->
-          let (_, _, _, p2, _, _, br2) = EConstr.annotate_case env sigma (ci2, u2, pms2, p2, iv, a2, br2) in
+          let (_, _, _, (p2,_), _, _, br2) = EConstr.annotate_case env sigma (ci2, u2, pms2, p2, iv, a2, br2) in
           let n2 = Array.length br2 in
           let () = match ci1.cip_ind with
           | None -> ()
@@ -577,7 +577,7 @@ let sub_match ?(closed=true) env sigma pat c =
      try_aux [(env, app); (env, Array.last lc)] mk_ctx next
   | Case (ci,u,pms,hd0,iv,c1,lc0) ->
       let (mib, mip) = Inductive.lookup_mind_specif env ci.ci_ind in
-      let (_, hd, _, _, br) = expand_case env sigma (ci, u, pms, hd0, iv, c1, lc0) in
+      let (_, (hd,hdr), _, _, br) = expand_case env sigma (ci, u, pms, hd0, iv, c1, lc0) in
       let hd =
         let (ctx, hd) = decompose_lambda_decls sigma hd in
         (push_rel_context ctx env, hd)
@@ -593,9 +593,9 @@ let sub_match ?(closed=true) env sigma pat c =
         let pms, rem = List.chop (Array.length pms) rem in
         let pms = Array.of_list pms in
         let hd, lc = match rem with [] -> assert false | x :: l -> (x, l) in
-        let hd = (fst hd0, hd) in
+        let hd = (fst (fst hd0), hd) in
         let map_br (nas, _) br = (nas, br) in
-        mk_ctx (mkCase (ci,u,pms,hd,iv,c1,Array.map2 map_br lc0 (Array.of_list lc)))
+        mk_ctx (mkCase (ci,u,pms,(hd,hdr),iv,c1,Array.map2 map_br lc0 (Array.of_list lc)))
       | _ -> assert false
       in
       let sub = (env, c1) :: Array.fold_right (fun c accu -> (env, c) :: accu) pms (hd :: lc) in

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -66,7 +66,7 @@ let instantiate_context u subst nas ctx =
   let () = if not (Int.equal (Array.length nas) (List.length ctx)) then raise_notrace Exit in
   instantiate (Array.length nas - 1) ctx
 
-let return_clause env sigma ind u params (nas, p) =
+let return_clause env sigma ind u params ((nas, p),_) =
   try
     let u = EConstr.Unsafe.to_instance u in
     let params = EConstr.Unsafe.to_constr_array params in
@@ -519,7 +519,7 @@ and align_tree nal isgoal (e,c as rhs) sigma = match nal with
   | [] -> [Id.Set.empty,[],rhs]
   | na::nal ->
     match EConstr.kind sigma c with
-    | Case (ci,u,pms,p,iv,c,cl) when
+    | Case (ci,u,pms,(p,_),iv,c,cl) when
         eq_constr (snd (snd e)) sigma c (mkRel (List.index Name.equal na (fst (snd e))))
         && not (Int.equal (Array.length cl) 0)
         && (* don't contract if p dependent *)
@@ -953,7 +953,7 @@ and detype_r d flags avoid env sigma t =
     | Construct (cstr_sp,u) ->
         GRef (GlobRef.ConstructRef cstr_sp, detype_instance sigma u)
     | Case (ci,u,pms,p,iv,c,bl) ->
-        let comp = computable sigma p in
+        let comp = computable sigma (fst p) in
         let case = (ci, u, pms, p, iv, c, bl) in
         detype_case comp (detype d flags avoid env sigma)
           (detype_eqns d flags avoid env sigma comp)

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -449,8 +449,8 @@ let rec ise_stack2 no_app env evd f sk1 sk2 =
     match revsk1, revsk2 with
     | [], [] -> None, Success i
     | Stack.Case cse1 :: q1, Stack.Case cse2 :: q2 ->
-      let (ci1, u1, pms1, t1, br1) = Stack.expand_case env evd cse1 in
-      let (ci2, u2, pms2, t2, br2) = Stack.expand_case env evd cse2 in
+      let (ci1, u1, pms1, (t1,_), br1) = Stack.expand_case env evd cse1 in
+      let (ci2, u2, pms2, (t2,_), br2) = Stack.expand_case env evd cse2 in
       let hd1 = mkIndU (ci1.ci_ind, u1) in
       let hd2 = mkIndU (ci2.ci_ind, u2) in
       let fctx i (ctx1, t1) (_ctx2, t2) = f (push_rel_context ctx1 env) i CONV t1 t2 in
@@ -494,8 +494,8 @@ let rec exact_ise_stack2 env evd f sk1 sk2 =
     match revsk1, revsk2 with
     | [], [] -> Success i
     | Stack.Case cse1 :: q1, Stack.Case cse2 :: q2 ->
-      let (ci1, u1, pms1, t1, br1) = Stack.expand_case env evd cse1 in
-      let (ci2, u2, pms2, t2, br2) = Stack.expand_case env evd cse2 in
+      let (ci1, u1, pms1, (t1,_), br1) = Stack.expand_case env evd cse1 in
+      let (ci2, u2, pms2, (t2,_), br2) = Stack.expand_case env evd cse2 in
       let hd1 = mkIndU (ci1.ci_ind, u1) in
       let hd2 = mkIndU (ci2.ci_ind, u2) in
       let fctx i (ctx1, t1) (_ctx2, t2) = f (push_rel_context ctx1 env) i CONV t1 t2 in

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -243,7 +243,7 @@ let has_dependent_elim (mib,mip) =
   | NotRecord | FakeRecord -> true
 
 (* Annotation for cases *)
-let make_case_info env ind r style =
+let make_case_info env ind style =
   let (mib,mip) = Inductive.lookup_mind_specif env ind in
   let ind_tags =
     Context.Rel.to_tags (List.firstn mip.mind_nrealdecls mip.mind_arity_ctxt) in
@@ -256,7 +256,6 @@ let make_case_info env ind r style =
     ci_npar    = mib.mind_nparams;
     ci_cstr_ndecls = mip.mind_consnrealdecls;
     ci_cstr_nargs = mip.mind_consnrealargs;
-    ci_relevance = r;
     ci_pp_info = print_info }
 
 (*s Useful functions *)
@@ -310,8 +309,8 @@ let get_constructors env (ind,params) =
 
 let get_projections = Environ.get_projections
 
-let make_case_invert env (IndType (((ind,u),params),indices)) ci =
-  if Typeops.should_invert_case env ci
+let make_case_invert env (IndType (((ind,u),params),indices)) ~case_relevance:r ci =
+  if Typeops.should_invert_case env r ci
   then CaseInvert {indices=Array.of_list indices}
   else NoInvert
 
@@ -374,7 +373,7 @@ let simple_make_case_or_project env sigma ci pred invert c branches =
   let projs = get_projections env ind in
   match projs with
   | None -> mkCase (EConstr.contract_case env sigma (ci, pred, invert, c, branches))
-  | Some ps -> make_project env sigma ind pred c branches ps
+  | Some ps -> make_project env sigma ind (fst pred) c branches ps
 
 let make_case_or_project env sigma indt ci pred c branches =
   let open EConstr in
@@ -382,9 +381,9 @@ let make_case_or_project env sigma indt ci pred c branches =
   let projs = get_projections env ind in
   match projs with
   | None ->
-     let invert = make_case_invert env indt ci in
+     let invert = make_case_invert env indt ~case_relevance:(snd pred) ci in
      mkCase (EConstr.contract_case env sigma (ci, pred, invert, c, branches))
-  | Some ps -> make_project env sigma ind pred c branches ps
+  | Some ps -> make_project env sigma ind (fst pred) c branches ps
 
 (* substitution in a signature *)
 

--- a/pretyping/inductiveops.mli
+++ b/pretyping/inductiveops.mli
@@ -177,7 +177,7 @@ val arity_of_case_predicate :
   env -> inductive_family -> bool -> Sorts.t -> types
 
 (** Annotation for cases *)
-val make_case_info : env -> inductive -> Sorts.relevance -> case_style -> case_info
+val make_case_info : env -> inductive -> case_style -> case_info
 
 (** Make a case or substitute projections if the inductive type is a record
     with primitive projections.
@@ -185,15 +185,15 @@ val make_case_info : env -> inductive -> Sorts.relevance -> case_style -> case_i
     inductive type does not allow dependent elimination. *)
 val make_case_or_project :
   env -> evar_map -> inductive_type -> case_info ->
-  (* pred *) EConstr.constr -> (* term *) EConstr.constr -> (* branches *) EConstr.constr array -> EConstr.constr
+  (* pred *) EConstr.constr * Sorts.relevance -> (* term *) EConstr.constr -> (* branches *) EConstr.constr array -> EConstr.constr
 
 (** Sometimes [make_case_or_project] is nicer to call with a pre-built
    [case_invert] than [inductive_type]. *)
 val simple_make_case_or_project :
   env -> evar_map -> case_info ->
-  (* pred *) EConstr.constr -> EConstr.case_invert -> (* term *) EConstr.constr -> (* branches *) EConstr.constr array -> EConstr.constr
+  (* pred *) EConstr.constr * Sorts.relevance -> EConstr.case_invert -> (* term *) EConstr.constr -> (* branches *) EConstr.constr array -> EConstr.constr
 
-val make_case_invert : env -> inductive_type -> case_info
+val make_case_invert : env -> inductive_type -> case_relevance:Sorts.relevance -> case_info
   -> EConstr.case_invert
 
 (*i Compatibility

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -338,12 +338,12 @@ and nf_atom_type env sigma atom =
       let branchs = Array.mapi mkbranch bsw in
       let tcase = build_case_type (pctx, p) realargs a in
       let p = (get_case_annot pctx, p) in
-      let ci = Inductiveops.make_case_info env ind relevance RegularStyle in
-      let iv = if Typeops.should_invert_case env ci then
+      let ci = Inductiveops.make_case_info env ind RegularStyle in
+      let iv = if Typeops.should_invert_case env relevance ci then
           CaseInvert {indices=realargs}
         else NoInvert
       in
-      mkCase (ci, u, params, p, iv, a, branchs), tcase
+      mkCase (ci, u, params, (p,relevance), iv, a, branchs), tcase
   | Afix(tt,ft,rp,s) ->
       let tt = Array.map (fun t -> nf_type_sort env sigma t) tt in
       let tt = Array.map fst tt and rt = Array.map snd tt in

--- a/pretyping/patternops.ml
+++ b/pretyping/patternops.ml
@@ -187,14 +187,14 @@ let pattern_of_constr ~broken env sigma t =
       | _ ->
         PMeta None)
     | Case (ci, u, pms, p0, iv, a, br0) ->
-        let (ci, p, iv, a, br) = Inductive.expand_case env (ci, u, pms, p0, iv, a, br0) in
+        let (ci, (p,_), iv, a, br) = Inductive.expand_case env (ci, u, pms, p0, iv, a, br0) in
         let pattern_of_ctx c (nas, c0) =
           let ctx, c = Term.decompose_lambda_n_decls (Array.length nas) c in
           let env = push_rel_context ctx env in
           let c = pattern_of_constr env c in
           (Array.map Context.binder_name nas, c)
         in
-        let p = pattern_of_ctx p p0 in
+        let p = pattern_of_ctx p (fst p0) in
         let cip =
           { cip_style = ci.ci_pp_info.style;
             cip_ind = Some ci.ci_ind;

--- a/pretyping/pretype_errors.mli
+++ b/pretyping/pretype_errors.mli
@@ -77,6 +77,11 @@ exception PretypeError of env * Evd.evar_map * pretype_error
 val precatchable_exception : exn -> bool
 
 (** Raising errors *)
+val raise_type_error
+  : ?loc:Loc.t
+  -> Environ.env * Evd.evar_map * type_error
+  -> 'a
+
 val error_actual_type :
   ?loc:Loc.t -> ?info:Exninfo.info -> env -> Evd.evar_map -> unsafe_judgment -> constr ->
       unification_error -> 'b

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -1142,8 +1142,8 @@ struct
     let obj indt rci p v f =
       if not record then
         let f = it_mkLambda_or_LetIn f fsign in
-        let ci = make_case_info !!env (ind_of_ind_type indt) rci LetStyle in
-          mkCase (EConstr.contract_case !!env sigma (ci, p, make_case_invert !!env indt ci, cj.uj_val,[|f|]))
+        let ci = make_case_info !!env (ind_of_ind_type indt) LetStyle in
+          mkCase (EConstr.contract_case !!env sigma (ci, (p,rci), make_case_invert !!env indt ~case_relevance:rci ci, cj.uj_val,[|f|]))
       else it_mkLambda_or_LetIn f fsign
     in
     (* Make dependencies from arity signature impossible *)
@@ -1259,8 +1259,11 @@ struct
         let ind,_ = dest_ind_family indf in
         let pred = nf_evar sigma pred in
         let rci = Typing.check_allowed_sort !!env sigma ind cj.uj_val pred in
-        let ci = make_case_info !!env (fst ind) rci IfStyle in
-        mkCase (EConstr.contract_case !!env sigma (ci, pred, make_case_invert !!env indty ci, cj.uj_val, [|b1;b2|]))
+        let ci = make_case_info !!env (fst ind) IfStyle in
+        mkCase (EConstr.contract_case !!env sigma
+                  (ci, (pred,rci),
+                   make_case_invert !!env indty ~case_relevance:rci ci, cj.uj_val,
+                   [|b1;b2|]))
       in
       let cj = { uj_val = v; uj_type = p } in
       discard_trace @@ inh_conv_coerce_to_tycon ?loc ~flags env sigma cj tycon

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -215,7 +215,7 @@ sig
   val zip : evar_map -> constr * t -> constr
   val check_native_args : CPrimitives.t -> t -> bool
   val get_next_primitive_args : CPrimitives.args_red -> t -> CPrimitives.args_red * (t * EConstr.t * t) option
-  val expand_case : env -> evar_map -> case_stk -> case_info * EInstance.t * constr array * (rel_context * constr) * (rel_context * constr) array
+  val expand_case : env -> evar_map -> case_stk -> case_info * EInstance.t * constr array * ((rel_context * constr) * Sorts.relevance) * (rel_context * constr) array
 end =
 struct
   open EConstr
@@ -312,7 +312,7 @@ struct
         let t1,l1 = decomp_node_last n1 q1 in
         let t2,l2 = decomp_node_last n2 q2 in
         aux (f o t1 t2) l1 l2
-      | Case ((_,_,pms1,(_, t1),_,a1)) :: q1, Case ((_,_,pms2, (_, t2),_,a2)) :: q2 ->
+      | Case ((_,_,pms1,((_, t1),_),_,a1)) :: q1, Case ((_,_,pms2, ((_, t2),_),_,a2)) :: q2 ->
         let f' o (_, t1) (_, t2) = f o t1 t2 in
         aux (Array.fold_left2 f' (f (Array.fold_left2 f o pms1 pms2) t1 t2) a1 a2) q1 q2
       | Proj (p1,_) :: q1, Proj (p2,_) :: q2 ->

--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -114,7 +114,7 @@ module Stack : sig
   val zip : evar_map -> constr * t -> constr
 
   val expand_case : env -> evar_map -> case_stk ->
-    case_info * EInstance.t * constr array * (rel_context * constr) * (rel_context * constr) array
+    case_info * EInstance.t * constr array * ((rel_context * constr) * Sorts.relevance) * (rel_context * constr) array
 end
 
 (************************************************************************)

--- a/pretyping/retyping.ml
+++ b/pretyping/retyping.ml
@@ -152,7 +152,7 @@ let retype ?(polyprop=true) sigma =
     | Ind ind -> Inductiveops.e_type_of_inductive env sigma ind
     | Construct c -> Inductiveops.e_type_of_constructor env sigma c
     | Case (ci,u,pms,p,iv,c,lf) ->
-        let (_,p,iv,c,lf) = EConstr.expand_case env sigma (ci,u,pms,p,iv,c,lf) in
+        let (_,(p,_),iv,c,lf) = EConstr.expand_case env sigma (ci,u,pms,p,iv,c,lf) in
         let Inductiveops.IndType(indf,realargs) =
           let t = type_of env c in
           try Inductiveops.find_rectype env sigma t
@@ -350,7 +350,7 @@ let relevance_of_term env sigma c =
       | Construct (c,u) ->
         let u = Unsafe.to_instance u in
         Relevanceops.relevance_of_constructor env (c,u)
-      | Case (ci, _, _, _, _, _, _) -> ci.ci_relevance
+      | Case (_, _, _, (_, r), _, _, _) -> r
       | Fix ((_,i),(lna,_,_)) -> (lna.(i)).binder_relevance
       | CoFix (i,(lna,_,_)) -> (lna.(i)).binder_relevance
       | Proj (p, r, _) -> r

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -854,12 +854,12 @@ let rec unify_0_with_initial_metas (sigma,ms,es as subst : subst0) conv_at_top e
                unify_app_pattern true curenvnb pb opt substn cM f1 l1 cN f2 l2
              | _ -> raise ex)
 
-        | Case (ci1, u1, pms1, p1, iv1, c1, cl1), Case (ci2, u2, pms2, p2, iv2, c2, cl2) ->
+        | Case (ci1, u1, pms1, p1, iv1, c1, cl1), Case (ci2, u2, pms2, (p2,_), iv2, c2, cl2) ->
             (try
              let () = if not (QInd.equal curenv ci1.ci_ind ci2.ci_ind) then error_cannot_unify curenv sigma (cM,cN) in
              let opt' = {opt with at_top = true; with_types = false} in
              let substn = Array.fold_left2 (unirec_rec curenvnb CONV ~nargs:0 opt') substn pms1 pms2 in
-             let (ci1, _, _, p1, _, c1, cl1) = EConstr.annotate_case env sigma (ci1, u1, pms1, p1, iv1, c1, cl1) in
+             let (ci1, _, _, (p1,_), _, c1, cl1) = EConstr.annotate_case env sigma (ci1, u1, pms1, p1, iv1, c1, cl1) in
              let unif opt substn (ctx1, c1) (_, c2) =
                let curenvnb' = List.fold_right (fun decl (env, n) -> push_rel decl env, n + 1) ctx1 curenvnb in
                unirec_rec curenvnb' CONV opt' substn c1 c2
@@ -1895,7 +1895,7 @@ let rec make sigma c0 = match EConstr.kind sigma c0 with
   (* Unification doesn't recurse on the subterms in evar instances *)
   let data = SList.Skip.fold (fun accu v -> max accu (get_max_rel sigma v)) 0 al in
   { proj = c0; self = AOther [||]; data }
-| Case (ci, u, pms, p, iv, c, bl) ->
+| Case (ci, u, pms, (p,_), iv, c, bl) ->
   let pmsd = get_max_rel_array sigma pms in
   let pd =
     let (nas, p) = p in

--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -302,12 +302,12 @@ and nf_stk ?from:(from=0) env sigma c t stk  =
       let branchs = Array.mapi mkbranch bsw in
       let tcase = build_case_type (pctx, p) realargs c in
       let p = (get_case_annot pctx, p) in
-      let ci = Inductiveops.make_case_info env ind relevance RegularStyle in
-      let iv = if Typeops.should_invert_case env ci then
+      let ci = Inductiveops.make_case_info env ind RegularStyle in
+      let iv = if Typeops.should_invert_case env relevance ci then
           CaseInvert {indices=realargs}
         else NoInvert
       in
-      nf_stk env sigma (mkCase (ci, u, params, p, iv, c, branchs)) tcase stk
+      nf_stk env sigma (mkCase (ci, u, params, (p,relevance), iv, c, branchs)) tcase stk
   | Zproj p :: stk ->
     let () = assert (from = 0) in
     let ((ind, u), args) = Inductiveops.find_mrectype env sigma (EConstr.of_constr t) in

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -828,17 +828,17 @@ let build_case_analysis env sigma (ind, u) params pred indices indarg dep knd =
 
   match projs with
   | None ->
-    let ci = make_case_info env ind relevance RegularStyle in
+    let ci = make_case_info env ind RegularStyle in
     let pbody =
       mkApp
         (pred,
           if dep then Context.Rel.instance mkRel 0 deparsign
           else Context.Rel.instance mkRel 1 (List.tl deparsign)) in
     let iv =
-      if Typeops.should_invert_case env ci then CaseInvert { indices = indices }
+      if Typeops.should_invert_case env relevance ci then CaseInvert { indices = indices }
       else NoInvert
     in
-    RealCase (ci, u, params, (pnas, pbody), iv, indarg)
+    RealCase (ci, u, params, ((pnas, pbody), relevance), iv, indarg)
   | Some ps ->
     let args = Array.map (fun (p,r) ->
         let r = UVars.subst_instance_relevance (Unsafe.to_instance u) r in
@@ -911,11 +911,11 @@ let case_pf ?(with_evars=false) ~dep (indarg, typ) =
   let rec nf_betaiota c = EConstr.map sigma nf_betaiota (whd_betaiota env sigma c) in
   (* Call the legacy refiner on the result *)
   let arg = match body with
-  | RealCase (ci, u, pms, p, iv, c) ->
+  | RealCase (ci, u, pms, (p,r), iv, c) ->
     let c = nf_betaiota c in
     let pms = Array.map nf_betaiota pms in
     let p = on_snd nf_betaiota p in
-    Internal.Case ((ci, u, pms, p, iv, c), branches)
+    Internal.Case ((ci, u, pms, (p,r), iv, c), branches)
   | PrimitiveEta args ->
     let mv = new_meta () in
     let (ctx, t) = branches.(0) in

--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -185,7 +185,7 @@ struct
     | Construct (c,u)-> Some (DRef (ConstructRef c), [])
     | Meta _         -> assert false
     | Evar (i,_)     -> None
-    | Case (ci,u1,pms1,c1,_iv,c2,ca)     ->
+    | Case (ci,u1,pms1,(c1,_),_iv,c2,ca)     ->
       let f_ctx (_, p) = p in
       Some (DCase(ci), [f_ctx c1; c2] @ Array.map_to_list f_ctx ca)
     | Fix ((ia,i),(_,ta,ca)) ->

--- a/tactics/cbn.ml
+++ b/tactics/cbn.ml
@@ -544,7 +544,7 @@ let debug_RAKAM = Reductionops.debug_RAKAM
 let equal_stacks sigma (x, l) (y, l') =
   let f_equal x y = eq_constr sigma x y in
   let eq_fix a b = f_equal (mkFix a) (mkFix b) in
-  let eq_case (ci1, u1, pms1, p1, _, br1) (ci2, u2, pms2, p2, _, br2) =
+  let eq_case (ci1, u1, pms1, (p1,_), _, br1) (ci2, u2, pms2, (p2,_), _, br2) =
     Array.equal f_equal pms1 pms2 &&
     f_equal (snd p1) (snd p2) &&
     Array.equal (fun (_, c1) (_, c2) -> f_equal c1 c2) br1 br2

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -909,8 +909,8 @@ let descend_then env sigma head dirn =
         List.map build_branch
           (List.interval 1 (Array.length mip.mind_consnames)) in
       let rci = Sorts.Relevant in (* TODO relevance *)
-      let ci = make_case_info env ind rci RegularStyle in
-      Inductiveops.make_case_or_project env sigma indt ci p head (Array.of_list brl)))
+      let ci = make_case_info env ind RegularStyle in
+      Inductiveops.make_case_or_project env sigma indt ci (p, rci) head (Array.of_list brl)))
 
 (* Now we need to construct the discriminator, given a discriminable
    position.  This boils down to:
@@ -955,8 +955,8 @@ let build_selector env sigma dirn c ind special default =
   let brl =
     List.map build_branch(List.interval 1 (Array.length mip.mind_consnames)) in
   let rci = Sorts.Relevant in (* TODO relevance *)
-  let ci = make_case_info env ind rci RegularStyle in
-  let ans = Inductiveops.make_case_or_project env sigma indt ci p c (Array.of_list brl) in
+  let ci = make_case_info env ind RegularStyle in
+  let ans = Inductiveops.make_case_or_project env sigma indt ci (p, rci) c (Array.of_list brl) in
   ans
 
 let build_coq_False () = pf_constr_of_global (lib_ref "core.False.type")

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -931,7 +931,7 @@ let make_leibniz_proof env c ty r =
 
 let fold_match ?(force=false) env sigma c =
   let case = destCase sigma c in
-  let (ci, p, iv, c, brs) = EConstr.expand_case env sigma case in
+  let (ci, (p,_), iv, c, brs) = EConstr.expand_case env sigma case in
   let cty = Retyping.get_type_of env sigma c in
   let dep, pred, sk =
     let env', ctx, body =
@@ -1171,7 +1171,7 @@ let subterm all flags (s : 'a pure_strategy) : 'a pure_strategy =
         in state, res
 
       | Case (ci, u, pms, p, iv, c, brs) ->
-        let (ci, p, iv, c, brs) = EConstr.expand_case env (goalevars evars) (ci, u, pms, p, iv, c, brs) in
+        let (ci, (p,rp), iv, c, brs) = EConstr.expand_case env (goalevars evars) (ci, u, pms, p, iv, c, brs) in
         let cty = Retyping.get_type_of env (goalevars evars) c in
         let evars', eqty = app_poly_sort prop env evars coq_eq [| cty |] in
         let cstr' = Some eqty in
@@ -1181,7 +1181,7 @@ let subterm all flags (s : 'a pure_strategy) : 'a pure_strategy =
         let state, res =
           match c' with
           | Success r ->
-            let case = mkCase (EConstr.contract_case env (goalevars evars) (ci, lift 1 p, map_invert (lift 1) iv, mkRel 1, Array.map (lift 1) brs)) in
+            let case = mkCase (EConstr.contract_case env (goalevars evars) (ci, (lift 1 p,rp), map_invert (lift 1) iv, mkRel 1, Array.map (lift 1) brs)) in
             let res = make_leibniz_proof env case ty r in
               state, Success (coerce env (prop,cstr) res)
           | Fail | Identity ->
@@ -1203,7 +1203,7 @@ let subterm all flags (s : 'a pure_strategy) : 'a pure_strategy =
               in
                 match found with
                 | Some r ->
-                  let ctxc = mkCase (EConstr.contract_case env (goalevars evars) (ci, lift 1 p, map_invert (lift 1) iv, lift 1 c, Array.of_list (List.rev (brs' c')))) in
+                  let ctxc = mkCase (EConstr.contract_case env (goalevars evars) (ci, (lift 1 p, rp), map_invert (lift 1) iv, lift 1 c, Array.of_list (List.rev (brs' c')))) in
                     state, Success (make_leibniz_proof env ctxc ty r)
                 | None -> state, c'
             else

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1704,12 +1704,12 @@ let make_projection env sigma params cstr sign elim i n c (ind, u) =
         if Sorts.family_leq ksort mip.mind_kelim then
           let arity = List.firstn mip.mind_nrealdecls mip.mind_arity_ctxt in
           let mknas ctx = Array.of_list (List.rev_map get_annot ctx) in
-          let ci = Inductiveops.make_case_info env ind (get_relevance decl) RegularStyle in
+          let ci = Inductiveops.make_case_info env ind RegularStyle in
           let br = [| mknas cs_args, b |] in
           let args = Context.Rel.instance mkRel 0 sign in
           let pnas = Array.append (mknas arity) [|make_annot Anonymous mip.mind_relevance|] in
           let p = (pnas, lift (Array.length pnas) t) in
-          let c = mkCase (ci, u, Array.of_list params, p, NoInvert, mkApp (c, args), br) in
+          let c = mkCase (ci, u, Array.of_list params, (p, get_relevance decl), NoInvert, mkApp (c, args), br) in
           Some (it_mkLambda_or_LetIn c sign, it_mkProd_or_LetIn t sign)
         else None
       else

--- a/user-contrib/Ltac2/Constr.v
+++ b/user-contrib/Ltac2/Constr.v
@@ -62,7 +62,7 @@ Ltac2 Type kind := [
 | Constant (constant, instance)
 | Ind (inductive, instance)
 | Constructor (constructor, instance)
-| Case (case, constr, case_invert, constr, constr array)
+| Case (case, (constr * Binder.relevance), case_invert, constr, constr array)
 | Fix (int array, int, binder array, constr array)
 | CoFix (int, binder array, constr array)
 | Proj (projection, Binder.relevance, constr)
@@ -116,7 +116,7 @@ Ltac2 constructor (ind : inductive) (i : int) : constructor :=
 
 Module Case.
   Ltac2 @ external equal : case -> case -> bool := "coq-core.plugins.ltac2" "constr_case_equal".
-  (** Checks equality of the inductive and relevance components of the
+  (** Checks equality of the inductive components of the
       case info. When comparing the inductives, those obtained through
       module aliases or Include are not considered equal by this
       function. *)

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -183,7 +183,7 @@ let fold_with_full_binders g f n acc c =
   | Evar _ -> assert false
   | Case (ci, u, pms, p, iv, c, bl) ->
     let mib = lookup_mind (fst ci.ci_ind) in
-    let (ci, p, iv, c, bl) = Inductive.expand_case_specif mib (ci, u, pms, p, iv, c, bl) in
+    let (ci, (p,_), iv, c, bl) = Inductive.expand_case_specif mib (ci, u, pms, p, iv, c, bl) in
     Array.fold_left (f n) (f n (fold_invert (f n) (f n acc p) iv) c) bl
   | Fix (_,(lna,tl,bl)) ->
       let n' = CArray.fold_left2_i (fun i c n t -> g (LocalAssum (n,lift i t)) c) n lna tl in
@@ -221,7 +221,7 @@ let rec traverse current ctx accu t =
 | Construct (((mind, _), _) as cst, _) ->
   traverse_inductive accu mind (ConstructRef cst)
 | Meta _ | Evar _ -> assert false
-| Case (_, _, _, ([|_|], oty), _, c, [||]) when Vars.noccurn 1 oty ->
+| Case (_, _, _, (([|_|], oty),_), _, c, [||]) when Vars.noccurn 1 oty ->
     (* non dependent match on an inductive with no constructors *)
     begin match Constr.kind c with
     | Const (kn, _) when not (Declareops.constant_has_body (lookup_constant kn)) ->

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -820,9 +820,9 @@ let explain_bad_binder_relevance env sigma rlv decl =
     spc () ++ str "(maybe a bugged tactic)."
 
 let explain_bad_case_relevance env sigma rlv case =
-  let (ci, _, _, _, _, _, _) = EConstr.destCase sigma case in
+  let (_, _, _, (_,badr), _, _, _) = EConstr.destCase sigma case in
   strbrk "Pattern-matching" ++ spc () ++ pr_leconstr_env env sigma case ++
-    strbrk " has relevance mark set to " ++ pr_relevance sigma ci.ci_relevance ++
+    strbrk " has relevance mark set to " ++ pr_relevance sigma badr ++
     strbrk " but was expected to be " ++ pr_relevance sigma rlv ++
     spc () ++ str "(maybe a bugged tactic)."
 

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -400,10 +400,10 @@ let build_named_proj ~primitive ~flags ~poly ~univs ~uinstance ~kind env paramde
         let ccl' = liftn 1 2 ccl in
         let p = mkLambda (x, lift 1 rp, ccl') in
         let branch = it_mkLambda_or_LetIn (mkRel nfi) lifted_fields in
-        let ci = Inductiveops.make_case_info env indsp rci LetStyle in
+        let ci = Inductiveops.make_case_info env indsp LetStyle in
         (* Record projections are always NoInvert because they're at
            constant relevance *)
-        mkCase (Inductive.contract_case env (ci, p, NoInvert, mkRel 1, [|branch|])), None
+        mkCase (Inductive.contract_case env (ci, (p, rci), NoInvert, mkRel 1, [|branch|])), None
   in
   let proj = it_mkLambda_or_LetIn (mkLambda (x,rp,body)) paramdecls in
   let projtyp = it_mkProd_or_LetIn (mkProd (x,rp,ccl)) paramdecls in


### PR DESCRIPTION
Since sort poly made universe substitution affect it, it is IMO not appropriate in the should-be-static case_info.

Overlays:
- https://github.com/mit-plv/rewriter/pull/122
- https://github.com/lukaszcz/coqhammer/pull/170
- https://github.com/LPCIC/coq-elpi/pull/541
- https://github.com/mattam82/Coq-Equations/pull/568
- https://github.com/MetaCoq/metacoq/pull/1009
- https://github.com/unicoq/unicoq/pull/89
- https://github.com/Mtac2/Mtac2/pull/396
- https://github.com/coq-community/paramcoq/pull/118
- https://github.com/ejgallego/coq-serapi/pull/368
- https://github.com/coq-tactician/coq-tactician/pull/69
- https://github.com/impermeable/coq-waterproof/pull/37
- https://github.com/mit-plv/fiat-crypto/pull/1713