### PR TITLE
Fix refolding of named mutual fix/cofix defined in a section for "cbn"

### DIFF
--- a/doc/changelog/04-tactics/18601-master+fix17897-cbn-wrong-canonical-name-refolding.rst
+++ b/doc/changelog/04-tactics/18601-master+fix17897-cbn-wrong-canonical-name-refolding.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Support for refolding reduced global mutual fixpoints/cofixpoints
+  with parameters in :tacn:`cbn`
+  (`#18601 <https://github.com/coq/coq/pull/18601>`_,
+  fixes part of `#4056 <https://github.com/coq/coq/issues/4056>`_,
+  by Hugo Herbelin).

--- a/test-suite/success/cbn.v
+++ b/test-suite/success/cbn.v
@@ -39,3 +39,35 @@ Proof.
   cbn.
   match goal with |- _ + _ = _ => idtac end.
 Abort.
+
+Module MutualFixCoFixInSection.
+
+Section S.
+Variable p:nat.
+Fixpoint f n := match n with 0 => p | S n => f n + g n end
+with g n := match n with 0 => p | S n => f n + g n end.
+End S.
+
+Goal forall n, f n (S n) = g 0 (S n).
+intros. cbn.
+match goal with [ |- f n n + g n n = f 0 n + g 0 n ] => idtac end.
+Abort.
+
+CoInductive stream {A:Type} : Type :=
+  | scons: A->stream->stream.
+Definition stream_unfold {A} (s: @ stream A) := match s with
+| scons a s' => (a, scons a s')
+end.
+
+Section C.
+Variable (x:nat).
+CoFixpoint mut_stream1 (n:nat) := scons n (mut_stream2 (n+x))
+with mut_stream2 (n:nat) :=  scons n (mut_stream1  (n+x)).
+End C.
+
+Goal (forall x n, stream_unfold (mut_stream1 x n) = stream_unfold (mut_stream2 x n)).
+intros. cbn.
+match goal with [ |- (n, scons n (mut_stream2 x (n + x))) = (n, scons n (mut_stream1 x (n + x))) ] => idtac end.
+Abort.
+
+End MutualFixCoFixInSection.


### PR DESCRIPTION
Refolding was not yet working in `cbn` for global mutual `fix`/`cofix` with parameters.

The issue was mentioned e.g. in #4056 and the fix was actually much easier than imagined.

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
