### PR TITLE
coq_rules: generate correct plugin dependency when ocamlopt not available

### DIFF
--- a/config/coq_config.mli
+++ b/config/coq_config.mli
@@ -39,6 +39,9 @@ val caml_version : string    (* OCaml version used to compile Coq *)
 val caml_version_nums : int list    (* OCaml version used to compile Coq by components *)
 val vo_version : int32
 
+val best_compiler : string
+(** "opt" if ocamlopt is available, otherwise "byte" *)
+
 (* used in envars for coq_makefile *)
 val all_src_dirs : string list
 

--- a/tools/configure/configure.ml
+++ b/tools/configure/configure.ml
@@ -384,7 +384,7 @@ let print_summary prefs arch camlenv install_dirs browser =
 
 (** * Build the config/coq_config.ml file *)
 
-let write_configml install_prefix camlenv coqenv caml_flags caml_version_nums arch arch_is_win32 hasnatdynlink browser prefs o =
+let write_configml ~install_prefix ~camlenv ~coqenv ~caml_flags ~caml_version_nums ~arch ~arch_is_win32 ~hasnatdynlink ~browser ~best_compiler ~prefs o =
   let { CoqEnv.coqlib; coqlibsuffix; configdir; configdirsuffix; docdir; docdirsuffix; datadir; datadirsuffix } = coqenv in
   let { CamlConf.caml_version; _ } = camlenv in
   let pr s = fprintf o s in
@@ -411,6 +411,7 @@ let write_configml install_prefix camlenv coqenv caml_flags caml_version_nums ar
   pr_s "version" coq_version;
   pr_s "caml_version" caml_version;
   pr_li "caml_version_nums" caml_version_nums;
+  pr_s "best_compiler" best_compiler;
   pr_s "arch" arch;
   pr_b "arch_is_win32" arch_is_win32;
   pr_s "exec_extension" !exe;
@@ -495,7 +496,7 @@ let main () =
   if prefs.interactive then
     print_summary prefs arch camlenv install_dirs browser;
   write_config_file ~file:"config/coq_config.ml"
-    (write_configml install_prefix camlenv coqenv caml_flags caml_version_nums arch arch_is_win32 hasnatdynlink browser prefs);
+    (write_configml ~install_prefix ~camlenv ~coqenv ~caml_flags ~caml_version_nums ~arch ~arch_is_win32 ~hasnatdynlink ~browser ~best_compiler ~prefs);
   write_config_file ~file:"config/dune.c_flags" (write_dune_c_flags cflags);
   write_config_file ~file:"config/coq_config.py" write_configpy;
   ()

--- a/tools/coqdep/lib/common.ml
+++ b/tools/coqdep/lib/common.ml
@@ -208,10 +208,10 @@ let rec find_dependencies st basename =
                   | Some _ -> Some(Filename.dirname str)
                 in
                 match Loadpath.search_mllib_known st s with
-                | Some mldir -> declare ".cma" (pick_mldir mldir) s
+                | Some mldir -> declare Lib (pick_mldir mldir) s
                 | None ->
                   match Loadpath.search_mlpack_known st s with
-                  | Some mldir -> declare ".cmo" (pick_mldir mldir) s
+                  | Some mldir -> declare Pack (pick_mldir mldir) s
                   | None -> warning_declare (f,str)
               end
           in

--- a/tools/coqdep/lib/dep_info.ml
+++ b/tools/coqdep/lib/dep_info.ml
@@ -9,9 +9,15 @@
 (************************************************************************)
 
 module Dep = struct
+  type ml_kind = Pack | Lib
+
+  let byte_suff = function
+    | Pack -> ".cmo"
+    | Lib -> ".cma"
+
   type t =
   | Require of string (* one basename, to which we later append .vo or .vio or .vos *)
-  | Ml of string * string
+  | Ml of string * ml_kind
   | Other of string (* filenames of dependencies, separated by spaces *)
 end
 

--- a/tools/coqdep/lib/dep_info.mli
+++ b/tools/coqdep/lib/dep_info.mli
@@ -9,11 +9,17 @@
 (************************************************************************)
 
 module Dep : sig
+  type ml_kind = Pack | Lib
+  (** Whether a plugin is using -pack (matters for the bytecode file extension).
+      Note that dune (wrapped) is not using -pack. *)
+
+  val byte_suff : ml_kind -> string
+
   type t =
   | Require of string
   (** module basename, to which we later append .vo or .vio or .vos *)
-  | Ml of string * string
-  (** plugin basename and byte extension, resolved from Declare Ml Module *)
+  | Ml of string * ml_kind
+  (** plugin basename and whether it's using -pack, resolved from Declare Ml Module *)
   | Other of string
   (** load, meta, and external dependencies *)
 end

--- a/tools/coqdep/lib/makefile.ml
+++ b/tools/coqdep/lib/makefile.ml
@@ -65,7 +65,7 @@ let mldep_to_make (base, suff) =
 let string_of_dep ~suffix = let open Dep_info.Dep in
   function
   | Require basename -> [escape basename ^ suffix]
-  | Ml (base,suff) -> mldep_to_make (escape base,suff)
+  | Ml (base,suff) -> mldep_to_make (escape base,byte_suff suff)
   | Other s -> [escape s]
 
 let string_of_dependency_list ~suffix deps =

--- a/tools/dune_rule_gen/coq_rules.ml
+++ b/tools/dune_rule_gen/coq_rules.ml
@@ -79,7 +79,7 @@ let path_of_dep ~vo_ext dep =
   let open Coqdeplib.Dep_info in
   let file = match dep with
     | Dep.Require dep -> dep ^ vo_ext
-    | Dep.Ml (dep, _ext)-> dep ^ ".cmxs"
+    | Dep.Ml (dep, _kind)-> dep ^ ".cmxs"
     | Dep.Other dep -> dep
   in
   Path.make file

--- a/tools/dune_rule_gen/coq_rules.ml
+++ b/tools/dune_rule_gen/coq_rules.ml
@@ -79,7 +79,13 @@ let path_of_dep ~vo_ext dep =
   let open Coqdeplib.Dep_info in
   let file = match dep with
     | Dep.Require dep -> dep ^ vo_ext
-    | Dep.Ml (dep, _kind)-> dep ^ ".cmxs"
+    | Dep.Ml (dep, kind)->
+      assert (kind == Lib);
+      let suff =
+        if Coq_config.best_compiler = "opt" then ".cmxs"
+        else ".cma"
+      in
+      dep ^ suff
     | Dep.Other dep -> dep
   in
   Path.make file


### PR DESCRIPTION

Fix #18609


