### PR TITLE
A simplification of the interpretation of projections to unfold or to not unfold in reduction tactics

### DIFF
--- a/kernel/redFlags.ml
+++ b/kernel/redFlags.ml
@@ -59,7 +59,10 @@ let red_add red = function
     { red with r_const = { r with tr_cst = Cpred.add kn r.tr_cst } }
   | PROJ p ->
     let r = red.r_const in
-    { red with r_const = { r with tr_prj = PRpred.add p r.tr_prj } }
+    { red with r_const =
+                 { r with tr_prj = PRpred.add p r.tr_prj;
+                          (* set the constant associated to a projection also transparent *)
+                          tr_cst = Cpred.add (Projection.Repr.constant p) r.tr_cst } }
   | MATCH -> { red with r_match = true }
   | FIX -> { red with r_fix = true }
   | COFIX -> { red with r_cofix = true }

--- a/tactics/redexpr.ml
+++ b/tactics/redexpr.ml
@@ -129,14 +129,9 @@ type red_expr_val =
   (constr, Evaluable.t, constr_pattern, strength * RedFlags.reds) red_expr_gen0
 
 let make_flag_constant = function
-  | Evaluable.EvalVarRef id -> [fVAR id]
-  | Evaluable.EvalConstRef sp ->
-      begin
-        match Structures.PrimitiveProjections.find_opt sp with
-        | None -> [fCONST sp]
-        | Some p -> [fCONST sp; fPROJ p]
-      end
-  | Evaluable.EvalProjectionRef p -> [fPROJ p; fCONST (Projection.Repr.constant p)]
+  | Evaluable.EvalVarRef id -> fVAR id
+  | Evaluable.EvalConstRef sp -> fCONST sp
+  | Evaluable.EvalProjectionRef p -> fPROJ p
 
 let make_flag env f =
   let red = no_red in
@@ -151,12 +146,12 @@ let make_flag env f =
         let red = red_add_transparent red
                     (Conv_oracle.get_transp_state (Environ.oracle env)) in
         List.fold_right
-          (fun v red -> red_sub_list red (make_flag_constant v))
+          (fun v red -> red_sub red (make_flag_constant v))
           f.rConst red
     else (* Only rConst *)
         let red = red_add red fDELTA in
         List.fold_right
-          (fun v red -> red_add_list red (make_flag_constant v))
+          (fun v red -> red_add red (make_flag_constant v))
           f.rConst red
   in
   f.rStrength, red

--- a/test-suite/success/primitiveproj.v
+++ b/test-suite/success/primitiveproj.v
@@ -218,6 +218,10 @@ Goal True.
   let matched_snd := constr:(let 'pair _ x := v in x) in
   constr_eq unfolded_snd matched_snd.
 
+  let unfolded_snd := eval lazy beta delta [snd' snd] in (snd' v) in
+  let matched_snd := constr:(let 'pair _ x := v in x) in
+  constr_eq unfolded_snd matched_snd.
+
 Abort.
 
 Fixpoint split_at {A} (l : list A) (n : nat) : prod (list A) (list A) :=


### PR DESCRIPTION
We ensure transparency of the constant associated to a transparent projection at the exact point where it matters.