### PR TITLE
Documenting and reorganizing prettyp.ml; showing implicit arguments also in the main type shown by "Print"

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/18444-master+cleaning-print-about.rst
+++ b/doc/changelog/08-vernac-commands-and-options/18444-master+cleaning-print-about.rst
@@ -1,0 +1,7 @@
+- **Added:**
+  :cmd:`Print` :n:`@reference` now shows the implicit arguments of a
+  :n:`@reference` directly on the type of :n:`@reference`, using
+  `{...}` and `[...]` markers for respectively maximally-inserted and
+  non-maximally-inserted implicit arguments, as :cmd:`About` does
+  (`#18444 <https://github.com/coq/coq/pull/18444>`_,
+  by Hugo Herbelin).

--- a/test-suite/output/Arguments_renaming.out
+++ b/test-suite/output/Arguments_renaming.out
@@ -41,7 +41,7 @@ fix myplus (T : Type) (t : T) (n m : nat) {struct n} : nat :=
   | 0 => m
   | S n' => S (myplus T t n' m)
   end
-     : forall T : Type, T -> nat -> nat -> nat
+     : forall {T : Type}, T -> nat -> nat -> nat
 
 Arguments myplus {Z}%type_scope !t (!n m)%nat_scope
   (where some original arguments have been renamed)
@@ -76,7 +76,7 @@ fix myplus (T : Type) (t : T) (n m : nat) {struct n} : nat :=
   | 0 => m
   | S n' => S (myplus T t n' m)
   end
-     : forall T : Type, T -> nat -> nat -> nat
+     : forall {T : Type}, T -> nat -> nat -> nat
 
 Arguments myplus {Z}%type_scope !t (!n m)%nat_scope
   (where some original arguments have been renamed)

--- a/test-suite/output/Implicit.out
+++ b/test-suite/output/Implicit.out
@@ -3,7 +3,7 @@ compose S
 ex_intro (P:=fun _ : nat => True) (x:=0) I
      : ex (fun _ : nat => True)
 d2 = fun x : nat => d1 (y:=x)
-     : forall x x0 : nat, x0 = x -> x0 = x
+     : forall [x x0 : nat], x0 = x -> x0 = x
 
 Arguments d2 [x x]%nat_scope h
 map id (1 :: nil)

--- a/test-suite/output/PatternsInBinders.out
+++ b/test-suite/output/PatternsInBinders.out
@@ -21,7 +21,7 @@ fun '(Bar n1 _ tt p1) '(Bar _ _ tt _) => n1 + p1
 Arguments baz pat pat
 swap =
 fun (A B : Type) '(x, y) => (y, x)
-     : forall A B : Type, A * B -> B * A
+     : forall {A B : Type}, A * B -> B * A
 
 Arguments swap {A B}%type_scope pat
 fun (A B : Type) '(x, y) => swap (x, y) = (y, x)

--- a/test-suite/output/PrintMatch.out
+++ b/test-suite/output/PrintMatch.out
@@ -27,7 +27,7 @@ fun (A : Type) (x y : A) (H : @eq A x y) =>
 match H in (@eq _ _ a) return (@eq A a x) with
 | @eq_refl _ _ => @eq_refl A x
 end
-     : forall (A : Type) (x y : A) (_ : @eq A x y), @eq A y x
+     : forall [A : Type] [x y : A] (_ : @eq A x y), @eq A y x
 
 Arguments eq_sym [A]%type_scope [x y] _
 eq_sym =
@@ -35,7 +35,7 @@ fun (A : Type) (x y : A) (H : x = y) =>
 match H in (_ = a) return (a = x) with
 | @eq_refl _ _ => @eq_refl A x
 end
-     : forall (A : Type) (x y : A), x = y -> y = x
+     : forall [A : Type] [x y : A], x = y -> y = x
 
 Arguments eq_sym [A]%type_scope [x y] _
 eq_sym =
@@ -43,6 +43,6 @@ fun (A : Type) (x y : A) (H : x = y) =>
 match H in (_ = a) return (a = x) with
 | @eq_refl _ _ => @eq_refl A x
 end
-     : forall (A : Type) (x y : A), x = y -> y = x
+     : forall [A : Type] [x y : A], x = y -> y = x
 
 Arguments eq_sym [A]%type_scope [x y] _

--- a/test-suite/output/PrintModule.out
+++ b/test-suite/output/PrintModule.out
@@ -1,11 +1,7 @@
 Module N : S with Definition T := nat := M
-
 Module N : S with Definition T := M
-
 Module N : S with Module T := K := M
-
 Module N : S with Module T := M
-
 Module Type Func = Funsig (T0:Test) Sig Parameter x : T0.t. End
 Module
 A
@@ -14,4 +10,3 @@ A
      Record R : Set := Build_R { n : nat }.
      Definition n : R -> nat.
    End
-

--- a/test-suite/output/UnivBinders.out
+++ b/test-suite/output/UnivBinders.out
@@ -32,7 +32,7 @@ Wrap@{uu} = fun A : Type@{uu} => A
 Arguments Wrap A%type_scope
 wrap@{uu} =
 fun (A : Type@{uu}) (Wrap : Wrap@{uu} A) => Wrap
-     : forall A : Type@{uu}, Wrap@{uu} A -> A
+     : forall {A : Type@{uu}}, Wrap@{uu} A -> A
 (* uu |=  *)
 
 Arguments wrap {A}%type_scope {Wrap}

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -8,9 +8,9 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(* Changed by (and thus parts copyright ©) by Lionel Elie Mamane <lionel@mamane.lu>
- * on May-June 2006 for implementation of abstraction of pretty-printing of objects.
- *)
+(* Collective work; includes changes by (and thus parts copyright ©)
+   by Lionel Elie Mamane <lionel@mamane.lu> on May-June 2006 for
+   implementation of abstraction of pretty-printing of objects. *)
 
 open Pp
 open CErrors
@@ -51,7 +51,7 @@ let int_or_no n = if Int.equal n 0 then str "no" else int n
 (*******************)
 (** Basic printing *)
 
-let print_basename sp = pr_global (GlobRef.ConstRef sp)
+let print_basename cst = pr_global (GlobRef.ConstRef cst)
 
 let print_ref reduce ref udecl =
   let env = Global.env () in
@@ -82,8 +82,7 @@ let print_ref reduce ref udecl =
   hov 0 (pr_global ref ++ inst ++ str " :" ++ spc () ++ pr_ltype_env env sigma ~impargs typ ++
          Printer.pr_abstract_universe_ctx sigma ?variance univs ?priv)
 
-(********************************)
-(** Printing implicit arguments *)
+(** Command [Print Implicit], somehow subsumed by [About] *)
 
 let pr_impl_name imp = Id.print (name_of_implicit imp)
 
@@ -141,8 +140,13 @@ let print_impargs ref =
     (if has_impl then print_impargs_list (mt()) impl
      else [str "No implicit arguments"]))
 
-(*********************)
-(** Printing Opacity *)
+(** Printing reduction behavior *)
+
+let print_reduction_behaviour = function
+  | GlobRef.ConstRef ref -> let p = Reductionops.ReductionBehaviour.print ref in if Pp.ismt p then [] else [p]
+  | _ -> []
+
+(** Printing opacity status *)
 
 type opacity =
   | FullyOpaque
@@ -179,7 +183,7 @@ let print_opacity ref =
           | TransparentMaybeOpacified Conv_oracle.Expand ->
               str "transparent (with minimal expansion weight)"]
 
-(*******************)
+(** Printing coercion status *)
 
 let print_if_is_coercion ref =
   if Coercionops.coercion_exists ref then
@@ -188,8 +192,7 @@ let print_if_is_coercion ref =
     [pr_global ref ++ str " is a" ++ str r ++ str " coercion"]
   else []
 
-(*******************)
-(* *)
+(** Printing polymorphic status *)
 
 let pr_template_variables = function
   | [] -> mt ()
@@ -206,11 +209,15 @@ let print_polymorphism ref =
          ++ if !Detyping.print_universes then h (pr_template_variables template_variables) else mt()
        else str "not universe polymorphic") ]
 
+(** Printing type-in-type status *)
+
 let print_type_in_type ref =
   let unsafe = Global.is_type_in_type ref in
   if unsafe then
     [ pr_global ref ++ str " relies on an unsafe universe hierarchy"]
   else []
+
+(** Printing primitive projection status *)
 
 let print_primitive_record recflag mipv = function
   | PrimRecord _ ->
@@ -227,6 +234,8 @@ let print_primitive ref =
     let mib,_ = Global.lookup_inductive ind in
       print_primitive_record mib.mind_finite mib.mind_packets mib.mind_record
   | _ -> []
+
+(** Printing arguments status (scopes, implicit, names) *)
 
 let needs_extra_scopes ref scopes =
   let open Constr in
@@ -336,6 +345,8 @@ let print_arguments ref =
      (if not_renamed then mt () else
       fnl () ++ str "  (where some original arguments have been renamed)")]
 
+(** Printing dependencies in section variables *)
+
 let print_section_deps ref =
   let hyps = let open GlobRef in match ref with
   | VarRef _ -> None
@@ -353,6 +364,16 @@ let print_section_deps ref =
     [hov 0 (pr_global ref ++ str (String.plural (List.length hyps) " uses section variable") ++ spc () ++
             hv 1 (prlist_with_sep spc (fun d -> Id.print (NamedDecl.get_id d)) (List.rev hyps)) ++ str ".")]
 
+(** Printing bidirectionality status *)
+
+let print_bidi_hints gr =
+  match Pretyping.get_bidirectionality_hint gr with
+  | None -> []
+  | Some nargs ->
+    [str "Using typing information from context after typing the " ++ int nargs ++ str " first arguments"]
+
+(** Printing basic information about references (common to Print and About) *)
+
 let print_name_infos ref =
   let type_info_for_implicit =
     if need_expansion (select_impargs_size 0 (implicits_of_global ref)) ref then
@@ -368,21 +389,337 @@ let print_name_infos ref =
   print_section_deps ref @
   print_if_is_coercion ref
 
-let print_inductive_args sp mipv =
-  let flatmapi f v = List.flatten (Array.to_list (Array.mapi f v)) in
-  flatmapi
-    (fun i mip -> print_arguments (GlobRef.IndRef (sp,i)) @
-                  flatmapi (fun j _ -> print_arguments (GlobRef.ConstructRef ((sp,i),j+1)))
-                    mip.mind_consnames) mipv
+(******************************************)
+(**** Printing declarations and judgments *)
+(****  Gallina layer                  *****)
 
-let print_bidi_hints gr =
-  match Pretyping.get_bidirectionality_hint gr with
-  | None -> []
-  | Some nargs ->
-    [str "Using typing information from context after typing the " ++ int nargs ++ str " first arguments"]
+let print_typed_value_in_env env sigma (trm,typ) =
+  (pr_leconstr_env ~inctx:true env sigma trm ++ fnl () ++
+     str "     : " ++ pr_letype_env env sigma typ)
+
+(* To be improved; the type should be used to provide the types in the
+   abstractions. This should be done recursively inside pr_lconstr, so that
+   the pretty-print of a proposition (P:(nat->nat)->Prop)(P [u]u)
+   synthesizes the type nat of the abstraction on u *)
+
+let print_named_def env sigma name body typ =
+  let pbody = pr_lconstr_env ~inctx:true env sigma body in
+  let ptyp = pr_ltype_env env sigma typ in
+  let pbody = if Constr.isCast body then surround pbody else pbody in
+  (str "*** [" ++ str name ++ str " " ++
+     hov 0 (str ":=" ++ brk (1,2) ++ pbody ++ spc () ++
+              str ":" ++ brk (1,2) ++ ptyp) ++
+           str "]")
+
+let print_named_assum env sigma name typ =
+  str "*** [" ++ str name ++ str " : " ++ pr_ltype_env env sigma typ ++ str "]"
+
+let print_named_decl env sigma id =
+  let open Context.Named.Declaration in
+  match lookup_named id env with
+  | LocalAssum (id, typ) ->
+     print_named_assum env sigma (Id.to_string id.Context.binder_name) typ
+  | LocalDef (id, body, typ) ->
+     print_named_def env sigma (Id.to_string id.Context.binder_name) body typ
+
+let assumptions_for_print lna =
+  List.fold_right (fun na env -> add_name na env) lna empty_names_context
 
 (*********************)
-(* "Locate" commands *)
+(* *)
+
+let print_inductive_args mind mipv =
+  let flatmapi f v = List.flatten (Array.to_list (Array.mapi f v)) in
+  flatmapi
+    (fun i mip -> print_arguments (GlobRef.IndRef (mind,i)) @
+                  flatmapi (fun j _ -> print_arguments (GlobRef.ConstructRef ((mind,i),j+1)))
+                    mip.mind_consnames) mipv
+
+let print_inductive mind udecl =
+  let env = Global.env() in
+  let mib = Environ.lookup_mind mind env in
+  Printmod.pr_mutual_inductive_body env mind mib udecl
+
+let print_inductive_with_infos mind udecl =
+  let env = Global.env() in
+  let mib = Environ.lookup_mind mind env in
+  let mipv = mib.mind_packets in
+  Printmod.pr_mutual_inductive_body env mind mib udecl ++
+  with_line_skip
+    (print_primitive_record mib.mind_finite mipv mib.mind_record @
+     print_inductive_args mind mipv)
+
+let print_section_variable_with_infos env sigma id =
+  print_named_decl env sigma id ++
+  with_line_skip (print_name_infos (GlobRef.VarRef id))
+
+let print_body env evd = function
+  | Some c  -> pr_lconstr_env ~inctx:true env evd c
+  | None -> (str"<no body>")
+
+let print_typed_body env evd (val_0,typ) =
+  (print_body env evd val_0 ++ fnl () ++ str "     : " ++ pr_ltype_env env evd typ)
+
+let print_instance sigma cb =
+  if Declareops.constant_is_polymorphic cb then
+    let univs = Declareops.constant_polymorphic_context cb in
+    let inst = UVars.make_abstract_instance univs in
+    pr_universe_instance sigma inst
+  else mt()
+
+let print_constant with_values cst udecl =
+  let cb = Global.lookup_constant cst in
+  let val_0 = Global.body_of_constant_body Library.indirect_accessor cb in
+  let typ = cb.const_type in
+  let univs = cb.const_universes in
+  let uctx =
+    UState.of_names
+      (Printer.universe_binders_with_opt_names (Declareops.constant_polymorphic_context cb) udecl)
+  in
+  let env = Global.env () and sigma = Evd.from_ctx uctx in
+  let pr_ltype = pr_ltype_env env sigma in
+  hov 0 (
+    match val_0 with
+    | None ->
+        str"*** [ " ++
+        print_basename cst ++ print_instance sigma cb ++ str " :" ++ spc () ++ pr_ltype typ ++
+        str" ]" ++
+        Printer.pr_universes sigma univs
+    | Some (c, priv, ctx) ->
+      let priv = match priv with
+      | Opaqueproof.PrivateMonomorphic () -> None
+      | Opaqueproof.PrivatePolymorphic ctx -> Some ctx
+      in
+      print_basename cst ++ print_instance sigma cb ++
+      str (if with_values then " =" else " :") ++ spc() ++
+      (if with_values then print_typed_body env sigma (Some c,typ) else pr_ltype typ)++
+      Printer.pr_universes sigma univs ?priv)
+
+let print_constant_with_infos cst udecl =
+  print_constant true cst udecl ++
+  with_line_skip (print_name_infos (GlobRef.ConstRef cst))
+
+let print_global_reference env sigma gref udecl =
+  let open GlobRef in
+  match gref with
+  | ConstRef cst -> print_constant_with_infos cst udecl
+  | IndRef (mind,_) -> print_inductive_with_infos mind udecl
+  | ConstructRef ((mind,_),_) -> print_inductive_with_infos mind udecl
+  | VarRef id -> print_section_variable_with_infos env sigma id
+
+let glob_constr_of_abbreviation kn =
+  let (vars,a) = Abbreviation.search_abbreviation kn in
+  (List.map fst vars, Notation_ops.glob_constr_of_notation_constr a)
+
+let print_abbreviation_body env kn (vars,c) =
+  let qid = Nametab.shortest_qualid_of_abbreviation Id.Set.empty kn in
+  hov 2
+    (hov 4
+       (str "Notation " ++ pr_qualid qid ++
+        prlist (fun id -> spc () ++ Id.print id) vars ++
+        spc () ++ str ":=") ++
+     spc () ++
+     Vernacstate.System.protect (fun () ->
+         Abbreviation.toggle_abbreviation ~on:false ~use:ParsingAndPrinting kn;
+         pr_glob_constr_env env (Evd.from_env env) c) ())
+
+let print_abbreviation env kn =
+  print_abbreviation_body env kn (glob_constr_of_abbreviation kn)
+
+(** Unused outside? *)
+
+let pr_prefix_name prefix = Id.print (snd (split_dirpath prefix.Nametab.obj_dir))
+
+let print_library_node = function
+  | Lib.OpenedSection (prefix, _) ->
+    str " >>>>>>> Section " ++ pr_prefix_name prefix
+  | Lib.OpenedModule (_,_,prefix,_) ->
+    str " >>>>>>> Module " ++ pr_prefix_name prefix
+  | Lib.CompilingLibrary { Nametab.obj_dir; _ } ->
+    str " >>>>>>> Library " ++ DirPath.print obj_dir
+
+(** Printing part of command [Check] *)
+
+let print_judgment env sigma {uj_val=trm;uj_type=typ} =
+  print_typed_value_in_env env sigma (trm, typ)
+
+let print_safe_judgment {Safe_typing.jdg_env=senv; jdg_val=trm; jdg_type=typ} =
+  let env = Safe_typing.env_of_safe_env senv in
+  let sigma = Evd.from_env env in
+  let trm = EConstr.of_constr trm in
+  let typ = EConstr.of_constr typ in
+  print_typed_value_in_env env sigma (trm, typ)
+
+(** Command [Print All] *)
+
+module DynHandle = Libobject.Dyn.Map(struct type 'a t = 'a -> Pp.t option end)
+
+let handle h (Libobject.Dyn.Dyn (tag, o)) = match DynHandle.find tag h with
+  | f -> f o
+  | exception Not_found -> None
+
+(* TODO: this kind of feature should not rely on the Libobject stack. There is
+   no reason that an object in the stack corresponds to a user-facing
+   declaration. It may have been so at the time this was written, but this
+   needs to be done in a more principled way. *)
+let print_library_leaf env sigma with_values mp lobj =
+  match lobj with
+  | AtomicObject o ->
+    let handler =
+      DynHandle.add Declare.Internal.objVariable begin fun id ->
+          (* Outside sections, VARIABLES still exist but only with universes
+             constraints *)
+          (try Some(print_named_decl env sigma id) with Not_found -> None)
+      end @@
+      DynHandle.add Declare.Internal.Constant.tag begin fun (id,_) ->
+        let kn = Constant.make2 mp (Label.of_id id) in
+        Some (print_constant with_values kn None)
+      end @@
+      DynHandle.add DeclareInd.Internal.objInductive begin fun (id,_) ->
+        let kn = MutInd.make2 mp (Label.of_id id) in
+        Some (print_inductive kn None)
+      end @@
+      DynHandle.empty
+    in
+    handle handler o
+  | ModuleObject (id,_) ->
+    Some (Printmod.print_module ~with_body:with_values (MPdot (mp,Label.of_id id)))
+  | ModuleTypeObject (id,_) ->
+    Some (print_modtype (MPdot (mp, Label.of_id id)))
+  | IncludeObject _ | KeepObject _ | ExportObject _ -> None
+
+let decr = Option.map ((+) (-1))
+
+let is_done = Option.equal Int.equal (Some 0)
+
+let print_leaves env sigma with_values mp n leaves =
+  let rec prec n = function
+    | [] -> n, []
+    | o :: rest ->
+      if is_done n then n, []
+      else begin match print_library_leaf env sigma with_values mp o with
+        | Some pp ->
+          let n, prest = prec (decr n) rest in
+          n, pp :: prest
+        | None -> prec n rest
+      end
+  in
+  let n, l = prec n leaves in
+  n, v 0 (pr_sequence (fun x -> x) (List.rev l))
+
+let print_context env sigma with_values =
+  let rec prec n = function
+    | [] -> mt()
+    | (node, leaves) :: rest ->
+      if is_done n then mt()
+      else
+        let mp = (Lib.node_prefix node).Nametab.obj_mp in
+        let n, pleaves = print_leaves env sigma with_values mp n leaves in
+        if is_done n then pleaves
+        else prec n rest ++ pleaves
+  in
+  prec
+
+let print_full_context env sigma =
+  print_context env sigma true None (Lib.contents ())
+let print_full_context_typ env sigma = (* Command [Print All] *)
+  print_context env sigma false None (Lib.contents ())
+
+(** Command line [-output-context] *)
+
+module DynHandleF = Libobject.Dyn.Map(struct type 'a t = 'a -> Pp.t end)
+
+let handleF h (Libobject.Dyn.Dyn (tag, o)) = match DynHandleF.find tag h with
+  | f -> f o
+  | exception Not_found -> mt ()
+
+(* TODO: see the comment for {!print_leaf_entry} *)
+let print_full_pure_atomic env sigma mp lobj =
+  let handler =
+    DynHandleF.add Declare.Internal.Constant.tag begin fun (id,_) ->
+      let kn = KerName.make mp (Label.of_id id) in
+      let con = Global.constant_of_delta_kn kn in
+      let cb = Global.lookup_constant con in
+      let typ = cb.const_type in
+      hov 0 (
+        match cb.const_body with
+        | Undef _ ->
+          str "Parameter " ++
+          print_basename con ++ str " :" ++ spc () ++ pr_ltype_env env sigma typ
+        | OpaqueDef lc ->
+          str "Theorem " ++ print_basename con ++ cut () ++
+          str " : " ++ pr_ltype_env env sigma typ ++ str "." ++ fnl () ++
+          str "Proof " ++ pr_lconstr_env env sigma
+            (fst (Global.force_proof Library.indirect_accessor lc))
+        | Def c ->
+          str "Definition " ++ print_basename con ++ cut () ++
+          str "  : " ++ pr_ltype_env env sigma typ ++ cut () ++ str " := " ++
+          pr_lconstr_env env sigma c
+        | Primitive _ ->
+          str "Primitive " ++
+          print_basename con ++ str " :" ++ spc () ++ pr_ltype_env env sigma typ)
+      ++ str "." ++ fnl () ++ fnl ()
+    end @@
+    DynHandleF.add DeclareInd.Internal.objInductive begin fun (id,_) ->
+      let kn = KerName.make mp (Label.of_id id) in
+      let mind = Global.mind_of_delta_kn kn in
+      let mib = Global.lookup_mind mind in
+      Printmod.pr_mutual_inductive_body (Global.env()) mind mib None ++
+      str "." ++ fnl () ++ fnl ()
+    end @@
+    DynHandleF.empty
+  in
+  handleF handler lobj
+
+let print_full_pure_leaf env sigma mp = function
+  | AtomicObject lobj -> print_full_pure_atomic env sigma mp lobj
+  | ModuleObject (id, _) ->
+    (* TODO: make it reparsable *)
+    print_module (MPdot (mp,Label.of_id id)) ++ str "." ++ fnl () ++ fnl ()
+  | ModuleTypeObject (id, _) ->
+    (* TODO: make it reparsable *)
+    print_modtype (MPdot (mp,Label.of_id id)) ++ str "." ++ fnl () ++ fnl ()
+  | _ -> mt()
+
+let print_full_pure_context env sigma =
+  let rec prec = function
+    | (node,leaves)::rest ->
+      let mp = (Lib.node_prefix node).Nametab.obj_mp in
+      let pp = Pp.prlist (print_full_pure_leaf env sigma mp) leaves in
+      prec rest ++ pp
+  | [] -> mt ()
+  in
+  prec (Lib.contents ())
+
+(** Command [Print Section] *)
+
+(* For printing an inductive definition with
+   its constructors and elimination,
+   assume that the declaration of constructors and eliminations
+   follows the definition of the inductive type *)
+
+(* This is designed to print the contents of an opened section *)
+let read_sec_context qid =
+  let dir =
+    try Nametab.locate_section qid
+    with Not_found ->
+      user_err ?loc:qid.loc (str "Unknown section.") in
+  let rec get_cxt in_cxt = function
+    | (Lib.OpenedSection ({Nametab.obj_dir;_},_), _ as hd)::rest ->
+        if DirPath.equal dir obj_dir then (hd::in_cxt) else get_cxt (hd::in_cxt) rest
+    | [] -> []
+    | hd::rest -> get_cxt (hd::in_cxt) rest
+  in
+  let cxt = Lib.contents () in
+  List.rev (get_cxt [] cxt)
+
+let print_sec_context env sigma sec =
+  print_context env sigma true None (read_sec_context sec)
+
+let print_sec_context_typ env sigma sec =
+  print_context env sigma false None (read_sec_context sec)
+
+(** Command [Print] *)
 
 type 'a locatable_info = {
   locate : qualid -> 'a option;
@@ -393,8 +730,6 @@ type 'a locatable_info = {
   about : 'a -> Pp.t;
 }
 
-type locatable = Locatable : 'a locatable_info -> locatable
-
 type logical_name =
   | Term of GlobRef.t
   | Dir of Nametab.GlobDirRef.t
@@ -403,6 +738,8 @@ type logical_name =
   | ModuleType of ModPath.t
   | Other : 'a * 'a locatable_info -> logical_name
   | Undefined of qualid
+
+type locatable = Locatable : 'a locatable_info -> locatable
 
 (** Generic table for objects that are accessible through a name. *)
 let locatable_map : locatable String.Map.t ref = ref String.Map.empty
@@ -465,6 +802,227 @@ let pr_located_qualid = function
   | Other (obj, info) -> info.name obj
   | Undefined qid ->
       pr_qualid qid ++ spc () ++ str "not a defined object."
+
+let maybe_error_reject_univ_decl na udecl =
+  let open GlobRef in
+  match na, udecl with
+  | _, None | Term (ConstRef _ | IndRef _ | ConstructRef _), Some _ -> ()
+  | (Term (VarRef _) | Abbreviation _ | Dir _ | Module _ | ModuleType _ | Other _ | Undefined _), Some udecl ->
+    (* TODO Print na somehow *)
+    user_err (str "This object does not support universe names.")
+
+let print_any_name env sigma na udecl =
+  maybe_error_reject_univ_decl na udecl;
+  match na with
+  | Term gref -> print_global_reference env sigma gref udecl
+  | Abbreviation kn -> print_abbreviation env kn
+  | Module mp -> print_module mp
+  | Dir _ -> mt ()
+  | ModuleType mp -> print_modtype mp
+  | Other (obj, info) -> info.print obj
+  | Undefined qid ->
+  try  (* Var locale de but, pas var de section... donc pas d'implicits *)
+    let dir,str = repr_qualid qid in
+    if not (DirPath.is_empty dir) then raise Not_found;
+    print_named_decl env sigma str
+  with Not_found -> user_err ?loc:qid.loc (pr_qualid qid ++ spc () ++ str "not a defined object.")
+
+let print_name env sigma na udecl =
+  match na with
+  | {loc; v=Constrexpr.ByNotation (ntn,sc)} ->
+    print_any_name env sigma
+      (Term (Notation.interp_notation_as_global_reference ?loc ~head:false (fun _ -> true)
+               ntn sc))
+      udecl
+  | {loc; v=Constrexpr.AN ref} ->
+    print_any_name env sigma (locate_any_name ref) udecl
+
+(** Command [Print Notation] *)
+
+let print_notation_grammar env sigma ntn =
+  let ng = List.hd (Notgram_ops.grammar_of_notation ntn) in
+  let assoc = ng.Notation_gram.notgram_assoc in
+  let prdf () = Pp.str "no associativity" in
+  Pp.(pr_opt_no_spc_default prdf Gramlib.Gramext.pr_assoc assoc)
+
+exception PrintNotationNotFound of Constrexpr.notation_entry * string
+
+let () = CErrors.register_handler @@ function
+  | PrintNotationNotFound (entry, ntn_str) ->
+      let entry_string = match entry with
+      | Constrexpr.InConstrEntry -> "."
+      | Constrexpr.InCustomEntry e -> " in " ^ e ^ " entry."
+      in
+      Some Pp.(str "\"" ++ str ntn_str ++ str "\"" ++ spc ()
+        ++ str "cannot be interpreted as a known notation" ++ str entry_string ++ spc ()
+        ++ strbrk "Make sure that symbols are surrounded by spaces and that holes are explicitly denoted by \"_\".")
+  | _ -> None
+
+let error_print_notation_not_found e s =
+  raise @@ PrintNotationNotFound (e, s)
+
+let print_notation env sigma entry raw_ntn =
+  (* make sure entry exists *)
+  let () =
+    match entry with
+    | Constrexpr.InConstrEntry -> ()
+    | Constrexpr.InCustomEntry e -> Metasyntax.check_custom_entry e
+  in
+  (* convert notation string to key. eg. "x + y" to "_ + _" *)
+  let interp_ntn = Notation.interpret_notation_string raw_ntn in
+  let ntn = (entry, interp_ntn) in
+  try
+    let lvl = Notation.level_of_notation ntn in
+    let args = Notgram_ops.non_terminals_of_notation ntn in
+    let pplvl = Metasyntax.pr_level ntn lvl args in
+    Pp.(str "Notation \"" ++ str interp_ntn ++ str "\"" ++ spc ()
+      ++ pplvl ++ pr_comma () ++ print_notation_grammar env sigma ntn
+      ++ str ".")
+  with Not_found -> error_print_notation_not_found entry raw_ntn
+
+(** Command [About] *)
+
+let print_about_global_reference ?loc ref udecl =
+  pr_infos_list
+   (print_ref false ref udecl :: blankline ::
+    print_polymorphism ref @
+    print_name_infos ref @
+    print_reduction_behaviour ref @
+    print_opacity ref @
+    print_bidi_hints ref @
+    [hov 0 (str "Expands to: " ++ pr_located_qualid (Term ref))])
+
+let print_about_abbreviation env kn =
+  let (vars,c) = glob_constr_of_abbreviation kn in
+  print_abbreviation_body env kn (vars,c) ++ fnl () ++
+  hov 0 (str "Expands to: " ++ pr_located_qualid (Abbreviation kn))
+
+let print_about_any ?loc env sigma k udecl =
+  maybe_error_reject_univ_decl k udecl;
+  match k with
+  | Term ref -> Dumpglob.add_glob ?loc ref; print_about_global_reference ref udecl
+  | Abbreviation kn -> v 0 (print_about_abbreviation env kn)
+  | Dir _ | Module _ | ModuleType _ | Undefined _ -> hov 0 (pr_located_qualid k)
+  | Other (obj, info) -> hov 0 (info.about obj)
+
+let print_about env sigma na udecl =
+  match na with
+  | {loc;v=Constrexpr.ByNotation (ntn,sc)} ->
+      print_about_any ?loc env sigma
+        (Term (Notation.interp_notation_as_global_reference ?loc ~head:false (fun _ -> true)
+               ntn sc)) udecl
+  | {loc;v=Constrexpr.AN ref} ->
+      print_about_any ?loc env sigma (locate_any_name ref) udecl
+
+(* Command [Inspect], for debug *)
+
+let inspect env sigma depth =
+  print_context env sigma false (Some depth) (Lib.contents ())
+
+(*************************************************************************)
+(* Pretty-printing functions coming from classops.ml                     *)
+
+(** Command [Print Classes] *)
+
+open Coercionops
+
+let print_coercion_value v = Printer.pr_global v.coe_value
+
+let print_path ((i,j),p) =
+  hov 2 (
+    str"[" ++ hov 0 (prlist_with_sep pr_semicolon print_coercion_value p) ++
+    str"] : ") ++
+  pr_class i ++ str" >-> " ++ pr_class j ++
+  str (if path_is_reversible p then " (reversible)" else "")
+
+let _ = Coercionops.install_path_printer print_path
+
+let print_graph () =
+  prlist_with_sep fnl print_path (inheritance_graph())
+
+(** Command [Print Classes] *)
+
+let print_classes () =
+  pr_sequence pr_class (classes())
+
+(** Command [Print Coercions] *)
+
+let print_coercions () =
+  pr_sequence print_coercion_value (coercions())
+
+(** Command [Print Coercion Paths] *)
+
+let print_coercion_paths cls clt =
+  let p =
+    try
+      lookup_path_between_class (cls, clt)
+    with Not_found ->
+      user_err
+        (str"No path between " ++ pr_class cls ++ str" and " ++ pr_class clt
+         ++ str ".")
+  in
+  print_path ((cls, clt), p)
+
+(** Command [Print Canonical Projections] *)
+
+let print_canonical_projections env sigma grefs =
+  let open Structures in
+  let match_proj_gref { CSTable.projection; value; solution } gr =
+    QGlobRef.equal env projection gr ||
+    begin match value with
+      | ValuePattern.Const_cs y -> GlobRef.CanOrd.equal y gr
+      | _ -> false
+    end ||
+    QGlobRef.equal env solution gr
+  in
+  let projs =
+    List.filter (fun p -> List.for_all (match_proj_gref p) grefs)
+      (CSTable.entries ())
+  in
+  prlist_with_sep fnl
+    (fun { CSTable.projection; value; solution } ->
+    ValuePattern.print value ++
+    str " <- " ++
+    pr_global projection ++ str " ( " ++ pr_global solution ++ str " )")
+    projs
+
+(***********************************************)
+(** Pretty-printing functions for type classes *)
+
+(** Command [Print Typeclasses] *)
+
+open Typeclasses
+
+let pr_typeclass env t =
+  print_ref false t.cl_impl None
+
+let print_typeclasses () =
+  let env = Global.env () in
+    prlist_with_sep fnl (pr_typeclass env) (typeclasses ())
+
+(** Command [Print Instances] *)
+
+let pr_instance env i =
+  (*   print_constant_with_infos i.is_impl *)
+  (* lighter *)
+  print_ref false (instance_impl i) None ++
+  begin match hint_priority i with
+  | None -> mt ()
+  | Some i -> spc () ++ str "|" ++ spc () ++ int i
+  end
+
+let print_all_instances () =
+  let env = Global.env () in
+  let inst = all_instances () in
+    prlist_with_sep fnl (pr_instance env) inst
+
+let print_instances r =
+  let env = Global.env () in
+  let inst = instances_exn env (Evd.from_env env) r in
+  prlist_with_sep fnl (pr_instance env) inst
+
+(*********************)
+(* Commands [Locate] *)
 
 let canonize_ref = let open GlobRef in function
   | ConstRef c ->
@@ -531,10 +1089,10 @@ let locate_other s qid =
   List.map map ans
 
 type locatable_kind =
-| LocTerm
-| LocModule
-| LocOther of string
-| LocAny
+  | LocTerm
+  | LocModule
+  | LocOther of string
+  | LocAny
 
 let print_located_qualid name flags qid =
   let located = match flags with
@@ -568,515 +1126,3 @@ let print_located_term ref = print_located_qualid "term" LocTerm ref
 let print_located_other s ref = print_located_qualid s (LocOther s) ref
 let print_located_module ref = print_located_qualid "module" LocModule ref
 let print_located_qualid ref = print_located_qualid "object" LocAny ref
-
-(******************************************)
-(**** Printing declarations and judgments *)
-(****  Gallina layer                  *****)
-
-let print_typed_value_in_env env sigma (trm,typ) =
-  (pr_leconstr_env ~inctx:true env sigma trm ++ fnl () ++
-     str "     : " ++ pr_letype_env env sigma typ)
-
-(* To be improved; the type should be used to provide the types in the
-   abstractions. This should be done recursively inside pr_lconstr, so that
-   the pretty-print of a proposition (P:(nat->nat)->Prop)(P [u]u)
-   synthesizes the type nat of the abstraction on u *)
-
-let print_named_def env sigma name body typ =
-  let pbody = pr_lconstr_env ~inctx:true env sigma body in
-  let ptyp = pr_ltype_env env sigma typ in
-  let pbody = if Constr.isCast body then surround pbody else pbody in
-  (str "*** [" ++ str name ++ str " " ++
-     hov 0 (str ":=" ++ brk (1,2) ++ pbody ++ spc () ++
-              str ":" ++ brk (1,2) ++ ptyp) ++
-           str "]")
-
-let print_named_assum env sigma name typ =
-  str "*** [" ++ str name ++ str " : " ++ pr_ltype_env env sigma typ ++ str "]"
-
-let print_named_decl_gen env sigma =
-  let open Context.Named.Declaration in
-  function
-  | LocalAssum (id, typ) ->
-     print_named_assum env sigma (Id.to_string id.Context.binder_name) typ
-  | LocalDef (id, body, typ) ->
-     print_named_def env sigma (Id.to_string id.Context.binder_name) body typ
-
-let assumptions_for_print lna =
-  List.fold_right (fun na env -> add_name na env) lna empty_names_context
-
-(*********************)
-(* *)
-
-let print_inductive sp udecl =
-  let env = Global.env() in
-  let mib = Environ.lookup_mind sp env in
-  let mipv = mib.mind_packets in
-  Printmod.pr_mutual_inductive_body env sp mib udecl ++
-  with_line_skip
-    (print_primitive_record mib.mind_finite mipv mib.mind_record @
-     print_inductive_args sp mipv)
-
-let print_named_decl env sigma id =
-  print_named_decl_gen env sigma (Global.lookup_named id) ++ fnl ()
-
-let print_section_variable env sigma id =
-  print_named_decl env sigma id ++
-  with_line_skip (print_name_infos (GlobRef.VarRef id))
-
-let print_body env evd = function
-  | Some c  -> pr_lconstr_env ~inctx:true env evd c
-  | None -> (str"<no body>")
-
-let print_typed_body env evd (val_0,typ) =
-  (print_body env evd val_0 ++ fnl () ++ str "     : " ++ pr_ltype_env env evd typ)
-
-let print_instance sigma cb =
-  if Declareops.constant_is_polymorphic cb then
-    let univs = Declareops.constant_polymorphic_context cb in
-    let inst = UVars.make_abstract_instance univs in
-    pr_universe_instance sigma inst
-  else mt()
-
-let print_constant with_values sp udecl =
-  let cb = Global.lookup_constant sp in
-  let val_0 = Global.body_of_constant_body Library.indirect_accessor cb in
-  let typ = cb.const_type in
-  let univs = cb.const_universes in
-  let uctx =
-    UState.of_names
-      (Printer.universe_binders_with_opt_names (Declareops.constant_polymorphic_context cb) udecl)
-  in
-  let env = Global.env () and sigma = Evd.from_ctx uctx in
-  let pr_ltype = pr_ltype_env env sigma in
-  hov 0 (
-    match val_0 with
-    | None ->
-        str"*** [ " ++
-        print_basename sp ++ print_instance sigma cb ++ str " :" ++ spc () ++ pr_ltype typ ++
-        str" ]" ++
-        Printer.pr_universes sigma univs
-    | Some (c, priv, ctx) ->
-      let priv = match priv with
-      | Opaqueproof.PrivateMonomorphic () -> None
-      | Opaqueproof.PrivatePolymorphic ctx -> Some ctx
-      in
-      print_basename sp ++ print_instance sigma cb ++
-      str (if with_values then " =" else " :") ++ spc() ++
-      (if with_values then print_typed_body env sigma (Some c,typ) else pr_ltype typ)++
-      Printer.pr_universes sigma univs ?priv)
-
-let print_constant_with_infos sp udecl =
-  print_constant true sp udecl ++
-  with_line_skip (print_name_infos (GlobRef.ConstRef sp))
-
-let print_abbreviation env kn =
-  let qid = Nametab.shortest_qualid_of_abbreviation Id.Set.empty kn
-  and (vars,a) = Abbreviation.search_abbreviation kn in
-  let c = Notation_ops.glob_constr_of_notation_constr a in
-  hov 2
-    (hov 4
-       (str "Notation " ++ pr_qualid qid ++
-        prlist (fun id -> spc () ++ Id.print id) (List.map fst vars) ++
-        spc () ++ str ":=") ++
-     spc () ++
-     Vernacstate.System.protect (fun () ->
-         Abbreviation.toggle_abbreviation ~on:false ~use:ParsingAndPrinting kn;
-         pr_glob_constr_env env (Evd.from_env env) c) ())
-
-module DynHandle = Libobject.Dyn.Map(struct type 'a t = 'a -> Pp.t option end)
-
-let handle h (Libobject.Dyn.Dyn (tag, o)) = match DynHandle.find tag h with
-| f -> f o
-| exception Not_found -> None
-
-(* TODO: this kind of feature should not rely on the Libobject stack. There is
-   no reason that an object in the stack corresponds to a user-facing
-   declaration. It may have been so at the time this was written, but this
-   needs to be done in a more principled way. *)
-let print_library_leaf env sigma with_values mp lobj =
-  match lobj with
-  | AtomicObject o ->
-    let handler =
-      DynHandle.add Declare.Internal.objVariable begin fun id ->
-          (* Outside sections, VARIABLES still exist but only with universes
-             constraints *)
-          (try Some(print_named_decl env sigma id) with Not_found -> None)
-      end @@
-      DynHandle.add Declare.Internal.Constant.tag begin fun (id,_) ->
-        let kn = Constant.make2 mp (Label.of_id id) in
-        Some (print_constant with_values kn None)
-      end @@
-      DynHandle.add DeclareInd.Internal.objInductive begin fun (id,_) ->
-        let kn = MutInd.make2 mp (Label.of_id id) in
-        Some (print_inductive kn None)
-      end @@
-      DynHandle.empty
-    in
-    handle handler o
-  | ModuleObject (id,_) ->
-    Some (Printmod.print_module ~with_body:with_values (MPdot (mp,Label.of_id id)))
-  | ModuleTypeObject (id,_) ->
-    Some (print_modtype (MPdot (mp, Label.of_id id)))
-  | IncludeObject _ | KeepObject _ | ExportObject _ -> None
-
-let decr = Option.map ((+) (-1))
-
-let is_done = Option.equal Int.equal (Some 0)
-
-let print_leaves env sigma with_values mp =
-  let rec prec n = function
-    | [] -> n, mt()
-    | o :: rest ->
-      if is_done n then n, mt()
-      else begin match print_library_leaf env sigma with_values mp o with
-        | Some pp ->
-          let n, prest = prec (decr n) rest in
-          n, prest ++ pp
-        | None -> prec n rest
-      end
-  in
-  prec
-
-let print_context env sigma with_values =
-  let rec prec n = function
-    | [] -> mt()
-    | (node, leaves) :: rest ->
-      if is_done n then mt()
-      else
-        let mp = (Lib.node_prefix node).Nametab.obj_mp in
-        let n, pleaves = print_leaves env sigma with_values mp n leaves in
-        if is_done n then pleaves
-        else prec n rest ++ pleaves
-  in
-  prec
-
-let pr_prefix_name prefix = Id.print (snd (split_dirpath prefix.Nametab.obj_dir))
-
-let print_library_node = function
-  | Lib.OpenedSection (prefix, _) ->
-    str " >>>>>>> Section " ++ pr_prefix_name prefix
-  | Lib.OpenedModule (_,_,prefix,_) ->
-    str " >>>>>>> Module " ++ pr_prefix_name prefix
-  | Lib.CompilingLibrary { Nametab.obj_dir; _ } ->
-    str " >>>>>>> Library " ++ DirPath.print obj_dir
-
-(******************************************)
-(**** Printing declarations and judgments *)
-(****  Abstract layer                 *****)
-
-let print_judgment env sigma {uj_val=trm;uj_type=typ} =
-  print_typed_value_in_env env sigma (trm, typ)
-
-let print_safe_judgment {Safe_typing.jdg_env=senv; jdg_val=trm; jdg_type=typ} =
-  let env = Safe_typing.env_of_safe_env senv in
-  let sigma = Evd.from_env env in
-  let trm = EConstr.of_constr trm in
-  let typ = EConstr.of_constr typ in
-  print_typed_value_in_env env sigma (trm, typ)
-
-(*********************)
-(* *)
-
-let print_full_context env sigma =
-  print_context env sigma true None (Lib.contents ())
-let print_full_context_typ env sigma =
-  print_context env sigma false None (Lib.contents ())
-
-module DynHandleF = Libobject.Dyn.Map(struct type 'a t = 'a -> Pp.t end)
-
-let handleF h (Libobject.Dyn.Dyn (tag, o)) = match DynHandleF.find tag h with
-| f -> f o
-| exception Not_found -> mt ()
-
-(* TODO: see the comment for {!print_leaf_entry} *)
-let print_full_pure_atomic env sigma mp lobj =
-  let handler =
-    DynHandleF.add Declare.Internal.Constant.tag begin fun (id,_) ->
-      let kn = KerName.make mp (Label.of_id id) in
-      let con = Global.constant_of_delta_kn kn in
-      let cb = Global.lookup_constant con in
-      let typ = cb.const_type in
-      hov 0 (
-        match cb.const_body with
-        | Undef _ ->
-          str "Parameter " ++
-          print_basename con ++ str " :" ++ spc () ++ pr_ltype_env env sigma typ
-        | OpaqueDef lc ->
-          str "Theorem " ++ print_basename con ++ cut () ++
-          str " : " ++ pr_ltype_env env sigma typ ++ str "." ++ fnl () ++
-          str "Proof " ++ pr_lconstr_env env sigma
-            (fst (Global.force_proof Library.indirect_accessor lc))
-        | Def c ->
-          str "Definition " ++ print_basename con ++ cut () ++
-          str "  : " ++ pr_ltype_env env sigma typ ++ cut () ++ str " := " ++
-          pr_lconstr_env env sigma c
-        | Primitive _ ->
-          str "Primitive " ++
-          print_basename con ++ str " :" ++ spc () ++ pr_ltype_env env sigma typ)
-      ++ str "." ++ fnl () ++ fnl ()
-    end @@
-    DynHandleF.add DeclareInd.Internal.objInductive begin fun (id,_) ->
-      let kn = KerName.make mp (Label.of_id id) in
-      let mind = Global.mind_of_delta_kn kn in
-      let mib = Global.lookup_mind mind in
-      Printmod.pr_mutual_inductive_body (Global.env()) mind mib None ++
-      str "." ++ fnl () ++ fnl ()
-    end @@
-    DynHandleF.empty
-  in
-  handleF handler lobj
-
-let print_full_pure_leaf env sigma mp = function
-  | AtomicObject lobj -> print_full_pure_atomic env sigma mp lobj
-  | ModuleObject (id, _) ->
-    (* TODO: make it reparsable *)
-    print_module (MPdot (mp,Label.of_id id)) ++ str "." ++ fnl () ++ fnl ()
-  | ModuleTypeObject (id, _) ->
-    (* TODO: make it reparsable *)
-    print_modtype (MPdot (mp,Label.of_id id)) ++ str "." ++ fnl () ++ fnl ()
-  | _ -> mt()
-
-let print_full_pure_context env sigma =
-  let rec prec = function
-    | (node,leaves)::rest ->
-      let mp = (Lib.node_prefix node).Nametab.obj_mp in
-      let pp = Pp.prlist (print_full_pure_leaf env sigma mp) leaves in
-      prec rest ++ pp
-  | [] -> mt ()
-  in
-  prec (Lib.contents ())
-
-(* For printing an inductive definition with
-   its constructors and elimination,
-   assume that the declaration of constructors and eliminations
-   follows the definition of the inductive type *)
-
-(* This is designed to print the contents of an opened section *)
-let read_sec_context qid =
-  let dir =
-    try Nametab.locate_section qid
-    with Not_found ->
-      user_err ?loc:qid.loc (str "Unknown section.") in
-  let rec get_cxt in_cxt = function
-    | (Lib.OpenedSection ({Nametab.obj_dir;_},_), _ as hd)::rest ->
-        if DirPath.equal dir obj_dir then (hd::in_cxt) else get_cxt (hd::in_cxt) rest
-    | [] -> []
-    | hd::rest -> get_cxt (hd::in_cxt) rest
-  in
-  let cxt = Lib.contents () in
-  List.rev (get_cxt [] cxt)
-
-let print_sec_context env sigma sec =
-  print_context env sigma true None (read_sec_context sec)
-
-let print_sec_context_typ env sigma sec =
-  print_context env sigma false None (read_sec_context sec)
-
-let maybe_error_reject_univ_decl na udecl =
-  let open GlobRef in
-  match na, udecl with
-  | _, None | Term (ConstRef _ | IndRef _ | ConstructRef _), Some _ -> ()
-  | (Term (VarRef _) | Abbreviation _ | Dir _ | Module _ | ModuleType _ | Other _ | Undefined _), Some udecl ->
-    (* TODO Print na somehow *)
-    user_err (str "This object does not support universe names.")
-
-let print_any_name env sigma na udecl =
-  maybe_error_reject_univ_decl na udecl;
-  let open GlobRef in
-  match na with
-  | Term (ConstRef sp) -> print_constant_with_infos sp udecl
-  | Term (IndRef (sp,_)) -> print_inductive sp udecl
-  | Term (ConstructRef ((sp,_),_)) -> print_inductive sp udecl
-  | Term (VarRef sp) -> print_section_variable env sigma sp
-  | Abbreviation kn -> print_abbreviation env kn
-  | Module mp -> print_module mp
-  | Dir _ -> mt ()
-  | ModuleType mp -> print_modtype mp
-  | Other (obj, info) -> info.print obj
-  | Undefined qid ->
-  try  (* Var locale de but, pas var de section... donc pas d'implicits *)
-    let dir,str = repr_qualid qid in
-    if not (DirPath.is_empty dir) then raise Not_found;
-    str |> Global.lookup_named |> print_named_decl_gen env sigma
-
-  with Not_found -> user_err ?loc:qid.loc (pr_qualid qid ++ spc () ++ str "not a defined object.")
-
-let print_name env sigma na udecl =
-  match na with
-  | {loc; v=Constrexpr.ByNotation (ntn,sc)} ->
-    print_any_name env sigma
-      (Term (Notation.interp_notation_as_global_reference ?loc ~head:false (fun _ -> true)
-               ntn sc))
-      udecl
-  | {loc; v=Constrexpr.AN ref} ->
-    print_any_name env sigma (locate_any_name ref) udecl
-
-let print_notation_grammar env sigma ntn =
-  let ng = List.hd (Notgram_ops.grammar_of_notation ntn) in
-  let assoc = ng.Notation_gram.notgram_assoc in
-  let prdf () = Pp.str "no associativity" in
-  Pp.(pr_opt_no_spc_default prdf Gramlib.Gramext.pr_assoc assoc)
-
-exception PrintNotationNotFound of Constrexpr.notation_entry * string
-
-let () = CErrors.register_handler @@ function
-  | PrintNotationNotFound (entry, ntn_str) ->
-      let entry_string = match entry with
-      | Constrexpr.InConstrEntry -> "."
-      | Constrexpr.InCustomEntry e -> " in " ^ e ^ " entry."
-      in
-      Some Pp.(str "\"" ++ str ntn_str ++ str "\"" ++ spc ()
-        ++ str "cannot be interpreted as a known notation" ++ str entry_string ++ spc ()
-        ++ strbrk "Make sure that symbols are surrounded by spaces and that holes are explicitly denoted by \"_\".")
-  | _ -> None
-
-let error_print_notation_not_found e s =
-  raise @@ PrintNotationNotFound (e, s)
-
-let print_notation env sigma entry raw_ntn =
-  (* make sure entry exists *)
-  let () =
-    match entry with
-    | Constrexpr.InConstrEntry -> ()
-    | Constrexpr.InCustomEntry e -> Metasyntax.check_custom_entry e
-  in
-  (* convert notation string to key. eg. "x + y" to "_ + _" *)
-  let interp_ntn = Notation.interpret_notation_string raw_ntn in
-  let ntn = (entry, interp_ntn) in
-  try
-    let lvl = Notation.level_of_notation ntn in
-    let args = Notgram_ops.non_terminals_of_notation ntn in
-    let pplvl = Metasyntax.pr_level ntn lvl args in
-    Pp.(str "Notation \"" ++ str interp_ntn ++ str "\"" ++ spc ()
-      ++ pplvl ++ pr_comma () ++ print_notation_grammar env sigma ntn
-      ++ str ".")
-  with Not_found -> error_print_notation_not_found entry raw_ntn
-
-let print_about_any ?loc env sigma k udecl =
-  maybe_error_reject_univ_decl k udecl;
-  match k with
-  | Term ref ->
-    let rb = match ref with
-      | ConstRef ref -> Reductionops.ReductionBehaviour.print ref
-      | _ -> mt()
-    in
-    Dumpglob.add_glob ?loc ref;
-      pr_infos_list
-       (print_ref false ref udecl :: blankline ::
-        print_polymorphism ref @
-        print_name_infos ref @
-        (if Pp.ismt rb then [] else [rb]) @
-        print_opacity ref @
-  print_bidi_hints ref @
-  [hov 0 (str "Expands to: " ++ pr_located_qualid k)])
-  | Abbreviation kn ->
-      v 0 (
-      print_abbreviation env kn ++ fnl () ++
-      hov 0 (str "Expands to: " ++ pr_located_qualid k))
-  | Dir _ | Module _ | ModuleType _ | Undefined _ ->
-      hov 0 (pr_located_qualid k)
-  | Other (obj, info) -> hov 0 (info.about obj)
-
-let print_about env sigma na udecl =
-  match na with
-  | {loc;v=Constrexpr.ByNotation (ntn,sc)} ->
-      print_about_any ?loc env sigma
-        (Term (Notation.interp_notation_as_global_reference ?loc ~head:false (fun _ -> true)
-               ntn sc)) udecl
-  | {loc;v=Constrexpr.AN ref} ->
-      print_about_any ?loc env sigma (locate_any_name ref) udecl
-
-(* for debug *)
-let inspect env sigma depth =
-  print_context env sigma false (Some depth) (Lib.contents ())
-
-(*************************************************************************)
-(* Pretty-printing functions coming from classops.ml                     *)
-
-open Coercionops
-
-let print_coercion_value v = Printer.pr_global v.coe_value
-
-let print_path ((i,j),p) =
-  hov 2 (
-    str"[" ++ hov 0 (prlist_with_sep pr_semicolon print_coercion_value p) ++
-    str"] : ") ++
-  pr_class i ++ str" >-> " ++ pr_class j ++
-  str (if path_is_reversible p then " (reversible)" else "")
-
-let _ = Coercionops.install_path_printer print_path
-
-let print_graph () =
-  prlist_with_sep fnl print_path (inheritance_graph())
-
-let print_classes () =
-  pr_sequence pr_class (classes())
-
-let print_coercions () =
-  pr_sequence print_coercion_value (coercions())
-
-let print_path_between cls clt =
-  let p =
-    try
-      lookup_path_between_class (cls, clt)
-    with Not_found ->
-      user_err
-        (str"No path between " ++ pr_class cls ++ str" and " ++ pr_class clt
-         ++ str ".")
-  in
-  print_path ((cls, clt), p)
-
-let print_canonical_projections env sigma grefs =
-  let open Structures in
-  let match_proj_gref { CSTable.projection; value; solution } gr =
-    QGlobRef.equal env projection gr ||
-    begin match value with
-      | ValuePattern.Const_cs y -> GlobRef.CanOrd.equal y gr
-      | _ -> false
-    end ||
-    QGlobRef.equal env solution gr
-  in
-  let projs =
-    List.filter (fun p -> List.for_all (match_proj_gref p) grefs)
-      (CSTable.entries ())
-  in
-  prlist_with_sep fnl
-    (fun { CSTable.projection; value; solution } ->
-    ValuePattern.print value ++
-    str " <- " ++
-    pr_global projection ++ str " ( " ++ pr_global solution ++ str " )")
-    projs
-
-(*************************************************************************)
-
-(*************************************************************************)
-(* Pretty-printing functions for type classes                     *)
-
-open Typeclasses
-
-let pr_typeclass env t =
-  print_ref false t.cl_impl None
-
-let print_typeclasses () =
-  let env = Global.env () in
-    prlist_with_sep fnl (pr_typeclass env) (typeclasses ())
-
-let pr_instance env i =
-  (*   print_constant_with_infos i.is_impl *)
-  (* lighter *)
-  print_ref false (instance_impl i) None ++
-  begin match hint_priority i with
-  | None -> mt ()
-  | Some i -> spc () ++ str "|" ++ spc () ++ int i
-  end
-
-let print_all_instances () =
-  let env = Global.env () in
-  let inst = all_instances () in
-    prlist_with_sep fnl (pr_instance env) inst
-
-let print_instances r =
-  let env = Global.env () in
-  let inst = instances_exn env (Evd.from_env env) r in
-  prlist_with_sep fnl (pr_instance env) inst

--- a/vernac/prettyp.mli
+++ b/vernac/prettyp.mli
@@ -12,12 +12,12 @@ open Names
 open Environ
 open Libnames
 
-(** A Pretty-Printer for the Calculus of Inductive Constructions. *)
+(** This module implements Print/About/Locate commands *)
 
-val assumptions_for_print : Name.t list -> Termops.names_context
+val assumptions_for_print : Name.t list -> Termops.names_context (* unused? *)
 
 val print_closed_sections : bool ref
-val print_context
+val print_context (* unused? *)
   : env
   -> Evd.evar_map
   -> bool -> int option -> 'a Lib.library_segment -> Pp.t
@@ -28,7 +28,7 @@ val print_library_leaf
   -> ModPath.t
   -> Libobject.t
   -> Pp.t option
-val print_library_node : Summary.Interp.frozen Lib.node -> Pp.t
+val print_library_node : Summary.Interp.frozen Lib.node -> Pp.t (* unused? *)
 val print_full_context : env -> Evd.evar_map -> Pp.t
 val print_full_context_typ : env -> Evd.evar_map -> Pp.t
 
@@ -58,7 +58,7 @@ val print_impargs : GlobRef.t -> Pp.t
 val print_graph : unit -> Pp.t
 val print_classes : unit -> Pp.t
 val print_coercions : unit -> Pp.t
-val print_path_between : Coercionops.cl_typ -> Coercionops.cl_typ -> Pp.t
+val print_coercion_paths : Coercionops.cl_typ -> Coercionops.cl_typ -> Pp.t
 val print_canonical_projections : env -> Evd.evar_map -> GlobRef.t list -> Pp.t
 
 (** Pretty-printing functions for type classes and instances *)

--- a/vernac/printmod.ml
+++ b/vernac/printmod.ml
@@ -410,10 +410,10 @@ let print_module ~with_body mp =
   try
     if !short then raise ShortPrinting;
     unsafe_print_module WithContents
-      (Global.env ()) mp with_body me ++ fnl ()
+      (Global.env ()) mp with_body me
   with e when CErrors.noncritical e ->
     unsafe_print_module OnlyNames
-      (Global.env ()) mp with_body me ++ fnl ()
+      (Global.env ()) mp with_body me
 
 let print_modtype kn =
   let mtb = Global.lookup_modtype kn in

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1991,7 +1991,7 @@ let vernac_print ~pstate =
   | PrintCoercions -> Prettyp.print_coercions ()
   | PrintNotation (entry, ntnstr) -> Prettyp.print_notation env sigma entry ntnstr
   | PrintCoercionPaths (cls,clt) ->
-    Prettyp.print_path_between (cl_of_qualid cls) (cl_of_qualid clt)
+    Prettyp.print_coercion_paths (cl_of_qualid cls) (cl_of_qualid clt)
   | PrintCanonicalConversions qids ->
     let grefs = List.map Smartlocate.smart_global qids in
     Prettyp.print_canonical_projections env sigma grefs


### PR DESCRIPTION
The PR first makes a new pass of documentation and reorganization of `prettyp.ml`.

Then, it adds printing of implicit arguments in the main type printed by `Print`, and not only in the unfolded type. E.g.:

```coq
Print fst.
(* Before:
fst =
fun (A B : Type) (p : A * B) => let (x, _) := p in x
     : forall A B : Type, A * B -> A
*)
(* After:
fst =
fun (A B : Type) (p : A * B) => let (x, _) := p in x
     : forall {A B : Type}, A * B -> A
*)
```

Maybe the printing of `Arguments` can then be removed in `Print`?

What to exactly provide for GUIs supporting hovering to be discussed.

- [x] Added / updated **test-suite**.
