### PR TITLE
Internal cleanup: factorization of the code of interp_context_evars and interp_named_context_evars + ability to share types

### DIFF
--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -587,7 +587,7 @@ let glob_local_binder_of_extended = DAst.with_loc_val (fun ?loc -> function
       let t = DAst.make ?loc @@ GHole (GBinderType na) in
       (na,None,Explicit,Some c,t)
   | GLocalPattern (_,_,_,_) ->
-      Loc.raise ?loc (Gramlib.Grammar.Error "pattern with quote not allowed here")
+      Loc.raise ?loc (Gramlib.Grammar.Error "Pattern with quote not allowed here.")
   )
 
 let intern_cases_pattern_fwd = ref (fun _ -> failwith "intern_cases_pattern_fwd")

--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -166,17 +166,19 @@ val interp_binder  : env -> evar_map -> Name.t -> constr_expr ->
 
 val interp_binder_evars : env -> evar_map -> Name.t -> constr_expr -> evar_map * types
 
-(** Interpret contexts: returns extended env and context *)
+(** Interpret contexts: returns extended env and context;
+    [share:true] means that the interpretation of [t] in binders of
+    the form [(x y z : t)] is shared *)
 
 val interp_context_evars :
-  ?program_mode:bool -> ?impl_env:internalization_env ->
+  ?program_mode:bool -> ?impl_env:internalization_env -> ?share:bool ->
   env -> evar_map -> local_binder_expr list ->
   evar_map * (internalization_env * ((env * rel_context) * Impargs.manual_implicits))
 
-(** Interpret named contexts: returns context *)
+(** Interpret named contexts *)
 
 val interp_named_context_evars :
-  ?program_mode:bool -> ?impl_env:internalization_env ->
+  ?program_mode:bool -> ?impl_env:internalization_env -> ?share:bool ->
   env -> evar_map -> local_binder_expr list ->
   evar_map * (internalization_env * ((env * named_context) * Impargs.manual_implicits))
 


### PR DESCRIPTION
The PR does:
- an internal code factorization to reduce the number of different code paths
- the ability to share the interpretation of the type `t` when interpreting a multiple binder of the form `x y z : t`

The second item will be useful in #13445 to factorize the code for interpreting `Variables x y z : t` with the code for interpreting `Context (x y z : t)`, knowing that the former shares the type but not the second one.