### PR TITLE
small doc improvements around open_constr

### DIFF
--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -2568,14 +2568,7 @@ Tactic notations allow customizing the syntax of tactics.
 
    The nonterminals that can specified in the tactic notation are:
 
-     .. todo uconstr represents a type with holes.  At the moment uconstr doesn't
-        appear in the documented grammar.  Maybe worth ressurecting with a better name,
-        maybe "open_term"?
-        see https://github.com/coq/coq/pull/11718#discussion_r413721234
-
-     .. todo 'open_constr' appears to be another possible value based on the
-        the message from "Tactic Notation open_constr := idtac".
-        Also (at least) "ref", "string", "preident", "int" and "ssrpatternarg".
+     .. Some missing entries: "ref", "string", "preident", "int" and "ssrpatternarg".
         (from reading .v files).
         Looks like any string passed to "make0" in the code is valid.  But do
         we want to support all these?

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -2619,6 +2619,11 @@ Tactic notations allow customizing the syntax of tactics.
         - a term
         - :tacn:`exact`
 
+      * - ``open_constr``
+        - :token:`one_term`
+        - a term where all `_` which are not resolved by unification become evars; typeclass resolution is not triggered
+        - tacn:`epose`, tacn:`eapply`
+
       * - ``uconstr``
         - :token:`one_term`
         - an untyped term

--- a/user-contrib/Ltac2/Ltac1.v
+++ b/user-contrib/Ltac2/Ltac1.v
@@ -38,7 +38,9 @@ Ltac2 @ external apply : t -> t list -> (t -> unit) -> unit := "coq-core.plugins
 (** Conversion functions *)
 
 Ltac2 @ external of_constr : constr -> t := "coq-core.plugins.ltac2_ltac1" "ltac1_of_constr".
+(** Converts an Ltac2 constr into an Ltac1 value. *)
 Ltac2 @ external to_constr : t -> constr option := "coq-core.plugins.ltac2_ltac1" "ltac1_to_constr".
+(** Converts an Ltac1 constr (which includes terms created via open_constr) into an Ltac2 value. *)
 
 Ltac2 @ external of_ident : ident -> t := "coq-core.plugins.ltac2_ltac1" "ltac1_of_ident".
 Ltac2 @ external to_ident : t -> ident option := "coq-core.plugins.ltac2_ltac1" "ltac1_to_ident".


### PR DESCRIPTION
I wasn't sure whether there is a tactic that uses `open_constr` -- is there?