### PR TITLE
Handle compatibility constants in conversion

### DIFF
--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -192,7 +192,8 @@ val eta_expand_ind_stack : env -> pinductive -> fconstr -> stack ->
     reference is irrelevant and the infos was created with
     [create_conv_infos]. *)
 val unfold_ref_with_args
-  : clos_infos
+  : ?force_def:bool
+  -> clos_infos
   -> clos_tab
   -> table_key
   -> stack

--- a/kernel/conversion.ml
+++ b/kernel/conversion.ml
@@ -484,8 +484,18 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
        | None ->
          begin match t2 with
           | FFlex fl2 ->
-            begin match unfold_ref_with_args infos.cnv_inf infos.rgt_tab fl2 v2 with
+            let force_def =
+              match fl2 with
+              | ConstKey (cst, _) -> Constant.CanOrd.equal (Projection.constant p1) cst
+              | _ -> false
+            in
+            begin match unfold_ref_with_args ~force_def infos.cnv_inf infos.rgt_tab fl2 v2 with
              | Some t2 ->
+               let appr1 =
+                 if force_def then
+                   (lft1, (mk_red (FProj (Projection.unfold p1, r1, c1)), v1))
+                 else appr1
+               in
                eqappr cv_pb l2r infos appr1 (lft2, t2) cuniv
              | None -> raise NotConvertible
             end
@@ -500,8 +510,18 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
        | None ->
          begin match t1 with
           | FFlex fl1 ->
-            begin match unfold_ref_with_args infos.cnv_inf infos.lft_tab fl1 v1 with
+            let force_def =
+              match fl1 with
+              | ConstKey (cst, _) -> Constant.CanOrd.equal (Projection.constant p2) cst
+              | _ -> false
+            in
+            begin match unfold_ref_with_args ~force_def infos.cnv_inf infos.lft_tab fl1 v1 with
              | Some t1 ->
+               let appr2 =
+                 if force_def then
+                   (lft2, (mk_red (FProj (Projection.unfold p2, r2, c2)), v2))
+                 else appr2
+               in
                eqappr cv_pb l2r infos (lft1, t1) appr2 cuniv
              | None -> raise NotConvertible
             end

--- a/test-suite/bugs/bug_18281.v
+++ b/test-suite/bugs/bug_18281.v
@@ -1,0 +1,20 @@
+Require Import Ltac2.Ltac2.
+
+#[projections(primitive)]
+Record r (n : nat) := { w : Prop -> Prop -> Prop }.
+
+Class C (P : Prop) := {}.
+
+Goal forall (v : r 0) (Q P : Prop), C (v.(w _) P Q).
+Proof.
+  intros.
+
+  #[local] Opaque w.
+
+  lazy_match! goal with
+  | [ |- ?g ] =>
+      let t := constr:(w 0) in
+      let t := constr:(C ($t v P Q)) in
+      Unification.unify (TransparentState.current ()) g t
+  end.
+Abort.


### PR DESCRIPTION
When converting a primitive projection with the corresponding opaque compabitility constant, we force the unfolding of the compatibility constant, and also make the projection unfolded.

Both steps are required, since compabitiliy constants are defined to be unfolded projections, and unfolded projectons are pushed to the stack during weak-head reduction, while folded projections remain in head position.

This is an alternative to https://github.com/coq/coq/pull/18327, which has no chance of making it in time for 8.19 at this point.

CC @ppedrot.

Fixes https://github.com/coq/coq/issues/18281.

- [ ] Added **changelog**.