### PR TITLE
Fix #18193 don't trigger file deprecation transitively

### DIFF
--- a/checker/values.ml
+++ b/checker/values.ml
@@ -436,7 +436,7 @@ let v_stm_seg = v_pair v_tasks v_counters
 (** Toplevel structures in a vo (see Cic.mli) *)
 
 let v_deprecation =
-  v_pair (Opt String) (Opt String)
+  v_tuple "deprecation" [|Opt String; Opt String|]
 
 let v_library_info =
   v_sum "library_info" 0 [|[|String|];[|v_deprecation|]|]

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -439,7 +439,7 @@ let v_deprecation =
   v_tuple "deprecation" [|Opt String; Opt String|]
 
 let v_library_info =
-  v_sum "library_info" 0 [|[|String|];[|v_deprecation|]|]
+  v_sum "library_info" 0 [|[|v_deprecation|]|]
 
 let v_libsum =
   Tuple ("summary", [|v_dp;v_deps;String;List v_library_info|])

--- a/doc/sphinx/using/libraries/writing.rst
+++ b/doc/sphinx/using/libraries/writing.rst
@@ -31,16 +31,26 @@ deprecated compatibility alias using :cmd:`Notation (abbreviation)`
 
    It can trigger the following warnings:
 
-   .. warn:: Tactic @qualid is deprecated since @string__since. @string__note
-             Tactic Notation @qualid is deprecated since @string__since. @string__note
-             Notation @string is deprecated since @string__since. @string__note
-             Ltac2 definition @qualid is deprecated since @string__since. @string__note
+   .. warn:: Library File @qualid is deprecated since @string__since. @string__note
+             Library File (transitively required) @qualid is deprecated since @string__since. @string__note
              Ltac2 alias @qualid is deprecated since @string__since. @string__note
+             Ltac2 definition @qualid is deprecated since @string__since. @string__note
              Ltac2 notation {+ @ltac2_scope } is deprecated since @string__since. @string__note
+             Notation @string is deprecated since @string__since. @string__note
+             Tactic @qualid is deprecated since @string__since. @string__note
+             Tactic Notation @qualid is deprecated since @string__since. @string__note
 
       :n:`@qualid` or :n:`@string` is the notation,
       :n:`@string__since` is the version number, :n:`@string__note` is
       the note (usually explains the replacement).
+
+      Explicitly :cmd:`Require`\ing a file that has been deprecated,
+      using the :cmd:`Attributes` command, triggers a ``Library File``
+      deprecation warning. Requiring a deprecated file, even indirectly through a chain of
+      :cmd:`Require`\s, will produce a
+      ``Library File (transitively required)`` deprecation warning
+      if the :opt:`Warnings` option "deprecated-transitive-library-file"
+      is set (it is "-deprecated-transitive-library-file" by default, silencing the warning).
 
 .. note::
 

--- a/lib/deprecation.ml
+++ b/lib/deprecation.ml
@@ -37,9 +37,9 @@ let printer ~object_name pp (x,{since;note}) =
   pr_opt (fun since -> str "since " ++ str since) since ++
   str "." ++ pr_opt (fun note -> str note) note
 
-let create_warning ~object_name ~warning_name_if_no_since pp =
+let create_warning ?default ~object_name ~warning_name_if_no_since pp =
   let pp = printer ~object_name pp in
-  let main_cat, main_w = CWarnings.create_hybrid ~name:warning_name_if_no_since ~from:[depr_cat] () in
+  let main_cat, main_w = CWarnings.create_hybrid ?default ~name:warning_name_if_no_since ~from:[depr_cat] () in
   let main_w = CWarnings.create_in main_w pp in
   let warnings = ref CString.Map.empty in
   fun ?loc (v, ({since} as info)) ->
@@ -51,7 +51,7 @@ let create_warning ~object_name ~warning_name_if_no_since pp =
         | Some w -> w
         | None ->
           let generic_cat = get_generic_cat since in
-          let w = CWarnings.create_warning ~from:[main_cat; generic_cat]
+          let w = CWarnings.create_warning ?default ~from:[main_cat; generic_cat]
               ~name:(warning_name_if_no_since ^ "-since-" ^ since) ()
           in
           let w = CWarnings.create_in w pp in

--- a/lib/deprecation.mli
+++ b/lib/deprecation.mli
@@ -12,7 +12,7 @@ type t = { since : string option ; note : string option }
 
 val make : ?since:string -> ?note:string -> unit -> t
 
-val create_warning : object_name:string -> warning_name_if_no_since:string ->
+val create_warning : ?default:CWarnings.status -> object_name:string -> warning_name_if_no_since:string ->
   ('b -> Pp.t) -> ?loc:Loc.t -> 'b * t -> unit
 
 module Version : sig

--- a/library/library_info.ml
+++ b/library/library_info.ml
@@ -21,6 +21,14 @@ let warn_library_deprecated =
     ~warning_name_if_no_since:"deprecated-library-file"
     (fun dp -> DirPath.print dp)
 
-let warn_library_info ?loc (dp,infos) =
+let warn_library_deprecated_transitive =
+  Deprecation.create_warning ~object_name:"Library File (transitively required)"
+    ~warning_name_if_no_since:"deprecated-transitive-library-file"
+    ~default:CWarnings.Disabled
+    (fun dp -> DirPath.print dp)
+
+let warn_library_info ?loc ?(transitive=false) (dp,infos) =
   match infos with
-  | Deprecation t -> warn_library_deprecated ?loc (dp, t)
+  | Deprecation t ->
+     if transitive then warn_library_deprecated_transitive ?loc (dp, t)
+     else warn_library_deprecated ?loc (dp, t)

--- a/library/library_info.mli
+++ b/library/library_info.mli
@@ -14,4 +14,4 @@ open Names
 
 type t = Deprecation of Deprecation.t
 
-val warn_library_info : ?loc:Loc.t -> DirPath.t * t -> unit
+val warn_library_info : ?loc:Loc.t -> ?transitive:bool -> DirPath.t * t -> unit

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -308,6 +308,9 @@ unit-tests/%.ml.log: unit-tests/%.ml unit-tests/src/$(UNIT_LINK)
 # Other generic tests
 #######################################################################
 
+# There is a dependency between those two files
+prerequisite/library_attributes_require.v.log: prerequisite/library_attributes.v.log
+
 $(addsuffix .log,$(wildcard prerequisite/*.v)): %.v.log: %.v
 	@echo "TEST      $< $(call get_coq_prog_args_in_parens,"$<")"
 	$(HIDE){ \

--- a/test-suite/output/library_attributes_require_transitive.out
+++ b/test-suite/output/library_attributes_require_transitive.out
@@ -1,0 +1,4 @@
+File "./output/library_attributes_require_transitive.v", line 5, characters 0-37:
+Warning: Library File TestSuite.library_attributes is deprecated since XX YY.
+This library is useless.
+[deprecated-library-file-since-XX-YY,deprecated-since-XX-YY,deprecated-library-file,deprecated,default]

--- a/test-suite/output/library_attributes_require_transitive.out
+++ b/test-suite/output/library_attributes_require_transitive.out
@@ -2,3 +2,7 @@ File "./output/library_attributes_require_transitive.v", line 5, characters 0-37
 Warning: Library File TestSuite.library_attributes is deprecated since XX YY.
 This library is useless.
 [deprecated-library-file-since-XX-YY,deprecated-since-XX-YY,deprecated-library-file,deprecated,default]
+File "./output/library_attributes_require_transitive.v", line 11, characters 0-45:
+Warning: Library File (transitively required) TestSuite.library_attributes is
+deprecated since XX YY. This library is useless.
+[deprecated-transitive-library-file-since-XX-YY,deprecated-since-XX-YY,deprecated-transitive-library-file,deprecated]

--- a/test-suite/output/library_attributes_require_transitive.v
+++ b/test-suite/output/library_attributes_require_transitive.v
@@ -3,3 +3,9 @@ Require TestSuite.library_attributes_require.
 (* but still printed on direct requirement even if the Require doesn't actually
    do anything (because file is already loaded) *)
 Require TestSuite.library_attributes.
+
+(* We have the second warning "deprecated-transitive-library-file"
+   that always triggers (even on transitive requires) *)
+Reset Initial.
+Set Warnings "deprecated-transitive-library-file".
+Require TestSuite.library_attributes_require.

--- a/test-suite/output/library_attributes_require_transitive.v
+++ b/test-suite/output/library_attributes_require_transitive.v
@@ -1,0 +1,5 @@
+(* check that file deprecations are only printed on direct requirement *)
+Require TestSuite.library_attributes_require.
+(* but still printed on direct requirement even if the Require doesn't actually
+   do anything (because file is already loaded) *)
+Require TestSuite.library_attributes.

--- a/test-suite/prerequisite/library_attributes_require.v
+++ b/test-suite/prerequisite/library_attributes_require.v
@@ -1,0 +1,1 @@
+../output/library_attributes_require.v

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -285,6 +285,9 @@ let intern_from_file lib_resolver dir =
        DirPath.print lsd.md_name ++ spc () ++ str "and not library" ++
        spc() ++ DirPath.print dir ++ str ".");
   Feedback.feedback (Feedback.FileLoaded(DirPath.to_string dir, f));
+  List.iter (fun info ->
+      Library_info.warn_library_info ~transitive:true (lsd.md_name,info))
+    lsd.md_info;
   lsd, lmd, digest_lmd, univs, digest_u, del_opaque
 
 let rec intern_library ~intern (needed, contents as acc) dir =


### PR DESCRIPTION
Following https://github.com/coq/coq/pull/18193 we had the following behavior:

in A.v
```Coq
Attributes deprecated(note="A deprecated").
```

in B.v
```Coq
Require Import A.
(* warning as expected *)
```

in C.v
```Coq
Require Import B.
(* also a warning *)
```

Whereas we don't want the warning in the last case. This triggers the warnings only when directly requiring a file.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
<!-- Fixes / closes #???? -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] ~Added **changelog**.~
- [ ] ~Added / updated **documentation**.~
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] ~Documented any new / changed **user messages**.~
  - [ ] ~Updated **documented syntax** by running `make doc_gram_rsts`.~

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] ~Opened **overlay** pull requests.~

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
