### PR TITLE
Fix #18281: Make opaque compat. constants convertible to folded prim. projections

### DIFF
--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -80,6 +80,8 @@ val check_native_args : CPrimitives.t -> stack -> bool
 val get_native_args1 : CPrimitives.t -> pconstant -> stack ->
   fconstr list * fconstr * fconstr next_native_args * stack
 
+val drop_parameters : int -> int -> stack -> stack
+
 val stack_args_size : stack -> int
 
 val inductive_subst : Declarations.mutual_inductive_body

--- a/kernel/conversion.ml
+++ b/kernel/conversion.ml
@@ -477,6 +477,18 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
           else (* Two projections in WHNF: unfold *)
             raise NotConvertible)
 
+    | (FProj (p1,_r1,c1), FFlex(ConstKey (p2,_))) when Names.Constant.CanOrd.equal (Names.Projection.constant p1) p2 ->
+      (* TODO: relevance *)
+      let v1 = CClosure.append_stack [|c1|] v1 in
+      let v2 = CClosure.drop_parameters 0 (Names.Projection.npars p1) v2 in
+      convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
+
+    | (FFlex(ConstKey (p1,_)), FProj (p2,_r2,c2)) when Names.Constant.CanOrd.equal p1 (Names.Projection.constant p2) ->
+      (* TODO: relevance *)
+      let v1 = CClosure.drop_parameters 0 (Names.Projection.npars p2) v1 in
+      let v2 = CClosure.append_stack [|c2|] v2 in
+      convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
+
     | (FProj (p1,r1,c1), t2) ->
       begin match unfold_projection infos.cnv_inf p1 r1 with
        | Some s1 ->

--- a/test-suite/bugs/bug_18281.v
+++ b/test-suite/bugs/bug_18281.v
@@ -1,0 +1,36 @@
+Require Import Ltac2.Ltac2.
+
+#[projections(primitive)]
+Record r (n : nat) := { w : Prop -> Prop -> Prop }.
+
+Class C (P : Prop) := {}.
+
+Goal forall (v : r 0) (Q P : Prop), C (v.(w _) P Q).
+Proof.
+  intros.
+
+  (* Succeeds before and after #<TODO>. *)
+  Succeed lazy_match! goal with
+  | [ |- ?g ] =>
+      let t := open_constr:(C (v.(w 0) P Q)) in
+      Unification.unify (TransparentState.current ()) g t
+  end.
+
+  #[local] Opaque w.
+
+  (* Succeeds only after #<TODO>. *)
+  Succeed lazy_match! goal with
+  | [ |- ?g ] =>
+      let t := constr:(w 0) in
+      let t := constr:(C ($t v P Q)) in
+      Unification.unify (TransparentState.current ()) g t
+  end.
+
+  (* Succeeds only after #<TODO>. Symmetric case. *)
+  Succeed lazy_match! goal with
+  | [ |- ?g ] =>
+      let t := constr:(w 0) in
+      let t := constr:(C ($t v P Q)) in
+      Unification.unify (TransparentState.current ()) t g
+  end.
+Abort.


### PR DESCRIPTION
I am not sure what to do about the relevance of the projection.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes #18281


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
