### PR TITLE
Adhoc fix to nsatz segfault when running emulated x86-compiled Coq on MacOS arm

### DIFF
--- a/plugins/nsatz/polynom.ml
+++ b/plugins/nsatz/polynom.ml
@@ -558,6 +558,13 @@ let pseudo_div p q x =
             (!r,c,!delta, !s)
         )
 
+(* Hack to prevent segfault when running x86-compiled Coq on MacOS arm *)
+(* the line below has the effect to modify how the x86 code is aligned,  *)
+(* with the effect to prevent the bug (a just-in-time emulation issue    *)
+(* with page loading is suspected in Rosetta 2) *)
+
+let _f x = x
+
 (* gcd with subresultants *)
 
 let rec pgcdP p q =


### PR DESCRIPTION
After discussion with @MSoegtropIMC, and to avoid having to document the potential segfault, we propose to add the attached patch that prevent nsatz segfaults when running emulated x86-compiled Coq on MacOS arm (see [Zulip discussion](https://coq.zulipchat.com/#narrow/stream/237656-Coq-devs-.26-plugin-devs/topic/nsatz.20sefgault)).

The patch looks surrealistic but nevertheless works in practice: it is a cheap way to prevent problems for potential users running emulated x86-compiled Coq on MacOS.

