### PR TITLE
[CI] Fix after move of Analysis to MC2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -750,19 +750,19 @@ library:ci-finmap:
   extends: .ci-template-flambda
   needs:
   - build:edge+flambda
-  - library:ci-mathcomp_1
+  - library:ci-mathcomp
 
 library:ci-bigenough:
   extends: .ci-template-flambda
   needs:
   - build:edge+flambda
-  - library:ci-mathcomp_1
+  - library:ci-mathcomp
 
 library:ci-analysis:
   extends: .ci-template-flambda
   needs:
   - build:edge+flambda
-  - library:ci-mathcomp_1
+  - library:ci-mathcomp
   - library:ci-finmap
   - library:ci-bigenough
   - plugin:ci-elpi_hb  # for Hierarchy Builder

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -135,8 +135,8 @@ ci-fcsl_pcm: ci-mathcomp_1
 ci-mczify: ci-mathcomp
 ci-mathcomp_test: ci-mathcomp
 ci-mathcomp_word: ci-mathcomp_1
-ci-finmap: ci-mathcomp_1
-ci-bigenough: ci-mathcomp_1
+ci-finmap: ci-mathcomp
+ci-bigenough: ci-mathcomp
 ci-analysis: ci-elpi_hb ci-finmap ci-bigenough
 
 ci-hb: ci-elpi

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -57,9 +57,7 @@ project oddorder "https://github.com/math-comp/odd-order" "master"
 project mczify "https://github.com/math-comp/mczify" "master"
 # Contact @pi8027 on github
 
-project finmap "https://github.com/math-comp/finmap" "cea9f088c9cddea1173bc2f7c4c7ebda35081b60"
-# put back master when Analysis master moves to MathComp 2
-# project finmap "https://github.com/math-comp/finmap" "master"
+project finmap "https://github.com/math-comp/finmap" "master"
 # Contact @CohenCyril on github
 
 project bigenough "https://github.com/math-comp/bigenough" "master"


### PR DESCRIPTION
Following the merge of https://github.com/math-comp/analysis/pull/951 and https://github.com/math-comp/analysis/pull/1161