### PR TITLE
Granting wish #18097: Print and About see through abbreviations playing the role of aliases

### DIFF
--- a/dev/ci/user-overlays/18443-herbelin-master+wish18097-print-about-see-through-aliases.sh
+++ b/dev/ci/user-overlays/18443-herbelin-master+wish18097-print-about-see-through-aliases.sh
@@ -1,0 +1,1 @@
+overlay coq_lsp https://github.com/herbelin/coq-lsp  main+adapt-18443-print_abbreviation-sigma 18443 master+wish18097-print-about-see-through-aliases

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -276,7 +276,7 @@ type 'a notation_query_pattern_gen = {
 
 type notation_query_pattern = qualid notation_query_pattern_gen
 
-val toggle_notations : on:bool -> all:bool -> (glob_constr -> Pp.t) -> notation_query_pattern -> unit
+val toggle_notations : on:bool -> all:bool -> ?verbose:bool -> (glob_constr -> Pp.t) -> notation_query_pattern -> unit
 
 (** {6 Miscellaneous} *)
 
@@ -293,6 +293,11 @@ exception NotationAsReferenceError of notation_as_reference_error
     Raise NotationAsReferenceError if not resolvable as a global reference *)
 val interp_notation_as_global_reference : ?loc:Loc.t -> head:bool ->
       (GlobRef.t -> bool) -> notation_key -> delimiters option -> GlobRef.t
+
+(** Same together with the full notation *)
+val interp_notation_as_global_reference_expanded : ?loc:Loc.t -> head:bool ->
+      (GlobRef.t -> bool) -> notation_key -> delimiters option ->
+  (notation_entry * notation_key) * notation_key * notation_with_optional_scope * interpretation * GlobRef.t
 
 (** Declares and looks for scopes associated to arguments of a global ref *)
 val declare_arguments_scope :

--- a/test-suite/output/PrintInfos.out
+++ b/test-suite/output/PrintInfos.out
@@ -78,6 +78,13 @@ Arguments bar {x}
 Module Coq.Init.Peano
 Notation sym_eq := eq_sym
 Expands to: Notation Coq.Init.Logic.sym_eq
+
+eq_sym : forall [A : Type] [x y : A], x = y -> y = x
+
+eq_sym is not universe polymorphic
+Arguments eq_sym [A]%type_scope [x y] _
+eq_sym is transparent
+Expands to: Constant Coq.Init.Logic.eq_sym
 Inductive eq (A : Type) (x : A) : A -> Prop :=  eq_refl : x = x.
 
 Arguments eq {A}%type_scope x _

--- a/test-suite/output/bug_12777.out
+++ b/test-suite/output/bug_12777.out
@@ -1,1 +1,3 @@
 Notation tt' := tt
+
+Inductive unit : Set :=  tt : unit.

--- a/test-suite/output/wish_18097.out
+++ b/test-suite/output/wish_18097.out
@@ -1,0 +1,20 @@
+Notation pow := Nat.pow
+
+Nat.pow =
+fix pow (n m : nat) {struct m} : nat :=
+  match m with
+  | 0 => 1
+  | S m0 => n * pow n m0
+  end
+     : nat -> nat -> nat
+
+Arguments Nat.pow (n m)%nat_scope
+Notation pow := Nat.pow
+Expands to: Notation wish_18097.pow
+
+Nat.pow : nat -> nat -> nat
+
+Nat.pow is not universe polymorphic
+Arguments Nat.pow (n m)%nat_scope
+Nat.pow is transparent
+Expands to: Constant Coq.Init.Nat.pow

--- a/test-suite/output/wish_18097.v
+++ b/test-suite/output/wish_18097.v
@@ -1,0 +1,3 @@
+Notation pow := Nat.pow.
+Print pow.
+About pow.

--- a/vernac/prettyp.mli
+++ b/vernac/prettyp.mli
@@ -48,7 +48,7 @@ val print_notation : env -> Evd.evar_map
   -> string
   -> Pp.t
 
-val print_abbreviation : env -> KerName.t -> Pp.t
+val print_abbreviation : env -> Evd.evar_map -> KerName.t -> Pp.t
 
 val print_about : env -> Evd.evar_map -> qualid Constrexpr.or_by_notation ->
   UnivNames.full_name_list option -> Pp.t


### PR DESCRIPTION
Does the following:

```coq
Notation pow := Nat.pow.
Print pow.
(* Before:
Notation pow := Nat.pow
*)
(* After:
Notation pow := Nat.pow

Nat.pow =
fix pow (n m : nat) {struct m} : nat :=
  match m with
  | 0 => 1
  | S m0 => n * pow n m0
  end
     : nat -> nat -> nat

Arguments Nat.pow (n m)%nat_scope
*)
```

By uniformity, it now indicates the expanded notation in `Print ntn`:
```coq
Print "+".
(* Before:
Nat.add =
fix add (n m : nat) {struct n} : nat :=
  match n with
  | 0 => m
  | S p => S (add p m)
  end
     : nat -> nat -> nat

Arguments Nat.add (n m)%nat_scope
*)
(* After:
Notation "x + y" := (Nat.add x y)
Nat.add =
fix add (n m : nat) {struct n} : nat :=
  match n with
  | 0 => m
  | S p => S (add p m)
  end
     : nat -> nat -> nat

Arguments Nat.add (n m)%nat_scope
*)
```
Depends on the reorganization of `prettyp.ml` in #18444.

Closes #18097
See also: this [comment](https://github.com/coq/coq/issues/14486#issuecomment-859508412) at #14486

- [x] Added / updated **test-suite**.
- [ ] Added **changelog**.

Synchronous overlay: ejgallego/coq-lsp#638
