### PR TITLE
Fixes #18434: arguments of --external in coqdoc were inadvertently swapped

### DIFF
--- a/doc/changelog/09-cli-tools/18448-master+fix18434-coqdoc-external-regression.rst
+++ b/doc/changelog/09-cli-tools/18448-master+fix18434-coqdoc-external-regression.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Regression in option :g:`--external` of `coqdoc`, whose two arguments
+  were inadvertently swapped
+  (`#18448 <https://github.com/coq/coq/pull/18448>`_,
+  fixes `#18434 <https://github.com/coq/coq/issues/18434>`_,
+  by Hugo Herbelin).

--- a/tools/coqdoc/cmdArgs.ml
+++ b/tools/coqdoc/cmdArgs.ml
@@ -180,7 +180,7 @@ let args_options = Arg.align [
   "--verbose", arg_set (fun p -> { p with quiet = false }), " Verbose mode";
   "--no-externals", arg_set (fun p -> { p with externals = false }),
   " No links to Coq standard library";
-  "--external", arg_url_path Index.add_external_library,
+  "--external", arg_url_path (fun url lp -> Index.add_external_library lp url),
   "<url>+<d> set URL for external library <d>";
   "--coqlib_url", arg_string (fun p u -> { p with coqlib_url = u }),
   "<url> Set URL for Coq standard library (default: " ^ Coq_config.wwwstdlib ^ ")";


### PR DESCRIPTION
Fixes / closes #18434

- [ ] Added / updated **test-suite**.
- [x] Added **changelog**.

Should go to 8.18.1 (if any) or 8.19.0