### PR TITLE
Some improvements with the "with" syntax of some tactics

### DIFF
--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -484,7 +484,7 @@ let meta_with_name evd ({CAst.v=id} as lid) =
         in
         if na != Anonymous then Name.get_id na :: l else l
       in
-      let mvl = Evd.Metamap.fold fold (Evd.meta_list evd) [] in
+      let mvl = List.rev (Evd.Metamap.fold fold (Evd.meta_list evd) []) in
       explain_no_such_bound_variable mvl lid
     | (n::_,_|_,n::_) ->
         n

--- a/tactics/eClause.mli
+++ b/tactics/eClause.mli
@@ -45,6 +45,8 @@ type hole = {
       appears somewhere in the returned clause. *)
   hole_name : Name.t;
   (** Name of the hole coming from its binder. *)
+  hole_evar_key : Evar.t;
+  (** Internal evar key of the hole. *)
 }
 
 type clause = {
@@ -74,3 +76,5 @@ val check_bindings : 'a explicit_bindings -> unit
 val explain_no_such_bound_variable : Id.t list -> Id.t CAst.t -> 'a
 
 val error_not_right_number_missing_arguments : int -> 'a
+
+val check_evar_clause :  Environ.env -> evar_map -> evar_map -> clause -> unit

--- a/tactics/tacticals.mli
+++ b/tactics/tacticals.mli
@@ -115,6 +115,13 @@ val tclMAPDELAYEDWITHHOLES : bool -> 'a delayed_open list -> ('a -> unit tactic)
     argument of [l] are evaluated in the possibly-updated
     environment and updated sigma of each new successive goals *)
 
+val check_evar_list : Environ.env -> evar_map -> Evar.Set.t -> evar_map -> Evar.t list
+  (* [check_evar_list env sigma evars origsigma] returns the subset of
+     [evars] not instantiated (up to restriction) in the extension
+     [sigma] of [origsigma] where evars of [origsigma] are considered
+     as "axioms", that is that an evar of [evars] instantiated by an
+     evar of [origsigma] is considered to be instantiated *)
+
 val tclTIMEOUT : int -> unit tactic -> unit tactic
 val tclTIME : string option -> 'a tactic -> 'a tactic
 

--- a/test-suite/output/apply_with.out
+++ b/test-suite/output/apply_with.out
@@ -1,3 +1,18 @@
 File "./output/apply_with.v", line 3, characters 11-26:
 The command has indeed failed with message:
 No such bound variable d (possible names are: a, b and c).
+File "./output/apply_with.v", line 4, characters 11-26:
+The command has indeed failed with message:
+Unable to find an instance for the variable b.
+File "./output/apply_with.v", line 5, characters 24-25:
+The command has indeed failed with message:
+No such bound variable d (possible names are: a, b and c).
+File "./output/apply_with.v", line 6, characters 5-31:
+The command has indeed failed with message:
+Unable to find an instance for the variables b, c.
+File "./output/apply_with.v", line 14, characters 23-24:
+The command has indeed failed with message:
+No such bound variable c (possible names are: a and b).
+File "./output/apply_with.v", line 15, characters 5-16:
+The command has indeed failed with message:
+Unable to find an instance for the variables a, b.

--- a/test-suite/output/apply_with.out
+++ b/test-suite/output/apply_with.out
@@ -1,0 +1,3 @@
+File "./output/apply_with.v", line 3, characters 11-26:
+The command has indeed failed with message:
+No such bound variable d (possible names are: a, b and c).

--- a/test-suite/output/apply_with.v
+++ b/test-suite/output/apply_with.v
@@ -1,0 +1,6 @@
+Axiom f : forall a b c, a + b = 0 -> c = 0.
+Goal 0 = 0.
+Fail apply f with (d := 0).
+apply f with (a:=0) (b:=0).
+auto.
+Qed.

--- a/test-suite/output/apply_with.v
+++ b/test-suite/output/apply_with.v
@@ -1,6 +1,18 @@
 Axiom f : forall a b c, a + b = 0 -> c = 0.
 Goal 0 = 0.
 Fail apply f with (d := 0).
+Fail apply f with (a := 0).
+Fail rewrite <- f with (d := 0).
+Fail rewrite <- f with (a := 0).
 apply f with (a:=0) (b:=0).
+auto.
+Qed.
+
+Axiom g : forall a b, S a = S b.
+Goal forall n, n = 0.
+intros n.
+Fail injection g with (c := 0).
+Fail injection g.
+injection g with (a := n) (b := 0).
 auto.
 Qed.


### PR DESCRIPTION
The PR tries to improve on a few behaviors of the `with` clause:
- in `apply with`, when a variable is absent, it prints the names of possible variables in the natural left-to-right order
- it makes `injection t with (x:=0)` or `discriminate t with (x:=0)` not systematically failing, even when `x` is an existing name in `t` (the feature is probably uninteresting enough to have been detected in CI though, since it stopped working in #16194): the fix is not very nice and should probably be improved though so as not to use the "unsafe" part of econstr...

- [x] Added / updated **test-suite**.
- [ ] Added **changelog**.
