### PR TITLE
Reduce use of canonical name data in upper layers 

### DIFF
--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -855,6 +855,7 @@ sig
   val equal : env -> t -> t -> bool
   val compare : env -> t -> t -> int
   val hash : env -> t -> int
+  val canonize : env -> t -> t
 end
 
 module QConstant =
@@ -863,6 +864,7 @@ struct
   let equal _env c1 c2 = Constant.CanOrd.equal c1 c2
   let compare _env c1 c2 = Constant.CanOrd.compare c1 c2
   let hash _env c = Constant.CanOrd.hash c
+  let canonize _env c = Constant.canonize c
 end
 
 module QMutInd =
@@ -871,6 +873,7 @@ struct
   let equal _env c1 c2 = MutInd.CanOrd.equal c1 c2
   let compare _env c1 c2 = MutInd.CanOrd.compare c1 c2
   let hash _env c = MutInd.CanOrd.hash c
+  let canonize _env c = MutInd.canonize c
 end
 
 module QInd =
@@ -879,6 +882,7 @@ struct
   let equal _env c1 c2 = Ind.CanOrd.equal c1 c2
   let compare _env c1 c2 = Ind.CanOrd.compare c1 c2
   let hash _env c = Ind.CanOrd.hash c
+  let canonize _env c = Ind.canonize c
 end
 
 module QConstruct =
@@ -887,6 +891,7 @@ struct
   let equal _env c1 c2 = Construct.CanOrd.equal c1 c2
   let compare _env c1 c2 = Construct.CanOrd.compare c1 c2
   let hash _env c = Construct.CanOrd.hash c
+  let canonize _env c = Construct.canonize c
 end
 
 module QProjection =
@@ -895,12 +900,14 @@ struct
   let equal _env c1 c2 = Projection.CanOrd.equal c1 c2
   let compare _env c1 c2 = Projection.CanOrd.compare c1 c2
   let hash _env c = Projection.CanOrd.hash c
+  let canonize _env c = Projection.canonize c
   module Repr =
   struct
     type t = Projection.Repr.t
     let equal _env c1 c2 = Projection.Repr.CanOrd.equal c1 c2
     let compare _env c1 c2 = Projection.Repr.CanOrd.compare c1 c2
     let hash _env c = Projection.Repr.CanOrd.hash c
+    let canonize _env c = Projection.Repr.canonize c
   end
 end
 
@@ -910,4 +917,5 @@ struct
   let equal _env c1 c2 = GlobRef.CanOrd.equal c1 c2
   let compare _env c1 c2 = GlobRef.CanOrd.compare c1 c2
   let hash _env c = GlobRef.CanOrd.hash c
+  let canonize _env c = GlobRef.canonize c
 end

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -287,6 +287,7 @@ sig
   val equal : env -> t -> t -> bool
   val compare : env -> t -> t -> int
   val hash : env -> t -> int
+  val canonize : env -> t -> t
 end
 
 module QConstant : QNameS with type t = Constant.t

--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -454,6 +454,7 @@ sig
   module CanOrd : EqType with type t = t
   module UserOrd : EqType with type t = t
   module SyntacticOrd : EqType with type t = t
+  val canonize : t -> t
 end
 
 (** For constant and inductive names, we use a kernel name couple (kn1,kn2)
@@ -489,6 +490,10 @@ module KerPair = struct
   let user = function
     | Same kn -> kn
     | Dual (kn,_) -> kn
+
+  let canonize kp = match kp with
+  | Same _ -> kp
+  | Dual (_, kn) -> Same kn
 
   let same kn = Same kn
   let make knu knc = if KerName.equal knu knc then Same knc else Dual (knu,knc)
@@ -656,6 +661,10 @@ struct
       Hashset.Combine.combine (MutInd.SyntacticOrd.hash m) (Int.hash i)
   end
 
+  let canonize ((mind, i) as ind) =
+    let mind' = MutInd.canonize mind in
+    if mind' == mind then ind else (mind', i)
+
 end
 
 module Construct =
@@ -701,6 +710,10 @@ struct
     let hash (ind, i) =
       Hashset.Combine.combine (Ind.SyntacticOrd.hash ind) (Int.hash i)
   end
+
+  let canonize ((ind, i) as cstr) =
+    let ind' = Ind.canonize ind in
+    if ind' == ind then cstr else (ind', i)
 
 end
 
@@ -876,6 +889,13 @@ struct
     let equal = CanOrd.equal
     let compare = CanOrd.compare
 
+    let canonize p =
+      let { proj_ind; proj_npars; proj_arg; proj_name } = p in
+      let proj_ind' = Ind.canonize proj_ind in
+      let proj_name' = Constant.canonize proj_name in
+      if proj_ind' == proj_ind && proj_name' == proj_name then p
+      else { proj_ind = proj_ind'; proj_name = proj_name'; proj_npars; proj_arg }
+
     module Self_Hashcons = struct
       type nonrec t = t
       type u = (inductive -> inductive) * (Constant.t -> Constant.t)
@@ -961,6 +981,10 @@ struct
         x == y || (c == c' && b == b')
       let hash = hash
     end
+
+  let canonize ((r, u) as p) =
+    let r' = Repr.canonize r in
+    if r' == r then p else (r',  u)
 
   module HashProjection = Hashcons.Make(Self_Hashcons)
 
@@ -1077,6 +1101,18 @@ module GlobRef = struct
     let equal gr1 gr2 = GlobRefInternal.global_eq_gen Constant.SyntacticOrd.equal Ind.SyntacticOrd.equal Construct.SyntacticOrd.equal gr1 gr2
     let hash gr = GlobRefInternal.global_hash_gen Constant.SyntacticOrd.hash Ind.SyntacticOrd.hash Construct.SyntacticOrd.hash gr
   end
+
+  let canonize gr = match gr with
+  | VarRef _ -> gr
+  | ConstRef c ->
+    let c' = Constant.canonize c in
+    if c' == c then gr else ConstRef c'
+  | IndRef ind ->
+    let ind' = Ind.canonize ind in
+    if ind' == ind then gr else IndRef ind'
+  | ConstructRef c ->
+    let c' = Construct.canonize c in
+    if c' == c then gr else ConstructRef c'
 
   let is_bound = function
   | VarRef _ -> false

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -365,6 +365,9 @@ sig
 
   module SyntacticOrd : EqType with type t = t
   (** Equality functions using both names, for low-level uses. *)
+
+  val canonize : t -> t
+  (** Returns the canonical version of the name *)
 end
 
 (** {6 Constant Names } *)

--- a/library/coqlib.ml
+++ b/library/coqlib.ml
@@ -42,7 +42,7 @@ let has_ref s = CString.Map.mem s !table
 
 let check_ind_ref s ind =
   match CString.Map.find s !table with
-  | GlobRef.IndRef r -> Ind.CanOrd.equal r ind
+  | GlobRef.IndRef r -> Ind.UserOrd.equal r ind
   | _ -> false
   | exception Not_found -> false
 

--- a/plugins/btauto/refl_btauto.ml
+++ b/plugins/btauto/refl_btauto.ml
@@ -93,7 +93,7 @@ module Bool = struct
   | Negb of t
   | Ifb of t * t * t
 
-  let quote (env : Env.t) sigma (c : Constr.t) : t =
+  let quote (env : Env.t) genv sigma (c : Constr.t) : t =
     let trueb = Lazy.force trueb in
     let falseb = Lazy.force falseb in
     let andb = Lazy.force andb in
@@ -115,7 +115,7 @@ module Bool = struct
     | Case (info, _, _, _, _, arg, pats) ->
       let is_bool =
         let i = info.ci_ind in
-        Names.Ind.CanOrd.equal i (Lazy.force ind)
+        Environ.QInd.equal genv i (Lazy.force ind)
       in
       if is_bool then
         Ifb ((aux arg), (aux (snd pats.(0))), (aux (snd pats.(1))))
@@ -239,8 +239,8 @@ module Btauto = struct
       | App (c, [|typ; tl; tr|])
           when typ === bool && c === eq ->
           let env = Env.empty () in
-          let fl = Bool.quote env sigma tl in
-          let fr = Bool.quote env sigma tr in
+          let fl = Bool.quote env (Tacmach.pf_env gl) sigma tl in
+          let fr = Bool.quote env (Tacmach.pf_env gl) sigma tr in
           let env = Env.to_list env in
           let fl = reify env fl in
           let fr = reify env fr in

--- a/plugins/cc/ccalgo.mli
+++ b/plugins/cc/ccalgo.mli
@@ -29,7 +29,7 @@ sig
   val mkSymb : constr -> t
   val mkProduct : (Sorts.t * Sorts.t) -> t
   val mkAppli : (t * t) -> t
-  val mkConstructor : cinfo -> t
+  val mkConstructor : Environ.env -> cinfo -> t
   val constr : t -> constr
   val nth_arg : t -> int -> t
 end

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -64,14 +64,11 @@ let rec decompose_term env sigma t =
         ATerm.mkAppli (ATerm.mkAppli (ATerm.mkProduct (sort_a,sort_b),
                     decompose_term env sigma a),
               decompose_term env sigma b)
-    | Construct c ->
-        let (((mind,i_ind),i_con),u)= c in
+    | Construct ((ind, _ as cstr), u) ->
         let u = EInstance.kind sigma u in
-        let canon_mind = MutInd.make1 (MutInd.canonical mind) in
-        let canon_ind = canon_mind,i_ind in
-        let (oib,_)=Global.lookup_inductive (canon_ind) in
-        let nargs=constructor_nallargs env (canon_ind,i_con) in
-          ATerm.mkConstructor {ci_constr= ((canon_ind,i_con),u);
+        let oib = Environ.lookup_mind (fst ind) env in
+        let nargs = constructor_nallargs env cstr in
+        ATerm.mkConstructor env {ci_constr = (cstr, u);
                        ci_arity=nargs;
                        ci_nhyps=nargs-oib.mind_nparams}
     | Ind c ->

--- a/plugins/firstorder/formula.ml
+++ b/plugins/firstorder/formula.ml
@@ -217,6 +217,9 @@ type _ identifier =
 | GoalId : [ `Goal ] identifier
 | FormulaId : GlobRef.t -> [ `Hyp ] identifier
 
+let goal_id = GoalId
+let formula_id env gr = FormulaId (Environ.QGlobRef.canonize env gr)
+
 type _ pattern =
 | LeftPattern : left_pattern -> [ `Hyp ] pattern
 | RightPattern : right_pattern -> [ `Goal ] pattern

--- a/plugins/firstorder/formula.mli
+++ b/plugins/firstorder/formula.mli
@@ -67,9 +67,12 @@ type left_pattern=
   | Lexists of pinductive
   | LA of constr*left_arrow_pattern
 
-type _ identifier =
+type _ identifier = private
 | GoalId : [ `Goal ] identifier
 | FormulaId : GlobRef.t -> [ `Hyp ] identifier
+
+val goal_id : [ `Goal ] identifier
+val formula_id : Environ.env -> GlobRef.t -> [ `Hyp ] identifier
 
 type _ pattern =
 | LeftPattern : left_pattern -> [ `Hyp ] pattern

--- a/plugins/firstorder/ground.ml
+++ b/plugins/firstorder/ground.ml
@@ -39,7 +39,7 @@ let ground_tac ~flags solver startseq =
     tclORELSE (axiom_tac seq)
       begin
         try
-          let (hd,seq1)=take_formula (project gl) seq
+          let (hd, seq1) = take_formula (pf_env gl) (project gl) seq
           and re_add s=re_add_formula_list (project gl) skipped s in
           let continue=toptac []
           and backtrack =toptac (hd::skipped) seq1 in
@@ -63,7 +63,7 @@ let ground_tac ~flags solver startseq =
                           or_tac ~flags backtrack continue (re_add seq1)
                       | Rfalse->backtrack
                       | Rexists(i,dom,triv)->
-                          let (lfp,seq2)=collect_quantified (project gl) seq in
+                          let (lfp, seq2) = collect_quantified (pf_env gl) (project gl) seq in
                           let backtrack2=toptac (lfp@skipped) seq2 in
                             if flags.qflag && Sequent.has_fuel seq then
                               quantified_tac ~flags lfp backtrack2
@@ -83,7 +83,7 @@ let ground_tac ~flags solver startseq =
                           left_or_tac ~flags ind backtrack
                           (get_id hd) continue (re_add seq1)
                       | Lforall (_,_,_)->
-                          let (lfp,seq2)=collect_quantified (project gl) seq in
+                          let (lfp, seq2) = collect_quantified (pf_env gl) (project gl) seq in
                           let backtrack2=toptac (lfp@skipped) seq2 in
                             if flags.qflag && Sequent.has_fuel seq then
                               quantified_tac ~flags lfp backtrack2

--- a/plugins/firstorder/instances.mli
+++ b/plugins/firstorder/instances.mli
@@ -10,6 +10,6 @@
 
 open Rules
 
-val collect_quantified : Evd.evar_map -> Sequent.t -> Formula.any_formula list * Sequent.t
+val collect_quantified : Environ.env -> Evd.evar_map -> Sequent.t -> Formula.any_formula list * Sequent.t
 
 val quantified_tac : flags:Formula.flags -> Formula.any_formula list -> seqtac with_backtracking

--- a/plugins/firstorder/sequent.mli
+++ b/plugins/firstorder/sequent.mli
@@ -24,7 +24,7 @@ val iter_redexes : (Formula.any_formula -> unit) -> t -> unit
 
 val deepen: t -> t
 
-val record: h_item -> t -> t
+val record: Environ.env -> h_item -> t -> t
 
 val lookup: Environ.env -> Evd.evar_map -> h_item -> t -> bool
 
@@ -38,7 +38,7 @@ val find_left : Evd.evar_map -> constr -> t -> GlobRef.t
 
 val find_goal : Evd.evar_map -> t -> GlobRef.t
 
-val take_formula : Evd.evar_map -> t -> Formula.any_formula * t
+val take_formula : Environ.env -> Evd.evar_map -> t -> Formula.any_formula * t
 
 val empty_seq : int -> t
 

--- a/plugins/ltac/internals.ml
+++ b/plugins/ltac/internals.ml
@@ -343,7 +343,7 @@ let declare_equivalent_keys c c' =
     let evd = Evd.from_env env in
     let (evd, c) = Constrintern.interp_open_constr env evd c in
     let kind c = EConstr.kind evd c in
-    Keys.constr_key kind c
+    Keys.constr_key env kind c
   in
   let k1 = get_key c in
   let k2 = get_key c' in

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -83,7 +83,7 @@ let unfold_projection_under_eta env evd ts n c =
   let rec go c lams =
     match EConstr.kind evd c with
     | Lambda (b, t, c) -> go c ((b,t)::lams)
-    | Proj (p, r, c) when Names.Constant.CanOrd.equal n (Projection.constant p) ->
+    | Proj (p, r, c) when QConstant.equal env n (Projection.constant p) ->
       let c = unfold_projection env evd ts p r c in
       begin
         match c with

--- a/pretyping/indrec.ml
+++ b/pretyping/indrec.ml
@@ -309,7 +309,7 @@ let type_rec_branch is_rec dep env sigma (vargs,depPvect,decP) (mind,tyi) cs rec
               | [] -> None,[]
               | ra::rest ->
                   (match dest_recarg ra with
-                    | Mrec (RecArgInd (mind',j)) -> ((if is_rec && Names.MutInd.CanOrd.equal mind mind' then depPvect.(j) else None),rest)
+                    | Mrec (RecArgInd (mind',j)) -> ((if is_rec && QMutInd.equal env mind mind' then depPvect.(j) else None),rest)
                     | Norec | Mrec (RecArgPrim _) -> (None,rest))
           in
           (match optionpos with
@@ -382,7 +382,7 @@ let make_rec_branch_arg env sigma (nparrec,fvect,decF) mind f cstr recargs =
         let optionpos =
           match dest_recarg recarg with
             | Norec | Mrec (RecArgPrim _) -> None
-            | Mrec (RecArgInd (mind',i)) -> if Names.MutInd.CanOrd.equal mind mind' then fvect.(i) else None
+            | Mrec (RecArgInd (mind',i)) -> if QMutInd.equal env mind mind' then fvect.(i) else None
         in
         (match optionpos with
            | None ->

--- a/pretyping/keys.mli
+++ b/pretyping/keys.mli
@@ -16,7 +16,7 @@ val declare_equiv_keys : key -> key -> unit
 val equiv_keys : key -> key -> bool
 (** Check equivalence of keys. *)
 
-val constr_key : ('a -> ('a, 't, 'u, 'i) Constr.kind_of_term) -> 'a -> key option
+val constr_key : Environ.env -> ('a -> ('a, 't, 'u, 'i) Constr.kind_of_term) -> 'a -> key option
 (** Compute the head key of a term. *)
 
 val pr_keys : (Names.GlobRef.t -> Pp.t) -> Pp.t

--- a/pretyping/patternops.ml
+++ b/pretyping/patternops.ml
@@ -21,51 +21,51 @@ open Mod_subst
 open Pattern
 open Environ
 
-let case_info_pattern_eq i1 i2 =
+let case_info_pattern_eq env i1 i2 =
   i1.cip_style == i2.cip_style &&
-  Option.equal Ind.CanOrd.equal i1.cip_ind i2.cip_ind &&
+  Option.equal (fun i1 i2 -> QInd.equal env i1 i2) i1.cip_ind i2.cip_ind &&
   i1.cip_extensible == i2.cip_extensible
 
-let rec constr_pattern_eq (p1:constr_pattern) p2 = match p1, p2 with
-| PRef r1, PRef r2 -> GlobRef.CanOrd.equal r1 r2
+let rec constr_pattern_eq env (p1:constr_pattern) p2 = match p1, p2 with
+| PRef r1, PRef r2 -> QGlobRef.equal env r1 r2
 | PVar v1, PVar v2 -> Id.equal v1 v2
 | PEvar (ev1, ctx1), PEvar (ev2, ctx2) ->
-  Evar.equal ev1 ev2 && List.equal constr_pattern_eq ctx1 ctx2
+  Evar.equal ev1 ev2 && List.equal (fun c1 c2 -> constr_pattern_eq env c1 c2) ctx1 ctx2
 | PRel i1, PRel i2 ->
   Int.equal i1 i2
 | PApp (t1, arg1), PApp (t2, arg2) ->
-  constr_pattern_eq t1 t2 && Array.equal constr_pattern_eq arg1 arg2
+  constr_pattern_eq env t1 t2 && Array.equal (fun c1 c2 -> constr_pattern_eq env c1 c2) arg1 arg2
 | PSoApp (id1, arg1), PSoApp (id2, arg2) ->
-  Id.equal id1 id2 && List.equal constr_pattern_eq arg1 arg2
+  Id.equal id1 id2 && List.equal (fun c1 c2 -> constr_pattern_eq env c1 c2) arg1 arg2
 | PLambda (v1, t1, b1), PLambda (v2, t2, b2) ->
-  Name.equal v1 v2 && constr_pattern_eq t1 t2 && constr_pattern_eq b1 b2
+  Name.equal v1 v2 && constr_pattern_eq env t1 t2 && constr_pattern_eq env b1 b2
 | PProd (v1, t1, b1), PProd (v2, t2, b2) ->
-  Name.equal v1 v2 && constr_pattern_eq t1 t2 && constr_pattern_eq b1 b2
+  Name.equal v1 v2 && constr_pattern_eq env t1 t2 && constr_pattern_eq env b1 b2
 | PLetIn (v1, b1, t1, c1), PLetIn (v2, b2, t2, c2) ->
-  Name.equal v1 v2 && constr_pattern_eq b1 b2 &&
-  Option.equal constr_pattern_eq t1 t2 && constr_pattern_eq c1 c2
+  Name.equal v1 v2 && constr_pattern_eq env b1 b2 &&
+  Option.equal (fun c1 c2 -> constr_pattern_eq env c1 c2) t1 t2 && constr_pattern_eq env c1 c2
 | PSort s1, PSort s2 -> Sorts.family_equal s1 s2
 | PMeta m1, PMeta m2 -> Option.equal Id.equal m1 m2
 | PIf (t1, l1, r1), PIf (t2, l2, r2) ->
-  constr_pattern_eq t1 t2 && constr_pattern_eq l1 l2 && constr_pattern_eq r1 r2
+  constr_pattern_eq env t1 t2 && constr_pattern_eq env l1 l2 && constr_pattern_eq env r1 r2
 | PCase (info1, p1, r1, l1), PCase (info2, p2, r2, l2) ->
-  case_info_pattern_eq info1 info2 &&
-  Option.equal (fun (nas1, p1) (nas2, p2) -> Array.equal Name.equal nas1 nas2 && constr_pattern_eq p1 p2) p1 p2 &&
-  constr_pattern_eq r1 r2 &&
-  List.equal pattern_eq l1 l2
+  case_info_pattern_eq env info1 info2 &&
+  Option.equal (fun (nas1, p1) (nas2, p2) -> Array.equal Name.equal nas1 nas2 && constr_pattern_eq env p1 p2) p1 p2 &&
+  constr_pattern_eq env r1 r2 &&
+  List.equal (fun p1 p2 -> pattern_eq env p1 p2) l1 l2
 | PFix ((ln1,i1),f1), PFix ((ln2,i2),f2) ->
-  Array.equal Int.equal ln1 ln2 && Int.equal i1 i2 && rec_declaration_eq f1 f2
+  Array.equal Int.equal ln1 ln2 && Int.equal i1 i2 && rec_declaration_eq env f1 f2
 | PCoFix (i1,f1), PCoFix (i2,f2) ->
-  Int.equal i1 i2 && rec_declaration_eq f1 f2
+  Int.equal i1 i2 && rec_declaration_eq env f1 f2
 | PProj (p1, t1), PProj (p2, t2) ->
-   Projection.CanOrd.equal p1 p2 && constr_pattern_eq t1 t2
+   QProjection.equal env p1 p2 && constr_pattern_eq env t1 t2
 | PInt i1, PInt i2 ->
    Uint63.equal i1 i2
 | PFloat f1, PFloat f2 ->
    Float64.equal f1 f2
 | PArray (t1, def1, ty1), PArray (t2, def2, ty2) ->
-  Array.equal constr_pattern_eq t1 t2 && constr_pattern_eq def1 def2
-  && constr_pattern_eq ty1 ty2
+  Array.equal (fun c1 c2 -> constr_pattern_eq env c1 c2) t1 t2 && constr_pattern_eq env def1 def2
+  && constr_pattern_eq env ty1 ty2
 | PUninstantiated _, _ -> .
 | (PRef _ | PVar _ | PEvar _ | PRel _ | PApp _ | PSoApp _
    | PLambda _ | PProd _ | PLetIn _ | PSort _ | PMeta _
@@ -73,13 +73,13 @@ let rec constr_pattern_eq (p1:constr_pattern) p2 = match p1, p2 with
    | PFloat _ | PArray _), _ -> false
 (** FIXME: fixpoint and cofixpoint should be relativized to pattern *)
 
-and pattern_eq (i1, j1, p1) (i2, j2, p2) =
-  Int.equal i1 i2 && Array.equal Name.equal j1 j2 && constr_pattern_eq p1 p2
+and pattern_eq env (i1, j1, p1) (i2, j2, p2) =
+  Int.equal i1 i2 && Array.equal Name.equal j1 j2 && constr_pattern_eq env p1 p2
 
-and rec_declaration_eq (n1, c1, r1) (n2, c2, r2) =
+and rec_declaration_eq env (n1, c1, r1) (n2, c2, r2) =
   Array.equal Name.equal n1 n2 &&
-  Array.equal constr_pattern_eq c1 c2 &&
-  Array.equal constr_pattern_eq r1 r2
+  Array.equal (fun c1 c2 -> constr_pattern_eq env c1 c2) c1 c2 &&
+  Array.equal (fun c1 c2 -> constr_pattern_eq env c1 c2) r1 r2
 
 let rec occurn_pattern : 'a. _ -> 'a constr_pattern_r -> _
   = fun (type a) n (p:a constr_pattern_r) -> match p with
@@ -586,7 +586,7 @@ and pats_of_glob_branches loc metas vars ind brs =
         true, [] (* ends with _ => _ *)
       | PatCstr((indsp,j),lv,_), _, _ ->
         let () = match ind with
-        | Some sp when Ind.CanOrd.equal sp indsp -> ()
+        | Some sp when Ind.UserOrd.equal sp indsp -> ()
         | _ ->
           err ?loc (Pp.str "All constructors must be in the same inductive type.")
         in

--- a/pretyping/patternops.ml
+++ b/pretyping/patternops.ml
@@ -138,6 +138,9 @@ let head_of_constr_reference sigma c = match EConstr.kind sigma c with
   | Var id -> GlobRef.VarRef id
   | _ -> anomaly (Pp.str "Not a rigid reference.")
 
+let mkPRef env gr =
+  PRef (Environ.QGlobRef.canonize env gr)
+
 let pattern_of_constr ~broken env sigma t =
   let t = EConstr.Unsafe.to_constr t in
   let kind = if broken then Constr.kind else fun c -> EConstr.kind_upto sigma c in
@@ -170,9 +173,9 @@ let pattern_of_constr ~broken env sigma t =
          with
          | Some n -> PSoApp (n,Array.to_list (Array.map (pattern_of_constr env) a))
          | None -> PApp (pattern_of_constr env f,Array.map (pattern_of_constr env) a))
-    | Const (sp,u)  -> PRef (GlobRef.ConstRef (Constant.make1 (Constant.canonical sp)))
-    | Ind (sp,u)    -> PRef (canonical_gr (GlobRef.IndRef sp))
-    | Construct (sp,u) -> PRef (canonical_gr (GlobRef.ConstructRef sp))
+    | Const (sp,u)  -> mkPRef env (GlobRef.ConstRef sp)
+    | Ind (sp,u)    -> mkPRef env (GlobRef.IndRef sp)
+    | Construct (sp,u) -> mkPRef env (GlobRef.ConstructRef sp)
     | Proj (p, _, c) ->
       pattern_of_constr env (EConstr.Unsafe.to_constr (Retyping.expand_projection env sigma p (EConstr.of_constr c) []))
     | Evar (evk,ctxt as ev) ->

--- a/pretyping/patternops.mli
+++ b/pretyping/patternops.mli
@@ -16,7 +16,7 @@ open EConstr
 
 (** {5 Functions on patterns} *)
 
-val constr_pattern_eq : constr_pattern -> constr_pattern -> bool
+val constr_pattern_eq : Environ.env -> constr_pattern -> constr_pattern -> bool
 
 val subst_pattern : Environ.env -> Evd.evar_map -> substitution -> 'i constr_pattern_r -> 'i constr_pattern_r
 

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -477,7 +477,7 @@ let unfold_projection_under_eta env ts n c =
   let rec go c lams =
     match Constr.kind c with
     | Lambda (b, t, c) -> go c ((b,t)::lams)
-    | Proj (p, r, c) when Names.Constant.CanOrd.equal n (Projection.constant p) ->
+    | Proj (p, r, c) when QConstant.equal env n (Projection.constant p) ->
       let c = unfold_projection env ts p r c in
       begin
         match c with

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1846,7 +1846,7 @@ let keyed_unify env evd kop =
     | None -> fun _ -> true
     | Some kop ->
       fun cl ->
-        let kc = Keys.constr_key (fun c -> EConstr.kind evd c) cl in
+        let kc = Keys.constr_key env (fun c -> EConstr.kind evd c) cl in
           match kc with
           | None -> false
           | Some kc -> Keys.equiv_keys kop kc
@@ -1982,7 +1982,7 @@ end
    Fails if no match is found *)
 let w_unify_to_subterm env evd ?(flags=default_unify_flags ()) (op,cl) =
   let bestexn = ref None in
-  let kop = Keys.constr_key (fun c -> EConstr.kind evd c) op in
+  let kop = Keys.constr_key env (fun c -> EConstr.kind evd c) op in
   let opgnd = if occur_meta_or_undefined_evar evd op then NotGround else Ground in
   let rec matchrec cl =
     let rec strip_outer_cast c = match AConstr.kind c with

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -119,7 +119,7 @@ let compute_constructor_signatures env ~rec_flag ((_,k as ity),u) =
         begin match Declareops.dest_recarg recarg with
         | Norec | Mrec (RecArgPrim _)  -> true :: rest
         | Mrec (RecArgInd ind) ->
-            if rec_flag && Names.Ind.CanOrd.equal ity ind then true :: true :: rest
+            if rec_flag && Environ.QInd.equal env ity ind then true :: true :: rest
             else true :: rest
         end
     | RelDecl.LocalDef _ :: c, rest -> false :: analrec c rest

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -965,7 +965,7 @@ let do_replace_bl handle (ind,u as indu) aavoid narg lft rgt =
           let (ind',u as indu),v = try destruct_ind env sigma tt1
           (* trick so that the good sequence is returned*)
                 with e when CErrors.noncritical e -> indu,[||]
-          in if Ind.CanOrd.equal ind' ind
+          in if Environ.QInd.equal env ind' ind
              then Tacticals.tclTHENLIST [Equality.replace t1 t2; Auto.default_auto ; aux q1 q2 ]
              else (
                let c = get_scheme handle (!bl_scheme_kind_aux ()) ind' in
@@ -1125,13 +1125,14 @@ repeat ( apply andb_prop in z;let z1:= fresh "Z" in destruct z as [z1 z]).
  replace bi with ai; auto || replace bi with ai by  apply typeofbi_prod ; auto
                *)
               Proofview.Goal.enter begin fun gl ->
+                let env = Proofview.Goal.env gl in
                 let concl = Proofview.Goal.concl gl in
                 let sigma = Tacmach.project gl in
                 match EConstr.kind sigma concl with
                 | App (c,ca) -> (
                   match EConstr.kind sigma c with
                   | Ind (indeq, u) ->
-                     if GlobRef.CanOrd.equal (GlobRef.IndRef indeq) Coqlib.(lib_ref "core.eq.type")
+                     if Environ.QGlobRef.equal env (GlobRef.IndRef indeq) Coqlib.(lib_ref "core.eq.type")
                      then
                        Tacticals.tclTHEN
                          (do_replace_bl handle ind

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -994,7 +994,7 @@ let print_canonical_projections env sigma grefs =
   let match_proj_gref { CSTable.projection; value; solution } gr =
     QGlobRef.equal env projection gr ||
     begin match value with
-      | ValuePattern.Const_cs y -> GlobRef.CanOrd.equal y gr
+      | ValuePattern.Const_cs y -> QGlobRef.equal env y gr
       | _ -> false
     end ||
     QGlobRef.equal env solution gr

--- a/vernac/recLemmas.ml
+++ b/vernac/recLemmas.ml
@@ -70,7 +70,8 @@ let find_mutually_recursive_statements sigma thms =
       | [], _::_ ->
           let () = match same_indccl with
           | ind :: _ ->
-            if List.distinct_f Names.Ind.CanOrd.compare (List.map pi1 ind)
+            let eq i1 i2 = Environ.QInd.compare (Global.env ()) i1 i2 in
+            if List.distinct_f eq (List.map pi1 ind)
             then
               Flags.if_verbose Feedback.msg_info
                 (Pp.strbrk


### PR DESCRIPTION
This is a series of small commits to reduce the footprint of primitive functions exploiting the user-canonical name duality in the upper layer. We replace them by functions that have access to the environment to check the name aliasing. This PR is given as a series of tiny commits for easiness of bisecting if something goes wrong, as it is a delicate matter.