### PR TITLE
Ltac2: fix level of `red_flags:()` notation

### DIFF
--- a/user-contrib/Ltac2/RedFlags.v
+++ b/user-contrib/Ltac2/RedFlags.v
@@ -14,7 +14,7 @@ Require Import Ltac2.Std.
 Ltac2 Type t := Std.red_flags.
 
 Module Export Notations.
-Ltac2 Notation "red_flags:(" s(strategy) ")" := s.
+Ltac2 Notation "red_flags:(" s(strategy) ")" : 0 := s.
 End Notations.
 
 Ltac2 none := {


### PR DESCRIPTION
Fix #18309
