### PR TITLE
Fix artifacts for build:vio by merging build:vio and validate:vio

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -166,10 +166,10 @@ before_script:
   needs:
     - not-a-real-job
   script:
-    # exit 0: workaround for https://gitlab.com/gitlab-org/gitlab/issues/202505
+    # put || exit 0 as a workaround if https://gitlab.com/gitlab-org/gitlab/issues/202505 reoccurs
     # the validate:vio job is sometimes started before build:vio, without artifacts
     # we ignore these spurious errors so if the job fails it's a real error
-    - cd _install_ci || exit 0
+    - cd _install_ci
     - bin/coqchk -o -m -coqlib lib/coq/ -dir lib/coq > ../coqchk.log 2>&1 || touch coqchk.failed
     - tail -n 1000 ../coqchk.log # the log is too big for gitlab so pipe to a file and display the tail
     - "[ ! -f coqchk.failed ]" # needs quoting for yml syntax reasons

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -105,6 +105,7 @@ before_script:
   script:
     - make $DUNE_TARGET
     - find _build -name '*.vio' -exec rm -f {} \;
+    - if [ "$VALIDATE" ]; then _build/install/default/bin/coqchk -o -m -dir _build/install/default/ > coqchk.log 2>&1 || touch coqchk.failed; tail -n 1000 coqchk.log; test ! -f coqchk.failed; fi
     - tar cfj _build.tar.bz2 _build
   variables:
     DUNE_TARGET: world
@@ -330,23 +331,20 @@ build:base+async:
       - dmesg.txt
   timeout: 1h 30min
 
-build:vio:
+# merged job  because allow_failure has issues with dependencies
+# cf https://gitlab.com/gitlab-org/gitlab/issues/202505
+build-validate:vio:
   extends: .build-template:base:dev
   variables:
-    COQ_EXTRA_CONF: "-native-compiler no"
     COQ_DUNE_EXTRA_OPT: "-vio"
     DUNE_TARGET: "vio world"
+    VALIDATE: "true"
   after_script:
     - dmesg > dmesg.txt
   allow_failure: true # See https://github.com/coq/coq/issues/9637
   only:
     variables:
       - ($FULL_CI == "true" && $UNRELIABLE =~ /enabled/)
-  artifacts:
-    when: always
-    paths:
-      - _install_ci
-      - dmesg.txt
 
 lint:
   stage: build
@@ -571,14 +569,6 @@ validate:edge+flambda:
   variables:
     OPAM_VARIANT: "+flambda"
   only: *full-ci
-
-validate:vio:
-  extends: .validate-template
-  needs:
-    - build:vio
-  only:
-    variables:
-      - ($FULL_CI == "true" && $UNRELIABLE =~ /enabled/)
 
 # Libraries are by convention the projects that depend on Coq
 # but not on its ML API

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -169,8 +169,7 @@ before_script:
     # the validate:vio job is sometimes started before build:vio, without artifacts
     # we ignore these spurious errors so if the job fails it's a real error
     - cd _install_ci || exit 0
-    - find lib/coq/ -name '*.vo' -fprint0 vofiles
-    - xargs -0 --arg-file=vofiles bin/coqchk -o -m -coqlib lib/coq/ > ../coqchk.log 2>&1 || touch coqchk.failed
+    - bin/coqchk -o -m -coqlib lib/coq/ -dir lib/coq > ../coqchk.log 2>&1 || touch coqchk.failed
     - tail -n 1000 ../coqchk.log # the log is too big for gitlab so pipe to a file and display the tail
     - "[ ! -f coqchk.failed ]" # needs quoting for yml syntax reasons
   artifacts:

--- a/doc/sphinx/practical-tools/coq-commands.rst
+++ b/doc/sphinx/practical-tools/coq-commands.rst
@@ -635,6 +635,10 @@ Command-line options ``-Q``, ``-R``, ``-where`` and ``-impredicative-set`` are s
 by ``coqchk`` and have the same meaning as for ``coqtop``. As there is no notion of
 relative paths in object files ``-Q`` and ``-R`` have exactly the same meaning.
 
+:-dir *dir*:
+   Check `.vo` files in the given directory (skipping files
+   and directories starting with `.`)
+
 :-norec *module*: Check *module* but do not check its dependencies.
 :-admit *module*: Do not check *module* and any of its dependencies,
   unless explicitly required.

--- a/lib/system.mli
+++ b/lib/system.mli
@@ -40,7 +40,7 @@ val process_directory : (file_kind -> unit) -> unix_path -> unit
 
 (** [process_subdirectories f path] applies [f path/file file] on each
     [file] of the directory [path]; fails with Unix_error if the
-    latter does not exists; kips all files or dirs starting with "." *)
+    latter does not exists; skips all files or dirs starting with "." *)
 
 val process_subdirectories : (unix_path -> string -> unit) -> unix_path -> unit
 


### PR DESCRIPTION
https://github.com/coq/coq/pull/17785 changed the artifact paths but
this job wasn't adapted.

Because of the workaround for
https://gitlab.com/gitlab-org/gitlab/issues/202505 this wasn't detected.

In this PR we also try removing the workaround, maybe the problem is fixed?