### PR TITLE
Update CI branch for coqtail (master -> main)

### DIFF
--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -436,7 +436,7 @@ project sf "https://github.com/DeepSpec/sf" "master"
 ########################################################################
 # Coqtail
 ########################################################################
-project coqtail "https://github.com/whonore/Coqtail" "master"
+project coqtail "https://github.com/whonore/Coqtail" "main"
 # Contact @whonore on github
 
 ########################################################################


### PR DESCRIPTION
Somehow our `git_download` accepts nonexistent branches (for some reason
https://github.com/whonore/Coqtail/archive/master.tar.gz still works)
