### PR TITLE
Deprecate Nat and Int implementations in Numbers

### DIFF
--- a/doc/stdlib/hidden-files
+++ b/doc/stdlib/hidden-files
@@ -96,3 +96,6 @@ theories/ssr/ssrsetoid.v
 theories/Reals/Cauchy/ConstructiveExtra.v
 theories/Reals/Cauchy/PosExtra.v
 theories/Reals/Cauchy/QExtra.v
+theories/Numbers/Natural/Binary/NBinary.v
+theories/Numbers/Integer/Binary/ZBinary.v
+theories/Numbers/Integer/NatPairs/ZNatPairs.v

--- a/doc/stdlib/index-list.html.template
+++ b/doc/stdlib/index-list.html.template
@@ -304,7 +304,6 @@ through the <tt>Require Import</tt> command.</p>
     theories/Numbers/Natural/Abstract/NLcm0.v
     theories/Numbers/Natural/Abstract/NBits.v
     theories/Numbers/Natural/Abstract/NProperties.v
-    theories/Numbers/Natural/Binary/NBinary.v
     </dd>
 
     <dt> <b>&nbsp;&nbsp;Integer</b>:
@@ -330,8 +329,6 @@ through the <tt>Require Import</tt> command.</p>
     theories/Numbers/Integer/Abstract/ZDivEucl.v
     theories/Numbers/Integer/Abstract/ZDivFloor.v
     theories/Numbers/Integer/Abstract/ZDivTrunc.v
-    theories/Numbers/Integer/Binary/ZBinary.v
-    theories/Numbers/Integer/NatPairs/ZNatPairs.v
     </dd>
 
     <dt> <b>&nbsp;&nbsp;Floats</b>:

--- a/theories/Numbers/Integer/Binary/ZBinary.v
+++ b/theories/Numbers/Integer/Binary/ZBinary.v
@@ -10,6 +10,7 @@
 (*                      Evgeny Makarov, INRIA, 2007                     *)
 (************************************************************************)
 
+Attributes deprecated(since="8.20", note="Use Coq.ZArith.BinInt instead.").
 
 Require Import ZAxioms ZProperties BinInt.
 

--- a/theories/Numbers/Integer/NatPairs/ZNatPairs.v
+++ b/theories/Numbers/Integer/NatPairs/ZNatPairs.v
@@ -10,6 +10,7 @@
 (*                      Evgeny Makarov, INRIA, 2007                     *)
 (************************************************************************)
 
+Attributes deprecated(since="8.20", note="Use Coq.ZArith.BinInt instead.").
 Require Import NSub ZAxioms.
 Require Export Ring.
 

--- a/theories/Numbers/Natural/Binary/NBinary.v
+++ b/theories/Numbers/Natural/Binary/NBinary.v
@@ -10,6 +10,8 @@
 (*                      Evgeny Makarov, INRIA, 2007                     *)
 (************************************************************************)
 
+Attributes deprecated(since="8.20", note="Use Coq.NArith.BinNat instead.").
+
 Require Import BinPos.
 Require Export BinNat.
 Require Import NAxioms NProperties.


### PR DESCRIPTION
A library deprecation attribute has been inserted. The 3 files
- `theories/Numbers/Integer/Binary/ZBinary.v`
- `theories/Numbers/Integer/NatPairs/ZNatPairs.v`
- `theories/Numbers/Natural/Binary/NBinary.v`
are leaves in the stdlib and are probably not used anywhere.