### PR TITLE
Deprecate ZDivEucl and Zeuclid

### DIFF
--- a/doc/changelog/11-standard-library/18544-deprecate_Zeuclid.rst
+++ b/doc/changelog/11-standard-library/18544-deprecate_Zeuclid.rst
@@ -1,0 +1,5 @@
+- **Deprecated:**
+  The library files ``Coq.Numbers.Integers.Abstract.ZDivEucl``
+  and ``Coq.ZArith.Zeuclid`` are deprecated.
+  (`#18544 <https://github.com/coq/coq/pull/18544>`_,
+  by Pierre Rousselin).

--- a/doc/stdlib/hidden-files
+++ b/doc/stdlib/hidden-files
@@ -101,3 +101,5 @@ theories/Numbers/Integer/Binary/ZBinary.v
 theories/Numbers/Integer/NatPairs/ZNatPairs.v
 theories/Numbers/NatInt/NZProperties.v
 theories/Numbers/NatInt/NZDomain.v
+theories/Numbers/Integer/Abstract/ZDivEucl.v
+theories/ZArith/Zeuclid.v

--- a/doc/stdlib/index-list.html.template
+++ b/doc/stdlib/index-list.html.template
@@ -182,7 +182,6 @@ through the <tt>Require Import</tt> command.</p>
     theories/ZArith/Zpower.v
     theories/ZArith/Zdiv.v
     theories/ZArith/Zquot.v
-    theories/ZArith/Zeuclid.v
     (theories/ZArith/ZArith.v)
     theories/ZArith/Zgcd_alt.v
     theories/ZArith/Zwf.v
@@ -324,7 +323,6 @@ through the <tt>Require Import</tt> command.</p>
     theories/Numbers/Integer/Abstract/ZLcm.v
     theories/Numbers/Integer/Abstract/ZBits.v
     theories/Numbers/Integer/Abstract/ZProperties.v
-    theories/Numbers/Integer/Abstract/ZDivEucl.v
     theories/Numbers/Integer/Abstract/ZDivFloor.v
     theories/Numbers/Integer/Abstract/ZDivTrunc.v
     </dd>

--- a/theories/Numbers/Integer/Abstract/ZDivEucl.v
+++ b/theories/Numbers/Integer/Abstract/ZDivEucl.v
@@ -8,7 +8,10 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-Require Import ZAxioms ZMulOrder ZSgnAbs NZDiv.
+Attributes deprecated(since="8.20", note="Use ZDivTrunc or ZDivFloor instead.").
+
+From Coq.Numbers.Integer.Abstract Require Import ZAxioms ZMulOrder ZSgnAbs.
+From Coq.Numbers.NatInt Require Import NZDiv.
 
 (** * Euclidean Division for integers, Euclid convention
 

--- a/theories/ZArith/Zeuclid.v
+++ b/theories/ZArith/Zeuclid.v
@@ -8,7 +8,16 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-Require Import Morphisms BinInt ZDivEucl.
+Attributes deprecated(since="8.20",
+  note="Use floor division or truncation division in BinInt instead.").
+
+From Coq.Classes Require Import Morphisms.
+From Coq.ZArith Require Import BinInt.
+
+#[local]
+Set Warnings "-deprecated-library-file".
+From Coq.Numbers.Integer.Abstract Require Import ZDivEucl.
+
 Local Open Scope Z_scope.
 
 (** * Definitions of division for binary integers, Euclid convention. *)


### PR DESCRIPTION
Rationale: these files are not used elsewhere in the standard library. They define and study a third convention for euclidean division between integers numbers where the remainder is always nonnegative.

They are well written and interesting but probably more confusing than useful for the end user.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.