### PR TITLE
[docker] [ci] Bump base build edge deps.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,7 @@ variables:
   # echo $(md5sum dev/ci/docker/old_ubuntu_lts/Dockerfile | head -c 10)
   # echo $(md5sum dev/ci/docker/edge_ubuntu/Dockerfile | head -c 10)
   BASE_CACHEKEY: "old_ubuntu_lts-V2023-06-30-8ca33f9dfd"
-  EDGE_CACHEKEY: "edge_ubuntu-V2023-08-28-93124ee272"
+  EDGE_CACHEKEY: "edge_ubuntu-V2023-11-30-ba911a5fa6"
   BASE_IMAGE: "$CI_REGISTRY_IMAGE:$BASE_CACHEKEY"
   EDGE_IMAGE: "$CI_REGISTRY_IMAGE:$EDGE_CACHEKEY"
 

--- a/dev/ci/docker/edge_ubuntu/Dockerfile
+++ b/dev/ci/docker/edge_ubuntu/Dockerfile
@@ -38,9 +38,9 @@ ENV NJOBS="2" \
 
 # Edge opam is the set of edge packages required by Coq
 ENV COMPILER="4.14.1" \
-    BASE_OPAM="zarith.1.11 ounit2.2.2.6" \
+    BASE_OPAM="zarith.1.13 ounit2.2.2.6" \
     CI_OPAM="ocamlgraph.2.0.0 cppo.1.6.9" \
-    BASE_OPAM_EDGE="dune.3.6.1 dune-build-info.3.6.1 dune-release.1.6.2 ocamlfind.1.9.5 odoc.2.1.1" \
+    BASE_OPAM_EDGE="dune.3.12.1 dune-build-info.3.12.1 dune-release.2.0.0 ocamlfind.1.9.6 odoc.2.3.1" \
     CI_OPAM_EDGE="elpi.1.17.0 ppx_import.1.10.0 cmdliner.1.1.1 sexplib.v0.15.1 ppx_sexp_conv.v0.15.1 ppx_hash.v0.15.0 ppx_compare.v0.15.0 ppx_deriving_yojson.3.7.0 yojson.2.1.0 uri.4.2.0 ppx_yojson_conv.v0.15.1 ppx_inline_test.v0.15.1 ppx_assert.v0.15.0 lsp.1.16.2" \
     COQIDE_OPAM_EDGE="lablgtk3-sourceview3.3.1.3"
 


### PR DESCRIPTION
About time we bump, soon 3.6.1 will become the base dune build version.

