### PR TITLE
CoqIDE: A few fixes in file management

### DIFF
--- a/doc/changelog/10-coqide/18524-coqide.rst
+++ b/doc/changelog/10-coqide/18524-coqide.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Opening a file with drag and drop now works correctly (fixed regression)
+  (`#18524 <https://github.com/coq/coq/pull/18524>`_,
+  fixes `#3977 <https://github.com/coq/coq/issues/3977>`_,
+  by Sylvain Chiron).

--- a/ide/coqide/coqide.ml
+++ b/ide/coqide/coqide.ml
@@ -117,9 +117,12 @@ let make_coqtop_args fname =
         (* at initialization of coqtop (see #10286) *)
         (* If the file name is a valid identifier, use it as toplevel name; *)
         (* otherwise the default “Top” will be used. *)
-        match Unicode.ident_refutation (Filename.chop_extension (Filename.basename fname)) with
-        | Some _ -> args
-        | None -> "-topfile"::fname::args
+        try
+          match Unicode.ident_refutation (Filename.chop_extension (Filename.basename fname)) with
+          | Some _ -> args
+          | None -> "-topfile"::fname::args
+        with Invalid_argument _ ->
+          failwith "CoqIDE cannot open files which do not have an extension in their filename."
   in
   proj, args
 

--- a/ide/coqide/coqide.ml
+++ b/ide/coqide/coqide.ml
@@ -436,11 +436,11 @@ let saveall _ =
 
 let () = Coq.save_all := saveall
 
-let revert_all ?parent _ =
+let reload_all ?parent _ =
   List.iter
     (fun sn -> if sn.fileops#changed_on_disk then begin
         clear_all_bpts sn;
-        sn.fileops#revert ?parent ()
+        sn.fileops#reload ?parent ()
       end)
     notebook#pages
 
@@ -558,12 +558,12 @@ end
 
 (** Timers *)
 
-let reset_revert_timer () =
-  FileOps.revert_timer.kill ();
-  if global_auto_revert#get then
-    FileOps.revert_timer.run
-      ~ms:global_auto_revert_delay#get
-      ~callback:(fun () -> File.revert_all (); true)
+let reset_reload_timer () =
+  FileOps.reload_timer.kill ();
+  if global_auto_reload#get then
+    FileOps.reload_timer.run
+      ~ms:global_auto_reload_delay#get
+      ~callback:(fun () -> File.reload_all (); true)
 
 let reset_autosave_timer () =
   let autosave sn = try sn.fileops#auto_save with _ -> () in
@@ -600,7 +600,7 @@ let editor ?parent sn =
       File.save ();
       let f = Filename.quote f in
       let cmd = Util.subst_command_placeholder cmd_editor#get f in
-      run_command ignore (fun _ -> sn.fileops#revert ?parent ()) cmd
+      run_command ignore (fun _ -> sn.fileops#reload ?parent ()) cmd
 
 let editor ?parent = cb_on_current_term (editor ?parent)
 
@@ -1466,7 +1466,7 @@ let build_ui () =
           with e ->
             flash_info ("Editing preferences failed (" ^ Printexc.to_string e ^ ")")
         end;
-        reset_revert_timer ());
+        reset_reload_timer ());
   ];
 
   menu view_menu [
@@ -1768,7 +1768,7 @@ let make_scratch_buffer () =
 
 let main files =
   let w = build_ui () in
-  reset_revert_timer ();
+  reset_reload_timer ();
   reset_autosave_timer ();
   (match files with
     | [] -> make_scratch_buffer ()

--- a/ide/coqide/coqide.ml
+++ b/ide/coqide/coqide.ml
@@ -133,16 +133,15 @@ let load_file_cb : (string -> unit) ref = ref ignore
 let drop_received context ~x ~y data ~info ~time =
   if data#format = 8 then begin
     let files = Str.split (Str.regexp "\r?\n") data#data in
-    let path = Str.regexp "^file://\\(.*\\)$" in
     List.iter (fun f ->
-      if Str.string_match path f 0 then
-        !load_file_cb (Str.matched_group 1 f)
+      let _, f = Glib.Convert.filename_from_uri f in
+      !load_file_cb f;
     ) files;
     context#finish ~success:true ~del:false ~time
   end else context#finish ~success:false ~del:false ~time
 
 let drop_targets = [
-  { Gtk.target = "text/uri-list"; Gtk.flags = []; Gtk.info = 0}
+  { Gtk.target = "text/uri-list"; Gtk.flags = []; Gtk.info = 0 }
 ]
 
 let set_drag (w : GObj.drag_ops) =

--- a/ide/coqide/coqide.ml
+++ b/ide/coqide/coqide.ml
@@ -311,7 +311,7 @@ let select_and_save ?parent ~saveas ?filename sn =
       let ok = do_save f in
       confirm_save ok;
       if ok then begin
-        sn.tab_label#set_text (Filename.basename f);
+        sn.tab_label#set_text (Filename.remove_extension (Filename.basename f));
         sn.abs_file_name <- Some (Session.to_abs_file_name f);
         (* copying local breakpoints to other sessions seems pointless
            for a "save as" because the saved file needs to be compiled
@@ -347,7 +347,7 @@ let check_quit ?parent saveall =
       ~default:0
       ~icon:(warn_image ())#coerce
       ?parent
-      "There are unsaved buffers"
+      "There are unsaved buffers."
     in
     match answ with
       | 1 -> saveall ()

--- a/ide/coqide/fileOps.mli
+++ b/ide/coqide/fileOps.mli
@@ -8,7 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-val revert_timer : Ideutils.timer
+val reload_timer : Ideutils.timer
 val autosave_timer : Ideutils.timer
 
 class type ops =
@@ -16,7 +16,7 @@ object
   method filename : string option
   method update_stats : unit
   method changed_on_disk : bool
-  method revert : ?parent:GWindow.window -> unit -> unit
+  method reload : ?parent:GWindow.window -> unit -> unit
   method auto_save : unit
   method save : string -> bool
   method saveas : ?parent:GWindow.window -> string -> bool

--- a/ide/coqide/preferences.ml
+++ b/ide/coqide/preferences.ml
@@ -965,12 +965,12 @@ let configure ?(apply=(fun () -> ())) parent =
       (string_of_int window_width#get)
   in
 
-  let global_auto_reload = pbool "Enable global auto reload" global_auto_reload in
+  let global_auto_reload = pbool "Check for modified files" global_auto_reload in
   let global_auto_reload_delay =
     string
     ~f:(fun s -> global_auto_reload_delay#set
           (try int_of_string s with _ -> 10000))
-      "Global auto reload delay (ms)"
+      "Modified file check interval (ms)"
       (string_of_int global_auto_reload_delay#get)
   in
 

--- a/ide/coqide/preferences.ml
+++ b/ide/coqide/preferences.ml
@@ -273,11 +273,11 @@ let source_language =
 let source_style =
   new preference ~name:["source_style"] ~init:"coq_style" ~repr:Repr.(string)
 
-let global_auto_revert =
-  new preference ~name:["global_auto_revert"] ~init:false ~repr:Repr.(bool)
+let global_auto_reload =
+  new preference ~name:["global_auto_reload"] ~init:false ~repr:Repr.(bool)
 
-let global_auto_revert_delay =
-  new preference ~name:["global_auto_revert_delay"] ~init:10000 ~repr:Repr.(int)
+let global_auto_reload_delay =
+  new preference ~name:["global_auto_reload_delay"] ~init:10000 ~repr:Repr.(int)
 
 let auto_save =
   new preference ~name:["auto_save"] ~init:true ~repr:Repr.(bool)
@@ -965,13 +965,13 @@ let configure ?(apply=(fun () -> ())) parent =
       (string_of_int window_width#get)
   in
 
-  let global_auto_revert = pbool "Enable global auto revert" global_auto_revert in
-  let global_auto_revert_delay =
+  let global_auto_reload = pbool "Enable global auto reload" global_auto_reload in
+  let global_auto_reload_delay =
     string
-    ~f:(fun s -> global_auto_revert_delay#set
+    ~f:(fun s -> global_auto_reload_delay#set
           (try int_of_string s with _ -> 10000))
-      "Global auto revert delay (ms)"
-      (string_of_int global_auto_revert_delay#get)
+      "Global auto reload delay (ms)"
+      (string_of_int global_auto_reload_delay#get)
   in
 
   let auto_save = pbool "Enable auto save" auto_save in
@@ -1128,7 +1128,7 @@ let configure ?(apply=(fun () -> ())) parent =
              [config_tags]);
      Section("Editor", Some `EDIT, [config_editor]);
      Section("Files", Some `DIRECTORY,
-             [global_auto_revert;global_auto_revert_delay;
+             [global_auto_reload;global_auto_reload_delay;
               auto_save; auto_save_delay; (* auto_save_name*)
               encodings; line_ending;
              ]);

--- a/ide/coqide/preferences.mli
+++ b/ide/coqide/preferences.mli
@@ -58,8 +58,8 @@ val cmd_coqmakefile : string preference
 val cmd_coqdoc : string preference
 val source_language : string preference
 val source_style : string preference
-val global_auto_revert : bool preference
-val global_auto_revert_delay : int preference
+val global_auto_reload : bool preference
+val global_auto_reload_delay : int preference
 val auto_save : bool preference
 val auto_save_delay : int preference
 val auto_save_name : (string * string) preference


### PR DESCRIPTION
- More explicit message when trying in vain to open a file without extension
- Correctly load dropped files, using `filename_from_uri` (instead of a custom regexp which did not handle well all cases)
- Remove extension in tab label (as usual) when changing a file’s location
- Say “reload” instead of “revert” for files

Fixes #3977

- [x] Added **changelog**.