### PR TITLE
Fix universe abstraction for const_relevance of opaques

### DIFF
--- a/doc/changelog/01-kernel/18596-abstract-opaque-relevance.rst
+++ b/doc/changelog/01-kernel/18596-abstract-opaque-relevance.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  incorrect abstraction of sort variables for opaque constants
+  (`#18596 <https://github.com/coq/coq/pull/18596>`_,
+  fixes `#18594 <https://github.com/coq/coq/issues/18594>`_,
+  by Gaëtan Gilbert).

--- a/kernel/constant_typing.ml
+++ b/kernel/constant_typing.ml
@@ -243,7 +243,7 @@ let infer_opaque ~sec_univs env entry =
     const_type = typ;
     const_body_code = tps;
     const_universes = univs;
-    const_relevance = Sorts.relevance_of_sort typj.utj_type;
+    const_relevance = UVars.subst_sort_level_relevance usubst @@ Sorts.relevance_of_sort typj.utj_type;
     const_inline_code = false;
     const_typing_flags = Environ.typing_flags env;
   }, context

--- a/test-suite/bugs/bug_18594.v
+++ b/test-suite/bugs/bug_18594.v
@@ -1,0 +1,12 @@
+Set Universe Polymorphism.
+
+Lemma foo@{s| |} (A:Type@{s|Set}) (a:A) : A.
+Proof.
+  exact a.
+Qed.
+
+Definition bar : foo nat = foo (id nat) := eq_refl.
+
+Fail Definition baz x y : foo nat x = foo nat y := eq_refl.
+
+Definition baz' (A:SProp) (f:A->nat) x y : f (foo A x) = f (foo A y) := eq_refl.


### PR DESCRIPTION
Fix #18594
