### PR TITLE
rename push lemmas for `List.length` to match convention

### DIFF
--- a/doc/changelog/11-standard-library/18564-rename-push-length.rst
+++ b/doc/changelog/11-standard-library/18564-rename-push-length.rst
@@ -1,0 +1,26 @@
+- **Changed:** names of "push" lemmas for :g:`List.length` to follow the same
+  convention as push lemmas for other operations. For example, :g:`app_length`
+  became :g:`length_app`. The standard library was migrated using the following
+  script:
+
+.. code-block:: sh
+
+   find theories -name '*.v' | xargs sed -i -E '
+     s/\<app_length\>/length_app/g;
+     s/\<rev_length\>/length_rev/g;
+     s/\<map_length\>/length_map/g;
+     s/\<fold_left_length\>/fold_left_S_O/g;
+     s/\<split_length_l\>/length_fst_split/g;
+     s/\<split_length_r\>/length_snd_split/g;
+     s/\<combine_length\>/length_combine/g;
+     s/\<prod_length\>/length_prod/g;
+     s/\<firstn_length\>/length_firstn/g;
+     s/\<skipn_length\>/length_skipn/g;
+     s/\<seq_length\>/length_seq/g;
+     s/\<concat_length\>/length_concat/g;
+     s/\<flat_map_length\>/length_flat_map/g;
+     s/\<list_power_length\>/length_list_power/g;
+   '
+
+  (`#18564 <https://github.com/coq/coq/pull/18564>`_,
+  by Andres Erbsen).

--- a/theories/FSets/FMapFacts.v
+++ b/theories/FSets/FMapFacts.v
@@ -1231,7 +1231,7 @@ Module WProperties_fun (E:DecidableType)(M:WSfun E).
    cardinal m = fold (fun _ _ => S) m 0.
   Proof.
   intros; rewrite cardinal_1, fold_1.
-  symmetry; apply fold_left_length; auto.
+  symmetry; apply fold_left_S_O; auto.
   Qed.
 
   Lemma cardinal_Empty : forall m : t elt,

--- a/theories/FSets/FMapPositive.v
+++ b/theories/FSets/FMapPositive.v
@@ -477,7 +477,7 @@ Module PositiveMap <: S with Module E:=PositiveOrderedTypeBits.
    intros m; set (p:=1); clearbody p; revert m p.
    induction m; simpl; auto; intros.
    rewrite (IHm1 (append p 2)), (IHm2 (append p 3)).
-   destruct o; rewrite app_length; simpl; auto.
+   destruct o; rewrite length_app; simpl; auto.
   Qed.
 
   End CompcertSpec.

--- a/theories/FSets/FSetProperties.v
+++ b/theories/FSets/FSetProperties.v
@@ -700,7 +700,7 @@ Module WProperties_fun (Import E : DecidableType)(M : WSfun E).
   Lemma cardinal_fold : forall s, cardinal s = fold (fun _ => S) s 0.
   Proof.
   intros; rewrite cardinal_1; rewrite M.fold_1.
-  symmetry; apply fold_left_length; auto.
+  symmetry; apply fold_left_S_O; auto.
   Qed.
 
   (** ** Old specifications for [cardinal]. *)

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -222,14 +222,14 @@ Section Facts.
 
   (** Compatibility with other operations *)
 
-  Lemma app_length : forall l l' : list A, length (l++l') = length l + length l'.
+  Lemma length_app : forall l l' : list A, length (l++l') = length l + length l'.
   Proof.
     intro l; induction l; simpl; auto.
   Qed.
 
   Lemma last_length : forall (l : list A) a, length (l ++ a :: nil) = S (length l).
   Proof.
-    intros ; rewrite app_length ; simpl.
+    intros ; rewrite length_app ; simpl.
     rewrite Nat.add_succ_r, Nat.add_0_r; reflexivity.
   Qed.
 
@@ -999,17 +999,17 @@ Section ListOps.
     intros. cbn. rewrite in_app_iff, IHl. cbn. tauto.
   Qed.
 
-  Lemma rev_length : forall l, length (rev l) = length l.
+  Lemma length_rev : forall l, length (rev l) = length l.
   Proof.
     intro l; induction l as [|? l IHl];simpl; auto.
-    now rewrite app_length, IHl, Nat.add_comm.
+    now rewrite length_app, IHl, Nat.add_comm.
   Qed.
 
   Lemma rev_nth : forall l d n, n < length l ->
     nth n (rev l) d = nth (length l - S n) l d.
   Proof.
     intros l d; induction l as [|a l IHl] using rev_ind; [easy|].
-    rewrite rev_app_distr, app_length, Nat.add_comm. cbn. intros [|n].
+    rewrite rev_app_distr, length_app, Nat.add_comm. cbn. intros [|n].
     - now rewrite Nat.sub_0_r, nth_middle.
     - intros Hn %Nat.succ_lt_mono.
       rewrite (IHl _ Hn), app_nth1; [reflexivity|].
@@ -1136,7 +1136,7 @@ Section Map.
     intro l; induction l; firstorder (subst; auto).
   Qed.
 
-  Lemma map_length : forall l, length (map l) = length l.
+  Lemma length_map : forall l, length (map l) = length l.
   Proof.
     intro l; induction l; simpl; auto.
   Qed.
@@ -1338,7 +1338,7 @@ Proof.
   intros l n d ln dn Hlen.
   rewrite <- (map_nth (fun m => nth m l d)).
   destruct Hlen.
-  - apply nth_indep. now rewrite map_length.
+  - apply nth_indep. now rewrite length_map.
   - now rewrite (nth_overflow l).
 Qed.
 
@@ -1365,11 +1365,11 @@ Section Fold_Left_Recursor.
 
 End Fold_Left_Recursor.
 
-Lemma fold_left_length :
+Lemma fold_left_S_O :
   forall (A:Type)(l:list A), fold_left (fun x _ => S x) l 0 = length l.
 Proof.
   intros A l. induction l as [|? ? IH] using rev_ind; [reflexivity|].
-  now rewrite fold_left_app, app_length, IH, Nat.add_comm.
+  now rewrite fold_left_app, length_app, IH, Nat.add_comm.
 Qed.
 
 (************************************)
@@ -1779,14 +1779,14 @@ End Fold_Right_Recursor.
         + destruct a; destruct (split l); simpl in *; auto.
     Qed.
 
-    Lemma split_length_l : forall (l:list (A*B)),
+    Lemma length_fst_split : forall (l:list (A*B)),
       length (fst (split l)) = length l.
     Proof.
       intro l; induction l as [|a l IHl]; simpl; auto.
       destruct a; destruct (split l); simpl; auto.
     Qed.
 
-    Lemma split_length_r : forall (l:list (A*B)),
+    Lemma length_snd_split : forall (l:list (A*B)),
       length (snd (split l)) = length l.
     Proof.
       intro l; induction l as [|a l IHl]; simpl; auto.
@@ -1845,7 +1845,7 @@ End Fold_Right_Recursor.
         + right; apply IHl with x; auto.
     Qed.
 
-    Lemma combine_length : forall (l:list A)(l':list B),
+    Lemma length_combine : forall (l:list A)(l':list B),
       length (combine l l') = min (length l) (length l').
     Proof.
       intro l; induction l.
@@ -1902,11 +1902,11 @@ End Fold_Right_Recursor.
       intros [[? [[= -> ->] ?]] %in_map_iff|] %in_app_or; tauto.
     Qed.
 
-    Lemma prod_length : forall (l:list A)(l':list B),
+    Lemma length_prod : forall (l:list A)(l':list B),
       length (list_prod l l') = (length l) * (length l').
     Proof.
       intro l; induction l as [|? ? IHl]; simpl; [easy|].
-      intros. now rewrite app_length, map_length, IHl.
+      intros. now rewrite length_app, length_map, IHl.
     Qed.
 
   End ListPairs.
@@ -2238,12 +2238,12 @@ Section Cutting.
       f_equal; auto.
   Qed.
 
-  Lemma firstn_length : forall n l, length (firstn n l) = min n (length l).
+  Lemma length_firstn : forall n l, length (firstn n l) = min n (length l).
   Proof.
     intro n; induction n; intro l; destruct l; simpl; auto.
   Qed.
 
-  Lemma skipn_length n :
+  Lemma length_skipn n :
     forall l, length (skipn n l) = length l - n.
   Proof.
     induction n.
@@ -2259,22 +2259,22 @@ Section Cutting.
       firstn x l = rev (skipn (length l - x) (rev l)).
   Proof.
     intros x l; rewrite <-(firstn_skipn x l) at 3.
-    rewrite rev_app_distr, skipn_app, rev_app_distr, rev_length,
-            skipn_length, Nat.sub_diag; simpl; rewrite rev_involutive.
+    rewrite rev_app_distr, skipn_app, rev_app_distr, length_rev,
+            length_skipn, Nat.sub_diag; simpl; rewrite rev_involutive.
     rewrite <-app_nil_r at 1; f_equal; symmetry; apply length_zero_iff_nil.
-    repeat rewrite rev_length, skipn_length; apply Nat.sub_diag.
+    repeat rewrite length_rev, length_skipn; apply Nat.sub_diag.
   Qed.
 
   Lemma firstn_rev: forall x l,
     firstn x (rev l) = rev (skipn (length l - x) l).
   Proof.
-    now intros x l; rewrite firstn_skipn_rev, rev_involutive, rev_length.
+    now intros x l; rewrite firstn_skipn_rev, rev_involutive, length_rev.
   Qed.
 
   Lemma skipn_rev: forall x l,
       skipn x (rev l) = rev (firstn (length l - x) l).
   Proof.
-    intros x l; rewrite firstn_skipn_rev, rev_involutive, <-rev_length.
+    intros x l; rewrite firstn_skipn_rev, rev_involutive, <-length_rev.
     destruct (Nat.le_ge_cases (length (rev l)) x) as [L | L].
     - rewrite skipn_all2; [apply Nat.sub_0_le in L | trivial].
       now rewrite L, Nat.sub_0_r, skipn_all.
@@ -2337,7 +2337,7 @@ Section Combining.
     Proof.
       intros l.
       apply length_zero_iff_nil.
-      rewrite combine_length. simpl. rewrite Nat.min_0_r.
+      rewrite length_combine. simpl. rewrite Nat.min_0_r.
       reflexivity.
     Qed.
 
@@ -2664,8 +2664,8 @@ Section ReDun.
       inversion_clear Hnd as [|? ? Hnin Hnd'].
       apply (NoDup_Add (Add_app a l1' l2')); split.
       + apply IHl; auto.
-        * rewrite app_length.
-          rewrite app_length in Hlen; simpl in Hlen; rewrite Nat.add_succ_r in Hlen.
+        * rewrite length_app.
+          rewrite length_app in Hlen; simpl in Hlen; rewrite Nat.add_succ_r in Hlen.
           now apply Nat.succ_le_mono.
         * apply (incl_Add_inv (u:= l1' ++ l2')) in Hincl; auto.
           apply Add_app.
@@ -2676,7 +2676,7 @@ Section ReDun.
           apply in_app_or in Hin as [Hin|[->|Hin]]; intuition. }
         apply NoDup_incl_length in Hincl''; [ | now constructor ].
         apply (Nat.nle_succ_diag_l (length l1' + length l2')).
-        rewrite_all app_length.
+        rewrite_all length_app.
         simpl in Hlen; rewrite Nat.add_succ_r in Hlen.
         now transitivity (S (length l)).
   Qed.
@@ -2714,7 +2714,7 @@ Section NatSeq.
     reflexivity.
   Qed.
 
-  Lemma seq_length : forall len start, length (seq start len) = len.
+  Lemma length_seq : forall len start, length (seq start len) = len.
   Proof.
     intro len; induction len; simpl; auto.
   Qed.
@@ -3479,36 +3479,36 @@ simpl; rewrite IHl1.
 apply Nat.add_assoc.
 Qed.
 
-Lemma concat_length A l:
+Lemma length_concat A l:
   length (concat l) = list_sum (map (@length A) l).
 Proof.
   induction l; [reflexivity|].
-  simpl. rewrite app_length.
+  simpl. rewrite length_app.
   f_equal. assumption.
 Qed.
 
-Lemma flat_map_length A B (f: A -> list B) l:
+Lemma length_flat_map A B (f: A -> list B) l:
   length (flat_map f l) = list_sum (map (fun x => length (f x)) l).
 Proof.
-  rewrite flat_map_concat_map, concat_length, map_map. reflexivity.
+  rewrite flat_map_concat_map, length_concat, map_map. reflexivity.
 Qed.
 
 Corollary flat_map_constant_length A B c (f: A -> list B) l:
   (forall x, In x l -> length (f x) = c) -> length (flat_map f l) = (length l) * c.
 Proof.
-  intro H. rewrite flat_map_length.
+  intro H. rewrite length_flat_map.
   induction l as [ | a l IHl ]; [reflexivity|].
   simpl. rewrite IHl, H; [reflexivity | left; reflexivity | ].
   intros x Hx. apply H. right. assumption.
 Qed.
 
-Lemma list_power_length (A B:Type)(l:list A) (l':list B):
+Lemma length_list_power (A B:Type)(l:list A) (l':list B):
     length (list_power l l') = (length l')^(length l).
 Proof.
   induction l as [ | a m IH ]; [reflexivity|].
   cbn. rewrite flat_map_constant_length with (c := length l').
   - rewrite IH. apply Nat.mul_comm.
-  - intros x H. apply map_length.
+  - intros x H. apply length_map.
 Qed.
 
 (** Max of elements of a list of [nat]: [list_max] *)
@@ -3577,10 +3577,10 @@ Global Hint Rewrite
   rev_involutive (* rev (rev l) = l *)
   rev_unit (* rev (l ++ a :: nil) = a :: rev l *)
   map_nth (* nth n (map f l) (f d) = f (nth n l d) *)
-  map_length (* length (map f l) = length l *)
-  seq_length (* length (seq start len) = len *)
-  app_length (* length (l ++ l') = length l + length l' *)
-  rev_length (* length (rev l) = length l *)
+  length_app (* length (map f l) = length l *)
+  length_seq (* length (seq start len) = len *)
+  length_app (* length (l ++ l') = length l + length l' *)
+  length_rev (* length (rev l) = length l *)
   app_nil_r (* l ++ nil = l *)
   : list.
 
@@ -3621,6 +3621,35 @@ Notation app_assoc_reverse := app_assoc_reverse_deprecated (only parsing).
 
 #[global]
 Hint Resolve app_nil_end_deprecated : datatypes.
+
+#[deprecated(since = "8.20", note = "Use length_app instead.")]
+Notation app_length := length_app (only parsing).
+#[deprecated(since = "8.20", note = "Use length_rev instead.")]
+Notation rev_length := length_rev (only parsing).
+#[deprecated(since = "8.20", note = "Use length_map instead.")]
+Notation map_length := length_map (only parsing).
+#[deprecated(since = "8.20", note = "Use fold_left_S_O instead.")]
+Notation fold_left_length := fold_left_S_O (only parsing).
+#[deprecated(since = "8.20", note = "Use length_fst_split instead.")]
+Notation split_length_l := length_fst_split (only parsing).
+#[deprecated(since = "8.20", note = "Use length_snd_split instead.")]
+Notation split_length_r := length_snd_split (only parsing).
+#[deprecated(since = "8.20", note = "Use length_combine instead.")]
+Notation combine_length := length_combine (only parsing).
+#[deprecated(since = "8.20", note = "Use length_prod instead.")]
+Notation prod_length := length_prod (only parsing).
+#[deprecated(since = "8.20", note = "Use length_firstn instead.")]
+Notation firstn_length := length_firstn (only parsing).
+#[deprecated(since = "8.20", note = "Use length_skipn instead.")]
+Notation skipn_length := length_skipn (only parsing).
+#[deprecated(since = "8.20", note = "Use length_seq instead.")]
+Notation seq_length := length_seq (only parsing).
+#[deprecated(since = "8.20", note = "Use length_concat instead.")]
+Notation concat_length := length_concat (only parsing).
+#[deprecated(since = "8.20", note = "Use length_flat_map instead.")]
+Notation flat_map_length := length_flat_map (only parsing).
+#[deprecated(since = "8.20", note = "Use length_list_power instead.")]
+Notation list_power_length := length_list_power (only parsing).
 (* end hide *)
 
 

--- a/theories/Logic/FinFun.v
+++ b/theories/Logic/FinFun.v
@@ -157,14 +157,14 @@ Proof.
    destruct L as (N,F).
    assert (I : incl l (map f l)).
    { apply NoDup_length_incl; trivial.
-     - now rewrite map_length.
+     - now rewrite length_map.
      - intros x _. apply F. }
    intros x. apply I, F.
  - clear F d. intros (l,L).
    assert (N : NoDup l). { apply (NoDup_map_inv f), L. }
    assert (I : incl (map f l) l).
    { apply NoDup_length_incl; trivial.
-     - now rewrite map_length.
+     - now rewrite length_map.
      - intros x _. apply L. }
    assert (L' : Listing l).
    { split; trivial.

--- a/theories/MSets/MSetProperties.v
+++ b/theories/MSets/MSetProperties.v
@@ -700,7 +700,7 @@ Module WPropertiesOn (Import E : DecidableType)(M : WSetsOn E).
   Lemma cardinal_fold : forall s, cardinal s = fold (fun _ => S) s 0.
   Proof.
   intros; rewrite cardinal_1; rewrite FM.fold_1.
-  symmetry; apply fold_left_length; auto.
+  symmetry; apply fold_left_S_O; auto.
   Qed.
 
   (** ** Old specifications for [cardinal]. *)

--- a/theories/MSets/MSetRBT.v
+++ b/theories/MSets/MSetRBT.v
@@ -999,7 +999,7 @@ Proof.
  destruct (g acc1) as (t2,acc2).
  destruct Hg as (Hg1,Hg2).
   { revert LE. subst.
-    rewrite app_length, <- elements_cardinal. simpl.
+    rewrite length_app, <- elements_cardinal. simpl.
     rewrite Nat.add_succ_r, <- Nat.succ_le_mono.
     apply Nat.add_le_mono_l. }
  rewrite elements_node, <- app_assoc. now subst.
@@ -1041,7 +1041,7 @@ Proof.
  assert (H := treeify_aux_spec (plength l) true l).
  unfold treeify. destruct treeify_aux as (t,acc); simpl in *.
  destruct H as (H,H'). { now rewrite plength_spec. }
- subst l. rewrite plength_spec, app_length, <- elements_cardinal in *.
+ subst l. rewrite plength_spec, length_app, <- elements_cardinal in *.
  destruct acc.
  * now rewrite app_nil_r.
  * exfalso. revert H. simpl.

--- a/theories/Numbers/DecimalFacts.v
+++ b/theories/Numbers/DecimalFacts.v
@@ -176,7 +176,7 @@ Proof.
 Qed.
 
 Lemma nb_digits_rev d : nb_digits (rev d) = nb_digits d.
-Proof. now rewrite !nb_digits_spec, rev_spec, List.rev_length. Qed.
+Proof. now rewrite !nb_digits_spec, rev_spec, List.length_rev. Qed.
 
 Lemma nb_digits_del_head_sub d n :
   n <= nb_digits d ->
@@ -184,7 +184,7 @@ Lemma nb_digits_del_head_sub d n :
 Proof.
   rewrite !nb_digits_spec; intro Hn.
   rewrite del_head_spec_small; [|now apply Nat.le_sub_l].
-  rewrite List.skipn_length, <-(Nat2Z.id (_ - _)).
+  rewrite List.length_skipn, <-(Nat2Z.id (_ - _)).
   rewrite Nat2Z.inj_sub; [|now apply Nat.le_sub_l].
   rewrite (Nat2Z.inj_sub _ _ Hn).
   rewrite Z.sub_sub_distr, Z.sub_diag; apply Nat2Z.id.
@@ -248,7 +248,7 @@ Proof.
   rewrite !nb_digits_spec, !nzhead_spec, app_spec.
   induction (to_list d) as [|h t IHl]; [now simpl|].
   rewrite <-List.app_comm_cons.
-  now case h; [| simpl; rewrite List.app_length; intro Hl; exfalso; revert Hl;
+  now case h; [| simpl; rewrite List.length_app; intro Hl; exfalso; revert Hl;
     apply Nat.le_ngt, Nat.le_add_l..].
 Qed.
 
@@ -265,7 +265,7 @@ Proof.
   induction (to_list d) as [|h t IHl]; [now simpl|].
   now case h; [now simpl|..];
     simpl;intro H; exfalso; revert H; apply Nat.le_ngt;
-    rewrite List.app_length; apply Nat.le_add_l.
+    rewrite List.length_app; apply Nat.le_add_l.
 Qed.
 
 Lemma nzhead_app_nil_l d d' : nzhead (app d d') = Nil -> nzhead d = Nil.
@@ -305,7 +305,7 @@ Proof.
     now revert Hd'; case d'; [|intros d'' _; apply le_n_S, Peano.le_0_n..]. }
   intro Ha; rewrite (unorm_nzhead _ Ha).
   intro Hn; generalize Hn; rewrite (nzhead_app_l _ _ Hn).
-  rewrite !nb_digits_spec, app_spec, List.app_length.
+  rewrite !nb_digits_spec, app_spec, List.length_app.
   case (uint_eq_dec (nzhead d) Nil).
   { intros->; simpl; intro H; exfalso; revert H; apply Nat.lt_irrefl. }
   now intro H; rewrite (unorm_nzhead _ H).
@@ -366,7 +366,7 @@ Proof.
   rewrite nb_digits_spec; intro Hn.
   apply to_list_inj.
   rewrite del_head_spec_small.
-  2:{ now rewrite app_spec, List.app_length, <- Nat.le_add_r. }
+  2:{ now rewrite app_spec, List.length_app, <- Nat.le_add_r. }
   rewrite !app_spec, (del_head_spec_small _ _ Hn).
   rewrite List.skipn_app.
   now rewrite (proj2 (Nat.sub_0_le _ _) Hn).
@@ -379,7 +379,7 @@ Proof.
   unfold del_tail.
   rewrite <-(of_list_to_list (rev (app d d'))), rev_spec, app_spec.
   rewrite List.rev_app_distr, <-!rev_spec, <-app_spec, of_list_to_list.
-  rewrite del_head_app; [|now rewrite nb_digits_spec, rev_spec, List.rev_length].
+  rewrite del_head_app; [|now rewrite nb_digits_spec, rev_spec, List.length_rev].
   apply to_list_inj.
   rewrite rev_spec, !app_spec, !rev_spec.
   now rewrite List.rev_app_distr, List.rev_involutive.
@@ -394,7 +394,7 @@ Lemma app_del_tail_head n (d:uint) :
 Proof.
   rewrite nb_digits_spec; intro Hn; unfold del_tail.
   rewrite <-(of_list_to_list (app _ _)), app_spec, rev_spec.
-  rewrite del_head_spec_small; [|now rewrite rev_spec, List.rev_length].
+  rewrite del_head_spec_small; [|now rewrite rev_spec, List.length_rev].
   rewrite del_head_spec_small; [|now apply Nat.le_sub_l].
   rewrite rev_spec.
   set (n' := _ - n).
@@ -416,7 +416,7 @@ Proof.
   simpl; intro Hnb; generalize Hnb; rewrite (unorm_app_l _ _ Hnb); clear Hnb.
   replace (_ - _) with (nb_digits (unorm (abs i))).
   - now rewrite del_head_app; [rewrite del_head_nb_digits|].
-  - rewrite !nb_digits_spec, app_spec, List.app_length.
+  - rewrite !nb_digits_spec, app_spec, List.length_app.
     symmetry; apply Nat.add_sub.
 Qed.
 
@@ -591,7 +591,7 @@ Lemma nzhead_del_tail_nzhead_eq n u :
   n < nb_digits u ->
   nzhead (del_tail n u) = del_tail n u.
 Proof.
-  rewrite nb_digits_spec, <-List.rev_length.
+  rewrite nb_digits_spec, <-List.length_rev.
   intros Hu Hn.
   apply to_list_inj; unfold del_tail.
   rewrite nzhead_spec, rev_spec.
@@ -601,7 +601,7 @@ Proof.
   generalize (f_equal to_list Hu) Hn; rewrite nzhead_spec; intro Hu'.
   case (to_list u) as [|h t].
   { simpl; intro H; exfalso; revert H; apply Nat.le_ngt, Nat.le_0_l. }
-  intro Hn'; generalize (Nat.sub_gt _ _ Hn'); rewrite List.rev_length.
+  intro Hn'; generalize (Nat.sub_gt _ _ Hn'); rewrite List.length_rev.
   case (_ - _); [now simpl|]; intros n' _.
   rewrite List.firstn_cons, lnzhead_head_nd0; [now simpl|].
   intro Hh; revert Hu'; rewrite Hh; apply lnzhead_neq_d0_head.

--- a/theories/Numbers/HexadecimalFacts.v
+++ b/theories/Numbers/HexadecimalFacts.v
@@ -190,7 +190,7 @@ Proof.
 Qed.
 
 Lemma nb_digits_rev d : nb_digits (rev d) = nb_digits d.
-Proof. now rewrite !nb_digits_spec, rev_spec, List.rev_length. Qed.
+Proof. now rewrite !nb_digits_spec, rev_spec, List.length_rev. Qed.
 
 Lemma nb_digits_del_head_sub d n :
   n <= nb_digits d ->
@@ -198,7 +198,7 @@ Lemma nb_digits_del_head_sub d n :
 Proof.
   rewrite !nb_digits_spec; intro Hn.
   rewrite del_head_spec_small; [|now apply Nat.le_sub_l].
-  rewrite List.skipn_length, <-(Nat2Z.id (_ - _)).
+  rewrite List.length_skipn, <-(Nat2Z.id (_ - _)).
   rewrite Nat2Z.inj_sub; [|now apply Nat.le_sub_l].
   rewrite (Nat2Z.inj_sub _ _ Hn).
   rewrite Z.sub_sub_distr, Z.sub_diag; apply Nat2Z.id.
@@ -262,7 +262,7 @@ Proof.
   rewrite !nb_digits_spec, !nzhead_spec, app_spec.
   induction (to_list d) as [|h t IHl]; [now simpl|].
   rewrite <-List.app_comm_cons.
-  now case h; [| simpl; rewrite List.app_length; intro Hl; exfalso; revert Hl;
+  now case h; [| simpl; rewrite List.length_app; intro Hl; exfalso; revert Hl;
     apply Nat.le_ngt, Nat.le_add_l..].
 Qed.
 
@@ -279,7 +279,7 @@ Proof.
   induction (to_list d) as [|h t IHl]; [now simpl|].
   now case h; [now simpl|..];
     simpl;intro H; exfalso; revert H; apply Nat.le_ngt;
-    rewrite List.app_length; apply Nat.le_add_l.
+    rewrite List.length_app; apply Nat.le_add_l.
 Qed.
 
 Lemma nzhead_app_nil_l d d' : nzhead (app d d') = Nil -> nzhead d = Nil.
@@ -319,7 +319,7 @@ Proof.
     now revert Hd'; case d'; [|intros d'' _; apply le_n_S, Peano.le_0_n..]. }
   intro Ha; rewrite (unorm_nzhead _ Ha).
   intro Hn; generalize Hn; rewrite (nzhead_app_l _ _ Hn).
-  rewrite !nb_digits_spec, app_spec, List.app_length.
+  rewrite !nb_digits_spec, app_spec, List.length_app.
   case (uint_eq_dec (nzhead d) Nil).
   { intros->; simpl; intro H; exfalso; revert H; apply Nat.lt_irrefl. }
   now intro H; rewrite (unorm_nzhead _ H).
@@ -380,7 +380,7 @@ Proof.
   rewrite nb_digits_spec; intro Hn.
   apply to_list_inj.
   rewrite del_head_spec_small.
-  2:{ now rewrite app_spec, List.app_length, <- Nat.le_add_r. }
+  2:{ now rewrite app_spec, List.length_app, <- Nat.le_add_r. }
   rewrite !app_spec, (del_head_spec_small _ _ Hn).
   rewrite List.skipn_app.
   now rewrite (proj2 (Nat.sub_0_le _ _) Hn).
@@ -393,7 +393,7 @@ Proof.
   unfold del_tail.
   rewrite <-(of_list_to_list (rev (app d d'))), rev_spec, app_spec.
   rewrite List.rev_app_distr, <-!rev_spec, <-app_spec, of_list_to_list.
-  rewrite del_head_app; [|now rewrite nb_digits_spec, rev_spec, List.rev_length].
+  rewrite del_head_app; [|now rewrite nb_digits_spec, rev_spec, List.length_rev].
   apply to_list_inj.
   rewrite rev_spec, !app_spec, !rev_spec.
   now rewrite List.rev_app_distr, List.rev_involutive.
@@ -408,7 +408,7 @@ Lemma app_del_tail_head n (d:uint) :
 Proof.
   rewrite nb_digits_spec; intro Hn; unfold del_tail.
   rewrite <-(of_list_to_list (app _ _)), app_spec, rev_spec.
-  rewrite del_head_spec_small; [|now rewrite rev_spec, List.rev_length].
+  rewrite del_head_spec_small; [|now rewrite rev_spec, List.length_rev].
   rewrite del_head_spec_small; [|now apply Nat.le_sub_l].
   rewrite rev_spec.
   set (n' := _ - n).
@@ -430,7 +430,7 @@ Proof.
   simpl; intro Hnb; generalize Hnb; rewrite (unorm_app_l _ _ Hnb); clear Hnb.
   replace (_ - _) with (nb_digits (unorm (abs i))).
   - now rewrite del_head_app; [rewrite del_head_nb_digits|].
-  - rewrite !nb_digits_spec, app_spec, List.app_length.
+  - rewrite !nb_digits_spec, app_spec, List.length_app.
     symmetry; apply Nat.add_sub.
 Qed.
 
@@ -611,7 +611,7 @@ Lemma nzhead_del_tail_nzhead_eq n u :
   n < nb_digits u ->
   nzhead (del_tail n u) = del_tail n u.
 Proof.
-  rewrite nb_digits_spec, <-List.rev_length.
+  rewrite nb_digits_spec, <-List.length_rev.
   intros Hu Hn.
   apply to_list_inj; unfold del_tail.
   rewrite nzhead_spec, rev_spec.
@@ -621,7 +621,7 @@ Proof.
   generalize (f_equal to_list Hu) Hn; rewrite nzhead_spec; intro Hu'.
   case (to_list u) as [|h t].
   { simpl; intro H; exfalso; revert H; apply Nat.le_ngt, Nat.le_0_l. }
-  intro Hn'; generalize (Nat.sub_gt _ _ Hn'); rewrite List.rev_length.
+  intro Hn'; generalize (Nat.sub_gt _ _ Hn'); rewrite List.length_rev.
   case (_ - _); [now simpl|]; intros n' _.
   rewrite List.firstn_cons, lnzhead_head_nd0; [now simpl|].
   intro Hh; revert Hu'; rewrite Hh; apply lnzhead_neq_d0_head.

--- a/theories/Reals/RList.v
+++ b/theories/Reals/RList.v
@@ -650,7 +650,7 @@ Proof.
   - intros; reflexivity.
   - intros; rewrite <- (H l2 H0); induction  l2 as [| r1 l2 Hrecl2].
     + elim H0; reflexivity.
-    + do 2 rewrite app_length;
+    + do 2 rewrite length_app;
       replace (length (r :: r0) + length (r1 :: l2))%nat with
         (S (S (length r0 + length l2)));
       [ replace (length r0 + length (r1 :: l2))%nat with
@@ -720,17 +720,17 @@ Proof.
         -- clear r0 H i H0 H1 H2; induction  l1 as [| r0 l1 Hrecl1].
            ++ reflexivity.
            ++ simpl; assumption.
-        -- rewrite app_length; rewrite Nat.add_comm; simpl; apply Nat.lt_succ_diag_r.
+        -- rewrite length_app; rewrite Nat.add_comm; simpl; apply Nat.lt_succ_diag_r.
       * replace (S m - length l1)%nat with (S (S m - S (length l1))).
         -- rewrite H3; simpl;
              replace (S (length l1)) with (length (app l1 (r :: nil))).
            ++ apply (H (app l1 (r :: nil)) i).
-              ** rewrite app_length; rewrite Nat.add_comm; simpl; rewrite <- H3;
+              ** rewrite length_app; rewrite Nat.add_comm; simpl; rewrite <- H3;
                    apply le_n_S; assumption.
-              ** repeat rewrite app_length; simpl; rewrite app_length in H1;
+              ** repeat rewrite length_app; simpl; rewrite length_app in H1;
                    rewrite Nat.add_comm in H1; simpl in H1; rewrite (Nat.add_comm (length l1));
                    simpl; rewrite Nat.add_comm; apply H1.
-           ++ rewrite app_length; rewrite Nat.add_comm; reflexivity.
+           ++ rewrite length_app; rewrite Nat.add_comm; reflexivity.
         -- change (S (m - length l1) = (S m - length l1)%nat);
              symmetry; apply Nat.sub_succ_l; assumption.
     + replace (r :: r0) with (app (r :: nil) r0);

--- a/theories/Reals/RiemannInt_SF.v
+++ b/theories/Reals/RiemannInt_SF.v
@@ -1772,7 +1772,7 @@ Proof.
         | left; assumption ]. }
     red; intro; rewrite H1 in H11; discriminate.
   - apply StepFun_P20.
-    rewrite app_length; apply Nat.neq_0_lt_0; red; intro.
+    rewrite length_app; apply Nat.neq_0_lt_0; red; intro.
     assert (List.length l1 = 0)%nat as H12 by now destruct (List.length l1); inversion H1.
     rewrite H12 in H6; discriminate.
   - unfold constant_D_eq, open_interval; intros;
@@ -1920,7 +1920,7 @@ Proof.
       { apply Nat.lt_succ_lt_pred; rewrite <- Nat.sub_succ_l.
         { apply Nat.add_lt_mono_l with (length l1); rewrite Nat.add_comm, Nat.sub_add.
           { rewrite H19 in H1; simpl in H1; rewrite H19; simpl;
-              rewrite app_length in H1; apply -> Nat.succ_lt_mono; assumption. }
+              rewrite length_app in H1; apply -> Nat.succ_lt_mono; assumption. }
           apply Nat.le_trans with (S i); [ apply Nat.succ_le_mono; assumption | apply Nat.le_succ_diag_r ]. }
         apply Nat.succ_le_mono; assumption. }
       assert (H22 := H20 H21); repeat rewrite H22.
@@ -1932,7 +1932,7 @@ Proof.
           rewrite <- Nat.sub_succ_l.
           { apply Nat.add_lt_mono_l with (length l1); rewrite Nat.add_comm, Nat.sub_add.
             { rewrite H19 in H1; simpl in H1; rewrite H19; simpl;
-                rewrite app_length in H1; apply -> Nat.succ_lt_mono; assumption. }
+                rewrite length_app in H1; apply -> Nat.succ_lt_mono; assumption. }
             apply Nat.le_trans with (S i); [ apply Nat.succ_le_mono; assumption | apply Nat.le_succ_diag_r ]. }
           apply Nat.succ_le_mono; assumption. }
         elim H23; intro.

--- a/theories/Sorting/PermutEq.v
+++ b/theories/Sorting/PermutEq.v
@@ -198,9 +198,9 @@ Section Perm.
     - rewrite (permut_nil (permut_sym H)); auto.
     - destruct (In_split _ _ (permut_cons_In H)) as (h2,(t2,H1)).
       subst l2.
-      rewrite app_length.
+      rewrite length_app.
       simpl; rewrite <- plus_n_Sm; f_equal.
-      rewrite <- app_length.
+      rewrite <- length_app.
       apply IHl1.
       apply permut_remove_hd with a; auto with typeclass_instances.
   Qed.

--- a/theories/Sorting/PermutSetoid.v
+++ b/theories/Sorting/PermutSetoid.v
@@ -408,9 +408,9 @@ Proof.
   - assert (H0:=permut_cons_InA H).
     destruct (InA_split H0) as (h2,(b,(t2,(H1,H2)))).
     subst l2.
-    rewrite app_length.
+    rewrite length_app.
     simpl; rewrite <- plus_n_Sm; f_equal.
-    rewrite <- app_length.
+    rewrite <- length_app.
     apply IHl1.
     apply permut_remove_hd with b.
     apply permut_trans with (a::l1); auto.

--- a/theories/Sorting/Permutation.v
+++ b/theories/Sorting/Permutation.v
@@ -701,7 +701,7 @@ Lemma nat_bijection_Permutation n f :
 Proof.
  intros Hf BD.
  apply NoDup_Permutation_bis; auto using Injective_map_NoDup, seq_NoDup.
- * now rewrite map_length.
+ * now rewrite length_map.
  * intros x. rewrite in_map_iff. intros (y & <- & Hy').
    rewrite in_seq in *. simpl in *.
    destruct Hy' as (_,Hy').
@@ -792,7 +792,7 @@ Proof.
      destruct (nth_error_split l (f 0) Ha) as (l1 & l2 & L12 & L1).
      rewrite L12. rewrite <- Permutation_middle. constructor.
      apply IHl'; split; [|exists (adapt f); split].
-     * revert E. rewrite L12, !app_length. simpl.
+     * revert E. rewrite L12, !length_app. simpl.
        rewrite <- plus_n_Sm. now injection 1.
      * now apply adapt_injective.
      * intro n. rewrite <- (adapt_ok a), <- L12; auto.


### PR DESCRIPTION
For example, `app_length`  became `length_app`.

- [x] Added **changelog**.

Cc @Villetaneuse @JasonGross 