### PR TITLE
ci-menhir: don't set version to $(date) if already done

### DIFF
--- a/dev/ci/ci-menhir.sh
+++ b/dev/ci/ci-menhir.sh
@@ -10,8 +10,11 @@ git_download menhirlib
 if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
 
 ( cd "${CI_BUILD_DIR}/menhirlib"
-  sed -i.bak "s/unreleased/$(date +%Y%m%d)/" dune-project
-  echo "Definition require_$(date +%Y%m%d) := tt." > coq-menhirlib/src/Version.v
+  if grep -q unreleased dune-project; then
+    date=$(date +%Y%m%d)
+    sed -i.bak "s/unreleased/$date/" dune-project
+    echo "Definition require_$date := tt." > coq-menhirlib/src/Version.v
+  fi
   dune build @install -p menhirLib,menhirSdk,menhir
   dune install -p menhirLib,menhirSdk,menhir menhir menhirSdk menhirLib --prefix="$CI_INSTALL_DIR"
 


### PR DESCRIPTION
cf https://coq.zulipchat.com/#narrow/stream/237656-Coq-devs-.26-plugin-devs/topic/Menhir/near/407561493 https://gitlab.inria.fr/coq/coq/-/jobs/3691631

The problem is the `echo ... > Version.v` command not the `sed s/unreleased/.../` since sed won't have an effect when the version is already set, but we may as well guard both.
