### PR TITLE
Fix #18572: tactic clear sometimes too eager to remove a dependency in an existential variable vs restricting the context of the existential variable

### DIFF
--- a/doc/changelog/04-tactics/18617-master+fix18572-clear-too-eager-with-evars.rst
+++ b/doc/changelog/04-tactics/18617-master+fix18572-clear-too-eager-with-evars.rst
@@ -1,0 +1,7 @@
+- **Fixed:**
+  :tacn:`clear` restricts the context of the existential variables
+  referring to the hypotheses to clear also when these existential
+  variables occur in the instance of other existential variables
+  (`#18617 <https://github.com/coq/coq/pull/18617>`_,
+  fixes `#18572 <https://github.com/coq/coq/issues/18572>`_,
+  by Hugo Herbelin).

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -893,8 +893,8 @@ let apply_to_hyp ctxt id f =
     | None -> raise Hyp_not_found
   in aux [] ctxt
 
-(* To be used in Logic.clear_hyps *)
-let remove_hyps ids check_context ctxt =
+(* To be used in Evarutil.clear_hyps *)
+let remove_hyps ids ctxt =
   let rec remove_hyps ids ctxt =
     if Id.Set.is_empty ids then ctxt, false
     else match match_named_context_val ctxt with
@@ -903,17 +903,15 @@ let remove_hyps ids check_context ctxt =
       let id0 = Context.Named.Declaration.get_id d in
       let removed = Id.Set.mem id0 ids in
       let ids = if removed then Id.Set.remove id0 ids else ids in
-      let (ans, seen) = remove_hyps ids rctxt in
-      if removed then (ans, true)
+      let (rctxt', seen) = remove_hyps ids rctxt in
+      if removed then (rctxt', true)
       else if not seen then ctxt, false
       else
-        let rctxt' = ans in
-        let d' = check_context d in
-        if d == d' && rctxt == rctxt' then
-          ctxt, true
-        else push_named_context_val d' rctxt', true
+        if rctxt == rctxt' then ctxt, true
+        else push_named_context_val d rctxt', true
   in
-  fst (remove_hyps ids ctxt)
+  let ids, _ = remove_hyps ids ctxt in
+  ids
 
 (* A general request *)
 

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -438,7 +438,7 @@ val apply_to_hyp : named_context_val -> variable ->
   (Constr.named_context -> Constr.named_declaration -> Constr.named_context -> Constr.named_declaration) ->
     named_context_val
 
-val remove_hyps : Id.Set.t -> (Constr.named_declaration -> Constr.named_declaration) -> named_context_val -> named_context_val
+val remove_hyps : Id.Set.t -> named_context_val -> named_context_val
 
 val is_polymorphic : env -> Names.GlobRef.t -> bool
 val is_template_polymorphic : env -> GlobRef.t -> bool

--- a/test-suite/bugs/bug_18572.v
+++ b/test-suite/bugs/bug_18572.v
@@ -1,0 +1,17 @@
+Parameters F G: Prop.
+
+Axiom F2G: F -> G.
+
+Goal F -> exists n: nat, n * n = 0.
+Proof.
+  intros HF.
+  eapply ex_ind.
+  intros x Hx.
+  unshelve eexists. (* Check that [x] is not cleared *)
+  2:clear HF.
+  Fail Check HF. (* check that HF is transitively cleared *)
+  exact x.
+  exact Hx.
+  exists 0.
+  reflexivity.
+Qed.


### PR DESCRIPTION
Fixes / closes #18572

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
