### PR TITLE
Turn Impargs.implicit_status into a record.

### DIFF
--- a/dev/ci/user-overlays/18312-ppedrot-detuplify-impargs.sh
+++ b/dev/ci/user-overlays/18312-ppedrot-detuplify-impargs.sh
@@ -1,0 +1,5 @@
+overlay elpi https://github.com/ppedrot/coq-elpi detuplify-impargs 18312
+
+overlay serapi https://github.com/ppedrot/coq-serapi detuplify-impargs 18312
+
+overlay vscoq https://github.com/ppedrot/vscoq detuplify-impargs 18312

--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -317,9 +317,14 @@ type force_inference = bool (* true = always infer, never turn into evar/subgoal
 
 type implicit_position = Name.t * int * int option
 
-type implicit_status =
-    (* None = Not implicit *)
-    (implicit_position * implicit_explanation * (maximal_insertion * force_inference)) option
+type implicit_status_info = {
+  impl_pos : implicit_position;
+  impl_expl : implicit_explanation;
+  impl_max : maximal_insertion;
+  impl_force : force_inference;
+}
+
+type implicit_status = implicit_status_info option
 
 type implicit_side_condition = DefaultImpArgs | LessArgsThan of int
 
@@ -332,47 +337,48 @@ let is_status_implicit = function
 let name_of_pos k = Id.of_string ("arg_" ^ string_of_int k)
 
 let binding_kind_of_status = function
-  | Some (_, _, (false, _)) -> NonMaxImplicit
-  | Some (_, _, (true, _)) -> MaxImplicit
+  | Some { impl_max = false } -> NonMaxImplicit
+  | Some { impl_max = true } -> MaxImplicit
   | None -> Explicit
 
 let name_of_implicit = function
   | None -> anomaly (Pp.str "Not an implicit argument.")
-  | Some ((Name id,_,_),_,_) -> id
-  | Some ((Anonymous,k,_),_,_) -> name_of_pos k
+  | Some { impl_pos = (Name id, _, _) } -> id
+  | Some { impl_pos = (Anonymous, k, _) } -> name_of_pos k
 
 let match_implicit imp pos = match imp, pos with
   | None, _ -> anomaly (Pp.str "Not an implicit argument.")
-  | Some ((Name id,_,_),_,_), ExplByName id' -> Id.equal id id'
-  | Some ((_,_,Some n),_,_), ExplByPos n' -> Int.equal n n'
-  | Some ((_,n,_),_,_), ExplByName id -> Id.equal id (name_of_pos n)
+  | Some { impl_pos = (Name id, _, _) }, ExplByName id' -> Id.equal id id'
+  | Some { impl_pos = (_, _, Some n) }, ExplByPos n' -> Int.equal n n'
+  | Some { impl_pos = (_, n, _) }, ExplByName id -> Id.equal id (name_of_pos n)
   | _ -> false
 
 let maximal_insertion_of = function
-  | Some (_,_,(b,_)) -> b
+  | Some imp -> imp.impl_max
   | None -> anomaly (Pp.str "Not an implicit argument.")
 
 let force_inference_of = function
-  | Some (_, _, (_, b)) -> b
+  | Some imp -> imp.impl_force
   | None -> anomaly (Pp.str "Not an implicit argument.")
 
 let is_nondep_implicit p imps =
-  List.exists (function Some ((_,_,Some p'),_,_) -> Int.equal p p' | _ -> false) imps
+  List.exists (function Some { impl_pos = (_,_,Some p') } -> Int.equal p p' | _ -> false) imps
 
 (* [in_ctx] means we know the expected type, [n] is the index of the argument *)
 let is_inferable_implicit in_ctx n = function
   | None -> false
-  | Some (_,DepRigid (Hyp p),_) -> in_ctx || n >= p
-  | Some (_,DepFlex (Hyp p),_) -> false
-  | Some (_,DepFlexAndRigid (_,Hyp q),_) -> in_ctx || n >= q
-  | Some (_,DepRigid Conclusion,_) -> in_ctx
-  | Some (_,DepFlex Conclusion,_) -> false
-  | Some (_,DepFlexAndRigid (_,Conclusion),_) -> in_ctx
-  | Some (_,Manual,_) -> true
+  | Some { impl_expl = DepRigid (Hyp p) } -> in_ctx || n >= p
+  | Some { impl_expl = DepFlex (Hyp p) } -> false
+  | Some { impl_expl = DepFlexAndRigid (_,Hyp q) } -> in_ctx || n >= q
+  | Some { impl_expl = DepRigid Conclusion } -> in_ctx
+  | Some { impl_expl = DepFlex Conclusion } -> false
+  | Some { impl_expl = DepFlexAndRigid (_,Conclusion) } -> in_ctx
+  | Some { impl_expl = Manual } -> true
 
 let explicitation = function
   | None -> anomaly (Pp.str "not implicit")
-  | Some ((na,_,p),_,_) ->
+  | Some imp ->
+    let (na, _, p) = imp.impl_pos in
     match na, p with
     | Name id, _ -> ExplByName id
     | _, Some p -> ExplByPos p
@@ -391,7 +397,13 @@ let rec prepare_implicits i f = function
   | [] -> []
   | ((na,_,_ as pos), Some imp)::imps ->
       let imps' = prepare_implicits (i+1) f imps in
-      Some (pos,imp,(set_maximality Silent na i imps' f.maximal,true)) :: imps'
+      let data = {
+        impl_pos = pos;
+        impl_expl = imp;
+        impl_max = set_maximality Silent na i imps' f.maximal;
+        impl_force = true
+      } in
+      Some data :: imps'
   | _::imps -> None :: prepare_implicits (i+1) f imps
 
 let set_manual_implicits silent flags enriching autoimps l =
@@ -401,11 +413,26 @@ let set_manual_implicits silent flags enriching autoimps l =
        let imps' = merge (k+1) autoimps explimps in
        begin match autoimp, explimp.CAst.v with
        | ((Name _ as na,_,_ as pos),_), Some (_,max) ->
-          Some (pos, Manual, (set_maximality (if silent then Silent else Error) na k imps' max, true))
+          Some {
+            impl_pos = pos;
+            impl_expl = Manual;
+            impl_max = set_maximality (if silent then Silent else Error) na k imps' max;
+            impl_force = true;
+          }
        | ((Anonymous,n1,n2),_), Some (na,max) ->
-          Some ((na,n1,n2),Manual,(max,true))
+          Some {
+            impl_pos = (na,n1,n2);
+            impl_expl = Manual;
+            impl_max = max;
+            impl_force = true;
+          }
        | ((na,_,_ as pos),Some exp), None when enriching ->
-          Some (pos, exp, (set_maximality (if silent then Silent else Info) na k imps' flags.maximal, true))
+          Some {
+            impl_pos = pos;
+            impl_expl = exp;
+            impl_max = set_maximality (if silent then Silent else Info) na k imps' flags.maximal;
+            impl_force = true;
+          }
        | (pos,_), None -> None
        end :: imps'
     | [], [] -> []
@@ -488,7 +515,7 @@ let merge_impls (cond,oldimpls) (_,newimpls) =
   let oldimpls,usersuffiximpls = List.chop (List.length newimpls) oldimpls in
   cond, (List.map2 (fun orig ni ->
     match orig with
-    | Some (_, Manual, _) -> orig
+    | Some { impl_expl = Manual } -> orig
     | _ -> ni) oldimpls newimpls)@usersuffiximpls
 
 (* Caching implicits *)
@@ -514,15 +541,15 @@ let implicits_of_global ref =
       let rec rename implicits names = match implicits, names with
         | [], _ -> []
         | _, [] -> implicits
-        | Some ((_,n1,n2), x,y) :: implicits, Name id :: names ->
-           Some ((Name id,n1,n2), x,y) :: rename implicits names
+        | Some ({ impl_pos = (_, n1, n2) } as impl) :: implicits, Name id :: names ->
+           Some { impl with impl_pos = (Name id, n1, n2) } :: rename implicits names
         | imp :: implicits, _ :: names -> imp :: rename implicits names
       in
       List.map (fun (t, il) -> t, rename il rename_l) l
     with Not_found -> l
   with Not_found -> [DefaultImpArgs,[]]
 
-let cache_implicits_decl (ref,imps) =
+let cache_implicits_decl (ref, imps) =
   implicits_table := GlobRef.Map.add ref imps !implicits_table
 
 let load_implicits _ (_,l) = List.iter cache_implicits_decl l
@@ -543,9 +570,12 @@ let sec_implicits =
 
 let impls_of_context vars =
   let map n id =
+    let impl_pos = (Name id, n, None) in
     match Id.Map.get id !sec_implicits with
-    | NonMaxImplicit -> Some ((Name id,n,None), Manual, (false, true))
-    | MaxImplicit -> Some ((Name id,n,None), Manual, (true, true))
+    | NonMaxImplicit ->
+      Some { impl_pos; impl_expl = Manual; impl_max = false; impl_force = true }
+    | MaxImplicit ->
+      Some { impl_pos; impl_expl = Manual; impl_max = true; impl_force = true }
     | Explicit -> None
   in
   List.map_i map 1 vars
@@ -564,7 +594,9 @@ let lift_explanation p = function
   | DepFlexAndRigid (e1,e2) -> DepFlexAndRigid (lift_argument_position p e1,lift_argument_position p e2)
   | Manual -> Manual
 
-let lift_implicits p ((na,n1,o),e,b) = ((na,n1+p,o),lift_explanation p e,b)
+let lift_implicits p imp =
+  let (na, n1, o) = imp.impl_pos in
+  { imp with impl_pos = (na, n1 + p, o); impl_expl = lift_explanation p imp.impl_expl }
 
 let add_section_impls vars extra_impls (cond,impls) =
   let p = List.length vars - List.length extra_impls in
@@ -715,11 +747,23 @@ let compute_implicit_statuses autoimps l =
   let rec aux i = function
     | _ :: autoimps, (_, Explicit) :: manualimps -> None :: aux (i+1) (autoimps, manualimps)
     | pos :: autoimps, (na, MaxImplicit) :: manualimps ->
-       Some (set_name pos na, Manual, (true, true)) :: aux (i+1) (autoimps, manualimps)
+      let imp = {
+        impl_pos = set_name pos na;
+        impl_expl = Manual;
+        impl_max = true;
+        impl_force = true;
+      } in
+      Some imp :: aux (i+1) (autoimps, manualimps)
     | pos :: autoimps, (na, NonMaxImplicit) :: manualimps ->
-       let imps' = aux (i+1) (autoimps, manualimps) in
-       let max = set_maximality Error na i imps' false in
-       Some (set_name pos na, Manual, (max, true)) :: imps'
+      let imps' = aux (i+1) (autoimps, manualimps) in
+      let max = set_maximality Error na i imps' false in
+      let imp = {
+        impl_pos = set_name pos na;
+        impl_expl = Manual;
+        impl_max = max;
+        impl_force = true;
+      } in
+      Some imp :: imps'
     | autoimps, [] -> List.map (fun _ -> None) autoimps
     | [], _::_ -> assert false
   in aux 1 (autoimps, l)

--- a/interp/impargs.mli
+++ b/interp/impargs.mli
@@ -70,8 +70,14 @@ type force_inference = bool (** true = always infer, never turn into evar/subgoa
 
 type implicit_position = Name.t * int * int option
 
-type implicit_status = (implicit_position * implicit_explanation *
-                          (maximal_insertion * force_inference)) option
+type implicit_status_info = {
+  impl_pos : implicit_position;
+  impl_expl : implicit_explanation;
+  impl_max : maximal_insertion;
+  impl_force : force_inference;
+}
+
+type implicit_status = implicit_status_info option
     (** [None] = Not implicit *)
 
 type implicit_side_condition

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -202,10 +202,14 @@ let build_wellfounded pm (recname,pl,bl,arityc,body) poly ?typing_flags ?depreca
       Constrintern.compute_internalization_data env sigma recname
         Constrintern.Recursive full_arity impls
     in
+    let impl = Some Impargs.{
+      impl_pos = (Name (Id.of_string "recproof"), 1, None);
+      impl_expl = Manual;
+      impl_max = true;
+      impl_force = false;
+    } in
     let newimpls = Id.Map.singleton recname
-        (Constrintern.extend_internalization_data interning_data
-           (Some ((Name (Id.of_string "recproof"),1,None), Impargs.Manual, (true, false)))
-           []) in
+        (Constrintern.extend_internalization_data interning_data impl []) in
     interp_casted_constr_evars ~program_mode:true (push_rel_context ctx env) sigma
       ~impls:newimpls body (lift 1 top_arity)
   in

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -242,7 +242,7 @@ let needs_extra_scopes ref scopes =
 
 let implicit_kind_of_status = function
   | None -> Anonymous, Glob_term.Explicit
-  | Some ((na,_,_),_,(maximal,_)) -> na, if maximal then Glob_term.MaxImplicit else Glob_term.NonMaxImplicit
+  | Some imp -> pi1 imp.impl_pos, if imp.impl_max then Glob_term.MaxImplicit else Glob_term.NonMaxImplicit
 
 let extra_implicit_kind_of_status imp =
   let _,imp = implicit_kind_of_status imp in


### PR DESCRIPTION
Trivial cleanup on my way to sorting out the mess we currently have with evar kinds.

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/547
- https://github.com/ejgallego/coq-serapi/pull/370
- https://github.com/coq-community/vscoq/pull/688