### PR TITLE
Fix ci-compcert/ci-vst for local ci

### DIFF
--- a/dev/ci/ci-compcert.sh
+++ b/dev/ci/ci-compcert.sh
@@ -12,9 +12,15 @@ if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
 # CompCert does compile with -native-compiler yes
 # but with excessive memory requirements
 export COQCOPTS='-native-compiler no -w -undeclared-scope -w -omega-is-deprecated'
-( cd "${CI_BUILD_DIR}/compcert"
-  [ -e Makefile.config ] || ./configure -ignore-coq-version x86_32-linux -install-coqdev -clightgen -use-external-MenhirLib -use-external-Flocq -prefix ${CI_INSTALL_DIR} -coqdevdir ${CI_INSTALL_DIR}/lib/coq/user-contrib/compcert
-  make
-  make check-proof COQCHK='"$(COQBIN)coqchk" -silent -o $(COQINCLUDES)'
-  make install
+(
+	cd "${CI_BUILD_DIR}/compcert"
+	if ! [ -e Makefile.config ]; then
+		./configure -ignore-coq-version x86_32-linux -install-coqdev \
+		-clightgen -use-external-MenhirLib -use-external-Flocq \
+		-prefix "$COQBIN" \
+		-coqdevdir "$COQLIB"/user-contrib/compcert
+	fi
+	make
+	make check-proof COQCHK='"$(COQBIN)coqchk" -silent -o $(COQINCLUDES)'
+	make install
 )


### PR DESCRIPTION
This (hopefully) fixes a problem when running `make ci-vst` from a local repository.