### PR TITLE
Small cleanup of declare_variable in declare.ml and comAssumption.ml

### DIFF
--- a/dev/ci/user-overlays/18397-herbelin-master+small-cleanup-declare_variable.sh
+++ b/dev/ci/user-overlays/18397-herbelin-master+small-cleanup-declare_variable.sh
@@ -1,0 +1,3 @@
+overlay smtcoq https://github.com/herbelin/smtcoq coq-master+adapt-18397-declare_variable_api 18397 master+small-cleanup-declare_variable
+overlay metacoq https://github.com/herbelin/template-coq main+adapt-coq-pr18397-declare_variable-api 18397 master+small-cleanup-declare_variable
+overlay elpi https://github.com/proux01/coq-elpi coq-master+adapt-coq-pr18397-declare_variable-api 18397 master+small-cleanup-declare_variable

--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -20,7 +20,7 @@ open Pretyping
 module RelDecl = Context.Rel.Declaration
 (* 2| Variable/Hypothesis/Parameter/Axiom declarations *)
 
-let declare_variable is_coe ~kind typ univs imps impl {CAst.v=name} =
+let declare_variable is_coe ~kind typ univs imps impl name =
   let kind = Decls.IsAssumption kind in
   let () = Declare.declare_variable ~name ~kind ~typing_flags:None (Declare.SectionLocalAssum {typ; impl; univs}) in
   let () = Declare.assumption_message name in
@@ -33,13 +33,13 @@ let declare_variable is_coe ~kind typ univs imps impl {CAst.v=name} =
     if is_coe = Vernacexpr.AddCoercion then
       ComCoercion.try_add_new_coercion
         r ~local:true ~reversible:true in
-  ()
+  (r, UVars.Instance.empty)
 
 let instance_of_univ_entry = function
   | UState.Polymorphic_entry univs -> UVars.UContext.instance univs
   | UState.Monomorphic_entry _ -> UVars.Instance.empty
 
-let declare_axiom is_coe ~local ~kind ?user_warns typ (univs, ubinders) imps nl {CAst.v=name} =
+let declare_axiom is_coe ~local ~kind ?user_warns typ (univs, ubinders) imps nl name =
   let inl = let open Declaremods in match nl with
     | NoInline -> None
     | DefaultInline -> Some (Flags.get_inline_level())
@@ -90,15 +90,14 @@ let declare_assumptions ~scope ~kind ?user_warns univs nl l =
       (* NB: here univs are ignored when scope=Discharge *)
       let typ = replace_vars subst typ in
       let univs,subst' =
-        List.fold_left_map (fun univs id ->
+        List.fold_left_map (fun univs {CAst.v=id} ->
             let refu = match scope with
               | Locality.Discharge ->
-                declare_variable is_coe ~kind typ univs imps Glob_term.Explicit id;
-                GlobRef.VarRef id.CAst.v, UVars.Instance.empty
+                declare_variable is_coe ~kind typ univs imps Glob_term.Explicit id
               | Locality.Global local ->
                 declare_axiom is_coe ~local ~kind ?user_warns typ univs imps nl id
             in
-            clear_univs scope univs, (id.CAst.v, Constr.mkRef refu))
+            clear_univs scope univs, (id, Constr.mkRef refu))
           univs idl
       in
       subst'@subst, clear_univs scope univs)
@@ -185,21 +184,21 @@ let context_insection sigma ~poly ctx =
   let fn i subst (name,_,_,_ as d) =
     let d = context_subst subst d in
     let univs = if i = 0 then univs else empty_univ_entry ~poly in
-    let () = match d with
+    let refu = match d with
       | name, None, t, impl ->
         let kind = Decls.Context in
-        declare_variable NoCoercion ~kind t univs [] impl (CAst.make name)
+        declare_variable NoCoercion ~kind t univs [] impl name
       | name, Some b, t, impl ->
         let entry = Declare.definition_entry ~univs ~types:t b in
         (* XXX Fixme: Use Declare.prepare_definition *)
         let kind = Decls.(IsDefinition Definition) in
-        let _ : GlobRef.t =
+        let gr =
           Declare.declare_entry ~name ~scope:Locality.Discharge
             ~kind ~impargs:[] ~uctx entry
         in
-        ()
+        (gr,UVars.Instance.empty)
     in
-    Constr.mkVar name :: subst
+    Constr.mkRef refu :: subst
   in
   let _ : Vars.substl = List.fold_left_i fn 0 [] ctx in
   ()

--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -22,7 +22,7 @@ module RelDecl = Context.Rel.Declaration
 
 let declare_variable is_coe ~kind typ univs imps impl {CAst.v=name} =
   let kind = Decls.IsAssumption kind in
-  let () = Declare.declare_variable ~name ~kind ~typing_flags:None ~typ ~impl ~univs in
+  let () = Declare.declare_variable ~name ~kind ~typing_flags:None (Declare.SectionLocalAssum {typ; impl; univs}) in
   let () = Declare.assumption_message name in
   let r = GlobRef.VarRef name in
   let () = maybe_declare_manual_implicits true r imps in

--- a/vernac/comAssumption.mli
+++ b/vernac/comAssumption.mli
@@ -40,8 +40,8 @@ val declare_variable
   -> UState.named_universes_entry
   -> Impargs.manual_implicits
   -> Glob_term.binding_kind
-  -> variable CAst.t
-  -> unit
+  -> variable
+  -> GlobRef.t * UVars.Instance.t
 
 val declare_axiom
   : coercion_flag
@@ -52,7 +52,7 @@ val declare_axiom
   -> UState.named_universes_entry
   -> Impargs.manual_implicits
   -> Declaremods.inline
-  -> variable CAst.t
+  -> variable
   -> GlobRef.t * UVars.Instance.t
 
 (** Context command *)

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -473,9 +473,15 @@ let inline_private_constants ~uctx env ce =
 
 (** Declaration of section variables and local definitions *)
 type variable_declaration =
-  | SectionLocalDef of { clearbody : bool; entry : proof_entry }
-  | SectionLocalAssum of { typ:Constr.types; impl:Glob_term.binding_kind ;
-                           univs:UState.named_universes_entry }
+  | SectionLocalDef of {
+      clearbody : bool;
+      entry : proof_entry;
+    }
+  | SectionLocalAssum of {
+      typ : Constr.types;
+      impl : Glob_term.binding_kind;
+      univs : UState.named_universes_entry;
+    }
 
 (* This object is only for things which iterate over objects to find
    variables (only Prettyp.print_context AFAICT) *)
@@ -486,7 +492,7 @@ let objVariable : Id.t Libobject.Dyn.tag =
 
 let inVariable v = Libobject.Dyn.Easy.inj v objVariable
 
-let declare_variable_core ~name ~kind ~typing_flags d =
+let declare_variable ~name ~kind ~typing_flags d =
   (* Variables are distinguished by only short names *)
   if Decls.variable_exists name then
     raise (DeclareUniv.AlreadyDeclared (None, name));
@@ -557,9 +563,6 @@ let declare_variable_core ~name ~kind ~typing_flags d =
   Lib.add_leaf (inVariable name);
   Impargs.declare_var_implicits ~impl name;
   Notation.declare_ref_arguments_scope (GlobRef.VarRef name)
-
-let declare_variable ~name ~kind ~typing_flags ~typ ~impl ~univs =
-  declare_variable_core ~name ~kind ~typing_flags (SectionLocalAssum { typ; impl; univs })
 
 (* Declaration messages *)
 
@@ -687,7 +690,7 @@ let declare_entry_core ~name ?(scope=Locality.default_scope) ?(clearbody=false) 
   in
   let dref = match scope with
   | Locality.Discharge ->
-    let () = declare_variable_core ~typing_flags ~name ~kind (SectionLocalDef {clearbody; entry}) in
+    let () = declare_variable ~typing_flags ~name ~kind (SectionLocalDef {clearbody; entry}) in
     if should_suggest then Proof_using.suggest_variable (Global.env ()) name;
     Names.GlobRef.VarRef name
   | Locality.Global local ->

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -384,14 +384,24 @@ val declare_entry
   -> proof_entry
   -> GlobRef.t
 
+(** Declaration of section variables and local definitions *)
+type variable_declaration =
+  | SectionLocalDef of {
+      clearbody : bool;
+      entry : proof_entry;
+    }
+  | SectionLocalAssum of {
+      typ : Constr.types;
+      impl : Glob_term.binding_kind;
+      univs : UState.named_universes_entry;
+    }
+
 (** Declaration of local constructions (Variable/Hypothesis/Local) *)
 val declare_variable
   :  name:variable
   -> kind:Decls.logical_kind
   -> typing_flags:Declarations.typing_flags option
-  -> typ:Constr.types
-  -> impl:Glob_term.binding_kind
-  -> univs:UState.named_universes_entry
+  -> variable_declaration
   -> unit
 
 (** Declaration of global constructions


### PR DESCRIPTION
The PR does the following:
- it aligns `Declare.declare_variable` to the style of `Declare.declare_constant`:
   - use in `declare_variable` the "variable" equivalent to `constant_entry`, that is `variable_declaration`
   - include thus support for local definitions
- it aligns `ComAssumption.declare_variable` on the style of `ComAssumption.declare_axiom`; it also gets rid of a useless `Loc.t`

This covers the most important source of API incompatibility of #13445.

Synchronous overlays:
- smtcoq/smtcoq#132
- MetaCoq/metacoq#1029
- LPCIC/coq-elpi#561