### PR TITLE
[bench] run on 4.14.1

### DIFF
--- a/dev/bench/bench.sh
+++ b/dev/bench/bench.sh
@@ -64,8 +64,8 @@ check_variable () {
 
 : "${coq_pr_number:=}"
 : "${coq_pr_comment_id:=}"
-: "${new_ocaml_version:=4.09.1}"
-: "${old_ocaml_version:=4.09.1}"
+: "${new_ocaml_version:=4.14.1}"
+: "${old_ocaml_version:=4.14.1}"
 : "${new_coq_repository:=$CI_REPOSITORY_URL}"
 : "${old_coq_repository:=$CI_REPOSITORY_URL}"
 : "${new_coq_opam_archive_git_uri:=https://github.com/coq/opam-coq-archive.git}"


### PR DESCRIPTION
This is because 4.09.1 is too old for elpi/coq-elpi/math-comp2