### PR TITLE
More robust treatment of maximal implicit arguments in notations

### DIFF
--- a/dev/ci/user-overlays/18445-herbelin-master+more-robust-notations-with-max-impargs.sh
+++ b/dev/ci/user-overlays/18445-herbelin-master+more-robust-notations-with-max-impargs.sh
@@ -1,0 +1,2 @@
+overlay category_theory https://github.com/herbelin/category-theory master+adapt-coq-pr18445-fix-applied-notations-multiple-implicit 18445 master+more-robust-notations-with-max-impargs
+overlay fiat_crypto_legacy https://github.com/herbelin/fiat-crypto sp2019latest+adapt-coq-pr18445-notation-multiple-implicit-arguments 18445 master+more-robust-notations-with-max-impargs

--- a/doc/changelog/03-notations/18445-master+more-robust-notations-with-max-impargs.rst
+++ b/doc/changelog/03-notations/18445-master+more-robust-notations-with-max-impargs.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Notations for applied constants equipped with multiple signatures of
+  implicit arguments were not correctly inserting as many maximal
+  implicit arguments as they should have
+  (`#18445 <https://github.com/coq/coq/pull/18445>`_,
+  by Hugo Herbelin).

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -1271,7 +1271,7 @@ and extern_notation inctx ((custom,(lev_after: int option)),scopes as allscopes)
           match DAst.get f with
           | GRef (ref,_) ->
             let subscopes = find_arguments_scope ref in
-            let impls = select_impargs_size nallargs (implicits_of_global ref) in
+            let impls = select_stronger_impargs (implicits_of_global ref) in
             subscopes, impls
           | _ ->
             [], [] in

--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -813,7 +813,7 @@ let rec drop_first_implicits p l =
   | DefaultImpArgs,imp::impls ->
       drop_first_implicits (p-1) (DefaultImpArgs,impls)
   | LessArgsThan n,imp::impls ->
-      let n = if is_status_implicit imp then n-1 else n in
+      let n = if is_status_implicit imp then n else n-1 in
       drop_first_implicits (p-1) (LessArgsThan n,impls)
 
 let rec chop_and_adjust n l1 l2 =

--- a/test-suite/success/Notations.v
+++ b/test-suite/success/Notations.v
@@ -159,3 +159,16 @@ Fail Declare Scope _scope_start_underscore.
 
 (* Scope delimiters should not start with an underscore *)
 Fail Delimit Scope type_scope with _type.
+
+Module ImplicitArgumentsPrimToken.
+
+(* Check that implicit arguments of number notations are taken into account *)
+
+Class T (A:Type).
+Context (a:T nat).
+Axiom f : forall A, T A -> A.
+Arguments f {A} {_}.
+Notation "0" := f.
+Check 0 = 1.
+
+End ImplicitArgumentsPrimToken.

--- a/test-suite/success/implicit.v
+++ b/test-suite/success/implicit.v
@@ -187,3 +187,12 @@ Arguments bar {A} {x} _ {B} {y}.
 Check bar (1:=true) 0 (3:=false).
 
 End TestUnnamedImplicit.
+
+Module NotationAppliedConstantMultipleImplicit.
+
+Axiom f : nat -> nat -> nat -> nat.
+Arguments f {_} _ _, {_ _} _.
+Notation "#" := (@f 0).
+Check # 0 : nat.
+
+End NotationAppliedConstantMultipleImplicit.


### PR DESCRIPTION
The PR does the following:
- fixes a bug with notations denoting applied constant and applied to multiple blocks of implicit arguments (in `Impargs.drop_first_implicit`) (first commit)
- fixes a small printing bug (spurious extra parentheses) when an applied notation absorbs all its arguments as maximal implicit arguments (second commit, now merged via #18447)
- decide to hide as more as possible implicit arguments behind notations when there are several possible blocks of implicit arguments (e.g. if we do a notation for `eq_refl` which accepts 1 or 2 arguments, it will hide 2 arguments) (third commit, now second)
- add support for insertion of maximal implicit arguments to number/string notations referring to a functional constant (useful e.g. if a field of a record is written `0` or `1`) (fourth commit, now third)

This will be useful in #18446 for fixing #3516 and for generalizing the support for maximal implicit arguments and multiple blocks of implicit arguments in notations. 

- [X] change log added
- [X] test-suite updated

##### Backwards-compatible overlays

* jwiegley/category-theory#137 (merged)
* mit-plv/fiat-crypto#1807 (merged)