### PR TITLE
Fix check that sections are not opened when starting a module

### DIFF
--- a/library/lib.ml
+++ b/library/lib.ml
@@ -387,6 +387,7 @@ module SynterpActions : LibActions with type summary = Summary.Synterp.frozen = 
     let dir = Libnames.add_dirpath_suffix !synterp_state.path_prefix.Nametab.obj_dir id in
     let prefix = Nametab.{ obj_dir = dir; obj_mp = mp; } in
     check_mod_fresh ~is_type prefix id;
+    assert (not (sections_are_opened()));
     add_entry (OpenedModule (is_type,export,prefix,fs));
     synterp_state := { !synterp_state with path_prefix = prefix } ;
     prefix

--- a/test-suite/bugs/bug_18307.v
+++ b/test-suite/bugs/bug_18307.v
@@ -1,0 +1,17 @@
+
+Module E. End E.
+Module Type ET. End ET.
+
+Section S.
+  Fail Module Type Prover.
+
+  Fail Module M.
+
+  Fail Module M := E.
+
+  Fail Module Type M := ET.
+
+  Fail Include E.
+
+  Fail Declare Module M : ET.
+End S.

--- a/vernac/synterp.ml
+++ b/vernac/synterp.ml
@@ -155,6 +155,8 @@ let synterp_import export refl =
   export, List.map (fun (qid,f) -> CAst.make ?loc:qid.loc @@ synterp_import_mod export qid f, f) refl
 
 let synterp_define_module export {loc;v=id} (binders_ast : module_binder list) mty_ast_o mexpr_ast_l =
+  if Lib.sections_are_opened () then
+    user_err Pp.(str "Modules and Module Types are not allowed inside sections.");
   let export = Option.map (on_snd synterp_import_cats) export in
   match mexpr_ast_l with
     | [] ->
@@ -187,6 +189,8 @@ let synterp_define_module export {loc;v=id} (binders_ast : module_binder list) m
        export, args, [], expr, sign
 
 let synterp_declare_module_type_syntax {loc;v=id} binders_ast mty_sign mty_ast_l =
+  if Lib.sections_are_opened () then
+    user_err Pp.(str "Modules and Module Types are not allowed inside sections.");
   match mty_ast_l with
     | [] ->
        let binders_ast,argsexport =


### PR DESCRIPTION
Lib.sections_are_opened relies on the invariant that there are no modules in sections.

This was broken by the synterp phase.

We enforce the invariant in Lib with an assert and in vernac with proper user readable errors.

Fix #18307
