### PR TITLE
Remove include type

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/18482-remove-include-type.rst
+++ b/doc/changelog/08-vernac-commands-and-options/18482-remove-include-type.rst
@@ -3,7 +3,7 @@
   (`#18482 <https://github.com/coq/coq/pull/18482>`_,
   by Pierre Rousselin).
 - **Changed:**
-  The `Include` command can now include module types with a `with` declaration
+  The :cmd:`Include` command can now include module types with a `with` clause (:n:`@with_declaration`)
   to instantiate some parameters
   (`#18482 <https://github.com/coq/coq/pull/18482>`_,
   by Pierre Rousselin).

--- a/doc/changelog/08-vernac-commands-and-options/18482-remove-include-type.rst
+++ b/doc/changelog/08-vernac-commands-and-options/18482-remove-include-type.rst
@@ -1,0 +1,9 @@
+- **Removed:**
+  the `Include Type` command after a long period of deprecation
+  (`#18482 <https://github.com/coq/coq/pull/18482>`_,
+  by Pierre Rousselin).
+- **Changed:**
+  The `Include` command can now include module types with a `with` declaration
+  to instantiate some parameters
+  (`#18482 <https://github.com/coq/coq/pull/18482>`_,
+  by Pierre Rousselin).

--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -182,12 +182,6 @@ are now available through the dot notation.
    Including multiple modules in a single :cmd:`Include` is equivalent to including each module
    in a separate :cmd:`Include` command.
 
-.. cmd:: Include Type {+<+ @module_type_inl }
-
-   .. deprecated:: 8.3
-
-      Use :cmd:`Include` instead.
-
 .. cmd:: Declare Module {? {| Import | Export } {? @import_categories } } @ident {* @module_binder } : @module_type_inl
 
    Declares a module :token:`ident` of type :token:`module_type_inl`.

--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -171,7 +171,7 @@ are now available through the dot notation.
   #. Assumptions such as :cmd:`Axiom` that include the :n:`Inline` clause will be automatically
      expanded when the functor is applied, except when the function application is prefixed by ``!``.
 
-.. cmd:: Include @module_type_inl {* <+ @module_expr_inl }
+.. cmd:: Include @module_type_inl {* <+ @module_type_inl }
 
    Includes the content of module(s) in the current
    interactive module. Here :n:`@module_type_inl` can be a module expression or a module

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -744,9 +744,6 @@ gallina_ext: [
 | REPLACE "Coercion" global OPT [ OPT univ_decl def_body ]
 | WITH "Coercion" ident_decl def_body
 
-| REPLACE "Include" "Type" module_type_inl LIST0 ext_module_type
-| WITH "Include" "Type" LIST1 module_type_inl SEP "<+"
-
 | REPLACE "Generalizable" [ "All" "Variables" | "No" "Variables" | [ "Variable" | "Variables" ] LIST1 identref ]
 | WITH "Generalizable" [  [ "Variable" | "Variables" ] LIST1 identref | "All" "Variables" | "No" "Variables" ]
 

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1156,7 +1156,7 @@ gallina_ext: [
 | "From" global "Require" export_token LIST1 filtered_import
 | "Import" OPT import_categories LIST1 filtered_import
 | "Export" OPT import_categories LIST1 filtered_import
-| "Include" module_type_inl LIST0 ext_module_expr
+| "Include" module_type_inl LIST0 ext_module_type
 | "Transparent" OPT "!" LIST1 smart_global
 | "Opaque" OPT "!" LIST1 smart_global
 | "Strategy" LIST1 [ strategy_level "[" LIST1 smart_global "]" ]

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1157,7 +1157,6 @@ gallina_ext: [
 | "Import" OPT import_categories LIST1 filtered_import
 | "Export" OPT import_categories LIST1 filtered_import
 | "Include" module_type_inl LIST0 ext_module_expr
-| "Include" "Type" module_type_inl LIST0 ext_module_type
 | "Transparent" OPT "!" LIST1 smart_global
 | "Opaque" OPT "!" LIST1 smart_global
 | "Strategy" LIST1 [ strategy_level "[" LIST1 smart_global "]" ]

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -938,7 +938,7 @@ command: [
 | OPT [ "From" dirpath ] "Require" OPT ( [ "Import" | "Export" ] OPT import_categories ) LIST1 filtered_import
 | "Import" OPT import_categories LIST1 filtered_import
 | "Export" OPT import_categories LIST1 filtered_import
-| "Include" module_type_inl LIST0 ( "<+" module_expr_inl )
+| "Include" module_type_inl LIST0 ( "<+" module_type_inl )
 | "Transparent" OPT "!" LIST1 reference
 | "Opaque" OPT "!" LIST1 reference
 | "Strategy" LIST1 [ strategy_level "[" LIST1 reference "]" ]

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -939,7 +939,6 @@ command: [
 | "Import" OPT import_categories LIST1 filtered_import
 | "Export" OPT import_categories LIST1 filtered_import
 | "Include" module_type_inl LIST0 ( "<+" module_expr_inl )
-| "Include" "Type" LIST1 module_type_inl SEP "<+"
 | "Transparent" OPT "!" LIST1 reference
 | "Opaque" OPT "!" LIST1 reference
 | "Strategy" LIST1 [ strategy_level "[" LIST1 reference "]" ]

--- a/test-suite/modules/include_module_type.v
+++ b/test-suite/modules/include_module_type.v
@@ -1,0 +1,14 @@
+Module Type type1.
+  Parameter A : Prop.
+End type1.
+
+Module Type type2.
+  Parameter B : Prop.
+End type2.
+
+Module Type type3 := type1 <+ type2 with Definition B := True.
+Print type3.
+
+Module Type type3''.
+  Include type1 <+ type2 with Definition B := True.
+End type3''.

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -632,10 +632,6 @@ let starredidentreflist_to_expr l =
   | [] -> SsEmpty
   | x :: xs -> List.fold_right (fun i acc -> SsUnion(i,acc)) xs x
 
-let warn_deprecated_include_type =
-  CWarnings.create ~name:"deprecated-include-type" ~category:Deprecation.Version.v8_3
-         (fun () -> strbrk "Include Type is deprecated; use Include instead")
-
 let warn_deprecated_as_ident_kind =
   CWarnings.create ~name:"deprecated-as-ident-kind" ~category:Deprecation.Version.v8_14
          (fun () -> strbrk "grammar kind \"as ident\" no longer accepts \"_\"; use \"as name\" instead to accept \"_\", too, or silence the warning if you actually intended to accept only identifiers.")
@@ -686,10 +682,7 @@ GRAMMAR EXTEND Gram
       | IDENT "Export"; cats = OPT import_categories; qidl = LIST1 filtered_import ->
         { VernacSynterp (VernacImport ((Export,cats),qidl)) }
       | IDENT "Include"; e = module_type_inl; l = LIST0 ext_module_expr ->
-          { VernacSynterp (VernacInclude(e::l)) }
-      | IDENT "Include"; "Type"; e = module_type_inl; l = LIST0 ext_module_type ->
-         { warn_deprecated_include_type ~loc ();
-        VernacSynterp (VernacInclude(e::l)) } ] ]
+          { VernacSynterp (VernacInclude(e::l)) } ] ]
   ;
   import_categories:
   [ [ negative = OPT "-"; "("; cats = LIST1 qualid SEP ","; ")" ->

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -681,7 +681,7 @@ GRAMMAR EXTEND Gram
         { VernacSynterp (VernacImport ((Import,cats),qidl)) }
       | IDENT "Export"; cats = OPT import_categories; qidl = LIST1 filtered_import ->
         { VernacSynterp (VernacImport ((Export,cats),qidl)) }
-      | IDENT "Include"; e = module_type_inl; l = LIST0 ext_module_expr ->
+      | IDENT "Include"; e = module_type_inl; l = LIST0 ext_module_type ->
           { VernacSynterp (VernacInclude(e::l)) } ] ]
   ;
   import_categories:


### PR DESCRIPTION
DO NOTE MERGE: Waiting to be rebased on Coq/Coq#19144 once/if it is merged.
Removing "Include Type" which was deprecated since 8.3.
"Include" now supports "Include type <+ type' with Definition foo := bar".
[Here](https://coq.gitlabpages.inria.fr/-/coq/-/jobs/4333244/artifacts/_build/default/doc/refman-html/language/core/modules.html?highlight=include#coq:cmd.Include) is the relevant part of the updated refman.