### PR TITLE
Algorithmically efficient implementation of evar normalization

### DIFF
--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -68,16 +68,16 @@ let nf_evar sigma c =
   let lsubst = Evd.universe_subst sigma in
   let univ_value l = UnivFlex.normalize_univ_variable lsubst l in
   let qvar_value q = UState.nf_qvar (Evd.evar_universe_context sigma) q in
-  let rec self c = match Constr.kind c with
+  let rec self () c = match Constr.kind c with
   | Evar (evk, args) ->
-    let args' = SList.Smart.map self args in
+    let args' = SList.Smart.map (self ()) args in
     begin match try Evd.existential_opt_value0 sigma (evk, args') with Not_found -> None with
     | None -> if args == args' then c else mkEvar (evk, args')
-    | Some c -> self c
+    | Some c -> self () c
     end
-  | _ -> UnivSubst.map_universes_opt_subst self qvar_value univ_value c
+  | _ -> UnivSubst.map_universes_opt_subst_with_binders ignore self qvar_value univ_value () c
   in
-  EConstr.of_constr @@ self (EConstr.Unsafe.to_constr c)
+  EConstr.of_constr @@ self () (EConstr.Unsafe.to_constr c)
 
 let j_nf_evar sigma j =
   { uj_val = nf_evar sigma j.uj_val;

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -64,20 +64,7 @@ let kind_of_term_upto = EConstr.kind_upto
 let nf_evars_universes sigma t = EConstr.to_constr ~abort_on_undefined_evars:false sigma (EConstr.of_constr t)
 let whd_evar = EConstr.whd_evar
 
-let nf_evar sigma c =
-  let lsubst = Evd.universe_subst sigma in
-  let univ_value l = UnivFlex.normalize_univ_variable lsubst l in
-  let qvar_value q = UState.nf_qvar (Evd.evar_universe_context sigma) q in
-  let rec self () c = match Constr.kind c with
-  | Evar (evk, args) ->
-    let args' = SList.Smart.map (self ()) args in
-    begin match try Evd.existential_opt_value0 sigma (evk, args') with Not_found -> None with
-    | None -> if args == args' then c else mkEvar (evk, args')
-    | Some c -> self () c
-    end
-  | _ -> UnivSubst.map_universes_opt_subst_with_binders ignore self qvar_value univ_value () c
-  in
-  EConstr.of_constr @@ self () (EConstr.Unsafe.to_constr c)
+let nf_evar = Evd.MiniEConstr.nf_evar
 
 let j_nf_evar sigma j =
   { uj_val = nf_evar sigma j.uj_val;

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -66,7 +66,12 @@ let whd_evar = EConstr.whd_evar
 
 let nf_evar sigma c =
   let lsubst = Evd.universe_subst sigma in
-  let evar_value ev = Evd.existential_opt_value0 sigma ev in
+  let evar_value self (evk, args) =
+    let args' = SList.Smart.map self args in
+    match try Evd.existential_opt_value0 sigma (evk, args') with Not_found -> None with
+    | None -> mkEvar (evk, args')
+    | Some c -> self c
+  in
   let univ_value l = UnivFlex.normalize_univ_variable lsubst l in
   let qvar_value q = UState.nf_qvar (Evd.evar_universe_context sigma) q in
   EConstr.of_constr @@ UnivSubst.nf_evars_and_universes_opt_subst evar_value qvar_value univ_value (EConstr.Unsafe.to_constr c)

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1820,6 +1820,10 @@ module MiniEConstr = struct
     let saw_evar, c = to_constr_gen ~expand:false sigma c in
     if saw_evar && check_evar c then None else Some c
 
+  let nf_evar sigma c =
+    let _, c = to_constr_gen ~expand:false sigma c in
+    c
+
   let of_named_decl d = d
   let unsafe_to_named_decl d = d
   let of_rel_decl d = d

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1712,21 +1712,27 @@ module MiniEConstr = struct
   let unsafe_eq = Refl
 
   let to_constr_nocheck sigma c =
-    let evar_value ((evk, args) as ev) = match EvMap.find_opt evk sigma.defn_evars with
-    | None ->
-      (* Hack: we fully expand the evar instance *)
-      let rec has_default = function
-      | SList.Nil -> false
-      | SList.Cons (_, l) -> has_default l
-      | SList.Default _ -> true
+    let evar_value self (evk, args) =
+      let args' = SList.Smart.map self args in
+      let v = match EvMap.find_opt evk sigma.defn_evars with
+      | None ->
+        (* Hack: we fully expand the evar instance *)
+        let rec has_default = function
+        | SList.Nil -> false
+        | SList.Cons (_, l) -> has_default l
+        | SList.Default _ -> true
+        in
+        if has_default args' then
+          let args' = expand_existential sigma (evk, args') in
+          Some (mkEvar (evk, SList.of_full_list args'))
+        else None
+      | Some info ->
+        let Evar_defined c = evar_body info in
+        Some (instantiate_evar_array sigma info c args')
       in
-      if has_default args then
-        let args = expand_existential sigma ev in
-        Some (mkEvar (evk, SList.of_full_list args))
-      else None
-    | Some info ->
-      let Evar_defined c = evar_body info in
-      Some (instantiate_evar_array sigma info c args)
+      match v with
+      | None -> mkEvar (evk, args')
+      | Some c -> self c
     in
     let lsubst = universe_subst sigma in
     let univ_value l =
@@ -1737,10 +1743,13 @@ module MiniEConstr = struct
 
   let to_constr_gen sigma c =
     let saw_evar = ref false in
-    let evar_value ev =
-      let v = existential_opt_value sigma ev in
-      saw_evar := !saw_evar || Option.is_empty v;
-      v
+    let evar_value self (evk, args) =
+      let args' = SList.Smart.map self args in
+      let v = existential_opt_value sigma (evk, args') in
+      let () = saw_evar := !saw_evar || Option.is_empty v in
+      match v with
+      | None -> mkEvar (evk, args')
+      | Some c -> self c
     in
     let lsubst = universe_subst sigma in
     let univ_value l =

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -793,6 +793,7 @@ module MiniEConstr : sig
 
   val to_constr : ?abort_on_undefined_evars:bool -> evar_map -> t -> Constr.t
   val to_constr_opt : evar_map -> t -> Constr.t option
+  val nf_evar : evar_map -> t -> t
 
   val unsafe_to_constr : t -> Constr.t
   val unsafe_to_constr_array : t array -> Constr.t array

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -410,7 +410,11 @@ let nf_relevance uctx r = match r with
 let nf_universes uctx c =
   let lsubst = uctx.univ_variables in
   let nf_univ u = UnivFlex.normalize_univ_variable lsubst u in
-  UnivSubst.nf_evars_and_universes_opt_subst (fun _ -> None) (nf_qvar uctx) nf_univ c
+  let nf_evar self (evk, args) =
+    let args' = SList.Smart.map self args in
+    Constr.mkEvar (evk, args')
+  in
+  UnivSubst.nf_evars_and_universes_opt_subst nf_evar (nf_qvar uctx) nf_univ c
 
 type small_universe = USet | UProp | USProp
 

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -410,11 +410,13 @@ let nf_relevance uctx r = match r with
 let nf_universes uctx c =
   let lsubst = uctx.univ_variables in
   let nf_univ u = UnivFlex.normalize_univ_variable lsubst u in
-  let nf_evar self (evk, args) =
+  let rec self c = match Constr.kind c with
+  | Evar (evk, args) ->
     let args' = SList.Smart.map self args in
-    Constr.mkEvar (evk, args')
+    if args == args' then c else Constr.mkEvar (evk, args')
+  | _ -> UnivSubst.map_universes_opt_subst self (nf_qvar uctx) nf_univ c
   in
-  UnivSubst.nf_evars_and_universes_opt_subst nf_evar (nf_qvar uctx) nf_univ c
+  self c
 
 type small_universe = USet | UProp | USProp
 

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -410,13 +410,13 @@ let nf_relevance uctx r = match r with
 let nf_universes uctx c =
   let lsubst = uctx.univ_variables in
   let nf_univ u = UnivFlex.normalize_univ_variable lsubst u in
-  let rec self c = match Constr.kind c with
+  let rec self () c = match Constr.kind c with
   | Evar (evk, args) ->
-    let args' = SList.Smart.map self args in
+    let args' = SList.Smart.map (self ()) args in
     if args == args' then c else Constr.mkEvar (evk, args')
-  | _ -> UnivSubst.map_universes_opt_subst self (nf_qvar uctx) nf_univ c
+  | _ -> UnivSubst.map_universes_opt_subst_with_binders ignore self (nf_qvar uctx) nf_univ () c
   in
-  self c
+  self ()  c
 
 type small_universe = USet | UProp | USProp
 

--- a/engine/univSubst.ml
+++ b/engine/univSubst.ml
@@ -173,11 +173,12 @@ let nf_evars_and_universes_opt_subst fevar fqual funiv c =
   let flevel = fqual, level_subst_of funiv in
   let rec aux c =
     match kind c with
-    | Evar (evk, args) ->
-      let args' = SList.Smart.map aux args in
-      (match try fevar (evk, args') with Not_found -> None with
-      | None -> if args == args' then c else mkEvar (evk, args')
-      | Some c -> aux c)
+    | Evar (evk, args as ev) ->
+      let ans = fevar aux ev in
+      begin match Constr.kind ans with
+      | Evar (evk', args') when Evar.equal evk evk' && args == args' -> c
+      | _ -> ans
+      end
     | Const pu ->
       let pu' = subst_univs_fn_puniverses flevel pu in
         if pu' == pu then c else mkConstU pu'

--- a/engine/univSubst.ml
+++ b/engine/univSubst.ml
@@ -168,92 +168,85 @@ let nf_binder_annot frel na =
   if rel' == na.binder_relevance then na
   else { binder_name = na.binder_name; binder_relevance = rel' }
 
-let nf_evars_and_universes_opt_subst fevar fqual funiv c =
+let map_universes_opt_subst aux fqual funiv c =
   let frel = Sorts.relevance_subst_fn fqual in
   let flevel = fqual, level_subst_of funiv in
-  let rec aux c =
-    match kind c with
-    | Evar (evk, args as ev) ->
-      let ans = fevar aux ev in
-      begin match Constr.kind ans with
-      | Evar (evk', args') when Evar.equal evk evk' && args == args' -> c
-      | _ -> ans
-      end
-    | Const pu ->
-      let pu' = subst_univs_fn_puniverses flevel pu in
-        if pu' == pu then c else mkConstU pu'
-    | Ind pu ->
-      let pu' = subst_univs_fn_puniverses flevel pu in
-        if pu' == pu then c else mkIndU pu'
-    | Construct pu ->
-      let pu' = subst_univs_fn_puniverses flevel pu in
-        if pu' == pu then c else mkConstructU pu'
-    | Sort s ->
-      let s' = Sorts.subst_fn (fqual, subst_univs_universe funiv) s in
-      if s' == s then c else mkSort s'
-    | Case (ci,u,pms,(p,rel),iv,t,br) ->
-      let u' = Instance.subst_fn flevel u in
-      let rel' = frel rel in
-      let pms' = Array.Smart.map aux pms in
-      let p' = aux_ctx p in
-      let iv' = map_invert aux iv in
-      let t' = aux t in
-      let br' = Array.Smart.map aux_ctx br in
-      if rel' == rel && u' == u && pms' == pms && p' == p && iv' == iv && t' == t && br' == br then c
-      else mkCase (ci, u', pms', (p',rel'), iv', t', br')
-    | Array (u,elems,def,ty) ->
-      let u' = Instance.subst_fn flevel u in
-      let elems' = CArray.Smart.map aux elems in
-      let def' = aux def in
-      let ty' = aux ty in
-      if u == u' && elems == elems' && def == def' && ty == ty' then c
-      else mkArray (u',elems',def',ty')
-    | Prod (na, t, u) ->
-      let na' = nf_binder_annot frel na in
-      let t' = aux t in
-      let u' = aux u in
-      if na' == na && t' == t && u' == u then c
-      else mkProd (na', t', u')
-    | Lambda (na, t, u) ->
-      let na' = nf_binder_annot frel na in
-      let t' = aux t in
-      let u' = aux u in
-      if na' == na && t' == t && u' == u then c
-      else mkLambda (na', t', u')
-    | LetIn (na, b, t, u) ->
-      let na' = nf_binder_annot frel na in
-      let b' = aux b in
-      let t' = aux t in
-      let u' = aux u in
-      if na' == na && b' == b && t' == t && u' == u then c
-      else mkLetIn (na', b', t', u')
-    | Fix (i, rc) ->
-      let rc' = aux_rec rc in
-      if rc' == rc then c
-      else mkFix (i, rc')
-    | CoFix (i, rc) ->
-      let rc' = aux_rec rc in
-      if rc' == rc then c
-      else mkCoFix (i, rc')
-    | Proj (p, r, v) ->
-      let r' = frel r in
-      let v' = aux v in
-      if r' == r && v' == v then  c
-      else mkProj (p, r', v')
-    | _ -> Constr.map aux c
-  and aux_rec ((nas, tys, bds) as rc) =
+  let aux_rec ((nas, tys, bds) as rc) =
     let nas' = Array.Smart.map (fun na -> nf_binder_annot frel na) nas in
     let tys' = Array.Smart.map aux tys in
     let bds' = Array.Smart.map aux bds in
     if nas' == nas && tys' == tys && bds' == bds then rc
     else (nas', tys', bds')
-  and aux_ctx ((nas, c) as p) =
+  in
+  let aux_ctx ((nas, c) as p) =
     let nas' = Array.Smart.map (fun na -> nf_binder_annot frel na) nas in
     let c' = aux c in
     if nas' == nas && c' == c then p
     else (nas', c')
   in
-  aux c
+  match kind c with
+  | Const pu ->
+    let pu' = subst_univs_fn_puniverses flevel pu in
+    if pu' == pu then c else mkConstU pu'
+  | Ind pu ->
+    let pu' = subst_univs_fn_puniverses flevel pu in
+    if pu' == pu then c else mkIndU pu'
+  | Construct pu ->
+    let pu' = subst_univs_fn_puniverses flevel pu in
+    if pu' == pu then c else mkConstructU pu'
+  | Sort s ->
+    let s' = Sorts.subst_fn (fqual, subst_univs_universe funiv) s in
+    if s' == s then c else mkSort s'
+  | Case (ci,u,pms,(p,rel),iv,t,br) ->
+    let u' = Instance.subst_fn flevel u in
+    let rel' = frel rel in
+    let pms' = Array.Smart.map aux pms in
+    let p' = aux_ctx p in
+    let iv' = map_invert aux iv in
+    let t' = aux t in
+    let br' = Array.Smart.map aux_ctx br in
+    if rel' == rel && u' == u && pms' == pms && p' == p && iv' == iv && t' == t && br' == br then c
+    else mkCase (ci, u', pms', (p',rel'), iv', t', br')
+  | Array (u,elems,def,ty) ->
+    let u' = Instance.subst_fn flevel u in
+    let elems' = CArray.Smart.map aux elems in
+    let def' = aux def in
+    let ty' = aux ty in
+    if u == u' && elems == elems' && def == def' && ty == ty' then c
+    else mkArray (u',elems',def',ty')
+  | Prod (na, t, u) ->
+    let na' = nf_binder_annot frel na in
+    let t' = aux t in
+    let u' = aux u in
+    if na' == na && t' == t && u' == u then c
+    else mkProd (na', t', u')
+  | Lambda (na, t, u) ->
+    let na' = nf_binder_annot frel na in
+    let t' = aux t in
+    let u' = aux u in
+    if na' == na && t' == t && u' == u then c
+    else mkLambda (na', t', u')
+  | LetIn (na, b, t, u) ->
+    let na' = nf_binder_annot frel na in
+    let b' = aux b in
+    let t' = aux t in
+    let u' = aux u in
+    if na' == na && b' == b && t' == t && u' == u then c
+    else mkLetIn (na', b', t', u')
+  | Fix (i, rc) ->
+    let rc' = aux_rec rc in
+    if rc' == rc then c
+    else mkFix (i, rc')
+  | CoFix (i, rc) ->
+    let rc' = aux_rec rc in
+    if rc' == rc then c
+    else mkCoFix (i, rc')
+  | Proj (p, r, v) ->
+    let r' = frel r in
+    let v' = aux v in
+    if r' == r && v' == v then  c
+    else mkProj (p, r', v')
+  | _ -> Constr.map aux c
 
 let pr_universe_subst prl =
   let open Pp in

--- a/engine/univSubst.mli
+++ b/engine/univSubst.mli
@@ -30,11 +30,12 @@ val nf_binder_annot : (Sorts.relevance -> Sorts.relevance) ->
 
 (** Full universes substitutions into terms *)
 
-val map_universes_opt_subst
-  : (constr -> constr)
+val map_universes_opt_subst_with_binders
+  : ('a -> 'a)
+  -> ('a -> constr -> constr)
   -> quality_subst_fn
   -> universe_subst_fn
-  -> constr -> constr
+  -> 'a -> constr -> constr
 
 val subst_univs_universe : universe_subst_fn -> Universe.t -> Universe.t
 

--- a/engine/univSubst.mli
+++ b/engine/univSubst.mli
@@ -37,6 +37,13 @@ val map_universes_opt_subst_with_binders
   -> universe_subst_fn
   -> 'a -> constr -> constr
 
+val nf_evars_and_universes_opt_subst
+  : (existential -> constr option)
+  -> quality_subst_fn
+  -> universe_subst_fn
+  -> constr -> constr
+  [@@ocaml.deprecated "Use [UnivSubst.map_universes_opt_subst_with_binders]"]
+
 val subst_univs_universe : universe_subst_fn -> Universe.t -> Universe.t
 
 val pr_universe_subst : (Level.t -> Pp.t) -> universe_subst -> Pp.t

--- a/engine/univSubst.mli
+++ b/engine/univSubst.mli
@@ -30,8 +30,8 @@ val nf_binder_annot : (Sorts.relevance -> Sorts.relevance) ->
 
 (** Full universes substitutions into terms *)
 
-val nf_evars_and_universes_opt_subst
-  : ((constr -> constr) -> existential -> constr)
+val map_universes_opt_subst
+  : (constr -> constr)
   -> quality_subst_fn
   -> universe_subst_fn
   -> constr -> constr

--- a/engine/univSubst.mli
+++ b/engine/univSubst.mli
@@ -31,7 +31,7 @@ val nf_binder_annot : (Sorts.relevance -> Sorts.relevance) ->
 (** Full universes substitutions into terms *)
 
 val nf_evars_and_universes_opt_subst
-  : (existential -> constr option)
+  : ((constr -> constr) -> existential -> constr)
   -> quality_subst_fn
   -> universe_subst_fn
   -> constr -> constr


### PR DESCRIPTION
We reimplement Evd.to_constr, Evd.to_constr_opt and Evarutil.nf_evar in a more algorithmically efficient way. Instead of substituting evars on sight, we carry around a closure binding the evar instance being replaced. The old algorithm was intuitively a badly implemented call-by-value, the new one is a properly implemented call-by-need.

This is a somewhat different implementation of #15879.

This makes the Qed part of  #8237 reproduce below instantaneous (vs about 80s on master).
```coq
Goal True. Time (do 4000 pose proof I). exact I. Qed.
```