### PR TITLE
Fixes #9086: make "cbv" behave like other reductions with respect to unfoldable primitive projections

### DIFF
--- a/doc/changelog/04-tactics/18618-master+fix9086-align-cbv-prim-proj-other-reduction.rst
+++ b/doc/changelog/04-tactics/18618-master+fix9086-align-cbv-prim-proj-other-reduction.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  :tacn:`cbv` of primitive projections applied to a tuple now ignores `beta`
+  like it does for :tacn:`cbn`, :tacn:`lazy` and :tacn:`simpl`
+  (`#18618 <https://github.com/coq/coq/pull/18618>`_,
+  fixes `#9086 <https://github.com/coq/coq/issues/9086>`_,
+  by Hugo Herbelin).

--- a/pretyping/cbv.ml
+++ b/pretyping/cbv.ml
@@ -518,7 +518,6 @@ let rec norm_head info env t stack =
   | Proj (p, r, c) ->
     let p' =
       if red_set info.reds (fPROJ (Projection.repr p))
-        && red_set info.reds fBETA
       then Projection.unfold p
       else p
     in

--- a/test-suite/bugs/bug_9086.v
+++ b/test-suite/bugs/bug_9086.v
@@ -1,0 +1,47 @@
+(* Systematic study around issue #9086 *)
+
+Local Set Primitive Projections.
+Record pair {A B} := mk { _1 : A; _2 : B _1 }.
+
+Module Folded.
+
+Goal (@mk Prop (fun _ => Prop) True True).(_1).
+  assert_succeeds (progress (cbn iota delta [_1])).
+  assert_succeeds (progress (cbv iota delta [_1])).
+  assert_succeeds (progress (lazy iota delta [_1])).
+  assert_succeeds (progress simpl).
+Opaque _1. (* has an impact on "_1" *)
+  assert_fails (progress cbn).
+  assert_fails (progress cbv).
+  assert_fails (progress lazy).
+  assert_fails (progress simpl).
+Abort.
+
+End Folded.
+
+Module Unfolded.
+
+Goal (@mk Prop (fun _ => Prop) True True).(_1).
+  lazy delta [_1]. (* move to unfolded form *)
+  assert_succeeds (progress (cbn iota delta [_1])).
+  assert_succeeds (progress (cbv iota delta [_1])).
+  assert_succeeds (progress (lazy iota delta [_1])).
+  assert_succeeds (progress simpl).
+Opaque _1. (* no impact on "unfolded _1" *)
+  assert_succeeds (progress (cbn iota delta [_1])).
+  assert_succeeds (progress (cbv iota delta [_1])).
+  assert_succeeds (progress (lazy iota delta [_1])).
+  assert_succeeds (progress simpl).
+Abort.
+
+End Unfolded.
+
+Module Unfold.
+
+Set Printing Unfolded Projection As Match.
+Goal (@mk Prop (fun _ => Prop) True True).(_1).
+  cbv delta [_1]. (* should internally unfold the projection *)
+  progress lazy iota. (* allowed by the unfolding *)
+Abort.
+
+End Unfold.


### PR DESCRIPTION
Fixes #9086

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
