### PR TITLE
Document AddOrder Mul and MulOrder in NatInt

### DIFF
--- a/doc/changelog/11-standard-library/18501-more_NatInt_doc.rst
+++ b/doc/changelog/11-standard-library/18501-more_NatInt_doc.rst
@@ -1,0 +1,6 @@
+- **Deprecated:**
+  The library file ``Coq.Numbers.NatInt.NZProperties`` is deprecated.
+  Users can require ``Coq.Numbers.NatInt.NZMulOrder`` instead and replace the
+  module ``NZProperties.NZProp`` with ``NZMulOrder.NZMulOrderProp``.
+  (`#18501 <https://github.com/coq/coq/pull/18501>`_,
+  by Pierre Rousselin).

--- a/doc/stdlib/hidden-files
+++ b/doc/stdlib/hidden-files
@@ -99,3 +99,4 @@ theories/Reals/Cauchy/QExtra.v
 theories/Numbers/Natural/Binary/NBinary.v
 theories/Numbers/Integer/Binary/ZBinary.v
 theories/Numbers/Integer/NatPairs/ZNatPairs.v
+theories/Numbers/NatInt/NZProperties.v

--- a/doc/stdlib/index-list.html.template
+++ b/doc/stdlib/index-list.html.template
@@ -254,7 +254,6 @@ through the <tt>Require Import</tt> command.</p>
     theories/Numbers/NatInt/NZMulOrder.v
     theories/Numbers/NatInt/NZOrder.v
     theories/Numbers/NatInt/NZDomain.v
-    theories/Numbers/NatInt/NZProperties.v
     theories/Numbers/NatInt/NZParity.v
     theories/Numbers/NatInt/NZPow.v
     theories/Numbers/NatInt/NZSqrt.v

--- a/theories/Numbers/Integer/Abstract/ZBase.v
+++ b/theories/Numbers/Integer/Abstract/ZBase.v
@@ -12,10 +12,10 @@
 
 Require Export Decidable.
 Require Export ZAxioms.
-Require Import NZProperties.
+Require Import NZMulOrder.
 
 Module ZBaseProp (Import Z : ZAxiomsMiniSig').
-Include NZProp Z.
+Include NZMulOrderProp Z.
 
 (* Theorems that are true for integers but not for natural numbers *)
 

--- a/theories/Numbers/NatInt/NZAddOrder.v
+++ b/theories/Numbers/NatInt/NZAddOrder.v
@@ -10,7 +10,15 @@
 (*                      Evgeny Makarov, INRIA, 2007                     *)
 (************************************************************************)
 
-Require Import NZAxioms NZBase NZMul NZOrder.
+(**
+* Properties of orders and addition for modules implementing [NZOrdAxiomsSig']
+
+This file defines the [NZAddOrderProp] functor type, meant to be [Include]d
+in a module implementing [NZOrdAxiomsSig'] (see [Coq.Numbers.NatInt.NZAxioms]).
+
+This gives important basic compatibility lemmas between [add] and [lt], [le].
+*)
+From Coq.Numbers.NatInt Require Import NZAxioms NZBase NZMul NZOrder.
 
 Module Type NZAddOrderProp (Import NZ : NZOrdAxiomsSig').
 Include NZBaseProp NZ <+ NZMulProp NZ <+ NZOrderProp NZ.

--- a/theories/Numbers/NatInt/NZMul.v
+++ b/theories/Numbers/NatInt/NZMul.v
@@ -10,9 +10,26 @@
 (*                      Evgeny Makarov, INRIA, 2007                     *)
 (************************************************************************)
 
-Require Import NZAxioms NZBase NZAdd.
+(**
+* Some properties of the multiplication for modules implementing [NZBasicFunsSig']
 
-Module Type NZMulProp (Import NZ : NZAxiomsSig')(Import NZBase : NZBaseProp NZ).
+This file defines the [NZMulProp] functor type on top of [NZAddProp]. This
+functor type is meant to be [Include]d in a module implementing [NZBasicFunsSig'].
+
+This gives the following basic lemmas:
+- [mul_0_r], [mul_1_l], [mul_1_r]
+- [mul_succ_r], [mul_comm]
+- [mul_add_distr_r], [mul_add_distr_l]
+- [mul_assoc]
+- [mul_shuffle0] and [mul_shuffle3] to rearrange products of 3 terms
+- [mul_shuffle1] and [mul_shuffle2] to rearrange products of 4 terms
+
+Notice that [NZMulProp] itself [Include]s [NZAddProp].
+*)
+
+From Coq.Numbers.NatInt Require Import NZAxioms NZBase NZAdd.
+
+Module Type NZMulProp (Import NZ : NZBasicFunsSig')(Import NZBase : NZBaseProp NZ).
 Include NZAddProp NZ NZBase.
 
 Theorem mul_0_r : forall n, n * 0 == 0.

--- a/theories/Numbers/NatInt/NZMulOrder.v
+++ b/theories/Numbers/NatInt/NZMulOrder.v
@@ -10,6 +10,21 @@
 (*                      Evgeny Makarov, INRIA, 2007                     *)
 (************************************************************************)
 
+(**
+* Properties of orders and multiplication for modules implementing [NZOrdAxiomsSig']
+
+This file defines the [NZMulOrderProp] functor type, meant to be [Include]d
+in a module implementing [NZOrdAxiomsSig'] (see [Coq.Numbers.NatInt.NZAxioms]).
+
+This gives important basic compatibility lemmas between [mul] and [lt], [le].
+It also gives cancellation lemmas between [mul] and [eq].
+
+Since it applies both to natural numbers and integers, some of these lemmas
+have nonnegativity conditions which could disappear when used with natural
+numbers.
+
+Notice that [NZMulOrderProp] [Include]s [NZAddOrderProp].
+*)
 Require Import NZAxioms.
 Require Import NZAddOrder.
 
@@ -268,11 +283,11 @@ intros n m H1 H2; apply eq_mul_0 in H1. destruct H1 as [H1 | H1].
 - false_hyp H1 H2. - assumption.
 Qed.
 
-(** Some alternative names: *)
+(* Some alternative names: *)
 
-Definition mul_eq_0 := eq_mul_0.
-Definition mul_eq_0_l := eq_mul_0_l.
-Definition mul_eq_0_r := eq_mul_0_r.
+Notation mul_eq_0 := eq_mul_0.
+Notation mul_eq_0_l := eq_mul_0_l.
+Notation mul_eq_0_r := eq_mul_0_r.
 
 Theorem lt_0_mul n m : 0 < n * m <-> (0 < n /\ 0 < m) \/ (m < 0 /\ n < 0).
 Proof.

--- a/theories/Numbers/NatInt/NZProperties.v
+++ b/theories/Numbers/NatInt/NZProperties.v
@@ -10,6 +10,7 @@
 (*                      Evgeny Makarov, INRIA, 2007                     *)
 (************************************************************************)
 
+Attributes deprecated(since="8.20", note="use Coq.Numbers.NatInt.NZMulOrder instead").
 Require Export NZAxioms NZMulOrder.
 
 (** This functor summarizes all known facts about NZ.

--- a/theories/Numbers/Natural/Abstract/NBase.v
+++ b/theories/Numbers/Natural/Abstract/NBase.v
@@ -12,11 +12,11 @@
 
 Require Export Decidable.
 Require Export NAxioms.
-Require Import NZProperties.
+Require Import NZMulOrder.
 
 Module NBaseProp (Import N : NAxiomsMiniSig').
 (** First, we import all known facts about both natural numbers and integers. *)
-Include NZProp N.
+Include NZMulOrderProp N.
 
 (** From [pred_0] and order facts, we can prove that 0 isn't a successor. *)
 


### PR DESCRIPTION
Besides documentation, we also:
- deprecate `NZProperties`, update hidden-files and index-list accordingly, and
  modify accordingly NBase and ZBase to use NZMulOrder instead
- change Definitions of `mul_eq_0`, `mul_eq_0_l` and `mul_eq_0_r` into
  Notations to clean up the Search output and for consistency.