### PR TITLE
Fix mistake about iris in ci-basic-overlays

### DIFF
--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -84,7 +84,7 @@ project corn "https://github.com/coq-community/corn" "master"
 ########################################################################
 
 # NB: stdpp and Iris refs are gotten from the opam files in the Iris
-# and lambdaRust repos respectively.
+# and iris_examples repos respectively.
 project stdpp "https://gitlab.mpi-sws.org/iris/stdpp" ""
 
 project iris "https://gitlab.mpi-sws.org/iris/iris" ""


### PR DESCRIPTION
The CI actually uses the iris version in iris-examples, not in LambdaRust.