### PR TITLE
Remove dune file in test-suite/unit-tests/parsing

### DIFF
--- a/test-suite/unit-tests/parsing/dune
+++ b/test-suite/unit-tests/parsing/dune
@@ -1,5 +1,0 @@
-(executable
- (name resumption)
- (modules resumption)
- (libraries coq-core.vernac)
- (link_flags -linkall))


### PR DESCRIPTION
For some reason when running on my machine this file breaks `make test-suite` from toplevel (ie `dune runtest`) but
`test-suite:base:dev` in CI which is supposed to do the same thing was not broken.
