### PR TITLE
Correctly run tests with opam + use in bench

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -147,11 +147,8 @@ before_script:
   script:
     - cd test-suite
     - make clean
-    # careful with the ending /
-    - BIN=$(readlink -f ../_install_ci/bin)/
-    - LIB=$(readlink -f ../_install_ci/lib/coq)/
     - export OCAMLPATH=$(readlink -f ../_install_ci/lib/):"$OCAMLPATH"
-    - COQEXTRAFLAGS="${COQEXTRAFLAGS}" make -j "$NJOBS" BIN="$BIN" COQLIB="$LIB" all
+    - COQEXTRAFLAGS="${COQEXTRAFLAGS}" make -j "$NJOBS" all
   artifacts:
     name: "$CI_JOB_NAME.logs"
     when: on_failure

--- a/coq.opam
+++ b/coq.opam
@@ -44,8 +44,8 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
+    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
-  [ make "-C" "test-suite" "-j" jobs "COQ_INSTALLED=1" "PRINT_LOGS=1" ] {with-test}
   ["dune" "install" "-p" name "--create-install-files" name]
 ]

--- a/coq.opam
+++ b/coq.opam
@@ -26,8 +26,15 @@ depends: [
   "coqide-server" {= version}
   "odoc" {with-doc}
 ]
+dev-repo: "git+https://github.com/coq/coq.git"
 build: [
   ["dune" "subst"] {dev}
+  [ "./configure"
+    "-prefix" prefix
+    "-mandir" man
+    "-libdir" "%{lib}%/coq"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
+  ] {with-test}
   [
     "dune"
     "build"
@@ -37,9 +44,8 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
+  [ make "-C" "test-suite" "-j" jobs "COQ_INSTALLED=1" "PRINT_LOGS=1" ] {with-test}
   ["dune" "install" "-p" name "--create-install-files" name]
 ]
-dev-repo: "git+https://github.com/coq/coq.git"

--- a/coq.opam.template
+++ b/coq.opam.template
@@ -15,8 +15,8 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
+    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
-  [ make "-C" "test-suite" "-j" jobs "COQ_INSTALLED=1" "PRINT_LOGS=1" ] {with-test}
   ["dune" "install" "-p" name "--create-install-files" name]
 ]

--- a/coq.opam.template
+++ b/coq.opam.template
@@ -1,0 +1,22 @@
+build: [
+  ["dune" "subst"] {dev}
+  [ "./configure"
+    "-prefix" prefix
+    "-mandir" man
+    "-libdir" "%{lib}%/coq"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
+  ] {with-test}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@doc" {with-doc}
+  ]
+  [ make "-C" "test-suite" "-j" jobs "COQ_INSTALLED=1" "PRINT_LOGS=1" ] {with-test}
+  ["dune" "install" "-p" name "--create-install-files" name]
+]

--- a/dev/bench/bench.sh
+++ b/dev/bench/bench.sh
@@ -73,6 +73,7 @@ check_variable () {
 : "${timeout:=3h}"
 : "${coq_opam_packages:=coq-bignums coq-hott coq-performance-tests-lite coq-engine-bench-lite coq-mathcomp-ssreflect coq-mathcomp-fingroup coq-mathcomp-algebra coq-mathcomp-solvable coq-mathcomp-field coq-mathcomp-character coq-mathcomp-odd-order coq-math-classes coq-corn coq-compcert coq-equations coq-metacoq-template coq-metacoq-pcuic coq-metacoq-safechecker coq-metacoq-erasure coq-metacoq-translations coq-color coq-coqprime coq-coqutil coq-bedrock2 coq-rewriter coq-fiat-core coq-fiat-parsers coq-fiat-crypto-with-bedrock coq-unimath coq-coquelicot coq-iris-examples coq-verdi coq-verdi-raft coq-fourcolor coq-rewriter-perf-SuperFast coq-perennial coq-vst coq-category-theory}"
 : "${coq_native:=}"
+: "${skip_coq_tests:=}"
 
 : "${new_coq_commit:=$(git rev-parse HEAD^2)}"
 : "${old_coq_commit:=$(git merge-base HEAD^1 $new_coq_commit)}"
@@ -386,8 +387,11 @@ create_opam() {
         local this_nproc=$number_of_processors
         if [ "$package" = coq-stdlib ]; then this_nproc=1; fi
 
+        with_test=--with-test
+        if [ "$skip_coq_tests" ]; then with_test=; fi
+
         _RES=0
-        opam pin add -y -b -j "$this_nproc" --kind=path --with-test $package.dev . \
+        opam pin add -y -b -j "$this_nproc" --kind=path $with_test $package.dev . \
              3>$log_dir/$package.$RUNNER.opam_install.1.stdout.log 1>&3 \
              4>$log_dir/$package.$RUNNER.opam_install.1.stderr.log 2>&4 || \
             _RES=$?

--- a/dev/bench/bench.sh
+++ b/dev/bench/bench.sh
@@ -22,6 +22,8 @@ mkdir "$BIN"
 wget https://github.com/ocaml/opam/releases/download/2.1.3/opam-2.1.3-x86_64-linux -O "$BIN"/opam
 chmod +x "$BIN"/opam
 
+export NJOBS=1 # used by the test suite through dune
+
 export PATH="$BIN":$PATH
 
 echo "Global env info:"

--- a/dev/bench/bench.sh
+++ b/dev/bench/bench.sh
@@ -385,7 +385,7 @@ create_opam() {
         if [ "$package" = coq-stdlib ]; then this_nproc=1; fi
 
         _RES=0
-        opam pin add -y -b -j "$this_nproc" --kind=path $package.dev . \
+        opam pin add -y -b -j "$this_nproc" --kind=path --with-test $package.dev . \
              3>$log_dir/$package.$RUNNER.opam_install.1.stdout.log 1>&3 \
              4>$log_dir/$package.$RUNNER.opam_install.1.stderr.log 2>&4 || \
             _RES=$?
@@ -416,8 +416,8 @@ create_opam "OLD" "$old_ocaml_version" "$old_coq_commit" "$old_coq_opam_archive_
 old_coq_commit_long="$COQ_HASH_LONG"
 
 # Packages which appear in the rendered table
-# Deliberately don't include the dummy "coq" package
-installable_coq_opam_packages="coq-core coq-stdlib"
+# Deliberately don't include the "coqide-server" package
+installable_coq_opam_packages="coq-core coq-stdlib coq"
 
 echo "DEBUG: $render_results $log_dir $num_of_iterations $new_coq_commit_long $old_coq_commit_long 0 user_time_pdiff $installable_coq_opam_packages"
 rendered_results="$($render_results "$log_dir" $num_of_iterations $new_coq_commit_long $old_coq_commit_long 0 user_time_pdiff $installable_coq_opam_packages)"

--- a/dune
+++ b/dune
@@ -57,7 +57,7 @@
 ; Use summary.log as the target
 (alias
  (name runtest)
- (package coqide-server)
+ (package coq)
  (deps test-suite/summary.log))
 
 ; For make compat

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -37,11 +37,9 @@ endif
 # Variables
 #######################################################################
 
-# Using quotes to anticipate the possibility of spaces in the directory name
+# COQPREFIX is quoted to anticipate the possibility of spaces in the directory name
 # Note that this will later need an eval in shell to interpret the quotes
-ROOT='$(shell cd ..; pwd)'
-
-BIN:=$(ROOT)/_build/install/default/bin/
+BIN:=$(COQPREFIX)/bin/
 
 # An alternative is ifeq ($(OS),Windows_NT) using make's own variable.
 ifeq ($(ARCH),win32)

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -530,8 +530,8 @@ $(addsuffix .log,$(wildcard output-modulo-time/*.v)): %.v.log: %.v %.out
 	@echo "TEST      $< $(call get_coq_prog_args_in_parens,"$<")"
 	$(HIDE){ \
 	  echo $(call log_intro,$<); \
-	  tmpoutput=`mktemp /tmp/coqcheck.XXXXXX`; \
-	  tmpexpected=`mktemp /tmp/coqcheck.XXXXXX`; \
+	  tmpoutput=`mktemp`; \
+	  tmpexpected=`mktemp`; \
 	  $(coqc_interactive) "$<" $(call get_coq_prog_args,"$<") 2>&1 \
 	    | grep -v "Welcome to Coq" \
 	    | grep -v "\[Loading ML file" \
@@ -746,7 +746,7 @@ coqwc : $(patsubst %.v,%.v.log,$(wildcard coqwc/*.v))
 coqwc/%.v.log : coqwc/%.v
 	$(HIDE){ \
 	  echo $(call log_intro,$<); \
-	  tmpoutput=`mktemp /tmp/coqwc.XXXXXX`; \
+	  tmpoutput=`mktemp`; \
 	  $(BIN)coqwc $< 2>&1 > $$tmpoutput; \
 	  diff -u --strip-trailing-cr coqwc/$*.out $$tmpoutput 2>&1; R=$$?; times; \
 	  if [ $$R = 0 ]; then \

--- a/test-suite/complexity/pattern.v
+++ b/test-suite/complexity/pattern.v
@@ -1,5 +1,5 @@
 (** Testing the performance of [pattern].  For not regressing on COQBUG(https://github.com/coq/coq/issues/11150) and COQBUG(https://github.com/coq/coq/issues/6502) *)
-(* Expected time < 1.65s *)
+(* Expected time < 2.00s *)
 (* reference: 0.673s after adjustment *)
 Definition Let_In {A P} (v : A) (f : forall x : A, P x) : P v
 := let x := v in f x.

--- a/test-suite/complexity/pretyping.v
+++ b/test-suite/complexity/pretyping.v
@@ -1,5 +1,5 @@
 (* Test parsing/interpretation/pretyping on a large example *)
-(* Expected time < 1.50s *)
+(* Expected time < 2.00s *)
 
 Require Import Reals.
 Require Import Ring_tac.

--- a/test-suite/dune
+++ b/test-suite/dune
@@ -26,6 +26,7 @@
    ../dev/header.ml
    ../dev/tools/update-compat.py
    ../doc/stdlib/index-list.html.template
+   ../sysinit/coqargs.ml
    ; For the misc/printers.sh test
    ../dev/incdir_dune
    ../dev/base_include

--- a/test-suite/dune
+++ b/test-suite/dune
@@ -8,14 +8,6 @@
  (dev (flags :standard -w -70)))
 
 (rule
- (targets libpath.inc)
- (action (with-stdout-to %{targets} (run ./ocaml_pwd.exe -quoted ../../install/%{context_name}/lib/coq/ ))))
-
-(rule
- (targets bin.inc)
- (action (with-stdout-to %{targets} (run ./ocaml_pwd.exe -quoted -trailing-slash ../../install/%{context_name}/bin/ ))))
-
-(rule
  (targets summary.log)
  (deps
    ; File that should be promoted.
@@ -52,4 +44,4 @@
    ; %{bin:fake_ide}
  (action
   (progn
-   (bash "make -j %{env:NJOBS=2} BIN=%{read:bin.inc} COQLIB=%{read:libpath.inc} PRINT_LOGS=1 UNIT_TESTS=%{env:COQ_UNIT_TEST=unit-tests}"))))
+   (bash "make -j %{env:NJOBS=2} PRINT_LOGS=1 UNIT_TESTS=%{env:COQ_UNIT_TEST=unit-tests}"))))

--- a/test-suite/misc/deps-order-distinct-root.sh
+++ b/test-suite/misc/deps-order-distinct-root.sh
@@ -3,9 +3,9 @@
 # Check that both coqdep and coqtop/coqc take the latter -R
 # See also bugs #2242, #2337, #2339
 rm -f misc/deps/DistinctRoot/*.vo misc/deps/DistinctRoot/*.vo/{A,B}/*.vo
-tmpoutput=$(mktemp /tmp/coqcheck.XXXXXX)
-(cd misc/deps; $coqdep -f _CoqDistinctRoot) > "$tmpoutput" 2>&1
-diff -u --strip-trailing-cr misc/deps/DistinctRootDeps.out "$tmpoutput"
+output=misc/deps/DistinctRootDeps.real
+(cd misc/deps; $coqdep -f _CoqDistinctRoot) > "$output" 2>&1
+diff -u --strip-trailing-cr misc/deps/DistinctRootDeps.out "$output"
 R=$?
 times
 $coqc -R misc/deps/DistinctRoot/A A -R misc/deps/DistinctRoot/B B misc/deps/DistinctRoot/A/File1.v

--- a/test-suite/misc/deps-order-from.sh
+++ b/test-suite/misc/deps-order-from.sh
@@ -3,9 +3,9 @@
 # Check that both coqdep and coqtop/coqc take the latter -R
 # See bugs #11631, #14539
 rm -f misc/deps/test-from/A/C.vo misc/deps/test-from/B/C.vo misc/deps/test-from/D.vo misc/deps/test-from/E.vo
-tmpoutput=$(mktemp /tmp/coqcheck.XXXXXX)
-$coqdep -R misc/deps/test-from T misc/deps/test-from/D.v misc/deps/test-from/E.v > "$tmpoutput" 2>&1
-diff -u --strip-trailing-cr misc/deps/deps-from.out "$tmpoutput"
+output=misc/deps/deps-from.real
+$coqdep -R misc/deps/test-from T misc/deps/test-from/D.v misc/deps/test-from/E.v > "$output" 2>&1
+diff -u --strip-trailing-cr misc/deps/deps-from.out "$output"
 R=$?
 times
 $coqc -R misc/deps/test-from T misc/deps/test-from/A/C.v

--- a/test-suite/misc/deps-order-subdir1-file.sh
+++ b/test-suite/misc/deps-order-subdir1-file.sh
@@ -2,9 +2,9 @@
 # Check that both coqdep and coqtop/coqc takes a file matching exactly
 # the logical path (if any)
 rm -f misc/deps/Theory1/*.vo misc/deps/Theory1/Subtheory?/*.vo misc/deps/Theory1/Subtheory?/Subsubtheory?/*.vo
-tmpoutput=$(mktemp /tmp/coqcheck.XXXXXX)
-(cd misc/deps; $coqdep -f _CoqTheory1Project) > "$tmpoutput" 2>&1
-diff -u --strip-trailing-cr misc/deps/Theory1Deps.out "$tmpoutput"
+output=misc/deps/Theory1Deps.real
+(cd misc/deps; $coqdep -f _CoqTheory1Project) > "$output" 2>&1
+diff -u --strip-trailing-cr misc/deps/Theory1Deps.out "$output"
 R=$?
 times
 $coqc -Q misc/deps/Theory1 Theory misc/deps/Theory1/File1.v

--- a/test-suite/misc/deps-order-subdir2-file.sh
+++ b/test-suite/misc/deps-order-subdir2-file.sh
@@ -7,9 +7,9 @@
 dotest=true
 if [ $dotest = false ]; then exit 0; fi
 rm -f misc/deps/Theory2/*.vo misc/deps/Theory2/Subtheory?/*.vo misc/deps/Theory2/Subtheory?/Subsubtheory?/*.vo
-tmpoutput=$(mktemp /tmp/coqcheck.XXXXXX)
-(cd misc/deps; $coqdep -f _CoqTheory2Project) > "$tmpoutput" 2>&1
-diff -u --strip-trailing-cr misc/deps/Theory2Deps.out $tmpoutput
+output=misc/deps/Theory2Deps.real
+(cd misc/deps; $coqdep -f _CoqTheory2Project) > "$output" 2>&1
+diff -u --strip-trailing-cr misc/deps/Theory2Deps.out $output
 R=$?
 if [ $R != 0 ]; then
     printf "Unexpected coqdep result.\n"

--- a/test-suite/misc/deps-order-subdir3-file.sh
+++ b/test-suite/misc/deps-order-subdir3-file.sh
@@ -8,9 +8,9 @@
 dotest=true
 if [ $dotest = false ]; then exit 0; fi
 rm -f misc/deps/Theory3/*.vo misc/deps/Theory3/Subtheory?/*.vo misc/deps/Theory3/Subtheory?/Subsubtheory?/*.vo
-tmpoutput=$(mktemp /tmp/coqcheck.XXXXXX)
-(cd misc/deps; $coqdep -f _CoqTheory3Project) > "$tmpoutput" 2>&1
-diff -u --strip-trailing-cr misc/deps/Theory3Deps.out $tmpoutput
+output=misc/deps/Theory3Deps.real
+(cd misc/deps; $coqdep -f _CoqTheory3Project) > "$output" 2>&1
+diff -u --strip-trailing-cr misc/deps/Theory3Deps.out $output
 R=$?
 if [ $R != 0 ]; then
     printf "Unexpected coqdep result.\n"

--- a/test-suite/misc/deps-order.sh
+++ b/test-suite/misc/deps-order.sh
@@ -3,9 +3,9 @@
 # Check that both coqdep and coqtop/coqc takes the later -R
 # See bugs 2242, 2337, 2339
 rm -f misc/deps/lib/*.vo misc/deps/client/*.vo
-tmpoutput=$(mktemp /tmp/coqcheck.XXXXXX)
-$coqdep -R misc/deps/lib lib -R misc/deps/client client misc/deps/client/bar.v 2>&1 | head -n 1 > "$tmpoutput"
-diff -u --strip-trailing-cr misc/deps/deps.out "$tmpoutput" 2>&1
+output=misc/deps/deps.real
+$coqdep -R misc/deps/lib lib -R misc/deps/client client misc/deps/client/bar.v 2>&1 | head -n 1 > "$output"
+diff -u --strip-trailing-cr misc/deps/deps.out "$output" 2>&1
 R=$?
 times
 $coqc -R misc/deps/lib lib misc/deps/lib/foo.v 2>&1

--- a/test-suite/misc/deps-utf8.sh
+++ b/test-suite/misc/deps-utf8.sh
@@ -5,7 +5,7 @@
 a=$(uname)
 if [ "$a" = "Darwin" ] || [ "$a" = "Linux" ]; then
 rm -f misc/deps/théorèmes/*.v
-tmpoutput=$(mktemp /tmp/coqcheck.XXXXXX)
+
 $coqc -R misc/deps AlphaBêta misc/deps/αβ/γδ.v
 R=$?
 $coqc -R misc/deps AlphaBêta misc/deps/αβ/εζ.v

--- a/test-suite/misc/external-deps.sh
+++ b/test-suite/misc/external-deps.sh
@@ -2,26 +2,28 @@
 
 set -e
 
-tmpoutput=$(mktemp /tmp/coqcheck.XXXXXX)
-
 # Set Extra Dependency syntax
-$coqdep -Q misc/external-deps/deps foo.bar misc/external-deps/file1.v > $tmpoutput 2>&1
-diff -u --strip-trailing-cr misc/external-deps/file1.found.deps $tmpoutput
+output=misc/external-deps/file1.found.real
+$coqdep -Q misc/external-deps/deps foo.bar misc/external-deps/file1.v > $output 2>&1
+diff -u --strip-trailing-cr misc/external-deps/file1.found.deps $output
 
-$coqdep -Q misc/external-deps/deps foo.bar -Q misc/external-deps/more foo.bar misc/external-deps/file1.v > $tmpoutput 2>&1
-diff -u --strip-trailing-cr misc/external-deps/file1.ambiguous.deps $tmpoutput
+output=misc/external-deps/file1.ambiguous.real
+$coqdep -Q misc/external-deps/deps foo.bar -Q misc/external-deps/more foo.bar misc/external-deps/file1.v > $output 2>&1
+diff -u --strip-trailing-cr misc/external-deps/file1.ambiguous.deps $output
 
-$coqdep misc/external-deps/file1.v > $tmpoutput 2>&1
-diff -u --strip-trailing-cr misc/external-deps/file1.notfound.deps $tmpoutput
+output=misc/external-deps/file1.notfound.real
+$coqdep misc/external-deps/file1.v > $output 2>&1
+diff -u --strip-trailing-cr misc/external-deps/file1.notfound.deps $output
 
 # From bla Extra Dependency syntax
-$coqdep -Q misc/external-deps/deps foo.bar misc/external-deps/file2.v > $tmpoutput 2>&1
-diff -u --strip-trailing-cr misc/external-deps/file2.found.deps $tmpoutput
+output=misc/external-deps/file2.found.real
+$coqdep -Q misc/external-deps/deps foo.bar misc/external-deps/file2.v > $output 2>&1
+diff -u --strip-trailing-cr misc/external-deps/file2.found.deps $output
 
-$coqdep -Q misc/external-deps/deps foo.bar -Q misc/external-deps/more foo.bar misc/external-deps/file2.v > $tmpoutput 2>&1
-diff -u --strip-trailing-cr misc/external-deps/file2.ambiguous.deps $tmpoutput
+output=misc/external-deps/file2.ambiguous.real
+$coqdep -Q misc/external-deps/deps foo.bar -Q misc/external-deps/more foo.bar misc/external-deps/file2.v > $output 2>&1
+diff -u --strip-trailing-cr misc/external-deps/file2.ambiguous.deps $output
 
-$coqdep misc/external-deps/file2.v > $tmpoutput 2>&1
-diff -u --strip-trailing-cr misc/external-deps/file2.notfound.deps $tmpoutput
-
-rm -f $tmpoutput
+output=misc/external-deps/file2.notfound.real
+$coqdep misc/external-deps/file2.v > $output 2>&1
+diff -u --strip-trailing-cr misc/external-deps/file2.notfound.deps $output

--- a/test-suite/report.sh
+++ b/test-suite/report.sh
@@ -11,7 +11,7 @@ SAVEDIR="logs"
 rm -rf "$SAVEDIR"
 mkdir "$SAVEDIR"
 
-FAILED=$(mktemp /tmp/coq-check-XXXXXX)
+FAILED=$(mktemp)
 find . '(' -name '*.log' -exec grep -q -F "Error!" '{}' ';' -print0 ')' > "$FAILED"
 
 rsync -a --from0 --files-from="$FAILED" . "$SAVEDIR"


### PR DESCRIPTION
I have no clue how to get it to work with dune so I call make directly.

We make test suite get BIN from configure.
(COQLIB was already found that way)
We also use this in CI test-suite-template instead of passing them
through the command line.

Close #17923

Might be worth adding `--with-test` in the CI `pkg:opam` script?

TODO:
- [x] some way to avoid running tests in bench so we can bench old commits