### PR TITLE
Fix relevance handling in Tactics.mutual_fix

### DIFF
--- a/test-suite/bugs/bug_18308.v
+++ b/test-suite/bugs/bug_18308.v
@@ -1,0 +1,8 @@
+Inductive thing : SProp :=.
+
+Fixpoint foobar (x:thing) {struct x} : thing.
+Proof.
+  Guarded.
+  exact x.
+  Guarded.
+Defined.


### PR DESCRIPTION
This is used by the interactive Fixpoint command so fix #18308
