### PR TITLE
doc NZBase, NZadd, NZOrder

### DIFF
--- a/theories/Numbers/NatInt/NZAdd.v
+++ b/theories/Numbers/NatInt/NZAdd.v
@@ -10,9 +10,24 @@
 (*                      Evgeny Makarov, INRIA, 2007                     *)
 (************************************************************************)
 
-Require Import NZAxioms NZBase.
+(**
+* Some properties of the addition for modules implementing [NZBasicFunsSig']
 
-Module Type NZAddProp (Import NZ : NZAxiomsSig')(Import NZBase : NZBaseProp NZ).
+This file defines the [NZAddProp] functor type. This functor type is meant
+to be [Include]d in a module implementing [NZBasicFunsSig'].
+
+This gives the following lemmas:
+- [add_0_r], [add_1_l], [add_1_r]
+- [add_succ_r], [add_succ_comm], [add_comm]
+- [add_assoc]
+- [add_cancel_l], [add_cancel_r]
+- [add_shuffle0],  [add_shuffle3] to rearrange sums of 3 elements
+- [add_shuffle1],  [add_shuffle2] to rearrange sums of 4 elements
+- [sub_1_r]
+*)
+From Coq.Numbers.NatInt Require Import NZAxioms NZBase.
+
+Module Type NZAddProp (Import NZ : NZBasicFunsSig')(Import NZBase : NZBaseProp NZ).
 
 Global Hint Rewrite
  pred_succ add_0_l add_succ_l mul_0_l mul_succ_l sub_0_r sub_succ_r : nz.

--- a/theories/Numbers/NatInt/NZBase.v
+++ b/theories/Numbers/NatInt/NZBase.v
@@ -10,11 +10,27 @@
 (*                      Evgeny Makarov, INRIA, 2007                     *)
 (************************************************************************)
 
-Require Import NZAxioms.
+(**
+* Basic lemmas about modules implementing [NZDomainSig']
+
+This file defines the functor type [NZBaseProp] which adds the following
+lemmas:
+- [eq_refl], [eq_sym], [eq_trans]
+- [eq_sym_iff], [neq_sym], [eq_stepl]
+- [succ_inj], [succ_inj_wd], [succ_inj_wd_neg]
+- [central_induction] and the tactic notation [nzinduct]
+
+The functor type [NZBaseProp] is meant to be [Include]d in a module implementing
+[NZDomainSig'].
+*)
+
+From Coq.Numbers.NatInt Require Import NZAxioms.
 
 Module Type NZBaseProp (Import NZ : NZDomainSig').
 
-Include BackportEq NZ NZ. (** eq_refl, eq_sym, eq_trans *)
+(** This functor from [Coq.Structures.Equalities] gives
+    [eq_refl], [eq_sym] and [eq_trans]. *)
+Include BackportEq NZ NZ.
 
 Lemma eq_sym_iff : forall x y, x==y <-> y==x.
 Proof.
@@ -28,6 +44,8 @@ Theorem neq_sym : forall n m, n ~= m -> m ~= n.
 Proof.
 intros n m H1 H2; symmetry in H2; false_hyp H2 H1.
 Qed.
+
+(** We add entries in the [stepl] and [stepr] databases. *)
 
 Theorem eq_stepl : forall x y z, x == y -> x == z -> z == y.
 Proof.


### PR DESCRIPTION
Documentation (in `coqdoc` format) of `NZBase.v`, `NZAdd.v`, `NZOrder.v` in `Coq.Numbers.NatInt`.

The first module argument of `NZAddProp` had its type changed according to [this line in NZAxioms](https://github.com/coq/coq/blob/bc8ec32a42c4d162808ca87ea54ee92c5dc1e1c9/theories/Numbers/NatInt/NZAxioms.v#L193) stating that it was an old name (that is why I did not remove the `needs: full CI` label).

rendered:
- [NZBase](https://coq.gitlabpages.inria.fr/-/coq/-/jobs/3771097/artifacts/_build/default/doc/stdlib/html/Coq.Numbers.NatInt.NZBase.html)
- [NZAdd](https://coq.gitlabpages.inria.fr/-/coq/-/jobs/3771097/artifacts/_build/default/doc/stdlib/html/Coq.Numbers.NatInt.NZAdd.html)
- [NZOrder](https://coq.gitlabpages.inria.fr/-/coq/-/jobs/3771097/artifacts/_build/default/doc/stdlib/html/Coq.Numbers.NatInt.NZOrder.html)