### PR TITLE
Fixes #17897: lost of canonical name of auxiliary constants of mutual fix/cofix at refolding time in "cbn"

### DIFF
--- a/doc/changelog/04-tactics/18616-master+fix17897-cbn-wrong-canonical-name-refolding.rst
+++ b/doc/changelog/04-tactics/18616-master+fix17897-cbn-wrong-canonical-name-refolding.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  :tacn:`cbn` was leaving behind unnamable constants when refolding
+  mutual fixpoints/cofixpoints from aliased modules
+  (`#18616 <https://github.com/coq/coq/pull/18616>`_,
+  fixes `#17897 <https://github.com/coq/coq/issues/17897>`_,
+  by Hugo Herbelin).

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -382,7 +382,7 @@ sig
   (** Special case of [make] where the user name is canonical.  *)
 
   val make2 : ModPath.t -> Label.t -> t
-  (** Shortcut for [(make1 (KerName.make2 ...))] *)
+  (** Shortcut for [(make1 (KerName.make ...))] *)
 
   (** Projections *)
 
@@ -453,7 +453,7 @@ sig
   (** Special case of [make] where the user name is canonical.  *)
 
   val make2 : ModPath.t -> Label.t -> t
-  (** Shortcut for [(make1 (KerName.make2 ...))] *)
+  (** Shortcut for [(make1 (KerName.make ...))] *)
 
   (** Projections *)
 

--- a/tactics/cbn.ml
+++ b/tactics/cbn.ml
@@ -439,8 +439,7 @@ let magically_constant_of_fixbody env sigma reference bd = function
   | Name.Anonymous -> bd
   | Name.Name id ->
     let open UnivProblem in
-    let cst_mod = KerName.modpath (Constant.user reference) in
-    let cst = Constant.make2 cst_mod (Label.of_id id) in
+    let cst = Constant.change_label reference (Label.of_id id) in
     if not (Environ.mem_constant cst env) then bd
     else
       let (cst, u), ctx = UnivGen.fresh_constant_instance env cst in

--- a/test-suite/bugs/bug_17897.v
+++ b/test-suite/bugs/bug_17897.v
@@ -1,0 +1,6 @@
+From Coq Require Import PArith.
+Local Open Scope positive_scope.
+Goal Pos.add 3 3 = 1.
+cbn [Pos.add Pos.add_carry Pos.succ]. (* There was a problem with canonical names *)
+match goal with [ |- 6 = 1 ] => idtac end.
+Abort.


### PR DESCRIPTION
Fixes / closes #17897

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
