### PR TITLE
Doc: don't hide unsafe declarations of inductives

### DIFF
--- a/doc/sphinx/language/core/inductive.rst
+++ b/doc/sphinx/language/core/inductive.rst
@@ -901,7 +901,7 @@ between universes for inductive types in the Type hierarchy.
    contradiction from it (we can test this by disabling the
    :flag:`Positivity Checking` flag):
 
-   .. coqtop:: none
+   .. coqtop:: in
 
       #[bypass_check(positivity)] Inductive I : Prop := not_I_I (not_I : I -> False) : I.
 
@@ -935,7 +935,7 @@ between universes for inductive types in the Type hierarchy.
    Again, if we were to accept it, we could derive a contradiction
    (this time through a non-terminating recursive function):
 
-   .. coqtop:: none
+   .. coqtop:: in
 
       #[bypass_check(positivity)] Inductive Lam := lam (_ : Lam -> Lam).
 
@@ -964,7 +964,7 @@ between universes for inductive types in the Type hierarchy.
    the type :math:`A` with the function :math:`λx. λz. z = x` injecting
    any type :math:`T` into :math:`T → \Prop`.
 
-   .. coqtop:: none
+   .. coqtop:: in
 
       #[bypass_check(positivity)] Inductive A: Type := introA: ((A -> Prop) -> Prop) -> A.
 


### PR DESCRIPTION
Hiding them makes the following uses hard to understand as the inductive appears from nowhere.

cf https://coq.zulipchat.com/#narrow/stream/237977-Coq-users/topic/Non.20strictly.20positive.20occurrence.20exampl.2C.20COQManual.20problem.3F
