### PR TITLE
Declare global sort variables

### DIFF
--- a/checker/values.ml
+++ b/checker/values.ml
@@ -580,7 +580,7 @@ let v_vodigest = v_sum_c ("module_impl",0, [| [|v_string|]; [|v_string;v_string|
 let v_deps = v_array (v_tuple "dep" [|v_dp;v_vodigest|])
 let v_flags = v_tuple "flags" [|v_bool|] (* Allow Rewrite Rules *)
 let v_compiled_lib =
-  v_tuple "compiled" [|v_dp;v_module;v_context_set;v_deps; v_flags|]
+  v_tuple "compiled" [|v_dp;v_module;v_context_set;v_set v_qvar;v_deps; v_flags|]
 
 (** Toplevel structures in a vo (see Cic.mli) *)
 

--- a/dev/ci/user-overlays/18615-SkySkimmer-decl-sort.sh
+++ b/dev/ci/user-overlays/18615-SkySkimmer-decl-sort.sh
@@ -1,0 +1,3 @@
+overlay coq_lsp https://github.com/SkySkimmer/coq-lsp decl-sort 18615
+
+overlay equations https://github.com/SkySkimmer/Coq-Equations decl-sort 18615

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -279,8 +279,8 @@ let pprelevance (r:Sorts.relevance) = match r with
 let pperelevance r = pprelevance (EConstr.Unsafe.to_relevance r)
 
 let prlev l = UnivNames.pr_level_with_global_universes l
-let prqvar q = Sorts.QVar.raw_pr q
-let ppqvarset l = pp (hov 1 (str "{" ++ prlist_with_sep spc QVar.raw_pr (QVar.Set.elements l) ++ str "}"))
+let prqvar q = UnivNames.pr_quality_with_global_universes q
+let ppqvarset l = pp (hov 1 (str "{" ++ prlist_with_sep spc prqvar (QVar.Set.elements l) ++ str "}"))
 let ppuniverse_set l = pp (Level.Set.pr prlev l)
 let ppuniverse_instance l = pp (Instance.pr prqvar prlev l)
 let ppuniverse_context l = pp (pr_universe_context prqvar prlev l)

--- a/doc/changelog/08-vernac-commands-and-options/18615-decl-sort.rst
+++ b/doc/changelog/08-vernac-commands-and-options/18615-decl-sort.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  :cmd:`Sort` to declare global or section-scoped sort qualities
+  (`#18615 <https://github.com/coq/coq/pull/18615>`_,
+  by Kenji Maillard).

--- a/doc/sphinx/addendum/universe-polymorphism.rst
+++ b/doc/sphinx/addendum/universe-polymorphism.rst
@@ -892,6 +892,76 @@ However elimination to `Type` or to a polymorphic sort with `s := Prop` is allow
         : Type@{s|max(u,v)}
         := pair { pr1 : A; pr2 : B pr1 }.
 
+Explicit Sorts
+---------------
+
+Similar to universes, fresh global sorts can be declared with the :cmd:`Sort`.
+
+.. cmd:: Sort {+ @ident }
+         Sorts {+ @ident }
+
+   In the monomorphic case, declares new global sort qualities
+   with the given names.  Global quality names live in their own namespace.
+   Inside sections, the command respects the `Universe Polymorphism` flag,
+   either set globally or locally through the :attr:`universes(polymorphic)` attribute (or
+   the ``Polymorphic`` legacy attribute), meaning the sort
+   quantification will be discharged for each section definition
+   independently. Polymorphic sort qualities are forbidden outside sections.
+
+  .. exn:: Polymorphic sorts can only be declared inside sections, use #[universe(polymorphic=no)] Sort in order to declare a global sort.
+
+    Generated when a :cmd:`Sort` command is issued outside a section with universe polymorphism set.
+    Either scope the :cmd:`Sort` with an enclosing :cmd:`Section` or be explicit about creating a global sort
+    by turning universe polymorphism off.
+
+  .. exn:: Cannot declare global sort qualities inside module types.
+
+    The :cmd:`Sort` command is not supported inside module types.
+
+.. cmd:: Print Sorts
+
+   Print the list of global named sorts in the current global environment. Use :cmd:`Show Universes` to print sort variables local to a proof context.
+
+  .. rocqtop:: all
+
+    Set Universe Polymorphism.
+
+    (* A global sort named g. *)
+    #[universes(polymorphic=no)]
+    Sort g.
+
+    Print Sorts.
+
+    (* Universe of g-sorted type. *)
+    Definition G@{l|} : Type@{l+1} := Type@{g|l}.
+
+    Section LocalSorts.
+      Sort u v w.
+
+      Definition arr2@{l|} (A : Type@{u|l}) (B : Type@{v|l}) (C : Type@{w|l}) : Type@{w|l} :=
+        A -> B -> C.
+
+      Print Sorts.
+
+      Sort x y.
+
+      Definition arr1@{l|} (X : Type@{x|l}) (Y : Type@{y|l}) : Type@{y|l} :=
+        X -> Y.
+
+      Print Sorts.
+
+    End LocalSorts.
+
+    (* The sorts u, v, w, x and y are no longer present. *)
+    Print Sorts.
+
+    (* Equivalent definition of arr2 outside the section LocalSorts. *)
+    Definition arr2'@{u v w | l |} (A : Type@{u|l}) (B : Type@{v|l}) (C : Type@{w|l}) : Type@{w|l} :=
+        A -> B -> C.
+
+    (* All sort declarations of the section are bound, even the unused one. *)
+    About arr1.
+
 .. _universe-polymorphism-in-sections:
 
 Universe polymorphism and sections

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -895,6 +895,8 @@ gallina: [
 | "Primitive" ident_decl OPT [ ":" lconstr ] ":=" register_token
 | "Universe" LIST1 identref
 | "Universes" LIST1 identref
+| "Sort" LIST1 identref
+| "Sorts" LIST1 identref
 | "Constraint" LIST1 univ_constraint SEP ","
 | "Rewrite" "Rule" identref ":=" OPT "|" LIST1 rewrite_rule SEP "|"
 | "Rewrite" "Rules" identref ":=" OPT "|" LIST1 rewrite_rule SEP "|"
@@ -1418,6 +1420,7 @@ printable: [
 | "Visibility" OPT IDENT
 | "Implicit" smart_global
 | [ "Sorted" | ] "Universes" OPT printunivs_subgraph OPT [ [ "With" | "Without" ] "Constraint" "Sources" ] OPT ne_string
+| "Sorts"
 | "Assumptions" smart_global
 | "Opaque" "Dependencies" smart_global
 | "Transparent" "Dependencies" smart_global

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -771,6 +771,7 @@ command: [
 | "Print" "Visibility" OPT scope_name
 | "Print" "Implicit" reference
 | "Print" OPT "Sorted" "Universes" OPT ( "Subgraph" "(" LIST0 debug_univ_name ")" ) OPT [ [ "With" | "Without" ] "Constraint" "Sources" ] OPT string
+| "Print" "Sorts"
 | "Print" "Assumptions" reference
 | "Print" "Opaque" "Dependencies" reference
 | "Print" "Transparent" "Dependencies" reference
@@ -927,6 +928,8 @@ command: [
 | "Primitive" ident_decl OPT [ ":" term ] ":=" "#" ident
 | "Universe" LIST1 ident
 | "Universes" LIST1 ident
+| "Sort" LIST1 ident
+| "Sorts" LIST1 ident
 | "Constraint" LIST1 univ_constraint SEP ","
 | "Rewrite" [ "Rule" | "Rules" ] ident ":=" OPT "|" LIST1 rewrite_rule SEP "|"
 | "CoInductive" inductive_definition LIST0 ( "with" inductive_definition )

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1108,9 +1108,9 @@ let make_nonalgebraic_variable evd u =
 (* Operations on constants              *)
 (****************************************)
 
-let fresh_sort_quality ?loc ?(rigid=univ_flexible) evd s =
+let fresh_sort_in_quality ?loc ?(rigid=univ_flexible) evd s =
   with_sort_context_set ?loc rigid evd
-    (UnivGen.fresh_sort_quality s)
+    (UnivGen.fresh_sort_in_quality s)
 
 let fresh_constant_instance ?loc ?(rigid=univ_flexible) env evd c =
   with_sort_context_set ?loc rigid evd (UnivGen.fresh_constant_instance env c)

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -631,7 +631,7 @@ val update_sigma_univs : UGraph.t -> evar_map -> evar_map
 
 (** Polymorphic universes *)
 
-val fresh_sort_quality : ?loc:Loc.t -> ?rigid:rigid
+val fresh_sort_in_quality : ?loc:Loc.t -> ?rigid:rigid
   -> evar_map -> UnivGen.QualityOrSet.t -> evar_map * esorts
 val fresh_constant_instance : ?loc:Loc.t -> ?rigid:rigid
   -> env -> evar_map -> Constant.t -> evar_map * pconstant

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -32,10 +32,10 @@ type t
 
 val empty : t
 
-val make : UGraph.t -> t
+val make : qualities:QVar.Set.t -> UGraph.t -> t
 [@@ocaml.deprecated "(8.13) Use from_env"]
 
-val make_with_initial_binders : UGraph.t -> lident list -> t
+val make_with_initial_binders : qualities:QVar.Set.t -> UGraph.t -> lident list -> t
 [@@ocaml.deprecated "(8.13) Use from_env"]
 
 val from_env : ?binders:lident list -> Environ.env -> t

--- a/engine/univGen.ml
+++ b/engine/univGen.ml
@@ -195,7 +195,7 @@ let constr_of_monomorphic_global env gr =
       Pp.(str "globalization of polymorphic reference " ++ Nametab.pr_global_env Id.Set.empty gr ++
           str " would forget universes.")
 
-let fresh_sort_quality =
+let fresh_sort_in_quality =
   let open QualityOrSet in
   function
   | Qual (QConstant QSProp) -> Sorts.sprop, empty_sort_context

--- a/engine/univGen.ml
+++ b/engine/univGen.ml
@@ -127,13 +127,16 @@ let new_sort_id =
   let cnt = ref 0 in
   fun () -> incr cnt; !cnt
 
-let new_sort_global () =
+let new_sort_global id =
+  Sorts.QGlobal.make (Global.current_dirpath ()) id
+
+let fresh_sort_quality () =
   let s = if Flags.async_proofs_is_worker() then !Flags.async_proofs_worker_id else "" in
   Sorts.QVar.make_unif s (new_sort_id ())
 
 let fresh_instance auctx : _ in_sort_context_set =
   let qlen, ulen = AbstractContext.size auctx in
-  let qinst = Array.init qlen (fun _ -> Sorts.Quality.QVar (new_sort_global())) in
+  let qinst = Array.init qlen (fun _ -> Sorts.Quality.QVar (fresh_sort_quality ())) in
   let uinst = Array.init ulen (fun _ -> fresh_level()) in
   let qctx = Array.fold_left (fun qctx q -> match q with
       | Sorts.Quality.QVar q -> Sorts.QVar.Set.add q qctx
@@ -225,7 +228,7 @@ let fresh_universe_context_set_instance ctx =
 let fresh_sort_context_instance ((qs,us),csts) =
   let usubst, (us, csts) = fresh_universe_context_set_instance (us,csts) in
   let qsubst, qs = QVar.Set.fold (fun q (qsubst,qs) ->
-      let q' = new_sort_global () in
+      let q' = fresh_sort_quality () in
       QVar.Map.add q (Sorts.Quality.QVar q') qsubst, QVar.Set.add q' qs)
       qs
       (QVar.Map.empty, QVar.Set.empty)

--- a/engine/univGen.mli
+++ b/engine/univGen.mli
@@ -55,8 +55,9 @@ exception UniverseLengthMismatch of univ_length_mismatch
 (** Side-effecting functions creating new universe levels. *)
 
 val new_univ_global : unit -> UGlobal.t
-val new_sort_global : unit -> Sorts.QVar.t
+val new_sort_global : Id.t -> Sorts.QGlobal.t
 val fresh_level : unit -> Level.t
+val fresh_sort_quality : unit -> Sorts.QVar.t
 
 val new_global_univ : unit -> Universe.t in_universe_context_set
 

--- a/engine/univGen.mli
+++ b/engine/univGen.mli
@@ -81,7 +81,7 @@ val fresh_instance : AbstractContext.t -> Instance.t in_sort_context_set
 val fresh_instance_from : ?loc:Loc.t -> AbstractContext.t -> (GlobRef.t * Instance.t) option ->
   Instance.t in_sort_context_set
 
-val fresh_sort_quality : QualityOrSet.t -> Sorts.t in_sort_context_set
+val fresh_sort_in_quality : QualityOrSet.t -> Sorts.t in_sort_context_set
 (** NB: QSort is treated as QType *)
 
 val fresh_constant_instance : env -> Constant.t ->

--- a/engine/univNames.ml
+++ b/engine/univNames.ml
@@ -35,3 +35,15 @@ let pr_level_with_global_universes ?(binders=empty_binders) l =
   match qualid_of_level binders l with
   | Some qid  -> Libnames.pr_qualid qid
   | None -> Level.raw_pr l
+
+let qualid_of_quality (ctx,_) q =
+  match Sorts.QVar.repr q with
+  | Global qid ->
+    (try Some (Nametab.shortest_qualid_of_quality ctx qid)
+     with Not_found -> None)
+  | _ -> None
+
+let pr_quality_with_global_universes ?(binders=empty_binders) q =
+  match qualid_of_quality binders q with
+  | Some qid  -> Libnames.pr_qualid qid
+  | None -> Sorts.QVar.raw_pr q

--- a/engine/univNames.mli
+++ b/engine/univNames.mli
@@ -28,3 +28,6 @@ type full_name_list = lname list * lname list
 
 val pr_level_with_global_universes : ?binders:universe_binders -> Level.t -> Pp.t
 val qualid_of_level : universe_binders -> Level.t -> Libnames.qualid option
+
+val pr_quality_with_global_universes : ?binders:universe_binders -> Sorts.QVar.t -> Pp.t
+val qualid_of_quality : universe_binders -> Sorts.QVar.t -> Libnames.qualid option

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -878,25 +878,28 @@ let extern_glob_sort_name uvars = function
       | None -> CRawType u
     end
 
-let extern_glob_qvar = function
+let extern_glob_qvar uvars = function
   | GLocalQVar {v=Anonymous;loc} -> CQAnon loc
   | GLocalQVar {v=Name id; loc} -> CQVar (qualid_of_ident ?loc id)
   | GRawQVar q -> CRawQVar q
-  | GQVar q -> CRawQVar q
+  | GQVar q -> begin match UnivNames.qualid_of_quality uvars q with
+    | Some qid -> CQVar qid
+    | None -> CRawQVar q
+    end
 
-let extern_relevance = function
+let extern_relevance uvars = function
   | GRelevant -> CRelevant
   | GIrrelevant -> CIrrelevant
-  | GRelevanceVar q -> CRelevanceVar (extern_glob_qvar q)
+  | GRelevanceVar q -> CRelevanceVar (extern_glob_qvar uvars q)
 
-let extern_relevance_info = Option.map extern_relevance
+let extern_relevance_info uvars = Option.map (extern_relevance uvars)
 
-let extern_glob_quality = function
+let extern_glob_quality uvars = function
   | GQConstant q -> CQConstant q
-  | GQualVar q -> CQualVar (extern_glob_qvar q)
+  | GQualVar q -> CQualVar (extern_glob_qvar uvars q)
 
 let extern_glob_sort uvars (q, l) =
-  Option.map extern_glob_qvar q,
+  Option.map (extern_glob_qvar uvars) q,
   map_glob_sort_gen (List.map (on_fst (extern_glob_sort_name uvars))) l
 
 (** wrapper to handle print_universes: don't forget small univs *)
@@ -913,7 +916,7 @@ let extern_glob_sort uvars (s:glob_sort) =
 
 let extern_instance uvars = function
   | Some (ql,ul) when !print_universes ->
-    let ql = List.map extern_glob_quality ql in
+    let ql = List.map (extern_glob_quality uvars) ql in
     let ul = List.map (map_glob_sort_gen (extern_glob_sort_name uvars)) ul in
     Some (ql,ul)
   | _ -> None
@@ -1173,7 +1176,7 @@ and sub_extern depth inctx (subentry,(_,scopes)) = extern depth inctx (subentry,
 
 and factorize_prod depth scopes vars na r bk t c =
   let implicit_type = is_reserved_type na t in
-  let r = extern_relevance_info r in
+  let r = extern_relevance_info (snd vars) r in
   let aty = extern_typ depth scopes vars t in
   let vars = add_vname vars na in
   let store, get = set_temporary_memory () in
@@ -1210,7 +1213,7 @@ and factorize_prod depth scopes vars na r bk t c =
 
 and factorize_lambda depth inctx scopes vars na r bk t c =
   let implicit_type = is_reserved_type na t in
-  let r = extern_relevance_info r in
+  let r = extern_relevance_info (snd vars) r in
   let aty = extern_typ depth scopes vars t in
   let vars = add_vname vars na in
   let store, get = set_temporary_memory () in
@@ -1253,7 +1256,7 @@ and extern_local_binder depth scopes vars = function
       let (assums,ids,l) =
         extern_local_binder depth scopes (on_fst (Name.fold_right Id.Set.add na) vars) l in
       (assums,na::ids,
-       CLocalDef(CAst.make na, extern_relevance_info r, extern depth false scopes vars bd,
+       CLocalDef(CAst.make na, extern_relevance_info (snd vars) r, extern depth false scopes vars bd,
                    Option.map (extern_typ depth scopes vars) ty) :: l)
 
     | GLocalAssum (na,r,bk,ty) ->
@@ -1270,7 +1273,7 @@ and extern_local_binder depth scopes vars = function
        | (assums,ids,l) ->
          let ty = if implicit_type then hole else ty in
          (na::assums,na::ids,
-          CLocalAssum([CAst.make na],extern_relevance_info r,Default bk,ty) :: l))
+          CLocalAssum([CAst.make na],extern_relevance_info (snd vars) r,Default bk,ty) :: l))
 
     | GLocalPattern ((p,_),_,bk,ty) ->
       let ty =

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -1250,10 +1250,12 @@ let intern_qvar ~local_univs = function
     match local with
     | Some u -> GQVar u
     | None ->
-      if is_id && local_univs.unb_univs
-      then GLocalQVar (CAst.make ?loc:qid.loc (Name (qualid_basename qid)))
-      else
-        CErrors.user_err ?loc:qid.loc Pp.(str "Undeclared quality " ++ pr_qualid qid ++ str".")
+      try GQVar (Sorts.QVar.make_global (Nametab.locate_quality qid))
+      with Not_found ->
+        if is_id && local_univs.unb_univs
+        then GLocalQVar (CAst.make ?loc:qid.loc (Name (qualid_basename qid)))
+        else
+          CErrors.user_err ?loc:qid.loc Pp.(str "Undeclared quality " ++ pr_qualid qid ++ str".")
 
 let intern_quality ~local_univs q =
   match q with

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -563,7 +563,7 @@ let rec check_glob env sigma g c = match DAst.get g, Constr.kind c with
      let sigma,ty = check_glob env sigma ty ty' in
      sigma, mkArray (u,t,def,ty)
   | Glob_term.GSort s, Constr.Sort s' ->
-     let sigma,s = Glob_ops.fresh_glob_sort_quality sigma s in
+     let sigma,s = Glob_ops.fresh_glob_sort_in_quality sigma s in
      let s = EConstr.ESorts.kind sigma s in
      if not (Sorts.equal s s') then raise NotAValidPrimToken;
      sigma,mkSort s
@@ -622,7 +622,7 @@ let rec constr_of_glob to_post post env sigma g = match DAst.get g with
       let sigma, ty' = constr_of_glob to_post post env sigma ty in
        sigma, mkArray (u',t',def',ty')
   | Glob_term.GSort gs ->
-      let sigma,c = Glob_ops.fresh_glob_sort_quality sigma gs in
+      let sigma,c = Glob_ops.fresh_glob_sort_in_quality sigma gs in
       let c = EConstr.ESorts.kind sigma c in
       sigma,mkSort c
   | _ ->

--- a/kernel/cooking.ml
+++ b/kernel/cooking.ml
@@ -276,10 +276,12 @@ let abstract_named_context expand_info abstr_ausubst hyps =
     let cache = RefTable.create 13 in
     let decl = match decl with
     | NamedDecl.LocalDef (id, b, t) ->
+      let id = Context.map_annot_relevance (UVars.subst_sort_level_relevance (make_instance_subst abstr_ausubst)) id in
       let b = expand_subst0 cache expand_info abstr_ctx abstr_ausubst b in
       let t = expand_subst0 cache expand_info abstr_ctx abstr_ausubst t in
       NamedDecl.LocalDef (id, b, t)
     | NamedDecl.LocalAssum (id, t) ->
+      let id = Context.map_annot_relevance (UVars.subst_sort_level_relevance (make_instance_subst abstr_ausubst)) id in
       let t = expand_subst0 cache expand_info abstr_ctx abstr_ausubst t in
       NamedDecl.LocalAssum (id, t)
     in
@@ -388,3 +390,6 @@ let lift_private_mono_univs info a =
 let lift_private_poly_univs info (inst, cstrs) =
   let cstrs = Univ.subst_univs_level_constraints (snd (make_instance_subst info.abstr_info.abstr_ausubst)) cstrs in
   (inst, cstrs)
+
+let lift_relevance info relevance =
+  UVars.subst_sort_level_relevance (make_instance_subst info.abstr_info.abstr_ausubst) relevance

--- a/kernel/cooking.mli
+++ b/kernel/cooking.mli
@@ -74,4 +74,6 @@ val lift_private_mono_univs : cooking_info -> 'a -> 'a
 
 val lift_private_poly_univs : cooking_info -> Univ.ContextSet.t -> Univ.ContextSet.t
 
+val lift_relevance : cooking_info -> Sorts.relevance -> Sorts.relevance
+
 val discharge_proj_repr : cooking_info -> Names.Projection.Repr.t -> Names.Projection.Repr.t

--- a/kernel/discharge.ml
+++ b/kernel/discharge.ml
@@ -78,7 +78,7 @@ let cook_constant _env info cb =
     const_type = typ;
     const_body_code = ();
     const_universes = univs;
-    const_relevance = cb.const_relevance;
+    const_relevance =  lift_relevance info cb.const_relevance;
     const_inline_code = cb.const_inline_code;
     const_typing_flags = cb.const_typing_flags;
   }
@@ -111,7 +111,7 @@ let cook_projection cache ~params t =
   let _, t = decompose_prod_n_decls (Context.Rel.length params + 1 + nrels) t in
   t
 
-let cook_one_ind cache ~ntypes mip =
+let cook_one_ind info cache ~ntypes mip =
   let mind_user_arity = abstract_as_type cache mip.mind_user_arity in
   let mind_sort = abstract_as_sort cache mip.mind_sort in
   let mind_arity_ctxt = cook_rel_context cache mip.mind_arity_ctxt in
@@ -135,7 +135,7 @@ let cook_one_ind cache ~ntypes mip =
     mind_consnrealargs = mip.mind_consnrealargs;
     mind_consnrealdecls = mip.mind_consnrealdecls;
     mind_recargs = mip.mind_recargs;
-    mind_relevance = mip.mind_relevance;
+    mind_relevance = lift_relevance info mip.mind_relevance;
     mind_nb_constant = mip.mind_nb_constant;
     mind_nb_args = mip.mind_nb_args;
     mind_reloc_tbl = mip.mind_reloc_tbl;
@@ -147,13 +147,14 @@ let cook_inductive info mib =
   let nnewparams = Context.Rel.nhyps (rel_context_of_cooking_cache cache) in
   let mind_params_ctxt = cook_rel_context cache mib.mind_params_ctxt in
   let ntypes = mib.mind_ntypes in
-  let mind_packets = Array.map (cook_one_ind cache ~ntypes) mib.mind_packets in
+  let mind_packets = Array.map (cook_one_ind info cache ~ntypes) mib.mind_packets in
   let mind_record = match mib.mind_record with
     | NotRecord -> NotRecord
     | FakeRecord -> FakeRecord
     | PrimRecord data ->
       let data = Array.map (fun (id,projs,relevances,tys) ->
           let tys = Array.map (cook_projection cache ~params:mib.mind_params_ctxt) tys in
+          let relevances = Array.map (lift_relevance info) relevances in
           (id,projs,relevances,tys))
           data
       in

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -337,12 +337,15 @@ let universes env = env.env_universes
 let set_universes g env =
   {env with env_universes=g}
 
-let qualities env = env.env_qualities
+let set_qualities qs env =
+  { env with env_qualities = qs }
 
 let named_context env = env.env_named_context.env_named_ctx
 let named_context_val env = env.env_named_context
 let rel_context env = env.env_rel_context.env_rel_ctx
 let rel_context_val env = env.env_rel_context
+
+let qualities env = env.env_qualities
 
 let empty_context env =
   match env.env_rel_context.env_rel_ctx, env.env_named_context.env_named_ctx with
@@ -487,6 +490,10 @@ let push_context_set ?(strict=false) ctx env =
 
 let push_qualities ctx env =
   { env with env_qualities = Sorts.QVar.Set.union env.env_qualities ctx }
+
+let push_quality_set qs env =
+  { env with
+    env_qualities = Sorts.QVar.Set.union qs env.env_qualities }
 
 let push_subgraph (levels,csts) env =
   let add_subgraph g =

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -68,13 +68,15 @@ val eq_named_context_val : named_context_val -> named_context_val -> bool
 val empty_env : env
 
 val universes     : env -> UGraph.t
-val qualities     : env -> Sorts.QVar.Set.t
 val rel_context   : env -> Constr.rel_context
 val rel_context_val : env -> rel_context_val
 val named_context : env -> Constr.named_context
 val named_context_val : env -> named_context_val
 
 val set_universes : UGraph.t -> env -> env
+
+val qualities : env -> Sorts.QVar.Set.t
+val set_qualities : Sorts.QVar.Set.t -> env -> env
 
 val typing_flags    : env -> typing_flags
 val is_impredicative_set : env -> bool
@@ -343,6 +345,11 @@ val push_context_set : ?strict:bool -> ContextSet.t -> env -> env
 
 val push_qualities : Sorts.QVar.Set.t -> env -> env
 (** Add the qualities to the environment. Only used in higher layers. *)
+
+val push_quality_set : Sorts.QVar.Set.t -> env -> env
+(** [push_quality_set qs env] pushes the set of quality variables in
+    the environment. It does not fail even if a quality variable is
+    already declared. *)
 
 val push_subgraph : ContextSet.t -> env -> env
 (** [push_subgraph univs env] adds the universes and constraints in

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -176,6 +176,7 @@ type compiled_library = {
   comp_name : DirPath.t;
   comp_mod : module_body;
   comp_univs : Univ.ContextSet.t;
+  comp_qualities : Sorts.QVar.Set.t;
   comp_deps : library_info array;
   comp_flags : permanent_flags;
 }
@@ -226,6 +227,7 @@ type safe_environment =
     modlabels : Label.Set.t;
     objlabels : Label.Set.t;
     univ : Univ.ContextSet.t;
+    qualities : Sorts.QVar.Set.t ;
     future_cst : (Constant_typing.typing_context * safe_environment * Nonce.t) HandleMap.t;
     required : required_lib DPmap.t;
     loads : (ModPath.t * module_body) list;
@@ -257,6 +259,7 @@ let empty_environment =
     sections = None;
     future_cst = HandleMap.empty;
     univ = Univ.ContextSet.empty;
+    qualities = Sorts.QVar.Set.empty ;
     required = DPmap.empty;
     loads = [];
     local_retroknowledge = [];
@@ -496,6 +499,12 @@ let structure_body_of_safe_env env = env.revstruct
 
 let sections_of_safe_env senv = senv.sections
 
+let rec is_modtype senv =
+  match senv.modvariant with
+  | STRUCT (_,senv) -> is_modtype senv
+  | SIG _ -> true
+  | NONE | LIBRARY -> false
+
 let get_section = function
   | None -> CErrors.user_err Pp.(str "No open section.")
   | Some s -> s
@@ -512,6 +521,20 @@ let push_context_set ~strict cst senv =
 
 let add_constraints cst senv =
   push_context_set ~strict:true cst senv
+
+let push_quality_set qs senv =
+  if Sorts.QVar.Set.is_empty qs then senv
+  else
+    let () = if is_modtype senv
+      then CErrors.user_err (Pp.str "Cannot declare global sort qualities inside module types.")  ;
+    in
+    let sections = Option.map (Section.push_mono_qualities qs) senv.sections
+    in
+    { senv with
+      env = Environ.push_quality_set qs senv.env ;
+      qualities = Sorts.QVar.Set.union qs senv.qualities ;
+      sections
+    }
 
 let is_curmod_library senv =
   match senv.modvariant with LIBRARY -> true | _ -> false
@@ -629,11 +652,12 @@ let push_section_context uctx senv =
   let sections = Section.push_local_universe_context uctx sections in
   let senv = { senv with sections=Some sections } in
   let qualities, ctx = UVars.UContext.to_context_set uctx in
-  assert (Sorts.QVar.Set.is_empty qualities);
+  assert Sorts.QVar.Set.(is_empty (inter qualities senv.qualities));
   (* push_context checks freshness *)
   { senv with
     env = Environ.push_context ~strict:false uctx senv.env;
-    univ = Univ.ContextSet.union ctx senv.univ }
+    univ = Univ.ContextSet.union ctx senv.univ ;
+    qualities = Sorts.QVar.Set.union qualities senv.qualities }
 
 (** {6 Insertion of new declarations to current environment } *)
 
@@ -1239,6 +1263,7 @@ let start_mod_modtype ~istype l senv =
     modresolver = Mod_subst.empty_delta_resolver mp;
     paramresolver = ParamResolver.add_delta_resolver senv.modpath senv.modresolver senv.paramresolver;
     univ = senv.univ;
+    qualities = senv.qualities;
     required = senv.required;
     opaquetab = senv.opaquetab;
     sections = None; (* checked in check_empty_context *)
@@ -1335,6 +1360,7 @@ let propagate_senv newdef newenv newresolver senv oldsenv =
     revstruct = newdef::oldsenv.revstruct;
     modlabels = Label.Set.add (fst newdef) oldsenv.modlabels;
     univ = senv.univ;
+    qualities = senv.qualities ;
     future_cst = senv.future_cst;
     required = senv.required;
     loads = senv.loads@oldsenv.loads;
@@ -1351,6 +1377,7 @@ let end_module l restype senv =
   let mbids = List.rev_map fst params in
   let mb = build_module_body params restype senv in
   let newenv = Environ.set_universes (Environ.universes senv.env) oldsenv.env in
+  let newenv = Environ.set_qualities (Environ.qualities senv.env) newenv in
   let newenv = if Environ.rewrite_rules_allowed senv.env then Environ.allow_rewrite_rules newenv else newenv in
   let newenv = Environ.set_vm_library (Environ.vm_library senv.env) newenv in
   let senv' = propagate_loads { senv with env = newenv } in
@@ -1460,6 +1487,7 @@ let start_library dir senv =
     sections = None;
     future_cst = HandleMap.empty;
     univ = Univ.ContextSet.empty;
+    qualities = Sorts.QVar.Set.empty;
     loads = [];
     local_retroknowledge = [];
     opaquetab = Opaqueproof.empty_opaquetab;
@@ -1467,8 +1495,6 @@ let start_library dir senv =
 
 let export ~output_native_objects senv dir =
   let () = check_current_library dir senv in
-  (* qualities are in the senv only during sections *)
-  let () = assert (Sorts.QVar.Set.is_empty @@ Environ.qualities senv.env) in
   let mp = senv.modpath in
   let str = NoFunctor (List.rev senv.revstruct) in
   let mb = Mod_declarations.make_module_body str senv.modresolver senv.local_retroknowledge in
@@ -1488,6 +1514,7 @@ let export ~output_native_objects senv dir =
     comp_name = dir;
     comp_mod = mb;
     comp_univs = senv.univ;
+    comp_qualities = Environ.qualities senv.env;
     comp_deps = Array.of_list comp_deps;
     comp_flags = permanent_flags
   } in
@@ -1505,6 +1532,7 @@ let import lib vmtab vodigest senv =
   let mb = lib.comp_mod in
   let env = Environ.push_context_set ~strict:true lib.comp_univs senv.env in
   let env = Environ.link_vm_library vmtab env in
+  let env = Environ.push_quality_set lib.comp_qualities env in
   let env =
     let linkinfo = Nativecode.link_info_of_dirpath lib.comp_name in
     Modops.add_linked_module mp mb linkinfo env
@@ -1550,7 +1578,7 @@ let close_section senv =
   let sections0 = get_section senv.sections in
   let env0 = senv.env in
   (* First phase: revert the declarations added in the section *)
-  let sections, entries, cstrs, revert = Section.close_section sections0 in
+  let sections, entries, cstrs, qs, revert = Section.close_section sections0 in
   (* Don't revert the delayed constraints (future_cst). If some delayed constraints
      were forced inside the section, they have been turned into global monomorphic
      that are going to be replayed. Those that are not forced are not readded
@@ -1565,6 +1593,7 @@ let close_section senv =
   in
   (* Third phase: replay the discharged section contents *)
   let senv = push_context_set ~strict:true cstrs senv in
+  let senv = push_quality_set qs senv in
   let fold entry senv =
     match entry with
   | SecDefinition kn ->

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -156,6 +156,11 @@ val push_context_set :
 val add_constraints :
   Univ.Constraints.t -> safe_transformer0
 
+(** Adding global sort qualities *)
+
+val push_quality_set :
+    Sorts.QVar.Set.t -> safe_transformer0
+
 (* (\** Generator of universes *\) *)
 (* val next_universe : int safe_transformer *)
 

--- a/kernel/section.ml
+++ b/kernel/section.ml
@@ -30,6 +30,8 @@ type 'a t = {
       with global declarations *)
   mono_universes : ContextSet.t;
   (** Global universes introduced in the section *)
+  mono_qualities : Sorts.QVar.Set.t;
+  (** Global universes introduced in the section *)
   poly_universes : UContext.t;
   (** Universes local to the section *)
   all_poly_univs : Instance.t;
@@ -78,11 +80,15 @@ let push_constraints uctx sec =
   let mono_universes =  (ContextSet.union uctx uctx') in
   { sec with mono_universes }
 
+let push_mono_qualities qs sec =
+  { sec with mono_qualities = Sorts.QVar.Set.union sec.mono_qualities qs }
+
 let open_section ~custom prev =
   {
     prev;
     context = [];
     mono_universes = ContextSet.empty;
+    mono_qualities = Sorts.QVar.Set.empty;
     poly_universes = UContext.empty;
     all_poly_univs = Option.cata (fun sec -> sec.all_poly_univs) Instance.empty prev;
     has_poly_univs = Option.cata has_poly_univs false prev;
@@ -93,7 +99,7 @@ let open_section ~custom prev =
   }
 
 let close_section sec =
-  sec.prev, sec.entries, sec.mono_universes, sec.custom
+  sec.prev, sec.entries, sec.mono_universes, sec.mono_qualities, sec.custom
 
 let push_local d sec =
   { sec with context = d :: sec.context }

--- a/kernel/section.mli
+++ b/kernel/section.mli
@@ -36,7 +36,7 @@ val open_section : custom:'a -> 'a t option -> 'a t
     inside a monomorphic one. A custom data can be attached to this section,
     that will be returned by {!close_section}. *)
 
-val close_section : 'a t -> 'a t option * section_entry list * ContextSet.t * 'a
+val close_section : 'a t -> 'a t option * section_entry list * ContextSet.t * Sorts.QVar.Set.t * 'a
 (** Close the current section and returns the entries defined inside, the set
     of global monomorphic constraints added in this section, and the custom data
     provided at the opening of the section. *)
@@ -53,6 +53,9 @@ val push_local_universe_context : UContext.t -> 'a t -> 'a t
 val push_constraints : ContextSet.t -> 'a t -> 'a t
 (** Extend the current section with a global universe context.
     Assumes that the last opened section is monomorphic. *)
+
+val push_mono_qualities : Sorts.QVar.Set.t -> 'a t -> 'a t
+(** Extend the current section with a global quality context. *)
 
 val push_global : Environ.env -> poly:bool -> section_entry -> 'a t -> 'a t
 (** Push a global entry in this section. *)

--- a/kernel/sorts.ml
+++ b/kernel/sorts.ml
@@ -10,25 +10,57 @@
 
 open Univ
 
+module QGlobal = struct
+  open Names
+
+  type t = {
+    library : DirPath.t;
+    id : Id.t
+  }
+
+  let make library id = { library ; id }
+
+  let repr x = (x.library, x.id)
+
+  let equal u1 u2 =
+    Id.equal u1.id u2.id &&
+    DirPath.equal u1.library u2.library
+
+  let hash u = Hashset.Combine.combine (Id.hash u.id) (DirPath.hash u.library)
+
+  let compare u1 u2 =
+    let c = Id.compare u1.id u2.id in
+    if c <> 0 then c
+    else
+      DirPath.compare u1.library u2.library
+
+  let to_string { library = d ; id } =
+    DirPath.to_string d ^ "." ^ Id.to_string id
+end
+
 module QVar =
 struct
   type repr =
     | Var of int
     | Unif of string * int
-
+    | Global of QGlobal.t
   type t = repr
 
   let make_var n = Var n
 
   let make_unif s n = Unif (s,n)
 
+  let make_global id = Global id
+
   let var_index = function
     | Var q -> Some q
     | Unif _ -> None
+    | Global _ -> None
 
   let hash = function
     | Var q -> Hashset.Combine.combinesmall 1 q
     | Unif (s,q) -> Hashset.Combine.(combinesmall 2 (combine (CString.hash s) q))
+    | Global id -> Hashset.Combine.combinesmall 3 (QGlobal.hash id)
 
   module Hstruct = struct
     type nonrec t = t
@@ -40,12 +72,14 @@ struct
       | Unif (s,i) as q ->
         let hs, s' = CString.hcons s in
         combinesmall 2 (combine hs i), if s == s' then q else Unif (s',i)
+      | Global id as q -> combinesmall 3 (QGlobal.hash id), q
 
     let eq a b =
       match a, b with
       | Var a, Var b -> Int.equal a b
       | Unif (sa, ia), Unif (sb, ib) -> sa == sb && Int.equal ia ib
-      | (Var _ | Unif _), _ -> false
+      | Global ida, Global idb -> QGlobal.equal ida idb
+      | (Var _ | Unif _| Global _), _ -> false
   end
 
   module Hasher = Hashcons.Make(Hstruct)
@@ -58,20 +92,25 @@ struct
       let c = Int.compare i1 i2 in
       if c <> 0 then c
       else CString.compare s1 s2
-    | Var _, Unif _ -> -1
-    | Unif _, Var _ -> 1
+    | Global ida, Global idb -> QGlobal.compare ida idb
+    | Var _, _ -> -1
+    | _, Var _ -> 1
+    | Unif _, _ -> -1
+    | _, Unif _ -> 1
 
   let equal a b = match a, b with
     | Var a, Var b ->  Int.equal a b
     | Unif (s1,i1), Unif (s2,i2) ->
       Int.equal i1 i2 && CString.equal s1 s2
-    | Var _, Unif _ | Unif _, Var _ -> false
+    | Global ida, Global idb -> QGlobal.equal ida idb
+    | (Var _| Unif _ | Global _), _ -> false
 
   let to_string = function
     | Var q -> Printf.sprintf "β%d" q
     | Unif (s,q) ->
       let s = if CString.is_empty s then "" else s^"." in
       Printf.sprintf "%sα%d" s q
+    | Global id -> Printf.sprintf "γ%s" (QGlobal.to_string id)
 
   let raw_pr q = Pp.str (to_string q)
 
@@ -88,6 +127,12 @@ module Quality = struct
   type t = QVar of QVar.t | QConstant of constant
 
   let var i = QVar (QVar.make_var i)
+  let global sg = QVar (QVar.make_global sg)
+
+  let is_var x =
+    match x with
+    | QVar _ -> true
+    | QConstant _ -> false
 
   let var_index = function
     | QVar q -> QVar.var_index q

--- a/kernel/sorts.mli
+++ b/kernel/sorts.mli
@@ -10,6 +10,20 @@
 
 (** {6 The sorts of CCI. } *)
 
+module QGlobal :
+sig
+
+  type t
+
+  val make : Names.DirPath.t -> Names.Id.t -> t
+  val repr : t -> Names.DirPath.t * Names.Id.t
+  val equal : t -> t -> bool
+  val hash : t -> int
+  val compare : t -> t -> int
+  val to_string : t -> string
+
+end
+
 module QVar :
 sig
   type t
@@ -18,6 +32,7 @@ sig
 
   val make_var : int -> t
   val make_unif : string -> int -> t
+  val make_global : QGlobal.t -> t
 
   val equal : t -> t -> bool
   val compare : t -> t -> int
@@ -33,6 +48,7 @@ sig
   type repr =
     | Var of int
     | Unif of string * int
+    | Global of QGlobal.t
 
   val repr : t -> repr
   val of_repr : repr -> t
@@ -62,6 +78,11 @@ module Quality : sig
 
   val var : int -> t
   (** [var i] is [QVar (QVar.make_var i)] *)
+
+  val global : QGlobal.t -> t
+  (** [global i] is [QVar (QVar.make_global i)] *)
+
+  val is_var : t -> bool
 
   val var_index : t -> int option
 

--- a/library/global.ml
+++ b/library/global.ml
@@ -85,6 +85,7 @@ let push_named_def d = globalize0 (Safe_typing.push_named_def d)
 let push_section_context c = globalize0 (Safe_typing.push_section_context c)
 let add_constraints c = globalize0 (Safe_typing.add_constraints c)
 let push_context_set c = globalize0 (Safe_typing.push_context_set ~strict:true c)
+let push_quality_set c = globalize0 (Safe_typing.push_quality_set c)
 
 let set_impredicative_set c = globalize0 (Safe_typing.set_impredicative_set c)
 let set_indices_matter b = globalize0 (Safe_typing.set_indices_matter b)
@@ -165,6 +166,7 @@ let add_module_parameter mbid mte inl =
 (** Queries on the global environment *)
 
 let universes () = Environ.universes (env())
+let qualities () = Environ.qualities (env())
 let named_context () = Environ.named_context (env())
 let named_context_val () = Environ.named_context_val (env())
 

--- a/library/global.mli
+++ b/library/global.mli
@@ -22,6 +22,7 @@ val safe_env : unit -> Safe_typing.safe_environment
 val env : unit -> Environ.env
 
 val universes : unit -> UGraph.t
+val qualities : unit -> Sorts.QVar.Set.t
 val named_context_val : unit -> Environ.named_context_val
 val named_context : unit -> Constr.named_context
 
@@ -67,6 +68,9 @@ val add_mind :
 val add_constraints : Univ.Constraints.t -> unit
 
 val push_context_set : Univ.ContextSet.t -> unit
+
+(** Extra sort qualities *)
+val push_quality_set : Sorts.QVar.Set.t -> unit
 
 (** Non-interactive modules and module types *)
 

--- a/library/nametab.ml
+++ b/library/nametab.ml
@@ -407,6 +407,10 @@ module UnivTab = Make(Univ.UGlobal)
 type univtab = UnivTab.t
 let the_univtab = Summary.ref ~name:"univtab" (UnivTab.empty : univtab)
 
+module QualityTab = Make(Sorts.QGlobal)
+type qualitytab = QualityTab.t
+let the_qualitytab = Summary.ref ~name:"qualitytab" (QualityTab.empty : qualitytab)
+
 (* Reversed name tables ***************************************************)
 
 (* This table translates extended_global_references back to section paths *)
@@ -424,6 +428,10 @@ module UnivIdMap = HMap.Make(Univ.UGlobal)
 
 type univrevtab = full_path UnivIdMap.t
 let the_univrevtab = Summary.ref ~name:"univrevtab" (UnivIdMap.empty : univrevtab)
+
+module QualityIdMap = HMap.Make(Sorts.QGlobal)
+type qualityrevtab = full_path QualityIdMap.t
+let the_qualityrevtab = Summary.ref ~name:"qualityrevtab" (QualityIdMap.empty : qualityrevtab)
 
 (** Module-related nametab *)
 module Modules = struct
@@ -511,6 +519,10 @@ let push_universe vis sp univ =
   the_univtab := UnivTab.push vis sp univ !the_univtab;
   the_univrevtab := UnivIdMap.add univ sp !the_univrevtab
 
+let push_sort vis sp quality =
+  the_qualitytab := QualityTab.push vis sp quality !the_qualitytab;
+  the_qualityrevtab := QualityIdMap.add quality sp !the_qualityrevtab
+
 (* Reverse locate functions ***********************************************)
 
 let path_of_global ref =
@@ -565,6 +577,10 @@ let shortest_qualid_of_dir ?loc sp =
 let shortest_qualid_of_universe ?loc ctx kn =
   let sp = UnivIdMap.find kn !the_univrevtab in
   UnivTab.shortest_qualid_gen ?loc (fun id -> Id.Map.mem id ctx) sp !the_univtab
+
+let shortest_qualid_of_quality ?loc ctx kn =
+  let sp = QualityIdMap.find kn !the_qualityrevtab in
+  QualityTab.shortest_qualid_gen ?loc (fun id -> Id.Map.mem id ctx) sp !the_qualitytab
 
 let pr_global_env env ref =
   try pr_qualid (shortest_qualid_of_global env ref)
@@ -635,6 +651,8 @@ let locate_modtype qid = MPTab.locate qid Modules.(!nametab.modtypetab)
 let full_name_modtype qid = MPTab.full_path qid Modules.(!nametab.modtypetab)
 
 let locate_universe qid = UnivTab.locate qid !the_univtab
+
+let locate_quality qid = QualityTab.locate qid !the_qualitytab
 
 let locate_dir qid = DirTab.locate qid Modules.(!nametab.dirtab)
 
@@ -712,6 +730,8 @@ let exists_module dir = MPDTab.exists dir Modules.(!nametab.modtab)
 let exists_modtype sp = MPTab.exists sp Modules.(!nametab.modtypetab)
 
 let exists_universe kn = UnivTab.exists kn !the_univtab
+
+let exists_sort kn = QualityTab.exists kn !the_qualitytab
 
 (* Source locations *)
 

--- a/library/nametab.mli
+++ b/library/nametab.mli
@@ -91,6 +91,7 @@ val push_dir : visibility -> full_path -> GlobDirRef.t -> unit
 val push_abbreviation : ?user_warns:Globnames.extended_global_reference UserWarn.with_qf -> visibility -> full_path -> Globnames.abbreviation -> unit
 
 val push_universe : visibility -> full_path -> Univ.UGlobal.t -> unit
+val push_sort : visibility -> full_path -> Sorts.QGlobal.t -> unit
 
 (** Deprecation and user warn info *)
 
@@ -112,6 +113,7 @@ val locate_dir : qualid -> GlobDirRef.t
 val locate_module : qualid -> ModPath.t
 val locate_section : qualid -> full_path
 val locate_universe : qualid -> Univ.UGlobal.t
+val locate_quality : qualid -> Sorts.QGlobal.t
 
 val locate_extended_nowarn : qualid -> Globnames.extended_global_reference
 
@@ -153,6 +155,7 @@ val exists_modtype : full_path -> bool
 val exists_module : full_path -> bool
 val exists_dir : full_path -> bool
 val exists_universe : full_path -> bool
+val exists_sort : full_path -> bool
 
 (** {6 These functions declare (resp. return) the source location of the object if known } *)
 
@@ -206,6 +209,8 @@ val shortest_qualid_of_dir : ?loc:Loc.t -> full_path -> qualid
 val shortest_qualid_of_universe : ?loc:Loc.t -> 'u Id.Map.t -> Univ.UGlobal.t -> qualid
 
 val pr_depr_xref : Globnames.extended_global_reference -> Pp.t
+
+val shortest_qualid_of_quality : ?loc:Loc.t -> 'u Id.Map.t -> Sorts.QGlobal.t -> qualid
 
 (** {5 Generic name handling} *)
 

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -249,7 +249,7 @@ let generate_functional_principle (evd : Evd.evar_map ref) old_princ_type sorts
     new_princ_name funs i proof_tac =
   try
     let f = funs.(i) in
-    let sigma, type_sort = Evd.fresh_sort_quality !evd UnivGen.QualityOrSet.qtype in
+    let sigma, type_sort = Evd.fresh_sort_in_quality !evd UnivGen.QualityOrSet.qtype in
     evd := sigma;
     let new_sorts =
       match sorts with
@@ -269,7 +269,7 @@ let generate_functional_principle (evd : Evd.evar_map ref) old_princ_type sorts
         (*     let id_of_f = Label.to_id (con_label f) in *)
         let register_with_sort sort =
           let evd' = Evd.from_env (Global.env ()) in
-          let evd', s = Evd.fresh_sort_quality evd' sort in
+          let evd', s = Evd.fresh_sort_in_quality evd' sort in
           let name =
             Indrec.make_elimination_ident base_new_princ_name sort
           in
@@ -1316,7 +1316,7 @@ let make_scheme evd (fas : (Constr.pconstant * UnivGen.QualityOrSet.t) list) : _
   let sorts =
     List.rev_map
       (fun (_, x) ->
-        let sigma, fs = Evd.fresh_sort_quality !evd x in
+        let sigma, fs = Evd.fresh_sort_in_quality !evd x in
         evd := sigma;
         fs)
       fas
@@ -1527,7 +1527,7 @@ let derive_correctness (funs : Constr.pconstant list) (graphs : inductive list)
       let mib, _mip = Inductive.lookup_mind_specif env graph_ind in
       let sigma, scheme =
         let sigma, inds = CArray.fold_left_map_i (fun i sigma _ ->
-            let sigma, s = Evd.fresh_sort_quality ~rigid:UnivRigid sigma UnivGen.QualityOrSet.qtype in
+            let sigma, s = Evd.fresh_sort_in_quality ~rigid:UnivRigid sigma UnivGen.QualityOrSet.qtype in
             sigma, (((kn, i), u), true, s))
             !evd
             mib.mind_packets
@@ -2214,7 +2214,7 @@ let build_case_scheme fa =
   in
   let scheme, scheme_type = Indrec.eval_case_analysis scheme in
   let sorts = (fun (_, _, x) ->
-      EConstr.ESorts.make @@ fst @@ UnivGen.fresh_sort_quality x) fa in
+      EConstr.ESorts.make @@ fst @@ UnivGen.fresh_sort_in_quality x) fa in
   let princ_name = (fun (x, _, _) -> x) fa in
   let (_ : unit) =
     (* Pp.msgnl (str "Generating " ++ Ppconstr.pr_id princ_name ++str " with " ++

--- a/plugins/ltac/leminv.ml
+++ b/plugins/ltac/leminv.ml
@@ -246,7 +246,7 @@ let add_inversion_lemma_exn ~poly na com comsort bool tac =
   let sigma = Evd.from_env env in
   let c, uctx = Constrintern.interp_type env sigma com in
   let sigma = Evd.from_ctx uctx in
-  let sigma, sort = Evd.fresh_sort_quality ~rigid:univ_rigid sigma comsort in
+  let sigma, sort = Evd.fresh_sort_in_quality ~rigid:univ_rigid sigma comsort in
   add_inversion_lemma ~poly na env sigma c sort bool tac
 
 (* ================================= *)

--- a/plugins/syntax/number_string.ml
+++ b/plugins/syntax/number_string.ml
@@ -180,7 +180,7 @@ let locate_global_sort_inductive_or_constant env sigma qid =
     | Globnames.Abbrev kn ->
     match Abbreviation.search_abbreviation kn with
     | [], Notation_term.NSort r ->
-       let sigma,c = Glob_ops.fresh_glob_sort_quality sigma r in
+       let sigma,c = Glob_ops.fresh_glob_sort_in_quality sigma r in
        let c = EConstr.ESorts.kind sigma c in
        sigma, Constr.mkSort c
     | _ -> raise Not_found in

--- a/pretyping/glob_ops.ml
+++ b/pretyping/glob_ops.ml
@@ -101,8 +101,8 @@ let glob_sort_quality s =
           end
        | _ -> raise ComplexSort
 
-let fresh_glob_sort_quality sigma s =
-  Evd.fresh_sort_quality sigma @@ glob_sort_quality s
+let fresh_glob_sort_in_quality sigma s =
+  Evd.fresh_sort_in_quality sigma @@ glob_sort_quality s
 
 let glob_level_eq u1 u2 =
   glob_sort_gen_eq glob_sort_name_eq u1 u2

--- a/pretyping/glob_ops.mli
+++ b/pretyping/glob_ops.mli
@@ -38,7 +38,7 @@ val cases_pattern_eq : 'a cases_pattern_g -> 'a cases_pattern_g -> bool
     contains a max, an increment, or a flexible universe *)
 exception ComplexSort
 val glob_sort_quality : glob_sort -> UnivGen.QualityOrSet.t
-val fresh_glob_sort_quality : Evd.evar_map -> glob_sort -> Evd.evar_map * Evd.esorts
+val fresh_glob_sort_in_quality : Evd.evar_map -> glob_sort -> Evd.evar_map * Evd.esorts
 
 val alias_of_pat : 'a cases_pattern_g -> Name.t
 

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -205,8 +205,9 @@ let is_correct_arity env sigma c pj ind specif params =
         sigma, s
       end
     | Evar (ev,_), [] ->
-       let sigma, s = Evd.fresh_sort_quality sigma
-                            (UnivGen.QualityOrSet.of_quality @@ elim_sort specif) in
+       let sigma, s = Evd.fresh_sort_in_quality sigma
+           (UnivGen.QualityOrSet.of_quality @@ elim_sort specif)
+       in
        let sigma = Evd.define ev (mkSort s) sigma in
        sigma, s
     | _, (LocalDef _ as d)::ar' ->

--- a/tactics/elimschemes.ml
+++ b/tactics/elimschemes.ml
@@ -27,7 +27,7 @@ let build_induction_scheme_in_type env dep sort ind =
   let sigma = Evd.from_env env in
   let sigma, pind = Evd.fresh_inductive_instance ~rigid:UState.univ_rigid env sigma ind in
   let pind = Util.on_snd EConstr.EInstance.make pind in
-  let sigma, sort = Evd.fresh_sort_quality ~rigid:UnivRigid sigma sort in
+  let sigma, sort = Evd.fresh_sort_in_quality ~rigid:UnivRigid sigma sort in
   let sigma, c = build_induction_scheme env sigma pind dep sort in
   EConstr.to_constr sigma c, Evd.ustate sigma
 
@@ -96,7 +96,7 @@ let optimize_non_type_induction_scheme kind dep sort env _handle ind =
         mib.mind_nparams in
     (* here, if [sort] is [Type] then it means that it's actually a [Set]:
        we optimise non-[Type] schemes *)
-    let sigma, sort = Evd.fresh_sort_quality sigma sort in
+    let sigma, sort = Evd.fresh_sort_in_quality sigma sort in
     let sigma, t', c' = weaken_sort_scheme env sigma sort npars c t in
     let sigma = Evd.minimize_universes sigma in
     (Evarutil.nf_evars_universes sigma c', Evd.ustate sigma)
@@ -156,7 +156,7 @@ let build_case_analysis_scheme_in_type env dep sort ind =
   let sigma = Evd.from_env env in
   let (sigma, indu) = Evd.fresh_inductive_instance env sigma ind in
   let indu = Util.on_snd EConstr.EInstance.make indu in
-  let sigma, sort = Evd.fresh_sort_quality ~rigid:UnivRigid sigma sort in
+  let sigma, sort = Evd.fresh_sort_in_quality ~rigid:UnivRigid sigma sort in
   let (sigma, c) = build_case_analysis_scheme env sigma indu dep sort in
   let (c, _) = Indrec.eval_case_analysis c in
   EConstr.Unsafe.to_constr c, Evd.ustate sigma

--- a/tactics/eqschemes.ml
+++ b/tactics/eqschemes.ml
@@ -412,7 +412,7 @@ let build_l2r_rew_scheme dep env handle ind kind =
                      rel_vect (nrealargs+4) nrealargs;
                      rel_vect 1 nrealargs;
                      [|mkRel 1|]]) in
-  let s, ctx' = UnivGen.fresh_sort_quality kind in
+  let s, ctx' = UnivGen.fresh_sort_in_quality kind in
   let ctx = UnivGen.sort_context_union ctx ctx' in
   let s = mkSort s in
   let rci = Sorts.Relevant in (* TODO relevance *)
@@ -520,7 +520,7 @@ let build_l2r_forward_rew_scheme dep env ind kind =
     name_context env ((LocalAssum (make_annot (Name varH) indr,applied_ind))::realsign) in
   let realsign_ind_P n aP =
     name_context env ((LocalAssum (make_annot (Name varH) indr,aP))::realsign_P n) in
-  let s, ctx' = UnivGen.fresh_sort_quality kind in
+  let s, ctx' = UnivGen.fresh_sort_in_quality kind in
   let ctx = UnivGen.sort_context_union ctx ctx' in
   let s = mkSort s in
   let rci = Sorts.Relevant in
@@ -602,7 +602,7 @@ let build_r2l_forward_rew_scheme dep env ind kind =
   let applied_ind = build_dependent_inductive indu specif in
   let realsign_ind =
     name_context env ((LocalAssum (make_annot (Name varH) indr,applied_ind))::realsign) in
-  let s, ctx' = UnivGen.fresh_sort_quality kind in
+  let s, ctx' = UnivGen.fresh_sort_in_quality kind in
   let ctx = UnivGen.sort_context_union ctx ctx' in
   let s = mkSort s in
   let rci = Sorts.Relevant in (* TODO relevance *)
@@ -693,7 +693,7 @@ let build_r2l_rew_scheme dep env ind k =
   let sigma = Evd.from_env env in
   let (sigma, indu) = Evd.fresh_inductive_instance env sigma ind in
   let indu = on_snd EConstr.EInstance.make indu in
-  let sigma, k = Evd.fresh_sort_quality ~rigid:UnivRigid sigma k in
+  let sigma, k = Evd.fresh_sort_in_quality ~rigid:UnivRigid sigma k in
   let (sigma, c) = build_case_analysis_scheme env sigma indu dep k in
   let (c, _) = Indrec.eval_case_analysis c in
   EConstr.Unsafe.to_constr c, Evd.ustate sigma

--- a/tactics/inv.ml
+++ b/tactics/inv.ml
@@ -99,7 +99,7 @@ let make_inv_predicate env evd indf realargs id status concl =
               | Some concl -> concl (*assumed it's some [x1..xn,H:I(x1..xn)]C*)
               | None ->
                 let sort = get_sort_quality_of env !evd concl in
-                let sort = evd_comb1 Evd.fresh_sort_quality evd sort in
+                let sort = evd_comb1 Evd.fresh_sort_in_quality evd sort in
                 let p = make_arity env !evd true indf sort in
                 let evd',(p,ptyp) = Unification.abstract_list_all env
                   !evd p concl (realargs@[mkVar id])

--- a/test-suite/output/DeclareSort.out
+++ b/test-suite/output/DeclareSort.out
@@ -1,0 +1,58 @@
+File "./output/DeclareSort.v", line 4, characters 35-36:
+The command has indeed failed with message:
+In environment
+A : Type@{s | _}
+The term "A" has type "Type@{s | _}" while it is expected to have type
+ "Type@{s' | _}"
+(universe inconsistency: Cannot enforce Type@{s | Set} <=
+Type@{s' | DeclareSort.21}).
+File "./output/DeclareSort.v", line 6, characters 35-36:
+The command has indeed failed with message:
+In environment
+A : Type@{s | _}
+The term "A" has type "Type@{s | _}" while it is expected to have type 
+"Type" (universe inconsistency: Cannot enforce Type@{s | Set} <=
+DeclareSort.22).
+File "./output/DeclareSort.v", line 8, characters 26-27:
+The command has indeed failed with message:
+In environment
+A : Set
+The term "A" has type "Set" while it is expected to have type 
+"Type@{s | _}" (universe inconsistency: Cannot enforce Set <=
+Type@{s | DeclareSort.23}).
+fun A : Type@{s | _} => A : Type@{s | _}
+     : Type@{s | _} -> Type@{s | _}
+foo
+     : Type@{S1 | _} -> Type@{S2 | _}
+foo@{S2 |  |} : Type -> Type
+
+foo is universe polymorphic
+Arguments foo _%_type_scope
+Expands to: Constant DeclareSort.foo
+Declared in library DeclareSort, line 17, characters 8-11
+foo@{S2 |  |} : Type@{S1 | Set} -> Type@{S2 | Set}
+(* S2 |  |=  *)
+
+foo is universe polymorphic
+Arguments foo _%_type_scope
+Expands to: Constant DeclareSort.foo
+Declared in library DeclareSort, line 17, characters 8-11
+foo@{SProp | } : Type@{S1 | Set} -> SProp
+     : Type@{S1 | Set} -> SProp
+foo@{Type | } : Type@{S1 | Set} -> Set
+     : Type@{S1 | Set} -> Set
+File "./output/DeclareSort.v", line 29, characters 11-14:
+The command has indeed failed with message:
+The term "foo@{α6 | }" has type "Type@{S1 | Set} -> Type@{α6 | Set}"
+while it is expected to have type "SProp -> ?T"
+(universe inconsistency: Cannot enforce SProp <= Type@{S1 | Set}).
+File "./output/DeclareSort.v", line 30, characters 11-14:
+The command has indeed failed with message:
+The term "foo@{α8 | }" has type "Type@{S1 | Set} -> Type@{α8 | Set}"
+while it is expected to have type "Set -> ?T"
+(universe inconsistency: Cannot enforce Set <= Type@{S1 | Set}).
+foo@{Type | } : Type@{S1 | Set} -> Set
+     : Type@{S1 | Set} -> Set
+File "./output/DeclareSort.v", line 35, characters 4-18:
+The command has indeed failed with message:
+Cannot declare global sort qualities inside module types.

--- a/test-suite/output/DeclareSort.v
+++ b/test-suite/output/DeclareSort.v
@@ -1,0 +1,37 @@
+Sort s.
+Sort s'.
+
+Fail Check fun (A:Type@{s|Set}) => A : Type@{s'|_}.
+
+Fail Check fun (A:Type@{s|Set}) => A : Type.
+
+Fail Check fun (A:Set) => A : Type@{s|_}.
+
+Check fun (A:Type@{s|Set}) => A : Type@{s|_}.
+
+Section S.
+  Sort S1.
+  Local Set Universe Polymorphism.
+  Sort S2.
+
+  Axiom foo : Type@{S1|Set} -> Type@{S2|Set}.
+  Check foo.
+
+End S.
+
+About foo.
+Set Printing Universes.
+About foo.
+
+Check foo : _ -> SProp.
+Check foo : _ -> Set.
+
+Fail Check foo : SProp -> _.
+Fail Check foo : Set -> _.
+Check foo : Type@{S1|Set} -> Set.
+
+Module Type T.
+  Module M.
+    Fail Sort foz.
+  End M.
+End T.

--- a/vernac/declareUniv.ml
+++ b/vernac/declareUniv.ml
@@ -14,7 +14,7 @@ open Univ
 (* object_kind , id *)
 exception AlreadyDeclared of (string option * Id.t)
 
-let _ = CErrors.register_handler (function
+let () = CErrors.register_handler (function
     | AlreadyDeclared (kind, id) ->
       Some
         Pp.(seq [ Pp.pr_opt_no_spc (fun s -> str s ++ spc ()) kind
@@ -28,6 +28,15 @@ type universe_source =
   | UnqualifiedUniv (* other global universe, todo merge with [QualifiedUniv []] *)
 
 type universe_name_decl = universe_source * (Id.t * UGlobal.t) list
+
+type sort_source =
+  | BoundQuality
+  | UnqualifiedQuality
+
+type sort_name_decl = {
+  sdecl_src : sort_source; (* global sort introduced by some global value *)
+  sdecl_named : (Id.t * Sorts.QGlobal.t) list;
+}
 
 let check_exists_universe sp =
   if Nametab.exists_universe sp then
@@ -84,6 +93,50 @@ let invent_name prefix (named,cnt) u =
     else na, (Id.Map.add na u named, i+1)
   in
   aux cnt
+
+let check_exists_sort sp =
+  if Nametab.exists_sort sp then
+    raise (AlreadyDeclared (Some "Sort", Libnames.basename sp))
+  else ()
+
+let qualify_sort i dp id =
+  i, Libnames.add_path_suffix dp id
+
+let do_sort_name ~check i dp (id,quality) =
+  let i, sp = qualify_sort i dp id in
+  if check then check_exists_sort sp;
+  Nametab.push_sort i sp quality
+
+let cache_sort_names (prefix, decl) =
+  let depth = Lib.sections_depth () in
+  let dp = Libnames.path_pop_n_suffixes depth prefix.Libobject.obj_path in
+  List.iter (do_sort_name ~check:true (Nametab.Until 1) dp) decl.sdecl_named
+
+let load_sort_names i (prefix, decl) =
+  List.iter (do_sort_name ~check:false (Nametab.Until i) prefix.Libobject.obj_path) decl.sdecl_named
+
+let open_sort_names i (prefix, decl) =
+  List.iter (do_sort_name ~check:false (Nametab.Exactly i) prefix.Libobject.obj_path) decl.sdecl_named
+
+let discharge_sort_names decl =
+  match decl.sdecl_src with
+  | BoundQuality -> None
+  | UnqualifiedQuality -> Some decl
+
+let input_sort_names : sort_name_decl -> Libobject.obj =
+  let open Libobject in
+  declare_named_object_gen
+    { (default_object "Global sort name state") with
+      cache_function = cache_sort_names;
+      load_function = load_sort_names;
+      open_function = filtered_open open_sort_names;
+      discharge_function = discharge_sort_names;
+      classify_function = (fun a -> Escape) }
+
+let input_sort_names (src, l) =
+  if CList.is_empty l then ()
+  else Lib.add_leaf (input_sort_names { sdecl_src = src; sdecl_named = l })
+
 
 let label_of = let open GlobRef in function
 | ConstRef c -> Label.to_id @@ Constant.label c
@@ -156,7 +209,33 @@ let do_universe ~poly l =
     let names = CArray.map_of_list (fun (na,_) -> Name na) l in
     let us = CArray.map_of_list (fun (_,l) -> Level.make l) l in
     let ctx =
-      UVars.UContext.make {quals = [||]; univs = names} (UVars.Instance.of_array ([||],us), Constraints.empty)
+      UVars.UContext.make {quals = [||]; univs = names}
+        (UVars.Instance.of_array ([||],us), Constraints.empty)
+    in
+    Global.push_section_context ctx
+
+let do_sort ~poly l =
+  let in_section = Lib.sections_are_opened () in
+  let () =
+    if poly && not in_section then
+      CErrors.user_err
+        (Pp.str"Cannot declare polymorphic sorts outside sections.")
+  in
+  let l = List.map (fun {CAst.v=id} -> (id, UnivGen.new_sort_global id)) l in
+  let src = if poly then BoundQuality else UnqualifiedQuality in
+  let () = input_sort_names (src, l) in
+  match poly with
+  | false ->
+    let qs = List.fold_left  (fun qs (_, qv) -> Sorts.QVar.(Set.add (make_global qv) qs))
+      Sorts.QVar.Set.empty l
+    in
+    Global.push_quality_set qs
+  | true ->
+    let names = CArray.map_of_list (fun (na,_) -> Name na) l in
+    let qs = CArray.map_of_list (fun (_,sg) -> Sorts.Quality.global sg) l in
+    let ctx =
+      UVars.UContext.make {quals=names; univs=[||]}
+        (UVars.Instance.of_array (qs,[||]), Constraints.empty)
     in
     Global.push_section_context ctx
 

--- a/vernac/declareUniv.mli
+++ b/vernac/declareUniv.mli
@@ -31,3 +31,6 @@ val add_constraint_source : GlobRef.t -> Univ.ContextSet.t -> unit
 
 val constraint_sources : unit -> (GlobRef.t * Univ.Constraints.t) list
 (** Returns constraints associated to globrefs, newest first. *)
+
+(** Command [Sort]. *)
+val do_sort : poly:bool -> lident list -> unit

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -293,6 +293,8 @@ GRAMMAR EXTEND Gram
           { VernacPrimitive(id, r, typopt) }
       | IDENT "Universe"; l = LIST1 identref -> { VernacUniverse l }
       | IDENT "Universes"; l = LIST1 identref -> { VernacUniverse l }
+      | IDENT "Sort"; l = LIST1 identref -> { VernacSort l }
+      | IDENT "Sorts"; l = LIST1 identref -> { VernacSort l }
       | IDENT "Constraint"; l = LIST1 univ_constraint SEP "," -> { VernacConstraint l }
       | IDENT "Rewrite"; IDENT "Rule"; id = identref; ":="; OPT"|"; rules = LIST1 rewrite_rule SEP "|" ->
           { VernacAddRewRule (id, rules) }
@@ -1173,6 +1175,7 @@ GRAMMAR EXTEND Gram
           IDENT "Constraint"; IDENT "Sources" -> { b } ];
         fopt = OPT ne_string ->
         { PrintUniverses {sort=b; subgraph=g; with_sources; file=fopt;} }
+      | IDENT "Sorts" -> { PrintSorts }
       | IDENT "Assumptions"; qid = smart_global -> { PrintAssumptions (false, false, qid) }
       | IDENT "Opaque"; IDENT "Dependencies"; qid = smart_global -> { PrintAssumptions (true, false, qid) }
       | IDENT "Transparent"; IDENT "Dependencies"; qid = smart_global -> { PrintAssumptions (false, true, qid) }

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1660,7 +1660,7 @@ let rec vernac_interp_error_handler = function
   | UGraph.UniverseInconsistency i ->
     str "Universe inconsistency." ++ spc() ++
     UGraph.explain_universe_inconsistency
-      Sorts.QVar.raw_pr
+      UnivNames.pr_quality_with_global_universes
       UnivNames.pr_level_with_global_universes
       i ++ str "."
   | TypeError(env,te) ->

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -389,7 +389,7 @@ let do_mutual_induction_scheme ?(force_mutual=false) env ?(isrec=true) l =
   in
   let sigma, lrecspec =
     List.fold_left_map (fun sigma (_,dep,ind,sort) ->
-        let sigma, sort = Evd.fresh_sort_quality ~rigid:UnivRigid sigma sort in
+        let sigma, sort = Evd.fresh_sort_in_quality ~rigid:UnivRigid sigma sort in
         (sigma, ((ind,inst),dep,sort)))
       sigma
       l

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -658,6 +658,8 @@ let pr_printable = function
       else str "Without Constraint Sources"
     in
     keyword cmd ++ pr_opt pr_subgraph g ++ pr_opt pr_with_src with_sources ++ pr_opt str fopt
+  | PrintSorts ->
+    keyword "Print Sorts"
   | PrintName (qid,udecl) ->
     keyword "Print" ++ spc()  ++ pr_smart_global qid ++ pr_full_univ_name_list udecl
   | PrintModuleType qid ->
@@ -978,6 +980,11 @@ let pr_synpure_vernac_expr v =
   | VernacUniverse v ->
     return (
       hov 2 (keyword "Universe" ++ spc () ++
+             prlist_with_sep (fun _ -> str",") pr_lident v)
+    )
+  | VernacSort v ->
+    return (
+      hov 2 (keyword "Sort" ++ spc () ++
              prlist_with_sep (fun _ -> str",") pr_lident v)
     )
   | VernacConstraint v ->

--- a/vernac/vernac_classifier.ml
+++ b/vernac/vernac_classifier.ml
@@ -171,7 +171,7 @@ let classify_vernac e =
         let ids = List.map (fun {v}->v) (CList.map_filter (fun (x,_) -> x) l) in
         VtSideff (ids, VtLater)
     | VernacCombinedScheme ({v=id},_) -> VtSideff ([id], VtLater)
-    | VernacUniverse _ | VernacConstraint _
+    | VernacUniverse _ | VernacSort _ | VernacConstraint _
     | VernacCanonical _ | VernacCoercion _ | VernacIdentityCoercion _
     | VernacCreateHintDb _ | VernacRemoveHints _ | VernacHints _
     | VernacArguments _

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -702,6 +702,11 @@ let print_universes { sort; subgraph; with_sources; file; } =
   | Some s -> dump_universes_gen (fun u -> Pp.string_of_ppcmds (prl u)) univ s
   end
 
+let print_sorts () =
+  let qualities = Sorts.QVar.Set.elements (Global.qualities ()) in
+  let prq = UnivNames.pr_quality_with_global_universes in
+  Pp.prlist_with_sep Pp.spc prq qualities
+
 (*********************)
 (* "Locate" commands *)
 
@@ -1329,6 +1334,13 @@ let vernac_universe ~poly l =
                  (str"Polymorphic universes can only be declared inside sections, " ++
                   str "use Monomorphic Universe instead.");
   DeclareUniv.do_universe ~poly l
+
+let vernac_sort ~poly l =
+  if poly && not (Lib.sections_are_opened ()) then
+    user_err
+                 (str"Polymorphic sorts can only be declared inside sections, " ++
+                  str "use #[universes(polymorphic=no)] Sort in order to declare a global sort.");
+  DeclareUniv.do_sort ~poly l
 
 let vernac_constraint ~poly l =
   if poly && not (Lib.sections_are_opened ()) then
@@ -2243,6 +2255,7 @@ let vernac_print =
     Prettyp.print_canonical_projections env sigma grefs
   | PrintUniverses prunivs -> no_state @@ fun ()->
     print_universes prunivs
+  | PrintSorts -> no_state print_sorts
   | PrintHint r -> with_proof_env @@ fun env sigma ->
     Hints.pr_hint_ref env sigma (smart_global r)
   | PrintHintGoal -> with_pstate @@ fun ~pstate ->
@@ -2682,6 +2695,9 @@ let translate_pure_vernac ?loc ~atts v = let open Vernactypes in match v with
         vernac_combined_scheme id l ~locmap:(Ind_tables.Locmap.default loc))
   | VernacUniverse l ->
     vtdefault(fun () -> vernac_universe ~poly:(only_polymorphism atts) l)
+
+  | VernacSort l ->
+    vtdefault(fun () -> vernac_sort ~poly:(only_polymorphism atts) l)
 
   | VernacConstraint l ->
     vtdefault(fun () -> vernac_constraint ~poly:(only_polymorphism atts) l)

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -62,6 +62,7 @@ type printable =
   | PrintCoercionPaths of coercion_class * coercion_class
   | PrintCanonicalConversions of qualid or_by_notation list
   | PrintUniverses of print_universes
+  | PrintSorts
   | PrintHint of qualid or_by_notation
   | PrintHintGoal
   | PrintHintDbName of string
@@ -433,6 +434,7 @@ type nonrec synpure_vernac_expr =
   | VernacSchemeEquality of equality_scheme_type * Libnames.qualid Constrexpr.or_by_notation
   | VernacCombinedScheme of lident * lident list
   | VernacUniverse of lident list
+  | VernacSort of lident list
   | VernacConstraint of univ_constraint_expr list
   | VernacAddRewRule of lident * (universe_decl_expr option * constr_expr * constr_expr) list
 


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

This PR adds new vernacular instructions `Sort q1 ... qn.` / `Sorts q1 ... qn.` to declare global fresh sort qualities `q1`, ..., `qn`.
Its intended usage is to add new sorts with axiomatised content that do not leak necessarily in the standard sorts.
For instance an exceptional sort can be defined as follow, without compromising the soundness of the `Type` hierarchy:
```coq
Sort exc.
Definition Exc@{u} := Type@{exc|u}.
Axiom raise@{u} : forall (A : Exc@{u}), A.
```

The implementation is based on the work on sort-polymorphism, treating new sort qualities as fresh variables that cannot be unified, nor substituted.

The current implementation is a very rough draft and is not meant to be merged yet before heavy testing.

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [x] Documented any new / changed **user messages**.
  - [x] Updated **documented syntax** by running `make doc_gram_rsts`.

Overlays:
- https://github.com/ejgallego/coq-lsp/pull/920
- https://github.com/mattam82/Coq-Equations/pull/650