### PR TITLE
[build] [gen_rules] Refactor and remove useless case

### DIFF
--- a/tools/dune_rule_gen/coq_rules.mli
+++ b/tools/dune_rule_gen/coq_rules.mli
@@ -7,6 +7,19 @@
 (* Written by: Rudi Grinberg                                            *)
 (************************************************************************)
 
+module Theory : sig
+  (** A theory binding; directories should be relative to Coq's
+      sources root *)
+  type t =
+    { directory : Path.t
+    (** Directory of the theory *)
+    ; dirname: string list
+    (** Coq's logical path *)
+    ; implicit : bool
+    (** Use -R or -Q *)
+    }
+end
+
 (** theory kind *)
 module Boot_type : sig
 
@@ -14,25 +27,26 @@ module Boot_type : sig
       Stdlib
     (** Standard library *)
     | NoInit
-    (** Standalone library (without Coq's stdlib) *)
-    | Regular of Path.t option
-    (** Regular library, path controls where the Coq stdlib is *)
+    (** Standalone library (without Coq's stdlib, for example the prelude) *)
+    | Regular of Theory.t
+    (** Regular library, qualified with -Q, path controls where the
+        Coq stdlib is *)
 
 end
 
 module Context : sig
   type t
 
+  (** *)
   val make :
     root_lvl:int
-    -> tname:string list
+    -> theory:Theory.t
     -> user_flags:Arg.t list
-    -> rule:Coq_module.Rule_type.t
     -> boot:Boot_type.t
+    -> rule:Coq_module.Rule_type.t (* quick, native, etc... *)
     -> async:bool
-    -> dir_info:Coq_module.t Dir_info.t
-    -> package:string
-    -> split:bool
+    -> dir_info:Coq_module.t Dir_info.t (* contents of the directory scan *)
+    -> split:bool (* whether we are building coq-core + coq-stdlib or only coq-stdlib *)
     -> t
 
 end

--- a/tools/dune_rule_gen/gen_rules.ml
+++ b/tools/dune_rule_gen/gen_rules.ml
@@ -60,15 +60,23 @@ let main () =
   let tname, base_dir, async, rule, user_flags, split = parse_args () in
   let root_lvl = List.length (String.split_on_char '/' base_dir) in
 
-  let boot = if tname = ["Coq"]
-    then Coq_rules.Boot_type.Stdlib
-    else Coq_rules.Boot_type.Regular (Some (Path.make "theories"))
+  let stdlib =
+    let directory = Path.make "theories" in
+    Coq_rules.Theory.{ directory; dirname = ["Coq"]; implicit = true }
+  in
+
+  (* usually the else case here is Ltac2, but other libraries could be
+     handled as well *)
+  let boot, implicit = if tname = ["Coq"]
+    then Coq_rules.Boot_type.Stdlib, true
+    else Coq_rules.Boot_type.Regular stdlib, false
   in
 
   (* Rule generation *)
   let dir_info = Dir_info.scan ~prefix:[] base_dir in
-  let package = base_dir in
-  let cctx = Coq_rules.Context.make ~root_lvl ~tname ~user_flags ~rule ~boot ~dir_info ~async ~package ~split in
+  let directory = Path.make base_dir in
+  let theory = Coq_rules.Theory.{ directory; dirname = tname; implicit } in
+  let cctx = Coq_rules.Context.make ~root_lvl ~theory ~user_flags ~rule ~boot ~dir_info ~async ~split in
   let vo_rules = Coq_rules.vo_rules ~dir_info ~cctx in
   let install_rules = Coq_rules.install_rules ~dir_info ~cctx in
 


### PR DESCRIPTION
We remove the `Regular None` case which was in fact identical to `NoInit`.

We also refactor theory management to get closer to what happens in
upstream Dune's Coq rules.

cc: #18384