### PR TITLE
Ltac2: a `fail` returning `'a` instead of `unit` and accepting printf-style arguments

### DIFF
--- a/doc/changelog/06-Ltac2-language/18420-failf.rst
+++ b/doc/changelog/06-Ltac2-language/18420-failf.rst
@@ -1,0 +1,7 @@
+- **Added:**
+  Ltac2 ``gfail``: a version of ``fail`` that does not auto-focus,
+  and thus can return any ``'a`` instead of only ``unit``, and
+  also accepts printf-style arguments
+  (`#18420 <https://github.com/coq/coq/pull/18420>`_,
+  fixes `#17463 <https://github.com/coq/coq/issues/17463>`_,
+  by Samuel Gruetter).

--- a/doc/stdlib/index-list.html.template
+++ b/doc/stdlib/index-list.html.template
@@ -673,6 +673,7 @@ through the <tt>Require Import</tt> command.</p>
     user-contrib/Ltac2/Control.v
     user-contrib/Ltac2/Env.v
     user-contrib/Ltac2/Evar.v
+    user-contrib/Ltac2/Failf.v
     user-contrib/Ltac2/Float.v
     user-contrib/Ltac2/FMap.v
     user-contrib/Ltac2/FSet.v

--- a/test-suite/ltac2/Failf_tests.v
+++ b/test-suite/ltac2/Failf_tests.v
@@ -1,0 +1,23 @@
+Require Import Ltac2.Ltac2.
+Require Import Ltac2.Failf.
+
+Ltac2 pose_andb x :=
+  let t := Constr.type constr:($x) in
+  let r := lazy_match! t with
+           | nat => gfail "expected bool, got %t" t
+           | bool => constr:(andb $x $x)
+           end in
+  pose $r.
+
+Goal forall (x: nat) (b: bool), True.
+  intros.
+  Fail (let r := (if true then gfail "nope" else constr:(1)) in pose $r).
+  Fail gfail "The problem is %t" constr:(x + x).
+  if false then fail else ().
+  if false then fail "nope" else ().
+  Fail if true then fail "nope" else ().
+  pose_andb 'b.
+  Fail pose_andb 'x.
+  Fail try (anomaly "testing anomaly notation for nat %t and bool %t" 'x 'b).
+  Fail anomaly.
+Abort.

--- a/user-contrib/Ltac2/Failf.v
+++ b/user-contrib/Ltac2/Failf.v
@@ -1,9 +1,9 @@
-(* printf-style formatted failures gfail/fail/anomaly *)
+(** printf-style formatted failures gfail/fail/anomaly *)
 
 Require Import Ltac2.Ltac2.
 
-(* "global fail", i.e. without first focusing on a goal.
-   Advantage over normal `fail` is that it can return any 'a instead of unit *)
+(** "global fail", i.e. without first focusing on a goal.
+   Advantage over normal [fail] is that it can return any ['a] instead of [unit] *)
 Ltac2 gfail0 () := Control.zero (Tactic_failure None).
 Ltac2 gfail_with_fmt fmt :=
   Message.Format.kfprintf (fun msg => Control.zero (Tactic_failure (Some msg))) fmt.
@@ -11,7 +11,7 @@ Ltac2 gfail_with_fmt fmt :=
 Ltac2 Notation "gfail" fmt(format) := gfail_with_fmt fmt.
 Ltac2 Notation "gfail" := gfail0 ().
 
-(* Unfortunately, since `fail` auto-focuses, we can't pass it constr arguments,
+(* Unfortunately, since [fail] auto-focuses, we can't pass it constr arguments,
    because that would require focusing first, so it would have to be thunked constrs,
    which doesn't work nicely either, see https://github.com/coq/coq/issues/17463.
    So for now, we only support simple string messages. *)

--- a/user-contrib/Ltac2/Failf.v
+++ b/user-contrib/Ltac2/Failf.v
@@ -1,0 +1,31 @@
+(* printf-style formatted failures gfail/fail/anomaly *)
+
+Require Import Ltac2.Ltac2.
+
+(* "global fail", i.e. without first focusing on a goal.
+   Advantage over normal `fail` is that it can return any 'a instead of unit *)
+Ltac2 gfail0 () := Control.zero (Tactic_failure None).
+Ltac2 gfail_with_fmt fmt :=
+  Message.Format.kfprintf (fun msg => Control.zero (Tactic_failure (Some msg))) fmt.
+
+Ltac2 Notation "gfail" fmt(format) := gfail_with_fmt fmt.
+Ltac2 Notation "gfail" := gfail0 ().
+
+(* Unfortunately, since `fail` auto-focuses, we can't pass it constr arguments,
+   because that would require focusing first, so it would have to be thunked constrs,
+   which doesn't work nicely either, see https://github.com/coq/coq/issues/17463.
+   So for now, we only support simple string messages. *)
+Ltac2 fail_with_string (s : string) : unit :=
+  Control.enter (fun _ => Control.zero (Tactic_failure (Some (Message.of_string s)))).
+
+Ltac2 Notation "fail" s(tactic) := fail_with_string s.
+Ltac2 Notation "fail" := fail0 ().
+
+Ltac2 Type exn ::= [ Anomaly (message option) ].
+
+Ltac2 anomaly0 () := Control.throw (Anomaly None).
+Ltac2 anomaly_with_fmt fmt :=
+  Message.Format.kfprintf (fun msg => Control.throw (Anomaly (Some msg))) fmt.
+
+Ltac2 Notation "anomaly" fmt(format) := anomaly_with_fmt fmt.
+Ltac2 Notation "anomaly" := anomaly0 ().

--- a/user-contrib/Ltac2/Failf.v
+++ b/user-contrib/Ltac2/Failf.v
@@ -1,6 +1,7 @@
 (** printf-style formatted failures gfail/fail/anomaly *)
 
-Require Import Ltac2.Ltac2.
+Require Import Ltac2.Init.
+Require Ltac2.Control Ltac2.Notations.
 
 (** "global fail", i.e. without first focusing on a goal.
    Advantage over normal [fail] is that it can return any ['a] instead of [unit] *)
@@ -19,7 +20,7 @@ Ltac2 fail_with_string (s : string) : unit :=
   Control.enter (fun _ => Control.zero (Tactic_failure (Some (Message.of_string s)))).
 
 Ltac2 Notation "fail" s(tactic) := fail_with_string s.
-Ltac2 Notation "fail" := fail0 ().
+Ltac2 Notation "fail" := Notations.fail0 ().
 
 Ltac2 Type exn ::= [ Anomaly (message option) ].
 

--- a/user-contrib/Ltac2/Ltac2.v
+++ b/user-contrib/Ltac2/Ltac2.v
@@ -19,6 +19,7 @@ Require Ltac2.Constructor.
 Require Ltac2.Control.
 Require Ltac2.Env.
 Require Ltac2.Evar.
+Require Ltac2.Failf.
 Require Ltac2.Float.
 Require Ltac2.Fresh.
 Require Ltac2.Ident.


### PR DESCRIPTION
Fixes https://github.com/coq/coq/issues/17463

(but for `fail`, only supports plain string messages, but no printf-style messages, because that seems not possible in a reasonable way)

- [X] Added / updated **test-suite**.
- [x] Added **changelog**.
