### PR TITLE
Uniformize semantics of :> in class after deprecation phase of #16230

### DIFF
--- a/doc/changelog/02-specification-language/18590-cleanup_16230.rst
+++ b/doc/changelog/02-specification-language/18590-cleanup_16230.rst
@@ -1,0 +1,51 @@
+- **Changed:**
+  warnings `future-coercion-class-constructor`
+  and `future-coercion-class-field` about ``:>`` in :cmd:`Class` as
+  error by default. This offers a last opportunity to replace ``:>``
+  with ``::`` (available since Coq 8.18) to declare typeclass instances
+  before making ``:>`` consistently declare coercions in all records in
+  next version.
+  To adapt huge codebases, you can try
+  `this script <https://gist.github.com/JasonGross/59fc3c03664f2280849abf50b531be42>`_
+  or the one below. But beware that both are incomplete.
+
+  .. code-block:: sh
+
+     #!/bin/awk -f
+     BEGIN {
+       startclass = 0;
+       inclass = 0;
+       indefclass = 0;  # definitionalclasses (single field, without { ... })
+     }
+     {
+       if ($0 ~ "[ ]*Class") {
+         startclass = 1;
+       }
+       if (startclass == 1 && $0 ~ ":=") {
+         inclass = 1;
+         indefclass = 1;
+       }
+       if (startclass == 1 && $0 ~ ":=.*{") {
+         indefclass = 0;
+       }
+       if (inclass == 1) startclass = 0;
+
+       if (inclass == 1 && $0 ~ ":>") {
+         if ($0 ~ "{ .*:>") {  # first field on a single line
+           sub("{ ", "{ #[global] ");
+         } else if ($0 ~ ":=.*:>") {  # definitional classes on a single line
+           sub(":= ", ":= #[global] ");
+         } else if ($0 ~ "^  ") {
+           sub("  ", "  #[global] ");
+         } else {
+           $0 = "#[global] " $0;
+         }
+         sub(":>", "::")
+       }
+     print $0;
+
+     if ($0 ~ ".*}[.]" || indefclass == 1 && $0 ~ "[.]$") inclass = 0;
+   }
+
+  (`#18590 <https://github.com/coq/coq/pull/18590>`_,
+  by Pierre Roux).

--- a/doc/sphinx/addendum/type-classes.rst
+++ b/doc/sphinx/addendum/type-classes.rst
@@ -248,7 +248,7 @@ the implicit arguments mechanism if available, as shown in the example.
 Substructures
 ~~~~~~~~~~~~~
 
-.. index:: :> (substructure)
+.. index:: :: (substructure)
 
 Substructures are components of a typeclass which are themselves instances of a
 typeclass. They often arise when using typeclasses for logical properties, e.g.:

--- a/test-suite/bugs/HoTT_coq_058.v
+++ b/test-suite/bugs/HoTT_coq_058.v
@@ -30,7 +30,7 @@ Local Open Scope equiv_scope.
 
 Notation "f ^-1" := (@equiv_inv _ _ f _) (at level 3) : equiv_scope.
 
-Class Funext := { isequiv_apD10 :> forall (A : Type) (P : A -> Type) f g, IsEquiv (@apD10 A P f g) }.
+Class Funext := { isequiv_apD10 :: forall (A : Type) (P : A -> Type) f g, IsEquiv (@apD10 A P f g) }.
 
 Definition path_forall `{Funext} {A : Type} {P : A -> Type} (f g : forall x : A, P x) :
   (forall x, f x = g x) -> f = g

--- a/test-suite/bugs/HoTT_coq_059.v
+++ b/test-suite/bugs/HoTT_coq_059.v
@@ -5,7 +5,7 @@ Inductive eq {A} (x : A) : A -> Type := eq_refl : eq x x.
 Notation "a = b" := (eq a b) : type_scope.
 
 Section foo.
-  Class Funext := { path_forall :> forall A P (f g : forall x : A, P x), (forall x, f x = g x) -> f = g }.
+  Class Funext := { path_forall :: forall A P (f g : forall x : A, P x), (forall x, f x = g x) -> f = g }.
   Context `{Funext, Funext}.
 
   Set Printing Universes.

--- a/test-suite/bugs/HoTT_coq_062.v
+++ b/test-suite/bugs/HoTT_coq_062.v
@@ -52,7 +52,7 @@ Definition equiv_path (A B : Type) (p : A = B) : A <~> B
   := BuildEquiv _ _ (transport (fun X:Type => X) p) admit.
 
 Class Univalence :=
-  isequiv_equiv_path :> forall (A B : Type), IsEquiv (equiv_path A B) .
+  isequiv_equiv_path :: forall (A B : Type), IsEquiv (equiv_path A B) .
 
 Section Univalence.
   Context `{Univalence}.

--- a/test-suite/bugs/HoTT_coq_088.v
+++ b/test-suite/bugs/HoTT_coq_088.v
@@ -35,7 +35,7 @@ Definition equiv_path (A B : Type) (p : A = B) : Equiv A B.
 Admitted.
 
 Class Univalence := {
-  isequiv_equiv_path :> forall (A B : Type), IsEquiv (equiv_path A B)
+  isequiv_equiv_path :: forall (A B : Type), IsEquiv (equiv_path A B)
 }.
 
 Definition ua_downward_closed `{Univalence} : Univalence.

--- a/test-suite/bugs/HoTT_coq_108.v
+++ b/test-suite/bugs/HoTT_coq_108.v
@@ -61,7 +61,7 @@ Notation Contr := (IsTrunc minus_two).
 Notation IsHSet := (IsTrunc 0).
 
 Class Funext :=
-  { isequiv_apD10 :> forall (A : Type) (P : A -> Type) f g, IsEquiv (@apD10 A P f g) }.
+  { isequiv_apD10 :: forall (A : Type) (P : A -> Type) f g, IsEquiv (@apD10 A P f g) }.
 Global Instance contr_forall `{Funext} `{P : A -> Type} `{forall a, Contr (P a)}
 : Contr (forall a, P a) | 100.
 admit.

--- a/test-suite/bugs/HoTT_coq_112.v
+++ b/test-suite/bugs/HoTT_coq_112.v
@@ -42,7 +42,7 @@ Definition equiv_path (A B : Type) (p : A = B) : A <~> B
   := BuildEquiv _ _ (transport (fun X:Type => X) p) _.
 
 Class Univalence := {
-  isequiv_equiv_path :> forall (A B : Type), IsEquiv (equiv_path A B)
+  isequiv_equiv_path :: forall (A B : Type), IsEquiv (equiv_path A B)
 }.
 
 Section Univalence.

--- a/test-suite/bugs/HoTT_coq_123.v
+++ b/test-suite/bugs/HoTT_coq_123.v
@@ -46,7 +46,7 @@ Class IsTrunc (n : trunc_index) (A : Type) : Type :=
 Notation IsHSet := (IsTrunc minus_two).
 
 Class Funext :=
-  { isequiv_apD10 :> forall (A : Type) (P : A -> Type) f g, IsEquiv (@apD10 A P f g) }.
+  { isequiv_apD10 :: forall (A : Type) (P : A -> Type) f g, IsEquiv (@apD10 A P f g) }.
 
 Local Open Scope equiv_scope.
 

--- a/test-suite/bugs/bug_14221.v
+++ b/test-suite/bugs/bug_14221.v
@@ -14,7 +14,7 @@ Notation "∀  x .. y , P" := (forall x, .. (forall y, P) ..)
 
 Class Setoid A := {
   equiv : crelation A;
-  setoid_equiv :> Equivalence equiv
+  setoid_equiv :: Equivalence equiv
 }.
 
 Notation "f ≈ g" := (equiv f g) (at level 79).
@@ -46,7 +46,7 @@ Class Category := {
 
   uhom := Type : Type;
   hom : obj -> obj -> uhom where "a ~> b" := (hom a b);
-  homset :> ∀ X Y, Setoid (X ~> Y);
+  homset :: ∀ X Y, Setoid (X ~> Y);
 
   id {x} : x ~> x;
 }.
@@ -71,7 +71,7 @@ Class Functor (C D : Category) := {
   fobj : C -> D;
   fmap {x y : C} (f : x ~> y) : fobj x ~> fobj y;
 
-  fmap_respects :> ∀ x y, Proper (equiv ==> equiv) (@fmap x y);
+  fmap_respects :: ∀ x y, Proper (equiv ==> equiv) (@fmap x y);
 
   fmap_id {x : C} : fmap (@id C x) ≈ id;
 }.

--- a/test-suite/bugs/bug_15099.v
+++ b/test-suite/bugs/bug_15099.v
@@ -8,7 +8,7 @@ Set Universe Polymorphism.
 
 Class Setoid A := {
   equiv : crelation A;
-  setoid_equiv :> Equivalence equiv
+  setoid_equiv :: Equivalence equiv
 }.
 
 Notation "f ≈ g" := (equiv f g) (at level 79) : category_theory_scope.
@@ -19,7 +19,7 @@ Class Category := {
   obj : Type;
 
   hom : obj -> obj -> Type where "a ~> b" := (hom a b);
-  homset :> forall X Y, Setoid (X ~> Y);
+  homset :: forall X Y, Setoid (X ~> Y);
 
   id {x} : x ~> x;
 
@@ -38,7 +38,7 @@ Class Functor {C D : Category} := {
   fobj : C -> D;
   fmap {x y : C} (f : x ~> y) : fobj x ~> fobj y;
 
-  fmap_respects :> forall x y, Proper (equiv ==> equiv) (@fmap x y);
+  fmap_respects :: forall x y, Proper (equiv ==> equiv) (@fmap x y);
 
   fmap_id {x : C} : fmap (@id C x) ≈ id;
 }.

--- a/test-suite/bugs/bug_16204.v
+++ b/test-suite/bugs/bug_16204.v
@@ -6,7 +6,7 @@ Class IsProp (A : Type) : Prop :=
   irrel (x y : A) : x = y.
 
 Class IsProofIrrel : Prop :=
-  proof_irrel (A : Prop) :> IsProp A.
+  proof_irrel (A : Prop) :: IsProp A.
 
 Class IsPropExt : Prop :=
   prop_ext (A B : Prop) (a : A <-> B) : A = B.

--- a/test-suite/bugs/bug_3321.v
+++ b/test-suite/bugs/bug_3321.v
@@ -7,7 +7,7 @@ Class IsEquiv {A B : Type} (f : A -> B) := BuildIsEquiv { equiv_inv : B -> A ; e
 Record Equiv A B := BuildEquiv { equiv_fun :> A -> B ; equiv_isequiv :> IsEquiv equiv_fun }.
 Definition hfiber {A B : Type} (f : A -> B) (y : B) := { x : A & f x = y }.
 Definition equiv_path (A B : Type) (p : A = B) : Equiv A B := admit.
-Class Univalence := { isequiv_equiv_path :> forall (A B : Type), IsEquiv (equiv_path A B) }.
+Class Univalence := { isequiv_equiv_path :: forall (A B : Type), IsEquiv (equiv_path A B) }.
 Definition path_universe `{Univalence} {A B : Type} (f : A -> B) {feq : IsEquiv f} : (A = B) := admit.
 Context `{ua:Univalence}.
 Variable A:Type.

--- a/test-suite/bugs/bug_3329.v
+++ b/test-suite/bugs/bug_3329.v
@@ -15,7 +15,7 @@ Definition apD10 {A} {B:A->Type} {f g : forall x, B x} (h:f=g)
   := fun x => match h with idpath => idpath end.
 Class IsEquiv {A B : Type} (f : A -> B) := BuildIsEquiv { equiv_inv : B -> A }.
 Class IsHSet (A : Type) := { _ : False }.
-Class Funext := { isequiv_apD10 :> forall (A : Type) (P : A -> Type) f g, IsEquiv (@apD10 A P f g) }.
+Class Funext := { isequiv_apD10 :: forall (A : Type) (P : A -> Type) f g, IsEquiv (@apD10 A P f g) }.
 Record PreCategory :=
   { object :> Type;
     morphism : object -> object -> Type;

--- a/test-suite/bugs/bug_3330.v
+++ b/test-suite/bugs/bug_3330.v
@@ -132,7 +132,7 @@ Class IsTrunc (n : trunc_index) (A : Type) : Type :=
 Notation IsHSet := (IsTrunc 0).
 
 Class Funext :=
-  { isequiv_apD10 :> forall (A : Type) (P : A -> Type) f g, IsEquiv (@apD10 A P f g) }.
+  { isequiv_apD10 :: forall (A : Type) (P : A -> Type) f g, IsEquiv (@apD10 A P f g) }.
 
 Definition path_forall `{Funext} {A : Type} {P : A -> Type} (f g : forall x : A, P x) :
   f == g -> f = g
@@ -357,8 +357,8 @@ Class IsIsomorphism {C : PreCategory} {s d} (m : morphism C s d) :=
 
 Class Isomorphic {C : PreCategory} s d :=
   {
-    morphism_isomorphic :> morphism C s d;
-    isisomorphism_isomorphic :> IsIsomorphism morphism_isomorphic
+    morphism_isomorphic :: morphism C s d;
+    isisomorphism_isomorphic :: IsIsomorphism morphism_isomorphic
   }.
 
 Module Export CategoryMorphismsNotations.

--- a/test-suite/bugs/bug_3393.v
+++ b/test-suite/bugs/bug_3393.v
@@ -13,7 +13,7 @@ Class IsEquiv {A B : Type} (f : A -> B) := BuildIsEquiv { equiv_inv : B -> A }.
 Delimit Scope equiv_scope with equiv.
 Local Open Scope equiv_scope.
 Notation "f ^-1" := (@equiv_inv _ _ f _) (at level 3) : equiv_scope.
-Class Funext := { isequiv_apD10 :> forall (A : Type) (P : A -> Type) f g, IsEquiv (@apD10 A P f g) }.
+Class Funext := { isequiv_apD10 :: forall (A : Type) (P : A -> Type) f g, IsEquiv (@apD10 A P f g) }.
 Definition path_forall `{Funext} {A : Type} {P : A -> Type} (f g : forall x : A, P x) : (forall x, f x = g x) -> f = g := (@apD10 A P f g)^-1.
 Record PreCategory :=
   { object :> Type;
@@ -33,8 +33,8 @@ Notation "F '_1' m" := (@morphism_of _ _ F _ _ m) (at level 10, no associativity
 Class IsIsomorphism {C : PreCategory} {s d} (m : morphism C s d) := { morphism_inverse : morphism C d s }.
 Local Notation "m ^-1" := (morphism_inverse (m := m)) : morphism_scope.
 Class Isomorphic {C : PreCategory} s d :=
-  { morphism_isomorphic :> morphism C s d;
-    isisomorphism_isomorphic :> IsIsomorphism morphism_isomorphic }.
+  { morphism_isomorphic :: morphism C s d;
+    isisomorphism_isomorphic :: IsIsomorphism morphism_isomorphic }.
 Coercion morphism_isomorphic : Isomorphic >-> morphism.
 Definition isisomorphism_inverse `(@IsIsomorphism C x y m) : IsIsomorphism m^-1 := {| morphism_inverse := m |}.
 

--- a/test-suite/bugs/bug_3422.v
+++ b/test-suite/bugs/bug_3422.v
@@ -52,8 +52,8 @@ Local Notation "m ^-1" := (morphism_inverse (m := m)) : morphism_scope.
 
 Class Isomorphic {C : PreCategory} s d :=
   {
-    morphism_isomorphic :> morphism C s d;
-    isisomorphism_isomorphic :> IsIsomorphism morphism_isomorphic
+    morphism_isomorphic :: morphism C s d;
+    isisomorphism_isomorphic :: IsIsomorphism morphism_isomorphic
   }.
 
 Coercion morphism_isomorphic : Isomorphic >-> morphism.

--- a/test-suite/bugs/bug_3427.v
+++ b/test-suite/bugs/bug_3427.v
@@ -74,7 +74,7 @@ Notation IsHProp := (IsTrunc minus_one).
 Notation IsHSet := (IsTrunc 0).
 
 Class Funext :=
-  { isequiv_apD10 :> forall (A : Type) (P : A -> Type) f g, IsEquiv (@apD10 A P f g) }.
+  { isequiv_apD10 :: forall (A : Type) (P : A -> Type) f g, IsEquiv (@apD10 A P f g) }.
 
 Definition concat_pV {A : Type} {x y : A} (p : x = y) :
   p @ p^ = 1
@@ -136,7 +136,7 @@ Definition equiv_path (A B : Type) (p : A = B) : A <~> B
   := BuildEquiv _ _ (transport (fun X:Type => X) p) _.
 
 Class Univalence := {
-                     isequiv_equiv_path :> forall (A B : Type), IsEquiv (equiv_path A B)
+                     isequiv_equiv_path :: forall (A B : Type), IsEquiv (equiv_path A B)
                    }.
 
 Section Univalence.

--- a/test-suite/bugs/bug_3480.v
+++ b/test-suite/bugs/bug_3480.v
@@ -10,7 +10,7 @@ Delimit Scope category_scope with category.
 Record PreCategory := { object :> Type ; morphism : object -> object -> Type }.
 Local Open Scope category_scope.
 Class IsIsomorphism {C : PreCategory} {s d} (m : morphism C s d) := { morphism_inverse : morphism C d s }.
-Class Isomorphic {C : PreCategory} s d := { morphism_isomorphic :> @morphism C s d ; isisomorphism_isomorphic :> IsIsomorphism morphism_isomorphic }.
+Class Isomorphic {C : PreCategory} s d := { morphism_isomorphic :: @morphism C s d ; isisomorphism_isomorphic :: IsIsomorphism morphism_isomorphic }.
 Coercion morphism_isomorphic : Isomorphic >-> morphism.
 Local Infix "<~=~>" := Isomorphic (at level 70, no associativity) : category_scope.
 Definition idtoiso (C : PreCategory) (x y : C) (H : x = y) : Isomorphic x y := admit.

--- a/test-suite/bugs/bug_3513.v
+++ b/test-suite/bugs/bug_3513.v
@@ -10,7 +10,7 @@ Class ILogicOps Frm := { lentails: relation Frm;
                          land: Frm -> Frm -> Frm;
                          lor: Frm -> Frm -> Frm }.
 Infix "|--"  := lentails (at level 79, no associativity).
-Class ILogic Frm {ILOps: ILogicOps Frm} := { lentailsPre:> PreOrder lentails }.
+Class ILogic Frm {ILOps: ILogicOps Frm} := { lentailsPre :: PreOrder lentails }.
 Definition lequiv `{ILogic Frm} P Q := P |-- Q /\ Q |-- P.
 Infix "-|-"  := lequiv (at level 85, no associativity).
 #[export] Instance lequiv_inverse_lentails `{ILogic Frm} {inverse} : subrelation lequiv (inverse lentails) := admit.

--- a/test-suite/bugs/bug_3647.v
+++ b/test-suite/bugs/bug_3647.v
@@ -266,7 +266,7 @@ Notation "'Exists' x .. y , p" :=
   (lexists (fun x => .. (lexists (fun y => p)) .. )) (at level 78, x binder, y binder, right associativity).
 
 Class ILogic Frm {ILOps: ILogicOps Frm} := {
-                                            lentailsPre:> PreOrder lentails;
+                                            lentailsPre :: PreOrder lentails;
                                             ltrueR: forall C, C |-- ltrue;
                                             lfalseL: forall C, lfalse |-- C;
                                             lforallL: forall T x (P: T -> Frm) C, P x |-- C -> lforall P |-- C;

--- a/test-suite/bugs/bug_3661.v
+++ b/test-suite/bugs/bug_3661.v
@@ -15,8 +15,8 @@ Class IsIsomorphism {C : PreCategory} {s d} (m : morphism C s d) := { morphism_i
 Record NaturalTransformation C D (F G : Functor C D) := { components_of :> forall c, morphism D (F c) (G c) }.
 Unset Primitive Projections.
 Class Isomorphic {C : PreCategory} s d :=
-  { morphism_isomorphic :> morphism C s d;
-    isisomorphism_isomorphic :> IsIsomorphism morphism_isomorphic }.
+  { morphism_isomorphic :: morphism C s d;
+    isisomorphism_isomorphic :: IsIsomorphism morphism_isomorphic }.
 Arguments morphism_inverse {C s d} m {_} / .
 Local Notation "m ^-1" := (morphism_inverse m) (at level 3, format "m '^-1'") : morphism_scope.
 Definition functor_category (C D : PreCategory) : PreCategory.

--- a/test-suite/bugs/bug_3699.v
+++ b/test-suite/bugs/bug_3699.v
@@ -21,12 +21,12 @@ Module NonPrim.
   Notation "x .1" := (pr1 x) (at level 3, format "x '.1'") : fibration_scope.
   Notation "x .2" := (pr2 x) (at level 3, format "x '.2'") : fibration_scope.
   Definition hfiber {A B : Type} (f : A -> B) (y : B) := { x : A & f x = y }.
-  Class IsConnected (n : trunc_index) (A : Type) := isconnected_contr_trunc :> Contr (Trunc n A).
+  Class IsConnected (n : trunc_index) (A : Type) := isconnected_contr_trunc :: Contr (Trunc n A).
   Axiom isconnected_elim : forall {n} {A} `{IsConnected n A}
                                   (C : Type) `{IsTrunc n C} (f : A -> C),
                              { c:C & forall a:A, f a = c }.
   Class IsConnMap (n : trunc_index) {A B : Type} (f : A -> B)
-    := isconnected_hfiber_conn_map :> forall b:B, IsConnected n (hfiber f b).
+    := isconnected_hfiber_conn_map :: forall b:B, IsConnected n (hfiber f b).
   Definition conn_map_elim {n : trunc_index}
              {A B : Type} (f : A -> B) `{IsConnMap n _ _ f}
              (P : B -> Type) {HP : forall b:B, IsTrunc n (P b)}
@@ -96,12 +96,12 @@ Module Prim.
   Notation "x .1" := (pr1 x) (at level 3, format "x '.1'") : fibration_scope.
   Notation "x .2" := (pr2 x) (at level 3, format "x '.2'") : fibration_scope.
   Definition hfiber {A B : Type} (f : A -> B) (y : B) := { x : A & f x = y }.
-  Class IsConnected (n : trunc_index) (A : Type) := isconnected_contr_trunc :> Contr (Trunc n A).
+  Class IsConnected (n : trunc_index) (A : Type) := isconnected_contr_trunc :: Contr (Trunc n A).
   Axiom isconnected_elim : forall {n} {A} `{IsConnected n A}
                                   (C : Type) `{IsTrunc n C} (f : A -> C),
                              { c:C & forall a:A, f a = c }.
   Class IsConnMap (n : trunc_index) {A B : Type} (f : A -> B)
-    := isconnected_hfiber_conn_map :> forall b:B, IsConnected n (hfiber f b).
+    := isconnected_hfiber_conn_map :: forall b:B, IsConnected n (hfiber f b).
   Definition conn_map_elim {n : trunc_index}
              {A B : Type} (f : A -> B) `{IsConnMap n _ _ f}
              (P : B -> Type) {HP : forall b:B, IsTrunc n (P b)}

--- a/test-suite/bugs/bug_3943.v
+++ b/test-suite/bugs/bug_3943.v
@@ -35,8 +35,8 @@ Arguments morphism_inverse {C s d} m {_}.
 Local Notation "m ^-1" := (morphism_inverse m) (at level 3, format "m '^-1'") : morphism_scope.
 
 Class Isomorphic {C : PreCategory} s d := {
-    morphism_isomorphic :> morphism C s d;
-    isisomorphism_isomorphic :> IsIsomorphism morphism_isomorphic }.
+    morphism_isomorphic :: morphism C s d;
+    isisomorphism_isomorphic :: IsIsomorphism morphism_isomorphic }.
 Coercion morphism_isomorphic : Isomorphic >-> morphism.
 
 Variable C : PreCategory.

--- a/test-suite/bugs/bug_3960.v
+++ b/test-suite/bugs/bug_3960.v
@@ -16,7 +16,7 @@ Class myClass (A: Type) :=
 
 Class myClassP (A : Type)  :=
   {
-    super :> myClass A;
+    super :: myClass A;
     barP : forall (a : A), bar a
   }.
 

--- a/test-suite/bugs/bug_4095.v
+++ b/test-suite/bugs/bug_4095.v
@@ -12,7 +12,7 @@ Class ILogicOps Frm := { lentails: relation Frm;
                          land: Frm -> Frm -> Frm;
                          lor: Frm -> Frm -> Frm }.
 Infix "|--"  := lentails (at level 79, no associativity).
-Class ILogic Frm {ILOps: ILogicOps Frm} := { lentailsPre:> PreOrder lentails }.
+Class ILogic Frm {ILOps: ILogicOps Frm} := { lentailsPre :: PreOrder lentails }.
 Definition lequiv `{ILogic Frm} P Q := P |-- Q /\ Q |-- P.
 Infix "-|-"  := lequiv (at level 85, no associativity).
 #[export] Instance lequiv_inverse_lentails `{ILogic Frm} {inverse} : subrelation lequiv (inverse lentails) := admit.

--- a/test-suite/bugs/bug_4116.v
+++ b/test-suite/bugs/bug_4116.v
@@ -251,8 +251,8 @@ Module Export Morphisms.
 
   Class Isomorphic {C : PreCategory} s d :=
     {
-      morphism_isomorphic :> morphism C s d;
-      isisomorphism_isomorphic :> IsIsomorphism morphism_isomorphic
+      morphism_isomorphic :: morphism C s d;
+      isisomorphism_isomorphic :: IsIsomorphism morphism_isomorphic
     }.
 
   Coercion morphism_isomorphic : Isomorphic >-> morphism.

--- a/test-suite/bugs/bug_4151.v
+++ b/test-suite/bugs/bug_4151.v
@@ -148,7 +148,7 @@ Module Export BaseTypes.
         ntl_wf : well_founded nonterminals_listT_R }.
 
     Class parser_computational_types_dataT :=
-      { predata :> parser_computational_predataT;
+      { predata :: parser_computational_predataT;
         split_stateT : String -> nonterminals_listT -> any_grammar CharType -> String -> Type }.
 
     Class parser_computational_dataT' `{parser_computational_types_dataT} :=
@@ -242,9 +242,9 @@ Section general.
   Context {CharType} {String : string_like CharType} {G : grammar CharType}.
 
   Class boolean_parser_dataT :=
-    { predata :> parser_computational_predataT;
+    { predata :: parser_computational_predataT;
       split_stateT : String -> Type;
-      data' :> _ := {| BaseTypes.predata := predata ; BaseTypes.split_stateT := fun _ _ _ => split_stateT |};
+      data' :: _ := {| BaseTypes.predata := predata ; BaseTypes.split_stateT := fun _ _ _ => split_stateT |};
       split_string_for_production
       : forall it its,
           StringWithSplitState String split_stateT
@@ -254,7 +254,7 @@ Section general.
           let P f := List.Forall f (split_string_for_production it its str) in
           P (fun s1s2 =>
                (fst s1s2 ++ snd s1s2 =s str) = true);
-      premethods :> parser_computational_dataT'
+      premethods :: parser_computational_dataT'
       := @Build_parser_computational_dataT'
            _ String data'
            (fun _ _ => split_string_for_production)

--- a/test-suite/bugs/bug_4187.v
+++ b/test-suite/bugs/bug_4187.v
@@ -131,7 +131,7 @@ Import Coq.Classes.Morphisms.
 Module Export StringLike.
   Class StringLike {Char : Type} :=
     {
-      String :> Type;
+      String :: Type;
       is_char : String -> Char -> bool;
       length : String -> nat;
       take : nat -> String -> String;
@@ -154,11 +154,11 @@ Module Export StringLike.
       singleton_unique : forall s ch ch', s ~= [ ch ] -> s ~= [ ch' ] -> ch = ch';
       length_singleton : forall s ch, s ~= [ ch ] -> length s = 1;
       bool_eq_char : forall s s' ch, s ~= [ ch ] -> s' ~= [ ch ] -> s =s s';
-      is_char_Proper :> Proper (beq ==> eq ==> eq) is_char;
-      length_Proper :> Proper (beq ==> eq) length;
-      take_Proper :> Proper (eq ==> beq ==> beq) take;
-      drop_Proper :> Proper (eq ==> beq ==> beq) drop;
-      bool_eq_Equivalence :> Equivalence beq;
+      is_char_Proper :: Proper (beq ==> eq ==> eq) is_char;
+      length_Proper :: Proper (beq ==> eq) length;
+      take_Proper :: Proper (eq ==> beq ==> beq) take;
+      drop_Proper :: Proper (eq ==> beq ==> beq) drop;
+      bool_eq_Equivalence :: Equivalence beq;
       bool_eq_empty : forall str str', length str = 0 -> length str' = 0 -> str =s str';
       take_short_length : forall str n, n <= length str -> length (take n str) = n;
       take_long : forall str n, length str <= n -> take n str =s str;
@@ -340,7 +340,7 @@ Section general.
   Context {Char} {HSL : StringLike Char} {G : grammar Char}.
 
   Class boolean_parser_dataT :=
-    { predata :> parser_computational_predataT;
+    { predata :: parser_computational_predataT;
       split_string_for_production
       : item Char -> production Char -> String -> list nat }.
 

--- a/test-suite/bugs/bug_4232.v
+++ b/test-suite/bugs/bug_4232.v
@@ -1,7 +1,7 @@
 Require Import Setoid Morphisms Vector.
 
 Class Equiv A := equiv : A -> A -> Prop.
-Class Setoid A `{Equiv A} := setoid_equiv:> Equivalence (equiv).
+Class Setoid A `{Equiv A} := setoid_equiv :: Equivalence (equiv).
 
 Global Declare Instance vec_equiv {A} `{Equiv A} {n}: Equiv (Vector.t A n).
 Global Declare Instance vec_setoid A `{Setoid A} n : Setoid (Vector.t A n).

--- a/test-suite/bugs/bug_4456.v
+++ b/test-suite/bugs/bug_4456.v
@@ -51,7 +51,7 @@ Local Coercion is_true : bool >-> Sortclass.
 Module Export StringLike.
   Class StringLike {Char : Type} :=
     {
-      String :> Type;
+      String :: Type;
       is_char : String -> Char -> bool;
       length : String -> nat;
       take : nat -> String -> String;
@@ -76,11 +76,11 @@ Module Export StringLike.
       unsafe_get_correct : forall n s ch, get n s = Some ch -> unsafe_get n s = ch;
       length_singleton : forall s ch, s ~= [ ch ] -> length s = 1;
       bool_eq_char : forall s s' ch, s ~= [ ch ] -> s' ~= [ ch ] -> s =s s';
-      is_char_Proper :> Proper (beq ==> eq ==> eq) is_char;
-      length_Proper :> Proper (beq ==> eq) length;
-      take_Proper :> Proper (eq ==> beq ==> beq) take;
-      drop_Proper :> Proper (eq ==> beq ==> beq) drop;
-      bool_eq_Equivalence :> Equivalence beq;
+      is_char_Proper :: Proper (beq ==> eq ==> eq) is_char;
+      length_Proper :: Proper (beq ==> eq) length;
+      take_Proper :: Proper (eq ==> beq ==> beq) take;
+      drop_Proper :: Proper (eq ==> beq ==> beq) drop;
+      bool_eq_Equivalence :: Equivalence beq;
       bool_eq_empty : forall str str', length str = 0 -> length str' = 0 -> str =s str';
       take_short_length : forall str n, n <= length str -> length (take n str) = n;
       take_long : forall str n, length str <= n -> take n str =s str;
@@ -211,8 +211,8 @@ Section recursive_descent_parser.
       : item Char -> production Char -> String -> list nat }.
 
   Class boolean_parser_dataT :=
-    { predata :> parser_computational_predataT;
-      split_data :> split_dataT }.
+    { predata :: parser_computational_predataT;
+      split_data :: split_dataT }.
 End recursive_descent_parser.
 
 End BaseTypes.

--- a/test-suite/bugs/bug_4503.v
+++ b/test-suite/bugs/bug_4503.v
@@ -22,7 +22,7 @@ Set Universe Polymorphism.
 Class ILogic@{L} (A : Type@{L}) : Type := mkILogic
 {
   lentails: A -> A -> Prop;
-  lentailsPre:> RelationClasses.PreOrder lentails
+  lentailsPre:: RelationClasses.PreOrder lentails
 }.
 
 

--- a/test-suite/bugs/bug_5521.v
+++ b/test-suite/bugs/bug_5521.v
@@ -25,7 +25,7 @@ Class Category := {
 }.
 
 Class Isomorphism `{C : Category} (X Y : @ob C) : Type := {
-  to   :> hom X Y;
+  to   :: hom X Y;
   from :  hom Y X
 
   (* If these two lines are commented out, the rewrite works at the bottom. *)

--- a/test-suite/bugs/bug_7916.v
+++ b/test-suite/bugs/bug_7916.v
@@ -166,7 +166,7 @@ Module Iris.
    Global Arguments decide _ {_} : simpl never, assert.
 
    Class RelDecision {A B} (R : A → B → Prop) :=
-     decide_rel x y :> Decision (R x y).
+     decide_rel x y :: Decision (R x y).
    Notation EqDecision A := (RelDecision (=@{A})).
 
    Class Inj {A B} (R : relation A) (S : relation B) (f : A → B) : Prop :=

--- a/test-suite/bugs/bug_8004.v
+++ b/test-suite/bugs/bug_8004.v
@@ -9,7 +9,7 @@ Infix "∧" := prod (at level 80, right associativity) : category_theory_scope.
 
 Class Setoid A := {
   equiv : crelation A;
-  setoid_equiv :> Equivalence equiv
+  setoid_equiv :: Equivalence equiv
 }.
 
 Notation "f ≈ g" := (equiv f g) (at level 79) : category_theory_scope.

--- a/test-suite/bugs/bug_8739.v
+++ b/test-suite/bugs/bug_8739.v
@@ -16,7 +16,7 @@ Notation "x → y" := (x -> y)
 
 Class Setoid A := {
   equiv : crelation A;
-  setoid_equiv :> Equivalence equiv
+  setoid_equiv :: Equivalence equiv
 }.
 
 Notation "f ≈ g" := (equiv f g) (at level 79) : category_theory_scope.
@@ -28,13 +28,13 @@ Class Category := {
 
   uhom := Type : Type;
   hom : obj -> obj -> uhom where "a ~> b" := (hom a b);
-  homset :> ∀ X Y, Setoid (X ~> Y);
+  homset :: ∀ X Y, Setoid (X ~> Y);
 
   id {x} : x ~> x;
   compose {x y z} (f: y ~> z) (g : x ~> y) : x ~> z
     where "f ∘ g" := (compose f g);
 
-  compose_respects x y z :>
+  compose_respects x y z ::
     Proper (equiv ==> equiv ==> equiv) (@compose x y z);
 
   dom {x y} (f: x ~> y) := x;
@@ -69,7 +69,7 @@ Open Scope morphism_scope.
 Context {C : Category}.
 
 Class Isomorphism (x y : C) : Type := {
-  to   :> x ~> y;
+  to   :: x ~> y;
   from :  y ~> x;
 
   iso_to_from : to ∘ from ≈ id;

--- a/test-suite/bugs/bug_9014.v
+++ b/test-suite/bugs/bug_9014.v
@@ -1,19 +1,19 @@
 (* A type, not a class *)
 Variant T := mkT.
 
-(* In records, :> declares a coercion *)
+(* :> declares a coercion *)
 Record R := { t_of_r :> T }.
 Check forall r : R, r = r :> T.
 
 (* A class *)
 Class A := { p : Prop }.
 (* A sub-class *)
-Class B := { a_of_b :> A ; t_of_b :> T }.
-(* The sub-instance is automatically inferred due to :> for a_of_b *)
+Class B := { a_of_b :: A ; t_of_b :: T }.
+(* The sub-instance is automatically inferred due to :: for a_of_b *)
 Check forall b : B, p.
 (* No coercion is introduced by :> in t_of_b *)
 Fail Check forall b : B, b = b :> T.
 
-(* Using :> when the RHS is not a class produces a “not-a-class” warning. *)
+(* Using :: when the RHS is not a class produces a “not-a-class” warning. *)
 Set Warnings "+not-a-class".
-Fail Class B' := { a_of_b' :> A ; t_of_b' :> T }.
+Fail Class B' := { a_of_b' :: A ; t_of_b' :: T }.

--- a/test-suite/output/bug_16224.out
+++ b/test-suite/output/bug_16224.out
@@ -1,12 +1,3 @@
-File "./output/bug_16224.v", line 9, characters 0-24:
-Warning: A coercion will be introduced instead of an instance in future
-versions when using ':>' in 'Class' declarations. Replace ':>' with '::' (or
-use '#[global] Existing Instance field.' for compatibility with Coq < 8.18).
-Beware that the default locality for '::' is #[export], as opposed to
-#[global] for ':>' currently. Add an explicit #[global] attribute to the
-field if you need to keep the current behavior. For example: "Class foo := {
-#[global] field :: bar }."
-[future-coercion-class-field,deprecated-since-8.17,deprecated,default]
 [reverse_coercion] : ReverseCoercionSource >-> ReverseCoercionTarget
 [rc] : Rc >-> A (reversible)
 [ric] : Ric >-> A (reversible)
@@ -14,4 +5,3 @@ ric : Ric -> A
 cic : Cic -> A
 ri : Ri -> A
 ci : Ci -> A
-cc : Cc -> A

--- a/test-suite/output/bug_16224.v
+++ b/test-suite/output/bug_16224.v
@@ -6,8 +6,6 @@ Class Cn := { cn : A }.
 
 Record Rc := { rc :> A }.
 
-Class Cc := { cc :> A }.
-
 Record Ri := { ri :: A }.
 
 Class Ci := { ci :: A }.

--- a/test-suite/success/Generalization.v
+++ b/test-suite/success/Generalization.v
@@ -14,7 +14,7 @@ Print a_eq_b.
 Require Import Morphisms.
 
 Class Equiv A := equiv : A -> A -> Prop.
-Class Setoid A `{Equiv A} := setoid_equiv:> Equivalence (equiv).
+Class Setoid A `{Equiv A} := setoid_equiv :: Equivalence (equiv).
 
 Lemma vcons_proper A `[Equiv A] `[!Setoid A] (x : True) : True.
 Admitted.

--- a/test-suite/success/StuckHintMode.v
+++ b/test-suite/success/StuckHintMode.v
@@ -2,7 +2,7 @@
 Require Import Coq.Setoids.Setoid Coq.Classes.Morphisms.
 
 Class PartialOrder {A} (R : relation A) : Prop := {
-  partial_order_pre :> PreOrder R;
+  partial_order_pre :: PreOrder R;
 }.
 Global Hint Mode PartialOrder - ! : typeclass_instances.
 

--- a/test-suite/success/TCbacktrack.v
+++ b/test-suite/success/TCbacktrack.v
@@ -47,7 +47,7 @@ Module BacktrackGreenCut.
   Unset Typeclasses Unique Solutions.
   Class C (A : Type) := c : A.
 
-  Class D (A : Type) : Type := { c_of_d :> C A }.
+  Class D (A : Type) : Type := { c_of_d :: C A }.
 
   #[export] Instance D1 : D unit.
   Admitted.
@@ -67,9 +67,9 @@ Module BacktrackGreenCut.
 
   Unset Typeclasses Strict Resolution.
   Class Transitive (A : Type) := { trans : True }.
-  Class PreOrder (A : Type) := { preorder_trans :> Transitive A }.
-  Class PartialOrder (A : Type) := { partialorder_trans :> Transitive A }.
-  Class PartialOrder' (A : Type) := { partialorder_trans' :> Transitive A }.
+  Class PreOrder (A : Type) := { preorder_trans :: Transitive A }.
+  Class PartialOrder (A : Type) := { partialorder_trans :: Transitive A }.
+  Class PartialOrder' (A : Type) := { partialorder_trans' :: Transitive A }.
 
   #[export] Instance: PreOrder nat. Admitted.
   #[export] Instance: PartialOrder nat. Admitted.

--- a/test-suite/success/Typeclasses.v
+++ b/test-suite/success/Typeclasses.v
@@ -193,7 +193,7 @@ Notation "'return' t" := (unit t).
 (* Test correct handling of existentials and defined fields. *)
 
 Class A `(e: T) := { a := True }.
-Class B `(e_: T) := { e := e_; sg_ass :> A e }.
+Class B `(e_: T) := { e := e_; sg_ass :: A e }.
 
 (* Set Typeclasses Debug. *)
 (* Set Typeclasses Debug Verbosity 2. *)
@@ -206,7 +206,7 @@ Goal forall `{B T}, Prop.
   intros. refine (@a _ _ _).
 Defined.
 
-Class B' `(e_: T) := { e' := e_; sg_ass' :> A e_ }.
+Class B' `(e_: T) := { e' := e_; sg_ass' :: A e_ }.
 
 Goal forall `{B' T}, a.
   intros. exact I.

--- a/test-suite/success/bteauto.v
+++ b/test-suite/success/bteauto.v
@@ -88,7 +88,7 @@ Qed.
 
 Module Hierarchies.
   Class A := mkA { data : nat }.
-  Class B := mkB { aofb :> A }.
+  Class B := mkB { aofb :: A }.
 
   #[export] Existing Instance mkB.
 

--- a/test-suite/success/polymorphism.v
+++ b/test-suite/success/polymorphism.v
@@ -220,15 +220,15 @@ Section cats.
   
   Class Equivalence T (Eq : Hom T):= 
     {
-      Equivalence_Identity :> Identity Eq ;
-      Equivalence_Inverse :> Inverse Eq ;
-      Equivalence_Composition :> Composition Eq 
+      Equivalence_Identity :: Identity Eq ;
+      Equivalence_Inverse :: Inverse Eq ;
+      Equivalence_Composition :: Composition Eq
     }.
 
   Class EquivalenceType (T : Type) : Type := 
     {
       m2: Hom T;
-      equiv_struct :> Equivalence T m2 }.
+      equiv_struct :: Equivalence T m2 }.
   
   Polymorphic Record cat (T : Type) := 
     { cat_hom : Hom T;

--- a/test-suite/success/rewrite_dep.v
+++ b/test-suite/success/rewrite_dep.v
@@ -6,7 +6,7 @@ Notation vector := Vector.t.
 Notation Vcons n t := (@Vector.cons _ n _ t). 
 
 Class Equiv A := equiv : A -> A -> Prop.
-Class Setoid A `{Equiv A} := setoid_equiv:> Equivalence (equiv).
+Class Setoid A `{Equiv A} := setoid_equiv :: Equivalence (equiv).
 
 #[export] Instance vecequiv A `{Equiv A} n : Equiv (vector A n).
 admit.

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -679,6 +679,7 @@ let warn_future_coercion_class_constructor =
    (c.f., https://github.com/coq/coq/pull/16230 ) *)
 let warn_future_coercion_class_field =
   CWarnings.create ~name:"future-coercion-class-field" ~category:Deprecation.Version.v8_17
+    ~default:CWarnings.AsError
     Pp.(fun definitional ->
     strbrk "A coercion will be introduced instead of an instance in future versions when using ':>' in 'Class' declarations. "
     ++ strbrk "Replace ':>' with '::' (or use '#[global] Existing Instance field.' for compatibility with Coq < 8.18). Beware that the default locality for '::' is #[export], as opposed to #[global] for ':>' currently."


### PR DESCRIPTION
This ends the deprecation phases of https://github.com/coq/coq/pull/16230 and https://github.com/coq/coq/pull/15802 that introduced :: instead of :> for subclasses in Class declarations. Now :> produces an error in `Class` before we can make it mean coercion in all record declarations (including typeclasses) in next version.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
<!-- Fixes / closes #???? -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [x] Documented any new / changed **user messages**.
  - [ ] ~Updated **documented syntax** by running `make doc_gram_rsts`.~

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md
-->

#### Overlays (to be merged before the current PR):

To prepare overlays, just ensure that the code compiles with any Coq >= 8.18 and options `-w +future-coercion-class-constructor` and `-w +future-coercion-class-field`

* [x] https://github.com/math-comp/analysis/pull/1168
* [x] https://github.com/coq-community/atbr/pull/42
* [x] https://gitlab.inria.fr/coquelicot/coquelicot/-/commit/ca1a747aa8b7ccbfa67a55ae5c8e5c8df71cc396
* [x] https://github.com/coq-community/coq-ext-lib/pull/142
* [x] https://github.com/coq-community/corn/pull/203
* [x] https://github.com/DeepSpec/InteractionTrees/pull/261
* [x] https://github.com/coq-community/math-classes/pull/123
* [x] https://github.com/proux01/menhir/commit/60eaa1f64d3544a7bff95b97ac0dd08257a58595
* [x] https://github.com/QuickChick/QuickChick/pull/353
* [x] https://github.com/damien-pous/relation-algebra/pull/41
* [x] https://gitlab.mpi-sws.org/iris/stdpp/-/merge_requests/537
* [x] https://github.com/MetaCoq/metacoq/pull/1055
* [x] https://github.com/mit-plv/bedrock2/pull/402
* [x] https://github.com/mit-plv/fiat-crypto/pull/1821
* [x] https://github.com/mit-plv/fiat/pull/105
* [x] https://github.com/LPCIC/coq-elpi/pull/607
* [x] https://github.com/smtcoq/smtcoq/pull/138
* [x] https://github.com/mit-plv/fiat-crypto/pull/1827 (fiat-crypto legacy)
* [x] https://github.com/mit-plv/fiat-crypto/pull/1830  (fiat-crypto legacy)
