### PR TITLE
Fixes #15020: printing implicit arguments in the presence of notations

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/18442-master+fixes15020-print-about-fully-see-through-notations.rst
+++ b/doc/changelog/08-vernac-commands-and-options/18442-master+fixes15020-print-about-fully-see-through-notations.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Fixes missing implicit arguments coming after a :g:`->` in the main type
+  printed by :cmd:`Print` and :cmd:`About`
+  (`#18442 <https://github.com/coq/coq/pull/18442>`_,
+  fixes `#15020 <https://github.com/coq/coq/issues/15020>`_,
+  by Hugo Herbelin).

--- a/test-suite/output/Arguments.out
+++ b/test-suite/output/Arguments.out
@@ -40,7 +40,7 @@ Nat.sub is transparent
 Expands to: Constant Coq.Init.Nat.sub
 pf :
 forall {D1 C1 : Type},
-(D1 -> C1) -> forall D2 C2 : Type, (D2 -> C2) -> D1 * D2 -> C1 * C2
+(D1 -> C1) -> forall [D2 C2 : Type], (D2 -> C2) -> D1 * D2 -> C1 * C2
 
 pf is not universe polymorphic
 Arguments pf {D1}%foo_scope {C1}%type_scope f [D2 C2] g x : simpl never

--- a/test-suite/output/Search.out
+++ b/test-suite/output/Search.out
@@ -49,7 +49,7 @@ Nat.bitwise: (bool -> bool -> bool) -> nat -> nat -> nat -> nat
 eq_true_rec_r:
   forall (P : bool -> Set) [b : bool], P b -> eq_true b -> P true
 eq_true_ind:
-  forall P : bool -> Prop, P true -> forall b : bool, eq_true b -> P b
+  forall P : bool -> Prop, P true -> forall [b : bool], eq_true b -> P b
 bool_rec: forall P : bool -> Set, P true -> P false -> forall b : bool, P b
 eq_true_rect_r:
   forall (P : bool -> Type) [b : bool], P b -> eq_true b -> P true
@@ -57,14 +57,14 @@ bool_rect: forall P : bool -> Type, P true -> P false -> forall b : bool, P b
 eq_true_ind_r:
   forall (P : bool -> Prop) [b : bool], P b -> eq_true b -> P true
 eq_true_rect:
-  forall P : bool -> Type, P true -> forall b : bool, eq_true b -> P b
+  forall P : bool -> Type, P true -> forall [b : bool], eq_true b -> P b
 bool_sind:
   forall P : bool -> SProp, P true -> P false -> forall b : bool, P b
 eq_true_rec:
-  forall P : bool -> Set, P true -> forall b : bool, eq_true b -> P b
+  forall P : bool -> Set, P true -> forall [b : bool], eq_true b -> P b
 bool_ind: forall P : bool -> Prop, P true -> P false -> forall b : bool, P b
 eq_true_sind:
-  forall P : bool -> SProp, P true -> forall b : bool, eq_true b -> P b
+  forall P : bool -> SProp, P true -> forall [b : bool], eq_true b -> P b
 Number.internal_uint_dec_bl1:
   forall x y : Number.uint, Number.uint_beq x y = true -> x = y
 Hexadecimal.internal_hexadecimal_dec_lb:
@@ -125,11 +125,11 @@ andb_true_intro:
 BoolSpec_ind:
   forall [P Q : Prop] (P0 : bool -> Prop),
   (P -> P0 true) ->
-  (Q -> P0 false) -> forall b : bool, BoolSpec P Q b -> P0 b
+  (Q -> P0 false) -> forall [b : bool], BoolSpec P Q b -> P0 b
 BoolSpec_sind:
   forall [P Q : Prop] (P0 : bool -> SProp),
   (P -> P0 true) ->
-  (Q -> P0 false) -> forall b : bool, BoolSpec P Q b -> P0 b
+  (Q -> P0 false) -> forall [b : bool], BoolSpec P Q b -> P0 b
 Byte.to_bits_of_bits:
   forall
     b : bool * (bool * (bool * (bool * (bool * (bool * (bool * bool)))))),

--- a/test-suite/output/bug_15020.out
+++ b/test-suite/output/bug_15020.out
@@ -1,0 +1,9 @@
+eq_rect :
+forall {A : Type} {x : A} (P : A -> Type),
+P x -> forall {y : A}, x = y -> P y
+
+eq_rect is not universe polymorphic
+Arguments eq_rect {A}%type_scope {x} P%function_scope f {y} e
+  (where some original arguments have been renamed)
+eq_rect is transparent
+Expands to: Constant Coq.Init.Logic.eq_rect

--- a/test-suite/output/bug_15020.v
+++ b/test-suite/output/bug_15020.v
@@ -1,0 +1,3 @@
+(* A variant of bug #13392 *)
+Arguments eq_rect {_ _} _ _ {_}.
+About eq_rect.

--- a/test-suite/output/bug_3810.out
+++ b/test-suite/output/bug_3810.out
@@ -1,4 +1,4 @@
-test : Foo -> nat -> forall A : Type, A
+test : Foo -> nat -> forall {A : Type}, A
 
 test is not universe polymorphic
 Arguments test H n%nat_scope {A}%type_scope


### PR DESCRIPTION
This refines #15685 by deactivating the notation-unaware previous mechanism of tagging dependent function types with implicit status: in #15020, the `->` notation was used in printing but its implicit arguments were later overriden by the previous tagging mechanism (applied to an empty list of implicit statuses).

Fixes / closes #15020

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
