### PR TITLE
Deprecate NZDomain

### DIFF
--- a/doc/changelog/11-standard-library/18539-deprecate_NZDomain.rst
+++ b/doc/changelog/11-standard-library/18539-deprecate_NZDomain.rst
@@ -1,0 +1,4 @@
+- **Deprecated:**
+  The library file ``Coq.Numbers.NatInt.NZDomain`` is deprecated.
+  (`#18539 <https://github.com/coq/coq/pull/18539>`_,
+  by Pierre Rousselin).

--- a/doc/stdlib/hidden-files
+++ b/doc/stdlib/hidden-files
@@ -100,3 +100,4 @@ theories/Numbers/Natural/Binary/NBinary.v
 theories/Numbers/Integer/Binary/ZBinary.v
 theories/Numbers/Integer/NatPairs/ZNatPairs.v
 theories/Numbers/NatInt/NZProperties.v
+theories/Numbers/NatInt/NZDomain.v

--- a/doc/stdlib/index-list.html.template
+++ b/doc/stdlib/index-list.html.template
@@ -253,7 +253,6 @@ through the <tt>Require Import</tt> command.</p>
     theories/Numbers/NatInt/NZDiv.v
     theories/Numbers/NatInt/NZMulOrder.v
     theories/Numbers/NatInt/NZOrder.v
-    theories/Numbers/NatInt/NZDomain.v
     theories/Numbers/NatInt/NZParity.v
     theories/Numbers/NatInt/NZPow.v
     theories/Numbers/NatInt/NZSqrt.v

--- a/theories/Numbers/NatInt/NZAxioms.v
+++ b/theories/Numbers/NatInt/NZAxioms.v
@@ -87,9 +87,23 @@ Module Type
 
 (** ** Axiomatization of a domain with [zero], [succ], [pred] and a bi-directional induction principle. *)
 
+(* NB: This was Pierre Letouzey's conclusion in the (now deprecated) NZDomain
+   file. *)
 (** We require [P (S n) = n] but not the other way around, since this domain
     is meant to be either N or Z. In fact it can be a few other things,
-    for instance [Z/nZ] (See file [NZDomain] for a study of that).
+
+    S is always injective, P is always surjective  (thanks to [pred_succ]).
+
+    I) If S is not surjective, we have an initial point, which is unique.
+       This bottom is below zero: we have N shifted (or not) to the left.
+       P cannot be injective: P init = P (S (P init)).
+       (P init) can be arbitrary.
+
+    II) If S is surjective, we have [forall n, S (P n) = n], S and P are
+       bijective and reciprocal.
+
+       IIa) if [exists k<>O, 0 == S^k 0], then we have a cyclic structure Z/nZ
+       IIb) otherwise, we have Z
 *)
 
 (** The [Typ] module type in [Equalities] only has a parameter [t : Type]. *)

--- a/theories/Numbers/NatInt/NZDomain.v
+++ b/theories/Numbers/NatInt/NZDomain.v
@@ -8,6 +8,8 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+Attributes deprecated(since="8.20").
+
 Require Export NumPrelude NZAxioms.
 Require Import NZBase NZOrder NZAddOrder PeanoNat.
 


### PR DESCRIPTION
The file NZDomain, while informative and well written, is of little use to the end user and makes NatInt depend on PeanoNat.

- [x] Added **changelog**.
- [x] Added / updated **documentation**.