### PR TITLE
[build] [gen_rules] Don't allow cyclic deps between stdlib and ltac2

### DIFF
--- a/tools/dune_rule_gen/coq_rules.ml
+++ b/tools/dune_rule_gen/coq_rules.ml
@@ -137,7 +137,6 @@ module Boot_type = struct
   type t = Stdlib | NoInit | Regular of Theory.t
 end
 
-
 (* Context for a Coq theory *)
 module Context = struct
 
@@ -181,13 +180,6 @@ module Context = struct
   let build_dep_info ~coqdep_args dir_info =
     Dep_info.make ~args:coqdep_args ~dir_info
 
-  let ltac2_theory =
-    Theory.
-      { directory = Path.make "user-contrib/Ltac2"
-      ; dirname = ["Ltac2"]
-      ; implicit = false
-      }
-
   let make ~root_lvl ~theory ~user_flags ~boot ~rule ~async ~dir_info ~split =
 
     let flags =
@@ -198,7 +190,7 @@ module Context = struct
 
       let boot_paths = match boot with
         | Boot_type.NoInit -> []
-        | Stdlib -> Theory.args theory @ Theory.args ltac2_theory
+        | Stdlib -> Theory.args theory
         | Regular stdlib -> Theory.args stdlib @ Theory.args theory
       in
       let loadpath =


### PR DESCRIPTION
Due to #18381 , I think this is the wisest choice for now, until we
decide what we want to do.

We refactor the file a bit, and remove the `Regular None` case which
was in fact identical to `NoInit`.

This reverts 82775de4defa3f6303c0f00777af15bdd9c455e8 part of #17568 .

This requires PR #18382 .
