### PR TITLE
Fixes #18342: try to insert an entry coercion when a notation in a custom entry has arguments

### DIFF
--- a/doc/changelog/03-notations/18447-master+fix18342-insert-entry-coercion-applied-custom-notation.rst
+++ b/doc/changelog/03-notations/18447-master+fix18342-insert-entry-coercion-applied-custom-notation.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Add support for printing notations applied to extra arguments in
+  custom entries, thus replacing an anomaly
+  (`#18447 <https://github.com/coq/coq/pull/18447>`_,
+  fixes `#18342 <https://github.com/coq/coq/issues/18342>`_,
+  by Hugo Herbelin).

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -710,8 +710,8 @@ let mkFlattenedCApp (head,args) =
     (* may happen with notations for a prefix of an n-ary application *)
     (* or after removal of a coercion to funclass *)
     CApp (g,args'@args)
-  | _ ->
-    CApp (head, args)
+  | h ->
+    if List.is_empty args then h else CApp (head, args)
 
 let extern_applied_notation inctx n impl f args =
   if List.is_empty args then

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1619,10 +1619,10 @@ let rec search nfrom nto = function
   | ((pfrom,pto),coe)::l ->
     if entry_relative_level_le pfrom nfrom && entry_relative_level_le nto pto then coe else search nfrom nto l
 
-let availability_of_entry_coercion ?(non_empty=false)
+let availability_of_entry_coercion ?(non_included=false)
     ({ notation_subentry = entry; notation_relative_level = sublev } as entry_sublev)
     ({ notation_entry = entry'; notation_level = lev' } as entry_lev) =
-  if included entry_lev entry_sublev && not non_empty then
+  if included entry_lev entry_sublev && not non_included then
     (* [entry] is by default included in [relative_entry] *)
     Some []
   else

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -370,7 +370,7 @@ val declare_entry_coercion : specific_notation -> notation_entry_level -> notati
   (** Add a coercion from some-entry to some-relative-entry *)
 
 type entry_coercion = (notation_with_optional_scope * notation) list
-val availability_of_entry_coercion : ?non_empty:bool -> notation_entry_relative_level -> notation_entry_level -> entry_coercion option
+val availability_of_entry_coercion : ?non_included:bool -> notation_entry_relative_level -> notation_entry_level -> entry_coercion option
   (** Return a coercion path from some-relative-entry to some-entry if there is one *)
 
 (** Special properties of entries *)

--- a/test-suite/output/bug_18342.out
+++ b/test-suite/output/bug_18342.out
@@ -1,0 +1,9 @@
+<{ SS (? I) }>
+     : nat
+<{ SS [[{{?}} I]] }>
+     : nat
+fun x : I => match x with
+             | <{ DD [[{{?}} y]] }> => y
+             | _ => 0
+             end
+     : I -> nat

--- a/test-suite/output/bug_18342.v
+++ b/test-suite/output/bug_18342.v
@@ -1,0 +1,40 @@
+Declare Custom Entry stlc.
+
+Module Bug18342.
+Definition A (T : True) := 0.
+Notation "?" := A.
+
+Notation "<{ e }>" := e (e custom stlc at level 99).
+Notation "x" := x (in custom stlc at level 0, x constr at level 0).
+Notation "'SS' x" := (S x) (in custom stlc at level 89, x custom stlc at level 99).
+
+Check <{SS (? I)}>.
+End Bug18342.
+
+Declare Custom Entry qmark.
+
+Module Bug18342VariantWithExplicitCoercions.
+Definition A (T : True) := 0.
+
+Notation "?" := A (in custom qmark).
+Notation "{{ x }}" := x (x custom qmark).
+
+Notation "<{ e }>" := e (e custom stlc at level 99).
+Notation "[[ x ]]" := x (in custom stlc at level 0, x constr).
+Notation "'SS' x" := (S x) (in custom stlc at level 89, x custom stlc at level 99).
+
+Check <{SS [[{{?}} I]]}>.
+End Bug18342VariantWithExplicitCoercions.
+
+Module Bug18342VariantPattern.
+Inductive I := C : nat -> I | D : I -> I.
+
+Notation "?" := C (in custom qmark).
+Notation "{{ x }}" := x (x custom qmark).
+
+Notation "<{ e }>" := e (e custom stlc at level 99).
+Notation "[[ x ]]" := x (in custom stlc at level 0, x constr).
+Notation "'DD' x" := (D x) (in custom stlc at level 89, x custom stlc at level 99).
+
+Check fun x => match x with <{DD [[{{?}} y]]}> => y | _ => 0 end.
+End Bug18342VariantPattern.


### PR DESCRIPTION
There was an anomaly while coercion entries could have instead been inserted.

Fixes / closes #18342

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
