### PR TITLE
[compat] Split ltac2 compat to its own file.

### DIFF
--- a/doc/stdlib/index-list.html.template
+++ b/doc/stdlib/index-list.html.template
@@ -717,6 +717,7 @@ through the <tt>Require Import</tt> command.</p>
     theories/Compat/Coq818.v
     theories/Compat/Coq819.v
     theories/Compat/Coq820.v
+    user-contrib/Ltac2/Compat/Coq818.v
   </dd>
 
   <dt> <b>Array</b>:

--- a/sysinit/coqargs.ml
+++ b/sysinit/coqargs.ml
@@ -238,6 +238,13 @@ let get_compat_file = function
     CErrors.user_err
       Pp.(str "Unknown compatibility version \"" ++ str s ++ str "\".")
 
+(* Workaround for the OCaml parser using regex in update-compat.py *)
+let get_compat_files v =
+  let coq_compat = get_compat_file v in
+  match v with
+  | "8.18" | "8.17" -> coq_compat :: ["Ltac2.Compat.Coq818"]
+  | _ -> [coq_compat]
+
 let to_opt_key = Str.(split (regexp " +"))
 
 let parse_option_set opt =
@@ -300,7 +307,8 @@ let parse_args ~usage ~init arglist : t * string list =
       }}
 
     |"-compat" ->
-      add_vo_require oval (get_compat_file (next ())) None (Some Lib.Import)
+      get_compat_files (next ()) |>
+      List.fold_left (fun oval lib -> add_vo_require oval lib None (Some Lib.Import)) oval
 
     |"-exclude-dir" ->
       System.exclude_directory (next ()); oval

--- a/theories/Compat/Coq818.v
+++ b/theories/Compat/Coq818.v
@@ -55,14 +55,3 @@ Ltac Z.euclidean_division_equations_cleanup ::=
          | [ H : ?A -> ?x = ?y -> _, H' : ?x < ?y |- _ ] => clear H
          | [ H : ?A -> ?x = ?y -> _, H' : ?y < ?x |- _ ] => clear H
          end.
-
-Local Set Warnings "-masking-absolute-name".
-
-Require Ltac2.Array.
-
-Module Export Ltac2.
-  Module Array.
-    Export Ltac2.Array.
-    Ltac2 empty () := empty.
-  End Array.
-End Ltac2.

--- a/user-contrib/Ltac2/Compat/Coq818.v
+++ b/user-contrib/Ltac2/Compat/Coq818.v
@@ -1,0 +1,10 @@
+Local Set Warnings "-masking-absolute-name".
+
+Require Ltac2.Array.
+
+Module Export Ltac2.
+  Module Array.
+    Export Ltac2.Array.
+    Ltac2 empty () := empty.
+  End Array.
+End Ltac2.


### PR DESCRIPTION
Fixes #18381

In a next PR, I will remove `-Q $ltac2_dir Ltac2` from the stdlib build, so we don't get this problem again.

