### PR TITLE
[ci] Test native Dune build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -311,6 +311,22 @@ build:edge+flambda:
 build:base:dev:
   extends: .build-template:base:dev
 
+# Build using native dune rules
+build:base:dev:dune:
+  stage: build
+  image: $EDGE_IMAGE
+  variables:
+    OPAM_VARIANT: "+flambda"
+  interruptible: true
+  extends: .auto-use-tags
+  script:
+    - cp theories/dune.disabled theories/dune
+    - cp user-contrib/Ltac2/dune.disabled user-contrib/Ltac2/dune
+    - dune build -p coq-core,coq-stdlib,coq,coqide-server
+    - ls _build/install/default/lib/coq/theories/Reals/Reals.vo
+    - ls _build/install/default/lib/coq/user-contrib/Ltac2/Ltac2.vo
+  only: *full-ci
+
 build:base+async:
   extends: .build-template
   variables:

--- a/dune-project
+++ b/dune-project
@@ -5,7 +5,7 @@
 (using directory-targets 0.1)
 
 ; We need this due to `(coq.pp )` declarations
-(using coq 0.3)
+(using coq 0.6)
 
 (formatting
  (enabled_for ocaml))


### PR DESCRIPTION
This build mode is used in some projects like jsCoq, coq-universe, and
quite a few others that look to rely on them.

This is an important sanity test, as Coq rules are usually first
developed in Dune, then ported to Coq's own generator.
