### PR TITLE
CI: use macos 12 instead of 11

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   macOS:
-    runs-on: macos-11
+    runs-on: macos-12
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
brew doesn't support 11:
https://github.com/SkySkimmer/coq/actions/runs/7711502009/job/21016981504

~~~
[45/165] clang -Isrc/libvmaf.3.dylib.p -Isrc -I../src -Iinclude -I../include -I../src/feature -I../src/feature/common -fdiagnostics-color=always -Wall -Winvalid-pch -Wextra -std=c11 -O3 -D_DARWIN_C_SOURCE -pedantic -DOC_NEW_STYLE_INCLUDES -MD -MQ src/libvmaf.3.dylib.p/meson-generated_.._vmaf_b_v0.6.3.json.c.o -MF src/libvmaf.3.dylib.p/meson-generated_.._vmaf_b_v0.6.3.json.c.o.d -o src/libvmaf.3.dylib.p/meson-generated_.._vmaf_b_v0.6.3.json.c.o -c src/vmaf_b_v0.6.3.json.c FAILED: src/libvmaf.3.dylib.p/meson-generated_.._vmaf_b_v0.6.3.json.c.o clang -Isrc/libvmaf.3.dylib.p -Isrc -I../src -Iinclude -I../include -I../src/feature -I../src/feature/common -fdiagnostics-color=always -Wall -Winvalid-pch -Wextra -std=c11 -O3 -D_DARWIN_C_SOURCE -pedantic -DOC_NEW_STYLE_INCLUDES -MD -MQ src/libvmaf.3.dylib.p/meson-generated_.._vmaf_b_v0.6.3.json.c.o -MF src/libvmaf.3.dylib.p/meson-generated_.._vmaf_b_v0.6.3.json.c.o.d -o src/libvmaf.3.dylib.p/meson-generated_.._vmaf_b_v0.6.3.json.c.o -c src/vmaf_b_v0.6.3.json.c src/vmaf_b_v0.6.3.json.c:34077:1: error: unknown type name 'size_t' size_t src_vmaf_b_v0_6_3_json_len = 408883;
^
1 error generated.
[46/165] clang -Isrc/liblibvmaf_feature.a.p -Isrc -I../src -Iinclude -I../include -I../src/feature -I../src/feature/common -I../src/cuda -fdiagnostics-color=always -Wall -Winvalid-pch -Wextra -std=c11 -O3 -D_DARWIN_C_SOURCE -MD -MQ src/liblibvmaf_feature.a.p/feature_integer_adm.c.o -MF src/liblibvmaf_feature.a.p/feature_integer_adm.c.o.d -o src/liblibvmaf_feature.a.p/feature_integer_adm.c.o -c ../src/feature/integer_adm.c ninja: build stopped: subcommand failed.

Do not report this issue to Homebrew/brew or Homebrew/homebrew-core!

Error: You are using macOS 11.
We (and Apple) do not provide support for this old version.
~~~
