### PR TITLE
Vernactypes: combine In and Out infos and abstract use of state info

### DIFF
--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1374,22 +1374,19 @@ let vernac_end_segment ~pm ~proof ({v=id} as lid) =
   | _ -> assert false
 
 let vernac_end_segment lid =
-  Vernactypes.TypedVernac {
-    inprog = Use; outprog = Pop; inproof = UseOpt; outproof = No;
-    run = (fun ~pm ~proof ->
-        let () = vernac_end_segment ~pm ~proof lid in
-        (), ())
-  }
+  Vernactypes.typed_vernac Pop ReadOpt
+    (fun ~pm ~proof ->
+       let () = vernac_end_segment ~pm ~proof lid in
+       (), ())
 
 let vernac_begin_segment ~interactive f =
-  let inproof = Vernactypes.InProof.(if interactive then Reject else Ignore) in
-  let outprog = Vernactypes.OutProg.(if interactive then Push else No) in
-  Vernactypes.TypedVernac {
-    inprog = Ignore; outprog; inproof; outproof = No;
-    run = (fun ~pm ~proof ->
-        let () = f () in
-        (), ())
-  }
+  let open Vernactypes in
+  let proof = Proof.(if interactive then Reject else Ignore) in
+  let prog = Prog.(if interactive then Push else Ignore) in
+  typed_vernac prog proof
+    (fun ~pm ~proof ->
+       let () = f () in
+       (), ())
 
 (* Libraries *)
 

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -13,26 +13,7 @@ open Synterp
 
 let vernac_pperr_endline = CDebug.create ~name:"vernacinterp" ()
 
-let interp_typed_vernac (Vernactypes.TypedVernac { inprog; outprog; inproof; outproof; run })
-    ~pm ~stack =
-  let open Vernactypes in
-  let module LStack = Vernacstate.LemmaStack in
-  let proof = Option.map LStack.get_top stack in
-  let pm', proof' = run
-      ~pm:(InProg.cast (NeList.head pm) inprog)
-      ~proof:(InProof.cast proof inproof)
-  in
-  let pm = OutProg.cast pm' outprog pm in
-  let stack = let open OutProof in
-    match stack, outproof with
-    | stack, No -> stack
-    | None, Close -> assert false
-    | Some stack, Close -> snd (LStack.pop stack)
-    | None, Update -> assert false
-    | Some stack, Update -> Some (LStack.map_top ~f:(fun _ -> proof') stack)
-    | stack, New -> Some (LStack.push stack proof')
-  in
-  stack, pm
+let interp_typed_vernac = Vernactypes.run
 
 (* Timeout *)
 let vernac_timeout ~timeout (f : 'a -> 'b) (x : 'a) : 'b =


### PR DESCRIPTION
Many combinations did not make sense.

The abstraction

~~~ocaml
type ('a,'b,'x) runner = { run : 'd. 'x -> ('a -> 'b * 'd) -> 'x * 'd } 
~~~

should hopefully make adding more independent states easier in the future.
