### PR TITLE
Fixes #7982: add support for reduction of primitive projection of cofixpoints in "simpl" reduction strategy

### DIFF
--- a/doc/changelog/04-tactics/18577-master+fix7982-primproj-cofix-simpl.rst
+++ b/doc/changelog/04-tactics/18577-master+fix7982-primproj-cofix-simpl.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  The reduction of primitive projections of cofixpoints by
+  :tacn:`simpl` is now implemented
+  (`#18577 <https://github.com/coq/coq/pull/18577>`_,
+  fixes `#7982 <https://github.com/coq/coq/issues/7982>`_,
+  by Hugo Herbelin).

--- a/test-suite/bugs/bug_7982.v
+++ b/test-suite/bugs/bug_7982.v
@@ -1,0 +1,12 @@
+Set Primitive Projections.
+
+CoInductive stream (A : Type) := cons { hd : A; tl : stream A }.
+
+CoFixpoint const {A} (x : A) := cons A x (const x).
+
+Goal forall A x, (@const A x).(tl _) = const x.
+Proof.
+intros.
+simpl.
+match goal with [ |- ?x = ?x ] => idtac end.
+Abort.


### PR DESCRIPTION
The patch is rather canonical: it adds a line for the Proj/CoFix case. First commit is pure reorganization of code (no change of semantics). Second commit adds the new reduction.

Depends on the 7 commits of #18576 (merged)

Fixes / closes #7982 

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.

----

An open question, for both the primitive and non-primitive projections case:
```coq
CoInductive stream := cons { hd : bool; tl : stream }.
CoFixpoint const (x : bool) := if x then cons x (const x) else cons x (const x).
Eval simpl in fun x => (const x).(tl).
(* currently, returns
   fun x : bool =>
       let (_, tl) := if x then {| hd := x; tl := const x |} else {| hd := x; tl := const x |} in tl *)
```
Should we continue unfolding the cofixpoints even though it does not immediately produce a constructor, or should we do it only if we are sure that it produces a constructor?