### PR TITLE
Fix type of Ltac2's Std.fix_ and Std.cofix_

### DIFF
--- a/user-contrib/Ltac2/Std.v
+++ b/user-contrib/Ltac2/Std.v
@@ -214,8 +214,8 @@ Ltac2 @ external revert : ident list -> unit := "coq-core.plugins.ltac2" "tac_re
 
 Ltac2 @ external admit : unit -> unit := "coq-core.plugins.ltac2" "tac_admit".
 
-Ltac2 @ external fix_ : ident option -> int -> unit := "coq-core.plugins.ltac2" "tac_fix".
-Ltac2 @ external cofix_ : ident option -> unit := "coq-core.plugins.ltac2" "tac_cofix".
+Ltac2 @ external fix_ : ident -> int -> unit := "coq-core.plugins.ltac2" "tac_fix".
+Ltac2 @ external cofix_ : ident -> unit := "coq-core.plugins.ltac2" "tac_cofix".
 
 Ltac2 @ external clear : ident list -> unit := "coq-core.plugins.ltac2" "tac_clear".
 Ltac2 @ external keep : ident list -> unit := "coq-core.plugins.ltac2" "tac_keep".


### PR DESCRIPTION
Ltac2 side of the declaration wasn't updated when fix and cofix were changed to not take an anonymous name (see commit 8db84ee and issue #7196).

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #18464.
