### PR TITLE
Ltac2: split value APIs from Tac2ffi to new Tac2val

### DIFF
--- a/dev/ci/user-overlays/18624-SkySkimmer-split-tac2ffi.sh
+++ b/dev/ci/user-overlays/18624-SkySkimmer-split-tac2ffi.sh
@@ -1,0 +1,5 @@
+overlay ltac2_compiler https://github.com/SkySkimmer/coq-ltac2-compiler split-tac2ffi 18624
+
+overlay rewriter https://github.com/SkySkimmer/rewriter split-tac2ffi 18624
+
+overlay waterproof https://github.com/SkySkimmer/coq-waterproof split-tac2ffi 18624

--- a/plugins/ltac2/tac2core.mli
+++ b/plugins/ltac2/tac2core.mli
@@ -17,7 +17,7 @@ module Core :
 sig
 
 val t_unit : type_constant
-val v_unit : Tac2ffi.valexpr
+val v_unit : Tac2val.valexpr
 
 val t_list : type_constant
 val c_nil : ltac_constructor
@@ -42,7 +42,7 @@ module type MapType = sig
   module S : CSig.SetS
   module M : CMap.ExtS with type key = S.elt and module Set := S
   type valmap
-  val valmap_eq : (valmap, Tac2ffi.valexpr M.t) Util.eq
+  val valmap_eq : (valmap, Tac2val.valexpr M.t) Util.eq
   val repr : S.elt Tac2ffi.repr
 end
 
@@ -64,9 +64,9 @@ val register_map : ?plugin:string -> tag_name:string
 
 (** Default registered maps *)
 
-val ident_map_tag : (Id.t, Id.Set.t, Tac2ffi.valexpr Id.Map.t) map_tag
-val int_map_tag : (int, Int.Set.t, Tac2ffi.valexpr Int.Map.t) map_tag
-val string_map_tag : (string, CString.Set.t, Tac2ffi.valexpr CString.Map.t) map_tag
-val inductive_map_tag : (inductive, Indset_env.t, Tac2ffi.valexpr Indmap_env.t) map_tag
-val constructor_map_tag : (constructor, Constrset_env.t, Tac2ffi.valexpr Constrmap_env.t) map_tag
-val constant_map_tag : (Constant.t, Cset_env.t, Tac2ffi.valexpr Cmap_env.t) map_tag
+val ident_map_tag : (Id.t, Id.Set.t, Tac2val.valexpr Id.Map.t) map_tag
+val int_map_tag : (int, Int.Set.t, Tac2val.valexpr Int.Map.t) map_tag
+val string_map_tag : (string, CString.Set.t, Tac2val.valexpr CString.Map.t) map_tag
+val inductive_map_tag : (inductive, Indset_env.t, Tac2val.valexpr Indmap_env.t) map_tag
+val constructor_map_tag : (constructor, Constrset_env.t, Tac2val.valexpr Constrmap_env.t) map_tag
+val constant_map_tag : (Constant.t, Cset_env.t, Tac2val.valexpr Cmap_env.t) map_tag

--- a/plugins/ltac2/tac2env.ml
+++ b/plugins/ltac2/tac2env.ml
@@ -12,7 +12,7 @@ open Util
 open Names
 open Libnames
 open Tac2expr
-open Tac2ffi
+open Tac2val
 
 type global_data = {
   gdata_expr : glb_tacexpr;

--- a/plugins/ltac2/tac2env.mli
+++ b/plugins/ltac2/tac2env.mli
@@ -13,7 +13,7 @@ open Names
 open Libnames
 open Nametab
 open Tac2expr
-open Tac2ffi
+open Tac2val
 
 (** Ltac2 global environment *)
 

--- a/plugins/ltac2/tac2externals.ml
+++ b/plugins/ltac2/tac2externals.ml
@@ -12,7 +12,7 @@ open Proofview
 open Tac2ffi
 
 (* Local shortcuts. *)
-type v = Tac2ffi.valexpr
+type v = Tac2val.valexpr
 type 'r of_v = v -> 'r
 type 'r to_v = 'r -> v
 type 'a with_env = Environ.env -> Evd.evar_map -> 'a
@@ -68,13 +68,13 @@ let rec interp_spec : type v f. (v,f) spec -> f -> v = fun (S ar) f ->
   | G tr -> Goal.enter_one @@ fun g -> tclUNIT (tr (f g))
   | F (tr,ar) -> fun v -> interp_spec (S ar) (f (tr v))
 
-let rec arity_of : type v f. (v,f) spec -> v Tac2ffi.arity = fun (S ar) ->
+let rec arity_of : type v f. (v,f) spec -> v Tac2val.arity = fun (S ar) ->
   match ar with
-  | F (_, T _) -> Tac2ffi.arity_one
-  | F (_, V _) -> Tac2ffi.arity_one
-  | F (_, E _) -> Tac2ffi.arity_one
-  | F (_, G _) -> Tac2ffi.arity_one
-  | F (_, ar) -> Tac2ffi.arity_suc (arity_of (S ar))
+  | F (_, T _) -> Tac2val.arity_one
+  | F (_, V _) -> Tac2val.arity_one
+  | F (_, E _) -> Tac2val.arity_one
+  | F (_, G _) -> Tac2val.arity_one
+  | F (_, ar) -> Tac2val.arity_suc (arity_of (S ar))
   | _ -> invalid_arg "Tac2def.arity_of: not a function spec"
 
 let define : type v f. _ -> (v,f) spec -> f -> unit = fun n ar v ->
@@ -82,7 +82,7 @@ let define : type v f. _ -> (v,f) spec -> f -> unit = fun n ar v ->
     match ar with
     | S (V tr) -> tr v
     | S (F _) ->
-        let cl = Tac2ffi.mk_closure (arity_of ar) (interp_spec ar v) in
+        let cl = Tac2val.mk_closure (arity_of ar) (interp_spec ar v) in
         Tac2ffi.of_closure cl
     | _ -> invalid_arg "Tac2def.define: not a pure value"
   in

--- a/plugins/ltac2/tac2externals.mli
+++ b/plugins/ltac2/tac2externals.mli
@@ -10,6 +10,7 @@
 
 open Proofview
 open Tac2ffi
+open Tac2val
 
 (** Interface for defining external tactics via a high-level spec. *)
 

--- a/plugins/ltac2/tac2extffi.ml
+++ b/plugins/ltac2/tac2extffi.ml
@@ -8,6 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+open Tac2val
 open Tac2ffi
 open Tac2types
 

--- a/plugins/ltac2/tac2ffi.ml
+++ b/plugins/ltac2/tac2ffi.ml
@@ -9,69 +9,8 @@
 (************************************************************************)
 
 open Util
-open Names
 open Tac2dyn
-open Proofview.Notations
-
-type ('a, _) arity0 =
-| OneAty : ('a, 'a -> 'a Proofview.tactic) arity0
-| AddAty : ('a, 'b) arity0 -> ('a, 'a -> 'b) arity0
-
-type tag = int
-
-type valexpr =
-| ValInt of int
-  (** Immediate integers *)
-| ValBlk of tag * valexpr array
-  (** Structured blocks *)
-| ValStr of Bytes.t
-  (** Strings *)
-| ValCls of closure
-  (** Closures *)
-| ValOpn of KerName.t * valexpr array
-  (** Open constructors *)
-| ValExt : 'a Tac2dyn.Val.tag * 'a -> valexpr
-  (** Arbitrary data *)
-
-and closure = MLTactic : (valexpr, 'v) arity0 * Tac2expr.frame option * 'v -> closure
-
-let arity_one = OneAty
-let arity_suc a = AddAty a
-
-type 'a arity = (valexpr, 'a) arity0
-
-let mk_closure arity f = MLTactic (arity, None, f)
-
-let mk_closure_val arity f = ValCls (mk_closure arity f)
-
-module Valexpr =
-struct
-
-type t = valexpr
-
-let is_int = function
-| ValInt _ -> true
-| ValBlk _ | ValStr _ | ValCls _ | ValOpn _ | ValExt _ -> false
-
-let tag v = match v with
-| ValBlk (n, _) -> n
-| ValInt _ | ValStr _ | ValCls _ | ValOpn _ | ValExt _ ->
-  CErrors.anomaly (Pp.str "Unexpected value shape")
-
-let field v n = match v with
-| ValBlk (_, v) -> v.(n)
-| ValInt _ | ValStr _ | ValCls _ | ValOpn _ | ValExt _ ->
-  CErrors.anomaly (Pp.str "Unexpected value shape")
-
-let set_field v n w = match v with
-| ValBlk (_, v) -> v.(n) <- w
-| ValInt _ | ValStr _ | ValCls _ | ValOpn _ | ValExt _ ->
-  CErrors.anomaly (Pp.str "Unexpected value shape")
-
-let make_block tag v = ValBlk (tag, v)
-let make_int n = ValInt n
-
-end
+open Tac2val
 
 type 'a repr = {
   r_of : 'a -> valexpr;
@@ -126,7 +65,7 @@ match Val.eq tag tag' with
 
 (** Exception *)
 
-exception LtacError of KerName.t * valexpr array
+exception LtacError of Names.KerName.t * valexpr array
 
 (** Conversion functions *)
 
@@ -211,9 +150,7 @@ let list r = {
 
 let of_closure cls = ValCls cls
 
-let to_closure = function
-| ValCls cls -> cls
-| ValExt _ | ValInt _ | ValBlk _ | ValStr _ | ValOpn _ -> assert false
+let to_closure = Tac2val.to_closure
 
 let closure = {
   r_of = of_closure;
@@ -384,13 +321,13 @@ let of_constant c = of_ext val_constant c
 let to_constant c = to_ext val_constant c
 let constant = repr_ext val_constant
 
-let of_reference = let open GlobRef in function
+let of_reference = let open Names.GlobRef in function
 | VarRef id -> ValBlk (0, [| of_ident id |])
 | ConstRef cst -> ValBlk (1, [| of_constant cst |])
 | IndRef ind -> ValBlk (2, [| of_ext val_inductive ind |])
 | ConstructRef cstr -> ValBlk (3, [| of_ext val_constructor cstr |])
 
-let to_reference = let open GlobRef in function
+let to_reference = let open Names.GlobRef in function
 | ValBlk (0, [| id |]) -> VarRef (to_ident id)
 | ValBlk (1, [| cst |]) -> ConstRef (to_constant cst)
 | ValBlk (2, [| ind |]) -> IndRef (to_ext val_inductive ind)
@@ -407,53 +344,6 @@ type ('a, 'b) fun1 = closure
 let fun1 (r0 : 'a repr) (r1 : 'b repr) : ('a, 'b) fun1 repr = closure
 let to_fun1 r0 r1 f = to_closure f
 
-let wrap fr tac = match fr with
-  | None -> tac
-  | Some fr -> Tac2bt.with_frame fr tac
-
-let rec apply : type a. a arity -> _ -> a -> valexpr list -> valexpr Proofview.tactic =
-  fun arity fr f args -> match args, arity with
-  | [], arity -> Proofview.tclUNIT (ValCls (MLTactic (arity, fr, f)))
-  (* A few hardcoded cases for efficiency *)
-  | [a0], OneAty -> wrap fr (f a0)
-  | [a0; a1], AddAty OneAty -> wrap fr (f a0 a1)
-  | [a0; a1; a2], AddAty (AddAty OneAty) -> wrap fr (f a0 a1 a2)
-  | [a0; a1; a2; a3], AddAty (AddAty (AddAty OneAty)) -> wrap fr (f a0 a1 a2 a3)
-  (* Generic cases *)
-  | a :: args, OneAty ->
-    wrap fr (f a) >>= fun f ->
-    let MLTactic (arity, fr, f) = to_closure f in
-    apply arity fr f args
-  | a :: args, AddAty arity ->
-    apply arity fr (f a) args
-
-let apply (MLTactic (arity, wrap, f)) args = apply arity wrap f args
-
-let apply_val v args = apply (to_closure v) args
-
-type n_closure =
-| NClosure : 'a arity * (valexpr list -> 'a) -> n_closure
-
-let rec abstract n f =
-  if Int.equal n 1 then NClosure (OneAty, fun accu v -> f (List.rev (v :: accu)))
-  else
-    let NClosure (arity, fe) = abstract (n - 1) f in
-    NClosure (AddAty arity, fun accu v -> fe (v :: accu))
-
-let abstract n f =
-  match n with
-  | 1 -> MLTactic (OneAty, None, fun a -> f [a])
-  | 2 -> MLTactic (AddAty OneAty, None, fun a b -> f [a;b])
-  | 3 -> MLTactic (AddAty (AddAty OneAty), None, fun a b c -> f [a;b;c])
-  | 4 -> MLTactic (AddAty (AddAty (AddAty OneAty)), None, fun a b c d -> f [a;b;c;d])
-  | _ ->
-    let () = assert (n > 0) in
-    let NClosure (arity, f) = abstract n f in
-    MLTactic (arity, None, f [])
-
 let app_fun1 cls r0 r1 x =
+  let open Proofview.Notations in
   apply cls [r0.r_of x] >>= fun v -> Proofview.tclUNIT (r1.r_to v)
-
-let annotate_closure fr (MLTactic (arity, fr0, f)) =
-  assert (Option.is_empty fr0);
-  MLTactic (arity, Some fr, f)

--- a/plugins/ltac2/tac2ffi.mli
+++ b/plugins/ltac2/tac2ffi.mli
@@ -11,57 +11,7 @@
 open Names
 open EConstr
 open Tac2dyn
-
-(** {5 Toplevel values} *)
-
-(** {5 Dynamic semantics} *)
-
-(** Values are represented in a way similar to OCaml, i.e. they contrast
-    immediate integers (integers, constructors without arguments) and structured
-    blocks (tuples, arrays, constructors with arguments), as well as a few other
-    base cases, namely closures, strings, named constructors, and dynamic type
-    coming from the Coq implementation. *)
-
-type tag = int
-
-type closure
-
-type valexpr =
-| ValInt of int
-  (** Immediate integers *)
-| ValBlk of tag * valexpr array
-  (** Structured blocks *)
-| ValStr of Bytes.t
-  (** Strings *)
-| ValCls of closure
-  (** Closures *)
-| ValOpn of KerName.t * valexpr array
-  (** Open constructors *)
-| ValExt : 'a Tac2dyn.Val.tag * 'a -> valexpr
-  (** Arbitrary data *)
-
-type 'a arity
-
-val arity_one : (valexpr -> valexpr Proofview.tactic) arity
-val arity_suc : 'a arity -> (valexpr -> 'a) arity
-
-val mk_closure : 'v arity -> 'v -> closure
-val mk_closure_val : 'v arity -> 'v -> valexpr
-(** Composition of [mk_closure] and [ValCls] *)
-
-val annotate_closure : Tac2expr.frame -> closure -> closure
-(** The closure must not be already annotated *)
-
-module Valexpr :
-sig
-  type t = valexpr
-  val is_int : t -> bool
-  val tag : t -> int
-  val field : t -> int -> t
-  val set_field : t -> int -> t -> unit
-  val make_block : int -> t array -> t
-  val make_int : int -> t
-end
+open Tac2val
 
 (** {5 Ltac2 FFI} *)
 
@@ -241,19 +191,6 @@ val val_exninfo : Exninfo.info Tac2dyn.Val.tag
 val val_exn : Exninfo.iexn Tac2dyn.Val.tag
 (** Toplevel representation of OCaml exceptions. Invariant: no [LtacError]
     should be put into a value with tag [val_exn]. *)
-
-(** Closures *)
-
-val apply : closure -> valexpr list -> valexpr Proofview.tactic
-(** Given a closure, apply it to some arguments. Handling of argument mismatches
-    is done automatically, i.e. in case of over or under-application. *)
-
-val apply_val : valexpr -> valexpr list -> valexpr Proofview.tactic
-(** Composition of [to_closure] and [apply] *)
-
-val abstract : int -> (valexpr list -> valexpr Proofview.tactic) -> closure
-(** Turn a fixed-arity function into a closure. The inner function is guaranteed
-    to be applied to a list whose size is the integer argument. *)
 
 (** Exception *)
 

--- a/plugins/ltac2/tac2interp.ml
+++ b/plugins/ltac2/tac2interp.ml
@@ -14,7 +14,7 @@ open CErrors
 open Names
 open Proofview.Notations
 open Tac2expr
-open Tac2ffi
+open Tac2val
 open Tac2bt
 
 exception LtacError = Tac2ffi.LtacError
@@ -121,7 +121,7 @@ let rec interp (ist : environment) = function
 | GTacApp (f, args) ->
   interp ist f >>= fun f ->
   Proofview.Monad.List.map (fun e -> interp ist e) args >>= fun args ->
-  Tac2ffi.apply (Tac2ffi.to_closure f) args
+  Tac2val.apply_val f args
 | GTacLet (false, el, e) ->
   let fold accu (na, e) =
     interp ist e >>= fun e ->

--- a/plugins/ltac2/tac2interp.mli
+++ b/plugins/ltac2/tac2interp.mli
@@ -10,7 +10,7 @@
 
 open Names
 open Tac2expr
-open Tac2ffi
+open Tac2val
 
 type environment = Tac2env.environment
 

--- a/plugins/ltac2/tac2print.ml
+++ b/plugins/ltac2/tac2print.ml
@@ -13,7 +13,6 @@ open Pp
 open Names
 open Tac2expr
 open Tac2env
-open Tac2ffi
 
 let pr_tacref avoid kn =
   try Libnames.pr_qualid (Tac2env.shortest_qualid_of_ltac avoid (TacConstant kn))
@@ -728,7 +727,7 @@ let rec kind t = match t with
 | GTypArrow _ | GTypRef (Tuple _, _) -> t
 
 type val_printer =
-  { val_printer : 'a. Environ.env -> Evd.evar_map -> valexpr -> 'a glb_typexpr list -> Pp.t }
+  { val_printer : 'a. Environ.env -> Evd.evar_map -> Tac2val.valexpr -> 'a glb_typexpr list -> Pp.t }
 
 let printers = ref KNmap.empty
 
@@ -755,7 +754,7 @@ let rec pr_valexpr_gen env sigma lvl v t = match kind t with
       (* Shouldn't happen thanks to kind *)
       assert false
     | GTydAlg alg ->
-      if Valexpr.is_int v then
+      if Tac2val.Valexpr.is_int v then
         pr_internal_constructor kn (Tac2ffi.to_int v) true
       else
         let paren = match lvl with

--- a/plugins/ltac2/tac2print.mli
+++ b/plugins/ltac2/tac2print.mli
@@ -9,7 +9,7 @@
 (************************************************************************)
 
 open Tac2expr
-open Tac2ffi
+open Tac2val
 open Names
 
 val pr_tacref : Id.Set.t -> ltac_constant -> Pp.t

--- a/plugins/ltac2/tac2stdlib.ml
+++ b/plugins/ltac2/tac2stdlib.ml
@@ -11,6 +11,7 @@
 open Names
 open Genredexpr
 open Tac2expr
+open Tac2val
 open Tac2ffi
 open Tac2types
 open Tac2extffi

--- a/plugins/ltac2/tac2val.ml
+++ b/plugins/ltac2/tac2val.ml
@@ -1,0 +1,125 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Util
+open Names
+open Proofview.Notations
+
+type ('a, _) arity0 =
+| OneAty : ('a, 'a -> 'a Proofview.tactic) arity0
+| AddAty : ('a, 'b) arity0 -> ('a, 'a -> 'b) arity0
+
+type tag = int
+
+type valexpr =
+| ValInt of int
+  (** Immediate integers *)
+| ValBlk of tag * valexpr array
+  (** Structured blocks *)
+| ValStr of Bytes.t
+  (** Strings *)
+| ValCls of closure
+  (** Closures *)
+| ValOpn of KerName.t * valexpr array
+  (** Open constructors *)
+| ValExt : 'a Tac2dyn.Val.tag * 'a -> valexpr
+  (** Arbitrary data *)
+
+and closure = MLTactic : (valexpr, 'v) arity0 * Tac2expr.frame option * 'v -> closure
+
+let arity_one = OneAty
+let arity_suc a = AddAty a
+
+type 'a arity = (valexpr, 'a) arity0
+
+let mk_closure arity f = MLTactic (arity, None, f)
+
+let mk_closure_val arity f = ValCls (mk_closure arity f)
+
+module Valexpr =
+struct
+
+type t = valexpr
+
+let is_int = function
+| ValInt _ -> true
+| ValBlk _ | ValStr _ | ValCls _ | ValOpn _ | ValExt _ -> false
+
+let tag v = match v with
+| ValBlk (n, _) -> n
+| ValInt _ | ValStr _ | ValCls _ | ValOpn _ | ValExt _ ->
+  CErrors.anomaly (Pp.str "Unexpected value shape")
+
+let field v n = match v with
+| ValBlk (_, v) -> v.(n)
+| ValInt _ | ValStr _ | ValCls _ | ValOpn _ | ValExt _ ->
+  CErrors.anomaly (Pp.str "Unexpected value shape")
+
+let set_field v n w = match v with
+| ValBlk (_, v) -> v.(n) <- w
+| ValInt _ | ValStr _ | ValCls _ | ValOpn _ | ValExt _ ->
+  CErrors.anomaly (Pp.str "Unexpected value shape")
+
+let make_block tag v = ValBlk (tag, v)
+let make_int n = ValInt n
+
+end
+
+let to_closure = function
+| ValCls cls -> cls
+| ValExt _ | ValInt _ | ValBlk _ | ValStr _ | ValOpn _ -> assert false
+
+let wrap fr tac = match fr with
+  | None -> tac
+  | Some fr -> Tac2bt.with_frame fr tac
+
+let rec apply : type a. a arity -> _ -> a -> valexpr list -> valexpr Proofview.tactic =
+  fun arity fr f args -> match args, arity with
+  | [], arity -> Proofview.tclUNIT (ValCls (MLTactic (arity, fr, f)))
+  (* A few hardcoded cases for efficiency *)
+  | [a0], OneAty -> wrap fr (f a0)
+  | [a0; a1], AddAty OneAty -> wrap fr (f a0 a1)
+  | [a0; a1; a2], AddAty (AddAty OneAty) -> wrap fr (f a0 a1 a2)
+  | [a0; a1; a2; a3], AddAty (AddAty (AddAty OneAty)) -> wrap fr (f a0 a1 a2 a3)
+  (* Generic cases *)
+  | a :: args, OneAty ->
+    wrap fr (f a) >>= fun f ->
+    let MLTactic (arity, fr, f) = to_closure f in
+    apply arity fr f args
+  | a :: args, AddAty arity ->
+    apply arity fr (f a) args
+
+let apply (MLTactic (arity, wrap, f)) args = apply arity wrap f args
+
+let apply_val v args = apply (to_closure v) args
+
+type n_closure =
+| NClosure : 'a arity * (valexpr list -> 'a) -> n_closure
+
+let rec abstract n f =
+  if Int.equal n 1 then NClosure (OneAty, fun accu v -> f (List.rev (v :: accu)))
+  else
+    let NClosure (arity, fe) = abstract (n - 1) f in
+    NClosure (AddAty arity, fun accu v -> fe (v :: accu))
+
+let abstract n f =
+  match n with
+  | 1 -> MLTactic (OneAty, None, fun a -> f [a])
+  | 2 -> MLTactic (AddAty OneAty, None, fun a b -> f [a;b])
+  | 3 -> MLTactic (AddAty (AddAty OneAty), None, fun a b c -> f [a;b;c])
+  | 4 -> MLTactic (AddAty (AddAty (AddAty OneAty)), None, fun a b c d -> f [a;b;c;d])
+  | _ ->
+    let () = assert (n > 0) in
+    let NClosure (arity, f) = abstract n f in
+    MLTactic (arity, None, f [])
+
+let annotate_closure fr (MLTactic (arity, fr0, f)) =
+  assert (Option.is_empty fr0);
+  MLTactic (arity, Some fr, f)

--- a/plugins/ltac2/tac2val.mli
+++ b/plugins/ltac2/tac2val.mli
@@ -1,0 +1,77 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Names
+
+(** {5 Toplevel values} *)
+
+(** {5 Dynamic semantics} *)
+
+(** Values are represented in a way similar to OCaml, i.e. they contrast
+    immediate integers (integers, constructors without arguments) and structured
+    blocks (tuples, arrays, constructors with arguments), as well as a few other
+    base cases, namely closures, strings, named constructors, and dynamic type
+    coming from the Coq implementation. *)
+
+type tag = int
+
+type closure
+
+type valexpr =
+| ValInt of int
+  (** Immediate integers *)
+| ValBlk of tag * valexpr array
+  (** Structured blocks *)
+| ValStr of Bytes.t
+  (** Strings *)
+| ValCls of closure
+  (** Closures *)
+| ValOpn of KerName.t * valexpr array
+  (** Open constructors *)
+| ValExt : 'a Tac2dyn.Val.tag * 'a -> valexpr
+  (** Arbitrary data *)
+
+module Valexpr :
+sig
+  type t = valexpr
+  val is_int : t -> bool
+  val tag : t -> int
+  val field : t -> int -> t
+  val set_field : t -> int -> t -> unit
+  val make_block : int -> t array -> t
+  val make_int : int -> t
+end
+
+(** Closures *)
+
+type 'a arity
+
+val arity_one : (valexpr -> valexpr Proofview.tactic) arity
+val arity_suc : 'a arity -> (valexpr -> 'a) arity
+
+val mk_closure : 'v arity -> 'v -> closure
+val mk_closure_val : 'v arity -> 'v -> valexpr
+(** Composition of [mk_closure] and [ValCls] *)
+
+val annotate_closure : Tac2expr.frame -> closure -> closure
+(** The closure must not be already annotated *)
+
+val to_closure : valexpr -> closure
+
+val apply : closure -> valexpr list -> valexpr Proofview.tactic
+(** Given a closure, apply it to some arguments. Handling of argument mismatches
+    is done automatically, i.e. in case of over or under-application. *)
+
+val apply_val : valexpr -> valexpr list -> valexpr Proofview.tactic
+(** Composition of [to_closure] and [apply] *)
+
+val abstract : int -> (valexpr list -> valexpr Proofview.tactic) -> closure
+(** Turn a fixed-arity function into a closure. The inner function is guaranteed
+    to be applied to a list whose size is the integer argument. *)

--- a/plugins/ltac2_ltac1/tac2core_ltac1.ml
+++ b/plugins/ltac2_ltac1/tac2core_ltac1.ml
@@ -13,6 +13,7 @@ open Pp
 open Names
 open Genarg
 open Ltac2_plugin
+open Tac2val
 open Tac2ffi
 open Tac2env
 open Tac2expr
@@ -59,7 +60,7 @@ let () =
   let open Tacexpr in
   let open Locus in
   let k ret =
-    Proofview.tclIGNORE (Tac2ffi.apply k [Tac2ffi.of_ext val_ltac1 ret])
+    Proofview.tclIGNORE (Tac2val.apply k [Tac2ffi.of_ext val_ltac1 ret])
   in
   let fold arg (i, vars, lfun) =
     let id = Id.of_string ("x" ^ string_of_int i) in
@@ -144,7 +145,7 @@ let () =
     if Int.equal len 0 then
       clos []
     else
-      return (Tac2ffi.of_closure (Tac2ffi.abstract len clos))
+      return (Tac2ffi.of_closure (Tac2val.abstract len clos))
   in
   let subst s (ids, tac) = (ids, Gensubst.substitute Ltac_plugin.Tacarg.wit_tactic s tac) in
   let print env sigma (ids, tac) =
@@ -201,7 +202,7 @@ let () =
     if Int.equal len 0 then
       clos []
     else
-      return (Tac2ffi.of_closure (Tac2ffi.abstract len clos))
+      return (Tac2ffi.of_closure (Tac2val.abstract len clos))
   in
   let subst s (ids, tac) = (ids, Gensubst.substitute Tacarg.wit_tactic s tac) in
   let print env sigma (ids, tac) =
@@ -266,7 +267,7 @@ let () =
     let tac = cast_typ typ_ltac2 @@ Id.Map.get tac_id ist.Tacinterp.lfun in
     let arg = Id.Map.get arg_id ist.Tacinterp.lfun in
     let tac = Tac2ffi.to_closure tac in
-    Tac2ffi.apply tac [of_ltac1 arg] >>= fun ans ->
+    Tac2val.apply tac [of_ltac1 arg] >>= fun ans ->
     let ans = Tac2ffi.to_ext val_ltac1 ans in
     Ftactic.return ans
   in
@@ -293,7 +294,7 @@ let ltac2_eval =
     let tac = cast_typ typ_ltac2 tac in
     let tac = Tac2ffi.to_closure tac in
     let args = List.map (fun arg -> Tac2ffi.of_ext val_ltac1 arg) args in
-    Proofview.tclIGNORE (Tac2ffi.apply tac args)
+    Proofview.tclIGNORE (Tac2val.apply tac args)
   in
   let () = Tacenv.register_ml_tactic ml_name [|eval_fun|] in
   { Tacexpr.mltac_name = ml_name; mltac_index = 0 }

--- a/plugins/ltac2_ltac1/tac2stdlib_ltac1.ml
+++ b/plugins/ltac2_ltac1/tac2stdlib_ltac1.ml
@@ -12,6 +12,7 @@ open Util
 open Genarg
 open Geninterp
 open Ltac2_plugin
+open Tac2val
 open Tac2ffi
 open Tac2expr
 open Proofview.Notations


### PR DESCRIPTION
Overlays:
- https://github.com/mit-plv/rewriter/pull/149
- https://github.com/impermeable/coq-waterproof/pull/49
- https://github.com/SkySkimmer/coq-ltac2-compiler/pull/23