### PR TITLE
Fix check that fixpoints on SProp inductives produce SProp values

### DIFF
--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -1437,7 +1437,7 @@ let inductive_of_mutfix env ((nvect,bodynum),(names,types,bodies as recdef)) =
        not (Environ.is_type_in_type env (GlobRef.IndRef ind))
     then
       begin
-        if names.(i).Context.binder_relevance == Sorts.Relevant
+        if not (names.(i).Context.binder_relevance == Sorts.Irrelevant)
         then raise_err env i FixpointOnIrrelevantInductive
       end;
     res

--- a/test-suite/bugs/bug_18314.v
+++ b/test-suite/bugs/bug_18314.v
@@ -1,0 +1,19 @@
+Section Well_founded.
+
+ Variable A : Type.
+ Variable R : A -> A -> Prop.
+
+ Inductive Acc (x: A) : SProp :=
+     Acc_intro : (forall y:A, R y x -> Acc y) -> Acc x.
+
+ Lemma Acc_inv : forall x:A, Acc x -> forall y:A, R y x -> Acc y.
+  destruct 1; trivial.
+ Defined.
+
+ Global Arguments Acc_inv [x] _ [y] _, [x] _ y _.
+
+ Fail Polymorphic Definition Fix_F@{s|u|} (P:A -> Type@{s|u}) (F:forall {x:A}, (forall y:A, R y x -> P y) -> P x)
+   := fix Fix_F {x:A} (a:Acc x) {struct a} : P x :=
+     F (fun (y:A) (h:R y x) => Fix_F (Acc_inv a h)).
+
+End Well_founded.


### PR DESCRIPTION
Fix #18314
