### PR TITLE
[notation] Add warning for closed notations not at level 0

### DIFF
--- a/doc/changelog/03-notations/18588-closed_notation_level0.rst
+++ b/doc/changelog/03-notations/18588-closed_notation_level0.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  :warn:`closed-notation-not-level-0` and :warn:`postfix-notation-not-level-1`
+  warnings about closed and postfix notations at unusual levels
+  (`#18588 <https://github.com/coq/coq/pull/18588>`_,
+  by Pierre Roux).

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -245,6 +245,11 @@ have to be observed for notations starting with a symbol, e.g., rules
 starting with “\ ``{``\ ” or “\ ``(``\ ” should be put at level 0. The list
 of Coq predefined notations can be found in the chapter on :ref:`thecoqlibrary`.
 
+.. warn:: Closed notations (i.e. starting and ending with a terminal symbol) should usually be at level 0 (default).
+   :name: closed-notation-not-level-0
+
+   It is usually better to put closed notations, that is the ones starting and ending with a terminal symbol, at level 0.
+
 .. _UseOfNotationsForPrinting:
 
 Use of notations for printing

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -250,6 +250,11 @@ of Coq predefined notations can be found in the chapter on :ref:`thecoqlibrary`.
 
    It is usually better to put closed notations, that is the ones starting and ending with a terminal symbol, at level 0.
 
+.. warn:: Postfix notations (i.e. starting with a nonterminal symbol and ending with a terminal symbol) should usually be at level 1 (default).")
+   :name: postfix-notation-not-level-1
+
+   It is usually better to put postfix notations, that is the ones ending with a terminal symbol, at level 1.
+
 .. _UseOfNotationsForPrinting:
 
 Use of notations for printing

--- a/test-suite/output/Notations3.out
+++ b/test-suite/output/Notations3.out
@@ -116,6 +116,10 @@ where
      : nat * (nat * nat)
 {{0, 1, 2, 3}}
      : nat * (nat * (nat * nat))
+File "./output/Notations3.v", line 178, characters 0-174:
+Warning: Closed notations (i.e. starting and ending with a terminal symbol)
+should usually be at level 0 (default).
+[closed-notation-not-level-0,parsing,default]
 letpair x [1] = {0};
 return (1, 2, 3, 4)
      : nat * nat * nat * nat

--- a/theories/Init/Notations.v
+++ b/theories/Init/Notations.v
@@ -69,6 +69,7 @@ Reserved Notation "{ x }" (at level 0, x at level 99).
 
 (** Notations for sigma-types or subsets *)
 
+#[warning="-closed-notation-not-level-0"]
 Reserved Notation "{ A }  +  { B }" (at level 50, left associativity).
 Reserved Notation "A  +  { B }" (at level 50, left associativity).
 

--- a/theories/Init/Notations.v
+++ b/theories/Init/Notations.v
@@ -71,6 +71,7 @@ Reserved Notation "{ x }" (at level 0, x at level 99).
 
 #[warning="-closed-notation-not-level-0"]
 Reserved Notation "{ A }  +  { B }" (at level 50, left associativity).
+#[warning="-postfix-notation-not-level-1"]
 Reserved Notation "A  +  { B }" (at level 50, left associativity).
 
 Reserved Notation "{ x | P }" (at level 0, x at level 99).

--- a/theories/Logic/Hurkens.v
+++ b/theories/Logic/Hurkens.v
@@ -102,6 +102,7 @@ Reserved Notation "'λ₁' x , u" (at level 200, x name, right associativity).
 Reserved Notation "f '·₁' x" (at level 5, left associativity).
 Reserved Notation "'∀₂' A , F" (at level 200, A name, right associativity).
 Reserved Notation "'λ₂' x , u" (at level 200, x name, right associativity).
+#[warning="-postfix-notation-not-level-1"]
 Reserved Notation "f '·₁' [ A ]" (at level 5, left associativity).
 Reserved Notation "'∀₀' x : A , B" (at level 200, x name, A at level 200,right associativity).
 Reserved Notation "A '⟶₀' B" (at level 99, right associativity, B at level 200).
@@ -109,6 +110,7 @@ Reserved Notation "'λ₀' x , u" (at level 200, x name, right associativity).
 Reserved Notation "f '·₀' x" (at level 5, left associativity).
 Reserved Notation "'∀₀¹' A : U , F" (at level 200, A name, right associativity).
 Reserved Notation "'λ₀¹' x , u" (at level 200, x name, right associativity).
+#[warning="-postfix-notation-not-level-1"]
 Reserved Notation "f '·₀' [ A ]" (at level 5, left associativity).
 
 (* end hide *)

--- a/theories/ssr/ssreflect.v
+++ b/theories/ssr/ssreflect.v
@@ -89,11 +89,11 @@ Module SsrSyntax.
  Arguments of application-style notations (at level 10) should be declared
  at level 8 rather than 9 or the camlp5 grammar will not factor properly.    **)
 
-Reserved Notation "(* x 'is' y 'of' z 'isn't' // /= //= *)" (at level 8).
-Reserved Notation "(* 69 *)" (at level 69).
+Reserved Notation "(* x 'is' y 'of' z 'isn't' // /= //= *)".
+Reserved Notation "(* 69 *)".
 
 (**  Non ambiguous keyword to check if the SsrSyntax module is imported  **)
-Reserved Notation "(* Use to test if 'SsrSyntax_is_Imported' *)" (at level 8).
+Reserved Notation "(* Use to test if 'SsrSyntax_is_Imported' *)".
 
 Reserved Notation "<hidden n >" (at level 0, n at level 0,
   format "<hidden  n >").

--- a/theories/ssr/ssreflect.v
+++ b/theories/ssr/ssreflect.v
@@ -97,6 +97,7 @@ Reserved Notation "(* Use to test if 'SsrSyntax_is_Imported' *)".
 
 Reserved Notation "<hidden n >" (at level 0, n at level 0,
   format "<hidden  n >").
+#[warning="-postfix-notation-not-level-1"]
 Reserved Notation "T (* n *)" (at level 200, format "T  (* n *)").
 
 End SsrSyntax.

--- a/theories/ssr/ssrfun.v
+++ b/theories/ssr/ssrfun.v
@@ -287,6 +287,7 @@ Reserved Notation "{ 'mono' f : x y /~ a }" (at level 0, f at level 99,
   x name, y name, format "{ 'mono'  f  :  x  y  /~  a }").
 
 Reserved Notation "@ 'id' T" (at level 10, T at level 8, format "@ 'id'  T").
+#[warning="-closed-notation-not-level-0"]
 Reserved Notation "@ 'sval'" (at level 10, format "@ 'sval'").
 
 (**

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1292,6 +1292,12 @@ let warn_closed_notation_not_level_0 =
                        terminal symbol) should usually be at level 0 \
                        (default).")
 
+let warn_postfix_notation_not_level_1 =
+  CWarnings.create ~name:"postfix-notation-not-level-1" ~category:CWarnings.CoreCategories.parsing
+    (fun () -> strbrk "Postfix notations (i.e. starting with a \
+                       nonterminal symbol and ending with a terminal \
+                       symbol) should usually be at level 1 (default).")
+
 let find_precedence custom lev etyps symbols onlyprint =
   let first_symbol =
     let rec aux = function
@@ -1309,11 +1315,16 @@ let find_precedence custom lev etyps symbols onlyprint =
   match first_symbol with
   | None -> [],0
   | Some (NonTerminal x) ->
+      let msgs, lev = match last_is_terminal (), lev with
+        | false, _ -> [], lev
+        | true, None -> [fun () -> Flags.if_verbose (Feedback.msg_info ?loc:None) (strbrk "Setting postfix notation at level 1.")], Some 1
+        | true, Some 1 -> [], Some 1
+        | true, Some n -> [fun () -> warn_postfix_notation_not_level_1 ()], Some n in
       let test () =
         if onlyprint then
           if Option.is_empty lev then
             user_err Pp.(str "Explicit level needed in only-printing mode when the level of the leftmost non-terminal is given.")
-          else [],Option.get lev
+          else msgs,Option.get lev
         else
           user_err Pp.(str "The level of the leftmost non-terminal cannot be changed.") in
       (try match List.assoc x etyps, custom with
@@ -1323,7 +1334,7 @@ let find_precedence custom lev etyps symbols onlyprint =
             | None ->
               ([fun () -> Flags.if_verbose (Feedback.msg_info ?loc:None) (strbrk "Setting notation at level 0.")],0)
             | Some 0 ->
-              ([],0)
+              (msgs,0)
             | _ ->
               user_err Pp.(str "A notation starting with an atomic expression must be at level 0.")
             end
@@ -1334,11 +1345,11 @@ let find_precedence custom lev etyps symbols onlyprint =
             (* Give a default ? *)
             if Option.is_empty lev then
               user_err Pp.(str "Need an explicit level.")
-            else [],Option.get lev
+            else msgs,Option.get lev
       with Not_found ->
         if Option.is_empty lev then
           user_err Pp.(str "A left-recursive notation must have an explicit level.")
-        else [],Option.get lev)
+        else msgs,Option.get lev)
   | Some (Terminal _) when last_is_terminal () ->
       begin match lev with
       | None -> [fun () -> Flags.if_verbose (Feedback.msg_info ?loc:None) (strbrk "Setting notation at level 0.")], 0


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
<!-- Fixes / closes #???? -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [x] Documented any new / changed **user messages**.
  - [ ] ~Updated **documented syntax** by running `make doc_gram_rsts`.~

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] ~Opened **overlay** pull requests.~

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
