### PR TITLE
More uniform support for maximal implicit arguments and multiple blocks of implicit arguments in notations, including a fix to #3516 (improved Print for abbreviations aliasing a name)

### DIFF
--- a/doc/changelog/03-notations/18446-master+fixes3516-improved-print-of-abbreviation.rst
+++ b/doc/changelog/03-notations/18446-master+fixes3516-improved-print-of-abbreviation.rst
@@ -1,0 +1,7 @@
+- **Fixed:**
+  :cmd:`Print` and :cmd:`About` display abbreviations aliasing
+  constants in a way faithful to how their maximal implicit arguments
+  are inserted
+  (`#18446 <https://github.com/coq/coq/pull/18446>`_,
+  fixes `#3516 <https://github.com/coq/coq/issues/3516>`_,
+  by Hugo Herbelin).

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -1267,16 +1267,6 @@ let intern_instance ~local_univs = function
     let us = List.map (map_glob_sort_gen (intern_sort_name ~local_univs)) us in
     Some (qs, us)
 
-let intern_name_alias = function
-  | { CAst.v = CRef(qid,u) } ->
-      let r =
-        try Some (intern_extended_global_of_qualid qid)
-        with Not_found -> None
-      in
-      Option.bind r Smartlocate.global_of_extended_global |>
-      Option.map (fun r -> r, intern_instance ~local_univs:empty_local_univs u)
-  | _ -> None
-
 let intern_field_ref qid =
   match
     Smartlocate.global_of_extended_global (intern_extended_global_of_qualid qid) |>

--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -155,10 +155,6 @@ val intern_uninstantiated_constr_pattern :
     if not existing *)
 val intern_reference : qualid -> GlobRef.t option
 
-(** Returns None if not a reference or a abbrev not bound to a name *)
-val intern_name_alias :
-  constr_expr -> (GlobRef.t * Glob_term.glob_instance option) option
-
 (** Expands abbreviations; raise an error if not existing *)
 val interp_reference : ltac_sign -> qualid -> glob_constr
 

--- a/test-suite/output/bug_3516.out
+++ b/test-suite/output/bug_3516.out
@@ -70,3 +70,21 @@ foo2 3
      : nat * nat
 expfoo 3
      : 3 = 3
+foo
+     : 0 = 0
+foo
+     : 0 = 0
+foo
+     : ?b = ?b
+where
+?B : [ |- Type]
+?b : [ |- ?B]
+foo
+     : 0 = 0
+foo
+     : 0 = 0
+foo
+     : ?b = ?b
+where
+?B : [ |- Type]
+?b : [ |- ?B]

--- a/test-suite/output/bug_3516.out
+++ b/test-suite/output/bug_3516.out
@@ -1,0 +1,72 @@
+Notation foo := eq_refl
+
+Inductive eq (A : Type) (x : A) : A -> Prop :=  eq_refl : x = x.
+
+Arguments eq {A}%type_scope x _
+Arguments eq_refl {A}%type_scope {x}, [_] _
+Notation foo := eq_refl
+Expands to: Notation bug_3516.A.AA.foo
+
+eq_refl : forall {A : Type} {x : A}, x = x
+
+eq_refl is not universe polymorphic
+Arguments eq_refl {A}%type_scope {x}, [_] _
+Expands to: Constructor Coq.Init.Logic.eq_refl
+foo
+     : 3 = 3
+foo
+     : 3 = 3
+Notation foo2 := eq_refl
+Notation foo2 := eq_refl
+Expands to: Notation bug_3516.A.AB.foo2
+foo2
+     : 3 = 3
+Notation foo := foo2
+
+Inductive eq (A : Type) (x : A) : A -> Prop :=  eq_refl : x = x.
+
+Arguments eq {A}%type_scope x _
+Arguments eq_refl {A}%type_scope {x}, [_] _
+foo2
+     : ?x = ?x
+where
+?A : [ |- Type]
+?x : [ |- ?A]
+foo2
+     : ?x = ?x
+where
+?A : [ |- Type]
+?x : [ |- ?A]
+foo2
+     : ?x = ?x
+where
+?A : [ |- Type]
+?x : [ |- ?A]
+Notation foo := foo2
+Expands to: Notation bug_3516.A.AA.foo
+
+eq_refl : forall {A : Type} {x : A}, x = x
+
+eq_refl is not universe polymorphic
+Arguments eq_refl {A}%type_scope {x}, [_] _
+Expands to: Constructor Coq.Init.Logic.eq_refl
+Notation foo2 := foo
+Notation foo2 := foo
+Expands to: Notation bug_3516.A.AB.foo2
+Notation foo := (id 2)
+Notation foo := (id 2)
+Expands to: Notation bug_3516.B.foo
+foo 3
+     : nat * nat
+foo 3
+     : nat * nat
+Notation foo2 := foo
+Notation foo2 := foo
+Expands to: Notation bug_3516.B.foo2
+Notation foo := foo2
+Notation foo := foo2
+Expands to: Notation bug_3516.B.foo
+foo2 3
+     : nat * nat
+expfoo 3
+     : 3 = 3

--- a/test-suite/output/bug_3516.v
+++ b/test-suite/output/bug_3516.v
@@ -45,3 +45,23 @@ Module MakeArgumentPrinted.
 Notation expfoo x := (eq_refl x).
 Check expfoo 3.
 End MakeArgumentPrinted.
+
+Module AtomWithMultipleImplSign.
+(* An example with an argument followed by further maximal arguments *)
+Definition id B (b:B) := eq_refl b.
+Arguments id {B} b, {B b}, B b.
+Notation foo := id.
+Check foo nat 0.
+Check foo 0.
+Check foo.
+End AtomWithMultipleImplSign.
+
+Module NonAtomWithMultipleImplSign.
+(* An example with an argument followed by further maximal arguments *)
+Definition id (a:nat) B (b:B) := eq_refl b.
+Arguments id a {B} b, a {B b}, a B b.
+Notation foo := (id 0).
+Check foo nat 0.
+Check foo 0.
+Check foo.
+End NonAtomWithMultipleImplSign.

--- a/test-suite/output/bug_3516.v
+++ b/test-suite/output/bug_3516.v
@@ -1,0 +1,47 @@
+Module A.
+Module AA.
+Notation foo := eq_refl.
+Print foo.
+About foo.
+Check eq_refl 3.
+Check foo 3.
+End AA.
+
+Module AB.
+Notation foo2 := (@eq_refl _).
+Print foo2.
+About foo2.
+Check foo2 3.
+End AB.
+
+Import AA.
+Import AB.
+Print foo.
+Check foo.
+Check foo2 _.
+Check foo _.
+About foo.
+Print foo2.
+About foo2.
+End A.
+
+Module B.
+Definition id {A:Type} (a:A) {B:Type} (b:B) := (a,b).
+Notation foo := (@id _ 2 _).
+Print foo.
+About foo.
+Check id 2 3.
+Check foo 3.
+
+Notation foo2 := (id 2).
+Print foo2.
+About foo2.
+Print foo.
+About foo.
+Check foo2 3.
+End B.
+
+Module MakeArgumentPrinted.
+Notation expfoo x := (eq_refl x).
+Check expfoo 3.
+End MakeArgumentPrinted.

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1929,12 +1929,6 @@ let add_abbreviation ~local user_warns env ident (vars,c) modl =
   let (only_parsing, scopes) = interp_abbreviation_modifiers user_warns modl in
   let vars = List.map (fun v -> v, List.assoc_opt v scopes) vars in
   let acvars,pat,reversibility =
-    match vars, intern_name_alias c with
-    | [], Some(r,u) ->
-      (* Check if abbreviation to a name and avoid early insertion of
-         maximal implicit arguments *)
-      Id.Map.empty, NRef(r, u), APrioriReversible
-    | _ ->
       let fold accu (id,scope) = Id.Map.add id (NtnInternTypeAny scope) accu in
       let i_vars = List.fold_left fold Id.Map.empty vars in
       let nenv = {


### PR DESCRIPTION
So as to be more flexible at use time in the choice of a block of implicit arguments among several, an abbreviation of the form `Notation foo := ref` internally drops maximal implicits of `ref` if it has some. The PR then does the following:
- fixes printing of such notations (#3516) (first commit)
- generalizes (second commit) and simplifies (third commit) the special treatment of maximal implicit arguments for `Notation foo := ref` to `Notation foo := (ref args)` (see `use_maximal_impls`)

Fixes / closes #3516

Depends on #18444 (merged) and #18445 (merged).

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
