### PR TITLE
Ltac2: desugar `[| |]` to `Array.empty` instead of `Array.of_list []`

### DIFF
--- a/plugins/ltac2/g_ltac2.mlg
+++ b/plugins/ltac2/g_ltac2.mlg
@@ -235,7 +235,7 @@ GRAMMAR EXTEND Gram
   ;
   array_literal:
   [ [ test_array_opening; "["; "|"; a = LIST0 ltac2_expr LEVEL "5" SEP ";"; test_array_closing; "|"; "]" ->
-      { Tac2quote.array_of_list (Tac2quote.of_list ~loc (fun x -> x) a) } ] ]
+      { Tac2quote.array_literal ~loc a } ] ]
   ;
   list_literal:
   [ [ "["; a = LIST0 ltac2_expr LEVEL "5" SEP ";"; "]" ->

--- a/plugins/ltac2/tac2quote.ml
+++ b/plugins/ltac2/tac2quote.ml
@@ -134,9 +134,11 @@ let rec of_list ?loc f = function
 | e :: l ->
   constructor ?loc (coq_core "::") [f e; of_list ?loc f l]
 
-let array_of_list ?loc l =
-  let of_list = global_ref ?loc (kername array_prefix "of_list")  in
-  CAst.make ?loc @@ CTacApp (of_list, [l])
+let array_literal ?loc a =
+  if CList.is_empty a then global_ref ?loc (kername array_prefix "empty")
+  else
+    let of_list_kn = global_ref ?loc (kername array_prefix "of_list")  in
+    CAst.make ?loc @@ CTacApp (of_list_kn, [of_list ?loc (fun x -> x) a])
 
 let of_qhyp {loc;v=h} = match h with
 | QAnonHyp n -> std_constructor ?loc "AnonHyp" [of_int n]

--- a/plugins/ltac2/tac2quote.mli
+++ b/plugins/ltac2/tac2quote.mli
@@ -42,7 +42,7 @@ val of_preterm : ?delimiters:Id.t list -> Constrexpr.constr_expr -> raw_tacexpr
 
 val of_list : ?loc:Loc.t -> ('a -> raw_tacexpr) -> 'a list -> raw_tacexpr
 
-val array_of_list : ?loc:Loc.t -> raw_tacexpr -> raw_tacexpr
+val array_literal : ?loc:Loc.t -> raw_tacexpr list -> raw_tacexpr
 
 val of_bindings : bindings -> raw_tacexpr
 


### PR DESCRIPTION
This makes the empty array literal a syntactic value.

