### PR TITLE
Delay the lookup of csdp until the tool is actually needed.

### DIFF
--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -2194,7 +2194,7 @@ end)
   *)
 
 let require_csdp =
-  if System.is_in_system_path "csdp" then lazy () else lazy (raise CsdpNotFound)
+  lazy (if System.is_in_system_path "csdp" then () else raise CsdpNotFound)
 
 let really_call_csdpcert :
     provername -> micromega_polys -> Sos_types.positivstellensatz option =


### PR DESCRIPTION
This was prompted by https://coq.discourse.group/t/how-to-get-rid-of-warnings-like-warning-cannot-open-directory-usr-games/2155. While this pull request does not impact the original issue (warning on non-existing entries in `PATH`), it should at least reduce the flood. And more importantly, it will avoid a flurry of system calls for the vast majority of Coq users.