### PR TITLE
Fix typo in documentation

### DIFF
--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -159,7 +159,7 @@ One can define new types with the following commands.
       tac2rec_field ::= {? mutable } @ident : @ltac2_type
 
    :n:`:=`
-     Defines a type with with an explicit set of constructors
+     Defines a type with an explicit set of constructors
 
    :n:`::=`
      Extends an existing open variant type, a special kind of variant type whose constructors are not

--- a/theories/ssr/ssreflect.v
+++ b/theories/ssr/ssreflect.v
@@ -332,7 +332,7 @@ Register protect_term as plugins.ssreflect.protect_term.
   - unkeyed t will match any subterm that unifies with t, regardless of
     whether it displays the same head symbol as t.
   - unkeyed t a b will match any application of a term f unifying with t,
-    to two arguments unifying with with a and b, respectively, regardless of
+    to two arguments unifying with a and b, respectively, regardless of
     apparent head symbols.
   - unkeyed x where x is a variable will match any subterm with the same
     type as x (when x would raise the 'indeterminate pattern' error).        **)


### PR DESCRIPTION
"with with" should be "with"

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->

<!-- If this is a feature pull request / breaks compatibility: -->
  <!-- Check if the following applies, otherwise remove these lines. -->

<!-- If this breaks external libraries or plugins in CI: -->

<!-- Pointers to relevant developer documentation:
