### PR TITLE
Do not use "simpl never" and cie in "hnf"

### DIFF
--- a/doc/changelog/04-tactics/18580-master+hnf-without-simpl-never.rst
+++ b/doc/changelog/04-tactics/18580-master+hnf-without-simpl-never.rst
@@ -1,0 +1,8 @@
+- **Changed:**
+
+  The reduction tactic :tacn:`hnf` becomes insensitive to the
+  :g:`simpl never` status of constants, as prescribed in the reference
+  manual; this can exceptionally impact the behavior of :tacn:`intros`
+  on goals defining an implicative or universally quantified statement
+  by recursion (`#18580 <https://github.com/coq/coq/pull/18580>`_,
+  by Hugo Herbelin).

--- a/test-suite/output/simpl.out
+++ b/test-suite/output/simpl.out
@@ -39,7 +39,7 @@
      : nat
      = 0 + 0
      : nat
-     = 0 + 0
+     = 0
      : nat
 "** NonPrimitiveProjection"
      : string

--- a/test-suite/success/intros.v
+++ b/test-suite/success/intros.v
@@ -164,3 +164,20 @@ exact _H.
 Qed.
 
 End Wildcard.
+
+Module SimplNever.
+
+Fixpoint arrow n X :=
+  match n with
+  | 0 => X
+  | S n => X -> arrow n X
+  end.
+
+Arguments arrow : simpl never.
+
+Goal arrow 1 False.
+intro H.
+exact H.
+Qed.
+
+End SimplNever.


### PR DESCRIPTION
Whether `hnf` should grant `simpl never` is unclear. In practice:
- it follows what `simpl` does on named fixpoints and named cofixpoints as well as on terms hiding a projection or a `match`, when those are not occurring at the head of the term; in particular it also follows `simpl` on *not* respecting the `never` flag on arguments of a `match`/`fix`
- it does not follow `simpl` on head constants hiding a projection or a `match`.

PR #15667 was making official that `hnf` should not grant `simpl never` even if it was still hybrid in practice. The PR makes `hnf` comply with the reference manual.

This addresses for instance the `simpl never` result of `hnf` in #18578:
```coq
Arguments Nat.add : simpl never.
Eval hnf in 0+0.  (* before: 0 + 0 ; after : 0 *)
Eval hnf in 1*(0+0).  (* before: (0 + 0) + 0 * (0 + 0) ; after : 0 *)
```

The PR has a minor dependency in #18579 (merged)

Note: this PR mostly corresponds to the first two commits of #15661 (minus the change to primitive projections).
 
Note: the PR also introduces a record for `simpl` flags.

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
