### PR TITLE
[CI] Temporary fix for coqword

### DIFF
--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -386,7 +386,9 @@ project itauto "https://gitlab.inria.fr/fbesson/itauto" "master"
 ########################################################################
 # Mathcomp-word
 ########################################################################
-project mathcomp_word "https://github.com/jasmin-lang/coqword" "main"
+project mathcomp_word "https://github.com/jasmin-lang/coqword" "v2.2"
+# go back to "main" and change dependency to MC 2 when
+# https://github.com/jasmin-lang/jasmin/pull/560 is merged
 
 ########################################################################
 # Jasmin


### PR DESCRIPTION
coqword moved to mathcomp 2, temporarily fix the branch to the version just before port until the reverse dependency jasmin is ported.
