### PR TITLE
Introduce a dedicated type for evar kinds in raw / glob terms

### DIFF
--- a/dev/ci/user-overlays/18294-ppedrot-glob-evar-kinds.sh
+++ b/dev/ci/user-overlays/18294-ppedrot-glob-evar-kinds.sh
@@ -1,0 +1,13 @@
+overlay bignums https://github.com/ppedrot/bignums glob-evar-kinds 18294
+
+overlay elpi https://github.com/ppedrot/coq-elpi glob-evar-kinds 18294
+
+overlay equations https://github.com/ppedrot/Coq-Equations glob-evar-kinds 18294
+
+overlay metacoq https://github.com/ppedrot/metacoq glob-evar-kinds 18294
+
+overlay quickchick https://github.com/ppedrot/QuickChick glob-evar-kinds 18294
+
+overlay serapi https://github.com/ppedrot/coq-serapi glob-evar-kinds 18294
+
+overlay tactician https://github.com/ppedrot/coq-tactician glob-evar-kinds 18294

--- a/engine/evar_kinds.ml
+++ b/engine/evar_kinds.ml
@@ -55,7 +55,7 @@ type t =
 type glob_evar_kind =
   | GImplicitArg of GlobRef.t * (int * Id.t option) * bool (** Force inference *)
   | GBinderType of Name.t
-  | GNamedHole of Id.t (* coming from some ?[id] syntax *)
+  | GNamedHole of bool (* fresh? *) * Id.t (* coming from some ?[id] syntax *)
   | GQuestionMark of question_mark
   | GCasesType
   | GInternalHole

--- a/engine/evar_kinds.ml
+++ b/engine/evar_kinds.ml
@@ -51,3 +51,12 @@ type t =
   | MatchingVar of matching_var_kind
   | VarInstance of Id.t
   | SubEvar of subevar_kind option * Evar.t
+
+type glob_evar_kind =
+  | GImplicitArg of GlobRef.t * (int * Id.t option) * bool (** Force inference *)
+  | GBinderType of Name.t
+  | GNamedHole of Id.t (* coming from some ?[id] syntax *)
+  | GQuestionMark of question_mark
+  | GCasesType
+  | GInternalHole
+  | GImpossibleCase

--- a/engine/evar_kinds.mli
+++ b/engine/evar_kinds.mli
@@ -54,7 +54,7 @@ type t =
 type glob_evar_kind =
   | GImplicitArg of GlobRef.t * (int * Id.t option) * bool (** Force inference *)
   | GBinderType of Name.t
-  | GNamedHole of Id.t (* coming from some ?[id] syntax *)
+  | GNamedHole of bool (* fresh? *) * Id.t (* coming from some ?[id] syntax *)
   | GQuestionMark of question_mark
   | GCasesType
   | GInternalHole

--- a/engine/evar_kinds.mli
+++ b/engine/evar_kinds.mli
@@ -50,3 +50,12 @@ type t =
   | MatchingVar of matching_var_kind
   | VarInstance of Id.t
   | SubEvar of subevar_kind option * Evar.t
+
+type glob_evar_kind =
+  | GImplicitArg of GlobRef.t * (int * Id.t option) * bool (** Force inference *)
+  | GBinderType of Name.t
+  | GNamedHole of Id.t (* coming from some ?[id] syntax *)
+  | GQuestionMark of question_mark
+  | GCasesType
+  | GInternalHole
+  | GImpossibleCase

--- a/interp/constrexpr.mli
+++ b/interp/constrexpr.mli
@@ -151,7 +151,7 @@ and constr_expr_r =
                  constr_expr * constr_expr
   | CIf of constr_expr * (lname option * constr_expr option)
          * constr_expr * constr_expr
-  | CHole   of Evar_kinds.t option * Namegen.intro_pattern_naming_expr
+  | CHole   of Evar_kinds.glob_evar_kind option * Namegen.intro_pattern_naming_expr
   | CGenarg of Genarg.raw_generic_argument
 
   (* because print for genargs wants to print directly the glob without an extern phase (??) *)

--- a/interp/constrexpr.mli
+++ b/interp/constrexpr.mli
@@ -151,7 +151,7 @@ and constr_expr_r =
                  constr_expr * constr_expr
   | CIf of constr_expr * (lname option * constr_expr option)
          * constr_expr * constr_expr
-  | CHole   of Evar_kinds.glob_evar_kind option * Namegen.intro_pattern_naming_expr
+  | CHole   of Evar_kinds.glob_evar_kind option
   | CGenarg of Genarg.raw_generic_argument
 
   (* because print for genargs wants to print directly the glob without an extern phase (??) *)

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -1393,7 +1393,7 @@ let extern_closed_glob ?(goal_concl_style=false) ?(inctx=false) ?scope env sigma
 
 let any_any_branch =
   (* | _ => _ *)
-  CAst.make ([],[DAst.make @@ PatVar Anonymous], DAst.make @@ GHole (Evar_kinds.InternalHole,IntroAnonymous))
+  CAst.make ([],[DAst.make @@ PatVar Anonymous], DAst.make @@ GHole (GInternalHole, IntroAnonymous))
 
 let compute_displayed_name_in_pattern sigma avoid na c =
   let open Namegen in
@@ -1420,7 +1420,7 @@ let rec glob_of_pat avoid env sigma pat = DAst.make @@ match pat with
             anomaly ~label:"glob_constr_of_pattern" (Pp.str "index to an anonymous variable.")
       with Not_found -> Id.of_string ("_UNBOUND_REL_"^(string_of_int n)) in
       GVar id
-  | PMeta None -> GHole (Evar_kinds.InternalHole, IntroAnonymous)
+  | PMeta None -> GHole (GInternalHole, IntroAnonymous)
   | PMeta (Some n) -> GPatVar (Evar_kinds.FirstOrderPatVar n)
   | PProj (p,c) -> GApp (DAst.make @@ GRef (GlobRef.ConstRef (Projection.constant p),None),
                          [glob_of_pat avoid env sigma c])

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -16,7 +16,6 @@ open Names
 open Nameops
 open Termops
 open Libnames
-open Namegen
 open Impargs
 open CAst
 open Notation
@@ -75,7 +74,7 @@ let print_raw_literal = ref false
 
 (**********************************************************************)
 
-let hole = CAst.make @@ CHole (None, IntroAnonymous)
+let hole = CAst.make @@ CHole (None)
 
 let is_reserved_type na t =
   not !Flags.raw_print && print_use_implicit_types () &&
@@ -819,7 +818,8 @@ let extended_glob_local_binder_of_decl loc = function
   | (p,bk,Some x, t) ->
     assert (bk = Explicit);
     match DAst.get t with
-    | GHole (_, IntroAnonymous) -> GLocalDef (p,x,None)
+    | GHole (GNamedHole _) -> GLocalDef (p,x,Some t)
+    | GHole _ -> GLocalDef (p,x,None)
     | _ -> GLocalDef (p,x,Some t)
 
 let extended_glob_local_binder_of_decl ?loc u = DAst.make ?loc (extended_glob_local_binder_of_decl loc u)
@@ -950,13 +950,13 @@ let rec extern inctx ?impargs scopes vars r =
 
   | GVar id -> extern_var ?loc id
 
-  | GEvar (n,[]) when !print_meta_as_hole -> CHole (None, IntroAnonymous)
+  | GEvar (n,[]) when !print_meta_as_hole -> CHole (None)
 
   | GEvar (n,l) ->
       extern_evar n (List.map (on_snd (extern false scopes vars)) l)
 
   | GPatVar kind ->
-      if !print_meta_as_hole then CHole (None, IntroAnonymous) else
+      if !print_meta_as_hole then CHole (None) else
        (match kind with
          | Evar_kinds.SecondOrderPatVar n -> CPatVar n
          | Evar_kinds.FirstOrderPatVar n -> CEvar (CAst.make n,[]))
@@ -1076,7 +1076,7 @@ let rec extern inctx ?impargs scopes vars r =
 
   | GSort s -> CSort (extern_glob_sort (snd vars) s)
 
-  | GHole (e,naming) -> CHole (Some e, naming)
+  | GHole e -> CHole (Some e)
 
   | GGenarg arg -> CGenargGlob arg
 
@@ -1393,7 +1393,7 @@ let extern_closed_glob ?(goal_concl_style=false) ?(inctx=false) ?scope env sigma
 
 let any_any_branch =
   (* | _ => _ *)
-  CAst.make ([],[DAst.make @@ PatVar Anonymous], DAst.make @@ GHole (GInternalHole, IntroAnonymous))
+  CAst.make ([],[DAst.make @@ PatVar Anonymous], DAst.make @@ GHole (GInternalHole))
 
 let compute_displayed_name_in_pattern sigma avoid na c =
   let open Namegen in
@@ -1420,7 +1420,7 @@ let rec glob_of_pat avoid env sigma pat = DAst.make @@ match pat with
             anomaly ~label:"glob_constr_of_pattern" (Pp.str "index to an anonymous variable.")
       with Not_found -> Id.of_string ("_UNBOUND_REL_"^(string_of_int n)) in
       GVar id
-  | PMeta None -> GHole (GInternalHole, IntroAnonymous)
+  | PMeta None -> GHole (GInternalHole)
   | PMeta (Some n) -> GPatVar (Evar_kinds.FirstOrderPatVar n)
   | PProj (p,c) -> GApp (DAst.make @@ GRef (GlobRef.ConstRef (Projection.constant p),None),
                          [glob_of_pat avoid env sigma c])

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -705,7 +705,7 @@ let rec postprocess token_kind ?loc ty to_post post g =
   let rec f n a gl = match a, gl with
     | [], [] -> []
     | ToPostHole :: a, gl ->
-       let e = Evar_kinds.ImplicitArg (r, (n, None), true) in
+       let e = GImplicitArg (r, (n, None), true) in
        let h = DAst.make ?loc (Glob_term.GHole (e, Namegen.IntroAnonymous)) in
        h :: f (n+1) a gl
     | (ToPostCopy | ToPostCheck _) :: a, g :: gl -> g :: f (n+1) a gl

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -706,7 +706,7 @@ let rec postprocess token_kind ?loc ty to_post post g =
     | [], [] -> []
     | ToPostHole :: a, gl ->
        let e = GImplicitArg (r, (n, None), true) in
-       let h = DAst.make ?loc (Glob_term.GHole (e, Namegen.IntroAnonymous)) in
+       let h = DAst.make ?loc (Glob_term.GHole e) in
        h :: f (n+1) a gl
     | (ToPostCopy | ToPostCheck _) :: a, g :: gl -> g :: f (n+1) a gl
     | ToPostAs c :: a, g :: gl ->

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -327,11 +327,11 @@ let rec cases_pattern_fold_map ?loc g e = DAst.with_val (function
   )
 
 let subst_binder_type_vars l = function
-  | Evar_kinds.BinderType (Name id) ->
+  | GBinderType (Name id) ->
      let id =
        try match DAst.get (Id.List.assoc id l) with GVar id' -> id' | _ -> id
        with Not_found -> id in
-     Evar_kinds.BinderType (Name id)
+     GBinderType (Name id)
   | e -> e
 
 let rec subst_glob_vars l gc = DAst.map (function
@@ -384,7 +384,7 @@ let protect g e na =
   e',na
 
 let set_anonymous_type na = function
-  | None -> DAst.make @@ GHole (Evar_kinds.BinderType na, IntroAnonymous)
+  | None -> DAst.make @@ GHole (GBinderType na, IntroAnonymous)
   | Some t -> t
 
 let apply_cases_pattern_term ?loc (ids,disjpat) tm c =
@@ -714,7 +714,7 @@ let notation_constr_and_vars_of_glob_constr recvars a =
       user_err Pp.(str "Existential variables not allowed in notations.")
   ) x
   and aux_type t = DAst.with_val (function
-  | GHole (Evar_kinds.BinderType _,IntroAnonymous) -> None
+  | GHole (GBinderType _, IntroAnonymous) -> None
   | _ -> Some (aux t)) t
   in
   let t = aux a in
@@ -911,9 +911,9 @@ let rec subst_notation_constr subst bound raw =
 
   | NHole (knd, naming) ->
     let nknd = match knd with
-    | Evar_kinds.ImplicitArg (ref, i, b) ->
+    | GImplicitArg (ref, i, b) ->
       let nref, _ = subst_global subst ref in
-      if nref == ref then knd else Evar_kinds.ImplicitArg (nref, i, b)
+      if nref == ref then knd else GImplicitArg (nref, i, b)
     | _ -> knd
     in
     if nknd == knd then raw
@@ -955,7 +955,7 @@ let abstract_return_type_context pi mklam tml rtno =
 let abstract_return_type_context_glob_constr tml rtn =
   abstract_return_type_context (fun {CAst.v=(_,nal)} -> nal)
     (fun na c -> DAst.make @@
-      GLambda(na,Explicit,DAst.make @@ GHole(Evar_kinds.InternalHole,IntroAnonymous),c)) tml rtn
+      GLambda(na,Explicit,DAst.make @@ GHole (GInternalHole, IntroAnonymous), c)) tml rtn
 
 let abstract_return_type_context_notation_constr tml rtn =
   abstract_return_type_context snd
@@ -1558,7 +1558,7 @@ let rec match_ inner u alp metas sigma a1 a2 =
       let avoid =
         Id.Set.union (free_glob_vars a1) (* as in Namegen: *) (glob_visible_short_qualid a1) in
       let id' = Namegen.next_ident_away id avoid in
-      let t1 = DAst.make @@ GHole(Evar_kinds.BinderType (Name id'),IntroAnonymous) in
+      let t1 = DAst.make @@ GHole (GBinderType (Name id'),IntroAnonymous) in
       let sigma = match t2 with
       | None -> sigma
       | Some (NVar id2) -> bind_term_env alp sigma id2 t1
@@ -1674,7 +1674,7 @@ let group_by_type ids (terms,termlists,binders,binderlists) =
            | GLocalPattern ((disjpat,_),_,_,_) ->
              List.map (glob_constr_of_cases_pattern (Global.env())) disjpat
            | GLocalAssum (Anonymous,bk,t) ->
-             let hole = DAst.make (GHole (Evar_kinds.BinderType Anonymous,IntroAnonymous)) in
+             let hole = DAst.make (GHole (GBinderType Anonymous,IntroAnonymous)) in
              [DAst.make (GCast (hole, Some DEFAULTcast, t))]
            | GLocalAssum (Name id,bk,t) ->
              [DAst.make (GCast (DAst.make (GVar id), Some DEFAULTcast, t))]

--- a/interp/notation_term.mli
+++ b/interp/notation_term.mli
@@ -25,7 +25,7 @@ type notation_constr =
   | NVar of Id.t
   | NApp of notation_constr * notation_constr list
   | NProj of (Constant.t * glob_instance option) * notation_constr list * notation_constr
-  | NHole of glob_evar_kind * Namegen.intro_pattern_naming_expr
+  | NHole of glob_evar_kind
   | NGenarg of Genarg.glob_generic_argument
   | NList of Id.t * Id.t * notation_constr * notation_constr * (* associativity: *) bool
   (* Part only in [glob_constr] *)

--- a/interp/notation_term.mli
+++ b/interp/notation_term.mli
@@ -25,7 +25,7 @@ type notation_constr =
   | NVar of Id.t
   | NApp of notation_constr * notation_constr list
   | NProj of (Constant.t * glob_instance option) * notation_constr list * notation_constr
-  | NHole of Evar_kinds.t * Namegen.intro_pattern_naming_expr
+  | NHole of glob_evar_kind * Namegen.intro_pattern_naming_expr
   | NGenarg of Genarg.glob_generic_argument
   | NList of Id.t * Id.t * notation_constr * notation_constr * (* associativity: *) bool
   (* Part only in [glob_constr] *)

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -30,7 +30,7 @@ let ldots_var = Id.of_string ".."
 
 let binder_of_name expl { CAst.loc = loc; v = na } =
   CLocalAssum ([CAst.make ?loc na], Default expl,
-    CAst.make ?loc @@ CHole (Some (Evar_kinds.BinderType na), IntroAnonymous))
+    CAst.make ?loc @@ CHole (Some (GBinderType na), IntroAnonymous))
 
 let binders_of_names l =
   List.map (binder_of_name Explicit) l

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -19,7 +19,6 @@ open Glob_term
 open Constrexpr
 open Constrexpr_ops
 open Util
-open Namegen
 
 open Pcoq
 open Pcoq.Prim
@@ -30,7 +29,7 @@ let ldots_var = Id.of_string ".."
 
 let binder_of_name expl { CAst.loc = loc; v = na } =
   CLocalAssum ([CAst.make ?loc na], Default expl,
-    CAst.make ?loc @@ CHole (Some (GBinderType na), IntroAnonymous))
+    CAst.make ?loc @@ CHole (Some (GBinderType na)))
 
 let binders_of_names l =
   List.map (binder_of_name Explicit) l
@@ -296,9 +295,9 @@ GRAMMAR EXTEND Gram
   ;
   atomic_constr:
     [ [ s = sort   -> { CAst.make ~loc @@ CSort s }
-      | "_"      -> { CAst.make ~loc @@ CHole (None, IntroAnonymous) }
-      | "?"; "["; id = identref; "]"  -> { CAst.make ~loc @@  CHole (None, IntroIdentifier id.CAst.v) }
-      | "?"; "["; id = pattern_ident; "]"  -> { CAst.make ~loc @@  CHole (None, IntroFresh id.CAst.v) }
+      | "_"      -> { CAst.make ~loc @@ CHole (None) }
+      | "?"; "["; id = identref; "]"  -> { CAst.make ~loc @@  CHole (Some (GNamedHole (false, id.CAst.v))) }
+      | "?"; "["; id = pattern_ident; "]"  -> { CAst.make ~loc @@  CHole (Some (GNamedHole (true, id.CAst.v))) }
       | id = pattern_ident; inst = evar_instance -> { CAst.make ~loc @@ CEvar(id,inst) } ] ]
   ;
   inst:
@@ -440,7 +439,7 @@ GRAMMAR EXTEND Gram
         { binders_of_names (id::idl) @ bl }
       | id1 = name; ".."; id2 = name ->
         { [CLocalAssum ([id1;(CAst.make ~loc (Name ldots_var));id2],
-                        Default Explicit, CAst.make ~loc @@ CHole (None, IntroAnonymous))] }
+                        Default Explicit, CAst.make ~loc @@ CHole (None))] }
       | bl = closed_binder; bl' = binders ->
         { bl@bl' } ] ]
   ;
@@ -448,7 +447,7 @@ GRAMMAR EXTEND Gram
     [ [ l = LIST0 binder -> { List.flatten l } ] ]
   ;
   binder:
-    [ [ id = name -> { [CLocalAssum ([id],Default Explicit, CAst.make ~loc @@ CHole (None, IntroAnonymous))] }
+    [ [ id = name -> { [CLocalAssum ([id],Default Explicit, CAst.make ~loc @@ CHole (None))] }
       | bl = closed_binder -> { bl } ] ]
   ;
   closed_binder:
@@ -463,21 +462,21 @@ GRAMMAR EXTEND Gram
       | "("; id = name; ":"; t = lconstr; ":="; c = lconstr; ")" ->
         { [CLocalDef (id,c,Some t)] }
       | "{"; id = name; "}" ->
-        { [CLocalAssum ([id],Default MaxImplicit, CAst.make ~loc @@ CHole (None, IntroAnonymous))] }
+        { [CLocalAssum ([id],Default MaxImplicit, CAst.make ~loc @@ CHole (None))] }
       | "{"; id = name; idl = LIST1 name; ":"; c = lconstr; "}" ->
         { [CLocalAssum (id::idl,Default MaxImplicit,c)] }
       | "{"; id = name; ":"; c = lconstr; "}" ->
         { [CLocalAssum ([id],Default MaxImplicit,c)] }
       | "{"; id = name; idl = LIST1 name; "}" ->
-        { List.map (fun id -> CLocalAssum ([id],Default MaxImplicit, CAst.make ~loc @@ CHole (None, IntroAnonymous))) (id::idl) }
+        { List.map (fun id -> CLocalAssum ([id],Default MaxImplicit, CAst.make ~loc @@ CHole (None))) (id::idl) }
       | "["; id = name; "]" ->
-        { [CLocalAssum ([id],Default NonMaxImplicit, CAst.make ~loc @@ CHole (None, IntroAnonymous))] }
+        { [CLocalAssum ([id],Default NonMaxImplicit, CAst.make ~loc @@ CHole (None))] }
       | "["; id = name; idl = LIST1 name; ":"; c = lconstr; "]" ->
         { [CLocalAssum (id::idl,Default NonMaxImplicit,c)] }
       | "["; id = name; ":"; c = lconstr; "]" ->
         { [CLocalAssum ([id],Default NonMaxImplicit,c)] }
       | "["; id = name; idl = LIST1 name; "]" ->
-        { List.map (fun id -> CLocalAssum ([id],Default NonMaxImplicit, CAst.make ~loc @@ CHole (None, IntroAnonymous))) (id::idl) }
+        { List.map (fun id -> CLocalAssum ([id],Default NonMaxImplicit, CAst.make ~loc @@ CHole (None))) (id::idl) }
       | "`("; tc = LIST1 typeclass_constraint SEP "," ; ")" ->
         { List.map (fun (n, b, t) -> CLocalAssum ([n], Generalized (Explicit, b), t)) tc }
       | "`{"; tc = LIST1 typeclass_constraint SEP "," ; "}" ->
@@ -510,7 +509,7 @@ GRAMMAR EXTEND Gram
   ;
   type_cstr:
     [ [ ":"; c = lconstr -> { c }
-      | -> { CAst.make ~loc @@ CHole (None, IntroAnonymous) } ] ]
+      | -> { CAst.make ~loc @@ CHole (None) } ] ]
   ;
   let_type_cstr:
     [ [ c = OPT [":"; c = lconstr -> { c } ] -> { Loc.tag ~loc c } ] ]

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -449,7 +449,7 @@ let cc_tactic depth additional_terms b =
       | Incomplete terms_to_complete ->
         let open Glob_term in
         let env = Proofview.Goal.env gl in
-        let hole = DAst.make @@ GHole (GInternalHole, Namegen.IntroAnonymous) in
+        let hole = DAst.make @@ GHole (GInternalHole) in
         let pr_missing (c, missing) =
           let c = Detyping.detype Detyping.Now Id.Set.empty env sigma c in
           let holes = List.init missing (fun _ -> hole) in

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -449,7 +449,7 @@ let cc_tactic depth additional_terms b =
       | Incomplete terms_to_complete ->
         let open Glob_term in
         let env = Proofview.Goal.env gl in
-        let hole = DAst.make @@ GHole (Evar_kinds.InternalHole, Namegen.IntroAnonymous) in
+        let hole = DAst.make @@ GHole (GInternalHole, Namegen.IntroAnonymous) in
         let pr_missing (c, missing) =
           let c = Detyping.detype Detyping.Now Id.Set.empty env sigma c in
           let holes = List.init missing (fun _ -> hole) in

--- a/plugins/funind/glob_termops.ml
+++ b/plugins/funind/glob_termops.ml
@@ -28,7 +28,7 @@ let mkGCases (rto, l, brl) = DAst.make @@ GCases (RegularStyle, rto, l, brl)
 
 let mkGHole () =
   DAst.make
-  @@ GHole (GBinderType Anonymous, Namegen.IntroAnonymous)
+  @@ GHole (GBinderType Anonymous)
 
 (*
   Some basic functions to decompose glob_constrs
@@ -564,8 +564,8 @@ let resolve_and_replace_implicits exptyp env sigma rt =
     | GBinderType na -> binder_holes := ((loc, na), evk) :: !binder_holes
     | _ -> ()
     in
-    let pretype_hole self (kind, pat) ?loc ~flags tycon env sigma =
-      let sigma, j = default_pretyper.pretype_hole self (kind, pat) ?loc ~flags tycon env sigma in
+    let pretype_hole self kind ?loc ~flags tycon env sigma =
+      let sigma, j = default_pretyper.pretype_hole self kind ?loc ~flags tycon env sigma in
       (* The value is guaranteed to be an undefined evar at this point *)
       let evk, _ = EConstr.destEvar sigma j.uj_val in
       let () = register_evar kind loc evk  in
@@ -574,7 +574,7 @@ let resolve_and_replace_implicits exptyp env sigma rt =
     let pretype_type self c ?loc ~flags valcon env sigma =
       let sigma, j = default_pretyper.pretype_type self c ?loc ~flags valcon env sigma in
       let () = match DAst.get c, EConstr.kind sigma j.utj_val with
-      | GHole (kind, _), Evar (evk, _) -> register_evar kind c.CAst.loc evk
+      | GHole (kind), Evar (evk, _) -> register_evar kind c.CAst.loc evk
       | _ -> ()
       in
       sigma, j
@@ -614,13 +614,13 @@ let resolve_and_replace_implicits exptyp env sigma rt =
   (* then we map [rt] to replace the implicit holes by their values *)
   let rec change rt =
     match DAst.get rt with
-    | GHole (GImplicitArg (grk, pk, bk), _) ->
+    | GHole (GImplicitArg (grk, pk, bk)) ->
       let eq (loc1, gr1, p1, b1) (loc2, gr2, p2, b2) =
         Environ.QGlobRef.equal env gr1 gr2 && p1 = p2 && b1 == (b2 : bool) && loc1 = (loc2 : Loc.t option)
       in
       let evopt = List.assoc_f_opt eq (rt.CAst.loc, grk, pk, bk) !implicit_holes in
       expand_hole evopt rt
-    | GHole (GBinderType na, _) ->
+    | GHole (GBinderType na) ->
       let eq (loc1, na1) (loc2, na2) = Name.equal na1 na2 && loc1 = (loc2 : Loc.t option) in
       let evopt = List.assoc_f_opt eq (rt.CAst.loc, na) !binder_holes in
       expand_hole evopt rt

--- a/plugins/funind/glob_termops.ml
+++ b/plugins/funind/glob_termops.ml
@@ -28,7 +28,7 @@ let mkGCases (rto, l, brl) = DAst.make @@ GCases (RegularStyle, rto, l, brl)
 
 let mkGHole () =
   DAst.make
-  @@ GHole (Evar_kinds.BinderType Anonymous, Namegen.IntroAnonymous)
+  @@ GHole (GBinderType Anonymous, Namegen.IntroAnonymous)
 
 (*
   Some basic functions to decompose glob_constrs
@@ -560,8 +560,8 @@ let resolve_and_replace_implicits exptyp env sigma rt =
     let open Evarutil in
     (* Intercept the pretyper for holes and record the generated evar *)
     let register_evar kind loc evk = match kind with
-    | ImplicitArg (grk, pk, bk) -> implicit_holes := ((loc, grk, pk, bk), evk) :: !implicit_holes
-    | BinderType na -> binder_holes := ((loc, na), evk) :: !binder_holes
+    | GImplicitArg (grk, pk, bk) -> implicit_holes := ((loc, grk, pk, bk), evk) :: !implicit_holes
+    | GBinderType na -> binder_holes := ((loc, na), evk) :: !binder_holes
     | _ -> ()
     in
     let pretype_hole self (kind, pat) ?loc ~flags tycon env sigma =
@@ -614,13 +614,13 @@ let resolve_and_replace_implicits exptyp env sigma rt =
   (* then we map [rt] to replace the implicit holes by their values *)
   let rec change rt =
     match DAst.get rt with
-    | GHole (ImplicitArg (grk, pk, bk), _) ->
+    | GHole (GImplicitArg (grk, pk, bk), _) ->
       let eq (loc1, gr1, p1, b1) (loc2, gr2, p2, b2) =
         Environ.QGlobRef.equal env gr1 gr2 && p1 = p2 && b1 == (b2 : bool) && loc1 = (loc2 : Loc.t option)
       in
       let evopt = List.assoc_f_opt eq (rt.CAst.loc, grk, pk, bk) !implicit_holes in
       expand_hole evopt rt
-    | GHole (BinderType na, _) ->
+    | GHole (GBinderType na, _) ->
       let eq (loc1, na1) (loc2, na2) = Name.equal na1 na2 && loc1 = (loc2 : Loc.t option) in
       let evopt = List.assoc_f_opt eq (rt.CAst.loc, na) !binder_holes in
       expand_hole evopt rt

--- a/plugins/ltac/comRewrite.ml
+++ b/plugins/ltac/comRewrite.ml
@@ -141,7 +141,7 @@ let declare_relation atts ?(binders=[]) a aeq n refl symm trans =
        (qualid_of_ident (Id.of_string "Equivalence_Symmetric"), lemma2);
        (qualid_of_ident (Id.of_string "Equivalence_Transitive"), lemma3)]
 
-let cHole = CAst.make @@ CHole (None, Namegen.IntroAnonymous)
+let cHole = CAst.make @@ CHole (None)
 
 let proper_projection env sigma r ty =
   let rel_vect n m = Array.init m (fun i -> mkRel(n+m-i)) in

--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -16,7 +16,6 @@ open Util
 open Pp
 open Constrexpr
 open Tacexpr
-open Namegen
 open Genarg
 open Genredexpr
 open Names
@@ -241,7 +240,7 @@ GRAMMAR EXTEND Gram
               | { CAst.v = CCast (t, Some DEFAULTcast, ty) } -> Term t, Some (Term ty)
               | _ -> mpv, None)
             | _ -> mpv, None
-          in Def (na, t, Option.default (Term (CAst.make @@ CHole (None, IntroAnonymous))) ty) }
+          in Def (na, t, Option.default (Term (CAst.make @@ CHole (None))) ty) }
     ] ]
   ;
   match_context_rule:

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -443,7 +443,7 @@ GRAMMAR EXTEND Gram
   ;
   simple_binder:
     [ [ na=name -> { ([na],Default Glob_term.Explicit, CAst.make ~loc @@
-                    CHole (Some (Evar_kinds.BinderType na.CAst.v), IntroAnonymous)) }
+                    CHole (Some (GBinderType na.CAst.v), IntroAnonymous)) }
       | "("; nal=LIST1 name; ":"; c=lconstr; ")" -> { (nal,Default Glob_term.Explicit,c) }
     ] ]
   ;

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -443,7 +443,7 @@ GRAMMAR EXTEND Gram
   ;
   simple_binder:
     [ [ na=name -> { ([na],Default Glob_term.Explicit, CAst.make ~loc @@
-                    CHole (Some (GBinderType na.CAst.v), IntroAnonymous)) }
+                    CHole (Some (GBinderType na.CAst.v))) }
       | "("; nal=LIST1 name; ":"; c=lconstr; ")" -> { (nal,Default Glob_term.Explicit,c) }
     ] ]
   ;

--- a/plugins/ltac2/g_ltac2.mlg
+++ b/plugins/ltac2/g_ltac2.mlg
@@ -839,7 +839,7 @@ GRAMMAR EXTEND Gram
                 let ty = CAst.make ?loc:ty.loc @@ QConstrMatchPattern ty in
                 t, ty
               | _ ->
-                let ty = CAst.make @@ QConstrMatchPattern (CAst.make @@ CHole (None, IntroAnonymous)) in
+                let ty = CAst.make @@ QConstrMatchPattern (CAst.make @@ CHole None) in
                 bod, ty
           in
           (na, Some bod, ty) }

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -112,7 +112,7 @@ let option_assert_get o msg =
 (** Constructors for rawconstr *)
 open Glob_term
 
-let mkRHole = DAst.make @@ GHole (GInternalHole, Namegen.IntroAnonymous)
+let mkRHole = DAst.make @@ GHole (GInternalHole)
 
 let rec mkRHoles n = if n > 0 then mkRHole :: mkRHoles (n - 1) else []
 let rec isRHoles cl = match cl with
@@ -714,8 +714,8 @@ let mkCProp loc = CAst.make ?loc @@ CSort (UNamed (None, [CProp, 0]))
 let mkCType loc = CAst.make ?loc @@ CSort (UAnonymous {rigid=UnivRigid})
 let mkCVar ?loc id = CAst.make ?loc @@ CRef (qualid_of_ident ?loc id, None)
 let rec mkCHoles ?loc n =
-  if n <= 0 then [] else (CAst.make ?loc @@ CHole (None, Namegen.IntroAnonymous)) :: mkCHoles ?loc (n - 1)
-let mkCHole loc = CAst.make ?loc @@ CHole (None, Namegen.IntroAnonymous)
+  if n <= 0 then [] else (CAst.make ?loc @@ CHole (None)) :: mkCHoles ?loc (n - 1)
+let mkCHole loc = CAst.make ?loc @@ CHole (None)
 let mkCLambda ?loc name ty t =  CAst.make ?loc @@
    CLambdaN ([CLocalAssum([CAst.make ?loc name], Default Explicit, ty)], t)
 let mkCArrow ?loc ty t = CAst.make ?loc @@

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -112,7 +112,7 @@ let option_assert_get o msg =
 (** Constructors for rawconstr *)
 open Glob_term
 
-let mkRHole = DAst.make @@ GHole (Evar_kinds.InternalHole, Namegen.IntroAnonymous)
+let mkRHole = DAst.make @@ GHole (GInternalHole, Namegen.IntroAnonymous)
 
 let rec mkRHoles n = if n > 0 then mkRHole :: mkRHoles (n - 1) else []
 let rec isRHoles cl = match cl with

--- a/plugins/ssr/ssrview.ml
+++ b/plugins/ssr/ssrview.ml
@@ -185,7 +185,7 @@ let tclINJ_CONSTR_IST ist p =
 
 let mkGHole =
   DAst.make
-    (Glob_term.GHole(Evar_kinds.InternalHole, Namegen.IntroAnonymous))
+    (Glob_term.GHole (GInternalHole, Namegen.IntroAnonymous))
 let rec mkGHoles n = if n > 0 then mkGHole :: mkGHoles (n - 1) else []
 let mkGApp f args =
   if args = [] then f

--- a/plugins/ssr/ssrview.ml
+++ b/plugins/ssr/ssrview.ml
@@ -185,7 +185,7 @@ let tclINJ_CONSTR_IST ist p =
 
 let mkGHole =
   DAst.make
-    (Glob_term.GHole (GInternalHole, Namegen.IntroAnonymous))
+    (Glob_term.GHole (GInternalHole))
 let rec mkGHoles n = if n > 0 then mkGHole :: mkGHoles (n - 1) else []
 let mkGApp f args =
   if args = [] then f

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -136,7 +136,7 @@ let mkCLetIn ?loc name bo t = CAst.make ?loc @@
 let mkCCast ?loc t ty = CAst.make ?loc @@ CCast (t, Some DEFAULTcast, ty)
 
 (** Constructors for rawconstr *)
-let mkRHole = DAst.make @@ GHole (InternalHole, IntroAnonymous)
+let mkRHole = DAst.make @@ GHole (GInternalHole, IntroAnonymous)
 let mkRApp f args = if args = [] then f else DAst.make @@ GApp (f, args)
 let mkRCast rc rt =  DAst.make @@ GCast (rc, Some DEFAULTcast, rt)
 let mkRLambda n s t = DAst.make @@ GLambda (n, Explicit, s, t)
@@ -1155,7 +1155,7 @@ let interp_pattern ?wit_ssrpatternarg env sigma0 red redty =
   | Some b -> {kind; pattern=(g,Some (mkCLetIn ?loc x (mkCHole ~loc) b)); interpretation}
   | None -> { kind
             ; pattern = DAst.make ?loc @@ GLetIn
-                  (x, DAst.make ?loc @@ GHole (BinderType x, IntroAnonymous), None, g), None
+                  (x, DAst.make ?loc @@ GHole (GBinderType x, IntroAnonymous), None, g), None
             ; interpretation} in
   match red with
   | T t -> let sigma, t = interp_term env sigma0 t in { pat_sigma = sigma; pat_pat = T t }

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -28,7 +28,6 @@ open Tacinterp
 open Pretyping
 open Ppconstr
 open Printer
-open Namegen
 open Evar_kinds
 open Constrexpr
 open Constrexpr_ops
@@ -128,7 +127,7 @@ let isGLambda c = match DAst.get c with GLambda (Name _, _, _, _) -> true | _ ->
 let destGLambda c = match DAst.get c with GLambda (Name id, _, _, c) -> (id, c)
   | _ -> CErrors.anomaly (str "not a GLambda")
 let isGHole c = match DAst.get c with GHole _ -> true | _ -> false
-let mkCHole ~loc = CAst.make ?loc @@ CHole (None, IntroAnonymous)
+let mkCHole ~loc = CAst.make ?loc @@ CHole (None)
 let mkCLambda ?loc name ty t = CAst.make ?loc @@
    CLambdaN ([CLocalAssum([CAst.make ?loc name], Default Explicit, ty)], t)
 let mkCLetIn ?loc name bo t = CAst.make ?loc @@
@@ -136,7 +135,7 @@ let mkCLetIn ?loc name bo t = CAst.make ?loc @@
 let mkCCast ?loc t ty = CAst.make ?loc @@ CCast (t, Some DEFAULTcast, ty)
 
 (** Constructors for rawconstr *)
-let mkRHole = DAst.make @@ GHole (GInternalHole, IntroAnonymous)
+let mkRHole = DAst.make @@ GHole (GInternalHole)
 let mkRApp f args = if args = [] then f else DAst.make @@ GApp (f, args)
 let mkRCast rc rt =  DAst.make @@ GCast (rc, Some DEFAULTcast, rt)
 let mkRLambda n s t = DAst.make @@ GLambda (n, Explicit, s, t)
@@ -1155,7 +1154,7 @@ let interp_pattern ?wit_ssrpatternarg env sigma0 red redty =
   | Some b -> {kind; pattern=(g,Some (mkCLetIn ?loc x (mkCHole ~loc) b)); interpretation}
   | None -> { kind
             ; pattern = DAst.make ?loc @@ GLetIn
-                  (x, DAst.make ?loc @@ GHole (GBinderType x, IntroAnonymous), None, g), None
+                  (x, DAst.make ?loc @@ GHole (GBinderType x), None, g), None
             ; interpretation} in
   match red with
   | T t -> let sigma, t = interp_term env sigma0 t in { pat_sigma = sigma; pat_pat = T t }

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -2231,8 +2231,7 @@ let hole na = DAst.make @@
   GHole (GQuestionMark {
       Evar_kinds.qm_obligation= Evar_kinds.Define false;
       Evar_kinds.qm_name=na;
-      Evar_kinds.qm_record_field=None},
-         IntroAnonymous)
+      Evar_kinds.qm_record_field=None})
 
 let constr_of_pat env sigma arsign pat avoid =
   let rec typ env sigma (ty, realargs) pat avoid =

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -2228,7 +2228,7 @@ let mk_JMeq_refl env sigma typ x =
   papp env sigma coq_JMeq_refl [| typ; x |]
 
 let hole na = DAst.make @@
-  GHole (Evar_kinds.QuestionMark {
+  GHole (GQuestionMark {
       Evar_kinds.qm_obligation= Evar_kinds.Define false;
       Evar_kinds.qm_name=na;
       Evar_kinds.qm_record_field=None},

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -594,7 +594,7 @@ let detype_case computable detype detype_eqns avoid env sigma (ci, univs, params
         then tomatch
         else
           let _, mip = Global.lookup_inductive ci.ci_ind in
-          let hole = DAst.make @@ GHole (GInternalHole, Namegen.IntroAnonymous) in
+          let hole = DAst.make @@ GHole (GInternalHole) in
           let indices = List.make mip.mind_nrealargs hole in
           let t = mkApp (mkIndU (ci.ci_ind,univs), params) in
           DAst.make @@ GCast (tomatch, None, mkGApp (detype t) indices)
@@ -880,7 +880,7 @@ and detype_r d flags avoid env sigma t =
       else
         let noparams () =
           let pars = Projection.npars p in
-          let hole = DAst.make @@ GHole (GInternalHole, Namegen.IntroAnonymous) in
+          let hole = DAst.make @@ GHole (GInternalHole) in
           let args = List.make pars hole in
           GApp (DAst.make @@ GRef (GlobRef.ConstRef (Projection.constant p), None),
                 (args @ [detype d flags avoid env sigma c]))
@@ -1239,7 +1239,7 @@ let rec subst_glob_constr env subst = DAst.map (function
         if ra1' == ra1 && ra2' == ra2 && bl'==bl then raw else
           GRec (fix,ida,bl',ra1',ra2')
 
-  | GHole (knd, naming) as raw ->
+  | GHole knd as raw ->
     let nknd = match knd with
     | GImplicitArg (ref, i, b) ->
       let nref, _ = subst_global subst ref in
@@ -1247,7 +1247,7 @@ let rec subst_glob_constr env subst = DAst.map (function
     | _ -> knd
     in
     if nknd == knd then raw
-    else GHole (nknd, naming)
+    else GHole nknd
 
   | GGenarg arg as raw ->
     let arg' = Hook.get f_subst_genarg subst arg in

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -594,7 +594,7 @@ let detype_case computable detype detype_eqns avoid env sigma (ci, univs, params
         then tomatch
         else
           let _, mip = Global.lookup_inductive ci.ci_ind in
-          let hole = DAst.make @@ GHole(Evar_kinds.InternalHole,Namegen.IntroAnonymous) in
+          let hole = DAst.make @@ GHole (GInternalHole, Namegen.IntroAnonymous) in
           let indices = List.make mip.mind_nrealargs hole in
           let t = mkApp (mkIndU (ci.ci_ind,univs), params) in
           DAst.make @@ GCast (tomatch, None, mkGApp (detype t) indices)
@@ -880,7 +880,7 @@ and detype_r d flags avoid env sigma t =
       else
         let noparams () =
           let pars = Projection.npars p in
-          let hole = DAst.make @@ GHole(Evar_kinds.InternalHole,Namegen.IntroAnonymous) in
+          let hole = DAst.make @@ GHole (GInternalHole, Namegen.IntroAnonymous) in
           let args = List.make pars hole in
           GApp (DAst.make @@ GRef (GlobRef.ConstRef (Projection.constant p), None),
                 (args @ [detype d flags avoid env sigma c]))
@@ -1241,9 +1241,9 @@ let rec subst_glob_constr env subst = DAst.map (function
 
   | GHole (knd, naming) as raw ->
     let nknd = match knd with
-    | Evar_kinds.ImplicitArg (ref, i, b) ->
+    | GImplicitArg (ref, i, b) ->
       let nref, _ = subst_global subst ref in
-      if nref == ref then knd else Evar_kinds.ImplicitArg (nref, i, b)
+      if nref == ref then knd else GImplicitArg (nref, i, b)
     | _ -> knd
     in
     if nknd == knd then raw

--- a/pretyping/glob_ops.ml
+++ b/pretyping/glob_ops.ml
@@ -604,7 +604,7 @@ let rec glob_constr_of_cases_pattern_aux env isclosed x = DAst.map_with_loc (fun
   | PatVar (Name id) when not isclosed ->
       GVar id
   | PatVar Anonymous when not isclosed ->
-      GHole (Evar_kinds.QuestionMark {
+      GHole (GQuestionMark {
         Evar_kinds.default_question_mark with Evar_kinds.qm_obligation=Define false;
       },Namegen.IntroAnonymous)
   | _ -> raise Not_found
@@ -618,6 +618,15 @@ let glob_constr_of_closed_cases_pattern env p = match DAst.get p with
       raise Not_found
 
 let glob_constr_of_cases_pattern env p = glob_constr_of_cases_pattern_aux env false p
+
+let kind_of_glob_kind = function
+| GImplicitArg (gr, p, b) -> ImplicitArg (gr, p, b)
+| GBinderType na -> BinderType na
+| GNamedHole id -> NamedHole id
+| GQuestionMark qm -> QuestionMark qm
+| GCasesType -> CasesType false
+| GInternalHole -> InternalHole
+| GImpossibleCase -> ImpossibleCase
 
 (* This has to be in some file... *)
 

--- a/pretyping/glob_ops.mli
+++ b/pretyping/glob_ops.mli
@@ -118,3 +118,5 @@ val add_patterns_for_params_remove_local_defs : Environ.env -> constructor ->
 val empty_lvar : Ltac_pretype.ltac_var_map
 
 val kind_of_glob_kind : glob_evar_kind -> Evar_kinds.t
+
+val naming_of_glob_kind : glob_evar_kind -> Namegen.intro_pattern_naming_expr

--- a/pretyping/glob_ops.mli
+++ b/pretyping/glob_ops.mli
@@ -116,3 +116,5 @@ val add_patterns_for_params_remove_local_defs : Environ.env -> constructor ->
   'a cases_pattern_g list -> 'a cases_pattern_g list
 
 val empty_lvar : Ltac_pretype.ltac_var_map
+
+val kind_of_glob_kind : glob_evar_kind -> Evar_kinds.t

--- a/pretyping/glob_term.mli
+++ b/pretyping/glob_term.mli
@@ -76,6 +76,15 @@ type cases_pattern = [ `any ] cases_pattern_g
 
 type binding_kind = Explicit | MaxImplicit | NonMaxImplicit
 
+type glob_evar_kind = Evar_kinds.glob_evar_kind =
+  | GImplicitArg of GlobRef.t * (int * Id.t option) * bool (** Force inference *)
+  | GBinderType of Name.t
+  | GNamedHole of Id.t (* coming from some ?[id] syntax *)
+  | GQuestionMark of Evar_kinds.question_mark
+  | GCasesType
+  | GInternalHole
+  | GImpossibleCase
+
 (** Representation of an internalized (or in other words globalized) term. *)
 type 'a glob_constr_r =
   | GRef of GlobRef.t * glob_instance option
@@ -97,7 +106,7 @@ type 'a glob_constr_r =
   | GRec  of glob_fix_kind * Id.t array * 'a glob_decl_g list array *
              'a glob_constr_g array * 'a glob_constr_g array
   | GSort of glob_sort
-  | GHole of Evar_kinds.t * Namegen.intro_pattern_naming_expr
+  | GHole of glob_evar_kind * Namegen.intro_pattern_naming_expr
   | GGenarg of Genarg.glob_generic_argument
   | GCast of 'a glob_constr_g * Constr.cast_kind option * 'a glob_constr_g
   | GProj of (Constant.t * glob_instance option) * 'a glob_constr_g list * 'a glob_constr_g

--- a/pretyping/glob_term.mli
+++ b/pretyping/glob_term.mli
@@ -79,7 +79,7 @@ type binding_kind = Explicit | MaxImplicit | NonMaxImplicit
 type glob_evar_kind = Evar_kinds.glob_evar_kind =
   | GImplicitArg of GlobRef.t * (int * Id.t option) * bool (** Force inference *)
   | GBinderType of Name.t
-  | GNamedHole of Id.t (* coming from some ?[id] syntax *)
+  | GNamedHole of bool (* fresh? *) * Id.t (* coming from some ?[id] syntax *)
   | GQuestionMark of Evar_kinds.question_mark
   | GCasesType
   | GInternalHole
@@ -106,7 +106,7 @@ type 'a glob_constr_r =
   | GRec  of glob_fix_kind * Id.t array * 'a glob_decl_g list array *
              'a glob_constr_g array * 'a glob_constr_g array
   | GSort of glob_sort
-  | GHole of glob_evar_kind * Namegen.intro_pattern_naming_expr
+  | GHole of glob_evar_kind
   | GGenarg of Genarg.glob_generic_argument
   | GCast of 'a glob_constr_g * Constr.cast_kind option * 'a glob_constr_g
   | GProj of (Constant.t * glob_instance option) * 'a glob_constr_g list * 'a glob_constr_g

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -576,7 +576,7 @@ type pretyper = {
   pretype_if : pretyper -> glob_constr * (Name.t * glob_constr option) * glob_constr * glob_constr -> unsafe_judgment pretype_fun;
   pretype_rec : pretyper -> glob_fix_kind * Id.t array * glob_decl list array * glob_constr array * glob_constr array -> unsafe_judgment pretype_fun;
   pretype_sort : pretyper -> glob_sort -> unsafe_judgment pretype_fun;
-  pretype_hole : pretyper -> Evar_kinds.glob_evar_kind * Namegen.intro_pattern_naming_expr -> unsafe_judgment pretype_fun;
+  pretype_hole : pretyper -> Evar_kinds.glob_evar_kind -> unsafe_judgment pretype_fun;
   pretype_genarg : pretyper -> Genarg.glob_generic_argument -> unsafe_judgment pretype_fun;
   pretype_cast : pretyper -> glob_constr * cast_kind option * glob_constr -> unsafe_judgment pretype_fun;
   pretype_int : pretyper -> Uint63.t -> unsafe_judgment pretype_fun;
@@ -617,8 +617,8 @@ let eval_pretyper self ~flags tycon env sigma t =
     self.pretype_rec self (knd, nas, decl, c, t) ?loc ~flags tycon env sigma
   | GSort s ->
     self.pretype_sort self s ?loc ~flags tycon env sigma
-  | GHole (knd, nam) ->
-    self.pretype_hole self (knd, nam) ?loc ~flags tycon env sigma
+  | GHole knd ->
+    self.pretype_hole self knd ?loc ~flags tycon env sigma
   | GGenarg arg ->
     self.pretype_genarg self arg ?loc ~flags tycon env sigma
   | GCast (c, k, t) ->
@@ -724,8 +724,9 @@ struct
     let sigma, uj_val, uj_type = new_typed_evar env sigma ~src:(loc,k) tycon in
     sigma, { uj_val; uj_type }
 
-  let pretype_hole self (k, naming) ?loc ~flags tycon env sigma =
+  let pretype_hole self k ?loc ~flags tycon env sigma =
     let open Namegen in
+    let naming = naming_of_glob_kind k in
     let naming = match naming with
       | IntroIdentifier id -> IntroIdentifier (interp_ltac_id env id)
       | IntroAnonymous -> IntroAnonymous
@@ -1306,8 +1307,9 @@ struct
 
 (* [pretype_type valcon env sigma c] coerces [c] into a type *)
 let pretype_type self c ?loc ~flags valcon (env : GlobEnv.t) sigma = match DAst.get c with
-  | GHole (knd, naming) ->
+  | GHole knd ->
       let loc = loc_of_glob_constr c in
+      let naming = naming_of_glob_kind knd in
       let knd = kind_of_glob_kind knd in
       (match valcon with
        | Some v ->
@@ -1535,7 +1537,7 @@ let path_convertible env sigma cl p q =
   let mkGApp(rt,rtl)      = DAst.make @@ Glob_term.GApp(rt,rtl) in
   let mkGLambda(n,t,b)    = DAst.make @@ Glob_term.GLambda(n,Explicit,t,b) in
   let mkGSort u           = DAst.make @@ Glob_term.GSort u in
-  let mkGHole ()          = DAst.make @@ Glob_term.GHole (GBinderType Anonymous, Namegen.IntroAnonymous) in
+  let mkGHole ()          = DAst.make @@ Glob_term.GHole (GBinderType Anonymous) in
   let path_to_gterm p =
     match p with
     | ic :: p' ->

--- a/pretyping/pretyping.mli
+++ b/pretyping/pretyping.mli
@@ -172,7 +172,7 @@ type pretyper = {
   pretype_if : pretyper -> glob_constr * (Name.t * glob_constr option) * glob_constr * glob_constr -> unsafe_judgment pretype_fun;
   pretype_rec : pretyper -> glob_fix_kind * Id.t array * glob_decl list array * glob_constr array * glob_constr array -> unsafe_judgment pretype_fun;
   pretype_sort : pretyper -> glob_sort -> unsafe_judgment pretype_fun;
-  pretype_hole : pretyper -> Evar_kinds.glob_evar_kind * Namegen.intro_pattern_naming_expr -> unsafe_judgment pretype_fun;
+  pretype_hole : pretyper -> Evar_kinds.glob_evar_kind -> unsafe_judgment pretype_fun;
   pretype_genarg : pretyper -> Genarg.glob_generic_argument -> unsafe_judgment pretype_fun;
   pretype_cast : pretyper -> glob_constr * Constr.cast_kind option * glob_constr -> unsafe_judgment pretype_fun;
   pretype_int : pretyper -> Uint63.t -> unsafe_judgment pretype_fun;

--- a/pretyping/pretyping.mli
+++ b/pretyping/pretyping.mli
@@ -172,7 +172,7 @@ type pretyper = {
   pretype_if : pretyper -> glob_constr * (Name.t * glob_constr option) * glob_constr * glob_constr -> unsafe_judgment pretype_fun;
   pretype_rec : pretyper -> glob_fix_kind * Id.t array * glob_decl list array * glob_constr array * glob_constr array -> unsafe_judgment pretype_fun;
   pretype_sort : pretyper -> glob_sort -> unsafe_judgment pretype_fun;
-  pretype_hole : pretyper -> Evar_kinds.t * Namegen.intro_pattern_naming_expr -> unsafe_judgment pretype_fun;
+  pretype_hole : pretyper -> Evar_kinds.glob_evar_kind * Namegen.intro_pattern_naming_expr -> unsafe_judgment pretype_fun;
   pretype_genarg : pretyper -> Genarg.glob_generic_argument -> unsafe_judgment pretype_fun;
   pretype_cast : pretyper -> glob_constr * Constr.cast_kind option * glob_constr -> unsafe_judgment pretype_fun;
   pretype_int : pretyper -> Uint63.t -> unsafe_judgment pretype_fun;

--- a/tactics/hipattern.ml
+++ b/tactics/hipattern.ml
@@ -261,7 +261,7 @@ let mkGApp f args = DAst.make @@ GApp (f, args)
 let mkGHole = DAst.make @@
   GHole (GQuestionMark {
         Evar_kinds.default_question_mark with Evar_kinds.qm_obligation=Define false;
-  }, Namegen.IntroAnonymous)
+  })
 let mkGProd id c1 c2 = DAst.make @@
   GProd (Name (Id.of_string id), Explicit, c1, c2)
 let mkGArrow c1 c2 = DAst.make @@

--- a/tactics/hipattern.ml
+++ b/tactics/hipattern.ml
@@ -259,7 +259,7 @@ open Evar_kinds
 let mkPattern c = snd (Patternops.pattern_of_glob_constr c)
 let mkGApp f args = DAst.make @@ GApp (f, args)
 let mkGHole = DAst.make @@
-  GHole (QuestionMark {
+  GHole (GQuestionMark {
         Evar_kinds.default_question_mark with Evar_kinds.qm_obligation=Define false;
   }, Namegen.IntroAnonymous)
 let mkGProd id c1 c2 = DAst.make @@

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -458,7 +458,7 @@ let do_instance_type_ctx_instance props k env' ctx' sigma ~program_mode subst =
                    Option.iter (fun x -> Dumpglob.add_glob ?loc (GlobRef.ConstRef x)) m.meth_const) k.cl_projs;
              c :: props, rest'
            with Not_found ->
-             ((CAst.make @@ CHole (None(* Some Evar_kinds.GoalEvar *), Namegen.IntroAnonymous)) :: props), rest
+             ((CAst.make @@ CHole (None)) :: props), rest
          else props, rest)
       ([], props) k.cl_props
   in

--- a/vernac/comDefinition.ml
+++ b/vernac/comDefinition.ml
@@ -49,7 +49,7 @@ let protect_pattern_in_binder bl c ctypopt =
   if List.exists (function Constrexpr.CLocalPattern _ -> true | _ -> false) bl
   then
     let t = match ctypopt with
-      | None -> CAst.make ?loc:c.CAst.loc (Constrexpr.CHole (None,Namegen.IntroAnonymous))
+      | None -> CAst.make ?loc:c.CAst.loc (Constrexpr.CHole (None))
       | Some t -> t in
     let loc = Loc.merge_opt c.CAst.loc t.CAst.loc in
     let c = CAst.make ?loc @@ Constrexpr.CCast (c, Some Constr.DEFAULTcast, t) in

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -22,7 +22,6 @@ open Constrexpr_ops
 open Extend
 open Decls
 open Declaremods
-open Namegen
 
 module C = Constr
 
@@ -540,7 +539,7 @@ GRAMMAR EXTEND Gram
              ((NoCoercion,NoInstance),DefExpr(id,l,b,None)) } ] ]
   ;
   record_binder:
-    [ [ id = name -> { ((NoCoercion,NoInstance),AssumExpr(id, [], CAst.make ~loc @@ CHole (None, IntroAnonymous))) }
+    [ [ id = name -> { ((NoCoercion,NoInstance),AssumExpr(id, [], CAst.make ~loc @@ CHole (None))) }
       | id = name; f = field_body -> { f id } ] ]
   ;
   assum_list:
@@ -559,7 +558,7 @@ GRAMMAR EXTEND Gram
       t= [ coe = of_type_inst; c = lconstr ->
                     { fun l attr id -> ((attr, fst coe, snd coe),(id,mkProdCN ~loc l c)) }
             |  ->
-                 { fun l attr id -> ((attr,NoCoercion,NoInstance),(id,mkProdCN ~loc l (CAst.make ~loc @@ CHole (None, IntroAnonymous)))) } ]
+                 { fun l attr id -> ((attr,NoCoercion,NoInstance),(id,mkProdCN ~loc l (CAst.make ~loc @@ CHole (None)))) } ]
          -> { t l }
      ]]
 ;

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -394,7 +394,8 @@ let pr_module_binders l pr_c =
   prlist_strict (pr_module_vardecls pr_c) l
 
 let pr_type_option pr_c = function
-  | { v = CHole (k, Namegen.IntroAnonymous) } -> mt()
+  | { v = CHole (Some GNamedHole _) } as c -> brk(0,2) ++ str" :" ++ pr_c c
+  | { v = CHole _ } -> mt()
   | _ as c -> brk(0,2) ++ str" :" ++ pr_c c
 
 let pr_binders_arg =


### PR DESCRIPTION
We split the Evar_kinds.t type in two variants, the new one being used for user-facing ASTs. Many constructors are never used from the user-facing side, making the type much more compact. We also enforce more static invariants by merging the hole naming information with glob evar kinds.

Overlays:
- https://github.com/coq-community/bignums/pull/83
- https://github.com/LPCIC/coq-elpi/pull/542
- https://github.com/mattam82/Coq-Equations/pull/569
- https://github.com/MetaCoq/metacoq/pull/1010
- https://github.com/QuickChick/QuickChick/pull/343
- https://github.com/ejgallego/coq-serapi/pull/369
- https://github.com/coq-tactician/coq-tactician/pull/70