### PR TITLE
Fix typos in universe polymorphism documentation

### DIFF
--- a/doc/sphinx/addendum/universe-polymorphism.rst
+++ b/doc/sphinx/addendum/universe-polymorphism.rst
@@ -364,7 +364,7 @@ Insufficiently restrictive variance annotations lead to errors:
 
       Inductive Invariant @{=u} : Type@{u}.
       Inductive Covariant @{+u} : Type@{u}.
-      Inductive Irrelevent@{*u} : Type@{u}.
+      Inductive Irrelevant@{*u} : Type@{u}.
 
       Section Universes.
         Universe low high.
@@ -388,13 +388,13 @@ Insufficiently restrictive variance annotations lead to errors:
         Fail Check (co_high : Covariant@{low}).
    .. coqtop:: in
 
-        (* An invariant universe allows cumulativity from any level *)
-        Axiom irr_low  : Irrelevent@{low}.
-        Axiom irr_high : Irrelevent@{high}.
+        (* An irrelevant universe allows cumulativity from any level *)
+        Axiom irr_low  : Irrelevant@{low}.
+        Axiom irr_high : Irrelevant@{high}.
    .. coqtop:: all
 
-        Check (irr_low : Irrelevent@{high}).
-        Check (irr_high : Irrelevent@{low}).
+        Check (irr_low : Irrelevant@{high}).
+        Check (irr_high : Irrelevant@{low}).
    .. coqtop:: in
 
       End Universes.

--- a/test-suite/success/coercions.v
+++ b/test-suite/success/coercions.v
@@ -79,7 +79,7 @@ Defined.
 
 Definition ClaimA := forall (X Y:Setoid) (f: extSetoid X Y) x, f x= f x.
 
-Coercion irrelevent := (fun _ => I) : True -> car (Build_Setoid True).
+Coercion irrelevant := (fun _ => I) : True -> car (Build_Setoid True).
 
 Definition ClaimB := forall (X Y:Setoid) (f: extSetoid X Y) (x:X), f x= f x.
 


### PR DESCRIPTION
There was an "invariant" which should have been "irrelevant", and "irrelevant" was spelled "irrelevent".