### PR TITLE
Take into account the local delta flags for "simpl"

### DIFF
--- a/dev/top_printers.dbg
+++ b/dev/top_printers.dbg
@@ -54,6 +54,7 @@ install_printer Top_printers.ppdelta
 install_printer Top_printers.pp_idpred
 install_printer Top_printers.pp_cpred
 install_printer Top_printers.pp_transparent_state
+install_printer Top_printers.pp_redflags
 install_printer Top_printers.pp_estack_t
 install_printer Top_printers.pp_state_t
 install_printer Top_printers.ppmetas

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -215,7 +215,8 @@ let ppdelta s = pp (Mod_subst.debug_pr_delta s)
 
 let pp_idpred s = pp (pr_idpred s)
 let pp_cpred s = pp (pr_cpred s)
-let pp_transparent_state s = pp (pr_transparent_state s)
+let pp_transparent_state s = pp (TransparentState.debug_pr_transparent_state s)
+let pp_redflags s = pp (RedFlags.debug_pr s)
 let pp_estack_t n = pp (Reductionops.Stack.pr pr_econstr n)
 let pp_state_t n = pp (Reductionops.pr_state Global.(env()) Evd.empty n)
 

--- a/dev/top_printers.mli
+++ b/dev/top_printers.mli
@@ -120,6 +120,7 @@ val ppdelta : Mod_subst.delta_resolver -> unit
 val pp_idpred : Names.Id.Pred.t -> unit
 val pp_cpred : Names.Cpred.t -> unit
 val pp_transparent_state : TransparentState.t -> unit
+val pp_redflags : RedFlags.reds -> unit
 
 val pp_estack_t : Reductionops.Stack.t -> unit
 val pp_state_t : Reductionops.state -> unit

--- a/kernel/redFlags.ml
+++ b/kernel/redFlags.ml
@@ -126,3 +126,19 @@ let betazeta = mkflags [fBETA;fZETA]
 let delta = mkfullflags [fDELTA]
 let zeta = mkflags [fZETA]
 let nored = no_red
+
+(* Debugging *)
+
+open Pp
+
+let debug_pr f =
+  let flags =
+    (if f.r_beta then ["beta"] else []) @
+    (if f.r_delta then ["delta"] else []) @
+    (if f.r_zeta then ["zeta"] else []) @
+    (if f.r_match then ["match"] else []) @
+    (if f.r_fix then ["fix"] else []) @
+    (if f.r_cofix then ["cofix"] else [])
+  in
+  str "[" ++ prlist_with_sep (fun () -> str ",") str flags ++ str "," ++ spc ()
+          ++ str "transparency=[" ++ debug_pr_transparent_state f.r_const ++ str "]]"

--- a/kernel/redFlags.ml
+++ b/kernel/redFlags.ml
@@ -90,9 +90,7 @@ let red_add_list = List.fold_left red_add
 
 let red_transparent red = red.r_const
 
-let red_add_transparent red tr =
-  { red with r_const = tr }
-
+let red_add_transparent red tr = { red with r_const = tr }
 let mkflags = List.fold_left red_add no_red
 
 let mkfullflags = List.fold_left red_add { no_red with r_const = TransparentState.full }

--- a/kernel/redFlags.mli
+++ b/kernel/redFlags.mli
@@ -71,3 +71,7 @@ val betazeta : reds
 val delta : reds
 val zeta : reds
 val nored : reds
+
+(* Debugging *)
+
+val debug_pr : reds -> Pp.t

--- a/kernel/transparentState.ml
+++ b/kernel/transparentState.ml
@@ -41,3 +41,23 @@ let is_transparent_constant ts cst =
 
 let is_transparent_projection ts p =
   PRpred.mem p ts.tr_prj
+
+(* Debugging *)
+
+open Util
+open Pp
+
+let pr_predicate pr_elt (b, elts) =
+  let pr_elts = prlist_with_sep spc pr_elt elts in
+    if b then
+      str"all" ++
+        (if List.is_empty elts then mt () else str" except: " ++ pr_elts)
+    else
+      if List.is_empty elts then str"none" else pr_elts
+
+let pr_cpred p = pr_predicate Names.Constant.print (Cpred.elements p)
+let pr_idpred p = pr_predicate Id.print (Id.Pred.elements p)
+
+let debug_pr_transparent_state ts =
+  hv 0 (str"VARIABLES: " ++ pr_idpred ts.tr_var ++ spc () ++
+        str"CONSTANTS: " ++ pr_cpred ts.tr_cst)

--- a/kernel/transparentState.mli
+++ b/kernel/transparentState.mli
@@ -28,3 +28,7 @@ val is_empty : t -> bool
 val is_transparent_variable : t -> Id.t -> bool
 val is_transparent_constant : t -> Constant.t -> bool
 val is_transparent_projection : t -> Projection.Repr.t -> bool
+
+(** Debugging *)
+
+val debug_pr_transparent_state : t -> Pp.t

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -181,6 +181,8 @@ module ReductionBehaviour = struct
     let empty = (Cpred.empty, Cmap.empty)
     let print = print_from_db
     let all_never_unfold table = fst table
+    let unset_never r table =
+      (Cpred.remove r (fst table), snd table)
   end
 
   let get r = get_from_db (Db.get ()) r

--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -39,6 +39,7 @@ module ReductionBehaviour : sig
     val empty : t
     val print : t -> Constant.t -> Pp.t
     val all_never_unfold : t -> Cpred.t
+    val unset_never : Constant.t -> t -> t
   end
 
   val set : local:bool -> Constant.t -> t option -> unit

--- a/pretyping/tacred.mli
+++ b/pretyping/tacred.mli
@@ -59,9 +59,11 @@ val red_product : env -> evar_map -> constr -> constr option
 
 (** Simpl *)
 val simpl : reduction_function
+val simpl_with_constants : bool * Evaluable.t list -> reduction_function
 
 (** Simpl only at the head *)
 val whd_simpl : reduction_function
+val whd_simpl_with_constants : bool * Evaluable.t list -> reduction_function
 
 (** Hnf: like whd_simpl but force delta-reduction of constants that do
    not immediately hide a non reducible fix or cofix *)

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -529,11 +529,6 @@ let pr_idpred p = pr_predicate Id.print (Id.Pred.elements p)
 
 let pr_prpred p = pr_predicate Projection.Repr.print (PRpred.elements p)
 
-let pr_transparent_state ts =
-  hv 0 (str"VARIABLES: " ++ pr_idpred ts.TransparentState.tr_var ++ fnl () ++
-        str"CONSTANTS: " ++ pr_cpred ts.TransparentState.tr_cst ++ fnl () ++
-        str"PROJECTIONS: " ++ pr_prpred ts.TransparentState.tr_prj ++ fnl ())
-
 let goal_repr sigma g =
   let EvarInfo evi = Evd.find sigma g in
   let env = Evd.evar_filtered_env (Global.env ()) evi in

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -191,7 +191,6 @@ val pr_predicate           : ('a -> Pp.t) -> (bool * 'a list) -> Pp.t
 val pr_cpred               : Cpred.t -> Pp.t
 val pr_idpred              : Id.Pred.t -> Pp.t
 val pr_prpred              : PRpred.t -> Pp.t
-val pr_transparent_state   : TransparentState.t -> Pp.t
 
 (** Proofs, these functions obey [Hyps Limit] and [Compact contexts]. *)
 

--- a/test-suite/output/ltac.out
+++ b/test-suite/output/ltac.out
@@ -63,3 +63,4 @@ Ltac foo :=
 
 goal 2 is:
  forall a : nat, a = 0
+Ltac simpl_head := simpl head

--- a/test-suite/output/ltac.v
+++ b/test-suite/output/ltac.v
@@ -83,3 +83,6 @@ end.
 intro.
 Show.
 Abort.
+
+Ltac simpl_head := simpl head.
+Print Ltac simpl_head.

--- a/test-suite/success/simpl.v
+++ b/test-suite/success/simpl.v
@@ -321,3 +321,24 @@ match goal with [ |- n + (n + 1) * n = 0 ] => idtac end.
 Abort.
 
 End RefoldingOfNeverConstantInArgOfDestructor.
+
+Module SimplWithLocalConstants.
+
+Goal 0 + 0 = 0.
+simpl -[Nat.add].
+match goal with [ |- 0 + 0 = 0 ] => idtac end.
+Abort.
+
+Arguments Nat.add : simpl never.
+Goal 0 + 0 = 0.
+simpl [Nat.add].
+match goal with [ |- 0 = 0 ] => idtac end.
+Abort.
+
+Opaque Nat.add.
+Goal 0 + 0 = 0.
+simpl [Nat.add].
+match goal with [ |- 0 = 0 ] => idtac end.
+Abort.
+
+End SimplWithLocalConstants.


### PR DESCRIPTION
The reduction strategy `simpl` accepted the syntax `simpl [constants]` and `simpl -[constants]` but no implementation was associated to it. The PR provides the support.

The semantics is to start the list of constants to unfold/block first with the transparency state, then to consider the simpl-never constants (when in head position), then to consider the local constants. The latters have thus stronger priority.

- [x] Added / updated **test-suite**.
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.

Depends on #18576 (merged), #18577 (merged), #18579 (merged), #18580 (merged), #18591 (merged).