### PR TITLE
Stronger disambiguation of vernac extension names.

### DIFF
--- a/dev/ci/user-overlays/18345-ppedrot-harden-vernacextend-naming.sh
+++ b/dev/ci/user-overlays/18345-ppedrot-harden-vernacextend-naming.sh
@@ -1,0 +1,3 @@
+overlay elpi https://github.com/ppedrot/coq-elpi harden-vernacextend-naming 18345
+
+overlay serapi https://github.com/ppedrot/coq-serapi harden-vernacextend-naming 18345

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -126,13 +126,7 @@ let pr_ast { expr; indentation } = Pp.(int indentation ++ str " " ++ Ppvernac.pr
 (* Commands piercing opaque *)
 let may_pierce_opaque = function
   | VernacSynPure (VernacPrint _) -> true
-  | VernacSynterp (VernacExtend (("Extraction",_), _)
-    | VernacExtend (("SeparateExtraction",_), _)
-    | VernacExtend (("ExtractionLibrary",_), _)
-    | VernacExtend (("RecursiveExtractionLibrary",_), _)
-    | VernacExtend (("ExtractionConstant",_), _)
-    | VernacExtend (("ExtractionInlinedConstant",_), _)
-    | VernacExtend (("ExtractionInductive",_), _)) -> true
+  | VernacSynterp (VernacExtend ({ ext_plugin = "coq-core.plugins.extraction" }, _)) -> true
   | _ -> false
 
 type depth = int

--- a/vernac/egramml.ml
+++ b/vernac/egramml.ml
@@ -82,7 +82,7 @@ let get_extend_vernac_rule s =
 
 let declare_vernac_command_grammar ~allow_override s nt gl =
   let () = if not allow_override && Hashtbl.mem vernac_exts s
-    then CErrors.anomaly Pp.(str "bad vernac extend: " ++ str (fst s) ++ str ", " ++ int (snd s))
+    then CErrors.anomaly Pp.(str "bad vernac extend: " ++ str s.ext_entry ++ str ", " ++ int s.ext_index)
   in
   let nt = Option.default Pvernac.Vernac_.command nt in
   Hashtbl.add vernac_exts s (nt, gl)

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -686,7 +686,7 @@ let pr_using e =
 let pr_extend s cl =
   let pr_arg a =
     try pr_gen a
-    with Failure _ -> str "<error in " ++ str (fst s) ++ str ">" in
+    with Failure _ -> str "<error in " ++ str s.ext_entry ++ str ">" in
   try
     let rl = Egramml.get_extend_vernac_rule s in
     let rec aux rl cl =
@@ -697,7 +697,7 @@ let pr_extend s cl =
       | _ -> assert false in
     hov 1 (pr_sequence identity (aux rl cl))
   with Not_found ->
-    hov 1 (str "TODO(" ++ str (fst s) ++ spc () ++ prlist_with_sep sep pr_arg cl ++ str ")")
+    hov 1 (str "TODO(" ++ str s.ext_entry ++ spc () ++ prlist_with_sep sep pr_arg cl ++ str ")")
 
 let pr_synpure_vernac_expr v =
   let return = tag_vernac v in

--- a/vernac/vernac_classifier.ml
+++ b/vernac/vernac_classifier.ml
@@ -84,7 +84,7 @@ let classify_vernac e =
     | VernacLoad _ -> VtSideff ([], VtNow)
     | VernacExtend (s,l) ->
         try Vernacextend.get_vernac_classifier s l
-        with Not_found -> anomaly(str"No classifier for"++spc()++str (fst s)++str".")
+        with Not_found -> anomaly(str"No classifier for"++spc()++str s.ext_entry ++str".")
   in
   let static_pure_classifier ~atts e = match e with
     (* Qed *)

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -327,13 +327,16 @@ type arguments_modifier =
   | `ReductionNeverUnfold
   | `Rename ]
 
-type extend_name =
-  (* Name of the vernac entry where the tactic is defined, typically found
+type extend_name = {
+  ext_plugin : string;
+  (** Name of the plugin where the extension is defined as per DECLARE PLUGIN *)
+  ext_entry : string;
+  (** Name of the vernac entry where the tactic is defined, typically found
      after the VERNAC EXTEND statement in the source. *)
-  string *
+  ext_index : int;
   (* Index of the extension in the VERNAC EXTEND statement. Each parsing branch
      is given an offset, starting from zero. *)
-  int
+}
 
 type discharge = DoDischarge | NoDischarge
 

--- a/vernac/vernacextend.mli
+++ b/vernac/vernacextend.mli
@@ -122,7 +122,7 @@ val static_linking_done : unit -> unit
     enabled it.
 *)
 val declare_dynamic_vernac_extend
-  : command:string
+  : command:Vernacexpr.extend_name
   -> ?entry:Vernacexpr.vernac_expr Pcoq.Entry.t
   -> depr:bool
   -> 's (* classifier *)


### PR DESCRIPTION
We prepend the plugin name to the vernac entry name. This prevents accidental conflict between two plugins defining VERNAC EXTEND entries with the same name. This happens currently with equations and quickchick that both define a Derive command, leading to the impossibility of requiring both at the same time.

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/550
- https://github.com/ejgallego/coq-serapi/pull/372