### PR TITLE
Ensure that names of constants, inductive types or constructors have distinct names and that binders are named

### DIFF
--- a/engine/namegen.ml
+++ b/engine/namegen.ml
@@ -175,8 +175,10 @@ let hdchar env sigma c =
   in
   hdrec 0 c
 
+let hd_ident env sigma a = Id.of_string (hdchar env sigma a)
+
 let id_of_name_using_hdchar env sigma a = function
-  | Anonymous -> Id.of_string (hdchar env sigma a)
+  | Anonymous -> hd_ident env sigma a
   | Name id   -> id
 
 let named_hd env sigma a = function
@@ -268,6 +270,10 @@ let next_ident_away_from_post_mangling id bad =
 let next_ident_away_from id bad =
   let id = mangle_id id in
   next_ident_away_from_post_mangling id bad
+
+let next_canonical_ident id avoid =
+  let rec name_rec id = if Id.Set.mem id avoid then name_rec (increment_subscript id) else id in
+  name_rec id
 
 (* Restart subscript from x0 if name starts with xN, or x00 if name
    starts with x0N, etc *)

--- a/engine/namegen.mli
+++ b/engine/namegen.mli
@@ -40,6 +40,7 @@ val default_dependent_ident : Id.t     (* "x" *)
 val lowercase_first_char : Id.t -> string
 val sort_hdchar : Sorts.t -> string
 val hdchar : env -> evar_map -> types -> string
+val hd_ident : env -> evar_map -> types -> Id.t
 val id_of_name_using_hdchar : env -> evar_map -> types -> Name.t -> Id.t
 val named_hd : env -> evar_map -> types -> Name.t -> Name.t
 val head_name : evar_map -> types -> Id.t option
@@ -101,6 +102,8 @@ val next_name_away_with_default_using_types : string -> Name.t ->
   Id.Set.t -> types -> Id.t
 
 val set_reserved_typed_name : (types -> Name.t) -> unit
+
+val next_canonical_ident : Id.t -> Id.Set.t -> Id.t
 
 (*********************************************************************
    Making name distinct for displaying *)

--- a/engine/nameops.ml
+++ b/engine/nameops.ml
@@ -520,6 +520,7 @@ sig
   val pick : t -> t -> t
   val pick_annot : (t,'r) Context.pbinder_annot -> (t,'r) Context.pbinder_annot -> (t,'r) Context.pbinder_annot
   val cons : t -> Id.t list -> Id.t list
+  val add : Name.t -> Id.Set.t -> Id.Set.t
   val to_option : Name.t -> Id.t option
 
 end
@@ -572,6 +573,11 @@ struct
     match na with
     | Anonymous -> l
     | Name id -> id::l
+
+  let add na l =
+    match na with
+    | Anonymous -> l
+    | Name id -> Id.Set.add id l
 
   let to_option = function
     | Anonymous -> None

--- a/engine/nameops.mli
+++ b/engine/nameops.mli
@@ -141,6 +141,9 @@ module Name : sig
   val cons : Name.t -> Id.t list -> Id.t list
   (** [cons na l] returns [id::l] if [na] is [Name id] and [l] otherwise. *)
 
+  val add : Name.t -> Id.Set.t -> Id.Set.t
+  (** [add na l] returns [Id.Set.add id l] if [na] is [Name id] and [l] otherwise. *)
+
   val to_option : Name.t -> Id.t option
   (** [to_option Anonymous] is [None] and [to_option (Name id)] is [Some id] *)
 

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -628,7 +628,7 @@ let intern_cases_pattern_as_binder ~dump intern test_kind ntnvars env bk (CAst.{
   let t = match t with
     | Some t -> t
     | None -> CAst.make ?loc @@ CHole (Some (GBinderType na.v)) in
-  let _, bl' = intern_assumption ~dump intern ntnvars env [na] (Default bk) t in
+  let env, bl' = intern_assumption ~dump intern ntnvars env [na] (Default bk) t in
   let {v=(_,bk,t)} = List.hd bl' in
   let il = List.map (fun id -> id.v) il in
   env,((disjpat,il),id),bk,t

--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -21,19 +21,6 @@ open EConstr
 open Reductionops
 open Constrexpr
 
-let whd_prod env sigma typ =
-  let open CClosure in
-  let infos = Evarutil.create_clos_infos env sigma RedFlags.all in
-  let tab = create_tab () in
-  let typ = inject (EConstr.Unsafe.to_constr typ) in
-  let typ, stk = whd_stack infos tab typ [] in
-  match fterm_of typ with
-  | FProd (na, c1, c2, e) ->
-    let c1 = EConstr.of_constr @@ term_of_fconstr c1 in
-    let c2 = EConstr.of_constr @@ term_of_fconstr (mk_clos (CClosure.usubs_lift e) c2) in
-    Some (EConstr.of_binder_annot na, c1, c2)
-  | _ -> None
-
 module NamedDecl = Context.Named.Declaration
 
 (*s Flags governing the computation of implicit arguments *)

--- a/pretyping/arguments_renaming.mli
+++ b/pretyping/arguments_renaming.mli
@@ -17,6 +17,8 @@ val rename_arguments : bool -> GlobRef.t -> Name.t list -> unit
 (** [Not_found] is raised if no names are defined for [r] *)
 val arguments_names : GlobRef.t -> Name.t list
 
+val declare_arguments_names : GlobRef.t -> unit
+
 val rename_type : types -> GlobRef.t -> types
 
 val rename_typing : env -> constr -> unsafe_judgment

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1577,6 +1577,19 @@ let whd_decompose_lambda_n_assum env sigma n =
   in
   decrec env n Context.Rel.empty
 
+let whd_prod env sigma typ =
+  let open CClosure in
+  let infos = Evarutil.create_clos_infos env sigma RedFlags.all in
+  let tab = create_tab () in
+  let typ = inject (EConstr.Unsafe.to_constr typ) in
+  let typ, stk = whd_stack infos tab typ [] in
+  match fterm_of typ with
+  | FProd (na, c1, c2, e) ->
+    let c1 = EConstr.of_constr @@ term_of_fconstr c1 in
+    let c2 = EConstr.of_constr @@ term_of_fconstr (mk_clos (CClosure.usubs_lift e) c2) in
+    Some (EConstr.of_binder_annot na, c1, c2)
+  | _ -> None
+
 let is_sort env sigma t =
   match EConstr.kind sigma (whd_all env sigma t) with
   | Sort s -> true

--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -225,6 +225,9 @@ val whd_decompose_lambda_n_assum : env -> evar_map -> int -> constr -> rel_conte
 (** Extract the n first lambdas of a term, preserving let-ins (but not counting them);
     Raises [Invalid_argument] if not enough lambdas *)
 
+val whd_prod : env -> evar_map -> types -> (Name.t EConstr.binder_annot * types * types) option
+(** Extract the first product if any *)
+
 val reducible_mind_case : evar_map -> constr -> bool
 
 val find_conclusion : env -> evar_map -> constr -> (constr, constr, ESorts.t, EInstance.t, ERelevance.t) kind_of_term

--- a/test-suite/bugs/bug_12001.v
+++ b/test-suite/bugs/bug_12001.v
@@ -8,13 +8,17 @@ Unset Mangle Names.
 (* Coq doesn't make up names for arguments *)
 Definition bar (a a : nat) : nat := 3.
 Arguments bar _ _ : assert.
-Fail Arguments bar a a0 : assert.
+Arguments bar a a0 : assert.
+Definition bar' (a a0 : nat) : nat := 3.
+Arguments bar' a a0 : assert.
 
 (* This definition caused an anomaly in a version of this PR
 without the change to prepare_implicits *)
 Set Implicit Arguments.
 Definition foo (_ : nat) (_ : @eq nat ltac:(assumption) 2) : True := I.
-Fail Check foo (H := 2).
+Check foo (n := 2). (* Generated name *)
+Definition foo' (x : nat) (_ : @eq nat ltac:(assumption) 2) : True := I.
+Check foo' (x := 2).
 
 Definition baz (a b : nat) := b.
 Arguments baz a {b}.

--- a/test-suite/output/Implicit.out
+++ b/test-suite/output/Implicit.out
@@ -5,7 +5,8 @@ ex_intro (P:=fun _ : nat => True) (x:=0) I
 d2 = fun x : nat => d1 (y:=x)
      : forall [x x0 : nat], x0 = x -> x0 = x
 
-Arguments d2 [x x]%nat_scope h
+Arguments d2 [x x0]%nat_scope h
+  (where some original arguments have been renamed)
 map id (1 :: nil)
      : list nat
 map id' (1 :: nil)

--- a/test-suite/output/PatternsInBinders.out
+++ b/test-suite/output/PatternsInBinders.out
@@ -18,7 +18,7 @@ baz =
 fun '(Bar n1 _ tt p1) '(Bar _ _ tt _) => n1 + p1
      : Foo -> Foo -> nat
 
-Arguments baz pat pat
+Arguments baz pat pat0
 swap =
 fun (A B : Type) '(x, y) => (y, x)
      : forall {A B : Type}, A * B -> B * A

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -355,6 +355,7 @@ let do_declare_instance sigma ~locality ~poly k u ctx ctx' pri udecl impargs sub
       ~kind:Decls.(IsAssumption Logical) (Declare.ParameterEntry entry) in
   let cst = (GlobRef.ConstRef cst) in
   Impargs.maybe_declare_manual_implicits false cst impargs;
+  Arguments_renaming.declare_arguments_names cst;
   instance_hook pri locality cst
 
 let declare_instance_program pm env sigma ~locality ~poly name pri impargs udecl term termtype =

--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -36,6 +36,7 @@ let declare_local ~coe ~try_assum_as_instance ~kind ~univs ~impargs ~impl ~name 
   let () = if body = None then Declare.assumption_message name else Declare.definition_message name in
   let r = GlobRef.VarRef name in
   let () = maybe_declare_manual_implicits true r impargs in
+  let () = Arguments_renaming.declare_arguments_names r in
   let _ = if try_assum_as_instance && Option.is_empty body then
       let env = Global.env () in
       let sigma = Evd.from_env env in
@@ -72,6 +73,7 @@ let declare_global ~coe ~try_assum_as_instance ~local ~kind ?user_warns ~univs ~
   let kn = Declare.declare_constant ~name ~local ~kind ?user_warns decl in
   let gr = GlobRef.ConstRef kn in
   let () = maybe_declare_manual_implicits false gr impargs in
+  let () = Arguments_renaming.declare_arguments_names gr in
   let () = match body with None -> Declare.assumption_message name | Some _ -> Declare.definition_message name in
   let local = match local with
     | Locality.ImportNeedQualified -> true

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -396,7 +396,7 @@ let declare_constant_core ~name ~typing_flags cd =
         (* This globally defines the side-effects in the environment
            and registers their libobjects. *)
         let () = export_side_effects eff in
-        let de = { de with proof_entry_body = body, () } in
+        let de = { de with proof_entry_body = (body, ()) } in
         let e, ctx = cast_proof_entry de in
         let ubinders = make_ubinders ctx de.proof_entry_universes in
         (* We register the global universes after exporting side-effects, since
@@ -714,6 +714,7 @@ let declare_entry_core ~name ?(scope=Locality.default_scope) ?(clearbody=false) 
     gr
   in
   let () = Impargs.maybe_declare_manual_implicits false dref impargs in
+  let () = Arguments_renaming.declare_arguments_names dref in
   let () = definition_message name in
   Hook.call ?hook { Hook.S.uctx; obls; scope; dref };
   dref

--- a/vernac/declareInd.ml
+++ b/vernac/declareInd.ml
@@ -172,10 +172,12 @@ let declare_mutual_inductive_with_eliminations ?(primitive_expected=false) ?typi
       let ind = (mind,i) in
       let gr = GlobRef.IndRef ind in
       Impargs.maybe_declare_manual_implicits false gr indimpls;
+      Arguments_renaming.declare_arguments_names gr;
       List.iteri
         (fun j impls ->
            Impargs.maybe_declare_manual_implicits false
-             (GlobRef.ConstructRef (ind, succ j)) impls)
+             (GlobRef.ConstructRef (ind, succ j)) impls;
+           Arguments_renaming.declare_arguments_names gr)
         constrimpls)
     impls;
   let () = match default_dep_elim with

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -453,6 +453,7 @@ let build_named_proj ~primitive ~flags ~poly ~univs ~uinstance ~kind env paramde
   in
   let refi = GlobRef.ConstRef kn in
   Impargs.maybe_declare_manual_implicits false refi impls;
+  Arguments_renaming.declare_arguments_names refi;
   declare_proj_coercion_instance ~flags refi (GlobRef.IndRef indsp) ~with_coercion:true;
   let i = if is_local_assum decl then i+1 else i in
   (Some kn, i, Projection term::subst)


### PR DESCRIPTION
The PR does the following:
- ensure that Coq objects have distinct names, e.g.:
   ```coq
    Definition f (a a:nat) := a.
    About f.
    (* Before: Arguments f (a a)%nat_scope *)
    (* With the PR: Arguments f (a a0)%nat_scope *)
  ```
  Possible alternative: failing instead of renaming silently but this would require adaptations (see note below).

- ensure that binders are named:
   ```coq
   Definition g (_:nat) (P:nat -> Prop) (x : P ltac:(auto)) := x.
   About g.
   (* Before: Arguments g _%nat_scope P%function_scope x *)
   (* With the PR: Arguments g n%nat_scope P%function_scope x *)
   ```
   Note: The alternative to force naming user-side would require several changes in the CI.

The last point will be useful for #14597 which requires named binders but for which CI showed that this is sometimes not the case.

See also issue #6786 about non-distinct names in inductive types.
 
Depends on #18393.

- [x] Added / updated **test-suite**
- [ ] Added **changelog**.

Note: Here are typical cases which indirectly generate definitions with several times the same name:
- Instantiated definitions
  ```coq
  Definition d1 {y} x (h : x = y :>nat) := h. 
  Definition d2 x := d1 (y:=x).
  About d2.  (* With the PR: "Arguments d2 (x x0)%nat_scope h"; before "(x x)%nat_scope h" *)
  ```
- Auxiliary definitions
  ```coq
  Definition idnat (x:nat) := x.
  Definition f (x:nat) := idnat.
  About f. (* With the PR: "Arguments f (x x0)%nat_scope"; before "(x x)%nat_scope" *)
  ```

Related issue: avoid the time spent at renaming the types of objects in `Typing.type_of_constant` & cie.