### PR TITLE
Compatibility of #18338 with MacOS: BSD style needs a specific call to "script"

### DIFF
--- a/dev/ci/ci-wrapper.sh
+++ b/dev/ci/ci-wrapper.sh
@@ -29,7 +29,11 @@ if [ "$color_wanted" ] && command -v script > /dev/null; then
       export TERM=xterm-color
       export GIT_PAGER=
     fi
-  script --quiet --flush --return -c "bash '${DIR}/${CI_SCRIPT}'" /dev/null 2>&1 | tee "$CI_NAME.log"
+    if [ "$OSTYPE" = darwin ]; then
+        script -q /dev/null bash "${DIR}/${CI_SCRIPT}" 2>&1 | tee "$CI_NAME.log"
+    else
+        script --quiet --flush --return -c "bash '${DIR}/${CI_SCRIPT}'" /dev/null 2>&1 | tee "$CI_NAME.log"
+    fi
 else
   if [ "$color_wanted" ]; then
     >&2 echo 'script command not available, colors will be hidden'


### PR DESCRIPTION
This refines #18338 so that "make ci-foo" works with default "script" command on MacOS.

I don't know if this is the best solution but at least it works for me (see #18338 for details).