### PR TITLE
Move [Names.Evaluable] to pretyping + copy in the kernel.

### DIFF
--- a/dev/ci/user-overlays/18546-rlepigre-brevaluable_refactoring.sh
+++ b/dev/ci/user-overlays/18546-rlepigre-brevaluable_refactoring.sh
@@ -1,0 +1,9 @@
+overlay elpi https://github.com/rlepigre/coq-elpi br/evaluable_refactoring 18546
+
+overlay equations https://github.com/rlepigre/Coq-Equations br/evaluable_refactoring 18546
+
+overlay lean_importer https://github.com/rlepigre/coq-lean-import br/evaluable_refactoring 18546
+
+overlay serapi https://github.com/rlepigre/coq-serapi br/evaluable_refactoring 18546
+
+overlay waterproof https://github.com/rlepigre/coq-waterproof br/evaluable_refactoring 18546

--- a/kernel/conv_oracle.mli
+++ b/kernel/conv_oracle.mli
@@ -10,6 +10,12 @@
 
 open Names
 
+(** Evaluable references (whose transparency can be controlled). *)
+type evaluable =
+  | EvalVarRef of Id.t
+  | EvalConstRef of Constant.t
+  | EvalProjectionRef of Projection.Repr.t
+
 type oracle
 
 val empty : oracle
@@ -19,7 +25,7 @@ val empty : oracle
    Note: the oracle does not introduce incompleteness, it only
    tries to postpone unfolding of "opaque" constants. *)
 val oracle_order :
-  oracle -> bool -> Evaluable.t option -> Evaluable.t option -> bool
+  oracle -> bool -> evaluable option -> evaluable option -> bool
 
 (** Priority for the expansion of constant in the conversion test.
  * Higher levels means that the expansion is less prioritary.
@@ -33,13 +39,13 @@ val transparent : level
 (** Check whether a level is transparent *)
 val is_transparent : level -> bool
 
-val get_strategy : oracle -> Evaluable.t -> level
+val get_strategy : oracle -> evaluable -> level
 
 (** Sets the level of a constant.
  * Level of RelKey constant cannot be set. *)
-val set_strategy : oracle -> Evaluable.t -> level -> oracle
+val set_strategy : oracle -> evaluable -> level -> oracle
 
 (** Fold over the non-transparent levels of the oracle. Order unspecified. *)
-val fold_strategy : (Evaluable.t -> level -> 'a -> 'a) -> oracle -> 'a -> 'a
+val fold_strategy : (evaluable -> level -> 'a -> 'a) -> oracle -> 'a -> 'a
 
 val get_transp_state : oracle -> TransparentState.t

--- a/kernel/conversion.ml
+++ b/kernel/conversion.ml
@@ -444,8 +444,8 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
           let oracle = CClosure.oracle_of_infos infos.cnv_inf in
           let to_er fl =
             match fl with
-            | ConstKey (c, _) -> Some (Evaluable.EvalConstRef c)
-            | VarKey id -> Some (Evaluable.EvalVarRef id)
+            | ConstKey (c, _) -> Some (Conv_oracle.EvalConstRef c)
+            | VarKey id -> Some (Conv_oracle.EvalVarRef id)
             | RelKey _ -> None
           in
           if Conv_oracle.oracle_order oracle l2r (to_er fl1) (to_er fl2) then

--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -1147,28 +1147,3 @@ type lname = Name.t CAst.t
 type lstring = string CAst.t
 
 let lident_eq = CAst.eq Id.equal
-
-(** Evaluable references (whose transparency can be controlled) *)
-
-module Evaluable = struct
-  type t =
-    | EvalVarRef of Id.t
-    | EvalConstRef of Constant.t
-    | EvalProjectionRef of Projection.Repr.t
-
-  let map fvar fcst fprj = function
-    | EvalVarRef v -> EvalVarRef (fvar v)
-    | EvalConstRef c -> EvalConstRef (fcst c)
-    | EvalProjectionRef p -> EvalProjectionRef (fprj p)
-
-  let equal er1 er2 =
-    er1 == er2 ||
-    match er1, er2 with
-    | EvalVarRef v1, EvalVarRef v2 ->
-        Id.equal v1 v2
-    | EvalConstRef c1, EvalConstRef c2 ->
-        Constant.CanOrd.equal c1 c2
-    | EvalProjectionRef p1, EvalProjectionRef p2 ->
-        Projection.Repr.CanOrd.equal p1 p2
-    | _ -> false
-end

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -697,17 +697,3 @@ type lname = Name.t CAst.t
 type lstring = string CAst.t
 
 val lident_eq : lident -> lident -> bool
-
-(** Evaluable references (whose transparency can be controlled) *)
-
-module Evaluable : sig
-  type t =
-    | EvalVarRef of Id.t
-    | EvalConstRef of Constant.t
-    | EvalProjectionRef of Projection.Repr.t
-
-  val map : (Id.t -> Id.t) -> (Constant.t -> Constant.t) ->
-    (Projection.Repr.t -> Projection.Repr.t) -> t -> t
-
-  val equal : t -> t -> bool
-end

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -274,4 +274,4 @@ val mind_of_delta_kn_senv : safe_environment -> KerName.t -> MutInd.t
 val register_inline : Constant.t -> safe_transformer0
 val register_inductive : inductive -> 'a CPrimitives.prim_ind -> safe_transformer0
 
-val set_strategy : Names.Evaluable.t -> Conv_oracle.level -> safe_transformer0
+val set_strategy : Conv_oracle.evaluable -> Conv_oracle.level -> safe_transformer0

--- a/library/global.mli
+++ b/library/global.mli
@@ -169,7 +169,7 @@ val register_inductive : inductive -> 'a CPrimitives.prim_ind -> unit
 
 (** {6 Oracle } *)
 
-val set_strategy : Evaluable.t -> Conv_oracle.level -> unit
+val set_strategy : Conv_oracle.evaluable -> Conv_oracle.level -> unit
 
 (** {6 Conversion settings } *)
 

--- a/plugins/ltac/pptactic.mli
+++ b/plugins/ltac/pptactic.mli
@@ -106,7 +106,7 @@ val pr_may_eval :
 
 val pr_and_short_name : ('a -> Pp.t) -> 'a Genredexpr.and_short_name -> Pp.t
 
-val pr_evaluable_reference_env : env -> Names.Evaluable.t -> Pp.t
+val pr_evaluable_reference_env : env -> Evaluable.t -> Pp.t
 
 val pr_quantified_hypothesis : quantified_hypothesis -> Pp.t
 

--- a/pretyping/evaluable.ml
+++ b/pretyping/evaluable.ml
@@ -1,0 +1,40 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** Evaluable references (whose transparency can be controlled) *)
+
+open Names
+
+type t =
+  | EvalVarRef of Id.t
+  | EvalConstRef of Constant.t
+  | EvalProjectionRef of Projection.Repr.t
+
+let map fvar fcst fprj = function
+  | EvalVarRef v -> EvalVarRef (fvar v)
+  | EvalConstRef c -> EvalConstRef (fcst c)
+  | EvalProjectionRef p -> EvalProjectionRef (fprj p)
+
+let equal er1 er2 =
+  er1 == er2 ||
+  match er1, er2 with
+  | EvalVarRef v1, EvalVarRef v2 ->
+      Id.equal v1 v2
+  | EvalConstRef c1, EvalConstRef c2 ->
+      Constant.CanOrd.equal c1 c2
+  | EvalProjectionRef p1, EvalProjectionRef p2 ->
+      Projection.Repr.CanOrd.equal p1 p2
+  | _ -> false
+
+let to_kevaluable : t -> Conv_oracle.evaluable = fun er ->
+  match er with
+  | EvalVarRef v -> Conv_oracle.EvalVarRef v
+  | EvalConstRef c -> Conv_oracle.EvalConstRef c
+  | EvalProjectionRef p -> Conv_oracle.EvalProjectionRef p

--- a/pretyping/evaluable.mli
+++ b/pretyping/evaluable.mli
@@ -1,0 +1,25 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** Evaluable references (whose transparency can be controlled) *)
+
+open Names
+
+type t =
+  | EvalVarRef of Id.t
+  | EvalConstRef of Constant.t
+  | EvalProjectionRef of Projection.Repr.t
+
+val map : (Id.t -> Id.t) -> (Constant.t -> Constant.t) ->
+  (Projection.Repr.t -> Projection.Repr.t) -> t -> t
+
+val equal : t -> t -> bool
+
+val to_kevaluable : t -> Conv_oracle.evaluable

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1132,7 +1132,7 @@ let nf_all env sigma =
 (********************************************************************)
 
 let is_transparent e k =
-  match Conv_oracle.get_strategy (Environ.oracle e) k with
+  match Conv_oracle.get_strategy (Environ.oracle e) (Evaluable.to_kevaluable k) with
   | Conv_oracle.Opaque -> false
   | _ -> true
 

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -569,13 +569,13 @@ let key_of env sigma b flags f =
 
 
 let translate_key = function
-  | ConstKey (cst,u) -> Some (Evaluable.EvalConstRef cst)
-  | VarKey id -> Some (Evaluable.EvalVarRef id)
+  | ConstKey (cst,u) -> Some (Conv_oracle.EvalConstRef cst)
+  | VarKey id -> Some (Conv_oracle.EvalVarRef id)
   | RelKey _ -> None
 
 let translate_key = function
   | IsKey k -> translate_key k
-  | IsProj (p, _, _) -> Some (Evaluable.EvalProjectionRef (Projection.repr p))
+  | IsProj (p, _, _) -> Some (Conv_oracle.EvalProjectionRef (Projection.repr p))
 
 let oracle_order env cf1 cf2 =
   match cf1 with

--- a/tactics/genredexpr.mli
+++ b/tactics/genredexpr.mli
@@ -75,6 +75,6 @@ type 'a and_short_name = 'a * Names.lident option
 
 type g_trm = Genintern.glob_constr_and_expr
 type g_pat = Genintern.glob_constr_pattern_and_expr
-type g_cst = Names.Evaluable.t and_short_name Locus.or_var
+type g_cst = Evaluable.t and_short_name Locus.or_var
 
 type glob_red_expr = (g_trm, g_cst, g_pat) red_expr_gen

--- a/tactics/redexpr.ml
+++ b/tactics/redexpr.ml
@@ -56,7 +56,7 @@ let { Goptions.get = simplIsCbn } =
     ()
 
 let set_strategy_one ref l =
-  Global.set_strategy ref l;
+  Global.set_strategy (Evaluable.to_kevaluable ref) l;
   match ref, l with
   | Evaluable.EvalConstRef sp, Conv_oracle.Opaque -> ()
   | Evaluable.EvalConstRef sp, _ ->

--- a/tactics/redexpr.mli
+++ b/tactics/redexpr.mli
@@ -17,7 +17,7 @@ open Genredexpr
 open Reductionops
 open Locus
 
-type red_expr = (constr, Names.Evaluable.t, constr_pattern) red_expr_gen
+type red_expr = (constr, Evaluable.t, constr_pattern) red_expr_gen
 
 type red_expr_val
 
@@ -48,7 +48,7 @@ val declare_red_expr : bool -> string -> red_expr -> unit
    true, the effect is non-synchronous (i.e. it does not survive
    section and module closure). *)
 val set_strategy :
-  bool -> (Conv_oracle.level * Names.Evaluable.t list) list -> unit
+  bool -> (Conv_oracle.level * Evaluable.t list) list -> unit
 
 (** call by value normalisation function using the virtual machine *)
 val cbv_vm : reduction_function
@@ -62,6 +62,6 @@ open Libnames
 
 val wit_red_expr :
   ((constr_expr,qualid or_by_notation,constr_expr) red_expr_gen,
-   (Genintern.glob_constr_and_expr,Names.Evaluable.t and_short_name Locus.or_var,Genintern.glob_constr_pattern_and_expr) red_expr_gen,
-   (EConstr.t,Names.Evaluable.t,Pattern.constr_pattern) red_expr_gen)
+   (Genintern.glob_constr_and_expr,Evaluable.t and_short_name Locus.or_var,Genintern.glob_constr_pattern_and_expr) red_expr_gen,
+   (EConstr.t,Evaluable.t,Pattern.constr_pattern) red_expr_gen)
     Genarg.genarg_type

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -3453,7 +3453,7 @@ let with_set_strategy lvl_ql k =
   tclWRAPFINALLY
     (Proofview.tclENV >>= fun env ->
      let orig_kl = List.map (fun (_lvl, k) ->
-         (Conv_oracle.get_strategy (Environ.oracle env) k, k))
+         (Conv_oracle.get_strategy (Environ.oracle env) (Evaluable.to_kevaluable k), k))
          kl in
      (* Because the global env might be desynchronized from the
         proof-local env, we need to update the global env to have this
@@ -3461,27 +3461,27 @@ let with_set_strategy lvl_ql k =
         TODO: When abstract no longer depends on Global, delete this
         let orig_kl_global = ... in *)
      let orig_kl_global = List.map (fun (_lvl, k) ->
-         (Conv_oracle.get_strategy (Environ.oracle (Global.env ())) k, k))
+         (Conv_oracle.get_strategy (Environ.oracle (Global.env ())) (Evaluable.to_kevaluable k), k))
          kl in
      let env = List.fold_left (fun env (lvl, k) ->
          Environ.set_oracle env
-           (Conv_oracle.set_strategy (Environ.oracle env) k lvl)) env kl in
+           (Conv_oracle.set_strategy (Environ.oracle env) (Evaluable.to_kevaluable k) lvl)) env kl in
      Proofview.Unsafe.tclSETENV env <*>
      (* TODO: When abstract no longer depends on Global, remove this
         [Proofview.tclLIFT] block *)
      Proofview.tclLIFT (Proofview.NonLogical.make (fun () ->
-         List.iter (fun (lvl, k) -> Global.set_strategy k lvl) kl)) <*>
+         List.iter (fun (lvl, k) -> Global.set_strategy (Evaluable.to_kevaluable k) lvl) kl)) <*>
      Proofview.tclUNIT (orig_kl, orig_kl_global))
     k
     (fun (orig_kl, orig_kl_global) ->
        (* TODO: When abstract no longer depends on Global, remove this
           [Proofview.tclLIFT] block *)
        Proofview.tclLIFT (Proofview.NonLogical.make (fun () ->
-           List.iter (fun (lvl, k) -> Global.set_strategy k lvl) orig_kl_global)) <*>
+           List.iter (fun (lvl, k) -> Global.set_strategy (Evaluable.to_kevaluable k) lvl) orig_kl_global)) <*>
        Proofview.tclENV >>= fun env ->
        let env = List.fold_left (fun env (lvl, k) ->
            Environ.set_oracle env
-             (Conv_oracle.set_strategy (Environ.oracle env) k lvl)) env orig_kl in
+             (Conv_oracle.set_strategy (Environ.oracle env) (Evaluable.to_kevaluable k) lvl)) env orig_kl in
        Proofview.Unsafe.tclSETENV env)
 
 module Simple = struct

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -155,7 +155,7 @@ let opacity env =
   function
   | GlobRef.VarRef v when NamedDecl.is_local_def (Environ.lookup_named v env) ->
       Some(TransparentMaybeOpacified
-        (Conv_oracle.get_strategy (Environ.oracle env) (Evaluable.EvalVarRef v)))
+        (Conv_oracle.get_strategy (Environ.oracle env) (Conv_oracle.EvalVarRef v)))
   | GlobRef.ConstRef cst ->
       let cb = Environ.lookup_constant cst env in
       (match cb.const_body with
@@ -163,7 +163,7 @@ let opacity env =
         | OpaqueDef _ -> Some FullyOpaque
         | Def _ -> Some
           (TransparentMaybeOpacified
-            (Conv_oracle.get_strategy (Environ.oracle env) (Evaluable.EvalConstRef cst))))
+            (Conv_oracle.get_strategy (Environ.oracle env) (Conv_oracle.EvalConstRef cst))))
   | _ -> None
 
 let print_opacity env ref =

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -279,9 +279,9 @@ let print_strategy r =
   match r with
   | None ->
     let fold key lvl (vacc, cacc, pacc) = match key with
-    | Evaluable.EvalVarRef id -> ((GlobRef.VarRef id, lvl) :: vacc, cacc, pacc)
-    | Evaluable.EvalConstRef cst -> (vacc, (GlobRef.ConstRef cst, lvl) :: cacc, pacc)
-    | Evaluable.EvalProjectionRef p -> (vacc, cacc, (GlobRef.ConstRef (Projection.Repr.constant p), lvl) :: pacc)
+    | Conv_oracle.EvalVarRef id -> ((GlobRef.VarRef id, lvl) :: vacc, cacc, pacc)
+    | Conv_oracle.EvalConstRef cst -> (vacc, (GlobRef.ConstRef cst, lvl) :: cacc, pacc)
+    | Conv_oracle.EvalProjectionRef p -> (vacc, cacc, (GlobRef.ConstRef (Projection.Repr.constant p), lvl) :: pacc)
     in
     let var_lvl, cst_lvl, prj_lvl = fold_strategy fold oracle ([], [], []) in
     let var_msg =
@@ -307,7 +307,7 @@ let print_strategy r =
     | ConstRef cst -> Evaluable.EvalConstRef cst
     | IndRef _ | ConstructRef _ -> user_err Pp.(str "The reference is not unfoldable.")
     in
-    let lvl = get_strategy oracle key in
+    let lvl = get_strategy oracle (Evaluable.to_kevaluable key) in
     pr_strategy (r, lvl)
 
 let print_registered () =


### PR DESCRIPTION
This is a follow-up to https://github.com/coq/coq/pull/18327, addressing [this comment](https://github.com/coq/coq/pull/18327#discussion_r1453162814) by @ppedrot.

It would probably make sense to move the kernel version of the `Evaluable.t` type to `kernel/conv_oracle.mli`, since it is its only client in the kernel (sometimes indirectly, but that's fine).

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/588
- https://github.com/mattam82/Coq-Equations/pull/582
- https://github.com/SkySkimmer/coq-lean-import/pull/16
- https://github.com/ejgallego/coq-serapi/pull/388
- https://github.com/impermeable/coq-waterproof/pull/48