### PR TITLE
Forbid opening a functor with `Import`

### DIFF
--- a/test-suite/bugs/bug_18504.v
+++ b/test-suite/bugs/bug_18504.v
@@ -1,0 +1,12 @@
+Module Type SIG.
+End SIG.
+
+Fail Module Import A (S:SIG).
+
+Module Type F(X:SIG). End F.
+
+Fail Declare Module Import M : F.
+
+Declare Module M : F.
+
+Fail Module Import N := M.

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -776,6 +776,9 @@ let start_module_core id args res =
   mp, res_entry_o, mbids, sign, args
 
 let start_module export id args res =
+  let () = if Option.has_some export && not (CList.is_empty args)
+    then user_err Pp.(str "Cannot import functors.")
+  in
   let fs = Summary.Synterp.freeze_summaries () in
   let mp, res_entry_o, mbids, sign, args = start_module_core id args res in
   set_openmod_syntax_info { cur_mp = mp; cur_typ = res_entry_o; cur_mbids = mbids };


### PR DESCRIPTION
Fix #18504
