### PR TITLE
[v8.17] Backport PR #17638: Guard many unguarded `try..with` expressions

### DIFF
--- a/parsing/cLexer.ml
+++ b/parsing/cLexer.ml
@@ -564,9 +564,9 @@ let peek_string v s =
     if Int.equal i l then true
     else
       let l' = Stream.npeek (i + 1) s in
-      match List.nth l' i with
-      | c -> Char.equal c v.[i] && aux (i + 1)
-      | exception _ -> false (* EOF *) in
+      match List.nth_opt l' i with
+      | Some c -> Char.equal c v.[i] && aux (i + 1)
+      | None -> false (* EOF *) in
   aux 0
 
 let find_keyword loc id bp s =

--- a/parsing/pcoq.ml
+++ b/parsing/pcoq.ml
@@ -318,7 +318,7 @@ let epsilon_value (type s tr a) f (e : (s, tr, a) Symbol.t) =
   let entry = Entry.make "epsilon" in
   let ext = Fresh (Gramlib.Gramext.First, [None, None, [r]]) in
   let () = safe_extend entry ext in
-  try Some (parse_string entry "") with _ -> None
+  try Some (parse_string entry "") with e when CErrors.noncritical e -> None
 
 (** Synchronized grammar extensions *)
 

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -394,7 +394,7 @@ let make_eq () =
   try
     EConstr.of_constr
       (UnivGen.constr_of_monomorphic_global (Global.env ()) (Coqlib.lib_ref "core.eq.type"))
-  with _ -> assert false
+  with e when CErrors.noncritical e -> assert false
 
 let evaluable_of_global_reference r =
   let open Tacred in

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -427,8 +427,8 @@ let () = define1 "ident_to_string" ident begin fun id ->
 end
 
 let () = define1 "ident_of_string" string begin fun s ->
-  let id = try Some (Id.of_string s) with _ -> None in
-  return (Value.of_option Value.of_ident id)
+    let id = try Some (Id.of_string s) with e when CErrors.noncritical e -> None in
+    return (Value.of_option Value.of_ident id)
 end
 
 (** Int *)

--- a/plugins/micromega/persistent_cache.ml
+++ b/plugins/micromega/persistent_cache.ml
@@ -198,7 +198,7 @@ module PHashtable (Key : HashedType) : PHashtable with type key = Key.t = struct
               let () = data.obj <- Some (k, v) in
               Some v
             else None
-          | exception _ -> None
+          | exception End_of_file | exception Failure _ -> None
       in
       let lookup () = CList.find_map find lpos in
       let res = do_under_lock Read (descr_of_in_channel ch) lookup in
@@ -206,7 +206,7 @@ module PHashtable (Key : HashedType) : PHashtable with type key = Key.t = struct
       try Option.get res with isNone -> raise Not_found
 
   let memo cache f =
-    let tbl = lazy (try Some (open_in cache) with _ -> None) in
+    let tbl = lazy (try Some (open_in cache) with e when CErrors.noncritical e -> None) in
     fun x ->
       match Lazy.force tbl with
       | None -> f x
@@ -217,7 +217,7 @@ module PHashtable (Key : HashedType) : PHashtable with type key = Key.t = struct
           add tbl x res; res )
 
   let memo_cond cache cond f =
-    let tbl = lazy (try Some (open_in cache) with _ -> None) in
+    let tbl = lazy (try Some (open_in cache) with e when CErrors.noncritical e -> None) in
     fun x ->
       match Lazy.force tbl with
       | None -> f x

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -353,7 +353,7 @@ let is_id_constr sigma c = match EConstr.kind sigma c with
 
 let red_product_skip_id env sigma c = match EConstr.kind sigma c with
   | App(hd,args) when Array.length args = 1 && is_id_constr sigma hd -> args.(0)
-  | _ -> try Tacred.red_product env sigma c with _ -> c
+  | _ -> try Tacred.red_product env sigma c with e when CErrors.noncritical e -> c
 
 let ssrevaltac ist gtac = Tacinterp.tactic_of_value ist gtac
 
@@ -503,7 +503,7 @@ let abs_evars_pirrel env sigma0 (sigma, c0) =
       try
         let sigma = call_on_evar env sigma !ssrautoprop_tac i in
         List.filter (fun (j,_) -> j <> i) ev, evp, sigma
-      with _ -> ev, p::evp, sigma) (evlist, [], sigma) (List.rev evplist) in
+      with e when CErrors.noncritical e -> ev, p::evp, sigma) (evlist, [], sigma) (List.rev evplist) in
   let c0 = Evarutil.nf_evar sigma c0 in
   let evlist =
     List.map (fun (x,(y,t,z)) -> x,(y,Evarutil.nf_evar sigma t,z)) evlist in
@@ -556,7 +556,7 @@ let nb_evar_deps = function
     let s = Id.to_string id in
     if not (is_tagged evar_tag s) then 0 else
     let m = String.length evar_tag in
-    (try int_of_string (String.sub s m (String.length s - 1 - m)) with _ -> 0)
+    (try int_of_string (String.sub s m (String.length s - 1 - m)) with e when CErrors.noncritical e -> 0)
   | _ -> 0
 
 let type_id env sigma t = Id.of_string (Namegen.hdchar env sigma t)

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -85,7 +85,7 @@ let interp_congrarg_at env sigma ist ~concl n rf ty m =
       let rt = mkRApp congrn (args1 @  mkRApp rf (mkRHoles i) :: args2) in
       debug_ssr (fun () -> Pp.(str"rt=" ++ Printer.pr_glob_constr_env env sigma rt));
       Some (interp_refine env sigma ist ~concl rt)
-    with _ -> loop (i + 1) in
+    with e when CErrors.noncritical e -> loop (i + 1) in
   loop 0
 
 let pattern_id = mk_internal_id "pattern value"
@@ -310,7 +310,7 @@ let unfoldintac occ rdx t (kt,_) =
           in aux c
       else
         try body env t (fs (unify_HO env sigma c t) t)
-        with _ -> errorstrm Pp.(str "The term " ++
+        with e when CErrors.noncritical e -> errorstrm Pp.(str "The term " ++
           pr_econstr_env env sigma c ++spc()++ str "does not unify with " ++ pr_econstr_pat env sigma t)),
     ignore in
   let concl =
@@ -340,8 +340,9 @@ let foldtac occ rdx ft =
        try
          let sigma = unify_HO env sigma c t in
          Reductionops.nf_evar sigma t
-    with _ -> errorstrm Pp.(str "fold pattern " ++ pr_econstr_pat env sigma t ++ spc ()
-      ++ str "does not match redex " ++ pr_econstr_pat env sigma c)),
+       with e when CErrors.noncritical e ->
+         errorstrm Pp.(str "fold pattern " ++ pr_econstr_pat env sigma t ++ spc ()
+                       ++ str "does not match redex " ++ pr_econstr_pat env sigma c)),
     ignore in
   let concl = eval_pattern env0 sigma0 concl0 rdx occ fold in
   let () = conclude () in
@@ -487,7 +488,7 @@ let rwcltac ?under ?map_redex cl rdx dir (sigma, r) =
     else
       let dc, r2 = EConstr.decompose_lam_n_assum sigma0 n r' in
       let r3, _, r3t  =
-        try EConstr.destCast sigma0 r2 with _ ->
+        try EConstr.destCast sigma0 r2 with e when CErrors.noncritical e ->
         errorstrm Pp.(str "no cast from " ++ pr_econstr_pat env sigma0 r
                     ++ str " to " ++ pr_econstr_env env sigma0 r2) in
       let cl' = EConstr.mkNamedProd sigma (make_annot rule_id Sorts.Relevant) (EConstr.it_mkProd_or_LetIn r3t dc) (EConstr.Vars.lift 1 cl) in
@@ -537,7 +538,7 @@ let lz_setoid_relation =
     let srel =
        try Some (UnivGen.constr_of_monomorphic_global (Global.env ()) @@
                  Coqlib.find_reference "Class_setoid" ("Coq"::sdir) "RewriteRelation" [@ocaml.warning "-3"])
-       with _ -> None in
+       with e when CErrors.noncritical e -> None in
     last_srel := Some (env, srel); srel
 
 let ssr_is_setoid env =
@@ -645,7 +646,7 @@ let rwrxtac ?under ?map_redex occ rdx_pat dir rule =
           let ise = unify_HO env (Evd.create_evar_defs r_sigma) lhs rdx in
           if not (rw_progress rhs rdx ise) then raise NoMatch else
           d, (ise, Evd.evar_universe_context ise, Reductionops.nf_evar ise r)
-        with _ -> rwtac rs in
+        with e when CErrors.noncritical e -> rwtac rs in
      rwtac rules in
   let env0 = env in
   let concl0 = Proofview.Goal.concl gl in
@@ -712,10 +713,11 @@ let rwargtac ?under ?map_redex ist ((dir, mult), (((oclr, occ), grx), (kind, gt)
   let fail = ref false in
   let interp_rpattern env sigma gc =
     try interp_rpattern env sigma gc
-    with _ when snd mult = May -> fail := true; { pat_sigma = sigma; pat_pat = T EConstr.mkProp } in
+    with e when CErrors.noncritical e && snd mult = May ->
+      fail := true; { pat_sigma = sigma; pat_pat = T EConstr.mkProp } in
   let interp env sigma gc =
     try interp_term env sigma ist gc
-    with _ when snd mult = May -> fail := true; (sigma, EConstr.mkProp) in
+    with e when CErrors.noncritical e && snd mult = May -> fail := true; (sigma, EConstr.mkProp) in
   let rwtac =
     Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -392,7 +392,7 @@ let interp_index ist env sigma idx =
           end
         | None -> raise Not_found
         end end
-    with _ -> CErrors.user_err ?loc:id.CAst.loc (str"Index not a number") in
+    with e when CErrors.noncritical e -> CErrors.user_err ?loc:id.CAst.loc (str"Index not a number") in
     ArgArg (check_index ?loc:id.CAst.loc i)
 
 open Pltac
@@ -684,7 +684,8 @@ let interp_intro_pattern = Tacinterp.interp_intro_pattern
 
 let interp_introid ist env sigma id =
  try IntroNaming (IntroIdentifier (hyp_id (interp_hyp ist env sigma (SsrHyp (Loc.tag id)))))
- with _ -> (interp_intro_pattern ist env sigma (CAst.make @@ IntroNaming (IntroIdentifier id))).CAst.v
+ with e when CErrors.noncritical e ->
+   (interp_intro_pattern ist env sigma (CAst.make @@ IntroNaming (IntroIdentifier id))).CAst.v
 
 let get_intro_id = function
   | IntroNaming (IntroIdentifier id) -> id

--- a/plugins/ssr/ssrvernac.mlg
+++ b/plugins/ssr/ssrvernac.mlg
@@ -144,7 +144,7 @@ END
 let declare_one_prenex_implicit locality f =
   let fref =
     try Smartlocate.global_with_alias f
-    with _ -> errorstrm (pr_qualid f ++ str " is not declared") in
+    with e when CErrors.noncritical e -> errorstrm (pr_qualid f ++ str " is not declared") in
   let rec loop = function
   | a :: args' when Impargs.is_status_implicit a ->
     MaxImplicit :: loop args'

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -814,7 +814,7 @@ and detype_r d flags avoid env sigma t =
       in
       if flags.flg_lax || !Flags.in_debugger || !Flags.in_toplevel then
         try noparams ()
-        with _ ->
+        with e when !Flags.in_debugger ->
             (* lax mode, used by debug printers only *)
           GApp (DAst.make @@ GRef (GlobRef.ConstRef (Projection.constant p), None),
                 [detype d flags avoid env sigma c])

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -265,8 +265,7 @@ let check_conv_record env sigma (t1,sk1) (t2,sk2) =
       let ty = Retyping.get_type_of ~lax:true env sigma c in
       let (i,u), ind_args =
         (* Are we sure that ty is not an evar? *)
-        try Inductiveops.find_mrectype env sigma ty
-        with _ -> raise Not_found
+        Inductiveops.find_mrectype env sigma ty
       in ind_args, c, sk1
     | None ->
       match Stack.strip_n_app solution.nparams sk1 with

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -405,10 +405,10 @@ end = struct (* {{{ *)
       "stm_" ^ Str.global_replace (Str.regexp " ") "_" (Spawned.process_id ()) in
     let string_of_transaction = function
       | Cmd { cast = t } | Fork (t, _,_,_) ->
-          (try Pp.string_of_ppcmds (pr_ast t) with _ -> "ERR")
+          (try Pp.string_of_ppcmds (pr_ast t) with e when CErrors.noncritical e -> "ERR")
       | Sideff (ReplayCommand t) ->
           sprintf "Sideff(%s)"
-            (try Pp.string_of_ppcmds (pr_ast t) with _ -> "ERR")
+            (try Pp.string_of_ppcmds (pr_ast t) with e when CErrors.noncritical e -> "ERR")
       | Sideff CherryPickEnv -> "EnvChange"
       | Noop -> " "
       | Alias (id,_) -> sprintf "Alias(%s)" (Stateid.to_string id)

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -1929,7 +1929,7 @@ let setoid_proof ty fn fallback =
           let rel, ty1, ty2, concl, _, _ = decompose_app_rel_error env sigma concl in
           let (sigma, t) = Typing.type_of env sigma rel in
           let car = snd (List.hd (fst (Reductionops.splay_prod env sigma t))) in
-            (try init_relation_classes () with _ -> raise Not_found);
+            (try init_relation_classes () with e when CErrors.noncritical e -> raise Not_found);
             fn env sigma car rel
         with e when CErrors.noncritical e ->
           (* XXX what is the right test here as to whether e can be converted ? *)

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -377,7 +377,7 @@ let convert_gen pb x y =
     | None ->
       let info = Exninfo.reify () in
       Tacticals.tclFAIL ~info (str "Not convertible")
-    | exception e ->
+    | exception e when CErrors.noncritical e ->
       let _, info = Exninfo.capture e in
       (* FIXME: Sometimes an anomaly is raised from conversion *)
       Tacticals.tclFAIL ~info (str "Not convertible")

--- a/tools/coqworkmgr/coqworkmgrApi.ml
+++ b/tools/coqworkmgr/coqworkmgrApi.ml
@@ -64,9 +64,9 @@ let parse_response s =
   | [ "TOKENS"; n ] -> Tokens (positive_int_of_string n)
   | [ "NOLUCK" ] -> Noluck
   | [ "PONG"; n; m; p ] ->
-      let n = try int_of_string n with _ -> raise ParseError in
-      let m = try int_of_string m with _ -> raise ParseError in
-      let p = try int_of_string p with _ -> raise ParseError in
+      let n = try int_of_string n with Failure _ -> raise ParseError in
+      let m = try int_of_string m with Failure _ -> raise ParseError in
+      let p = try int_of_string p with Failure _ -> raise ParseError in
       Pong (n,m,p)
   | _ -> raise ParseError
 

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -200,7 +200,7 @@ let get_constant_body kn =
   | OpaqueDef o ->
     match Global.force_proof access o with
     | c, _ -> Some c
-    | exception _ -> None (* missing delayed body, e.g. in vok mode *)
+    | exception e when CErrors.noncritical e -> None (* missing delayed body, e.g. in vok mode *)
 
 let rec traverse current ctx accu t =
   let open GlobRef in

--- a/vernac/egramcoq.ml
+++ b/vernac/egramcoq.ml
@@ -290,7 +290,7 @@ let find_custom_entry s =
 
 let exists_custom_entry s = match find_custom_entry s with
 | _ -> true
-| exception _ -> false
+| exception e when CErrors.noncritical e -> false
 
 let locality_of_custom_entry s = String.Set.mem s !custom_entry_locality
 


### PR DESCRIPTION
This backport has been tested by `coq-lsp` users. No problem reported.

See #17638 for the full changelog and commit messages.

Submitting as discussed in today's Coq Call, a milestone for 8.17.2 needs to be created if we consider merging this.