### PR TITLE
coqchk: fix mismatches between values.ml and actual types

### DIFF
--- a/checker/check.ml
+++ b/checker/check.ml
@@ -267,16 +267,16 @@ let raw_intern_library f =
 (************************************************************************)
 (* Internalise libraries *)
 
+type library_info
+
 type summary_disk = {
   md_name : compilation_unit_name;
   md_deps : (compilation_unit_name * Safe_typing.vodigest) array;
   md_ocaml : string;
+  md_info : library_info;
 }
 
-module Dyn = Dyn.Make ()
-type obj = Dyn.t (* persistent dynamic objects *)
-type lib_objects = (Id.t * obj) list
-type library_objects = lib_objects * lib_objects
+type library_objects
 
 type library_disk = {
   md_compiled : Safe_typing.compiled_library;

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -334,7 +334,6 @@ let v_retro_action =
   v_sum "retro_action" 0 [|
     [|v_prim_ind; v_ind|];
     [|v_prim_type; v_cst|];
-    [|v_cst|];
   |]
 
 let v_retroknowledge =
@@ -382,33 +381,6 @@ let v_deps = Array (v_tuple "dep" [|v_dp;v_vodigest|])
 let v_compiled_lib =
   v_tuple "compiled" [|v_dp;v_module;v_context_set;v_deps|]
 
-(** Library objects *)
-
-let v_obj = Dyn
-
-let v_open_filter = Sum ("open_filter",1,[|[|v_pred String|]|])
-
-let rec v_aobjs = Sum("algebraic_objects", 0,
-  [| [|v_libobjs|];
-     [|v_mp;v_subst|]
-  |])
-and v_substobjs =
-  Tuple("*", [|List v_uid;v_aobjs|])
-and v_libobjt = Sum("Libobject.t",0,
-  [| [| v_id; v_substobjs |];
-     [| v_id; v_substobjs |];
-     [| v_aobjs |];
-     [| v_id; v_libobjs |];
-     [| List (v_pair v_open_filter v_mp)|];
-     [| v_obj |]
-  |])
-
-and v_libobjs = List v_libobjt
-
-let v_libraryobjs = Tuple ("library_objects",[|v_libobjs;v_libobjs|])
-
-let v_librarysyntaxobjs = Tuple ("library_syntax_objects",[|v_libobjs;v_libobjs|])
-
 (** STM objects *)
 
 let v_frozen = Tuple ("frozen", [|List (v_pair Int Dyn); Opt Dyn|])
@@ -436,17 +408,11 @@ let v_stm_seg = v_pair v_tasks v_counters
 
 (** Toplevel structures in a vo (see Cic.mli) *)
 
-let v_deprecation =
-  v_tuple "deprecation" [|Opt String; Opt String|]
-
-let v_library_info =
-  v_sum "library_info" 0 [|[|v_deprecation|]|]
-
 let v_libsum =
-  Tuple ("summary", [|v_dp;v_deps;String;List v_library_info|])
+  Tuple ("summary", [|v_dp;v_deps;String;Any|])
 
 let v_lib =
-  Tuple ("library",[|v_compiled_lib;v_librarysyntaxobjs;v_libraryobjs|])
+  Tuple ("library",[|v_compiled_lib;Any;Any|])
 
 let v_delayed_universes =
   Sum ("delayed_universes", 0, [| [| v_unit |]; [| v_context_set |] |])

--- a/dev/doc/critical-bugs
+++ b/dev/doc/critical-bugs
@@ -611,6 +611,19 @@ Conflicts with axioms in library
   GH issue number: #17871
   risk: proof of false when using primitive floats and native_compute
 
+Deserialization
+
+  component: coqchk (coqc trusts that .vo files are well formed)
+  summary: deserialization of .vo data not properly checked
+  introduced: 8.16 (univ levels), 8.10 (retroknowledge)
+  impacted released versions: 8.10-8.18.1
+  impacted coqchk versions: same
+  fixed in: 8.19
+  found by: Mario Carneiro
+  GH issue number: N/A (fix pull requests: #18403, #18406)
+  risk: can lead to segfaults or arbitrary code execution on crafted .vo files
+    (files produced by coqc are fine)
+
 There were otherwise several bugs in beta-releases, from memory, bugs with beta versions of primitive projections or template polymorphism or native compilation or guard (e7fc96366, 2a4d714a1).
 
 There were otherwise maybe unexploitable kernel bugs, e.g. 2df88d83 (Require overloading), 0adf0838 ("Univs: uncovered bug in strengthening of opaque polymorphic definitions."), 5122a398 (#3746 about functors), #4346 (casts in VM), a14bef4 (guard condition in 8.1), 6ed40a8 ("Georges' bug" with ill-typed lazy machine), and various other bugs in 8.0 or 8.1 w/o knowing if they are critical.

--- a/topbin/coqnative_bin.ml
+++ b/topbin/coqnative_bin.ml
@@ -91,13 +91,17 @@ type compilation_unit_name = DirPath.t
 
 type library_disk = {
   md_compiled : Safe_typing.compiled_library;
+  md_syntax_objects : library_objects;
   md_objects : library_objects;
 }
+
+type library_info
 
 type summary_disk = {
   md_name : compilation_unit_name;
   md_deps : (compilation_unit_name * Safe_typing.vodigest) array;
   md_ocaml : string;
+  md_info : library_info;
 }
 
 type library_t = {


### PR DESCRIPTION
We stop checking anything about the libobject structures as that is out of scope for coqchk.

Also add missing fields to records in coqnative_bin (the fields are unused by coqnative so probably no observable bug there)

Reported-by: Mario Carneiro <digama0@users.noreply.github.com>
