### PR TITLE
Program: don't error when Program.Tactics / Program.Wf are not required unless necessary

### DIFF
--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -2654,8 +2654,7 @@ let next_obligation ~pm ?(final=false) n tac =
 
 let check_program_libraries () =
   Coqlib.check_required_library Coqlib.datatypes_module_name;
-  Coqlib.check_required_library ["Coq";"Init";"Specif"];
-  Coqlib.check_required_library ["Coq";"Program";"Tactics"]
+  Coqlib.check_required_library ["Coq";"Init";"Specif"]
 
 (* aliases *)
 let prepare_obligation = prepare_obligation


### PR DESCRIPTION
Program.Tactics is never necessary AFAICT

Program.Wf is necessary when doing wellfounded recursion AND the related constants aren't registered (in master we error even if they're registered)