### PR TITLE
Fast name generation in evar naming algorithm

### DIFF
--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -406,8 +406,7 @@ let next_evar_name sigma naming = match naming with
 | IntroAnonymous -> None
 | IntroIdentifier id -> Some id
 | IntroFresh id ->
-  let has_name id = try let _ = Evd.evar_key id sigma in true with Not_found -> false in
-  let id = Namegen.next_ident_away_from id has_name in
+  let id = Nameops.Fresh.next id (Evd.evar_names sigma) in
   Some id
 
 (* [new_evar] declares a new existential in an env env with type typ *)

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -372,6 +372,8 @@ val rename : Evar.t -> Id.t -> evar_map -> evar_map
 
 val evar_key : Id.t -> evar_map -> Evar.t
 
+val evar_names : evar_map -> Nameops.Fresh.t
+
 val evar_source_of_meta : metavariable -> evar_map -> Evar_kinds.t located
 
 val dependent_evar_ident : Evar.t -> evar_map -> Id.t

--- a/engine/nameops.ml
+++ b/engine/nameops.ml
@@ -200,6 +200,307 @@ let add_prefix s id = Id.of_string (s ^ Id.to_string id)
 
 let atompart_of_id id = fst (repr_ident id)
 
+(** Segment trees: efficient lookup of the next free integer *)
+module SegTree :
+sig
+  type t
+  val empty : t
+  val mem : int -> t -> bool
+  val add : int -> t -> t
+  val remove : int -> t -> t
+
+  val next : int -> t -> int
+  (** [next n s] returns the smallest integer [k] not in [s] s.t. [n <= k] *)
+
+  val fresh : int -> t -> int * t
+  (** Efficient composition of [next] and [add] *)
+
+end =
+struct
+
+module Segment =
+struct
+  type t = int * int (* segment [p, q[, in particular p < q *)
+  let compare (p, _) (q, _) = Int.compare p q
+end
+
+module SegSet = Set.Make(Segment)
+
+type t = SegSet.t
+(* Invariants: forall [p1, q1[, [p2, q2[ in such a set, either:
+  - p1 = p2 and q1 = q2
+  - p1 < q1 < p2 < q2
+  - p2 < q2 < p1 < q1 *)
+
+let empty = SegSet.empty
+
+let mem n s =
+  let find (_p, q) = n < q in
+  match SegSet.find_first_opt find s with
+  | None -> false
+  | Some (p, _q) -> p <= n
+
+let add n s =
+  let find_min (_p, q) = n < q in
+  let find_max (_p, q) = q <= n in
+  match SegSet.find_first_opt find_min s with
+  | None ->
+    (* n larger than all elements *)
+    begin match SegSet.max_elt_opt s with
+    | None -> SegSet.add (n, n + 1) s
+    | Some (pl, ql) ->
+      if Int.equal n ql then SegSet.add (pl, n + 1) (SegSet.remove (pl, ql) s)
+      else SegSet.add (n, n + 1) s
+    end
+  | Some (pr, qr) ->
+    if pr <= n then s (* already present *)
+    else match SegSet.find_last_opt find_max s with
+    | None ->
+      (* n smaller than all elements *)
+      if Int.equal pr (n + 1) then
+        SegSet.add (n, qr) (SegSet.remove (pr, qr) s)
+      else SegSet.add (n, n + 1) s
+    | Some (pl, ql) ->
+      (* pl < ql <= n < pr < qr *)
+      if Int.equal ql n && Int.equal pr (n + 1) then
+        SegSet.add (pl, qr) (SegSet.remove (pl, ql) (SegSet.remove (pr, qr) s))
+      else if Int.equal ql n then
+        SegSet.add (pl, n + 1) (SegSet.remove (pl, ql) s)
+      else if Int.equal pr (n + 1) then
+        SegSet.add (n, qr) (SegSet.remove (pr, qr) s)
+      else
+        SegSet.add (n, n + 1) s
+
+let remove n s =
+  let find_min (_p, q) = n < q in
+  match SegSet.find_first_opt find_min s with
+  | None -> s
+  | Some (pr, qr) ->
+    if pr <= n then
+      let s = SegSet.remove (pr, qr) s in
+      if Int.equal (pr + 1) qr then s
+      else if Int.equal pr n then SegSet.add (n + 1, qr) s
+      else if Int.equal (n + 1) qr then SegSet.add (pr, n) s
+      else SegSet.add (pr, n) (SegSet.add (n + 1, qr) s)
+   else s
+
+let next n s =
+  let find (_p, q) = n < q in
+  match SegSet.find_first_opt find s with
+  | None -> n
+  | Some (p, q) -> if p <= n then q else n
+
+let fresh n s =
+  let find_min (_p, q) = n < q in
+  let find_max (_p, q) = q <= n in
+  match SegSet.find_first_opt find_min s with
+  | None ->
+    let s = match SegSet.max_elt_opt s with
+    | None -> SegSet.add (n, n + 1) s
+    | Some (pl, ql) ->
+      if Int.equal n ql then SegSet.add (pl, n + 1) (SegSet.remove (pl, ql) s)
+      else SegSet.add (n, n + 1) s
+    in
+    n, s
+  | Some (pr, qr) ->
+    if pr <= n then
+      (* equivalent to adding qr *)
+      let next = SegSet.find_first_opt (fun (p, _q) -> qr < p) s in
+      let s = match next with
+      | None -> SegSet.add (pr, qr + 1) (SegSet.remove (pr, qr) s)
+      | Some (pk, qk) ->
+        if Int.equal (qr + 1) pk then
+          SegSet.add (pr, qk) (SegSet.remove (pk, qk) (SegSet.remove (pr, qr) s))
+        else
+          SegSet.add (pr, qr + 1) (SegSet.remove (pr, qr) s)
+      in
+      qr, s
+    else
+      let s = match SegSet.find_last_opt find_max s with
+      | None ->
+        if Int.equal pr (n + 1) then
+          SegSet.add (n, qr) (SegSet.remove (pr, qr) s)
+        else SegSet.add (n, n + 1) s
+      | Some (pl, ql) ->
+        if Int.equal ql n && Int.equal pr (n + 1) then
+          SegSet.add (pl, qr) (SegSet.remove (pl, ql) (SegSet.remove (pr, qr) s))
+        else if Int.equal ql n then
+          SegSet.add (pl, n + 1) (SegSet.remove (pl, ql) s)
+        else if Int.equal pr (n + 1) then
+          SegSet.add (n, qr) (SegSet.remove (pr, qr) s)
+        else
+          SegSet.add (n, n + 1) s
+      in
+      n, s
+
+end
+
+module SubSet =
+struct
+
+  type t = {
+    num : SegTree.t;
+    pre : SegTree.t list; (* lists are OK because we are already logarithmic *)
+  }
+  (* We represent sets of subscripts by case-splitting on ss_zero.
+     If it is zero, we store the number in the [num] set. Otherwise, we know
+     the set of possible values is finite. At position k, [pre] contains a set
+     of maximum size 10^k representing k-digit numbers with at least one leading
+     zero. *)
+
+  let empty = {
+    num = SegTree.empty;
+    pre = [];
+  }
+
+  let rec pow10 k accu = if k <= 0 then accu else pow10 (k - 1) (10 * accu)
+
+  let rec log10 n accu = if n <= 0 then accu else log10 (n / 10) (accu + 1)
+
+  let max_subscript ss =
+    let exp = log10 ss.Subscript.ss_subs 0 + ss.Subscript.ss_zero - 1 in
+    pow10 exp 1
+
+  let add ss s =
+    let open Subscript in
+    if Int.equal ss.ss_zero 0 then
+      { s with num = SegTree.add ss.ss_subs s.num }
+    else
+      let pre =
+        let len = List.length s.pre in
+        if len < ss.ss_zero then
+          s.pre @ List.make (ss.ss_zero - len) SegTree.empty
+        else s.pre
+      in
+      let set = match List.nth_opt pre (ss.ss_zero - 1) with
+      | None -> assert false
+      | Some m -> SegTree.add ss.ss_subs m
+      in
+      { s with pre = List.assign pre (ss.ss_zero - 1) set }
+
+  let remove ss s =
+    let open Subscript in
+    if Int.equal ss.ss_zero 0 then
+      { s with num = SegTree.remove ss.ss_subs s.num }
+    else match List.nth_opt s.pre (ss.ss_zero - 1) with
+    | None -> s
+    | Some m ->
+      let m = SegTree.remove ss.ss_subs m in
+      { s with pre = List.assign s.pre (ss.ss_zero - 1) m }
+
+  let mem ss s =
+    let open Subscript in
+    if Int.equal ss.ss_zero 0 then SegTree.mem ss.ss_subs s.num
+    else match List.nth_opt s.pre (ss.ss_zero - 1) with
+    | None -> false
+    | Some m -> SegTree.mem ss.ss_subs m
+
+  let ss_O = { Subscript.ss_zero = 1; ss_subs = 0 } (* [0] *)
+
+  let next ss s =
+    let open Subscript in
+    if ss.ss_zero > 0 then
+      match List.nth_opt s.pre (ss.ss_zero - 1) with
+      | None -> ss
+      | Some m ->
+        let next = SegTree.next ss.ss_subs m in
+        let max = max_subscript ss in
+        if max <= next then (* overflow *)
+          { ss_zero = 0; ss_subs = SegTree.next max s.num }
+        else
+          { ss_zero = ss.ss_zero; ss_subs = next }
+    else if Int.equal ss.ss_subs 0 then
+      (* Handle specially [] *)
+      if not @@ SegTree.mem 0 s.num then Subscript.zero
+      else match s.pre with
+      | [] -> ss_O
+      | m :: _ ->
+        if SegTree.mem 0 m then { ss_zero = 0; ss_subs = SegTree.next 1 s.num }
+        else ss_O
+    else
+      { ss_zero = 0; ss_subs = SegTree.next ss.ss_subs s.num }
+
+  let fresh ss s =
+    let open Subscript in
+    if ss.ss_zero > 0 then
+      match List.nth_opt s.pre (ss.ss_zero - 1) with
+      | None -> ss, add ss s
+      | Some m ->
+        let subs, m = SegTree.fresh ss.ss_subs m in
+        let max = max_subscript ss in
+        if max <= subs then
+          let subs, num = SegTree.fresh max s.num in
+          { ss_zero = 0; ss_subs = subs }, { s with num }
+        else
+          let s = { s with pre = List.assign s.pre (ss.ss_zero - 1) m } in
+          { ss_zero = ss.ss_zero; ss_subs = subs }, s
+    else if Int.equal ss.ss_subs 0 then
+      if not @@ SegTree.mem 0 s.num then
+        Subscript.zero, { num = SegTree.add 0 s.num; pre = s.pre }
+      else match s.pre with
+      | [] -> ss_O, { num = s.num; pre = [SegTree.add 0 SegTree.empty] }
+      | m :: rem ->
+        if SegTree.mem 0 m then
+          let subs, num = SegTree.fresh 1 s.num in
+          { ss_zero = 0; ss_subs = subs }, { num; pre = s.pre }
+        else ss_O, { num = s.num; pre = SegTree.add 0 SegTree.empty :: rem }
+    else
+      let subs, num = SegTree.fresh ss.ss_subs s.num in
+      { ss_zero = 0; ss_subs = subs }, { s with num }
+
+end
+
+module Fresh =
+struct
+
+type t = SubSet.t Id.Map.t
+
+let empty = Id.Map.empty
+
+let add id m =
+  let (id, s) = get_subscript id in
+  let old = try Id.Map.find id m with Not_found -> SubSet.empty in
+  Id.Map.add id (SubSet.add s old) m
+
+let remove id m =
+  let (id, s) = get_subscript id in
+  match Id.Map.find id m with
+  | old -> Id.Map.add id (SubSet.remove s old) m
+  | exception Not_found -> m
+
+let mem id m =
+  let (id, s) = get_subscript id in
+  try SubSet.mem s (Id.Map.find id m)
+  with Not_found -> false
+
+let next id0 m =
+  let (id, s) = get_subscript id0 in
+  match Id.Map.find_opt id m with
+  | None -> id0
+  | Some old ->
+    let ss = SubSet.next s old in
+    add_subscript id ss
+
+let fresh id0 m =
+  let (id, s) = get_subscript id0 in
+  match Id.Map.find_opt id m with
+  | None ->
+    id0, Id.Map.add id (SubSet.add s SubSet.empty) m
+  | Some old ->
+    let ss, n = SubSet.fresh s old in
+    add_subscript id ss, Id.Map.add id n m
+
+let of_list l =
+  List.fold_left (fun accu id -> add id accu) empty l
+
+let of_set s =
+  Id.Set.fold add s empty
+
+let of_named_context_val s =
+  of_set @@ Environ.ids_of_named_context_val s
+
+end
+
 (* Names *)
 
 module type ExtName =

--- a/engine/nameops.mli
+++ b/engine/nameops.mli
@@ -52,6 +52,22 @@ sig
 
 end
 
+module Fresh :
+sig
+  type t
+  val empty : t
+  val add : Id.t -> t -> t
+  val remove : Id.t -> t -> t
+  val mem : Id.t -> t -> bool
+  val next : Id.t -> t -> Id.t
+  val fresh : Id.t -> t -> Id.t * t
+
+  val of_list : Id.t list -> t
+  val of_set : Id.Set.t -> t
+  val of_named_context_val : Environ.named_context_val -> t
+end
+
+
 val has_subscript       : Id.t -> bool
 
 val get_subscript : Id.t -> Id.t * Subscript.t


### PR DESCRIPTION
This is the subset of #18502 that doesn't touch the kernel and only adds the name set locally to the evarmap.

Fixes #8231: creation of evars with empty contexts is quadratic. Arguably the solution to this bug was rather to not generate fresh names in the `evar` tactic but this was never done and this PR solves the algorithmic issue without having to debate about the expected semantics of `evar`, so we can postpone the decision indefinitely.