### PR TITLE
[v8.18] Backport PR #17638: Guard many unguarded `try..with` expressions

### DIFF
--- a/parsing/cLexer.ml
+++ b/parsing/cLexer.ml
@@ -563,9 +563,9 @@ let peek_string v s =
     if Int.equal i l then true
     else
       let l' = Stream.npeek () (i + 1) s in
-      match List.nth l' i with
-      | c -> Char.equal c v.[i] && aux (i + 1)
-      | exception _ -> false (* EOF *) in
+      match List.nth_opt l' i with
+      | Some c -> Char.equal c v.[i] && aux (i + 1)
+      | None -> false (* EOF *) in
   aux 0
 
 let find_keyword ttree loc id bp s =

--- a/parsing/pcoq.ml
+++ b/parsing/pcoq.ml
@@ -367,7 +367,7 @@ let epsilon_value (type s tr a) f (e : (s, tr, a) Symbol.t) =
   let entry = Entry.make "epsilon" in
   let ext = Fresh (Gramlib.Gramext.First, [None, None, [r]]) in
   safe_extend entry ext;
-  try Some (parse_string entry "") with _ -> None
+  try Some (parse_string entry "") with e when CErrors.noncritical e -> None
 
 (** Synchronized grammar extensions *)
 

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -399,7 +399,7 @@ let make_eq () =
   try
     EConstr.of_constr
       (UnivGen.constr_of_monomorphic_global (Global.env ()) (Coqlib.lib_ref "core.eq.type"))
-  with _ -> assert false
+  with e when CErrors.noncritical e -> assert false
 
 let evaluable_of_global_reference r =
   let open Tacred in

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -442,8 +442,8 @@ let () = define1 "ident_to_string" ident begin fun id ->
 end
 
 let () = define1 "ident_of_string" string begin fun s ->
-  let id = try Some (Id.of_string s) with _ -> None in
-  return (Value.of_option Value.of_ident id)
+    let id = try Some (Id.of_string s) with e when CErrors.noncritical e -> None in
+    return (Value.of_option Value.of_ident id)
 end
 
 (** Int *)

--- a/plugins/micromega/persistent_cache.ml
+++ b/plugins/micromega/persistent_cache.ml
@@ -198,7 +198,7 @@ module PHashtable (Key : HashedType) : PHashtable with type key = Key.t = struct
               let () = data.obj <- Some (k, v) in
               Some v
             else None
-          | exception _ -> None
+          | exception End_of_file | exception Failure _ -> None
       in
       let lookup () = CList.find_map find lpos in
       let res = do_under_lock Read (descr_of_in_channel ch) lookup in
@@ -208,7 +208,7 @@ module PHashtable (Key : HashedType) : PHashtable with type key = Key.t = struct
       | None | Some None -> raise Not_found
 
   let memo cache f =
-    let tbl = lazy (try Some (open_in cache) with _ -> None) in
+    let tbl = lazy (try Some (open_in cache) with e when CErrors.noncritical e -> None) in
     fun x ->
       match Lazy.force tbl with
       | None -> f x
@@ -219,7 +219,7 @@ module PHashtable (Key : HashedType) : PHashtable with type key = Key.t = struct
           add tbl x res; res )
 
   let memo_cond cache cond f =
-    let tbl = lazy (try Some (open_in cache) with _ -> None) in
+    let tbl = lazy (try Some (open_in cache) with e when CErrors.noncritical e -> None) in
     fun x ->
       match Lazy.force tbl with
       | None -> f x

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -353,7 +353,7 @@ let is_id_constr sigma c = match EConstr.kind sigma c with
 
 let red_product_skip_id env sigma c = match EConstr.kind sigma c with
   | App(hd,args) when Array.length args = 1 && is_id_constr sigma hd -> args.(0)
-  | _ -> try Tacred.red_product env sigma c with _ -> c
+  | _ -> try Tacred.red_product env sigma c with e when CErrors.noncritical e -> c
 
 let ssrevaltac ist gtac = Tacinterp.tactic_of_value ist gtac
 
@@ -503,7 +503,7 @@ let abs_evars_pirrel env sigma0 (sigma, c0) =
       try
         let sigma = call_on_evar env sigma !ssrautoprop_tac i in
         List.filter (fun (j,_) -> j <> i) ev, evp, sigma
-      with _ -> ev, p::evp, sigma) (evlist, [], sigma) (List.rev evplist) in
+      with e when CErrors.noncritical e -> ev, p::evp, sigma) (evlist, [], sigma) (List.rev evplist) in
   let c0 = Evarutil.nf_evar sigma c0 in
   let evlist =
     List.map (fun (x,(y,t,z)) -> x,(y,Evarutil.nf_evar sigma t,z)) evlist in
@@ -556,7 +556,7 @@ let nb_evar_deps = function
     let s = Id.to_string id in
     if not (is_tagged evar_tag s) then 0 else
     let m = String.length evar_tag in
-    (try int_of_string (String.sub s m (String.length s - 1 - m)) with _ -> 0)
+    (try int_of_string (String.sub s m (String.length s - 1 - m)) with e when CErrors.noncritical e -> 0)
   | _ -> 0
 
 let type_id env sigma t = Id.of_string (Namegen.hdchar env sigma t)

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -383,7 +383,7 @@ let interp_index ist env sigma idx =
           end
         | None -> raise Not_found
         end end
-    with _ -> CErrors.user_err ?loc:id.CAst.loc (str"Index not a number") in
+    with e when CErrors.noncritical e -> CErrors.user_err ?loc:id.CAst.loc (str"Index not a number") in
     ArgArg (check_index ?loc:id.CAst.loc i)
 
 open Pltac
@@ -674,7 +674,8 @@ let interp_intro_pattern = Tacinterp.interp_intro_pattern
 
 let interp_introid ist env sigma id =
  try IntroNaming (IntroIdentifier (hyp_id (interp_hyp ist env sigma (SsrHyp (Loc.tag id)))))
- with _ -> (interp_intro_pattern ist env sigma (CAst.make @@ IntroNaming (IntroIdentifier id))).CAst.v
+ with e when CErrors.noncritical e ->
+   (interp_intro_pattern ist env sigma (CAst.make @@ IntroNaming (IntroIdentifier id))).CAst.v
 
 let get_intro_id = function
   | IntroNaming (IntroIdentifier id) -> id

--- a/plugins/ssr/ssrvernac.mlg
+++ b/plugins/ssr/ssrvernac.mlg
@@ -144,7 +144,7 @@ END
 let declare_one_prenex_implicit locality f =
   let fref =
     try Smartlocate.global_with_alias f
-    with _ -> errorstrm (pr_qualid f ++ str " is not declared") in
+    with e when CErrors.noncritical e -> errorstrm (pr_qualid f ++ str " is not declared") in
   let rec loop = function
   | a :: args' when Impargs.is_status_implicit a ->
     MaxImplicit :: loop args'

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -940,13 +940,13 @@ let glob_cpattern gs p =
      if k = Cpattern then glob_ssrterm gs {kind=InParens; pattern=(v, Some t); interpretation=None} else
      match t.CAst.v with
      | CNotation(_,(InConstrEntry,"( _ in _ )"), ([t1; t2], [], [], [])) ->
-         (try match glob t1, glob t2 with
-         | (r1, None), (r2, None) -> encode k "In" [r1;r2]
-         | (r1, Some _), (r2, Some _) when isCVar t1 ->
-             encode k "In" [r1; r2; bind_in t1 t2]
-         | (r1, Some _), (r2, Some _) -> encode k "In" [r1; r2]
-         | _ -> CErrors.anomaly (str"where are we?.")
-         with _ when isCVar t1 -> encode k "In" [bind_in t1 t2])
+       (try match glob t1, glob t2 with
+          | (r1, None), (r2, None) -> encode k "In" [r1;r2]
+          | (r1, Some _), (r2, Some _) when isCVar t1 ->
+            encode k "In" [r1; r2; bind_in t1 t2]
+          | (r1, Some _), (r2, Some _) -> encode k "In" [r1; r2]
+          | _ -> CErrors.anomaly (str"where are we?.")
+        with e when CErrors.noncritical e && isCVar t1 -> encode k "In" [bind_in t1 t2])
      | CNotation(_,(InConstrEntry,"( _ in _ in _ )"), ([t1; t2; t3], [], [], [])) ->
          check_var t2; encode k "In" [fst (glob t1); bind_in t2 t3]
      | CNotation(_,(InConstrEntry,"( _ as _ )"), ([t1; t2], [], [], [])) ->
@@ -1329,13 +1329,13 @@ let fill_occ_term env sigma0 cl occ (sigma, t) =
     if changed then CErrors.user_err Pp.(str "matching impacts evars")
     else cl, t'
   with NoMatch -> try
-    let changed, sigma', uc, t' =
-      unif_end env sigma0 (create_evar_defs sigma) t (fun _ -> true) in
-    if changed then raise NoMatch
-    else cl, t'
-  with _ ->
-    errorstrm (str "partial term " ++ pr_econstr_pat env sigma t
-            ++ str " does not match any subterm of the goal")
+      let changed, sigma', uc, t' =
+        unif_end env sigma0 (create_evar_defs sigma) t (fun _ -> true) in
+      if changed then raise NoMatch
+      else cl, t'
+    with e when CErrors.noncritical e ->
+      errorstrm (str "partial term " ++ pr_econstr_pat env sigma t
+                 ++ str " does not match any subterm of the goal")
 
 let cpattern_of_id id =
   { kind= NoFlag

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -847,7 +847,7 @@ and detype_r d flags avoid env sigma t =
           try
             let _, mip = Global.lookup_inductive (Projection.inductive p) in
             mip.mind_consnrealargs.(0), Projection.arg p
-          with _ when !Flags.in_debugger ->
+          with e when !Flags.in_debugger ->
             (* kinda weird printing but the name should be enough to
                indicate which projection it is *)
             1, 0

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -265,8 +265,7 @@ let check_conv_record env sigma (t1,sk1) (t2,sk2) =
       let ty = Retyping.get_type_of ~lax:true env sigma c in
       let (i,u), ind_args =
         (* Are we sure that ty is not an evar? *)
-        try Inductiveops.find_mrectype env sigma ty
-        with _ -> raise Not_found
+        Inductiveops.find_mrectype env sigma ty
       in ind_args, c, sk1
     | None ->
       match Stack.strip_n_app solution.nparams sk1 with

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -99,14 +99,12 @@ let tokenize_string s =
       stream_tok ((Tok.extract_string true e) :: acc) str
   in
   let st = CLexer.Lexer.State.get () in
+  Fun.protect ~finally:(fun () -> CLexer.Lexer.State.set st) @@ fun () ->
   try
     let istr = Gramlib.Stream.of_string s in
     let lex = CLexer.LexerDiff.tok_func istr in
-    let toks = stream_tok [] lex in
-    CLexer.Lexer.State.set st;
-    toks
-  with exn ->
-    CLexer.Lexer.State.set st;
+    stream_tok [] lex
+  with exn when CErrors.noncritical exn ->
     raise (Diff_Failure "Input string is not lexable")
 
 type hyp_info = {
@@ -319,7 +317,7 @@ let goal_info goal =
     let () = List.iter (build_hyp_info env sigma) (List.rev hyps) in
     let concl_pp = pp_of_type env sigma ty in
     ( List.rev !line_idents, !map, concl_pp )
-  with _ -> ([], !map, Pp.mt ())
+  with e when CErrors.noncritical e -> ([], !map, Pp.mt ())
 
 let diff_goal_info ~short o_info n_info =
   let (o_idents_in_lines, o_hyp_map, o_concl_pp) = o_info in

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -410,10 +410,10 @@ end = struct (* {{{ *)
       "stm_" ^ Str.global_replace (Str.regexp " ") "_" (Spawned.process_id ()) in
     let string_of_transaction = function
       | Cmd { cast = t } | Fork (t, _,_,_) ->
-          (try Pp.string_of_ppcmds (pr_ast t) with _ -> "ERR")
+          (try Pp.string_of_ppcmds (pr_ast t) with e when CErrors.noncritical e -> "ERR")
       | Sideff (ReplayCommand t) ->
           sprintf "Sideff(%s)"
-            (try Pp.string_of_ppcmds (pr_ast t) with _ -> "ERR")
+            (try Pp.string_of_ppcmds (pr_ast t) with e when CErrors.noncritical e -> "ERR")
       | Sideff CherryPickEnv -> "EnvChange"
       | Noop -> " "
       | Alias (id,_) -> sprintf "Alias(%s)" (Stateid.to_string id)

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -1898,8 +1898,8 @@ let setoid_proof ty fn fallback =
           let rel, ty1, ty2, concl, _, _ = decompose_app_rel_error env sigma concl in
           let (sigma, t) = Typing.type_of env sigma rel in
           let car = snd (List.hd (fst (Reductionops.hnf_decompose_prod env sigma t))) in
-            (try init_relation_classes () with _ -> raise Not_found);
-            fn env sigma car rel
+          (try init_relation_classes () with e when CErrors.noncritical e -> raise Not_found);
+          fn env sigma car rel
         with e when CErrors.noncritical e ->
           (* XXX what is the right test here as to whether e can be converted ? *)
           let e, info = Exninfo.capture e in

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -375,7 +375,7 @@ let convert_gen pb x y =
     | None ->
       let info = Exninfo.reify () in
       Tacticals.tclFAIL ~info (str "Not convertible")
-    | exception e ->
+    | exception e when CErrors.noncritical e ->
       let _, info = Exninfo.capture e in
       (* FIXME: Sometimes an anomaly is raised from conversion *)
       Tacticals.tclFAIL ~info (str "Not convertible")

--- a/tools/coqworkmgr/coqworkmgrApi.ml
+++ b/tools/coqworkmgr/coqworkmgrApi.ml
@@ -64,9 +64,9 @@ let parse_response s =
   | [ "TOKENS"; n ] -> Tokens (positive_int_of_string n)
   | [ "NOLUCK" ] -> Noluck
   | [ "PONG"; n; m; p ] ->
-      let n = try int_of_string n with _ -> raise ParseError in
-      let m = try int_of_string m with _ -> raise ParseError in
-      let p = try int_of_string p with _ -> raise ParseError in
+      let n = try int_of_string n with Failure _ -> raise ParseError in
+      let m = try int_of_string m with Failure _ -> raise ParseError in
+      let p = try int_of_string p with Failure _ -> raise ParseError in
       Pong (n,m,p)
   | _ -> raise ParseError
 

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -204,7 +204,7 @@ let get_constant_body kn =
   | OpaqueDef o ->
     match Global.force_proof access o with
     | c, _ -> Some c
-    | exception _ -> None (* missing delayed body, e.g. in vok mode *)
+    | exception e when CErrors.noncritical e -> None (* missing delayed body, e.g. in vok mode *)
 
 let rec traverse current ctx accu t =
   let open GlobRef in

--- a/vernac/egramcoq.ml
+++ b/vernac/egramcoq.ml
@@ -292,7 +292,7 @@ let find_custom_entry s =
 
 let exists_custom_entry s = match find_custom_entry s with
 | _ -> true
-| exception _ -> false
+| exception e when CErrors.noncritical e -> false
 
 let locality_of_custom_entry s = String.Set.mem s !custom_entry_locality
 

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1919,11 +1919,6 @@ let vernac_global_check c =
   pr_universe_ctx_set sigma uctx
 
 
-let get_nth_goal ~pstate n =
-  let pf = Declare.Proof.get pstate in
-  let Proof.{goals;sigma} = Proof.data pf in
-  (sigma, List.nth goals (n - 1))
-
 (* Printing "About" information of a hypothesis of the current goal.
    We only print the type and a small statement to this comes from the
    goal. Precondition: there must be at least one current goal. *)
@@ -1938,16 +1933,20 @@ let print_about_hyp_globs ~pstate ?loc ref_or_by_not udecl glopt =
     in
     (* FIXME error on non None udecl if we find the hyp. *)
     let glnumopt = query_command_selector ?loc glopt in
-    let (sigma, ev), id =
+    let pf = Declare.Proof.get pstate in
+    let Proof.{goals; sigma} = Proof.data pf in
+    let ev, id =
       let open Constrexpr in
       match glnumopt, ref_or_by_not.v with
       | None,AN qid when qualid_is_ident qid -> (* goal number not given, catch any failure *)
-         (try get_nth_goal ~pstate 1, qualid_basename qid with _ -> raise NoHyp)
+        (match List.nth_opt goals 0 with
+         | None -> raise NoHyp
+         | Some goal -> goal), qualid_basename qid
       | Some n,AN qid when qualid_is_ident qid ->  (* goal number given, catch if wong *)
-         (try get_nth_goal ~pstate n, qualid_basename qid
-          with
-            Failure _ -> user_err ?loc
-                          (str "No such goal: " ++ int n ++ str "."))
+        (match List.nth_opt goals (n - 1) with
+         | None  -> user_err ?loc
+                      (str "No such goal: " ++ int n ++ str ".")
+         | Some goal -> goal), qualid_basename qid
       | _ , _ -> raise NoHyp in
     let hyps = Evd.evar_filtered_context (Evd.find_undefined sigma ev) in
     let decl = Context.Named.lookup id hyps in


### PR DESCRIPTION
This backport has been tested by `coq-lsp` users. No problem reported.

See #17638 for the full changelog and commit messages.

Submitting as discussed in today's Coq Call.