### PR TITLE
coqdoc: update refman and stdlib URLs

### DIFF
--- a/tools/configure/configure.ml
+++ b/tools/configure/configure.ml
@@ -419,8 +419,8 @@ let write_configml install_prefix camlenv coqenv caml_flags caml_version_nums ar
   pr_s "browser" browser;
   pr_s "wwwcoq" prefs.coqwebsite;
   pr_s "wwwbugtracker" (prefs.coqwebsite ^ "bugs/");
-  pr_s "wwwrefman" (prefs.coqwebsite ^ "distrib/V" ^ coq_version ^ "/refman/");
-  pr_s "wwwstdlib" (prefs.coqwebsite ^ "distrib/V" ^ coq_version ^ "/stdlib/");
+  pr_s "wwwrefman" (prefs.coqwebsite ^ "doc/V" ^ coq_version ^ "/refman/");
+  pr_s "wwwstdlib" (prefs.coqwebsite ^ "doc/V" ^ coq_version ^ "/stdlib/");
   pr_b "bytecode_compiler" prefs.bytecodecompiler;
   pr "type native_compiler = NativeOff | NativeOn of { ondemand : bool }\n";
   pr "let native_compiler = %s\n"


### PR DESCRIPTION
The reference manual and the standard library documentation have moved on the Coq homepage. The URLs are now `https://coq.inria.fr/doc/V${VERSION}/refman/`  and `https://coq.inria.fr/doc/V${VERSION}/stdlib/`, respectively. 

While there is an automatic redirect from the old URL to the new one, the redirect breaks the anchors that `coqdoc` uses to refer to specific symbols. To avoid the problem, this patch updates the configuration to link to the actual URL instead to avoid the anchor-breaking redirect. 

See also: https://github.com/coq/coq.github.io/issues/235
