### PR TITLE
New command Register Scheme

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/18299-regscheme.rst
+++ b/doc/changelog/08-vernac-commands-and-options/18299-regscheme.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  :cmd:`Register Scheme` to add entries to the scheme database used by some tactics
+  (`#18299 <https://github.com/coq/coq/pull/18299>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -1171,6 +1171,19 @@ Exposing constants to OCaml libraries
 
    List the currently registered constants.
 
+.. cmd:: Register Scheme @qualid__1 as @qualid__2 for @qualid__3
+
+   Make the constant :n:`@qualid__1` accessible to the "scheme"
+   mechanism for scheme kind :n:`@qualid__2` and inductive
+   :n:`@qualid__3`.
+
+.. cmd:: Print Registered Schemes
+
+   List the currently registered schemes.
+
+   This can be useful to find information about the (currently
+   undocumented) scheme kinds.
+
 Inlining hints for the fast reduction machines
 ``````````````````````````````````````````````
 

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -1168,7 +1168,8 @@ Exposing constants to OCaml libraries
    .. seealso:: :ref:`primitive-integers`
 
 .. cmd:: Print Registered
-   :undocumented:
+
+   List the currently registered constants.
 
 Inlining hints for the fast reduction machines
 ``````````````````````````````````````````````

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -825,6 +825,7 @@ gallina: [
 | "Scheme" "Boolean" "Equality" "for" smart_global
 | "Combined" "Scheme" identref "from" LIST1 identref SEP ","
 | "Register" global "as" qualid
+| "Register" "Scheme" global "as" qualid "for" global
 | "Register" "Inline" global
 | "Primitive" ident_decl OPT [ ":" lconstr ] ":=" register_token
 | "Universe" LIST1 identref
@@ -1337,6 +1338,7 @@ printable: [
 | "Strategy" smart_global
 | "Strategies"
 | "Registered"
+| "Registered" "Schemes"
 ]
 
 printunivs_subgraph: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -772,6 +772,7 @@ command: [
 | "Print" "Strategy" reference
 | "Print" "Strategies"
 | "Print" "Registered"
+| "Print" "Registered" "Schemes"
 | "Print" OPT "Term" reference OPT univ_name_list
 | "Print" "Module" "Type" qualid
 | "Print" "Module" qualid
@@ -914,6 +915,7 @@ command: [
 | "Scheme" OPT "Boolean" "Equality" "for" reference
 | "Combined" "Scheme" ident "from" LIST1 ident SEP ","
 | "Register" qualid "as" qualid
+| "Register" "Scheme" qualid "as" qualid "for" qualid
 | "Register" "Inline" qualid
 | "Primitive" ident_decl OPT [ ":" term ] ":=" "#" ident
 | "Universe" LIST1 ident

--- a/tactics/declareScheme.ml
+++ b/tactics/declareScheme.ml
@@ -13,23 +13,25 @@ open Names
 let scheme_map = Summary.ref Indmap.empty ~name:"Schemes"
 
 let cache_one_scheme kind (ind,const) =
-  let map = try Indmap.find ind !scheme_map with Not_found -> CString.Map.empty in
-  scheme_map := Indmap.add ind (CString.Map.add kind const map) !scheme_map
+  scheme_map := Indmap.update ind (function
+      | None -> Some (CString.Map.singleton kind const)
+      | Some map -> Some (CString.Map.add kind const map))
+      !scheme_map
 
 let cache_scheme (kind,l) =
-  Array.iter (cache_one_scheme kind) l
+  cache_one_scheme kind l
 
 let subst_one_scheme subst (ind,const) =
   (* Remark: const is a def: the result of substitution is a constant *)
   (Mod_subst.subst_ind subst ind, Mod_subst.subst_constant subst const)
 
 let subst_scheme (subst,(kind,l)) =
-  (kind, CArray.Smart.map (subst_one_scheme subst) l)
+  (kind, subst_one_scheme subst l)
 
 let discharge_scheme (kind,l) =
   Some (kind, l)
 
-let inScheme : string * (inductive * Constant.t) array -> Libobject.obj =
+let inScheme : string * (inductive * Constant.t) -> Libobject.obj =
   let open Libobject in
   declare_object @@ superglobal_object "SCHEME"
     ~cache:cache_scheme

--- a/tactics/declareScheme.mli
+++ b/tactics/declareScheme.mli
@@ -10,6 +10,6 @@
 
 open Names
 
-val declare_scheme : string -> (inductive * Constant.t) array -> unit
+val declare_scheme : string -> (inductive * Constant.t) -> unit
 val lookup_scheme : string -> inductive -> Constant.t
 val all_schemes : unit -> Constant.t CString.Map.t Indmap.t

--- a/tactics/elimschemes.ml
+++ b/tactics/elimschemes.ml
@@ -105,23 +105,23 @@ let rect_scheme_kind_from_type =
     (fun env _ x -> build_induction_scheme_in_type env false InType x)
 
 let rect_scheme_kind_from_prop =
-  declare_individual_scheme_object "rect" ~aux:"rect_from_prop"
+  declare_individual_scheme_object ~suff:"rect" "rect_from_prop"
     (fun env _ x -> build_induction_scheme_in_type env false InType x)
 
 let rect_dep_scheme_kind_from_type =
-  declare_individual_scheme_object "rect" ~aux:"rect_from_type"
+  declare_individual_scheme_object ~suff:"rect" "rect_from_type"
     (fun env _ x -> build_induction_scheme_in_type env true InType x)
 
 let rec_scheme_kind_from_type =
-  declare_individual_scheme_object "rec_nodep" ~aux:"rec_nodep_from_type"
+  declare_individual_scheme_object ~suff:"rec_nodep" "rec_nodep_from_type"
   (optimize_non_type_induction_scheme rect_scheme_kind_from_type false InSet)
 
 let rec_scheme_kind_from_prop =
-  declare_individual_scheme_object "rec" ~aux:"rec_from_prop"
+  declare_individual_scheme_object ~suff:"rec" "rec_from_prop"
   (optimize_non_type_induction_scheme rect_scheme_kind_from_prop false InSet)
 
 let rec_dep_scheme_kind_from_type =
-  declare_individual_scheme_object "rec" ~aux:"rec_from_type"
+  declare_individual_scheme_object ~suff:"rec" "rec_from_type"
   (optimize_non_type_induction_scheme rect_dep_scheme_kind_from_type true InSet)
 
 let ind_scheme_kind_from_type =
@@ -133,19 +133,19 @@ let sind_scheme_kind_from_type =
   (fun env _ x -> build_induction_scheme_in_type env false InSProp x)
 
 let ind_dep_scheme_kind_from_type =
-  declare_individual_scheme_object "ind" ~aux:"ind_from_type"
+  declare_individual_scheme_object ~suff:"ind" "ind_from_type"
   (optimize_non_type_induction_scheme rec_dep_scheme_kind_from_type true InProp)
 
 let sind_dep_scheme_kind_from_type =
-  declare_individual_scheme_object "sind" ~aux:"sind_from_type"
+  declare_individual_scheme_object ~suff:"sind" "sind_from_type"
   (fun env _ x -> build_induction_scheme_in_type env true InSProp x)
 
 let ind_scheme_kind_from_prop =
-  declare_individual_scheme_object "ind" ~aux:"ind_from_prop"
+  declare_individual_scheme_object ~suff:"ind" "ind_from_prop"
   (optimize_non_type_induction_scheme rec_scheme_kind_from_prop false InProp)
 
 let sind_scheme_kind_from_prop =
-  declare_individual_scheme_object "sind" ~aux:"sind_from_prop"
+  declare_individual_scheme_object ~suff:"sind" "sind_from_prop"
   (fun env _ x -> build_induction_scheme_in_type env false InSProp x)
 
 let nondep_elim_scheme from_kind to_kind =
@@ -173,11 +173,11 @@ let case_scheme_kind_from_type =
   (fun env _ x -> build_case_analysis_scheme_in_type env false InType x)
 
 let case_scheme_kind_from_prop =
-  declare_individual_scheme_object "case" ~aux:"case_from_prop"
+  declare_individual_scheme_object ~suff:"case" "case_from_prop"
   (fun env _ x -> build_case_analysis_scheme_in_type env false InType x)
 
 let case_dep_scheme_kind_from_type =
-  declare_individual_scheme_object "case" ~aux:"case_from_type"
+  declare_individual_scheme_object ~suff:"case" "case_from_type"
   (fun env _ x -> build_case_analysis_scheme_in_type env true InType x)
 
 let case_dep_scheme_kind_from_type_in_prop =

--- a/tactics/elimschemes.ml
+++ b/tactics/elimschemes.ml
@@ -101,51 +101,51 @@ let optimize_non_type_induction_scheme kind dep sort env _handle ind =
     build_induction_scheme_in_type env dep sort ind
 
 let rect_scheme_kind_from_type =
-  declare_individual_scheme_object "_rect_nodep"
+  declare_individual_scheme_object "rect_nodep"
     (fun env _ x -> build_induction_scheme_in_type env false InType x)
 
 let rect_scheme_kind_from_prop =
-  declare_individual_scheme_object "_rect" ~aux:"_rect_from_prop"
+  declare_individual_scheme_object "rect" ~aux:"rect_from_prop"
     (fun env _ x -> build_induction_scheme_in_type env false InType x)
 
 let rect_dep_scheme_kind_from_type =
-  declare_individual_scheme_object "_rect" ~aux:"_rect_from_type"
+  declare_individual_scheme_object "rect" ~aux:"rect_from_type"
     (fun env _ x -> build_induction_scheme_in_type env true InType x)
 
 let rec_scheme_kind_from_type =
-  declare_individual_scheme_object "_rec_nodep" ~aux:"_rec_nodep_from_type"
+  declare_individual_scheme_object "rec_nodep" ~aux:"rec_nodep_from_type"
   (optimize_non_type_induction_scheme rect_scheme_kind_from_type false InSet)
 
 let rec_scheme_kind_from_prop =
-  declare_individual_scheme_object "_rec" ~aux:"_rec_from_prop"
+  declare_individual_scheme_object "rec" ~aux:"rec_from_prop"
   (optimize_non_type_induction_scheme rect_scheme_kind_from_prop false InSet)
 
 let rec_dep_scheme_kind_from_type =
-  declare_individual_scheme_object "_rec" ~aux:"_rec_from_type"
+  declare_individual_scheme_object "rec" ~aux:"rec_from_type"
   (optimize_non_type_induction_scheme rect_dep_scheme_kind_from_type true InSet)
 
 let ind_scheme_kind_from_type =
-  declare_individual_scheme_object "_ind_nodep"
+  declare_individual_scheme_object "ind_nodep"
   (optimize_non_type_induction_scheme rec_scheme_kind_from_type false InProp)
 
 let sind_scheme_kind_from_type =
-  declare_individual_scheme_object "_sind_nodep"
+  declare_individual_scheme_object "sind_nodep"
   (fun env _ x -> build_induction_scheme_in_type env false InSProp x)
 
 let ind_dep_scheme_kind_from_type =
-  declare_individual_scheme_object "_ind" ~aux:"_ind_from_type"
+  declare_individual_scheme_object "ind" ~aux:"ind_from_type"
   (optimize_non_type_induction_scheme rec_dep_scheme_kind_from_type true InProp)
 
 let sind_dep_scheme_kind_from_type =
-  declare_individual_scheme_object "_sind" ~aux:"_sind_from_type"
+  declare_individual_scheme_object "sind" ~aux:"sind_from_type"
   (fun env _ x -> build_induction_scheme_in_type env true InSProp x)
 
 let ind_scheme_kind_from_prop =
-  declare_individual_scheme_object "_ind" ~aux:"_ind_from_prop"
+  declare_individual_scheme_object "ind" ~aux:"ind_from_prop"
   (optimize_non_type_induction_scheme rec_scheme_kind_from_prop false InProp)
 
 let sind_scheme_kind_from_prop =
-  declare_individual_scheme_object "_sind" ~aux:"_sind_from_prop"
+  declare_individual_scheme_object "sind" ~aux:"sind_from_prop"
   (fun env _ x -> build_induction_scheme_in_type env false InSProp x)
 
 let nondep_elim_scheme from_kind to_kind =
@@ -169,25 +169,25 @@ let build_case_analysis_scheme_in_type env dep sort ind =
   EConstr.Unsafe.to_constr c, Evd.evar_universe_context sigma
 
 let case_scheme_kind_from_type =
-  declare_individual_scheme_object "_case_nodep"
+  declare_individual_scheme_object "case_nodep"
   (fun env _ x -> build_case_analysis_scheme_in_type env false InType x)
 
 let case_scheme_kind_from_prop =
-  declare_individual_scheme_object "_case" ~aux:"_case_from_prop"
+  declare_individual_scheme_object "case" ~aux:"case_from_prop"
   (fun env _ x -> build_case_analysis_scheme_in_type env false InType x)
 
 let case_dep_scheme_kind_from_type =
-  declare_individual_scheme_object "_case" ~aux:"_case_from_type"
+  declare_individual_scheme_object "case" ~aux:"case_from_type"
   (fun env _ x -> build_case_analysis_scheme_in_type env true InType x)
 
 let case_dep_scheme_kind_from_type_in_prop =
-  declare_individual_scheme_object "_casep_dep"
+  declare_individual_scheme_object "casep_dep"
   (fun env _ x -> build_case_analysis_scheme_in_type env true InProp x)
 
 let case_dep_scheme_kind_from_prop =
-  declare_individual_scheme_object "_case_dep"
+  declare_individual_scheme_object "case_dep"
   (fun env _ x -> build_case_analysis_scheme_in_type env true InType x)
 
 let case_dep_scheme_kind_from_prop_in_prop =
-  declare_individual_scheme_object "_casep"
+  declare_individual_scheme_object "casep"
   (fun env _ x -> build_case_analysis_scheme_in_type env true InProp x)

--- a/tactics/elimschemes.mli
+++ b/tactics/elimschemes.mli
@@ -12,26 +12,11 @@ open Ind_tables
 
 (** Induction/recursion schemes *)
 
-val rect_scheme_kind_from_prop : individual scheme_kind
-val ind_scheme_kind_from_prop : individual scheme_kind
-val sind_scheme_kind_from_prop : individual scheme_kind
-val rec_scheme_kind_from_prop : individual scheme_kind
-val rect_scheme_kind_from_type : individual scheme_kind
-val rect_dep_scheme_kind_from_type : individual scheme_kind
-val ind_scheme_kind_from_type : individual scheme_kind
-val ind_dep_scheme_kind_from_type : individual scheme_kind
-val sind_scheme_kind_from_type : individual scheme_kind
-val sind_dep_scheme_kind_from_type : individual scheme_kind
-val rec_scheme_kind_from_type : individual scheme_kind
-val rec_dep_scheme_kind_from_type : individual scheme_kind
-
-val nondep_elim_scheme : Sorts.family -> Sorts.family -> individual scheme_kind
+val elim_scheme : dep:bool -> to_kind:Sorts.family -> individual scheme_kind
 
 (** Case analysis schemes *)
 
-val case_scheme_kind_from_type : individual scheme_kind
-val case_scheme_kind_from_prop : individual scheme_kind
-val case_dep_scheme_kind_from_type : individual scheme_kind
-val case_dep_scheme_kind_from_type_in_prop : individual scheme_kind
-val case_dep_scheme_kind_from_prop : individual scheme_kind
-val case_dep_scheme_kind_from_prop_in_prop : individual scheme_kind
+val case_dep : individual scheme_kind
+val case_nodep : individual scheme_kind
+val casep_dep : individual scheme_kind
+val casep_nodep : individual scheme_kind

--- a/tactics/eqschemes.ml
+++ b/tactics/eqschemes.ml
@@ -231,7 +231,7 @@ let build_sym_scheme env _handle ind =
   c, UState.of_context_set ctx
 
 let sym_scheme_kind =
-  declare_individual_scheme_object "_sym_internal"
+  declare_individual_scheme_object "sym_internal"
   build_sym_scheme
 
 (**********************************************************************)
@@ -304,7 +304,7 @@ let build_sym_involutive_scheme env handle ind =
   in (c, UState.of_context_set ctx)
 
 let sym_involutive_scheme_kind =
-  declare_individual_scheme_object "_sym_involutive"
+  declare_individual_scheme_object "sym_involutive"
   ~deps:(fun _ ind -> [SchemeIndividualDep (ind, sym_scheme_kind)])
   build_sym_involutive_scheme
 
@@ -705,7 +705,7 @@ let build_r2l_rew_scheme dep env ind k =
 (* with H:I p1..pn a1..an in Gamma                                    *)
 (**********************************************************************)
 let rew_l2r_dep_scheme_kind =
-  declare_individual_scheme_object "_rew_r_dep"
+  declare_individual_scheme_object "rew_r_dep"
   ~deps:(fun _ ind -> [
     SchemeIndividualDep (ind, sym_scheme_kind);
     SchemeIndividualDep (ind, sym_involutive_scheme_kind);
@@ -719,7 +719,7 @@ let rew_l2r_dep_scheme_kind =
 (* or   H:I b1..bn a1..an in Gamma (symmetric case)                   *)
 (**********************************************************************)
 let rew_r2l_dep_scheme_kind =
-  declare_individual_scheme_object "_rew_dep"
+  declare_individual_scheme_object "rew_dep"
   (fun env _ ind -> build_r2l_rew_scheme true env ind InType)
 
 (**********************************************************************)
@@ -729,7 +729,7 @@ let rew_r2l_dep_scheme_kind =
 (* or   H:I b1..bn a1..an in Gamma (symmetric case)                   *)
 (**********************************************************************)
 let rew_r2l_forward_dep_scheme_kind =
-  declare_individual_scheme_object "_rew_fwd_dep"
+  declare_individual_scheme_object "rew_fwd_dep"
   (fun env _ ind -> build_r2l_forward_rew_scheme true env ind InType)
 
 (**********************************************************************)
@@ -739,7 +739,7 @@ let rew_r2l_forward_dep_scheme_kind =
 (* with H:I p1..pn a1..an in Gamma                                    *)
 (**********************************************************************)
 let rew_l2r_forward_dep_scheme_kind =
-  declare_individual_scheme_object "_rew_fwd_r_dep"
+  declare_individual_scheme_object "rew_fwd_r_dep"
   (fun env _ ind -> build_l2r_forward_rew_scheme true env ind InType)
 
 (**********************************************************************)
@@ -752,7 +752,7 @@ let rew_l2r_forward_dep_scheme_kind =
 (* standard form of schemes in Coq)                                   *)
 (**********************************************************************)
 let rew_l2r_scheme_kind =
-  declare_individual_scheme_object "_rew_r"
+  declare_individual_scheme_object "rew_r"
   (fun env _ ind -> fix_r2l_forward_rew_scheme env
      (build_r2l_forward_rew_scheme false env ind InType))
 
@@ -763,7 +763,7 @@ let rew_l2r_scheme_kind =
 (* introducing commutative cuts, we adopt it                          *)
 (**********************************************************************)
 let rew_r2l_scheme_kind =
-  declare_individual_scheme_object "_rew"
+  declare_individual_scheme_object "rew"
   (fun env _ ind -> build_r2l_rew_scheme false env ind InType)
 
 (* End of rewriting schemes *)
@@ -848,7 +848,7 @@ let build_congr env (eq,refl,ctx) ind =
             mkApp (mkVar varf, [|lift (mip.mind_nrealargs+3) b|])|])|])))))))
   in c, UState.of_context_set ctx
 
-let congr_scheme_kind = declare_individual_scheme_object "_congr"
+let congr_scheme_kind = declare_individual_scheme_object "congr"
   (fun env _ ind ->
      (* May fail if equality is not defined *)
    build_congr env (get_coq_eq env UnivGen.empty_sort_context) ind)

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -1004,11 +1004,8 @@ let gen_absurdity id =
 *)
 
 let ind_scheme_of_eq lbeq to_kind =
-  Proofview.tclENV >>= fun env ->
-  let (mib,mip) = Inductive.lookup_mind_specif env (destIndRef lbeq.eq) in
-  let from_kind = inductive_sort_family mip in
   (* use ind rather than case by compatibility *)
-  let kind = Elimschemes.nondep_elim_scheme from_kind to_kind in
+  let kind = Elimschemes.elim_scheme ~dep:false ~to_kind in
   find_scheme kind (destIndRef lbeq.eq) >>= fun c ->
   Proofview.tclUNIT (GlobRef.ConstRef c)
 

--- a/tactics/ind_tables.ml
+++ b/tactics/ind_tables.ml
@@ -103,10 +103,7 @@ let redeclare_schemes eff =
       String.Map.add kind ((ind, c) :: old) accu
   in
   let schemes = Cmap.fold fold eff.Evd.seff_roles String.Map.empty in
-  let iter kind defs =
-    let defs = Array.of_list defs in
-    DeclareScheme.declare_scheme kind defs
-  in
+  let iter kind defs = List.iter (DeclareScheme.declare_scheme kind) defs in
   String.Map.iter iter schemes
 
 let local_lookup_scheme eff kind ind = match lookup_scheme kind ind with

--- a/tactics/ind_tables.mli
+++ b/tactics/ind_tables.mli
@@ -33,7 +33,17 @@ type individual_scheme_object_function =
 
 (** Main functions to register a scheme builder. Note these functions
    are not safe to be used by plugins as their effects won't be undone
-   on backtracking *)
+   on backtracking.
+
+    The first string argument is used as the suffix (after a "_") for
+    the name of generated schemes with no explicit names. It is also
+    the default value of [aux].
+
+    [aux] must be unique: across the Coq process's lifetime
+    [declare_*_scheme_object] may be called at most once with a given
+    [aux]. It is used to generate [scheme_kind] in a marshal-stable
+    way and otherwise unused.
+*)
 
 val declare_mutual_scheme_object : string ->
   ?deps:(Environ.env -> MutInd.t -> scheme_dependency list) ->
@@ -45,6 +55,9 @@ val declare_individual_scheme_object : string ->
   ?aux:string ->
   individual_scheme_object_function ->
   individual scheme_kind
+
+val is_declared_scheme_object : string -> bool
+(** Is the string used as the name of a [scheme_kind]? *)
 
 (** Force generation of a (mutually) scheme with possibly user-level names *)
 

--- a/tactics/ind_tables.mli
+++ b/tactics/ind_tables.mli
@@ -35,24 +35,24 @@ type individual_scheme_object_function =
    are not safe to be used by plugins as their effects won't be undone
    on backtracking.
 
-    The first string argument is used as the suffix (after a "_") for
-    the name of generated schemes with no explicit names. It is also
-    the default value of [aux].
+    In [declare_X_scheme_object key ?suff ?deps f], [key] is the name
+    of the scheme kind. It must be unique across the Coq process's
+    lifetime. It is used to generate [scheme_kind] in a marshal-stable
+    way and as the scheme name in Register Scheme.
 
-    [aux] must be unique: across the Coq process's lifetime
-    [declare_*_scheme_object] may be called at most once with a given
-    [aux]. It is used to generate [scheme_kind] in a marshal-stable
-    way and otherwise unused.
+    [suff] defaults to [key], generated schemes which aren't given an
+    explicit name will be named "ind_suff" where "ind" is the
+    inductive's name.
 *)
 
 val declare_mutual_scheme_object : string ->
+  ?suff:string ->
   ?deps:(Environ.env -> MutInd.t -> scheme_dependency list) ->
-  ?aux:string ->
   mutual_scheme_object_function -> mutual scheme_kind
 
 val declare_individual_scheme_object : string ->
+  ?suff:string ->
   ?deps:(Environ.env -> inductive -> scheme_dependency list) ->
-  ?aux:string ->
   individual_scheme_object_function ->
   individual scheme_kind
 

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -948,18 +948,19 @@ let fold_match ?(force=false) env sigma c =
         it_mkProd_or_LetIn (subst1 mkProp body) (List.tl ctx)
     in
     let sk =
+      (* not sure how correct this is *)
       if sortp == Sorts.InProp then
         if sortc == Sorts.InProp then
-          if dep then case_dep_scheme_kind_from_prop
-          else case_scheme_kind_from_prop
+          if dep then case_dep
+          else case_nodep
         else (
           if dep
-          then case_dep_scheme_kind_from_type_in_prop
-          else case_scheme_kind_from_type)
+          then casep_dep
+          else case_nodep (* should this be casep_nodep? *))
       else ((* sortc <> InProp by typing *)
         if dep
-        then case_dep_scheme_kind_from_type
-        else case_scheme_kind_from_type)
+        then case_dep
+        else case_nodep)
     in
     match Ind_tables.lookup_scheme sk ci.ci_ind with
     | Some cst ->

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -852,7 +852,7 @@ let build_beq_scheme env handle kn =
   res, uctx
 
 let beq_scheme_kind =
-  Ind_tables.declare_mutual_scheme_object "_beq"
+  Ind_tables.declare_mutual_scheme_object "beq"
   ~deps:build_beq_scheme_deps
   build_beq_scheme
 
@@ -1182,7 +1182,7 @@ let make_bl_scheme_deps env ind =
   Ind_tables.SchemeMutualDep (ind, beq_scheme_kind) :: List.map map inds
 
 let bl_scheme_kind =
-  Ind_tables.declare_mutual_scheme_object "_dec_bl"
+  Ind_tables.declare_mutual_scheme_object "dec_bl"
   ~deps:make_bl_scheme_deps
   make_bl_scheme
 
@@ -1313,7 +1313,7 @@ let make_lb_scheme_deps env ind =
   Ind_tables.SchemeMutualDep (ind, beq_scheme_kind) :: List.map map inds
 
 let lb_scheme_kind =
-  Ind_tables.declare_mutual_scheme_object "_dec_lb"
+  Ind_tables.declare_mutual_scheme_object "dec_lb"
   ~deps:make_lb_scheme_deps
   make_lb_scheme
 
@@ -1494,7 +1494,7 @@ let make_eq_decidability env handle mind =
   ([|ans|], ctx)
 
 let eq_dec_scheme_kind =
-  Ind_tables.declare_mutual_scheme_object "_eq_dec"
+  Ind_tables.declare_mutual_scheme_object "eq_dec"
   ~deps:(fun _ ind -> [SchemeMutualDep (ind, bl_scheme_kind); SchemeMutualDep (ind, lb_scheme_kind)])
   make_eq_decidability
 

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -251,7 +251,7 @@ let register_side_effect (c, body, role) =
   let () = register_constant c Decls.(IsProof Theorem) Locality.ImportDefaultBehavior in
   match role with
   | None -> ()
-  | Some (Evd.Schema (ind, kind)) -> DeclareScheme.declare_scheme kind [|ind,c|]
+  | Some (Evd.Schema (ind, kind)) -> DeclareScheme.declare_scheme kind (ind,c)
 
 let get_roles export eff =
   let map (c, body) =

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -277,6 +277,8 @@ GRAMMAR EXTEND Gram
               l = LIST1 identref SEP "," -> { VernacCombinedScheme (id, l) }
       | IDENT "Register"; g = global; "as"; quid = qualid ->
           { VernacRegister(g, RegisterCoqlib quid) }
+      | IDENT "Register"; IDENT "Scheme"; g = global; "as"; qid = qualid; IDENT "for"; g' = global ->
+        { VernacRegister(g, RegisterScheme {inductive = g'; scheme_kind = qid}) }
       | IDENT "Register"; IDENT "Inline"; g = global ->
           { VernacRegister(g, RegisterInline) }
       | IDENT "Primitive"; id = ident_decl; typopt = OPT [ ":"; typ = lconstr -> { typ } ]; ":="; r = register_token ->
@@ -1122,6 +1124,7 @@ GRAMMAR EXTEND Gram
       | IDENT "Strategy"; qid = smart_global -> { PrintStrategy (Some qid) }
       | IDENT "Strategies" -> { PrintStrategy None }
       | IDENT "Registered" -> { PrintRegistered }
+      | IDENT "Registered"; IDENT "Schemes" -> { PrintRegisteredSchemes }
     ] ]
   ;
   printunivs_subgraph:

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -676,6 +676,8 @@ let pr_printable = function
     keyword "Print Strategy" ++ pr_smart_global qid
   | PrintRegistered ->
     keyword "Print Registered"
+  | PrintRegisteredSchemes ->
+    keyword "Print Registered Schemes"
   | PrintNotation (Constrexpr.InConstrEntry, ntn_key) ->
     keyword "Print Notation" ++ spc() ++ str ntn_key
   | PrintNotation (Constrexpr.InCustomEntry ent, ntn_key) ->
@@ -1224,6 +1226,12 @@ let pr_synpure_vernac_expr v =
       hov 2
         (keyword "Register" ++ spc() ++ pr_qualid qid ++ spc () ++ str "as"
          ++ spc () ++ pr_qualid name)
+    )
+  | VernacRegister (qid, RegisterScheme {inductive; scheme_kind}) ->
+    return (
+      hov 2
+        (keyword "Register" ++ spc() ++ keyword "Scheme" ++ spc() ++ pr_qualid qid ++ spc () ++ str "as"
+         ++ spc () ++ pr_qualid scheme_kind ++ spc() ++ str "for" ++ spc() ++ pr_qualid inductive)
     )
   | VernacRegister (qid, RegisterInline) ->
     return (

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -63,6 +63,7 @@ type printable =
   | PrintAssumptions of bool * bool * qualid or_by_notation
   | PrintStrategy of qualid or_by_notation option
   | PrintRegistered
+  | PrintRegisteredSchemes
   | PrintNotation of Constrexpr.notation_entry * string
 
 type glob_search_where = InHyp | InConcl | Anywhere
@@ -297,6 +298,7 @@ type section_subset_expr =
 type register_kind =
   | RegisterInline
   | RegisterCoqlib of qualid
+  | RegisterScheme of { inductive : qualid; scheme_kind : qualid }
 
 (** {6 Types concerning the module layer} *)
 


### PR DESCRIPTION
This allows to register constants in the scheme mechanism, such that the scheme generator does not run.

Useful to work around bugs like https://github.com/coq/coq/issues/5341: instead of having to write a dummy definition to get subst to generate its schemes we can define them directly, and use alternate definitions if we want.

See also https://github.com/HoTT/Coq-HoTT/pull/1794

The scheme kinds are currently low level and undocumented. This is IMO acceptable in the same way as we accept undocumented names in the regular `Register`.
It would be nice to stabilize and document some (especially for induction principles, then we could deprecate finding them by name) but first we should probably do a bit of refactoring so that the situation is less confusing (currently there are a bunch of scheme_kinds for induction principles depending on if the inductive lives in Prop and if target is in prop, for instance `Register False_ind as ind_from_prop for False` is not very nice and we should be able to make `Register False_ind as ind for False` work).

Also fix #18298 

Future work: make `induction` lookup registered schemes instead of hacking names