### PR TITLE
Guard profiling with a flag in Ltac2.

### DIFF
--- a/doc/changelog/06-Ltac2-language/18293-br-ltac2-profiling.rst
+++ b/doc/changelog/06-Ltac2-language/18293-br-ltac2-profiling.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  A new flag :flag:`Ltac2 In Ltac1 Profiling` (unset by default) to control
+  whether Ltac2 stack frames are included in Ltac profiles
+  (`#18293 <https://github.com/coq/coq/pull/18293>`_,
+  by Rodolphe Lepigre).

--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -1751,6 +1751,14 @@ Debug
 
    When this :term:`flag` is set, toplevel failures will be printed with a backtrace.
 
+Profiling
+---------
+
+.. flag:: Ltac2 In Ltac1 Profiling
+
+   When this :term:`flag` and :flag:`Ltac Profiling` are set, profiling data is gathered for Ltac2 via the
+   Ltac profiler. It is unset by default.
+
 Compatibility layer with Ltac1
 ------------------------------
 

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -965,14 +965,6 @@ let register_struct atts str = match str with
 
 (** Toplevel exception *)
 
-let () = Goptions.declare_bool_option {
-  Goptions.optstage = Summary.Stage.Interp;
-  Goptions.optdepr = None;
-  Goptions.optkey = ["Ltac2"; "Backtrace"];
-  Goptions.optread = (fun () -> !Tac2bt.print_ltac2_backtrace);
-  Goptions.optwrite = (fun b -> Tac2bt.print_ltac2_backtrace := b);
-}
-
 let pr_frame = function
 | FrAnon e -> str "Call {" ++ pr_glbexpr ~avoid:Id.Set.empty e ++ str "}"
 | FrLtac kn ->


### PR DESCRIPTION
@Janno recently noticed that using `Ltac Profiling` in our large development had become very slow since https://github.com/coq/coq/pull/17371. However, for us at least, it is sometimes useful to get profiling information just for Ltac1. 

This PR lets one control whether profiling for Ltac2 is enabled using a new flag `Ltac2 In Ltac1 Profiling`.